### PR TITLE
Compat: Note those 3 LEGO games requires Buffered rendering

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -489,6 +489,15 @@ NPJH50051 = true
 # Manhunt 2
 ULUS10280 = true
 ULES00756 = true
+# LEGO Star Wars II: The Original Trilogy
+ULUS10155 = true
+ULES00479 = true
+# LEGO Indiana Jones: The Original Adventures
+ULUS10365 = true
+ULES01086 = true
+# LEGO Batman: The Videogame
+ULUS10380 = true
+ULES01151 = true
 # TODO: There are many more.
 
 [RequireBlockTransfer]


### PR DESCRIPTION
Those are 3 LEGO games that requires Buffered rendering when I change to skip buffer effects it went black screen.