### PR TITLE
In lighting, always normalize zero to (0, 0, 1)

### DIFF
--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include "Common/CPUDetect.h"
 #include "Common/Math/math_util.h"
 #include "Common/GPU/OpenGL/GLFeatures.h"
 
@@ -266,7 +267,7 @@ void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVt
 						normal = -normal;
 					}
 					Norm3ByMatrix43(worldnormal.AsArray(), normal.AsArray(), gstate.worldMatrix);
-					worldnormal = worldnormal.Normalized();
+					worldnormal = worldnormal.NormalizedOr001(cpu_info.bSSE4_1);
 				}
 			} else {
 				float weights[8];
@@ -298,7 +299,7 @@ void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVt
 						normal = -normal;
 					}
 					Norm3ByMatrix43(worldnormal.AsArray(), normal.AsArray(), gstate.worldMatrix);
-					worldnormal = worldnormal.Normalized();
+					worldnormal = worldnormal.NormalizedOr001(cpu_info.bSSE4_1);
 				}
 			}
 
@@ -358,7 +359,7 @@ void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVt
 						break;
 
 					case GE_PROJMAP_NORMALIZED_NORMAL: // Use normalized normal as source
-						source = normal.Normalized();
+						source = normal.NormalizedOr001(cpu_info.bSSE4_1);
 						if (!reader.hasNormal()) {
 							ERROR_LOG_REPORT(G3D, "Normal projection mapping without normal?");
 						}
@@ -391,11 +392,7 @@ void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVt
 					};
 					auto calcShadingLPos = [&](int l) {
 						Vec3f pos = getLPos(l);
-						if (pos.Length2() == 0.0f) {
-							return Vec3f(0.0f, 0.0f, 1.0f);
-						} else {
-							return pos.Normalized();
-						}
+						return pos.NormalizedOr001(cpu_info.bSSE4_1);
 					};
 					// Might not have lighting enabled, so don't use lighter.
 					Vec3f lightpos0 = calcShadingLPos(gstate.getUVLS0());

--- a/GPU/Common/TransformCommon.cpp
+++ b/GPU/Common/TransformCommon.cpp
@@ -17,6 +17,7 @@
 
 #include <stdio.h>
 
+#include "Common/CPUDetect.h"
 #include "GPU/GPUState.h"
 #include "GPU/Common/TransformCommon.h"
 
