### PR TITLE
Remove asserts from OpenSL init. Expose error inside audio settings

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -80,6 +80,14 @@
 #include "Windows/W32Util/ShellUtil.h"
 #endif
 
+#if PPSSPP_PLATFORM(ANDROID)
+
+#include "android/jni/AndroidAudio.h"
+
+extern AndroidAudioState *g_audioState;
+
+#endif
+
 GameSettingsScreen::GameSettingsScreen(const Path &gamePath, std::string gameID, bool editThenRestore)
 	: UIDialogScreenWithGameBackground(gamePath), gameID_(gameID), enableReports_(false), editThenRestore_(editThenRestore) {
 	lastVertical_ = UseVerticalLayout();
@@ -640,6 +648,12 @@ void GameSettingsScreen::CreateViews() {
 #if defined(__ANDROID__)
 	CheckBox *extraAudio = audioSettings->Add(new CheckBox(&g_Config.bExtraAudioBuffering, a->T("AudioBufferingForBluetooth", "Bluetooth-friendly buffer (slower)")));
 	extraAudio->SetEnabledPtr(&g_Config.bEnableSound);
+
+	// Show OpenSL debug info
+	const std::string audioErrorStr = AndroidAudio_GetErrorString(g_audioState);
+	if (!audioErrorStr.empty()) {
+		audioSettings->Add(new InfoItem(a->T("Audio Error"), audioErrorStr));
+	}
 #endif
 
 	// Control

--- a/android/jni/AndroidAudio.cpp
+++ b/android/jni/AndroidAudio.cpp
@@ -132,3 +132,13 @@ bool AndroidAudio_Shutdown(AndroidAudioState *state) {
 	INFO_LOG(AUDIO, "OpenSLWrap completely unloaded.");
 	return true;
 }
+
+const std::string AndroidAudio_GetErrorString(AndroidAudioState *state) {
+	if (!state) {
+		return "No state";
+	}
+	if (!state->ctx) {
+		return "No context";
+	}
+	return state->ctx->GetErrorString();
+}

--- a/android/jni/AndroidAudio.h
+++ b/android/jni/AndroidAudio.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <mutex>
 
 typedef int (*AndroidAudioCallback)(short *buffer, int num_samples);
 
@@ -8,18 +9,31 @@ class AudioContext {
 public:
 	AudioContext(AndroidAudioCallback cb, int _FramesPerBuffer, int _SampleRate);
 	virtual bool Init() { return false; }
-	virtual int AudioRecord_Start(int sampleRate) { return false; };
-	virtual int AudioRecord_Stop() { return false; };
+	virtual bool AudioRecord_Start(int sampleRate) { return false; };
+	virtual bool AudioRecord_Stop() { return false; };
+	const std::string &GetErrorString() {
+		std::unique_lock<std::mutex> lock(errorMutex_);
+		return error_;
+	}
+
 	virtual ~AudioContext() {}
 
 protected:
+	void SetErrorString(const std::string &error) {
+		std::unique_lock<std::mutex> lock(errorMutex_);
+		error_ = error;
+	}
 	AndroidAudioCallback audioCallback;
 
 	int framesPerBuffer;
 	int sampleRate;
+	std::string error_ = "";
+	std::mutex errorMutex_;
 };
 
 struct AndroidAudioState;
+
+// TODO: Get rid of this unnecessary wrapper layer from the old .so days
 
 // It's okay for optimalFramesPerBuffer and optimalSampleRate to be 0. Defaults will be used.
 AndroidAudioState *AndroidAudio_Init(AndroidAudioCallback cb, int optimalFramesPerBuffer, int optimalSampleRate);
@@ -30,3 +44,4 @@ bool AndroidAudio_Recording_State(AndroidAudioState *state);
 bool AndroidAudio_Pause(AndroidAudioState *state);
 bool AndroidAudio_Resume(AndroidAudioState *state);
 bool AndroidAudio_Shutdown(AndroidAudioState *state);
+const std::string AndroidAudio_GetErrorString(AndroidAudioState *state);

--- a/android/jni/OpenSLContext.h
+++ b/android/jni/OpenSLContext.h
@@ -10,11 +10,15 @@ public:
 	OpenSLContext(AndroidAudioCallback cb, int framesPerBuffer, int sampleRate);
 
 	bool Init() override;
-	int AudioRecord_Start(int sampleRate) override;
-	int AudioRecord_Stop() override;
+	bool AudioRecord_Start(int sampleRate) override;
+	bool AudioRecord_Stop() override;
+
 	~OpenSLContext();
 
 private:
+	bool CheckResult(SLresult result, const char *str);
+	static bool CheckResultStatic(SLresult result, const char *str);
+
 	// Should be no reason to need more than two buffers, but make it clear in the code.
 	enum {
 		NUM_BUFFERS = 2,

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -113,7 +113,7 @@ static std::atomic<int> emuThreadState((int)EmuThreadState::DISABLED);
 
 void UpdateRunLoopAndroid(JNIEnv *env);
 
-static AndroidAudioState *g_audioState;
+AndroidAudioState *g_audioState;
 
 struct FrameCommand {
 	FrameCommand() {}


### PR DESCRIPTION
This saves any error occuring during OpenSL init in a string, which is then shown on the audio settings menu.

Might help diagnosing, or finding good detection methods for, weird OpenSL errors like #14529 .