### PR TITLE
Don't cache time in a variable.

### DIFF
--- a/Common/TimeUtil.cpp
+++ b/Common/TimeUtil.cpp
@@ -24,7 +24,7 @@ LARGE_INTEGER frequency;
 double frequencyMult;
 LARGE_INTEGER startTime;
 
-double real_time_now() {
+double time_now_d() {
 	if (frequency.QuadPart == 0) {
 		QueryPerformanceFrequency(&frequency);
 		QueryPerformanceCounter(&startTime);
@@ -42,7 +42,7 @@ double real_time_now() {
 uint64_t _frequency = 0;
 uint64_t _starttime = 0;
 
-double real_time_now() {
+double time_now_d() {
 	static time_t start;
 	struct timeval tv;
 	gettimeofday(&tv, NULL);
@@ -54,18 +54,6 @@ double real_time_now() {
 }
 
 #endif
-
-void time_update() {
-	curtime = real_time_now();
-}
-
-double time_now_d() {
-	return curtime;
-}
-
-int time_now_ms() {
-	return int(curtime*1000.0);
-}
 
 void sleep_ms(int ms) {
 #ifdef _WIN32
@@ -79,7 +67,6 @@ void sleep_ms(int ms) {
 
 LoggingDeadline::LoggingDeadline(const char *name, int ms) : name_(name), endCalled_(false) {
 	totalTime_ = (double)ms * 0.001;
-	time_update();
 	endTime_ = time_now_d() + totalTime_;
 }
 
@@ -90,9 +77,9 @@ LoggingDeadline::~LoggingDeadline() {
 
 bool LoggingDeadline::End() {
 	endCalled_ = true;
-	time_update();
-	if (time_now_d() > endTime_) {
-		double late = (time_now_d() - endTime_);
+	double now = time_now_d();
+	if (now > endTime_) {
+		double late = (now - endTime_);
 		double totalTime = late + totalTime_;
 		ERROR_LOG(SYSTEM, "===== %0.2fms DEADLINE PASSED FOR %s at %0.2fms - %0.2fms late =====", totalTime_ * 1000.0, name_, 1000.0 * totalTime, 1000.0 * late);
 		return false;

--- a/Common/TimeUtil.h
+++ b/Common/TimeUtil.h
@@ -2,24 +2,11 @@
 
 // http://linux.die.net/man/3/clock_gettime
 
-// This time implementation caches the time for max performance (call time_now_d() as much as you like).
-// You need to call time_update() once per frame (or whenever you need the correct time right now).
-// Or you can use real_time_now() directly.
-
-void time_update();
-
 // Seconds.
 double time_now_d();
 
-// Uncached time. Slower than the above cached time functions. Does not update cached time, call time_update for that.
-double real_time_now();
-
-int time_now_ms();
-
-
 // Sleep. Does not necessarily have millisecond granularity, especially on Windows.
 void sleep_ms(int ms);
-
 
 // Can be sprinkled around the code to make sure that thing don't take
 // unexpectedly long. What that means is up to you.

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -218,12 +218,10 @@ void Core_RunLoop(GraphicsContext *ctx) {
 	while ((GetUIState() != UISTATE_INGAME || !PSP_IsInited()) && GetUIState() != UISTATE_EXIT) {
 		// In case it was pending, we're not in game anymore.  We won't get to Core_Run().
 		Core_StateProcessed();
-		time_update();
 		double startTime = time_now_d();
 		UpdateRunLoop();
 
 		// Simple throttling to not burn the GPU in the menu.
-		time_update();
 		double diffTime = time_now_d() - startTime;
 		int sleepTime = (int)(1000.0 / 60.0) - (int)(diffTime * 1000.0);
 		if (sleepTime > 0)
@@ -234,7 +232,6 @@ void Core_RunLoop(GraphicsContext *ctx) {
 	}
 
 	while ((coreState == CORE_RUNNING || coreState == CORE_STEPPING) && GetUIState() == UISTATE_INGAME) {
-		time_update();
 		UpdateRunLoop();
 		if (!windowHidden && !Core_IsStepping()) {
 			ctx->SwapBuffers();

--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -91,7 +91,7 @@ int PSPNetconfDialog::Init(u32 paramAddr) {
 	connResult = -1;
 	scanInfosAddr = 0;
 	scanStep = 0;
-	startTime = (u64)(real_time_now() * 1000000.0);
+	startTime = (u64)(time_now_d() * 1000000.0);
 
 	StartFade(true);
 	return 0;
@@ -252,7 +252,7 @@ int PSPNetconfDialog::Update(int animSpeed) {
 	UpdateButtons();
 	auto di = GetI18NCategory("Dialog");
 	auto err = GetI18NCategory("Error");
-	u64 now = (u64)(real_time_now() * 1000000.0);
+	u64 now = (u64)(time_now_d() * 1000000.0);
 	
 	// It seems JPCSP doesn't check for NETCONF_STATUS_APNET
 	if (request.netAction == NETCONF_CONNECT_APNET || request.netAction == NETCONF_STATUS_APNET || request.netAction == NETCONF_CONNECT_APNET_LAST) {

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -705,7 +705,6 @@ void CallSyscall(MIPSOpcode op)
 	PROFILE_THIS_SCOPE("syscall");
 	double start = 0.0;  // need to initialize to fix the race condition where coreCollectDebugStats is enabled in the middle of this func.
 	if (coreCollectDebugStats) {
-		time_update();
 		start = time_now_d();
 	}
 
@@ -729,7 +728,6 @@ void CallSyscall(MIPSOpcode op)
 	}
 
 	if (coreCollectDebugStats) {
-		time_update();
 		u32 callno = (op >> 6) & 0xFFFFF; //20 bits
 		int funcnum = callno & 0xFFF;
 		int modulenum = (callno & 0xFF000) >> 12;

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -578,7 +578,7 @@ void postAcceptAddSiblings(SceNetAdhocMatchingContext * context, int siblingcoun
 				sibling->state = PSP_ADHOC_MATCHING_PEER_CHILD;
 
 				// Initialize Ping Timer
-				sibling->lastping = CoreTiming::GetGlobalTimeUsScaled(); //real_time_now()*1000000.0;
+				sibling->lastping = CoreTiming::GetGlobalTimeUsScaled(); //time_now_d()*1000000.0;
 
 				// Link Peer
 				sibling->next = context->peerlist;
@@ -979,7 +979,7 @@ void handleTimeout(SceNetAdhocMatchingContext * context)
 		// Get Next Pointer (to avoid crash on memory freeing)
 		SceNetAdhocMatchingMemberInternal * next = peer->next;
 
-		u64_le now = CoreTiming::GetGlobalTimeUsScaled(); //real_time_now()*1000000.0
+		u64_le now = CoreTiming::GetGlobalTimeUsScaled(); //time_now_d()*1000000.0
 		// Timeout!
 		if (peer->state != 0 && (now - peer->lastping) > context->timeout) 
 		{
@@ -1343,7 +1343,7 @@ int friendFinder(){
 
 		if (networkInited) {
 			// Ping Server
-			now = real_time_now() * 1000000.0; // Use real_time_now()*1000000.0 instead of CoreTiming::GetGlobalTimeUsScaled() if the game gets disconnected from AdhocServer too soon when FPS wasn't stable
+			now = time_now_d() * 1000000.0; // Use time_now_d()*1000000.0 instead of CoreTiming::GetGlobalTimeUsScaled() if the game gets disconnected from AdhocServer too soon when FPS wasn't stable
 			// original code : ((sceKernelGetSystemTimeWide() - lastping) >= ADHOCCTL_PING_TIMEOUT)
 			if (now - lastping >= PSP_ADHOCCTL_PING_TIMEOUT) { // We may need to use lower interval to prevent getting timeout at Pro Adhoc Server through internet
 				// Prepare Packet
@@ -2078,9 +2078,9 @@ int initNetwork(SceNetAdhocctlAdhocId *adhoc_id){
 	errorcode = errno;
 
 	if (iResult == SOCKET_ERROR && errorcode != EISCONN) {
-		u64 startTime = (u64)(real_time_now() * 1000.0);
+		u64 startTime = (u64)(time_now_d() * 1000.0);
 		while (IsSocketReady(metasocket, false, true) <= 0) {
-			u64 now = (u64)(real_time_now() * 1000.0);
+			u64 now = (u64)(time_now_d() * 1000.0);
 			if (coreState == CORE_POWERDOWN) return iResult;
 			if (now - startTime > adhocDefaultTimeout) break;
 			sleep_ms(10);

--- a/Core/HW/StereoResampler.cpp
+++ b/Core/HW/StereoResampler.cpp
@@ -291,7 +291,7 @@ void StereoResampler::PushSamples(const s32 *samples, unsigned int numSamples) {
 }
 
 void StereoResampler::GetAudioDebugStats(char *buf, size_t bufSize) {
-	double elapsed = real_time_now() - startTime_;
+	double elapsed = time_now_d() - startTime_;
 
 	double effective_input_sample_rate = (double)inputSampleCount_ / elapsed;
 	double effective_output_sample_rate = (double)outputSampleCount_ / elapsed;
@@ -335,7 +335,7 @@ void StereoResampler::ResetStatCounters() {
 	overrunCountTotal_ = 0;
 	inputSampleCount_ = 0;
 	outputSampleCount_ = 0;
-	startTime_ = real_time_now();
+	startTime_ = time_now_d();
 }
 
 void StereoResampler::DoState(PointerWrap &p) {

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -924,13 +924,13 @@ skip:
 
 		// TODO: Load from cache file if available instead.
 
-		double st = real_time_now();
+		double st = time_now_d();
 		for (auto iter = functions.begin(), end = functions.end(); iter != end; iter++) {
 			const AnalyzedFunction &f = *iter;
 
 			PrecompileFunction(f.start, f.end - f.start + 4);
 		}
-		double et = real_time_now();
+		double et = time_now_d();
 
 		NOTICE_LOG(JIT, "Precompiled %d MIPS functions in %0.2f milliseconds", (int)functions.size(), (et - st) * 1000.0);
 	}

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -683,12 +683,12 @@ namespace SaveState
 			return;
 
 		// For fast-forwarding, otherwise they may be useless and too close.
-		time_update();
-		float diff = time_now_d() - rewindLastTime;
+		double now = time_now_d();
+		float diff = now - rewindLastTime;
 		if (diff < rewindMaxWallFrequency)
 			return;
 
-		rewindLastTime = time_now_d();
+		rewindLastTime = now;
 		DEBUG_LOG(BOOT, "saving rewind state");
 		rewindStates.Save();
 	}

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -257,11 +257,11 @@ static void ExecuteWebServer() {
 
 	g_Config.iRemoteISOPort = http->Port();
 	RegisterServer(http->Port());
-	double lastRegister = real_time_now();
+	double lastRegister = time_now_d();
 	while (RetrieveStatus() == ServerStatus::RUNNING) {
 		http->RunSlice(1.0);
 
-		double now = real_time_now();
+		double now = time_now_d();
 		if (now > lastRegister + 540.0) {
 			RegisterServer(http->Port());
 			lastRegister = now;

--- a/GPU/Common/TextureScalerCommon.cpp
+++ b/GPU/Common/TextureScalerCommon.cpp
@@ -542,7 +542,7 @@ void TextureScalerCommon::ScaleAlways(u32 *out, u32 *src, u32 &dstFmt, int &widt
 
 bool TextureScalerCommon::ScaleInto(u32 *outputBuf, u32 *src, u32 &dstFmt, int &width, int &height, int factor) {
 #ifdef SCALING_MEASURE_TIME
-	double t_start = real_time_now();
+	double t_start = time_now_d();
 #endif
 
 	bufInput.resize(width*height); // used to store the input image image if it needs to be reformatted
@@ -583,7 +583,7 @@ bool TextureScalerCommon::ScaleInto(u32 *outputBuf, u32 *src, u32 &dstFmt, int &
 
 #ifdef SCALING_MEASURE_TIME
 	if (width*height > 64 * 64 * factor*factor) {
-		double t = real_time_now() - t_start;
+		double t = time_now_d() - t_start;
 		NOTICE_LOG(G3D, "TextureScaler: processed %9d pixels in %6.5lf seconds. (%9.2lf Mpixels/second)",
 			width*height, t, (width*height) / (t * 1000 * 1000));
 	}

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -850,7 +850,6 @@ void ShaderManagerGLES::Load(const std::string &filename) {
 	if (header.magic != CACHE_HEADER_MAGIC || header.version != CACHE_VERSION || header.featureFlags != gstate_c.featureFlags) {
 		return;
 	}
-	time_update();
 	diskCachePending_.start = time_now_d();
 	diskCachePending_.Clear();
 
@@ -908,12 +907,12 @@ bool ShaderManagerGLES::ContinuePrecompile(float sliceTime) {
 
 	PSP_SetLoading("Compiling shaders...");
 
-	double start = real_time_now();
+	double start = time_now_d();
 	// Let's try to keep it under sliceTime if possible.
 	double end = start + sliceTime;
 
 	for (size_t &i = pending.vertPos; i < pending.vert.size(); i++) {
-		if (real_time_now() >= end) {
+		if (time_now_d() >= end) {
 			// We'll finish later.
 			return false;
 		}
@@ -943,7 +942,7 @@ bool ShaderManagerGLES::ContinuePrecompile(float sliceTime) {
 	}
 
 	for (size_t &i = pending.fragPos; i < pending.frag.size(); i++) {
-		if (real_time_now() >= end) {
+		if (time_now_d() >= end) {
 			// We'll finish later.
 			return false;
 		}
@@ -957,7 +956,7 @@ bool ShaderManagerGLES::ContinuePrecompile(float sliceTime) {
 	}
 
 	for (size_t &i = pending.linkPos; i < pending.link.size(); i++) {
-		if (real_time_now() >= end) {
+		if (time_now_d() >= end) {
 			// We'll finish later.
 			return false;
 		}
@@ -974,7 +973,6 @@ bool ShaderManagerGLES::ContinuePrecompile(float sliceTime) {
 	}
 
 	// Okay, finally done.  Time to report status.
-	time_update();
 	double finish = time_now_d();
 
 	NOTICE_LOG(G3D, "Precompile: Compiled and linked %d programs (%d vertex, %d fragment) in %0.1f milliseconds", (int)pending.link.size(), (int)pending.vert.size(), (int)pending.frag.size(), 1000 * (finish - pending.start));

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -928,7 +928,6 @@ u32 GPUCommon::Break(int mode) {
 
 void GPUCommon::NotifySteppingEnter() {
 	if (coreCollectDebugStats) {
-		time_update();
 		timeSteppingStarted_ = time_now_d();
 	}
 }
@@ -937,7 +936,6 @@ void GPUCommon::NotifySteppingExit() {
 		if (timeSteppingStarted_ <= 0.0) {
 			ERROR_LOG(G3D, "Mismatched stepping enter/exit.");
 		}
-		time_update();
 		timeSpentStepping_ += time_now_d() - timeSteppingStarted_;
 		timeSteppingStarted_ = 0.0;
 	}
@@ -947,7 +945,6 @@ bool GPUCommon::InterpretList(DisplayList &list) {
 	// Initialized to avoid a race condition with bShowDebugStats changing.
 	double start = 0.0;
 	if (coreCollectDebugStats) {
-		time_update();
 		start = time_now_d();
 	}
 
@@ -1012,7 +1009,6 @@ bool GPUCommon::InterpretList(DisplayList &list) {
 	list.offsetAddr = gstate_c.offsetAddr;
 
 	if (coreCollectDebugStats) {
-		time_update();
 		double total = time_now_d() - start - timeSpentStepping_;
 		hleSetSteppingTime(timeSpentStepping_);
 		timeSpentStepping_ = 0.0;

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -1122,7 +1122,6 @@ int main(int argc, char *argv[]) {
 		ToggleFullScreenIfFlagSet(window);
 
 		// Simple throttling to not burn the GPU in the menu.
-		time_update();
 		if (GetUIState() != UISTATE_INGAME || !PSP_IsInited() || renderThreadPaused) {
 			double diffTime = time_now_d() - startTime;
 			int sleepTime = (int)(1000.0 / 60.0) - (int)(diffTime * 1000.0);
@@ -1130,7 +1129,6 @@ int main(int argc, char *argv[]) {
 				sleep_ms(sleepTime);
 		}
 
-		time_update();
 		framecount++;
 	}
 

--- a/UI/BackgroundAudio.cpp
+++ b/UI/BackgroundAudio.cpp
@@ -311,8 +311,6 @@ void BackgroundAudio::Clear(bool hard) {
 }
 
 void BackgroundAudio::SetGame(const std::string &path) {
-	time_update();
-
 	std::lock_guard<std::mutex> lock(mutex_);
 	if (path == bgGamePath_) {
 		// Do nothing
@@ -332,8 +330,6 @@ void BackgroundAudio::SetGame(const std::string &path) {
 }
 
 int BackgroundAudio::Play() {
-	time_update();
-
 	std::lock_guard<std::mutex> lock(mutex_);
 
 	// Immediately stop the sound if it is turned off while playing.

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -427,12 +427,12 @@ void RemoteISOConnectScreen::update() {
 		break;
 
 	case ScanStatus::FAILED:
-		nextRetry_ = real_time_now() + 15.0;
+		nextRetry_ = time_now_d() + 15.0;
 		status_ = ScanStatus::RETRY_SCAN;
 		break;
 
 	case ScanStatus::RETRY_SCAN:
-		if (nextRetry_ < real_time_now()) {
+		if (nextRetry_ < time_now_d()) {
 			status_ = ScanStatus::SCANNING;
 			nextRetry_ = 0.0;
 

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -170,9 +170,7 @@ bool PPSSPP_UWPMain::Render() {
 		hasSetThreadName = true;
 	}
 
-	time_update();
 	auto context = m_deviceResources->GetD3DDeviceContext();
-
 
 	switch (m_deviceResources->ComputeDisplayRotation()) {
 	case DXGI_MODE_ROTATION_IDENTITY: g_display_rotation = DisplayRotation::ROTATE_0; break;

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -614,14 +614,14 @@ namespace MainWindow
 
 				// Simulate doubleclick, doesn't work with RawInput enabled
 				static double lastMouseDown;
-				double now = real_time_now();
+				double now = time_now_d();
 				if ((now - lastMouseDown) < 0.001 * GetDoubleClickTime()) {
 					if (!g_Config.bShowTouchControls && !g_Config.bMouseControl && GetUIState() == UISTATE_INGAME && g_Config.bFullscreenOnDoubleclick) {
 						SendToggleFullscreen(!g_Config.bFullScreen);
 					}
 					lastMouseDown = 0.0;
 				} else {
-					lastMouseDown = real_time_now();
+					lastMouseDown = time_now_d();
 				}
 			}
 			break;

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -864,7 +864,6 @@ void UpdateRunLoopAndroid(JNIEnv *env) {
 	NativeUpdate();
 
 	NativeRender(graphicsContext);
-	time_update();
 
 	std::lock_guard<std::mutex> guard(frameCommandLock);
 	if (!nativeActivity) {
@@ -1287,7 +1286,6 @@ extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(J
 			NativeUpdate();
 
 			NativeRender(graphicsContext);
-			time_update();
 
 			graphicsContext->SwapBuffers();
 

--- a/ext/native/profiler/profiler.cpp
+++ b/ext/native/profiler/profiler.cpp
@@ -140,7 +140,7 @@ int internal_profiler_enter(const char *category_name, int *out_thread_id) {
 
 	int &depth = profiler.depth[thread_id];
 	if (profiler.eventStart[thread_id][category] == 0.0f) {
-		double now = real_time_now();
+		double now = time_now_d();
 		int parent = profiler.parentCategory[thread_id][depth];
 		// Temporarily suspend the parent on entering a child.
 		if (parent != -1) {
@@ -170,7 +170,7 @@ void internal_profiler_leave(int thread_id, int category) {
 		return;
 	}
 
-	double now = real_time_now();
+	double now = time_now_d();
 
 	depth--;
 	_assert_msg_(depth >= 0, "Profiler enter/leave mismatch!");
@@ -191,7 +191,7 @@ void internal_profiler_leave(int thread_id, int category) {
 void internal_profiler_end_frame() {
 	int thread_id = internal_profiler_find_thread();
 	_assert_msg_(profiler.depth[thread_id] == 0, "Can't be inside a profiler scope at end of frame!");
-	profiler.curFrameStart = real_time_now();
+	profiler.curFrameStart = time_now_d();
 	profiler.historyPos++;
 	profiler.historyPos &= (HISTORY_SIZE - 1);
 	memset(&history[MAX_THREADS * profiler.historyPos], 0, sizeof(CategoryFrame) * MAX_THREADS);

--- a/ext/native/thin3d/VulkanQueueRunner.cpp
+++ b/ext/native/thin3d/VulkanQueueRunner.cpp
@@ -479,7 +479,7 @@ void VulkanQueueRunner::PreprocessSteps(std::vector<VKRStep *> &steps) {
 
 void VulkanQueueRunner::RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &steps, QueueProfileContext *profile) {
 	if (profile)
-		profile->cpuStartTime = real_time_now();
+		profile->cpuStartTime = time_now_d();
 
 	bool emitLabels = vulkan_->Extensions().EXT_debug_utils;
 	for (size_t i = 0; i < steps.size(); i++) {
@@ -528,7 +528,7 @@ void VulkanQueueRunner::RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &st
 	}
 
 	if (profile)
-		profile->cpuEndTime = real_time_now();
+		profile->cpuEndTime = time_now_d();
 }
 
 void VulkanQueueRunner::ApplyMGSHack(std::vector<VKRStep *> &steps) {

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -170,7 +170,6 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool 
 	if (autoCompare)
 		headlessHost->SetComparisonScreenshot(ExpectedScreenshotFromFilename(coreParameter.fileToStart));
 
-	time_update();
 	bool passed = true;
 	// TODO: We must have some kind of stack overflow or we're not following the ABI right.
 	// This gets trashed if it's not static.
@@ -194,7 +193,6 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool 
 			coreState = CORE_RUNNING;
 			headlessHost->SwapBuffers();
 		}
-		time_update();
 		if (time_now_d() > deadline) {
 			// Don't compare, print the output at least up to this point, and bail.
 			printf("%s", output.c_str());

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -249,7 +249,6 @@ static LocationHelper *locationHelper;
 		while (threadEnabled) {
 			NativeUpdate();
 			NativeRender(graphicsContext);
-			time_update();
 		}
 
 

--- a/unittest/JitHarness.cpp
+++ b/unittest/JitHarness.cpp
@@ -55,7 +55,7 @@ HLEFunction UnitTestFakeSyscalls[] = {
 double ExecCPUTest() {
 	int blockTicks = 1000000;
 	int total = 0;
-	double st = real_time_now();
+	double st = time_now_d();
 	do {
 		for (int j = 0; j < 1000; ++j) {
 			currentMIPS->pc = PSP_GetUserMemoryBase();
@@ -67,8 +67,8 @@ double ExecCPUTest() {
 			++total;
 		}
 	}
-	while (real_time_now() - st < 0.5);
-	double elapsed = real_time_now() - st;
+	while (time_now_d() - st < 0.5);
+	double elapsed = time_now_d() - st;
 
 	return total / elapsed;
 }

--- a/unittest/TestVertexJit.cpp
+++ b/unittest/TestVertexJit.cpp
@@ -86,14 +86,14 @@ public:
 		SetupExecute(vtype, useJit);
 
 		int total = 0;
-		double st = real_time_now();
+		double st = time_now_d();
 		do {
 			for (int j = 0; j < ROUNDS; ++j) {
 				dec_->DecodeVerts(dst_, src_, indexLowerBound_, indexUpperBound);
 				++total;
 			}
-		} while (real_time_now() - st < 0.5);
-		double elapsed = real_time_now() - st;
+		} while (time_now_d() - st < 0.5);
+		double elapsed = time_now_d() - st;
 
 		return total / elapsed;
 	}


### PR DESCRIPTION
A little weirdness in the code that has stuck around for a long, long time. `time_now_d` is now the same as the old `real_time_now`, which has been removed.

It's really not necessary and mostly just confusing. If calling time_now_d() is a bottleneck anywhere, that code should be fixed.