### PR TITLE
UI: Avoid audio locks where possible

### DIFF
--- a/UI/BackgroundAudio.h
+++ b/UI/BackgroundAudio.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <string>
+#include <atomic>
 #include <mutex>
+#include <string>
 #include <vector>
 
 #include "Common/UI/Root.h"
@@ -13,7 +14,6 @@ public:
 	BackgroundAudio();
 	~BackgroundAudio();
 
-	void Clear(bool hard);
 	void SetGame(const std::string &path);
 	void Update();
 	int Play();
@@ -22,12 +22,15 @@ public:
 	void PlaySFX(UI::UISound sfx);
 
 private:
+	void Clear(bool hard);
+
 	enum {
 		BUFSIZE = 44100,
 	};
 
 	std::mutex mutex_;
 	std::string bgGamePath_;
+	std::atomic<bool> sndLoadPending_;
 	int playbackOffset_ = 0;
 	AT3PlusReader *at3Reader_;
 	double gameLastChanged_ = 0.0;


### PR DESCRIPTION
In case of thread contention, avoid locking if not necessary.  See #13469.

Normally, `SetGame()` and `Update()` are called from UI thread, and `Play()` (from `NativeMix()`) is called from the audio thread.  I'm just trying to reduce the cross talk here, so they can't possibly block each other.  Though, I'm not really seeing a deadlock here...

-[Unknown]