### PR TITLE
Remove File::OpenCPPFile()

### DIFF
--- a/Common/ArmCPUDetect.cpp
+++ b/Common/ArmCPUDetect.cpp
@@ -74,10 +74,12 @@ const char procfile[] = "/proc/cpuinfo";
 const char syscpupresentfile[] = "/sys/devices/system/cpu/present";
 
 std::string GetCPUString() {
+	std::string procdata;
+	bool readSuccess = File::ReadFileToString(true, procfile, procdata);
+	std::istringstream file(procdata);
 	std::string cpu_string;
-	std::fstream file;
 
-	if (File::OpenCPPFile(file, procfile, std::ios::in)) {
+	if (readSuccess) {
 		std::string line, marker = "Hardware\t: ";
 		while (std::getline(file, line)) {
 			if (line.find(marker) != std::string::npos) {
@@ -95,10 +97,12 @@ std::string GetCPUString() {
 }
 
 std::string GetCPUBrandString() {
+	std::string procdata;
+	bool readSuccess = File::ReadFileToString(true, procfile, procdata);
+	std::istringstream file(procdata);
 	std::string brand_string;
-	std::fstream file;
 
-	if (File::OpenCPPFile(file, procfile, std::ios::in)) {
+	if (readSuccess) {
 		std::string line, marker = "Processor\t: ";
 		while (std::getline(file, line)) {
 			if (line.find(marker) != std::string::npos) {
@@ -122,10 +126,11 @@ unsigned char GetCPUImplementer()
 {
 	std::string line, marker = "CPU implementer\t: ";
 	unsigned char implementer = 0;
-	std::fstream file;
 
-	if (!File::OpenCPPFile(file, procfile, std::ios::in))
+	std::string procdata;
+	if (!File::ReadFileToString(true, procfile, procdata))
 		return 0;
+	std::istringstream file(procdata);
 
 	while (std::getline(file, line))
 	{
@@ -144,10 +149,11 @@ unsigned short GetCPUPart()
 {
 	std::string line, marker = "CPU part\t: ";
 	unsigned short part = 0;
-	std::fstream file;
 
-	if (!File::OpenCPPFile(file, procfile, std::ios::in))
+	std::string procdata;
+	if (!File::ReadFileToString(true, procfile, procdata))
 		return 0;
+	std::istringstream file(procdata);
 
 	while (std::getline(file, line))
 	{
@@ -165,10 +171,11 @@ unsigned short GetCPUPart()
 bool CheckCPUFeature(const std::string& feature)
 {
 	std::string line, marker = "Features\t: ";
-	std::fstream file;
 
-	if (!File::OpenCPPFile(file, procfile, std::ios::in))
-		return 0;
+	std::string procdata;
+	if (!File::ReadFileToString(true, procfile, procdata))
+		return false;
+	std::istringstream file(procdata);
 
 	while (std::getline(file, line))
 	{
@@ -191,12 +198,14 @@ int GetCoreCount()
 {
 	std::string line, marker = "processor\t: ";
 	int cores = 1;
-	std::fstream file;
 
-	if (File::OpenCPPFile(file, syscpupresentfile, std::ios::in))
-	{
+	std::string presentData;
+	bool presentSuccess = File::ReadFileToString(true, syscpupresentfile, presentData);
+	std::istringstream presentFile(presentData);
+
+	if (presentSuccess) {
 		int low, high, found;
-		std::getline(file, line);
+		std::getline(presentFile, line);
 		found = sscanf(line.c_str(), "%d-%d", &low, &high);
 		if (found == 1)
 			return 1;
@@ -204,8 +213,10 @@ int GetCoreCount()
 			return high - low + 1;
 	}
 
-	if (!File::OpenCPPFile(file, procfile, std::ios::in))
+	std::string procdata;
+	if (!File::ReadFileToString(true, procfile, procdata))
 		return 1;
+	std::istringstream file(procdata);
 	
 	while (std::getline(file, line))
 	{

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -103,16 +103,6 @@ FILE *OpenCFile(const std::string &filename, const char *mode)
 #endif
 }
 
-bool OpenCPPFile(std::fstream & stream, const std::string &filename, std::ios::openmode mode)
-{
-#if defined(_WIN32) && defined(UNICODE) && !defined(__MINGW32__)
-	stream.open(ConvertUTF8ToWString(filename), mode);
-#else
-	stream.open(filename.c_str(), mode);
-#endif
-	return stream.is_open();
-}
-
 #ifdef _WIN32
 static bool ResolvePathVista(const std::wstring &path, wchar_t *buf, DWORD bufSize) {
 	typedef DWORD(WINAPI *getFinalPathNameByHandleW_f)(HANDLE hFile, LPWSTR lpszFilePath, DWORD cchFilePath, DWORD dwFlags);

--- a/Common/File/FileUtil.h
+++ b/Common/File/FileUtil.h
@@ -38,7 +38,6 @@ namespace File {
 
 // Mostly to handle UTF-8 filenames better on Windows.
 FILE *OpenCFile(const std::string &filename, const char *mode);
-bool OpenCPPFile(std::fstream & stream, const std::string &filename, std::ios::openmode mode);
 
 // Resolves symlinks and similar.
 std::string ResolvePath(const std::string &path);

--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -291,12 +291,13 @@ void LogManager::RemoveListener(LogListener *listener) {
 }
 
 FileLogListener::FileLogListener(const char *filename) {
-#if defined(_WIN32) && !defined(__MINGW32__)
-	m_logfile.open(ConvertUTF8ToWString(filename).c_str(), std::ios::app);
-#else
-	m_logfile.open(filename, std::ios::app);
-#endif
-	SetEnabled(true);
+	fp_ = File::OpenCFile(filename, "at");
+	SetEnabled(fp_ != nullptr);
+}
+
+FileLogListener::~FileLogListener() {
+	if (fp_)
+		fclose(fp_);
 }
 
 void FileLogListener::Log(const LogMessage &message) {
@@ -304,7 +305,8 @@ void FileLogListener::Log(const LogMessage &message) {
 		return;
 
 	std::lock_guard<std::mutex> lk(m_log_lock);
-	m_logfile << message.timestamp << " " << message.header << " " << message.msg << std::flush;
+	fprintf(fp_, "%s %s %s", message.timestamp, message.header, message.msg.c_str());
+	fflush(fp_);
 }
 
 void OutputDebugStringLogListener::Log(const LogMessage &message) {

--- a/Common/LogManager.h
+++ b/Common/LogManager.h
@@ -19,10 +19,10 @@
 
 #include "ppsspp_config.h"
 
-#include <fstream>
 #include <mutex>
 #include <vector>
 #include <cstdarg>
+#include <cstdio>
 
 #include "Common/Data/Format/IniFile.h"
 #include "Common/CommonFuncs.h"
@@ -53,18 +53,19 @@ public:
 class FileLogListener : public LogListener {
 public:
 	FileLogListener(const char *filename);
+	~FileLogListener();
 
 	void Log(const LogMessage &msg);
 
-	bool IsValid() { if (!m_logfile) return false; else return true; }
+	bool IsValid() { if (!fp_) return false; else return true; }
 	bool IsEnabled() const { return m_enable; }
 	void SetEnabled(bool enable) { m_enable = enable; }
 
-	const char* GetName() const { return "file"; }
+	const char *GetName() const { return "file"; }
 
 private:
 	std::mutex m_log_lock;
-	std::ofstream m_logfile;
+	FILE *fp_ = nullptr;
 	bool m_enable;
 };
 

--- a/Common/MipsCPUDetect.cpp
+++ b/Common/MipsCPUDetect.cpp
@@ -32,13 +32,14 @@ const char procfile[] = "/proc/cpuinfo";
 // https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-system-cpu
 const char syscpupresentfile[] = "/sys/devices/system/cpu/present";
 
-std::string GetCPUString()
-{
+std::string GetCPUString() {
 	std::string line, marker = "Hardware\t: ";
 	std::string cpu_string = "Unknown";
-	std::fstream file;
-	if (!File::OpenCPPFile(file, procfile, std::ios::in))
+
+	std::string procdata;
+	if (!File::ReadFileToString(true, procfile, procdata))
 		return cpu_string;
+	std::istringstream file(procdata);
 	
 	while (std::getline(file, line))
 	{
@@ -56,10 +57,11 @@ unsigned char GetCPUImplementer()
 {
 	std::string line, marker = "CPU implementer\t: ";
 	unsigned char implementer = 0;
-	std::fstream file;
 
-	if (!File::OpenCPPFile(file, procfile, std::ios::in))
+	std::string procdata;
+	if (!File::ReadFileToString(true, procfile, procdata))
 		return 0;
+	std::istringstream file(procdata);
 
 	while (std::getline(file, line))
 	{
@@ -78,10 +80,11 @@ unsigned short GetCPUPart()
 {
 	std::string line, marker = "CPU part\t: ";
 	unsigned short part = 0;
-	std::fstream file;
 
-	if (!File::OpenCPPFile(file, procfile, std::ios::in))
+	std::string procdata;
+	if (!File::ReadFileToString(true, procfile, procdata))
 		return 0;
+	std::istringstream file(procdata);
 
 	while (std::getline(file, line))
 	{
@@ -99,10 +102,11 @@ unsigned short GetCPUPart()
 bool CheckCPUASE(const std::string& ase)
 {
 	std::string line, marker = "ASEs implemented\t: ";
-	std::fstream file;
 
-	if (!File::OpenCPPFile(file, procfile, std::ios::in))
-		return 0;
+	std::string procdata;
+	if (!File::ReadFileToString(true, procfile, procdata))
+		return false;
+	std::istringstream file(procdata);
 	
 	while (std::getline(file, line))
 	{
@@ -125,12 +129,14 @@ int GetCoreCount()
 {
 	std::string line, marker = "processor\t: ";
 	int cores = 1;
-	std::fstream file;
 
-	if (File::OpenCPPFile(file, syscpupresentfile, std::ios::in))
-	{
+	std::string presentData;
+	bool presentSuccess = File::ReadFileToString(true, syscpupresentfile, presentData);
+	std::istringstream presentFile(presentData);
+
+	if (presentSuccess) {
 		int low, high, found;
-		std::getline(file, line);
+		std::getline(presentFile, line);
 		found = sscanf(line.c_str(), "%d-%d", &low, &high);
 		if (found == 1)
 			return 1;
@@ -138,8 +144,10 @@ int GetCoreCount()
 			return high - low + 1;
 	}
 
-	if (!File::OpenCPPFile(file, procfile, std::ios::in))
+	std::string procdata;
+	if (!File::ReadFileToString(true, procfile, procdata))
 		return 1;
+	std::istringstream file(procdata);
 	
 	while (std::getline(file, line))
 	{

--- a/Core/ELF/PBPReader.cpp
+++ b/Core/ELF/PBPReader.cpp
@@ -15,7 +15,6 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include <fstream>
 #include <string>
 #include <cstring>
 

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -82,19 +82,16 @@ void VirtualDiscFileSystem::LoadFileListIndex() {
 		return;
 	}
 
-	std::ifstream in;
-	in.open(filename.c_str(), std::ios::in);
-	if (in.fail()) {
+	FILE *f = File::OpenCFile(filename, "r");
+	if (!f) {
 		return;
 	}
 
 	std::string buf;
-	static const int MAX_LINE_SIZE = 1024;
-	while (!in.eof()) {
-		buf.resize(MAX_LINE_SIZE, '\0');
-		in.getline(&buf[0], MAX_LINE_SIZE);
-
-		std::string line = buf.data();
+	static const int MAX_LINE_SIZE = 2048;
+	char linebuf[MAX_LINE_SIZE]{};
+	while (fgets(linebuf, MAX_LINE_SIZE, f)) {
+		std::string line = linebuf;
 
 		// Ignore any UTF-8 BOM.
 		if (line.substr(0, 3) == "\xEF\xBB\xBF") {
@@ -163,7 +160,7 @@ void VirtualDiscFileSystem::LoadFileListIndex() {
 		fileList.push_back(entry);
 	}
 
-	in.close();
+	fclose(f);
 }
 
 void VirtualDiscFileSystem::DoState(PointerWrap &p)

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -92,6 +92,9 @@ void VirtualDiscFileSystem::LoadFileListIndex() {
 	char linebuf[MAX_LINE_SIZE]{};
 	while (fgets(linebuf, MAX_LINE_SIZE, f)) {
 		std::string line = linebuf;
+		// Strip newline from fgets.
+		if (!line.empty() && line.back() == '\n')
+			line.resize(line.size() - 1);
 
 		// Ignore any UTF-8 BOM.
 		if (line.substr(0, 3) == "\xEF\xBB\xBF") {

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -15,7 +15,6 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include <fstream>
 #include <algorithm>
 #include <set>
 

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -743,35 +743,32 @@ bool TextureReplacer::GenerateIni(const std::string &gameID, std::string *genera
 
 	FILE *f = File::OpenCFile(texturesDirectory + INI_FILENAME, "wb");
 	if (f) {
-		fwrite("\xEF\xBB\xBF", 0, 3, f);
-		fclose(f);
+		fwrite("\xEF\xBB\xBF", 1, 3, f);
 
 		// Let's also write some defaults.
-		std::fstream fs;
-		File::OpenCPPFile(fs, texturesDirectory + INI_FILENAME, std::ios::out | std::ios::ate);
-		fs << "# This file is optional and describes your textures.\n";
-		fs << "# Some information on syntax available here:\n";
-		fs << "# https://github.com/hrydgard/ppsspp/wiki/Texture-replacement-ini-syntax\n";
-		fs << "[options]\n";
-		fs << "version = 1\n";
-		fs << "hash = quick\n";
-		fs << "ignoreMipmap = false\n";
-		fs << "\n";
-		fs << "[games]\n";
-		fs << "# Used to make it easier to install, and override settings for other regions.\n";
-		fs << "# Files still have to be copied to each TEXTURES folder.";
-		fs << gameID << " = " << INI_FILENAME << "\n";
-		fs << "\n";
-		fs << "[hashes]\n";
-		fs << "# Use / for folders not \\, avoid special characters, and stick to lowercase.\n";
-		fs << "# See wiki for more info.\n";
-		fs << "\n";
-		fs << "[hashranges]\n";
-		fs << "\n";
-		fs << "[filtering]\n";
-		fs << "\n";
-		fs << "[reducehashranges]\n";
-		fs.close();
+		fprintf(f, "# This file is optional and describes your textures.\n");
+		fprintf(f, "# Some information on syntax available here:\n");
+		fprintf(f, "# https://github.com/hrydgard/ppsspp/wiki/Texture-replacement-ini-syntax \n");
+		fprintf(f, "[options]\n");
+		fprintf(f, "version = 1\n");
+		fprintf(f, "hash = quick\n");
+		fprintf(f, "ignoreMipmap = false\n");
+		fprintf(f, "\n");
+		fprintf(f, "[games]\n");
+		fprintf(f, "# Used to make it easier to install, and override settings for other regions.\n");
+		fprintf(f, "# Files still have to be copied to each TEXTURES folder.");
+		fprintf(f, "%s = %s\n", gameID.c_str(), INI_FILENAME.c_str());
+		fprintf(f, "\n");
+		fprintf(f, "[hashes]\n");
+		fprintf(f, "# Use / for folders not \\, avoid special characters, and stick to lowercase.\n");
+		fprintf(f, "# See wiki for more info.\n");
+		fprintf(f, "\n");
+		fprintf(f, "[hashranges]\n");
+		fprintf(f, "\n");
+		fprintf(f, "[filtering]\n");
+		fprintf(f, "\n");
+		fprintf(f, "[reducehashranges]\n");
+		fclose(f);
 	}
 	return File::Exists(texturesDirectory + INI_FILENAME);
 }

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -958,25 +958,21 @@ void GameSettingsScreen::CreateViews() {
 			SavePathInMyDocumentChoice->SetEnabled(false);
 	} else {
 		if (installed_ && myDocsExists) {
-#ifdef _MSC_VER
-			std::ifstream inputFile(ConvertUTF8ToWString(installedFile));
-#else
-			std::ifstream inputFile(installedFile);
-#endif
-			if (!inputFile.fail() && inputFile.is_open()) {
-				std::string tempString;
-				std::getline(inputFile, tempString);
-
+			FILE *testInstalled = File::OpenCFile(installedFile, "rt");
+			if (testInstalled) {
+				char temp[2048];
+				char *tempStr = fgets(temp, sizeof(temp), testInstalled);
 				// Skip UTF-8 encoding bytes if there are any. There are 3 of them.
-				if (tempString.substr(0, 3) == "\xEF\xBB\xBF")
-					tempString = tempString.substr(3);
+				if (tempStr && strncmp(tempStr, "\xEF\xBB\xBF", 3) == 0) {
+					tempStr += 3;
+				}
 				SavePathInOtherChoice->SetEnabled(!PSP_IsInited());
-				if (!(tempString == "")) {
+				if (tempStr && strlen(tempStr) != 0 && strcmp(tempStr, "\n") != 0) {
 					installed_ = false;
 					otherinstalled_ = true;
 				}
+				fclose(testInstalled);
 			}
-			inputFile.close();
 		} else if (!myDocsExists) {
 			SavePathInMyDocumentChoice->SetEnabled(false);
 		}

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1150,10 +1150,9 @@ UI::EventReturn GameSettingsScreen::OnSavePathMydoc(UI::EventParams &e) {
 		installed_ = false;
 		g_Config.memStickDirectory = PPSSPPpath + "memstick/";
 	} else {
-		std::ofstream myfile;
-		myfile.open(PPSSPPpath + "installed.txt");
-		if (myfile.is_open()){
-			myfile.close();
+		FILE *f = File::OpenCFile(PPSSPPpath + "installed.txt", "wb");
+		if (f) {
+			fclose(f);
 		}
 
 		const std::string myDocsPath = W32Util::UserDocumentsPath() + "/PPSSPP/";

--- a/Windows/stdafx.h
+++ b/Windows/stdafx.h
@@ -67,6 +67,5 @@
 #include <vector>
 #include <map>
 #include <string>
-#include <fstream>
 
 #include "Common/Log.h"

--- a/android/jni/TestRunner.cpp
+++ b/android/jni/TestRunner.cpp
@@ -21,7 +21,6 @@
 // It currently just runs one test but that can be easily changed.
 
 #include <string>
-#include <fstream>
 #include <sstream>
 #include <iostream>
 
@@ -144,13 +143,14 @@ bool RunTests() {
 			}
 		}
 		PSP_EndHostFrame();
-	
-		std::ifstream expected(expectedFile.c_str(), std::ios_base::in);
-		if (!expected) {
+
+		std::string expect_results;
+		if (!File::ReadFileToString(true, expectedFile.c_str(), expect_results)) {
 			ERROR_LOG(SYSTEM, "Error opening expectedFile %s", expectedFile.c_str());
 			break;
 		}
 
+		std::istringstream expected(expect_results);
 		std::istringstream logoutput(output);
 
 		int line = 0;

--- a/headless/Compare.cpp
+++ b/headless/Compare.cpp
@@ -19,7 +19,6 @@
 #include <cmath>
 #include <cstdarg>
 #include <iostream>
-#include <fstream>
 #include <vector>
 #include "headless/Compare.h"
 
@@ -75,7 +74,7 @@ struct BufferedLineReader {
 	const static int MAX_BUFFER = 5;
 	const static int TEMP_BUFFER_SIZE = 32768;
 
-	BufferedLineReader(const std::string &data) : valid_(0), data_(data), pos_(0) {
+	BufferedLineReader(const std::string &data) : data_(data) {
 	}
 
 	void Fill() {
@@ -135,7 +134,7 @@ struct BufferedLineReader {
 	}
 
 protected:
-	BufferedLineReader() : valid_(0) {
+	BufferedLineReader() {
 	}
 
 	virtual bool HasMoreLines() {
@@ -163,28 +162,10 @@ protected:
 		return s.substr(0, p + 1);
 	}
 
-	int valid_;
+	int valid_ = 0;
 	std::string buffer_[MAX_BUFFER];
 	const std::string data_;
-	size_t pos_;
-};
-
-struct BufferedLineReaderFile : public BufferedLineReader {
-	BufferedLineReaderFile(std::ifstream &in) : BufferedLineReader(), in_(in) {
-	}
-
-protected:
-	virtual bool HasMoreLines() {
-		return !in_.eof();
-	}
-
-	virtual std::string ReadLine() {
-		char temp[TEMP_BUFFER_SIZE];
-		in_.getline(temp, TEMP_BUFFER_SIZE);
-		return temp;
-	}
-
-	std::ifstream &in_;
+	size_t pos_ = 0;
 };
 
 std::string ExpectedFromFilename(const std::string &bootFilename) {


### PR DESCRIPTION
This reduces the distance for #14436, bringing in some of its changes and taking out the rest of C++ files.  Also fixed an issue with virtual disc index files.

Biggest risk here is some issue with cheat importing.

-[Unknown]