### PR TITLE
glslang: Update to latest glslang

### DIFF
--- a/UWP/glslang_UWP/glslang_UWP.vcxproj
+++ b/UWP/glslang_UWP/glslang_UWP.vcxproj
@@ -379,6 +379,13 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\ext\glslang\glslang\build_info.h" />
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\pch.h" />
+    <ClInclude Include="..\..\ext\glslang\glslang\MachineIndependent\pch.h" />
+    <ClInclude Include="..\..\ext\glslang\SPIRV\GLSL.ext.EXT.h" />
+    <ClInclude Include="..\..\ext\glslang\SPIRV\GLSL.ext.NV.h" />
+    <ClInclude Include="..\..\ext\glslang\SPIRV\NonSemanticDebugPrintf.h" />
+    <ClInclude Include="..\..\ext\glslang\SPIRV\SpvTools.h" />
     <ClInclude Include="..\..\ext\glslang\glslang\Include\arrays.h" />
     <ClInclude Include="..\..\ext\glslang\glslang\Include\BaseTypes.h" />
     <ClInclude Include="..\..\ext\glslang\glslang\Include\Common.h" />
@@ -409,14 +416,14 @@
     <ClInclude Include="..\..\ext\glslang\glslang\MachineIndependent\ScanContext.h" />
     <ClInclude Include="..\..\ext\glslang\glslang\MachineIndependent\SymbolTable.h" />
     <ClInclude Include="..\..\ext\glslang\glslang\MachineIndependent\Versions.h" />
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslAttributes.h" />
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslGrammar.h" />
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslOpMap.h" />
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslParseables.h" />
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslParseHelper.h" />
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslScanContext.h" />
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslTokens.h" />
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslTokenStream.h" />
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslAttributes.h" />
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslGrammar.h" />
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslOpMap.h" />
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslParseables.h" />
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslParseHelper.h" />
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslScanContext.h" />
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslTokens.h" />
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslTokenStream.h" />
     <ClInclude Include="..\..\ext\glslang\OGLCompilersDLL\InitializeDll.h" />
     <ClInclude Include="..\..\ext\glslang\SPIRV\bitutils.h" />
     <ClInclude Include="..\..\ext\glslang\SPIRV\disassemble.h" />
@@ -436,6 +443,7 @@
     <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\ext\glslang\SPIRV\SpvTools.cpp" />
     <ClCompile Include="..\..\ext\glslang\glslang\GenericCodeGen\CodeGen.cpp" />
     <ClCompile Include="..\..\ext\glslang\glslang\GenericCodeGen\Link.cpp" />
     <ClCompile Include="..\..\ext\glslang\glslang\MachineIndependent\attribute.cpp" />
@@ -466,13 +474,13 @@
     <ClCompile Include="..\..\ext\glslang\glslang\MachineIndependent\SymbolTable.cpp" />
     <ClCompile Include="..\..\ext\glslang\glslang\MachineIndependent\Versions.cpp" />
     <ClCompile Include="..\..\ext\glslang\glslang\OSDependent\Windows\ossource.cpp" />
