### PR TITLE
Allow PNGs and http:// for headless test expected files

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -33,6 +33,7 @@
 #include "Core/HLE/HLETables.h"
 #include "Core/HLE/Plugins.h"
 #include "Core/HLE/ReplaceTables.h"
+#include "Core/HLE/sceDisplay.h"
 #include "Core/Reporting.h"
 #include "Core/Host.h"
 #include "Core/Loaders.h"
@@ -1878,6 +1879,14 @@ void __KernelGPUReplay() {
 
 	std::string filename(filenamep, currentMIPS->r[MIPS_REG_S0]);
 	if (!GPURecord::RunMountedReplay(filename)) {
+		Core_Stop();
+	}
+
+	if (PSP_CoreParameter().headLess && !PSP_CoreParameter().startBreak) {
+		PSPPointer<u8> topaddr;
+		u32 linesize = 512;
+		__DisplayGetFramebuf(&topaddr, &linesize, nullptr, 0);
+		host->SendDebugScreenshot(topaddr, linesize, 272);
 		Core_Stop();
 	}
 }

--- a/headless/Compare.cpp
+++ b/headless/Compare.cpp
@@ -187,14 +187,24 @@ protected:
 	std::ifstream &in_;
 };
 
-std::string ExpectedFromFilename(const std::string &bootFilename)
-{
-	return bootFilename.substr(0, bootFilename.length() - 4) + ".expected";
+std::string ExpectedFromFilename(const std::string &bootFilename) {
+	size_t pos = bootFilename.find_last_of('.');
+	if (pos == bootFilename.npos) {
+		return bootFilename + ".expected";
+	}
+	return bootFilename.substr(0, pos) + ".expected";
 }
 
-std::string ExpectedScreenshotFromFilename(const std::string &bootFilename)
-{
-	return bootFilename.substr(0, bootFilename.length() - 4) + ".expected.bmp";
+std::string ExpectedScreenshotFromFilename(const std::string &bootFilename) {
+	size_t pos = bootFilename.find_last_of('.');
+	if (pos == bootFilename.npos) {
+		return bootFilename + ".bmp";
+	}
+	// Let's use pngs as the default for ppdmp tests.
+	if (bootFilename.substr(pos) == ".ppdmp") {
+		return bootFilename.substr(0, pos) + ".png";
+	}
+	return bootFilename.substr(0, pos) + ".expected.bmp";
 }
 
 static std::string ChopFront(std::string s, std::string front)

--- a/headless/StubHost.cpp
+++ b/headless/StubHost.cpp
@@ -60,22 +60,19 @@ void HeadlessHost::SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h) {
 		SendOrCollectDebugOutput(temp);
 	}
 
-	if (errors > 0 && !teamCityMode)
-	{
-		// Lazy, just read in the original header to output the failed screenshot.
-		u8 header[14 + 40] = {0};
-		FILE *bmp = File::OpenCFile(comparisonScreenshot_, "rb");
-		if (bmp)
-		{
-			if (fread(&header, sizeof(header), 1, bmp) != 1) {
-				SendOrCollectDebugOutput("Failed to read original screenshot header.\n");
-			}
-			fclose(bmp);
-		}
+	if (errors > 0 && !teamCityMode && !getenv("GITHUB_ACTIONS")) {
+		static const u8 header[14 + 40] = {
+			0x42, 0x4D, 0x38, 0x80, 0x08, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x36, 0x00, 0x00, 0x00, 0x28, 0x00,
+			0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x10, 0x01,
+			0x00, 0x00, 0x01, 0x00, 0x20, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x02, 0x80, 0x08, 0x00, 0x12, 0x0B,
+			0x00, 0x00, 0x12, 0x0B, 0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		};
 
 		FILE *saved = File::OpenCFile("__testfailure.bmp", "wb");
-		if (saved)
-		{
+		if (saved) {
 			fwrite(&header, sizeof(header), 1, saved);
 			fwrite(pixels.data(), sizeof(u32), FRAME_STRIDE * FRAME_HEIGHT, saved);
 			fclose(saved);

--- a/headless/StubHost.cpp
+++ b/headless/StubHost.cpp
@@ -33,12 +33,7 @@ void HeadlessHost::SendOrCollectDebugOutput(const std::string &data)
 		DEBUG_LOG(COMMON, "%s", data.c_str());
 }
 
-void HeadlessHost::SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h)
-{
-	if (!gfx_) {
-		return;
-	}
-
+void HeadlessHost::SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h) {
 	// Only if we're actually comparing.
 	if (comparisonScreenshot_.empty()) {
 		return;


### PR DESCRIPTION
This makes a few related changes:
 * Fixes screenshot compare without a backend (i.e. on CI.)
 * Allows the `.expected` and `.expected.bmp` files to be read via http:// for prx tests.
 * Allows `.ppdmp` files to be run in one shot via headless and output a screenshot for compare.
 * Makes `--compare` use PNGs by default for ppdmps since it's more convenient there.

This is in some ways related to #11888.  However, at this point it just makes headless able to run `.ppdmp` tests via CI or command line effectively, which I see as a prerequisite to even maintaining tests for mobile devices/etc.

-[Unknown]