### PR TITLE
PPGe: Interpret invalid UTF-8 sequences better

### DIFF
--- a/Common/Data/Encoding/Utf8.cpp
+++ b/Common/Data/Encoding/Utf8.cpp
@@ -234,6 +234,32 @@ uint32_t u8_nextchar(const char *s, int *i)
   return ch;
 }
 
+uint32_t u8_nextchar_unsafe(const char *s, int *i) {
+	uint32_t ch = (unsigned char)s[(*i)++];
+	int sz = 1;
+
+	if (ch >= 0xF0) {
+		sz++;
+		ch &= ~0x10;
+	}
+	if (ch >= 0xE0) {
+		sz++;
+		ch &= ~0x20;
+	}
+	if (ch >= 0xC0) {
+		sz++;
+		ch &= ~0xC0;
+	}
+
+	// Just assume the bytes must be there.  This is the logic used on the PSP.
+	for (int j = 1; j < sz; ++j) {
+		ch <<= 6;
+		ch += ((unsigned char)s[(*i)++]) & 0x3F;
+	}
+
+	return ch;
+}
+
 void u8_inc(const char *s, int *i)
 {
   (void)(isutf(s[++(*i)]) || isutf(s[++(*i)]) ||
@@ -489,9 +515,10 @@ std::string SanitizeUTF8(const std::string &utf8string) {
 	// Worst case.
 	s.resize(utf8string.size() * 4);
 
+	// This stops at invalid start bytes.
 	size_t pos = 0;
-	while (!utf.end_or_overlong_end()) {
-		int c = utf.next();
+	while (!utf.end() && !utf.invalid()) {
+		int c = utf.next_unsafe();
 		pos += UTF8::encode(&s[pos], c);
 	}
 	s.resize(pos);

--- a/Common/Data/Encoding/Utf8.h
+++ b/Common/Data/Encoding/Utf8.h
@@ -20,6 +20,7 @@
 #include <string>
 
 uint32_t u8_nextchar(const char *s, int *i);
+uint32_t u8_nextchar_unsafe(const char *s, int *i);
 int u8_wc_toutf8(char *dest, uint32_t ch);
 int u8_strlen(const char *s);
 void u8_inc(const char *s, int *i);
@@ -31,9 +32,17 @@ public:
 	UTF8(const char *c) : c_(c), index_(0) {}
 	UTF8(const char *c, int index) : c_(c), index_(index) {}
 	bool end() const { return c_[index_] == 0; }
-	bool end_or_overlong_end() const { return peek() == 0; }
+	// Returns true if the next character is outside BMP and Planes 1 - 16.
+	bool invalid() const {
+		unsigned char c = (unsigned char)c_[index_];
+		return (c >= 0x80 && c <= 0xC1) || c >= 0xF5;
+	}
 	uint32_t next() {
 		return u8_nextchar(c_, &index_);
+	}
+	// Allow invalid continuation bytes.
+	uint32_t next_unsafe() {
+		return u8_nextchar_unsafe(c_, &index_);
 	}
 	uint32_t peek() const {
 		int tempIndex = index_;

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -960,7 +960,7 @@ static std::string PPGeSanitizeText(const std::string &text) {
 	// the overlong null, the rest of the string is missing in the bottom left corner (save size, etc).
 	// It doesn't seem to be using sceCcc.
 	// Note how the double "" is required in the middle of the string to end the \x80 constant (otherwise it takes E).
-	// TODO: Potentially if the string is only ended by a C080, ReplaceAll might overshoot :(
+	// This behavior doesn't replicate within other games, so it may be a game bug workaround.
 	std::string str = ReplaceAll(text, "\xC0\x80""ENTR", "");
 	// Then SanitizeUTF8 is needed to get rid of various other overlong encodings.
 	return SanitizeUTF8(str);

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -954,10 +954,7 @@ static void PPGeDecimateTextImages(int age) {
 	}
 }
 
-void PPGeDrawText(const char *text, float x, float y, const PPGeStyle &style) {
-	if (!text) {
-		return;
-	}
+static std::string PPGeSanitizeText(const std::string &text) {
 	// Seen in Ratchet & Clank - Secret Agent. To match the output of the real thing, we have to remove
 	// both the overlong encoding and "ENTR", whatever that is. If we just let SanitizeUTF8 remove
 	// the overlong null, the rest of the string is missing in the bottom left corner (save size, etc).
@@ -966,7 +963,14 @@ void PPGeDrawText(const char *text, float x, float y, const PPGeStyle &style) {
 	// TODO: Potentially if the string is only ended by a C080, ReplaceAll might overshoot :(
 	std::string str = ReplaceAll(text, "\xC0\x80""ENTR", "");
 	// Then SanitizeUTF8 is needed to get rid of various other overlong encodings.
-	str = SanitizeUTF8(str);
+	return SanitizeUTF8(str);
+}
+
+void PPGeDrawText(const char *text, float x, float y, const PPGeStyle &style) {
+	if (!text) {
+		return;
+	}
+	std::string str = PPGeSanitizeText(text);
 	if (str.empty()) {
 		return;
 	}
@@ -1013,7 +1017,7 @@ static std::string CropLinesToCount(const std::string &s, int numLines) {
 }
 
 void PPGeDrawTextWrapped(const char *text, float x, float y, float wrapWidth, float wrapHeight, const PPGeStyle &style) {
-	std::string s = text;
+	std::string s = PPGeSanitizeText(text);
 	if (wrapHeight != 0.0f) {
 		s = StripTrailingWhite(s);
 	}


### PR DESCRIPTION
Fixes #14297.  I mean, #14306 basically fixed it but this matches observed behavior per tests more closely.

Overlong sequences are allowed, and the continuation bytes are not validated in any way.  Because the previous decoding subtracted a fixed value after reading all characters, it effectively validated in a way.

The PSP also rejects 5 or 6 byte UTF-8 sequences (which are illegal anyway, since they should only be used to encode a Unicode code point outside valid values.  This matches that too.

-[Unknown]