### PR TITLE
Update our miniupnp fork to match upstream.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1886,6 +1886,7 @@ if(USE_MINIUPNPC)
 	configure_file(${MINIUPNP_DIR}/miniupnpcstrings.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/miniupnpcstrings.h) # by default miniupnp repo doesn't contains miniupnpcstrings.h and need to be generated
 	set(MINIUPNPC_SOURCES
         # the needed bits of miniupnpc (no python module, no tests, no cli)
+		${MINIUPNP_DIR}/addr_is_reserved.c
 		${MINIUPNP_DIR}/connecthostport.c
         ${MINIUPNP_DIR}/igd_desc_parse.c
         ${MINIUPNP_DIR}/minisoap.c

--- a/UWP/miniupnpc_UWP/miniupnpc_UWP.vcxproj
+++ b/UWP/miniupnpc_UWP/miniupnpc_UWP.vcxproj
@@ -439,6 +439,7 @@ cd ..\..\..\..\UWP\miniupnpc_UWP</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\ext\miniupnp\miniupnpc\addr_is_reserved.h" />
     <ClInclude Include="..\..\ext\miniupnp\miniupnpc\connecthostport.h" />
     <ClInclude Include="..\..\ext\miniupnp\miniupnpc\igd_desc_parse.h" />
     <ClInclude Include="..\..\ext\miniupnp\miniupnpc\minisoap.h" />
@@ -452,6 +453,7 @@ cd ..\..\..\..\UWP\miniupnpc_UWP</Command>
     <ClInclude Include="..\..\ext\miniupnp\miniupnpc\upnpdev.h" />
     <ClInclude Include="..\..\ext\miniupnp\miniupnpc\upnperrors.h" />
     <ClInclude Include="..\..\ext\miniupnp\miniupnpc\upnpreplyparse.h" />
+    <ClCompile Include="..\..\ext\miniupnp\miniupnpc\addr_is_reserved.c" />
     <ClCompile Include="..\..\ext\miniupnp\miniupnpc\connecthostport.c" />
     <ClCompile Include="..\..\ext\miniupnp\miniupnpc\igd_desc_parse.c" />
     <ClCompile Include="..\..\ext\miniupnp\miniupnpc\minisoap.c" />

--- a/UWP/miniupnpc_UWP/miniupnpc_UWP.vcxproj.filters
+++ b/UWP/miniupnpc_UWP/miniupnpc_UWP.vcxproj.filters
@@ -44,6 +44,9 @@
       <Filter>src</Filter>
     </ClCompile>
     <ClCompile Include="pch.c" />
+    <ClCompile Include="..\..\ext\miniupnp\miniupnpc\addr_is_reserved.c">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\ext\miniupnp\miniupnpc\connecthostport.h">
@@ -83,6 +86,9 @@
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="..\..\ext\miniupnp\miniupnpc\upnpreplyparse.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\miniupnp\miniupnpc\addr_is_reserved.h">
       <Filter>src</Filter>
     </ClInclude>
   </ItemGroup>

--- a/ext/miniupnp-build/Android.mk
+++ b/ext/miniupnp-build/Android.mk
@@ -7,6 +7,7 @@ include $(CLEAR_VARS)
 LOCAL_MODULE    := libminiupnp-build
 LOCAL_ARM_MODE := arm
 LOCAL_SRC_FILES := \
+    ../miniupnp/miniupnpc/addr_is_reserved.c \
     ../miniupnp/miniupnpc/connecthostport.c \
     ../miniupnp/miniupnpc/igd_desc_parse.c \
     ../miniupnp/miniupnpc/minisoap.c \

--- a/ext/miniupnpc.vcxproj
+++ b/ext/miniupnpc.vcxproj
@@ -35,6 +35,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="miniupnp\miniupnpc\addr_is_reserved.h" />
     <ClInclude Include="miniupnp\miniupnpc\connecthostport.h" />
     <ClInclude Include="miniupnp\miniupnpc\igd_desc_parse.h" />
     <ClInclude Include="miniupnp\miniupnpc\minisoap.h" />
@@ -50,6 +51,7 @@
     <ClInclude Include="miniupnp\miniupnpc\upnpreplyparse.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="miniupnp\miniupnpc\addr_is_reserved.c" />
     <ClCompile Include="miniupnp\miniupnpc\connecthostport.c" />
     <ClCompile Include="miniupnp\miniupnpc\igd_desc_parse.c" />
     <ClCompile Include="miniupnp\miniupnpc\minisoap.c" />

--- a/ext/miniupnpc.vcxproj.filters
+++ b/ext/miniupnpc.vcxproj.filters
@@ -14,6 +14,7 @@
     <ClInclude Include="miniupnp\miniupnpc\receivedata.h" />
     <ClInclude Include="miniupnp\miniupnpc\upnpdev.h" />
     <ClInclude Include="miniupnp\miniupnpc\minissdpc.h" />
+    <ClInclude Include="miniupnp\miniupnpc\addr_is_reserved.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="miniupnp\miniupnpc\igd_desc_parse.c" />
@@ -30,6 +31,7 @@
     <ClCompile Include="miniupnp\miniupnpc\receivedata.c" />
     <ClCompile Include="miniupnp\miniupnpc\upnpdev.c" />
     <ClCompile Include="miniupnp\miniupnpc\minissdpc.c" />
+    <ClCompile Include="miniupnp\miniupnpc\addr_is_reserved.c" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="scripts">

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -629,6 +629,7 @@ SOURCES_C += $(EXTDIR)/udis86/decode.c \
 
 INCFLAGS += -I$(EXTDIR)/miniupnp-build
 SOURCES_C += \
+    $(EXTDIR)/miniupnp/miniupnpc/addr_is_reserved.c \
     $(EXTDIR)/miniupnp/miniupnpc/connecthostport.c \
     $(EXTDIR)/miniupnp/miniupnpc/igd_desc_parse.c \
     $(EXTDIR)/miniupnp/miniupnpc/minisoap.c \


### PR DESCRIPTION
There's no difference from upstream anymore, since https://github.com/miniupnp/miniupnp/pull/486 was merged.

Should take care of #14386. 

Could probably just switch to using upstream directly, but this'll do just as well.