### PR TITLE
Add games that requires buffered rendering

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -406,6 +406,10 @@ ULES00740 = true
 # Chili Con Carnage
 ULUS10216 = true
 ULES00629 = true
+# Digimon Adventure
+NPJH50686 = true
+# Super Danganronpa 2
+NPJH50631 = true
 # TODO: There are many more.
 
 [RequireBlockTransfer]


### PR DESCRIPTION
I added games to RequireBufferedRendering for some games that are requires buffered Rendering.

Here's Danganronpa 2 and Digimon Adventure:

Danganronpa 2 does not interact objects and characters:
![Screenshot_2020-12-07-00-47-36-61_2f85358b2198d26f8aca533d68bee793](https://user-images.githubusercontent.com/37503397/101287469-67bb2800-382b-11eb-8163-e745348e2c00.png)

Digimon Adventure does not draw 3d models
![Screenshot_2020-08-29-18-56-27-28_2f85358b2198d26f8aca533d68bee793](https://user-images.githubusercontent.com/37503397/101287514-9f29d480-382b-11eb-9657-48c80974bab9.png)

