### PR TITLE
More depth texturing fixes, re-fixing Me and My Katamari in Vulkan

### DIFF
--- a/Common/Vulkan/VulkanImage.cpp
+++ b/Common/Vulkan/VulkanImage.cpp
@@ -181,6 +181,20 @@ void VulkanTexture::UploadMip(VkCommandBuffer cmd, int mip, int mipWidth, int mi
 	vkCmdCopyBufferToImage(cmd, buffer, image_, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
 }
 
+void VulkanTexture::ClearMip(VkCommandBuffer cmd, int mip, uint32_t value) {
+	// Must be in TRANSFER_DST mode.
+	VkClearColorValue clearVal;
+	for (int i = 0; i < 4; i++) {
+		clearVal.float32[i] = ((value >> (i * 8)) & 0xFF) / 255.0f;
+	}
+	VkImageSubresourceRange range{};
+	range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	range.layerCount = 1;
+	range.baseMipLevel = mip;
+	range.levelCount = 1;
+	vkCmdClearColorImage(cmd, image_, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clearVal, 1, &range);
+}
+
 void VulkanTexture::GenerateMip(VkCommandBuffer cmd, int mip) {
 	_assert_msg_(mip != 0, "Cannot generate the first level");
 	_assert_msg_(mip < numMips_, "Cannot generate mipmaps past the maximum created (%d vs %d)", mip, numMips_);

--- a/Common/Vulkan/VulkanImage.h
+++ b/Common/Vulkan/VulkanImage.h
@@ -19,6 +19,7 @@ public:
 	// Usage must at least include VK_IMAGE_USAGE_TRANSFER_DST_BIT in order to use UploadMip.
 	// When using UploadMip, initialLayout should be VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL.
 	bool CreateDirect(VkCommandBuffer cmd, VulkanDeviceAllocator *allocator, int w, int h, int numMips, VkFormat format, VkImageLayout initialLayout, VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, const VkComponentMapping *mapping = nullptr);
+	void ClearMip(VkCommandBuffer cmd, int mip, uint32_t value);
 	void UploadMip(VkCommandBuffer cmd, int mip, int mipWidth, int mipHeight, VkBuffer buffer, uint32_t offset, size_t rowLength);  // rowLength is in pixels
 	void GenerateMip(VkCommandBuffer cmd, int mip);
 	void EndCreate(VkCommandBuffer cmd, bool vertexTexture = false, VkImageLayout layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -255,7 +255,12 @@ inline void Write_Float(float f, u32 address)
 
 u8* GetPointer(const u32 address);
 bool IsRAMAddress(const u32 address);
-bool IsVRAMAddress(const u32 address);
+inline bool IsVRAMAddress(const u32 address) {
+	return ((address & 0x3F800000) == 0x04000000);
+}
+inline bool IsDepthTexVRAMAddress(const u32 address) {
+	return ((address & 0x3FE00000) == 0x04200000) || ((address & 0x3FE00000) == 0x04600000);
+}
 bool IsScratchpadAddress(const u32 address);
 
 // Used for auto-converted char * parameters, which can sometimes legitimately be null -

--- a/Core/MemMapFunctions.cpp
+++ b/Core/MemMapFunctions.cpp
@@ -112,10 +112,6 @@ bool IsRAMAddress(const u32 address) {
 	}
 }
 
-bool IsVRAMAddress(const u32 address) {
-	return ((address & 0x3F800000) == 0x04000000);
-}
-
 bool IsScratchpadAddress(const u32 address) {
 	return (address & 0xBFFF0000) == 0x00010000 && (address & 0x0000FFFF) < SCRATCHPAD_SIZE;
 }

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -489,7 +489,7 @@ void FramebufferManagerCommon::NotifyRenderFramebufferCreated(VirtualFramebuffer
 void FramebufferManagerCommon::NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) {
 	if (vfbFormatChanged) {
 		textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_UPDATED, NOTIFY_FB_COLOR);
-		textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_UPDATED, NOTIFY_FB_DEPTH);
+		textureCache_->NotifyFramebuffer(vfb->z_address, vfb, NOTIFY_FB_UPDATED, NOTIFY_FB_DEPTH);
 		if (vfb->drawnFormat != vfb->format) {
 			ReformatFramebufferFrom(vfb, vfb->drawnFormat);
 		}

--- a/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
+++ b/GPU/Vulkan/FragmentShaderGeneratorVulkan.cpp
@@ -195,7 +195,8 @@ bool GenerateVulkanGLSLFragmentShader(const FShaderID &id, char *buffer, uint32_
 				}
 			} else {
 				if (doTextureProjection) {
-					// We don't use textureProj because we need better control and it's probably not much of a savings anyway.
+					// We don't use textureProj because we need to manually offset from the divided coordinate to do filtering here.
+					// On older hardware it has the advantage of higher resolution math, but such old hardware can't run Vulkan.
 					WRITE(p, "  vec2 uv = %s.xy/%s.z;\n  vec2 uv_round;\n", texcoord, texcoord);
 				} else {
 					WRITE(p, "  vec2 uv = %s.xy;\n  vec2 uv_round;\n", texcoord);


### PR DESCRIPTION
Failed to consider that multiple TexEntries can have the same framebuffer (such as when they have different CLUTs).

Also cleans up some depth texture handling but there's more to do there.