### PR TITLE
Mpeg: Set low latency flag for video decode

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -805,6 +805,8 @@ static bool InitPmp(MpegContext * ctx){
 		return false;
 	}
 
+	pmp_CodecCtx->flags |= AV_CODEC_FLAG_OUTPUT_CORRUPT | AV_CODEC_FLAG_LOW_DELAY;
+
 	// each pmp video context is corresponding to one pmp video codec
 	mediaengine->m_pCodecCtxs[0] = pmp_CodecCtx;
 

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -542,6 +542,8 @@ bool MediaEngine::setVideoStream(int streamNum, bool force) {
 		}
 #endif
 
+		m_pCodecCtx->flags |= AV_CODEC_FLAG_OUTPUT_CORRUPT | AV_CODEC_FLAG_LOW_DELAY;
+
 		AVDictionary *opt = nullptr;
 		// Allow ffmpeg to use any number of threads it wants.  Without this, it doesn't use threads.
 		av_dict_set(&opt, "threads", "0", 0);


### PR DESCRIPTION
This helps the videos in the latest comments from #11490.  Added the flag for all versions, but mainly improves newer FFmpeg.

-[Unknown]