### PR TITLE
Add support for ZIMs in texture replacements

### DIFF
--- a/Common/Data/Format/ZIMSave.h
+++ b/Common/Data/Format/ZIMSave.h
@@ -11,4 +11,4 @@
 // * Generate mipmaps if requested
 // * Convert images to the requested format
 // Input image is always 8888 RGBA. SaveZIM takes care of downsampling and mipmap generation.
-void SaveZIM(FILE *f, int width, int height, int pitch, int format, const uint8_t *image);
+void SaveZIM(FILE *f, int width, int height, int pitch, int format, const uint8_t *image, int compressLevel = 0);

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -456,7 +456,10 @@ bool TextureReplacer::PopulateLevel(ReplacedTextureLevel &level) {
 		fseek(fp, 4, SEEK_SET);
 		fread(&level.w, 1, 4, fp);
 		fread(&level.h, 1, 4, fp);
-		good = true;
+		int flags;
+		if (fread(&flags, 1, 4, fp) == 4) {
+			good = (flags & ZIM_FORMAT_MASK) == ZIM_RGBA8888;
+		}
 	} else if (imageType == ReplacedImageType::PNG) {
 		png_image png = {};
 		png.version = PNG_IMAGE_VERSION;

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -204,6 +204,7 @@ protected:
 	std::string LookupHashFile(u64 cachekey, u32 hash, int level);
 	std::string HashName(u64 cachekey, u32 hash, int level);
 	void PopulateReplacement(ReplacedTexture *result, u64 cachekey, u32 hash, int w, int h);
+	bool PopulateLevel(ReplacedTextureLevel &level);
 
 	SimpleBuf<u32> saveBuf;
 	bool enabled_ = false;

--- a/ext/native/tools/zimtool.cpp
+++ b/ext/native/tools/zimtool.cpp
@@ -14,7 +14,7 @@ const char *format_strings[4] = { "8888", "4444", "565", "ETC1" };
 int formats[3] = { ZIM_RGBA8888, ZIM_RGBA4444, ZIM_RGB565 };
 
 void printusage() {
-	fprintf(stderr, "Usage: zimtool infile.png outfile.zim [-f=FORMAT] [-m] [-g]\n");
+	fprintf(stderr, "Usage: zimtool infile.png outfile.zim [-f=FORMAT] [-m] [-g] [-z[LEVEL]]\n");
 	fprintf(stderr, "Formats: 8888 4444 565 ETC1\n");
 }
 
@@ -40,6 +40,7 @@ int main(int argc, char **argv) {
 	}
 
 	int flags = 0;
+	int level = 0;
 	bool format_set = false;
 	for (int i = 3; i < argc; i++) {
 		if (argv[i][0] != '-') {
@@ -68,6 +69,16 @@ int main(int argc, char **argv) {
 			}
 		}
 		break;
+		case 'z':
+			flags |= ZIM_ZSTD_COMPRESSED;
+			if (argv[i][2] != '\0') {
+				int pos = 2;
+				while (argv[i][pos] >= '0' && argv[i][pos] <= '9') {
+					level = level * 10 + argv[i][pos] - '0';
+					pos++;
+				}
+			}
+			break;
 		}
 	}
 	// TODO: make setting?
@@ -87,7 +98,7 @@ int main(int argc, char **argv) {
 	}
 
 	FILE *f = fopen(FLAGS_outfile, "wb");
-	SaveZIM(f, width, height, width * 4, flags, image_data);
+	SaveZIM(f, width, height, width * 4, flags, image_data, level);
 	fclose(f);
 	int in_file_size = filesize(FLAGS_infile);
 	int out_file_size = filesize(FLAGS_outfile);


### PR DESCRIPTION
This makes zimtool (built as ext\native\tools\build\ZimTool.exe on Windows) able to compress using ZSTD, and then supports such images in texture replacements.  Only 8888 is supported.

I realize we could support more exotic formats, but this was a very easy format to support given our codebase already handles it.

To test, I hacked replacements to always reload the texture and went to an area with primarily a single 512x512 texture upscaled to 1024x1024.  Then I measured different image types:

 * PNG: 1x speed
 * ZIM, ZSTD level 22: 2.75x speed
 * ZIM, ZSTD level 12: 3x speed
 * ZIM, uncompressed: 4x speed

Most of the time was in `fread()` when uncompressed.  Importantly, this was the same image over and over again - so this doesn't measure the stresses of a large texture pack accurately.  Still, ZIMs load much faster.

In my tests, ZIMs were about 25% larger on disk at level 22 (keep in mind there are no PNG filters at play here), and less than 50% larger at level 12.  Uncompressed was obviously much larger.

-[Unknown]