### PR TITLE
UnitTest: test that the function pointer for vfpu_sincos() is non-null

### DIFF
--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -298,6 +298,7 @@ bool TestParsers() {
 
 bool TestVFPUSinCos() {
 	float sine, cosine;
+	EXPECT_FALSE(vfpu_sincos == nullptr);
 	vfpu_sincos(0.0f, sine, cosine);
 	EXPECT_EQ_FLOAT(sine, 0.0f);
 	EXPECT_EQ_FLOAT(cosine, 1.0f);


### PR DESCRIPTION
The VFPUSinCos test will still fail, but at least now it will not cause a segmentation fault.