### PR TITLE
Only allow sceMpegGetAvcAu warmup for God Eater Series

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -79,6 +79,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ShaderColorBitmask", &flags_.ShaderColorBitmask);
 	CheckSetting(iniFile, gameID, "DisableFirstFrameReadback", &flags_.DisableFirstFrameReadback);
 	CheckSetting(iniFile, gameID, "DisableRangeCulling", &flags_.DisableRangeCulling);
+	CheckSetting(iniFile, gameID, "MpegWarmUpForGodEaterSeries", &flags_.MpegWarmUpForGodEaterSeries);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -77,6 +77,7 @@ struct CompatFlags {
 	bool ShaderColorBitmask;
 	bool DisableFirstFrameReadback;
 	bool DisableRangeCulling;
+	bool MpegWarmUpForGodEaterSeries;
 };
 
 class IniFile;

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -35,6 +35,7 @@
 #include "GPU/GPUInterface.h"
 #include "GPU/GPUState.h"
 #include "Core/HLE/sceKernelMemory.h"
+#include "Core/Core.h"
 
 // MPEG AVC elementary stream.
 static const int MPEG_AVC_ES_SIZE = 2048;          // MPEG packet size.
@@ -1586,11 +1587,12 @@ static int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 		return -1;
 	}
 	
-	int sdkver = sceKernelGetCompiledSdkVersion();
-	if ((sdkver >= 0x06000000) && (ctx->mpegwarmUp < MPEG_WARMUP_FRAMES)) {
-		DEBUG_LOG(ME, "sceMpegGetAvcAu(%08x, %08x, %08x, %08x): warming up", mpeg, streamId, auAddr, attrAddr);
-		ctx->mpegwarmUp++;
-		return ERROR_MPEG_NO_DATA;
+	if (PSP_CoreParameter().compat.flags().MpegWarmUpForGodEaterSeries) {
+		if (ctx->mpegwarmUp == 0) {
+			DEBUG_LOG(ME, "sceMpegGetAvcAu(%08x, %08x, %08x, %08x): warming up", mpeg, streamId, auAddr, attrAddr);
+			ctx->mpegwarmUp++;
+			return ERROR_MPEG_NO_DATA;
+		}
 	}
 
 	SceMpegAu avcAu;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -988,3 +988,28 @@ UCJS10007 = true
 UCES00001 = true
 UCKS45008 = true
 NPJG00059 = true
+
+[MpegWarmUpForGodEaterSeries]
+# God Eater issue #13527 ,It is custom mpeg library that required sceMpegGetAvcAu return ERROR_MPEG_NO_DATA but break FIFA 14 issue #14086
+# God Eater 1
+ULJS00237 = true
+ULKS46238 = true
+
+# God Eater 2
+ULJS00597 = true
+NPJH50832 = true
+ULJS19093 = true
+NPJH50832 = true
+
+# God Eater Burst
+ULJS00351 = true
+NPJH50352 = true
+ULJS00350 = true
+ULKS46263 = true
+ULUS10563 = true
+ULES01519 = true
+ULJS19056 = true
+NPJH50352 = true
+ULUS10563FV = true
+ULJS19081 = true
+NPJH50352 = true


### PR DESCRIPTION
Fix #14086

This is the worse thing that I find this fix God Eater.