### PR TITLE
GLSL Vulkan: Specify the precision of function arguments.

### DIFF
--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -157,10 +157,10 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 		}
 
 		if (enableAlphaTest && !alphaTestAgainstZero) {
-			WRITE(p, "int roundAndScaleTo255i(in float x) { return int(floor(x * 255.0 + 0.5)); }\n");
+			WRITE(p, "int roundAndScaleTo255i(in highp float x) { return int(floor(x * 255.0 + 0.5)); }\n");
 		}
 		if (enableColorTest && !colorTestAgainstZero) {
-			WRITE(p, "ivec3 roundAndScaleTo255iv(in vec3 x) { return ivec3(floor(x * 255.0 + 0.5)); }\n");
+			WRITE(p, "ivec3 roundAndScaleTo255iv(in highp vec3 x) { return ivec3(floor(x * 255.0 + 0.5)); }\n");
 		}
 
 		WRITE(p, "layout (location = 0, index = 0) out vec4 fragColor0;\n");
@@ -423,7 +423,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 
 	// Provide implementations of packUnorm4x8 and unpackUnorm4x8 if not available.
 	if (colorWriteMask && !hasPackUnorm4x8) {
-		WRITE(p, "uint packUnorm4x8(vec4 v) {\n");
+		WRITE(p, "uint packUnorm4x8(highp vec4 v) {\n");
 		WRITE(p, "  highp vec4 f = clamp(v, 0.0, 1.0);\n");
 		WRITE(p, "  uvec4 u = uvec4(255.0 * f);\n");
 		WRITE(p, "  return u.x | (u.y << 8) | (u.z << 16) | (u.w << 24);\n");

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -982,7 +982,7 @@ public:
 	GameInfoBGView(const std::string &gamePath, UI::LayoutParams *layoutParams) : InertView(layoutParams), gamePath_(gamePath) {
 	}
 
-	void Draw(UIContext &dc) {
+	void Draw(UIContext &dc) override {
 		// Should only be called when visible.
 		std::shared_ptr<GameInfo> ginfo = g_gameInfoCache->GetInfo(dc.GetDrawContext(), gamePath_, GAMEINFO_WANTBG);
 		dc.Flush();

--- a/UI/OnScreenDisplay.h
+++ b/UI/OnScreenDisplay.h
@@ -42,7 +42,7 @@ private:
 class OnScreenMessagesView : public UI::InertView {
 public:
 	OnScreenMessagesView(UI::LayoutParams *layoutParams = nullptr) : UI::InertView(layoutParams) {}
-	void Draw(UIContext &dc);
+	void Draw(UIContext &dc) override;
 	std::string DescribeText() const override;
 };
 


### PR DESCRIPTION
Works around (or fixes, not sure whose fault this really is) #14269.