### PR TITLE
CMake: use vendor GL implementations by setting CMP0072 to NEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,9 @@ if(NOT OPENGL_LIBRARIES AND USING_GLES2)
 endif()
 
 if(NOT OPENGL_LIBRARIES)
+	if(POLICY CMP0072)
+		cmake_policy(SET CMP0072 NEW)
+	endif()
 	find_package(OpenGL REQUIRED)
 endif()
 


### PR DESCRIPTION
Recent CMake now complains loudly if this is unset.