### PR TITLE
Vulkan: improved LogSteps logging

### DIFF
--- a/Common/Vulkan/VulkanDebug.cpp
+++ b/Common/Vulkan/VulkanDebug.cpp
@@ -75,14 +75,13 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDebugUtilsCallback(
 			DebugBreak();
 		}
 	}
-#else
-	// TODO: Improve.
+#endif
+
 	if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
 		ERROR_LOG(G3D, "VKDEBUG: %s", msg.c_str());
 	} else {
 		WARN_LOG(G3D, "VKDEBUG: %s", msg.c_str());
 	}
-#endif
 
 	// false indicates that layer should not bail-out of an
 	// API call that had validation failures. This may mean that the

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1760,8 +1760,8 @@ void FramebufferManagerCommon::DestroyAllFBOs() {
 	tempFBOs_.clear();
 }
 
-Draw::Framebuffer *FramebufferManagerCommon::GetTempFBO(TempFBO reason, u16 w, u16 h, Draw::FBColorDepth depth) {
-	u64 key = ((u64)reason << 48) | ((u64)depth << 32) | ((u32)w << 16) | h;
+Draw::Framebuffer *FramebufferManagerCommon::GetTempFBO(TempFBO reason, u16 w, u16 h, Draw::FBColorDepth color_depth) {
+	u64 key = ((u64)reason << 48) | ((u64)color_depth << 32) | ((u32)w << 16) | h;
 	auto it = tempFBOs_.find(key);
 	if (it != tempFBOs_.end()) {
 		it->second.last_frame_used = gpuStats.numFlips;
@@ -1770,10 +1770,12 @@ Draw::Framebuffer *FramebufferManagerCommon::GetTempFBO(TempFBO reason, u16 w, u
 
 	textureCache_->ForgetLastTexture();
 	bool z_stencil = reason == TempFBO::STENCIL;
-	const char *name = "temp_fbo";
-	Draw::Framebuffer *fbo = draw_->CreateFramebuffer({ w, h, 1, 1, z_stencil, depth, name });
-	if (!fbo)
-		return fbo;
+	char name[128];
+	snprintf(name, sizeof(name), "temp_fbo_%dx%d%s", w, h, z_stencil ? "_depth" : "");
+	Draw::Framebuffer *fbo = draw_->CreateFramebuffer({ w, h, 1, 1, z_stencil, color_depth, name });
+	if (!fbo) {
+		return nullptr;
+	}
 
 	const TempFBOInfo info = { fbo, gpuStats.numFlips };
 	tempFBOs_[key] = info;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -141,7 +141,7 @@ void GPU_Vulkan::LoadCache(std::string filename) {
 	}
 	fclose(f);
 	if (!result) {
-		WARN_LOG(G3D, "Bad Vulkan pipeline cache");
+		WARN_LOG(G3D, "Incompatible Vulkan pipeline cache - rebuilding.");
 		// Bad cache file for this GPU/Driver/etc. Delete it.
 		File::Delete(filename);
 	} else {

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -583,6 +583,8 @@ struct StoredVulkanPipelineKey {
 	}
 };
 
+// If you're looking for how to invalidate the cache, it's done in ShaderManagerVulkan, look for CACHE_VERSION and increment it.
+// (Header of the same file this is stored in).
 void PipelineManagerVulkan::SaveCache(FILE *file, bool saveRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext) {
 	VulkanRenderManager *rm = (VulkanRenderManager *)drawContext->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 	VulkanQueueRunner *queueRunner = rm->GetQueueRunner();

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -182,7 +182,7 @@ public:
 
 	// RunSteps can modify steps but will leave it in a valid state.
 	void RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &steps, QueueProfileContext *profile);
-	void LogSteps(const std::vector<VKRStep *> &steps);
+	void LogSteps(const std::vector<VKRStep *> &steps, bool verbose);
 
 	std::string StepToString(const VKRStep &step) const;
 
@@ -210,7 +210,7 @@ public:
 		VKRRenderPassAction depthLoadAction;
 		VKRRenderPassAction stencilLoadAction;
 		VkImageLayout prevColorLayout;
-		VkImageLayout prevDepthLayout;
+		VkImageLayout prevDepthStencilLayout;
 		VkImageLayout finalColorLayout;
 		VkImageLayout finalDepthStencilLayout;
 	};
@@ -250,7 +250,7 @@ private:
 	void PerformReadback(const VKRStep &pass, VkCommandBuffer cmd);
 	void PerformReadbackImage(const VKRStep &pass, VkCommandBuffer cmd);
 
-	void LogRenderPass(const VKRStep &pass);
+	void LogRenderPass(const VKRStep &pass, bool verbose);
 	void LogCopy(const VKRStep &pass);
 	void LogBlit(const VKRStep &pass);
 	void LogReadback(const VKRStep &pass);

--- a/ext/native/thin3d/VulkanQueueRunner.h
+++ b/ext/native/thin3d/VulkanQueueRunner.h
@@ -180,7 +180,7 @@ public:
 		backbufferImage_ = img;
 	}
 
-	// RunSteps can modify steps but will leave it in a valid state.
+	void PreprocessSteps(std::vector<VKRStep *> &steps);
 	void RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &steps, QueueProfileContext *profile);
 	void LogSteps(const std::vector<VKRStep *> &steps, bool verbose);
 

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -1256,7 +1256,8 @@ void VulkanRenderManager::Run(int frame) {
 	FrameData &frameData = frameData_[frame];
 	auto &stepsOnThread = frameData_[frame].steps;
 	VkCommandBuffer cmd = frameData.mainCmd;
-	// queueRunner_.LogSteps(stepsOnThread);
+	queueRunner_.PreprocessSteps(stepsOnThread);
+	//queueRunner_.LogSteps(stepsOnThread, false);
 	queueRunner_.RunSteps(cmd, stepsOnThread, frameData.profilingEnabled_ ? &frameData.profile : nullptr);
 	stepsOnThread.clear();
 

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -19,8 +19,57 @@
 #define UINT64_MAX 0xFFFFFFFFFFFFFFFFULL
 #endif
 
+VKRFramebuffer::VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VkRenderPass renderPass, int _width, int _height, const char *tag) : vulkan_(vk) {
+	width = _width;
+	height = _height;
 
-void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int width, int height, VkFormat format, VkImageLayout initialLayout, bool color) {
+	CreateImage(vulkan_, initCmd, color, width, height, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, true, tag);
+	CreateImage(vulkan_, initCmd, depth, width, height, vulkan_->GetDeviceInfo().preferredDepthStencilFormat, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, false, tag);
+
+	VkFramebufferCreateInfo fbci{ VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO };
+	VkImageView views[2]{};
+
+	fbci.renderPass = renderPass;
+	fbci.attachmentCount = 2;
+	fbci.pAttachments = views;
+	views[0] = color.imageView;
+	views[1] = depth.imageView;
+	fbci.width = width;
+	fbci.height = height;
+	fbci.layers = 1;
+
+	vkCreateFramebuffer(vulkan_->GetDevice(), &fbci, nullptr, &framebuf);
+	if (vk->Extensions().EXT_debug_utils) {
+		vk->SetDebugName(color.image, VK_OBJECT_TYPE_IMAGE, StringFromFormat("fb_color_%s", tag).c_str());
+		vk->SetDebugName(depth.image, VK_OBJECT_TYPE_IMAGE, StringFromFormat("fb_depth_%s", tag).c_str());
+		vk->SetDebugName(framebuf, VK_OBJECT_TYPE_FRAMEBUFFER, StringFromFormat("fb_%s", tag).c_str());
+	}
+
+	if (tag) {
+		this->tag = tag;
+	}
+}
+
+VKRFramebuffer::~VKRFramebuffer() {
+	if (color.image)
+		vulkan_->Delete().QueueDeleteImage(color.image);
+	if (depth.image)
+		vulkan_->Delete().QueueDeleteImage(depth.image);
+	if (color.imageView)
+		vulkan_->Delete().QueueDeleteImageView(color.imageView);
+	if (depth.imageView)
+		vulkan_->Delete().QueueDeleteImageView(depth.imageView);
+	if (depth.depthSampleView)
+		vulkan_->Delete().QueueDeleteImageView(depth.depthSampleView);
+	if (color.memory)
+		vulkan_->Delete().QueueDeleteDeviceMemory(color.memory);
+	if (depth.memory)
+		vulkan_->Delete().QueueDeleteDeviceMemory(depth.memory);
+	if (framebuf)
+		vulkan_->Delete().QueueDeleteFramebuffer(framebuf);
+}
+
+void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int width, int height, VkFormat format, VkImageLayout initialLayout, bool color, const char *tag) {
 	VkImageCreateInfo ici{ VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
 	ici.arrayLayers = 1;
 	ici.mipLevels = 1;
@@ -111,6 +160,7 @@ void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int 
 	img.layout = initialLayout;
 
 	img.format = format;
+	img.tag = tag ? tag : "N/A";
 }
 
 VulkanRenderManager::VulkanRenderManager(VulkanContext *vulkan) : vulkan_(vulkan), queueRunner_(vulkan) {

--- a/ext/native/thin3d/thin3d_vulkan.cpp
+++ b/ext/native/thin3d/thin3d_vulkan.cpp
@@ -1460,6 +1460,8 @@ private:
 
 Framebuffer *VKContext::CreateFramebuffer(const FramebufferDesc &desc) {
 	VkCommandBuffer cmd = renderManager_.GetInitCmd();
+	// TODO: We always create with depth here, even when it's not needed (such as color temp FBOs).
+	// Should optimize those away.
 	VKRFramebuffer *vkrfb = new VKRFramebuffer(vulkan_, cmd, renderManager_.GetFramebufferRenderPass(), desc.width, desc.height, desc.tag);
 	return new VKFramebuffer(vkrfb);
 }


### PR DESCRIPTION
While working on debugging #13340, I improved LogSteps in VulkanQueueRunner by quite a lot. It's very useful to get a quick overview of a frame and to see at least some potential layout transitions and so on.

Also keeps track internally of the tags for framebuffers and images so we can log them.