### PR TITLE
Fix headless test run, small cleanups to Path usage

### DIFF
--- a/Common/Buffer.cpp
+++ b/Common/Buffer.cpp
@@ -3,6 +3,8 @@
 #include <cstring>
 
 #include "Common/Buffer.h"
+#include "Common/File/FileUtil.h"
+#include "Common/File/Path.h"
 #include "Common/Log.h"
 
 Buffer::Buffer() { }
@@ -115,8 +117,8 @@ void Buffer::Printf(const char *fmt, ...) {
 	memcpy(ptr, buffer, retval);
 }
 
-bool Buffer::FlushToFile(const char *filename) {
-	FILE *f = fopen(filename, "wb");
+bool Buffer::FlushToFile(const Path &filename) {
+	FILE *f = File::OpenCFile(filename, "wb");
 	if (!f)
 		return false;
 	if (data_.size()) {

--- a/Common/Buffer.h
+++ b/Common/Buffer.h
@@ -5,6 +5,8 @@
 
 #include "Common/Common.h"
 
+class Path;
+
 // Acts as a queue. Intended to be as fast as possible for most uses.
 // Does not do synchronization, must use external mutexes.
 class Buffer {
@@ -66,7 +68,7 @@ public:
 	// Writes the entire buffer to the file descriptor. Also resets the
 	// size to zero. On failure, data remains in buffer and nothing is
 	// written.
-	bool FlushToFile(const char *filename);
+	bool FlushToFile(const Path &filename);
 
 	// Utilities. Try to avoid checking for size.
 	size_t size() const { return data_.size(); }

--- a/Common/File/DirListing.cpp
+++ b/Common/File/DirListing.cpp
@@ -197,7 +197,7 @@ size_t GetFilesInDir(const Path &directory, std::vector<FileInfo> * files, const
 		info.size = 0;
 		info.isWritable = false;  // TODO - implement some kind of check
 		if (!info.isDirectory) {
-			std::string ext = Path(info.fullName).GetFileExtension();
+			std::string ext = info.fullName.GetFileExtension();
 			if (!ext.empty()) {
 				ext = ext.substr(1);  // Remove the dot.
 				if (filter && filters.find(ext) == filters.end()) {

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -578,14 +578,6 @@ std::string GetDir(const std::string &path) {
 	return cutpath;
 }
 
-std::string GetFilename(std::string path) {
-	size_t off = GetDir(path).size() + 1;
-	if (off < path.size())
-		return path.substr(off);
-	else
-		return path;
-}
-
 std::string GetFileExtension(const std::string & fn) {
 	size_t pos = fn.rfind(".");
 	if (pos == std::string::npos) {

--- a/Common/File/FileUtil.h
+++ b/Common/File/FileUtil.h
@@ -59,9 +59,6 @@ std::string GetFileExtension(const std::string &filename);
 // Extracts the directory from a path.
 std::string GetDir(const std::string &path);
 
-// Extracts the filename from a path.
-std::string GetFilename(std::string path);
-
 // Returns struct with modification date of file
 bool GetModifTime(const Path &filename, tm &return_time);
 

--- a/Common/File/PathBrowser.cpp
+++ b/Common/File/PathBrowser.cpp
@@ -209,9 +209,9 @@ bool PathBrowser::IsListingReady() {
 }
 
 std::string PathBrowser::GetFriendlyPath() const {
-	std::string str = GetPath().ToString();
+	std::string str = GetPath().ToVisualString();
 	// Show relative to memstick root if there.
-	std::string root = GetSysDirectory(DIRECTORY_MEMSTICK_ROOT).ToString();
+	std::string root = GetSysDirectory(DIRECTORY_MEMSTICK_ROOT).ToVisualString();
 
 	if (startsWith(str, root)) {
 		return std::string("ms:/") + str.substr(root.size());

--- a/Common/File/PathBrowser.cpp
+++ b/Common/File/PathBrowser.cpp
@@ -258,7 +258,7 @@ bool PathBrowser::GetListing(std::vector<File::FileInfo> &fileInfo, const char *
 		fileInfo = ApplyFilter(pendingFiles_, filter);
 		return true;
 	} else {
-		File::GetFilesInDir(Path(path_), &fileInfo, filter);
+		File::GetFilesInDir(path_, &fileInfo, filter);
 		return true;
 	}
 }

--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -457,7 +457,7 @@ int Client::ReadResponseEntity(net::Buffer *readbuf, const std::vector<std::stri
 	return 0;
 }
 
-Download::Download(const std::string &url, const std::string &outfile)
+Download::Download(const std::string &url, const Path &outfile)
 	: progress_(&cancelled_), url_(url), outfile_(outfile) {
 }
 
@@ -552,12 +552,12 @@ void Download::Do() {
 		}
 
 		if (resultCode == 200) {
-			INFO_LOG(IO, "Completed downloading %s to %s", url_.c_str(), outfile_.empty() ? "memory" : outfile_.c_str());
-			if (!outfile_.empty() && !buffer_.FlushToFile(outfile_.c_str())) {
-				ERROR_LOG(IO, "Failed writing download to %s", outfile_.c_str());
+			INFO_LOG(IO, "Completed downloading %s to %s", url_.c_str(), outfile_.empty() ? "memory" : outfile_.ToVisualString().c_str());
+			if (!outfile_.empty() && !buffer_.FlushToFile(outfile_)) {
+				ERROR_LOG(IO, "Failed writing download to %s", outfile_.ToVisualString().c_str());
 			}
 		} else {
-			ERROR_LOG(IO, "Error downloading %s to %s: %i", url_.c_str(), outfile_.c_str(), resultCode);
+			ERROR_LOG(IO, "Error downloading %s to %s: %i", url_.c_str(), outfile_.ToVisualString().c_str(), resultCode);
 		}
 		resultCode_ = resultCode;
 	}
@@ -569,7 +569,7 @@ void Download::Do() {
 	completed_ = true;
 }
 
-std::shared_ptr<Download> Downloader::StartDownload(const std::string &url, const std::string &outfile) {
+std::shared_ptr<Download> Downloader::StartDownload(const std::string &url, const Path &outfile) {
 	std::shared_ptr<Download> dl(new Download(url, outfile));
 	downloads_.push_back(dl);
 	dl->Start();
@@ -578,7 +578,7 @@ std::shared_ptr<Download> Downloader::StartDownload(const std::string &url, cons
 
 std::shared_ptr<Download> Downloader::StartDownloadWithCallback(
 	const std::string &url,
-	const std::string &outfile,
+	const Path &outfile,
 	std::function<void(Download &)> callback) {
 	std::shared_ptr<Download> dl(new Download(url, outfile));
 	dl->SetCallback(callback);

--- a/Common/Net/HTTPClient.h
+++ b/Common/Net/HTTPClient.h
@@ -5,6 +5,7 @@
 #include <thread>
 #include <cstdint>
 
+#include "Common/File/Path.h"
 #include "Common/Net/NetBuffer.h"
 #include "Common/Net/Resolve.h"
 
@@ -90,7 +91,7 @@ protected:
 // Not particularly efficient, but hey - it's a background download, that's pretty cool :P
 class Download {
 public:
-	Download(const std::string &url, const std::string &outfile);
+	Download(const std::string &url, const Path &outfile);
 	~Download();
 
 	void Start();
@@ -108,7 +109,7 @@ public:
 	int ResultCode() const { return resultCode_; }
 
 	std::string url() const { return url_; }
-	std::string outfile() const { return outfile_; }
+	const Path &outfile() const { return outfile_; }
 
 	// If not downloading to a file, access this to get the result.
 	Buffer &buffer() { return buffer_; }
@@ -147,7 +148,7 @@ private:
 	Buffer buffer_;
 	std::vector<std::string> responseHeaders_;
 	std::string url_;
-	std::string outfile_;
+	Path outfile_;
 	std::thread thread_;
 	int resultCode_ = 0;
 	bool completed_ = false;
@@ -166,11 +167,11 @@ public:
 		CancelAll();
 	}
 
-	std::shared_ptr<Download> StartDownload(const std::string &url, const std::string &outfile);
+	std::shared_ptr<Download> StartDownload(const std::string &url, const Path &outfile);
 
 	std::shared_ptr<Download> StartDownloadWithCallback(
 		const std::string &url,
-		const std::string &outfile,
+		const Path &outfile,
 		std::function<void(Download &)> callback);
 
 	// Drops finished downloads from the list.

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1301,7 +1301,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	// upgrade number in the ini.
 	if (iRunCount % 10 == 0 && bCheckForNewVersion) {
 		std::shared_ptr<http::Download> dl = g_DownloadManager.StartDownloadWithCallback(
-			"http://www.ppsspp.org/version.json", "", &DownloadCompletedCallback);
+			"http://www.ppsspp.org/version.json", Path(), &DownloadCompletedCallback);
 		dl->SetHidden(true);
 	}
 

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1593,7 +1593,7 @@ void Config::RestoreDefaults() {
 		createGameConfig(gameId_);
 	} else {
 		if (File::Exists(iniFilename_))
-			File::Delete(Path(iniFilename_));
+			File::Delete(iniFilename_);
 		recentIsos.clear();
 		currentDirectory = "";
 	}

--- a/Core/HLE/Plugins.cpp
+++ b/Core/HLE/Plugins.cpp
@@ -86,8 +86,8 @@ static std::vector<PluginInfo> FindPlugins(const std::string &gameID, const std:
 	GetFilesInDir(GetSysDirectory(DIRECTORY_PLUGINS), &pluginDirs);
 
 	std::vector<PluginInfo> found;
-	for (auto subdir : pluginDirs) {
-		Path subdirFullName(subdir.fullName);
+	for (const auto &subdir : pluginDirs) {
+		const Path &subdirFullName = subdir.fullName;
 		if (!subdir.isDirectory || !File::Exists(subdirFullName / "plugin.ini"))
 			continue;
 

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -397,22 +397,22 @@ namespace SaveState
 		return title + " (" + filename + ")";
 	}
 
-	std::string GetTitle(const std::string &filename) {
+	std::string GetTitle(const Path &filename) {
 		std::string title;
-		if (CChunkFileReader::GetFileTitle(Path(filename), &title) == CChunkFileReader::ERROR_NONE) {
+		if (CChunkFileReader::GetFileTitle(filename, &title) == CChunkFileReader::ERROR_NONE) {
 			if (title.empty()) {
-				return File::GetFilename(filename);
+				return filename.GetFilename();
 			}
 
-			return AppendSlotTitle(filename, title);
+			return AppendSlotTitle(filename.GetFilename(), title);
 		}
 
 		// The file can't be loaded - let's note that.
 		auto sy = GetI18NCategory("System");
-		return File::GetFilename(filename) + " " + sy->T("(broken)");
+		return filename.GetFilename() + " " + sy->T("(broken)");
 	}
 
-	Path GenerateSaveSlotFilename(const std::string &gameFilename, int slot, const char *extension)
+	Path GenerateSaveSlotFilename(const Path &gameFilename, int slot, const char *extension)
 	{
 		std::string discId = g_paramSFO.GetValueString("DISC_ID");
 		std::string discVer = g_paramSFO.GetValueString("DISC_VERSION");
@@ -437,7 +437,7 @@ namespace SaveState
 		g_Config.iCurrentStateSlot = (g_Config.iCurrentStateSlot + 1) % NUM_SLOTS;
 	}
 
-	void LoadSlot(const std::string &gameFilename, int slot, Callback callback, void *cbUserData)
+	void LoadSlot(const Path &gameFilename, int slot, Callback callback, void *cbUserData)
 	{
 		Path fn = GenerateSaveSlotFilename(gameFilename, slot, STATE_EXTENSION);
 		if (!fn.empty()) {
@@ -471,7 +471,7 @@ namespace SaveState
 		}
 	}
 
-	void SaveSlot(const std::string &gameFilename, int slot, Callback callback, void *cbUserData)
+	void SaveSlot(const Path &gameFilename, int slot, Callback callback, void *cbUserData)
 	{
 		Path fn = GenerateSaveSlotFilename(gameFilename, slot, STATE_EXTENSION);
 		Path shot = GenerateSaveSlotFilename(gameFilename, slot, SCREENSHOT_EXTENSION);
@@ -506,7 +506,7 @@ namespace SaveState
 		}
 	}
 
-	bool UndoSaveSlot(const std::string &gameFilename, int slot) {
+	bool UndoSaveSlot(const Path &gameFilename, int slot) {
 		Path fn = GenerateSaveSlotFilename(gameFilename, slot, STATE_EXTENSION);
 		Path shot = GenerateSaveSlotFilename(gameFilename, slot, SCREENSHOT_EXTENSION);
 		Path fnUndo = GenerateSaveSlotFilename(gameFilename, slot, UNDO_STATE_EXTENSION);
@@ -523,19 +523,19 @@ namespace SaveState
 		return false;
 	}
 
-	bool HasSaveInSlot(const std::string &gameFilename, int slot)
+	bool HasSaveInSlot(const Path &gameFilename, int slot)
 	{
 		Path fn = GenerateSaveSlotFilename(gameFilename, slot, STATE_EXTENSION);
 		return File::Exists(fn);
 	}
 
-	bool HasUndoSaveInSlot(const std::string &gameFilename, int slot)
+	bool HasUndoSaveInSlot(const Path &gameFilename, int slot)
 	{
 		Path fn = GenerateSaveSlotFilename(gameFilename, slot, STATE_EXTENSION);
 		return File::Exists(fn.WithExtraExtension(".undo"));
 	}
 
-	bool HasScreenshotInSlot(const std::string &gameFilename, int slot)
+	bool HasScreenshotInSlot(const Path &gameFilename, int slot)
 	{
 		Path fn = GenerateSaveSlotFilename(gameFilename, slot, SCREENSHOT_EXTENSION);
 		return File::Exists(fn);
@@ -578,7 +578,7 @@ namespace SaveState
 		return true;
 	}
 
-	int GetNewestSlot(const std::string &gameFilename) {
+	int GetNewestSlot(const Path &gameFilename) {
 		int newestSlot = -1;
 		tm newestDate = {0};
 		for (int i = 0; i < NUM_SLOTS; i++) {
@@ -595,7 +595,7 @@ namespace SaveState
 		return newestSlot;
 	}
 
-	int GetOldestSlot(const std::string &gameFilename) {
+	int GetOldestSlot(const Path &gameFilename) {
 		int oldestSlot = -1;
 		tm oldestDate = {0};
 		for (int i = 0; i < NUM_SLOTS; i++) {
@@ -612,7 +612,7 @@ namespace SaveState
 		return oldestSlot;
 	}
 
-	std::string GetSlotDateAsString(const std::string &gameFilename, int slot) {
+	std::string GetSlotDateAsString(const Path &gameFilename, int slot) {
 		Path fn = GenerateSaveSlotFilename(gameFilename, slot, STATE_EXTENSION);
 		if (File::Exists(fn)) {
 			tm time;

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -42,24 +42,24 @@ namespace SaveState
 
 	// Cycle through the 5 savestate slots
 	void NextSlot();
-	void SaveSlot(const std::string &gameFilename, int slot, Callback callback, void *cbUserData = 0);
-	void LoadSlot(const std::string &gameFilename, int slot, Callback callback, void *cbUserData = 0);
-	bool UndoSaveSlot(const std::string &gameFilename, int slot);
+	void SaveSlot(const Path &gameFilename, int slot, Callback callback, void *cbUserData = 0);
+	void LoadSlot(const Path &gameFilename, int slot, Callback callback, void *cbUserData = 0);
+	bool UndoSaveSlot(const Path &gameFilename, int slot);
 	// Checks whether there's an existing save in the specified slot.
-	bool HasSaveInSlot(const std::string &gameFilename, int slot);
-	bool HasUndoSaveInSlot(const std::string &gameFilename, int slot);
-	bool HasScreenshotInSlot(const std::string &gameFilename, int slot);
+	bool HasSaveInSlot(const Path &gameFilename, int slot);
+	bool HasUndoSaveInSlot(const Path &gameFilename, int slot);
+	bool HasScreenshotInSlot(const Path &gameFilename, int slot);
 
 	int GetCurrentSlot();
 
 	// Returns -1 if there's no oldest/newest slot.
-	int GetNewestSlot(const std::string &gameFilename);
-	int GetOldestSlot(const std::string &gameFilename);
+	int GetNewestSlot(const Path &gameFilename);
+	int GetOldestSlot(const Path &gameFilename);
 	
-	std::string GetSlotDateAsString(const std::string &gameFilename, int slot);
-	Path GenerateSaveSlotFilename(const std::string &gameFilename, int slot, const char *extension);
+	std::string GetSlotDateAsString(const Path &gameFilename, int slot);
+	Path GenerateSaveSlotFilename(const Path &gameFilename, int slot, const char *extension);
 
-	std::string GetTitle(const std::string &filename);
+	std::string GetTitle(const Path &filename);
 
 	// Load the specified file into the current state (async.)
 	// Warning: callback will be called on a different thread.

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -206,7 +206,7 @@ bool DiscIDFromGEDumpPath(const Path &path, FileLoader *fileLoader, std::string 
 	}
 
 	// Fall back to using the filename.
-	std::string filename = File::GetFilename(path.ToString());
+	std::string filename = path.GetFilename();
 	// Could be more discerning, but hey..
 	if (filename.size() > 10 && filename[0] == 'U' && filename[9] == '_') {
 		*id = filename.substr(0, 9);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -676,7 +676,7 @@ void InitSysDirectories() {
 		INFO_LOG(COMMON, "Memstick directory not present, creating at '%s'", g_Config.memStickDirectory.c_str());
 	}
 
-	Path testFile = Path(g_Config.memStickDirectory) / "_writable_test.$$$";
+	Path testFile = g_Config.memStickDirectory / "_writable_test.$$$";
 
 	// If any directory is read-only, fall back to the Documents directory.
 	// We're screwed anyway if we can't write to Documents, or can't detect it.

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -696,7 +696,7 @@ void ReplacedTexture::Load(int level, void *out, int rowPitch) {
 	png_image png = {};
 	png.version = PNG_IMAGE_VERSION;
 
-	FILE *fp = File::OpenCFile(Path(info.file), "rb");
+	FILE *fp = File::OpenCFile(info.file, "rb");
 	if (!png_image_begin_read_from_stdio(&png, fp)) {
 		ERROR_LOG(G3D, "Could not load texture replacement info: %s - %s", info.file.c_str(), png.message);
 		return;
@@ -733,7 +733,7 @@ bool TextureReplacer::GenerateIni(const std::string &gameID, Path &generatedFile
 	if (gameID.empty())
 		return false;
 
-	Path texturesDirectory = Path(GetSysDirectory(DIRECTORY_TEXTURES)) / gameID;
+	Path texturesDirectory = GetSysDirectory(DIRECTORY_TEXTURES) / gameID;
 	if (!File::Exists(texturesDirectory)) {
 		File::CreateFullPath(texturesDirectory);
 	}

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -580,7 +580,7 @@ bool GameManager::InstallMemstickGame(struct zip *z, const Path &zipfile, const 
 	installInProgress_ = false;
 	installError_ = "";
 	if (deleteAfter) {
-		File::Delete(Path(zipfile));
+		File::Delete(zipfile);
 	}
 	InstallDone();
 	return true;

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -52,15 +52,15 @@ GameManager g_GameManager;
 GameManager::GameManager() {
 }
 
-std::string GameManager::GetTempFilename() const {
+Path GameManager::GetTempFilename() const {
 #ifdef _WIN32
 	wchar_t tempPath[MAX_PATH];
 	GetTempPath(MAX_PATH, tempPath);
 	wchar_t buffer[MAX_PATH];
 	GetTempFileName(tempPath, L"PSP", 1, buffer);
-	return ConvertWStringToUTF8(buffer);
+	return Path(buffer);
 #else
-	return (g_Config.memStickDirectory / "ppsspp.dl").ToString();
+	return g_Config.memStickDirectory / "ppsspp.dl";
 #endif
 }
 
@@ -79,7 +79,7 @@ bool GameManager::DownloadAndInstall(std::string storeFileUrl) {
 		return false;
 	}
 
-	std::string filename = GetTempFilename();
+	Path filename = GetTempFilename();
 	curDownload_ = g_DownloadManager.StartDownload(storeFileUrl, filename);
 	return true;
 }

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -85,7 +85,7 @@ private:
 	bool DetectTexturePackDest(struct zip *z, int iniIndex, Path &dest);
 	void SetInstallError(const std::string &err);
 
-	std::string GetTempFilename() const;
+	Path GetTempFilename() const;
 	std::string GetGameID(const Path &path) const;
 	std::string GetPBPGameID(FileLoader *loader) const;
 	std::string GetISOGameID(FileLoader *loader) const;

--- a/Qt/QtHost.cpp
+++ b/Qt/QtHost.cpp
@@ -19,9 +19,5 @@
 #include "Qt/QtHost.h"
 
 Path QtHost::SymbolMapFilename(Path currentFilename) {
-	std::string ext = currentFilename.GetFileExtension();
-	if (ext == "")
-		return currentFilename.WithExtraExtension("map");
-	else
-		return currentFilename.WithReplacedExtension(ext, "map");
+	return currentFilename.WithReplacedExtension(".map");
 }

--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -157,13 +157,13 @@ void SaveStateActionFinished(SaveState::Status status, const std::string &messag
 
 void MainWindow::qlstateAct()
 {
-	std::string gamePath = PSP_CoreParameter().fileToStart.ToString();
+	Path gamePath = PSP_CoreParameter().fileToStart;
 	SaveState::LoadSlot(gamePath, 0, SaveStateActionFinished, this);
 }
 
 void MainWindow::qsstateAct()
 {
-	std::string gamePath = PSP_CoreParameter().fileToStart.ToString();
+	Path gamePath = PSP_CoreParameter().fileToStart;
 	SaveState::SaveSlot(gamePath, 0, SaveStateActionFinished, this);
 }
 

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -1192,7 +1192,7 @@ void FrameDumpTestScreen::update() {
 	UIScreen::update();
 
 	if (!listing_) {
-		listing_ = g_DownloadManager.StartDownload(framedumpsBaseUrl, "");
+		listing_ = g_DownloadManager.StartDownload(framedumpsBaseUrl, Path());
 	}
 
 	if (listing_ && listing_->Done() && files_.empty()) {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -629,10 +629,10 @@ void EmuScreen::onVKeyDown(int virtualKeyCode) {
 		}
 		break;
 	case VIRTKEY_SAVE_STATE:
-		SaveState::SaveSlot(gamePath_.ToString(), g_Config.iCurrentStateSlot, &AfterSaveStateAction);
+		SaveState::SaveSlot(gamePath_, g_Config.iCurrentStateSlot, &AfterSaveStateAction);
 		break;
 	case VIRTKEY_LOAD_STATE:
-		SaveState::LoadSlot(gamePath_.ToString(), g_Config.iCurrentStateSlot, &AfterSaveStateAction);
+		SaveState::LoadSlot(gamePath_, g_Config.iCurrentStateSlot, &AfterSaveStateAction);
 		break;
 	case VIRTKEY_NEXT_SLOT:
 		SaveState::NextSlot();
@@ -1226,8 +1226,8 @@ void EmuScreen::update() {
 			saveStateSlot_ = currentSlot;
 
 			Path fn;
-			if (SaveState::HasSaveInSlot(gamePath_.ToString(), currentSlot)) {
-				fn = SaveState::GenerateSaveSlotFilename(gamePath_.ToString(), currentSlot, SaveState::SCREENSHOT_EXTENSION);
+			if (SaveState::HasSaveInSlot(gamePath_, currentSlot)) {
+				fn = SaveState::GenerateSaveSlotFilename(gamePath_, currentSlot, SaveState::SCREENSHOT_EXTENSION);
 			}
 
 			saveStatePreview_->SetFilename(fn);
@@ -1672,18 +1672,18 @@ void EmuScreen::autoLoad() {
 	case (int)AutoLoadSaveState::OFF: // "AutoLoad Off"
 		return;
 	case (int)AutoLoadSaveState::OLDEST: // "Oldest Save"
-		autoSlot = SaveState::GetOldestSlot(gamePath_.ToString());
+		autoSlot = SaveState::GetOldestSlot(gamePath_);
 		break;
 	case (int)AutoLoadSaveState::NEWEST: // "Newest Save"
-		autoSlot = SaveState::GetNewestSlot(gamePath_.ToString());
+		autoSlot = SaveState::GetNewestSlot(gamePath_);
 		break;
 	default: // try the specific save state slot specified
-		autoSlot = (SaveState::HasSaveInSlot(gamePath_.ToString(), g_Config.iAutoLoadSaveState - 3)) ? (g_Config.iAutoLoadSaveState - 3) : -1;
+		autoSlot = (SaveState::HasSaveInSlot(gamePath_, g_Config.iAutoLoadSaveState - 3)) ? (g_Config.iAutoLoadSaveState - 3) : -1;
 		break;
 	}
 
 	if (g_Config.iAutoLoadSaveState && autoSlot != -1) {
-		SaveState::LoadSlot(gamePath_.ToString(), autoSlot, &AfterSaveStateAction);
+		SaveState::LoadSlot(gamePath_, autoSlot, &AfterSaveStateAction);
 		g_Config.iCurrentStateSlot = autoSlot;
 	}
 }

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -206,7 +206,7 @@ bool GameInfo::LoadFromPath(const Path &gamePath) {
 		filePath_ = gamePath;
 
 		// This is a fallback title, while we're loading / if unable to load.
-		title = File::GetFilename(filePath_.ToString());
+		title = filePath_.GetFilename();
 	}
 
 	return true;

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -491,7 +491,7 @@ handleELF:
 			std::lock_guard<std::mutex> guard(info_->lock);
 
 			// Let's use the screenshot as an icon, too.
-			Path screenshotPath = gamePath_.WithReplacedExtension("ppst", "jpg");
+			Path screenshotPath = gamePath_.WithReplacedExtension(".ppst", ".jpg");
 			if (File::Exists(screenshotPath)) {
 				if (File::ReadFileToString(false, screenshotPath, info_->icon.data)) {
 					info_->icon.dataLoaded = true;

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -62,7 +62,7 @@ bool GameInfo::Delete() {
 	case IdentifiedFileType::PSP_ISO_NP:
 		{
 			// Just delete the one file (TODO: handle two-disk games as well somehow).
-			Path fileToRemove = Path(filePath_);
+			Path fileToRemove = filePath_;
 			File::Delete(fileToRemove);
 			g_Config.RemoveRecent(filePath_.ToString());
 			return true;
@@ -134,7 +134,7 @@ std::vector<Path> GameInfo::GetSaveDataDirectories() {
 	}
 	for (size_t i = 0; i < dirs.size(); i++) {
 		if (startsWith(dirs[i].name, id)) {
-			directories.push_back(Path(dirs[i].fullName));
+			directories.push_back(dirs[i].fullName);
 		}
 	}
 
@@ -155,7 +155,7 @@ u64 GameInfo::GetSaveDataSizeInBytes() {
 		// Note: GetFilesInDir does not fill in fileSize properly.
 		for (size_t i = 0; i < fileInfo.size(); i++) {
 			File::FileInfo finfo;
-			File::GetFileInfo(Path(fileInfo[i].fullName), &finfo);
+			File::GetFileInfo(fileInfo[i].fullName, &finfo);
 			if (!finfo.isDirectory)
 				filesSizeInDir += finfo.size;
 		}
@@ -182,7 +182,7 @@ u64 GameInfo::GetInstallDataSizeInBytes() {
 		// Note: GetFilesInDir does not fill in fileSize properly.
 		for (size_t i = 0; i < fileInfo.size(); i++) {
 			File::FileInfo finfo;
-			File::GetFileInfo(Path(fileInfo[i].fullName), &finfo);
+			File::GetFileInfo(fileInfo[i].fullName, &finfo);
 			if (!finfo.isDirectory)
 				filesSizeInDir += finfo.size;
 		}
@@ -235,7 +235,7 @@ bool GameInfo::DeleteAllSaveData() {
 		File::GetFilesInDir(saveDataDir[j], &fileInfo);
 
 		for (size_t i = 0; i < fileInfo.size(); i++) {
-			File::Delete(Path(fileInfo[i].fullName));
+			File::Delete(fileInfo[i].fullName);
 		}
 
 		File::DeleteDir(saveDataDir[j]);
@@ -493,7 +493,7 @@ handleELF:
 			// Let's use the screenshot as an icon, too.
 			Path screenshotPath = gamePath_.WithReplacedExtension("ppst", "jpg");
 			if (File::Exists(screenshotPath)) {
-				if (File::ReadFileToString(false, Path(screenshotPath), info_->icon.data)) {
+				if (File::ReadFileToString(false, screenshotPath, info_->icon.data)) {
 					info_->icon.dataLoaded = true;
 				} else {
 					ERROR_LOG(G3D, "Error loading screenshot data: '%s'", screenshotPath.c_str());

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -486,7 +486,7 @@ handleELF:
 
 		case IdentifiedFileType::PPSSPP_SAVESTATE:
 		{
-			info_->SetTitle(SaveState::GetTitle(gamePath_.ToString()));
+			info_->SetTitle(SaveState::GetTitle(gamePath_));
 
 			std::lock_guard<std::mutex> guard(info_->lock);
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1772,7 +1772,7 @@ UI::EventReturn DeveloperToolsScreen::OnCopyStatesToRoot(UI::EventParams &e) {
 	GetFilesInDir(savestate_dir, &files, nullptr, 0);
 
 	for (const File::FileInfo &file : files) {
-		Path src = Path(file.fullName);
+		Path src = file.fullName;
 		Path dst = root_dir / file.name;
 		INFO_LOG(SYSTEM, "Copying file '%s' to '%s'", src.c_str(), dst.c_str());
 		File::Copy(src, dst);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -429,7 +429,7 @@ static void ClearFailedGPUBackends() {
 	// In case they update drivers and have totally different problems much later, clear the failed list.
 	g_Config.sFailedGPUBackends.clear();
 	if (System_GetPropertyBool(SYSPROP_SUPPORTS_PERMISSIONS)) {
-		File::Delete(Path(GetSysDirectory(DIRECTORY_APP_CACHE)) / "FailedGraphicsBackends.txt");
+		File::Delete(GetSysDirectory(DIRECTORY_APP_CACHE) / "FailedGraphicsBackends.txt");
 	} else {
 		g_Config.Save("clearFailedGPUBackends");
 	}
@@ -1004,7 +1004,7 @@ void NativeShutdownGraphics() {
 void TakeScreenshot() {
 	g_TakeScreenshot = false;
 
-	Path path = Path(GetSysDirectory(DIRECTORY_SCREENSHOT));
+	Path path = GetSysDirectory(DIRECTORY_SCREENSHOT);
 	if (!File::Exists(path)) {
 		File::CreateDir(path);
 	}

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -206,7 +206,7 @@ public:
 	}
 
 	std::string GetScreenshotTitle() const {
-		return SaveState::GetSlotDateAsString(gamePath_.ToString(), slot_);
+		return SaveState::GetSlotDateAsString(gamePath_, slot_);
 	}
 
 	UI::Event OnStateLoaded;
@@ -229,7 +229,7 @@ private:
 SaveSlotView::SaveSlotView(const Path &gameFilename, int slot, UI::LayoutParams *layoutParams) : UI::LinearLayout(UI::ORIENT_HORIZONTAL, layoutParams), slot_(slot), gamePath_(gameFilename) {
 	using namespace UI;
 
-	screenshotFilename_ = SaveState::GenerateSaveSlotFilename(gamePath_.ToString(), slot, SaveState::SCREENSHOT_EXTENSION);
+	screenshotFilename_ = SaveState::GenerateSaveSlotFilename(gamePath_, slot, SaveState::SCREENSHOT_EXTENSION);
 	Add(new Spacer(5));
 
 	AsyncImageFileView *fv = Add(new AsyncImageFileView(screenshotFilename_, IS_DEFAULT, new UI::LayoutParams(82 * 2, 47 * 2)));
@@ -246,11 +246,11 @@ SaveSlotView::SaveSlotView(const Path &gameFilename, int slot, UI::LayoutParams 
 
 	fv->OnClick.Handle(this, &SaveSlotView::OnScreenshotClick);
 
-	if (SaveState::HasSaveInSlot(gamePath_.ToString(), slot)) {
+	if (SaveState::HasSaveInSlot(gamePath_, slot)) {
 		loadStateButton_ = buttons->Add(new Button(pa->T("Load State"), new LinearLayoutParams(0.0, G_VCENTER)));
 		loadStateButton_->OnClick.Handle(this, &SaveSlotView::OnLoadState);
 
-		std::string dateStr = SaveState::GetSlotDateAsString(gamePath_.ToString(), slot_);
+		std::string dateStr = SaveState::GetSlotDateAsString(gamePath_, slot_);
 		std::vector<std::string> dateStrs;
 		SplitString(dateStr, ' ', dateStrs);
 		if (!dateStrs.empty() && !dateStrs[0].empty()) {
@@ -281,7 +281,7 @@ static void AfterSaveStateAction(SaveState::Status status, const std::string &me
 
 UI::EventReturn SaveSlotView::OnLoadState(UI::EventParams &e) {
 	g_Config.iCurrentStateSlot = slot_;
-	SaveState::LoadSlot(gamePath_.ToString(), slot_, &AfterSaveStateAction);
+	SaveState::LoadSlot(gamePath_, slot_, &AfterSaveStateAction);
 	UI::EventParams e2{};
 	e2.v = this;
 	OnStateLoaded.Trigger(e2);
@@ -290,7 +290,7 @@ UI::EventReturn SaveSlotView::OnLoadState(UI::EventParams &e) {
 
 UI::EventReturn SaveSlotView::OnSaveState(UI::EventParams &e) {
 	g_Config.iCurrentStateSlot = slot_;
-	SaveState::SaveSlot(gamePath_.ToString(), slot_, &AfterSaveStateAction);
+	SaveState::SaveSlot(gamePath_, slot_, &AfterSaveStateAction);
 	UI::EventParams e2{};
 	e2.v = this;
 	OnStateSaved.Trigger(e2);
@@ -408,7 +408,7 @@ void GamePauseScreen::dialogFinished(const Screen *dialog, DialogResult dr) {
 		ScreenshotViewScreen *s = (ScreenshotViewScreen *)dialog;
 		int slot = s->GetSlot();
 		g_Config.iCurrentStateSlot = slot;
-		SaveState::LoadSlot(gamePath_.ToString(), slot, &AfterSaveStateAction);
+		SaveState::LoadSlot(gamePath_, slot, &AfterSaveStateAction);
 
 		finishNextFrame_ = true;
 	} else {
@@ -421,7 +421,7 @@ UI::EventReturn GamePauseScreen::OnScreenshotClicked(UI::EventParams &e) {
 	SaveSlotView *v = static_cast<SaveSlotView *>(e.v);
 	int slot = v->GetSlot();
 	g_Config.iCurrentStateSlot = v->GetSlot();
-	if (SaveState::HasSaveInSlot(gamePath_.ToString(), slot)) {
+	if (SaveState::HasSaveInSlot(gamePath_, slot)) {
 		Path fn = v->GetScreenshotFilename();
 		std::string title = v->GetScreenshotTitle();
 		auto pa = GetI18NCategory("Pause");

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -159,7 +159,7 @@ void AsyncImageFileView::Draw(UIContext &dc) {
 
 class ScreenshotViewScreen : public PopupScreen {
 public:
-	ScreenshotViewScreen(Path filename, std::string title, int slot, std::shared_ptr<I18NCategory> i18n)
+	ScreenshotViewScreen(const Path &filename, std::string title, int slot, std::shared_ptr<I18NCategory> i18n)
 		: PopupScreen(title, i18n->T("Load State"), "Back"), filename_(filename), slot_(slot) {}   // PopupScreen will translate Back on its own
 
 	int GetSlot() const {

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -114,7 +114,7 @@ public:
 		} else {
 			Path image_path = savePath_.WithReplacedExtension(".ppst", ".jpg");
 			if (File::Exists(image_path)) {
-				toprow->Add(new AsyncImageFileView(Path(image_path), IS_KEEP_ASPECT, new LinearLayoutParams(480, 272, Margins(10, 0))));
+				toprow->Add(new AsyncImageFileView(image_path, IS_KEEP_ASPECT, new LinearLayoutParams(480, 272, Margins(10, 0))));
 			} else {
 				toprow->Add(new TextView(sa->T("No screenshot"), new LinearLayoutParams(Margins(10, 5))))->SetTextColor(textStyle.fgColor);
 			}

--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -134,7 +134,7 @@ void HttpImageFileView::DownloadCompletedCallback(http::Download &download) {
 void HttpImageFileView::Draw(UIContext &dc) {
 	using namespace Draw;
 	if (!texture_ && !textureFailed_ && !path_.empty() && !download_) {
-		download_ = downloader_->StartDownloadWithCallback(path_, "", std::bind(&HttpImageFileView::DownloadCompletedCallback, this, std::placeholders::_1));
+		download_ = downloader_->StartDownloadWithCallback(path_, Path(), std::bind(&HttpImageFileView::DownloadCompletedCallback, this, std::placeholders::_1));
 		download_->SetHidden(true);
 	}
 
@@ -367,7 +367,7 @@ StoreScreen::StoreScreen() {
 
 	std::string indexPath = storeBaseUrl + "index.json";
 
-	listing_ = g_DownloadManager.StartDownload(indexPath, "");
+	listing_ = g_DownloadManager.StartDownload(indexPath, Path());
 }
 
 StoreScreen::~StoreScreen() {

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -96,8 +96,7 @@ PPSSPP_UWPMain::PPSSPP_UWPMain(App ^app, const std::shared_ptr<DX::DeviceResourc
 	char controlsConfigFilename[MAX_PATH] = { 0 };
 
 	std::wstring memstickFolderW = ApplicationData::Current->LocalFolder->Path->Data();
-
-	g_Config.memStickDirectory = Path(ReplaceAll(ConvertWStringToUTF8(memstickFolderW), "\\", "/"));
+	g_Config.memStickDirectory = Path(memstickFolderW);
 
 	// On Win32 it makes more sense to initialize the system directories here
 	// because the next place it was called was in the EmuThread, and it's too late by then.

--- a/UWP/UWPHost.cpp
+++ b/UWP/UWPHost.cpp
@@ -121,36 +121,27 @@ void UWPHost::BootDone() {
 	Core_EnableStepping(false);
 }
 
-static Path SymbolMapFilename(const char *currentFilename, const char *ext) {
+static Path SymbolMapFilename(const Path &currentFilename, const char *ext) {
 	File::FileInfo info;
-
-	std::string result = currentFilename;
-
 	// can't fail, definitely exists if it gets this far
-	File::GetFileInfo(Path(currentFilename), &info);
+	File::GetFileInfo(currentFilename, &info);
 	if (info.isDirectory) {
-		return Path(result) / (std::string(".ppsspp-symbols") + ext);
-	} else {
-		size_t dot = result.rfind('.');
-		if (dot == result.npos)
-			return Path(result + ext);
-
-		result.replace(dot, result.npos, ext);
-		return Path(result);
+		return currentFilename / (std::string(".ppsspp-symbols") + ext);
 	}
+	return currentFilename.WithReplacedExtension(ext);
 }
 
 bool UWPHost::AttemptLoadSymbolMap() {
-	bool result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".ppmap"));
+	bool result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart, ".ppmap"));
 	// Load the old-style map file.
 	if (!result1)
-		result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".map"));
-	bool result2 = g_symbolMap->LoadNocashSym(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".sym"));
+		result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart, ".map"));
+	bool result2 = g_symbolMap->LoadNocashSym(SymbolMapFilename(PSP_CoreParameter().fileToStart, ".sym"));
 	return result1 || result2;
 }
 
 void UWPHost::SaveSymbolMap() {
-	g_symbolMap->SaveSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".ppmap"));
+	g_symbolMap->SaveSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart, ".ppmap"));
 }
 
 void UWPHost::NotifySymbolMapUpdated() {

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -681,7 +681,7 @@ namespace MainWindow {
 		case ID_FILE_QUICKLOADSTATE:
 		{
 			SetCursor(LoadCursor(0, IDC_WAIT));
-			SaveState::LoadSlot(PSP_CoreParameter().fileToStart.ToString(), g_Config.iCurrentStateSlot, SaveStateActionFinished);
+			SaveState::LoadSlot(PSP_CoreParameter().fileToStart, g_Config.iCurrentStateSlot, SaveStateActionFinished);
 			break;
 		}
 
@@ -690,14 +690,14 @@ namespace MainWindow {
 			if (KeyMap::g_controllerMap[VIRTKEY_LOAD_STATE].empty())
 			{
 				SetCursor(LoadCursor(0, IDC_WAIT));
-				SaveState::LoadSlot(PSP_CoreParameter().fileToStart.ToString(), g_Config.iCurrentStateSlot, SaveStateActionFinished);
+				SaveState::LoadSlot(PSP_CoreParameter().fileToStart, g_Config.iCurrentStateSlot, SaveStateActionFinished);
 			}
 			break;
 		}
 		case ID_FILE_QUICKSAVESTATE:
 		{
 			SetCursor(LoadCursor(0, IDC_WAIT));
-			SaveState::SaveSlot(PSP_CoreParameter().fileToStart.ToString(), g_Config.iCurrentStateSlot, SaveStateActionFinished);
+			SaveState::SaveSlot(PSP_CoreParameter().fileToStart, g_Config.iCurrentStateSlot, SaveStateActionFinished);
 			break;
 		}
 
@@ -706,7 +706,7 @@ namespace MainWindow {
 			if (KeyMap::g_controllerMap[VIRTKEY_SAVE_STATE].empty())
 			{
 				SetCursor(LoadCursor(0, IDC_WAIT));
-				SaveState::SaveSlot(PSP_CoreParameter().fileToStart.ToString(), g_Config.iCurrentStateSlot, SaveStateActionFinished);
+				SaveState::SaveSlot(PSP_CoreParameter().fileToStart, g_Config.iCurrentStateSlot, SaveStateActionFinished);
 				break;
 			}
 			break;

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -268,39 +268,30 @@ void WindowsHost::BootDone() {
 	SetDebugMode(!g_Config.bAutoRun);
 }
 
-static Path SymbolMapFilename(const char *currentFilename, const char* ext) {
+static Path SymbolMapFilename(const Path &currentFilename, const char *ext) {
 	File::FileInfo info;
-
-	std::string result = currentFilename;
-
 	// can't fail, definitely exists if it gets this far
-	File::GetFileInfo(Path(currentFilename), &info);
+	File::GetFileInfo(currentFilename, &info);
 	if (info.isDirectory) {
-		return Path(result) / (std::string(".ppsspp-symbols") + ext);
-	} else {
-		const size_t dot = result.rfind('.');
-		if (dot == result.npos)
-			return Path(result + ext);
-
-		result.replace(dot, result.npos, ext);
-		return Path(result);
+		return currentFilename / (std::string(".ppsspp-symbols") + ext);
 	}
+	return currentFilename.WithReplacedExtension(ext);
 }
 
 bool WindowsHost::AttemptLoadSymbolMap() {
 	if (!g_symbolMap)
 		return false;
-	bool result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".ppmap"));
+	bool result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart, ".ppmap"));
 	// Load the old-style map file.
 	if (!result1)
-		result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".map"));
-	bool result2 = g_symbolMap->LoadNocashSym(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(), ".sym"));
+		result1 = g_symbolMap->LoadSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart, ".map"));
+	bool result2 = g_symbolMap->LoadNocashSym(SymbolMapFilename(PSP_CoreParameter().fileToStart, ".sym"));
 	return result1 || result2;
 }
 
 void WindowsHost::SaveSymbolMap() {
 	if (g_symbolMap)
-		g_symbolMap->SaveSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart.c_str(),".ppmap"));
+		g_symbolMap->SaveSymbolMap(SymbolMapFilename(PSP_CoreParameter().fileToStart, ".ppmap"));
 }
 
 void WindowsHost::NotifySymbolMapUpdated() {

--- a/headless/Compare.cpp
+++ b/headless/Compare.cpp
@@ -209,7 +209,7 @@ std::string GetTestName(const Path &bootFilename)
 }
 
 bool CompareOutput(const Path &bootFilename, const std::string &output, bool verbose) {
-	Path expect_filename = bootFilename.WithReplacedExtension("prx", "expected");
+	Path expect_filename = bootFilename.WithReplacedExtension(".prx", ".expected");
 	std::unique_ptr<FileLoader> expect_loader(ConstructFileLoader(expect_filename));
 
 	if (expect_loader->Exists()) {
@@ -271,7 +271,7 @@ bool CompareOutput(const Path &bootFilename, const std::string &output, bool ver
 				printf("%s", output.c_str());
 				printf("============== expected output:\n");
 				std::string fullExpected;
-				if (File::ReadFileToString(true, Path(expect_filename), fullExpected))
+				if (File::ReadFileToString(true, expect_filename, fullExpected))
 					printf("%s", fullExpected.c_str());
 				printf("===============================\n");
 			}


### PR DESCRIPTION
There were a few places we had extension replacement wrong (no dot.)

Otherwise cleans up some places still using strings and some places unnecessarily copying Path.

-[Unknown]