### PR TITLE
Dialog: Simulate volatile memory lock behavior

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -28,11 +28,7 @@
 #define FADE_TIME 1.0
 const float FONT_SCALE = 0.55f;
 
-PSPDialog::PSPDialog()
-	: status(SCE_UTILITY_STATUS_NONE), pendingStatus(SCE_UTILITY_STATUS_NONE),
-	  pendingStatusTicks(0), lastButtons(0), buttons(0)
-{
-
+PSPDialog::PSPDialog() {
 }
 
 PSPDialog::~PSPDialog() {

--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -21,9 +21,11 @@
 #include "Common/Serialize/SerializeFuncs.h"
 #include "Common/StringUtils.h"
 #include "Core/CoreTiming.h"
-#include "Core/HLE/sceCtrl.h"
-#include "Core/Util/PPGeDraw.h"
 #include "Core/Dialog/PSPDialog.h"
+#include "Core/HLE/sceCtrl.h"
+#include "Core/HLE/scePower.h"
+#include "Core/MemMapHelpers.h"
+#include "Core/Util/PPGeDraw.h"
 
 #define FADE_TIME 1.0
 const float FONT_SCALE = 0.55f;
@@ -34,11 +36,24 @@ PSPDialog::PSPDialog() {
 PSPDialog::~PSPDialog() {
 }
 
-PSPDialog::DialogStatus PSPDialog::GetStatus()
-{
+PSPDialog::DialogStatus PSPDialog::GetStatus() {
 	if (pendingStatusTicks != 0 && CoreTiming::GetTicks() >= pendingStatusTicks) {
-		status = pendingStatus;
-		pendingStatusTicks = 0;
+		bool changeAllowed = true;
+		if (pendingStatus == SCE_UTILITY_STATUS_NONE && status == SCE_UTILITY_STATUS_SHUTDOWN) {
+			if (volatileLocked_) {
+				KernelVolatileMemUnlock(0);
+				volatileLocked_ = false;
+			}
+		} else if (pendingStatus == SCE_UTILITY_STATUS_RUNNING && status == SCE_UTILITY_STATUS_INITIALIZE) {
+			if (!volatileLocked_) {
+				volatileLocked_ = KernelVolatileMemLock(0, 0, 0) == 0;
+				changeAllowed = volatileLocked_;
+			}
+		}
+		if (changeAllowed) {
+			status = pendingStatus;
+			pendingStatusTicks = 0;
+		}
 	}
 
 	PSPDialog::DialogStatus retval = status;
@@ -53,11 +68,30 @@ PSPDialog::DialogStatus PSPDialog::GetStatus()
 
 void PSPDialog::ChangeStatus(DialogStatus newStatus, int delayUs) {
 	if (delayUs <= 0) {
+		if (newStatus == SCE_UTILITY_STATUS_NONE && status == SCE_UTILITY_STATUS_SHUTDOWN) {
+			if (volatileLocked_) {
+				KernelVolatileMemUnlock(0);
+				volatileLocked_ = false;
+			}
+		} else if (newStatus == SCE_UTILITY_STATUS_RUNNING && status == SCE_UTILITY_STATUS_INITIALIZE) {
+			if (!volatileLocked_) {
+				// TODO: Should probably make the status pending instead?
+				volatileLocked_ = KernelVolatileMemLock(0, 0, 0) == 0;
+			}
+		}
 		status = newStatus;
 		pendingStatusTicks = 0;
 	} else {
 		pendingStatus = newStatus;
 		pendingStatusTicks = CoreTiming::GetTicks() + usToCycles(delayUs);
+	}
+}
+
+void PSPDialog::FinishVolatile() {
+	if (KernelVolatileMemUnlock(0) == 0) {
+		volatileLocked_ = false;
+		// Simulate modifications to volatile memory.
+		Memory::Memset(PSP_GetVolatileMemoryStart(), 0, PSP_GetVolatileMemoryEnd() - PSP_GetVolatileMemoryStart());
 	}
 }
 
@@ -128,9 +162,8 @@ u32 PSPDialog::CalcFadedColor(u32 inColor)
 	return (inColor & 0x00FFFFFF) | (alpha << 24);
 }
 
-void PSPDialog::DoState(PointerWrap &p)
-{
-	auto s = p.Section("PSPDialog", 1, 2);
+void PSPDialog::DoState(PointerWrap &p) {
+	auto s = p.Section("PSPDialog", 1, 3);
 	if (!s)
 		return;
 
@@ -156,6 +189,12 @@ void PSPDialog::DoState(PointerWrap &p)
 		Do(p, pendingStatusTicks);
 	} else {
 		pendingStatusTicks = 0;
+	}
+
+	if (s >= 3) {
+		Do(p, volatileLocked_);
+	} else {
+		volatileLocked_ = false;
 	}
 }
 

--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -94,23 +94,23 @@ protected:
 	void ChangeStatus(DialogStatus newStatus, int delayUs);
 	void ChangeStatusInit(int delayUs);
 	void ChangeStatusShutdown(int delayUs);
+	DialogStatus ReadStatus() {
+		return status;
+	}
 
 	// TODO: Remove this once all dialogs are updated.
-	virtual bool UseAutoStatus() {
-		return true;
-	}
+	virtual bool UseAutoStatus() = 0;
 
 	void StartFade(bool fadeIn_);
 	void UpdateFade(int animSpeed);
 	virtual void FinishFadeOut();
 	u32 CalcFadedColor(u32 inColor);
 
-	DialogStatus status;
-	DialogStatus pendingStatus;
-	u64 pendingStatusTicks;
+	DialogStatus pendingStatus = SCE_UTILITY_STATUS_NONE;
+	u64 pendingStatusTicks = 0;
 
-	unsigned int lastButtons;
-	unsigned int buttons;
+	unsigned int lastButtons = 0;
+	unsigned int buttons = 0;
 
 	float fadeTimer;
 	bool isFading;
@@ -121,4 +121,7 @@ protected:
 	ImageID cancelButtonImg;
 	int okButtonFlag;
 	int cancelButtonFlag;
+
+private:
+	DialogStatus status = SCE_UTILITY_STATUS_NONE;
 };

--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -123,5 +123,8 @@ protected:
 	int cancelButtonFlag;
 
 private:
+	void FinishVolatile();
+
 	DialogStatus status = SCE_UTILITY_STATUS_NONE;
+	bool volatileLocked_ = false;
 };

--- a/Core/Dialog/PSPGamedataInstallDialog.h
+++ b/Core/Dialog/PSPGamedataInstallDialog.h
@@ -46,6 +46,12 @@ public:
 	int Abort();
 	std::string GetGameDataInstallFileName(SceUtilityGamedataInstallParam *param, std::string filename);
 
+protected:
+	// TODO: Manage status correctly.
+	bool UseAutoStatus() override {
+		return true;
+	}
+
 private:
 	void UpdateProgress();
 	void OpenNextFile();

--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -62,7 +62,7 @@ PSPNetconfDialog::~PSPNetconfDialog() {
 
 int PSPNetconfDialog::Init(u32 paramAddr) {
 	// Already running
-	if (status != SCE_UTILITY_STATUS_NONE)
+	if (ReadStatus() != SCE_UTILITY_STATUS_NONE)
 		return SCE_ERROR_UTILITY_INVALID_STATUS;
 
 	requestAddr = paramAddr;
@@ -471,7 +471,7 @@ int PSPNetconfDialog::Update(int animSpeed) {
 }
 
 int PSPNetconfDialog::Shutdown(bool force) {
-	if (status != SCE_UTILITY_STATUS_FINISHED && !force)
+	if (ReadStatus() != SCE_UTILITY_STATUS_FINISHED && !force)
 		return SCE_ERROR_UTILITY_INVALID_STATUS;
 
 	PSPDialog::Shutdown(force);

--- a/Core/Dialog/PSPPlaceholderDialog.cpp
+++ b/Core/Dialog/PSPPlaceholderDialog.cpp
@@ -25,20 +25,18 @@ PSPPlaceholderDialog::~PSPPlaceholderDialog() {
 }
 
 
-int PSPPlaceholderDialog::Init()
-{
-	status = SCE_UTILITY_STATUS_INITIALIZE;
+int PSPPlaceholderDialog::Init() {
+	ChangeStatus(SCE_UTILITY_STATUS_INITIALIZE, 0);
 	return 0;
 }
 
-int PSPPlaceholderDialog::Update(int animSpeed)
-{
-	if (status == SCE_UTILITY_STATUS_INITIALIZE) {
-		status = SCE_UTILITY_STATUS_RUNNING;
-	} else if (status == SCE_UTILITY_STATUS_RUNNING) {
-		status = SCE_UTILITY_STATUS_FINISHED;
-	} else if (status == SCE_UTILITY_STATUS_FINISHED) {
-		status = SCE_UTILITY_STATUS_SHUTDOWN;
+int PSPPlaceholderDialog::Update(int animSpeed) {
+	if (ReadStatus() == SCE_UTILITY_STATUS_INITIALIZE) {
+		ChangeStatus(SCE_UTILITY_STATUS_RUNNING, 0);
+	} else if (ReadStatus() == SCE_UTILITY_STATUS_RUNNING) {
+		ChangeStatus(SCE_UTILITY_STATUS_FINISHED, 0);
+	} else if (ReadStatus() == SCE_UTILITY_STATUS_FINISHED) {
+		ChangeStatus(SCE_UTILITY_STATUS_SHUTDOWN, 0);
 	}
 
 	return 0;

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -1013,7 +1013,7 @@ int PSPSaveDialog::Update(int animSpeed)
 		break;
 	}
 
-	if (status == SCE_UTILITY_STATUS_FINISHED || pendingStatus == SCE_UTILITY_STATUS_FINISHED)
+	if (ReadStatus() == SCE_UTILITY_STATUS_FINISHED || pendingStatus == SCE_UTILITY_STATUS_FINISHED)
 		Memory::Memcpy(requestAddr, &request, request.common.size);
 	
 	return 0;

--- a/Core/Dialog/PSPScreenshotDialog.cpp
+++ b/Core/Dialog/PSPScreenshotDialog.cpp
@@ -61,7 +61,7 @@ PSPScreenshotDialog::~PSPScreenshotDialog() {
 
 int PSPScreenshotDialog::Init(u32 paramAddr) {
 	// Already running
-	if (status != SCE_UTILITY_STATUS_NONE && status != SCE_UTILITY_STATUS_SHUTDOWN) {
+	if (ReadStatus() != SCE_UTILITY_STATUS_NONE && ReadStatus() != SCE_UTILITY_STATUS_SHUTDOWN) {
 		ERROR_LOG_REPORT(HLE, "sceUtilityScreenshotInitStart(%08x): invalid status", paramAddr);
 		return SCE_ERROR_UTILITY_INVALID_STATUS;
 	}
@@ -84,23 +84,23 @@ int PSPScreenshotDialog::Init(u32 paramAddr) {
 	}
 
 	mode = params_->mode;
-	status = SCE_UTILITY_STATUS_INITIALIZE;
+	ChangeStatus(SCE_UTILITY_STATUS_INITIALIZE, 0);
 
 	return 0;
 }
 
 int PSPScreenshotDialog::Update(int animSpeed) {
 	if (UseAutoStatus()) {
-		if (status == SCE_UTILITY_STATUS_INITIALIZE) {
-			status = SCE_UTILITY_STATUS_RUNNING;
-		} else if (status == SCE_UTILITY_STATUS_RUNNING) {
+		if (ReadStatus() == SCE_UTILITY_STATUS_INITIALIZE) {
+			ChangeStatus(SCE_UTILITY_STATUS_RUNNING, 0);
+		} else if (ReadStatus() == SCE_UTILITY_STATUS_RUNNING) {
 			if (mode == SCE_UTILITY_SCREENSHOT_TYPE_CONT_START) {
-				status = SCE_UTILITY_STATUS_SCREENSHOT_UNKNOWN;
+				ChangeStatus(SCE_UTILITY_STATUS_SCREENSHOT_UNKNOWN, 0);
 			} else {
-				status = SCE_UTILITY_STATUS_FINISHED;
+				ChangeStatus(SCE_UTILITY_STATUS_FINISHED, 0);
 			}
-		} else if (status == SCE_UTILITY_STATUS_FINISHED) {
-			status = SCE_UTILITY_STATUS_SHUTDOWN;
+		} else if (ReadStatus() == SCE_UTILITY_STATUS_FINISHED) {
+			ChangeStatus(SCE_UTILITY_STATUS_SHUTDOWN, 0);
 		}
 	}
 	return 0;
@@ -108,11 +108,11 @@ int PSPScreenshotDialog::Update(int animSpeed) {
 
 int PSPScreenshotDialog::ContStart() {
 	// Based on JPCSP http://code.google.com/p/jpcsp/source/detail?r=3381
-	if (status != SCE_UTILITY_STATUS_SCREENSHOT_UNKNOWN)
+	if (ReadStatus() != SCE_UTILITY_STATUS_SCREENSHOT_UNKNOWN)
 		return SCE_ERROR_UTILITY_INVALID_STATUS;
 
 	// Check with JPCSPTrace log of Dream Club Portable
-	status = SCE_UTILITY_STATUS_FINISHED;
+	ChangeStatus(SCE_UTILITY_STATUS_FINISHED, 0);
 
 	return 0;
 }

--- a/Core/Dialog/PSPScreenshotDialog.h
+++ b/Core/Dialog/PSPScreenshotDialog.h
@@ -33,6 +33,11 @@ public:
 	virtual void DoState(PointerWrap &p) override;
 
 protected:
+	// TODO: Manage status correctly.
+	bool UseAutoStatus() override {
+		return true;
+	}
+
 	int mode;
 	PSPPointer<SceUtilityScreenshotParams> params_;
 };

--- a/Core/HLE/scePower.h
+++ b/Core/HLE/scePower.h
@@ -24,3 +24,6 @@ void __PowerDoState(PointerWrap &p);
 
 void Register_scePower();
 void Register_sceSuspendForUser();
+
+int KernelVolatileMemLock(int type, u32 paddr, u32 psize);
+int KernelVolatileMemUnlock(int type);

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -465,8 +465,11 @@ inline u32 PSP_GetScratchpadMemoryEnd() { return 0x00014000;}
 inline u32 PSP_GetKernelMemoryBase() { return 0x08000000;}
 inline u32 PSP_GetUserMemoryEnd() { return PSP_GetKernelMemoryBase() + Memory::g_MemorySize;}
 inline u32 PSP_GetKernelMemoryEnd() { return 0x08400000;}
+
 // "Volatile" RAM is between 0x08400000 and 0x08800000, can be requested by the
 // game through sceKernelVolatileMemTryLock.
+inline u32 PSP_GetVolatileMemoryStart() { return 0x08400000; }
+inline u32 PSP_GetVolatileMemoryEnd() { return 0x08800000; }
 
 inline u32 PSP_GetUserMemoryBase() { return 0x08800000;}
 inline u32 PSP_GetDefaultLoadAddress() { return 0;}


### PR DESCRIPTION
See notes in #13765.  While not using a thread (which is likely more correct), this largely simulates the observable behavior for most dialogs.  It also prevents state changes until the lock is acquired, which might be important for timing things in some games.

Should help #8288.

-[Unknown]