### PR TITLE
GPU: Respect stencil write mask for 5551 buffers

### DIFF
--- a/GPU/D3D11/StateMappingD3D11.cpp
+++ b/GPU/D3D11/StateMappingD3D11.cpp
@@ -284,6 +284,9 @@ void DrawEngineD3D11::ApplyDrawState(int prim) {
 	}
 
 	if (gstate_c.IsDirty(DIRTY_DEPTHSTENCIL_STATE)) {
+		GenericStencilFuncState stencilState;
+		ConvertStencilFuncState(stencilState);
+
 		if (gstate.isModeClear()) {
 			keys_.depthStencil.value = 0;
 			keys_.depthStencil.depthTestEnable = true;
@@ -307,7 +310,7 @@ void DrawEngineD3D11::ApplyDrawState(int prim) {
 				// We override this value in the pipeline from software transform for clear rectangles.
 				dynState_.stencilRef = 0xFF;
 				// But we still apply the stencil write mask.
-				keys_.depthStencil.stencilWriteMask = (~gstate.getStencilWriteMask()) & 0xFF;
+				keys_.depthStencil.stencilWriteMask = stencilState.writeMask;
 			} else {
 				keys_.depthStencil.stencilTestEnable = false;
 				dynState_.useStencil = false;
@@ -328,9 +331,6 @@ void DrawEngineD3D11::ApplyDrawState(int prim) {
 				keys_.depthStencil.depthWriteEnable = false;
 				keys_.depthStencil.depthCompareOp = D3D11_COMPARISON_ALWAYS;
 			}
-
-			GenericStencilFuncState stencilState;
-			ConvertStencilFuncState(stencilState);
 
 			// Stencil Test
 			if (stencilState.enabled) {

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -553,7 +553,7 @@ rotateVBO:
 		params.fbman = framebufferManager_;
 		params.texCache = textureCache_;
 		params.allowClear = true;
-		params.allowSeparateAlphaClear = true;
+		params.allowSeparateAlphaClear = false;
 		params.provokeFlatFirst = true;
 
 		int maxIndex = indexGen.MaxIndex();
@@ -602,7 +602,6 @@ rotateVBO:
 				framebufferManager_->SetColorUpdated(gstate_c.skipDrawReason);
 			}
 
-			dxstate.colorMask.set((mask & D3DCLEAR_TARGET) != 0, (mask & D3DCLEAR_TARGET) != 0, (mask & D3DCLEAR_TARGET) != 0, (mask & D3DCLEAR_STENCIL) != 0);
 			device_->Clear(0, NULL, mask, SwapRB(clearColor), clearDepth, clearColor >> 24);
 
 			if ((gstate_c.featureFlags & GPU_USE_CLEAR_RAM_HACK) && gstate.isClearModeColorMask() && (gstate.isClearModeAlphaMask() || gstate.FrameBufFormat() == GE_FORMAT_565)) {

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -187,6 +187,9 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 
 	if (gstate_c.IsDirty(DIRTY_DEPTHSTENCIL_STATE)) {
 		gstate_c.Clean(DIRTY_DEPTHSTENCIL_STATE);
+		GenericStencilFuncState stencilState;
+		ConvertStencilFuncState(stencilState);
+
 		// Set Stencil/Depth
 		if (gstate.isModeClear()) {
 			// Depth Test
@@ -203,7 +206,7 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 				dxstate.stencilTest.enable();
 				dxstate.stencilOp.set(D3DSTENCILOP_REPLACE, D3DSTENCILOP_REPLACE, D3DSTENCILOP_REPLACE);
 				dxstate.stencilFunc.set(D3DCMP_ALWAYS, 255, 0xFF);
-				dxstate.stencilMask.set((~gstate.getStencilWriteMask()) & 0xFF);
+				dxstate.stencilMask.set(stencilState.writeMask);
 			} else {
 				dxstate.stencilTest.disable();
 			}
@@ -220,9 +223,6 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 			} else {
 				dxstate.depthTest.disable();
 			}
-
-			GenericStencilFuncState stencilState;
-			ConvertStencilFuncState(stencilState);
 
 			// Stencil Test
 			if (stencilState.enabled) {

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -235,13 +235,16 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 
 	if (gstate_c.IsDirty(DIRTY_DEPTHSTENCIL_STATE)) {
 		gstate_c.Clean(DIRTY_DEPTHSTENCIL_STATE);
+		GenericStencilFuncState stencilState;
+		ConvertStencilFuncState(stencilState);
+
 		if (gstate.isModeClear()) {
 			// Depth Test
 			if (gstate.isClearModeDepthMask()) {
 				framebufferManager_->SetDepthUpdated();
 			}
 			renderManager->SetStencilFunc(gstate.isClearModeAlphaMask(), GL_ALWAYS, 0xFF, 0xFF);
-			renderManager->SetStencilOp((~gstate.getStencilWriteMask()) & 0xFF, GL_REPLACE, GL_REPLACE, GL_REPLACE);
+			renderManager->SetStencilOp(stencilState.writeMask, GL_REPLACE, GL_REPLACE, GL_REPLACE);
 			renderManager->SetDepth(true, gstate.isClearModeDepthMask() ? true : false, GL_ALWAYS);
 		} else {
 			// Depth Test
@@ -250,8 +253,6 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 				framebufferManager_->SetDepthUpdated();
 			}
 
-			GenericStencilFuncState stencilState;
-			ConvertStencilFuncState(stencilState);
 			// Stencil Test
 			if (stencilState.enabled) {
 				renderManager->SetStencilFunc(stencilState.enabled, compareOps[stencilState.testFunc], stencilState.testRef, stencilState.testMask);

--- a/GPU/Vulkan/StateMappingVulkan.cpp
+++ b/GPU/Vulkan/StateMappingVulkan.cpp
@@ -253,6 +253,9 @@ void DrawEngineVulkan::ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManag
 	}
 
 	if (gstate_c.IsDirty(DIRTY_DEPTHSTENCIL_STATE)) {
+		GenericStencilFuncState stencilState;
+		ConvertStencilFuncState(stencilState);
+
 		if (gstate.isModeClear()) {
 			key.depthTestEnable = true;
 			key.depthCompareOp = VK_COMPARE_OP_ALWAYS;
@@ -275,7 +278,7 @@ void DrawEngineVulkan::ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManag
 				// We override this value in the pipeline from software transform for clear rectangles.
 				dynState.stencilRef = 0xFF;
 				// But we still apply the stencil write mask.
-				dynState.stencilWriteMask = (~gstate.getStencilWriteMask()) & 0xFF;
+				dynState.stencilWriteMask = stencilState.writeMask;
 			} else {
 				key.stencilTestEnable = false;
 				key.stencilCompareOp = VK_COMPARE_OP_ALWAYS;
@@ -298,9 +301,6 @@ void DrawEngineVulkan::ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManag
 				key.depthWriteEnable = false;
 				key.depthCompareOp = VK_COMPARE_OP_ALWAYS;
 			}
-
-			GenericStencilFuncState stencilState;
-			ConvertStencilFuncState(stencilState);
 
 			// Stencil Test
 			if (stencilState.enabled) {


### PR DESCRIPTION
If the mask is 0x7F on 5551, that's equivalent to allowing the clear entirely.  See #13391, hoping this fixes it based on the dump.

Also see #11902.  I don't think that `dxstate.colorMask` applies to clears, so I set it the same way as everything but GLES.

It's a shame that games do a separate clear for color/stencil and then depth sometimes...

-[Unknown]