### PR TITLE
 SaveState: Start new events at end properly

### DIFF
--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -689,7 +689,7 @@ void DoState(PointerWrap &p) {
 		event_types[i].callback = AntiCrashCallback;
 		event_types[i].name = "INVALID EVENT";
 	}
-	nextEventTypeRestoreId = n;
+	nextEventTypeRestoreId = n - 1;
 
 	if (s >= 3) {
 		DoLinkedList<BaseEvent, GetNewEvent, FreeEvent, Event_DoState>(p, first, (Event **) NULL);

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -93,4 +93,7 @@ namespace SaveState
 
 	// Check if there's any save stating needing to be done.  Normally called once per frame.
 	void Process();
+
+	// Cleanup by triggering a restart if needed.
+	void Cleanup();
 };

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -525,6 +525,7 @@ void PSP_EndHostFrame() {
 	if (gpu) {
 		gpu->EndHostFrame();
 	}
+	SaveState::Cleanup();
 }
 
 void PSP_RunLoopWhileState() {


### PR DESCRIPTION
Dumb off by one mistake, forgot to subtract 1 from the size.  Fixes #14194.

Also should fix a crash we saw reported from broken save state loading - we'd restart mid-frame, causing an unmatched Unmap() assert.

-[Unknown]