### PR TITLE
When stops and unloads self module, make sure that the thread is properly deleted.

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -2362,7 +2362,7 @@ void __KernelReturnFromModuleFunc()
 		{
 			if (module->nm.status == MODULE_STATUS_UNLOADING) {
 				// TODO: Maybe should maintain the exitCode?
-				sceKernelDeleteThread(it->threadID);
+				sceKernelTerminateDeleteThread(it->threadID);
 			} else {
 				if (it->statusPtr != 0)
 					Memory::Write_U32(exitStatus, it->statusPtr);


### PR DESCRIPTION
Uses sceKernelTerminateDeleteThread instead of sceKernelDeleteThread here, or this will just return as `thread not dormant`.
Should help #13607.