### PR TITLE
Simulate blocking behavior using non-blocking on networking

### DIFF
--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -45,7 +45,7 @@ static const float FONT_SCALE = 0.65f;
 
 // Needs testing.
 const static int NET_INIT_DELAY_US = 300000;
-const static int NET_SHUTDOWN_DELAY_US = 26000;
+const static int NET_SHUTDOWN_DELAY_US = 260000;
 const static int NET_RUNNING_DELAY_US = 1000000; // KHBBS is showing adhoc dialog for about 3-4 seconds, but feels too long, so we're faking it to 1 sec instead to let players read the text
 const static int NET_CONNECT_TIMEOUT = 5000000;
 

--- a/Core/Dialog/PSPNetconfDialog.h
+++ b/Core/Dialog/PSPNetconfDialog.h
@@ -34,6 +34,7 @@ struct SceUtilityNetconfParam {
 	int netWifiSpot;			// Flag to allow WIFI connections
 };
 
+
 class PSPNetconfDialog: public PSPDialog {
 public:
 	PSPNetconfDialog();
@@ -57,11 +58,15 @@ private:
 
 	SceUtilityNetconfParam request = {};
 	u32 requestAddr = 0;
-	int connResult = 0;
+	int connResult = -1;
 	bool hideNotice = false;
 
 	int yesnoChoice = 0;
 	float scrollPos_ = 0.0f;
 	int framesUpHeld_ = 0;
 	int framesDownHeld_ = 0;
+
+	u32 scanInfosAddr = 0;
+	int scanStep = 0;
+	u64 startTime = 0;
 };

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -55,7 +55,8 @@ bool friendFinderRunning              = false;
 SceNetAdhocctlPeerInfo * friends      = NULL;
 SceNetAdhocctlScanInfo * networks     = NULL;
 SceNetAdhocctlScanInfo * newnetworks  = NULL;
-int threadStatus                      = ADHOCCTL_STATE_DISCONNECTED;
+int adhocctlState                     = ADHOCCTL_STATE_DISCONNECTED;
+int adhocConnectionType               = ADHOC_CONNECT;
 
 int actionAfterAdhocMipsCall;
 int actionAfterMatchingMipsCall;
