### PR TITLE
Workaround for date bug in Car Jack Streets.

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -72,6 +72,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ForceSoftwareRenderer", &flags_.ForceSoftwareRenderer);
 	CheckSetting(iniFile, gameID, "DarkStalkersPresentHack", &flags_.DarkStalkersPresentHack);
 	CheckSetting(iniFile, gameID, "ReportSmallMemstick", &flags_.ReportSmallMemstick);
+	CheckSetting(iniFile, gameID, "DateLimited", &flags_.DateLimited);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -70,6 +70,7 @@ struct CompatFlags {
 	bool ForceSoftwareRenderer;
 	bool DarkStalkersPresentHack;
 	bool ReportSmallMemstick;
+	bool DateLimited;
 };
 
 class IniFile;

--- a/Core/HLE/sceKernelTime.cpp
+++ b/Core/HLE/sceKernelTime.cpp
@@ -32,6 +32,7 @@
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/HLE/sceRtc.h"
 #include "Core/MemMap.h"
+#include "Core/System.h"
 #include "StringUtils.h"
 
 // The time when the game started.
@@ -40,6 +41,14 @@ static time_t start_time;
 void __KernelTimeInit()
 {
 	time(&start_time);
+	if (PSP_CoreParameter().compat.flags().DateLimited) {
+		// Car Jack Streets(NPUZ00043) requires that the date cannot exceed a certain time.
+		// 2011 year makes it work fine.
+		tm *tm;
+		tm = localtime(&start_time);
+		tm->tm_year = 111;// 2011 year.
+		start_time = mktime(tm);
+	}
 }
 
 void __KernelTimeDoState(PointerWrap &p)

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -783,3 +783,7 @@ ULES00235 = true
 ULJM05225 = true
 CPCS01043 = true
 ULUS10062 = true
+
+[DateLimited]
+# Car Jack Streets - issue #12698
+NPUZ00043 = true


### PR DESCRIPTION
Fixes #12698. There is a date bug in that game, using a compat setting to work around for this seems a good choice.