### PR TITLE
[Adhoc] Replacing sceKernelDelayThread with ScheduleEvent on fake HLE to wait for event availability

### DIFF
--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -171,7 +171,7 @@ static void __ApctlPollEvent(u64 userdata, int cyclesLate) {
 
 	u32 waitVal = __KernelGetWaitValue(threadID, error);
 	if (error == 0) {
-		if (netApctlInited && apctlEvents.empty()) {
+		if (netApctlInited && apctlEvents.empty() && npAuthEvents.empty()) {
 			// Try again in another 10ms until adhocctl terminated.
 			CoreTiming::ScheduleEvent(usToCycles(10000) - cyclesLate, apctlPollEvent, userdata);
 			return;

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -208,6 +208,7 @@ void __NetApctlInit() {
 	netApctlInited = false;
 	netApctlState = PSP_NET_APCTL_STATE_DISCONNECTED;
 	apctlStateEvent = CoreTiming::RegisterEvent("__ApctlState", __ApctlState);
+	apctlPollEvent = CoreTiming::RegisterEvent("__ApctlPollEvent", __ApctlPollEvent);
 	apctlHandlers.clear();
 	apctlEvents.clear();
 	memset(&netApctlInfo, 0, sizeof(netApctlInfo));


### PR DESCRIPTION
I'm not sure which one is better, i just had this worry that calling `sceKernelDelayThread` too often could potentially wake up other threads at a bad/critical time.
But if something like that is not possible to happen, i prefer using the simple one (ie. `sceKernelDelayThread`) than the complicated Scheduled Event.