### PR TITLE
Debugger: Show string in status bar for li, etc.

### DIFF
--- a/Core/Debugger/DisassemblyManager.h
+++ b/Core/Debugger/DisassemblyManager.h
@@ -224,3 +224,4 @@ private:
 };
 
 bool isInInterval(u32 start, u32 size, u32 value);
+bool IsLikelyStringAt(uint32_t addr);

--- a/Core/Debugger/WebSocket/DisasmSubscriber.cpp
+++ b/Core/Debugger/WebSocket/DisasmSubscriber.cpp
@@ -188,6 +188,10 @@ void WebSocketDisasmState::WriteDisasmLine(JsonWriter &json, const DisassemblyLi
 			json.writeUint("uintValue", Memory::ReadUnchecked_U32(l.info.relevantAddress));
 		else
 			json.writeNull("uintValue");
+		if (IsLikelyStringAt(l.info.relevantAddress))
+			json.writeString("stringValue", Memory::GetCharPointer(l.info.relevantAddress));
+		else
+			json.writeNull("stringValue");
 		json.pop();
 	} else {
 		json.writeNull("relevantData");

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -1094,6 +1094,10 @@ void CtrlDisAsmView::updateStatusBarText()
 	text[0] = 0;
 	if (line.type == DISTYPE_OPCODE || line.type == DISTYPE_MACRO)
 	{
+		if (line.info.hasRelevantAddress && IsLikelyStringAt(line.info.relevantAddress)) {
+			snprintf(text, sizeof(text), "[%08X] = \"%s\"", line.info.relevantAddress, Memory::GetCharPointer(line.info.relevantAddress));
+		}
+
 		if (line.info.isDataAccess)
 		{
 			if (!Memory::IsValidAddress(line.info.dataAddress))


### PR DESCRIPTION
This is helpful when stepping through the debugger.  Only shows likely UTF-8 or similar formatted text, but often names or error messages are.

-[Unknown]