### PR TITLE
Apply integer math narrowing before VFPU sin/cos

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -75,7 +75,6 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "MemstickFixedFree", &flags_.MemstickFixedFree);
 	CheckSetting(iniFile, gameID, "DateLimited", &flags_.DateLimited);
 	CheckSetting(iniFile, gameID, "ReinterpretFramebuffers", &flags_.ReinterpretFramebuffers);
-	CheckSetting(iniFile, gameID, "DoublePrecisionSinCos", &flags_.DoublePrecisionSinCos);
 	CheckSetting(iniFile, gameID, "ShaderColorBitmask", &flags_.ShaderColorBitmask);
 	CheckSetting(iniFile, gameID, "DisableFirstFrameReadback", &flags_.DisableFirstFrameReadback);
 	CheckSetting(iniFile, gameID, "DisableRangeCulling", &flags_.DisableRangeCulling);

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -73,7 +73,6 @@ struct CompatFlags {
 	bool MemstickFixedFree;
 	bool DateLimited;
 	bool ReinterpretFramebuffers;
-	bool DoublePrecisionSinCos;
 	bool ShaderColorBitmask;
 	bool DisableFirstFrameReadback;
 	bool DisableRangeCulling;

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -29,6 +29,11 @@
 #define V(i)   (currentMIPS->v[voffset[i]])
 #define VI(i)  (currentMIPS->vi[voffset[i]])
 
+union float2int {
+	uint32_t i;
+	float f;
+};
+
 void GetVectorRegs(u8 regs[4], VectorSize N, int vectorReg) {
 	int mtx = (vectorReg >> 2) & 7;
 	int col = vectorReg & 3;
@@ -610,10 +615,7 @@ bool GetVFPUCtrlMask(int reg, u32 *mask) {
 
 float Float16ToFloat32(unsigned short l)
 {
-	union float2int {
-		unsigned int i;
-		float f;
-	} float2int;
+	float2int f2i;
 
 	unsigned short float16 = l;
 	unsigned int sign = (float16 >> VFPU_SH_FLOAT16_SIGN) & VFPU_MASK_FLOAT16_SIGN;
@@ -623,10 +625,10 @@ float Float16ToFloat32(unsigned short l)
 	float f;
 	if (exponent == VFPU_FLOAT16_EXP_MAX)
 	{
-		float2int.i = sign << 31;
-		float2int.i |= 255 << 23;
-		float2int.i |= fraction;
-		f = float2int.f;
+		f2i.i = sign << 31;
+		f2i.i |= 255 << 23;
+		f2i.i |= fraction;
+		f = f2i.f;
 	}
 	else if (exponent == 0 && fraction == 0)
 	{
@@ -647,10 +649,10 @@ float Float16ToFloat32(unsigned short l)
 		}
 
 		/* Convert to 32-bit single-precision IEEE754. */
-		float2int.i = sign << 31;
-		float2int.i |= (exponent + 112) << 23;
-		float2int.i |= fraction << 13;
-		f=float2int.f;
+		f2i.i = sign << 31;
+		f2i.i |= (exponent + 112) << 23;
+		f2i.i |= fraction << 13;
+		f=f2i.f;
 	}
 	return f;
 }
@@ -674,10 +676,6 @@ static int32_t get_sign(uint32_t x) {
 
 float vfpu_dot(float a[4], float b[4]) {
 	static const int EXTRA_BITS = 2;
-	union float2int {
-		uint32_t i;
-		float f;
-	};
 	float2int result;
 	float2int src[2];
 
@@ -791,31 +789,27 @@ float vfpu_dot(float a[4], float b[4]) {
 
 // TODO: This is still not completely accurate compared to the PSP's vsqrt.
 float vfpu_sqrt(float a) {
-	union float2int {
-		uint32_t u;
-		float f;
-	};
 	float2int val;
 	val.f = a;
 
-	if ((val.u & 0xff800000) == 0x7f800000) {
-		if ((val.u & 0x007fffff) != 0) {
-			val.u = 0x7f800001;
+	if ((val.i & 0xff800000) == 0x7f800000) {
+		if ((val.i & 0x007fffff) != 0) {
+			val.i = 0x7f800001;
 		}
 		return val.f;
 	}
-	if ((val.u & 0x7f800000) == 0) {
+	if ((val.i & 0x7f800000) == 0) {
 		// Kill any sign.
-		val.u = 0;
+		val.i = 0;
 		return val.f;
 	}
-	if (val.u & 0x80000000) {
-		val.u = 0x7f800001;
+	if (val.i & 0x80000000) {
+		val.i = 0x7f800001;
 		return val.f;
 	}
 
-	int k = get_exp(val.u);
-	uint32_t sp = get_mant(val.u);
+	int k = get_exp(val.i);
+	uint32_t sp = get_mant(val.i);
 	int less_bits = k & 1;
 	k >>= 1;
 
@@ -826,9 +820,9 @@ float vfpu_sqrt(float a) {
 		z = (z >> 1) + (uint32_t)(halfsp / z);
 	}
 
-	val.u = ((k + 127) << 23) | ((z << less_bits) & 0x007FFFFF);
+	val.i = ((k + 127) << 23) | ((z << less_bits) & 0x007FFFFF);
 	// The lower two bits never end up set on the PSP, it seems like.
-	val.u &= 0xFFFFFFFC;
+	val.i &= 0xFFFFFFFC;
 
 	return val.f;
 }
@@ -842,31 +836,27 @@ static inline uint32_t mant_mul(uint32_t a, uint32_t b) {
 }
 
 float vfpu_rsqrt(float a) {
-	union float2int {
-		uint32_t u;
-		float f;
-	};
 	float2int val;
 	val.f = a;
 
-	if (val.u == 0x7f800000) {
+	if (val.i == 0x7f800000) {
 		return 0.0f;
 	}
-	if ((val.u & 0x7fffffff) > 0x7f800000) {
-		val.u = (val.u & 0x80000000) | 0x7f800001;
+	if ((val.i & 0x7fffffff) > 0x7f800000) {
+		val.i = (val.i & 0x80000000) | 0x7f800001;
 		return val.f;
 	}
-	if ((val.u & 0x7f800000) == 0) {
-		val.u = (val.u & 0x80000000) | 0x7f800000;
+	if ((val.i & 0x7f800000) == 0) {
+		val.i = (val.i & 0x80000000) | 0x7f800000;
 		return val.f;
 	}
-	if (val.u & 0x80000000) {
-		val.u = 0xff800001;
+	if (val.i & 0x80000000) {
+		val.i = 0xff800001;
 		return val.f;
 	}
 
-	int k = get_exp(val.u);
-	uint32_t sp = get_mant(val.u);
+	int k = get_exp(val.i);
+	uint32_t sp = get_mant(val.i);
 	int less_bits = k & 1;
 	k = -(k >> 1);
 
@@ -889,8 +879,8 @@ float vfpu_rsqrt(float a) {
 
 	z >>= less_bits;
 
-	val.u = ((k + 127) << 23) | (z & 0x007FFFFF);
-	val.u &= 0xFFFFFFFC;
+	val.i = ((k + 127) << 23) | (z & 0x007FFFFF);
+	val.i &= 0xFFFFFFFC;
 
 	return val.f;
 }

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -885,58 +885,7 @@ float vfpu_rsqrt(float a) {
 	return val.f;
 }
 
-float vfpu_sin_single(float angle) {
-	angle -= floorf(angle * 0.25f) * 4.f;
-	if (angle == 0.0f || angle == 2.0f) {
-		return 0.0f;
-	} else if (angle == 1.0f) {
-		return 1.0f;
-	} else if (angle == 3.0f) {
-		return -1.0f;
-	}
-	angle *= (float)M_PI_2;
-	return sinf(angle);
-}
-
-float vfpu_cos_single(float angle) {
-	angle -= floorf(angle * 0.25f) * 4.f;
-	if (angle == 1.0f || angle == 3.0f) {
-		return 0.0f;
-	} else if (angle == 0.0f) {
-		return 1.0f;
-	} else if (angle == 2.0f) {
-		return -1.0f;
-	}
-	angle *= (float)M_PI_2;
-	return cosf(angle);
-}
-
-void vfpu_sincos_single(float angle, float &sine, float &cosine) {
-	angle -= floorf(angle * 0.25f) * 4.f;
-	if (angle == 0.0f) {
-		sine = 0.0f;
-		cosine = 1.0f;
-	} else if (angle == 1.0f) {
-		sine = 1.0f;
-		cosine = 0.0f;
-	} else if (angle == 2.0f) {
-		sine = 0.0f;
-		cosine = -1.0f;
-	} else if (angle == 3.0f) {
-		sine = -1.0f;
-		cosine = 0.0f;
-	} else {
-		angle *= (float)M_PI_2;
-#if defined(__linux__)
-		sincosf(angle, &sine, &cosine);
-#else
-		sine = sinf(angle);
-		cosine = cosf(angle);
-#endif
-	}
-}
-
-float vfpu_sin_mod2(float a) {
+float vfpu_sin(float a) {
 	float2int val;
 	val.f = a;
 
@@ -980,7 +929,7 @@ float vfpu_sin_mod2(float a) {
 	return val.f;
 }
 
-float vfpu_cos_mod2(float a) {
+float vfpu_cos(float a) {
 	float2int val;
 	val.f = a;
 	bool negate = false;
@@ -1025,7 +974,7 @@ float vfpu_cos_mod2(float a) {
 	return negate ? -val.f : val.f;
 }
 
-void vfpu_sincos_mod2(float a, float &s, float &c) {
+void vfpu_sincos(float a, float &s, float &c) {
 	float2int val;
 	val.f = a;
 	// For sin, negate the input, for cos negate the output.
@@ -1106,12 +1055,6 @@ void vfpu_sincos_mod2(float a, float &s, float &c) {
 	return ;
 }
 
-float (*vfpu_sin)(float);
-float (*vfpu_cos)(float);
-void (*vfpu_sincos)(float, float&, float&);
-
-void InitVFPUSinCos(bool useDoublePrecision) {
-	vfpu_sin = useDoublePrecision ? vfpu_sin_mod2 : vfpu_sin_single;
-	vfpu_cos = useDoublePrecision ? vfpu_cos_mod2 : vfpu_cos_single;
-	vfpu_sincos = useDoublePrecision ? vfpu_sincos_mod2 : vfpu_sincos_single;
+void InitVFPUSinCos() {
+	// TODO: Could prepare a CORDIC table here.
 }

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -1017,6 +1017,9 @@ float vfpu_cos_mod2(float a) {
 
 	// This is the value with modulus applied.
 	val.i = (val.i & 0x80000000) | (k << 23) | (mantissa & ~(1 << 23));
+	if (val.f == 1.0f || val.f == -1.0f) {
+		return negate ? 0.0f : -0.0f;
+	}
 	val.f = (float)cos((double)val.f * M_PI_2);
 	val.i &= 0xFFFFFFFC;
 	return negate ? -val.f : val.f;
@@ -1073,7 +1076,13 @@ void vfpu_sincos_mod2(float a, float &s, float &c) {
 	// This is the value with modulus applied.
 	val.i = (val.i & 0x80000000) | (k << 23) | (mantissa & ~(1 << 23));
 	float2int i_sine, i_cosine;
-	if (negate) {
+	if (val.f == 1.0f) {
+		i_sine.f = negate ? -1.0f : 1.0f;
+		i_cosine.f = negate ? 0.0f : -0.0f;
+	} else if (val.f == -1.0f) {
+		i_sine.f = negate ? 1.0f : -1.0f;
+		i_cosine.f = negate ? 0.0f : -0.0f;
+	} else if (negate) {
 		i_sine.f = (float)sin((double)-val.f * M_PI_2);
 		i_cosine.f = -(float)cos((double)val.f * M_PI_2);
 	} else {

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -50,9 +50,9 @@ inline int Xpose(int v) {
 //
 // Messing around with the modulo functions? try https://www.desmos.com/calculator.
 
-extern float (*vfpu_sin)(float);
-extern float (*vfpu_cos)(float);
-extern void (*vfpu_sincos)(float, float&, float&);
+extern float vfpu_sin(float);
+extern float vfpu_cos(float);
+extern void vfpu_sincos(float, float&, float&);
 
 inline float vfpu_asin(float angle) {
 	return asinf(angle) / M_PI_2;
@@ -215,4 +215,4 @@ int GetVectorOverlap(int reg1, VectorSize size1, int reg2, VectorSize size2);
 bool GetVFPUCtrlMask(int reg, u32 *mask);
 
 float Float16ToFloat32(unsigned short l);
-void InitVFPUSinCos(bool useDoublePrecision);
+void InitVFPUSinCos();

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -458,7 +458,7 @@ bool Jit::DescribeCodePtr(const u8 *ptr, std::string &name) {
 			name = "UnknownOrDeletedBlock";
 		} else if (jitAddr != (u32)-1) {
 			char temp[1024];
-			const std::string label = g_symbolMap->GetDescription(jitAddr);
+			const std::string label = g_symbolMap ? g_symbolMap->GetDescription(jitAddr) : "";
 			if (!label.empty())
 				snprintf(temp, sizeof(temp), "%08x_%s", jitAddr, label.c_str());
 			else

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -284,7 +284,7 @@ bool CPU_Init() {
 	// likely to collide with any commercial ones.
 	coreParameter.compat.Load(g_paramSFO.GetDiscID());
 
-	InitVFPUSinCos(coreParameter.compat.flags().DoublePrecisionSinCos);
+	InitVFPUSinCos(true);
 
 	if (allowPlugins)
 		HLEPlugins::Init();

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -284,7 +284,7 @@ bool CPU_Init() {
 	// likely to collide with any commercial ones.
 	coreParameter.compat.Load(g_paramSFO.GetDiscID());
 
-	InitVFPUSinCos(true);
+	InitVFPUSinCos();
 
 	if (allowPlugins)
 		HLEPlugins::Init();

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -989,12 +989,6 @@ ULJM05533 = true
 NPJH50006 = true
 ULES01301 = true
 
-[DoublePrecisionSinCos]
-# Hitman Reborn Battle Arena 2 (#12900)
-ULJS00218 = true
-# Hitman Reborn Battle Arena
-ULJS00157 = true
-
 [DisableFirstFrameReadback]
 # Wipeout Pure: Temporary workaround for lens flare flicker. See #13344
 UCUS98612 = true

--- a/unittest/JitHarness.cpp
+++ b/unittest/JitHarness.cpp
@@ -23,12 +23,14 @@
 #include "Common/System/System.h"
 #include "Common/TimeUtil.h"
 #include "Core/ConfigValues.h"
+#include "Core/Debugger/SymbolMap.h"
 #include "Core/MIPS/JitCommon/JitCommon.h"
 #include "Core/MIPS/JitCommon/JitBlockCache.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
 #include "Core/MIPS/MIPSDebugInterface.h"
 #include "Core/MIPS/MIPSAsm.h"
 #include "Core/MIPS/MIPSTables.h"
+#include "Core/MIPS/MIPSVFPUUtils.h"
 #include "Core/MemMap.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -82,6 +84,7 @@ static void SetupJitHarness() {
 	// This is pretty much the bare minimum required to setup jit.
 	coreState = CORE_POWERUP;
 	currentMIPS = &mipsr4k;
+	g_symbolMap = new SymbolMap();
 	Memory::g_MemorySize = Memory::RAM_NORMAL_SIZE;
 	PSP_CoreParameter().cpuCore = CPUCore::INTERPRETER;
 	PSP_CoreParameter().unthrottle = true;
@@ -89,6 +92,7 @@ static void SetupJitHarness() {
 	Memory::Init();
 	mipsr4k.Reset();
 	CoreTiming::Init();
+	InitVFPUSinCos(true);
 }
 
 static void DestroyJitHarness() {
@@ -99,6 +103,7 @@ static void DestroyJitHarness() {
 	Memory::Shutdown();
 	coreState = CORE_POWERDOWN;
 	currentMIPS = nullptr;
+	delete g_symbolMap;
 }
 
 bool TestJit() {

--- a/unittest/JitHarness.cpp
+++ b/unittest/JitHarness.cpp
@@ -92,7 +92,7 @@ static void SetupJitHarness() {
 	Memory::Init();
 	mipsr4k.Reset();
 	CoreTiming::Init();
-	InitVFPUSinCos(true);
+	InitVFPUSinCos();
 }
 
 static void DestroyJitHarness() {

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -303,7 +303,7 @@ bool TestParsers() {
 
 bool TestVFPUSinCos() {
 	float sine, cosine;
-	InitVFPUSinCos(false);
+	InitVFPUSinCos();
 	EXPECT_FALSE(vfpu_sincos == nullptr);
 	vfpu_sincos(0.0f, sine, cosine);
 	EXPECT_EQ_FLOAT(sine, 0.0f);


### PR DESCRIPTION
There's a speed penalty for this but it's not that significant (about 30% of the sin/cos instruction time, looks like.)

This seems to do a better job of narrowing than fmod/fmodf and gives results that match the PSP much better.  It also handles some NAN/INF/zero cases carefully.  I had to special case +1/-1 on cosine though, to make sure it's properly calculated.

Could use some help testing if this has negative effects.  I don't have Cho Aniki Zero (@sum2012), Hajime no Ippo (@Saramagrean), or Hitman Reborn (@somepunkid).  I'm hoping all three games still work with this.  You can test by going to the Checks tab of this pull request and downloading a build from the Artifacts button.

FF3 does still work fine from my tests.  It does not help Ridge Racer of course.

If it works well, I'll probably remove the old single float code entirely.

I might still try to figure out more exact calculation (still suspect it uses CORDIC from the vrot instruction), but it's much closer with this change.

Fixes #12900.

-[Unknown]