### PR TITLE
More header cleanups

### DIFF
--- a/Common/ArmCPUDetect.cpp
+++ b/Common/ArmCPUDetect.cpp
@@ -16,6 +16,9 @@
 // http://code.google.com/p/dolphin-emu/
 
 #include "ppsspp_config.h"
+
+#include <sstream>
+
 #if PPSSPP_ARCH(ARM) || PPSSPP_ARCH(ARM64)
 
 #include <ctype.h>

--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -916,7 +916,7 @@ void LoadFromIni(IniFile &file) {
 		return;
 	}
 
-	IniFile::Section *controls = file.GetOrCreateSection("ControlMapping");
+	Section *controls = file.GetOrCreateSection("ControlMapping");
 	for (size_t i = 0; i < ARRAY_SIZE(psp_button_names); i++) {
 		std::string value;
 		controls->Get(psp_button_names[i].name, &value, "");
@@ -943,7 +943,7 @@ void LoadFromIni(IniFile &file) {
 }
 
 void SaveToIni(IniFile &file) {
-	IniFile::Section *controls = file.GetOrCreateSection("ControlMapping");
+	Section *controls = file.GetOrCreateSection("ControlMapping");
 
 	for (size_t i = 0; i < ARRAY_SIZE(psp_button_names); i++) {
 		std::vector<KeyDef> keys;

--- a/Common/KeyMap.cpp
+++ b/Common/KeyMap.cpp
@@ -25,6 +25,7 @@
 #endif
 
 #include "base/logging.h"
+#include "base/stringutil.h"
 #include "base/NativeApp.h"
 #include "file/ini_file.h"
 #include "input/input_state.h"

--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -185,14 +185,14 @@ void LogManager::ChangeFileLog(const char *filename) {
 	}
 }
 
-void LogManager::SaveConfig(IniFile::Section *section) {
+void LogManager::SaveConfig(Section *section) {
 	for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; i++) {
 		section->Set((std::string(log_[i].m_shortName) + "Enabled").c_str(), log_[i].enabled);
 		section->Set((std::string(log_[i].m_shortName) + "Level").c_str(), (int)log_[i].level);
 	}
 }
 
-void LogManager::LoadConfig(IniFile::Section *section, bool debugDefaults) {
+void LogManager::LoadConfig(Section *section, bool debugDefaults) {
 	for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; i++) {
 		bool enabled = false;
 		int level = 0;

--- a/Common/LogManager.h
+++ b/Common/LogManager.h
@@ -180,6 +180,6 @@ public:
 
 	void ChangeFileLog(const char *filename);
 
-	void SaveConfig(IniFile::Section *section);
-	void LoadConfig(IniFile::Section *section, bool debugDefaults);
+	void SaveConfig(Section *section);
+	void LoadConfig(Section *section, bool debugDefaults);
 };

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -20,6 +20,7 @@
 #include <ctime>
 #include <functional>
 #include <set>
+#include <sstream>
 
 #include "base/display.h"
 #include "base/NativeApp.h"

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -203,7 +203,7 @@ struct ConfigSetting {
 		return type_ != TYPE_TERMINATOR;
 	}
 
-	bool Get(IniFile::Section *section) {
+	bool Get(Section *section) {
 		switch (type_) {
 		case TYPE_BOOL:
 			if (cb_.b) {
@@ -256,7 +256,7 @@ struct ConfigSetting {
 		}
 	}
 
-	void Set(IniFile::Section *section) {
+	void Set(Section *section) {
 		if (!save_)
 			return;
 
@@ -1108,9 +1108,9 @@ static ConfigSectionSettings sections[] = {
 	{"Theme", themeSettings},
 };
 
-static void IterateSettings(IniFile &iniFile, std::function<void(IniFile::Section *section, ConfigSetting *setting)> func) {
+static void IterateSettings(IniFile &iniFile, std::function<void(Section *section, ConfigSetting *setting)> func) {
 	for (size_t i = 0; i < ARRAY_SIZE(sections); ++i) {
-		IniFile::Section *section = iniFile.GetOrCreateSection(sections[i].section);
+		Section *section = iniFile.GetOrCreateSection(sections[i].section);
 		for (auto setting = sections[i].settings; setting->HasMore(); ++setting) {
 			func(section, setting);
 		}
@@ -1147,8 +1147,8 @@ std::map<std::string, std::pair<std::string, int>> GetLangValuesMapping() {
 	langCodeMapping["CHINESE_TRADITIONAL"] = PSP_SYSTEMPARAM_LANGUAGE_CHINESE_TRADITIONAL;
 	langCodeMapping["CHINESE_SIMPLIFIED"] = PSP_SYSTEMPARAM_LANGUAGE_CHINESE_SIMPLIFIED;
 
-	IniFile::Section *langRegionNames = mapping.GetOrCreateSection("LangRegionNames");
-	IniFile::Section *systemLanguage = mapping.GetOrCreateSection("SystemLanguage");
+	Section *langRegionNames = mapping.GetOrCreateSection("LangRegionNames");
+	Section *systemLanguage = mapping.GetOrCreateSection("SystemLanguage");
 
 	for (size_t i = 0; i < keys.size(); i++) {
 		std::string langName;
@@ -1187,7 +1187,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 		// Continue anyway to initialize the config.
 	}
 
-	IterateSettings(iniFile, [](IniFile::Section *section, ConfigSetting *setting) {
+	IterateSettings(iniFile, [](Section *section, ConfigSetting *setting) {
 		setting->Get(section);
 	});
 
@@ -1195,7 +1195,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	if (!File::Exists(currentDirectory))
 		currentDirectory = "";
 
-	IniFile::Section *log = iniFile.GetOrCreateSection(logSectionName);
+	Section *log = iniFile.GetOrCreateSection(logSectionName);
 
 	bool debugDefaults = false;
 #ifdef _DEBUG
@@ -1203,7 +1203,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 #endif
 	LogManager::GetInstance()->LoadConfig(log, debugDefaults);
 
-	IniFile::Section *recent = iniFile.GetOrCreateSection("Recent");
+	Section *recent = iniFile.GetOrCreateSection("Recent");
 	recent->Get("MaxRecent", &iMaxRecent, 30);
 
 	// Fix issue from switching from uint (hex in .ini) to int (dec)
@@ -1249,7 +1249,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	}
 
 	// Check for an old dpad setting
-	IniFile::Section *control = iniFile.GetOrCreateSection("Control");
+	Section *control = iniFile.GetOrCreateSection("Control");
 	float f;
 	control->Get("DPadRadius", &f, 0.0f);
 	if (f > 0.0f) {
@@ -1338,13 +1338,13 @@ void Config::Save(const char *saveReason) {
 		// Need to do this somewhere...
 		bFirstRun = false;
 
-		IterateSettings(iniFile, [&](IniFile::Section *section, ConfigSetting *setting) {
+		IterateSettings(iniFile, [&](Section *section, ConfigSetting *setting) {
 			if (!bGameSpecific || !setting->perGame_) {
 				setting->Set(section);
 			}
 		});
 
-		IniFile::Section *recent = iniFile.GetOrCreateSection("Recent");
+		Section *recent = iniFile.GetOrCreateSection("Recent");
 		recent->Set("MaxRecent", iMaxRecent);
 
 		for (int i = 0; i < iMaxRecent; i++) {
@@ -1357,7 +1357,7 @@ void Config::Save(const char *saveReason) {
 			}
 		}
 
-		IniFile::Section *pinnedPaths = iniFile.GetOrCreateSection("PinnedPaths");
+		Section *pinnedPaths = iniFile.GetOrCreateSection("PinnedPaths");
 		pinnedPaths->Clear();
 		for (size_t i = 0; i < vPinnedPaths.size(); ++i) {
 			char keyName[64];
@@ -1366,17 +1366,17 @@ void Config::Save(const char *saveReason) {
 		}
 
 		if (!bGameSpecific) {
-			IniFile::Section *postShaderSetting = iniFile.GetOrCreateSection("PostShaderSetting");
+			Section *postShaderSetting = iniFile.GetOrCreateSection("PostShaderSetting");
 			postShaderSetting->Clear();
 			for (auto it = mPostShaderSetting.begin(), end = mPostShaderSetting.end(); it != end; ++it) {
 				postShaderSetting->Set(it->first.c_str(), it->second);
 			}
 		}
 
-		IniFile::Section *control = iniFile.GetOrCreateSection("Control");
+		Section *control = iniFile.GetOrCreateSection("Control");
 		control->Delete("DPadRadius");
 
-		IniFile::Section *log = iniFile.GetOrCreateSection(logSectionName);
+		Section *log = iniFile.GetOrCreateSection(logSectionName);
 		if (LogManager::GetInstance())
 			LogManager::GetInstance()->SaveConfig(log);
 
@@ -1614,16 +1614,16 @@ bool Config::saveGameConfig(const std::string &pGameId, const std::string &title
 
 	IniFile iniFile;
 
-	IniFile::Section *top = iniFile.GetOrCreateSection("");
+	Section *top = iniFile.GetOrCreateSection("");
 	top->AddComment(StringFromFormat("Game config for %s - %s", pGameId.c_str(), title.c_str()));
 
-	IterateSettings(iniFile, [](IniFile::Section *section, ConfigSetting *setting) {
+	IterateSettings(iniFile, [](Section *section, ConfigSetting *setting) {
 		if (setting->perGame_) {
 			setting->Set(section);
 		}
 	});
 
-	IniFile::Section *postShaderSetting = iniFile.GetOrCreateSection("PostShaderSetting");
+	Section *postShaderSetting = iniFile.GetOrCreateSection("PostShaderSetting");
 	postShaderSetting->Clear();
 	for (auto it = mPostShaderSetting.begin(), end = mPostShaderSetting.end(); it != end; ++it) {
 		postShaderSetting->Set(it->first.c_str(), it->second);
@@ -1653,7 +1653,7 @@ bool Config::loadGameConfig(const std::string &pGameId, const std::string &title
 		mPostShaderSetting[it.first] = std::stof(it.second);
 	}
 
-	IterateSettings(iniFile, [](IniFile::Section *section, ConfigSetting *setting) {
+	IterateSettings(iniFile, [](Section *section, ConfigSetting *setting) {
 		if (setting->perGame_) {
 			setting->Get(section);
 		}
@@ -1671,7 +1671,7 @@ void Config::unloadGameConfig() {
 		iniFile.Load(iniFilename_);
 
 		// Reload game specific settings back to standard.
-		IterateSettings(iniFile, [](IniFile::Section *section, ConfigSetting *setting) {
+		IterateSettings(iniFile, [](Section *section, ConfigSetting *setting) {
 			if (setting->perGame_) {
 				setting->Get(section);
 			}

--- a/Core/Debugger/WebSocket/WebSocketUtils.cpp
+++ b/Core/Debugger/WebSocket/WebSocketUtils.cpp
@@ -17,6 +17,7 @@
 
 #include <cmath>
 #include <limits>
+#include "util/text/parsers.h"
 #include "Common/StringUtils.h"
 #include "Core/Debugger/WebSocket/WebSocketUtils.h"
 

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -21,6 +21,7 @@
 
 #include <thread>
 
+#include "base/stringutil.h"
 #include "i18n/i18n.h"
 #include "thread/threadutil.h"
 

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <limits>
+#include "base/stringutil.h"
 #include "file/free.h"
 #include "file/zip_read.h"
 #include "i18n/i18n.h"

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -19,6 +19,8 @@
 
 #include <algorithm>
 #include <limits>
+
+#include "base/stringutil.h"
 #include "file/free.h"
 #include "file/zip_read.h"
 #include "i18n/i18n.h"

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -20,6 +20,7 @@
 #include <thread>
 #include <mutex>
 
+#include "base/stringutil.h"
 #include "base/timeutil.h"
 #include "i18n/i18n.h"
 #include "thread/threadutil.h"

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -21,6 +21,7 @@
 #include <mutex>
 
 #include "base/timeutil.h"
+#include "base/stringutil.h"
 #include "i18n/i18n.h"
 #include "thread/threadutil.h"
 #include "util/text/parsers.h"

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -26,6 +26,7 @@
 #include "i18n/i18n.h"
 #include "ext/xxhash.h"
 #include "file/ini_file.h"
+#include "util/text/parsers.h"
 #include "Common/ColorConv.h"
 #include "Common/FileUtil.h"
 #include "Core/Config.h"

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include <algorithm>
+#include "base/stringutil.h"
 #include "i18n/i18n.h"
 #include "ext/xxhash.h"
 #include "file/ini_file.h"

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -21,6 +21,7 @@
 #include <set>
 #include <cstring>
 #include <thread>
+#include <sstream>
 
 #include "file/file_util.h"
 #ifdef SHARED_LIBZIP

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -30,6 +30,7 @@
 #include "ext/libzip/zip.h"
 #endif
 #include "util/text/utf8.h"
+#include "file/ini_file.h"
 
 #include "Common/Log.h"
 #include "Common/FileUtil.h"

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -103,7 +103,7 @@ void LoadPostShaderInfo(const std::vector<std::string> &directories) {
 
 			// Alright, let's loop through the sections and see if any is a shader.
 			for (size_t i = 0; i < ini.Sections().size(); i++) {
-				IniFile::Section &section = ini.Sections()[i];
+				Section &section = ini.Sections()[i];
 				std::string shaderType;
 				section.Get("Type", &shaderType, "render");
 

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -23,6 +23,7 @@
 #include <map>
 #include "gfx/d3d9_shader.h"
 #include "base/logging.h"
+#include "base/stringutil.h"
 #include "i18n/i18n.h"
 #include "math/lin/matrix4x4.h"
 #include "math/math_util.h"

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -1,6 +1,7 @@
 #include <cstring>
 #include <memory>
 #include <set>
+#include <sstream>
 
 #include "profiler/profiler.h"
 

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "base/stringutil.h"
 #include "ext/cityhash/city.h"
 #include "i18n/i18n.h"
 #include "ui/ui.h"

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 
 #include "base/display.h"
+#include "base/stringutil.h"
 #include "gfx_es2/gpu_features.h"
 #include "i18n/i18n.h"
 #include "ui/ui_context.h"

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -44,8 +44,9 @@
 #endif
 
 #include "base/display.h"
-#include "base/timeutil.h"
 #include "base/logging.h"
+#include "base/stringutil.h"
+#include "base/timeutil.h"
 #include "base/NativeApp.h"
 #include "file/vfs.h"
 #include "file/zip_read.h"

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -17,6 +17,8 @@
 
 #include <algorithm>
 #include <memory>
+
+#include "base/stringutil.h"
 #include "i18n/i18n.h"
 #include "gfx_es2/draw_buffer.h"
 #include "ui/view.h"

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <memory>
+#include "base/stringutil.h"
 #include "i18n/i18n.h"
 #include "gfx_es2/draw_buffer.h"
 #include "ui/view.h"

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -25,6 +25,7 @@
 #include <netfw.h>
 #endif
 
+#include "base/stringutil.h"
 #include "base/timeutil.h"
 #include "file/path.h"
 // TODO: For text align flags, probably shouldn't be in gfx_es2/...

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -16,7 +16,9 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include <string>
+
 #include "base/display.h"
+#include "base/stringutil.h"
 // TODO: For text align flags, probably shouldn't be in gfx_es2/...
 #include "gfx_es2/draw_buffer.h"
 #include "i18n/i18n.h"

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -17,6 +17,7 @@
 
 #include <string>
 #include "base/display.h"
+#include "base/stringutil.h"
 // TODO: For text align flags, probably shouldn't be in gfx_es2/...
 #include "gfx_es2/draw_buffer.h"
 #include "i18n/i18n.h"

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -20,6 +20,7 @@
 
 #include "base/colorutil.h"
 #include "base/timeutil.h"
+#include "base/stringutil.h"
 #include "gfx_es2/draw_buffer.h"
 #include "i18n/i18n.h"
 #include "math/curves.h"

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -19,6 +19,7 @@
 #include <functional>
 
 #include "base/colorutil.h"
+#include "base/stringutil.h"
 #include "base/timeutil.h"
 #include "gfx_es2/draw_buffer.h"
 #include "i18n/i18n.h"

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "base/stringutil.h"
+#include "util/text/parsers.h"
 #include "Common/ColorConv.h"
 #include "Core/Config.h"
 #include "Core/Screenshot.h"

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -34,6 +34,7 @@
 
 #include "base/display.h"
 #include "base/NativeApp.h"
+#include "base/stringutil.h"
 #include "base/timeutil.h"
 #include "i18n/i18n.h"
 #include "input/input_state.h"

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -1,11 +1,13 @@
 #include <map>
 #include <string>
+#include <sstream>
 
 #include "CommonWindows.h"
 #include <shellapi.h>
 
 #include "resource.h"
 
+#include "base/stringutil.h"
 #include "i18n/i18n.h"
 #include "util/text/utf8.h"
 #include "base/NativeApp.h"

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -1,5 +1,6 @@
 #include <map>
 #include <string>
+#include <sstream>
 
 #include "CommonWindows.h"
 #include <shellapi.h>

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -31,8 +31,9 @@
 #include <ShlObj.h>
 #include <mmsystem.h>
 
-#include "base/NativeApp.h"
 #include "base/display.h"
+#include "base/stringutil.h"
+#include "base/NativeApp.h"
 #include "file/vfs.h"
 #include "file/zip_read.h"
 #include "i18n/i18n.h"

--- a/ext/native/base/stringutil.cpp
+++ b/ext/native/base/stringutil.cpp
@@ -8,8 +8,8 @@
 #define _GNU_SOURCE
 #include <stdio.h>
 #endif
-#include <string.h>
-#include <stdarg.h>
+#include <cstring>
+#include <cstdarg>
 #include <errno.h>
 #include <string>
 #include <sstream>
@@ -240,6 +240,7 @@ bool TryParse(const std::string &str, uint32_t *const output)
 	if (errno == ERANGE)
 		return false;
 
+	// Range check
 	if (ULONG_MAX > UINT_MAX) {
 #ifdef _MSC_VER
 #pragma warning (disable:4309)
@@ -264,6 +265,30 @@ bool TryParse(const std::string &str, bool *const output)
 		return false;
 
 	return true;
+}
+
+template <typename N>
+bool TryParseImpl(const std::string &str, N *const output) {
+	std::istringstream iss(str);
+	N tmp = 0;
+	if (iss >> tmp) {
+		*output = tmp;
+		return true;
+	} else {
+		return false;
+	}
+}
+
+bool TryParse(const std::string &str, int32_t *const output) {
+	return TryParseImpl(str, output);
+}
+
+bool TryParse(const std::string &str, float *const output) {
+	return TryParseImpl(str, output);
+}
+
+bool TryParse(const std::string &str, double *const output) {
+	return TryParseImpl(str, output);
 }
 
 void SplitString(const std::string& str, const char delim, std::vector<std::string>& output)

--- a/ext/native/base/stringutil.cpp
+++ b/ext/native/base/stringutil.cpp
@@ -22,8 +22,6 @@
 #include "base/stringutil.h"
 
 #ifdef _WIN32
-// Function Cross-Compatibility
-#define strcasecmp _stricmp
 
 void OutputDebugStringUTF8(const char *p) {
 	wchar_t temp[4096];
@@ -82,46 +80,6 @@ void StringUpper(char *str, int len) {
 		*str = toupper(*str);
 		str++;
 	}
-}
-
-
-unsigned int parseHex(const char *_szValue)
-{
-	int Value = 0;
-	size_t Finish = strlen(_szValue);
-	if (Finish > 8 ) { Finish = 8; }
-
-	for (size_t Count = 0; Count < Finish; Count++) {
-		Value = (Value << 4);
-		switch( _szValue[Count] ) {
-		case '0': break;
-		case '1': Value += 1; break;
-		case '2': Value += 2; break;
-		case '3': Value += 3; break;
-		case '4': Value += 4; break;
-		case '5': Value += 5; break;
-		case '6': Value += 6; break;
-		case '7': Value += 7; break;
-		case '8': Value += 8; break;
-		case '9': Value += 9; break;
-		case 'A': Value += 10; break;
-		case 'a': Value += 10; break;
-		case 'B': Value += 11; break;
-		case 'b': Value += 11; break;
-		case 'C': Value += 12; break;
-		case 'c': Value += 12; break;
-		case 'D': Value += 13; break;
-		case 'd': Value += 13; break;
-		case 'E': Value += 14; break;
-		case 'e': Value += 14; break;
-		case 'F': Value += 15; break;
-		case 'f': Value += 15; break;
-		default:
-			Value = (Value >> 4);
-			Count = Finish;
-		}
-	}
-	return Value;
 }
 
 void DataToHexString(const uint8_t *data, size_t size, std::string *output) {
@@ -221,49 +179,6 @@ std::string ArrayToString(const uint8_t *data, uint32_t size, int line_len, bool
 	}
 
 	return oss.str();
-}
-
-bool TryParse(const std::string &str, uint32_t *const output)
-{
-	char *endptr = NULL;
-
-	// Holy crap this is ugly.
-
-	// Reset errno to a value other than ERANGE
-	errno = 0;
-
-	unsigned long value = strtoul(str.c_str(), &endptr, 0);
-
-	if (!endptr || *endptr)
-		return false;
-
-	if (errno == ERANGE)
-		return false;
-
-	if (ULONG_MAX > UINT_MAX) {
-#ifdef _MSC_VER
-#pragma warning (disable:4309)
-#endif
-		// Note: The typecasts avoid GCC warnings when long is 32 bits wide.
-		if (value >= static_cast<unsigned long>(0x100000000ull)
-			&& value <= static_cast<unsigned long>(0xFFFFFFFF00000000ull))
-			return false;
-	}
-
-	*output = static_cast<uint32_t>(value);
-	return true;
-}
-
-bool TryParse(const std::string &str, bool *const output)
-{
-	if ("1" == str || !strcasecmp("true", str.c_str()))
-		*output = true;
-	else if ("0" == str || !strcasecmp("false", str.c_str()))
-		*output = false;
-	else
-		return false;
-
-	return true;
 }
 
 void SplitString(const std::string& str, const char delim, std::vector<std::string>& output)

--- a/ext/native/base/stringutil.h
+++ b/ext/native/base/stringutil.h
@@ -9,6 +9,7 @@
 #ifdef _MSC_VER
 #pragma warning (disable:4996)
 #define strncasecmp _strnicmp
+#define strcasecmp _stricmp
 #else
 #include <strings.h>
 #endif
@@ -59,10 +60,6 @@ inline void StringToHexString(const std::string &data, std::string *output) {
   DataToHexString((uint8_t *)(&data[0]), data.size(), output);
 }
 
-
-// highly unsafe and not recommended.
-unsigned int parseHex(const char* _szValue);
-
 std::string StringFromFormat(const char* format, ...);
 std::string StringFromInt(int value);
 std::string StringFromBool(bool value);
@@ -72,23 +69,6 @@ std::string ArrayToString(const uint8_t *data, uint32_t size, int line_len = 20,
 std::string StripSpaces(const std::string &s);
 std::string StripQuotes(const std::string &s);
 
-bool TryParse(const std::string &str, bool *const output);
-bool TryParse(const std::string &str, uint32_t *const output);
-
-template <typename N>
-static bool TryParse(const std::string &str, N *const output)
-{
-	std::istringstream iss(str);
-
-	N tmp = 0;
-	if (iss >> tmp)
-	{
-		*output = tmp;
-		return true;
-	}
-	else
-		return false;
-}
 void SplitString(const std::string& str, const char delim, std::vector<std::string>& output);
 
 void GetQuotedStrings(const std::string& str, std::vector<std::string>& output);
@@ -97,14 +77,6 @@ std::string ReplaceAll(std::string input, const std::string& src, const std::str
 
 // Compare two strings, ignore the difference between the ignorestr1 and the ignorestr2 in str1 and str2.
 int strcmpIgnore(std::string str1, std::string str2, std::string ignorestr1, std::string ignorestr2);
-
-template <typename N>
-static std::string ValueToString(const N value)
-{
-	std::stringstream string;
-	string << value;
-	return string.str();
-}
 
 void StringTrimEndNonAlphaNum(char *str);
 void SkipSpace(const char **ptr);

--- a/ext/native/base/stringutil.h
+++ b/ext/native/base/stringutil.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <sstream>
 #include <vector>
 
 #include "base/basictypes.h"
@@ -37,7 +36,7 @@ inline bool startsWith(const std::string &str, const std::string &what) {
 inline bool endsWith(const std::string &str, const std::string &what) {
 	if (str.size() < what.size())
 		return false;
-  return str.substr(str.size() - what.size()) == what;
+	return str.substr(str.size() - what.size()) == what;
 }
 
 // Only use on strings where you're only concerned about ASCII.
@@ -56,9 +55,8 @@ inline bool endsWithNoCase(const std::string &str, const std::string &what) {
 
 void DataToHexString(const uint8_t *data, size_t size, std::string *output);
 inline void StringToHexString(const std::string &data, std::string *output) {
-  DataToHexString((uint8_t *)(&data[0]), data.size(), output);
+	DataToHexString((uint8_t *)(&data[0]), data.size(), output);
 }
-
 
 // highly unsafe and not recommended.
 unsigned int parseHex(const char* _szValue);
@@ -74,21 +72,10 @@ std::string StripQuotes(const std::string &s);
 
 bool TryParse(const std::string &str, bool *const output);
 bool TryParse(const std::string &str, uint32_t *const output);
+bool TryParse(const std::string &str, int32_t *const output);
+bool TryParse(const std::string &str, float *const output);
+bool TryParse(const std::string &str, double *const output);
 
-template <typename N>
-static bool TryParse(const std::string &str, N *const output)
-{
-	std::istringstream iss(str);
-
-	N tmp = 0;
-	if (iss >> tmp)
-	{
-		*output = tmp;
-		return true;
-	}
-	else
-		return false;
-}
 void SplitString(const std::string& str, const char delim, std::vector<std::string>& output);
 
 void GetQuotedStrings(const std::string& str, std::vector<std::string>& output);
@@ -97,14 +84,6 @@ std::string ReplaceAll(std::string input, const std::string& src, const std::str
 
 // Compare two strings, ignore the difference between the ignorestr1 and the ignorestr2 in str1 and str2.
 int strcmpIgnore(std::string str1, std::string str2, std::string ignorestr1, std::string ignorestr2);
-
-template <typename N>
-static std::string ValueToString(const N value)
-{
-	std::stringstream string;
-	string << value;
-	return string.str();
-}
 
 void StringTrimEndNonAlphaNum(char *str);
 void SkipSpace(const char **ptr);

--- a/ext/native/file/file_util.cpp
+++ b/ext/native/file/file_util.cpp
@@ -4,9 +4,6 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #include <direct.h>
-#ifndef strcasecmp
-#define strcasecmp _stricmp
-#endif
 #else
 #include <strings.h>
 #include <dirent.h>
@@ -23,6 +20,7 @@
 
 #include "base/logging.h"
 #include "base/basictypes.h"
+#include "base/stringutil.h"
 #include "file/file_util.h"
 #include "util/text/utf8.h"
 

--- a/ext/native/file/ini_file.cpp
+++ b/ext/native/file/ini_file.cpp
@@ -149,11 +149,11 @@ static std::string EscapeComments(const std::string &value) {
 	return result;
 }
 
-void IniFile::Section::Clear() {
+void Section::Clear() {
 	lines.clear();
 }
 
-std::string* IniFile::Section::GetLine(const char* key, std::string* valueOut, std::string* commentOut)
+std::string* Section::GetLine(const char* key, std::string* valueOut, std::string* commentOut)
 {
 	for (std::vector<std::string>::iterator iter = lines.begin(); iter != lines.end(); ++iter)
 	{
@@ -166,7 +166,7 @@ std::string* IniFile::Section::GetLine(const char* key, std::string* valueOut, s
 	return 0;
 }
 
-void IniFile::Section::Set(const char* key, const char* newValue)
+void Section::Set(const char* key, const char* newValue)
 {
 	std::string value, commented;
 	std::string* line = GetLine(key, &value, &commented);
@@ -182,7 +182,7 @@ void IniFile::Section::Set(const char* key, const char* newValue)
 	}
 }
 
-void IniFile::Section::Set(const char* key, const std::string& newValue, const std::string& defaultValue)
+void Section::Set(const char* key, const std::string& newValue, const std::string& defaultValue)
 {
 	if (newValue != defaultValue)
 		Set(key, newValue);
@@ -190,7 +190,7 @@ void IniFile::Section::Set(const char* key, const std::string& newValue, const s
 		Delete(key);
 }
 
-bool IniFile::Section::Get(const char* key, std::string* value, const char* defaultValue)
+bool Section::Get(const char* key, std::string* value, const char* defaultValue)
 {
 	const std::string* line = GetLine(key, value, 0);
 	if (!line)
@@ -204,7 +204,7 @@ bool IniFile::Section::Get(const char* key, std::string* value, const char* defa
 	return true;
 }
 
-void IniFile::Section::Set(const char* key, const float newValue, const float defaultValue)
+void Section::Set(const char* key, const float newValue, const float defaultValue)
 {
 	if (newValue != defaultValue)
 		Set(key, newValue);
@@ -212,7 +212,7 @@ void IniFile::Section::Set(const char* key, const float newValue, const float de
 		Delete(key);
 }
 
-void IniFile::Section::Set(const char* key, int newValue, int defaultValue)
+void Section::Set(const char* key, int newValue, int defaultValue)
 {
 	if (newValue != defaultValue)
 		Set(key, newValue);
@@ -220,7 +220,7 @@ void IniFile::Section::Set(const char* key, int newValue, int defaultValue)
 		Delete(key);
 }
 
-void IniFile::Section::Set(const char* key, bool newValue, bool defaultValue)
+void Section::Set(const char* key, bool newValue, bool defaultValue)
 {
 	if (newValue != defaultValue)
 		Set(key, newValue);
@@ -228,7 +228,7 @@ void IniFile::Section::Set(const char* key, bool newValue, bool defaultValue)
 		Delete(key);
 }
 
-void IniFile::Section::Set(const char* key, const std::vector<std::string>& newValues) 
+void Section::Set(const char* key, const std::vector<std::string>& newValues) 
 {
 	std::string temp;
 	// Join the strings with , 
@@ -243,11 +243,11 @@ void IniFile::Section::Set(const char* key, const std::vector<std::string>& newV
 	Set(key, temp.c_str());
 }
 
-void IniFile::Section::AddComment(const std::string &comment) {
+void Section::AddComment(const std::string &comment) {
 	lines.push_back("# " + comment);
 }
 
-bool IniFile::Section::Get(const char* key, std::vector<std::string>& values) 
+bool Section::Get(const char* key, std::vector<std::string>& values) 
 {
 	std::string temp;
 	bool retval = Get(key, &temp, 0);
@@ -275,7 +275,7 @@ bool IniFile::Section::Get(const char* key, std::vector<std::string>& values)
 	return true;
 }
 
-bool IniFile::Section::Get(const char* key, int* value, int defaultValue)
+bool Section::Get(const char* key, int* value, int defaultValue)
 {
 	std::string temp;
 	bool retval = Get(key, &temp, 0);
@@ -285,7 +285,7 @@ bool IniFile::Section::Get(const char* key, int* value, int defaultValue)
 	return false;
 }
 
-bool IniFile::Section::Get(const char* key, uint32_t* value, uint32_t defaultValue)
+bool Section::Get(const char* key, uint32_t* value, uint32_t defaultValue)
 {
 	std::string temp;
 	bool retval = Get(key, &temp, 0);
@@ -295,7 +295,7 @@ bool IniFile::Section::Get(const char* key, uint32_t* value, uint32_t defaultVal
 	return false;
 }
 
-bool IniFile::Section::Get(const char* key, bool* value, bool defaultValue)
+bool Section::Get(const char* key, bool* value, bool defaultValue)
 {
 	std::string temp;
 	bool retval = Get(key, &temp, 0);
@@ -305,7 +305,7 @@ bool IniFile::Section::Get(const char* key, bool* value, bool defaultValue)
 	return false;
 }
 
-bool IniFile::Section::Get(const char* key, float* value, float defaultValue)
+bool Section::Get(const char* key, float* value, float defaultValue)
 {
 	std::string temp;
 	bool retval = Get(key, &temp, 0);
@@ -315,7 +315,7 @@ bool IniFile::Section::Get(const char* key, float* value, float defaultValue)
 	return false;
 }
 
-bool IniFile::Section::Get(const char* key, double* value, double defaultValue)
+bool Section::Get(const char* key, double* value, double defaultValue)
 {
 	std::string temp;
 	bool retval = Get(key, &temp, 0);
@@ -325,7 +325,7 @@ bool IniFile::Section::Get(const char* key, double* value, double defaultValue)
 	return false;
 }
 
-bool IniFile::Section::Exists(const char *key) const
+bool Section::Exists(const char *key) const
 {
 	for (std::vector<std::string>::const_iterator iter = lines.begin(); iter != lines.end(); ++iter)
 	{
@@ -337,7 +337,7 @@ bool IniFile::Section::Exists(const char *key) const
 	return false;
 }
 
-std::map<std::string, std::string> IniFile::Section::ToMap() const
+std::map<std::string, std::string> Section::ToMap() const
 {
 	std::map<std::string, std::string> outMap;
 	for (std::vector<std::string>::const_iterator iter = lines.begin(); iter != lines.end(); ++iter)
@@ -351,7 +351,7 @@ std::map<std::string, std::string> IniFile::Section::ToMap() const
 }
 
 
-bool IniFile::Section::Delete(const char *key)
+bool Section::Delete(const char *key)
 {
 	std::string* line = GetLine(key, 0, 0);
 	for (std::vector<std::string>::iterator liter = lines.begin(); liter != lines.end(); ++liter)
@@ -367,7 +367,7 @@ bool IniFile::Section::Delete(const char *key)
 
 // IniFile
 
-const IniFile::Section* IniFile::GetSection(const char* sectionName) const
+const Section* IniFile::GetSection(const char* sectionName) const
 {
 	for (std::vector<Section>::const_iterator iter = sections.begin(); iter != sections.end(); ++iter)
 		if (!strcasecmp(iter->name().c_str(), sectionName))
@@ -375,7 +375,7 @@ const IniFile::Section* IniFile::GetSection(const char* sectionName) const
 	return 0;
 }
 
-IniFile::Section* IniFile::GetSection(const char* sectionName)
+Section* IniFile::GetSection(const char* sectionName)
 {
 	for (std::vector<Section>::iterator iter = sections.begin(); iter != sections.end(); ++iter)
 		if (!strcasecmp(iter->name().c_str(), sectionName))
@@ -383,7 +383,7 @@ IniFile::Section* IniFile::GetSection(const char* sectionName)
 	return 0;
 }
 
-IniFile::Section* IniFile::GetOrCreateSection(const char* sectionName)
+Section* IniFile::GetOrCreateSection(const char* sectionName)
 {
 	Section* section = GetSection(sectionName);
 	if (!section)

--- a/ext/native/file/ini_file.cpp
+++ b/ext/native/file/ini_file.cpp
@@ -2,8 +2,8 @@
 // Taken from Dolphin but relicensed by me, Henrik Rydgard, under the MIT
 // license as I wrote the whole thing originally and it has barely changed.
 
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 
 #ifndef _MSC_VER
 #include <strings.h>
@@ -13,6 +13,7 @@
 #include <vector>
 #include <iostream>
 #include <fstream>
+#include <sstream>
 #include <algorithm>
 
 #include "base/logging.h"

--- a/ext/native/file/ini_file.cpp
+++ b/ext/native/file/ini_file.cpp
@@ -19,11 +19,10 @@
 #include "base/stringutil.h"
 #include "file/ini_file.h"
 #include "file/vfs.h"
+#include "util/text/parsers.h"
 
 #ifdef _WIN32
 #include "../util/text/utf8.h"
-	// Function Cross-Compatibility
-#define strcasecmp _stricmp
 #endif
 
 static bool ParseLineKey(const std::string &line, size_t &pos, std::string *keyOut) {

--- a/ext/native/file/ini_file.h
+++ b/ext/native/file/ini_file.h
@@ -19,120 +19,120 @@ inline std::string ValueToString(const N value)
 	return string.str();
 }
 
+class Section
+{
+	friend class IniFile;
+
+public:
+	Section() {}
+	Section(const std::string& name) : name_(name) {}
+
+	bool Exists(const char *key) const;
+	bool Delete(const char *key);
+
+	void Clear();
+
+	std::map<std::string, std::string> ToMap() const;
+
+	std::string* GetLine(const char* key, std::string* valueOut, std::string* commentOut);
+	void Set(const char* key, const char* newValue);
+	void Set(const char* key, const std::string& newValue, const std::string& defaultValue);
+
+	void Set(const std::string &key, const std::string &value) {
+		Set(key.c_str(), value.c_str());
+	}
+	bool Get(const char* key, std::string* value, const char* defaultValue);
+
+	void Set(const char* key, uint32_t newValue) {
+		Set(key, StringFromFormat("0x%08x", newValue).c_str());
+	}
+	void Set(const char* key, float newValue) {
+		Set(key, StringFromFormat("%f", newValue).c_str());
+	}
+	void Set(const char* key, const float newValue, const float defaultValue);
+	void Set(const char* key, double newValue) {
+		Set(key, StringFromFormat("%f", newValue).c_str());
+	}
+
+	void Set(const char* key, int newValue, int defaultValue);
+	void Set(const char* key, int newValue) {
+		Set(key, StringFromInt(newValue).c_str());
+	}
+
+	void Set(const char* key, bool newValue, bool defaultValue);
+	void Set(const char* key, bool newValue) {
+		Set(key, StringFromBool(newValue).c_str());
+	}
+	void Set(const char* key, const std::vector<std::string>& newValues);
+
+	template<typename U, typename V>
+	void Set(const char* key, const std::map<U, V>& newValues)
+	{
+		std::vector<std::string> temp;
+		for (typename std::map<U, V>::const_iterator it = newValues.begin(); it != newValues.end(); it++)
+		{
+			temp.push_back(ValueToString<U>(it->first) + "_" + ValueToString<V>(it->second));
+		}
+		Set(key, temp);
+	}
+
+	// Declare without a body to make it fail to compile. This is to prevent accidentally
+	// setting a pointer as a bool. The failure is in the linker unfortunately, but that's better
+	// than accidentally succeeding in a bad way.
+	template<class T>
+	void Set(const char *key, T *ptr);
+
+	void AddComment(const std::string &comment);
+
+	bool Get(const char* key, int* value, int defaultValue = 0);
+	bool Get(const char* key, uint32_t* value, uint32_t defaultValue = 0);
+	bool Get(const char* key, bool* value, bool defaultValue = false);
+	bool Get(const char* key, float* value, float defaultValue = false);
+	bool Get(const char* key, double* value, double defaultValue = false);
+	bool Get(const char* key, std::vector<std::string>& values);
+	template<typename U, typename V>
+	bool Get(const char* key, std::map<U, V>& values)
+	{
+		std::vector<std::string> temp;
+		if (!Get(key, temp))
+		{
+			return false;
+		}
+		values.clear();
+		for (size_t i = 0; i < temp.size(); i++)
+		{
+			std::vector<std::string> key_val;
+			SplitString(temp[i], '_', key_val);
+			if (key_val.size() < 2)
+				continue;
+			U mapKey;
+			V mapValue;
+			if (!TryParse(key_val[0], &mapKey))
+				continue;
+			if (!TryParse(key_val[1], &mapValue))
+				continue;
+			values[mapKey] = mapValue;
+		}
+		return true;
+	}
+
+	bool operator < (const Section& other) const {
+		return name_ < other.name_;
+	}
+
+	const std::string &name() const {
+		return name_;
+	}
+
+protected:
+	std::vector<std::string> lines;
+	std::string name_;
+	std::string comment;
+};
+
 class IniFile
 {
 public:
-	class Section
-	{
-		friend class IniFile;
-
-	public:
-		Section() {}
-		Section(const std::string& name) : name_(name) {}
-
-		bool Exists(const char *key) const;
-		bool Delete(const char *key);
-
-		void Clear();
-
-		std::map<std::string, std::string> ToMap() const;
-
-		std::string* GetLine(const char* key, std::string* valueOut, std::string* commentOut);
-		void Set(const char* key, const char* newValue);
-		void Set(const char* key, const std::string& newValue, const std::string& defaultValue);
-
-		void Set(const std::string &key, const std::string &value) {
-			Set(key.c_str(), value.c_str());
-		}
-		bool Get(const char* key, std::string* value, const char* defaultValue);
-
-		void Set(const char* key, uint32_t newValue) {
-			Set(key, StringFromFormat("0x%08x", newValue).c_str());
-		}
-		void Set(const char* key, float newValue) {
-			Set(key, StringFromFormat("%f", newValue).c_str());
-		}
-		void Set(const char* key, const float newValue, const float defaultValue);
-		void Set(const char* key, double newValue) {
-			Set(key, StringFromFormat("%f", newValue).c_str());
-		}
-		
-		void Set(const char* key, int newValue, int defaultValue);
-		void Set(const char* key, int newValue) {
-			Set(key, StringFromInt(newValue).c_str());
-		}
-		
-		void Set(const char* key, bool newValue, bool defaultValue);
-		void Set(const char* key, bool newValue) {
-			Set(key, StringFromBool(newValue).c_str());
-		}
-		void Set(const char* key, const std::vector<std::string>& newValues);
-
-		template<typename U, typename V>
-		void Set(const char* key, const std::map<U,V>& newValues)
-		{
-			std::vector<std::string> temp;
-			for(typename std::map<U,V>::const_iterator it = newValues.begin(); it != newValues.end(); it++)
-			{
-				temp.push_back(ValueToString<U>(it->first)+"_"+ValueToString<V>(it->second));
-			}
-			Set(key,temp);
-		}
-
-		// Declare without a body to make it fail to compile. This is to prevent accidentally
-		// setting a pointer as a bool. The failure is in the linker unfortunately, but that's better
-		// than accidentally succeeding in a bad way.
-		template<class T>
-		void Set(const char *key, T *ptr);
-
-		void AddComment(const std::string &comment);
-
-		bool Get(const char* key, int* value, int defaultValue = 0);
-		bool Get(const char* key, uint32_t* value, uint32_t defaultValue = 0);
-		bool Get(const char* key, bool* value, bool defaultValue = false);
-		bool Get(const char* key, float* value, float defaultValue = false);
-		bool Get(const char* key, double* value, double defaultValue = false);
-		bool Get(const char* key, std::vector<std::string>& values);
-		template<typename U, typename V>
-		bool Get(const char* key, std::map<U,V>& values)
-		{
-			std::vector<std::string> temp;
-			if(!Get(key,temp))
-			{
-				return false;
-			}
-			values.clear();
-			for(size_t i = 0; i < temp.size(); i++)
-			{
-				std::vector<std::string> key_val;
-				SplitString(temp[i], '_', key_val);
-				if (key_val.size() < 2)
-					continue;
-				U mapKey;
-				V mapValue;
-				if (!TryParse(key_val[0], &mapKey))
-					continue;
-				if (!TryParse(key_val[1], &mapValue))
-					continue;
-				values[mapKey] = mapValue;
-			}
-			return true;
-		}
-
-		bool operator < (const Section& other) const {
-			return name_ < other.name_;
-		}
-
-		const std::string &name() const {
-			return name_;
-		}
-
-	protected:
-		std::vector<std::string> lines;
-		std::string name_;
-		std::string comment;
-	};
-
 	bool Load(const char* filename);
 	bool Load(const std::string &filename) { return Load(filename.c_str()); }
 	bool Load(std::istream &istream);

--- a/ext/native/file/ini_file.h
+++ b/ext/native/file/ini_file.h
@@ -10,6 +10,14 @@
 
 #include "base/stringutil.h"
 
+template <typename N>
+inline std::string ValueToString(const N value)
+{
+	std::stringstream string;
+	string << value;
+	return string.str();
+}
+
 class IniFile
 {
 public:

--- a/ext/native/file/ini_file.h
+++ b/ext/native/file/ini_file.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <sstream>
 
 #include "base/stringutil.h"
 

--- a/ext/native/file/ini_file.h
+++ b/ext/native/file/ini_file.h
@@ -4,11 +4,14 @@
 
 #pragma once
 
+#include <istream>
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
 
-#include "base/stringutil.h"
+std::string StringFromFormat(const char* format, ...);
+std::string StringFromInt(int value);
+std::string StringFromBool(bool value);
 
 class IniFile
 {
@@ -59,17 +62,6 @@ public:
 		}
 		void Set(const char* key, const std::vector<std::string>& newValues);
 
-		template<typename U, typename V>
-		void Set(const char* key, const std::map<U,V>& newValues)
-		{
-			std::vector<std::string> temp;
-			for(typename std::map<U,V>::const_iterator it = newValues.begin(); it != newValues.end(); it++)
-			{
-				temp.push_back(ValueToString<U>(it->first)+"_"+ValueToString<V>(it->second));
-			}
-			Set(key,temp);
-		}
-
 		// Declare without a body to make it fail to compile. This is to prevent accidentally
 		// setting a pointer as a bool. The failure is in the linker unfortunately, but that's better
 		// than accidentally succeeding in a bad way.
@@ -84,31 +76,6 @@ public:
 		bool Get(const char* key, float* value, float defaultValue = false);
 		bool Get(const char* key, double* value, double defaultValue = false);
 		bool Get(const char* key, std::vector<std::string>& values);
-		template<typename U, typename V>
-		bool Get(const char* key, std::map<U,V>& values)
-		{
-			std::vector<std::string> temp;
-			if(!Get(key,temp))
-			{
-				return false;
-			}
-			values.clear();
-			for(size_t i = 0; i < temp.size(); i++)
-			{
-				std::vector<std::string> key_val;
-				SplitString(temp[i],'_',key_val);
-				if(key_val.size() < 2)
-					continue;
-				U mapKey;
-				V mapValue;
-				if(!TryParse<U>(key_val[0],&mapKey))
-					continue;
-				if(!TryParse<V>(key_val[1],&mapValue))
-					continue;
-				values[mapKey] = mapValue;
-			}
-			return true;
-		}
 
 		bool operator < (const Section& other) const {
 			return name_ < other.name_;
@@ -189,6 +156,4 @@ private:
 
 	const Section* GetSection(const char* section) const;
 	Section* GetSection(const char* section);
-	std::string* GetLine(const char* section, const char* key);
-	void CreateSection(const char* section);
 };

--- a/ext/native/file/ini_file.h
+++ b/ext/native/file/ini_file.h
@@ -104,14 +104,14 @@ public:
 			for(size_t i = 0; i < temp.size(); i++)
 			{
 				std::vector<std::string> key_val;
-				SplitString(temp[i],'_',key_val);
-				if(key_val.size() < 2)
+				SplitString(temp[i], '_', key_val);
+				if (key_val.size() < 2)
 					continue;
 				U mapKey;
 				V mapValue;
-				if(!TryParse<U>(key_val[0],&mapKey))
+				if (!TryParse(key_val[0], &mapKey))
 					continue;
-				if(!TryParse<V>(key_val[1],&mapValue))
+				if (!TryParse(key_val[1], &mapValue))
 					continue;
 				values[mapKey] = mapValue;
 			}

--- a/ext/native/i18n/i18n.cpp
+++ b/ext/native/i18n/i18n.cpp
@@ -1,4 +1,5 @@
 #include "base/logging.h"
+#include "base/stringutil.h"
 #include "i18n/i18n.h"
 #include "file/ini_file.h"
 #include "file/vfs.h"

--- a/ext/native/i18n/i18n.cpp
+++ b/ext/native/i18n/i18n.cpp
@@ -95,7 +95,7 @@ bool I18NRepo::LoadIni(const std::string &languageID, const std::string &overrid
 
 	Clear();
 
-	const std::vector<IniFile::Section> &sections = ini.Sections();
+	const std::vector<Section> &sections = ini.Sections();
 
 	std::lock_guard<std::mutex> guard(catsLock_);
 	for (auto iter = sections.begin(); iter != sections.end(); ++iter) {
@@ -108,7 +108,7 @@ bool I18NRepo::LoadIni(const std::string &languageID, const std::string &overrid
 	return true;
 }
 
-I18NCategory *I18NRepo::LoadSection(const IniFile::Section *section, const char *name) {
+I18NCategory *I18NRepo::LoadSection(const Section *section, const char *name) {
 	I18NCategory *cat = new I18NCategory(this, name);
 	std::map<std::string, std::string> sectionMap = section->ToMap();
 	cat->SetMap(sectionMap);
@@ -123,13 +123,13 @@ void I18NRepo::SaveIni(const std::string &languageID) {
 	std::lock_guard<std::mutex> guard(catsLock_);
 	for (auto iter = cats_.begin(); iter != cats_.end(); ++iter) {
 		std::string categoryName = iter->first;
-		IniFile::Section *section = ini.GetOrCreateSection(categoryName.c_str());
+		Section *section = ini.GetOrCreateSection(categoryName.c_str());
 		SaveSection(ini, section, iter->second);
 	}
 	ini.Save(GetIniPath(languageID));
 }
 
-void I18NRepo::SaveSection(IniFile &ini, IniFile::Section *section, std::shared_ptr<I18NCategory> cat) {
+void I18NRepo::SaveSection(IniFile &ini, Section *section, std::shared_ptr<I18NCategory> cat) {
 	const std::map<std::string, std::string> &missed = cat->Missed();
 
 	for (auto iter = missed.begin(); iter != missed.end(); ++iter) {

--- a/ext/native/i18n/i18n.h
+++ b/ext/native/i18n/i18n.h
@@ -13,11 +13,13 @@
 #include <string>
 #include <vector>
 
-#include "file/ini_file.h"
+#include "Common/Common.h"
 
 // Reasonably thread safe.
 
 class I18NRepo;
+class IniFile;
+class Section;
 
 struct I18NEntry {
 	I18NEntry(const std::string &t) : text(t), readFlag(false) {}
@@ -63,8 +65,6 @@ private:
 
 	// Noone else can create these.
 	friend class I18NRepo;
-
-	DISALLOW_COPY_AND_ASSIGN(I18NCategory);
 };
 
 class I18NRepo {
@@ -88,8 +88,8 @@ public:
 private:
 	std::string GetIniPath(const std::string &languageID) const;
 	void Clear();
-	I18NCategory *LoadSection(const IniFile::Section *section, const char *name);
-	void SaveSection(IniFile &ini, IniFile::Section *section, std::shared_ptr<I18NCategory> cat);
+	I18NCategory *LoadSection(const Section *section, const char *name);
+	void SaveSection(IniFile &ini, Section *section, std::shared_ptr<I18NCategory> cat);
 
 	mutable std::mutex catsLock_;
 	std::map<std::string, std::shared_ptr<I18NCategory>> cats_;

--- a/ext/native/i18n/i18n.h
+++ b/ext/native/i18n/i18n.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <vector>
 
+#include "base/basictypes.h"
 #include "file/ini_file.h"
 
 // Reasonably thread safe.

--- a/ext/native/i18n/i18n.h
+++ b/ext/native/i18n/i18n.h
@@ -9,7 +9,6 @@
 // As usual, everything is UTF-8. Nothing else allowed.
 
 #include <map>
-#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>

--- a/ext/native/net/websocket_server.cpp
+++ b/ext/native/net/websocket_server.cpp
@@ -23,11 +23,6 @@
 // TODO: Not a great cross dependency.
 #include "Common/Crypto/sha1.h"
 
-#ifdef _WIN32
-// Function Cross-Compatibility
-#define strcasecmp _stricmp
-#endif
-
 static const char *const WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 namespace net {

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -1,5 +1,7 @@
 #include <algorithm>
 #include <map>
+#include <sstream>
+
 #include "base/display.h"
 #include "input/input_state.h"
 #include "input/keycodes.h"

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
 #include <map>
+#include <sstream>
 #include "base/display.h"
+#include "base/stringutil.h"
 #include "input/input_state.h"
 #include "input/keycodes.h"
 #include "math/curves.h"

--- a/ext/native/ui/ui_screen.cpp
+++ b/ext/native/ui/ui_screen.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 
 #include "base/display.h"
+#include "base/stringutil.h"
 #include "input/input_state.h"
 #include "input/keycodes.h"
 #include "math/curves.h"

--- a/ext/native/util/text/parsers.cpp
+++ b/ext/native/util/text/parsers.cpp
@@ -1,3 +1,4 @@
+#include <climits>
 #include <cstdio>
 #include <string>
 

--- a/ext/native/util/text/parsers.h
+++ b/ext/native/util/text/parsers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <sstream>
 
 #include "base/basictypes.h"
 
@@ -54,3 +55,18 @@ private:
 };
 
 bool ParseMacAddress(std::string str, uint8_t macAddr[6]);
+
+bool TryParse(const std::string &str, bool *const output);
+bool TryParse(const std::string &str, uint32_t *const output);
+
+template <typename N>
+static bool TryParse(const std::string &str, N *const output) {
+	std::istringstream iss(str);
+
+	N tmp = 0;
+	if (iss >> tmp) {
+		*output = tmp;
+		return true;
+	} else
+		return false;
+}


### PR DESCRIPTION
Includes #13268.  The timing didn't seem to improve much (I didn't average any runs, though), but Config.h as an include is now showing up and the overall stats look better.

Now we have:
25514 ms: Core/Config.h (included 178 times, avg 143 ms)

Surprisingly, SDLVulkanGraphicsContext.cpp.o  (833 ms) spent a lot on Config.h somehow.

-[Unknown]