### PR TITLE
Implement basic depth texturing for OpenGL

### DIFF
--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -1284,6 +1284,7 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last
 				glDisable(GL_DITHER);
 				ditherEnabled = false;
 			}
+#ifndef USING_GLES2
 			if (c.raster.depthClampEnable) {
 				if (!depthClampEnabled) {
 					glEnable(GL_DEPTH_CLAMP);
@@ -1293,6 +1294,7 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last
 				glDisable(GL_DEPTH_CLAMP);
 				depthClampEnabled = false;
 			}
+#endif
 			CHECK_GL_ERROR_IF_DEBUG();
 			break;
 		default:
@@ -1331,9 +1333,9 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last
 		glDisable(GL_BLEND);
 	if (cullEnabled)
 		glDisable(GL_CULL_FACE);
+#ifndef USING_GLES2
 	if (depthClampEnabled)
 		glDisable(GL_DEPTH_CLAMP);
-#ifndef USING_GLES2
 	if (!gl_extensions.IsGLES && logicEnabled) {
 		glDisable(GL_COLOR_LOGIC_OP);
 	}

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -793,6 +793,7 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last
 	bool blendEnabled = false;
 	bool cullEnabled = false;
 	bool ditherEnabled = false;
+	bool depthClampEnabled = false;
 #ifndef USING_GLES2
 	int logicOp = -1;
 	bool logicEnabled = false;
@@ -1283,6 +1284,15 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last
 				glDisable(GL_DITHER);
 				ditherEnabled = false;
 			}
+			if (c.raster.depthClampEnable) {
+				if (!depthClampEnabled) {
+					glEnable(GL_DEPTH_CLAMP);
+					depthClampEnabled = true;
+				}
+			} else if (!c.raster.depthClampEnable && depthClampEnabled) {
+				glDisable(GL_DEPTH_CLAMP);
+				depthClampEnabled = false;
+			}
 			CHECK_GL_ERROR_IF_DEBUG();
 			break;
 		default:
@@ -1321,6 +1331,8 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last
 		glDisable(GL_BLEND);
 	if (cullEnabled)
 		glDisable(GL_CULL_FACE);
+	if (depthClampEnabled)
+		glDisable(GL_DEPTH_CLAMP);
 #ifndef USING_GLES2
 	if (!gl_extensions.IsGLES && logicEnabled) {
 		glDisable(GL_COLOR_LOGIC_OP);

--- a/Common/GPU/OpenGL/GLQueueRunner.h
+++ b/Common/GPU/OpenGL/GLQueueRunner.h
@@ -196,6 +196,7 @@ struct GLRRenderData {
 			GLenum frontFace;
 			GLenum cullFace;
 			GLboolean ditherEnable;
+			GLboolean depthClampEnable;
 		} raster;
 	};
 };

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -813,13 +813,14 @@ public:
 		curRenderStep_->commands.push_back(data);
 	}
 
