### PR TITLE
Transform labels to lower case for armips

### DIFF
--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -1013,6 +1013,7 @@ void SymbolMap::GetLabels(std::vector<LabelDefinition> &dest) {
 		LabelDefinition entry;
 		entry.value = it->first;
 		entry.name = ConvertUTF8ToWString(it->second.name);
+		std::transform(entry.name.begin(), entry.name.end(), entry.name.begin(), ::towlower);
 		dest.push_back(entry);
 	}
 }


### PR DESCRIPTION
Due to questionable design choices, armips expects labels that are passed in from the outside to be lowercase. Not doing so makes it impossible to reference any label that contains at least one upper case letter.