### PR TITLE
PPGe: Scale down by worst of window/internal res

### DIFF
--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -957,6 +957,7 @@ void PPGeDrawTextWrapped(const char *text, float x, float y, float wrapWidth, fl
 	}
 
 	int zoom = (PSP_CoreParameter().pixelHeight + 479) / 480;
+	zoom = std::min(zoom, PSP_CoreParameter().renderScaleFactor);
 	float maxScaleDown = zoom == 1 ? 1.3f : 2.0f;
 
 	if (HasTextDrawer()) {


### PR DESCRIPTION
If you have a really low render resolution but a high window resolution, we were allowing more scale down than intended.  Though, it still looked more readable for me than #13958.

This just takes the lowest of the two when considering how much to shrink text.  This only happens when there's a lot of text, so most games will be unchanged.

-[Unknown]