### PR TITLE
Ge: Restore saved context when ending a list

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -563,12 +563,11 @@ static int sceGeGetMtx(int type, u32 matrixPtr) {
 }
 
 static u32 sceGeGetCmd(int cmd) {
-	INFO_LOG(SCEGE, "sceGeGetCmd(%i)", cmd);
 	if (cmd >= 0 && cmd < (int)ARRAY_SIZE(gstate.cmdmem)) {
-		return gstate.cmdmem[cmd];  // Does not mask away the high bits.
-	} else {
-		return SCE_KERNEL_ERROR_INVALID_INDEX;
+		// Does not mask away the high bits.
+		return hleLogSuccessInfoX(SCEGE, gstate.cmdmem[cmd]);
 	}
+	return hleLogError(SCEGE, SCE_KERNEL_ERROR_INVALID_INDEX);
 }
 
 static int sceGeGetStack(int index, u32 stackPtr) {


### PR DESCRIPTION
I think this is the cause of #13346, based on logging for when the save/restore happens.

Basically, if you enqueue with a context address, that's where to save context before starting your list, and restore context after your list completes.  It means that you don't intend any state modifications by your list to be permanent.  But we were running other lists before eventually restoring after the interrupt processing finished.

This seems slightly risky for v1.11.0 and could use more testing on more games...

-[Unknown]