### PR TITLE
Windows: Add file menu command to easily load up a new identical instance of PPSSPP.

### DIFF
--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -227,6 +227,7 @@ namespace MainWindow {
 		TranslateMenuItem(menu, ID_FILE_LOAD);
 		TranslateMenuItem(menu, ID_FILE_LOAD_DIR);
 		TranslateMenuItem(menu, ID_FILE_LOAD_MEMSTICK);
+		TranslateMenuItem(menu, ID_FILE_OPEN_NEW_INSTANCE);
 		TranslateMenuItem(menu, ID_FILE_MEMSTICK);
 		TranslateMenuItem(menu, ID_FILE_SAVESTATE_SLOT_MENU, useDefHotkey(VIRTKEY_NEXT_SLOT) ? L"\tF3" : L"");
 		TranslateMenuItem(menu, ID_FILE_QUICKLOADSTATE, useDefHotkey(VIRTKEY_LOAD_STATE) ? L"\tF4" : L"");
@@ -567,6 +568,10 @@ namespace MainWindow {
 
 		case ID_FILE_LOAD_MEMSTICK:
 			BrowseAndBoot(GetSysDirectory(DIRECTORY_GAME));
+			break;
+
+		case ID_FILE_OPEN_NEW_INSTANCE:
+			W32Util::SpawnNewInstance(false);
 			break;
 
 		case ID_FILE_MEMSTICK:

--- a/Windows/W32Util/Misc.cpp
+++ b/Windows/W32Util/Misc.cpp
@@ -154,6 +154,12 @@ namespace W32Util
 	}
 
 	void ExitAndRestart(bool overrideArgs, const std::string &args) {
+		SpawnNewInstance(overrideArgs, args);
+
+		ExitProcess(0);
+	}
+
+	void SpawnNewInstance(bool overrideArgs, const std::string &args) {
 		// This preserves arguments (for example, config file) and working directory.
 		std::wstring workingDirectory;
 		std::wstring moduleFilename;
@@ -168,12 +174,8 @@ namespace W32Util
 			cmdline = RemoveExecutableFromCommandLine(GetCommandLineW());
 		}
 		ShellExecute(nullptr, nullptr, moduleFilename.c_str(), cmdline, workingDirectory.c_str(), SW_SHOW);
-
-		ExitProcess(0);
 	}
 }
-
-
 
 GenericListControl::GenericListControl(HWND hwnd, const GenericListViewDef& def)
 	: handle(hwnd), columns(def.columns),columnCount(def.columnCount),valid(false),

--- a/Windows/W32Util/Misc.h
+++ b/Windows/W32Util/Misc.h
@@ -12,6 +12,7 @@ namespace W32Util
 	BOOL CopyTextToClipboard(HWND hwnd, const std::wstring &wtext);
 	void MakeTopMost(HWND hwnd, bool topMost);
 	void ExitAndRestart(bool overrideArgs = false, const std::string &args = "");
+	void SpawnNewInstance(bool overrideArgs = false, const std::string &args = "");
 	void GetSelfExecuteParams(std::wstring &workingDirectory, std::wstring &moduleFilename);
 }
 

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -65,6 +65,7 @@ IDB_IMAGE_PSP           IMAGE                   "pspmode.png"
 IDR_ACCELS ACCELERATORS
 BEGIN
     "O",            ID_FILE_LOAD,           VIRTKEY, CONTROL, NOINVERT
+    "I",            ID_FILE_OPEN_NEW_INSTANCE, VIRTKEY, CONTROL, NOINVERT
     "W",            ID_EMULATION_STOP,      VIRTKEY, CONTROL, NOINVERT
     "B",            ID_EMULATION_RESET,     VIRTKEY, CONTROL, NOINVERT
     "T",            ID_EMULATION_CHEATS,    VIRTKEY, CONTROL, NOINVERT
@@ -479,6 +480,8 @@ BEGIN
         MENUITEM "Open from MS:/PSP/GAME...",               ID_FILE_LOAD_MEMSTICK
         MENUITEM "", 0, MFT_SEPARATOR
         MENUITEM "Open Memory Stick",                       ID_FILE_MEMSTICK
+        MENUITEM "", 0, MFT_SEPARATOR
+        MENUITEM "Open New Instance",                       ID_FILE_OPEN_NEW_INSTANCE
         MENUITEM "", 0, MFT_SEPARATOR
 
         POPUP "Savestate Slot",                             ID_FILE_SAVESTATE_SLOT_MENU

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -22,6 +22,7 @@
 #define WHEEL_DELTA                     120
 #define ID_DEBUG_LOG                    121
 #define ID_DEBUG_BREAKPOINTS            122
+#define ID_FILE_OPEN_NEW_INSTANCE       123
 #define ID_FILE_LOADSTATEFILE           126
 #define ID_FILE_SAVESTATEFILE           127
 #define ID_EMULATION_RESET              130


### PR DESCRIPTION
Useful for debugging adhoc multiplayer locally with the new multi-instance support.

Windows-only so far.

(Would be even cooler if it started the same game too, if one was running. Maybe later.)