### PR TITLE
GachiTora! requires block transfer

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -519,6 +519,9 @@ NPJH50518 = true
 ULUS10103 = true
 ULES00381 = true
 ULJM05091 = true
+# GachiTora! Abarenbou Kyoushi in High School need it to render shadows properly (see #14136)
+ULJS00355 = true
+NPJH50409 = true
 
 [DisableAccurateDepth]
 # Midnight Club: LA Remix


### PR DESCRIPTION
See #14136, this game needs block transfer effects to be enabled to fix shadows properly.