-    <ClCompile Include="..\..\ext\glslang\hlsl\hlslAttributes.cpp" />
-    <ClCompile Include="..\..\ext\glslang\hlsl\hlslGrammar.cpp" />
-    <ClCompile Include="..\..\ext\glslang\hlsl\hlslOpMap.cpp" />
-    <ClCompile Include="..\..\ext\glslang\hlsl\hlslParseables.cpp" />
-    <ClCompile Include="..\..\ext\glslang\hlsl\hlslParseHelper.cpp" />
-    <ClCompile Include="..\..\ext\glslang\hlsl\hlslScanContext.cpp" />
-    <ClCompile Include="..\..\ext\glslang\hlsl\hlslTokenStream.cpp" />
+    <ClCompile Include="..\..\ext\glslang\glslang\HLSL\hlslAttributes.cpp" />
+    <ClCompile Include="..\..\ext\glslang\glslang\HLSL\hlslGrammar.cpp" />
+    <ClCompile Include="..\..\ext\glslang\glslang\HLSL\hlslOpMap.cpp" />
+    <ClCompile Include="..\..\ext\glslang\glslang\HLSL\hlslParseables.cpp" />
+    <ClCompile Include="..\..\ext\glslang\glslang\HLSL\hlslParseHelper.cpp" />
+    <ClCompile Include="..\..\ext\glslang\glslang\HLSL\hlslScanContext.cpp" />
+    <ClCompile Include="..\..\ext\glslang\glslang\HLSL\hlslTokenStream.cpp" />
     <ClCompile Include="..\..\ext\glslang\OGLCompilersDLL\InitializeDll.cpp" />
     <ClCompile Include="..\..\ext\glslang\SPIRV\disassemble.cpp" />
     <ClCompile Include="..\..\ext\glslang\SPIRV\doc.cpp" />

--- a/UWP/glslang_UWP/glslang_UWP.vcxproj.filters
+++ b/UWP/glslang_UWP/glslang_UWP.vcxproj.filters
@@ -136,22 +136,25 @@
     <ClCompile Include="..\..\ext\glslang\SPIRV\SPVRemapper.cpp">
       <Filter>SPIRV</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\ext\glslang\hlsl\hlslAttributes.cpp">
+    <ClCompile Include="..\..\ext\glslang\SPIRV\SpvTools.cpp">
+      <Filter>SPIRV</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ext\glslang\glslang\HLSL\hlslAttributes.cpp">
       <Filter>hlsl</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\ext\glslang\hlsl\hlslGrammar.cpp">
+    <ClCompile Include="..\..\ext\glslang\glslang\HLSL\hlslGrammar.cpp">
       <Filter>hlsl</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\ext\glslang\hlsl\hlslOpMap.cpp">
+    <ClCompile Include="..\..\ext\glslang\glslang\HLSL\hlslOpMap.cpp">
       <Filter>hlsl</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\ext\glslang\hlsl\hlslParseables.cpp">
+    <ClCompile Include="..\..\ext\glslang\glslang\HLSL\hlslParseables.cpp">
       <Filter>hlsl</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\ext\glslang\hlsl\hlslScanContext.cpp">
+    <ClCompile Include="..\..\ext\glslang\glslang\HLSL\hlslScanContext.cpp">
       <Filter>hlsl</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\ext\glslang\hlsl\hlslTokenStream.cpp">
+    <ClCompile Include="..\..\ext\glslang\glslang\HLSL\hlslTokenStream.cpp">
       <Filter>hlsl</Filter>
     </ClCompile>
     <ClCompile Include="..\..\ext\glslang\glslang\OSDependent\Windows\ossource.cpp">
@@ -164,7 +167,7 @@
       <Filter>glslang\MachineIndependent</Filter>
     </ClCompile>
     <ClCompile Include="..\..\ext\glslang\SPIRV\SpvPostProcess.cpp" />
-    <ClCompile Include="..\..\ext\glslang\hlsl\hlslParseHelper.cpp">
+    <ClCompile Include="..\..\ext\glslang\glslang\HLSL\hlslParseHelper.cpp">
       <Filter>hlsl</Filter>
     </ClCompile>
   </ItemGroup>
@@ -270,6 +273,9 @@
     <ClInclude Include="..\..\ext\glslang\SPIRV\GLSL.ext.AMD.h">
       <Filter>SPIRV</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\ext\glslang\SPIRV\GLSL.ext.EXT.h">
+      <Filter>SPIRV</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\ext\glslang\SPIRV\GLSL.ext.KHR.h">
       <Filter>SPIRV</Filter>
     </ClInclude>
@@ -288,6 +294,9 @@
     <ClInclude Include="..\..\ext\glslang\SPIRV\Logger.h">
       <Filter>SPIRV</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\ext\glslang\SPIRV\NonSemanticDebugPrintf.h">
