### PR TITLE
Remove deprecated API calls for new FFmpeg 4.3.x

### DIFF
--- a/Core/AVIDump.cpp
+++ b/Core/AVIDump.cpp
@@ -65,7 +65,9 @@ static void InitAVCodec() {
 	static bool first_run = true;
 	if (first_run) {
 #ifdef USE_FFMPEG
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 12, 100)
 		av_register_all();
+#endif
 #endif
 		first_run = false;
 	}

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -636,8 +636,12 @@ void __AtracInit() {
 	atracIDTypes[5] = 0;
 
 #ifdef USE_FFMPEG
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 18, 100)
 	avcodec_register_all();
+#endif
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 12, 100)
 	av_register_all();
+#endif
 #endif // USE_FFMPEG
 }
 

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -393,8 +393,12 @@ void __MpegInit() {
 	actionPostPut = __KernelRegisterActionType(PostPutAction::Create);
 
 #ifdef USE_FFMPEG
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 18, 100)
 	avcodec_register_all();
+#endif
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 12, 100)
 	av_register_all();
+#endif
 #endif
 }
 

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -426,8 +426,9 @@ bool MediaEngine::addVideoStream(int streamNum, int streamId) {
 #if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 33, 100)
 			stream->codecpar->codec_type = AVMEDIA_TYPE_VIDEO;
 			stream->codecpar->codec_id = AV_CODEC_ID_H264;
-#endif
+#else
 			stream->request_probe = 0;
+#endif
 			stream->need_parsing = AVSTREAM_PARSE_FULL;
 			// We could set the width here, but we don't need to.
 			if (streamNum >= m_expectedVideoStreams) {

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -313,8 +313,10 @@ bool MediaEngine::openContext(bool keepReadPos) {
 	av_dict_free(&open_opt);
 
 	if (!SetupStreams()) {
-		// Fallback to old behavior.
-		if (avformat_find_stream_info(m_pFormatCtx, NULL) < 0) {
+		// Fallback to old behavior.  Reads too much and corrupts when game doesn't read fast enough.
+		// SetupStreams should work for newer FFmpeg 3.1+ now.
+		WARN_LOG_REPORT_ONCE(setupStreams, ME, "Failed to read valid video stream data from header");
+		if (avformat_find_stream_info(m_pFormatCtx, nullptr) < 0) {
 			closeContext();
 			return false;
 		}

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -62,8 +62,12 @@ SimpleAudio::SimpleAudio(int audioType, int sample_rate, int channels)
 
 void SimpleAudio::Init() {
 #ifdef USE_FFMPEG
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 18, 100)
 	avcodec_register_all();
+#endif
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 12, 100)
 	av_register_all();
+#endif
 	InitFFmpeg();
 
 	frame_ = av_frame_alloc();

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -192,7 +192,25 @@ bool SimpleAudio::Decode(void *inbuf, int inbytes, uint8_t *outbuf, int *outbyte
 
 	*outbytes = 0;
 	srcPos = 0;
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)
+	if (inbytes != 0) {
+		int err = avcodec_send_packet(codecCtx_, &packet);
+		if (err < 0) {
+			ERROR_LOG(ME, "Error sending audio frame to decoder (%d bytes): %d (%08x)", inbytes, err, err);
+			return false;
+		}
+	}
+	int err = avcodec_receive_frame(codecCtx_, frame_);
+	int len = 0;
+	if (err >= 0) {
+		len = frame_->pkt_size;
+		got_frame = 1;
+	} else if (err != AVERROR(EAGAIN)) {
+		len = err;
+	}
+#else
 	int len = avcodec_decode_audio4(codecCtx_, frame_, &got_frame, &packet);
+#endif
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 12, 100)
 	av_packet_unref(&packet);
 #else


### PR DESCRIPTION
This uses ifdefs to remove deprecated function / field usage, corrects `SetupStreams()` usage on FFmpeg 3.1+.

Should fix #11490 and probably #13849 (didn't try any unreleased versions.)  May help #11278.

Note: at this point, no updates to any builds to use newer FFmpeg, so this would only affect those using system FFmpeg.

-[Unknown]