### PR TITLE
Plugins: Enable by default

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -507,7 +507,7 @@ static ConfigSetting generalSettings[] = {
 	ConfigSetting("FullscreenOnDoubleclick", &g_Config.bFullscreenOnDoubleclick, true, false, false),
 
 	ReportedConfigSetting("MemStickInserted", &g_Config.bMemStickInserted, true, true, true),
-	ConfigSetting("LoadPlugins", &g_Config.bLoadPlugins, false, true, true),
+	ConfigSetting("EnablePlugins", &g_Config.bLoadPlugins, true, true, true),
 
 	ConfigSetting(false),
 };


### PR DESCRIPTION
I think I had meant to flip this.  It is a bit like cheats and might want it off, but not like there are any default plugins anyway.

-[Unknown]