### PR TITLE
Windows: Faster startup by not filling the symbol listbox immediately

### DIFF
--- a/Common/Vulkan/VulkanImage.cpp
+++ b/Common/Vulkan/VulkanImage.cpp
@@ -80,7 +80,8 @@ bool VulkanTexture::CreateDirect(VkCommandBuffer cmd, VulkanDeviceAllocator *all
 
 	if (allocator && !dedicatedAllocation) {
 		allocator_ = allocator;
-		offset_ = allocator_->Allocate(mem_reqs, &mem_, Tag());
+		// ok to use the tag like this, because the lifetime of the VulkanImage exceeds that of the allocation.
+		offset_ = allocator_->Allocate(mem_reqs, &mem_, Tag().c_str());
 		if (offset_ == VulkanDeviceAllocator::ALLOCATE_FAILED) {
 			ERROR_LOG(G3D, "Image memory allocation failed (mem_reqs.size=%d, typebits=%08x", (int)mem_reqs.size, (int)mem_reqs.memoryTypeBits);
 			// Destructor will take care of the image.

--- a/Common/Vulkan/VulkanImage.h
+++ b/Common/Vulkan/VulkanImage.h
@@ -30,10 +30,10 @@ public:
 
 	void Destroy();
 
-	void SetTag(const std::string &tag) {
+	void SetTag(const char *tag) {
 		tag_ = tag;
 	}
-	std::string Tag() const {
+	const std::string &Tag() const {
 		return tag_;
 	}
 	void Touch();

--- a/Common/Vulkan/VulkanMemory.h
+++ b/Common/Vulkan/VulkanMemory.h
@@ -149,7 +149,8 @@ public:
 	}
 
 	// May return ALLOCATE_FAILED if the allocation fails.
-	size_t Allocate(const VkMemoryRequirements &reqs, VkDeviceMemory *deviceMemory, const std::string &tag);
+	// NOTE: Lifetime of the string tag points to must exceed that of the allocation.
+	size_t Allocate(const VkMemoryRequirements &reqs, VkDeviceMemory *deviceMemory, const char *tag);
 
 	// Crashes on a double or misfree.
 	void Free(VkDeviceMemory deviceMemory, size_t offset);
@@ -177,9 +178,9 @@ private:
 	static const uint32_t UNDEFINED_MEMORY_TYPE = -1;
 
 	struct UsageInfo {
-		std::string tag;
 		double created;
 		double touched;
+		const char *tag;
 	};
 
 	struct Slab {
@@ -212,7 +213,7 @@ private:
 	}
 
 	bool AllocateSlab(VkDeviceSize minBytes, int memoryTypeIndex);
-	bool AllocateFromSlab(Slab &slab, size_t &start, size_t blocks, const std::string &tag);
+	bool AllocateFromSlab(Slab &slab, size_t &start, size_t blocks, const char *tag);
 	void Decimate();
 	void DoTouch(VkDeviceMemory deviceMemory, size_t offset);
 	void ExecuteFree(FreeInfo *userdata);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1753,6 +1753,9 @@ bool TextureCacheCommon::CheckFullHash(TexCacheEntry *entry, bool &doDelete) {
 
 void TextureCacheCommon::Invalidate(u32 addr, int size, GPUInvalidationType type) {
 	// They could invalidate inside the texture, let's just give a bit of leeway.
+	// TODO: Keep track of the largest texture size in bytes, and use that instead of this
+	// humongous unrealistic value.
+
 	const int LARGEST_TEXTURE_SIZE = 512 * 512 * 4;
 
 	addr &= 0x3FFFFFFF;
@@ -1785,7 +1788,8 @@ void TextureCacheCommon::Invalidate(u32 addr, int size, GPUInvalidationType type
 		u32 texAddr = iter->second->addr;
 		u32 texEnd = iter->second->addr + iter->second->sizeInRAM;
 
-		if (texAddr < addr_end && addr < texEnd) {
+		// Quick check for overlap. Yes the check is right.
+		if (addr < texEnd && addr_end > texAddr) {
 			if (iter->second->GetHashStatus() == TexCacheEntry::STATUS_RELIABLE) {
 				iter->second->SetHashStatus(TexCacheEntry::STATUS_HASHING);
 			}

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -193,6 +193,7 @@ void GPU_D3D11::BuildReportingInfo() {
 }
 
 void GPU_D3D11::DeviceLost() {
+	draw_->InvalidateCachedState();
 	// Simply drop all caches and textures.
 	// FBOs appear to survive? Or no?
 	shaderManagerD3D11_->ClearShaders();

--- a/Windows/Debugger/CtrlRegisterList.cpp
+++ b/Windows/Debugger/CtrlRegisterList.cpp
@@ -19,8 +19,6 @@
 
 #include "Windows/main.h"
 
-static const int numCPUs = 1;
-
 extern HMENU g_hPopupMenus;
 
 enum { REGISTER_PC = 32, REGISTER_HI, REGISTER_LO, REGISTERS_END };
@@ -520,9 +518,8 @@ void CtrlRegisterList::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 			SendMessage(GetParent(wnd),WM_DEB_GOTOHEXEDIT,val,0);
 			break;
 		case ID_REGLIST_GOTOINDISASM:
-			for (int i=0; i<numCPUs; i++)
-				if (disasmWindow[i])
-					disasmWindow[i]->Goto(val);
+			if (disasmWindow)
+				disasmWindow->Goto(val);
 			break;
 		case ID_REGLIST_COPYVALUE:
 			copyRegisterValue();

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -848,22 +848,33 @@ void CDisasm::SetDebugMode(bool _bDebug, bool switchPC)
 	}
 }
 
-void CDisasm::NotifyMapLoaded()
-{
-	if (g_symbolMap)
-		g_symbolMap->FillSymbolListBox(GetDlgItem(m_hDlg, IDC_FUNCTIONLIST),ST_FUNCTION);
-	CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg,IDC_DISASMVIEW));
+void CDisasm::Show(bool bShow) {
+	if (deferredSymbolFill_ && bShow) {
+		if (g_symbolMap)
+			g_symbolMap->FillSymbolListBox(GetDlgItem(m_hDlg, IDC_FUNCTIONLIST), ST_FUNCTION);
+		deferredSymbolFill_ = false;
+	}
+	Dialog::Show(bShow);
+}
+
+void CDisasm::NotifyMapLoaded() {
+	if (m_bShowState == SW_SHOW) {
+		if (g_symbolMap)
+			g_symbolMap->FillSymbolListBox(GetDlgItem(m_hDlg, IDC_FUNCTIONLIST), ST_FUNCTION);
+	} else {
+		deferredSymbolFill_ = true;
+	}
+	CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg, IDC_DISASMVIEW));
 	ptr->clearFunctions();
 	ptr->redraw();
 }
 
 void CDisasm::Goto(u32 addr)
 {
-	CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg,IDC_DISASMVIEW));
+	CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg, IDC_DISASMVIEW));
 	ptr->gotoAddr(addr);
 	SetFocus(GetDlgItem(m_hDlg, IDC_DISASMVIEW));
 	ptr->redraw();
-	
 }
 
 void CDisasm::UpdateDialog(bool _bComplete)

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -31,12 +31,10 @@
 #include <windowsx.h>
 #include <commctrl.h>
 
-static const int numCPUs = 1;
-
 // How long (max) to wait for Core to pause before clearing temp breakpoints.
-const int TEMP_BREAKPOINT_WAIT_MS = 100;
+static const int TEMP_BREAKPOINT_WAIT_MS = 100;
 
-FAR WNDPROC DefGotoEditProc;
+static FAR WNDPROC DefGotoEditProc;
 
 LRESULT CALLBACK GotoEditProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
@@ -66,7 +64,7 @@ LRESULT CALLBACK GotoEditProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lPa
 	return (LRESULT)CallWindowProc((WNDPROC)DefGotoEditProc,hDlg,message,wParam,lParam);
 }
 
