### PR TITLE
Include more memory info in debugger tags

### DIFF
--- a/Core/Debugger/MemBlockInfo.cpp
+++ b/Core/Debugger/MemBlockInfo.cpp
@@ -46,7 +46,7 @@ private:
 		uint64_t ticks = 0;
 		uint32_t pc = 0;
 		bool allocated = false;
-		char tag[32]{};
+		char tag[128]{};
 		Slab *prev = nullptr;
 		Slab *next = nullptr;
 
@@ -77,7 +77,7 @@ struct PendingNotifyMem {
 	uint32_t size;
 	uint64_t ticks;
 	uint32_t pc;
-	char tag[32];
+	char tag[128];
 };
 
 static constexpr size_t MAX_PENDING_NOTIFIES = 512;
@@ -199,7 +199,7 @@ void MemSlabMap::DoState(PointerWrap &p) {
 }
 
 void MemSlabMap::Slab::DoState(PointerWrap &p) {
-	auto s = p.Section("MemSlabMapSlab", 1, 2);
+	auto s = p.Section("MemSlabMapSlab", 1, 3);
 	if (!s)
 		return;
 
@@ -208,8 +208,12 @@ void MemSlabMap::Slab::DoState(PointerWrap &p) {
 	Do(p, ticks);
 	Do(p, pc);
 	Do(p, allocated);
-	if (s >= 2) {
+	if (s >= 3) {
 		Do(p, tag);
+	} else if (s >= 2) {
+		char shortTag[32];
+		Do(p, shortTag);
+		memcpy(tag, shortTag, sizeof(shortTag));
 	} else {
 		std::string stringTag;
 		Do(p, stringTag);

--- a/Core/Debugger/MemBlockInfo.cpp
+++ b/Core/Debugger/MemBlockInfo.cpp
@@ -433,6 +433,14 @@ std::vector<MemBlockInfo> FindMemInfoByFlag(MemBlockFlags flags, uint32_t start,
 	return results;
 }
 
+std::string GetMemWriteTagAt(uint32_t start, uint32_t size) {
+	std::vector<MemBlockInfo> memRangeInfo = FindMemInfoByFlag(MemBlockFlags::WRITE, start, size);
+	for (auto range : memRangeInfo) {
+		return range.tag;
+	}
+	return "none";
+}
+
 void MemBlockInfoInit() {
 	std::lock_guard<std::mutex> guard(pendingMutex);
 	pendingNotifies.reserve(MAX_PENDING_NOTIFIES);

--- a/Core/Debugger/MemBlockInfo.cpp
+++ b/Core/Debugger/MemBlockInfo.cpp
@@ -438,6 +438,12 @@ std::string GetMemWriteTagAt(uint32_t start, uint32_t size) {
 	for (auto range : memRangeInfo) {
 		return range.tag;
 	}
+
+	// Fall back to alloc and texture, especially for VRAM.  We prefer write above.
+	memRangeInfo = FindMemInfoByFlag(MemBlockFlags::ALLOC | MemBlockFlags::TEXTURE, start, size);
+	for (auto range : memRangeInfo) {
+		return range.tag;
+	}
 	return "none";
 }
 

--- a/Core/Debugger/MemBlockInfo.h
+++ b/Core/Debugger/MemBlockInfo.h
@@ -63,6 +63,8 @@ inline void NotifyMemInfo(MemBlockFlags flags, uint32_t start, uint32_t size, co
 std::vector<MemBlockInfo> FindMemInfo(uint32_t start, uint32_t size);
 std::vector<MemBlockInfo> FindMemInfoByFlag(MemBlockFlags flags, uint32_t start, uint32_t size);
 
+std::string GetMemWriteTagAt(uint32_t start, uint32_t size);
+
 void MemBlockInfoInit();
 void MemBlockInfoShutdown();
 void MemBlockInfoDoState(PointerWrap &p);

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -364,8 +364,8 @@ private:
 	PSPFileInfo GetSaveInfo(std::string saveDir);
 
 	int LoadSaveData(SceUtilitySavedataParam *param, const std::string &saveDirName, const std::string& dirPath, bool secureMode);
-	void LoadCryptedSave(SceUtilitySavedataParam *param, u8 *data, const u8 *saveData, int &saveSize, int prevCryptMode, const u8 *expectedHash, bool &saveDone);
-	void LoadNotCryptedSave(SceUtilitySavedataParam *param, u8 *data, u8 *saveData, int &saveSize);
+	u32 LoadCryptedSave(SceUtilitySavedataParam *param, u8 *data, const u8 *saveData, int &saveSize, int prevCryptMode, const u8 *expectedHash, bool &saveDone);
+	u32 LoadNotCryptedSave(SceUtilitySavedataParam *param, u8 *data, u8 *saveData, int &saveSize);
 	void LoadSFO(SceUtilitySavedataParam *param, const std::string& dirPath);
 	void LoadFile(const std::string& dirPath, const std::string& filename, PspUtilitySavedataFileData *fileData);
 

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -156,8 +156,9 @@ static int Replace_memcpy() {
 	}
 	RETURN(destPtr);
 
-	NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, "ReplaceMemcpy");
-	NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, "ReplaceMemcpy");
+	const std::string tag = "ReplaceMemcpy/" + GetMemWriteTagAt(srcPtr, bytes);
+	NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, tag.c_str(), tag.size());
+	NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, tag.c_str(), tag.size());
 
 	return 10 + bytes / 4;  // approximation
 }
@@ -198,8 +199,9 @@ static int Replace_memcpy_jak() {
 	currentMIPS->r[MIPS_REG_A3] = destPtr + bytes;
 	RETURN(destPtr);
 
-	NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, "ReplaceMemcpy");
-	NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, "ReplaceMemcpy");
+	const std::string tag = "ReplaceMemcpy/" + GetMemWriteTagAt(srcPtr, bytes);
+	NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, tag.c_str(), tag.size());
+	NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, tag.c_str(), tag.size());
 
 	return 5 + bytes * 8 + 2;  // approximation. This is a slow memcpy - a byte copy loop..
 }
