### PR TITLE
Log errors when delaying or waiting an already waiting thread

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1528,16 +1528,16 @@ u32 __KernelResumeThreadFromWait(SceUID threadID, u64 retval)
 }
 
 // makes the current thread wait for an event
-void __KernelWaitCurThread(WaitType type, SceUID waitID, u32 waitValue, u32 timeoutPtr, bool processCallbacks, const char *reason)
-{
-	if (!dispatchEnabled)
-	{
+void __KernelWaitCurThread(WaitType type, SceUID waitID, u32 waitValue, u32 timeoutPtr, bool processCallbacks, const char *reason) {
+	if (!dispatchEnabled) {
 		WARN_LOG_REPORT(SCEKERNEL, "Ignoring wait, dispatching disabled... right thing to do?");
 		return;
 	}
 
 	PSPThread *thread = __GetCurrentThread();
 	_assert_(thread != nullptr);
+	if ((thread->nt.status & THREADSTATUS_WAIT) != 0)
+		WARN_LOG_REPORT(SCEKERNEL, "Waiting thread for %d that was already waiting for %d", type, thread->nt.waitType);
 	thread->nt.waitID = waitID;
 	thread->nt.waitType = type;
 	__KernelChangeThreadState(thread, ThreadStatus(THREADSTATUS_WAIT | (thread->nt.status & THREADSTATUS_SUSPEND)));
@@ -1545,22 +1545,21 @@ void __KernelWaitCurThread(WaitType type, SceUID waitID, u32 waitValue, u32 time
 	thread->waitInfo.waitValue = waitValue;
 	thread->waitInfo.timeoutPtr = timeoutPtr;
 
-	// TODO: time waster
 	if (!reason)
 		reason = "started wait";
 
 	hleReSchedule(processCallbacks, reason);
 }
 
-void __KernelWaitCallbacksCurThread(WaitType type, SceUID waitID, u32 waitValue, u32 timeoutPtr)
-{
-	if (!dispatchEnabled)
-	{
+void __KernelWaitCallbacksCurThread(WaitType type, SceUID waitID, u32 waitValue, u32 timeoutPtr) {
+	if (!dispatchEnabled) {
 		WARN_LOG_REPORT(SCEKERNEL, "Ignoring wait, dispatching disabled... right thing to do?");
 		return;
 	}
 
 	PSPThread *thread = __GetCurrentThread();
+	if ((thread->nt.status & THREADSTATUS_WAIT) != 0)
+		WARN_LOG_REPORT(SCEKERNEL, "Waiting thread for %d that was already waiting for %d", type, thread->nt.waitType);
 	thread->nt.waitID = waitID;
 	thread->nt.waitType = type;
 	__KernelChangeThreadState(thread, ThreadStatus(THREADSTATUS_WAIT | (thread->nt.status & THREADSTATUS_SUSPEND)));

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1212,7 +1212,15 @@ bool KernelIsThreadDormant(SceUID threadID) {
 	PSPThread *t = kernelObjects.Get<PSPThread>(threadID, error);
 	if (t)
 		return (t->nt.status & (THREADSTATUS_DEAD | THREADSTATUS_DORMANT)) != 0;
-	return 0;
+	return false;
+}
+
+bool KernelIsThreadWaiting(SceUID threadID) {
+	u32 error;
+	PSPThread *t = kernelObjects.Get<PSPThread>(threadID, error);
+	if (t)
+		return (t->nt.status & (THREADSTATUS_WAITSUSPEND)) != 0;
+	return false;
 }
 
 u32 __KernelGetWaitValue(SceUID threadID, u32 &error) {

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -173,6 +173,7 @@ u32 __KernelGetCurThreadStack();
 u32 __KernelGetCurThreadStackStart();
 const char *__KernelGetThreadName(SceUID threadID);
 bool KernelIsThreadDormant(SceUID threadID);
+bool KernelIsThreadWaiting(SceUID threadID);
 
 void __KernelSaveContext(PSPThreadContext *ctx, bool vfpuEnabled);
 void __KernelLoadContext(PSPThreadContext *ctx, bool vfpuEnabled);


### PR DESCRIPTION
I don't think either of these operations are good things, and noted in #14072.  This should help us catch easier.

-[Unknown]