### PR TITLE
Remove support for D3D11_level_9 

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -233,6 +233,9 @@ D3D11DrawContext::D3D11DrawContext(ID3D11Device *device, ID3D11DeviceContext *de
 		hWnd_(hWnd),
 		deviceList_(deviceList) {
 
+	// We no longer support Windows Phone.
+	_assert_(featureLevel_ >= D3D_FEATURE_LEVEL_9_3);
+
 	// Seems like a fair approximation...
 	caps_.dualSourceBlend = featureLevel_ >= D3D_FEATURE_LEVEL_10_0;
 	caps_.depthClampSupported = featureLevel_ >= D3D_FEATURE_LEVEL_10_0;

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -329,7 +329,6 @@ void GenerateDepalShader(char *buffer, GEBufferFormat pixelFormat, ShaderLanguag
 	case HLSL_DX9:
 		GenerateDepalShaderFloat(buffer, pixelFormat, language);
 		break;
-	case HLSL_D3D11_LEVEL9:
 	default:
 		_assert_msg_(false, "Depal shader language not supported: %d", (int)language);
 	}

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -372,7 +372,7 @@ Draw::Pipeline *PresentationCommon::CreatePipeline(std::vector<Draw::ShaderModul
 	Semantic pos = SEM_POSITION;
 	Semantic tc = SEM_TEXCOORD0;
 	// Shader translation marks these both as "TEXCOORDs" on HLSL...
-	if (postShader && (lang_ == HLSL_D3D11 || lang_ == HLSL_D3D11_LEVEL9 || lang_ == HLSL_DX9)) {
+	if (postShader && (lang_ == HLSL_D3D11 || lang_ == HLSL_DX9)) {
 		pos = SEM_TEXCOORD0;
 		tc = SEM_TEXCOORD1;
 	}
@@ -492,7 +492,6 @@ Draw::ShaderModule *PresentationCommon::CompileShaderModule(Draw::ShaderStage st
 		mappedLang = Draw::ShaderLanguage::HLSL_D3D9;
 		break;
 	case HLSL_D3D11:
-	case HLSL_D3D11_LEVEL9:
 		mappedLang = Draw::ShaderLanguage::HLSL_D3D11;
 		break;
 	default:

--- a/GPU/Common/ShaderCommon.h
+++ b/GPU/Common/ShaderCommon.h
@@ -30,7 +30,6 @@ enum ShaderLanguage {
 	GLSL_VULKAN,
 	HLSL_DX9,
 	HLSL_D3D11,
-	HLSL_D3D11_LEVEL9,
 };
 
 enum DebugShaderType {

--- a/GPU/D3D11/ShaderManagerD3D11.cpp
+++ b/GPU/D3D11/ShaderManagerD3D11.cpp
@@ -209,7 +209,7 @@ void ShaderManagerD3D11::GetShaders(int prim, u32 vertType, D3D11VertexShader **
 	if (vsIter == vsCache_.end()) {
 		// Vertex shader not in cache. Let's compile it.
 		std::string genErrorString;
-		GenerateVertexShaderHLSL(VSID, codeBuffer_, featureLevel_ <= D3D_FEATURE_LEVEL_9_3 ? HLSL_D3D11_LEVEL9 : HLSL_D3D11, &genErrorString);
+		GenerateVertexShaderHLSL(VSID, codeBuffer_, HLSL_D3D11, &genErrorString);
 		vs = new D3D11VertexShader(device_, featureLevel_, VSID, codeBuffer_, vertType, useHWTransform);
 		vsCache_[VSID] = vs;
 	} else {
@@ -222,7 +222,7 @@ void ShaderManagerD3D11::GetShaders(int prim, u32 vertType, D3D11VertexShader **
 	if (fsIter == fsCache_.end()) {
 		// Fragment shader not in cache. Let's compile it.
 		std::string genErrorString;
-		GenerateFragmentShaderHLSL(FSID, codeBuffer_, featureLevel_ <= D3D_FEATURE_LEVEL_9_3 ? HLSL_D3D11_LEVEL9 : HLSL_D3D11, &genErrorString);
+		GenerateFragmentShaderHLSL(FSID, codeBuffer_, HLSL_D3D11, &genErrorString);
 		fs = new D3D11FragmentShader(device_, featureLevel_, FSID, codeBuffer_, useHWTransform);
 		fsCache_[FSID] = fs;
 	} else {

--- a/GPU/Directx9/FragmentShaderGeneratorHLSL.cpp
+++ b/GPU/Directx9/FragmentShaderGeneratorHLSL.cpp
@@ -72,7 +72,6 @@ bool GenerateFragmentShaderHLSL(const FShaderID &id, char *buffer, ShaderLanguag
 		WRITE(p, "#define DISCARD clip(-1)\n");
 		break;
 	case ShaderLanguage::HLSL_D3D11:
-	case ShaderLanguage::HLSL_D3D11_LEVEL9:
 		WRITE(p, "#define DISCARD discard\n");
 		break;
 	}
@@ -156,7 +155,7 @@ bool GenerateFragmentShaderHLSL(const FShaderID &id, char *buffer, ShaderLanguag
 	if (enableFog) {
 		WRITE(p, "  float v_fogdepth: TEXCOORD1;\n");
 	}
-	if ((lang == HLSL_D3D11 || lang == HLSL_D3D11_LEVEL9) && ((replaceBlend == REPLACE_BLEND_COPY_FBO) || gstate_c.Supports(GPU_ROUND_FRAGMENT_DEPTH_TO_16BIT))) {
+	if (lang == HLSL_D3D11 && ((replaceBlend == REPLACE_BLEND_COPY_FBO) || gstate_c.Supports(GPU_ROUND_FRAGMENT_DEPTH_TO_16BIT))) {
 		WRITE(p, "  float4 pixelPos : SV_POSITION;\n");
 	}
 	WRITE(p, "};\n");
@@ -228,7 +227,7 @@ bool GenerateFragmentShaderHLSL(const FShaderID &id, char *buffer, ShaderLanguag
 				doTextureProjection = false;
 			}
 
-			if (lang == HLSL_D3D11 || lang == HLSL_D3D11_LEVEL9) {
+			if (lang == HLSL_D3D11) {
 				if (doTextureProjection) {
 					WRITE(p, "  float4 t = tex.Sample(samp, In.v_texcoord.xy / In.v_texcoord.z)%s;\n", bgraTexture ? ".bgra" : "");
 				} else {
@@ -393,7 +392,7 @@ bool GenerateFragmentShaderHLSL(const FShaderID &id, char *buffer, ShaderLanguag
 			WRITE(p, "  v.rgb = v.rgb * %s;\n", srcFactor);
 		}
 
-		if ((lang == HLSL_D3D11 || lang == HLSL_D3D11_LEVEL9) && replaceBlend == REPLACE_BLEND_COPY_FBO) {
+		if (lang == HLSL_D3D11 && replaceBlend == REPLACE_BLEND_COPY_FBO) {
 			WRITE(p, "  float4 destColor = fboTex.Load(int3((int)In.pixelPos.x, (int)In.pixelPos.y, 0));\n");
 
 			const char *srcFactor = nullptr;
@@ -539,7 +538,7 @@ bool GenerateFragmentShaderHLSL(const FShaderID &id, char *buffer, ShaderLanguag
 		WRITE(p, "  outfragment.depth = z;\n");
 	}
 
-	if (lang == HLSL_D3D11 || lang == HLSL_D3D11_LEVEL9) {
+	if (lang == HLSL_D3D11) {
 		if (stencilToAlpha == REPLACE_ALPHA_DUALSOURCE) {
 			WRITE(p, "  outfragment.target = float4(v.rgb, %s);\n", replacedAlpha.c_str());
 			WRITE(p, "  outfragment.target1 = float4(0.0, 0.0, 0.0, v.a);\n");

--- a/GPU/Directx9/VertexShaderGeneratorHLSL.cpp
+++ b/GPU/Directx9/VertexShaderGeneratorHLSL.cpp
@@ -266,7 +266,7 @@ bool GenerateVertexShaderHLSL(const VShaderID &id, char *buffer, ShaderLanguage 
 
 	// Hardware tessellation
 	if (doSpline || doBezier) {
-		if (lang == HLSL_D3D11 || lang == HLSL_D3D11_LEVEL9) {
+		if (lang == HLSL_D3D11) {
 			WRITE(p, "struct TessData {\n");
 			WRITE(p, "  float3 pos; float pad1;\n");
 			WRITE(p, "  float2 tex; float2 pad2;\n");
@@ -380,7 +380,7 @@ bool GenerateVertexShaderHLSL(const VShaderID &id, char *buffer, ShaderLanguage 
 		if (enableFog) {
 			WRITE(p, "  Out.v_fogdepth = In.position.w;\n");
 		}
-		if (lang == HLSL_D3D11 || lang == HLSL_D3D11_LEVEL9) {
+		if (lang == HLSL_D3D11) {
 			if (isModeThrough) {
 				WRITE(p, "  float4 outPos = mul(u_proj_through, float4(In.position.xyz, 1.0));\n");
 			} else {
@@ -428,7 +428,7 @@ bool GenerateVertexShaderHLSL(const VShaderID &id, char *buffer, ShaderLanguage 
 				"a_w2.x", "a_w2.y", "a_w2.z", "a_w2.w",
 			};
 
-			if (lang == HLSL_D3D11 || lang == HLSL_D3D11_LEVEL9) {
+			if (lang == HLSL_D3D11) {
 				if (numBoneWeights == 1)
 					WRITE(p, "  float4x3 skinMatrix = mul(In.a_w1, u_bone[0])");
 				else
@@ -470,7 +470,7 @@ bool GenerateVertexShaderHLSL(const VShaderID &id, char *buffer, ShaderLanguage 
 
 		WRITE(p, "  float4 viewPos = float4(mul(float4(worldpos, 1.0), u_view), 1.0);\n");
 
-		if (lang == HLSL_D3D11 || lang == HLSL_D3D11_LEVEL9) {
+		if (lang == HLSL_D3D11) {
 			// Final view and projection transforms.
 			if (gstate_c.Supports(GPU_ROUND_DEPTH_TO_16BIT)) {
 				WRITE(p, "  float4 outPos = depthRoundZVP(mul(u_proj, viewPos));\n");

--- a/Windows/GPU/D3D11Context.cpp
+++ b/Windows/GPU/D3D11Context.cpp
@@ -74,9 +74,6 @@ HRESULT D3D11Context::CreateTheDevice(IDXGIAdapter *adapter) {
 		D3D_FEATURE_LEVEL_11_0,
 		D3D_FEATURE_LEVEL_10_1,
 		D3D_FEATURE_LEVEL_10_0,
-		D3D_FEATURE_LEVEL_9_3,
-		D3D_FEATURE_LEVEL_9_2,
-		D3D_FEATURE_LEVEL_9_1,
 	};
 	const UINT numFeatureLevels = ARRAYSIZE(featureLevels);
 

--- a/libretro/LibretroD3D11Context.cpp
+++ b/libretro/LibretroD3D11Context.cpp
@@ -31,6 +31,12 @@ void LibretroD3D11Context::CreateDrawContext() {
 		return;
 	}
 
+   // Reject lower feature levels. We have D3D9 for these ancient GPUs.
+   if (d3d11_->featureLevel < D3D_FEATURE_LEVEL_10_0) {
+      ERROR_LOG(G3D, "D3D11 featureLevel not high enough - rejecting!\n");
+      return;
+   }
+
 	ptr_D3DCompile = d3d11_->D3DCompile;
 
 	ID3D11Device1 *device1 = nullptr;


### PR DESCRIPTION
Previously only really used for Windows Phone, I think, which hereby is no longer supported in any form (not that I have tested it in ages.

Can always fall back to D3D9, which is not going away anytime soon and still needs to be there. One less HLSL variant to care about.