### PR TITLE
Workaround for ULJS00218 until a more correct VFPU sin/cos implementation can be found.

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -71,6 +71,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ForceSoftwareRenderer", &flags_.ForceSoftwareRenderer);
 	CheckSetting(iniFile, gameID, "DarkStalkersPresentHack", &flags_.DarkStalkersPresentHack);
 	CheckSetting(iniFile, gameID, "ReportSmallMemstick", &flags_.ReportSmallMemstick);
+	CheckSetting(iniFile, gameID, "UseOldSinCos", &flags_.UseOldSinCos);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -69,6 +69,7 @@ struct CompatFlags {
 	bool ForceSoftwareRenderer;
 	bool DarkStalkersPresentHack;
 	bool ReportSmallMemstick;
+	bool UseOldSinCos;
 };
 
 class IniFile;

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -624,14 +624,14 @@ namespace MIPSInt
 			case 16: d[i] = 1.0f / s[i]; break; //vrcp
 			case 17: d[i] = USE_VPFU_SQRT ? vfpu_rsqrt(s[i]) : 1.0f / sqrtf(s[i]); break; //vrsq
 				
-			case 18: { d[i] = vfpu_sin(s[i]); } break; //vsin
-			case 19: { d[i] = vfpu_cos(s[i]); } break; //vcos
+			case 18: { d[i] = vfpu_sin_checked(s[i]); } break; //vsin
+			case 19: { d[i] = vfpu_cos_checked(s[i]); } break; //vcos
 			case 20: d[i] = powf(2.0f, s[i]); break; //vexp2
 			case 21: d[i] = logf(s[i])/log(2.0f); break; //vlog2
 			case 22: d[i] = USE_VPFU_SQRT ? vfpu_sqrt(s[i])  : fabsf(sqrtf(s[i])); break; //vsqrt
 			case 23: d[i] = asinf(s[i]) / M_PI_2; break; //vasin
 			case 24: d[i] = -1.0f / s[i]; break; // vnrcp
-			case 26: { d[i] = -vfpu_sin(s[i]); } break; // vnsin
+			case 26: { d[i] = -vfpu_sin_checked(s[i]); } break; // vnsin
 			case 28: d[i] = 1.0f / powf(2.0, s[i]); break; // vrexp2
 			default:
 				_dbg_assert_msg_( false, "Invalid VV2Op op type %d", optype);
@@ -1589,8 +1589,8 @@ namespace MIPSInt
 			ApplyPrefixST(s, VFPURewritePrefix(VFPU_CTRL_SPREFIX, sprefixRemove, sprefixAdd), V_Single);
 
 			// Cosine ignores all prefixes, so take the original.
-			cosine = vfpu_cos(V(vs));
-			sine = vfpu_sin(s[0]);
+			cosine = vfpu_cos_checked(V(vs));
+			sine = vfpu_sin_checked(s[0]);
 
 			if (negSin)
 				sine = -sine;

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -63,6 +63,32 @@ inline float vfpu_cos(float angle) {
 	return cosf(angle);
 }
 
+inline float vfpu_sin_old(float angle) {
+	float checkAngle = angle - floorf(angle * 0.25f) * 4.f;
+	if (checkAngle == 0.0f || checkAngle == 2.0f) {
+		return 0.0f;
+	} else if (checkAngle == 1.0f) {
+		return 1.0f;
+	} else if (checkAngle == 3.0f) {
+		return -1.0f;
+	}
+	angle *= (float)M_PI_2;
+	return sinf(angle);
+}
+
+inline float vfpu_cos_old(float angle) {
+	float checkAngle = angle - floorf(angle * 0.25f) * 4.f;
+	if (checkAngle == 0.0f || checkAngle == 2.0f) {
+		return 0.0f;
+	} else if (checkAngle == 1.0f) {
+		return 1.0f;
+	} else if (checkAngle == 3.0f) {
+		return -1.0f;
+	}
+	angle *= (float)M_PI_2;
+	return cosf(angle);
+}
+
 inline float vfpu_asin(float angle) {
 	return asinf(angle) / M_PI_2;
 }

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -19,6 +19,7 @@
 #include <cmath>
 
 #include "Common/CommonTypes.h"
