### PR TITLE
Savedata: Eat less cycles in savedata init

### DIFF
--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -332,8 +332,8 @@ static int UtilityWorkUs(int us) {
 	// This blocks, but other better priority threads can get time.
 	// Simulate this by allowing a reschedule.
 	if (us > 1000) {
-		hleEatMicro(us - 400);
-		return hleDelayResult(0, "utility work", 400);
+		hleEatMicro(1000);
+		return hleDelayResult(0, "utility work", us - 1000);
 	}
 	hleEatMicro(us);
 	hleReSchedule("utility work");


### PR DESCRIPTION
Other threads do get scheduled more than 400us in most cases, but I'm not sure what factors this is based off of.  Hoping this helps #14382.  It shouldn't be unsafe compared to before, I kinda wanted to see if it was a problem...

-[Unknown]