### PR TITLE
Add temp chinese font support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,6 @@ PPSSPPDebug64.exe.manifest
 PPSSPPDebug.exe.manifest
 PPSSPPDebugARM64.exe.manifest
 PPSSPPDebugARM.exe.manifest
-assets/flash0
 UWP/icph
 UWP/Content/*
 !UWP/Content/.empty

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -98,6 +98,10 @@ struct FontRegistryEntry {
 static const FontRegistryEntry fontRegistry[] = {
 	// This was added for Chinese translations and is not normally loaded on a PSP.
 	{ 0x288, 0x288, 0x2000, 0x2000, 0, 0, FONT_FAMILY_SANS_SERIF, FONT_STYLE_DB, 0, FONT_LANGUAGE_CHINESE, 0, 1, "zh_gb.pgf", "FTT-NewRodin Pro DB", 0, 0, 1581700, 145844, true },
+	
+	// This is also added for Chinese translations and is not normally loaded on a PSP.	
+	{ 0x288, 0x288, 0x2000, 0x2000, 0, 0, FONT_FAMILY_SANS_SERIF, FONT_STYLE_DB, 0, FONT_LANGUAGE_CHINESE, 0, 1, "chn.pgf", "FTT-NewRodin Pro DB", 0, 0, 1581700, 145844 },
+
 	{ 0x288, 0x288, 0x2000, 0x2000, 0, 0, FONT_FAMILY_SANS_SERIF, FONT_STYLE_DB, 0, FONT_LANGUAGE_JAPANESE, 0, 1, "jpn0.pgf", "FTT-NewRodin Pro DB", 0, 0, 1581700, 145844 },
 	{ 0x288, 0x288, 0x2000, 0x2000, 0, 0, FONT_FAMILY_SANS_SERIF, FONT_STYLE_REGULAR, 0, FONT_LANGUAGE_LATIN, 0, 1, "ltn0.pgf", "FTT-NewRodin Pro Latin", 0, 0, 69108, 16680 },
 	{ 0x288, 0x288, 0x2000, 0x2000, 0, 0, FONT_FAMILY_SERIF, FONT_STYLE_REGULAR, 0, FONT_LANGUAGE_LATIN, 0, 1, "ltn1.pgf", "FTT-Matisse Pro Latin", 0, 0, 65124, 16920 },
@@ -1170,6 +1174,11 @@ static int sceFontFindOptimumFont(u32 libHandle, u32 fontStylePtr, u32 errorCode
 	}
 	if (nearestFont) {
 		optimumFont = nearestFont;
+	}
+	//Special chinese font support
+	if ((g_Config.iLanguage == 11) || (g_Config.iLanguage == 10)) {
+		if (optimumFont == internalFonts[2])
+			optimumFont = internalFonts[0];
 	}
 	if (optimumFont) {
 		*errorCode = 0;

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -1176,7 +1176,7 @@ static int sceFontFindOptimumFont(u32 libHandle, u32 fontStylePtr, u32 errorCode
 		optimumFont = nearestFont;
 	}
 	//Special chinese font support
-	if ((g_Config.iLanguage == 11) || (g_Config.iLanguage == 10)) {
+	if ((optimumFont) && (g_Config.iLanguage == 11) || (g_Config.iLanguage == 10)) {
 		if (optimumFont == internalFonts[2])
 			optimumFont = internalFonts[0];
 	}


### PR DESCRIPTION
Temp work around for #13652
We can wait until nassau-tk make chinese compatible 's jpn0.pdf

@shenweip What do you think ?
Do we also blacklist known game which need use nassau-tk's font ?
Qix++ (NPJH50199)
GUNDAM VS GUNDAM NEXT PLUS (NPJH50107)
Neon Genesis Evangelion 2 \Shinseiki Evangelion 2 (ULJS00064)