### PR TITLE
Headless: Define consistent memstick size

### DIFF
--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -392,9 +392,12 @@ int main(int argc, const char* argv[])
 	g_Config.iSplineBezierQuality = 2;
 	g_Config.bHighQualityDepth = true;
 	g_Config.bMemStickInserted = true;
+	g_Config.iMemStickSizeGB = 16;
 	g_Config.bFragmentTestCache = true;
 	g_Config.bEnableWlan = true;
 	g_Config.sMACAddress = "12:34:56:78:9A:BC";
+	g_Config.iFirmwareVersion = PSP_DEFAULT_FIRMWARE;
+	g_Config.iPSPModel = PSP_MODEL_SLIM;
 
 #ifdef _WIN32
 	g_Config.internalDataDirectory = "";

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -352,7 +352,7 @@ void retro_init(void)
 
    g_Config.bEnableLogging = true;
    g_Config.iUnthrottleMode = (int)UnthrottleMode::CONTINUOUS;
-   g_Config.bMemStickInserted = PSP_MEMORYSTICK_STATE_INSERTED;
+   g_Config.bMemStickInserted = true;
    g_Config.iGlobalVolume = VOLUME_MAX - 1;
    g_Config.iAltSpeedVolume = -1;
    g_Config.bEnableSound = true;


### PR DESCRIPTION
Just to make sure tests are run consistently.  Similar to 2a6e4df.

-[Unknown]