### PR TITLE
More log/assert cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,6 +440,8 @@ add_library(Common STATIC
 	Common/KeyMap.cpp
 	Common/KeyMap.h
 	Common/Hashmaps.h
+	Common/Log.h
+	Common/Log.cpp
 	Common/LogManager.cpp
 	Common/LogManager.h
 	Common/MakeUnique.h
@@ -451,8 +453,6 @@ add_library(Common STATIC
 	Common/MemoryUtil.cpp
 	Common/MemoryUtil.h
 	Common/Misc.cpp
-	Common/MsgHandler.cpp
-	Common/MsgHandler.h
 	Common/OSVersion.cpp
 	Common/OSVersion.h
 	Common/StringUtils.cpp

--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -23,7 +23,6 @@
 #include "Common.h"
 #include "ArmCommon.h"
 #include "CodeBlock.h"
-#include "MsgHandler.h"
 
 // VCVT flags
 #define TO_FLOAT      0

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -354,6 +354,7 @@
     <ClInclude Include="ArmEmitter.h" />
     <ClInclude Include="BitScan.h" />
     <ClInclude Include="BitSet.h" />
+    <ClInclude Include="FakeEmitter.h" />
     <ClInclude Include="Serialize\SerializeDeque.h" />
     <ClInclude Include="Serialize\SerializeFuncs.h" />
     <ClInclude Include="ColorConvNEON.h" />
@@ -407,7 +408,6 @@
     <ClInclude Include="MemArena.h" />
     <ClInclude Include="MemoryUtil.h" />
     <ClInclude Include="MipsEmitter.h" />
-    <ClInclude Include="MsgHandler.h" />
     <ClInclude Include="OSVersion.h" />
     <ClInclude Include="Serialize\SerializeSet.h" />
     <ClInclude Include="stdafx.h" />
@@ -450,6 +450,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">false</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="Log.cpp" />
     <ClCompile Include="Serialize\Serializer.cpp" />
     <ClCompile Include="ColorConv.cpp" />
     <ClCompile Include="ConsoleListener.cpp" />
@@ -498,7 +499,6 @@
     <ClCompile Include="MemoryUtil.cpp" />
     <ClCompile Include="MipsEmitter.cpp" />
     <ClCompile Include="Misc.cpp" />
-    <ClCompile Include="MsgHandler.cpp" />
     <ClCompile Include="OSVersion.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -14,7 +14,6 @@
     <ClInclude Include="LogManager.h" />
     <ClInclude Include="MemArena.h" />
     <ClInclude Include="MemoryUtil.h" />
-    <ClInclude Include="MsgHandler.h" />
     <ClInclude Include="StringUtils.h" />
     <ClInclude Include="Thunk.h" />
     <ClInclude Include="Timer.h" />
@@ -93,6 +92,8 @@
     <ClInclude Include="Serialize\SerializeSet.h">
       <Filter>Serialize</Filter>
     </ClInclude>
+    <ClInclude Include="TimeUtil.h" />
+    <ClInclude Include="FakeEmitter.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp" />
@@ -103,7 +104,6 @@
     <ClCompile Include="LogManager.cpp" />
     <ClCompile Include="MemoryUtil.cpp" />
     <ClCompile Include="Misc.cpp" />
-    <ClCompile Include="MsgHandler.cpp" />
     <ClCompile Include="StringUtils.cpp" />
     <ClCompile Include="Thunk.cpp" />
     <ClCompile Include="Timer.cpp" />
@@ -159,6 +159,8 @@
     <ClCompile Include="Serialize\Serializer.cpp">
       <Filter>Serialize</Filter>
     </ClCompile>
+    <ClCompile Include="TimeUtil.cpp" />
+    <ClCompile Include="Log.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Crypto">

--- a/Common/CommonFuncs.h
+++ b/Common/CommonFuncs.h
@@ -25,7 +25,6 @@
 
 #if !defined(_WIN32)
 
-
 #include <unistd.h>
 #include <errno.h>
 

--- a/Common/ConsoleListener.cpp
+++ b/Common/ConsoleListener.cpp
@@ -49,8 +49,8 @@ HANDLE ConsoleListener::hTriggerEvent = NULL;
 CRITICAL_SECTION ConsoleListener::criticalSection;
 
 char *ConsoleListener::logPending = NULL;
-std::atomic<u32> ConsoleListener::logPendingReadPos;
-std::atomic<u32> ConsoleListener::logPendingWritePos;
+std::atomic<uint32_t> ConsoleListener::logPendingReadPos;
+std::atomic<uint32_t> ConsoleListener::logPendingWritePos;
 #endif
 
 ConsoleListener::ConsoleListener() : bHidden(true)

--- a/Common/ConsoleListener.h
+++ b/Common/ConsoleListener.h
@@ -63,8 +63,8 @@ private:
 	static CRITICAL_SECTION criticalSection;
 
 	static char *logPending;
-	static std::atomic<u32> logPendingReadPos;
-	static std::atomic<u32> logPendingWritePos;
+	static std::atomic<uint32_t> logPendingReadPos;
+	static std::atomic<uint32_t> logPendingWritePos;
 
 	int openWidth_;
 	int openHeight_;

--- a/Common/ExceptionHandlerSetup.cpp
+++ b/Common/ExceptionHandlerSetup.cpp
@@ -15,7 +15,6 @@
 
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
-#include "Common/MsgHandler.h"
 #include "Common/Log.h"
 #include "ext/native/thread/threadutil.h"
 

--- a/Common/FakeEmitter.h
+++ b/Common/FakeEmitter.h
@@ -24,7 +24,6 @@
 #include <stdint.h>
 
 #include "Common.h"
-#include "MsgHandler.h"
 
 // VCVT flags
 #define TO_FLOAT      0

--- a/Common/Log.cpp
+++ b/Common/Log.cpp
@@ -30,6 +30,21 @@
 #include "CommonWindows.h"
 #endif
 
+#if defined(__ANDROID__)
+
+#define LOG_BUF_SIZE 1024
+
+void AndroidAssert(const char *func, const char *file, int line, const char *condition, const char *fmt, ...) {
+	char buf[LOG_BUF_SIZE];
+	va_list args;
+	va_start(args, fmt);
+	vsnprintf(buf, sizeof(buf), fmt, args);
+	__android_log_assert(condition, "PPSSPP", "%s:%d (%s): [%s] %s", file, line, func, condition, buf);
+	va_end(args);
+}
+
+#endif
+
 bool ShowAssertDialog(const char *function, const char *file, int line, const char *expression, const char* format, ...) {
 	// Read message and write it to the log
 	char text[2048];
@@ -55,19 +70,3 @@ bool ShowAssertDialog(const char *function, const char *file, int line, const ch
 	return false;
 #endif
 }
-
-
-#if defined(__ANDROID__)
-
-#define LOG_BUF_SIZE 1024
-
-void AndroidAssert(const char *func, const char *file, int line, const char *condition, const char *fmt, ...) {
-	char buf[LOG_BUF_SIZE];
-	va_list args;
-	va_start(args, fmt);
-	vsnprintf(buf, sizeof(buf), fmt, args);
-	__android_log_assert(condition, "PPSSPP", "%s:%d (%s): [%s] %s", file, line, func, condition, buf);
-	va_end(args);
-}
-
-#endif

--- a/Common/Log.h
+++ b/Common/Log.h
@@ -112,42 +112,26 @@ bool GenericLogEnabled(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type);
 #define DEBUG_LOG(t,...)   do { GENERIC_LOG(LogTypes::t, LogTypes::LDEBUG, __VA_ARGS__) } while (false)
 #define VERBOSE_LOG(t,...) do { GENERIC_LOG(LogTypes::t, LogTypes::LVERBOSE, __VA_ARGS__) } while (false)
 
-#if defined(__ANDROID__)
-
-// Tricky macro to get the basename, that also works if *built* on Win32.
-#define __FILENAME__ (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 : (__builtin_strrchr(__FILE__, '\\') ? __builtin_strrchr(__FILE__, '\\') + 1 : __FILE__))
-void AndroidAssertLog(const char *func, const char *file, int line, const char *condition, const char *fmt, ...);
-
-#endif
-
 // If we're in "debug" assert mode
 #if MAX_LOGLEVEL >= DEBUG_LEVEL
 
 #define _dbg_assert_(_a_) \
 	if (!(_a_)) {\
-		printf(#_a_ "\n\nError...\n\n  Line: %d\n  File: %s\n\n", \
-					   __LINE__, __FILE__); \
-		ERROR_LOG(SYSTEM, #_a_ "\n\nError...\n\n  Line: %d\n  File: %s\n\nIgnore and continue?", \
-					   __LINE__, __FILE__); \
-		if (!ShowAssertDialog(__FILE__, __LINE__, "*** Assertion ***\n")) { Crash(); } \
+		if (!ShowAssertDialog(__FUNCTION__, __FILE__, __LINE__, #_a_, "*** Assertion ***\n")) { Crash(); } \
 	}
 
 #if defined(__ANDROID__)
 
 #define _dbg_assert_msg_(_a_, ...)\
 	if (!(_a_)) {\
-		printf(__VA_ARGS__); \
-		ERROR_LOG(SYSTEM, __VA_ARGS__); \
-		if (!ShowAssertDialog(__FILE__, __LINE__, __VA_ARGS__)) AndroidAssertLog(__FUNCTION__, __FILENAME__, __LINE__, #_a_, __VA_ARGS__); \
+		if (!ShowAssertDialog(__FUNCTION__, __FILE__, __LINE__, #_a_, __VA_ARGS__)) AndroidAssert(__FUNCTION__, __FILENAME__, __LINE__, #_a_, __VA_ARGS__); \
 	}
 
 #else  // !defined(__ANDROID__)
 
 #define _dbg_assert_msg_(_a_, ...)\
 	if (!(_a_)) {\
-		printf(__VA_ARGS__); \
-		ERROR_LOG(SYSTEM, __VA_ARGS__); \
-		if (!ShowAssertDialog(__FILE__, __LINE__, __VA_ARGS__)) { Crash();} \
+		if (!ShowAssertDialog(__FUNCTION__, __FILE__, __LINE__, #_a_, __VA_ARGS__)) { Crash();} \
 	}
 
 #endif  // __ANDROID__
@@ -165,24 +149,23 @@ void AndroidAssertLog(const char *func, const char *file, int line, const char *
 
 #define _assert_(_a_) \
 	if (!(_a_)) {\
-		AndroidAssertLog(__FUNCTION__, __FILENAME__, __LINE__, #_a_, "Assertion failed!"); \
+		AndroidAssert(__FUNCTION__, __FILENAME__, __LINE__, #_a_, "Assertion failed!"); \
 	}
 
 #define _assert_msg_(_a_, ...)		\
-	if (!(_a_) && !ShowAssertDialog(__FILENAME__, __LINE__, __VA_ARGS__)) { \
-		AndroidAssertLog(__FUNCTION__, __FILENAME__, __LINE__, #_a_, __VA_ARGS__); \
+	if (!(_a_) && !ShowAssertDialog(__FUNCTION__,__FILENAME__, __LINE__, #_a_, __VA_ARGS__)) { \
+		AndroidAssert(__FUNCTION__, __FILENAME__, __LINE__, #_a_, __VA_ARGS__); \
 	}
 
 #else  // __ANDROID__
 
 #define _assert_(_a_) \
 	if (!(_a_)) {\
-		ERROR_LOG(SYSTEM, "Error...\n\n  Line: %d\n  File: %s\n\nIgnore and continue?", __LINE__, __FILE__); \
-		if (!ShowAssertDialog(__FILE__, __LINE__, "*** Assertion ***\n")) { Crash(); } \
+		if (!ShowAssertDialog(__FUNCTION__, __FILE__, __LINE__, #_a_, "*** Assertion ***\n")) { Crash(); } \
 	}
 
 #define _assert_msg_(_a_, ...)		\
-	if (!(_a_) && !ShowAssertDialog(__FILE__, __LINE__, __VA_ARGS__)) { \
+	if (!(_a_) && !ShowAssertDialog(__FUNCTION__, __FILE__, __LINE__, #_a_, __VA_ARGS__)) { \
 		Crash(); \
 	}
 

--- a/Common/Log.h
+++ b/Common/Log.h
@@ -20,7 +20,7 @@
 #include <cstdio>
 
 #include "CommonFuncs.h"
-#include "Common/MsgHandler.h"
+#include "MsgHandler.h"  // For ShowAssertDialog
 
 #define	NOTICE_LEVEL  1  // VERY important information that is NOT errors. Like startup and debugprintfs from the game itself.
 #define	ERROR_LEVEL   2  // Important errors.
@@ -129,7 +129,7 @@ void AndroidAssertLog(const char *func, const char *file, int line, const char *
 					   __LINE__, __FILE__); \
 		ERROR_LOG(SYSTEM, #_a_ "\n\nError...\n\n  Line: %d\n  File: %s\n\nIgnore and continue?", \
 					   __LINE__, __FILE__); \
-		if (!PanicYesNo("*** Assertion ***\n")) { Crash(); } \
+		if (!ShowAssertDialog(__FILE__, __LINE__, "*** Assertion ***\n")) { Crash(); } \
 	}
 
 #if defined(__ANDROID__)
@@ -138,7 +138,7 @@ void AndroidAssertLog(const char *func, const char *file, int line, const char *
 	if (!(_a_)) {\
 		printf(__VA_ARGS__); \
 		ERROR_LOG(SYSTEM, __VA_ARGS__); \
-		if (!PanicYesNo(__VA_ARGS__)) AndroidAssertLog(__FUNCTION__, __FILENAME__, __LINE__, #_a_, __VA_ARGS__); \
+		if (!ShowAssertDialog(__FILE__, __LINE__, __VA_ARGS__)) AndroidAssertLog(__FUNCTION__, __FILENAME__, __LINE__, #_a_, __VA_ARGS__); \
 	}
 
 #else  // !defined(__ANDROID__)
@@ -147,7 +147,7 @@ void AndroidAssertLog(const char *func, const char *file, int line, const char *
 	if (!(_a_)) {\
 		printf(__VA_ARGS__); \
 		ERROR_LOG(SYSTEM, __VA_ARGS__); \
-		if (!PanicYesNo(__VA_ARGS__)) { Crash();} \
+		if (!ShowAssertDialog(__FILE__, __LINE__, __VA_ARGS__)) { Crash();} \
 	}
 
 #endif  // __ANDROID__
@@ -169,7 +169,7 @@ void AndroidAssertLog(const char *func, const char *file, int line, const char *
 	}
 
 #define _assert_msg_(_a_, ...)		\
-	if (!(_a_) && !PanicYesNo(__VA_ARGS__)) { \
+	if (!(_a_) && !ShowAssertDialog(__FILENAME__, __LINE__, __VA_ARGS__)) { \
 		AndroidAssertLog(__FUNCTION__, __FILENAME__, __LINE__, #_a_, __VA_ARGS__); \
 	}
 
@@ -177,13 +177,12 @@ void AndroidAssertLog(const char *func, const char *file, int line, const char *
 
 #define _assert_(_a_) \
 	if (!(_a_)) {\
-		ERROR_LOG(SYSTEM, "Error...\n\n  Line: %d\n  File: %s\n\nIgnore and continue?", \
-					   __LINE__, __FILE__); \
-		if (!PanicYesNo("*** Assertion ***\n")) { Crash(); } \
+		ERROR_LOG(SYSTEM, "Error...\n\n  Line: %d\n  File: %s\n\nIgnore and continue?", __LINE__, __FILE__); \
+		if (!ShowAssertDialog(__FILE__, __LINE__, "*** Assertion ***\n")) { Crash(); } \
 	}
 
 #define _assert_msg_(_a_, ...)		\
-	if (!(_a_) && !PanicYesNo(__VA_ARGS__)) { \
+	if (!(_a_) && !ShowAssertDialog(__FILE__, __LINE__, __VA_ARGS__)) { \
 		Crash(); \
 	}
 

--- a/Common/Log.h
+++ b/Common/Log.h
@@ -20,7 +20,6 @@
 #include <cstdio>
 
 #include "CommonFuncs.h"
-#include "MsgHandler.h"  // For ShowAssertDialog
 
 #define	NOTICE_LEVEL  1  // VERY important information that is NOT errors. Like startup and debugprintfs from the game itself.
 #define	ERROR_LEVEL   2  // Important errors.
@@ -105,11 +104,11 @@ bool GenericLogEnabled(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type);
 		GenericLog(v, t, __FILE__, __LINE__, __VA_ARGS__); \
 	}
 
-#define ERROR_LOG(t,...)   do { GENERIC_LOG(LogTypes::t, LogTypes::LERROR, __VA_ARGS__) } while (false)
+#define ERROR_LOG(t,...)   do { GENERIC_LOG(LogTypes::t, LogTypes::LERROR,   __VA_ARGS__) } while (false)
 #define WARN_LOG(t,...)    do { GENERIC_LOG(LogTypes::t, LogTypes::LWARNING, __VA_ARGS__) } while (false)
-#define NOTICE_LOG(t,...)  do { GENERIC_LOG(LogTypes::t, LogTypes::LNOTICE, __VA_ARGS__) } while (false)
-#define INFO_LOG(t,...)    do { GENERIC_LOG(LogTypes::t, LogTypes::LINFO, __VA_ARGS__) } while (false)
-#define DEBUG_LOG(t,...)   do { GENERIC_LOG(LogTypes::t, LogTypes::LDEBUG, __VA_ARGS__) } while (false)
+#define NOTICE_LOG(t,...)  do { GENERIC_LOG(LogTypes::t, LogTypes::LNOTICE,  __VA_ARGS__) } while (false)
+#define INFO_LOG(t,...)    do { GENERIC_LOG(LogTypes::t, LogTypes::LINFO,    __VA_ARGS__) } while (false)
+#define DEBUG_LOG(t,...)   do { GENERIC_LOG(LogTypes::t, LogTypes::LDEBUG,   __VA_ARGS__) } while (false)
 #define VERBOSE_LOG(t,...) do { GENERIC_LOG(LogTypes::t, LogTypes::LVERBOSE, __VA_ARGS__) } while (false)
 
 // If we're in "debug" assert mode
@@ -173,3 +172,18 @@ bool GenericLogEnabled(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type);
 
 // Just INFO_LOGs on nonWindows. On Windows it outputs to the VS output console.
 void OutputDebugStringUTF8(const char *p);
+
+// Currently only actually shows a dialog box on Windows.
+bool ShowAssertDialog(const char *function, const char *file, int line, const char *expression, const char* format, ...)
+#ifdef __GNUC__
+__attribute__((format(printf, 5, 6)))
+#endif
+;
+
+#if defined(__ANDROID__)
+
+// Tricky macro to get the basename, that also works if *built* on Win32.
+#define __FILENAME__ (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 : (__builtin_strrchr(__FILE__, '\\') ? __builtin_strrchr(__FILE__, '\\') + 1 : __FILE__))
+void AndroidAssert(const char *func, const char *file, int line, const char *condition, const char *fmt, ...);
+
+#endif

--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -28,10 +28,6 @@
 #include "Common/FileUtil.h"
 #include "Common/StringUtils.h"
 
-#if PPSSPP_PLATFORM(ANDROID)
-#include <android/log.h>
-#endif
-
 // Don't need to savestate this.
 const char *hleCurrentThreadName = nullptr;
 
@@ -66,21 +62,6 @@ bool GenericLogEnabled(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type) {
 		return (*g_bLogEnabledSetting) && LogManager::GetInstance()->IsEnabled(level, type);
 	return false;
 }
-
-#if defined(__ANDROID__)
-
-#define LOG_BUF_SIZE 1024
-
-void AndroidAssertLog(const char *func, const char *file, int line, const char *condition, const char *fmt, ...) {
-	char buf[LOG_BUF_SIZE];
-	va_list args;
-	va_start(args, fmt);
-	vsnprintf(buf, sizeof(buf), fmt, args);
-	__android_log_assert(condition, "PPSSPP", "%s:%d (%s): [%s] %s", file, line, func, condition, buf);
-	va_end(args);
-}
-
-#endif
 
 LogManager *LogManager::logManager_ = NULL;
 

--- a/Common/LogManager.h
+++ b/Common/LogManager.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "file/ini_file.h"
+#include "Common/CommonFuncs.h"
 #include "Common/Log.h"
 
 #define	MAX_MESSAGES 8000   

--- a/Common/MipsEmitter.h
+++ b/Common/MipsEmitter.h
@@ -22,7 +22,6 @@
 #include <stdint.h>
 
 #include "Common.h"
-#include "MsgHandler.h"
 
 namespace MIPSGen {
 

--- a/Common/MsgHandler.h
+++ b/Common/MsgHandler.h
@@ -17,19 +17,9 @@
 
 #pragma once
 
-// Message alerts
-enum MSG_TYPE {
-	INFORMATION,
-	QUESTION,
-	WARNING,
-	CRITICAL
-};
-
-bool MsgAlert(bool yes_no, int Style, const char *file, int line, const char* format, ...)
+// Currently only actually shows a dialog box on Windows.
+bool ShowAssertDialog(const char *file, int line, const char* format, ...)
 #ifdef __GNUC__
-	__attribute__((format(printf, 5, 6)))
+	__attribute__((format(printf, 3, 4)))
 #endif
 	;
-
-// Used only for asserts.
-#define PanicYesNo(...) MsgAlert(true, CRITICAL, __FILE__, __LINE__, __VA_ARGS__)

--- a/Common/MsgHandler.h
+++ b/Common/MsgHandler.h
@@ -18,8 +18,16 @@
 #pragma once
 
 // Currently only actually shows a dialog box on Windows.
-bool ShowAssertDialog(const char *file, int line, const char* format, ...)
+bool ShowAssertDialog(const char *function, const char *file, int line, const char *expression, const char* format, ...)
 #ifdef __GNUC__
-	__attribute__((format(printf, 3, 4)))
+	__attribute__((format(printf, 5, 6)))
 #endif
 	;
+
+#if defined(__ANDROID__)
+
+// Tricky macro to get the basename, that also works if *built* on Win32.
+#define __FILENAME__ (__builtin_strrchr(__FILE__, '/') ? __builtin_strrchr(__FILE__, '/') + 1 : (__builtin_strrchr(__FILE__, '\\') ? __builtin_strrchr(__FILE__, '\\') + 1 : __FILE__))
+void AndroidAssert(const char *func, const char *file, int line, const char *condition, const char *fmt, ...);
+
+#endif

--- a/Common/StringUtils.cpp
+++ b/Common/StringUtils.cpp
@@ -39,6 +39,7 @@ long parseHexLong(std::string s) {
 	value = strtoul(s.c_str(),0, 0);
 	return value;
 }
+
 long parseLong(std::string s) {
 	long value = 0;
 	if (s.substr(0,2) == "0x") {

--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -21,7 +21,6 @@
 #include "ABI.h"
 #include "CPUDetect.h"
 #include "MemoryUtil.h"
-#include "MsgHandler.h"
 
 #define PRIx64 "llx"
 

--- a/Core/AVIDump.cpp
+++ b/Core/AVIDump.cpp
@@ -24,7 +24,6 @@ extern "C" {
 #endif
 
 #include "Common/FileUtil.h"
-#include "Common/MsgHandler.h"
 #include "Common/ColorConv.h"
 
 #include "Core/Config.h"

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -22,7 +22,6 @@
 
 #include "profiler/profiler.h"
 
-#include "Common/MsgHandler.h"
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeList.h"
 #include "Core/CoreTiming.h"
@@ -43,25 +42,17 @@ int CPU_HZ = 222000000;
 namespace CoreTiming
 {
 
-struct EventType
-{
-	EventType() {}
-
-	EventType(TimedCallback cb, const char *n)
-		: callback(cb), name(n) {}
-
+struct EventType {
 	TimedCallback callback;
 	const char *name;
 };
 
 std::vector<EventType> event_types;
 
-struct BaseEvent
-{
+struct BaseEvent {
 	s64 time;
 	u64 userdata;
 	int type;
-//	Event *next;
 };
 
 typedef LinkedListItem<BaseEvent> Event;
@@ -171,7 +162,7 @@ void FreeTsEvent(Event* ev)
 
 int RegisterEvent(const char *name, TimedCallback callback)
 {
-	event_types.push_back(EventType(callback, name));
+	event_types.push_back(EventType{ callback, name });
 	return (int)event_types.size() - 1;
 }
 
@@ -185,9 +176,9 @@ void RestoreRegisterEvent(int event_type, const char *name, TimedCallback callba
 {
 	_assert_msg_(event_type >= 0, "Invalid event type %d", event_type)
 	if (event_type >= (int) event_types.size())
-		event_types.resize(event_type + 1, EventType(AntiCrashCallback, "INVALID EVENT"));
+		event_types.resize(event_type + 1, EventType{ AntiCrashCallback, "INVALID EVENT" });
 
-	event_types[event_type] = EventType(callback, name);
+	event_types[event_type] = EventType{ callback, name };
 }
 
 void UnregisterAllEvents()
@@ -692,7 +683,7 @@ void DoState(PointerWrap &p)
 	int n = (int) event_types.size();
 	Do(p, n);
 	// These (should) be filled in later by the modules.
-	event_types.resize(n, EventType(AntiCrashCallback, "INVALID EVENT"));
+	event_types.resize(n, EventType{ AntiCrashCallback, "INVALID EVENT" });
 
 	if (s >= 3) {
 		DoLinkedList<BaseEvent, GetNewEvent, FreeEvent, Event_DoState>(p, first, (Event **) NULL);

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -17,8 +17,10 @@
 
 #pragma once
 
+#include <cstdio>
 #include <cstdarg>
 #include <type_traits>
+
 #include "Common/CommonTypes.h"
 #include "Common/Log.h"
 #include "Core/MIPS/MIPS.h"

--- a/Core/WaveFile.cpp
+++ b/Core/WaveFile.cpp
@@ -5,8 +5,7 @@
 #include <string>
 
 #include "Core/WaveFile.h"
-#include "Common/CommonTypes.h"
-#include "Common/MsgHandler.h"
+#include "Common/Log.h"
 #include "Core/Config.h"
 
 constexpr size_t WaveFileWriter::BUFFER_SIZE;

--- a/Core/WaveFile.h
+++ b/Core/WaveFile.h
@@ -14,7 +14,7 @@
 
 #include <array>
 #include <string>
-#include "Common/CommonTypes.h"
+
 #include "Common/FileUtil.h"
 
 class WaveFileWriter
@@ -27,14 +27,14 @@ public:
 	void Stop();
 
 	void SetSkipSilence(bool skip) { skip_silence = skip; }
-	void AddStereoSamples(const short* sample_data, u32 count);
-	u32 GetAudioSize() const { return audio_size; }
+	void AddStereoSamples(const short* sample_data, uint32_t count);
+	uint32_t GetAudioSize() const { return audio_size; }
 private:
 	static constexpr size_t BUFFER_SIZE = 32 * 1024;
 
 	File::IOFile file;
 	bool skip_silence = false;
-	u32 audio_size = 0;
+	uint32_t audio_size = 0;
 	std::array<short, BUFFER_SIZE> conv_buffer{};
 	void Write(u32 value);
 	void Write4(const char* ptr);

--- a/GPU/Common/TextureScalerCommon.cpp
+++ b/GPU/Common/TextureScalerCommon.cpp
@@ -30,7 +30,6 @@
 #include "Core/Config.h"
 #include "Common/Common.h"
 #include "Common/Log.h"
-#include "Common/MsgHandler.h"
 #include "Common/CommonFuncs.h"
 #include "Common/ThreadPools.h"
 #include "Common/CPUDetect.h"

--- a/GPU/D3D11/D3D11Util.cpp
+++ b/GPU/D3D11/D3D11Util.cpp
@@ -6,7 +6,6 @@
 #include <d3d11.h>
 #include <D3Dcompiler.h>
 
-
 #if PPSSPP_PLATFORM(UWP)
 #define ptr_D3DCompile D3DCompile
 #else
@@ -15,8 +14,9 @@
 
 #include "base/stringutil.h"
 
-#include "D3D11Util.h"
+#include "Common/CommonFuncs.h"
 #include "Common/Log.h"
+#include "D3D11Util.h"
 
 static std::vector<uint8_t> CompileShaderToBytecode(const char *code, size_t codeSize, const char *target, UINT flags) {
 	ID3DBlob *compiledCode = nullptr;

--- a/GPU/GeDisasm.cpp
+++ b/GPU/GeDisasm.cpp
@@ -15,9 +15,10 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include "Core/MemMap.h"
+#include <cstdio>
 
-#include "ge_constants.h"
+#include "Core/MemMap.h"
+#include "GPU/ge_constants.h"
 #include "GPU/GPU.h"
 #include "GPU/GPUState.h"
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -762,6 +762,8 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 
 	// Must be done restarting by now.
 	restarting = false;
+
+	_assert_msg_(false, "assert test");
 }
 
 static UI::Style MakeStyle(uint32_t fg, uint32_t bg) {

--- a/UI/TextureUtil.cpp
+++ b/UI/TextureUtil.cpp
@@ -107,9 +107,7 @@ bool ManagedTexture::LoadFromFileData(const uint8_t *data, size_t dataSize, Imag
 		return false;
 	}
 
-	if (!image[0]) {
-		Crash();
-	}
+	_assert_(image[0] != nullptr);
 
 	if (num_levels < 0 || num_levels >= 16) {
 		ERROR_LOG(IO, "Invalid num_levels: %d. Falling back to one. Image: %dx%d", num_levels, width[0], height[0]);

--- a/UWP/CommonUWP/CommonUWP.vcxproj
+++ b/UWP/CommonUWP/CommonUWP.vcxproj
@@ -414,7 +414,6 @@
     <ClInclude Include="..\..\Common\MemArena.h" />
     <ClInclude Include="..\..\Common\MemoryUtil.h" />
     <ClInclude Include="..\..\Common\MipsEmitter.h" />
-    <ClInclude Include="..\..\Common\MsgHandler.h" />
     <ClInclude Include="..\..\Common\OSVersion.h" />
     <ClInclude Include="..\..\Common\stdafx.h" />
     <ClInclude Include="..\..\Common\StringUtils.h" />
@@ -445,6 +444,7 @@
     <ClCompile Include="..\..\Common\ExceptionHandlerSetup.cpp" />
     <ClCompile Include="..\..\Common\FileUtil.cpp" />
     <ClCompile Include="..\..\Common\KeyMap.cpp" />
+    <ClCompile Include="..\..\Common\Log.cpp" />
     <ClCompile Include="..\..\Common\LogManager.cpp" />
     <ClCompile Include="..\..\Common\MemArenaAndroid.cpp" />
     <ClCompile Include="..\..\Common\MemArenaDarwin.cpp" />
@@ -454,7 +454,6 @@
     <ClCompile Include="..\..\Common\MipsCPUDetect.cpp" />
     <ClCompile Include="..\..\Common\MipsEmitter.cpp" />
     <ClCompile Include="..\..\Common\Misc.cpp" />
-    <ClCompile Include="..\..\Common\MsgHandler.cpp" />
     <ClCompile Include="..\..\Common\OSVersion.cpp" />
     <ClCompile Include="..\..\Common\stdafx.cpp" />
     <ClCompile Include="..\..\Common\StringUtils.cpp" />

--- a/UWP/CommonUWP/CommonUWP.vcxproj.filters
+++ b/UWP/CommonUWP/CommonUWP.vcxproj.filters
@@ -19,6 +19,7 @@
     <ClCompile Include="..\..\Common\ExceptionHandlerSetup.cpp" />
     <ClCompile Include="..\..\Common\FileUtil.cpp" />
     <ClCompile Include="..\..\Common\KeyMap.cpp" />
+    <ClCompile Include="..\..\Common\Log.cpp" />
     <ClCompile Include="..\..\Common\LogManager.cpp" />
     <ClCompile Include="..\..\Common\MemArenaAndroid.cpp" />
     <ClCompile Include="..\..\Common\MemArenaDarwin.cpp" />
@@ -28,7 +29,6 @@
     <ClCompile Include="..\..\Common\MipsCPUDetect.cpp" />
     <ClCompile Include="..\..\Common\MipsEmitter.cpp" />
     <ClCompile Include="..\..\Common\Misc.cpp" />
-    <ClCompile Include="..\..\Common\MsgHandler.cpp" />
     <ClCompile Include="..\..\Common\OSVersion.cpp" />
     <ClCompile Include="..\..\Common\stdafx.cpp" />
     <ClCompile Include="..\..\Common\StringUtils.cpp" />
@@ -83,7 +83,6 @@
     <ClInclude Include="..\..\Common\MemArena.h" />
     <ClInclude Include="..\..\Common\MemoryUtil.h" />
     <ClInclude Include="..\..\Common\MipsEmitter.h" />
-    <ClInclude Include="..\..\Common\MsgHandler.h" />
     <ClInclude Include="..\..\Common\OSVersion.h" />
     <ClInclude Include="..\..\Common\stdafx.h" />
     <ClInclude Include="..\..\Common\StringUtils.h" />

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -209,13 +209,13 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Common/ColorConv.cpp \
   $(SRC)/Common/ExceptionHandlerSetup.cpp \
   $(SRC)/Common/KeyMap.cpp \
+  $(SRC)/Common/Log.cpp \
   $(SRC)/Common/LogManager.cpp \
   $(SRC)/Common/MemArenaAndroid.cpp \
   $(SRC)/Common/MemArenaDarwin.cpp \
   $(SRC)/Common/MemArenaWin32.cpp \
   $(SRC)/Common/MemArenaPosix.cpp \
   $(SRC)/Common/MemoryUtil.cpp \
-  $(SRC)/Common/MsgHandler.cpp \
   $(SRC)/Common/FileUtil.cpp \
   $(SRC)/Common/StringUtils.cpp \
   $(SRC)/Common/ThreadPools.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -146,11 +146,11 @@ SOURCES_CXX += \
 	$(COMMONDIR)/ExceptionHandlerSetup.cpp \
 	$(COMMONDIR)/FileUtil.cpp \
 	$(COMMONDIR)/KeyMap.cpp \
+	$(COMMONDIR)/Log.cpp \
 	$(COMMONDIR)/LogManager.cpp \
 	$(COMMONDIR)/OSVersion.cpp \
 	$(COMMONDIR)/MemoryUtil.cpp \
 	$(COMMONDIR)/Misc.cpp \
-	$(COMMONDIR)/MsgHandler.cpp \
 	$(COMMONDIR)/StringUtils.cpp \
 	$(COMMONDIR)/Timer.cpp \
 	$(COMMONDIR)/TimeUtil.cpp \


### PR DESCRIPTION
Tried to unify things as much as possible, no more separate defines for Android, and was able to get rid of the `<cstdio>` inclusion in Log.h.