### PR TITLE
Allow polygon upscaling in Boku no Natsuyasumi series 

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -673,6 +673,10 @@ ULJM06218 = true
 UCAS40346 = true
 UCAS40347 = true
 
+# Boku no Natsuyasumi: Mushi Mushi Hakase to Teppen-yama no Himitsu!!
+UCJS10038 = true
+UCJS18013 = true
+
 # Note! This whole flag is disabled temporarily by appending "Disabled" to its name). See 7914
 [YugiohSaveFixDisabled]
 # The cause of Yu-gi-oh series 's bad save (cannot save) are load "save status" and use cwcheat,


### PR DESCRIPTION
There is some minor block transfer glitch with those games(tested only 1st), but it also happens without IntraVRAMBlockTransferAllowCreateFB hack, so I'll open a new issue for it if it wasn't already existing. This fixes #14259 at least as much as it can be "fixed" since most of the game is still made of pre-rendered backgrounds in a PSOne resolution stretched to PSP which can't be pretty.