### PR TITLE
(libretro) Fix static makefile

### DIFF
--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -362,6 +362,7 @@ SOURCES_CXX += \
 	       $(COREDIR)/Instance.cpp \
 	       $(COREDIR)/Debugger/Breakpoints.cpp \
 	       $(COREDIR)/Debugger/SymbolMap.cpp \
+	       $(COREDIR)/Debugger/MemBlockInfo.cpp \
 	       $(COREDIR)/Dialog/PSPDialog.cpp \
 	       $(COREDIR)/Dialog/PSPGamedataInstallDialog.cpp \
 	       $(COREDIR)/Dialog/PSPMsgDialog.cpp \


### PR DESCRIPTION
This trivial PR fixes the libretro static makefile by adding the new `Core/Debugger/MemBlockInfo.cpp` file to `libretro/Makefile.common`. This is required for Windows builds on the new libretro build infrastructure.