### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/Common/MemArenaPosix.cpp
+++ b/Common/MemArenaPosix.cpp
@@ -26,6 +26,11 @@
 #include <cstring>
 #include <string>
 
+#ifndef MAP_NORESERVE
+// Not implemented on BSDs
+#define MAP_NORESERVE 0
+#endif
+
 #include "Common/Log.h"
 #include "Common/File/FileUtil.h"
 #include "Common/MemoryUtil.h"

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -20,6 +20,7 @@
 #include <vector>
 #include <string>
 #include <cstring>
+#include <ctime>
 
 #include "Common.h"
 #include "Core/HLE/sceKernel.h"

--- a/Core/Instance.cpp
+++ b/Core/Instance.cpp
@@ -17,7 +17,7 @@
 
 #include "Instance.h"
 
-#if __linux__ || __APPLE__
+#if !PPSSPP_PLATFORM(WINDOWS) && !PPSSPP_PLATFORM(ANDROID) && !defined(__LIBRETRO__)
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/mman.h>


### PR DESCRIPTION
*Probably* regressed by #13172, #13427, #13489 but I haven't bisected. From [error log](https://github.com/hrydgard/ppsspp/files/5744104/ppsspp-1.10.3.1395.log):
```c++
Common/MemArenaPosix.cpp:111:71: error: use of undeclared identifier 'MAP_NORESERVE'
        void *base = mmap(0, EIGHT_GIGS, PROT_NONE, MAP_ANON | MAP_PRIVATE | MAP_NORESERVE, -1, 0);
                                                                             ^
Core/Instance.cpp:90:56: error: use of undeclared identifier 'PROT_READ'
        InstanceInfo *buf = (InstanceInfo *)mmap(0, BUF_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, hIDMapFile, 0);
                                                              ^
Core/Instance.cpp:90:68: error: use of undeclared identifier 'PROT_WRITE'
        InstanceInfo *buf = (InstanceInfo *)mmap(0, BUF_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, hIDMapFile, 0);
                                                                          ^
Core/Instance.cpp:90:80: error: use of undeclared identifier 'MAP_SHARED'
        InstanceInfo *buf = (InstanceInfo *)mmap(0, BUF_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, hIDMapFile, 0);
                                                                                      ^
Core/Instance.cpp:91:13: error: use of undeclared identifier 'MAP_FAILED'
        if (buf == MAP_FAILED) {
                   ^
Core/Instance.cpp:147:37: error: use of undeclared identifier 'O_CREAT'
        hIDMapFile = shm_open(ID_SHM_NAME, O_CREAT | O_RDWR, 0);
                                           ^
Core/Instance.cpp:147:47: error: use of undeclared identifier 'O_RDWR'
        hIDMapFile = shm_open(ID_SHM_NAME, O_CREAT | O_RDWR, 0);
                                                     ^
Core/Instance.cpp:185:3: error: use of undeclared identifier 'shm_unlink'
                shm_unlink(ID_SHM_NAME);     // If program exited or crashed before unlinked the shared memory object and it's contents will persist.
                ^
Core/FileSystems/FileSystem.h:102:5: error: field has incomplete type 'tm'
        tm atime{};
           ^
/usr/include/wchar.h:111:8: note: forward declaration of 'tm'
struct tm;
       ^
In file included from Core/FileSystems/FileSystem.cpp:20:
Core/FileSystems/FileSystem.h:103:5: error: field has incomplete type 'tm'
        tm ctime{};
           ^
/usr/include/wchar.h:111:8: note: forward declaration of 'tm'
struct tm;
       ^
In file included from Core/FileSystems/FileSystem.cpp:20:
Core/FileSystems/FileSystem.h:104:5: error: field has incomplete type 'tm'
        tm mtime{};
           ^
/usr/include/wchar.h:111:8: note: forward declaration of 'tm'
struct tm;
       ^
```
