### PR TITLE
Vulkan: Automatically generate mipmaps for replaced/scaled textures

### DIFF
--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -600,34 +600,6 @@ void ReplacedTexture::Load(int level, void *out, int rowPitch) {
 
 	const ReplacedTextureLevel &info = levels_[level];
 
-#ifdef USING_QT_UI
-	QImage image(info.file.c_str(), "PNG");
-	if (image.isNull()) {
-		ERROR_LOG(G3D, "Could not load texture replacement info: %s", info.file.c_str());
-		return;
-	}
-
-	image = image.convertToFormat(QImage::Format_ARGB32);
-	bool alphaFull = true;
-	for (int y = 0; y < image.height(); ++y) {
-		const QRgb *src = (const QRgb *)image.constScanLine(y);
-		uint8_t *outLine = (uint8_t *)out + y * rowPitch;
-		for (int x = 0; x < image.width(); ++x) {
-			outLine[x * 4 + 0] = qRed(src[x]);
-			outLine[x * 4 + 1] = qGreen(src[x]);
-			outLine[x * 4 + 2] = qBlue(src[x]);
-			outLine[x * 4 + 3] = qAlpha(src[x]);
-			// We're already scanning each pixel...
-			if (qAlpha(src[x]) != 255) {
-				alphaFull = false;
-			}
-		}
-	}
-
-	if (level == 0 || !alphaFull) {
-		alphaStatus_ = alphaFull ? ReplacedTextureAlpha::FULL : ReplacedTextureAlpha::UNKNOWN;
-	}
-#else
 	png_image png = {};
 	png.version = PNG_IMAGE_VERSION;
 
@@ -662,7 +634,6 @@ void ReplacedTexture::Load(int level, void *out, int rowPitch) {
 
 	fclose(fp);
 	png_image_free(&png);
-#endif
 }
 
 bool TextureReplacer::GenerateIni(const std::string &gameID, std::string *generatedFilename) {

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -15,16 +15,13 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#ifdef USING_QT_UI
-#include <QtGui/QImage>
-#else
 #include <png.h>
-#endif
 
 #include <algorithm>
 
-#include "Common/Data/Text/I18n.h"
 #include "ext/xxhash.h"
+
+#include "Common/Data/Text/I18n.h"
 #include "Common/Data/Format/IniFile.h"
 #include "Common/Data/Text/Parsers.h"
 #include "Common/ColorConv.h"
@@ -333,16 +330,6 @@ void TextureReplacer::PopulateReplacement(ReplacedTexture *result, u64 cachekey,
 		level.fmt = ReplacedTextureFormat::F_8888;
 		level.file = filename;
 
-#ifdef USING_QT_UI
-		QImage image(filename.c_str(), "PNG");
-		if (image.isNull()) {
-			ERROR_LOG(G3D, "Could not load texture replacement info: %s", filename.c_str());
-		} else {
-			level.w = (image.width() * w) / newW;
-			level.h = (image.height() * h) / newH;
-			good = true;
-		}
-#else
 		png_image png = {};
 		png.version = PNG_IMAGE_VERSION;
 		FILE *fp = File::OpenCFile(filename, "rb");
@@ -357,7 +344,6 @@ void TextureReplacer::PopulateReplacement(ReplacedTexture *result, u64 cachekey,
 		fclose(fp);
 
 		png_image_free(&png);
-#endif
 
 		if (good && i != 0) {
 			// Check that the mipmap size is correct.  Can't load mips of the wrong size.
@@ -377,7 +363,6 @@ void TextureReplacer::PopulateReplacement(ReplacedTexture *result, u64 cachekey,
 	result->alphaStatus_ = ReplacedTextureAlpha::UNKNOWN;
 }
 
-#ifndef USING_QT_UI
 static bool WriteTextureToPNG(png_imagep image, const std::string &filename, int convert_to_8bit, const void *buffer, png_int_32 row_stride, const void *colormap) {
 	FILE *fp = File::OpenCFile(filename, "wb");
 	if (!fp) {
@@ -395,7 +380,6 @@ static bool WriteTextureToPNG(png_imagep image, const std::string &filename, int
 		return false;
 	}
 }
-#endif
 
 void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &replacedInfo, const void *data, int pitch, int level, int w, int h) {
 	_assert_msg_(enabled_, "Replacement not enabled");
@@ -459,9 +443,6 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 		h = lookupH * replacedInfo.scaleFactor;
 	}
 
-#ifdef USING_QT_UI
-	ERROR_LOG(G3D, "Replacement texture saving not implemented for Qt");
-#else
 	if (replacedInfo.fmt != ReplacedTextureFormat::F_8888) {
 		saveBuf.resize((pitch * h) / sizeof(u16));
 		switch (replacedInfo.fmt) {
@@ -512,7 +493,6 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 	} else if (success) {
 		NOTICE_LOG(G3D, "Saving texture for replacement: %08x / %dx%d", replacedInfo.hash, w, h);
 	}
-#endif
 
 	// Remember that we've saved this for next time.
 	ReplacedTextureLevel saved;


### PR DESCRIPTION
Scaled textures always lack mipmaps (as we only scale the top layer) and replaced textures may lack them.

This generates as many mipmaps as the game had normally specified (later it may be an option to generate more). Mipmaps improve performance and image quality.

This implements it for Vulkan only. OpenGL already has this to some extent. 

Also deletes some useless special casing for png loading in Qt builds.