### PR TITLE
Core: Correct branch analysis truncation

### DIFF
--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -49,7 +49,7 @@
 #define _SIZE ((op>>11) & 0x1F)
 #define _IMM16 (signed short)(op & 0xFFFF)
 #define _IMM26 (op & 0x03FFFFFF)
-#define TARGET16 ((int)((uint32_t)_IMM16 << 2))
+#define TARGET16 ((int)((uint32_t)(int)_IMM16 << 2))
 #define TARGET26 (_IMM26 << 2)
 
 #define LOOPOPTIMIZATION 0

--- a/Core/MIPS/ARM64/Arm64CompBranch.cpp
+++ b/Core/MIPS/ARM64/Arm64CompBranch.cpp
@@ -49,7 +49,7 @@
 #define _SIZE ((op>>11) & 0x1F)
 #define _IMM16 (signed short)(op & 0xFFFF)
 #define _IMM26 (op & 0x03FFFFFF)
-#define TARGET16 ((int)((uint32_t)_IMM16 << 2))
+#define TARGET16 ((int)((uint32_t)(int)_IMM16 << 2))
 #define TARGET26 (_IMM26 << 2)
 
 #define LOOPOPTIMIZATION 0

--- a/Core/MIPS/IR/IRCompBranch.cpp
+++ b/Core/MIPS/IR/IRCompBranch.cpp
@@ -42,7 +42,7 @@
 #define _SIZE ((op>>11) & 0x1F)
 #define _IMM16 (signed short)(op & 0xFFFF)
 #define _IMM26 (op & 0x03FFFFFF)
-#define TARGET16 ((int)((uint32_t)_IMM16 << 2))
+#define TARGET16 ((int)((uint32_t)(int)_IMM16 << 2))
 #define TARGET26 (_IMM26 << 2)
 
 #define LOOPOPTIMIZATION 0

--- a/Core/MIPS/MIPSCodeUtils.cpp
+++ b/Core/MIPS/MIPSCodeUtils.cpp
@@ -30,7 +30,7 @@ namespace MIPSCodeUtils
 #define _RT   ((op>>16) & 0x1F)
 #define _IMM16 (signed short)(op & 0xFFFF)
 #define _IMM26 (op & 0x03FFFFFF)
-#define TARGET16 ((int)((uint32_t)_IMM16 << 2))
+#define TARGET16 ((int)((uint32_t)(int)_IMM16 << 2))
 #define TARGET26 (_IMM26 << 2)
 
 	u32 GetJumpTarget(u32 addr) {

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -48,7 +48,7 @@
 #define _SIZE ((op>>11) & 0x1F)
 #define _IMM16 (signed short)(op & 0xFFFF)
 #define _IMM26 (op & 0x03FFFFFF)
-#define TARGET16 ((int)((uint32_t)_IMM16 << 2))
+#define TARGET16 ((int)((uint32_t)(int)_IMM16 << 2))
 #define TARGET26 (_IMM26 << 2)
 
 #define LOOPOPTIMIZATION 0


### PR DESCRIPTION
#14017 broke these functions, by truncating the signed offset to 16 bits (discarding the two most significant bits.)  Only matters for larger branch jumps, but I don't want the debugger / function scanning / stack walk to get confused.

For clarity, just to explain since #14017 got merged:
```
    ((signed short)(op & 0xFFFF) << 2)

    Means take the IMM16 16-bit immediate value from the instruction:
    XXXXXXXX XXXXXXXX 10101010 10101010

    Then sign extend that value:
    11111111 11111111 10101010 10101010

    And shift left 2:
    11111111 11111110 10101010 10101000
```

In contrast:
```
    ((signed short)((op & 0xFFFF) << 2))

    Means take the IMM16 16-bit immediate value from the instruction:
    XXXXXXXX XXXXXXXX 10101010 10101010

    Then zero extend that value as unsigned:
    00000000 00000000 10101010 10101010

    And shift left 2:
    00000000 00000010 10101010 10101000

    And truncate it to 16-bits:
    XXXXXXXX XXXXXXXX 10101010 10101000

    And finally sign extend based on the bit that incorectly became the sign:
    11111111 11111111 10101010 10101000
```

Which could result in values becoming incorrectly unsigned or signed after the truncation, as well as reducing the magnitude incorrectly.

-[Unknown]