@@ -226,8 +228,9 @@ static int Replace_memcpy16() {
 	}
 	RETURN(destPtr);
 
-	NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, "ReplaceMemcpy16");
-	NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, "ReplaceMemcpy16");
+	const std::string tag = "ReplaceMemcpy16/" + GetMemWriteTagAt(srcPtr, bytes);
+	NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, tag.c_str(), tag.size());
+	NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, tag.c_str(), tag.size());
 
 	return 10 + bytes / 4;  // approximation
 }
@@ -264,8 +267,9 @@ static int Replace_memcpy_swizzled() {
 
 	RETURN(0);
 
-	NotifyMemInfo(MemBlockFlags::READ, srcPtr, pitch * h, "ReplaceMemcpySwizzle");
-	NotifyMemInfo(MemBlockFlags::WRITE, destPtr, pitch * h, "ReplaceMemcpySwizzle");
+	const std::string tag = "ReplaceMemcpySwizzle/" + GetMemWriteTagAt(srcPtr, pitch * h);
+	NotifyMemInfo(MemBlockFlags::READ, srcPtr, pitch * h, tag.c_str(), tag.size());
+	NotifyMemInfo(MemBlockFlags::WRITE, destPtr, pitch * h, tag.c_str(), tag.size());
 
 	return 10 + (pitch * h) / 4;  // approximation
 }
@@ -292,8 +296,9 @@ static int Replace_memmove() {
 	}
 	RETURN(destPtr);
 
