### PR TITLE
UWP: Add a missing bounds check from  TextDrawerWin32::DrawStringBitmap

### DIFF
--- a/Common/Render/Text/draw_text_uwp.cpp
+++ b/Common/Render/Text/draw_text_uwp.cpp
@@ -359,6 +359,11 @@ void TextDrawerUWP::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStrin
 	size.cx = metrics.width + 1;
 	size.cy = metrics.height + 1;
 
+	if (size.cx > MAX_TEXT_WIDTH)
+		size.cx = MAX_TEXT_WIDTH;
+	if (size.cy > MAX_TEXT_HEIGHT)
+		size.cy = MAX_TEXT_HEIGHT;
+
 	// Prevent zero-sized textures, which can occur. Not worth to avoid
 	// creating the texture altogether in this case. One example is a string
 	// containing only '\r\n', see issue #10764.


### PR DESCRIPTION
Fixes a crash on switching tabs due to an out of bounds access. While it's not a clean fix, it improves feature parity between Win32 and UWP implementations.