### PR TITLE
Use full homebrew game title / id in reporting if available

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -249,16 +249,9 @@ static void __CheatStop() {
 static void __CheatStart() {
 	__CheatStop();
 
-	std::string realGameID = g_paramSFO.GetValueString("DISC_ID");
-	std::string gameID = realGameID;
-	const std::string gamePath = PSP_CoreParameter().fileToStart;
-	const bool badGameSFO = realGameID.empty() || !g_paramSFO.GetValueInt("DISC_TOTAL");
-	if (badGameSFO && gamePath.find("/PSP/GAME/") != std::string::npos) {
-		gameID = g_paramSFO.GenerateFakeID(gamePath);
-	}
-
-	cheatEngine = new CWCheatEngine(gameID);
+	cheatEngine = new CWCheatEngine(g_paramSFO.GetDiscID());
 	// This only generates ini files on boot, let's leave homebrew ini file for UI.
+	std::string realGameID = g_paramSFO.GetValueString("DISC_ID");
 	if (!realGameID.empty()) {
 		cheatEngine->CreateCheatFile();
 	}

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -637,7 +637,7 @@ void __IoInit() {
 	pspFileSystem.Mount("flash0:", flash0System);
 
 	if (g_RemasterMode) {
-		const std::string gameId = g_paramSFO.GetValueString("DISC_ID");
+		const std::string gameId = g_paramSFO.GetDiscID();
 		const std::string exdataPath = g_Config.memStickDirectory + "exdata/" + gameId + "/";
 		if (File::Exists(exdataPath)) {
 			exdataSystem = new DirectoryFileSystem(&pspFileSystem, exdataPath, FileSystemFlags::SIMULATE_FAT32 | FileSystemFlags::CARD);

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -879,7 +879,7 @@ static void __SaveDecryptedEbootToStorageMedia(const u8 *decryptedEbootDataPtr, 
 		return;
 	}
 
-	const std::string filenameToDumpTo = g_paramSFO.GetValueString("DISC_ID") + ".BIN";
+	const std::string filenameToDumpTo = g_paramSFO.GetDiscID() + ".BIN";
 	const std::string dumpDirectory = GetSysDirectory(DIRECTORY_DUMP);
 	const std::string fullPath = dumpDirectory + filenameToDumpTo;
 

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -400,7 +400,7 @@ namespace Reporting
 	std::string CurrentGameID()
 	{
 		// TODO: Maybe ParamSFOData shouldn't include nulls in std::strings?  Don't work to break savedata, though...
-		const std::string disc_id = StripTrailingNull(g_paramSFO.GetValueString("DISC_ID"));
+		const std::string disc_id = StripTrailingNull(g_paramSFO.GetDiscID());
 		const std::string disc_version = StripTrailingNull(g_paramSFO.GetValueString("DISC_VERSION"));
 		return disc_id + "_" + disc_version;
 	}


### PR DESCRIPTION
Soem homebrew do have valid data here - better to use it if possible.

This affects reporting, which recently got a large chunk of homebrew reports with empty titles because of this.

-[Unknown]