### PR TITLE
PPGe: Fallback to atlas text on alloc fail

### DIFF
--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -913,8 +913,10 @@ void PPGeDrawText(const char *text, float x, float y, const PPGeStyle &style) {
 
 	if (HasTextDrawer()) {
 		PPGeTextDrawerImage im = PPGeGetTextImage(text, style, 480.0f - x, false);
-		PPGeDrawTextImage(im, x, y, style);
-		return;
+		if (im.ptr) {
+			PPGeDrawTextImage(im, x, y, style);
+			return;
+		}
 	}
 
 	if (style.hasShadow) {
@@ -988,8 +990,10 @@ void PPGeDrawTextWrapped(const char *text, float x, float y, float wrapWidth, fl
 		}
 
 		PPGeTextDrawerImage im = PPGeGetTextImage(s.c_str(), adjustedStyle, wrapWidth <= 0 ? 480.0f - x : wrapWidth, true);
-		PPGeDrawTextImage(im, x, y, adjustedStyle);
-		return;
+		if (im.ptr) {
+			PPGeDrawTextImage(im, x, y, adjustedStyle);
+			return;
+		}
 	}
 
 	int sx = style.hasShadow ? 1 : 0;

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -125,7 +125,7 @@ struct PPGeTextDrawerImage {
 	TextStringEntry entry;
 	u32 ptr;
 };
-std::map<PPGeTextDrawerCacheKey, PPGeTextDrawerImage> textDrawerImages;
+static std::map<PPGeTextDrawerCacheKey, PPGeTextDrawerImage> textDrawerImages;
 
 void PPGeSetDrawContext(Draw::DrawContext *draw) {
 	g_draw = draw;
@@ -364,6 +364,10 @@ void __PPGeShutdown()
 
 	delete textDrawer;
 	textDrawer = nullptr;
+
+	for (auto im : textDrawerImages)
+		kernelMemory.Free(im.second.ptr);
+	textDrawerImages.clear();
 }
 
 void PPGeBegin()


### PR DESCRIPTION
Not sure if #13518 indicates a leak, but we can in most cases still draw the text even if allocations fail.

This also cleans up tracking on exit, which was previously only cleaned up via decimation.  Mainly would've mattered on a save state or something.

-[Unknown]