### PR TITLE
Change pointer ID allocation on iOS. Fixes part of #14240

### DIFF
--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -226,8 +226,9 @@ bool PopupScreen::touch(const TouchInput &touch) {
 		return UIDialogScreen::touch(touch);
 	}
 
-	if (!box_->GetBounds().Contains(touch.x, touch.y))
+	if (!box_->GetBounds().Contains(touch.x, touch.y)) {
 		TriggerFinish(DR_BACK);
+	}
 
 	return UIDialogScreen::touch(touch);
 }

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -386,8 +386,8 @@ static LocationHelper *locationHelper;
 }
 
 int ToTouchID(UITouch *uiTouch, bool allowAllocate) {
-	// Find the id for the touch.  Avoid 0 (mouse.)
-	for (int localId = 1; localId < (int)ARRAY_SIZE(g_touches); ++localId) {
+	// Find the id for the touch.
+	for (int localId = 0; localId < (int)ARRAY_SIZE(g_touches); ++localId) {
 		if (g_touches[localId] == uiTouch) {
 			return localId;
 		}
@@ -395,7 +395,7 @@ int ToTouchID(UITouch *uiTouch, bool allowAllocate) {
 
 	// Allocate a new one, perhaps?
 	if (allowAllocate) {
-		for (int localId = 1; localId < (int)ARRAY_SIZE(g_touches); ++localId) {
+		for (int localId = 0; localId < (int)ARRAY_SIZE(g_touches); ++localId) {
 			if (g_touches[localId] == 0) {
 				g_touches[localId] = uiTouch;
 				return localId;


### PR DESCRIPTION
The dialog code checks for touch.id != 0 to decide whether to close.

Not sure if really necessary, but keeping it and just changing the IDs to start from 0.

See #14240 