### PR TITLE
HLE: Hook Worms text render copy func

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -1238,6 +1238,17 @@ static int Hook_motorstorm_pixel_read() {
 	return 0;
 }
 
+static int Hook_worms_copy_normalize_alpha() {
+	// At this point in the function (0x0CC), s1 is the framebuf and a2 is the size.
+	u32 fb_address = currentMIPS->r[MIPS_REG_S1];
+	u32 fb_size = currentMIPS->r[MIPS_REG_A2];
+	if (Memory::IsVRAMAddress(fb_address) && Memory::IsValidRange(fb_address, fb_size)) {
+		gpu->PerformMemoryDownload(fb_address, fb_size);
+		CBreakPoints::ExecMemCheck(fb_address, true, fb_size, currentMIPS->pc);
+	}
+	return 0;
+}
+
 #define JITFUNC(f) (&MIPSComp::MIPSFrontendInterface::f)
 
 // Can either replace with C functions or functions emitted in Asm/ArmAsm.
@@ -1350,6 +1361,7 @@ static const ReplacementTableEntry entries[] = {
 	{ "starocean_clear_framebuf", &Hook_starocean_clear_framebuf_before, 0, REPFLAG_HOOKENTER, 0 },
 	{ "starocean_clear_framebuf", &Hook_starocean_clear_framebuf_after, 0, REPFLAG_HOOKEXIT, 0 },
 	{ "motorstorm_pixel_read", &Hook_motorstorm_pixel_read, 0, REPFLAG_HOOKENTER, 0 },
+	{ "worms_copy_normalize_alpha", &Hook_worms_copy_normalize_alpha, 0, REPFLAG_HOOKENTER, 0x0CC },
 	{}
 };
 

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -325,6 +325,7 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0x8df2928848857e97, 164, "strcat", },
 	{ 0x8e48cabd529ca6b5, 52, "vector_multiply_t", },
 	{ 0x8e97dcb03fbaba5c, 104, "vmmul_q_transp", },
+	{ 0x8ecf804bbe7922e5, 572, "worms_copy_normalize_alpha" }, // Worms Battle Islands (US)
 	{ 0x8ee81b03d2eef1e7, 28, "vmul_t", },
 	{ 0x8f09fb8693c3c49d, 992, "kirameki_school_life_download_frame", }, // Hentai Ouji To Warawanai Neko
 	{ 0x8f19c41e8b987e18, 100, "matrix_mogrify", },


### PR DESCRIPTION
This func takes drawn text and replaces stencil with alpha based on the color intensity to prepare text for blending.

See #12380.  Tested only with the Worms Battle Islands US demo, but it might be the same func in all the games.

Here's a rough picture of the top of the func for reference with the hook (which hooks at the end of this sequence):

```
void worms_copy_normalize_alpha(Unk *s0) {
	v0 = z_un_089d3d78();
	a0 = *(Unk2 *)v0;
	a0->unk004Cfp(v0 + a0->unk0048h, 0, a0->unk0048h);

	v0 = z_un_089d3d78();
	a0 = *(Unk2 *)v0;
	// Frame buffer size here, stride fixed 512 and 32-bit.
	s1 = a0->unk014Cfp(v0 + a0->unk0148h, a0->unk0148h);

	v0 = z_un_089d3d78();
	a0 = *(Unk2 *)v0;
	a0->unk004Cfp(v0 + a0->unk0048h, 1, a0->unk0048h);

	z_un_08a1b110(0, 0);

	a3 = s0->unk0030p->unk0004h;
	// Total size calculated here.
	a2 = s0->unk002Ch * s0->unk002Eh * 4;
```

-[Unknown]