### PR TITLE
Io: Account for free space on the host device

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -72,6 +72,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ForceSoftwareRenderer", &flags_.ForceSoftwareRenderer);
 	CheckSetting(iniFile, gameID, "DarkStalkersPresentHack", &flags_.DarkStalkersPresentHack);
 	CheckSetting(iniFile, gameID, "ReportSmallMemstick", &flags_.ReportSmallMemstick);
+	CheckSetting(iniFile, gameID, "MemstickFixedFree", &flags_.MemstickFixedFree);
 	CheckSetting(iniFile, gameID, "DateLimited", &flags_.DateLimited);
 }
 

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -70,6 +70,7 @@ struct CompatFlags {
 	bool ForceSoftwareRenderer;
 	bool DarkStalkersPresentHack;
 	bool ReportSmallMemstick;
+	bool MemstickFixedFree;
 	bool DateLimited;
 };
 

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -621,8 +621,6 @@ static void __IoVblank() {
 }
 
 void __IoInit() {
-	MemoryStick_Init();
-
 	asyncNotifyEvent = CoreTiming::RegisterEvent("IoAsyncNotify", __IoAsyncNotify);
 	syncNotifyEvent = CoreTiming::RegisterEvent("IoSyncNotify", __IoSyncNotify);
 
@@ -663,6 +661,7 @@ void __IoInit() {
 
 	__KernelRegisterWaitTypeFuncs(WAITTYPE_ASYNCIO, __IoAsyncBeginCallback, __IoAsyncEndCallback);
 
+	MemoryStick_Init();
 	lastMemStickState = MemoryStick_State();
 	lastMemStickFatState = MemoryStick_FatState();
 	__DisplayListenVblank(__IoVblank);

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -784,6 +784,12 @@ ULJM05225 = true
 CPCS01043 = true
 ULUS10062 = true
 
+[MemstickFixedFree]
+ULJM05571 = true
+ULES01367 = true
+NPEH00029 = true
+ULUS10455 = true
+
 [DateLimited]
 # Car Jack Streets - issue #12698
 NPUZ00043 = true


### PR DESCRIPTION
See #13520.  If there's less free space on the actual device, return that instead of simulated free space based on usage.  This will tell games about the space problems properly.

Also changed the comment slightly - I'm pretty sure they released 2 GB memory sticks before that Harry Potter game was released.  I don't think it was an imagination problem, just a testing problem.

-[Unknown]