### PR TITLE
[Adhoc] Implement blocking AdhocMatchingStop

### DIFF
--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1139,18 +1139,18 @@ void AfterMatchingMipsCall::SetData(int ContextID, int eventId, u32_le BufAddr) 
 
 bool SetMatchingInCallback(SceNetAdhocMatchingContext* context, bool IsInCB) {
 	if (context == NULL) return false;
-	context->eventlock->lock(); //peerlock.lock();
+	peerlock.lock();
 	context->IsMatchingInCB = IsInCB;
-	context->eventlock->unlock(); //peerlock.unlock();
+	peerlock.unlock();
 	return IsInCB;
 }
 
 bool IsMatchingInCallback(SceNetAdhocMatchingContext* context) {
 	bool inCB = false;
 	if (context == NULL) return inCB;
-	context->eventlock->lock(); //peerlock.lock();
+	peerlock.lock();
 	inCB = (context->IsMatchingInCB);
-	context->eventlock->unlock(); //peerlock.unlock();
+	peerlock.unlock();
 	return inCB;
 }
 

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1908,20 +1908,10 @@ u_long getAvailToRecv(int sock, int udpBufferSize) {
 		return 0;
 
 	if (udpBufferSize > 0 && n > 0) {
-		// Cap number of bytes of full DGRAM message(s?) up to buffer size
-		static int lastUdpBufSize = 0;
-		static char* buf = NULL;
-		if (udpBufferSize > lastUdpBufSize) {
-			// Reusing temp buffer to prevent causing too many fragmentation due to repeated alloc -> free (was getting out of memory issue)
-			char *tmp = (char*)realloc(buf, udpBufferSize);
-			if (tmp) {
-				buf = tmp;
-				lastUdpBufSize = udpBufferSize;
-			}
-		}
-		// Does each recv can only received one message?
-		err = recvfrom(sock, buf, udpBufferSize, MSG_PEEK | MSG_NOSIGNAL | MSG_TRUNC, NULL, NULL);
-		//free(buf); // Repeated alloc -> free seems to cause too many fragmentation and ended getting out of memory due to too many alloc -> free
+		// TODO: Cap number of bytes of full DGRAM message(s) up to buffer size
+		char buf[8];
+		// Each recv can only received one message, not sure how to read the next pending msg without actually receiving the first one
+		err = recvfrom(sock, buf, sizeof(buf), MSG_PEEK | MSG_NOSIGNAL | MSG_TRUNC, NULL, NULL);
 		if (err >= 0)
 			return (u_long)err;
 	}

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1214,7 +1214,7 @@ void notifyMatchingHandler(SceNetAdhocMatchingContext * context, ThreadMessage *
 	// Don't share buffer address space with other mipscall in the queue since mipscalls aren't immediately executed
 	MatchingArgs argsNew = { 0 };
 	u32_le dataBufLen = msg->optlen + 8; //max(bufLen, msg->optlen + 8);
-	u32_le dataBufAddr = userMemory.Alloc(dataBufLen); // We will free this memory after returning from mipscall
+	u32_le dataBufAddr = userMemory.Alloc(dataBufLen, true, "adhoc matching"); // We will free this memory after returning from mipscall
 	uint8_t * dataPtr = Memory::GetPointer(dataBufAddr);
 	if (dataPtr) {
 		memcpy(dataPtr, &msg->mac, sizeof(msg->mac));

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -876,11 +876,12 @@ public:
 	static PSPAction *Create() { return new AfterMatchingMipsCall(); }
 	void DoState(PointerWrap &p) override;
 	void run(MipsCall &call) override;
-	void SetData(int ContextID, int eventId, u32_le BufAddr);
+	void SetData(int ContextID, int eventId, u32_le BufAddr, int OptSize);
 
 private:
 	int contextID = -1;
 	int EventID = -1;
+	int OptLen = 0;
 	u32_le bufAddr = 0;
 	SceNetAdhocMatchingContext* context = nullptr;
 };

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -109,7 +109,7 @@ int PollAdhocSocket(SceNetAdhocPollSd* sds, int count, int timeout, int nonblock
 int FlushPtpSocket(int socketId);
 int NetAdhocGameMode_DeleteMaster();
 int NetAdhocctl_ExitGameMode();
-int NetAdhoc_PtpConnect(int id, int timeout, int flag, bool allowForcedConnect = true);
+int NetAdhocPtp_Connect(int id, int timeout, int flag, bool allowForcedConnect = true);
 static int sceNetAdhocPdpSend(int id, const char* mac, u32 port, void* data, int len, int timeout, int flag);
 static int sceNetAdhocPdpRecv(int id, void* addr, void* port, void* buf, void* dataLength, u32 timeout, int flag);
 
@@ -3210,7 +3210,7 @@ static int sceNetAdhocPtpOpen(const char *srcmac, int sport, const char *dstmac,
 								changeBlockingMode(tcpsocket, 1);
 
 								// Initiate PtpConnect (ie. The Warrior seems to try to PtpSend right after PtpOpen without trying to PtpConnect first)
-								NetAdhoc_PtpConnect(i + 1, rexmt_int, 1, false);
+								NetAdhocPtp_Connect(i + 1, rexmt_int, 1, false);
 
 								// Return PTP Socket Pointer
 								return hleLogDebug(SCENET, i + 1, "success");
@@ -3459,7 +3459,7 @@ static int sceNetAdhocPtpAccept(int id, u32 peerMacAddrPtr, u32 peerPortPtr, int
 	return hleLogSuccessVerboseI(SCENET, ERROR_NET_ADHOC_NOT_INITIALIZED, "not initialized");
 }
 
-int NetAdhoc_PtpConnect(int id, int timeout, int flag, bool allowForcedConnect) {
+int NetAdhocPtp_Connect(int id, int timeout, int flag, bool allowForcedConnect) {
 	// Library is initialized
 	if (netAdhocInited)
 	{
@@ -3578,7 +3578,7 @@ static int sceNetAdhocPtpConnect(int id, int timeout, int flag) {
 		return -1;
 	}
 
-	return NetAdhoc_PtpConnect(id, timeout, flag);
+	return NetAdhocPtp_Connect(id, timeout, flag);
 }
 
 int NetAdhocPtp_Close(int id, int unknown) {

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1808,14 +1808,16 @@ int NetAdhoc_SetSocketAlert(int id, s32_le flag) {
 	adhocSockets[id - 1]->flags = flg;
 	adhocSockets[id - 1]->alerted_flags = 0;
 
-	return hleDelayResult(0, "set socket alert delay", 1000);
+	return 0;
 }
 
 // Flags seems to be bitmasks of ADHOC_F_ALERT... (need more games to test this)
 int sceNetAdhocSetSocketAlert(int id, int flag) {
  	WARN_LOG_REPORT_ONCE(sceNetAdhocSetSocketAlert, SCENET, "UNTESTED sceNetAdhocSetSocketAlert(%d, %08x) at %08x", id, flag, currentMIPS->pc);
 
-	return hleLogDebug(SCENET, NetAdhoc_SetSocketAlert(id, flag), "");
+	int retval = NetAdhoc_SetSocketAlert(id, flag);
+	hleDelayResult(retval, "set socket alert delay", 1000);
+	return hleLogDebug(SCENET, retval, "");
 }
 
 int PollAdhocSocket(SceNetAdhocPollSd* sds, int count, int timeout, int nonblock) {


### PR DESCRIPTION
Implement blocking AdhocMatchingStop to prevent possible data loss and PSP memory leaks due to unprocessed pending Matching Event's callbacks.

PS: Currently this PR is making Lord of Arcana worse than already is compared to v1.10.3-1731-g5babc1af2 :( 
Will need to be tested whether it's causing regression or improving other games.

Test builds:
------------
Win32/x64: https://www.dropbox.com/s/b2mxcsw3w6gb9wq/PPSSPP_1.10.3-testbuild_Win32x64.zip?dl=0
Android(ARMv7): https://www.dropbox.com/s/329379pz4i7g0eo/PPSSPP_1.10.3-testbuild_ARMv7.apk?dl=0