### PR TITLE
PSP kernel: Improve logging when accessing bad kernel object handles.

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -112,7 +112,7 @@ void hleDelayResultFinish(u64 userdata, int cycleslate)
 		__KernelReSchedule("woke from hle delay");
 	}
 	else
-		WARN_LOG(HLE, "Someone else woke up HLE-blocked thread?");
+		WARN_LOG(HLE, "Someone else woke up HLE-blocked thread %d?", threadID);
 }
 
 void HLEInit() {

--- a/Core/HLE/sceHeap.cpp
+++ b/Core/HLE/sceHeap.cpp
@@ -26,7 +26,7 @@
 #include <map>
 
 struct Heap {
-	Heap():alloc(4) {}
+	Heap() : alloc(4) {}
 
 	u32 size;
 	u32 address;

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -209,7 +209,8 @@ public:
 		pgd_close(pgdInfo);
 	}
 	const char *GetName() override { return fullpath.c_str(); }
-	const char *GetTypeName() override { return "OpenFile"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "OpenFile"; }
 	void GetQuickInfo(char *ptr, int size) override {
 		sprintf(ptr, "Seekpos: %08x", (u32)pspFileSystem.GetSeekPos(handle));
 	}
@@ -2232,7 +2233,8 @@ static u32 sceIoPollAsync(int id, u32 address) {
 class DirListing : public KernelObject {
 public:
 	const char *GetName() override { return name.c_str(); }
-	const char *GetTypeName() override { return "DirListing"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "DirListing"; }
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_BADF; }
 	static int GetStaticIDType() { return PPSSPP_KERNEL_TMID_DirList; }
 	int GetIDType() const override { return PPSSPP_KERNEL_TMID_DirList; }

--- a/Core/HLE/sceKernel.h
+++ b/Core/HLE/sceKernel.h
@@ -458,17 +458,17 @@ public:
 		if (handle < handleOffset || handle >= handleOffset+maxCount || !occupied[handle-handleOffset]) {
 			// Tekken 6 spams 0x80020001 gets wrong with no ill effects, also on the real PSP
 			if (handle != 0 && (u32)handle != 0x80020001) {
-				WARN_LOG(SCEKERNEL, "Kernel: Bad object handle %i (%08x)", handle, handle);
+				WARN_LOG(SCEKERNEL, "Kernel: Bad %s handle %d (%08x)", T::GetStaticTypeName(), handle, handle);
 			}
 			outError = T::GetMissingErrorCode();
 			return 0;
 		} else {
 			// Previously we had a dynamic_cast here, but since RTTI was disabled traditionally,
-			// it just acted as a static case and everything worked. This means that we will never
+			// it just acted as a static cast and everything worked. This means that we will never
 			// see the Wrong type object error below, but we'll just have to live with that danger.
 			T* t = static_cast<T*>(pool[handle - handleOffset]);
-			if (t == 0 || t->GetIDType() != T::GetStaticIDType()) {
-				WARN_LOG(SCEKERNEL, "Kernel: Wrong object type for %i (%08x)", handle, handle);
+			if (t == nullptr || t->GetIDType() != T::GetStaticIDType()) {
+				WARN_LOG(SCEKERNEL, "Kernel: Wrong object type for %d (%08x), was %s, should have been %s", handle, handle, t->GetTypeName(), T::GetStaticTypeName());
 				outError = T::GetMissingErrorCode();
 				return 0;
 			}

--- a/Core/HLE/sceKernelAlarm.cpp
+++ b/Core/HLE/sceKernelAlarm.cpp
@@ -39,7 +39,8 @@ struct NativeAlarm
 
 struct PSPAlarm : public KernelObject {
 	const char *GetName() override {return "[Alarm]";}
-	const char *GetTypeName() override {return "Alarm";}
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "Alarm"; }
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_ALMID; }
 	static int GetStaticIDType() { return SCE_KERNEL_TMID_Alarm; }
 	int GetIDType() const override { return SCE_KERNEL_TMID_Alarm; }

--- a/Core/HLE/sceKernelEventFlag.cpp
+++ b/Core/HLE/sceKernelEventFlag.cpp
@@ -53,7 +53,8 @@ struct EventFlagTh {
 class EventFlag : public KernelObject {
 public:
 	const char *GetName() override { return nef.name; }
-	const char *GetTypeName() override { return "EventFlag"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "EventFlag"; }
 	void GetQuickInfo(char *ptr, int size) override {
 		sprintf(ptr, "init=%08x cur=%08x numwait=%i",
 			nef.initPattern,

--- a/Core/HLE/sceKernelHeap.cpp
+++ b/Core/HLE/sceKernelHeap.cpp
@@ -23,6 +23,8 @@ struct Heap : public KernelObject {
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_UID; }
 	static int GetStaticIDType() { return PPSSPP_KERNEL_TMID_Heap; }
 	int GetIDType() const override { return PPSSPP_KERNEL_TMID_Heap; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "Heap"; }
 
 	void DoState(PointerWrap &p) override {
 		p.Do(uid);

--- a/Core/HLE/sceKernelMbx.cpp
+++ b/Core/HLE/sceKernelMbx.cpp
@@ -61,7 +61,8 @@ struct NativeMbx
 struct Mbx : public KernelObject
 {
 	const char *GetName() override { return nmb.name; }
-	const char *GetTypeName() override { return "Mbx"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "Mbx"; }
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_MBXID; }
 	static int GetStaticIDType() { return SCE_KERNEL_TMID_Mbox; }
 	int GetIDType() const override { return SCE_KERNEL_TMID_Mbox; }

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -93,7 +93,8 @@ struct FPL : public KernelObject
 		}
 	}
 	const char *GetName() override { return nf.name; }
-	const char *GetTypeName() override { return "FPL"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "FPL"; }
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_FPLID; }
 	static int GetStaticIDType() { return SCE_KERNEL_TMID_Fpl; }
 	int GetIDType() const override { return SCE_KERNEL_TMID_Fpl; }
@@ -375,7 +376,8 @@ struct SceKernelVplHeader {
 struct VPL : public KernelObject
 {
 	const char *GetName() override { return nv.name; }
-	const char *GetTypeName() override { return "VPL"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "VPL"; }
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_VPLID; }
 	static int GetStaticIDType() { return SCE_KERNEL_TMID_Vpl; }
 	int GetIDType() const override { return SCE_KERNEL_TMID_Vpl; }
@@ -899,7 +901,8 @@ class PartitionMemoryBlock : public KernelObject
 {
 public:
 	const char *GetName() override { return name; }
-	const char *GetTypeName() override { return "MemoryPart"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "MemoryPart"; }
 	void GetQuickInfo(char *ptr, int size) override
 	{
 		int sz = alloc->GetBlockSizeFromAddress(address);
@@ -1869,7 +1872,8 @@ struct NativeTlspl
 struct TLSPL : public KernelObject
 {
 	const char *GetName() override { return ntls.name; }
-	const char *GetTypeName() override { return "TLS"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "TLS"; }
 	static u32 GetMissingErrorCode() { return PSP_ERROR_UNKNOWN_TLSPL_ID; }
 	static int GetStaticIDType() { return SCE_KERNEL_TMID_Tlspl; }
 	int GetIDType() const override { return SCE_KERNEL_TMID_Tlspl; }

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -244,7 +244,8 @@ public:
 		}
 	}
 	const char *GetName() override { return nm.name; }
-	const char *GetTypeName() override { return "Module"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "Module"; }
 	void GetQuickInfo(char *ptr, int size) override
 	{
 		// ignore size

--- a/Core/HLE/sceKernelMsgPipe.cpp
+++ b/Core/HLE/sceKernelMsgPipe.cpp
@@ -131,7 +131,8 @@ static bool __KernelMsgPipeThreadSortPriority(MsgPipeWaitingThread thread1, MsgP
 struct MsgPipe : public KernelObject
 {
 	const char *GetName() override { return nmp.name; }
-	const char *GetTypeName() override { return "MsgPipe"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "MsgPipe"; }
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_MPPID; }
 	static int GetStaticIDType() { return SCE_KERNEL_TMID_Mpipe; }
 	int GetIDType() const override { return SCE_KERNEL_TMID_Mpipe; }

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -65,7 +65,8 @@ struct NativeMutex
 struct PSPMutex : public KernelObject
 {
 	const char *GetName() override { return nm.name; }
-	const char *GetTypeName() override { return "Mutex"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "Mutex"; }
 	static u32 GetMissingErrorCode() { return PSP_MUTEX_ERROR_NO_SUCH_MUTEX; }
 	static int GetStaticIDType() { return SCE_KERNEL_TMID_Mutex; }
 	int GetIDType() const override { return SCE_KERNEL_TMID_Mutex; }
@@ -130,7 +131,8 @@ struct NativeLwMutex
 struct LwMutex : public KernelObject
 {
 	const char *GetName() override { return nm.name; }
-	const char *GetTypeName() override { return "LwMutex"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "LwMutex"; }
 	static u32 GetMissingErrorCode() { return PSP_LWMUTEX_ERROR_NO_SUCH_LWMUTEX; }
 	static int GetStaticIDType() { return SCE_KERNEL_TMID_LwMutex; }
 	int GetIDType() const override { return SCE_KERNEL_TMID_LwMutex; }

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -55,7 +55,8 @@ struct NativeSemaphore
 
 struct PSPSemaphore : public KernelObject {
 	const char *GetName() override { return ns.name; }
-	const char *GetTypeName() override { return "Semaphore"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "Semaphore"; }
 
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_SEMID; }
 	static int GetStaticIDType() { return SCE_KERNEL_TMID_Semaphore; }

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -138,7 +138,8 @@ struct NativeCallback
 class PSPCallback : public KernelObject {
 public:
 	const char *GetName() override { return nc.name; }
-	const char *GetTypeName() override { return "CallBack"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "CallBack"; }
 
 	void GetQuickInfo(char *ptr, int size) override {
 		sprintf(ptr, "thread=%i, argument= %08x",
@@ -376,9 +377,9 @@ public:
 	PSPThread() : debug(currentMIPS, context) {}
 
 	const char *GetName() override { return nt.name; }
-	const char *GetTypeName() override { return "Thread"; }
-	void GetQuickInfo(char *ptr, int size) override
-	{
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "Thread"; }
+	void GetQuickInfo(char *ptr, int size) override {
 		sprintf(ptr, "pc= %08x sp= %08x %s %s %s %s %s %s (wt=%i wid=%i wv= %08x )",
 			context.pc, context.r[MIPS_REG_SP],
 			(nt.status & THREADSTATUS_RUNNING) ? "RUN" : "", 
@@ -3659,7 +3660,8 @@ struct NativeThreadEventHandler {
 
 struct ThreadEventHandler : public KernelObject {
 	const char *GetName() { return nteh.name; }
-	const char *GetTypeName() { return "ThreadEventHandler"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "ThreadEventHandler"; }
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_TEID; }
 	static int GetStaticIDType() { return SCE_KERNEL_TMID_ThreadEventHandler; }
 	int GetIDType() const { return SCE_KERNEL_TMID_ThreadEventHandler; }

--- a/Core/HLE/sceKernelVTimer.cpp
+++ b/Core/HLE/sceKernelVTimer.cpp
@@ -43,7 +43,8 @@ struct NativeVTimer {
 
 struct VTimer : public KernelObject {
 	const char *GetName() override { return nvt.name; }
-	const char *GetTypeName() override { return "VTimer"; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "VTimer"; }
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_VTID; }
 	static int GetStaticIDType() { return SCE_KERNEL_TMID_VTimer; }
 	int GetIDType() const override { return SCE_KERNEL_TMID_VTimer; }

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1734,7 +1734,7 @@ static u32 scePsmfPlayerGetCurrentPts(u32 psmfPlayer, u32 currentPtsAddr)
 		return ERROR_PSMFPLAYER_INVALID_STATUS;
 	}
 	if (psmfplayer->psmfPlayerAvcAu.pts < 0) {
-		WARN_LOG(ME, "scePsmfPlayerGetCurrentPts(%08x, %08x): no frame yet", psmfPlayer, currentPtsAddr);
+		VERBOSE_LOG(ME, "scePsmfPlayerGetCurrentPts(%08x, %08x): no frame yet", psmfPlayer, currentPtsAddr);
 		return ERROR_PSMFPLAYER_NO_MORE_DATA;
 	}
 


### PR DESCRIPTION
Previously:

`W[SCEKERNEL]: HLE\sceKernel.h:461 Kernel: Bad object handle -1 (ffffffff)`

With this:

`W[SCEKERNEL]: HLE\sceKernel.h:461 Kernel: Bad Thread handle -1 (ffffffff)`

Plus a few other minor tweaks.