### PR TITLE
http: Treat buffer full flush correctly

### DIFF
--- a/Common/Net/Sinks.cpp
+++ b/Common/Net/Sinks.cpp
@@ -343,6 +343,10 @@ bool OutputSink::Flush(bool allowBlock) {
 		size_t avail = std::min(BUFFER_SIZE - read_, valid_);
 
 		int bytes = send(fd_, buf_ + read_, (int)avail, MSG_NOSIGNAL);
+#if !PPSSPP_PLATFORM(WINDOWS)
+		if (bytes == -1 && (errno == EAGAIN || errno == EWOULDBLOCK))
+			bytes = 0;
+#endif
 		AccountDrain(bytes);
 
 		if (bytes == 0) {
@@ -371,6 +375,10 @@ void OutputSink::Drain() {
 		size_t avail = std::min(BUFFER_SIZE - read_, valid_);
 
 		int bytes = send(fd_, buf_ + read_, (int)avail, MSG_NOSIGNAL);
+#if !PPSSPP_PLATFORM(WINDOWS)
+		if (bytes == -1 && (errno == EAGAIN || errno == EWOULDBLOCK))
+			bytes = 0;
+#endif
 		AccountDrain(bytes);
 	}
 }

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -60,7 +60,8 @@ static ServerStatus RetrieveStatus() {
 
 // This reports the local IP address to report.ppsspp.org, which can then
 // relay that address to a mobile device searching for the server.
-static void RegisterServer(int port) {
+static bool RegisterServer(int port) {
+	bool success = false;
 	http::Client http;
 	Buffer theVoid;
 
@@ -70,31 +71,39 @@ static void RegisterServer(int port) {
 			std::string ip = fd_util::GetLocalIP(http.sock());
 			snprintf(resource4, sizeof(resource4) - 1, "/match/update?local=%s&port=%d", ip.c_str(), port);
 
-			http.GET(resource4, &theVoid);
+			if (http.GET(resource4, &theVoid) > 0)
+				success = true;
 			theVoid.Skip(theVoid.size());
 			http.Disconnect();
 		}
 	}
 
 	if (http.Resolve(REPORT_HOSTNAME, REPORT_PORT, net::DNSType::IPV6)) {
+		// If IPv4 was successful, don't give this as much time (it blocks and sometimes IPv6 is broken.)
+		double timeout = success ? 2.0 : 20.0;
+
 		// We register both IPv4 and IPv6 in case the other client is using a different one.
-		if (resource4[0] != 0 && http.Connect()) {
-			http.GET(resource4, &theVoid);
+		if (resource4[0] != 0 && http.Connect(timeout)) {
+			if (http.GET(resource4, &theVoid) > 0)
+				success = true;
 			theVoid.Skip(theVoid.size());
 			http.Disconnect();
 		}
 
 		// Currently, we're not using keepalive, so gotta reconnect...
-		if (http.Connect()) {
+		if (http.Connect(timeout)) {
 			char resource6[1024] = {};
 			std::string ip = fd_util::GetLocalIP(http.sock());
 			snprintf(resource6, sizeof(resource6) - 1, "/match/update?local=%s&port=%d", ip.c_str(), port);
 
-			http.GET(resource6, &theVoid);
+			if (http.GET(resource6, &theVoid) > 0)
+				success = true;
 			theVoid.Skip(theVoid.size());
 			http.Disconnect();
 		}
 	}
+
+	return success;
 }
 
 bool RemoteISOFileSupported(const std::string &filename) {


### PR DESCRIPTION
Saw an issue on a macOS device where IPv6 wasn't routing properly, but was being attempted.  This caused the debugger/streaming to be unavailable for almost a full minute which was annoying.  Most of the time, a shorter timeout should be fine, so this makes it shorter if IPv4 is working at least...

Additionally, on the same device, `send()` was returning an error (EAGAIN) for large sends, but this wasn't being handled properly (only it saying 0 bytes were sent was.)

-[Unknown]