### PR TITLE
Texture invalidation fixes

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -441,8 +441,8 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const Frame
 
 void FramebufferManagerCommon::DestroyFramebuf(VirtualFramebuffer *v) {
 	// Notify the texture cache of both the color and depth buffers.
-	textureCache_->NotifyFramebuffer(v->fb_address, v, NOTIFY_FB_DESTROYED, NOTIFY_FB_COLOR);
-	textureCache_->NotifyFramebuffer(v->z_address, v, NOTIFY_FB_DESTROYED, NOTIFY_FB_DEPTH);
+	textureCache_->NotifyFramebuffer(v, NOTIFY_FB_DESTROYED, NOTIFY_FB_COLOR);
+	textureCache_->NotifyFramebuffer(v, NOTIFY_FB_DESTROYED, NOTIFY_FB_DEPTH);
 	if (v->fbo) {
 		v->fbo->Release();
 		v->fbo = nullptr;
@@ -469,8 +469,8 @@ void FramebufferManagerCommon::NotifyRenderFramebufferCreated(VirtualFramebuffer
 		DownloadFramebufferOnSwitch(currentRenderVfb_);
 	}
 
-	textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_CREATED, NOTIFY_FB_COLOR);
-	textureCache_->NotifyFramebuffer(vfb->z_address, vfb, NOTIFY_FB_CREATED, NOTIFY_FB_DEPTH);
+	textureCache_->NotifyFramebuffer(vfb, NOTIFY_FB_CREATED, NOTIFY_FB_COLOR);
+	textureCache_->NotifyFramebuffer(vfb, NOTIFY_FB_CREATED, NOTIFY_FB_DEPTH);
 
 	// Ugly...
 	if (gstate_c.curRTWidth != vfb->width || gstate_c.curRTHeight != vfb->height) {
@@ -484,8 +484,8 @@ void FramebufferManagerCommon::NotifyRenderFramebufferCreated(VirtualFramebuffer
 
 void FramebufferManagerCommon::NotifyRenderFramebufferUpdated(VirtualFramebuffer *vfb, bool vfbFormatChanged) {
 	if (vfbFormatChanged) {
-		textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_UPDATED, NOTIFY_FB_COLOR);
-		textureCache_->NotifyFramebuffer(vfb->z_address, vfb, NOTIFY_FB_UPDATED, NOTIFY_FB_DEPTH);
+		textureCache_->NotifyFramebuffer(vfb, NOTIFY_FB_UPDATED, NOTIFY_FB_COLOR);
+		textureCache_->NotifyFramebuffer(vfb, NOTIFY_FB_UPDATED, NOTIFY_FB_DEPTH);
 		if (vfb->drawnFormat != vfb->format) {
 			ReformatFramebufferFrom(vfb, vfb->drawnFormat);
 		}
@@ -553,8 +553,8 @@ void FramebufferManagerCommon::NotifyRenderFramebufferSwitched(VirtualFramebuffe
 	} else {
 		if (vfb->fbo) {
 			// This should only happen very briefly when toggling useBufferedRendering_.
-			textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_DESTROYED, NOTIFY_FB_COLOR);
-			textureCache_->NotifyFramebuffer(vfb->z_address, vfb, NOTIFY_FB_DESTROYED, NOTIFY_FB_DEPTH);
+			textureCache_->NotifyFramebuffer(vfb, NOTIFY_FB_DESTROYED, NOTIFY_FB_COLOR);
+			textureCache_->NotifyFramebuffer(vfb, NOTIFY_FB_DESTROYED, NOTIFY_FB_DEPTH);
 			vfb->fbo->Release();
 			vfb->fbo = nullptr;
 		}
@@ -566,8 +566,8 @@ void FramebufferManagerCommon::NotifyRenderFramebufferSwitched(VirtualFramebuffe
 			gstate_c.skipDrawReason |= SKIPDRAW_NON_DISPLAYED_FB;
 		}
 	}
-	textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_UPDATED, NOTIFY_FB_COLOR);
-	textureCache_->NotifyFramebuffer(vfb->z_address, vfb, NOTIFY_FB_UPDATED, NOTIFY_FB_DEPTH);
+	textureCache_->NotifyFramebuffer(vfb, NOTIFY_FB_UPDATED, NOTIFY_FB_COLOR);
+	textureCache_->NotifyFramebuffer(vfb, NOTIFY_FB_UPDATED, NOTIFY_FB_DEPTH);
 
 	// ugly... is all this needed?
 	if (gstate_c.curRTWidth != vfb->width || gstate_c.curRTHeight != vfb->height) {
@@ -1348,7 +1348,7 @@ VirtualFramebuffer *FramebufferManagerCommon::CreateRAMFramebuffer(uint32_t fbAd
 	SetColorUpdated(vfb, 0);
 	char name[64];
 	snprintf(name, sizeof(name), "%08x_color_RAM", vfb->fb_address);
-	textureCache_->NotifyFramebuffer(vfb->fb_address, vfb, NOTIFY_FB_CREATED, NOTIFY_FB_COLOR);
+	textureCache_->NotifyFramebuffer(vfb, NOTIFY_FB_CREATED, NOTIFY_FB_COLOR);
 	vfb->fbo = draw_->CreateFramebuffer({ vfb->renderWidth, vfb->renderHeight, 1, 1, true, (Draw::FBColorDepth)vfb->colorDepth, name });
 	vfbs_.push_back(vfb);
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -365,7 +365,7 @@ TexCacheEntry *TextureCacheCommon::SetTexture(bool force) {
 
 	u32 texhash = MiniHash((const u32 *)Memory::GetPointerUnchecked(texaddr));
 
-	TexCache::iterator iter = cache_.find(cachekey);
+	TexCache::iterator entryIter = cache_.find(cachekey);
 	TexCacheEntry *entry = nullptr;
 
 	// Note: It's necessary to reset needshadertexclamp, for otherwise DIRTY_TEXCLAMP won't get set later.
@@ -377,8 +377,8 @@ TexCacheEntry *TextureCacheCommon::SetTexture(bool force) {
 	}
 	gstate_c.bgraTexture = isBgraBackend_;
 
-	if (iter != cache_.end()) {
-		entry = iter->second.get();
+	if (entryIter != cache_.end()) {
+		entry = entryIter->second.get();
 		// Validate the texture still matches the cache entry.
 		bool match = entry->Matches(dim, format, maxLevel);
 		const char *reason = "different params";
@@ -488,6 +488,11 @@ TexCacheEntry *TextureCacheCommon::SetTexture(bool force) {
 	if (candidates.size() > 0) {
 		int index = GetBestCandidateIndex(candidates);
 		if (index != -1) {
+			// If we had a texture entry here, let's get rid of it.
+			if (entryIter != cache_.end()) {
+				DeleteTexture(entryIter);
+			}
+
 			nextTexture_ = nullptr;
 			nextNeedsRebuild_ = false;
 			SetTextureFramebuffer(candidates[index]);

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -245,7 +245,7 @@ public:
 
 	// FramebufferManager keeps TextureCache updated about what regions of memory are being rendered to,
 	// so that it can invalidate TexCacheEntries pointed at those addresses.
-	void NotifyFramebuffer(u32 address, VirtualFramebuffer *framebuffer, FramebufferNotification msg, FramebufferNotificationChannel channel);
+	void NotifyFramebuffer(VirtualFramebuffer *framebuffer, FramebufferNotification msg, FramebufferNotificationChannel channel);
 	void NotifyVideoUpload(u32 addr, int size, int width, GEBufferFormat fmt);
 
 	size_t NumLoadedTextures() const {

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -63,6 +63,7 @@ struct GPUStatistics {
 		numUncachedVertsDrawn = 0;
 		numTrackedVertexArrays = 0;
 		numTextureInvalidations = 0;
+		numTextureInvalidationsByFramebuffer = 0;
 		numTextureSwitches = 0;
 		numShaderSwitches = 0;
 		numFlushes = 0;
@@ -86,6 +87,7 @@ struct GPUStatistics {
 	int numUncachedVertsDrawn;
 	int numTrackedVertexArrays;
 	int numTextureInvalidations;
+	int numTextureInvalidationsByFramebuffer;
 	int numTextureSwitches;
 	int numShaderSwitches;
 	int numTexturesDecoded;

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -172,6 +172,7 @@ void DrawEngineVulkan::InitDeviceObjects() {
 	samp.magFilter = VK_FILTER_NEAREST;
 	samp.minFilter = VK_FILTER_NEAREST;
 	res = vkCreateSampler(device, &samp, nullptr, &samplerSecondary_);
+	_dbg_assert_(VK_SUCCESS == res);
 	res = vkCreateSampler(device, &samp, nullptr, &nullSampler_);
 	_dbg_assert_(VK_SUCCESS == res);
 

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -287,6 +287,9 @@ void DrawEngineVulkan::BeginFrame() {
 		vertexCache_->Destroy(vulkan_);
 		delete vertexCache_;  // orphans the buffers, they'll get deleted once no longer used by an in-flight frame.
 		vertexCache_ = new VulkanPushBuffer(vulkan_, VERTEX_CACHE_SIZE, VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
+		vai_.Iterate([&](uint32_t hash, VertexArrayInfoVulkan *vai) {
+			delete vai;
+		});
 		vai_.Clear();
 	}
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -565,7 +565,7 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 		"Vertices submitted: %i\n"
 		"Cached, Uncached Vertices Drawn: %i, %i\n"
 		"FBOs active: %i (evaluations: %d)\n"
-		"Textures active: %i, decoded: %i  invalidated: %i\n"
+		"Textures active: %i, decoded: %i  invalidated: %d (%d by fb)\n"
 		"Readbacks: %d, uploads: %d\n"
 		"Vertex, Fragment, Pipelines loaded: %i, %i, %i\n"
 		"Pushbuffer space used: UBO %d, Vtx %d, Idx %d\n"
@@ -587,6 +587,7 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 		(int)textureCacheVulkan_->NumLoadedTextures(),
 		gpuStats.numTexturesDecoded,
 		gpuStats.numTextureInvalidations,
+		gpuStats.numTextureInvalidationsByFramebuffer,
 		gpuStats.numReadbacks,
 		gpuStats.numUploads,
 		shaderManagerVulkan_->GetNumVertexShaders(),

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -363,7 +363,8 @@ void TextureCacheVulkan::DeviceRestore(VulkanContext *vulkan, Draw::DrawContext 
 	samp.magFilter = VK_FILTER_NEAREST;
 	samp.minFilter = VK_FILTER_NEAREST;
 	samp.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
-	vkCreateSampler(vulkan_->GetDevice(), &samp, nullptr, &samplerNearest_);
+	VkResult res = vkCreateSampler(vulkan_->GetDevice(), &samp, nullptr, &samplerNearest_);
+	_assert_(res == VK_SUCCESS);
 
 	CompileScalingShader();
 

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -549,7 +549,8 @@ VkPipeline VulkanComputeShaderManager::GetPipeline(VkShaderModule cs) {
 	pci.layout = pipelineLayout_;
 	pci.flags = 0;
 
-	vkCreateComputePipelines(vulkan_->GetDevice(), pipelineCache_, 1, &pci, nullptr, &pipeline);
+	VkResult res = vkCreateComputePipelines(vulkan_->GetDevice(), pipelineCache_, 1, &pci, nullptr, &pipeline);
+	_assert_(res == VK_SUCCESS);
 
 	pipelines_.Insert(key, pipeline);
 	return pipeline;

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -49,7 +49,8 @@ void VulkanQueueRunner::ResizeReadbackBuffer(VkDeviceSize requiredSize) {
 	buf.size = readbackBufferSize_;
 	buf.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 
-	vkCreateBuffer(device, &buf, nullptr, &readbackBuffer_);
+	VkResult res = vkCreateBuffer(device, &buf, nullptr, &readbackBuffer_);
+	_assert_(res == VK_SUCCESS);
 
 	VkMemoryRequirements reqs{};
 	vkGetBufferMemoryRequirements(device, readbackBuffer_, &reqs);
@@ -75,7 +76,7 @@ void VulkanQueueRunner::ResizeReadbackBuffer(VkDeviceSize requiredSize) {
 	_assert_(successTypeReqs != 0);
 	readbackBufferIsCoherent_ = (successTypeReqs & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) != 0;
 
-	VkResult res = vkAllocateMemory(device, &allocInfo, nullptr, &readbackMemory_);
+	res = vkAllocateMemory(device, &allocInfo, nullptr, &readbackMemory_);
 	if (res != VK_SUCCESS) {
 		readbackMemory_ = VK_NULL_HANDLE;
 		vkDestroyBuffer(device, readbackBuffer_, nullptr);

--- a/ext/native/thin3d/VulkanRenderManager.cpp
+++ b/ext/native/thin3d/VulkanRenderManager.cpp
@@ -38,7 +38,9 @@ VKRFramebuffer::VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VkRen
 	fbci.height = height;
 	fbci.layers = 1;
 
-	vkCreateFramebuffer(vulkan_->GetDevice(), &fbci, nullptr, &framebuf);
+	VkResult res = vkCreateFramebuffer(vulkan_->GetDevice(), &fbci, nullptr, &framebuf);
+	_assert_(res == VK_SUCCESS);
+
 	if (tag && vk->Extensions().EXT_debug_utils) {
 		vk->SetDebugName(color.image, VK_OBJECT_TYPE_IMAGE, StringFromFormat("fb_color_%s", tag).c_str());
 		vk->SetDebugName(depth.image, VK_OBJECT_TYPE_IMAGE, StringFromFormat("fb_depth_%s", tag).c_str());
@@ -86,7 +88,8 @@ void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int 
 		ici.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
 	}
 
-	vkCreateImage(vulkan->GetDevice(), &ici, nullptr, &img.image);
+	VkResult res = vkCreateImage(vulkan->GetDevice(), &ici, nullptr, &img.image);
+	_dbg_assert_(res == VK_SUCCESS);
 
 	VkMemoryRequirements memreq;
 	bool dedicatedAllocation = false;
@@ -102,7 +105,7 @@ void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int 
 
 	vulkan->MemoryTypeFromProperties(memreq.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &alloc.memoryTypeIndex);
 
-	VkResult res = vkAllocateMemory(vulkan->GetDevice(), &alloc, nullptr, &img.memory);
+	res = vkAllocateMemory(vulkan->GetDevice(), &alloc, nullptr, &img.memory);
 	_dbg_assert_(res == VK_SUCCESS);
 
 	res = vkBindImageMemory(vulkan->GetDevice(), img.image, img.memory, 0);


### PR DESCRIPTION
TextureCache: Don't drastically over-invalidate in NotifyFramebuffers. Burnout has a case where a framebuffer that's updated a lot (the lens flare effect virtual framebuffer) has a misdetected height and overlaps a lot of textures, so cap to make sure that when creating framebuffers, we only really kill off cached textures that start at or nearly at the same address.

Should help at least the performance part of #13431. Can't quite account for the broken graphics yet, which don't repro on NV. (however there's a related lost-device issue on Intel...).

Snuck in a couple of unrelated bugfixes and some more asserts.