### PR TITLE
Enable save encryption in libretro build

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -364,6 +364,7 @@ void retro_init(void)
    g_Config.iCwCheatRefreshRate = 60;
    g_Config.iMemStickSizeGB = 16;
    g_Config.bFuncReplacements = true;
+   g_Config.bEncryptSave = true;
 
    g_Config.iFirmwareVersion = PSP_DEFAULT_FIRMWARE;
    g_Config.iPSPModel = PSP_MODEL_SLIM;


### PR DESCRIPTION
Since the libretro build doesn't read the ppsspp.ini file the default true value for EncryptSave is not picked up and all save files are stored plainly.
Uncrypted saves fail to load in Toca Race Driver 2 and 3 and potenitally others.

This should bring libretro in line with the default behaviour of the main build.
