### PR TITLE
sz must be longer than target string

### DIFF
--- a/Common/ArmCPUDetect.cpp
+++ b/Common/ArmCPUDetect.cpp
@@ -251,7 +251,7 @@ void CPUInfo::Detect()
 	isVFP4 = true;
 #endif
 #endif // PPSSPP_PLATFORM(IOS)
-	size_t sz;
+	size_t sz = 0x41; // char brand_string[0x41]
 	if (sysctlbyname("machdep.cpu.brand_string", brand_string, &sz, nullptr, 0) != 0) {
 		strcpy(brand_string, "Unknown");
 	}


### PR DESCRIPTION
I am not sure if it is necessary. sz (size_t type, aka unsigned long) will be a random value when it is not defined. Nevertheless, it is basically difficult (or impossible at all) to be smaller than the target string size. But once this happens, an error string will be returned. So just in case define it first.