### PR TITLE
Savedata: Prevent garbage bleeding into save icons

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -209,6 +209,12 @@ PPGeStyle PSPDialog::FadedStyle(PPGeAlign align, float scale) {
 	return textStyle;
 }
 
+PPGeImageStyle PSPDialog::FadedImageStyle() {
+	PPGeImageStyle style;
+	style.color = CalcFadedColor(style.color);
+	return style;
+}
+
 void PSPDialog::DisplayButtons(int flags, const char *caption)
 {
 	bool useCaption = false;

--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -85,6 +85,7 @@ public:
 	void EndDraw();
 protected:
 	PPGeStyle FadedStyle(PPGeAlign align, float scale);
+	PPGeImageStyle FadedImageStyle();
 	void UpdateButtons();
 	bool IsButtonPressed(int checkButton);
 	bool IsButtonHeld(int checkButton, int &framesHeld, int framesHeldThreshold = 30, int framesHeldRepeatRate = 10);

--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -104,15 +104,14 @@ void PSPNetconfDialog::DrawBanner() {
 	textStyle.hasShadow = false;
 
 	// TODO: Draw a hexagon icon
-	PPGeDrawImage(10, 5, 11.0f, 10.0f, 1, 10, 1, 10, 10, 10, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawImage(10, 5, 11.0f, 10.0f, 1, 10, 1, 10, 10, 10, FadedImageStyle());
 	auto di = GetI18NCategory("Dialog");
 	PPGeDrawText(di->T("Network Connection"), 31, 10, textStyle);
 }
 
 void PSPNetconfDialog::DrawIndicator() {
-
 	// TODO: Draw animated circle as processing indicator
-	PPGeDrawImage(456, 248, 20.0f, 20.0f, 1, 10, 1, 10, 10, 10, CalcFadedColor(0xFFFFFFFF));
+	PPGeDrawImage(456, 248, 20.0f, 20.0f, 1, 10, 1, 10, 10, 10, FadedImageStyle());
 }
 
 void PSPNetconfDialog::DisplayMessage(std::string text1, std::string text2a, std::string text2b, std::string text3a, std::string text3b, bool hasYesNo, bool hasOK) {

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -331,7 +331,7 @@ void PSPSaveDialog::DisplayBanner(int which)
 		break;
 	}
 	// TODO: Draw a hexagon icon
-	PPGeDrawImage(10, 6, 12.0f, 12.0f, 1, 10, 1, 10, 10, 10, textStyle.color);
+	PPGeDrawImage(10, 6, 12.0f, 12.0f, 1, 10, 1, 10, 10, 10, FadedImageStyle());
 	PPGeDrawText(title, 30, 11, textStyle);
 }
 
@@ -340,13 +340,12 @@ void PSPSaveDialog::DisplaySaveList(bool canMove) {
 	static int upFramesHeld = 0;
 	static int downFramesHeld = 0;
 
-	for (int displayCount = 0; displayCount < param.GetFilenameCount(); displayCount++)
-	{
-		int textureColor = 0xFFFFFFFF;
+	for (int displayCount = 0; displayCount < param.GetFilenameCount(); displayCount++) {
+		PPGeImageStyle imageStyle = FadedImageStyle();
 		auto fileInfo = param.GetFileInfo(displayCount);
 
 		if (fileInfo.size == 0 && fileInfo.texture != NULL)
-			textureColor = 0xFF777777;
+			imageStyle.color = CalcFadedColor(0xFF777777);
 
 		// Calc save image position on screen
 		float w, h , x, b;
@@ -380,7 +379,7 @@ void PSPSaveDialog::DisplaySaveList(bool canMove) {
 			fileInfo.texture->SetTexture();
 			tw = fileInfo.texture->Width();
 			th = fileInfo.texture->Height();
-			PPGeDrawImage(x, y, w, h, 0, 0, 1, 1, tw, th, textureColor);
+			PPGeDrawImage(x, y, w, h, 0, 0, 1, 1, tw, th, imageStyle);
 		}
 		PPGeSetDefaultTexture();
 	}
@@ -397,11 +396,11 @@ void PSPSaveDialog::DisplaySaveList(bool canMove) {
 void PSPSaveDialog::DisplaySaveIcon(bool checkExists)
 {
 	std::lock_guard<std::mutex> guard(paramLock);
-	int textureColor = CalcFadedColor(0xFFFFFFFF);
+	PPGeImageStyle imageStyle = FadedImageStyle();
 	auto curSave = param.GetFileInfo(currentSelectedSave);
 
 	if (curSave.size == 0 && checkExists)
-		textureColor = CalcFadedColor(0xFF777777);
+		imageStyle.color = CalcFadedColor(0xFF777777);
 
 	// Calc save image position on screen
 	float w = 144;
@@ -418,7 +417,7 @@ void PSPSaveDialog::DisplaySaveIcon(bool checkExists)
 	} else {
 		PPGeDisableTexture();
 	}
-	PPGeDrawImage(x, y, w, h, 0, 0, 1, 1, tw, th, textureColor);
+	PPGeDrawImage(x, y, w, h, 0, 0, 1, 1, tw, th, imageStyle);
 	PPGeSetDefaultTexture();
 }
 

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -1130,13 +1130,12 @@ void PPGeDrawImage(ImageID atlasImage, float x, float y, float w, float h, const
 	EndVertexDataAndDraw(GE_PRIM_RECTANGLES);
 }
 
-void PPGeDrawImage(float x, float y, float w, float h, float u1, float v1, float u2, float v2, int tw, int th, u32 color)
-{
+void PPGeDrawImage(float x, float y, float w, float h, float u1, float v1, float u2, float v2, int tw, int th, const PPGeImageStyle &style) {
 	if (!dlPtr)
 		return;
 	BeginVertexData();
-	Vertex(x, y, u1, v1, tw, th, color);
-	Vertex(x + w, y + h, u2, v2, tw, th, color);
+	Vertex(x, y, u1, v1, tw, th, style.color);
+	Vertex(x + w, y + h, u2, v2, tw, th, style.color);
 	EndVertexDataAndDraw(GE_PRIM_RECTANGLES);
 }
 
@@ -1222,7 +1221,8 @@ bool PPGeImage::Load() {
 		return false;
 	}
 
-	u32 texSize = width_ * height_ * 4;
+	u32 dataSize = width_ * height_ * 4;
+	u32 texSize = dataSize + width_ * 4;
 	texture_ = __PPGeDoAlloc(texSize, true, "Savedata Icon");
 	if (texture_ == 0) {
 		free(textureData);
@@ -1230,7 +1230,8 @@ bool PPGeImage::Load() {
 		return false;
 	}
 
-	Memory::Memcpy(texture_, textureData, texSize);
+	Memory::Memcpy(texture_, textureData, dataSize);
+	Memory::Memset(texture_ + dataSize, 0, texSize - dataSize);
 	free(textureData);
 
 	lastFrame_ = gpuStats.numFlips;

--- a/Core/Util/PPGeDraw.h
+++ b/Core/Util/PPGeDraw.h
@@ -65,9 +65,7 @@ enum class PPGeAlign {
 
 	ANY = 0xFF,
 };
-inline bool operator &(const PPGeAlign &lhs, const PPGeAlign &rhs) {
-	return ((int)lhs & (int)rhs) != 0;
-}
+ENUM_CLASS_BITOPS(PPGeAlign);
 
 enum {
 	PPGE_LINE_NONE         = 0,
@@ -84,6 +82,10 @@ struct PPGeStyle {
 	uint32_t shadowColor = 0x80000000;
 };
 
+struct PPGeImageStyle {
+	uint32_t color = 0xFFFFFFFF;
+};
+
 // Get the metrics of the bounding box of the text without changing the buffer or state.
 void PPGeMeasureText(float *w, float *h, const char *text, float scale, int WrapType = PPGE_LINE_NONE, int wrapWidth = 0);
 
@@ -98,7 +100,7 @@ void PPGeDraw4Patch(ImageID atlasImage, float x, float y, float w, float h, u32 
 // Just blits an image to the screen, multiplied with the color.
 void PPGeDrawImage(ImageID atlasImage, float x, float y, const PPGeStyle &style);
 void PPGeDrawImage(ImageID atlasImage, float x, float y, float w, float h, const PPGeStyle &style);
-void PPGeDrawImage(float x, float y, float w, float h, float u1, float v1, float u2, float v2, int tw, int th, u32 color);
+void PPGeDrawImage(float x, float y, float w, float h, float u1, float v1, float u2, float v2, int tw, int th, const PPGeImageStyle &style);
 
 // Note: x2/y2 are exclusive.
 void PPGeScissor(int x1, int y1, int x2, int y2);


### PR DESCRIPTION
This pads out the icon data and also fixes a potential buffer overflow during image data copy.

Improves (perhaps fixes) #13854.  Initially, I did this plus NEAREST, which removes any bleed, but also ditches linear filtering.  I decided to let the black bleed into the bottom edge.  Note that the edges bleed together for the same reason.  I kept the PPGeImageStyle change though, in case it's useful later (maybe we fold shadows in too, but didn't want to mess with that.)

We can't really prevent bleed without using nearest, since the texture isn't a power of two.  This just makes the bleed not random garbage.

Additionally, the allocated size is up-aligned to a multiple of 256.  If a PNG wasn't 144x80 (which also aligns to 256), it might've read outside the buffer in the memcpy.

-[Unknown]