### PR TITLE
Linux: Properly avoid committing address space for large mmap().

### DIFF
--- a/Common/MemArenaPosix.cpp
+++ b/Common/MemArenaPosix.cpp
@@ -108,7 +108,7 @@ u8* MemArena::Find4GBBase() {
 	// aligned to 4GB for the movk trick. We can ensure that we get an aligned 4GB
 	// address by grabbing 8GB and aligning the pointer.
 	const uint64_t EIGHT_GIGS = 0x200000000ULL;
-	void *base = mmap(0, EIGHT_GIGS, PROT_READ | PROT_WRITE, MAP_ANON | MAP_SHARED | MAP_NORESERVE, -1, 0);
+	void *base = mmap(0, EIGHT_GIGS, PROT_NONE, MAP_ANON | MAP_PRIVATE | MAP_NORESERVE, -1, 0);
 	if (base && base != MAP_FAILED) {
 		INFO_LOG(MEMMAP, "base: %p", base);
 		uint64_t aligned_base = ((uint64_t)base + 0xFFFFFFFF) & ~0xFFFFFFFFULL;


### PR DESCRIPTION
A shared or writable mapping is charged to the process's memory commitment regardless of MAP_NORESERVE, so the mmap() call to find a 4G base can still fail depending on memory usage and overcommit settings.