### PR TITLE
UI: Load BG image properly on init

### DIFF
--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -203,6 +203,7 @@ private:
 
 static BackgroundAnimation g_CurBackgroundAnimation = BackgroundAnimation::OFF;
 static std::unique_ptr<Animation> g_Animation;
+static bool bgTextureInited = false;
 
 void UIBackgroundInit(UIContext &dc) {
 	const std::string bgPng = GetSysDirectory(DIRECTORY_SYSTEM) + "background.png";
@@ -216,9 +217,15 @@ void UIBackgroundInit(UIContext &dc) {
 void UIBackgroundShutdown() {
 	bgTexture.reset(nullptr);
 	g_Animation.reset(nullptr);
+	g_CurBackgroundAnimation = BackgroundAnimation::OFF;
+	bgTextureInited = false;
 }
 
 void DrawBackground(UIContext &dc, float alpha) {
+	if (!bgTextureInited) {
+		UIBackgroundInit(dc);
+		bgTextureInited = true;
+	}
 	if (g_CurBackgroundAnimation != (BackgroundAnimation)g_Config.iBackgroundAnimation) {
 		g_CurBackgroundAnimation = (BackgroundAnimation)g_Config.iBackgroundAnimation;
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1170,7 +1170,7 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 			File::Copy(value, dest);
 		}
 		UIBackgroundShutdown();
-		UIBackgroundInit(*uiContext);
+		// It will init again automatically.  We can't init outside a frame on Vulkan.
 	}
 	if (msg == "savestate_displayslot") {
 		auto sy = GetI18NCategory("System");


### PR DESCRIPTION
Also fix the update on Vulkan.  Before #14313 even, you couldn't see your new background immediately.  This probably also fixes it when the render loop restarts.

Not sharing flags with the animation because the PNG can be updated and still exist, and the animation can be off even with a PNG.  They're really separate.

This also probably fixes the animation breaking on certain resizing or graphics restarts (possibly rotating, etc.)

Fixes #14384.

-[Unknown]