### PR TITLE
Core: Maintain frame dump disc ID in SFO

### DIFF
--- a/Core/FileLoaders/DiskCachingFileLoader.cpp
+++ b/Core/FileLoaders/DiskCachingFileLoader.cpp
@@ -98,6 +98,10 @@ size_t DiskCachingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, 
 		// While in case the cache size is too small for the entire read.
 		while (readSize < bytes) {
 			readSize += cache_->SaveIntoCache(backend_, absolutePos + readSize, bytes - readSize, (u8 *)data + readSize, flags);
+			// We're done, nothing more to read.
+			if (readSize == bytes) {
+				break;
+			}
 			// If there are already-cached blocks afterward, we have to read them.
 			size_t bytesFromCache = cache_->ReadFromCache(absolutePos + readSize, bytes - readSize, (u8 *)data + readSize);
 			readSize += bytesFromCache;
@@ -440,6 +444,9 @@ s64 DiskCachingFileLoaderCache::GetBlockOffset(u32 block) {
 bool DiskCachingFileLoaderCache::ReadBlockData(u8 *dest, BlockInfo &info, size_t offset, size_t size) {
 	if (!f_) {
 		return false;
+	}
+	if (size == 0) {
+		return true;
 	}
 	s64 blockOffset = GetBlockOffset(info.block);
 

--- a/Core/FileLoaders/LocalFileLoader.cpp
+++ b/Core/FileLoaders/LocalFileLoader.cpp
@@ -119,6 +119,9 @@ std::string LocalFileLoader::Path() const {
 }
 
 size_t LocalFileLoader::ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags) {
+	if (bytes == 0)
+		return 0;
+
 #if PPSSPP_PLATFORM(SWITCH)
 	// Toolchain has no fancy IO API.  We must lock.
 	std::lock_guard<std::mutex> guard(readLock_);


### PR DESCRIPTION
Just to prevent any issues/confusion.  Might make us take ini settings from the game too, I suppose?  See #14037.

Also fixes an unrelated issue I saw opening that dump, where the disk cache tried to read zero bytes and therefore got marked broken and wasn't used.  Not a big deal, but means the cache won't persist if that happens.

-[Unknown]