### PR TITLE
Adhoc Socket Reindexing - Fix Crash issue due to out of bound when indexing

### DIFF
--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -71,8 +71,10 @@ SceNetAdhocctlParameter parameter;
 SceNetAdhocctlAdhocId product_code;
 std::thread friendFinderThread;
 std::recursive_mutex peerlock;
-SceNetAdhocPdpStat * pdp[255];
-SceNetAdhocPtpStat * ptp[255];
+SceNetAdhocPdpStat * pdp[MAX_SOCKET];
+SceNetAdhocPtpStat * ptp[MAX_SOCKET];
+const int PdpIdStart = MAX_SOCKET + 1; //256
+const int PdpIdEnd = PdpIdStart + MAX_SOCKET;
 std::map<int, int> ptpConnectCount;
 std::vector<std::string> chatLog;
 std::string name = "";
@@ -101,7 +103,7 @@ bool isLocalMAC(const SceNetEtherAddr * addr) {
 
 bool isPDPPortInUse(uint16_t port) {
 	// Iterate Elements
-	for (int i = 0; i < 255; i++) if (pdp[i] != NULL && pdp[i]->lport == port) return true;
+	for (int i = 0; i < MAX_SOCKET; i++) if (pdp[i] != NULL && pdp[i]->lport == port) return true;
 
 	// Unused Port
 	return false;
@@ -109,7 +111,7 @@ bool isPDPPortInUse(uint16_t port) {
 
 bool isPTPPortInUse(uint16_t port) {
 	// Iterate Sockets
-	for(int i = 0; i < 255; i++) if(ptp[i] != NULL && ptp[i]->lport == port) return true;
+	for(int i = 0; i < MAX_SOCKET; i++) if(ptp[i] != NULL && ptp[i]->lport == port) return true;
 	
 	// Unused Port
 	return false;
@@ -1861,7 +1863,7 @@ int getPDPSocketCount()
 	int counter = 0;
 
 	// Count Sockets
-	for (int i = 0; i < 255; i++) if (pdp[i] != NULL) counter++;
+	for (int i = 0; i < MAX_SOCKET; i++) if (pdp[i] != NULL) counter++;
 
 	// Return Socket Count
 	return counter;
@@ -1872,7 +1874,7 @@ int getPTPSocketCount() {
 	int counter = 0;
 
 	// Count Sockets
-	for (int i = 0; i < 255; i++) if (ptp[i] != NULL) counter++;
+	for (int i = 0; i < MAX_SOCKET; i++) if (ptp[i] != NULL) counter++;
 
 	// Return Socket Count
 	return counter;

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -820,14 +820,17 @@ private:
 extern int actionAfterAdhocMipsCall;
 extern int actionAfterMatchingMipsCall;
 
+#define MAX_SOCKET	255
 // Aux vars
 extern int metasocket;
 extern SceNetAdhocctlParameter parameter;
 extern SceNetAdhocctlAdhocId product_code;
 extern std::thread friendFinderThread;
 extern std::recursive_mutex peerlock;
-extern SceNetAdhocPdpStat * pdp[255];
-extern SceNetAdhocPtpStat * ptp[255];
+extern SceNetAdhocPdpStat * pdp[MAX_SOCKET];
+extern SceNetAdhocPtpStat * ptp[MAX_SOCKET];
+extern const int PdpIdStart;
+extern const int PdpIdEnd;
 extern std::map<int, int> ptpConnectCount;
 
 union SockAddrIN4 {

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -281,7 +281,7 @@ int DoBlockingPdpRecv(int uid, AdhocSocketRequest& req, s64& result) {
 }
 
 int DoBlockingPdpSend(int uid, AdhocSocketRequest& req, s64& result, AdhocSendTargets& targetPeers) {
-	SceNetAdhocPdpStat* pdpsocket = pdp[req.id - 1];
+	SceNetAdhocPdpStat* pdpsocket = pdp[req.id - 256];
 
 	result = 0;
 	bool retry = false;


### PR DESCRIPTION
I forgot to reindex PDP socket on the blocking socket simulation PR after rebasing from Gran Turismo fix PR which have been reindexed :( 
it's so hard to works on multiple branch if they are using the same things... because the blocking simulation PR was completed since days ago i forgotten about it LOL

This should fix crash issue due to out of bound while indexing PDP array (was having this issue when testing Monster Hunter Portable 3rd with 4 players in localhost)