### PR TITLE
Update path extension and PSP/GAME/ handling

### DIFF
--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -532,7 +532,7 @@ std::string GetFileExtension(const std::string & fn) {
 	if (pos == std::string::npos) {
 		return "";
 	}
-	std::string ext = fn.substr(pos + 1);
+	std::string ext = fn.substr(pos);
 	for (size_t i = 0; i < ext.size(); i++) {
 		ext[i] = tolower(ext[i]);
 	}

--- a/Common/File/PathBrowser.cpp
+++ b/Common/File/PathBrowser.cpp
@@ -101,20 +101,20 @@ std::vector<File::FileInfo> ApplyFilter(std::vector<File::FileInfo> files, const
 		std::string tmp;
 		while (*filter) {
 			if (*filter == ':') {
-				filters.insert(std::move(tmp));
+				filters.insert("." + tmp);
 			} else {
 				tmp.push_back(*filter);
 			}
 			filter++;
 		}
 		if (!tmp.empty())
-			filters.insert(std::move(tmp));
+			filters.insert("." + tmp);
 	}
 
 	auto pred = [&](const File::FileInfo &info) {
 		if (info.isDirectory || !filter)
 			return false;
-		std::string ext = File::GetFileExtension(info.fullName);
+		std::string ext = "." + File::GetFileExtension(info.fullName);
 		return filters.find(ext) == filters.end();
 	};
 	files.erase(std::remove_if(files.begin(), files.end(), pred), files.end());

--- a/Common/File/PathBrowser.cpp
+++ b/Common/File/PathBrowser.cpp
@@ -114,7 +114,7 @@ std::vector<File::FileInfo> ApplyFilter(std::vector<File::FileInfo> files, const
 	auto pred = [&](const File::FileInfo &info) {
 		if (info.isDirectory || !filter)
 			return false;
-		std::string ext = "." + File::GetFileExtension(info.fullName);
+		std::string ext = File::GetFileExtension(info.fullName);
 		return filters.find(ext) == filters.end();
 	};
 	files.erase(std::remove_if(files.begin(), files.end(), pred), files.end());

--- a/Common/File/VFS/AssetReader.cpp
+++ b/Common/File/VFS/AssetReader.cpp
@@ -74,7 +74,7 @@ bool ZipAssetReader::GetFileListing(const char *orig_path, std::vector<File::Fil
 	if (filter) {
 		while (*filter) {
 			if (*filter == ':') {
-				filters.insert(tmp);
+				filters.insert("." + tmp);
 				tmp = "";
 			} else {
 				tmp.push_back(*filter);
@@ -83,7 +83,7 @@ bool ZipAssetReader::GetFileListing(const char *orig_path, std::vector<File::Fil
 		}
 	}
 	if (tmp.size())
-		filters.insert(tmp);
+		filters.insert("." + tmp);
 
 	// We just loop through the whole ZIP file and deduce what files are in this directory, and what subdirectories there are.
 	std::set<std::string> files;

--- a/Core/ELF/PBPReader.cpp
+++ b/Core/ELF/PBPReader.cpp
@@ -26,21 +26,21 @@
 
 PBPReader::PBPReader(FileLoader *fileLoader) : file_(nullptr), header_(), isELF_(false) {
 	if (!fileLoader->Exists()) {
-		ERROR_LOG(LOADER, "Failed to open PBP file %s", fileLoader->Path().c_str());
+		ERROR_LOG(LOADER, "Failed to open PBP file %s", fileLoader->GetPath().c_str());
 		return;
 	}
 
 	fileSize_ = (size_t)fileLoader->FileSize();
 	if (fileLoader->ReadAt(0, sizeof(header_), (u8 *)&header_) != sizeof(header_)) {
-		ERROR_LOG(LOADER, "PBP is too small to be valid: %s", fileLoader->Path().c_str());
+		ERROR_LOG(LOADER, "PBP is too small to be valid: %s", fileLoader->GetPath().c_str());
 		return;
 	}
 	if (memcmp(header_.magic, "\0PBP", 4) != 0) {
 		if (memcmp(header_.magic, "\nFLE", 4) != 0) {
-			VERBOSE_LOG(LOADER, "%s: File actually an ELF, not a PBP", fileLoader->Path().c_str());
+			VERBOSE_LOG(LOADER, "%s: File actually an ELF, not a PBP", fileLoader->GetPath().c_str());
 			isELF_ = true;
 		} else {
-			ERROR_LOG(LOADER, "Magic number in %s indicated no PBP: %s", fileLoader->Path().c_str(), header_.magic);
+			ERROR_LOG(LOADER, "Magic number in %s indicated no PBP: %s", fileLoader->GetPath().c_str(), header_.magic);
 		}
 		return;
 	}

--- a/Core/FileLoaders/DiskCachingFileLoader.cpp
+++ b/Core/FileLoaders/DiskCachingFileLoader.cpp
@@ -133,7 +133,7 @@ std::vector<std::string> DiskCachingFileLoader::GetCachedPathsInUse() {
 void DiskCachingFileLoader::InitCache() {
 	std::lock_guard<std::mutex> guard(cachesMutex_);
 
-	std::string path = ProxiedFileLoader::Path();
+	std::string path = ProxiedFileLoader::GetPath();
 	auto &entry = caches_[path];
 	if (!entry) {
 		entry = new DiskCachingFileLoaderCache(path, filesize_);
@@ -149,7 +149,7 @@ void DiskCachingFileLoader::ShutdownCache() {
 	if (cache_->Release()) {
 		// If it ran out of counts, delete it.
 		delete cache_;
-		caches_.erase(ProxiedFileLoader::Path());
+		caches_.erase(ProxiedFileLoader::GetPath());
 	}
 	cache_ = nullptr;
 }

--- a/Core/FileLoaders/HTTPFileLoader.cpp
+++ b/Core/FileLoaders/HTTPFileLoader.cpp
@@ -172,7 +172,7 @@ s64 HTTPFileLoader::FileSize() {
 	return filesize_;
 }
 
-std::string HTTPFileLoader::Path() const {
+std::string HTTPFileLoader::GetPath() const {
 	return filename_;
 }
 

--- a/Core/FileLoaders/HTTPFileLoader.h
+++ b/Core/FileLoaders/HTTPFileLoader.h
@@ -38,7 +38,7 @@ public:
 	virtual bool ExistsFast() override;
 	virtual bool IsDirectory() override;
 	virtual s64 FileSize() override;
-	virtual std::string Path() const override;
+	virtual std::string GetPath() const override;
 
 	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override {
 		return ReadAt(absolutePos, bytes * count, data, flags) / bytes;

--- a/Core/FileLoaders/LocalFileLoader.cpp
+++ b/Core/FileLoaders/LocalFileLoader.cpp
@@ -130,7 +130,7 @@ s64 LocalFileLoader::FileSize() {
 	return filesize_;
 }
 
-std::string LocalFileLoader::Path() const {
+std::string LocalFileLoader::GetPath() const {
 	return filename_;
 }
 

--- a/Core/FileLoaders/LocalFileLoader.h
+++ b/Core/FileLoaders/LocalFileLoader.h
@@ -33,7 +33,7 @@ public:
 	virtual bool Exists() override;
 	virtual bool IsDirectory() override;
 	virtual s64 FileSize() override;
-	virtual std::string Path() const override;
+	virtual std::string GetPath() const override;
 	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override;
 
 private:

--- a/Core/FileSystems/BlobFileSystem.cpp
+++ b/Core/FileSystems/BlobFileSystem.cpp
@@ -129,7 +129,7 @@ bool BlobFileSystem::RemoveFile(const std::string &filename) {
 }
 
 bool BlobFileSystem::GetHostPath(const std::string &inpath, std::string &outpath) {
-	outpath = fileLoader_->Path();
+	outpath = fileLoader_->GetPath();
 	return true;
 }
 

--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -202,7 +202,7 @@ CISOFileBlockDevice::CISOFileBlockDevice(FileLoader *fileLoader)
 	u64 expectedFileSize = lastIndexPos << indexShift;
 	if (expectedFileSize > fileSize) {
 		ERROR_LOG(LOADER, "Expected CSO to at least be %lld bytes, but file is %lld bytes. File: '%s'",
-			expectedFileSize, fileSize, fileLoader->Path().c_str());
+			expectedFileSize, fileSize, fileLoader->GetPath().c_str());
 		NotifyReadError();
 	}
 }

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -337,7 +337,7 @@ bool DirectoryFileHandle::Open(const std::string &basePath, std::string &fileNam
 #endif
 
 	// Try to detect reads/writes to PSP/GAME to avoid them in replays.
-	if (fullName.find("/PSP/GAME/") != fullName.npos || fullName.find("\\PSP\\GAME\\") != fullName.npos) {
+	if (fullName.find("PSP/GAME/") != fullName.npos || fullName.find("PSP\\GAME\\") != fullName.npos) {
 		inGameDir_ = true;
 	}
 

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -63,8 +63,8 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 		ERROR_LOG(LOADER, "Invalid fileLoader");
 		return IdentifiedFileType::ERROR_IDENTIFYING;
 	}
-	if (fileLoader->Path().size() == 0) {
-		ERROR_LOG(LOADER, "Invalid filename %s", fileLoader->Path().c_str());
+	if (fileLoader->GetPath().size() == 0) {
+		ERROR_LOG(LOADER, "Invalid filename %s", fileLoader->GetPath().c_str());
 		return IdentifiedFileType::ERROR_IDENTIFYING;
 	}
 
@@ -101,7 +101,7 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 
 	// First, check if it's a directory with an EBOOT.PBP in it.
 	if (fileLoader->IsDirectory()) {
-		std::string filename = fileLoader->Path();
+		std::string filename = fileLoader->GetPath();
 		if (filename.size() > 4) {
 			// Check for existence of EBOOT.PBP, as required for "Directory games".
 			if (File::Exists((filename + "/EBOOT.PBP").c_str())) {
@@ -142,7 +142,7 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 	}
 
 	if (id == 'FLE\x7F') {
-		std::string filename = fileLoader->Path();
+		std::string filename = fileLoader->GetPath();
 		// There are a few elfs misnamed as pbp (like Trig Wars), accept that.
 		if (!strcasecmp(extension.c_str(), ".plf") || strstr(filename.c_str(),"BOOT.BIN") ||
 				!strcasecmp(extension.c_str(), ".elf") || !strcasecmp(extension.c_str(), ".prx") ||
@@ -177,7 +177,7 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 
 		// Let's check if we got pointed to a PBP within such a directory.
 		// If so we just move up and return the directory itself as the game.
-		std::string path = File::GetDir(fileLoader->Path());
+		std::string path = File::GetDir(fileLoader->GetPath());
 		// If loading from memstick...
 		size_t pos = path.find("/PSP/GAME/");
 		if (pos != std::string::npos) {
@@ -207,8 +207,8 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 FileLoader *ResolveFileLoaderTarget(FileLoader *fileLoader) {
 	IdentifiedFileType type = Identify_File(fileLoader);
 	if (type == IdentifiedFileType::PSP_PBP_DIRECTORY) {
-		const std::string ebootFilename = ResolvePBPFile(fileLoader->Path());
-		if (ebootFilename != fileLoader->Path()) {
+		const std::string ebootFilename = ResolvePBPFile(fileLoader->GetPath());
+		if (ebootFilename != fileLoader->GetPath()) {
 			// Switch fileLoader to the actual EBOOT.
 			delete fileLoader;
 			fileLoader = ConstructFileLoader(ebootFilename);
@@ -262,7 +262,7 @@ bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string) {
 					coreState = CORE_BOOT_ERROR;
 					return false;
 				}
-				std::string path = fileLoader->Path();
+				std::string path = fileLoader->GetPath();
 				size_t pos = path.find("/PSP/GAME/");
 				if (pos != std::string::npos) {
 					path = ResolvePBPDirectory(path);
@@ -369,7 +369,7 @@ bool UmdReplace(std::string filepath, std::string &error) {
 
 	if (!loadedFile->Exists()) {
 		delete loadedFile;
-		error = loadedFile->Path() + " doesn't exist";
+		error = loadedFile->GetPath() + " doesn't exist";
 		return false;
 	}
 	UpdateLoadedFile(loadedFile);

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -72,8 +72,8 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 		return IdentifiedFileType::ERROR_IDENTIFYING;
 	}
 
-	std::string extension = fileLoader->Extension();
-	if (!strcasecmp(extension.c_str(), ".iso")) {
+	std::string extension = "." + File::GetFileExtension(fileLoader->GetPath());
+	if (extension == ".iso") {
 		// may be a psx iso, they have 2352 byte sectors. You never know what some people try to open
 		if ((fileLoader->FileSize() % 2352) == 0) {
 			unsigned char sync[12];
@@ -87,11 +87,11 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 			// maybe it also just happened to have that size, 
 		}
 		return IdentifiedFileType::PSP_ISO;
-	} else if (!strcasecmp(extension.c_str(), ".cso")) {
+	} else if (extension == ".cso") {
 		return IdentifiedFileType::PSP_ISO;
-	} else if (!strcasecmp(extension.c_str(), ".ppst")) {
+	} else if (extension == ".ppst") {
 		return IdentifiedFileType::PPSSPP_SAVESTATE;
-	} else if (!strcasecmp(extension.c_str(), ".ppdmp")) {
+	} else if (extension == ".ppdmp") {
 		char data[8]{};
 		fileLoader->ReadAt(0, 8, data);
 		if (memcmp(data, "PPSSPPGE", 8) == 0) {
@@ -144,14 +144,12 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 	if (id == 'FLE\x7F') {
 		std::string filename = fileLoader->GetPath();
 		// There are a few elfs misnamed as pbp (like Trig Wars), accept that.
-		if (!strcasecmp(extension.c_str(), ".plf") || strstr(filename.c_str(),"BOOT.BIN") ||
-				!strcasecmp(extension.c_str(), ".elf") || !strcasecmp(extension.c_str(), ".prx") ||
-				!strcasecmp(extension.c_str(), ".pbp")) {
+		if (extension == ".plf" || strstr(filename.c_str(), "BOOT.BIN") ||
+			extension == ".elf" || extension == ".prx" || extension == ".pbp") {
 			return IdentifiedFileType::PSP_ELF;
 		}
 		return IdentifiedFileType::UNKNOWN_ELF;
-	}
-	else if (id == 'PBP\x00') {
+	} else if (id == 'PBP\x00') {
 		// Do this PS1 eboot check FIRST before checking other eboot types.
 		// It seems like some are malformed and slip through the PSAR check below.
 		PBPReader pbp(fileLoader);
@@ -184,21 +182,20 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 			return IdentifiedFileType::PSP_PBP_DIRECTORY;
 		}
 		return IdentifiedFileType::PSP_PBP;
-	}
-	else if (!strcasecmp(extension.c_str(),".pbp")) {
+	} else if (extension == ".pbp") {
 		ERROR_LOG(LOADER, "A PBP with the wrong magic number?");
 		return IdentifiedFileType::PSP_PBP;
-	} else if (!strcasecmp(extension.c_str(),".bin")) {
+	} else if (extension == ".bin") {
 		return IdentifiedFileType::UNKNOWN_BIN;
-	} else if (!strcasecmp(extension.c_str(),".zip")) {
+	} else if (extension == ".zip") {
 		return IdentifiedFileType::ARCHIVE_ZIP;
-	} else if (!strcasecmp(extension.c_str(),".rar")) {
+	} else if (extension == ".rar") {
 		return IdentifiedFileType::ARCHIVE_RAR;
-	} else if (!strcasecmp(extension.c_str(),".r00")) {
+	} else if (extension == ".r00") {
 		return IdentifiedFileType::ARCHIVE_RAR;
-	} else if (!strcasecmp(extension.c_str(),".r01")) {
+	} else if (extension == ".r01") {
 		return IdentifiedFileType::ARCHIVE_RAR;
-	} else if (!extension.empty() && !strcasecmp(extension.substr(1).c_str(), ".7z")) {
+	} else if (extension == ".7z") {
 		return IdentifiedFileType::ARCHIVE_7Z;
 	}
 	return IdentifiedFileType::UNKNOWN;

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -72,7 +72,7 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 		return IdentifiedFileType::ERROR_IDENTIFYING;
 	}
 
-	std::string extension = "." + File::GetFileExtension(fileLoader->GetPath());
+	std::string extension = File::GetFileExtension(fileLoader->GetPath());
 	if (extension == ".iso") {
 		// may be a psx iso, they have 2352 byte sectors. You never know what some people try to open
 		if ((fileLoader->FileSize() % 2352) == 0) {

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -177,7 +177,7 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader) {
 		// If so we just move up and return the directory itself as the game.
 		std::string path = File::GetDir(fileLoader->GetPath());
 		// If loading from memstick...
-		size_t pos = path.find("/PSP/GAME/");
+		size_t pos = path.find("PSP/GAME/");
 		if (pos != std::string::npos) {
 			return IdentifiedFileType::PSP_PBP_DIRECTORY;
 		}
@@ -260,10 +260,10 @@ bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string) {
 					return false;
 				}
 				std::string path = fileLoader->GetPath();
-				size_t pos = path.find("/PSP/GAME/");
+				size_t pos = path.find("PSP/GAME/");
 				if (pos != std::string::npos) {
 					path = ResolvePBPDirectory(path);
-					pspFileSystem.SetStartingDirectory("ms0:" + path.substr(pos));
+					pspFileSystem.SetStartingDirectory("ms0:/" + path.substr(pos));
 				}
 				return Load_PSP_ELF_PBP(fileLoader, error_string);
 			} else {

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -75,15 +75,6 @@ public:
 	virtual bool IsDirectory() = 0;
 	virtual s64 FileSize() = 0;
 	virtual std::string GetPath() const = 0;
-	virtual std::string Extension() {
-		const std::string filename = GetPath();
-		size_t pos = filename.find_last_of('.');
-		if (pos == filename.npos) {
-			return "";
-		} else {
-			return filename.substr(pos);
-		}
-	}
 	virtual size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) = 0;
 	virtual size_t ReadAt(s64 absolutePos, size_t bytes, void *data, Flags flags = Flags::NONE) {
 		return ReadAt(absolutePos, 1, bytes, data, flags);

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -74,9 +74,9 @@ public:
 	}
 	virtual bool IsDirectory() = 0;
 	virtual s64 FileSize() = 0;
-	virtual std::string Path() const = 0;
+	virtual std::string GetPath() const = 0;
 	virtual std::string Extension() {
-		const std::string filename = Path();
+		const std::string filename = GetPath();
 		size_t pos = filename.find_last_of('.');
 		if (pos == filename.npos) {
 			return "";
@@ -121,8 +121,8 @@ public:
 	s64 FileSize() override {
 		return backend_->FileSize();
 	}
-	std::string Path() const override {
-		return backend_->Path();
+	std::string GetPath() const override {
+		return backend_->GetPath();
 	}
 	void Cancel() override {
 		backend_->Cancel();

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -374,11 +374,17 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 	std::string full_path = fileLoader->GetPath();
 	std::string path, file, extension;
 	SplitPath(ReplaceAll(full_path, "\\", "/"), &path, &file, &extension);
+	if (!path.empty() && path.back() == '/')
+		path.resize(path.size() - 1);
+#ifdef _WIN32
+	if (!path.empty() && path.back() == '\\')
+		path.resize(path.size() - 1);
+#endif
 
-	size_t pos = path.find("/PSP/GAME/");
+	size_t pos = path.find("PSP/GAME/");
 	std::string ms_path;
 	if (pos != std::string::npos) {
-		ms_path = "ms0:" + path.substr(pos);
+		ms_path = "ms0:/" + path.substr(pos) + "/";
 	} else {
 		// This is wrong, but it's better than not having a working directory at all.
 		// Note that umd0:/ is actually the writable containing directory, in this case.

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -328,7 +328,7 @@ bool Load_PSP_ISO(FileLoader *fileLoader, std::string *error_string) {
 		} else {
 			coreState = CORE_BOOT_ERROR;
 			// TODO: This is a crummy way to communicate the error...
-			PSP_CoreParameter().fileToStart = "";
+			PSP_CoreParameter().fileToStart.clear();
 		}
 	});
 	return true;
@@ -461,7 +461,7 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 		} else {
 			coreState = CORE_BOOT_ERROR;
 			// TODO: This is a crummy way to communicate the error...
-			PSP_CoreParameter().fileToStart = "";
+			PSP_CoreParameter().fileToStart.clear();
 		}
 	});
 	return true;
@@ -485,7 +485,7 @@ bool Load_PSP_GE_Dump(FileLoader *fileLoader, std::string *error_string) {
 		} else {
 			coreState = CORE_BOOT_ERROR;
 			// TODO: This is a crummy way to communicate the error...
-			PSP_CoreParameter().fileToStart = "";
+			PSP_CoreParameter().fileToStart.clear();
 		}
 	});
 	return true;

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -84,7 +84,7 @@ void InitMemoryForGameISO(FileLoader *fileLoader) {
 	IFileSystem *blockSystem = nullptr;
 
 	if (fileLoader->IsDirectory()) {
-		fileSystem = new VirtualDiscFileSystem(&pspFileSystem, fileLoader->Path());
+		fileSystem = new VirtualDiscFileSystem(&pspFileSystem, fileLoader->GetPath());
 		blockSystem = fileSystem;
 	} else {
 		auto bd = constructBlockDevice(fileLoader);
@@ -152,7 +152,7 @@ bool ReInitMemoryForGameISO(FileLoader *fileLoader) {
 	IFileSystem *blockSystem = nullptr;
 
 	if (fileLoader->IsDirectory()) {
-		fileSystem = new VirtualDiscFileSystem(&pspFileSystem, fileLoader->Path());
+		fileSystem = new VirtualDiscFileSystem(&pspFileSystem, fileLoader->GetPath());
 		blockSystem = fileSystem;
 	} else {
 		auto bd = constructBlockDevice(fileLoader);
@@ -371,7 +371,7 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 		}
 	}
 
-	std::string full_path = fileLoader->Path();
+	std::string full_path = fileLoader->GetPath();
 	std::string path, file, extension;
 	SplitPath(ReplaceAll(full_path, "\\", "/"), &path, &file, &extension);
 

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -311,7 +311,7 @@ bool CPU_Init() {
 	// Note: this may return before init is complete, which is checked if CPU_IsReady().
 	if (!LoadFile(&loadedFile, &coreParameter.errorString)) {
 		CPU_Shutdown();
-		coreParameter.fileToStart = "";
+		coreParameter.fileToStart.clear();
 		return false;
 	}
 
@@ -426,7 +426,7 @@ bool PSP_InitStart(const CoreParameter &coreParam, std::string *error_string) {
 	}
 
 	*error_string = coreParameter.errorString;
-	bool success = coreParameter.fileToStart != "";
+	bool success = !coreParameter.fileToStart.empty();
 	if (!success) {
 		Core_NotifyLifecycle(CoreLifecycle::START_COMPLETE);
 		pspIsIniting = false;
@@ -443,7 +443,7 @@ bool PSP_InitUpdate(std::string *error_string) {
 		return false;
 	}
 
-	bool success = coreParameter.fileToStart != "";
+	bool success = !coreParameter.fileToStart.empty();
 	*error_string = coreParameter.errorString;
 	if (success && gpu == nullptr) {
 		PSP_SetLoading("Starting graphics...");

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -239,7 +239,7 @@ bool CPU_Init() {
 	IdentifiedFileType type = Identify_File(loadedFile);
 
 	// TODO: Put this somewhere better?
-	if (coreParameter.mountIso != "") {
+	if (!coreParameter.mountIso.empty()) {
 		coreParameter.mountIsoLoader = ConstructFileLoader(coreParameter.mountIso);
 	}
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -246,8 +246,8 @@ void EmuScreen::bootGame(const std::string &filename) {
 	coreParam.graphicsContext = PSP_CoreParameter().graphicsContext;
 	coreParam.enableSound = g_Config.bEnableSound;
 	coreParam.fileToStart = filename;
-	coreParam.mountIso = "";
-	coreParam.mountRoot = "";
+	coreParam.mountIso.clear();
+	coreParam.mountRoot.clear();
 	coreParam.startBreak = !g_Config.bAutoRun;
 	coreParam.printfEmuLog = false;
 	coreParam.headLess = false;

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -370,7 +370,7 @@ public:
 					if (pbp.IsELF()) {
 						goto handleELF;
 					}
-					ERROR_LOG(LOADER, "invalid pbp %s\n", pbpLoader->Path().c_str());
+					ERROR_LOG(LOADER, "invalid pbp %s\n", pbpLoader->GetPath().c_str());
 					info_->pending = false;
 					info_->working = false;
 					return;

--- a/UWP/StorageFileLoader.cpp
+++ b/UWP/StorageFileLoader.cpp
@@ -135,10 +135,6 @@ std::string StorageFileLoader::GetPath() const {
 	return path_;
 }
 
-std::string StorageFileLoader::Extension() {
-	return "." + File::GetFileExtension(path_);
-}
-
 void StorageFileLoader::EnsureOpen() {
 	while (size_ == -1)
 		Sleep(50);

--- a/UWP/StorageFileLoader.cpp
+++ b/UWP/StorageFileLoader.cpp
@@ -131,7 +131,7 @@ s64 StorageFileLoader::FileSize() {
 	return size_;
 }
 
-std::string StorageFileLoader::Path() const {
+std::string StorageFileLoader::GetPath() const {
 	return path_;
 }
 

--- a/UWP/StorageFileLoader.h
+++ b/UWP/StorageFileLoader.h
@@ -24,7 +24,7 @@ public:
 
 	bool IsDirectory() override;
 	s64 FileSize() override;
-	std::string Path() const override;
+	std::string GetPath() const override;
 	std::string Extension() override;
 
 	size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override;

--- a/UWP/StorageFileLoader.h
+++ b/UWP/StorageFileLoader.h
@@ -25,7 +25,6 @@ public:
 	bool IsDirectory() override;
 	s64 FileSize() override;
 	std::string GetPath() const override;
-	std::string Extension() override;
 
 	size_t ReadAt(s64 absolutePos, size_t bytes, size_t count, void *data, Flags flags = Flags::NONE) override;
 

--- a/UWP/StorageFolderBrowser.h
+++ b/UWP/StorageFolderBrowser.h
@@ -21,7 +21,7 @@ public:
 	StorageFolderBrowser(Windows::Storage::StorageFolder ^folder);
 	~StorageFolderBrowser();
 
-	std::string Path() const {
+	std::string GetPath() const {
 		return path_;
 	}
 

--- a/android/jni/TestRunner.cpp
+++ b/android/jni/TestRunner.cpp
@@ -93,7 +93,7 @@ bool RunTests() {
 	coreParam.gpuCore = GPUCORE_SOFTWARE;
 	coreParam.enableSound = g_Config.bEnableSound;
 	coreParam.graphicsContext = nullptr;
-	coreParam.mountIso = "";
+	coreParam.mountIso.clear();
 	coreParam.mountRoot = baseDirectory + "pspautotests/";
 	coreParam.startBreak = false;
 	coreParam.printfEmuLog = false;

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -245,9 +245,9 @@ int main(int argc, const char* argv[])
 	int debuggerPort = -1;
 
 	std::vector<std::string> testFilenames;
-	const char *mountIso = 0;
-	const char *mountRoot = 0;
-	const char *screenshotFilename = 0;
+	const char *mountIso = nullptr;
+	const char *mountRoot = nullptr;
+	const char *screenshotFilename = nullptr;
 	float timeout = std::numeric_limits<float>::infinity();
 
 	for (int i = 1; i < argc; i++)
@@ -355,8 +355,10 @@ int main(int argc, const char* argv[])
 	coreParameter.gpuCore = glWorking ? gpuCore : GPUCORE_SOFTWARE;
 	coreParameter.graphicsContext = graphicsContext;
 	coreParameter.enableSound = false;
-	coreParameter.mountIso = mountIso ? mountIso : "";
-	coreParameter.mountRoot = mountRoot ? mountRoot : "";
+	if (mountIso)
+		coreParameter.mountIso = mountIso;
+	if (mountRoot)
+		coreParameter.mountRoot = mountRoot;
 	coreParameter.startBreak = false;
 	coreParameter.printfEmuLog = !autoCompare;
 	coreParameter.headLess = true;

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -650,7 +650,7 @@ bool retro_load_game(const struct retro_game_info *game)
    CoreParameter coreParam   = {};
    coreParam.enableSound     = true;
    coreParam.fileToStart     = std::string(game->path);
-   coreParam.mountIso        = "";
+   coreParam.mountIso.clear();
    coreParam.startBreak      = false;
    coreParam.printfEmuLog    = true;
    coreParam.headLess        = true;


### PR DESCRIPTION
This also reduces distance for #14436, although not by much.  It does fix a bug with AssetReader extensions, though.

I'll note that the original reason I had a virtual Extension() method on file loaders was thinking I might convert an HTTP mime type to an extension (example: "application/x-iso9660-image" -> ".iso", regardless of filename.)  But it hasn't really materialized as something worth spending time on, anyway.

-[Unknown]