### PR TITLE
Dialog: Lock volatile on thread

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -97,6 +97,8 @@ void PSPDialog::FinishVolatile() {
 int PSPDialog::FinishInit() {
 	if (ReadStatus() != SCE_UTILITY_STATUS_INITIALIZE)
 		return -1;
+	// The thread already locked.
+	volatileLocked_ = true;
 	ChangeStatus(SCE_UTILITY_STATUS_RUNNING, 0);
 	return 0;
 }

--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -75,6 +75,7 @@ void PSPDialog::ChangeStatus(DialogStatus newStatus, int delayUs) {
 			}
 		}
 		status = newStatus;
+		pendingStatus = newStatus;
 		pendingStatusTicks = 0;
 	} else {
 		pendingStatus = newStatus;
@@ -93,6 +94,13 @@ void PSPDialog::FinishVolatile() {
 	}
 }
 
+int PSPDialog::FinishInit() {
+	if (ReadStatus() != SCE_UTILITY_STATUS_INITIALIZE)
+		return -1;
+	ChangeStatus(SCE_UTILITY_STATUS_RUNNING, 0);
+	return 0;
+}
+
 int PSPDialog::FinishShutdown() {
 	if (ReadStatus() != SCE_UTILITY_STATUS_SHUTDOWN)
 		return -1;
@@ -101,12 +109,18 @@ int PSPDialog::FinishShutdown() {
 }
 
 void PSPDialog::ChangeStatusInit(int delayUs) {
-	status = SCE_UTILITY_STATUS_INITIALIZE;
-	ChangeStatus(SCE_UTILITY_STATUS_RUNNING, delayUs);
+	ChangeStatus(SCE_UTILITY_STATUS_INITIALIZE, 0);
+
+	auto params = GetCommonParam();
+	if (params)
+		UtilityDialogInitialize(DialogType(), delayUs, params->accessThread);
+	else
+		ChangeStatus(SCE_UTILITY_STATUS_RUNNING, delayUs);
 }
 
 void PSPDialog::ChangeStatusShutdown(int delayUs) {
-	status = SCE_UTILITY_STATUS_SHUTDOWN;
+	ChangeStatus(SCE_UTILITY_STATUS_SHUTDOWN, 0);
+
 	auto params = GetCommonParam();
 	if (params)
 		UtilityDialogShutdown(DialogType(), delayUs, params->accessThread);

--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -86,6 +86,7 @@ public:
 	void EndDraw();
 
 	void FinishVolatile();
+	int FinishInit();
 	int FinishShutdown();
 
 protected:

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -130,7 +130,7 @@ static PSPNetconfDialog *netDialog;
 static PSPScreenshotDialog *screenshotDialog;
 static PSPGamedataInstallDialog *gamedataInstallDialog;
 
-static int oldStatus = 100; //random value
+static int oldStatus = -1;
 static std::map<int, u32> currentlyLoadedModules;
 static int volatileUnlockEvent = -1;
 static HLEHelperThread *accessThread = nullptr;
@@ -146,6 +146,8 @@ static void ActivateDialog(UtilityDialogType type) {
 	if (!currentDialogActive) {
 		currentDialogType = type;
 		currentDialogActive = true;
+		// So that we log the next one.
+		oldStatus = -1;
 	}
 	CleanupDialogThreads();
 }
@@ -361,7 +363,6 @@ static int sceUtilitySavedataInitStart(u32 paramAddr) {
 		}
 	}
 
-	oldStatus = 100;
 	ActivateDialog(UtilityDialogType::SAVEDATA);
 	return hleLogSuccessX(SCEUTILITY, saveDialog->Init(paramAddr));
 }
@@ -491,7 +492,6 @@ static int sceUtilityMsgDialogInitStart(u32 paramAddr) {
 		return hleLogWarning(SCEUTILITY, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 	
-	oldStatus = 100;
 	ActivateDialog(UtilityDialogType::MSG);
 	return hleLogSuccessInfoX(SCEUTILITY, msgDialog->Init(paramAddr));
 }
@@ -545,7 +545,6 @@ static int sceUtilityOskInitStart(u32 oskPtr) {
 		return hleLogWarning(SCEUTILITY, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 	
-	oldStatus = 100;
 	ActivateDialog(UtilityDialogType::OSK);
 	return hleLogSuccessInfoX(SCEUTILITY, oskDialog->Init(oskPtr));
 }
@@ -587,7 +586,6 @@ static int sceUtilityNetconfInitStart(u32 paramsAddr) {
 		return hleLogWarning(SCEUTILITY, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 	
-	oldStatus = 100;
 	ActivateDialog(UtilityDialogType::NET);
 	return hleLogSuccessInfoI(SCEUTILITY, netDialog->Init(paramsAddr));
 }
@@ -640,7 +638,6 @@ static int sceUtilityScreenshotInitStart(u32 paramAddr) {
 		return hleLogWarning(SCEUTILITY, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 	
-	oldStatus = 100;
 	ActivateDialog(UtilityDialogType::SCREENSHOT);
 	return hleReportWarning(SCEUTILITY, screenshotDialog->Init(paramAddr));
 }

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -283,6 +283,12 @@ void UtilityDialogInitialize(UtilityDialogType type, int delayUs, int priority) 
 		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A0, MIPS_REG_S0, 0),
 		(u32_le)MIPS_MAKE_SYSCALL("sceUtility", "__UtilityWorkUs"),
 
+		// Now actually lock the volatile memory.  Maybe this should be earlier...
+		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A0, MIPS_REG_ZERO, 0),
+		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A1, MIPS_REG_ZERO, 0),
+		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A2, MIPS_REG_ZERO, 0),
+		(u32_le)MIPS_MAKE_SYSCALL("sceSuspendForUser", "sceKernelVolatileMemLock"),
+
 		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A0, MIPS_REG_ZERO, (int)type),
 		(u32_le)MIPS_MAKE_JR_RA(),
 		(u32_le)MIPS_MAKE_SYSCALL("sceUtility", "__UtilityInitDialog"),

--- a/Core/HLE/sceUtility.h
+++ b/Core/HLE/sceUtility.h
@@ -94,6 +94,7 @@ void __UtilityInit();
 void __UtilityDoState(PointerWrap &p);
 void __UtilityShutdown();
 
+void UtilityDialogInitialize(UtilityDialogType type, int delayUs, int priority);
 void UtilityDialogShutdown(UtilityDialogType type, int delayUs, int priority);
 
 void Register_sceUtility();


### PR DESCRIPTION
This moves init locking to a thread as well, so it doesn't matter when and how GetStatus is called.

From #14355, it almost sounds like it's being locked around GetStatus calls like a condition variable or something.

This may also help #14212 as it may be a similar problem.

-[Unknown]