### PR TITLE
Fix longstanding depth/stencil view issue in Vulkan. 

### DIFF
--- a/ext/native/thin3d/VulkanRenderManager.h
+++ b/ext/native/thin3d/VulkanRenderManager.h
@@ -23,6 +23,7 @@
 struct VKRImage {
 	VkImage image;
 	VkImageView imageView;
+	VkImageView depthSampleView;
 	VkDeviceMemory memory;
 	VkImageLayout layout;
 	VkFormat format;
@@ -67,6 +68,8 @@ public:
 			vulkan_->Delete().QueueDeleteImageView(color.imageView);
 		if (depth.imageView)
 			vulkan_->Delete().QueueDeleteImageView(depth.imageView);
+		if (depth.depthSampleView)
+			vulkan_->Delete().QueueDeleteImageView(depth.depthSampleView);
 		if (color.memory)
 			vulkan_->Delete().QueueDeleteDeviceMemory(color.memory);
 		if (depth.memory)

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -1525,15 +1525,21 @@ void VKContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPass
 void VKContext::BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int attachment) {
 	VKFramebuffer *fb = (VKFramebuffer *)fbo;
 
-	if (fb == curFramebuffer_) {
-		Crash();
-	}
+	// TODO: There are cases where this is okay, actually.
+	_assert_(fb != curFramebuffer_);
 
 	int aspect = 0;
-	if (channelBit & FBChannel::FB_COLOR_BIT) aspect |= VK_IMAGE_ASPECT_COLOR_BIT;
-	if (channelBit & FBChannel::FB_DEPTH_BIT) aspect |= VK_IMAGE_ASPECT_DEPTH_BIT;
-	if (channelBit & FBChannel::FB_STENCIL_BIT) aspect |= VK_IMAGE_ASPECT_STENCIL_BIT;
-
+	switch (channelBit) {
+	case FBChannel::FB_COLOR_BIT:
+		aspect = VK_IMAGE_ASPECT_COLOR_BIT;
+		break;
+	case FBChannel::FB_DEPTH_BIT:
+		aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
+		break;
+	default:
+		_assert_(false);
+		break;
+	}
 	boundTextures_[binding] = nullptr;
 	boundImageView_[binding] = renderManager_.BindFramebufferAsTexture(fb->GetFB(), binding, aspect, attachment);
 }


### PR DESCRIPTION
Validates clean again (since the depth texturing merge, some things didn't).

We didn't specify DEPTH|STENCIL as aspects for views we rendered to, only DEPTH. Who knows how many of the driver bugs we "found" are this. Though, it seems drivers don't care much about the aspects here - if they did, all our stencil would be broken. It's probably just undefined behavior.

DEPTH|STENCIL views can't be sampled though, so we create a separate DEPTH view for that. This keeps Katamari working.


Finding this was quite a slog... this will be followed by a PR with a bunch of other stuff I found during debugging.