### PR TITLE
Fix error in sceUsbMic savestate handling (need to accept old savestates without the section)

### DIFF
--- a/Core/HLE/sceUsbMic.cpp
+++ b/Core/HLE/sceUsbMic.cpp
@@ -118,7 +118,7 @@ void __UsbMicShutdown() {
 }
 
 void __UsbMicDoState(PointerWrap &p) {
-	auto s = p.Section("sceUsbMic", 1, 1);
+	auto s = p.Section("sceUsbMic", 0, 1);
 	if (!s) {
 		return;
 	}


### PR DESCRIPTION
Hopefully helps #13236.