### PR TITLE
Fix IR issue in Persona 3

### DIFF
--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -8,6 +8,10 @@
 #include "Core/MIPS/IR/IRPassSimplify.h"
 #include "Core/MIPS/IR/IRRegCache.h"
 
+// #define CONDITIONAL_DISABLE { for (IRInst inst : in.GetInstructions()) { out.Write(inst); } return false; }
+#define CONDITIONAL_DISABLE
+#define DISABLE { for (IRInst inst : in.GetInstructions()) { out.Write(inst); } return false; }
+
 u32 Evaluate(u32 a, u32 b, IROp op) {
 	switch (op) {
 	case IROp::Add: case IROp::AddConst: return a + b;
@@ -101,8 +105,11 @@ bool IRApplyPasses(const IRPassFunc *passes, size_t c, const IRWriter &in, IRWri
 }
 
 bool OptimizeFPMoves(const IRWriter &in, IRWriter &out, const IROptions &opts) {
+	CONDITIONAL_DISABLE;
+
 	bool logBlocks = false;
 	IRInst prev{ IROp::Nop };
+
 	for (int i = 0; i < (int)in.GetInstructions().size(); i++) {
 		IRInst inst = in.GetInstructions()[i];
 		switch (inst.op) {
@@ -151,6 +158,8 @@ bool OptimizeFPMoves(const IRWriter &in, IRWriter &out, const IROptions &opts) {
 
 // Might be useful later on x86.
 bool ThreeOpToTwoOp(const IRWriter &in, IRWriter &out, const IROptions &opts) {
+	CONDITIONAL_DISABLE;
+
 	bool logBlocks = false;
 	for (int i = 0; i < (int)in.GetInstructions().size(); i++) {
 		IRInst inst = in.GetInstructions()[i];
@@ -201,6 +210,8 @@ bool ThreeOpToTwoOp(const IRWriter &in, IRWriter &out, const IROptions &opts) {
 }
 
 bool RemoveLoadStoreLeftRight(const IRWriter &in, IRWriter &out, const IROptions &opts) {
+	CONDITIONAL_DISABLE;
+
 	bool logBlocks = false;
 	for (int i = 0, n = (int)in.GetInstructions().size(); i < n; ++i) {
 		const IRInst &inst = in.GetInstructions()[i];
@@ -366,6 +377,7 @@ bool RemoveLoadStoreLeftRight(const IRWriter &in, IRWriter &out, const IROptions
 }
 
 bool PropagateConstants(const IRWriter &in, IRWriter &out, const IROptions &opts) {
+	CONDITIONAL_DISABLE;
 	IRRegCache gpr(&out);
 
 	bool logBlocks = false;
@@ -784,6 +796,7 @@ bool IRMutatesDestGPR(const IRInst &inst, int reg) {
 }
 
 bool PurgeTemps(const IRWriter &in, IRWriter &out, const IROptions &opts) {
+	CONDITIONAL_DISABLE;
 	std::vector<IRInst> insts;
 	insts.reserve(in.GetInstructions().size());
 
@@ -903,6 +916,7 @@ bool PurgeTemps(const IRWriter &in, IRWriter &out, const IROptions &opts) {
 }
 
 bool ReduceLoads(const IRWriter &in, IRWriter &out, const IROptions &opts) {
+	CONDITIONAL_DISABLE;
 	// This tells us to skip an AND op that has been optimized out.
 	// Maybe we could skip multiple, but that'd slow things down and is pretty uncommon.
 	int nextSkip = -1;
@@ -1039,6 +1053,8 @@ static std::vector<IRInst> ReorderLoadStoreOps(std::vector<IRInst> &ops) {
 }
 
 bool ReorderLoadStore(const IRWriter &in, IRWriter &out, const IROptions &opts) {
+	CONDITIONAL_DISABLE;
+
 	bool logBlocks = false;
 
 	enum class RegState : u8 {
@@ -1234,6 +1250,8 @@ bool ReorderLoadStore(const IRWriter &in, IRWriter &out, const IROptions &opts) 
 }
 
 bool MergeLoadStore(const IRWriter &in, IRWriter &out, const IROptions &opts) {
+	CONDITIONAL_DISABLE;
+
 	bool logBlocks = false;
 
 	auto opsCompatible = [&](const IRInst &a, const IRInst &b, int dist) {

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -835,6 +835,8 @@ bool PurgeTemps(const IRWriter &in, IRWriter &out, const IROptions &opts) {
 					insts[check.index] = IRReplaceDestGPR(insts[check.index], check.reg, inst.dest);
 					lastWrittenTo[inst.dest] = check.index;
 					check.reg = inst.dest;
+					// Update the read by exit flag to match the new reg.
+					check.readByExit = inst.dest < IRTEMP_0 || inst.dest > IRTEMP_LR_SHIFT;
 					// And swap the args for this mov, since we changed the other dest.  We'll optimize this out later.
 					std::swap(inst.dest, inst.src1);
 				} else {


### PR DESCRIPTION
We'd end up generating something along the lines of:

```
Load32 irtemp_value, zero, ADDR
Mov v0, irtemp_value
```

We'd swap them, creating:

```
Load32 v0, zero, ADDR
Mov irtemp_value, v0
```

But since we didn't update the readByExit flag, we'd subsequently discard the Load32, which caused the crash.

-[Unknown]