### PR TITLE
[Adhoc] Fix possible lock issue and Updated PdpStat

### DIFF
--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -1271,8 +1271,10 @@ bool isPrivateIP(uint32_t ip);
 
 /*
  * Get Number of bytes available in buffer to be Received
+ * @param sock fd
+ * @param udpBufferSize (UDP only)
  */
-u_long getAvailToRecv(int sock);
+u_long getAvailToRecv(int sock, int udpBufferSize = 0);
 
 /*
  * Get UDP Socket Max Message Size

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -4661,8 +4661,10 @@ int NetAdhocMatching_Start(int matchingId, int evthPri, int evthPartitionId, int
 		// Create PDP Socket
 		int sock = sceNetAdhocPdpCreate((const char*)&item->mac, static_cast<int>(item->port), item->rxbuflen, 0);
 		item->socket = sock;
-		if (sock < 1)
+		if (sock < 1) {
+			peerlock.unlock();
 			return hleLogError(SCENET, ERROR_NET_ADHOC_MATCHING_PORT_IN_USE, "adhoc matching port in use");
+		}
 
 		// Create & Start the Fake PSP Thread ("matching_ev%d" and "matching_io%d")
 		netAdhocValidateLoopMemory();


### PR DESCRIPTION
- Fix possible lock issue during AdhocMatchingStart
- Updated PdpStat to prevent rcv_sb_cc from exceeding the buffer size arg (since we use larger buffer size to prevent micro stutters or disconnection issue due to too many dropped packets with small buffer size).
TODO: May need to improve it to be able to calculate the correct size if there are multiple datagram messages