### PR TITLE
GPU: Rotate screenshot framebuffer per display

### DIFF
--- a/GPU/Common/GPUDebugInterface.cpp
+++ b/GPU/Common/GPUDebugInterface.cpp
@@ -39,7 +39,7 @@ void GPUDebugBuffer::Allocate(u32 stride, u32 height, GPUDebugBufferFormat fmt, 
 	fmt_ = fmt;
 	flipped_ = flipped;
 
-	u32 pixelSize = PixelSize(fmt);
+	u32 pixelSize = PixelSize();
 	data_ = new u8[pixelSize * stride * height];
 }
 
@@ -50,8 +50,8 @@ void GPUDebugBuffer::Free() {
 	data_ = NULL;
 }
 
-u32 GPUDebugBuffer::PixelSize(GPUDebugBufferFormat fmt) const {	
-	switch (fmt) {
+u32 GPUDebugBuffer::PixelSize() const {
+	switch (fmt_) {
 	case GPU_DBG_FORMAT_8888:
 	case GPU_DBG_FORMAT_8888_BGRA:
 	case GPU_DBG_FORMAT_FLOAT:
@@ -81,7 +81,7 @@ u32 GPUDebugBuffer::GetRawPixel(int x, int y) const {
 		y = height_ - y - 1;
 	}
 
-	u32 pixelSize = PixelSize(fmt_);
+	u32 pixelSize = PixelSize();
 	u32 byteOffset = pixelSize * (stride_ * y + x);
 	const u8 *ptr = &data_[byteOffset];
 
@@ -96,5 +96,38 @@ u32 GPUDebugBuffer::GetRawPixel(int x, int y) const {
 		return *(const u8 *)ptr;
 	default:
 		return 0;
+	}
+}
+
+void GPUDebugBuffer::SetRawPixel(int x, int y, u32 c) {
+	if (data_ == nullptr) {
+		return;
+	}
+
+	if (flipped_) {
+		y = height_ - y - 1;
+	}
+
+	u32 pixelSize = PixelSize();
+	u32 byteOffset = pixelSize * (stride_ * y + x);
+	u8 *ptr = &data_[byteOffset];
+
+	switch (pixelSize) {
+	case 4:
+		*(u32 *)ptr = c;
+		break;
+	case 3:
+		ptr[0] = (c >> 0) & 0xFF;
+		ptr[1] = (c >> 8) & 0xFF;
+		ptr[2] = (c >> 16) & 0xFF;
+		break;
+	case 2:
+		*(u16 *)ptr = (u16)c;
+		break;
+	case 1:
+		*ptr = (u8)c;
+		break;
+	default:
+		break;
 	}
 }

--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -140,6 +140,7 @@ struct GPUDebugBuffer {
 	}
 
 	u32 GetRawPixel(int x, int y) const;
+	void SetRawPixel(int x, int y, u32 c);
 
 	const u8 *GetData() const {
 		return data_;
@@ -161,9 +162,9 @@ struct GPUDebugBuffer {
 		return fmt_;
 	}
 
-private:
-	u32 PixelSize(GPUDebugBufferFormat fmt) const;
+	u32 PixelSize() const;
 
+private:
 	bool alloc_ = false;
 	u8 *data_ = nullptr;
 	u32 stride_ = 0;


### PR DESCRIPTION
Fixes #14053.  Not entirely efficient, but much simpler than doing it inside `ConvertBufferToScreenshot()`.  And this is just for screenshots, which aren't that common.

-[Unknown]