### PR TITLE
Fix libretro OSX build

### DIFF
--- a/ext/zlib/gzguts.h
+++ b/ext/zlib/gzguts.h
@@ -27,6 +27,10 @@
 #endif
 #include <fcntl.h>
 
+#ifdef __APPLE__
+#include <unistd.h>
+#endif
+
 #ifdef _WIN32
 #  include <stddef.h>
 #endif


### PR DESCRIPTION
Fixes these errors:

```
../ext/zlib/gzlib.c:492:14: error: implicit declaration of function 'lseek' is invalid in C99
      [-Werror,-Wimplicit-function-declaration]
../ext/zlib/gzwrite.c:84:15: error: implicit declaration of function 'write' is invalid in C99
      [-Werror,-Wimplicit-function-declaration]
  1 /* gzguts.h -- zlib internal header definitions for gz* operations
        got = write(state->fd, strm->next_in, strm->avail_in);
```