-	NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, "ReplaceMemmove");
-	NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, "ReplaceMemmove");
+	const std::string tag = "ReplaceMemmove/" + GetMemWriteTagAt(srcPtr, bytes);
+	NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, tag.c_str(), tag.size());
+	NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, tag.c_str(), tag.size());
 
 	return 10 + bytes / 4;  // approximation
 }

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -153,7 +153,7 @@ struct InputBuffer {
 
 struct Atrac;
 int __AtracSetContext(Atrac *atrac);
-void _AtracGenerateContext(Atrac *atrac, SceAtracId *context);
+void _AtracGenerateContext(Atrac *atrac);
 
 struct AtracLoopInfo {
 	int cuePointID;
@@ -1031,7 +1031,7 @@ u32 _AtracAddStreamData(int atracID, u32 bufPtr, u32 bytesToAdd) {
 	if (!atrac)
 		return 0;
 	int addbytes = std::min(bytesToAdd, atrac->first_.filesize - atrac->first_.fileoffset);
-	Memory::Memcpy(atrac->dataBuf_ + atrac->first_.fileoffset, bufPtr, addbytes);
+	Memory::Memcpy(atrac->dataBuf_ + atrac->first_.fileoffset, bufPtr, addbytes, "AtracAddStreamData");
 	atrac->first_.size += bytesToAdd;
 	if (atrac->first_.size >= atrac->first_.filesize) {
 		atrac->first_.size = atrac->first_.filesize;
@@ -1041,7 +1041,7 @@ u32 _AtracAddStreamData(int atracID, u32 bufPtr, u32 bytesToAdd) {
 	atrac->first_.fileoffset += addbytes;
 	if (atrac->context_.IsValid()) {
 		// refresh context_
-		_AtracGenerateContext(atrac, atrac->context_);
+		_AtracGenerateContext(atrac);
 	}
 	return 0;
 }
@@ -1142,7 +1142,7 @@ static u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd) {
 		atrac->first_.fileoffset = readOffset;
 		int addbytes = std::min(bytesToAdd, atrac->first_.filesize - atrac->first_.fileoffset);
 		if (!atrac->ignoreDataBuf_) {
-			Memory::Memcpy(atrac->dataBuf_ + atrac->first_.fileoffset, atrac->first_.addr + atrac->first_.offset, addbytes);
+			Memory::Memcpy(atrac->dataBuf_ + atrac->first_.fileoffset, atrac->first_.addr + atrac->first_.offset, addbytes, "AtracAddStreamData");
 		}
 		atrac->first_.fileoffset += addbytes;
 	}
@@ -1152,7 +1152,7 @@ static u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd) {
 		if (atrac->bufferState_ == ATRAC_STATUS_HALFWAY_BUFFER)
 			atrac->bufferState_ = ATRAC_STATUS_ALL_DATA_LOADED;
 		if (atrac->context_.IsValid()) {
-			_AtracGenerateContext(atrac, atrac->context_);
+			_AtracGenerateContext(atrac);
 		}
 	}
 
@@ -1313,7 +1313,7 @@ u32 _AtracDecodeData(int atracID, u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u3
 		}
 		if (atrac->context_.IsValid()) {
 			// refresh context_
-			_AtracGenerateContext(atrac, atrac->context_);
+			_AtracGenerateContext(atrac);
 		}
 	}
 
@@ -1729,7 +1729,7 @@ static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFi
 			// Okay, it's a valid number of bytes.  Let's set them up.
 			if (bytesWrittenFirstBuf != 0) {
 				if (!atrac->ignoreDataBuf_) {
-					Memory::Memcpy(atrac->dataBuf_ + atrac->first_.size, atrac->first_.addr + atrac->first_.size, bytesWrittenFirstBuf);
+					Memory::Memcpy(atrac->dataBuf_ + atrac->first_.size, atrac->first_.addr + atrac->first_.size, bytesWrittenFirstBuf, "AtracResetPlayPosition");
 				}
 				atrac->first_.fileoffset += bytesWrittenFirstBuf;
 				atrac->first_.size += bytesWrittenFirstBuf;
@@ -1752,7 +1752,7 @@ static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFi
 
 			if (bytesWrittenFirstBuf != 0) {
 				if (!atrac->ignoreDataBuf_) {
-					Memory::Memcpy(atrac->dataBuf_ + atrac->first_.fileoffset, atrac->first_.addr, bytesWrittenFirstBuf);
+					Memory::Memcpy(atrac->dataBuf_ + atrac->first_.fileoffset, atrac->first_.addr, bytesWrittenFirstBuf, "AtracResetPlayPosition");
 				}
 				atrac->first_.fileoffset += bytesWrittenFirstBuf;
 			}
@@ -1769,7 +1769,7 @@ static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFi
 		}
 
 		if (atrac->context_.IsValid()) {
-			_AtracGenerateContext(atrac, atrac->context_);
+			_AtracGenerateContext(atrac);
 		}
 
 		return hleDelayResult(hleLogSuccessInfoI(ME, 0), "reset play pos", 3000);
@@ -1924,7 +1924,7 @@ static int _AtracSetData(Atrac *atrac, u32 buffer, u32 readSize, u32 bufferSize,
 	atrac->dataBuf_ = new u8[atrac->first_.filesize];
 	if (!atrac->ignoreDataBuf_) {
 		u32 copybytes = std::min(bufferSize, atrac->first_.filesize);
-		Memory::Memcpy(atrac->dataBuf_, buffer, copybytes);
+		Memory::Memcpy(atrac->dataBuf_, buffer, copybytes, "AtracSetData");
 	}
 	int ret = __AtracSetContext(atrac);
 	if (ret < 0) {
@@ -2083,7 +2083,7 @@ static u32 sceAtracSetLoopNum(int atracID, int loopNum) {
 			atrac->loopEndSample_ = atrac->endSample_ + atrac->firstSampleOffset_ + atrac->FirstOffsetExtra();
 		}
 		if (atrac->context_.IsValid()) {
-			_AtracGenerateContext(atrac, atrac->context_);
+			_AtracGenerateContext(atrac);
 		}
 	}
 	return 0;
@@ -2291,7 +2291,8 @@ int _AtracGetIDByContext(u32 contextAddr) {
 	return atracID;
 }
 
-void _AtracGenerateContext(Atrac *atrac, SceAtracId *context) {
+void _AtracGenerateContext(Atrac *atrac) {
+	SceAtracId *context = atrac->context_;
 	context->info.buffer = atrac->first_.addr;
 	context->info.bufferByte = atrac->bufferMaxSize_;
 	context->info.secondBuffer = atrac->second_.addr;
@@ -2321,6 +2322,8 @@ void _AtracGenerateContext(Atrac *atrac, SceAtracId *context) {
 
 	u8 *buf = (u8 *)context;
 	*(u32_le *)(buf + 0xfc) = atrac->atracID_;
+
+	NotifyMemInfo(MemBlockFlags::WRITE, atrac->context_.ptr, sizeof(SceAtracId), "AtracContext");
 }
 
 static u32 _sceAtracGetContextAddress(int atracID) {
@@ -2341,7 +2344,7 @@ static u32 _sceAtracGetContextAddress(int atracID) {
 	else
 		WARN_LOG(ME, "%08x=_sceAtracGetContextAddress(%i)", atrac->context_.ptr, atracID);
 	if (atrac->context_.IsValid())
-		_AtracGenerateContext(atrac, atrac->context_);
+		_AtracGenerateContext(atrac);
 	return atrac->context_.ptr;
 }
 
@@ -2430,7 +2433,7 @@ static int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 	int ret = __AtracSetContext(atrac);
 
 	if (atrac->context_.IsValid()) {
-		_AtracGenerateContext(atrac, atrac->context_);
+		_AtracGenerateContext(atrac);
 	}
 
 	if (ret < 0) {

--- a/Core/HLE/sceDeflt.cpp
+++ b/Core/HLE/sceDeflt.cpp
@@ -38,7 +38,8 @@ static int CommonDecompress(int windowBits, u32 OutBuffer, int OutBufferLength, 
 	z_stream stream{};
 	u8 *outBufferPtr = Memory::GetPointer(OutBuffer);
 	stream.next_in = (Bytef*)Memory::GetPointer(InBuffer);
-	stream.avail_in = (uInt)OutBufferLength;
+	// We don't know the available length, just let it use as much as it wants.
+	stream.avail_in = (uInt)Memory::ValidSize(InBuffer, Memory::g_MemorySize);
 	stream.next_out = outBufferPtr;
 	stream.avail_out = (uInt)OutBufferLength;
 

--- a/Core/HLE/sceDeflt.cpp
+++ b/Core/HLE/sceDeflt.cpp
@@ -18,6 +18,7 @@
 #include "zlib.h"
 
 #include "Common/CommonTypes.h"
+#include "Core/Debugger/MemBlockInfo.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/FunctionWrappers.h"
 #include "Core/HLE/sceDeflt.h"
@@ -55,6 +56,11 @@ static int CommonDecompress(int windowBits, u32 OutBuffer, int OutBufferLength, 
 		uLong crc = crc32(0L, Z_NULL, 0);
 		*crc32Addr = crc32(crc, outBufferPtr, stream.total_out);
 	}
+
+	const std::string tag = "sceDeflt/" + GetMemWriteTagAt(InBuffer, stream.total_in);
+	NotifyMemInfo(MemBlockFlags::READ, InBuffer, stream.total_in, tag.c_str(), tag.size());
+	NotifyMemInfo(MemBlockFlags::WRITE, OutBuffer, stream.total_out, tag.c_str(), tag.size());
+
 	return hleLogSuccessI(HLE, stream.total_out);
 }
 

--- a/Core/HLE/sceDeflt.cpp
+++ b/Core/HLE/sceDeflt.cpp
@@ -23,142 +23,51 @@
 #include "Core/HLE/sceDeflt.h"
 #include "Core/MemMap.h"
 
-// All the decompress functions are identical with only differing window bits. Possibly should be one function
-
-static int sceDeflateDecompress(u32 OutBuffer, int OutBufferLength, u32 InBuffer, u32 Crc32Addr) {
-	DEBUG_LOG(HLE, "sceGzipDecompress(%08x, %x, %08x, %08x)", OutBuffer, OutBufferLength, InBuffer, Crc32Addr);
-	int err;
-	uLong crc;
-	z_stream stream;
-	u8 *outBufferPtr;
-	u32_le *crc32AddrPtr = nullptr;
-
+// All the decompress functions are identical with only differing window bits.
+static int CommonDecompress(int windowBits, u32 OutBuffer, int OutBufferLength, u32 InBuffer, u32 Crc32Addr) {
 	if (!Memory::IsValidAddress(OutBuffer) || !Memory::IsValidAddress(InBuffer)) {
-		ERROR_LOG(HLE, "sceZlibDecompress: Bad address %08x %08x", OutBuffer, InBuffer);
-		return 0;
+		return hleLogError(HLE, 0, "bad address");
 	}
-	if (Crc32Addr) {
-		if (!Memory::IsValidAddress(Crc32Addr)) {
-			ERROR_LOG(HLE, "sceZlibDecompress: Bad address %08x", Crc32Addr);
-			return 0;
-		}
-		crc32AddrPtr = (u32_le *)Memory::GetPointer(Crc32Addr);
+
+	auto crc32Addr = PSPPointer<u32_le>::Create(Crc32Addr);
+	if (Crc32Addr && !crc32Addr.IsValid()) {
+		return hleLogError(HLE, 0, "bad crc32 address");
 	}
-	outBufferPtr = Memory::GetPointer(OutBuffer);
+
+	z_stream stream{};
+	u8 *outBufferPtr = Memory::GetPointer(OutBuffer);
 	stream.next_in = (Bytef*)Memory::GetPointer(InBuffer);
 	stream.avail_in = (uInt)OutBufferLength;
 	stream.next_out = outBufferPtr;
 	stream.avail_out = (uInt)OutBufferLength;
-	stream.zalloc = (alloc_func)0;
-	stream.zfree = (free_func)0;
-	err = inflateInit2(&stream, -MAX_WBITS);
+
+	int err = inflateInit2(&stream, windowBits);
 	if (err != Z_OK) {
-		ERROR_LOG(HLE, "sceZlibDecompress: inflateInit2 failed %08x", err);
-		return 0;
+		return hleLogError(HLE, 0, "inflateInit2 failed %08x", err);
 	}
 	err = inflate(&stream, Z_FINISH);
-	if (err != Z_STREAM_END) {
-		inflateEnd(&stream);
-		ERROR_LOG(HLE, "sceZlibDecompress: inflate failed %08x", err);
-		return 0;
-	}
 	inflateEnd(&stream);
-	if (crc32AddrPtr) {
-		crc = crc32(0L, Z_NULL, 0);
-		*crc32AddrPtr = crc32(crc, outBufferPtr, stream.total_out);
+
+	if (err != Z_STREAM_END) {
+		return hleLogError(HLE, 0, "inflate failed %08x", err);
 	}
-	return stream.total_out;
+	if (crc32Addr.IsValid()) {
+		uLong crc = crc32(0L, Z_NULL, 0);
+		*crc32Addr = crc32(crc, outBufferPtr, stream.total_out);
+	}
+	return hleLogSuccessI(HLE, stream.total_out);
 }
 
+static int sceDeflateDecompress(u32 OutBuffer, int OutBufferLength, u32 InBuffer, u32 Crc32Addr) {
+	return CommonDecompress(-MAX_WBITS, OutBuffer, OutBufferLength, InBuffer, Crc32Addr);
+}
 
 static int sceGzipDecompress(u32 OutBuffer, int OutBufferLength, u32 InBuffer, u32 Crc32Addr) {
-	DEBUG_LOG(HLE, "sceGzipDecompress(%08x, %x, %08x, %08x)", OutBuffer, OutBufferLength, InBuffer, Crc32Addr);
-	int err;
-	uLong crc;
-	z_stream stream;
-	u8 *outBufferPtr;
-	u32_le *crc32AddrPtr = nullptr;
-
-	if (!Memory::IsValidAddress(OutBuffer) || !Memory::IsValidAddress(InBuffer)) {
-		ERROR_LOG(HLE, "sceZlibDecompress: Bad address %08x %08x", OutBuffer, InBuffer);
-		return 0;
-	}
-	if (Crc32Addr) {
-		if (!Memory::IsValidAddress(Crc32Addr)) {
-			ERROR_LOG(HLE, "sceZlibDecompress: Bad address %08x", Crc32Addr);
-			return 0;
-		}
-		crc32AddrPtr = (u32_le *)Memory::GetPointer(Crc32Addr);
-	}
-	outBufferPtr = Memory::GetPointer(OutBuffer);
-	stream.next_in = (Bytef*)Memory::GetPointer(InBuffer);
-	stream.avail_in = (uInt)OutBufferLength;
-	stream.next_out = outBufferPtr;
-	stream.avail_out = (uInt)OutBufferLength;
-	stream.zalloc = (alloc_func)0;
-	stream.zfree = (free_func)0;
-	err = inflateInit2(&stream, 16+MAX_WBITS);
-	if (err != Z_OK) {
-		ERROR_LOG(HLE, "sceZlibDecompress: inflateInit2 failed %08x", err);
-		return 0;
-	}
-	err = inflate(&stream, Z_FINISH);
-	if (err != Z_STREAM_END) {
-		inflateEnd(&stream);
-		ERROR_LOG(HLE, "sceZlibDecompress: inflate failed %08x", err);
-		return 0;
-	}
-	inflateEnd(&stream);
-	if (crc32AddrPtr) {
-		crc = crc32(0L, Z_NULL, 0);
-		*crc32AddrPtr = crc32(crc, outBufferPtr, stream.total_out);
-	}
-	return stream.total_out;
+	return CommonDecompress(16 + MAX_WBITS, OutBuffer, OutBufferLength, InBuffer, Crc32Addr);
 }
 
 static int sceZlibDecompress(u32 OutBuffer, int OutBufferLength, u32 InBuffer, u32 Crc32Addr) {
-	DEBUG_LOG(HLE, "sceZlibDecompress(%08x, %x, %08x, %08x)", OutBuffer, OutBufferLength, InBuffer, Crc32Addr);
-	int err;
-	uLong crc;
-	z_stream stream;
-	u8 *outBufferPtr;
-	u32_le *crc32AddrPtr = 0;
-
-	if (!Memory::IsValidAddress(OutBuffer) || !Memory::IsValidAddress(InBuffer)) {
-		ERROR_LOG(HLE, "sceZlibDecompress: Bad address %08x %08x", OutBuffer, InBuffer);
-		return 0;
-	}
-	if (Crc32Addr) {
-		if (!Memory::IsValidAddress(Crc32Addr)) {
-			ERROR_LOG(HLE, "sceZlibDecompress: Bad address %08x", Crc32Addr);
-			return 0;
-		}
-		crc32AddrPtr = (u32_le *)Memory::GetPointer(Crc32Addr);
-	}
-	outBufferPtr = Memory::GetPointer(OutBuffer);
-	stream.next_in = (Bytef*)Memory::GetPointer(InBuffer);
-	stream.avail_in = (uInt)OutBufferLength;
-	stream.next_out = outBufferPtr;
-	stream.avail_out = (uInt)OutBufferLength;
-	stream.zalloc = (alloc_func)0;
-	stream.zfree = (free_func)0;
-	err = inflateInit2(&stream, MAX_WBITS);
-	if (err != Z_OK) {
-		ERROR_LOG(HLE, "sceZlibDecompress: inflateInit failed %08x", err);
-		return 0;
-	}
-	err = inflate(&stream, Z_FINISH);
-	if (err != Z_STREAM_END) {
-		inflateEnd(&stream);
-		ERROR_LOG(HLE, "sceZlibDecompress: inflate failed %08x", err);
-		return 0;
-	}
-	inflateEnd(&stream);
-	if (crc32AddrPtr) {
-		crc = crc32(0L, Z_NULL, 0);
-		*crc32AddrPtr = crc32(crc, outBufferPtr, stream.total_out);
-	}
-	return stream.total_out;
+	return CommonDecompress(MAX_WBITS, OutBuffer, OutBufferLength, InBuffer, Crc32Addr);
 }
 
 const HLEFunction sceDeflt[] = {
@@ -166,11 +75,11 @@ const HLEFunction sceDeflt[] = {
 	{0X106A3552, nullptr,                            "sceGzipGetName",           '?', ""    },
 	{0X1B5B82BC, nullptr,                            "sceGzipIsValid",           '?', ""    },
 	{0X2EE39A64, nullptr,                            "sceZlibAdler32",           '?', ""    },
-	{0X44054E03, &WrapI_UIUU<sceDeflateDecompress>,  "sceDeflateDecompress",     'i', "xixx"},
+	{0X44054E03, &WrapI_UIUU<sceDeflateDecompress>,  "sceDeflateDecompress",     'i', "xixp"},
 	{0X6A548477, nullptr,                            "sceZlibGetCompressedData", '?', ""    },
-	{0X6DBCF897, &WrapI_UIUU<sceGzipDecompress>,     "sceGzipDecompress",        'i', "xixx"},
+	{0X6DBCF897, &WrapI_UIUU<sceGzipDecompress>,     "sceGzipDecompress",        'i', "xixp"},
 	{0X8AA82C92, nullptr,                            "sceGzipGetInfo",           '?', ""    },
-	{0XA9E4FB28, &WrapI_UIUU<sceZlibDecompress>,     "sceZlibDecompress",        'i', "xixx"},
+	{0XA9E4FB28, &WrapI_UIUU<sceZlibDecompress>,     "sceZlibDecompress",        'i', "xixp"},
 	{0XAFE01FD3, nullptr,                            "sceZlibGetInfo",           '?', ""    },
 	{0XB767F9A0, nullptr,                            "sceGzipGetComment",        '?', ""    },
 	{0XE46EB986, nullptr,                            "sceZlibIsValid",           '?', ""    },

--- a/Core/HLE/sceDmac.cpp
+++ b/Core/HLE/sceDmac.cpp
@@ -50,8 +50,9 @@ static int __DmacMemcpy(u32 dst, u32 src, u32 size) {
 		skip = gpu->PerformMemoryCopy(dst, src, size);
 	}
 	if (!skip) {
-		// TODO: InvalidateICache src before copy?
-		Memory::Memcpy(dst, Memory::GetPointer(src), size, "DmacMemcpy");
+		currentMIPS->InvalidateICache(src, size);
+		const std::string tag = "DmacMemcpy/" + GetMemWriteTagAt(src, size);
+		Memory::Memcpy(dst, src, size, tag.c_str(), tag.size());
 		currentMIPS->InvalidateICache(dst, size);
 	}
 

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -658,8 +658,9 @@ static u32 sceKernelMemcpy(u32 dst, u32 src, u32 size)
 		}
 	}
 
-	NotifyMemInfo(MemBlockFlags::READ, src, size, "KernelMemcpy");
-	NotifyMemInfo(MemBlockFlags::WRITE, dst, size, "KernelMemcpy");
+	const std::string tag = "KernelMemcpy/" + GetMemWriteTagAt(src, size);
+	NotifyMemInfo(MemBlockFlags::READ, src, size, tag.c_str(), tag.size());
+	NotifyMemInfo(MemBlockFlags::WRITE, dst, size, tag.c_str(), tag.size());
 
 	return dst;
 }
@@ -690,8 +691,9 @@ static u32 sysclib_memcpy(u32 dst, u32 src, u32 size) {
 	if (Memory::IsValidRange(dst, size) && Memory::IsValidRange(src, size)) {
 		memcpy(Memory::GetPointer(dst), Memory::GetPointer(src), size);
 	}
-	NotifyMemInfo(MemBlockFlags::READ, src, size, "KernelMemcpy");
-	NotifyMemInfo(MemBlockFlags::WRITE, dst, size, "KernelMemcpy");
+	const std::string tag = "KernelMemcpy/" + GetMemWriteTagAt(src, size);
+	NotifyMemInfo(MemBlockFlags::READ, src, size, tag.c_str(), tag.size());
+	NotifyMemInfo(MemBlockFlags::WRITE, dst, size, tag.c_str(), tag.size());
 	return dst;
 }
 
@@ -790,8 +792,9 @@ static u32 sysclib_memmove(u32 dst, u32 src, u32 size) {
 	if (Memory::IsValidRange(dst, size) && Memory::IsValidRange(src, size)) {
 		memmove(Memory::GetPointer(dst), Memory::GetPointer(src), size);
 	}
-	NotifyMemInfo(MemBlockFlags::READ, src, size, "KernelMemmove");
-	NotifyMemInfo(MemBlockFlags::WRITE, dst, size, "KernelMemmove");
+	const std::string tag = "KernelMemmove/" + GetMemWriteTagAt(src, size);
+	NotifyMemInfo(MemBlockFlags::READ, src, size, tag.c_str(), tag.size());
+	NotifyMemInfo(MemBlockFlags::WRITE, dst, size, tag.c_str(), tag.size());
 	return 0;
 }
 

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -149,6 +149,8 @@ void VagDecoder::GetSamples(s16 *outSamples, int numSamples) {
 	}
 
 	if (readp > origp) {
+		if (g_Config.bDebugMemInfoDetailed)
+			NotifyMemInfo(MemBlockFlags::READ, read_, readp - origp, "SasVagDecoder");
 		read_ += readp - origp;
 	}
 }
@@ -426,7 +428,7 @@ void SasVoice::ReadSamples(s16 *output, int numSamples) {
 					pcmIndex = 0;
 					break;
 				}
-				Memory::Memcpy(out, pcmAddr + pcmIndex * sizeof(s16), size * sizeof(s16));
+				Memory::Memcpy(out, pcmAddr + pcmIndex * sizeof(s16), size * sizeof(s16), "SasVoicePCM");
 				pcmIndex += size;
 				needed -= size;
 				out += size;
@@ -580,6 +582,11 @@ void SasInstance::Mix(u32 outAddr, u32 inAddr, int leftVol, int rightVol) {
 	if (outputMode == PSP_SAS_OUTPUTMODE_MIXED) {
 		// Okay, apply effects processing to the Send buffer.
 		WriteMixedOutput(outp, inp, leftVol, rightVol);
+		if (g_Config.bDebugMemInfoDetailed) {
+			if (inp)
+				NotifyMemInfo(MemBlockFlags::READ, inAddr, grainSize * sizeof(u16) * 2, "SasMix");
+			NotifyMemInfo(MemBlockFlags::WRITE, outAddr, grainSize * sizeof(u16) * 2, "SasMix");
+		}
 	} else {
 		s16 *outpL = outp + grainSize * 0;
 		s16 *outpR = outp + grainSize * 1;
@@ -592,6 +599,7 @@ void SasInstance::Mix(u32 outAddr, u32 inAddr, int leftVol, int rightVol) {
 			*outpSendL++ = clamp_s16(sendBuffer[i + 0]);
 			*outpSendR++ = clamp_s16(sendBuffer[i + 1]);
 		}
+		NotifyMemInfo(MemBlockFlags::WRITE, outAddr, grainSize * sizeof(u16) * 4, "SasMix");
 	}
 	memset(mixBuffer, 0, grainSize * sizeof(int) * 2);
 	memset(sendBuffer, 0, grainSize * sizeof(int) * 2);

--- a/Core/MIPS/MIPSAsm.cpp
+++ b/Core/MIPS/MIPSAsm.cpp
@@ -35,7 +35,7 @@ public:
 		if (!Memory::IsValidAddress((u32)(address+length-1)))
 			return false;
 
-		Memory::Memcpy((u32)address,data,(u32)length);
+		Memory::Memcpy((u32)address, data, (u32)length, "Debugger");
 		
 		// In case this is a delay slot or combined instruction, clear cache above it too.
 		if (MIPSComp::jit)

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2179,7 +2179,9 @@ void FramebufferManagerCommon::PackFramebufferSync_(VirtualFramebuffer *vfb, int
 
 	if (destPtr) {
 		draw_->CopyFramebufferToMemorySync(vfb->fbo, Draw::FB_COLOR_BIT, x, y, w, h, destFormat, destPtr, vfb->fb_stride, "PackFramebufferSync_");
-		NotifyMemInfo(MemBlockFlags::WRITE, fb_address + dstByteOffset, dstSize, "FramebufferPack");
+		char tag[128];
+		size_t len = snprintf(tag, sizeof(tag), "FramebufferPack/%08x_%08x_%dx%d_%s", vfb->fb_address, vfb->z_address, w, h, GeBufferFormatToString(vfb->format));
+		NotifyMemInfo(MemBlockFlags::WRITE, fb_address + dstByteOffset, dstSize, tag, len);
 	} else {
 		ERROR_LOG(G3D, "PackFramebufferSync_: Tried to readback to bad address %08x (stride = %d)", fb_address + dstByteOffset, vfb->fb_stride);
 	}

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2742,8 +2742,9 @@ bool GPUCommon::PerformMemoryCopy(u32 dest, u32 src, int size) {
 		return true;
 	}
 
-	NotifyMemInfo(MemBlockFlags::READ, src, size, "GPUMemcpy");
-	NotifyMemInfo(MemBlockFlags::WRITE, dest, size, "GPUMemcpy");
+	const std::string tag = "GPUMemcpy/" + GetMemWriteTagAt(src, size);
+	NotifyMemInfo(MemBlockFlags::READ, src, size, tag.c_str(), tag.size());
+	NotifyMemInfo(MemBlockFlags::WRITE, dest, size, tag.c_str(), tag.size());
 	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
 	GPURecord::NotifyMemcpy(dest, src, size);
 	return false;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2738,7 +2738,8 @@ bool GPUCommon::PerformMemoryCopy(u32 dest, u32 src, int size) {
 			// We use a little hack for PerformMemoryDownload/PerformMemoryUpload using a VRAM mirror.
 			// Since they're identical we don't need to copy.
 			if (!Memory::IsVRAMAddress(dest) || (dest ^ 0x00400000) != src) {
-				Memory::Memcpy(dest, src, size);
+				const std::string tag = "GPUMemcpy/" + GetMemWriteTagAt(src, size);
+				Memory::Memcpy(dest, src, size, tag.c_str(), tag.size());
 			}
 		}
 		InvalidateCache(dest, size, GPU_INVALIDATE_HINT);

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2721,8 +2721,11 @@ void GPUCommon::DoBlockTransfer(u32 skipDrawReason) {
 		framebufferManager_->NotifyBlockTransferAfter(dstBasePtr, dstStride, dstX, dstY, srcBasePtr, srcStride, srcX, srcY, width, height, bpp, skipDrawReason);
 	}
 
-	NotifyMemInfo(MemBlockFlags::READ, srcBasePtr + (srcY * srcStride + srcX) * bpp, height * srcStride * bpp, "GPUBlockTransfer");
-	NotifyMemInfo(MemBlockFlags::WRITE, dstBasePtr + (dstY * dstStride + dstX) * bpp, height * dstStride * bpp, "GPUBlockTransfer");
+	const uint32_t src = srcBasePtr + (srcY * srcStride + srcX) * bpp;
+	const uint32_t srcSize = height * srcStride * bpp;
+	const std::string tag = "GPUBlockTransfer/" + GetMemWriteTagAt(src, srcSize);
+	NotifyMemInfo(MemBlockFlags::READ, src, srcSize, tag.c_str(), tag.size());
+	NotifyMemInfo(MemBlockFlags::WRITE, dstBasePtr + (dstY * dstStride + dstX) * bpp, height * dstStride * bpp, tag.c_str(), tag.size());
 
 	// TODO: Correct timing appears to be 1.9, but erring a bit low since some of our other timing is inaccurate.
 	cyclesExecuted += ((height * width * bpp) * 16) / 10;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -653,8 +653,11 @@ void SoftGPU::ExecuteOp(u32 op, u32 diff) {
 				memcpy(dst, src, width * bpp);
 			}
 
-			NotifyMemInfo(MemBlockFlags::READ, srcBasePtr + (srcY * srcStride + srcX) * bpp, height * srcStride * bpp, "GPUBlockTransfer");
-			NotifyMemInfo(MemBlockFlags::WRITE, dstBasePtr + (dstY * dstStride + dstX) * bpp, height * dstStride * bpp, "GPUBlockTransfer");
+			const uint32_t src = srcBasePtr + (srcY * srcStride + srcX) * bpp;
+			const uint32_t srcSize = height * srcStride * bpp;
+			const std::string tag = "GPUBlockTransfer/" + GetMemWriteTagAt(src, srcSize);
+			NotifyMemInfo(MemBlockFlags::READ, src, srcSize, tag.c_str(), tag.size());
+			NotifyMemInfo(MemBlockFlags::WRITE, dstBasePtr + (dstY * dstStride + dstX) * bpp, height * dstStride * bpp, tag.c_str(), tag.size());
 
 			// TODO: Correct timing appears to be 1.9, but erring a bit low since some of our other timing is inaccurate.
 			cyclesExecuted += ((height * width * bpp) * 16) / 10;

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -533,6 +533,28 @@ void CtrlMemView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 			}
 			break;
 
+		case ID_MEMVIEW_EXTENTBEGIN:
+		{
+			std::vector<MemBlockInfo> memRangeInfo = FindMemInfoByFlag(highlightFlags_, curAddress, 1);
+			uint32_t addr = curAddress;
+			for (MemBlockInfo info : memRangeInfo) {
+				addr = info.start;
+			}
+			gotoAddr(addr);
+			break;
+		}
+
+		case ID_MEMVIEW_EXTENTEND:
+		{
+			std::vector<MemBlockInfo> memRangeInfo = FindMemInfoByFlag(highlightFlags_, curAddress, 1);
+			uint32_t addr = curAddress;
+			for (MemBlockInfo info : memRangeInfo) {
+				addr = info.start + info.size - 1;
+			}
+			gotoAddr(addr);
+			break;
+		}
+
 		case ID_MEMVIEW_COPYADDRESS:
 			{
 				char temp[24];
@@ -845,6 +867,7 @@ void CtrlMemView::toggleOffsetScale(CommonToggles toggle)
 void CtrlMemView::setHighlightType(MemBlockFlags flags) {
 	if (highlightFlags_ != flags) {
 		highlightFlags_ = flags;
+		updateStatusBarText();
 		redraw();
 	}
 }

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -679,6 +679,9 @@ BEGIN
         MENUITEM "Go to in Disasm",            ID_MEMVIEW_GOTOINDISASM
         MENUITEM "Copy address",               ID_MEMVIEW_COPYADDRESS
         MENUITEM SEPARATOR
+        MENUITEM "Go to Extent Begin",         ID_MEMVIEW_EXTENTBEGIN
+        MENUITEM "Go to Extent End",           ID_MEMVIEW_EXTENTEND
+        MENUITEM SEPARATOR
         MENUITEM "Copy Value (8 bit)",         ID_MEMVIEW_COPYVALUE_8
         MENUITEM "Copy Value (16 bit)",        ID_MEMVIEW_COPYVALUE_16
         MENUITEM "Copy Value (32 bit)",        ID_MEMVIEW_COPYVALUE_32

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -376,6 +376,8 @@
 #define ID_FILE_DUMP_VIDEO_OUTPUT        40204
 #define ID_EMULATION_CHAT                40205
 #define IDC_MEMVIEW_STATUS               40206
+#define ID_MEMVIEW_EXTENTBEGIN           40207
+#define ID_MEMVIEW_EXTENTEND             40208
 
 // Dummy option to let the buffered rendering hotkey cycle through all the options.
 #define ID_OPTIONS_BUFFEREDRENDERINGDUMMY 40500
@@ -388,7 +390,7 @@
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        256
-#define _APS_NEXT_COMMAND_VALUE         40207
+#define _APS_NEXT_COMMAND_VALUE         40209
 #define _APS_NEXT_CONTROL_VALUE         1202
 #define _APS_NEXT_SYMED_VALUE           101
 #endif


### PR DESCRIPTION
This also allows navigating among tags in the memory view.

Some games also read data from files, then memcpy it elsewhere, so this carries the tag along for copies.  So far it seemed fine for performance, but we could put it behind the higher resolution config setting if it's a problem.

Decided to also have the file offset, always, especially for large files.

Also small tweaks to deflate and dmac.

-[Unknown]