### PR TITLE
SaveState: Prevent crash on bad cookie marker

### DIFF
--- a/Common/Serialize/Serializer.cpp
+++ b/Common/Serialize/Serializer.cpp
@@ -174,7 +174,7 @@ void PointerWrap::DoMarker(const char *prevName, u32 arbitraryNumber) {
 	u32 cookie = arbitraryNumber;
 	Do(*this, cookie);
 	if (mode == PointerWrap::MODE_READ && cookie != arbitraryNumber) {
-		_assert_msg_(false, "Error: After \"%s\", found %d (0x%X) instead of save marker %d (0x%X). Aborting savestate load...", prevName, cookie, cookie, arbitraryNumber, arbitraryNumber);
+		ERROR_LOG(SAVESTATE, "Error: After \"%s\", found %d (0x%X) instead of save marker %d (0x%X). Aborting savestate load...", prevName, cookie, cookie, arbitraryNumber, arbitraryNumber);
 		SetError(ERROR_FAILURE);
 	}
 }


### PR DESCRIPTION
Just fail to load the save state.  Seen in #14082.

This should mean a corrupt file.

-[Unknown]