-FAR WNDPROC DefFuncListProc;
+static FAR WNDPROC DefFuncListProc;
 
 LRESULT CALLBACK FuncListProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
@@ -94,8 +92,6 @@ LRESULT CALLBACK FuncListProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lPa
 CDisasm::CDisasm(HINSTANCE _hInstance, HWND _hParent, DebugInterface *_cpu) : Dialog((LPCSTR)IDD_DISASM, _hInstance, _hParent) {
 	cpu = _cpu;
 	lastTicks = PSP_IsInited() ? CoreTiming::GetTicks() : 0;
-	keepStatusBarText = false;
-	hideBottomTabs = false;
 
 	SetWindowText(m_hDlg, ConvertUTF8ToWString(_cpu->GetName()).c_str());
 
@@ -113,8 +109,7 @@ CDisasm::CDisasm(HINSTANCE _hInstance, HWND _hParent, DebugInterface *_cpu) : Di
 
 	// init status bar
 	statusBarWnd = CreateWindowEx(0, STATUSCLASSNAME, L"", WS_CHILD | WS_VISIBLE, 0, 0, 0, 0, m_hDlg, (HMENU)IDC_DISASMSTATUSBAR, _hInstance, NULL);
-	if (g_Config.bDisplayStatusBar == false)
-	{
+	if (g_Config.bDisplayStatusBar == false) {
 		ShowWindow(statusBarWnd,SW_HIDE);
 	}
 
@@ -897,9 +892,8 @@ void CDisasm::UpdateDialog(bool _bComplete)
 		SetDlgItemText(m_hDlg, IDC_DEBUG_COUNT, tempTicks);
 	}
 	// Update Register Dialog
-	for (int i=0; i<numCPUs; i++)
-		if (memoryWindow[i])
-			memoryWindow[i]->Update();
+	if (memoryWindow)
+		memoryWindow->Update();
 
 	// repaint windows at the bottom. only the memory view needs to be forced to
 	// redraw. all others are updated manually

--- a/Windows/Debugger/Debugger_Disasm.h
+++ b/Windows/Debugger/Debugger_Disasm.h
@@ -29,8 +29,8 @@ private:
 	TabControl* bottomTabs;
 	std::vector<BreakPoint> displayedBreakPoints_;
 	std::vector<MemCheck> displayedMemChecks_;
-	bool keepStatusBarText;
-	bool hideBottomTabs;
+	bool keepStatusBarText = false;
+	bool hideBottomTabs = false;
 
 	BOOL DlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 	void UpdateSize(WORD width, WORD height);
@@ -40,17 +40,14 @@ private:
 	void stepOver();
 	void stepOut();
 	void runToLine();
+
 public:
-	int index; //helper 
+	int index;
 
 	CDisasm(HINSTANCE _hInstance, HWND _hParent, DebugInterface *cpu);
 	~CDisasm();
-	//
-	// --- tools ---
-	//
-	
-	virtual void Update()
-	{
+
+	virtual void Update() {
 		UpdateDialog(true);
 		SetDebugMode(Core_IsStepping(), false);
 		breakpointList->reloadBreakpoints();
@@ -58,7 +55,7 @@ public:
 	void UpdateDialog(bool _bComplete = false);
 	// SetDebugMode 
 	void SetDebugMode(bool _bDebug, bool switchPC);
-	// show dialog
+
 	void Goto(u32 addr);
 	void NotifyMapLoaded();
 };

--- a/Windows/Debugger/Debugger_Disasm.h
+++ b/Windows/Debugger/Debugger_Disasm.h
@@ -16,7 +16,8 @@
 class CDisasm : public Dialog
 {
 private:
-	int minWidth,minHeight;
+	int minWidth;
+	int minHeight;
 	DebugInterface *cpu;
 	u64 lastTicks;
 
@@ -31,8 +32,9 @@ private:
 	std::vector<MemCheck> displayedMemChecks_;
 	bool keepStatusBarText = false;
 	bool hideBottomTabs = false;
+	bool deferredSymbolFill_ = false;
 
-	BOOL DlgProc(UINT message, WPARAM wParam, LPARAM lParam);
+	BOOL DlgProc(UINT message, WPARAM wParam, LPARAM lParam) override;
 	void UpdateSize(WORD width, WORD height);
 	void SavePosition();
 	void updateThreadLabel(bool clear);
@@ -47,7 +49,9 @@ public:
 	CDisasm(HINSTANCE _hInstance, HWND _hParent, DebugInterface *cpu);
 	~CDisasm();
 
-	virtual void Update() {
+	void Show(bool bShow) override;
+
+	void Update() override {
 		UpdateDialog(true);
 		SetDebugMode(Core_IsStepping(), false);
 		breakpointList->reloadBreakpoints();

--- a/Windows/Debugger/Debugger_Lists.cpp
+++ b/Windows/Debugger/Debugger_Lists.cpp
@@ -10,8 +10,6 @@
 #include "../../Core/HLE/sceKernelThread.h"
 #include "util/text/utf8.h"
 
-static const int numCPUs = 1;
-
 enum { TL_NAME, TL_PROGRAMCOUNTER, TL_ENTRYPOINT, TL_PRIORITY, TL_STATE, TL_WAITTYPE, TL_COLUMNCOUNT };
 enum { BPL_ENABLED, BPL_TYPE, BPL_OFFSET, BPL_SIZELABEL, BPL_OPCODE, BPL_CONDITION, BPL_HITS, BPL_COLUMNCOUNT };
 enum { SF_ENTRY, SF_ENTRYNAME, SF_CURPC, SF_CUROPCODE, SF_CURSP, SF_FRAMESIZE, SF_COLUMNCOUNT };
@@ -375,22 +373,18 @@ void CtrlBreakpointList::toggleEnabled(int itemIndex)
 void CtrlBreakpointList::gotoBreakpointAddress(int itemIndex)
 {
 	bool isMemory;
-	int index = getBreakpointIndex(itemIndex,isMemory);
-	if (index == -1) return;
+	int index = getBreakpointIndex(itemIndex, isMemory);
+	if (index == -1)
+		return;
 
-	if (isMemory)
-	{
+	if (isMemory) {
 		u32 address = displayedMemChecks_[index].start;
-			
-		for (int i=0; i<numCPUs; i++)
-			if (memoryWindow[i])
-				memoryWindow[i]->Goto(address);
+		if (memoryWindow)
+			memoryWindow->Goto(address);
 	} else {
 		u32 address = displayedBreakPoints_[index].addr;
-		
-		for (int i=0; i<numCPUs; i++)
-			if (disasmWindow[i])
-				disasmWindow[i]->Goto(address);
+		if (disasmWindow)
+			disasmWindow->Goto(address);
 	}
 }
 
@@ -413,8 +407,7 @@ void CtrlBreakpointList::removeBreakpoint(int itemIndex)
 int CtrlBreakpointList::getTotalBreakpointCount()
 {
 	int count = (int)CBreakPoints::GetMemChecks().size();
-	for (size_t i = 0; i < CBreakPoints::GetBreakpoints().size(); i++)
-	{
+	for (size_t i = 0; i < CBreakPoints::GetBreakpoints().size(); i++) {
 		if (!displayedBreakPoints_[i].temporary) count++;
 	}
 

--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -9,8 +9,6 @@
 
 #include <algorithm>
 
-static const int numCPUs = 1;
-
 const PTCHAR CtrlDisplayListView::windowClass = _T("CtrlDisplayListView");
 
 const int POPUP_SUBMENU_ID_DISPLAYLISTVIEW = 8;
@@ -308,9 +306,8 @@ void CtrlDisplayListView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 		switch(TrackPopupMenuEx(GetSubMenu(g_hPopupMenus,POPUP_SUBMENU_ID_DISPLAYLISTVIEW),TPM_RIGHTBUTTON|TPM_RETURNCMD,pt.x,pt.y,wnd,0))
 		{
 		case ID_DISASM_GOTOINMEMORYVIEW:
-			for (int i=0; i<numCPUs; i++)
-				if (memoryWindow[i])
-					memoryWindow[i]->Goto(curAddress);
+			if (memoryWindow)
+				memoryWindow->Goto(curAddress);
 			break;
 		case ID_DISASM_TOGGLEBREAKPOINT:
 			toggleBreakpoint();

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -536,23 +536,23 @@ namespace MainWindow
 	}
 
 	void CreateDebugWindows() {
-		disasmWindow[0] = new CDisasm(MainWindow::GetHInstance(), MainWindow::GetHWND(), currentDebugMIPS);
-		DialogManager::AddDlg(disasmWindow[0]);
-		disasmWindow[0]->Show(g_Config.bShowDebuggerOnLoad);
+		disasmWindow = new CDisasm(MainWindow::GetHInstance(), MainWindow::GetHWND(), currentDebugMIPS);
+		DialogManager::AddDlg(disasmWindow);
+		disasmWindow->Show(g_Config.bShowDebuggerOnLoad);
 
 #if PPSSPP_API(ANY_GL)
 		geDebuggerWindow = new CGEDebugger(MainWindow::GetHInstance(), MainWindow::GetHWND());
 		DialogManager::AddDlg(geDebuggerWindow);
 #endif
-		memoryWindow[0] = new CMemoryDlg(MainWindow::GetHInstance(), MainWindow::GetHWND(), currentDebugMIPS);
-		DialogManager::AddDlg(memoryWindow[0]);
+		memoryWindow = new CMemoryDlg(MainWindow::GetHInstance(), MainWindow::GetHWND(), currentDebugMIPS);
+		DialogManager::AddDlg(memoryWindow);
 	}
 
 	void DestroyDebugWindows() {
-		DialogManager::RemoveDlg(disasmWindow[0]);
-		if (disasmWindow[0])
-			delete disasmWindow[0];
-		disasmWindow[0] = 0;
+		DialogManager::RemoveDlg(disasmWindow);
+		if (disasmWindow)
+			delete disasmWindow;
+		disasmWindow = 0;
 
 #if PPSSPP_API(ANY_GL)
 		DialogManager::RemoveDlg(geDebuggerWindow);
@@ -561,10 +561,10 @@ namespace MainWindow
 		geDebuggerWindow = 0;
 #endif
 
-		DialogManager::RemoveDlg(memoryWindow[0]);
-		if (memoryWindow[0])
-			delete memoryWindow[0];
-		memoryWindow[0] = 0;
+		DialogManager::RemoveDlg(memoryWindow);
+		if (memoryWindow)
+			delete memoryWindow;
+		memoryWindow = 0;
 	}
 
 	LRESULT CALLBACK DisplayProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
@@ -678,10 +678,8 @@ namespace MainWindow
 			break;
 
 		case WM_TOUCH:
-			{
-				touchHandler.handleTouchEvent(hWnd, message, wParam, lParam);
-				return 0;
-			}
+			touchHandler.handleTouchEvent(hWnd, message, wParam, lParam);
+			return 0;
 
 		default:
 			return DefWindowProc(hWnd, message, wParam, lParam);
@@ -725,8 +723,8 @@ namespace MainWindow
 				}
 				if (!noFocusPause && g_Config.bPauseOnLostFocus && GetUIState() == UISTATE_INGAME) {
 					if (pause != Core_IsStepping()) {	// != is xor for bools
-						if (disasmWindow[0])
-							SendMessage(disasmWindow[0]->GetDlgHandle(), WM_COMMAND, IDC_STOPGO, 0);
+						if (disasmWindow)
+							SendMessage(disasmWindow->GetDlgHandle(), WM_COMMAND, IDC_STOPGO, 0);
 						else
 							Core_EnableStepping(pause);
 					}
@@ -928,13 +926,13 @@ namespace MainWindow
 			break;
 
 		case WM_USER + 1:
-			if (disasmWindow[0])
-				disasmWindow[0]->NotifyMapLoaded();
-			if (memoryWindow[0])
-				memoryWindow[0]->NotifyMapLoaded();
+			if (disasmWindow)
+				disasmWindow->NotifyMapLoaded();
+			if (memoryWindow)
+				memoryWindow->NotifyMapLoaded();
 
-			if (disasmWindow[0])
-				disasmWindow[0]->UpdateDialog();
+			if (disasmWindow)
+				disasmWindow->UpdateDialog();
 
 			SetForegroundWindow(hwndMain);
 			break;

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -51,7 +51,6 @@ extern bool g_ShaderNameListChanged;
 
 namespace MainWindow {
 	extern HINSTANCE hInst;
-	static const int numCPUs = 1;  // what?
 	extern bool noFocusPause;
 	static W32Util::AsyncBrowseDialog *browseDialog;
 	static W32Util::AsyncBrowseDialog *browseImageDialog;
@@ -586,16 +585,16 @@ namespace MainWindow {
 				// Causes hang
 				//NativeMessageReceived("run", "");
 
-				if (disasmWindow[0])
-					SendMessage(disasmWindow[0]->GetDlgHandle(), WM_COMMAND, IDC_STOPGO, 0);
+				if (disasmWindow)
+					SendMessage(disasmWindow->GetDlgHandle(), WM_COMMAND, IDC_STOPGO, 0);
 			} else if (Core_IsStepping()) { // It is paused, then continue to run.
-				if (disasmWindow[0])
-					SendMessage(disasmWindow[0]->GetDlgHandle(), WM_COMMAND, IDC_STOPGO, 0);
+				if (disasmWindow)
+					SendMessage(disasmWindow->GetDlgHandle(), WM_COMMAND, IDC_STOPGO, 0);
 				else
 					Core_EnableStepping(false);
 			} else {
-				if (disasmWindow[0])
-					SendMessage(disasmWindow[0]->GetDlgHandle(), WM_COMMAND, IDC_STOPGO, 0);
+				if (disasmWindow)
+					SendMessage(disasmWindow->GetDlgHandle(), WM_COMMAND, IDC_STOPGO, 0);
 				else
 					Core_EnableStepping(true);
 			}
@@ -854,11 +853,11 @@ namespace MainWindow {
 			if (W32Util::BrowseForFileName(true, hWnd, L"Load .ppmap", 0, L"Maps\0*.ppmap\0All files\0*.*\0\0", L"ppmap", fn)) {
 				g_symbolMap->LoadSymbolMap(fn.c_str());
 
-				if (disasmWindow[0])
-					disasmWindow[0]->NotifyMapLoaded();
+				if (disasmWindow)
+					disasmWindow->NotifyMapLoaded();
 
-				if (memoryWindow[0])
-					memoryWindow[0]->NotifyMapLoaded();
+				if (memoryWindow)
+					memoryWindow->NotifyMapLoaded();
 			}
 			break;
 
@@ -871,11 +870,11 @@ namespace MainWindow {
 			if (W32Util::BrowseForFileName(true, hWnd, L"Load .sym", 0, L"Symbols\0*.sym\0All files\0*.*\0\0", L"sym", fn)) {
 				g_symbolMap->LoadNocashSym(fn.c_str());
 
-				if (disasmWindow[0])
-					disasmWindow[0]->NotifyMapLoaded();
+				if (disasmWindow)
+					disasmWindow->NotifyMapLoaded();
 
-				if (memoryWindow[0])
-					memoryWindow[0]->NotifyMapLoaded();
+				if (memoryWindow)
+					memoryWindow->NotifyMapLoaded();
 			}
 			break;
 
@@ -887,18 +886,16 @@ namespace MainWindow {
 		case ID_DEBUG_RESETSYMBOLTABLE:
 			g_symbolMap->Clear();
 
-			for (int i = 0; i < numCPUs; i++)
-				if (disasmWindow[i])
-					disasmWindow[i]->NotifyMapLoaded();
+			if (disasmWindow)
+				disasmWindow->NotifyMapLoaded();
 
-			for (int i = 0; i < numCPUs; i++)
-				if (memoryWindow[i])
-					memoryWindow[i]->NotifyMapLoaded();
+			if (memoryWindow)
+				memoryWindow->NotifyMapLoaded();
 			break;
 
 		case ID_DEBUG_DISASSEMBLY:
-			if (disasmWindow[0])
-				disasmWindow[0]->Show(true);
+			if (disasmWindow)
+				disasmWindow->Show(true);
 			break;
 
 		case ID_DEBUG_GEDEBUGGER:
@@ -909,8 +906,8 @@ namespace MainWindow {
 			break;
 
 		case ID_DEBUG_MEMORYVIEW:
-			if (memoryWindow[0])
-				memoryWindow[0]->Show(true);
+			if (memoryWindow)
+				memoryWindow->Show(true);
 			break;
 
 		case ID_DEBUG_EXTRACTFILE:

--- a/Windows/W32Util/DialogManager.cpp
+++ b/Windows/W32Util/DialogManager.cpp
@@ -8,7 +8,7 @@ Dialog::Dialog(LPCSTR res, HINSTANCE _hInstance, HWND _hParent)
 {
 	m_hInstance = _hInstance;
 	m_hParent = _hParent;
-	m_hResource=res;
+	m_hResource = res;
 	m_bValid = true;
 	Create();
 }
@@ -32,11 +32,11 @@ void Dialog::Destroy()
 
 void Dialog::Show(bool _bShow)
 {
-	ShowWindow(m_hDlg, _bShow ? SW_NORMAL : SW_HIDE);
+	m_bShowState = _bShow ? SW_NORMAL : SW_HIDE;
+	ShowWindow(m_hDlg, m_bShowState);
 	if (_bShow)
 		BringWindowToTop(m_hDlg);
 }
-
 
 INT_PTR Dialog::DlgProcStatic(HWND hdlg, UINT message, WPARAM wParam, LPARAM lParam)
 {

--- a/Windows/W32Util/DialogManager.h
+++ b/Windows/W32Util/DialogManager.h
@@ -4,32 +4,31 @@
 
 class Dialog
 {
+public:
+	Dialog(LPCSTR res, HINSTANCE _hInstance, HWND _hParent);
+	virtual ~Dialog();
+
+	virtual void Show(bool _bShow);
+	virtual void Update() {}
+
+	HWND GetDlgHandle() {
+		return m_hDlg;
+	}
 protected:
-	HINSTANCE m_hInstance;
+	virtual void Create();
+	void Destroy();
+
 	HWND m_hParent;
 	HWND m_hDlg;
 	LPCSTR m_hResource;
 	bool m_bValid;
+	UINT m_bShowState = SW_HIDE;
 
-	virtual BOOL DlgProc(UINT message, WPARAM wParam, LPARAM lParam) 
-	{
-		MessageBox(0,L"WTF? Pure Call",0,0);	
-		return 0;
-	}
+	virtual BOOL DlgProc(UINT message, WPARAM wParam, LPARAM lParam) = 0;
 	static INT_PTR CALLBACK DlgProcStatic(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
-	virtual void Create();
-	void Destroy();
-public:
-	Dialog(LPCSTR res, HINSTANCE _hInstance, HWND _hParent);
-	virtual ~Dialog();
-	void Show(bool _bShow);
 
-	virtual void Update() {}
-
-	HWND GetDlgHandle()
-	{
-		return m_hDlg;
-	}
+private:
+	HINSTANCE m_hInstance;
 };
 
 

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -72,8 +72,6 @@
 #include "Windows/main.h"
 #include "UI/OnScreenDisplay.h"
 
-static const int numCPUs = 1;
-
 float g_mouseDeltaX = 0;
 float g_mouseDeltaY = 0;
 
@@ -201,21 +199,18 @@ void WindowsHost::UpdateUI() {
 }
 
 void WindowsHost::UpdateMemView() {
-	for (int i = 0; i < numCPUs; i++)
-		if (memoryWindow[i])
-			PostDialogMessage(memoryWindow[i], WM_DEB_UPDATE);
+	if (memoryWindow)
+		PostDialogMessage(memoryWindow, WM_DEB_UPDATE);
 }
 
 void WindowsHost::UpdateDisassembly() {
-	for (int i = 0; i < numCPUs; i++)
-		if (disasmWindow[i])
-			PostDialogMessage(disasmWindow[i], WM_DEB_UPDATE);
+	if (disasmWindow)
+		PostDialogMessage(disasmWindow, WM_DEB_UPDATE);
 }
 
 void WindowsHost::SetDebugMode(bool mode) {
-	for (int i = 0; i < numCPUs; i++)
-		if (disasmWindow[i])
-			PostDialogMessage(disasmWindow[i], WM_DEB_SETDEBUGLPARAM, 0, (LPARAM)mode);
+	if (disasmWindow)
+		PostDialogMessage(disasmWindow, WM_DEB_SETDEBUGLPARAM, 0, (LPARAM)mode);
 }
 
 void WindowsHost::PollControllers() {

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -88,11 +88,11 @@ extern "C" {
 	__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 }
 #if PPSSPP_API(ANY_GL)
-CGEDebugger* geDebuggerWindow = 0;
+CGEDebugger* geDebuggerWindow = nullptr;
 #endif
 
-CDisasm *disasmWindow[MAX_CPUCOUNT] = {0};
-CMemoryDlg *memoryWindow[MAX_CPUCOUNT] = {0};
+CDisasm *disasmWindow = nullptr;
+CMemoryDlg *memoryWindow = nullptr;
 
 static std::string langRegion;
 static std::string osName;
@@ -678,7 +678,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 			accel = hAccelTable;
 			break;
 		case WINDOW_CPUDEBUGGER:
-			wnd = disasmWindow[0] ? disasmWindow[0]->GetDlgHandle() : 0;
+			wnd = disasmWindow ? disasmWindow->GetDlgHandle() : 0;
 			accel = hDebugAccelTable;
 			break;
 		case WINDOW_GEDEBUGGER:

--- a/Windows/main.h
+++ b/Windows/main.h
@@ -22,10 +22,8 @@
 #include "Debugger/Debugger_MemoryDlg.h"
 #include "Common/CommonWindows.h"
 
-#define MAX_CPUCOUNT 1
-
-extern CDisasm *disasmWindow[MAX_CPUCOUNT];
-extern CMemoryDlg *memoryWindow[MAX_CPUCOUNT];
+extern CDisasm *disasmWindow;
+extern CMemoryDlg *memoryWindow;
 
 #if PPSSPP_API(ANY_GL)
 #include "Windows/GEDebugger/GEDebugger.h"


### PR DESCRIPTION
Especially in debug mode, filling the symbol listbox in the disasm window can take several seconds in large games - so don't do it until the user opens the disasm window.

Also does some general cleanup, and removes some unnecessary std::string use in the Vulkan memory allocator.