### PR TITLE
Make --windowed available on all platform

### DIFF
--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -24,13 +24,6 @@ MainWindow::MainWindow(QWidget *parent, bool fullscreen) :
 	nextState(CORE_POWERDOWN),
 	lastUIState(UISTATE_MENU)
 {
-	QDesktopWidget *desktop = QApplication::desktop();
-	int screenNum = QProcessEnvironment::systemEnvironment().value("SDL_VIDEO_FULLSCREEN_HEAD", "0").toInt();
-
-	// Move window to the center of selected screen
-	QRect rect = desktop->screenGeometry(screenNum);
-	move((rect.width() - frameGeometry().width()) / 4, (rect.height() - frameGeometry().height()) / 4);
-
 	setWindowIcon(QIcon(qApp->applicationDirPath() + "/assets/icon_regular_72.png"));
 
 	SetGameTitle("");
@@ -63,6 +56,9 @@ void MainWindow::newFrame()
 
 		updateMenus();
 	}
+
+	if (g_Config.bFullScreen != isFullScreen())
+		SetFullScreen(g_Config.bFullScreen);
 
 	std::unique_lock<std::mutex> lock(msgMutex_);
 	while (!msgQueue_.empty()) {
@@ -112,9 +108,6 @@ void MainWindow::updateMenus()
 
 void MainWindow::bootDone()
 {
-	if (g_Config.bFullScreen != isFullScreen())
-		SetFullScreen(g_Config.bFullScreen);
-
 	if (nextState == CORE_RUNNING)
 		runAct();
 	updateMenus();
@@ -389,6 +382,13 @@ void MainWindow::SetFullScreen(bool fullscreen) {
 
 		if (GetUIState() == UISTATE_INGAME && QApplication::overrideCursor())
 			QApplication::restoreOverrideCursor();
+
+		QDesktopWidget *desktop = QApplication::desktop();
+		int screenNum = QProcessEnvironment::systemEnvironment().value("SDL_VIDEO_FULLSCREEN_HEAD", "0").toInt();
+
+		// Move window to the center of selected screen
+		QRect rect = desktop->screenGeometry(screenNum);
+		move((rect.width() - frameGeometry().width()) / 4, (rect.height() - frameGeometry().height()) / 4);
 	}
 }
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -595,8 +595,14 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 #endif
 				if (!strncmp(argv[i], "--pause-menu-exit", strlen("--pause-menu-exit")))
 					g_Config.bPauseMenuExitsEmulator = true;
-				if (!strcmp(argv[i], "--fullscreen"))
+				if (!strcmp(argv[i], "--fullscreen")) {
 					g_Config.bFullScreen = true;
+					System_SendMessage("toggle_fullscreen", "1");
+				}
+				if (!strcmp(argv[i], "--windowed")) {
+					g_Config.bFullScreen = false;
+					System_SendMessage("toggle_fullscreen", "0");
+				}
 				if (!strcmp(argv[i], "--touchscreentest"))
 					gotoTouchScreenTest = true;
 				if (!strcmp(argv[i], "--gamesettings"))

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -564,9 +564,6 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 				break;
 			}
 
-			if (wideArgs[i] == L"--windowed")
-				g_Config.bFullScreen = false;
-
 			if (wideArgs[i].find(gpuBackend) != std::wstring::npos && wideArgs[i].size() > gpuBackend.size()) {
 				const std::wstring restOfOption = wideArgs[i].substr(gpuBackend.size());
 


### PR DESCRIPTION
Fix #13170, the `--maximize` flag request is missing tho'

Also make sure to trigger resize message to avoid race at start (on my Windows PC wasn't working on first run).

Change Qt fullscreen logic a bit so it get applied even when you change it from "GameSettingUI" and to recenter the window when disabling fullscreen