### PR TITLE
add assets to ubuntu build artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,6 +215,7 @@ jobs:
           cp -r build*/PPSSPPSDL.app ppsspp/
         elif [ -e build*/PPSSPPSDL ]; then
           cp build*/PPSSPPSDL ppsspp/
+          cp -r assets ppsspp/assets
         fi
         if [ -e build*/$BUILD_CONFIGURATION/PPSSPPHeadless ]; then
           cp build*/$BUILD_CONFIGURATION/PPSSPPHeadless ppsspp/


### PR DESCRIPTION
This enables us to run PPSSPPSDL in the ubuntu artifact zip as normal release. Can be uploaded to the automated ppsspp download pake. After downloading the artiact zip just chmod +x PPSSPPSDL and install libsdl2-dev libgl1-mesa-dev libglu1-mesa-dev. Then everything works fine :). I don't know how to add a link automaticially to this site: https://buildbot.orphis.net/ppsspp/index.php