### PR TITLE
Further Path cleanup

### DIFF
--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -560,36 +560,6 @@ bool Move(const Path &srcFilename, const Path &destFilename) {
 	}
 }
 
-std::string GetDir(const std::string &path) {
-	if (path == "/")
-		return path;
-	int n = (int)path.size() - 1;
-	while (n >= 0 && path[n] != '\\' && path[n] != '/')
-		n--;
-	std::string cutpath = n > 0 ? path.substr(0, n) : "";
-	for (size_t i = 0; i < cutpath.size(); i++) {
-		if (cutpath[i] == '\\') cutpath[i] = '/';
-	}
-#ifndef _WIN32
-	if (!cutpath.size()) {
-		return "/";
-	}
-#endif
-	return cutpath;
-}
-
-std::string GetFileExtension(const std::string & fn) {
-	size_t pos = fn.rfind(".");
-	if (pos == std::string::npos) {
-		return "";
-	}
-	std::string ext = fn.substr(pos);
-	for (size_t i = 0; i < ext.size(); i++) {
-		ext[i] = tolower(ext[i]);
-	}
-	return ext;
-}
-
 // Returns the size of file (64bit)
 // TODO: Add a way to return an error.
 uint64_t GetFileSize(const std::string &filename) {

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -731,21 +731,17 @@ void OpenFileInEditor(const Path &fileName) {
 #endif
 }
 
-const std::string &GetExeDirectory() {
-	static std::string ExePath;
+const Path &GetExeDirectory() {
+	static Path ExePath;
 
 	if (ExePath.empty()) {
 #ifdef _WIN32
-#ifdef UNICODE
 		std::wstring program_path;
-#else
-		std::string program_path;
-#endif
 		size_t sz;
 		do {
 			program_path.resize(program_path.size() + MAX_PATH);
 			// On failure, this will return the same value as passed in, but success will always be one lower.
-			sz = GetModuleFileName(nullptr, &program_path[0], (DWORD)program_path.size());
+			sz = GetModuleFileNameW(nullptr, &program_path[0], (DWORD)program_path.size());
 		} while (sz >= program_path.size());
 
 		const wchar_t *last_slash = wcsrchr(&program_path[0], '\\');
@@ -753,11 +749,7 @@ const std::string &GetExeDirectory() {
 			program_path.resize(last_slash - &program_path[0] + 1);
 		else
 			program_path.resize(sz);
-#ifdef UNICODE
-		ExePath = ConvertWStringToUTF8(program_path);
-#else
-		ExePath = program_path;
-#endif
+		ExePath = Path(program_path);
 
 #elif (defined(__APPLE__) && !PPSSPP_PLATFORM(IOS)) || defined(__linux__) || defined(KERN_PROC_PATHNAME)
 		char program_path[4096];
@@ -789,9 +781,9 @@ const std::string &GetExeDirectory() {
 		{
 			program_path[sizeof(program_path) - 1] = '\0';
 			char *last_slash = strrchr(program_path, '/');
-			if (last_slash != NULL)
-				*(last_slash + 1) = '\0';
-			ExePath = program_path;
+			if (last_slash != nullptr)
+				*last_slash = '\0';
+			ExePath = Path(program_path);
 		}
 #endif
 	}

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -562,10 +562,10 @@ bool Move(const Path &srcFilename, const Path &destFilename) {
 
 // Returns the size of file (64bit)
 // TODO: Add a way to return an error.
-uint64_t GetFileSize(const std::string &filename) {
+uint64_t GetFileSize(const Path &filename) {
 #if defined(_WIN32) && defined(UNICODE)
 	WIN32_FILE_ATTRIBUTE_DATA attr;
-	if (!GetFileAttributesEx(ConvertUTF8ToWString(filename).c_str(), GetFileExInfoStandard, &attr))
+	if (!GetFileAttributesEx(filename.ToWString().c_str(), GetFileExInfoStandard, &attr))
 		return 0;
 	if (attr.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 		return 0;
@@ -579,14 +579,14 @@ uint64_t GetFileSize(const std::string &filename) {
 	int result = stat64(filename.c_str(), &file_info);
 #endif
 	if (result != 0) {
-		WARN_LOG(COMMON, "GetSize: failed %s: No such file", filename.c_str());
+		WARN_LOG(COMMON, "GetSize: failed %s: No such file", filename.ToVisualString().c_str());
 		return 0;
 	}
 	if (S_ISDIR(file_info.st_mode)) {
-		WARN_LOG(COMMON, "GetSize: failed %s: is a directory", filename.c_str());
+		WARN_LOG(COMMON, "GetSize: failed %s: is a directory", filename.ToVisualString().c_str());
 		return 0;
 	}
-	DEBUG_LOG(COMMON, "GetSize: %s: %lld", filename.c_str(), (long long)file_info.st_size);
+	DEBUG_LOG(COMMON, "GetSize: %s: %lld", filename.ToVisualString().c_str(), (long long)file_info.st_size);
 	return file_info.st_size;
 #endif
 }

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -791,28 +791,21 @@ const Path &GetExeDirectory() {
 	return ExePath;
 }
 
-IOFile::IOFile()
-	: m_file(NULL), m_good(true)
-{}
+IOFile::IOFile() {}
 
 IOFile::IOFile(std::FILE* file)
-	: m_file(file), m_good(true)
+	: m_file(file)
 {}
 
-IOFile::IOFile(const std::string& filename, const char openmode[])
-	: m_file(NULL), m_good(true)
-{
+IOFile::IOFile(const std::string &filename, const char openmode[]) {
 	Open(filename, openmode);
 }
 
-IOFile::IOFile(const Path &filename, const char openmode[]) 
-	: m_file(NULL), m_good(true)
-{
+IOFile::IOFile(const Path &filename, const char openmode[])  {
 	Open(filename.ToString(), openmode);
 }
 
-IOFile::~IOFile()
-{
+IOFile::~IOFile() {
 	Close();
 }
 

--- a/Common/File/FileUtil.h
+++ b/Common/File/FileUtil.h
@@ -53,12 +53,6 @@ bool ExistsInDir(const Path &path, const std::string &filename);
 // Supports Android content URIs.
 bool IsDirectory(const Path &filename);
 
-// Parses the extension out from a filename.
-std::string GetFileExtension(const std::string &filename);
-
-// Extracts the directory from a path.
-std::string GetDir(const std::string &path);
-
 // Returns struct with modification date of file
 bool GetModifTime(const Path &filename, tm &return_time);
 

--- a/Common/File/FileUtil.h
+++ b/Common/File/FileUtil.h
@@ -100,7 +100,7 @@ bool CreateEmptyFile(const Path &filename);
 void OpenFileInEditor(const Path &fileName);
 
 // TODO: Belongs in System or something.
-const std::string &GetExeDirectory();
+const Path &GetExeDirectory();
 
 // simple wrapper for cstdlib file functions to
 // hopefully will make error checking easier

--- a/Common/File/FileUtil.h
+++ b/Common/File/FileUtil.h
@@ -57,7 +57,7 @@ bool IsDirectory(const Path &filename);
 bool GetModifTime(const Path &filename, tm &return_time);
 
 // Returns the size of filename (64bit)
-uint64_t GetFileSize(const std::string &filename);
+uint64_t GetFileSize(const Path &filename);
 
 // Overloaded GetSize, accepts FILE*
 uint64_t GetFileSize(FILE *f);

--- a/Common/File/FileUtil.h
+++ b/Common/File/FileUtil.h
@@ -109,7 +109,6 @@ class IOFile {
 public:
 	IOFile();
 	IOFile(FILE* file);
-	IOFile(const std::string& filename, const char openmode[]);
 	IOFile(const Path &filename, const char openmode[]);
 	~IOFile();
 
@@ -117,7 +116,6 @@ public:
 	IOFile(const IOFile &) = delete;
 	void operator=(const IOFile &) = delete;
 
-	bool Open(const std::string& filename, const char openmode[]);
 	bool Open(const Path &filename, const char openmode[]);
 	bool Close();
 
@@ -149,11 +147,11 @@ public:
 		return WriteArray(reinterpret_cast<const char*>(data), length);
 	}
 
-	bool IsOpen() { return NULL != m_file; }
+	bool IsOpen() const { return nullptr != m_file; }
 
 	// m_good is set to false when a read, write or other function fails
-	bool IsGood() {	return m_good; }
-	operator void*() { return m_good ? m_file : NULL; }
+	bool IsGood() const { return m_good; }
+	operator bool() const { return IsGood() && IsOpen(); }
 
 	std::FILE* ReleaseHandle();
 
@@ -175,8 +173,11 @@ public:
 	}
 
 private:
-	std::FILE *m_file;
-	bool m_good;
+	IOFile(const std::string &filename, const char openmode[]);
+	bool Open(const std::string &filename, const char openmode[]);
+
+	std::FILE *m_file = nullptr;
+	bool m_good = true;
 };
 
 // TODO: Refactor, this was moved from the old file_util.cpp.

--- a/Common/File/VFS/AssetReader.cpp
+++ b/Common/File/VFS/AssetReader.cpp
@@ -166,61 +166,30 @@ bool ZipAssetReader::GetFileInfo(const char *path, File::FileInfo *info) {
 
 #endif
 
-DirectoryAssetReader::DirectoryAssetReader(const char *path) {
-	strncpy(path_, path, ARRAY_SIZE(path_));
-	path_[ARRAY_SIZE(path_) - 1] = '\0';
+DirectoryAssetReader::DirectoryAssetReader(const Path &path) {
+	path_ = path;
 }
 
 uint8_t *DirectoryAssetReader::ReadAsset(const char *path, size_t *size) {
-	char new_path[2048];
-	new_path[0] = '\0';
-	// Check if it already contains the path
-	if (strlen(path) > strlen(path_) && 0 == memcmp(path, path_, strlen(path_))) {
-	}
-	else {
-		strcpy(new_path, path_);
-	}
-	strcat(new_path, path);
-	return File::ReadLocalFile(new_path, size);
+	Path new_path = Path(path).StartsWith(path_) ? Path(path) : path_ / path;
+	return File::ReadLocalFile(new_path.c_str(), size);
 }
 
-bool DirectoryAssetReader::GetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter = 0)
-{
-	char new_path[2048];
-	new_path[0] = '\0';
-	// Check if it already contains the path
-	if (strlen(path) > strlen(path_) && 0 == memcmp(path, path_, strlen(path_))) {
-	}
-	else {
-		strcpy(new_path, path_);
-	}
-	strcat(new_path, path);
+bool DirectoryAssetReader::GetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter = nullptr) {
+	Path new_path = Path(path).StartsWith(path_) ? Path(path) : path_ / path;
 
 	File::FileInfo info;
-	if (!File::GetFileInfo(Path(new_path), &info))
+	if (!File::GetFileInfo(new_path, &info))
 		return false;
 
-	if (info.isDirectory)
-	{
-		File::GetFilesInDir(Path(new_path), listing, filter);
+	if (info.isDirectory) {
+		File::GetFilesInDir(new_path, listing, filter);
 		return true;
 	}
-	else
-	{
-		return false;
-	}
+	return false;
 }
 
-bool DirectoryAssetReader::GetFileInfo(const char *path, File::FileInfo *info)
-{
-	char new_path[2048];
-	new_path[0] = '\0';
-	// Check if it already contains the path
-	if (strlen(path) > strlen(path_) && 0 == memcmp(path, path_, strlen(path_))) {
-	}
-	else {
-		strcpy(new_path, path_);
-	}
-	strcat(new_path, path);
-	return File::GetFileInfo(Path(new_path), info);
+bool DirectoryAssetReader::GetFileInfo(const char *path, File::FileInfo *info) {
+	Path new_path = Path(path).StartsWith(path_) ? Path(path) : path_ / path;
+	return File::GetFileInfo(new_path, info);
 }

--- a/Common/File/VFS/AssetReader.h
+++ b/Common/File/VFS/AssetReader.h
@@ -10,6 +10,7 @@
 
 #include "Common/File/VFS/VFS.h"
 #include "Common/File/FileUtil.h"
+#include "Common/File/Path.h"
 
 class AssetReader {
 public:
@@ -44,16 +45,16 @@ private:
 
 class DirectoryAssetReader : public AssetReader {
 public:
-	explicit DirectoryAssetReader(const char *path);
+	explicit DirectoryAssetReader(const Path &path);
 	// use delete[]
 	virtual uint8_t *ReadAsset(const char *path, size_t *size);
 	virtual bool GetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter);
 	virtual bool GetFileInfo(const char *path, File::FileInfo *info);
 	virtual std::string toString() const {
-		return path_;
+		return path_.ToString();
 	}
 
 private:
-	char path_[512]{};
+	Path path_;
 };
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -478,11 +478,11 @@ public:
 
 	// Various directories. Autoconfigured, not read from ini.
 	std::string currentDirectory;
-	std::string externalDirectory;
+	Path externalDirectory;
 	Path memStickDirectory;
 	Path flash0Directory;
-	std::string internalDataDirectory;
-	std::string appCacheDirectory;
+	Path internalDataDirectory;
+	Path appCacheDirectory;
 
 	// Data for upgrade prompt
 	std::string upgradeMessage;  // The actual message from the server is currently not used, need a translation mechanism. So this just acts as a flag.

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -142,7 +142,7 @@ void VirtualDiscFileSystem::LoadFileListIndex() {
 				ERROR_LOG(FILESYS, "Unable to open virtual file: %s", entry.fileName.c_str());
 			}
 		} else {
-			entry.totalSize = File::GetFileSize(GetLocalPath(entry.fileName).ToString());
+			entry.totalSize = File::GetFileSize(GetLocalPath(entry.fileName));
 		}
 
 		// Try to keep currentBlockIndex sane, in case there are other files.
@@ -291,7 +291,7 @@ int VirtualDiscFileSystem::getFileListIndex(std::string &fileName)
 
 	FileListEntry entry = {""};
 	entry.fileName = normalized;
-	entry.totalSize = File::GetFileSize(fullName.ToString());
+	entry.totalSize = File::GetFileSize(fullName);
 	entry.firstBlock = currentBlockIndex;
 	currentBlockIndex += (entry.totalSize+2047)/2048;
 

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -627,7 +627,7 @@ void InitSysDirectories() {
 	if (!g_Config.memStickDirectory.empty() && !g_Config.flash0Directory.empty())
 		return;
 
-	const Path path = Path(File::GetExeDirectory());
+	const Path &path = File::GetExeDirectory();
 
 	// Mount a filesystem
 	g_Config.flash0Directory = path / "assets/flash0";

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -605,7 +605,7 @@ Path GetSysDirectory(PSPDirectories directoryType) {
 		return g_Config.memStickDirectory / "PSP/PLUGINS";
 	case DIRECTORY_APP_CACHE:
 		if (!g_Config.appCacheDirectory.empty()) {
-			return Path(g_Config.appCacheDirectory);
+			return g_Config.appCacheDirectory;
 		}
 		return g_Config.memStickDirectory / "PSP/SYSTEM/CACHE";
 	case DIRECTORY_VIDEO:
@@ -638,7 +638,7 @@ void InitSysDirectories() {
 
 #else
 	// Caller sets this to the Documents folder.
-	const Path rootMyDocsPath = Path(g_Config.internalDataDirectory);
+	const Path rootMyDocsPath = g_Config.internalDataDirectory;
 	const Path myDocsPath = rootMyDocsPath / "PPSSPP";
 	const Path installedFile = path / "installed.txt";
 	const bool installed = File::Exists(installedFile);

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -159,7 +159,7 @@ static Path LocalFromRemotePath(const std::string &path) {
 }
 
 static void DiscHandler(const http::Request &request, const Path &filename) {
-	s64 sz = File::GetFileSize(filename.ToString());
+	s64 sz = File::GetFileSize(filename);
 
 	std::string range;
 	if (request.Method() == http::RequestHeader::HEAD) {

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -590,9 +590,9 @@ void SystemInfoScreen::CreateViews() {
 	storage->Add(new ItemHeader(si->T("Directories")));
 	// Intentionally non-translated
 	storage->Add(new InfoItem("MemStickDirectory", g_Config.memStickDirectory.ToVisualString()));
-	storage->Add(new InfoItem("InternalDataDirectory", g_Config.internalDataDirectory));
-	storage->Add(new InfoItem("AppCacheDir", g_Config.appCacheDirectory));
-	storage->Add(new InfoItem("ExtStorageDir", g_Config.externalDirectory));
+	storage->Add(new InfoItem("InternalDataDirectory", g_Config.internalDataDirectory.ToVisualString()));
+	storage->Add(new InfoItem("AppCacheDir", g_Config.appCacheDirectory.ToVisualString()));
+	storage->Add(new InfoItem("ExtStorageDir", g_Config.externalDirectory.ToVisualString()));
 
 #if PPSSPP_PLATFORM(ANDROID)
 	storage->Add(new InfoItem("ExtFilesDir", g_extFilesDir));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -945,7 +945,7 @@ void GameSettingsScreen::CreateViews() {
 	SavePathInOtherChoice->OnClick.Handle(this, &GameSettingsScreen::OnSavePathOther);
 	const bool myDocsExists = W32Util::UserDocumentsPath().size() != 0;
 
-	const Path PPSSPPpath = Path(File::GetExeDirectory());
+	const Path &PPSSPPpath = File::GetExeDirectory();
 	const Path installedFile = PPSSPPpath / "installed.txt";
 	installed_ = File::Exists(installedFile);
 	otherinstalled_ = false;
@@ -1134,7 +1134,7 @@ UI::EventReturn GameSettingsScreen::OnChangeMemStickDir(UI::EventParams &e) {
 #elif defined(_WIN32) && !PPSSPP_PLATFORM(UWP)
 
 UI::EventReturn GameSettingsScreen::OnSavePathMydoc(UI::EventParams &e) {
-	const Path PPSSPPpath = Path(File::GetExeDirectory());
+	const Path &PPSSPPpath = File::GetExeDirectory();
 	const Path installedFile = installedFile / "installed.txt";
 	installed_ = File::Exists(installedFile);
 	if (otherinstalled_) {
@@ -1161,7 +1161,7 @@ UI::EventReturn GameSettingsScreen::OnSavePathMydoc(UI::EventParams &e) {
 }
 
 UI::EventReturn GameSettingsScreen::OnSavePathOther(UI::EventParams &e) {
-	const Path PPSSPPpath = Path(File::GetExeDirectory());
+	const Path &PPSSPPpath = File::GetExeDirectory();
 	if (otherinstalled_) {
 		auto di = GetI18NCategory("Dialog");
 		std::string folder = W32Util::BrowseForFolder(MainWindow::GetHWND(), di->T("Choose PPSSPP save folder"));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1295,7 +1295,7 @@ void GameSettingsScreen::CallbackMemstickFolder(bool yes) {
 	auto sy = GetI18NCategory("System");
 
 	if (yes) {
-		std::string memstickDirFile = g_Config.internalDataDirectory + "/memstick_dir.txt";
+		Path memstickDirFile = g_Config.internalDataDirectory / "memstick_dir.txt";
 		std::string testWriteFile = pendingMemstickFolder_ + "/.write_verify_file";
 
 		// Already, create away.
@@ -1308,7 +1308,7 @@ void GameSettingsScreen::CallbackMemstickFolder(bool yes) {
 		}
 		File::Delete(Path(testWriteFile));
 
-		File::WriteDataToFile(true, pendingMemstickFolder_.c_str(), (unsigned int)pendingMemstickFolder_.size(), Path(memstickDirFile));
+		File::WriteDataToFile(true, pendingMemstickFolder_.c_str(), (unsigned int)pendingMemstickFolder_.size(), memstickDirFile);
 		// Save so the settings, at least, are transferred.
 		g_Config.memStickDirectory = Path(pendingMemstickFolder_);
 		g_Config.Save("MemstickPathChanged");

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -460,26 +460,26 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	// We want this to be FIRST.
 #if PPSSPP_PLATFORM(IOS)
 	// Packed assets are included in app
-	VFSRegister("", new DirectoryAssetReader(external_dir));
+	VFSRegister("", new DirectoryAssetReader(Path(external_dir)));
 #endif
 #if defined(ASSETS_DIR)
-	VFSRegister("", new DirectoryAssetReader(ASSETS_DIR));
+	VFSRegister("", new DirectoryAssetReader(Path(ASSETS_DIR)));
 #endif
 #if !defined(MOBILE_DEVICE) && !defined(_WIN32) && !PPSSPP_PLATFORM(SWITCH)
-	VFSRegister("", new DirectoryAssetReader((File::GetExeDirectory() + "assets/").c_str()));
-	VFSRegister("", new DirectoryAssetReader((File::GetExeDirectory()).c_str()));
-	VFSRegister("", new DirectoryAssetReader("/usr/local/share/ppsspp/assets/"));
-	VFSRegister("", new DirectoryAssetReader("/usr/local/share/games/ppsspp/assets/"));
-	VFSRegister("", new DirectoryAssetReader("/usr/share/ppsspp/assets/"));
-	VFSRegister("", new DirectoryAssetReader("/usr/share/games/ppsspp/assets/"));
+	VFSRegister("", new DirectoryAssetReader(Path(File::GetExeDirectory()) / "assets"));
+	VFSRegister("", new DirectoryAssetReader(Path(File::GetExeDirectory())));
+	VFSRegister("", new DirectoryAssetReader(Path("/usr/local/share/ppsspp/assets")));
+	VFSRegister("", new DirectoryAssetReader(Path("/usr/local/share/games/ppsspp/assets")));
+	VFSRegister("", new DirectoryAssetReader(Path("/usr/share/ppsspp/assets")));
+	VFSRegister("", new DirectoryAssetReader(Path("/usr/share/games/ppsspp/assets")));
 #endif
 #if PPSSPP_PLATFORM(SWITCH)
-	std::string assetPath = user_data_path + "assets/";
-	VFSRegister("", new DirectoryAssetReader(assetPath.c_str()));
+	Path assetPath = Path(user_data_path) / "assets";
+	VFSRegister("", new DirectoryAssetReader(assetPath));
 #else
-	VFSRegister("", new DirectoryAssetReader("assets/"));
+	VFSRegister("", new DirectoryAssetReader(Path("assets")));
 #endif
-	VFSRegister("", new DirectoryAssetReader(savegame_dir));
+	VFSRegister("", new DirectoryAssetReader(Path(savegame_dir)));
 
 #if (defined(MOBILE_DEVICE) || !defined(USING_QT_UI)) && !PPSSPP_PLATFORM(UWP)
 	if (host == nullptr) {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -321,9 +321,9 @@ static void PostLoadConfig() {
 #ifndef _WIN32
 	if (g_Config.currentDirectory.empty()) {
 #if defined(__ANDROID__)
-		g_Config.currentDirectory = g_Config.externalDirectory;
+		g_Config.currentDirectory = g_Config.externalDirectory.ToString();
 #elif PPSSPP_PLATFORM(IOS)
-		g_Config.currentDirectory = g_Config.internalDataDirectory;
+		g_Config.currentDirectory = g_Config.internalDataDirectory.ToString();
 #elif PPSSPP_PLATFORM(SWITCH)
 		g_Config.currentDirectory = "/";
 #else
@@ -487,8 +487,8 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	}
 #endif
 
-	g_Config.internalDataDirectory = savegame_dir;
-	g_Config.externalDirectory = external_dir;
+	g_Config.internalDataDirectory = Path(savegame_dir);
+	g_Config.externalDirectory = Path(external_dir);
 
 #if defined(__ANDROID__)
 	// TODO: This needs to change in Android 12.
@@ -499,7 +499,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	g_Config.memStickDirectory = Path(external_dir);
 	g_Config.flash0Directory = Path(external_dir) / "flash0";
 
-	Path memstickDirFile = Path(g_Config.internalDataDirectory) / "memstick_dir.txt";
+	Path memstickDirFile = g_Config.internalDataDirectory / "memstick_dir.txt";
 	if (File::Exists(memstickDirFile)) {
 		std::string memstickDir;
 		File::ReadFileToString(true, memstickDirFile, memstickDir);
@@ -514,8 +514,8 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	g_Config.memStickDirectory = Path(user_data_path);
 	g_Config.flash0Directory = Path(std::string(external_dir)) / "flash0";
 #elif PPSSPP_PLATFORM(SWITCH)
-	g_Config.memStickDirectory = Path(g_Config.internalDataDirectory) / "config/ppsspp";
-	g_Config.flash0Directory = Path(g_Config.internalDataDirectory) / "assets/flash0";
+	g_Config.memStickDirectory = g_Config.internalDataDirectory / "config/ppsspp";
+	g_Config.flash0Directory = g_Config.internalDataDirectory / "assets/flash0";
 #elif !PPSSPP_PLATFORM(WINDOWS)
 	std::string config;
 	if (getenv("XDG_CONFIG_HOME") != NULL)
@@ -530,8 +530,8 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 #endif
 
 	if (cache_dir && strlen(cache_dir)) {
-		DiskCachingFileLoaderCache::SetCacheDir(Path(cache_dir));
-		g_Config.appCacheDirectory = cache_dir;
+		g_Config.appCacheDirectory = Path(cache_dir);
+		DiskCachingFileLoaderCache::SetCacheDir(g_Config.appCacheDirectory);
 	}
 
 	if (!LogManager::GetInstance())

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -466,8 +466,8 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	VFSRegister("", new DirectoryAssetReader(Path(ASSETS_DIR)));
 #endif
 #if !defined(MOBILE_DEVICE) && !defined(_WIN32) && !PPSSPP_PLATFORM(SWITCH)
-	VFSRegister("", new DirectoryAssetReader(Path(File::GetExeDirectory()) / "assets"));
-	VFSRegister("", new DirectoryAssetReader(Path(File::GetExeDirectory())));
+	VFSRegister("", new DirectoryAssetReader(File::GetExeDirectory() / "assets"));
+	VFSRegister("", new DirectoryAssetReader(File::GetExeDirectory()));
 	VFSRegister("", new DirectoryAssetReader(Path("/usr/local/share/ppsspp/assets")));
 	VFSRegister("", new DirectoryAssetReader(Path("/usr/local/share/games/ppsspp/assets")));
 	VFSRegister("", new DirectoryAssetReader(Path("/usr/share/ppsspp/assets")));
@@ -526,7 +526,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 		config = "./config";
 
 	g_Config.memStickDirectory = Path(config) / "ppsspp";
-	g_Config.flash0Directory = Path(File::GetExeDirectory()) / "assets/flash0";
+	g_Config.flash0Directory = File::GetExeDirectory() / "assets/flash0";
 #endif
 
 	if (cache_dir && strlen(cache_dir)) {

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -76,7 +76,7 @@ PPSSPP_UWPMain::PPSSPP_UWPMain(App ^app, const std::shared_ptr<DX::DeviceResourc
 
 	ctx_.reset(new UWPGraphicsContext(deviceResources));
 
-	const Path exePath = Path(File::GetExeDirectory());
+	const Path &exePath = File::GetExeDirectory();
 	VFSRegister("", new DirectoryAssetReader(exePath / "Content"));
 	VFSRegister("", new DirectoryAssetReader(exePath));
 

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -76,9 +76,9 @@ PPSSPP_UWPMain::PPSSPP_UWPMain(App ^app, const std::shared_ptr<DX::DeviceResourc
 
 	ctx_.reset(new UWPGraphicsContext(deviceResources));
 
-	const std::string &exePath = File::GetExeDirectory();
-	VFSRegister("", new DirectoryAssetReader((exePath + "/Content/").c_str()));
-	VFSRegister("", new DirectoryAssetReader(exePath.c_str()));
+	const Path exePath = Path(File::GetExeDirectory());
+	VFSRegister("", new DirectoryAssetReader(exePath / "Content"));
+	VFSRegister("", new DirectoryAssetReader(exePath));
 
 	wchar_t lcCountry[256];
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -527,9 +527,9 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	bool showLog = true;
 #endif
 
-	const std::string &exePath = File::GetExeDirectory();
-	VFSRegister("", new DirectoryAssetReader((exePath + "/assets/").c_str()));
-	VFSRegister("", new DirectoryAssetReader(exePath.c_str()));
+	const Path exePath = Path(File::GetExeDirectory());
+	VFSRegister("", new DirectoryAssetReader(exePath / "assets"));
+	VFSRegister("", new DirectoryAssetReader(exePath));
 
 	langRegion = GetDefaultLangRegion();
 	osName = GetWindowsVersion() + " " + GetWindowsSystemArchitecture();

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -527,7 +527,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	bool showLog = true;
 #endif
 
-	const Path exePath = Path(File::GetExeDirectory());
+	const Path &exePath = File::GetExeDirectory();
 	VFSRegister("", new DirectoryAssetReader(exePath / "assets"));
 	VFSRegister("", new DirectoryAssetReader(exePath));
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -562,7 +562,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	// On Win32 it makes more sense to initialize the system directories here
 	// because the next place it was called was in the EmuThread, and it's too late by then.
-	g_Config.internalDataDirectory = W32Util::UserDocumentsPath();
+	g_Config.internalDataDirectory = Path(W32Util::UserDocumentsPath());
 	InitSysDirectories();
 
 	// Check for the Vulkan workaround before any serious init.

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -420,7 +420,7 @@ int main(int argc, const char* argv[])
 	}
 	// Or else, maybe in the executable's dir.
 	if (!File::Exists(g_Config.flash0Directory))
-		g_Config.flash0Directory = Path(File::GetExeDirectory()) / "assets/flash0";
+		g_Config.flash0Directory = File::GetExeDirectory() / "assets/flash0";
 
 	if (screenshotFilename != 0)
 		headlessHost->SetComparisonScreenshot(Path(std::string(screenshotFilename)));

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -403,7 +403,7 @@ int main(int argc, const char* argv[])
 	g_Config.iPSPModel = PSP_MODEL_SLIM;
 
 #ifdef _WIN32
-	g_Config.internalDataDirectory = "";
+	g_Config.internalDataDirectory.clear();
 	InitSysDirectories();
 #endif
 

--- a/headless/SDLHeadlessHost.cpp
+++ b/headless/SDLHeadlessHost.cpp
@@ -103,9 +103,9 @@ private:
 };
 
 void SDLHeadlessHost::LoadNativeAssets() {
-	VFSRegister("", new DirectoryAssetReader("assets/"));
-	VFSRegister("", new DirectoryAssetReader(""));
-	VFSRegister("", new DirectoryAssetReader("../"));
+	VFSRegister("", new DirectoryAssetReader(Path("assets")));
+	VFSRegister("", new DirectoryAssetReader(Path("")));
+	VFSRegister("", new DirectoryAssetReader(Path("..")));
 }
 
 bool GLDummyGraphicsContext::InitFromRenderThread(std::string *errorMessage) {

--- a/headless/WindowsHeadlessHost.cpp
+++ b/headless/WindowsHeadlessHost.cpp
@@ -68,11 +68,11 @@ HWND CreateHiddenWindow() {
 
 void WindowsHeadlessHost::LoadNativeAssets()
 {
-	VFSRegister("", new DirectoryAssetReader("assets/"));
-	VFSRegister("", new DirectoryAssetReader(""));
-	VFSRegister("", new DirectoryAssetReader("../"));
-	VFSRegister("", new DirectoryAssetReader("../Windows/assets/"));
-	VFSRegister("", new DirectoryAssetReader("../Windows/"));
+	VFSRegister("", new DirectoryAssetReader(Path("assets")));
+	VFSRegister("", new DirectoryAssetReader(Path("")));
+	VFSRegister("", new DirectoryAssetReader(Path("..")));
+	VFSRegister("", new DirectoryAssetReader(Path("../Windows/assets")));
+	VFSRegister("", new DirectoryAssetReader(Path("../Windows")));
 }
 
 void WindowsHeadlessHost::SendDebugOutput(const std::string &output)

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -559,8 +559,8 @@ namespace Libretro
 
 bool retro_load_game(const struct retro_game_info *game)
 {
-   static std::string retro_base_dir;
-   static std::string retro_save_dir;
+   static Path retro_base_dir;
+   static Path retro_save_dir;
    std::string error_string;
    enum retro_pixel_format fmt          = RETRO_PIXEL_FORMAT_XRGB8888;
    const char *nickname                 = NULL;
@@ -600,41 +600,28 @@ bool retro_load_game(const struct retro_game_info *game)
    if (environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &dir_ptr) 
          && dir_ptr)
    {
-      size_t last;
-      retro_base_dir = dir_ptr;
-      // Make sure that we don't have any lingering slashes, etc, as they break Windows.
-      last = retro_base_dir.find_last_not_of(DIR_SEP_CHRS);
-      if (last != std::string::npos)
-         last++;
-
-      retro_base_dir = retro_base_dir.substr(0, last) + DIR_SEP;
+      retro_base_dir = Path(dir_ptr);
    }
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &dir_ptr) 
          && dir_ptr)
    {
-      retro_save_dir = dir_ptr;
-      // Make sure that we don't have any lingering slashes, etc, as they break Windows.
-      size_t last = retro_save_dir.find_last_not_of(DIR_SEP_CHRS);
-      if (last != std::string::npos)
-         last++;
-
-      retro_save_dir = retro_save_dir.substr(0, last) + DIR_SEP;
+      retro_save_dir = Path(dir_ptr);
    }
 
    if (retro_base_dir.empty())
-      retro_base_dir = File::GetDir(game->path);
+      retro_base_dir = Path(game->path).NavigateUp();
 
-   retro_base_dir            += "PPSSPP" DIR_SEP;
+   retro_base_dir            /= "PPSSPP";
 
    if (retro_save_dir.empty())
-      retro_save_dir = File::GetDir(game->path);
+      retro_save_dir = Path(game->path).NavigateUp();
 
-   g_Config.currentDirectory      = retro_base_dir;
-   g_Config.externalDirectory     = retro_base_dir;
-   g_Config.memStickDirectory     = Path(retro_save_dir);
-   g_Config.flash0Directory       = Path(retro_base_dir) / "flash0";
-   g_Config.internalDataDirectory = retro_base_dir;
+   g_Config.currentDirectory      = retro_base_dir.ToString();
+   g_Config.externalDirectory     = retro_base_dir.ToString();
+   g_Config.memStickDirectory     = retro_save_dir;
+   g_Config.flash0Directory       = retro_base_dir / "flash0";
+   g_Config.internalDataDirectory = retro_base_dir.ToString();
 
    VFSRegister("", new DirectoryAssetReader(retro_base_dir.c_str()));
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -618,10 +618,10 @@ bool retro_load_game(const struct retro_game_info *game)
       retro_save_dir = Path(game->path).NavigateUp();
 
    g_Config.currentDirectory      = retro_base_dir.ToString();
-   g_Config.externalDirectory     = retro_base_dir.ToString();
+   g_Config.externalDirectory     = retro_base_dir;
    g_Config.memStickDirectory     = retro_save_dir;
    g_Config.flash0Directory       = retro_base_dir / "flash0";
-   g_Config.internalDataDirectory = retro_base_dir.ToString();
+   g_Config.internalDataDirectory = retro_base_dir;
 
    VFSRegister("", new DirectoryAssetReader(retro_base_dir.c_str()));
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -623,7 +623,7 @@ bool retro_load_game(const struct retro_game_info *game)
    g_Config.flash0Directory       = retro_base_dir / "flash0";
    g_Config.internalDataDirectory = retro_base_dir;
 
-   VFSRegister("", new DirectoryAssetReader(retro_base_dir.c_str()));
+   VFSRegister("", new DirectoryAssetReader(retro_base_dir));
 
    coreState = CORE_POWERUP;
    ctx       = LibretroGraphicsContext::CreateGraphicsContext();


### PR DESCRIPTION
This might have some small conflicts with #14232, just because it makes a few more things Path instead of string.

This largely cleans up things that can be simpler now with Path, or are redundant with Path.  I also made it so the base path for DirectoryAssetReader is a Path, just for consistency (I realize it won't be an Android URI, but I want it to be obvious to anyone in the codebase that Path is how you address files.)

-[Unknown]