### PR TITLE
Fix "naturalA" - Natural Colors (no blur) - postprocessing shader

### DIFF
--- a/assets/shaders/defaultshaders.ini
+++ b/assets/shaders/defaultshaders.ini
@@ -17,7 +17,7 @@ Vertex=natural.vsh
 [NaturalA]
 Name=Natural Colors (No Blur)
 Fragment=naturalA.fsh
-Vertex=natural.vsh
+Vertex=naturalA.vsh
 [Vignette]
 Name=Vignette
 Author=Henrik

--- a/assets/shaders/naturalA.fsh
+++ b/assets/shaders/naturalA.fsh
@@ -1,6 +1,6 @@
-// Natural Vision Shader with removed blur.
+// Natural Vision Shader, modified to use in PPSSPP.
 
-// by ShadX (Modded by SimoneT and Leopard20)
+// by ShadX (Modded by SimoneT)
 // http://forums.ngemu.com/showthread.php?t=76098
 
 #ifdef GL_ES
@@ -9,10 +9,7 @@ precision mediump int;
 #endif
 
 uniform sampler2D sampler0;
-varying vec4 v_texcoord0;
-varying vec4 v_texcoord1;
-varying vec4 v_texcoord2;
-varying vec4 v_texcoord3;
+varying vec2 v_texcoord0;
 
 const mat3 RGBtoYIQ = mat3(0.299, 0.596, 0.212, 
                            0.587,-0.275,-0.523, 
@@ -28,7 +25,7 @@ void main()
 {
 vec3 c0,c1;
 
-c0 = texture2D(sampler0,v_texcoord0.xy).xyz;
+c0 = texture2D(sampler0,v_texcoord0).xyz;
 
 c1=RGBtoYIQ*c0;
 

--- a/assets/shaders/naturalA.vsh
+++ b/assets/shaders/naturalA.vsh
@@ -1,0 +1,12 @@
+uniform vec2 u_texelDelta;
+
+attribute vec4 a_position;
+attribute vec2 a_texcoord0;
+
+varying vec2 v_texcoord0;
+
+void main()
+{
+  gl_Position=a_position;
+  v_texcoord0=a_texcoord0;
+}

--- a/assets/shaders/naturalA.vsh
+++ b/assets/shaders/naturalA.vsh
@@ -1,5 +1,3 @@
-uniform vec2 u_texelDelta;
-
 attribute vec4 a_position;
 attribute vec2 a_texcoord0;
 


### PR DESCRIPTION
This fixes the shaking issue on Vulkan and OpenGL in: https://github.com/hrydgard/ppsspp/issues/13374
The issue with D3D9 still remains (it is not related to the PP shaders)