### PR TITLE
Update .gitlab-ci.yml for libretro

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,6 +89,8 @@ libretro-build-linux-i686:
 
 # MacOS 64-bit
 libretro-build-osx-x64:
+  tags:
+    - macosx-packaging
   extends:
     - .libretro-osx-x64-make-default
     - .core-defs


### PR DESCRIPTION
Hi there, could this be merged please? What this change does is that it builds the core with the MacRunner, which should hopefully result in more reliable builds.