+      <Filter>SPIRV</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\ext\glslang\SPIRV\spirv.hpp">
       <Filter>SPIRV</Filter>
     </ClInclude>
@@ -300,25 +309,28 @@
     <ClInclude Include="..\..\ext\glslang\SPIRV\SPVRemapper.h">
       <Filter>SPIRV</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslAttributes.h">
+    <ClInclude Include="..\..\ext\glslang\SPIRV\SpvTools.h">
+      <Filter>SPIRV</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslAttributes.h">
       <Filter>hlsl</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslGrammar.h">
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslGrammar.h">
       <Filter>hlsl</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslOpMap.h">
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslOpMap.h">
       <Filter>hlsl</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslParseables.h">
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslParseables.h">
       <Filter>hlsl</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslScanContext.h">
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslScanContext.h">
       <Filter>hlsl</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslTokens.h">
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslTokens.h">
       <Filter>hlsl</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslTokenStream.h">
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslTokenStream.h">
       <Filter>hlsl</Filter>
     </ClInclude>
     <ClInclude Include="..\..\ext\glslang\OGLCompilersDLL\InitializeDll.h">
@@ -327,8 +339,17 @@
     <ClInclude Include="..\..\ext\glslang\glslang\MachineIndependent\attribute.h">
       <Filter>glslang\MachineIndependent</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\ext\glslang\hlsl\hlslParseHelper.h">
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\hlslParseHelper.h">
       <Filter>hlsl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\glslang\glslang\HLSL\pch.h">
+      <Filter>HLSL</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\glslang\glslang\MachineIndependent\pch.h">
+      <Filter>glslang</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\glslang\glslang\build_info.h">
+      <Filter>glslang</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/ext/glslang-build/Android.mk
+++ b/ext/glslang-build/Android.mk
@@ -37,13 +37,13 @@ LOCAL_SRC_FILES := \
     ../glslang/glslang/MachineIndependent/preprocessor/PpScanner.cpp \
     ../glslang/glslang/MachineIndependent/preprocessor/PpTokens.cpp \
     ../glslang/glslang/OSDependent/Unix/ossource.cpp \
-    ../glslang/hlsl/hlslAttributes.cpp \
-    ../glslang/hlsl/hlslGrammar.cpp \
-    ../glslang/hlsl/hlslOpMap.cpp \
-    ../glslang/hlsl/hlslParseables.cpp \
-    ../glslang/hlsl/hlslParseHelper.cpp \
-    ../glslang/hlsl/hlslScanContext.cpp \
-    ../glslang/hlsl/hlslTokenStream.cpp \
+    ../glslang/glslang/HLSL/hlslAttributes.cpp \
+    ../glslang/glslang/HLSL/hlslGrammar.cpp \
+    ../glslang/glslang/HLSL/hlslOpMap.cpp \
+    ../glslang/glslang/HLSL/hlslParseables.cpp \
+    ../glslang/glslang/HLSL/hlslParseHelper.cpp \
+    ../glslang/glslang/HLSL/hlslScanContext.cpp \
+    ../glslang/glslang/HLSL/hlslTokenStream.cpp \
     ../glslang/SPIRV/disassemble.cpp \
     ../glslang/SPIRV/doc.cpp \
     ../glslang/SPIRV/GlslangToSpv.cpp \
@@ -52,6 +52,7 @@ LOCAL_SRC_FILES := \
     ../glslang/SPIRV/SpvBuilder.cpp \
     ../glslang/SPIRV/SPVRemapper.cpp \
     ../glslang/SPIRV/SpvPostProcess.cpp \
+    ../glslang/SPIRV/SpvTools.cpp \
     ../glslang/OGLCompilersDLL/InitializeDll.cpp
 
 

