### PR TITLE
Enable color reinterpret for Ultimate Ghosts & Goblins

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -76,6 +76,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "DateLimited", &flags_.DateLimited);
 	CheckSetting(iniFile, gameID, "ReinterpretFramebuffers", &flags_.ReinterpretFramebuffers);
 	CheckSetting(iniFile, gameID, "DoublePrecisionSinCos", &flags_.DoublePrecisionSinCos);
+	CheckSetting(iniFile, gameID, "ShaderColorBitmask", &flags_.ShaderColorBitmask);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -74,6 +74,7 @@ struct CompatFlags {
 	bool DateLimited;
 	bool ReinterpretFramebuffers;
 	bool DoublePrecisionSinCos;
+	bool ShaderColorBitmask;
 };
 
 class IniFile;

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -531,6 +531,9 @@ void FramebufferManagerCommon::ReinterpretFramebufferFrom(VirtualFramebuffer *vf
 		if (oldFormat == GE_FORMAT_565) {
 			// We have to bind here instead of clear, since it can be that no framebuffer is bound.
 			// The backend can sometimes directly optimize it to a clear.
+			// TODO: Ultimate Ghosts and Goblins, if we don't enable reinterpret, long after this hits an assert
+			// in VKContext::BindFramebufferAsTexture indicating that we've fallen out of sync between
+			// VKContext::curFramebuffer and currentRenderVfb_. That's issue #13717.
 			draw_->BindFramebufferAsRenderTarget(vfb->fbo, { Draw::RPAction::CLEAR, Draw::RPAction::KEEP, Draw::RPAction::CLEAR }, "FakeReinterpret");
 			// Need to dirty anything that has command buffer dynamic state, in case we started a new pass above.
 			// Should find a way to feed that information back, maybe... Or simply correct the issue in the rendermanager.
@@ -1009,7 +1012,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput(bool reallyDirty) {
 	DownloadFramebufferOnSwitch(currentRenderVfb_);
 	shaderManager_->DirtyLastShader();
 
-	currentRenderVfb_ = 0;
+	currentRenderVfb_ = nullptr;
 
 	if (displayFramebufPtr_ == 0) {
 		if (Core_IsStepping())
@@ -1146,7 +1149,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput(bool reallyDirty) {
 }
 
 void FramebufferManagerCommon::DecimateFBOs() {
-	currentRenderVfb_ = 0;
+	currentRenderVfb_ = nullptr;
 
 	for (auto iter : fbosToDelete_) {
 		iter->Release();

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -959,7 +959,7 @@ void ApplyStencilReplaceAndLogicOpIgnoreBlend(ReplaceAlphaType replaceAlphaWithS
 bool IsColorWriteMaskComplex(bool allowFramebufferRead) {
 	// Restrict to Outrun temporarily (by uglily reusing the ReinterpretFramebuffers flag)
 	// This check must match the one in ConvertMaskState.
-	if (!allowFramebufferRead || !PSP_CoreParameter().compat.flags().ReinterpretFramebuffers) {
+	if (!allowFramebufferRead || !PSP_CoreParameter().compat.flags().ShaderColorBitmask) {
 		// Don't have a choice - we'll make do but it won't always be right.
 		return false;
 	}
@@ -999,9 +999,9 @@ void ConvertMaskState(GenericMaskState &maskState, bool allowFramebufferRead) {
 			break;
 		default:
 			if (allowFramebufferRead) {
-				// Instead of just 'true', restrict shader bitmasks to Outrun temporarily (by uglily reusing the ReinterpretFramebuffers flag)
+				// Instead of just 'true', restrict shader bitmasks to Outrun temporarily.
 				// TODO: This check must match the one in IsColorWriteMaskComplex.
-				maskState.applyFramebufferRead = PSP_CoreParameter().compat.flags().ReinterpretFramebuffers;
+				maskState.applyFramebufferRead = PSP_CoreParameter().compat.flags().ShaderColorBitmask;
 				maskState.rgba[i] = true;
 			} else {
 				// Use the old heuristic.

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -808,6 +808,18 @@ ULKS46087 = true
 # ULJM05533 = true
 # NPJH50006 = true
 
+# Ultimate Ghosts & Goblins
+ULJM05147 = true
+ULUS10105 = true
+ULES00419 = true
+NPJH50235 = true
+
+[ShaderColorBitmask]
+# Outrun 2006: Coast to Coast - issue #11358
+ULES00262 = true
+ULUS10064 = true
+ULKS46087 = true
+
 [DoublePrecisionSinCos]
 # Hitman Reborn Battle Arena 2 (#12900)
 ULJS00218 = true


### PR DESCRIPTION
The game uses it by accident probably, but whatever - it's a clean fix.

Fixes, but only for "modern" APIs, #13717.

There's something else lurking too.