### PR TITLE
Fix UI import cheat crash if no cheat.db is present

### DIFF
--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -211,6 +211,7 @@ UI::EventReturn CwCheatScreen::OnImportCheat(UI::EventParams &params) {
 
 	if (!in) {
 		WARN_LOG(COMMON, "Unable to open %s\n", cheatFile.c_str());
+		return UI::EVENT_SKIPPED;
 	}
 
 	char linebuf[2048]{};


### PR DESCRIPTION
As in the title, just a quick fix.