### PR TITLE
Add debugger APIs for replay recording

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1580,6 +1580,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/Debugger/WebSocket/MemoryInfoSubscriber.h
 	Core/Debugger/WebSocket/MemorySubscriber.cpp
 	Core/Debugger/WebSocket/MemorySubscriber.h
+	Core/Debugger/WebSocket/ReplaySubscriber.cpp
+	Core/Debugger/WebSocket/ReplaySubscriber.h
 	Core/Debugger/WebSocket/SteppingBroadcaster.cpp
 	Core/Debugger/WebSocket/SteppingBroadcaster.h
 	Core/Debugger/WebSocket/SteppingSubscriber.cpp

--- a/Common/Net/WebsocketServer.cpp
+++ b/Common/Net/WebsocketServer.cpp
@@ -341,8 +341,8 @@ bool WebSocketServer::ReadFrame() {
 
 		mask = &header[10];
 		// Read from big endian.
-		uint64_t high = (header[2] << 24) | (header[3] << 16) || (header[4] << 8) | (header[5] << 0);
-		uint64_t low = (header[6] << 24) | (header[7] << 16) || (header[8] << 8) | (header[9] << 0);
+		uint64_t high = (header[2] << 24) | (header[3] << 16) | (header[4] << 8) | (header[5] << 0);
+		uint64_t low = (header[6] << 24) | (header[7] << 16) | (header[8] << 8) | (header[9] << 0);
 		sz = (high << 32) | low;
 
 		if ((sz & 0x8000000000000000ULL) != 0) {

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -525,6 +525,7 @@
     <ClCompile Include="Debugger\WebSocket\DisasmSubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\MemoryInfoSubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\MemorySubscriber.cpp" />
+    <ClCompile Include="Debugger\WebSocket\ReplaySubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\SteppingBroadcaster.cpp" />
     <ClCompile Include="Debugger\WebSocket\SteppingSubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\WebSocketUtils.cpp" />
@@ -1076,6 +1077,7 @@
     <ClInclude Include="Debugger\WebSocket\InputBroadcaster.h" />
     <ClInclude Include="Debugger\WebSocket\InputSubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\MemoryInfoSubscriber.h" />
+    <ClInclude Include="Debugger\WebSocket\ReplaySubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\SteppingSubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\WebSocketUtils.h" />
     <ClInclude Include="Debugger\WebSocket\CPUCoreSubscriber.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -1172,6 +1172,9 @@
     <ClCompile Include="..\ext\libzip\zip_random_win32.c">
       <Filter>Ext\libzip</Filter>
     </ClCompile>
+    <ClCompile Include="Debugger\WebSocket\ReplaySubscriber.cpp">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -1885,6 +1888,9 @@
     </ClInclude>
     <ClInclude Include="..\ext\libzip\zipconf.h">
       <Filter>Ext\libzip</Filter>
+    </ClInclude>
+    <ClInclude Include="Debugger\WebSocket\ReplaySubscriber.h">
+      <Filter>Debugger\WebSocket</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Core/Debugger/WebSocket.cpp
+++ b/Core/Debugger/WebSocket.cpp
@@ -59,6 +59,7 @@
 #include "Core/Debugger/WebSocket/InputSubscriber.h"
 #include "Core/Debugger/WebSocket/MemoryInfoSubscriber.h"
 #include "Core/Debugger/WebSocket/MemorySubscriber.h"
+#include "Core/Debugger/WebSocket/ReplaySubscriber.h"
 #include "Core/Debugger/WebSocket/SteppingSubscriber.h"
 
 typedef DebuggerSubscriber *(*SubscriberInit)(DebuggerEventHandlerMap &map);
@@ -73,6 +74,7 @@ static const std::vector<SubscriberInit> subscribers({
 	&WebSocketInputInit,
 	&WebSocketMemoryInfoInit,
 	&WebSocketMemoryInit,
+	&WebSocketReplayInit,
 	&WebSocketSteppingInit,
 });
 

--- a/Core/Debugger/WebSocket/ReplaySubscriber.cpp
+++ b/Core/Debugger/WebSocket/ReplaySubscriber.cpp
@@ -15,7 +15,11 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <cstdint>
+#include "Common/Swap.h"
+#include "Core/HLE/sceRtc.h"
 #include "Core/Replay.h"
+#include "Core/System.h"
 #include "Core/Debugger/WebSocket/ReplaySubscriber.h"
 
 DebuggerSubscriber *WebSocketReplayInit(DebuggerEventHandlerMap &map) {
@@ -31,19 +35,42 @@ DebuggerSubscriber *WebSocketReplayInit(DebuggerEventHandlerMap &map) {
 	return nullptr;
 }
 
+// Begin or resume recording of replay data (replay.begin)
+//
+// If a replay was previously being played back, this will keep any executed replay data up to
+// this point for the next flush.  To discard, break the CPU, abort, and then begin.
+//
+// No parameters.
+//
+// Empty response.
 void WebSocketReplayBegin(DebuggerRequest &req) {
-	// TODO
+	ReplayBeginSave();
+	req.Respond();
 }
 
+// Abort any replay execution or recording (replay.abort)
+//
+// This stops executing any replay and discards any in progress recording.
+//
+// No parameters.
+//
+// Empty response.
 void WebSocketReplayAbort(DebuggerRequest &req) {
-	// TODO
+	ReplayAbort();
+	req.Respond();
 }
 
 void WebSocketReplayFlush(DebuggerRequest &req) {
+	if (!PSP_IsInited())
+		return req.Fail("Game not running");
+
 	// TODO
 }
 
 void WebSocketReplayExecute(DebuggerRequest &req) {
+	if (!PSP_IsInited())
+		return req.Fail("Game not running");
+
 	// TODO
 }
 
@@ -51,10 +78,38 @@ void WebSocketReplayStatus(DebuggerRequest &req) {
 	// TODO
 }
 
+// Get the base RTC (real time clock) time for replay data (replay.time.get)
+//
+// The base time is constant during a game session, and represents the "power on" time of the
+// emulated PSP.
+//
+// No parameters.
+//
+// Response (same event name):
+//  - value: unsigned integer, may have more than 32 integer bits.
 void WebSocketReplayTimeGet(DebuggerRequest &req) {
-	// TODO
+	if (!PSP_IsInited())
+		return req.Fail("Game not running");
+
+	JsonWriter &json = req.Respond();
+	json.writeUint("value", RtcBaseTime());
 }
 
+// Overwrite the base RTC time (replay.time.set)
+//
+// Parameters:
+//  - value: unsigned integer.
+//
+// Empty response.
 void WebSocketReplayTimeSet(DebuggerRequest &req) {
-	// TODO
+	if (!PSP_IsInited())
+		return req.Fail("Game not running");
+
+	uint32_t value;
+	if (!req.ParamU32("value", &value, false)) {
+		return;
+	}
+
+	RtcSetBaseTime((int32_t)value);
+	req.Respond();
 }

--- a/Core/Debugger/WebSocket/ReplaySubscriber.cpp
+++ b/Core/Debugger/WebSocket/ReplaySubscriber.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2021- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "Core/Replay.h"
+#include "Core/Debugger/WebSocket/ReplaySubscriber.h"
+
+DebuggerSubscriber *WebSocketReplayInit(DebuggerEventHandlerMap &map) {
+	// No need to bind or alloc state, these are all global.
+	map["replay.begin"] = &WebSocketReplayBegin;
+	map["replay.abort"] = &WebSocketReplayAbort;
+	map["replay.flush"] = &WebSocketReplayFlush;
+	map["replay.execute"] = &WebSocketReplayExecute;
+	map["replay.status"] = &WebSocketReplayStatus;
+	map["replay.time.get"] = &WebSocketReplayTimeGet;
+	map["replay.time.set"] = &WebSocketReplayTimeSet;
+
+	return nullptr;
+}
+
+void WebSocketReplayBegin(DebuggerRequest &req) {
+	// TODO
+}
+
+void WebSocketReplayAbort(DebuggerRequest &req) {
+	// TODO
+}
+
+void WebSocketReplayFlush(DebuggerRequest &req) {
+	// TODO
+}
+
+void WebSocketReplayExecute(DebuggerRequest &req) {
+	// TODO
+}
+
+void WebSocketReplayStatus(DebuggerRequest &req) {
+	// TODO
+}
+
+void WebSocketReplayTimeGet(DebuggerRequest &req) {
+	// TODO
+}
+
+void WebSocketReplayTimeSet(DebuggerRequest &req) {
+	// TODO
+}

--- a/Core/Debugger/WebSocket/ReplaySubscriber.h
+++ b/Core/Debugger/WebSocket/ReplaySubscriber.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2021- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "Core/Debugger/WebSocket/WebSocketUtils.h"
+
+DebuggerSubscriber *WebSocketReplayInit(DebuggerEventHandlerMap &map);
+
+void WebSocketReplayBegin(DebuggerRequest &req);
+void WebSocketReplayAbort(DebuggerRequest &req);
+void WebSocketReplayFlush(DebuggerRequest &req);
+void WebSocketReplayExecute(DebuggerRequest &req);
+void WebSocketReplayStatus(DebuggerRequest &req);
+void WebSocketReplayTimeGet(DebuggerRequest &req);
+void WebSocketReplayTimeSet(DebuggerRequest &req);

--- a/Core/Replay.cpp
+++ b/Core/Replay.cpp
@@ -206,6 +206,8 @@ bool ReplayExecuteFile(const Path &filename) {
 			WARN_LOG(SYSTEM, "Replay version %d scary and futuristic, trying anyway", fh.version);
 		}
 
+		RtcSetBaseTime((int32_t)fh.rtcBaseSeconds, 0);
+
 		data.resize(sz);
 
 		if (fread(&data[0], sz, 1, fp) != 1) {

--- a/Core/Replay.cpp
+++ b/Core/Replay.cpp
@@ -116,7 +116,7 @@ struct ReplayFileInfo {
 
 struct ReplayItem {
 	ReplayItemHeader info;
-	std::vector<u8> data;
+	std::vector<uint8_t> data;
 
 	ReplayItem(ReplayItemHeader h) : info(h) {
 	}
@@ -136,7 +136,7 @@ static uint8_t lastAnalog[2][2]{};
 static size_t replayDiskPos = 0;
 static bool diskFailed = false;
 
-void ReplayExecuteBlob(const std::vector<u8> &data) {
+void ReplayExecuteBlob(const std::vector<uint8_t> &data) {
 	ReplayAbort();
 
 	// Rough estimate.
@@ -178,7 +178,7 @@ bool ReplayExecuteFile(const Path &filename) {
 		return false;
 	}
 
-	std::vector<u8> data;
+	std::vector<uint8_t> data;
 	auto loadData = [&]() {
 		// TODO: Maybe stream instead.
 		size_t sz = File::GetFileSize(fp);
@@ -243,7 +243,7 @@ void ReplayBeginSave() {
 	replayState = ReplayState::SAVE;
 }
 
-void ReplayFlushBlob(std::vector<u8> *data) {
+void ReplayFlushBlob(std::vector<uint8_t> *data) {
 	size_t sz = replayItems.size() * sizeof(ReplayItemHeader);
 	// Add in any side data.
 	for (const auto &item : replayItems) {
@@ -289,7 +289,7 @@ bool ReplayFlushFile(const Path &filename) {
 	size_t c = replayItems.size();
 	if (success && c != 0) {
 		// TODO: Maybe stream instead.
-		std::vector<u8> data;
+		std::vector<uint8_t> data;
 		ReplayFlushBlob(&data);
 
 		success = fwrite(&data[0], data.size(), 1, fp) == 1;

--- a/Core/Replay.h
+++ b/Core/Replay.h
@@ -49,17 +49,17 @@ enum class ReplayAction : uint8_t {
 struct PSPFileInfo;
 
 // Replay from data in memory.  Does not manipulate base time / RNG state.
-void ReplayExecuteBlob(const std::vector<u8> &data);
+void ReplayExecuteBlob(const std::vector<uint8_t> &data);
 // Replay from data in a file.  Returns false if invalid.
 bool ReplayExecuteFile(const Path &filename);
-// Returns whether there are unexected events to replay.
+// Returns whether there are unexecuted events to replay.
 bool ReplayHasMoreEvents();
 
 // Begin recording.  If currently executing, discards unexecuted events.
 void ReplayBeginSave();
 // Flush buffered events to memory.  Continues recording (next call will receive new events only.)
 // No header is flushed with this operation - don't mix with ReplayFlushFile().
-void ReplayFlushBlob(std::vector<u8> *data);
+void ReplayFlushBlob(std::vector<uint8_t> *data);
 // Flush buffered events to file.  Continues recording (next call will receive new events only.)
 // Do not call with a different filename before ReplayAbort().
 bool ReplayFlushFile(const Path &filename);

--- a/Core/Replay.h
+++ b/Core/Replay.h
@@ -49,7 +49,7 @@ enum class ReplayAction : uint8_t {
 struct PSPFileInfo;
 
 // Replay from data in memory.  Does not manipulate base time / RNG state.
-void ReplayExecuteBlob(const std::vector<uint8_t> &data);
+bool ReplayExecuteBlob(int version, const std::vector<uint8_t> &data);
 // Replay from data in a file.  Returns false if invalid.
 bool ReplayExecuteFile(const Path &filename);
 // Returns whether there are unexecuted events to replay.
@@ -63,9 +63,15 @@ void ReplayFlushBlob(std::vector<uint8_t> *data);
 // Flush buffered events to file.  Continues recording (next call will receive new events only.)
 // Do not call with a different filename before ReplayAbort().
 bool ReplayFlushFile(const Path &filename);
+// Get current replay data version.
+int ReplayVersion();
 
 // Abort any execute or record operation in progress.
 void ReplayAbort();
+
+// Check if replay data is being executed or saved.
+bool ReplayIsExecuting();
+bool ReplayIsSaving();
 
 void ReplayApplyCtrl(uint32_t &buttons, uint8_t analog[2][2], uint64_t t);
 uint32_t ReplayApplyDisk(ReplayAction action, uint32_t result, uint64_t t);

--- a/UWP/CoreUWP/CoreUWP.vcxproj
+++ b/UWP/CoreUWP/CoreUWP.vcxproj
@@ -405,6 +405,7 @@
     <ClInclude Include="..\..\Core\Debugger\WebSocket\LogBroadcaster.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\MemorySubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\MemoryInfoSubscriber.h" />
+    <ClInclude Include="..\..\Core\Debugger\WebSocket\ReplaySubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\SteppingBroadcaster.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\SteppingSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\WebSocketUtils.h" />
@@ -636,6 +637,7 @@
     <ClCompile Include="..\..\Core\Debugger\WebSocket\LogBroadcaster.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\MemorySubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\MemoryInfoSubscriber.cpp" />
+    <ClCompile Include="..\..\Core\Debugger\WebSocket\ReplaySubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\SteppingBroadcaster.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\SteppingSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\WebSocketUtils.cpp" />

--- a/UWP/CoreUWP/CoreUWP.vcxproj.filters
+++ b/UWP/CoreUWP/CoreUWP.vcxproj.filters
@@ -700,6 +700,9 @@
     <ClCompile Include="..\..\Core\Debugger\WebSocket\MemoryInfoSubscriber.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Core\Debugger\WebSocket\ReplaySubscriber.cpp">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Core\Debugger\WebSocket\SteppingBroadcaster.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
@@ -1699,6 +1702,9 @@
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Core\Debugger\WebSocket\MemoryInfoSubscriber.h">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Core\Debugger\WebSocket\ReplaySubscriber.h">
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Core\Debugger\WebSocket\SteppingBroadcaster.h">

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -422,6 +422,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/Debugger/WebSocket/LogBroadcaster.cpp \
   $(SRC)/Core/Debugger/WebSocket/MemorySubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/MemoryInfoSubscriber.cpp \
+  $(SRC)/Core/Debugger/WebSocket/ReplaySubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/SteppingBroadcaster.cpp \
   $(SRC)/Core/Debugger/WebSocket/SteppingSubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/WebSocketUtils.cpp \


### PR DESCRIPTION
This exposes APIs to record and re-execute replay data.

A simple example is to send `replay.begin`, wait for a while (possibly listening for a certain keypress), and then send `replay.flush` to save the data.  Then use `replay.execute` at the start.  Also allows you to save/restore the RTC time.

In theory this can be used for TAS (and ties events to exact internal clock times), but as noted in #10888 I'm not necessarily pursuing TAS.  This is useful for debugging and automated functional testing.

There's no integration with rewind or save states still.

Also, this fixes reading larger data packets - surprised I missed that.  Might fix memory API issues for some if writing large chunks.

-[Unknown]