### PR TITLE
Add an option to disable video decoding threads.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -521,7 +521,7 @@ static ConfigSetting cpuSettings[] = {
 	ReportedConfigSetting("SeparateSASThread", &g_Config.bSeparateSASThread, &DefaultSasThread, true, true),
 	ReportedConfigSetting("SeparateIOThread", &g_Config.bSeparateIOThread, true, true, true),
 	ReportedConfigSetting("IOTimingMethod", &g_Config.iIOTimingMethod, IOTIMING_FAST, true, true),
-	ReportedConfigSetting("VideoDecodingThreads", &g_Config.iVideoDecodingThreads, 0, true, false),
+	ReportedConfigSetting("DisableVideoDecodingThread", &g_Config.bDisableVideoDecodingThreads, false, true, false),
 	ConfigSetting("FastMemoryAccess", &g_Config.bFastMemory, true, true, true),
 	ReportedConfigSetting("FuncReplacements", &g_Config.bFuncReplacements, true, true, true),
 	ConfigSetting("HideSlowWarnings", &g_Config.bHideSlowWarnings, false, true, false),

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -521,6 +521,7 @@ static ConfigSetting cpuSettings[] = {
 	ReportedConfigSetting("SeparateSASThread", &g_Config.bSeparateSASThread, &DefaultSasThread, true, true),
 	ReportedConfigSetting("SeparateIOThread", &g_Config.bSeparateIOThread, true, true, true),
 	ReportedConfigSetting("IOTimingMethod", &g_Config.iIOTimingMethod, IOTIMING_FAST, true, true),
+	ReportedConfigSetting("VideoDecodingThreads", &g_Config.iVideoDecodingThreads, 0, true, false),
 	ConfigSetting("FastMemoryAccess", &g_Config.bFastMemory, true, true, true),
 	ReportedConfigSetting("FuncReplacements", &g_Config.bFuncReplacements, true, true, true),
 	ConfigSetting("HideSlowWarnings", &g_Config.bHideSlowWarnings, false, true, false),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -111,6 +111,7 @@ public:
 
 	bool bSeparateSASThread;
 	bool bSeparateIOThread;
+	int iVideoDecodingThreads;
 	int iIOTimingMethod;
 	int iLockedCPUSpeed;
 	bool bAutoSaveSymbolMap;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -111,7 +111,7 @@ public:
 
 	bool bSeparateSASThread;
 	bool bSeparateIOThread;
-	int iVideoDecodingThreads;
+	bool bDisableVideoDecodingThreads;
 	int iIOTimingMethod;
 	int iLockedCPUSpeed;
 	bool bAutoSaveSymbolMap;

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -516,10 +516,8 @@ bool MediaEngine::setVideoStream(int streamNum, bool force) {
 		// Allow ffmpeg to use any number of threads it wants for improving performance.  Without this, it doesn't use threads.
 		// Using threads will increase the decoding delay, it requires the future frmaes are provided.
 		// However some games don't provide enough future frames, may casue blurring.
-		char num_Threads[3];
-		snprintf(num_Threads, sizeof(num_Threads), "%i", g_Config.iVideoDecodingThreads);
-		av_dict_set(&opt, "threads", num_Threads, 0);
-		int openResult = avcodec_open2(m_pCodecCtx, pCodec, &opt);
+		av_dict_set(&opt, "threads", "0", 0);
+		int openResult = avcodec_open2(m_pCodecCtx, pCodec, g_Config.bDisableVideoDecodingThreads ? nullptr : &opt);
 		av_dict_free(&opt);
 		if (openResult < 0) {
 			return false;

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -514,7 +514,7 @@ bool MediaEngine::setVideoStream(int streamNum, bool force) {
 
 		AVDictionary *opt = nullptr;
 		// Allow ffmpeg to use any number of threads it wants for improving performance.  Without this, it doesn't use threads.
-		// Using threads will improves the decoding delay, it requires the future frmaes are provided.
+		// Using threads will increase the decoding delay, it requires the future frmaes are provided.
 		// However some games don't provide enough future frames, may casue blurring.
 		char num_Threads[3];
 		snprintf(num_Threads, sizeof(num_Threads), "%i", g_Config.iVideoDecodingThreads);

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -513,8 +513,12 @@ bool MediaEngine::setVideoStream(int streamNum, bool force) {
 		}
 
 		AVDictionary *opt = nullptr;
-		// Allow ffmpeg to use any number of threads it wants.  Without this, it doesn't use threads.
-		av_dict_set(&opt, "threads", "0", 0);
+		// Allow ffmpeg to use any number of threads it wants for improving performance.  Without this, it doesn't use threads.
+		// Using threads will improves the decoding delay, it requires the future frmaes are provided.
+		// However some games don't provide enough future frames, may casue blurring.
+		char num_Threads[3];
+		snprintf(num_Threads, sizeof(num_Threads), "%i", g_Config.iVideoDecodingThreads);
+		av_dict_set(&opt, "threads", num_Threads, 0);
 		int openResult = avcodec_open2(m_pCodecCtx, pCodec, &opt);
 		av_dict_free(&opt);
 		if (openResult < 0) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -888,6 +888,13 @@ void GameSettingsScreen::CreateViews() {
 	static const char *ioTimingMethods[] = { "Fast (lag on slow storage)", "Host (bugs, less lag)", "Simulate UMD delays" };
 	View *ioTimingMethod = systemSettings->Add(new PopupMultiChoice(&g_Config.iIOTimingMethod, sy->T("IO timing method"), ioTimingMethods, 0, ARRAY_SIZE(ioTimingMethods), sy->GetName(), screenManager()));
 	ioTimingMethod->SetEnabledPtr(&g_Config.bSeparateIOThread);
+	PopupSliderChoice *videoDecodingThreads = systemSettings->Add(new PopupSliderChoice(&g_Config.iVideoDecodingThreads, 0, 16, sy->T("Video decoding threads", "Video decoding threads"), screenManager(), ""));
+	videoDecodingThreads->SetZeroLabel(sy->T("Auto"));
+	videoDecodingThreads->OnChange.Add([&](UI::EventParams &e) {
+		settingInfo_->Show(sy->T("Video decoding threads tip", "Higher values may improve performance, but may make video blur"), e.v);
+		return UI::EVENT_CONTINUE;
+	});
+	
 	systemSettings->Add(new CheckBox(&g_Config.bForceLagSync, sy->T("Force real clock sync (slower, less lag)")));
 	PopupSliderChoice *lockedMhz = systemSettings->Add(new PopupSliderChoice(&g_Config.iLockedCPUSpeed, 0, 1000, sy->T("Change CPU Clock", "Change CPU Clock (unstable)"), screenManager(), sy->T("MHz, 0:default")));
 	lockedMhz->OnChange.Add([&](UI::EventParams &) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -888,10 +888,10 @@ void GameSettingsScreen::CreateViews() {
 	static const char *ioTimingMethods[] = { "Fast (lag on slow storage)", "Host (bugs, less lag)", "Simulate UMD delays" };
 	View *ioTimingMethod = systemSettings->Add(new PopupMultiChoice(&g_Config.iIOTimingMethod, sy->T("IO timing method"), ioTimingMethods, 0, ARRAY_SIZE(ioTimingMethods), sy->GetName(), screenManager()));
 	ioTimingMethod->SetEnabledPtr(&g_Config.bSeparateIOThread);
-	PopupSliderChoice *videoDecodingThreads = systemSettings->Add(new PopupSliderChoice(&g_Config.iVideoDecodingThreads, 0, 16, sy->T("Video decoding threads", "Video decoding threads"), screenManager(), ""));
-	videoDecodingThreads->SetZeroLabel(sy->T("Auto"));
-	videoDecodingThreads->OnChange.Add([&](UI::EventParams &e) {
-		settingInfo_->Show(sy->T("Video decoding threads tip", "Higher values may improve performance, but may make video blur"), e.v);
+	CheckBox *VideoThreads = systemSettings->Add(new CheckBox(&g_Config.bDisableVideoDecodingThreads, sy->T("Disable Video Decoding Threads")));
+	VideoThreads->OnClick.Add([=](EventParams &e) {
+		if (!g_Config.bDisableVideoDecodingThreads)
+			settingInfo_->Show(gr->T("Disable Video Decoding Threads Tip", "May fix video blur, but slower"), e.v);
 		return UI::EVENT_CONTINUE;
 	});
 	


### PR DESCRIPTION
See https://github.com/hrydgard/ppsspp/issues/13759#issuecomment-750292447. Use an adjustable visual option to balance performance and correctness. Fixes possible video blur.

A fixed example(LocoRoco2)
Number of video decoing threads was set to auto:
![1](https://user-images.githubusercontent.com/3080636/103002436-e32a1280-4569-11eb-86bf-d48b4a611579.png)

Number of video decoing threads was set to 4:
![2](https://user-images.githubusercontent.com/3080636/103002579-1c628280-456a-11eb-98d2-9aebf8d1c542.png)

