### PR TITLE
Code cleanup: Asserts

### DIFF
--- a/Common/Arm64Emitter.cpp
+++ b/Common/Arm64Emitter.cpp
@@ -211,7 +211,7 @@ bool IsImmLogical(uint64_t value, unsigned int width, unsigned int *n, unsigned 
   };
   int multiplier_idx = CountLeadingZeros(d, kXRegSizeInBits) - 57;
   // Ensure that the index to the multipliers array is within bounds.
-  _dbg_assert_(JIT, (multiplier_idx >= 0) &&
+  _dbg_assert_((multiplier_idx >= 0) &&
          (static_cast<size_t>(multiplier_idx) < ARRAY_SIZE(multipliers)));
   uint64_t multiplier = multipliers[multiplier_idx];
   uint64_t candidate = (b - a) * multiplier;
@@ -491,11 +491,11 @@ void ARM64XEmitter::EncodeCompareBranchInst(u32 op, ARM64Reg Rt, const void* ptr
 	bool b64Bit = Is64Bit(Rt);
 	s64 distance = (s64)ptr - (s64)m_code;
 
-	_assert_msg_(DYNA_REC, !(distance & 0x3), "%s: distance must be a multiple of 4: %llx", __FUNCTION__, distance);
+	_assert_msg_(!(distance & 0x3), "%s: distance must be a multiple of 4: %llx", __FUNCTION__, distance);
 
 	distance >>= 2;
 
-	_assert_msg_(DYNA_REC, distance >= -0x40000 && distance <= 0x3FFFF, "%s: Received too large distance: %llx", __FUNCTION__, distance);
+	_assert_msg_(distance >= -0x40000 && distance <= 0x3FFFF, "%s: Received too large distance: %llx", __FUNCTION__, distance);
 
 	Rt = DecodeReg(Rt);
 	Write32((b64Bit << 31) | (0x34 << 24) | (op << 24) | \
@@ -507,11 +507,11 @@ void ARM64XEmitter::EncodeTestBranchInst(u32 op, ARM64Reg Rt, u8 bits, const voi
 	bool b64Bit = Is64Bit(Rt);
 	s64 distance = (s64)ptr - (s64)m_code;
 
-	_assert_msg_(DYNA_REC, !(distance & 0x3), "%s: distance must be a multiple of 4: %llx", __FUNCTION__, distance);
+	_assert_msg_(!(distance & 0x3), "%s: distance must be a multiple of 4: %llx", __FUNCTION__, distance);
 
 	distance >>= 2;
 
-	_assert_msg_(DYNA_REC, distance >= -0x1FFF && distance < 0x1FFF, "%s: Received too large distance: %llx", __FUNCTION__, distance);
+	_assert_msg_(distance >= -0x1FFF && distance < 0x1FFF, "%s: Received too large distance: %llx", __FUNCTION__, distance);
 
 	Rt = DecodeReg(Rt);
 	Write32((b64Bit << 31) | (0x36 << 24) | (op << 24) | \
@@ -522,11 +522,11 @@ void ARM64XEmitter::EncodeUnconditionalBranchInst(u32 op, const void* ptr)
 {
 	s64 distance = (s64)ptr - s64(m_code);
 
-	_assert_msg_(DYNA_REC, !(distance & 0x3), "%s: distance must be a multiple of 4: %llx", __FUNCTION__, distance);
+	_assert_msg_(!(distance & 0x3), "%s: distance must be a multiple of 4: %llx", __FUNCTION__, distance);
 
 	distance >>= 2;
 
-	_assert_msg_(DYNA_REC, distance >= -0x2000000LL && distance <= 0x1FFFFFFLL, "%s: Received too large distance: %llx", __FUNCTION__, distance);
+	_assert_msg_(distance >= -0x2000000LL && distance <= 0x1FFFFFFLL, "%s: Received too large distance: %llx", __FUNCTION__, distance);
 
 	Write32((op << 31) | (0x5 << 26) | (distance & 0x3FFFFFF));
 }
@@ -539,7 +539,7 @@ void ARM64XEmitter::EncodeUnconditionalBranchInst(u32 opc, u32 op2, u32 op3, u32
 
 void ARM64XEmitter::EncodeExceptionInst(u32 instenc, u32 imm)
 {
-	_assert_msg_(DYNA_REC, !(imm & ~0xFFFF), "%s: Exception instruction too large immediate: %d", __FUNCTION__, imm);
+	_assert_msg_(!(imm & ~0xFFFF), "%s: Exception instruction too large immediate: %d", __FUNCTION__, imm);
 
 	Write32((0xD4 << 24) | (ExcEnc[instenc][0] << 21) | (imm << 5) | (ExcEnc[instenc][1] << 2) | ExcEnc[instenc][2]);
 }
@@ -575,8 +575,8 @@ void ARM64XEmitter::EncodeCondCompareImmInst(u32 op, ARM64Reg Rn, u32 imm, u32 n
 {
 	bool b64Bit = Is64Bit(Rn);
 
-	_assert_msg_(DYNA_REC, !(imm & ~0x1F), "%s: too large immediate: %d", __FUNCTION__, imm)
-	_assert_msg_(DYNA_REC, !(nzcv & ~0xF), "%s: Flags out of range: %d", __FUNCTION__, nzcv)
+	_assert_msg_(!(imm & ~0x1F), "%s: too large immediate: %d", __FUNCTION__, imm)
+	_assert_msg_(!(nzcv & ~0xF), "%s: Flags out of range: %d", __FUNCTION__, nzcv)
 
 	Rn = DecodeReg(Rn);
 	Write32((b64Bit << 31) | (op << 30) | (1 << 29) | (0xD2 << 21) | \
@@ -587,7 +587,7 @@ void ARM64XEmitter::EncodeCondCompareRegInst(u32 op, ARM64Reg Rn, ARM64Reg Rm, u
 {
 	bool b64Bit = Is64Bit(Rm);
 
-	_assert_msg_(DYNA_REC, !(nzcv & ~0xF), "%s: Flags out of range: %d", __FUNCTION__, nzcv)
+	_assert_msg_(!(nzcv & ~0xF), "%s: Flags out of range: %d", __FUNCTION__, nzcv)
 
 	Rm = DecodeReg(Rm);
 	Rn = DecodeReg(Rn);
@@ -659,7 +659,7 @@ void ARM64XEmitter::EncodeLoadRegisterInst(u32 bitop, ARM64Reg Rt, u32 imm)
 	bool b64Bit = Is64Bit(Rt);
 	bool bVec = IsVector(Rt);
 
-	_assert_msg_(DYNA_REC, !(imm & 0xFFFFF), "%s: offset too large %d", __FUNCTION__, imm);
+	_assert_msg_(!(imm & 0xFFFFF), "%s: offset too large %d", __FUNCTION__, imm);
 
 	Rt = DecodeReg(Rt);
 	if (b64Bit && bitop != 0x2) // LDRSW(0x2) uses 64bit reg, doesn't have 64bit bit set
@@ -692,7 +692,7 @@ void ARM64XEmitter::EncodeLoadStorePairedInst(u32 op, ARM64Reg Rt, ARM64Reg Rt2,
 	else
 		imm >>= 2;
 
-	_assert_msg_(DYNA_REC, !(imm & ~0xF), "%s: offset too large %d", __FUNCTION__, imm);
+	_assert_msg_(!(imm & ~0xF), "%s: offset too large %d", __FUNCTION__, imm);
 
 	u32 opc = 0;
 	if (b128Bit)
@@ -715,7 +715,7 @@ void ARM64XEmitter::EncodeLoadStoreIndexedInst(u32 op, u32 op2, ARM64Reg Rt, ARM
 
 	u32 offset = imm & 0x1FF;
 
-	_assert_msg_(DYNA_REC, !(imm < -256 || imm > 255), "%s: offset too large %d", __FUNCTION__, imm);
+	_assert_msg_(!(imm < -256 || imm > 255), "%s: offset too large %d", __FUNCTION__, imm);
 
 	Rt = DecodeReg(Rt);
 	Rn = DecodeReg(Rn);
@@ -736,12 +736,12 @@ void ARM64XEmitter::EncodeLoadStoreIndexedInst(u32 op, ARM64Reg Rt, ARM64Reg Rn,
 		shift = 1;
 
 	if (shift) {
-		_assert_msg_(DYNA_REC, ((imm >> shift) << shift) == imm, "%s(INDEX_UNSIGNED): offset must be aligned %d", __FUNCTION__, imm);
+		_assert_msg_(((imm >> shift) << shift) == imm, "%s(INDEX_UNSIGNED): offset must be aligned %d", __FUNCTION__, imm);
 		imm >>= shift;
 	}
 
-	_assert_msg_(DYNA_REC, imm >= 0, "%s(INDEX_UNSIGNED): offset must be positive %d", __FUNCTION__, imm);
-	_assert_msg_(DYNA_REC, !(imm & ~0xFFF), "%s(INDEX_UNSIGNED): offset too large %d", __FUNCTION__, imm);
+	_assert_msg_(imm >= 0, "%s(INDEX_UNSIGNED): offset must be positive %d", __FUNCTION__, imm);
+	_assert_msg_(!(imm & ~0xFFF), "%s(INDEX_UNSIGNED): offset too large %d", __FUNCTION__, imm);
 
 	Rt = DecodeReg(Rt);
 	Rn = DecodeReg(Rn);
@@ -752,7 +752,7 @@ void ARM64XEmitter::EncodeMOVWideInst(u32 op, ARM64Reg Rd, u32 imm, ShiftAmount 
 {
 	bool b64Bit = Is64Bit(Rd);
 
-	_assert_msg_(DYNA_REC, !(imm & ~0xFFFF), "%s: immediate out of range: %d", __FUNCTION__, imm);
+	_assert_msg_(!(imm & ~0xFFFF), "%s: immediate out of range: %d", __FUNCTION__, imm);
 
 	Rd = DecodeReg(Rd);
 	Write32((b64Bit << 31) | (op << 29) | (0x25 << 23) | (pos << 21) | (imm << 5) | Rd);
@@ -782,7 +782,7 @@ void ARM64XEmitter::EncodeAddSubImmInst(u32 op, bool flags, u32 shift, u32 imm, 
 {
 	bool b64Bit = Is64Bit(Rd);
 
-	_assert_msg_(DYNA_REC, !(imm & ~0xFFF), "%s: immediate too large: %x", __FUNCTION__, imm);
+	_assert_msg_(!(imm & ~0xFFF), "%s: immediate too large: %x", __FUNCTION__, imm);
 
 	Rd = DecodeReg(Rd);
 	Rn = DecodeReg(Rn);
@@ -819,7 +819,7 @@ void ARM64XEmitter::EncodeLoadStorePair(u32 op, u32 load, IndexType type, ARM64R
 		type_encode = 3;
 		break;
 	case INDEX_UNSIGNED:
-		_assert_msg_(DYNA_REC, false, "%s doesn't support INDEX_UNSIGNED!", __FUNCTION__);
+		_assert_msg_(false, "%s doesn't support INDEX_UNSIGNED!", __FUNCTION__);
 		break;
 	}
 
@@ -832,7 +832,7 @@ void ARM64XEmitter::EncodeLoadStorePair(u32 op, u32 load, IndexType type, ARM64R
 		imm >>= 2;
 	}
 
-	_assert_msg_(JIT, imm >= -64 && imm <= 63, "%s recieved too large imm: %d", __FUNCTION__, imm);
+	_assert_msg_(imm >= -64 && imm <= 63, "%s recieved too large imm: %d", __FUNCTION__, imm);
 
 	Rt = DecodeReg(Rt);
 	Rt2 = DecodeReg(Rt2);
@@ -851,7 +851,7 @@ void ARM64XEmitter::EncodeAddressInst(u32 op, ARM64Reg Rd, s32 imm)
 
 void ARM64XEmitter::EncodeLoadStoreUnscaled(u32 size, u32 op, ARM64Reg Rt, ARM64Reg Rn, s32 imm)
 {
-	_assert_msg_(DYNA_REC, !(imm < -256 || imm > 255), "%s received too large offset: %d", __FUNCTION__, imm);
+	_assert_msg_(!(imm < -256 || imm > 255), "%s received too large offset: %d", __FUNCTION__, imm);
 	Rt = DecodeReg(Rt);
 	Rn = DecodeReg(Rn);
 
@@ -896,31 +896,31 @@ void ARM64XEmitter::SetJumpTarget(FixupBranch const& branch)
 			Not = true;
 		case 0: // CBZ
 		{
-			_assert_msg_(DYNA_REC, IsInRangeImm19(distance), "%s(%d): Received too large distance: %llx", __FUNCTION__, branch.type, distance);
+			_assert_msg_(IsInRangeImm19(distance), "%s(%d): Received too large distance: %llx", __FUNCTION__, branch.type, distance);
 			bool b64Bit = Is64Bit(branch.reg);
 			ARM64Reg reg = DecodeReg(branch.reg);
 			inst = (b64Bit << 31) | (0x1A << 25) | (Not << 24) | (MaskImm19(distance) << 5) | reg;
 		}
 		break;
 		case 2: // B (conditional)
-			_assert_msg_(DYNA_REC, IsInRangeImm19(distance), "%s(%d): Received too large distance: %llx", __FUNCTION__, branch.type, distance);
+			_assert_msg_(IsInRangeImm19(distance), "%s(%d): Received too large distance: %llx", __FUNCTION__, branch.type, distance);
 			inst = (0x2A << 25) | (MaskImm19(distance) << 5) | branch.cond;
 		break;
 		case 4: // TBNZ
 			Not = true;
 		case 3: // TBZ
 		{
-			_assert_msg_(DYNA_REC, IsInRangeImm14(distance), "%s(%d): Received too large distance: %llx", __FUNCTION__, branch.type, distance);
+			_assert_msg_(IsInRangeImm14(distance), "%s(%d): Received too large distance: %llx", __FUNCTION__, branch.type, distance);
 			ARM64Reg reg = DecodeReg(branch.reg);
 			inst = ((branch.bit & 0x20) << 26) | (0x1B << 25) | (Not << 24) | ((branch.bit & 0x1F) << 19) | (MaskImm14(distance) << 5) | reg;
 		}
 		break;
 		case 5: // B (unconditional)
-			_assert_msg_(DYNA_REC, IsInRangeImm26(distance), "%s(%d): Received too large distance: %llx", __FUNCTION__, branch.type, distance);
+			_assert_msg_(IsInRangeImm26(distance), "%s(%d): Received too large distance: %llx", __FUNCTION__, branch.type, distance);
 			inst = (0x5 << 26) | MaskImm26(distance);
 		break;
 		case 6: // BL (unconditional)
-			_assert_msg_(DYNA_REC, IsInRangeImm26(distance), "%s(%d): Received too large distance: %llx", __FUNCTION__, branch.type, distance);
+			_assert_msg_(IsInRangeImm26(distance), "%s(%d): Received too large distance: %llx", __FUNCTION__, branch.type, distance);
 			inst = (0x25 << 26) | MaskImm26(distance);
 		break;
 	}
@@ -1010,7 +1010,7 @@ void ARM64XEmitter::B(CCFlags cond, const void* ptr)
 
 	distance >>= 2;
 
-	_assert_msg_(DYNA_REC, IsInRangeImm19(distance), "%s: Received too large distance: %p->%p %lld %llx", __FUNCTION__, m_code, ptr, distance, distance);
+	_assert_msg_(IsInRangeImm19(distance), "%s: Received too large distance: %p->%p %lld %llx", __FUNCTION__, m_code, ptr, distance, distance);
 	Write32((0x54 << 24) | (MaskImm19(distance) << 5) | cond);
 }
 
@@ -1119,7 +1119,7 @@ void ARM64XEmitter::_MSR(PStateField field, u8 imm)
 		case FIELD_DAIFSet: op1 = 3; op2 = 6; break;
 		case FIELD_DAIFClr: op1 = 3; op2 = 7; break;
 		default:
-			_assert_msg_(JIT, false, "Invalid PStateField to do a imm move to");
+			_assert_msg_(false, "Invalid PStateField to do a imm move to");
 			break;
 	}
 	EncodeSystemInst(0, op1, 4, imm, op2, WSP);
@@ -1137,21 +1137,21 @@ static void GetSystemReg(PStateField field, int &o0, int &op1, int &CRn, int &CR
 		o0 = 3; op1 = 3; CRn = 4; CRm = 4; op2 = 1;
 		break;
 	default:
-		_assert_msg_(JIT, false, "Invalid PStateField to do a register move from/to");
+		_assert_msg_(false, "Invalid PStateField to do a register move from/to");
 		break;
 	}
 }
 
 void ARM64XEmitter::_MSR(PStateField field, ARM64Reg Rt) {
 	int o0 = 0, op1 = 0, CRn = 0, CRm = 0, op2 = 0;
-	_assert_msg_(JIT, Is64Bit(Rt), "MSR: Rt must be 64-bit");
+	_assert_msg_(Is64Bit(Rt), "MSR: Rt must be 64-bit");
 	GetSystemReg(field, o0, op1, CRn, CRm, op2);
 	EncodeSystemInst(o0, op1, CRn, CRm, op2, DecodeReg(Rt));
 }
 
 void ARM64XEmitter::MRS(ARM64Reg Rt, PStateField field) {
 	int o0 = 0, op1 = 0, CRn = 0, CRm = 0, op2 = 0;
-	_assert_msg_(JIT, Is64Bit(Rt), "MRS: Rt must be 64-bit");
+	_assert_msg_(Is64Bit(Rt), "MRS: Rt must be 64-bit");
 	GetSystemReg(field, o0, op1, CRn, CRm, op2);
 	EncodeSystemInst(o0 | 4, op1, CRn, CRm, op2, DecodeReg(Rt));
 }
@@ -1475,7 +1475,7 @@ void ARM64XEmitter::MOV(ARM64Reg Rd, ARM64Reg Rm)
 	if (IsGPR(Rd) && IsGPR(Rm)) {
 		ORR(Rd, Is64Bit(Rd) ? ZR : WZR, Rm, ArithOption(Rm, ST_LSL, 0));
 	} else {
-		_assert_msg_(JIT, false, "Non-GPRs not supported in MOV");
+		_assert_msg_(false, "Non-GPRs not supported in MOV");
 	}
 }
 
@@ -1587,14 +1587,14 @@ void ARM64XEmitter::UBFM(ARM64Reg Rd, ARM64Reg Rn, u32 immr, u32 imms)
 void ARM64XEmitter::BFI(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
 {
 	u32 size = Is64Bit(Rn) ? 64 : 32;
-	_assert_msg_(DYNA_REC, (lsb + width) <= size, "%s passed lsb %d and width %d which is greater than the register size!",
+	_assert_msg_((lsb + width) <= size, "%s passed lsb %d and width %d which is greater than the register size!",
 			__FUNCTION__, lsb, width);
 	EncodeBitfieldMOVInst(1, Rd, Rn, (size - lsb) % size, width - 1);
 }
 void ARM64XEmitter::UBFIZ(ARM64Reg Rd, ARM64Reg Rn, u32 lsb, u32 width)
 {
 	u32 size = Is64Bit(Rn) ? 64 : 32;
-	_assert_msg_(DYNA_REC, (lsb + width) <= size, "%s passed lsb %d and width %d which is greater than the register size!",
+	_assert_msg_((lsb + width) <= size, "%s passed lsb %d and width %d which is greater than the register size!",
 			__FUNCTION__, lsb, width);
 	EncodeBitfieldMOVInst(2, Rd, Rn, (size - lsb) % size, width - 1);
 }
@@ -1616,7 +1616,7 @@ void ARM64XEmitter::SXTH(ARM64Reg Rd, ARM64Reg Rn)
 }
 void ARM64XEmitter::SXTW(ARM64Reg Rd, ARM64Reg Rn)
 {
-	_assert_msg_(DYNA_REC, Is64Bit(Rd), "%s requires 64bit register as destination", __FUNCTION__);
+	_assert_msg_(Is64Bit(Rd), "%s requires 64bit register as destination", __FUNCTION__);
 	SBFM(Rd, Rn, 0, 31);
 }
 void ARM64XEmitter::UXTB(ARM64Reg Rd, ARM64Reg Rn)
@@ -1912,7 +1912,7 @@ void ARM64XEmitter::LDUR(ARM64Reg Rt, ARM64Reg Rn, s32 imm)
 }
 void ARM64XEmitter::LDURSW(ARM64Reg Rt, ARM64Reg Rn, s32 imm)
 {
-	_assert_msg_(DYNA_REC, !Is64Bit(Rt), "%s must have a 64bit destination register!", __FUNCTION__);
+	_assert_msg_(!Is64Bit(Rt), "%s must have a 64bit destination register!", __FUNCTION__);
 	EncodeLoadStoreUnscaled(2, 2, Rt, Rn, imm);
 }
 
@@ -2067,8 +2067,8 @@ void ARM64FloatEmitter::EmitLoadStoreImmediate(u8 size, u32 opc, IndexType type,
 
 	if (type == INDEX_UNSIGNED)
 	{
-		_assert_msg_(DYNA_REC, !(imm & ((size - 1) >> 3)), "%s(INDEX_UNSIGNED) immediate offset must be aligned to size! (%d) (%p)", __FUNCTION__, imm, m_emit->GetCodePointer());
-		_assert_msg_(DYNA_REC, imm >= 0, "%s(INDEX_UNSIGNED) immediate offset must be positive!", __FUNCTION__);
+		_assert_msg_(!(imm & ((size - 1) >> 3)), "%s(INDEX_UNSIGNED) immediate offset must be aligned to size! (%d) (%p)", __FUNCTION__, imm, m_emit->GetCodePointer());
+		_assert_msg_(imm >= 0, "%s(INDEX_UNSIGNED) immediate offset must be positive!", __FUNCTION__);
 		if (size == 16)
 			imm >>= 1;
 		else if (size == 32)
@@ -2081,7 +2081,7 @@ void ARM64FloatEmitter::EmitLoadStoreImmediate(u8 size, u32 opc, IndexType type,
 	}
 	else
 	{
-		_assert_msg_(DYNA_REC, !(imm < -256 || imm > 255), "%s immediate offset must be within range of -256 to 255!", __FUNCTION__);
+		_assert_msg_(!(imm < -256 || imm > 255), "%s immediate offset must be within range of -256 to 255!", __FUNCTION__);
 		encoded_imm = (imm & 0x1FF) << 2;
 		if (type == INDEX_POST)
 			encoded_imm |= 1;
@@ -2095,7 +2095,7 @@ void ARM64FloatEmitter::EmitLoadStoreImmediate(u8 size, u32 opc, IndexType type,
 
 void ARM64FloatEmitter::EmitScalar2Source(bool M, bool S, u32 type, u32 opcode, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {
-	_assert_msg_(DYNA_REC, !IsQuad(Rd), "%s only supports double and single registers!", __FUNCTION__);
+	_assert_msg_(!IsQuad(Rd), "%s only supports double and single registers!", __FUNCTION__);
 	Rd = DecodeReg(Rd);
 	Rn = DecodeReg(Rn);
 	Rm = DecodeReg(Rm);
@@ -2106,7 +2106,7 @@ void ARM64FloatEmitter::EmitScalar2Source(bool M, bool S, u32 type, u32 opcode, 
 
 void ARM64FloatEmitter::EmitThreeSame(bool U, u32 size, u32 opcode, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {
-	_assert_msg_(DYNA_REC, !IsSingle(Rd), "%s doesn't support singles!", __FUNCTION__);
+	_assert_msg_(!IsSingle(Rd), "%s doesn't support singles!", __FUNCTION__);
 	bool quad = IsQuad(Rd);
 	Rd = DecodeReg(Rd);
 	Rn = DecodeReg(Rn);
@@ -2127,7 +2127,7 @@ void ARM64FloatEmitter::EmitCopy(bool Q, u32 op, u32 imm5, u32 imm4, ARM64Reg Rd
 
 void ARM64FloatEmitter::Emit2RegMisc(bool Q, bool U, u32 size, u32 opcode, ARM64Reg Rd, ARM64Reg Rn)
 {
-	_assert_msg_(DYNA_REC, !IsSingle(Rd), "%s doesn't support singles!", __FUNCTION__);
+	_assert_msg_(!IsSingle(Rd), "%s doesn't support singles!", __FUNCTION__);
 	Rd = DecodeReg(Rd);
 	Rn = DecodeReg(Rn);
 
@@ -2137,7 +2137,7 @@ void ARM64FloatEmitter::Emit2RegMisc(bool Q, bool U, u32 size, u32 opcode, ARM64
 
 void ARM64FloatEmitter::EmitLoadStoreSingleStructure(bool L, bool R, u32 opcode, bool S, u32 size, ARM64Reg Rt, ARM64Reg Rn)
 {
-	_assert_msg_(DYNA_REC, !IsSingle(Rt), "%s doesn't support singles!", __FUNCTION__);
+	_assert_msg_(!IsSingle(Rt), "%s doesn't support singles!", __FUNCTION__);
 	bool quad = IsQuad(Rt);
 	Rt = DecodeReg(Rt);
 	Rn = DecodeReg(Rn);
@@ -2148,7 +2148,7 @@ void ARM64FloatEmitter::EmitLoadStoreSingleStructure(bool L, bool R, u32 opcode,
 
 void ARM64FloatEmitter::EmitLoadStoreSingleStructure(bool L, bool R, u32 opcode, bool S, u32 size, ARM64Reg Rt, ARM64Reg Rn, ARM64Reg Rm)
 {
-	_assert_msg_(DYNA_REC, !IsSingle(Rt), "%s doesn't support singles!", __FUNCTION__);
+	_assert_msg_(!IsSingle(Rt), "%s doesn't support singles!", __FUNCTION__);
 	bool quad = IsQuad(Rt);
 	Rt = DecodeReg(Rt);
 	Rn = DecodeReg(Rn);
@@ -2160,7 +2160,7 @@ void ARM64FloatEmitter::EmitLoadStoreSingleStructure(bool L, bool R, u32 opcode,
 
 void ARM64FloatEmitter::Emit1Source(bool M, bool S, u32 type, u32 opcode, ARM64Reg Rd, ARM64Reg Rn)
 {
-	_assert_msg_(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __FUNCTION__);
+	_assert_msg_(!IsQuad(Rd), "%s doesn't support vector!", __FUNCTION__);
 	Rd = DecodeReg(Rd);
 	Rn = DecodeReg(Rn);
 
@@ -2170,7 +2170,7 @@ void ARM64FloatEmitter::Emit1Source(bool M, bool S, u32 type, u32 opcode, ARM64R
 
 void ARM64FloatEmitter::EmitConversion(bool sf, bool S, u32 type, u32 rmode, u32 opcode, ARM64Reg Rd, ARM64Reg Rn)
 {
-	_assert_msg_(DYNA_REC, Rn <= SP, "%s only supports GPR as source!", __FUNCTION__);
+	_assert_msg_(Rn <= SP, "%s only supports GPR as source!", __FUNCTION__);
 	Rd = DecodeReg(Rd);
 	Rn = DecodeReg(Rn);
 
@@ -2180,7 +2180,7 @@ void ARM64FloatEmitter::EmitConversion(bool sf, bool S, u32 type, u32 rmode, u32
 
 void ARM64FloatEmitter::EmitConvertScalarToInt(ARM64Reg Rd, ARM64Reg Rn, RoundingMode round, bool sign)
 {
-	_dbg_assert_msg_(JIT, IsScalar(Rn), "fcvts: Rn must be floating point");
+	_dbg_assert_msg_(IsScalar(Rn), "fcvts: Rn must be floating point");
 	if (IsGPR(Rd)) {
 		// Use the encoding that transfers the result to a GPR.
 		bool sf = Is64Bit(Rd);
@@ -2235,7 +2235,7 @@ void ARM64FloatEmitter::EmitConversion2(bool sf, bool S, bool direction, u32 typ
 
 void ARM64FloatEmitter::EmitCompare(bool M, bool S, u32 op, u32 opcode2, ARM64Reg Rn, ARM64Reg Rm)
 {
-	_assert_msg_(DYNA_REC, !IsQuad(Rn), "%s doesn't support vector!", __FUNCTION__);
+	_assert_msg_(!IsQuad(Rn), "%s doesn't support vector!", __FUNCTION__);
 	bool is_double = IsDouble(Rn);
 
 	Rn = DecodeReg(Rn);
@@ -2247,7 +2247,7 @@ void ARM64FloatEmitter::EmitCompare(bool M, bool S, u32 op, u32 opcode2, ARM64Re
 
 void ARM64FloatEmitter::EmitCondSelect(bool M, bool S, CCFlags cond, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {
-	_assert_msg_(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __FUNCTION__);
+	_assert_msg_(!IsQuad(Rd), "%s doesn't support vector!", __FUNCTION__);
 	bool is_double = IsDouble(Rd);
 
 	Rd = DecodeReg(Rd);
@@ -2260,7 +2260,7 @@ void ARM64FloatEmitter::EmitCondSelect(bool M, bool S, CCFlags cond, ARM64Reg Rd
 
 void ARM64FloatEmitter::EmitPermute(u32 size, u32 op, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {
-	_assert_msg_(DYNA_REC, !IsSingle(Rd), "%s doesn't support singles!", __FUNCTION__);
+	_assert_msg_(!IsSingle(Rd), "%s doesn't support singles!", __FUNCTION__);
 
 	bool quad = IsQuad(Rd);
 
@@ -2282,7 +2282,7 @@ void ARM64FloatEmitter::EmitPermute(u32 size, u32 op, ARM64Reg Rd, ARM64Reg Rn, 
 
 void ARM64FloatEmitter::EmitScalarImm(bool M, bool S, u32 type, u32 imm5, ARM64Reg Rd, u32 imm8)
 {
-	_assert_msg_(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __FUNCTION__);
+	_assert_msg_(!IsQuad(Rd), "%s doesn't support vector!", __FUNCTION__);
 
 	bool is_double = !IsSingle(Rd);
 
@@ -2294,7 +2294,7 @@ void ARM64FloatEmitter::EmitScalarImm(bool M, bool S, u32 type, u32 imm5, ARM64R
 
 void ARM64FloatEmitter::EmitShiftImm(bool Q, bool U, u32 immh, u32 immb, u32 opcode, ARM64Reg Rd, ARM64Reg Rn)
 {
-	_assert_msg_(DYNA_REC, immh, "%s bad encoding! Can't have zero immh", __FUNCTION__);
+	_assert_msg_(immh, "%s bad encoding! Can't have zero immh", __FUNCTION__);
 
 	Rd = DecodeReg(Rd);
 	Rn = DecodeReg(Rn);
@@ -2352,7 +2352,7 @@ void ARM64FloatEmitter::EmitLoadStoreMultipleStructurePost(u32 size, bool L, u32
 
 void ARM64FloatEmitter::EmitScalar1Source(bool M, bool S, u32 type, u32 opcode, ARM64Reg Rd, ARM64Reg Rn)
 {
-	_assert_msg_(DYNA_REC, !IsQuad(Rd), "%s doesn't support vector!", __FUNCTION__);
+	_assert_msg_(!IsQuad(Rd), "%s doesn't support vector!", __FUNCTION__);
 
 	Rd = DecodeReg(Rd);
 	Rn = DecodeReg(Rn);
@@ -2375,7 +2375,7 @@ void ARM64FloatEmitter::EmitVectorxElement(bool U, u32 size, bool L, u32 opcode,
 
 void ARM64FloatEmitter::EmitLoadStoreUnscaled(u32 size, u32 op, ARM64Reg Rt, ARM64Reg Rn, s32 imm)
 {
-	_assert_msg_(DYNA_REC, !(imm < -256 || imm > 255), "%s received too large offset: %d", __FUNCTION__, imm);
+	_assert_msg_(!(imm < -256 || imm > 255), "%s received too large offset: %d", __FUNCTION__, imm);
 	Rt = DecodeReg(Rt);
 	Rn = DecodeReg(Rn);
 
@@ -2399,25 +2399,25 @@ void ARM64FloatEmitter::EncodeLoadStorePair(u32 size, bool load, IndexType type,
 		type_encode = 3;
 		break;
 	case INDEX_UNSIGNED:
-		_assert_msg_(DYNA_REC, false, "%s doesn't support INDEX_UNSIGNED!", __FUNCTION__);
+		_assert_msg_(false, "%s doesn't support INDEX_UNSIGNED!", __FUNCTION__);
 		break;
 	}
 
 	if (size == 128)
 	{
-		_assert_msg_(DYNA_REC, !(imm & 0xF), "%s received invalid offset 0x%x!", __FUNCTION__, imm);
+		_assert_msg_(!(imm & 0xF), "%s received invalid offset 0x%x!", __FUNCTION__, imm);
 		opc = 2;
 		imm >>= 4;
 	}
 	else if (size == 64)
 	{
-		_assert_msg_(DYNA_REC, !(imm & 0x7), "%s received invalid offset 0x%x!", __FUNCTION__, imm);
+		_assert_msg_(!(imm & 0x7), "%s received invalid offset 0x%x!", __FUNCTION__, imm);
 		opc = 1;
 		imm >>= 3;
 	}
 	else if (size == 32)
 	{
-		_assert_msg_(DYNA_REC, !(imm & 0x3), "%s received invalid offset 0x%x!", __FUNCTION__, imm);
+		_assert_msg_(!(imm & 0x3), "%s received invalid offset 0x%x!", __FUNCTION__, imm);
 		opc = 0;
 		imm >>= 2;
 	}
@@ -2433,7 +2433,7 @@ void ARM64FloatEmitter::EncodeLoadStorePair(u32 size, bool load, IndexType type,
 
 void ARM64FloatEmitter::EncodeLoadStoreRegisterOffset(u32 size, bool load, ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm)
 {
-	_assert_msg_(DYNA_REC, Rm.GetType() == ArithOption::TYPE_EXTENDEDREG, "%s must contain an extended reg as Rm!", __FUNCTION__);
+	_assert_msg_(Rm.GetType() == ArithOption::TYPE_EXTENDEDREG, "%s must contain an extended reg as Rm!", __FUNCTION__);
 
 	u32 encoded_size = 0;
 	u32 encoded_op = 0;
@@ -2786,7 +2786,7 @@ void ARM64FloatEmitter::ST1(u8 size, ARM64Reg Rt, u8 index, ARM64Reg Rn, ARM64Re
 // Loadstore multiple structure
 void ARM64FloatEmitter::LD1(u8 size, u8 count, ARM64Reg Rt, ARM64Reg Rn)
 {
-	_assert_msg_(DYNA_REC, !(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!", __FUNCTION__);
+	_assert_msg_(!(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!", __FUNCTION__);
 	u32 opcode = 0;
 	if (count == 1)
 		opcode = 7;
@@ -2800,8 +2800,8 @@ void ARM64FloatEmitter::LD1(u8 size, u8 count, ARM64Reg Rt, ARM64Reg Rn)
 }
 void ARM64FloatEmitter::LD1(u8 size, u8 count, IndexType type, ARM64Reg Rt, ARM64Reg Rn, ARM64Reg Rm)
 {
-	_assert_msg_(DYNA_REC, !(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!", __FUNCTION__);
-	_assert_msg_(DYNA_REC, type == INDEX_POST, "%s only supports post indexing!", __FUNCTION__);
+	_assert_msg_(!(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!", __FUNCTION__);
+	_assert_msg_(type == INDEX_POST, "%s only supports post indexing!", __FUNCTION__);
 
 	u32 opcode = 0;
 	if (count == 1)
@@ -2816,7 +2816,7 @@ void ARM64FloatEmitter::LD1(u8 size, u8 count, IndexType type, ARM64Reg Rt, ARM6
 }
 void ARM64FloatEmitter::ST1(u8 size, u8 count, ARM64Reg Rt, ARM64Reg Rn)
 {
-	_assert_msg_(DYNA_REC, !(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!", __FUNCTION__);
+	_assert_msg_(!(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!", __FUNCTION__);
 	u32 opcode = 0;
 	if (count == 1)
 		opcode = 7;
@@ -2830,8 +2830,8 @@ void ARM64FloatEmitter::ST1(u8 size, u8 count, ARM64Reg Rt, ARM64Reg Rn)
 }
 void ARM64FloatEmitter::ST1(u8 size, u8 count, IndexType type, ARM64Reg Rt, ARM64Reg Rn, ARM64Reg Rm)
 {
-	_assert_msg_(DYNA_REC, !(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!", __FUNCTION__);
-	_assert_msg_(DYNA_REC, type == INDEX_POST, "%s only supports post indexing!", __FUNCTION__);
+	_assert_msg_(!(count == 0 || count > 4), "%s must have a count of 1 to 4 registers!", __FUNCTION__);
+	_assert_msg_(type == INDEX_POST, "%s only supports post indexing!", __FUNCTION__);
 
 	u32 opcode = 0;
 	if (count == 1)
@@ -2851,7 +2851,7 @@ void ARM64FloatEmitter::FMOV(ARM64Reg Rd, ARM64Reg Rn, bool top)
 	if (IsScalar(Rd) && IsScalar(Rn)) {
 		EmitScalar1Source(0, 0, IsDouble(Rd), 0, Rd, Rn);
 	} else {
-		_assert_msg_(JIT, !IsQuad(Rd) && !IsQuad(Rn), "FMOV can't move to/from quads");
+		_assert_msg_(!IsQuad(Rd) && !IsQuad(Rn), "FMOV can't move to/from quads");
 		int rmode = 0;
 		int opcode = 6;
 		int sf = 0;
@@ -2862,7 +2862,7 @@ void ARM64FloatEmitter::FMOV(ARM64Reg Rd, ARM64Reg Rn, bool top)
 			// Scalar single to GPR - defaults are correct
 		} else {
 			// TODO
-			_assert_msg_(JIT, 0, "FMOV: Unhandled case");
+			_assert_msg_(false, "FMOV: Unhandled case");
 		}
 		Rd = DecodeReg(Rd);
 		Rn = DecodeReg(Rn);
@@ -3234,8 +3234,8 @@ void ARM64FloatEmitter::INS(u8 size, ARM64Reg Rd, u8 index1, ARM64Reg Rn, u8 ind
 void ARM64FloatEmitter::UMOV(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index)
 {
 	bool b64Bit = Is64Bit(Rd);
-	_assert_msg_(DYNA_REC, Rd < SP, "%s destination must be a GPR!", __FUNCTION__);
-	_assert_msg_(DYNA_REC, !(b64Bit && size != 64), "%s must have a size of 64 when destination is 64bit!", __FUNCTION__);
+	_assert_msg_(Rd < SP, "%s destination must be a GPR!", __FUNCTION__);
+	_assert_msg_(!(b64Bit && size != 64), "%s must have a size of 64 when destination is 64bit!", __FUNCTION__);
 	u32 imm5 = 0;
 
 	if (size == 8)
@@ -3264,8 +3264,8 @@ void ARM64FloatEmitter::UMOV(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index)
 void ARM64FloatEmitter::SMOV(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index)
 {
 	bool b64Bit = Is64Bit(Rd);
-	_assert_msg_(DYNA_REC, Rd < SP, "%s destination must be a GPR!", __FUNCTION__);
-	_assert_msg_(DYNA_REC, size != 64, "%s doesn't support 64bit destination. Use UMOV!", __FUNCTION__);
+	_assert_msg_(Rd < SP, "%s destination must be a GPR!", __FUNCTION__);
+	_assert_msg_(size != 64, "%s doesn't support 64bit destination. Use UMOV!", __FUNCTION__);
 	u32 imm5 = 0;
 
 	if (size == 8)
@@ -3499,40 +3499,40 @@ static u32 EncodeImmShiftRight(u8 src_size, u32 shift) {
 
 void ARM64FloatEmitter::SSHLL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, bool upper)
 {
-	_assert_msg_(DYNA_REC, shift < src_size, "%s shift amount must less than the element size!", __FUNCTION__);
+	_assert_msg_(shift < src_size, "%s shift amount must less than the element size!", __FUNCTION__);
 	u32 imm = EncodeImmShiftLeft(src_size, shift);
 	EmitShiftImm(upper, 0, imm >> 3, imm & 7, 0x14, Rd, Rn);
 }
 
 void ARM64FloatEmitter::USHLL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, bool upper)
 {
-	_assert_msg_(DYNA_REC, shift < src_size, "%s shift amount must less than the element size!", __FUNCTION__);
+	_assert_msg_(shift < src_size, "%s shift amount must less than the element size!", __FUNCTION__);
 	u32 imm = EncodeImmShiftLeft(src_size, shift);
 	EmitShiftImm(upper, 1, imm >> 3, imm & 7, 0x14, Rd, Rn);
 }
 
 void ARM64FloatEmitter::SHRN(u8 dest_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, bool upper)
 {
-	_assert_msg_(DYNA_REC, shift > 0, "%s shift amount must be greater than zero!", __FUNCTION__);
-	_assert_msg_(DYNA_REC, shift <= dest_size, "%s shift amount must less than or equal to the element size!", __FUNCTION__);
+	_assert_msg_(shift > 0, "%s shift amount must be greater than zero!", __FUNCTION__);
+	_assert_msg_(shift <= dest_size, "%s shift amount must less than or equal to the element size!", __FUNCTION__);
 	u32 imm = EncodeImmShiftRight(dest_size, shift);
 	EmitShiftImm(upper, 0, imm >> 3, imm & 7, 0x10, Rd, Rn);
 }
 
 void ARM64FloatEmitter::SHL(u8 dest_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift) {
-	_assert_msg_(DYNA_REC, shift < dest_size, "%s shift amount must less than the element size!", __FUNCTION__);
+	_assert_msg_(shift < dest_size, "%s shift amount must less than the element size!", __FUNCTION__);
 	u32 imm = EncodeImmShiftLeft(dest_size, shift);
 	EmitShiftImm(IsQuad(Rd), false, imm >> 3, imm & 7, 0xA, Rd, Rn);
 }
 
 void ARM64FloatEmitter::USHR(u8 dest_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift) {
-	_assert_msg_(DYNA_REC, shift < dest_size, "%s shift amount must less than the element size!", __FUNCTION__);
+	_assert_msg_(shift < dest_size, "%s shift amount must less than the element size!", __FUNCTION__);
 	u32 imm = EncodeImmShiftRight(dest_size, shift);
 	EmitShiftImm(IsQuad(Rd), true, imm >> 3, imm & 7, 0x0, Rd, Rn);
 }
 
 void ARM64FloatEmitter::SSHR(u8 dest_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift) {
-	_assert_msg_(DYNA_REC, shift < dest_size, "%s shift amount must less than the element size!", __FUNCTION__);
+	_assert_msg_(shift < dest_size, "%s shift amount must less than the element size!", __FUNCTION__);
 	u32 imm = EncodeImmShiftRight(dest_size, shift);
 	EmitShiftImm(IsQuad(Rd), false, imm >> 3, imm & 7, 0x0, Rd, Rn);
 }
@@ -3550,7 +3550,7 @@ void ARM64FloatEmitter::UXTL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, bool upper)
 // vector x indexed element
 void ARM64FloatEmitter::FMUL(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 index)
 {
-	_assert_msg_(DYNA_REC, size == 32 || size == 64, "%s only supports 32bit or 64bit size!", __FUNCTION__);
+	_assert_msg_(size == 32 || size == 64, "%s only supports 32bit or 64bit size!", __FUNCTION__);
 
 	bool L = false;
 	bool H = false;
@@ -3566,7 +3566,7 @@ void ARM64FloatEmitter::FMUL(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 
 
 void ARM64FloatEmitter::FMLA(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 index)
 {
-	_assert_msg_(DYNA_REC, size == 32 || size == 64, "%s only supports 32bit or 64bit size!", __FUNCTION__);
+	_assert_msg_(size == 32 || size == 64, "%s only supports 32bit or 64bit size!", __FUNCTION__);
 
 	bool L = false;
 	bool H = false;
@@ -3581,7 +3581,7 @@ void ARM64FloatEmitter::FMLA(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 
 }
 
 void ARM64FloatEmitter::ABI_PushRegisters(uint32_t registers, uint32_t fp_registers) {
-	_assert_msg_(DYNA_REC, (registers & 0x60000000) == 0, "ABI_PushRegisters: Do not include FP and LR, those are handled non-conditionally");
+	_assert_msg_((registers & 0x60000000) == 0, "ABI_PushRegisters: Do not include FP and LR, those are handled non-conditionally");
 
 	ARM64Reg gprs[32]{}, fprs[32]{};
 	int num_gprs = 0, num_fprs = 0;
@@ -3676,25 +3676,25 @@ void ARM64XEmitter::ANDI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch) 
 	if (!Is64Bit(Rn))
 		imm &= 0xFFFFFFFF;
 	if (!TryANDI2R(Rd, Rn, imm)) {
-		_assert_msg_(JIT, scratch != INVALID_REG, "ANDI2R - failed to construct logical immediate value from %08x, need scratch", (u32)imm);
+		_assert_msg_(scratch != INVALID_REG, "ANDI2R - failed to construct logical immediate value from %08x, need scratch", (u32)imm);
 		MOVI2R(scratch, imm);
 		AND(Rd, Rn, scratch);
 	}
 }
 
 void ARM64XEmitter::ORRI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch) {
-	_assert_msg_(JIT, Is64Bit(Rn) || (imm & 0xFFFFFFFF00000000UL) == 0, "ORRI2R - more bits in imm than Rn");
+	_assert_msg_(Is64Bit(Rn) || (imm & 0xFFFFFFFF00000000UL) == 0, "ORRI2R - more bits in imm than Rn");
 	if (!TryORRI2R(Rd, Rn, imm)) {
-		_assert_msg_(JIT, scratch != INVALID_REG, "ORRI2R - failed to construct logical immediate value from %08x, need scratch", (u32)imm);
+		_assert_msg_(scratch != INVALID_REG, "ORRI2R - failed to construct logical immediate value from %08x, need scratch", (u32)imm);
 		MOVI2R(scratch, imm);
 		ORR(Rd, Rn, scratch);
 	}
 }
 
 void ARM64XEmitter::EORI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch) {
-	_assert_msg_(JIT, Is64Bit(Rn) || (imm & 0xFFFFFFFF00000000UL) == 0, "EORI2R - more bits in imm than Rn");
+	_assert_msg_(Is64Bit(Rn) || (imm & 0xFFFFFFFF00000000UL) == 0, "EORI2R - more bits in imm than Rn");
 	if (!TryEORI2R(Rd, Rn, imm)) {
-		_assert_msg_(JIT, scratch != INVALID_REG, "EORI2R - failed to construct logical immediate value from %08x, need scratch", (u32)imm);
+		_assert_msg_(scratch != INVALID_REG, "EORI2R - failed to construct logical immediate value from %08x, need scratch", (u32)imm);
 		MOVI2R(scratch, imm);
 		EOR(Rd, Rn, scratch);
 	}
@@ -3709,7 +3709,7 @@ void ARM64XEmitter::ANDSI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch)
 	} else if (imm == 0) {
 		ANDS(Rd, Rn, Is64Bit(Rn) ? ZR : WZR);
 	} else {
-		_assert_msg_(JIT, scratch != INVALID_REG, "ANDSI2R - failed to construct logical immediate value from %08x, need scratch", (u32)imm);
+		_assert_msg_(scratch != INVALID_REG, "ANDSI2R - failed to construct logical immediate value from %08x, need scratch", (u32)imm);
 		MOVI2R(scratch, imm);
 		ANDS(Rd, Rn, scratch);
 	}
@@ -3717,7 +3717,7 @@ void ARM64XEmitter::ANDSI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch)
 
 void ARM64XEmitter::ADDI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch) {
 	if (!TryADDI2R(Rd, Rn, imm)) {
-		_assert_msg_(JIT, scratch != INVALID_REG, "ADDI2R - failed to construct arithmetic immediate value from %08x, need scratch", (u32)imm);
+		_assert_msg_(scratch != INVALID_REG, "ADDI2R - failed to construct arithmetic immediate value from %08x, need scratch", (u32)imm);
 		MOVI2R(scratch, imm);
 		ADD(Rd, Rn, scratch);
 	}
@@ -3725,7 +3725,7 @@ void ARM64XEmitter::ADDI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch) 
 
 void ARM64XEmitter::SUBI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch) {
 	if (!TrySUBI2R(Rd, Rn, imm)) {
-		_assert_msg_(JIT, scratch != INVALID_REG, "SUBI2R - failed to construct arithmetic immediate value from %08x, need scratch", (u32)imm);
+		_assert_msg_(scratch != INVALID_REG, "SUBI2R - failed to construct arithmetic immediate value from %08x, need scratch", (u32)imm);
 		MOVI2R(scratch, imm);
 		SUB(Rd, Rn, scratch);
 	}
@@ -3733,7 +3733,7 @@ void ARM64XEmitter::SUBI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch) 
 
 void ARM64XEmitter::CMPI2R(ARM64Reg Rn, u64 imm, ARM64Reg scratch) {
 	if (!TryCMPI2R(Rn, imm)) {
-		_assert_msg_(JIT, scratch != INVALID_REG, "CMPI2R - failed to construct arithmetic immediate value from %08x, need scratch", (u32)imm);
+		_assert_msg_(scratch != INVALID_REG, "CMPI2R - failed to construct arithmetic immediate value from %08x, need scratch", (u32)imm);
 		MOVI2R(scratch, imm);
 		CMP(Rn, scratch);
 	}
@@ -3807,7 +3807,7 @@ bool ARM64XEmitter::TryANDI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm) {
 	}
 }
 bool ARM64XEmitter::TryORRI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm) {
-	_assert_msg_(JIT, Is64Bit(Rn) || (imm & 0xFFFFFFFF00000000UL) == 0, "TryORRI2R - more bits in imm than Rn");
+	_assert_msg_(Is64Bit(Rn) || (imm & 0xFFFFFFFF00000000UL) == 0, "TryORRI2R - more bits in imm than Rn");
 	u32 n, imm_r, imm_s;
 	if (IsImmLogical(imm, Is64Bit(Rn) ? 64 : 32, &n, &imm_s, &imm_r)) {
 		ORR(Rd, Rn, imm_r, imm_s, n != 0);
@@ -3822,7 +3822,7 @@ bool ARM64XEmitter::TryORRI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm) {
 	}
 }
 bool ARM64XEmitter::TryEORI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm) {
-	_assert_msg_(JIT, Is64Bit(Rn) || (imm & 0xFFFFFFFF00000000UL) == 0, "TryEORI2R - more bits in imm than Rn");
+	_assert_msg_(Is64Bit(Rn) || (imm & 0xFFFFFFFF00000000UL) == 0, "TryEORI2R - more bits in imm than Rn");
 	u32 n, imm_r, imm_s;
 	if (IsImmLogical(imm, Is64Bit(Rn) ? 64 : 32, &n, &imm_s, &imm_r)) {
 		EOR(Rd, Rn, imm_r, imm_s, n != 0);
@@ -3872,7 +3872,7 @@ bool FPImm8FromFloat(float value, uint8_t *immOut) {
 }
 
 void ARM64FloatEmitter::MOVI2F(ARM64Reg Rd, float value, ARM64Reg scratch, bool negate) {
-	_assert_msg_(JIT, !IsDouble(Rd), "MOVI2F does not yet support double precision");
+	_assert_msg_(!IsDouble(Rd), "MOVI2F does not yet support double precision");
 	uint8_t imm8;
 	if (value == 0.0) {
 		if (std::signbit(value)) {
@@ -3891,7 +3891,7 @@ void ARM64FloatEmitter::MOVI2F(ARM64Reg Rd, float value, ARM64Reg scratch, bool 
 			FNEG(Rd, Rd);
 		}
 	} else {
-		_assert_msg_(JIT, scratch != INVALID_REG, "Failed to find a way to generate FP immediate %f without scratch", value);
+		_assert_msg_(scratch != INVALID_REG, "Failed to find a way to generate FP immediate %f without scratch", value);
 		u32 ival;
 		if (negate) {
 			value = -value;
@@ -3923,7 +3923,7 @@ void ARM64XEmitter::SUBSI2R(ARM64Reg Rd, ARM64Reg Rn, u64 imm, ARM64Reg scratch)
 	if (IsImmArithmetic(imm, &val, &shift)) {
 		SUBS(Rd, Rn, val, shift);
 	} else {
-		_assert_msg_(JIT, scratch != INVALID_REG, "SUBSI2R - failed to construct immediate value from %08x, need scratch", (u32)imm);
+		_assert_msg_(scratch != INVALID_REG, "SUBSI2R - failed to construct immediate value from %08x, need scratch", (u32)imm);
 		MOVI2R(scratch, imm);
 		SUBS(Rd, Rn, scratch);
 	}

--- a/Common/Arm64Emitter.h
+++ b/Common/Arm64Emitter.h
@@ -329,7 +329,7 @@ public:
 				       (m_shift << 10);
 			break;
 			default:
-				_dbg_assert_msg_(DYNA_REC, false, "Invalid type in GetData");
+				_dbg_assert_msg_(false, "Invalid type in GetData");
 			break;
 		}
 		return 0;
@@ -697,7 +697,7 @@ public:
 	void MOVI2R(ARM64Reg Rd, u64 imm, bool optimize = true);
 	template <class P>
 	void MOVP2R(ARM64Reg Rd, P *ptr) {
-		_assert_msg_(JIT, Is64Bit(Rd), "Can't store pointers in 32-bit registers");
+		_assert_msg_(Is64Bit(Rd), "Can't store pointers in 32-bit registers");
 		MOVI2R(Rd, (uintptr_t)ptr);
 	}
 

--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -905,12 +905,12 @@ void ARMXEmitter::WriteSignedMultiply(u32 Op, u32 Op2, u32 Op3, ARMReg dest, ARM
 }
 void ARMXEmitter::UDIV(ARMReg dest, ARMReg dividend, ARMReg divisor)
 {
-	_assert_(cpu_info.bIDIVa, "Trying to use integer divide on hardware that doesn't support it. Bad programmer.");
+	_assert_msg_(cpu_info.bIDIVa, "Trying to use integer divide on hardware that doesn't support it.");
 	WriteSignedMultiply(3, 0xF, 0, dest, divisor, dividend);
 }
 void ARMXEmitter::SDIV(ARMReg dest, ARMReg dividend, ARMReg divisor)
 {
-	_assert_(cpu_info.bIDIVa, "Trying to use integer divide on hardware that doesn't support it. Bad programmer.");
+	_assert_msg_(cpu_info.bIDIVa, "Trying to use integer divide on hardware that doesn't support it.");
 	WriteSignedMultiply(1, 0xF, 0, dest, divisor, dividend);
 }
 

--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -95,7 +95,7 @@ bool TryMakeOperand2_AllowNegation(s32 imm, Operand2 &op2, bool *negated)
 Operand2 AssumeMakeOperand2(u32 imm) {
 	Operand2 op2;
 	bool result = TryMakeOperand2(imm, op2);
-	_dbg_assert_msg_(JIT, result, "Could not make assumed Operand2.");
+	_dbg_assert_msg_(result, "Could not make assumed Operand2.");
 	if (!result) {
 		// Make double sure that we get it logged.
 		ERROR_LOG(JIT, "Could not make assumed Operand2.");
@@ -705,7 +705,7 @@ FixupBranch ARMXEmitter::B_CC(CCFlags Cond)
 void ARMXEmitter::B_CC(CCFlags Cond, const void *fnptr)
 {
 	ptrdiff_t distance = (intptr_t)fnptr - ((intptr_t)(code) + 8);
-	_assert_msg_(JIT, distance > -0x2000000 && distance < 0x2000000,
+	_assert_msg_(distance > -0x2000000 && distance < 0x2000000,
                      "B_CC out of range (%p calls %p)", code, fnptr);
 
 	Write32((Cond << 28) | 0x0A000000 | ((distance >> 2) & 0x00FFFFFF));
@@ -723,7 +723,7 @@ FixupBranch ARMXEmitter::BL_CC(CCFlags Cond)
 void ARMXEmitter::SetJumpTarget(FixupBranch const &branch)
 {
 	ptrdiff_t distance =  ((intptr_t)(code) - 8)  - (intptr_t)branch.ptr;
-	_assert_msg_(JIT, distance > -0x2000000 && distance < 0x2000000,
+	_assert_msg_(distance > -0x2000000 && distance < 0x2000000,
 	             "SetJumpTarget out of range (%p calls %p)", code, branch.ptr);
 	u32 instr = (u32)(branch.condition | ((distance >> 2) & 0x00FFFFFF));
 	instr |= branch.type == 0 ? /* B */ 0x0A000000 : /* BL */ 0x0B000000;
@@ -732,7 +732,7 @@ void ARMXEmitter::SetJumpTarget(FixupBranch const &branch)
 void ARMXEmitter::B(const void *fnptr)
 {
 	ptrdiff_t distance = (intptr_t)fnptr - (intptr_t(code) + 8);
-	_assert_msg_(JIT, distance > -0x2000000 && distance < 0x2000000,
+	_assert_msg_(distance > -0x2000000 && distance < 0x2000000,
                      "B out of range (%p calls %p)", code, fnptr);
 
 	Write32(condition | 0x0A000000 | ((distance >> 2) & 0x00FFFFFF));
@@ -754,7 +754,7 @@ bool ARMXEmitter::BLInRange(const void *fnptr) const {
 void ARMXEmitter::BL(const void *fnptr)
 {
 	ptrdiff_t distance = (intptr_t)fnptr - (intptr_t(code) + 8);
-	_assert_msg_(JIT, distance > -0x2000000 && distance < 0x2000000,
+	_assert_msg_(distance > -0x2000000 && distance < 0x2000000,
                      "BL out of range (%p calls %p)", code, fnptr);
 	Write32(condition | 0x0B000000 | ((distance >> 2) & 0x00FFFFFF));
 }
@@ -894,7 +894,7 @@ void ARMXEmitter::WriteInstruction (u32 Op, ARMReg Rd, ARMReg Rn, Operand2 Rm, b
 		}
 	}
 	if (op == -1)
-		_assert_msg_(JIT, false, "%s not yet support %d", InstNames[Op], Rm.GetType()); 
+		_assert_msg_(false, "%s not yet support %d", InstNames[Op], Rm.GetType()); 
 	Write32(condition | (op << 21) | (SetFlags ? (1 << 20) : 0) | Rn << 16 | Rd << 12 | Data);
 }
 
@@ -921,21 +921,21 @@ void ARMXEmitter::LSLS(ARMReg dest, ARMReg src, Operand2 op2) { WriteShiftedData
 void ARMXEmitter::LSL (ARMReg dest, ARMReg src, ARMReg op2)   { WriteShiftedDataOp(1, false, dest, src, op2);} 
 void ARMXEmitter::LSLS(ARMReg dest, ARMReg src, ARMReg op2)   { WriteShiftedDataOp(1, true, dest, src, op2);}
 void ARMXEmitter::LSR (ARMReg dest, ARMReg src, Operand2 op2) {
-	_assert_msg_(JIT, op2.GetType() != TYPE_IMM || op2.Imm5() != 0, "LSR must have a non-zero shift (use LSL.)"); 
+	_assert_msg_(op2.GetType() != TYPE_IMM || op2.Imm5() != 0, "LSR must have a non-zero shift (use LSL.)"); 
 	WriteShiftedDataOp(2, false, dest, src, op2);
 }
 void ARMXEmitter::LSRS(ARMReg dest, ARMReg src, Operand2 op2) {
-	_assert_msg_(JIT, op2.GetType() != TYPE_IMM || op2.Imm5() != 0, "LSRS must have a non-zero shift (use LSLS.)");
+	_assert_msg_(op2.GetType() != TYPE_IMM || op2.Imm5() != 0, "LSRS must have a non-zero shift (use LSLS.)");
 	WriteShiftedDataOp(2, true, dest, src, op2);
 }
 void ARMXEmitter::LSR (ARMReg dest, ARMReg src, ARMReg op2)   { WriteShiftedDataOp(3, false, dest, src, op2);}
 void ARMXEmitter::LSRS(ARMReg dest, ARMReg src, ARMReg op2)   { WriteShiftedDataOp(3, true, dest, src, op2);}
 void ARMXEmitter::ASR (ARMReg dest, ARMReg src, Operand2 op2) {
-	_assert_msg_(JIT, op2.GetType() != TYPE_IMM || op2.Imm5() != 0, "ASR must have a non-zero shift (use LSL.)");
+	_assert_msg_(op2.GetType() != TYPE_IMM || op2.Imm5() != 0, "ASR must have a non-zero shift (use LSL.)");
 	WriteShiftedDataOp(4, false, dest, src, op2);
 }
 void ARMXEmitter::ASRS(ARMReg dest, ARMReg src, Operand2 op2) {
-	_assert_msg_(JIT, op2.GetType() != TYPE_IMM || op2.Imm5() != 0, "ASRS must have a non-zero shift (use LSLS.)");
+	_assert_msg_(op2.GetType() != TYPE_IMM || op2.Imm5() != 0, "ASRS must have a non-zero shift (use LSLS.)");
 	WriteShiftedDataOp(4, true, dest, src, op2);
 }
 void ARMXEmitter::ASR (ARMReg dest, ARMReg src, ARMReg op2)   { WriteShiftedDataOp(5, false, dest, src, op2);}
@@ -990,7 +990,7 @@ void ARMXEmitter::CLZ(ARMReg rd, ARMReg rm)
 }
 
 void ARMXEmitter::PLD(ARMReg rn, int offset, bool forWrite) {
-	_dbg_assert_msg_(JIT, offset < 0x3ff && offset > -0x3ff, "PLD: Max 12 bits of offset allowed");
+	_dbg_assert_msg_(offset < 0x3ff && offset > -0x3ff, "PLD: Max 12 bits of offset allowed");
 
 	bool U = offset >= 0;
 	if (offset < 0) offset = -offset;
@@ -1060,7 +1060,7 @@ void ARMXEmitter::LDREX(ARMReg dest, ARMReg base)
 }
 void ARMXEmitter::STREX(ARMReg result, ARMReg base, ARMReg op)
 {
-	_assert_msg_(JIT, (result != base && result != op), "STREX dest can't be other two registers");
+	_assert_msg_((result != base && result != op), "STREX dest can't be other two registers");
 	Write32(condition | (24 << 20) | (base << 16) | (result << 12) | (0xF9 << 4) | op);
 }
 void ARMXEmitter::DMB ()
@@ -1113,7 +1113,7 @@ void ARMXEmitter::WriteStoreOp(u32 Op, ARMReg Rt, ARMReg Rn, Operand2 Rm, bool R
 	bool SignedLoad = false;
 
 	if (op == -1)
-		_assert_msg_(JIT, false, "%s does not support %d", LoadStoreNames[Op], Rm.GetType()); 
+		_assert_msg_(false, "%s does not support %d", LoadStoreNames[Op], Rm.GetType()); 
 
 	switch (Op)
 	{
@@ -1205,7 +1205,7 @@ void ARMXEmitter::WriteRegStoreOp(u32 op, ARMReg dest, bool WriteBack, u16 RegLi
 }
 void ARMXEmitter::WriteVRegStoreOp(u32 op, ARMReg Rn, bool Double, bool WriteBack, ARMReg Vd, u8 numregs)
 {
-	_dbg_assert_msg_(JIT, !WriteBack || Rn != R_PC, "VLDM/VSTM cannot use WriteBack with PC (PC is deprecated anyway.)");
+	_dbg_assert_msg_(!WriteBack || Rn != R_PC, "VLDM/VSTM cannot use WriteBack with PC (PC is deprecated anyway.)");
 	Write32(condition | (op << 20) | (WriteBack << 21) | (Rn << 16) | EncodeVd(Vd) | ((0xA | (int)Double) << 8) | (numregs << (int)Double));
 }
 void ARMXEmitter::STMFD(ARMReg dest, bool WriteBack, const int Regnum, ...)
@@ -1259,8 +1259,8 @@ void ARMXEmitter::LDMBitmask(ARMReg dest, bool Add, bool Before, bool WriteBack,
 // NEON Specific
 void ARMXEmitter::VABD(IntegerSize Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_assert_msg_(JIT, Vd >= D0, "Pass invalid register to VABD(float)");
-	_assert_msg_(JIT, cpu_info.bNEON, "Can't use VABD(float) when CPU doesn't support it");
+	_assert_msg_(Vd >= D0, "Pass invalid register to VABD(float)");
+	_assert_msg_(cpu_info.bNEON, "Can't use VABD(float) when CPU doesn't support it");
 	bool register_quad = Vd >= Q0;
 
 	// Gets encoded as a double register
@@ -1274,8 +1274,8 @@ void ARMXEmitter::VABD(IntegerSize Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VADD(IntegerSize Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_assert_msg_(JIT, Vd >= D0, "Pass invalid register to VADD(integer)");
-	_assert_msg_(JIT, cpu_info.bNEON, "Can't use VADD(integer) when CPU doesn't support it");
+	_assert_msg_(Vd >= D0, "Pass invalid register to VADD(integer)");
+	_assert_msg_(cpu_info.bNEON, "Can't use VADD(integer) when CPU doesn't support it");
 
 	bool register_quad = Vd >= Q0;
 
@@ -1291,8 +1291,8 @@ void ARMXEmitter::VADD(IntegerSize Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VSUB(IntegerSize Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_assert_msg_(JIT, Vd >= Q0, "Pass invalid register to VSUB(integer)");
-	_assert_msg_(JIT, cpu_info.bNEON, "Can't use VSUB(integer) when CPU doesn't support it");
+	_assert_msg_(Vd >= Q0, "Pass invalid register to VSUB(integer)");
+	_assert_msg_(cpu_info.bNEON, "Can't use VSUB(integer) when CPU doesn't support it");
 
 	// Gets encoded as a double register
 	Vd = SubBase(Vd);
@@ -1399,7 +1399,7 @@ u32 encodedSize(u32 value)
 	else if (value & I_64)
 		return 3;
 	else
-		_dbg_assert_msg_(JIT, false, "Passed invalid size to integer NEON instruction");
+		_dbg_assert_msg_(false, "Passed invalid size to integer NEON instruction");
 	return 0;
 }
 
@@ -1444,7 +1444,7 @@ void ARMXEmitter::WriteVFPDataOp(u32 Op, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 
 	VFPEnc enc = VFPOps[Op][quad_reg];
 	if (enc.opc1 == -1 && enc.opc2 == -1)
-		_assert_msg_(JIT, false, "%s does not support %s", VFPOpNames[Op], quad_reg ? "NEON" : "VFP"); 
+		_assert_msg_(false, "%s does not support %s", VFPOpNames[Op], quad_reg ? "NEON" : "VFP"); 
 	u32 VdEnc = EncodeVd(Vd);
 	u32 VnEnc = EncodeVn(Vn);
 	u32 VmEnc = EncodeVm(Vm);
@@ -1481,25 +1481,25 @@ void ARMXEmitter::VSTMIA(ARMReg ptr, bool WriteBack, ARMReg firstvreg, int numvr
 
 void ARMXEmitter::VLDMDB(ARMReg ptr, bool WriteBack, ARMReg firstvreg, int numvregs)
 {
-	_dbg_assert_msg_(JIT, WriteBack, "Writeback is required for VLDMDB");
+	_dbg_assert_msg_(WriteBack, "Writeback is required for VLDMDB");
 	WriteVRegStoreOp(0x80 | 0x040 | 0x10 | 1, ptr, firstvreg >= D0, WriteBack, firstvreg, numvregs);
 }
 
 void ARMXEmitter::VSTMDB(ARMReg ptr, bool WriteBack, ARMReg firstvreg, int numvregs)
 {
-	_dbg_assert_msg_(JIT, WriteBack, "Writeback is required for VSTMDB");
+	_dbg_assert_msg_(WriteBack, "Writeback is required for VSTMDB");
 	WriteVRegStoreOp(0x80 | 0x040 | 0x10, ptr, firstvreg >= D0, WriteBack, firstvreg, numvregs);
 }
 
 void ARMXEmitter::VLDR(ARMReg Dest, ARMReg Base, s16 offset)
 {
-	_assert_msg_(JIT, Dest >= S0 && Dest <= D31, "Passed Invalid dest register to VLDR");
-	_assert_msg_(JIT, Base <= R15, "Passed invalid Base register to VLDR");
+	_assert_msg_(Dest >= S0 && Dest <= D31, "Passed Invalid dest register to VLDR");
+	_assert_msg_(Base <= R15, "Passed invalid Base register to VLDR");
 
 	bool Add = offset >= 0 ? true : false;
 	u32 imm = abs(offset);
 
-	_assert_msg_(JIT, (imm & 0xC03) == 0, "VLDR: Offset needs to be word aligned and small enough");
+	_assert_msg_((imm & 0xC03) == 0, "VLDR: Offset needs to be word aligned and small enough");
 
 	if (imm & 0xC03)
 		ERROR_LOG(JIT, "VLDR: Bad offset %08x", imm);
@@ -1521,13 +1521,13 @@ void ARMXEmitter::VLDR(ARMReg Dest, ARMReg Base, s16 offset)
 }
 void ARMXEmitter::VSTR(ARMReg Src, ARMReg Base, s16 offset)
 {
-	_assert_msg_(JIT, Src >= S0 && Src <= D31, "Passed invalid src register to VSTR");
-	_assert_msg_(JIT, Base <= R15, "Passed invalid base register to VSTR");
+	_assert_msg_(Src >= S0 && Src <= D31, "Passed invalid src register to VSTR");
+	_assert_msg_(Base <= R15, "Passed invalid base register to VSTR");
 
 	bool Add = offset >= 0 ? true : false;
 	u32 imm = abs(offset);
 
-	_assert_msg_(JIT, (imm & 0xC03) == 0, "VSTR: Offset needs to be word aligned and small enough");
+	_assert_msg_((imm & 0xC03) == 0, "VSTR: Offset needs to be word aligned and small enough");
 
 	if (imm & 0xC03)
 		ERROR_LOG(JIT, "VSTR: Bad offset %08x", imm);
@@ -1560,15 +1560,15 @@ void ARMXEmitter::VMSR(ARMReg Rt) {
 
 void ARMXEmitter::VMOV(ARMReg Dest, Operand2 op2)
 {
-	_assert_msg_(JIT, cpu_info.bVFPv3, "VMOV #imm requires VFPv3");
+	_assert_msg_(cpu_info.bVFPv3, "VMOV #imm requires VFPv3");
 	int sz = Dest >= D0 ? (1 << 8) : 0;
 	Write32(condition | (0xEB << 20) | EncodeVd(Dest) | (5 << 9) | sz | op2.Imm8VFP());
 }
 
 void ARMXEmitter::VMOV_neon(u32 Size, ARMReg Vd, u32 imm)
 {
-	_assert_msg_(JIT, cpu_info.bNEON, "VMOV_neon #imm requires NEON");
-	_assert_msg_(JIT, Vd >= D0, "VMOV_neon #imm must target a double or quad");
+	_assert_msg_(cpu_info.bNEON, "VMOV_neon #imm requires NEON");
+	_assert_msg_(Vd >= D0, "VMOV_neon #imm must target a double or quad");
 	bool register_quad = Vd >= Q0;
 
 	int cmode = 0;
@@ -1642,7 +1642,7 @@ void ARMXEmitter::VMOV_neon(u32 Size, ARMReg Vd, u32 imm)
 			cmode = 7 << 1;
 			op2 = IMM(imm8 | (imm8 << 4));
 		} else {
-			_assert_msg_(JIT, false, "VMOV_neon #imm invalid constant value");
+			_assert_msg_(false, "VMOV_neon #imm invalid constant value");
 		}
 	}
 
@@ -1652,7 +1652,7 @@ void ARMXEmitter::VMOV_neon(u32 Size, ARMReg Vd, u32 imm)
 
 void ARMXEmitter::VMOV_neon(u32 Size, ARMReg Vd, ARMReg Rt, int lane)
 {
-	_assert_msg_(JIT, cpu_info.bNEON, "VMOV_neon requires NEON");
+	_assert_msg_(cpu_info.bNEON, "VMOV_neon requires NEON");
 
 	int opc1 = 0;
 	int opc2 = 0;
@@ -1666,7 +1666,7 @@ void ARMXEmitter::VMOV_neon(u32 Size, ARMReg Vd, ARMReg Rt, int lane)
 		opc1 = lane & 1;
 		break;
 	default:
-		_assert_msg_(JIT, false, "VMOV_neon unsupported size");
+		_assert_msg_(false, "VMOV_neon unsupported size");
 	}
 
 	if (Vd < S0 && Rt >= D0 && Rt < Q0)
@@ -1675,7 +1675,7 @@ void ARMXEmitter::VMOV_neon(u32 Size, ARMReg Vd, ARMReg Rt, int lane)
 		ARMReg Src = Rt;
 		ARMReg Dest = Vd;
 
-		_dbg_assert_msg_(JIT, (Size & (I_UNSIGNED | I_SIGNED | F_32)) != 0, "Must specify I_SIGNED or I_UNSIGNED in VMOV, unless F_32");
+		_dbg_assert_msg_((Size & (I_UNSIGNED | I_SIGNED | F_32)) != 0, "Must specify I_SIGNED or I_UNSIGNED in VMOV, unless F_32");
 		int U = (Size & I_UNSIGNED) ? (1 << 23) : 0;
 
 		Write32(condition | (0xE1 << 20) | U | (opc1 << 21) | EncodeVn(Src) | (Dest << 12) | (0xB << 8) | (opc2 << 5) | (1 << 4));
@@ -1687,12 +1687,12 @@ void ARMXEmitter::VMOV_neon(u32 Size, ARMReg Vd, ARMReg Rt, int lane)
 		Write32(condition | (0xE0 << 20) | (opc1 << 21) | EncodeVn(Dest) | (Src << 12) | (0xB << 8) | (opc2 << 5) | (1 << 4));
 	}
 	else
-		_assert_msg_(JIT, false, "VMOV_neon unsupported arguments (Dx -> Rx or Rx -> Dx)");
+		_assert_msg_(false, "VMOV_neon unsupported arguments (Dx -> Rx or Rx -> Dx)");
 }
 
 void ARMXEmitter::VMOV(ARMReg Vd, ARMReg Rt, ARMReg Rt2)
 {
-	_assert_msg_(JIT, cpu_info.bVFP | cpu_info.bNEON, "VMOV_neon requires VFP or NEON");
+	_assert_msg_(cpu_info.bVFP | cpu_info.bNEON, "VMOV_neon requires VFP or NEON");
 
 	if (Vd < S0 && Rt < S0 && Rt2 >= D0)
 	{
@@ -1710,13 +1710,13 @@ void ARMXEmitter::VMOV(ARMReg Vd, ARMReg Rt, ARMReg Rt2)
 		Write32(condition | (0xC4 << 20) | (Src2 << 16) | (Src1 << 12) | (0xB << 8) | EncodeVm(Dest) | (1 << 4));
 	}
 	else
-		_assert_msg_(JIT, false, "VMOV_neon requires either Dm, Rt, Rt2 or Rt, Rt2, Dm.");
+		_assert_msg_(false, "VMOV_neon requires either Dm, Rt, Rt2 or Rt, Rt2, Dm.");
 }
 
 void ARMXEmitter::VMOV(ARMReg Dest, ARMReg Src, bool high)
 {
-	_assert_msg_(JIT, Src < S0, "This VMOV doesn't support SRC other than ARM Reg");
-	_assert_msg_(JIT, Dest >= D0, "This VMOV doesn't support DEST other than VFP");
+	_assert_msg_(Src < S0, "This VMOV doesn't support SRC other than ARM Reg");
+	_assert_msg_(Dest >= D0, "This VMOV doesn't support DEST other than VFP");
 
 	Dest = SubBase(Dest);
 
@@ -1744,7 +1744,7 @@ void ARMXEmitter::VMOV(ARMReg Dest, ARMReg Src)
 			else
 			{
 				// Move 64bit from Arm reg
-				_assert_msg_(JIT, false, "This VMOV doesn't support moving 64bit ARM to NEON");
+				_assert_msg_(false, "This VMOV doesn't support moving 64bit ARM to NEON");
 				return;
 			}
 		}
@@ -1764,14 +1764,14 @@ void ARMXEmitter::VMOV(ARMReg Dest, ARMReg Src)
 			else
 			{
 				// Move 64bit To Arm reg
-				_assert_msg_(JIT, false, "This VMOV doesn't support moving 64bit ARM From NEON");
+				_assert_msg_(false, "This VMOV doesn't support moving 64bit ARM From NEON");
 				return;
 			}
 		}
 		else
 		{
 			// Move Arm reg to Arm reg
-			_assert_msg_(JIT, false, "VMOV doesn't support moving ARM registers");
+			_assert_msg_(false, "VMOV doesn't support moving ARM registers");
 		}
 	}
 	// Moving NEON registers
@@ -1780,7 +1780,7 @@ void ARMXEmitter::VMOV(ARMReg Dest, ARMReg Src)
 	bool Single = DestSize == 1;
 	bool Quad = DestSize == 4;
 
-	_assert_msg_(JIT, SrcSize == DestSize, "VMOV doesn't support moving different register sizes");
+	_assert_msg_(SrcSize == DestSize, "VMOV doesn't support moving different register sizes");
 	if (SrcSize != DestSize) {
 		ELOG("SrcSize: %i (%s)  DestDize: %i (%s)", SrcSize, ARMRegAsString(Src), DestSize, ARMRegAsString(Dest));
 	}
@@ -1798,7 +1798,7 @@ void ARMXEmitter::VMOV(ARMReg Dest, ARMReg Src)
 		// Double and quad
 		if (Quad)
 		{
-			_assert_msg_(JIT, cpu_info.bNEON, "Trying to use quad registers when you don't support ASIMD."); 
+			_assert_msg_(cpu_info.bNEON, "Trying to use quad registers when you don't support ASIMD."); 
 			// Gets encoded as a Double register
 			Write32((0xF2 << 24) | ((Dest & 0x10) << 18) | (2 << 20) | ((Src & 0xF) << 16) \
 				| ((Dest & 0xF) << 12) | (1 << 8) | ((Src & 0x10) << 3) | (1 << 6) \
@@ -1859,9 +1859,9 @@ void ARMXEmitter::VCVT(ARMReg Dest, ARMReg Source, int flags)
 
 void ARMXEmitter::VABA(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 	bool register_quad = Vd >= Q0;
 
 	Write32((0xF2 << 24) | ((Size & I_UNSIGNED ? 1 : 0) << 24) | EncodeVn(Vn) \
@@ -1870,11 +1870,11 @@ void ARMXEmitter::VABA(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 
 void ARMXEmitter::VABAL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vn >= D0 && Vn < Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vm >= D0 && Vm < Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vn >= D0 && Vn < Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vm >= D0 && Vm < Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 
 	Write32((0xF2 << 24) | ((Size & I_UNSIGNED ? 1 : 0) << 24) | (1 << 23) | EncodeVn(Vn) \
 		| (encodedSize(Size) << 20) | EncodeVd(Vd) | (0x50 << 4) | EncodeVm(Vm));
@@ -1882,8 +1882,8 @@ void ARMXEmitter::VABAL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 
 void ARMXEmitter::VABD(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	bool register_quad = Vd >= Q0;
 
 	if (Size & F_32)
@@ -1895,11 +1895,11 @@ void ARMXEmitter::VABD(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 
 void ARMXEmitter::VABDL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vn >= D0 && Vn < Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vm >= D0 && Vm < Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vn >= D0 && Vn < Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vm >= D0 && Vm < Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 
 	Write32((0xF2 << 24) | ((Size & I_UNSIGNED ? 1 : 0) << 24) | (1 << 23) | EncodeVn(Vn) \
 		| (encodedSize(Size) << 20) | EncodeVd(Vd) | (0x70 << 4) | EncodeVm(Vm));
@@ -1907,8 +1907,8 @@ void ARMXEmitter::VABDL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 
 void ARMXEmitter::VABS(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	bool register_quad = Vd >= Q0;
 
 	Write32((0xF3 << 24) | (0xB1 << 16) | (encodedSize(Size) << 18) | EncodeVd(Vd) \
@@ -1918,8 +1918,8 @@ void ARMXEmitter::VABS(u32 Size, ARMReg Vd, ARMReg Vm)
 void ARMXEmitter::VACGE(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
 	// Only Float
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	bool register_quad = Vd >= Q0;
 
 	Write32((0xF3 << 24) | EncodeVn(Vn) | EncodeVd(Vd) \
@@ -1929,8 +1929,8 @@ void ARMXEmitter::VACGE(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 void ARMXEmitter::VACGT(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
 	// Only Float
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	bool register_quad = Vd >= Q0;
 
 	Write32((0xF3 << 24) | (1 << 21) | EncodeVn(Vn) | EncodeVd(Vd) \
@@ -1949,8 +1949,8 @@ void ARMXEmitter::VACLT(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 
 void ARMXEmitter::VADD(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -1963,11 +1963,11 @@ void ARMXEmitter::VADD(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 
 void ARMXEmitter::VADDHN(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd < Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vn >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vm >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd < Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vn >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vm >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 
 	Write32((0xF2 << 24) | (1 << 23) | (encodedSize(Size) << 20) | EncodeVn(Vn) \
 		| EncodeVd(Vd) | (0x80 << 4) | EncodeVm(Vm));
@@ -1975,84 +1975,84 @@ void ARMXEmitter::VADDHN(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 
 void ARMXEmitter::VADDL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vn >= D0 && Vn < Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vm >= D0 && Vm < Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vn >= D0 && Vn < Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vm >= D0 && Vm < Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 
 	Write32((0xF2 << 24) | ((Size & I_UNSIGNED ? 1 : 0) << 24) | (1 << 23) | (encodedSize(Size) << 20) | EncodeVn(Vn) \
 		| EncodeVd(Vd) | EncodeVm(Vm));
 }
 void ARMXEmitter::VADDW(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vn >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vm >= D0 && Vm < Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vn >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vm >= D0 && Vm < Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 
 	Write32((0xF2 << 24) | ((Size & I_UNSIGNED ? 1 : 0) << 24) | (1 << 23) | (encodedSize(Size) << 20) | EncodeVn(Vn) \
 		| EncodeVd(Vd) | (1 << 8) | EncodeVm(Vm));
 }
 void ARMXEmitter::VAND(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Vd == Vn && Vn == Vm), "All operands the same for %s is a nop", __FUNCTION__);
-	// _dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Vd == Vn && Vn == Vm), "All operands the same for %s is a nop", __FUNCTION__);
+	// _dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 	bool register_quad = Vd >= Q0;
 
 	Write32((0xF2 << 24) | EncodeVn(Vn) | EncodeVd(Vd) | (0x11 << 4) | (register_quad << 6) | EncodeVm(Vm));
 }
 void ARMXEmitter::VBIC(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	//  _dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	//  _dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 	bool register_quad = Vd >= Q0;
 
 	Write32((0xF2 << 24) | (1 << 20) | EncodeVn(Vn) | EncodeVd(Vd) | (0x11 << 4) | (register_quad << 6) | EncodeVm(Vm));
 }
 void ARMXEmitter::VEOR(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s: %i", __FUNCTION__, Vd);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s: %i", __FUNCTION__, Vd);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	bool register_quad = Vd >= Q0;	
 
 	Write32((0xF3 << 24) | EncodeVn(Vn) | EncodeVd(Vd) | (0x11 << 4) | (register_quad << 6) | EncodeVm(Vm));
 }
 void ARMXEmitter::VBIF(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	// _dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	// _dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 	bool register_quad = Vd >= Q0;
 
 	Write32((0xF3 << 24) | (3 << 20) | EncodeVn(Vn) | EncodeVd(Vd) | (0x11 << 4) | (register_quad << 6) | EncodeVm(Vm));
 }
 void ARMXEmitter::VBIT(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	// _dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	// _dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 	bool register_quad = Vd >= Q0;
 
 	Write32((0xF3 << 24) | (2 << 20) | EncodeVn(Vn) | EncodeVd(Vd) | (0x11 << 4) | (register_quad << 6) | EncodeVm(Vm));
 }
 void ARMXEmitter::VBSL(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	// _dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	// _dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 	bool register_quad = Vd >= Q0;
 
 	Write32((0xF3 << 24) | (1 << 20) | EncodeVn(Vn) | EncodeVd(Vd) | (0x11 << 4) | (register_quad << 6) | EncodeVm(Vm));
 }
 void ARMXEmitter::VCEQ(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 	if (Size & F_32)
@@ -2064,8 +2064,8 @@ void ARMXEmitter::VCEQ(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VCEQ(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2074,8 +2074,8 @@ void ARMXEmitter::VCEQ(u32 Size, ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VCGE(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 	if (Size & F_32)
@@ -2086,8 +2086,8 @@ void ARMXEmitter::VCGE(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VCGE(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 	Write32((0xF3 << 24) | (0xB << 20) | (encodedSize(Size) << 18) | (1 << 16) \
@@ -2095,8 +2095,8 @@ void ARMXEmitter::VCGE(u32 Size, ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VCGT(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 	if (Size & F_32)
@@ -2107,8 +2107,8 @@ void ARMXEmitter::VCGT(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VCGT(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 	Write32((0xF3 << 24) | (0xD << 20) | (encodedSize(Size) << 18) | (1 << 16) \
@@ -2120,8 +2120,8 @@ void ARMXEmitter::VCLE(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VCLE(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 	Write32((0xF3 << 24) | (0xD << 20) | (encodedSize(Size) << 18) | (1 << 16) \
@@ -2129,9 +2129,9 @@ void ARMXEmitter::VCLE(u32 Size, ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VCLS(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 	Write32((0xF3 << 24) | (0xD << 20) | (encodedSize(Size) << 18) \
@@ -2143,8 +2143,8 @@ void ARMXEmitter::VCLT(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VCLT(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 	Write32((0xF3 << 24) | (0xD << 20) | (encodedSize(Size) << 18) | (1 << 16) \
@@ -2152,8 +2152,8 @@ void ARMXEmitter::VCLT(u32 Size, ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VCLZ(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 	Write32((0xF3 << 24) | (0xD << 20) | (encodedSize(Size) << 18) \
@@ -2161,9 +2161,9 @@ void ARMXEmitter::VCLZ(u32 Size, ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VCNT(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Size & I_8, "Can only use I_8 with %s", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Size & I_8, "Can only use I_8 with %s", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 	Write32((0xF3 << 24) | (0xD << 20) | (encodedSize(Size) << 18) \
@@ -2171,9 +2171,9 @@ void ARMXEmitter::VCNT(u32 Size, ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VDUP(u32 Size, ARMReg Vd, ARMReg Vm, u8 index)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vm >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vm >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 	u32 imm4 = 0;
@@ -2188,9 +2188,9 @@ void ARMXEmitter::VDUP(u32 Size, ARMReg Vd, ARMReg Vm, u8 index)
 }
 void ARMXEmitter::VDUP(u32 Size, ARMReg Vd, ARMReg Rt)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Rt < S0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Rt < S0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 	Vd = SubBase(Vd);
@@ -2207,8 +2207,8 @@ void ARMXEmitter::VDUP(u32 Size, ARMReg Vd, ARMReg Rt)
 }
 void ARMXEmitter::VEXT(ARMReg Vd, ARMReg Vn, ARMReg Vm, u8 index)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	bool register_quad = Vd >= Q0;
 
 	Write32((0xF2 << 24) | (0xB << 20) | EncodeVn(Vn) | EncodeVd(Vd) | (index & 0xF) \
@@ -2216,29 +2216,29 @@ void ARMXEmitter::VEXT(ARMReg Vd, ARMReg Vn, ARMReg Vm, u8 index)
 }
 void ARMXEmitter::VFMA(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Size == F_32, "Passed invalid size to FP-only NEON instruction");
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bVFPv4, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Size == F_32, "Passed invalid size to FP-only NEON instruction");
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bVFPv4, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	bool register_quad = Vd >= Q0;
 
 	Write32((0xF2 << 24) | EncodeVn(Vn) | EncodeVd(Vd) | (0xC1 << 4) | (register_quad << 6) | EncodeVm(Vm));
 }
 void ARMXEmitter::VFMS(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Size == F_32, "Passed invalid size to FP-only NEON instruction");
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bVFPv4, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Size == F_32, "Passed invalid size to FP-only NEON instruction");
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bVFPv4, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	bool register_quad = Vd >= Q0;
 
 	Write32((0xF2 << 24) | (1 << 21) | EncodeVn(Vn) | EncodeVd(Vd) | (0xC1 << 4) | (register_quad << 6) | EncodeVm(Vm));
 }
 void ARMXEmitter::VHADD(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2247,9 +2247,9 @@ void ARMXEmitter::VHADD(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VHSUB(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2258,8 +2258,8 @@ void ARMXEmitter::VHSUB(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VMAX(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2271,8 +2271,8 @@ void ARMXEmitter::VMAX(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VMIN(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2284,8 +2284,8 @@ void ARMXEmitter::VMIN(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VMLA(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2296,8 +2296,8 @@ void ARMXEmitter::VMLA(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VMLS(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2308,30 +2308,30 @@ void ARMXEmitter::VMLS(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VMLAL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vn >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vm >= D0 && Vm < Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vn >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vm >= D0 && Vm < Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 
 	Write32((0xF2 << 24) | ((Size & I_UNSIGNED ? 1 : 0) << 24) | (encodedSize(Size) << 20) \
 		| EncodeVn(Vn) | EncodeVd(Vd) | (0x80 << 4) | EncodeVm(Vm));
 }
 void ARMXEmitter::VMLSL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vn >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vm >= D0 && Vm < Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float.", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vn >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vm >= D0 && Vm < Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float.", __FUNCTION__);
 
 	Write32((0xF2 << 24) | ((Size & I_UNSIGNED ? 1 : 0) << 24) | (encodedSize(Size) << 20) \
 		| EncodeVn(Vn) | EncodeVd(Vd) | (0xA0 << 4) | EncodeVm(Vm));
 }
 void ARMXEmitter::VMUL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2343,17 +2343,17 @@ void ARMXEmitter::VMUL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VMULL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	Write32((0xF2 << 24) | (1 << 23) | (encodedSize(Size) << 20) | EncodeVn(Vn) | EncodeVd(Vd) | \
 			(0xC0 << 4) | ((Size & I_POLYNOMIAL) ? 1 << 9 : 0) | EncodeVm(Vm));
 }
 void ARMXEmitter::VMLA_scalar(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2361,15 +2361,15 @@ void ARMXEmitter::VMLA_scalar(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 	if (Size & F_32)
 		Write32((0xF2 << 24) | (register_quad << 24) | (1 << 23) | (2 << 20) | EncodeVn(Vn) | EncodeVd(Vd) | (0x14 << 4) | EncodeVm(Vm));
 	else
-		_dbg_assert_msg_(JIT, false, "VMLA_scalar only supports float atm");
+		_dbg_assert_msg_(false, "VMLA_scalar only supports float atm");
 	//else
 	//	Write32((0xF2 << 24) | (1 << 23) | (encodedSize(Size) << 20) | EncodeVn(Vn) | EncodeVd(Vd) | (0x90 << 4) | (1 << 6) | EncodeVm(Vm));
 	// Unsigned support missing
 }
 void ARMXEmitter::VMUL_scalar(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2378,7 +2378,7 @@ void ARMXEmitter::VMUL_scalar(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 	if (Size & F_32)  // Q flag
 		Write32((0xF2 << 24) | (register_quad << 24) | (1 << 23) | (2 << 20) | EncodeVn(Vn) | EncodeVd(Vd) | (0x94 << 4) | VmEnc);
 	else
-		_dbg_assert_msg_(JIT, false, "VMUL_scalar only supports float atm");
+		_dbg_assert_msg_(false, "VMUL_scalar only supports float atm");
 	
 		// Write32((0xF2 << 24) | ((Size & I_POLYNOMIAL) ? (1 << 24) : 0) | (1 << 23) | (encodedSize(Size) << 20) | 
 		// EncodeVn(Vn) | EncodeVd(Vd) | (0x84 << 4) | (register_quad << 6) | EncodeVm(Vm));
@@ -2387,8 +2387,8 @@ void ARMXEmitter::VMUL_scalar(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 
 void ARMXEmitter::VMVN(ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2398,8 +2398,8 @@ void ARMXEmitter::VMVN(ARMReg Vd, ARMReg Vm)
 
 void ARMXEmitter::VNEG(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2408,8 +2408,8 @@ void ARMXEmitter::VNEG(u32 Size, ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VORN(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2417,9 +2417,9 @@ void ARMXEmitter::VORN(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VORR(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Vd == Vn && Vn == Vm), "All operands the same for %s is a nop", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Vd == Vn && Vn == Vm), "All operands the same for %s is a nop", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2427,9 +2427,9 @@ void ARMXEmitter::VORR(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VPADAL(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2438,8 +2438,8 @@ void ARMXEmitter::VPADAL(u32 Size, ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VPADD(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	if (Size & F_32)
 		Write32((0xF3 << 24) | EncodeVn(Vn) | EncodeVd(Vd) | (0xD0 << 4) | EncodeVm(Vm));
@@ -2449,9 +2449,9 @@ void ARMXEmitter::VPADD(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VPADDL(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2460,8 +2460,8 @@ void ARMXEmitter::VPADDL(u32 Size, ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VPMAX(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	if (Size & F_32)
 		Write32((0xF3 << 24) | EncodeVn(Vn) | EncodeVd(Vd) | (0xF0 << 4) | EncodeVm(Vm));
@@ -2471,8 +2471,8 @@ void ARMXEmitter::VPMAX(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VPMIN(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	if (Size & F_32)
 		Write32((0xF3 << 24) | (1 << 21) | EncodeVn(Vn) | EncodeVd(Vd) | (0xF0 << 4) | EncodeVm(Vm));
@@ -2482,9 +2482,9 @@ void ARMXEmitter::VPMIN(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VQABS(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2493,9 +2493,9 @@ void ARMXEmitter::VQABS(u32 Size, ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VQADD(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2504,45 +2504,45 @@ void ARMXEmitter::VQADD(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VQDMLAL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	Write32((0xF2 << 24) | (1 << 23) | (encodedSize(Size) << 20) | EncodeVn(Vn) | EncodeVd(Vd) | \
 			(0x90 << 4) | EncodeVm(Vm));
 }
 void ARMXEmitter::VQDMLSL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	Write32((0xF2 << 24) | (1 << 23) | (encodedSize(Size) << 20) | EncodeVn(Vn) | EncodeVd(Vd) | \
 			(0xB0 << 4) | EncodeVm(Vm));
 }
 void ARMXEmitter::VQDMULH(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	Write32((0xF2 << 24) | (encodedSize(Size) << 20) | EncodeVn(Vn) | EncodeVd(Vd) | \
 			(0xB0 << 4) | EncodeVm(Vm));
 }
 void ARMXEmitter::VQDMULL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	Write32((0xF2 << 24) | (1 << 23) | (encodedSize(Size) << 20) | EncodeVn(Vn) | EncodeVd(Vd) | \
 			(0xD0 << 4) | EncodeVm(Vm));
 }
 void ARMXEmitter::VQNEG(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2551,18 +2551,18 @@ void ARMXEmitter::VQNEG(u32 Size, ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VQRDMULH(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	Write32((0xF3 << 24) | (encodedSize(Size) << 20) | EncodeVn(Vn) | EncodeVd(Vd) | \
 			(0xB0 << 4) | EncodeVm(Vm));
 }
 void ARMXEmitter::VQRSHL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2571,9 +2571,9 @@ void ARMXEmitter::VQRSHL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VQSHL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2582,9 +2582,9 @@ void ARMXEmitter::VQSHL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VQSUB(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2593,17 +2593,17 @@ void ARMXEmitter::VQSUB(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VRADDHN(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	Write32((0xF3 << 24) | (1 << 23) | ((encodedSize(Size) - 1) << 20) | EncodeVn(Vn) | EncodeVd(Vd) | \
 			(0x40 << 4) | EncodeVm(Vm));
 }
 void ARMXEmitter::VRECPE(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2612,8 +2612,8 @@ void ARMXEmitter::VRECPE(u32 Size, ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VRECPS(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2621,9 +2621,9 @@ void ARMXEmitter::VRECPS(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VRHADD(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2632,9 +2632,9 @@ void ARMXEmitter::VRHADD(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VRSHL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2643,8 +2643,8 @@ void ARMXEmitter::VRSHL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VRSQRTE(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 	Vd = SubBase(Vd);
@@ -2656,8 +2656,8 @@ void ARMXEmitter::VRSQRTE(u32 Size, ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VRSQRTS(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2666,18 +2666,18 @@ void ARMXEmitter::VRSQRTS(ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VRSUBHN(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	Write32((0xF3 << 24) | (1 << 23) | ((encodedSize(Size) - 1) << 20) | EncodeVn(Vn) | EncodeVd(Vd) | \
 			(0x60 << 4) | EncodeVm(Vm));
 }
 void ARMXEmitter::VSHL(u32 Size, ARMReg Vd, ARMReg Vm, ARMReg Vn)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2694,7 +2694,7 @@ static int EncodeSizeShift(u32 Size, int amount, bool inverse, bool halve) {
 	case I_64: sz = 64; break;
 	}
 	if (inverse && halve) {
-		_dbg_assert_msg_(JIT, amount <= sz / 2, "Amount %d too large for narrowing shift (max %d)", amount, sz/2);
+		_dbg_assert_msg_(amount <= sz / 2, "Amount %d too large for narrowing shift (max %d)", amount, sz/2);
 		return (sz / 2) + (sz / 2) - amount;
 	} else if (inverse) {
 		return sz + (sz - amount);
@@ -2704,9 +2704,9 @@ static int EncodeSizeShift(u32 Size, int amount, bool inverse, bool halve) {
 }
 
 void ARMXEmitter::EncodeShiftByImm(u32 Size, ARMReg Vd, ARMReg Vm, int shiftAmount, u8 opcode, bool register_quad, bool inverse, bool halve) {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, !(Size & F_32), "%s doesn't support float", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(!(Size & F_32), "%s doesn't support float", __FUNCTION__);
 	int imm7 = EncodeSizeShift(Size, shiftAmount, inverse, halve);
 	int L = (imm7 >> 6) & 1;
 	int U = (Size & I_UNSIGNED) ? 1 : 0;
@@ -2727,7 +2727,7 @@ void ARMXEmitter::VSHLL(u32 Size, ARMReg Vd, ARMReg Vm, int shiftAmount) {
 		case I_16: sz = 1; break;
 		case I_32: sz = 2; break;
 		case I_64:
-			_dbg_assert_msg_(JIT, false, "Cannot VSHLL 64-bit elements");
+			_dbg_assert_msg_(false, "Cannot VSHLL 64-bit elements");
 		}
 		int imm6 = 0x32 | (sz << 2);
 		u32 value = (0xF3 << 24) | (1 << 23) | (imm6 << 16) | EncodeVd(Vd) | (0x3 << 8) | EncodeVm(Vm);
@@ -2748,8 +2748,8 @@ void ARMXEmitter::VSHRN(u32 Size, ARMReg Vd, ARMReg Vm, int shiftAmount) {
 
 void ARMXEmitter::VSUB(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2762,32 +2762,32 @@ void ARMXEmitter::VSUB(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VSUBHN(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	Write32((0xF2 << 24) | (1 << 23) | ((encodedSize(Size) - 1) << 20) | EncodeVn(Vn) | EncodeVd(Vd) | \
 			(0x60 << 4) | EncodeVm(Vm));
 }
 void ARMXEmitter::VSUBL(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	Write32((0xF2 << 24) | (Size & I_UNSIGNED ? 1 << 24 : 0) | (1 << 23) | (encodedSize(Size) << 20) | EncodeVn(Vn) | EncodeVd(Vd) | \
 			(0x20 << 4) | EncodeVm(Vm));
 }
 void ARMXEmitter::VSUBW(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	Write32((0xF2 << 24) | (Size & I_UNSIGNED ? 1 << 24 : 0) | (1 << 23) | (encodedSize(Size) << 20) | EncodeVn(Vn) | EncodeVd(Vd) | \
 			(0x30 << 4) | EncodeVm(Vm));
 }
 void ARMXEmitter::VSWP(ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2796,8 +2796,8 @@ void ARMXEmitter::VSWP(ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VTRN(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2806,8 +2806,8 @@ void ARMXEmitter::VTRN(u32 Size, ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VTST(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2816,8 +2816,8 @@ void ARMXEmitter::VTST(u32 Size, ARMReg Vd, ARMReg Vn, ARMReg Vm)
 }
 void ARMXEmitter::VUZP(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2826,8 +2826,8 @@ void ARMXEmitter::VUZP(u32 Size, ARMReg Vd, ARMReg Vm)
 }
 void ARMXEmitter::VZIP(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	 _dbg_assert_msg_(JIT, Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	 _dbg_assert_msg_(Vd >= D0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 
 	bool register_quad = Vd >= Q0;
 
@@ -2837,10 +2837,10 @@ void ARMXEmitter::VZIP(u32 Size, ARMReg Vd, ARMReg Vm)
 
 void ARMXEmitter::VMOVL(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vm >= D0 && Vm <= D31, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, (Size & (I_UNSIGNED | I_SIGNED)) != 0, "Must specify I_SIGNED or I_UNSIGNED in VMOVL");
+	_dbg_assert_msg_(Vd >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vm >= D0 && Vm <= D31, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_((Size & (I_UNSIGNED | I_SIGNED)) != 0, "Must specify I_SIGNED or I_UNSIGNED in VMOVL");
 
 	bool unsign = (Size & I_UNSIGNED) != 0;
 	int imm3 = 0;
@@ -2854,10 +2854,10 @@ void ARMXEmitter::VMOVL(u32 Size, ARMReg Vd, ARMReg Vm)
 
 void ARMXEmitter::VMOVN(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vm >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vd >= D0 && Vd <= D31, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, (Size & I_8) == 0, "%s cannot narrow from I_8", __FUNCTION__);
+	_dbg_assert_msg_(Vm >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0 && Vd <= D31, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_((Size & I_8) == 0, "%s cannot narrow from I_8", __FUNCTION__);
 
 	// For consistency with assembler syntax and VMOVL - encode one size down.
 	int halfSize = encodedSize(Size) - 1;
@@ -2867,11 +2867,11 @@ void ARMXEmitter::VMOVN(u32 Size, ARMReg Vd, ARMReg Vm)
 
 void ARMXEmitter::VQMOVN(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vm >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vd >= D0 && Vd <= D31, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, (Size & (I_UNSIGNED | I_SIGNED)) != 0, "Must specify I_SIGNED or I_UNSIGNED in %s NEON", __FUNCTION__);
-	_dbg_assert_msg_(JIT, (Size & I_8) == 0, "%s cannot narrow from I_8", __FUNCTION__);
+	_dbg_assert_msg_(Vm >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0 && Vd <= D31, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_((Size & (I_UNSIGNED | I_SIGNED)) != 0, "Must specify I_SIGNED or I_UNSIGNED in %s NEON", __FUNCTION__);
+	_dbg_assert_msg_((Size & I_8) == 0, "%s cannot narrow from I_8", __FUNCTION__);
 
 	int halfSize = encodedSize(Size) - 1;
 	int op = (1 << 7) | (Size & I_UNSIGNED ? 1 << 6 : 0);
@@ -2881,10 +2881,10 @@ void ARMXEmitter::VQMOVN(u32 Size, ARMReg Vd, ARMReg Vm)
 
 void ARMXEmitter::VQMOVUN(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, Vm >= Q0, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, Vd >= D0 && Vd <= D31, "Pass invalid register to %s", __FUNCTION__);
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
-	_dbg_assert_msg_(JIT, (Size & I_8) == 0, "%s cannot narrow from I_8", __FUNCTION__);
+	_dbg_assert_msg_(Vm >= Q0, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(Vd >= D0 && Vd <= D31, "Pass invalid register to %s", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_((Size & I_8) == 0, "%s cannot narrow from I_8", __FUNCTION__);
 
 	int halfSize = encodedSize(Size) - 1;
 	int op = (1 << 6);
@@ -2894,7 +2894,7 @@ void ARMXEmitter::VQMOVUN(u32 Size, ARMReg Vd, ARMReg Vm)
 
 void ARMXEmitter::VCVT(u32 Size, ARMReg Vd, ARMReg Vm)
 {
-	_dbg_assert_msg_(JIT, (Size & (I_UNSIGNED | I_SIGNED)) != 0, "Must specify I_SIGNED or I_UNSIGNED in VCVT NEON");
+	_dbg_assert_msg_((Size & (I_UNSIGNED | I_SIGNED)) != 0, "Must specify I_SIGNED or I_UNSIGNED in VCVT NEON");
 
 	bool register_quad = Vd >= Q0;
 	bool toInteger = (Size & I_32) != 0;
@@ -2907,18 +2907,18 @@ void ARMXEmitter::VCVT(u32 Size, ARMReg Vd, ARMReg Vm)
 static int RegCountToType(int nRegs, NEONAlignment align) {
 	switch (nRegs) {
 	case 1:
-		_dbg_assert_msg_(JIT, !((int)align & 1), "align & 1 must be == 0");
+		_dbg_assert_msg_(!((int)align & 1), "align & 1 must be == 0");
 		return 7;
 	case 2:
-		_dbg_assert_msg_(JIT, !((int)align == 3), "align must be != 3");
+		_dbg_assert_msg_(!((int)align == 3), "align must be != 3");
 		return 10;
 	case 3:
-		_dbg_assert_msg_(JIT, !((int)align & 1), "align & 1 must be == 0");
+		_dbg_assert_msg_(!((int)align & 1), "align & 1 must be == 0");
 		return 6;
 	case 4:
 		return 2;
 	default:
-		_dbg_assert_msg_(JIT, false, "Invalid number of registers passed to vector load/store");
+		_dbg_assert_msg_(false, "Invalid number of registers passed to vector load/store");
 		return 0;
 	}
 }
@@ -2935,12 +2935,12 @@ void ARMXEmitter::WriteVLDST1(bool load, u32 Size, ARMReg Vd, ARMReg Rn, int reg
 }
 
 void ARMXEmitter::VLD1(u32 Size, ARMReg Vd, ARMReg Rn, int regCount, NEONAlignment align, ARMReg Rm) {
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	WriteVLDST1(true, Size, Vd, Rn, regCount, align, Rm);
 }
 
 void ARMXEmitter::VST1(u32 Size, ARMReg Vd, ARMReg Rn, int regCount, NEONAlignment align, ARMReg Rm) {
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	WriteVLDST1(false, Size, Vd, Rn, regCount, align, Rm);
 }
 
@@ -2970,12 +2970,12 @@ void ARMXEmitter::WriteVLDST1_lane(bool load, u32 Size, ARMReg Vd, ARMReg Rn, in
 }
 
 void ARMXEmitter::VLD1_lane(u32 Size, ARMReg Vd, ARMReg Rn, int lane, bool aligned, ARMReg Rm) {
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	WriteVLDST1_lane(true, Size, Vd, Rn, lane, aligned, Rm);
 }
 
 void ARMXEmitter::VST1_lane(u32 Size, ARMReg Vd, ARMReg Rn, int lane, bool aligned, ARMReg Rm) {
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	WriteVLDST1_lane(false, Size, Vd, Rn, lane, aligned, Rm);
 }
 
@@ -3012,7 +3012,7 @@ void ARMXEmitter::WriteVimm(ARMReg Vd, int cmode, u8 imm, int op) {
 }
 
 void ARMXEmitter::VMOV_imm(u32 Size, ARMReg Vd, VIMMMode type, int imm) {
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	// Only let through the modes that apply.
 	switch (type) {
 	case VIMM___x___x:
@@ -3045,11 +3045,11 @@ void ARMXEmitter::VMOV_imm(u32 Size, ARMReg Vd, VIMMMode type, int imm) {
 	return;
 
 error:
-	_dbg_assert_msg_(JIT, false, "Bad Size or type specified in %s: Size %i Type %i", __FUNCTION__, (int)Size, type);
+	_dbg_assert_msg_(false, "Bad Size or type specified in %s: Size %i Type %i", __FUNCTION__, (int)Size, type);
 }
 
 void ARMXEmitter::VMOV_immf(ARMReg Vd, float value) {  // This only works with a select few values. I've hardcoded 1.0f.
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	u8 bits = 0;
 
 	if (value == 0.0f) {
@@ -3065,13 +3065,13 @@ void ARMXEmitter::VMOV_immf(ARMReg Vd, float value) {  // This only works with a
 	} else if (value == -1.0f) {
 		bits = 0xF0;
 	} else {
-		_dbg_assert_msg_(JIT, false, "%s: Invalid floating point immediate", __FUNCTION__);
+		_dbg_assert_msg_(false, "%s: Invalid floating point immediate", __FUNCTION__);
 	}
 	WriteVimm(Vd, VIMMf000f000, bits, 0);
 }
 
 void ARMXEmitter::VORR_imm(u32 Size, ARMReg Vd, VIMMMode type, int imm) {
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	// Only let through the modes that apply.
 	switch (type) {
 	case VIMM___x___x:
@@ -3093,11 +3093,11 @@ void ARMXEmitter::VORR_imm(u32 Size, ARMReg Vd, VIMMMode type, int imm) {
 	}
 	return;
 error:
-	_dbg_assert_msg_(JIT, false, "Bad Size or type specified in VORR_imm");
+	_dbg_assert_msg_(false, "Bad Size or type specified in VORR_imm");
 }
 
 void ARMXEmitter::VBIC_imm(u32 Size, ARMReg Vd, VIMMMode type, int imm) {
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	// Only let through the modes that apply.
 	switch (type) {
 	case VIMM___x___x:
@@ -3119,12 +3119,12 @@ void ARMXEmitter::VBIC_imm(u32 Size, ARMReg Vd, VIMMMode type, int imm) {
 	}
 	return;
 error:
-	_dbg_assert_msg_(JIT, false, "Bad Size or type specified in VBIC_imm");
+	_dbg_assert_msg_(false, "Bad Size or type specified in VBIC_imm");
 }
 
 
 void ARMXEmitter::VMVN_imm(u32 Size, ARMReg Vd, VIMMMode type, int imm) {
-	_dbg_assert_msg_(JIT, cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
+	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	// Only let through the modes that apply.
 	switch (type) {
 	case VIMM___x___x:
@@ -3146,7 +3146,7 @@ void ARMXEmitter::VMVN_imm(u32 Size, ARMReg Vd, VIMMMode type, int imm) {
 	}
 	return;
 error:
-	_dbg_assert_msg_(JIT, false, "Bad Size or type specified in VMVN_imm");
+	_dbg_assert_msg_(false, "Bad Size or type specified in VMVN_imm");
 }
 
 
@@ -3180,9 +3180,9 @@ void ARMXEmitter::VREV16(u32 Size, ARMReg Vd, ARMReg Vm)
 
 // Dest is a Q register, Src is a D register.
 void ARMXEmitter::VCVTF32F16(ARMReg Dest, ARMReg Src) {
-	_assert_msg_(JIT, cpu_info.bVFPv4, "Can't use half-float conversions when you don't support VFPv4");
+	_assert_msg_(cpu_info.bVFPv4, "Can't use half-float conversions when you don't support VFPv4");
 	if (Dest < Q0 || Dest > Q15 || Src < D0 || Src > D15) {
-		_assert_msg_(JIT, cpu_info.bNEON, "Bad inputs to VCVTF32F16"); 
+		_assert_msg_(cpu_info.bNEON, "Bad inputs to VCVTF32F16"); 
 		// Invalid!
 	}
 
@@ -3196,9 +3196,9 @@ void ARMXEmitter::VCVTF32F16(ARMReg Dest, ARMReg Src) {
 // UNTESTED
 // Dest is a D register, Src is a Q register.
 void ARMXEmitter::VCVTF16F32(ARMReg Dest, ARMReg Src) {
-	_assert_msg_(JIT, cpu_info.bVFPv4, "Can't use half-float conversions when you don't support VFPv4");
+	_assert_msg_(cpu_info.bVFPv4, "Can't use half-float conversions when you don't support VFPv4");
 	if (Dest < D0 || Dest > D15 || Src < Q0 || Src > Q15) {
-		_assert_msg_(JIT, cpu_info.bNEON, "Bad inputs to VCVTF32F16"); 
+		_assert_msg_(cpu_info.bNEON, "Bad inputs to VCVTF32F16"); 
 		// Invalid!
 	}
 	Dest = SubBase(Dest);

--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -905,14 +905,12 @@ void ARMXEmitter::WriteSignedMultiply(u32 Op, u32 Op2, u32 Op3, ARMReg dest, ARM
 }
 void ARMXEmitter::UDIV(ARMReg dest, ARMReg dividend, ARMReg divisor)
 {
-	if (!cpu_info.bIDIVa)
-		PanicAlert("Trying to use integer divide on hardware that doesn't support it. Bad programmer.");
+	_assert_(cpu_info.bIDIVa, "Trying to use integer divide on hardware that doesn't support it. Bad programmer.");
 	WriteSignedMultiply(3, 0xF, 0, dest, divisor, dividend);
 }
 void ARMXEmitter::SDIV(ARMReg dest, ARMReg dividend, ARMReg divisor)
 {
-	if (!cpu_info.bIDIVa)
-		PanicAlert("Trying to use integer divide on hardware that doesn't support it. Bad programmer.");
+	_assert_(cpu_info.bIDIVa, "Trying to use integer divide on hardware that doesn't support it. Bad programmer.");
 	WriteSignedMultiply(1, 0xF, 0, dest, divisor, dividend);
 }
 

--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -145,7 +145,7 @@ public:
 	Operand2(ARMReg base, ShiftType type, ARMReg shift) // RSR
 	{
 		Type = TYPE_RSR;
-		_assert_msg_(JIT, type != ST_RRX, "Invalid Operand2: RRX does not take a register shift amount");
+		_assert_msg_(type != ST_RRX, "Invalid Operand2: RRX does not take a register shift amount");
 		IndexOrShift = shift;
 		Shift = type;
 		Value = base;
@@ -157,29 +157,29 @@ public:
 		switch (type)
 		{
 		case ST_LSL:
-			_assert_msg_(JIT, shift < 32, "Invalid Operand2: LSL %u", shift);
+			_assert_msg_(shift < 32, "Invalid Operand2: LSL %u", shift);
 			break;
 		case ST_LSR:
-			_assert_msg_(JIT, shift <= 32, "Invalid Operand2: LSR %u", shift);
+			_assert_msg_(shift <= 32, "Invalid Operand2: LSR %u", shift);
 			if (!shift)
 				type = ST_LSL;
 			if (shift == 32)
 				shift = 0;
 			break;
 		case ST_ASR:
-			_assert_msg_(JIT, shift < 32, "Invalid Operand2: ASR %u", shift);
+			_assert_msg_(shift < 32, "Invalid Operand2: ASR %u", shift);
 			if (!shift)
 				type = ST_LSL;
 			if (shift == 32)
 				shift = 0;
 			break;
 		case ST_ROR:
-			_assert_msg_(JIT, shift < 32, "Invalid Operand2: ROR %u", shift);
+			_assert_msg_(shift < 32, "Invalid Operand2: ROR %u", shift);
 			if (!shift)
 				type = ST_LSL;
 			break;
 		case ST_RRX:
-			_assert_msg_(JIT, shift == 0, "Invalid Operand2: RRX does not take an immediate shift amount");
+			_assert_msg_(shift == 0, "Invalid Operand2: RRX does not take an immediate shift amount");
 			type = ST_ROR;
 			break;
 		}
@@ -201,45 +201,45 @@ public:
 		case TYPE_RSR:
 			return RSR();
 		default:
-			_assert_msg_(JIT, false, "GetData with Invalid Type");
+			_assert_msg_(false, "GetData with Invalid Type");
 			return 0;
 		}
 	}
 	u32 IMMSR() // IMM shifted register
 	{
-		_assert_msg_(JIT, Type == TYPE_IMMSREG, "IMMSR must be imm shifted register");
+		_assert_msg_(Type == TYPE_IMMSREG, "IMMSR must be imm shifted register");
 		return ((IndexOrShift & 0x1f) << 7 | (Shift << 5) | Value);
 	}
 	u32 RSR() // Register shifted register
 	{
-		_assert_msg_(JIT, Type == TYPE_RSR, "RSR must be RSR Of Course");
+		_assert_msg_(Type == TYPE_RSR, "RSR must be RSR Of Course");
 		return (IndexOrShift << 8) | (Shift << 5) | 0x10 | Value;
 	}
 	u32 Rm() const
 	{
-		_assert_msg_(JIT, Type == TYPE_REG, "Rm must be with Reg");
+		_assert_msg_(Type == TYPE_REG, "Rm must be with Reg");
 		return Value;
 	}
 
 	u32 Imm5() const
 	{
-		_assert_msg_(JIT, (Type == TYPE_IMM), "Imm5 not IMM value");
+		_assert_msg_((Type == TYPE_IMM), "Imm5 not IMM value");
 		return ((Value & 0x0000001F) << 7);
 	}
 	u32 Imm8() const
 	{
-		_assert_msg_(JIT, (Type == TYPE_IMM), "Imm8Rot not IMM value");
+		_assert_msg_((Type == TYPE_IMM), "Imm8Rot not IMM value");
 		return Value & 0xFF;
 	}
 	u32 Imm8Rot() const // IMM8 with Rotation
 	{
-		_assert_msg_(JIT, (Type == TYPE_IMM), "Imm8Rot not IMM value");
-		_assert_msg_(JIT, (Rotation & 0xE1) != 0, "Invalid Operand2: immediate rotation %u", Rotation);
+		_assert_msg_((Type == TYPE_IMM), "Imm8Rot not IMM value");
+		_assert_msg_((Rotation & 0xE1) != 0, "Invalid Operand2: immediate rotation %u", Rotation);
 		return (1 << 25) | (Rotation << 7) | (Value & 0x000000FF);
 	}
 	u32 Imm12() const
 	{
-		_assert_msg_(JIT, (Type == TYPE_IMM), "Imm12 not IMM");
+		_assert_msg_((Type == TYPE_IMM), "Imm12 not IMM");
 		return (Value & 0x00000FFF);
 	}
 
@@ -250,12 +250,12 @@ public:
 		// expand a 8bit IMM to a 32bit value and gives you some rotation as
 		// well.
 		// Each rotation rotates to the right by 2 bits
-		_assert_msg_(JIT, (Type == TYPE_IMM), "Imm12Mod not IMM");
+		_assert_msg_((Type == TYPE_IMM), "Imm12Mod not IMM");
 		return ((Rotation & 0xF) << 8) | (Value & 0xFF);
 	}
 	u32 Imm16() const
 	{
-		_assert_msg_(JIT, (Type == TYPE_IMM), "Imm16 not IMM");
+		_assert_msg_((Type == TYPE_IMM), "Imm16 not IMM");
 		return ( (Value & 0xF000) << 4) | (Value & 0x0FFF);
 	}
 	u32 Imm16Low() const
@@ -264,23 +264,23 @@ public:
 	}
 	u32 Imm16High() const // Returns high 16bits
 	{
-		_assert_msg_(JIT, (Type == TYPE_IMM), "Imm16 not IMM");
+		_assert_msg_((Type == TYPE_IMM), "Imm16 not IMM");
 		return ( ((Value >> 16) & 0xF000) << 4) | ((Value >> 16) & 0x0FFF);
 	}
 	u32 Imm24() const
 	{
-		_assert_msg_(JIT, (Type == TYPE_IMM), "Imm16 not IMM");
+		_assert_msg_((Type == TYPE_IMM), "Imm16 not IMM");
 		return (Value & 0x0FFFFFFF);
 	}
 	// NEON and ASIMD specific
 	u32 Imm8ASIMD() const
 	{
-		_assert_msg_(JIT, (Type == TYPE_IMM), "Imm8ASIMD not IMM");
+		_assert_msg_((Type == TYPE_IMM), "Imm8ASIMD not IMM");
 		return  ((Value & 0x80) << 17) | ((Value & 0x70) << 12) | (Value & 0xF);
 	}
 	u32 Imm8VFP() const
 	{
-		_assert_msg_(JIT, (Type == TYPE_IMM), "Imm8VFP not IMM");
+		_assert_msg_((Type == TYPE_IMM), "Imm8VFP not IMM");
 		return ((Value & 0xF0) << 12) | (Value & 0xF);
 	}
 };
@@ -733,7 +733,7 @@ public:
 	}
 	void VMOV_neon(u32 Size, ARMReg Vd, u32 imm);
 	void VMOV_neon(u32 Size, ARMReg Vd, float imm) {
-		_dbg_assert_msg_(JIT, Size == F_32, "Expecting F_32 immediate for VMOV_neon float arg.");
+		_dbg_assert_msg_(Size == F_32, "Expecting F_32 immediate for VMOV_neon float arg.");
 		union {
 			float f;
 			u32 u;

--- a/Common/ChunkFile.cpp
+++ b/Common/ChunkFile.cpp
@@ -168,7 +168,7 @@ void PointerWrap::DoMarker(const char *prevName, u32 arbitraryNumber) {
 	u32 cookie = arbitraryNumber;
 	Do(cookie);
 	if (mode == PointerWrap::MODE_READ && cookie != arbitraryNumber) {
-		PanicAlert("Error: After \"%s\", found %d (0x%X) instead of save marker %d (0x%X). Aborting savestate load...", prevName, cookie, cookie, arbitraryNumber, arbitraryNumber);
+		_assert_msg_(false, "Error: After \"%s\", found %d (0x%X) instead of save marker %d (0x%X). Aborting savestate load...", prevName, cookie, cookie, arbitraryNumber, arbitraryNumber);
 		SetError(ERROR_FAILURE);
 	}
 }

--- a/Common/ChunkFile.cpp
+++ b/Common/ChunkFile.cpp
@@ -69,7 +69,7 @@ bool PointerWrap::ExpectVoid(void *data, int size) {
 	case MODE_MEASURE: break;  // MODE_MEASURE - don't need to do anything
 	case MODE_VERIFY:
 		for (int i = 0; i < size; i++)
-			_dbg_assert_msg_(COMMON, ((u8*)data)[i] == (*ptr)[i], "Savestate verification failure: %d (0x%X) (at %p) != %d (0x%X) (at %p).\n", ((u8*)data)[i], ((u8*)data)[i], &((u8*)data)[i], (*ptr)[i], (*ptr)[i], &(*ptr)[i]);
+			_dbg_assert_msg_(((u8*)data)[i] == (*ptr)[i], "Savestate verification failure: %d (0x%X) (at %p) != %d (0x%X) (at %p).\n", ((u8*)data)[i], ((u8*)data)[i], &((u8*)data)[i], (*ptr)[i], (*ptr)[i], &(*ptr)[i]);
 		break;
 	default: break;  // throw an error?
 	}
@@ -84,7 +84,7 @@ void PointerWrap::DoVoid(void *data, int size) {
 	case MODE_MEASURE: break;  // MODE_MEASURE - don't need to do anything
 	case MODE_VERIFY:
 		for (int i = 0; i < size; i++)
-			_dbg_assert_msg_(COMMON, ((u8*)data)[i] == (*ptr)[i], "Savestate verification failure: %d (0x%X) (at %p) != %d (0x%X) (at %p).\n", ((u8*)data)[i], ((u8*)data)[i], &((u8*)data)[i], (*ptr)[i], (*ptr)[i], &(*ptr)[i]);
+			_dbg_assert_msg_(((u8*)data)[i] == (*ptr)[i], "Savestate verification failure: %d (0x%X) (at %p) != %d (0x%X) (at %p).\n", ((u8*)data)[i], ((u8*)data)[i], &((u8*)data)[i], (*ptr)[i], (*ptr)[i], &(*ptr)[i]);
 		break;
 	default: break;  // throw an error?
 	}
@@ -99,7 +99,7 @@ void PointerWrap::Do(std::string &x) {
 	case MODE_READ:		x = (char*)*ptr; break;
 	case MODE_WRITE:	memcpy(*ptr, x.c_str(), stringLen); break;
 	case MODE_MEASURE: break;
-	case MODE_VERIFY: _dbg_assert_msg_(COMMON, !strcmp(x.c_str(), (char*)*ptr), "Savestate verification failure: \"%s\" != \"%s\" (at %p).\n", x.c_str(), (char*)*ptr, ptr); break;
+	case MODE_VERIFY: _dbg_assert_msg_(!strcmp(x.c_str(), (char*)*ptr), "Savestate verification failure: \"%s\" != \"%s\" (at %p).\n", x.c_str(), (char*)*ptr, ptr); break;
 	}
 	(*ptr) += stringLen;
 }
@@ -112,7 +112,7 @@ void PointerWrap::Do(std::wstring &x) {
 	case MODE_READ:		x = (wchar_t*)*ptr; break;
 	case MODE_WRITE:	memcpy(*ptr, x.c_str(), stringLen); break;
 	case MODE_MEASURE: break;
-	case MODE_VERIFY: _dbg_assert_msg_(COMMON, x == (wchar_t*)*ptr, "Savestate verification failure: \"%ls\" != \"%ls\" (at %p).\n", x.c_str(), (wchar_t*)*ptr, ptr); break;
+	case MODE_VERIFY: _dbg_assert_msg_(x == (wchar_t*)*ptr, "Savestate verification failure: \"%ls\" != \"%ls\" (at %p).\n", x.c_str(), (wchar_t*)*ptr, ptr); break;
 	}
 	(*ptr) += stringLen;
 }
@@ -125,7 +125,7 @@ void PointerWrap::Do(std::u16string &x) {
 	case MODE_READ: x = (char16_t*)*ptr; break;
 	case MODE_WRITE: memcpy(*ptr, x.c_str(), stringLen); break;
 	case MODE_MEASURE: break;
-	case MODE_VERIFY: _dbg_assert_msg_(COMMON, x == (char16_t*)*ptr, "Savestate verification failure: (at %p).\n", x.c_str()); break;
+	case MODE_VERIFY: _dbg_assert_msg_(x == (char16_t*)*ptr, "Savestate verification failure: (at %p).\n", x.c_str()); break;
 	}
 	(*ptr) += stringLen;
 }

--- a/Common/CodeBlock.h
+++ b/Common/CodeBlock.h
@@ -85,11 +85,8 @@ public:
 	// If you don't specify a size and we later encounter an executable non-writable block, we're screwed.
 	// These CANNOT be nested. We rely on the memory protection starting at READ|WRITE after start and reset.
 	void BeginWrite(size_t sizeEstimate = 1) {
-#ifdef _DEBUG
-		if (writeStart_) {
-			PanicAlert("Can't nest BeginWrite calls");
-		}
-#endif
+		_dbg_assert_msg_(!writeStart_, "Can't nest BeginWrite calls");
+
 		// In case the last block made the current page exec/no-write, let's fix that.
 		if (PlatformIsWXExclusive()) {
 			writeStart_ = GetCodePtr();

--- a/Common/Common.h
+++ b/Common/Common.h
@@ -64,7 +64,7 @@
 	#if defined(_DEBUG)
 		#include <crtdbg.h>
 		#undef CHECK_HEAP_INTEGRITY
-		#define CHECK_HEAP_INTEGRITY() {if (!_CrtCheckMemory()) PanicAlert("memory corruption detected. see log.");}
+		#define CHECK_HEAP_INTEGRITY() {if (!_CrtCheckMemory()) _assert_msg_(false, "Memory corruption detected. See log.");}
 	#endif
 #else
 

--- a/Common/ConsoleListener.cpp
+++ b/Common/ConsoleListener.cpp
@@ -232,7 +232,7 @@ bool ConsoleListener::IsOpen()
 */
 void ConsoleListener::BufferWidthHeight(int BufferWidth, int BufferHeight, int ScreenWidth, int ScreenHeight, bool BufferFirst)
 {
-	_dbg_assert_msg_(COMMON, IsOpen(), "Don't call this before opening the console.");
+	_dbg_assert_msg_(IsOpen(), "Don't call this before opening the console.");
 #if defined(USING_WIN_UI)
 	BOOL SB, SW;
 	if (BufferFirst)
@@ -257,7 +257,7 @@ void ConsoleListener::BufferWidthHeight(int BufferWidth, int BufferHeight, int S
 }
 void ConsoleListener::LetterSpace(int Width, int Height)
 {
-	_dbg_assert_msg_(COMMON, IsOpen(), "Don't call this before opening the console.");
+	_dbg_assert_msg_(IsOpen(), "Don't call this before opening the console.");
 #if defined(USING_WIN_UI)
 	// Get console info
 	CONSOLE_SCREEN_BUFFER_INFO ConInfo;
@@ -392,7 +392,7 @@ void ConsoleListener::SendToThread(LogTypes::LOG_LEVELS Level, const char *Text)
 		// Not ANSI, since the console doesn't support it, but ANSI-like.
 		snprintf(ColorAttr, 16, "\033%d", Level);
 		// For now, rather than properly support it.
-		_dbg_assert_msg_(COMMON, strlen(ColorAttr) == 2, "Console logging doesn't support > 9 levels.");
+		_dbg_assert_msg_(strlen(ColorAttr) == 2, "Console logging doesn't support > 9 levels.");
 		ColorLen = (int)strlen(ColorAttr);
 	}
 
@@ -455,7 +455,7 @@ void ConsoleListener::SendToThread(LogTypes::LOG_LEVELS Level, const char *Text)
 
 void ConsoleListener::WriteToConsole(LogTypes::LOG_LEVELS Level, const char *Text, size_t Len)
 {
-	_dbg_assert_msg_(COMMON, IsOpen(), "Don't call this before opening the console.");
+	_dbg_assert_msg_(IsOpen(), "Don't call this before opening the console.");
 
 	/*
 	const int MAX_BYTES = 1024*10;
@@ -510,7 +510,7 @@ void ConsoleListener::WriteToConsole(LogTypes::LOG_LEVELS Level, const char *Tex
 
 void ConsoleListener::PixelSpace(int Left, int Top, int Width, int Height, bool Resize)
 {
-	_dbg_assert_msg_(COMMON, IsOpen(), "Don't call this before opening the console.");
+	_dbg_assert_msg_(IsOpen(), "Don't call this before opening the console.");
 #if defined(USING_WIN_UI)
 	// Check size
 	if (Width < 8 || Height < 12) return;
@@ -632,7 +632,7 @@ void ConsoleListener::Log(const LogMessage &msg) {
 // Clear console screen
 void ConsoleListener::ClearScreen(bool Cursor)
 { 
-	_dbg_assert_msg_(COMMON, IsOpen(), "Don't call this before opening the console.");
+	_dbg_assert_msg_(IsOpen(), "Don't call this before opening the console.");
 #if defined(USING_WIN_UI)
 	COORD coordScreen = { 0, 0 }; 
 	DWORD cCharsWritten; 

--- a/Common/Hashmaps.h
+++ b/Common/Hashmaps.h
@@ -53,7 +53,7 @@ public:
 				return NullValue;
 			p = (p + 1) & mask;  // If the state is REMOVED, we just keep on walking. 
 			if (p == pos) {
-				_assert_msg_(SYSTEM, false, "DenseHashMap: Hit full on Get()");
+				_assert_msg_(false, "DenseHashMap: Hit full on Get()");
 			}
 		}
 		return NullValue;
@@ -72,7 +72,7 @@ public:
 			if (state[p] == BucketState::TAKEN) {
 				if (KeyEquals(key, map[p].key)) {
 					// Bad! We already got this one. Let's avoid this case.
-					_assert_msg_(SYSTEM, false, "DenseHashMap: Duplicate key inserted");
+					_assert_msg_(false, "DenseHashMap: Duplicate key inserted");
 					return false;
 				}
 				// continue looking....
@@ -83,7 +83,7 @@ public:
 			p = (p + 1) & mask;
 			if (p == pos) {
 				// FULL! Error. Should not happen thanks to Grow().
-				_assert_msg_(SYSTEM, false, "DenseHashMap: Hit full on Insert()");
+				_assert_msg_(false, "DenseHashMap: Hit full on Insert()");
 			}
 		}
 		if (state[p] == BucketState::REMOVED) {
@@ -111,7 +111,7 @@ public:
 			p = (p + 1) & mask;
 			if (p == pos) {
 				// FULL! Error. Should not happen.
-				_assert_msg_(SYSTEM, false, "DenseHashMap: Hit full on Remove()");
+				_assert_msg_(false, "DenseHashMap: Hit full on Remove()");
 			}
 		}
 		return false;
@@ -168,7 +168,7 @@ private:
 				Insert(old[i].key, old[i].value);
 			}
 		}
-		_assert_msg_(SYSTEM, oldCount == count_, "DenseHashMap: count should not change in Grow()");
+		_assert_msg_(oldCount == count_, "DenseHashMap: count should not change in Grow()");
 	}
 	struct Pair {
 		Key key;
@@ -204,7 +204,7 @@ public:
 				return NullValue;
 			p = (p + 1) & mask;  // If the state is REMOVED, we just keep on walking. 
 			if (p == pos) {
-				_assert_msg_(SYSTEM, false, "PrehashMap: Hit full on Get()");
+				_assert_msg_(false, "PrehashMap: Hit full on Get()");
 			}
 		}
 		return NullValue;
@@ -230,7 +230,7 @@ public:
 			p = (p + 1) & mask;
 			if (p == pos) {
 				// FULL! Error. Should not happen thanks to Grow().
-				_assert_msg_(SYSTEM, false, "PrehashMap: Hit full on Insert()");
+				_assert_msg_(false, "PrehashMap: Hit full on Insert()");
 			}
 		}
 		if (state[p] == BucketState::REMOVED) {
@@ -257,7 +257,7 @@ public:
 			}
 			p = (p + 1) & mask;
 			if (p == pos) {
-				_assert_msg_(SYSTEM, false, "PrehashMap: Hit full on Remove()");
+				_assert_msg_(false, "PrehashMap: Hit full on Remove()");
 			}
 		}
 		return false;
@@ -317,7 +317,7 @@ private:
 			}
 		}
 		INFO_LOG(G3D, "Grew hashmap capacity from %d to %d", oldCapacity, capacity_);
-		_assert_msg_(SYSTEM, oldCount == count_, "PrehashMap: count should not change in Grow()");
+		_assert_msg_(oldCount == count_, "PrehashMap: count should not change in Grow()");
 	}
 	struct Pair {
 		uint32_t hash;

--- a/Common/Log.h
+++ b/Common/Log.h
@@ -120,30 +120,30 @@ void AndroidAssertLog(const char *func, const char *file, int line, const char *
 #endif
 
 #if MAX_LOGLEVEL >= DEBUG_LEVEL
-#define _dbg_assert_(_t_, _a_) \
+#define _dbg_assert_(_a_) \
 	if (!(_a_)) {\
 		printf(#_a_ "\n\nError...\n\n  Line: %d\n  File: %s\n\n", \
 					   __LINE__, __FILE__); \
-		ERROR_LOG(_t_, #_a_ "\n\nError...\n\n  Line: %d\n  File: %s\n\nIgnore and continue?", \
+		ERROR_LOG(SYSTEM, #_a_ "\n\nError...\n\n  Line: %d\n  File: %s\n\nIgnore and continue?", \
 					   __LINE__, __FILE__); \
 		if (!PanicYesNo("*** Assertion ***\n")) { Crash(); } \
 	}
 
 #if defined(__ANDROID__)
 
-#define _dbg_assert_msg_(_t_, _a_, ...)\
+#define _dbg_assert_msg_(_a_, ...)\
 	if (!(_a_)) {\
 		printf(__VA_ARGS__); \
-		ERROR_LOG(_t_, __VA_ARGS__); \
+		ERROR_LOG(SYSTEM, __VA_ARGS__); \
 		if (!PanicYesNo(__VA_ARGS__)) AndroidAssertLog(__FUNCTION__, __FILENAME__, __LINE__, #_a_, __VA_ARGS__); \
 	}
 
 #else  // !defined(__ANDROID__)
 
-#define _dbg_assert_msg_(_t_, _a_, ...)\
+#define _dbg_assert_msg_(_a_, ...)\
 	if (!(_a_)) {\
 		printf(__VA_ARGS__); \
-		ERROR_LOG(_t_, __VA_ARGS__); \
+		ERROR_LOG(SYSTEM, __VA_ARGS__); \
 		if (!PanicYesNo(__VA_ARGS__)) { Crash();} \
 	}
 
@@ -167,7 +167,7 @@ void AndroidAssertLog(const char *func, const char *file, int line, const char *
 		AndroidAssertLog(__FUNCTION__, __FILENAME__, __LINE__, #_a_, "Assertion failed!"); \
 	}
 
-#define _assert_msg_(_t_, _a_, ...)		\
+#define _assert_msg_(_a_, ...)		\
 	if (!(_a_) && !PanicYesNo(__VA_ARGS__)) { \
 		AndroidAssertLog(__FUNCTION__, __FILENAME__, __LINE__, #_a_, __VA_ARGS__); \
 	}
@@ -181,9 +181,9 @@ void AndroidAssertLog(const char *func, const char *file, int line, const char *
 		if (!PanicYesNo("*** Assertion ***\n")) { Crash(); } \
 	}
 
-#define _assert_msg_(_t_, _a_, ...)		\
+#define _assert_msg_(_a_, ...)		\
 	if (!(_a_) && !PanicYesNo(__VA_ARGS__)) { \
-    Crash(); \
+		Crash(); \
 	}
 
 #endif  // __ANDROID__

--- a/Common/Log.h
+++ b/Common/Log.h
@@ -155,8 +155,8 @@ void AndroidAssertLog(const char *func, const char *file, int line, const char *
 #define _dbg_update_() ;
 
 #ifndef _dbg_assert_
-#define _dbg_assert_(_t_, _a_) {}
-#define _dbg_assert_msg_(_t_, _a_, _desc_, ...) {}
+#define _dbg_assert_(_a_) {}
+#define _dbg_assert_msg_(_a_, _desc_, ...) {}
 #endif // dbg_assert
 #endif // MAX_LOGLEVEL DEBUG
 

--- a/Common/MemArenaAndroid.cpp
+++ b/Common/MemArenaAndroid.cpp
@@ -156,10 +156,7 @@ u8* MemArena::Find4GBBase() {
 #else
 	// Address masking is used in 32-bit mode, so we can get away with less memory.
 	void* base = mmap(0, 0x10000000, PROT_READ | PROT_WRITE, MAP_ANON | MAP_SHARED, -1, 0);
-	if (base == MAP_FAILED) {
-		PanicAlert("Failed to map 256 MB of memory space: %s", strerror(errno));
-		return 0;
-	}
+	_assert_msg_(base != MAP_FAILED, "Failed to map 256 MB of memory space: %s", strerror(errno));
 	munmap(base, 0x10000000);
 	return static_cast<u8*>(base);
 #endif

--- a/Common/MemArenaPosix.cpp
+++ b/Common/MemArenaPosix.cpp
@@ -124,12 +124,8 @@ u8* MemArena::Find4GBBase() {
 	}
 #else
 	size_t size = 0x10000000;
-	void* base = mmap(0, size, PROT_READ | PROT_WRITE,
-		MAP_ANON | MAP_SHARED, -1, 0);
-	if (base == MAP_FAILED) {
-		PanicAlert("Failed to map 256 MB of memory space: %s", strerror(errno));
-		return 0;
-	}
+	void* base = mmap(0, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_SHARED, -1, 0);
+	_assert_msg_(base != MAP_FAILED, "Failed to map 256 MB of memory space: %s", strerror(errno));
 	munmap(base, size);
 	return static_cast<u8*>(base);
 #endif

--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -292,8 +292,7 @@ bool ProtectMemoryPages(const void* ptr, size_t size, uint32_t memProtFlags) {
 
 	if (PlatformIsWXExclusive()) {
 		if ((memProtFlags & (MEM_PROT_WRITE | MEM_PROT_EXEC)) == (MEM_PROT_WRITE | MEM_PROT_EXEC)) {
-			ERROR_LOG(MEMMAP, "Bad memory protection %d!", memProtFlags);
-			PanicAlert("Bad memory protect : W^X is in effect, can't both write and exec");
+			_assert_msg_(false, "Bad memory protect flags %d: W^X is in effect, can't both write and exec", memProtFlags);
 		}
 	}
 	// Note - VirtualProtect will affect the full pages containing the requested range.

--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -19,12 +19,13 @@
 
 #include "base/logging.h"
 
-#include "Common.h"
-#include "MemoryUtil.h"
-#include "StringUtils.h"
+#include "Common/Common.h"
+#include "Common/Log.h"
+#include "Common/MemoryUtil.h"
+#include "Common/StringUtils.h"
 
 #ifdef _WIN32
-#include "CommonWindows.h"
+#include "Common/CommonWindows.h"
 #else
 #include <errno.h>
 #include <stdio.h>
@@ -53,7 +54,7 @@ static SYSTEM_INFO sys_info;
 #define ppsspp_round_page(x) ((((uintptr_t)(x)) + MEM_PAGE_MASK) & ~(MEM_PAGE_MASK))
 
 #ifdef _WIN32
-// Win32 flags are odd...
+// Win32 memory protection flags are odd...
 static uint32_t ConvertProtFlagsWin32(uint32_t flags) {
 	uint32_t protect = 0;
 	switch (flags) {
@@ -185,7 +186,6 @@ void *AllocateExecutableMemory(size_t size) {
 	if (ptr == failed_result) {
 		ptr = nullptr;
 		ERROR_LOG(MEMMAP, "Failed to allocate executable memory (%d) errno=%d", (int)size, errno);
-		PanicAlert("Failed to allocate executable memory\n%s", GetLastErrorMsg());
 	}
 
 #if defined(_M_X64) && !defined(_WIN32)
@@ -214,13 +214,15 @@ void *AllocateMemoryPages(size_t size, uint32_t memProtFlags) {
 #else
 	void* ptr = VirtualAlloc(0, size, MEM_COMMIT, protect);
 #endif
-	if (!ptr)
-		PanicAlert("Failed to allocate raw memory");
+	if (!ptr) {
+		ERROR_LOG(MEMMAP, "Failed to allocate raw memory pages");
+		return nullptr;
+	}
 #else
 	uint32_t protect = ConvertProtFlagsUnix(memProtFlags);
 	void *ptr = mmap(0, size, protect, MAP_ANON | MAP_PRIVATE, -1, 0);
 	if (ptr == MAP_FAILED) {
-		ERROR_LOG(MEMMAP, "Failed to allocate memory pages: errno=%d", errno);
+		ERROR_LOG(MEMMAP, "Failed to allocate raw memory pages: errno=%d", errno);
 		return nullptr;
 	}
 #endif
@@ -232,23 +234,19 @@ void *AllocateMemoryPages(size_t size, uint32_t memProtFlags) {
 
 void *AllocateAlignedMemory(size_t size, size_t alignment) {
 #ifdef _WIN32
-	void* ptr =  _aligned_malloc(size,alignment);
+	void* ptr = _aligned_malloc(size,alignment);
 #else
 	void* ptr = NULL;
 #ifdef __ANDROID__
 	ptr = memalign(alignment, size);
 #else
-	if (posix_memalign(&ptr, alignment, size) != 0)
-		ptr = NULL;
+	if (posix_memalign(&ptr, alignment, size) != 0) {
+		ptr = nullptr;
+	}
 #endif
 #endif
 
-	// printf("Mapped memory at %p (size %ld)\n", ptr,
-	//	(unsigned long)size);
-
-	if (ptr == NULL)
-		PanicAlert("Failed to allocate aligned memory");
-
+	_assert_msg_(ptr != nullptr, "Failed to allocate aligned memory");
 	return ptr;
 }
 
@@ -258,8 +256,9 @@ void FreeMemoryPages(void *ptr, size_t size) {
 	uintptr_t page_size = GetMemoryProtectPageSize();
 	size = (size + page_size - 1) & (~(page_size - 1));
 #ifdef _WIN32
-	if (!VirtualFree(ptr, 0, MEM_RELEASE))
-		PanicAlert("FreeMemoryPages failed!\n%s", GetLastErrorMsg());
+	if (!VirtualFree(ptr, 0, MEM_RELEASE)) {
+		ERROR_LOG(MEMMAP, "FreeMemoryPages failed!\n%s", GetLastErrorMsg());
+	}
 #else
 	munmap(ptr, size);
 #endif
@@ -303,13 +302,13 @@ bool ProtectMemoryPages(const void* ptr, size_t size, uint32_t memProtFlags) {
 #if PPSSPP_PLATFORM(UWP)
 	DWORD oldValue;
 	if (!VirtualProtectFromApp((void *)ptr, size, protect, &oldValue)) {
-		PanicAlert("WriteProtectMemory failed!\n%s", GetLastErrorMsg());
+		ERROR_LOG(MEMMAP, "WriteProtectMemory failed!\n%s", GetLastErrorMsg());
 		return false;
 	}
 #else
 	DWORD oldValue;
 	if (!VirtualProtect((void *)ptr, size, protect, &oldValue)) {
-		PanicAlert("WriteProtectMemory failed!\n%s", GetLastErrorMsg());
+		ERROR_LOG(MEMMAP, "WriteProtectMemory failed!\n%s", GetLastErrorMsg());
 		return false;
 	}
 #endif

--- a/Common/MipsEmitter.cpp
+++ b/Common/MipsEmitter.cpp
@@ -76,7 +76,7 @@ void MIPSEmitter::FlushIcacheSection(u8 *start, u8 *end) {
 
 void MIPSEmitter::BREAK(u32 code) {
 	// 000000 iiiiiiiiiiiiiiiiiiii 001101
-	_dbg_assert_msg_(JIT, code <= 0xfffff, "Bad emitter arguments");
+	_dbg_assert_msg_(code <= 0xfffff, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 6, code & 0xfffff, 0, 0x0d);
 }
 
@@ -106,21 +106,21 @@ void MIPSEmitter::JAL(const void *func, std::function<void ()> delaySlot) {
 
 void MIPSEmitter::JR(MIPSReg rs, std::function<void ()> delaySlot) {
 	// 000000 sssss xxxxxxxxxx hint- 001000 (hint must be 0.)
-	_dbg_assert_msg_(JIT, rs < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rs < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 21, rs, 0, 0x08);
 	ApplyDelaySlot(delaySlot);
 }
 
 void MIPSEmitter::JALR(MIPSReg rd, MIPSReg rs, std::function<void ()> delaySlot) {
 	// 000000 sssss xxxxx ddddd hint- 001001 (hint must be 0.)
-	_dbg_assert_msg_(JIT, rs < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rs < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 21, rs, 11, rd, 0, 0x09);
 	ApplyDelaySlot(delaySlot);
 }
 
 FixupBranch MIPSEmitter::BLTZ(MIPSReg rs, std::function<void ()> delaySlot) {
 	// 000001 sssss xxxxx iiiiiiiiiiiiiii (fix up)
-	_dbg_assert_msg_(JIT, rs < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rs < F_BASE, "Bad emitter arguments");
 	FixupBranch b = MakeFixupBranch(BRANCH_16);
 	Write32Fields(26, 0x01, 21, rs);
 	ApplyDelaySlot(delaySlot);
@@ -133,7 +133,7 @@ void MIPSEmitter::BLTZ(MIPSReg rs, const void *func, std::function<void ()> dela
 
 FixupBranch MIPSEmitter::BEQ(MIPSReg rs, MIPSReg rt, std::function<void ()> delaySlot) {
 	// 000100 sssss ttttt iiiiiiiiiiiiiii (fix up)
-	_dbg_assert_msg_(JIT, rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
 	FixupBranch b = MakeFixupBranch(BRANCH_16);
 	Write32Fields(26, 0x04, 21, rs, 16, rt);
 	ApplyDelaySlot(delaySlot);
@@ -146,7 +146,7 @@ void MIPSEmitter::BEQ(MIPSReg rs, MIPSReg rt, const void *func, std::function<vo
 
 FixupBranch MIPSEmitter::BNE(MIPSReg rs, MIPSReg rt, std::function<void ()> delaySlot) {
 	// 000101 sssss ttttt iiiiiiiiiiiiiii (fix up)
-	_dbg_assert_msg_(JIT, rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
 	FixupBranch b = MakeFixupBranch(BRANCH_16);
 	Write32Fields(26, 0x05, 21, rs, 16, rt);
 	ApplyDelaySlot(delaySlot);
@@ -159,7 +159,7 @@ void MIPSEmitter::BNE(MIPSReg rs, MIPSReg rt, const void *func, std::function<vo
 
 FixupBranch MIPSEmitter::BLEZ(MIPSReg rs, std::function<void ()> delaySlot) {
 	// 000110 sssss xxxxx iiiiiiiiiiiiiii (fix up)
-	_dbg_assert_msg_(JIT, rs < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rs < F_BASE, "Bad emitter arguments");
 	FixupBranch b = MakeFixupBranch(BRANCH_16);
 	Write32Fields(26, 0x06, 21, rs);
 	ApplyDelaySlot(delaySlot);
@@ -172,7 +172,7 @@ void MIPSEmitter::BLEZ(MIPSReg rs, const void *func, std::function<void ()> dela
 
 FixupBranch MIPSEmitter::BGTZ(MIPSReg rs, std::function<void ()> delaySlot) {
 	// 000111 sssss xxxxx iiiiiiiiiiiiiii (fix up)
-	_dbg_assert_msg_(JIT, rs < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rs < F_BASE, "Bad emitter arguments");
 	FixupBranch b = MakeFixupBranch(BRANCH_16);
 	Write32Fields(26, 0x07, 21, rs);
 	ApplyDelaySlot(delaySlot);
@@ -200,16 +200,16 @@ void MIPSEmitter::SetJumpTarget(const FixupBranch &branch, const void *dst) {
 	const intptr_t dstp = (intptr_t)dst;
 	u32 *fixup = (u32 *)branch.ptr;
 
-	_dbg_assert_msg_(JIT, (dstp & 3) == 0, "Destination should be aligned");
+	_dbg_assert_msg_((dstp & 3) == 0, "Destination should be aligned");
 
 	if (branch.type == BRANCH_16) {
 		// The distance is encoded as words from the delay slot.
 		ptrdiff_t distance = (dstp - srcp - 4) >> 2;
-		_dbg_assert_msg_(JIT, BInRange(branch.ptr, dst), "Destination is too far away (%p -> %p)", branch.ptr, dst);
+		_dbg_assert_msg_(BInRange(branch.ptr, dst), "Destination is too far away (%p -> %p)", branch.ptr, dst);
 		*fixup = (*fixup & 0xffff0000) | (distance & 0x0000ffff);
 	} else {
 		// Absolute, easy.
-		_dbg_assert_msg_(JIT, JInRange(branch.ptr, dst), "Destination is too far away (%p -> %p)", branch.ptr, dst);
+		_dbg_assert_msg_(JInRange(branch.ptr, dst), "Destination is too far away (%p -> %p)", branch.ptr, dst);
 		*fixup = (*fixup & 0xfc000000) | ((dstp >> 2) & 0x03ffffff);
 	}
 }
@@ -240,7 +240,7 @@ void MIPSEmitter::ApplyDelaySlot(std::function<void ()> delaySlot) {
 }
 
 void MIPSEmitter::QuickCallFunction(MIPSReg scratchreg, const void *func) {
-	_dbg_assert_msg_(JIT, scratchreg < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(scratchreg < F_BASE, "Bad emitter arguments");
 	if (JInRange(func)) {
 		JAL(func);
 	} else {
@@ -259,176 +259,176 @@ FixupBranch MIPSEmitter::MakeFixupBranch(FixupBranchType type) {
 
 void MIPSEmitter::LB(MIPSReg value, MIPSReg base, s16 offset) {
 	// 100000 sssss ttttt iiiiiiiiiiiiiiii - rs = base, rt = value
-	_dbg_assert_msg_(JIT, value < F_BASE && base < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(value < F_BASE && base < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x20, 21, base, 16, value, 0, (u16)offset);
 }
 
 void MIPSEmitter::LH(MIPSReg value, MIPSReg base, s16 offset) {
 	// 100001 sssss ttttt iiiiiiiiiiiiiiii - rs = base, rt = value
-	_dbg_assert_msg_(JIT, value < F_BASE && base < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(value < F_BASE && base < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x21, 21, base, 16, value, 0, (u16)offset);
 }
 
 void MIPSEmitter::LW(MIPSReg value, MIPSReg base, s16 offset) {
 	// 100011 sssss ttttt iiiiiiiiiiiiiiii - rs = base, rt = value
-	_dbg_assert_msg_(JIT, value < F_BASE && base < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(value < F_BASE && base < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x23, 21, base, 16, value, 0, (u16)offset);
 }
 
 void MIPSEmitter::SB(MIPSReg value, MIPSReg base, s16 offset) {
 	// 101000 sssss ttttt iiiiiiiiiiiiiiii - rs = base, rt = value
-	_dbg_assert_msg_(JIT, value < F_BASE && base < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(value < F_BASE && base < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x28, 21, base, 16, value, 0, (u16)offset);
 }
 
 void MIPSEmitter::SH(MIPSReg value, MIPSReg base, s16 offset) {
 	// 101001 sssss ttttt iiiiiiiiiiiiiiii - rs = base, rt = value
-	_dbg_assert_msg_(JIT, value < F_BASE && base < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(value < F_BASE && base < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x29, 21, base, 16, value, 0, (u16)offset);
 }
 
 void MIPSEmitter::SW(MIPSReg value, MIPSReg base, s16 offset) {
 	// 101011 sssss ttttt iiiiiiiiiiiiiiii - rs = base, rt = value
-	_dbg_assert_msg_(JIT, value < F_BASE && base < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(value < F_BASE && base < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x2b, 21, base, 16, value, 0, (u16)offset);
 }
 
 void MIPSEmitter::SLL(MIPSReg rd, MIPSReg rt, u8 sa) {
 	// 000000 xxxxx ttttt ddddd aaaaa 000000
-	_dbg_assert_msg_(JIT, rd < F_BASE && rt < F_BASE && sa <= 0x1f, "Bad emitter arguments");
+	_dbg_assert_msg_(rd < F_BASE && rt < F_BASE && sa <= 0x1f, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 16, rt, 11, rd, 6, sa & 0x1f, 0, 0x00);
 }
 
 void MIPSEmitter::SRL(MIPSReg rd, MIPSReg rt, u8 sa) {
 	// 000000 xxxxx ttttt ddddd aaaaa 000010
-	_dbg_assert_msg_(JIT, rd < F_BASE && rt < F_BASE && sa <= 0x1f, "Bad emitter arguments");
+	_dbg_assert_msg_(rd < F_BASE && rt < F_BASE && sa <= 0x1f, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 16, rt, 11, rd, 6, sa & 0x1f, 0, 0x02);
 }
 
 void MIPSEmitter::SRA(MIPSReg rd, MIPSReg rt, u8 sa) {
 	// 000000 xxxxx ttttt ddddd aaaaa 000011
-	_dbg_assert_msg_(JIT, rd < F_BASE && rt < F_BASE && sa <= 0x1f, "Bad emitter arguments");
+	_dbg_assert_msg_(rd < F_BASE && rt < F_BASE && sa <= 0x1f, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 16, rt, 11, rd, 6, sa & 0x1f, 0, 0x03);
 }
 
 void MIPSEmitter::SLLV(MIPSReg rd, MIPSReg rt, MIPSReg rs) {
 	// 000000 sssss ttttt ddddd xxxxx 000100
-	_dbg_assert_msg_(JIT, rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 21, rs, 16, rt, 11, rd, 0, 0x04);
 }
 
 void MIPSEmitter::SRLV(MIPSReg rd, MIPSReg rt, MIPSReg rs) {
 	// 000000 sssss ttttt ddddd xxxxx 000110
-	_dbg_assert_msg_(JIT, rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 21, rs, 16, rt, 11, rd, 0, 0x06);
 }
 
 void MIPSEmitter::SRAV(MIPSReg rd, MIPSReg rt, MIPSReg rs) {
 	// 000000 sssss ttttt ddddd xxxxx 000111
-	_dbg_assert_msg_(JIT, rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 21, rs, 16, rt, 11, rd, 0, 0x07);
 }
 
 void MIPSEmitter::SLT(MIPSReg rd, MIPSReg rs, MIPSReg rt) {
 	// 000000 sssss ttttt ddddd xxxxx 101010
-	_dbg_assert_msg_(JIT, rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 21, rs, 16, rt, 11, rd, 0, 0x2a);
 }
 
 void MIPSEmitter::SLTU(MIPSReg rd, MIPSReg rs, MIPSReg rt) {
 	// 000000 sssss ttttt ddddd xxxxx 101011
-	_dbg_assert_msg_(JIT, rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 21, rs, 16, rt, 11, rd, 0, 0x2b);
 }
 
 void MIPSEmitter::SLTI(MIPSReg rt, MIPSReg rs, s16 imm) {
 	// 001010 sssss ttttt iiiiiiiiiiiiiiii
-	_dbg_assert_msg_(JIT, rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x0a, 21, rs, 16, rt, 0, (u16)imm);
 }
 
 void MIPSEmitter::SLTIU(MIPSReg rt, MIPSReg rs, s16 imm) {
 	// 001011 sssss ttttt iiiiiiiiiiiiiiii
-	_dbg_assert_msg_(JIT, rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x0b, 21, rs, 16, rt, 0, (u16)imm);
 }
 
 void MIPSEmitter::ADDU(MIPSReg rd, MIPSReg rs, MIPSReg rt) {
 	// 000000 sssss ttttt ddddd 00000100001
-	_dbg_assert_msg_(JIT, rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 21, rs, 16, rt, 11, rd, 0, 0x21);
 }
 
 void MIPSEmitter::SUBU(MIPSReg rd, MIPSReg rs, MIPSReg rt) {
 	// 000000 sssss ttttt ddddd 00000100011
-	_dbg_assert_msg_(JIT, rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 21, rs, 16, rt, 11, rd, 0, 0x23);
 }
 
 void MIPSEmitter::ADDIU(MIPSReg rt, MIPSReg rs, s16 imm) {
 	// 001001 sssss ttttt iiiiiiiiiiiiiiii
-	_dbg_assert_msg_(JIT, rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x09, 21, rs, 16, rt, 0, (u16)imm);
 }
 
 void MIPSEmitter::AND(MIPSReg rd, MIPSReg rs, MIPSReg rt) {
 	// 000000 sssss ttttt ddddd 00000100100
-	_dbg_assert_msg_(JIT, rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 21, rs, 16, rt, 11, rd, 0, 0x24);
 }
 
 void MIPSEmitter::OR(MIPSReg rd, MIPSReg rs, MIPSReg rt) {
 	// 000000 sssss ttttt ddddd 00000100101
-	_dbg_assert_msg_(JIT, rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 21, rs, 16, rt, 11, rd, 0, 0x25);
 }
 
 void MIPSEmitter::XOR(MIPSReg rd, MIPSReg rs, MIPSReg rt) {
 	// 000000 sssss ttttt ddddd 00000100110
-	_dbg_assert_msg_(JIT, rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rd < F_BASE && rt < F_BASE && rs < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x00, 21, rs, 16, rt, 11, rd, 0, 0x26);
 }
 
 void MIPSEmitter::ANDI(MIPSReg rt, MIPSReg rs, s16 imm) {
 	// 001100 sssss ttttt iiiiiiiiiiiiiiii
-	_dbg_assert_msg_(JIT, rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x0c, 21, rs, 16, rt, 0, (u16)imm);
 }
 
 void MIPSEmitter::ORI(MIPSReg rt, MIPSReg rs, s16 imm) {
 	// 001101 sssss ttttt iiiiiiiiiiiiiiii
-	_dbg_assert_msg_(JIT, rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x0d, 21, rs, 16, rt, 0, (u16)imm);
 }
 
 void MIPSEmitter::XORI(MIPSReg rt, MIPSReg rs, s16 imm) {
 	// 001110 sssss ttttt iiiiiiiiiiiiiiii
-	_dbg_assert_msg_(JIT, rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rs < F_BASE && rt < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x0e, 21, rs, 16, rt, 0, (u16)imm);
 }
 
 void MIPSEmitter::LUI(MIPSReg rt, s16 imm) {
 	// 001111 00000 ttttt iiiiiiiiiiiiiiii
-	_dbg_assert_msg_(JIT, rt < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(rt < F_BASE, "Bad emitter arguments");
 	Write32Fields(26, 0x0f, 16, rt, 0, (u16)imm);
 }
 
 void MIPSEmitter::INS(MIPSReg rt, MIPSReg rs, s8 pos, s8 size) {
 	// 011111 sssss ttttt xxxxx yyyyy 000100
-	_dbg_assert_msg_(JIT, rt < F_BASE && rs < F_BASE && pos <= 0x1f && (size+pos+1) <= 0x1f, "Bad emitter arguments");
+	_dbg_assert_msg_(rt < F_BASE && rs < F_BASE && pos <= 0x1f && (size+pos+1) <= 0x1f, "Bad emitter arguments");
 	Write32Fields(26, 0x1f, 21, rt, 16, rs, 11, (size+pos+1) & 0x1f, 6, pos & 0x1f, 0, 0x04);
 }
 
 void MIPSEmitter::EXT(MIPSReg rt, MIPSReg rs, s8 pos, s8 size) {
 	// 111111 sssss ttttt xxxxx yyyyy 000000
-	_dbg_assert_msg_(JIT, rt < F_BASE && rs < F_BASE && pos <= 0x1f && size >= 1, "Bad emitter arguments");
+	_dbg_assert_msg_(rt < F_BASE && rs < F_BASE && pos <= 0x1f && size >= 1, "Bad emitter arguments");
 	Write32Fields(26, 0x3f, 21, rt, 16, rs, 11, (size-1) & 0x1f, 6, pos & 0x1f, 0, 0x00);
 }
 
 void MIPSEmitter::DSLL(MIPSReg rd, MIPSReg rt, u8 sa) {
 	// 000000 xxxxx ttttt ddddd aaaaa 111000 DSLL
 	// 000000 xxxxx ttttt ddddd aaaaa 111100 DSLL32
-	_dbg_assert_msg_(JIT, rd < F_BASE && rt < F_BASE && sa <= 0x3f, "Bad emitter arguments");
+	_dbg_assert_msg_(rd < F_BASE && rt < F_BASE && sa <= 0x3f, "Bad emitter arguments");
 	// TODO: Assert MIPS64.
 	if (sa >= 32) {
 		Write32Fields(26, 0x00, 16, rt, 11, rd, 6, (sa - 32) & 0x1f, 0, 0x3c);
@@ -438,7 +438,7 @@ void MIPSEmitter::DSLL(MIPSReg rd, MIPSReg rt, u8 sa) {
 }
 
 void MIPSEmitter::MOVI2R(MIPSReg reg, u64 imm) {
-	_dbg_assert_msg_(JIT, reg < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(reg < F_BASE, "Bad emitter arguments");
 	// TODO: Assert MIPS64.
 
 	// Probably better to use a literal pool and load.
@@ -451,7 +451,7 @@ void MIPSEmitter::MOVI2R(MIPSReg reg, u64 imm) {
 }
 
 void MIPSEmitter::MOVI2R(MIPSReg reg, u32 imm) {
-	_dbg_assert_msg_(JIT, reg < F_BASE, "Bad emitter arguments");
+	_dbg_assert_msg_(reg < F_BASE, "Bad emitter arguments");
 
 	if ((imm & 0xffff0000) != 0) {
 #if 0

--- a/Common/MsgHandler.h
+++ b/Common/MsgHandler.h
@@ -31,7 +31,5 @@ bool MsgAlert(bool yes_no, int Style, const char *file, int line, const char* fo
 #endif
 	;
 
-#define PanicAlert(...) MsgAlert(false, WARNING, __FILE__, __LINE__, __VA_ARGS__)
-
 // Used only for asserts.
 #define PanicYesNo(...) MsgAlert(true, CRITICAL, __FILE__, __LINE__, __VA_ARGS__)

--- a/Common/Thunk.cpp
+++ b/Common/Thunk.cpp
@@ -147,8 +147,8 @@ const void *ThunkManager::ProtectFunction(const void *function, int num_params) 
 	iter = thunks.find(function);
 	if (iter != thunks.end())
 		return (const void *)iter->second;
-	if (!region)
-		PanicAlert("Trying to protect functions before the emu is started. Bad bad bad.");
+
+	_assert_msg_(region != nullptr, "Can't protect functions before the emu is started.");
 
 	BeginWrite();
 	const u8 *call_point = GetCodePtr();

--- a/Common/Vulkan/VulkanContext.cpp
+++ b/Common/Vulkan/VulkanContext.cpp
@@ -781,7 +781,7 @@ VkResult VulkanContext::ReinitSurface() {
 #endif
 
 	default:
-		_assert_msg_(G3D, false, "Vulkan support for chosen window system not implemented");
+		_assert_msg_(false, "Vulkan support for chosen window system not implemented");
 		return VK_ERROR_INITIALIZATION_FAILED;
 	}
 
@@ -843,7 +843,7 @@ bool VulkanContext::ChooseQueue() {
 	// Get the list of VkFormats that are supported:
 	uint32_t formatCount = 0;
 	VkResult res = vkGetPhysicalDeviceSurfaceFormatsKHR(physical_devices_[physical_device_], surface_, &formatCount, nullptr);
-	_assert_msg_(G3D, res == VK_SUCCESS, "Failed to get formats for device %d: %d", physical_device_, (int)res);
+	_assert_msg_(res == VK_SUCCESS, "Failed to get formats for device %d: %d", physical_device_, (int)res);
 	if (res != VK_SUCCESS) {
 		return false;
 	}

--- a/Common/Vulkan/VulkanImage.cpp
+++ b/Common/Vulkan/VulkanImage.cpp
@@ -101,7 +101,7 @@ bool VulkanTexture::CreateDirect(VkCommandBuffer cmd, VulkanDeviceAllocator *all
 		res = vkAllocateMemory(vulkan_->GetDevice(), &mem_alloc, NULL, &mem_);
 		if (res != VK_SUCCESS) {
 			ELOG("vkAllocateMemory failed: %s", VulkanResultToString(res));
-			_assert_msg_(G3D, res != VK_ERROR_TOO_MANY_OBJECTS, "Too many Vulkan memory objects!");
+			_assert_msg_(res != VK_ERROR_TOO_MANY_OBJECTS, "Too many Vulkan memory objects!");
 			_assert_(res == VK_ERROR_OUT_OF_HOST_MEMORY || res == VK_ERROR_OUT_OF_DEVICE_MEMORY || res == VK_ERROR_TOO_MANY_OBJECTS);
 			return false;
 		}
@@ -178,8 +178,8 @@ void VulkanTexture::UploadMip(VkCommandBuffer cmd, int mip, int mipWidth, int mi
 }
 
 void VulkanTexture::GenerateMip(VkCommandBuffer cmd, int mip) {
-	_assert_msg_(G3D, mip != 0, "Cannot generate the first level");
-	_assert_msg_(G3D, mip < numMips_, "Cannot generate mipmaps past the maximum created (%d vs %d)", mip, numMips_);
+	_assert_msg_(mip != 0, "Cannot generate the first level");
+	_assert_msg_(mip < numMips_, "Cannot generate mipmaps past the maximum created (%d vs %d)", mip, numMips_);
 	VkImageBlit blit{};
 	blit.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 	blit.srcSubresource.layerCount = 1;

--- a/Common/Vulkan/VulkanMemory.cpp
+++ b/Common/Vulkan/VulkanMemory.cpp
@@ -47,7 +47,7 @@ bool VulkanPushBuffer::AddBuffer() {
 
 	VkResult res = vkCreateBuffer(device, &b, nullptr, &info.buffer);
 	if (VK_SUCCESS != res) {
-		_assert_msg_(G3D, false, "vkCreateBuffer failed! result=%d", (int)res);
+		_assert_msg_(false, "vkCreateBuffer failed! result=%d", (int)res);
 		return false;
 	}
 
@@ -62,7 +62,7 @@ bool VulkanPushBuffer::AddBuffer() {
 
 	res = vkAllocateMemory(device, &alloc, nullptr, &info.deviceMemory);
 	if (VK_SUCCESS != res) {
-		_assert_msg_(G3D, false, "vkAllocateMemory failed! size=%d result=%d", (int)reqs.size, (int)res);
+		_assert_msg_(false, "vkAllocateMemory failed! size=%d result=%d", (int)reqs.size, (int)res);
 		vkDestroyBuffer(device, info.buffer, nullptr);
 		return false;
 	}
@@ -136,14 +136,14 @@ size_t VulkanPushBuffer::GetTotalSize() const {
 }
 
 void VulkanPushBuffer::Map() {
-	_dbg_assert_(G3D, !writePtr_);
+	_dbg_assert_(!writePtr_);
 	VkResult res = vkMapMemory(vulkan_->GetDevice(), buffers_[buf_].deviceMemory, 0, size_, 0, (void **)(&writePtr_));
-	_dbg_assert_(G3D, writePtr_);
+	_dbg_assert_(writePtr_);
 	assert(VK_SUCCESS == res);
 }
 
 void VulkanPushBuffer::Unmap() {
-	_dbg_assert_(G3D, writePtr_ != 0);
+	_dbg_assert_(writePtr_ != 0);
 
 	if ((memoryPropertyMask_ & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) == 0) {
 		VkMappedMemoryRange range{ VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE };
@@ -177,7 +177,7 @@ void VulkanDeviceAllocator::Destroy() {
 			if (slabUsage == 1) {
 				ERROR_LOG(G3D, "VulkanDeviceAllocator detected memory leak of size %d", (int)pair.second);
 			} else {
-				_dbg_assert_msg_(G3D, slabUsage == 2, "Destroy: slabUsage has unexpected value %d", slabUsage);
+				_dbg_assert_msg_(slabUsage == 2, "Destroy: slabUsage has unexpected value %d", slabUsage);
 			}
 		}
 
@@ -314,13 +314,13 @@ void VulkanDeviceAllocator::DoTouch(VkDeviceMemory deviceMemory, size_t offset) 
 		}
 	}
 
-	_assert_msg_(G3D, found, "Failed to find allocation to touch - use after free?");
+	_assert_msg_(found, "Failed to find allocation to touch - use after free?");
 }
 
 void VulkanDeviceAllocator::Free(VkDeviceMemory deviceMemory, size_t offset) {
 	assert(!destroyed_);
 
-	_assert_msg_(G3D, !slabs_.empty(), "No slabs - can't be anything to free! double-freed?");
+	_assert_msg_(!slabs_.empty(), "No slabs - can't be anything to free! double-freed?");
 
 	// First, let's validate.  This will allow stack traces to tell us when frees are bad.
 	size_t start = offset >> SLAB_GRAIN_SHIFT;
@@ -331,9 +331,9 @@ void VulkanDeviceAllocator::Free(VkDeviceMemory deviceMemory, size_t offset) {
 		}
 
 		auto it = slab.allocSizes.find(start);
-		_assert_msg_(G3D, it != slab.allocSizes.end(), "Double free?");
+		_assert_msg_(it != slab.allocSizes.end(), "Double free?");
 		// This means a double free, while queued to actually free.
-		_assert_msg_(G3D, slab.usage[start] == 1, "Double free when queued to free!");
+		_assert_msg_(slab.usage[start] == 1, "Double free when queued to free!");
 
 		// Mark it as "free in progress".
 		slab.usage[start] = 2;
@@ -342,7 +342,7 @@ void VulkanDeviceAllocator::Free(VkDeviceMemory deviceMemory, size_t offset) {
 	}
 
 	// Wrong deviceMemory even?  Maybe it was already decimated, but that means a double-free.
-	_assert_msg_(G3D, found, "Failed to find allocation to free! Double-freed?");
+	_assert_msg_(found, "Failed to find allocation to free! Double-freed?");
 
 	// Okay, now enqueue.  It's valid.
 	FreeInfo *info = new FreeInfo(this, deviceMemory, offset);
@@ -383,7 +383,7 @@ void VulkanDeviceAllocator::ExecuteFree(FreeInfo *userdata) {
 			}
 		} else {
 			// Ack, a double free?
-			_assert_msg_(G3D, false, "Double free? Block missing at offset %d", (int)userdata->offset);
+			_assert_msg_(false, "Double free? Block missing at offset %d", (int)userdata->offset);
 		}
 		auto itTag = slab.tags.find(start);
 		if (itTag != slab.tags.end()) {
@@ -394,7 +394,7 @@ void VulkanDeviceAllocator::ExecuteFree(FreeInfo *userdata) {
 	}
 
 	// Wrong deviceMemory even?  Maybe it was already decimated, but that means a double-free.
-	_assert_msg_(G3D, found, "ExecuteFree: Block not found (offset %d)", (int)offset);
+	_assert_msg_(found, "ExecuteFree: Block not found (offset %d)", (int)offset);
 	delete userdata;
 }
 

--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -25,9 +25,6 @@
 
 #define PRIx64 "llx"
 
-// Minimize the diff against Dolphin
-#define DYNA_REC JIT
-
 namespace Gen
 {
 
@@ -148,7 +145,7 @@ const u8 *XEmitter::AlignCodePage()
 // causing a subtle JIT bug.
 void XEmitter::CheckFlags()
 {
-	_assert_msg_(DYNA_REC, !flags_locked, "Attempt to modify flags while flags locked!");
+	_assert_msg_(!flags_locked, "Attempt to modify flags while flags locked!");
 }
 
 void XEmitter::WriteModRM(int mod, int reg, int rm)
@@ -182,16 +179,16 @@ void OpArg::WriteRex(XEmitter *emit, int opBits, int bits, int customOp) const
 	{
 		emit->Write8(op);
 		// Check the operation doesn't access AH, BH, CH, or DH.
-		_dbg_assert_(DYNA_REC, (offsetOrBaseReg & 0x100) == 0);
-		_dbg_assert_(DYNA_REC, (customOp & 0x100) == 0);
+		_dbg_assert_((offsetOrBaseReg & 0x100) == 0);
+		_dbg_assert_((customOp & 0x100) == 0);
 	}
 #else
-	_dbg_assert_(DYNA_REC, opBits != 64);
-	_dbg_assert_(DYNA_REC, (customOp & 8) == 0 || customOp == -1);
-	_dbg_assert_(DYNA_REC, (indexReg & 8) == 0);
-	_dbg_assert_(DYNA_REC, (offsetOrBaseReg & 8) == 0);
-	_dbg_assert_(DYNA_REC, opBits != 8 || (customOp & 0x10c) != 4 || customOp == -1);
-	_dbg_assert_(DYNA_REC, scale == SCALE_ATREG || bits != 8 || (offsetOrBaseReg & 0x10c) != 4);
+	_dbg_assert_(opBits != 64);
+	_dbg_assert_((customOp & 8) == 0 || customOp == -1);
+	_dbg_assert_((indexReg & 8) == 0);
+	_dbg_assert_((offsetOrBaseReg & 8) == 0);
+	_dbg_assert_(opBits != 8 || (customOp & 0x10c) != 4 || customOp == -1);
+	_dbg_assert_(scale == SCALE_ATREG || bits != 8 || (offsetOrBaseReg & 0x10c) != 4);
 #endif
 }
 
@@ -239,7 +236,7 @@ void OpArg::WriteRest(XEmitter *emit, int extraBytes, X64Reg _operandReg,
 #ifdef _M_X64
 		u64 ripAddr = (u64)emit->GetCodePointer() + 4 + extraBytes;
 		s64 distance = (s64)offset - (s64)ripAddr;
-		_assert_msg_(DYNA_REC,
+		_assert_msg_(
 		             (distance < 0x80000000LL &&
 		              distance >=  -0x80000000LL) ||
 		             !warn_64bit_offset,
@@ -344,7 +341,7 @@ void OpArg::WriteRest(XEmitter *emit, int extraBytes, X64Reg _operandReg,
 		case SCALE_NOBASE_4: ss = 2; break;
 		case SCALE_NOBASE_8: ss = 3; break;
 		case SCALE_ATREG: ss = 0; break;
-		default: _assert_msg_(DYNA_REC, 0, "Invalid scale for SIB byte"); ss = 0; break;
+		default: _assert_msg_(false, "Invalid scale for SIB byte"); ss = 0; break;
 		}
 		emit->Write8((u8)((ss << 6) | ((ireg&7)<<3) | (_offsetOrBaseReg&7)));
 	}
@@ -380,7 +377,7 @@ void XEmitter::JMP(const u8 *addr, bool force5Bytes)
 	if (!force5Bytes)
 	{
 		s64 distance = (s64)(fn - ((u64)code + 2));
-		_assert_msg_(DYNA_REC, distance >= -0x80 && distance < 0x80,
+		_assert_msg_(distance >= -0x80 && distance < 0x80,
 			     "Jump target too far away, needs force5Bytes = true");
 		//8 bits will do
 		Write8(0xEB);
@@ -390,8 +387,7 @@ void XEmitter::JMP(const u8 *addr, bool force5Bytes)
 	{
 		s64 distance = (s64)(fn - ((u64)code + 5));
 
-		_assert_msg_(DYNA_REC,
-		             distance >= -0x80000000LL && distance < 0x80000000LL,
+		_assert_msg_(distance >= -0x80000000LL && distance < 0x80000000LL,
 		             "Jump target too far away, needs indirect register");
 		Write8(0xE9);
 		Write32((u32)(s32)distance);
@@ -401,7 +397,7 @@ void XEmitter::JMP(const u8 *addr, bool force5Bytes)
 void XEmitter::JMPptr(const OpArg &arg2)
 {
 	OpArg arg = arg2;
-	if (arg.IsImm()) _assert_msg_(DYNA_REC, 0, "JMPptr - Imm argument");
+	if (arg.IsImm()) _assert_msg_(false, "JMPptr - Imm argument");
 	arg.operandReg = 4;
 	arg.WriteRex(this, 0, 0);
 	Write8(0xFF);
@@ -418,7 +414,7 @@ void XEmitter::JMPself()
 
 void XEmitter::CALLptr(OpArg arg)
 {
-	if (arg.IsImm()) _assert_msg_(DYNA_REC, 0, "CALLptr - Imm argument");
+	if (arg.IsImm()) _assert_msg_(false, "CALLptr - Imm argument");
 	arg.operandReg = 2;
 	arg.WriteRex(this, 0, 0);
 	Write8(0xFF);
@@ -428,8 +424,7 @@ void XEmitter::CALLptr(OpArg arg)
 void XEmitter::CALL(const void *fnptr)
 {
 	u64 distance = u64(fnptr) - (u64(code) + 5);
-	_assert_msg_(DYNA_REC,
-	             distance < 0x0000000080000000ULL ||
+	_assert_msg_(distance < 0x0000000080000000ULL ||
 	             distance >=  0xFFFFFFFF80000000ULL,
 	             "CALL out of range (%p calls %p)", code, fnptr);
 	Write8(0xE8);
@@ -482,8 +477,7 @@ void XEmitter::J_CC(CCFlags conditionCode, const u8* addr, bool force5bytes)
 	if (distance < -0x80 || distance >= 0x80 || force5bytes)
 	{
 		distance = (s64)(fn - ((u64)code + 6));
-		_assert_msg_(DYNA_REC,
-		             distance >= -0x80000000LL && distance < 0x80000000LL,
+		_assert_msg_(distance >= -0x80000000LL && distance < 0x80000000LL,
 		             "Jump target too far away, needs indirect register");
 		Write8(0x0F);
 		Write8(0x80 + conditionCode);
@@ -501,13 +495,13 @@ void XEmitter::SetJumpTarget(const FixupBranch &branch)
 	if (branch.type == 0)
 	{
 		s64 distance = (s64)(code - branch.ptr);
-		_assert_msg_(DYNA_REC, distance >= -0x80 && distance < 0x80, "Jump target too far away, needs force5Bytes = true");
+		_assert_msg_(distance >= -0x80 && distance < 0x80, "Jump target too far away, needs force5Bytes = true");
 		branch.ptr[-1] = (u8)(s8)distance;
 	}
 	else if (branch.type == 1)
 	{
 		s64 distance = (s64)(code - branch.ptr);
-		_assert_msg_(DYNA_REC, distance >= -0x80000000LL && distance < 0x80000000LL, "Jump target too far away, needs indirect register");
+		_assert_msg_(distance >= -0x80000000LL && distance < 0x80000000LL, "Jump target too far away, needs indirect register");
 		((s32*)branch.ptr)[-1] = (s32)distance;
 	}
 }
@@ -518,7 +512,7 @@ void XEmitter::SetJumpTarget(const FixupBranch &branch)
 /*
 void XEmitter::INC(int bits, OpArg arg)
 {
-	if (arg.IsImm()) _assert_msg_(DYNA_REC, 0, "INC - Imm argument");
+	if (arg.IsImm()) _assert_msg_(false, "INC - Imm argument");
 	arg.operandReg = 0;
 	if (bits == 16) {Write8(0x66);}
 	arg.WriteRex(this, bits, bits);
@@ -527,7 +521,7 @@ void XEmitter::INC(int bits, OpArg arg)
 }
 void XEmitter::DEC(int bits, OpArg arg)
 {
-	if (arg.IsImm()) _assert_msg_(DYNA_REC, 0, "DEC - Imm argument");
+	if (arg.IsImm()) _assert_msg_(false, "DEC - Imm argument");
 	arg.operandReg = 1;
 	if (bits == 16) {Write8(0x66);}
 	arg.WriteRex(this, bits, bits);
@@ -545,7 +539,7 @@ void XEmitter::RET_FAST()  {Write8(0xF3); Write8(0xC3);} //two-byte return (rep 
 // The first sign of decadence: optimized NOPs.
 void XEmitter::NOP(size_t size)
 {
-	_dbg_assert_(DYNA_REC, (int)size > 0);
+	_dbg_assert_((int)size > 0);
 	while (true)
 	{
 		switch (size)
@@ -689,7 +683,7 @@ void XEmitter::PUSH(int bits, const OpArg &reg)
 			Write32((u32)reg.offset);
 			break;
 		default:
-			_assert_msg_(DYNA_REC, 0, "PUSH - Bad imm bits");
+			_assert_msg_(false, "PUSH - Bad imm bits");
 			break;
 		}
 	}
@@ -708,7 +702,7 @@ void XEmitter::POP(int /*bits*/, const OpArg &reg)
 	if (reg.IsSimpleReg())
 		POP(reg.GetSimpleReg());
 	else
-		_assert_msg_(DYNA_REC, 0, "POP - Unsupported encoding");
+		_assert_msg_(false, "POP - Unsupported encoding");
 }
 
 void XEmitter::BSWAP(int bits, X64Reg reg)
@@ -727,7 +721,7 @@ void XEmitter::BSWAP(int bits, X64Reg reg)
 	}
 	else
 	{
-		_assert_msg_(DYNA_REC, 0, "BSWAP - Wrong number of bits");
+		_assert_msg_(false, "BSWAP - Wrong number of bits");
 	}
 }
 
@@ -741,7 +735,7 @@ void XEmitter::UD2()
 
 void XEmitter::PREFETCH(PrefetchLevel level, OpArg arg)
 {
-	_assert_msg_(DYNA_REC, !arg.IsImm(), "PREFETCH - Imm argument");
+	_assert_msg_(!arg.IsImm(), "PREFETCH - Imm argument");
 	arg.operandReg = (u8)level;
 	arg.WriteRex(this, 0, 0);
 	Write8(0x0F);
@@ -751,7 +745,7 @@ void XEmitter::PREFETCH(PrefetchLevel level, OpArg arg)
 
 void XEmitter::SETcc(CCFlags flag, OpArg dest)
 {
-	_assert_msg_(DYNA_REC, !dest.IsImm(), "SETcc - Imm argument");
+	_assert_msg_(!dest.IsImm(), "SETcc - Imm argument");
 	dest.operandReg = 0;
 	dest.WriteRex(this, 0, 8);
 	Write8(0x0F);
@@ -761,8 +755,8 @@ void XEmitter::SETcc(CCFlags flag, OpArg dest)
 
 void XEmitter::CMOVcc(int bits, X64Reg dest, OpArg src, CCFlags flag)
 {
-	_assert_msg_(DYNA_REC, !src.IsImm(), "CMOVcc - Imm argument");
-	_assert_msg_(DYNA_REC, bits != 8, "CMOVcc - 8 bits unsupported");
+	_assert_msg_(!src.IsImm(), "CMOVcc - Imm argument");
+	_assert_msg_(bits != 8, "CMOVcc - 8 bits unsupported");
 	if (bits == 16)
 		Write8(0x66);
 	src.operandReg = dest;
@@ -774,7 +768,7 @@ void XEmitter::CMOVcc(int bits, X64Reg dest, OpArg src, CCFlags flag)
 
 void XEmitter::WriteMulDivType(int bits, OpArg src, int ext)
 {
-	_assert_msg_(DYNA_REC, !src.IsImm(), "WriteMulDivType - Imm argument");
+	_assert_msg_(!src.IsImm(), "WriteMulDivType - Imm argument");
 	CheckFlags();
 	src.operandReg = ext;
 	if (bits == 16)
@@ -800,7 +794,7 @@ void XEmitter::NOT(int bits, OpArg src)  {WriteMulDivType(bits, src, 2);}
 
 void XEmitter::WriteBitSearchType(int bits, X64Reg dest, OpArg src, u8 byte2, bool rep)
 {
-	_assert_msg_(DYNA_REC, !src.IsImm(), "WriteBitSearchType - Imm argument");
+	_assert_msg_(!src.IsImm(), "WriteBitSearchType - Imm argument");
 	CheckFlags();
 	src.operandReg = (u8)dest;
 	if (bits == 16)
@@ -816,7 +810,7 @@ void XEmitter::WriteBitSearchType(int bits, X64Reg dest, OpArg src, u8 byte2, bo
 void XEmitter::MOVNTI(int bits, OpArg dest, X64Reg src)
 {
 	if (bits <= 16)
-		_assert_msg_(DYNA_REC, 0, "MOVNTI - bits<=16");
+		_assert_msg_(false, "MOVNTI - bits<=16");
 	WriteBitSearchType(bits, src, dest, 0xC3);
 }
 
@@ -840,7 +834,7 @@ void XEmitter::LZCNT(int bits, X64Reg dest, OpArg src)
 
 void XEmitter::MOVSX(int dbits, int sbits, X64Reg dest, OpArg src)
 {
-	_assert_msg_(DYNA_REC, !src.IsImm(), "MOVSX - Imm argument");
+	_assert_msg_(!src.IsImm(), "MOVSX - Imm argument");
 	if (dbits == sbits)
 	{
 		MOV(dbits, R(dest), src);
@@ -873,7 +867,7 @@ void XEmitter::MOVSX(int dbits, int sbits, X64Reg dest, OpArg src)
 
 void XEmitter::MOVZX(int dbits, int sbits, X64Reg dest, OpArg src)
 {
-	_assert_msg_(DYNA_REC, !src.IsImm(), "MOVZX - Imm argument");
+	_assert_msg_(!src.IsImm(), "MOVZX - Imm argument");
 	if (dbits == sbits)
 	{
 		MOV(dbits, R(dest), src);
@@ -900,14 +894,14 @@ void XEmitter::MOVZX(int dbits, int sbits, X64Reg dest, OpArg src)
 	}
 	else
 	{
-		_assert_msg_(DYNA_REC, 0, "MOVZX - Invalid size");
+		_assert_msg_(false, "MOVZX - Invalid size");
 	}
 	src.WriteRest(this);
 }
 
 void XEmitter::MOVBE(int bits, const OpArg& dest, const OpArg& src)
 {
-	_assert_msg_(DYNA_REC, cpu_info.bMOVBE, "Generating MOVBE on a system that does not support it.");
+	_assert_msg_(cpu_info.bMOVBE, "Generating MOVBE on a system that does not support it.");
 	if (bits == 8)
 	{
 		MOV(bits, dest, src);
@@ -919,28 +913,28 @@ void XEmitter::MOVBE(int bits, const OpArg& dest, const OpArg& src)
 
 	if (dest.IsSimpleReg())
 	{
-		_assert_msg_(DYNA_REC, !src.IsSimpleReg() && !src.IsImm(), "MOVBE: Loading from !mem");
+		_assert_msg_(!src.IsSimpleReg() && !src.IsImm(), "MOVBE: Loading from !mem");
 		src.WriteRex(this, bits, bits, dest.GetSimpleReg());
 		Write8(0x0F); Write8(0x38); Write8(0xF0);
 		src.WriteRest(this, 0, dest.GetSimpleReg());
 	}
 	else if (src.IsSimpleReg())
 	{
-		_assert_msg_(DYNA_REC, !dest.IsSimpleReg() && !dest.IsImm(), "MOVBE: Storing to !mem");
+		_assert_msg_(!dest.IsSimpleReg() && !dest.IsImm(), "MOVBE: Storing to !mem");
 		dest.WriteRex(this, bits, bits, src.GetSimpleReg());
 		Write8(0x0F); Write8(0x38); Write8(0xF1);
 		dest.WriteRest(this, 0, src.GetSimpleReg());
 	}
 	else
 	{
-		_assert_msg_(DYNA_REC, 0, "MOVBE: Not loading or storing to mem");
+		_assert_msg_(false, "MOVBE: Not loading or storing to mem");
 	}
 }
 
 
 void XEmitter::LEA(int bits, X64Reg dest, OpArg src)
 {
-	_assert_msg_(DYNA_REC, !src.IsImm(), "LEA - Imm argument");
+	_assert_msg_(!src.IsImm(), "LEA - Imm argument");
 	src.operandReg = (u8)dest;
 	if (bits == 16)
 		Write8(0x66); //TODO: performance warning
@@ -956,11 +950,11 @@ void XEmitter::WriteShift(int bits, OpArg dest, OpArg &shift, int ext)
 	bool writeImm = false;
 	if (dest.IsImm())
 	{
-		_assert_msg_(DYNA_REC, 0, "WriteShift - can't shift imms");
+		_assert_msg_(false, "WriteShift - can't shift imms");
 	}
 	if ((shift.IsSimpleReg() && shift.GetSimpleReg() != ECX) || (shift.IsImm() && shift.GetImmBits() != 8))
 	{
-		_assert_msg_(DYNA_REC, 0, "WriteShift - illegal argument");
+		_assert_msg_(false, "WriteShift - illegal argument");
 	}
 	dest.operandReg = ext;
 	if (bits == 16)
@@ -1005,11 +999,11 @@ void XEmitter::WriteBitTest(int bits, OpArg &dest, OpArg &index, int ext)
 	CheckFlags();
 	if (dest.IsImm())
 	{
-		_assert_msg_(DYNA_REC, 0, "WriteBitTest - can't test imms");
+		_assert_msg_(false, "WriteBitTest - can't test imms");
 	}
 	if ((index.IsImm() && index.GetImmBits() != 8))
 	{
-		_assert_msg_(DYNA_REC, 0, "WriteBitTest - illegal argument");
+		_assert_msg_(false, "WriteBitTest - illegal argument");
 	}
 	if (bits == 16)
 		Write8(0x66);
@@ -1040,15 +1034,15 @@ void XEmitter::SHRD(int bits, OpArg dest, OpArg src, OpArg shift)
 	CheckFlags();
 	if (dest.IsImm())
 	{
-		_assert_msg_(DYNA_REC, 0, "SHRD - can't use imms as destination");
+		_assert_msg_(false, "SHRD - can't use imms as destination");
 	}
 	if (!src.IsSimpleReg())
 	{
-		_assert_msg_(DYNA_REC, 0, "SHRD - must use simple register as source");
+		_assert_msg_(false, "SHRD - must use simple register as source");
 	}
 	if ((shift.IsSimpleReg() && shift.GetSimpleReg() != ECX) || (shift.IsImm() && shift.GetImmBits() != 8))
 	{
-		_assert_msg_(DYNA_REC, 0, "SHRD - illegal shift");
+		_assert_msg_(false, "SHRD - illegal shift");
 	}
 	if (bits == 16)
 		Write8(0x66);
@@ -1072,15 +1066,15 @@ void XEmitter::SHLD(int bits, OpArg dest, OpArg src, OpArg shift)
 	CheckFlags();
 	if (dest.IsImm())
 	{
-		_assert_msg_(DYNA_REC, 0, "SHLD - can't use imms as destination");
+		_assert_msg_(false, "SHLD - can't use imms as destination");
 	}
 	if (!src.IsSimpleReg())
 	{
-		_assert_msg_(DYNA_REC, 0, "SHLD - must use simple register as source");
+		_assert_msg_(false, "SHLD - must use simple register as source");
 	}
 	if ((shift.IsSimpleReg() && shift.GetSimpleReg() != ECX) || (shift.IsImm() && shift.GetImmBits() != 8))
 	{
-		_assert_msg_(DYNA_REC, 0, "SHLD - illegal shift");
+		_assert_msg_(false, "SHLD - illegal shift");
 	}
 	if (bits == 16)
 		Write8(0x66);
@@ -1116,7 +1110,7 @@ void OpArg::WriteNormalOp(XEmitter *emit, bool toRM, NormalOp op, const OpArg &o
 	X64Reg _operandReg;
 	if (IsImm())
 	{
-		_assert_msg_(DYNA_REC, 0, "WriteNormalOp - Imm argument, wrong order");
+		_assert_msg_(false, "WriteNormalOp - Imm argument, wrong order");
 	}
 
 	if (bits == 16)
@@ -1130,7 +1124,7 @@ void OpArg::WriteNormalOp(XEmitter *emit, bool toRM, NormalOp op, const OpArg &o
 
 		if (!toRM)
 		{
-			_assert_msg_(DYNA_REC, 0, "WriteNormalOp - Writing to Imm (!toRM)");
+			_assert_msg_(false, "WriteNormalOp - Writing to Imm (!toRM)");
 		}
 
 		if (operand.scale == SCALE_IMM8 && bits == 8)
@@ -1206,7 +1200,7 @@ void OpArg::WriteNormalOp(XEmitter *emit, bool toRM, NormalOp op, const OpArg &o
 		{
 			if (scale)
 			{
-				_assert_msg_(DYNA_REC, 0, "WriteNormalOp - MOV with 64-bit imm requres register destination");
+				_assert_msg_(false, "WriteNormalOp - MOV with 64-bit imm requres register destination");
 			}
 			// mov reg64, imm64
 			else if (op == nrmMOV)
@@ -1215,11 +1209,11 @@ void OpArg::WriteNormalOp(XEmitter *emit, bool toRM, NormalOp op, const OpArg &o
 				emit->Write64((u64)operand.offset);
 				return;
 			}
-			_assert_msg_(DYNA_REC, 0, "WriteNormalOp - Only MOV can take 64-bit imm");
+			_assert_msg_(false, "WriteNormalOp - Only MOV can take 64-bit imm");
 		}
 		else
 		{
-			_assert_msg_(DYNA_REC, 0, "WriteNormalOp - Unhandled case");
+			_assert_msg_(false, "WriteNormalOp - Unhandled case");
 		}
 		_operandReg = (X64Reg)normalops[op].ext; //pass extension in REG of ModRM
 	}
@@ -1253,7 +1247,7 @@ void OpArg::WriteNormalOp(XEmitter *emit, bool toRM, NormalOp op, const OpArg &o
 		emit->Write32((u32)operand.offset);
 		break;
 	default:
-		_assert_msg_(DYNA_REC, 0, "WriteNormalOp - Unhandled case");
+		_assert_msg_(false, "WriteNormalOp - Unhandled case");
 	}
 }
 
@@ -1262,7 +1256,7 @@ void XEmitter::WriteNormalOp(XEmitter *emit, int bits, NormalOp op, const OpArg 
 	if (a1.IsImm())
 	{
 		//Booh! Can't write to an imm
-		_assert_msg_(DYNA_REC, 0, "WriteNormalOp - a1 cannot be imm");
+		_assert_msg_(false, "WriteNormalOp - a1 cannot be imm");
 		return;
 	}
 	if (a2.IsImm())
@@ -1277,7 +1271,7 @@ void XEmitter::WriteNormalOp(XEmitter *emit, int bits, NormalOp op, const OpArg 
 		}
 		else
 		{
-			_assert_msg_(DYNA_REC, a2.IsSimpleReg() || a2.IsImm(), "WriteNormalOp - a1 and a2 cannot both be memory");
+			_assert_msg_(a2.IsSimpleReg() || a2.IsImm(), "WriteNormalOp - a1 and a2 cannot both be memory");
 			a1.WriteNormalOp(emit, true, op, a2, bits);
 		}
 	}
@@ -1293,7 +1287,7 @@ void XEmitter::XOR (int bits, const OpArg &a1, const OpArg &a2) {CheckFlags(); W
 void XEmitter::MOV (int bits, const OpArg &a1, const OpArg &a2)
 {
 	if (a1.IsSimpleReg() && a2.IsSimpleReg() && a1.GetSimpleReg() == a2.GetSimpleReg())
-		ERROR_LOG(DYNA_REC, "Redundant MOV @ %p - bug in JIT?", code);
+		ERROR_LOG(JIT, "Redundant MOV @ %p - bug in JIT?", code);
 	WriteNormalOp(this, bits, nrmMOV, a1, a2);
 }
 void XEmitter::TEST(int bits, const OpArg &a1, const OpArg &a2) {CheckFlags(); WriteNormalOp(this, bits, nrmTEST, a1, a2);}
@@ -1305,19 +1299,19 @@ void XEmitter::IMUL(int bits, X64Reg regOp, OpArg a1, OpArg a2)
 	CheckFlags();
 	if (bits == 8)
 	{
-		_assert_msg_(DYNA_REC, 0, "IMUL - illegal bit size!");
+		_assert_msg_(false, "IMUL - illegal bit size!");
 		return;
 	}
 
 	if (a1.IsImm())
 	{
-		_assert_msg_(DYNA_REC, 0, "IMUL - second arg cannot be imm!");
+		_assert_msg_(false, "IMUL - second arg cannot be imm!");
 		return;
 	}
 
 	if (!a2.IsImm())
 	{
-		_assert_msg_(DYNA_REC, 0, "IMUL - third arg must be imm!");
+		_assert_msg_(false, "IMUL - third arg must be imm!");
 		return;
 	}
 
@@ -1348,7 +1342,7 @@ void XEmitter::IMUL(int bits, X64Reg regOp, OpArg a1, OpArg a2)
 		}
 		else
 		{
-			_assert_msg_(DYNA_REC, 0, "IMUL - unhandled case!");
+			_assert_msg_(false, "IMUL - unhandled case!");
 		}
 	}
 }
@@ -1358,7 +1352,7 @@ void XEmitter::IMUL(int bits, X64Reg regOp, OpArg a)
 	CheckFlags();
 	if (bits == 8)
 	{
-		_assert_msg_(DYNA_REC, 0, "IMUL - illegal bit size!");
+		_assert_msg_(false, "IMUL - illegal bit size!");
 		return;
 	}
 
@@ -1508,7 +1502,7 @@ void XEmitter::MOVQ_xmm(OpArg arg, X64Reg src)
 void XEmitter::WriteMXCSR(OpArg arg, int ext)
 {
 	if (arg.IsImm() || arg.IsSimpleReg())
-		_assert_msg_(DYNA_REC, 0, "MXCSR - invalid operand");
+		_assert_msg_(false, "MXCSR - invalid operand");
 
 	arg.operandReg = ext;
 	arg.WriteRex(this, 0, 0);
@@ -1968,13 +1962,13 @@ void XEmitter::FWAIT()
 void XEmitter::WriteFloatLoadStore(int bits, FloatOp op, FloatOp op_80b, OpArg arg)
 {
 	int mf = 0;
-	_assert_msg_(DYNA_REC, !(bits == 80 && op_80b == floatINVALID), "WriteFloatLoadStore: 80 bits not supported for this instruction");
+	_assert_msg_(!(bits == 80 && op_80b == floatINVALID), "WriteFloatLoadStore: 80 bits not supported for this instruction");
 	switch (bits)
 	{
 	case 32: mf = 0; break;
 	case 64: mf = 4; break;
 	case 80: mf = 2; break;
-	default: _assert_msg_(DYNA_REC, 0, "WriteFloatLoadStore: invalid bits (should be 32/64/80)");
+	default: _assert_msg_(false, "WriteFloatLoadStore: invalid bits (should be 32/64/80)");
 	}
 	Write8(0xd9 | mf);
 	// x87 instructions use the reg field of the ModR/M byte as opcode:

--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -820,15 +820,13 @@ void XEmitter::BSR(int bits, X64Reg dest, OpArg src) {WriteBitSearchType(bits,de
 void XEmitter::TZCNT(int bits, X64Reg dest, OpArg src)
 {
 	CheckFlags();
-	if (!cpu_info.bBMI1)
-		PanicAlert("Trying to use BMI1 on a system that doesn't support it. Bad programmer.");
+	_assert_msg_(cpu_info.bBMI1, "Trying to use BMI1 on a system that doesn't support it.");
 	WriteBitSearchType(bits, dest, src, 0xBC, true);
 }
 void XEmitter::LZCNT(int bits, X64Reg dest, OpArg src)
 {
 	CheckFlags();
-	if (!cpu_info.bLZCNT)
-		PanicAlert("Trying to use LZCNT on a system that doesn't support it. Bad programmer.");
+	_assert_msg_(cpu_info.bLZCNT, "Trying to use LZCNT on a system that doesn't support it.");
 	WriteBitSearchType(bits, dest, src, 0xBD, true);
 }
 
@@ -1414,7 +1412,7 @@ static int GetVEXpp(u8 opPrefix)
 
 void XEmitter::WriteAVXOp(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes)
 {
-	_assert_msg_(cpu_info.bAVX, "Trying to use AVX on a system that doesn't support it. Bad programmer.");
+	_assert_msg_(cpu_info.bAVX, "Trying to use AVX on a system that doesn't support it.");
 	int mmmmm = GetVEXmmmmm(op);
 	int pp = GetVEXpp(opPrefix);
 	// FIXME: we currently don't support 256-bit instructions, and "size" is not the vector size here
@@ -1426,8 +1424,7 @@ void XEmitter::WriteAVXOp(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpA
 // Like the above, but more general; covers GPR-based VEX operations, like BMI1/2
 void XEmitter::WriteVEXOp(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes)
 {
-	if (size != 32 && size != 64)
-		PanicAlert("VEX GPR instructions only support 32-bit and 64-bit modes!");
+	_assert_msg_(size == 32 || size == 64, "VEX GPR instructions only support 32-bit and 64-bit modes!");
 	int mmmmm = GetVEXmmmmm(op);
 	int pp = GetVEXpp(opPrefix);
 	arg.WriteVex(this, regOp1, regOp2, 0, pp, mmmmm, size == 64);
@@ -1438,14 +1435,14 @@ void XEmitter::WriteVEXOp(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg r
 void XEmitter::WriteBMI1Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes)
 {
 	CheckFlags();
-	_assert_msg_(cpu_info.bBMI1, "Trying to use BMI1 on a system that doesn't support it. Bad programmer.");
+	_assert_msg_(cpu_info.bBMI1, "Trying to use BMI1 on a system that doesn't support it.");
 	WriteVEXOp(size, opPrefix, op, regOp1, regOp2, arg, extrabytes);
 }
 
 void XEmitter::WriteBMI2Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes)
 {
 	CheckFlags();
-	_assert_msg_(cpu_info.bBMI2, "Trying to use BMI2 on a system that doesn't support it. Bad programmer.");
+	_assert_msg_(cpu_info.bBMI2, "Trying to use BMI2 on a system that doesn't support it.");
 	WriteVEXOp(size, opPrefix, op, regOp1, regOp2, arg, extrabytes);
 }
 
@@ -1739,13 +1736,13 @@ void XEmitter::PMULUDQ(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0xF4, de
 
 void XEmitter::WriteSSSE3Op(u8 opPrefix, u16 op, X64Reg regOp, OpArg arg, int extrabytes)
 {
-	_assert_msg_(cpu_info.bSSSE3, "Trying to use SSSE3 on a system that doesn't support it. Bad programmer.");
+	_assert_msg_(cpu_info.bSSSE3, "Trying to use SSSE3 on a system that doesn't support it.");
 	WriteSSEOp(opPrefix, op, regOp, arg, extrabytes);
 }
 
 void XEmitter::WriteSSE41Op(u8 opPrefix, u16 op, X64Reg regOp, OpArg arg, int extrabytes)
 {
-	_assert_msg_(cpu_info.bSSE4_1, "Trying to use SSE4.1 on a system that doesn't support it. Bad programmer.");
+	_assert_msg_(cpu_info.bSSE4_1, "Trying to use SSE4.1 on a system that doesn't support it.");
 	WriteSSEOp(opPrefix, op, regOp, arg, extrabytes);
 }
 

--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -1414,8 +1414,7 @@ static int GetVEXpp(u8 opPrefix)
 
 void XEmitter::WriteAVXOp(u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes)
 {
-	if (!cpu_info.bAVX)
-		PanicAlert("Trying to use AVX on a system that doesn't support it. Bad programmer.");
+	_assert_msg_(cpu_info.bAVX, "Trying to use AVX on a system that doesn't support it. Bad programmer.");
 	int mmmmm = GetVEXmmmmm(op);
 	int pp = GetVEXpp(opPrefix);
 	// FIXME: we currently don't support 256-bit instructions, and "size" is not the vector size here
@@ -1439,16 +1438,14 @@ void XEmitter::WriteVEXOp(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg r
 void XEmitter::WriteBMI1Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes)
 {
 	CheckFlags();
-	if (!cpu_info.bBMI1)
-		PanicAlert("Trying to use BMI1 on a system that doesn't support it. Bad programmer.");
+	_assert_msg_(cpu_info.bBMI1, "Trying to use BMI1 on a system that doesn't support it. Bad programmer.");
 	WriteVEXOp(size, opPrefix, op, regOp1, regOp2, arg, extrabytes);
 }
 
 void XEmitter::WriteBMI2Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg regOp2, OpArg arg, int extrabytes)
 {
 	CheckFlags();
-	if (!cpu_info.bBMI2)
-		PanicAlert("Trying to use BMI2 on a system that doesn't support it. Bad programmer.");
+	_assert_msg_(cpu_info.bBMI2, "Trying to use BMI2 on a system that doesn't support it. Bad programmer.");
 	WriteVEXOp(size, opPrefix, op, regOp1, regOp2, arg, extrabytes);
 }
 
@@ -1742,15 +1739,13 @@ void XEmitter::PMULUDQ(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0xF4, de
 
 void XEmitter::WriteSSSE3Op(u8 opPrefix, u16 op, X64Reg regOp, OpArg arg, int extrabytes)
 {
-	if (!cpu_info.bSSSE3)
-		PanicAlert("Trying to use SSSE3 on a system that doesn't support it. Bad programmer.");
+	_assert_msg_(cpu_info.bSSSE3, "Trying to use SSSE3 on a system that doesn't support it. Bad programmer.");
 	WriteSSEOp(opPrefix, op, regOp, arg, extrabytes);
 }
 
 void XEmitter::WriteSSE41Op(u8 opPrefix, u16 op, X64Reg regOp, OpArg arg, int extrabytes)
 {
-	if (!cpu_info.bSSE4_1)
-		PanicAlert("Trying to use SSE4.1 on a system that doesn't support it. Bad programmer.");
+	_assert_msg_(cpu_info.bSSE4_1, "Trying to use SSE4.1 on a system that doesn't support it. Bad programmer.");
 	WriteSSEOp(opPrefix, op, regOp, arg, extrabytes);
 }
 

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -292,7 +292,7 @@ template<> inline u32 PtrOffsetTpl<8>(const void *ptr, const void* base) {
 	if (distance >= 0x80000000LL ||
 	    distance < -0x80000000LL)
 	{
-		_assert_msg_(DYNA_REC, 0, "pointer offset out of range");
+		_assert_msg_(false, "pointer offset out of range");
 		return 0;
 	}
 

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -249,7 +249,7 @@ struct ConfigSetting {
 			}
 			return true;
 		default:
-			_dbg_assert_msg_(LOADER, false, "Unexpected ini setting type");
+			_dbg_assert_msg_(false, "Unexpected ini setting type");
 			return false;
 		}
 	}
@@ -282,7 +282,7 @@ struct ConfigSetting {
 			}
 			return;
 		default:
-			_dbg_assert_msg_(LOADER, false, "Unexpected ini setting type");
+			_dbg_assert_msg_(false, "Unexpected ini setting type");
 			return;
 		}
 	}
@@ -306,7 +306,7 @@ struct ConfigSetting {
 			// Doesn't report.
 			return;
 		default:
-			_dbg_assert_msg_(LOADER, false, "Unexpected ini setting type");
+			_dbg_assert_msg_(false, "Unexpected ini setting type");
 			return;
 		}
 	}

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -183,7 +183,7 @@ void AntiCrashCallback(u64 userdata, int cyclesLate)
 
 void RestoreRegisterEvent(int event_type, const char *name, TimedCallback callback)
 {
-	_assert_msg_(CORETIMING, event_type >= 0, "Invalid event type %d", event_type)
+	_assert_msg_(event_type >= 0, "Invalid event type %d", event_type)
 	if (event_type >= (int) event_types.size())
 		event_types.resize(event_type + 1, EventType(AntiCrashCallback, "INVALID EVENT"));
 
@@ -572,7 +572,7 @@ void ForceCheck()
 	slicelength = -1;
 
 #ifdef _DEBUG
-	_dbg_assert_msg_(CPU, cyclesExecuted >= 0, "Shouldn't have a negative cyclesExecuted");
+	_dbg_assert_msg_( cyclesExecuted >= 0, "Shouldn't have a negative cyclesExecuted");
 #endif
 }
 

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -192,8 +192,7 @@ void RestoreRegisterEvent(int event_type, const char *name, TimedCallback callba
 
 void UnregisterAllEvents()
 {
-	if (first)
-		PanicAlert("Cannot unregister events with events pending");
+	_dbg_assert_msg_(first == nullptr, "Unregistering events with events pending - this isn't good.");
 	event_types.clear();
 }
 
@@ -647,17 +646,18 @@ void Idle(int maxIdle)
 		currentMIPS->downcount = -1;
 }
 
-std::string GetScheduledEventsSummary()
-{
+std::string GetScheduledEventsSummary() {
 	Event *ptr = first;
 	std::string text = "Scheduled events\n";
 	text.reserve(1000);
-	while (ptr)
-	{
+	while (ptr) {
 		unsigned int t = ptr->type;
-		if (t >= event_types.size())
-			PanicAlert("Invalid event type"); // %i", t);
-		const char *name = event_types[ptr->type].name;
+		if (t >= event_types.size()) {
+			_dbg_assert_msg_(false, "Invalid event type %d", t);
+			ptr = ptr->next;
+			continue;
+		}
+		const char *name = event_types[t].name;
 		if (!name)
 			name = "[unknown]";
 		char temp[512];

--- a/Core/FileLoaders/DiskCachingFileLoader.cpp
+++ b/Core/FileLoaders/DiskCachingFileLoader.cpp
@@ -398,7 +398,7 @@ u32 DiskCachingFileLoaderCache::AllocateBlock(u32 indexPos) {
 		}
 	}
 
-	_dbg_assert_msg_(LOADER, false, "Not enough free blocks");
+	_dbg_assert_msg_(false, "Not enough free blocks");
 	return INVALID_BLOCK;
 }
 

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -535,7 +535,9 @@ size_t ISOFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) {
 		u32 secNum = (u32)(positionOnIso / 2048);
 		u8 theSector[2048];
 
-		_dbg_assert_msg_(FILESYS, (middleSize & 2047) == 0, "Remaining size should be aligned");
+		if ((middleSize & 2047) != 0) {
+			ERROR_LOG(FILESYS, "Remaining size should be aligned");
+		}
 
 		const u8 *const start = pointer;
 		if (firstBlockSize > 0) {

--- a/Core/FileSystems/tlzrc.cpp
+++ b/Core/FileSystems/tlzrc.cpp
@@ -63,7 +63,7 @@ typedef struct{
 static u8 rc_getbyte(LZRC_DECODE *rc)
 {
 	if(rc->in_ptr == rc->in_len){
-		_dbg_assert_msg_(LOADER, false, "LZRC: End of input!");
+		_dbg_assert_msg_(false, "LZRC: End of input!");
 	}
 
 	return rc->input[rc->in_ptr++];
@@ -72,7 +72,7 @@ static u8 rc_getbyte(LZRC_DECODE *rc)
 static void rc_putbyte(LZRC_DECODE *rc, u8 byte)
 {
 	if(rc->out_ptr == rc->out_len){
-		_dbg_assert_msg_(LOADER, false, "LZRC: Output overflow!");
+		_dbg_assert_msg_(false, "LZRC: Output overflow!");
 	}
 
 	rc->output[rc->out_ptr++] = byte;

--- a/Core/Font/PGF.cpp
+++ b/Core/Font/PGF.cpp
@@ -37,7 +37,7 @@ static bool isJPCSPFont(const char *fontName) {
 
 // Gets a number of bits from an offset.
 static int getBits(int numBits, const u8 *buf, size_t pos) {
-	_dbg_assert_msg_(SCEFONT, numBits <= 32, "Unable to return more than 32 bits, %d requested", numBits);
+	_dbg_assert_msg_(numBits <= 32, "Unable to return more than 32 bits, %d requested", numBits);
 
 	const size_t wordpos = pos >> 5;
 	const u32 *wordbuf = (const u32 *)buf;

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -215,7 +215,7 @@ const HLEFunction *GetFunc(const char *moduleName, u32 nib)
 
 const char *GetFuncName(const char *moduleName, u32 nib)
 {
-	_dbg_assert_msg_(HLE, moduleName != NULL, "Invalid module name.");
+	_dbg_assert_msg_(moduleName != nullptr, "Invalid module name.");
 
 	const HLEFunction *func = GetFunc(moduleName,nib);
 	if (func)
@@ -314,7 +314,7 @@ void hleCheckCurrentCallbacks()
 void hleReSchedule(const char *reason)
 {
 #ifdef _DEBUG
-	_dbg_assert_msg_(HLE, reason != nullptr && strlen(reason) < 256, "hleReSchedule: Invalid or too long reason.");
+	_dbg_assert_msg_(reason != nullptr && strlen(reason) < 256, "hleReSchedule: Invalid or too long reason.");
 #endif
 
 	hleAfterSyscall |= HLE_AFTER_RESCHED;
@@ -820,7 +820,7 @@ size_t hleFormatLogArgs(char *message, size_t sz, const char *argmask) {
 		// TODO: Double?  Does it ever happen?
 
 		default:
-			_dbg_assert_msg_(HLE, false, "Invalid argmask character: %c", argmask[i]);
+			_dbg_assert_msg_(false, "Invalid argmask character: %c", argmask[i]);
 			APPEND_FMT(" -- invalid arg format: %c -- %08x", argmask[i], regval);
 			break;
 		}
@@ -844,7 +844,7 @@ void hleDoLogInternal(LogTypes::LOG_TYPE t, LogTypes::LOG_LEVELS level, u64 res,
 	const char *funcName = "?";
 	u32 funcFlags = 0;
 	if (latestSyscall) {
-		_dbg_assert_(HLE, latestSyscall->argmask != nullptr);
+		_dbg_assert_(latestSyscall->argmask != nullptr);
 		hleFormatLogArgs(formatted_args, sizeof(formatted_args), latestSyscall->argmask);
 
 		// This acts as an override (for error returns which are usually hex.)
@@ -866,7 +866,7 @@ void hleDoLogInternal(LogTypes::LOG_TYPE t, LogTypes::LOG_LEVELS level, u64 res,
 		// TODO: For now, floats are just shown as bits.
 		fmt = "%s%08x=%s(%s)%s";
 	} else {
-		_dbg_assert_msg_(HLE, false, "Invalid return format: %c", retmask);
+		_dbg_assert_msg_(false, "Invalid return format: %c", retmask);
 		fmt = "%s%08llx=%s(%s)%s";
 	}
 

--- a/Core/HLE/ThreadQueueList.h
+++ b/Core/HLE/ThreadQueueList.h
@@ -82,7 +82,7 @@ struct ThreadQueueList {
 			cur = cur->next;
 		}
 
-		_dbg_assert_msg_(SCEKERNEL, false, "ThreadQueueList should not be empty.");
+		_dbg_assert_msg_(false, "ThreadQueueList should not be empty.");
 		return 0;
 	}
 
@@ -127,7 +127,7 @@ struct ThreadQueueList {
 
 	inline void remove(u32 priority, const SceUID threadID) {
 		Queue *cur = &queues[priority];
-		_dbg_assert_msg_(SCEKERNEL, cur->next != nullptr, "ThreadQueueList::Queue should already be linked up.");
+		_dbg_assert_msg_(cur->next != nullptr, "ThreadQueueList::Queue should already be linked up.");
 
 		for (int i = cur->first; i < cur->end; ++i) {
 			if (cur->data[i] == threadID) {
@@ -148,7 +148,7 @@ struct ThreadQueueList {
 
 	inline void rotate(u32 priority) {
 		Queue *cur = &queues[priority];
-		_dbg_assert_msg_(SCEKERNEL, cur->next != nullptr, "ThreadQueueList::Queue should already be linked up.");
+		_dbg_assert_msg_(cur->next != nullptr, "ThreadQueueList::Queue should already be linked up.");
 
 		if (cur->size() > 1) {
 			// Grab the front and push it on the end.
@@ -222,7 +222,7 @@ private:
 
 	// Initialize a priority level and link to other queues.
 	void link(u32 priority, int size) {
-		_dbg_assert_msg_(SCEKERNEL, queues[priority].data == nullptr, "ThreadQueueList::Queue should only be initialized once.");
+		_dbg_assert_msg_(queues[priority].data == nullptr, "ThreadQueueList::Queue should only be initialized once.");
 
 		// Make sure we stay a multiple of INITIAL_CAPACITY.
 		if (size <= INITIAL_CAPACITY)

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -306,7 +306,7 @@ static void __CtrlVblank()
 static void __CtrlTimerUpdate(u64 userdata, int cyclesLate)
 {
 	// This only runs in timer mode (ctrlCycle > 0.)
-	_dbg_assert_msg_(SCECTRL, ctrlCycle > 0, "Ctrl: sampling cycle should be > 0");
+	_dbg_assert_msg_(ctrlCycle > 0, "Ctrl: sampling cycle should be > 0");
 
 	CoreTiming::ScheduleEvent(usToCycles(ctrlCycle) - cyclesLate, ctrlTimer, 0);
 

--- a/Core/HLE/sceKernel.h
+++ b/Core/HLE/sceKernel.h
@@ -418,13 +418,12 @@ public:
 	virtual int GetIDType() const = 0;
 	virtual void GetQuickInfo(char *ptr, int size);
 
-	// Implement this in all subclasses:
+	// Implement the following in all subclasses:
 	// static u32 GetMissingErrorCode()
 	// static int GetStaticIDType()
 
-	virtual void DoState(PointerWrap &p)
-	{
-		_dbg_assert_msg_(SCEKERNEL, false, "Unable to save state: bad kernel object.");
+	virtual void DoState(PointerWrap &p) {
+		_dbg_assert_msg_(false, "Unable to save state: bad kernel object.");
 	}
 };
 
@@ -482,7 +481,7 @@ public:
 	template <class T>
 	T *GetFast(SceUID handle) {
 		const SceUID realHandle = handle - handleOffset;
-		_dbg_assert_(SCEKERNEL, realHandle >= 0 && realHandle < maxCount && occupied[realHandle]);
+		_dbg_assert_(realHandle >= 0 && realHandle < maxCount && occupied[realHandle]);
 		return static_cast<T *>(pool[realHandle]);
 	}
 

--- a/Core/HLE/sceKernelMbx.cpp
+++ b/Core/HLE/sceKernelMbx.cpp
@@ -273,7 +273,7 @@ static void __KernelWaitMbx(Mbx *m, u32 timeoutPtr)
 
 static std::vector<MbxWaitingThread>::iterator __KernelMbxFindPriority(std::vector<MbxWaitingThread> &waiting)
 {
-	_dbg_assert_msg_(SCEKERNEL, !waiting.empty(), "__KernelMutexFindPriority: Trying to find best of no threads.");
+	_dbg_assert_msg_(!waiting.empty(), "__KernelMutexFindPriority: Trying to find best of no threads.");
 
 	std::vector<MbxWaitingThread>::iterator iter, end, best = waiting.end();
 	u32 best_prio = 0xFFFFFFFF;
@@ -287,7 +287,7 @@ static std::vector<MbxWaitingThread>::iterator __KernelMbxFindPriority(std::vect
 		}
 	}
 
-	_dbg_assert_msg_(SCEKERNEL, best != waiting.end(), "__KernelMutexFindPriority: Returning invalid best thread.");
+	_dbg_assert_msg_(best != waiting.end(), "__KernelMutexFindPriority: Returning invalid best thread.");
 	return best;
 }
 

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -302,11 +302,11 @@ struct SceKernelVplHeader {
 
 	inline void Validate() {
 		auto lastBlock = LastBlock();
-		_dbg_assert_msg_(SCEKERNEL, nextFreeBlock_->next.ptr != SentinelPtr(), "Next free block should not be allocated.");
-		_dbg_assert_msg_(SCEKERNEL, nextFreeBlock_->next.ptr != sentinel_, "Next free block should not point to sentinel.");
-		_dbg_assert_msg_(SCEKERNEL, lastBlock->sizeInBlocks == 0, "Last block should have size of 0.");
-		_dbg_assert_msg_(SCEKERNEL, lastBlock->next.ptr != SentinelPtr(), "Last block should not be allocated.");
-		_dbg_assert_msg_(SCEKERNEL, lastBlock->next.ptr != sentinel_, "Last block should not point to sentinel.");
+		_dbg_assert_msg_(nextFreeBlock_->next.ptr != SentinelPtr(), "Next free block should not be allocated.");
+		_dbg_assert_msg_(nextFreeBlock_->next.ptr != sentinel_, "Next free block should not point to sentinel.");
+		_dbg_assert_msg_(lastBlock->sizeInBlocks == 0, "Last block should have size of 0.");
+		_dbg_assert_msg_(lastBlock->next.ptr != SentinelPtr(), "Last block should not be allocated.");
+		_dbg_assert_msg_(lastBlock->next.ptr != sentinel_, "Last block should not point to sentinel.");
 
 		auto b = PSPPointer<SceKernelVplBlock>::Create(FirstBlockPtr());
 		bool sawFirstFree = false;
@@ -314,22 +314,22 @@ struct SceKernelVplHeader {
 			bool isFree = b->next.ptr != SentinelPtr();
 			if (isFree) {
 				if (!sawFirstFree) {
-					_dbg_assert_msg_(SCEKERNEL, lastBlock->next.ptr == b.ptr, "Last block should point to first free block.");
+					_dbg_assert_msg_(lastBlock->next.ptr == b.ptr, "Last block should point to first free block.");
 					sawFirstFree = true;
 				}
-				_dbg_assert_msg_(SCEKERNEL, b->next.ptr != SentinelPtr(), "Free blocks should only point to other free blocks.");
-				_dbg_assert_msg_(SCEKERNEL, b->next.ptr > b.ptr, "Free blocks should be in order.");
-				_dbg_assert_msg_(SCEKERNEL, b + b->sizeInBlocks < b->next || b->next.ptr == lastBlock.ptr, "Two free blocks should not be next to each other.");
+				_dbg_assert_msg_(b->next.ptr != SentinelPtr(), "Free blocks should only point to other free blocks.");
+				_dbg_assert_msg_(b->next.ptr > b.ptr, "Free blocks should be in order.");
+				_dbg_assert_msg_(b + b->sizeInBlocks < b->next || b->next.ptr == lastBlock.ptr, "Two free blocks should not be next to each other.");
 			} else {
-				_dbg_assert_msg_(SCEKERNEL, b->next.ptr == SentinelPtr(), "Allocated blocks should point to the sentinel.");
+				_dbg_assert_msg_(b->next.ptr == SentinelPtr(), "Allocated blocks should point to the sentinel.");
 			}
-			_dbg_assert_msg_(SCEKERNEL, b->sizeInBlocks != 0, "Only the last block should have a size of 0.");
+			_dbg_assert_msg_(b->sizeInBlocks != 0, "Only the last block should have a size of 0.");
 			b += b->sizeInBlocks;
 		}
 		if (!sawFirstFree) {
-			_dbg_assert_msg_(SCEKERNEL, lastBlock->next.ptr == lastBlock.ptr, "Last block should point to itself when full.");
+			_dbg_assert_msg_(lastBlock->next.ptr == lastBlock.ptr, "Last block should point to itself when full.");
 		}
-		_dbg_assert_msg_(SCEKERNEL, b.ptr == lastBlock.ptr, "Blocks should not extend outside vpl.");
+		_dbg_assert_msg_(b.ptr == lastBlock.ptr, "Blocks should not extend outside vpl.");
 	}
 
 	void ListBlocks() {

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -206,7 +206,7 @@ static void __KernelMutexAcquireLock(PSPMutex *mutex, int count, SceUID thread) 
 #if defined(_DEBUG)
 	auto locked = mutexHeldLocks.equal_range(thread);
 	for (MutexMap::iterator iter = locked.first; iter != locked.second; ++iter)
-		_dbg_assert_msg_(SCEKERNEL, (*iter).second != mutex->GetUID(), "Thread %d / mutex %d wasn't removed from mutexHeldLocks properly.", thread, mutex->GetUID());
+		_dbg_assert_msg_((*iter).second != mutex->GetUID(), "Thread %d / mutex %d wasn't removed from mutexHeldLocks properly.", thread, mutex->GetUID());
 #endif
 
 	mutexHeldLocks.insert(std::make_pair(thread, mutex->GetUID()));
@@ -238,7 +238,7 @@ static void __KernelMutexEraseLock(PSPMutex *mutex) {
 
 static std::vector<SceUID>::iterator __KernelMutexFindPriority(std::vector<SceUID> &waiting)
 {
-	_dbg_assert_msg_(SCEKERNEL, !waiting.empty(), "__KernelMutexFindPriority: Trying to find best of no threads.");
+	_dbg_assert_msg_(!waiting.empty(), "__KernelMutexFindPriority: Trying to find best of no threads.");
 
 	std::vector<SceUID>::iterator iter, end, best = waiting.end();
 	u32 best_prio = 0xFFFFFFFF;
@@ -252,7 +252,7 @@ static std::vector<SceUID>::iterator __KernelMutexFindPriority(std::vector<SceUI
 		}
 	}
 
-	_dbg_assert_msg_(SCEKERNEL, best != waiting.end(), "__KernelMutexFindPriority: Returning invalid best thread.");
+	_dbg_assert_msg_(best != waiting.end(), "__KernelMutexFindPriority: Returning invalid best thread.");
 	return best;
 }
 

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -397,7 +397,7 @@ public:
 	int GetIDType() const override { return SCE_KERNEL_TMID_Thread; }
 
 	bool AllocateStack(u32 &stackSize) {
-		_assert_msg_(SCEKERNEL, stackSize >= 0x200, "thread stack should be 256 bytes or larger");
+		_assert_msg_(stackSize >= 0x200, "thread stack should be 256 bytes or larger");
 
 		FreeStack();
 
@@ -1046,7 +1046,7 @@ static void __KernelFireThreadEnd(SceUID threadID)
 // TODO: Use __KernelChangeThreadState instead?  It has other affects...
 static void __KernelChangeReadyState(PSPThread *thread, SceUID threadID, bool ready) {
 	// Passing the id as a parameter is just an optimization, if it's wrong it will cause havoc.
-	_dbg_assert_msg_(SCEKERNEL, thread->GetUID() == threadID, "Incorrect threadID");
+	_dbg_assert_msg_(thread->GetUID() == threadID, "Incorrect threadID");
 	int prio = thread->nt.currentPriority;
 
 	if (thread->isReady())
@@ -1422,7 +1422,7 @@ u32 sceKernelGetThreadmanIdList(u32 type, u32 readBufPtr, u32 readBufSize, u32 i
 			break;
 
 		default:
-			_dbg_assert_msg_(SCEKERNEL, false, "Unexpected type %d", type);
+			_dbg_assert_msg_(false, "Unexpected type %d", type);
 		}
 
 		for (size_t i = 0; i < threadqueue.size(); i++) {
@@ -2132,7 +2132,7 @@ void __KernelReturnFromThread()
 
 	int exitStatus = currentMIPS->r[MIPS_REG_V0];
 	PSPThread *thread = __GetCurrentThread();
-	_dbg_assert_msg_(SCEKERNEL, thread != NULL, "Returned from a NULL thread.");
+	_dbg_assert_msg_(thread != NULL, "Returned from a NULL thread.");
 
 	DEBUG_LOG(SCEKERNEL, "__KernelReturnFromThread: %d", exitStatus);
 	__KernelStopThread(currentThread, exitStatus, "thread returned");
@@ -2147,7 +2147,7 @@ void __KernelReturnFromThread()
 
 void sceKernelExitThread(int exitStatus) {
 	PSPThread *thread = __GetCurrentThread();
-	_dbg_assert_msg_(SCEKERNEL, thread != NULL, "Exited from a NULL thread.");
+	_dbg_assert_msg_(thread != NULL, "Exited from a NULL thread.");
 
 	INFO_LOG(SCEKERNEL, "sceKernelExitThread(%d)", exitStatus);
 	__KernelStopThread(currentThread, exitStatus, "thread exited");
@@ -2162,7 +2162,7 @@ void sceKernelExitThread(int exitStatus) {
 
 void _sceKernelExitThread(int exitStatus) {
 	PSPThread *thread = __GetCurrentThread();
-	_dbg_assert_msg_(SCEKERNEL, thread != NULL, "_Exited from a NULL thread.");
+	_dbg_assert_msg_(thread != NULL, "_Exited from a NULL thread.");
 
 	ERROR_LOG_REPORT(SCEKERNEL, "_sceKernelExitThread(%d): should not be called directly", exitStatus);
 	__KernelStopThread(currentThread, exitStatus, "thread _exited");
@@ -3133,7 +3133,7 @@ void __KernelCallAddress(PSPThread *thread, u32 entryPoint, PSPAction *afterActi
 		WARN_LOG_REPORT(SCEKERNEL, "Running mipscall on dormant thread");
 	}
 
-	_dbg_assert_msg_(SCEKERNEL, numargs <= 6, "MipsCalls can only take 6 args.");
+	_dbg_assert_msg_(numargs <= 6, "MipsCalls can only take 6 args.");
 
 	if (thread) {
 		ActionAfterMipsCall *after = (ActionAfterMipsCall *) __KernelCreateAction(actionAfterMipsCall);
@@ -3338,7 +3338,7 @@ void __KernelReturnFromMipsCall()
 
 // First arg must be current thread, passed to avoid perf cost of a lookup.
 bool __KernelExecutePendingMipsCalls(PSPThread *thread, bool reschedAfter) {
-	_dbg_assert_msg_(SCEKERNEL, thread->GetUID() == __KernelGetCurThread(), "__KernelExecutePendingMipsCalls() should be called only with the current thread.");
+	_dbg_assert_msg_(thread->GetUID() == __KernelGetCurThread(), "__KernelExecutePendingMipsCalls() should be called only with the current thread.");
 
 	if (thread->pendingMipsCalls.empty()) {
 		// Nothing to do

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -189,7 +189,7 @@ void __UmdBeginCallback(SceUID threadID, SceUID prevCallbackId)
 		if (umdPausedWaits.find(pauseKey) != umdPausedWaits.end())
 			return;
 
-		_dbg_assert_msg_(SCEIO, umdStatTimeoutEvent != -1, "Must have a umd timer");
+		_dbg_assert_msg_(umdStatTimeoutEvent != -1, "Must have a umd timer");
 		s64 cyclesLeft = CoreTiming::UnscheduleEvent(umdStatTimeoutEvent, threadID);
 		if (cyclesLeft != 0)
 			umdPausedWaits[pauseKey] = CoreTiming::GetTicks() + cyclesLeft;
@@ -234,7 +234,7 @@ void __UmdEndCallback(SceUID threadID, SceUID prevCallbackId)
 		__KernelResumeThreadFromWait(threadID, SCE_KERNEL_ERROR_WAIT_TIMEOUT);
 	else
 	{
-		_dbg_assert_msg_(SCEIO, umdStatTimeoutEvent != -1, "Must have a umd timer");
+		_dbg_assert_msg_(umdStatTimeoutEvent != -1, "Must have a umd timer");
 		CoreTiming::ScheduleEvent(cyclesLeft, umdStatTimeoutEvent, __KernelGetCurThread());
 
 		umdWaitingThreads.push_back(threadID);

--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -86,7 +86,7 @@ void ArmJit::BranchRSRTComp(MIPSOpcode op, CCFlags cc, bool likely)
 		{
 		case CC_EQ: immBranchNotTaken = rsImm == rtImm; break;
 		case CC_NEQ: immBranchNotTaken = rsImm != rtImm; break;
-		default: immBranchNotTaken = false; _dbg_assert_msg_(JIT, false, "Bad cc flag in BranchRSRTComp().");
+		default: immBranchNotTaken = false; _dbg_assert_msg_(false, "Bad cc flag in BranchRSRTComp().");
 		}
 		immBranch = true;
 		immBranchTaken = !immBranchNotTaken;
@@ -199,7 +199,7 @@ void ArmJit::BranchRSZeroComp(MIPSOpcode op, CCFlags cc, bool andLink, bool like
 		case CC_GE: immBranchNotTaken = imm >= 0; break;
 		case CC_LT: immBranchNotTaken = imm < 0; break;
 		case CC_LE: immBranchNotTaken = imm <= 0; break;
-		default: immBranchNotTaken = false; _dbg_assert_msg_(JIT, false, "Bad cc flag in BranchRSZeroComp().");
+		default: immBranchNotTaken = false; _dbg_assert_msg_(false, "Bad cc flag in BranchRSZeroComp().");
 		}
 		immBranch = true;
 		immBranchTaken = !immBranchNotTaken;
@@ -298,7 +298,7 @@ void ArmJit::Comp_RelBranch(MIPSOpcode op)
 	case 23: BranchRSZeroComp(op, CC_LE, false, true); break;//bgtzl
 
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 }
@@ -316,7 +316,7 @@ void ArmJit::Comp_RelBranchRI(MIPSOpcode op)
 	case 18: BranchRSZeroComp(op, CC_GE, true, true);  break;  //R(MIPS_REG_RA) = PC + 8; if ((s32)R(rs) <  0) DelayBranchTo(addr); else SkipLikely(); break;//bltzall
 	case 19: BranchRSZeroComp(op, CC_LT, true, true);   break; //R(MIPS_REG_RA) = PC + 8; if ((s32)R(rs) >= 0) DelayBranchTo(addr); else SkipLikely(); break;//bgezall
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 }
@@ -374,7 +374,7 @@ void ArmJit::Comp_FPUBranch(MIPSOpcode op)
 	case 2: BranchFPFlag(op, CC_NEQ, true);  break;  // bc1fl
 	case 3: BranchFPFlag(op, CC_EQ,  true);  break;  // bc1tl
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+		_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 		break;
 	}
 }
@@ -511,7 +511,7 @@ void ArmJit::Comp_Jump(MIPSOpcode op) {
 		break;
 
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 	js.compiling = false;
@@ -587,7 +587,7 @@ void ArmJit::Comp_JumpReg(MIPSOpcode op)
 	case 9: //jalr
 		break;
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 

--- a/Core/MIPS/ARM/ArmCompLoadStore.cpp
+++ b/Core/MIPS/ARM/ArmCompLoadStore.cpp
@@ -182,7 +182,7 @@ namespace MIPSComp
 		// This gets hit in a few games, as a result of never-taken delay slots (some branch types
 		// conditionally execute the delay slot instructions). Ignore in those cases.
 		if (!js.inDelaySlot) {
-			_dbg_assert_msg_(JIT, !gpr.IsImm(rs), "Invalid immediate address %08x?  CPU bug?", iaddr);
+			_dbg_assert_msg_(!gpr.IsImm(rs), "Invalid immediate address %08x?  CPU bug?", iaddr);
 		}
 
 		if (load) {
@@ -339,7 +339,7 @@ namespace MIPSComp
 					addrReg = R0;
 				}
 			} else {
-				_dbg_assert_msg_(JIT, !gpr.IsImm(rs), "Invalid immediate address?  CPU bug?");
+				_dbg_assert_msg_(!gpr.IsImm(rs), "Invalid immediate address?  CPU bug?");
 				load ? gpr.MapDirtyIn(rt, rs) : gpr.MapInIn(rt, rs);
 
 				if (!g_Config.bFastMemory && rs != MIPS_REG_SP) {

--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -543,7 +543,7 @@ namespace MIPSComp
 			VMOV(fpr.V(dregs[3]), (vd&3)==3 ? S1 : S0);
 			break;
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 		
@@ -1320,7 +1320,7 @@ namespace MIPSComp
 				}
 			} else {
 				//ERROR
-				_dbg_assert_msg_(CPU,0,"mtv - invalid register");
+				_dbg_assert_msg_(false,"mtv - invalid register");
 			}
 			break;
 

--- a/Core/MIPS/ARM/ArmCompVFPUNEON.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPUNEON.cpp
@@ -730,7 +730,7 @@ void ArmJit::CompNEON_Mftv(MIPSOpcode op) {
 			}
 		} else {
 			//ERROR
-			_dbg_assert_msg_(CPU,0,"mtv - invalid register");
+			_dbg_assert_msg_(false,"mtv - invalid register");
 		}
 		break;
 
@@ -808,7 +808,7 @@ void ArmJit::CompNEON_VMatrixInit(MIPSOpcode op) {
 			// NEONTranspose4x4(cols);
 			break;
 		default:
-			_assert_msg_(JIT, 0, "Bad matrix size");
+			_assert_msg_(false, "Bad matrix size");
 			break;
 		}
 		break;
@@ -1159,7 +1159,7 @@ void ArmJit::CompNEON_VIdt(MIPSOpcode op) {
 		}
 		break;
 	default:
-		_dbg_assert_msg_(CPU,0,"Bad vidt instruction");
+		_dbg_assert_msg_(false,"Bad vidt instruction");
 		break;
 	}
 

--- a/Core/MIPS/ARM/ArmRegCacheFPU.cpp
+++ b/Core/MIPS/ARM/ArmRegCacheFPU.cpp
@@ -561,7 +561,7 @@ int ArmRegCacheFPU::GetTempR() {
 	}
 
 	ERROR_LOG(CPU, "Out of temp regs! Might need to DiscardR() some");
-	_assert_msg_(JIT, 0, "Regcache ran out of temp regs, might need to DiscardR() some.");
+	_assert_msg_(false, "Regcache ran out of temp regs, might need to DiscardR() some.");
 	return -1;
 }
 

--- a/Core/MIPS/ARM64/Arm64CompBranch.cpp
+++ b/Core/MIPS/ARM64/Arm64CompBranch.cpp
@@ -86,7 +86,7 @@ void Arm64Jit::BranchRSRTComp(MIPSOpcode op, CCFlags cc, bool likely)
 		{
 		case CC_EQ: immBranchNotTaken = rsImm == rtImm; break;
 		case CC_NEQ: immBranchNotTaken = rsImm != rtImm; break;
-		default: immBranchNotTaken = false; _dbg_assert_msg_(JIT, false, "Bad cc flag in BranchRSRTComp().");
+		default: immBranchNotTaken = false; _dbg_assert_msg_(false, "Bad cc flag in BranchRSRTComp().");
 		}
 		immBranch = true;
 		immBranchTaken = !immBranchNotTaken;
@@ -217,7 +217,7 @@ void Arm64Jit::BranchRSZeroComp(MIPSOpcode op, CCFlags cc, bool andLink, bool li
 		case CC_GE: immBranchNotTaken = imm >= 0; break;
 		case CC_LT: immBranchNotTaken = imm < 0; break;
 		case CC_LE: immBranchNotTaken = imm <= 0; break;
-		default: immBranchNotTaken = false; _dbg_assert_msg_(JIT, false, "Bad cc flag in BranchRSZeroComp().");
+		default: immBranchNotTaken = false; _dbg_assert_msg_(false, "Bad cc flag in BranchRSZeroComp().");
 		}
 		immBranch = true;
 		immBranchTaken = !immBranchNotTaken;
@@ -316,7 +316,7 @@ void Arm64Jit::Comp_RelBranch(MIPSOpcode op)
 	case 23: BranchRSZeroComp(op, CC_LE, false, true); break;//bgtzl
 
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 }
@@ -334,7 +334,7 @@ void Arm64Jit::Comp_RelBranchRI(MIPSOpcode op)
 	case 18: BranchRSZeroComp(op, CC_GE, true, true);  break;  //R(MIPS_REG_RA) = PC + 8; if ((s32)R(rs) <  0) DelayBranchTo(addr); else SkipLikely(); break;//bltzall
 	case 19: BranchRSZeroComp(op, CC_LT, true, true);   break; //R(MIPS_REG_RA) = PC + 8; if ((s32)R(rs) >= 0) DelayBranchTo(addr); else SkipLikely(); break;//bgezall
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 }
@@ -391,7 +391,7 @@ void Arm64Jit::Comp_FPUBranch(MIPSOpcode op) {
 	case 2: BranchFPFlag(op, CC_NEQ, true);  break;  // bc1fl
 	case 3: BranchFPFlag(op, CC_EQ, true);  break;  // bc1tl
 	default:
-		_dbg_assert_msg_(CPU, 0, "Trying to interpret instruction that can't be interpreted");
+		_dbg_assert_msg_( 0, "Trying to interpret instruction that can't be interpreted");
 		break;
 	}
 }
@@ -526,7 +526,7 @@ void Arm64Jit::Comp_Jump(MIPSOpcode op) {
 		break;
 
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 	js.compiling = false;
@@ -604,7 +604,7 @@ void Arm64Jit::Comp_JumpReg(MIPSOpcode op)
 	case 9: //jalr
 		break;
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 

--- a/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
+++ b/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
@@ -180,7 +180,7 @@ namespace MIPSComp {
 			return;
 		}
 
-		_dbg_assert_msg_(JIT, !gpr.IsImm(rs), "Invalid immediate address %08x?  CPU bug?", iaddr);
+		_dbg_assert_msg_(!gpr.IsImm(rs), "Invalid immediate address %08x?  CPU bug?", iaddr);
 		if (load) {
 			gpr.MapDirtyIn(rt, rs, false);
 		} else {
@@ -380,7 +380,7 @@ namespace MIPSComp {
 				// This gets hit in a few games, as a result of never-taken delay slots (some branch types
 				// conditionally execute the delay slot instructions). Ignore in those cases.
 				if (!js.inDelaySlot) {
-					_dbg_assert_msg_(JIT, !gpr.IsImm(rs), "Invalid immediate address %08x?  CPU bug?", iaddr);
+					_dbg_assert_msg_(!gpr.IsImm(rs), "Invalid immediate address %08x?  CPU bug?", iaddr);
 				}
 
 				// If we already have a targetReg, we optimized an imm, and rs is already mapped.

--- a/Core/MIPS/ARM64/Arm64CompVFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompVFPU.cpp
@@ -171,7 +171,7 @@ namespace MIPSComp {
 	}
 
 	void Arm64Jit::ApplyPrefixD(const u8 *vregs, VectorSize sz) {
-		_assert_msg_(JIT, js.prefixDFlag & JitState::PREFIX_KNOWN, "Unexpected unknown prefix!");
+		_assert_msg_(js.prefixDFlag & JitState::PREFIX_KNOWN, "Unexpected unknown prefix!");
 		if (!js.prefixD)
 			return;
 
@@ -435,7 +435,7 @@ namespace MIPSComp {
 			fp.FMOV(fpr.V(dregs[3]), (vd & 3) == 3 ? S1 : S0);
 			break;
 		default:
-			_dbg_assert_msg_(CPU, 0, "Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_( 0, "Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 
@@ -1069,7 +1069,7 @@ namespace MIPSComp {
 				}
 			} else {
 				//ERROR
-				_dbg_assert_msg_(CPU, 0, "mtv - invalid register");
+				_dbg_assert_msg_( 0, "mtv - invalid register");
 			}
 			break;
 

--- a/Core/MIPS/ARM64/Arm64RegCache.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCache.cpp
@@ -215,7 +215,7 @@ void Arm64RegCache::MapRegTo(ARM64Reg reg, MIPSGPReg mipsReg, int mapFlags) {
 					mr[mipsReg].loc = ML_ARMREG_IMM;
 				break;
 			default:
-				_assert_msg_(JIT, mr[mipsReg].loc != ML_ARMREG_AS_PTR, "MapRegTo with a pointer?");
+				_assert_msg_(mr[mipsReg].loc != ML_ARMREG_AS_PTR, "MapRegTo with a pointer?");
 				mr[mipsReg].loc = ML_ARMREG;
 				break;
 			}

--- a/Core/MIPS/ARM64/Arm64RegCacheFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCacheFPU.cpp
@@ -479,7 +479,7 @@ int Arm64RegCacheFPU::GetTempR() {
 	}
 
 	ERROR_LOG(CPU, "Out of temp regs! Might need to DiscardR() some");
-	_assert_msg_(JIT, 0, "Regcache ran out of temp regs, might need to DiscardR() some.");
+	_assert_msg_(false, "Regcache ran out of temp regs, might need to DiscardR() some.");
 	return -1;
 }
 

--- a/Core/MIPS/IR/IRCompBranch.cpp
+++ b/Core/MIPS/IR/IRCompBranch.cpp
@@ -165,7 +165,7 @@ void IRFrontend::Comp_RelBranch(MIPSOpcode op) {
 	case 23: BranchRSZeroComp(op, IRComparison::LessEqual, false, true); break;//bgtzl
 
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 }
@@ -181,7 +181,7 @@ void IRFrontend::Comp_RelBranchRI(MIPSOpcode op) {
 	case 18: BranchRSZeroComp(op, IRComparison::GreaterEqual, true, true);  break;  //R(MIPS_REG_RA) = PC + 8; if ((s32)R(rs) <  0) DelayBranchTo(addr); else SkipLikely(); break;//bltzall
 	case 19: BranchRSZeroComp(op, IRComparison::Less, true, true);   break; //R(MIPS_REG_RA) = PC + 8; if ((s32)R(rs) >= 0) DelayBranchTo(addr); else SkipLikely(); break;//bgezall
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 }
@@ -224,7 +224,7 @@ void IRFrontend::Comp_FPUBranch(MIPSOpcode op) {
 	case 2: BranchFPFlag(op, IRComparison::NotEqual, true);  break;  // bc1fl
 	case 3: BranchFPFlag(op, IRComparison::Equal, true);  break;  // bc1tl
 	default:
-		_dbg_assert_msg_(CPU, 0, "Trying to interpret instruction that can't be interpreted");
+		_dbg_assert_msg_( 0, "Trying to interpret instruction that can't be interpreted");
 		break;
 	}
 }
@@ -315,7 +315,7 @@ void IRFrontend::Comp_Jump(MIPSOpcode op) {
 		break;
 
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 
@@ -379,7 +379,7 @@ void IRFrontend::Comp_JumpReg(MIPSOpcode op) {
 	case 9: //jalr
 		break;
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -104,7 +104,7 @@ void IRJit::Compile(u32 em_address) {
 bool IRJit::CompileBlock(u32 em_address, std::vector<IRInst> &instructions, u32 &mipsBytes, bool preload) {
 	frontend_.DoJit(em_address, instructions, mipsBytes, preload);
 	if (instructions.empty()) {
-		_dbg_assert_(JIT, preload);
+		_dbg_assert_(preload);
 		// We return true when preloading so it doesn't abort.
 		return preload;
 	}

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -420,7 +420,7 @@ void JitBlockCache::LinkBlock(int i) {
 	if (ppp.first == ppp.second)
 		return;
 	for (auto iter = ppp.first; iter != ppp.second; ++iter) {
-		// PanicAlert("Linking block %i to block %i", iter->second, i);
+		// INFO_LOG(JIT, "Linking block %i to block %i", iter->second, i);
 		LinkBlockExits(iter->second);
 	}
 }

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -180,7 +180,7 @@ namespace MIPSInt
 		case 23: if ((s32)R(rs) >  0) DelayBranchTo(addr); else SkipLikely(); break; //bgtzl
 
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 	}
@@ -202,7 +202,7 @@ namespace MIPSInt
 		case 18: R(MIPS_REG_RA) = PC + 8; if ((s32)R(rs) <	0) DelayBranchTo(addr); else SkipLikely(); break;//bltzall
 		case 19: R(MIPS_REG_RA) = PC + 8; if ((s32)R(rs) >= 0) DelayBranchTo(addr); else SkipLikely(); break;//bgezall
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 	}
@@ -237,7 +237,7 @@ namespace MIPSInt
 		case 2: if (!currentMIPS->fpcond) DelayBranchTo(addr); else SkipLikely(); break;//bc1fl
 		case 3: if ( currentMIPS->fpcond) DelayBranchTo(addr); else SkipLikely(); break;//bc1tl
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 	}
@@ -245,7 +245,7 @@ namespace MIPSInt
 	void Int_JumpType(MIPSOpcode op)
 	{
 		if (mipsr4k.inDelaySlot)
-			_dbg_assert_msg_(CPU,0,"Jump in delay slot :(");
+			_dbg_assert_msg_(false,"Jump in delay slot :(");
 
 		u32 off = ((op & 0x03FFFFFF) << 2);
 		u32 addr = (currentMIPS->pc & 0xF0000000) | off;
@@ -258,7 +258,7 @@ namespace MIPSInt
 			DelayBranchTo(addr);
 			break;
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 	}
@@ -271,7 +271,7 @@ namespace MIPSInt
 			if (op == 0x03e00008)
 				return;
 			ERROR_LOG(CPU, "Jump in delay slot :(");
-			_dbg_assert_msg_(CPU,0,"Jump in delay slot :(");
+			_dbg_assert_msg_(false,"Jump in delay slot :(");
 		}
 
 		int rs = _RS;
@@ -316,7 +316,7 @@ namespace MIPSInt
 		case 14: R(rt) = R(rs) ^ uimm; break; //xori
 		case 15: R(rt) = uimm << 16;	 break; //lui
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 		PC += 4;
@@ -348,7 +348,7 @@ namespace MIPSInt
 			}
 			break;
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 		PC += 4;
@@ -386,7 +386,7 @@ namespace MIPSInt
 		case 44: R(rd) = ((s32)R(rs) > (s32)R(rt)) ? R(rs) : R(rt); break; //max
 		case 45: R(rd) = ((s32)R(rs) < (s32)R(rt)) ? R(rs) : R(rt); break;//min
 		default:
-			_dbg_assert_msg_(CPU, 0, "Unknown MIPS instruction %08x", op.encoding);
+			_dbg_assert_msg_( 0, "Unknown MIPS instruction %08x", op.encoding);
 			break;
 		}
 		PC += 4;
@@ -457,7 +457,7 @@ namespace MIPSInt
 			break;
 
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret Mem instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret Mem instruction that can't be interpreted");
 			break;
 		}
 		PC += 4;
@@ -475,7 +475,7 @@ namespace MIPSInt
 		case 49: FI(ft) = Memory::Read_U32(addr); break; //lwc1
 		case 57: Memory::Write_U32(FI(ft), addr); break; //swc1
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret FPULS instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret FPULS instruction that can't be interpreted");
 			break;
 		}
 		PC += 4;
@@ -528,7 +528,7 @@ namespace MIPSInt
 			}
 		
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 		PC += 4;
@@ -555,7 +555,7 @@ namespace MIPSInt
 			R(rd) = clz32(~R(rs));
 			break;
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 		PC += 4;
@@ -659,7 +659,7 @@ namespace MIPSInt
 			break;
 
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 		PC += 4;
@@ -714,7 +714,7 @@ namespace MIPSInt
 		case 7: R(rd) = (u32)(((s32)R(rt)) >> (R(rs)&0x1F)); break; //srav
 		default:
 			wrong:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 		PC += 4;
@@ -757,7 +757,7 @@ namespace MIPSInt
 			break;
 
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret ALLEGREX instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret ALLEGREX instruction that can't be interpreted");
 			break;
 		}
 		PC += 4;
@@ -784,7 +784,7 @@ namespace MIPSInt
 			R(rd) = swap32(R(rt));
 			break;
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret ALLEGREX instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret ALLEGREX instruction that can't be interpreted");
 			break;
 		}
 		PC += 4;
@@ -902,7 +902,7 @@ namespace MIPSInt
 			}
 			break; //cvt.w.s
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret FPU2Op instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret FPU2Op instruction that can't be interpreted");
 			break;
 		}
 		PC += 4;
@@ -956,7 +956,7 @@ namespace MIPSInt
 			break;
 
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret FPUComp instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret FPUComp instruction that can't be interpreted");
 			cond = false;
 			break;
 		}
@@ -984,7 +984,7 @@ namespace MIPSInt
 			break;
 		case 3: F(fd) = F(fs) / F(ft); break; // div.s
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret FPU3Op instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret FPU3Op instruction that can't be interpreted");
 			break;
 		}
 		PC += 4;
@@ -1009,7 +1009,7 @@ namespace MIPSInt
 	void Int_Emuhack(MIPSOpcode op)
 	{
 		if (((op >> 24) & 3) != EMUOP_CALL_REPLACEMENT) {
-			_dbg_assert_msg_(CPU,0,"Trying to interpret emuhack instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret emuhack instruction that can't be interpreted");
 		}
 		// It's a replacement func!
 		int index = op.encoding & 0xFFFFFF;

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -213,7 +213,7 @@ namespace MIPSInt
 			{
 				if (addr & 0x3)
 				{
-					_dbg_assert_msg_(CPU, 0, "Misaligned lvX.q at %08x (pc = %08x)", addr, PC);
+					_dbg_assert_msg_( 0, "Misaligned lvX.q at %08x (pc = %08x)", addr, PC);
 				}
 				float d[4];
 				ReadVector(d, V_Quad, vt);
@@ -241,7 +241,7 @@ namespace MIPSInt
 		case 54: //lv.q
 			if (addr & 0xF)
 			{
-				_dbg_assert_msg_(CPU, 0, "Misaligned lv.q at %08x (pc = %08x)", addr, PC);
+				_dbg_assert_msg_( 0, "Misaligned lv.q at %08x (pc = %08x)", addr, PC);
 			}
 #ifndef COMMON_BIG_ENDIAN
 			WriteVector((const float*)Memory::GetPointer(addr), V_Quad, vt);
@@ -261,7 +261,7 @@ namespace MIPSInt
 			{
 				if (addr & 0x3)
 				{
-					_dbg_assert_msg_(CPU, 0, "Misaligned svX.q at %08x (pc = %08x)", addr, PC);
+					_dbg_assert_msg_( 0, "Misaligned svX.q at %08x (pc = %08x)", addr, PC);
 				}
 				float d[4];
 				ReadVector(d, V_Quad, vt);
@@ -288,7 +288,7 @@ namespace MIPSInt
 		case 62: //sv.q
 			if (addr & 0xF)
 			{
-				_dbg_assert_msg_(CPU, 0, "Misaligned sv.q at %08x (pc = %08x)", addr, PC);
+				_dbg_assert_msg_( 0, "Misaligned sv.q at %08x (pc = %08x)", addr, PC);
 			}
 #ifndef COMMON_BIG_ENDIAN
 			ReadVector(reinterpret_cast<float *>(Memory::GetPointer(addr)), V_Quad, vt);
@@ -304,7 +304,7 @@ namespace MIPSInt
 			break;
 
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret VQ instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret VQ instruction that can't be interpreted");
 			break;
 		}
 		PC += 4;
@@ -338,7 +338,7 @@ namespace MIPSInt
 		case 6: m=zero; break;             // vmzero
 		case 7: m=one; break;              // vmone
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			PC += 4;
 			EatPrefixes();
 			return;
@@ -369,7 +369,7 @@ namespace MIPSInt
 				sprefixAdd = VFPU_MAKE_CONSTANTS(VFPUConst::ONE, VFPUConst::ONE, VFPUConst::ONE, VFPUConst::ONE);
 				break;
 			default:
-				_dbg_assert_msg_(CPU, 0, "Unknown matrix init op");
+				_dbg_assert_msg_( 0, "Unknown matrix init op");
 				break;
 			}
 			ApplyPrefixST(&prefixed[off * 4], VFPURewritePrefix(VFPU_CTRL_SPREFIX, sprefixRemove, sprefixAdd), V_Quad);
@@ -393,7 +393,7 @@ namespace MIPSInt
 		case 6: constant = VFPUConst::ZERO; break;  //vzero
 		case 7: constant = VFPUConst::ONE; break;   //vone
 		default:
-			_dbg_assert_msg_(CPU, 0, "Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_( 0, "Trying to interpret instruction that can't be interpreted");
 			PC += 4;
 			EatPrefixes();
 			return;
@@ -422,7 +422,7 @@ namespace MIPSInt
 		} else if (type == 7) {
 			f[0] = Float16ToFloat32((u16)uimm16);   // vfim
 		} else {
-			_dbg_assert_msg_(CPU, 0, "Invalid Viim opcode type %d", type);
+			_dbg_assert_msg_( 0, "Invalid Viim opcode type %d", type);
 			f[0] = 0;
 		}
 		
@@ -634,7 +634,7 @@ namespace MIPSInt
 			case 26: { d[i] = -vfpu_sin(s[i]); } break; // vnsin
 			case 28: d[i] = 1.0f / powf(2.0, s[i]); break; // vrexp2
 			default:
-				_dbg_assert_msg_(CPU, false, "Invalid VV2Op op type %d", optype);
+				_dbg_assert_msg_( false, "Invalid VV2Op op type %d", optype);
 				break;
 			}
 		}
@@ -993,7 +993,7 @@ namespace MIPSInt
 			break;
 
 		default:
-			_dbg_assert_msg_(CPU, false, "Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_( false, "Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 
@@ -1051,7 +1051,7 @@ namespace MIPSInt
 			case V_Pair: oz = V_Single; break;
 			case V_Single: oz = V_Single; break;
 			default:
-				_dbg_assert_msg_(CPU, false, "Trying to interpret instruction that can't be interpreted");
+				_dbg_assert_msg_( false, "Trying to interpret instruction that can't be interpreted");
 				oz = V_Single;
 				break;
 			}
@@ -1070,13 +1070,13 @@ namespace MIPSInt
 			case V_Pair: oz = V_Single; break;
 			case V_Single: oz = V_Single; break;
 			default:
-				_dbg_assert_msg_(CPU, 0, "Trying to interpret instruction that can't be interpreted");
+				_dbg_assert_msg_( 0, "Trying to interpret instruction that can't be interpreted");
 				oz = V_Single;
 				break;
 			}
 			break;
 		default:
-			_dbg_assert_msg_(CPU, 0, "Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_( 0, "Trying to interpret instruction that can't be interpreted");
 			oz = V_Single;
 			break;
 		}
@@ -1550,7 +1550,7 @@ namespace MIPSInt
 			case 1: d.u[i] = currentMIPS->rng.R32(); break;  // vrndi
 			case 2: d.f[i] = 1.0f + ((float)currentMIPS->rng.R32() / 0xFFFFFFFF); break; // vrndf1   TODO: make more accurate
 			case 3: d.f[i] = 2.0f + 2 * ((float)currentMIPS->rng.R32() / 0xFFFFFFFF); break; // vrndf2   TODO: make more accurate
-			default: _dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+			default: _dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			}
 		}
 		// D prefix is broken and applies to the last element only (mask and sat.)
@@ -1724,7 +1724,7 @@ namespace MIPSInt
 			Memory::Write_U32(VI(vt), addr);
 			break;
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 		PC += 4;
@@ -1746,7 +1746,7 @@ namespace MIPSInt
 					R(rt) = currentMIPS->vfpuCtrl[imm - 128];
 				} else {
 					//ERROR - maybe need to make this value too an "interlock" value?
-					_dbg_assert_msg_(CPU,0,"mfv - invalid register");
+					_dbg_assert_msg_(false,"mfv - invalid register");
 				}
 			}
 			break;
@@ -1761,12 +1761,12 @@ namespace MIPSInt
 				}
 			} else {
 				//ERROR
-				_dbg_assert_msg_(CPU,0,"mtv - invalid register");
+				_dbg_assert_msg_(false,"mtv - invalid register");
 			}
 			break;
 
 		default:
-			_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 		PC += 4;
@@ -1853,7 +1853,7 @@ namespace MIPSInt
 			case VC_NS: c = !(my_isnanorinf(s[i])); break;   // How about t[i] ?
 
 			default:
-				_dbg_assert_msg_(CPU,0,"Unsupported vcmp condition code %d", cond);
+				_dbg_assert_msg_(false,"Unsupported vcmp condition code %d", cond);
 				PC += 4;
 				EatPrefixes();
 				return;
@@ -1920,7 +1920,7 @@ namespace MIPSInt
 			}
 			break;
 		default:
-			_dbg_assert_msg_(CPU,0,"unknown min/max op %d", cond);
+			_dbg_assert_msg_(false,"unknown min/max op %d", cond);
 			PC += 4;
 			EatPrefixes();
 			return;
@@ -2075,7 +2075,7 @@ namespace MIPSInt
 			break;
 		default:
 		bad:
-			_dbg_assert_msg_(CPU, 0, "Trying to interpret instruction that can't be interpreted");
+			_dbg_assert_msg_( 0, "Trying to interpret instruction that can't be interpreted");
 			break;
 		}
 

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -948,7 +948,7 @@ void MIPSInterpret(MIPSOpcode op) {
 		// Try to disassemble it
 		char disasm[256];
 		MIPSDisAsm(op, currentMIPS->pc, disasm);
-		_dbg_assert_msg_(CPU, 0, "%s", disasm);
+		_dbg_assert_msg_( 0, "%s", disasm);
 		currentMIPS->pc += 4;
 	}
 }

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -41,7 +41,7 @@ void GetVectorRegs(u8 regs[4], VectorSize N, int vectorReg) {
 	case V_Pair:   row=(vectorReg>>5)&2; length = 2; break;
 	case V_Triple: row=(vectorReg>>6)&1; length = 3; break;
 	case V_Quad:   row=(vectorReg>>5)&2; length = 4; break;
-	default: _assert_msg_(JIT, 0, "%s: Bad vector size", __FUNCTION__);
+	default: _assert_msg_(false, "%s: Bad vector size", __FUNCTION__);
 	}
 
 	for (int i = 0; i < length; i++) {
@@ -67,7 +67,7 @@ void GetMatrixRegs(u8 regs[16], MatrixSize N, int matrixReg) {
 	case M_2x2: row = (matrixReg >> 5) & 2; side = 2; break;
 	case M_3x3: row = (matrixReg >> 6) & 1; side = 3; break;
 	case M_4x4: row = (matrixReg >> 5) & 2; side = 4; break;
-	default: _assert_msg_(JIT, 0, "%s: Bad matrix size", __FUNCTION__);
+	default: _assert_msg_(false, "%s: Bad matrix size", __FUNCTION__);
 	}
 
 	for (int i = 0; i < side; i++) {
@@ -112,7 +112,7 @@ int GetMatrixName(int matrix, MatrixSize msize, int column, int row, bool transp
 		name |= (row << 5) | column;
 		break;
 
-	default: _assert_msg_(JIT, 0, "%s: Bad matrix size", __FUNCTION__);
+	default: _assert_msg_(false, "%s: Bad matrix size", __FUNCTION__);
 	}
 
 	return name;
@@ -161,7 +161,7 @@ void ReadVector(float *rd, VectorSize size, int reg) {
 	case V_Pair:   row=(reg>>5)&2; length = 2; break;
 	case V_Triple: row=(reg>>6)&1; length = 3; break;
 	case V_Quad:   row=(reg>>5)&2; length = 4; break;
-	default: _assert_msg_(JIT, 0, "%s: Bad vector size", __FUNCTION__);
+	default: _assert_msg_(false, "%s: Bad vector size", __FUNCTION__);
 	}
 	int transpose = (reg>>5) & 1;
 	const int mtx = (reg >> 2) & 7;
@@ -194,11 +194,11 @@ void WriteVector(const float *rd, VectorSize size, int reg) {
 	int length = 0;
 
 	switch (size) {
-	case V_Single: _dbg_assert_(JIT, 0); return; // transpose = 0; row=(reg>>5)&3; length = 1; break;
+	case V_Single: _dbg_assert_(false); return; // transpose = 0; row=(reg>>5)&3; length = 1; break;
 	case V_Pair:   row=(reg>>5)&2; length = 2; break;
 	case V_Triple: row=(reg>>6)&1; length = 3; break;
 	case V_Quad:   row=(reg>>5)&2; length = 4; break;
-	default: _assert_msg_(JIT, 0, "%s: Bad vector size", __FUNCTION__);
+	default: _assert_msg_(false, "%s: Bad vector size", __FUNCTION__);
 	}
 
 	if (currentMIPS->VfpuWriteMask() == 0) {
@@ -243,7 +243,7 @@ void ReadMatrix(float *rd, MatrixSize size, int reg) {
 	case M_2x2: row = (reg >> 5) & 2; side = 2; break;
 	case M_3x3: row = (reg >> 6) & 1; side = 3; break;
 	case M_4x4: row = (reg >> 5) & 2; side = 4; break;
-	default: _assert_msg_(JIT, 0, "%s: Bad matrix size", __FUNCTION__);
+	default: _assert_msg_(false, "%s: Bad matrix size", __FUNCTION__);
 	}
 
 	// The voffset ordering is now integrated in these formulas,
@@ -293,7 +293,7 @@ void WriteMatrix(const float *rd, MatrixSize size, int reg) {
 	case M_2x2: row = (reg >> 5) & 2; side = 2; break;
 	case M_3x3: row = (reg >> 6) & 1; side = 3; break;
 	case M_4x4: row = (reg >> 5) & 2; side = 4; break;
-	default: _assert_msg_(JIT, 0, "%s: Bad matrix size", __FUNCTION__);
+	default: _assert_msg_(false, "%s: Bad matrix size", __FUNCTION__);
 	}
 
 	if (currentMIPS->VfpuWriteMask() != 0) {
@@ -374,7 +374,7 @@ VectorSize GetHalfVectorSizeSafe(VectorSize sz) {
 
 VectorSize GetHalfVectorSize(VectorSize sz) {
 	VectorSize res = GetHalfVectorSizeSafe(sz);
-	_assert_msg_(JIT, res != V_Invalid, "%s: Bad vector size", __FUNCTION__);
+	_assert_msg_(res != V_Invalid, "%s: Bad vector size", __FUNCTION__);
 	return res;
 }
 
@@ -388,7 +388,7 @@ VectorSize GetDoubleVectorSizeSafe(VectorSize sz) {
 
 VectorSize GetDoubleVectorSize(VectorSize sz) {
 	VectorSize res = GetDoubleVectorSizeSafe(sz);
-	_assert_msg_(JIT, res != V_Invalid, "%s: Bad vector size", __FUNCTION__);
+	_assert_msg_(res != V_Invalid, "%s: Bad vector size", __FUNCTION__);
 	return res;
 }
 
@@ -407,7 +407,7 @@ VectorSize GetVecSizeSafe(MIPSOpcode op) {
 
 VectorSize GetVecSize(MIPSOpcode op) {
 	VectorSize res = GetVecSizeSafe(op);
-	_assert_msg_(JIT, res != V_Invalid, "%s: Bad vector size", __FUNCTION__);
+	_assert_msg_(res != V_Invalid, "%s: Bad vector size", __FUNCTION__);
 	return res;
 }
 
@@ -423,7 +423,7 @@ VectorSize GetVectorSizeSafe(MatrixSize sz) {
 
 VectorSize GetVectorSize(MatrixSize sz) {
 	VectorSize res = GetVectorSizeSafe(sz);
-	_assert_msg_(JIT, res != V_Invalid, "%s: Bad vector size", __FUNCTION__);
+	_assert_msg_(res != V_Invalid, "%s: Bad vector size", __FUNCTION__);
 	return res;
 }
 
@@ -439,7 +439,7 @@ MatrixSize GetMatrixSizeSafe(VectorSize sz) {
 
 MatrixSize GetMatrixSize(VectorSize sz) {
 	MatrixSize res = GetMatrixSizeSafe(sz);
-	_assert_msg_(JIT, res != M_Invalid, "%s: Bad vector size", __FUNCTION__);
+	_assert_msg_(res != M_Invalid, "%s: Bad vector size", __FUNCTION__);
 	return res;
 }
 
@@ -458,7 +458,7 @@ MatrixSize GetMtxSizeSafe(MIPSOpcode op) {
 
 MatrixSize GetMtxSize(MIPSOpcode op) {
 	MatrixSize res = GetMtxSizeSafe(op);
-	_assert_msg_(JIT, res != M_Invalid, "%s: Bad matrix size", __FUNCTION__);
+	_assert_msg_(res != M_Invalid, "%s: Bad matrix size", __FUNCTION__);
 	return res;
 }
 
@@ -474,7 +474,7 @@ VectorSize MatrixVectorSizeSafe(MatrixSize sz) {
 
 VectorSize MatrixVectorSize(MatrixSize sz) {
 	VectorSize res = MatrixVectorSizeSafe(sz);
-	_assert_msg_(JIT, res != V_Invalid, "%s: Bad matrix size", __FUNCTION__);
+	_assert_msg_(res != V_Invalid, "%s: Bad matrix size", __FUNCTION__);
 	return res;
 }
 
@@ -490,7 +490,7 @@ int GetMatrixSideSafe(MatrixSize sz) {
 
 int GetMatrixSide(MatrixSize sz) {
 	int res = GetMatrixSideSafe(sz);
-	_assert_msg_(JIT, res != 0, "%s: Bad matrix size", __FUNCTION__);
+	_assert_msg_(res != 0, "%s: Bad matrix size", __FUNCTION__);
 	return res;
 }
 
@@ -776,7 +776,7 @@ float vfpu_dot(float a[4], float b[4]) {
 		mant_sum <<= shift;
 		max_exp -= shift;
 	}
-	_dbg_assert_msg_(JIT, (mant_sum & 0x00800000) != 0, "Mantissa wrong: %08x", mant_sum);
+	_dbg_assert_msg_((mant_sum & 0x00800000) != 0, "Mantissa wrong: %08x", mant_sum);
 
 	if (max_exp >= 255) {
 		max_exp = 255;

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -163,13 +163,13 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 #endif
 
 #ifdef _M_IX86
-			_assert_msg_(CPU, Memory::base != 0, "Memory base bogus");
+			_assert_msg_( Memory::base != 0, "Memory base bogus");
 			MOV(32, R(EAX), MDisp(EAX, (u32)Memory::base));
 #elif _M_X64
 			MOV(32, R(EAX), MComplex(MEMBASEREG, RAX, SCALE_1, 0));
 #endif
 			MOV(32, R(EDX), R(EAX));
-			_assert_msg_(JIT, MIPS_JITBLOCK_MASK == 0xFF000000, "Hardcoded assumption of emuhack mask");
+			_assert_msg_(MIPS_JITBLOCK_MASK == 0xFF000000, "Hardcoded assumption of emuhack mask");
 			SHR(32, R(EDX), Imm8(24));
 			CMP(32, R(EDX), Imm8(MIPS_EMUHACK_OPCODE >> 24));
 			FixupBranch notfound = J_CC(CC_NE);

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -336,7 +336,7 @@ void Jit::BranchRSRTComp(MIPSOpcode op, Gen::CCFlags cc, bool likely)
 		{
 		case CC_E: immBranchNotTaken = rsImm == rtImm; break;
 		case CC_NE: immBranchNotTaken = rsImm != rtImm; break;
-		default: immBranchNotTaken = false; _dbg_assert_msg_(JIT, false, "Bad cc flag in BranchRSRTComp().");
+		default: immBranchNotTaken = false; _dbg_assert_msg_(false, "Bad cc flag in BranchRSRTComp().");
 		}
 		immBranch = true;
 		immBranchTaken = !immBranchNotTaken;
@@ -412,7 +412,7 @@ void Jit::BranchRSZeroComp(MIPSOpcode op, Gen::CCFlags cc, bool andLink, bool li
 		case CC_GE: immBranchNotTaken = imm >= 0; break;
 		case CC_L: immBranchNotTaken = imm < 0; break;
 		case CC_LE: immBranchNotTaken = imm <= 0; break;
-		default: immBranchNotTaken = false; _dbg_assert_msg_(JIT, false, "Bad cc flag in BranchRSZeroComp().");
+		default: immBranchNotTaken = false; _dbg_assert_msg_(false, "Bad cc flag in BranchRSZeroComp().");
 		}
 		immBranch = true;
 		immBranchTaken = !immBranchNotTaken;
@@ -479,7 +479,7 @@ void Jit::Comp_RelBranch(MIPSOpcode op)
 	case 23: BranchRSZeroComp(op, CC_LE, false, true); break;//bgtzl
 
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 }
@@ -497,7 +497,7 @@ void Jit::Comp_RelBranchRI(MIPSOpcode op)
 	case 18: BranchRSZeroComp(op, CC_GE, true, true);  break; //R(MIPS_REG_RA) = PC + 8; if ((s32)R(rs) <  0) DelayBranchTo(addr); else SkipLikely(); break;//bltzall
 	case 19: BranchRSZeroComp(op, CC_L, true, true);   break; //R(MIPS_REG_RA) = PC + 8; if ((s32)R(rs) >= 0) DelayBranchTo(addr); else SkipLikely(); break;//bgezall
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 }
@@ -536,7 +536,7 @@ void Jit::Comp_FPUBranch(MIPSOpcode op)
 	case 2: BranchFPFlag(op, CC_NZ, true);	break; //bc1fl
 	case 3: BranchFPFlag(op, CC_Z,	true);	break; //bc1tl
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+		_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 		break;
 	}
 }
@@ -587,7 +587,7 @@ void Jit::Comp_VBranch(MIPSOpcode op)
 	case 2: BranchVFPUFlag(op, CC_NZ, true);	break; //bvfl
 	case 3: BranchVFPUFlag(op, CC_Z,	true);	break; //bvtl
 	default:
-		_dbg_assert_msg_(CPU,0,"Comp_VBranch: Invalid instruction");
+		_dbg_assert_msg_(false,"Comp_VBranch: Invalid instruction");
 		break;
 	}
 }
@@ -665,7 +665,7 @@ void Jit::Comp_Jump(MIPSOpcode op) {
 		break;
 
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 	js.compiling = false;
@@ -699,7 +699,7 @@ void Jit::Comp_JumpReg(MIPSOpcode op)
 		CompileDelaySlot(DELAYSLOT_FLUSH);
 
 		// Syscalls write the exit code for us.
-		_dbg_assert_msg_(JIT, !js.compiling, "Expected syscall to write an exit code.");
+		_dbg_assert_msg_(!js.compiling, "Expected syscall to write an exit code.");
 		return;
 	}
 	else if (delaySlotIsNice)
@@ -753,7 +753,7 @@ void Jit::Comp_JumpReg(MIPSOpcode op)
 	case 9: //jalr
 		break;
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile instruction that can't be compiled");
+		_dbg_assert_msg_(false,"Trying to compile instruction that can't be compiled");
 		break;
 	}
 

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -116,7 +116,7 @@ void Jit::Comp_FPU3op(MIPSOpcode op) {
 		break;
 	case 3: CompFPTriArith(op, &XEmitter::DIVSS, true); break;  //F(fd) = F(fs) / F(ft); //div
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to compile FPU3Op instruction that can't be interpreted");
+		_dbg_assert_msg_(false,"Trying to compile FPU3Op instruction that can't be interpreted");
 		break;
 	}
 }
@@ -169,7 +169,7 @@ void Jit::Comp_FPULS(MIPSOpcode op) {
 		break;
 
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to interpret FPULS instruction that can't be interpreted");
+		_dbg_assert_msg_(false,"Trying to interpret FPULS instruction that can't be interpreted");
 		break;
 	}
 }

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -228,7 +228,7 @@ namespace MIPSComp {
 			break;
 
 		default:
-			_dbg_assert_msg_(JIT, 0, "Unsupported left/right load/store instruction.");
+			_dbg_assert_msg_(false, "Unsupported left/right load/store instruction.");
 		}
 
 		// Flip ECX around from 3 bytes / 24 bits.
@@ -279,7 +279,7 @@ namespace MIPSComp {
 			break;
 
 		default:
-			_dbg_assert_msg_(JIT, 0, "Unsupported left/right load/store instruction.");
+			_dbg_assert_msg_(false, "Unsupported left/right load/store instruction.");
 		}
 	}
 

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -602,7 +602,7 @@ void Jit::Comp_VIdt(MIPSOpcode op) {
 		MOVSS(fpr.VX(dregs[3]), R((vd&3)==3 ? XMM1 : XMM0));
 		break;
 	default:
-		_dbg_assert_msg_(CPU,0,"Trying to interpret instruction that can't be interpreted");
+		_dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 		break;
 	}
 	ApplyPrefixD(dregs, sz);
@@ -2478,7 +2478,7 @@ void Jit::Comp_Mftv(MIPSOpcode op) {
 				}
 			} else {
 				//ERROR - maybe need to make this value too an "interlock" value?
-				_dbg_assert_msg_(CPU,0,"mfv - invalid register");
+				_dbg_assert_msg_(false,"mfv - invalid register");
 			}
 		}
 		break;
@@ -2519,7 +2519,7 @@ void Jit::Comp_Mftv(MIPSOpcode op) {
 			}
 		} else {
 			//ERROR
-			_dbg_assert_msg_(CPU,0,"mtv - invalid register");
+			_dbg_assert_msg_(false,"mtv - invalid register");
 		}
 		break;
 

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -633,7 +633,7 @@ void Jit::Comp_ReplacementFunc(MIPSOpcode op) {
 void Jit::Comp_Generic(MIPSOpcode op) {
 	FlushAll();
 	MIPSInterpretFunc func = MIPSGetInterpretFunc(op);
-	_dbg_assert_msg_(JIT, (MIPSGetInfo(op) & DELAYSLOT) == 0, "Cannot use interpreter for branch ops.");
+	_dbg_assert_msg_((MIPSGetInfo(op) & DELAYSLOT) == 0, "Cannot use interpreter for branch ops.");
 
 	if (func)
 	{
@@ -663,7 +663,7 @@ static void HitInvalidBranch(uint32_t dest) {
 }
 
 void Jit::WriteExit(u32 destination, int exit_num) {
-	_dbg_assert_msg_(JIT, exit_num < MAX_JIT_BLOCK_EXITS, "Expected a valid exit_num");
+	_dbg_assert_msg_(exit_num < MAX_JIT_BLOCK_EXITS, "Expected a valid exit_num");
 
 	if (!Memory::IsValidAddress(destination)) {
 		ERROR_LOG_REPORT(JIT, "Trying to write block exit to illegal destination %08x: pc = %08x", destination, currentMIPS->pc);

--- a/Core/MIPS/x86/JitSafeMem.cpp
+++ b/Core/MIPS/x86/JitSafeMem.cpp
@@ -142,7 +142,7 @@ OpArg JitSafeMem::NextFastAddress(int suboffset)
 #endif
 	}
 
-	_dbg_assert_msg_(JIT, (suboffset & alignMask_) == suboffset, "suboffset must be aligned");
+	_dbg_assert_msg_((suboffset & alignMask_) == suboffset, "suboffset must be aligned");
 
 #if PPSSPP_ARCH(32BIT)
 	return MDisp(xaddr_, (u32) Memory::base + offset_ + suboffset);
@@ -303,7 +303,7 @@ bool JitSafeMem::PrepareSlowRead(const void *safeFunc)
 
 void JitSafeMem::NextSlowRead(const void *safeFunc, int suboffset)
 {
-	_dbg_assert_msg_(JIT, !fast_, "NextSlowRead() called in fast memory mode?");
+	_dbg_assert_msg_(!fast_, "NextSlowRead() called in fast memory mode?");
 
 	// For simplicity, do nothing for 0.  We already read in PrepareSlowRead().
 	if (suboffset == 0)
@@ -311,7 +311,7 @@ void JitSafeMem::NextSlowRead(const void *safeFunc, int suboffset)
 
 	if (jit_->gpr.IsImm(raddr_))
 	{
-		_dbg_assert_msg_(JIT, !Memory::IsValidAddress(iaddr_ + suboffset), "NextSlowRead() for an invalid immediate address?");
+		_dbg_assert_msg_(!Memory::IsValidAddress(iaddr_ + suboffset), "NextSlowRead() for an invalid immediate address?");
 
 		jit_->MOV(32, R(EAX), Imm32((iaddr_ + suboffset) & alignMask_));
 	}

--- a/Core/MIPS/x86/RegCache.cpp
+++ b/Core/MIPS/x86/RegCache.cpp
@@ -198,7 +198,7 @@ X64Reg GPRRegCache::GetFreeXReg()
 	}
 
 	//Still no dice? Die!
-	_assert_msg_(JIT, 0, "Regcache ran out of regs");
+	_assert_msg_(false, "Regcache ran out of regs");
 	return (X64Reg) -1;
 }
 
@@ -302,7 +302,7 @@ bool GPRRegCache::IsImm(MIPSGPReg preg) const {
 }
 
 u32 GPRRegCache::GetImm(MIPSGPReg preg) const {
-	_dbg_assert_msg_(JIT, IsImm(preg), "Reg %d must be an immediate.", preg);
+	_dbg_assert_msg_(IsImm(preg), "Reg %d must be an immediate.", preg);
 	// Always 0 for ZERO.
 	if (preg == MIPS_REG_ZERO)
 		return 0;
@@ -411,15 +411,12 @@ void GPRRegCache::StoreFromRegister(MIPSGPReg i) {
 
 void GPRRegCache::Flush() {
 	for (int i = 0; i < NUM_X_REGS; i++) {
-		if (xregs[i].allocLocked)
-			PanicAlert("Someone forgot to unlock X64 reg %i.", i);
+		_assert_msg_(!xregs[i].allocLocked, "Someone forgot to unlock X64 reg %i.", i);
 	}
 	SetImm(MIPS_REG_ZERO, 0);
 	for (int i = 1; i < NUM_MIPS_GPRS; i++) {
 		const MIPSGPReg r = MIPSGPReg(i);
-		if (regs[i].locked) {
-			PanicAlert("Somebody forgot to unlock MIPS reg %i.", i);
-		}
+		_assert_msg_(!regs[i].locked, "Somebody forgot to unlock MIPS reg %i.", i);
 		if (regs[i].away) {
 			if (regs[i].location.IsSimpleReg()) {
 				X64Reg xr = RX(r);
@@ -429,7 +426,7 @@ void GPRRegCache::Flush() {
 			else if (regs[i].location.IsImm()) {
 				StoreFromRegister(r);
 			} else {
-				_assert_msg_(JIT,0,"Jit64 - Flush unhandled case, reg %i PC: %08x", i, mips->pc);
+				_assert_msg_(false, "Jit64 - Flush unhandled case, reg %i PC: %08x", i, mips->pc);
 			}
 		}
 	}

--- a/Core/MIPS/x86/RegCache.cpp
+++ b/Core/MIPS/x86/RegCache.cpp
@@ -356,8 +356,8 @@ void GPRRegCache::MapReg(MIPSGPReg i, bool doLoad, bool makeDirty) {
 
 	if (!regs[i].away || (regs[i].away && regs[i].location.IsImm())) {
 		X64Reg xr = GetFreeXReg();
-		if (xregs[xr].dirty) PanicAlert("Xreg already dirty");
-		if (xregs[xr].allocLocked) PanicAlert("GetFreeXReg returned locked register");
+		_assert_msg_(!xregs[xr].dirty, "Xreg already dirty");
+		_assert_msg_(!xregs[xr].allocLocked, "GetFreeXReg returned locked register");
 		xregs[xr].free = false;
 		xregs[xr].mipsReg = i;
 		xregs[xr].dirty = makeDirty || regs[i].location.IsImm();
@@ -371,8 +371,7 @@ void GPRRegCache::MapReg(MIPSGPReg i, bool doLoad, bool makeDirty) {
 		}
 		for (int j = 0; j < 32; j++) {
 			if (i != MIPSGPReg(j) && regs[j].location.IsSimpleReg(xr)) {
-				ERROR_LOG(JIT, "BindToRegister: Strange condition");
-				Crash();
+				_assert_msg_(false, "BindToRegister: Strange condition");
 			}
 		}
 		regs[i].away = true;

--- a/Core/MIPS/x86/RegCache.h
+++ b/Core/MIPS/x86/RegCache.h
@@ -101,7 +101,7 @@ public:
 	{
 		if (regs[preg].away && regs[preg].location.IsSimpleReg()) 
 			return regs[preg].location.GetSimpleReg(); 
-		PanicAlert("Not so simple - %i", preg); 
+		_assert_msg_(false, "Not so simple - %d", preg); 
 		return (Gen::X64Reg)-1;
 	}
 	Gen::OpArg GetDefaultLocation(MIPSGPReg reg) const;

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -111,15 +111,10 @@ void FPURegCache::ReduceSpillLockV(const u8 *vec, VectorSize sz) {
 
 void FPURegCache::FlushRemap(int oldreg, int newreg) {
 	OpArg oldLocation = regs[oldreg].location;
-	if (!oldLocation.IsSimpleReg()) {
-		PanicAlert("FlushRemap: Must already be in an x86 SSE register");
-	}
-	if (regs[oldreg].lane != 0) {
-		PanicAlert("FlushRemap only supports FPR registers");
-	}
+	_assert_msg_(oldLocation.IsSimpleReg(), "FlushRemap: Must already be in an x86 SSE register");
+	_assert_msg_(regs[oldreg].lane == 0, "FlushRemap only supports FPR registers");
 
 	X64Reg xr = oldLocation.GetSimpleReg();
-
 	if (oldreg == newreg) {
 		xregs[xr].dirty = true;
 		return;
@@ -642,7 +637,7 @@ static int MMShuffleSwapTo0(int lane) {
 	} else if (lane == 3) {
 		return _MM_SHUFFLE(0, 2, 1, 3);
 	} else {
-		PanicAlert("MMShuffleSwapTo0: Invalid lane %d", lane);
+		_assert_msg_(false, "MMShuffleSwapTo0: Invalid lane %d", lane);
 		return 0;
 	}
 }
@@ -868,9 +863,7 @@ void FPURegCache::Flush() {
 		return;
 	}
 	for (int i = 0; i < NUM_MIPS_FPRS; i++) {
-		if (regs[i].locked) {
-			PanicAlert("Somebody forgot to unlock MIPS reg %i.", i);
-		}
+		_assert_msg_(!regs[i].locked, "Somebody forgot to unlock MIPS reg %d.", i);
 		if (regs[i].away) {
 			if (regs[i].location.IsSimpleReg()) {
 				X64Reg xr = RX(i);
@@ -1093,7 +1086,7 @@ int FPURegCache::GetFreeXRegs(X64Reg *res, int n, bool spill) {
 
 void FPURegCache::FlushX(X64Reg reg) {
 	if (reg >= NUM_X_FPREGS) {
-		PanicAlert("Flushing non existent reg");
+		_assert_msg_(false, "Flushing non existent reg");
 	} else if (xregs[reg].mipsReg != -1) {
 		StoreFromRegister(xregs[reg].mipsReg);
 	}

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -199,7 +199,7 @@ bool FPURegCache::IsMappedVS(const u8 *v, VectorSize vsz) {
 void FPURegCache::MapRegsVS(const u8 *r, VectorSize vsz, int flags) {
 	const int n = GetNumVectorElements(vsz);
 
-	_dbg_assert_msg_(JIT, jo_->enableVFPUSIMD, "Should not map simd regs when option is off.");
+	_dbg_assert_msg_(jo_->enableVFPUSIMD, "Should not map simd regs when option is off.");
 
 	if (!TryMapRegsVS(r, vsz, flags)) {
 		// TODO: Could be more optimal.
@@ -207,7 +207,7 @@ void FPURegCache::MapRegsVS(const u8 *r, VectorSize vsz, int flags) {
 			StoreFromRegisterV(r[i]);
 		}
 		if (!TryMapRegsVS(r, vsz, flags)) {
-			_dbg_assert_msg_(JIT, false, "MapRegsVS() failed on second try.");
+			_dbg_assert_msg_(false, "MapRegsVS() failed on second try.");
 		}
 	}
 }
@@ -223,8 +223,8 @@ bool FPURegCache::CanMapVS(const u8 *v, VectorSize vsz) {
 		return true;
 	} else if (vregs[v[0]].lane != 0) {
 		const MIPSCachedFPReg &v0 = vregs[v[0]];
-		_dbg_assert_msg_(JIT, v0.away, "Must be away when lane != 0");
-		_dbg_assert_msg_(JIT, v0.location.IsSimpleReg(), "Must be is register when lane != 0");
+		_dbg_assert_msg_(v0.away, "Must be away when lane != 0");
+		_dbg_assert_msg_(v0.location.IsSimpleReg(), "Must be is register when lane != 0");
 
 		// Already in a different simd set.
 		return false;
@@ -245,7 +245,7 @@ bool FPURegCache::CanMapVS(const u8 *v, VectorSize vsz) {
 		if (vregs[v[i]].locked) {
 			return false;
 		}
-		_assert_msg_(JIT, !vregs[v[i]].location.IsImm(), "Cannot handle imms in fp cache.");
+		_assert_msg_(!vregs[v[i]].location.IsImm(), "Cannot handle imms in fp cache.");
 	}
 
 	return true;
@@ -331,7 +331,7 @@ X64Reg FPURegCache::LoadRegsVS(const u8 *v, int n) {
 	X64Reg xrs[4] = {INVALID_REG, INVALID_REG, INVALID_REG, INVALID_REG};
 	bool xrsLoaded[4] = {false, false, false, false};
 
-	_dbg_assert_msg_(JIT, n >= 2 && n <= 4, "LoadRegsVS is only implemented for simd loads.");
+	_dbg_assert_msg_(n >= 2 && n <= 4, "LoadRegsVS is only implemented for simd loads.");
 
 	for (int i = 0; i < n; ++i) {
 		const MIPSCachedFPReg &mr = vregs[v[i]];
@@ -345,7 +345,7 @@ X64Reg FPURegCache::LoadRegsVS(const u8 *v, int n) {
 				++regsLoaded;
 				++regsAvail;
 			} else if (mr.lane != 0) {
-				_dbg_assert_msg_(JIT, false, "LoadRegsVS is not able to handle simd remapping yet, store first.");
+				_dbg_assert_msg_(false, "LoadRegsVS is not able to handle simd remapping yet, store first.");
 			}
 		}
 	}
@@ -386,8 +386,8 @@ X64Reg FPURegCache::LoadRegsVS(const u8 *v, int n) {
 	// TODO: Not handling the case of some regs avail and some loaded right now.
 	if (regsAvail < n && (sequential != n || regsLoaded == n || regsAvail == 0)) {
 		regsAvail = GetFreeXRegs(xrs, 2, true);
-		_dbg_assert_msg_(JIT, regsAvail >= 2, "Ran out of fp regs for loading simd regs with.");
-		_dbg_assert_msg_(JIT, xrs[0] != xrs[1], "Regs for simd load are the same, bad things await.");
+		_dbg_assert_msg_(regsAvail >= 2, "Ran out of fp regs for loading simd regs with.");
+		_dbg_assert_msg_(xrs[0] != xrs[1], "Regs for simd load are the same, bad things await.");
 		// We spilled, so we assume that all our regs are screwed up now anyway.
 		for (int i = 0; i < 4; ++i) {
 			xrsLoaded[i] = false;
@@ -448,7 +448,7 @@ X64Reg FPURegCache::LoadRegsVS(const u8 *v, int n) {
 		}
 		res = xrs[0];
 	} else {
-		_dbg_assert_msg_(JIT, n > 2, "2 should not be possible here.");
+		_dbg_assert_msg_(n > 2, "2 should not be possible here.");
 
 		// Available regs are less than n, and some may be loaded.
 		// Let's grab the most optimal unloaded ones.
@@ -513,8 +513,8 @@ bool FPURegCache::TryMapDirtyInVS(const u8 *vd, VectorSize vdsz, const u8 *vs, V
 	ReleaseSpillLockV(vs, vssz);
 	ReleaseSpillLockV(vd, vdsz);
 
-	_dbg_assert_msg_(JIT, !success || IsMappedVS(vd, vdsz), "vd should be mapped now");
-	_dbg_assert_msg_(JIT, !success || IsMappedVS(vs, vssz), "vs should be mapped now");
+	_dbg_assert_msg_(!success || IsMappedVS(vd, vdsz), "vd should be mapped now");
+	_dbg_assert_msg_(!success || IsMappedVS(vs, vssz), "vs should be mapped now");
 
 	return success;
 }
@@ -538,9 +538,9 @@ bool FPURegCache::TryMapDirtyInInVS(const u8 *vd, VectorSize vdsz, const u8 *vs,
 	ReleaseSpillLockV(vs, vssz);
 	ReleaseSpillLockV(vt, vtsz);
 
-	_dbg_assert_msg_(JIT, !success || IsMappedVS(vd, vdsz), "vd should be mapped now");
-	_dbg_assert_msg_(JIT, !success || IsMappedVS(vs, vssz), "vs should be mapped now");
-	_dbg_assert_msg_(JIT, !success || IsMappedVS(vt, vtsz), "vt should be mapped now");
+	_dbg_assert_msg_(!success || IsMappedVS(vd, vdsz), "vd should be mapped now");
+	_dbg_assert_msg_(!success || IsMappedVS(vs, vssz), "vs should be mapped now");
+	_dbg_assert_msg_(!success || IsMappedVS(vt, vtsz), "vt should be mapped now");
 
 	return success;
 }
@@ -585,7 +585,7 @@ void FPURegCache::SimpleRegV(const u8 v, int flags) {
 		if (flags & MAP_DIRTY) {
 			xregs[VX(v)].dirty = true;
 		}
-		_assert_msg_(JIT, vr.location.IsSimpleReg(), "not loaded and not simple.");
+		_assert_msg_(vr.location.IsSimpleReg(), "not loaded and not simple.");
 	}
 	Invariant();
 }
@@ -603,13 +603,13 @@ void FPURegCache::ReleaseSpillLocks() {
 
 void FPURegCache::MapReg(const int i, bool doLoad, bool makeDirty) {
 	pendingFlush = true;
-	_assert_msg_(JIT, !regs[i].location.IsImm(), "WTF - FPURegCache::MapReg - imm");
-	_assert_msg_(JIT, i >= 0 && i < NUM_MIPS_FPRS, "WTF - FPURegCache::MapReg - invalid mips reg %d", i);
+	_assert_msg_(!regs[i].location.IsImm(), "WTF - FPURegCache::MapReg - imm");
+	_assert_msg_(i >= 0 && i < NUM_MIPS_FPRS, "WTF - FPURegCache::MapReg - invalid mips reg %d", i);
 
 	if (!regs[i].away) {
 		// Reg is at home in the memory register file. Let's pull it out.
 		X64Reg xr = GetFreeXReg();
-		_assert_msg_(JIT, xr < NUM_X_FPREGS, "WTF - FPURegCache::MapReg - invalid reg %d", (int)xr);
+		_assert_msg_(xr < NUM_X_FPREGS, "WTF - FPURegCache::MapReg - invalid reg %d", (int)xr);
 		xregs[xr].mipsReg = i;
 		xregs[xr].dirty = makeDirty;
 		OpArg newloc = ::Gen::R(xr);
@@ -627,7 +627,7 @@ void FPURegCache::MapReg(const int i, bool doLoad, bool makeDirty) {
 	} else {
 		// There are no immediates in the FPR reg file, so we already had this in a register. Make dirty as necessary.
 		xregs[RX(i)].dirty |= makeDirty;
-		_assert_msg_(JIT, regs[i].location.IsSimpleReg(), "not loaded and not simple.");
+		_assert_msg_(regs[i].location.IsSimpleReg(), "not loaded and not simple.");
 	}
 	Invariant();
 }
@@ -648,12 +648,12 @@ static int MMShuffleSwapTo0(int lane) {
 }
 
 void FPURegCache::StoreFromRegister(int i) {
-	_assert_msg_(JIT, !regs[i].location.IsImm(), "WTF - FPURegCache::StoreFromRegister - it's an imm");
-	_assert_msg_(JIT, i >= 0 && i < NUM_MIPS_FPRS, "WTF - FPURegCache::StoreFromRegister - invalid mipsreg %i PC=%08x", i, js_->compilerPC);
+	_assert_msg_(!regs[i].location.IsImm(), "WTF - FPURegCache::StoreFromRegister - it's an imm");
+	_assert_msg_(i >= 0 && i < NUM_MIPS_FPRS, "WTF - FPURegCache::StoreFromRegister - invalid mipsreg %i PC=%08x", i, js_->compilerPC);
 
 	if (regs[i].away) {
 		X64Reg xr = regs[i].location.GetSimpleReg();
-		_assert_msg_(JIT, xr < NUM_X_FPREGS, "WTF - FPURegCache::StoreFromRegister - invalid reg: x %i (mr: %i). PC=%08x", (int)xr, i, js_->compilerPC);
+		_assert_msg_(xr < NUM_X_FPREGS, "WTF - FPURegCache::StoreFromRegister - invalid reg: x %i (mr: %i). PC=%08x", (int)xr, i, js_->compilerPC);
 		if (regs[i].lane != 0) {
 			const int *mri = xregs[xr].mipsRegs;
 			int seq = 1;
@@ -727,16 +727,16 @@ void FPURegCache::StoreFromRegister(int i) {
 		xregs[xr].dirty = false;
 		regs[i].away = false;
 	} else {
-		//	_assert_msg_(DYNA_REC,0,"already stored");
+		//	_assert_msg_(false,"already stored");
 	}
 	Invariant();
 }
 
 void FPURegCache::DiscardR(int i) {
-	_assert_msg_(JIT, !regs[i].location.IsImm(), "FPU can't handle imm yet.");
+	_assert_msg_(!regs[i].location.IsImm(), "FPU can't handle imm yet.");
 	if (regs[i].away) {
 		X64Reg xr = regs[i].location.GetSimpleReg();
-		_assert_msg_(JIT, xr < NUM_X_FPREGS, "DiscardR: MipsReg had bad X64Reg");
+		_assert_msg_(xr < NUM_X_FPREGS, "DiscardR: MipsReg had bad X64Reg");
 		// Note that we DO NOT write it back here. That's the whole point of Discard.
 		if (regs[i].lane != 0) {
 			// But we can't just discard all of them in SIMD, just the one lane.
@@ -769,19 +769,19 @@ void FPURegCache::DiscardR(int i) {
 		regs[i].away = false;
 		regs[i].tempLocked = false;
 	} else {
-		//	_assert_msg_(DYNA_REC,0,"already stored");
+		//	_assert_msg_(false,"already stored");
 		regs[i].tempLocked = false;
 	}
 	Invariant();
 }
 
 void FPURegCache::DiscardVS(int vreg) {
-	_assert_msg_(JIT, !vregs[vreg].location.IsImm(), "FPU can't handle imm yet.");
+	_assert_msg_(!vregs[vreg].location.IsImm(), "FPU can't handle imm yet.");
 
 	if (vregs[vreg].away) {
-		_assert_msg_(JIT, vregs[vreg].lane != 0, "VS expects a SIMD reg.");
+		_assert_msg_(vregs[vreg].lane != 0, "VS expects a SIMD reg.");
 		X64Reg xr = vregs[vreg].location.GetSimpleReg();
-		_assert_msg_(JIT, xr < NUM_X_FPREGS, "DiscardR: MipsReg had bad X64Reg");
+		_assert_msg_(xr < NUM_X_FPREGS, "DiscardR: MipsReg had bad X64Reg");
 		// Note that we DO NOT write it back here. That's the whole point of Discard.
 		for (int i = 0; i < 4; ++i) {
 			int mr = xregs[xr].mipsRegs[i];
@@ -813,7 +813,7 @@ int FPURegCache::GetTempR() {
 		}
 	}
 
-	_assert_msg_(JIT, 0, "Regcache ran out of temp regs, might need to DiscardR() some.");
+	_assert_msg_(false, "Regcache ran out of temp regs, might need to DiscardR() some.");
 	return -1;
 }
 
@@ -852,7 +852,7 @@ int FPURegCache::GetTempVS(u8 *v, VectorSize vsz) {
 	}
 
 	if (found != n) {
-		_assert_msg_(JIT, 0, "Regcache ran out of temp regs, might need to DiscardR() some.");
+		_assert_msg_(false, "Regcache ran out of temp regs, might need to DiscardR() some.");
 		return -1;
 	}
 
@@ -879,7 +879,7 @@ void FPURegCache::Flush() {
 			} else if (regs[i].location.IsImm()) {
 				StoreFromRegister(i);
 			} else {
-				_assert_msg_(JIT,0,"Jit64 - Flush unhandled case, reg %i PC: %08x", i, mips->pc);
+				_assert_msg_(false, "Jit64 - Flush unhandled case, reg %i PC: %08x", i, mips->pc);
 			}
 		}
 	}
@@ -909,7 +909,7 @@ OpArg FPURegCache::GetDefaultLocation(int reg) const {
 
 void FPURegCache::Invariant() const {
 #ifdef _DEBUG
-	_dbg_assert_msg_(JIT, SanityCheck() == 0, "Sanity check failed: %d", SanityCheck());
+	_dbg_assert_msg_(SanityCheck() == 0, "Sanity check failed: %d", SanityCheck());
 #endif
 }
 
@@ -1043,7 +1043,7 @@ X64Reg FPURegCache::GetFreeXReg() {
 	X64Reg res;
 	int obtained = GetFreeXRegs(&res, 1);
 
-	_assert_msg_(JIT, obtained == 1, "Regcache ran out of regs");
+	_assert_msg_(obtained == 1, "Regcache ran out of regs");
 	return res;
 }
 
@@ -1052,7 +1052,7 @@ int FPURegCache::GetFreeXRegs(X64Reg *res, int n, bool spill) {
 	int aCount;
 	const int *aOrder = GetAllocationOrder(aCount);
 
-	_dbg_assert_msg_(JIT, n <= NUM_X_FPREGS - 2, "Cannot obtain that many regs.");
+	_dbg_assert_msg_(n <= NUM_X_FPREGS - 2, "Cannot obtain that many regs.");
 
 	int r = 0;
 
@@ -1072,7 +1072,7 @@ int FPURegCache::GetFreeXRegs(X64Reg *res, int n, bool spill) {
 		for (int i = 0; i < aCount; i++) {
 			X64Reg xr = (X64Reg)aOrder[i];
 			int preg = xregs[xr].mipsReg;
-			_assert_msg_(JIT, preg >= -1 && preg < NUM_MIPS_FPRS, "WTF - FPURegCache::GetFreeXRegs - invalid mips reg %d in xr %d", preg, (int)xr);
+			_assert_msg_(preg >= -1 && preg < NUM_MIPS_FPRS, "WTF - FPURegCache::GetFreeXRegs - invalid mips reg %d in xr %d", preg, (int)xr);
 
 			// We're only spilling here, so don't overlap.
 			if (preg != -1 && !regs[preg].locked) {

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -137,7 +137,7 @@ public:
 	Gen::X64Reg RX(int freg) const {
 		if (regs[freg].away && regs[freg].location.IsSimpleReg())
 			return regs[freg].location.GetSimpleReg();
-		PanicAlert("Not so simple - f%i", freg);
+		_assert_msg_(false, "Not so simple - f%i", freg);
 		return (Gen::X64Reg)-1;
 	}
 
@@ -145,7 +145,7 @@ public:
 		_dbg_assert_msg_(vregs[vreg].lane == 0, "SIMD reg %d used as V reg (use VSX instead). pc=%08x", vreg, mips->pc);
 		if (vregs[vreg].away && vregs[vreg].location.IsSimpleReg())
 			return vregs[vreg].location.GetSimpleReg();
-		PanicAlert("Not so simple - v%i", vreg);
+		_assert_msg_(false, "Not so simple - v%i", vreg);
 		return (Gen::X64Reg)-1;
 	}
 
@@ -153,7 +153,7 @@ public:
 		_dbg_assert_msg_(vregs[vs[0]].lane != 0, "V reg %d used as VS reg (use VX instead). pc=%08x", vs[0], mips->pc);
 		if (vregs[vs[0]].away && vregs[vs[0]].location.IsSimpleReg())
 			return vregs[vs[0]].location.GetSimpleReg();
-		PanicAlert("Not so simple - v%i", vs[0]);
+		_assert_msg_(false, "Not so simple - v%i", vs[0]);
 		return (Gen::X64Reg)-1;
 	}
 

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -126,11 +126,11 @@ public:
 
 	const Gen::OpArg &R(int freg) const {return regs[freg].location;}
 	const Gen::OpArg &V(int vreg) const {
-		_dbg_assert_msg_(JIT, vregs[vreg].lane == 0, "SIMD reg %d used as V reg (use VS instead). pc=%08x", vreg, mips->pc);
+		_dbg_assert_msg_(vregs[vreg].lane == 0, "SIMD reg %d used as V reg (use VS instead). pc=%08x", vreg, mips->pc);
 		return vregs[vreg].location;
 	}
 	const Gen::OpArg &VS(const u8 *vs) const {
-		_dbg_assert_msg_(JIT, vregs[vs[0]].lane != 0, "V reg %d used as VS reg (use V instead). pc=%08x", vs[0], mips->pc);
+		_dbg_assert_msg_(vregs[vs[0]].lane != 0, "V reg %d used as VS reg (use V instead). pc=%08x", vs[0], mips->pc);
 		return vregs[vs[0]].location;
 	}
 
@@ -142,7 +142,7 @@ public:
 	}
 
 	Gen::X64Reg VX(int vreg) const {
-		_dbg_assert_msg_(JIT, vregs[vreg].lane == 0, "SIMD reg %d used as V reg (use VSX instead). pc=%08x", vreg, mips->pc);
+		_dbg_assert_msg_(vregs[vreg].lane == 0, "SIMD reg %d used as V reg (use VSX instead). pc=%08x", vreg, mips->pc);
 		if (vregs[vreg].away && vregs[vreg].location.IsSimpleReg())
 			return vregs[vreg].location.GetSimpleReg();
 		PanicAlert("Not so simple - v%i", vreg);
@@ -150,7 +150,7 @@ public:
 	}
 
 	Gen::X64Reg VSX(const u8 *vs) const {
-		_dbg_assert_msg_(JIT, vregs[vs[0]].lane != 0, "V reg %d used as VS reg (use VX instead). pc=%08x", vs[0], mips->pc);
+		_dbg_assert_msg_(vregs[vs[0]].lane != 0, "V reg %d used as VS reg (use VX instead). pc=%08x", vs[0], mips->pc);
 		if (vregs[vs[0]].away && vregs[vs[0]].location.IsSimpleReg())
 			return vregs[vs[0]].location.GetSimpleReg();
 		PanicAlert("Not so simple - v%i", vs[0]);

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -250,7 +250,6 @@ bool MemoryMap_Setup(u32 flags) {
 			}
 		}
 		ERROR_LOG(MEMMAP, "MemoryMap_Setup: Failed finding a memory base.");
-		PanicAlert("MemoryMap_Setup: Failed finding a memory base.");
 		return false;
 	}
 	else
@@ -281,7 +280,7 @@ void MemoryMap_Shutdown(u32 flags) {
 #endif
 }
 
-void Init() {
+bool Init() {
 	// On some 32 bit platforms, you can only map < 32 megs at a time.
 	// TODO: Wait, wtf? What platforms are those? This seems bad.
 	const static int MAX_MMAP_SIZE = 31 * 1024 * 1024;
@@ -294,13 +293,17 @@ void Init() {
 		if (views[i].flags & MV_IS_EXTRA2_RAM)
 			views[i].size = std::min(std::max((int)g_MemorySize - MAX_MMAP_SIZE * 2, 0), MAX_MMAP_SIZE);
 	}
+
 	int flags = 0;
-	MemoryMap_Setup(flags);
+	if (!MemoryMap_Setup(flags)) {
+		return false;
+	}
 
 	INFO_LOG(MEMMAP, "Memory system initialized. Base at %p (RAM at @ %p, uncached @ %p)",
 		base, m_pPhysicalRAM, m_pUncachedRAM);
 
 	MemFault_Init();
+	return true;
 }
 
 void Reinit() {

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -285,7 +285,7 @@ void Init() {
 	// On some 32 bit platforms, you can only map < 32 megs at a time.
 	// TODO: Wait, wtf? What platforms are those? This seems bad.
 	const static int MAX_MMAP_SIZE = 31 * 1024 * 1024;
-	_dbg_assert_msg_(MEMMAP, g_MemorySize < MAX_MMAP_SIZE * 3, "ACK - too much memory for three mmap views.");
+	_dbg_assert_msg_(g_MemorySize < MAX_MMAP_SIZE * 3, "ACK - too much memory for three mmap views.");
 	for (size_t i = 0; i < ARRAY_SIZE(views); i++) {
 		if (views[i].flags & MV_IS_PRIMARY_RAM)
 			views[i].size = std::min((int)g_MemorySize, MAX_MMAP_SIZE);
@@ -304,7 +304,7 @@ void Init() {
 }
 
 void Reinit() {
-	_assert_msg_(SYSTEM, PSP_IsInited(), "Cannot reinit during startup/shutdown");
+	_assert_msg_(PSP_IsInited(), "Cannot reinit during startup/shutdown");
 	Core_NotifyLifecycle(CoreLifecycle::MEMORY_REINITING);
 	Shutdown();
 	Init();

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -126,7 +126,7 @@ bool MemoryMap_Setup(u32 flags);
 void MemoryMap_Shutdown(u32 flags);
 
 // Init and Shutdown
-void Init();
+bool Init();
 void Shutdown();
 void DoState(PointerWrap &p);
 void Clear();

--- a/Core/Screenshot.cpp
+++ b/Core/Screenshot.cpp
@@ -229,7 +229,7 @@ static bool ConvertPixelTo8888RGBA(GPUDebugBufferFormat fmt, u8 &r, u8 &g, u8 &b
 		a = (src >> 8) & 0xFF;
 		break;
 	default:
-		_assert_msg_(SYSTEM, false, "Unsupported framebuffer format for screenshot: %d", fmt);
+		_assert_msg_(false, "Unsupported framebuffer format for screenshot: %d", fmt);
 		return false;
 	}
 

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -222,7 +222,7 @@ void TextureReplacer::ParseHashRange(const std::string &key, const std::string &
 }
 
 u32 TextureReplacer::ComputeHash(u32 addr, int bufw, int w, int h, GETextureFormat fmt, u16 maxSeenV) {
-	_dbg_assert_msg_(G3D, enabled_, "Replacement not enabled");
+	_dbg_assert_msg_(enabled_, "Replacement not enabled");
 
 	if (!LookupHashRange(addr, w, h)) {
 		// There wasn't any hash range, let's fall back to maxSeenV logic.
@@ -398,7 +398,7 @@ static bool WriteTextureToPNG(png_imagep image, const std::string &filename, int
 #endif
 
 void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &replacedInfo, const void *data, int pitch, int level, int w, int h) {
-	_assert_msg_(G3D, enabled_, "Replacement not enabled");
+	_assert_msg_(enabled_, "Replacement not enabled");
 	if (!g_Config.bSaveNewTextures) {
 		// Ignore.
 		return;
@@ -595,8 +595,8 @@ bool TextureReplacer::LookupHashRange(u32 addr, int &w, int &h) {
 }
 
 void ReplacedTexture::Load(int level, void *out, int rowPitch) {
-	_assert_msg_(G3D, (size_t)level < levels_.size(), "Invalid miplevel");
-	_assert_msg_(G3D, out != nullptr && rowPitch > 0, "Invalid out/pitch");
+	_assert_msg_((size_t)level < levels_.size(), "Invalid miplevel");
+	_assert_msg_(out != nullptr && rowPitch > 0, "Invalid out/pitch");
 
 	const ReplacedTextureLevel &info = levels_[level];
 

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -222,8 +222,7 @@ void __PPGeInit() {
 
 	bool loadedZIM = !skipZIM && LoadZIM("ppge_atlas.zim", width, height, &flags, imageData);
 	if (!skipZIM && !loadedZIM) {
-		PanicAlert("Failed to load ppge_atlas.zim.\n\nPlace it in the directory \"assets\" under your PPSSPP directory.");
-		ERROR_LOG(SCEGE, "PPGe init failed - no atlas texture. PPGe stuff will not be drawn.");
+		ERROR_LOG(SCEGE, "Failed to load ppge_atlas.zim.\n\nPlace it in the directory \"assets\" under your PPSSPP directory.\n\nPPGe stuff will not be drawn.");
 	}
 
 	if (loadedZIM) {

--- a/Core/WaveFile.cpp
+++ b/Core/WaveFile.cpp
@@ -23,19 +23,14 @@ WaveFileWriter::~WaveFileWriter()
 bool WaveFileWriter::Start(const std::string& filename, unsigned int HLESampleRate)
 {
 	// Check if the file is already open
-	if (file)
-	{
-		PanicAlert("The file %s was already open, the file header will not be written.",
-			filename.c_str());
+	if (file) {
+		ERROR_LOG(SYSTEM, "The file %s was already open, the file header will not be written.", filename.c_str());
 		return false;
 	}
 
 	file.Open(filename, "wb");
-	if (!file)
-	{
-		PanicAlert("The file %s could not be opened for writing. Please check if it's already opened "
-			"by another program.",
-			filename.c_str());
+	if (!file) {
+		ERROR_LOG(SYSTEM, "The file %s could not be opened for writing. Please check if it's already opened by another program.", filename.c_str());
 		return false;
 	}
 
@@ -61,9 +56,8 @@ bool WaveFileWriter::Start(const std::string& filename, unsigned int HLESampleRa
 	Write(100 * 1000 * 1000 - 32);
 
 	// We are now at offset 44
-	if (file.Tell() != 44)
-		PanicAlert("Wrong offset: %lld", (long long)file.Tell());
-
+	u64 offset = file.Tell();
+	_assert_msg_(offset == 44, "Wrong offset: %lld", (long long)offset);
 	return true;
 }
 
@@ -91,11 +85,8 @@ void WaveFileWriter::Write4(const char* ptr)
 
 void WaveFileWriter::AddStereoSamples(const short* sample_data, u32 count)
 {
-	if (!file)
-		PanicAlert("WaveFileWriter - file not open.");
-
-	if (count > BUFFER_SIZE * 2)
-		PanicAlert("WaveFileWriter - buffer too small (count = %u).", count);
+	_assert_msg_(file, "WaveFileWriter - file not open.");
+	_assert_msg_(count <= BUFFER_SIZE * 2, "WaveFileWriter - buffer too small (count = %u).", count);
 
 	if (skip_silence)
 	{

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -292,7 +292,7 @@ void GenerateDepalShader(char *buffer, GEBufferFormat pixelFormat, ShaderLanguag
 		break;
 	case HLSL_D3D11_LEVEL9:
 	default:
-		_assert_msg_(G3D, false, "Depal shader language not supported: %d", (int)language);
+		_assert_msg_(false, "Depal shader language not supported: %d", (int)language);
 	}
 }
 

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -746,7 +746,7 @@ Draw::Texture *FramebufferManagerCommon::MakePixelTexture(const u8 *srcPixels, G
 				break;
 
 			case GE_FORMAT_INVALID:
-				_dbg_assert_msg_(G3D, false, "Invalid pixelFormat passed to DrawPixels().");
+				_dbg_assert_msg_(false, "Invalid pixelFormat passed to DrawPixels().");
 				break;
 			}
 		}
@@ -1441,7 +1441,7 @@ void FramebufferManagerCommon::ApplyClearToMemory(int x1, int y1, int x2, int y2
 		case GE_FORMAT_565: ConvertRGBA8888ToRGB565(&clear16, &clearColor, 1); break;
 		case GE_FORMAT_5551: ConvertRGBA8888ToRGBA5551(&clear16, &clearColor, 1); break;
 		case GE_FORMAT_4444: ConvertRGBA8888ToRGBA4444(&clear16, &clearColor, 1); break;
-		default: _dbg_assert_(G3D, 0); break;
+		default: _dbg_assert_(0); break;
 		}
 		clearBits = clear16 | (clear16 << 16);
 	}

--- a/GPU/Common/FramebufferCommon.h
+++ b/GPU/Common/FramebufferCommon.h
@@ -210,8 +210,8 @@ public:
 			FramebufferHeuristicParams inputs;
 			GetFramebufferHeuristicInputs(&inputs, gstate);
 			VirtualFramebuffer *vfb = DoSetRenderFrameBuffer(inputs, skipDrawReason);
-			_dbg_assert_msg_(G3D, vfb, "DoSetRenderFramebuffer must return a valid framebuffer.");
-			_dbg_assert_msg_(G3D, currentRenderVfb_, "DoSetRenderFramebuffer must set a valid framebuffer.");
+			_dbg_assert_msg_(vfb, "DoSetRenderFramebuffer must return a valid framebuffer.");
+			_dbg_assert_msg_(currentRenderVfb_, "DoSetRenderFramebuffer must set a valid framebuffer.");
 			return vfb;
 		}
 	}

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -147,7 +147,7 @@ void ComputeVertexShaderID(VShaderID *id_out, u32 vertType, bool useHWTransform,
 	id.SetBit(VS_BIT_FLATSHADE, doFlatShading);
 
 	// These two bits cannot be combined, otherwise havoc occurs. We get reports that indicate this happened somehow... "ERROR: 0:14: 'u_proj' : undeclared identifier"
-	_dbg_assert_msg_(G3D, !id.Bit(VS_BIT_USE_HW_TRANSFORM) || !id.Bit(VS_BIT_IS_THROUGH), "Can't have both THROUGH and USE_HW_TRANSFORM together!");
+	_dbg_assert_msg_(!id.Bit(VS_BIT_USE_HW_TRANSFORM) || !id.Bit(VS_BIT_IS_THROUGH), "Can't have both THROUGH and USE_HW_TRANSFORM together!");
 
 	*id_out = id;
 }

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -866,7 +866,7 @@ bool TextureCacheCommon::AttachFramebuffer(TexCacheEntry *entry, u32 address, Vi
 }
 
 void TextureCacheCommon::SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer) {
-	_dbg_assert_msg_(G3D, framebuffer != nullptr, "Framebuffer must not be null.");
+	_dbg_assert_msg_(framebuffer != nullptr, "Framebuffer must not be null.");
 
 	framebuffer->usageFlags |= FB_USAGE_TEXTURE;
 	if (framebufferManager_->UseBufferedRendering()) {
@@ -1181,7 +1181,7 @@ static inline void ConvertFormatToRGBA8888(GETextureFormat format, u32 *dst, con
 		ConvertRGB565ToRGBA8888(dst, src, numPixels);
 		break;
 	default:
-		_dbg_assert_msg_(G3D, false, "Incorrect texture format.");
+		_dbg_assert_msg_(false, "Incorrect texture format.");
 		break;
 	}
 }

--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -543,7 +543,7 @@ void VertexDecoderJitCache::Jit_WeightsU16Skin() {
 
 void VertexDecoderJitCache::Jit_WeightsFloatSkin() {
 	for (int i = 1; i < dec_->nweights; ++i) {
-		_dbg_assert_msg_(JIT, weightRegs[i - 1] + 1 == weightRegs[i], "VertexDecoder weightRegs must be in order.");
+		_dbg_assert_msg_(weightRegs[i - 1] + 1 == weightRegs[i], "VertexDecoder weightRegs must be in order.");
 	}
 
 	// Weights are always first, so we can use srcReg directly.
@@ -1210,8 +1210,8 @@ void VertexDecoderJitCache::Jit_NormalFloat() {
 // Through expands into floats, always. Might want to look at changing this.
 void VertexDecoderJitCache::Jit_PosS8Through() {
 	DEBUG_LOG_REPORT_ONCE(vertexS8Through, G3D, "Using S8 positions in throughmode");
-	_dbg_assert_msg_(JIT, fpScratchReg + 1 == fpScratchReg2, "VertexDecoder fpScratchRegs must be in order.");
-	_dbg_assert_msg_(JIT, fpScratchReg2 + 1 == fpScratchReg3, "VertexDecoder fpScratchRegs must be in order.");
+	_dbg_assert_msg_(fpScratchReg + 1 == fpScratchReg2, "VertexDecoder fpScratchRegs must be in order.");
+	_dbg_assert_msg_(fpScratchReg2 + 1 == fpScratchReg3, "VertexDecoder fpScratchRegs must be in order.");
 
 	// TODO: SIMD
 	LDRSB(tempReg1, srcReg, dec_->posoff);
@@ -1236,8 +1236,8 @@ void VertexDecoderJitCache::Jit_PosS8Through() {
 
 // Through expands into floats, always. Might want to look at changing this.
 void VertexDecoderJitCache::Jit_PosS16Through() {
-	_dbg_assert_msg_(JIT, fpScratchReg + 1 == fpScratchReg2, "VertexDecoder fpScratchRegs must be in order.");
-	_dbg_assert_msg_(JIT, fpScratchReg2 + 1 == fpScratchReg3, "VertexDecoder fpScratchRegs must be in order.");
+	_dbg_assert_msg_(fpScratchReg + 1 == fpScratchReg2, "VertexDecoder fpScratchRegs must be in order.");
+	_dbg_assert_msg_(fpScratchReg2 + 1 == fpScratchReg3, "VertexDecoder fpScratchRegs must be in order.");
 
 	LDRSH(tempReg1, srcReg, dec_->posoff);
 	LDRSH(tempReg2, srcReg, dec_->posoff + 2);
@@ -1301,7 +1301,7 @@ void VertexDecoderJitCache::Jit_NormalS16Skin() {
 
 void VertexDecoderJitCache::Jit_NormalFloatSkin() {
 	for (int i = 1; i < 3; ++i) {
-		_dbg_assert_msg_(JIT, src[i - 1] + 1 == src[i], "VertexDecoder src regs must be in order.");
+		_dbg_assert_msg_(src[i - 1] + 1 == src[i], "VertexDecoder src regs must be in order.");
 	}
 
 	ADD(tempReg1, srcReg, dec_->nrmoff);
@@ -1325,8 +1325,8 @@ void VertexDecoderJitCache::Jit_WriteMatrixMul(int outOff, bool pos) {
 		}
 		VST1(F_32, accNEON, scratchReg, 2);
 	} else {
-		_dbg_assert_msg_(JIT, fpScratchReg + 1 == fpScratchReg2, "VertexDecoder fpScratchRegs must be in order.");
-		_dbg_assert_msg_(JIT, fpScratchReg2 + 1 == fpScratchReg3, "VertexDecoder fpScratchRegs must be in order.");
+		_dbg_assert_msg_(fpScratchReg + 1 == fpScratchReg2, "VertexDecoder fpScratchRegs must be in order.");
+		_dbg_assert_msg_(fpScratchReg2 + 1 == fpScratchReg3, "VertexDecoder fpScratchRegs must be in order.");
 
 		MOVP2R(tempReg1, skinMatrix);
 		VLDMIA(tempReg1, true, fpScratchReg, 3);
@@ -1364,7 +1364,7 @@ void VertexDecoderJitCache::Jit_PosS16Skin() {
 
 void VertexDecoderJitCache::Jit_PosFloatSkin() {
 	for (int i = 1; i < 3; ++i) {
-		_dbg_assert_msg_(JIT, src[i - 1] + 1 == src[i], "VertexDecoder src regs must be in order.");
+		_dbg_assert_msg_(src[i - 1] + 1 == src[i], "VertexDecoder src regs must be in order.");
 	}
 
 	ADD(tempReg1, srcReg, dec_->posoff);

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -1452,8 +1452,8 @@ void VertexDecoderJitCache::Jit_AnyS16ToFloat(int srcoff) {
 }
 
 void VertexDecoderJitCache::Jit_AnyU8ToFloat(int srcoff, u32 bits) {
-	_dbg_assert_msg_(JIT, (bits & ~(32 | 16 | 8)) == 0, "Bits must be a multiple of 8.");
-	_dbg_assert_msg_(JIT, bits >= 8 && bits <= 32, "Bits must be a between 8 and 32.");
+	_dbg_assert_msg_((bits & ~(32 | 16 | 8)) == 0, "Bits must be a multiple of 8.");
+	_dbg_assert_msg_(bits >= 8 && bits <= 32, "Bits must be a between 8 and 32.");
 
 	if (!cpu_info.bSSE4_1) {
 		PXOR(XMM3, R(XMM3));
@@ -1484,8 +1484,8 @@ void VertexDecoderJitCache::Jit_AnyU8ToFloat(int srcoff, u32 bits) {
 }
 
 void VertexDecoderJitCache::Jit_AnyU16ToFloat(int srcoff, u32 bits) {
-	_dbg_assert_msg_(JIT, (bits & ~(64 | 32 | 16)) == 0, "Bits must be a multiple of 16.");
-	_dbg_assert_msg_(JIT, bits >= 16 && bits <= 64, "Bits must be a between 16 and 64.");
+	_dbg_assert_msg_((bits & ~(64 | 32 | 16)) == 0, "Bits must be a multiple of 16.");
+	_dbg_assert_msg_(bits >= 16 && bits <= 64, "Bits must be a between 16 and 64.");
 
 	if (!cpu_info.bSSE4_1) {
 		PXOR(XMM3, R(XMM3));

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -437,7 +437,7 @@ void DrawEngineD3D11::DoFlush() {
 							vai->numVerts = indexGen.PureCount();
 						}
 
-						_dbg_assert_msg_(G3D, gstate_c.vertBounds.minV >= gstate_c.vertBounds.maxV, "Should not have checked UVs when caching.");
+						_dbg_assert_msg_(gstate_c.vertBounds.minV >= gstate_c.vertBounds.maxV, "Should not have checked UVs when caching.");
 
 						// TODO: Combine these two into one buffer?
 						u32 size = dec_->GetDecVtxFmt().stride * indexGen.MaxIndex();

--- a/GPU/Debugger/Playback.cpp
+++ b/GPU/Debugger/Playback.cpp
@@ -664,7 +664,7 @@ static void ReplayStop() {
 }
 
 bool RunMountedReplay(const std::string &filename) {
-	_assert_msg_(SYSTEM, !GPURecord::IsActivePending(), "Cannot run replay while recording.");
+	_assert_msg_(!GPURecord::IsActivePending(), "Cannot run replay while recording.");
 
 	std::lock_guard<std::mutex> guard(executeLock);
 	Core_ListenStopRequest(&ReplayStop);

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -417,7 +417,7 @@ void DrawEngineDX9::DoFlush() {
 							vai->numVerts = indexGen.PureCount();
 						}
 
-						_dbg_assert_msg_(G3D, gstate_c.vertBounds.minV >= gstate_c.vertBounds.maxV, "Should not have checked UVs when caching.");
+						_dbg_assert_msg_(gstate_c.vertBounds.minV >= gstate_c.vertBounds.maxV, "Should not have checked UVs when caching.");
 
 						void * pVb;
 						u32 size = dec_->GetDecVtxFmt().stride * indexGen.MaxIndex();

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -109,7 +109,7 @@ void DrawEngineGLES::DeviceRestore(Draw::DrawContext *draw) {
 }
 
 void DrawEngineGLES::InitDeviceObjects() {
-	_assert_msg_(G3D, render_ != nullptr, "Render manager must be set");
+	_assert_msg_(render_ != nullptr, "Render manager must be set");
 
 	for (int i = 0; i < GLRenderManager::MAX_INFLIGHT_FRAMES; i++) {
 		frameData_[i].pushVertex = render_->CreatePushBuffer(i, GL_ARRAY_BUFFER, 1024 * 1024);
@@ -416,7 +416,7 @@ void DrawEngineGLES::DoFlush() {
 					}
 
 					if (vai->vbo == nullptr) {
-						_dbg_assert_msg_(G3D, gstate_c.vertBounds.minV >= gstate_c.vertBounds.maxV, "Should not have checked UVs when caching.");
+						_dbg_assert_msg_(gstate_c.vertBounds.minV >= gstate_c.vertBounds.maxV, "Should not have checked UVs when caching.");
 
 						// We'll populate the cache this time around, use it next time.
 						populateCache = true;

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -312,7 +312,7 @@ void FramebufferManagerGLES::BindFramebufferAsColorTexture(int stage, VirtualFra
 }
 
 void FramebufferManagerGLES::UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
-	_assert_msg_(G3D, nvfb->fbo, "Expecting a valid nvfb in UpdateDownloadTempBuffer");
+	_assert_msg_(nvfb->fbo, "Expecting a valid nvfb in UpdateDownloadTempBuffer");
 
 	// Discard the previous contents of this buffer where possible.
 	if (gl_extensions.GLES3) {

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -736,10 +736,10 @@ LinkedShader *ShaderManagerGLES::ApplyFragmentShader(VShaderID VSID, Shader *vs,
 	shaderSwitchDirtyUniforms_ = 0;
 
 	if (ls == nullptr) {
-		_dbg_assert_(G3D, FSID.Bit(FS_BIT_LMODE) == VSID.Bit(VS_BIT_LMODE));
-		_dbg_assert_(G3D, FSID.Bit(FS_BIT_DO_TEXTURE) == VSID.Bit(VS_BIT_DO_TEXTURE));
-		_dbg_assert_(G3D, FSID.Bit(FS_BIT_ENABLE_FOG) == VSID.Bit(VS_BIT_ENABLE_FOG));
-		_dbg_assert_(G3D, FSID.Bit(FS_BIT_FLATSHADE) == VSID.Bit(VS_BIT_FLATSHADE));
+		_dbg_assert_(FSID.Bit(FS_BIT_LMODE) == VSID.Bit(VS_BIT_LMODE));
+		_dbg_assert_(FSID.Bit(FS_BIT_DO_TEXTURE) == VSID.Bit(VS_BIT_DO_TEXTURE));
+		_dbg_assert_(FSID.Bit(FS_BIT_ENABLE_FOG) == VSID.Bit(VS_BIT_ENABLE_FOG));
+		_dbg_assert_(FSID.Bit(FS_BIT_FLATSHADE) == VSID.Bit(VS_BIT_FLATSHADE));
 
 		// Check if we can link these.
 		ls = new LinkedShader(render_, VSID, vs, FSID, fs, vs->UseHWTransform());

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2541,7 +2541,7 @@ std::vector<DisplayList> GPUCommon::ActiveDisplayLists() {
 
 void GPUCommon::ResetListPC(int listID, u32 pc) {
 	if (listID < 0 || listID >= DisplayListMaxCount) {
-		_dbg_assert_msg_(G3D, false, "listID out of range: %d", listID);
+		_dbg_assert_msg_(false, "listID out of range: %d", listID);
 		return;
 	}
 
@@ -2550,7 +2550,7 @@ void GPUCommon::ResetListPC(int listID, u32 pc) {
 
 void GPUCommon::ResetListStall(int listID, u32 stall) {
 	if (listID < 0 || listID >= DisplayListMaxCount) {
-		_dbg_assert_msg_(G3D, false, "listID out of range: %d", listID);
+		_dbg_assert_msg_(false, "listID out of range: %d", listID);
 		return;
 	}
 
@@ -2559,7 +2559,7 @@ void GPUCommon::ResetListStall(int listID, u32 stall) {
 
 void GPUCommon::ResetListState(int listID, DisplayListState state) {
 	if (listID < 0 || listID >= DisplayListMaxCount) {
-		_dbg_assert_msg_(G3D, false, "listID out of range: %d", listID);
+		_dbg_assert_msg_(false, "listID out of range: %d", listID);
 		return;
 	}
 

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -268,7 +268,7 @@ static inline u32 GetPixelColor(int x, int y)
 		return fb.Get32(x, y, gstate.FrameBufStride());
 
 	case GE_FORMAT_INVALID:
-		_dbg_assert_msg_(G3D, false, "Software: invalid framebuf format.");
+		_dbg_assert_msg_(false, "Software: invalid framebuf format.");
 	}
 	return 0;
 }
@@ -293,7 +293,7 @@ static inline void SetPixelColor(int x, int y, u32 value)
 		break;
 
 	case GE_FORMAT_INVALID:
-		_dbg_assert_msg_(G3D, false, "Software: invalid framebuf format.");
+		_dbg_assert_msg_(false, "Software: invalid framebuf format.");
 	}
 }
 
@@ -1498,7 +1498,7 @@ void ClearRectangle(const VertexData &v0, const VertexData &v1)
 		break;
 
 	case GE_FORMAT_INVALID:
-		_dbg_assert_msg_(G3D, false, "Software: invalid framebuf format.");
+		_dbg_assert_msg_(false, "Software: invalid framebuf format.");
 		break;
 	}
 

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -97,7 +97,7 @@ alignas(16) static const float by256[4] = { 1.0f / 256.0f, 1.0f / 256.0f, 1.0f /
 alignas(16) static const float ones[4] = { 1.0f, 1.0f, 1.0f, 1.0f, };
 
 LinearFunc SamplerJitCache::CompileLinear(const SamplerID &id) {
-	_assert_msg_(G3D, id.linear, "Linear should be set on sampler id");
+	_assert_msg_(id.linear, "Linear should be set on sampler id");
 	BeginWrite();
 
 	// We'll first write the nearest sampler, which we will CALL.

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -54,7 +54,7 @@ void SoftwareDrawEngine::DispatchFlush() {
 }
 
 void SoftwareDrawEngine::DispatchSubmitPrim(void *verts, void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead) {
-	_assert_msg_(G3D, cullMode == gstate.getCullMode(), "Mixed cull mode not supported.");
+	_assert_msg_(cullMode == gstate.getCullMode(), "Mixed cull mode not supported.");
 	transformUnit.SubmitPrimitive(verts, inds, prim, vertexCount, vertTypeID, bytesRead, this);
 }
 
@@ -398,7 +398,7 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 					break;
 
 				default:
-					_dbg_assert_msg_(G3D, false, "Unexpected prim type: %d", prim_type);
+					_dbg_assert_msg_(false, "Unexpected prim type: %d", prim_type);
 				}
 			}
 			break;

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -393,9 +393,9 @@ VkDescriptorSet DrawEngineVulkan::GetOrCreateDescriptorSet(VkImageView imageView
 	key.base_ = base;
 	key.light_ = light;
 	key.bone_ = bone;
-	_dbg_assert_(G3D, base != VK_NULL_HANDLE);
-	_dbg_assert_(G3D, light != VK_NULL_HANDLE);
-	_dbg_assert_(G3D, bone != VK_NULL_HANDLE);
+	_dbg_assert_(base != VK_NULL_HANDLE);
+	_dbg_assert_(light != VK_NULL_HANDLE);
+	_dbg_assert_(bone != VK_NULL_HANDLE);
 
 	FrameData &frame = frame_[vulkan_->GetCurFrame()];
 	// See if we already have this descriptor set cached.
@@ -425,14 +425,14 @@ VkDescriptorSet DrawEngineVulkan::GetOrCreateDescriptorSet(VkImageView imageView
 		// so let's do that. See https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkAllocateDescriptorSets.html
 		// Fragmentation shouldn't really happen though since we wipe the pool every frame..
 		VkResult res = RecreateDescriptorPool(frame, frame.descPoolSize);
-		_assert_msg_(G3D, res == VK_SUCCESS, "Ran out of descriptor space (frag?) and failed to recreate a descriptor pool. sz=%d res=%d", (int)frame.descSets.size(), (int)res);
+		_assert_msg_(res == VK_SUCCESS, "Ran out of descriptor space (frag?) and failed to recreate a descriptor pool. sz=%d res=%d", (int)frame.descSets.size(), (int)res);
 		descAlloc.descriptorPool = frame.descPool;  // Need to update this pointer since we have allocated a new one.
 		result = vkAllocateDescriptorSets(vulkan_->GetDevice(), &descAlloc, &desc);
-		_assert_msg_(G3D, result == VK_SUCCESS, "Ran out of descriptor space (frag?) and failed to allocate after recreating a descriptor pool. res=%d", (int)result);
+		_assert_msg_(result == VK_SUCCESS, "Ran out of descriptor space (frag?) and failed to allocate after recreating a descriptor pool. res=%d", (int)result);
 	}
 
 	// Even in release mode, this is bad.
-	_assert_msg_(G3D, result == VK_SUCCESS, "Ran out of descriptor space in pool. sz=%d res=%d", (int)frame.descSets.size(), (int)result);
+	_assert_msg_(result == VK_SUCCESS, "Ran out of descriptor space in pool. sz=%d res=%d", (int)frame.descSets.size(), (int)result);
 
 	// We just don't write to the slots we don't care about, which is fine.
 	VkWriteDescriptorSet writes[7]{};
@@ -713,7 +713,7 @@ void DrawEngineVulkan::DoFlush() {
 				if (!vai->vb) {
 					// Directly push to the vertex cache.
 					DecodeVertsToPushBuffer(vertexCache_, &vai->vbOffset, &vai->vb);
-					_dbg_assert_msg_(G3D, gstate_c.vertBounds.minV >= gstate_c.vertBounds.maxV, "Should not have checked UVs when caching.");
+					_dbg_assert_msg_(gstate_c.vertBounds.minV >= gstate_c.vertBounds.maxV, "Should not have checked UVs when caching.");
 					vai->numVerts = indexGen.VertexCount();
 					vai->prim = indexGen.Prim();
 					vai->maxIndex = indexGen.MaxIndex();
@@ -823,7 +823,7 @@ void DrawEngineVulkan::DoFlush() {
 			}
 
 			shaderManager_->GetShaders(prim, lastVType_, &vshader, &fshader, true, useHWTessellation_);  // usehwtransform
-			_dbg_assert_msg_(G3D, vshader->UseHWTransform(), "Bad vshader");
+			_dbg_assert_msg_(vshader->UseHWTransform(), "Bad vshader");
 
 			Draw::NativeObject object = framebufferManager_->UseBufferedRendering() ? Draw::NativeObject::FRAMEBUFFER_RENDERPASS : Draw::NativeObject::BACKBUFFER_RENDERPASS;
 			VkRenderPass renderPass = (VkRenderPass)draw_->GetNativeObject(object);
@@ -946,7 +946,7 @@ void DrawEngineVulkan::DoFlush() {
 			}
 			if (!lastPipeline_ || gstate_c.IsDirty(DIRTY_BLEND_STATE | DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_RASTER_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_VERTEXSHADER_STATE | DIRTY_FRAGMENTSHADER_STATE) || prim != lastPrim_) {
 				shaderManager_->GetShaders(prim, lastVType_, &vshader, &fshader, false, false);  // usehwtransform
-				_dbg_assert_msg_(G3D, !vshader->UseHWTransform(), "Bad vshader");
+				_dbg_assert_msg_(!vshader->UseHWTransform(), "Bad vshader");
 				if (prim != lastPrim_ || gstate_c.IsDirty(DIRTY_BLEND_STATE | DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_RASTER_STATE | DIRTY_DEPTHSTENCIL_STATE)) {
 					ConvertStateToVulkanKey(*framebufferManager_, shaderManager_, prim, pipelineKey_, dynState_);
 				}

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -307,7 +307,7 @@ static VulkanPipeline *CreateVulkanPipeline(VkDevice device, VkPipelineCache pip
 			// Bad return value seen on Adreno in Burnout :(  Try to ignore?
 			// TODO: Log all the information we can here!
 		} else {
-			_dbg_assert_msg_(G3D, false, "Failed creating graphics pipeline! result='%s'", VulkanResultToString(result));
+			_dbg_assert_msg_(false, "Failed creating graphics pipeline! result='%s'", VulkanResultToString(result));
 		}
 		ERROR_LOG(G3D, "Failed creating graphics pipeline! result='%s'", VulkanResultToString(result));
 		// Create a placeholder to avoid creating over and over if something is broken.
@@ -335,7 +335,7 @@ VulkanPipeline *PipelineManagerVulkan::GetOrCreatePipeline(VkPipelineLayout layo
 	}
 
 	VulkanPipelineKey key{};
-	_assert_msg_(G3D, renderPass, "Can't create a pipeline with a null renderpass");
+	_assert_msg_(renderPass, "Can't create a pipeline with a null renderpass");
 
 	key.raster = rasterKey;
 	key.renderPass = renderPass;

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -245,16 +245,16 @@ void ShaderManagerVulkan::GetShaders(int prim, u32 vertType, VulkanVertexShader 
 		FSID = lastFSID_;
 	}
 
-	_dbg_assert_(G3D, FSID.Bit(FS_BIT_LMODE) == VSID.Bit(VS_BIT_LMODE));
-	_dbg_assert_(G3D, FSID.Bit(FS_BIT_DO_TEXTURE) == VSID.Bit(VS_BIT_DO_TEXTURE));
-	_dbg_assert_(G3D, FSID.Bit(FS_BIT_ENABLE_FOG) == VSID.Bit(VS_BIT_ENABLE_FOG));
-	_dbg_assert_(G3D, FSID.Bit(FS_BIT_FLATSHADE) == VSID.Bit(VS_BIT_FLATSHADE));
+	_dbg_assert_(FSID.Bit(FS_BIT_LMODE) == VSID.Bit(VS_BIT_LMODE));
+	_dbg_assert_(FSID.Bit(FS_BIT_DO_TEXTURE) == VSID.Bit(VS_BIT_DO_TEXTURE));
+	_dbg_assert_(FSID.Bit(FS_BIT_ENABLE_FOG) == VSID.Bit(VS_BIT_ENABLE_FOG));
+	_dbg_assert_(FSID.Bit(FS_BIT_FLATSHADE) == VSID.Bit(VS_BIT_FLATSHADE));
 
 	// Just update uniforms if this is the same shader as last time.
 	if (lastVShader_ != nullptr && lastFShader_ != nullptr && VSID == lastVSID_ && FSID == lastFSID_) {
 		*vshader = lastVShader_;
 		*fshader = lastFShader_;
-		_dbg_assert_msg_(G3D, (*vshader)->UseHWTransform() == useHWTransform, "Bad vshader was cached");
+		_dbg_assert_msg_((*vshader)->UseHWTransform() == useHWTransform, "Bad vshader was cached");
 		// Already all set, no need to look up in shader maps.
 		return;
 	}
@@ -284,7 +284,7 @@ void ShaderManagerVulkan::GetShaders(int prim, u32 vertType, VulkanVertexShader 
 
 	*vshader = vs;
 	*fshader = fs;
-	_dbg_assert_msg_(G3D, (*vshader)->UseHWTransform() == useHWTransform, "Bad vshader was computed");
+	_dbg_assert_msg_((*vshader)->UseHWTransform() == useHWTransform, "Bad vshader was computed");
 }
 
 std::vector<std::string> ShaderManagerVulkan::DebugGetShaderIDs(DebugShaderType type) {

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -654,9 +654,9 @@ void TextureCacheVulkan::DeviceRestore(VulkanContext *vulkan, Draw::DrawContext 
 
 	if (g_Config.bTexHardwareScaling) {
 		uploadCS_ = CompileShaderModule(vulkan_, VK_SHADER_STAGE_COMPUTE_BIT, fullUploadShader.c_str(), &error);
-		_dbg_assert_msg_(G3D, uploadCS_ != VK_NULL_HANDLE, "failed to compile upload shader");
+		_dbg_assert_msg_(uploadCS_ != VK_NULL_HANDLE, "failed to compile upload shader");
 		copyCS_ = CompileShaderModule(vulkan_, VK_SHADER_STAGE_COMPUTE_BIT, fullCopyShader.c_str(), &error);
-		_dbg_assert_msg_(G3D, copyCS_!= VK_NULL_HANDLE, "failed to compile copy shader");
+		_dbg_assert_msg_(copyCS_!= VK_NULL_HANDLE, "failed to compile copy shader");
 	}
 
 	computeShaderManager_.DeviceRestore(vulkan);

--- a/Qt/QtMain.h
+++ b/Qt/QtMain.h
@@ -55,7 +55,7 @@ public:
 		renderManager_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 		renderManager_->SetInflightFrames(g_Config.iInflightFrames);
 		bool success = draw_->CreatePresets();
-		_assert_msg_(G3D, success, "Failed to compile preset shaders");
+		_assert_msg_(success, "Failed to compile preset shaders");
 
 		// TODO: Need to figure out how to implement SetSwapInterval for Qt.
 	}

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -808,7 +808,7 @@ void RenderOverlays(UIContext *dc, void *userdata);
 
 bool NativeInitGraphics(GraphicsContext *graphicsContext) {
 	ILOG("NativeInitGraphics");
-	_assert_msg_(G3D, graphicsContext, "No graphics context!");
+	_assert_msg_(graphicsContext, "No graphics context!");
 
 	// We set this now so any resize during init is processed later.
 	resized = false;
@@ -816,8 +816,8 @@ bool NativeInitGraphics(GraphicsContext *graphicsContext) {
 	using namespace Draw;
 	Core_SetGraphicsContext(graphicsContext);
 	g_draw = graphicsContext->GetDrawContext();
-	_assert_msg_(G3D, g_draw, "No draw context available!");
-	_assert_msg_(G3D, g_draw->GetVshaderPreset(VS_COLOR_2D) != nullptr, "Failed to compile presets");
+	_assert_msg_(g_draw, "No draw context available!");
+	_assert_msg_(g_draw->GetVshaderPreset(VS_COLOR_2D) != nullptr, "Failed to compile presets");
 
 	// Load the atlas.
 
@@ -825,7 +825,7 @@ bool NativeInitGraphics(GraphicsContext *graphicsContext) {
 	if (!g_ui_atlas.IsMetadataLoaded()) {
 		const uint8_t *atlas_data = VFSReadFile("ui_atlas.meta", &atlas_data_size);
 		bool load_success = atlas_data != nullptr && g_ui_atlas.Load(atlas_data, atlas_data_size);
-		_assert_msg_(G3D, load_success, "Failed to load ui_atlas.meta");
+		_assert_msg_(load_success, "Failed to load ui_atlas.meta");
 		delete[] atlas_data;
 	}
 	ui_draw2d.SetAtlas(&g_ui_atlas);

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -280,7 +280,7 @@ void CGEDebugger::DescribePrimaryPreview(const GPUgstate &state, wchar_t desc[25
 		return;
 	}
 
-	_assert_msg_(G3D, primaryBuffer_ != nullptr, "Must have a valid primaryBuffer_");
+	_assert_msg_(primaryBuffer_ != nullptr, "Must have a valid primaryBuffer_");
 
 	switch (PrimaryDisplayType(fbTabs->CurrentTabIndex())) {
 	case PRIMARY_FRAMEBUF:

--- a/Windows/GEDebugger/SimpleGLWindow.cpp
+++ b/Windows/GEDebugger/SimpleGLWindow.cpp
@@ -296,7 +296,7 @@ void SimpleGLWindow::Draw(const u8 *data, int w, int h, bool flipped, Format fmt
 			glfmt = GL_UNSIGNED_BYTE;
 			components = GL_RED;
 		} else {
-			_dbg_assert_msg_(COMMON, false, "Invalid SimpleGLWindow format.");
+			_dbg_assert_msg_(false, "Invalid SimpleGLWindow format.");
 		}
 	}
 

--- a/Windows/GPU/D3D11Context.cpp
+++ b/Windows/GPU/D3D11Context.cpp
@@ -187,7 +187,7 @@ bool D3D11Context::Init(HINSTANCE hInst, HWND wnd, std::string *error_message) {
 	draw_ = Draw::T3DCreateD3D11Context(device_, context_, device1_, context1_, featureLevel_, hWnd_, adapterNames);
 	SetGPUBackend(GPUBackend::DIRECT3D11, chosenAdapterName);
 	bool success = draw_->CreatePresets();  // If we can run D3D11, there's a compiler installed. I think.
-	_assert_msg_(G3D, success, "Failed to compile preset shaders");
+	_assert_msg_(success, "Failed to compile preset shaders");
 
 	int width;
 	int height;

--- a/Windows/GPU/D3D9Context.cpp
+++ b/Windows/GPU/D3D9Context.cpp
@@ -218,7 +218,7 @@ void D3D9Context::Resize() {
 		HRESULT hr = device_->Reset(&presentParams_);
 		if (FAILED(hr)) {
 			// Had to remove DXGetErrorStringA calls here because dxerr.lib is deprecated and will not link with VS 2015.
-			PanicAlert("Unable to reset D3D9 device");
+			_assert_msg_(false, "Unable to reset D3D9 device");
 		}
 		draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, 0, 0, nullptr);
 	}

--- a/Windows/GPU/WindowsGLContext.cpp
+++ b/Windows/GPU/WindowsGLContext.cpp
@@ -409,7 +409,7 @@ bool WindowsGLContext::InitFromRenderThread(std::string *error_message) {
 	renderManager_->SetInflightFrames(g_Config.iInflightFrames);
 	SetGPUBackend(GPUBackend::OPENGL);
 	bool success = draw_->CreatePresets();  // if we get this far, there will always be a GLSL compiler capable of compiling these.
-	_assert_msg_(G3D, success, "Failed to compile preset shaders");
+	_assert_msg_(success, "Failed to compile preset shaders");
 	renderManager_->SetSwapFunction([&]() {::SwapBuffers(hDC); });
 	if (wglSwapIntervalEXT) {
 		// glew loads wglSwapIntervalEXT if available

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -138,7 +138,7 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 	draw_ = Draw::T3DCreateVulkanContext(vulkan_, splitSubmit);
 	SetGPUBackend(GPUBackend::VULKAN, vulkan_->GetPhysicalDeviceProperties(deviceNum).properties.deviceName);
 	bool success = draw_->CreatePresets();
-	_assert_msg_(G3D, success, "Failed to compile preset shaders");
+	_assert_msg_(success, "Failed to compile preset shaders");
 	draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
 
 	renderManager_ = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);

--- a/android/jni/AndroidEGLContext.cpp
+++ b/android/jni/AndroidEGLContext.cpp
@@ -53,7 +53,7 @@ bool AndroidEGLGraphicsContext::InitFromRenderThread(ANativeWindow *wnd, int des
 	renderManager_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 	renderManager_->SetInflightFrames(g_Config.iInflightFrames);
 	bool success = draw_->CreatePresets();  // There will always be a GLSL compiler capable of compiling these.
-	_assert_msg_(G3D, success, "Failed to compile preset shaders");
+	_assert_msg_(success, "Failed to compile preset shaders");
 	return true;
 }
 

--- a/android/jni/AndroidJavaGLContext.cpp
+++ b/android/jni/AndroidJavaGLContext.cpp
@@ -21,7 +21,7 @@ bool AndroidJavaEGLGraphicsContext::InitFromRenderThread(ANativeWindow *wnd, int
 	renderManager_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 	renderManager_->SetInflightFrames(g_Config.iInflightFrames);
 	bool success = draw_->CreatePresets();
-	_assert_msg_(G3D, success, "Failed to compile preset shaders");
+	_assert_msg_(success, "Failed to compile preset shaders");
 	return success;
 }
 

--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -104,7 +104,7 @@ bool AndroidVulkanContext::InitFromRenderThread(ANativeWindow *wnd, int desiredB
 		draw_ = Draw::T3DCreateVulkanContext(g_Vulkan, g_Config.bGfxDebugSplitSubmit);
 		SetGPUBackend(GPUBackend::VULKAN);
 		success = draw_->CreatePresets();  // Doesn't fail, we ship the compiler.
-		_assert_msg_(G3D, success, "Failed to compile preset shaders");
+		_assert_msg_(success, "Failed to compile preset shaders");
 		draw_->HandleEvent(Draw::Event::GOT_BACKBUFFER, g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
 
 		VulkanRenderManager *renderManager = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);

--- a/ext/native/thin3d/GLQueueRunner.cpp
+++ b/ext/native/thin3d/GLQueueRunner.cpp
@@ -180,10 +180,10 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps, bool ski
 			CHECK_GL_ERROR_IF_DEBUG();
 			GLRProgram *program = step.create_program.program;
 			program->program = glCreateProgram();
-			_assert_msg_(G3D, step.create_program.num_shaders > 0, "Can't create a program with zero shaders");
+			_assert_msg_(step.create_program.num_shaders > 0, "Can't create a program with zero shaders");
 			bool anyFailed = false;
 			for (int j = 0; j < step.create_program.num_shaders; j++) {
-				_dbg_assert_msg_(G3D, step.create_program.shaders[j]->shader, "Can't create a program with a null shader");
+				_dbg_assert_msg_(step.create_program.shaders[j]->shader, "Can't create a program with a null shader");
 				anyFailed = anyFailed || step.create_program.shaders[j]->failed;
 				glAttachShader(program->program, step.create_program.shaders[j]->shader);
 			}
@@ -1310,7 +1310,7 @@ void GLQueueRunner::PerformCopy(const GLRStep &step) {
 		break;
 	case GL_DEPTH_BUFFER_BIT:
 		// TODO: Support depth copies.
-		_assert_msg_(G3D, false, "Depth copies not yet supported - soon");
+		_assert_msg_(false, "Depth copies not yet supported - soon");
 		target = GL_RENDERBUFFER;
 		/*
 		srcTex = src->depth.texture;
@@ -1319,8 +1319,8 @@ void GLQueueRunner::PerformCopy(const GLRStep &step) {
 		break;
 	}
 
-	_dbg_assert_(G3D, srcTex);
-	_dbg_assert_(G3D, dstTex);
+	_dbg_assert_(srcTex);
+	_dbg_assert_(dstTex);
 
 #if defined(USING_GLES2)
 #ifndef IOS

--- a/ext/native/thin3d/GLRenderManager.cpp
+++ b/ext/native/thin3d/GLRenderManager.cpp
@@ -320,7 +320,7 @@ void GLRenderManager::BindFramebufferAsRenderTarget(GLRFramebuffer *fb, GLRRende
 }
 
 void GLRenderManager::BindFramebufferAsTexture(GLRFramebuffer *fb, int binding, int aspectBit, int attachment) {
-	_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+	_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 	GLRRenderData data{ GLRRenderCommand::BIND_FB_TEXTURE };
 	data.bind_fb_texture.slot = binding;
 	data.bind_fb_texture.framebuffer = fb;
@@ -675,7 +675,7 @@ void GLPushBuffer::Unmap() {
 
 void GLPushBuffer::Flush() {
 	// Must be called from the render thread.
-	_dbg_assert_(G3D, OnRenderThread());
+	_dbg_assert_(OnRenderThread());
 
 	buffers_[buf_].flushOffset = offset_;
 	if (!buffers_[buf_].deviceMemory && writePtr_) {
@@ -760,7 +760,7 @@ void GLPushBuffer::NextBuffer(size_t minSize) {
 }
 
 void GLPushBuffer::Defragment() {
-	_dbg_assert_msg_(G3D, !OnRenderThread(), "Defragment must not run on the render thread");
+	_dbg_assert_msg_(!OnRenderThread(), "Defragment must not run on the render thread");
 
 	if (buffers_.size() <= 1) {
 		// Let's take this chance to jetison localMemory we don't need.
@@ -780,7 +780,7 @@ void GLPushBuffer::Defragment() {
 
 	size_ = newSize;
 	bool res = AddBuffer();
-	_assert_msg_(G3D, res, "AddBuffer failed");
+	_assert_msg_(res, "AddBuffer failed");
 }
 
 size_t GLPushBuffer::GetTotalSize() const {
@@ -792,7 +792,7 @@ size_t GLPushBuffer::GetTotalSize() const {
 }
 
 void GLPushBuffer::MapDevice(GLBufferStrategy strategy) {
-	_dbg_assert_msg_(G3D, OnRenderThread(), "MapDevice must run on render thread");
+	_dbg_assert_msg_(OnRenderThread(), "MapDevice must run on render thread");
 
 	strategy_ = strategy;
 	if (strategy_ == GLBufferStrategy::SUBDATA) {
@@ -815,7 +815,7 @@ void GLPushBuffer::MapDevice(GLBufferStrategy strategy) {
 			mapChanged = true;
 		}
 
-		_dbg_assert_msg_(G3D, info.localMemory || info.deviceMemory, "Local or device memory must succeed");
+		_dbg_assert_msg_(info.localMemory || info.deviceMemory, "Local or device memory must succeed");
 	}
 
 	if (writePtr_ && mapChanged) {
@@ -826,7 +826,7 @@ void GLPushBuffer::MapDevice(GLBufferStrategy strategy) {
 }
 
 void GLPushBuffer::UnmapDevice() {
-	_dbg_assert_msg_(G3D, OnRenderThread(), "UnmapDevice must run on render thread");
+	_dbg_assert_msg_(OnRenderThread(), "UnmapDevice must run on render thread");
 
 	for (auto &info : buffers_) {
 		if (info.deviceMemory) {

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -325,7 +325,7 @@ public:
 	}
 
 	void Take(GLDeleter &other) {
-		_assert_msg_(G3D, IsEmpty(), "Deleter already has stuff");
+		_assert_msg_(IsEmpty(), "Deleter already has stuff");
 		shaders = std::move(other.shaders);
 		programs = std::move(other.programs);
 		buffers = std::move(other.buffers);
@@ -437,7 +437,7 @@ public:
 		step.create_program.program->queries_ = queries;
 		step.create_program.program->initialize_ = initalizers;
 		step.create_program.support_dual_source = supportDualSource;
-		_assert_msg_(G3D, shaders.size() > 0, "Can't create a program with zero shaders");
+		_assert_msg_(shaders.size() > 0, "Can't create a program with zero shaders");
 		for (size_t i = 0; i < shaders.size(); i++) {
 			step.create_program.shaders[i] = shaders[i];
 		}
@@ -531,8 +531,8 @@ public:
 		// TODO: Maybe should be a render command instead of an init command? When possible it's better as
 		// an init command, that's for sure.
 		GLRInitStep step{ GLRInitStepType::BUFFER_SUBDATA };
-		_dbg_assert_(G3D, offset >= 0);
-		_dbg_assert_(G3D, offset <= buffer->size_ - size);
+		_dbg_assert_(offset >= 0);
+		_dbg_assert_(offset <= buffer->size_ - size);
 		step.buffer_subdata.buffer = buffer;
 		step.buffer_subdata.offset = (int)offset;
 		step.buffer_subdata.size = (int)size;
@@ -556,7 +556,7 @@ public:
 	}
 
 	void TextureSubImage(GLRTexture *texture, int level, int x, int y, int width, int height, Draw::DataFormat format, uint8_t *data, GLRAllocType allocType = GLRAllocType::NEW) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData _data{ GLRRenderCommand::TEXTURE_SUBIMAGE };
 		_data.texture_subimage.texture = texture;
 		_data.texture_subimage.data = data;
@@ -579,18 +579,18 @@ public:
 	}
 
 	void BindTexture(int slot, GLRTexture *tex) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::BINDTEXTURE };
-		_dbg_assert_(G3D, slot < 16);
+		_dbg_assert_(slot < 16);
 		data.texture.slot = slot;
 		data.texture.texture = tex;
 		curRenderStep_->commands.push_back(data);
 	}
 
 	void BindProgram(GLRProgram *program) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::BINDPROGRAM };
-		_dbg_assert_(G3D, program != nullptr);
+		_dbg_assert_(program != nullptr);
 		data.program.program = program;
 		curRenderStep_->commands.push_back(data);
 #ifdef _DEBUG
@@ -599,7 +599,7 @@ public:
 	}
 
 	void BindPixelPackBuffer(GLRBuffer *buffer) {  // Want to support an offset but can't in ES 2.0. We supply an offset when binding the buffers instead.
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::BIND_BUFFER };
 		data.bind_buffer.buffer = buffer;
 		data.bind_buffer.target = GL_PIXEL_PACK_BUFFER;
@@ -607,7 +607,7 @@ public:
 	}
 
 	void BindIndexBuffer(GLRBuffer *buffer) {  // Want to support an offset but can't in ES 2.0. We supply an offset when binding the buffers instead.
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::BIND_BUFFER};
 		data.bind_buffer.buffer = buffer;
 		data.bind_buffer.target = GL_ELEMENT_ARRAY_BUFFER;
@@ -615,7 +615,7 @@ public:
 	}
 
 	void BindVertexBuffer(GLRInputLayout *inputLayout, GLRBuffer *buffer, size_t offset) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		assert(inputLayout);
 		GLRRenderData data{ GLRRenderCommand::BIND_VERTEX_BUFFER };
 		data.bindVertexBuffer.inputLayout = inputLayout;
@@ -625,7 +625,7 @@ public:
 	}
 
 	void SetDepth(bool enabled, bool write, GLenum func) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::DEPTH };
 		data.depth.enabled = enabled;
 		data.depth.write = write;
@@ -634,21 +634,21 @@ public:
 	}
 
 	void SetViewport(const GLRViewport &vp) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::VIEWPORT };
 		data.viewport.vp = vp;
 		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetScissor(const GLRect2D &rc) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::SCISSOR };
 		data.scissor.rc = rc;
 		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetUniformI(const GLint *loc, int count, const int *udata) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 #ifdef _DEBUG
 		assert(curProgram_);
 #endif
@@ -660,7 +660,7 @@ public:
 	}
 
 	void SetUniformI1(const GLint *loc, int udata) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 #ifdef _DEBUG
 		assert(curProgram_);
 #endif
@@ -672,7 +672,7 @@ public:
 	}
 
 	void SetUniformF(const GLint *loc, int count, const float *udata) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 #ifdef _DEBUG
 		assert(curProgram_);
 #endif
@@ -684,7 +684,7 @@ public:
 	}
 
 	void SetUniformF1(const GLint *loc, const float udata) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 #ifdef _DEBUG
 		assert(curProgram_);
 #endif
@@ -696,7 +696,7 @@ public:
 	}
 
 	void SetUniformF(const char *name, int count, const float *udata) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 #ifdef _DEBUG
 		assert(curProgram_);
 #endif
@@ -708,7 +708,7 @@ public:
 	}
 
 	void SetUniformM4x4(const GLint *loc, const float *udata) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 #ifdef _DEBUG
 		assert(curProgram_);
 #endif
@@ -719,7 +719,7 @@ public:
 	}
 
 	void SetUniformM4x4(const char *name, const float *udata) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 #ifdef _DEBUG
 		assert(curProgram_);
 #endif
@@ -730,7 +730,7 @@ public:
 	}
 
 	void SetBlendAndMask(int colorMask, bool blendEnabled, GLenum srcColor, GLenum dstColor, GLenum srcAlpha, GLenum dstAlpha, GLenum funcColor, GLenum funcAlpha) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::BLEND };
 		data.blend.mask = colorMask;
 		data.blend.enabled = blendEnabled;
@@ -744,7 +744,7 @@ public:
 	}
 
 	void SetNoBlendAndMask(int colorMask) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::BLEND };
 		data.blend.mask = colorMask;
 		data.blend.enabled = false;
@@ -753,7 +753,7 @@ public:
 
 #ifndef USING_GLES2
 	void SetLogicOp(bool enabled, GLenum logicOp) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::LOGICOP };
 		data.logic.enabled = enabled;
 		data.logic.logicOp = logicOp;
@@ -762,7 +762,7 @@ public:
 #endif
 
 	void SetStencilFunc(bool enabled, GLenum func, uint8_t refValue, uint8_t compareMask) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::STENCILFUNC };
 		data.stencilFunc.enabled = enabled;
 		data.stencilFunc.func = func;
@@ -772,7 +772,7 @@ public:
 	}
 
 	void SetStencilOp(uint8_t writeMask, GLenum sFail, GLenum zFail, GLenum pass) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::STENCILOP };
 		data.stencilOp.writeMask = writeMask;
 		data.stencilOp.sFail = sFail;
@@ -782,7 +782,7 @@ public:
 	}
 
 	void SetStencilDisabled() {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data;
 		data.cmd = GLRRenderCommand::STENCILFUNC;
 		data.stencilFunc.enabled = false;
@@ -790,14 +790,14 @@ public:
 	}
 
 	void SetBlendFactor(const float color[4]) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::BLENDCOLOR };
 		CopyFloat4(data.blendColor.color, color);
 		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetRaster(GLboolean cullEnable, GLenum frontFace, GLenum cullFace, GLboolean ditherEnable) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::RASTER };
 		data.raster.cullEnable = cullEnable;
 		data.raster.frontFace = frontFace;
@@ -808,7 +808,7 @@ public:
 	
 	// Modifies the current texture as per GL specs, not global state.
 	void SetTextureSampler(int slot, GLenum wrapS, GLenum wrapT, GLenum magFilter, GLenum minFilter, float anisotropy) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::TEXTURESAMPLER };
 		data.textureSampler.slot = slot;
 		data.textureSampler.wrapS = wrapS;
@@ -820,7 +820,7 @@ public:
 	}
 
 	void SetTextureLod(int slot, float minLod, float maxLod, float lodBias) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::TEXTURELOD};
 		data.textureLod.slot = slot;
 		data.textureLod.minLod = minLod;
@@ -831,7 +831,7 @@ public:
 
 	// If scissorW == 0, no scissor is applied (the whole render target is cleared).
 	void Clear(uint32_t clearColor, float clearZ, int clearStencil, int clearMask, int colorMask, int scissorX, int scissorY, int scissorW, int scissorH) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		if (!clearMask)
 			return;
 		GLRRenderData data{ GLRRenderCommand::CLEAR };
@@ -848,14 +848,14 @@ public:
 	}
 
 	void Invalidate(int invalidateMask) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::INVALIDATE };
 		data.clear.clearMask = invalidateMask;
 		curRenderStep_->commands.push_back(data);
 	}
 
 	void Draw(GLenum mode, int first, int count) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::DRAW };
 		data.draw.mode = mode;
 		data.draw.first = first;
@@ -866,7 +866,7 @@ public:
 	}
 
 	void DrawIndexed(GLenum mode, int count, GLenum indexType, void *indices, int instances = 1) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::DRAW_INDEXED };
 		data.drawIndexed.mode = mode;
 		data.drawIndexed.count = count;

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -289,7 +289,7 @@ VkRenderPass VulkanQueueRunner::GetRenderPass(const RPKey &key) {
 		deps[numDeps].srcStageMask |= VK_PIPELINE_STAGE_TRANSFER_BIT;
 		break;
 	default:
-		_dbg_assert_msg_(G3D, false, "GetRenderPass: Unexpected color layout %d", (int)key.prevColorLayout);
+		_dbg_assert_msg_(false, "GetRenderPass: Unexpected color layout %d", (int)key.prevColorLayout);
 		break;
 	}
 
@@ -313,7 +313,7 @@ VkRenderPass VulkanQueueRunner::GetRenderPass(const RPKey &key) {
 		deps[numDeps].srcStageMask |= VK_PIPELINE_STAGE_TRANSFER_BIT;
 		break;
 	default:
-		_dbg_assert_msg_(G3D, false, "PerformBindRT: Unexpected depth layout %d", (int)key.prevDepthLayout);
+		_dbg_assert_msg_(false, "PerformBindRT: Unexpected depth layout %d", (int)key.prevDepthLayout);
 		break;
 	}
 
@@ -346,7 +346,7 @@ VkRenderPass VulkanQueueRunner::GetRenderPass(const RPKey &key) {
 		// Nothing to do.
 		break;
 	default:
-		_dbg_assert_msg_(G3D, false, "GetRenderPass: Unexpected final color layout %d", (int)key.finalColorLayout);
+		_dbg_assert_msg_(false, "GetRenderPass: Unexpected final color layout %d", (int)key.finalColorLayout);
 		break;
 	}
 
@@ -976,7 +976,7 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 				srcStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
 				break;
 			default:
-				_assert_msg_(G3D, false, "PerformRenderPass: Unexpected oldLayout: %d", (int)barrier.oldLayout);
+				_assert_msg_(false, "PerformRenderPass: Unexpected oldLayout: %d", (int)barrier.oldLayout);
 				break;
 			}
 			barrier.newLayout = iter.targetLayout;
@@ -986,7 +986,7 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 				dstStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 				break;
 			default:
-				_assert_msg_(G3D, false, "PerformRenderPass: Unexpected newLayout: %d", (int)barrier.newLayout);
+				_assert_msg_(false, "PerformRenderPass: Unexpected newLayout: %d", (int)barrier.newLayout);
 				break;
 			}
 			barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -1081,8 +1081,8 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 				const VkRect2D &rc = c.scissor.scissor;
 				DisplayRect<int> rotated_rc{ rc.offset.x, rc.offset.y, (int)rc.extent.width, (int)rc.extent.height };
 				RotateRectToDisplay(rotated_rc, vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
-				_dbg_assert_(G3D, rotated_rc.x >= 0);
-				_dbg_assert_(G3D, rotated_rc.y >= 0);
+				_dbg_assert_(rotated_rc.x >= 0);
+				_dbg_assert_(rotated_rc.y >= 0);
 				VkRect2D finalRect = VkRect2D{ { rotated_rc.x, rotated_rc.y }, { (uint32_t)rotated_rc.w, (uint32_t)rotated_rc.h} };
 				vkCmdSetScissor(cmd, 0, 1, &finalRect);
 			}
@@ -1185,7 +1185,7 @@ void VulkanQueueRunner::PerformBindFramebufferAsRenderTarget(const VKRStep &step
 	int w;
 	int h;
 	if (step.render.framebuffer) {
-		_dbg_assert_(G3D, step.render.finalColorLayout != VK_IMAGE_LAYOUT_UNDEFINED);
+		_dbg_assert_(step.render.finalColorLayout != VK_IMAGE_LAYOUT_UNDEFINED);
 
 		VKRFramebuffer *fb = step.render.framebuffer;
 		framebuf = fb->framebuf;
@@ -1429,7 +1429,7 @@ void VulkanQueueRunner::SetupTransitionToTransferSrc(VKRImage &img, VkImageMemor
 		stage |= VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 		break;
 	default:
-		_dbg_assert_msg_(G3D, false, "Transition from this layout to transfer src not supported (%d)", (int)img.layout);
+		_dbg_assert_msg_(false, "Transition from this layout to transfer src not supported (%d)", (int)img.layout);
 		break;
 	}
 	barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
@@ -1488,7 +1488,7 @@ void VulkanQueueRunner::SetupTransitionToTransferDst(VKRImage &img, VkImageMemor
 		stage |= VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 		break;
 	default:
-		_dbg_assert_msg_(G3D, false, "Transition from this layout to transfer dst not supported (%d)", (int)img.layout);
+		_dbg_assert_msg_(false, "Transition from this layout to transfer dst not supported (%d)", (int)img.layout);
 		break;
 	}
 	barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
@@ -1553,7 +1553,7 @@ void VulkanQueueRunner::PerformReadback(const VKRStep &step, VkCommandBuffer cmd
 		} else if (step.readback.aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) {
 			srcImage = &step.readback.src->depth;
 		} else {
-			_dbg_assert_msg_(G3D, false, "No image aspect to readback?");
+			_dbg_assert_msg_(false, "No image aspect to readback?");
 			return;
 		}
 

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -841,7 +841,7 @@ static void CleanupRenderCommands(std::vector<VkRenderData> *cmds) {
 }
 
 void VulkanRenderManager::Clear(uint32_t clearColor, float clearZ, int clearStencil, int clearMask) {
-	_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
+	_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
 	if (!clearMask)
 		return;
 	// If this is the first drawing command or clears everything, merge it into the pass.
@@ -868,18 +868,18 @@ void VulkanRenderManager::Clear(uint32_t clearColor, float clearZ, int clearSten
 }
 
 void VulkanRenderManager::CopyFramebuffer(VKRFramebuffer *src, VkRect2D srcRect, VKRFramebuffer *dst, VkOffset2D dstPos, int aspectMask, const char *tag) {
-	_dbg_assert_msg_(G3D, srcRect.offset.x >= 0, "srcrect offset x (%d) < 0", srcRect.offset.x);
-	_dbg_assert_msg_(G3D, srcRect.offset.y >= 0, "srcrect offset y (%d) < 0", srcRect.offset.y);
-	_dbg_assert_msg_(G3D, srcRect.offset.x + srcRect.extent.width <= (uint32_t)src->width, "srcrect offset x (%d) + extent (%d) > width (%d)", srcRect.offset.x, srcRect.extent.width, (uint32_t)src->width);
-	_dbg_assert_msg_(G3D, srcRect.offset.y + srcRect.extent.height <= (uint32_t)src->height, "srcrect offset y (%d) + extent (%d) > height (%d)", srcRect.offset.y, srcRect.extent.height, (uint32_t)src->height);
+	_dbg_assert_msg_(srcRect.offset.x >= 0, "srcrect offset x (%d) < 0", srcRect.offset.x);
+	_dbg_assert_msg_(srcRect.offset.y >= 0, "srcrect offset y (%d) < 0", srcRect.offset.y);
+	_dbg_assert_msg_(srcRect.offset.x + srcRect.extent.width <= (uint32_t)src->width, "srcrect offset x (%d) + extent (%d) > width (%d)", srcRect.offset.x, srcRect.extent.width, (uint32_t)src->width);
+	_dbg_assert_msg_(srcRect.offset.y + srcRect.extent.height <= (uint32_t)src->height, "srcrect offset y (%d) + extent (%d) > height (%d)", srcRect.offset.y, srcRect.extent.height, (uint32_t)src->height);
 
-	_dbg_assert_msg_(G3D, srcRect.extent.width > 0, "copy srcwidth == 0");
-	_dbg_assert_msg_(G3D, srcRect.extent.height > 0, "copy srcheight == 0");
+	_dbg_assert_msg_(srcRect.extent.width > 0, "copy srcwidth == 0");
+	_dbg_assert_msg_(srcRect.extent.height > 0, "copy srcheight == 0");
 
-	_dbg_assert_msg_(G3D, dstPos.x >= 0, "dstPos offset x (%d) < 0", dstPos.x);
-	_dbg_assert_msg_(G3D, dstPos.y >= 0, "dstPos offset y (%d) < 0", dstPos.y);
-	_dbg_assert_msg_(G3D, dstPos.x + srcRect.extent.width <= (uint32_t)dst->width, "dstPos + extent x > width");
-	_dbg_assert_msg_(G3D, dstPos.y + srcRect.extent.height <= (uint32_t)dst->height, "dstPos + extent y > height");
+	_dbg_assert_msg_(dstPos.x >= 0, "dstPos offset x (%d) < 0", dstPos.x);
+	_dbg_assert_msg_(dstPos.y >= 0, "dstPos offset y (%d) < 0", dstPos.y);
+	_dbg_assert_msg_(dstPos.x + srcRect.extent.width <= (uint32_t)dst->width, "dstPos + extent x > width");
+	_dbg_assert_msg_(dstPos.y + srcRect.extent.height <= (uint32_t)dst->height, "dstPos + extent y > height");
 
 	for (int i = (int)steps_.size() - 1; i >= 0; i--) {
 		if (steps_[i]->stepType == VKRStepType::RENDER && steps_[i]->render.framebuffer == src) {
@@ -918,21 +918,21 @@ void VulkanRenderManager::CopyFramebuffer(VKRFramebuffer *src, VkRect2D srcRect,
 }
 
 void VulkanRenderManager::BlitFramebuffer(VKRFramebuffer *src, VkRect2D srcRect, VKRFramebuffer *dst, VkRect2D dstRect, int aspectMask, VkFilter filter, const char *tag) {
-	_dbg_assert_msg_(G3D, srcRect.offset.x >= 0, "srcrect offset x (%d) < 0", srcRect.offset.x);
-	_dbg_assert_msg_(G3D, srcRect.offset.y >= 0, "srcrect offset y (%d) < 0", srcRect.offset.y);
-	_dbg_assert_msg_(G3D, srcRect.offset.x + srcRect.extent.width <= (uint32_t)src->width, "srcrect offset x (%d) + extent (%d) > width (%d)", srcRect.offset.x, srcRect.extent.width, (uint32_t)src->width);
-	_dbg_assert_msg_(G3D, srcRect.offset.y + srcRect.extent.height <= (uint32_t)src->height, "srcrect offset y (%d) + extent (%d) > height (%d)", srcRect.offset.y, srcRect.extent.height, (uint32_t)src->height);
+	_dbg_assert_msg_(srcRect.offset.x >= 0, "srcrect offset x (%d) < 0", srcRect.offset.x);
+	_dbg_assert_msg_(srcRect.offset.y >= 0, "srcrect offset y (%d) < 0", srcRect.offset.y);
+	_dbg_assert_msg_(srcRect.offset.x + srcRect.extent.width <= (uint32_t)src->width, "srcrect offset x (%d) + extent (%d) > width (%d)", srcRect.offset.x, srcRect.extent.width, (uint32_t)src->width);
+	_dbg_assert_msg_(srcRect.offset.y + srcRect.extent.height <= (uint32_t)src->height, "srcrect offset y (%d) + extent (%d) > height (%d)", srcRect.offset.y, srcRect.extent.height, (uint32_t)src->height);
 
-	_dbg_assert_msg_(G3D, srcRect.extent.width > 0, "blit srcwidth == 0");
-	_dbg_assert_msg_(G3D, srcRect.extent.height > 0, "blit srcheight == 0");
+	_dbg_assert_msg_(srcRect.extent.width > 0, "blit srcwidth == 0");
+	_dbg_assert_msg_(srcRect.extent.height > 0, "blit srcheight == 0");
 
-	_dbg_assert_msg_(G3D, dstRect.offset.x >= 0, "dstrect offset x < 0");
-	_dbg_assert_msg_(G3D, dstRect.offset.y >= 0, "dstrect offset y < 0");
-	_dbg_assert_msg_(G3D, dstRect.offset.x + dstRect.extent.width <= (uint32_t)dst->width, "dstrect offset x + extent > width");
-	_dbg_assert_msg_(G3D, dstRect.offset.y + dstRect.extent.height <= (uint32_t)dst->height, "dstrect offset y + extent > height");
+	_dbg_assert_msg_(dstRect.offset.x >= 0, "dstrect offset x < 0");
+	_dbg_assert_msg_(dstRect.offset.y >= 0, "dstrect offset y < 0");
+	_dbg_assert_msg_(dstRect.offset.x + dstRect.extent.width <= (uint32_t)dst->width, "dstrect offset x + extent > width");
+	_dbg_assert_msg_(dstRect.offset.y + dstRect.extent.height <= (uint32_t)dst->height, "dstrect offset y + extent > height");
 
-	_dbg_assert_msg_(G3D, dstRect.extent.width > 0, "blit dstwidth == 0");
-	_dbg_assert_msg_(G3D, dstRect.extent.height > 0, "blit dstheight == 0");
+	_dbg_assert_msg_(dstRect.extent.width > 0, "blit dstwidth == 0");
+	_dbg_assert_msg_(dstRect.extent.height > 0, "blit dstheight == 0");
 
 	for (int i = (int)steps_.size() - 1; i >= 0; i--) {
 		if (steps_[i]->stepType == VKRStepType::RENDER && steps_[i]->render.framebuffer == src) {
@@ -961,7 +961,7 @@ void VulkanRenderManager::BlitFramebuffer(VKRFramebuffer *src, VkRect2D srcRect,
 }
 
 VkImageView VulkanRenderManager::BindFramebufferAsTexture(VKRFramebuffer *fb, int binding, int aspectBit, int attachment) {
-	_dbg_assert_(G3D, curRenderStep_ != nullptr);
+	_dbg_assert_(curRenderStep_ != nullptr);
 	// Mark the dependency, check for required transitions, and return the image.
 
 	for (int i = (int)steps_.size() - 1; i >= 0; i--) {
@@ -1043,14 +1043,14 @@ void VulkanRenderManager::BeginSubmitFrame(int frame) {
 			WLOG("VK_ERROR_OUT_OF_DATE_KHR returned - processing the frame, but not presenting");
 			frameData.skipSwap = true;
 		} else {
-			_assert_msg_(G3D, res == VK_SUCCESS, "vkAcquireNextImageKHR failed! result=%s", VulkanResultToString(res));
+			_assert_msg_(res == VK_SUCCESS, "vkAcquireNextImageKHR failed! result=%s", VulkanResultToString(res));
 		}
 
 		VkCommandBufferBeginInfo begin{ VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
 		begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
 		res = vkBeginCommandBuffer(frameData.mainCmd, &begin);
 
-		_assert_msg_(G3D, res == VK_SUCCESS, "vkBeginCommandBuffer failed! result=%s", VulkanResultToString(res));
+		_assert_msg_(res == VK_SUCCESS, "vkBeginCommandBuffer failed! result=%s", VulkanResultToString(res));
 
 		queueRunner_.SetBackbuffer(framebuffers_[frameData.curSwapchainImage], swapchainImages_[frameData.curSwapchainImage].image);
 
@@ -1066,11 +1066,11 @@ void VulkanRenderManager::Submit(int frame, bool triggerFrameFence) {
 			vkCmdWriteTimestamp(frameData.initCmd, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, frameData.profile.queryPool, 1);
 		}
 		VkResult res = vkEndCommandBuffer(frameData.initCmd);
-		_assert_msg_(G3D, res == VK_SUCCESS, "vkEndCommandBuffer failed (init)! result=%s", VulkanResultToString(res));
+		_assert_msg_(res == VK_SUCCESS, "vkEndCommandBuffer failed (init)! result=%s", VulkanResultToString(res));
 	}
 
 	VkResult res = vkEndCommandBuffer(frameData.mainCmd);
-	_assert_msg_(G3D, res == VK_SUCCESS, "vkEndCommandBuffer failed (main)! result=%s", VulkanResultToString(res));
+	_assert_msg_(res == VK_SUCCESS, "vkEndCommandBuffer failed (main)! result=%s", VulkanResultToString(res));
 
 	VkCommandBuffer cmdBufs[2];
 	int numCmdBufs = 0;
@@ -1084,9 +1084,9 @@ void VulkanRenderManager::Submit(int frame, bool triggerFrameFence) {
 			submit_info.pCommandBuffers = cmdBufs;
 			res = vkQueueSubmit(vulkan_->GetGraphicsQueue(), 1, &submit_info, VK_NULL_HANDLE);
 			if (res == VK_ERROR_DEVICE_LOST) {
-				_assert_msg_(G3D, false, "Lost the Vulkan device in split submit! If this happens again, switch Graphics Backend away from Vulkan");
+				_assert_msg_(false, "Lost the Vulkan device in split submit! If this happens again, switch Graphics Backend away from Vulkan");
 			} else {
-				_assert_msg_(G3D, res == VK_SUCCESS, "vkQueueSubmit failed (init)! result=%s", VulkanResultToString(res));
+				_assert_msg_(res == VK_SUCCESS, "vkQueueSubmit failed (init)! result=%s", VulkanResultToString(res));
 			}
 			numCmdBufs = 0;
 		}
@@ -1108,9 +1108,9 @@ void VulkanRenderManager::Submit(int frame, bool triggerFrameFence) {
 	}
 	res = vkQueueSubmit(vulkan_->GetGraphicsQueue(), 1, &submit_info, triggerFrameFence ? frameData.fence : frameData.readbackFence);
 	if (res == VK_ERROR_DEVICE_LOST) {
-		_assert_msg_(G3D, false, "Lost the Vulkan device in vkQueueSubmit! If this happens again, switch Graphics Backend away from Vulkan");
+		_assert_msg_(false, "Lost the Vulkan device in vkQueueSubmit! If this happens again, switch Graphics Backend away from Vulkan");
 	} else {
-		_assert_msg_(G3D, res == VK_SUCCESS, "vkQueueSubmit failed (main, split=%d)! result=%s", (int)splitSubmit_, VulkanResultToString(res));
+		_assert_msg_(res == VK_SUCCESS, "vkQueueSubmit failed (main, split=%d)! result=%s", (int)splitSubmit_, VulkanResultToString(res));
 	}
 
 	// When !triggerFence, we notify after syncing with Vulkan.
@@ -1145,7 +1145,7 @@ void VulkanRenderManager::EndSubmitFrame(int frame) {
 		} else if (res == VK_SUBOPTIMAL_KHR) {
 			outOfDateFrames_++;
 		} else if (res != VK_SUCCESS) {
-			_assert_msg_(G3D, false, "vkQueuePresentKHR failed! result=%s", VulkanResultToString(res));
+			_assert_msg_(false, "vkQueuePresentKHR failed! result=%s", VulkanResultToString(res));
 		} else {
 			// Success
 			outOfDateFrames_ = 0;

--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -133,17 +133,17 @@ public:
 	void BlitFramebuffer(VKRFramebuffer *src, VkRect2D srcRect, VKRFramebuffer *dst, VkRect2D dstRect, int aspectMask, VkFilter filter, const char *tag);
 
 	void BindPipeline(VkPipeline pipeline) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
-		_dbg_assert_(G3D, pipeline != VK_NULL_HANDLE);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
+		_dbg_assert_(pipeline != VK_NULL_HANDLE);
 		VkRenderData data{ VKRRenderCommand::BIND_PIPELINE };
 		data.pipeline.pipeline = pipeline;
 		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetViewport(const VkViewport &vp) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
-		_dbg_assert_(G3D, (int)vp.width >= 0);
-		_dbg_assert_(G3D, (int)vp.height >= 0);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
+		_dbg_assert_((int)vp.width >= 0);
+		_dbg_assert_((int)vp.height >= 0);
 		VkRenderData data{ VKRRenderCommand::VIEWPORT };
 		data.viewport.vp.x = vp.x;
 		data.viewport.vp.y = vp.y;
@@ -159,9 +159,9 @@ public:
 	}
 
 	void SetScissor(const VkRect2D &rc) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
-		_dbg_assert_(G3D, (int)rc.extent.width >= 0);
-		_dbg_assert_(G3D, (int)rc.extent.height >= 0);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
+		_dbg_assert_((int)rc.extent.width >= 0);
+		_dbg_assert_((int)rc.extent.height >= 0);
 		VkRenderData data{ VKRRenderCommand::SCISSOR };
 		data.scissor.scissor = rc;
 		curRenderStep_->commands.push_back(data);
@@ -169,7 +169,7 @@ public:
 	}
 
 	void SetStencilParams(uint8_t writeMask, uint8_t compareMask, uint8_t refValue) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
 		VkRenderData data{ VKRRenderCommand::STENCIL };
 		data.stencil.stencilWriteMask = writeMask;
 		data.stencil.stencilCompareMask = compareMask;
@@ -178,14 +178,14 @@ public:
 	}
 
 	void SetBlendFactor(uint32_t color) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
 		VkRenderData data{ VKRRenderCommand::BLEND };
 		data.blendColor.color = color;
 		curRenderStep_->commands.push_back(data);
 	}
 
 	void PushConstants(VkPipelineLayout pipelineLayout, VkShaderStageFlags stages, int offset, int size, void *constants) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
 		assert(size + offset < 40);
 		VkRenderData data{ VKRRenderCommand::PUSH_CONSTANTS };
 		data.push.pipelineLayout = pipelineLayout;
@@ -199,7 +199,7 @@ public:
 	void Clear(uint32_t clearColor, float clearZ, int clearStencil, int clearMask);
 
 	void Draw(VkPipelineLayout layout, VkDescriptorSet descSet, int numUboOffsets, const uint32_t *uboOffsets, VkBuffer vbuffer, int voffset, int count, int offset = 0) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER && curStepHasViewport_ && curStepHasScissor_);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER && curStepHasViewport_ && curStepHasScissor_);
 		VkRenderData data{ VKRRenderCommand::DRAW };
 		data.draw.count = count;
 		data.draw.offset = offset;
@@ -216,7 +216,7 @@ public:
 	}
 
 	void DrawIndexed(VkPipelineLayout layout, VkDescriptorSet descSet, int numUboOffsets, const uint32_t *uboOffsets, VkBuffer vbuffer, int voffset, VkBuffer ibuffer, int ioffset, int count, int numInstances, VkIndexType indexType) {
-		_dbg_assert_(G3D, curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER && curStepHasViewport_ && curStepHasScissor_);
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER && curStepHasViewport_ && curStepHasScissor_);
 		VkRenderData data{ VKRRenderCommand::DRAW_INDEXED };
 		data.drawIndexed.count = count;
 		data.drawIndexed.instances = numInstances;

--- a/ext/native/thin3d/thin3d.cpp
+++ b/ext/native/thin3d/thin3d.cpp
@@ -78,13 +78,13 @@ bool RefCountedObject::Release() {
 		}
 	}
 	else {
-		_dbg_assert_msg_(G3D, false, "Refcount (%d) invalid for object %p - corrupt?", refcount_, this);
+		_dbg_assert_msg_(false, "Refcount (%d) invalid for object %p - corrupt?", refcount_, this);
 	}
 	return false;
 }
 
 bool RefCountedObject::ReleaseAssertLast() {
-	_dbg_assert_msg_(G3D, refcount_ == 1, "RefCountedObject: Expected to be the last reference, but isn't!");
+	_dbg_assert_msg_(refcount_ == 1, "RefCountedObject: Expected to be the last reference, but isn't!");
 	if (refcount_ > 0 && refcount_ < 10000) {
 		refcount_--;
 		if (refcount_ == 0) {

--- a/ext/native/thin3d/thin3d_gl.cpp
+++ b/ext/native/thin3d/thin3d_gl.cpp
@@ -1107,15 +1107,15 @@ void OpenGLContext::UpdateDynamicUniformBuffer(const void *ub, size_t size) {
 }
 
 void OpenGLContext::Draw(int vertexCount, int offset) {
-	_dbg_assert_msg_(G3D, curVBuffers_[0], "Can't call Draw without a vertex buffer");
+	_dbg_assert_msg_(curVBuffers_[0], "Can't call Draw without a vertex buffer");
 	ApplySamplers();
 	renderManager_.BindVertexBuffer(curPipeline_->inputLayout->inputLayout_, curVBuffers_[0]->buffer_, curVBufferOffsets_[0]);
 	renderManager_.Draw(curPipeline_->prim, offset, vertexCount);
 }
 
 void OpenGLContext::DrawIndexed(int vertexCount, int offset) {
-	_dbg_assert_msg_(G3D, curVBuffers_[0], "Can't call DrawIndexed without a vertex buffer");
-	_dbg_assert_msg_(G3D, curIBuffer_, "Can't call DrawIndexed without an index buffer");
+	_dbg_assert_msg_(curVBuffers_[0], "Can't call DrawIndexed without a vertex buffer");
+	_dbg_assert_msg_(curIBuffer_, "Can't call DrawIndexed without an index buffer");
 	ApplySamplers();
 	renderManager_.BindVertexBuffer(curPipeline_->inputLayout->inputLayout_, curVBuffers_[0]->buffer_, curVBufferOffsets_[0]);
 	renderManager_.BindIndexBuffer(curIBuffer_->buffer_);

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -1451,9 +1451,9 @@ uint32_t VKContext::GetDataFormatSupport(DataFormat fmt) const {
 // use this frame's init command buffer.
 class VKFramebuffer : public Framebuffer {
 public:
-	VKFramebuffer(VKRFramebuffer *fb) : buf_(fb) { _assert_msg_(G3D, fb, "Null fb in VKFramebuffer constructor"); }
+	VKFramebuffer(VKRFramebuffer *fb) : buf_(fb) { _assert_msg_(fb, "Null fb in VKFramebuffer constructor"); }
 	~VKFramebuffer() {
-		_assert_msg_(G3D, buf_, "Null buf_ in VKFramebuffer - double delete?");
+		_assert_msg_(buf_, "Null buf_ in VKFramebuffer - double delete?");
 		buf_->vulkan_->Delete().QueueCallback([](void *fb) {
 			VKRFramebuffer *vfb = static_cast<VKRFramebuffer *>(fb);
 			delete vfb;

--- a/ext/native/ui/ui_context.cpp
+++ b/ext/native/ui/ui_context.cpp
@@ -38,9 +38,7 @@ void UIContext::Init(Draw::DrawContext *thin3d, Draw::Pipeline *uipipe, Draw::Pi
 void UIContext::BeginFrame() {
 	if (!uitexture_) {
 		uitexture_ = CreateTextureFromFile(draw_, "ui_atlas.zim", ImageFileType::ZIM, false);
-		if (!uitexture_) {
-			PanicAlert("Failed to load ui_atlas.zim.\n\nPlace it in the directory \"assets\" under your PPSSPP directory.");
-		}
+		_dbg_assert_msg_(uitexture_, "Failed to load ui_atlas.zim.\n\nPlace it in the directory \"assets\" under your PPSSPP directory.");
 	}
 	uidrawbufferTop_->SetCurZ(0.0f);
 	uidrawbuffer_->SetCurZ(0.0f);

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -47,7 +47,7 @@ public:
 		renderManager_->SetInflightFrames(g_Config.iInflightFrames);
 		SetGPUBackend(GPUBackend::OPENGL);
 		bool success = draw_->CreatePresets();
-		_assert_msg_(G3D, success, "Failed to compile preset shaders");
+		_assert_msg_(success, "Failed to compile preset shaders");
 	}
 	~IOSGraphicsContext() {
 		delete draw_;


### PR DESCRIPTION
We have too many types of asserts, with too many argument orders.

Now all asserts are either `(_dbg)_assert_msg_(condition, message, ...)` or `(_dbg)_assert_(condition)`.  Makes things more uniform.

Basically I removed the category argument where it existed (since we don't filter asserts by category anyway), and removed `PanicAlert` entirely.