### PR TITLE
Global: Tether wildcard git ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,10 +64,9 @@ PPSSPPControls.dat
 .idea
 *.iml
 build
-build.ios
+/build*/
 versionname.txt
 versioncode.txt
-build*/
 android/.cxx
 
 # Temp file used by jenkins windows build (TODO: remove)
@@ -75,7 +74,7 @@ desc.txt
 
 Logs
 Memstick
-memstick*
+/memstick*
 Cheats
 
 /git-version.cpp


### PR DESCRIPTION
This way they won't impact files unexpectedly, such as UI/MemStickScreen.cpp.  Personally I prefer starting all ignore rules with / unless there's a good reason otherwise.

-[Unknown]