### PR TITLE
Vulkan:Add more Dirty flag

### DIFF
--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -959,7 +959,7 @@ void DrawEngineVulkan::DoFlush() {
 				int curRenderStepId = renderManager->GetCurrentStepId();
 				if (lastRenderStepId_ != curRenderStepId) {
 					// Dirty everything that has dynamic state that will need re-recording.
-					gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_BLEND_STATE);
+					gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_BLEND_STATE | DIRTY_TEXTURE_IMAGE | DIRTY_TEXTURE_PARAMS);
 					lastRenderStepId_ = curRenderStepId;
 				}
 


### PR DESCRIPTION
Fix #13741
Fix Princess Maker 5 Portable half screen in Vulkan

edit2: Not sure line 839 also need more dirty flag.