### PR TITLE
Fix: remove filename prefix for reducehashranges

### DIFF
--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -198,8 +198,8 @@ protected:
 	void ParseReduceHashRange(const std::string& key, const std::string& value);
 	bool LookupHashRange(u32 addr, int &w, int &h);
 	float LookupReduceHashRange(int& w, int& h);
-	std::string LookupHashFile(u64 cachekey, u32 hash, int level, int w, int h);
-	std::string HashName(u64 cachekey, u32 hash, int level, int w, int h);
+	std::string LookupHashFile(u64 cachekey, u32 hash, int level);
+	std::string HashName(u64 cachekey, u32 hash, int level);
 	void PopulateReplacement(ReplacedTexture *result, u64 cachekey, u32 hash, int w, int h);
 
 	SimpleBuf<u32> saveBuf;


### PR DESCRIPTION
Hello, just fixing a small mistake of mine from #14332.

About adding the dimensions as a prefix for textures using a non-default reducehashvalue: 
It was because I thought multiple differents reducehash value could create a mess with other textures that use the other values but it doesn't look like it. 

I tried to be safe but I now realize that this way [reducehashranges] does not work with [hashes] (unless some changes are made) or at least, isn't intuitive since this won't work:
```
[hashes]
128x256_addresscluthash = images1.png
```
but this works (even though the dumped file is still named with the prefix):
```
[hashes]
addresscluthash = images1.png
```
 So to correct my mistake (sorry), I simply removed the prefix I previously added which should fix that.

```
[reducehashranges]
;; doesn't do anything unless reduceHash = true
;; syntax : w,h = reducehashvalue
128,256 = 0.3125
[hashes]
;; dumped file using the reducehash value, the following still work and is coherent with the filename
addresscluthash = images1.png
```
Filenames will be back to: addresscluthash.png
Like all the others.

Double-checked how it would interact with [hashranges] and it looks ok (I don't think anyone is going to be using both though).