### PR TITLE
Enable "masked memory" on iOS

### DIFF
--- a/Core/MIPS/ARM64/Arm64Asm.cpp
+++ b/Core/MIPS/ARM64/Arm64Asm.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "ppsspp_config.h"
+
 #if PPSSPP_ARCH(ARM64)
 
 #include "Common/Log.h"

--- a/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
+++ b/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
@@ -311,6 +311,7 @@ namespace MIPSComp {
 		case 40: //sb
 		case 41: //sh
 		case 43: //sw
+#ifndef MASKED_PSP_MEMORY
 			if (jo.cachePointers && g_Config.bFastMemory) {
 				// ARM has smaller load/store immediate displacements than MIPS, 12 bits - and some memory ops only have 8 bits.
 				int offsetRange = 0x3ff;
@@ -327,6 +328,7 @@ namespace MIPSComp {
 						gpr.MapReg(rt, load ? MAP_NOINIT : 0);
 						targetReg = gpr.R(rt);
 					}
+
 					switch (o) {
 					case 35: LDR(INDEX_UNSIGNED, targetReg, gpr.RPtr(rs), offset); break;
 					case 37: LDRH(INDEX_UNSIGNED, targetReg, gpr.RPtr(rs), offset); break;
@@ -342,6 +344,7 @@ namespace MIPSComp {
 					break;
 				}
 			}
+#endif
 
 			if (!load && gpr.IsImm(rt) && gpr.TryMapTempImm(rt) != INVALID_REG) {
 				// We're storing an immediate value, let's see if we can optimize rt.

--- a/Core/MIPS/ARM64/Arm64CompVFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompVFPU.cpp
@@ -358,7 +358,6 @@ namespace MIPSComp {
 						ADD(SCRATCH1_64, SCRATCH1_64, MEMBASEREG);
 					}
 				}
-
 				fp.STP(32, INDEX_SIGNED, fpr.V(vregs[0]), fpr.V(vregs[1]), SCRATCH1_64, 0);
 				fp.STP(32, INDEX_SIGNED, fpr.V(vregs[2]), fpr.V(vregs[3]), SCRATCH1_64, 8);
 

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -100,6 +100,10 @@ Arm64Jit::Arm64Jit(MIPSState *mips) : blocks(mips, this), gpr(mips, &js, &jo), f
 		jo.enablePointerify = false;
 	}
 
+#ifdef MASKED_PSP_MEMORY
+	jo.enablePointerify = false;
+#endif
+
 	logBlocks = 0;
 	dontLogBlocks = 0;
 	blocks.Init();

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -121,7 +121,7 @@ static MemoryView views[] =
 static const int num_views = sizeof(views) / sizeof(MemoryView);
 
 inline static bool CanIgnoreView(const MemoryView &view) {
-#if PPSSPP_ARCH(32BIT)
+#ifdef MASKED_PSP_MEMORY
 	// Basically, 32-bit platforms can ignore views that are masked out anyway.
 	return (view.flags & MV_MIRROR_PREVIOUS) && (view.virtual_address & ~MEMVIEW32_MASK) != 0;
 #else

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -84,7 +84,7 @@ extern u32 g_PSPModel;
 
 // UWP has such limited memory management that we need to mask
 // even in 64-bit mode. Also, when using the sanitizer, we need to mask as well.
-#if PPSSPP_ARCH(32BIT) || PPSSPP_PLATFORM(UWP) || USE_ADDRESS_SANITIZER
+#if PPSSPP_ARCH(32BIT) || PPSSPP_PLATFORM(UWP) || USE_ADDRESS_SANITIZER || PPSSPP_PLATFORM(IOS)
 #define MASKED_PSP_MEMORY
 #endif
 


### PR DESCRIPTION
Might, or might not, fix #13451 .

Just a theory I want to test...

(This emulates the PSP's memory mirrors (normal memory at 0x0xxxxxxx, uncached at 0x4xxxxxxx, but same data), by simply masking off the top bits of the address on every access, while normally, PPSSPP uses the operating system to set up memory mirrors. I suspect that is broken/disallowed on iOS 14).

Note: This is not tested on iOS.