### PR TITLE
IO:Don't read data more than data size of pgd files.

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -967,6 +967,8 @@ static u32 npdrmRead(FileNode *f, u8 *data, int size) {
 	block  = pgd->file_offset/pgd->block_size;
 	offset = pgd->file_offset%pgd->block_size;
 
+	if (size > pgd->data_size)
+		size = pgd->data_size;
 	remain_size = size;
 
 	while(remain_size){


### PR DESCRIPTION
Fixes #6025 , matches a PSP.