### PR TITLE
Minor cleanup in texturecache

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -698,6 +698,8 @@ void DrawEngineCommon::SubmitPrim(void *verts, void *inds, GEPrimitiveType prim,
 	}
 
 	*bytesRead = vertexCount * dec_->VertexSize();
+
+	// Check that we have enough vertices to form the requested primitive.
 	if ((vertexCount < 2 && prim > 0) || (vertexCount < 3 && prim > 2 && prim != GE_PRIM_RECTANGLES))
 		return;
 

--- a/GPU/Common/ShaderCommon.h
+++ b/GPU/Common/ShaderCommon.h
@@ -104,7 +104,7 @@ enum : uint64_t {
 
 	// Other dirty elements that aren't uniforms!
 	DIRTY_FRAMEBUF = 1ULL << 40,
-	DIRTY_TEXTURE_IMAGE = 1ULL << 41,
+	DIRTY_TEXTURE_IMAGE = 1ULL << 41,  // Means that the definition of the texture image has changed (address, stride etc), and we need to look up again.
 	DIRTY_TEXTURE_PARAMS = 1ULL << 42,
 
 	// Render State

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -321,11 +321,7 @@ void TextureCacheCommon::UpdateMaxSeenV(TexCacheEntry *entry, bool throughMode) 
 	}
 }
 
-TexCacheEntry *TextureCacheCommon::SetTexture(bool force) {
-	if (force) {
-		InvalidateLastTexture();
-	}
-
+TexCacheEntry *TextureCacheCommon::SetTexture() {
 	u8 level = 0;
 	if (IsFakeMipmapChange())
 		level = std::max(0, gstate.getTexLevelOffset16() / 16);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1588,6 +1588,7 @@ void TextureCacheCommon::ApplyTexture() {
 		// Maybe we bound a framebuffer?
 		if (nextFramebufferTexture_) {
 			bool depth = Memory::IsDepthTexVRAMAddress(gstate.getTextureAddress(0));
+			InvalidateLastTexture();
 			ApplyTextureFramebuffer(nextFramebufferTexture_, gstate.getTextureFormat(), depth ? NOTIFY_FB_DEPTH : NOTIFY_FB_COLOR);
 			nextFramebufferTexture_ = nullptr;
 		}

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -231,7 +231,10 @@ public:
 	void LoadClut(u32 clutAddr, u32 loadBytes);
 	bool GetCurrentClutBuffer(GPUDebugBuffer &buffer);
 
-	TexCacheEntry *SetTexture(bool force = false);
+	// This updates nextTexture_ / nextFramebufferTexture_, which is then used by ApplyTexture.
+	// TODO: Return stuff directly instead of keeping state.
+	TexCacheEntry *SetTexture();
+
 	void ApplyTexture();
 	bool SetOffsetTexture(u32 yOffset);
 	void Invalidate(u32 addr, int size, GPUInvalidationType type);
@@ -239,7 +242,7 @@ public:
 	void ClearNextFrame();
 
 	virtual void ForgetLastTexture() = 0;
-	virtual void InvalidateLastTexture(TexCacheEntry *entry = nullptr) = 0;
+	virtual void InvalidateLastTexture() = 0;
 	virtual void Clear(bool delete_them);
 	virtual void NotifyConfigChanged();
 

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -149,10 +149,8 @@ void TextureCacheD3D11::ForgetLastTexture() {
 	context_->PSSetShaderResources(0, 2, nullTex);
 }
 
-void TextureCacheD3D11::InvalidateLastTexture(TexCacheEntry *entry) {
-	if (!entry || entry->texturePtr == lastBoundTexture) {
-		lastBoundTexture = INVALID_TEX;
-	}
+void TextureCacheD3D11::InvalidateLastTexture() {
+	lastBoundTexture = INVALID_TEX;
 }
 
 void TextureCacheD3D11::StartFrame() {
@@ -409,7 +407,6 @@ void TextureCacheD3D11::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer,
 
 	gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_RASTER_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_BLEND_STATE | DIRTY_FRAGMENTSHADER_STATE);
 }
-
 
 void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 	entry->status &= ~TexCacheEntry::STATUS_ALPHA_MASK;
@@ -736,7 +733,7 @@ void TextureCacheD3D11::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &
 }
 
 bool TextureCacheD3D11::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) {
-	SetTexture(false);
+	SetTexture();
 	if (!nextTexture_) {
 		if (nextFramebufferTexture_) {
 			VirtualFramebuffer *vfb = nextFramebufferTexture_;

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -145,6 +145,7 @@ void TextureCacheD3D11::ReleaseTexture(TexCacheEntry *entry, bool delete_them) {
 void TextureCacheD3D11::ForgetLastTexture() {
 	InvalidateLastTexture();
 	gstate_c.Dirty(DIRTY_TEXTURE_PARAMS);
+
 	ID3D11ShaderResourceView *nullTex[2]{};
 	context_->PSSetShaderResources(0, 2, nullTex);
 }

--- a/GPU/D3D11/TextureCacheD3D11.h
+++ b/GPU/D3D11/TextureCacheD3D11.h
@@ -58,7 +58,7 @@ public:
 	}
 
 	void ForgetLastTexture() override;
-	void InvalidateLastTexture(TexCacheEntry *entry = nullptr) override;
+	void InvalidateLastTexture() override;
 
 	bool GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) override;
 

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -97,10 +97,8 @@ void TextureCacheDX9::ForgetLastTexture() {
 	gstate_c.Dirty(DIRTY_TEXTURE_PARAMS);
 }
 
-void TextureCacheDX9::InvalidateLastTexture(TexCacheEntry *entry) {
-	if (!entry || entry->texturePtr == lastBoundTexture) {
-		lastBoundTexture = INVALID_TEX;
-	}
+void TextureCacheDX9::InvalidateLastTexture() {
+	lastBoundTexture = INVALID_TEX;
 }
 
 D3DFORMAT getClutDestFormat(GEPaletteFormat format) {
@@ -690,7 +688,7 @@ void TextureCacheDX9::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &re
 }
 
 bool TextureCacheDX9::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) {
-	SetTexture(true);
+	SetTexture();
 	ApplyTexture();
 	int w = gstate.getTextureWidth(level);
 	int h = gstate.getTextureHeight(level);

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -50,7 +50,7 @@ public:
 	}
 
 	void ForgetLastTexture() override;
-	void InvalidateLastTexture(TexCacheEntry *entry = nullptr) override;
+	void InvalidateLastTexture() override;
 
 	bool GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) override;
 

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -730,7 +730,9 @@ bool TextureCacheGLES::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level)
 		gstate.texbufwidth[0] = gstate.texbufwidth[level];
 	}
 
