### PR TITLE
Wipe the volatile RAM when a dialog ends (hack for NBA Live 08)

### DIFF
--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -30,6 +30,7 @@
 #include "Core/Reporting.h"
 #include "Core/Config.h"
 #include "Core/System.h"
+#include "Core/MemMap.h"
 
 #include "Core/HLE/sceKernel.h"
 #include "Core/HLE/sceKernelMemory.h"
@@ -155,8 +156,13 @@ static void ActivateDialog(UtilityDialogType type) {
 
 static void DeactivateDialog() {
 	if (currentDialogActive) {
-		// TODO: Unlock and zero volatile RAM.
 		currentDialogActive = false;
+
+		// TODO: Zero volatile RAM. Hack version of the solution for #8288 (JPCSP does it more properly).
+		u32 addr = PSP_GetVolatileMemoryStart();
+		u32 size = PSP_GetVolatileMemoryEnd() - PSP_GetVolatileMemoryStart();
+
+		Memory::Memset(addr, 0, size);
 	}
 }
 

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -468,6 +468,9 @@ inline u32 PSP_GetKernelMemoryEnd() { return 0x08400000;}
 // "Volatile" RAM is between 0x08400000 and 0x08800000, can be requested by the
 // game through sceKernelVolatileMemTryLock.
 
+inline u32 PSP_GetVolatileMemoryStart() { return 0x08400000; }
+inline u32 PSP_GetVolatileMemoryEnd() { return 0x08800000; }
+
 inline u32 PSP_GetUserMemoryBase() { return 0x08800000;}
 inline u32 PSP_GetDefaultLoadAddress() { return 0;}
 inline u32 PSP_GetVidMemBase() { return 0x04000000;}


### PR DESCRIPTION
Unsafe hackfix attempt for NBA Live 08! 

See issue #8288

Please test.