### PR TITLE
TexCache: Always apply detach matches if found

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -622,7 +622,7 @@ bool TextureCacheCommon::AttachBestCandidate(const std::vector<AttachCandidate> 
 		case FramebufferMatch::VALID_DEPAL:
 			relevancy += 1000;
 			break;
-		case FramebufferMatch::INVALID:
+		case FramebufferMatch::INEXACT:
 			relevancy += 100;
 			break;
 		}
@@ -859,8 +859,8 @@ void TextureCacheCommon::AttachFramebufferValid(TexCacheEntry *entry, VirtualFra
 	}
 }
 
-void TextureCacheCommon::AttachFramebufferInvalid(TexCacheEntry *entry, VirtualFramebuffer *framebuffer, const FramebufferMatchInfo &fbInfo, FramebufferNotificationChannel channel) {
-	_dbg_assert_(fbInfo.match == FramebufferMatch::INVALID);
+void TextureCacheCommon::AttachFramebufferInexact(TexCacheEntry *entry, VirtualFramebuffer *framebuffer, const FramebufferMatchInfo &fbInfo, FramebufferNotificationChannel channel) {
+	_dbg_assert_(fbInfo.match == FramebufferMatch::INEXACT);
 	const u64 cachekey = entry->CacheKey();
 
 	if (entry->framebuffer == nullptr || entry->framebuffer == framebuffer) {
@@ -902,8 +902,8 @@ bool TextureCacheCommon::ApplyFramebufferMatch(FramebufferMatchInfo match, TexCa
 		AttachFramebufferValid(entry, framebuffer, match, channel);
 		entry->status |= TexCacheEntry::STATUS_DEPALETTIZE;
 		return true;
-	case FramebufferMatch::INVALID:
-		AttachFramebufferInvalid(entry, framebuffer, match, channel);
+	case FramebufferMatch::INEXACT:
+		AttachFramebufferInexact(entry, framebuffer, match, channel);
 		return true;
 	case FramebufferMatch::NO_MATCH:
 		DetachFramebuffer(entry, address, framebuffer, channel);
@@ -1063,7 +1063,7 @@ FramebufferMatchInfo TextureCacheCommon::MatchFramebuffer(TexCacheEntry *entry, 
 			} else {
 				WARN_LOG_ONCE(subarea, G3D, "Render to area containing texture at %08x +%dx%d", fb_address, fbInfo.xOffset, fbInfo.yOffset);
 				// If we return VALID here, God of War Ghost of Sparta/Chains of Olympus will be missing some special effect according to an old comment.
-				fbInfo.match = FramebufferMatch::INVALID;
+				fbInfo.match = FramebufferMatch::INEXACT;
 				return fbInfo;
 			}
 		} else {

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -193,10 +193,15 @@ typedef std::map<u64, std::unique_ptr<TexCacheEntry>> TexCache;
 
 // TODO: Try to get rid of IGNORE, it doesn't match what we want to do
 enum class FramebufferMatch {
+	// Valid, exact match.
 	VALID = 0,
+	// Valid match that is exact after depal.
 	VALID_DEPAL,
-	INVALID,
+	// Inexact match (such as wrong fmt or at a questionable offset.)
+	INEXACT,
+	// Not a match, remove if currently attached.
 	NO_MATCH,
+	// Not a match, but don't remove yet.  Used to avoid deatching depth mismatch.
 	IGNORE,
 };
 
@@ -288,7 +293,7 @@ protected:
 	bool AttachBestCandidate(const std::vector<AttachCandidate> &candidates);
 
 	void AttachFramebufferValid(TexCacheEntry *entry, VirtualFramebuffer *framebuffer, const FramebufferMatchInfo &fbInfo, FramebufferNotificationChannel channel);
-	void AttachFramebufferInvalid(TexCacheEntry *entry, VirtualFramebuffer *framebuffer, const FramebufferMatchInfo &fbInfo, FramebufferNotificationChannel channel);
+	void AttachFramebufferInexact(TexCacheEntry *entry, VirtualFramebuffer *framebuffer, const FramebufferMatchInfo &fbInfo, FramebufferNotificationChannel channel);
 	void DetachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, FramebufferNotificationChannel channel);
 
 	void SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer);


### PR DESCRIPTION
Fixes #13370.  Also renames "invalid" to "inexact" which makes more sense.

Basically, the idea has been that an exact match always wins, but an inexact match only wins if there wasn't something better.  Because we still apply on fb notify, this is still a very relevant distinction.

Before, we were actively detaching framebuffers that didn't match (i.e. because the offset made it clear they were the wrong one), but then the new framebuffer was off by 12 pixels so we gave it only an inexact match.

When we stopped detaching, the old attachment was kept (since it was, previously, exact), halving Breath of Fire 3's FPS and also causing texcoords to be wrong.

In theory, this logic could be replaced by the heuristic scoring, but we'd really need to re-examine all possible framebuffers in NOTIFY_FB_UPDATED to ensure we're picking the right one.  Instead, we're just applying the update to each texture there.  This change follows along with that, applying each detachment.

-[Unknown]