### PR TITLE
Debugger: Add memory.read_*, memory write_*

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1482,6 +1482,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/Debugger/WebSocket/HLESubscriber.h
 	Core/Debugger/WebSocket/LogBroadcaster.cpp
 	Core/Debugger/WebSocket/LogBroadcaster.h
+	Core/Debugger/WebSocket/MemorySubscriber.cpp
+	Core/Debugger/WebSocket/MemorySubscriber.h
 	Core/Debugger/WebSocket/SteppingBroadcaster.cpp
 	Core/Debugger/WebSocket/SteppingBroadcaster.h
 	Core/Debugger/WebSocket/SteppingSubscriber.cpp

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -378,6 +378,7 @@
     <ClCompile Include="Debugger\WebSocket\HLESubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\LogBroadcaster.cpp" />
     <ClCompile Include="Debugger\WebSocket\DisasmSubscriber.cpp" />
+    <ClCompile Include="Debugger\WebSocket\MemorySubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\SteppingBroadcaster.cpp" />
     <ClCompile Include="Debugger\WebSocket\SteppingSubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\WebSocketUtils.cpp" />
@@ -909,6 +910,7 @@
     <ClInclude Include="Debugger\WebSocket\SteppingSubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\WebSocketUtils.h" />
     <ClInclude Include="Debugger\WebSocket\CPUCoreSubscriber.h" />
+    <ClInclude Include="Debugger\WebSocket\MemorySubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\GameBroadcaster.h" />
     <ClInclude Include="Debugger\WebSocket\LogBroadcaster.h" />
     <ClInclude Include="Debugger\WebSocket\SteppingBroadcaster.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -713,6 +713,9 @@
     <ClCompile Include="Debugger\WebSocket\GameSubscriber.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="Debugger\WebSocket\MemorySubscriber.cpp">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClCompile>
     <ClCompile Include="Debugger\WebSocket\DisasmSubscriber.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
@@ -1350,6 +1353,9 @@
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>
     <ClInclude Include="Debugger\WebSocket\GameSubscriber.h">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClInclude>
+    <ClInclude Include="Debugger\WebSocket\MemorySubscriber.h">
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>
     <ClInclude Include="Debugger\WebSocket\DisasmSubscriber.h">

--- a/Core/Debugger/WebSocket.cpp
+++ b/Core/Debugger/WebSocket.cpp
@@ -55,6 +55,7 @@
 #include "Core/Debugger/WebSocket/GPUBufferSubscriber.h"
 #include "Core/Debugger/WebSocket/GPURecordSubscriber.h"
 #include "Core/Debugger/WebSocket/HLESubscriber.h"
+#include "Core/Debugger/WebSocket/MemorySubscriber.h"
 #include "Core/Debugger/WebSocket/SteppingSubscriber.h"
 
 typedef DebuggerSubscriber *(*SubscriberInit)(DebuggerEventHandlerMap &map);
@@ -66,6 +67,7 @@ static const std::vector<SubscriberInit> subscribers({
 	&WebSocketGPUBufferInit,
 	&WebSocketGPURecordInit,
 	&WebSocketHLEInit,
+	&WebSocketMemoryInit,
 	&WebSocketSteppingInit,
 });
 

