### PR TITLE
Some homebrew like Triple Triad tries to load flash0:/kd/pspnet*.prx. Let's lie.

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -96,6 +96,11 @@ static const char * const lieAboutSuccessModules[] = {
 	"flash0:/kd/audiocodec_260.prx",
 	"flash0:/kd/libatrac3plus.prx",
 	"disc0:/PSP_GAME/SYSDIR/UPDATE/EBOOT.BIN",
+	"flash0:/kd/ifhandle.prx",
+	"flash0:/kd/pspnet.prx",
+	"flash0:/kd/pspnet_inet.prx",
+	"flash0:/kd/pspnet_apctl.prx",
+	"flash0:/kd/pspnet_resolver.prx",
 };
 
 // Modules to not load. TODO: Look into loosening this a little (say sceFont).


### PR DESCRIPTION
Fixes https://www.brewology.com/downloads/download.php?id=6684&mcid=1 reported by Peduls on Discord.

Commercial games don't try to do this:

```
E[LOADER]: HLE\sceKernelModule.cpp:1978 80010002=sceKernelLoadModule(flash0:/kd/ifhandle.prx, 00000000, 083fd4cc): file does not exist
```

They always ship their PRXs on disc, so we should be safe from major regressions.