--- a/ext/glslang.vcxproj
+++ b/ext/glslang.vcxproj
@@ -300,6 +300,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="glslang\SPIRV\SpvTools.cpp" />
     <ClCompile Include="glslang\glslang\GenericCodeGen\CodeGen.cpp" />
     <ClCompile Include="glslang\glslang\GenericCodeGen\Link.cpp" />
     <ClCompile Include="glslang\glslang\MachineIndependent\attribute.cpp" />
@@ -330,13 +331,13 @@
     <ClCompile Include="glslang\glslang\MachineIndependent\SymbolTable.cpp" />
     <ClCompile Include="glslang\glslang\MachineIndependent\Versions.cpp" />
     <ClCompile Include="glslang\glslang\OSDependent\Windows\ossource.cpp" />
-    <ClCompile Include="glslang\hlsl\hlslAttributes.cpp" />
-    <ClCompile Include="glslang\hlsl\hlslGrammar.cpp" />
-    <ClCompile Include="glslang\hlsl\hlslOpMap.cpp" />
-    <ClCompile Include="glslang\hlsl\hlslParseables.cpp" />
-    <ClCompile Include="glslang\hlsl\hlslParseHelper.cpp" />
-    <ClCompile Include="glslang\hlsl\hlslScanContext.cpp" />
-    <ClCompile Include="glslang\hlsl\hlslTokenStream.cpp" />
+    <ClCompile Include="glslang\glslang\HLSL\hlslAttributes.cpp" />
+    <ClCompile Include="glslang\glslang\HLSL\hlslGrammar.cpp" />
+    <ClCompile Include="glslang\glslang\HLSL\hlslOpMap.cpp" />
+    <ClCompile Include="glslang\glslang\HLSL\hlslParseables.cpp" />
+    <ClCompile Include="glslang\glslang\HLSL\hlslParseHelper.cpp" />
+    <ClCompile Include="glslang\glslang\HLSL\hlslScanContext.cpp" />
+    <ClCompile Include="glslang\glslang\HLSL\hlslTokenStream.cpp" />
     <ClCompile Include="glslang\OGLCompilersDLL\InitializeDll.cpp" />
     <ClCompile Include="glslang\SPIRV\disassemble.cpp" />
     <ClCompile Include="glslang\SPIRV\doc.cpp" />
@@ -348,6 +349,13 @@
     <ClCompile Include="glslang\SPIRV\SPVRemapper.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="glslang\glslang\build_info.h" />
+    <ClInclude Include="glslang\glslang\HLSL\pch.h" />
+    <ClInclude Include="glslang\glslang\MachineIndependent\pch.h" />
+    <ClInclude Include="glslang\SPIRV\GLSL.ext.EXT.h" />
+    <ClInclude Include="glslang\SPIRV\GLSL.ext.NV.h" />
+    <ClInclude Include="glslang\SPIRV\NonSemanticDebugPrintf.h" />
+    <ClInclude Include="glslang\SPIRV\SpvTools.h" />
     <ClInclude Include="glslang\glslang\Include\arrays.h" />
     <ClInclude Include="glslang\glslang\Include\BaseTypes.h" />
     <ClInclude Include="glslang\glslang\Include\Common.h" />
@@ -379,14 +387,14 @@
     <ClInclude Include="glslang\glslang\MachineIndependent\SymbolTable.h" />
     <ClInclude Include="glslang\glslang\MachineIndependent\Versions.h" />
     <ClInclude Include="glslang\glslang\Public\ShaderLang.h" />
