### PR TITLE
Adhocctl fix - Fix SceNetAdhocctlParameter structure

### DIFF
--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -248,8 +248,8 @@ typedef struct SceNetAdhocctlNickname {
 typedef struct SceNetAdhocctlParameter {
   s32_le channel;
   SceNetAdhocctlGroupName group_name; // This group name is probably similar to SSID name on AP
-  SceNetAdhocctlBSSId bssid;
-  SceNetAdhocctlNickname nickname;
+  SceNetAdhocctlNickname nickname; // According to the old PSPSDK this is the bssid, but according to the dumped content when using newer firmware this is the nickname (this is also the nickname on VitaSDK)
+  SceNetAdhocctlBSSId bssid; // FIXME: bssid and nickname position might be swapped on older/newer firmware?
 } PACK SceNetAdhocctlParameter;
 
 // Peer Information (internal use only)
@@ -270,7 +270,7 @@ typedef struct SceNetAdhocctlPeerInfoEmu {
   SceNetAdhocctlNickname nickname;
   SceNetEtherAddr mac_addr;
   u16_le padding; //00 00
-  u32_le flags; //00 04 00 00 // State of the peer? Or related to sceNetAdhocAuth_CF4D9BED ?
+  u32_le flags; //00 04 00 00 on KHBBS and FF FF FF FF on Ys vs. Sora no Kiseki // State of the peer? Or related to sceNetAdhocAuth_CF4D9BED ?
   u64_le last_recv; // Need to use the same method with sceKernelGetSystemTimeWide (ie. CoreTiming::GetGlobalTimeUsScaled) to prevent timing issue (ie. in game timeout)
 } PACK SceNetAdhocctlPeerInfoEmu;
 

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -645,7 +645,7 @@ static u32 sceWlanGetSwitchState() {
 
 // Probably a void function, but often returns a useful value.
 static void sceNetEtherNtostr(u32 macPtr, u32 bufferPtr) {
-	DEBUG_LOG(SCENET, "sceNetEtherNtostr(%08x, %08x)", macPtr, bufferPtr);
+	DEBUG_LOG(SCENET, "sceNetEtherNtostr(%08x, %08x) at %08x", macPtr, bufferPtr, currentMIPS->pc);
 
 	if (Memory::IsValidAddress(bufferPtr) && Memory::IsValidAddress(macPtr)) {
 		char *buffer = (char *)Memory::GetPointer(bufferPtr);

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1953,7 +1953,7 @@ int sceNetAdhocctlTerm() {
 }
 
 static int sceNetAdhocctlGetNameByAddr(const char *mac, u32 nameAddr) {
-	DEBUG_LOG(SCENET, "UNTESTED sceNetAdhocctlGetNameByAddr(%s, %08x)", mac2str((SceNetEtherAddr*)mac).c_str(), nameAddr);
+	DEBUG_LOG(SCENET, "UNTESTED sceNetAdhocctlGetNameByAddr(%s, %08x) at %08x", mac2str((SceNetEtherAddr*)mac).c_str(), nameAddr, currentMIPS->pc);
 	
 	// Library initialized
 	if (netAdhocctlInited)
@@ -5043,8 +5043,16 @@ void broadcastHelloMessage(SceNetAdhocMatchingContext * context)
 		// Hello Data Length (have to memcpy this to avoid cpu alignment crash)
 		memcpy(hello + 1, &context->hellolen, sizeof(context->hellolen));
 
+		// FIXME: When using JPCSP + prx files the data being sent have a header of 12 bytes instead of 5 bytes: 
+		// [01(always 1? size of the next data? or combined with next byte as U16_BE opcode?) 01(matching opcode, or combined with previous byte as U16_BE opcode?) 01 E0(size of next data + hello data in big-endian/U16_BE) 00 0F 42 40(U32_BE? time?) 00 0F 42 40(U32_BE? time?)], 
+		// followed by hello data (0x1D8 bytes of opt data, based on Ys vs. Sora no Kiseki), and followed by 16 bytes of (optional?) footer [01 00 00 .. 00 00](footer doesn't exist if the size after opcode is 00 00)
+
 		// Copy Hello Data
 		if (context->hellolen > 0) memcpy(hello + 5, context->hello, context->hellolen);
+
+		std::string hellohex;
+		DataToHexString("          ", 0, context->hello, context->hellolen, &hellohex);
+		DEBUG_LOG(SCENET, "HELLO Dump:\n%s", hellohex.c_str());
 
 		// Send Broadcast
 		context->socketlock->lock();
@@ -5472,6 +5480,10 @@ void actOnHelloPacket(SceNetAdhocMatchingContext * context, SceNetEtherAddr * se
 				// Peer available now
 				if (peer != NULL && peer->state != PSP_ADHOC_MATCHING_PEER_OUTGOING_REQUEST && peer->state != PSP_ADHOC_MATCHING_PEER_INCOMING_REQUEST)
 				{
+					std::string hellohex;
+					DataToHexString("          ", 0, (u8*)opt, optlen, &hellohex);
+					DEBUG_LOG(SCENET, "HELLO Dump:\n%s", hellohex.c_str());
+
 					// Spawn Hello Event. FIXME: HELLO event should not be triggered in the middle of joining? This will cause Bleach 7 to Cancel the join request
 					spawnLocalEvent(context, PSP_ADHOC_MATCHING_EVENT_HELLO, sendermac, optlen, opt);
 				}
@@ -6210,6 +6222,7 @@ int matchingInputThread(int matchingId) // TODO: The MatchingInput thread is usi
 				}
 
 				// Receive PDP Datagram
+				// FIXME: When using JPCSP + prx files, the "SceNetAdhocMatchingInput" thread is using blocking PdpRecv with infinite(0) timeout, which can be stopped/aborted using SetSocketAlert, while "SceNetAdhocMatchingEvent" thread is using non-blocking for sending
 				rxbuflen = context->rxbuflen;
 				senderport = 0;
 				context->socketlock->lock();

--- a/ext/native/base/stringutil.cpp
+++ b/ext/native/base/stringutil.cpp
@@ -71,6 +71,34 @@ void DataToHexString(const uint8_t *data, size_t size, std::string *output) {
 	buffer.TakeAll(output);
 }
 
+void DataToHexString(const char* prefix, uint32_t startAddr, const uint8_t* data, size_t size, std::string* output) {
+	Buffer buffer;
+	size_t i = 0;
+	for (; i < size; i++) {
+		if (i && !(i & 15)) {
+			buffer.Printf(" ");
+			for (size_t j = i - 16; j < i; j++) {
+				buffer.Printf("%c", ((data[j] < 0x20) || (data[j] > 0x7e)) ? 0x2e : data[j]);
+			}
+			buffer.Printf("\n");
+		}
+		if (!(i & 15))
+			buffer.Printf("%s%08x  ", prefix, startAddr + i);
+		buffer.Printf("%02x ", data[i]);
+	}
+	if (size & 15) {
+		size_t padded_size = ((size-1) | 15) + 1;
+		for (size_t j = size; j < padded_size; j++) {
+			buffer.Printf("   ");
+		}
+		buffer.Printf(" ");
+		for (size_t j = size & ~UINT64_C(0xF); j < size; j++) {
+			buffer.Printf("%c", ((data[j] < 0x20) || (data[j] > 0x7e)) ? 0x2e : data[j]);
+		}
+	}
+	buffer.TakeAll(output);
+}
+
 std::string StringFromFormat(const char* format, ...)
 {
 	va_list args;

--- a/ext/native/base/stringutil.cpp
+++ b/ext/native/base/stringutil.cpp
@@ -64,9 +64,9 @@ void StringUpper(char *str, int len) {
 void DataToHexString(const uint8_t *data, size_t size, std::string *output) {
 	Buffer buffer;
 	for (size_t i = 0; i < size; i++) {
-		buffer.Printf("%02x ", data[i]);
 		if (i && !(i & 15))
 			buffer.Printf("\n");
+		buffer.Printf("%02x ", data[i]);
 	}
 	buffer.TakeAll(output);
 }

--- a/ext/native/base/stringutil.h
+++ b/ext/native/base/stringutil.h
@@ -55,6 +55,7 @@ inline bool endsWithNoCase(const std::string &str, const std::string &what) {
 }
 
 void DataToHexString(const uint8_t *data, size_t size, std::string *output);
+void DataToHexString(const char* prefix, uint32_t startAddr, const uint8_t* data, size_t size, std::string* output);
 inline void StringToHexString(const std::string &data, std::string *output) {
 	DataToHexString((uint8_t *)(&data[0]), data.size(), output);
 }


### PR DESCRIPTION
This should fix the gibberish/random Player name in Ys vs. Sora no Kiseki Multiplayer Lobby.

Apparently PPSSPP and JPCSP have been using the wrong SceNetAdhocctlParameter structure for a long time (or may be it was changed on newer firmware?)

Based on the old unofficial PSPSDK the structure is like this:
```
struct SceNetAdhocctlParams
{
	/** Channel number */
	int channel;
	/** Name of the connection */
	char name[8];
	/** The BSSID */
	unsigned char bssid[6];
	/** Nickname */
	char nickname[128];
};
```
But when tested using JPCSP + prx files from newer firmware, based on the outputted content, it looked similar to the one on VitaSDK
```
typedef struct SceNetAdhocctlParameter {
     int channel;
     struct SceNetAdhocctlGroupName groupName;
     struct SceNetAdhocctlNickname nickname;
     struct SceNetAdhocctlBSSId bssid;
 } SceNetAdhocctlParameter;
```