### PR TITLE
Vulkan: Delete only created swapchain images

### DIFF
--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -346,8 +346,8 @@ void VulkanRenderManager::DestroyBackbuffers() {
 	StopThread();
 	vulkan_->WaitUntilQueueIdle();
 
-	for (uint32_t i = 0; i < swapchainImageCount_; i++) {
-		vulkan_->Delete().QueueDeleteImageView(swapchainImages_[i].view);
+	for (auto &image : swapchainImages_) {
+		vulkan_->Delete().QueueDeleteImageView(image.view);
 	}
 	swapchainImages_.clear();
 


### PR DESCRIPTION
We do other null checks here, same reason.  Create may have failed.

See https://github.com/hrydgard/ppsspp/issues/13921#issuecomment-761728146.

-[Unknown]