### PR TITLE
Module: Block a few network modules already HLE'd

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -114,9 +114,14 @@ static const char * const blacklistedModules[] = {
 	"sceNetInet_Library",
 	"sceNetResolver_Library",
 	"sceNet_Library",
+	"sceNetAdhoc_Library",
+	"sceNetAdhocAuth_Service",
+	"sceNetAdhocctl_Library",
+	"sceNetIfhandle_Service",
 	"sceSsl_Module",
 	"sceDEFLATE_Library",
 	"sceMD5_Library",
+	"sceMemab",
 };
 
 struct WriteVarSymbolState;


### PR DESCRIPTION
In #13723, some of these modules loaded and ran code which might break because they're accessing kernel functions or potentially direct network hardware registers.

No idea if it actually helps the game.

-[Unknown]