### PR TITLE
Debugger: Expose API to reset game

### DIFF
--- a/Core/Debugger/WebSocket/GameSubscriber.h
+++ b/Core/Debugger/WebSocket/GameSubscriber.h
@@ -21,5 +21,6 @@
 
 DebuggerSubscriber *WebSocketGameInit(DebuggerEventHandlerMap &map);
 
+void WebSocketGameReset(DebuggerRequest &req);
 void WebSocketGameStatus(DebuggerRequest &req);
 void WebSocketVersion(DebuggerRequest &req);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -468,7 +468,8 @@ bool PSP_InitUpdate(std::string *error_string) {
 }
 
 bool PSP_Init(const CoreParameter &coreParam, std::string *error_string) {
-	PSP_InitStart(coreParam, error_string);
+	if (!PSP_InitStart(coreParam, error_string))
+		return false;
 
 	while (!PSP_InitUpdate(error_string))
 		sleep_ms(10);


### PR DESCRIPTION
This can be useful to put the game back to a known-good state before setting up breakpoints, overwriting memory, and processing replay data.

For example, along with #14493, this can be used to "run" a saved replay or enforce that recording is always done from the beginning.  But there are many useful reasons to script resetting.

-[Unknown]