### PR TITLE
Fix FixPathCase bug when constructing the full path.

### DIFF
--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -151,8 +151,8 @@ bool FixPathCase(const std::string &basePath, std::string &path, FixPathCaseBeha
 
 			path.replace(start, i - start, component);
 
-			fullPath.append(component);
 			fullPath.append(1, '/');
+			fullPath.append(component);
 		}
 
 		start = i + 1;


### PR DESCRIPTION
For some reason the slash was appended after the component, not before.
Swap the order to enable saving in-game in *nix.