### PR TITLE
cmake: Add an install target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2188,6 +2188,12 @@ if(IOS)
 	)
 endif()
 
+configure_file(
+	"${CMAKE_SOURCE_DIR}/ppsspp.desktop.in"
+	"${CMAKE_BINARY_DIR}/ppsspp.desktop"
+	@ONLY
+)
+
 install(
 	TARGETS ${TargetBin}
 	DESTINATION "${CMAKE_INSTALL_BINDIR}"
@@ -2196,6 +2202,11 @@ install(
 	DIRECTORY "${CMAKE_BINARY_DIR}/assets"
 	DESTINATION "${CMAKE_INSTALL_DATADIR}/ppsspp"
 	PATTERN ".git*" EXCLUDE
+)
+install(
+	FILES "${CMAKE_BINARY_DIR}/ppsspp.desktop"
+	DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications"
+	RENAME ${TargetBin}.desktop
 )
 install(
 	DIRECTORY "${CMAKE_SOURCE_DIR}/icons/hicolor"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,9 @@ if(NOT (ARM64 AND MACOSX))
 endif()
 
 include(ccache)
+include(GNUInstallDirs)
 
+add_definitions(-DASSETS_DIR="${CMAKE_INSTALL_FULL_DATADIR}/ppsspp/assets/")
 
 if(GOLD)
 	add_definitions(-DGOLD)
@@ -1015,7 +1017,6 @@ elseif(TARGET SDL2::SDL2)
 	elseif(USING_EGL)
 		set(nativeExtraLibs ${nativeExtraLibs} pthread)
 	endif()
-	set(TargetBin PPSSPPSDL)
 elseif(NOT LIBRETRO)
 	message(FATAL_ERROR "Could not find SDL2. Failing.")
 endif()
@@ -2186,3 +2187,22 @@ if(IOS)
 		XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "-"
 	)
 endif()
+
+install(
+	TARGETS ${TargetBin}
+	DESTINATION "${CMAKE_INSTALL_BINDIR}"
+)
+install(
+	DIRECTORY "${CMAKE_BINARY_DIR}/assets"
+	DESTINATION "${CMAKE_INSTALL_DATADIR}/ppsspp"
+	PATTERN ".git*" EXCLUDE
+)
+install(
+	DIRECTORY "${CMAKE_SOURCE_DIR}/icons/hicolor"
+	DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons"
+)
+install(
+	FILES "${CMAKE_SOURCE_DIR}/icons/icon-512.svg"
+	DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pixmaps"
+	RENAME ppsspp.svg
+)

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -466,6 +466,9 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	// Packed assets are included in app
 	VFSRegister("", new DirectoryAssetReader(external_dir));
 #endif
+#if defined(ASSETS_DIR)
+	VFSRegister("", new DirectoryAssetReader(ASSETS_DIR));
+#endif
 #if !defined(MOBILE_DEVICE) && !defined(_WIN32) && !PPSSPP_PLATFORM(SWITCH)
 	VFSRegister("", new DirectoryAssetReader((File::GetExeDirectory() + "assets/").c_str()));
 	VFSRegister("", new DirectoryAssetReader((File::GetExeDirectory()).c_str()));

--- a/ppsspp.desktop.in
+++ b/ppsspp.desktop.in
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=@TargetBin@
+Exec=@TargetBin@
+Icon=ppsspp
+Type=Application
+Comment=ppsspp (fast and portable PSP emulator)
+Categories=Game


### PR DESCRIPTION
This adds an `install` target and a desktop file for both the SDL and Qt5 frontends.

This is very useful for installing ppsspp system wide as is done with distros and required for anyone that wants to install ppsspp into a non-standard location.