### PR TITLE
Adds two new tests to GPU driver test screen: Adreno shader logic test and flat shading

### DIFF
--- a/Common/GPU/OpenGL/GLFeatures.cpp
+++ b/Common/GPU/OpenGL/GLFeatures.cpp
@@ -594,6 +594,8 @@ std::string ApplyGLSLPrelude(const std::string &source, uint32_t stage) {
 	if (!gl_extensions.IsGLES && gl_extensions.IsCoreContext) {
 		// We need to add a corresponding #version.  Apple drivers fail without an exact match.
 		version = StringFromFormat("#version %d\n", gl_extensions.GLSLVersion());
+	} else if (gl_extensions.IsGLES && gl_extensions.GLES3) {
+		version = StringFromFormat("#version %d es\n", gl_extensions.GLSLVersion());
 	}
 	if (stage == GL_FRAGMENT_SHADER) {
 		temp = version + glsl_fragment_prelude + source;

--- a/Common/Render/DrawBuffer.cpp
+++ b/Common/Render/DrawBuffer.cpp
@@ -236,6 +236,18 @@ void DrawBuffer::DrawImageStretch(ImageID atlas_image, float x1, float y1, float
 	V(x1,	y2, color, image->u1, image->v2);
 }
 
+void DrawBuffer::DrawImageStretchVGradient(ImageID atlas_image, float x1, float y1, float x2, float y2, Color color1, Color color2) {
+	const AtlasImage *image = atlas->getImage(atlas_image);
+	if (!image)
+		return;
+	V(x1, y1, color1, image->u1, image->v1);
+	V(x2, y1, color1, image->u2, image->v1);
+	V(x2, y2, color2, image->u2, image->v2);
+	V(x1, y1, color1, image->u1, image->v1);
+	V(x2, y2, color2, image->u2, image->v2);
+	V(x1, y2, color2, image->u1, image->v2);
+}
+
 inline void rot(float *v, float angle, float xc, float yc) {
 	const float x = v[0] - xc;
 	const float y = v[1] - yc;

--- a/Common/Render/DrawBuffer.h
+++ b/Common/Render/DrawBuffer.h
@@ -108,6 +108,7 @@ public:
 	bool MeasureImage(ImageID atlas_image, float *w, float *h);
 	void DrawImage(ImageID atlas_image, float x, float y, float scale, Color color = COLOR(0xFFFFFF), int align = ALIGN_TOPLEFT);
 	void DrawImageStretch(ImageID atlas_image, float x1, float y1, float x2, float y2, Color color = COLOR(0xFFFFFF));
+	void DrawImageStretchVGradient(ImageID atlas_image, float x1, float y1, float x2, float y2, Color color1, Color color2);
 	void DrawImageStretch(ImageID atlas_image, const Bounds &bounds, Color color = COLOR(0xFFFFFF)) {
 		DrawImageStretch(atlas_image, bounds.x, bounds.y, bounds.x2(), bounds.y2(), color);
 	}

--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -237,8 +237,8 @@ void UIContext::FillRect(const UI::Drawable &drawable, const Bounds &bounds) {
 	} 
 }
 
-void UIContext::FillRectVGradient(uint32_t color1, uint32_t color2, const Bounds &bounds) {
-	uidrawbuffer_->DrawImageStretchVGradient(theme->whiteImage, bounds.x, bounds.y, bounds.x2(), bounds.y2(), color1, color2);
+void UIContext::DrawImageVGradient(ImageID image, uint32_t color1, uint32_t color2, const Bounds &bounds) {
+	uidrawbuffer_->DrawImageStretchVGradient(image, bounds.x, bounds.y, bounds.x2(), bounds.y2(), color1, color2);
 }
 
 void UIContext::PushTransform(const UITransform &transform) {

--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -55,6 +55,7 @@ void UIContext::BeginNoTex() {
 }
 
 void UIContext::BeginPipeline(Draw::Pipeline *pipeline, Draw::SamplerState *samplerState) {
+	_assert_(pipeline != nullptr);
 	draw_->BindSamplerStates(0, 1, &samplerState);
 	RebindTexture();
 	UIBegin(pipeline);
@@ -234,6 +235,10 @@ void UIContext::FillRect(const UI::Drawable &drawable, const Bounds &bounds) {
 	case UI::DRAW_NOTHING:
 		break;
 	} 
+}
+
+void UIContext::FillRectVGradient(uint32_t color1, uint32_t color2, const Bounds &bounds) {
+	uidrawbuffer_->DrawImageStretchVGradient(theme->whiteImage, bounds.x, bounds.y, bounds.x2(), bounds.y2(), color1, color2);
 }
 
 void UIContext::PushTransform(const UITransform &transform) {

--- a/Common/UI/Context.h
+++ b/Common/UI/Context.h
@@ -85,6 +85,7 @@ public:
 	void DrawTextShadow(const char *str, float x, float y, uint32_t color, int align = 0);
 	void DrawTextRect(const char *str, const Bounds &bounds, uint32_t color, int align = 0);
 	void FillRect(const UI::Drawable &drawable, const Bounds &bounds);
+	void FillRectVGradient(uint32_t color1, uint32_t color2, const Bounds &bounds);
 
 	// in dps, like dp_xres and dp_yres
 	void SetBounds(const Bounds &b) { bounds_ = b; }

--- a/Common/UI/Context.h
+++ b/Common/UI/Context.h
@@ -85,7 +85,7 @@ public:
 	void DrawTextShadow(const char *str, float x, float y, uint32_t color, int align = 0);
 	void DrawTextRect(const char *str, const Bounds &bounds, uint32_t color, int align = 0);
 	void FillRect(const UI::Drawable &drawable, const Bounds &bounds);
-	void FillRectVGradient(uint32_t color1, uint32_t color2, const Bounds &bounds);
+	void DrawImageVGradient(ImageID image, uint32_t color1, uint32_t color2, const Bounds &bounds);
 
 	// in dps, like dp_xres and dp_yres
 	void SetBounds(const Bounds &b) { bounds_ = b; }

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -394,7 +394,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 
 		if (!strcmp(compat.fragColor0, "fragColor0")) {
 			const char *qualifierColor0 = "out";
-			if (compat.lastFragData && !strcmp(compat.lastFragData, compat.fragColor0)) {
+			if (readFramebuffer && compat.lastFragData && !strcmp(compat.lastFragData, compat.fragColor0)) {
 				qualifierColor0 = "inout";
 			}
 			// Output the output color definitions.

--- a/UI/GPUDriverTestScreen.cpp
+++ b/UI/GPUDriverTestScreen.cpp
@@ -543,17 +543,17 @@ void GPUDriverTestScreen::ShaderTest() {
 	y += 100;
 
 	dc.Begin();
-	dc.DrawText("Flat shading", x, y, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
+	dc.DrawText("Flat shaded tex", x, y, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
 	dc.DrawText("(TEST OK if no gradient!)", x + 400, y, 0xFFFFFFFF, ALIGN_LEFT);
 	dc.Flush();
 
-	bounds = { x + 200, y, testW, 70 };
+	bounds = { x + 200, y, 100, 100 };
 
 	// Draw rectangle that should be flat shaded
 	dc.BeginPipeline(flatShadingPipeline_, samplerNearest_);
 	// There is a "provoking vertex" difference here between GL and Vulkan when using flat shading. One gets one color, one gets the other.
 	// Wherever possible we should reconfigure the GL provoking vertex to match Vulkan, probably.
-	dc.FillRectVGradient(bgColorOK, textColorOK, bounds);
+	dc.DrawImageVGradient(ImageID("I_ICON"), 0xFFFFFFFF, 0x808080FF, bounds);
 	dc.Flush();
 }
 

--- a/UI/GPUDriverTestScreen.cpp
+++ b/UI/GPUDriverTestScreen.cpp
@@ -2,6 +2,14 @@
 #include "Common/Data/Text/I18n.h"
 #include "Common/UI/View.h"
 #include "Common/GPU/Shader.h"
+#include "Common/GPU/ShaderWriter.h"
+
+const uint32_t textColorOK = 0xFF30FF30;
+const uint32_t textColorBAD = 0xFF3030FF;
+const uint32_t bgColorOK = 0xFF106010;
+const uint32_t bgColorBAD = 0xFF101060;
+
+// TODO: One day, port these to use ShaderWriter.
 
 static const std::vector<Draw::ShaderSource> fsDiscard = {
 	{ShaderLanguage::GLSL_1xx,
@@ -45,6 +53,119 @@ static const std::vector<Draw::ShaderSource> fsDiscard = {
 	},
 };
 
+static const std::vector<Draw::ShaderSource> fsAdrenoLogicTest = {
+	{ShaderLanguage::GLSL_1xx,
+	R"(
+	#ifdef GL_ES
+	precision lowp float;
+	#endif
+	#if __VERSION__ >= 130
+	#define varying in
+	#define gl_FragColor fragColor0
+	out vec4 fragColor0;
+	#endif
+	varying vec4 oColor0;
+	varying vec2 oTexCoord0;
+	uniform sampler2D Sampler0;
+	void main() {
+	#if __VERSION__ >= 130
+		vec4 color = (texture(Sampler0, oTexCoord0) * oColor0).aaaa;
+	#else
+		vec4 color = (texture2D(Sampler0, oTexCoord0) * oColor0).aaaa;
+	#endif
+		color *= 2.0;
+		if (color.r < 0.002 && color.g < 0.002 && color.b < 0.002) discard;
+		gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+	})"
+	},
+	{ShaderLanguage::GLSL_VULKAN,
+	R"(#version 450
+	#extension GL_ARB_separate_shader_objects : enable
+	#extension GL_ARB_shading_language_420pack : enable
+	precision lowp float;
+	layout(location = 0) flat in lowp vec4 oColor0;
+	layout(location = 1) in highp vec2 oTexCoord0;
+	layout(location = 0) out vec4 fragColor0;
+	layout(set = 0, binding = 1) uniform sampler2D Sampler0;
+	void main() {
+		vec4 t = texture(Sampler0, oTexCoord0).aaaa;
+		vec4 p = oColor0;
+		vec4 v = p * t;
+		v.rgb = clamp(v.rgb * 2.0, 0.0, 1.0);
+		if (v.r < 0.2 && v.g < 0.2 && v.b < 0.2) discard;
+		fragColor0 = vec4(0.0, 1.0, 0.0, 1.0);
+	})"
+	},
+};
+
+static const std::vector<Draw::ShaderSource> fsFlat = {
+	{ShaderLanguage::GLSL_1xx,
+	"#ifdef GL_ES\n"
+	"precision lowp float;\n"
+	"#endif\n"
+	"#if __VERSION__ >= 130\n"
+	"#define varying in\n"
+	"#define texture2D texture\n"
+	"#define gl_FragColor fragColor0\n"
+	"out vec4 fragColor0;\n"
+	"#endif\n"
+	"flat varying vec4 oColor0;\n"
+	"varying vec2 oTexCoord0;\n"
+	"uniform sampler2D Sampler0;\n"
+	"void main() { gl_FragColor = texture2D(Sampler0, oTexCoord0) * oColor0; }\n"
+	},
+	{ShaderLanguage::GLSL_VULKAN,
+	"#version 140\n"
+	"#extension GL_ARB_separate_shader_objects : enable\n"
+	"#extension GL_ARB_shading_language_420pack : enable\n"
+	"layout(location = 0) flat in lowp vec4 oColor0;\n"
+	"layout(location = 1) in highp vec2 oTexCoord0;\n"
+	"layout(location = 0) out vec4 fragColor0;\n"
+	"layout(set = 0, binding = 1) uniform sampler2D Sampler0;\n"
+	"void main() { fragColor0 = texture(Sampler0, oTexCoord0) * oColor0; }\n"
+	}
+};
+
+// shared with the adreno test
+static const std::vector<Draw::ShaderSource> vsFlat = {
+	{ GLSL_1xx,
+	"#if __VERSION__ >= 130\n"
+	"#define attribute in\n"
+	"#define varying out\n"
+	"#endif\n"
+	"attribute vec3 Position;\n"
+	"attribute vec4 Color0;\n"
+	"attribute vec2 TexCoord0;\n"
+	"flat varying vec4 oColor0;\n"
+	"varying vec2 oTexCoord0;\n"
+	"uniform mat4 WorldViewProj;\n"
+	"void main() {\n"
+	"  gl_Position = WorldViewProj * vec4(Position, 1.0);\n"
+	"  oColor0 = Color0;\n"
+	"  oTexCoord0 = TexCoord0;\n"
+	"}\n"
+	},
+	{ ShaderLanguage::GLSL_VULKAN,
+	"#version 450\n"
+	"#extension GL_ARB_separate_shader_objects : enable\n"
+	"#extension GL_ARB_shading_language_420pack : enable\n"
+	"layout (std140, set = 0, binding = 0) uniform bufferVals {\n"
+	"    mat4 WorldViewProj;\n"
+	"} myBufferVals;\n"
+	"layout (location = 0) in vec4 pos;\n"
+	"layout (location = 1) in vec4 inColor;\n"
+	"layout (location = 2) in vec2 inTexCoord;\n"
+	"layout (location = 0) flat out lowp vec4 outColor;\n"
+	"layout (location = 1) out highp vec2 outTexCoord;\n"
+	"out gl_PerVertex { vec4 gl_Position; };\n"
+	"void main() {\n"
+	"   outColor = inColor;\n"
+	"   outTexCoord = inTexCoord;\n"
+	"   gl_Position = myBufferVals.WorldViewProj * pos;\n"
+	"}\n"
+	}
+};
+
 GPUDriverTestScreen::GPUDriverTestScreen() {
 	using namespace Draw;
 }
@@ -76,11 +197,33 @@ GPUDriverTestScreen::~GPUDriverTestScreen() {
 
 	if (discardFragShader_)
 		discardFragShader_->Release();
+
+	// Shader test
+	if (adrenoLogicDiscardPipeline_)
+		adrenoLogicDiscardPipeline_->Release();
+	if (flatShadingPipeline_)
+		flatShadingPipeline_->Release();
+
+	if (adrenoLogicDiscardFragShader_)
+		adrenoLogicDiscardFragShader_->Release();
+	if (flatFragShader_)
+		flatFragShader_->Release();
+	if (flatVertShader_)
+		flatVertShader_->Release();
+
 	if (samplerNearest_)
 		samplerNearest_->Release();
 }
 
 void GPUDriverTestScreen::CreateViews() {
+	using namespace Draw;
+
+	if (!samplerNearest_) {
+		DrawContext *draw = screenManager()->getDrawContext();
+		SamplerStateDesc nearestDesc{};
+		samplerNearest_ = draw->CreateSamplerState(nearestDesc);
+	}
+
 	// Don't bother with views for now.
 	using namespace UI;
 	auto di = GetI18NCategory("Dialog");
@@ -92,6 +235,7 @@ void GPUDriverTestScreen::CreateViews() {
 	tabHolder_ = new TabHolder(ORIENT_HORIZONTAL, 30.0f, new AnchorLayoutParams(FILL_PARENT, FILL_PARENT, false));
 	anchor->Add(tabHolder_);
 	tabHolder_->AddTab("Discard", new LinearLayout(ORIENT_VERTICAL));
+	tabHolder_->AddTab("Shader", new LinearLayout(ORIENT_VERTICAL));
 
 	Choice *back = new Choice(di->T("Back"), "", false, new AnchorLayoutParams(100, WRAP_CONTENT, 10, NONE, NONE, 10));
 	back->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
@@ -230,9 +374,6 @@ void GPUDriverTestScreen::DiscardTest() {
 		depthTestLessEqual->Release();
 		depthTestGreater->Release();
 		rasterNoCull->Release();
-
-		SamplerStateDesc nearestDesc{};
-		samplerNearest_ = draw->CreateSamplerState(nearestDesc);
 	}
 
 	UIContext &dc = *screenManager()->getUIContext();
@@ -252,11 +393,6 @@ void GPUDriverTestScreen::DiscardTest() {
 		{true, true, false, false},
 		{false, false, true, true},
 	};
-
-	uint32_t textColorOK = 0xFF30FF30;
-	uint32_t textColorBAD = 0xFF3030FF;
-	uint32_t bgColorOK = 0xFF106010;
-	uint32_t bgColorBAD = 0xFF101060;
 
 	// Don't want any fancy font texture stuff going on here, so use FLAG_DYNAMIC_ASCII everywhere!
 
@@ -328,11 +464,110 @@ void GPUDriverTestScreen::DiscardTest() {
 	dc.Flush();
 }
 
+void GPUDriverTestScreen::ShaderTest() {
+	using namespace Draw;
+
+	UIContext &dc = *screenManager()->getUIContext();
+	Draw::DrawContext *draw = dc.GetDrawContext();
+
+	if (!adrenoLogicDiscardPipeline_) {
+		adrenoLogicDiscardFragShader_ = CreateShader(draw, ShaderStage::Fragment, fsAdrenoLogicTest);
+
+		flatFragShader_ = CreateShader(draw, ShaderStage::Fragment, fsFlat);
+		flatVertShader_ = CreateShader(draw, ShaderStage::Vertex, vsFlat);
+
+		InputLayout *inputLayout = ui_draw2d.CreateInputLayout(draw);
+		// No blending used.
+		BlendState *blendOff = draw->CreateBlendState({ false, 0xF });
+
+		// No depth or stencil, we only use discard in this test.
+		DepthStencilStateDesc dsDesc{};
+		dsDesc.depthTestEnabled = false;
+		dsDesc.depthWriteEnabled = false;
+		DepthStencilState *depthStencilOff = draw->CreateDepthStencilState(dsDesc);
+
+		RasterState *rasterNoCull = draw->CreateRasterState({});
+
+		PipelineDesc adrenoLogicDiscardDesc{
+			Primitive::TRIANGLE_LIST,
+			{ flatVertShader_, adrenoLogicDiscardFragShader_ },
+			inputLayout, depthStencilOff, blendOff, rasterNoCull, &vsColBufDesc,
+		};
+		adrenoLogicDiscardPipeline_ = draw->CreateGraphicsPipeline(adrenoLogicDiscardDesc);
+
+		PipelineDesc flatDesc{
+			Primitive::TRIANGLE_LIST,
+			{ flatVertShader_, flatFragShader_ },
+			inputLayout, depthStencilOff, blendOff, rasterNoCull, &vsColBufDesc,
+		};
+		flatShadingPipeline_ = draw->CreateGraphicsPipeline(flatDesc);
+
+		inputLayout->Release();
+		blendOff->Release();
+		depthStencilOff->Release();
+		rasterNoCull->Release();
+	}
+
+	Bounds layoutBounds = dc.GetLayoutBounds();
+
+	dc.Begin();
+	dc.SetFontScale(1.0f, 1.0f);
+	std::string apiName = screenManager()->getDrawContext()->GetInfoString(InfoField::APINAME);
+	std::string vendor = screenManager()->getDrawContext()->GetInfoString(InfoField::VENDORSTRING);
+	std::string driver = screenManager()->getDrawContext()->GetInfoString(InfoField::DRIVER);
+	dc.DrawText(apiName.c_str(), layoutBounds.centerX(), 20, 0xFFFFFFFF, ALIGN_CENTER);
+	dc.DrawText(vendor.c_str(), layoutBounds.centerX(), 60, 0xFFFFFFFF, ALIGN_CENTER);
+	dc.DrawText(driver.c_str(), layoutBounds.centerX(), 100, 0xFFFFFFFF, ALIGN_CENTER);
+	dc.Flush();
+
+	float y = layoutBounds.y + 150;
+	float x = layoutBounds.x + 10;
+	dc.Begin();
+	dc.DrawText("Adreno logic", x, y, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
+	dc.Flush();
+
+	float testW = 170.f;
+
+	Bounds bounds = { x + 200, y, testW, 70 };
+
+	// Draw rectangle that should result in the bg
+	dc.Begin();
+	dc.FillRect(UI::Drawable(bgColorOK), bounds);
+	dc.Flush();
+
+	// Draw text on it using the shader.
+	dc.BeginPipeline(adrenoLogicDiscardPipeline_, samplerNearest_);
+	dc.DrawTextRect("TEST OK", bounds, textColorOK, ALIGN_HCENTER | ALIGN_VCENTER | FLAG_DYNAMIC_ASCII);
+	dc.Flush();
+
+	y += 100;
+
+	dc.Begin();
+	dc.DrawText("Flat shading", x, y, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
+	dc.DrawText("(TEST OK if no gradient!)", x + 400, y, 0xFFFFFFFF, ALIGN_LEFT);
+	dc.Flush();
+
+	bounds = { x + 200, y, testW, 70 };
+
+	// Draw rectangle that should be flat shaded
+	dc.BeginPipeline(flatShadingPipeline_, samplerNearest_);
+	// There is a "provoking vertex" difference here between GL and Vulkan when using flat shading. One gets one color, one gets the other.
+	// Wherever possible we should reconfigure the GL provoking vertex to match Vulkan, probably.
+	dc.FillRectVGradient(bgColorOK, textColorOK, bounds);
+	dc.Flush();
+}
+
+
 void GPUDriverTestScreen::render() {
 	using namespace Draw;
 	UIScreen::render();
 
-	if (tabHolder_->GetCurrentTab() == 0) {
+	switch (tabHolder_->GetCurrentTab()) {
+	case 0:
 		DiscardTest();
+		break;
+	case 1:
+		ShaderTest();
+		break;
 	}
 }

--- a/UI/GPUDriverTestScreen.h
+++ b/UI/GPUDriverTestScreen.h
@@ -51,6 +51,7 @@ private:
 
 	Draw::Pipeline *adrenoLogicDiscardPipeline_ = nullptr;
 	Draw::ShaderModule *adrenoLogicDiscardFragShader_ = nullptr;
+	Draw::ShaderModule *adrenoLogicDiscardVertShader_ = nullptr;
 	Draw::Pipeline *flatShadingPipeline_ = nullptr;
 	Draw::ShaderModule *flatFragShader_ = nullptr;
 	Draw::ShaderModule *flatVertShader_ = nullptr;

--- a/UI/GPUDriverTestScreen.h
+++ b/UI/GPUDriverTestScreen.h
@@ -20,6 +20,13 @@ public:
 
 private:
 	void DiscardTest();
+	void ShaderTest();
+
+	// Common objects
+	Draw::SamplerState *samplerNearest_ = nullptr;
+
+	// Discard/depth/stencil stuff
+	// ===========================
 
 	Draw::ShaderModule *discardFragShader_ = nullptr;
 	Draw::Pipeline *discardWriteDepthStencil_ = nullptr;
@@ -38,6 +45,15 @@ private:
 	Draw::Pipeline *drawTestDepthLessEqual_ = nullptr;
 	Draw::Pipeline *drawTestDepthGreater_ = nullptr;
 
-	Draw::SamplerState *samplerNearest_ = nullptr;
+
+	// Shader tests
+	// ============
+
+	Draw::Pipeline *adrenoLogicDiscardPipeline_ = nullptr;
+	Draw::ShaderModule *adrenoLogicDiscardFragShader_ = nullptr;
+	Draw::Pipeline *flatShadingPipeline_ = nullptr;
+	Draw::ShaderModule *flatFragShader_ = nullptr;
+	Draw::ShaderModule *flatVertShader_ = nullptr;
+
 	UI::TabHolder *tabHolder_ = nullptr;
 };


### PR DESCRIPTION
The adreno test tests for a serious shader compiler bug mentioned in #13910.
Basically it miscompiles ``if (color.r < 0.002 && color.g < 0.002 && color.b < 0.002) discard;``.

Access through Settings/Tools/Developer Tools/GPU Driver Test/Shader.

Bad (adreno test):

![image](https://user-images.githubusercontent.com/130929/104827726-46554f00-5861-11eb-977f-57e052d0b917.png)

Good (adreno test):

![image](https://user-images.githubusercontent.com/130929/104827735-6127c380-5861-11eb-8b6b-d5c9390a3297.png)


Very clear repro on Adreno 630, Pocophone F1.

The flat shading test is an untested attempt at a repro of #13451 (corrupt rendering of flat shading on iOS 14.x).

(will test that soon).