### PR TITLE
Mpeg: Correct stream buffer wrapping, cleanup

### DIFF
--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -515,7 +515,6 @@ bool MediaEngine::setVideoStream(int streamNum, bool force) {
 		}
 
 		AVStream *stream = m_pFormatCtx->streams[streamNum];
-		int err;
 #if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 33, 100)
 		AVCodec *pCodec = avcodec_find_decoder(stream->codecpar->codec_id);
 		if (!pCodec) {
@@ -523,9 +522,9 @@ bool MediaEngine::setVideoStream(int streamNum, bool force) {
 			return false;
 		}
 		AVCodecContext *m_pCodecCtx = avcodec_alloc_context3(pCodec);
-		err = avcodec_parameters_to_context(m_pCodecCtx, stream->codecpar);
-		if (err < 0) {
-			WARN_LOG_REPORT(ME, "Failed to prepare context parameters: %08x", err);
+		int paramResult = avcodec_parameters_to_context(m_pCodecCtx, stream->codecpar);
+		if (paramResult < 0) {
+			WARN_LOG_REPORT(ME, "Failed to prepare context parameters: %08x", paramResult);
 			return false;
 		}
 #else


### PR DESCRIPTION
See #12539.  Based on the call stack, my best guess is that `start` or `end` became equal to `bufQueueSize` or else `memcpy` misbehaved on a zero sized pointer.

This cleans up the handling a bit so we always reset start/end to 0 if they get to the `bufQueueSize`.

-[Unknown]