### PR TITLE
Avoid getting Fatal signal 6 (SIGABRT) on linux/android

### DIFF
--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -230,6 +230,10 @@ int IsSocketReady(int fd, bool readfd, bool writefd, int* errorcode, int timeout
 	fd_set readfds, writefds;
 	timeval tval;
 
+	// Avoid getting Fatal signal 6 (SIGABRT) on linux/android
+	if (fd < 0)
+	    return SOCKET_ERROR;
+
 	FD_ZERO(&readfds);
 	writefds = readfds;
 	if (readfd) {	


### PR DESCRIPTION
Avoid getting Fatal signal 6 (SIGABRT) on linux/android when losing connectivity to the Adhoc Server.
This should fix the crashing issue on https://github.com/hrydgard/ppsspp/issues/13398