### PR TITLE
Fix Libretro core ashmem crashes with targetSdk 29.

### DIFF
--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -486,7 +486,6 @@ SOURCES_CXX += $(NATIVEDIR)/math/dataconv.cpp \
 	       $(COREDIR)/Util/PPGeDraw.cpp \
 	       $(COREDIR)/Util/AudioFormat.cpp \
 	       $(COREDIR)/Util/PortManager.cpp \
-          $(EXTDIR)/disarm.cpp \
           $(CORE_DIR)/UI/TextureUtil.cpp \
           $(CORE_DIR)/UI/GameInfoCache.cpp
 
@@ -509,6 +508,7 @@ ifeq ($(WITH_DYNAREC),1)
 			       $(COREDIR)/MIPS/ARM/ArmJit.cpp \
 			       $(COREDIR)/MIPS/ARM/ArmRegCache.cpp \
 			       $(COREDIR)/MIPS/ARM/ArmRegCacheFPU.cpp \
+                               $(EXTDIR)/disarm.cpp \
 			       $(GPUCOMMONDIR)/VertexDecoderArm.cpp
 
 		ifeq ($(HAVE_NEON),1)
@@ -545,6 +545,7 @@ ifeq ($(WITH_DYNAREC),1)
 			SOURCES_CXX   += \
 					 $(COREDIR)/MIPS/ARM/ArmCompVFPUNEON.cpp \
 					 $(COREDIR)/MIPS/ARM/ArmCompVFPUNEONUtil.cpp \
+					 $(COREDIR)/Util/AudioFormatNEON.cpp \
 					 $(COMMONDIR)/ColorConvNEON.cpp \
 					 $(GPUDIR)/Common/TextureDecoderNEON.cpp
 
@@ -591,11 +592,6 @@ endif
 		SOURCES_C   += $(NATIVEDIR)/math/fast/fast_matrix_sse.c
    endif
 endif
-SOURCES_CXX += \
-   $(COMMONDIR)/ArmEmitter.cpp \
-   $(COMMONDIR)/Arm64Emitter.cpp \
-   $(COREDIR)/Util/DisArm64.cpp
-
 #UDIS86
 # Compiled and linked even on ARM for now
 

--- a/libretro/jni/Android.mk
+++ b/libretro/jni/Android.mk
@@ -9,6 +9,7 @@ COREFLAGS  :=
 CORE_DIR   := ../..
 FFMPEGDIR  := $(CORE_DIR)/ffmpeg
 FFMPEGLIBS += libavformat libavcodec libavutil libswresample libswscale
+WITH_DYNAREC := 1
 
 ifeq ($(TARGET_ARCH),arm64)
   COREFLAGS += -DARM64 -D_ARCH_64

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -3,6 +3,7 @@
 #include <thread>
 #include <atomic>
 #include <vector>
+#include <stdlib.h>
 
 #include "base/timeutil.h"
 #include "Common/ChunkFile.h"
@@ -31,6 +32,10 @@
 
 #include "libretro/libretro.h"
 #include "libretro/LibretroGraphicsContext.h"
+
+#if PPSSPP_PLATFORM(ANDROID)
+#include <sys/system_properties.h>
+#endif
 
 #define DIR_SEP "/"
 #ifdef _WIN32
@@ -857,6 +862,15 @@ int System_GetPropertyInt(SystemProperty prop)
    {
       case SYSPROP_AUDIO_SAMPLE_RATE:
          return SAMPLERATE;
+#if PPSSPP_PLATFORM(ANDROID)
+      case SYSPROP_SYSTEMVERSION: {
+         char sdk[PROP_VALUE_MAX] = {0};
+         if (__system_property_get("ro.build.version.sdk", sdk) != 0) {
+            return atoi(sdk);
+         }
+         return -1;
+      }
+#endif
       default:
          break;
    }


### PR DESCRIPTION
This pull request fixes #13240 along with the build [issue](https://github.com/libretro/libretro-super/issues/1457) I was experiencing on master.

I just tried it out in a sample application with targetSdk 29 and it no longer crashes.