-    <ClInclude Include="glslang\hlsl\hlslAttributes.h" />
-    <ClInclude Include="glslang\hlsl\hlslGrammar.h" />
-    <ClInclude Include="glslang\hlsl\hlslOpMap.h" />
-    <ClInclude Include="glslang\hlsl\hlslParseables.h" />
-    <ClInclude Include="glslang\hlsl\hlslParseHelper.h" />
-    <ClInclude Include="glslang\hlsl\hlslScanContext.h" />
-    <ClInclude Include="glslang\hlsl\hlslTokens.h" />
-    <ClInclude Include="glslang\hlsl\hlslTokenStream.h" />
+    <ClInclude Include="glslang\glslang\HLSL\hlslAttributes.h" />
+    <ClInclude Include="glslang\glslang\HLSL\hlslGrammar.h" />
+    <ClInclude Include="glslang\glslang\HLSL\hlslOpMap.h" />
+    <ClInclude Include="glslang\glslang\HLSL\hlslParseables.h" />
+    <ClInclude Include="glslang\glslang\HLSL\hlslParseHelper.h" />
+    <ClInclude Include="glslang\glslang\HLSL\hlslScanContext.h" />
+    <ClInclude Include="glslang\glslang\HLSL\hlslTokens.h" />
+    <ClInclude Include="glslang\glslang\HLSL\hlslTokenStream.h" />
     <ClInclude Include="glslang\OGLCompilersDLL\InitializeDll.h" />
     <ClInclude Include="glslang\SPIRV\bitutils.h" />
     <ClInclude Include="glslang\SPIRV\disassemble.h" />

--- a/ext/glslang.vcxproj.filters
+++ b/ext/glslang.vcxproj.filters
@@ -119,32 +119,35 @@
     <ClCompile Include="glslang\SPIRV\Logger.cpp">
       <Filter>SPIRV</Filter>
     </ClCompile>
-    <ClCompile Include="glslang\hlsl\hlslAttributes.cpp">
-      <Filter>HLSL</Filter>
-    </ClCompile>
-    <ClCompile Include="glslang\hlsl\hlslGrammar.cpp">
-      <Filter>HLSL</Filter>
-    </ClCompile>
-    <ClCompile Include="glslang\hlsl\hlslOpMap.cpp">
-      <Filter>HLSL</Filter>
-    </ClCompile>
-    <ClCompile Include="glslang\hlsl\hlslParseables.cpp">
-      <Filter>HLSL</Filter>
-    </ClCompile>
-    <ClCompile Include="glslang\hlsl\hlslScanContext.cpp">
-      <Filter>HLSL</Filter>
-    </ClCompile>
-    <ClCompile Include="glslang\hlsl\hlslTokenStream.cpp">
-      <Filter>HLSL</Filter>
-    </ClCompile>
     <ClCompile Include="glslang\glslang\MachineIndependent\attribute.cpp">
       <Filter>glslang</Filter>
     </ClCompile>
     <ClCompile Include="glslang\SPIRV\SpvPostProcess.cpp">
       <Filter>SPIRV</Filter>
     </ClCompile>
-    <ClCompile Include="glslang\hlsl\hlslParseHelper.cpp">
+    <ClCompile Include="glslang\glslang\HLSL\hlslAttributes.cpp">
       <Filter>HLSL</Filter>
+    </ClCompile>
+    <ClCompile Include="glslang\glslang\HLSL\hlslGrammar.cpp">
+      <Filter>HLSL</Filter>
+    </ClCompile>
+    <ClCompile Include="glslang\glslang\HLSL\hlslOpMap.cpp">
+      <Filter>HLSL</Filter>
+    </ClCompile>
+    <ClCompile Include="glslang\glslang\HLSL\hlslParseables.cpp">
+      <Filter>HLSL</Filter>
+    </ClCompile>
+    <ClCompile Include="glslang\glslang\HLSL\hlslParseHelper.cpp">
+      <Filter>HLSL</Filter>
+    </ClCompile>
+    <ClCompile Include="glslang\glslang\HLSL\hlslScanContext.cpp">
+      <Filter>HLSL</Filter>
+    </ClCompile>
+    <ClCompile Include="glslang\glslang\HLSL\hlslTokenStream.cpp">
+      <Filter>HLSL</Filter>
+    </ClCompile>
+    <ClCompile Include="glslang\SPIRV\SpvTools.cpp">
+      <Filter>SPIRV</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -278,32 +281,53 @@
     <ClInclude Include="glslang\SPIRV\Logger.h">
       <Filter>SPIRV</Filter>
     </ClInclude>
