### PR TITLE
Remove time_now() - time_now_d() is the replacement. 

### DIFF
--- a/Common/TimeUtil.cpp
+++ b/Common/TimeUtil.cpp
@@ -17,7 +17,6 @@
 #include "Common/Log.h"
 
 static double curtime = 0;
-static float curtime_f = 0;
 
 #ifdef _WIN32
 
@@ -58,19 +57,6 @@ double real_time_now() {
 
 void time_update() {
 	curtime = real_time_now();
-	curtime_f = (float)curtime;
-
-	//printf("curtime: %f %f\n", curtime, curtime_f);
-	// also smooth time.
-	//curtime+=float((double) (time-_starttime) / (double) _frequency);
-	//curtime*=0.5f;
-	//curtime+=1.0f/60.0f;
-	//lastTime=curtime;
-	//curtime_f = (float)curtime;
-}
-
-float time_now() {
-	return curtime_f;
 }
 
 double time_now_d() {

--- a/Common/TimeUtil.h
+++ b/Common/TimeUtil.h
@@ -8,7 +8,6 @@
 void time_update();
 
 // Seconds.
-float time_now();
 double time_now_d();
 
 // Uncached time. Slower than the above cached time functions. Does not update cached time, call time_update for that.

--- a/Common/TimeUtil.h
+++ b/Common/TimeUtil.h
@@ -2,8 +2,9 @@
 
 // http://linux.die.net/man/3/clock_gettime
 
-// This time implementation caches the time for max performance (call time_now() as much as you like).
+// This time implementation caches the time for max performance (call time_now_d() as much as you like).
 // You need to call time_update() once per frame (or whenever you need the correct time right now).
+// Or you can use real_time_now() directly.
 
 void time_update();
 

--- a/Common/Vulkan/VulkanMemory.cpp
+++ b/Common/Vulkan/VulkanMemory.cpp
@@ -278,7 +278,7 @@ bool VulkanDeviceAllocator::AllocateFromSlab(Slab &slab, size_t &start, size_t b
 
 	// Remember the size so we can free.
 	slab.allocSizes[start] = blocks;
-	slab.tags[start] = { tag, time_now(), 0.0f };
+	slab.tags[start] = { tag, (float)time_now_d(), 0.0f };
 	slab.totalUsage += blocks;
 	return true;
 }
@@ -312,7 +312,7 @@ void VulkanDeviceAllocator::DoTouch(VkDeviceMemory deviceMemory, size_t offset) 
 
 		auto it = slab.tags.find(start);
 		if (it != slab.tags.end()) {
-			it->second.touched = time_now();
+			it->second.touched = time_now_d();
 			found = true;
 		}
 	}
@@ -436,7 +436,7 @@ bool VulkanDeviceAllocator::AllocateSlab(VkDeviceSize minBytes, int memoryTypeIn
 }
 
 void VulkanDeviceAllocator::ReportOldUsage() {
-	float now = time_now();
+	float now = time_now_d();
 	static const float OLD_AGE = 10.0f;
 	for (size_t i = 0; i < slabs_.size(); ++i) {
 		const auto &slab = slabs_[i];

--- a/Common/Vulkan/VulkanMemory.cpp
+++ b/Common/Vulkan/VulkanMemory.cpp
@@ -278,7 +278,7 @@ bool VulkanDeviceAllocator::AllocateFromSlab(Slab &slab, size_t &start, size_t b
 
 	// Remember the size so we can free.
 	slab.allocSizes[start] = blocks;
-	slab.tags[start] = { tag, (float)time_now_d(), 0.0f };
+	slab.tags[start] = { tag, time_now_d(), 0.0 };
 	slab.totalUsage += blocks;
 	return true;
 }
@@ -436,15 +436,15 @@ bool VulkanDeviceAllocator::AllocateSlab(VkDeviceSize minBytes, int memoryTypeIn
 }
 
 void VulkanDeviceAllocator::ReportOldUsage() {
-	float now = time_now_d();
-	static const float OLD_AGE = 10.0f;
+	double now = time_now_d();
+	static const double OLD_AGE = 10.0;
 	for (size_t i = 0; i < slabs_.size(); ++i) {
 		const auto &slab = slabs_[i];
 
 		bool hasOldAllocs = false;
 		for (auto it : slab.tags) {
 			const auto info = it.second;
-			float touchedAge = now - info.touched;
+			double touchedAge = now - info.touched;
 			if (touchedAge >= OLD_AGE) {
 				hasOldAllocs = true;
 				break;
@@ -456,8 +456,8 @@ void VulkanDeviceAllocator::ReportOldUsage() {
 			for (auto it : slab.tags) {
 				const auto info = it.second;
 
-				float createAge = now - info.created;
-				float touchedAge = now - info.touched;
+				double createAge = now - info.created;
+				double touchedAge = now - info.touched;
 				NOTICE_LOG(G3D, "  * %s (created %fs ago, used %fs ago)", info.tag.c_str(), createAge, touchedAge);
 			}
 		}

--- a/Common/Vulkan/VulkanMemory.h
+++ b/Common/Vulkan/VulkanMemory.h
@@ -176,8 +176,8 @@ private:
 
 	struct UsageInfo {
 		std::string tag;
-		float created;
-		float touched;
+		double created;
+		double touched;
 	};
 
 	struct Slab {

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -263,7 +263,7 @@ namespace SaveState
 	static StateRingbuffer rewindStates(REWIND_NUM_STATES);
 	// TODO: Any reason for this to be configurable?
 	const static float rewindMaxWallFrequency = 1.0f;
-	static float rewindLastTime = 0.0f;
+	static double rewindLastTime = 0.0f;
 	const int StateRingbuffer::BLOCK_SIZE = 8192;
 	const int StateRingbuffer::BASE_USAGE_INTERVAL = 15;
 
@@ -671,11 +671,11 @@ namespace SaveState
 
 		// For fast-forwarding, otherwise they may be useless and too close.
 		time_update();
-		float diff = time_now() - rewindLastTime;
+		float diff = time_now_d() - rewindLastTime;
 		if (diff < rewindMaxWallFrequency)
 			return;
 
-		rewindLastTime = time_now();
+		rewindLastTime = time_now_d();
 		DEBUG_LOG(BOOT, "saving rewind state");
 		rewindStates.Save();
 	}

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -178,7 +178,7 @@ void PresentationCommon::CalculatePostShaderUniforms(int bufferWidth, int buffer
 	float v_pixel_delta = 1.0f / targetHeight;
 	int flipCount = __DisplayGetFlipCount();
 	int vCount = __DisplayGetVCount();
-	float time[4] = { time_now(), (vCount % 60) * 1.0f / 60.0f, (float)vCount, (float)(flipCount % 60) };
+	float time[4] = { (float)time_now_d(), (vCount % 60) * 1.0f / 60.0f, (float)vCount, (float)(flipCount % 60) };
 
 	uniforms->texelDelta[0] = u_delta;
 	uniforms->texelDelta[1] = v_delta;

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -36,7 +36,7 @@ static u32 GetButtonColor() {
 	return g_Config.iTouchButtonStyle != 0 ? 0xFFFFFF : 0xc0b080;
 }
 
-GamepadView::GamepadView(UI::LayoutParams *layoutParams) : UI::View(layoutParams), secondsWithoutTouch_(0) {
+GamepadView::GamepadView(UI::LayoutParams *layoutParams) : UI::View(layoutParams) {
 	lastFrameTime_ = time_now_d();
 }
 
@@ -45,7 +45,7 @@ void GamepadView::Touch(const TouchInput &input) {
 }
 
 void GamepadView::Update() {
-	const float now = time_now();
+	const double now = time_now_d();
 	float delta = now - lastFrameTime_;
 	if (delta > 0) {
 		secondsWithoutTouch_ += delta;
@@ -195,7 +195,7 @@ void AnalogRotationButton::Touch(const TouchInput &input) {
 }
 
 void AnalogRotationButton::Update() {
-	const float now = time_now();
+	const float now = time_now_d();
 	float delta = now - lastFrameTime_;
 	if (delta > 0) {
 		secondsWithoutTouch_ += delta;

--- a/UI/GamepadEmu.h
+++ b/UI/GamepadEmu.h
@@ -37,8 +37,8 @@ public:
 protected:
 	virtual float GetButtonOpacity();
 
-	float lastFrameTime_;
-	float secondsWithoutTouch_;
+	double lastFrameTime_;
+	float secondsWithoutTouch_ = 0.0;
 };
 
 class MultiTouchButton : public GamepadView {

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -317,7 +317,7 @@ void GameButton::Draw(UIContext &dc) {
 		if (HasFocus()) {
 			dc.Draw()->Flush();
 			dc.RebindTexture();
-			float pulse = sinf(time_now() * 7.0f) * 0.25 + 0.8;
+			float pulse = sin(time_now_d() * 7.0) * 0.25 + 0.8;
 			dc.Draw()->DrawImage4Grid(dc.theme->dropShadow4Grid, x - dropsize*1.5f, y - dropsize*1.5f, x + w + dropsize*1.5f, y + h + dropsize*1.5f, alphaMul(color, pulse), 1.0f);
 			dc.Draw()->Flush();
 		} else {

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -123,11 +123,11 @@ void DrawBackground(UIContext &dc, float alpha) {
 		ui_draw2d.DrawImageStretch(img, dc.GetBounds(), bgColor);
 	}
 
-	float t = time_now();
+	double t = time_now_d();
 	for (int i = 0; i < 100; i++) {
 		float x = xbase[i] + dc.GetBounds().x;
 		float y = ybase[i] + dc.GetBounds().y + 40 * cosf(i * 7.2f + t * 1.3f);
-		float angle = sinf(i + t);
+		float angle = (float)sin(i + t);
 		int n = i & 3;
 		ui_draw2d.DrawImageRotated(symbols[n], x, y, 1.0f, angle, colorAlpha(colors[n], alpha * 0.1f));
 	}

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -248,7 +248,7 @@ void SavedataButton::Draw(UIContext &dc) {
 		if (HasFocus()) {
 			dc.Draw()->Flush();
 			dc.RebindTexture();
-			float pulse = sinf(time_now() * 7.0f) * 0.25 + 0.8;
+			float pulse = sin(time_now_d() * 7.0) * 0.25 + 0.8;
 			dc.Draw()->DrawImage4Grid(dc.theme->dropShadow4Grid, x - dropsize*1.5f, y - dropsize*1.5f, x + w + dropsize*1.5f, y + h + dropsize*1.5f, alphaMul(color, pulse), 1.0f);
 			dc.Draw()->Flush();
 		} else {

--- a/ext/native/ui/ui_tween.h
+++ b/ext/native/ui/ui_tween.h
@@ -12,7 +12,7 @@ namespace UI {
 class Tween {
 public:
 	explicit Tween(float duration, float (*curve)(float)) : duration_(duration), curve_(curve) {
-		start_ = time_now();
+		start_ = time_now_d();
 	}
 	virtual ~Tween() {
 	}
@@ -21,7 +21,7 @@ public:
 	void Apply(View *view);
 
 	bool Finished() {
-		return finishApplied_ && time_now() >= start_ + delay_ + duration_;
+		return finishApplied_ && time_now_d() >= start_ + delay_ + duration_;
 	}
 
 	void Persist() {
@@ -41,7 +41,7 @@ public:
 
 protected:
 	float DurationOffset() {
-		return time_now() - start_ - delay_;
+		return (time_now_d() - start_) - delay_;
 	}
 
 	float Position() {
@@ -50,7 +50,7 @@ protected:
 
 	virtual void DoApply(View *view, float pos) = 0;
 
-	float start_;
+	double start_;
 	float duration_;
 	float delay_ = 0.0f;
 	bool finishApplied_ = false;
@@ -78,7 +78,7 @@ public:
 		const Value newFrom = valid_ ? Current(Position()) : newTo;
 
 		// Are we already part way through another transition?
-		if (time_now() < start_ + delay_ + duration_ && valid_) {
+		if (time_now_d() < start_ + delay_ + duration_ && valid_) {
 			if (newTo == to_) {
 				// Already on course.  Don't change.
 				return;
@@ -88,17 +88,17 @@ public:
 				if (newDuration >= 0.0f) {
 					newOffset *= newDuration / duration_;
 				}
-				start_ = time_now() - newOffset - delay_;
-			} else if (time_now() <= start_ + delay_) {
+				start_ = time_now_d() - newOffset - delay_;
+			} else if (time_now_d() <= start_ + delay_) {
 				// Start the delay over again.
-				start_ = time_now();
+				start_ = time_now_d();
 			} else {
 				// Since we've partially animated to the other value, skip delay.
-				start_ = time_now() - delay_;
+				start_ = time_now_d() - delay_;
 			}
 		} else {
 			// Already finished, so restart.
-			start_ = time_now();
+			start_ = time_now_d();
 			finishApplied_ = false;
 		}
 

--- a/ext/native/ui/view.cpp
+++ b/ext/native/ui/view.cpp
@@ -201,12 +201,12 @@ Clickable::Clickable(LayoutParams *layoutParams)
 
 void Clickable::DrawBG(UIContext &dc, const Style &style) {
 	if (style.background.type == DRAW_SOLID_COLOR) {
-		if (time_now() - bgColorLast_ >= 0.25f) {
+		if (time_now_d() - bgColorLast_ >= 0.25f) {
 			bgColor_->Reset(style.background.color);
 		} else {
 			bgColor_->Divert(style.background.color, down_ ? 0.05f : 0.1f);
 		}
-		bgColorLast_ = time_now();
+		bgColorLast_ = time_now_d();
 
 		dc.FillRect(Drawable(bgColor_->CurrentValue()), bounds_);
 	} else {

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -175,7 +175,7 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool 
 	// TODO: We must have some kind of stack overflow or we're not following the ABI right.
 	// This gets trashed if it's not static.
 	static double deadline;
-	deadline = time_now() + timeout;
+	deadline = time_now_d() + timeout;
 
 	Core_UpdateDebugStats(g_Config.bShowDebugStats || g_Config.bLogFrameDrops);
 


### PR DESCRIPTION
Absolute time values can't be stored reliably in floats, just not enough precision. Let's not pretend they can - mostly to prevent future mistakes as none of these uses seem particularly dangerous.