### PR TITLE
GPU: Preconvert light vecs to Vec3f

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1219,7 +1219,7 @@ bool SavedataParam::GetList(SceUtilitySavedataParam *param)
 		param->idList->resultCount = (u32)validDir.size();
 
 		NotifyMemInfo(MemBlockFlags::WRITE, param->idList.ptr, sizeof(SceUtilitySavedataIdListInfo), "SavedataGetList");
-		NotifyMemInfo(MemBlockFlags::WRITE, param->idList->entries.ptr, validDir.size() * sizeof(SceUtilitySavedataIdListEntry), "SavedataGetList");
+		NotifyMemInfo(MemBlockFlags::WRITE, param->idList->entries.ptr, (uint32_t)validDir.size() * sizeof(SceUtilitySavedataIdListEntry), "SavedataGetList");
 	}
 	return true;
 }

--- a/GPU/Common/TransformCommon.cpp
+++ b/GPU/Common/TransformCommon.cpp
@@ -51,15 +51,9 @@ Lighter::Lighter(int vertType) {
 		lconv[l] = getFloat24(gstate.lconv[l]);
 		int i = l * 3;
 		if (gstate.isLightChanEnabled(l)) {
-			lpos[i] = getFloat24(gstate.lpos[i]);
-			lpos[i + 1] = getFloat24(gstate.lpos[i + 1]);
-			lpos[i + 2] = getFloat24(gstate.lpos[i + 2]);
-			ldir[i] = getFloat24(gstate.ldir[i]);
-			ldir[i + 1] = getFloat24(gstate.ldir[i + 1]);
-			ldir[i + 2] = getFloat24(gstate.ldir[i + 2]);
-			latt[i] = getFloat24(gstate.latt[i]);
-			latt[i + 1] = getFloat24(gstate.latt[i + 1]);
-			latt[i + 2] = getFloat24(gstate.latt[i + 2]);
+			lpos[l] = Vec3fFromGE(&gstate.lpos[i]);
+			ldir[l] = Vec3fFromGE(&gstate.ldir[i]);
+			latt[l] = Vec3fFromGE(&gstate.latt[i]);
 			for (int t = 0; t < 3; t++) {
 				u32 data = gstate.lcolor[l * 3 + t] & 0xFFFFFF;
 				float r = (float)(data & 0xff) * (1.0f / 255.0f);
@@ -108,9 +102,9 @@ void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[
 		Vec3f lightDir(0, 0, 0);
 
 		if (type == GE_LIGHTTYPE_DIRECTIONAL)
-			toLight = Vec3Packedf(&lpos[l * 3]);  // lightdir is for spotlights
+			toLight = lpos[l];  // lightdir is for spotlights
 		else
-			toLight = Vec3Packedf(&lpos[l * 3]) - pos;
+			toLight = lpos[l] - pos;
 
 		bool doSpecular = gstate.isUsingSpecularLight(l);
 		bool poweredDiffuse = gstate.isUsingPoweredDiffuseLight(l);
@@ -136,14 +130,14 @@ void Lighter::Light(float colorOut0[4], float colorOut1[4], const float colorIn[
 			lightScale = 1.0f;
 			break;
 		case GE_LIGHTTYPE_POINT:
-			lightScale = clamp(1.0f / (latt[l * 3] + latt[l * 3 + 1] * distanceToLight + latt[l * 3 + 2] * distanceToLight*distanceToLight), 0.0f, 1.0f);
+			lightScale = clamp(1.0f / (latt[l].x + latt[l].y * distanceToLight + latt[l].z * distanceToLight*distanceToLight), 0.0f, 1.0f);
 			break;
 		case GE_LIGHTTYPE_SPOT:
 		case GE_LIGHTTYPE_UNKNOWN:
-			lightDir = Vec3Packedf(&ldir[l * 3]);
+			lightDir = ldir[l];
 			angle = Dot(toLight.NormalizedOr001(cpu_info.bSSE4_1), lightDir.NormalizedOr001(cpu_info.bSSE4_1));
 			if (angle >= lcutoff[l])
-				lightScale = clamp(1.0f / (latt[l * 3] + latt[l * 3 + 1] * distanceToLight + latt[l * 3 + 2] * distanceToLight*distanceToLight), 0.0f, 1.0f) * powf(angle, lconv[l]);
+				lightScale = clamp(1.0f / (latt[l].x + latt[l].y * distanceToLight + latt[l].z * distanceToLight*distanceToLight), 0.0f, 1.0f) * powf(angle, lconv[l]);
 			break;
 		default:
 			// ILLEGAL

--- a/GPU/Common/TransformCommon.h
+++ b/GPU/Common/TransformCommon.h
@@ -69,6 +69,13 @@ public:
 	void Light(float colorOut0[4], float colorOut1[4], const float colorIn[4], const Vec3f &pos, const Vec3f &normal);
 
 private:
+	inline Vec3f Vec3fFromGE(const u32 *values) const {
+		float x = getFloat24(values[0]);
+		float y = getFloat24(values[1]);
+		float z = getFloat24(values[2]);
+		return Vec3f(x, y, z);
+	}
+
 	Color4 globalAmbient;
 	Color4 materialEmissive;
 	Color4 materialAmbient;
@@ -80,11 +87,9 @@ private:
 	int materialUpdate_;
 
 	// Converted light parameters
-public:
-	float lpos[12];  // Used by shade UV mapping
-private:
-	float ldir[12];
-	float latt[12];
+	Vec3f lpos[4];  // Used by shade UV mapping
+	Vec3f ldir[4];
+	Vec3f latt[4];
 	float lcutoff[4];
 	float lconv[4];
 	float lcolor[3][4][3];


### PR DESCRIPTION
This might align better for simd anyway, but should also prevent any memory over-reads.  See #14353.  More importantly, this is cleaner and simpler - at least, imho.

Did not actually run AddressSanitizer, though.

-[Unknown]