### PR TITLE
GPU: Fix safe size checks when rect offscreen

### DIFF
--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -471,8 +471,8 @@ void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVt
 	if (!result->setSafeSize && prim == GE_PRIM_RECTANGLES && maxIndex == 2) {
 		bool clearingColor = gstate.isModeClear() && (gstate.isClearModeColorMask() || gstate.isClearModeAlphaMask());
 		bool writingColor = gstate.getColorMask() != 0xFFFFFFFF;
-		bool startsZeroX = transformed[0].x <= 0.0f && transformed[1].x > transformed[0].x;
-		bool startsZeroY = transformed[0].y <= 0.0f && transformed[1].y > transformed[0].y;
+		bool startsZeroX = transformed[0].x <= 0.0f && transformed[1].x > 0.0f && transformed[1].x > transformed[0].x;
+		bool startsZeroY = transformed[0].y <= 0.0f && transformed[1].y > 0.0f && transformed[1].y > transformed[0].y;
 
 		if (startsZeroX && startsZeroY && (clearingColor || writingColor)) {
 			int scissorX2 = gstate.getScissorX2() + 1;


### PR DESCRIPTION
Related to #13327 and #12858.  When something had all coordinates negative, we could set safeWidth or safeHeight to negative values.  This would then overflow to very positive values (since they are uint16_t) and cause incorrect clearing.

For desktop, this is the cause of #13916 (possibly also mobile.)  May also be the cause of #13346 and #13344.  If so perhaps we can consider removing the "skip first frame" hack.

-[Unknown]