### PR TITLE
An attempt to add BlockTransferAllowCreateFB for Naruto Shippuden: Ultimate Ninja Impact

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -604,6 +604,11 @@ ULUS10249 = true
 ULES00637 = true
 ULKS46126 = true
 
+# Naruto Shippuden: Ultimate Ninja Impact
+ULUS10582 = true
+ULES01537 = true
+NPJH50435 = true
+
 [IntraVRAMBlockTransferAllowCreateFB]
 # Final Fantasy - Type 0
 NPJH50443 = true


### PR DESCRIPTION
This is attempt for adding BlockTransferAllowCreateFB for Naruto Shippuden: Ultimate Ninja Impact. This helps #12544 and Low-end Devices. If successful I'll ready to merge

Anyone tried to test this PR for improves performance for Low-end Devices?