### PR TITLE
Net: Simplify local IP lookup and cleanup instance counter a bit

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1117,12 +1117,13 @@ static void IterateSettings(IniFile &iniFile, std::function<void(Section *sectio
 	}
 }
 
-Config::Config() : bGameSpecific(false) {
-	InitInstanceCounter();
+Config::Config() {
 }
 
 Config::~Config() {
-	ShutdownInstanceCounter();
+	if (bUpdatedInstanceCounter) {
+		ShutdownInstanceCounter();
+	}
 }
 
 std::map<std::string, std::pair<std::string, int>> GetLangValuesMapping() {
@@ -1172,6 +1173,11 @@ void Config::Reload() {
 void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	const bool useIniFilename = iniFileName != nullptr && strlen(iniFileName) > 0;
 	iniFilename_ = FindConfigFile(useIniFilename ? iniFileName : "ppsspp.ini");
+
+	if (!bUpdatedInstanceCounter) {
+		InitInstanceCounter();
+		bUpdatedInstanceCounter = true;
+	}
 
 	const bool useControllerIniFilename = controllerIniFilename != nullptr && strlen(controllerIniFilename) > 0;
 	controllerIniFilename_ = FindConfigFile(useControllerIniFilename ? controllerIniFilename : "controls.ini");

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -61,7 +61,8 @@ public:
 	// Whether to save the config on close.
 	bool bSaveSettings;
 	bool bFirstRun;
-	bool bGameSpecific;
+	bool bGameSpecific = false;
+	bool bUpdatedInstanceCounter = false;
 
 	int iRunCount; // To be used to for example check for updates every 10 runs and things like that.
 

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -829,11 +829,16 @@ extern std::recursive_mutex peerlock;
 extern SceNetAdhocPdpStat * pdp[255];
 extern SceNetAdhocPtpStat * ptp[255];
 
+union SockAddrIN4 {
+	sockaddr addr;
+	sockaddr_in in;
+};
+
 extern uint16_t portOffset;
 extern uint32_t minSocketTimeoutUS;
 extern bool isOriPort;
 extern bool isLocalServer;
-extern sockaddr LocalhostIP; // Used to differentiate localhost IP on multiple-instance
+extern SockAddrIN4 g_localhostIP; // Used to differentiate localhost IP on multiple-instance
 extern sockaddr LocalIP; // IP of Network Adapter used to connect to Adhoc Server (LAN/WAN)
 extern int defaultWlanChannel; // Default WLAN Channel for Auto, JPCSP uses 11
 

--- a/Core/HLE/proAdhocServer.cpp
+++ b/Core/HLE/proAdhocServer.cpp
@@ -1826,7 +1826,7 @@ int create_listen_socket(uint16_t port)
 		//Should only bind to specific IP for the 2nd or more instance of PPSSPP to prevent communication interference issue when sharing the same port. Doesn't work well when PPSSPP_ID reseted everytime emulation restarted.
 		/*
 		if (PPSSPP_ID > 1) {
-			local.sin_addr = ((sockaddr_in *)&LocalhostIP)->sin_addr;
+			local.sin_addr = g_localhostIP.in.sin_addr;
 		}
 		*/
 

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -123,19 +123,19 @@ static int InitLocalhostIP() {
 	if (iResult != 0) {
 		ERROR_LOG(SCENET, "DNS Error (%s) result: %d\n", ipstr, iResult);
 		//osm.Show("DNS Error, can't resolve client bind " + ipstr, 8.0f);
-		((sockaddr_in*)&LocalhostIP)->sin_family = AF_INET;
-		((sockaddr_in*)&LocalhostIP)->sin_addr.s_addr = inet_addr(ipstr); //"127.0.0.1"
-		((sockaddr_in*)&LocalhostIP)->sin_port = 0;
+		g_localhostIP.in.sin_family = AF_INET;
+		g_localhostIP.in.sin_addr.s_addr = inet_addr(ipstr); //"127.0.0.1"
+		g_localhostIP.in.sin_port = 0;
 		return iResult;
 	}
 	for (ptr = localAddr; ptr != NULL; ptr = ptr->ai_next) {
 		switch (ptr->ai_family) {
 		case AF_INET:
-			memcpy(&LocalhostIP, ptr->ai_addr, sizeof(sockaddr));
+			memcpy(&g_localhostIP.addr, ptr->ai_addr, sizeof(sockaddr));
 			break;
 		}
 	}
-	((sockaddr_in*)&LocalhostIP)->sin_port = 0;
+	g_localhostIP.in.sin_port = 0;
 	freeaddrinfo(localAddr);
 
 	// Resolve server dns
@@ -198,7 +198,7 @@ void __NetInit() {
 
 	SceNetEtherAddr mac;
 	getLocalMac(&mac);
-	INFO_LOG(SCENET, "LocalHost IP will be %s [%s]", inet_ntoa(((sockaddr_in*)&LocalhostIP)->sin_addr), mac2str(&mac).c_str());
+	INFO_LOG(SCENET, "LocalHost IP will be %s [%s]", inet_ntoa(g_localhostIP.in.sin_addr), mac2str(&mac).c_str());
 	
 	// TODO: May be we should initialize & cleanup somewhere else than here for PortManager to be used as general purpose for whatever port forwarding PPSSPP needed
 	__UPnPInit();

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -114,49 +114,27 @@ void AfterApctlMipsCall::SetData(int HandlerID, int OldState, int NewState, int 
 }
 
 static int InitLocalhostIP() {
-	// find local IP
-	addrinfo* localAddr;
-	addrinfo* ptr;
-	char ipstr[256];
-	sprintf(ipstr, "127.0.0.%u", PPSSPP_ID);
-	int iResult = getaddrinfo(ipstr, 0, NULL, &localAddr);
-	if (iResult != 0) {
-		ERROR_LOG(SCENET, "DNS Error (%s) result: %d\n", ipstr, iResult);
-		//osm.Show("DNS Error, can't resolve client bind " + ipstr, 8.0f);
-		g_localhostIP.in.sin_family = AF_INET;
-		g_localhostIP.in.sin_addr.s_addr = inet_addr(ipstr); //"127.0.0.1"
-		g_localhostIP.in.sin_port = 0;
-		return iResult;
-	}
-	for (ptr = localAddr; ptr != NULL; ptr = ptr->ai_next) {
-		switch (ptr->ai_family) {
-		case AF_INET:
-			memcpy(&g_localhostIP.addr, ptr->ai_addr, sizeof(sockaddr));
-			break;
-		}
-	}
+	// The entire 127.*.*.* is reserved for loopback.
+	uint32_t localIP = 0x7F000001 + PPSSPP_ID - 1;
+
+	g_localhostIP.in.sin_family = AF_INET;
+	g_localhostIP.in.sin_addr.s_addr = htonl(localIP);
 	g_localhostIP.in.sin_port = 0;
-	freeaddrinfo(localAddr);
 
-	// Resolve server dns
-	addrinfo* resultAddr;
-	in_addr serverIp;
-	serverIp.s_addr = INADDR_NONE;
+	// If lookup fails, we'll assume it's not local.
+	isLocalServer = false;
 
-	iResult = getaddrinfo(g_Config.proAdhocServer.c_str(), 0, NULL, &resultAddr);
-	if (iResult != 0) {
-		ERROR_LOG(SCENET, "DNS Error (%s)\n", g_Config.proAdhocServer.c_str());
-		return iResult;
-	}
-	for (ptr = resultAddr; ptr != NULL; ptr = ptr->ai_next) {
-		switch (ptr->ai_family) {
-		case AF_INET:
-			serverIp = ((sockaddr_in*)ptr->ai_addr)->sin_addr;
-			break;
+	addrinfo *resultAddr = nullptr;
+	std::string error;
+	if (net::DNSResolve(g_Config.proAdhocServer, "", &resultAddr, error, net::DNSType::IPV4)) {
+		for (addrinfo *ptr = resultAddr; ptr != nullptr; ptr = ptr->ai_next) {
+			auto addr4 = ((sockaddr_in *)ptr->ai_addr)->sin_addr.s_addr;
+			isLocalServer = (ntohl(addr4) & 0x7F000000) == 0x7F000000;
 		}
+
+		net::DNSResolveFree(resultAddr);
+		resultAddr = nullptr;
 	}
-	freeaddrinfo(resultAddr);
-	isLocalServer = (((uint8_t*)&serverIp.s_addr)[0] == 0x7f);
 
 	return 0;
 }

--- a/Core/Instance.cpp
+++ b/Core/Instance.cpp
@@ -105,6 +105,14 @@ static bool UpdateInstanceCounter(void (*callback)(volatile InstanceInfo *)) {
 #endif
 }
 
+int GetInstancePeerCount() {
+	static int c = 0;
+	UpdateInstanceCounter([](volatile InstanceInfo *buf) {
+		c = buf->total;
+	});
+	return c;
+}
+
 // Get current number of instance of PPSSPP running.
 // Must be called only once during init.
 void InitInstanceCounter() {

--- a/Core/Instance.h
+++ b/Core/Instance.h
@@ -25,6 +25,7 @@ extern uint8_t PPSSPP_ID;
 
 void InitInstanceCounter();
 void ShutdownInstanceCounter();
+int GetInstancePeerCount();
 
 inline bool IsFirstInstance() {
 	return PPSSPP_ID == 1;

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -46,6 +46,7 @@
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
 #include "Core/Debugger/SymbolMap.h"
+#include "Core/Instance.h"
 #include "Core/MIPS/JitCommon/JitCommon.h"
 #include "Core/MIPS/JitCommon/JitBlockCache.h"
 #include "Windows/InputBox.h"
@@ -466,7 +467,11 @@ namespace MainWindow
 
 	void UpdateWindowTitle() {
 		// Seems to be fine to call now since we use a UNICODE build...
-		SetWindowText(hwndMain, windowTitle.c_str());
+		std::wstring title = windowTitle;
+		if (PPSSPP_ID >= 1 && GetInstancePeerCount() > 1) {
+			title.append(ConvertUTF8ToWString(StringFromFormat(" (instance: %d)", (int)PPSSPP_ID)));
+		}
+		SetWindowText(hwndMain, title.c_str());
 	}
 
 	void SetWindowTitle(const wchar_t *title) {
@@ -708,6 +713,7 @@ namespace MainWindow
 
 		case WM_ACTIVATE:
 			{
+				UpdateWindowTitle();
 				bool pause = true;
 				if (wParam == WA_ACTIVE || wParam == WA_CLICKACTIVE) {
 					WindowsRawInput::GainFocus();
@@ -739,6 +745,10 @@ namespace MainWindow
 					trapMouse = false;
 				}
 			}
+			break;
+
+		case WM_SETFOCUS:
+			UpdateWindowTitle();
 			break;
 
 		case WM_ERASEBKGND:

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -170,9 +170,7 @@ void WindowsHost::SetWindowTitle(const char *message) {
 #ifdef _DEBUG
 	winTitle.append(L" (debug)");
 #endif
-	if (PPSSPP_ID >= 1) {
-		winTitle.append(ConvertUTF8ToWString(StringFromFormat(" (instance: %d)", (int)PPSSPP_ID)));
-	}
+	lastTitle_ = winTitle;
 
 	MainWindow::SetWindowTitle(winTitle.c_str());
 	PostMessage(mainWindow_, MainWindow::WM_USER_WINDOW_TITLE_CHANGED, 0, 0);
@@ -194,6 +192,12 @@ void WindowsHost::ShutdownSound() {
 
 void WindowsHost::UpdateUI() {
 	PostMessage(mainWindow_, MainWindow::WM_USER_UPDATE_UI, 0, 0);
+
+	int peers = GetInstancePeerCount();
+	if (PPSSPP_ID >= 1 && peers != lastNumInstances_) {
+		lastNumInstances_ = peers;
+		PostMessage(mainWindow_, MainWindow::WM_USER_WINDOW_TITLE_CHANGED, 0, 0);
+	}
 }
 
 void WindowsHost::UpdateMemView() {

--- a/Windows/WindowsHost.h
+++ b/Windows/WindowsHost.h
@@ -73,6 +73,8 @@ private:
 	HWND mainWindow_;
 	GraphicsContext *gfx_ = nullptr;
 	size_t numDinputDevices_ = 0;
+	std::wstring lastTitle_;
+	int lastNumInstances_ = 0;
 
 	std::list<std::unique_ptr<InputDevice>> input;
 };

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -516,6 +516,22 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	g_Config.internalDataDirectory = W32Util::UserDocumentsPath();
 	InitSysDirectories();
 
+	// Check for the Vulkan workaround before any serious init.
+	for (size_t i = 1; i < wideArgs.size(); ++i) {
+		if (wideArgs[i][0] == L'-') {
+			// This should only be called by DetectVulkanInExternalProcess().
+			if (wideArgs[i] == L"--vulkan-available-check") {
+				// Just call it, this way it will crash here if it doesn't work.
+				// (this is an external process.)
+				bool result = VulkanMayBeAvailable();
+
+				LogManager::Shutdown();
+				WinMainCleanup();
+				return result ? EXIT_CODE_VULKAN_WORKS : EXIT_FAILURE;
+			}
+		}
+	}
+
 	// Load config up here, because those changes below would be overwritten
 	// if it's not loaded here first.
 	g_Config.AddSearchPath("");
@@ -573,17 +589,6 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 					g_Config.iGPUBackend = (int)GPUBackend::OPENGL;
 					g_Config.bSoftwareRendering = true;
 				}
-			}
-
-			// This should only be called by DetectVulkanInExternalProcess().
-			if (wideArgs[i] == L"--vulkan-available-check") {
-				// Just call it, this way it will crash here if it doesn't work.
-				// (this is an external process.)
-				bool result = VulkanMayBeAvailable();
-
-				LogManager::Shutdown();
-				WinMainCleanup();
-				return result ? EXIT_CODE_VULKAN_WORKS : EXIT_FAILURE;
 			}
 		}
 	}

--- a/ext/native/net/resolve.h
+++ b/ext/native/net/resolve.h
@@ -11,10 +11,6 @@ namespace net {
 void Init();
 void Shutdown();
 
-// use free() to free the returned string.
-char *DNSResolveTry(const char *host, const char **err);
-char *DNSResolve(const char *host);
-
 enum class DNSType {
 	ANY = 0,
 	IPV4 = 1,

--- a/ext/native/ui/ui_context.cpp
+++ b/ext/native/ui/ui_context.cpp
@@ -12,6 +12,7 @@
 #include "gfx_es2/draw_text.h"
 
 #include "Common/Log.h"
+#include "UI/TextureUtil.h"
 
 UIContext::UIContext() {
 	fontStyle_ = new UI::FontStyle();

--- a/ext/native/ui/ui_context.h
+++ b/ext/native/ui/ui_context.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "base/basictypes.h"
 #include "math/geom2d.h"
 #include "math/lin/vec3.h"
 #include "gfx/texture_atlas.h"
-#include "UI/TextureUtil.h"
 
 // Everything you need to draw a UI collected into a single unit that can be passed around.
 // Everything forward declared so this header is safe everywhere.
@@ -22,13 +22,17 @@ namespace Draw {
 }
 
 class Texture;
+class ManagedTexture;
 class DrawBuffer;
 class TextDrawer;
 
 namespace UI {
 	struct Drawable;
+	struct EventParams;
 	struct Theme;
 	struct FontStyle;
+	class Event;
+	class View;
 }
 
 class DrawBuffer;


### PR DESCRIPTION
I'd prefer it only shows when there are other peers.

Initially added (instance: 1/2) but you could close one and get (instance: 3/2) which is probably confusing, and we don't want to renumber.

This fixes a few other things like Windows using 1, 3, 5, etc.  May help #13300.

-[Unknown]