### PR TITLE
Introduce Path, start using it all over the place.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,6 +501,8 @@ add_library(Common STATIC
 	Common/File/VFS/AssetReader.h
 	Common/File/DiskFree.h
 	Common/File/DiskFree.cpp
+	Common/File/Path.h
+	Common/File/Path.cpp
 	Common/File/PathBrowser.h
 	Common/File/PathBrowser.cpp
 	Common/File/FileUtil.cpp

--- a/Common/ArmCPUDetect.cpp
+++ b/Common/ArmCPUDetect.cpp
@@ -75,7 +75,7 @@ const char syscpupresentfile[] = "/sys/devices/system/cpu/present";
 
 std::string GetCPUString() {
 	std::string procdata;
-	bool readSuccess = File::ReadFileToString(true, procfile, procdata);
+	bool readSuccess = File::ReadFileToString(true, Path(procfile), procdata);
 	std::istringstream file(procdata);
 	std::string cpu_string;
 
@@ -98,7 +98,7 @@ std::string GetCPUString() {
 
 std::string GetCPUBrandString() {
 	std::string procdata;
-	bool readSuccess = File::ReadFileToString(true, procfile, procdata);
+	bool readSuccess = File::ReadFileToString(true, Path(procfile), procdata);
 	std::istringstream file(procdata);
 	std::string brand_string;
 
@@ -128,7 +128,7 @@ unsigned char GetCPUImplementer()
 	unsigned char implementer = 0;
 
 	std::string procdata;
-	if (!File::ReadFileToString(true, procfile, procdata))
+	if (!File::ReadFileToString(true, Path(procfile), procdata))
 		return 0;
 	std::istringstream file(procdata);
 
@@ -151,7 +151,7 @@ unsigned short GetCPUPart()
 	unsigned short part = 0;
 
 	std::string procdata;
-	if (!File::ReadFileToString(true, procfile, procdata))
+	if (!File::ReadFileToString(true, Path(procfile), procdata))
 		return 0;
 	std::istringstream file(procdata);
 
@@ -173,7 +173,7 @@ bool CheckCPUFeature(const std::string& feature)
 	std::string line, marker = "Features\t: ";
 
 	std::string procdata;
-	if (!File::ReadFileToString(true, procfile, procdata))
+	if (!File::ReadFileToString(true, Path(procfile), procdata))
 		return false;
 	std::istringstream file(procdata);
 	while (std::getline(file, line))
@@ -199,7 +199,7 @@ int GetCoreCount()
 	int cores = 1;
 
 	std::string presentData;
-	bool presentSuccess = File::ReadFileToString(true, syscpupresentfile, presentData);
+	bool presentSuccess = File::ReadFileToString(true, Path(syscpupresentfile), presentData);
 	std::istringstream presentFile(presentData);
 
 	if (presentSuccess) {
@@ -213,7 +213,7 @@ int GetCoreCount()
 	}
 
 	std::string procdata;
-	if (!File::ReadFileToString(true, procfile, procdata))
+	if (!File::ReadFileToString(true, Path(procfile), procdata))
 		return 1;
 	std::istringstream file(procdata);
 	

--- a/Common/ArmCPUDetect.cpp
+++ b/Common/ArmCPUDetect.cpp
@@ -176,7 +176,6 @@ bool CheckCPUFeature(const std::string& feature)
 	if (!File::ReadFileToString(true, procfile, procdata))
 		return false;
 	std::istringstream file(procdata);
-
 	while (std::getline(file, line))
 	{
 		if (line.find(marker) != std::string::npos)

--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -120,7 +120,7 @@ static std::vector<int> ParseCPUList(const std::string &filename) {
 	std::string data;
 	std::vector<int> results;
 
-	if (File::ReadFileToString(true, filename.c_str(), data)) {
+	if (File::ReadFileToString(true, Path(filename), data)) {
 		std::vector<std::string> ranges;
 		SplitString(data, ',', ranges);
 		for (auto range : ranges) {
@@ -372,7 +372,7 @@ void CPUInfo::Detect() {
 	// This seems to be the count per core.  Hopefully all cores are the same, but we counted each above.
 	logical_cpu_count /= std::max(num_cores, 1);
 #elif PPSSPP_PLATFORM(LINUX)
-	if (File::Exists("/sys/devices/system/cpu/present")) {
+	if (File::Exists(Path("/sys/devices/system/cpu/present"))) {
 		// This may not count unplugged cores, but at least it's a best guess.
 		// Also, this assumes the CPU cores are heterogeneous (e.g. all cores could be active simultaneously.)
 		num_cores = 0;

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -413,6 +413,7 @@
     <ClInclude Include="File\DiskFree.h" />
     <ClInclude Include="File\FileDescriptor.h" />
     <ClInclude Include="File\FileUtil.h" />
+    <ClInclude Include="File\Path.h" />
     <ClInclude Include="File\PathBrowser.h" />
     <ClInclude Include="File\VFS\VFS.h" />
     <ClInclude Include="File\VFS\AssetReader.h" />
@@ -736,6 +737,7 @@
     <ClCompile Include="File\DiskFree.cpp" />
     <ClCompile Include="File\FileDescriptor.cpp" />
     <ClCompile Include="File\FileUtil.cpp" />
+    <ClCompile Include="File\Path.cpp" />
     <ClCompile Include="File\PathBrowser.cpp" />
     <ClCompile Include="File\VFS\VFS.cpp" />
     <ClCompile Include="File\VFS\AssetReader.cpp" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -391,6 +391,9 @@
     <ClInclude Include="Net\NetBuffer.h">
       <Filter>Net</Filter>
     </ClInclude>
+    <ClInclude Include="File\Path.h">
+      <Filter>File</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />
@@ -753,6 +756,9 @@
     <ClCompile Include="Buffer.cpp" />
     <ClCompile Include="Net\NetBuffer.cpp">
       <Filter>Net</Filter>
+    </ClCompile>
+    <ClCompile Include="File\Path.cpp">
+      <Filter>File</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Common/Data/Format/IniFile.cpp
+++ b/Common/Data/Format/IniFile.cpp
@@ -598,7 +598,7 @@ bool IniFile::Load(std::istream &in) {
 
 bool IniFile::Save(const char* filename)
 {
-	FILE *file = File::OpenCFile(filename, "w");
+	FILE *file = File::OpenCFile(Path(filename), "w");
 	if (!file) {
 		return false;
 	}

--- a/Common/Data/Format/IniFile.cpp
+++ b/Common/Data/Format/IniFile.cpp
@@ -524,7 +524,7 @@ bool IniFile::Load(const Path &path)
 
 	// Open file
 	std::string data;
-	if (!File::ReadFileToString(true, path.ToString().c_str(), data)) {
+	if (!File::ReadFileToString(true, path, data)) {
 		return false;
 	}
 	std::stringstream sstream(data);

--- a/Common/Data/Format/IniFile.cpp
+++ b/Common/Data/Format/IniFile.cpp
@@ -516,23 +516,19 @@ void IniFile::SortSections()
 	std::sort(sections.begin(), sections.end());
 }
 
-bool IniFile::Load(const char* filename)
+bool IniFile::Load(const Path &path)
 {
 	sections.clear();
 	sections.push_back(Section(""));
 	// first section consists of the comments before the first real section
 
 	// Open file
-	std::ifstream in;
-#if defined(_WIN32) && !defined(__MINGW32__)
-	in.open(ConvertUTF8ToWString(filename), std::ios::in);
-#else
-	in.open(filename, std::ios::in);
-#endif
-	if (in.fail()) return false;
-
-	bool success = Load(in);
-	in.close();
+	std::string data;
+	if (!File::ReadFileToString(true, path.ToString().c_str(), data)) {
+		return false;
+	}
+	std::stringstream sstream(data);
+	bool success = Load(sstream);
 	return success;
 }
 
@@ -559,13 +555,13 @@ bool IniFile::Load(std::istream &in) {
 		std::string line = templine;
 
 		// Remove UTF-8 byte order marks.
-		if (line.substr(0, 3) == "\xEF\xBB\xBF")
+		if (line.substr(0, 3) == "\xEF\xBB\xBF") {
 			line = line.substr(3);
+		}
 		 
 #ifndef _WIN32
 		// Check for CRLF eol and convert it to LF
-		if (!line.empty() && line.at(line.size()-1) == '\r')
-		{
+		if (!line.empty() && line.at(line.size()-1) == '\r') {
 			line.erase(line.size()-1);
 		}
 #endif
@@ -596,7 +592,7 @@ bool IniFile::Load(std::istream &in) {
 	return true;
 }
 
-bool IniFile::Save(const char* filename)
+bool IniFile::Save(const Path &filename)
 {
 	FILE *file = File::OpenCFile(Path(filename), "w");
 	if (!file) {

--- a/Common/Data/Format/IniFile.cpp
+++ b/Common/Data/Format/IniFile.cpp
@@ -594,7 +594,7 @@ bool IniFile::Load(std::istream &in) {
 
 bool IniFile::Save(const Path &filename)
 {
-	FILE *file = File::OpenCFile(Path(filename), "w");
+	FILE *file = File::OpenCFile(filename, "w");
 	if (!file) {
 		return false;
 	}

--- a/Common/Data/Format/IniFile.h
+++ b/Common/Data/Format/IniFile.h
@@ -9,8 +9,9 @@
 #include <string>
 #include <vector>
 
-class Section
-{
+#include "Common/File/Path.h"
+
+class Section {
 	friend class IniFile;
 
 public:
@@ -78,13 +79,15 @@ protected:
 
 class IniFile
 {
+	bool Load(const char *filename);
+	bool Save(const char *filename);
 public:
-	bool Load(const char* filename);
+	bool Load(const Path &path) { return Load(path.c_str()); } // TODO(scoped)
 	bool Load(const std::string &filename) { return Load(filename.c_str()); }
 	bool Load(std::istream &istream);
 	bool LoadFromVFS(const std::string &filename);
 
-	bool Save(const char* filename);
+	bool Save(const Path &path) { return Save(path.c_str()); } // TODO(scoped)
 	bool Save(const std::string &filename) { return Save(filename.c_str()); }
 
 	// Returns true if key exists in section

--- a/Common/Data/Format/IniFile.h
+++ b/Common/Data/Format/IniFile.h
@@ -77,18 +77,15 @@ protected:
 	std::string comment;
 };
 
-class IniFile
-{
-	bool Load(const char *filename);
-	bool Save(const char *filename);
+class IniFile {
 public:
-	bool Load(const Path &path) { return Load(path.c_str()); } // TODO(scoped)
-	bool Load(const std::string &filename) { return Load(filename.c_str()); }
+	bool Load(const Path &path);
+	bool Load(const std::string &filename) { return Load(Path(filename)); }
 	bool Load(std::istream &istream);
 	bool LoadFromVFS(const std::string &filename);
 
-	bool Save(const Path &path) { return Save(path.c_str()); } // TODO(scoped)
-	bool Save(const std::string &filename) { return Save(filename.c_str()); }
+	bool Save(const Path &path);
+	bool Save(const std::string &filename) { return Save(Path(filename)); }
 
 	// Returns true if key exists in section
 	bool Exists(const char* sectionName, const char* key) const;

--- a/Common/Data/Text/I18n.cpp
+++ b/Common/Data/Text/I18n.cpp
@@ -80,18 +80,18 @@ bool I18NRepo::IniExists(const std::string &languageID) const {
 	return true;
 }
 
-bool I18NRepo::LoadIni(const std::string &languageID, const std::string &overridePath) {
+bool I18NRepo::LoadIni(const std::string &languageID, const Path &overridePath) {
 	IniFile ini;
-	std::string iniPath;
+	Path iniPath;
 
 //	INFO_LOG(SYSTEM, "Loading lang ini %s", iniPath.c_str());
 	if (!overridePath.empty()) {
-		iniPath = overridePath + languageID + ".ini";
+		iniPath = overridePath / (languageID + ".ini");
 	} else {
-		iniPath = GetIniPath(languageID);
+		iniPath = Path(GetIniPath(languageID));
 	}
 
-	if (!ini.LoadFromVFS(iniPath))
+	if (!ini.LoadFromVFS(iniPath.ToString()))
 		return false;
 
 	Clear();

--- a/Common/Data/Text/I18n.h
+++ b/Common/Data/Text/I18n.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "Common/Common.h"
+#include "Common/File/Path.h"
 
 // Reasonably thread safe.
 
@@ -76,7 +77,7 @@ public:
 	~I18NRepo();
 
 	bool IniExists(const std::string &languageID) const;
-	bool LoadIni(const std::string &languageID, const std::string &overridePath = ""); // NOT the filename!
+	bool LoadIni(const std::string &languageID, const Path &overridePath = Path()); // NOT the filename!
 	void SaveIni(const std::string &languageID);
 
 	std::string LanguageID();

--- a/Common/File/DirListing.cpp
+++ b/Common/File/DirListing.cpp
@@ -45,7 +45,7 @@ bool GetFileInfo(const Path &path, FileInfo * fileInfo) {
 	}
 
 	// TODO: Expand relative paths?
-	fileInfo->fullName = path.ToString();
+	fileInfo->fullName = path;
 
 #ifdef _WIN32
 	auto FiletimeToStatTime = [](FILETIME ft) {
@@ -191,15 +191,7 @@ size_t GetFilesInDir(const Path &directory, std::vector<FileInfo> * files, const
 		FileInfo info;
 		info.name = virtualName;
 
-		// It's OK not to use Path /-concat here.
-		std::string dir = directory.ToString();
-
-		// Only append a slash if there isn't one on the end.
-		size_t lastSlash = dir.find_last_of("/");
-		if (lastSlash != (dir.length() - 1))
-			dir.append("/");
-
-		info.fullName = dir + virtualName;
+		info.fullName = directory / virtualName;
 		info.isDirectory = IsDirectory(Path(info.fullName));
 		info.exists = true;
 		info.size = 0;

--- a/Common/File/DirListing.cpp
+++ b/Common/File/DirListing.cpp
@@ -192,7 +192,7 @@ size_t GetFilesInDir(const Path &directory, std::vector<FileInfo> * files, const
 		info.name = virtualName;
 
 		info.fullName = directory / virtualName;
-		info.isDirectory = IsDirectory(Path(info.fullName));
+		info.isDirectory = IsDirectory(info.fullName);
 		info.exists = true;
 		info.size = 0;
 		info.isWritable = false;  // TODO - implement some kind of check
@@ -228,11 +228,11 @@ int64_t GetDirectoryRecursiveSize(const Path &path, const char *filter, int flag
 	// Note: GetFilesInDir does not fill in fileSize.
 	for (size_t i = 0; i < fileInfo.size(); i++) {
 		FileInfo finfo;
-		GetFileInfo(Path(fileInfo[i].fullName), &finfo);
+		GetFileInfo(fileInfo[i].fullName, &finfo);
 		if (!finfo.isDirectory)
 			sizeSum += finfo.size;
 		else
-			sizeSum += GetDirectoryRecursiveSize(Path(finfo.fullName), filter, flags);
+			sizeSum += GetDirectoryRecursiveSize(finfo.fullName, filter, flags);
 	}
 	return sizeSum;
 }

--- a/Common/File/DirListing.h
+++ b/Common/File/DirListing.h
@@ -7,17 +7,17 @@
 
 #include <inttypes.h>
 
-// Beginnings of a directory utility system. TODO: Improve.
+#include "Common/File/Path.h"
 
 namespace File {
 
 struct FileInfo {
 	std::string name;
-	std::string fullName;
-	bool exists;
-	bool isDirectory;
-	bool isWritable;
-	uint64_t size;
+	std::string fullName;  // TODO: Make into Path
+	bool exists = false;
+	bool isDirectory = false;
+	bool isWritable = false;
+	uint64_t size = 0;
 
 	uint64_t atime;
 	uint64_t mtime;
@@ -27,16 +27,18 @@ struct FileInfo {
 	bool operator <(const FileInfo &other) const;
 };
 
-bool GetFileInfo(const char *path, FileInfo *fileInfo);
+bool GetFileInfo(const Path &path, FileInfo *fileInfo);
 
 enum {
 	GETFILES_GETHIDDEN = 1
 };
-size_t GetFilesInDir(const char *directory, std::vector<FileInfo> *files, const char *filter = nullptr, int flags = 0);
-int64_t GetDirectoryRecursiveSize(const std::string &path, const char *filter = nullptr, int flags = 0);
+
+
+size_t GetFilesInDir(const Path &directory, std::vector<FileInfo> *files, const char *filter = nullptr, int flags = 0);
+int64_t GetDirectoryRecursiveSize(const Path &path, const char *filter = nullptr, int flags = 0);
 
 #ifdef _WIN32
 std::vector<std::string> GetWindowsDrives();
 #endif
 
-}
+}  // namespace File

--- a/Common/File/DirListing.h
+++ b/Common/File/DirListing.h
@@ -13,7 +13,7 @@ namespace File {
 
 struct FileInfo {
 	std::string name;
-	std::string fullName;  // TODO: Make into Path
+	Path fullName;
 	bool exists = false;
 	bool isDirectory = false;
 	bool isWritable = false;

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -715,7 +715,7 @@ bool DeleteDirRecursively(const Path &directory) {
 			continue;
 
 		Path newPath = directory / virtualName;
-		if (IsDirectory(Path(newPath))) {
+		if (IsDirectory(newPath)) {
 			if (!DeleteDirRecursively(newPath)) {
 #ifndef _WIN32
 				closedir(dirp);
@@ -726,7 +726,7 @@ bool DeleteDirRecursively(const Path &directory) {
 			}
 		}
 		else {
-			if (!File::Delete(Path(newPath))) {
+			if (!File::Delete(newPath)) {
 #ifndef _WIN32
 				closedir(dirp);
 #else
@@ -743,7 +743,7 @@ bool DeleteDirRecursively(const Path &directory) {
 	}
 	closedir(dirp);
 #endif
-	return File::DeleteDir(Path(directory));
+	return File::DeleteDir(directory);
 }
 
 void OpenFileInEditor(const Path &fileName) {

--- a/Common/File/FileUtil.h
+++ b/Common/File/FileUtil.h
@@ -25,6 +25,7 @@
 #include <cstdint>
 
 #include "Common/Common.h"
+#include "Common/File/Path.h"
 
 #ifdef _MSC_VER
 inline struct tm* localtime_r(const time_t *clock, struct tm *result) {
@@ -37,16 +38,21 @@ inline struct tm* localtime_r(const time_t *clock, struct tm *result) {
 namespace File {
 
 // Mostly to handle UTF-8 filenames better on Windows.
-FILE *OpenCFile(const std::string &filename, const char *mode);
+FILE *OpenCFile(const Path &filename, const char *mode);
 
 // Resolves symlinks and similar.
 std::string ResolvePath(const std::string &path);
 
 // Returns true if file filename exists
-bool Exists(const std::string &filename);
+bool Exists(const std::string &path);
+bool Exists(const Path &path);
 
-// Returns true if filename is a directory
-bool IsDirectory(const std::string &filename);
+// Returns true if file filename exists in directory path.
+bool ExistsInDir(const Path &path, const std::string &filename);
+
+// Returns true if filename exists, and is a directory
+// Supports Android content URIs.
+bool IsDirectory(const Path &filename);
 
 // Parses the extension out from a filename.
 std::string GetFileExtension(const std::string &filename);
@@ -58,7 +64,7 @@ std::string GetDir(const std::string &path);
 std::string GetFilename(std::string path);
 
 // Returns struct with modification date of file
-bool GetModifTime(const std::string &filename, tm &return_time);
+bool GetModifTime(const Path &filename, tm &return_time);
 
 // Returns the size of filename (64bit)
 uint64_t GetFileSize(const std::string &filename);
@@ -67,14 +73,14 @@ uint64_t GetFileSize(const std::string &filename);
 uint64_t GetFileSize(FILE *f);
 
 // Returns true if successful, or path already exists.
-bool CreateDir(const std::string &filename);
+bool CreateDir(const Path &filename);
 
 // Creates the full path of fullPath returns true on success
-bool CreateFullPath(const std::string &fullPath);
+bool CreateFullPath(const Path &fullPath);
 
 // Deletes a given filename, return true on success
 // Doesn't supports deleting a directory
-bool Delete(const std::string &filename);
+bool Delete(const Path &filename);
 
 // Deletes a directory filename, returns true on success
 // Directory must be empty.
@@ -87,7 +93,7 @@ bool Rename(const std::string &srcFilename, const std::string &destFilename);
 bool Copy(const std::string &srcFilename, const std::string &destFilename);
 
 // creates an empty file filename, returns true on success 
-bool CreateEmptyFile(const std::string &filename);
+bool CreateEmptyFile(const Path &filename);
 
 // deletes the given directory and anything under it. Returns true on success.
 bool DeleteDirRecursively(const std::string &directory);
@@ -99,7 +105,6 @@ void OpenFileInEditor(const std::string& fileName);
 // TODO: Belongs in System or something.
 const std::string &GetExeDirectory();
 
-
 // simple wrapper for cstdlib file functions to
 // hopefully will make error checking easier
 // and make forgetting an fclose() harder
@@ -108,6 +113,7 @@ public:
 	IOFile();
 	IOFile(FILE* file);
 	IOFile(const std::string& filename, const char openmode[]);
+	IOFile(const Path &filename, const char openmode[]);
 	~IOFile();
 
 	// Prevent copies.
@@ -115,6 +121,7 @@ public:
 	void operator=(const IOFile &) = delete;
 
 	bool Open(const std::string& filename, const char openmode[]);
+	bool Open(const Path &filename, const char openmode[]);
 	bool Close();
 
 	template <typename T>

--- a/Common/File/FileUtil.h
+++ b/Common/File/FileUtil.h
@@ -84,7 +84,10 @@ bool Delete(const Path &filename);
 
 // Deletes a directory filename, returns true on success
 // Directory must be empty.
-bool DeleteDir(const std::string &filename);
+bool DeleteDir(const Path &filename);
+
+// Deletes the given directory and anything under it. Returns true on success.
+bool DeleteDirRecursively(const Path &directory);
 
 // renames file srcFilename to destFilename, returns true on success 
 bool Rename(const std::string &srcFilename, const std::string &destFilename);
@@ -95,12 +98,9 @@ bool Copy(const std::string &srcFilename, const std::string &destFilename);
 // creates an empty file filename, returns true on success 
 bool CreateEmptyFile(const Path &filename);
 
-// deletes the given directory and anything under it. Returns true on success.
-bool DeleteDirRecursively(const std::string &directory);
-
 // Opens ini file (cheats, texture replacements etc.)
 // TODO: Belongs in System or something.
-void OpenFileInEditor(const std::string& fileName);
+void OpenFileInEditor(const Path &fileName);
 
 // TODO: Belongs in System or something.
 const std::string &GetExeDirectory();
@@ -185,10 +185,10 @@ private:
 // TODO: Refactor, this was moved from the old file_util.cpp.
 
 // Whole-file reading/writing
-bool WriteStringToFile(bool text_file, const std::string &str, const char *filename);
-bool WriteDataToFile(bool text_file, const void* data, const unsigned int size, const char *filename);
+bool WriteStringToFile(bool text_file, const std::string &str, const Path &filename);
+bool WriteDataToFile(bool text_file, const void* data, const unsigned int size, const Path &filename);
 
-bool ReadFileToString(bool text_file, const char *filename, std::string &str);
+bool ReadFileToString(bool text_file, const Path &filename, std::string &str);
 // Return value must be delete[]-d.
 uint8_t *ReadLocalFile(const char *filename, size_t *size);
 

--- a/Common/File/FileUtil.h
+++ b/Common/File/FileUtil.h
@@ -44,7 +44,6 @@ FILE *OpenCFile(const Path &filename, const char *mode);
 std::string ResolvePath(const std::string &path);
 
 // Returns true if file filename exists
-bool Exists(const std::string &path);
 bool Exists(const Path &path);
 
 // Returns true if file filename exists in directory path.
@@ -89,11 +88,18 @@ bool DeleteDir(const Path &filename);
 // Deletes the given directory and anything under it. Returns true on success.
 bool DeleteDirRecursively(const Path &directory);
 
-// renames file srcFilename to destFilename, returns true on success 
-bool Rename(const std::string &srcFilename, const std::string &destFilename);
+// Renames file srcFilename to destFilename, returns true on success 
+// Will usually only work with in the same partition or other unit of storage,
+// so you might have to fall back to copy/delete.
+bool Rename(const Path &srcFilename, const Path &destFilename);
 
 // copies file srcFilename to destFilename, returns true on success 
-bool Copy(const std::string &srcFilename, const std::string &destFilename);
+bool Copy(const Path &srcFilename, const Path &destFilename);
+
+// Tries to rename srcFilename to destFilename, if that fails,
+// it tries to copy and delete the src if succeeded. If that fails too,
+// returns false, otherwise returns true.
+bool Move(const Path &srcFilename, const Path &destFilename);
 
 // creates an empty file filename, returns true on success 
 bool CreateEmptyFile(const Path &filename);

--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -34,7 +34,8 @@ void Path::Init(const std::string &str) {
 	}
 #endif
 
-	if (type_ == PathType::NATIVE && !path_.empty() && path_.back() == '/') {
+	// Don't pop_back if it's just "/".
+	if (type_ == PathType::NATIVE && path_.size() > 1 && path_.back() == '/') {
 		path_.pop_back();
 	}
 }
@@ -92,7 +93,6 @@ std::string Path::GetFilename() const {
 	if (pos != std::string::npos) {
 		return path_.substr(pos + 1);
 	}
-	// No directory components, just return the full path.
 	return path_;
 }
 
@@ -116,7 +116,13 @@ std::string Path::GetFileExtension() const {
 std::string Path::GetDirectory() const {
 	size_t pos = path_.rfind('/');
 	if (pos != std::string::npos) {
+		if (pos == 0) {
+			return "/";  // We're at the root.
+		}
 		return path_.substr(0, pos);
+	} else if (path_.size() == 2 && path_[1] == ':') {
+		// Windows fake-root.
+		return "/";
 	} else {
 		// There could be a ':', too. Unlike the slash, let's include that
 		// in the returned directory.
@@ -125,7 +131,7 @@ std::string Path::GetDirectory() const {
 			return path_.substr(0, c_pos + 1);
 		}
 	}
-	// No directory components, just return the full path.
+	// No directory components, we're a relative path.
 	return path_;
 }
 

--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -1,3 +1,5 @@
+#include "ppsspp_config.h"
+
 #include "Common/File/Path.h"
 #include "Common/StringUtils.h"
 #include "Common/Log.h"
@@ -120,9 +122,11 @@ std::string Path::GetDirectory() const {
 			return "/";  // We're at the root.
 		}
 		return path_.substr(0, pos);
+#if PPSSPP_PLATFORM(WINDOWS)
 	} else if (path_.size() == 2 && path_[1] == ':') {
 		// Windows fake-root.
 		return "/";
+#endif
 	} else {
 		// There could be a ':', too. Unlike the slash, let's include that
 		// in the returned directory.
@@ -185,8 +189,10 @@ bool Path::IsAbsolute() const {
 		return true;
 	else if (path_.front() == '/')
 		return true;
+#if PPSSPP_PLATFORM(WINDOWS)
 	else if (path_.size() > 3 && path_[1] == ':')
 		return true; // Windows path with drive letter
+#endif
 	else
 		return false;
 }

--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -1,0 +1,126 @@
+#include "Common/File/Path.h"
+#include "Common/StringUtils.h"
+
+#include "Common/Data/Encoding/Utf8.h"
+
+Path::Path(const std::string &str) {
+	if (startsWith(str, "http://") || startsWith(str, "https://")) {
+		type_ = PathType::HTTP;
+	} else {
+		type_ = PathType::NATIVE;
+	}
+
+	Init(str);
+}
+
+#if PPSSPP_PLATFORM(WINDOWS)
+Path::Path(const std::wstring &str) {
+	type_ = PathType::NATIVE;
+	Init(ConvertWStringToUTF8(str));
+}
+#endif
+
+void Path::Init(const std::string &str) {
+	path_ = str;
+
+#if PPSSPP_PLATFORM(WINDOWS)
+	// Flip all the slashes around. We flip them back on ToWString().
+	for (size_t i = 0; i < path_.size(); i++) {
+		if (path_[i] == '\\') {
+			path_[i] = '/';
+		}
+	}
+#endif
+
+	if (type_ == PathType::NATIVE && !path_.empty() && path_.back() == '/') {
+		path_.pop_back();
+	}
+}
+
+Path Path::operator /(const std::string &subdir) const {
+	// We always use forward slashes internally, we convert to backslash only when
+	// converted to a wstring.
+	return Path(path_ + "/" + subdir);
+}
+
+void Path::operator /=(const std::string &subdir) {
+	path_ += path_ + "/" + subdir;
+}
+
+Path Path::WithExtraExtension(const std::string &ext) const {
+	return Path(path_ + "." + ext);
+}
+
+std::string Path::GetFileExtension() const {
+	size_t pos = path_.rfind(".");
+	if (pos == std::string::npos) {
+		return "";
+	}
+	size_t slash_pos = path_.rfind("/");
+	if (slash_pos != std::string::npos && slash_pos > pos) {
+		// Don't want to detect "df/file" from "/as.df/file"
+		return "";
+	}
+	std::string ext = path_.substr(pos + 1);
+	for (size_t i = 0; i < ext.size(); i++) {
+		ext[i] = tolower(ext[i]);
+	}
+	return ext;
+}
+
+Path Path::Directory() const {
+	std::string directory;
+	SplitPath(path_, &directory, nullptr, nullptr);
+	return Path(directory);
+}
+
+bool Path::FilePathContains(const std::string &needle) const {
+	const std::string &haystack = path_;
+	return haystack.find(needle) != std::string::npos;
+}
+
+bool Path::StartsWith(const Path &other) const {
+	if (type_ != other.type_) {
+		// Bad
+		return false;
+	}
+	return startsWith(path_, other.path_);
+}
+
+const std::string &Path::ToString() const {
+	return path_;
+}
+
+#if PPSSPP_PLATFORM(WINDOWS)
+std::wstring Path::ToWString() const {
+	std::wstring w = ConvertUTF8ToWString(path_);
+	for (size_t i = 0; i < w.size(); i++) {
+		if (w[i] == '/') {
+			w[i] = '\\';
+		}
+	}
+	return w;
+}
+#endif
+
+std::string Path::ToVisualString() const {
+	return path_;
+}
+
+bool Path::CanNavigateUp() const {
+	if (path_ == "/" || path_ == "") {
+		return false;
+	}
+	return true;
+}
+
+bool Path::IsAbsolute() const {
+	if (path_.empty())
+		return true;
+	else if (path_.front() == '/')
+		return true;
+	else if (path_.size() > 3 && path_[1] == ':')
+		return true; // Windows path with drive letter
+	else
+		return false;
+}

--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -55,7 +55,7 @@ Path Path::WithExtraExtension(const std::string &ext) const {
 
 Path Path::WithReplacedExtension(const std::string &oldExtension, const std::string &newExtension) const {
 	if (endsWithNoCase(path_, "." + oldExtension)) {
-		std::string newPath = path_.substr(path_.size() - oldExtension.size() - 1);
+		std::string newPath = path_.substr(0, path_.size() - oldExtension.size() - 1);
 		return Path(newPath + "." + newExtension);
 	} else {
 		return Path(*this);

--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -59,7 +59,7 @@ Path Path::operator /(const std::string &subdir) const {
 }
 
 void Path::operator /=(const std::string &subdir) {
-	path_ += path_ + "/" + subdir;
+	*this = *this / subdir;
 }
 
 Path Path::WithExtraExtension(const std::string &ext) const {

--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -4,7 +4,9 @@
 #include "Common/Data/Encoding/Utf8.h"
 
 Path::Path(const std::string &str) {
-	if (startsWith(str, "http://") || startsWith(str, "https://")) {
+	if (str.empty()) {
+		type_ = PathType::UNDEFINED;
+	} else if (startsWith(str, "http://") || startsWith(str, "https://")) {
 		type_ = PathType::HTTP;
 	} else {
 		type_ = PathType::NATIVE;
@@ -49,6 +51,15 @@ void Path::operator /=(const std::string &subdir) {
 
 Path Path::WithExtraExtension(const std::string &ext) const {
 	return Path(path_ + "." + ext);
+}
+
+Path Path::WithReplacedExtension(const std::string &oldExtension, const std::string &newExtension) const {
+	if (endsWithNoCase(path_, "." + oldExtension)) {
+		std::string newPath = path_.substr(path_.size() - oldExtension.size() - 1);
+		return Path(newPath + "." + newExtension);
+	} else {
+		return Path(*this);
+	}
 }
 
 std::string Path::GetFileExtension() const {

--- a/Common/File/Path.h
+++ b/Common/File/Path.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "ppsspp_config.h"
+
+#include <string>
+
+enum class PathType {
+	UNDEFINED = 0,
+	NATIVE = 1,
+	// RELATIVE, // (do we need this?)
+	// CONTENT_URI = 2,  // Android only
+	HTTP = 3,  // http://, https://
+};
+
+// Windows paths are always stored with '/' slashes in a Path.
+// On .ToWString(), they are flipped back to '\'.
+
+class Path {
+private:
+	void Init(const std::string &str);
+
+public:
+	Path() : type_(PathType::UNDEFINED) {}
+	explicit Path(const std::string &str);
+
+#if PPSSPP_PLATFORM(WINDOWS)
+	explicit Path(const std::wstring &str);
+#endif
+
+	PathType Type() const {
+		return type_;
+	}
+
+	bool Valid() const { return !path_.empty(); }
+
+	// Some std::string emulation for simplicity.
+	bool empty() const { return !Valid(); }
+	void clear() {
+		type_ = PathType::UNDEFINED;
+		path_.clear();
+	}
+	// WARNING: Unsafe usage.
+	const char *c_str() const {
+		return path_.c_str();
+	}
+
+	bool IsAbsolute() const;
+
+	// Returns a path extended with a subdirectory.
+	Path operator /(const std::string &subdir) const;
+
+	// Navigates down into a subdir.
+	void operator /=(const std::string &subdir);
+
+	// File extension manipulation.
+	Path WithExtraExtension(const std::string &ext) const;
+
+	// Removes the last component.
+	Path Directory() const;
+
+	std::string GetFileExtension() const;
+
+	const std::string &ToString() const;
+
+#if PPSSPP_PLATFORM(WINDOWS)
+	std::wstring ToWString() const;
+#endif
+
+	std::string ToVisualString() const;
+
+	bool CanNavigateUp() const;
+	bool operator ==(const Path &other) const {
+		return path_ == other.path_ && type_ == other.type_;
+	}
+	bool operator !=(const Path &other) const {
+		return path_ != other.path_ || type_ != other.type_;
+	}
+
+	bool FilePathContains(const std::string &needle) const;
+
+	bool StartsWith(const Path &other) const;
+
+private:
+	// The internal representation is currently always the plain string.
+	// For CPU efficiency we could keep an AndroidStorageContentURI too,
+	// but I don't think the encode/decode cost is significant. We simply create
+	// those for processing instead.
+	std::string path_;
+
+	PathType type_;
+};

--- a/Common/File/Path.h
+++ b/Common/File/Path.h
@@ -80,6 +80,10 @@ public:
 
 	bool StartsWith(const Path &other) const;
 
+	bool operator <(const Path &other) const {
+		return path_ < other.path_;
+	}
+
 private:
 	// The internal representation is currently always the plain string.
 	// For CPU efficiency we could keep an AndroidStorageContentURI too,

--- a/Common/File/Path.h
+++ b/Common/File/Path.h
@@ -32,6 +32,7 @@ public:
 	}
 
 	bool Valid() const { return !path_.empty(); }
+	bool IsRoot() const { return path_ == "/"; }  // Special value - only path that can end in a slash.
 
 	// Some std::string emulation for simplicity.
 	bool empty() const { return !Valid(); }
@@ -62,7 +63,7 @@ public:
 	Path WithReplacedExtension(const std::string &newExtension) const;
 
 	// Removes the last component.
-	std::string GetFilename() const;  // Really, GetLastComponent. Could be a file or directory.
+	std::string GetFilename() const;  // Really, GetLastComponent. Could be a file or directory. Includes the extension.
 	std::string GetFileExtension() const;  // Always lowercase return. Includes the dot.
 	std::string GetDirectory() const;
 

--- a/Common/File/Path.h
+++ b/Common/File/Path.h
@@ -59,11 +59,12 @@ public:
 	// File extension manipulation.
 	Path WithExtraExtension(const std::string &ext) const;
 	Path WithReplacedExtension(const std::string &oldExtension, const std::string &newExtension) const;
+	Path WithReplacedExtension(const std::string &newExtension) const;
 
 	// Removes the last component.
-	Path Directory() const;
-
-	std::string GetFileExtension() const;
+	std::string GetFilename() const;  // Really, GetLastComponent. Could be a file or directory.
+	std::string GetFileExtension() const;  // Always lowercase return. Includes the dot.
+	std::string GetDirectory() const;
 
 	const std::string &ToString() const;
 
@@ -74,6 +75,8 @@ public:
 	std::string ToVisualString() const;
 
 	bool CanNavigateUp() const;
+	Path NavigateUp() const;
+
 	bool operator ==(const Path &other) const {
 		return path_ == other.path_ && type_ == other.type_;
 	}

--- a/Common/File/Path.h
+++ b/Common/File/Path.h
@@ -39,6 +39,10 @@ public:
 		type_ = PathType::UNDEFINED;
 		path_.clear();
 	}
+	size_t size() const {
+		return path_.size();
+	}
+
 	// WARNING: Unsafe usage.
 	const char *c_str() const {
 		return path_.c_str();
@@ -54,6 +58,7 @@ public:
 
 	// File extension manipulation.
 	Path WithExtraExtension(const std::string &ext) const;
+	Path WithReplacedExtension(const std::string &oldExtension, const std::string &newExtension) const;
 
 	// Removes the last component.
 	Path Directory() const;

--- a/Common/File/PathBrowser.cpp
+++ b/Common/File/PathBrowser.cpp
@@ -83,7 +83,7 @@ bool LoadRemoteFileList(const std::string &url, bool *cancel, std::vector<File::
 
 		File::FileInfo info;
 		info.name = item;
-		info.fullName = baseURL.Relative(item).ToString();
+		info.fullName = Path(baseURL.Relative(item).ToString());
 		info.isDirectory = endsWith(item, "/");
 		info.exists = true;
 		info.size = 0;
@@ -115,7 +115,7 @@ std::vector<File::FileInfo> ApplyFilter(std::vector<File::FileInfo> files, const
 	auto pred = [&](const File::FileInfo &info) {
 		if (info.isDirectory || !filter)
 			return false;
-		std::string ext = File::GetFileExtension(info.fullName);
+		std::string ext = info.fullName.GetFileExtension();
 		return filters.find(ext) == filters.end();
 	};
 	files.erase(std::remove_if(files.begin(), files.end(), pred), files.end());
@@ -255,7 +255,7 @@ bool PathBrowser::GetListing(std::vector<File::FileInfo> &fileInfo, const char *
 			if (*drive == "A:/" || *drive == "B:/")
 				continue;
 			File::FileInfo fake;
-			fake.fullName = *drive;
+			fake.fullName = Path(*drive);
 			fake.name = *drive;
 			fake.isDirectory = true;
 			fake.exists = true;

--- a/Common/File/PathBrowser.cpp
+++ b/Common/File/PathBrowser.cpp
@@ -219,7 +219,7 @@ bool PathBrowser::IsListingReady() {
 std::string PathBrowser::GetFriendlyPath() const {
 	std::string str = GetPath();
 	// Show relative to memstick root if there.
-	std::string root = GetSysDirectory(DIRECTORY_MEMSTICK_ROOT);
+	std::string root = GetSysDirectory(DIRECTORY_MEMSTICK_ROOT).ToString();
 	for (size_t i = 0; i < root.size(); i++) {
 		if (root[i] == '\\')
 			root[i] = '/';
@@ -270,7 +270,7 @@ bool PathBrowser::GetListing(std::vector<File::FileInfo> &fileInfo, const char *
 		fileInfo = ApplyFilter(pendingFiles_, filter);
 		return true;
 	} else {
-		File::GetFilesInDir(path_.c_str(), &fileInfo, filter);
+		File::GetFilesInDir(Path(path_), &fileInfo, filter);
 		return true;
 	}
 }

--- a/Common/File/PathBrowser.h
+++ b/Common/File/PathBrowser.h
@@ -8,7 +8,9 @@
 #include <vector>
 #include <cstdlib>
 
+
 #include "Common/File/DirListing.h"
+#include "Common/File/Path.h"
 
 // Abstraction above path that lets you navigate easily.
 // "/" is a special path that means the root of the file system. On Windows,
@@ -16,22 +18,19 @@
 class PathBrowser {
 public:
 	PathBrowser() {}
-	PathBrowser(std::string path) { SetPath(path); }
+	PathBrowser(const Path &path) { SetPath(path); }
 	~PathBrowser();
 
-	void SetPath(const std::string &path);
+	void SetPath(const Path &path);
 	bool IsListingReady();
 	bool GetListing(std::vector<File::FileInfo> &fileInfo, const char *filter = nullptr, bool *cancel = nullptr);
 
 	bool CanNavigateUp();
 	void NavigateUp();
-	void Navigate(const std::string &path);
+	void Navigate(const std::string &subdir);
 
-	std::string GetPath() const {
-		if (path_ != "/")
-			return path_;
-		else
-			return "";
+	Path GetPath() const {
+		return path_;
 	}
 	std::string GetFriendlyPath() const;
 
@@ -39,8 +38,8 @@ private:
 	void HandlePath();
 	void ResetPending();
 
-	std::string path_;
-	std::string pendingPath_;
+	Path path_;
+	Path pendingPath_;
 	std::vector<File::FileInfo> pendingFiles_;
 	std::condition_variable pendingCond_;
 	std::mutex pendingLock_;

--- a/Common/File/VFS/AssetReader.cpp
+++ b/Common/File/VFS/AssetReader.cpp
@@ -201,13 +201,14 @@ bool DirectoryAssetReader::GetFileListing(const char *path, std::vector<File::Fi
 		strcpy(new_path, path_);
 	}
 	strcat(new_path, path);
+
 	File::FileInfo info;
-	if (!File::GetFileInfo(new_path, &info))
+	if (!File::GetFileInfo(Path(new_path), &info))
 		return false;
 
 	if (info.isDirectory)
 	{
-		File::GetFilesInDir(new_path, listing, filter);
+		File::GetFilesInDir(Path(new_path), listing, filter);
 		return true;
 	}
 	else
@@ -227,5 +228,5 @@ bool DirectoryAssetReader::GetFileInfo(const char *path, File::FileInfo *info)
 		strcpy(new_path, path_);
 	}
 	strcat(new_path, path);
-	return File::GetFileInfo(new_path, info);
+	return File::GetFileInfo(Path(new_path), info);
 }

--- a/Common/File/VFS/AssetReader.cpp
+++ b/Common/File/VFS/AssetReader.cpp
@@ -113,13 +113,9 @@ bool ZipAssetReader::GetFileListing(const char *orig_path, std::vector<File::Fil
 	for (auto diter = directories.begin(); diter != directories.end(); ++diter) {
 		File::FileInfo info;
 		info.name = *diter;
-		info.fullName = std::string(path);
-		if (info.fullName[info.fullName.size() - 1] == '/')
-			info.fullName = info.fullName.substr(0, info.fullName.size() - 1);
 
 		// Remove the "inzip" part of the fullname.
-		info.fullName = info.fullName.substr(strlen(in_zip_path_));
-		info.fullName += "/" + *diter;
+		info.fullName = Path(std::string(path).substr(strlen(in_zip_path_))) / *diter;
 		info.exists = true;
 		info.isWritable = false;
 		info.isDirectory = true;
@@ -127,17 +123,14 @@ bool ZipAssetReader::GetFileListing(const char *orig_path, std::vector<File::Fil
 	}
 
 	for (auto fiter = files.begin(); fiter != files.end(); ++fiter) {
+		std::string fpath = path;
 		File::FileInfo info;
 		info.name = *fiter;
-		info.fullName = std::string(path);
-		if (info.fullName[info.fullName.size() - 1] == '/')
-			info.fullName = info.fullName.substr(0, info.fullName.size() - 1);
-		info.fullName = info.fullName.substr(strlen(in_zip_path_));
-		info.fullName += "/" + *fiter;
+		info.fullName = Path(std::string(path).substr(strlen(in_zip_path_))) / *fiter;
 		info.exists = true;
 		info.isWritable = false;
 		info.isDirectory = false;
-		std::string ext = File::GetFileExtension(info.fullName);
+		std::string ext = File::GetFileExtension(info.fullName.ToString());
 		if (filter) {
 			if (filters.find(ext) == filters.end())
 				continue;
@@ -162,7 +155,7 @@ bool ZipAssetReader::GetFileInfo(const char *path, File::FileInfo *info) {
 		return false;
 	}
 
-	info->fullName = path;
+	info->fullName = Path(path);
 	info->exists = true; // TODO
 	info->isWritable = false;
 	info->isDirectory = false;    // TODO

--- a/Common/File/VFS/AssetReader.cpp
+++ b/Common/File/VFS/AssetReader.cpp
@@ -132,10 +132,9 @@ bool ZipAssetReader::GetFileListing(const char *orig_path, std::vector<File::Fil
 		info.isDirectory = false;
 		std::string ext = info.fullName.GetFileExtension();
 		if (filter) {
-			if (!ext.empty())
-				ext = ext.substr(1);
-			if (filters.find(ext) == filters.end())
+			if (filters.find(ext) == filters.end()) {
 				continue;
+			}
 		}
 		listing->push_back(info);
 	}

--- a/Common/File/VFS/AssetReader.cpp
+++ b/Common/File/VFS/AssetReader.cpp
@@ -130,8 +130,10 @@ bool ZipAssetReader::GetFileListing(const char *orig_path, std::vector<File::Fil
 		info.exists = true;
 		info.isWritable = false;
 		info.isDirectory = false;
-		std::string ext = File::GetFileExtension(info.fullName.ToString());
+		std::string ext = info.fullName.GetFileExtension();
 		if (filter) {
+			if (!ext.empty())
+				ext = ext.substr(1);
 			if (filters.find(ext) == filters.end())
 				continue;
 		}

--- a/Common/File/VFS/VFS.cpp
+++ b/Common/File/VFS/VFS.cpp
@@ -24,7 +24,8 @@ void VFSShutdown() {
 	num_entries = 0;
 }
 
-static bool IsLocalPath(const char *path) {
+// TODO: Use Path more.
+static bool IsLocalAbsolutePath(const char *path) {
 	bool isUnixLocal = path[0] == '/';
 #ifdef _WIN32
 	bool isWindowsLocal = isalpha(path[0]) && path[1] == ':';
@@ -36,7 +37,7 @@ static bool IsLocalPath(const char *path) {
 
 // The returned data should be free'd with delete[].
 uint8_t *VFSReadFile(const char *filename, size_t *size) {
-	if (IsLocalPath(filename)) {
+	if (IsLocalAbsolutePath(filename)) {
 		// Local path, not VFS.
 		// INFO_LOG(IO, "Not a VFS path: %s . Reading local file.", filename);
 		return File::ReadLocalFile(filename, size);
@@ -65,7 +66,7 @@ uint8_t *VFSReadFile(const char *filename, size_t *size) {
 }
 
 bool VFSGetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter) {
-	if (IsLocalPath(path)) {
+	if (IsLocalAbsolutePath(path)) {
 		// Local path, not VFS.
 		// INFO_LOG(IO, "Not a VFS path: %s . Reading local directory.", path);
 		File::GetFilesInDir(Path(std::string(path)), listing, filter);
@@ -92,7 +93,7 @@ bool VFSGetFileListing(const char *path, std::vector<File::FileInfo> *listing, c
 }
 
 bool VFSGetFileInfo(const char *path, File::FileInfo *info) {
-	if (IsLocalPath(path)) {
+	if (IsLocalAbsolutePath(path)) {
 		// Local path, not VFS.
 		// INFO_LOG(IO, "Not a VFS path: %s . Getting local file info.", path);
 		return File::GetFileInfo(Path(std::string(path)), info);

--- a/Common/File/VFS/VFS.cpp
+++ b/Common/File/VFS/VFS.cpp
@@ -68,7 +68,7 @@ bool VFSGetFileListing(const char *path, std::vector<File::FileInfo> *listing, c
 	if (IsLocalPath(path)) {
 		// Local path, not VFS.
 		// INFO_LOG(IO, "Not a VFS path: %s . Reading local directory.", path);
-		File::GetFilesInDir(path, listing, filter);
+		File::GetFilesInDir(Path(std::string(path)), listing, filter);
 		return true;
 	}
 
@@ -95,7 +95,7 @@ bool VFSGetFileInfo(const char *path, File::FileInfo *info) {
 	if (IsLocalPath(path)) {
 		// Local path, not VFS.
 		// INFO_LOG(IO, "Not a VFS path: %s . Getting local file info.", path);
-		return File::GetFileInfo(path, info);
+		return File::GetFileInfo(Path(std::string(path)), info);
 	}
 
 	bool fileSystemFound = false;

--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -291,7 +291,7 @@ void LogManager::RemoveListener(LogListener *listener) {
 }
 
 FileLogListener::FileLogListener(const char *filename) {
-	fp_ = File::OpenCFile(filename, "at");
+	fp_ = File::OpenCFile(Path(std::string(filename)), "at");
 	SetEnabled(fp_ != nullptr);
 }
 

--- a/Common/MemArenaPosix.cpp
+++ b/Common/MemArenaPosix.cpp
@@ -56,7 +56,7 @@ void MemArena::GrabLowMemSpace(size_t size) {
 	// Some platforms (like Raspberry Pi) end up flushing to disk.
 	// To avoid this, we try to use /dev/shm (tmpfs) if it exists.
 	fd = -1;
-	if (File::Exists(tmpfs_location)) {
+	if (File::Exists(Path(tmpfs_location))) {
 		fd = open(tmpfs_ram_temp_file.c_str(), O_RDWR | O_CREAT, mode);
 		if (fd >= 0) {
 			// Great, this definitely shouldn't flush to disk.

--- a/Common/Serialize/Serializer.cpp
+++ b/Common/Serialize/Serializer.cpp
@@ -250,7 +250,7 @@ CChunkFileReader::Error CChunkFileReader::LoadFileHeader(File::IOFile &pFile, SC
 	return ERROR_NONE;
 }
 
-CChunkFileReader::Error CChunkFileReader::GetFileTitle(const std::string &filename, std::string *title) {
+CChunkFileReader::Error CChunkFileReader::GetFileTitle(const Path &filename, std::string *title) {
 	if (!File::Exists(filename)) {
 		ERROR_LOG(SAVESTATE, "ChunkReader: File doesn't exist");
 		return ERROR_BAD_FILE;
@@ -261,7 +261,7 @@ CChunkFileReader::Error CChunkFileReader::GetFileTitle(const std::string &filena
 	return LoadFileHeader(pFile, header, title);
 }
 
-CChunkFileReader::Error CChunkFileReader::LoadFile(const std::string &filename, std::string *gitVersion, u8 *&_buffer, size_t &sz, std::string *failureReason) {
+CChunkFileReader::Error CChunkFileReader::LoadFile(const Path &filename, std::string *gitVersion, u8 *&_buffer, size_t &sz, std::string *failureReason) {
 	if (!File::Exists(filename)) {
 		*failureReason = "LoadStateDoesntExist";
 		ERROR_LOG(SAVESTATE, "ChunkReader: File doesn't exist");
@@ -325,7 +325,7 @@ CChunkFileReader::Error CChunkFileReader::LoadFile(const std::string &filename, 
 }
 
 // Takes ownership of buffer.
-CChunkFileReader::Error CChunkFileReader::SaveFile(const std::string &filename, const std::string &title, const char *gitVersion, u8 *buffer, size_t sz) {
+CChunkFileReader::Error CChunkFileReader::SaveFile(const Path &filename, const std::string &title, const char *gitVersion, u8 *buffer, size_t sz) {
 	INFO_LOG(SAVESTATE, "ChunkReader: Writing %s", filename.c_str());
 
 	File::IOFile pFile(filename, "wb");

--- a/Common/Serialize/Serializer.h
+++ b/Common/Serialize/Serializer.h
@@ -35,6 +35,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Log.h"
+#include "Common/File/Path.h"
 
 namespace File {
 class IOFile;
@@ -172,7 +173,7 @@ public:
 
 	// Load file template
 	template<class T>
-	static Error Load(const std::string &filename, std::string *gitVersion, T& _class, std::string *failureReason)
+	static Error Load(const Path &filename, std::string *gitVersion, T& _class, std::string *failureReason)
 	{
 		*failureReason = "LoadStateWrongVersion";
 
@@ -192,7 +193,7 @@ public:
 
 	// Save file template
 	template<class T>
-	static Error Save(const std::string &filename, const std::string &title, const char *gitVersion, T& _class)
+	static Error Save(const Path &filename, const std::string &title, const char *gitVersion, T& _class)
 	{
 		// Get data
 		size_t const sz = MeasurePtr(_class);
@@ -231,7 +232,7 @@ public:
 		return ERROR_NONE;
 	}
 
-	static Error GetFileTitle(const std::string &filename, std::string *title);
+	static Error GetFileTitle(const Path &filename, std::string *title);
 
 private:
 	struct SChunkHeader
@@ -249,7 +250,7 @@ private:
 		REVISION_CURRENT = REVISION_TITLE,
 	};
 
-	static Error LoadFile(const std::string &filename, std::string *gitVersion, u8 *&buffer, size_t &sz, std::string *failureReason);
-	static Error SaveFile(const std::string &filename, const std::string &title, const char *gitVersion, u8 *buffer, size_t sz);
+	static Error LoadFile(const Path &filename, std::string *gitVersion, u8 *&buffer, size_t &sz, std::string *failureReason);
+	static Error SaveFile(const Path &filename, const std::string &title, const char *gitVersion, u8 *buffer, size_t sz);
 	static Error LoadFileHeader(File::IOFile &pFile, SChunkHeader &header, std::string *title);
 };

--- a/Common/StringUtils.cpp
+++ b/Common/StringUtils.cpp
@@ -125,22 +125,6 @@ bool SplitPath(const std::string& full_path, std::string* _pPath, std::string* _
 	return true;
 }
 
-std::string GetFilenameFromPath(std::string full_path) {
-	size_t pos;
-#ifdef _WIN32
-	pos = full_path.rfind('\\');
-	if (pos != std::string::npos) {
-		return full_path.substr(pos + 1);
-	}
-#endif
-	pos = full_path.rfind('/');
-	if (pos != std::string::npos) {
-		return full_path.substr(pos + 1);
-	}
-	// No directory components, just return the full path.
-	return full_path;
-}
-
 std::string LineNumberString(const std::string &str) {
 	std::stringstream input(str);
 	std::stringstream output;

--- a/Common/StringUtils.h
+++ b/Common/StringUtils.h
@@ -101,5 +101,3 @@ inline void CharArrayFromFormat(char (& out)[Count], const char* format, ...)
 
 // "C:/Windows/winhelp.exe" to "C:/Windows/", "winhelp", ".exe"
 bool SplitPath(const std::string& full_path, std::string* _pPath, std::string* _pFilename, std::string* _pExtension);
-
-std::string GetFilenameFromPath(std::string full_path);

--- a/Core/AVIDump.cpp
+++ b/Core/AVIDump.cpp
@@ -25,6 +25,7 @@ extern "C" {
 
 #include "Common/Data/Convert/ColorConv.h"
 #include "Common/File/FileUtil.h"
+#include "Common/File/Path.h"
 
 #include "Core/Config.h"
 #include "Core/AVIDump.h"
@@ -94,7 +95,7 @@ bool AVIDump::CreateAVI() {
 
 	// Use gameID_EmulatedTimestamp for filename
 	std::string discID = g_paramSFO.GetDiscID();
-	std::string video_file_name = StringFromFormat("%s%s_%s.avi", GetSysDirectory(DIRECTORY_VIDEO).c_str(), discID.c_str(), KernelTimeNowFormatted().c_str()).c_str();
+	Path video_file_name = GetSysDirectory(DIRECTORY_VIDEO) / StringFromFormat("%s_%s.avi", discID.c_str(), KernelTimeNowFormatted().c_str());
 
 	s_format_context = avformat_alloc_context();
 
@@ -106,14 +107,14 @@ bool AVIDump::CreateAVI() {
 	const char *filename = s_format_context->filename;
 	snprintf(s_format_context->filename, sizeof(s_format_context->filename), "%s", video_file_name.c_str());
 #endif
-	INFO_LOG(COMMON, "Recording Video to: %s", filename);
+	INFO_LOG(COMMON, "Recording Video to: %s", video_file_name.c_str());
 
 	// Make sure that the path exists
 	if (!File::Exists(GetSysDirectory(DIRECTORY_VIDEO)))
 		File::CreateDir(GetSysDirectory(DIRECTORY_VIDEO));
 
-	if (File::Exists(filename))
-		File::Delete(filename);
+	if (File::Exists(video_file_name))
+		File::Delete(video_file_name);
 
 	s_format_context->oformat = av_guess_format("avi", nullptr, nullptr);
 	if (!s_format_context->oformat)

--- a/Core/AVIDump.cpp
+++ b/Core/AVIDump.cpp
@@ -107,7 +107,7 @@ bool AVIDump::CreateAVI() {
 	const char *filename = s_format_context->filename;
 	snprintf(s_format_context->filename, sizeof(s_format_context->filename), "%s", video_file_name.c_str());
 #endif
-	INFO_LOG(COMMON, "Recording Video to: %s", video_file_name.c_str());
+	INFO_LOG(COMMON, "Recording Video to: %s", video_file_name.ToVisualString().c_str());
 
 	// Make sure that the path exists
 	if (!File::Exists(GetSysDirectory(DIRECTORY_VIDEO)))

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -35,8 +35,8 @@ void Compatibility::Load(const std::string &gameID) {
 	{
 		IniFile compat2;
 		// This one is user-editable. Need to load it after the system one.
-		std::string path = GetSysDirectory(DIRECTORY_SYSTEM) + "compat.ini";
-		if (compat2.Load(path)) {
+		Path path = GetSysDirectory(DIRECTORY_SYSTEM) / "compat.ini";
+		if (compat2.Load(path.ToString())) {
 			CheckSettings(compat2, gameID);
 		}
 	}

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1536,7 +1536,7 @@ void Config::RemoveRecent(const std::string &file) {
 void Config::CleanRecent() {
 	std::vector<std::string> cleanedRecent;
 	for (size_t i = 0; i < recentIsos.size(); i++) {
-		FileLoader *loader = ConstructFileLoader(recentIsos[i]);
+		FileLoader *loader = ConstructFileLoader(Path(recentIsos[i]));
 		if (loader->ExistsFast()) {
 			// Make sure we don't have any redundant items.
 			auto duplicate = std::find(cleanedRecent.begin(), cleanedRecent.end(), recentIsos[i]);
@@ -1577,7 +1577,8 @@ const Path Config::FindConfigFile(const std::string &baseFilename) {
 
 	const Path filename = defaultPath_ / baseFilename;
 	if (!File::Exists(filename)) {
-		Path path = filename.Directory();
+		// Make sure at least the directory it's supposed to be in exists.
+		Path path = filename.NavigateUp();
 		if (createdPath_ != path) {
 			File::CreateFullPath(path);
 			createdPath_ = path;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1425,7 +1425,7 @@ void Config::Save(const char *saveReason) {
 		{
 			IniFile controllerIniFile;
 			if (!controllerIniFile.Load(controllerIniFilename_)) {
-				ERROR_LOG(LOADER, "Error saving config - can't read ini '%s'", controllerIniFilename_.c_str());
+				ERROR_LOG(LOADER, "Error saving controller config - can't read ini first '%s'", controllerIniFilename_.c_str());
 			}
 			KeyMap::SaveToIni(controllerIniFile);
 			if (!controllerIniFile.Save(controllerIniFilename_)) {

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1614,13 +1614,12 @@ void Config::changeGameSpecific(const std::string &pGameId, const std::string &t
 }
 
 bool Config::createGameConfig(const std::string &pGameId) {
-	Path fullIniFilePath = Path(getGameConfigFile(pGameId));
+	Path fullIniFilePath = getGameConfigFile(pGameId);
 
 	if (hasGameConfig(pGameId)) {
 		return false;
 	}
 
-	// TODO(scoped):
 	File::CreateEmptyFile(fullIniFilePath);
 	return true;
 }

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1202,7 +1202,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	bShowFrameProfiler = true;
 
 	IniFile iniFile;
-	if (!iniFile.Load(iniFilename_)) {
+	if (!iniFile.Load(iniFilename_.ToString())) {
 		ERROR_LOG(LOADER, "Failed to read '%s'. Setting config to default.", iniFilename_.c_str());
 		// Continue anyway to initialize the config.
 	}
@@ -1353,12 +1353,12 @@ void Config::Save(const char *saveReason) {
 		// if JIT has been forced off, we don't want to screw up the user's ppsspp.ini
 		g_Config.iCpuCore = (int)CPUCore::JIT;
 	}
-	if (iniFilename_.size() && g_Config.bSaveSettings) {
+	if (!iniFilename_.empty() && g_Config.bSaveSettings) {
 		saveGameConfig(gameId_, gameIdTitle_);
 
 		CleanRecent();
 		IniFile iniFile;
-		if (!iniFile.Load(iniFilename_.c_str())) {
+		if (!iniFile.Load(iniFilename_)) {
 			ERROR_LOG(LOADER, "Error saving config - can't read ini '%s'", iniFilename_.c_str());
 		}
 
@@ -1414,7 +1414,7 @@ void Config::Save(const char *saveReason) {
 		if (LogManager::GetInstance())
 			LogManager::GetInstance()->SaveConfig(log);
 
-		if (!iniFile.Save(iniFilename_.c_str())) {
+		if (!iniFile.Save(iniFilename_)) {
 			ERROR_LOG(LOADER, "Error saving config (%s)- can't write ini '%s'", saveReason, iniFilename_.c_str());
 			System_SendMessage("toast", "Failed to save settings!\nCheck permissions, or try to restart the device.");
 			return;
@@ -1424,11 +1424,11 @@ void Config::Save(const char *saveReason) {
 		if (!bGameSpecific) //otherwise we already did this in saveGameConfig()
 		{
 			IniFile controllerIniFile;
-			if (!controllerIniFile.Load(controllerIniFilename_.c_str())) {
+			if (!controllerIniFile.Load(controllerIniFilename_)) {
 				ERROR_LOG(LOADER, "Error saving config - can't read ini '%s'", controllerIniFilename_.c_str());
 			}
 			KeyMap::SaveToIni(controllerIniFile);
-			if (!controllerIniFile.Save(controllerIniFilename_.c_str())) {
+			if (!controllerIniFile.Save(controllerIniFilename_)) {
 				ERROR_LOG(LOADER, "Error saving config - can't write ini '%s'", controllerIniFilename_.c_str());
 				return;
 			}
@@ -1549,36 +1549,35 @@ void Config::CleanRecent() {
 	recentIsos = cleanedRecent;
 }
 
-void Config::SetDefaultPath(const std::string &defaultPath) {
+void Config::SetDefaultPath(const Path &defaultPath) {
 	defaultPath_ = defaultPath;
 }
 
-void Config::AddSearchPath(const std::string &path) {
+void Config::AddSearchPath(const Path &path) {
 	searchPath_.push_back(path);
 }
 
-const std::string Config::FindConfigFile(const std::string &baseFilename) {
+const Path Config::FindConfigFile(const std::string &baseFilename) {
 	// Don't search for an absolute path.
 	if (baseFilename.size() > 1 && baseFilename[0] == '/') {
-		return baseFilename;
+		return Path(baseFilename);
 	}
 #ifdef _WIN32
 	if (baseFilename.size() > 3 && baseFilename[1] == ':' && (baseFilename[2] == '/' || baseFilename[2] == '\\')) {
-		return baseFilename;
+		return Path(baseFilename);
 	}
 #endif
 
 	for (size_t i = 0; i < searchPath_.size(); ++i) {
-		std::string filename = searchPath_[i] + baseFilename;
+		Path filename = searchPath_[i] / baseFilename;
 		if (File::Exists(filename)) {
 			return filename;
 		}
 	}
 
-	const std::string filename = defaultPath_.empty() ? baseFilename : defaultPath_ + baseFilename;
+	const Path filename = defaultPath_ / baseFilename;
 	if (!File::Exists(filename)) {
-		std::string path;
-		SplitPath(filename, &path, NULL, NULL);
+		Path path = filename.Directory();
 		if (createdPath_ != path) {
 			File::CreateFullPath(path);
 			createdPath_ = path;
@@ -1593,7 +1592,7 @@ void Config::RestoreDefaults() {
 		createGameConfig(gameId_);
 	} else {
 		if (File::Exists(iniFilename_))
-			File::Delete(iniFilename_);
+			File::Delete(Path(iniFilename_));
 		recentIsos.clear();
 		currentDirectory = "";
 	}
@@ -1601,7 +1600,7 @@ void Config::RestoreDefaults() {
 }
 
 bool Config::hasGameConfig(const std::string &pGameId) {
-	std::string fullIniFilePath = getGameConfigFile(pGameId);
+	Path fullIniFilePath = getGameConfigFile(pGameId);
 	return File::Exists(fullIniFilePath);
 }
 
@@ -1614,27 +1613,27 @@ void Config::changeGameSpecific(const std::string &pGameId, const std::string &t
 }
 
 bool Config::createGameConfig(const std::string &pGameId) {
-	std::string fullIniFilePath = getGameConfigFile(pGameId);
+	Path fullIniFilePath = Path(getGameConfigFile(pGameId));
 
 	if (hasGameConfig(pGameId)) {
 		return false;
 	}
 
+	// TODO(scoped):
 	File::CreateEmptyFile(fullIniFilePath);
-
 	return true;
 }
 
 bool Config::deleteGameConfig(const std::string& pGameId) {
-	std::string fullIniFilePath = getGameConfigFile(pGameId);
+	Path fullIniFilePath = Path(getGameConfigFile(pGameId));
 
 	File::Delete(fullIniFilePath);
 	return true;
 }
 
-std::string Config::getGameConfigFile(const std::string &pGameId) {
+Path Config::getGameConfigFile(const std::string &pGameId) {
 	std::string iniFileName = pGameId + "_ppsspp.ini";
-	std::string iniFileNameFull = FindConfigFile(iniFileName);
+	Path iniFileNameFull = FindConfigFile(iniFileName);
 
 	return iniFileNameFull;
 }
@@ -1644,7 +1643,7 @@ bool Config::saveGameConfig(const std::string &pGameId, const std::string &title
 		return false;
 	}
 
-	std::string fullIniFilePath = getGameConfigFile(pGameId);
+	Path fullIniFilePath = getGameConfigFile(pGameId);
 
 	IniFile iniFile;
 
@@ -1672,13 +1671,13 @@ bool Config::saveGameConfig(const std::string &pGameId, const std::string &title
 	}
 
 	KeyMap::SaveToIni(iniFile);
-	iniFile.Save(fullIniFilePath);
+	iniFile.Save(fullIniFilePath.ToString());
 
 	return true;
 }
 
 bool Config::loadGameConfig(const std::string &pGameId, const std::string &title) {
-	std::string iniFileNameFull = getGameConfigFile(pGameId);
+	Path iniFileNameFull = getGameConfigFile(pGameId);
 
 	if (!hasGameConfig(pGameId)) {
 		INFO_LOG(LOADER, "Failed to read %s. No game-specific settings found, using global defaults.", iniFileNameFull.c_str());
@@ -1687,7 +1686,7 @@ bool Config::loadGameConfig(const std::string &pGameId, const std::string &title
 
 	changeGameSpecific(pGameId, title);
 	IniFile iniFile;
-	iniFile.Load(iniFileNameFull);
+	iniFile.Load(iniFileNameFull.ToString());
 
 	auto postShaderSetting = iniFile.GetOrCreateSection("PostShaderSetting")->ToMap();
 	mPostShaderSetting.clear();
@@ -1717,7 +1716,7 @@ void Config::unloadGameConfig() {
 		changeGameSpecific();
 
 		IniFile iniFile;
-		iniFile.Load(iniFilename_);
+		iniFile.Load(iniFilename_.ToString());
 
 		// Reload game specific settings back to standard.
 		IterateSettings(iniFile, [](Section *section, ConfigSetting *setting) {
@@ -1745,7 +1744,7 @@ void Config::unloadGameConfig() {
 
 void Config::LoadStandardControllerIni() {
 	IniFile controllerIniFile;
-	if (!controllerIniFile.Load(controllerIniFilename_)) {
+	if (!controllerIniFile.Load(controllerIniFilename_.ToString())) {
 		ERROR_LOG(LOADER, "Failed to read %s. Setting controller config to default.", controllerIniFilename_.c_str());
 		KeyMap::RestoreDefault();
 	} else {

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1212,7 +1212,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	});
 
 	iRunCount++;
-	if (!File::Exists(currentDirectory))
+	if (!File::Exists(Path(currentDirectory)))
 		currentDirectory = "";
 
 	Section *log = iniFile.GetOrCreateSection(logSectionName);
@@ -1249,7 +1249,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	for (auto it = pinnedPaths.begin(), end = pinnedPaths.end(); it != end; ++it) {
 		// Unpin paths that are deleted automatically.
 		const std::string &path = it->second;
-		if (startsWith(path, "http://") || startsWith(path, "https://") || File::Exists(path)) {
+		if (startsWith(path, "http://") || startsWith(path, "https://") || File::Exists(Path(path))) {
 			vPinnedPaths.push_back(File::ResolvePath(path));
 		}
 	}

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -22,7 +22,9 @@
 #include <vector>
 
 #include "ppsspp_config.h"
+
 #include "Common/CommonTypes.h"
+#include "Common/File/Path.h"
 #include "Core/ConfigValues.h"
 
 extern const char *PPSSPP_GIT_VERSION;
@@ -477,8 +479,8 @@ public:
 	// Various directories. Autoconfigured, not read from ini.
 	std::string currentDirectory;
 	std::string externalDirectory;
-	std::string memStickDirectory;
-	std::string flash0Directory;
+	Path memStickDirectory;
+	Path flash0Directory;
 	std::string internalDataDirectory;
 	std::string appCacheDirectory;
 
@@ -499,14 +501,14 @@ public:
 	bool loadGameConfig(const std::string &game_id, const std::string &title);
 	bool saveGameConfig(const std::string &pGameId, const std::string &title);
 	void unloadGameConfig();
-	std::string getGameConfigFile(const std::string &gameId);
+	Path getGameConfigFile(const std::string &gameId);
 	bool hasGameConfig(const std::string &game_id);
 
 	// Used when the file is not found in the search path.  Trailing slash.
-	void SetDefaultPath(const std::string &defaultPath);
+	void SetDefaultPath(const Path &defaultPath);
 	// Use a trailing slash.
-	void AddSearchPath(const std::string &path);
-	const std::string FindConfigFile(const std::string &baseFilename);
+	void AddSearchPath(const Path &path);
+	const Path FindConfigFile(const std::string &baseFilename);
 
 	// Utility functions for "recent" management
 	void AddRecent(const std::string &file);
@@ -531,11 +533,11 @@ private:
 	bool reload_ = false;
 	std::string gameId_;
 	std::string gameIdTitle_;
-	std::string iniFilename_;
-	std::string controllerIniFilename_;
-	std::vector<std::string> searchPath_;
-	std::string defaultPath_;
-	std::string createdPath_;
+	Path iniFilename_;
+	Path controllerIniFilename_;
+	std::vector<Path> searchPath_;
+	Path defaultPath_;
+	Path createdPath_;
 };
 
 std::map<std::string, std::pair<std::string, int>> GetLangValuesMapping();

--- a/Core/CoreParameter.h
+++ b/Core/CoreParameter.h
@@ -55,9 +55,9 @@ struct CoreParameter {
 	GraphicsContext *graphicsContext = nullptr;  // TODO: Find a better place.
 	bool enableSound;  // there aren't multiple sound cores.
 
-	std::string fileToStart;
-	std::string mountIso;  // If non-empty, and fileToStart is an ELF or PBP, will mount this ISO in the background to umd1:.
-	std::string mountRoot;  // If non-empty, and fileToStart is an ELF or PBP, mount this as host0: / umd0:.
+	Path fileToStart;
+	Path mountIso;  // If non-empty, and fileToStart is an ELF or PBP, will mount this ISO in the background to umd1:.
+	Path mountRoot;  // If non-empty, and fileToStart is an ELF or PBP, mount this as host0: / umd0:.
 	std::string errorString;
 
 	bool startBreak;

--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -44,7 +44,7 @@ static inline std::string TrimString(const std::string &s) {
 
 class CheatFileParser {
 public:
-	CheatFileParser(const std::string &filename, const std::string &gameID = "") {
+	CheatFileParser(const Path &filename, const std::string &gameID = "") {
 		fp_ = File::OpenCFile(filename, "rt");
 		validGameID_ = ReplaceAll(gameID, "-", "");
 	}
@@ -356,7 +356,7 @@ void hleCheat(u64 userdata, int cyclesLate) {
 }
 
 CWCheatEngine::CWCheatEngine(const std::string &gameID) : gameID_(gameID) {
-	filename_ = GetSysDirectory(DIRECTORY_CHEATS) + gameID_ + ".ini";
+	filename_ = GetSysDirectory(DIRECTORY_CHEATS) / (gameID_ + ".ini");
 }
 
 void CWCheatEngine::CreateCheatFile() {
@@ -375,7 +375,7 @@ void CWCheatEngine::CreateCheatFile() {
 	}
 }
 
-std::string CWCheatEngine::CheatFilename() {
+Path CWCheatEngine::CheatFilename() {
 	return filename_;
 }
 

--- a/Core/CwCheat.h
+++ b/Core/CwCheat.h
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "Common/File/Path.h"
 #include "Core/MemMap.h"
 
 class PointerWrap;
@@ -49,7 +50,7 @@ public:
 	std::vector<CheatFileInfo> FileInfo();
 	void ParseCheats();
 	void CreateCheatFile();
-	std::string CheatFilename();
+	Path CheatFilename();
 	void Run();
 	bool HasCheats();
 	void InvalidateICache(u32 addr, int size);
@@ -67,5 +68,5 @@ private:
 
 	std::vector<CheatCode> cheats_;
 	std::string gameID_;
-	std::string filename_;
+	Path filename_;
 };

--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -65,15 +65,16 @@ void SymbolMap::Clear() {
 	activeNeedUpdate_ = false;
 }
 
-bool SymbolMap::LoadSymbolMap(const char *filename) {
+bool SymbolMap::LoadSymbolMap(const Path &filename) {
 	Clear();  // let's not recurse the lock
 
 	std::lock_guard<std::recursive_mutex> guard(lock_);
 
+	// TODO(scoped): We're screwed here
 #if defined(_WIN32) && defined(UNICODE)
-	gzFile f = gzopen_w(ConvertUTF8ToWString(filename).c_str(), "r");
+	gzFile f = gzopen_w(filename.ToWString().c_str(), "r");
 #else
-	gzFile f = gzopen(filename, "r");
+	gzFile f = gzopen(filename.c_str(), "r");
 #endif
 
 	if (f == Z_NULL)
@@ -186,7 +187,7 @@ bool SymbolMap::LoadSymbolMap(const char *filename) {
 	return started;
 }
 
-void SymbolMap::SaveSymbolMap(const char *filename) const {
+void SymbolMap::SaveSymbolMap(const Path &filename) const {
 	std::lock_guard<std::recursive_mutex> guard(lock_);
 
 	// Don't bother writing a blank file.
@@ -195,9 +196,10 @@ void SymbolMap::SaveSymbolMap(const char *filename) const {
 	}
 
 #if defined(_WIN32) && defined(UNICODE)
-	gzFile f = gzopen_w(ConvertUTF8ToWString(filename).c_str(), "w9");
+	gzFile f = gzopen_w(filename.ToWString().c_str(), "w9");
 #else
-	gzFile f = gzopen(filename, "w9");
+	// TODO(scoped): We're screwed here
+	gzFile f = gzopen(filename.c_str(), "w9");
 #endif
 
 	if (f == Z_NULL)
@@ -222,7 +224,7 @@ void SymbolMap::SaveSymbolMap(const char *filename) const {
 	gzclose(f);
 }
 
-bool SymbolMap::LoadNocashSym(const char *filename) {
+bool SymbolMap::LoadNocashSym(const Path &filename) {
 	std::lock_guard<std::recursive_mutex> guard(lock_);
 	FILE *f = File::OpenCFile(filename, "r");
 	if (!f)
@@ -280,7 +282,7 @@ bool SymbolMap::LoadNocashSym(const char *filename) {
 	return true;
 }
 
-void SymbolMap::SaveNocashSym(const char *filename) const {
+void SymbolMap::SaveNocashSym(const Path &filename) const {
 	std::lock_guard<std::recursive_mutex> guard(lock_);
 
 	// Don't bother writing a blank file.

--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -198,7 +198,7 @@ void SymbolMap::SaveSymbolMap(const Path &filename) const {
 #if defined(_WIN32) && defined(UNICODE)
 	gzFile f = gzopen_w(filename.ToWString().c_str(), "w9");
 #else
-	// TODO(scoped): We're screwed here
+	// TODO(scoped): Use gzdopen? If we care, otherwise just compress into a buffer.
 	gzFile f = gzopen(filename.c_str(), "w9");
 #endif
 

--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -24,6 +24,7 @@
 #include <mutex>
 
 #include "Common/CommonTypes.h"
+#include "Common/File/Path.h"
 
 enum SymbolType {
 	ST_NONE     = 0,
@@ -69,10 +70,10 @@ public:
 	void Clear();
 	void SortSymbols();
 
-	bool LoadSymbolMap(const char *filename);
-	void SaveSymbolMap(const char *filename) const;
-	bool LoadNocashSym(const char *ilename);
-	void SaveNocashSym(const char *filename) const;
+	bool LoadSymbolMap(const Path &filename);
+	void SaveSymbolMap(const Path &filename) const;
+	bool LoadNocashSym(const Path &filename);
+	void SaveNocashSym(const Path &filename) const;
 
 	SymbolType GetSymbolType(u32 address);
 	bool GetSymbolInfo(SymbolInfo *info, u32 address, SymbolType symmask = ST_FUNCTION);

--- a/Core/Debugger/WebSocket/GPURecordSubscriber.cpp
+++ b/Core/Debugger/WebSocket/GPURecordSubscriber.cpp
@@ -31,7 +31,7 @@ struct WebSocketGPURecordState : public DebuggerSubscriber {
 protected:
 	bool pending_ = false;
 	std::string lastTicket_;
-	std::string lastFilename_;
+	Path lastFilename_;
 };
 
 DebuggerSubscriber *WebSocketGPURecordInit(DebuggerEventHandlerMap &map) {
@@ -63,7 +63,7 @@ void WebSocketGPURecordState::Dump(DebuggerRequest &req) {
 		return req.Fail("Recording already in progress");
 
 	pending_ = true;
-	GPURecord::SetCallback([=](const std::string &filename) {
+	GPURecord::SetCallback([=](const Path &filename) {
 		lastFilename_ = filename;
 		pending_ = false;
 	});

--- a/Core/ELF/ParamSFO.cpp
+++ b/Core/ELF/ParamSFO.cpp
@@ -271,7 +271,7 @@ void ParamSFOData::ValueData::SetData(const u8* data, int size) {
 std::string ParamSFOData::GenerateFakeID(std::string filename) {
 	// Generates fake gameID for homebrew based on it's folder name.
 	// Should probably not be a part of ParamSFO, but it'll be called in same places.
-	std::string file = PSP_CoreParameter().fileToStart;
+	std::string file = PSP_CoreParameter().fileToStart.ToString();
 	if (filename != "")
 		file = filename;
 

--- a/Core/FileLoaders/DiskCachingFileLoader.cpp
+++ b/Core/FileLoaders/DiskCachingFileLoader.cpp
@@ -827,7 +827,7 @@ void DiskCachingFileLoaderCache::GarbageCollectCacheFiles(u64 goalBytes) {
 		}
 
 #ifdef _WIN32
-		const std::wstring w32path = ConvertUTF8ToWString(file.fullName);
+		const std::wstring w32path = file.fullName.ToWString();
 		bool success = DeleteFileW(w32path.c_str()) != 0;
 #else
 		bool success = unlink(file.fullName.c_str()) == 0;

--- a/Core/FileLoaders/DiskCachingFileLoader.h
+++ b/Core/FileLoaders/DiskCachingFileLoader.h
@@ -42,7 +42,7 @@ public:
 	}
 	size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) override;
 
-	static std::vector<std::string> GetCachedPathsInUse();
+	static std::vector<Path> GetCachedPathsInUse();
 
 private:
 	void Prepare();
@@ -55,13 +55,13 @@ private:
 
 	// We don't support concurrent disk cache access (we use memory cached indexes.)
 	// So we have to ensure there's only one of these per.
-	static std::map<std::string, DiskCachingFileLoaderCache *> caches_;
+	static std::map<Path, DiskCachingFileLoaderCache *> caches_;
 	static std::mutex cachesMutex_;
 };
 
 class DiskCachingFileLoaderCache {
 public:
-	DiskCachingFileLoaderCache(const std::string &path, u64 filesize);
+	DiskCachingFileLoaderCache(const Path &path, u64 filesize);
 	~DiskCachingFileLoaderCache();
 
 	bool IsValid() {
@@ -87,7 +87,7 @@ public:
 	bool HasData() const;
 
 private:
-	void InitCache(const std::string &path);
+	void InitCache(const Path &path);
 	void ShutdownCache();
 	bool MakeCacheSpaceFor(size_t blocks);
 	void RebalanceGenerations();
@@ -99,8 +99,8 @@ private:
 	void WriteIndexData(u32 indexPos, BlockInfo &info);
 	s64 GetBlockOffset(u32 block);
 
-	::Path MakeCacheFilePath(const std::string &filename);
-	std::string MakeCacheFilename(const std::string &path);
+	Path MakeCacheFilePath(const Path &filename);
+	std::string MakeCacheFilename(const Path &path);
 	bool LoadCacheFile(const Path &path);
 	void LoadCacheIndex();
 	void CreateCacheFile(const Path &path);

--- a/Core/FileLoaders/DiskCachingFileLoader.h
+++ b/Core/FileLoaders/DiskCachingFileLoader.h
@@ -22,6 +22,7 @@
 #include <mutex>
 
 #include "Common/Common.h"
+#include "Common/File/Path.h"
 #include "Common/Swap.h"
 #include "Core/Loaders.h"
 
@@ -75,7 +76,7 @@ public:
 		return --refCount_ == 0;
 	}
 
-	static void SetCacheDir(const std::string &path) {
+	static void SetCacheDir(const Path &path) {
 		cacheDir_ = path;
 	}
 
@@ -98,13 +99,13 @@ private:
 	void WriteIndexData(u32 indexPos, BlockInfo &info);
 	s64 GetBlockOffset(u32 block);
 
-	std::string MakeCacheFilePath(const std::string &path);
+	::Path MakeCacheFilePath(const std::string &filename);
 	std::string MakeCacheFilename(const std::string &path);
-	bool LoadCacheFile(const std::string &path);
+	bool LoadCacheFile(const Path &path);
 	void LoadCacheIndex();
-	void CreateCacheFile(const std::string &path);
+	void CreateCacheFile(const Path &path);
 	bool LockCacheFile(bool lockStatus);
-	bool RemoveCacheFile(const std::string &path);
+	bool RemoveCacheFile(const Path &path);
 	void CloseFileHandle();
 
 	u64 FreeDiskSpace();
@@ -146,7 +147,7 @@ private:
 	size_t cacheSize_;
 	size_t indexCount_;
 	std::mutex lock_;
-	std::string origPath_;
+	Path origPath_;
 
 	struct FileHeader {
 		char magic[8];
@@ -176,5 +177,5 @@ private:
 	FILE *f_ = nullptr;
 	int fd_ = 0;
 
-	static std::string cacheDir_;
+	static Path cacheDir_;
 };

--- a/Core/FileLoaders/HTTPFileLoader.cpp
+++ b/Core/FileLoaders/HTTPFileLoader.cpp
@@ -23,8 +23,8 @@
 #include "Core/Config.h"
 #include "Core/FileLoaders/HTTPFileLoader.h"
 
-HTTPFileLoader::HTTPFileLoader(const std::string &filename)
-	: url_(filename), progress_(&cancel_), filename_(filename) {
+HTTPFileLoader::HTTPFileLoader(const ::Path &filename)
+	: url_(filename.ToString()), progress_(&cancel_), filename_(filename) {
 }
 
 void HTTPFileLoader::Prepare() {
@@ -172,7 +172,7 @@ s64 HTTPFileLoader::FileSize() {
 	return filesize_;
 }
 
-std::string HTTPFileLoader::GetPath() const {
+Path HTTPFileLoader::GetPath() const {
 	return filename_;
 }
 

--- a/Core/FileLoaders/HTTPFileLoader.h
+++ b/Core/FileLoaders/HTTPFileLoader.h
@@ -20,6 +20,7 @@
 #include <mutex>
 #include <vector>
 
+#include "Common/File/Path.h"
 #include "Common/Net/HTTPClient.h"
 #include "Common/Net/Resolve.h"
 #include "Common/Net/URL.h"
@@ -28,7 +29,7 @@
 
 class HTTPFileLoader : public FileLoader {
 public:
-	HTTPFileLoader(const std::string &filename);
+	HTTPFileLoader(const ::Path &filename);
 	virtual ~HTTPFileLoader() override;
 
 	bool IsRemote() override {
@@ -38,7 +39,7 @@ public:
 	virtual bool ExistsFast() override;
 	virtual bool IsDirectory() override;
 	virtual s64 FileSize() override;
-	virtual std::string GetPath() const override;
+	virtual Path GetPath() const override;
 
 	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
 		return ReadAt(absolutePos, bytes * count, data, flags) / bytes;
@@ -71,7 +72,7 @@ private:
 	Url url_;
 	http::Client client_;
 	http::RequestProgress progress_;
-	std::string filename_;
+	::Path filename_;
 	bool connected_ = false;
 	bool cancel_ = false;
 	const char *latestError_ = "";

--- a/Core/FileLoaders/LocalFileLoader.cpp
+++ b/Core/FileLoaders/LocalFileLoader.cpp
@@ -113,14 +113,14 @@ bool LocalFileLoader::Exists() {
 	if (handle_ != INVALID_HANDLE_VALUE || IsDirectory()) {
 #endif
 		File::FileInfo info;
-		return File::GetFileInfo(filename_.c_str(), &info);
+		return File::GetFileInfo(filename_, &info);
 	}
 	return false;
 }
 
 bool LocalFileLoader::IsDirectory() {
 	File::FileInfo info;
-	if (File::GetFileInfo(filename_.c_str(), &info)) {
+	if (File::GetFileInfo(filename_, &info)) {
 		return info.isDirectory;
 	}
 	return false;
@@ -131,7 +131,7 @@ s64 LocalFileLoader::FileSize() {
 }
 
 std::string LocalFileLoader::GetPath() const {
-	return filename_;
+	return filename_.ToString();
 }
 
 size_t LocalFileLoader::ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags) {

--- a/Core/FileLoaders/LocalFileLoader.cpp
+++ b/Core/FileLoaders/LocalFileLoader.cpp
@@ -32,7 +32,7 @@
 #endif
 
 #ifndef _WIN32
-LocalFileLoader::LocalFileLoader(int fd, const std::string &filename) : fd_(fd), filename_(filename), isOpenedByFd_(fd != -1) {
+LocalFileLoader::LocalFileLoader(int fd, const Path &filename) : fd_(fd), filename_(filename), isOpenedByFd_(fd != -1) {
 	if (fd != -1) {
 		DetectSizeFd();
 	}
@@ -51,7 +51,7 @@ void LocalFileLoader::DetectSizeFd() {
 }
 #endif
 
-LocalFileLoader::LocalFileLoader(const std::string &filename)
+LocalFileLoader::LocalFileLoader(const Path &filename)
 	: filesize_(0), filename_(filename), isOpenedByFd_(false) {
 	if (filename.empty()) {
 		ERROR_LOG(FILESYS, "LocalFileLoader can't load empty filenames");
@@ -70,9 +70,9 @@ LocalFileLoader::LocalFileLoader(const std::string &filename)
 
 	const DWORD access = GENERIC_READ, share = FILE_SHARE_READ, mode = OPEN_EXISTING, flags = FILE_ATTRIBUTE_NORMAL;
 #if PPSSPP_PLATFORM(UWP)
-	handle_ = CreateFile2(ConvertUTF8ToWString(filename).c_str(), access, share, mode, nullptr);
+	handle_ = CreateFile2(filename.ToWString().c_str(), access, share, mode, nullptr);
 #else
-	handle_ = CreateFile(ConvertUTF8ToWString(filename).c_str(), access, share, nullptr, mode, flags, nullptr);
+	handle_ = CreateFile(filename.ToWString().c_str(), access, share, nullptr, mode, flags, nullptr);
 #endif
 	if (handle_ == INVALID_HANDLE_VALUE) {
 		return;
@@ -128,10 +128,6 @@ bool LocalFileLoader::IsDirectory() {
 
 s64 LocalFileLoader::FileSize() {
 	return filesize_;
-}
-
-std::string LocalFileLoader::GetPath() const {
-	return filename_.ToString();
 }
 
 size_t LocalFileLoader::ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags) {

--- a/Core/FileLoaders/LocalFileLoader.h
+++ b/Core/FileLoaders/LocalFileLoader.h
@@ -23,21 +23,22 @@
 #include "Common/File/Path.h"
 #include "Core/Loaders.h"
 
-
 #ifdef _WIN32
 typedef void *HANDLE;
 #endif
 
 class LocalFileLoader : public FileLoader {
 public:
-	LocalFileLoader(const std::string &filename);
-	LocalFileLoader(const int fd, const std::string &filename);
+	LocalFileLoader(const Path &filename);
+	LocalFileLoader(const int fd, const Path &filename);
 	virtual ~LocalFileLoader();
 
 	virtual bool Exists() override;
 	virtual bool IsDirectory() override;
 	virtual s64 FileSize() override;
-	virtual std::string GetPath() const override;
+	virtual Path GetPath() const override {
+		return filename_;
+	}
 	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override;
 
 private:
@@ -48,7 +49,7 @@ private:
 	HANDLE handle_;
 #endif
 	u64 filesize_;
-	::Path filename_;
+	Path filename_;
 	std::mutex readLock_;
 	bool isOpenedByFd_;
 };

--- a/Core/FileLoaders/LocalFileLoader.h
+++ b/Core/FileLoaders/LocalFileLoader.h
@@ -18,8 +18,12 @@
 #pragma once
 
 #include <mutex>
+
 #include "Common/CommonTypes.h"
+#include "Common/File/Path.h"
 #include "Core/Loaders.h"
+
+
 #ifdef _WIN32
 typedef void *HANDLE;
 #endif
@@ -44,7 +48,7 @@ private:
 	HANDLE handle_;
 #endif
 	u64 filesize_;
-	std::string filename_;
+	::Path filename_;
 	std::mutex readLock_;
 	bool isOpenedByFd_;
 };

--- a/Core/FileSystems/BlobFileSystem.cpp
+++ b/Core/FileSystems/BlobFileSystem.cpp
@@ -128,8 +128,8 @@ bool BlobFileSystem::RemoveFile(const std::string &filename) {
 	return false;
 }
 
-bool BlobFileSystem::GetHostPath(const std::string &inpath, std::string &outpath) {
-	outpath = fileLoader_->GetPath();
+bool BlobFileSystem::GetHostPath(const std::string &inpath, Path &outpath) {
+	outpath = Path(fileLoader_->GetPath());
 	return true;
 }
 

--- a/Core/FileSystems/BlobFileSystem.cpp
+++ b/Core/FileSystems/BlobFileSystem.cpp
@@ -129,7 +129,7 @@ bool BlobFileSystem::RemoveFile(const std::string &filename) {
 }
 
 bool BlobFileSystem::GetHostPath(const std::string &inpath, Path &outpath) {
-	outpath = Path(fileLoader_->GetPath());
+	outpath = fileLoader_->GetPath();
 	return true;
 }
 

--- a/Core/FileSystems/BlobFileSystem.cpp
+++ b/Core/FileSystems/BlobFileSystem.cpp
@@ -128,11 +128,6 @@ bool BlobFileSystem::RemoveFile(const std::string &filename) {
 	return false;
 }
 
-bool BlobFileSystem::GetHostPath(const std::string &inpath, Path &outpath) {
-	outpath = fileLoader_->GetPath();
-	return true;
-}
-
 u64 BlobFileSystem::FreeSpace(const std::string &path) {
 	return 0;
 }

--- a/Core/FileSystems/BlobFileSystem.h
+++ b/Core/FileSystems/BlobFileSystem.h
@@ -52,7 +52,6 @@ public:
 	bool RmDir(const std::string &dirname) override;
 	int  RenameFile(const std::string &from, const std::string &to) override;
 	bool RemoveFile(const std::string &filename) override;
-	bool GetHostPath(const std::string &inpath, Path &outpath) override;
 	u64 FreeSpace(const std::string &path) override;
 
 private:

--- a/Core/FileSystems/BlobFileSystem.h
+++ b/Core/FileSystems/BlobFileSystem.h
@@ -23,6 +23,8 @@
 
 #include <map>
 #include <string>
+
+#include "Common/File/Path.h"
 #include "Core/Loaders.h"
 #include "Core/FileSystems/FileSystem.h"
 
@@ -50,7 +52,7 @@ public:
 	bool RmDir(const std::string &dirname) override;
 	int  RenameFile(const std::string &from, const std::string &to) override;
 	bool RemoveFile(const std::string &filename) override;
-	bool GetHostPath(const std::string &inpath, std::string &outpath) override;
+	bool GetHostPath(const std::string &inpath, Path &outpath) override;
 	u64 FreeSpace(const std::string &path) override;
 
 private:

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -764,12 +764,6 @@ PSPFileInfo DirectoryFileSystem::GetFileInfo(std::string filename) {
 	return ReplayApplyDiskFileInfo(x, CoreTiming::GetGlobalTimeUs());
 }
 
-// Same as GetLocalPath. Confusing.
-bool DirectoryFileSystem::GetHostPath(const std::string &inpath, Path &outpath) {
-	outpath = GetLocalPath(inpath);
-	return true;
-}
-
 #ifdef _WIN32
 #define FILETIME_FROM_UNIX_EPOCH_US 11644473600000000ULL
 
@@ -1172,12 +1166,6 @@ size_t VFSFileSystem::SeekFile(u32 handle, s32 position, FileMove type) {
 		ERROR_LOG(FILESYS,"Cannot seek in file that hasn't been opened: %08x", handle);
 		return 0;
 	}
-}
-
-
-bool VFSFileSystem::GetHostPath(const std::string &inpath, Path &outpath) {
-	// NOT SUPPORTED
-	return false;
 }
 
 std::vector<PSPFileInfo> VFSFileSystem::GetDirListing(std::string path) {

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -70,7 +70,7 @@
 static bool FixFilenameCase(const std::string &path, std::string &filename)
 {
 	// Are we lucky?
-	if (File::Exists(path + filename))
+	if (File::Exists(Path(path + filename)))
 		return true;
 
 	size_t filenameSize = filename.size();  // size in bytes, not characters
@@ -512,7 +512,7 @@ bool DirectoryFileSystem::RmDir(const std::string &dirname) {
 
 #if HOST_IS_CASE_SENSITIVE
 	// Maybe we're lucky?
-	if (File::DeleteDirRecursively(fullName.ToString()))
+	if (File::DeleteDirRecursively(fullName))
 		return (bool)ReplayApplyDisk(ReplayAction::RMDIR, true, CoreTiming::GetGlobalTimeUs());
 
 	// Nope, fix case and try again.  Should we try again?

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -180,9 +180,7 @@ Path DirectoryFileHandle::GetLocalPath(const Path &basePath, std::string localpa
 	if (localpath[0] == '/')
 		localpath.erase(0, 1);
 
-	Path result = basePath / localpath;
-	// TODO?: Windows used to translate to backslashes here.
-	return result;
+	return basePath / localpath;
 }
 
 bool DirectoryFileHandle::Open(const Path &basePath, std::string &fileName, FileAccess access, u32 &error) {

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -163,7 +163,7 @@ bool FixPathCase(const std::string &basePath, std::string &path, FixPathCaseBeha
 
 #endif
 
-DirectoryFileSystem::DirectoryFileSystem(IHandleAllocator *_hAlloc, std::string _basePath, FileSystemFlags _flags) : basePath(_basePath), flags(_flags) {
+DirectoryFileSystem::DirectoryFileSystem(IHandleAllocator *_hAlloc, const Path & _basePath, FileSystemFlags _flags) : basePath(_basePath), flags(_flags) {
 	File::CreateFullPath(basePath);
 	hAlloc = _hAlloc;
 }
@@ -172,7 +172,7 @@ DirectoryFileSystem::~DirectoryFileSystem() {
 	CloseAll();
 }
 
-std::string DirectoryFileHandle::GetLocalPath(const std::string &basePath, std::string localpath)
+Path DirectoryFileHandle::GetLocalPath(const Path &basePath, std::string localpath)
 {
 	if (localpath.empty())
 		return basePath;
@@ -180,23 +180,18 @@ std::string DirectoryFileHandle::GetLocalPath(const std::string &basePath, std::
 	if (localpath[0] == '/')
 		localpath.erase(0, 1);
 
-	std::string result = basePath + localpath;
-#ifdef _WIN32
-	for (char &c : result) {
-		if (c == '/')
-			c = '\\';
-	}
-#endif
+	Path result = basePath / localpath;
+	// TODO?: Windows used to translate to backslashes here.
 	return result;
 }
 
-bool DirectoryFileHandle::Open(const std::string &basePath, std::string &fileName, FileAccess access, u32 &error) {
+bool DirectoryFileHandle::Open(const Path &basePath, std::string &fileName, FileAccess access, u32 &error) {
 	error = 0;
 
 #if HOST_IS_CASE_SENSITIVE
 	if (access & (FILEACCESS_APPEND|FILEACCESS_CREATE|FILEACCESS_WRITE)) {
 		DEBUG_LOG(FILESYS, "Checking case for path %s", fileName.c_str());
-		if (!FixPathCase(basePath, fileName, FPC_PATH_MUST_EXIST)) {
+		if (!FixPathCase(basePath.ToString(), fileName, FPC_PATH_MUST_EXIST)) {
 			error = SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND;
 			return false;  // or go on and attempt (for a better error code than just 0?)
 		}
@@ -204,8 +199,8 @@ bool DirectoryFileHandle::Open(const std::string &basePath, std::string &fileNam
 	// else we try fopen first (in case we're lucky) before simulating case insensitivity
 #endif
 
-	std::string fullName = GetLocalPath(basePath, fileName);
-	VERBOSE_LOG(FILESYS,"Actually opening %s", fullName.c_str());
+	Path fullName = GetLocalPath(basePath, fileName);
+	VERBOSE_LOG(FILESYS, "Actually opening %s", fullName.c_str());
 
 	// On the PSP, truncating doesn't lose data.  If you seek later, you'll recover it.
 	// This is abnormal, so we deviate from the PSP's behavior and truncate on write/close.
@@ -240,9 +235,9 @@ bool DirectoryFileHandle::Open(const std::string &basePath, std::string &fileNam
 
 	// Let's do it!
 #if PPSSPP_PLATFORM(UWP)
-	hFile = CreateFile2(ConvertUTF8ToWString(fullName).c_str(), desired, sharemode, openmode, nullptr);
+	hFile = CreateFile2(fullName.ToWString().c_str(), desired, sharemode, openmode, nullptr);
 #else
-	hFile = CreateFile(ConvertUTF8ToWString(fullName).c_str(), desired, sharemode, 0, openmode, 0, 0);
+	hFile = CreateFile(fullName.ToWString().c_str(), desired, sharemode, 0, openmode, 0, 0);
 #endif
 	bool success = hFile != INVALID_HANDLE_VALUE;
 	if (!success) {
@@ -252,9 +247,9 @@ bool DirectoryFileHandle::Open(const std::string &basePath, std::string &fileNam
 			// Sometimes, the file is locked for write, let's try again.
 			sharemode |= FILE_SHARE_WRITE;
 #if PPSSPP_PLATFORM(UWP)
-			hFile = CreateFile2(ConvertUTF8ToWString(fullName).c_str(), desired, sharemode, openmode, nullptr);
+			hFile = CreateFile2(fullName.ToWString().c_str(), desired, sharemode, openmode, nullptr);
 #else
-			hFile = CreateFile(ConvertUTF8ToWString(fullName).c_str(), desired, sharemode, 0, openmode, 0, 0);
+			hFile = CreateFile(fullName.ToWString().c_str(), desired, sharemode, 0, openmode, 0, 0);
 #endif
 			success = hFile != INVALID_HANDLE_VALUE;
 			if (!success) {
@@ -296,11 +291,11 @@ bool DirectoryFileHandle::Open(const std::string &basePath, std::string &fileNam
 
 #if HOST_IS_CASE_SENSITIVE
 	if (!success && !(access & FILEACCESS_CREATE)) {
-		if (!FixPathCase(basePath, fileName, FPC_PATH_MUST_EXIST)) {
+		if (!FixPathCase(basePath.ToString(), fileName, FPC_PATH_MUST_EXIST)) {
 			error = SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND;
 			return false;
 		}
-		fullName = GetLocalPath(basePath,fileName); 
+		fullName = GetLocalPath(basePath, fileName);
 		const char *fullNameC = fullName.c_str();
 
 		DEBUG_LOG(FILESYS, "Case may have been incorrect, second try opening %s (%s)", fullNameC, fileName.c_str());
@@ -337,7 +332,7 @@ bool DirectoryFileHandle::Open(const std::string &basePath, std::string &fileNam
 #endif
 
 	// Try to detect reads/writes to PSP/GAME to avoid them in replays.
-	if (fullName.find("PSP/GAME/") != fullName.npos || fullName.find("PSP\\GAME\\") != fullName.npos) {
+	if (fullName.FilePathContains("PSP/GAME/")) {
 		inGameDir_ = true;
 	}
 
@@ -479,20 +474,20 @@ void DirectoryFileSystem::CloseAll() {
 	entries.clear();
 }
 
-std::string DirectoryFileSystem::GetLocalPath(std::string localpath) {
-	if (localpath.empty())
+Path DirectoryFileSystem::GetLocalPath(std::string internalPath) {
+	if (internalPath.empty())
 		return basePath;
 
-	if (localpath[0] == '/')
-		localpath.erase(0,1);
+	if (internalPath[0] == '/')
+		internalPath.erase(0, 1);
 	//Convert slashes
 #ifdef _WIN32
-	for (size_t i = 0; i < localpath.size(); i++) {
-		if (localpath[i] == '/')
-			localpath[i] = '\\';
+	for (size_t i = 0; i < internalPath.size(); i++) {
+		if (internalPath[i] == '/')
+			internalPath[i] = '\\';
 	}
 #endif
-	return basePath + localpath;
+	return basePath / internalPath;
 }
 
 bool DirectoryFileSystem::MkDir(const std::string &dirname) {
@@ -502,7 +497,7 @@ bool DirectoryFileSystem::MkDir(const std::string &dirname) {
 	// duplicate (different case) directories
 
 	std::string fixedCase = dirname;
-	if (!FixPathCase(basePath,fixedCase, FPC_PARTIAL_ALLOWED))
+	if (!FixPathCase(basePath.ToString(), fixedCase, FPC_PARTIAL_ALLOWED))
 		result = false;
 	else
 		result = File::CreateFullPath(GetLocalPath(fixedCase));
@@ -513,19 +508,19 @@ bool DirectoryFileSystem::MkDir(const std::string &dirname) {
 }
 
 bool DirectoryFileSystem::RmDir(const std::string &dirname) {
-	std::string fullName = GetLocalPath(dirname);
+	Path fullName = GetLocalPath(dirname);
 
 #if HOST_IS_CASE_SENSITIVE
 	// Maybe we're lucky?
-	if (File::DeleteDirRecursively(fullName))
+	if (File::DeleteDirRecursively(fullName.ToString()))
 		return (bool)ReplayApplyDisk(ReplayAction::RMDIR, true, CoreTiming::GetGlobalTimeUs());
 
 	// Nope, fix case and try again.  Should we try again?
-	fullName = dirname;
-	if (!FixPathCase(basePath,fullName, FPC_FILE_MUST_EXIST))
+	std::string fullPath = dirname;
+	if (!FixPathCase(basePath.ToString(), fullPath, FPC_FILE_MUST_EXIST))
 		return (bool)ReplayApplyDisk(ReplayAction::RMDIR, false, CoreTiming::GetGlobalTimeUs());
 
-	fullName = GetLocalPath(fullName);
+	fullName = GetLocalPath(fullPath);
 #endif
 
 /*#ifdef _WIN32
@@ -533,7 +528,7 @@ bool DirectoryFileSystem::RmDir(const std::string &dirname) {
 #else
 	return 0 == rmdir(fullName.c_str());
 #endif*/
-	bool result = File::DeleteDirRecursively(fullName);
+	bool result = File::DeleteDirRecursively(fullName.ToString());
 	return ReplayApplyDisk(ReplayAction::RMDIR, result, CoreTiming::GetGlobalTimeUs()) != 0;
 }
 
@@ -554,36 +549,35 @@ int DirectoryFileSystem::RenameFile(const std::string &from, const std::string &
 	if (from == fullTo)
 		return ReplayApplyDisk(ReplayAction::FILE_RENAME, SCE_KERNEL_ERROR_ERRNO_FILE_ALREADY_EXISTS, CoreTiming::GetGlobalTimeUs());
 
-	std::string fullFrom = GetLocalPath(from);
+	Path fullFrom = GetLocalPath(from);
 
 #if HOST_IS_CASE_SENSITIVE
 	// In case TO should overwrite a file with different case.  Check error code?
-	if (!FixPathCase(basePath,fullTo, FPC_PATH_MUST_EXIST))
+	if (!FixPathCase(basePath.ToString(), fullTo, FPC_PATH_MUST_EXIST))
 		return ReplayApplyDisk(ReplayAction::FILE_RENAME, -1, CoreTiming::GetGlobalTimeUs());
 #endif
 
-	fullTo = GetLocalPath(fullTo);
-	const char * fullToC = fullTo.c_str();
+	Path fullToPath = GetLocalPath(fullTo);
 
 #ifdef _WIN32
-	bool retValue = (MoveFileEx(ConvertUTF8ToWString(fullFrom).c_str(), ConvertUTF8ToWString(fullToC).c_str(), 0) == TRUE);
+	bool retValue = (MoveFileEx(fullFrom.ToWString().c_str(), fullToPath.ToWString().c_str(), 0) == TRUE);
 #else
-	bool retValue = (0 == rename(fullFrom.c_str(), fullToC));
+	bool retValue = (0 == rename(fullFrom.c_str(), fullToPath.c_str()));
 #endif
 
 #if HOST_IS_CASE_SENSITIVE
 	if (! retValue)
 	{
 		// May have failed due to case sensitivity on FROM, so try again.  Check error code?
-		fullFrom = from;
-		if (!FixPathCase(basePath,fullFrom, FPC_FILE_MUST_EXIST))
+		std::string fullFromPath = from;
+		if (!FixPathCase(basePath.ToString(), fullFromPath, FPC_FILE_MUST_EXIST))
 			return ReplayApplyDisk(ReplayAction::FILE_RENAME, -1, CoreTiming::GetGlobalTimeUs());
-		fullFrom = GetLocalPath(fullFrom);
+		fullFrom = GetLocalPath(fullFromPath);
 
 #ifdef _WIN32
-		retValue = (MoveFile(fullFrom.c_str(), fullToC) == TRUE);
+		retValue = (MoveFile(fullFrom.c_str(), fullToPath.c_str()) == TRUE);
 #else
-		retValue = (0 == rename(fullFrom.c_str(), fullToC));
+		retValue = (0 == rename(fullFrom.c_str(), fullToPath.c_str()));
 #endif
 	}
 #endif
@@ -594,7 +588,7 @@ int DirectoryFileSystem::RenameFile(const std::string &from, const std::string &
 }
 
 bool DirectoryFileSystem::RemoveFile(const std::string &filename) {
-	std::string fullName = GetLocalPath(filename);
+	Path fullName = GetLocalPath(filename);
 #ifdef _WIN32
 	bool retValue = (::DeleteFileA(fullName.c_str()) == TRUE);
 #else
@@ -605,10 +599,10 @@ bool DirectoryFileSystem::RemoveFile(const std::string &filename) {
 	if (! retValue)
 	{
 		// May have failed due to case sensitivity, so try again.  Try even if it fails?
-		fullName = filename;
-		if (!FixPathCase(basePath,fullName, FPC_FILE_MUST_EXIST))
+		std::string fullNamePath = filename;
+		if (!FixPathCase(basePath.ToString(), fullNamePath, FPC_FILE_MUST_EXIST))
 			return (bool)ReplayApplyDisk(ReplayAction::FILE_REMOVE, false, CoreTiming::GetGlobalTimeUs());
-		fullName = GetLocalPath(fullName);
+		fullName = GetLocalPath(fullNamePath);
 
 #ifdef _WIN32
 		retValue = (::DeleteFileA(fullName.c_str()) == TRUE);
@@ -736,10 +730,10 @@ PSPFileInfo DirectoryFileSystem::GetFileInfo(std::string filename) {
 	PSPFileInfo x;
 	x.name = filename;
 
-	std::string fullName = GetLocalPath(filename);
+	Path fullName = GetLocalPath(filename);
 	if (!File::Exists(fullName)) {
 #if HOST_IS_CASE_SENSITIVE
-		if (! FixPathCase(basePath,filename, FPC_FILE_MUST_EXIST))
+		if (! FixPathCase(basePath.ToString(), filename, FPC_FILE_MUST_EXIST))
 			return ReplayApplyDiskFileInfo(x, CoreTiming::GetGlobalTimeUs());
 		fullName = GetLocalPath(filename);
 
@@ -754,7 +748,7 @@ PSPFileInfo DirectoryFileSystem::GetFileInfo(std::string filename) {
 
 	if (x.type != FILETYPE_DIRECTORY) {
 		File::FileInfo info;
-		if (!File::GetFileInfo(fullName.c_str(), &info)) {
+		if (!File::GetFileInfo(fullName, &info)) {
 			ERROR_LOG(FILESYS, "DirectoryFileSystem::GetFileInfo: GetFileInfo failed: %s", fullName.c_str());
 		} else {
 			x.size = info.size;
@@ -772,7 +766,8 @@ PSPFileInfo DirectoryFileSystem::GetFileInfo(std::string filename) {
 	return ReplayApplyDiskFileInfo(x, CoreTiming::GetGlobalTimeUs());
 }
 
-bool DirectoryFileSystem::GetHostPath(const std::string &inpath, std::string &outpath) {
+// Same as GetLocalPath. Confusing.
+bool DirectoryFileSystem::GetHostPath(const std::string &inpath, Path &outpath) {
 	outpath = GetLocalPath(inpath);
 	return true;
 }
@@ -858,9 +853,9 @@ std::vector<PSPFileInfo> DirectoryFileSystem::GetDirListing(std::string path) {
 	WIN32_FIND_DATA findData;
 	HANDLE hFind;
 
-	std::string w32path = GetLocalPath(path) + "\\*.*";
+	std::wstring w32path = GetLocalPath(path).ToWString() + L"\\*.*";
 
-	hFind = FindFirstFileEx(ConvertUTF8ToWString(w32path).c_str(), FindExInfoStandard, &findData, FindExSearchNameMatch, NULL, 0);
+	hFind = FindFirstFileEx(w32path.c_str(), FindExInfoStandard, &findData, FindExSearchNameMatch, NULL, 0);
 
 	if (hFind == INVALID_HANDLE_VALUE) {
 		// Just return the empty array.
@@ -905,11 +900,11 @@ std::vector<PSPFileInfo> DirectoryFileSystem::GetDirListing(std::string path) {
 	FindClose(hFind);
 #else
 	dirent *dirp;
-	std::string localPath = GetLocalPath(path);
+	Path localPath = GetLocalPath(path);
 	DIR *dp = opendir(localPath.c_str());
 
 #if HOST_IS_CASE_SENSITIVE
-	if (dp == NULL && FixPathCase(basePath,path, FPC_FILE_MUST_EXIST)) {
+	if (dp == NULL && FixPathCase(basePath.ToString(), path, FPC_FILE_MUST_EXIST)) {
 		// May have failed due to case sensitivity, try again
 		localPath = GetLocalPath(path);
 		dp = opendir(localPath.c_str());
@@ -925,7 +920,7 @@ std::vector<PSPFileInfo> DirectoryFileSystem::GetDirListing(std::string path) {
 	while ((dirp = readdir(dp)) != NULL) {
 		PSPFileInfo entry;
 		struct stat s;
-		std::string fullName = GetLocalPath(path) + "/"+dirp->d_name;
+		Path fullName = GetLocalPath(path) / std::string(dirp->d_name);
 		stat(fullName.c_str(), &s);
 		if (S_ISDIR(s.st_mode))
 			entry.type = FILETYPE_DIRECTORY;
@@ -957,15 +952,15 @@ std::vector<PSPFileInfo> DirectoryFileSystem::GetDirListing(std::string path) {
 
 u64 DirectoryFileSystem::FreeSpace(const std::string &path) {
 	uint64_t result = 0;
-	if (free_disk_space(GetLocalPath(path), result)) {
+	if (free_disk_space(GetLocalPath(path).ToString(), result)) {
 		return ReplayApplyDisk64(ReplayAction::FREESPACE, result, CoreTiming::GetGlobalTimeUs());
 	}
 
 #if HOST_IS_CASE_SENSITIVE
 	std::string fixedCase = path;
-	if (FixPathCase(basePath, fixedCase, FPC_FILE_MUST_EXIST)) {
+	if (FixPathCase(basePath.ToString(), fixedCase, FPC_FILE_MUST_EXIST)) {
 		// May have failed due to case sensitivity, try again.
-		if (free_disk_space(GetLocalPath(fixedCase), result)) {
+		if (free_disk_space(GetLocalPath(fixedCase).ToString(), result)) {
 			return ReplayApplyDisk64(ReplayAction::FREESPACE, result, CoreTiming::GetGlobalTimeUs());
 		}
 	}
@@ -1182,7 +1177,7 @@ size_t VFSFileSystem::SeekFile(u32 handle, s32 position, FileMove type) {
 }
 
 
-bool VFSFileSystem::GetHostPath(const std::string &inpath, std::string &outpath) {
+bool VFSFileSystem::GetHostPath(const std::string &inpath, Path &outpath) {
 	// NOT SUPPORTED
 	return false;
 }

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -528,7 +528,7 @@ bool DirectoryFileSystem::RmDir(const std::string &dirname) {
 #else
 	return 0 == rmdir(fullName.c_str());
 #endif*/
-	bool result = File::DeleteDirRecursively(fullName.ToString());
+	bool result = File::DeleteDirRecursively(fullName);
 	return ReplayApplyDisk(ReplayAction::RMDIR, result, CoreTiming::GetGlobalTimeUs()) != 0;
 }
 

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -20,6 +20,8 @@
 // TODO: Remove the Windows-specific code, FILE is fine there too.
 
 #include <map>
+
+#include "Common/File/Path.h"
 #include "Core/FileSystems/FileSystem.h"
 
 #ifdef _WIN32
@@ -74,8 +76,8 @@ struct DirectoryFileHandle {
 	DirectoryFileHandle(Flags flags) : replay_(flags != SKIP_REPLAY) {
 	}
 
-	std::string GetLocalPath(const std::string &basePath, std::string localpath);
-	bool Open(const std::string &basePath, std::string &fileName, FileAccess access, u32 &err);
+	Path GetLocalPath(const Path &basePath, std::string localpath);
+	bool Open(const Path &basePath, std::string &fileName, FileAccess access, u32 &err);
 	size_t Read(u8* pointer, s64 size);
 	size_t Write(const u8* pointer, s64 size);
 	size_t Seek(s32 position, FileMove type);
@@ -84,7 +86,7 @@ struct DirectoryFileHandle {
 
 class DirectoryFileSystem : public IFileSystem {
 public:
-	DirectoryFileSystem(IHandleAllocator *_hAlloc, std::string _basePath, FileSystemFlags _flags = FileSystemFlags::NONE);
+	DirectoryFileSystem(IHandleAllocator *_hAlloc, const Path &_basePath, FileSystemFlags _flags = FileSystemFlags::NONE);
 	~DirectoryFileSystem();
 
 	void CloseAll();
@@ -107,7 +109,7 @@ public:
 	bool RmDir(const std::string &dirname) override;
 	int  RenameFile(const std::string &from, const std::string &to) override;
 	bool RemoveFile(const std::string &filename) override;
-	bool GetHostPath(const std::string &inpath, std::string &outpath) override;
+	bool GetHostPath(const std::string &inpath, Path &outpath) override;
 	FileSystemFlags Flags() override { return flags; }
 	u64 FreeSpace(const std::string &path) override;
 
@@ -120,11 +122,11 @@ private:
 
 	typedef std::map<u32, OpenFileEntry> EntryMap;
 	EntryMap entries;
-	std::string basePath;
+	Path basePath;
 	IHandleAllocator *hAlloc;
 	FileSystemFlags flags;
 	// In case of Windows: Translate slashes, etc.
-	std::string GetLocalPath(std::string localpath);
+	Path GetLocalPath(std::string internalPath);
 };
 
 // VFSFileSystem: Ability to map in Android APK paths as well! Does not support all features, only meant for fonts.
@@ -152,7 +154,7 @@ public:
 	bool RmDir(const std::string &dirname) override;
 	int  RenameFile(const std::string &from, const std::string &to) override;
 	bool RemoveFile(const std::string &filename) override;
-	bool GetHostPath(const std::string &inpath, std::string &outpath) override;
+	bool GetHostPath(const std::string &inpath, Path &outpath) override;
 	FileSystemFlags Flags() override { return FileSystemFlags::FLASH; }
 	u64 FreeSpace(const std::string &path) override { return 0; }
 

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -109,7 +109,6 @@ public:
 	bool RmDir(const std::string &dirname) override;
 	int  RenameFile(const std::string &from, const std::string &to) override;
 	bool RemoveFile(const std::string &filename) override;
-	bool GetHostPath(const std::string &inpath, Path &outpath) override;
 	FileSystemFlags Flags() override { return flags; }
 	u64 FreeSpace(const std::string &path) override;
 
@@ -154,7 +153,6 @@ public:
 	bool RmDir(const std::string &dirname) override;
 	int  RenameFile(const std::string &from, const std::string &to) override;
 	bool RemoveFile(const std::string &filename) override;
-	bool GetHostPath(const std::string &inpath, Path &outpath) override;
 	FileSystemFlags Flags() override { return FileSystemFlags::FLASH; }
 	u64 FreeSpace(const std::string &path) override { return 0; }
 

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -23,6 +23,7 @@
 #include <ctime>
 
 #include "Common.h"
+#include "Common/File/Path.h"
 #include "Core/HLE/sceKernel.h"
 
 enum FileAccess {
@@ -130,7 +131,7 @@ public:
 	virtual bool     RmDir(const std::string &dirname) = 0;
 	virtual int      RenameFile(const std::string &from, const std::string &to) = 0;
 	virtual bool     RemoveFile(const std::string &filename) = 0;
-	virtual bool     GetHostPath(const std::string &inpath, std::string &outpath) = 0;
+	virtual bool     GetHostPath(const std::string &inpath, Path &outpath) = 0;
 	virtual int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) = 0;
 	virtual PSPDevType DevType(u32 handle) = 0;
 	virtual FileSystemFlags Flags() = 0;
@@ -156,7 +157,7 @@ public:
 	virtual bool RmDir(const std::string &dirname) override {return false;}
 	virtual int RenameFile(const std::string &from, const std::string &to) override {return -1;}
 	virtual bool RemoveFile(const std::string &filename) override {return false;}
-	virtual bool GetHostPath(const std::string &inpath, std::string &outpath) override {return false;}
+	virtual bool GetHostPath(const std::string &inpath, Path &outpath) override {return false;}
 	virtual int Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override {return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED; }
 	virtual PSPDevType DevType(u32 handle) override { return PSPDevType::INVALID; }
 	virtual FileSystemFlags Flags() override { return FileSystemFlags::NONE; }

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -131,7 +131,6 @@ public:
 	virtual bool     RmDir(const std::string &dirname) = 0;
 	virtual int      RenameFile(const std::string &from, const std::string &to) = 0;
 	virtual bool     RemoveFile(const std::string &filename) = 0;
-	virtual bool     GetHostPath(const std::string &inpath, Path &outpath) = 0;
 	virtual int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) = 0;
 	virtual PSPDevType DevType(u32 handle) = 0;
 	virtual FileSystemFlags Flags() = 0;
@@ -157,7 +156,6 @@ public:
 	virtual bool RmDir(const std::string &dirname) override {return false;}
 	virtual int RenameFile(const std::string &from, const std::string &to) override {return -1;}
 	virtual bool RemoveFile(const std::string &filename) override {return false;}
-	virtual bool GetHostPath(const std::string &inpath, Path &outpath) override {return false;}
 	virtual int Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override {return SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED; }
 	virtual PSPDevType DevType(u32 handle) override { return PSPDevType::INVALID; }
 	virtual FileSystemFlags Flags() override { return FileSystemFlags::NONE; }

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -182,7 +182,7 @@ void ISOFileSystem::ReadDirectory(TreeEntry *root) {
 		u8 theSector[2048];
 		if (!blockDevice->ReadBlock(secnum, theSector)) {
 			blockDevice->NotifyReadError();
-			ERROR_LOG(FILESYS, "Error reading block for directory %s - skipping", root->name.c_str());
+			ERROR_LOG(FILESYS, "Error reading block for directory '%s' in sector %d - skipping", root->name.c_str(), secnum);
 			root->valid = true;  // Prevents re-reading
 			return;
 		}

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -48,7 +48,7 @@ public:
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size) override;
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec) override;
 
-	bool GetHostPath(const std::string &inpath, std::string &outpath) override {return false;}
+	bool GetHostPath(const std::string &inpath, Path &outpath) override {return false;}
 	bool MkDir(const std::string &dirname) override {return false;}
 	bool RmDir(const std::string &dirname) override { return false; }
 	int  RenameFile(const std::string &from, const std::string &to) override { return -1; }
@@ -146,7 +146,7 @@ public:
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec) override {
 		return isoFileSystem_->WriteFile(handle, pointer, size, usec);
 	}
-	bool GetHostPath(const std::string &inpath, std::string &outpath) override { return false; }
+	bool GetHostPath(const std::string &inpath, Path &outpath) override { return false; }
 	bool MkDir(const std::string &dirname) override { return false; }
 	bool RmDir(const std::string &dirname) override { return false; }
 	int  RenameFile(const std::string &from, const std::string &to) override { return -1; }

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -48,7 +48,6 @@ public:
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size) override;
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec) override;
 
-	bool GetHostPath(const std::string &inpath, Path &outpath) override {return false;}
 	bool MkDir(const std::string &dirname) override {return false;}
 	bool RmDir(const std::string &dirname) override { return false; }
 	int  RenameFile(const std::string &from, const std::string &to) override { return -1; }
@@ -146,7 +145,6 @@ public:
 	size_t WriteFile(u32 handle, const u8 *pointer, s64 size, int &usec) override {
 		return isoFileSystem_->WriteFile(handle, pointer, size, usec);
 	}
-	bool GetHostPath(const std::string &inpath, Path &outpath) override { return false; }
 	bool MkDir(const std::string &dirname) override { return false; }
 	bool RmDir(const std::string &dirname) override { return false; }
 	int  RenameFile(const std::string &from, const std::string &to) override { return -1; }

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -377,7 +377,7 @@ PSPFileInfo MetaFileSystem::GetFileInfo(std::string filename)
 	}
 }
 
-bool MetaFileSystem::GetHostPath(const std::string &inpath, std::string &outpath)
+bool MetaFileSystem::GetHostPath(const std::string &inpath, Path &outpath)
 {
 	std::lock_guard<std::recursive_mutex> guard(lock);
 	std::string of;

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -377,19 +377,6 @@ PSPFileInfo MetaFileSystem::GetFileInfo(std::string filename)
 	}
 }
 
-bool MetaFileSystem::GetHostPath(const std::string &inpath, Path &outpath)
-{
-	std::lock_guard<std::recursive_mutex> guard(lock);
-	std::string of;
-	IFileSystem *system;
-	int error = MapFilePath(inpath, of, &system);
-	if (error == 0) {
-		return system->GetHostPath(of, outpath);
-	} else {
-		return false;
-	}
-}
-
 std::vector<PSPFileInfo> MetaFileSystem::GetDirListing(std::string path)
 {
 	std::lock_guard<std::recursive_mutex> guard(lock);

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -93,9 +93,6 @@ public:
 
 	std::string NormalizePrefix(std::string prefix) const;
 
-	// Only possible if a file system is a DirectoryFileSystem or similar.
-	bool GetHostPath(const std::string &inpath, Path &outpath) override;
-
 	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
 	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override;
 	void     CloseFile(u32 handle) override;
@@ -106,8 +103,7 @@ public:
 	size_t   SeekFile(u32 handle, s32 position, FileMove type) override;
 	PSPFileInfo GetFileInfo(std::string filename) override;
 	bool     OwnsHandle(u32 handle) override { return false; }
-	inline size_t GetSeekPos(u32 handle)
-	{
+	inline size_t GetSeekPos(u32 handle) {
 		return SeekFile(handle, 0, FILEMOVE_CURRENT);
 	}
 

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -94,7 +94,7 @@ public:
 	std::string NormalizePrefix(std::string prefix) const;
 
 	// Only possible if a file system is a DirectoryFileSystem or similar.
-	bool GetHostPath(const std::string &inpath, std::string &outpath) override;
+	bool GetHostPath(const std::string &inpath, Path &outpath) override;
 
 	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
 	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override;

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -646,12 +646,6 @@ PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {
 	return x;
 }
 
-bool VirtualDiscFileSystem::GetHostPath(const std::string &inpath, Path &outpath)
-{
-	ERROR_LOG(FILESYS,"VirtualDiscFileSystem: Retrieving host path");
-	return false;
-}
-
 #ifdef _WIN32
 #define FILETIME_FROM_UNIX_EPOCH_US 11644473600000000ULL
 

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -50,8 +50,8 @@
 
 const std::string INDEX_FILENAME = ".ppsspp-index.lst";
 
-VirtualDiscFileSystem::VirtualDiscFileSystem(IHandleAllocator *_hAlloc, std::string _basePath)
-	: basePath(_basePath),currentBlockIndex(0) {
+VirtualDiscFileSystem::VirtualDiscFileSystem(IHandleAllocator *_hAlloc, const Path &_basePath)
+	: basePath(_basePath), currentBlockIndex(0) {
 	hAlloc = _hAlloc;
 	LoadFileListIndex();
 }
@@ -77,13 +77,6 @@ void VirtualDiscFileSystem::LoadFileListIndex() {
 	if (!f) {
 		return;
 	}
-
-	/*
-	in.open(filename.c_str(), std::ios::in);
-	if (in.fail()) {
->>>>>>> 52a34c2de (Introduce Path, start using it all over the place.)
-		return;
-	}*/
 
 	std::string buf;
 	static const int MAX_LINE_SIZE = 2048;

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -52,15 +52,6 @@ const std::string INDEX_FILENAME = ".ppsspp-index.lst";
 
 VirtualDiscFileSystem::VirtualDiscFileSystem(IHandleAllocator *_hAlloc, std::string _basePath)
 	: basePath(_basePath),currentBlockIndex(0) {
-
-#ifdef _WIN32
-		if (!endsWith(basePath, "\\") && !endsWith(basePath, "/"))
-			basePath = basePath + "\\";
-#else
-		if (!endsWith(basePath, "/"))
-			basePath = basePath + "/";
-#endif
-
 	hAlloc = _hAlloc;
 	LoadFileListIndex();
 }
@@ -77,7 +68,7 @@ VirtualDiscFileSystem::~VirtualDiscFileSystem() {
 }
 
 void VirtualDiscFileSystem::LoadFileListIndex() {
-	const std::string filename = basePath + INDEX_FILENAME;
+	const Path filename = basePath / INDEX_FILENAME;
 	if (!File::Exists(filename)) {
 		return;
 	}
@@ -86,6 +77,13 @@ void VirtualDiscFileSystem::LoadFileListIndex() {
 	if (!f) {
 		return;
 	}
+
+	/*
+	in.open(filename.c_str(), std::ios::in);
+	if (in.fail()) {
+>>>>>>> 52a34c2de (Introduce Path, start using it all over the place.)
+		return;
+	}*/
 
 	std::string buf;
 	static const int MAX_LINE_SIZE = 2048;
@@ -144,14 +142,14 @@ void VirtualDiscFileSystem::LoadFileListIndex() {
 		entry.firstBlock = strtol(line.c_str(), NULL, 16);
 		if (entry.handler != NULL && entry.handler->IsValid()) {
 			HandlerFileHandle temp = entry.handler;
-			if (temp.Open(basePath, entry.fileName, FILEACCESS_READ)) {
+			if (temp.Open(basePath.ToString(), entry.fileName, FILEACCESS_READ)) {
 				entry.totalSize = (u32)temp.Seek(0, FILEMOVE_END);
 				temp.Close();
 			} else {
 				ERROR_LOG(FILESYS, "Unable to open virtual file: %s", entry.fileName.c_str());
 			}
 		} else {
-			entry.totalSize = File::GetFileSize(GetLocalPath(entry.fileName));
+			entry.totalSize = File::GetFileSize(GetLocalPath(entry.fileName).ToString());
 		}
 
 		// Try to keep currentBlockIndex sane, in case there are other files.
@@ -248,7 +246,7 @@ void VirtualDiscFileSystem::DoState(PointerWrap &p)
 	// We don't savestate handlers (loaded on fs load), but if they change, it may not load properly.
 }
 
-std::string VirtualDiscFileSystem::GetLocalPath(std::string localpath) {
+Path VirtualDiscFileSystem::GetLocalPath(std::string localpath) {
 	if (localpath.empty())
 		return basePath;
 
@@ -261,7 +259,7 @@ std::string VirtualDiscFileSystem::GetLocalPath(std::string localpath) {
 			localpath[i] = '\\';
 	}
 #endif
-	return basePath + localpath;
+	return basePath / localpath;
 }
 
 int VirtualDiscFileSystem::getFileListIndex(std::string &fileName)
@@ -280,10 +278,10 @@ int VirtualDiscFileSystem::getFileListIndex(std::string &fileName)
 	}
 
 	// unknown file - add it
-	std::string fullName = GetLocalPath(fileName);
+	Path fullName = GetLocalPath(fileName);
 	if (! File::Exists(fullName)) {
 #if HOST_IS_CASE_SENSITIVE
-		if (! FixPathCase(basePath,fileName, FPC_FILE_MUST_EXIST))
+		if (! FixPathCase(basePath.ToString(), fileName, FPC_FILE_MUST_EXIST))
 			return -1;
 		fullName = GetLocalPath(fileName);
 
@@ -300,7 +298,7 @@ int VirtualDiscFileSystem::getFileListIndex(std::string &fileName)
 
 	FileListEntry entry = {""};
 	entry.fileName = normalized;
-	entry.totalSize = File::GetFileSize(fullName);
+	entry.totalSize = File::GetFileSize(fullName.ToString());
 	entry.firstBlock = currentBlockIndex;
 	currentBlockIndex += (entry.totalSize+2047)/2048;
 
@@ -599,7 +597,7 @@ PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {
 		x.access = 0555;
 
 		HandlerFileHandle temp = fileList[fileIndex].handler;
-		if (temp.Open(basePath, filename, FILEACCESS_READ)) {
+		if (temp.Open(basePath.ToString(), filename, FILEACCESS_READ)) {
 			x.exists = true;
 			x.size = temp.Seek(0, FILEMOVE_END);
 			temp.Close();
@@ -609,10 +607,10 @@ PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {
 		return x;
 	}
 
-	std::string fullName = GetLocalPath(filename);
-	if (! File::Exists(fullName)) {
+	Path fullName = GetLocalPath(filename);
+	if (!File::Exists(fullName)) {
 #if HOST_IS_CASE_SENSITIVE
-		if (! FixPathCase(basePath,filename, FPC_FILE_MUST_EXIST))
+		if (! FixPathCase(basePath.ToString(), filename, FPC_FILE_MUST_EXIST))
 			return x;
 		fullName = GetLocalPath(filename);
 
@@ -633,7 +631,7 @@ PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {
 
 	if (x.type != FILETYPE_DIRECTORY) {
 		File::FileInfo details;
-		if (!File::GetFileInfo(fullName.c_str(), &details)) {
+		if (!File::GetFileInfo(fullName, &details)) {
 			ERROR_LOG(FILESYS, "DirectoryFileSystem::GetFileInfo: GetFileInfo failed: %s", fullName.c_str());
 			x.size = 0;
 			x.access = 0;
@@ -655,7 +653,7 @@ PSPFileInfo VirtualDiscFileSystem::GetFileInfo(std::string filename) {
 	return x;
 }
 
-bool VirtualDiscFileSystem::GetHostPath(const std::string &inpath, std::string &outpath)
+bool VirtualDiscFileSystem::GetHostPath(const std::string &inpath, Path &outpath)
 {
 	ERROR_LOG(FILESYS,"VirtualDiscFileSystem: Retrieving host path");
 	return false;
@@ -683,9 +681,9 @@ std::vector<PSPFileInfo> VirtualDiscFileSystem::GetDirListing(std::string path)
 
 	// TODO: Handler files that are virtual might not be listed.
 
-	std::string w32path = GetLocalPath(path) + "\\*.*";
+	std::wstring w32path = GetLocalPath(path).ToWString() + L"\\*.*";
 
-	hFind = FindFirstFileEx(ConvertUTF8ToWString(w32path).c_str(), FindExInfoStandard, &findData, FindExSearchNameMatch, NULL, 0);
+	hFind = FindFirstFileEx(w32path.c_str(), FindExInfoStandard, &findData, FindExSearchNameMatch, NULL, 0);
 
 	if (hFind == INVALID_HANDLE_VALUE) {
 		return myVector; //the empty list
@@ -720,11 +718,11 @@ std::vector<PSPFileInfo> VirtualDiscFileSystem::GetDirListing(std::string path)
 	FindClose(hFind);
 #else
 	dirent *dirp;
-	std::string localPath = GetLocalPath(path);
+	Path localPath = GetLocalPath(path);
 	DIR *dp = opendir(localPath.c_str());
 
 #if HOST_IS_CASE_SENSITIVE
-	if(dp == NULL && FixPathCase(basePath,path, FPC_FILE_MUST_EXIST)) {
+	if(dp == NULL && FixPathCase(basePath.ToString(), path, FPC_FILE_MUST_EXIST)) {
 		// May have failed due to case sensitivity, try again
 		localPath = GetLocalPath(path);
 		dp = opendir(localPath.c_str());
@@ -743,7 +741,7 @@ std::vector<PSPFileInfo> VirtualDiscFileSystem::GetDirListing(std::string path)
 
 		PSPFileInfo entry;
 		struct stat s;
-		std::string fullName = GetLocalPath(path) + "/"+dirp->d_name;
+		std::string fullName = (GetLocalPath(path) / std::string(dirp->d_name)).ToString();
 		stat(fullName.c_str(), &s);
 		if (S_ISDIR(s.st_mode))
 			entry.type = FILETYPE_DIRECTORY;

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -27,7 +27,7 @@
 
 class VirtualDiscFileSystem: public IFileSystem {
 public:
-	VirtualDiscFileSystem(IHandleAllocator *_hAlloc, std::string _basePath);
+	VirtualDiscFileSystem(IHandleAllocator *_hAlloc, const Path &_basePath);
 	~VirtualDiscFileSystem();
 
 	void DoState(PointerWrap &p) override;

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -40,7 +40,6 @@ public:
 	bool     OwnsHandle(u32 handle) override;
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override;
 	PSPDevType DevType(u32 handle) override;
-	bool GetHostPath(const std::string &inpath, Path &outpath) override;
 	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
 	FileSystemFlags Flags() override { return FileSystemFlags::UMD; }
 	u64  FreeSpace(const std::string &path) override { return 0; }

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -21,6 +21,7 @@
 
 #include <map>
 
+#include "Common/File/Path.h"
 #include "Core/FileSystems/FileSystem.h"
 #include "Core/FileSystems/DirectoryFileSystem.h"
 
@@ -39,7 +40,7 @@ public:
 	bool     OwnsHandle(u32 handle) override;
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override;
 	PSPDevType DevType(u32 handle) override;
-	bool GetHostPath(const std::string &inpath, std::string &outpath) override;
+	bool GetHostPath(const std::string &inpath, Path &outpath) override;
 	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
 	FileSystemFlags Flags() override { return FileSystemFlags::UMD; }
 	u64  FreeSpace(const std::string &path) override { return 0; }
@@ -57,7 +58,7 @@ private:
 	// Warning: modifies input string.
 	int getFileListIndex(std::string &fileName);
 	int getFileListIndex(u32 accessBlock, u32 accessSize, bool blockMode = false);
-	std::string GetLocalPath(std::string localpath);
+	Path GetLocalPath(std::string localpath);
 
 	typedef void *HandlerLibrary;
 	typedef int HandlerHandle;
@@ -99,7 +100,7 @@ private:
 		HandlerFileHandle(Handler *handler_) : handler(handler_), handle(-1) {
 		}
 
-		bool Open(std::string& basePath, std::string& fileName, FileAccess access) {
+		bool Open(const std::string& basePath, const std::string& fileName, FileAccess access) {
 			// Ignore access, read only.
 			handle = handler->Open(basePath.c_str(), fileName.c_str());
 			return handle > 0;
@@ -135,11 +136,11 @@ private:
 		u64 startOffset;	// only used by lbn files
 		u64 size;			// only used by lbn files
 
-		bool Open(std::string& basePath, std::string& fileName, FileAccess access) {
+		bool Open(const Path &basePath, std::string& fileName, FileAccess access) {
 			// Ignored, we're read only.
 			u32 err;
 			if (handler.IsValid()) {
-				return handler.Open(basePath, fileName, access);
+				return handler.Open(basePath.ToString(), fileName, access);
 			} else {
 				return hFile.Open(basePath, fileName, access, err);
 			}
@@ -170,7 +171,7 @@ private:
 	typedef std::map<u32, OpenFileEntry> EntryMap;
 	EntryMap entries;
 	IHandleAllocator *hAlloc;
-	std::string basePath;
+	Path basePath;
 
 	struct FileListEntry {
 		std::string fileName;

--- a/Core/HLE/Plugins.cpp
+++ b/Core/HLE/Plugins.cpp
@@ -83,7 +83,7 @@ static PluginInfo ReadPluginIni(const std::string &subdir, IniFile &ini) {
 
 static std::vector<PluginInfo> FindPlugins(const std::string &gameID, const std::string &lang) {
 	std::vector<File::FileInfo> pluginDirs;
-	GetFilesInDir(GetSysDirectory(DIRECTORY_PLUGINS).c_str(), &pluginDirs);
+	GetFilesInDir(GetSysDirectory(DIRECTORY_PLUGINS), &pluginDirs);
 
 	std::vector<PluginInfo> found;
 	for (auto subdir : pluginDirs) {

--- a/Core/HLE/Plugins.cpp
+++ b/Core/HLE/Plugins.cpp
@@ -87,12 +87,13 @@ static std::vector<PluginInfo> FindPlugins(const std::string &gameID, const std:
 
 	std::vector<PluginInfo> found;
 	for (auto subdir : pluginDirs) {
-		if (!subdir.isDirectory || !File::Exists(subdir.fullName + "/plugin.ini"))
+		Path subdirFullName(subdir.fullName);
+		if (!subdir.isDirectory || !File::Exists(subdirFullName / "plugin.ini"))
 			continue;
 
 		IniFile ini;
-		if (!ini.Load(subdir.fullName + "/plugin.ini")) {
-			ERROR_LOG(SYSTEM, "Failed to load plugin ini: %s/plugin.ini", subdir.fullName.c_str());
+		if (!ini.Load(subdirFullName / "plugin.ini")) {
+			ERROR_LOG(SYSTEM, "Failed to load plugin ini: %s/plugin.ini", subdirFullName.c_str());
 			continue;
 		}
 
@@ -117,8 +118,8 @@ static std::vector<PluginInfo> FindPlugins(const std::string &gameID, const std:
 
 		std::set<std::string> langMatches;
 		for (const std::string &subini : matches) {
-			if (!ini.Load(subdir.fullName + "/" + subini)) {
-				ERROR_LOG(SYSTEM, "Failed to load plugin ini: %s/%s", subdir.fullName.c_str(), subini.c_str());
+			if (!ini.Load(subdirFullName / subini)) {
+				ERROR_LOG(SYSTEM, "Failed to load plugin ini: %s/%s", subdirFullName.c_str(), subini.c_str());
 				continue;
 			}
 
@@ -132,8 +133,8 @@ static std::vector<PluginInfo> FindPlugins(const std::string &gameID, const std:
 		}
 
 		for (const std::string &subini : langMatches) {
-			if (!ini.Load(subdir.fullName + "/" + subini)) {
-				ERROR_LOG(SYSTEM, "Failed to load plugin ini: %s/%s", subdir.fullName.c_str(), subini.c_str());
+			if (!ini.Load(subdirFullName / subini)) {
+				ERROR_LOG(SYSTEM, "Failed to load plugin ini: %s/%s", subdirFullName.c_str(), subini.c_str());
 				continue;
 			}
 

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -19,6 +19,7 @@
 #include <mutex>
 
 #include "Common/CommonTypes.h"
+#include "Common/File/Path.h"
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"
 #include "Common/Data/Collections/FixedSizeQueue.h"
@@ -429,7 +430,7 @@ void __AudioUpdate(bool resetRecording) {
 		if (g_Config.bSaveLoadResetsAVdumping && resetRecording) {
 			__StopLogAudio();
 			std::string discID = g_paramSFO.GetDiscID();
-			std::string audio_file_name = StringFromFormat("%s%s_%s.wav", GetSysDirectory(DIRECTORY_AUDIO).c_str(), discID.c_str(), KernelTimeNowFormatted().c_str()).c_str();
+			Path audio_file_name = GetSysDirectory(DIRECTORY_AUDIO) / StringFromFormat("%s_%s.wav", discID.c_str(), KernelTimeNowFormatted().c_str()).c_str();
 			INFO_LOG(COMMON, "Restarted audio recording to: %s", audio_file_name.c_str());
 			if (!File::Exists(GetSysDirectory(DIRECTORY_AUDIO)))
 				File::CreateDir(GetSysDirectory(DIRECTORY_AUDIO));
@@ -440,7 +441,7 @@ void __AudioUpdate(bool resetRecording) {
 			if (g_Config.bDumpAudio) {
 				// Use gameID_EmulatedTimestamp for filename
 				std::string discID = g_paramSFO.GetDiscID();
-				std::string audio_file_name = StringFromFormat("%s%s_%s.wav", GetSysDirectory(DIRECTORY_AUDIO).c_str(), discID.c_str(), KernelTimeNowFormatted().c_str()).c_str();
+				Path audio_file_name = GetSysDirectory(DIRECTORY_AUDIO) / StringFromFormat("%s_%s.wav", discID.c_str(), KernelTimeNowFormatted().c_str());
 				INFO_LOG(COMMON,"Recording audio to: %s", audio_file_name.c_str());
 				// Create the path just in case it doesn't exist
 				if (!File::Exists(GetSysDirectory(DIRECTORY_AUDIO)))
@@ -480,7 +481,7 @@ void __PushExternalAudio(const s32 *audio, int numSamples) {
 	}
 }
 #ifndef MOBILE_DEVICE
-void __StartLogAudio(const std::string& filename) {
+void __StartLogAudio(const Path& filename) {
 	if (!m_logAudio) {
 		m_logAudio = true;
 		g_wave_writer.Start(filename, 44100);

--- a/Core/HLE/__sceAudio.h
+++ b/Core/HLE/__sceAudio.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "Common/File/Path.h"
+
 #include "sceAudio.h"
 
 struct AudioDebugStats {
@@ -49,7 +51,7 @@ void __AudioGetDebugStats(char *buf, size_t bufSize);
 void __PushExternalAudio(const s32 *audio, int numSamples);  // Should not be used in-game, only at the menu!
 
 // Audio Dumping stuff
-void __StartLogAudio(const std::string& filename);
+void __StartLogAudio(const Path &filename);
 void __StopLogAudio();
 
 class WAVDump

--- a/Core/HLE/proAdhocServer.cpp
+++ b/Core/HLE/proAdhocServer.cpp
@@ -1429,7 +1429,7 @@ void game_product_override(SceNetAdhocctlProductCode * product)
 void update_status()
 {
 	// Open Logfile
-	FILE * log = File::OpenCFile(SERVER_STATUS_XMLOUT, "w");
+	FILE * log = File::OpenCFile(Path(SERVER_STATUS_XMLOUT), "w");
 
 	// Opened Logfile
 	if(log != NULL)

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -639,7 +639,7 @@ void __IoInit() {
 
 	if (g_RemasterMode) {
 		const std::string gameId = g_paramSFO.GetDiscID();
-		const std::string exdataPath = g_Config.memStickDirectory + "exdata/" + gameId + "/";
+		const Path exdataPath = g_Config.memStickDirectory / "exdata" / gameId;
 		if (File::Exists(exdataPath)) {
 			exdataSystem = new DirectoryFileSystem(&pspFileSystem, exdataPath, FileSystemFlags::SIMULATE_FAT32 | FileSystemFlags::CARD);
 			pspFileSystem.Mount("exdata0:", exdataSystem);

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -886,8 +886,8 @@ static void __SaveDecryptedEbootToStorageMedia(const u8 *decryptedEbootDataPtr, 
 	}
 
 	const std::string filenameToDumpTo = g_paramSFO.GetDiscID() + ".BIN";
-	const std::string dumpDirectory = GetSysDirectory(DIRECTORY_DUMP);
-	const std::string fullPath = dumpDirectory + filenameToDumpTo;
+	const Path dumpDirectory = GetSysDirectory(DIRECTORY_DUMP);
+	const Path fullPath = dumpDirectory / filenameToDumpTo;
 
 	// If the file already exists, don't dump it again.
 	if (File::Exists(fullPath)) {

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -482,7 +482,7 @@ static u32 sceUmdGetErrorStat()
 	return umdErrorStat;
 }
 
-void __UmdReplace(std::string filepath) {
+void __UmdReplace(Path filepath) {
 	std::string error = "";
 	if (!UmdReplace(filepath, error)) {
 		ERROR_LOG(SCEIO, "UMD Replace failed: %s", error.c_str());

--- a/Core/HLE/sceUmd.h
+++ b/Core/HLE/sceUmd.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "Common/File/Path.h"
+
 enum pspUmdState { 
 	PSP_UMD_INIT        = 0x00,
 	PSP_UMD_NOT_PRESENT = 0x01,
@@ -41,7 +43,7 @@ enum pspUmdType {
 void __UmdInit();
 void __UmdDoState(PointerWrap &p);
 
-void __UmdReplace(std::string filepath);
+void __UmdReplace(Path filepath);
 bool getUMDReplacePermit();
 
 void Register_sceUmdUser();

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -102,7 +102,7 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 
 	// First, check if it's a directory with an EBOOT.PBP in it.
 	if (fileLoader->IsDirectory()) {
-		Path filename = Path(fileLoader->GetPath());
+		Path filename = fileLoader->GetPath();
 		if (filename.size() > 4) {
 			// Check for existence of EBOOT.PBP, as required for "Directory games".
 			if (File::Exists(filename / "EBOOT.PBP")) {

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -181,8 +181,7 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 			return IdentifiedFileType::PSP_PBP_DIRECTORY;
 		}
 		return IdentifiedFileType::PSP_PBP;
-	}
-	else if (extension == ".pbp") {
+	} else if (extension == ".pbp") {
 		ERROR_LOG(LOADER, "A PBP with the wrong magic number?");
 		return IdentifiedFileType::PSP_PBP;
 	} else if (extension == ".bin") {

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -19,6 +19,7 @@
 #include <cstdio>
 
 #include "Common/File/FileUtil.h"
+#include "Common/File/Path.h"
 #include "Common/StringUtils.h"
 #include "Core/FileLoaders/CachingFileLoader.h"
 #include "Core/FileLoaders/DiskCachingFileLoader.h"
@@ -101,20 +102,20 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 
 	// First, check if it's a directory with an EBOOT.PBP in it.
 	if (fileLoader->IsDirectory()) {
-		std::string filename = fileLoader->GetPath();
+		Path filename = Path(fileLoader->GetPath());
 		if (filename.size() > 4) {
 			// Check for existence of EBOOT.PBP, as required for "Directory games".
-			if (File::Exists((filename + "/EBOOT.PBP").c_str())) {
+			if (File::Exists(filename / "EBOOT.PBP")) {
 				return IdentifiedFileType::PSP_PBP_DIRECTORY;
 			}
 
 			// check if it's a disc directory
-			if (File::Exists((filename + "/PSP_GAME").c_str())) {
+			if (File::Exists(filename / "PSP_GAME")) {
 				return IdentifiedFileType::PSP_DISC_DIRECTORY;
 			}
 
 			// Not that, okay, let's guess it's a savedata directory if it has a param.sfo...
-			if (File::Exists((filename + "/PARAM.SFO").c_str())) {
+			if (File::Exists(filename / "PARAM.SFO")) {
 				return IdentifiedFileType::PSP_SAVEDATA_DIRECTORY;
 			}
 		}

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -40,8 +40,8 @@ void RegisterFileLoaderFactory(std::string prefix, std::unique_ptr<FileLoaderFac
 	factories[prefix] = std::move(factory);
 }
 
-FileLoader *ConstructFileLoader(const std::string &filename) {
-	if (filename.find("http://") == 0 || filename.find("https://") == 0) {
+FileLoader *ConstructFileLoader(const Path &filename) {
+	if (filename.Type() == PathType::HTTP) {
 		FileLoader *baseLoader = new RetryingFileLoader(new HTTPFileLoader(filename));
 		// For headless, avoid disk caching since it's usually used for tests that might mutate.
 		if (!PSP_CoreParameter().headLess) {
@@ -51,7 +51,7 @@ FileLoader *ConstructFileLoader(const std::string &filename) {
 	}
 
 	for (auto &iter : factories) {
-		if (startsWith(filename, iter.first)) {
+		if (startsWith(filename.ToString(), iter.first)) {
 			return iter.second->ConstructFileLoader(filename);
 		}
 	}
@@ -73,7 +73,7 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 		return IdentifiedFileType::ERROR_IDENTIFYING;
 	}
 
-	std::string extension = File::GetFileExtension(fileLoader->GetPath());
+	std::string extension = fileLoader->GetPath().GetFileExtension();
 	if (extension == ".iso") {
 		// may be a psx iso, they have 2352 byte sectors. You never know what some people try to open
 		if ((fileLoader->FileSize() % 2352) == 0) {
@@ -143,9 +143,9 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 	}
 
 	if (id == 'FLE\x7F') {
-		std::string filename = fileLoader->GetPath();
+		Path filename = fileLoader->GetPath();
 		// There are a few elfs misnamed as pbp (like Trig Wars), accept that.
-		if (extension == ".plf" || strstr(filename.c_str(), "BOOT.BIN") ||
+		if (extension == ".plf" || strstr(filename.GetFilename().c_str(), "BOOT.BIN") ||
 			extension == ".elf" || extension == ".prx" || extension == ".pbp") {
 			return IdentifiedFileType::PSP_ELF;
 		}
@@ -176,14 +176,13 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 
 		// Let's check if we got pointed to a PBP within such a directory.
 		// If so we just move up and return the directory itself as the game.
-		std::string path = File::GetDir(fileLoader->GetPath());
 		// If loading from memstick...
-		size_t pos = path.find("PSP/GAME/");
-		if (pos != std::string::npos) {
+		if (fileLoader->GetPath().FilePathContains("PSP/GAME/")) {
 			return IdentifiedFileType::PSP_PBP_DIRECTORY;
 		}
 		return IdentifiedFileType::PSP_PBP;
-	} else if (extension == ".pbp") {
+	}
+	else if (extension == ".pbp") {
 		ERROR_LOG(LOADER, "A PBP with the wrong magic number?");
 		return IdentifiedFileType::PSP_PBP;
 	} else if (extension == ".bin") {
@@ -205,7 +204,7 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 FileLoader *ResolveFileLoaderTarget(FileLoader *fileLoader) {
 	IdentifiedFileType type = Identify_File(fileLoader);
 	if (type == IdentifiedFileType::PSP_PBP_DIRECTORY) {
-		const std::string ebootFilename = ResolvePBPFile(fileLoader->GetPath());
+		const Path ebootFilename = ResolvePBPFile(fileLoader->GetPath());
 		if (ebootFilename != fileLoader->GetPath()) {
 			// Switch fileLoader to the actual EBOOT.
 			delete fileLoader;
@@ -215,28 +214,20 @@ FileLoader *ResolveFileLoaderTarget(FileLoader *fileLoader) {
 	return fileLoader;
 }
 
-std::string ResolvePBPDirectory(const std::string &filename) {
-	bool hasPBP = endsWith(filename, "/EBOOT.PBP");
-#ifdef _WIN32
-	hasPBP = hasPBP || endsWith(filename, "\\EBOOT.PBP");
-#endif
-
-	if (hasPBP) {
-		return filename.substr(0, filename.length() - strlen("/EBOOT.PBP"));
+Path ResolvePBPDirectory(const Path &filename) {
+	if (filename.GetFilename() == "EBOOT.PBP") {
+		return filename.NavigateUp();
+	} else {
+		return filename;
 	}
-	return filename;
 }
 
-std::string ResolvePBPFile(const std::string &filename) {
-	bool hasPBP = endsWith(filename, "/EBOOT.PBP");
-#ifdef _WIN32
-	hasPBP = hasPBP || endsWith(filename, "\\EBOOT.PBP");
-#endif
-
-	if (!hasPBP) {
-		return filename + "/EBOOT.PBP";
+Path ResolvePBPFile(const Path &filename) {
+	if (filename.GetFilename() != "EBOOT.PBP") {
+		return filename / "EBOOT.PBP";
+	} else {
+		return filename;
 	}
-	return filename;
 }
 
 bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string) {
@@ -260,11 +251,12 @@ bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string) {
 					coreState = CORE_BOOT_ERROR;
 					return false;
 				}
-				std::string path = fileLoader->GetPath();
-				size_t pos = path.find("PSP/GAME/");
+
+				std::string dir = fileLoader->GetPath().GetDirectory();
+				size_t pos = dir.find("PSP/GAME/");
 				if (pos != std::string::npos) {
-					path = ResolvePBPDirectory(path);
-					pspFileSystem.SetStartingDirectory("ms0:/" + path.substr(pos));
+					dir = ResolvePBPDirectory(Path(dir)).ToString();
+					pspFileSystem.SetStartingDirectory("ms0:/" + dir.substr(pos));
 				}
 				return Load_PSP_ELF_PBP(fileLoader, error_string);
 			} else {
@@ -355,7 +347,7 @@ bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string) {
 	return false;
 }
 
-bool UmdReplace(std::string filepath, std::string &error) {
+bool UmdReplace(const Path &filepath, std::string &error) {
 	IFileSystem* currentUMD = pspFileSystem.GetSystem("disc0:");
 
 	if (!currentUMD) {
@@ -367,7 +359,7 @@ bool UmdReplace(std::string filepath, std::string &error) {
 
 	if (!loadedFile->Exists()) {
 		delete loadedFile;
-		error = loadedFile->GetPath() + " doesn't exist";
+		error = loadedFile->GetPath().ToVisualString() + " doesn't exist";
 		return false;
 	}
 	UpdateLoadedFile(loadedFile);

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include "Common/CommonTypes.h"
+#include "Common/File/Path.h"
 
 enum class IdentifiedFileType {
 	ERROR_IDENTIFYING,
@@ -74,15 +75,15 @@ public:
 	}
 	virtual bool IsDirectory() = 0;
 	virtual s64 FileSize() = 0;
-	virtual std::string GetPath() const = 0;
+	virtual Path GetPath() const = 0;
+
 	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) = 0;
 	virtual size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) {
 		return ReadAt(absolutePos, 1, bytes, data, flags);
 	}
 
 	// Cancel any operations that might block, if possible.
-	virtual void Cancel() {
-	}
+	virtual void Cancel() {}
 
 	virtual std::string LatestError() const {
 		return "";
@@ -112,7 +113,7 @@ public:
 	s64 FileSize() override {
 		return backend_->FileSize();
 	}
-	std::string GetPath() const override {
+	Path GetPath() const override {
 		return backend_->GetPath();
 	}
 	void Cancel() override {
@@ -136,23 +137,23 @@ inline u32 operator & (const FileLoader::Flags &a, const FileLoader::Flags &b) {
 	return (u32)a & (u32)b;
 }
 
-FileLoader *ConstructFileLoader(const std::string &filename);
+FileLoader *ConstructFileLoader(const Path &filename);
 // Resolve to the target binary, ISO, or other file (e.g. from a directory.)
 FileLoader *ResolveFileLoaderTarget(FileLoader *fileLoader);
 
-std::string ResolvePBPDirectory(const std::string &filename);
-std::string ResolvePBPFile(const std::string &filename);
+Path ResolvePBPDirectory(const Path &filename);
+Path ResolvePBPFile(const Path &filename);
 
 IdentifiedFileType Identify_File(FileLoader *fileLoader);
 
 class FileLoaderFactory {
 public:
 	virtual ~FileLoaderFactory() {}
-	virtual FileLoader *ConstructFileLoader(const std::string &filename) = 0;
+	virtual FileLoader *ConstructFileLoader(const Path &filename) = 0;
 };
-void RegisterFileLoaderFactory(std::string name, std::unique_ptr<FileLoaderFactory> factory);
+void RegisterFileLoaderFactory(std::string prefix, std::unique_ptr<FileLoaderFactory> factory);
 
 // Can modify the string filename, as it calls IdentifyFile above.
 bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string);
 
-bool UmdReplace(std::string filepath, std::string &error);
+bool UmdReplace(const Path &filepath, std::string &error);

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -77,7 +77,7 @@ namespace std {
 
 static std::unordered_set<HashMapFunc> hashMap;
 
-static std::string hashmapFileName;
+static Path hashmapFileName;
 
 #define MIPSTABLE_IMM_MASK 0xFC000000
 
@@ -1185,7 +1185,7 @@ skip:
 	void FinalizeScan(bool insertSymbols) {
 		HashFunctions();
 
-		std::string hashMapFilename = GetSysDirectory(DIRECTORY_SYSTEM) + "knownfuncs.ini";
+		Path hashMapFilename = GetSysDirectory(DIRECTORY_SYSTEM) / "knownfuncs.ini";
 		if (g_Config.bFuncHashMap || g_Config.bFuncReplacements) {
 			LoadBuiltinHashMap();
 			if (g_Config.bFuncHashMap) {
@@ -1311,12 +1311,12 @@ skip:
 
 	void SetHashMapFilename(const std::string& filename) {
 		if (filename.empty())
-			hashmapFileName = GetSysDirectory(DIRECTORY_SYSTEM) + "knownfuncs.ini";
+			hashmapFileName = GetSysDirectory(DIRECTORY_SYSTEM) / "knownfuncs.ini";
 		else
-			hashmapFileName = filename;
+			hashmapFileName = Path(filename);
 	}
 
-	void StoreHashMap(std::string filename) {
+	void StoreHashMap(Path filename) {
 		if (filename.empty())
 			filename = hashmapFileName;
 
@@ -1381,7 +1381,7 @@ skip:
 		}
 	}
 
-	void LoadHashMap(const std::string& filename) {
+	void LoadHashMap(const Path &filename) {
 		FILE *file = File::OpenCFile(filename, "rt");
 		if (!file) {
 			WARN_LOG(LOADER, "Could not load hash map: %s", filename.c_str());

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/File/Path.h"
 #include "Core/MIPS/MIPS.h"
 
 class DebugInterface;
@@ -114,8 +115,8 @@ namespace MIPSAnalyst
 
 	void SetHashMapFilename(const std::string& filename = "");
 	void LoadBuiltinHashMap();
-	void LoadHashMap(const std::string& filename);
-	void StoreHashMap(std::string filename = "");
+	void LoadHashMap(const Path &filename);
+	void StoreHashMap(Path filename = Path());
 
 	const char *LookupHash(u64 hash, u32 funcSize);
 	void ReplaceFunctions();

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -375,16 +375,10 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 			pspFileSystem.Mount("umd:", blockSystem);
 		}
 	}
-
-	std::string full_path = fileLoader->GetPath();
-	std::string path, file, extension;
-	SplitPath(ReplaceAll(full_path, "\\", "/"), &path, &file, &extension);
-	if (!path.empty() && path.back() == '/')
-		path.resize(path.size() - 1);
-#ifdef _WIN32
-	if (!path.empty() && path.back() == '\\')
-		path.resize(path.size() - 1);
-#endif
+	Path full_path = fileLoader->GetPath();
+	std::string path = full_path.GetDirectory();
+	std::string extension = full_path.GetFileExtension();
+	std::string file = full_path.GetFilename();
 
 	size_t pos = path.find("PSP/GAME/");
 	std::string ms_path;
@@ -395,11 +389,6 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 		// Note that umd0:/ is actually the writable containing directory, in this case.
 		ms_path = "umd0:/";
 	}
-
-#ifdef _WIN32
-	// Turn the slashes back to the Windows way.
-	path = ReplaceAll(path, "/", "\\");
-#endif
 
 	if (!PSP_CoreParameter().mountRoot.empty()) {
 		// We don't want to worry about .. and cwd and such.
@@ -425,7 +414,7 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 	DirectoryFileSystem *fs = new DirectoryFileSystem(&pspFileSystem, Path(path), FileSystemFlags::SIMULATE_FAT32 | FileSystemFlags::CARD);
 	pspFileSystem.Mount("umd0:", fs);
 
-	std::string finalName = ms_path + file + extension;
+	std::string finalName = ms_path + file;
 
 	std::string homebrewName = PSP_CoreParameter().fileToStart.ToVisualString();
 	std::size_t lslash = homebrewName.find_last_of("/");
@@ -449,14 +438,14 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 		Path oldNamePrefix = savestateDir / StringFromFormat("%s_%d", homebrewName.c_str(), i);
 		Path oldIDPrefix = savestateDir / StringFromFormat("%s_1.00_%d", madeUpID.c_str(), i);
 
-		if (oldIDPrefix != newPrefix && File::Exists(oldIDPrefix.WithExtraExtension("ppst")))
-			File::Rename(oldIDPrefix.WithExtraExtension("ppst"), newPrefix.WithExtraExtension("ppst"));
-		else if (File::Exists(oldNamePrefix.WithExtraExtension("ppst")))
-			File::Rename(oldNamePrefix.WithExtraExtension("ppst"), newPrefix.WithExtraExtension("ppst"));
-		if (oldIDPrefix != newPrefix && File::Exists(oldIDPrefix.WithExtraExtension("jpg")))
-			File::Rename(oldIDPrefix.WithExtraExtension("jpg"), newPrefix.WithExtraExtension("jpg"));
-		else if (File::Exists(oldNamePrefix.WithExtraExtension("jpg")))
-			File::Rename(oldNamePrefix.WithExtraExtension("jpg"), newPrefix.WithExtraExtension("jpg"));
+		if (oldIDPrefix != newPrefix && File::Exists(oldIDPrefix.WithExtraExtension(".ppst")))
+			File::Rename(oldIDPrefix.WithExtraExtension(".ppst"), newPrefix.WithExtraExtension(".ppst"));
+		else if (File::Exists(oldNamePrefix.WithExtraExtension(".ppst")))
+			File::Rename(oldNamePrefix.WithExtraExtension(".ppst"), newPrefix.WithExtraExtension(".ppst"));
+		if (oldIDPrefix != newPrefix && File::Exists(oldIDPrefix.WithExtraExtension(".jpg")))
+			File::Rename(oldIDPrefix.WithExtraExtension(".jpg"), newPrefix.WithExtraExtension(".jpg"));
+		else if (File::Exists(oldNamePrefix.WithExtraExtension(".jpg")))
+			File::Rename(oldNamePrefix.WithExtraExtension(".jpg"), newPrefix.WithExtraExtension(".jpg"));
 	}
 
 	PSPLoaders_Shutdown();

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -449,15 +449,14 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 		Path oldNamePrefix = savestateDir / StringFromFormat("%s_%d", homebrewName.c_str(), i);
 		Path oldIDPrefix = savestateDir / StringFromFormat("%s_1.00_%d", madeUpID.c_str(), i);
 
-		// TODO(scoped): ...
-		if (oldIDPrefix != newPrefix && File::Exists(oldIDPrefix.ToString() + ".ppst"))
-			File::Rename(oldIDPrefix.ToString() + ".ppst", newPrefix.ToString() + ".ppst");
-		else if (File::Exists(oldNamePrefix.ToString() + ".ppst"))
-			File::Rename(oldNamePrefix.ToString() + ".ppst", newPrefix.ToString() + ".ppst");
-		if (oldIDPrefix != newPrefix && File::Exists(oldIDPrefix.ToString() + ".jpg"))
-			File::Rename(oldIDPrefix.ToString() + ".jpg", newPrefix.ToString() + ".jpg");
-		else if (File::Exists(oldNamePrefix.ToString() + ".jpg"))
-			File::Rename(oldNamePrefix.ToString() + ".jpg", newPrefix.ToString() + ".jpg");
+		if (oldIDPrefix != newPrefix && File::Exists(oldIDPrefix.WithExtraExtension("ppst")))
+			File::Rename(oldIDPrefix.WithExtraExtension("ppst"), newPrefix.WithExtraExtension("ppst"));
+		else if (File::Exists(oldNamePrefix.WithExtraExtension("ppst")))
+			File::Rename(oldNamePrefix.WithExtraExtension("ppst"), newPrefix.WithExtraExtension("ppst"));
+		if (oldIDPrefix != newPrefix && File::Exists(oldIDPrefix.WithExtraExtension("jpg")))
+			File::Rename(oldIDPrefix.WithExtraExtension("jpg"), newPrefix.WithExtraExtension("jpg"));
+		else if (File::Exists(oldNamePrefix.WithExtraExtension("jpg")))
+			File::Rename(oldNamePrefix.WithExtraExtension("jpg"), newPrefix.WithExtraExtension("jpg"));
 	}
 
 	PSPLoaders_Shutdown();

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -334,9 +334,14 @@ bool Load_PSP_ISO(FileLoader *fileLoader, std::string *error_string) {
 	return true;
 }
 
-static std::string NormalizePath(const std::string &path) {
+static Path NormalizePath(const Path &path) {
+	if (path.Type() != PathType::NATIVE) {
+		// Nothing to do - these can't be non-normalized.
+		return path;
+	}
+
 #ifdef _WIN32
-	std::wstring wpath = ConvertUTF8ToWString(path);
+	std::wstring wpath = path.ToWString();
 	std::wstring buf;
 	buf.resize(512);
 	size_t sz = GetFullPathName(wpath.c_str(), (DWORD)buf.size(), &buf[0], nullptr);
@@ -348,12 +353,12 @@ static std::string NormalizePath(const std::string &path) {
 		// This should truncate off the null terminator.
 		buf.resize(sz);
 	}
-	return ConvertWStringToUTF8(buf);
+	return Path(buf);
 #else
 	char buf[PATH_MAX + 1];
-	if (realpath(path.c_str(), buf) == NULL)
-		return "";
-	return buf;
+	if (!realpath(path.c_str(), buf))
+		return Path();
+	return Path(buf);
 #endif
 }
 
@@ -398,30 +403,31 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 
 	if (!PSP_CoreParameter().mountRoot.empty()) {
 		// We don't want to worry about .. and cwd and such.
-		const std::string rootNorm = NormalizePath(PSP_CoreParameter().mountRoot + "/");
-		const std::string pathNorm = NormalizePath(path + "/");
+		const Path rootNorm = NormalizePath(PSP_CoreParameter().mountRoot);
+		const Path pathNorm = NormalizePath(Path(path));
 
 		// If root is not a subpath of path, we can't boot the game.
-		if (!startsWith(pathNorm, rootNorm)) {
+		if (!pathNorm.StartsWith(rootNorm)) {
 			*error_string = "Cannot boot ELF located outside mountRoot.";
 			coreState = CORE_BOOT_ERROR;
 			return false;
 		}
 
-		const std::string filepath = ReplaceAll(pathNorm.substr(rootNorm.size()), "\\", "/");
+		// TODO(scoped): This won't work!
+		const std::string filepath = ReplaceAll(pathNorm.ToString().substr(rootNorm.ToString().size()), "\\", "/");
 		file = filepath + "/" + file;
-		path = rootNorm + "/";
+		path = rootNorm.ToString() + "/";
 		pspFileSystem.SetStartingDirectory(filepath);
 	} else {
 		pspFileSystem.SetStartingDirectory(ms_path);
 	}
 
-	DirectoryFileSystem *fs = new DirectoryFileSystem(&pspFileSystem, path, FileSystemFlags::SIMULATE_FAT32 | FileSystemFlags::CARD);
+	DirectoryFileSystem *fs = new DirectoryFileSystem(&pspFileSystem, Path(path), FileSystemFlags::SIMULATE_FAT32 | FileSystemFlags::CARD);
 	pspFileSystem.Mount("umd0:", fs);
 
 	std::string finalName = ms_path + file + extension;
 
-	std::string homebrewName = PSP_CoreParameter().fileToStart;
+	std::string homebrewName = PSP_CoreParameter().fileToStart.ToVisualString();
 	std::size_t lslash = homebrewName.find_last_of("/");
 	if (lslash != homebrewName.npos)
 		homebrewName = homebrewName.substr(lslash + 1);
@@ -437,20 +443,21 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 	host->SetWindowTitle(title.c_str());
 
 	// Migrate old save states from old versions of fake game IDs.
-	const std::string savestateDir = GetSysDirectory(DIRECTORY_SAVESTATE);
+	const Path savestateDir = GetSysDirectory(DIRECTORY_SAVESTATE);
 	for (int i = 0; i < 5; ++i) {
-		std::string newPrefix = StringFromFormat("%s%s_%s_%d", savestateDir.c_str(), discID.c_str(), discVersion.c_str(), i);
-		std::string oldNamePrefix = StringFromFormat("%s%s_%d", savestateDir.c_str(), homebrewName.c_str(), i);
-		std::string oldIDPrefix = StringFromFormat("%s%s_1.00_%d", savestateDir.c_str(), madeUpID.c_str(), i);
+		Path newPrefix = savestateDir / StringFromFormat("%s_%s_%d", discID.c_str(), discVersion.c_str(), i);
+		Path oldNamePrefix = savestateDir / StringFromFormat("%s_%d", homebrewName.c_str(), i);
+		Path oldIDPrefix = savestateDir / StringFromFormat("%s_1.00_%d", madeUpID.c_str(), i);
 
-		if (oldIDPrefix != newPrefix && File::Exists(oldIDPrefix + ".ppst"))
-			File::Rename(oldIDPrefix + ".ppst", newPrefix + ".ppst");
-		else if (File::Exists(oldNamePrefix + ".ppst"))
-			File::Rename(oldNamePrefix + ".ppst", newPrefix + ".ppst");
-		if (oldIDPrefix != newPrefix && File::Exists(oldIDPrefix + ".jpg"))
-			File::Rename(oldIDPrefix + ".jpg", newPrefix + ".jpg");
-		else if (File::Exists(oldNamePrefix + ".jpg"))
-			File::Rename(oldNamePrefix + ".jpg", newPrefix + ".jpg");
+		// TODO(scoped): ...
+		if (oldIDPrefix != newPrefix && File::Exists(oldIDPrefix.ToString() + ".ppst"))
+			File::Rename(oldIDPrefix.ToString() + ".ppst", newPrefix.ToString() + ".ppst");
+		else if (File::Exists(oldNamePrefix.ToString() + ".ppst"))
+			File::Rename(oldNamePrefix.ToString() + ".ppst", newPrefix.ToString() + ".ppst");
+		if (oldIDPrefix != newPrefix && File::Exists(oldIDPrefix.ToString() + ".jpg"))
+			File::Rename(oldIDPrefix.ToString() + ".jpg", newPrefix.ToString() + ".jpg");
+		else if (File::Exists(oldNamePrefix.ToString() + ".jpg"))
+			File::Rename(oldNamePrefix.ToString() + ".jpg", newPrefix.ToString() + ".jpg");
 	}
 
 	PSPLoaders_Shutdown();

--- a/Core/Replay.cpp
+++ b/Core/Replay.cpp
@@ -169,7 +169,7 @@ void ReplayExecuteBlob(const std::vector<u8> &data) {
 	INFO_LOG(SYSTEM, "Executing replay with %lld items", (long long)replayItems.size());
 }
 
-bool ReplayExecuteFile(const std::string &filename) {
+bool ReplayExecuteFile(const Path &filename) {
 	ReplayAbort();
 
 	FILE *fp = File::OpenCFile(filename, "rb");
@@ -269,7 +269,7 @@ void ReplayFlushBlob(std::vector<u8> *data) {
 	replayItems.clear();
 }
 
-bool ReplayFlushFile(const std::string &filename) {
+bool ReplayFlushFile(const Path &filename) {
 	FILE *fp = File::OpenCFile(filename, replaySaveWroteHeader ? "ab" : "wb");
 	if (!fp) {
 		ERROR_LOG(SYSTEM, "Failed to open replay file: %s", filename.c_str());

--- a/Core/Replay.h
+++ b/Core/Replay.h
@@ -21,6 +21,8 @@
 #include <string>
 #include <vector>
 
+#include "Common/File/Path.h"
+
 // Be careful about changing these values (used in file data.)
 enum class ReplayAction : uint8_t {
 	BUTTONS = 0x00,
@@ -49,7 +51,7 @@ struct PSPFileInfo;
 // Replay from data in memory.  Does not manipulate base time / RNG state.
 void ReplayExecuteBlob(const std::vector<u8> &data);
 // Replay from data in a file.  Returns false if invalid.
-bool ReplayExecuteFile(const std::string &filename);
+bool ReplayExecuteFile(const Path &filename);
 // Returns whether there are unexected events to replay.
 bool ReplayHasMoreEvents();
 
@@ -60,7 +62,7 @@ void ReplayBeginSave();
 void ReplayFlushBlob(std::vector<u8> *data);
 // Flush buffered events to file.  Continues recording (next call will receive new events only.)
 // Do not call with a different filename before ReplayAbort().
-bool ReplayFlushFile(const std::string &filename);
+bool ReplayFlushFile(const Path &filename);
 
 // Abort any execute or record operation in progress.
 void ReplayAbort();

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -171,13 +171,13 @@ namespace Reporting
 		return it->second;
 	}
 
-	static uint32_t RetrieveCRCUnlessPowerSaving(const std::string &gamePath) {
+	static uint32_t RetrieveCRCUnlessPowerSaving(const Path &gamePath) {
 		// It's okay to use it if we have it already.
-		if (Core_GetPowerSaving() && !HasCRC(gamePath)) {
+		if (Core_GetPowerSaving() && !HasCRC(gamePath.ToString())) {
 			return 0;
 		}
 
-		return RetrieveCRC(gamePath);
+		return RetrieveCRC(gamePath.ToString());
 	}
 
 	static void PurgeCRC() {
@@ -552,7 +552,7 @@ namespace Reporting
 		// Some users run the exe from a zip or something, and don't have fonts.
 		// This breaks things, but let's not report it since it's confusing.
 #if defined(USING_WIN_UI) || defined(APPLE)
-		if (!File::Exists(g_Config.flash0Directory + "/font/jpn0.pgf"))
+		if (!File::Exists(g_Config.flash0Directory / "font/jpn0.pgf"))
 			return false;
 #else
 		File::FileInfo fo;

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -450,10 +450,10 @@ namespace Reporting
 		postdata.Add("savestate_used", SaveState::HasLoadedState());
 	}
 
-	void AddScreenshotData(MultipartFormDataEncoder &postdata, std::string filename)
+	void AddScreenshotData(MultipartFormDataEncoder &postdata, const Path &filename)
 	{
 		std::string data;
-		if (!filename.empty() && File::ReadFileToString(false, filename.c_str(), data))
+		if (!filename.empty() && File::ReadFileToString(false, filename, data))
 			postdata.Add("screenshot", data, "screenshot.jpg", "image/jpeg");
 
 		const std::string iconFilename = "disc0:/PSP_GAME/ICON0.PNG";
@@ -502,7 +502,7 @@ namespace Reporting
 			postdata.Add("gameplay", StringFromFormat("%d", payload.int3));
 			postdata.Add("crc", StringFromFormat("%08x", RetrieveCRCUnlessPowerSaving(PSP_CoreParameter().fileToStart)));
 			postdata.Add("suggestions", payload.string1 != "perfect" && payload.string1 != "playable" ? "1" : "0");
-			AddScreenshotData(postdata, payload.string2);
+			AddScreenshotData(postdata, Path(payload.string2));
 			payload.string1.clear();
 			payload.string2.clear();
 

--- a/Core/Reporting.h
+++ b/Core/Reporting.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/File/Path.h"
 #include "Common/Log.h"
 
 #define DEBUG_LOG_REPORT(t,...)   do { DEBUG_LOG(t, __VA_ARGS__);  Reporting::ReportMessage(__VA_ARGS__); } while (false)
@@ -88,14 +89,14 @@ namespace Reporting
 	std::vector<std::string> CompatibilitySuggestions();
 
 	// Queues game for CRC hash if needed.
-	void QueueCRC(const std::string &gamePath);
+	void QueueCRC(const Path &gamePath);
 
 	// Returns true if the hash is available, does not queue if not.
-	bool HasCRC(const std::string &gamePath);
+	bool HasCRC(const Path &gamePath);
 
 	// Blocks until the CRC hash is available for game, and returns it.
 	// To avoid stalling, call HasCRC() in update() or similar and call this if it returns true.
-	uint32_t RetrieveCRC(const std::string &gamePath);
+	uint32_t RetrieveCRC(const Path &gamePath);
 
 	// Returns true if that identifier has not been logged yet.
 	bool ShouldLogNTimes(const char *identifier, int n);

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -463,7 +463,7 @@ namespace SaveState
 	}
 
 	static void SwapIfExists(const Path &from, const Path &to) {
-		Path temp = from.WithExtraExtension("tmp");
+		Path temp = from.WithExtraExtension(".tmp");
 		if (File::Exists(from)) {
 			File::Rename(from, temp);
 			File::Rename(to, from);
@@ -486,7 +486,7 @@ namespace SaveState
 					} else {
 						DeleteIfExists(fn);
 					}
-					File::Rename(fn.WithExtraExtension("tmp"), fn);
+					File::Rename(fn.WithExtraExtension(".tmp"), fn);
 				}
 				if (callback) {
 					callback(status, message, data);
@@ -498,7 +498,7 @@ namespace SaveState
 				RenameIfExists(shot, shotUndo);
 			}
 			SaveScreenshot(shot, Callback(), 0);
-			Save(fn.WithExtraExtension("tmp"), slot, renameCallback, cbUserData);
+			Save(fn.WithExtraExtension(".tmp"), slot, renameCallback, cbUserData);
 		} else {
 			auto sy = GetI18NCategory("System");
 			if (callback)
@@ -532,7 +532,7 @@ namespace SaveState
 	bool HasUndoSaveInSlot(const std::string &gameFilename, int slot)
 	{
 		Path fn = GenerateSaveSlotFilename(gameFilename, slot, STATE_EXTENSION);
-		return File::Exists(fn.WithExtraExtension("undo"));
+		return File::Exists(fn.WithExtraExtension(".undo"));
 	}
 
 	bool HasScreenshotInSlot(const std::string &gameFilename, int slot)

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -458,16 +458,16 @@ namespace SaveState
 
 	static void RenameIfExists(const Path &from, const Path &to) {
 		if (File::Exists(from)) {
-			File::Rename(from.ToString(), to.ToString());
+			File::Rename(from, to);
 		}
 	}
 
 	static void SwapIfExists(const Path &from, const Path &to) {
-		std::string temp = from.ToString() + ".tmp";
+		Path temp = from.WithExtraExtension("tmp");
 		if (File::Exists(from)) {
-			File::Rename(from.ToString(), temp);
-			File::Rename(to.ToString(), from.ToString());
-			File::Rename(temp, to.ToString());
+			File::Rename(from, temp);
+			File::Rename(to, from);
+			File::Rename(temp, to);
 		}
 	}
 
@@ -486,7 +486,7 @@ namespace SaveState
 					} else {
 						DeleteIfExists(fn);
 					}
-					File::Rename(fn.WithExtraExtension("tmp").ToString(), fn.ToString());
+					File::Rename(fn.WithExtraExtension("tmp"), fn);
 				}
 				if (callback) {
 					callback(status, message, data);

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -864,7 +864,7 @@ namespace SaveState
 			{
 				int maxRes = g_Config.iInternalResolution > 2 ? 2 : -1;
 				// TODO(scoped): Pass the path properly into TakeGameScreenshot.
-				tempResult = TakeGameScreenshot(Path(op.filename), ScreenshotFormat::JPG, SCREENSHOT_DISPLAY, nullptr, nullptr, maxRes);
+				tempResult = TakeGameScreenshot(op.filename, ScreenshotFormat::JPG, SCREENSHOT_DISPLAY, nullptr, nullptr, maxRes);
 				callbackResult = tempResult ? Status::SUCCESS : Status::FAILURE;
 				if (!tempResult) {
 					ERROR_LOG(SAVESTATE, "Failed to take a screenshot for the savestate! %s", op.filename.c_str());

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "Common/File/Path.h"
 #include "Common/Serialize/Serializer.h"
 
 namespace SaveState
@@ -56,17 +57,17 @@ namespace SaveState
 	int GetOldestSlot(const std::string &gameFilename);
 	
 	std::string GetSlotDateAsString(const std::string &gameFilename, int slot);
-	std::string GenerateSaveSlotFilename(const std::string &gameFilename, int slot, const char *extension);
+	Path GenerateSaveSlotFilename(const std::string &gameFilename, int slot, const char *extension);
 
 	std::string GetTitle(const std::string &filename);
 
 	// Load the specified file into the current state (async.)
 	// Warning: callback will be called on a different thread.
-	void Load(const std::string &filename, int slot, Callback callback = Callback(), void *cbUserData = 0);
+	void Load(const Path &filename, int slot, Callback callback = Callback(), void *cbUserData = 0);
 
 	// Save the current state to the specified file (async.)
 	// Warning: callback will be called on a different thread.
-	void Save(const std::string &filename, int slot, Callback callback = Callback(), void *cbUserData = 0);
+	void Save(const Path &filename, int slot, Callback callback = Callback(), void *cbUserData = 0);
 
 	CChunkFileReader::Error SaveToRam(std::vector<u8> &state);
 	CChunkFileReader::Error LoadFromRam(std::vector<u8> &state, std::string *errorString);

--- a/Core/Screenshot.cpp
+++ b/Core/Screenshot.cpp
@@ -23,6 +23,7 @@
 
 #include "Common/Data/Convert/ColorConv.h"
 #include "Common/File/FileUtil.h"
+#include "Common/File/Path.h"
 #include "Common/Log.h"
 #include "Common/System/Display.h"
 #include "Core/Config.h"
@@ -37,7 +38,7 @@
 class JPEGFileStream : public jpge::output_stream
 {
 public:
-	JPEGFileStream(const char *filename) {
+	JPEGFileStream(const Path &filename) {
 		fp_ = File::OpenCFile(filename, "wb");
 	}
 	~JPEGFileStream() override {
@@ -65,7 +66,7 @@ private:
 	FILE *fp_;
 };
 
-static bool WriteScreenshotToJPEG(const char *filename, int width, int height, int num_channels, const uint8_t *image_data, const jpge::params &comp_params) {
+static bool WriteScreenshotToJPEG(const Path &filename, int width, int height, int num_channels, const uint8_t *image_data, const jpge::params &comp_params) {
 	JPEGFileStream dst_stream(filename);
 	if (!dst_stream.Valid()) {
 		ERROR_LOG(IO, "Unable to open screenshot file for writing.");
@@ -97,7 +98,7 @@ static bool WriteScreenshotToJPEG(const char *filename, int width, int height, i
 	return dst_stream.Valid();
 }
 
-static bool WriteScreenshotToPNG(png_imagep image, const char *filename, int convert_to_8bit, const void *buffer, png_int_32 row_stride, const void *colormap) {
+static bool WriteScreenshotToPNG(png_imagep image, const Path &filename, int convert_to_8bit, const void *buffer, png_int_32 row_stride, const void *colormap) {
 	FILE *fp = File::OpenCFile(filename, "wb");
 	if (!fp) {
 		ERROR_LOG(IO, "Unable to open screenshot file for writing.");
@@ -110,7 +111,8 @@ static bool WriteScreenshotToPNG(png_imagep image, const char *filename, int con
 	} else {
 		ERROR_LOG(IO, "Screenshot PNG encode failed.");
 		fclose(fp);
-		remove(filename);
+		// Should we even do this?
+		File::Delete(filename);
 		return false;
 	}
 }
@@ -326,7 +328,7 @@ static GPUDebugBuffer ApplyRotation(const GPUDebugBuffer &buf, DisplayRotation r
 	return rotated;
 }
 
-bool TakeGameScreenshot(const char *filename, ScreenshotFormat fmt, ScreenshotType type, int *width, int *height, int maxRes) {
+bool TakeGameScreenshot(const Path &filename, ScreenshotFormat fmt, ScreenshotType type, int *width, int *height, int maxRes) {
 	if (!gpuDebug) {
 		ERROR_LOG(SYSTEM, "Can't take screenshots when GPU not running");
 		return false;
@@ -378,7 +380,7 @@ bool TakeGameScreenshot(const char *filename, ScreenshotFormat fmt, ScreenshotTy
 	return success;
 }
 
-bool Save888RGBScreenshot(const char *filename, ScreenshotFormat fmt, const u8 *bufferRGB888, int w, int h) {
+bool Save888RGBScreenshot(const Path &filename, ScreenshotFormat fmt, const u8 *bufferRGB888, int w, int h) {
 	if (fmt == ScreenshotFormat::PNG) {
 		png_image png;
 		memset(&png, 0, sizeof(png));
@@ -403,7 +405,7 @@ bool Save888RGBScreenshot(const char *filename, ScreenshotFormat fmt, const u8 *
 	}
 }
 
-bool Save8888RGBAScreenshot(const char *filename, const u8 *buffer, int w, int h) {
+bool Save8888RGBAScreenshot(const Path &filename, const u8 *buffer, int w, int h) {
 	png_image png;
 	memset(&png, 0, sizeof(png));
 	png.version = PNG_IMAGE_VERSION;

--- a/Core/Screenshot.h
+++ b/Core/Screenshot.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "Common/File/Path.h"
+
 struct GPUDebugBuffer;
 
 enum class ScreenshotFormat {
@@ -36,6 +38,6 @@ enum ScreenshotType {
 const u8 *ConvertBufferToScreenshot(const GPUDebugBuffer &buf, bool alpha, u8 *&temp, u32 &w, u32 &h);
 
 // Can only be used while in game.
-bool TakeGameScreenshot(const char *filename, ScreenshotFormat fmt, ScreenshotType type, int *width = nullptr, int *height = nullptr, int maxRes = -1);
-bool Save888RGBScreenshot(const char *filename, ScreenshotFormat fmt, const u8 *bufferRGB888, int w, int h);
-bool Save8888RGBAScreenshot(const char *filename, const u8 *bufferRGBA8888, int w, int h);
+bool TakeGameScreenshot(const Path &filename, ScreenshotFormat fmt, ScreenshotType type, int *width = nullptr, int *height = nullptr, int maxRes = -1);
+bool Save888RGBScreenshot(const Path &filename, ScreenshotFormat fmt, const u8 *bufferRGB888, int w, int h);
+bool Save8888RGBAScreenshot(const Path &filename, const u8 *bufferRGBA8888, int w, int h);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -621,8 +621,7 @@ Path GetSysDirectory(PSPDirectories directoryType) {
 	}
 }
 
-
-#if defined(_WIN32)
+#if PPSSPP_PLATFORM(WINDOWS)
 // Run this at startup time. Please use GetSysDirectory if you need to query where folders are.
 void InitSysDirectories() {
 	if (!g_Config.memStickDirectory.empty() && !g_Config.flash0Directory.empty())

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -231,7 +231,7 @@ bool CPU_Init() {
 	Memory::g_PSPModel = g_Config.iPSPModel;
 
 	Path filename = coreParameter.fileToStart;
-	loadedFile = ResolveFileLoaderTarget(ConstructFileLoader(filename.ToString()));
+	loadedFile = ResolveFileLoaderTarget(ConstructFileLoader(filename));
 #if PPSSPP_ARCH(AMD64)
 	if (g_Config.bCacheFullIsoInRam) {
 		loadedFile = new RamCachingFileLoader(loadedFile);
@@ -241,7 +241,7 @@ bool CPU_Init() {
 
 	// TODO: Put this somewhere better?
 	if (!coreParameter.mountIso.empty()) {
-		coreParameter.mountIsoLoader = ConstructFileLoader(coreParameter.mountIso.ToString());
+		coreParameter.mountIsoLoader = ConstructFileLoader(coreParameter.mountIso);
 	}
 
 	MIPSAnalyst::Reset();

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -33,6 +33,7 @@
 #include <condition_variable>
 
 #include "Common/System/System.h"
+#include "Common/File/Path.h"
 #include "Common/Math/math_util.h"
 #include "Common/Thread/ThreadUtil.h"
 #include "Common/Data/Encoding/Utf8.h"
@@ -188,7 +189,7 @@ bool CPU_HasPendingAction() {
 
 void CPU_Shutdown();
 
-bool DiscIDFromGEDumpPath(const std::string &path, FileLoader *fileLoader, std::string *id) {
+bool DiscIDFromGEDumpPath(const Path &path, FileLoader *fileLoader, std::string *id) {
 	using namespace GPURecord;
 
 	// For newer files, it's stored in the dump.
@@ -205,7 +206,7 @@ bool DiscIDFromGEDumpPath(const std::string &path, FileLoader *fileLoader, std::
 	}
 
 	// Fall back to using the filename.
-	std::string filename = File::GetFilename(path);
+	std::string filename = File::GetFilename(path.ToString());
 	// Could be more discerning, but hey..
 	if (filename.size() > 10 && filename[0] == 'U' && filename[9] == '_') {
 		*id = filename.substr(0, 9);
@@ -229,8 +230,8 @@ bool CPU_Init() {
 	g_DoubleTextureCoordinates = false;
 	Memory::g_PSPModel = g_Config.iPSPModel;
 
-	std::string filename = coreParameter.fileToStart;
-	loadedFile = ResolveFileLoaderTarget(ConstructFileLoader(filename));
+	Path filename = coreParameter.fileToStart;
+	loadedFile = ResolveFileLoaderTarget(ConstructFileLoader(filename.ToString()));
 #if PPSSPP_ARCH(AMD64)
 	if (g_Config.bCacheFullIsoInRam) {
 		loadedFile = new RamCachingFileLoader(loadedFile);
@@ -240,7 +241,7 @@ bool CPU_Init() {
 
 	// TODO: Put this somewhere better?
 	if (!coreParameter.mountIso.empty()) {
-		coreParameter.mountIsoLoader = ConstructFileLoader(coreParameter.mountIso);
+		coreParameter.mountIsoLoader = ConstructFileLoader(coreParameter.mountIso.ToString());
 	}
 
 	MIPSAnalyst::Reset();
@@ -316,7 +317,7 @@ bool CPU_Init() {
 	}
 
 	if (coreParameter.updateRecent) {
-		g_Config.AddRecent(filename);
+		g_Config.AddRecent(filename.ToString());
 	}
 
 	InstallExceptionHandler(&Memory::HandleFault);
@@ -578,39 +579,39 @@ CoreParameter &PSP_CoreParameter() {
 	return coreParameter;
 }
 
-std::string GetSysDirectory(PSPDirectories directoryType) {
+Path GetSysDirectory(PSPDirectories directoryType) {
 	switch (directoryType) {
 	case DIRECTORY_CHEATS:
-		return g_Config.memStickDirectory + "PSP/Cheats/";
+		return g_Config.memStickDirectory / "PSP/Cheats";
 	case DIRECTORY_GAME:
-		return g_Config.memStickDirectory + "PSP/GAME/";
+		return g_Config.memStickDirectory / "PSP/GAME";
 	case DIRECTORY_SAVEDATA:
-		return g_Config.memStickDirectory + "PSP/SAVEDATA/";
+		return g_Config.memStickDirectory / "PSP/SAVEDATA";
 	case DIRECTORY_SCREENSHOT:
-		return g_Config.memStickDirectory + "PSP/SCREENSHOT/";
+		return g_Config.memStickDirectory / "PSP/SCREENSHOT";
 	case DIRECTORY_SYSTEM:
-		return g_Config.memStickDirectory + "PSP/SYSTEM/";
+		return g_Config.memStickDirectory / "PSP/SYSTEM";
 	case DIRECTORY_PAUTH:
-		return g_Config.memStickDirectory + "PAUTH/";
+		return g_Config.memStickDirectory / "PAUTH";
 	case DIRECTORY_DUMP:
-		return g_Config.memStickDirectory + "PSP/SYSTEM/DUMP/";
+		return g_Config.memStickDirectory / "PSP/SYSTEM/DUMP";
 	case DIRECTORY_SAVESTATE:
-		return g_Config.memStickDirectory + "PSP/PPSSPP_STATE/";
+		return g_Config.memStickDirectory / "PSP/PPSSPP_STATE";
 	case DIRECTORY_CACHE:
-		return g_Config.memStickDirectory + "PSP/SYSTEM/CACHE/";
+		return g_Config.memStickDirectory / "PSP/SYSTEM/CACHE";
 	case DIRECTORY_TEXTURES:
-		return g_Config.memStickDirectory + "PSP/TEXTURES/";
+		return g_Config.memStickDirectory / "PSP/TEXTURES";
 	case DIRECTORY_PLUGINS:
-		return g_Config.memStickDirectory + "PSP/PLUGINS/";
+		return g_Config.memStickDirectory / "PSP/PLUGINS";
 	case DIRECTORY_APP_CACHE:
 		if (!g_Config.appCacheDirectory.empty()) {
-			return g_Config.appCacheDirectory;
+			return Path(g_Config.appCacheDirectory);
 		}
-		return g_Config.memStickDirectory + "PSP/SYSTEM/CACHE/";
+		return g_Config.memStickDirectory / "PSP/SYSTEM/CACHE";
 	case DIRECTORY_VIDEO:
-		return g_Config.memStickDirectory + "PSP/VIDEO/";
+		return g_Config.memStickDirectory / "PSP/VIDEO";
 	case DIRECTORY_AUDIO:
-		return g_Config.memStickDirectory + "PSP/AUDIO/";
+		return g_Config.memStickDirectory / "PSP/AUDIO";
 	case DIRECTORY_MEMSTICK_ROOT:
 		return g_Config.memStickDirectory;
 	// Just return the memory stick root if we run into some sort of problem.
@@ -620,16 +621,17 @@ std::string GetSysDirectory(PSPDirectories directoryType) {
 	}
 }
 
+
 #if defined(_WIN32)
 // Run this at startup time. Please use GetSysDirectory if you need to query where folders are.
 void InitSysDirectories() {
 	if (!g_Config.memStickDirectory.empty() && !g_Config.flash0Directory.empty())
 		return;
 
-	const std::string path = File::GetExeDirectory();
+	const Path path = Path(File::GetExeDirectory());
 
 	// Mount a filesystem
-	g_Config.flash0Directory = path + "assets/flash0/";
+	g_Config.flash0Directory = path / "assets/flash0";
 
 	// Detect the "My Documents"(XP) or "Documents"(on Vista/7/8) folder.
 #if PPSSPP_PLATFORM(UWP)
@@ -637,13 +639,13 @@ void InitSysDirectories() {
 
 #else
 	// Caller sets this to the Documents folder.
-	const std::string rootMyDocsPath = g_Config.internalDataDirectory;
-	const std::string myDocsPath = rootMyDocsPath + "/PPSSPP/";
-	const std::string installedFile = path + "installed.txt";
+	const Path rootMyDocsPath = Path(g_Config.internalDataDirectory);
+	const Path myDocsPath = rootMyDocsPath / "PPSSPP";
+	const Path installedFile = path / "installed.txt";
 	const bool installed = File::Exists(installedFile);
 
 	// If installed.txt exists(and we can determine the Documents directory)
-	if (installed && rootMyDocsPath.size() > 0) {
+	if (installed && !rootMyDocsPath.empty()) {
 		FILE *fp = File::OpenCFile(installedFile, "rt");
 		if (fp) {
 			char temp[2048];
@@ -656,19 +658,15 @@ void InitSysDirectories() {
 			if (!tempString.empty() && tempString.back() == '\n')
 				tempString.resize(tempString.size() - 1);
 
-			g_Config.memStickDirectory = tempString;
+			g_Config.memStickDirectory = Path(tempString);
 			fclose(fp);
 		}
 
 		// Check if the file is empty first, before appending the slash.
 		if (g_Config.memStickDirectory.empty())
 			g_Config.memStickDirectory = myDocsPath;
-
-		size_t lastSlash = g_Config.memStickDirectory.find_last_of("/");
-		if (lastSlash != (g_Config.memStickDirectory.length() - 1))
-			g_Config.memStickDirectory.append("/");
 	} else {
-		g_Config.memStickDirectory = path + "memstick/";
+		g_Config.memStickDirectory = path / "memstick";
 	}
 
 	// Create the memstickpath before trying to write to it, and fall back on Documents yet again
@@ -679,7 +677,7 @@ void InitSysDirectories() {
 		INFO_LOG(COMMON, "Memstick directory not present, creating at '%s'", g_Config.memStickDirectory.c_str());
 	}
 
-	const std::string testFile = g_Config.memStickDirectory + "_writable_test.$$$";
+	Path testFile = Path(g_Config.memStickDirectory) / "_writable_test.$$$";
 
 	// If any directory is read-only, fall back to the Documents directory.
 	// We're screwed anyway if we can't write to Documents, or can't detect it.
@@ -693,14 +691,14 @@ void InitSysDirectories() {
 
 	// Create the default directories that a real PSP creates. Good for homebrew so they can
 	// expect a standard environment. Skipping THEME though, that's pointless.
-	File::CreateDir(g_Config.memStickDirectory + "PSP");
-	File::CreateDir(g_Config.memStickDirectory + "PSP/COMMON");
+	File::CreateDir(g_Config.memStickDirectory / "PSP");
+	File::CreateDir(g_Config.memStickDirectory / "PSP/COMMON");
 	File::CreateDir(GetSysDirectory(DIRECTORY_GAME));
 	File::CreateDir(GetSysDirectory(DIRECTORY_SAVEDATA));
 	File::CreateDir(GetSysDirectory(DIRECTORY_SAVESTATE));
 
 	if (g_Config.currentDirectory.empty()) {
-		g_Config.currentDirectory = GetSysDirectory(DIRECTORY_GAME);
+		g_Config.currentDirectory = GetSysDirectory(DIRECTORY_GAME).ToString();
 	}
 }
 #endif

--- a/Core/System.h
+++ b/Core/System.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "Common/CommonTypes.h"
+#include "Common/File/Path.h"
 #include "Core/CoreParameter.h"
 
 class MetaFileSystem;
@@ -96,7 +97,7 @@ bool IsAudioInitialised();
 
 void UpdateLoadedFile(FileLoader *fileLoader);
 
-std::string GetSysDirectory(PSPDirectories directoryType);
+Path GetSysDirectory(PSPDirectories directoryType);
 #ifdef _WIN32
 void InitSysDirectories();
 #endif

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -55,7 +55,7 @@ void TextureReplacer::NotifyConfigChanged() {
 
 	enabled_ = g_Config.bReplaceTextures || g_Config.bSaveNewTextures;
 	if (enabled_) {
-		basePath_ = Path(GetSysDirectory(DIRECTORY_TEXTURES)) / gameID_;
+		basePath_ = GetSysDirectory(DIRECTORY_TEXTURES) / gameID_;
 
 		Path newTextureDir = basePath_ / NEW_TEXTURE_DIR;
 
@@ -400,7 +400,7 @@ void TextureReplacer::PopulateReplacement(ReplacedTexture *result, u64 cachekey,
 		bool good = false;
 		ReplacedTextureLevel level;
 		level.fmt = ReplacedTextureFormat::F_8888;
-		level.file = filename.ToString();
+		level.file = filename;
 
 		png_image png = {};
 		png.version = PNG_IMAGE_VERSION;
@@ -569,7 +569,7 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 	// Remember that we've saved this for next time.
 	ReplacedTextureLevel saved;
 	saved.fmt = ReplacedTextureFormat::F_8888;
-	saved.file = filename.ToString();
+	saved.file = filename;
 	saved.w = w;
 	saved.h = h;
 	savedCache_[replacementKey] = saved;
@@ -729,7 +729,7 @@ void ReplacedTexture::Load(int level, void *out, int rowPitch) {
 	png_image_free(&png);
 }
 
-bool TextureReplacer::GenerateIni(const std::string &gameID, Path *generatedFilename) {
+bool TextureReplacer::GenerateIni(const std::string &gameID, Path &generatedFilename) {
 	if (gameID.empty())
 		return false;
 
@@ -738,12 +738,11 @@ bool TextureReplacer::GenerateIni(const std::string &gameID, Path *generatedFile
 		File::CreateFullPath(texturesDirectory);
 	}
 
-	if (generatedFilename)
-		*generatedFilename = texturesDirectory / INI_FILENAME;
-	if (File::Exists(*generatedFilename))
+	generatedFilename = texturesDirectory / INI_FILENAME;
+	if (File::Exists(generatedFilename))
 		return true;
 
-	FILE *f = File::OpenCFile(texturesDirectory / INI_FILENAME, "wb");
+	FILE *f = File::OpenCFile(generatedFilename, "wb");
 	if (f) {
 		fwrite("\xEF\xBB\xBF", 1, 3, f);
 
@@ -772,5 +771,5 @@ bool TextureReplacer::GenerateIni(const std::string &gameID, Path *generatedFile
 		fprintf(f, "[reducehashranges]\n");
 		fclose(f);
 	}
-	return File::Exists(texturesDirectory / INI_FILENAME);
+	return File::Exists(generatedFilename);
 }

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -57,10 +57,12 @@ void TextureReplacer::NotifyConfigChanged() {
 	if (enabled_) {
 		basePath_ = Path(GetSysDirectory(DIRECTORY_TEXTURES)) / gameID_;
 
+		Path newTextureDir = basePath_ / NEW_TEXTURE_DIR;
+
 		// If we're saving, auto-create the directory.
-		if (g_Config.bSaveNewTextures && !File::Exists((basePath_ / NEW_TEXTURE_DIR).ToString())) {
-			File::CreateFullPath(basePath_ / NEW_TEXTURE_DIR);
-			File::CreateEmptyFile(basePath_ / NEW_TEXTURE_DIR / ".nomedia");
+		if (g_Config.bSaveNewTextures && !File::Exists(newTextureDir)) {
+			File::CreateFullPath(newTextureDir);
+			File::CreateEmptyFile(newTextureDir / ".nomedia");
 		}
 
 		enabled_ = File::Exists(basePath_) && File::IsDirectory(basePath_);

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -21,8 +21,11 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 #include "Common/Common.h"
 #include "Common/MemoryUtil.h"
+#include "Common/File/Path.h"
+
 #include "GPU/Common/TextureDecoder.h"
 #include "GPU/ge_constants.h"
 
@@ -188,7 +191,7 @@ public:
 
 	void NotifyTextureDecoded(const ReplacedTextureDecodeInfo &replacedInfo, const void *data, int pitch, int level, int w, int h);
 
-	static bool GenerateIni(const std::string &gameID, std::string *generatedFilename);
+	static bool GenerateIni(const std::string &gameID, Path *generatedFilename);
 
 protected:
 	bool LoadIni();
@@ -211,7 +214,7 @@ protected:
 	float reduceHashGlobalValue = 0.5; // Global value for textures dump pngs of all sizes, 0.5 by default but can be set in textures.ini
 	bool ignoreMipmap_ = false;
 	std::string gameID_;
-	std::string basePath_;
+	Path basePath_;
 	ReplacedTextureHash hash_ = ReplacedTextureHash::QUICK;
 	typedef std::pair<int, int> WidthHeightPair;
 	std::unordered_map<u64, WidthHeightPair> hashranges_;

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -61,7 +61,7 @@ struct ReplacedTextureLevel {
 	int w;
 	int h;
 	ReplacedTextureFormat fmt;
-	std::string file;
+	Path file;
 };
 
 struct ReplacementCacheKey {
@@ -191,7 +191,7 @@ public:
 
 	void NotifyTextureDecoded(const ReplacedTextureDecodeInfo &replacedInfo, const void *data, int pitch, int level, int w, int h);
 
-	static bool GenerateIni(const std::string &gameID, Path *generatedFilename);
+	static bool GenerateIni(const std::string &gameID, Path &generatedFilename);
 
 protected:
 	bool LoadIni();

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -532,13 +532,11 @@ bool GameManager::InstallMemstickGame(struct zip *z, const Path &zipfile, const 
 		}
 		std::string outFilename = dest + zippedName.substr(info.stripChars);
 
-		zip_uint32_t attrs = 0;
-		if (0 != zip_file_get_external_attributes(z, i, 0, nullptr, &attrs)) {
-			continue;
-		}
-		bool isDir = attrs & 
-		if (!isDir && outFilename.find("/") != std::string::npos) {
-			outFilename = outFilename.substr(0, outFilename.rfind('/'));
+		bool isDir = zippedName.empty() || zippedName.back() == '/';
+		if (!isDir && zippedName.find("/") != std::string::npos) {
+			outFilename = dest + zippedName.substr(0, zippedName.rfind('/'));
+		} else if (!isDir) {
+			outFilename = dest;
 		}
 
 		Path outPath(outFilename);
@@ -561,9 +559,10 @@ bool GameManager::InstallMemstickGame(struct zip *z, const Path &zipfile, const 
 		// Note that we do NOT write files that are not in a directory, to avoid random
 		// README files etc. (unless allowRoot is true.)
 		if (fileAllowed(fn) && strlen(fn) > (size_t)info.stripChars) {
+			std::string zippedName = fn;
 			fn += info.stripChars;
 			std::string outFilename = dest + fn;
-			bool isDir = *outFilename.rbegin() == '/';
+			bool isDir = zippedName.empty() || zippedName.back() == '/';
 			if (isDir)
 				continue;
 

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -260,7 +260,7 @@ bool GameManager::InstallGame(const std::string &url, const std::string &fileNam
 		return false;
 	}
 
-	if (!File::Exists(fileName)) {
+	if (!File::Exists(Path(fileName))) {
 		ERROR_LOG(HLE, "Game file '%s' doesn't exist", fileName.c_str());
 		return false;
 	}
@@ -634,9 +634,9 @@ bool GameManager::InstallGameOnThread(std::string url, std::string fileName, boo
 }
 
 bool GameManager::InstallRawISO(const std::string &file, const std::string &originalName, bool deleteAfter) {
-	std::string destPath = g_Config.currentDirectory + "/" + originalName;
+	Path destPath = Path(g_Config.currentDirectory) / originalName;
 	// TODO: To save disk space, we should probably attempt a move first.
-	if (File::Copy(file, destPath)) {
+	if (File::Copy(Path(file), destPath)) {
 		if (deleteAfter) {
 			File::Delete(Path(file));
 		}

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -77,7 +77,7 @@ public:
 
 private:
 	bool InstallGame(Path url, Path tempFileName, bool deleteAfter);
-	bool InstallMemstickGame(struct zip *z, const Path &zipFile, const std::string &pspGame, const ZipFileInfo &info, bool allowRoot, bool deleteAfter);
+	bool InstallMemstickGame(struct zip *z, const Path &zipFile, const Path &dest, const ZipFileInfo &info, bool allowRoot, bool deleteAfter);
 	bool InstallZippedISO(struct zip *z, int isoFileIndex, const Path &zipfile, bool deleteAfter);
 	bool InstallRawISO(const Path &zipFile, const std::string &originalName, bool deleteAfter);
 	void InstallDone();

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -73,20 +73,20 @@ public:
 	}
 
 	// Only returns false if there's already an installation in progress.
-	bool InstallGameOnThread(std::string url, std::string tempFileName, bool deleteAfter);
+	bool InstallGameOnThread(const Path &url, const Path &tempFileName, bool deleteAfter);
 
 private:
-	bool InstallGame(const std::string &url, const std::string &tempFileName, bool deleteAfter);
-	bool InstallMemstickGame(struct zip *z, const std::string &zipFile, const std::string &pspGame, const ZipFileInfo &info, bool allowRoot, bool deleteAfter);
-	bool InstallZippedISO(struct zip *z, int isoFileIndex, std::string zipfile, bool deleteAfter);
-	bool InstallRawISO(const std::string &zipFile, const std::string &originalName, bool deleteAfter);
+	bool InstallGame(Path url, Path tempFileName, bool deleteAfter);
+	bool InstallMemstickGame(struct zip *z, const Path &zipFile, const std::string &pspGame, const ZipFileInfo &info, bool allowRoot, bool deleteAfter);
+	bool InstallZippedISO(struct zip *z, int isoFileIndex, const Path &zipfile, bool deleteAfter);
+	bool InstallRawISO(const Path &zipFile, const std::string &originalName, bool deleteAfter);
 	void InstallDone();
 	bool ExtractFile(struct zip *z, int file_index, const Path &outFilename, size_t *bytesCopied, size_t allBytes);
 	bool DetectTexturePackDest(struct zip *z, int iniIndex, Path &dest);
 	void SetInstallError(const std::string &err);
 
 	std::string GetTempFilename() const;
-	std::string GetGameID(const std::string &path) const;
+	std::string GetGameID(const Path &path) const;
 	std::string GetPBPGameID(FileLoader *loader) const;
 	std::string GetISOGameID(FileLoader *loader) const;
 	std::shared_ptr<http::Download> curDownload_;
@@ -115,4 +115,4 @@ struct ZipFileInfo {
 };
 
 ZipFileContents DetectZipFileContents(struct zip *z, ZipFileInfo *info);
-ZipFileContents DetectZipFileContents(std::string fileName, ZipFileInfo *info);
+ZipFileContents DetectZipFileContents(const Path &fileName, ZipFileInfo *info);

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -23,7 +23,9 @@
 #pragma once
 
 #include <thread>
+
 #include "Common/Net/HTTPClient.h"
+#include "Common/File/Path.h"
 
 enum class GameManagerState {
 	IDLE,
@@ -79,8 +81,8 @@ private:
 	bool InstallZippedISO(struct zip *z, int isoFileIndex, std::string zipfile, bool deleteAfter);
 	bool InstallRawISO(const std::string &zipFile, const std::string &originalName, bool deleteAfter);
 	void InstallDone();
-	bool ExtractFile(struct zip *z, int file_index, std::string outFilename, size_t *bytesCopied, size_t allBytes);
-	bool DetectTexturePackDest(struct zip *z, int iniIndex, std::string *dest);
+	bool ExtractFile(struct zip *z, int file_index, const Path &outFilename, size_t *bytesCopied, size_t allBytes);
+	bool DetectTexturePackDest(struct zip *z, int iniIndex, Path &dest);
 	void SetInstallError(const std::string &err);
 
 	std::string GetTempFilename() const;

--- a/Core/WaveFile.cpp
+++ b/Core/WaveFile.cpp
@@ -17,7 +17,7 @@ WaveFileWriter::~WaveFileWriter()
 	Stop();
 }
 
-bool WaveFileWriter::Start(const std::string& filename, unsigned int HLESampleRate)
+bool WaveFileWriter::Start(const Path &filename, unsigned int HLESampleRate)
 {
 	// Check if the file is already open
 	if (file) {

--- a/Core/WaveFile.h
+++ b/Core/WaveFile.h
@@ -24,7 +24,7 @@ public:
 	WaveFileWriter();
 	~WaveFileWriter();
 
-	bool Start(const std::string& filename, unsigned int HLESampleRate);
+	bool Start(const Path& filename, unsigned int HLESampleRate);
 	void Stop();
 
 	void SetSkipSilence(bool skip) { skip_silence = skip; }

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -158,8 +158,8 @@ static std::string LocalFromRemotePath(const std::string &path) {
 	return "";
 }
 
-static void DiscHandler(const http::Request &request, const std::string &filename) {
-	s64 sz = File::GetFileSize(filename);
+static void DiscHandler(const http::Request &request, const Path &filename) {
+	s64 sz = File::GetFileSize(filename.ToString());
 
 	std::string range;
 	if (request.Method() == http::RequestHeader::HEAD) {
@@ -231,7 +231,8 @@ static void HandleFallback(const http::Request &request) {
 	if (serverFlags & (int)WebServerFlags::DISCS) {
 		std::string filename = LocalFromRemotePath(request.resource());
 		if (!filename.empty()) {
-			DiscHandler(request, filename);
+			// TODO(scoped): Is this right?
+			DiscHandler(request, Path(filename));
 			return;
 		}
 	}

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -148,14 +148,14 @@ static std::string RemotePathForRecent(const std::string &filename) {
 	return "";
 }
 
-static std::string LocalFromRemotePath(const std::string &path) {
+static Path LocalFromRemotePath(const std::string &path) {
 	for (const std::string &filename : g_Config.recentIsos) {
 		std::string basename = RemotePathForRecent(filename);
 		if (basename == path) {
-			return filename;
+			return Path(filename);
 		}
 	}
-	return "";
+	return Path();
 }
 
 static void DiscHandler(const http::Request &request, const Path &filename) {
@@ -229,10 +229,9 @@ static void HandleListing(const http::Request &request) {
 
 static void HandleFallback(const http::Request &request) {
 	if (serverFlags & (int)WebServerFlags::DISCS) {
-		std::string filename = LocalFromRemotePath(request.resource());
+		Path filename = LocalFromRemotePath(request.resource());
 		if (!filename.empty()) {
-			// TODO(scoped): Is this right?
-			DiscHandler(request, Path(filename));
+			DiscHandler(request, filename);
 			return;
 		}
 	}

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -38,7 +38,7 @@ static std::vector<TextureShaderInfo> textureShaderInfo;
 
 // Scans the directories for shader ini files and collects info about all the shaders found.
 
-void LoadPostShaderInfo(const std::vector<std::string> &directories) {
+void LoadPostShaderInfo(const std::vector<Path> &directories) {
 	std::vector<ShaderInfo> notVisible;
 
 	shaderInfo.clear();
@@ -79,7 +79,7 @@ void LoadPostShaderInfo(const std::vector<std::string> &directories) {
 
 	for (size_t d = 0; d < directories.size(); d++) {
 		std::vector<File::FileInfo> fileInfo;
-		File::GetFilesInDir(directories[d].c_str(), &fileInfo, "ini:");
+		File::GetFilesInDir(directories[d], &fileInfo, "ini:");
 
 		if (fileInfo.size() == 0) {
 			VFSGetFileListing(directories[d].c_str(), &fileInfo, "ini:");
@@ -89,7 +89,7 @@ void LoadPostShaderInfo(const std::vector<std::string> &directories) {
 			IniFile ini;
 			bool success = false;
 			std::string name = fileInfo[f].fullName;
-			std::string path = directories[d];
+			std::string path = directories[d].ToString();
 			// Hack around Android VFS path bug. really need to redesign this.
 			if (name.substr(0, 7) == "assets/")
 				name = name.substr(7);
@@ -181,9 +181,9 @@ void LoadPostShaderInfo(const std::vector<std::string> &directories) {
 
 // Scans the directories for shader ini files and collects info about all the shaders found.
 void ReloadAllPostShaderInfo() {
-	std::vector<std::string> directories;
-	directories.push_back("shaders");
-	directories.push_back(g_Config.memStickDirectory + "PSP/shaders");
+	std::vector<Path> directories;
+	directories.push_back(Path("shaders"));  // Hm, why?
+	directories.push_back(g_Config.memStickDirectory / "PSP" / "shaders");
 	LoadPostShaderInfo(directories);
 }
 

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -88,18 +88,19 @@ void LoadPostShaderInfo(const std::vector<Path> &directories) {
 		for (size_t f = 0; f < fileInfo.size(); f++) {
 			IniFile ini;
 			bool success = false;
-			std::string name = fileInfo[f].fullName;
-			std::string path = directories[d].ToString();
+			Path name = fileInfo[f].fullName;
+			Path path = directories[d];
 			// Hack around Android VFS path bug. really need to redesign this.
-			if (name.substr(0, 7) == "assets/")
-				name = name.substr(7);
-			if (path.substr(0, 7) == "assets/")
-				path = path.substr(7);
+			if (name.ToString().substr(0, 7) == "assets/")
+				name = Path(name.ToString().substr(7));
+			if (path.ToString().substr(0, 7) == "assets/")
+				path = Path(path.ToString().substr(7));
 
-			if (ini.LoadFromVFS(name) || ini.Load(fileInfo[f].fullName)) {
+			if (ini.LoadFromVFS(name.ToString()) || ini.Load(fileInfo[f].fullName)) {
 				success = true;
 				// vsh load. meh.
 			}
+
 			if (!success)
 				continue;
 
@@ -118,9 +119,9 @@ void LoadPostShaderInfo(const std::vector<Path> &directories) {
 					section.Get("Parent", &info.parent, "");
 					section.Get("Visible", &info.visible, true);
 					section.Get("Fragment", &temp, "");
-					info.fragmentShaderFile = path + "/" + temp;
+					info.fragmentShaderFile = path / temp;
 					section.Get("Vertex", &temp, "");
-					info.vertexShaderFile = path + "/" + temp;
+					info.vertexShaderFile = path / temp;
 					section.Get("OutputResolution", &info.outputResolution, false);
 					section.Get("Upscaling", &info.isUpscalingFilter, false);
 					section.Get("SSAA", &info.SSAAFilterLevel, 0);
@@ -165,7 +166,7 @@ void LoadPostShaderInfo(const std::vector<Path> &directories) {
 					section.Get("Name", &info.name, section.name().c_str());
 					section.Get("Compute", &temp, "");
 					section.Get("MaxScale", &info.maxScale, 255);
-					info.computeShaderFile = path + "/" + temp;
+					info.computeShaderFile = path / temp;
 
 					appendTextureShader(info);
 				}

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include <algorithm>
 
+#include "Common/Log.h"
 #include "Common/Data/Format/IniFile.h"
 #include "Common/File/FileUtil.h"
 #include "Common/File/DirListing.h"
@@ -183,7 +184,7 @@ void LoadPostShaderInfo(const std::vector<Path> &directories) {
 // Scans the directories for shader ini files and collects info about all the shaders found.
 void ReloadAllPostShaderInfo() {
 	std::vector<Path> directories;
-	directories.push_back(Path("shaders"));  // Hm, why?
+	directories.push_back(Path("shaders"));  // For VFS
 	directories.push_back(g_Config.memStickDirectory / "PSP" / "shaders");
 	LoadPostShaderInfo(directories);
 }

--- a/GPU/Common/PostShader.h
+++ b/GPU/Common/PostShader.h
@@ -25,13 +25,13 @@
 #include "Common/Data/Format/IniFile.h"
 
 struct ShaderInfo {
-	std::string iniFile;  // which ini file was this definition in? So we can write settings back later
+	Path iniFile;  // which ini file was this definition in? So we can write settings back later
 	std::string section;  // ini file section. This is saved.
 	std::string name;     // Fancy display name.
 	std::string parent;   // Parent shader ini section name.
 
-	std::string fragmentShaderFile;
-	std::string vertexShaderFile;
+	Path fragmentShaderFile;
+	Path vertexShaderFile;
 
 	// Show this shader in lists (i.e. not just for chaining.)
 	bool visible;
@@ -65,11 +65,11 @@ struct ShaderInfo {
 };
 
 struct TextureShaderInfo {
-	std::string iniFile;
+	Path iniFile;
 	std::string section;
 	std::string name;
 
-	std::string computeShaderFile;
+	Path computeShaderFile;
 	int maxScale;
 
 	bool operator == (const std::string &other) {

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -197,11 +197,13 @@ void PresentationCommon::CalculatePostShaderUniforms(int bufferWidth, int buffer
 	uniforms->setting[3] = g_Config.mPostShaderSetting[shaderInfo->section + "SettingValue4"];
 }
 
-static std::string ReadShaderSrc(const std::string &filename) {
+static std::string ReadShaderSrc(const Path &filename) {
 	size_t sz = 0;
+	// TODO(scoped): VFS paths not handled well.
 	char *data = (char *)VFSReadFile(filename.c_str(), &sz);
-	if (!data)
+	if (!data) {
 		return "";
+	}
 
 	std::string src(data, sz);
 	delete[] data;

--- a/GPU/Debugger/Record.h
+++ b/GPU/Debugger/Record.h
@@ -19,7 +19,9 @@
 
 #include <functional>
 #include <string>
+
 #include "Common/CommonTypes.h"
+#include "Common/File/Path.h"
 
 namespace GPURecord {
 
@@ -27,7 +29,7 @@ bool IsActive();
 bool IsActivePending();
 bool Activate();
 // Call only if Activate() returns true.
-void SetCallback(const std::function<void(const std::string &)> callback);
+void SetCallback(const std::function<void(const Path &)> callback);
 
 void NotifyCommand(u32 pc);
 void NotifyMemcpy(u32 dest, u32 src, u32 sz);

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -53,7 +53,7 @@
 #endif
 
 GPU_GLES::GPU_GLES(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
-: GPUCommon(gfxCtx, draw), depalShaderCache_(draw), drawEngine_(draw), fragmentTestCache_(draw) {
+	: GPUCommon(gfxCtx, draw), depalShaderCache_(draw), drawEngine_(draw), fragmentTestCache_(draw) {
 	UpdateVsyncInterval(true);
 	CheckGPUFeatures();
 
@@ -104,7 +104,7 @@ GPU_GLES::GPU_GLES(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	std::string discID = g_paramSFO.GetDiscID();
 	if (discID.size()) {
 		File::CreateFullPath(GetSysDirectory(DIRECTORY_APP_CACHE));
-		shaderCachePath_ = GetSysDirectory(DIRECTORY_APP_CACHE) + "/" + discID + ".glshadercache";
+		shaderCachePath_ = GetSysDirectory(DIRECTORY_APP_CACHE) / (discID + ".glshadercache");
 		// Actually precompiled by IsReady() since we're single-threaded.
 		shaderManagerGL_->Load(shaderCachePath_);
 	}
@@ -128,7 +128,7 @@ GPU_GLES::~GPU_GLES() {
 	// If we're here during app shutdown (exiting the Windows app in-game, for example)
 	// everything should already be cleared since DeviceLost has been run.
 
-	if (!shaderCachePath_.empty() && draw_) {
+	if (shaderCachePath_.Valid() && draw_) {
 		shaderManagerGL_->Save(shaderCachePath_);
 	}
 
@@ -354,7 +354,7 @@ void GPU_GLES::BeginFrame() {
 	GPUCommon::BeginFrame();
 
 	// Save the cache from time to time. TODO: How often? We save on exit, so shouldn't need to do this all that often.
-	if (!shaderCachePath_.empty() && (gpuStats.numFlips & 4095) == 0) {
+	if (shaderCachePath_.Valid() && (gpuStats.numFlips & 4095) == 0) {
 		shaderManagerGL_->Save(shaderCachePath_);
 	}
 

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -20,6 +20,8 @@
 #include <string>
 #include <vector>
 
+#include "Common/File/Path.h"
+
 #include "GPU/GPUCommon.h"
 #include "GPU/GLES/FramebufferManagerGLES.h"
 #include "GPU/GLES/DrawEngineGLES.h"
@@ -86,5 +88,5 @@ private:
 	FragmentTestCacheGLES fragmentTestCache_;
 	ShaderManagerGLES *shaderManagerGL_;
 
-	std::string shaderCachePath_;
+	Path shaderCachePath_;
 };

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -849,7 +849,7 @@ struct CacheHeader {
 	int numLinkedPrograms;
 };
 
-void ShaderManagerGLES::Load(const std::string &filename) {
+void ShaderManagerGLES::Load(const Path &filename) {
 	File::IOFile f(filename, "rb");
 	u64 sz = f.GetSize();
 	if (!f.IsOpen()) {
@@ -997,7 +997,7 @@ void ShaderManagerGLES::CancelPrecompile() {
 	diskCachePending_.Clear();
 }
 
-void ShaderManagerGLES::Save(const std::string &filename) {
+void ShaderManagerGLES::Save(const Path &filename) {
 	if (!diskCacheDirty_) {
 		return;
 	}

--- a/GPU/GLES/ShaderManagerGLES.h
+++ b/GPU/GLES/ShaderManagerGLES.h
@@ -21,6 +21,7 @@
 
 #include "Common/Data/Collections/Hashmaps.h"
 #include "Common/GPU/OpenGL/GLRenderManager.h"
+#include "Common/File/Path.h"
 #include "GPU/Common/ShaderCommon.h"
 #include "GPU/Common/ShaderId.h"
 #include "GPU/Common/VertexShaderGenerator.h"
@@ -162,10 +163,10 @@ public:
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType type);
 	std::string DebugGetShaderString(std::string id, DebugShaderType type, DebugShaderStringType stringType);
 
-	void Load(const std::string &filename);
+	void Load(const Path &filename);
 	bool ContinuePrecompile(float sliceTime = 1.0f / 60.0f);
 	void CancelPrecompile();
-	void Save(const std::string &filename);
+	void Save(const Path &filename);
 
 private:
 	void Clear();

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -104,7 +104,7 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	std::string discID = g_paramSFO.GetDiscID();
 	if (discID.size()) {
 		File::CreateFullPath(GetSysDirectory(DIRECTORY_APP_CACHE));
-		shaderCachePath_ = GetSysDirectory(DIRECTORY_APP_CACHE) + "/" + discID + ".vkshadercache";
+		shaderCachePath_ = GetSysDirectory(DIRECTORY_APP_CACHE) / (discID + ".vkshadercache");
 		shaderCacheLoaded_ = false;
 
 		std::thread th([&] {
@@ -125,7 +125,7 @@ void GPU_Vulkan::CancelReady() {
 	pipelineManager_->CancelCache();
 }
 
-void GPU_Vulkan::LoadCache(std::string filename) {
+void GPU_Vulkan::LoadCache(const Path &filename) {
 	PSP_SetLoading("Loading shader cache...");
 	// Actually precompiled by IsReady() since we're single-threaded.
 	FILE *f = File::OpenCFile(filename, "rb");
@@ -150,7 +150,7 @@ void GPU_Vulkan::LoadCache(std::string filename) {
 	}
 }
 
-void GPU_Vulkan::SaveCache(std::string filename) {
+void GPU_Vulkan::SaveCache(const Path &filename) {
 	if (!draw_) {
 		// Already got the lost message, we're in shutdown.
 		WARN_LOG(G3D, "Not saving shaders - shutting down from in-game.");
@@ -524,7 +524,7 @@ void GPU_Vulkan::DeviceLost() {
 	while (!IsReady()) {
 		sleep_ms(10);
 	}
-	if (!shaderCachePath_.empty()) {
+	if (shaderCachePath_.Valid()) {
 		SaveCache(shaderCachePath_);
 	}
 	DestroyDeviceObjects();

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -20,6 +20,8 @@
 #include <string>
 #include <vector>
 
+#include "Common/File/Path.h"
+
 #include "GPU/GPUCommon.h"
 #include "GPU/Vulkan/DrawEngineVulkan.h"
 #include "GPU/Vulkan/PipelineManagerVulkan.h"
@@ -84,8 +86,8 @@ private:
 	void InitDeviceObjects();
 	void DestroyDeviceObjects();
 
-	void LoadCache(std::string filename);
-	void SaveCache(std::string filename);
+	void LoadCache(const Path &filename);
+	void SaveCache(const Path &filename);
 
 	VulkanContext *vulkan_;
 	FramebufferManagerVulkan *framebufferManagerVulkan_;
@@ -108,6 +110,6 @@ private:
 
 	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES]{};
 
-	std::string shaderCachePath_;
+	Path shaderCachePath_;
 	bool shaderCacheLoaded_ = false;
 };

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -375,7 +375,7 @@ void TextureCacheVulkan::NotifyConfigChanged() {
 	CompileScalingShader();
 }
 
-static std::string ReadShaderSrc(const std::string &filename) {
+static std::string ReadShaderSrc(const Path &filename) {
 	size_t sz = 0;
 	char *data = (char *)VFSReadFile(filename.c_str(), &sz);
 	if (!data)

--- a/Qt/QtHost.cpp
+++ b/Qt/QtHost.cpp
@@ -18,12 +18,10 @@
 #include <string>
 #include "Qt/QtHost.h"
 
-std::string QtHost::SymbolMapFilename(std::string currentFilename) {
-	size_t dot = currentFilename.rfind('.');
-	if (dot == std::string::npos)
-		currentFilename.append(".map");
+Path QtHost::SymbolMapFilename(Path currentFilename) {
+	std::string ext = currentFilename.GetFileExtension();
+	if (ext == "")
+		return currentFilename.WithExtraExtension("map");
 	else
-		currentFilename.replace(dot, -1, ".map");
-
-	return currentFilename;
+		return currentFilename.WithReplacedExtension(ext, "map");
 }

--- a/Qt/QtHost.h
+++ b/Qt/QtHost.h
@@ -65,14 +65,14 @@ public:
 	}
 	virtual bool AttemptLoadSymbolMap() override {
 		auto fn = SymbolMapFilename(PSP_CoreParameter().fileToStart);
-		return g_symbolMap->LoadSymbolMap(fn.c_str());
+		return g_symbolMap->LoadSymbolMap(fn);
 	}
 
 	virtual void NotifySymbolMapUpdated() override { g_symbolMap->SortSymbols(); }
 
 	void PrepareShutdown() {
 		auto fn = SymbolMapFilename(PSP_CoreParameter().fileToStart);
-		g_symbolMap->SaveSymbolMap(fn.c_str());
+		g_symbolMap->SaveSymbolMap(fn);
 	}
 	void SetWindowTitle(const char *message) override {
 		std::string title = std::string("PPSSPP ") + PPSSPP_GIT_VERSION;
@@ -95,6 +95,6 @@ public:
 	void NotifySwitchUMDUpdated() override {}
 
 private:
-	std::string SymbolMapFilename(std::string currentFilename);
+	Path SymbolMapFilename(Path currentFilename);
 	MainWindow* mainWindow;
 };

--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -11,6 +11,7 @@
 #include "Common/System/Display.h"
 #include "Common/System/NativeApp.h"
 #include "Common/System/System.h"
+#include "Common/File/Path.h"
 #include "Core/MIPS/MIPSDebugInterface.h"
 #include "Core/Debugger/SymbolMap.h"
 #include "Core/HLE/sceUmd.h"
@@ -252,7 +253,7 @@ void MainWindow::switchUMDAct()
 	{
 		QFileInfo info(filename);
 		g_Config.currentDirectory = info.absolutePath().toStdString();
-		__UmdReplace(filename.toStdString().c_str());
+		__UmdReplace(Path(filename.toStdString()));
 	}
 }
 

--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -156,13 +156,13 @@ void SaveStateActionFinished(SaveState::Status status, const std::string &messag
 
 void MainWindow::qlstateAct()
 {
-	std::string gamePath = PSP_CoreParameter().fileToStart;
+	std::string gamePath = PSP_CoreParameter().fileToStart.ToString();
 	SaveState::LoadSlot(gamePath, 0, SaveStateActionFinished, this);
 }
 
 void MainWindow::qsstateAct()
 {
-	std::string gamePath = PSP_CoreParameter().fileToStart;
+	std::string gamePath = PSP_CoreParameter().fileToStart.ToString();
 	SaveState::SaveSlot(gamePath, 0, SaveStateActionFinished, this);
 }
 
@@ -177,7 +177,7 @@ void MainWindow::lstateAct()
 	if (dialog.exec())
 	{
 		QStringList fileNames = dialog.selectedFiles();
-		SaveState::Load(fileNames[0].toStdString(), -1, SaveStateActionFinished, this);
+		SaveState::Load(Path(fileNames[0].toStdString()), -1, SaveStateActionFinished, this);
 	}
 }
 
@@ -192,7 +192,7 @@ void MainWindow::sstateAct()
 	if (dialog.exec())
 	{
 		QStringList fileNames = dialog.selectedFiles();
-		SaveState::Save(fileNames[0].toStdString(), -1, SaveStateActionFinished, this);
+		SaveState::Save(Path(fileNames[0].toStdString()), -1, SaveStateActionFinished, this);
 	}
 }
 
@@ -276,7 +276,7 @@ void MainWindow::lmapAct()
 	if (fileNames.count() > 0)
 	{
 		QString fileName = QFileInfo(fileNames[0]).absoluteFilePath();
-		g_symbolMap->LoadSymbolMap(fileName.toStdString().c_str());
+		g_symbolMap->LoadSymbolMap(Path(fileName.toStdString()));
 	}
 }
 
@@ -292,7 +292,7 @@ void MainWindow::smapAct()
 	if (dialog.exec())
 	{
 		fileNames = dialog.selectedFiles();
-		g_symbolMap->SaveSymbolMap(fileNames[0].toStdString().c_str());
+		g_symbolMap->SaveSymbolMap(Path(fileNames[0].toStdString()));
 	}
 }
 
@@ -311,7 +311,7 @@ void MainWindow::lsymAct()
 	if (fileNames.count() > 0)
 	{
 		QString fileName = QFileInfo(fileNames[0]).absoluteFilePath();
-		g_symbolMap->LoadNocashSym(fileName.toStdString().c_str());
+		g_symbolMap->LoadNocashSym(Path(fileName.toStdString()));
 	}
 }
 
@@ -327,7 +327,7 @@ void MainWindow::ssymAct()
 	if (dialog.exec())
 	{
 		fileNames = dialog.selectedFiles();
-		g_symbolMap->SaveNocashSym(fileNames[0].toStdString().c_str());
+		g_symbolMap->SaveNocashSym(Path(fileNames[0].toStdString()));
 	}
 }
 

--- a/UI/BackgroundAudio.cpp
+++ b/UI/BackgroundAudio.cpp
@@ -312,7 +312,7 @@ void BackgroundAudio::Clear(bool hard) {
 	sndLoadPending_ = false;
 }
 
-void BackgroundAudio::SetGame(const std::string &path) {
+void BackgroundAudio::SetGame(const Path &path) {
 	if (path == bgGamePath_) {
 		// Do nothing
 		return;

--- a/UI/BackgroundAudio.h
+++ b/UI/BackgroundAudio.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "Common/File/Path.h"
 #include "Common/UI/Root.h"
 
 class AT3PlusReader;
@@ -14,7 +15,7 @@ public:
 	BackgroundAudio();
 	~BackgroundAudio();
 
-	void SetGame(const std::string &path);
+	void SetGame(const Path &path);
 	void Update();
 	int Play();
 
@@ -29,7 +30,7 @@ private:
 	};
 
 	std::mutex mutex_;
-	std::string bgGamePath_;
+	Path bgGamePath_;
 	std::atomic<bool> sndLoadPending_;
 	int playbackOffset_ = 0;
 	AT3PlusReader *at3Reader_;

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -63,7 +63,7 @@ void CwCheatScreen::LoadCheatInfo() {
 
 	// We won't parse this, just using it to detect changes to the file.
 	std::string str;
-	if (File::ReadFileToString(true, engine_->CheatFilename().c_str(), str)) {
+	if (File::ReadFileToString(true, engine_->CheatFilename(), str)) {
 		fileCheckHash_ = XXH3_64bits(str.c_str(), str.size());
 	}
 	fileCheckCounter_ = 0;
@@ -120,7 +120,7 @@ void CwCheatScreen::update() {
 	if (fileCheckCounter_++ >= FILE_CHECK_FRAME_INTERVAL && engine_) {
 		// Check if the file has changed.  If it has, we'll reload.
 		std::string str;
-		if (File::ReadFileToString(true, engine_->CheatFilename().c_str(), str)) {
+		if (File::ReadFileToString(true, engine_->CheatFilename(), str)) {
 			uint64_t newHash = XXH3_64bits(str.c_str(), str.size());
 			if (newHash != fileCheckHash_) {
 				// This will update the hash.
@@ -176,7 +176,7 @@ UI::EventReturn CwCheatScreen::OnEditCheatFile(UI::EventParams &params) {
 #if PPSSPP_PLATFORM(UWP)
 		LaunchBrowser(engine_->CheatFilename().c_str());
 #else
-		File::OpenFileInEditor(engine_->CheatFilename().ToString());
+		File::OpenFileInEditor(engine_->CheatFilename());
 #endif
 	}
 	return UI::EVENT_DONE;

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -34,7 +34,7 @@
 
 static const int FILE_CHECK_FRAME_INTERVAL = 53;
 
-CwCheatScreen::CwCheatScreen(const std::string &gamePath)
+CwCheatScreen::CwCheatScreen(const Path &gamePath)
 	: UIDialogScreenWithBackground() {
 	gamePath_ = gamePath;
 }
@@ -50,8 +50,8 @@ void CwCheatScreen::LoadCheatInfo() {
 		gameID = info->paramSFO.GetValueString("DISC_ID");
 	}
 	if ((info->id.empty() || !info->disc_total)
-		&& gamePath_.find("/PSP/GAME/") != std::string::npos) {
-		gameID = g_paramSFO.GenerateFakeID(gamePath_);
+		&& gamePath_.FilePathContains("PSP/GAME/")) {
+		gameID = g_paramSFO.GenerateFakeID(gamePath_.ToString());
 	}
 
 	if (engine_ == nullptr || gameID != gameID_) {
@@ -176,7 +176,7 @@ UI::EventReturn CwCheatScreen::OnEditCheatFile(UI::EventParams &params) {
 #if PPSSPP_PLATFORM(UWP)
 		LaunchBrowser(engine_->CheatFilename().c_str());
 #else
-		File::OpenFileInEditor(engine_->CheatFilename());
+		File::OpenFileInEditor(engine_->CheatFilename().ToString());
 #endif
 	}
 	return UI::EVENT_DONE;
@@ -204,7 +204,7 @@ UI::EventReturn CwCheatScreen::OnImportCheat(UI::EventParams &params) {
 	bool finished = false;
 	std::vector<std::string> newList;
 
-	std::string cheatFile = GetSysDirectory(DIRECTORY_CHEATS) + "cheat.db";
+	Path cheatFile = GetSysDirectory(DIRECTORY_CHEATS) / "cheat.db";
 	std::string gameID = StringFromFormat("_S %s-%s", gameID_.substr(0, 4).c_str(), gameID_.substr(4).c_str());
 
 	FILE *in = File::OpenCFile(cheatFile, "rt");

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -28,7 +28,7 @@ class CWCheatEngine;
 
 class CwCheatScreen : public UIDialogScreenWithBackground {
 public:
-	CwCheatScreen(const std::string &gamePath);
+	CwCheatScreen(const Path &gamePath);
 	~CwCheatScreen();
 
 	void LoadCheatInfo();
@@ -53,7 +53,7 @@ private:
 	UI::ScrollView *rightScroll_ = nullptr;
 	CWCheatEngine *engine_ = nullptr;
 	std::vector<CheatFileInfo> fileInfo_;
-	std::string gamePath_;
+	Path gamePath_;
 	std::string gameID_;
 	int fileCheckCounter_ = 0;
 	uint64_t fileCheckHash_;

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -589,7 +589,7 @@ void SystemInfoScreen::CreateViews() {
 
 	storage->Add(new ItemHeader(si->T("Directories")));
 	// Intentionally non-translated
-	storage->Add(new InfoItem("MemStickDirectory", g_Config.memStickDirectory));
+	storage->Add(new InfoItem("MemStickDirectory", g_Config.memStickDirectory.ToVisualString()));
 	storage->Add(new InfoItem("InternalDataDirectory", g_Config.internalDataDirectory));
 	storage->Add(new InfoItem("AppCacheDir", g_Config.appCacheDirectory));
 	storage->Add(new InfoItem("ExtStorageDir", g_Config.externalDirectory));
@@ -1184,7 +1184,7 @@ UI::EventReturn FrameDumpTestScreen::OnLoadDump(UI::EventParams &params) {
 	// Our disc streaming functionality detects the URL and takes over and handles loading framedumps well,
 	// except for some reason the game ID.
 	// TODO: Fix that since it can be important for compat settings.
-	LaunchFile(screenManager(), url);
+	LaunchFile(screenManager(), Path(url));
 	return UI::EVENT_DONE;
 }
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -129,7 +129,7 @@ static void __EmuScreenVblank()
 #endif
 }
 
-EmuScreen::EmuScreen(const std::string &filename)
+EmuScreen::EmuScreen(const Path &filename)
 	: bootPending_(true), gamePath_(filename), invalid_(true), quit_(false), pauseTrigger_(false), saveStatePreviewShownTime_(0.0), saveStatePreview_(nullptr) {
 	memset(axisState_, 0, sizeof(axisState_));
 	saveStateSlot_ = SaveState::GetCurrentSlot();
@@ -147,10 +147,11 @@ EmuScreen::EmuScreen(const std::string &filename)
 	OnChatMenu.Handle(this, &EmuScreen::OnChat);
 }
 
-bool EmuScreen::bootAllowStorage(const std::string &filename) {
+bool EmuScreen::bootAllowStorage(const Path &filename) {
 	// No permissions needed.  The easy life.
-	if (filename.find("http://") == 0 || filename.find("https://") == 0)
+	if (filename.Type() == PathType::HTTP)
 		return true;
+
 	if (!System_GetPropertyBool(SYSPROP_SUPPORTS_PERMISSIONS))
 		return true;
 
@@ -178,7 +179,7 @@ bool EmuScreen::bootAllowStorage(const std::string &filename) {
 	return false;
 }
 
-void EmuScreen::bootGame(const std::string &filename) {
+void EmuScreen::bootGame(const Path &filename) {
 	if (PSP_IsIniting()) {
 		std::string error_string;
 		bootPending_ = !PSP_InitUpdate(&error_string);
@@ -195,7 +196,7 @@ void EmuScreen::bootGame(const std::string &filename) {
 		return;
 	}
 
-	g_BackgroundAudio.SetGame("");
+	g_BackgroundAudio.SetGame(Path());
 
 	// Check permission status first, in case we came from a shortcut.
 	if (!bootAllowStorage(filename))
@@ -413,11 +414,11 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 	} else if (!strcmp(message, "boot")) {
 		const char *ext = strrchr(value, '.');
 		if (ext != nullptr && !strcmp(ext, ".ppst")) {
-			SaveState::Load(value, -1, &AfterStateBoot);
+			SaveState::Load(Path(value), -1, &AfterStateBoot);
 		} else {
 			PSP_Shutdown();
 			bootPending_ = true;
-			gamePath_ = value;
+			gamePath_ = Path(value);
 			// Don't leave it on CORE_POWERDOWN, we'll sometimes aggressively bail.
 			Core_UpdateState(CORE_POWERUP);
 		}
@@ -628,10 +629,10 @@ void EmuScreen::onVKeyDown(int virtualKeyCode) {
 		}
 		break;
 	case VIRTKEY_SAVE_STATE:
-		SaveState::SaveSlot(gamePath_, g_Config.iCurrentStateSlot, &AfterSaveStateAction);
+		SaveState::SaveSlot(gamePath_.ToString(), g_Config.iCurrentStateSlot, &AfterSaveStateAction);
 		break;
 	case VIRTKEY_LOAD_STATE:
-		SaveState::LoadSlot(gamePath_, g_Config.iCurrentStateSlot, &AfterSaveStateAction);
+		SaveState::LoadSlot(gamePath_.ToString(), g_Config.iCurrentStateSlot, &AfterSaveStateAction);
 		break;
 	case VIRTKEY_NEXT_SLOT:
 		SaveState::NextSlot();
@@ -977,7 +978,7 @@ void EmuScreen::processAxis(const AxisInput &axis, int direction) {
 
 class GameInfoBGView : public UI::InertView {
 public:
-	GameInfoBGView(const std::string &gamePath, UI::LayoutParams *layoutParams) : InertView(layoutParams), gamePath_(gamePath) {
+	GameInfoBGView(const Path &gamePath, UI::LayoutParams *layoutParams) : InertView(layoutParams), gamePath_(gamePath) {
 	}
 
 	void Draw(UIContext &dc) override {
@@ -1009,7 +1010,7 @@ public:
 	}
 
 protected:
-	std::string gamePath_;
+	Path gamePath_;
 	uint32_t color_ = 0xFFC0C0C0;
 };
 
@@ -1074,7 +1075,7 @@ void EmuScreen::CreateViews() {
 		chatButton_ = nullptr;
 	}
 
-	saveStatePreview_ = new AsyncImageFileView("", IS_FIXED, new AnchorLayoutParams(bounds.centerX(), 100, NONE, NONE, true));
+	saveStatePreview_ = new AsyncImageFileView(Path(), IS_FIXED, new AnchorLayoutParams(bounds.centerX(), 100, NONE, NONE, true));
 	saveStatePreview_->SetFixedSize(160, 90);
 	saveStatePreview_->SetColor(0x90FFFFFF);
 	saveStatePreview_->SetVisibility(V_GONE);
@@ -1188,7 +1189,7 @@ void EmuScreen::update() {
 
 	if (errorMessage_.size()) {
 		auto err = GetI18NCategory("Error");
-		std::string errLoadingFile = gamePath_ + "\n";
+		std::string errLoadingFile = gamePath_.ToString() + "\n";
 		errLoadingFile.append(err->T("Error loading file", "Could not load game"));
 		errLoadingFile.append(" ");
 		errLoadingFile.append(err->T(errorMessage_.c_str()));
@@ -1224,9 +1225,9 @@ void EmuScreen::update() {
 		if (saveStateSlot_ != currentSlot) {
 			saveStateSlot_ = currentSlot;
 
-			std::string fn;
-			if (SaveState::HasSaveInSlot(gamePath_, currentSlot)) {
-				fn = SaveState::GenerateSaveSlotFilename(gamePath_, currentSlot, SaveState::SCREENSHOT_EXTENSION);
+			Path fn;
+			if (SaveState::HasSaveInSlot(gamePath_.ToString(), currentSlot)) {
+				fn = SaveState::GenerateSaveSlotFilename(gamePath_.ToString(), currentSlot, SaveState::SCREENSHOT_EXTENSION);
 			}
 
 			saveStatePreview_->SetFilename(fn);
@@ -1671,18 +1672,18 @@ void EmuScreen::autoLoad() {
 	case (int)AutoLoadSaveState::OFF: // "AutoLoad Off"
 		return;
 	case (int)AutoLoadSaveState::OLDEST: // "Oldest Save"
-		autoSlot = SaveState::GetOldestSlot(gamePath_);
+		autoSlot = SaveState::GetOldestSlot(gamePath_.ToString());
 		break;
 	case (int)AutoLoadSaveState::NEWEST: // "Newest Save"
-		autoSlot = SaveState::GetNewestSlot(gamePath_);
+		autoSlot = SaveState::GetNewestSlot(gamePath_.ToString());
 		break;
 	default: // try the specific save state slot specified
-		autoSlot = (SaveState::HasSaveInSlot(gamePath_, g_Config.iAutoLoadSaveState - 3)) ? (g_Config.iAutoLoadSaveState - 3) : -1;
+		autoSlot = (SaveState::HasSaveInSlot(gamePath_.ToString(), g_Config.iAutoLoadSaveState - 3)) ? (g_Config.iAutoLoadSaveState - 3) : -1;
 		break;
 	}
 
 	if (g_Config.iAutoLoadSaveState && autoSlot != -1) {
-		SaveState::LoadSlot(gamePath_, autoSlot, &AfterSaveStateAction);
+		SaveState::LoadSlot(gamePath_.ToString(), autoSlot, &AfterSaveStateAction);
 		g_Config.iCurrentStateSlot = autoSlot;
 	}
 }

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1189,7 +1189,7 @@ void EmuScreen::update() {
 
 	if (errorMessage_.size()) {
 		auto err = GetI18NCategory("Error");
-		std::string errLoadingFile = gamePath_.ToString() + "\n";
+		std::string errLoadingFile = gamePath_.ToVisualString() + "\n";
 		errLoadingFile.append(err->T("Error loading file", "Could not load game"));
 		errLoadingFile.append(" ");
 		errLoadingFile.append(err->T(errorMessage_.c_str()));

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -21,6 +21,7 @@
 #include <vector>
 #include <list>
 
+#include "Common/File/Path.h"
 #include "Common/Input/KeyCodes.h"
 #include "Common/UI/Screen.h"
 #include "Common/UI/UIScreen.h"
@@ -34,7 +35,7 @@ class OnScreenMessagesView;
 
 class EmuScreen : public UIScreen {
 public:
-	EmuScreen(const std::string &filename);
+	EmuScreen(const Path &filename);
 	~EmuScreen();
 
 	void update() override;
@@ -56,8 +57,8 @@ private:
 	UI::EventReturn OnChat(UI::EventParams &params);
 	UI::EventReturn OnResume(UI::EventParams &params);
 
-	void bootGame(const std::string &filename);
-	bool bootAllowStorage(const std::string &filename);
+	void bootGame(const Path &filename);
+	bool bootAllowStorage(const Path &filename);
 	void bootComplete();
 	bool hasVisibleUI();
 	void renderUI();
@@ -74,7 +75,7 @@ private:
 	UI::Event OnDevMenu;
 	UI::Event OnChatMenu;
 	bool bootPending_;
-	std::string gamePath_;
+	Path gamePath_;
 
 	// Something invalid was loaded, don't try to emulate
 	bool invalid_;

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -404,9 +404,9 @@ public:
 					Path screenshot_png = GetSysDirectory(DIRECTORY_SCREENSHOT) / (info_->id + "_00000.png");
 					// Try using png/jpg screenshots first
 					if (File::Exists(screenshot_png))
-						File::ReadFileToString(false, screenshot_png.c_str(), info_->icon.data);
+						File::ReadFileToString(false, screenshot_png, info_->icon.data);
 					else if (File::Exists(screenshot_jpg))
-						File::ReadFileToString(false, screenshot_jpg.c_str(), info_->icon.data);
+						File::ReadFileToString(false, screenshot_jpg, info_->icon.data);
 					else
 						// Read standard icon
 						ReadVFSToString("unknown.png", &info_->icon.data, &info_->lock);
@@ -451,9 +451,9 @@ handleELF:
 				Path screenshot_png = GetSysDirectory(DIRECTORY_SCREENSHOT) / (info_->id + "_00000.png");
 				// Try using png/jpg screenshots first
 				if (File::Exists(screenshot_png)) {
-					File::ReadFileToString(false, screenshot_png.c_str(), info_->icon.data);
+					File::ReadFileToString(false, screenshot_png, info_->icon.data);
 				} else if (File::Exists(screenshot_jpg)) {
-					File::ReadFileToString(false, screenshot_jpg.c_str(), info_->icon.data);
+					File::ReadFileToString(false, screenshot_jpg, info_->icon.data);
 				} else {
 					// Read standard icon
 					VERBOSE_LOG(LOADER, "Loading unknown.png because there was an ELF");
@@ -492,9 +492,9 @@ handleELF:
 			std::lock_guard<std::mutex> guard(info_->lock);
 
 			// Let's use the screenshot as an icon, too.
-			std::string screenshotPath = ReplaceAll(gamePath_.ToString(), ".ppst", ".jpg");
+			Path screenshotPath = gamePath_.WithReplacedExtension("ppst", "jpg");
 			if (File::Exists(screenshotPath)) {
-				if (File::ReadFileToString(false, screenshotPath.c_str(), info_->icon.data)) {
+				if (File::ReadFileToString(false, Path(screenshotPath), info_->icon.data)) {
 					info_->icon.dataLoaded = true;
 				} else {
 					ERROR_LOG(G3D, "Error loading screenshot data: '%s'", screenshotPath.c_str());
@@ -579,9 +579,9 @@ handleELF:
 					Path screenshot_png = GetSysDirectory(DIRECTORY_SCREENSHOT) / (info_->id + "_00000.png");
 					// Try using png/jpg screenshots first
 					if (File::Exists(screenshot_png))
-						File::ReadFileToString(false, screenshot_png.c_str(), info_->icon.data);
+						File::ReadFileToString(false, screenshot_png, info_->icon.data);
 					else if (File::Exists(screenshot_jpg))
-						File::ReadFileToString(false, screenshot_jpg.c_str(), info_->icon.data);
+						File::ReadFileToString(false, screenshot_jpg, info_->icon.data);
 					else {
 						DEBUG_LOG(LOADER, "Loading unknown.png because no icon was found");
 						ReadVFSToString("unknown.png", &info_->icon.data, &info_->lock);

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -98,8 +98,7 @@ bool GameInfo::Delete() {
 		{
 			const Path &ppstPath = filePath_;
 			File::Delete(ppstPath);
-			// TODO(scoped): This doesn't work properly with Content URIs.
-			const Path screenshotPath = Path(ReplaceAll(filePath_.ToString(), ".ppst", ".jpg"));
+			const Path screenshotPath = filePath_.WithReplacedExtension(".ppst", ".jpg");
 			if (File::Exists(screenshotPath)) {
 				File::Delete(screenshotPath);
 			}
@@ -372,7 +371,7 @@ public:
 					if (pbp.IsELF()) {
 						goto handleELF;
 					}
-					ERROR_LOG(LOADER, "invalid pbp '%s'\n", pbpLoader->GetPath().c_str());
+					ERROR_LOG(LOADER, "invalid pbp '%s'\n", pbpLoader->GetPath().ToVisualString().c_str());
 					info_->pending = false;
 					info_->working = false;
 					return;

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -26,6 +26,7 @@
 #include "Common/Thread/PrioritizedWorkQueue.h"
 #include "Common/File/VFS/VFS.h"
 #include "Common/File/FileUtil.h"
+#include "Common/File/Path.h"
 #include "Common/StringUtils.h"
 #include "Common/TimeUtil.h"
 #include "Core/FileSystems/ISOFileSystem.h"
@@ -61,16 +62,16 @@ bool GameInfo::Delete() {
 	case IdentifiedFileType::PSP_ISO_NP:
 		{
 			// Just delete the one file (TODO: handle two-disk games as well somehow).
-			const char *fileToRemove = filePath_.c_str();
+			Path fileToRemove = Path(filePath_);
 			File::Delete(fileToRemove);
-			g_Config.RemoveRecent(filePath_);
+			g_Config.RemoveRecent(filePath_.ToString());
 			return true;
 		}
 	case IdentifiedFileType::PSP_PBP_DIRECTORY:
 	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY:
 		{
 			// TODO: This could be handled by Core/Util/GameManager too somehow.
-			std::string directoryToRemove = ResolvePBPDirectory(filePath_);
+			std::string directoryToRemove = ResolvePBPDirectory(filePath_.ToString());
 			INFO_LOG(SYSTEM, "Deleting %s", directoryToRemove.c_str());
 			if (!File::DeleteDirRecursively(directoryToRemove)) {
 				ERROR_LOG(SYSTEM, "Failed to delete file");
@@ -87,17 +88,18 @@ bool GameInfo::Delete() {
 	case IdentifiedFileType::ARCHIVE_7Z:
 	case IdentifiedFileType::PPSSPP_GE_DUMP:
 		{
-			const std::string &fileToRemove = filePath_;
+			const Path &fileToRemove = filePath_;
 			File::Delete(fileToRemove);
-			g_Config.RemoveRecent(filePath_);
+			g_Config.RemoveRecent(filePath_.ToString());
 			return true;
 		}
 
 	case IdentifiedFileType::PPSSPP_SAVESTATE:
 		{
-			const std::string &ppstPath = filePath_;
+			const Path &ppstPath = filePath_;
 			File::Delete(ppstPath);
-			const std::string screenshotPath = ReplaceAll(filePath_, ".ppst", ".jpg");
+			// TODO(scoped): This doesn't work properly with Content URIs.
+			const Path screenshotPath = Path(ReplaceAll(filePath_.ToString(), ".ppst", ".jpg"));
 			if (File::Exists(screenshotPath)) {
 				File::Delete(screenshotPath);
 			}
@@ -113,7 +115,7 @@ u64 GameInfo::GetGameSizeInBytes() {
 	switch (fileType) {
 	case IdentifiedFileType::PSP_PBP_DIRECTORY:
 	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY:
-		return File::GetDirectoryRecursiveSize(ResolvePBPDirectory(filePath_), nullptr, File::GETFILES_GETHIDDEN);
+		return File::GetDirectoryRecursiveSize(Path(ResolvePBPDirectory(filePath_.ToString())), nullptr, File::GETFILES_GETHIDDEN);
 
 	default:
 		return GetFileLoader()->FileSize();
@@ -121,19 +123,19 @@ u64 GameInfo::GetGameSizeInBytes() {
 }
 
 // Not too meaningful if the object itself is a savedata directory...
-std::vector<std::string> GameInfo::GetSaveDataDirectories() {
-	std::string memc = GetSysDirectory(DIRECTORY_SAVEDATA);
+std::vector<Path> GameInfo::GetSaveDataDirectories() {
+	Path memc = GetSysDirectory(DIRECTORY_SAVEDATA);
 
 	std::vector<File::FileInfo> dirs;
-	File::GetFilesInDir(memc.c_str(), &dirs);
+	File::GetFilesInDir(memc, &dirs);
 
-	std::vector<std::string> directories;
+	std::vector<Path> directories;
 	if (id.size() < 5) {
 		return directories;
 	}
 	for (size_t i = 0; i < dirs.size(); i++) {
 		if (startsWith(dirs[i].name, id)) {
-			directories.push_back(dirs[i].fullName);
+			directories.push_back(Path(dirs[i].fullName));
 		}
 	}
 
@@ -144,17 +146,17 @@ u64 GameInfo::GetSaveDataSizeInBytes() {
 	if (fileType == IdentifiedFileType::PSP_SAVEDATA_DIRECTORY || fileType == IdentifiedFileType::PPSSPP_SAVESTATE) {
 		return 0;
 	}
-	std::vector<std::string> saveDataDir = GetSaveDataDirectories();
+	std::vector<Path> saveDataDir = GetSaveDataDirectories();
 
 	u64 totalSize = 0;
 	u64 filesSizeInDir = 0;
 	for (size_t j = 0; j < saveDataDir.size(); j++) {
 		std::vector<File::FileInfo> fileInfo;
-		File::GetFilesInDir(saveDataDir[j].c_str(), &fileInfo);
+		File::GetFilesInDir(saveDataDir[j], &fileInfo);
 		// Note: GetFilesInDir does not fill in fileSize properly.
 		for (size_t i = 0; i < fileInfo.size(); i++) {
 			File::FileInfo finfo;
-			File::GetFileInfo(fileInfo[i].fullName.c_str(), &finfo);
+			File::GetFileInfo(Path(fileInfo[i].fullName), &finfo);
 			if (!finfo.isDirectory)
 				filesSizeInDir += finfo.size;
 		}
@@ -171,17 +173,17 @@ u64 GameInfo::GetInstallDataSizeInBytes() {
 	if (fileType == IdentifiedFileType::PSP_SAVEDATA_DIRECTORY || fileType == IdentifiedFileType::PPSSPP_SAVESTATE) {
 		return 0;
 	}
-	std::vector<std::string> saveDataDir = GetSaveDataDirectories();
+	std::vector<Path> saveDataDir = GetSaveDataDirectories();
 
 	u64 totalSize = 0;
 	u64 filesSizeInDir = 0;
 	for (size_t j = 0; j < saveDataDir.size(); j++) {
 		std::vector<File::FileInfo> fileInfo;
-		File::GetFilesInDir(saveDataDir[j].c_str(), &fileInfo);
+		File::GetFilesInDir(saveDataDir[j], &fileInfo);
 		// Note: GetFilesInDir does not fill in fileSize properly.
 		for (size_t i = 0; i < fileInfo.size(); i++) {
 			File::FileInfo finfo;
-			File::GetFileInfo(fileInfo[i].fullName.c_str(), &finfo);
+			File::GetFileInfo(Path(fileInfo[i].fullName), &finfo);
 			if (!finfo.isDirectory)
 				filesSizeInDir += finfo.size;
 		}
@@ -195,17 +197,17 @@ u64 GameInfo::GetInstallDataSizeInBytes() {
 	return totalSize;
 }
 
-bool GameInfo::LoadFromPath(const std::string &gamePath) {
+bool GameInfo::LoadFromPath(const Path &gamePath) {
 	std::lock_guard<std::mutex> guard(lock);
 	// No need to rebuild if we already have it loaded.
 	if (filePath_ != gamePath) {
-		fileLoader.reset(ConstructFileLoader(gamePath));
+		fileLoader.reset(ConstructFileLoader(gamePath.ToString()));
 		if (!fileLoader)
 			return false;
 		filePath_ = gamePath;
 
 		// This is a fallback title, while we're loading / if unable to load.
-		title = File::GetFilename(filePath_);
+		title = File::GetFilename(filePath_.ToString());
 	}
 
 	return true;
@@ -218,7 +220,7 @@ std::shared_ptr<FileLoader> GameInfo::GetFileLoader() {
 		return fileLoader;
 	}
 	if (!fileLoader) {
-		fileLoader.reset(ConstructFileLoader(filePath_));
+		fileLoader.reset(ConstructFileLoader(filePath_.ToString()));
 	}
 	return fileLoader;
 }
@@ -228,13 +230,13 @@ void GameInfo::DisposeFileLoader() {
 }
 
 bool GameInfo::DeleteAllSaveData() {
-	std::vector<std::string> saveDataDir = GetSaveDataDirectories();
+	std::vector<Path> saveDataDir = GetSaveDataDirectories();
 	for (size_t j = 0; j < saveDataDir.size(); j++) {
 		std::vector<File::FileInfo> fileInfo;
-		File::GetFilesInDir(saveDataDir[j].c_str(), &fileInfo);
+		File::GetFilesInDir(saveDataDir[j], &fileInfo);
 
 		for (size_t i = 0; i < fileInfo.size(); i++) {
-			File::Delete(fileInfo[i].fullName.c_str());
+			File::Delete(Path(fileInfo[i].fullName));
 		}
 
 		File::DeleteDir(saveDataDir[j].c_str());
@@ -332,7 +334,7 @@ static bool ReadVFSToString(const char *filename, std::string *contents, std::mu
 
 class GameInfoWorkItem : public PrioritizedWorkQueueItem {
 public:
-	GameInfoWorkItem(const std::string &gamePath, std::shared_ptr<GameInfo> &info)
+	GameInfoWorkItem(const Path &gamePath, std::shared_ptr<GameInfo> &info)
 		: gamePath_(gamePath), info_(info) {
 	}
 
@@ -359,9 +361,9 @@ public:
 			{
 				auto pbpLoader = info_->GetFileLoader();
 				if (info_->fileType == IdentifiedFileType::PSP_PBP_DIRECTORY) {
-					std::string ebootPath = ResolvePBPFile(gamePath_);
+					Path ebootPath = Path(ResolvePBPFile(gamePath_.ToString()));
 					if (ebootPath != gamePath_) {
-						pbpLoader.reset(ConstructFileLoader(ebootPath));
+						pbpLoader.reset(ConstructFileLoader(ebootPath.ToString()));
 					}
 				}
 
@@ -385,9 +387,9 @@ public:
 
 					// Assuming PSP_PBP_DIRECTORY without ID or with disc_total < 1 in GAME dir must be homebrew
 					if ((info_->id.empty() || !info_->disc_total)
-						&& gamePath_.find("/PSP/GAME/") != std::string::npos 
+						&& gamePath_.FilePathContains("PSP/GAME/")
 						&& info_->fileType == IdentifiedFileType::PSP_PBP_DIRECTORY) {
-						info_->id = g_paramSFO.GenerateFakeID(gamePath_);
+						info_->id = g_paramSFO.GenerateFakeID(gamePath_.ToString());
 						info_->id_version = info_->id + "_1.00";
 						info_->region = GAMEREGION_MAX + 1; // Homebrew
 					}
@@ -398,8 +400,8 @@ public:
 					std::lock_guard<std::mutex> lock(info_->lock);
 					pbp.GetSubFileAsString(PBP_ICON0_PNG, &info_->icon.data);
 				} else {
-					std::string screenshot_jpg = GetSysDirectory(DIRECTORY_SCREENSHOT) + info_->id + "_00000.jpg";
-					std::string screenshot_png = GetSysDirectory(DIRECTORY_SCREENSHOT) + info_->id + "_00000.png";
+					Path screenshot_jpg = GetSysDirectory(DIRECTORY_SCREENSHOT) / (info_->id + "_00000.jpg");
+					Path screenshot_png = GetSysDirectory(DIRECTORY_SCREENSHOT) / (info_->id + "_00000.png");
 					// Try using png/jpg screenshots first
 					if (File::Exists(screenshot_png))
 						File::ReadFileToString(false, screenshot_png.c_str(), info_->icon.data);
@@ -438,15 +440,15 @@ handleELF:
 			// An elf on its own has no usable information, no icons, no nothing.
 			{
 				std::lock_guard<std::mutex> lock(info_->lock);
-				info_->id = g_paramSFO.GenerateFakeID(gamePath_);
+				info_->id = g_paramSFO.GenerateFakeID(gamePath_.ToString());
 				info_->id_version = info_->id + "_1.00";
 				info_->region = GAMEREGION_MAX + 1; // Homebrew
 
 				info_->paramSFOLoaded = true;
 			}
 			{
-				std::string screenshot_jpg = GetSysDirectory(DIRECTORY_SCREENSHOT) + info_->id + "_00000.jpg";
-				std::string screenshot_png = GetSysDirectory(DIRECTORY_SCREENSHOT) + info_->id + "_00000.png";
+				Path screenshot_jpg = GetSysDirectory(DIRECTORY_SCREENSHOT) / (info_->id + "_00000.jpg");
+				Path screenshot_png = GetSysDirectory(DIRECTORY_SCREENSHOT) / (info_->id + "_00000.png");
 				// Try using png/jpg screenshots first
 				if (File::Exists(screenshot_png)) {
 					File::ReadFileToString(false, screenshot_png.c_str(), info_->icon.data);
@@ -485,12 +487,12 @@ handleELF:
 
 		case IdentifiedFileType::PPSSPP_SAVESTATE:
 		{
-			info_->SetTitle(SaveState::GetTitle(gamePath_));
+			info_->SetTitle(SaveState::GetTitle(gamePath_.ToString()));
 
 			std::lock_guard<std::mutex> guard(info_->lock);
 
 			// Let's use the screenshot as an icon, too.
-			std::string screenshotPath = ReplaceAll(gamePath_, ".ppst", ".jpg");
+			std::string screenshotPath = ReplaceAll(gamePath_.ToString(), ".ppst", ".jpg");
 			if (File::Exists(screenshotPath)) {
 				if (File::ReadFileToString(false, screenshotPath.c_str(), info_->icon.data)) {
 					info_->icon.dataLoaded = true;
@@ -573,8 +575,8 @@ handleELF:
 
 				// Fall back to unknown icon if ISO is broken/is a homebrew ISO, override is allowed though
 				if (!ReadFileToString(&umd, "/PSP_GAME/ICON0.PNG", &info_->icon.data, &info_->lock)) {
-					std::string screenshot_jpg = GetSysDirectory(DIRECTORY_SCREENSHOT) + info_->id + "_00000.jpg";
-					std::string screenshot_png = GetSysDirectory(DIRECTORY_SCREENSHOT) + info_->id + "_00000.png";
+					Path screenshot_jpg = GetSysDirectory(DIRECTORY_SCREENSHOT) / (info_->id + "_00000.jpg");
+					Path screenshot_png = GetSysDirectory(DIRECTORY_SCREENSHOT) / (info_->id + "_00000.png");
 					// Try using png/jpg screenshots first
 					if (File::Exists(screenshot_png))
 						File::ReadFileToString(false, screenshot_png.c_str(), info_->icon.data);
@@ -643,7 +645,7 @@ handleELF:
 	}
 
 private:
-	std::string gamePath_;
+	Path gamePath_;
 	std::shared_ptr<GameInfo> info_;
 	DISALLOW_COPY_AND_ASSIGN(GameInfoWorkItem);
 };
@@ -732,10 +734,12 @@ void GameInfoCache::WaitUntilDone(std::shared_ptr<GameInfo> &info) {
 
 // Runs on the main thread. Only call from render() and similar, not update()!
 // Can also be called from the audio thread for menu background music.
-std::shared_ptr<GameInfo> GameInfoCache::GetInfo(Draw::DrawContext *draw, const std::string &gamePath, int wantFlags) {
+std::shared_ptr<GameInfo> GameInfoCache::GetInfo(Draw::DrawContext *draw, const Path &gamePath, int wantFlags) {
 	std::shared_ptr<GameInfo> info;
 
-	auto iter = info_.find(gamePath);
+	std::string pathStr = gamePath.ToString();
+
+	auto iter = info_.find(pathStr);
 	if (iter != info_.end()) {
 		info = iter->second;
 	}
@@ -776,8 +780,8 @@ std::shared_ptr<GameInfo> GameInfoCache::GetInfo(Draw::DrawContext *draw, const 
 	gameInfoWQ_->Add(item);
 
 	// Don't re-insert if we already have it.
-	if (info_.find(gamePath) == info_.end())
-		info_[gamePath] = std::shared_ptr<GameInfo>(info);
+	if (info_.find(pathStr) == info_.end())
+		info_[pathStr] = std::shared_ptr<GameInfo>(info);
 	return info;
 }
 

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -71,7 +71,7 @@ bool GameInfo::Delete() {
 	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY:
 		{
 			// TODO: This could be handled by Core/Util/GameManager too somehow.
-			std::string directoryToRemove = ResolvePBPDirectory(filePath_.ToString());
+			Path directoryToRemove = Path(ResolvePBPDirectory(filePath_.ToString()));
 			INFO_LOG(SYSTEM, "Deleting %s", directoryToRemove.c_str());
 			if (!File::DeleteDirRecursively(directoryToRemove)) {
 				ERROR_LOG(SYSTEM, "Failed to delete file");
@@ -239,7 +239,7 @@ bool GameInfo::DeleteAllSaveData() {
 			File::Delete(Path(fileInfo[i].fullName));
 		}
 
-		File::DeleteDir(saveDataDir[j].c_str());
+		File::DeleteDir(saveDataDir[j]);
 	}
 	return true;
 }

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -24,6 +24,7 @@
 #include <atomic>
 
 #include "Core/ELF/ParamSFO.h"
+#include "Common/File/Path.h"
 #include "UI/TextureUtil.h"
 
 namespace Draw {
@@ -84,7 +85,7 @@ public:
 
 	bool Delete();  // Better be sure what you're doing when calling this.
 	bool DeleteAllSaveData();
-	bool LoadFromPath(const std::string &gamePath);
+	bool LoadFromPath(const Path &gamePath);
 
 	std::shared_ptr<FileLoader> GetFileLoader();
 	void DisposeFileLoader();
@@ -95,7 +96,7 @@ public:
 
 	void ParseParamSFO();
 
-	std::vector<std::string> GetSaveDataDirectories();
+	std::vector<Path> GetSaveDataDirectories();
 
 	std::string GetTitle();
 	void SetTitle(const std::string &newTitle);
@@ -148,7 +149,7 @@ protected:
 
 	// TODO: Get rid of this shared_ptr and managae lifetime better instead.
 	std::shared_ptr<FileLoader> fileLoader;
-	std::string filePath_;
+	Path filePath_;
 
 private:
 	DISALLOW_COPY_AND_ASSIGN(GameInfo);
@@ -167,7 +168,7 @@ public:
 	// but filled in later asynchronously in the background. So keep calling this,
 	// redrawing the UI often. Only set flags to GAMEINFO_WANTBG or WANTSND if you really want them 
 	// because they're big. bgTextures and sound may be discarded over time as well.
-	std::shared_ptr<GameInfo> GetInfo(Draw::DrawContext *draw, const std::string &gamePath, int wantFlags);
+	std::shared_ptr<GameInfo> GetInfo(Draw::DrawContext *draw, const Path &gamePath, int wantFlags);
 	void FlushBGs();  // Gets rid of all BG textures. Also gets rid of bg sounds.
 
 	void CancelAll();

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -43,7 +43,7 @@
 #include "UI/MainScreen.h"
 #include "UI/BackgroundAudio.h"
 
-GameScreen::GameScreen(const std::string &gamePath) : UIDialogScreenWithGameBackground(gamePath) {
+GameScreen::GameScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {
 	g_BackgroundAudio.SetGame(gamePath);
 }
 
@@ -84,7 +84,7 @@ void GameScreen::CreateViews() {
 		tvTitle_->SetShadow(true);
 		infoLayout->Add(new Spacer(12));
 		// This one doesn't need to be updated.
-		infoLayout->Add(new TextView(gamePath_, ALIGN_LEFT | FLAG_WRAP_TEXT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetShadow(true);
+		infoLayout->Add(new TextView(gamePath_.ToVisualString(), ALIGN_LEFT | FLAG_WRAP_TEXT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetShadow(true);
 		tvGameSize_ = infoLayout->Add(new TextView("...", ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 		tvGameSize_->SetShadow(true);
 		tvSaveDataSize_ = infoLayout->Add(new TextView("...", ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
@@ -96,7 +96,7 @@ void GameScreen::CreateViews() {
 		tvRegion_->SetShadow(true);
 		tvCRC_ = infoLayout->Add(new TextView("", ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 		tvCRC_->SetShadow(true);
-		tvCRC_->SetVisibility(Reporting::HasCRC(gamePath_) ? V_VISIBLE : V_GONE);
+		tvCRC_->SetVisibility(Reporting::HasCRC(gamePath_.ToString()) ? V_VISIBLE : V_GONE);
 	} else {
 		tvTitle_ = nullptr;
 		tvGameSize_ = nullptr;
@@ -240,9 +240,9 @@ void GameScreen::render() {
 		}
 	}
 
-	if (tvCRC_ && Reporting::HasCRC(gamePath_)) {
+	if (tvCRC_ && Reporting::HasCRC(gamePath_.ToString())) {
 		auto rp = GetI18NCategory("Reporting");
-		std::string crc = StringFromFormat("%08X", Reporting::RetrieveCRC(gamePath_));
+		std::string crc = StringFromFormat("%08X", Reporting::RetrieveCRC(gamePath_.ToString()));
 		tvCRC_->SetText(ReplaceAll(rp->T("FeedbackCRCValue", "Disc CRC: [VALUE]"), "[VALUE]", crc));
 		tvCRC_->SetVisibility(UI::V_VISIBLE);
 	}
@@ -292,8 +292,8 @@ UI::EventReturn GameScreen::OnGameSettings(UI::EventParams &e) {
 	std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(NULL, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
 	if (info && info->paramSFOLoaded) {
 		std::string discID = info->paramSFO.GetValueString("DISC_ID");
-		if ((discID.empty() || !info->disc_total) && gamePath_.find("/PSP/GAME/") != std::string::npos)
-			discID = g_paramSFO.GenerateFakeID(gamePath_);
+		if ((discID.empty() || !info->disc_total) && gamePath_.FilePathContains("PSP/GAME/"))
+			discID = g_paramSFO.GenerateFakeID(gamePath_.ToString());
 		screenManager()->push(new GameSettingsScreen(gamePath_, discID, true));
 	}
 	return UI::EVENT_DONE;
@@ -350,16 +350,16 @@ void GameScreen::CallbackDeleteGame(bool yes) {
 UI::EventReturn GameScreen::OnCreateShortcut(UI::EventParams &e) {
 	std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(NULL, gamePath_, 0);
 	if (info) {
-		host->CreateDesktopShortcut(gamePath_, info->GetTitle());
+		host->CreateDesktopShortcut(gamePath_.ToString(), info->GetTitle());
 	}
 	return UI::EVENT_DONE;
 }
 
-bool GameScreen::isRecentGame(const std::string &gamePath) {
+bool GameScreen::isRecentGame(const Path &gamePath) {
 	if (g_Config.iMaxRecent <= 0)
 		return false;
 
-	const std::string resolved = File::ResolvePath(gamePath);
+	const std::string resolved = File::ResolvePath(gamePath.ToString());
 	for (auto it = g_Config.recentIsos.begin(); it != g_Config.recentIsos.end(); ++it) {
 		const std::string recent = File::ResolvePath(*it);
 		if (resolved == recent)
@@ -369,14 +369,14 @@ bool GameScreen::isRecentGame(const std::string &gamePath) {
 }
 
 UI::EventReturn GameScreen::OnRemoveFromRecent(UI::EventParams &e) {
-	g_Config.RemoveRecent(gamePath_);
+	g_Config.RemoveRecent(gamePath_.ToString());
 	screenManager()->switchScreen(new MainScreen());
 	return UI::EVENT_DONE;
 }
 
 class SetBackgroundPopupScreen : public PopupScreen {
 public:
-	SetBackgroundPopupScreen(const std::string &title, const std::string &gamePath);
+	SetBackgroundPopupScreen(const std::string &title, const Path &gamePath);
 
 protected:
 	bool FillVertical() const override { return false; }
@@ -385,7 +385,7 @@ protected:
 	void update() override;
 
 private:
-	std::string gamePath_;
+	Path gamePath_;
 	double timeStart_;
 	double timeDone_ = 0.0;
 
@@ -397,7 +397,7 @@ private:
 	Status status_ = Status::PENDING;
 };
 
-SetBackgroundPopupScreen::SetBackgroundPopupScreen(const std::string &title, const std::string &gamePath)
+SetBackgroundPopupScreen::SetBackgroundPopupScreen(const std::string &title, const Path &gamePath)
 	: PopupScreen(title), gamePath_(gamePath) {
 	timeStart_ = time_now_d();
 }
@@ -420,7 +420,7 @@ void SetBackgroundPopupScreen::update() {
 		}
 
 		if (pic) {
-			const std::string bgPng = GetSysDirectory(DIRECTORY_SYSTEM) + "background.png";
+			const Path bgPng = GetSysDirectory(DIRECTORY_SYSTEM) / "background.png";
 			File::WriteStringToFile(false, pic->data, bgPng.c_str());
 		}
 

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -96,7 +96,7 @@ void GameScreen::CreateViews() {
 		tvRegion_->SetShadow(true);
 		tvCRC_ = infoLayout->Add(new TextView("", ALIGN_LEFT, true, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 		tvCRC_->SetShadow(true);
-		tvCRC_->SetVisibility(Reporting::HasCRC(gamePath_.ToString()) ? V_VISIBLE : V_GONE);
+		tvCRC_->SetVisibility(Reporting::HasCRC(gamePath_) ? V_VISIBLE : V_GONE);
 	} else {
 		tvTitle_ = nullptr;
 		tvGameSize_ = nullptr;
@@ -240,9 +240,9 @@ void GameScreen::render() {
 		}
 	}
 
-	if (tvCRC_ && Reporting::HasCRC(gamePath_.ToString())) {
+	if (tvCRC_ && Reporting::HasCRC(gamePath_)) {
 		auto rp = GetI18NCategory("Reporting");
-		std::string crc = StringFromFormat("%08X", Reporting::RetrieveCRC(gamePath_.ToString()));
+		std::string crc = StringFromFormat("%08X", Reporting::RetrieveCRC(gamePath_));
 		tvCRC_->SetText(ReplaceAll(rp->T("FeedbackCRCValue", "Disc CRC: [VALUE]"), "[VALUE]", crc));
 		tvCRC_->SetVisibility(UI::V_VISIBLE);
 	}

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -421,7 +421,7 @@ void SetBackgroundPopupScreen::update() {
 
 		if (pic) {
 			const Path bgPng = GetSysDirectory(DIRECTORY_SYSTEM) / "background.png";
-			File::WriteStringToFile(false, pic->data, bgPng.c_str());
+			File::WriteStringToFile(false, pic->data, bgPng);
 		}
 
 		NativeMessageReceived("bgImage_updated", "");

--- a/UI/GameScreen.h
+++ b/UI/GameScreen.h
@@ -21,6 +21,7 @@
 
 #include "UI/MiscScreens.h"
 #include "Common/UI/UIScreen.h"
+#include "Common/File/Path.h"
 
 // Game screen: Allows you to start a game, delete saves, delete the game,
 // set game specific settings, etc.
@@ -30,7 +31,7 @@
 
 class GameScreen : public UIDialogScreenWithGameBackground {
 public:
-	GameScreen(const std::string &gamePath);
+	GameScreen(const Path &gamePath);
 	~GameScreen();
 
 	void render() override;
@@ -42,7 +43,7 @@ protected:
 	void CallbackDeleteConfig(bool yes);
 	void CallbackDeleteSaveData(bool yes);
 	void CallbackDeleteGame(bool yes);
-	bool isRecentGame(const std::string &gamePath);
+	bool isRecentGame(const Path &gamePath);
 
 private:
 	UI::Choice *AddOtherChoice(UI::Choice *choice);
@@ -75,5 +76,5 @@ private:
 	UI::Choice *btnDeleteSaveData_;
 	UI::Choice *btnSetBackground_;
 	std::vector<UI::Choice *> otherChoices_;
-	std::vector<std::string> saveDirs;
+	std::vector<Path> saveDirs;
 };

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1120,7 +1120,7 @@ UI::EventReturn GameSettingsScreen::OnChangeMemStickDir(UI::EventParams &e) {
 
 			pendingMemstickFolder_ = newPath;
 			std::string promptMessage = sy->T("ChangingMemstickPath", "Save games, save states, and other data will not be copied to this folder.\n\nChange the Memory Stick folder?");
-			if (!File::Exists(newPath)) {
+			if (!File::Exists(Path(newPath))) {
 				promptMessage = sy->T("ChangingMemstickPathNotExists", "That folder doesn't exist yet.\n\nSave games, save states, and other data will not be copied to this folder.\n\nCreate a new Memory Stick folder?");
 			}
 			// Add the path for clarity and proper confirmation.
@@ -1299,16 +1299,16 @@ void GameSettingsScreen::CallbackMemstickFolder(bool yes) {
 		std::string testWriteFile = pendingMemstickFolder_ + "/.write_verify_file";
 
 		// Already, create away.
-		if (!File::Exists(pendingMemstickFolder_)) {
+		if (!File::Exists(Path(pendingMemstickFolder_))) {
 			File::CreateFullPath(Path(pendingMemstickFolder_));
 		}
-		if (!File::WriteDataToFile(true, "1", 1, testWriteFile.c_str())) {
+		if (!File::WriteDataToFile(true, "1", 1, Path(testWriteFile))) {
 			settingInfo_->Show(sy->T("ChangingMemstickPathInvalid", "That path couldn't be used to save Memory Stick files."), nullptr);
 			return;
 		}
 		File::Delete(Path(testWriteFile));
 
-		File::WriteDataToFile(true, pendingMemstickFolder_.c_str(), (unsigned int)pendingMemstickFolder_.size(), memstickDirFile.c_str());
+		File::WriteDataToFile(true, pendingMemstickFolder_.c_str(), (unsigned int)pendingMemstickFolder_.size(), Path(memstickDirFile));
 		// Save so the settings, at least, are transferred.
 		g_Config.memStickDirectory = Path(pendingMemstickFolder_);
 		g_Config.Save("MemstickPathChanged");
@@ -1729,7 +1729,7 @@ UI::EventReturn DeveloperToolsScreen::OnOpenTexturesIniFile(UI::EventParams &e) 
 	std::string gameID = g_paramSFO.GetDiscID();
 	Path generatedFilename;
 	if (TextureReplacer::GenerateIni(gameID, &generatedFilename)) {
-		File::OpenFileInEditor(generatedFilename.ToString());
+		File::OpenFileInEditor(generatedFilename);
 	}
 	return UI::EVENT_DONE;
 }
@@ -1772,8 +1772,8 @@ UI::EventReturn DeveloperToolsScreen::OnCopyStatesToRoot(UI::EventParams &e) {
 	GetFilesInDir(savestate_dir, &files, nullptr, 0);
 
 	for (const File::FileInfo &file : files) {
-		std::string src = file.fullName;
-		std::string dst = root_dir.ToString() + file.name;
+		Path src = Path(file.fullName);
+		Path dst = root_dir / file.name;
 		INFO_LOG(SYSTEM, "Copying file '%s' to '%s'", src.c_str(), dst.c_str());
 		File::Copy(src, dst);
 	}

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1728,7 +1728,7 @@ UI::EventReturn DeveloperToolsScreen::OnLoadLanguageIni(UI::EventParams &e) {
 UI::EventReturn DeveloperToolsScreen::OnOpenTexturesIniFile(UI::EventParams &e) {
 	std::string gameID = g_paramSFO.GetDiscID();
 	Path generatedFilename;
-	if (TextureReplacer::GenerateIni(gameID, &generatedFilename)) {
+	if (TextureReplacer::GenerateIni(gameID, generatedFilename)) {
 		File::OpenFileInEditor(generatedFilename);
 	}
 	return UI::EVENT_DONE;

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -30,7 +30,7 @@ class SettingInfoMessage;
 // per game.
 class GameSettingsScreen : public UIDialogScreenWithGameBackground {
 public:
-	GameSettingsScreen(std::string gamePath, std::string gameID = "", bool editThenRestore = false);
+	GameSettingsScreen(const Path &gamePath, std::string gameID = "", bool editThenRestore = false);
 
 	void update() override;
 	void onFinish(DialogResult result) override;
@@ -66,6 +66,8 @@ private:
 	bool installed_;
 	bool otherinstalled_;
 #endif
+
+	std::string memstickDisplay_;
 
 	// Event handlers
 	UI::EventReturn OnControlMapping(UI::EventParams &e);

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -29,7 +29,7 @@ void InstallZipScreen::CreateViews() {
 	using namespace UI;
 
 	File::FileInfo fileInfo;
-	bool success = File::GetFileInfo(zipPath_.c_str(), &fileInfo);
+	bool success = File::GetFileInfo(Path(zipPath_), &fileInfo);
 
 	auto di = GetI18NCategory("Dialog");
 	auto iz = GetI18NCategory("InstallZip");

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -29,7 +29,7 @@ void InstallZipScreen::CreateViews() {
 	using namespace UI;
 
 	File::FileInfo fileInfo;
-	bool success = File::GetFileInfo(Path(zipPath_), &fileInfo);
+	bool success = File::GetFileInfo(zipPath_, &fileInfo);
 
 	auto di = GetI18NCategory("Dialog");
 	auto iz = GetI18NCategory("InstallZip");
@@ -43,7 +43,7 @@ void InstallZipScreen::CreateViews() {
 	root_->Add(leftColumn);
 	root_->Add(rightColumnItems);
 
-	std::string shortFilename = GetFilenameFromPath(zipPath_);
+	std::string shortFilename = zipPath_.GetFilename();
 	
 	// TODO: Do in the background?
 	ZipFileInfo zipInfo;

--- a/UI/InstallZipScreen.h
+++ b/UI/InstallZipScreen.h
@@ -26,7 +26,7 @@
 
 class InstallZipScreen : public UIDialogScreenWithBackground {
 public:
-	InstallZipScreen(std::string zipPath) : zipPath_(zipPath) {}
+	InstallZipScreen(const Path &zipPath) : zipPath_(zipPath) {}
 	virtual void update() override;
 	virtual bool key(const KeyInput &key) override;
 
@@ -40,7 +40,7 @@ private:
 	UI::Choice *backChoice_ = nullptr;
 	UI::ProgressBar *progressBar_ = nullptr;
 	UI::TextView *doneView_ = nullptr;
-	std::string zipPath_;
+	Path zipPath_;
 	bool returnToHomebrew_ = true;
 	bool installStarted_ = false;
 	bool deleteZipFile_ = false;

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -69,7 +69,7 @@ bool MainScreen::showHomebrewTab = false;
 
 bool LaunchFile(ScreenManager *screenManager, const Path &path) {
 	// Depending on the file type, we don't want to launch EmuScreen at all.
-	auto loader = ConstructFileLoader(path.ToString());
+	auto loader = ConstructFileLoader(path);
 	if (!loader) {
 		return false;
 	}
@@ -79,7 +79,7 @@ bool LaunchFile(ScreenManager *screenManager, const Path &path) {
 
 	switch (type) {
 	case IdentifiedFileType::ARCHIVE_ZIP:
-		screenManager->push(new InstallZipScreen(path.ToString()));
+		screenManager->push(new InstallZipScreen(path));
 		break;
 	default:
 		// Let the EmuScreen take care of it.
@@ -620,7 +620,7 @@ static bool IsValidPBP(const Path &path, bool allowHomebrew) {
 	if (!File::Exists(path))
 		return false;
 
-	std::unique_ptr<FileLoader> loader(ConstructFileLoader(path.ToString()));
+	std::unique_ptr<FileLoader> loader(ConstructFileLoader(path));
 	PBPReader pbp(loader.get());
 	std::vector<u8> sfoData;
 	if (!pbp.GetSubFile(PBP_PARAM_SFO, &sfoData))
@@ -1509,7 +1509,7 @@ void UmdReplaceScreen::update() {
 }
 
 UI::EventReturn UmdReplaceScreen::OnGameSelected(UI::EventParams &e) {
-	__UmdReplace(e.s);
+	__UmdReplace(Path(e.s));
 	TriggerFinish(DR_OK);
 	return UI::EVENT_DONE;
 }
@@ -1525,7 +1525,7 @@ UI::EventReturn UmdReplaceScreen::OnGameSettings(UI::EventParams &e) {
 }
 
 UI::EventReturn UmdReplaceScreen::OnGameSelectedInstant(UI::EventParams &e) {
-	__UmdReplace(e.s);
+	__UmdReplace(Path(e.s));
 	TriggerFinish(DR_OK);
 	return UI::EVENT_DONE;
 }

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -613,11 +613,11 @@ void GameBrowser::Draw(UIContext &dc) {
 	}
 }
 
-static bool IsValidPBP(const std::string &path, bool allowHomebrew) {
+static bool IsValidPBP(const Path &path, bool allowHomebrew) {
 	if (!File::Exists(path))
 		return false;
 
-	std::unique_ptr<FileLoader> loader(ConstructFileLoader(path));
+	std::unique_ptr<FileLoader> loader(ConstructFileLoader(path.ToString()));
 	PBPReader pbp(loader.get());
 	std::vector<u8> sfoData;
 	if (!pbp.GetSubFile(PBP_PARAM_SFO, &sfoData))
@@ -719,11 +719,11 @@ void GameBrowser::Refresh() {
 			bool isGame = !fileInfo[i].isDirectory;
 			bool isSaveData = false;
 			// Check if eboot directory
-			if (!isGame && path_.GetPath().size() >= 4 && IsValidPBP(path_.GetPath() + fileInfo[i].name + "/EBOOT.PBP", true))
+			if (!isGame && path_.GetPath().size() >= 4 && IsValidPBP(Path(path_.GetPath()) / fileInfo[i].name / "EBOOT.PBP", true))
 				isGame = true;
-			else if (!isGame && File::Exists(path_.GetPath() + fileInfo[i].name + "/PSP_GAME/SYSDIR"))
+			else if (!isGame && File::Exists(Path(path_.GetPath() + fileInfo[i].name + "/PSP_GAME/SYSDIR")))
 				isGame = true;
-			else if (!isGame && File::Exists(path_.GetPath() + fileInfo[i].name + "/PARAM.SFO"))
+			else if (!isGame && File::Exists(Path(path_.GetPath() + fileInfo[i].name + "/PARAM.SFO")))
 				isSaveData = true;
 
 			if (!isGame && !isSaveData) {

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -722,7 +722,7 @@ void GameBrowser::Refresh() {
 			bool isGame = !fileInfo[i].isDirectory;
 			bool isSaveData = false;
 			// Check if eboot directory
-			if (!isGame && path_.GetPath().size() >= 4 && IsValidPBP(Path(path_.GetPath()) / fileInfo[i].name / "EBOOT.PBP", true))
+			if (!isGame && path_.GetPath().size() >= 4 && IsValidPBP(path_.GetPath() / fileInfo[i].name / "EBOOT.PBP", true))
 				isGame = true;
 			else if (!isGame && File::Exists(path_.GetPath() / fileInfo[i].name / "PSP_GAME/SYSDIR"))
 				isGame = true;

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -19,6 +19,7 @@
 
 #include <functional>
 
+#include "Common/File/Path.h"
 #include "Common/UI/UIScreen.h"
 #include "Common/UI/ViewGroup.h"
 #include "UI/MiscScreens.h"
@@ -55,13 +56,13 @@ public:
 
 protected:
 	virtual bool DisplayTopBar();
-	virtual bool HasSpecialFiles(std::vector<std::string> &filenames);
+	virtual bool HasSpecialFiles(std::vector<Path> &filenames);
 
 	void Refresh();
 
 private:
 	bool IsCurrentPathPinned();
-	const std::vector<std::string> GetPinnedPaths();
+	const std::vector<Path> GetPinnedPaths();
 	const std::string GetBaseName(const std::string &path);
 
 	UI::EventReturn GameButtonClick(UI::EventParams &e);

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -38,18 +38,18 @@ enum class BrowseFlags {
 };
 ENUM_CLASS_BITOPS(BrowseFlags);
 
-bool LaunchFile(ScreenManager *screenManager, std::string path);
+bool LaunchFile(ScreenManager *screenManager, const Path &path);
 
 class GameBrowser : public UI::LinearLayout {
 public:
-	GameBrowser(std::string path, BrowseFlags browseFlags, bool *gridStyle, ScreenManager *screenManager, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = nullptr);
+	GameBrowser(const std::string &path, BrowseFlags browseFlags, bool *gridStyle, ScreenManager *screenManager, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = nullptr);
 
 	UI::Event OnChoice;
 	UI::Event OnHoldChoice;
 	UI::Event OnHighlight;
 
-	void FocusGame(const std::string &gamePath);
-	void SetPath(const std::string &path);
+	void FocusGame(const Path &gamePath);
+	void SetPath(const Path &path);
 	void Draw(UIContext &dc) override;
 	void Update() override;
 
@@ -84,7 +84,7 @@ private:
 	BrowseFlags browseFlags_;
 	std::string lastText_;
 	std::string lastLink_;
-	std::string focusGamePath_;
+	Path focusGamePath_;
 	bool listingPending_ = false;
 	float lastScale_ = 1.0f;
 	bool lastLayoutWasGrid_ = true;
@@ -111,7 +111,7 @@ protected:
 	void dialogFinished(const Screen *dialog, DialogResult result) override;
 
 	bool UseVerticalLayout() const;
-	bool DrawBackgroundFor(UIContext &dc, const std::string &gamePath, float progress);
+	bool DrawBackgroundFor(UIContext &dc, const Path &gamePath, float progress);
 
 	UI::EventReturn OnGameSelected(UI::EventParams &e);
 	UI::EventReturn OnGameSelectedInstant(UI::EventParams &e);
@@ -133,11 +133,11 @@ protected:
 	UI::TabHolder *tabHolder_ = nullptr;
 	UI::Button *fullscreenButton_ = nullptr;
 
-	std::string restoreFocusGamePath_;
+	Path restoreFocusGamePath_;
 	std::vector<GameBrowser *> gameBrowsers_;
 
-	std::string highlightedGamePath_;
-	std::string prevHighlightedGamePath_;
+	Path highlightedGamePath_;
+	Path prevHighlightedGamePath_;
 	float highlightProgress_ = 0.0f;
 	float prevHighlightProgress_ = 0.0f;
 	bool backFromStore_ = false;

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -43,7 +43,7 @@ bool LaunchFile(ScreenManager *screenManager, const Path &path);
 
 class GameBrowser : public UI::LinearLayout {
 public:
-	GameBrowser(const std::string &path, BrowseFlags browseFlags, bool *gridStyle, ScreenManager *screenManager, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = nullptr);
+	GameBrowser(const Path &path, BrowseFlags browseFlags, bool *gridStyle, ScreenManager *screenManager, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = nullptr);
 
 	UI::Event OnChoice;
 	UI::Event OnHoldChoice;

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -579,9 +579,9 @@ void NewLanguageScreen::OnCompleted(DialogResult result) {
 void LogoScreen::Next() {
 	if (!switched_) {
 		switched_ = true;
-		Path gamePath = Path(boot_filename);
+		Path gamePath = boot_filename;
 		if (gotoGameSettings_) {
-			if (boot_filename.size()) {
+			if (!gamePath.empty()) {
 				screenManager()->switchScreen(new EmuScreen(gamePath));
 			} else {
 				screenManager()->switchScreen(new MainScreen());

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -29,7 +29,7 @@
 struct ShaderInfo;
 struct TextureShaderInfo;
 
-extern std::string boot_filename;
+extern Path boot_filename;
 void UIBackgroundInit(UIContext &dc);
 void UIBackgroundShutdown();
 

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -24,6 +24,7 @@
 
 #include "Common/UI/UIScreen.h"
 #include "Common/File/DirListing.h"
+#include "Common/File/Path.h"
 
 struct ShaderInfo;
 struct TextureShaderInfo;
@@ -49,7 +50,7 @@ public:
 	void DrawBackground(UIContext &dc) override;
 	void sendMessage(const char *message, const char *value) override;
 protected:
-	std::string gamePath_;
+	Path gamePath_;
 };
 
 class UIDialogScreenWithBackground : public UIDialogScreen {
@@ -64,12 +65,12 @@ protected:
 
 class UIDialogScreenWithGameBackground : public UIDialogScreenWithBackground {
 public:
-	UIDialogScreenWithGameBackground(const std::string &gamePath)
+	UIDialogScreenWithGameBackground(const Path &gamePath)
 		: UIDialogScreenWithBackground(), gamePath_(gamePath) {}
 	void DrawBackground(UIContext &dc) override;
 	void sendMessage(const char *message, const char *value) override;
 protected:
-	std::string gamePath_;
+	Path gamePath_;
 };
 
 class PromptScreen : public UIDialogScreenWithBackground {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -511,11 +511,11 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 		}
 	}
 #elif PPSSPP_PLATFORM(IOS)
-	g_Config.memStickDirectory = user_data_path;
-	g_Config.flash0Directory = std::string(external_dir) + "/flash0/";
+	g_Config.memStickDirectory = Path(user_data_path);
+	g_Config.flash0Directory = Path(std::string(external_dir)) / "flash0";
 #elif PPSSPP_PLATFORM(SWITCH)
-	g_Config.memStickDirectory = g_Config.internalDataDirectory + "config/ppsspp/";
-	g_Config.flash0Directory = g_Config.internalDataDirectory + "assets/flash0/";
+	g_Config.memStickDirectory = Path(g_Config.internalDataDirectory) / "config/ppsspp";
+	g_Config.flash0Directory = Path(g_Config.internalDataDirectory) / "assets/flash0";
 #elif !PPSSPP_PLATFORM(WINDOWS)
 	std::string config;
 	if (getenv("XDG_CONFIG_HOME") != NULL)

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -386,7 +386,7 @@ static void CheckFailedGPUBackends() {
 
 	if (System_GetPropertyBool(SYSPROP_SUPPORTS_PERMISSIONS)) {
 		std::string data;
-		if (File::ReadFileToString(true, cache.c_str(), data))
+		if (File::ReadFileToString(true, cache, data))
 			g_Config.sFailedGPUBackends = data;
 	}
 
@@ -414,7 +414,7 @@ static void CheckFailedGPUBackends() {
 		// Let's try to create, in case it doesn't exist.
 		if (!File::Exists(GetSysDirectory(DIRECTORY_APP_CACHE)))
 			File::CreateDir(GetSysDirectory(DIRECTORY_APP_CACHE));
-		File::WriteStringToFile(true, g_Config.sFailedGPUBackends, cache.c_str());
+		File::WriteStringToFile(true, g_Config.sFailedGPUBackends, cache);
 	} else {
 		// Just save immediately, since we have storage.
 		g_Config.Save("got storage permission");
@@ -499,13 +499,15 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	g_Config.memStickDirectory = Path(external_dir);
 	g_Config.flash0Directory = Path(external_dir) / "flash0";
 
-	std::string memstickDirFile = g_Config.internalDataDirectory + "/memstick_dir.txt";
+	Path memstickDirFile = Path(g_Config.internalDataDirectory) / "memstick_dir.txt";
 	if (File::Exists(memstickDirFile)) {
 		std::string memstickDir;
-		File::ReadFileToString(true, memstickDirFile.c_str(), memstickDir);
+		File::ReadFileToString(true, memstickDirFile, memstickDir);
 		Path memstickPath(memstickDir);
 		if (!memstickPath.empty() && File::Exists(memstickPath)) {
 			g_Config.memStickDirectory = memstickPath;
+		} else {
+		    ERROR_LOG(SYSTEM, "Couldn't read directory '%s' specified by memstick_dir.txt.", memstickDir.c_str());
 		}
 	}
 #elif PPSSPP_PLATFORM(IOS)
@@ -1165,7 +1167,7 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 	if (msg == "bgImage_updated") {
 		if (!value.empty()) {
 			Path dest = GetSysDirectory(DIRECTORY_SYSTEM) / (endsWithNoCase(value, ".jpg") ? "background.jpg" : "background.png");
-			File::Copy(value, dest.ToString());
+			File::Copy(Path(value), dest);
 		}
 		UIBackgroundShutdown();
 		// It will init again automatically.  We can't init outside a frame on Vulkan.

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -207,7 +207,7 @@ int Win32Mix(short *buffer, int numSamples, int bits, int rate, int channels) {
 
 // globals
 static LogListener *logger = nullptr;
-std::string boot_filename = "";
+Path boot_filename;
 
 void NativeHost::InitSound() {
 #if PPSSPP_PLATFORM(IOS)
@@ -559,7 +559,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	bool gotBootFilename = false;
 	bool gotoGameSettings = false;
 	bool gotoTouchScreenTest = false;
-	boot_filename = "";
+	boot_filename.clear();
 
 	// Parse command line
 	LogTypes::LOG_LEVELS logLevel = LogTypes::LINFO;
@@ -644,10 +644,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 					}
 				}
 				if (okToLoad) {
-					boot_filename = argv[i];
-#ifdef _WIN32
-					boot_filename = ReplaceAll(boot_filename, "\\", "/");
-#endif
+					boot_filename = Path(std::string(argv[i]));
 					skipLogo = true;
 				}
 				if (okToLoad && okToCheck) {
@@ -758,7 +755,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 		screenManager->switchScreen(new MainScreen());
 		screenManager->push(new TouchTestScreen());
 	} else if (skipLogo) {
-		screenManager->switchScreen(new EmuScreen(Path(boot_filename)));
+		screenManager->switchScreen(new EmuScreen(boot_filename));
 	} else {
 		screenManager->switchScreen(new LogoScreen());
 	}

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -537,8 +537,8 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 
 #if !PPSSPP_PLATFORM(WINDOWS)
 	g_Config.AddSearchPath(Path(user_data_path));
-	g_Config.AddSearchPath(Path(GetSysDirectory(DIRECTORY_SYSTEM)));
-	g_Config.SetDefaultPath(Path(GetSysDirectory(DIRECTORY_SYSTEM)));
+	g_Config.AddSearchPath(GetSysDirectory(DIRECTORY_SYSTEM));
+	g_Config.SetDefaultPath(GetSysDirectory(DIRECTORY_SYSTEM));
 
 	// Note that if we don't have storage permission here, loading the config will
 	// fail and it will be set to the default. Later, we load again when we get permission.

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -20,6 +20,7 @@
 #include <functional>
 #include <memory>
 
+#include "Common/File/Path.h"
 #include "Common/UI/UIScreen.h"
 #include "Common/UI/ViewGroup.h"
 #include "UI/MiscScreens.h"
@@ -27,7 +28,7 @@
 
 class GamePauseScreen : public UIDialogScreenWithGameBackground {
 public:
-	GamePauseScreen(const std::string &filename) : UIDialogScreenWithGameBackground(filename), gamePath_(filename) {}
+	GamePauseScreen(const Path &filename) : UIDialogScreenWithGameBackground(filename), gamePath_(filename) {}
 	virtual ~GamePauseScreen();
 
 	virtual void dialogFinished(const Screen *dialog, DialogResult dr) override;
@@ -55,14 +56,14 @@ private:
 
 	// hack
 	bool finishNextFrame_ = false;
-	std::string gamePath_;
+	Path gamePath_;
 };
 
 // AsyncImageFileView loads a texture from a file, and reloads it as necessary.
 // TODO: Actually make async, doh.
 class AsyncImageFileView : public UI::Clickable {
 public:
-	AsyncImageFileView(const std::string &filename, UI::ImageSizeMode sizeMode, UI::LayoutParams *layoutParams = 0);
+	AsyncImageFileView(const Path &filename, UI::ImageSizeMode sizeMode, UI::LayoutParams *layoutParams = 0);
 	~AsyncImageFileView();
 
 	void GetContentDimensionsBySpec(const UIContext &dc, UI::MeasureSpec horiz, UI::MeasureSpec vert, float &w, float &h) const override;
@@ -72,7 +73,7 @@ public:
 	void DeviceLost() override;
 	void DeviceRestored(Draw::DrawContext *draw) override;
 
-	void SetFilename(std::string filename);
+	void SetFilename(const Path &filename);
 	void SetColor(uint32_t color) { color_ = color; }
 	void SetOverlayText(std::string text) { text_ = text; }
 	void SetFixedSize(float fixW, float fixH) { fixedSizeW_ = fixW; fixedSizeH_ = fixH; }
@@ -80,11 +81,11 @@ public:
 
 	bool CanBeFocused() const override { return canFocus_; }
 
-	const std::string &GetFilename() const { return filename_; }
+	const Path &GetFilename() const { return filename_; }
 
 private:
 	bool canFocus_;
-	std::string filename_;
+	Path filename_;
 	std::string text_;
 	uint32_t color_;
 	UI::ImageSizeMode sizeMode_;

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -499,7 +499,7 @@ void RemoteISOConnectScreen::ExecuteLoad() {
 class RemoteGameBrowser : public GameBrowser {
 public:
 	RemoteGameBrowser(const std::string &url, const std::vector<std::string> &games, BrowseFlags browseFlags, bool *gridStyle_, ScreenManager* screenManager, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = nullptr)
-	: GameBrowser(url, browseFlags, gridStyle_, screenManager, lastText, lastLink, layoutParams) {
+		: GameBrowser(url, browseFlags, gridStyle_, screenManager, lastText, lastLink, layoutParams) {
 		games_ = games;
 		Refresh();
 	}

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -243,7 +243,7 @@ bool RemoteISOConnectScreen::FindServer(std::string &resultHost, int &resultPort
 	return false;
 }
 
-static bool LoadGameList(const std::string &url, std::vector<std::string> &games) {
+static bool LoadGameList(const std::string &url, std::vector<Path> &games) {
 	PathBrowser browser(url);
 	std::vector<File::FileInfo> files;
 	browser.GetListing(files, "iso:cso:pbp:elf:prx:ppdmp:", &scanCancelled);
@@ -498,7 +498,7 @@ void RemoteISOConnectScreen::ExecuteLoad() {
 
 class RemoteGameBrowser : public GameBrowser {
 public:
-	RemoteGameBrowser(const std::string &url, const std::vector<std::string> &games, BrowseFlags browseFlags, bool *gridStyle_, ScreenManager* screenManager, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = nullptr)
+	RemoteGameBrowser(const std::string &url, const std::vector<Path> &games, BrowseFlags browseFlags, bool *gridStyle_, ScreenManager* screenManager, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = nullptr)
 		: GameBrowser(url, browseFlags, gridStyle_, screenManager, lastText, lastLink, layoutParams) {
 		games_ = games;
 		Refresh();
@@ -509,18 +509,18 @@ protected:
 		return false;
 	}
 
-	bool HasSpecialFiles(std::vector<std::string> &filenames) override;
+	bool HasSpecialFiles(std::vector<Path> &filenames) override;
 
 	std::string url_;
-	std::vector<std::string> games_;
+	std::vector<Path> games_;
 };
 
-bool RemoteGameBrowser::HasSpecialFiles(std::vector<std::string> &filenames) {
+bool RemoteGameBrowser::HasSpecialFiles(std::vector<Path> &filenames) {
 	filenames = games_;
 	return true;
 }
 
-RemoteISOBrowseScreen::RemoteISOBrowseScreen(const std::string &url, const std::vector<std::string> &games)
+RemoteISOBrowseScreen::RemoteISOBrowseScreen(const std::string &url, const std::vector<Path> &games)
 	: url_(url), games_(games) {
 }
 

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -243,7 +243,7 @@ bool RemoteISOConnectScreen::FindServer(std::string &resultHost, int &resultPort
 	return false;
 }
 
-static bool LoadGameList(const std::string &url, std::vector<Path> &games) {
+static bool LoadGameList(const Path &url, std::vector<Path> &games) {
 	PathBrowser browser(url);
 	std::vector<File::FileInfo> files;
 	browser.GetListing(files, "iso:cso:pbp:elf:prx:ppdmp:", &scanCancelled);
@@ -482,7 +482,7 @@ ScanStatus RemoteISOConnectScreen::GetStatus() {
 void RemoteISOConnectScreen::ExecuteLoad() {
 	std::string subdir = RemoteSubdir();
 	url_ = StringFromFormat("http://%s:%d%s", host_.c_str(), port_, subdir.c_str());
-	bool result = LoadGameList(url_, games_);
+	bool result = LoadGameList(Path(url_), games_);
 	if (scanAborted) {
 		return;
 	}
@@ -498,7 +498,7 @@ void RemoteISOConnectScreen::ExecuteLoad() {
 
 class RemoteGameBrowser : public GameBrowser {
 public:
-	RemoteGameBrowser(const std::string &url, const std::vector<Path> &games, BrowseFlags browseFlags, bool *gridStyle_, ScreenManager* screenManager, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = nullptr)
+	RemoteGameBrowser(const Path &url, const std::vector<Path> &games, BrowseFlags browseFlags, bool *gridStyle_, ScreenManager* screenManager, std::string lastText, std::string lastLink, UI::LayoutParams *layoutParams = nullptr)
 		: GameBrowser(url, browseFlags, gridStyle_, screenManager, lastText, lastLink, layoutParams) {
 		games_ = games;
 		Refresh();
@@ -542,7 +542,7 @@ void RemoteISOBrowseScreen::CreateViews() {
 	ScrollView *scrollRecentGames = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 	scrollRecentGames->SetTag("RemoteGamesTab");
 	RemoteGameBrowser *tabRemoteGames = new RemoteGameBrowser(
-		url_, games_, BrowseFlags::PIN, &g_Config.bGridView1, screenManager(), "", "",
+		Path(url_), games_, BrowseFlags::PIN, &g_Config.bGridView1, screenManager(), "", "",
 		new LinearLayoutParams(FILL_PARENT, FILL_PARENT));
 	scrollRecentGames->Add(tabRemoteGames);
 	gameBrowsers_.push_back(tabRemoteGames);

--- a/UI/RemoteISOScreen.h
+++ b/UI/RemoteISOScreen.h
@@ -76,18 +76,18 @@ protected:
 	std::string host_;
 	int port_;
 	std::string url_;
-	std::vector<std::string> games_;
+	std::vector<Path> games_;
 };
 
 class RemoteISOBrowseScreen : public MainScreen {
 public:
-	RemoteISOBrowseScreen(const std::string &url, const std::vector<std::string> &games);
+	RemoteISOBrowseScreen(const std::string &url, const std::vector<Path> &games);
 
 protected:
 	void CreateViews() override;
 
 	std::string url_;
-	std::vector<std::string> games_;
+	std::vector<Path> games_;
 };
 
 class RemoteISOSettingsScreen : public UIDialogScreenWithBackground {

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -270,7 +270,7 @@ void ReportScreen::CreateViews() {
 	}
 
 #ifdef MOBILE_DEVICE
-	if (!Core_GetPowerSaving() && !Reporting::HasCRC(gamePath_.ToString())) {
+	if (!Core_GetPowerSaving() && !Reporting::HasCRC(gamePath_)) {
 		auto crcWarning = new TextView(rp->T("FeedbackIncludeCRC", "Note: Battery will be used to send a disc CRC"), FLAG_WRAP_TEXT, false, new LinearLayoutParams(Margins(12, 5, 0, 5)));
 		crcWarning->SetShadow(true);
 		crcWarning->SetEnabledPtr(&enableReporting_);
@@ -334,8 +334,8 @@ void ReportScreen::UpdateCRCInfo() {
 	auto rp = GetI18NCategory("Reporting");
 	std::string updated;
 
-	if (Reporting::HasCRC(gamePath_.ToString())) {
-		std::string crc = StringFromFormat("%08X", Reporting::RetrieveCRC(gamePath_.ToString()));
+	if (Reporting::HasCRC(gamePath_)) {
+		std::string crc = StringFromFormat("%08X", Reporting::RetrieveCRC(gamePath_));
 		updated = ReplaceAll(rp->T("FeedbackCRCValue", "Disc CRC: [VALUE]"), "[VALUE]", crc);
 	} else if (showCRC_) {
 		updated = rp->T("FeedbackCRCCalculating", "Disc CRC: Calculating...");
@@ -395,7 +395,7 @@ EventReturn ReportScreen::HandleBrowser(EventParams &e) {
 }
 
 EventReturn ReportScreen::HandleShowCRC(EventParams &e) {
-	Reporting::QueueCRC(gamePath_.ToString());
+	Reporting::QueueCRC(gamePath_);
 	showCRC_ = true;
 	return EVENT_DONE;
 }

--- a/UI/ReportScreen.h
+++ b/UI/ReportScreen.h
@@ -22,6 +22,7 @@
 #include "Common/UI/UIScreen.h"
 #include "Common/UI/ViewGroup.h"
 #include "UI/MiscScreens.h"
+#include "Common/File/Path.h"
 
 enum class ReportingOverallScore : int {
 	PERFECT = 0,
@@ -34,7 +35,7 @@ enum class ReportingOverallScore : int {
 
 class ReportScreen : public UIDialogScreenWithGameBackground {
 public:
-	ReportScreen(const std::string &gamePath);
+	ReportScreen(const Path &gamePath);
 
 protected:
 	void postRender() override;
@@ -57,7 +58,7 @@ protected:
 	UI::TextView *overallDescription_ = nullptr;
 	UI::TextView *crcInfo_ = nullptr;
 	UI::Choice *showCrcButton_ = nullptr;
-	std::string screenshotFilename_;
+	Path screenshotFilename_;
 
 	ReportingOverallScore overall_ = ReportingOverallScore::INVALID;
 	int graphics_ = -1;
@@ -72,7 +73,7 @@ protected:
 
 class ReportFinishScreen : public UIDialogScreenWithGameBackground {
 public:
-	ReportFinishScreen(const std::string &gamePath, ReportingOverallScore score);
+	ReportFinishScreen(const Path &gamePath, ReportingOverallScore score);
 
 protected:
 	void update() override;

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -112,8 +112,7 @@ public:
 			content->Add(new TextView(ReplaceAll(savedata_detail, "\r", ""), ALIGN_LEFT | FLAG_WRAP_TEXT, true, new LinearLayoutParams(Margins(10, 0))))->SetTextColor(textStyle.fgColor);
 			content->Add(new Spacer(3.0));
 		} else {
-			// TODO(scoped): This can't work
-			Path image_path = Path(ReplaceAll(savePath_.ToString(), ".ppst", ".jpg"));
+			Path image_path = savePath_.WithReplacedExtension(".ppst", ".jpg");
 			if (File::Exists(image_path)) {
 				toprow->Add(new AsyncImageFileView(Path(image_path), IS_KEEP_ASPECT, new LinearLayoutParams(480, 272, Margins(10, 0))));
 			} else {

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -170,9 +170,9 @@ void SortedLinearLayout::Update() {
 
 class SavedataButton : public UI::Clickable {
 public:
-	SavedataButton(const std::string &gamePath, UI::LayoutParams *layoutParams = 0)
+	SavedataButton(const Path &gamePath, UI::LayoutParams *layoutParams = 0)
 		: UI::Clickable(layoutParams), savePath_(gamePath) {
-		SetTag(gamePath);
+		SetTag(gamePath.ToString());
 	}
 
 	void Draw(UIContext &dc) override;

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -46,7 +46,7 @@
 
 class SavedataButton;
 
-std::string GetFileDateAsString(std::string filename) {
+std::string GetFileDateAsString(const Path &filename) {
 	tm time;
 	if (File::GetModifTime(filename, time)) {
 		char buf[256];
@@ -106,15 +106,16 @@ public:
 			topright->SetSpacing(1.0f);
 			topright->Add(new TextView(savedata_title, ALIGN_LEFT | FLAG_WRAP_TEXT, false))->SetTextColor(textStyle.fgColor);
 			topright->Add(new TextView(StringFromFormat("%lld kB", ginfo->gameSize / 1024), 0, true))->SetTextColor(textStyle.fgColor);
-			topright->Add(new TextView(GetFileDateAsString(savePath_ + "/PARAM.SFO"), 0, true))->SetTextColor(textStyle.fgColor);
+			topright->Add(new TextView(GetFileDateAsString(savePath_ / "PARAM.SFO"), 0, true))->SetTextColor(textStyle.fgColor);
 			toprow->Add(topright);
 			content->Add(new Spacer(3.0));
 			content->Add(new TextView(ReplaceAll(savedata_detail, "\r", ""), ALIGN_LEFT | FLAG_WRAP_TEXT, true, new LinearLayoutParams(Margins(10, 0))))->SetTextColor(textStyle.fgColor);
 			content->Add(new Spacer(3.0));
 		} else {
-			std::string image_path = ReplaceAll(savePath_, ".ppst", ".jpg");
+			// TODO(scoped): This can't work
+			Path image_path = Path(ReplaceAll(savePath_.ToString(), ".ppst", ".jpg"));
 			if (File::Exists(image_path)) {
-				toprow->Add(new AsyncImageFileView(image_path, IS_KEEP_ASPECT, new LinearLayoutParams(480, 272, Margins(10, 0))));
+				toprow->Add(new AsyncImageFileView(Path(image_path), IS_KEEP_ASPECT, new LinearLayoutParams(480, 272, Margins(10, 0))));
 			} else {
 				toprow->Add(new TextView(sa->T("No screenshot"), new LinearLayoutParams(Margins(10, 5))))->SetTextColor(textStyle.fgColor);
 			}
@@ -133,7 +134,7 @@ protected:
 
 private:
 	UI::EventReturn OnDeleteButtonClick(UI::EventParams &e);
-	std::string savePath_;
+	Path savePath_;
 };
 
 class SortedLinearLayout : public UI::LinearLayoutList {
@@ -182,12 +183,12 @@ public:
 		h = 74;
 	}
 
-	const std::string &GamePath() const { return savePath_; }
+	const Path &GamePath() const { return savePath_; }
 
 private:
 	void UpdateText(const std::shared_ptr<GameInfo> &ginfo);
 
-	std::string savePath_;
+	Path savePath_;
 	std::string title_;
 	std::string subtitle_;
 };
@@ -345,7 +346,7 @@ std::string SavedataButton::DescribeText() const {
 	return ReplaceAll(u->T("%1 button"), "%1", title_) + "\n" + subtitle_;
 }
 
-SavedataBrowser::SavedataBrowser(std::string path, UI::LayoutParams *layoutParams)
+SavedataBrowser::SavedataBrowser(const Path &path, UI::LayoutParams *layoutParams)
 	: LinearLayout(UI::ORIENT_VERTICAL, layoutParams), path_(path) {
 	Refresh();
 }
@@ -425,11 +426,11 @@ bool SavedataBrowser::ByFilename(const UI::View *v1, const UI::View *v2) {
 }
 
 static time_t GetTotalSize(const SavedataButton *b) {
-	auto fileLoader = std::unique_ptr<FileLoader>(ConstructFileLoader(b->GamePath()));
+	auto fileLoader = std::unique_ptr<FileLoader>(ConstructFileLoader(b->GamePath().ToString()));
 	switch (Identify_File(fileLoader.get())) {
 	case IdentifiedFileType::PSP_PBP_DIRECTORY:
 	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY:
-		return File::GetDirectoryRecursiveSize(ResolvePBPDirectory(b->GamePath()), nullptr, File::GETFILES_GETHIDDEN);
+		return File::GetDirectoryRecursiveSize(Path(ResolvePBPDirectory(b->GamePath().ToString())), nullptr, File::GETFILES_GETHIDDEN);
 
 	default:
 		return fileLoader->FileSize();
@@ -446,11 +447,11 @@ bool SavedataBrowser::BySize(const UI::View *v1, const UI::View *v2) {
 }
 
 static time_t GetDateSeconds(const SavedataButton *b) {
-	auto fileLoader = std::unique_ptr<FileLoader>(ConstructFileLoader(b->GamePath()));
+	auto fileLoader = std::unique_ptr<FileLoader>(ConstructFileLoader(b->GamePath().ToString()));
 	tm datetm;
 	bool success;
 	if (Identify_File(fileLoader.get()) == IdentifiedFileType::PSP_SAVEDATA_DIRECTORY) {
-		success = File::GetModifTime(b->GamePath() + "/PARAM.SFO", datetm);
+		success = File::GetModifTime(b->GamePath() / "PARAM.SFO", datetm);
 	} else {
 		success = File::GetModifTime(b->GamePath(), datetm);
 	}
@@ -488,13 +489,13 @@ void SavedataBrowser::Refresh() {
 	std::vector<SavedataButton *> savedataButtons;
 
 	std::vector<File::FileInfo> fileInfo;
-	GetFilesInDir(path_.c_str(), &fileInfo, "ppst:");
+	GetFilesInDir(path_, &fileInfo, "ppst:");
 
 	for (size_t i = 0; i < fileInfo.size(); i++) {
 		bool isState = !fileInfo[i].isDirectory;
 		bool isSaveData = false;
 		
-		if (!isState && File::Exists(path_ + fileInfo[i].name + "/PARAM.SFO"))
+		if (!isState && File::Exists(path_ / fileInfo[i].name / "PARAM.SFO"))
 			isSaveData = true;
 
 		if (isSaveData || isState) {
@@ -537,13 +538,13 @@ UI::EventReturn SavedataBrowser::SavedataButtonClick(UI::EventParams &e) {
 	SavedataButton *button = static_cast<SavedataButton *>(e.v);
 	UI::EventParams e2{};
 	e2.v = e.v;
-	e2.s = button->GamePath();
+	e2.s = button->GamePath().ToString();
 	// Insta-update - here we know we are already on the right thread.
 	OnChoice.Trigger(e2);
 	return UI::EVENT_DONE;
 }
 
-SavedataScreen::SavedataScreen(std::string gamePath) : UIDialogScreenWithGameBackground(gamePath) {
+SavedataScreen::SavedataScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {
 }
 
 SavedataScreen::~SavedataScreen() {
@@ -557,8 +558,8 @@ void SavedataScreen::CreateViews() {
 	using namespace UI;
 	auto sa = GetI18NCategory("Savedata");
 	auto di = GetI18NCategory("Dialog");
-	std::string savedata_dir = GetSysDirectory(DIRECTORY_SAVEDATA);
-	std::string savestate_dir = GetSysDirectory(DIRECTORY_SAVESTATE);
+	Path savedata_dir = GetSysDirectory(DIRECTORY_SAVEDATA);
+	Path savestate_dir = GetSysDirectory(DIRECTORY_SAVESTATE);
 
 	gridStyle_ = false;
 	root_ = new AnchorLayout();
@@ -627,7 +628,7 @@ UI::EventReturn SavedataScreen::OnSearch(UI::EventParams &e) {
 }
 
 UI::EventReturn SavedataScreen::OnSavedataButtonClick(UI::EventParams &e) {
-	std::shared_ptr<GameInfo> ginfo = g_gameInfoCache->GetInfo(screenManager()->getDrawContext(), e.s, 0);
+	std::shared_ptr<GameInfo> ginfo = g_gameInfoCache->GetInfo(screenManager()->getDrawContext(), Path(e.s), 0);
 	SavedataPopupScreen *popupScreen = new SavedataPopupScreen(e.s, ginfo->GetTitle());
 	if (e.v) {
 		popupScreen->SetPopupOrigin(e.v);

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -426,11 +426,11 @@ bool SavedataBrowser::ByFilename(const UI::View *v1, const UI::View *v2) {
 }
 
 static time_t GetTotalSize(const SavedataButton *b) {
-	auto fileLoader = std::unique_ptr<FileLoader>(ConstructFileLoader(b->GamePath().ToString()));
+	auto fileLoader = std::unique_ptr<FileLoader>(ConstructFileLoader(b->GamePath()));
 	switch (Identify_File(fileLoader.get())) {
 	case IdentifiedFileType::PSP_PBP_DIRECTORY:
 	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY:
-		return File::GetDirectoryRecursiveSize(Path(ResolvePBPDirectory(b->GamePath().ToString())), nullptr, File::GETFILES_GETHIDDEN);
+		return File::GetDirectoryRecursiveSize(ResolvePBPDirectory(b->GamePath()), nullptr, File::GETFILES_GETHIDDEN);
 
 	default:
 		return fileLoader->FileSize();
@@ -447,7 +447,7 @@ bool SavedataBrowser::BySize(const UI::View *v1, const UI::View *v2) {
 }
 
 static time_t GetDateSeconds(const SavedataButton *b) {
-	auto fileLoader = std::unique_ptr<FileLoader>(ConstructFileLoader(b->GamePath().ToString()));
+	auto fileLoader = std::unique_ptr<FileLoader>(ConstructFileLoader(b->GamePath()));
 	tm datetm;
 	bool success;
 	if (Identify_File(fileLoader.get()) == IdentifiedFileType::PSP_SAVEDATA_DIRECTORY) {

--- a/UI/SavedataScreen.h
+++ b/UI/SavedataScreen.h
@@ -20,6 +20,8 @@
 #include <functional>
 #include <string>
 
+#include "Common/File/Path.h"
+
 #include "Common/UI/UIScreen.h"
 #include "Common/UI/View.h"
 #include "Common/UI/ViewGroup.h"
@@ -34,7 +36,7 @@ enum class SavedataSortOption {
 
 class SavedataBrowser : public UI::LinearLayout {
 public:
-	SavedataBrowser(std::string path, UI::LayoutParams *layoutParams = 0);
+	SavedataBrowser(const Path &path, UI::LayoutParams *layoutParams = 0);
 
 	void Update() override;
 
@@ -56,7 +58,7 @@ private:
 	UI::ViewGroup *gameList_ = nullptr;
 	UI::TextView *noMatchView_ = nullptr;
 	UI::TextView *searchingView_ = nullptr;
-	std::string path_;
+	Path path_;
 	std::string searchFilter_;
 	bool searchPending_ = false;
 };
@@ -64,7 +66,7 @@ private:
 class SavedataScreen : public UIDialogScreenWithGameBackground {
 public:
 	// gamePath can be empty, in that case this screen will show all savedata in the save directory.
-	SavedataScreen(std::string gamePath);
+	SavedataScreen(const Path &gamePath);
 	~SavedataScreen();
 
 	void dialogFinished(const Screen *dialog, DialogResult result) override;

--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -257,6 +257,7 @@ void ProductView::CreateViews() {
 		Add(progressDisplay);
 	} else {
 		installButton_ = nullptr;
+		speedView_ = nullptr;
 		Add(new TextView(st->T("Already Installed")));
 		Add(new Button(st->T("Uninstall")))->OnClick.Handle(this, &ProductView::OnUninstall);
 		launchButton_ = new Button(st->T("Launch Game"));

--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -348,14 +348,11 @@ UI::EventReturn ProductView::OnLaunchClick(UI::EventParams &e) {
 		return UI::EVENT_DONE;
 	}
 
-	std::string pspGame = GetSysDirectory(DIRECTORY_GAME);
-	std::string path = pspGame + entry_.file;
-#ifdef _WIN32
-	path = ReplaceAll(path, "\\", "/");
-#endif
+	Path pspGame = GetSysDirectory(DIRECTORY_GAME);
+	Path path = pspGame / entry_.file;
 	UI::EventParams e2{};
 	e2.v = e.v;
-	e2.s = path;
+	e2.s = path.ToString();
 	// Insta-update - here we know we are already on the right thread.
 	OnClickLaunch.Trigger(e2);
 	return UI::EVENT_DONE;
@@ -547,7 +544,7 @@ UI::EventReturn StoreScreen::OnGameSelected(UI::EventParams &e) {
 
 UI::EventReturn StoreScreen::OnGameLaunch(UI::EventParams &e) {
 	std::string path = e.s;
-	screenManager()->switchScreen(new EmuScreen(path));
+	screenManager()->switchScreen(new EmuScreen(Path(path)));
 	return UI::EVENT_DONE;
 }
 

--- a/UI/TextureUtil.h
+++ b/UI/TextureUtil.h
@@ -4,6 +4,7 @@
 
 #include "Common/GPU/thin3d.h"
 #include "Common/UI/View.h"
+#include "Common/File/Path.h"
 
 enum ImageFileType {
 	PNG,
@@ -44,7 +45,7 @@ std::unique_ptr<ManagedTexture> CreateTextureFromFileData(Draw::DrawContext *dra
 
 class GameIconView : public UI::InertView {
 public:
-	GameIconView(std::string gamePath, float scale, UI::LayoutParams *layoutParams = 0)
+	GameIconView(const Path &gamePath, float scale, UI::LayoutParams *layoutParams = 0)
 		: InertView(layoutParams), gamePath_(gamePath), scale_(scale) {}
 
 	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
@@ -52,7 +53,7 @@ public:
 	std::string DescribeText() const override { return ""; }
 
 private:
-	std::string gamePath_;
+	Path gamePath_;
 	float scale_ = 1.0f;
 	int textureWidth_ = 0;
 	int textureHeight_ = 0;

--- a/UWP/CommonUWP/CommonUWP.vcxproj
+++ b/UWP/CommonUWP/CommonUWP.vcxproj
@@ -415,6 +415,7 @@
     <ClInclude Include="..\..\Common\File\DiskFree.h" />
     <ClInclude Include="..\..\Common\File\FileDescriptor.h" />
     <ClInclude Include="..\..\Common\File\FileUtil.h" />
+    <ClInclude Include="..\..\Common\File\Path.h" />
     <ClInclude Include="..\..\Common\File\PathBrowser.h" />
     <ClInclude Include="..\..\Common\File\VFS\AssetReader.h" />
     <ClInclude Include="..\..\Common\File\VFS\VFS.h" />
@@ -535,6 +536,7 @@
     <ClCompile Include="..\..\Common\File\DiskFree.cpp" />
     <ClCompile Include="..\..\Common\File\FileDescriptor.cpp" />
     <ClCompile Include="..\..\Common\File\FileUtil.cpp" />
+    <ClCompile Include="..\..\Common\File\Path.cpp" />
     <ClCompile Include="..\..\Common\File\PathBrowser.cpp" />
     <ClCompile Include="..\..\Common\File\VFS\AssetReader.cpp" />
     <ClCompile Include="..\..\Common\File\VFS\VFS.cpp" />

--- a/UWP/CommonUWP/CommonUWP.vcxproj.filters
+++ b/UWP/CommonUWP/CommonUWP.vcxproj.filters
@@ -242,6 +242,9 @@
     <ClCompile Include="..\..\Common\File\DiskFree.cpp">
       <Filter>File</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\File\Path.cpp">
+      <Filter>File</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Common\File\PathBrowser.cpp">
       <Filter>File</Filter>
     </ClCompile>
@@ -531,6 +534,9 @@
       <Filter>File</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Common\File\PathBrowser.h">
+      <Filter>File</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\File\Path.h">
       <Filter>File</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Common\Data\Format\RIFF.h">

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -109,8 +109,8 @@ PPSSPP_UWPMain::PPSSPP_UWPMain(App ^app, const std::shared_ptr<DX::DeviceResourc
 
 	// Load config up here, because those changes below would be overwritten
 	// if it's not loaded here first.
-	g_Config.AddSearchPath(GetSysDirectory(DIRECTORY_SYSTEM));
-	g_Config.SetDefaultPath(GetSysDirectory(DIRECTORY_SYSTEM));
+	g_Config.AddSearchGetSysDirectory(DIRECTORY_SYSTEM);
+	g_Config.SetDefaultGetSysDirectory(DIRECTORY_SYSTEM);
 	g_Config.Load(configFilename, controlsConfigFilename);
 
 	bool debugLogLevel = false;

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -97,9 +97,7 @@ PPSSPP_UWPMain::PPSSPP_UWPMain(App ^app, const std::shared_ptr<DX::DeviceResourc
 
 	std::wstring memstickFolderW = ApplicationData::Current->LocalFolder->Path->Data();
 
-	g_Config.memStickDirectory = ReplaceAll(ConvertWStringToUTF8(memstickFolderW), "\\", "/");
-	if (g_Config.memStickDirectory.back() != '/')
-		g_Config.memStickDirectory += "/";
+	g_Config.memStickDirectory = Path(ReplaceAll(ConvertWStringToUTF8(memstickFolderW), "\\", "/"));
 
 	// On Win32 it makes more sense to initialize the system directories here
 	// because the next place it was called was in the EmuThread, and it's too late by then.
@@ -109,8 +107,8 @@ PPSSPP_UWPMain::PPSSPP_UWPMain(App ^app, const std::shared_ptr<DX::DeviceResourc
 
 	// Load config up here, because those changes below would be overwritten
 	// if it's not loaded here first.
-	g_Config.AddSearchGetSysDirectory(DIRECTORY_SYSTEM);
-	g_Config.SetDefaultGetSysDirectory(DIRECTORY_SYSTEM);
+	g_Config.AddSearchPath(GetSysDirectory(DIRECTORY_SYSTEM));
+	g_Config.SetDefaultPath(GetSysDirectory(DIRECTORY_SYSTEM));
 	g_Config.Load(configFilename, controlsConfigFilename);
 
 	bool debugLogLevel = false;

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -312,7 +312,7 @@ void PPSSPP_UWPMain::OnSuspend() {
 void PPSSPP_UWPMain::LoadStorageFile(StorageFile ^file) {
 	std::unique_ptr<FileLoaderFactory> factory(new StorageFileLoaderFactory(file, IdentifiedFileType::PSP_ISO));
 	RegisterFileLoaderFactory("override://", std::move(factory));
-	NativeMessageReceived("boot", "override://");
+	NativeMessageReceived("boot", "override://file");
 }
 
 UWPGraphicsContext::UWPGraphicsContext(std::shared_ptr<DX::DeviceResources> resources) {

--- a/UWP/StorageFileLoader.cpp
+++ b/UWP/StorageFileLoader.cpp
@@ -175,6 +175,6 @@ size_t StorageFileLoader::ReadAt(s64 absolutePos, size_t bytes, size_t count, vo
 	}
 }
 
-FileLoader *StorageFileLoaderFactory::ConstructFileLoader(const std::string &filename) {
+FileLoader *StorageFileLoaderFactory::ConstructFileLoader(const Path &filename) {
 	return file_ ? new StorageFileLoader(file_) : nullptr;
 }

--- a/UWP/StorageFileLoader.cpp
+++ b/UWP/StorageFileLoader.cpp
@@ -3,6 +3,7 @@
 
 #include "Common/Log.h"
 #include "Common/File/FileUtil.h"
+#include "Common/File/Path.h"
 #include "Common/File/DirListing.h"
 #include "Common/Thread/ThreadUtil.h"
 #include "StorageFileLoader.h"
@@ -19,7 +20,7 @@ static std::mutex initMutex;
 StorageFileLoader::StorageFileLoader(Windows::Storage::StorageFile ^file) {
 	active_ = false;
 	file_ = file;
-	path_ = FromPlatformString(file_->Path);
+	path_ = Path(FromPlatformString(file_->Path));
 	thread_.reset(new std::thread([this]() { this->threadfunc(); }));
 
 	// Before we proceed, we need to block until the thread has found the size.
@@ -131,7 +132,7 @@ s64 StorageFileLoader::FileSize() {
 	return size_;
 }
 
-std::string StorageFileLoader::GetPath() const {
+Path StorageFileLoader::GetPath() const {
 	return path_;
 }
 

--- a/UWP/StorageFileLoader.h
+++ b/UWP/StorageFileLoader.h
@@ -54,7 +54,7 @@ private:
 
 	Windows::Storage::StorageFile ^file_;
 	Windows::Storage::Streams::IRandomAccessStreamWithContentType ^stream_;
-	std::string path_;
+	Path path_;
 
 	bool operationRequested_ = false;
 	Operation operation_{ OpType::NONE, 0, 0 };

--- a/UWP/StorageFileLoader.h
+++ b/UWP/StorageFileLoader.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "Common/CommonTypes.h"
+#include "Common/File/Path.h"
 #include "Core/Loaders.h"
 
 // This thing is a terrible abomination that wraps asynchronous file access behind a synchronous interface,
@@ -24,7 +25,7 @@ public:
 
 	bool IsDirectory() override;
 	s64 FileSize() override;
-	std::string GetPath() const override;
+	Path GetPath() const override;
 
 	size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override;
 
@@ -73,7 +74,7 @@ private:
 class StorageFileLoaderFactory : public FileLoaderFactory {
 public:
 	StorageFileLoaderFactory(Windows::Storage::StorageFile ^file, IdentifiedFileType fileType) : file_(file), fileType_(fileType) { }
-	FileLoader *ConstructFileLoader(const std::string &filename) override;
+	FileLoader *ConstructFileLoader(const Path &filename) override;
 
 private:
 	Windows::Storage::StorageFile ^file_;

--- a/UWP/UWPHost.cpp
+++ b/UWP/UWPHost.cpp
@@ -121,44 +121,36 @@ void UWPHost::BootDone() {
 	Core_EnableStepping(false);
 }
 
-static std::string SymbolMapFilename(const char *currentFilename, char* ext) {
+static Path SymbolMapFilename(const char *currentFilename, const char *ext) {
 	File::FileInfo info;
 
 	std::string result = currentFilename;
 
 	// can't fail, definitely exists if it gets this far
-	File::GetFileInfo(currentFilename, &info);
+	File::GetFileInfo(Path(currentFilename), &info);
 	if (info.isDirectory) {
-#ifdef _WIN32
-		char* slash = "\\";
-#else
-		char* slash = "/";
-#endif
-		if (!endsWith(result, slash))
-			result += slash;
-
-		return result + ".ppsspp-symbols" + ext;
+		return Path(result) / (std::string(".ppsspp-symbols") + ext);
 	} else {
 		size_t dot = result.rfind('.');
 		if (dot == result.npos)
-			return result + ext;
+			return Path(result + ext);
 
 		result.replace(dot, result.npos, ext);
-		return result;
+		return Path(result);
 	}
 }
 
 bool UWPHost::AttemptLoadSymbolMap() {
-	bool result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".ppmap").c_str());
+	bool result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".ppmap"));
 	// Load the old-style map file.
 	if (!result1)
-		result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".map").c_str());
-	bool result2 = g_symbolMap->LoadNocashSym(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".sym").c_str());
+		result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".map"));
+	bool result2 = g_symbolMap->LoadNocashSym(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".sym"));
 	return result1 || result2;
 }
 
 void UWPHost::SaveSymbolMap() {
-	g_symbolMap->SaveSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".ppmap").c_str());
+	g_symbolMap->SaveSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".ppmap"));
 }
 
 void UWPHost::NotifySymbolMapUpdated() {

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -313,6 +313,8 @@ void CGEDebugger::PreviewExport(const GPUDebugBuffer *dbgBuffer) {
 	std::string fn;
 	if (W32Util::BrowseForFileName(false, GetDlgHandle(), L"Save Preview Image...", nullptr, filter, L"png", fn)) {
 		ScreenshotFormat fmt = fn.find(".jpg") != fn.npos ? ScreenshotFormat::JPG : ScreenshotFormat::PNG;
+
+		Path filename(fn);
 		bool saveAlpha = fmt == ScreenshotFormat::PNG;
 
 		u8 *flipbuffer = nullptr;
@@ -321,9 +323,9 @@ void CGEDebugger::PreviewExport(const GPUDebugBuffer *dbgBuffer) {
 		const u8 *buffer = ConvertBufferToScreenshot(*dbgBuffer, saveAlpha, flipbuffer, w, h);
 		if (buffer != nullptr) {
 			if (saveAlpha) {
-				Save8888RGBAScreenshot(fn.c_str(), buffer, w, h);
+				Save8888RGBAScreenshot(filename, buffer, w, h);
 			} else {
-				Save888RGBScreenshot(fn.c_str(), fmt, buffer, w, h);
+				Save888RGBScreenshot(filename, fmt, buffer, w, h);
 			}
 		}
 		delete [] flipbuffer;

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -450,8 +450,7 @@ namespace MainWindow {
 		}
 
 		if (W32Util::BrowseForFileName(true, GetHWND(), L"Switch UMD", 0, ConvertUTF8ToWString(filter).c_str(), L"*.pbp;*.elf;*.iso;*.cso;", fn)) {
-			fn = ReplaceAll(fn, "\\", "/");
-			__UmdReplace(fn);
+			__UmdReplace(Path(fn));
 		}
 	}
 

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -425,9 +425,9 @@ namespace MainWindow {
 			std::wstring src = ConvertUTF8ToWString(filename);
 			std::wstring dest;
 			if (filename.size() >= 5 && (filename.substr(filename.size() - 4) == ".jpg" || filename.substr(filename.size() - 5) == ".jpeg")) {
-				dest = ConvertUTF8ToWString(GetSysDirectory(DIRECTORY_SYSTEM) + "background.jpg");
+				dest = (GetSysDirectory(DIRECTORY_SYSTEM) / "background.jpg").ToWString();
 			} else {
-				dest = ConvertUTF8ToWString(GetSysDirectory(DIRECTORY_SYSTEM) + "background.png");
+				dest = (GetSysDirectory(DIRECTORY_SYSTEM) / "background.png").ToWString();
 			}
 
 			CopyFileW(src.c_str(), dest.c_str(), FALSE);
@@ -570,7 +570,7 @@ namespace MainWindow {
 			break;
 
 		case ID_FILE_LOAD_MEMSTICK:
-			BrowseAndBoot(GetSysDirectory(DIRECTORY_GAME));
+			BrowseAndBoot(GetSysDirectory(DIRECTORY_GAME).ToString());
 			break;
 
 		case ID_FILE_OPEN_NEW_INSTANCE:
@@ -578,7 +578,7 @@ namespace MainWindow {
 			break;
 
 		case ID_FILE_MEMSTICK:
-			ShellExecute(NULL, L"open", ConvertUTF8ToWString(g_Config.memStickDirectory).c_str(), 0, 0, SW_SHOW);
+			ShellExecute(NULL, L"open", g_Config.memStickDirectory.ToWString().c_str(), 0, 0, SW_SHOW);
 			break;
 
 		case ID_TOGGLE_BREAK:
@@ -646,14 +646,13 @@ namespace MainWindow {
 		case ID_FILE_LOADSTATEFILE:
 			if (W32Util::BrowseForFileName(true, hWnd, L"Load state", 0, L"Save States (*.ppst)\0*.ppst\0All files\0*.*\0\0", L"ppst", fn)) {
 				SetCursor(LoadCursor(0, IDC_WAIT));
-				SaveState::Load(fn, -1, SaveStateActionFinished);
+				SaveState::Load(Path(fn), -1, SaveStateActionFinished);
 			}
 			break;
-
 		case ID_FILE_SAVESTATEFILE:
 			if (W32Util::BrowseForFileName(false, hWnd, L"Save state", 0, L"Save States (*.ppst)\0*.ppst\0All files\0*.*\0\0", L"ppst", fn)) {
 				SetCursor(LoadCursor(0, IDC_WAIT));
-				SaveState::Save(fn, -1, SaveStateActionFinished);
+				SaveState::Save(Path(fn), -1, SaveStateActionFinished);
 			}
 			break;
 
@@ -683,7 +682,7 @@ namespace MainWindow {
 		case ID_FILE_QUICKLOADSTATE:
 		{
 			SetCursor(LoadCursor(0, IDC_WAIT));
-			SaveState::LoadSlot(PSP_CoreParameter().fileToStart, g_Config.iCurrentStateSlot, SaveStateActionFinished);
+			SaveState::LoadSlot(PSP_CoreParameter().fileToStart.ToString(), g_Config.iCurrentStateSlot, SaveStateActionFinished);
 			break;
 		}
 
@@ -692,14 +691,14 @@ namespace MainWindow {
 			if (KeyMap::g_controllerMap[VIRTKEY_LOAD_STATE].empty())
 			{
 				SetCursor(LoadCursor(0, IDC_WAIT));
-				SaveState::LoadSlot(PSP_CoreParameter().fileToStart, g_Config.iCurrentStateSlot, SaveStateActionFinished);
+				SaveState::LoadSlot(PSP_CoreParameter().fileToStart.ToString(), g_Config.iCurrentStateSlot, SaveStateActionFinished);
 			}
 			break;
 		}
 		case ID_FILE_QUICKSAVESTATE:
 		{
 			SetCursor(LoadCursor(0, IDC_WAIT));
-			SaveState::SaveSlot(PSP_CoreParameter().fileToStart, g_Config.iCurrentStateSlot, SaveStateActionFinished);
+			SaveState::SaveSlot(PSP_CoreParameter().fileToStart.ToString(), g_Config.iCurrentStateSlot, SaveStateActionFinished);
 			break;
 		}
 
@@ -708,7 +707,7 @@ namespace MainWindow {
 			if (KeyMap::g_controllerMap[VIRTKEY_SAVE_STATE].empty())
 			{
 				SetCursor(LoadCursor(0, IDC_WAIT));
-				SaveState::SaveSlot(PSP_CoreParameter().fileToStart, g_Config.iCurrentStateSlot, SaveStateActionFinished);
+				SaveState::SaveSlot(PSP_CoreParameter().fileToStart.ToString(), g_Config.iCurrentStateSlot, SaveStateActionFinished);
 				break;
 			}
 			break;
@@ -856,7 +855,7 @@ namespace MainWindow {
 
 		case ID_DEBUG_LOADMAPFILE:
 			if (W32Util::BrowseForFileName(true, hWnd, L"Load .ppmap", 0, L"Maps\0*.ppmap\0All files\0*.*\0\0", L"ppmap", fn)) {
-				g_symbolMap->LoadSymbolMap(fn.c_str());
+				g_symbolMap->LoadSymbolMap(Path(fn));
 
 				if (disasmWindow)
 					disasmWindow->NotifyMapLoaded();
@@ -868,12 +867,12 @@ namespace MainWindow {
 
 		case ID_DEBUG_SAVEMAPFILE:
 			if (W32Util::BrowseForFileName(false, hWnd, L"Save .ppmap", 0, L"Maps\0*.ppmap\0All files\0*.*\0\0", L"ppmap", fn))
-				g_symbolMap->SaveSymbolMap(fn.c_str());
+				g_symbolMap->SaveSymbolMap(Path(fn));
 			break;
 
 		case ID_DEBUG_LOADSYMFILE:
 			if (W32Util::BrowseForFileName(true, hWnd, L"Load .sym", 0, L"Symbols\0*.sym\0All files\0*.*\0\0", L"sym", fn)) {
-				g_symbolMap->LoadNocashSym(fn.c_str());
+				g_symbolMap->LoadNocashSym(Path(fn));
 
 				if (disasmWindow)
 					disasmWindow->NotifyMapLoaded();
@@ -885,7 +884,7 @@ namespace MainWindow {
 
 		case ID_DEBUG_SAVESYMFILE:
 			if (W32Util::BrowseForFileName(false, hWnd, L"Save .sym", 0, L"Symbols\0*.sym\0All files\0*.*\0\0", L"sym", fn))
-				g_symbolMap->SaveNocashSym(fn.c_str());
+				g_symbolMap->SaveNocashSym(Path(fn));
 			break;
 
 		case ID_DEBUG_RESETSYMBOLTABLE:
@@ -940,7 +939,7 @@ namespace MainWindow {
 				size_t len = pspFileSystem.SeekFile(handle, 0, FILEMOVE_END);
 				bool isBlockMode = pspFileSystem.DevType(handle) & PSPDevType::BLOCK;
 
-				FILE *fp = File::OpenCFile(fn, "wb");
+				FILE *fp = File::OpenCFile(Path(fn), "wb");
 				pspFileSystem.SeekFile(handle, 0, FILEMOVE_BEGIN);
 				u8 buffer[4096];
 				size_t bufferSize = isBlockMode ? sizeof(buffer) / 2048 : sizeof(buffer);

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -268,47 +268,39 @@ void WindowsHost::BootDone() {
 	SetDebugMode(!g_Config.bAutoRun);
 }
 
-static std::string SymbolMapFilename(const char *currentFilename, const char* ext) {
+static Path SymbolMapFilename(const char *currentFilename, const char* ext) {
 	File::FileInfo info;
 
 	std::string result = currentFilename;
 
 	// can't fail, definitely exists if it gets this far
-	File::GetFileInfo(currentFilename, &info);
+	File::GetFileInfo(Path(currentFilename), &info);
 	if (info.isDirectory) {
-#ifdef _WIN32
-		const char* slash = "\\";
-#else
-		const char* slash = "/";
-#endif
-		if (!endsWith(result,slash))
-			result += slash;
-
-		return result + ".ppsspp-symbols" + ext;
+		return Path(result) / (std::string(".ppsspp-symbols") + ext);
 	} else {
 		const size_t dot = result.rfind('.');
 		if (dot == result.npos)
-			return result + ext;
+			return Path(result + ext);
 
 		result.replace(dot, result.npos, ext);
-		return result;
+		return Path(result);
 	}
 }
 
 bool WindowsHost::AttemptLoadSymbolMap() {
 	if (!g_symbolMap)
 		return false;
-	bool result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(),".ppmap").c_str());
+	bool result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".ppmap"));
 	// Load the old-style map file.
 	if (!result1)
-		result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(),".map").c_str());
-	bool result2 = g_symbolMap->LoadNocashSym(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(),".sym").c_str());
+		result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".map"));
+	bool result2 = g_symbolMap->LoadNocashSym(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".sym"));
 	return result1 || result2;
 }
 
 void WindowsHost::SaveSymbolMap() {
 	if (g_symbolMap)
-		g_symbolMap->SaveSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(),".ppmap").c_str());
+		g_symbolMap->SaveSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(),".ppmap"));
 }
 
 void WindowsHost::NotifySymbolMapUpdated() {

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -583,7 +583,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	// Load config up here, because those changes below would be overwritten
 	// if it's not loaded here first.
-	g_Config.AddSearchPath("");
+	g_Config.AddSearchPath(Path());
 	g_Config.AddSearchPath(GetSysDirectory(DIRECTORY_SYSTEM));
 	g_Config.SetDefaultPath(GetSysDirectory(DIRECTORY_SYSTEM));
 	g_Config.Load(configFilename.c_str(), controlsConfigFilename.c_str());

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -250,6 +250,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Common/File/VFS/VFS.cpp \
   $(SRC)/Common/File/VFS/AssetReader.cpp \
   $(SRC)/Common/File/DiskFree.cpp \
+  $(SRC)/Common/File/Path.cpp \
   $(SRC)/Common/File/PathBrowser.cpp \
   $(SRC)/Common/File/FileUtil.cpp \
   $(SRC)/Common/File/DirListing.cpp \

--- a/android/jni/TestRunner.cpp
+++ b/android/jni/TestRunner.cpp
@@ -67,7 +67,7 @@ bool TestsAvailable() {
 	if (File::IsDirectory(Path("../pspautotests"))) {
 		testDirectory = Path("..");
 	}
-	return File::Exists(Path(testDirectory) / "pspautotests" / "tests");
+	return File::Exists(testDirectory / "pspautotests" / "tests");
 }
 
 bool RunTests() {

--- a/android/jni/TestRunner.cpp
+++ b/android/jni/TestRunner.cpp
@@ -59,15 +59,15 @@ static std::string TrimNewlines(const std::string &s) {
 
 bool TestsAvailable() {
 #if PPSSPP_PLATFORM(IOS)
-	std::string testDirectory = g_Config.flash0Directory + "../";
+	Path testDirectory = Path(g_Config.flash0Directory) + "../";
 #else
-	std::string testDirectory = g_Config.memStickDirectory;
+	Path testDirectory = g_Config.memStickDirectory;
 #endif
 	// Hack to easily run the tests on Windows from the submodule
-	if (File::IsDirectory("../pspautotests")) {
-		testDirectory = "../";
+	if (File::IsDirectory(Path("../pspautotests"))) {
+		testDirectory = Path("..");
 	}
-	return File::Exists(testDirectory + "pspautotests/tests/");
+	return File::Exists(Path(testDirectory) / "pspautotests" / "tests");
 }
 
 bool RunTests() {
@@ -76,10 +76,10 @@ bool RunTests() {
 #if PPSSPP_PLATFORM(IOS)
 	std::string baseDirectory = g_Config.flash0Directory + "../";
 #else
-	std::string baseDirectory = g_Config.memStickDirectory;
+	Path baseDirectory = g_Config.memStickDirectory;
 	// Hack to easily run the tests on Windows from the submodule
-	if (File::IsDirectory("../pspautotests")) {
-		baseDirectory = "../";
+	if (File::IsDirectory(Path("../pspautotests"))) {
+		baseDirectory = Path("..");
 	}
 #endif
 
@@ -93,7 +93,7 @@ bool RunTests() {
 	coreParam.enableSound = g_Config.bEnableSound;
 	coreParam.graphicsContext = nullptr;
 	coreParam.mountIso.clear();
-	coreParam.mountRoot = baseDirectory + "pspautotests/";
+	coreParam.mountRoot = baseDirectory / "pspautotests";
 	coreParam.startBreak = false;
 	coreParam.printfEmuLog = false;
 	coreParam.headLess = true;
@@ -110,11 +110,11 @@ bool RunTests() {
 	g_Config.sReportHost = "";
 
 	for (size_t i = 0; i < ARRAY_SIZE(testsToRun); i++) {
-		const char *testName = testsToRun[i];
-		coreParam.fileToStart = baseDirectory + "pspautotests/tests/" + testName + ".prx";
-		std::string expectedFile = baseDirectory + "pspautotests/tests/" + testName + ".expected";
+		std::string testName = testsToRun[i];
+		coreParam.fileToStart = baseDirectory / "pspautotests" / "tests" / (testName + ".prx");
+		Path expectedFile = baseDirectory / "pspautotests" / "tests" / (testName + ".expected");
 
-		INFO_LOG(SYSTEM, "Preparing to execute '%s'", testName);
+		INFO_LOG(SYSTEM, "Preparing to execute '%s'", testName.c_str());
 		std::string error_string;
 		output = "";
 		if (!PSP_Init(coreParam, &error_string)) {
@@ -138,7 +138,7 @@ bool RunTests() {
 				// set back to running for the next frame
 				coreState = CORE_RUNNING;
 			} else if (coreState == CORE_POWERDOWN)	{
-				INFO_LOG(SYSTEM, "Finished running test %s", testName);
+				INFO_LOG(SYSTEM, "Finished running test %s", testName.c_str());
 				break;
 			}
 		}

--- a/android/jni/TestRunner.cpp
+++ b/android/jni/TestRunner.cpp
@@ -59,7 +59,7 @@ static std::string TrimNewlines(const std::string &s) {
 
 bool TestsAvailable() {
 #if PPSSPP_PLATFORM(IOS)
-	Path testDirectory = Path(g_Config.flash0Directory) + "../";
+	Path testDirectory = g_Config.flash0Directory / "..";
 #else
 	Path testDirectory = g_Config.memStickDirectory;
 #endif
@@ -74,7 +74,7 @@ bool RunTests() {
 	std::string output;
 
 #if PPSSPP_PLATFORM(IOS)
-	std::string baseDirectory = g_Config.flash0Directory + "../";
+	Path baseDirectory = g_Config.flash0Directory / "..";
 #else
 	Path baseDirectory = g_Config.memStickDirectory;
 	// Hack to easily run the tests on Windows from the submodule

--- a/android/jni/TestRunner.cpp
+++ b/android/jni/TestRunner.cpp
@@ -145,7 +145,7 @@ bool RunTests() {
 		PSP_EndHostFrame();
 
 		std::string expect_results;
-		if (!File::ReadFileToString(true, expectedFile.c_str(), expect_results)) {
+		if (!File::ReadFileToString(true, expectedFile, expect_results)) {
 			ERROR_LOG(SYSTEM, "Error opening expectedFile %s", expectedFile.c_str());
 			break;
 		}

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -60,6 +60,7 @@ struct JNIEnv {};
 #include "Common/System/NativeApp.h"
 #include "Common/System/System.h"
 #include "Common/Thread/ThreadUtil.h"
+#include "Common/File/Path.h"
 #include "Common/File/VFS/VFS.h"
 #include "Common/File/VFS/AssetReader.h"
 #include "Common/Input/InputState.h"
@@ -248,9 +249,9 @@ int Android_OpenContentUriFd(const std::string &filename) {
 
 class ContentURIFileLoader : public ProxiedFileLoader {
 public:
-	ContentURIFileLoader(const std::string &filename)
+	ContentURIFileLoader(const Path &filename)
 		: ProxiedFileLoader(nullptr) {  // we overwrite the nullptr below
-		int fd = Android_OpenContentUriFd(filename);
+		int fd = Android_OpenContentUriFd(filename.ToString());
 		INFO_LOG(SYSTEM, "Fd %d for content URI: '%s'", fd, filename.c_str());
 		backend_ = new LocalFileLoader(fd, filename);
 	}
@@ -267,7 +268,7 @@ public:
 class AndroidContentLoaderFactory : public FileLoaderFactory {
 public:
 	AndroidContentLoaderFactory() {}
-	FileLoader *ConstructFileLoader(const std::string &filename) override {
+	FileLoader *ConstructFileLoader(const Path &filename) override {
 		return new ContentURIFileLoader(filename);
 	}
 };

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1459,7 +1459,7 @@ extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runEGLRenderLoop(J
 }
 
 extern "C" jstring Java_org_ppsspp_ppsspp_ShortcutActivity_queryGameName(JNIEnv *env, jclass, jstring jpath) {
-	std::string path = GetJavaString(env, jpath);
+	Path path = Path(GetJavaString(env, jpath));
 	std::string result = "";
 
 	GameInfoCache *cache = new GameInfoCache();

--- a/android/jni/app-android.h
+++ b/android/jni/app-android.h
@@ -20,3 +20,4 @@ public:
 };
 
 extern std::string g_extFilesDir;
+

--- a/android/jni/app-android.h
+++ b/android/jni/app-android.h
@@ -20,4 +20,3 @@ public:
 };
 
 extern std::string g_extFilesDir;
-

--- a/headless/Compare.cpp
+++ b/headless/Compare.cpp
@@ -278,7 +278,7 @@ bool CompareOutput(const std::string &bootFilename, const std::string &output, b
 				printf("%s", output.c_str());
 				printf("============== expected output:\n");
 				std::string fullExpected;
-				if (File::ReadFileToString(true, expect_filename.c_str(), fullExpected))
+				if (File::ReadFileToString(true, Path(expect_filename), fullExpected))
 					printf("%s", fullExpected.c_str());
 				printf("===============================\n");
 			}

--- a/headless/Compare.cpp
+++ b/headless/Compare.cpp
@@ -168,24 +168,17 @@ protected:
 	size_t pos_ = 0;
 };
 
-std::string ExpectedFromFilename(const std::string &bootFilename) {
-	size_t pos = bootFilename.find_last_of('.');
-	if (pos == bootFilename.npos) {
-		return bootFilename + ".expected";
+Path ExpectedScreenshotFromFilename(const Path &bootFilename) {
+	std::string extension = bootFilename.GetFileExtension();
+	if (extension.empty()) {
+		return bootFilename.WithExtraExtension(".bmp");
 	}
-	return bootFilename.substr(0, pos) + ".expected";
-}
 
-std::string ExpectedScreenshotFromFilename(const std::string &bootFilename) {
-	size_t pos = bootFilename.find_last_of('.');
-	if (pos == bootFilename.npos) {
-		return bootFilename + ".bmp";
-	}
 	// Let's use pngs as the default for ppdmp tests.
-	if (bootFilename.substr(pos) == ".ppdmp") {
-		return bootFilename.substr(0, pos) + ".png";
+	if (extension == ".ppdmp") {
+		return bootFilename.WithReplacedExtension(".png");
 	}
-	return bootFilename.substr(0, pos) + ".expected.bmp";
+	return bootFilename.WithReplacedExtension(".expected.bmp");
 }
 
 static std::string ChopFront(std::string s, std::string front)
@@ -209,14 +202,14 @@ static std::string ChopEnd(std::string s, std::string end)
 	return s;
 }
 
-std::string GetTestName(const std::string &bootFilename)
+std::string GetTestName(const Path &bootFilename)
 {
 	// Kinda ugly, trying to guesstimate the test name from filename...
-	return ChopEnd(ChopFront(ChopFront(bootFilename, "tests/"), "pspautotests/tests/"), ".prx");
+	return ChopEnd(ChopFront(ChopFront(bootFilename.ToString(), "tests/"), "pspautotests/tests/"), ".prx");
 }
 
-bool CompareOutput(const std::string &bootFilename, const std::string &output, bool verbose) {
-	std::string expect_filename = ExpectedFromFilename(bootFilename);
+bool CompareOutput(const Path &bootFilename, const std::string &output, bool verbose) {
+	Path expect_filename = bootFilename.WithReplacedExtension("prx", "expected");
 	std::unique_ptr<FileLoader> expect_loader(ConstructFileLoader(expect_filename));
 
 	if (expect_loader->Exists()) {
@@ -372,7 +365,7 @@ std::vector<u32> TranslateDebugBufferToCompare(const GPUDebugBuffer *buffer, u32
 	return data;
 }
 
-double CompareScreenshot(const std::vector<u32> &pixels, u32 stride, u32 w, u32 h, const std::string& screenshotFilename, std::string &error)
+double CompareScreenshot(const std::vector<u32> &pixels, u32 stride, u32 w, u32 h, const Path& screenshotFilename, std::string &error)
 {
 	if (pixels.size() < stride * h)
 	{
@@ -388,7 +381,7 @@ double CompareScreenshot(const std::vector<u32> &pixels, u32 stride, u32 w, u32 
 	if (loader->Exists()) {
 		uint8_t header[2];
 		if (loader->ReadAt(0, 2, header) != 2) {
-			error = "Unable to read screenshot data: " + screenshotFilename;
+			error = "Unable to read screenshot data: " + screenshotFilename.ToVisualString();
 			return -1.0f;
 		}
 
@@ -397,7 +390,7 @@ double CompareScreenshot(const std::vector<u32> &pixels, u32 stride, u32 w, u32 
 			asBitmap = true;
 			// The bitmap header is 14 + 40 bytes.  We could validate it but the test would fail either way.
 			if (reference && loader->ReadAt(14 + 40, sizeof(u32), stride * h, reference) != stride * h) {
-				error = "Unable to read screenshot data: " + screenshotFilename;
+				error = "Unable to read screenshot data: " + screenshotFilename.ToVisualString();
 				return -1.0f;
 			}
 		} else {
@@ -405,23 +398,23 @@ double CompareScreenshot(const std::vector<u32> &pixels, u32 stride, u32 w, u32 
 			std::vector<uint8_t> compressed;
 			compressed.resize(loader->FileSize());
 			if (loader->ReadAt(0, compressed.size(), &compressed[0]) != compressed.size()) {
-				error = "Unable to read screenshot data: " + screenshotFilename;
+				error = "Unable to read screenshot data: " + screenshotFilename.ToVisualString();
 				return -1.0f;
 			}
 
 			int width, height;
 			if (!pngLoadPtr(&compressed[0], compressed.size(), &width, &height, (unsigned char **)&reference)) {
-				error = "Unable to read screenshot data: " + screenshotFilename;
+				error = "Unable to read screenshot data: " + screenshotFilename.ToVisualString();
 				return -1.0f;
 			}
 		}
 	} else {
-		error = "Unable to read screenshot: " + screenshotFilename;
+		error = "Unable to read screenshot: " + screenshotFilename.ToVisualString();
 		return -1.0f;
 	}
 
 	if (!reference) {
-		error = "Unable to allocate screenshot data: " + screenshotFilename;
+		error = "Unable to allocate screenshot data: " + screenshotFilename.ToVisualString();
 		return -1.0f;
 	}
 

--- a/headless/Compare.h
+++ b/headless/Compare.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "Common/CommonTypes.h"
+#include "Common/File/Path.h"
 
 struct GPUDebugBuffer;
 
@@ -27,10 +28,10 @@ extern std::string currentTestName;
 void TeamCityPrint(const char *fmt, ...);
 void GitHubActionsPrint(const char *type, const char *fmt, ...);
 
-std::string ExpectedFromFilename(const std::string &bootFilename);
-std::string ExpectedScreenshotFromFilename(const std::string &bootFilename);
-std::string GetTestName(const std::string &bootFilename);
+Path ExpectedFromFilename(const Path &bootFilename);
+Path ExpectedScreenshotFromFilename(const Path &bootFilename);
+std::string GetTestName(const Path &bootFilename);
 
-bool CompareOutput(const std::string &bootFilename, const std::string &output, bool verbose);
+bool CompareOutput(const Path &bootFilename, const std::string &output, bool verbose);
 std::vector<u32> TranslateDebugBufferToCompare(const GPUDebugBuffer *buffer, u32 stride, u32 h);
-double CompareScreenshot(const std::vector<u32> &pixels, u32 stride, u32 w, u32 h, const std::string& screenshotFilename, std::string &error);
+double CompareScreenshot(const std::vector<u32> &pixels, u32 stride, u32 w, u32 h, const Path &screenshotFilename, std::string &error);

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -427,10 +427,10 @@ int main(int argc, const char* argv[])
 
 #ifdef __ANDROID__
 	// For some reason the debugger installs it with this name?
-	if (File::Exists("/data/app/org.ppsspp.ppsspp-2.apk")) {
+	if (File::Exists(Path("/data/app/org.ppsspp.ppsspp-2.apk"))) {
 		VFSRegister("", new ZipAssetReader("/data/app/org.ppsspp.ppsspp-2.apk", "assets/"));
 	}
-	if (File::Exists("/data/app/org.ppsspp.ppsspp.apk")) {
+	if (File::Exists(Path("/data/app/org.ppsspp.ppsspp.apk"))) {
 		VFSRegister("", new ZipAssetReader("/data/app/org.ppsspp.ppsspp.apk", "assets/"));
 	}
 #endif

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -408,7 +408,7 @@ int main(int argc, const char* argv[])
 #endif
 
 #if !defined(__ANDROID__) && !defined(_WIN32)
-	g_Config.memStickDirectory = std::string(getenv("HOME")) + "/.ppsspp/";
+	g_Config.memStickDirectory = Path(std::string(getenv("HOME"))) / ".ppsspp";
 #endif
 
 	// Try to find the flash0 directory.  Often this is from a subdirectory.

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -152,7 +152,7 @@ static HeadlessHost *getHost(GPUCore gpuCore) {
 bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool autoCompare, bool verbose, double timeout)
 {
 	// Kinda ugly, trying to guesstimate the test name from filename...
-	currentTestName = GetTestName(coreParameter.fileToStart.ToString());
+	currentTestName = GetTestName(coreParameter.fileToStart);
 
 	std::string output;
 	if (autoCompare)
@@ -172,7 +172,7 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool 
 	host->BootDone();
 
 	if (autoCompare)
-		headlessHost->SetComparisonScreenshot(ExpectedScreenshotFromFilename(coreParameter.fileToStart.ToString()));
+		headlessHost->SetComparisonScreenshot(ExpectedScreenshotFromFilename(coreParameter.fileToStart));
 
 	bool passed = true;
 	// TODO: We must have some kind of stack overflow or we're not following the ABI right.
@@ -221,7 +221,7 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool 
 	headlessHost->FlushDebugOutput();
 
 	if (autoCompare && passed)
-		passed = CompareOutput(coreParameter.fileToStart.ToString(), output, verbose);
+		passed = CompareOutput(coreParameter.fileToStart, output, verbose);
 
 	TeamCityPrint("testFinished name='%s'", currentTestName.c_str());
 
@@ -423,7 +423,7 @@ int main(int argc, const char* argv[])
 		g_Config.flash0Directory = Path(File::GetExeDirectory()) / "assets/flash0";
 
 	if (screenshotFilename != 0)
-		headlessHost->SetComparisonScreenshot(screenshotFilename);
+		headlessHost->SetComparisonScreenshot(Path(std::string(screenshotFilename)));
 
 #ifdef __ANDROID__
 	// For some reason the debugger installs it with this name?
@@ -456,7 +456,7 @@ int main(int argc, const char* argv[])
 		bool passed = RunAutoTest(headlessHost, coreParameter, autoCompare, verbose, timeout);
 		if (autoCompare)
 		{
-			std::string testName = GetTestName(coreParameter.fileToStart.ToString());
+			std::string testName = GetTestName(coreParameter.fileToStart);
 			if (passed)
 			{
 				passedTests.push_back(testName);

--- a/headless/StubHost.cpp
+++ b/headless/StubHost.cpp
@@ -71,7 +71,7 @@ void HeadlessHost::SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h) {
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		};
 
-		FILE *saved = File::OpenCFile("__testfailure.bmp", "wb");
+		FILE *saved = File::OpenCFile(Path("__testfailure.bmp"), "wb");
 		if (saved) {
 			fwrite(&header, sizeof(header), 1, saved);
 			fwrite(pixels.data(), sizeof(u32), FRAME_STRIDE * FRAME_HEIGHT, saved);

--- a/headless/StubHost.h
+++ b/headless/StubHost.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "Common/File/Path.h"
+
 #include "Core/CoreParameter.h"
 #include "Core/Host.h"
 #include "Core/Debugger/SymbolMap.h"
@@ -66,7 +68,7 @@ public:
 		}
 	}
 
-	virtual void SetComparisonScreenshot(const std::string &filename) {
+	virtual void SetComparisonScreenshot(const Path &filename) {
 		comparisonScreenshot_ = filename;
 	}
 
@@ -80,7 +82,7 @@ public:
 protected:
 	void SendOrCollectDebugOutput(const std::string &output);
 
-	std::string comparisonScreenshot_;
+	Path comparisonScreenshot_;
 	std::string debugOutputBuffer_;
 	GPUCore gpuCore_;
 	GraphicsContext *gfx_ = nullptr;

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -234,6 +234,7 @@ SOURCES_CXX += \
 	$(COMMONDIR)/File/VFS/VFS.cpp \
 	$(COMMONDIR)/File/VFS/AssetReader.cpp \
 	$(COMMONDIR)/File/DiskFree.cpp \
+	$(COMMONDIR)/File/Path.cpp \
 	$(COMMONDIR)/File/PathBrowser.cpp \
 	$(COMMONDIR)/File/FileUtil.cpp \
 	$(COMMONDIR)/File/FileDescriptor.cpp \

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -632,8 +632,8 @@ bool retro_load_game(const struct retro_game_info *game)
 
    g_Config.currentDirectory      = retro_base_dir;
    g_Config.externalDirectory     = retro_base_dir;
-   g_Config.memStickDirectory     = retro_save_dir;
-   g_Config.flash0Directory       = retro_base_dir + "flash0" DIR_SEP;
+   g_Config.memStickDirectory     = Path(retro_save_dir);
+   g_Config.flash0Directory       = Path(retro_base_dir) / "flash0";
    g_Config.internalDataDirectory = retro_base_dir;
 
    VFSRegister("", new DirectoryAssetReader(retro_base_dir.c_str()));
@@ -649,7 +649,7 @@ bool retro_load_game(const struct retro_game_info *game)
 
    CoreParameter coreParam   = {};
    coreParam.enableSound     = true;
-   coreParam.fileToStart     = std::string(game->path);
+   coreParam.fileToStart     = Path(std::string(game->path));
    coreParam.mountIso.clear();
    coreParam.startBreak      = false;
    coreParam.printfEmuLog    = true;

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -594,7 +594,7 @@ static bool TestPath() {
 	EXPECT_EQ_STR(path3.WithExtraExtension("txt").ToString(), std::string("/asdf/jkl/foo/bar.txt"));
 
 	EXPECT_EQ_STR(Path("foo.bar/hello").GetFileExtension(), std::string(""));
-
+	EXPECT_EQ_STR(Path("foo.bar/hello.txt").WithReplacedExtension("txt", "html").ToString(), std::string("foo.bar/hello.html"));
 	return true;
 }
 

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -28,12 +28,14 @@
 // Search for "availableTests".
 
 #include "ppsspp_config.h"
+
 #include <cstdio>
 #include <cstdlib>
 #include <cmath>
 #include <vector>
 #include <string>
 #include <sstream>
+
 #if PPSSPP_PLATFORM(ANDROID)
 #include <jni.h>
 #endif
@@ -41,7 +43,7 @@
 #include "Common/System/NativeApp.h"
 #include "Common/System/System.h"
 #include "Common/Input/InputState.h"
-#include "ext/disarm.h"
+#include "Common/File/Path.h"
 #include "Common/Math/math_util.h"
 #include "Common/Data/Text/Parsers.h"
 #include "Common/Data/Encoding/Utf8.h"
@@ -580,6 +582,22 @@ static bool TestMemMap() {
 	return true;
 }
 
+static bool TestPath() {
+	// Also test the Path class while we're at it.
+	Path path("/asdf/jkl/");
+	EXPECT_EQ_STR(path.ToString(), std::string("/asdf/jkl"));
+
+	Path path2("/asdf/jkl");
+	EXPECT_EQ_STR(path2.ToString(), std::string("/asdf/jkl"));
+
+	Path path3 = path2 / "foo/bar";
+	EXPECT_EQ_STR(path3.WithExtraExtension("txt").ToString(), std::string("/asdf/jkl/foo/bar.txt"));
+
+	EXPECT_EQ_STR(Path("foo.bar/hello").GetFileExtension(), std::string(""));
+
+	return true;
+}
+
 typedef bool (*TestFunc)();
 struct TestItem {
 	const char *name;
@@ -616,6 +634,7 @@ TestItem availableTests[] = {
 	TEST_ITEM(CLZ),
 	TEST_ITEM(MemMap),
 	TEST_ITEM(ShaderGenerators),
+	TEST_ITEM(Path),
 };
 
 int main(int argc, const char *argv[]) {

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -588,13 +588,18 @@ static bool TestPath() {
 	EXPECT_EQ_STR(path.ToString(), std::string("/asdf/jkl"));
 
 	Path path2("/asdf/jkl");
-	EXPECT_EQ_STR(path2.ToString(), std::string("/asdf/jkl"));
+	EXPECT_EQ_STR(path2.NavigateUp().ToString(), std::string("/asdf"));
 
 	Path path3 = path2 / "foo/bar";
-	EXPECT_EQ_STR(path3.WithExtraExtension("txt").ToString(), std::string("/asdf/jkl/foo/bar.txt"));
+	EXPECT_EQ_STR(path3.WithExtraExtension(".txt").ToString(), std::string("/asdf/jkl/foo/bar.txt"));
 
 	EXPECT_EQ_STR(Path("foo.bar/hello").GetFileExtension(), std::string(""));
-	EXPECT_EQ_STR(Path("foo.bar/hello.txt").WithReplacedExtension("txt", "html").ToString(), std::string("foo.bar/hello.html"));
+	EXPECT_EQ_STR(Path("foo.bar/hello.txt").WithReplacedExtension(".txt", ".html").ToString(), std::string("foo.bar/hello.html"));
+
+	EXPECT_EQ_STR(Path("C:\\Yo").GetDirectory(), std::string("C:"));
+	EXPECT_EQ_STR(Path("C:\\Yo").GetFilename(), std::string("Yo"));
+	EXPECT_EQ_STR(Path("C:\\Yo\\Lo").GetDirectory(), std::string("C:/Yo"));
+	EXPECT_EQ_STR(Path("C:\\Yo\\Lo").GetFilename(), std::string("Lo"));
 	return true;
 }
 

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -596,6 +596,9 @@ static bool TestPath() {
 	EXPECT_EQ_STR(Path("foo.bar/hello").GetFileExtension(), std::string(""));
 	EXPECT_EQ_STR(Path("foo.bar/hello.txt").WithReplacedExtension(".txt", ".html").ToString(), std::string("foo.bar/hello.html"));
 
+	EXPECT_EQ_STR(Path("C:\\Yo").NavigateUp().ToString(), std::string("C:"));
+	EXPECT_EQ_STR(Path("C:").NavigateUp().ToString(), std::string("/"));
+
 	EXPECT_EQ_STR(Path("C:\\Yo").GetDirectory(), std::string("C:"));
 	EXPECT_EQ_STR(Path("C:\\Yo").GetFilename(), std::string("Yo"));
 	EXPECT_EQ_STR(Path("C:\\Yo\\Lo").GetDirectory(), std::string("C:/Yo"));


### PR DESCRIPTION
Prerequisite for upcoming changes in #14232 , will rebase that on this when merged.

The problem is that on Android content URIs, you can't simply append subdirectories to the filename, and cut the path in the normal ways. You need to decode, append, and re-encode - so all direct string manipulation of paths needs to go through a wrapper.

Still lots left to convert! Falling back on .ToString() and Path(std::string) to convert back and forth for now.