### PR TITLE
vertexjit: Correct saved registers on x64

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -732,6 +732,7 @@ void CallSyscall(MIPSOpcode op)
 		int funcnum = callno & 0xFFF;
 		int modulenum = (callno & 0xFF000) >> 12;
 		double total = time_now_d() - start - hleSteppingTime;
+		_dbg_assert_msg_(total >= 0.0, "Time spent in syscall became negative");
 		hleSteppingTime = 0.0;
 		updateSyscallStats(modulenum, funcnum, total);
 	}

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -185,7 +185,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 	// Parameters automatically fall into place.
 
 	// This will align the stack properly to 16 bytes (the call of this function pushed RIP, which is 8 bytes).
-	const uint8_t STACK_FIXED_ALLOC = 64 + 8;
+	const uint8_t STACK_FIXED_ALLOC = 96 + 8;
 #endif
 
 	// Allocate temporary storage on the stack.
@@ -197,6 +197,8 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 	MOVUPS(MDisp(ESP, 16), XMM5);
 	MOVUPS(MDisp(ESP, 32), XMM6);
 	MOVUPS(MDisp(ESP, 48), XMM7);
+	MOVUPS(MDisp(ESP, 64), XMM8);
+	MOVUPS(MDisp(ESP, 80), XMM9);
 
 	bool prescaleStep = false;
 	// Look for prescaled texcoord steps
@@ -273,6 +275,8 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 	MOVUPS(XMM5, MDisp(ESP, 16));
 	MOVUPS(XMM6, MDisp(ESP, 32));
 	MOVUPS(XMM7, MDisp(ESP, 48));
+	MOVUPS(XMM8, MDisp(ESP, 64));
+	MOVUPS(XMM9, MDisp(ESP, 80));
 	ADD(PTRBITS, R(ESP), Imm8(STACK_FIXED_ALLOC));
 
 #ifdef _M_IX86

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -954,7 +954,9 @@ void GPUCommon::NotifySteppingExit() {
 		if (timeSteppingStarted_ <= 0.0) {
 			ERROR_LOG(G3D, "Mismatched stepping enter/exit.");
 		}
-		timeSpentStepping_ += time_now_d() - timeSteppingStarted_;
+		double total = time_now_d() - timeSteppingStarted_;
+		_dbg_assert_msg_(total >= 0.0, "Time spent stepping became negative");
+		timeSpentStepping_ += total;
 		timeSteppingStarted_ = 0.0;
 	}
 }
@@ -1028,6 +1030,7 @@ bool GPUCommon::InterpretList(DisplayList &list) {
 
 	if (coreCollectDebugStats) {
 		double total = time_now_d() - start - timeSpentStepping_;
+		_dbg_assert_msg_(total >= 0.0, "Time spent DL processing became negative");
 		hleSetSteppingTime(timeSpentStepping_);
 		timeSpentStepping_ = 0.0;
 		gpuStats.msProcessingDisplayLists += total;


### PR DESCRIPTION
In #7073, apparently I forgot to ensure XMM8-9 were saved.

Not sure what other problems this is causing, but when debug stats were enabled it caused the time to become corrupt.

-[Unknown]