### PR TITLE
GE Debugger: Include game ID inside dump file

### DIFF
--- a/GPU/Debugger/Record.cpp
+++ b/GPU/Debugger/Record.cpp
@@ -115,8 +115,11 @@ static std::string WriteRecording() {
 	NOTICE_LOG(G3D, "Recording filename: %s", filename.c_str());
 
 	FILE *fp = File::OpenCFile(filename, "wb");
-	fwrite(HEADER, 8, 1, fp);
-	fwrite(&VERSION, sizeof(VERSION), 1, fp);
+	Header header{};
+	strncpy(header.magic, HEADER_MAGIC, sizeof(header.magic));
+	header.version = VERSION;
+	strncpy(header.gameID, g_paramSFO.GetDiscID().c_str(), sizeof(header.gameID));
+	fwrite(&header, sizeof(header), 1, fp);
 
 	u32 sz = (u32)commands.size();
 	fwrite(&sz, sizeof(sz), 1, fp);

--- a/GPU/Debugger/RecordFormat.h
+++ b/GPU/Debugger/RecordFormat.h
@@ -21,11 +21,19 @@
 
 namespace GPURecord {
 
-static const char *HEADER = "PPSSPPGE";
+struct Header {
+	char magic[8];
+	uint32_t version;
+	char gameID[9];
+	uint8_t pad[3];
+};
+
+static const char *HEADER_MAGIC = "PPSSPPGE";
 // Version 1: Uncompressed
 // Version 2: Uses snappy
 // Version 3: Adds FRAMEBUF0-FRAMEBUF9
-static const int VERSION = 3;
+// Version 4: Expanded header with game ID
+static const int VERSION = 4;
 static const int MIN_VERSION = 2;
 
 enum class CommandType : u8 {


### PR DESCRIPTION
Just so we're not relying on filename parsing.  It's useful information.

-[Unknown]