### PR TITLE
PsmfPlayer:The status will not be changed until the delay result is finished.

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -698,7 +698,7 @@ void __PsmfDoState(PointerWrap &p) {
 }
 
 void __PsmfPlayerDoState(PointerWrap &p) {
-	auto s = p.Section("scePsmfPlayer", 1, 2);
+	auto s = p.Section("scePsmfPlayer", 1, 3);
 	if (!s)
 		return;
 
@@ -706,6 +706,10 @@ void __PsmfPlayerDoState(PointerWrap &p) {
 	Do(p, videoPixelMode);
 	Do(p, videoLoopStatus);
 	if (s >= 2) {
+		if (s >= 3) {
+			Do(p, eventPsmfPlayerStatusChange);
+			CoreTiming::RestoreRegisterEvent(eventPsmfPlayerStatusChange, "PsmfPlayerStatusChangeEvent", &__PsmfPlayerStatusChange);
+		}
 		Do(p, psmfPlayerLibVersion);
 	} else {
 		// Assume the latest, which is what we were emulating before.


### PR DESCRIPTION
These funcs are done in a thread blocking way, and they change status and end delay after completing the func. Before, the status was changed too early. Should helps #11975.