### PR TITLE
Mpeg: prevent some cases where a valid mpeg stream was being flagged as invalid.

### DIFF
--- a/Core/HW/MpegDemux.cpp
+++ b/Core/HW/MpegDemux.cpp
@@ -202,6 +202,7 @@ bool MpegDemux::demux(int audioChannel)
 		}
 		// Not enough data available yet.
 		if (m_readSize - m_index < 16) {
+			looksValid = true;
 			m_index -= 4;
 			break;
 		}


### PR DESCRIPTION
this avoids spamming the console with the `sceMpegRingbufferPut(): invalid mpeg data` error, for example during the intro video of `Mega Man Powered Up`