### PR TITLE
Generalized multi-instance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1449,6 +1449,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/CwCheat.h
 	Core/HDRemaster.cpp
 	Core/HDRemaster.h
+	Core/Instance.cpp
+	Core/Instance.h
 	Core/ThreadEventQueue.h
 	Core/WebServer.cpp
 	Core/WebServer.h

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1297,6 +1297,11 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 		g_Config.iCpuCore = (int)CPUCore::INTERPRETER;
 	}
 
+	// Automatically silence secondary instances. Could be an option I guess, but meh.
+	if (PPSSPP_ID > 1) {
+		g_Config.iGlobalVolume = 0;
+	}
+
 	INFO_LOG(LOADER, "Config loaded: '%s'", iniFilename_.c_str());
 }
 

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -388,6 +388,7 @@
     <ClCompile Include="HLE\sceUsbCam.cpp" />
     <ClCompile Include="HLE\sceUsbMic.cpp" />
     <ClCompile Include="HW\Camera.cpp" />
+    <ClCompile Include="Instance.cpp" />
     <ClCompile Include="MemFault.cpp" />
     <ClCompile Include="MIPS\IR\IRAsm.cpp" />
     <ClCompile Include="MIPS\IR\IRCompALU.cpp" />
@@ -918,6 +919,7 @@
     <ClInclude Include="HLE\sceUsbCam.h" />
     <ClInclude Include="HLE\sceUsbMic.h" />
     <ClInclude Include="HW\Camera.h" />
+    <ClInclude Include="Instance.h" />
     <ClInclude Include="MemFault.h" />
     <ClInclude Include="MIPS\IR\IRFrontend.h" />
     <ClInclude Include="MIPS\IR\IRInst.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -746,6 +746,9 @@
     <ClCompile Include="MemFault.cpp">
       <Filter>Core</Filter>
     </ClCompile>
+    <ClCompile Include="Instance.cpp">
+      <Filter>Core</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -1383,6 +1386,9 @@
       <Filter>HLE\Kernel</Filter>
     </ClInclude>
     <ClInclude Include="MemFault.h">
+      <Filter>Core</Filter>
+    </ClInclude>
+    <ClInclude Include="Instance.h">
       <Filter>Core</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -32,6 +32,7 @@
 #include "Core/HLE/sceKernelInterrupt.h"
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/HLE/sceKernelMemory.h"
+#include "Core/Instance.h"
 #include "proAdhoc.h" 
 #include "i18n/i18n.h"
 
@@ -68,7 +69,6 @@ bool updateChatScreen = false;
 int newChat = 0;
 
 bool isLocalServer = false;
