### PR TITLE
Dialog: Use dialog type header more consistently

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -31,7 +31,7 @@
 #define FADE_TIME 1.0
 const float FONT_SCALE = 0.55f;
 
-PSPDialog::PSPDialog(int type) : dialogType_(type) {
+PSPDialog::PSPDialog(UtilityDialogType type) : dialogType_(type) {
 }
 
 PSPDialog::~PSPDialog() {

--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -17,11 +17,11 @@
 
 #pragma once
 
-#include "Common/Render/TextureAtlas.h"
-
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
+#include "Common/Render/TextureAtlas.h"
 #include "Common/Swap.h"
+#include "Core/HLE/sceUtility.h"
 #include "Core/Util/PPGeDraw.h"
 
 class PointerWrap;
@@ -53,7 +53,7 @@ struct pspUtilityDialogCommon
 class PSPDialog
 {
 public:
-	PSPDialog(int type);
+	PSPDialog(UtilityDialogType type);
 	virtual ~PSPDialog();
 
 	virtual int Update(int animSpeed) = 0;
@@ -80,7 +80,7 @@ public:
 	};
 
 	DialogStatus GetStatus();
-	int DialogType() { return dialogType_; }
+	UtilityDialogType DialogType() { return dialogType_; }
 
 	void StartDraw();
 	void EndDraw();
@@ -129,6 +129,6 @@ protected:
 
 private:
 	DialogStatus status = SCE_UTILITY_STATUS_NONE;
-	int dialogType_;
+	UtilityDialogType dialogType_;
 	bool volatileLocked_ = false;
 };

--- a/Core/Dialog/PSPGamedataInstallDialog.cpp
+++ b/Core/Dialog/PSPGamedataInstallDialog.cpp
@@ -55,7 +55,7 @@ namespace
 	}
 }
 
