### PR TITLE
Android: Update to Gradle 6.5. Enable automatic debug symbol uploads for release builds.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,6 +76,7 @@ android {
 		release {
 			minifyEnabled = false
 			signingConfig signingConfigs.release
+			ndk.debugSymbolLevel = 'FULL'
 		}
 	}
 	externalNativeBuild {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.android.tools.build:gradle:4.1.2'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
This will require switching to Android Studio 4.1.2. 

Fortunately all the crippling bugs of Android Studio 4.1 seem to be fixed with this point release, so we can make the move now.