### PR TITLE
Add iOS version detection, turn off JIT on bootup if >= 14.3.

### DIFF
--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -98,6 +98,8 @@ enum SystemProperty {
 
 	SYSPROP_SUPPORTS_PERMISSIONS,
 	SYSPROP_SUPPORTS_SUSTAINED_PERF_MODE,
+
+	SYSPROP_CAN_JIT,
 };
 
 std::string System_GetProperty(SystemProperty prop);

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -225,6 +225,8 @@ bool System_GetPropertyBool(SystemProperty prop) {
 #else
 		return false;
 #endif
+	case SYSPROP_CAN_JIT:
+		return true;
 	default:
 		return false;
 	}

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -387,6 +387,8 @@ bool System_GetPropertyBool(SystemProperty prop) {
 #else
 		return false;
 #endif
+	case SYSPROP_CAN_JIT:
+		return true;
 	default:
 		return false;
 	}

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -473,6 +473,8 @@ void SystemInfoScreen::CreateViews() {
 	std::string cores = StringFromFormat(si->T("%d (%d per core, %d cores)"), totalThreads, cpu_info.logical_cpu_count, cpu_info.num_cores);
 	deviceSpecs->Add(new InfoItem(si->T("Threads"), cores));
 #endif
+	deviceSpecs->Add(new InfoItem(si->T("JIT available"), System_GetPropertyBool(SYSPROP_CAN_JIT) ? di->T("Yes") : di->T("No")));
+
 	deviceSpecs->Add(new ItemHeader(si->T("GPU Information")));
 
 	DrawContext *draw = screenManager()->getDrawContext();

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -473,8 +473,9 @@ void SystemInfoScreen::CreateViews() {
 	std::string cores = StringFromFormat(si->T("%d (%d per core, %d cores)"), totalThreads, cpu_info.logical_cpu_count, cpu_info.num_cores);
 	deviceSpecs->Add(new InfoItem(si->T("Threads"), cores));
 #endif
+#if PPSSPP_PLATFORM(IOS)
 	deviceSpecs->Add(new InfoItem(si->T("JIT available"), System_GetPropertyBool(SYSPROP_CAN_JIT) ? di->T("Yes") : di->T("No")));
-
+#endif
 	deviceSpecs->Add(new ItemHeader(si->T("GPU Information")));
 
 	DrawContext *draw = screenManager()->getDrawContext();

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -694,6 +694,12 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 		}
 	}
 
+	if (System_GetPropertyBool(SYSPROP_CAN_JIT) == false && g_Config.iCpuCore == (int)CPUCore::JIT) {
+		// Just gonna force it to the IR interpreter on startup.
+		// We don't hide the option, but we make sure it's off on bootup. In case someone wants
+		// to experiment in future iOS versions or something...
+		g_Config.iCpuCore = (int)CPUCore::IR_JIT;
+	}
 
 	auto des = GetI18NCategory("DesktopUI");
 	// Note to translators: do not translate this/add this to PPSSPP-lang's files.

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -439,6 +439,8 @@ bool System_GetPropertyBool(SystemProperty prop) {
 #else
 		return false;
 #endif
+	case SYSPROP_CAN_JIT:
+		return true;
 	default:
 		return false;
 	}

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -310,6 +310,8 @@ bool System_GetPropertyBool(SystemProperty prop) {
 #else
 		return false;
 #endif
+	case SYSPROP_CAN_JIT:
+		return true;
 	default:
 		return false;
 	}

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -443,6 +443,8 @@ bool System_GetPropertyBool(SystemProperty prop) {
 #else
 		return false;
 #endif
+	case SYSPROP_CAN_JIT:
+		return true;
 	default:
 		return false;
 	}

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -89,7 +89,14 @@ std::string System_GetProperty(SystemProperty prop) { return ""; }
 std::vector<std::string> System_GetPropertyStringVec(SystemProperty prop) { return std::vector<std::string>(); }
 int System_GetPropertyInt(SystemProperty prop) { return -1; }
 float System_GetPropertyFloat(SystemProperty prop) { return -1.0f; }
-bool System_GetPropertyBool(SystemProperty prop) { return false; }
+bool System_GetPropertyBool(SystemProperty prop) { 
+	switch (prop) {
+		case SYSPROP_CAN_JIT:
+			return true;
+		default:
+			return false;
+	}
+}
 
 void System_SendMessage(const char *command, const char *parameter) {}
 void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb) { cb(false, ""); }

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -69,6 +69,10 @@ float System_GetPropertyFloat(SystemProperty prop) {
 	return -1;
 }
 bool System_GetPropertyBool(SystemProperty prop) {
+	switch (prop) {
+	case SYSPROP_CAN_JIT:
+		return true;
+	}
 	return false;
 }
 


### PR DESCRIPTION
I'm a bit undecided on exactly what we should do.

"Fixes" #14196

Options seem to be:

* Entirely hide JIT if iOS version >= 14.3 (and debugger is not attached)
* Default it to off, but let the user turn it on persistently. Which will persistently crash if no debugger attached.
* Force off on startup if iOS version >= 14.3 and no debugger attached.

In the two second options, the user can still attempt to turn it on in case Apple makes a boo-boo and accidentally allows it again.

This implements the building blocks, and option 3 above.

Hm.