### PR TITLE
Handle exec addr errors better - don't let IgnoreBadMemoryAccesses skip dispatcher exceptions

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -398,6 +398,7 @@ const char *MemoryExceptionTypeAsString(MemoryExceptionType type) {
 	case MemoryExceptionType::WRITE_WORD: return "Write Word";
 	case MemoryExceptionType::READ_BLOCK: return "Read Block";
 	case MemoryExceptionType::WRITE_BLOCK: return "Read/Write Block";
+	case MemoryExceptionType::EXEC_ADDR: return "Bad Exec Addr";
 	default:
 		return "N/A";
 	}

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -398,7 +398,6 @@ const char *MemoryExceptionTypeAsString(MemoryExceptionType type) {
 	case MemoryExceptionType::WRITE_WORD: return "Write Word";
 	case MemoryExceptionType::READ_BLOCK: return "Read Block";
 	case MemoryExceptionType::WRITE_BLOCK: return "Read/Write Block";
-	case MemoryExceptionType::EXEC_ADDR: return "Bad Exec Addr";
 	default:
 		return "N/A";
 	}
@@ -461,17 +460,15 @@ void Core_ExecException(u32 address, u32 pc, ExecExceptionType type) {
 	const char *desc = ExecExceptionTypeAsString(type);
 	WARN_LOG(MEMMAP, "%s: Invalid destination %08x PC %08x LR %08x", desc, address, currentMIPS->pc, currentMIPS->r[MIPS_REG_RA]);
 
-	if (!g_Config.bIgnoreBadMemAccess) {
-		ExceptionInfo &e = g_exceptionInfo;
-		e = {};
-		e.type = ExceptionType::BAD_EXEC_ADDR;
-		e.info = "";
-		e.exec_type = type;
-		e.address = address;
-		e.pc = pc;
-		Core_EnableStepping(true);
-		host->SetDebugMode(true);
-	}
+	ExceptionInfo &e = g_exceptionInfo;
+	e = {};
+	e.type = ExceptionType::BAD_EXEC_ADDR;
+	e.info = "";
+	e.exec_type = type;
+	e.address = address;
+	e.pc = pc;
+	Core_EnableStepping(true);
+	host->SetDebugMode(true);
 }
 
 void Core_Break() {

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -88,7 +88,6 @@ enum class MemoryExceptionType {
 	WRITE_WORD,
 	READ_BLOCK,
 	WRITE_BLOCK,
-	EXEC_ADDR,
 };
 enum class ExecExceptionType {
 	JUMP,

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -88,6 +88,7 @@ enum class MemoryExceptionType {
 	WRITE_WORD,
 	READ_BLOCK,
 	WRITE_BLOCK,
+	EXEC_ADDR,
 };
 enum class ExecExceptionType {
 	JUMP,

--- a/Core/MIPS/ARM/ArmAsm.cpp
+++ b/Core/MIPS/ARM/ArmAsm.cpp
@@ -204,6 +204,7 @@ void ArmJit::GenerateFixedCode() {
 			LDR(R0, CTXREG, offsetof(MIPSState, pc));
 			// TODO: In practice, do we ever run code from uncached space (| 0x40000000)? If not, we can remove this BIC.
 			BIC(R0, R0, Operand2(0xC0, 4));   // &= 0x3FFFFFFF
+			dispatcherFetch = GetCodePtr();
 			LDR(R0, MEMBASEREG, R0);
 			AND(R1, R0, Operand2(0xFF, 4));   // rotation is to the right, in 2-bit increments.
 			BIC(R0, R0, Operand2(0xFF, 4));

--- a/Core/MIPS/ARM/ArmJit.h
+++ b/Core/MIPS/ARM/ArmJit.h
@@ -184,6 +184,9 @@ public:
 	const u8 *GetDispatcher() const override {
 		return dispatcher;
 	}
+	bool IsAtDispatchFetch(const u8 *ptr) const override {
+		return ptr == dispatcherFetch;
+	}
 
 	void LinkBlock(u8 *exitPoint, const u8 *checkedEntry) override;
 	void UnlinkBlock(u8 *checkedEntry, u32 originalAddress) override;
@@ -311,6 +314,7 @@ public:
 	const u8 *dispatcherCheckCoreState;
 	const u8 *dispatcherPCInR0;
 	const u8 *dispatcher;
+	const u8 *dispatcherFetch;
 	const u8 *dispatcherNoCheck;
 
 	const u8 *restoreRoundingMode;

--- a/Core/MIPS/ARM64/Arm64Asm.cpp
+++ b/Core/MIPS/ARM64/Arm64Asm.cpp
@@ -250,6 +250,7 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 #ifdef MASKED_PSP_MEMORY
 			ANDI2R(SCRATCH1, SCRATCH1, 0x3FFFFFFF);
 #endif
+			dispatcherFetch = GetCodePtr();
 			LDR(SCRATCH1, MEMBASEREG, SCRATCH1_64);
 			LSR(SCRATCH2, SCRATCH1, 24);   // or UBFX(SCRATCH2, SCRATCH1, 24, 8)
 			ANDI2R(SCRATCH1, SCRATCH1, 0x00FFFFFF);

--- a/Core/MIPS/ARM64/Arm64Jit.h
+++ b/Core/MIPS/ARM64/Arm64Jit.h
@@ -185,6 +185,9 @@ public:
 	const u8 *GetDispatcher() const override {
 		return dispatcher;
 	}
+	bool IsAtDispatchFetch(const u8 *ptr) const override {
+		return ptr == dispatcherFetch;
+	}
 
 	void LinkBlock(u8 *exitPoint, const u8 *checkedEntry) override;
 	void UnlinkBlock(u8 *checkedEntry, u32 originalAddress) override;
@@ -275,6 +278,7 @@ public:
 	const u8 *dispatcherPCInSCRATCH1;
 	const u8 *dispatcher;
 	const u8 *dispatcherNoCheck;
+	const u8 *dispatcherFetch;
 
 	const u8 *saveStaticRegisters;
 	const u8 *loadStaticRegisters;

--- a/Core/MIPS/JitCommon/JitCommon.h
+++ b/Core/MIPS/JitCommon/JitCommon.h
@@ -123,6 +123,9 @@ namespace MIPSComp {
 
 		virtual bool CodeInRange(const u8 *ptr) const = 0;
 		virtual bool DescribeCodePtr(const u8 *ptr, std::string &name) = 0;
+		virtual bool IsAtDispatchFetch(const u8 *ptr) const {
+			return false;
+		}
 		virtual const u8 *GetDispatcher() const = 0;
 		virtual const u8 *GetCrashHandler() const = 0;
 		virtual JitBlockCache *GetBlockCache() = 0;

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -161,7 +161,7 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 #ifdef MASKED_PSP_MEMORY
 			AND(32, R(EAX), Imm32(Memory::MEMVIEW32_MASK));
 #endif
-
+			dispatcherFetch = GetCodePtr();
 #ifdef _M_IX86
 			_assert_msg_( Memory::base != 0, "Memory base bogus");
 			MOV(32, R(EAX), MDisp(EAX, (u32)Memory::base));

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -274,6 +274,11 @@ void Jit::Compile(u32 em_address) {
 		ClearCache();
 	}
 
+	if (!Memory::IsValidAddress(em_address)) {
+		Core_ExecException(em_address, em_address, ExecExceptionType::JUMP);
+		return;
+	}
+
 	BeginWrite();
 
 	int block_num = blocks.AllocateBlock(em_address);

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -298,6 +298,11 @@ private:
 		}
 		return true;
 	}
+
+	bool IsAtDispatchFetch(const u8 *codePtr) const override {
+		return codePtr == dispatcherFetch;
+	}
+
 	void SaveFlags();
 	void LoadFlags();
 
@@ -321,6 +326,7 @@ private:
 	const u8 *dispatcherCheckCoreState;
 	const u8 *dispatcherNoCheck;
 	const u8 *dispatcherInEAXNoCheck;
+	const u8 *dispatcherFetch;
 
 	const u8 *restoreRoundingMode;
 	const u8 *applyRoundingMode;

--- a/Core/MemFault.cpp
+++ b/Core/MemFault.cpp
@@ -189,7 +189,7 @@ bool HandleFault(uintptr_t hostAddress, void *ctx) {
 
 	g_lastMemoryExceptionType = type;
 
-	if (success && !isAtDispatch && (g_Config.bIgnoreBadMemAccess || g_ignoredAddresses.find(codePtr) != g_ignoredAddresses.end())) {
+	if (success && (g_Config.bIgnoreBadMemAccess || g_ignoredAddresses.find(codePtr) != g_ignoredAddresses.end())) {
 		if (!info.isMemoryWrite) {
 			// It was a read. Fill the destination register with 0.
 			// TODO

--- a/Core/MemFault.cpp
+++ b/Core/MemFault.cpp
@@ -167,11 +167,11 @@ bool HandleFault(uintptr_t hostAddress, void *ctx) {
 
 	if (isAtDispatch) {
 		u32 targetAddr = currentMIPS->pc;  // bad approximation
-#if PPSSPP_ARCH(AMD64)
+		// TODO: Do the other archs and platforms.
+#if PPSSPP_ARCH(AMD64) && PPSSPP_PLATFORM(WINDOWS)
 		// We know which register the address is in, look in Asm.cpp.
 		targetAddr = context->Rax;
 #endif
-		// TODO: Do the other archs.
 		Core_ExecException(targetAddr, currentMIPS->pc, ExecExceptionType::JUMP);
 		// Redirect execution to a crash handler that will switch to CoreState::CORE_RUNTIME_ERROR immediately.
 		context->CTX_PC = (uintptr_t)MIPSComp::jit->GetCrashHandler();


### PR DESCRIPTION
Skipping these would then just fall through into the compiler and die.

Should remove one of the "mystery" crashes from #14082.

x86 and ARM64 only for now, only tested on x86. will finish up tomorrow.

It handles this fine now (nice bluescreen):

https://github.com/hrydgard/pspautotests/commit/1047400eaec6bcbdb2a64d326375ef6a6617c4ac