### PR TITLE
cmake: Silence warning.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -775,7 +775,7 @@ if(NOT MSVC)
 endif()
 
 
-find_package(LibZip)
+find_package(LIBZIP)
 if(LIBZIP_FOUND AND USE_SYSTEM_LIBZIP)
 	add_definitions(-DSHARED_LIBZIP)
 else()

--- a/cmake/Modules/FindLIBZIP.cmake
+++ b/cmake/Modules/FindLIBZIP.cmake
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
-
 # Locate libzip
 # This module defines
 # LIBZIP_LIBRARY


### PR DESCRIPTION
```
CMake Warning (dev) at /usr/share/cmake-3.18/Modules/FindPackageHandleStandardArgs.cmake:273 (message):
  The package name passed to `find_package_handle_standard_args` (LIBZIP)
  does not match the name of the calling package (LibZip).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/Modules/FindLibZip.cmake:74 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:778 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
It was fewer lines to change everything to `LIBZIP` than to `LibZip`.