### PR TITLE
UI: Flip Y analog direction based on config, normalize dinput right analog

### DIFF
--- a/Common/Input/InputState.cpp
+++ b/Common/Input/InputState.cpp
@@ -33,6 +33,7 @@ std::vector<KeyDef> confirmKeys;
 std::vector<KeyDef> cancelKeys;
 std::vector<KeyDef> tabLeftKeys;
 std::vector<KeyDef> tabRightKeys;
+static std::unordered_map<int, int> uiFlipAnalogY;
 
 static void AppendKeys(std::vector<KeyDef> &keys, const std::vector<KeyDef> &newKeys) {
 	for (auto iter = newKeys.begin(); iter != newKeys.end(); ++iter) {
@@ -60,4 +61,15 @@ void SetConfirmCancelKeys(const std::vector<KeyDef> &confirm, const std::vector<
 void SetTabLeftRightKeys(const std::vector<KeyDef> &tabLeft, const std::vector<KeyDef> &tabRight) {
 	tabLeftKeys = tabLeft;
 	tabRightKeys = tabRight;
+}
+
+void SetAnalogFlipY(std::unordered_map<int, int> flipYByDeviceId) {
+	uiFlipAnalogY = flipYByDeviceId;
+}
+
+int GetAnalogYDirection(int deviceId) {
+	auto configured = uiFlipAnalogY.find(deviceId);
+	if (configured != uiFlipAnalogY.end())
+		return configured->second;
+	return 0;
 }

--- a/Common/Input/InputState.h
+++ b/Common/Input/InputState.h
@@ -4,8 +4,9 @@
 // own mapping. Might later move the mapping system from PPSSPP to native.
 
 #include <map>
-#include <vector>
 #include <mutex>
+#include <unordered_map>
+#include <vector>
 
 #include "Common/Math/lin/vec3.h"
 #include "Common/Input/KeyCodes.h"
@@ -162,3 +163,7 @@ void SetDPadKeys(const std::vector<KeyDef> &leftKey, const std::vector<KeyDef> &
 		const std::vector<KeyDef> &upKey, const std::vector<KeyDef> &downKey);
 void SetConfirmCancelKeys(const std::vector<KeyDef> &confirm, const std::vector<KeyDef> &cancel);
 void SetTabLeftRightKeys(const std::vector<KeyDef> &tabLeft, const std::vector<KeyDef> &tabRight);
+
+// 0 means unknown (attempt autodetect), -1 means flip, 1 means original direction.
+void SetAnalogFlipY(std::unordered_map<int, int> flipYByDeviceId);
+int GetAnalogYDirection(int deviceId);

--- a/Common/UI/Root.cpp
+++ b/Common/UI/Root.cpp
@@ -4,11 +4,11 @@
 
 #include "ppsspp_config.h"
 
-#include "Common/UI/Root.h"
-#include "Common/UI/ViewGroup.h"
-
+#include "Common/Input/InputState.h"
 #include "Common/Log.h"
 #include "Common/TimeUtil.h"
+#include "Common/UI/Root.h"
+#include "Common/UI/ViewGroup.h"
 
 namespace UI {
 
@@ -346,14 +346,21 @@ bool AxisEvent(const AxisInput &axis, ViewGroup *root) {
 			old.x = dir;
 		}
 		if (axis.axisId == JOYSTICK_AXIS_Y || axis.axisId == JOYSTICK_AXIS_HAT_Y) {
-			// We stupidly interpret the joystick Y axis backwards on Android and Linux instead of reversing
-			// it early (see keymaps...). Too late to fix without invalidating a lot of config files, so we
-			// reverse it here too.
+			int direction = GetAnalogYDirection(axis.deviceId);
+			if (direction == 0) {
+				// We stupidly interpret the joystick Y axis backwards on Android and Linux instead of reversing
+				// it early (see keymaps...). Too late to fix without invalidating a lot of config files, so we
+				// reverse it here too.
 #if PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(LINUX)
-			GenerateKeyFromAxis(old.y, dir, NKCODE_DPAD_UP, NKCODE_DPAD_DOWN);
+				GenerateKeyFromAxis(old.y, dir, NKCODE_DPAD_UP, NKCODE_DPAD_DOWN);
 #else
-			GenerateKeyFromAxis(old.y, dir, NKCODE_DPAD_DOWN, NKCODE_DPAD_UP);
+				GenerateKeyFromAxis(old.y, dir, NKCODE_DPAD_DOWN, NKCODE_DPAD_UP);
 #endif
+			} else if (direction == -1) {
+				GenerateKeyFromAxis(old.y, dir, NKCODE_DPAD_UP, NKCODE_DPAD_DOWN);
+			} else {
+				GenerateKeyFromAxis(old.y, dir, NKCODE_DPAD_DOWN, NKCODE_DPAD_UP);
+			}
 			old.y = dir;
 		}
 		break;

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -849,6 +849,37 @@ bool AxisFromPspButton(int btn, int *deviceId, int *axisId, int *direction) {
 	return false;
 }
 
+MappedAnalogAxes MappedAxesForDevice(int deviceId) {
+	MappedAnalogAxes result{};
+
+	// Find the axisId mapped for a specific virtual button.
+	auto findAxisId = [&](int btn) -> int {
+		for (const auto &key : g_controllerMap[btn]) {
+			if (key.deviceId == deviceId) {
+				int direction = 0;
+				return TranslateKeyCodeToAxis(key.keyCode, direction);
+			}
+		}
+		return -1;
+	};
+
+	// Find the axisId of a pair of opposing buttons.
+	auto findAxisIdPair = [&](int minBtn, int maxBtn) -> int {
+		int foundMin = findAxisId(minBtn);
+		int foundMax = findAxisId(maxBtn);
+		if (foundMin == foundMax) {
+			return foundMax;
+		}
+		return -1;
+	};
+
+	result.leftXAxisId = findAxisIdPair(VIRTKEY_AXIS_X_MIN, VIRTKEY_AXIS_X_MAX);
+	result.leftYAxisId = findAxisIdPair(VIRTKEY_AXIS_Y_MIN, VIRTKEY_AXIS_Y_MAX);
+	result.rightXAxisId = findAxisIdPair(VIRTKEY_AXIS_RIGHT_X_MIN, VIRTKEY_AXIS_RIGHT_X_MAX);
+	result.rightYAxisId = findAxisIdPair(VIRTKEY_AXIS_RIGHT_Y_MIN, VIRTKEY_AXIS_RIGHT_Y_MAX);
+	return result;
+}
+
 void RemoveButtonMapping(int btn) {
 	for (auto iter = g_controllerMap.begin(); iter != g_controllerMap.end(); ++iter)	{
 		if (iter->first == btn) {

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -15,8 +15,9 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include <set>
 #include <algorithm>
+#include <set>
+#include <unordered_map>
 
 #if defined(SDL)
 #include <SDL_keyboard.h>
@@ -49,6 +50,7 @@ struct DefMappingStruct {
 KeyMapping g_controllerMap;
 int g_controllerMapGeneration = 0;
 std::set<std::string> g_seenPads;
+static std::set<int> g_seenDeviceIds;
 
 bool g_swapped_keys = false;
 
@@ -352,6 +354,13 @@ void UpdateNativeMenuKeys() {
 	SetDPadKeys(upKeys, downKeys, leftKeys, rightKeys);
 	SetConfirmCancelKeys(confirmKeys, cancelKeys);
 	SetTabLeftRightKeys(tabLeft, tabRight);
+
+	std::unordered_map<int, int> flipYByDeviceId;
+	for (int deviceId : g_seenDeviceIds) {
+		auto analogs = MappedAxesForDevice(deviceId);
+		flipYByDeviceId[deviceId] = analogs.leftY.direction;
+	}
+	SetAnalogFlipY(flipYByDeviceId);
 }
 
 static void SetDefaultKeyMap(int deviceId, const DefMappingStruct *array, size_t count, bool replace) {
@@ -361,6 +370,7 @@ static void SetDefaultKeyMap(int deviceId, const DefMappingStruct *array, size_t
 		else
 			SetAxisMapping(array[i].pspKey, deviceId, array[i].key, array[i].direction, replace);
 	}
+	g_seenDeviceIds.insert(deviceId);
 }
 
 void SetDefaultKeyMap(DefaultMaps dmap, bool replace) {
@@ -853,30 +863,31 @@ MappedAnalogAxes MappedAxesForDevice(int deviceId) {
 	MappedAnalogAxes result{};
 
 	// Find the axisId mapped for a specific virtual button.
-	auto findAxisId = [&](int btn) -> int {
+	auto findAxisId = [&](int btn) -> MappedAnalogAxis {
+		MappedAnalogAxis info{ -1 };
 		for (const auto &key : g_controllerMap[btn]) {
 			if (key.deviceId == deviceId) {
-				int direction = 0;
-				return TranslateKeyCodeToAxis(key.keyCode, direction);
+				info.axisId = TranslateKeyCodeToAxis(key.keyCode, info.direction);
+				return info;
 			}
 		}
-		return -1;
+		return info;
 	};
 
 	// Find the axisId of a pair of opposing buttons.
-	auto findAxisIdPair = [&](int minBtn, int maxBtn) -> int {
-		int foundMin = findAxisId(minBtn);
-		int foundMax = findAxisId(maxBtn);
-		if (foundMin == foundMax) {
+	auto findAxisIdPair = [&](int minBtn, int maxBtn) -> MappedAnalogAxis {
+		MappedAnalogAxis foundMin = findAxisId(minBtn);
+		MappedAnalogAxis foundMax = findAxisId(maxBtn);
+		if (foundMin.axisId == foundMax.axisId) {
 			return foundMax;
 		}
-		return -1;
+		return MappedAnalogAxis{ -1 };
 	};
 
-	result.leftXAxisId = findAxisIdPair(VIRTKEY_AXIS_X_MIN, VIRTKEY_AXIS_X_MAX);
-	result.leftYAxisId = findAxisIdPair(VIRTKEY_AXIS_Y_MIN, VIRTKEY_AXIS_Y_MAX);
-	result.rightXAxisId = findAxisIdPair(VIRTKEY_AXIS_RIGHT_X_MIN, VIRTKEY_AXIS_RIGHT_X_MAX);
-	result.rightYAxisId = findAxisIdPair(VIRTKEY_AXIS_RIGHT_Y_MIN, VIRTKEY_AXIS_RIGHT_Y_MAX);
+	result.leftX = findAxisIdPair(VIRTKEY_AXIS_X_MIN, VIRTKEY_AXIS_X_MAX);
+	result.leftY = findAxisIdPair(VIRTKEY_AXIS_Y_MIN, VIRTKEY_AXIS_Y_MAX);
+	result.rightX = findAxisIdPair(VIRTKEY_AXIS_RIGHT_X_MIN, VIRTKEY_AXIS_RIGHT_X_MAX);
+	result.rightY = findAxisIdPair(VIRTKEY_AXIS_RIGHT_Y_MIN, VIRTKEY_AXIS_RIGHT_Y_MAX);
 	return result;
 }
 
@@ -905,6 +916,7 @@ void SetKeyMapping(int btn, KeyDef key, bool replace) {
 	}
 	g_controllerMapGeneration++;
 
+	g_seenDeviceIds.insert(key.deviceId);
 	UpdateNativeMenuKeys();
 }
 
@@ -969,6 +981,7 @@ void LoadFromIni(IniFile &file) {
 			int keyCode = atoi(parts[1].c_str());
 
 			SetKeyMapping(psp_button_names[i].key, KeyDef(deviceId, keyCode), false);
+			g_seenDeviceIds.insert(deviceId);
 		}
 	}
 

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -80,11 +80,16 @@ const float AXIS_BIND_THRESHOLD_MOUSE = 0.01f;
 
 typedef std::map<int, std::vector<KeyDef>> KeyMapping;
 
+struct MappedAnalogAxis {
+	int axisId;
+	int direction;
+};
+
 struct MappedAnalogAxes {
-	int leftXAxisId;
-	int leftYAxisId;
-	int rightXAxisId;
-	int rightYAxisId;
+	MappedAnalogAxis leftX;
+	MappedAnalogAxis leftY;
+	MappedAnalogAxis rightX;
+	MappedAnalogAxis rightY;
 };
 
 // KeyMap

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -80,6 +80,13 @@ const float AXIS_BIND_THRESHOLD_MOUSE = 0.01f;
 
 typedef std::map<int, std::vector<KeyDef>> KeyMapping;
 
+struct MappedAnalogAxes {
+	int leftXAxisId;
+	int leftYAxisId;
+	int rightXAxisId;
+	int rightYAxisId;
+};
+
 // KeyMap
 // A translation layer for key assignment. Provides
 // integration with Core's config state.
@@ -129,7 +136,7 @@ namespace KeyMap {
 
 	bool AxisToPspButton(int deviceId, int axisId, int direction, std::vector<int> *pspKeys);
 	bool AxisFromPspButton(int btn, int *deviceId, int *axisId, int *direction);
-	std::string NamePspButtonFromAxis(int deviceId, int axisId, int direction);
+	MappedAnalogAxes MappedAxesForDevice(int deviceId);
 
 	void LoadFromIni(IniFile &iniFile);
 	void SaveToIni(IniFile &iniFile);

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -531,7 +531,8 @@ bool AnalogTestScreen::axis(const AxisInput &axis) {
 	if (IgnoreAxisForMapping(axis.axisId))
 		return false;
 
-	if (axis.value > AXIS_BIND_THRESHOLD || axis.value < -AXIS_BIND_THRESHOLD) {
+	const float AXIS_LOG_THRESHOLD = AXIS_BIND_THRESHOLD * 0.5f;
+	if (axis.value > AXIS_LOG_THRESHOLD || axis.value < -AXIS_LOG_THRESHOLD) {
 		char buf[512];
 		snprintf(buf, sizeof(buf), "Axis: %d (value %1.3f) Device ID: %d",
 			axis.axisId, axis.value, axis.deviceId);

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -26,14 +26,10 @@
 #include "Common/System/NativeApp.h"
 #include "Core/Config.h"
 #include "Core/HLE/sceCtrl.h"
+#include "Core/KeyMap.h"
 #include "Core/Reporting.h"
 #include "Windows/DinputDevice.h"
 #pragma comment(lib,"dinput8.lib")
-
-#ifdef min
-#undef min
-#undef max
-#endif
 
 //initialize static members of DinputDevice
 unsigned int                  DinputDevice::pInstances = 0;
@@ -227,6 +223,69 @@ inline float LinearMaps(float val, float a0, float a1, float b0, float b1) {
 	return b0 + (((val - a0) * (b1 - b0)) / (a1 - a0));
 }
 
+static void ApplyNormalization(LONG &jsx, LONG &jsy) {
+	// Circle to Square mapping, cribbed from XInputDevice
+	float sx = (float)jsx;
+	float sy = (float)jsy;
+	float scaleFactor = sqrtf((sx * sx + sy * sy) / std::max(sx * sx, sy * sy));
+	jsx = (int)(sx * scaleFactor);
+	jsy = (int)(sy * scaleFactor);
+
+	// Linear range mapping (used to invert deadzones)
+	float dz = g_Config.fDInputAnalogDeadzone;
+	int idzm = g_Config.iDInputAnalogInverseMode;
+	float idz = g_Config.fDInputAnalogInverseDeadzone;
+	float md = std::max(dz, idz);
+	float st = g_Config.fDInputAnalogSensitivity;
+
+	float magnitude = sqrtf((float)(jsx * jsx + jsy * jsy));
+	if (magnitude > dz * 10000.0f) {
+		if (idzm == 1) {
+			int xSign = Signs(jsx);
+			if (xSign != 0) {
+				jsx = LinearMaps(jsx, xSign * (int)(dz * 10000), xSign * 10000, xSign * (int)(md * 10000), xSign * (int)(st * 10000));
+			}
+		} else if (idzm == 2) {
+			int ySign = Signs(jsy);
+			if (ySign != 0) {
+				jsy = LinearMaps(jsy, ySign * (int)(dz * 10000.0f), ySign * 10000, ySign * (int)(md * 10000.0f), ySign * (int)(st * 10000));
+			}
+		} else if (idzm == 3) {
+			float xNorm = (float)jsx / magnitude;
+			float yNorm = (float)jsy / magnitude;
+			float mapMag = LinearMaps(magnitude, dz * 10000.0f, 10000.0f, md * 10000.0f, 10000.0f * st);
+			jsx = (short)(xNorm * mapMag);
+			jsy = (short)(yNorm * mapMag);
+		}
+	} else {
+		jsx = 0;
+		jsy = 0;
+	}
+
+	jsx = (short)std::min(10000.0f, std::max((float)jsx, -10000.0f));
+	jsy = (short)std::min(10000.0f, std::max((float)jsy, -10000.0f));
+}
+
+static LONG *ValueForAxisId(DIJOYSTATE2 &js, int axisId) {
+	switch (axisId) {
+	case JOYSTICK_AXIS_X: return &js.lX;
+	case JOYSTICK_AXIS_Y: return &js.lY;
+	case JOYSTICK_AXIS_Z: return &js.lZ;
+	case JOYSTICK_AXIS_RX: return &js.lRx;
+	case JOYSTICK_AXIS_RY: return &js.lRy;
+	case JOYSTICK_AXIS_RZ: return &js.lRz;
+	default: return nullptr;
+	}
+}
+
+static void ApplyNormalization(DIJOYSTATE2 &js, int xAxisId, int yAxisId) {
+	LONG *nrmX = ValueForAxisId(js, xAxisId);
+	LONG *nrmY = ValueForAxisId(js, yAxisId);
+	if (nrmX != nullptr && nrmY != nullptr) {
+		ApplyNormalization(*nrmX, *nrmY);
+	}
+}
+
 int DinputDevice::UpdateState() {
 	if (!pJoystick) return -1;
 
@@ -246,53 +305,11 @@ int DinputDevice::UpdateState() {
 		AxisInput axis;
 		axis.deviceId = DEVICE_ID_PAD_0 + pDevNum;
 
-		// Circle to Square mapping, cribbed from XInputDevice
-		float sx = (float)js.lX;
-		float sy = (float)js.lY;
-		float scaleFactor = sqrtf((sx * sx + sy * sy) / std::max(sx * sx, sy * sy));
-		js.lX = (int)(sx * scaleFactor);
-		js.lY = (int)(sy * scaleFactor);
-		
-		// Linear range mapping (used to invert deadzones)
-		float dz = g_Config.fDInputAnalogDeadzone;
-		int idzm = g_Config.iDInputAnalogInverseMode;
-		float idz = g_Config.fDInputAnalogInverseDeadzone;
-		float md = std::max(dz, idz);
-		float st = g_Config.fDInputAnalogSensitivity;
-
-		float magnitude = sqrtf((float)(js.lX * js.lX + js.lY * js.lY));
-		if (magnitude > dz * 10000.0f) {
-			if (idzm == 1)
-			{
-				int xSign = Signs(js.lX);
-				if (xSign != 0) {
-					js.lX = LinearMaps(js.lX, xSign * (int)(dz * 10000), xSign * 10000, xSign * (int)(md * 10000), xSign * (int)(st * 10000));
-				}
-			}
-			else if (idzm == 2)
-			{
-				int ySign = Signs(js.lY);
-				if (ySign != 0) {
-					js.lY = LinearMaps(js.lY, ySign * (int)(dz * 10000.0f), ySign * 10000, ySign * (int)(md * 10000.0f), ySign * (int)(st * 10000));
-				}
-			}
-			else if (idzm == 3)
-			{
-				float xNorm = (float)js.lX / magnitude;
-				float yNorm = (float)js.lY / magnitude;
-				float mapMag = LinearMaps(magnitude, dz * 10000.0f, 10000.0f, md * 10000.0f, 10000.0f * st);
-				js.lX = (short)(xNorm * mapMag);
-				js.lY = (short)(yNorm * mapMag);
-			}
-		}
-		else
-		{
-			js.lX = 0;
-			js.lY = 0;
-		}
-
-		js.lX = (short)std::min(10000.0f, std::max((float)js.lX, -10000.0f));
-		js.lY = (short)std::min(10000.0f, std::max((float)js.lY, -10000.0f));
+		auto axesToSquare = KeyMap::MappedAxesForDevice(axis.deviceId);
+		ApplyNormalization(js, axesToSquare.leftXAxisId, axesToSquare.leftYAxisId);
+		// Prevent double normalization.
+		if (axesToSquare.leftXAxisId != axesToSquare.rightXAxisId && axesToSquare.leftXAxisId != axesToSquare.rightYAxisId)
+			ApplyNormalization(js, axesToSquare.rightXAxisId, axesToSquare.rightYAxisId);
 
 		SendNativeAxis(DEVICE_ID_PAD_0 + pDevNum, js.lX, last_lX_, JOYSTICK_AXIS_X);
 		SendNativeAxis(DEVICE_ID_PAD_0 + pDevNum, js.lY, last_lY_, JOYSTICK_AXIS_Y);

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -306,10 +306,10 @@ int DinputDevice::UpdateState() {
 		axis.deviceId = DEVICE_ID_PAD_0 + pDevNum;
 
 		auto axesToSquare = KeyMap::MappedAxesForDevice(axis.deviceId);
-		ApplyNormalization(js, axesToSquare.leftXAxisId, axesToSquare.leftYAxisId);
+		ApplyNormalization(js, axesToSquare.leftX.axisId, axesToSquare.leftY.axisId);
 		// Prevent double normalization.
-		if (axesToSquare.leftXAxisId != axesToSquare.rightXAxisId && axesToSquare.leftXAxisId != axesToSquare.rightYAxisId)
-			ApplyNormalization(js, axesToSquare.rightXAxisId, axesToSquare.rightYAxisId);
+		if (axesToSquare.leftX.axisId != axesToSquare.rightX.axisId && axesToSquare.leftX.axisId != axesToSquare.rightY.axisId)
+			ApplyNormalization(js, axesToSquare.rightX.axisId, axesToSquare.rightY.axisId);
 
 		SendNativeAxis(DEVICE_ID_PAD_0 + pDevNum, js.lX, last_lX_, JOYSTICK_AXIS_X);
 		SendNativeAxis(DEVICE_ID_PAD_0 + pDevNum, js.lY, last_lY_, JOYSTICK_AXIS_Y);


### PR DESCRIPTION
This detects the configured left analog stick direction.  If it's reversed, we also reverse the UI analog stick handling.

That should help #14274 and #13062 (which aren't entirely different issues.)

For dinput, we previously assumed that the left analog was mapped to X and Y (which is typically true), and only normalized that.  This now reads the mapped axes, and normalizes the left and right analogs based on configuration.  Would be good to centralize normalization, but I didn't want to deal with the multiple config settings.

Lastly, fixes #12062 by reducing the logging threshold.

-[Unknown]