### PR TITLE
Reporting: Avoid generated homebrew IDs

### DIFF
--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -371,7 +371,7 @@ int Client::ReadResponseHeaders(Buffer *readbuf, std::vector<std::string> &respo
 	if (code_pos != line.npos) {
 		code = atoi(&line[code_pos]);
 	} else {
-		ERROR_LOG(IO, "Code not parse HTTP status code");
+		ERROR_LOG(IO, "Could not parse HTTP status code: %s", line.c_str());
 		return -1;
 	}
 

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -194,13 +194,15 @@ void InitMemoryForGamePBP(FileLoader *fileLoader) {
 				}
 
 				std::string discID = paramSFO.GetValueString("DISC_ID");
+				std::string systemVer = paramSFO.GetValueString("PSP_SYSTEM_VER");
 				// Homebrew typically always leave this zero.
 				bool discTotalCheck = paramSFO.GetValueInt("DISC_TOTAL") != 0;
 				// A lot of homebrew reuse real game disc IDs - avoid.
 				bool formatCheck = discID.substr(0, 2) != "NP" && discID.substr(0, 2) != "UL" && discID.substr(0, 2) != "UC";
 				char region = discID.size() > 3 ? discID[2] : '\0';
 				bool regionCheck = region != 'A' && region != 'E' && region != 'H' && region != 'I' && region != 'J' && region != 'K' && region != 'U' && region != 'X';
-				if (formatCheck || regionCheck || discTotalCheck) {
+				bool systemVerCheck = !systemVer.empty() && systemVer[0] >= '5';
+				if ((formatCheck || regionCheck || discTotalCheck || systemVerCheck) && !discID.empty()) {
 					g_paramSFO.SetValue("DISC_ID", discID, (int)discID.size());
 					std::string ver = paramSFO.GetValueString("DISC_VERSION");
 					if (ver.empty())

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -540,6 +540,11 @@ namespace Reporting
 		// Don't allow builds without version info from git.  They're useless for reporting.
 		if (strcmp(PPSSPP_GIT_VERSION, "unknown") == 0)
 			return false;
+		// Don't report from games without a version ID (i.e. random hashed homebrew IDs.)
+		// The problem is, these aren't useful because the hashes end up different for different people.
+		// TODO: Should really hash the ELF instead of the path, but then that affects savestates/cheats.
+		if (g_paramSFO.GetValueString("DISC_VERSION").empty())
+			return false;
 
 		// Some users run the exe from a zip or something, and don't have fonts.
 		// This breaks things, but let's not report it since it's confusing.


### PR DESCRIPTION
But let through a few more, homebrew rarely reused newer system version SFOs.  By that point they were doing their own SFOs finally.

There's a bunch of noise in reporting from allowing hashed homebrew paths IDs to report.  Those aren't currently useful since people won't see each other's feedback.  Already blocked on the server, but want to make it clear to users by not showing the reporting button.

-[Unknown]