### PR TITLE
Ace Combat X/Joint Assault: Avoid slow readback for lens flare effect.

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -552,6 +552,24 @@ ULUS10249 = true
 ULES00637 = true
 ULKS46126 = true
 
+# Ace Combat X: Skies of Deception
+# Lens flare effect 
+ULUS10176 = true
+ULJS00086 = true
+UCKS45067 = true
+UCES00423 = true
+ULJS19018 = true
+
+# Ace Combat: Joint Assault 
+# Lens flare effect 
+ULJS00290 = true
+ULKS46254 = true
+ULUS10511 = true
+ULJS19057 = true
+NPJH50263 = true
+ULES01408 = true
+NPJH90123 = true
+
 [IntraVRAMBlockTransferAllowCreateFB]
 # Final Fantasy - Type 0
 NPJH50443 = true


### PR DESCRIPTION
Turns on the good old BlockTransferAllowCreateFB setting for these games, which allows PPSSPP to create a GPU surface instead of reading back to the CPU when a block transfer happens to memory where we didn't already have a framebuffer registered.

(I was able to confirm that there's a readback happening on the lens flare effect in #12870, slowing things down on some devices. This should eliminate that.)

(Yeah I know this is the type of change Unknown doesn't like because you don't know what else it will break in the game so someone will need to give the games some solid testing before we can safely merge... or we merge and wait for complaints. At least it's not an RPG so all scenes have one sun I guess... should be pretty uniform.).

@LunaMoo wanna try the Ace Combat games with this and see if there are no glitches?