### PR TITLE
TestVertexJit: fmodf() definition requires math.h

### DIFF
--- a/unittest/TestVertexJit.cpp
+++ b/unittest/TestVertexJit.cpp
@@ -15,6 +15,8 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <math.h>
+
 #include "Common/Common.h"
 #include "Common/TimeUtil.h"
 #include "Core/Config.h"


### PR DESCRIPTION
At least on Linux, this file fails to compile without it. However, it is currently only noticeable when the unit tests are enabled.