### PR TITLE
Reduce startup locks

### DIFF
--- a/Common/File/PathBrowser.h
+++ b/Common/File/PathBrowser.h
@@ -37,6 +37,7 @@ public:
 
 private:
 	void HandlePath();
+	void ResetPending();
 
 	std::string path_;
 	std::string pendingPath_;
@@ -44,6 +45,7 @@ private:
 	std::condition_variable pendingCond_;
 	std::mutex pendingLock_;
 	std::thread pendingThread_;
+	bool pendingActive_ = false;
 	bool pendingCancel_ = false;
 	bool pendingStop_ = false;
 	bool ready_ = false;

--- a/Common/UI/Tween.cpp
+++ b/Common/UI/Tween.cpp
@@ -6,7 +6,7 @@
 namespace UI {
 
 void Tween::Apply(View *view) {
-	if (!valid_)
+	if (!valid_ || finishApplied_)
 		return;
 
 	if (DurationOffset() >= duration_)

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -201,7 +201,7 @@ void Clickable::DrawBG(UIContext &dc, const Style &style) {
 	if (style.background.type == DRAW_SOLID_COLOR) {
 		if (time_now_d() - bgColorLast_ >= 0.25f) {
 			bgColor_->Reset(style.background.color);
-		} else {
+		} else if (bgColor_->CurrentValue() != style.background.color) {
 			bgColor_->Divert(style.background.color, down_ ? 0.05f : 0.1f);
 		}
 		bgColorLast_ = time_now_d();


### PR DESCRIPTION
I have to believe #13469 is from thread contention with PPSSPP threads getting starved or something.  Startup is when we trigger the most threads, video and audio drivers spin off the most work, etc.

This reduces some easily avoidable locks on startup, to hopefully reduce any contention.  I also think it makes the code a bit clearer, anyway.

-[Unknown]