### PR TITLE
Android: Ensure shutdown waits for render

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1060,6 +1060,9 @@ void RenderOverlays(UIContext *dc, void *userdata) {
 }
 
 void NativeRender(GraphicsContext *graphicsContext) {
+	_assert_(graphicsContext != nullptr);
+	_assert_(screenManager != nullptr);
+
 	g_GameManager.Update();
 
 	if (GetUIState() != UISTATE_INGAME) {


### PR DESCRIPTION
We apparently have a case where render is busy during shutdown, based on crash reports.

Trying to catch #14082's LogoScreen crash.  I feel like it must mean these race, which in theory could happen if `onDestroy()` doesn't prevent render() from being called I suppose.

-[Unknown]