### PR TITLE
Mpeg:Correctly handle stuffing data of pack header.

### DIFF
--- a/Core/HW/MpegDemux.cpp
+++ b/Core/HW/MpegDemux.cpp
@@ -182,6 +182,7 @@ bool MpegDemux::skipPackHeader() {
 		if (read8() != 0xFF) {
 			return false;
 		}
+		--stuffing;
 	}
 	return true;
 }


### PR DESCRIPTION
This seems to be a potential issue. Maybe just a mistake?