### PR TITLE
Add initial search to savedata manager

### DIFF
--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -1288,7 +1288,7 @@ void TabHolder::SetCurrentTab(int tab, bool skipTween) {
 
 		currentTab_ = tab;
 	}
-	tabStrip_->SetSelection(tab);
+	tabStrip_->SetSelection(tab, false);
 }
 
 EventReturn TabHolder::OnTabClick(EventParams &e) {
@@ -1369,7 +1369,7 @@ EventReturn ChoiceStrip::OnChoiceClick(EventParams &e) {
 	return OnChoice.Dispatch(e2);
 }
 
-void ChoiceStrip::SetSelection(int sel) {
+void ChoiceStrip::SetSelection(int sel, bool triggerClick) {
 	int prevSelected = selected_;
 	StickyChoice *prevChoice = Choice(selected_);
 	if (prevChoice)
@@ -1384,7 +1384,7 @@ void ChoiceStrip::SetSelection(int sel) {
 			e.v = views_[selected_];
 			e.a = selected_;
 			// Set to 0 to indicate a selection change (not a click.)
-			e.b = 0;
+			e.b = triggerClick ? 1 : 0;
 			OnChoice.Trigger(e);
 		}
 	}
@@ -1398,16 +1398,16 @@ void ChoiceStrip::HighlightChoice(unsigned int choice){
 
 bool ChoiceStrip::Key(const KeyInput &input) {
 	bool ret = false;
-	if (input.flags & KEY_DOWN) {
+	if (topTabs_ && (input.flags & KEY_DOWN)) {
 		if (IsTabLeftKey(input)) {
 			if (selected_ > 0) {
-				SetSelection(selected_ - 1);
+				SetSelection(selected_ - 1, true);
 				UI::PlayUISound(UI::UISound::TOGGLE_OFF);  // Maybe make specific sounds for this at some point?
 			}
 			ret = true;
 		} else if (IsTabRightKey(input)) {
 			if (selected_ < (int)views_.size() - 1) {
-				SetSelection(selected_ + 1);
+				SetSelection(selected_ + 1, true);
 				UI::PlayUISound(UI::UISound::TOGGLE_ON);
 			}
 			ret = true;

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -300,7 +300,7 @@ public:
 	void AddChoice(ImageID buttonImage);
 
 	int GetSelection() const { return selected_; }
-	void SetSelection(int sel);
+	void SetSelection(int sel, bool triggerClick);
 
 	void HighlightChoice(unsigned int choice);
 

--- a/UI/ComboKeyMappingScreen.cpp
+++ b/UI/ComboKeyMappingScreen.cpp
@@ -52,7 +52,7 @@ void ComboKeyScreen::CreateViews() {
 	for (int i = 0; i < 5; i++) {
 		comboselect->AddChoice(comboKeyImages[i]);
 	}
-	comboselect->SetSelection(*mode);
+	comboselect->SetSelection(*mode, false);
 	comboselect->OnChoice.Handle(this, &ComboKeyScreen::onCombo);
 	leftColumn->Add(comboselect);
 	root__->Add(leftColumn);

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -319,7 +319,7 @@ void DisplayLayoutScreen::CreateViews() {
 			mode_ = new ChoiceStrip(ORIENT_VERTICAL, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10 + leftInset, NONE, NONE, 158 + 64 + 10));
 			mode_->AddChoice(di->T("Move"));
 			mode_->AddChoice(di->T("Resize"));
-			mode_->SetSelection(0);
+			mode_->SetSelection(0, false);
 		}
 		displayRepresentation_ = new DragDropDisplay(g_Config.fSmallDisplayOffsetX, g_Config.fSmallDisplayOffsetY, ImageID("I_PSP_DISPLAY"), ScaleSettingToUI(), bounds);
 		displayRepresentation_->SetVisibility(V_VISIBLE);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -664,7 +664,7 @@ void GameBrowser::Refresh() {
 		ChoiceStrip *layoutChoice = topBar->Add(new ChoiceStrip(ORIENT_HORIZONTAL));
 		layoutChoice->AddChoice(ImageID("I_GRID"));
 		layoutChoice->AddChoice(ImageID("I_LINES"));
-		layoutChoice->SetSelection(*gridStyle_ ? 0 : 1);
+		layoutChoice->SetSelection(*gridStyle_ ? 0 : 1, false);
 		layoutChoice->OnChoice.Handle(this, &GameBrowser::LayoutChange);
 		topBar->Add(new Choice(ImageID("I_GEAR"), new LayoutParams(64.0f, 64.0f)))->OnClick.Handle(this, &GameBrowser::GridSettingsClick);
 		Add(topBar);

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -510,7 +510,7 @@ void SavedataScreen::CreateViews() {
 	sortStrip->AddChoice(sa->T("Filename"));
 	sortStrip->AddChoice(sa->T("Size"));
 	sortStrip->AddChoice(sa->T("Date"));
-	sortStrip->SetSelection((int)sortOption_);
+	sortStrip->SetSelection((int)sortOption_, false);
 	sortStrip->OnChoice.Handle<SavedataScreen>(this, &SavedataScreen::OnSortClick);
 
 	root_->Add(main);

--- a/UI/SavedataScreen.h
+++ b/UI/SavedataScreen.h
@@ -36,7 +36,10 @@ class SavedataBrowser : public UI::LinearLayout {
 public:
 	SavedataBrowser(std::string path, UI::LayoutParams *layoutParams = 0);
 
+	void Update() override;
+
 	void SetSortOption(SavedataSortOption opt);
+	void SetSearchFilter(const std::string &filter);
 
 	UI::Event OnChoice;
 
@@ -51,7 +54,11 @@ private:
 
 	SavedataSortOption sortOption_ = SavedataSortOption::FILENAME;
 	UI::ViewGroup *gameList_ = nullptr;
+	UI::TextView *noMatchView_ = nullptr;
+	UI::TextView *searchingView_ = nullptr;
 	std::string path_;
+	std::string searchFilter_;
+	bool searchPending_ = false;
 };
 
 class SavedataScreen : public UIDialogScreenWithGameBackground {
@@ -61,13 +68,17 @@ public:
 	~SavedataScreen();
 
 	void dialogFinished(const Screen *dialog, DialogResult result) override;
+	void sendMessage(const char *message, const char *value) override;
 
 protected:
 	UI::EventReturn OnSavedataButtonClick(UI::EventParams &e);
 	UI::EventReturn OnSortClick(UI::EventParams &e);
+	UI::EventReturn OnSearch(UI::EventParams &e);
 	void CreateViews() override;
+
 	bool gridStyle_;
 	SavedataSortOption sortOption_ = SavedataSortOption::FILENAME;
 	SavedataBrowser *dataBrowser_;
 	SavedataBrowser *stateBrowser_;
+	std::string searchFilter_;
 };

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -511,7 +511,7 @@ void TouchControlLayoutScreen::CreateViews() {
 	mode_ = new ChoiceStrip(ORIENT_VERTICAL, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 140 + 158 + 64 + 10));
 	mode_->AddChoice(di->T("Move"));
 	mode_->AddChoice(di->T("Resize"));
-	mode_->SetSelection(0);
+	mode_->SetSelection(0, false);
 	mode_->OnChoice.Handle(this, &TouchControlLayoutScreen::OnMode);
 
 	reset->OnClick.Handle(this, &TouchControlLayoutScreen::OnReset);


### PR DESCRIPTION
This adds a button to type a term, and does a simple search for that term among the list.

Some improvements that would still be good, but don't block usefulness:
 * Better lowercasing for search (Unicode aware), maybe even romanji match for the common case of Japanese names.
 * Inline search field entry on desktop / separate keyboard devices, and filter as you type.
 * Some sort of throbber as it searches (currently async, but no indication of progress.)
 * Maybe clearer indication to clear your search (considered swapping "Search" to "Clear Search"...)

Thought this might be an obvious application of #14202, but of course the delayed loading of ginfo made it more complex.  That's actually a problem if we expose to accessibility anyway, since `Draw` is not really relevant...

Still, I think this is a very useful place for UI search.  Other candidates:
 * Recent list (not sure where to put it...)
 * Other game lists, including remote browsing.
 * System info (namely extensions lists.)

-[Unknown]