### PR TITLE
Fixes for MIPSDetect and Logmanager.h

### DIFF
--- a/Common/LogManager.h
+++ b/Common/LogManager.h
@@ -22,6 +22,7 @@
 #include <fstream>
 #include <mutex>
 #include <vector>
+#include <cstdarg>
 
 #include "Common/Data/Format/IniFile.h"
 #include "Common/CommonFuncs.h"

--- a/Common/MipsCPUDetect.cpp
+++ b/Common/MipsCPUDetect.cpp
@@ -17,10 +17,13 @@
 
 #ifdef __mips__
 
-#include "Common.h"
-#include "CPUDetect.h"
-#include "StringUtils.h"
-#include "FileUtil.h"
+#include "Common/Common.h"
+#include "Common/CPUDetect.h"
+#include "Common/StringUtils.h"
+#include "Common/File/FileUtil.h"
+#include "Common/Data/Encoding/Utf8.h"
+#include <cstring>
+#include <sstream>
 
 // Only Linux platforms have /proc/cpuinfo
 #if defined(__linux__)


### PR DESCRIPTION
MipsCPUDetect had some missing headers that prevented compilation so add them back.

LogManager.h needs `#include <cstdarg>` or else it will poop on this
```c
In file included from ppsspp/Common/LogManager.cpp:25:
ppsspp/Common/LogManager.h:136:50: error: ‘va_list’ has not been declared
  136 |     const char *file, int line, const char *fmt, va_list args);
```

This doesn't fix the other mips issue yet (see https://github.com/hrydgard/ppsspp/issues/13739) as it would require renaming some of the variables that are named "mips" to something else.