### PR TITLE
Configurable analog head size

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1024,6 +1024,10 @@ static ConfigSetting controlSettings[] = {
 
 	ConfigSetting("AnalogLimiterDeadzone", &g_Config.fAnalogLimiterDeadzone, 0.6f, true, true),
 
+	ConfigSetting("LeftStickHeadScale", &g_Config.fLeftStickHeadScale, 1.0f, true, true),
+	ConfigSetting("RightStickHeadScale", &g_Config.fRightStickHeadScale, 1.0f, true, true),
+	ConfigSetting("HideStickBackground", &g_Config.bHideStickBackground, false, true, true),
+
 	ConfigSetting("UseMouse", &g_Config.bMouseControl, false, true, true),
 	ConfigSetting("MapMouse", &g_Config.bMapMouse, false, true, true),
 	ConfigSetting("ConfineMap", &g_Config.bMouseConfine, false, true, true),
@@ -1850,6 +1854,8 @@ void Config::ResetControlLayout() {
 	reset(g_Config.touchCombo7);
 	reset(g_Config.touchCombo8);
 	reset(g_Config.touchCombo9);
+	g_Config.fLeftStickHeadScale = 1.0f;
+	g_Config.fRightStickHeadScale = 1.0f;
 }
 
 void Config::GetReportingInfo(UrlEncoder &data) {

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -366,6 +366,10 @@ public:
 	ConfigTouchPos touchCombo8;
 	ConfigTouchPos touchCombo9;
 
+	float fLeftStickHeadScale;
+	float fRightStickHeadScale;
+	bool bHideStickBackground;
+
 	// Controls Visibility
 	bool bShowTouchControls;
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -704,6 +704,10 @@ void GameSettingsScreen::CreateViews() {
 		CheckBox *floatingAnalog = controlsSettings->Add(new CheckBox(&g_Config.bAutoCenterTouchAnalog, co->T("Auto-centering analog stick")));
 		floatingAnalog->SetEnabledPtr(&g_Config.bShowTouchControls);
 
+		// Hide stick background, usefull when increasing the size
+		CheckBox *hideStickBackground = controlsSettings->Add(new CheckBox(&g_Config.bHideStickBackground, co->T("Hide touch analog stick background circle")));
+		hideStickBackground->SetEnabledPtr(&g_Config.bShowTouchControls);
+
 		// On non iOS systems, offer to let the user see this button.
 		// Some Windows touch devices don't have a back button or other button to call up the menu.
 		if (System_GetPropertyBool(SYSPROP_HAS_BACK_BUTTON)) {

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -351,6 +351,8 @@ PSPStick::PSPStick(ImageID bgImg, const char *key, ImageID stickImg, ImageID sti
 
 void PSPStick::GetContentDimensions(const UIContext &dc, float &w, float &h) const {
 	dc.Draw()->GetAtlas()->measureImage(bgImg_, &w, &h);
+	w *= scale_;
+	h *= scale_;
 }
 
 void PSPStick::Draw(UIContext &dc) {
@@ -376,10 +378,12 @@ void PSPStick::Draw(UIContext &dc) {
 	float dx, dy;
 	__CtrlPeekAnalog(stick_, &dx, &dy);
 
-	dc.Draw()->DrawImage(bgImg_, stickX, stickY, 1.0f * scale_, colorBg, ALIGN_CENTER);
+	if (!g_Config.bHideStickBackground)
+		dc.Draw()->DrawImage(bgImg_, stickX, stickY, 1.0f * scale_, colorBg, ALIGN_CENTER);
+	float headScale = stick_ ? g_Config.fRightStickHeadScale : g_Config.fLeftStickHeadScale;
 	if (dragPointerId_ != -1 && g_Config.iTouchButtonStyle == 2 && stickDownImg_ != stickImageIndex_)
-		dc.Draw()->DrawImage(stickDownImg_, stickX + dx * stick_size_ * scale_, stickY - dy * stick_size_ * scale_, 1.0f * scale_, downBg, ALIGN_CENTER);
-	dc.Draw()->DrawImage(stickImageIndex_, stickX + dx * stick_size_ * scale_, stickY - dy * stick_size_ * scale_, 1.0f * scale_, colorBg, ALIGN_CENTER);
+		dc.Draw()->DrawImage(stickDownImg_, stickX + dx * stick_size_ * scale_, stickY - dy * stick_size_ * scale_, 1.0f * scale_ * headScale, downBg, ALIGN_CENTER);
+	dc.Draw()->DrawImage(stickImageIndex_, stickX + dx * stick_size_ * scale_, stickY - dy * stick_size_ * scale_, 1.0f * scale_ * headScale, colorBg, ALIGN_CENTER);
 }
 
 void PSPStick::Touch(const TouchInput &input) {
@@ -392,7 +396,8 @@ void PSPStick::Touch(const TouchInput &input) {
 		return;
 	}
 	if (input.flags & TOUCH_DOWN) {
-		if (dragPointerId_ == -1 && bounds_.Contains(input.x, input.y)) {
+		float fac = 0.5f*(stick_ ? g_Config.fRightStickHeadScale : g_Config.fLeftStickHeadScale)-0.5f;
+		if (dragPointerId_ == -1 && bounds_.Expand(bounds_.w*fac, bounds_.h*fac).Contains(input.x, input.y)) {
 			if (g_Config.bAutoCenterTouchAnalog) {
 				centerX_ = input.x;
 				centerY_ = input.y;
@@ -472,10 +477,11 @@ void PSPCustomStick::Draw(UIContext &dc) {
 	dx = posX_;
 	dy = -posY_;
 
-	dc.Draw()->DrawImage(bgImg_, stickX, stickY, 1.0f * scale_, colorBg, ALIGN_CENTER);
+	if (!g_Config.bHideStickBackground)
+		dc.Draw()->DrawImage(bgImg_, stickX, stickY, 1.0f * scale_, colorBg, ALIGN_CENTER);
 	if (dragPointerId_ != -1 && g_Config.iTouchButtonStyle == 2 && stickDownImg_ != stickImageIndex_)
-		dc.Draw()->DrawImage(stickDownImg_, stickX + dx * stick_size_ * scale_, stickY - dy * stick_size_ * scale_, 1.0f * scale_, downBg, ALIGN_CENTER);
-	dc.Draw()->DrawImage(stickImageIndex_, stickX + dx * stick_size_ * scale_, stickY - dy * stick_size_ * scale_, 1.0f * scale_, colorBg, ALIGN_CENTER);
+		dc.Draw()->DrawImage(stickDownImg_, stickX + dx * stick_size_ * scale_, stickY - dy * stick_size_ * scale_, 1.0f*scale_*g_Config.fRightStickHeadScale, downBg, ALIGN_CENTER);
+	dc.Draw()->DrawImage(stickImageIndex_, stickX + dx * stick_size_ * scale_, stickY - dy * stick_size_ * scale_, 1.0f*scale_*g_Config.fRightStickHeadScale, colorBg, ALIGN_CENTER);
 }
 
 void PSPCustomStick::Touch(const TouchInput &input) {
@@ -489,7 +495,8 @@ void PSPCustomStick::Touch(const TouchInput &input) {
 		return;
 	}
 	if (input.flags & TOUCH_DOWN) {
-		if (dragPointerId_ == -1 && bounds_.Contains(input.x, input.y)) {
+		float fac = 0.5f*g_Config.fRightStickHeadScale-0.5f;
+		if (dragPointerId_ == -1 && bounds_.Expand(bounds_.w*fac, bounds_.h*fac).Contains(input.x, input.y)) {
 			if (g_Config.bAutoCenterTouchAnalog) {
 				centerX_ = input.x;
 				centerY_ = input.y;

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -284,6 +284,35 @@ private:
 	float &spacing_;
 };
 
+class PSPStickDragDrop : public DragDropButton {
+public:
+	PSPStickDragDrop(ConfigTouchPos &pos, const char *key, ImageID bgImg, ImageID img, const Bounds &screenBounds, float &spacing)
+		: DragDropButton(pos, key, bgImg, img, screenBounds), spacing_(spacing) {
+	}
+
+	void Draw(UIContext &dc) override {
+		float opacity = g_Config.iTouchButtonOpacity / 100.0f;
+
+		uint32_t colorBg = colorAlpha(GetButtonColor(), opacity);
+		uint32_t downBg = colorAlpha(0x00FFFFFF, opacity * 0.5f);
+
+		const ImageID stickImage = g_Config.iTouchButtonStyle ? ImageID("I_STICK_LINE") : ImageID("I_STICK");
+		const ImageID stickBg = g_Config.iTouchButtonStyle ? ImageID("I_STICK_BG_LINE") : ImageID("I_STICK_BG");
+
+		dc.Draw()->DrawImage(stickBg, bounds_.centerX(), bounds_.centerY(), scale_, colorBg, ALIGN_CENTER);
+		dc.Draw()->DrawImage(stickImage, bounds_.centerX(), bounds_.centerY(), scale_ * spacing_, colorBg, ALIGN_CENTER);
+	}
+
+	float GetSpacing() const override { return spacing_; }
+	void SetSpacing(float s) override {
+		// In mapping spacing is clamped between 0.5 and 3.0 and passed to this method
+		spacing_ = s/3;
+	}
+
+private:
+	float &spacing_;
+};
+
 class SnapGrid : public UI::View {
 public:
 	SnapGrid(int leftMargin, int rightMargin, int topMargin, int bottomMargin, u32 color) {
@@ -471,8 +500,12 @@ void ControlLayoutView::CreateViews() {
 		rbutton->FlipImageH(true);
 	}
 
-	addDragDropButton(g_Config.touchAnalogStick, "Left analog stick", stickBg, stickImage);
-	addDragDropButton(g_Config.touchRightAnalogStick, "Right analog stick", stickBg, stickImage);
+	if (g_Config.touchAnalogStick.show) {
+		controls_.push_back(new PSPStickDragDrop(g_Config.touchAnalogStick, "Left analog stick", stickBg, stickImage, bounds, g_Config.fLeftStickHeadScale));
+	}
+	if (g_Config.touchRightAnalogStick.show) {
+		controls_.push_back(new PSPStickDragDrop(g_Config.touchRightAnalogStick, "Right analog stick", stickBg, stickImage, bounds, g_Config.fRightStickHeadScale));
+	}
 
 	auto addDragComboKey = [&](ConfigTouchPos &pos, const char *key, const ConfigCustomButton& cfg) {
 		DragDropButton *b = nullptr;

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -291,10 +291,8 @@ public:
 	}
 
 	void Draw(UIContext &dc) override {
-		float opacity = g_Config.iTouchButtonOpacity / 100.0f;
-
-		uint32_t colorBg = colorAlpha(GetButtonColor(), opacity);
-		uint32_t downBg = colorAlpha(0x00FFFFFF, opacity * 0.5f);
+		uint32_t colorBg = colorAlpha(GetButtonColor(), GetButtonOpacity());
+		uint32_t downBg = colorAlpha(0x00FFFFFF, GetButtonOpacity() * 0.5f);
 
 		const ImageID stickImage = g_Config.iTouchButtonStyle ? ImageID("I_STICK_LINE") : ImageID("I_STICK");
 		const ImageID stickBg = g_Config.iTouchButtonStyle ? ImageID("I_STICK_BG_LINE") : ImageID("I_STICK_BG");


### PR DESCRIPTION
Change the default a bit as now you have to press on the head to get the input (before pressing on the background would move the stick as well).

Also add a checkbox to disable the stick background if someone want to scale it pretty big (it's still being drawn in the layout editor to give feedback).