### PR TITLE
Dialog: Unlock volatile without Update call

### DIFF
--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -83,6 +83,9 @@ public:
 
 	void StartDraw();
 	void EndDraw();
+
+	void FinishVolatile();
+
 protected:
 	PPGeStyle FadedStyle(PPGeAlign align, float scale);
 	PPGeImageStyle FadedImageStyle();
@@ -123,8 +126,6 @@ protected:
 	int cancelButtonFlag;
 
 private:
-	void FinishVolatile();
-
 	DialogStatus status = SCE_UTILITY_STATUS_NONE;
 	bool volatileLocked_ = false;
 };

--- a/Core/HLE/sceUtility.h
+++ b/Core/HLE/sceUtility.h
@@ -83,4 +83,7 @@ void __UtilityInit();
 void __UtilityDoState(PointerWrap &p);
 void __UtilityShutdown();
 
+void UtilityScheduleVolatileUnlock(s64 cyclesIntoFuture);
+void UtilityCancelVolatileUnlock();
+
 void Register_sceUtility();


### PR DESCRIPTION
Crisis Core depends on this unlocking, likely it should really be on a thread.  Fixes #14159.

This is the simpler approach of just unlocking it when it would've changed status, roughly.

-[Unknown]