### PR TITLE
Core: Properly stop on abrupt shutdown

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -493,7 +493,7 @@ void PSP_Shutdown() {
 	// Make sure things know right away that PSP memory, etc. is going away.
 	pspIsQuitting = true;
 	if (coreState == CORE_RUNNING)
-		Core_UpdateState(CORE_POWERDOWN);
+		Core_Stop();
 
 #ifndef MOBILE_DEVICE
 	if (g_Config.bFuncHashMap) {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -420,6 +420,8 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 			PSP_Shutdown();
 			bootPending_ = true;
 			gamePath_ = value;
+			// Don't leave it on CORE_POWERDOWN, we'll sometimes aggressively bail.
+			Core_UpdateState(CORE_POWERUP);
 		}
 	} else if (!strcmp(message, "config_loaded")) {
 		// In case we need to position touch controls differently.


### PR DESCRIPTION
When dragging a game/dump/etc. into PPSSPP while running, we call shutdown immediately.  This wasn't properly notifying Stop handlers.

Fixes #13884.

-[Unknown]
