### PR TITLE
UI: Ignore duplicate axis events

### DIFF
--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -106,6 +106,17 @@ bool ScreenManager::key(const KeyInput &key) {
 
 bool ScreenManager::axis(const AxisInput &axis) {
 	std::lock_guard<std::recursive_mutex> guard(inputLock_);
+
+	// Ignore duplicate values to prevent axis values overwriting each other.
+	uint64_t key = ((uint64_t)axis.axisId << 32) | axis.deviceId;
+	// Center value far from zero just to ensure we send the first zero.
+	// PSP games can't see higher resolution than this.
+	int value = 128 + ceilf(axis.value * 127.5f + 127.5f);
+	if (lastAxis_[key] == value) {
+		return false;
+	}
+	lastAxis_[key] = value;
+
 	bool result = false;
 	// Send center axis to every screen layer.
 	if (axis.value == 0) {

--- a/Common/UI/Screen.h
+++ b/Common/UI/Screen.h
@@ -13,9 +13,11 @@
 
 #pragma once
 
-#include <vector>
+#include <cstdint>
 #include <mutex>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "Common/Common.h"
 #include "Common/Input/InputState.h"
@@ -165,4 +167,6 @@ private:
 	// Used for options, in-game menus and other things you expect to be able to back out from onto something.
 	std::vector<Layer> stack_;
 	std::vector<Layer> nextStack_;
+
+	std::unordered_map<int64_t, int> lastAxis_;
 };

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -864,16 +864,6 @@ void EmuScreen::pspKey(int pspKeyCode, int flags) {
 bool EmuScreen::axis(const AxisInput &axis) {
 	Core_NotifyActivity();
 
-	// Ignore duplicate values to prevent axis values overwriting each other.
-	uint64_t key = ((uint64_t)axis.axisId << 32) | axis.deviceId;
-	// Center value far from zero just to ensure we send the first zero.
-	// PSP games can't see higher resolution than this.
-	int value = 128 + ceilf(axis.value * 127.5f + 127.5f);
-	if (lastAxis_[key] == value) {
-		return false;
-	}
-	lastAxis_[key] = value;
-
 	if (axis.value > 0) {
 		processAxis(axis, 1);
 		return true;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -864,6 +864,16 @@ void EmuScreen::pspKey(int pspKeyCode, int flags) {
 bool EmuScreen::axis(const AxisInput &axis) {
 	Core_NotifyActivity();
 
+	// Ignore duplicate values to prevent axis values overwriting each other.
+	uint64_t key = ((uint64_t)axis.axisId << 32) | axis.deviceId;
+	// Center value far from zero just to ensure we send the first zero.
+	// PSP games can't see higher resolution than this.
+	int value = 128 + ceilf(axis.value * 127.5f + 127.5f);
+	if (lastAxis_[key] == value) {
+		return false;
+	}
+	lastAxis_[key] = value;
+
 	if (axis.value > 0) {
 		processAxis(axis, 1);
 		return true;

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -17,9 +17,11 @@
 
 #pragma once
 
-#include <string>
-#include <vector>
+#include <cstdint>
 #include <list>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "Common/File/Path.h"
 #include "Common/Input/KeyCodes.h"
@@ -113,4 +115,5 @@ private:
 
 	bool autoRotatingAnalogCW_ = false;
 	bool autoRotatingAnalogCCW_ = false;
+	std::unordered_map<int64_t, int> lastAxis_;
 };

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -17,10 +17,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <list>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 #include "Common/File/Path.h"
@@ -115,5 +113,4 @@ private:
 
 	bool autoRotatingAnalogCW_ = false;
 	bool autoRotatingAnalogCCW_ = false;
-	std::unordered_map<int64_t, int> lastAxis_;
 };

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -200,9 +200,6 @@ DinputDevice::~DinputDevice() {
 }
 
 void SendNativeAxis(int deviceId, int value, int &lastValue, int axisId) {
-	if (value == lastValue)
-		return;
-
 	AxisInput axis;
 	axis.deviceId = deviceId;
 	axis.axisId = axisId;

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -282,54 +282,34 @@ void XinputDevice::UpdatePad(int pad, const XINPUT_STATE &state, XINPUT_VIBRATIO
 	const float STICK_INV_DEADZONE = g_Config.fXInputAnalogInverseDeadzone;
 	const float STICK_SENSITIVITY = g_Config.fXInputAnalogSensitivity;
 
+	AxisInput axis;
+	axis.deviceId = DEVICE_ID_X360_0 + pad;
+	auto sendAxis = [&](AndroidJoystickAxis axisId, float value) {
+		axis.axisId = axisId;
+		axis.value = value;
+		NativeAxis(axis);
+	};
+
 	if (NormalizedDeadzoneDiffers(prevState[pad].Gamepad.sThumbLX, prevState[pad].Gamepad.sThumbLY, state.Gamepad.sThumbLX, state.Gamepad.sThumbLY, STICK_DEADZONE)) {
 		Stick left = NormalizedDeadzoneFilter(state.Gamepad.sThumbLX, state.Gamepad.sThumbLY, STICK_DEADZONE, STICK_INV_MODE, STICK_INV_DEADZONE, STICK_SENSITIVITY);
 
-		AxisInput axis;
-		axis.deviceId = DEVICE_ID_X360_0 + pad;
-		axis.axisId = JOYSTICK_AXIS_X;
-		axis.value = left.x;
-		if (prevState[pad].Gamepad.sThumbLX != state.Gamepad.sThumbLX) {
-			NativeAxis(axis);
-		}
-		axis.axisId = JOYSTICK_AXIS_Y;
-		axis.value = left.y;
-		if (prevState[pad].Gamepad.sThumbLY != state.Gamepad.sThumbLY) {
-			NativeAxis(axis);
-		}
+		sendAxis(JOYSTICK_AXIS_X, left.x);
+		sendAxis(JOYSTICK_AXIS_Y, left.y);
 	}
 
 	if (NormalizedDeadzoneDiffers(prevState[pad].Gamepad.sThumbRX, prevState[pad].Gamepad.sThumbRY, state.Gamepad.sThumbRX, state.Gamepad.sThumbRY, STICK_DEADZONE)) {
 		Stick right = NormalizedDeadzoneFilter(state.Gamepad.sThumbRX, state.Gamepad.sThumbRY, STICK_DEADZONE, STICK_INV_MODE, STICK_INV_DEADZONE, STICK_SENSITIVITY);
 
-		AxisInput axis;
-		axis.deviceId = DEVICE_ID_X360_0 + pad;
-		axis.axisId = JOYSTICK_AXIS_Z;
-		axis.value = right.x;
-		if (prevState[pad].Gamepad.sThumbRX != state.Gamepad.sThumbRX) {
-			NativeAxis(axis);
-		}
-		axis.axisId = JOYSTICK_AXIS_RZ;
-		axis.value = right.y;
-		if (prevState[pad].Gamepad.sThumbRY != state.Gamepad.sThumbRY) {
-			NativeAxis(axis);
-		}
+		sendAxis(JOYSTICK_AXIS_Z, right.x);
+		sendAxis(JOYSTICK_AXIS_RZ, right.y);
 	}
 
 	if (NormalizedDeadzoneDiffers(prevState[pad].Gamepad.bLeftTrigger, state.Gamepad.bLeftTrigger, XINPUT_GAMEPAD_TRIGGER_THRESHOLD)) {
-		AxisInput axis;
-		axis.deviceId = DEVICE_ID_X360_0 + pad;
-		axis.axisId = JOYSTICK_AXIS_LTRIGGER;
-		axis.value = (float)state.Gamepad.bLeftTrigger / 255.0f;
-		NativeAxis(axis);
+		sendAxis(JOYSTICK_AXIS_LTRIGGER, (float)state.Gamepad.bLeftTrigger / 255.0f);
 	}
 
 	if (NormalizedDeadzoneDiffers(prevState[pad].Gamepad.bRightTrigger, state.Gamepad.bRightTrigger, XINPUT_GAMEPAD_TRIGGER_THRESHOLD)) {
-		AxisInput axis;
-		axis.deviceId = DEVICE_ID_X360_0 + pad;
-		axis.axisId = JOYSTICK_AXIS_RTRIGGER;
-		axis.value = (float)state.Gamepad.bRightTrigger / 255.0f;
-		NativeAxis(axis);
+		sendAxis(JOYSTICK_AXIS_RTRIGGER, (float)state.Gamepad.bRightTrigger / 255.0f);
 	}
 
 	prevState[pad] = state;


### PR DESCRIPTION
We already ignore these on Windows, so this makes other platforms follow the same logic.

See #14440.  Generally, we don't want to process the analog value again if it's unchanged so that moving analog sticks has a more obvious impact.

Of course, we still need to apply deadzone more generically, etc. but this should help those mapping issues.

-[Unknown]