### PR TITLE
Vulkan: Prevent scaling shader leak

### DIFF
--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -394,6 +394,9 @@ void TextureCacheVulkan::CompileScalingShader() {
 		if (copyCS_ != VK_NULL_HANDLE)
 			vulkan_->Delete().QueueDeleteShaderModule(copyCS_);
 		textureShader_.clear();
+	} else if (uploadCS_ || copyCS_) {
+		// No need to recreate.
+		return;
 	}
 	if (!g_Config.bTexHardwareScaling)
 		return;


### PR DESCRIPTION
No need to recreate if they haven't changed (the if above this.)  This was overwriting the old shaders without deleting, causing a leak.

-[Unknown]