### PR TITLE
Fix remote disc browsing, support subfolders

### DIFF
--- a/Common/File/PathBrowser.cpp
+++ b/Common/File/PathBrowser.cpp
@@ -149,7 +149,7 @@ void PathBrowser::HandlePath() {
 		return;
 	}
 
-	if (path_.Type() == PathType::HTTP) {
+	if (path_.Type() != PathType::HTTP) {
 		if (pendingActive_)
 			ResetPending();
 		ready_ = true;

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -541,12 +541,16 @@ UI::EventReturn GameBrowser::StorageClick(UI::EventParams &e) {
 }
 
 UI::EventReturn GameBrowser::HomeClick(UI::EventParams &e) {
-#if PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(SWITCH) || defined(USING_WIN_UI) || PPSSPP_PLATFORM(UWP)
-	SetPath(g_Config.memStickDirectory);
-#else
-	SetPath(Path(getenv("HOME")));
-#endif
+	SetPath(HomePath());
 	return UI::EVENT_DONE;
+}
+
+Path GameBrowser::HomePath() {
+#if PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(SWITCH) || defined(USING_WIN_UI) || PPSSPP_PLATFORM(UWP)
+	return g_Config.memStickDirectory;
+#else
+	return Path(getenv("HOME"));
+#endif
 }
 
 UI::EventReturn GameBrowser::PinToggleClick(UI::EventParams &e) {

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -57,6 +57,7 @@ public:
 protected:
 	virtual bool DisplayTopBar();
 	virtual bool HasSpecialFiles(std::vector<Path> &filenames);
+	virtual Path HomePath();
 
 	void Refresh();
 


### PR DESCRIPTION
This fixes a mistake in the Path code that broke browsing remote paths.

While there, this improves navigation when a remote path contains subfolders (i.e. form the text index file), only allowing navigating up when sensible etc.

Finally, it also makes the experience in the remote browser have more of the browsing/UI and makes the home button go back to the root of the sharing.  This will make it easier to tie in future features, like filtering the list (search.)

-[Unknown]