### PR TITLE
Core: Leave delay slot when re-entering jit

### DIFF
--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -313,6 +313,10 @@ int MIPSState::RunLoopUntil(u64 globalTicks) {
 	switch (PSP_CoreParameter().cpuCore) {
 	case CPUCore::JIT:
 	case CPUCore::IR_JIT:
+		while (inDelaySlot) {
+			// We must get out of the delay slot before going into jit.
+			SingleStep();
+		}
 		MIPSComp::jit->RunLoopUntil(globalTicks);
 		break;
 


### PR DESCRIPTION
If stepping, we may get into a delay slot within interpreted code, and then try to run (i.e. Step Out), which won't clear the delay slot properly.

This can cause weird behavior when interp is used again later, in addition to immediate wrong branching behavior.

-[Unknown]