### PR TITLE
Additional fixes for FFmpeg 3.1+

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -994,7 +994,8 @@ static bool decodePmpVideo(PSPPointer<SceMpegRingBuffer> ringbuffer, u32 pmpctxA
 
 		// decode video frame
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)
-		avcodec_send_packet(pCodecCtx, &packet);
+		if (packet.size != 0)
+			avcodec_send_packet(pCodecCtx, &packet);
 		int len = avcodec_receive_frame(pCodecCtx, pFrame);
 		if (len == 0) {
 			len = pFrame->pkt_size;

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -314,7 +314,7 @@ bool MediaEngine::openContext(bool keepReadPos) {
 
 	if (!SetupStreams()) {
 		// Fallback to old behavior.  Reads too much and corrupts when game doesn't read fast enough.
-		// SetupStreams should work for newer FFmpeg 3.1+ now.
+		// SetupStreams sometimes work for newer FFmpeg 3.1+ now, but sometimes framerate is missing.
 		WARN_LOG_REPORT_ONCE(setupStreams, ME, "Failed to read valid video stream data from header");
 		if (avformat_find_stream_info(m_pFormatCtx, nullptr) < 0) {
 			closeContext();
@@ -677,7 +677,8 @@ bool MediaEngine::stepVideo(int videoPixelMode, bool skipFrame) {
 #endif
 
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 48, 101)
-			avcodec_send_packet(m_pCodecCtx, &packet);
+			if (packet.size != 0)
+				avcodec_send_packet(m_pCodecCtx, &packet);
 			int result = avcodec_receive_frame(m_pCodecCtx, m_pFrame);
 			if (result == 0) {
 				result = m_pFrame->pkt_size;

--- a/Core/HW/MediaEngine.h
+++ b/Core/HW/MediaEngine.h
@@ -124,7 +124,8 @@ public:  // TODO: Very little of this below should be public.
 	int m_desHeight;
 	int m_decodingsize;
 	int m_bufSize;
-	s64 m_videopts;
+	s64 m_videopts = 0;
+	s64 m_lastPts = -1;
 	BufferQueue *m_pdata;
 
 	MpegDemux *m_demux;


### PR DESCRIPTION
Noticed an issue with bad frames in certain Valkyrie Profile videos, because it was sending 0 size packets switching to flush mode.  Really, we should flush - but it's tricky because we never know when the frame is actually ending.  One of the tricky things about using the FFmpeg decoder APIs for this.

Also somehow forgot to pull over the sceAtrac changes, was working on another branch with vcxproj updates for FFmpeg 4.3.

Lastly added a workaround for #11490.

-[Unknown]