### PR TITLE
Add a command in developer tools to list and load framedumps from the web

### DIFF
--- a/Common/Render/DrawBuffer.cpp
+++ b/Common/Render/DrawBuffer.cpp
@@ -224,6 +224,20 @@ void DrawBuffer::DrawImage(ImageID atlas_image, float x, float y, float scale, C
 	DrawImageStretch(atlas_image, x, y, x + w, y + h, color);
 }
 
+void DrawBuffer::DrawImageCenterTexel(ImageID atlas_image, float x1, float y1, float x2, float y2, Color color) {
+	const AtlasImage *image = atlas->getImage(atlas_image);
+	if (!image)
+		return;
+	float centerU = (image->u1 + image->u2) * 0.5f;
+	float centerV = (image->v1 + image->v2) * 0.5f;
+	V(x1,	y1, color, centerU, centerV);
+	V(x2,	y1, color, centerU, centerV);
+	V(x2,	y2, color, centerU, centerV);
+	V(x1,	y1, color, centerU, centerV);
+	V(x2,	y2, color, centerU, centerV);
+	V(x1,	y2, color, centerU, centerV);
+}
+
 void DrawBuffer::DrawImageStretch(ImageID atlas_image, float x1, float y1, float x2, float y2, Color color) {
 	const AtlasImage *image = atlas->getImage(atlas_image);
 	if (!image)

--- a/Common/Render/DrawBuffer.h
+++ b/Common/Render/DrawBuffer.h
@@ -107,6 +107,9 @@ public:
 	const Atlas *GetAtlas() const { return atlas; }
 	bool MeasureImage(ImageID atlas_image, float *w, float *h);
 	void DrawImage(ImageID atlas_image, float x, float y, float scale, Color color = COLOR(0xFFFFFF), int align = ALIGN_TOPLEFT);
+
+	// Good for stretching out a white image without edge artifacts that I'm getting on iOS.
+	void DrawImageCenterTexel(ImageID atlas_image, float x1, float y1, float x2, float y2, Color color = COLOR(0xFFFFFF));
 	void DrawImageStretch(ImageID atlas_image, float x1, float y1, float x2, float y2, Color color = COLOR(0xFFFFFF));
 	void DrawImageStretchVGradient(ImageID atlas_image, float x1, float y1, float x2, float y2, Color color1, Color color2);
 	void DrawImageStretch(ImageID atlas_image, const Bounds &bounds, Color color = COLOR(0xFFFFFF)) {

--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -224,7 +224,7 @@ void UIContext::FillRect(const UI::Drawable &drawable, const Bounds &bounds) {
 
 	switch (drawable.type) {
 	case UI::DRAW_SOLID_COLOR:
-		uidrawbuffer_->DrawImageStretch(theme->whiteImage, bounds.x, bounds.y, bounds.x2(), bounds.y2(), drawable.color);
+		uidrawbuffer_->DrawImageCenterTexel(theme->whiteImage, bounds.x, bounds.y, bounds.x2(), bounds.y2(), drawable.color);
 		break;
 	case UI::DRAW_4GRID:
 		uidrawbuffer_->DrawImage4Grid(drawable.image, bounds.x, bounds.y, bounds.x2(), bounds.y2(), drawable.color);

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -544,7 +544,7 @@ void InfoItem::Draw(UIContext &dc) {
 	dc.SetFontStyle(dc.theme->uiFont);
 	dc.DrawText(text_.c_str(), bounds_.x + paddingX, bounds_.centerY(), style.fgColor, ALIGN_VCENTER);
 	dc.DrawText(rightText_.c_str(), bounds_.x2() - paddingX, bounds_.centerY(), style.fgColor, ALIGN_VCENTER | ALIGN_RIGHT);
-// 	dc.Draw()->DrawImageStretch(dc.theme->whiteImage, bounds_.x, bounds_.y, bounds_.x2(), bounds_.y + 2, dc.theme->itemDownStyle.bgColor);
+// 	dc.Draw()->DrawImageCenterTexel(dc.theme->whiteImage, bounds_.x, bounds_.y, bounds_.x2(), bounds_.y + 2, dc.theme->itemDownStyle.bgColor);
 }
 
 ItemHeader::ItemHeader(const std::string &text, LayoutParams *layoutParams)
@@ -556,7 +556,7 @@ ItemHeader::ItemHeader(const std::string &text, LayoutParams *layoutParams)
 void ItemHeader::Draw(UIContext &dc) {
 	dc.SetFontStyle(dc.theme->uiFontSmall);
 	dc.DrawText(text_.c_str(), bounds_.x + 4, bounds_.centerY(), dc.theme->headerStyle.fgColor, ALIGN_LEFT | ALIGN_VCENTER);
-	dc.Draw()->DrawImageStretch(dc.theme->whiteImage, bounds_.x, bounds_.y2()-2, bounds_.x2(), bounds_.y2(), dc.theme->headerStyle.fgColor);
+	dc.Draw()->DrawImageCenterTexel(dc.theme->whiteImage, bounds_.x, bounds_.y2()-2, bounds_.x2(), bounds_.y2(), dc.theme->headerStyle.fgColor);
 }
 
 void ItemHeader::GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const {
@@ -593,7 +593,7 @@ void PopupHeader::Draw(UIContext &dc) {
 	}
 
 	dc.DrawText(text_.c_str(), bounds_.x + tx, bounds_.centerY(), dc.theme->popupTitle.fgColor, ALIGN_LEFT | ALIGN_VCENTER);
-	dc.Draw()->DrawImageStretch(dc.theme->whiteImage, bounds_.x, bounds_.y2()-2, bounds_.x2(), bounds_.y2(), dc.theme->popupTitle.fgColor);
+	dc.Draw()->DrawImageCenterTexel(dc.theme->whiteImage, bounds_.x, bounds_.y2()-2, bounds_.x2(), bounds_.y2(), dc.theme->popupTitle.fgColor);
 
 	if (availableWidth < tw) {
 		dc.PopScissor();
@@ -1032,7 +1032,7 @@ void ProgressBar::GetContentDimensions(const UIContext &dc, float &w, float &h) 
 void ProgressBar::Draw(UIContext &dc) {
 	char temp[32];
 	sprintf(temp, "%i%%", (int)(progress_ * 100.0f));
-	dc.Draw()->DrawImageStretch(dc.theme->whiteImage, bounds_.x, bounds_.y, bounds_.x + bounds_.w * progress_, bounds_.y2(), 0xc0c0c0c0);
+	dc.Draw()->DrawImageCenterTexel(dc.theme->whiteImage, bounds_.x, bounds_.y, bounds_.x + bounds_.w * progress_, bounds_.y2(), 0xc0c0c0c0);
 	dc.SetFontStyle(dc.theme->uiFont);
 	dc.DrawTextRect(temp, bounds_, 0xFFFFFFFF, ALIGN_CENTER);
 }

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -1348,9 +1348,9 @@ void ChoiceStrip::Draw(UIContext &dc) {
 	ViewGroup::Draw(dc);
 	if (topTabs_) {
 		if (orientation_ == ORIENT_HORIZONTAL)
-			dc.Draw()->DrawImageStretch(dc.theme->whiteImage, bounds_.x, bounds_.y2() - 4, bounds_.x2(), bounds_.y2(), dc.theme->itemDownStyle.background.color );
+			dc.Draw()->DrawImageCenterTexel(dc.theme->whiteImage, bounds_.x, bounds_.y2() - 4, bounds_.x2(), bounds_.y2(), dc.theme->itemDownStyle.background.color );
 		else if (orientation_ == ORIENT_VERTICAL)
-			dc.Draw()->DrawImageStretch(dc.theme->whiteImage, bounds_.x2() - 4, bounds_.y, bounds_.x2(), bounds_.y2(), dc.theme->itemDownStyle.background.color );
+			dc.Draw()->DrawImageCenterTexel(dc.theme->whiteImage, bounds_.x2() - 4, bounds_.y, bounds_.x2(), bounds_.y2(), dc.theme->itemDownStyle.background.color );
 	}
 }
 

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -78,7 +78,10 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 	bool enableColorDoubling = id.Bit(FS_BIT_COLOR_DOUBLE);
 	bool doTextureProjection = id.Bit(FS_BIT_DO_TEXTURE_PROJ);
 	bool doTextureAlpha = id.Bit(FS_BIT_TEXALPHA);
-	bool doFlatShading = id.Bit(FS_BIT_FLATSHADE) && !bugs.Has(Draw::Bugs::BROKEN_FLAT_IN_SHADER);
+
+	bool flatBug = bugs.Has(Draw::Bugs::BROKEN_FLAT_IN_SHADER) && g_Config.bVendorBugChecksEnabled;
+
+	bool doFlatShading = id.Bit(FS_BIT_FLATSHADE) && !flatBug;
 	bool shaderDepal = id.Bit(FS_BIT_SHADER_DEPAL);
 	bool bgraTexture = id.Bit(FS_BIT_BGRA_TEXTURE);
 	bool colorWriteMask = id.Bit(FS_BIT_COLOR_WRITEMASK) && compat.bitwiseOps;

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -152,7 +152,9 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 	// this is only valid for some settings of uvGenMode
 	GETexProjMapMode uvProjMode = static_cast<GETexProjMapMode>(id.Bits(VS_BIT_UVPROJ_MODE, 2));
 	bool doShadeMapping = uvGenMode == GE_TEXMAP_ENVIRONMENT_MAP;
-	bool doFlatShading = id.Bit(VS_BIT_FLATSHADE) && !bugs.Has(Draw::Bugs::BROKEN_FLAT_IN_SHADER);
+
+	bool flatBug = bugs.Has(Draw::Bugs::BROKEN_FLAT_IN_SHADER) && g_Config.bVendorBugChecksEnabled;
+	bool doFlatShading = id.Bit(VS_BIT_FLATSHADE) && !flatBug;
 
 	bool useHWTransform = id.Bit(VS_BIT_USE_HW_TRANSFORM);
 	bool hasColor = id.Bit(VS_BIT_HAS_COLOR) || !useHWTransform;

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -49,6 +49,7 @@
 #include "GPU/GPUState.h"
 #include "UI/MiscScreens.h"
 #include "UI/DevScreens.h"
+#include "UI/MainScreen.h"
 #include "UI/ControlMappingScreen.h"
 #include "UI/GameSettingsScreen.h"
 
@@ -1107,7 +1108,7 @@ void ShaderViewScreen::CreateViews() {
 	layout->Add(new Button(di->T("Back")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
 }
 
-const std::string framedumpsBaseUrl = "http://framedumps.ppsspp.org/";
+const std::string framedumpsBaseUrl = "http://framedump.ppsspp.org/repro/";
 
 FrameDumpTestScreen::FrameDumpTestScreen() {
 
@@ -1118,12 +1119,48 @@ FrameDumpTestScreen::~FrameDumpTestScreen() {
 }
 
 void FrameDumpTestScreen::CreateViews() {
+	using namespace UI;
+
+	root_ = new AnchorLayout(new LayoutParams(FILL_PARENT, FILL_PARENT));
+	auto di = GetI18NCategory("Dialog");
+
+	TabHolder *tabHolder;
+	tabHolder = new TabHolder(ORIENT_VERTICAL, 200, new AnchorLayoutParams(10, 0, 10, 0, false));
+	root_->Add(tabHolder);
+	AddStandardBack(root_);
+	tabHolder->SetTag("DumpTypes");
+	root_->SetDefaultFocusView(tabHolder);
+
+	ViewGroup *dumpsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
+	dumpsScroll->SetTag("GameSettingsGraphics");
+	LinearLayout *dumps = new LinearLayout(ORIENT_VERTICAL);
+	dumps->SetSpacing(0);
+	dumpsScroll->Add(dumps);
+	tabHolder->AddTab("Dumps", dumps);
+
+	dumps->Add(new ItemHeader("GE Frame Dumps"));
+
 	for (auto &file : files_) {
 		std::string url = framedumpsBaseUrl + file;
+		Choice *c = dumps->Add(new Choice(file));
+		c->SetTag(url);
+		c->OnClick.Handle<FrameDumpTestScreen>(this, &FrameDumpTestScreen::OnLoadDump);
 	}
 }
 
+UI::EventReturn FrameDumpTestScreen::OnLoadDump(UI::EventParams &params) {
+	std::string url = params.v->Tag();
+	INFO_LOG(COMMON, "Trying to launch '%s'", url.c_str());
+	// Our disc streaming functionality detects the URL and takes over and handles loading framedumps well,
+	// except for some reason the game ID.
+	// TODO: Fix that since it can be important for compat settings.
+	LaunchFile(screenManager(), url);
+	return UI::EVENT_DONE;
+}
+
 void FrameDumpTestScreen::update() {
+	UIScreen::update();
+
 	if (!listing_) {
 		listing_ = g_DownloadManager.StartDownload(framedumpsBaseUrl, "");
 	}
@@ -1132,7 +1169,24 @@ void FrameDumpTestScreen::update() {
 		if (listing_->ResultCode() == 200) {
 			std::string listingHtml;
 			listing_->buffer().TakeAll(&listingHtml);
-			INFO_LOG(COMMON, "Listing: %s", listingHtml.c_str());
+
+			std::vector<std::string> lines;
+			// We rely slightly on nginx listing format here. Not great.
+			SplitString(listingHtml, '\n', lines);
+			for (auto &line : lines) {
+				std::string trimmed = StripSpaces(line);
+				if (startsWith(trimmed, "<a href=\"")) {
+					trimmed = trimmed.substr(strlen("<a href=\""));
+					size_t offset = trimmed.find('\"');
+					if (offset != std::string::npos) {
+						trimmed = trimmed.substr(0, offset);
+						if (endsWith(trimmed, ".ppdmp")) {
+							INFO_LOG(COMMON, "Found ppdmp: '%s'", trimmed.c_str());
+							files_.push_back(trimmed);
+						}
+					}
+				}
+			}
 		} else {
 			// something went bad. Too lazy to make UI, so let's just finish this screen.
 			TriggerFinish(DialogResult::DR_CANCEL);

--- a/UI/DevScreens.h
+++ b/UI/DevScreens.h
@@ -182,7 +182,7 @@ private:
 	DebugShaderType type_;
 };
 
-class FrameDumpTestScreen : public UIScreenWithBackground {
+class FrameDumpTestScreen : public UIDialogScreenWithBackground {
 public:
 	FrameDumpTestScreen();
 	~FrameDumpTestScreen();
@@ -191,8 +191,11 @@ public:
 	void update() override;
 
 private:
+	UI::EventReturn OnLoadDump(UI::EventParams &e);
+
 	std::vector<std::string> files_;
 	std::shared_ptr<http::Download> listing_;
+	std::shared_ptr<http::Download> dumpDownload_;
 };
 
 void DrawProfile(UIContext &ui);

--- a/UI/DevScreens.h
+++ b/UI/DevScreens.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "Common/Data/Text/I18n.h"
+#include "Common/Net/HTTPClient.h"
 #include "Common/UI/UIScreen.h"
 
 #include "UI/MiscScreens.h"
@@ -179,6 +180,19 @@ public:
 private:
 	std::string id_;
 	DebugShaderType type_;
+};
+
+class FrameDumpTestScreen : public UIScreenWithBackground {
+public:
+	FrameDumpTestScreen();
+	~FrameDumpTestScreen();
+
+	void CreateViews() override;
+	void update() override;
+
+private:
+	std::vector<std::string> files_;
+	std::shared_ptr<http::Download> listing_;
 };
 
 void DrawProfile(UIContext &ui);

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -220,7 +220,7 @@ public:
 	}
 
 	void Draw(UIContext &dc) override {
-		dc.Draw()->DrawImageStretch(dc.theme->whiteImage, bounds_.x, bounds_.y, bounds_.x2(), bounds_.y2(), dc.theme->itemDownStyle.background.color);
+		dc.Draw()->DrawImageCenterTexel(dc.theme->whiteImage, bounds_.x, bounds_.y, bounds_.x2(), bounds_.y2(), dc.theme->itemDownStyle.background.color);
 	}
 };
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1643,6 +1643,7 @@ void DeveloperToolsScreen::CreateViews() {
 	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN || g_Config.iGPUBackend == (int)GPUBackend::OPENGL) {
 		list->Add(new Choice(dev->T("GPU Driver Test")))->OnClick.Handle(this, &DeveloperToolsScreen::OnGPUDriverTest);
 	}
+	list->Add(new Choice(dev->T("Framedump tests")))->OnClick.Handle(this, &DeveloperToolsScreen::OnFramedumpTest);
 	list->Add(new Choice(dev->T("Touchscreen Test")))->OnClick.Handle(this, &DeveloperToolsScreen::OnTouchscreenTest);
 
 	allowDebugger_ = !WebServerStopped(WebServerFlags::DEBUGGER);
@@ -1749,6 +1750,11 @@ UI::EventReturn DeveloperToolsScreen::OnJitDebugTools(UI::EventParams &e) {
 
 UI::EventReturn DeveloperToolsScreen::OnGPUDriverTest(UI::EventParams &e) {
 	screenManager()->push(new GPUDriverTestScreen());
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn DeveloperToolsScreen::OnFramedumpTest(UI::EventParams &e) {
+	screenManager()->push(new FrameDumpTestScreen());
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1643,8 +1643,8 @@ void DeveloperToolsScreen::CreateViews() {
 	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN || g_Config.iGPUBackend == (int)GPUBackend::OPENGL) {
 		list->Add(new Choice(dev->T("GPU Driver Test")))->OnClick.Handle(this, &DeveloperToolsScreen::OnGPUDriverTest);
 	}
-	list->Add(new Choice(dev->T("Framedump tests")))->OnClick.Handle(this, &DeveloperToolsScreen::OnFramedumpTest);
 	list->Add(new CheckBox(&g_Config.bVendorBugChecksEnabled, dev->T("Enable driver bug workarounds")));
+	list->Add(new Choice(dev->T("Framedump tests")))->OnClick.Handle(this, &DeveloperToolsScreen::OnFramedumpTest);
 	list->Add(new Choice(dev->T("Touchscreen Test")))->OnClick.Handle(this, &DeveloperToolsScreen::OnTouchscreenTest);
 
 	allowDebugger_ = !WebServerStopped(WebServerFlags::DEBUGGER);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1644,6 +1644,7 @@ void DeveloperToolsScreen::CreateViews() {
 		list->Add(new Choice(dev->T("GPU Driver Test")))->OnClick.Handle(this, &DeveloperToolsScreen::OnGPUDriverTest);
 	}
 	list->Add(new Choice(dev->T("Framedump tests")))->OnClick.Handle(this, &DeveloperToolsScreen::OnFramedumpTest);
+	list->Add(new CheckBox(&g_Config.bVendorBugChecksEnabled, dev->T("Enable driver bug workarounds")));
 	list->Add(new Choice(dev->T("Touchscreen Test")))->OnClick.Handle(this, &DeveloperToolsScreen::OnTouchscreenTest);
 
 	allowDebugger_ = !WebServerStopped(WebServerFlags::DEBUGGER);

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -178,6 +178,7 @@ private:
 	UI::EventReturn OnJitDebugTools(UI::EventParams &e);
 	UI::EventReturn OnRemoteDebugger(UI::EventParams &e);
 	UI::EventReturn OnGPUDriverTest(UI::EventParams &e);
+	UI::EventReturn OnFramedumpTest(UI::EventParams &e);
 	UI::EventReturn OnTouchscreenTest(UI::EventParams &e);
 	UI::EventReturn OnCopyStatesToRoot(UI::EventParams &e);
 

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -38,6 +38,8 @@ enum class BrowseFlags {
 };
 ENUM_CLASS_BITOPS(BrowseFlags);
 
+bool LaunchFile(ScreenManager *screenManager, std::string path);
+
 class GameBrowser : public UI::LinearLayout {
 public:
 	GameBrowser(std::string path, BrowseFlags browseFlags, bool *gridStyle, ScreenManager *screenManager, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = nullptr);

--- a/UI/UI.vcxproj.filters
+++ b/UI/UI.vcxproj.filters
@@ -44,7 +44,6 @@
     <ClCompile Include="InstallZipScreen.cpp">
       <Filter>Screens</Filter>
     </ClCompile>
-    <ClCompile Include="Store.cpp" />
     <ClCompile Include="BackgroundAudio.cpp" />
     <ClCompile Include="ReportScreen.cpp">
       <Filter>Screens</Filter>
@@ -74,6 +73,9 @@
       <Filter>Screens</Filter>
     </ClCompile>
     <ClCompile Include="ChatScreen.cpp">
+      <Filter>Screens</Filter>
+    </ClCompile>
+    <ClCompile Include="Store.cpp">
       <Filter>Screens</Filter>
     </ClCompile>
   </ItemGroup>
@@ -120,7 +122,6 @@
     <ClInclude Include="InstallZipScreen.h">
       <Filter>Screens</Filter>
     </ClInclude>
-    <ClInclude Include="Store.h" />
     <ClInclude Include="BackgroundAudio.h" />
     <ClInclude Include="ReportScreen.h">
       <Filter>Screens</Filter>
@@ -151,6 +152,9 @@
       <Filter>Screens</Filter>
     </ClInclude>
     <ClInclude Include="ChatScreen.h">
+      <Filter>Screens</Filter>
+    </ClInclude>
+    <ClInclude Include="Store.h">
       <Filter>Screens</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Useful for reproducing and reporting rendering bugs to vendors. No need for them to copy files around and so on. Loads from framedump.ppsspp.org/repro/ .

![image](https://user-images.githubusercontent.com/130929/106386001-3302c180-63d3-11eb-9c39-044c02cce1fb.png)
