### PR TITLE
Add a setting for choosing background animation in PPSSPP's menus

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -494,6 +494,8 @@ static ConfigSetting generalSettings[] = {
 #endif
 	ConfigSetting("InternalScreenRotation", &g_Config.iInternalScreenRotation, ROTATION_LOCKED_HORIZONTAL),
 
+	ConfigSetting("BackgroundAnimation", &g_Config.iBackgroundAnimation, 1, true, false),
+
 #if defined(USING_WIN_UI)
 	ConfigSetting("TopMost", &g_Config.bTopMost, false),
 	ConfigSetting("WindowX", &g_Config.iWindowX, -1), // -1 tells us to center the window.

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -38,6 +38,11 @@ enum ChatPositions {
 	CENTER_RIGHT = 7,
 };
 
+enum class BackgroundAnimation {
+	OFF = 0,
+	FLOATING_SYMBOLS = 1,
+};
+
 namespace http {
 	class Download;
 	class Downloader;
@@ -239,6 +244,7 @@ public:
 	bool bShowIDOnGameIcon;
 	float fGameGridScale;
 	bool bShowOnScreenMessages;
+	int iBackgroundAnimation;  // enum BackgroundAnimation
 
 	// TODO: Maybe move to a separate theme system.
 	uint32_t uItemStyleFg;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -860,9 +860,23 @@ void GameSettingsScreen::CreateViews() {
 	systemSettingsScroll->Add(systemSettings);
 	tabHolder->AddTab(ms->T("System"), systemSettingsScroll);
 
-	systemSettings->Add(new ItemHeader(sy->T("UI Language")));  // Should be renamed "UI"?
+	systemSettings->Add(new ItemHeader(sy->T("UI")));
 	systemSettings->Add(new Choice(dev->T("Language", "Language")))->OnClick.Handle(this, &GameSettingsScreen::OnLanguage);
 	systemSettings->Add(new CheckBox(&g_Config.bUISound, sy->T("UI Sound")));
+	const std::string bgPng = GetSysDirectory(DIRECTORY_SYSTEM) + "background.png";
+	const std::string bgJpg = GetSysDirectory(DIRECTORY_SYSTEM) + "background.jpg";
+	if (File::Exists(bgPng) || File::Exists(bgJpg)) {
+		backgroundChoice_ = systemSettings->Add(new Choice(sy->T("Clear UI background")));
+	} else if (System_GetPropertyBool(SYSPROP_HAS_IMAGE_BROWSER)) {
+		backgroundChoice_ = systemSettings->Add(new Choice(sy->T("Set UI background...")));
+	} else {
+		backgroundChoice_ = nullptr;
+	}
+	if (backgroundChoice_ != nullptr) {
+		backgroundChoice_->OnClick.Handle(this, &GameSettingsScreen::OnChangeBackground);
+	}
+	static const char *backgroundAnimations[] = { "No animation", "Floating Symbols" };
+	systemSettings->Add(new PopupMultiChoice(&g_Config.iBackgroundAnimation, sy->T("UI background animation"), backgroundAnimations, 0, ARRAY_SIZE(backgroundAnimations), sy->GetName(), screenManager()));
 
 	systemSettings->Add(new ItemHeader(sy->T("Help the PPSSPP team")));
 	enableReports_ = Reporting::IsEnabled();
@@ -906,18 +920,6 @@ void GameSettingsScreen::CreateViews() {
 	}
 #endif
 	systemSettings->Add(new CheckBox(&g_Config.bCheckForNewVersion, sy->T("VersionCheck", "Check for new versions of PPSSPP")));
-	const std::string bgPng = GetSysDirectory(DIRECTORY_SYSTEM) + "background.png";
-	const std::string bgJpg = GetSysDirectory(DIRECTORY_SYSTEM) + "background.jpg";
-	if (File::Exists(bgPng) || File::Exists(bgJpg)) {
-		backgroundChoice_ = systemSettings->Add(new Choice(sy->T("Clear UI background")));
-	} else if (System_GetPropertyBool(SYSPROP_HAS_IMAGE_BROWSER)) {
-		backgroundChoice_ = systemSettings->Add(new Choice(sy->T("Set UI background...")));
-	} else {
-		backgroundChoice_ = nullptr;
-	}
-	if (backgroundChoice_ != nullptr) {
-		backgroundChoice_->OnClick.Handle(this, &GameSettingsScreen::OnChangeBackground);
-	}
 
 	systemSettings->Add(new Choice(sy->T("Restore Default Settings")))->OnClick.Handle(this, &GameSettingsScreen::OnRestoreDefaultSettings);
 	systemSettings->Add(new CheckBox(&g_Config.bEnableStateUndo, sy->T("Savestate slot backups")));


### PR DESCRIPTION
Off and Floating Symbols are the only choices so far, might add more in the future.

Was requested as a way to disable the symbols, which I agree can be a bit distracting. Figured might as well set it up as a multi-choice from the start.

Will need a small translation update, since I reorganized System settings slightly ("UI Language" heading is changed to "UI")

![image](https://user-images.githubusercontent.com/130929/112228293-63c3e200-8c31-11eb-8e9d-91c1bf45cf1c.png)
