### PR TITLE
SaveState: Copy RAM using threads

### DIFF
--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -30,20 +30,20 @@
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"
 
-#include "Core/MemMap.h"
-#include "Core/MemFault.h"
-#include "Core/HDRemaster.h"
-#include "Core/MIPS/MIPS.h"
-#include "Core/HLE/HLE.h"
-
 #include "Core/Core.h"
-#include "Core/Debugger/SymbolMap.h"
-#include "Core/Debugger/MemBlockInfo.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
+#include "Core/Debugger/SymbolMap.h"
+#include "Core/Debugger/MemBlockInfo.h"
+#include "Core/HDRemaster.h"
+#include "Core/HLE/HLE.h"
 #include "Core/HLE/ReplaceTables.h"
+#include "Core/MemMap.h"
+#include "Core/MemFault.h"
+#include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/JitCommon/JitBlockCache.h"
 #include "Core/MIPS/JitCommon/JitCommon.h"
+#include "Core/ThreadPools.h"
 #include "UI/OnScreenDisplay.h"
 
 namespace Memory {
@@ -314,6 +314,34 @@ void Reinit() {
 	Core_NotifyLifecycle(CoreLifecycle::MEMORY_REINITED);
 }
 
+static void DoMemoryVoid(PointerWrap &p, uint32_t start, uint32_t size) {
+	uint8_t *d = GetPointer(start);
+	uint8_t *&storage = *p.ptr;
+
+	switch (p.mode) {
+	case PointerWrap::MODE_READ:
+		GlobalThreadPool::Loop([&](int l, int h) {
+			memcpy(d + l, storage + l, h - l);
+		}, 0, size);
+		break;
+	case PointerWrap::MODE_WRITE:
+		GlobalThreadPool::Loop([&](int l, int h) {
+			memcpy(storage + l, d + l, h - l);
+		}, 0, size);
+		break;
+	case PointerWrap::MODE_MEASURE:
+		// Nothing to do here.
+		break;
+	case PointerWrap::MODE_VERIFY:
+		GlobalThreadPool::Loop([&](int l, int h) {
+			for (int i = l; i < h; i++)
+				_dbg_assert_msg_(d[i] == storage[i], "Savestate verification failure: %d (0x%X) (at %p) != %d (0x%X) (at %p).\n", d[i], d[i], &d[i], storage[i], storage[i], &storage[i]);
+		}, 0, size);
+		break;
+	}
+	storage += size;
+}
+
 void DoState(PointerWrap &p) {
 	auto s = p.Section("Memory", 1, 3);
 	if (!s)
@@ -346,10 +374,10 @@ void DoState(PointerWrap &p) {
 		}
 	}
 
-	DoArray(p, GetPointer(PSP_GetKernelMemoryBase()), g_MemorySize);
+	DoMemoryVoid(p, PSP_GetKernelMemoryBase(), g_MemorySize);
 	p.DoMarker("RAM");
 
-	DoArray(p, m_pPhysicalVRAM1, VRAM_SIZE);
+	DoMemoryVoid(p, PSP_GetVidMemBase(), VRAM_SIZE);
 	p.DoMarker("VRAM");
 	DoArray(p, m_pPhysicalScratchPad, SCRATCHPAD_SIZE);
 	p.DoMarker("ScratchPad");

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -46,6 +46,10 @@
 #include "Core/ThreadPools.h"
 #include "UI/OnScreenDisplay.h"
 
+#ifdef _M_SSE
+#include <emmintrin.h>
+#endif
+
 namespace Memory {
 
 // The base pointer to the auto-mirrored arena.
@@ -314,19 +318,51 @@ void Reinit() {
 	Core_NotifyLifecycle(CoreLifecycle::MEMORY_REINITED);
 }
 
+static void CopyAlignedFast(uint8_t *dst8, const uint8_t *src8, int l, int h) {
+#ifdef _M_SSE
+	// All threads round both down, so they will still align.
+	l &= ~0x3F;
+	h &= ~0x3F;
+	const int n = (h - l) / 16;
+	const __m128i *src = (__m128i *)(src8 + l);
+	__m128i *dst = (__m128i *)(dst8 + l);
+
+	for (int i = 0; i < n; i += 4) {
+		__m128i row0 = _mm_loadu_si128(src + 0);
+		__m128i row1 = _mm_loadu_si128(src + 1);
+		__m128i row2 = _mm_loadu_si128(src + 2);
+		__m128i row3 = _mm_loadu_si128(src + 3);
+		_mm_storeu_si128(dst + 0, row0);
+		_mm_storeu_si128(dst + 1, row1);
+		_mm_storeu_si128(dst + 2, row2);
+		_mm_storeu_si128(dst + 3, row3);
+		src += 4;
+		dst += 4;
+	}
+#else
+	memcpy(dst8 + l, src8 + l, h - l);
+#endif
+}
+
 static void DoMemoryVoid(PointerWrap &p, uint32_t start, uint32_t size) {
 	uint8_t *d = GetPointer(start);
 	uint8_t *&storage = *p.ptr;
 
+	// We only handle aligned data and sizes.
+#ifdef _M_SSE
+	if ((size & 0x3F) != 0 || ((uintptr_t)d & 0x3F) != 0)
+		return p.DoVoid(d, size);
+#endif
+
 	switch (p.mode) {
 	case PointerWrap::MODE_READ:
 		GlobalThreadPool::Loop([&](int l, int h) {
-			memcpy(d + l, storage + l, h - l);
+			CopyAlignedFast(d, storage, l, h);
 		}, 0, size);
 		break;
 	case PointerWrap::MODE_WRITE:
 		GlobalThreadPool::Loop([&](int l, int h) {
-			memcpy(storage + l, d + l, h - l);
+			CopyAlignedFast(storage, d, l, h);
 		}, 0, size);
 		break;
 	case PointerWrap::MODE_MEASURE:


### PR DESCRIPTION
On my (powerful) desktop, this reduces SaveStart::DoState from 17.5ms to 7.5ms.  This is significant for rewind, because it takes it from "slower than an entire frame" to "might fit within a frame".

Doing VRAM as well went from about 9.3ms -> 8.5ms, and doing SIMD took it from 8.5ms -> 7.5ms.  With that, it's actually taking about 50% time to do all the other non-memory stuff, so there could be other places to optimize.

Removing the SIMD copy and switching to memmove is slower, but still better than before.  My averages are all trending lower now (maybe because of zstd?, I'm measuring outside it but repeating the test which includes it), but it's around 3-4ms slower than SIMD in the common case, which is still good.

This is faster on mobile too (around 32ms -> 23ms on a Pixel.)

-[Unknown]