### PR TITLE
Build: Cache Qt during Actions run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - master
+    # For testing.
+    - actions
     paths-ignore:
     - '*.{txt,md}'
     - 'Tools/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,9 +178,19 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Cache Qt
+      uses: actions/cache@v1
+      if: matrix.extra == 'qt'
+      id: cache-qt
+      with:
+        path: ${{ runner.workspace }}/Qt
+        key: ${{ runner.os }}-QtCache
+
     - name: Install Qt
       uses: jurplel/install-qt-action@v2
       if: matrix.extra == 'qt'
+      with:
+        cached: ${{ steps.cache-qt.outputs.cache-hit }}
 
     - uses: nttld/setup-ndk@v1
       if: matrix.extra == 'android'


### PR DESCRIPTION
This will hopefully insulate us from the flaky download.qt.io a bit better.

-[Unknown]