### PR TITLE
Fix crash in HTTPServer when processing invalid request

### DIFF
--- a/Common/Net/HTTPServer.cpp
+++ b/Common/Net/HTTPServer.cpp
@@ -72,7 +72,9 @@ Request::Request(int fd)
 Request::~Request() {
 	Close();
 
-	_assert_(in_->Empty());
+	if (!in_->Empty()) {
+		ERROR_LOG(IO, "Input not empty - invalid request?");
+	}
 	delete in_;
 	if (!out_->Empty()) {
 		ERROR_LOG(IO, "Output not empty - connection abort?");
@@ -330,6 +332,10 @@ void Server::HandleRequest(const Request &request) {
 }
 
 void Server::HandleRequestDefault(const Request &request) {
+	if (request.resource() == nullptr) {
+		fallback_(request);
+		return;
+	}
 	// First, look through all handlers. If we got one, use it.
 	auto handler = handlers_.find(request.resource());
 	if (handler != handlers_.end()) {


### PR DESCRIPTION
Valid HTTP request must have `resource` so let's always return fallback when `resource` is missing.
Fixes:
- Crash when trying to use unsupported method, test case: `curl -X DELETE http://127.0.0.1:52203/debugger`
- Crash when trying to connect over HTTPS , test case: `curl https://127.0.0.1:52203/debugger`

Assertion removed because HTTPS request will have unprocessed data.