### PR TITLE
Debugger: Populate funcs if disassembly open early

### DIFF
--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -851,17 +851,17 @@ void CDisasm::SetDebugMode(bool _bDebug, bool switchPC)
 
 void CDisasm::Show(bool bShow) {
 	if (deferredSymbolFill_ && bShow) {
-		if (g_symbolMap)
+		if (g_symbolMap) {
 			g_symbolMap->FillSymbolListBox(GetDlgItem(m_hDlg, IDC_FUNCTIONLIST), ST_FUNCTION);
-		deferredSymbolFill_ = false;
+			deferredSymbolFill_ = false;
+		}
 	}
 	Dialog::Show(bShow);
 }
 
 void CDisasm::NotifyMapLoaded() {
-	if (m_bShowState == SW_SHOW) {
-		if (g_symbolMap)
-			g_symbolMap->FillSymbolListBox(GetDlgItem(m_hDlg, IDC_FUNCTIONLIST), ST_FUNCTION);
+	if (m_bShowState != SW_HIDE && g_symbolMap) {
+		g_symbolMap->FillSymbolListBox(GetDlgItem(m_hDlg, IDC_FUNCTIONLIST), ST_FUNCTION);
 	} else {
 		deferredSymbolFill_ = true;
 	}


### PR DESCRIPTION
This has been bugging me and looked into it, `m_bShowState` is initially SW_SHOWNORMAL (1) not SW_SHOW (5).

If you had the disassembly open before starting the game (which I always do), this caused the func list to be empty unless you closed and reopened the disassembly.

-[Unknown]