-    <ClInclude Include="glslang\hlsl\hlslAttributes.h">
-      <Filter>HLSL</Filter>
-    </ClInclude>
-    <ClInclude Include="glslang\hlsl\hlslGrammar.h">
-      <Filter>HLSL</Filter>
-    </ClInclude>
-    <ClInclude Include="glslang\hlsl\hlslOpMap.h">
-      <Filter>HLSL</Filter>
-    </ClInclude>
-    <ClInclude Include="glslang\hlsl\hlslParseables.h">
-      <Filter>HLSL</Filter>
-    </ClInclude>
-    <ClInclude Include="glslang\hlsl\hlslScanContext.h">
-      <Filter>HLSL</Filter>
-    </ClInclude>
-    <ClInclude Include="glslang\hlsl\hlslTokens.h">
-      <Filter>HLSL</Filter>
-    </ClInclude>
-    <ClInclude Include="glslang\hlsl\hlslTokenStream.h">
-      <Filter>HLSL</Filter>
-    </ClInclude>
     <ClInclude Include="glslang\glslang\MachineIndependent\attribute.h">
       <Filter>glslang</Filter>
     </ClInclude>
-    <ClInclude Include="glslang\hlsl\hlslParseHelper.h">
+    <ClInclude Include="glslang\glslang\HLSL\hlslAttributes.h">
       <Filter>HLSL</Filter>
+    </ClInclude>
+    <ClInclude Include="glslang\glslang\HLSL\hlslGrammar.h">
+      <Filter>HLSL</Filter>
+    </ClInclude>
+    <ClInclude Include="glslang\glslang\HLSL\hlslOpMap.h">
+      <Filter>HLSL</Filter>
+    </ClInclude>
+    <ClInclude Include="glslang\glslang\HLSL\hlslParseables.h">
+      <Filter>HLSL</Filter>
+    </ClInclude>
+    <ClInclude Include="glslang\glslang\HLSL\hlslParseHelper.h">
+      <Filter>HLSL</Filter>
+    </ClInclude>
+    <ClInclude Include="glslang\glslang\HLSL\hlslScanContext.h">
+      <Filter>HLSL</Filter>
+    </ClInclude>
+    <ClInclude Include="glslang\glslang\HLSL\hlslTokens.h">
+      <Filter>HLSL</Filter>
+    </ClInclude>
+    <ClInclude Include="glslang\glslang\HLSL\hlslTokenStream.h">
+      <Filter>HLSL</Filter>
+    </ClInclude>
+    <ClInclude Include="glslang\SPIRV\SpvTools.h">
+      <Filter>SPIRV</Filter>
+    </ClInclude>
+    <ClInclude Include="glslang\SPIRV\GLSL.ext.EXT.h">
+      <Filter>SPIRV</Filter>
+    </ClInclude>
+    <ClInclude Include="glslang\SPIRV\GLSL.ext.NV.h">
+      <Filter>SPIRV</Filter>
+    </ClInclude>
+    <ClInclude Include="glslang\SPIRV\NonSemanticDebugPrintf.h">
+      <Filter>SPIRV</Filter>
+    </ClInclude>
+    <ClInclude Include="glslang\glslang\HLSL\pch.h">
+      <Filter>HLSL</Filter>
+    </ClInclude>
+    <ClInclude Include="glslang\glslang\MachineIndependent\pch.h">
+      <Filter>glslang</Filter>
+    </ClInclude>
+    <ClInclude Include="glslang\glslang\build_info.h">
+      <Filter>glslang</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Should fix #14014.  Additionally includes many glslang fixes, including some precison handling, a mingw fix, and a few extensions.

-[Unknown]