### PR TITLE
UI sound fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2037,6 +2037,11 @@ set(NativeAssets
 	assets/rargray.png
 	assets/unknown.png
 	assets/zip.png
+	assets/sfx_back.wav
+	assets/sfx_confirm.wav
+	assets/sfx_select.wav
+	assets/sfx_toggle_off.wav
+	assets/sfx_toggle_on.wav
 	source_assets/image/logo.png
 	source_assets/image/icon_regular_72.png
 )

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -446,9 +446,6 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 
 	g_Discord.SetPresenceMenu();
 
-	// TODO: Load these in the background instead of synchronously.
-	g_BackgroundAudio.LoadSamples();
-
 	// Make sure UI state is MENU.
 	ResetUIState();
 
@@ -709,6 +706,9 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 		g_Config.sFont = des->T("Font", "Roboto Condensed");
 	}
 #endif
+
+	// TODO: Load these in the background instead of synchronously.
+	g_BackgroundAudio.LoadSamples();
 
 	if (!boot_filename.empty() && stateToLoad != NULL) {
 		SaveState::Load(stateToLoad, -1, [](SaveState::Status status, const std::string &message, void *) {


### PR DESCRIPTION
Add sounds assets to CMake and move `g_BackgroundAudio.LoadSamples();` after the various `VFSRegister` in `NativeInit` or will give error about missing file system (at least on linux it did).