### PR TITLE
Io: Truncate reads/writes to valid memory

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -844,11 +844,13 @@ bool SavedataParam::GetExpectedHash(const std::string &dirPath, const std::strin
 
 void SavedataParam::LoadFile(const std::string& dirPath, const std::string& filename, PspUtilitySavedataFileData *fileData) {
 	std::string filePath = dirPath + "/" + filename;
-	s64 readSize = -1;
-	if(!fileData->buf.IsValid())
+	if (!fileData->buf.IsValid())
 		return;
+
 	u8 *buf = fileData->buf;
-	if(ReadPSPFile(filePath, &buf, fileData->bufSize, &readSize))
+	u32 size = Memory::ValidSize(fileData->buf.ptr, fileData->bufSize);
+	s64 readSize = -1;
+	if (ReadPSPFile(filePath, &buf, size, &readSize))
 		fileData->size = readSize;
 }
 

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -417,7 +417,7 @@ int ISOFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outd
 			return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
 		} else {
 			int block = (u16)desc.firstLETableSector;
-			u32 size = (u32)desc.pathTableLength;
+			u32 size = Memory::ValidSize(outdataPtr, (u32)desc.pathTableLength);
 			u8 *out = Memory::GetPointer(outdataPtr);
 
 			int blocks = size / blockDevice->GetBlockSize();


### PR DESCRIPTION
A PSP might crash in these cases, but it's better if we avoid a crash.

Added based on #14082, although it's probably (?) some other corruption.  Still, this is safer and might prevent a needless crash.

-[Unknown]