### PR TITLE
Unlock Volatile Memory when in dialog Shutdown

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -66,6 +66,13 @@ PSPDialog::DialogStatus PSPDialog::GetStatus() {
 		if (status == SCE_UTILITY_STATUS_INITIALIZE)
 			status = SCE_UTILITY_STATUS_RUNNING;
 	}
+	if (status == SCE_UTILITY_STATUS_SHUTDOWN) {
+		if (volatileLocked_) {
+			FinishVolatile();
+			UtilityCancelVolatileUnlock();
+			volatileLocked_ = false;
+		}
+	}
 	return retval;
 }
 


### PR DESCRIPTION
Fix #14216
Original  v1.11.2-226-g35ad3106f-windows-amd64 log
https://gist.github.com/sum2012/51d0f4c849930975254f3adb5b4b151c