### PR TITLE
Actually clear memory when initializating.

### DIFF
--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -426,8 +426,10 @@ void __KernelFplEndCallback(SceUID threadID, SceUID prevCallbackId);
 
 void __KernelMemoryInit()
 {
-	kernelMemory.Init(PSP_GetKernelMemoryBase(), PSP_GetKernelMemoryEnd()-PSP_GetKernelMemoryBase());
-	userMemory.Init(PSP_GetUserMemoryBase(), PSP_GetUserMemoryEnd()-PSP_GetUserMemoryBase());
+	kernelMemory.Init(PSP_GetKernelMemoryBase(), PSP_GetKernelMemoryEnd() - PSP_GetKernelMemoryBase());
+	userMemory.Init(PSP_GetUserMemoryBase(), PSP_GetUserMemoryEnd() - PSP_GetUserMemoryBase());
+	Memory::Memset(PSP_GetKernelMemoryBase(), 0, PSP_GetKernelMemoryEnd() - PSP_GetKernelMemoryBase());
+	Memory::Memset(PSP_GetUserMemoryBase(), 0, PSP_GetUserMemoryEnd() - PSP_GetUserMemoryBase());
 	INFO_LOG(SCEKERNEL, "Kernel and user memory pools initialized");
 
 	vplWaitTimer = CoreTiming::RegisterEvent("VplTimeout", __KernelVplTimeout);

--- a/Core/Util/BlockAllocator.cpp
+++ b/Core/Util/BlockAllocator.cpp
@@ -23,6 +23,7 @@
 #include "Common/StringUtils.h"
 #include "Core/Util/BlockAllocator.h"
 #include "Core/Reporting.h"
+#include "Core/MemMapHelpers.h"
 
 // Slow freaking thing but works (eventually) :)
 
@@ -43,6 +44,7 @@ void BlockAllocator::Init(u32 rangeStart, u32 rangeSize)
 	//Initial block, covering everything
 	top_ = new Block(rangeStart_, rangeSize_, false, NULL, NULL);
 	bottom_ = top_;
+	Memory::Memset(rangeStart_, 0, rangeSize_);
 }
 
 void BlockAllocator::Shutdown()

--- a/Core/Util/BlockAllocator.cpp
+++ b/Core/Util/BlockAllocator.cpp
@@ -23,7 +23,6 @@
 #include "Common/StringUtils.h"
 #include "Core/Util/BlockAllocator.h"
 #include "Core/Reporting.h"
-#include "Core/MemMapHelpers.h"
 
 // Slow freaking thing but works (eventually) :)
 
@@ -44,7 +43,6 @@ void BlockAllocator::Init(u32 rangeStart, u32 rangeSize)
 	//Initial block, covering everything
 	top_ = new Block(rangeStart_, rangeSize_, false, NULL, NULL);
 	bottom_ = top_;
-	Memory::Memset(rangeStart_, 0, rangeSize_);
 }
 
 void BlockAllocator::Shutdown()


### PR DESCRIPTION
Fixes #4671, this aims to do a actual clear after calling sceKernelLoadExec, matches the behavior of a PSP.