### PR TITLE
Add more games to RequireBufferedRendering

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -408,8 +408,25 @@ ULUS10216 = true
 ULES00629 = true
 # Digimon Adventure
 NPJH50686 = true
+# Danganronpa
+NPJH50372 = true
+NPJH50515 = true
+# Danganronpa Demo
+NPJH90164 = true
 # Super Danganronpa 2
 NPJH50631 = true
+# The Simpsons Game
+ULUS10295 = true
+ULES00975 = true
+ULES00979 = true
+ULES00978 = true
+ULES00977 = true
+ULES00976 = true
+# Jeanne d'Arc
+UCUS98700 = true
+UCJS10048 = true
+# Jeanne d'Arc Senkou Taikenban Demo
+UCJX90019 = true
 # TODO: There are many more.
 
 [RequireBlockTransfer]


### PR DESCRIPTION
I added more games that requires buffered rendering

Jeanne d'arc:
![Screenshot_2020-12-07-09-31-07-94_2f85358b2198d26f8aca533d68bee793](https://user-images.githubusercontent.com/37503397/101300029-1df43100-386f-11eb-888d-75ac61f8c18f.png)

The Simpsons Game:
![Screenshot_2020-12-07-09-31-59-38_2f85358b2198d26f8aca533d68bee793](https://user-images.githubusercontent.com/37503397/101300055-36644b80-386f-11eb-8c33-758e4f74dc97.png)

Danganronpa 1 same as Super Danganronpa 2:
![Screenshot_2020-12-07-09-35-37-78_2f85358b2198d26f8aca533d68bee793](https://user-images.githubusercontent.com/37503397/101300159-a07cf080-386f-11eb-8187-e6b3f8387a41.png)
