### PR TITLE
Refactor framebuffer attachment. Fixes Test Drive Unlimited performance

### DIFF
--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -80,10 +80,20 @@ void GenerateDepalShader300(char *buffer, GEBufferFormat pixelFormat, ShaderLang
 	int shift = gstate.getClutIndexShift();
 	int offset = gstate.getClutIndexStartPos();
 	GEPaletteFormat clutFormat = gstate.getClutPaletteFormat();
-	// Unfortunately sampling turned our texture into floating point. To avoid this, might be able
+
+	// Sampling turns our texture into floating point. To avoid this, might be able
 	// to declare them as isampler2D objects, but these require integer textures, which needs more work.
-	// Anyhow, we simply work around this by converting back to integer. Hopefully there will be no loss of precision.
+	// Anyhow, we simply work around this by converting back to integer, which is fine.
 	// Use the mask to skip reading some components.
+
+	// TODO: Since we actually have higher precision color data here, we might want to apply a dithering pattern here
+	// in the 5551, 565 and 4444 modes. This would benefit Test Drive which renders at 16-bit on the real hardware
+	// and dithers immediately, while we render at higher color depth and thus don't dither resulting in banding
+	// when we sample it at low color depth like this.
+
+	// An alternative would be to have a special mode where we keep some extra precision here and sample the CLUT linearly - works for ramps such
+	// as those that Test Drive uses for its color remapping. But would need game specific flagging.
+
 	int shiftedMask = mask << shift;
 	switch (pixelFormat) {
 	case GE_FORMAT_8888:

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -274,6 +274,8 @@ protected:
 
 	FramebufferMatchInfo MatchFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, u32 texaddrOffset, FramebufferNotificationChannel channel) const;
 
+	bool AttachFramebufferToEntry(TexCacheEntry *entry, u32 texAddrOffset);
+
 	// Temporary utility during conversion
 	bool ApplyFramebufferMatch(FramebufferMatchInfo match, TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, FramebufferNotificationChannel channel);
 

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -207,6 +207,13 @@ struct FramebufferMatchInfo {
 	u32 yOffset;
 };
 
+struct AttachCandidate {
+	FramebufferMatchInfo match;
+	TexCacheEntry *entry;
+	VirtualFramebuffer *fb;
+	FramebufferNotificationChannel channel;
+};
+
 class TextureCacheCommon {
 public:
 	TextureCacheCommon(Draw::DrawContext *draw);
@@ -278,6 +285,7 @@ protected:
 
 	// Temporary utility during conversion
 	bool ApplyFramebufferMatch(FramebufferMatchInfo match, TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, FramebufferNotificationChannel channel);
+	bool AttachBestCandidate(const std::vector<AttachCandidate> &candidates);
 
 	void AttachFramebufferValid(TexCacheEntry *entry, VirtualFramebuffer *framebuffer, const FramebufferMatchInfo &fbInfo, FramebufferNotificationChannel channel);
 	void AttachFramebufferInvalid(TexCacheEntry *entry, VirtualFramebuffer *framebuffer, const FramebufferMatchInfo &fbInfo, FramebufferNotificationChannel channel);

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -538,6 +538,12 @@ ULJM05049 = true
 ULKS46027 = true
 ULAS42019 = true
 
+# Test Drive Unlimited
+ULET00386 = true
+ULUS10249 = true
+ULES00637 = true
+ULKS46126 = true
+
 # Note! This whole flag is disabled temporarily by appending "Disabled" to its name). See 7914
 [YugiohSaveFixDisabled]
 # The cause of Yu-gi-oh series 's bad save (cannot save) are load "save status" and use cwcheat,


### PR DESCRIPTION
Turns on virtual framebuffer copies for Test Drive Unlimited. With this, the game now runs great even on mobile (with Vulkan, at least - haven't yet tested other backends).

Switches framebuffer attachment to a scoring model, where we add a little bonus for matching stride.

Unfortunately, there's some banding, as can be seen in this screenshot, look at the shadow:

![ULET00386_00002](https://user-images.githubusercontent.com/130929/91645938-44255c00-ea4a-11ea-8a46-e7da905fcbed.jpg)

Explanation for the banding:

The slow thing the game is doing (which, with this change, no longer requires CPU readbacks) is color correction. It does this by tiling the display, and for each tile look up R, G and B of the rendered framebuffer in a table, separately, adding the outputs of the lookups together. Now, on the real PSP it renders to a 16-bit buffer (565) with dithering, and the dither kind of comes along for the ride through the lookup so the banding isn't so bad.

Now, in PPSSPP, we always render at full 8888 color resolution. When the game uses channels of the framebuffer to look up in a palette, we simply downgrade the (undithered) color and use that for the lookup. No dithering, so we get banding.

We could either dither the converted color values during the lookup according to the pixel coordinate, or we could linearly filter the palette with the extra precision. The latter would not work in many situations though so would require a game specific flag.

The dithering on the original PSP can be seen clearly in this screenshot I found:

![787613-932168_20070329_002](https://user-images.githubusercontent.com/130929/91646236-6076c800-ea4d-11ea-8467-cc7f9ad8611a.jpg)

Anyway, this at least makes the game very playable without any cheats.


~~Test Drive has another problem too - the vertex range culling is inaccurate with this game (as we've seen in some other games too), leading to missing triangles. I think we might have to add a compat.ini setting for that unless we can figure out the PSP's clipping once and for all....~~  (this only affects a beta version of TDU).