### PR TITLE
CMakeLists.txt: Stop overriding default cmake cflags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,14 +279,7 @@ if(NOT MSVC)
 		add_definitions(-DUSE_ADDRESS_SANITIZER)
 	endif()
 
-	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -D_DEBUG")
-	set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} -Os -D_NDEBUG")
-	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2 -D_NDEBUG")
-	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O2 -g -D_NDEBUG")
-	set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -D_DEBUG")
-	set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} -Os -D_NDEBUG")
-	set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2 -D_NDEBUG")
-	set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -O2 -g -D_NDEBUG")
+	add_compile_definitions($<IF:$<CONFIG:Debug>,_DEBUG,_NDEBUG>)
 	#TODO: Remove this and include the file properly everywhere it makes sense
 	# First step is too use the macros everywhere
 	# Second step is to remove the compatibility defines


### PR DESCRIPTION
There doesn't seem to be a specific reason for PPSSPP to override default c(xx)flags, making it difficult for user / build environment to override them.

NOTE: The default Release flags have `-O3`, should be careful with this given https://github.com/hrydgard/ppsspp/pull/13920 (should probably hold off with this until the underlying bug is fixed)