### PR TITLE
Correct the alignment size when allocating memory at a position

### DIFF
--- a/Core/Util/BlockAllocator.cpp
+++ b/Core/Util/BlockAllocator.cpp
@@ -169,7 +169,7 @@ u32 BlockAllocator::AllocAt(u32 position, u32 size, const char *tag)
 	// Upalign size to grain.
 	alignedSize = (alignedSize + grain_ - 1) & ~(grain_ - 1);
 	// Tell the caller the allocated size from their requested starting position.
-	size = alignedSize - (alignedPosition - position);
+	size = alignedSize - (position - alignedPosition);
 
 	Block *bp = GetBlockFromAddress(alignedPosition);
 	if (bp != NULL)

--- a/Core/Util/BlockAllocator.cpp
+++ b/Core/Util/BlockAllocator.cpp
@@ -163,7 +163,7 @@ u32 BlockAllocator::AllocAt(u32 position, u32 size, const char *tag)
 		alignedPosition &= ~(grain_ - 1);
 
 		// Since the position was decreased, size must increase.
-		alignedSize += alignedPosition - position;
+		alignedSize += position - alignedPosition;
 	}
 
 	// Upalign size to grain.


### PR DESCRIPTION
Since the position was **downaligned**, therefore the increased size should be `position - alignedPosition`.Fixes #10972