### PR TITLE
Add back the old implementation of vfpu_sin/cos/sincos.

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -75,6 +75,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "MemstickFixedFree", &flags_.MemstickFixedFree);
 	CheckSetting(iniFile, gameID, "DateLimited", &flags_.DateLimited);
 	CheckSetting(iniFile, gameID, "ReinterpretFramebuffers", &flags_.ReinterpretFramebuffers);
+	CheckSetting(iniFile, gameID, "DoublePrecisionSinCos", &flags_.DoublePrecisionSinCos);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -73,6 +73,7 @@ struct CompatFlags {
 	bool MemstickFixedFree;
 	bool DateLimited;
 	bool ReinterpretFramebuffers;
+	bool DoublePrecisionSinCos;
 };
 
 class IniFile;

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -895,3 +895,86 @@ float vfpu_rsqrt(float a) {
 
 	return val.f;
 }
+
+float vfpu_sin_single(float angle) {
+	angle -= floorf(angle * 0.25f) * 4.f;
+	if (angle == 0.0f || angle == 2.0f) {
+		return 0.0f;
+	} else if (angle == 1.0f) {
+		return 1.0f;
+	} else if (angle == 3.0f) {
+		return -1.0f;
+	}
+	angle *= (float)M_PI_2;
+	return sinf(angle);
+}
+
+float vfpu_cos_single(float angle) {
+	angle -= floorf(angle * 0.25f) * 4.f;
+	if (angle == 1.0f || angle == 3.0f) {
+		return 0.0f;
+	} else if (angle == 0.0f) {
+		return 1.0f;
+	} else if (angle == 2.0f) {
+		return -1.0f;
+	}
+	angle *= (float)M_PI_2;
+	return cosf(angle);
+}
+
+void vfpu_sincos_single(float angle, float &sine, float &cosine) {
+	angle -= floorf(angle * 0.25f) * 4.f;
+	if (angle == 0.0f) {
+		sine = 0.0f;
+		cosine = 1.0f;
+	} else if (angle == 1.0f) {
+		sine = 1.0f;
+		cosine = 0.0f;
+	} else if (angle == 2.0f) {
+		sine = 0.0f;
+		cosine = -1.0f;
+	} else if (angle == 3.0f) {
+		sine = -1.0f;
+		cosine = 0.0f;
+	} else {
+		angle *= (float)M_PI_2;
+#if defined(__linux__)
+		sincosf(angle, &sine, &cosine);
+#else
+		sine = sinf(angle);
+		cosine = cosf(angle);
+#endif
+	}
+}
+
+float vfpu_sin_double(float angle) {
+	return (float)sin((double)angle * M_PI_2);
+}
+
+float vfpu_cos_double(float angle) {
+	return (float)cos((double)angle * M_PI_2);
+}
+
+void vfpu_sincos_double(float angle_f, float &sine, float &cosine) {
+	double angle = (double)angle_f * M_PI_2;
+#if defined(__linux__)
+	double d_sine;
+	double d_cosine;
+	sincos(angle, &d_sine, &d_cosine);
+	sine = (float)d_sine;
+	cosine = (float)d_cosine;
+#else
+	sine = (float)sin(angle);
+	cosine = (float)cos(angle);
+#endif
+}
+
+float (*vfpu_sin)(float);
+float (*vfpu_cos)(float);
+void (*vfpu_sincos)(float, float&, float&);
+
+void InitVFPUSinCos(bool useDoublePrecision) {
+	vfpu_sin = useDoublePrecision ? vfpu_sin_double : vfpu_sin_single;
+	vfpu_cos = useDoublePrecision ? vfpu_cos_double : vfpu_cos_single;
+	vfpu_sincos = useDoublePrecision ? vfpu_sincos_double : vfpu_sincos_single;
+}

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -48,29 +48,58 @@ inline int Xpose(int v) {
 // Messing around with the modulo functions? try https://www.desmos.com/calculator.
 
 inline float vfpu_sin(float angle) {
-	return (float)sin((double)angle * M_PI_2);
+	angle -= floorf(angle * 0.25f) * 4.f;
+	if (angle == 0.0f || angle == 2.0f) {
+		return 0.0f;
+	} else if (angle == 1.0f) {
+		return 1.0f;
+	} else if (angle == 3.0f) {
+		return -1.0f;
+	}
+	angle *= (float)M_PI_2;
+	return sinf(angle);
 }
 
 inline float vfpu_cos(float angle) {
-	return (float)cos((double)angle * M_PI_2);
+	angle -= floorf(angle * 0.25f) * 4.f;
+	if (angle == 1.0f || angle == 3.0f) {
+		return 0.0f;
+	} else if (angle == 0.0f) {
+		return 1.0f;
+	} else if (angle == 2.0f) {
+		return -1.0f;
+	}
+	angle *= (float)M_PI_2;
+	return cosf(angle);
 }
 
 inline float vfpu_asin(float angle) {
 	return asinf(angle) / M_PI_2;
 }
 
-inline void vfpu_sincos(float angle_f, float &sine, float &cosine) {
-	double angle = (double)angle_f * M_PI_2;
+inline void vfpu_sincos(float angle, float &sine, float &cosine) {
+	angle -= floorf(angle * 0.25f) * 4.f;
+	if (angle == 0.0f) {
+		sine = 0.0f;
+		cosine = 1.0f;
+	} else if (angle == 1.0f) {
+		sine = 1.0f;
+		cosine = 0.0f;
+	} else if (angle == 2.0f) {
+		sine = 0.0f;
+		cosine = -1.0f;
+	} else if (angle == 3.0f) {
+		sine = -1.0f;
+		cosine = 0.0f;
+	} else {
+		angle *= (float)M_PI_2;
 #if defined(__linux__)
-	double d_sine;
-	double d_cosine;
-	sincos(angle, &d_sine, &d_cosine);
-	sine = (float)d_sine;
-	cosine = (float)d_cosine;
+		sincosf(angle, &sine, &cosine);
 #else
-	sine = (float)sin(angle);
-	cosine = (float)cos(angle);
+		sine = sinf(angle);
+		cosine = cosf(angle);
 #endif
+	}
 }
 
 inline float vfpu_clamp(float v, float min, float max) {

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -44,6 +44,7 @@
 #include "Core/HDRemaster.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSAnalyst.h"
+#include "Core/MIPS/MIPSVFPUUtils.h"
 #include "Core/Debugger/SymbolMap.h"
 #include "Core/Host.h"
 #include "Core/System.h"
@@ -66,7 +67,6 @@
 #include "Common/LogManager.h"
 #include "Common/ExceptionHandlerSetup.h"
 #include "Core/HLE/sceAudiocodec.h"
-
 #include "GPU/GPUState.h"
 #include "GPU/GPUInterface.h"
 #include "GPU/Debugger/RecordFormat.h"
@@ -286,6 +286,8 @@ bool CPU_Init() {
 	// Homebrew usually has an empty discID, and even if they do have a disc id, it's not
 	// likely to collide with any commercial ones.
 	coreParameter.compat.Load(discID);
+
+	InitVFPUSinCos(coreParameter.compat.flags().DoublePrecisionSinCos);
 
 	HLEPlugins::Init();
 	if (!Memory::Init()) {

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -808,3 +808,6 @@ ULKS46087 = true
 # ULJM05533 = true
 # NPJH50006 = true
 
+[DoublePrecisionSinCos]
+# Hitman Reborn Battle Arena 2 (#12900)
+ULJS00218 = true


### PR DESCRIPTION
I hate to do this, but here we go.

Reverts #13526 (#13705 (Cho Aniki Zero) and #13671 (Hajime no Ippo) broke), but keeps the new implementation too, specifically for Hitman Reborn Battle Arena 2, see #13605 (uses a compat.ini flag).

*Temporary measure* to avoid regressions in 1.11.

Hope to more accurately reverse engineer these operations in the future.