@@ -1293,9 +1294,9 @@ int friendFinder(){
 						// Update User BSSID
 						parameter.bssid.mac_addr = packet->mac; // This packet seems to contains Adhoc Group Creator's BSSID (similar to AP's BSSID) so it shouldn't get mixed up with local MAC address
 						// Notify Event Handlers
-						//notifyAdhocctlHandlers(ADHOCCTL_EVENT_CONNECT, 0);
+						notifyAdhocctlHandlers(ADHOCCTL_EVENT_CONNECT, 0);
 						// Change State
-						threadStatus = ADHOCCTL_STATE_CONNECTED;
+						//threadStatus = ADHOCCTL_STATE_CONNECTED;
 						// Give time a little time
 						//sceKernelDelayThread(adhocEventDelayMS * 1000);
 						//sleep_ms(adhocEventDelayMS);
@@ -1492,14 +1493,14 @@ int friendFinder(){
 					peerlock.unlock();
 
 					// Notify Event Handlers
-					//notifyAdhocctlHandlers(ADHOCCTL_EVENT_SCAN, 0);
+					notifyAdhocctlHandlers(ADHOCCTL_EVENT_SCAN, 0);
 					//int i = 0; for(; i < ADHOCCTL_MAX_HANDLER; i++)
 					//{
 					//        // Active Handler
 					//        if(_event_handler[i] != NULL) _event_handler[i](ADHOCCTL_EVENT_SCAN, 0, _event_args[i]);
 					//}
 					// Change State
-					threadStatus = ADHOCCTL_STATE_DISCONNECTED;
+					//threadStatus = ADHOCCTL_STATE_DISCONNECTED;
 					// Give time a little time
 					//sceKernelDelayThread(adhocEventDelayMS * 1000);
 					//sleep_ms(adhocEventDelayMS);
@@ -1522,7 +1523,7 @@ int friendFinder(){
 	// Groups/Networks should be deallocated isn't?
 
 	// Prevent the games from having trouble to reInitiate Adhoc (the next NetInit -> PdpCreate after NetTerm)
-	threadStatus = ADHOCCTL_STATE_DISCONNECTED;
+	adhocctlState = ADHOCCTL_STATE_DISCONNECTED;
 
 	// Log Shutdown
 	INFO_LOG(SCENET, "FriendFinder: End of Friend Finder Thread");

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -252,14 +252,16 @@ typedef struct SceNetAdhocctlParameter {
   SceNetAdhocctlNickname nickname;
 } PACK SceNetAdhocctlParameter;
 
-// Peer Information
+// Peer Information (internal use only)
 typedef struct SceNetAdhocctlPeerInfo {
   SceNetAdhocctlPeerInfo * next;
   SceNetAdhocctlNickname nickname;
   SceNetEtherAddr mac_addr;
-  u32_le ip_addr;
-  uint8_t padding[2];
+  u16_le padding;
+  u32_le flags;
   u64_le last_recv; // Need to use the same method with sceKernelGetSystemTimeWide (ie. CoreTiming::GetGlobalTimeUsScaled) to prevent timing issue (ie. in game timeout)
+  
+  u32_le ip_addr; // internal use only
 } PACK SceNetAdhocctlPeerInfo;
 
 // Peer Information with u32 pointers
@@ -267,8 +269,8 @@ typedef struct SceNetAdhocctlPeerInfoEmu {
   u32_le next; // Changed the pointer to u32
   SceNetAdhocctlNickname nickname;
   SceNetEtherAddr mac_addr;
-  u32_le ip_addr; //jpcsp wrote 6bytes of 0x11 for this & padding
-  u16 padding; // Changed the padding to u16
+  u16_le padding; //00 00
+  u32_le flags; //00 04 00 00 // State of the peer? Or related to sceNetAdhocAuth_CF4D9BED ?
   u64_le last_recv; // Need to use the same method with sceKernelGetSystemTimeWide (ie. CoreTiming::GetGlobalTimeUsScaled) to prevent timing issue (ie. in game timeout)
 } PACK SceNetAdhocctlPeerInfoEmu;
 

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -827,6 +827,7 @@ extern std::thread friendFinderThread;
 extern std::recursive_mutex peerlock;
 extern SceNetAdhocPdpStat * pdp[255];
 extern SceNetAdhocPtpStat * ptp[255];
+extern std::map<int, int> ptpConnectCount;
 
 union SockAddrIN4 {
 	sockaddr addr;
@@ -846,7 +847,8 @@ extern SceNetAdhocMatchingContext * contexts;
 extern int one;                 
 extern bool friendFinderRunning;
 extern SceNetAdhocctlPeerInfo * friends;
-extern SceNetAdhocctlScanInfo * networks; 
+extern SceNetAdhocctlScanInfo * networks;
+extern u64 adhocctlStartTime;
 extern int adhocctlState;
 extern int adhocConnectionType;
 // End of Aux vars
@@ -924,6 +926,13 @@ extern int newChat;
  * Find a Peer/Friend by MAC address
  */
 SceNetAdhocctlPeerInfo * findFriend(SceNetEtherAddr * MAC);
+
+/**
+ * Get the Non-Blocking Mode of the socket
+ * @param fd File Descriptor of the socket
+ * @return 1 for non-blocking, 0 for blocking
+ */
+int getNonBlockingFlag(int fd);
 
 /**
  * Changes the Blocking Mode of the socket

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -847,8 +847,16 @@ extern int one;
 extern bool friendFinderRunning;
 extern SceNetAdhocctlPeerInfo * friends;
 extern SceNetAdhocctlScanInfo * networks; 
-extern int threadStatus;
+extern int adhocctlState;
+extern int adhocConnectionType;
 // End of Aux vars
+
+enum AdhocConnectionType : int
+{
+	ADHOC_CONNECT = 0,
+	ADHOC_CREATE = 1,
+	ADHOC_JOIN = 2,
+};
 
 // Check if Matching callback is running
 bool IsMatchingInCallback(SceNetAdhocMatchingContext * context);

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -49,7 +49,6 @@
 #include "Core/MemMap.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/HLEHelperThread.h"
-#include "Core/HLE/sceNetAdhoc.h"
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/HLE/sceKernel.h"
 #include "Core/HLE/sceKernelMutex.h"
@@ -928,11 +927,12 @@ extern int newChat;
 SceNetAdhocctlPeerInfo * findFriend(SceNetEtherAddr * MAC);
 
 /**
- * Get the Non-Blocking Mode of the socket
+ * Get the Readability(ie. recv) and/or Writability(ie. send) of a socket
  * @param fd File Descriptor of the socket
- * @return 1 for non-blocking, 0 for blocking
+ * @param timeout in usec (micro seconds), 0 = non-blocking
+ * @return > 0 = ready, 0 = timeout, -1 = error (errorcode only represent error of select and doesn't represent error of the socket)
  */
-int getNonBlockingFlag(int fd);
+int IsSocketReady(int fd, bool readfd, bool writefd, int* errorcode = nullptr, int timeoutUS = 0);
 
 /**
  * Changes the Blocking Mode of the socket

--- a/Core/HLE/proAdhocServer.cpp
+++ b/Core/HLE/proAdhocServer.cpp
@@ -2075,7 +2075,7 @@ int server_loop(int server)
 		sleep_ms(1);
 
 		// Don't do anything if it's paused, otherwise the log will be flooded
-		while (adhocServerRunning && Core_IsStepping()) sleep_ms(1);
+		while (adhocServerRunning && Core_IsStepping() && coreState != CORE_POWERDOWN) sleep_ms(1);
 	}
 
 	// Free User Database Memory

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -81,6 +81,7 @@ const WaitTypeNames waitTypeNames[] = {
 	{ WAITTYPE_VMEM,            "Volatile Mem" },
 	{ WAITTYPE_ASYNCIO,         "AsyncIO" },
 	{ WAITTYPE_MICINPUT,        "Microphone input"},
+	{ WAITTYPE_NET,             "Network"},
 };
 
 const char *getWaitTypeName(WaitType type)

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -107,6 +107,7 @@ enum WaitType : int
 	WAITTYPE_VMEM         = 22,
 	WAITTYPE_ASYNCIO      = 23,
 	WAITTYPE_MICINPUT     = 24, // fake
+	WAITTYPE_NET          = 25, // fake
 
 	NUM_WAITTYPES
 };

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -162,7 +162,7 @@ void __NetInit() {
 
 	SceNetEtherAddr mac;
 	getLocalMac(&mac);
-	INFO_LOG(SCENET, "LocalHost IP will be %s [%s]", inet_ntoa(g_localhostIP.in.sin_addr), mac2str(&mac).c_str());
+	NOTICE_LOG(SCENET, "LocalHost IP will be %s [%s]", inet_ntoa(g_localhostIP.in.sin_addr), mac2str(&mac).c_str());
 	
 	// TODO: May be we should initialize & cleanup somewhere else than here for PortManager to be used as general purpose for whatever port forwarding PPSSPP needed
 	__UPnPInit();
@@ -249,6 +249,9 @@ void __NetDoState(PointerWrap &p) {
 		netApctlInited = cur_netApctlInited;
 		netInetInited = cur_netInetInited;
 		netInited = cur_netInited;
+
+		// Discard leftover events
+		apctlEvents.clear();
 
 		// Previously, this wasn't being saved.  It needs its own space.
 		if (!apctlThreadHackAddr || (apctlThreadHackAddr && strcmp("apctlThreadHack", kernelMemory.GetBlockTag(apctlThreadHackAddr)) != 0)) {
@@ -582,6 +585,7 @@ static int sceNetInit(u32 poolSize, u32 calloutPri, u32 calloutStack, u32 netini
 	// Clear Socket Translator Memory
 	memset(&pdp, 0, sizeof(pdp));
 	memset(&ptp, 0, sizeof(ptp));
+	ptpConnectCount.clear();
 	
 	return hleLogSuccessI(SCENET, 0);
 }

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -469,7 +469,7 @@ void __NetApctlCallbacks()
 
 	// Must be delayed long enough whenever there is a pending callback.
 	sceKernelDelayThread(delayus);
-	hleSkipDeadbeef();;
+	hleSkipDeadbeef();
 }
 
 static inline u32 AllocUser(u32 size, bool fromTop, const char *name) {

--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -30,6 +30,11 @@ typedef struct MatchingArgs {
 #pragma pack(pop)
 #endif
 
+struct AdhocctlRequest {
+	u8 opcode;
+	SceNetAdhocctlGroupName group;
+};
+
 struct AdhocSendTarget {
 	u32 ip;
 	u16 port; // original port
@@ -48,7 +53,7 @@ struct AdhocSocketRequest {
 	s32_le* length;
 	u32 timeout;
 	u64 startTime;
-	struct SceNetEtherAddr* remoteMAC;
+	SceNetEtherAddr* remoteMAC;
 	u16_le* remotePort;
 };
 

--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <deque>
 #include "Core/HLE/proAdhoc.h"
 
 #ifdef _MSC_VER
@@ -28,6 +29,39 @@ typedef struct MatchingArgs {
 #ifdef _MSC_VER
 #pragma pack(pop)
 #endif
+
+struct AdhocSendTarget {
+	u32 ip;
+	u16 port; // original port
+};
+
+struct AdhocSendTargets {
+	int length;
+	std::deque<AdhocSendTarget> peers;
+	bool isBroadcast;
+};
+
+struct AdhocSocketRequest {
+	int type;
+	int id; // PDP/PTP socket id
+	void* buffer;
+	s32_le* length;
+	u32 timeout;
+	u64 startTime;
+	struct SceNetEtherAddr* remoteMAC;
+	u16_le* remotePort;
+};
+
+enum AdhocSocketRequestType : int
+{
+	PTP_CONNECT = 0,
+	PTP_ACCEPT = 1,
+	PTP_SEND = 2,
+	PTP_RECV = 3,
+	PDP_SEND = 4,
+	PDP_RECV = 5,
+	ADHOC_POLL_SOCKET = 6,
+};
 
 class PointerWrap;
 

--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -41,7 +41,18 @@ void __UpdateAdhocctlHandlers(u32 flags, u32 error);
 void __UpdateMatchingHandler(MatchingArgs params);
 
 // I have to call this from netdialog
+int sceNetAdhocctlGetState(u32 ptrToStatus);
 int sceNetAdhocctlCreate(const char * groupName);
+int sceNetAdhocctlConnect(const char* groupName);
+int sceNetAdhocctlJoin(u32 scanInfoAddr);
+int sceNetAdhocctlScan();
+int sceNetAdhocctlGetScanInfo(u32 sizeAddr, u32 bufAddr);
+
+int NetAdhocMatching_Term();
+int NetAdhocctl_Term();
+int NetAdhocctl_GetState();
+int NetAdhocctl_Create(const char* groupName);
+int NetAdhoc_Term();
 
 // May need to use these from sceNet.cpp
 extern bool netAdhocInited;
@@ -60,7 +71,3 @@ extern u32_le dummyThreadCode[3];
 extern u32 matchingThreadHackAddr;
 extern u32_le matchingThreadCode[3];
 
-int NetAdhocMatching_Term();
-int NetAdhocctl_Term();
-int NetAdhocctl_GetState();
-int NetAdhoc_Term();


### PR DESCRIPTION
An attempt to improve multiplayer performance/reduce lags/stutters due to blocking behavior.
This should fixes games that get heavy performance degradation (ie. Power Stone Collection/2), and games that almost permanently frozen (ie. Hotshots Tennis, Digimon World Re:Digitize, etc).
Also bumped into possible crash related to AdhocMatching while testing this, thus fixing it along with this.

PS: This is my first time using ScheduleEvent so there are many questions and assumption :)

Here are the test builds:
Win32 & Win64: https://www.dropbox.com/s/kbwwx0q0w4ecm2d/PPSSPP_1.10.3-perftest_Win32x64.zip?dl=0
Android ARMv7 32bit: https://www.dropbox.com/s/3gl942pt5n91fer/PPSSPP_1.10.3-perftest_ARMv7.apk?dl=0