### PR TITLE
Display: Change default unthrottle mode on non-Windows

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -546,7 +546,7 @@ static int DefaultInternalResolution() {
 
 static int DefaultUnthrottleMode() {
 #if PPSSPP_PLATFORM(ANDROID) || defined(USING_QT_UI) || PPSSPP_PLATFORM(UWP) || PPSSPP_PLATFORM(IOS)
-	return (int)UnthrottleMode::SKIP_DRAW;
+	return (int)UnthrottleMode::SKIP_FLIP;
 #else
 	return (int)UnthrottleMode::CONTINUOUS;
 #endif
@@ -766,7 +766,7 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("AutoFrameSkip", &g_Config.bAutoFrameSkip, false, true, true),
 	ConfigSetting("FrameRate", &g_Config.iFpsLimit1, 0, true, true),
 	ConfigSetting("FrameRate2", &g_Config.iFpsLimit2, -1, true, true),
-	ConfigSetting("UnthrottleMode", &g_Config.iUnthrottleMode, &DefaultUnthrottleMode, &UnthrottleModeToString, &UnthrottleModeFromString, true, true),
+	ConfigSetting("UnthrottlingMode", &g_Config.iUnthrottleMode, &DefaultUnthrottleMode, &UnthrottleModeToString, &UnthrottleModeFromString, true, true),
 #if defined(USING_WIN_UI)
 	ConfigSetting("RestartRequired", &g_Config.bRestartRequired, false, false),
 #endif

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -354,7 +354,7 @@ void retro_init(void)
 #endif
 
    g_Config.bEnableLogging = true;
-   g_Config.iUnthrottleMode = (int)UnthrottleMode::CONTINUOUS;
+   g_Config.iUnthrottleMode = (int)UnthrottleMode::SKIP_FLIP;
    g_Config.bMemStickInserted = true;
    g_Config.iGlobalVolume = VOLUME_MAX - 1;
    g_Config.iAltSpeedVolume = -1;


### PR DESCRIPTION
This should reduce graphical corruption caused by fast forwarding.

See #13546 - this doesn't yet remove it or change the behavior.  Maybe we should merge after 1.11.0.  But as a starting point we can change the default.

May help #11207, #13444, #11122 and fixes #10519.

-[Unknown]