### PR TITLE
cmake: Enable the install target for non-linux unix systems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2187,7 +2187,7 @@ if(IOS)
 	)
 endif()
 
-if (LINUX AND NOT ANDROID)
+if(UNIX AND NOT ANDROID AND NOT APPLE)
 	configure_file(
 		"${CMAKE_SOURCE_DIR}/ppsspp.desktop.in"
 		"${CMAKE_BINARY_DIR}/ppsspp.desktop"


### PR DESCRIPTION
This should work on the various BSD operating systems too so its better to use `UNIX` and not `LINUX`. I'm not sure `ANDROID` is actually needed here, but I'd guess it doesn't hurt?