### PR TITLE
Debugger: Ignore small memory info by default

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1053,6 +1053,7 @@ static ConfigSetting debuggerSettings[] = {
 	ConfigSetting("ShowGpuProfile", &g_Config.bShowGpuProfile, false, false),
 	ConfigSetting("SkipDeadbeefFilling", &g_Config.bSkipDeadbeefFilling, false),
 	ConfigSetting("FuncHashMap", &g_Config.bFuncHashMap, false),
+	ConfigSetting("MemInfoDetailed", &g_Config.bDebugMemInfoDetailed, false),
 	ConfigSetting("DrawFrameGraph", &g_Config.bDrawFrameGraph, false),
 
 	ConfigSetting(false),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -467,6 +467,7 @@ public:
 	// Double edged sword: much easier debugging, but not accurate.
 	bool bSkipDeadbeefFilling;
 	bool bFuncHashMap;
+	bool bDebugMemInfoDetailed;
 	bool bDrawFrameGraph;
 
 	// Volatile development settings


### PR DESCRIPTION
The ini can be updated to enable higher resolution data.  Allocations are always at least 0x100, so this is still pretty useful.

Apparently this was taking >= 15% time in some EA games, due to constant use of `sceKernelReferThreadStatus()`, and similarly expensive if Gran Turismo due to tiny block transfers.  This will cause it to ignore that activity in both games by default.

Keeping enabled for larger memory info so that save states can be used, and the debugger has a default level of usefulness.

This takes the max resolution from 29360128 units to 114688 units for typical RAM + VRAM, and further means each slice will go from 64k to 256 max slabs (although the maxes aren't likely cases.)

-[Unknown]