### PR TITLE
Fix clear detection mistake

### DIFF
--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -445,7 +445,7 @@ void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVt
 		int scissorX2 = gstate.getScissorX2() + 1;
 		int scissorY2 = gstate.getScissorY2() + 1;
 		reallyAClear = IsReallyAClear(transformed, maxIndex, scissorX2, scissorY2);
-		if (reallyAClear && gstate.getColorMask() != 0 && gstate.getClearModeColorMask() != 0) {
+		if (reallyAClear && gstate.getColorMask() != 0xFFFFFFFF && (gstate.isClearModeColorMask() || gstate.isClearModeAlphaMask())) {
 			result->setSafeSize = true;
 			result->safeWidth = scissorX2;
 			result->safeHeight = scissorY2;
@@ -469,8 +469,8 @@ void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVt
 
 	// Detect full screen "clears" that might not be so obvious, to set the safe size if possible.
 	if (!result->setSafeSize && prim == GE_PRIM_RECTANGLES && maxIndex == 2) {
-		bool clearingColor = gstate.isModeClear() && gstate.getClearModeColorMask() != 0;
-		bool writingColor = gstate.getColorMask() != 0;
+		bool clearingColor = gstate.isModeClear() && (gstate.isClearModeColorMask() || gstate.isClearModeAlphaMask());
+		bool writingColor = gstate.getColorMask() != 0xFFFFFFFF;
 		bool startsZeroX = transformed[0].x <= 0.0f && transformed[1].x > transformed[0].x;
 		bool startsZeroY = transformed[0].y <= 0.0f && transformed[1].y > transformed[0].y;
 

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -634,7 +634,6 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 		}
 	}
 
-	// glBindTexture(GL_TEXTURE_2D, entry->textureName);
 	lastBoundTexture = entry->textureName;
 	
 	// GLES2 doesn't have support for a "Max lod" which is critical as PSP games often
@@ -859,12 +858,15 @@ bool TextureCacheGLES::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level)
 		gstate = saved;
 	}
 
-	buffer.Allocate(w, h, GE_FORMAT_8888, false);
-	renderManager->CopyImageToMemorySync(entry->textureName, level, 0, 0, w, h, Draw::DataFormat::R8G8B8A8_UNORM, (uint8_t *)buffer.GetData(), w, "GetCurrentTextureDebug");
+	bool result = entry->textureName != nullptr;
+	if (result) {
+		buffer.Allocate(w, h, GE_FORMAT_8888, false);
+		renderManager->CopyImageToMemorySync(entry->textureName, level, 0, 0, w, h, Draw::DataFormat::R8G8B8A8_UNORM, (uint8_t *)buffer.GetData(), w, "GetCurrentTextureDebug");
+	}
 	gstate_c.Dirty(DIRTY_TEXTURE_IMAGE | DIRTY_TEXTURE_PARAMS);
 	framebufferManager_->RebindFramebuffer("RebindFramebuffer - GetCurrentTextureDebug");
 
-	return true;
+	return result;
 #else
 	return false;
 #endif


### PR DESCRIPTION
Fixes #13320, was just a mistake in 1432cc9.

It's possible this may re-break #12858 because it may have been incorrectly setting the safe size when it was not, in fact, safe.  That said, I think it'll still work.

-[Unknown]