### PR TITLE
GLES: Remove direct khrplatform.h header include

### DIFF
--- a/Common/GPU/OpenGL/GLCommon.h
+++ b/Common/GPU/OpenGL/GLCommon.h
@@ -8,9 +8,6 @@
 #elif defined(USING_GLES2)
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
-// At least Nokia platforms need the three below
-#include <KHR/khrplatform.h>
-typedef char GLchar;
 #define GL_BGRA_EXT 0x80E1
 #else // OpenGL
 #include "GL/glew.h"


### PR DESCRIPTION
Shouldn't be needed anymore, was a hack for Nokia.  See #13978.

Let's hope CI tells me this is safe.  It should be...

-[Unknown]