### PR TITLE
GPU: Force reinterpret off without copy image

### DIFF
--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -1369,12 +1369,14 @@ void GLQueueRunner::PerformCopy(const GLRStep &step) {
 
 #if defined(USING_GLES2)
 #ifndef IOS
+	_assert_msg_(gl_extensions.OES_copy_image || gl_extensions.NV_copy_image || gl_extensions.EXT_copy_image, "Image copy extension expected");
 	glCopyImageSubDataOES(
 		srcTex, target, srcLevel, srcRect.x, srcRect.y, srcZ,
 		dstTex, target, dstLevel, dstPos.x, dstPos.y, dstZ,
 		srcRect.w, srcRect.h, depth);
 #endif
 #else
+	_assert_msg_(gl_extensions.ARB_copy_image || gl_extensions.NV_copy_image, "Image copy extension expected");
 	if (gl_extensions.ARB_copy_image) {
 		glCopyImageSubData(
 			srcTex, target, srcLevel, srcRect.x, srcRect.y, srcZ,

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -551,6 +551,9 @@ void FramebufferManagerCommon::ReinterpretFramebuffer(VirtualFramebuffer *vfb, G
 
 	bool doReinterpret = PSP_CoreParameter().compat.flags().ReinterpretFramebuffers &&
 		(lang == HLSL_D3D11 || lang == GLSL_VULKAN || lang == GLSL_3xx);
+	// Copy image required for now.
+	if (!gstate_c.Supports(GPU_SUPPORTS_COPY_IMAGE))
+		doReinterpret = false;
 	if (!doReinterpret) {
 		// Fake reinterpret - just clear the way we always did on Vulkan. Just clear color and stencil.
 		if (oldFormat == GE_FORMAT_565) {


### PR DESCRIPTION
Also, assert we have it when using it, since there's ifs.

See #14123 - this should prevent crashes even on those games where it's still enabled.

-[Unknown]