### PR TITLE
Framebuffer manager refactor: Don't cache framebuffer information in TexCacheEntry

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -311,6 +311,10 @@ public:
 	virtual bool GetStencilbuffer(u32 fb_address, int fb_stride, GPUDebugBuffer &buffer);
 	virtual bool GetOutputFramebuffer(GPUDebugBuffer &buffer);
 
+	const std::vector<VirtualFramebuffer *> &Framebuffers() {
+		return vfbs_;
+	}
+
 protected:
 	virtual void PackFramebufferSync_(VirtualFramebuffer *vfb, int x, int y, int w, int h);
 	void SetViewport2D(int x, int y, int w, int h);

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -49,24 +49,12 @@ namespace Draw {
 class VulkanFBO;
 
 struct VirtualFramebuffer {
-	int last_frame_used;
-	int last_frame_attached;
-	int last_frame_render;
-	int last_frame_displayed;
-	int last_frame_clut;
-	int last_frame_failed;
-	int last_frame_depth_updated;
-	int last_frame_depth_render;
-	u32 clutUpdatedBytes;
-	bool memoryUpdated;
-	bool firstFrameSaved;
-
 	u32 fb_address;
 	u32 z_address;  // If 0, it's a "RAM" framebuffer.
 	int fb_stride;
 	int z_stride;
 
-	// There's also a top left of the drawing region, but meh...
+	GEBufferFormat format;  // virtual, right now they are all RGBA8888
 
 	// width/height: The detected size of the current framebuffer, in original PSP pixels.
 	u16 width;
@@ -89,8 +77,6 @@ struct VirtualFramebuffer {
 	u16 newHeight;
 	int lastFrameNewSize;
 
-	GEBufferFormat format;  // virtual, right now they are all RGBA8888
-
 	// TODO: Handle fbo and colorDepth better.
 	u8 colorDepth;
 	Draw::Framebuffer *fbo;
@@ -103,6 +89,18 @@ struct VirtualFramebuffer {
 
 	bool dirtyAfterDisplay;
 	bool reallyDirtyAfterDisplay;  // takes frame skipping into account
+
+	int last_frame_used;
+	int last_frame_attached;
+	int last_frame_render;
+	int last_frame_displayed;
+	int last_frame_clut;
+	int last_frame_failed;
+	int last_frame_depth_updated;
+	int last_frame_depth_render;
+	u32 clutUpdatedBytes;
+	bool memoryUpdated;
+	bool firstFrameSaved;
 };
 
 struct FramebufferHeuristicParams {
@@ -354,7 +352,7 @@ protected:
 
 	void UpdateFramebufUsage(VirtualFramebuffer *vfb);
 
-	void SetColorUpdated(VirtualFramebuffer *dstBuffer, int skipDrawReason) {
+	static void SetColorUpdated(VirtualFramebuffer *dstBuffer, int skipDrawReason) {
 		dstBuffer->memoryUpdated = false;
 		dstBuffer->clutUpdatedBytes = 0;
 		dstBuffer->dirtyAfterDisplay = true;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -541,6 +541,7 @@ TexCacheEntry *TextureCacheCommon::SetTexture(bool force) {
 }
 
 std::vector<AttachCandidate> TextureCacheCommon::GetFramebufferCandidates(const TextureDefinition &entry, u32 texAddrOffset) {
+	gpuStats.numFramebufferEvaluations++;
 	bool success = false;
 	bool anyIgnores = false;
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -471,6 +471,7 @@ TexCacheEntry *TextureCacheCommon::SetTexture(bool force) {
 		int index = GetBestCandidateIndex(candidates);
 		if (index != -1) {
 			nextTexture_ = nullptr;
+			nextNeedsRebuild_ = false;
 			SetTextureFramebuffer(candidates[index]);
 			return nullptr;
 		}
@@ -552,7 +553,7 @@ std::vector<AttachCandidate> TextureCacheCommon::GetFramebufferCandidates(const 
 	for (size_t i = 0, n = framebuffers.size(); i < n; ++i) {
 		auto framebuffer = framebuffers[i];
 		uint32_t fb_addr = channel == NOTIFY_FB_DEPTH ? framebuffer->z_address : framebuffer->fb_address;
-		FramebufferMatchInfo match = MatchFramebuffer(entry, fb_addr, framebuffer, 0, channel);
+		FramebufferMatchInfo match = MatchFramebuffer(entry, fb_addr, framebuffer, texAddrOffset, channel);
 		if (match.match == FramebufferMatch::IGNORE) {
 			anyIgnores = true;
 		} else if (match.match != FramebufferMatch::NO_MATCH) {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -296,14 +296,6 @@ void TextureCacheCommon::UpdateMaxSeenV(TexCacheEntry *entry, bool throughMode) 
 }
 
 TexCacheEntry *TextureCacheCommon::SetTexture(bool force) {
-#ifdef DEBUG_TEXTURES
-	if (SetDebugTexture()) {
-		// A different texture was bound, let's rebind next time.
-		InvalidateLastTexture();
-		return;
-	}
-#endif
-
 	if (force) {
 		InvalidateLastTexture();
 	}

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -603,6 +603,12 @@ int TextureCacheCommon::GetBestCandidateIndex(const std::vector<AttachCandidate>
 			relevancy += 9;
 		}
 
+		if (candidate.channel == NOTIFY_FB_COLOR && candidate.fb->last_frame_render == gpuStats.numFlips) {
+			relevancy += 5;
+		} else if (candidate.channel == NOTIFY_FB_DEPTH && candidate.fb->last_frame_depth_render == gpuStats.numFlips) {
+			relevancy += 5;
+		}
+
 		if (relevancy > bestRelevancy) {
 			bestRelevancy = relevancy;
 			bestIndex = i;

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -340,9 +340,7 @@ protected:
 	TexCache secondCache_;
 	u32 secondCacheSizeEstimate_;
 
-	std::vector<VirtualFramebuffer *> fbCache_;
 	std::map<u64, FramebufferMatchInfo> fbTexInfo_;
-
 	std::map<u32, int> videos_;
 
 	SimpleBuf<u32> tmpTexBuf32_;

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -93,7 +93,19 @@ struct SamplerCacheKey {
 class GLRTexture;
 class VulkanTexture;
 
+// Enough information about a texture to match it to framebuffers.
+struct TextureDefinition {
+	u32 addr;
+	GETextureFormat format;
+	u32 dim;
+	u32 bufw;
+};
+
+
 // TODO: Shrink this struct. There is some fluff.
+
+// NOTE: These only handle textures loaded directly from PSP memory contents.
+// Framebuffer textures do not have entries, we bind the framebuffers directly.
 struct TexCacheEntry {
 	~TexCacheEntry() {
 		if (texturePtr || textureName || vkTex)
@@ -115,7 +127,6 @@ struct TexCacheEntry {
 		STATUS_CLUT_VARIANTS = 0x08,   // Has multiple CLUT variants.
 		STATUS_CHANGE_FREQUENT = 0x10, // Changes often (less than 6 frames in between.)
 		STATUS_CLUT_RECHECK = 0x20,    // Another texture with same addr had a hashfail.
-		STATUS_DEPALETTIZE = 0x40,     // Needs to go through a depalettize pass.
 		STATUS_TO_SCALE = 0x80,        // Pending texture scaling in a later frame.
 		STATUS_IS_SCALED = 0x100,      // Has been scaled (can't be replaceImages'd.)
 		// When hashing large textures, we optimize 512x512 down to 512x272 by default, since this
@@ -125,7 +136,8 @@ struct TexCacheEntry {
 
 		STATUS_BAD_MIPS = 0x400,       // Has bad or unusable mipmap levels.
 
-		STATUS_DEPTH = 0x800,
+		STATUS_FRAMEBUFFER_OVERLAP = 0x800,
+
 		STATUS_FORCE_REBUILD = 0x1000,
 	};
 
@@ -134,7 +146,6 @@ struct TexCacheEntry {
 
 	u32 addr;
 	u32 hash;
-	VirtualFramebuffer *framebuffer;  // if null, not sourced from an FBO. TODO: Collapse into texturePtr
 	u32 sizeInRAM;  // Could be computed
 	u8 format;  // GeTextureFormat
 	u8 maxLevel;
@@ -181,8 +192,7 @@ struct TexCacheEntry {
 	static u64 CacheKey(u32 addr, u8 format, u16 dim, u32 cluthash);
 };
 
-class FramebufferManagerCommon;
-// Can't be unordered_map, we use lower_bound ... although for some reason that compiles on MSVC.
+// Can't be unordered_map, we use lower_bound ... although for some reason that (used to?) compiles on MSVC.
 // Would really like to replace this with DenseHashMap but can't as long as we need lower_bound.
 typedef std::map<u64, std::unique_ptr<TexCacheEntry>> TexCache;
 
@@ -214,10 +224,12 @@ struct FramebufferMatchInfo {
 
 struct AttachCandidate {
 	FramebufferMatchInfo match;
-	TexCacheEntry *entry;
+	TextureDefinition entry;
 	VirtualFramebuffer *fb;
 	FramebufferNotificationChannel channel;
 };
+
+class FramebufferManagerCommon;
 
 class TextureCacheCommon {
 public:
@@ -227,7 +239,7 @@ public:
 	void LoadClut(u32 clutAddr, u32 loadBytes);
 	bool GetCurrentClutBuffer(GPUDebugBuffer &buffer);
 
-	void SetTexture(bool force = false);
+	TexCacheEntry *SetTexture(bool force = false);
 	void ApplyTexture();
 	bool SetOffsetTexture(u32 yOffset);
 	void Invalidate(u32 addr, int size, GPUInvalidationType type);
@@ -242,8 +254,6 @@ public:
 	void NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffer, FramebufferNotification msg, FramebufferNotificationChannel channel);
 	virtual void NotifyConfigChanged();
 	void NotifyVideoUpload(u32 addr, int size, int width, GEBufferFormat fmt);
-
-	int AttachedDrawingHeight();
 
 	size_t NumLoadedTextures() const {
 		return cache_.size();
@@ -264,7 +274,8 @@ protected:
 	void DeleteTexture(TexCache::iterator it);
 	void Decimate(bool forcePressure = false);
 
-	virtual void ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer) = 0;
+	virtual void ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer, GETextureFormat texFormat, FramebufferNotificationChannel channel) = 0;
+
 	void HandleTextureChange(TexCacheEntry *const entry, const char *reason, bool initialMatch, bool doDelete);
 	virtual void BuildTexture(TexCacheEntry *const entry) = 0;
 	virtual void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) = 0;
@@ -284,19 +295,12 @@ protected:
 	void UpdateSamplingParams(TexCacheEntry &entry, SamplerCacheKey &key);  // Used by D3D11 and Vulkan.
 	void UpdateMaxSeenV(TexCacheEntry *entry, bool throughMode);
 
-	FramebufferMatchInfo MatchFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, u32 texaddrOffset, FramebufferNotificationChannel channel) const;
+	FramebufferMatchInfo MatchFramebuffer(const TextureDefinition &entry, u32 address, VirtualFramebuffer *framebuffer, u32 texaddrOffset, FramebufferNotificationChannel channel) const;
 
-	bool AttachFramebufferToEntry(TexCacheEntry *entry, u32 texAddrOffset);
+	std::vector<AttachCandidate> GetFramebufferCandidates(const TextureDefinition &entry, u32 texAddrOffset);
+	int GetBestCandidateIndex(const std::vector<AttachCandidate> &candidates);
 
-	// Temporary utility during conversion
-	bool ApplyFramebufferMatch(FramebufferMatchInfo match, TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, FramebufferNotificationChannel channel);
-	bool AttachBestCandidate(const std::vector<AttachCandidate> &candidates);
-
-	void AttachFramebufferValid(TexCacheEntry *entry, VirtualFramebuffer *framebuffer, const FramebufferMatchInfo &fbInfo, FramebufferNotificationChannel channel);
-	void AttachFramebufferInexact(TexCacheEntry *entry, VirtualFramebuffer *framebuffer, const FramebufferMatchInfo &fbInfo, FramebufferNotificationChannel channel);
-	void DetachFramebuffer(TexCacheEntry *entry, u32 address, VirtualFramebuffer *framebuffer, FramebufferNotificationChannel channel);
-
-	void SetTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer);
+	void SetTextureFramebuffer(const AttachCandidate &candidate);
 
 	void DecimateVideos();
 
@@ -327,8 +331,8 @@ protected:
 	TextureReplacer replacer_;
 	FramebufferManagerCommon *framebufferManager_;
 
-	bool clearCacheNextFrame_;
-	bool lowMemoryMode_;
+	bool clearCacheNextFrame_ = false;
+	bool lowMemoryMode_ = false;
 
 	int decimationCounter_;
 	int texelsScaledThisFrame_;
@@ -340,13 +344,13 @@ protected:
 	TexCache secondCache_;
 	u32 secondCacheSizeEstimate_;
 
-	std::map<u64, FramebufferMatchInfo> fbTexInfo_;
 	std::map<u32, int> videos_;
 
 	SimpleBuf<u32> tmpTexBuf32_;
 	SimpleBuf<u32> tmpTexBufRearrange_;
 
-	TexCacheEntry *nextTexture_;
+	TexCacheEntry *nextTexture_ = nullptr;
+	VirtualFramebuffer *nextFramebufferTexture_ = nullptr;
 
 	u32 clutHash_ = 0;
 

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -205,17 +205,10 @@ typedef std::map<u64, std::unique_ptr<TexCacheEntry>> TexCache;
 enum class FramebufferMatch {
 	// Valid, exact match.
 	VALID = 0,
-	// Valid match that is exact after depal.
-	VALID_DEPAL,
-	// Inexact match (such as wrong fmt or at a questionable offset.)
-	INEXACT,
 	// Not a match, remove if currently attached.
 	NO_MATCH,
-	// Not a match, but don't remove yet.  Used to avoid deatching depth mismatch.
-	IGNORE,
 };
 
-// Separate to keep main texture cache size down.
 struct FramebufferMatchInfo {
 	FramebufferMatch match;
 	u32 xOffset;
@@ -249,10 +242,11 @@ public:
 	virtual void ForgetLastTexture() = 0;
 	virtual void InvalidateLastTexture(TexCacheEntry *entry = nullptr) = 0;
 	virtual void Clear(bool delete_them);
-
-	// FramebufferManager keeps TextureCache updated about what regions of memory are being rendered to.
-	void NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffer, FramebufferNotification msg, FramebufferNotificationChannel channel);
 	virtual void NotifyConfigChanged();
+
+	// FramebufferManager keeps TextureCache updated about what regions of memory are being rendered to,
+	// so that it can invalidate TexCacheEntries pointed at those addresses.
+	void NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffer, FramebufferNotification msg, FramebufferNotificationChannel channel);
 	void NotifyVideoUpload(u32 addr, int size, int width, GEBufferFormat fmt);
 
 	size_t NumLoadedTextures() const {
@@ -295,7 +289,7 @@ protected:
 	void UpdateSamplingParams(TexCacheEntry &entry, SamplerCacheKey &key);  // Used by D3D11 and Vulkan.
 	void UpdateMaxSeenV(TexCacheEntry *entry, bool throughMode);
 
-	FramebufferMatchInfo MatchFramebuffer(const TextureDefinition &entry, u32 address, VirtualFramebuffer *framebuffer, u32 texaddrOffset, FramebufferNotificationChannel channel) const;
+	FramebufferMatchInfo MatchFramebuffer(const TextureDefinition &entry, VirtualFramebuffer *framebuffer, u32 texaddrOffset, FramebufferNotificationChannel channel) const;
 
 	std::vector<AttachCandidate> GetFramebufferCandidates(const TextureDefinition &entry, u32 texAddrOffset);
 	int GetBestCandidateIndex(const std::vector<AttachCandidate> &candidates);

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -308,14 +308,13 @@ void GPU_D3D11::GetStats(char *buffer, size_t bufsize) {
 	float vertexAverageCycles = gpuStats.numVertsSubmitted > 0 ? (float)gpuStats.vertexGPUCycles / (float)gpuStats.numVertsSubmitted : 0.0f;
 	snprintf(buffer, bufsize - 1,
 		"DL processing time: %0.2f ms\n"
-		"Draw calls: %i, flushes %i, clears %i\n"
-		"Cached Draw calls: %i\n"
+		"Draw calls: %i, flushes %i, clears %i (cached: %d)\n"
 		"Num Tracked Vertex Arrays: %i\n"
 		"GPU cycles executed: %d (%f per vertex)\n"
 		"Commands per call level: %i %i %i %i\n"
 		"Vertices submitted: %i\n"
 		"Cached, Uncached Vertices Drawn: %i, %i\n"
-		"FBOs active: %i\n"
+		"FBOs active: %i (evaluations: %d)\n"
 		"Textures active: %i, decoded: %i  invalidated: %i\n"
 		"Readbacks: %d, uploads: %d\n"
 		"Vertex, Fragment shaders loaded: %i, %i\n",
@@ -332,6 +331,7 @@ void GPU_D3D11::GetStats(char *buffer, size_t bufsize) {
 		gpuStats.numCachedVertsDrawn,
 		gpuStats.numUncachedVertsDrawn,
 		(int)framebufferManagerD3D11_->NumVFBs(),
+		gpuStats.numFramebufferEvaluations,
 		(int)textureCacheD3D11_->NumLoadedTextures(),
 		gpuStats.numTexturesDecoded,
 		gpuStats.numTextureInvalidations,

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -762,28 +762,25 @@ void TextureCacheD3D11::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &
 
 bool TextureCacheD3D11::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) {
 	SetTexture(false);
-	if (!nextTexture_)
-		return false;
+	if (!nextTexture_) {
+		if (nextFramebufferTexture_) {
+			VirtualFramebuffer *vfb = nextFramebufferTexture_;
+			buffer.Allocate(vfb->bufferWidth, vfb->bufferHeight, GPU_DBG_FORMAT_8888, false);
+			bool retval = draw_->CopyFramebufferToMemorySync(vfb->fbo, Draw::FB_COLOR_BIT, 0, 0, vfb->bufferWidth, vfb->bufferHeight, Draw::DataFormat::R8G8B8A8_UNORM, buffer.GetData(), vfb->bufferWidth, "GetCurrentTextureDebug");
+			// Vulkan requires us to re-apply all dynamic state for each command buffer, and the above will cause us to start a new cmdbuf.
+			// So let's dirty the things that are involved in Vulkan dynamic state. Readbacks are not frequent so this won't hurt other backends.
+			gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE);
+			// We may have blitted to a temp FBO.
+			framebufferManager_->RebindFramebuffer("RebindFramebuffer - GetCurrentTextureDebug");
+			return retval;
+		} else {
+			return false;
+		}
+	}
 
 	// Apply texture may need to rebuild the texture if we're about to render, or bind a framebuffer.
 	TexCacheEntry *entry = nextTexture_;
 	ApplyTexture();
-
-	/*
-	// TODO: Centralize.
-	// TODO: Fix!
-	if (entry->framebuffer) {
-		VirtualFramebuffer *vfb = entry->framebuffer;
-		buffer.Allocate(vfb->bufferWidth, vfb->bufferHeight, GPU_DBG_FORMAT_8888, false);
-		bool retval = draw_->CopyFramebufferToMemorySync(vfb->fbo, Draw::FB_COLOR_BIT, 0, 0, vfb->bufferWidth, vfb->bufferHeight, Draw::DataFormat::R8G8B8A8_UNORM, buffer.GetData(), vfb->bufferWidth, "GetCurrentTextureDebug");
-		// Vulkan requires us to re-apply all dynamic state for each command buffer, and the above will cause us to start a new cmdbuf.
-		// So let's dirty the things that are involved in Vulkan dynamic state. Readbacks are not frequent so this won't hurt other backends.
-		gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE);
-		// We may have blitted to a temp FBO.
-		framebufferManager_->RebindFramebuffer("RebindFramebuffer - GetCurrentTextureDebug");
-		return retval;
-	}
-	*/
 
 	ID3D11Texture2D *texture = (ID3D11Texture2D *)entry->texturePtr;
 	if (!texture)

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -378,10 +378,11 @@ protected:
 	int renderH_;
 };
 
-void TextureCacheD3D11::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer) {
+void TextureCacheD3D11::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer, GETextureFormat texFormat, FramebufferNotificationChannel channel) {
 	ID3D11PixelShader *pshader = nullptr;
 	uint32_t clutMode = gstate.clutformat & 0xFFFFFF;
-	if ((entry->status & TexCacheEntry::STATUS_DEPALETTIZE) && !g_Config.bDisableSlowFramebufEffects) {
+	bool need_depalettize = IsClutFormat(texFormat);
+	if (need_depalettize && !g_Config.bDisableSlowFramebufEffects) {
 		pshader = depalShaderCache_->GetDepalettizePixelShader(clutMode, framebuffer->drawnFormat);
 	}
 
@@ -421,8 +422,6 @@ void TextureCacheD3D11::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFra
 		TexCacheEntry::TexStatus alphaStatus = CheckAlpha(clutBuf_, GetClutDestFormatD3D11(clutFormat), clutTotalColors, clutTotalColors, 1);
 		gstate_c.SetTextureFullAlpha(alphaStatus == TexCacheEntry::STATUS_ALPHA_FULL);
 	} else {
-		entry->status &= ~TexCacheEntry::STATUS_DEPALETTIZE;
-
 		framebufferManagerD3D11_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV | BINDFBCOLOR_APPLY_TEX_OFFSET);
 
 		gstate_c.SetTextureFullAlpha(gstate.getTextureFormat() == GE_TFMT_5650);
@@ -432,7 +431,6 @@ void TextureCacheD3D11::ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFra
 	SetFramebufferSamplingParams(framebuffer->bufferWidth, framebuffer->bufferHeight, samplerKey);
 	ID3D11SamplerState *state = samplerCache_.GetOrCreateSampler(device_, samplerKey);
 	context_->PSSetSamplers(0, 1, &state);
-	InvalidateLastTexture();
 
 	gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_RASTER_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_BLEND_STATE | DIRTY_FRAGMENTSHADER_STATE);
 }
@@ -443,14 +441,6 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 
 	// For the estimate, we assume cluts always point to 8888 for simplicity.
 	cacheSizeEstimate_ += EstimateTexMemoryUsage(entry);
-
-	// TODO: If a framebuffer is attached here, might end up with a bad entry.texture.
-	// Should just always create one here or something (like GLES.)
-
-	if (entry->framebuffer) {
-		// Nothing else to do here.
-		return;
-	}
 
 	if ((entry->bufw == 0 || (gstate.texbufwidth[0] & 0xf800) != 0) && entry->addr >= PSP_GetKernelMemoryEnd()) {
 		ERROR_LOG_REPORT(G3D, "Texture with unexpected bufw (full=%d)", gstate.texbufwidth[0] & 0xffff);
@@ -779,7 +769,9 @@ bool TextureCacheD3D11::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level
 	TexCacheEntry *entry = nextTexture_;
 	ApplyTexture();
 
+	/*
 	// TODO: Centralize.
+	// TODO: Fix!
 	if (entry->framebuffer) {
 		VirtualFramebuffer *vfb = entry->framebuffer;
 		buffer.Allocate(vfb->bufferWidth, vfb->bufferHeight, GPU_DBG_FORMAT_8888, false);
@@ -791,6 +783,7 @@ bool TextureCacheD3D11::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level
 		framebufferManager_->RebindFramebuffer("RebindFramebuffer - GetCurrentTextureDebug");
 		return retval;
 	}
+	*/
 
 	ID3D11Texture2D *texture = (ID3D11Texture2D *)entry->texturePtr;
 	if (!texture)

--- a/GPU/D3D11/TextureCacheD3D11.h
+++ b/GPU/D3D11/TextureCacheD3D11.h
@@ -74,7 +74,7 @@ private:
 	TexCacheEntry::TexStatus CheckAlpha(const u32 *pixelData, u32 dstFmt, int stride, int w, int h);
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;
 
-	void ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer) override;
+	void ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer, GETextureFormat texFormat, FramebufferNotificationChannel channel) override;
 	void BuildTexture(TexCacheEntry *const entry) override;
 
 	ID3D11Device *device_;

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -347,14 +347,13 @@ void GPU_DX9::GetStats(char *buffer, size_t bufsize) {
 	float vertexAverageCycles = gpuStats.numVertsSubmitted > 0 ? (float)gpuStats.vertexGPUCycles / (float)gpuStats.numVertsSubmitted : 0.0f;
 	snprintf(buffer, bufsize - 1,
 		"DL processing time: %0.2f ms\n"
-		"Draw calls: %i, flushes %i, clears %i\n"
-		"Cached Draw calls: %i\n"
+		"Draw calls: %i, flushes %i, clears %i (cached: %d)\n"
 		"Num Tracked Vertex Arrays: %i\n"
 		"GPU cycles executed: %d (%f per vertex)\n"
 		"Commands per call level: %i %i %i %i\n"
 		"Vertices submitted: %i\n"
 		"Cached, Uncached Vertices Drawn: %i, %i\n"
-		"FBOs active: %i\n"
+		"FBOs active: %i (evaluations: %d)\n"
 		"Textures active: %i, decoded: %i  invalidated: %i\n"
 		"Readbacks: %d, uploads: %d\n"
 		"Vertex, Fragment shaders loaded: %i, %i\n",
@@ -371,6 +370,7 @@ void GPU_DX9::GetStats(char *buffer, size_t bufsize) {
 		gpuStats.numCachedVertsDrawn,
 		gpuStats.numUncachedVertsDrawn,
 		(int)framebufferManagerDX9_->NumVFBs(),
+		gpuStats.numFramebufferEvaluations,
 		(int)textureCacheDX9_->NumLoadedTextures(),
 		gpuStats.numTexturesDecoded,
 		gpuStats.numTextureInvalidations,

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -68,7 +68,7 @@ private:
 	TexCacheEntry::TexStatus CheckAlpha(const u32 *pixelData, u32 dstFmt, int stride, int w, int h);
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;
 
-	void ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer) override;
+	void ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer, GETextureFormat texFormat, FramebufferNotificationChannel channel) override;
 	void BuildTexture(TexCacheEntry *const entry) override;
 
 	LPDIRECT3DTEXTURE9 &DxTex(TexCacheEntry *entry) {

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -454,14 +454,13 @@ void GPU_GLES::GetStats(char *buffer, size_t bufsize) {
 	float vertexAverageCycles = gpuStats.numVertsSubmitted > 0 ? (float)gpuStats.vertexGPUCycles / (float)gpuStats.numVertsSubmitted : 0.0f;
 	snprintf(buffer, bufsize - 1,
 		"DL processing time: %0.2f ms\n"
-		"Draw calls: %i, flushes %i, clears %i\n"
-		"Cached Draw calls: %i\n"
+		"Draw calls: %i, flushes %i, clears %i (cached: %d)\n"
 		"Num Tracked Vertex Arrays: %i\n"
 		"GPU cycles executed: %d (%f per vertex)\n"
 		"Commands per call level: %i %i %i %i\n"
 		"Vertices submitted: %i\n"
 		"Cached, Uncached Vertices Drawn: %i, %i\n"
-		"FBOs active: %i\n"
+		"FBOs active: %i (evaluations: %d)\n"
 		"Textures active: %i, decoded: %i  invalidated: %i\n"
 		"Readbacks: %d, uploads: %d\n"
 		"Vertex, Fragment, Programs loaded: %i, %i, %i\n",
@@ -478,6 +477,7 @@ void GPU_GLES::GetStats(char *buffer, size_t bufsize) {
 		gpuStats.numCachedVertsDrawn,
 		gpuStats.numUncachedVertsDrawn,
 		(int)framebufferManagerGL_->NumVFBs(),
+		gpuStats.numFramebufferEvaluations,
 		(int)textureCacheGL_->NumLoadedTextures(),
 		gpuStats.numTexturesDecoded,
 		gpuStats.numTextureInvalidations,

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -821,8 +821,22 @@ bool TextureCacheGLES::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level)
 
 	SetTexture(true);
 	if (!nextTexture_) {
-		ERROR_LOG(G3D, "Failed to get debug texture: no texture set");
-		return false;
+		if (nextFramebufferTexture_) {
+			VirtualFramebuffer *vfb = nextFramebufferTexture_;
+			buffer.Allocate(vfb->bufferWidth, vfb->bufferHeight, GPU_DBG_FORMAT_8888, false);
+			bool retval = draw_->CopyFramebufferToMemorySync(vfb->fbo, Draw::FB_COLOR_BIT, 0, 0, vfb->bufferWidth, vfb->bufferHeight, Draw::DataFormat::R8G8B8A8_UNORM, buffer.GetData(), vfb->bufferWidth, "GetCurrentTextureDebug");
+			// Vulkan requires us to re-apply all dynamic state for each command buffer, and the above will cause us to start a new cmdbuf.
+			// So let's dirty the things that are involved in Vulkan dynamic state. Readbacks are not frequent so this won't hurt other backends.
+			gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE);
+			// We may have blitted to a temp FBO.
+			framebufferManager_->RebindFramebuffer("RebindFramebuffer - GetCurrentTextureDebug");
+			if (!retval)
+				ERROR_LOG(G3D, "Failed to get debug texture: copy to memory failed");
+			return retval;
+		} else {
+			ERROR_LOG(G3D, "Failed to get debug texture: no texture set");
+			return false;
+		}
 	}
 
 	// Apply texture may need to rebuild the texture if we're about to render, or bind a framebuffer.
@@ -830,24 +844,6 @@ bool TextureCacheGLES::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level)
 	// We might need a render pass to set the sampling params, unfortunately.  Otherwise BuildTexture may crash.
 	framebufferManagerGL_->RebindFramebuffer("RebindFramebuffer - GetCurrentTextureDebug");
 	ApplyTexture();
-
-	/*
-	// TODO: Centralize?
-	// TODO: Needs fixing!
-	if (entry->framebuffer) {
-		VirtualFramebuffer *vfb = entry->framebuffer;
-		buffer.Allocate(vfb->bufferWidth, vfb->bufferHeight, GPU_DBG_FORMAT_8888, false);
-		bool retval = draw_->CopyFramebufferToMemorySync(vfb->fbo, Draw::FB_COLOR_BIT, 0, 0, vfb->bufferWidth, vfb->bufferHeight, Draw::DataFormat::R8G8B8A8_UNORM, buffer.GetData(), vfb->bufferWidth, "GetCurrentTextureDebug");
-		// Vulkan requires us to re-apply all dynamic state for each command buffer, and the above will cause us to start a new cmdbuf.
-		// So let's dirty the things that are involved in Vulkan dynamic state. Readbacks are not frequent so this won't hurt other backends.
-		gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE);
-		// We may have blitted to a temp FBO.
-		framebufferManager_->RebindFramebuffer("RebindFramebuffer - GetCurrentTextureDebug");
-		if (!retval)
-			ERROR_LOG(G3D, "Failed to get debug texture: copy to memory failed");
-		return retval;
-	}
-	*/
 
 	GLRenderManager *renderManager = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -282,48 +282,6 @@ void TextureCacheGLES::UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBas
 	clutLastFormat_ = gstate.clutformat;
 }
 
-// #define DEBUG_TEXTURES
-
-#ifdef DEBUG_TEXTURES
-bool SetDebugTexture() {
-	static const int highlightFrames = 30;
-
-	static int numTextures = 0;
-	static int lastFrames = 0;
-	static int mostTextures = 1;
-
-	if (lastFrames != gpuStats.numFlips) {
-		mostTextures = std::max(mostTextures, numTextures);
-		numTextures = 0;
-		lastFrames = gpuStats.numFlips;
-	}
-
-	static GLuint solidTexture = 0;
-
-	bool changed = false;
-	if (((gpuStats.numFlips / highlightFrames) % mostTextures) == numTextures) {
-		if (gpuStats.numFlips % highlightFrames == 0) {
-			NOTICE_LOG(G3D, "Highlighting texture # %d / %d", numTextures, mostTextures);
-		}
-		static const u32 solidTextureData[] = {0x99AA99FF};
-
-		if (solidTexture == 0) {
-			glGenTextures(1, &solidTexture);
-			glBindTexture(GL_TEXTURE_2D, solidTexture);
-			glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-			glPixelStorei(GL_PACK_ALIGNMENT, 1);
-			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, solidTextureData);
-		} else {
-			glBindTexture(GL_TEXTURE_2D, solidTexture);
-		}
-		changed = true;
-	}
-
-	++numTextures;
-	return changed;
-}
-#endif
-
 void TextureCacheGLES::BindTexture(TexCacheEntry *entry) {
 	if (entry->textureName != lastBoundTexture) {
 		render_->BindTexture(0, entry->textureName);

--- a/GPU/GLES/TextureCacheGLES.h
+++ b/GPU/GLES/TextureCacheGLES.h
@@ -81,7 +81,7 @@ private:
 
 	TexCacheEntry::TexStatus CheckAlpha(const uint8_t *pixelData, Draw::DataFormat dstFmt, int stride, int w, int h);
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;
-	void ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer) override;
+	void ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer, GETextureFormat texFormat, FramebufferNotificationChannel channel) override;
 
 	void BuildTexture(TexCacheEntry *const entry) override;
 

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -67,6 +67,7 @@ struct GPUStatistics {
 		numShaderSwitches = 0;
 		numFlushes = 0;
 		numTexturesDecoded = 0;
+		numFramebufferEvaluations = 0;
 		numReadbacks = 0;
 		numUploads = 0;
 		numClears = 0;
@@ -88,6 +89,7 @@ struct GPUStatistics {
 	int numTextureSwitches;
 	int numShaderSwitches;
 	int numTexturesDecoded;
+	int numFramebufferEvaluations;
 	int numReadbacks;
 	int numUploads;
 	int numClears;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -558,14 +558,13 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 	float vertexAverageCycles = gpuStats.numVertsSubmitted > 0 ? (float)gpuStats.vertexGPUCycles / (float)gpuStats.numVertsSubmitted : 0.0f;
 	snprintf(buffer, bufsize - 1,
 		"DL processing time: %0.2f ms\n"
-		"Draw calls: %i, flushes %i, clears %i\n"
-		"Cached Draw calls: %i\n"
+		"Draw calls: %i, flushes %i, clears %i (cached: %d)\n"
 		"Num Tracked Vertex Arrays: %i\n"
 		"GPU cycles executed: %d (%f per vertex)\n"
 		"Commands per call level: %i %i %i %i\n"
 		"Vertices submitted: %i\n"
 		"Cached, Uncached Vertices Drawn: %i, %i\n"
-		"FBOs active: %i\n"
+		"FBOs active: %i (evaluations: %d)\n"
 		"Textures active: %i, decoded: %i  invalidated: %i\n"
 		"Readbacks: %d, uploads: %d\n"
 		"Vertex, Fragment, Pipelines loaded: %i, %i, %i\n"
@@ -584,6 +583,7 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 		gpuStats.numCachedVertsDrawn,
 		gpuStats.numUncachedVertsDrawn,
 		(int)framebufferManager_->NumVFBs(),
+		gpuStats.numFramebufferEvaluations,
 		(int)textureCacheVulkan_->NumLoadedTextures(),
 		gpuStats.numTexturesDecoded,
 		gpuStats.numTextureInvalidations,

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -122,7 +122,7 @@ private:
 	TexCacheEntry::TexStatus CheckAlpha(const u32 *pixelData, VkFormat dstFmt, int stride, int w, int h);
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;
 
-	void ApplyTextureFramebuffer(TexCacheEntry *entry, VirtualFramebuffer *framebuffer) override;
+	void ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer, GETextureFormat texFormat, FramebufferNotificationChannel channel) override;
 	void BuildTexture(TexCacheEntry *const entry) override;
 
 	void CompileScalingShader();

--- a/Windows/CaptureDevice.cpp
+++ b/Windows/CaptureDevice.cpp
@@ -111,13 +111,15 @@ MediaParam defaultAudioParam = { 44100, 2, 16, MFAudioFormat_PCM };
 
 HRESULT GetDefaultStride(IMFMediaType *pType, LONG *plStride);
 
-ReaderCallback::ReaderCallback(WindowsCaptureDevice *device): img_convert_ctx(nullptr), resample_ctx(nullptr){
-	this->device = device;
-}
+ReaderCallback::ReaderCallback(WindowsCaptureDevice *_device) : device(_device) {}
 
 ReaderCallback::~ReaderCallback() {
-	sws_freeContext(img_convert_ctx);
-	swr_free(&resample_ctx);
+	if (img_convert_ctx) {
+		sws_freeContext(img_convert_ctx);
+	}
+	if (resample_ctx) {
+		swr_free(&resample_ctx);
+	}
 }
 
 HRESULT ReaderCallback::QueryInterface(REFIID riid, void** ppv)
@@ -439,20 +441,10 @@ u32 ReaderCallback::doResample(u8 **dst, u32 &dstSampleRate, u32 &dstChannels, u
 	return av_samples_get_buffer_size(nullptr, dstChannels, outSamplesCount, AV_SAMPLE_FMT_S16, 0);
 }
 
-WindowsCaptureDevice::WindowsCaptureDevice(CAPTUREDEVIDE_TYPE type) :
-	type(type),
-	m_pCallback(nullptr),
-	m_pSource(nullptr),
-	m_pReader(nullptr),
-	imageRGB(nullptr),
-	imageJpeg(nullptr),
-	imgJpegSize(0),
-	resampleBuf(nullptr),
-	resampleBufSize(0),
-	rawAudioBuf(nullptr),
+WindowsCaptureDevice::WindowsCaptureDevice(CAPTUREDEVIDE_TYPE _type) :
+	type(_type),
 	error(CAPTUREDEVIDE_ERROR_NO_ERROR),
 	errorMessage(""),
-	isDeviceChanged(false),
 	state(CAPTUREDEVIDE_STATE::UNINITIALIZED) {
 	param = { 0 };
 	deviceParam = { 0 };
@@ -482,6 +474,7 @@ WindowsCaptureDevice::~WindowsCaptureDevice() {
 		break;
 	}
 }
+
 void WindowsCaptureDevice::CheckDevices() {
 	isDeviceChanged = true;
 }

--- a/Windows/CaptureDevice.h
+++ b/Windows/CaptureDevice.h
@@ -171,8 +171,8 @@ public:
 
 protected:
 	WindowsCaptureDevice *device;
-	SwsContext *img_convert_ctx;
-	SwrContext *resample_ctx;
+	SwsContext *img_convert_ctx = nullptr;
+	SwrContext *resample_ctx = nullptr;
 };
 
 class WindowsCaptureDevice {
@@ -222,12 +222,12 @@ protected:
 	CAPTUREDEVIDE_ERROR error;
 	std::string errorMessage;
 
-	bool isDeviceChanged;
+	bool isDeviceChanged = false;
 
 // MF interface.
-	ReaderCallback *m_pCallback;
-	IMFSourceReader *m_pReader;
-	IMFMediaSource *m_pSource;
+	ReaderCallback *m_pCallback = nullptr;
+	IMFSourceReader *m_pReader = nullptr;
+	IMFMediaSource *m_pSource = nullptr;
 
 // Message loop.
 	std::mutex mutex;
@@ -241,15 +241,15 @@ protected:
 	std::mutex paramMutex;
 
 // Camera only
-	unsigned char *imageRGB;
-	int imgRGBLineSizes[4];
-	unsigned char *imageJpeg;
-	int imgJpegSize;
+	unsigned char *imageRGB = nullptr;
+	int imgRGBLineSizes[4]{};
+	unsigned char *imageJpeg = nullptr;
+	int imgJpegSize = 0;
 
 //Microphone only
-	u8 *resampleBuf;
-	u32 resampleBufSize;
-	QueueBuf *rawAudioBuf;
+	u8 *resampleBuf = nullptr;
+	u32 resampleBufSize = 0;
+	QueueBuf *rawAudioBuf = nullptr;
 };
 
 extern WindowsCaptureDevice *winCamera;


### PR DESCRIPTION
Instead, re-evaluate framebuffers every time we try to bind a texture and it doesn't find an entry in the texcache map.

This is not that many times per frame normally, so it's really not as bad as it seems. Plus, the code becomes a lot more readable and debuggable without having to take into account all that state.

Even difficult cases like Test Drive and God Of War's shadows work just fine.

~~Now, this is a draft PR because Breath of Fire III is broken yet again (oops - we lost the detach actions again but since we re-evaluate every time now, that should be ok) but all should be fixable with a little bit of work. And when it's done, it'll be much easier to work on these issues.~~ (UPDATE: fixed)