--- a/Core/Debugger/WebSocket/MemorySubscriber.cpp
+++ b/Core/Debugger/WebSocket/MemorySubscriber.cpp
@@ -1,0 +1,205 @@
+// Copyright (c) 2018- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "Common/StringUtils.h"
+#include "Core/MemMap.h"
+#include "Core/System.h"
+#include "Core/Debugger/WebSocket/MemorySubscriber.h"
+#include "Core/Debugger/WebSocket/WebSocketUtils.h"
+
+DebuggerSubscriber *WebSocketMemoryInit(DebuggerEventHandlerMap &map) {
+	// No need to bind or alloc state, these are all global.
+	map["memory.read_u8"] = &WebSocketMemoryReadU8;
+	map["memory.read_u16"] = &WebSocketMemoryReadU16;
+	map["memory.read_u32"] = &WebSocketMemoryReadU32;
+	map["memory.write_u8"] = &WebSocketMemoryWriteU8;
+	map["memory.write_u16"] = &WebSocketMemoryWriteU16;
+	map["memory.write_u32"] = &WebSocketMemoryWriteU32;
+
+	return nullptr;
+}
+
+// Read a byte from memory (memory.read_u8)
+//
+// Parameters:
+//  - address: unsigned integer
+//
+// Response (same event name):
+//  - value: unsigned integer
+void WebSocketMemoryReadU8(DebuggerRequest &req) {
+	auto memLock = Memory::Lock();
+	uint32_t addr;
+
+	if (!req.ParamU32("address", &addr, false)) {
+		req.Fail("No address given");
+		return;
+	}
+
+	if (!Memory::IsValidAddress(addr)) {
+		req.Fail("Invalid address");
+		return;
+	}
+
+	JsonWriter &json = req.Respond();
+	json.writeUint("value", Memory::Read_U8(addr));
+}
+
+// Read two bytes from memory (memory.read_u16)
+//
+// Parameters:
+//  - address: unsigned integer
+//
+// Response (same event name):
+//  - value: unsigned integer
+void WebSocketMemoryReadU16(DebuggerRequest &req) {
+	auto memLock = Memory::Lock();
+	uint32_t addr;
+
+	if (!req.ParamU32("address", &addr, false)) {
+		req.Fail("No address given");
+		return;
+	}
+
+	if (!Memory::IsValidAddress(addr)) {
+		req.Fail("Invalid address");
+		return;
+	}
+
+	JsonWriter &json = req.Respond();
+	json.writeUint("value", Memory::Read_U16(addr));
+}
+
+// Read four bytes from memory (memory.read_u32)
+//
+// Parameters:
+//  - address: unsigned integer
+//
+// Response (same event name):
+//  - value: unsigned integer
+void WebSocketMemoryReadU32(DebuggerRequest &req) {
+	auto memLock = Memory::Lock();
+	uint32_t addr;
+
+	if (!req.ParamU32("address", &addr, false)) {
+		req.Fail("No address given");
+		return;
+	}
+
+	if (!Memory::IsValidAddress(addr)) {
+		req.Fail("Invalid address");
+		return;
+	}
+
+	JsonWriter &json = req.Respond();
+	json.writeUint("value", Memory::Read_U32(addr));
+}
+
+// Write a byte to memory (memory.write_u8)
+//
+// Parameters:
+//  - address: unsigned integer
+//  - value: unsigned integer
+//
+// Response (same event name):
+//  - value: new value, unsigned integer
+void WebSocketMemoryWriteU8(DebuggerRequest &req) {
+	auto memLock = Memory::Lock();
+	uint32_t addr, val;
+
+	if (!req.ParamU32("address", &addr, false)) {
+		req.Fail("No address given");
+		return;
+	}
+
+	if (!req.ParamU32("value", &val, false)) {
+		req.Fail("No value given");
+		return;
+	}
+
+	if (!Memory::IsValidAddress(addr)) {
+		req.Fail("Invalid address");
+		return;
+	}
+	Memory::Write_U8(val, addr);
+
+	JsonWriter &json = req.Respond();
+	json.writeUint("value", Memory::Read_U8(addr));
+}
+
+// Write two bytes to memory (memory.write_u16)
+//
+// Parameters:
+//  - address: unsigned integer
+//  - value: unsigned integer
+//
+// Response (same event name):
+//  - value: new value, unsigned integer
+void WebSocketMemoryWriteU16(DebuggerRequest &req) {
+	auto memLock = Memory::Lock();
+	uint32_t addr, val;
+
+	if (!req.ParamU32("address", &addr, false)) {
+		req.Fail("No address given");
+		return;
+	}
+
+	if (!req.ParamU32("value", &val, false)) {
+		req.Fail("No value given");
+		return;
+	}
+
+	if (!Memory::IsValidAddress(addr)) {
+		req.Fail("Invalid address");
+		return;
+	}
+	Memory::Write_U16(val, addr);
+
+	JsonWriter &json = req.Respond();
+	json.writeUint("value", Memory::Read_U16(addr));
+}
+
+// Write four bytes to memory (memory.write_u32)
+//
+// Parameters:
+//  - address: unsigned integer
+//  - value: unsigned integer
+//
+// Response (same event name):
+//  - value: new value, unsigned integer
+void WebSocketMemoryWriteU32(DebuggerRequest &req) {
+	auto memLock = Memory::Lock();
+	uint32_t addr, val;
+
+	if (!req.ParamU32("address", &addr, false)) {
+		req.Fail("No address given");
+		return;
+	}
+
+	if (!req.ParamU32("value", &val, false)) {
+		req.Fail("No value given");
+		return;
+	}
+
+	if (!Memory::IsValidAddress(addr)) {
+		req.Fail("Invalid address");
+		return;
+	}
+	Memory::Write_U32(val, addr);
+
+	JsonWriter &json = req.Respond();
+	json.writeUint("value", Memory::Read_U32(addr));
+}

