### PR TITLE
GE dump loading: Try to use the correct GameID so compat.ini flags apply.

### DIFF
--- a/Core/ELF/ParamSFO.h
+++ b/Core/ELF/ParamSFO.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/Log.h"
 
 class ParamSFOData
 {
@@ -40,7 +41,9 @@ public:
 	std::string GetDiscID() {
 		const std::string discID = GetValueString("DISC_ID");
 		if (discID.empty()) {
-			return GenerateFakeID();
+			std::string fakeID = GenerateFakeID();
+			WARN_LOG(LOADER, "No DiscID found - generating a fake one: %s", fakeID.c_str());
+			return fakeID;
 		}
 		return discID;
 	}


### PR DESCRIPTION
compat.ini flags can sometimes impact rendering, such as BlockTransferAllowCreateFB (virtual framebuffer copies), so when replaying GE dumps, we should use the same compat.ini settings as the game. This change extracts the game ID from the dump filename, so if you want to avoid this, rename the GE dump.

I thought this might be why GE dumps from Test Drive like 
[ULES00637_0003.zip](https://github.com/hrydgard/ppsspp/files/5146610/ULES00637_0003.zip) didn't render correctly, but that did not fix it.

The problem is block transfer related, at least.