### PR TITLE
Bleach Soul Carnival. Disable the "First Frame Readback" compat setting.

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -901,3 +901,12 @@ UCJS10007 = true
 UCES00001 = true
 UCKS45008 = true
 NPJG00059 = true
+
+# Bleach Soul Carnival - crashes started happening after a change. See #13346
+UCKS45102 = true
+ULJS10085 = true
+UCAS40227 = true
+UCAS40234 = true
+UCAS40296 = true
+UCJS18038 = true
+NPJG00008 = true


### PR DESCRIPTION
Experimental workaround for #13346 after the changes in #13327 .

If this doesn't work, then the game was relying on clearing, rather than it not clearing... 