+#include "Core/Core.h"
 #include "Core/MIPS/MIPS.h"
 
 #define _VD (op & 0x7F)
@@ -87,6 +88,22 @@ inline float vfpu_cos_old(float angle) {
 	}
 	angle *= (float)M_PI_2;
 	return cosf(angle);
+}
+
+inline float vfpu_sin_checked(float angle) {
+	if (!PSP_CoreParameter().compat.flags().UseOldSinCos) {
+		return vfpu_sin(angle);
+	} else {
+		return vfpu_sin_old(angle);
+	}
+}
+
+inline float vfpu_cos_checked(float angle) {
+	if (!PSP_CoreParameter().compat.flags().UseOldSinCos) {
+		return vfpu_cos(angle);
+	} else {
+		return vfpu_cos_old(angle);
+	}
 }
 
 inline float vfpu_asin(float angle) {

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -2191,6 +2191,18 @@ void CosOnly(SinCosArg angle, float *output) {
 	output[1] = vfpu_cos(angle);
 }
 
+void SinOnlyOld(SinCosArg angle, float *output) {
+	output[0] = vfpu_sin_old(angle);
+}
+
+void NegSinOnlyOld(SinCosArg angle, float *output) {
+	output[0] = -vfpu_sin_old(angle);
+}
+
+void CosOnlyOld(SinCosArg angle, float *output) {
+	output[1] = vfpu_cos_old(angle);
+}
+
 void ASinScaled(SinCosArg angle, float *output) {
 	output[0] = vfpu_asin(angle);
 }
@@ -2389,11 +2401,11 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 			DIVSS(tempxregs[i], R(XMM0));
 			break;
 		case 18: // d[i] = sinf((float)M_PI_2 * s[i]); break; //vsin
-			trigCallHelper(&SinOnly, sregs[i]);
+			trigCallHelper(PSP_CoreParameter().compat.flags().UseOldSinCos ? &SinOnlyOld : &SinOnly, sregs[i]);
 			MOVSS(tempxregs[i], MIPSSTATE_VAR(sincostemp[0]));
 			break;
 		case 19: // d[i] = cosf((float)M_PI_2 * s[i]); break; //vcos
-			trigCallHelper(&CosOnly, sregs[i]);
+			trigCallHelper(PSP_CoreParameter().compat.flags().UseOldSinCos ? &CosOnlyOld : &CosOnly, sregs[i]);
 			MOVSS(tempxregs[i], MIPSSTATE_VAR(sincostemp[1]));
 			break;
 		case 20: // d[i] = powf(2.0f, s[i]); break; //vexp2
@@ -2419,7 +2431,7 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 			MOVSS(tempxregs[i], R(XMM0));
 			break;
 		case 26: // d[i] = -sinf((float)M_PI_2 * s[i]); break; // vnsin
-			trigCallHelper(&NegSinOnly, sregs[i]);
+			trigCallHelper(PSP_CoreParameter().compat.flags().UseOldSinCos ? &NegSinOnlyOld : &NegSinOnly, sregs[i]);
 			MOVSS(tempxregs[i], MIPSSTATE_VAR(sincostemp[0]));
 			break;
 		case 28: // d[i] = 1.0f / expf(s[i] * (float)M_LOG2E); break; // vrexp2

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -158,7 +158,7 @@ inline float Clampf(float val, float min, float max) {
 }
 
 inline float Signf(float val) {
-	return (0.0f < val) - (val < 0.0f);
+	return (float)((0.0f < val) - (val < 0.0f));
 }
 
 inline float LinearMapf(float val, float a0, float a1, float b0, float b1) {

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -779,3 +779,9 @@ ULES00235 = true
 ULJM05225 = true
 CPCS01043 = true
 ULUS10062 = true
+
+[UseOldSinCos]
+# Katekyō Hitman Reborn Battle Arena 2 - Player 2 side broken/reversed (issue #12900)
+# Game seem to be affected by some really small precision issue that falls out the right way
+# in the old code but not the "new" code, for some reason. Until it can be tested further.
+ULJS00218 = true


### PR DESCRIPTION
See issue #12900 for the broken game and rationale.

Basically we need a more accurate version of this function. This old one is probably actually slightly higher precision than what we're using now in other games.

JIT only for now.