### PR TITLE
[Adhoc] Fix Teenage Mutant Ninja Turtles Multiplayer

### DIFF
--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -243,7 +243,7 @@ void PSPNetconfDialog::DisplayMessage(std::string text1, std::string text2a, std
 }
 
 int PSPNetconfDialog::Update(int animSpeed) {
-	if (GetStatus() != SCE_UTILITY_STATUS_RUNNING) {
+	if (ReadStatus() != SCE_UTILITY_STATUS_RUNNING) {
 		return SCE_ERROR_UTILITY_INVALID_STATUS;
 	}
 
@@ -464,7 +464,7 @@ int PSPNetconfDialog::Update(int animSpeed) {
 		EndDraw();
 	}
 
-	if (GetStatus() == SCE_UTILITY_STATUS_FINISHED || pendingStatus == SCE_UTILITY_STATUS_FINISHED)
+	if (ReadStatus() == SCE_UTILITY_STATUS_FINISHED || pendingStatus == SCE_UTILITY_STATUS_FINISHED)
 		Memory::Memcpy(requestAddr, &request, request.common.size, "NetConfDialogParam");
 
 	return 0;


### PR DESCRIPTION
Fix Teenage Mutant Ninja Turtles Multiplayer. 

Apparently calling `GetStatus()` inside `PSPNetconfDialog::Update()` will cause `sceUtilityNetconfUpdate` to return `SCE_ERROR_UTILITY_INVALID_STATUS` right after Adhoc state changed to Connected state (which initiate the fade-out to finish the dialog)
```c++
// The Netconf dialog stays visible until the network reaches the state ADHOCCTL_STATE_CONNECTED.
if (state == ADHOCCTL_STATE_CONNECTED) {
	// Checking pendingStatus to make sure ChangeStatus not to continously extending the delay ticks on every call for eternity
	if (pendingStatus != SCE_UTILITY_STATUS_FINISHED) {
		StartFade(false);
		ChangeStatus(SCE_UTILITY_STATUS_FINISHED, NET_SHUTDOWN_DELAY_US);
	}

	...
}
```
Alternatively, changing NET_SHUTDOWN_DELAY_US from 200000 to 501000 usec or more will also works (500000 won't work), but i prefer this solution.