--- a/Core/Debugger/WebSocket/MemorySubscriber.h
+++ b/Core/Debugger/WebSocket/MemorySubscriber.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2018- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "Core/Debugger/WebSocket/WebSocketUtils.h"
+
+DebuggerSubscriber *WebSocketMemoryInit(DebuggerEventHandlerMap &map);
+
+void WebSocketMemoryReadU8(DebuggerRequest &req);
+void WebSocketMemoryReadU16(DebuggerRequest &req);
+void WebSocketMemoryReadU32(DebuggerRequest &req);
+void WebSocketMemoryWriteU8(DebuggerRequest &req);
+void WebSocketMemoryWriteU16(DebuggerRequest &req);
+void WebSocketMemoryWriteU32(DebuggerRequest &req);

--- a/UWP/CoreUWP/CoreUWP.vcxproj
+++ b/UWP/CoreUWP/CoreUWP.vcxproj
@@ -400,6 +400,7 @@
     <ClInclude Include="..\..\Core\Debugger\WebSocket\GPURecordSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\HLESubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\LogBroadcaster.h" />
+    <ClInclude Include="..\..\Core\Debugger\WebSocket\MemorySubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\SteppingBroadcaster.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\SteppingSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\WebSocketUtils.h" />
@@ -618,6 +619,7 @@
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GPURecordSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\HLESubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\LogBroadcaster.cpp" />
+    <ClCompile Include="..\..\Core\Debugger\WebSocket\MemorySubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\SteppingBroadcaster.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\SteppingSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\WebSocketUtils.cpp" />

--- a/UWP/CoreUWP/CoreUWP.vcxproj.filters
+++ b/UWP/CoreUWP/CoreUWP.vcxproj.filters
@@ -666,6 +666,9 @@
     <ClCompile Include="..\..\Core\Debugger\WebSocket\LogBroadcaster.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Core\Debugger\WebSocket\MemorySubscriber.cpp">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Core\Debugger\WebSocket\SteppingBroadcaster.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
@@ -1287,6 +1290,9 @@
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Core\Debugger\WebSocket\LogBroadcaster.h">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Core\Debugger\WebSocket\MemorySubscriber.h">
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Core\Debugger\WebSocket\SteppingBroadcaster.h">

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -324,6 +324,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/Debugger/WebSocket/GPURecordSubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/HLESubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/LogBroadcaster.cpp \
+  $(SRC)/Core/Debugger/WebSocket/MemorySubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/SteppingBroadcaster.cpp \
   $(SRC)/Core/Debugger/WebSocket/SteppingSubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/WebSocketUtils.cpp \


### PR DESCRIPTION
Add `memory.read_u8`, `memory.read_u16`, `memory.read_u32`, `memory.write_u8`, `memory.write_u16` and `memory.write_u32` to the websocket interface.