### PR TITLE
Vulkan: Remove #10097 hack for newer AMD drivers

### DIFF
--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -207,8 +207,9 @@ VulkanRenderManager::VulkanRenderManager(VulkanContext *vulkan) : vulkan_(vulkan
 
 	queueRunner_.CreateDeviceObjects();
 
-	// Temporary AMD hack for issue #10097
-	if (vulkan_->GetPhysicalDeviceProperties().properties.vendorID == VULKAN_VENDOR_AMD) {
+	// AMD hack for issue #10097 (older drivers only.)
+	const auto &props = vulkan_->GetPhysicalDeviceProperties().properties;
+	if (props.vendorID == VULKAN_VENDOR_AMD && props.apiVersion < VK_API_VERSION_1_1) {
 		useThread_ = false;
 	}
 }


### PR DESCRIPTION
Fixes #10643.  Assumes affected drivers only supported 1.0 due to year 1.1 supporting drivers started coming out.

-[Unknown]