### PR TITLE
Collapsing view group

### DIFF
--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -572,6 +572,44 @@ void ItemHeader::GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec hor
 	dc.MeasureTextRect(dc.theme->uiFontSmall, 1.0f, 1.0f, text_.c_str(), (int)text_.length(), bounds, &w, &h, ALIGN_LEFT | ALIGN_VCENTER);
 }
 
+CascadeHeader::CascadeHeader(const std::string &text, bool collapsed, LayoutParams *layoutParams)
+	: Choice(text, layoutParams), collapsed_(collapsed) {
+	layoutParams_->width = FILL_PARENT;
+	layoutParams_->height = 40;
+}
+
+void CascadeHeader::Draw(UIContext &dc) {
+	if (HasFocus()) {
+		DrawBG(dc, dc.theme->itemFocusedStyle);
+	}
+	if (down_) {
+		DrawBG(dc, dc.theme->itemDownStyle);
+	}
+
+	dc.SetFontStyle(dc.theme->uiFontSmall);
+	dc.DrawText(text_.c_str(), bounds_.x + 4, bounds_.centerY(), dc.theme->headerStyle.fgColor, ALIGN_LEFT | ALIGN_VCENTER);
+	dc.Draw()->DrawImageCenterTexel(dc.theme->whiteImage, bounds_.x, bounds_.y2()-2, bounds_.x2(), bounds_.y2(), dc.theme->headerStyle.fgColor);
+
+	dc.Draw()->DrawImageRotated(ImageID("I_ARROW"), bounds_.x2() - 40, bounds_.centerY(), 1.0f, collapsed_ ? PI/2 : 3*PI/2, dc.theme->headerStyle.fgColor, ALIGN_CENTER);
+}
+
+void CascadeHeader::SetCollapsed(bool c) {
+	collapsed_ = c;
+}
+
+void CascadeHeader::GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const {
+	Bounds bounds(0, 0, layoutParams_->width, layoutParams_->height);
+	if (bounds.w < 0) {
+		// If there's no size, let's grow as big as we want.
+		bounds.w = horiz.size == 0 ? MAX_ITEM_SIZE : horiz.size;
+	}
+	if (bounds.h < 0) {
+		bounds.h = vert.size == 0 ? MAX_ITEM_SIZE : vert.size;
+	}
+	ApplyBoundsBySpec(bounds, horiz, vert);
+	dc.MeasureTextRect(dc.theme->uiFontSmall, 1.0f, 1.0f, text_.c_str(), (int)text_.length(), bounds, &w, &h, ALIGN_LEFT | ALIGN_VCENTER);
+}
+
 void PopupHeader::Draw(UIContext &dc) {
 	const float paddingHorizontal = 12;
 	const float availableWidth = bounds_.w - paddingHorizontal * 2;

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -706,6 +706,16 @@ protected:
 	bool IsSticky() const override { return true; }
 };
 
+class CascadeHeader : public Choice {
+public:
+	CascadeHeader(const std::string &text, bool collapsed, LayoutParams *layoutParams = 0);
+	void Draw(UIContext &dc) override;
+	void GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const override;
+	void SetCollapsed(bool c);
+private:
+	bool collapsed_;
+};
+
 class InfoItem : public Item {
 public:
 	InfoItem(const std::string &text, const std::string &rightText, LayoutParams *layoutParams = nullptr);

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -1417,4 +1417,26 @@ bool StringVectorListAdaptor::AddEventCallback(View *view, std::function<EventRe
 	return EVENT_DONE;
 }
 
+CascadeList::CascadeList(const std::string &title, Orientation orientation, bool collapsed) : 
+	LinearLayout(orientation), header_(new CascadeHeader(title, collapsed)), collapsed_(collapsed) {
+	header_->OnClick.Handle(this, &CascadeList::OnToggleCollapse);
+	Add(header_);
+}
+
+void CascadeList::Update() {
+	ViewGroup::Update();
+	if (visibility_ == V_VISIBLE) {
+		header_->SetCollapsed(collapsed_);
+		for (View *view : views_) {
+			if (view != header_)
+				view->SetVisibility(collapsed_ ? V_GONE : V_VISIBLE);
+		}
+	}
+}
+
+EventReturn CascadeList::OnToggleCollapse(EventParams &e) {
+	collapsed_ = !collapsed_;
+	return EVENT_CONTINUE;
+}
+
 }  // namespace UI

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -269,6 +269,17 @@ class ViewPager : public ScrollView {
 public:
 };
 
+class CascadeList : public LinearLayout {
+public:
+	CascadeList(const std::string &title, Orientation orientation, bool collapsed = true);
+	void Update() override;
+
+	EventReturn OnToggleCollapse(EventParams &e);
+
+private:
+	CascadeHeader* header_;
+	bool collapsed_;
+};
 
 class ChoiceStrip : public LinearLayout {
 public:


### PR DESCRIPTION
PPSSPP setting menu is getting kinda crowed.

This is a attempt to make some setting group collapsing as a drop list.

This is applied only to graphic setting as a test (with just frame control section being collapsed by default for testing, no real reason for choosing this one).

Preview:
![Screenshot_2021-02-07_20-45-45](https://user-images.githubusercontent.com/13517524/107157731-1e4f9c00-6986-11eb-9312-868ea530af33.png)

Kinda want to hear what other people think about this and other possible solution or aids.
