### PR TITLE
Mpeg:Support warmup for sdkver == 0

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1587,7 +1587,7 @@ static int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	}
 
 	int sdkver = sceKernelGetCompiledSdkVersion();
-	if ((sdkver >= 0x03000000) || (sdkver == 0) && (ctx->mpegwarmUp < MPEG_WARMUP_FRAMES)) {
+	if ((sdkver >= 0x03000000 || sdkver == 0) && (ctx->mpegwarmUp < MPEG_WARMUP_FRAMES)) {
 		DEBUG_LOG(ME, "sceMpegGetAvcAu(%08x, %08x, %08x, %08x): warming up", mpeg, streamId, auAddr, attrAddr);
 		ctx->mpegwarmUp++;
 		return ERROR_MPEG_NO_DATA;

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1585,8 +1585,9 @@ static int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 		ERROR_LOG_REPORT(ME, "sceMpegGetAvcAu(%08x, %08x, %08x, %08x): invalid ringbuffer address", mpeg, streamId, auAddr, attrAddr);
 		return -1;
 	}
+
 	int sdkver = sceKernelGetCompiledSdkVersion();
-	if ((sdkver >= 0x03000000) && (ctx->mpegwarmUp < MPEG_WARMUP_FRAMES)) {
+	if ((sdkver >= 0x03000000) || (sdkver == 0) && (ctx->mpegwarmUp < MPEG_WARMUP_FRAMES)) {
 		DEBUG_LOG(ME, "sceMpegGetAvcAu(%08x, %08x, %08x, %08x): warming up", mpeg, streamId, auAddr, attrAddr);
 		ctx->mpegwarmUp++;
 		return ERROR_MPEG_NO_DATA;


### PR DESCRIPTION
fix #13759

(In the jpcsp,it is displayed as firmware 1.5
,maybe there is a bug in sceKernelGetCompiledSdkVersion() ?)

I have tested another game  which firmware is 1.5
Hokuto no ken Portable ULJM05020
tenchi no Mon UCAS40023