### PR TITLE
SwitchUMD:Only update Switch UMD item of Windows menu instead of entire UI.

### DIFF
--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -515,17 +515,21 @@ bool getUMDReplacePermit() {
 
 static u32 sceUmdReplaceProhibit()
 {
-	UMDReplacePermit = false;
 	DEBUG_LOG(SCEIO,"sceUmdReplaceProhibit()");
-	host->UpdateUI();
+	if (UMDReplacePermit) {
+		UMDReplacePermit = false;
+		host->NotifySwitchUMDUpdated();
+	}
 	return 0;
 }
 
 static u32 sceUmdReplacePermit()
 {
-	UMDReplacePermit = true;
 	DEBUG_LOG(SCEIO,"sceUmdReplacePermit()");
-	host->UpdateUI();
+	if (!UMDReplacePermit) {
+		UMDReplacePermit = true;
+		host->NotifySwitchUMDUpdated();
+	}
 	return 0;
 }
 

--- a/Core/Host.h
+++ b/Core/Host.h
@@ -57,6 +57,8 @@ public:
 	virtual void NotifyUserMessage(const std::string &message, float duration = 1.0f, u32 color = 0x00FFFFFF, const char *id = nullptr) {}
 	virtual void SendUIMessage(const std::string &message, const std::string &value) {}
 
+	virtual void NotifySwitchUMDUpdated() {}
+
 	// Used for headless.
 	virtual bool ShouldSkipUI() { return false; }
 	virtual void SendDebugOutput(const std::string &output) {}

--- a/Qt/QtHost.h
+++ b/Qt/QtHost.h
@@ -92,6 +92,8 @@ public:
 		NativeMessageReceived(message.c_str(), value.c_str());
 	}
 
+	void NotifySwitchUMDUpdated() override {}
+
 private:
 	std::string SymbolMapFilename(std::string currentFilename);
 	MainWindow* mainWindow;

--- a/UI/HostTypes.h
+++ b/UI/HostTypes.h
@@ -53,4 +53,6 @@ public:
 	void SendUIMessage(const std::string &message, const std::string &value) override {
 		NativeMessageReceived(message.c_str(), value.c_str());
 	}
+
+	void NotifySwitchUMDUpdated() override {}
 };

--- a/UWP/UWPHost.h
+++ b/UWP/UWPHost.h
@@ -40,6 +40,8 @@ public:
 
 	void NotifyUserMessage(const std::string &message, float duration = 1.0f, u32 color = 0x00FFFFFF, const char *id = nullptr) override;
 
+	void NotifySwitchUMDUpdated() override {}
+
 	GraphicsContext *GetGraphicsContext() { return nullptr; }
 
 private:

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -970,6 +970,10 @@ namespace MainWindow
 			InputDevice::BeginPolling();
 			break;
 
+		case WM_USER_SWITCHUMD_UPDATED:
+			UpdateSwitchUMD();
+			break;
+
 		case WM_MENUSELECT:
 			// Called when a menu is opened. Also when an item is selected, but meh.
 			UpdateMenus(true);

--- a/Windows/MainWindow.h
+++ b/Windows/MainWindow.h
@@ -21,6 +21,7 @@ namespace MainWindow
 		WM_USER_BROWSE_BOOT_DONE = WM_USER + 104,
 		WM_USER_TOGGLE_FULLSCREEN = WM_USER + 105,
 		WM_USER_RESTART_EMUTHREAD = WM_USER + 106,
+		WM_USER_SWITCHUMD_UPDATED = WM_USER + 107
 	};
 
 	enum {
@@ -66,6 +67,7 @@ namespace MainWindow
 	void Close();
 	void UpdateMenus(bool isMenuSelect = false);
 	void UpdateCommands();
+	void UpdateSwitchUMD();
 	void SetWindowTitle(const wchar_t *title);
 	void Redraw();
 	HWND GetHWND();

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -1379,6 +1379,13 @@ namespace MainWindow {
 		TranslateMenuItem(menu, ID_TOGGLE_BREAK, L"\tF8", isPaused ? "Run" : "Break");
 	}
 
+	void UpdateSwitchUMD() {
+		HMENU menu = GetMenu(GetHWND());
+		GlobalUIState state = GetUIState();
+		UINT umdSwitchEnable = state == UISTATE_INGAME && getUMDReplacePermit() ? MF_ENABLED : MF_GRAYED;
+		EnableMenuItem(menu, ID_EMULATION_SWITCH_UMD, umdSwitchEnable);
+	}
+
 	// Message handler for about box.
 	LRESULT CALLBACK About(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam) {
 		switch (message) {

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -407,3 +407,7 @@ void WindowsHost::NotifyUserMessage(const std::string &message, float duration, 
 void WindowsHost::SendUIMessage(const std::string &message, const std::string &value) {
 	NativeMessageReceived(message.c_str(), value.c_str());
 }
+
+void WindowsHost::NotifySwitchUMDUpdated() {
+	PostMessage(mainWindow_, MainWindow::WM_USER_SWITCHUMD_UPDATED, 0, 0);
+}

--- a/Windows/WindowsHost.h
+++ b/Windows/WindowsHost.h
@@ -63,6 +63,8 @@ public:
 	void NotifyUserMessage(const std::string &message, float duration = 1.0f, u32 color = 0x00FFFFFF, const char *id = nullptr) override;
 	void SendUIMessage(const std::string &message, const std::string &value) override;
 
+	void NotifySwitchUMDUpdated() override;
+
 	GraphicsContext *GetGraphicsContext() { return gfx_; }
 
 private:

--- a/headless/StubHost.h
+++ b/headless/StubHost.h
@@ -72,6 +72,8 @@ public:
 
 	void SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h) override;
 
+	void NotifySwitchUMDUpdated() override {}
+
 	// Unique for HeadlessHost
 	virtual void SwapBuffers() {}
 


### PR DESCRIPTION
Fixes #13571. That game is calling `sceUmdReplaceProhibit` and `sceUmdReplacePermit` repeatedly. If update entire UI repeatedly, that will cause stuck.