### PR TITLE
Cleanup color conv and net buffer handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,7 +400,7 @@ set(CommonARM
 	Common/ArmCPUDetect.cpp
 	Common/ArmEmitter.h
 	Common/ArmEmitter.cpp
-	Common/ColorConvNEON.cpp
+	Common/Data/Convert/ColorConvNEON.cpp
 )
 source_group(ARM FILES ${CommonARM})
 
@@ -460,6 +460,8 @@ add_library(Common STATIC
 	Common/Data/Collections/ThreadSafeList.h
 	Common/Data/Color/RGBAUtil.cpp
 	Common/Data/Color/RGBAUtil.h
+	Common/Data/Convert/ColorConv.cpp
+	Common/Data/Convert/ColorConv.h
 	Common/Data/Convert/SmallDataConvert.cpp
 	Common/Data/Convert/SmallDataConvert.h
 	Common/Data/Encoding/Base64.cpp
@@ -624,8 +626,6 @@ add_library(Common STATIC
 	Common/Buffer.h
 	Common/Buffer.cpp
 	Common/CodeBlock.h
-	Common/ColorConv.cpp
-	Common/ColorConv.h
 	Common/Common.h
 	Common/CommonFuncs.h
 	Common/CommonTypes.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,6 +575,8 @@ add_library(Common STATIC
 	Common/Net/HTTPHeaders.h
 	Common/Net/HTTPServer.cpp
 	Common/Net/HTTPServer.h
+	Common/Net/NetBuffer.cpp
+	Common/Net/NetBuffer.h
 	Common/Net/Resolve.cpp
 	Common/Net/Resolve.h
 	Common/Net/Sinks.cpp

--- a/Common/Buffer.cpp
+++ b/Common/Buffer.cpp
@@ -1,24 +1,7 @@
+#include <cstdarg>
+#include <cstdlib>
+#include <cstring>
 
-#include <stdarg.h>
-#include <stdlib.h>
-#include <algorithm>
-
-#ifdef _WIN32
-#include <winsock2.h>
-#undef min
-#undef max
-#else
-#include <sys/socket.h>
-#include <unistd.h>
-#endif
-
-#ifndef MSG_NOSIGNAL
-// Default value to 0x00 (do nothing) in systems where it's not supported.
-#define MSG_NOSIGNAL 0x00
-#endif
-
-#include "Common/File/FileDescriptor.h"
-#include "Common/TimeUtil.h"
 #include "Common/Buffer.h"
 #include "Common/Log.h"
 
@@ -36,14 +19,14 @@ char *Buffer::Append(size_t length) {
 }
 
 void Buffer::Append(const std::string &str) {
-  char *ptr = Append(str.size());
-  memcpy(ptr, str.data(), str.size());
+	char *ptr = Append(str.size());
+	memcpy(ptr, str.data(), str.size());
 }
 
 void Buffer::Append(const char *str) {
-  size_t len = strlen(str);
-  char *dest = Append(len);
-  memcpy(dest, str, len);
+	size_t len = strlen(str);
+	char *dest = Append(len);
+	memcpy(dest, str, len);
 }
 
 void Buffer::Append(const Buffer &other) {
@@ -55,10 +38,10 @@ void Buffer::Append(const Buffer &other) {
 }
 
 void Buffer::AppendValue(int value) {
-  char buf[16];
-  // This is slow.
-  sprintf(buf, "%i", value);
-  Append(buf);
+	char buf[16];
+	// This is slow.
+	sprintf(buf, "%i", value);
+	Append(buf);
 }
 
 void Buffer::Take(size_t length, std::string *dest) {
@@ -78,14 +61,14 @@ void Buffer::Take(size_t length, char *dest) {
 }
 
 int Buffer::TakeLineCRLF(std::string *dest) {
-  int after_next_line = OffsetToAfterNextCRLF();
-  if (after_next_line < 0)
-    return after_next_line;
-  else {
-    Take(after_next_line - 2, dest);
-    Skip(2);  // Skip the CRLF
-    return after_next_line - 2;
-  }
+	int after_next_line = OffsetToAfterNextCRLF();
+	if (after_next_line < 0) {
+		return after_next_line;
+	} else {
+		Take(after_next_line - 2, dest);
+		Skip(2);  // Skip the CRLF
+		return after_next_line - 2;
+	}
 }
 
 void Buffer::Skip(size_t length) {
@@ -97,48 +80,39 @@ void Buffer::Skip(size_t length) {
 }
 
 int Buffer::SkipLineCRLF() {
-  int after_next_line = OffsetToAfterNextCRLF();
-  if (after_next_line < 0)
-    return after_next_line;
-  else {
-    Skip(after_next_line);
-    return after_next_line - 2;
-  }
+	int after_next_line = OffsetToAfterNextCRLF();
+	if (after_next_line < 0) {
+		return after_next_line;
+	} else {
+		Skip(after_next_line);
+		return after_next_line - 2;
+	}
 }
 
 int Buffer::OffsetToAfterNextCRLF() {
-  for (int i = 0; i < (int)data_.size() - 1; i++) {
-    if (data_[i] == '\r' && data_[i + 1] == '\n') {
-      return i + 2;
-    }
-  }
-  return -1;
+	for (int i = 0; i < (int)data_.size() - 1; i++) {
+		if (data_[i] == '\r' && data_[i + 1] == '\n') {
+			return i + 2;
+		}
+	}
+	return -1;
 }
 
 void Buffer::Printf(const char *fmt, ...) {
-  char buffer[2048];
-  va_list vl;
-  va_start(vl, fmt);
-  size_t retval = vsnprintf(buffer, sizeof(buffer), fmt, vl);
-  if ((int)retval >= (int)sizeof(buffer)) {
-    // Output was truncated. TODO: Do something.
-    ERROR_LOG(IO, "Buffer::Printf truncated output");
-  }
-  if (retval < 0) {
-    ERROR_LOG(IO, "Buffer::Printf failed");
-  }
-  va_end(vl);
-  char *ptr = Append(retval);
-  memcpy(ptr, buffer, retval);
-}
-
-bool Buffer::Flush(int fd) {
-  // Look into using send() directly.
-  bool success = data_.size() == fd_util::WriteLine(fd, &data_[0], data_.size());
-  if (success) {
-    data_.resize(0);
-  }
-  return success;
+	char buffer[2048];
+	va_list vl;
+	va_start(vl, fmt);
+	size_t retval = vsnprintf(buffer, sizeof(buffer), fmt, vl);
+	if ((int)retval >= (int)sizeof(buffer)) {
+		// Output was truncated. TODO: Do something.
+		ERROR_LOG(IO, "Buffer::Printf truncated output");
+	}
+	if (retval < 0) {
+		ERROR_LOG(IO, "Buffer::Printf failed");
+	}
+	va_end(vl);
+	char *ptr = Append(retval);
+	memcpy(ptr, buffer, retval);
 }
 
 bool Buffer::FlushToFile(const char *filename) {
@@ -150,116 +124,6 @@ bool Buffer::FlushToFile(const char *filename) {
 	}
 	fclose(f);
 	return true;
-}
-
-bool Buffer::FlushSocket(uintptr_t sock, double timeout, bool *cancelled) {
-	static constexpr float CANCEL_INTERVAL = 0.25f;
-	for (size_t pos = 0, end = data_.size(); pos < end; ) {
-		bool ready = false;
-		double leftTimeout = timeout;
-		while (!ready && (leftTimeout >= 0 || cancelled)) {
-			if (cancelled && *cancelled)
-				return false;
-			ready = fd_util::WaitUntilReady(sock, CANCEL_INTERVAL, true);
-			if (!ready && leftTimeout >= 0.0) {
-				leftTimeout -= CANCEL_INTERVAL;
-				if (leftTimeout < 0) {
-					ERROR_LOG(IO, "FlushSocket timed out");
-					return false;
-				}
-			}
-		}
-		int sent = send(sock, &data_[pos], (int)(end - pos), MSG_NOSIGNAL);
-		if (sent < 0) {
-			ERROR_LOG(IO, "FlushSocket failed");
-			return false;
-		}
-		pos += sent;
-
-		// Buffer full, don't spin.
-		if (sent == 0 && timeout < 0.0) {
-			sleep_ms(1);
-		}
-	}
-	data_.resize(0);
-	return true;
-}
-
-bool Buffer::ReadAll(int fd, int hintSize) {
-	std::vector<char> buf;
-	if (hintSize >= 65536 * 16) {
-		buf.resize(65536);
-	} else if (hintSize >= 1024 * 16) {
-		buf.resize(hintSize / 16);
-	} else {
-		buf.resize(4096);
-	}
-
-	while (true) {
-		int retval = recv(fd, &buf[0], (int)buf.size(), MSG_NOSIGNAL);
-		if (retval == 0) {
-			break;
-		} else if (retval < 0) {
-			ERROR_LOG(IO, "Error reading from buffer: %i", retval);
-			return false;
-		}
-		char *p = Append((size_t)retval);
-		memcpy(p, &buf[0], retval);
-	}
-	return true;
-}
-
-bool Buffer::ReadAllWithProgress(int fd, int knownSize, float *progress, bool *cancelled) {
-	static constexpr float CANCEL_INTERVAL = 0.25f;
-	std::vector<char> buf;
-	if (knownSize >= 65536 * 16) {
-		buf.resize(65536);
-	} else if (knownSize >= 1024 * 16) {
-		buf.resize(knownSize / 16);
-	} else {
-		buf.resize(1024);
-	}
-
-	int total = 0;
-	while (true) {
-		bool ready = false;
-		while (!ready && cancelled) {
-			if (*cancelled)
-				return false;
-			ready = fd_util::WaitUntilReady(fd, CANCEL_INTERVAL, false);
-		}
-		int retval = recv(fd, &buf[0], (int)buf.size(), MSG_NOSIGNAL);
-		if (retval == 0) {
-			return true;
-		} else if (retval < 0) {
-			ERROR_LOG(IO, "Error reading from buffer: %i", retval);
-			return false;
-		}
-		char *p = Append((size_t)retval);
-		memcpy(p, &buf[0], retval);
-		total += retval;
-		if (progress)
-			*progress = (float)total / (float)knownSize;
-	}
-	return true;
-}
-
-int Buffer::Read(int fd, size_t sz) {
-	char buf[1024];
-	int retval;
-	size_t received = 0;
-	while ((retval = recv(fd, buf, (int)std::min(sz, sizeof(buf)), MSG_NOSIGNAL)) > 0) {
-		if (retval < 0) {
-			return retval;
-		}
-		char *p = Append((size_t)retval);
-		memcpy(p, buf, retval);
-		sz -= retval;
-		received += retval;
-		if (sz == 0)
-			return 0;
-	}
-	return (int)received;
 }
 
 void Buffer::PeekAll(std::string *dest) {

--- a/Common/Buffer.h
+++ b/Common/Buffer.h
@@ -10,7 +10,14 @@
 class Buffer {
 public:
 	Buffer();
+	Buffer(Buffer &&) = default;
 	~Buffer();
+
+	static Buffer Void() {
+		Buffer buf;
+		buf.void_ = true;
+		return buf;
+	}
 
 	// Write max [length] bytes to the returned pointer.
 	// Any other operation on this Buffer invalidates the pointer.
@@ -65,10 +72,12 @@ public:
 	size_t size() const { return data_.size(); }
 	bool empty() const { return size() == 0; }
 	void clear() { data_.resize(0); }
+	bool IsVoid() { return void_; }
 
 protected:
 	// TODO: Find a better internal representation, like a cord.
 	std::vector<char> data_;
+	bool void_ = false;
 
 private:
 	DISALLOW_COPY_AND_ASSIGN(Buffer);

--- a/Common/Buffer.h
+++ b/Common/Buffer.h
@@ -59,25 +59,17 @@ public:
 	// Writes the entire buffer to the file descriptor. Also resets the
 	// size to zero. On failure, data remains in buffer and nothing is
 	// written.
-	bool Flush(int fd);
 	bool FlushToFile(const char *filename);
-	bool FlushSocket(uintptr_t sock, double timeout = -1.0, bool *cancelled = nullptr);  // Windows portability
-
-	bool ReadAll(int fd, int hintSize = 0);
-	bool ReadAllWithProgress(int fd, int knownSize, float *progress, bool *cancelled);
-
-	// < 0: error
-	// >= 0: number of bytes read
-	int Read(int fd, size_t sz);
 
 	// Utilities. Try to avoid checking for size.
 	size_t size() const { return data_.size(); }
 	bool empty() const { return size() == 0; }
 	void clear() { data_.resize(0); }
 
-private:
+protected:
 	// TODO: Find a better internal representation, like a cord.
 	std::vector<char> data_;
 
+private:
 	DISALLOW_COPY_AND_ASSIGN(Buffer);
 };

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -452,6 +452,7 @@
     <ClInclude Include="Math\lin\matrix4x4.h" />
     <ClInclude Include="Math\lin\vec3.h" />
     <ClInclude Include="Math\math_util.h" />
+    <ClInclude Include="Net\NetBuffer.h" />
     <ClInclude Include="Net\HTTPClient.h" />
     <ClInclude Include="Net\HTTPHeaders.h" />
     <ClInclude Include="Net\HTTPServer.h" />
@@ -775,6 +776,7 @@
     <ClCompile Include="Math\lin\matrix4x4.cpp" />
     <ClCompile Include="Math\lin\vec3.cpp" />
     <ClCompile Include="Math\math_util.cpp" />
+    <ClCompile Include="Net\NetBuffer.cpp" />
     <ClCompile Include="Net\HTTPClient.cpp" />
     <ClCompile Include="Net\HTTPHeaders.cpp" />
     <ClCompile Include="Net\HTTPServer.cpp" />

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -469,12 +469,12 @@
     <ClInclude Include="Render\Text\draw_text_win.h" />
     <ClInclude Include="Serialize\SerializeDeque.h" />
     <ClInclude Include="Serialize\SerializeFuncs.h" />
-    <ClInclude Include="ColorConvNEON.h" />
+    <ClInclude Include="Data\Convert\ColorConvNEON.h" />
     <ClInclude Include="Serialize\SerializeList.h" />
     <ClInclude Include="Serialize\SerializeMap.h" />
     <ClInclude Include="Serialize\Serializer.h" />
     <ClInclude Include="CodeBlock.h" />
-    <ClInclude Include="ColorConv.h" />
+    <ClInclude Include="Data\Convert\ColorConv.h" />
     <ClInclude Include="Common.h" />
     <ClInclude Include="CommonFuncs.h" />
     <ClInclude Include="CommonTypes.h" />
@@ -705,7 +705,7 @@
     </ClCompile>
     <ClCompile Include="ArmEmitter.cpp" />
     <ClCompile Include="Buffer.cpp" />
-    <ClCompile Include="ColorConvNEON.cpp">
+    <ClCompile Include="Data\Convert\ColorConvNEON.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
@@ -791,7 +791,7 @@
     <ClCompile Include="Render\Text\draw_text_uwp.cpp" />
     <ClCompile Include="Render\Text\draw_text_win.cpp" />
     <ClCompile Include="Serialize\Serializer.cpp" />
-    <ClCompile Include="ColorConv.cpp" />
+    <ClCompile Include="Data\Convert\ColorConv.cpp" />
     <ClCompile Include="ConsoleListener.cpp" />
     <ClCompile Include="CPUDetect.cpp" />
     <ClCompile Include="MipsCPUDetect.cpp">

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -32,8 +32,6 @@
     <ClInclude Include="ArmCommon.h" />
     <ClInclude Include="BitSet.h" />
     <ClInclude Include="CodeBlock.h" />
-    <ClInclude Include="ColorConv.h" />
-    <ClInclude Include="ColorConvNEON.h" />
     <ClInclude Include="GL\GLInterface\EGL.h">
       <Filter>GL\GLInterface</Filter>
     </ClInclude>
@@ -384,6 +382,12 @@
     <ClInclude Include="GPU\ShaderTranslation.h">
       <Filter>GPU</Filter>
     </ClInclude>
+    <ClInclude Include="Data\Convert\ColorConvNEON.h">
+      <Filter>Data\Convert</Filter>
+    </ClInclude>
+    <ClInclude Include="Data\Convert\ColorConv.h">
+      <Filter>Data\Convert</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />
@@ -410,8 +414,6 @@
     </ClCompile>
     <ClCompile Include="MipsEmitter.cpp" />
     <ClCompile Include="Arm64Emitter.cpp" />
-    <ClCompile Include="ColorConv.cpp" />
-    <ClCompile Include="ColorConvNEON.cpp" />
     <ClCompile Include="GL\GLInterface\EGL.cpp">
       <Filter>GL\GLInterface</Filter>
     </ClCompile>
@@ -739,6 +741,12 @@
     </ClCompile>
     <ClCompile Include="GPU\ShaderTranslation.cpp">
       <Filter>GPU</Filter>
+    </ClCompile>
+    <ClCompile Include="Data\Convert\ColorConvNEON.cpp">
+      <Filter>Data\Convert</Filter>
+    </ClCompile>
+    <ClCompile Include="Data\Convert\ColorConv.cpp">
+      <Filter>Data\Convert</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -68,7 +68,6 @@
     </ClInclude>
     <ClInclude Include="TimeUtil.h" />
     <ClInclude Include="FakeEmitter.h" />
-    <ClInclude Include="Buffer.h" />
     <ClInclude Include="SysError.h" />
     <ClInclude Include="..\ext\libpng17\png.h">
       <Filter>ext\libpng17</Filter>
@@ -388,6 +387,10 @@
     <ClInclude Include="Data\Convert\ColorConv.h">
       <Filter>Data\Convert</Filter>
     </ClInclude>
+    <ClInclude Include="Buffer.h" />
+    <ClInclude Include="Net\NetBuffer.h">
+      <Filter>Net</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />
@@ -434,7 +437,6 @@
     </ClCompile>
     <ClCompile Include="TimeUtil.cpp" />
     <ClCompile Include="Log.cpp" />
-    <ClCompile Include="Buffer.cpp" />
     <ClCompile Include="SysError.cpp" />
     <ClCompile Include="..\ext\libpng17\png.c">
       <Filter>ext\libpng17</Filter>
@@ -747,6 +749,10 @@
     </ClCompile>
     <ClCompile Include="Data\Convert\ColorConv.cpp">
       <Filter>Data\Convert</Filter>
+    </ClCompile>
+    <ClCompile Include="Buffer.cpp" />
+    <ClCompile Include="Net\NetBuffer.cpp">
+      <Filter>Net</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Common/Data/Convert/ColorConv.cpp
+++ b/Common/Data/Convert/ColorConv.cpp
@@ -172,6 +172,15 @@ void ConvertBGRA8888ToRGBA8888(u32 *dst, const u32 *src, u32 numPixels) {
 	}
 }
 
+void ConvertBGRA8888ToRGB888(u8 *dst, const u32 *src, u32 numPixels) {
+	for (uint32_t x = 0; x < numPixels; ++x) {
+		uint32_t c = src[x];
+		dst[x * 3 + 0] = (c >> 16) & 0xFF;
+		dst[x * 3 + 1] = (c >> 8) & 0xFF;
+		dst[x * 3 + 2] = (c >> 0) & 0xFF;
+	}
+}
+
 void ConvertRGBA8888ToRGBA5551(u16 *dst, const u32 *src, u32 numPixels) {
 #if _M_SSE >= 0x401
 	const __m128i maskAG = _mm_set1_epi32(0x8000F800);
@@ -277,6 +286,12 @@ void ConvertRGBA8888ToRGB565(u16 *dst, const u32 *src, u32 numPixels) {
 void ConvertRGBA8888ToRGBA4444(u16 *dst, const u32 *src, u32 numPixels) {
 	for (u32 x = 0; x < numPixels; ++x) {
 		dst[x] = RGBA8888toRGBA4444(src[x]);
+	}
+}
+
+void ConvertRGBA8888ToRGB888(u8 *dst, const u32 *src, u32 numPixels) {
+	for (uint32_t x = 0; x < numPixels; ++x) {
+		memcpy(dst + x * 3, src + x, 3);
 	}
 }
 

--- a/Common/Data/Convert/ColorConv.cpp
+++ b/Common/Data/Convert/ColorConv.cpp
@@ -637,6 +637,21 @@ void ConvertRGB565ToBGR565Basic(u16 *dst, const u16 *src, u32 numPixels) {
 	}
 }
 
+void ConvertBGRA5551ToABGR1555(u16 *dst, const u16 *src, u32 numPixels) {
+	const u32 *src32 = (const u32 *)src;
+	u32 *dst32 = (u32 *)dst;
+	for (u32 i = 0; i < numPixels / 2; i++) {
+		const u32 c = src32[i];
+		dst32[i] = ((c >> 15) & 0x00010001) | ((c << 1) & 0xFFFEFFFE);
+	}
+
+	if (numPixels & 1) {
+		const u32 i = numPixels - 1;
+		const u16 c = src[i];
+		dst[i] = (c >> 15) | (c << 1);
+	}
+}
+
 // Reuse the logic from the header - if these aren't defined, we need externs.
 #ifndef ConvertRGBA4444ToABGR4444
 Convert16bppTo16bppFunc ConvertRGBA4444ToABGR4444 = &ConvertRGBA4444ToABGR4444Basic;

--- a/Common/Data/Convert/ColorConv.cpp
+++ b/Common/Data/Convert/ColorConv.cpp
@@ -16,12 +16,12 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "ppsspp_config.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/Data/Convert/SmallDataConvert.h"
-#include "ColorConv.h"
 // NEON is in a separate file so that it can be compiled with a runtime check.
-#include "ColorConvNEON.h"
-#include "Common.h"
-#include "CPUDetect.h"
+#include "Common/Data/Convert/ColorConvNEON.h"
+#include "Common/Common.h"
+#include "Common/CPUDetect.h"
 
 #ifdef _M_SSE
 #include <emmintrin.h>

--- a/Common/Data/Convert/ColorConv.h
+++ b/Common/Data/Convert/ColorConv.h
@@ -110,10 +110,12 @@ typedef void (*Convert32bppTo32bppFunc)(u32 *dst, const u32 *src, u32 numPixels)
 
 void ConvertBGRA8888ToRGBA8888(u32 *dst, const u32 *src, u32 numPixels);
 #define ConvertRGBA8888ToBGRA8888 ConvertBGRA8888ToRGBA8888
+void ConvertBGRA8888ToRGB888(u8 *dst, const u32 *src, u32 numPixels);
 
 void ConvertRGBA8888ToRGBA5551(u16 *dst, const u32 *src, u32 numPixels);
 void ConvertRGBA8888ToRGB565(u16 *dst, const u32 *src, u32 numPixels);
 void ConvertRGBA8888ToRGBA4444(u16 *dst, const u32 *src, u32 numPixels);
+void ConvertRGBA8888ToRGB888(u8 *dst, const u32 *src, u32 numPixels);
 
 void ConvertBGRA8888ToRGBA5551(u16 *dst, const u32 *src, u32 numPixels);
 void ConvertBGRA8888ToRGB565(u16 *dst, const u32 *src, u32 numPixels);

--- a/Common/Data/Convert/ColorConv.h
+++ b/Common/Data/Convert/ColorConv.h
@@ -134,6 +134,7 @@ void ConvertRGB565ToBGRA8888(u32 *dst, const u16 *src, u32 numPixels);
 void ConvertRGBA4444ToABGR4444Basic(u16 *dst, const u16 *src, u32 numPixels);
 void ConvertRGBA5551ToABGR1555Basic(u16 *dst, const u16 *src, u32 numPixels);
 void ConvertRGB565ToBGR565Basic(u16 *dst, const u16 *src, u32 numPixels);
+void ConvertBGRA5551ToABGR1555(u16 *dst, const u16 *src, u32 numPixels);
 
 #if PPSSPP_ARCH(ARM64)
 #define ConvertRGBA4444ToABGR4444 ConvertRGBA4444ToABGR4444NEON

--- a/Common/Data/Convert/ColorConv.h
+++ b/Common/Data/Convert/ColorConv.h
@@ -18,8 +18,8 @@
 #pragma once
 
 #include "ppsspp_config.h"
-#include "CommonTypes.h"
-#include "ColorConvNEON.h"
+#include "Common/CommonTypes.h"
+#include "Common/Data/Convert/ColorConvNEON.h"
 
 void SetupColorConv();
 

--- a/Common/Data/Convert/ColorConvNEON.cpp
+++ b/Common/Data/Convert/ColorConvNEON.cpp
@@ -23,9 +23,9 @@
 #else
 #include <arm_neon.h>
 #endif
-#include "ColorConvNEON.h"
-#include "Common.h"
-#include "CPUDetect.h"
+#include "Common/Data/Convert/ColorConvNEON.h"
+#include "Common/Common.h"
+#include "Common/CPUDetect.h"
 
 // TODO: More NEON color conversion funcs.
 

--- a/Common/Data/Convert/ColorConvNEON.h
+++ b/Common/Data/Convert/ColorConvNEON.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "ColorConv.h"
+#include "Common/Data/Convert/ColorConv.h"
 
 void ConvertRGBA4444ToABGR4444NEON(u16 *dst, const u16 *src, u32 numPixels);
 void ConvertRGBA5551ToABGR1555NEON(u16 *dst, const u16 *src, u32 numPixels);

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -245,7 +245,8 @@ bool IsDirectory(const std::string &filename)
 	std::wstring copy = ConvertUTF8ToWString(fn);
 	WIN32_FILE_ATTRIBUTE_DATA data{};
 	if (!GetFileAttributesEx(copy.c_str(), GetFileExInfoStandard, &data) || data.dwFileAttributes == INVALID_FILE_ATTRIBUTES) {
-		WARN_LOG(COMMON, "GetFileAttributes failed on %s: %08x", fn.c_str(), (uint32_t)GetLastError());
+		auto err = GetLastError();
+		WARN_LOG(COMMON, "GetFileAttributes failed on %s: %08x %s", fn.c_str(), (uint32_t)err, GetStringErrorMsg(err).c_str());
 		return false;
 	}
 	DWORD result = data.dwFileAttributes;
@@ -311,7 +312,7 @@ bool CreateDir(const std::string &path)
 		WARN_LOG(COMMON, "CreateDir: CreateDirectory failed on %s: already exists", path.c_str());
 		return true;
 	}
-	ERROR_LOG(COMMON, "CreateDir: CreateDirectory failed on %s: %08x", path.c_str(), (uint32_t)error);
+	ERROR_LOG(COMMON, "CreateDir: CreateDirectory failed on %s: %08x %s", path.c_str(), (uint32_t)error, GetStringErrorMsg(error).c_str());
 	return false;
 #else
 	if (mkdir(fn.c_str(), 0755) == 0)

--- a/Common/File/PathBrowser.cpp
+++ b/Common/File/PathBrowser.cpp
@@ -32,7 +32,8 @@ bool LoadRemoteFileList(const std::string &url, bool *cancel, std::vector<File::
 	// Start by requesting the list of files from the server.
 	if (http.Resolve(baseURL.Host().c_str(), baseURL.Port())) {
 		if (http.Connect(2, 20.0, cancel)) {
-			code = http.GET(baseURL.Resource().c_str(), &result, responseHeaders);
+			http::RequestProgress progress(cancel);
+			code = http.GET(baseURL.Resource().c_str(), &result, responseHeaders, &progress);
 			http.Disconnect();
 		}
 	}

--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -8,9 +8,9 @@
 #endif
 #include "Common/System/Display.h"
 
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/Data/Convert/SmallDataConvert.h"
 #include "Common/Data/Encoding/Utf8.h"
-#include "Common/ColorConv.h"
 #include "Common/Log.h"
 
 #include <cfloat>

--- a/Common/GPU/thin3d.cpp
+++ b/Common/GPU/thin3d.cpp
@@ -2,10 +2,10 @@
 #include <cstring>
 #include <cstdint>
 
-#include "Common/System/Display.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/GPU/thin3d.h"
 #include "Common/Log.h"
-#include "Common/ColorConv.h"
+#include "Common/System/Display.h"
 
 namespace Draw {
 

--- a/Common/GPU/thin3d.cpp
+++ b/Common/GPU/thin3d.cpp
@@ -396,8 +396,6 @@ DrawContext::~DrawContext() {
 	DestroyPresets();
 }
 
-// TODO: Use the functions we have in Common/ColorConv.cpp.
-// Could also make C fake-simd for 64-bit, two 8888 pixels fit in a register :)
 void ConvertFromRGBA8888(uint8_t *dst, const uint8_t *src, uint32_t dstStride, uint32_t srcStride, uint32_t width, uint32_t height, DataFormat format) {
 	// Must skip stride in the cases below.  Some games pack data into the cracks, like MotoGP.
 	const uint32_t *src32 = (const uint32_t *)src;
@@ -415,9 +413,7 @@ void ConvertFromRGBA8888(uint8_t *dst, const uint8_t *src, uint32_t dstStride, u
 		}
 	} else if (format == Draw::DataFormat::R8G8B8_UNORM) {
 		for (uint32_t y = 0; y < height; ++y) {
-			for (uint32_t x = 0; x < width; ++x) {
-				memcpy(dst + x * 3, src32 + x, 3);
-			}
+			ConvertRGBA8888ToRGB888(dst, src32, width);
 			src32 += srcStride;
 			dst += dstStride * 3;
 		}
@@ -455,8 +451,6 @@ void ConvertFromRGBA8888(uint8_t *dst, const uint8_t *src, uint32_t dstStride, u
 	}
 }
 
-// TODO: Use the functions we have in Common/ColorConv.cpp.
-// Could also make C fake-simd for 64-bit, two 8888 pixels fit in a register :)
 void ConvertFromBGRA8888(uint8_t *dst, const uint8_t *src, uint32_t dstStride, uint32_t srcStride, uint32_t width, uint32_t height, DataFormat format) {
 	// Must skip stride in the cases below.  Some games pack data into the cracks, like MotoGP.
 	const uint32_t *src32 = (const uint32_t *)src;
@@ -481,12 +475,7 @@ void ConvertFromBGRA8888(uint8_t *dst, const uint8_t *src, uint32_t dstStride, u
 		}
 	} else if (format == Draw::DataFormat::R8G8B8_UNORM) {
 		for (uint32_t y = 0; y < height; ++y) {
-			for (uint32_t x = 0; x < width; ++x) {
-				uint32_t c = src32[x];
-				dst[x * 3 + 0] = (c >> 16) & 0xFF;
-				dst[x * 3 + 1] = (c >> 8) & 0xFF;
-				dst[x * 3 + 2] = (c >> 0) & 0xFF;
-			}
+			ConvertBGRA8888ToRGB888(dst, src32, width);
 			src32 += srcStride;
 			dst += dstStride * 3;
 		}

--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -31,7 +31,7 @@
 #include "Common/File/FileDescriptor.h"
 #include "Common/Thread/ThreadUtil.h"
 #include "Common/Data/Encoding/Compression.h"
-#include "Common/Buffer.h"
+#include "Common/Net/NetBuffer.h"
 #include "Common/Log.h"
 
 namespace net {
@@ -253,7 +253,7 @@ int Client::GET(const char *resource, Buffer *output, std::vector<std::string> &
 		return err;
 	}
 
-	Buffer readbuf;
+	net::Buffer readbuf;
 	int code = ReadResponseHeaders(&readbuf, responseHeaders, progress, cancelled);
 	if (code < 0) {
 		return code;
@@ -284,7 +284,7 @@ int Client::POST(const char *resource, const std::string &data, const std::strin
 		return err;
 	}
 
-	Buffer readbuf;
+	net::Buffer readbuf;
 	std::vector<std::string> responseHeaders;
 	int code = ReadResponseHeaders(&readbuf, responseHeaders, progress);
 	if (code < 0) {
@@ -311,7 +311,7 @@ int Client::SendRequestWithData(const char *method, const char *resource, const 
 		*progress = 0.01f;
 	}
 
-	Buffer buffer;
+	net::Buffer buffer;
 	const char *tpl =
 		"%s %s HTTP/%s\r\n"
 		"Host: %s\r\n"
@@ -333,7 +333,7 @@ int Client::SendRequestWithData(const char *method, const char *resource, const 
 	return 0;
 }
 
-int Client::ReadResponseHeaders(Buffer *readbuf, std::vector<std::string> &responseHeaders, float *progress, bool *cancelled) {
+int Client::ReadResponseHeaders(net::Buffer *readbuf, std::vector<std::string> &responseHeaders, float *progress, bool *cancelled) {
 	// Snarf all the data we can into RAM. A little unsafe but hey.
 	static constexpr float CANCEL_INTERVAL = 0.25f;
 	bool ready = false;
@@ -389,7 +389,7 @@ int Client::ReadResponseHeaders(Buffer *readbuf, std::vector<std::string> &respo
 	return code;
 }
 
-int Client::ReadResponseEntity(Buffer *readbuf, const std::vector<std::string> &responseHeaders, Buffer *output, float *progress, bool *cancelled) {
+int Client::ReadResponseEntity(net::Buffer *readbuf, const std::vector<std::string> &responseHeaders, Buffer *output, float *progress, bool *cancelled) {
 	bool gzip = false;
 	bool chunked = false;
 	int contentLength = 0;

--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -147,7 +147,6 @@ bool Connection::Connect(int maxTries, double timeout, bool *cancelConnect) {
 			// Something connected.  Pick the first one that did (if multiple.)
 			for (int sock : sockets) {
 				if ((intptr_t)sock_ == -1 && FD_ISSET(sock, &fds)) {
-					fd_util::SetNonBlocking(sock, false);
 					sock_ = sock;
 				} else {
 					closesocket(sock);

--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -423,11 +423,11 @@ int Client::ReadResponseEntity(net::Buffer *readbuf, const std::vector<std::stri
 
 	if (!contentLength) {
 		// No way to know how far along we are. Let's just not update the progress counter.
-		if (!readbuf->ReadAllWithProgress(sock(), contentLength, nullptr, progress->cancelled))
+		if (!readbuf->ReadAllWithProgress(sock(), contentLength, nullptr, &progress->kBps, progress->cancelled))
 			return -1;
 	} else {
 		// Let's read in chunks, updating progress between each.
-		if (!readbuf->ReadAllWithProgress(sock(), contentLength, &progress->progress, progress->cancelled))
+		if (!readbuf->ReadAllWithProgress(sock(), contentLength, &progress->progress, &progress->kBps, progress->cancelled))
 			return -1;
 	}
 

--- a/Common/Net/HTTPClient.h
+++ b/Common/Net/HTTPClient.h
@@ -75,7 +75,7 @@ public:
 protected:
 	std::string userAgent_;
 	const char *httpVersion_;
-	double dataTimeout_ = -1.0;
+	double dataTimeout_ = 900.0;
 };
 
 // Not particularly efficient, but hey - it's a background download, that's pretty cool :P

--- a/Common/Net/HTTPClient.h
+++ b/Common/Net/HTTPClient.h
@@ -48,6 +48,7 @@ struct RequestProgress {
 	explicit RequestProgress(bool *c) : cancelled(c) {}
 
 	float progress = 0.0f;
+	float kBps = 0.0f;
 	bool *cancelled = nullptr;
 };
 
@@ -98,6 +99,7 @@ public:
 
 	// Returns 1.0 when done. That one value can be compared exactly - or just use Done().
 	float Progress() const { return progress_.progress; }
+	float SpeedKBps() const { return progress_.kBps; }
 
 	bool Done() const { return completed_; }
 	bool Failed() const { return failed_; }

--- a/Common/Net/HTTPClient.h
+++ b/Common/Net/HTTPClient.h
@@ -5,9 +5,8 @@
 #include <thread>
 #include <cstdint>
 
+#include "Common/Net/NetBuffer.h"
 #include "Common/Net/Resolve.h"
-
-#include "Common/Buffer.h"
 
 namespace net {
 
@@ -61,9 +60,9 @@ public:
 
 	int SendRequest(const char *method, const char *resource, const char *otherHeaders = nullptr, float *progress = nullptr, bool *cancelled = nullptr);
 	int SendRequestWithData(const char *method, const char *resource, const std::string &data, const char *otherHeaders = nullptr, float *progress = nullptr, bool *cancelled = nullptr);
-	int ReadResponseHeaders(Buffer *readbuf, std::vector<std::string> &responseHeaders, float *progress = nullptr, bool *cancelled = nullptr);
+	int ReadResponseHeaders(net::Buffer *readbuf, std::vector<std::string> &responseHeaders, float *progress = nullptr, bool *cancelled = nullptr);
 	// If your response contains a response, you must read it.
-	int ReadResponseEntity(Buffer *readbuf, const std::vector<std::string> &responseHeaders, Buffer *output, float *progress = nullptr, bool *cancelled = nullptr);
+	int ReadResponseEntity(net::Buffer *readbuf, const std::vector<std::string> &responseHeaders, Buffer *output, float *progress = nullptr, bool *cancelled = nullptr);
 
 	void SetDataTimeout(double t) {
 		dataTimeout_ = t;

--- a/Common/Net/HTTPClient.h
+++ b/Common/Net/HTTPClient.h
@@ -43,26 +43,34 @@ namespace http {
 
 bool GetHeaderValue(const std::vector<std::string> &responseHeaders, const std::string &header, std::string *value);
 
+struct RequestProgress {
+	RequestProgress() {}
+	explicit RequestProgress(bool *c) : cancelled(c) {}
+
+	float progress = 0.0f;
+	bool *cancelled = nullptr;
+};
+
 class Client : public net::Connection {
 public:
 	Client();
 	~Client();
 
 	// Return value is the HTTP return code. 200 means OK. < 0 means some local error.
-	int GET(const char *resource, Buffer *output, float *progress = nullptr, bool *cancelled = nullptr);
-	int GET(const char *resource, Buffer *output, std::vector<std::string> &responseHeaders, float *progress = nullptr, bool *cancelled = nullptr);
+	int GET(const char *resource, Buffer *output, RequestProgress *progress);
+	int GET(const char *resource, Buffer *output, std::vector<std::string> &responseHeaders, RequestProgress *progress);
 
 	// Return value is the HTTP return code.
-	int POST(const char *resource, const std::string &data, const std::string &mime, Buffer *output, float *progress = nullptr);
-	int POST(const char *resource, const std::string &data, Buffer *output, float *progress = nullptr);
+	int POST(const char *resource, const std::string &data, const std::string &mime, Buffer *output, RequestProgress *progress);
+	int POST(const char *resource, const std::string &data, Buffer *output, RequestProgress *progress);
 
 	// HEAD, PUT, DELETE aren't implemented yet, but can be done with SendRequest.
 
-	int SendRequest(const char *method, const char *resource, const char *otherHeaders = nullptr, float *progress = nullptr, bool *cancelled = nullptr);
-	int SendRequestWithData(const char *method, const char *resource, const std::string &data, const char *otherHeaders = nullptr, float *progress = nullptr, bool *cancelled = nullptr);
-	int ReadResponseHeaders(net::Buffer *readbuf, std::vector<std::string> &responseHeaders, float *progress = nullptr, bool *cancelled = nullptr);
+	int SendRequest(const char *method, const char *resource, const char *otherHeaders, RequestProgress *progress);
+	int SendRequestWithData(const char *method, const char *resource, const std::string &data, const char *otherHeaders, RequestProgress *progress);
+	int ReadResponseHeaders(net::Buffer *readbuf, std::vector<std::string> &responseHeaders, RequestProgress *progress);
 	// If your response contains a response, you must read it.
-	int ReadResponseEntity(net::Buffer *readbuf, const std::vector<std::string> &responseHeaders, Buffer *output, float *progress = nullptr, bool *cancelled = nullptr);
+	int ReadResponseEntity(net::Buffer *readbuf, const std::vector<std::string> &responseHeaders, Buffer *output, RequestProgress *progress);
 
 	void SetDataTimeout(double t) {
 		dataTimeout_ = t;
@@ -89,7 +97,7 @@ public:
 	void Join();
 
 	// Returns 1.0 when done. That one value can be compared exactly - or just use Done().
-	float Progress() const { return progress_; }
+	float Progress() const { return progress_.progress; }
 
 	bool Done() const { return completed_; }
 	bool Failed() const { return failed_; }
@@ -133,7 +141,7 @@ private:
 	int PerformGET(const std::string &url);
 	std::string RedirectLocation(const std::string &baseUrl);
 	void SetFailed(int code);
-	float progress_ = 0.0f;
+	RequestProgress progress_;
 	Buffer buffer_;
 	std::vector<std::string> responseHeaders_;
 	std::string url_;

--- a/Common/Net/HTTPHeaders.h
+++ b/Common/Net/HTTPHeaders.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <unordered_map>
 
-#include "Common/Buffer.h"
+#include "Common/Net/NetBuffer.h"
 
 namespace net {
 class InputSink;

--- a/Common/Net/HTTPServer.cpp
+++ b/Common/Net/HTTPServer.cpp
@@ -35,10 +35,9 @@
 #include <cstdlib>
 
 #include "Common/Net/HTTPServer.h"
+#include "Common/Net/NetBuffer.h"
 #include "Common/Net/Sinks.h"
 #include "Common/File/FileDescriptor.h"
-
-#include "Common/Buffer.h"
 #include "Common/Log.h"
 
 void NewThreadExecutor::Run(std::function<void()> &&func) {

--- a/Common/Net/NetBuffer.cpp
+++ b/Common/Net/NetBuffer.cpp
@@ -47,7 +47,7 @@ bool Buffer::FlushSocket(uintptr_t sock, double timeout, bool *cancelled) {
 	return true;
 }
 
-bool Buffer::ReadAllWithProgress(int fd, int knownSize, float *progress, bool *cancelled) {
+bool Buffer::ReadAllWithProgress(int fd, int knownSize, float *progress, float *kBps, bool *cancelled) {
 	static constexpr float CANCEL_INTERVAL = 0.25f;
 	std::vector<char> buf;
 	// We're non-blocking and reading from an OS buffer, so try to read as much as we can at a time.
@@ -59,6 +59,7 @@ bool Buffer::ReadAllWithProgress(int fd, int knownSize, float *progress, bool *c
 		buf.resize(1024);
 	}
 
+	double st = time_now_d();
 	int total = 0;
 	while (true) {
 		bool ready = false;
@@ -84,6 +85,8 @@ bool Buffer::ReadAllWithProgress(int fd, int knownSize, float *progress, bool *c
 		total += retval;
 		if (progress)
 			*progress = (float)total / (float)knownSize;
+		if (kBps)
+			*kBps = (float)(total / (time_now_d() - st)) / 1024.0f;
 	}
 	return true;
 }

--- a/Common/Net/NetBuffer.cpp
+++ b/Common/Net/NetBuffer.cpp
@@ -1,4 +1,5 @@
-﻿#ifdef _WIN32
+#include "ppsspp_config.h"
+#ifdef _WIN32
 #include <winsock2.h>
 #undef min
 #undef max
@@ -69,7 +70,12 @@ bool Buffer::ReadAllWithProgress(int fd, int knownSize, float *progress, bool *c
 		if (retval == 0) {
 			return true;
 		} else if (retval < 0) {
-			ERROR_LOG(IO, "Error reading from buffer: %i", retval);
+#if PPSSPP_PLATFORM(WINDOWS)
+			if (WSAGetLastError() != WSAEWOULDBLOCK)
+#else
+			if (errno != EWOULDBLOCK)
+#endif
+				ERROR_LOG(IO, "Error reading from buffer: %i", retval);
 			return false;
 		}
 		char *p = Append((size_t)retval);

--- a/Common/Net/NetBuffer.cpp
+++ b/Common/Net/NetBuffer.cpp
@@ -50,6 +50,7 @@ bool Buffer::FlushSocket(uintptr_t sock, double timeout, bool *cancelled) {
 bool Buffer::ReadAllWithProgress(int fd, int knownSize, float *progress, bool *cancelled) {
 	static constexpr float CANCEL_INTERVAL = 0.25f;
 	std::vector<char> buf;
+	// We're non-blocking and reading from an OS buffer, so try to read as much as we can at a time.
 	if (knownSize >= 65536 * 16) {
 		buf.resize(65536);
 	} else if (knownSize >= 1024 * 16) {

--- a/Common/Net/NetBuffer.h
+++ b/Common/Net/NetBuffer.h
@@ -1,0 +1,19 @@
+﻿#pragma once
+
+#include "Common/Buffer.h"
+
+namespace net {
+
+class Buffer : public ::Buffer {
+public:
+	bool FlushSocket(uintptr_t sock, double timeout = -1.0, bool *cancelled = nullptr);
+
+	bool ReadAll(int fd, int hintSize = 0);
+	bool ReadAllWithProgress(int fd, int knownSize, float *progress, bool *cancelled);
+
+	// < 0: error
+	// >= 0: number of bytes read
+	int Read(int fd, size_t sz);
+};
+
+}

--- a/Common/Net/NetBuffer.h
+++ b/Common/Net/NetBuffer.h
@@ -6,9 +6,8 @@ namespace net {
 
 class Buffer : public ::Buffer {
 public:
-	bool FlushSocket(uintptr_t sock, double timeout = -1.0, bool *cancelled = nullptr);
+	bool FlushSocket(uintptr_t sock, double timeout, bool *cancelled = nullptr);
 
-	bool ReadAll(int fd, int hintSize = 0);
 	bool ReadAllWithProgress(int fd, int knownSize, float *progress, bool *cancelled);
 
 	// < 0: error

--- a/Common/Net/NetBuffer.h
+++ b/Common/Net/NetBuffer.h
@@ -8,7 +8,7 @@ class Buffer : public ::Buffer {
 public:
 	bool FlushSocket(uintptr_t sock, double timeout, bool *cancelled = nullptr);
 
-	bool ReadAllWithProgress(int fd, int knownSize, float *progress, bool *cancelled);
+	bool ReadAllWithProgress(int fd, int knownSize, float *progress, float *kBps, bool *cancelled);
 
 	// < 0: error
 	// >= 0: number of bytes read

--- a/Core/AVIDump.cpp
+++ b/Core/AVIDump.cpp
@@ -23,8 +23,8 @@ extern "C" {
 
 #endif
 
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/File/FileUtil.h"
-#include "Common/ColorConv.h"
 
 #include "Core/Config.h"
 #include "Core/AVIDump.h"

--- a/Core/FileLoaders/HTTPFileLoader.cpp
+++ b/Core/FileLoaders/HTTPFileLoader.cpp
@@ -145,7 +145,7 @@ int HTTPFileLoader::SendHEAD(const Url &url, std::vector<std::string> &responseH
 		return -400;
 	}
 
-	Buffer readbuf;
+	net::Buffer readbuf;
 	return client_.ReadResponseHeaders(&readbuf, responseHeaders);
 }
 
@@ -203,7 +203,7 @@ size_t HTTPFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, Flags f
 		return 0;
 	}
 
-	Buffer readbuf;
+	net::Buffer readbuf;
 	std::vector<std::string> responseHeaders;
 	int code = client_.ReadResponseHeaders(&readbuf, responseHeaders);
 	if (code != 206) {
@@ -235,7 +235,7 @@ size_t HTTPFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, Flags f
 	}
 
 	// TODO: Would be nice to read directly.
-	Buffer output;
+	net::Buffer output;
 	int res = client_.ReadResponseEntity(&readbuf, responseHeaders, &output);
 	if (res != 0) {
 		ERROR_LOG(LOADER, "Unable to read HTTP response entity: %d", res);

--- a/Core/FileLoaders/HTTPFileLoader.h
+++ b/Core/FileLoaders/HTTPFileLoader.h
@@ -46,7 +46,7 @@ public:
 	virtual size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) override;
 
 	void Cancel() override {
-		cancelConnect_ = true;
+		cancel_ = true;
 	}
 
 	std::string LatestError() const override {
@@ -70,9 +70,10 @@ private:
 	s64 filepos_ = 0;
 	Url url_;
 	http::Client client_;
+	http::RequestProgress progress_;
 	std::string filename_;
 	bool connected_ = false;
-	bool cancelConnect_ = false;
+	bool cancel_ = false;
 	const char *latestError_ = "";
 
 	std::once_flag preparedFlag_;

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -36,6 +36,7 @@
 #include "Common/File/FileUtil.h"
 #include "Common/File/DiskFree.h"
 #include "Common/File/VFS/VFS.h"
+#include "Common/SysError.h"
 #include "Core/FileSystems/DirectoryFileSystem.h"
 #include "Core/FileSystems/ISOFileSystem.h"
 #include "Core/HLE/sceKernel.h"
@@ -631,7 +632,8 @@ int DirectoryFileSystem::OpenFile(std::string filename, FileAccess access, const
 	err = ReplayApplyDisk(ReplayAction::FILE_OPEN, err, CoreTiming::GetGlobalTimeUs());
 	if (err != 0) {
 #ifdef _WIN32
-		ERROR_LOG(FILESYS, "DirectoryFileSystem::OpenFile: FAILED, %i - access = %i", (int)GetLastError(), (int)access);
+		auto win32err = GetLastError();
+		ERROR_LOG(FILESYS, "DirectoryFileSystem::OpenFile: FAILED, %i - access = %i, %s", (int)win32err, (int)access, GetStringErrorMsg(win32err).c_str());
 #else
 		ERROR_LOG(FILESYS, "DirectoryFileSystem::OpenFile: FAILED, %i - access = %i", errno, (int)access);
 #endif

--- a/Core/Instance.cpp
+++ b/Core/Instance.cpp
@@ -25,13 +25,12 @@
 #include <fcntl.h>
 #endif
 
-#include "Common/Log.h"
-
 #if PPSSPP_PLATFORM(WINDOWS)
-
 #include "Common/CommonWindows.h"
-
 #endif
+
+#include "Common/Log.h"
+#include "Common/SysError.h"
 
 #include <cstdint>
 
@@ -65,7 +64,8 @@ static bool UpdateInstanceCounter(void (*callback)(volatile InstanceInfo *)) {
 		sizeof(InstanceInfo));
 
 	if (!buf) {
-		ERROR_LOG(SCENET, "Could not map view of file %s (%08x)", ID_SHM_NAME, (uint32_t)GetLastError());
+		auto err = GetLastError();
+		ERROR_LOG(SCENET, "Could not map view of file %s, %08x %s", ID_SHM_NAME, (uint32_t)err, GetStringErrorMsg(err).c_str());
 		return false;
 	}
 
@@ -137,7 +137,7 @@ void InitInstanceCounter() {
 
 	DWORD lasterr = GetLastError();
 	if (!hIDMapFile) {
-		ERROR_LOG(SCENET, "Could not create %s file mapping object (%08x)", ID_SHM_NAME, (uint32_t)lasterr);
+		ERROR_LOG(SCENET, "Could not create %s file mapping object, %08x %s", ID_SHM_NAME, (uint32_t)lasterr, GetStringErrorMsg(lasterr).c_str());
 		PPSSPP_ID = 1;
 		return;
 	}

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -261,6 +261,7 @@ namespace Reporting
 	bool SendReportRequest(const char *uri, const std::string &data, const std::string &mimeType, Buffer *output = NULL)
 	{
 		http::Client http;
+		http::RequestProgress progress;
 		Buffer theVoid;
 
 		http.SetUserAgent(StringFromFormat("PPSSPP/%s", PPSSPP_GIT_VERSION));
@@ -274,7 +275,7 @@ namespace Reporting
 
 		if (http.Resolve(serverHost, ServerPort())) {
 			http.Connect();
-			int result = http.POST(uri, data, mimeType, output);
+			int result = http.POST(uri, data, mimeType, output, &progress);
 			http.Disconnect();
 
 			return result >= 200 && result < 300;

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -262,11 +262,11 @@ namespace Reporting
 	{
 		http::Client http;
 		http::RequestProgress progress;
-		Buffer theVoid;
+		Buffer theVoid = Buffer::Void();
 
 		http.SetUserAgent(StringFromFormat("PPSSPP/%s", PPSSPP_GIT_VERSION));
 
-		if (output == NULL)
+		if (output == nullptr)
 			output = &theVoid;
 
 		const char *serverHost = ServerHostname();

--- a/Core/Screenshot.cpp
+++ b/Core/Screenshot.cpp
@@ -21,7 +21,7 @@
 #include <png.h>
 #include "ext/jpge/jpge.h"
 
-#include "Common/ColorConv.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/File/FileUtil.h"
 #include "Common/Log.h"
 #include "Common/System/Display.h"

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -21,10 +21,10 @@
 
 #include "ext/xxhash.h"
 
-#include "Common/Data/Text/I18n.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/Data/Format/IniFile.h"
+#include "Common/Data/Text/I18n.h"
 #include "Common/Data/Text/Parsers.h"
-#include "Common/ColorConv.h"
 #include "Common/File/FileUtil.h"
 #include "Common/StringUtils.h"
 #include "Core/Config.h"

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -82,6 +82,12 @@ bool GameManager::DownloadAndInstall(std::string storeFileUrl) {
 	return true;
 }
 
+bool GameManager::IsDownloading(std::string storeZipUrl) {
+	if (curDownload_)
+		return curDownload_->url() == storeZipUrl;
+	return false;
+}
+
 bool GameManager::CancelDownload() {
 	if (!curDownload_)
 		return false;

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -91,6 +91,12 @@ bool GameManager::CancelDownload() {
 	return true;
 }
 
+float GameManager::DownloadSpeedKBps() {
+	if (curDownload_)
+		return curDownload_->SpeedKBps();
+	return 0.0f;
+}
+
 bool GameManager::Uninstall(std::string name) {
 	if (name.empty()) {
 		ERROR_LOG(HLE, "Cannot remove an empty-named game");

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -43,6 +43,7 @@ public:
 
 	// This starts off a background process.
 	bool DownloadAndInstall(std::string storeZipUrl);
+	bool IsDownloading(std::string storeZipUrl);
 	bool Uninstall(std::string name);
 
 	// Cancels the download in progress, if any.

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -48,6 +48,8 @@ public:
 	// Cancels the download in progress, if any.
 	bool CancelDownload();
 
+	float DownloadSpeedKBps();
+
 	// Call from time to time to check on completed downloads from the
 	// main UI thread.
 	void Update();

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -63,6 +63,7 @@ static ServerStatus RetrieveStatus() {
 static bool RegisterServer(int port) {
 	bool success = false;
 	http::Client http;
+	http::RequestProgress progress;
 	Buffer theVoid;
 
 	http.SetUserAgent(StringFromFormat("PPSSPP/%s", PPSSPP_GIT_VERSION));
@@ -73,7 +74,7 @@ static bool RegisterServer(int port) {
 			std::string ip = fd_util::GetLocalIP(http.sock());
 			snprintf(resource4, sizeof(resource4) - 1, "/match/update?local=%s&port=%d", ip.c_str(), port);
 
-			if (http.GET(resource4, &theVoid) > 0)
+			if (http.GET(resource4, &theVoid, &progress) > 0)
 				success = true;
 			theVoid.Skip(theVoid.size());
 			http.Disconnect();
@@ -86,7 +87,7 @@ static bool RegisterServer(int port) {
 
 		// We register both IPv4 and IPv6 in case the other client is using a different one.
 		if (resource4[0] != 0 && http.Connect(timeout)) {
-			if (http.GET(resource4, &theVoid) > 0)
+			if (http.GET(resource4, &theVoid, &progress) > 0)
 				success = true;
 			theVoid.Skip(theVoid.size());
 			http.Disconnect();
@@ -98,7 +99,7 @@ static bool RegisterServer(int port) {
 			std::string ip = fd_util::GetLocalIP(http.sock());
 			snprintf(resource6, sizeof(resource6) - 1, "/match/update?local=%s&port=%d", ip.c_str(), port);
 
-			if (http.GET(resource6, &theVoid) > 0)
+			if (http.GET(resource6, &theVoid, &progress) > 0)
 				success = true;
 			theVoid.Skip(theVoid.size());
 			http.Disconnect();

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -64,7 +64,7 @@ static bool RegisterServer(int port) {
 	bool success = false;
 	http::Client http;
 	http::RequestProgress progress;
-	Buffer theVoid;
+	Buffer theVoid = Buffer::Void();
 
 	http.SetUserAgent(StringFromFormat("PPSSPP/%s", PPSSPP_GIT_VERSION));
 

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -17,8 +17,8 @@
 
 #include <algorithm>
 
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/Profiler/Profiler.h"
-#include "Common/ColorConv.h"
 #include "Core/Config.h"
 #include "GPU/Common/DrawEngineCommon.h"
 #include "GPU/Common/SplineCommon.h"

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -21,8 +21,8 @@
 
 #include "Common/GPU/thin3d.h"
 #include "Common/GPU/OpenGL/GLFeatures.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/Data/Text/I18n.h"
-#include "Common/ColorConv.h"
 #include "Common/Common.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -18,8 +18,8 @@
 #include <algorithm>
 
 #include "ppsspp_config.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/Profiler/Profiler.h"
-#include "Common/ColorConv.h"
 #include "Common/MemoryUtil.h"
 #include "Common/StringUtils.h"
 #include "Core/Config.h"

--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -17,16 +17,14 @@
 
 #include "ppsspp_config.h"
 #include "ext/xxhash.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/CPUDetect.h"
-#include "Common/ColorConv.h"
 
 #include "GPU/GPU.h"
 #include "GPU/GPUState.h"
 #include "GPU/Common/TextureDecoder.h"
 // NEON is in a separate file so that it can be compiled with a runtime check.
 #include "GPU/Common/TextureDecoderNEON.h"
-
-// TODO: Move some common things into here.
 
 #ifdef _M_SSE
 #include <emmintrin.h>

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -20,10 +20,10 @@
 
 #include "ppsspp_config.h"
 
-#include "Common/Log.h"
-#include "Common/CPUDetect.h"
-#include "Common/ColorConv.h"
 #include "Common/Common.h"
+#include "Common/CPUDetect.h"
+#include "Common/Data/Convert/ColorConv.h"
+#include "Common/Log.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
 #include "Core/MemMap.h"

--- a/GPU/D3D11/DepalettizeShaderD3D11.cpp
+++ b/GPU/D3D11/DepalettizeShaderD3D11.cpp
@@ -19,8 +19,8 @@
 #include <d3d11.h>
 
 #include "Common/Common.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/Log.h"
-#include "Common/ColorConv.h"
 #include "Common/StringUtils.h"
 #include "Core/Reporting.h"
 #include "GPU/D3D11/TextureCacheD3D11.h"

--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -20,11 +20,11 @@
 #include <D3Dcompiler.h>
 
 #include "Common/Common.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/System/Display.h"
 #include "Common/Math/lin/matrix4x4.h"
 #include "Common/Math/math_util.h"
 #include "Common/GPU/thin3d.h"
-#include "Common/ColorConv.h"
 
 #include "Core/MemMap.h"
 #include "Core/Config.h"

--- a/GPU/D3D11/TextureScalerD3D11.cpp
+++ b/GPU/D3D11/TextureScalerD3D11.cpp
@@ -18,7 +18,7 @@
 #include <algorithm>
 
 #include <d3d11.h>
-#include "Common/ColorConv.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Core/ThreadPools.h"
 #include "GPU/Common/TextureScalerCommon.h"
 #include "GPU/D3D11/TextureScalerD3D11.h"

--- a/GPU/Directx9/FramebufferManagerDX9.cpp
+++ b/GPU/Directx9/FramebufferManagerDX9.cpp
@@ -18,7 +18,7 @@
 #include "Common/Math/lin/matrix4x4.h"
 #include "Common/GPU/thin3d.h"
 
-#include "Common/ColorConv.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Core/MemMap.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"

--- a/GPU/Directx9/TextureScalerDX9.cpp
+++ b/GPU/Directx9/TextureScalerDX9.cpp
@@ -18,7 +18,7 @@
 #include <algorithm>
 
 #include "Common/Common.h"
-#include "Common/ColorConv.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Core/ThreadPools.h"
 #include "GPU/Common/TextureScalerCommon.h"
 #include "GPU/Directx9/TextureScalerDX9.h"

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -17,12 +17,12 @@
 
 #include <algorithm>
 
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/Profiler/Profiler.h"
 #include "Common/GPU/OpenGL/GLCommon.h"
 #include "Common/GPU/OpenGL/GLDebugLog.h"
 #include "Common/GPU/OpenGL/GLSLProgram.h"
 #include "Common/GPU/thin3d.h"
-#include "Common/ColorConv.h"
 #include "Core/MemMap.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -19,12 +19,12 @@
 #include <cstring>
 
 #include "ext/xxhash.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Math/math_util.h"
 #include "Common/Profiler/Profiler.h"
 #include "Common/GPU/OpenGL/GLRenderManager.h"
 
-#include "Common/ColorConv.h"
 #include "Core/Config.h"
 #include "Core/Host.h"
 #include "Core/MemMap.h"

--- a/GPU/GLES/TextureScalerGLES.cpp
+++ b/GPU/GLES/TextureScalerGLES.cpp
@@ -20,7 +20,7 @@
 
 #include "GPU/Common/TextureScalerCommon.h"
 #include "GPU/GLES/TextureScalerGLES.h"
-#include "Common/ColorConv.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/Log.h"
 #include "Core/ThreadPools.h"
 #include "Common/GPU/DataFormat.h"

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -5,7 +5,7 @@
 
 #include "Common/Profiler/Profiler.h"
 
-#include "Common/ColorConv.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/GraphicsContext.h"
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -19,10 +19,10 @@
 #include <algorithm>
 #include <cmath>
 
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/Profiler/Profiler.h"
 
 #include "Core/ThreadPools.h"
-#include "Common/ColorConv.h"
 #include "Core/Config.h"
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -3,17 +3,15 @@
 #include <algorithm>
 #include <cmath>
 
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/Profiler/Profiler.h"
 
-#include "Core/System.h"
-
-#include "Common/ColorConv.h"
 #include "Core/Config.h"
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
+#include "Core/System.h"
 #include "GPU/GPUState.h"
 
-#include "Rasterizer.h"
 #include "GPU/Common/TextureCacheCommon.h"
 #include "GPU/Software/SoftGpu.h"
 #include "GPU/Software/Rasterizer.h"

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -18,7 +18,7 @@
 #include "ppsspp_config.h"
 #include <unordered_map>
 #include <mutex>
-#include "Common/ColorConv.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Core/Reporting.h"
 #include "GPU/Common/TextureDecoder.h"
 #include "GPU/GPUState.h"

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -21,7 +21,7 @@
 #include "GPU/GPUState.h"
 #include "GPU/ge_constants.h"
 #include "GPU/Common/TextureDecoder.h"
-#include "Common/ColorConv.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/GraphicsContext.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"

--- a/GPU/Vulkan/DepalettizeShaderVulkan.cpp
+++ b/GPU/Vulkan/DepalettizeShaderVulkan.cpp
@@ -15,7 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include "Common/ColorConv.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/GPU/Vulkan/VulkanImage.h"
 #include "Common/GPU/Vulkan/VulkanMemory.h"
 #include "Common/GPU/Vulkan/VulkanContext.h"

--- a/GPU/Vulkan/FramebufferManagerVulkan.cpp
+++ b/GPU/Vulkan/FramebufferManagerVulkan.cpp
@@ -21,6 +21,7 @@
 
 #include "Common/System/Display.h"
 #include "Common/Math/lin/matrix4x4.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/Data/Convert/SmallDataConvert.h"
 #include "Common/GPU/thin3d.h"
 
@@ -28,7 +29,6 @@
 #include "Common/GPU/Vulkan/VulkanMemory.h"
 #include "Common/GPU/Vulkan/VulkanImage.h"
 #include "Common/GPU/Vulkan/VulkanRenderManager.h"
-#include "Common/ColorConv.h"
 #include "Core/MemMap.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -26,7 +26,7 @@
 #include "Common/GPU/thin3d.h"
 #include "Common/GPU/Vulkan/VulkanRenderManager.h"
 
-#include "Common/ColorConv.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/StringUtils.h"
 #include "Core/Config.h"
 #include "Core/Host.h"

--- a/GPU/Vulkan/TextureScalerVulkan.cpp
+++ b/GPU/Vulkan/TextureScalerVulkan.cpp
@@ -18,8 +18,8 @@
 #include <algorithm>
 
 #include "Common/Common.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/GPU/Vulkan/VulkanContext.h"
-#include "Common/ColorConv.h"
 #include "Common/Log.h"
 #include "Core/ThreadPools.h"
 #include "GPU/Common/TextureScalerCommon.h"

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -136,7 +136,8 @@ bool RemoteISOConnectScreen::FindServer(std::string &resultHost, int &resultPort
 		}
 
 		SetStatus("Loading game list from [URL]...", host, port);
-		code = http.GET(subdir.c_str(), &result);
+		http::RequestProgress progress(&scanCancelled);
+		code = http.GET(subdir.c_str(), &result, &progress);
 		http.Disconnect();
 
 		if (code != 200) {
@@ -189,7 +190,8 @@ bool RemoteISOConnectScreen::FindServer(std::string &resultHost, int &resultPort
 	SetStatus("Looking for peers...", "", 0);
 	if (http.Resolve(REPORT_HOSTNAME, REPORT_PORT)) {
 		if (http.Connect(2, 20.0, &scanCancelled)) {
-			code = http.GET("/match/list", &result);
+			http::RequestProgress progress(&scanCancelled);
+			code = http.GET("/match/list", &result, &progress);
 			http.Disconnect();
 		}
 	}

--- a/UWP/CommonUWP/CommonUWP.vcxproj
+++ b/UWP/CommonUWP/CommonUWP.vcxproj
@@ -386,6 +386,7 @@
     <ClInclude Include="..\..\Common\BitScan.h" />
     <ClInclude Include="..\..\Common\BitSet.h" />
     <ClInclude Include="..\..\Common\Buffer.h" />
+    <ClInclude Include="..\..\Common\Net\NetBuffer.h" />
     <ClInclude Include="..\..\Common\Data\Collections\ConstMap.h" />
     <ClInclude Include="..\..\Common\Data\Collections\FixedSizeQueue.h" />
     <ClInclude Include="..\..\Common\Data\Collections\Hashmaps.h" />
@@ -513,6 +514,7 @@
     <ClCompile Include="..\..\Common\ArmCPUDetect.cpp" />
     <ClCompile Include="..\..\Common\ArmEmitter.cpp" />
     <ClCompile Include="..\..\Common\Buffer.cpp" />
+    <ClCompile Include="..\..\Common\Net\NetBuffer.cpp" />
     <ClCompile Include="..\..\Common\Data\Color\RGBAUtil.cpp" />
     <ClCompile Include="..\..\Common\Data\Convert\SmallDataConvert.cpp" />
     <ClCompile Include="..\..\Common\Data\Encoding\Base64.cpp" />

--- a/UWP/CommonUWP/CommonUWP.vcxproj
+++ b/UWP/CommonUWP/CommonUWP.vcxproj
@@ -457,8 +457,8 @@
     <ClInclude Include="..\..\Common\Serialize\SerializeMap.h" />
     <ClInclude Include="..\..\Common\Serialize\SerializeSet.h" />
     <ClInclude Include="..\..\Common\CodeBlock.h" />
-    <ClInclude Include="..\..\Common\ColorConv.h" />
-    <ClInclude Include="..\..\Common\ColorConvNEON.h" />
+    <ClInclude Include="..\..\Common\Data\Convert\ColorConv.h" />
+    <ClInclude Include="..\..\Common\Data\Convert\ColorConvNEON.h" />
     <ClInclude Include="..\..\Common\Common.h" />
     <ClInclude Include="..\..\Common\CommonFuncs.h" />
     <ClInclude Include="..\..\Common\CommonTypes.h" />
@@ -568,8 +568,8 @@
     <ClCompile Include="..\..\Common\Render\Text\draw_text_uwp.cpp" />
     <ClCompile Include="..\..\Common\Render\Text\draw_text_win.cpp" />
     <ClCompile Include="..\..\Common\Serialize\Serializer.cpp" />
-    <ClCompile Include="..\..\Common\ColorConv.cpp" />
-    <ClCompile Include="..\..\Common\ColorConvNEON.cpp" />
+    <ClCompile Include="..\..\Common\Data\Convert\ColorConv.cpp" />
+    <ClCompile Include="..\..\Common\Data\Convert\ColorConvNEON.cpp" />
     <ClCompile Include="..\..\Common\ConsoleListener.cpp" />
     <ClCompile Include="..\..\Common\CPUDetect.cpp" />
     <ClCompile Include="..\..\Common\FakeCPUDetect.cpp" />

--- a/UWP/CommonUWP/CommonUWP.vcxproj.filters
+++ b/UWP/CommonUWP/CommonUWP.vcxproj.filters
@@ -92,8 +92,8 @@
     <ClCompile Include="..\..\Common\ArmCPUDetect.cpp" />
     <ClCompile Include="..\..\Common\ArmEmitter.cpp" />
     <ClCompile Include="..\..\Common\Serialize\Serializer.cpp" />
-    <ClCompile Include="..\..\Common\ColorConv.cpp" />
-    <ClCompile Include="..\..\Common\ColorConvNEON.cpp" />
+    <ClCompile Include="..\..\Common\Data\Convert\ColorConv.cpp" />
+    <ClCompile Include="..\..\Common\Data\Convert\ColorConvNEON.cpp" />
     <ClCompile Include="..\..\Common\ConsoleListener.cpp" />
     <ClCompile Include="..\..\Common\CPUDetect.cpp" />
     <ClCompile Include="..\..\Common\FakeCPUDetect.cpp" />
@@ -381,8 +381,8 @@
     <ClInclude Include="..\..\Common\BitScan.h" />
     <ClInclude Include="..\..\Common\Serialize\Serializer.h" />
     <ClInclude Include="..\..\Common\CodeBlock.h" />
-    <ClInclude Include="..\..\Common\ColorConv.h" />
-    <ClInclude Include="..\..\Common\ColorConvNEON.h" />
+    <ClInclude Include="..\..\Common\Data\Convert\ColorConv.h" />
+    <ClInclude Include="..\..\Common\Data\Convert\ColorConvNEON.h" />
     <ClInclude Include="..\..\Common\Common.h" />
     <ClInclude Include="..\..\Common\CommonFuncs.h" />
     <ClInclude Include="..\..\Common\CommonTypes.h" />

--- a/UWP/CommonUWP/CommonUWP.vcxproj.filters
+++ b/UWP/CommonUWP/CommonUWP.vcxproj.filters
@@ -124,6 +124,7 @@
       <Filter>Crypto</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Common\Buffer.cpp" />
+    <ClCompile Include="..\..\Common\Net\NetBuffer.cpp" />
     <ClCompile Include="..\..\ext\libpng17\png.c">
       <Filter>ext\libpng17</Filter>
     </ClCompile>
@@ -415,6 +416,7 @@
       <Filter>Crypto</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Common\Buffer.h" />
+    <ClInclude Include="..\..\Common\Net\NetBuffer.h" />
     <ClInclude Include="..\..\Common\Serialize\SerializeDeque.h" />
     <ClInclude Include="..\..\Common\Serialize\SerializeFuncs.h" />
     <ClInclude Include="..\..\Common\Serialize\SerializeList.h" />

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -21,9 +21,9 @@
 #include <string>
 #include <vector>
 
-#include "Common/Data/Text/Parsers.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/Data/Encoding/Utf8.h"
-#include "Common/ColorConv.h"
+#include "Common/Data/Text/Parsers.h"
 #include "Common/StringUtils.h"
 #include "Core/Config.h"
 #include "Core/Screenshot.h"

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -60,7 +60,7 @@ ARCH_FILES := \
   $(SRC)/GPU/Common/TextureDecoderNEON.cpp.neon \
   $(SRC)/Core/Util/AudioFormatNEON.cpp.neon \
   $(SRC)/Common/ArmEmitter.cpp \
-  $(SRC)/Common/ColorConvNEON.cpp.neon \
+  $(SRC)/Common/Data/Convert/ColorConvNEON.cpp.neon \
   $(SRC)/Common/Math/fast/fast_matrix_neon.S.neon \
   $(SRC)/Core/MIPS/ARM/ArmCompALU.cpp \
   $(SRC)/Core/MIPS/ARM/ArmCompBranch.cpp \
@@ -87,7 +87,7 @@ ARCH_FILES := \
   $(SRC)/GPU/Common/TextureDecoderNEON.cpp \
   $(SRC)/Core/Util/AudioFormatNEON.cpp \
   $(SRC)/Common/Arm64Emitter.cpp \
-  $(SRC)/Common/ColorConvNEON.cpp \
+  $(SRC)/Common/Data/Convert/ColorConvNEON.cpp \
   $(SRC)/Core/MIPS/ARM64/Arm64CompALU.cpp \
   $(SRC)/Core/MIPS/ARM64/Arm64CompBranch.cpp \
   $(SRC)/Core/MIPS/ARM64/Arm64CompFPU.cpp \
@@ -228,6 +228,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Common/Crypto/sha1.cpp \
   $(SRC)/Common/Crypto/sha256.cpp \
   $(SRC)/Common/Data/Color/RGBAUtil.cpp \
+  $(SRC)/Common/Data/Convert/ColorConv.cpp \
   $(SRC)/Common/Data/Convert/SmallDataConvert.cpp \
   $(SRC)/Common/Data/Encoding/Base64.cpp \
   $(SRC)/Common/Data/Encoding/Compression.cpp \
@@ -292,7 +293,6 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Common/UI/ViewGroup.cpp \
   $(SRC)/Common/Serialize/Serializer.cpp \
   $(SRC)/Common/ArmCPUDetect.cpp \
-  $(SRC)/Common/ColorConv.cpp \
   $(SRC)/Common/CPUDetect.cpp \
   $(SRC)/Common/ExceptionHandlerSetup.cpp \
   $(SRC)/Common/FakeCPUDetect.cpp \

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -274,6 +274,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Common/Net/HTTPClient.cpp \
   $(SRC)/Common/Net/HTTPHeaders.cpp \
   $(SRC)/Common/Net/HTTPServer.cpp \
+  $(SRC)/Common/Net/NetBuffer.cpp \
   $(SRC)/Common/Net/Resolve.cpp \
   $(SRC)/Common/Net/Sinks.cpp \
   $(SRC)/Common/Net/URL.cpp \

--- a/headless/Compare.cpp
+++ b/headless/Compare.cpp
@@ -23,7 +23,7 @@
 #include <vector>
 #include "headless/Compare.h"
 
-#include "Common/ColorConv.h"
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/Data/Format/PNGLoad.h"
 #include "Common/File/FileUtil.h"
 #include "Common/StringUtils.h"

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -197,6 +197,7 @@ SOURCES_CXX += \
 	$(COMMONDIR)/Net/HTTPClient.cpp \
 	$(COMMONDIR)/Net/HTTPHeaders.cpp \
 	$(COMMONDIR)/Net/HTTPServer.cpp \
+	$(COMMONDIR)/Net/NetBuffer.cpp \
 	$(COMMONDIR)/Net/Resolve.cpp \
 	$(COMMONDIR)/Net/Sinks.cpp \
 	$(COMMONDIR)/Net/URL.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -251,7 +251,7 @@ SOURCES_CXX += \
 	$(GPUCOMMONDIR)/IndexGenerator.cpp \
 	$(GPUCOMMONDIR)/TextureDecoder.cpp \
 	$(GPUCOMMONDIR)/PostShader.cpp \
-	$(COMMONDIR)/ColorConv.cpp \
+	$(COMMONDIR)/Data/Convert/ColorConv.cpp \
 	$(GPUDIR)/Debugger/Breakpoints.cpp \
 	$(GPUDIR)/Debugger/Debugger.cpp \
 	$(GPUDIR)/Debugger/Playback.cpp \
@@ -543,7 +543,7 @@ ifeq ($(WITH_DYNAREC),1)
 					 $(COREDIR)/MIPS/ARM/ArmCompVFPUNEON.cpp \
 					 $(COREDIR)/MIPS/ARM/ArmCompVFPUNEONUtil.cpp \
 					 $(COREDIR)/Util/AudioFormatNEON.cpp \
-					 $(COMMONDIR)/ColorConvNEON.cpp \
+					 $(COMMONDIR)/Data/Convert/ColorConvNEON.cpp \
 					 $(GPUDIR)/Common/TextureDecoderNEON.cpp
 
 			SOURCES_C += $(EXTDIR)/libpng17/arm/arm_init.c \
@@ -572,7 +572,7 @@ ifeq ($(WITH_DYNAREC),1)
 					 $(COREDIR)/MIPS/ARM/ArmCompVFPUNEON.cpp \
 					 $(COREDIR)/MIPS/ARM/ArmCompVFPUNEONUtil.cpp \
 					 $(COREDIR)/Util/AudioFormatNEON.cpp \
-					 $(COMMONDIR)/ColorConvNEON.cpp \
+					 $(COMMONDIR)/Data/Convert/ColorConvNEON.cpp \
 					 $(GPUDIR)/Common/TextureDecoderNEON.cpp
 
 			SOURCES_C += $(EXTDIR)/libpng17/arm/arm_init.c \


### PR DESCRIPTION
This does some miscellaneous cleanup in Common:

 * Moves ColorConv into the otherwise lonesome Data/Convert path (there's also Data/Color but I guess it could be either one...)
 * Moves some RGBA conversion into ColorConv from Draw.
 * Separates out the network parts of Buffer, do StringUtil isn't pulling them in.
 * Makes cancel/progress/timeout handling in all HTTP requests more consistent.
 * Switches all HTTP requests to non-blocking (which seemed to improve download speed, not unexpectedly... somehow I thought I'd already done this.)
 * Shows a KB/s speed in Store when selecting the game you're downloading.
 * Allows canceling a game download even after viewing another game or resizing your window.

Most of these changes (outside the store UI) aren't very user visible, but it may make some cancellations more responsive.

-[Unknown]