### PR TITLE
Dialog: Respect accessThread priority on shutdown

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -31,7 +31,7 @@
 #define FADE_TIME 1.0
 const float FONT_SCALE = 0.55f;
 
-PSPDialog::PSPDialog() {
+PSPDialog::PSPDialog(int type) : dialogType_(type) {
 }
 
 PSPDialog::~PSPDialog() {

--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -41,15 +41,10 @@ PSPDialog::DialogStatus PSPDialog::GetStatus() {
 	if (pendingStatusTicks != 0 && CoreTiming::GetTicks() >= pendingStatusTicks) {
 		bool changeAllowed = true;
 		if (pendingStatus == SCE_UTILITY_STATUS_NONE && status == SCE_UTILITY_STATUS_SHUTDOWN) {
-			if (volatileLocked_) {
-				FinishVolatile();
-				UtilityCancelVolatileUnlock();
-				volatileLocked_ = false;
-			}
+			FinishVolatile();
 		} else if (pendingStatus == SCE_UTILITY_STATUS_RUNNING && status == SCE_UTILITY_STATUS_INITIALIZE) {
 			if (!volatileLocked_) {
 				volatileLocked_ = KernelVolatileMemLock(0, 0, 0) == 0;
-				UtilityCancelVolatileUnlock();
 				changeAllowed = volatileLocked_;
 			}
 		}
@@ -72,16 +67,11 @@ PSPDialog::DialogStatus PSPDialog::GetStatus() {
 void PSPDialog::ChangeStatus(DialogStatus newStatus, int delayUs) {
 	if (delayUs <= 0) {
 		if (newStatus == SCE_UTILITY_STATUS_NONE && status == SCE_UTILITY_STATUS_SHUTDOWN) {
-			if (volatileLocked_) {
-				FinishVolatile();
-				UtilityCancelVolatileUnlock();
-				volatileLocked_ = false;
-			}
+			FinishVolatile();
 		} else if (newStatus == SCE_UTILITY_STATUS_RUNNING && status == SCE_UTILITY_STATUS_INITIALIZE) {
 			if (!volatileLocked_) {
 				// TODO: Should probably make the status pending instead?
 				volatileLocked_ = KernelVolatileMemLock(0, 0, 0) == 0;
-				UtilityCancelVolatileUnlock();
 			}
 		}
 		status = newStatus;
@@ -89,18 +79,25 @@ void PSPDialog::ChangeStatus(DialogStatus newStatus, int delayUs) {
 	} else {
 		pendingStatus = newStatus;
 		pendingStatusTicks = CoreTiming::GetTicks() + usToCycles(delayUs);
-		if (volatileLocked_ && newStatus == SCE_UTILITY_STATUS_NONE && status == SCE_UTILITY_STATUS_SHUTDOWN) {
-			UtilityScheduleVolatileUnlock(usToCycles(delayUs));
-		}
 	}
 }
 
 void PSPDialog::FinishVolatile() {
-	if (volatileLocked_ && KernelVolatileMemUnlock(0) == 0) {
+	if (!volatileLocked_)
+		return;
+
+	if (KernelVolatileMemUnlock(0) == 0) {
 		volatileLocked_ = false;
 		// Simulate modifications to volatile memory.
 		Memory::Memset(PSP_GetVolatileMemoryStart(), 0, PSP_GetVolatileMemoryEnd() - PSP_GetVolatileMemoryStart());
 	}
+}
+
+int PSPDialog::FinishShutdown() {
+	if (ReadStatus() != SCE_UTILITY_STATUS_SHUTDOWN)
+		return -1;
+	ChangeStatus(SCE_UTILITY_STATUS_NONE, 0);
+	return 0;
 }
 
 void PSPDialog::ChangeStatusInit(int delayUs) {
@@ -110,7 +107,11 @@ void PSPDialog::ChangeStatusInit(int delayUs) {
 
 void PSPDialog::ChangeStatusShutdown(int delayUs) {
 	status = SCE_UTILITY_STATUS_SHUTDOWN;
-	ChangeStatus(SCE_UTILITY_STATUS_NONE, delayUs);
+	auto params = GetCommonParam();
+	if (params)
+		UtilityDialogShutdown(DialogType(), delayUs, params->accessThread);
+	else
+		ChangeStatus(SCE_UTILITY_STATUS_NONE, delayUs);
 }
 
 void PSPDialog::StartDraw()

--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -96,7 +96,7 @@ void PSPDialog::ChangeStatus(DialogStatus newStatus, int delayUs) {
 }
 
 void PSPDialog::FinishVolatile() {
-	if (KernelVolatileMemUnlock(0) == 0) {
+	if (volatileLocked_ && KernelVolatileMemUnlock(0) == 0) {
 		volatileLocked_ = false;
 		// Simulate modifications to volatile memory.
 		Memory::Memset(PSP_GetVolatileMemoryStart(), 0, PSP_GetVolatileMemoryEnd() - PSP_GetVolatileMemoryStart());

--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -53,7 +53,7 @@ struct pspUtilityDialogCommon
 class PSPDialog
 {
 public:
-	PSPDialog();
+	PSPDialog(int type);
 	virtual ~PSPDialog();
 
 	virtual int Update(int animSpeed) = 0;
@@ -80,6 +80,7 @@ public:
 	};
 
 	DialogStatus GetStatus();
+	int DialogType() { return dialogType_; }
 
 	void StartDraw();
 	void EndDraw();
@@ -127,5 +128,6 @@ protected:
 
 private:
 	DialogStatus status = SCE_UTILITY_STATUS_NONE;
+	int dialogType_;
 	bool volatileLocked_ = false;
 };

--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -86,6 +86,7 @@ public:
 	void EndDraw();
 
 	void FinishVolatile();
+	int FinishShutdown();
 
 protected:
 	PPGeStyle FadedStyle(PPGeAlign align, float scale);

--- a/Core/Dialog/PSPGamedataInstallDialog.cpp
+++ b/Core/Dialog/PSPGamedataInstallDialog.cpp
@@ -55,7 +55,7 @@ namespace
 	}
 }
 
-PSPGamedataInstallDialog::PSPGamedataInstallDialog() {
+PSPGamedataInstallDialog::PSPGamedataInstallDialog(int type) : PSPDialog(type) {
 }
 
 PSPGamedataInstallDialog::~PSPGamedataInstallDialog() {

--- a/Core/Dialog/PSPGamedataInstallDialog.h
+++ b/Core/Dialog/PSPGamedataInstallDialog.h
@@ -35,7 +35,7 @@ struct SceUtilityGamedataInstallParam {
 
 class PSPGamedataInstallDialog: public PSPDialog {
 public:
-	PSPGamedataInstallDialog();
+	PSPGamedataInstallDialog(int type);
 	virtual ~PSPGamedataInstallDialog();
 
 	virtual int Init(u32 paramAddr);

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -35,10 +35,7 @@ static const float FONT_SCALE = 0.65f;
 const static int MSG_INIT_DELAY_US = 300000;
 const static int MSG_SHUTDOWN_DELAY_US = 26000;
 
-PSPMsgDialog::PSPMsgDialog()
-	: PSPDialog()
-	, flag(0)
-{
+PSPMsgDialog::PSPMsgDialog(int type) : PSPDialog(type) {
 }
 
 PSPMsgDialog::~PSPMsgDialog() {

--- a/Core/Dialog/PSPMsgDialog.h
+++ b/Core/Dialog/PSPMsgDialog.h
@@ -58,7 +58,7 @@ struct pspMessageDialog
 
 class PSPMsgDialog: public PSPDialog {
 public:
-	PSPMsgDialog();
+	PSPMsgDialog(int type);
 	virtual ~PSPMsgDialog();
 
 	virtual int Init(unsigned int paramAddr);
@@ -92,7 +92,7 @@ private:
 		DS_ABORT        = 0x200,
 	};
 
-	u32 flag;
+	u32 flag = 0;
 
 	pspMessageDialog messageDialog;
 	int messageDialogAddr;

--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -54,7 +54,7 @@ struct ScanInfos {
 } PACK;
 
 
-PSPNetconfDialog::PSPNetconfDialog() {
+PSPNetconfDialog::PSPNetconfDialog(int type) : PSPDialog(type) {
 }
 
 PSPNetconfDialog::~PSPNetconfDialog() {

--- a/Core/Dialog/PSPNetconfDialog.h
+++ b/Core/Dialog/PSPNetconfDialog.h
@@ -37,7 +37,7 @@ struct SceUtilityNetconfParam {
 
 class PSPNetconfDialog: public PSPDialog {
 public:
-	PSPNetconfDialog();
+	PSPNetconfDialog(int type);
 	virtual ~PSPNetconfDialog();
 
 	virtual int Init(u32 paramAddr);

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -156,7 +156,7 @@ int allowedInputFlagsMap[OSK_KEYBOARD_COUNT] = {
 	PSP_UTILITY_OSK_INPUTTYPE_JAPANESE_UPPERCASE | PSP_UTILITY_OSK_INPUTTYPE_JAPANESE_SYMBOL,
 };
 
-PSPOskDialog::PSPOskDialog() : PSPDialog() {
+PSPOskDialog::PSPOskDialog(int type) : PSPDialog(type) {
 	// This can break all kinds of stuff, changing the decimal point in sprintf for example.
 	// Not sure what the intended effect is so commented out for now.
 	// setlocale(LC_ALL, "");

--- a/Core/Dialog/PSPOskDialog.h
+++ b/Core/Dialog/PSPOskDialog.h
@@ -213,7 +213,7 @@ enum class PSPOskNativeStatus {
 
 class PSPOskDialog: public PSPDialog {
 public:
-	PSPOskDialog();
+	PSPOskDialog(int type);
 	virtual ~PSPOskDialog();
 
 	virtual int Init(u32 oskPtr);

--- a/Core/Dialog/PSPPlaceholderDialog.cpp
+++ b/Core/Dialog/PSPPlaceholderDialog.cpp
@@ -17,7 +17,7 @@
 
 #include "PSPPlaceholderDialog.h"
 
-PSPPlaceholderDialog::PSPPlaceholderDialog() : PSPDialog() {
+PSPPlaceholderDialog::PSPPlaceholderDialog(int type) : PSPDialog(type) {
 
 }
 

--- a/Core/Dialog/PSPPlaceholderDialog.h
+++ b/Core/Dialog/PSPPlaceholderDialog.h
@@ -21,7 +21,7 @@
 
 class PSPPlaceholderDialog: public PSPDialog {
 public:
-	PSPPlaceholderDialog();
+	PSPPlaceholderDialog(int type);
 	virtual ~PSPPlaceholderDialog();
 
 	virtual int Init();

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -56,12 +56,7 @@ const static int SAVEDATA_DIALOG_SIZE_V2 = 1500;
 const static int SAVEDATA_DIALOG_SIZE_V3 = 1536;
 
 
-PSPSaveDialog::PSPSaveDialog()
-	: PSPDialog()
-	, display(DS_NONE)
-	, currentSelectedSave(0)
-	, ioThread(0)
-{
+PSPSaveDialog::PSPSaveDialog(int type) : PSPDialog(type) {
 	param.SetPspParam(0);
 }
 

--- a/Core/Dialog/PSPSaveDialog.h
+++ b/Core/Dialog/PSPSaveDialog.h
@@ -71,7 +71,7 @@
 
 class PSPSaveDialog: public PSPDialog {
 public:
-	PSPSaveDialog();
+	PSPSaveDialog(int type);
 	virtual ~PSPSaveDialog();
 
 	virtual int Init(int paramAddr);
@@ -136,14 +136,14 @@ private:
 		DB_DELETE
 	};
 
-	DisplayState display;
+	DisplayState display = DS_NONE;
 
 	SavedataParam param;
 	SceUtilitySavedataParam request;
 	// For detecting changes made by the game.
 	SceUtilitySavedataParam originalRequest;
-	u32 requestAddr;
-	int currentSelectedSave;
+	u32 requestAddr = 0;
+	int currentSelectedSave = 0;
 
 	int yesnoChoice;
 
@@ -154,7 +154,7 @@ private:
 		SAVEIO_DONE,
 	};
 
-	std::thread *ioThread;
+	std::thread *ioThread = nullptr;
 	std::mutex paramLock;
 	volatile SaveIOStatus ioThreadStatus;
 };

--- a/Core/Dialog/PSPScreenshotDialog.cpp
+++ b/Core/Dialog/PSPScreenshotDialog.cpp
@@ -128,3 +128,9 @@ void PSPScreenshotDialog::DoState(PointerWrap &p) {
 		Do(p, params_);
 	}
 }
+
+pspUtilityDialogCommon *PSPScreenshotDialog::GetCommonParam() {
+	if (params_.IsValid())
+		return &params_->base;
+	return nullptr;
+}

--- a/Core/Dialog/PSPScreenshotDialog.cpp
+++ b/Core/Dialog/PSPScreenshotDialog.cpp
@@ -52,8 +52,7 @@ struct SceUtilityScreenshotParams {
 	// TODO
 };
 
-PSPScreenshotDialog::PSPScreenshotDialog() : PSPDialog() {
-
+PSPScreenshotDialog::PSPScreenshotDialog(int type) : PSPDialog(type) {
 }
 
 PSPScreenshotDialog::~PSPScreenshotDialog() {

--- a/Core/Dialog/PSPScreenshotDialog.h
+++ b/Core/Dialog/PSPScreenshotDialog.h
@@ -24,7 +24,7 @@ struct SceUtilityScreenshotParams;
 
 class PSPScreenshotDialog : public PSPDialog {
 public:
-	PSPScreenshotDialog();
+	PSPScreenshotDialog(int type);
 	virtual ~PSPScreenshotDialog();
 
 	virtual int Init(u32 paramAddr);

--- a/Core/Dialog/PSPScreenshotDialog.h
+++ b/Core/Dialog/PSPScreenshotDialog.h
@@ -31,6 +31,7 @@ public:
 	virtual int Update(int animSpeed) override;
 	virtual int ContStart();
 	virtual void DoState(PointerWrap &p) override;
+	virtual pspUtilityDialogCommon *GetCommonParam() override;
 
 protected:
 	// TODO: Manage status correctly.

--- a/Core/HLE/HLEHelperThread.cpp
+++ b/Core/HLE/HLEHelperThread.cpp
@@ -29,7 +29,7 @@
 HLEHelperThread::HLEHelperThread() : id_(-1), entry_(0) {
 }
 
-HLEHelperThread::HLEHelperThread(const char *threadName, u32 instructions[], u32 instrCount, u32 prio, int stacksize) {
+HLEHelperThread::HLEHelperThread(const char *threadName, const u32 instructions[], u32 instrCount, u32 prio, int stacksize) {
 	u32 instrBytes = instrCount * sizeof(u32);
 	u32 totalBytes = instrBytes + sizeof(u32) * 2;
 	AllocEntry(totalBytes);

--- a/Core/HLE/HLEHelperThread.h
+++ b/Core/HLE/HLEHelperThread.h
@@ -25,7 +25,7 @@ class HLEHelperThread {
 public:
 	// For savestates.
 	HLEHelperThread();
-	HLEHelperThread(const char *threadName, u32 instructions[], u32 instrCount, u32 prio, int stacksize);
+	HLEHelperThread(const char *threadName, const u32 instructions[], u32 instrCount, u32 prio, int stacksize);
 	HLEHelperThread(const char *threadName, const char *module, const char *func, u32 prio, int stacksize);
 	~HLEHelperThread();
 	void DoState(PointerWrap &p);

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -145,9 +145,6 @@ static int volatileUnlockEvent = -1;
 
 static void ActivateDialog(UtilityDialogType type) {
 	if (!currentDialogActive) {
-		// TODO: Lock volatile RAM (see https://github.com/hrydgard/ppsspp/issues/8288)
-		// We don't have a virtual dialog thread unlike JPSCP. Not sure if it's OK to
-		// just do it on the current thread - it does seem dangerous to assume so...
 		currentDialogType = type;
 		currentDialogActive = true;
 	}
@@ -155,7 +152,6 @@ static void ActivateDialog(UtilityDialogType type) {
 
 static void DeactivateDialog() {
 	if (currentDialogActive) {
-		// TODO: Unlock and zero volatile RAM.
 		currentDialogActive = false;
 	}
 }
@@ -249,19 +245,14 @@ static int sceUtilitySavedataInitStart(u32 paramAddr)
 	return ret;
 }
 
-static int sceUtilitySavedataShutdownStart()
-{
+static int sceUtilitySavedataShutdownStart() {
 	if (currentDialogType != UTILITY_DIALOG_SAVEDATA)
-	{
-		WARN_LOG(SCEUTILITY, "sceUtilitySavedataShutdownStart(): wrong dialog type");
-		return SCE_ERROR_UTILITY_WRONG_TYPE;
-	}
+		return hleLogWarning(SCEUTILITY, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 
 	DeactivateDialog();
-	DeactivateDialog();
 	int ret = saveDialog.Shutdown();
-	DEBUG_LOG(SCEUTILITY,"%08x=sceUtilitySavedataShutdownStart()",ret);
-	return ret;
+	hleEatCycles(90000);
+	return hleLogSuccessX(SCEUTILITY, ret);
 }
 
 static int sceUtilitySavedataGetStatus()

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -132,12 +132,12 @@ enum UtilityDialogType {
 // Only a single dialog is allowed at a time.
 static UtilityDialogType currentDialogType;
 bool currentDialogActive;
-static PSPSaveDialog saveDialog;
-static PSPMsgDialog msgDialog;
-static PSPOskDialog oskDialog;
-static PSPNetconfDialog netDialog;
-static PSPScreenshotDialog screenshotDialog;
-static PSPGamedataInstallDialog gamedataInstallDialog;
+static PSPSaveDialog saveDialog(UTILITY_DIALOG_SAVEDATA);
+static PSPMsgDialog msgDialog(UTILITY_DIALOG_MSG);
+static PSPOskDialog oskDialog(UTILITY_DIALOG_OSK);
+static PSPNetconfDialog netDialog(UTILITY_DIALOG_NET);
+static PSPScreenshotDialog screenshotDialog(UTILITY_DIALOG_SCREENSHOT);
+static PSPGamedataInstallDialog gamedataInstallDialog(UTILITY_DIALOG_GAMEDATAINSTALL);
 
 static int oldStatus = 100; //random value
 static std::map<int, u32> currentlyLoadedModules;

--- a/Core/HLE/sceUtility.h
+++ b/Core/HLE/sceUtility.h
@@ -83,7 +83,6 @@ void __UtilityInit();
 void __UtilityDoState(PointerWrap &p);
 void __UtilityShutdown();
 
-void UtilityScheduleVolatileUnlock(s64 cyclesIntoFuture);
-void UtilityCancelVolatileUnlock();
+void UtilityDialogShutdown(int type, int delayUs, int priority);
 
 void Register_sceUtility();


### PR DESCRIPTION
Fixes #14216, at least the one I have.  Closes #14226.  This uses a HLE thread to process the shutdown.

Behavior isn't exactly like real firmware because I'm only simulating one thread, and if the graphicsThread isn't worse priority it could slow things down.  But I've never seen it as a high value.

I wonder if this hack is no longer needed:
https://github.com/hrydgard/ppsspp/blob/5ed5947804f957d7e5a7d1f1f34619bc303ccaa0/Core/HLE/scePower.cpp#L314-L318

-[Unknown]