### PR TITLE
Fixed missing cstring include.

### DIFF
--- a/Common/FakeCPUDetect.cpp
+++ b/Common/FakeCPUDetect.cpp
@@ -15,8 +15,9 @@
 // Official SVN repository and contact information can be found at
 // http://code.google.com/p/dolphin-emu/
 
-#include <memory>
 #include <cstdint>
+#include <cstring>
+#include <memory>
 
 #include "Common.h"
 #include "CPUDetect.h"


### PR DESCRIPTION
This fixes cross compiling for x86_64 GCC 10.2 for me. I also sorted include order. 

```
/home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/recipe-sysroot-native/usr/bin/ccache /home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/recipe-sysroot-native/usr/bin/x86_64-poky-linux/x86_64-poky-linux-g++ -DGLEW_NO_GLU -DMINIUPNPC_SET_SOCKET_TIMEOUT -DMINIUPNP_STATICLIB -DSHARED_LIBZIP -DSHARED_ZLIB -DUSING_EGL -DUSING_GLES2 -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE=1 -D_POSIX_C_SOURCE=200112L -D_XOPEN_SOURCE=700 -D_XOPEN_SOURCE_EXTENDED -D__BSD_VISIBLE=1 -D__LIBRETRO__ -D__STDC_CONSTANT_MACROS -I/home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/git/ext/native -I/home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/git/ext/glslang -I/home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/git -I/home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/git/Common -I/home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/git/ext/cityhash -I/home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/git/ext/libpng17 -I/home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/git/ext/libkirk -I/home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/git/ext/sfmt19937 -I/home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/git/ext/xbrz -I/home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/git/ext/xxhash -I. -I/home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/git/ext/snappy/. -m64 -march=nehalem -mtune=generic -mfpmath=sse -msse4.2 -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/recipe-sysroot  -O3 -pipe -fcommon -D__LIBRETRO__ -fPIC -shared    -fvisibility-inlines-hidden  -m64 -march=nehalem -mtune=generic -mfpmath=sse -msse4.2 -fstack-protector-strong  -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security  --sysroot=/home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/recipe-sysroot -DNDEBUG -O3 -D_NDEBUG   -Wno-multichar -Wno-deprecated-register -Wno-tautological-pointer-compare -msse2 -Wno-psabi -fPIC -fPIC -include /home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/git/ppsspp_config.h -fno-strict-aliasing -std=gnu++11 -MD -MT CMakeFiles/Common.dir/Common/FakeCPUDetect.cpp.o -MF CMakeFiles/Common.dir/Common/FakeCPUDetect.cpp.o.d -o CMakeFiles/Common.dir/Common/FakeCPUDetect.cpp.o -c /home/dev/storage/SN750-1TB/embedded/yocto/master/retro-build-environment/build/tmp/work/corei7-64-poky-linux/ppsspp-libretro/2020+gitAUTOINC+ef08c0237f-r0/git/Common/FakeCPUDetect.cpp
| ../git/Common/FakeCPUDetect.cpp: In member function 'void CPUInfo::Detect()':
| ../git/Common/FakeCPUDetect.cpp:34:2: error: 'memset' was not declared in this scope
|    34 |  memset(this, 0, sizeof(*this));
|       |  ^~~~~~
| ../git/Common/FakeCPUDetect.cpp:24:1: note: 'memset' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
|    23 | #include "StringUtils.h"
|   +++ |+#include <cstring>
|    24 |
| ../git/Common/FakeCPUDetect.cpp:36:2: error: 'strcpy' was not declared in this scope
|    36 |  strcpy(cpu_string, "Unknown");
|       |  ^~~~~~
| ../git/Common/FakeCPUDetect.cpp:36:2: note: 'strcpy' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
| At global scope:
| cc1plus: note: unrecognized command-line option '-Wno-tautological-pointer-compare' may have been intended to silence earlier diagnostics
| cc1plus: note: unrecognized command-line option '-Wno-deprecated-register' may have been intended to silence earlier diagnostics
```

Signed-off-by: Bartłomiej Burdukiewicz <bartlomiej.burdukiewicz@gmail.com>

