### PR TITLE
SaveState: Fix Snappy build error on older clang

### DIFF
--- a/ext/snappy/snappy.cpp
+++ b/ext/snappy/snappy.cpp
@@ -1026,7 +1026,7 @@ size_t AdvanceToNextTag(const uint8_t** ip_p, size_t* tag) {
   size_t literal_len = *tag >> 2;
   size_t tag_type = *tag;
   bool is_literal;
-#if defined(__GNUC__) && defined(__x86_64__)
+#if defined(__GNUC__) && defined(__x86_64__) && defined(__GCC_ASM_FLAG_OUTPUTS__)
   // TODO clang misses the fact that the (c & 3) already correctly
   // sets the zero flag.
   asm("and $3, %k[tag_type]\n\t"


### PR DESCRIPTION
AFAICT, clang added ccz support sometime a while back and defined `__GCC_ASM_FLAG_OUTPUTS__` to indicate support.  Really an upstream bug I suppose.

-[Unknown]