### PR TITLE
Set ent_top/ent_size/stub_top/stub_size of struct NativeModule

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1431,8 +1431,14 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 		u8 unknown2;
 	};
 
+	module->nm.ent_top = modinfo->libent;
+	module->nm.ent_size = modinfo->libentend - modinfo->libent;
+	module->nm.stub_top = modinfo->libstub;
+	module->nm.stub_size = modinfo->libstubend - modinfo->libstub;
+
 	const u32_le *entPos = (u32_le *)Memory::GetPointer(modinfo->libent);
 	const u32_le *entEnd = (u32_le *)Memory::GetPointer(modinfo->libentend);
+
 	for (int m = 0; entPos < entEnd; ++m) {
 		const PspLibEntEntry *ent = (const PspLibEntEntry *)entPos;
 		entPos += ent->size;


### PR DESCRIPTION
Members `ent_top`, `ent_size`, `stub_top` and `stub_size` of the internal `struct NativeModule` were not set in function `__KernelLoadELFFromPtr`. Previously, they were only initialized to zero.

The following PSP kernel functions return a `SceModule *` corresponding to the internal `struct NativeModule`:
`sceKernelFindModuleByAddress` 
`sceKernelFindModuleByName` 
`sceKernelFindModuleByUID` 

The aforementioned members may be needed by the caller of the functions listed above.