### PR TITLE
Rtc: Cleanup and simplify date struct handling

### DIFF
--- a/Core/HLE/sceKernelMbx.cpp
+++ b/Core/HLE/sceKernelMbx.cpp
@@ -423,11 +423,10 @@ int sceKernelSendMbx(SceUID id, u32 packetAddr)
 		bool inserted = false;
 		if (m->nmb.attr & SCE_KERNEL_MBA_MSPRI)
 		{
-			NativeMbxPacket p;
 			for (int i = 0, n = m->nmb.numMessages; i < n; i++)
 			{
-				Memory::ReadStructUnchecked<NativeMbxPacket>(next, &p);
-				if (addPacket->priority < p.priority)
+				auto p = PSPPointer<NativeMbxPacket>::Create(next);
+				if (addPacket->priority < p->priority)
 				{
 					if (i == 0)
 						m->AddFirstMessage(prev, packetAddr);
@@ -438,7 +437,7 @@ int sceKernelSendMbx(SceUID id, u32 packetAddr)
 				}
 
 				prev = next;
-				next = Memory::Read_U32(next);
+				next = p->next;
 			}
 		}
 		if (!inserted)

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -962,11 +962,10 @@ static bool decodePmpVideo(PSPPointer<SceMpegRingBuffer> ringbuffer, u32 pmpctxA
 			pmpframes = new H264Frames;
 
 		// joint all blocks into H264Frames
-		SceMpegLLI lli;
 		for (int i = 0; i < pmp_nBlocks; i++){
-			Memory::ReadStructUnchecked(pmp_videoSource, &lli);
+			auto lli = PSPPointer<SceMpegLLI>::Create(pmp_videoSource);
 			// add source block into pmpframes
-			pmpframes->add(Memory::GetPointer(lli.pSrc), lli.iSize);
+			pmpframes->add(Memory::GetPointer(lli->pSrc), lli->iSize);
 			// get next block
 			pmp_videoSource += sizeof(SceMpegLLI);
 		}


### PR DESCRIPTION
Was looking at some ReadStruct/WriteStruct code (to decide if it made sense to maybe automatically trigger memory info), and decided to clean this part up.  Ultimately I think it's clearer to work with PSP memory directly instead of the struct copies.

-[Unknown]