### PR TITLE
Feature: reducehash configure different value for different dump dimensions

### DIFF
--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -195,9 +195,11 @@ protected:
 	bool LoadIniValues(IniFile &ini, bool isOverride = false);
 	void ParseHashRange(const std::string &key, const std::string &value);
 	void ParseFiltering(const std::string &key, const std::string &value);
+	void ParseReduceHashRange(const std::string& key, const std::string& value); //Banh-Canh Parse reduceHash settings
 	bool LookupHashRange(u32 addr, int &w, int &h);
-	std::string LookupHashFile(u64 cachekey, u32 hash, int level);
-	std::string HashName(u64 cachekey, u32 hash, int level);
+	float LookupReduceHashRange(int& w, int& h); //Banh-Canh lookup ranges
+	std::string LookupHashFile(u64 cachekey, u32 hash, int level, int w, int h); //Banh-Canh 
+	std::string HashName(u64 cachekey, u32 hash, int level, int w, int h); // Banh-Canh
 	void PopulateReplacement(ReplacedTexture *result, u64 cachekey, u32 hash, int w, int h);
 
 	SimpleBuf<u32> saveBuf;
@@ -205,12 +207,15 @@ protected:
 	bool allowVideo_ = false;
 	bool ignoreAddress_ = false;
 	bool reduceHash_ = false;
+	float reduceHashSize = 1.0; //Banh-Canh default value
+	float reduceHashGlobalValue = 0.5; //Banh-Canh Global value for textures dump pngs of all sizes
 	bool ignoreMipmap_ = false;
 	std::string gameID_;
 	std::string basePath_;
 	ReplacedTextureHash hash_ = ReplacedTextureHash::QUICK;
 	typedef std::pair<int, int> WidthHeightPair;
 	std::unordered_map<u64, WidthHeightPair> hashranges_;
+	std::unordered_map<u64, float> reducehashranges_; //Banh-Canh
 	std::unordered_map<ReplacementAliasKey, std::string> aliases_;
 	std::unordered_map<ReplacementCacheKey, TextureFiltering> filtering_;
 

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -195,11 +195,11 @@ protected:
 	bool LoadIniValues(IniFile &ini, bool isOverride = false);
 	void ParseHashRange(const std::string &key, const std::string &value);
 	void ParseFiltering(const std::string &key, const std::string &value);
-	void ParseReduceHashRange(const std::string& key, const std::string& value); //Banh-Canh Parse reduceHash settings
+	void ParseReduceHashRange(const std::string& key, const std::string& value);
 	bool LookupHashRange(u32 addr, int &w, int &h);
-	float LookupReduceHashRange(int& w, int& h); //Banh-Canh lookup ranges
-	std::string LookupHashFile(u64 cachekey, u32 hash, int level, int w, int h); //Banh-Canh 
-	std::string HashName(u64 cachekey, u32 hash, int level, int w, int h); // Banh-Canh
+	float LookupReduceHashRange(int& w, int& h);
+	std::string LookupHashFile(u64 cachekey, u32 hash, int level, int w, int h);
+	std::string HashName(u64 cachekey, u32 hash, int level, int w, int h);
 	void PopulateReplacement(ReplacedTexture *result, u64 cachekey, u32 hash, int w, int h);
 
 	SimpleBuf<u32> saveBuf;
@@ -207,15 +207,15 @@ protected:
 	bool allowVideo_ = false;
 	bool ignoreAddress_ = false;
 	bool reduceHash_ = false;
-	float reduceHashSize = 1.0; //Banh-Canh default value
-	float reduceHashGlobalValue = 0.5; //Banh-Canh Global value for textures dump pngs of all sizes
+	float reduceHashSize = 1.0; // default value with reduceHash to false
+	float reduceHashGlobalValue = 0.5; // Global value for textures dump pngs of all sizes, 0.5 by default but can be set in textures.ini
 	bool ignoreMipmap_ = false;
 	std::string gameID_;
 	std::string basePath_;
 	ReplacedTextureHash hash_ = ReplacedTextureHash::QUICK;
 	typedef std::pair<int, int> WidthHeightPair;
 	std::unordered_map<u64, WidthHeightPair> hashranges_;
-	std::unordered_map<u64, float> reducehashranges_; //Banh-Canh
+	std::unordered_map<u64, float> reducehashranges_;
 	std::unordered_map<ReplacementAliasKey, std::string> aliases_;
 	std::unordered_map<ReplacementCacheKey, TextureFiltering> filtering_;
 


### PR DESCRIPTION
Hello !

Basically what I said here some time ago : https://forums.ppsspp.org/showthread.php?tid=27097, I was wondering if it could interest anyone else here ?
I added the following settings to the textures.ini by imitating how the [hashranges] worked.
```
[options]
version = 1
hash = xxh64
ignoreAddress = true
reduceHash = true
reduceHashGlobalValue = 0.5
;; if reduceHash = true, then it makes ppsspp assume only the top half is important (by default) 
;; I tried to make it configurable.

[reducehashrange]
;; if reduceHash = true, then it allows to configure reduceHashSize that is specific to the specified dimensions
;; syntax : w,h = reducehashvalue
128,256 = 0.3125
;; resulting dump will be named like : 128x256_addresscluthash.png
```

It is not going to be used a lot but it worked for me (with Grownlanser WoT) and I was able to greatly reduce the amount of duplicates textures dumps (by using the above settings) without causing issues (so far, after multiple playthrough).
It did not mess with other games I use with reduceHash=true (Persona 2 IS) or with reduceHash=false (Persona 3).