### PR TITLE
Compat: Enable reinterpret for Kingdom Hearts

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -949,6 +949,12 @@ ULAS42073 = true
 ULJM05265 = true
 ULJM05366 = true
 
+# Kingdom Hearts (see #11223)
+ULUS10505 = true
+ULES01441 = true
+ULJM05600 = true
+ULJM05775 = true
+
 [ShaderColorBitmask]
 # Outrun 2006: Coast to Coast - issue #11358
 ULES00262 = true


### PR DESCRIPTION
Fixes #11223.  Should enable it for everything at some point, but this does fix it for Direct3D 9.

-[Unknown]