### PR TITLE
Debugger: Tweaks to memory read/write APIs

### DIFF
--- a/Common/Data/Encoding/Base64.cpp
+++ b/Common/Data/Encoding/Base64.cpp
@@ -49,15 +49,16 @@ std::vector<uint8_t> Base64Decode(const char *s, size_t sz) {
 		 41,  42,  43,  44,  45,  46,  47,  48,  49,  50,  51, 255, 255, 255, 255, 255,
 	};
 
+	const uint8_t *p = (const uint8_t *)s;
 	std::vector<uint8_t> result;
 	result.reserve(3 * sz / 4);
 
 	for (size_t i = 0; i < sz; i += 4) {
 		uint8_t quad[4] = {
-			lookup[s[i]],
-			i + 1 < sz ? lookup[s[i + 1]] : 255,
-			i + 2 < sz ? lookup[s[i + 2]] : 255,
-			i + 3 < sz ? lookup[s[i + 3]] : 255,
+			lookup[p[i]],
+			i + 1 < sz ? lookup[p[i + 1]] : (uint8_t)255,
+			i + 2 < sz ? lookup[p[i + 2]] : (uint8_t)255,
+			i + 3 < sz ? lookup[p[i + 3]] : (uint8_t)255,
 		};
 
 		// First: ABCDEF GHXXXX XXXXXX XXXXXX.  Neither 6-bit value should be invalid.

--- a/Common/Data/Encoding/Base64.cpp
+++ b/Common/Data/Encoding/Base64.cpp
@@ -2,7 +2,7 @@
 
 // TODO: This is a simple but not very efficient implementation.
 std::string Base64Encode(const uint8_t *p, size_t sz) {
-	const char digits[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	static const char digits[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 	size_t unpaddedLength = (4 * sz + 2) / 3;
 	std::string result;
@@ -35,7 +35,7 @@ std::string Base64Encode(const uint8_t *p, size_t sz) {
 }
 
 std::vector<uint8_t> Base64Decode(const char *s, size_t sz) {
-	const uint8_t lookup[256] = {
+	static const uint8_t lookup[256] = {
 		255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
 		255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
 		255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,  62,  63,  62, 255,  63,

--- a/Common/Data/Encoding/Base64.h
+++ b/Common/Data/Encoding/Base64.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
+#include <vector>
 
 std::string Base64Encode(const uint8_t *p, size_t sz);
+std::vector<uint8_t> Base64Decode(const char *s, size_t sz);

--- a/Common/Net/Sinks.cpp
+++ b/Common/Net/Sinks.cpp
@@ -164,6 +164,12 @@ bool InputSink::Skip(size_t bytes) {
 	return true;
 }
 
+void InputSink::Discard() {
+	read_ = 0;
+	write_ = 0;
+	valid_ = 0;
+}
+
 void InputSink::Fill() {
 	// Avoid small reads if possible.
 	if (BUFFER_SIZE - valid_ > PRESSURE) {

--- a/Common/Net/Sinks.h
+++ b/Common/Net/Sinks.h
@@ -19,6 +19,7 @@ public:
 	size_t TakeAtMost(char *buf, size_t bytes);
 	// Skip exactly this number of bytes, or fail.
 	bool Skip(size_t bytes);
+	void Discard();
 
 	bool Empty();
 	bool TryFill();

--- a/Core/Debugger/WebSocket.cpp
+++ b/Core/Debugger/WebSocket.cpp
@@ -196,6 +196,7 @@ void HandleDebuggerRequest(const http::Request &request) {
 	}
 
 	delete ws;
+	request.In()->Discard();
 	UpdateConnected(-1);
 }
 

--- a/Core/Debugger/WebSocket/MemorySubscriber.cpp
+++ b/Core/Debugger/WebSocket/MemorySubscriber.cpp
@@ -17,6 +17,7 @@
 
 #include "Common/StringUtils.h"
 #include "Core/MemMap.h"
+#include "Core/MIPS/MIPSDebugInterface.h"
 #include "Core/System.h"
 #include "Core/Debugger/WebSocket/MemorySubscriber.h"
 #include "Core/Debugger/WebSocket/WebSocketUtils.h"
@@ -42,10 +43,11 @@ DebuggerSubscriber *WebSocketMemoryInit(DebuggerEventHandlerMap &map) {
 //  - value: unsigned integer
 void WebSocketMemoryReadU8(DebuggerRequest &req) {
 	auto memLock = Memory::Lock();
-	uint32_t addr;
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
 
+	uint32_t addr;
 	if (!req.ParamU32("address", &addr, false)) {
-		req.Fail("No address given");
 		return;
 	}
 
@@ -67,10 +69,11 @@ void WebSocketMemoryReadU8(DebuggerRequest &req) {
 //  - value: unsigned integer
 void WebSocketMemoryReadU16(DebuggerRequest &req) {
 	auto memLock = Memory::Lock();
-	uint32_t addr;
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
 
+	uint32_t addr;
 	if (!req.ParamU32("address", &addr, false)) {
-		req.Fail("No address given");
 		return;
 	}
 
@@ -92,10 +95,11 @@ void WebSocketMemoryReadU16(DebuggerRequest &req) {
 //  - value: unsigned integer
 void WebSocketMemoryReadU32(DebuggerRequest &req) {
 	auto memLock = Memory::Lock();
-	uint32_t addr;
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
 
+	uint32_t addr;
 	if (!req.ParamU32("address", &addr, false)) {
-		req.Fail("No address given");
 		return;
 	}
 
@@ -118,15 +122,14 @@ void WebSocketMemoryReadU32(DebuggerRequest &req) {
 //  - value: new value, unsigned integer
 void WebSocketMemoryWriteU8(DebuggerRequest &req) {
 	auto memLock = Memory::Lock();
-	uint32_t addr, val;
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
 
+	uint32_t addr, val;
 	if (!req.ParamU32("address", &addr, false)) {
-		req.Fail("No address given");
 		return;
 	}
-
 	if (!req.ParamU32("value", &val, false)) {
-		req.Fail("No value given");
 		return;
 	}
 
@@ -150,15 +153,14 @@ void WebSocketMemoryWriteU8(DebuggerRequest &req) {
 //  - value: new value, unsigned integer
 void WebSocketMemoryWriteU16(DebuggerRequest &req) {
 	auto memLock = Memory::Lock();
-	uint32_t addr, val;
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
 
+	uint32_t addr, val;
 	if (!req.ParamU32("address", &addr, false)) {
-		req.Fail("No address given");
 		return;
 	}
-
 	if (!req.ParamU32("value", &val, false)) {
-		req.Fail("No value given");
 		return;
 	}
 
@@ -182,15 +184,14 @@ void WebSocketMemoryWriteU16(DebuggerRequest &req) {
 //  - value: new value, unsigned integer
 void WebSocketMemoryWriteU32(DebuggerRequest &req) {
 	auto memLock = Memory::Lock();
-	uint32_t addr, val;
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
 
+	uint32_t addr, val;
 	if (!req.ParamU32("address", &addr, false)) {
-		req.Fail("No address given");
 		return;
 	}
-
 	if (!req.ParamU32("value", &val, false)) {
-		req.Fail("No value given");
 		return;
 	}
 

--- a/Core/Debugger/WebSocket/MemorySubscriber.cpp
+++ b/Core/Debugger/WebSocket/MemorySubscriber.cpp
@@ -132,19 +132,16 @@ void WebSocketMemoryRead(DebuggerRequest &req) {
 		return req.Fail("CPU not started");
 
 	uint32_t addr;
-	if (!req.ParamU32("address", &addr)) {
+	if (!req.ParamU32("address", &addr))
 		return;
-	}
 	uint32_t size;
-	if (!req.ParamU32("size", &size)) {
+	if (!req.ParamU32("size", &size))
 		return;
-	}
 
-	if (!Memory::IsValidAddress(addr)) {
+	if (!Memory::IsValidAddress(addr))
 		return req.Fail("Invalid address");
-	} else if (!Memory::IsValidRange(addr, size)) {
+	else if (!Memory::IsValidRange(addr, size))
 		return req.Fail("Invalid size");
-	}
 
 	JsonWriter &json = req.Respond();
 	// Start a value without any actual data yet...
@@ -309,22 +306,19 @@ void WebSocketMemoryWrite(DebuggerRequest &req) {
 		return req.Fail("CPU not started");
 
 	uint32_t addr;
-	if (!req.ParamU32("address", &addr)) {
+	if (!req.ParamU32("address", &addr))
 		return;
-	}
 	std::string encoded;
-	if (!req.ParamString("base64", &encoded)) {
+	if (!req.ParamString("base64", &encoded))
 		return;
-	}
 
 	std::vector<uint8_t> value = Base64Decode(&encoded[0], encoded.size());
 	uint32_t size = (uint32_t)value.size();
 
-	if (!Memory::IsValidAddress(addr)) {
+	if (!Memory::IsValidAddress(addr))
 		return req.Fail("Invalid address");
-	} else if (value.size() != (size_t)size || !Memory::IsValidRange(addr, size)) {
+	else if (value.size() != (size_t)size || !Memory::IsValidRange(addr, size))
 		return req.Fail("Invalid size");
-	}
 
 	Memory::MemcpyUnchecked(addr, &value[0], size);
 	req.Respond();

--- a/Core/Debugger/WebSocket/MemorySubscriber.h
+++ b/Core/Debugger/WebSocket/MemorySubscriber.h
@@ -24,6 +24,8 @@ DebuggerSubscriber *WebSocketMemoryInit(DebuggerEventHandlerMap &map);
 void WebSocketMemoryReadU8(DebuggerRequest &req);
 void WebSocketMemoryReadU16(DebuggerRequest &req);
 void WebSocketMemoryReadU32(DebuggerRequest &req);
+void WebSocketMemoryRead(DebuggerRequest &req);
 void WebSocketMemoryWriteU8(DebuggerRequest &req);
 void WebSocketMemoryWriteU16(DebuggerRequest &req);
 void WebSocketMemoryWriteU32(DebuggerRequest &req);
+void WebSocketMemoryWrite(DebuggerRequest &req);

--- a/Core/Debugger/WebSocket/MemorySubscriber.h
+++ b/Core/Debugger/WebSocket/MemorySubscriber.h
@@ -25,6 +25,7 @@ void WebSocketMemoryReadU8(DebuggerRequest &req);
 void WebSocketMemoryReadU16(DebuggerRequest &req);
 void WebSocketMemoryReadU32(DebuggerRequest &req);
 void WebSocketMemoryRead(DebuggerRequest &req);
+void WebSocketMemoryReadString(DebuggerRequest &req);
 void WebSocketMemoryWriteU8(DebuggerRequest &req);
 void WebSocketMemoryWriteU16(DebuggerRequest &req);
 void WebSocketMemoryWriteU32(DebuggerRequest &req);


### PR DESCRIPTION
This mainly adds ways to read/write in larger chunks, including NUL terminated strings (since that's a common thing.)

Also fixes up some error handling for the other memory APIs, since they were sending two error responses for missing address parameters, etc.  Also needs to validate the game is running so memory isn't nullptr.

-[Unknown]