### PR TITLE
(.gitlab-ci.yml) Add windows-x64 target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,25 +11,34 @@ variables:
   variables:
     EXTRA_PATH: lib
 
+.windows-defs:
+  variables:
+    MAKEFILE_PATH: libretro
+
 include:
-  - template: Jobs/Code-Quality.gitlab-ci.yml
   - project: 'libretro-infrastructure/ci-templates'
     file: '/android-cmake.yml'
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-cmake.yml'
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/windows-x64-msvc19-msys2.yml'
 
 stages:
   - build-prepare
   - build-shared
-  - build-static
-  - test
 
-#Desktop
+# Desktop
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-cmake-x86_64
     - .core-defs
     - .linux-defs
+
+libretro-build-windows-x64:
+  extends:
+    - .libretro-windows-x64-msvc19-msys2-make-default
+    - .core-defs
+    - .windows-defs
 
 # Android
 libretro-build-android-armeabi-v7a:

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -304,7 +304,7 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	filter_out1 = $(filter-out $(firstword $1),$1)
 	filter_out2 = $(call filter_out1,$(call filter_out1,$1))
 
-	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>nul)))
+	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>null)))
 	fix_path = $(subst $(SPACE),\ ,$(subst \,/,$1))
 
 	b1 := (
@@ -415,7 +415,7 @@ else ifneq (,$(findstring windows_msvc2019,$(platform)))
 	filter_out1 = $(filter-out $(firstword $1),$1)
 	filter_out2 = $(call filter_out1,$(call filter_out1,$1))
 
-	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>nul)))
+	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>null)))
 	fix_path = $(subst $(SPACE),\ ,$(subst \,/,$1))
 
 	b1 := (

--- a/libretro/README_WINDOWS.txt
+++ b/libretro/README_WINDOWS.txt
@@ -13,7 +13,7 @@ pacman -S make
 Then use the following in msys:
 
 cd libretro
-make platform=windows_msvc2019_desktop_x64 -j32 && cp ppsspp_libretro.* /d/retroarch/cores && rm nul
+make platform=windows_msvc2019_desktop_x64 -j32 && cp ppsspp_libretro.* /d/retroarch/cores && rm null
 
 Note that the latter part copies the DLL/PDB into wherever retroarch reads it from. Might need to adjust the path,
 and adjust -j32 depending on your number of logical CPUs - might not need that many threads (or you might need more...).


### PR DESCRIPTION
This PR adds a 64bit Windows target to the libretro `.gitlab-ci.yml` file.

In addition:

- Unused `include`s and `stages` have been removed from `.gitlab-ci.yml`
- The temporary output redirection file generated by the static makefile in the `libretro` directory has been renamed from `nul` to `null`, since `nul` is a forbidden filename on Windows (and it's existence on the filesystem breaks the libretro build process)