### PR TITLE
Split the DepthRangeHack compat setting into itself and DisableRangeCulling

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -78,6 +78,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "DoublePrecisionSinCos", &flags_.DoublePrecisionSinCos);
 	CheckSetting(iniFile, gameID, "ShaderColorBitmask", &flags_.ShaderColorBitmask);
 	CheckSetting(iniFile, gameID, "DisableFirstFrameReadback", &flags_.DisableFirstFrameReadback);
+	CheckSetting(iniFile, gameID, "DisableRangeCulling", &flags_.DisableRangeCulling);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -76,6 +76,7 @@ struct CompatFlags {
 	bool DoublePrecisionSinCos;
 	bool ShaderColorBitmask;
 	bool DisableFirstFrameReadback;
+	bool DisableRangeCulling;
 };
 
 class IniFile;

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -125,7 +125,7 @@ GPU_D3D11::~GPU_D3D11() {
 void GPU_D3D11::CheckGPUFeatures() {
 	u32 features = 0;
 
-	if (!PSP_CoreParameter().compat.flags().DepthRangeHack) {
+	if (!PSP_CoreParameter().compat.flags().DisableRangeCulling) {
 		features |= GPU_SUPPORTS_VS_RANGE_CULLING;
 	}
 	features |= GPU_SUPPORTS_BLEND_MINMAX;

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -171,7 +171,7 @@ void GPU_DX9::CheckGPUFeatures() {
 	features |= GPU_SUPPORTS_ACCURATE_DEPTH;
 
 	auto vendor = draw_->GetDeviceCaps().vendor;
-	if (!PSP_CoreParameter().compat.flags().DepthRangeHack) {
+	if (!PSP_CoreParameter().compat.flags().DisableRangeCulling) {
 		// VS range culling (killing triangles in the vertex shader using NaN) causes problems on Intel.
 		// Also causes problems on old NVIDIA.
 		switch (vendor) {

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -149,7 +149,7 @@ void GPU_GLES::CheckGPUFeatures() {
 	features |= GPU_SUPPORTS_16BIT_FORMATS;
 
 	if (!draw_->GetBugs().Has(Draw::Bugs::BROKEN_NAN_IN_CONDITIONAL)) {
-		if (!PSP_CoreParameter().compat.flags().DepthRangeHack) {
+		if (!PSP_CoreParameter().compat.flags().DisableRangeCulling) {
 			features |= GPU_SUPPORTS_VS_RANGE_CULLING;
 		}
 	}

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -184,7 +184,7 @@ GPU_Vulkan::~GPU_Vulkan() {
 void GPU_Vulkan::CheckGPUFeatures() {
 	uint32_t features = 0;
 
-	if (!PSP_CoreParameter().compat.flags().DepthRangeHack) {
+	if (!PSP_CoreParameter().compat.flags().DisableRangeCulling) {
 		features |= GPU_SUPPORTS_VS_RANGE_CULLING;
 	}
 

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -155,9 +155,36 @@ ULJM91018 = true
 NPJH90062 = true
 # Phantasy Star Portable Infinity Demo
 NPJH90157 = true  # Infinity demo
+
+[DisableRangeCulling]
+# Phantasy Star games also have range culling issues.
+# Phantasy Star Portable 2 and Infinity
+ULJM05309 = true
+ULUS10410 = true
+ULES01218 = true
+ULJM08023 = true
+ULES01218 = true
+# Phantasy Star Portable 1 Demo
+NPUH90023 = true
+# Phantasy Star Portable 2
+ULES01439 = true
+ULUS10529 = true
+ULJM05493 = true
+NPJH50043 = true
+ULJM08030 = true
+NPUH90023 = true
+ULJM91014 = true
+NPJH90002 = true
+ULJM05732 = true
+NPJH50332 = true
+# Phantasy Star Portable 2 JP Demo
+ULJM91018 = true
+NPJH90062 = true
+# Phantasy Star Portable Infinity Demo
+NPJH90157 = true  # Infinity demo
+
 # Test Drive Unlimited
-# just to disable range culling without adding another hack
-# since it causes a lot of missing geometry when driving
+ULET00386 = true
 ULES00637 = true
 ULKS46126 = true
 ULUS10249 = true
@@ -187,6 +214,10 @@ ULUS10290 = true
 ULED90040 = true
 ULJM05284 = true
 ULES00645 = true
+
+# Splinter Cell Essentials (#13035)
+ULES00281 = true
+ULUS10070 = true
 
 [ClearToRAM]
 # SOCOM Navy Seals games require this. See issue #8973.


### PR DESCRIPTION
Most of our uses of DepthRangeHack was just to get DisableRangeCulling anyway - and we don't want the depth hack enabled when not needed.

Also disables range culling for Splinter Cell Essentials (see #13035)

We really need to understand range culling better. This is a "ship hack" for 1.11 .