### PR TITLE
libretro: Remove "Unsafe FuncReplacements" option. 

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -214,9 +214,9 @@ static RetroOption<bool> ppsspp_texture_deposterize("ppsspp_texture_deposterize"
 static RetroOption<bool> ppsspp_texture_replacement("ppsspp_texture_replacement", "Texture Replacement", false);
 static RetroOption<bool> ppsspp_gpu_hardware_transform("ppsspp_gpu_hardware_transform", "GPU Hardware T&L", true);
 static RetroOption<bool> ppsspp_vertex_cache("ppsspp_vertex_cache", "Vertex Cache (Speedhack)", true);
-static RetroOption<bool> ppsspp_unsafe_func_replacements("ppsspp_unsafe_func_replacements", "Unsafe FuncReplacements", true);
 static RetroOption<bool> ppsspp_cheats("ppsspp_cheats", "Internal Cheats Support", false);
 static RetroOption<IOTimingMethods> ppsspp_io_timing_method("ppsspp_io_timing_method", "IO Timing Method", { { "Fast", IOTimingMethods::IOTIMING_FAST }, { "Host", IOTimingMethods::IOTIMING_HOST }, { "Simulate UMD delays", IOTimingMethods::IOTIMING_REALISTIC } });
+static RetroOption<bool> ppsspp_frame_duplication("ppsspp_frame_duplication", "Duplicate frames in 30hz games", false);
 
 void retro_set_environment(retro_environment_t cb)
 {
@@ -240,10 +240,10 @@ void retro_set_environment(retro_environment_t cb)
    vars.push_back(ppsspp_texture_replacement.GetOptions());
    vars.push_back(ppsspp_gpu_hardware_transform.GetOptions());
    vars.push_back(ppsspp_vertex_cache.GetOptions());
-   vars.push_back(ppsspp_unsafe_func_replacements.GetOptions());
    vars.push_back(ppsspp_cheats.GetOptions());
    vars.push_back(ppsspp_io_timing_method.GetOptions());
    vars.push_back(ppsspp_lower_resolution_for_effects.GetOptions());
+   vars.push_back(ppsspp_frame_duplication.GetOptions());
    vars.push_back({});
 
    environ_cb = cb;
@@ -308,13 +308,13 @@ static void check_variables(CoreParameter &coreParam)
    ppsspp_texture_anisotropic_filtering.Update(&g_Config.iAnisotropyLevel);
    ppsspp_texture_deposterize.Update(&g_Config.bTexDeposterize);
    ppsspp_texture_replacement.Update(&g_Config.bReplaceTextures);
-   ppsspp_unsafe_func_replacements.Update(&g_Config.bFuncReplacements);
    ppsspp_cheats.Update(&g_Config.bEnableCheats);
    ppsspp_locked_cpu_speed.Update(&g_Config.iLockedCPUSpeed);
    ppsspp_rendering_mode.Update(&g_Config.iRenderingMode);
    ppsspp_cpu_core.Update((CPUCore *)&g_Config.iCpuCore);
    ppsspp_io_timing_method.Update((IOTimingMethods *)&g_Config.iIOTimingMethod);
    ppsspp_lower_resolution_for_effects.Update(&g_Config.iBloomHack);
+   ppsspp_frame_duplication.Update(&g_Config.bRenderDuplicateFrames);
 
    ppsspp_language.Update(&g_Config.iLanguage);
    if (g_Config.iLanguage < 0)


### PR DESCRIPTION
See #12322 .

Also, fixes #14108 by adding a frame duplication option.