### PR TITLE
Windows: Reduce focus juggling on game start

### DIFF
--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -848,14 +848,14 @@ void CDisasm::SetDebugMode(bool _bDebug, bool switchPC)
 	}
 }
 
-void CDisasm::Show(bool bShow) {
+void CDisasm::Show(bool bShow, bool includeToTop) {
 	if (deferredSymbolFill_ && bShow) {
 		if (g_symbolMap) {
 			g_symbolMap->FillSymbolListBox(GetDlgItem(m_hDlg, IDC_FUNCTIONLIST), ST_FUNCTION);
 			deferredSymbolFill_ = false;
 		}
 	}
-	Dialog::Show(bShow);
+	Dialog::Show(bShow, includeToTop);
 }
 
 void CDisasm::NotifyMapLoaded() {

--- a/Windows/Debugger/Debugger_Disasm.h
+++ b/Windows/Debugger/Debugger_Disasm.h
@@ -49,7 +49,7 @@ public:
 	CDisasm(HINSTANCE _hInstance, HWND _hParent, DebugInterface *cpu);
 	~CDisasm();
 
-	void Show(bool bShow) override;
+	void Show(bool bShow, bool includeToTop = true) override;
 
 	void Update() override {
 		UpdateDialog(true);

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -540,7 +540,7 @@ namespace MainWindow
 	void CreateDebugWindows() {
 		disasmWindow = new CDisasm(MainWindow::GetHInstance(), MainWindow::GetHWND(), currentDebugMIPS);
 		DialogManager::AddDlg(disasmWindow);
-		disasmWindow->Show(g_Config.bShowDebuggerOnLoad);
+		disasmWindow->Show(g_Config.bShowDebuggerOnLoad, false);
 
 #if PPSSPP_API(ANY_GL)
 		geDebuggerWindow = new CGEDebugger(MainWindow::GetHInstance(), MainWindow::GetHWND());
@@ -935,8 +935,6 @@ namespace MainWindow
 
 			if (disasmWindow)
 				disasmWindow->UpdateDialog();
-
-			SetForegroundWindow(hwndMain);
 			break;
 
 		case WM_USER_SAVESTATE_FINISH:

--- a/Windows/W32Util/DialogManager.cpp
+++ b/Windows/W32Util/DialogManager.cpp
@@ -30,11 +30,16 @@ void Dialog::Destroy()
 	DestroyWindow(m_hDlg);
 }
 
-void Dialog::Show(bool _bShow)
+void Dialog::Show(bool _bShow, bool includeToTop)
 {
-	m_bShowState = _bShow ? SW_NORMAL : SW_HIDE;
+	if (_bShow && includeToTop)
+		m_bShowState = SW_SHOWNORMAL;
+	else if (_bShow)
+		m_bShowState = SW_SHOWNOACTIVATE;
+	else
+		m_bShowState = SW_HIDE;
 	ShowWindow(m_hDlg, m_bShowState);
-	if (_bShow)
+	if (_bShow && includeToTop)
 		BringWindowToTop(m_hDlg);
 }
 

--- a/Windows/W32Util/DialogManager.h
+++ b/Windows/W32Util/DialogManager.h
@@ -8,7 +8,7 @@ public:
 	Dialog(LPCSTR res, HINSTANCE _hInstance, HWND _hParent);
 	virtual ~Dialog();
 
-	virtual void Show(bool _bShow);
+	virtual void Show(bool _bShow, bool includeToTop = true);
 	virtual void Update() {}
 
 	HWND GetDlgHandle() {


### PR DESCRIPTION
This has been bugging me for a while and is my fault since #1144.

Previously, we would activate the debugger (if enabled), and then reactivate the main window.  This meant if you switched to something, PPSSPP would demand focus once the game loaded.

I prefer apps not to steal focus if I've tabbed away while they're loading, etc.  This can also be annoying when trying to use profiling tools on load.

-[Unknown]