### PR TITLE
Fix Android Studio 4.1 + Gradle Plugin 6.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.android.tools.build:gradle:4.1.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu May 28 22:53:27 CEST 2020
+#Sat Nov 07 00:43:49 ICT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip


### PR DESCRIPTION
Not for merging, because the Timestamp usually causes a conflict on people who already upgrade their project to the latest gradle.

Just to investigate if you guys still generate an APK using the latest Android Studio that failed to be installed while it worked fine on my build https://github.com/hrydgard/ppsspp/issues/13577

Here is the test APK (ARMv7) i build based on v1.10.3-1139 https://www.dropbox.com/s/yuvjcd63gw5k03b/PPSSPP_v1.10.3-1139_ARMv7.apk?dl=0
PS: If it failed to be installed, try uninstalling PPSSPP first, as i remembered it will refuse to install if signature were different.

PPS: This was the only uncommited changes i found after upgrading