-PSPGamedataInstallDialog::PSPGamedataInstallDialog(int type) : PSPDialog(type) {
+PSPGamedataInstallDialog::PSPGamedataInstallDialog(UtilityDialogType type) : PSPDialog(type) {
 }
 
 PSPGamedataInstallDialog::~PSPGamedataInstallDialog() {

--- a/Core/Dialog/PSPGamedataInstallDialog.h
+++ b/Core/Dialog/PSPGamedataInstallDialog.h
@@ -35,7 +35,7 @@ struct SceUtilityGamedataInstallParam {
 
 class PSPGamedataInstallDialog: public PSPDialog {
 public:
-	PSPGamedataInstallDialog(int type);
+	PSPGamedataInstallDialog(UtilityDialogType type);
 	virtual ~PSPGamedataInstallDialog();
 
 	virtual int Init(u32 paramAddr);

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -35,7 +35,7 @@ static const float FONT_SCALE = 0.65f;
 const static int MSG_INIT_DELAY_US = 300000;
 const static int MSG_SHUTDOWN_DELAY_US = 26000;
 
-PSPMsgDialog::PSPMsgDialog(int type) : PSPDialog(type) {
+PSPMsgDialog::PSPMsgDialog(UtilityDialogType type) : PSPDialog(type) {
 }
 
 PSPMsgDialog::~PSPMsgDialog() {

--- a/Core/Dialog/PSPMsgDialog.h
+++ b/Core/Dialog/PSPMsgDialog.h
@@ -58,7 +58,7 @@ struct pspMessageDialog
 
 class PSPMsgDialog: public PSPDialog {
 public:
-	PSPMsgDialog(int type);
+	PSPMsgDialog(UtilityDialogType type);
 	virtual ~PSPMsgDialog();
 
 	virtual int Init(unsigned int paramAddr);

--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -54,7 +54,7 @@ struct ScanInfos {
 } PACK;
 
 
-PSPNetconfDialog::PSPNetconfDialog(int type) : PSPDialog(type) {
+PSPNetconfDialog::PSPNetconfDialog(UtilityDialogType type) : PSPDialog(type) {
 }
 
 PSPNetconfDialog::~PSPNetconfDialog() {

--- a/Core/Dialog/PSPNetconfDialog.h
+++ b/Core/Dialog/PSPNetconfDialog.h
@@ -37,7 +37,7 @@ struct SceUtilityNetconfParam {
 
 class PSPNetconfDialog: public PSPDialog {
 public:
-	PSPNetconfDialog(int type);
+	PSPNetconfDialog(UtilityDialogType type);
 	virtual ~PSPNetconfDialog();
 
 	virtual int Init(u32 paramAddr);

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -156,7 +156,7 @@ int allowedInputFlagsMap[OSK_KEYBOARD_COUNT] = {
 	PSP_UTILITY_OSK_INPUTTYPE_JAPANESE_UPPERCASE | PSP_UTILITY_OSK_INPUTTYPE_JAPANESE_SYMBOL,
 };
 
-PSPOskDialog::PSPOskDialog(int type) : PSPDialog(type) {
+PSPOskDialog::PSPOskDialog(UtilityDialogType type) : PSPDialog(type) {
 	// This can break all kinds of stuff, changing the decimal point in sprintf for example.
 	// Not sure what the intended effect is so commented out for now.
 	// setlocale(LC_ALL, "");

--- a/Core/Dialog/PSPOskDialog.h
+++ b/Core/Dialog/PSPOskDialog.h
@@ -213,7 +213,7 @@ enum class PSPOskNativeStatus {
 
 class PSPOskDialog: public PSPDialog {
 public:
-	PSPOskDialog(int type);
+	PSPOskDialog(UtilityDialogType type);
 	virtual ~PSPOskDialog();
 
 	virtual int Init(u32 oskPtr);

--- a/Core/Dialog/PSPPlaceholderDialog.cpp
+++ b/Core/Dialog/PSPPlaceholderDialog.cpp
@@ -17,7 +17,7 @@
 
 #include "PSPPlaceholderDialog.h"
 
-PSPPlaceholderDialog::PSPPlaceholderDialog(int type) : PSPDialog(type) {
+PSPPlaceholderDialog::PSPPlaceholderDialog(UtilityDialogType type) : PSPDialog(type) {
 
 }
 

--- a/Core/Dialog/PSPPlaceholderDialog.h
+++ b/Core/Dialog/PSPPlaceholderDialog.h
@@ -21,7 +21,7 @@
 
 class PSPPlaceholderDialog: public PSPDialog {
 public:
-	PSPPlaceholderDialog(int type);
+	PSPPlaceholderDialog(UtilityDialogType type);
 	virtual ~PSPPlaceholderDialog();
 
 	virtual int Init();

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -56,7 +56,7 @@ const static int SAVEDATA_DIALOG_SIZE_V2 = 1500;
 const static int SAVEDATA_DIALOG_SIZE_V3 = 1536;
 
 
-PSPSaveDialog::PSPSaveDialog(int type) : PSPDialog(type) {
+PSPSaveDialog::PSPSaveDialog(UtilityDialogType type) : PSPDialog(type) {
 	param.SetPspParam(0);
 }
 

--- a/Core/Dialog/PSPSaveDialog.h
+++ b/Core/Dialog/PSPSaveDialog.h
@@ -71,7 +71,7 @@
 
 class PSPSaveDialog: public PSPDialog {
 public:
-	PSPSaveDialog(int type);
+	PSPSaveDialog(UtilityDialogType type);
 	virtual ~PSPSaveDialog();
 
 	virtual int Init(int paramAddr);

--- a/Core/Dialog/PSPScreenshotDialog.cpp
+++ b/Core/Dialog/PSPScreenshotDialog.cpp
@@ -52,7 +52,7 @@ struct SceUtilityScreenshotParams {
 	// TODO
 };
 
-PSPScreenshotDialog::PSPScreenshotDialog(int type) : PSPDialog(type) {
+PSPScreenshotDialog::PSPScreenshotDialog(UtilityDialogType type) : PSPDialog(type) {
 }
 
 PSPScreenshotDialog::~PSPScreenshotDialog() {

--- a/Core/Dialog/PSPScreenshotDialog.h
+++ b/Core/Dialog/PSPScreenshotDialog.h
@@ -24,7 +24,7 @@ struct SceUtilityScreenshotParams;
 
 class PSPScreenshotDialog : public PSPDialog {
 public:
-	PSPScreenshotDialog(int type);
+	PSPScreenshotDialog(UtilityDialogType type);
 	virtual ~PSPScreenshotDialog();
 
 	virtual int Init(u32 paramAddr);

--- a/Core/HLE/sceUtility.h
+++ b/Core/HLE/sceUtility.h
@@ -79,10 +79,21 @@ class PointerWrap;
 #define PSP_SYSTEMPARAM_BUTTON_CIRCLE  0
 #define PSP_SYSTEMPARAM_BUTTON_CROSS   1
 
+enum class UtilityDialogType {
+	NONE,
+	SAVEDATA,
+	MSG,
+	OSK,
+	NET,
+	SCREENSHOT,
+	GAMESHARING,
+	GAMEDATAINSTALL,
+};
+
 void __UtilityInit();
 void __UtilityDoState(PointerWrap &p);
 void __UtilityShutdown();
 
-void UtilityDialogShutdown(int type, int delayUs, int priority);
+void UtilityDialogShutdown(UtilityDialogType type, int delayUs, int priority);
 
 void Register_sceUtility();


### PR DESCRIPTION
Minor blame spam, but I prefer to use an enum class if moving to a header.  Should give us better typechecks, though.

-[Unknown]