### PR TITLE
Cleanup ppsspp_config.h usage

### DIFF
--- a/Common/ABI.cpp
+++ b/Common/ABI.cpp
@@ -15,7 +15,8 @@
 // Official SVN repository and contact information can be found at
 // http://code.google.com/p/dolphin-emu/
 
-#if defined(_M_IX86) || defined(_M_X64)
+#include "ppsspp_config.h"
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 
 #include "x64Emitter.h"
 #include "ABI.h"
@@ -27,9 +28,9 @@ using namespace Gen;
 // Sets up a __cdecl function.
 void XEmitter::ABI_EmitPrologue(int maxCallParams)
 {
-#ifdef _M_IX86
+#if PPSSPP_ARCH(X86)
 	// Don't really need to do anything
-#elif defined(_M_X64)
+#elif PPSSPP_ARCH(AMD64)
 #if _WIN32
 	int stacksize = ((maxCallParams + 1) & ~1) * 8 + 8;
 	// Set up a stack frame so that we can call functions
@@ -43,9 +44,9 @@ void XEmitter::ABI_EmitPrologue(int maxCallParams)
 
 void XEmitter::ABI_EmitEpilogue(int maxCallParams)
 {
-#ifdef _M_IX86
+#if PPSSPP_ARCH(X86)
 	RET();
-#elif defined(_M_X64)
+#elif PPSSPP_ARCH(AMD64)
 #ifdef _WIN32
 	int stacksize = ((maxCallParams+1)&~1)*8 + 8;
 	ADD(64, R(RSP), Imm8(stacksize));
@@ -58,7 +59,7 @@ void XEmitter::ABI_EmitEpilogue(int maxCallParams)
 #endif
 }
 
-#ifdef _M_IX86 // All32
+#if PPSSPP_ARCH(X86) // All32
 
 // Shared code between Win32 and Unix32
 void XEmitter::ABI_CallFunction(const void *func) {
@@ -681,4 +682,4 @@ void XEmitter::ABI_RestoreStack(unsigned int /*frameSize*/) {
 
 #endif // 32bit
 
-#endif // defined(_M_IX86) || defined(_M_X64)
+#endif // PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)

--- a/Common/ABI.h
+++ b/Common/ABI.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "ppsspp_config.h"
 #include "Common.h"
 
 // x86/x64 ABI:s, and helpers to help follow them when JIT-ing code.
@@ -44,7 +45,7 @@
 // Callee-save:  RBX RBP R12 R13 R14 R15
 // Parameters:   RDI RSI RDX RCX R8 R9
 
-#ifdef _M_IX86 // 32 bit calling convention, shared by all
+#if PPSSPP_ARCH(X86) // 32 bit calling convention, shared by all
 
 // 32-bit don't pass parameters in regs, but these are convenient to have anyway when we have to
 // choose regs to put stuff in.
@@ -55,7 +56,7 @@
 // 32-bit bog standard cdecl, shared between linux and windows
 // MacOSX 32-bit is same as System V with a few exceptions that we probably don't care much about.
 
-#elif _M_X64 // 64 bit calling convention
+#elif PPSSPP_ARCH(AMD64) // 64 bit calling convention
 
 #ifdef _WIN32 // 64-bit Windows - the really exotic calling convention 
 

--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef IOS
+#if PPSSPP_PLATFORM(IOS)
 #include <libkern/OSCacheControl.h>
 #include <sys/mman.h>
 #endif
@@ -627,7 +627,7 @@ void ARMXEmitter::FlushIcache()
 
 void ARMXEmitter::FlushIcacheSection(u8 *start, u8 *end)
 {
-#if defined(IOS)
+#if PPSSPP_PLATFORM(IOS)
 	// Header file says this is equivalent to: sys_icache_invalidate(start, end - start);
 	sys_cache_control(kCacheFunctionPrepareForExecution, start, end - start);
 #elif PPSSPP_PLATFORM(WINDOWS)

--- a/Common/BitSet.h
+++ b/Common/BitSet.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "ppsspp_config.h"
 #include <cstdint>
 #include <cstdlib>  // for byte swapping
 #include <cstddef>
@@ -27,7 +28,7 @@ inline int LeastSignificantSetBit(u32 val)
 	_BitScanForward(&index, val);
 	return (int)index;
 }
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 inline int LeastSignificantSetBit(u64 val)
 {
 	unsigned long index;

--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -78,7 +78,7 @@ static uint64_t do_xgetbv(unsigned int index) {
 }
 #endif  // _M_SSE
 
-#if !defined(MIPS)
+#if !PPSSPP_ARCH(MIPS)
 
 void do_cpuidex(u32 regs[4], u32 cpuid_leaf, u32 ecxval) {
 #if defined(__i386__) && defined(__PIC__)
@@ -100,7 +100,7 @@ void do_cpuid(u32 regs[4], u32 cpuid_leaf)
 	do_cpuidex(regs, cpuid_leaf, 0);
 }
 
-#endif // !defined(MIPS)
+#endif // !PPSSPP_ARCH(MIPS)
 
 #endif  // !win32
 

--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -16,9 +16,9 @@
 // http://code.google.com/p/dolphin-emu/
 
 // Reference : https://stackoverflow.com/questions/6121792/how-to-check-if-a-cpu-supports-the-sse3-instruction-set
-#if defined(_M_IX86) || defined(_M_X64)
-
 #include "ppsspp_config.h"
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+
 #ifdef __ANDROID__
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -141,9 +141,9 @@ static std::vector<int> ParseCPUList(const std::string &filename) {
 // Detects the various cpu features
 void CPUInfo::Detect() {
 	memset(this, 0, sizeof(*this));
-#ifdef _M_IX86
+#if PPSSPP_ARCH(X86)
 	Mode64bit = false;
-#elif defined (_M_X64)
+#elif PPSSPP_ARCH(AMD64)
 	Mode64bit = true;
 	OS64bit = true;
 #endif
@@ -151,7 +151,7 @@ void CPUInfo::Detect() {
 
 #if PPSSPP_PLATFORM(UWP)
 	OS64bit = Mode64bit;  // TODO: Not always accurate!
-#elif defined(_WIN32) && defined(_M_IX86)
+#elif defined(_WIN32) && PPSSPP_ARCH(X86)
 	BOOL f64 = false;
 	IsWow64Process(GetCurrentProcess(), &f64);
 	OS64bit = (f64 == TRUE) ? true : false;
@@ -441,4 +441,4 @@ std::string CPUInfo::Summarize()
 	return sum;
 }
 
-#endif // defined(_M_IX86) || defined(_M_X64)
+#endif // PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)

--- a/Common/ColorConv.cpp
+++ b/Common/ColorConv.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include "Common/Data/Convert/SmallDataConvert.h"
 #include "ColorConv.h"
 // NEON is in a separate file so that it can be compiled with a runtime check.

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -63,9 +63,9 @@
 #include <CoreFoundation/CFString.h>
 #include <CoreFoundation/CFURL.h>
 #include <CoreFoundation/CFBundle.h>
-#if !defined(IOS)
+#if !PPSSPP_PLATFORM(IOS)
 #include <mach-o/dyld.h>
-#endif  // !defined(IOS)
+#endif  // !PPSSPP_PLATFORM(IOS)
 #endif  // __APPLE__
 
 #include "Common/Data/Encoding/Utf8.h"
@@ -844,13 +844,13 @@ const std::string &GetExeDirectory()
 		ExePath = program_path;
 #endif
 
-#elif (defined(__APPLE__) && !defined(IOS)) || defined(__linux__) || defined(KERN_PROC_PATHNAME)
+#elif (defined(__APPLE__) && !PPSSPP_PLATFORM(IOS)) || defined(__linux__) || defined(KERN_PROC_PATHNAME)
 		char program_path[4096];
 		uint32_t program_path_size = sizeof(program_path) - 1;
 
 #if defined(__linux__)
 		if (readlink("/proc/self/exe", program_path, program_path_size) > 0)
-#elif defined(__APPLE__) && !defined(IOS)
+#elif defined(__APPLE__) && !PPSSPP_PLATFORM(IOS)
 		if (_NSGetExecutablePath(program_path, &program_path_size) == 0)
 #elif defined(KERN_PROC_PATHNAME)
 		int mib[4] = {

--- a/Common/GPU/D3D11/D3D11Loader.cpp
+++ b/Common/GPU/D3D11/D3D11Loader.cpp
@@ -1,3 +1,4 @@
+#include "ppsspp_config.h"
 #include "Common/GPU/D3D11/D3D11Loader.h"
 
 #if PPSSPP_PLATFORM(UWP)

--- a/Common/GPU/OpenGL/GLCommon.h
+++ b/Common/GPU/OpenGL/GLCommon.h
@@ -2,7 +2,7 @@
 
 #include "ppsspp_config.h"
 
-#ifdef IOS
+#if PPSSPP_PLATFORM(IOS)
 #include <OpenGLES/ES3/gl.h>
 #include <OpenGLES/ES3/glext.h>
 #elif defined(USING_GLES2)
@@ -58,7 +58,7 @@ typedef void (EGLAPIENTRYP PFNGLBLITFRAMEBUFFERNVPROC) (
 #endif
 extern PFNGLBLITFRAMEBUFFERNVPROC glBlitFramebufferNV;
 
-#ifdef IOS
+#if PPSSPP_PLATFORM(IOS)
 extern PFNGLDISCARDFRAMEBUFFEREXTPROC glDiscardFramebufferEXT;
 extern PFNGLGENVERTEXARRAYSOESPROC glGenVertexArraysOES;
 extern PFNGLBINDVERTEXARRAYOESPROC glBindVertexArrayOES;

--- a/Common/GPU/OpenGL/GLFeatures.cpp
+++ b/Common/GPU/OpenGL/GLFeatures.cpp
@@ -31,7 +31,7 @@ PFNGLBINDVERTEXARRAYOESPROC glBindVertexArrayOES;
 PFNGLDELETEVERTEXARRAYSOESPROC glDeleteVertexArraysOES;
 PFNGLISVERTEXARRAYOESPROC glIsVertexArrayOES;
 #endif
-#ifndef IOS
+#if !PPSSPP_PLATFORM(IOS)
 #include "EGL/egl.h"
 #endif
 #endif

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -1,3 +1,4 @@
+#include "ppsspp_config.h"
 #include <algorithm>
 
 #include "Common/GPU/OpenGL/GLCommon.h"
@@ -18,7 +19,7 @@
 
 #define TEXCACHE_NAME_CACHE_SIZE 16
 
-#ifdef IOS
+#if PPSSPP_PLATFORM(IOS)
 extern void bindDefaultFBO();
 #endif
 
@@ -201,7 +202,7 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps, bool ski
 			} else if (gl_extensions.VersionGEThan(3, 3, 0)) {
 				glBindFragDataLocation(program->program, 0, "fragColor0");
 			}
-#elif !defined(IOS)
+#elif !PPSSPP_PLATFORM(IOS)
 			if (gl_extensions.GLES3 && step.create_program.support_dual_source) {
 				glBindFragDataLocationIndexedEXT(program->program, 0, 0, "fragColor0");
 				glBindFragDataLocationIndexedEXT(program->program, 0, 1, "fragColor1");
@@ -1368,7 +1369,7 @@ void GLQueueRunner::PerformCopy(const GLRStep &step) {
 	_dbg_assert_(dstTex);
 
 #if defined(USING_GLES2)
-#ifndef IOS
+#if !PPSSPP_PLATFORM(IOS)
 	_assert_msg_(gl_extensions.OES_copy_image || gl_extensions.NV_copy_image || gl_extensions.EXT_copy_image, "Image copy extension expected");
 	glCopyImageSubDataOES(
 		srcTex, target, srcLevel, srcRect.x, srcRect.y, srcZ,
@@ -1682,7 +1683,7 @@ void GLQueueRunner::fbo_unbind() {
 	glBindFramebuffer(GL_FRAMEBUFFER, g_defaultFBO);
 #endif
 
-#ifdef IOS
+#if PPSSPP_PLATFORM(IOS)
 	bindDefaultFBO();
 #endif
 

--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -1,3 +1,4 @@
+#include "ppsspp_config.h"
 #include "GLRenderManager.h"
 #include "Common/GPU/OpenGL/GLFeatures.h"
 #include "Common/GPU/thin3d.h"
@@ -889,7 +890,7 @@ void *GLRBuffer::Map(GLBufferStrategy strategy) {
 		glBindBuffer(target_, buffer_);
 
 		if (gl_extensions.ARB_buffer_storage || gl_extensions.EXT_buffer_storage) {
-#ifndef IOS
+#if !PPSSPP_PLATFORM(IOS)
 			if (!hasStorage_) {
 				GLbitfield storageFlags = access & ~(GL_MAP_INVALIDATE_BUFFER_BIT | GL_MAP_FLUSH_EXPLICIT_BIT);
 #ifdef USING_GLES2

--- a/Common/GPU/OpenGL/gl3stub.c
+++ b/Common/GPU/OpenGL/gl3stub.c
@@ -382,7 +382,7 @@ GLboolean gl3stubInit() {
 	return GL_TRUE;
 }
 
-#endif // IOS
+#endif // PPSPP_PLATFORM(IOS)
 
 #endif // GLES2
 

--- a/Common/GPU/OpenGL/gl3stub.h
+++ b/Common/GPU/OpenGL/gl3stub.h
@@ -514,7 +514,7 @@ extern GL_APICALL void           (* GL_APIENTRY glBufferStorageEXT) (GLenum targ
 /* OES_copy_image, etc. */
 extern GL_APICALL void           (* GL_APIENTRY glCopyImageSubDataOES) (GLuint srcName, GLenum srcTarget, GLint srcLevel, GLint srcX, GLint srcY, GLint srcZ, GLuint dstName, GLenum dstTarget, GLint dstLevel, GLint dstX, GLint dstY, GLint dstZ, GLsizei width, GLsizei height, GLsizei depth);
 
-#endif   // IOS
+#endif   // PPSSPP_PLATFORM(IOS)
 
 #ifdef __cplusplus
 }

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -61,7 +61,7 @@ static const unsigned short blendFactorToGL[] = {
 	GL_ONE_MINUS_SRC1_COLOR,
 	GL_SRC1_ALPHA,
 	GL_ONE_MINUS_SRC1_ALPHA,
-#elif !defined(IOS)
+#elif !PPSSPP_PLATFORM(IOS)
 	GL_SRC1_COLOR_EXT,
 	GL_ONE_MINUS_SRC1_COLOR_EXT,
 	GL_SRC1_ALPHA_EXT,

--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -238,7 +238,7 @@ static const char *device_name_blacklist[] = {
 
 #ifndef _WIN32
 static const char *so_names[] = {
-#ifdef IOS
+#if PPSSPP_PLATFORM(IOS)
 	"@executable_path/Frameworks/libMoltenVK.dylib",
 #elif PPSSPP_PLATFORM(MAC)
 	"@executable_path/../Frameworks/libMoltenVK.dylib",

--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -15,11 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include "Common/GPU/Vulkan/VulkanLoader.h"
+#include "ppsspp_config.h"
 #include <vector>
 #include <string>
 #include <cstring>
 
+#include "Common/GPU/Vulkan/VulkanLoader.h"
 #include "Common/Log.h"
 #include "Common/System/System.h"
 
@@ -239,7 +240,7 @@ static const char *device_name_blacklist[] = {
 static const char *so_names[] = {
 #ifdef IOS
 	"@executable_path/Frameworks/libMoltenVK.dylib",
-#elif defined(PPSSPP_PLATFORM_MAC)
+#elif PPSSPP_PLATFORM(MAC)
 	"@executable_path/../Frameworks/libMoltenVK.dylib",
 #else
 	"libvulkan.so",

--- a/Common/Math/fast/fast_math.c
+++ b/Common/Math/fast/fast_math.c
@@ -1,3 +1,4 @@
+#include "ppsspp_config.h"
 #include "fast_math.h"
 #include "fast_matrix.h"
 

--- a/Common/MemArenaDarwin.cpp
+++ b/Common/MemArenaDarwin.cpp
@@ -84,7 +84,7 @@ void MemArena::ReleaseView(void* view, size_t size) {
 }
 
 bool MemArena::NeedsProbing() {
-#if defined(IOS) && PPSSPP_ARCH(64BIT)
+#if PPSSPP_PLATFORM(IOS) && PPSSPP_ARCH(64BIT)
 	return true;
 #else
 	return false;
@@ -92,7 +92,7 @@ bool MemArena::NeedsProbing() {
 }
 
 u8* MemArena::Find4GBBase() {
-#if defined(IOS) && PPSSPP_ARCH(64BIT)
+#if PPSSPP_PLATFORM(IOS) && PPSSPP_ARCH(64BIT)
 	// The caller will need to do probing, like on 32-bit Windows.
 	return nullptr;
 #else

--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -87,7 +87,7 @@ static uint32_t ConvertProtFlagsUnix(uint32_t flags) {
 
 #endif
 
-#if defined(_WIN32) && defined(_M_X64)
+#if defined(_WIN32) && PPSSPP_ARCH(AMD64)
 static uintptr_t last_executable_addr;
 static void *SearchForFreeMem(size_t size) {
 	if (!last_executable_addr)
@@ -128,7 +128,7 @@ void *AllocateExecutableMemory(size_t size) {
 		prot = PAGE_READWRITE;
 	if (sys_info.dwPageSize == 0)
 		GetSystemInfo(&sys_info);
-#if defined(_M_X64)
+#if PPSSPP_ARCH(AMD64)
 	if ((uintptr_t)&hint_location > 0xFFFFFFFFULL) {
 		size_t aligned_size = ppsspp_round_page(size);
 #if 1   // Turn off to hunt for RIP bugs on x86-64.
@@ -159,7 +159,7 @@ void *AllocateExecutableMemory(size_t size) {
 	}
 #else
 	static char *map_hint = 0;
-#if defined(_M_X64)
+#if PPSSPP_ARCH(AMD64)
 	// Try to request one that is close to our memory location if we're in high memory.
 	// We use a dummy global variable to give us a good location to start from.
 	if (!map_hint) {
@@ -190,7 +190,7 @@ void *AllocateExecutableMemory(size_t size) {
 		ERROR_LOG(MEMMAP, "Failed to allocate executable memory (%d) errno=%d", (int)size, errno);
 	}
 
-#if defined(_M_X64) && !defined(_WIN32)
+#if PPSSPP_ARCH(AMD64) && !defined(_WIN32)
 	else if ((uintptr_t)map_hint <= 0xFFFFFFFF) {
 		// Round up if we're below 32-bit mark, probably allocating sequentially.
 		map_hint += ppsspp_round_page(size);

--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -279,7 +279,7 @@ void FreeAlignedMemory(void* ptr) {
 bool PlatformIsWXExclusive() {
 	// Needed on platforms that disable W^X pages for security. Even without block linking, still should be much faster than IR JIT.
 	// This might also come in useful for UWP (Universal Windows Platform) if I'm understanding things correctly.
-#if defined(IOS) || PPSSPP_PLATFORM(UWP) || defined(__OpenBSD__)
+#if PPSSPP_PLATFORM(IOS) || PPSSPP_PLATFORM(UWP) || defined(__OpenBSD__)
 	return true;
 #elif PPSSPP_PLATFORM(MAC) && PPSSPP_ARCH(ARM64)
 	return true;

--- a/Common/MipsCPUDetect.cpp
+++ b/Common/MipsCPUDetect.cpp
@@ -15,7 +15,8 @@
 // Official SVN repository and contact information can be found at
 // http://code.google.com/p/dolphin-emu/
 
-#ifdef __mips__
+#include "ppsspp_config.h"
+#if PPSSPP_ARCH(MIPS) || PPSSPP_ARCH(MIPS64)
 
 #include "Common/Common.h"
 #include "Common/CPUDetect.h"
@@ -202,4 +203,4 @@ std::string CPUInfo::Summarize()
 	return sum;
 }
 
-#endif // __mips__
+#endif // PPSSPP_ARCH(MIPS) || PPSSPP_ARCH(MIPS64)

--- a/Common/MipsEmitter.cpp
+++ b/Common/MipsEmitter.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -67,7 +68,7 @@ void MIPSEmitter::FlushIcache() {
 }
 
 void MIPSEmitter::FlushIcacheSection(u8 *start, u8 *end) {
-#if defined(MIPS)
+#if PPSSPP_ARCH(MIPS)
 #ifdef __clang__
 	__clear_cache(start, end);
 #else

--- a/Common/Render/Text/draw_text_android.cpp
+++ b/Common/Render/Text/draw_text_android.cpp
@@ -1,3 +1,4 @@
+#include "ppsspp_config.h"
 #include "Common/Log.h"
 #include "Common/StringUtils.h"
 #include "Common/System/Display.h"

--- a/Common/Render/Text/draw_text_uwp.cpp
+++ b/Common/Render/Text/draw_text_uwp.cpp
@@ -1,3 +1,4 @@
+#include "ppsspp_config.h"
 #include "Common/System/Display.h"
 #include "Common/GPU/thin3d.h"
 #include "Common/Data/Hash/Hash.h"

--- a/Common/Render/Text/draw_text_win.cpp
+++ b/Common/Render/Text/draw_text_win.cpp
@@ -1,3 +1,4 @@
+#include "ppsspp_config.h"
 #include "Common/System/Display.h"
 #include "Common/GPU/thin3d.h"
 #include "Common/Data/Hash/Hash.h"

--- a/Common/Thunk.cpp
+++ b/Common/Thunk.cpp
@@ -15,6 +15,7 @@
 // Official SVN repository and contact information can be found at
 // http://code.google.com/p/dolphin-emu/
 
+#include "ppsspp_config.h"
 #include "MemoryUtil.h"
 #include "ABI.h"
 #include "Thunk.h"
@@ -23,7 +24,7 @@
 
 namespace {
 
-#ifndef _M_X64
+#if !PPSSPP_ARCH(AMD64)
 alignas(32) static u8 saved_fp_state[16 * 4 * 4];
 alignas(32) static u8 saved_gpr_state[16 * 8];
 static u16 saved_mxcsr;
@@ -35,7 +36,7 @@ using namespace Gen;
 
 void ThunkManager::Init()
 {
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 	// Account for the return address and "home space" on Windows (which needs to be at the bottom.)
 	const int stackOffset = ThunkStackOffset();
 	int stackPosition;
@@ -44,7 +45,7 @@ void ThunkManager::Init()
 	AllocCodeSpace(THUNK_ARENA_SIZE);
 	BeginWrite();
 	save_regs = GetCodePtr();
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 	for (int i = 2; i < ABI_GetNumXMMRegs(); i++)
 		MOVAPS(MDisp(RSP, stackOffset + (i - 2) * 16), (X64Reg)(XMM0 + i));
 	stackPosition = (ABI_GetNumXMMRegs() - 2) * 2;
@@ -70,7 +71,7 @@ void ThunkManager::Init()
 	RET();
 
 	load_regs = GetCodePtr();
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 	for (int i = 2; i < ABI_GetNumXMMRegs(); i++)
 		MOVAPS((X64Reg)(XMM0 + i), MDisp(RSP, stackOffset + (i - 2) * 16));
 	stackPosition = (ABI_GetNumXMMRegs() - 2) * 2;
@@ -112,7 +113,7 @@ void ThunkManager::Shutdown()
 int ThunkManager::ThunkBytesNeeded()
 {
 	int space = (ABI_GetNumXMMRegs() - 2) * 16;
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 	// MXCSR
 	space += 8;
 	space += 7 * 8;
@@ -131,7 +132,7 @@ int ThunkManager::ThunkBytesNeeded()
 
 int ThunkManager::ThunkStackOffset()
 {
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 #ifdef _WIN32
 	return 0x28;
 #else
@@ -154,7 +155,7 @@ const void *ThunkManager::ProtectFunction(const void *function, int num_params) 
 	const u8 *call_point = GetCodePtr();
 	Enter(this, true);
 
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 	ABI_CallFunction(function);
 #else
 	// Since parameters are in the previous stack frame, not in registers, this takes some
@@ -180,7 +181,7 @@ const void *ThunkManager::ProtectFunction(const void *function, int num_params) 
 
 void ThunkManager::Enter(ThunkEmitter *emit, bool withinCall)
 {
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 	// Make sure to align stack.
 	emit->SUB(64, R(ESP), Imm32(ThunkStackOffset() + ThunkBytesNeeded() + (withinCall ? 0 : 8)));
 	emit->ABI_CallFunction(save_regs);
@@ -191,7 +192,7 @@ void ThunkManager::Enter(ThunkEmitter *emit, bool withinCall)
 
 void ThunkManager::Leave(ThunkEmitter *emit, bool withinCall)
 {
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 	emit->ABI_CallFunction(load_regs);
 	emit->ADD(64, R(ESP), Imm32(ThunkStackOffset() + ThunkBytesNeeded() + (withinCall ? 0 : 8)));
 #else

--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -15,6 +15,7 @@
 // Official SVN repository and contact information can be found at
 // http://code.google.com/p/dolphin-emu/
 
+#include "ppsspp_config.h"
 #include <cstring>
 
 #include "x64Emitter.h"
@@ -160,7 +161,7 @@ void XEmitter::WriteSIB(int scale, int index, int base)
 void OpArg::WriteRex(XEmitter *emit, int opBits, int bits, int customOp) const
 {
 	if (customOp == -1)       customOp = operandReg;
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 	u8 op = 0x40;
 	// REX.W (whether operation is a 64-bit operation)
 	if (opBits == 64)         op |= 8;
@@ -232,7 +233,7 @@ void OpArg::WriteRest(XEmitter *emit, int extraBytes, X64Reg _operandReg,
 		_offsetOrBaseReg = 5;
 		emit->WriteModRM(0, _operandReg, _offsetOrBaseReg);
 		//TODO : add some checks
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 		u64 ripAddr = (u64)emit->GetCodePointer() + 4 + extraBytes;
 		s64 distance = (s64)offset - (s64)ripAddr;
 		_assert_msg_(
@@ -1451,7 +1452,7 @@ void XEmitter::MOVD_xmm(const OpArg &arg, X64Reg src) {WriteSSEOp(0x66, 0x7E, sr
 
 void XEmitter::MOVQ_xmm(X64Reg dest, OpArg arg)
 {
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 		// Alternate encoding
 		// This does not display correctly in MSVC's debugger, it thinks it's a MOVD
 		arg.operandReg = dest;

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -1057,7 +1057,7 @@ public:
 	void ABI_EmitPrologue(int maxCallParams);
 	void ABI_EmitEpilogue(int maxCallParams);
 
-	#ifdef _M_IX86
+	#if PPSSPP_ARCH(X86)
 	inline int ABI_GetNumXMMRegs() { return 8; }
 	#else
 	inline int ABI_GetNumXMMRegs() { return 16; }
@@ -1075,7 +1075,7 @@ public:
 	bool RipAccessible(const void *ptr) const {
 		// For debugging
 		// return false;
-#ifdef _M_IX86
+#if PPSSPP_ARCH(X86)
 		return true;
 #else
 		ptrdiff_t diff = GetCodePtr() - (const uint8_t *)ptr;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -988,7 +988,7 @@ static ConfigSetting networkSettings[] = {
 
 static int DefaultPSPModel() {
 	// TODO: Can probably default this on, but not sure about its memory differences.
-#if !defined(_M_X64) && !defined(_WIN32)
+#if !PPSSPP_ARCH(AMD64) && !defined(_WIN32)
 	return PSP_MODEL_FAT;
 #else
 	return PSP_MODEL_SLIM;

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include <string>
 #include <algorithm>
 #include <map>
@@ -43,7 +44,7 @@ bool isInInterval(u32 start, u32 size, u32 value)
 
 static HashType computeHash(u32 address, u32 size)
 {
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 	return XXH3_64bits(Memory::GetPointer(address), size);
 #else
 	return XXH3_64bits(Memory::GetPointer(address), size) & 0xFFFFFFFF;

--- a/Core/Debugger/DisassemblyManager.h
+++ b/Core/Debugger/DisassemblyManager.h
@@ -17,12 +17,13 @@
 
 #pragma once
 
+#include "ppsspp_config.h"
 #include <mutex>
 #include "Common/CommonTypes.h"
 #include "Core/Debugger/SymbolMap.h"
 #include "Core/MIPS/MIPSAnalyst.h"
 
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 typedef u64 HashType;
 #else
 typedef u32 HashType;

--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -21,6 +21,7 @@
 #pragma optimize("gty", on)
 #endif
 
+#include "ppsspp_config.h"
 #ifdef _WIN32
 #include "Common/CommonWindows.h"
 #include <WindowsX.h>

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include <algorithm>
 
 #include "Common/Data/Text/I18n.h"

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include <algorithm>
 #include <map>
 #include <unordered_map>
@@ -39,7 +40,7 @@
 #include "GPU/GPUInterface.h"
 #include "GPU/GPUState.h"
 
-#if defined(_M_IX86) || defined(_M_X64)
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 #include <emmintrin.h>
 #endif
 
@@ -451,7 +452,7 @@ static int Replace_gta_dl_write_matrix() {
 		return 38;
 	}
 
-#if defined(_M_IX86) || defined(_M_X64)
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 	__m128i topBytes = _mm_set1_epi32(matrix);
 	__m128i m0 = _mm_loadu_si128((const __m128i *)src);
 	__m128i m1 = _mm_loadu_si128((const __m128i *)(src + 4));
@@ -533,7 +534,7 @@ static int Replace_dl_write_matrix() {
 	if (count == 16) {
 		// Ultra SIMD friendly! These intrinsics generate pretty much perfect code,
 		// no point in hand rolling.
-#if defined(_M_IX86) || defined(_M_X64)
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 		__m128i topBytes = _mm_set1_epi32(matrix);
 		__m128i m0 = _mm_loadu_si128((const __m128i *)src);
 		__m128i m1 = _mm_loadu_si128((const __m128i *)(src + 4));
@@ -569,7 +570,7 @@ static int Replace_dl_write_matrix() {
 		}
 #endif
 	} else {
-#if defined(_M_IX86) || defined(_M_X64)
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 		__m128i topBytes = _mm_set1_epi32(matrix);
 		__m128i m0 = _mm_loadu_si128((const __m128i *)src);
 		__m128i m1 = _mm_loadu_si128((const __m128i *)(src + 4));

--- a/Core/HLE/sceUsbMic.cpp
+++ b/Core/HLE/sceUsbMic.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include <algorithm>
 #include <mutex>
 

--- a/Core/HW/Camera.cpp
+++ b/Core/HW/Camera.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include "Camera.h"
 #include "Core/Config.h"
 

--- a/Core/HW/StereoResampler.cpp
+++ b/Core/HW/StereoResampler.cpp
@@ -32,6 +32,7 @@
 #define CONTROL_FACTOR  0.2f // in freq_shift per fifo size offset
 #define CONTROL_AVG     32.0f
 
+#include "ppsspp_config.h"
 #include <cstring>
 #include <atomic>
 

--- a/Core/Instance.cpp
+++ b/Core/Instance.cpp
@@ -15,7 +15,8 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include "Instance.h"
+#include "ppsspp_config.h"
+#include "Core/Instance.h"
 
 #if !PPSSPP_PLATFORM(WINDOWS) && !PPSSPP_PLATFORM(ANDROID) && !defined(__LIBRETRO__)
 #include <unistd.h>

--- a/Core/MIPS/ARM/ArmAsm.cpp
+++ b/Core/MIPS/ARM/ArmAsm.cpp
@@ -213,7 +213,7 @@ void ArmJit::GenerateFixedCode() {
 				// IDEA - we have 26 bits, why not just use offsets from base of code?
 				// Another idea: Shift the bloc number left by two in the op, this would let us do
 				// LDR(R0, R9, R0); here, replacing the next instructions.
-#ifdef IOS
+#if PPSSPP_PLATFORM(IOS)
 				// On iOS, R9 (JITBASEREG) is volatile.  We have to reload it.
 				MOVI2R(JITBASEREG, (u32)(uintptr_t)GetBasePtr());
 #endif

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -476,7 +476,7 @@ void ArmJit::UnlinkBlock(u8 *checkedEntry, u32 originalAddress) {
 }
 
 bool ArmJit::ReplaceJalTo(u32 dest) {
-#ifdef ARM
+#if PPSSPP_ARCH(ARM)
 	const ReplacementTableEntry *entry = nullptr;
 	u32 funcSize = 0;
 	if (!CanReplaceJalTo(dest, &entry, &funcSize)) {

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -15,13 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-// Enable define below to enable oprofile integration. For this to work,
-// it requires at least oprofile version 0.9.4, and changing the build
-// system to link the Dolphin executable against libopagent.	Since the
-// dependency is a little inconvenient and this is possibly a slight
-// performance hit, it's not enabled by default, but it's useful for
-// locating performance issues.
-
+#include "ppsspp_config.h"
 #include <cstddef>
 #include <algorithm>
 
@@ -45,6 +39,12 @@
 
 // #include "JitBase.h"
 
+// Enable define below to enable oprofile integration. For this to work,
+// it requires at least oprofile version 0.9.4, and changing the build
+// system to link the Dolphin executable against libopagent.	Since the
+// dependency is a little inconvenient and this is possibly a slight
+// performance hit, it's not enabled by default, but it's useful for
+// locating performance issues.
 #if defined USE_OPROFILE && USE_OPROFILE
 #include <opagent.h>
 

--- a/Core/MIPS/JitCommon/JitCommon.cpp
+++ b/Core/MIPS/JitCommon/JitCommon.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include <cstdlib>
 
 #include "ext/disarm.h"

--- a/Core/MIPS/JitCommon/JitState.cpp
+++ b/Core/MIPS/JitCommon/JitState.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include "Common/CPUDetect.h"
 #include "Core/Config.h"
 #include "Core/MIPS/JitCommon/JitState.h"

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include <map>
 #include <set>
 #include <unordered_map>
@@ -760,7 +761,7 @@ namespace MIPSAnalyst {
 		std::lock_guard<std::recursive_mutex> guard(functions_lock);
 		hashToFunction.clear();
 		// Really need to detect C++11 features with better defines.
-#if !defined(IOS)
+#if !PPSSPP_PLATFORM(IOS)
 		hashToFunction.reserve(functions.size());
 #endif
 		for (auto iter = functions.begin(); iter != functions.end(); iter++) {

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -74,11 +74,7 @@ static inline void SkipLikely()
 
 int MIPS_SingleStep()
 {
-#if defined(ARM)
-	MIPSOpcode op = MIPSOpcode(Memory::ReadUnchecked_U32(mipsr4k.pc));
-#else
 	MIPSOpcode op = Memory::Read_Opcode_JIT(mipsr4k.pc);
-#endif
 	if (mipsr4k.inDelaySlot) {
 		MIPSInterpret(op);
 		if (mipsr4k.inDelaySlot) {

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -111,7 +111,7 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 
 	enterDispatcher = AlignCode16();
 	ABI_PushAllCalleeSavedRegsAndAdjustStack();
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 	// Two statically allocated registers.
 	MOV(64, R(MEMBASEREG), ImmPtr(Memory::base));
 	uintptr_t jitbase = (uintptr_t)GetBasePtr();
@@ -162,10 +162,10 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 			AND(32, R(EAX), Imm32(Memory::MEMVIEW32_MASK));
 #endif
 			dispatcherFetch = GetCodePtr();
-#ifdef _M_IX86
+#if PPSSPP_ARCH(X86)
 			_assert_msg_( Memory::base != 0, "Memory base bogus");
 			MOV(32, R(EAX), MDisp(EAX, (u32)Memory::base));
-#elif _M_X64
+#elif PPSSPP_ARCH(AMD64)
 			MOV(32, R(EAX), MComplex(MEMBASEREG, RAX, SCALE_1, 0));
 #endif
 			MOV(32, R(EDX), R(EAX));
@@ -178,9 +178,9 @@ void Jit::GenerateFixedCode(JitOptions &jo) {
 				}
 				//grab from list and jump to it
 				AND(32, R(EAX), Imm32(MIPS_EMUHACK_VALUE_MASK));
-#ifdef _M_IX86
+#if PPSSPP_ARCH(X86)
 				ADD(32, R(EAX), ImmPtr(GetBasePtr()));
-#elif _M_X64
+#elif PPSSPP_ARCH(AMD64)
 				if (jo.reserveR15ForAsm)
 					ADD(64, R(RAX), R(JITBASEREG));
 				else

--- a/Core/MIPS/x86/CompALU.cpp
+++ b/Core/MIPS/x86/CompALU.cpp
@@ -53,7 +53,7 @@ namespace MIPSComp
 	using namespace X64JitConstants;
 
 	static bool HasLowSubregister(OpArg arg) {
-#ifndef _M_X64
+#if !PPSSPP_ARCH(AMD64)
 		// Can't use ESI or EDI (which we use), no 8-bit versions.  Only these.
 		if (!arg.IsSimpleReg(EAX) && !arg.IsSimpleReg(EBX) && !arg.IsSimpleReg(ECX) && !arg.IsSimpleReg(EDX)) {
 			return false;

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -94,7 +94,7 @@ namespace MIPSComp {
 			gpr.MapReg(rt, true, false);
 		}
 
-#ifdef _M_IX86
+#if PPSSPP_ARCH(X86)
 		// We use EDX so we can have DL for 8-bit ops.
 		const bool needSwap = bits == 8 && !gpr.R(rt).IsSimpleReg(EDX) && !gpr.R(rt).IsSimpleReg(ECX);
 		if (needSwap)
@@ -144,7 +144,7 @@ namespace MIPSComp {
 
 		X64Reg shiftReg = ECX;
 		gpr.FlushLockX(ECX, EDX);
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 		// On x64, we need ECX for CL, but it's also the first arg and gets lost.  Annoying.
 		gpr.FlushLockX(R9);
 		shiftReg = R9;

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -324,7 +324,7 @@ void Jit::Comp_SVQ(MIPSOpcode op) {
 			FixupBranch next = J_CC(CC_NE);
 
 			auto PSPMemAddr = [](X64Reg scaled, int offset) {
-#ifdef _M_IX86
+#if PPSSPP_ARCH(X86)
 				return MDisp(scaled, (u32)Memory::base + offset);
 #else
 				return MComplex(MEMBASEREG, scaled, 1, offset);
@@ -2164,7 +2164,7 @@ union u32float {
 	}
 };
 
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 typedef float SinCosArg;
 #else
 typedef u32float SinCosArg;
@@ -2202,7 +2202,7 @@ void Jit::Comp_VV2Op(MIPSOpcode op) {
 		DISABLE;
 
 	auto trigCallHelper = [this](void (*sinCosFunc)(SinCosArg, float *output), u8 sreg) {
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 		MOVSS(XMM0, fpr.V(sreg));
 		// TODO: This reg might be different on Linux...
 #ifdef _WIN32
@@ -2910,7 +2910,7 @@ void Jit::Comp_Vmmul(MIPSOpcode op) {
 			// Map the D column.
 			u8 dcol[4];
 			GetVectorRegs(dcol, vsz, dcols[i]);
-#ifndef _M_X64
+#if !PPSSPP_ARCH(AMD64)
 			fpr.MapRegsVS(dcol, vsz, MAP_DIRTY | MAP_NOINIT | MAP_NOLOCK);
 #else
 			fpr.MapRegsVS(dcol, vsz, MAP_DIRTY | MAP_NOINIT);
@@ -2923,7 +2923,7 @@ void Jit::Comp_Vmmul(MIPSOpcode op) {
 			}
 		}
 
-#ifndef _M_X64
+#if !PPSSPP_ARCH(AMD64)
 		fpr.ReleaseSpillLocks();
 #endif
 		if (transposeDest) {
@@ -3566,7 +3566,7 @@ void Jit::Comp_VRot(MIPSOpcode op) {
 
 	bool negSin1 = (imm & 0x10) ? true : false;
 
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 #ifdef _WIN32
 	LEA(64, RDX, MIPSSTATE_VAR(sincostemp));
 #else

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -216,7 +216,7 @@ void Jit::ClearCache()
 
 void Jit::SaveFlags() {
 	PUSHF();
-#if defined(_M_X64)
+#if PPSSPP_ARCH(AMD64)
 	// On X64, the above misaligns the stack. However there might be a cheaper solution than this.
 	POP(64, R(EAX));
 	MOV(64, MIPSSTATE_VAR(saved_flags), R(EAX));
@@ -224,7 +224,7 @@ void Jit::SaveFlags() {
 }
 
 void Jit::LoadFlags() {
-#if defined(_M_X64)
+#if PPSSPP_ARCH(AMD64)
 	MOV(64, R(EAX), MIPSSTATE_VAR(saved_flags));
 	PUSH(64, R(EAX));
 #endif

--- a/Core/MIPS/x86/RegCache.cpp
+++ b/Core/MIPS/x86/RegCache.cpp
@@ -34,18 +34,18 @@ using namespace X64JitConstants;
 static const X64Reg allocationOrder[] = {
 	// R12, when used as base register, for example in a LEA, can generate bad code! Need to look into this.
 	// On x64, RCX and RDX are the first args.  CallProtectedFunction() assumes they're not regcached.
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 #ifdef _WIN32
 	RSI, RDI, R8, R9, R10, R11, R12, R13,
 #else
 	RBP, R8, R9, R10, R11, R12, R13,
 #endif
-#elif _M_IX86
+#elif PPSSPP_ARCH(X86)
 	ESI, EDI, EDX, ECX, EBX,
 #endif
 };
 
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 static X64Reg allocationOrderR15[ARRAY_SIZE(allocationOrder) + 1] = {INVALID_REG};
 #endif
 
@@ -58,7 +58,7 @@ GPRRegCache::GPRRegCache() {
 }
 
 void GPRRegCache::Start(MIPSState *mipsState, MIPSComp::JitState *js, MIPSComp::JitOptions *jo, MIPSAnalyst::AnalysisResults &stats) {
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 	if (allocationOrderR15[0] == INVALID_REG) {
 		memcpy(allocationOrderR15, allocationOrder, sizeof(allocationOrder));
 		allocationOrderR15[ARRAY_SIZE(allocationOrderR15) - 1] = R15;
@@ -305,7 +305,7 @@ u32 GPRRegCache::GetImm(MIPSGPReg preg) const {
 }
 
 const X64Reg *GPRRegCache::GetAllocationOrder(int &count) {
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 	if (!jo_->reserveR15ForAsm) {
 		count = ARRAY_SIZE(allocationOrderR15);
 		return allocationOrderR15;

--- a/Core/MIPS/x86/RegCache.h
+++ b/Core/MIPS/x86/RegCache.h
@@ -17,12 +17,13 @@
 
 #pragma once
 
+#include "ppsspp_config.h"
 #include "Common/x64Emitter.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSAnalyst.h"
 
 namespace X64JitConstants {
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 	const Gen::X64Reg MEMBASEREG = Gen::RBX;
 	const Gen::X64Reg CTXREG = Gen::R14;
 	const Gen::X64Reg JITBASEREG = Gen::R15;
@@ -34,9 +35,9 @@ namespace X64JitConstants {
 	const Gen::X64Reg TEMPREG = Gen::EAX;
 	const int NUM_MIPS_GPRS = 36;
 
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 	const u32 NUM_X_REGS = 16;
-#elif _M_IX86
+#elif PPSSPP_ARCH(X86)
 	const u32 NUM_X_REGS = 8;
 #endif
 }

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -1020,9 +1020,9 @@ int FPURegCache::SanityCheck() const {
 
 const int *FPURegCache::GetAllocationOrder(int &count) {
 	static const int allocationOrder[] = {
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 		XMM6, XMM7, XMM8, XMM9, XMM10, XMM11, XMM12, XMM13, XMM14, XMM15, XMM2, XMM3, XMM4, XMM5
-#elif _M_IX86
+#elif PPSSPP_ARCH(X86)
 		XMM2, XMM3, XMM4, XMM5, XMM6, XMM7,
 #endif
 	};

--- a/Core/MIPS/x86/RegCacheFPU.h
+++ b/Core/MIPS/x86/RegCacheFPU.h
@@ -43,14 +43,16 @@
 // take into account in which XMM registers the values are. Fallback: Just dump out the values
 // and do it the old way.
 
+#include "ppsspp_config.h"
+
 enum {
 	TEMP0 = 32 + 128,
 	NUM_MIPS_FPRS = 32 + 128 + NUM_X86_FPU_TEMPS,
 };
 
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 #define NUM_X_FPREGS 16
-#elif _M_IX86
+#elif PPSSPP_ARCH(X86)
 #define NUM_X_FPREGS 8
 #endif
 

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -129,7 +129,7 @@ inline static bool CanIgnoreView(const MemoryView &view) {
 #endif
 }
 
-#if defined(IOS) && PPSSPP_ARCH(64BIT)
+#if PPSSPP_PLATFORM(IOS) && PPSSPP_ARCH(64BIT)
 #define SKIP(a_flags, b_flags) \
 	if ((b_flags) & MV_KERNEL) \
 		continue;

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include <deque>
 #include <thread>
 #include <mutex>
@@ -301,7 +302,7 @@ namespace Reporting
 		return "Windows ARM32";
 #elif defined(_WIN32)
 		return "Windows";
-#elif defined(IOS)
+#elif PPSSPP_PLATFORM(IOS)
 		return "iOS";
 #elif defined(__APPLE__)
 		return "Mac";

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -230,7 +230,7 @@ bool CPU_Init() {
 
 	std::string filename = coreParameter.fileToStart;
 	loadedFile = ResolveFileLoaderTarget(ConstructFileLoader(filename));
-#ifdef _M_X64
+#if PPSSPP_ARCH(AMD64)
 	if (g_Config.bCacheFullIsoInRam) {
 		loadedFile = new RamCachingFileLoader(loadedFile);
 	}
@@ -392,9 +392,9 @@ bool PSP_InitStart(const CoreParameter &coreParam, std::string *error_string) {
 		return false;
 	}
 
-#if defined(_WIN32) && defined(_M_X64)
+#if defined(_WIN32) && PPSSPP_ARCH(AMD64)
 	INFO_LOG(BOOT, "PPSSPP %s Windows 64 bit", PPSSPP_GIT_VERSION);
-#elif defined(_WIN32) && !defined(_M_X64)
+#elif defined(_WIN32) && !PPSSPP_ARCH(AMD64)
 	INFO_LOG(BOOT, "PPSSPP %s Windows 32 bit", PPSSPP_GIT_VERSION);
 #else
 	INFO_LOG(BOOT, "PPSSPP %s", PPSSPP_GIT_VERSION);

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -15,9 +15,9 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include <png.h>
-
+#include "ppsspp_config.h"
 #include <algorithm>
+#include <png.h>
 
 #include "ext/xxhash.h"
 

--- a/Core/Util/AudioFormat.cpp
+++ b/Core/Util/AudioFormat.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include "Common/Common.h"
 #include "Common/CPUDetect.h"
 #include "Core/Util/AudioFormat.h"

--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include "ext/xxhash.h"
 #include "Common/CPUDetect.h"
 #include "Common/ColorConv.h"

--- a/GPU/Common/TextureDecoderNEON.cpp
+++ b/GPU/Common/TextureDecoderNEON.cpp
@@ -41,7 +41,7 @@ u32 QuickTexHashNEON(const void *checkp, u32 size) {
 	__builtin_prefetch(checkp, 0, 0);
 
 	if (((intptr_t)checkp & 0xf) == 0 && (size & 0x3f) == 0) {
-#if defined(IOS) || PPSSPP_ARCH(ARM64) || defined(_MSC_VER) || !PPSSPP_ARCH(ARMV7)
+#if PPSSPP_PLATFORM(IOS) || PPSSPP_ARCH(ARM64) || defined(_MSC_VER) || !PPSSPP_ARCH(ARMV7)
 		uint32x4_t cursor = vdupq_n_u32(0);
 		uint16x8_t cursor2 = vld1q_u16(QuickTexHashInitial);
 		uint16x8_t update = vdupq_n_u16(0x2455U);

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -1377,7 +1377,7 @@ VertexDecoderJitCache::VertexDecoderJitCache()
 	AllocCodeSpace(1024 * 64 * 4);
 
 	// Add some random code to "help" MSVC's buggy disassembler :(
-#if defined(_WIN32) && (defined(_M_IX86) || defined(_M_X64))
+#if defined(_WIN32) && (PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64))
 	using namespace Gen;
 	for (int i = 0; i < 100; i++) {
 		MOV(32, R(EAX), R(EBX));

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -1383,7 +1383,7 @@ VertexDecoderJitCache::VertexDecoderJitCache()
 		MOV(32, R(EAX), R(EBX));
 		RET();
 	}
-#elif defined(ARM)
+#elif PPSSPP_ARCH(ARM)
 	BKPT(0);
 	BKPT(0);
 #endif

--- a/GPU/Common/VertexDecoderFake.cpp
+++ b/GPU/Common/VertexDecoderFake.cpp
@@ -18,6 +18,7 @@
 //TODO: Doesn't build, FIXME!
 #if 0
 
+#include "ppsspp_config.h"
 #include "Common/CPUDetect.h"
 #include "Core/Config.h"
 #include "Core/Reporting.h"
@@ -28,7 +29,7 @@ static const float by128 = 1.0f / 128.0f;
 static const float by16384 = 1.0f / 16384.0f;
 static const float by32768 = 1.0f / 32768.0f;
 
-#ifdef MIPS
+#if PPSSPP_ARCH(MIPS)
 using namespace MIPSGen;
 #else
 using namespace FakeGen;

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -19,7 +19,7 @@
 // Alpha/stencil is a convoluted mess. Some good comments are here:
 // https://github.com/hrydgard/ppsspp/issues/3768
 
-
+#include "ppsspp_config.h"
 #include "StateMappingGLES.h"
 #include "Common/Profiler/Profiler.h"
 #include "Common/GPU/OpenGL/GLDebugLog.h"
@@ -58,7 +58,7 @@ static const GLushort glBlendFactorLookup[(size_t)BlendFactor::COUNT] = {
 	GL_ONE_MINUS_SRC1_COLOR,
 	GL_SRC1_ALPHA,
 	GL_ONE_MINUS_SRC1_ALPHA,
-#elif !defined(IOS)
+#elif !PPSSPP_PLATFORM(IOS)
 	GL_SRC1_COLOR_EXT,
 	GL_ONE_MINUS_SRC1_COLOR_EXT,
 	GL_SRC1_ALPHA_EXT,

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1,3 +1,4 @@
+#include "ppsspp_config.h"
 #include <algorithm>
 #include <type_traits>
 #include <mutex>

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ppsspp_config.h"
 #include "Common/Common.h"
 #include "Common/MemoryUtil.h"
 #include "GPU/GPUInterface.h"

--- a/GPU/GPUState.cpp
+++ b/GPU/GPUState.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include "GPU/ge_constants.h"
 #include "GPU/GPUState.h"
 

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include <algorithm>
 #include <cmath>
 
@@ -39,7 +40,7 @@
 namespace Rasterizer {
 
 // Only OK on x64 where our stack is aligned
-#if defined(_M_SSE) && !defined(_M_IX86)
+#if defined(_M_SSE) && !PPSSPP_ARCH(X86)
 static inline __m128 Interpolate(const __m128 &c0, const __m128 &c1, const __m128 &c2, int w0, int w1, int w2, float wsum) {
 	__m128 v = _mm_mul_ps(c0, _mm_cvtepi32_ps(_mm_set1_epi32(w0)));
 	v = _mm_add_ps(v, _mm_mul_ps(c1, _mm_cvtepi32_ps(_mm_set1_epi32(w1))));
@@ -56,7 +57,7 @@ static inline __m128i Interpolate(const __m128i &c0, const __m128i &c1, const __
 // Not sure if that should be regarded as a bug or if casting to float is a valid fix.
 
 static inline Vec4<int> Interpolate(const Vec4<int> &c0, const Vec4<int> &c1, const Vec4<int> &c2, int w0, int w1, int w2, float wsum) {
-#if defined(_M_SSE) && !defined(_M_IX86)
+#if defined(_M_SSE) && !PPSSPP_ARCH(X86)
 	return Vec4<int>(Interpolate(c0.ivec, c1.ivec, c2.ivec, w0, w1, w2, wsum));
 #else
 	return ((c0.Cast<float>() * w0 + c1.Cast<float>() * w1 + c2.Cast<float>() * w2) * wsum).Cast<int>();
@@ -64,7 +65,7 @@ static inline Vec4<int> Interpolate(const Vec4<int> &c0, const Vec4<int> &c1, co
 }
 
 static inline Vec3<int> Interpolate(const Vec3<int> &c0, const Vec3<int> &c1, const Vec3<int> &c2, int w0, int w1, int w2, float wsum) {
-#if defined(_M_SSE) && !defined(_M_IX86)
+#if defined(_M_SSE) && !PPSSPP_ARCH(X86)
 	return Vec3<int>(Interpolate(c0.ivec, c1.ivec, c2.ivec, w0, w1, w2, wsum));
 #else
 	return ((c0.Cast<float>() * w0 + c1.Cast<float>() * w1 + c2.Cast<float>() * w2) * wsum).Cast<int>();
@@ -72,7 +73,7 @@ static inline Vec3<int> Interpolate(const Vec3<int> &c0, const Vec3<int> &c1, co
 }
 
 static inline Vec2<float> Interpolate(const Vec2<float> &c0, const Vec2<float> &c1, const Vec2<float> &c2, int w0, int w1, int w2, float wsum) {
-#if defined(_M_SSE) && !defined(_M_IX86)
+#if defined(_M_SSE) && !PPSSPP_ARCH(X86)
 	return Vec2<float>(Interpolate(c0.vec, c1.vec, c2.vec, w0, w1, w2, wsum));
 #else
 	return (c0 * w0 + c1 * w1 + c2 * w2) * wsum;
@@ -80,7 +81,7 @@ static inline Vec2<float> Interpolate(const Vec2<float> &c0, const Vec2<float> &
 }
 
 static inline Vec4<float> Interpolate(const float &c0, const float &c1, const float &c2, const Vec4<float> &w0, const Vec4<float> &w1, const Vec4<float> &w2, const Vec4<float> &wsum_recip) {
-#if defined(_M_SSE) && !defined(_M_IX86)
+#if defined(_M_SSE) && !PPSSPP_ARCH(X86)
 	__m128 v = _mm_mul_ps(w0.vec, _mm_set1_ps(c0));
 	v = _mm_add_ps(v, _mm_mul_ps(w1.vec, _mm_set1_ps(c1)));
 	v = _mm_add_ps(v, _mm_mul_ps(w2.vec, _mm_set1_ps(c2)));
@@ -1083,7 +1084,7 @@ Vec4<int> TriangleEdge::Start(const ScreenCoords &v0, const ScreenCoords &v1, co
 }
 
 inline Vec4<int> TriangleEdge::StepX(const Vec4<int> &w) {
-#if defined(_M_SSE) && !defined(_M_IX86)
+#if defined(_M_SSE) && !PPSSPP_ARCH(X86)
 	return _mm_add_epi32(w.ivec, stepX.ivec);
 #else
 	return w + stepX;
@@ -1091,7 +1092,7 @@ inline Vec4<int> TriangleEdge::StepX(const Vec4<int> &w) {
 }
 
 inline Vec4<int> TriangleEdge::StepY(const Vec4<int> &w) {
-#if defined(_M_SSE) && !defined(_M_IX86)
+#if defined(_M_SSE) && !PPSSPP_ARCH(X86)
 	return _mm_add_epi32(w.ivec, stepY.ivec);
 #else
 	return w + stepY;
@@ -1099,7 +1100,7 @@ inline Vec4<int> TriangleEdge::StepY(const Vec4<int> &w) {
 }
 
 static inline Vec4<int> MakeMask(const Vec4<int> &w0, const Vec4<int> &w1, const Vec4<int> &w2, const Vec4<int> &bias0, const Vec4<int> &bias1, const Vec4<int> &bias2, const Vec4<int> &scissor) {
-#if defined(_M_SSE) && !defined(_M_IX86)
+#if defined(_M_SSE) && !PPSSPP_ARCH(X86)
 	__m128i biased0 = _mm_add_epi32(w0.ivec, bias0.ivec);
 	__m128i biased1 = _mm_add_epi32(w1.ivec, bias1.ivec);
 	__m128i biased2 = _mm_add_epi32(w2.ivec, bias2.ivec);
@@ -1111,7 +1112,7 @@ static inline Vec4<int> MakeMask(const Vec4<int> &w0, const Vec4<int> &w1, const
 }
 
 static inline bool AnyMask(const Vec4<int> &mask) {
-#if defined(_M_SSE) && !defined(_M_IX86)
+#if defined(_M_SSE) && !PPSSPP_ARCH(X86)
 	// In other words: !(mask.x < 0 && mask.y < 0 && mask.z < 0 && mask.w < 0)
 	__m128i low2 = _mm_and_si128(mask.ivec, _mm_shuffle_epi32(mask.ivec, _MM_SHUFFLE(3, 2, 3, 2)));
 	__m128i low1 = _mm_and_si128(low2, _mm_shuffle_epi32(low2, _MM_SHUFFLE(1, 1, 1, 1)));
@@ -1123,7 +1124,7 @@ static inline bool AnyMask(const Vec4<int> &mask) {
 }
 
 static inline Vec4<float> EdgeRecip(const Vec4<int> &w0, const Vec4<int> &w1, const Vec4<int> &w2) {
-#if defined(_M_SSE) && !defined(_M_IX86)
+#if defined(_M_SSE) && !PPSSPP_ARCH(X86)
 	__m128i wsum = _mm_add_epi32(w0.ivec, _mm_add_epi32(w1.ivec, w2.ivec));
 	// _mm_rcp_ps loses too much precision.
 	return _mm_div_ps(_mm_set1_ps(1.0f), _mm_cvtepi32_ps(wsum));

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -89,7 +89,7 @@ SamplerJitCache::SamplerJitCache()
 	AllocCodeSpace(1024 * 64 * 4);
 
 	// Add some random code to "help" MSVC's buggy disassembler :(
-#if defined(_WIN32) && (defined(_M_IX86) || defined(_M_X64)) && !PPSSPP_PLATFORM(UWP)
+#if defined(_WIN32) && (PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)) && !PPSSPP_PLATFORM(UWP)
 	using namespace Gen;
 	for (int i = 0; i < 100; i++) {
 		MOV(32, R(EAX), R(EBX));
@@ -215,7 +215,7 @@ NearestFunc SamplerJitCache::GetNearest(const SamplerID &id) {
 		Clear();
 	}
 
-#if defined(_M_X64) && !PPSSPP_PLATFORM(UWP)
+#if PPSSPP_ARCH(AMD64) && !PPSSPP_PLATFORM(UWP)
 	addresses_[id] = GetCodePointer();
 	NearestFunc func = Compile(id);
 	cache_[id] = func;
@@ -238,8 +238,7 @@ LinearFunc SamplerJitCache::GetLinear(const SamplerID &id) {
 		Clear();
 	}
 
-	// TODO
-#if defined(_M_X64) && !PPSSPP_PLATFORM(UWP)
+#if PPSSPP_ARCH(AMD64) && !PPSSPP_PLATFORM(UWP)
 	addresses_[id] = GetCodePointer();
 	LinearFunc func = CompileLinear(id);
 	cache_[id] = (NearestFunc)func;

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -95,7 +95,7 @@ SamplerJitCache::SamplerJitCache()
 		MOV(32, R(EAX), R(EBX));
 		RET();
 	}
-#elif defined(ARM)
+#elif PPSSPP_ARCH(ARM)
 	BKPT(0);
 	BKPT(0);
 #endif

--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -1,4 +1,5 @@
 // Qt Desktop UI: works on Linux, Windows and Mac OSX
+#include "ppsspp_config.h"
 #include "mainwindow.h"
 
 #include <QApplication>

--- a/SDL/SDLCocoaMetalLayer.mm
+++ b/SDL/SDLCocoaMetalLayer.mm
@@ -1,4 +1,5 @@
-#if defined(PPSSPP_PLATFORM_MAC)
+#include "ppsspp_config.h"
+#if PPSSPP_PLATFORM(MAC)
 #import <Cocoa/Cocoa.h>
 #else
 #import <UIKit/UIKit.h>
@@ -9,7 +10,7 @@
 
 void *makeWindowMetalCompatible(void *window) {
 	// https://github.com/KhronosGroup/MoltenVK/issues/78#issuecomment-371118536
-#if defined(PPSSPP_PLATFORM_MAC)
+#if PPSSPP_PLATFORM(MAC)
 	NSView *view = ((NSWindow *)window).contentView;
 	assert([view isKindOfClass:[NSView class]]);
 

--- a/SDL/SDLVulkanGraphicsContext.cpp
+++ b/SDL/SDLVulkanGraphicsContext.cpp
@@ -1,3 +1,4 @@
+#include "ppsspp_config.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
 #include "Common/System/System.h"
@@ -93,7 +94,7 @@ bool SDLVulkanGraphicsContext::Init(SDL_Window *&window, int x, int y, int mode,
 		break;
 #endif
 #if defined(VK_USE_PLATFORM_METAL_EXT)
-#if defined(PPSSPP_PLATFORM_MAC)
+#if PPSSPP_PLATFORM(MAC)
 	case SDL_SYSWM_COCOA:
 		vulkan_->InitSurface(WINDOWSYSTEM_METAL_EXT, makeWindowMetalCompatible(sys_info.info.cocoa.window), nullptr);
 		break;

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include <algorithm>
 #include <deque>
 #include <mutex>

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include "ext/xxhash.h"
 #include "Common/UI/UI.h"
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -977,7 +977,7 @@ void GameSettingsScreen::CreateViews() {
 	}
 #endif
 
-#if defined(_M_X64)
+#if PPSSPP_ARCH(AMD64)
 	systemSettings->Add(new CheckBox(&g_Config.bCacheFullIsoInRam, sy->T("Cache ISO in RAM", "Cache full ISO in RAM")))->SetEnabled(!PSP_IsInited());
 #endif
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -133,7 +133,7 @@ Atlas g_ui_atlas;
 #include "../../android/jni/Arm64EmitterTest.h"
 #endif
 
-#ifdef IOS
+#if PPSSPP_PLATFORM(IOS)
 #include "ios/iOSCoreAudio.h"
 #elif defined(__APPLE__)
 #include <mach-o/dyld.h>
@@ -211,13 +211,13 @@ static LogListener *logger = nullptr;
 std::string boot_filename = "";
 
 void NativeHost::InitSound() {
-#ifdef IOS
+#if PPSSPP_PLATFORM(IOS)
 	iOSCoreAudioInit();
 #endif
 }
 
 void NativeHost::ShutdownSound() {
-#ifdef IOS
+#if PPSSPP_PLATFORM(IOS)
 	iOSCoreAudioShutdown();
 #endif
 }
@@ -323,7 +323,7 @@ static void PostLoadConfig() {
 	if (g_Config.currentDirectory.empty()) {
 #if defined(__ANDROID__)
 		g_Config.currentDirectory = g_Config.externalDirectory;
-#elif defined(IOS)
+#elif PPSSPP_PLATFORM(IOS)
 		g_Config.currentDirectory = g_Config.internalDataDirectory;
 #elif PPSSPP_PLATFORM(SWITCH)
 		g_Config.currentDirectory = "/";
@@ -454,12 +454,12 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	std::string user_data_path = savegame_dir;
 	pendingMessages.clear();
 	pendingInputBoxes.clear();
-#ifdef IOS
+#if PPSSPP_PLATFORM(IOS)
 	user_data_path += "/";
 #endif
 
 	// We want this to be FIRST.
-#if defined(IOS)
+#if PPSSPP_PLATFORM(IOS)
 	// Packed assets are included in app
 	VFSRegister("", new DirectoryAssetReader(external_dir));
 #endif
@@ -508,7 +508,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 			g_Config.memStickDirectory = memstickDir + "/";
 		}
 	}
-#elif defined(IOS)
+#elif PPSSPP_PLATFORM(IOS)
 	g_Config.memStickDirectory = user_data_path;
 	g_Config.flash0Directory = std::string(external_dir) + "/flash0/";
 #elif PPSSPP_PLATFORM(SWITCH)

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -1,3 +1,4 @@
+#include "ppsspp_config.h"
 #include <map>
 #include <string>
 #include <sstream>

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -497,7 +497,7 @@ static void WinMainInit() {
 #endif
 	PROFILE_INIT();
 
-#if defined(_M_X64) && defined(_MSC_VER) && _MSC_VER < 1900
+#if PPSSPP_ARCH(AMD64) && defined(_MSC_VER) && _MSC_VER < 1900
 	// FMA3 support in the 2013 CRT is broken on Vista and Windows 7 RTM (fixed in SP1). Just disable it.
 	_set_FMA3_enable(0);
 #endif

--- a/Windows/main.h
+++ b/Windows/main.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "ppsspp_config.h"
 #include "Debugger/Debugger_Disasm.h"
 #include "Debugger/Debugger_MemoryDlg.h"
 #include "Common/CommonWindows.h"

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -627,10 +627,6 @@ LOCAL_SRC_FILES := \
   $(SRC)/UI/TextureUtil.cpp \
   $(SRC)/UI/ComboKeyMappingScreen.cpp
 
-ifeq ($(findstring armeabi-v7a,$(TARGET_ARCH_ABI)),armeabi-v7a)
-LOCAL_CFLAGS := $(LOCAL_CFLAGS) -DARM
-endif
-
 ifneq ($(SKIPAPP),1)
   include $(BUILD_SHARED_LIBRARY)
 endif

--- a/android/jni/Locals.mk
+++ b/android/jni/Locals.mk
@@ -38,7 +38,7 @@ ifeq ($(findstring armeabi-v7a,$(TARGET_ARCH_ABI)),armeabi-v7a)
   LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv7/lib/libavutil.a
   LOCAL_C_INCLUDES += $(LOCAL_PATH)/../../ffmpeg/android/armv7/include
 
-  LOCAL_CFLAGS := $(LOCAL_CFLAGS) -D_ARCH_32 -DARM -DARMEABI_V7A
+  LOCAL_CFLAGS := $(LOCAL_CFLAGS) -D_ARCH_32
 endif
 ifeq ($(TARGET_ARCH_ABI),armeabi)
   LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv6/lib/libavformat.a
@@ -48,7 +48,7 @@ ifeq ($(TARGET_ARCH_ABI),armeabi)
   LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/armv6/lib/libavutil.a
   LOCAL_C_INCLUDES += $(LOCAL_PATH)/../../ffmpeg/android/armv6/include
 
-  LOCAL_CFLAGS := $(LOCAL_CFLAGS) -D_ARCH_32 -DARM -DARMEABI -march=armv6
+  LOCAL_CFLAGS := $(LOCAL_CFLAGS) -D_ARCH_32 -march=armv6
 endif
 ifeq ($(TARGET_ARCH_ABI),x86)
   LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/x86/lib/libavformat.a

--- a/android/jni/TestRunner.cpp
+++ b/android/jni/TestRunner.cpp
@@ -59,7 +59,7 @@ static std::string TrimNewlines(const std::string &s) {
 }
 
 bool TestsAvailable() {
-#ifdef IOS
+#if PPSSPP_PLATFORM(IOS)
 	std::string testDirectory = g_Config.flash0Directory + "../";
 #else
 	std::string testDirectory = g_Config.memStickDirectory;
@@ -74,7 +74,7 @@ bool TestsAvailable() {
 bool RunTests() {
 	std::string output;
 
-#ifdef IOS
+#if PPSSPP_PLATFORM(IOS)
 	std::string baseDirectory = g_Config.flash0Directory + "../";
 #else
 	std::string baseDirectory = g_Config.memStickDirectory;

--- a/ext/disarm.cpp
+++ b/ext/disarm.cpp
@@ -66,6 +66,7 @@
 #pragma GCC diagnostic ignored "-Wstring-plus-int"
 #endif
 
+#include "ppsspp_config.h"
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -132,7 +133,7 @@ int GetVm(uint32_t op, bool quad = false, bool dbl = false) {
 // Horrible array of hacks but hey. Can be cleaned up later.
 
 bool DisasmVFP(uint32_t op, char *text) {
-#if defined(__ANDROID__) && defined(_M_IX86)
+#if defined(__ANDROID__) && PPSSPP_ARCH(X86)
 	// Prevent linking errors with ArmEmitter which I've excluded on x86 android.
 	strcpy(text, "ARM disasm not available");
 #else

--- a/ext/glslang-build/Android.mk
+++ b/ext/glslang-build/Android.mk
@@ -62,9 +62,9 @@ LOCAL_CPPFLAGS := -fno-exceptions -std=gnu++11 -fno-rtti -Wno-reorder
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/.. $(LOCAL_PATH)/../libzip $(LOCAL_PATH)/../glslang ..
 
 ifeq ($(findstring armeabi-v7a,$(TARGET_ARCH_ABI)),armeabi-v7a)
-LOCAL_CFLAGS := $(LOCAL_CFLAGS) -DARM -DARMEABI_V7A
+LOCAL_CFLAGS := $(LOCAL_CFLAGS)
 else ifeq ($(TARGET_ARCH_ABI),armeabi)
-LOCAL_CFLAGS := $(LOCAL_CFLAGS) -DARM -DARMEABI -march=armv6
+LOCAL_CFLAGS := $(LOCAL_CFLAGS) -march=armv6
 else ifeq ($(TARGET_ARCH_ABI),x86)
 LOCAL_CFLAGS := $(LOCAL_CFLAGS) -D_M_IX86
 else ifeq ($(TARGET_ARCH_ABI),x86_64)

--- a/ext/miniupnp-build/Android.mk
+++ b/ext/miniupnp-build/Android.mk
@@ -28,9 +28,9 @@ LOCAL_CPPFLAGS := -fno-exceptions -std=gnu++11 -fno-rtti -Wno-reorder
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/.. $(LOCAL_PATH)/../miniupnp ..
 
 ifeq ($(findstring armeabi-v7a,$(TARGET_ARCH_ABI)),armeabi-v7a)
-LOCAL_CFLAGS := $(LOCAL_CFLAGS) -DARM -DARMEABI_V7A
+LOCAL_CFLAGS := $(LOCAL_CFLAGS)
 else ifeq ($(TARGET_ARCH_ABI),armeabi)
-LOCAL_CFLAGS := $(LOCAL_CFLAGS) -DARM -DARMEABI -march=armv6
+LOCAL_CFLAGS := $(LOCAL_CFLAGS) -march=armv6
 else ifeq ($(TARGET_ARCH_ABI),x86)
 LOCAL_CFLAGS := $(LOCAL_CFLAGS) -D_M_IX86
 else ifeq ($(TARGET_ARCH_ABI),x86_64)

--- a/ext/xbrz/xbrz.h
+++ b/ext/xbrz/xbrz.h
@@ -19,8 +19,9 @@
 #undef min
 #undef max
 
+#include "ppsspp_config.h"
 #include <cstddef> //size_t
-#if defined(IOS)
+#if PPSSPP_PLATFORM(IOS)
 #include <stdint.h>
 #else
 #include <cstdint> //uint32_t

--- a/ext/xxhash.h
+++ b/ext/xxhash.h
@@ -71,6 +71,7 @@ XXH64       13.8 GB/s            1.9 GB/s
 XXH32        6.8 GB/s            6.0 GB/s
 */
 
+#include "ppsspp_config.h"
 #if defined (__cplusplus)
 extern "C" {
 #endif
@@ -1366,7 +1367,7 @@ XXH32_endian_align(const xxh_u8* input, size_t len, xxh_u32 seed, XXH_alignment 
         xxh_u32 v4 = seed - XXH_PRIME32_1;
 
         do {
-#if defined(ARM) && defined(__GNUC__)
+#if PPSSPP_ARCH(ARM) && defined(__GNUC__)
             __builtin_prefetch(input + 0xc0, 0, 0);
 #endif
             v1 = XXH32_round(v1, XXH_get32bits(input)); input += 4;

--- a/headless/WindowsHeadlessHost.cpp
+++ b/headless/WindowsHeadlessHost.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include <cstdio>
 
 #include "headless/WindowsHeadlessHost.h"

--- a/libretro/LibretroGLCoreContext.cpp
+++ b/libretro/LibretroGLCoreContext.cpp
@@ -1,4 +1,4 @@
-
+#include "ppsspp_config.h"
 #include "Common/Log.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
@@ -17,7 +17,7 @@ bool LibretroGLCoreContext::Init() {
 
 void LibretroGLCoreContext::CreateDrawContext() {
 	if (!glewInitDone) {
-#if !defined(IOS) && !defined(USING_GLES2)
+#if !PPSSPP_PLATFORM(IOS) && !defined(USING_GLES2)
 		if (glewInit() != GLEW_OK) {
 			ERROR_LOG(G3D, "glewInit() failed.\n");
 			return;

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -147,7 +147,6 @@ else ifneq (,$(findstring osx,$(platform)))
 # iOS
 else ifneq (,$(findstring ios,$(platform)))
 	TARGET := $(TARGET_NAME)_libretro_ios.dylib
-	PLATCFLAGS += -DIOS
 	LDFLAGS += -dynamiclib -marm
 	fpic = -fPIC
 	GLES = 1
@@ -171,7 +170,7 @@ else ifneq (,$(findstring ios,$(platform)))
 		CXX += -miphoneos-version-min=5.0
 		PLATCFLAGS += -miphoneos-version-min=5.0
 	endif
-	PLATCFLAGS += -DIOS -DHAVE_POSIX_MEMALIGN
+	PLATCFLAGS += -DHAVE_POSIX_MEMALIGN
 	CPUFLAGS += -DARMv5_ONLY -DARM
 	PLATFORM_EXT := unix
 	TARGET_ARCH = arm

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -105,7 +105,6 @@ else ifneq (,$(findstring arm64,$(platform)))
 		GL_LIB := -lGL
 	endif
 	CPUFLAGS += -D__arm64__ -DARM64_ASM -D__NEON_OPT
-	PLATCFLAGS += -DARM64
 	LDFLAGS += -lrt -ldl
 	PLATFORM_EXT := unix
 
@@ -252,7 +251,6 @@ else ifneq (,$(findstring armv,$(platform)))
 		CPUFLAGS += -mfloat-abi=hard
 	endif
 	CPUFLAGS += -D__arm__ -DARM_ASM
-	PLATCFLAGS += -DARM
 	LDFLAGS += -lrt -ldl
 
 # emscripten

--- a/libretro/jni/Android.mk
+++ b/libretro/jni/Android.mk
@@ -12,14 +12,14 @@ FFMPEGLIBS += libavformat libavcodec libavutil libswresample libswscale
 WITH_DYNAREC := 1
 
 ifeq ($(TARGET_ARCH),arm64)
-  COREFLAGS += -DARM64 -D_ARCH_64
+  COREFLAGS += -D_ARCH_64
   HAVE_NEON := 1
   FFMPEGLIBDIR := $(FFMPEGDIR)/android/arm64/lib
   FFMPEGINCFLAGS := -I$(FFMPEGDIR)/android/arm64/include
 endif
 
 ifeq ($(TARGET_ARCH),arm)
-  COREFLAGS += -DARM -DARMEABI_V7A -D__arm__ -DARM_ASM -D_ARCH_32 -mfpu=neon
+  COREFLAGS += -D__arm__ -DARM_ASM -D_ARCH_32 -mfpu=neon
   HAVE_NEON := 1
   FFMPEGLIBDIR := $(FFMPEGDIR)/android/armv7/lib
   FFMPEGINCFLAGS := -I$(FFMPEGDIR)/android/armv7/include

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1,3 +1,4 @@
+#include "ppsspp_config.h"
 #include <cstring>
 #include <cassert>
 #include <thread>

--- a/ppsspp_config.h
+++ b/ppsspp_config.h
@@ -66,10 +66,6 @@
 #elif defined(__mips__)
     #define PPSSPP_ARCH_MIPS 1
     #define PPSSPP_ARCH_32BIT 1
-    //TODO: Remove this compat define
-    #ifndef MIPS
-        #define MIPS 1
-    #endif
 #endif
 
 

--- a/ppsspp_config.h
+++ b/ppsspp_config.h
@@ -91,16 +91,8 @@
     #if TARGET_IPHONE_SIMULATOR
         #define PPSSPP_PLATFORM_IOS 1
         #define PPSSPP_PLATFORM_IOS_SIMULATOR 1
-        //TODO: Remove this compat define
-        #ifndef IOS
-            #define IOS 1
-        #endif
     #elif TARGET_OS_IPHONE
         #define PPSSPP_PLATFORM_IOS 1
-        //TODO: Remove this compat define
-        #ifndef IOS
-            #define IOS 1
-        #endif
     #elif TARGET_OS_MAC
         #define PPSSPP_PLATFORM_MAC 1
     #else

--- a/ppsspp_config.h
+++ b/ppsspp_config.h
@@ -48,10 +48,6 @@
         #define PPSSPP_ARCH_ARMV7 1
         #define PPSSPP_ARCH_ARM_NEON 1
     #endif
-    //TODO: Remove this compat define
-    #ifndef ARM
-        #define ARM 1
-    #endif
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)


### PR DESCRIPTION
This cleans up a few things:

1. Adds explicit includes to `ppsspp_config.h` where PPSSPP_ARCH/PPSSPP_PLATFORM/PPSSPP_API are used.
2. Removes the IOS, MIPS, ARM, and ARM64 defines entirely.
3. Replaces most usage of _M_X64 and _M_IX86 for consistency.

I didn't remove the forced include, but in theory it should be safe now.  Given e29bb7b, this should hopefully make sure behavior is consistent between iOS, UWP, Windows, etc. which don't all force include that header.

Figured we should merge this first, make sure we get a build, then remove the header from cmake.

-[Unknown]