### PR TITLE
Fix some shader errors from reporting

### DIFF
--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -199,7 +199,7 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps, bool ski
 				// Dual source alpha
 				glBindFragDataLocationIndexed(program->program, 0, 0, "fragColor0");
 				glBindFragDataLocationIndexed(program->program, 0, 1, "fragColor1");
-			} else if (gl_extensions.VersionGEThan(3, 3, 0)) {
+			} else if (gl_extensions.VersionGEThan(3, 0, 0)) {
 				glBindFragDataLocation(program->program, 0, "fragColor0");
 			}
 #elif !PPSSPP_PLATFORM(IOS)

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -641,8 +641,12 @@ OpenGLContext::OpenGLContext() {
 		} else if (gl_extensions.VersionGEThan(3, 0, 0)) {
 			shaderLanguageDesc_.shaderLanguage = ShaderLanguage::GLSL_1xx;
 			shaderLanguageDesc_.fragColor0 = "fragColor0";
+			shaderLanguageDesc_.texture = "texture";
 			shaderLanguageDesc_.bitwiseOps = true;
 			shaderLanguageDesc_.texelFetch = "texelFetch";
+			shaderLanguageDesc_.varying_vs = "out";
+			shaderLanguageDesc_.varying_fs = "in";
+			shaderLanguageDesc_.attribute = "in";
 		} else {
 			// This too...
 			shaderLanguageDesc_.shaderLanguage = ShaderLanguage::GLSL_1xx;

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -949,11 +949,15 @@ static u32 sceIoGetstat(const char *filename, u32 addr) {
 }
 
 static u32 sceIoChstat(const char *filename, u32 iostatptr, u32 changebits) {
+	auto iostat = PSPPointer<SceIoStat>::Create(iostatptr);
+	if (!iostat.IsValid())
+		return hleReportError(SCEIO, SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT, "bad address");
+
 	ERROR_LOG_REPORT(SCEIO, "UNIMPL sceIoChstat(%s, %08x, %08x)", filename, iostatptr, changebits);
 	if (changebits & SCE_CST_MODE)
-		ERROR_LOG(SCEIO, "sceIoChstat: change mode requested");
+		ERROR_LOG_REPORT(SCEIO, "sceIoChstat: change mode to %03o requested", iostat->st_mode);
 	if (changebits & SCE_CST_ATTR)
-		ERROR_LOG(SCEIO, "sceIoChstat: change attr requested");
+		ERROR_LOG_REPORT(SCEIO, "sceIoChstat: change attr to %04x requested", iostat->st_attr);
 	if (changebits & SCE_CST_SIZE)
 		ERROR_LOG(SCEIO, "sceIoChstat: change size requested");
 	if (changebits & SCE_CST_CT)
@@ -961,7 +965,7 @@ static u32 sceIoChstat(const char *filename, u32 iostatptr, u32 changebits) {
 	if (changebits & SCE_CST_AT)
 		ERROR_LOG(SCEIO, "sceIoChstat: change access time requested");
 	if (changebits & SCE_CST_MT)
-		ERROR_LOG(SCEIO, "sceIoChstat: change modification time requested");
+		ERROR_LOG_REPORT(SCEIO, "sceIoChstat: change modification time to %04d-%02d-%02d requested", iostat->st_m_time.year, iostat->st_m_time.month, iostat->st_m_time.day);
 	if (changebits & SCE_CST_PRVT)
 		ERROR_LOG(SCEIO, "sceIoChstat: change private data requested");
 	return 0;

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -292,7 +292,7 @@ void GenerateDepalShaderFloat(char *buffer, GEBufferFormat pixelFormat, ShaderLa
 			WRITE(p, "precision mediump float;\n");
 		} else {
 			WRITE(p, "#version %d\n", gl_extensions.GLSLVersion());
-			if (gl_extensions.VersionGEThan(3, 3)) {
+			if (gl_extensions.VersionGEThan(3, 0, 0)) {
 				WRITE(p, "#define gl_FragColor fragColor0\n");
 				WRITE(p, "out vec4 fragColor0;\n");
 			}

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -589,8 +589,8 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 				WRITE(p, "  uint depalOffset = ((u_depal_mask_shift_off_fmt >> 16) & 0xFFU) << 4;\n");
 				WRITE(p, "  uint depalFmt = (u_depal_mask_shift_off_fmt >> 24) & 0x3U;\n");
 				WRITE(p, "  uvec4 col; uint index0; uint index1; uint index2; uint index3;\n");
-				WRITE(p, "  switch (depalFmt) {\n");  // We might want to include fmt in the shader ID if this is a performance issue.
-				WRITE(p, "  case 0U:\n");  // 565
+				WRITE(p, "  switch (int(depalFmt)) {\n");  // We might want to include fmt in the shader ID if this is a performance issue.
+				WRITE(p, "  case 0:\n");  // 565
 				WRITE(p, "    col = uvec4(t.rgb * vec3(31.99, 63.99, 31.99), 0);\n");
 				WRITE(p, "    index0 = (col.b << 11) | (col.g << 5) | (col.r);\n");
 				WRITE(p, "    if (bilinear) {\n");
@@ -602,7 +602,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 				WRITE(p, "      index3 = (col.b << 11) | (col.g << 5) | (col.r);\n");
 				WRITE(p, "    }\n");
 				WRITE(p, "    break;\n");
-				WRITE(p, "  case 1U:\n");  // 5551
+				WRITE(p, "  case 1:\n");  // 5551
 				WRITE(p, "    col = uvec4(t.rgba * vec4(31.99, 31.99, 31.99, 1.0));\n");
 				WRITE(p, "    index0 = (col.a << 15) | (col.b << 10) | (col.g << 5) | (col.r);\n");
 				WRITE(p, "    if (bilinear) {\n");
@@ -614,7 +614,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 				WRITE(p, "      index3 = (col.a << 15) | (col.b << 10) | (col.g << 5) | (col.r);\n");
 				WRITE(p, "    }\n");
 				WRITE(p, "    break;\n");
-				WRITE(p, "  case 2U:\n");  // 4444
+				WRITE(p, "  case 2:\n");  // 4444
 				WRITE(p, "    col = uvec4(t.rgba * 15.99);\n");
 				WRITE(p, "    index0 = (col.a << 12) | (col.b << 8) | (col.g << 4) | (col.r);\n");
 				WRITE(p, "    if (bilinear) {\n");
@@ -626,7 +626,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 				WRITE(p, "      index3 = (col.a << 12) | (col.b << 8) | (col.g << 4) | (col.r);\n");
 				WRITE(p, "    }\n");
 				WRITE(p, "    break;\n");
-				WRITE(p, "  case 3U:\n");  // 8888
+				WRITE(p, "  case 3:\n");  // 8888
 				WRITE(p, "    col = uvec4(t.rgba * 255.99);\n");
 				WRITE(p, "    index0 = (col.a << 24) | (col.b << 16) | (col.g << 8) | (col.r);\n");
 				WRITE(p, "    if (bilinear) {\n");

--- a/assets/shaders/4xhqglsl.vsh
+++ b/assets/shaders/4xhqglsl.vsh
@@ -1,3 +1,8 @@
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
 attribute vec4 a_position;
 attribute vec2 a_texcoord0;
 uniform vec2 u_texelDelta;

--- a/assets/shaders/5xBR.vsh
+++ b/assets/shaders/5xBR.vsh
@@ -18,6 +18,12 @@
    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
    
 */
+
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
 attribute vec4 a_position;
 attribute vec2 a_texcoord0;
 varying vec2 v_texcoord0;

--- a/assets/shaders/aacolor.vsh
+++ b/assets/shaders/aacolor.vsh
@@ -1,6 +1,11 @@
 // by guest(r) - guest.r@gmail.com
 // license: GNU-GPL
 
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
 attribute vec4 a_position;
 attribute vec2 a_texcoord0;
 uniform vec2 u_texelDelta;

--- a/assets/shaders/cartoon.vsh
+++ b/assets/shaders/cartoon.vsh
@@ -1,3 +1,8 @@
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
 attribute vec4 a_position;
 attribute vec2 a_texcoord0;
 uniform vec2 u_texelDelta;

--- a/assets/shaders/fxaa.vsh
+++ b/assets/shaders/fxaa.vsh
@@ -1,3 +1,8 @@
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
 attribute vec4 a_position;
 attribute vec2 a_texcoord0;
 varying vec2 v_texcoord0;

--- a/assets/shaders/natural.vsh
+++ b/assets/shaders/natural.vsh
@@ -1,3 +1,8 @@
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
 uniform vec2 u_texelDelta;
 
 attribute vec4 a_position;

--- a/assets/shaders/naturalA.vsh
+++ b/assets/shaders/naturalA.vsh
@@ -1,3 +1,8 @@
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
 attribute vec4 a_position;
 attribute vec2 a_texcoord0;
 

--- a/assets/shaders/upscale_spline36.vsh
+++ b/assets/shaders/upscale_spline36.vsh
@@ -1,3 +1,8 @@
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
 attribute vec4 a_position;
 attribute vec2 a_texcoord0;
 


### PR DESCRIPTION
As per commits.  All seen in reporting.

A tricky one that's not fixed:
```
ERROR: 0:32: 'packUnorm4x8' :  can't redefine/overload built-in functions!
```

On GLSL ES 3.00, Adreno 308 and Apple.  I couldn't find any useful extensions to detect with... just left it for now.

-[Unknown]