### PR TITLE
(.gitlab-ci.yml) Add linux-i686 and windows-i686 targets (+ prevent creation of 'null' file when building Windows libretro cores)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,3 @@ debian/ppsspp/
 
 # RenderDoc
 *.rdc
-
-# bad output from libretro. don't want to accidentally add it
-nul

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,8 @@ include:
     file: '/linux-cmake.yml'
   - project: 'libretro-infrastructure/ci-templates'
     file: '/windows-x64-msvc19-msys2.yml'
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/windows-i686-msvc19-msys2.yml'
 
 stages:
   - build-prepare
@@ -34,9 +36,21 @@ libretro-build-linux-x64:
     - .core-defs
     - .linux-defs
 
+libretro-build-linux-i686:
+  extends:
+    - .libretro-linux-cmake-x86
+    - .core-defs
+    - .linux-defs
+
 libretro-build-windows-x64:
   extends:
     - .libretro-windows-x64-msvc19-msys2-make-default
+    - .core-defs
+    - .windows-defs
+
+libretro-build-windows-i686:
+  extends:
+    - .libretro-windows-i686-msvc19-msys2-make-default
     - .core-defs
     - .windows-defs
 

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -304,7 +304,7 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	filter_out1 = $(filter-out $(firstword $1),$1)
 	filter_out2 = $(call filter_out1,$(call filter_out1,$1))
 
-	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>null)))
+	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>/dev/null)))
 	fix_path = $(subst $(SPACE),\ ,$(subst \,/,$1))
 
 	b1 := (
@@ -415,7 +415,7 @@ else ifneq (,$(findstring windows_msvc2019,$(platform)))
 	filter_out1 = $(filter-out $(firstword $1),$1)
 	filter_out2 = $(call filter_out1,$(call filter_out1,$1))
 
-	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>null)))
+	reg_query = $(call filter_out2,$(subst $2,,$(shell reg query "$2" -v "$1" 2>/dev/null)))
 	fix_path = $(subst $(SPACE),\ ,$(subst \,/,$1))
 
 	b1 := (

--- a/libretro/README_WINDOWS.txt
+++ b/libretro/README_WINDOWS.txt
@@ -13,7 +13,7 @@ pacman -S make
 Then use the following in msys:
 
 cd libretro
-make platform=windows_msvc2019_desktop_x64 -j32 && cp ppsspp_libretro.* /d/retroarch/cores && rm null
+make platform=windows_msvc2019_desktop_x64 -j32 && cp ppsspp_libretro.* /d/retroarch/cores
 
 Note that the latter part copies the DLL/PDB into wherever retroarch reads it from. Might need to adjust the path,
 and adjust -j32 depending on your number of logical CPUs - might not need that many threads (or you might need more...).


### PR DESCRIPTION
This PR adds 32bit Linux and Windows targets to the libretro `.gitlab-ci.yml` file.

It also prevents the creation of the spurious `null` file when building Windows libretro cores using the static makefile in the `libretro` directory, by correctly piping unwanted output to `/dev/null` (instead of just `null`)