### PR TITLE
Fix crash in sceusbmic on load old staus then save again

### DIFF
--- a/Core/HLE/sceUsbMic.cpp
+++ b/Core/HLE/sceUsbMic.cpp
@@ -133,7 +133,9 @@ void __UsbMicDoState(PointerWrap &p) {
 	Do(p, micState);
 	if (s > 1) {
 		Do(p, eventUsbMicAudioUpdate);
-		CoreTiming::RestoreRegisterEvent(eventUsbMicAudioUpdate, "UsbMicAudioUpdate", &__UsbMicAudioUpdate);
+		if (eventUsbMicAudioUpdate != -1) {
+			CoreTiming::RestoreRegisterEvent(eventUsbMicAudioUpdate, "UsbMicAudioUpdate", &__UsbMicAudioUpdate);
+		}
 	} else {
 		eventUsbMicAudioUpdate = -1;
 	}


### PR DESCRIPTION
Fix #13658 again
![1](https://user-images.githubusercontent.com/2177532/99172374-df25fc00-2744-11eb-923d-ebc4a3c010a3.png)

Can we directly add a check in the https://github.com/hrydgard/ppsspp/blob/master/Core/CoreTiming.cpp#L177 
for fix unknown problem ?