### PR TITLE
Core: Correct ValidSize outside scratchpad

### DIFF
--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -301,8 +301,8 @@ inline bool IsValidAddress(const u32 address) {
 		return true;
 	} else if ((address & 0x3F800000) == 0x04000000) {
 		return true;
-	} else if ((address & 0xBFFF0000) == 0x00010000) {
-		return (address & 0x0000FFFF) < SCRATCHPAD_SIZE;
+	} else if ((address & 0xBFFFC000) == 0x00010000) {
+		return true;
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
 		return true;
 	} else {
@@ -316,8 +316,8 @@ inline u32 ValidSize(const u32 address, const u32 requested_size) {
 		max_size = 0x08000000 + g_MemorySize - (address & 0x3FFFFFFF);
 	} else if ((address & 0x3F800000) == 0x04000000) {
 		max_size = 0x04800000 - (address & 0x3FFFFFFF);
-	} else if ((address & 0xBFFF0000) == 0x00010000) {
-		max_size = 0x00014000 - (address & 0xBFFFFFFF);
+	} else if ((address & 0xBFFFC000) == 0x00010000) {
+		max_size = 0x00014000 - (address & 0x3FFFFFFF);
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
 		max_size = 0x08000000 + g_MemorySize - (address & 0x3FFFFFFF);
 	} else {

--- a/Core/MemMapFunctions.cpp
+++ b/Core/MemMapFunctions.cpp
@@ -35,7 +35,7 @@ u8 *GetPointer(const u32 address) {
 	} else if ((address & 0x3F800000) == 0x04000000) {
 		// VRAM
 		return GetPointerUnchecked(address);
-	} else if ((address & 0xBFFF0000) == 0x00010000 && (address & 0x0000FFFF) < SCRATCHPAD_SIZE) {
+	} else if ((address & 0xBFFFC000) == 0x00010000) {
 		// Scratchpad
 		return GetPointerUnchecked(address);
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
@@ -61,7 +61,7 @@ inline void ReadFromHardware(T &var, const u32 address) {
 	} else if ((address & 0x3F800000) == 0x04000000) {
 		// VRAM
 		var = *((const T*)GetPointerUnchecked(address));
-	} else if ((address & 0xBFFF0000) == 0x00010000 && (address & 0x0000FFFF) < SCRATCHPAD_SIZE) {
+	} else if ((address & 0xBFFFC000) == 0x00010000) {
 		// Scratchpad
 		var = *((const T*)GetPointerUnchecked(address));
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
@@ -86,7 +86,7 @@ inline void WriteToHardware(u32 address, const T data) {
 	} else if ((address & 0x3F800000) == 0x04000000) {
 		// VRAM
 		*(T*)GetPointerUnchecked(address) = data;
-	} else if ((address & 0xBFFF0000) == 0x00010000 && (address & 0x0000FFFF) < SCRATCHPAD_SIZE) {
+	} else if ((address & 0xBFFFC000) == 0x00010000) {
 		// Scratchpad
 		*(T*)GetPointerUnchecked(address) = data;
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
@@ -113,7 +113,7 @@ bool IsRAMAddress(const u32 address) {
 }
 
 bool IsScratchpadAddress(const u32 address) {
-	return (address & 0xBFFF0000) == 0x00010000 && (address & 0x0000FFFF) < SCRATCHPAD_SIZE;
+	return (address & 0xBFFFC000) == 0x00010000;
 }
 
 u8 Read_U8(const u32 address) {

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -572,6 +572,11 @@ static bool TestMemMap() {
 		}
 	}
 
+	EXPECT_FALSE(Memory::IsValidAddress(0x00015000));
+	EXPECT_FALSE(Memory::IsValidAddress(0x04900000));
+	EXPECT_EQ_HEX(Memory::ValidSize(0x00015000, 4), 0);
+	EXPECT_EQ_HEX(Memory::ValidSize(0x04900000, 4), 0);
+
 	return true;
 }
 


### PR DESCRIPTION
And simplify all the scratchpad valid checks.

Sorry, another fix for even this same function.  Maybe this is related in some way to some of the scratchpad errors we saw in the past?  But it was only failing for ValidSize - it'd allow a start within 0x00014000 - 0x0001FFFF and this would cause a negative max size, and things went poorly from there.

-[Unknown]