### PR TITLE
Cleanup some MP3 SDK version differences

### DIFF
--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -404,8 +404,9 @@ static int sceMp3Init(u32 mp3) {
 	int versionBits = (header >> 19) & 0x3;
 	int bitrate = __CalculateMp3Bitrates((header >> 12) & 0xF, versionBits, layerBits);
 	int samplerate = __CalculateMp3SampleRates((header >> 10) & 0x3, versionBits);;
+	int channels = __CalculateMp3Channels((header >> 6) & 0x3);
 
-	DEBUG_LOG(ME, "sceMp3Init(): channels=%i, samplerate=%iHz, bitrate=%ikbps, layerBits=%d ,versionBits=%d,HEADER: %08x", ctx->Channels, ctx->SamplingRate, ctx->BitRate, layerBits, versionBits, header);
+	DEBUG_LOG(ME, "sceMp3Init(): channels=%i, samplerate=%iHz, bitrate=%ikbps, layerBits=%d ,versionBits=%d,HEADER: %08x", channels, samplerate, bitrate, layerBits, versionBits, header);
 
 	if (layerBits != 1) {
 		// TODO: Should return ERROR_AVCODEC_INVALID_DATA.
@@ -425,7 +426,7 @@ static int sceMp3Init(u32 mp3) {
 	}
 
 	ctx->SamplingRate = samplerate;
-	ctx->Channels = __CalculateMp3Channels((header >> 6) & 0x3);
+	ctx->Channels = channels;
 	ctx->BitRate = bitrate;
 	ctx->MaxOutputSample = CalculateMp3SamplesPerFrame(versionBits, layerBits);
 	ctx->freq = ctx->SamplingRate;

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -447,11 +447,9 @@ static int sceMp3Init(u32 mp3) {
 
 	ctx->Version = versionBits;
 
-	// for mp3, if required freq is 48000,32000, reset resampling Frequency to 48000,32000 seems get better sound quality (e.g. Miku Custom BGM,Hanayaka Nari Wa ga Ichizoku)
-	// TODO: Isn't this backwards?  Woudln't we want to read as 48kHz and resample to 44.1kHz?
-	if (ctx->freq == 48000 || ctx->freq == 32000) {
-		ctx->decoder->SetResampleFrequency(ctx->freq);
-	}
+	// This tells us to resample to the same frequency it decodes to.
+	ctx->decoder->SetResampleFrequency(ctx->freq);
+
 	return hleDelayResult(hleLogSuccessI(ME, 0), "mp3 init", PARSE_DELAY_MS);
 }
 

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -327,9 +327,8 @@ size_t AuCtx::FindNextMp3Sync() {
 
 // return output pcm size, <0 error
 u32 AuCtx::AuDecode(u32 pcmAddr) {
-	if (!Memory::IsValidAddress(pcmAddr)){
-		ERROR_LOG(ME, "%s: output bufferAddress %08x is invalctx", __FUNCTION__, pcmAddr);
-		return -1;
+	if (!Memory::GetPointer(PCMBuf)) {
+		return hleLogError(ME, -1, "ctx output bufferAddress %08x is invalid", PCMBuf);
 	}
 
 	auto outbuf = Memory::GetPointer(PCMBuf);
@@ -376,7 +375,8 @@ u32 AuCtx::AuDecode(u32 pcmAddr) {
 		memset(outbuf + outpcmbufsize, 0, PCMBufSize - outpcmbufsize);
 	}
 
-	Memory::Write_U32(PCMBuf, pcmAddr);
+	if (pcmAddr)
+		Memory::Write_U32(PCMBuf, pcmAddr);
 	return outpcmbufsize;
 }
 


### PR DESCRIPTION
This matches validation better with firmware differences depending on the compiled SDK version.

That's how you make other bitrates work.  I misunderstood the code before, the codecCtx sample rate is the detected sample rate.  So this just makes us not resample - and we should do it for all valid sample rates, including 8kHz.

Also made it not crash when a game decodes with a NULL pcm offset pointer.  This is valid, probably for skipping ahead.

-[Unknown]