### PR TITLE
sceMpegRingbufferPut:Add more 32 numPackets for firmware >= 3

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1537,6 +1537,12 @@ static u32 sceMpegRingbufferPut(u32 ringbufferAddr, int numPackets, int availabl
 		return 0;
 	}
 
+	int sdkver = sceKernelGetCompiledSdkVersion();
+	if (sdkver >= 0x03000000) {
+		if (numPackets + 32 < available)
+			numPackets += 32;
+	}
+
 	MpegContext *ctx = getMpegCtx(ringbuffer->mpeg);
 	if (!ctx) {
 		WARN_LOG(ME, "sceMpegRingbufferPut(%08x, %i, %i): bad mpeg handle %08x", ringbufferAddr, numPackets, available, ringbuffer->mpeg);


### PR DESCRIPTION
Fix #13146
JPCSPTrace of the game https://gist.github.com/sum2012/8a7a7b69a5312f6c89e69569d3770298
In the real psp , sceMpegGetAtracAu and sceMpegGetAvcAu don't return ERROR_MPEG_NO_DATA
This is the last method to solve for me.

I tested games firmware from 2.5 to 6.6
Hope don't break other games this time.
Hope to merge to after v1.11 to public test 