### PR TITLE
GL: Call CreateDeviceObjects *after* updating render_.

### DIFF
--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -103,9 +103,8 @@ FramebufferManagerGLES::FramebufferManagerGLES(Draw::DrawContext *draw, GLRender
 {
 	needBackBufferYSwap_ = true;
 	needGLESRebinds_ = true;
-	CreateDeviceObjects();
-	render_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 	presentation_->SetLanguage(draw_->GetShaderLanguageDesc().shaderLanguage);
+	CreateDeviceObjects();
 }
 
 void FramebufferManagerGLES::Init() {
@@ -344,8 +343,8 @@ void FramebufferManagerGLES::DeviceLost() {
 
 void FramebufferManagerGLES::DeviceRestore(Draw::DrawContext *draw) {
 	FramebufferManagerCommon::DeviceRestore(draw);
-	CreateDeviceObjects();
 	render_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+	CreateDeviceObjects();
 }
 
 void FramebufferManagerGLES::Resized() {


### PR DESCRIPTION
Also remove a redundant call to fetch render_ in the FramebufferManager constructor, it's already passed in.

Should fix another crash in https://github.com/hrydgard/ppsspp/issues/14082#issuecomment-775457717 .