### PR TITLE
UTF-8 PPGe: Remove overlong encodings. 

### DIFF
--- a/Common/Data/Encoding/Utf8.cpp
+++ b/Common/Data/Encoding/Utf8.cpp
@@ -483,6 +483,21 @@ std::string ConvertUCS2ToUTF8(const std::u16string &wstr) {
 	return s;
 }
 
+std::string SanitizeUTF8(const std::string &utf8string) {
+	UTF8 utf(utf8string.c_str());
+	std::string s;
+	// Worst case.
+	s.resize(utf8string.size() * 4);
+
+	size_t pos = 0;
+	while (!utf.end_or_overlong_end()) {
+		int c = utf.next();
+		pos += UTF8::encode(&s[pos], c);
+	}
+	s.resize(pos);
+	return s;
+}
+
 static size_t ConvertUTF8ToUCS2Internal(char16_t *dest, size_t destSize, const std::string &source) {
 	const char16_t *const orig = dest;
 	const char16_t *const destEnd = dest + destSize;

--- a/Common/Data/Encoding/Utf8.h
+++ b/Common/Data/Encoding/Utf8.h
@@ -31,10 +31,11 @@ public:
 	UTF8(const char *c) : c_(c), index_(0) {}
 	UTF8(const char *c, int index) : c_(c), index_(index) {}
 	bool end() const { return c_[index_] == 0; }
+	bool end_or_overlong_end() const { return peek() == 0; }
 	uint32_t next() {
 		return u8_nextchar(c_, &index_);
 	}
-	uint32_t peek() {
+	uint32_t peek() const {
 		int tempIndex = index_;
 		return u8_nextchar(c_, &tempIndex);
 	}
@@ -74,6 +75,10 @@ private:
 int UTF8StringNonASCIICount(const char *utf8string);
 
 bool UTF8StringHasNonASCII(const char *utf8string);
+
+
+// Removes overlong encodings and similar.
+std::string SanitizeUTF8(const std::string &utf8string);
 
 
 // UTF8 to Win32 UTF-16

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -44,6 +44,7 @@
 #include "ext/disarm.h"
 #include "Common/Math/math_util.h"
 #include "Common/Data/Text/Parsers.h"
+#include "Common/Data/Encoding/Utf8.h"
 
 #include "Common/ArmEmitter.h"
 #include "Common/BitScan.h"


### PR DESCRIPTION
Also work around a weird issue with \xC0\x80ENTR in Ratchet & Clank. See issue #14297