-	void SetRaster(GLboolean cullEnable, GLenum frontFace, GLenum cullFace, GLboolean ditherEnable) {
+	void SetRaster(GLboolean cullEnable, GLenum frontFace, GLenum cullFace, GLboolean ditherEnable, GLboolean depthClamp) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData data{ GLRRenderCommand::RASTER };
 		data.raster.cullEnable = cullEnable;
 		data.raster.frontFace = frontFace;
 		data.raster.cullFace = cullFace;
 		data.raster.ditherEnable = ditherEnable;
+		data.raster.depthClampEnable = depthClamp;
 		curRenderStep_->commands.push_back(data);
 	}
 	

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -188,7 +188,7 @@ public:
 class OpenGLRasterState : public RasterState {
 public:
 	void Apply(GLRenderManager *render) {
-		render->SetRaster(cullEnable, frontFace, cullMode, false);
+		render->SetRaster(cullEnable, frontFace, cullMode, GL_FALSE, GL_FALSE);
 	}
 
 	GLboolean cullEnable;
@@ -533,6 +533,10 @@ OpenGLContext::OpenGLContext() {
 	}
 	caps_.framebufferBlitSupported = gl_extensions.NV_framebuffer_blit || gl_extensions.ARB_framebuffer_object;
 	caps_.framebufferDepthBlitSupported = caps_.framebufferBlitSupported;
+	caps_.depthClampSupported = gl_extensions.ARB_depth_clamp;
+
+	// Interesting potential hack for emulating GL_DEPTH_CLAMP (use a separate varying, force depth in fragment shader):
+	// https://stackoverflow.com/questions/5960757/how-to-emulate-gl-depth-clamp-nv
 
 	switch (gl_extensions.gpuVendor) {
 	case GPU_VENDOR_AMD: caps_.vendor = GPUVendor::VENDOR_AMD; break;

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -536,6 +536,8 @@ OpenGLContext::OpenGLContext() {
 	caps_.depthClampSupported = gl_extensions.ARB_depth_clamp;
 
 	// Interesting potential hack for emulating GL_DEPTH_CLAMP (use a separate varying, force depth in fragment shader):
+	// This will induce a performance penalty on many architectures though so a blanket enable of this
+	// is probably not a good idea.
 	// https://stackoverflow.com/questions/5960757/how-to-emulate-gl-depth-clamp-nv
 
 	switch (gl_extensions.gpuVendor) {

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -82,11 +82,7 @@ void GenerateDepalShader300(char *buffer, GEBufferFormat pixelFormat, ShaderLang
 
 	if (language == HLSL_D3D11) {
 		WRITE(p, "float4 main(in float2 v_texcoord0 : TEXCOORD0) : SV_Target {\n");
-		if (pixelFormat == GE_FORMAT_DEPTH16) {
-			WRITE(p, "  float color = tex.Sample(texSamp, v_texcoord0).x;\n");
-		} else {
-			WRITE(p, "  float4 color = tex.Sample(texSamp, v_texcoord0);\n");
-		}
+		WRITE(p, "  float4 color = tex.Sample(texSamp, v_texcoord0);\n");
 	} else {
 		WRITE(p, "void main() {\n");
 		WRITE(p, "  vec4 color = texture(tex, v_texcoord0);\n");

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -25,6 +25,7 @@
 #include "Common/Log.h"
 #include "Core/Reporting.h"
 #include "GPU/GPUState.h"
+#include "GPU/Common/GPUStateUtils.h"
 #include "GPU/Common/DepalettizeShaderCommon.h"
 
 #define WRITE p+=sprintf
@@ -71,11 +72,21 @@ void GenerateDepalShader300(char *buffer, GEBufferFormat pixelFormat, ShaderLang
 		WRITE(p, "out vec4 fragColor0;\n");
 		WRITE(p, "uniform sampler2D tex;\n");
 		WRITE(p, "uniform sampler2D pal;\n");
+
+		if (pixelFormat == GE_FORMAT_DEPTH16) {
+			DepthScaleFactors factors = GetDepthScaleFactors();
+			WRITE(p, "const float z_scale = %f;\n", factors.scale);
+			WRITE(p, "const float z_offset = %f;\n", factors.offset);
+		}
 	}
 
 	if (language == HLSL_D3D11) {
 		WRITE(p, "float4 main(in float2 v_texcoord0 : TEXCOORD0) : SV_Target {\n");
-		WRITE(p, "  float4 color = tex.Sample(texSamp, v_texcoord0);\n");
+		if (pixelFormat == GE_FORMAT_DEPTH16) {
+			WRITE(p, "  float color = tex.Sample(texSamp, v_texcoord0).x;\n");
+		} else {
+			WRITE(p, "  float4 color = tex.Sample(texSamp, v_texcoord0);\n");
+		}
 	} else {
 		WRITE(p, "void main() {\n");
 		WRITE(p, "  vec4 color = texture(tex, v_texcoord0);\n");

--- a/GPU/GLES/DepthBufferGLES.cpp
+++ b/GPU/GLES/DepthBufferGLES.cpp
@@ -133,7 +133,7 @@ void FramebufferManagerGLES::PackDepthbuffer(VirtualFramebuffer *vfb, int x, int
 		// We must bind the program after starting the render pass, and set the color mask after clearing.
 		render_->SetScissor({ 0, 0, vfb->renderWidth, vfb->renderHeight });
 		render_->SetDepth(false, false, GL_ALWAYS);
-		render_->SetRaster(false, GL_CCW, GL_FRONT, GL_FALSE);
+		render_->SetRaster(false, GL_CCW, GL_FRONT, GL_FALSE, GL_FALSE);
 		render_->BindProgram(depthDownloadProgram_);
 
 		if (!gstate_c.Supports(GPU_SUPPORTS_ACCURATE_DEPTH)) {

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -203,7 +203,7 @@ void FramebufferManagerGLES::DrawActiveTexture(float x, float y, float w, float 
 
 	// We always want a plain state here, well, except for when it's used by the stencil stuff...
 	render_->SetDepth(false, false, GL_ALWAYS);
-	render_->SetRaster(false, GL_CCW, GL_FRONT, GL_FALSE);
+	render_->SetRaster(false, GL_CCW, GL_FRONT, GL_FALSE, GL_FALSE);
 	if (!(flags & DRAWTEX_KEEP_STENCIL_ALPHA)) {
 		render_->SetNoBlendAndMask(0xF);
 		render_->SetStencilDisabled();

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -222,7 +222,7 @@ void GPU_GLES::CheckGPUFeatures() {
 		features |= GPU_SUPPORTS_TEXTURE_FLOAT;
 
 	if (draw_->GetDeviceCaps().depthClampSupported) {
-		features |= GPU_SUPPORTS_DEPTH_CLAMP;
+		features |= GPU_SUPPORTS_DEPTH_CLAMP | GPU_SUPPORTS_ACCURATE_DEPTH;
 		// Our implementation of depth texturing needs simple Z range, so can't
 		// use the extension hacks (yet).
 		if (gl_extensions.GLES3)

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -221,6 +221,9 @@ void GPU_GLES::CheckGPUFeatures() {
 	if (gl_extensions.ARB_texture_float || gl_extensions.OES_texture_float)
 		features |= GPU_SUPPORTS_TEXTURE_FLOAT;
 
+	if (draw_->GetDeviceCaps().depthClampSupported)
+		features |= GPU_SUPPORTS_DEPTH_CLAMP;
+
 	// If we already have a 16-bit depth buffer, we don't need to round.
 	bool prefer24 = draw_->GetDeviceCaps().preferredDepthBufferFormat == Draw::DataFormat::D24_S8;
 	if (prefer24) {

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -221,8 +221,13 @@ void GPU_GLES::CheckGPUFeatures() {
 	if (gl_extensions.ARB_texture_float || gl_extensions.OES_texture_float)
 		features |= GPU_SUPPORTS_TEXTURE_FLOAT;
 
-	if (draw_->GetDeviceCaps().depthClampSupported)
+	if (draw_->GetDeviceCaps().depthClampSupported) {
 		features |= GPU_SUPPORTS_DEPTH_CLAMP;
+		// Our implementation of depth texturing needs simple Z range, so can't
+		// use the extension hacks (yet).
+		if (gl_extensions.GLES3)
+			features |= GPU_SUPPORTS_DEPTH_TEXTURE;
+	}
 
 	// If we already have a 16-bit depth buffer, we don't need to round.
 	bool prefer24 = draw_->GetDeviceCaps().preferredDepthBufferFormat == Draw::DataFormat::D24_S8;

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -236,7 +236,6 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 			// TODO: Might happen in clear mode if not through...
 			depthClampEnable = false;
 		} else {
-			// Set cull
 			if (gstate.getDepthRangeMin() == 0 || gstate.getDepthRangeMax() == 65535) {
 				// TODO: Still has a bug where we clamp to depth range if one is not the full range.
 				// But the alternate is not clamping in either direction...

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -230,7 +230,24 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 		GLenum cullMode = cullingMode[gstate.getCullMode() ^ !useBufferedRendering];
 
 		cullEnable = !gstate.isModeClear() && prim != GE_PRIM_RECTANGLES && gstate.isCullEnabled();
-		renderManager->SetRaster(cullEnable, GL_CCW, cullMode, dither);
+
+		bool depthClampEnable = false;
+		if (gstate.isModeClear() || gstate.isModeThrough()) {
+			// TODO: Might happen in clear mode if not through...
+			depthClampEnable = false;
+		} else {
+			// Set cull
+			if (gstate.getDepthRangeMin() == 0 || gstate.getDepthRangeMax() == 65535) {
+				// TODO: Still has a bug where we clamp to depth range if one is not the full range.
+				// But the alternate is not clamping in either direction...
+				depthClampEnable = gstate.isDepthClampEnabled() && gstate_c.Supports(GPU_SUPPORTS_DEPTH_CLAMP);
+			} else {
+				// We just want to clip in this case, the clamp would be clipped anyway.
+				depthClampEnable = false;
+			}
+		}
+
+		renderManager->SetRaster(cullEnable, GL_CCW, cullMode, dither, depthClampEnable);
 	}
 
 	if (gstate_c.IsDirty(DIRTY_DEPTHSTENCIL_STATE)) {

--- a/GPU/GLES/StencilBufferGLES.cpp
+++ b/GPU/GLES/StencilBufferGLES.cpp
@@ -191,7 +191,7 @@ bool FramebufferManagerGLES::NotifyStencilUpload(u32 addr, int size, StencilUplo
 	render_->SetDepth(false, false, GL_ALWAYS);
 	render_->Clear(0, 0, 0, GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT, 0x8, 0, 0, 0, 0);
 	render_->SetStencilFunc(GL_TRUE, GL_ALWAYS, 0xFF, 0xFF);
-	render_->SetRaster(false, GL_CCW, GL_FRONT, GL_FALSE);
+	render_->SetRaster(false, GL_CCW, GL_FRONT, GL_FALSE, GL_FALSE);
 	render_->BindProgram(stencilUploadProgram_);
 	render_->SetNoBlendAndMask(0x8);
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -220,7 +220,7 @@ void GPU_Vulkan::CheckGPUFeatures() {
 	}
 
 	// Might enable this later - in the first round we are mostly looking at depth/stencil/discard.
-	// if (g_Config.bDisableVendorBugChecks)
+	// if (!g_Config.bEnableVendorBugChecks)
 	// 	features |= GPU_SUPPORTS_ACCURATE_DEPTH;
 
 	// Mandatory features on Vulkan, which may be checked in "centralized" code


### PR DESCRIPTION
Dug up a couple of old branches and put them together and got it working.

Only works on desktop, this currently requires GL_ARB_depth_clamp which is not really supported on mobile (there is an extension, GL_EXT_depth_clamp, but few mobile devices support it).

Need to figure out what to do about the extended Z mappings we use when either extension is not available.

Helps #6411 for OpenGL on desktop primarily, and certain other games affected by #13256
are likely working too like the fog in Harry Potter.

Let's merge after 1.11.
