### PR TITLE
Store the OpenSL error in a global to avoid "No context"

### DIFF
--- a/android/jni/AndroidAudio.cpp
+++ b/android/jni/AndroidAudio.cpp
@@ -3,6 +3,9 @@
 #include "android/jni/AndroidAudio.h"
 #include "android/jni/OpenSLContext.h"
 
+std::string g_error;
+std::mutex g_errorMutex;
+
 AudioContext::AudioContext(AndroidAudioCallback cb, int _FramesPerBuffer, int _SampleRate)
 	: audioCallback(cb), framesPerBuffer(_FramesPerBuffer), sampleRate(_SampleRate) {
 	if (framesPerBuffer == 0)
@@ -13,6 +16,12 @@ AudioContext::AudioContext(AndroidAudioCallback cb, int _FramesPerBuffer, int _S
 		framesPerBuffer = 4096;
 
 	sampleRate = _SampleRate;
+	g_error = "";
+}
+
+void AudioContext::SetErrorString(const std::string &error) {
+	std::unique_lock<std::mutex> lock(g_errorMutex);
+	g_error = error;
 }
 
 struct AndroidAudioState {
@@ -137,8 +146,6 @@ const std::string AndroidAudio_GetErrorString(AndroidAudioState *state) {
 	if (!state) {
 		return "No state";
 	}
-	if (!state->ctx) {
-		return "No context";
-	}
-	return state->ctx->GetErrorString();
+	std::unique_lock<std::mutex> lock(g_errorMutex);
+	return g_error;
 }

--- a/android/jni/AndroidAudio.h
+++ b/android/jni/AndroidAudio.h
@@ -11,23 +11,15 @@ public:
 	virtual bool Init() { return false; }
 	virtual bool AudioRecord_Start(int sampleRate) { return false; };
 	virtual bool AudioRecord_Stop() { return false; };
-	const std::string &GetErrorString() {
-		std::unique_lock<std::mutex> lock(errorMutex_);
-		return error_;
-	}
 
 	virtual ~AudioContext() {}
 
 protected:
-	void SetErrorString(const std::string &error) {
-		std::unique_lock<std::mutex> lock(errorMutex_);
-		error_ = error;
-	}
+	void SetErrorString(const std::string &error);
 	AndroidAudioCallback audioCallback;
 
 	int framesPerBuffer;
 	int sampleRate;
-	std::string error_ = "";
 	std::mutex errorMutex_;
 };
 


### PR DESCRIPTION
Followup to #14536