### PR TITLE
UI: Show more detailed load error messages

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -412,7 +412,10 @@ bool PSP_InitStart(const CoreParameter &coreParam, std::string *error_string) {
 	PSP_SetLoading("Loading game...");
 
 	if (!CPU_Init()) {
-		*error_string = "Failed initializing CPU/Memory";
+		*error_string = coreParameter.errorString;
+		if (error_string->empty()) {
+			*error_string = "Failed initializing CPU/Memory";
+		}
 		pspIsIniting = false;
 		return false;
 	}


### PR DESCRIPTION
0829543 accidentally replaced detailed error messages, like "this is a PS1 game" always with a generic and confusing message, "Failed initializing CPU/Memory".  This brings back the detailed messages.

-[Unknown]