### PR TITLE
VK: Whenever safely possible, shrink the render area.

### DIFF
--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -152,6 +152,7 @@ struct VKRStep {
 			VkImageLayout finalColorLayout;
 			VkImageLayout finalDepthStencilLayout;
 			u32 pipelineFlags;
+			VkRect2D renderArea;
 		} render;
 		struct {
 			VKRFramebuffer *src;

--- a/GPU/Vulkan/DebugVisVulkan.cpp
+++ b/GPU/Vulkan/DebugVisVulkan.cpp
@@ -19,8 +19,8 @@
 #include "Common/GPU/thin3d.h"
 #include "Common/UI/Context.h"
 #include "Common/UI/View.h"
-#include "Common/System/System.h"
 #include "Common/System/Display.h"
+#include "Common/System/System.h"
 
 #include "DebugVisVulkan.h"
 #include "Common/GPU/Vulkan/VulkanMemory.h"
@@ -100,7 +100,7 @@ void DrawAllocatorVis(UIContext *ui, GPUInterface *gpu) {
 		iter->Release();
 }
 
-void DrawProfilerVis(UIContext *ui, GPUInterface *gpu) {
+void DrawGPUProfilerVis(UIContext *ui, GPUInterface *gpu) {
 	if (!gpu) {
 		return;
 	}

--- a/GPU/Vulkan/DebugVisVulkan.h
+++ b/GPU/Vulkan/DebugVisVulkan.h
@@ -24,4 +24,4 @@ class UIContext;
 
 // gpu MUST be an instance of GPU_Vulkan. If not, will definitely crash.
 void DrawAllocatorVis(UIContext *ui, GPUInterface *gpu);
-void DrawProfilerVis(UIContext *ui, GPUInterface *gpu);
+void DrawGPUProfilerVis(UIContext *ui, GPUInterface *gpu);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1574,7 +1574,7 @@ void EmuScreen::renderUI() {
 	}
 
 	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN && g_Config.bShowGpuProfile) {
-		DrawProfilerVis(ctx, gpu);
+		DrawGPUProfilerVis(ctx, gpu);
 	}
 
 #endif


### PR DESCRIPTION
When you begin a render pass you can specify the subarea of the render target you're going to render to.

We just set the render area to the union of the scissor rects used in a pass. Some games seem like they can benefit noticeably from this if the GPU driver actually makes use of this information, but it's not gonna be a big boost. Though it might indeed help some games on some mobile hardware, a little bit. Possibly #13464?