### PR TITLE
Guess at a fix for #13698 - sceKernelThreadGetExitStatus probably takes some cycles.

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -2335,7 +2335,7 @@ void __KernelReturnFromModuleFunc()
 
 	SceUID leftModuleID = __KernelGetCurThreadModuleId();
 	SceUID leftThreadID = __KernelGetCurThread();
-	int exitStatus = sceKernelGetThreadExitStatus(leftThreadID);
+	int exitStatus = __KernelGetThreadExitStatus(leftThreadID);
 
 	// Reschedule immediately (to leave the thread) and delete it and its stack.
 	__KernelReSchedule("returned from module");

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -48,6 +48,7 @@ int sceKernelGetThreadCurrentPriority();
 // Warning: will alter v0 in current MIPS state.
 int __KernelStartThread(SceUID threadToStartID, int argSize, u32 argBlockPtr, bool forceArgs = false);
 int __KernelStartThreadValidate(SceUID threadToStartID, int argSize, u32 argBlockPtr, bool forceArgs = false);
+int __KernelGetThreadExitStatus(SceUID threadID);
 int sceKernelStartThread(SceUID threadToStartID, int argSize, u32 argBlockPtr);
 u32 sceKernelSuspendDispatchThread();
 u32 sceKernelResumeDispatchThread(u32 suspended);


### PR DESCRIPTION
We could also just turn off the logging, but I think this might help enough.

Should help #13698 .