### PR TITLE
Logging and error handling improvements around save states

### DIFF
--- a/Common/Vulkan/VulkanDebug.cpp
+++ b/Common/Vulkan/VulkanDebug.cpp
@@ -33,13 +33,12 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDebugUtilsCallback(
 
 	const char *pMessage = pCallbackData->pMessage;
 
-	// Apparent bugs around timestamp validation in the validation layers
-	if (strstr(pMessage, "vkCmdBeginQuery(): VkQueryPool"))
-		return false;
-	if (strstr(pMessage, "vkGetQueryPoolResults() on VkQueryPool"))
-		return false;
-
 	int messageCode = pCallbackData->messageIdNumber;
+	if (messageCode == 101294395) {
+		// UNASSIGNED-CoreValidation-Shader-OutputNotConsumed - benign perf warning
+		return false;
+	}
+
 	const char *pLayerPrefix = "";
 	if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
 		message << "ERROR(";
@@ -58,7 +57,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDebugUtilsCallback(
 	} else if (messageType & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT) {
 		message << "validation";
 	}
-	message << ":" << pCallbackData->messageIdNumber << ") " << pMessage << "\n";
+	message << ":" << messageCode << ") " << pMessage << "\n";
 
 	std::string msg = message.str();
 

--- a/Common/Vulkan/VulkanMemory.cpp
+++ b/Common/Vulkan/VulkanMemory.cpp
@@ -143,7 +143,9 @@ void VulkanPushBuffer::Map() {
 }
 
 void VulkanPushBuffer::Unmap() {
-	_dbg_assert_(writePtr_ != 0);
+	_dbg_assert_msg_(writePtr_ != nullptr, "VulkanPushBuffer::Unmap: writePtr_ null here means we have a bug (map/unmap mismatch)");
+	if (!writePtr_)
+		return;
 
 	if ((memoryPropertyMask_ & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) == 0) {
 		VkMappedMemoryRange range{ VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE };

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -744,7 +744,7 @@ namespace SaveState
 			switch (op.type)
 			{
 			case SAVESTATE_LOAD:
-				INFO_LOG(SAVESTATE, "Loading state from %s", op.filename.c_str());
+				INFO_LOG(SAVESTATE, "Loading state from '%s'", op.filename.c_str());
 				// Use the state's latest version as a guess for saveStateInitialGitVersion.
 				result = CChunkFileReader::Load(op.filename, &saveStateInitialGitVersion, state, &reason);
 				if (result == CChunkFileReader::ERROR_NONE) {

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -91,9 +91,9 @@ namespace SaveState
 		return CChunkFileReader::SavePtr(&data[0], state);
 	}
 
-	CChunkFileReader::Error LoadFromRam(std::vector<u8> &data) {
+	CChunkFileReader::Error LoadFromRam(std::vector<u8> &data, std::string *errorString) {
 		SaveStart state;
-		return CChunkFileReader::LoadPtr(&data[0], state);
+		return CChunkFileReader::LoadPtr(&data[0], state, errorString);
 	}
 
 	struct StateRingbuffer
@@ -135,7 +135,7 @@ namespace SaveState
 			return err;
 		}
 
-		CChunkFileReader::Error Restore()
+		CChunkFileReader::Error Restore(std::string *errorString)
 		{
 			std::lock_guard<std::mutex> guard(lock_);
 
@@ -149,7 +149,7 @@ namespace SaveState
 
 			static std::vector<u8> buffer;
 			LockedDecompress(buffer, states_[n], bases_[baseMapping_[n]]);
-			return LoadFromRam(buffer);
+			return LoadFromRam(buffer, errorString);
 		}
 
 		void ScheduleCompress(std::vector<u8> *result, const std::vector<u8> *state, const std::vector<u8> *base)
@@ -632,13 +632,14 @@ namespace SaveState
 		return copy;
 	}
 
-	bool HandleFailure()
+	bool HandleLoadFailure()
 	{
 		// Okay, first, let's give the rewind state a shot - maybe we can at least not reset entirely.
 		// Even if this was a rewind, maybe we can still load a previous one.
 		CChunkFileReader::Error result;
 		do {
-			result = rewindStates.Restore();
+			std::string errorString;
+			result = rewindStates.Restore(&errorString);
 		} while (result == CChunkFileReader::ERROR_BROKEN_STATE);
 
 		if (result == CChunkFileReader::ERROR_NONE) {
@@ -728,7 +729,6 @@ namespace SaveState
 			Status callbackResult;
 			bool tempResult;
 			std::string callbackMessage;
-			std::string reason;
 			std::string title;
 
 			auto sc = GetI18NCategory("Screen");
@@ -740,13 +740,14 @@ namespace SaveState
 				i18nSaveFailure = sc->T("Failed to save state");
 
 			std::string slot_prefix = op.slot >= 0 ? StringFromFormat("(%d) ", op.slot + 1) : "";
+			std::string errorString;
 
 			switch (op.type)
 			{
 			case SAVESTATE_LOAD:
 				INFO_LOG(SAVESTATE, "Loading state from '%s'", op.filename.c_str());
 				// Use the state's latest version as a guess for saveStateInitialGitVersion.
-				result = CChunkFileReader::Load(op.filename, &saveStateInitialGitVersion, state, &reason);
+				result = CChunkFileReader::Load(op.filename, &saveStateInitialGitVersion, state, &errorString);
 				if (result == CChunkFileReader::ERROR_NONE) {
 					callbackMessage = slot_prefix + sc->T("Loaded State");
 					callbackResult = Status::SUCCESS;
@@ -777,12 +778,13 @@ namespace SaveState
 					}
 #endif
 				} else if (result == CChunkFileReader::ERROR_BROKEN_STATE) {
-					HandleFailure();
-					callbackMessage = i18nLoadFailure;
-					ERROR_LOG(SAVESTATE, "Load state failure: %s", reason.c_str());
+					HandleLoadFailure();
+					callbackMessage = std::string(i18nLoadFailure) + ": " + errorString;
+					ERROR_LOG(SAVESTATE, "Load state failure: %s", errorString.c_str());
 					callbackResult = Status::FAILURE;
 				} else {
-					callbackMessage = sc->T(reason.c_str(), i18nLoadFailure);
+					// ?
+					callbackMessage = sc->T(errorString.c_str(), i18nLoadFailure);
 					callbackResult = Status::FAILURE;
 				}
 				break;
@@ -812,9 +814,9 @@ namespace SaveState
 					}
 #endif
 				} else if (result == CChunkFileReader::ERROR_BROKEN_STATE) {
-					HandleFailure();
+					// TODO: What else might we want to do here? This should be very unusual.
 					callbackMessage = i18nSaveFailure;
-					ERROR_LOG(SAVESTATE, "Save state failure: %s", reason.c_str());
+					ERROR_LOG(SAVESTATE, "Save state failure");
 					callbackResult = Status::FAILURE;
 				} else {
 					callbackMessage = i18nSaveFailure;
@@ -834,24 +836,24 @@ namespace SaveState
 
 			case SAVESTATE_REWIND:
 				INFO_LOG(SAVESTATE, "Rewinding to recent savestate snapshot");
-				result = rewindStates.Restore();
+				result = rewindStates.Restore(&errorString);
 				if (result == CChunkFileReader::ERROR_NONE) {
 					callbackMessage = sc->T("Loaded State");
 					callbackResult = Status::SUCCESS;
 					hasLoadedState = true;
 				} else if (result == CChunkFileReader::ERROR_BROKEN_STATE) {
 					// Cripes.  Good news is, we might have more.  Let's try those too, better than a reset.
-					if (HandleFailure()) {
+					if (HandleLoadFailure()) {
 						// Well, we did rewind, even if too much...
 						callbackMessage = sc->T("Loaded State");
 						callbackResult = Status::SUCCESS;
 						hasLoadedState = true;
 					} else {
-						callbackMessage = i18nLoadFailure;
+						callbackMessage = std::string(i18nLoadFailure) + ": " + errorString;
 						callbackResult = Status::FAILURE;
 					}
 				} else {
-					callbackMessage = i18nLoadFailure;
+					callbackMessage = std::string(i18nLoadFailure) + ": " + errorString;
 					callbackResult = Status::FAILURE;
 				}
 				break;

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -783,7 +783,6 @@ namespace SaveState
 					ERROR_LOG(SAVESTATE, "Load state failure: %s", errorString.c_str());
 					callbackResult = Status::FAILURE;
 				} else {
-					// ?
 					callbackMessage = sc->T(errorString.c_str(), i18nLoadFailure);
 					callbackResult = Status::FAILURE;
 				}

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -69,7 +69,7 @@ namespace SaveState
 	void Save(const std::string &filename, int slot, Callback callback = Callback(), void *cbUserData = 0);
 
 	CChunkFileReader::Error SaveToRam(std::vector<u8> &state);
-	CChunkFileReader::Error LoadFromRam(std::vector<u8> &state);
+	CChunkFileReader::Error LoadFromRam(std::vector<u8> &state, std::string *errorString);
 
 	// For testing / automated tests.  Runs a save state verification pass (async.)
 	// Warning: callback will be called on a different thread.

--- a/GPU/Common/FramebufferCommon.cpp
+++ b/GPU/Common/FramebufferCommon.cpp
@@ -403,7 +403,7 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const Frame
 				// This happens a lot, but virtually always it's cleared.
 				// It's possible the other might not clear, but when every game is reported it's not useful.
 				if (params.isWritingDepth) {
-					WARN_LOG(SCEGE, "FBO reusing depthbuffer, %08x/%08x and %08x/%08x", params.fb_address, params.z_address, vfbs_[i]->fb_address, vfbs_[i]->z_address);
+					WARN_LOG(SCEGE, "FBO reusing depthbuffer, c=%08x/d=%08x and c=%08x/d=%08x", params.fb_address, params.z_address, vfbs_[i]->fb_address, vfbs_[i]->z_address);
 					sharingReported = true;
 				}
 			}
@@ -412,7 +412,7 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const Frame
 	// We already have it!
 	} else if (vfb != currentRenderVfb_) {
 		// Use it as a render target.
-		DEBUG_LOG(FRAMEBUF, "Switching render target to FBO for %08x: %i x %i x %i ", vfb->fb_address, vfb->width, vfb->height, vfb->format);
+		DEBUG_LOG(FRAMEBUF, "Switching render target to FBO for %08x: %d x %d x %d ", vfb->fb_address, vfb->width, vfb->height, vfb->format);
 		vfb->usageFlags |= FB_USAGE_RENDERTARGET;
 		vfb->last_frame_render = gpuStats.numFlips;
 		frameLastFramebufUsed_ = gpuStats.numFlips;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1439,13 +1439,15 @@ void EmuScreen::render() {
 		return;
 	}
 
+	// Freeze-frame functionality (loads a savestate on every frame).
 	if (PSP_CoreParameter().freezeNext) {
 		PSP_CoreParameter().frozen = true;
 		PSP_CoreParameter().freezeNext = false;
 		SaveState::SaveToRam(freezeState_);
 	} else if (PSP_CoreParameter().frozen) {
-		if (CChunkFileReader::ERROR_NONE != SaveState::LoadFromRam(freezeState_)) {
-			ERROR_LOG(SAVESTATE, "Failed to load freeze state. Unfreezing.");
+		std::string errorString;
+		if (CChunkFileReader::ERROR_NONE != SaveState::LoadFromRam(freezeState_, &errorString)) {
+			ERROR_LOG(SAVESTATE, "Failed to load freeze state (%s). Unfreezing.", errorString.c_str());
 			PSP_CoreParameter().frozen = false;
 		}
 	}
@@ -1503,23 +1505,6 @@ void EmuScreen::render() {
 		screenManager()->getUIContext()->BeginFrame();
 		renderUI();
 	}
-
-	// We have no use for backbuffer depth or stencil, so let tiled renderers discard them after tiling.
-	/*
-	if (gl_extensions.GLES3 && glInvalidateFramebuffer != nullptr) {
-		GLenum attachments[2] = { GL_DEPTH, GL_STENCIL };
-		glInvalidateFramebuffer(GL_FRAMEBUFFER, 2, attachments);
-	} else if (!gl_extensions.GLES3) {
-#ifdef USING_GLES2
-		// Tiled renderers like PowerVR should benefit greatly from this. However - seems I can't call it?
-		bool hasDiscard = gl_extensions.EXT_discard_framebuffer;  // TODO
-		if (hasDiscard) {
-			//const GLenum targets[3] = { GL_COLOR_EXT, GL_DEPTH_EXT, GL_STENCIL_EXT };
-			//glDiscardFramebufferEXT(GL_FRAMEBUFFER, 3, targets);
-		}
-#endif
-	}
-	*/
 }
 
 bool EmuScreen::hasVisibleUI() {

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -820,7 +820,8 @@ bool retro_unserialize(const void *data, size_t size)
    if (useEmuThread)
       EmuThreadPause(); // Does nothing if already paused
 
-   retVal = CChunkFileReader::LoadPtr((u8 *)data, state) 
+   std::string errorString;
+   retVal = CChunkFileReader::LoadPtr((u8 *)data, state, &errorString) 
       == CChunkFileReader::ERROR_NONE;
 
    if (useEmuThread)


### PR DESCRIPTION
When a Section is rejected, we now log out the name of it. This would have found the cause of #13236 faster.

Also, doesn't apply "load" error handling in case we get errors during a save.

Plus some assorted minor changes.