### PR TITLE
Add option for the clear-fb-on-first-use speedhack.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -818,6 +818,8 @@ static ConfigSetting graphicsSettings[] = {
 	ConfigSetting("InflightFrames", &g_Config.iInflightFrames, 3, true, false),
 	ConfigSetting("RenderDuplicateFrames", &g_Config.bRenderDuplicateFrames, false, true, true),
 
+	ConfigSetting("ClearFramebuffersOnFirstUseHack", &g_Config.bClearFramebuffersOnFirstUseHack, false, true, true),
+
 	ConfigSetting(false),
 };
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -165,6 +165,7 @@ public:
 	int iFrameSkipType;
 	int iUnthrottleMode; // See UnthrottleMode in ConfigValues.h.
 	bool bAutoFrameSkip;
+	bool bClearFramebuffersOnFirstUseHack;
 
 	bool bEnableCardboardVR; // Cardboard Master Switch
 	int iCardboardScreenSize; // Screen Size (in %)

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -44,10 +44,6 @@ FramebufferManagerCommon::FramebufferManagerCommon(Draw::DrawContext *draw)
 	: draw_(draw),
 		displayFormat_(GE_FORMAT_565) {
 	presentation_ = new PresentationCommon(draw);
-
-	// See comment from where it's used below.
-	// As for the use of IsGLES, just the way it was. Scary to change it.
-	clearFramebufferOnFirstUseHack_ = gl_extensions.IsGLES;
 }
 
 FramebufferManagerCommon::~FramebufferManagerCommon() {
@@ -536,7 +532,7 @@ void FramebufferManagerCommon::NotifyRenderFramebufferSwitched(VirtualFramebuffe
 	if (useBufferedRendering_) {
 		if (vfb->fbo) {
 			shaderManager_->DirtyLastShader();
-			if (clearFramebufferOnFirstUseHack_) {
+			if (g_Config.bClearFramebuffersOnFirstUseHack) {
 				// HACK: Some tiled mobile GPUs benefit IMMENSELY from clearing an FBO before rendering
 				// to it (or in Vulkan, clear during framebuffer load). This is a hack to force this
 				// the first time a framebuffer is bound for rendering in a frame.

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -396,7 +396,6 @@ protected:
 	std::vector<VirtualFramebuffer *> bvfbs_; // blitting framebuffers (for download)
 
 	bool gameUsesSequentialCopies_ = false;
-	bool clearFramebufferOnFirstUseHack_ = false;
 
 	// Sampled in BeginFrame for safety.
 	float renderWidth_ = 0.0f;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -415,6 +415,15 @@ void GameSettingsScreen::CreateViews() {
 		return !g_Config.bSoftwareRendering && g_Config.bHardwareTransform;
 	});
 
+	CheckBox *clearHack = graphicsSettings->Add(new CheckBox(&g_Config.bClearFramebuffersOnFirstUseHack, gr->T("Clear Speedhack", "Clear framebuffers on first use (speedhack)")));
+	clearHack->OnClick.Add([=](EventParams &e) {
+		settingInfo_->Show(gr->T("ClearSpeedhack Tip", "Sometimes faster (mostly on mobile devices), may cause glitches"), e.v);
+		return UI::EVENT_CONTINUE;
+	});
+	clearHack->SetEnabledFunc([] {
+		return !g_Config.bSoftwareRendering;
+	});
+
 	CheckBox *texBackoff = graphicsSettings->Add(new CheckBox(&g_Config.bTextureBackoffCache, gr->T("Lazy texture caching", "Lazy texture caching (speedup)")));
 	texBackoff->SetDisabledPtr(&g_Config.bSoftwareRendering);
 


### PR DESCRIPTION
See #13295.

End goal is probably to remove it. Defaults to false so we'll see if anyone notices any speed difference.