### PR TITLE
VK: Track and accumulate pipeline flags for render passes.

### DIFF
--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -32,11 +32,19 @@ enum class VKRRenderCommand : uint8_t {
 	NUM_RENDER_COMMANDS,
 };
 
+enum PipelineFlags {
+	PIPELINE_FLAG_NONE = 0,
+	PIPELINE_FLAG_USES_LINES = (1 << 2),
+	PIPELINE_FLAG_USES_BLEND_CONSTANT = (1 << 3),
+	PIPELINE_FLAG_USES_DEPTH_STENCIL = (1 << 4),  // Reads or writes the depth buffer.
+};
+
 struct VkRenderData {
 	VKRRenderCommand cmd;
 	union {
 		struct {
 			VkPipeline pipeline;
+			PipelineFlags flags;
 		} pipeline;
 		struct {
 			VkPipelineLayout pipelineLayout;
@@ -143,6 +151,7 @@ struct VKRStep {
 			int numReads;
 			VkImageLayout finalColorLayout;
 			VkImageLayout finalDepthStencilLayout;
+			u32 pipelineFlags;
 		} render;
 		struct {
 			VKRFramebuffer *src;

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -104,11 +104,12 @@ public:
 	void CopyFramebuffer(VKRFramebuffer *src, VkRect2D srcRect, VKRFramebuffer *dst, VkOffset2D dstPos, VkImageAspectFlags aspectMask, const char *tag);
 	void BlitFramebuffer(VKRFramebuffer *src, VkRect2D srcRect, VKRFramebuffer *dst, VkRect2D dstRect, VkImageAspectFlags aspectMask, VkFilter filter, const char *tag);
 
-	void BindPipeline(VkPipeline pipeline) {
+	void BindPipeline(VkPipeline pipeline, PipelineFlags flags) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
 		_dbg_assert_(pipeline != VK_NULL_HANDLE);
 		VkRenderData data{ VKRRenderCommand::BIND_PIPELINE };
 		data.pipeline.pipeline = pipeline;
+		curPipelineFlags_ |= flags;
 		curRenderStep_->commands.push_back(data);
 	}
 
@@ -265,6 +266,8 @@ public:
 private:
 	bool InitBackbufferFramebuffers(int width, int height);
 	bool InitDepthStencilBuffer(VkCommandBuffer cmd);  // Used for non-buffered rendering.
+	void EndCurRenderStep();
+
 	void BeginSubmitFrame(int frame);
 	void EndSubmitFrame(int frame);
 	void Submit(int frame, bool triggerFence);
@@ -328,6 +331,8 @@ private:
 	VKRStep *curRenderStep_ = nullptr;
 	bool curStepHasViewport_ = false;
 	bool curStepHasScissor_ = false;
+	u32 curPipelineFlags_ = 0;
+
 	std::vector<VKRStep *> steps_;
 	bool splitSubmit_ = false;
 

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -839,7 +839,7 @@ void DrawEngineVulkan::DoFlush() {
 				lastRenderStepId_ = curRenderStepId;
 			}
 
-			renderManager->BindPipeline(pipeline->pipeline);
+			renderManager->BindPipeline(pipeline->pipeline, (PipelineFlags)pipeline->flags);
 			if (pipeline != lastPipeline_) {
 				if (lastPipeline_ && !(lastPipeline_->UsesBlendConstant() && pipeline->UsesBlendConstant())) {
 					gstate_c.Dirty(DIRTY_BLEND_STATE);
@@ -964,7 +964,7 @@ void DrawEngineVulkan::DoFlush() {
 					lastRenderStepId_ = curRenderStepId;
 				}
 
-				renderManager->BindPipeline(pipeline->pipeline);
+				renderManager->BindPipeline(pipeline->pipeline, (PipelineFlags)pipeline->flags);
 				if (pipeline != lastPipeline_) {
 					if (lastPipeline_ && !lastPipeline_->UsesBlendConstant() && pipeline->UsesBlendConstant()) {
 						gstate_c.Dirty(DIRTY_BLEND_STATE);

--- a/GPU/Vulkan/FramebufferManagerVulkan.cpp
+++ b/GPU/Vulkan/FramebufferManagerVulkan.cpp
@@ -225,7 +225,7 @@ void FramebufferManagerVulkan::DrawActiveTexture(float x, float y, float w, floa
 	VkDescriptorSet descSet = vulkan2D_->GetDescriptorSet(view, (flags & DRAWTEX_LINEAR) ? linearSampler_ : nearestSampler_, VK_NULL_HANDLE, VK_NULL_HANDLE);
 	VkBuffer vbuffer;
 	VkDeviceSize offset = push_->Push(vtx, sizeof(vtx), &vbuffer);
-	renderManager->BindPipeline(cur2DPipeline_);
+	renderManager->BindPipeline(cur2DPipeline_, (PipelineFlags)0);
 	renderManager->Draw(vulkan2D_->GetPipelineLayout(), descSet, 0, nullptr, vbuffer, offset, 4);
 }
 

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -25,6 +25,8 @@
 #include "GPU/Vulkan/VulkanUtil.h"
 #include "GPU/Vulkan/StateMappingVulkan.h"
 
+#include "GPU/Vulkan/VulkanQueueRunner.h"
+
 // PSP vertex format.
 enum class PspAttributeLocation {
 	POSITION = 0,
@@ -56,19 +58,14 @@ struct VulkanPipelineKey {
 	std::string GetDescription(DebugShaderStringType stringType) const;
 };
 
-enum PipelineFlags {
-	PIPELINE_FLAG_USES_LINES = (1 << 2),
-	PIPELINE_FLAG_USES_BLEND_CONSTANT = (1 << 3),
-};
-
 // Simply wraps a Vulkan pipeline, providing some metadata.
 struct VulkanPipeline {
 	VkPipeline pipeline;
 	int flags;  // PipelineFlags enum above.
 
-	// Convenience.
 	bool UsesBlendConstant() const { return (flags & PIPELINE_FLAG_USES_BLEND_CONSTANT) != 0; }
 	bool UsesLines() const { return (flags & PIPELINE_FLAG_USES_LINES) != 0; }
+	bool UsesDepthStencil() const { return (flags & PIPELINE_FLAG_USES_DEPTH_STENCIL) != 0; }
 };
 
 class VulkanContext;

--- a/GPU/Vulkan/StencilBufferVulkan.cpp
+++ b/GPU/Vulkan/StencilBufferVulkan.cpp
@@ -180,7 +180,7 @@ bool FramebufferManagerVulkan::NotifyStencilUpload(u32 addr, int size, StencilUp
 	}
 
 	VkPipeline pipeline = vulkan2D_->GetPipeline(rp, stencilVs_, stencilFs_, false, Vulkan2D::VK2DDepthStencilMode::STENCIL_REPLACE_ALWAYS);
-	renderManager->BindPipeline(pipeline);
+	renderManager->BindPipeline(pipeline, PIPELINE_FLAG_USES_DEPTH_STENCIL);
 	renderManager->SetViewport({ 0.0f, 0.0f, (float)w, (float)h, 0.0f, 1.0f });
 	renderManager->SetScissor({ { 0, 0, },{ (uint32_t)w, (uint32_t)h } });
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -635,7 +635,7 @@ void TextureCacheVulkan::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 
 		VkDescriptorSet descSet = vulkan2D_->GetDescriptorSet(fbo, samplerNearest_, clutTexture->GetImageView(), samplerNearest_);
 		VulkanRenderManager *renderManager = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
-		renderManager->BindPipeline(depalShader->pipeline);
+		renderManager->BindPipeline(depalShader->pipeline, (PipelineFlags)0);
 
 		if (depth) {
 			DepthScaleFactors scaleFactors = GetDepthScaleFactors();


### PR DESCRIPTION
Basically, lets us tell things like if the depth buffer is used at all during a render pass.

This doesn't do any optimizations by itself, but I want this in before I do some other stuff.

Could later allow us to save a lot of bandwidth on tiled renderers (mobile) by creating special render passes and pipelines that don't touch the depth buffer at all, for stuff like post processing and similar things that games do that don't need depth.