### PR TITLE
Only consider the actual PPGe texture in kernel ram reliable.

### DIFF
--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -197,6 +197,10 @@ static void EndVertexDataAndDraw(int prim) {
 	WriteCmd(GE_CMD_PRIM, (prim << 16) | vertexCount);
 }
 
+bool PPGeIsFontTextureAddress(u32 addr) {
+	return addr == atlasPtr;
+}
+
 static u32 __PPGeDoAlloc(u32 &size, bool fromTop, const char *name) {
 	u32 ptr = kernelMemory.Alloc(size, fromTop, name);
 	// Didn't get it, try again after decimating images.

--- a/Core/Util/PPGeDraw.h
+++ b/Core/Util/PPGeDraw.h
@@ -108,6 +108,9 @@ void PPGeScissorReset();
 
 void PPGeNotifyFrame();
 
+// Could have returned the address directly I guess, but nothing out side of PPGe should actually use it so..
+bool PPGeIsFontTextureAddress(u32 addr);
+
 class PPGeImage {
 public:
 	PPGeImage(const std::string &pspFilename);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -33,6 +33,7 @@
 #include "GPU/GPUCommon.h"
 #include "GPU/GPUInterface.h"
 #include "GPU/GPUState.h"
+#include "Core/Util/PPGeDraw.h"
 
 #if defined(_M_SSE)
 #include <emmintrin.h>
@@ -502,7 +503,7 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 			WARN_LOG_REPORT_ONCE(clutUseRender, G3D, "Using texture with rendered CLUT: texfmt=%d, clutfmt=%d", gstate.getTextureFormat(), gstate.getClutPaletteFormat());
 		}
 
-		if (Memory::IsKernelAndNotVolatileAddress(texaddr)) {
+		if (PPGeIsFontTextureAddress(texaddr)) {
 			// It's the builtin font texture.
 			entry->status = TexCacheEntry::STATUS_RELIABLE;
 		} else if (g_Config.bTextureBackoffCache) {


### PR DESCRIPTION
It seems some Chinese patches like to allocate kernel space for textures.

(On that note, we should probably allocate our texture elsewhere... in case it takes up too much space).

Should help #14144 .