### PR TITLE
GPU: Dirty texparams when cropping a self-copy

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -901,6 +901,9 @@ void FramebufferManagerCommon::CopyFramebufferForColorTexture(VirtualFramebuffer
 			x += gstate_c.curTextureXOffset;
 			y += gstate_c.curTextureYOffset;
 		}
+
+		// We'll have to reapply these next time since we cropped to UV.
+		gstate_c.Dirty(DIRTY_TEXTURE_PARAMS);
 	}
 
 	if (x < src->drawnWidth && y < src->drawnHeight && w > 0 && h > 0) {


### PR DESCRIPTION
If we used UV to limit the blit, we may need to do the blit again next time, so re-examine texture params.

Might be #13741, but even if it isn't we should be dirtying here.

-[Unknown]