### PR TITLE
Core: Reset state properly on CPU init failure

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -412,6 +412,7 @@ bool PSP_InitStart(const CoreParameter &coreParam, std::string *error_string) {
 
 	if (!CPU_Init()) {
 		*error_string = "Failed initializing CPU/Memory";
+		pspIsIniting = false;
 		return false;
 	}
 

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -261,7 +261,8 @@ void WindowsHost::PollControllers() {
 }
 
 void WindowsHost::BootDone() {
-	g_symbolMap->SortSymbols();
+	if (g_symbolMap)
+		g_symbolMap->SortSymbols();
 	PostMessage(mainWindow_, WM_USER + 1, 0, 0);
 
 	SetDebugMode(!g_Config.bAutoRun);
@@ -295,6 +296,8 @@ static std::string SymbolMapFilename(const char *currentFilename, const char* ex
 }
 
 bool WindowsHost::AttemptLoadSymbolMap() {
+	if (!g_symbolMap)
+		return false;
 	bool result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(),".ppmap").c_str());
 	// Load the old-style map file.
 	if (!result1)
@@ -304,11 +307,13 @@ bool WindowsHost::AttemptLoadSymbolMap() {
 }
 
 void WindowsHost::SaveSymbolMap() {
-	g_symbolMap->SaveSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(),".ppmap").c_str());
+	if (g_symbolMap)
+		g_symbolMap->SaveSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(),".ppmap").c_str());
 }
 
 void WindowsHost::NotifySymbolMapUpdated() {
-	g_symbolMap->SortSymbols();
+	if (g_symbolMap)
+		g_symbolMap->SortSymbols();
 	PostMessage(mainWindow_, WM_USER + 1, 0, 0);
 }
 


### PR DESCRIPTION
Some state not being reset properly.  Surprised we haven't caught this before.  Fixes #14054.

Could've just moved setting it true down, but we might add more checks, so this seems safer.

-[Unknown]