### PR TITLE
Atrac addStream:SeekToSample when RemainingFrames > 2

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1134,9 +1134,12 @@ static u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd) {
 
 	atrac->first_.offset += bytesToAdd;
 	atrac->bufferValidBytes_ += bytesToAdd;
-	if (atrac->RemainingFrames() > 2) // Code Lyoko don't like SeekToSample for unknown reason
-		atrac->SeekToSample(atrac->loopStartSample_ - atrac->FirstOffsetExtra() - atrac->firstSampleOffset_);
-
+	
+	if (atrac->bufferState_ == ATRAC_STATUS_STREAMED_LOOP_FROM_END && atrac->RemainingFrames() > 2) { // Code Lyoko don't like SeekToSample for unknown reason		
+		atrac->loopNum_++;
+		atrac->SeekToSample(atrac->loopStartSample_ - atrac->FirstOffsetExtra() - atrac->firstSampleOffset_ + atrac->loopNum_);		
+	}
+	
 	return hleLogSuccessI(ME, 0);
 }
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1134,6 +1134,8 @@ static u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd) {
 
 	atrac->first_.offset += bytesToAdd;
 	atrac->bufferValidBytes_ += bytesToAdd;
+	if (atrac->RemainingFrames() > 2) // Code Lyoko don't like SeekToSample for unknown reason
+		atrac->SeekToSample(atrac->loopStartSample_ - atrac->FirstOffsetExtra() - atrac->firstSampleOffset_);
 
 	return hleLogSuccessI(ME, 0);
 }


### PR DESCRIPTION
Test with Code Lyoko #2539 still work 
Fix #13773 fix #7601 Fix #11586 Fix #10139
Fix #12083 the Golf Rally fixed

Coded Arms Contagion
v1.10.3-1330-g73da378ef log:
https://gist.github.com/sum2012/2261ff5a3b769a17d9864cd98d6bcff9

modify log: 2  (no "orignal FF: Frame decoding error!")
https://gist.github.com/sum2012/8213cb6351656b7e3138bf0089caa3b6

real psp log:
https://gist.github.com/sum2012/05ae453e97050a77497d132a676582fb

Hope other people give me feed back by Atrac 
This is windows 64 bit  test build 2
https://drive.google.com/file/d/1kKVEwousMWlkHlMbN2X3B13tOxsR4VbZ/view?usp=sharing

edit: Loco roco 2  also remain frame < 2 at the beginning ,not test much