### PR TITLE
Postshader: Let shaders use the previous frame

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -1331,7 +1331,7 @@ Framebuffer *D3D11DrawContext::CreateFramebuffer(const FramebufferDesc &desc) {
 
 void D3D11DrawContext::BindTextures(int start, int count, Texture **textures) {
 	// Collect the resource views from the textures.
-	ID3D11ShaderResourceView *views[8];
+	ID3D11ShaderResourceView *views[MAX_BOUND_TEXTURES];
 	_assert_(start + count <= ARRAY_SIZE(views));
 	for (int i = 0; i < count; i++) {
 		D3D11Texture *tex = (D3D11Texture *)textures[i];
@@ -1341,7 +1341,7 @@ void D3D11DrawContext::BindTextures(int start, int count, Texture **textures) {
 }
 
 void D3D11DrawContext::BindSamplerStates(int start, int count, SamplerState **states) {
-	ID3D11SamplerState *samplers[8];
+	ID3D11SamplerState *samplers[MAX_BOUND_TEXTURES];
 	_assert_(start + count <= ARRAY_SIZE(samplers));
 	for (int i = 0; i < count; i++) {
 		D3D11SamplerState *samp = (D3D11SamplerState *)states[i];

--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -26,6 +26,8 @@
 
 namespace Draw {
 
+static constexpr int MAX_BOUND_TEXTURES = 8;
+
 // A problem is that we can't get the D3Dcompiler.dll without using a later SDK than 7.1, which was the last that
 // supported XP. A possible solution might be here:
 // https://tedwvc.wordpress.com/2014/01/01/how-to-target-xp-with-vc2012-or-vc2013-and-continue-to-use-the-windows-8-x-sdk/
@@ -1162,6 +1164,7 @@ void D3D11DrawContext::UpdateBuffer(Buffer *buffer, const uint8_t *data, size_t 
 }
 
 void D3D11DrawContext::BindVertexBuffers(int start, int count, Buffer **buffers, int *offsets) {
+	_assert_(start + count <= ARRAY_SIZE(nextVertexBuffers_));
 	// Lazy application
 	for (int i = 0; i < count; i++) {
 		D3D11Buffer *buf = (D3D11Buffer *)buffers[i];
@@ -1329,6 +1332,7 @@ Framebuffer *D3D11DrawContext::CreateFramebuffer(const FramebufferDesc &desc) {
 void D3D11DrawContext::BindTextures(int start, int count, Texture **textures) {
 	// Collect the resource views from the textures.
 	ID3D11ShaderResourceView *views[8];
+	_assert_(start + count <= ARRAY_SIZE(views));
 	for (int i = 0; i < count; i++) {
 		D3D11Texture *tex = (D3D11Texture *)textures[i];
 		views[i] = tex ? tex->view : nullptr;
@@ -1338,6 +1342,7 @@ void D3D11DrawContext::BindTextures(int start, int count, Texture **textures) {
 
 void D3D11DrawContext::BindSamplerStates(int start, int count, SamplerState **states) {
 	ID3D11SamplerState *samplers[8];
+	_assert_(start + count <= ARRAY_SIZE(samplers));
 	for (int i = 0; i < count; i++) {
 		D3D11SamplerState *samp = (D3D11SamplerState *)states[i];
 		samplers[i] = samp->ss;
@@ -1613,6 +1618,7 @@ void D3D11DrawContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, const Ren
 }
 
 void D3D11DrawContext::BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int attachment) {
+	_assert_(binding < MAX_BOUND_TEXTURES);
 	D3D11Framebuffer *fb = (D3D11Framebuffer *)fbo;
 	switch (channelBit) {
 	case FBChannel::FB_COLOR_BIT:

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -28,6 +28,8 @@
 
 namespace Draw {
 
+static constexpr int MAX_BOUND_TEXTURES = 8;
+
 // Could be declared as u8
 static const D3DCMPFUNC compareToD3D9[] = {
 	D3DCMP_NEVER,
@@ -525,12 +527,14 @@ public:
 
 	void BindTextures(int start, int count, Texture **textures) override;
 	void BindSamplerStates(int start, int count, SamplerState **states) override {
+		_assert_(start + count <= MAX_BOUND_TEXTURES);
 		for (int i = 0; i < count; ++i) {
 			D3D9SamplerState *s = static_cast<D3D9SamplerState *>(states[i]);
 			s->Apply(device_, start + i);
 		}
 	}
 	void BindVertexBuffers(int start, int count, Buffer **buffers, int *offsets) override {
+		_assert_(start + count <= ARRAY_SIZE(curVBuffers_));
 		for (int i = 0; i < count; i++) {
 			curVBuffers_[i + start] = (D3D9Buffer *)buffers[i];
 			curVBufferOffsets_[i + start] = offsets ? offsets[i] : 0;
@@ -785,6 +789,7 @@ Texture *D3D9Context::CreateTexture(const TextureDesc &desc) {
 }
 
 void D3D9Context::BindTextures(int start, int count, Texture **textures) {
+	_assert_(start + count <= MAX_BOUND_TEXTURES);
 	for (int i = start; i < start + count; i++) {
 		D3D9Texture *tex = static_cast<D3D9Texture *>(textures[i - start]);
 		if (tex) {
@@ -1182,6 +1187,7 @@ uintptr_t D3D9Context::GetFramebufferAPITexture(Framebuffer *fbo, int channelBit
 }
 
 void D3D9Context::BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int color) {
+	_assert_(binding < MAX_BOUND_TEXTURES);
 	D3D9Framebuffer *fb = (D3D9Framebuffer *)fbo;
 	switch (channelBit) {
 	case FB_DEPTH_BIT:

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -17,7 +17,7 @@
 #include "GLRenderManager.h"
 #include "DataFormatGL.h"
 
-#define TEXCACHE_NAME_CACHE_SIZE 16
+static constexpr int TEXCACHE_NAME_CACHE_SIZE = 16;
 
 #if PPSSPP_PLATFORM(IOS)
 extern void bindDefaultFBO();
@@ -800,7 +800,7 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last
 	GLuint blendEqColor = (GLuint)-1;
 	GLuint blendEqAlpha = (GLuint)-1;
 
-	GLRTexture *curTex[8]{};
+	GLRTexture *curTex[MAX_GL_TEXTURE_SLOTS]{};
 
 	CHECK_GL_ERROR_IF_DEBUG();
 	auto &commands = step.commands;

--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -357,6 +357,7 @@ void GLRenderManager::BindFramebufferAsRenderTarget(GLRFramebuffer *fb, GLRRende
 
 void GLRenderManager::BindFramebufferAsTexture(GLRFramebuffer *fb, int binding, int aspectBit, int attachment) {
 	_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+	_dbg_assert_(binding < MAX_GL_TEXTURE_SLOTS);
 	GLRRenderData data{ GLRRenderCommand::BIND_FB_TEXTURE };
 	data.bind_fb_texture.slot = binding;
 	data.bind_fb_texture.framebuffer = fb;

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -21,6 +21,8 @@ namespace Draw {
 class DrawContext;
 }
 
+constexpr int MAX_GL_TEXTURE_SLOTS = 8;
+
 class GLRTexture {
 public:
 	GLRTexture(int width, int height, int numMips);
@@ -571,8 +573,8 @@ public:
 
 	void BindTexture(int slot, GLRTexture *tex) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(slot < MAX_GL_TEXTURE_SLOTS);
 		GLRRenderData data{ GLRRenderCommand::BINDTEXTURE };
-		_dbg_assert_(slot < 16);
 		data.texture.slot = slot;
 		data.texture.texture = tex;
 		curRenderStep_->commands.push_back(data);
@@ -824,6 +826,7 @@ public:
 	// Modifies the current texture as per GL specs, not global state.
 	void SetTextureSampler(int slot, GLenum wrapS, GLenum wrapT, GLenum magFilter, GLenum minFilter, float anisotropy) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(slot < MAX_GL_TEXTURE_SLOTS);
 		GLRRenderData data{ GLRRenderCommand::TEXTURESAMPLER };
 		data.textureSampler.slot = slot;
 		data.textureSampler.wrapS = wrapS;
@@ -836,6 +839,7 @@ public:
 
 	void SetTextureLod(int slot, float minLod, float maxLod, float lodBias) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(slot < MAX_GL_TEXTURE_SLOTS);
 		GLRRenderData data{ GLRRenderCommand::TEXTURELOD};
 		data.textureLod.slot = slot;
 		data.textureLod.minLod = minLod;

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -299,7 +299,7 @@ public:
 
 	// TODO: Optimize by getting the locations first and putting in a custom struct
 	UniformBufferDesc dynamicUniforms;
-	GLint samplerLocs_[8]{};
+	GLint samplerLocs_[MAX_TEXTURE_SLOTS]{};
 	std::vector<GLint> dynamicUniformLocs_;
 	GLRProgram *program_ = nullptr;
 
@@ -1149,13 +1149,13 @@ bool OpenGLPipeline::LinkShaders() {
 	queries.push_back({ &samplerLocs_[0], "sampler0" });
 	queries.push_back({ &samplerLocs_[1], "sampler1" });
 	queries.push_back({ &samplerLocs_[2], "sampler2" });
+	_assert_(queries.size() >= MAX_TEXTURE_SLOTS);
 	for (size_t i = 0; i < dynamicUniforms.uniforms.size(); ++i) {
 		queries.push_back({ &dynamicUniformLocs_[i], dynamicUniforms.uniforms[i].name });
 	}
 	std::vector<GLRProgram::Initializer> initialize;
-	initialize.push_back({ &samplerLocs_[0], 0, 0 });
-	initialize.push_back({ &samplerLocs_[1], 0, 1 });
-	initialize.push_back({ &samplerLocs_[2], 0, 2 });
+	for (int i = 0; i < MAX_TEXTURE_SLOTS; ++i)
+		initialize.push_back({ &samplerLocs_[i], 0, i });
 	program_ = render_->CreateProgram(linkShaders, semantics, queries, initialize, false);
 	return true;
 }

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -368,9 +368,7 @@ public:
 	void GetFramebufferDimensions(Framebuffer *fbo, int *w, int *h) override;
 
 	void BindSamplerStates(int start, int count, SamplerState **states) override {
-		if (start + count > MAX_TEXTURE_SLOTS) {
-			return;
-		}
+		_assert_(start + count <= MAX_TEXTURE_SLOTS);
 		for (int i = 0; i < count; i++) {
 			int index = i + start;
 			boundSamplers_[index] = static_cast<OpenGLSamplerState *>(states[i]);
@@ -402,6 +400,7 @@ public:
 	void BindTextures(int start, int count, Texture **textures) override;
 	void BindPipeline(Pipeline *pipeline) override;
 	void BindVertexBuffers(int start, int count, Buffer **buffers, int *offsets) override {
+		_assert_(start + count <= ARRAY_SIZE(curVBuffers_));
 		for (int i = 0; i < count; i++) {
 			curVBuffers_[i + start] = (OpenGLBuffer *)buffers[i];
 			curVBufferOffsets_[i + start] = offsets ? offsets[i] : 0;
@@ -1070,9 +1069,7 @@ Pipeline *OpenGLContext::CreateGraphicsPipeline(const PipelineDesc &desc) {
 }
 
 void OpenGLContext::BindTextures(int start, int count, Texture **textures) {
-	if (start + count > MAX_TEXTURE_SLOTS) {
-		return;
-	}
+	_assert_(start + count <= MAX_TEXTURE_SLOTS);
 	for (int i = start; i < start + count; i++) {
 		OpenGLTexture *glTex = static_cast<OpenGLTexture *>(textures[i - start]);
 		if (!glTex) {
@@ -1354,6 +1351,7 @@ bool OpenGLContext::BlitFramebuffer(Framebuffer *fbsrc, int srcX1, int srcY1, in
 
 void OpenGLContext::BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int color) {
 	OpenGLFramebuffer *fb = (OpenGLFramebuffer *)fbo;
+	_assert_(binding < MAX_TEXTURE_SLOTS);
 
 	GLuint aspect = 0;
 	if (channelBit & FB_COLOR_BIT) {

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -1148,12 +1148,14 @@ bool OpenGLPipeline::LinkShaders() {
 	std::vector<GLRProgram::UniformLocQuery> queries;
 	queries.push_back({ &samplerLocs_[0], "sampler0" });
 	queries.push_back({ &samplerLocs_[1], "sampler1" });
+	queries.push_back({ &samplerLocs_[2], "sampler2" });
 	for (size_t i = 0; i < dynamicUniforms.uniforms.size(); ++i) {
 		queries.push_back({ &dynamicUniformLocs_[i], dynamicUniforms.uniforms[i].name });
 	}
 	std::vector<GLRProgram::Initializer> initialize;
 	initialize.push_back({ &samplerLocs_[0], 0, 0 });
 	initialize.push_back({ &samplerLocs_[1], 0, 1 });
+	initialize.push_back({ &samplerLocs_[2], 0, 2 });
 	program_ = render_->CreateProgram(linkShaders, semantics, queries, initialize, false);
 	return true;
 }

--- a/Common/GPU/ShaderTranslation.cpp
+++ b/Common/GPU/ShaderTranslation.cpp
@@ -85,6 +85,7 @@ cbuffer data : register(b0) {
 	float2 u_texelDelta;
 	float2 u_pixelDelta;
 	float4 u_time;
+	float4 u_timeDelta;
 	float4 u_setting;
 	float u_video;
 };
@@ -101,6 +102,7 @@ layout (std140, set = 0, binding = 0) uniform Data {
 	vec2 u_texelDelta;
 	vec2 u_pixelDelta;
 	vec4 u_time;
+	vec4 u_timeDelta;
 	vec4 u_setting;
 	float u_video;
 };
@@ -111,8 +113,9 @@ float4 gl_HalfPixel : register(c0);
 float2 u_texelDelta : register(c1);
 float2 u_pixelDelta : register(c2);
 float4 u_time : register(c3);
-float4 u_setting : register(c4);
-float u_video : register(c5);
+float4 u_timeDelta : register(c4);
+float4 u_setting : register(c5);
+float u_video : register(c6);
 )";
 
 // SPIRV-Cross' HLSL output has some deficiencies we need to work around.

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -295,7 +295,7 @@ class VKBuffer;
 class VKSamplerState;
 
 enum {
-	MAX_BOUND_TEXTURES = 2
+	MAX_BOUND_TEXTURES = MAX_TEXTURE_SLOTS,
 };
 
 struct DescriptorSetKey {
@@ -416,6 +416,7 @@ public:
 
 	// TODO: Make VKBuffers proper buffers, and do a proper binding model. This is just silly.
 	void BindVertexBuffers(int start, int count, Buffer **buffers, int *offsets) override {
+		_assert_(start + count <= ARRAY_SIZE(curVBuffers_));
 		for (int i = 0; i < count; i++) {
 			curVBuffers_[i + start] = (VKBuffer *)buffers[i];
 			curVBufferOffsets_[i + start] = offsets ? offsets[i] : 0;
@@ -689,6 +690,7 @@ RasterState *VKContext::CreateRasterState(const RasterStateDesc &desc) {
 }
 
 void VKContext::BindSamplerStates(int start, int count, SamplerState **state) {
+	_assert_(start + count <= MAX_BOUND_TEXTURES);
 	for (int i = start; i < start + count; i++) {
 		boundSamplers_[i] = (VKSamplerState *)state[i - start];
 	}
@@ -1271,6 +1273,7 @@ void VKContext::UpdateBuffer(Buffer *buffer, const uint8_t *data, size_t offset,
 }
 
 void VKContext::BindTextures(int start, int count, Texture **textures) {
+	_assert_(start + count <= MAX_BOUND_TEXTURES);
 	for (int i = start; i < start + count; i++) {
 		boundTextures_[i] = static_cast<VKTexture *>(textures[i - start]);
 		boundImageView_[i] = boundTextures_[i] ? boundTextures_[i]->GetImageView() : GetNullTexture()->GetImageView();
@@ -1544,6 +1547,7 @@ void VKContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPass
 
 void VKContext::BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int attachment) {
 	VKFramebuffer *fb = (VKFramebuffer *)fbo;
+	_assert_(binding < MAX_BOUND_TEXTURES);
 
 	// TODO: There are cases where this is okay, actually. But requires layout transitions and stuff -
 	// we're not ready for this.

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -278,7 +278,7 @@ enum class Event {
 	PRESENTED,
 };
 
-constexpr uint32_t MAX_TEXTURE_SLOTS = 2;
+constexpr uint32_t MAX_TEXTURE_SLOTS = 3;
 
 struct FramebufferDesc {
 	int width;

--- a/Core/Font/PGF.cpp
+++ b/Core/Font/PGF.cpp
@@ -230,13 +230,13 @@ bool PGF::ReadPtr(const u8 *ptr, size_t dataSize) {
 
 	const u8 *uptr = (const u8 *)wptr;
 
-	if (uptr >= startPtr + dataSize) {
-		return false;
-	}
-
 	int shadowCharMapSize = ((header.shadowMapLength * header.shadowMapBpe + 31) & ~31) / 8;
 	const u8 *shadowCharMap = uptr;
 	uptr += shadowCharMapSize;
+
+	if (uptr < startPtr || uptr >= startPtr + dataSize) {
+		return false;
+	}
 
 	const u16_le *sptr = (const u16_le *)uptr;
 	if (header.revision == 3) {
@@ -257,10 +257,6 @@ bool PGF::ReadPtr(const u8 *ptr, size_t dataSize) {
 
 	uptr = (const u8 *)sptr;
 
-	if (uptr >= startPtr + dataSize) {
-		return false;
-	}
-
 	int charMapSize = ((header.charMapLength * header.charMapBpe + 31) & ~31) / 8;
 	const u8 *charMap = uptr;
 	uptr += charMapSize;
@@ -268,6 +264,10 @@ bool PGF::ReadPtr(const u8 *ptr, size_t dataSize) {
 	int charPointerSize = (((header.charPointerLength * header.charPointerBpe + 31) & ~31) / 8);
 	const u8 *charPointerTable = uptr;
 	uptr += charPointerSize;
+
+	if (uptr < startPtr || uptr >= startPtr + dataSize) {
+		return false;
+	}
 
 	// PGF Fontdata.
 	u32 fontDataOffset = (u32)(uptr - startPtr);

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -127,6 +127,7 @@ void LoadPostShaderInfo(const std::vector<Path> &directories) {
 					section.Get("Upscaling", &info.isUpscalingFilter, false);
 					section.Get("SSAA", &info.SSAAFilterLevel, 0);
 					section.Get("60fps", &info.requires60fps, false);
+					section.Get("UsePreviousFrame", &info.usePreviousFrame, false);
 
 					if (info.parent == "Off")
 						info.parent = "";

--- a/GPU/Common/PostShader.h
+++ b/GPU/Common/PostShader.h
@@ -43,6 +43,8 @@ struct ShaderInfo {
 	int SSAAFilterLevel;
 	// Force constant/max refresh for animated filters
 	bool requires60fps;
+	// Takes previous frame as input (for blending effects.)
+	bool usePreviousFrame;
 
 	struct Setting {
 		std::string name;

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -31,6 +31,7 @@ struct CardboardSettings {
 struct PostShaderUniforms {
 	float texelDelta[2]; float pixelDelta[2];
 	float time[4];
+	float timeDelta[4];
 	float setting[4];
 	float video; float pad[3];
 	// Used on Direct3D9.
@@ -133,6 +134,7 @@ protected:
 	std::vector<ShaderInfo> postShaderInfo_;
 	std::vector<Draw::Framebuffer *> previousFramebuffers_;
 	int previousIndex_ = 0;
+	PostShaderUniforms previousUniforms_{};
 
 	Draw::Texture *srcTexture_ = nullptr;
 	Draw::Framebuffer *srcFramebuffer_ = nullptr;

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -131,6 +131,8 @@ protected:
 	std::vector<Draw::Pipeline *> postShaderPipelines_;
 	std::vector<Draw::Framebuffer *> postShaderFramebuffers_;
 	std::vector<ShaderInfo> postShaderInfo_;
+	std::vector<Draw::Framebuffer *> previousFramebuffers_;
+	int previousIndex_ = 0;
 
 	Draw::Texture *srcTexture_ = nullptr;
 	Draw::Framebuffer *srcFramebuffer_ = nullptr;


### PR DESCRIPTION
This is useful for i.e. simulating the slow update speed of the PSP's LCD screen, but could in theory be used for other effects.

Here's a test fragment shader I was using:

```glsl
#ifdef GL_ES
precision mediump float;
precision mediump int;
#endif

uniform sampler2D sampler0;
uniform sampler2D sampler2;
varying vec2 v_texcoord0;

void main() {
	vec3 update = texture2D(sampler0, v_texcoord0.xy).rgb;
	vec3 prev = texture2D(sampler2, v_texcoord0.xy).rgb;

	gl_FragColor.rgb = mix(prev, update, 0.1);
	gl_FragColor.a = 1.0;
}
```

Using `0.1` makes the effect very obvious, but of course that varies by rendered FPS.  For that reason I added a u_timeDelta:

Value | Meaning | Speeds up if unthrottled | Changes on load state
--- | --- | --- | ---
`u_timeDelta.x` | Fractional seconds, in real time, since last frame | No | No
`u_timeDelta.y` | Fractional seconds, in emulated time, since last frame (approx) | Yes | Yes
`u_timeDelta.z` | Number of vblanks (which occur 60 times every 1001ms, i.e. 59.94 times per second) since last frame | Yes | Yes
`u_timeDelta.w` | In practice, always 1.0 (delta number of flips) | N/A | N/A

With this, the above example can be amended with `uniform vec4 u_timeDelta;` at the top, and `u_timeDelta.y * 6` in place of 0.1 to have a more stable effect regardless of game FPS.  But you could also force 60 FPS output.

-[Unknown]