-uint8_t PPSSPP_ID = 0;
 sockaddr localIP; // This might serves the same purpose with existing "localip" above, but since this is copied from my old code so here it is (too lazy to rewrite the code)
 
 int isLocalMAC(const SceNetEtherAddr * addr) {

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -798,7 +798,6 @@ extern std::map<int, AdhocctlHandler> adhocctlHandlers;
 
 extern uint16_t portOffset;
 extern bool isLocalServer;
-extern uint8_t PPSSPP_ID;
 extern sockaddr localIP;
 extern uint32_t fakePoolSize;
 extern SceNetAdhocMatchingContext * contexts;

--- a/Core/Instance.cpp
+++ b/Core/Instance.cpp
@@ -116,7 +116,7 @@ void InitInstanceCounter() {
 		ERROR_LOG(SCENET, "mmap(%s) failure.", ID_SHM_NAME);
 		pIDBuf = NULL;
 		PPSSPP_ID = 1;
-		return 1;
+		return;
 	}
 
 	int id = 1;

--- a/Core/Instance.cpp
+++ b/Core/Instance.cpp
@@ -107,13 +107,15 @@ void InitInstanceCounter() {
 
 	if ((ftruncate(hIDMapFile, BUF_SIZE)) == -1) {    // Set the size 
 		ERROR_LOG(SCENET, "ftruncate(%s) failure.", ID_SHM_NAME);
-		return 1;
+		PPSSPP_ID = 1;
+		return;
 	}
 
 	pIDBuf = (int32_t*)mmap(0, BUF_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, hIDMapFile, 0);
 	if (pIDBuf == MAP_FAILED) {    // Set the size 
 		ERROR_LOG(SCENET, "mmap(%s) failure.", ID_SHM_NAME);
 		pIDBuf = NULL;
+		PPSSPP_ID = 1;
 		return 1;
 	}
 
@@ -128,7 +130,7 @@ void InitInstanceCounter() {
 	//status = close(hIDMapFile);                   //   Close file, should be called when program exits?
 	//status = shm_unlink(ID_SHM_NAME);     // Unlink [& delete] shared-memory object, should be called when program exits
 
-	return id;
+	PPSSPP_ID = id;
 #endif
 }
 

--- a/Core/Instance.cpp
+++ b/Core/Instance.cpp
@@ -1,0 +1,151 @@
+// Copyright (c) 2020 PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "Instance.h"
+
+#if __linux__ || __APPLE__
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#endif
+
+#include "Common/Log.h"
+
+#if PPSSPP_PLATFORM(WINDOWS)
+
+#include "Common/CommonWindows.h"
+
+#endif
+
+#include <cstdint>
+
+uint8_t PPSSPP_ID = 0;
+
+#if PPSSPP_PLATFORM(WINDOWS)
+static HANDLE hIDMapFile = NULL;
+#else
+static int hIDMapFile = 0;
+#endif
+
+static int32_t* pIDBuf = NULL;
+#define ID_SHM_NAME "/PPSSPP_ID"
+
+// Get current number of instance of PPSSPP running.
+// Must be called only once during init.
+void InitInstanceCounter() {
+#if PPSSPP_PLATFORM(WINDOWS)
+	uint32_t BUF_SIZE = 4096;
+	SYSTEM_INFO sysInfo;
+
+	GetSystemInfo(&sysInfo);
+	int gran = sysInfo.dwAllocationGranularity ? sysInfo.dwAllocationGranularity : 0x10000;
+	BUF_SIZE = (BUF_SIZE + gran - 1) & ~(gran - 1);
+
+	hIDMapFile = CreateFileMapping(
+		INVALID_HANDLE_VALUE,    // use paging file
+		NULL,                    // default security
+		PAGE_READWRITE,          // read/write access
+		0,                       // maximum object size (high-order DWORD)
+		BUF_SIZE,                // maximum object size (low-order DWORD)
+		TEXT(ID_SHM_NAME));       // name of mapping object
+
+	DWORD lasterr = GetLastError();
+	if (hIDMapFile == NULL)
+	{
+		ERROR_LOG(SCENET, "Could not create %s file mapping object (%d).", ID_SHM_NAME, lasterr);
+		PPSSPP_ID = 1;
+		return;
+	}
+
+	pIDBuf = (int32_t*)MapViewOfFile(hIDMapFile,   // handle to map object
+		FILE_MAP_ALL_ACCESS, // read/write permission
+		0,
+		0,
+		sizeof(int32_t)); //BUF_SIZE
+
+	if (pIDBuf == NULL) {
+		ERROR_LOG(SCENET, "Could not map view of file %s (%d).", ID_SHM_NAME, GetLastError());
+		//CloseHandle(hIDMapFile);
+		PPSSPP_ID = 1;
+		return;
+	}
+
+	(*pIDBuf)++;
+	int id = *pIDBuf;
+	UnmapViewOfFile(pIDBuf);
+	//CloseHandle(hIDMapFile); //Should be called when program exits
+	//hIDMapFile = NULL;
+
+	PPSSPP_ID = id;
+#elif PPSSPP_PLATFORM(ANDROID)
+	// TODO : replace shm_open & shm_unlink with ashmem or android-shmem
+	PPSSPP_ID = 1;
+#else
+	long BUF_SIZE = 4096;
+	//caddr_t pIDBuf;
+	int status;
+
+	// Create shared memory object 
+
+	hIDMapFile = shm_open(ID_SHM_NAME, O_CREAT | O_RDWR, 0);
+	BUF_SIZE = (BUF_SIZE < sysconf(_SC_PAGE_SIZE)) ? sysconf(_SC_PAGE_SIZE) : BUF_SIZE;
+
+	if ((ftruncate(hIDMapFile, BUF_SIZE)) == -1) {    // Set the size 
+		ERROR_LOG(SCENET, "ftruncate(%s) failure.", ID_SHM_NAME);
+		return 1;
+	}
+
+	pIDBuf = (int32_t*)mmap(0, BUF_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, hIDMapFile, 0);
+	if (pIDBuf == MAP_FAILED) {    // Set the size 
+		ERROR_LOG(SCENET, "mmap(%s) failure.", ID_SHM_NAME);
+		pIDBuf = NULL;
+		return 1;
+	}
+
+	int id = 1;
+	if (mlock(pIDBuf, BUF_SIZE) == 0) {
+		(*pIDBuf)++;
+		id = *pIDBuf;
+		munlock(pIDBuf, BUF_SIZE);
+	}
+
+	status = munmap(pIDBuf, BUF_SIZE);  // Unmap the page 
+	//status = close(hIDMapFile);                   //   Close file, should be called when program exits?
+	//status = shm_unlink(ID_SHM_NAME);     // Unlink [& delete] shared-memory object, should be called when program exits
+
+	return id;
+#endif
+}
+
+void ShutdownInstanceCounter() {
+#if PPSSPP_PLATFORM(WINDOWS)
+	if (hIDMapFile != NULL) {
+		CloseHandle(hIDMapFile); // If program exited(or crashed?) or the last handle reference closed the shared memory object will be deleted.
+		hIDMapFile = NULL;
+	}
+#elif PPSSPP_PLATFORM(ANDROID)
+	// Do nothing
+#else
+	// TODO : This unlink should be called when program exits instead of everytime the game reset.
+	if (hIDMapFile != 0) {
+		close(hIDMapFile);
+		shm_unlink(ID_SHM_NAME);     // If program exited or crashed before unlinked the shared memory object and it's contents will persist.
+		hIDMapFile = 0;
+	}
+#endif
+}

--- a/Core/Instance.h
+++ b/Core/Instance.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "ppsspp_config.h"
+
+#include <cstdint>
+
+extern uint8_t PPSSPP_ID;
+
+void InitInstanceCounter();
+void ShutdownInstanceCounter();
+
+inline bool IsFirstInstance() {
+	return PPSSPP_ID == 1;
+}

--- a/UWP/CoreUWP/CoreUWP.vcxproj
+++ b/UWP/CoreUWP/CoreUWP.vcxproj
@@ -432,6 +432,7 @@
     <ClInclude Include="..\..\Core\FileSystems\VirtualDiscFileSystem.h" />
     <ClInclude Include="..\..\Core\Font\PGF.h" />
     <ClInclude Include="..\..\Core\HDRemaster.h" />
+    <ClInclude Include="..\..\Core\Instance.h" />
     <ClInclude Include="..\..\Core\HLE\FunctionWrappers.h" />
     <ClInclude Include="..\..\Core\HLE\HLE.h" />
     <ClInclude Include="..\..\Core\HLE\HLEHelperThread.h" />
@@ -648,6 +649,7 @@
     <ClCompile Include="..\..\Core\FileSystems\VirtualDiscFileSystem.cpp" />
     <ClCompile Include="..\..\Core\Font\PGF.cpp" />
     <ClCompile Include="..\..\Core\HDRemaster.cpp" />
+    <ClCompile Include="..\..\Core\Instance.cpp" />
     <ClCompile Include="..\..\Core\HLE\HLE.cpp" />
     <ClCompile Include="..\..\Core\HLE\HLEHelperThread.cpp" />
     <ClCompile Include="..\..\Core\HLE\HLETables.cpp" />

--- a/UWP/CoreUWP/CoreUWP.vcxproj.filters
+++ b/UWP/CoreUWP/CoreUWP.vcxproj.filters
@@ -80,6 +80,7 @@
     <ClCompile Include="..\..\Core\CoreTiming.cpp" />
     <ClCompile Include="..\..\Core\CwCheat.cpp" />
     <ClCompile Include="..\..\Core\HDRemaster.cpp" />
+    <ClCompile Include="..\..\Core\Instance.cpp" />
     <ClCompile Include="..\..\Core\Host.cpp" />
     <ClCompile Include="..\..\Core\Loaders.cpp" />
     <ClCompile Include="..\..\Core\MemFault.cpp" />
@@ -718,6 +719,7 @@
     <ClInclude Include="..\..\Core\CoreTiming.h" />
     <ClInclude Include="..\..\Core\CwCheat.h" />
     <ClInclude Include="..\..\Core\HDRemaster.h" />
+    <ClInclude Include="..\..\Core\Instance.h" />
     <ClInclude Include="..\..\Core\Host.h" />
     <ClInclude Include="..\..\Core\Loaders.h" />
     <ClInclude Include="..\..\Core\MemFault.h" />

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -291,6 +291,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/CoreTiming.cpp \
   $(SRC)/Core/CwCheat.cpp \
   $(SRC)/Core/HDRemaster.cpp \
+  $(SRC)/Core/Instance.cpp \
   $(SRC)/Core/Host.cpp \
   $(SRC)/Core/Loaders.cpp \
   $(SRC)/Core/PSPLoaders.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -342,6 +342,7 @@ SOURCES_CXX += $(NATIVEDIR)/math/dataconv.cpp \
 	       $(COREDIR)/CoreTiming.cpp \
 	       $(COREDIR)/CwCheat.cpp \
 	       $(COREDIR)/HDRemaster.cpp \
+	       $(COREDIR)/Instance.cpp \
 	       $(COREDIR)/Debugger/Breakpoints.cpp \
 	       $(COREDIR)/Debugger/SymbolMap.cpp \
 	       $(COREDIR)/Dialog/PSPDialog.cpp \


### PR DESCRIPTION
Takes #13169 and extracts it to a separate file, and changes how it's called.

Instance counter is now initialized on startup, enabling us to do the following things for secondary instances:

* They don't save their configs
* They are silent (can be overridden at runtime if desired).
* The title bar shows the instance number (Windows only so far).

Which makes the experience a lot better.

Possible alternatives would be to have a separate configs: ppsspp2.ini, ppsspp3.ini and so on, but felt this was simpler.

