### PR TITLE
SaveState: Allow rewind on mobile

### DIFF
--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -681,9 +681,9 @@ const KeyMap_IntStrPair psp_button_names[] = {
 	{VIRTKEY_PAUSE, "Pause"},
 #ifndef MOBILE_DEVICE
 	{VIRTKEY_FRAME_ADVANCE, "Frame Advance"},
-	{VIRTKEY_REWIND, "Rewind"},
 	{VIRTKEY_RECORD, "Audio/Video Recording" },
 #endif
+	{VIRTKEY_REWIND, "Rewind"},
 	{VIRTKEY_SAVE_STATE, "Save State"},
 	{VIRTKEY_LOAD_STATE, "Load State"},
 	{VIRTKEY_NEXT_SLOT,  "Next Slot"},

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -676,7 +676,6 @@ namespace SaveState
 		return false;
 	}
 
-#ifndef MOBILE_DEVICE
 	static inline void CheckRewindState()
 	{
 		if (gpuStats.numFlips % g_Config.iRewindFlipFrequency != 0)
@@ -689,10 +688,9 @@ namespace SaveState
 			return;
 
 		rewindLastTime = now;
-		DEBUG_LOG(BOOT, "saving rewind state");
+		DEBUG_LOG(BOOT, "Saving rewind state");
 		rewindStates.Save();
 	}
-#endif
 
 	bool HasLoadedState() {
 		return hasLoadedState;
@@ -719,10 +717,8 @@ namespace SaveState
 
 	void Process()
 	{
-#ifndef MOBILE_DEVICE
 		if (g_Config.iRewindFlipFrequency != 0 && gpuStats.numFlips != 0)
 			CheckRewindState();
-#endif
 
 		if (!needsProcess)
 			return;


### PR DESCRIPTION
It's in the settings, so it should work.  Mobile devices have a lot more RAM than they did 7 years ago in cd2adf8.

-[Unknown]