@@ -140,7 +141,7 @@ void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[
 		case GE_LIGHTTYPE_SPOT:
 		case GE_LIGHTTYPE_UNKNOWN:
 			lightDir = Vec3Packedf(&ldir[l * 3]);
-			angle = Dot(toLight.Normalized(), lightDir.Normalized());
+			angle = Dot(toLight.NormalizedOr001(cpu_info.bSSE4_1), lightDir.NormalizedOr001(cpu_info.bSSE4_1));
 			if (angle >= lcutoff[l])
 				lightScale = clamp(1.0f / (latt[l * 3] + latt[l * 3 + 1] * distanceToLight + latt[l * 3 + 2] * distanceToLight*distanceToLight), 0.0f, 1.0f) * powf(angle, lconv[l]);
 			break;
@@ -155,11 +156,10 @@ void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[
 		// Real PSP specular
 		Vec3f toViewer(0, 0, 1);
 		// Better specular
-		// Vec3f toViewer = (viewer - pos).Normalized();
+		// Vec3f toViewer = (viewer - pos).NormalizedOr001(cpu_info.bSSE4_1);
 
 		if (doSpecular) {
-			Vec3f halfVec = (toLight + toViewer);
-			halfVec.Normalize();
+			Vec3f halfVec = (toLight + toViewer).NormalizedOr001(cpu_info.bSSE4_1);
 
 			dot = Dot(halfVec, norm);
 			if (dot > 0.0f) {

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -722,6 +722,12 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 		WRITE(p, "}\n");
 	}
 
+	if (useHWTransform) {
+		WRITE(p, "vec3 normalizeOr001(vec3 v) {\n");
+		WRITE(p, "   return length(v) == 0.0 ? vec3(0.0, 0.0, 1.0) : normalize(v);\n");
+		WRITE(p, "}\n");
+	}
+
 	if (ShaderLanguageIsOpenGL(compat.shaderLanguage) || compat.shaderLanguage == GLSL_VULKAN) {
 		WRITE(p, "void main() {\n");
 	} else if (compat.shaderLanguage == HLSL_D3D9 || compat.shaderLanguage == HLSL_D3D11) {
@@ -798,7 +804,7 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 
 				WRITE(p, "  vec3 worldpos = mul(vec4(tess.pos.xyz, 1.0), u_world).xyz;\n");
 				if (hasNormalTess) {
-					WRITE(p, "  mediump vec3 worldnormal = normalize(mul(vec4(%stess.nrm, 0.0), u_world).xyz);\n", flipNormalTess ? "-" : "");
+					WRITE(p, "  mediump vec3 worldnormal = normalizeOr001(mul(vec4(%stess.nrm, 0.0), u_world).xyz);\n", flipNormalTess ? "-" : "");
 				} else {
 					WRITE(p, "  mediump vec3 worldnormal = vec3(0.0, 0.0, 1.0);\n");
 				}
@@ -806,7 +812,7 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 				// No skinning, just standard T&L.
 				WRITE(p, "  vec3 worldpos = mul(vec4(position, 1.0), u_world).xyz;\n");
 				if (hasNormal)
-					WRITE(p, "  mediump vec3 worldnormal = normalize(mul(vec4(%snormal, 0.0), u_world).xyz);\n", flipNormal ? "-" : "");
+					WRITE(p, "  mediump vec3 worldnormal = normalizeOr001(mul(vec4(%snormal, 0.0), u_world).xyz);\n", flipNormal ? "-" : "");
 				else
 					WRITE(p, "  mediump vec3 worldnormal = vec3(0.0, 0.0, 1.0);\n");
 			}
@@ -847,7 +853,7 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 			} else {
 				WRITE(p, "  mediump vec3 skinnednormal = mul(vec4(0.0, 0.0, %s1.0, 0.0), skinMatrix).xyz%s;\n", flipNormal ? "-" : "", factor);
 			}
-			WRITE(p, "  mediump vec3 worldnormal = normalize(mul(vec4(skinnednormal, 0.0), u_world).xyz);\n");
+			WRITE(p, "  mediump vec3 worldnormal = normalizeOr001(mul(vec4(skinnednormal, 0.0), u_world).xyz);\n");
 		}
 
 		WRITE(p, "  vec4 viewPos = vec4(mul(vec4(worldpos, 1.0), u_view).xyz, 1.0);\n");
@@ -1056,7 +1062,7 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 						break;
 					case GE_PROJMAP_NORMALIZED_NORMAL:  // Use normalized transformed normal as source
 						if (hasNormal)
-							temp_tc = flipNormal ? "vec4(normalize(-normal), 1.0)" : "vec4(normalize(normal), 1.0)";
+							temp_tc = StringFromFormat("length(%snormal) == 0.0 ? vec4(0.0, 0.0, 1.0, 1.0) : vec4(normalize(%snormal), 1.0)", flipNormal ? "-" : "");
 						else
 							temp_tc = "vec4(0.0, 0.0, 1.0, 1.0)";
 						break;

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -297,7 +297,9 @@ public:
 	Vec3 WithLength(const float l) const;
 	float Distance2To(Vec3 &other);
 	Vec3 Normalized(bool useSSE4 = false) const;
+	Vec3 NormalizedOr001(bool useSSE4 = false) const;
 	float Normalize(); // returns the previous length, which is often useful
+	float NormalizeOr001();
 
 	T& operator [] (int i) //allow vector[2] = 3   (vector.z=3)
 	{

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <algorithm>
 
+#include "Common/CPUDetect.h"
 #include "Common/Math/math_util.h"
 #include "Common/MemoryUtil.h"
 #include "Core/Config.h"
@@ -256,7 +257,7 @@ VertexData TransformUnit::ReadVertex(VertexReader& vreader)
 				break;
 
 			case GE_PROJMAP_NORMALIZED_NORMAL:
-				source = vertex.normal.Normalized();
+				source = vertex.normal.NormalizedOr001(cpu_info.bSSE4_1);
 				break;
 
 			case GE_PROJMAP_NORMAL:

--- a/Windows/GEDebugger/TabState.cpp
+++ b/Windows/GEDebugger/TabState.cpp
@@ -744,7 +744,7 @@ void FormatStateRow(wchar_t *dest, const TabStateRow &info, u32 value, bool enab
 			const char *lightComputations[] = {
 				"diffuse",
 				"diffuse + spec",
-				"pow(diffuse) + spec",
+				"pow(diffuse)",
 				"unknown (diffuse?)",
 			};
 			const char *lightTypes[] = {


### PR DESCRIPTION
Fixes #14167.  We've seen several cases of this now, so I think it's better to just assume it's the case for all normalize usage.

-[Unknown]