-	SetTexture(true);
+	InvalidateLastTexture();
+	SetTexture();
+
 	if (!nextTexture_) {
 		if (nextFramebufferTexture_) {
 			VirtualFramebuffer *vfb = nextFramebufferTexture_;

--- a/GPU/GLES/TextureCacheGLES.h
+++ b/GPU/GLES/TextureCacheGLES.h
@@ -57,10 +57,8 @@ public:
 		lastBoundTexture = nullptr;
 		gstate_c.Dirty(DIRTY_TEXTURE_PARAMS);
 	}
-	void InvalidateLastTexture(TexCacheEntry *entry = nullptr) override {
-		if (!entry || entry->textureName == lastBoundTexture) {
-			lastBoundTexture = nullptr;
-		}
+	void InvalidateLastTexture() override {
+		lastBoundTexture = nullptr;
 	}
 
 	bool GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) override;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -509,11 +509,8 @@ void TextureCacheVulkan::UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutB
 }
 
 void TextureCacheVulkan::BindTexture(TexCacheEntry *entry) {
-	if (!entry || !entry->vkTex) {
-		imageView_ = VK_NULL_HANDLE;
-		curSampler_ = VK_NULL_HANDLE;
-		return;
-	}
+	_assert_(entry);
+	_assert_(entry->vkTex);
 
 	entry->vkTex->Touch();
 	imageView_ = entry->vkTex->GetImageView();
@@ -1114,7 +1111,7 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 }
 
 bool TextureCacheVulkan::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) {
-	SetTexture(false);
+	SetTexture();
 	if (!nextTexture_) {
 		if (nextFramebufferTexture_) {
 			VirtualFramebuffer *vfb = nextFramebufferTexture_;

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -88,10 +88,8 @@ public:
 		gstate_c.Dirty(DIRTY_TEXTURE_PARAMS);
 	}
 
-	void InvalidateLastTexture(TexCacheEntry *entry = nullptr) override {
-		if (!entry || entry->vkTex == lastBoundTexture) {
-			lastBoundTexture = nullptr;
-		}
+	void InvalidateLastTexture() override {
+		lastBoundTexture = nullptr;
 	}
 
 	void NotifyConfigChanged() override;

--- a/ext/native/thin3d/GLRenderManager.h
+++ b/ext/native/thin3d/GLRenderManager.h
@@ -30,7 +30,8 @@ public:
 	}
 
 	GLuint texture = 0;
-	// Could also trust OpenGL defaults I guess..
+
+	// We don't trust OpenGL defaults - setting wildly off values ensures that we'll end up overwriting these parameters.
 	GLenum target = 0xFFFF;
 	GLenum wrapS = 0xFFFF;
 	GLenum wrapT = 0xFFFF;
@@ -63,7 +64,7 @@ public:
 
 	int width;
 	int height;
-	GLuint colorDepth;
+	GLuint colorDepth = 0;
 
 	bool z_stencil_;
 };


### PR DESCRIPTION
Minor cleanups of things I found digging around in the texture cache.

Fixes part of #13431 for D3D11.