### PR TITLE
Windows: Handle fullscreen message consistently

### DIFF
--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -447,11 +447,16 @@ void System_SendMessage(const char *command, const char *parameter) {
 		});
 	} else if (!strcmp(command, "toggle_fullscreen")) {
 		auto view = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
+		bool flag = !view->IsFullScreenMode;
 		if (strcmp(parameter, "0") == 0) {
-			view->ExitFullScreenMode();
+			flag = false;
+		} else if (strcmp(parameter, "1") == 0){
+			flag = true;
 		}
-		else if (strcmp(parameter, "1") == 0){
+		if (flag) {
 			view->TryEnterFullScreenMode();
+		} else {
+			view->ExitFullScreenMode();
 		}
 	}
 }

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -132,6 +132,7 @@ namespace MainWindow
 	static bool inFullscreenResize = false;
 	static bool inResizeMove = false;
 	static bool hasFocus = true;
+	static bool g_isFullscreen = false;
 
 	// gross hack
 	bool noFocusPause = false;	// TOGGLE_PAUSE state to override pause on lost focus
@@ -355,6 +356,7 @@ namespace MainWindow
 		::SetMenu(hWnd, goingFullscreen ? NULL : menu);
 
 		g_Config.bFullScreen = goingFullscreen;
+		g_isFullscreen = goingFullscreen;
 
 		g_IgnoreWM_SIZE = false;
 
@@ -1027,6 +1029,10 @@ namespace MainWindow
 
 	void SendToggleFullscreen(bool fullscreen) {
 		PostMessage(hwndMain, WM_USER_TOGGLE_FULLSCREEN, fullscreen, 0);
+	}
+
+	bool IsFullscreen() {
+		return g_isFullscreen;
 	}
 
 }  // namespace

--- a/Windows/MainWindow.h
+++ b/Windows/MainWindow.h
@@ -76,6 +76,7 @@ namespace MainWindow
 	void ToggleFullscreen(HWND hWnd, bool goingFullscreen);
 	void Minimize();
 	void SendToggleFullscreen(bool fullscreen);  // To be used off-thread
+	bool IsFullscreen();
 	void ToggleDebugConsoleVisibility();
 	void SetInternalResolution(int res = -1);
 	void SetWindowSize(int zoom);

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -330,7 +330,7 @@ void System_SendMessage(const char *command, const char *parameter) {
 	} else if (!strcmp(command, "bgImage_browse")) {
 		MainWindow::BrowseBackground();
 	} else if (!strcmp(command, "toggle_fullscreen")) {
-		bool flag = !g_Config.bFullScreen;
+		bool flag = !MainWindow::IsFullscreen();
 		if (strcmp(parameter, "0") == 0) {
 			flag = false;
 		} else if (strcmp(parameter, "1") == 0) {


### PR DESCRIPTION
This handles it the same way as SDL, etc. so that the new button on the main screen works again.  It actually stopped working on Windows temporarily as of #13895.

Similar fixes UWP.

-[Unknown]