### PR TITLE
Add compat.ini setting to work around memstick size math problem in Harry Potter - Goblet of Fire

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -70,6 +70,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "MoreAccurateVMMUL", &flags_.MoreAccurateVMMUL);
 	CheckSetting(iniFile, gameID, "ForceSoftwareRenderer", &flags_.ForceSoftwareRenderer);
 	CheckSetting(iniFile, gameID, "DarkStalkersPresentHack", &flags_.DarkStalkersPresentHack);
+	CheckSetting(iniFile, gameID, "ReportSmallMemstick", &flags_.ReportSmallMemstick);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -68,6 +68,7 @@ struct CompatFlags {
 	bool MoreAccurateVMMUL;
 	bool ForceSoftwareRenderer;
 	bool DarkStalkersPresentHack;
+	bool ReportSmallMemstick;
 };
 
 class IniFile;

--- a/Core/HW/MemoryStick.cpp
+++ b/Core/HW/MemoryStick.cpp
@@ -1,6 +1,24 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"
 #include "Core/CoreTiming.h"
+#include "Core/Compatibility.h"
 #include "Core/FileSystems/MetaFileSystem.h"
 #include "Core/HW/MemoryStick.h"
 #include "Core/System.h"
@@ -8,26 +26,31 @@
 // MS and FatMS states.
 static MemStickState memStickState;
 static MemStickFatState memStickFatState;
-static u64 memStickSize;
 static bool memStickNeedsAssign = false;
 static u64 memStickInsertedAt = 0;
 
+const u64 normalMemstickSize = 9ULL * 1024 * 1024 * 1024;
+const u64 smallMemstickSize = 1ULL * 1024 * 1024 * 1024;
+
 void MemoryStick_DoState(PointerWrap &p) {
-	auto s = p.Section("MemoryStick", 1, 3);
+	auto s = p.Section("MemoryStick", 1, 4);
 	if (!s)
 		return;
 
 	Do(p, memStickState);
 	Do(p, memStickFatState);
-	if (s >= 2)
+	if (s >= 4) {
+		// Do nothing.
+	} else if (s >= 2) {
+		// Really no point in storing the memstick size.
+		u64 memStickSize = normalMemstickSize;
 		Do(p, memStickSize);
-	else
-		memStickSize = 1ULL * 1024 * 1024 * 1024;
+	}
+
 	if (s >= 3) {
 		Do(p, memStickNeedsAssign);
 		Do(p, memStickInsertedAt);
 	}
-
 }
 
 MemStickState MemoryStick_State() {
@@ -49,6 +72,11 @@ u64 MemoryStick_SectorSize() {
 
 u64 MemoryStick_FreeSpace() {
 	u64 freeSpace = pspFileSystem.FreeSpace("ms0:/");
+
+	// Cap the memory stick size to avoid math errors when old games get sizes that were
+	// hard to imagine back then.
+	// We have a compat setting to make it even smaller for Harry Potter : Goblet of Fire, see #13266.
+	const u64 memStickSize = PSP_CoreParameter().compat.flags().ReportSmallMemstick ? smallMemstickSize : normalMemstickSize;
 	if (freeSpace < memStickSize)
 		return freeSpace;
 	return memStickSize;
@@ -84,9 +112,5 @@ void MemoryStick_Init() {
 		memStickFatState = PSP_FAT_MEMORYSTICK_STATE_UNASSIGNED;
 	}
 
-	// Harry Potter and the Goblet of Fire has a bug where it can't handle certain amounts
-	// of free space due to incorrect 32-bit math.
-	// We use 9GB here, which does not trigger the bug, as a cap for the max free space.
-	memStickSize = 9ULL * 1024 * 1024 * 1024; // 9GB
 	memStickNeedsAssign = false;
 }

--- a/Core/HW/MemoryStick.h
+++ b/Core/HW/MemoryStick.h
@@ -1,3 +1,20 @@
+// Copyright (c) 2012- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
 #pragma once
 
 #include "Common/CommonTypes.h"

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -767,3 +767,8 @@ ULJM05005 = true
 ULES00016 = true
 ULUS10005 = true
 ULJM05005 = true
+
+[ReportSmallMemStick]
+# Harry Potter and the Goblet of Fire - issue #13266
+ULUS10032 = true
+ULES00210 = true

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -772,3 +772,10 @@ ULJM05005 = true
 # Harry Potter and the Goblet of Fire - issue #13266
 ULUS10032 = true
 ULES00210 = true
+# Street Fighter Alpha 3 MAX - issue #10462
+ULJM05082 = true
+ULUS10062 = true
+ULES00235 = true
+ULJM05225 = true
+CPCS01043 = true
+ULUS10062 = true


### PR DESCRIPTION
Fixes issue #13266.

Should we raise the "normal" cap?