### PR TITLE
Refactor and unify analog input settings

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -962,18 +962,11 @@ static ConfigSetting controlSettings[] = {
 	ConfigSetting("AnalogRotationCWKeyX", "AnalogRotationKeyCWY", "AnalogRotationKeyCWScale", "ShowAnalogRotationCWKey", &g_Config.touchAnalogRotationCWKey, defaultTouchPosHide, true, true),
 	ConfigSetting("AnalogRotationCCWKeyX", "AnalogRotationKeyCCWY", "AnalogRotationKeyCCWScale", "ShowAnalogRotationCCWKey", &g_Config.touchAnalogRotationCCWKey, defaultTouchPosHide, true, true),
 
-#ifdef _WIN32
-	ConfigSetting("DInputAnalogDeadzone", &g_Config.fDInputAnalogDeadzone, 0.1f, true, true),
-	ConfigSetting("DInputAnalogInverseMode", &g_Config.iDInputAnalogInverseMode, 0, true, true),
-	ConfigSetting("DInputAnalogInverseDeadzone", &g_Config.fDInputAnalogInverseDeadzone, 0.0f, true, true),
-	ConfigSetting("DInputAnalogSensitivity", &g_Config.fDInputAnalogSensitivity, 1.0f, true, true),
+	ConfigSetting("AnalogDeadzone", &g_Config.fAnalogDeadzone, 0.0f, true, true),
+	ConfigSetting("AnalogInverseDeadzone", &g_Config.fAnalogInverseDeadzone, 0.0f, true, true),
+	ConfigSetting("AnalogSensitivity", &g_Config.fAnalogSensitivity, 1.0f, true, true),
+	ConfigSetting("AnalogIsCircular", &g_Config.bAnalogIsCircular, true, true, true),
 
-	ConfigSetting("XInputAnalogDeadzone", &g_Config.fXInputAnalogDeadzone, 0.24f, true, true),
-	ConfigSetting("XInputAnalogInverseMode", &g_Config.iXInputAnalogInverseMode, 0, true, true),
-	ConfigSetting("XInputAnalogInverseDeadzone", &g_Config.fXInputAnalogInverseDeadzone, 0.0f, true, true),
-#endif
-	// Also reused as generic analog sensitivity
-	ConfigSetting("XInputAnalogSensitivity", &g_Config.fXInputAnalogSensitivity, 1.0f, true, true),
 	ConfigSetting("AnalogLimiterDeadzone", &g_Config.fAnalogLimiterDeadzone, 0.6f, true, true),
 
 	ConfigSetting("UseMouse", &g_Config.bMouseControl, false, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -381,16 +381,13 @@ public:
 
 	bool bHapticFeedback;
 
-	float fDInputAnalogDeadzone;
-	int iDInputAnalogInverseMode;
-	float fDInputAnalogInverseDeadzone;
-	float fDInputAnalogSensitivity;
-
 	// We also use the XInput settings as analog settings on other platforms like Android.
-	float fXInputAnalogDeadzone;
-	int iXInputAnalogInverseMode;
-	float fXInputAnalogInverseDeadzone;
-	float fXInputAnalogSensitivity;
+	float fAnalogDeadzone;
+	float fAnalogInverseDeadzone;
+	float fAnalogSensitivity;
+	// convert analog stick circle to square
+	bool bAnalogIsCircular;
+
 
 	float fAnalogLimiterDeadzone;
 

--- a/SDL/SDLJoystick.cpp
+++ b/SDL/SDLJoystick.cpp
@@ -174,8 +174,7 @@ void SDLJoystick::ProcessInput(SDL_Event &event){
 	case SDL_CONTROLLERAXISMOTION:
 		AxisInput axis;
 		axis.axisId = event.caxis.axis;
-		// 1.2 to try to approximate the PSP's clamped rectangular range.
-		axis.value = 1.2 * event.caxis.value * g_Config.fXInputAnalogSensitivity / 32767.0f;
+		axis.value = event.caxis.value / 32767.0f;
 		if (axis.value > 1.0f) axis.value = 1.0f;
 		if (axis.value < -1.0f) axis.value = -1.0f;
 		axis.deviceId = DEVICE_ID_PAD_0 + getDeviceIndex(event.caxis.which);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -727,23 +727,12 @@ void GameSettingsScreen::CreateViews() {
 		style->SetEnabledPtr(&g_Config.bShowTouchControls);
 	}
 
-#ifdef _WIN32
-	static const char *inverseDeadzoneModes[] = { "Off", "X", "Y", "X + Y" };
+	controlsSettings->Add(new ItemHeader(co->T("Analog Settings", "Analog Settings")));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fAnalogDeadzone, 0.0f, 1.0f, co->T("Deadzone Radius"), 0.01f, screenManager(), "/ 1.0"));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fAnalogInverseDeadzone, 0.0f, 1.0f, co->T("Analog Mapper Low End", "Analog Mapper Low End (Inverse Deadzone)"), 0.01f, screenManager(), "/ 1.0"));
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fAnalogSensitivity, 0.0f, 10.0f, co->T("Analog Mapper High End", "Analog Mapper High End (Axis Sensitivity)"), 0.01f, screenManager(), "x"));
+	controlsSettings->Add(new CheckBox(&g_Config.bAnalogIsCircular, co->T("Circular Analog Stick Input")));
 
-	controlsSettings->Add(new ItemHeader(co->T("DInput Analog Settings", "DInput Analog Settings")));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogDeadzone, 0.0f, 1.0f, co->T("Deadzone Radius"), 0.01f, screenManager(), "/ 1.0"));
-	controlsSettings->Add(new PopupMultiChoice(&g_Config.iDInputAnalogInverseMode, co->T("Analog Mapper Mode"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), co->GetName(), screenManager()));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogInverseDeadzone, 0.0f, 1.0f, co->T("Analog Mapper Low End", "Analog Mapper Low End (Inverse Deadzone)"), 0.01f, screenManager(), "/ 1.0"));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fDInputAnalogSensitivity, 0.0f, 10.0f, co->T("Analog Mapper High End", "Analog Mapper High End (Axis Sensitivity)"), 0.01f, screenManager(), "x"));
-
-	controlsSettings->Add(new ItemHeader(co->T("XInput Analog Settings", "XInput Analog Settings")));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputAnalogDeadzone, 0.0f, 1.0f, co->T("Deadzone Radius"), 0.01f, screenManager(), "/ 1.0"));
-	controlsSettings->Add(new PopupMultiChoice(&g_Config.iXInputAnalogInverseMode, co->T("Analog Mapper Mode"), inverseDeadzoneModes, 0, ARRAY_SIZE(inverseDeadzoneModes), co->GetName(), screenManager()));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputAnalogInverseDeadzone, 0.0f, 1.0f, co->T("Analog Mapper Low End", "Analog Mapper Low End (Inverse Deadzone)"), 0.01f, screenManager(), "/ 1.0"));
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputAnalogSensitivity, 0.0f, 10.0f, co->T("Analog Mapper High End", "Analog Mapper High End (Axis Sensitivity)"), 0.01f, screenManager(), "x"));
-#else
-	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fXInputAnalogSensitivity, 0.0f, 10.0f, co->T("Analog Axis Sensitivity", "Analog Axis Sensitivity"), 0.01f, screenManager(), "x"));
-#endif
 	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fAnalogAutoRotSpeed, 0.0f, 25.0f, co->T("Analog auto-rotation speed"), 1.0f, screenManager()));
 
 	controlsSettings->Add(new ItemHeader(co->T("Keyboard", "Keyboard Control Settings")));

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1326,8 +1326,83 @@ bool NativeKey(const KeyInput &key) {
 	return retval;
 }
 
+static float MapAxisValue(float v) {
+	const float deadzone = g_Config.fAnalogDeadzone;
+	const float invDeadzone = g_Config.fAnalogInverseDeadzone;
+	const float sensitivity = g_Config.fAnalogSensitivity;
+	const float sign = v >= 0.0f ? 1.0f : -1.0f;
+	return sign * Clamp(invDeadzone + (abs(v) - deadzone) / (1.0f - deadzone) * (sensitivity - invDeadzone), 0.0f, 1.0f);
+}
+
+static void ConvertAnalogStick(float &x, float &y) {
+	const bool isCircular = g_Config.bAnalogIsCircular;
+
+	float norm = std::max(fabsf(x), fabsf(y));
+
+	if (norm == 0.0f)
+		return;
+
+	if (isCircular) {
+		float newNorm = sqrtf(x * x + y * y);
+		float factor = newNorm / norm;
+		x *= factor;
+		y *= factor;
+		norm = newNorm;
+	}
+
+	float mappedNorm = MapAxisValue(norm);
+	x = Clamp(x / norm * mappedNorm, -1.0f, 1.0f);
+	y = Clamp(y / norm * mappedNorm, -1.0f, 1.0f);
+}
+
+static bool AnalogStickAxis(const AxisInput &axis) {
+	static float history[JOYSTICK_AXIS_MAX+1] = { 0.0f };
+
+	if (history[axis.axisId] == axis.value) {
+		return true;
+	}
+
+	history[axis.axisId] = axis.value;
+	AxisInput axisA = axis;
+	AxisInput axisB = axis;
+
+	switch (axis.axisId) {
+		case JOYSTICK_AXIS_X:
+		case JOYSTICK_AXIS_Y:
+			axisA.axisId = JOYSTICK_AXIS_X;
+			axisB.axisId = JOYSTICK_AXIS_Y;
+			axisA.value = history[JOYSTICK_AXIS_X];
+			axisB.value = history[JOYSTICK_AXIS_Y];
+			break;
+		case JOYSTICK_AXIS_Z:
+		case JOYSTICK_AXIS_RZ:
+			axisA.axisId = JOYSTICK_AXIS_Z;
+			axisB.axisId = JOYSTICK_AXIS_RZ;
+			axisA.value = history[JOYSTICK_AXIS_Z];
+			axisB.value = history[JOYSTICK_AXIS_RZ];
+			break;
+		default:
+			break;
+	}
+
+	ConvertAnalogStick(axisA.value, axisB.value);
+	bool retA = screenManager->axis(axisA);
+	bool retB = screenManager->axis(axisB);
+	return retA && retB;
+}
+
 bool NativeAxis(const AxisInput &axis) {
 	using namespace TiltEventProcessor;
+
+	switch (axis.axisId) {
+		case JOYSTICK_AXIS_X:
+		case JOYSTICK_AXIS_Y:
+		case JOYSTICK_AXIS_Z:
+		case JOYSTICK_AXIS_RZ:
+			return AnalogStickAxis(axis);
+		default:
+			break;
+	}
 
 	// only handle tilt events if tilt is enabled.
 	if (g_Config.iTiltInputType == TILT_NULL) {

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -176,7 +176,7 @@ DinputDevice::DinputDevice(int devnum) {
 	dipw.diph.dwHow        = DIPH_DEVICE;
 	dipw.diph.dwObj        = 0;
 	// dwData 10000 is deadzone(0% - 100%), multiply by config scalar
-	dipw.dwData            = (int)(g_Config.fDInputAnalogDeadzone * 10000);
+	dipw.dwData            = 0;
 
 	analog |= FAILED(pJoystick->SetProperty(DIPROP_DEADZONE, &dipw.diph)) ? false : true;
 }
@@ -209,60 +209,6 @@ void SendNativeAxis(int deviceId, int value, int &lastValue, int axisId) {
 	lastValue = value;
 }
 
-inline int Signs(int val) {
-	return (0 < val) - (val < 0);
-}
-
-inline int LinearMaps(int val, int a0, int a1, int b0, int b1) {
-	return b0 + (((val - a0) * (b1 - b0)) / (a1 - a0));
-}
-inline float LinearMaps(float val, float a0, float a1, float b0, float b1) {
-	return b0 + (((val - a0) * (b1 - b0)) / (a1 - a0));
-}
-
-static void ApplyNormalization(LONG &jsx, LONG &jsy) {
-	// Circle to Square mapping, cribbed from XInputDevice
-	float sx = (float)jsx;
-	float sy = (float)jsy;
-	float scaleFactor = sqrtf((sx * sx + sy * sy) / std::max(sx * sx, sy * sy));
-	jsx = (int)(sx * scaleFactor);
-	jsy = (int)(sy * scaleFactor);
-
-	// Linear range mapping (used to invert deadzones)
-	float dz = g_Config.fDInputAnalogDeadzone;
-	int idzm = g_Config.iDInputAnalogInverseMode;
-	float idz = g_Config.fDInputAnalogInverseDeadzone;
-	float md = std::max(dz, idz);
-	float st = g_Config.fDInputAnalogSensitivity;
-
-	float magnitude = sqrtf((float)(jsx * jsx + jsy * jsy));
-	if (magnitude > dz * 10000.0f) {
-		if (idzm == 1) {
-			int xSign = Signs(jsx);
-			if (xSign != 0) {
-				jsx = LinearMaps(jsx, xSign * (int)(dz * 10000), xSign * 10000, xSign * (int)(md * 10000), xSign * (int)(st * 10000));
-			}
-		} else if (idzm == 2) {
-			int ySign = Signs(jsy);
-			if (ySign != 0) {
-				jsy = LinearMaps(jsy, ySign * (int)(dz * 10000.0f), ySign * 10000, ySign * (int)(md * 10000.0f), ySign * (int)(st * 10000));
-			}
-		} else if (idzm == 3) {
-			float xNorm = (float)jsx / magnitude;
-			float yNorm = (float)jsy / magnitude;
-			float mapMag = LinearMaps(magnitude, dz * 10000.0f, 10000.0f, md * 10000.0f, 10000.0f * st);
-			jsx = (short)(xNorm * mapMag);
-			jsy = (short)(yNorm * mapMag);
-		}
-	} else {
-		jsx = 0;
-		jsy = 0;
-	}
-
-	jsx = (short)std::min(10000.0f, std::max((float)jsx, -10000.0f));
-	jsy = (short)std::min(10000.0f, std::max((float)jsy, -10000.0f));
-}
-
 static LONG *ValueForAxisId(DIJOYSTATE2 &js, int axisId) {
 	switch (axisId) {
 	case JOYSTICK_AXIS_X: return &js.lX;
@@ -272,14 +218,6 @@ static LONG *ValueForAxisId(DIJOYSTATE2 &js, int axisId) {
 	case JOYSTICK_AXIS_RY: return &js.lRy;
 	case JOYSTICK_AXIS_RZ: return &js.lRz;
 	default: return nullptr;
-	}
-}
-
-static void ApplyNormalization(DIJOYSTATE2 &js, int xAxisId, int yAxisId) {
-	LONG *nrmX = ValueForAxisId(js, xAxisId);
-	LONG *nrmY = ValueForAxisId(js, yAxisId);
-	if (nrmX != nullptr && nrmY != nullptr) {
-		ApplyNormalization(*nrmX, *nrmY);
 	}
 }
 
@@ -303,10 +241,6 @@ int DinputDevice::UpdateState() {
 		axis.deviceId = DEVICE_ID_PAD_0 + pDevNum;
 
 		auto axesToSquare = KeyMap::MappedAxesForDevice(axis.deviceId);
-		ApplyNormalization(js, axesToSquare.leftX.axisId, axesToSquare.leftY.axisId);
-		// Prevent double normalization.
-		if (axesToSquare.leftX.axisId != axesToSquare.rightX.axisId && axesToSquare.leftX.axisId != axesToSquare.rightY.axisId)
-			ApplyNormalization(js, axesToSquare.rightX.axisId, axesToSquare.rightY.axisId);
 
 		SendNativeAxis(DEVICE_ID_PAD_0 + pDevNum, js.lX, last_lX_, JOYSTICK_AXIS_X);
 		SendNativeAxis(DEVICE_ID_PAD_0 + pDevNum, js.lY, last_lY_, JOYSTICK_AXIS_Y);

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1082,9 +1082,6 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_joystickAxis(
 	axis.deviceId = deviceId;
 	axis.value = value;
 
-	float sensitivity = g_Config.fXInputAnalogSensitivity;
-	axis.value *= sensitivity;
-
 	return NativeAxis(axis);
 }
 

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -718,7 +718,7 @@ int ToTouchID(UITouch *uiTouch, bool allowAllocate) {
 		axisInput.deviceId = DEVICE_ID_PAD_0;
 		axisInput.flags = 0;
 		axisInput.axisId = JOYSTICK_AXIS_X;
-		axisInput.value = value * g_Config.fXInputAnalogSensitivity;
+		axisInput.value = value;
 		NativeAxis(axisInput);
 	};
 	
@@ -727,7 +727,7 @@ int ToTouchID(UITouch *uiTouch, bool allowAllocate) {
 		axisInput.deviceId = DEVICE_ID_PAD_0;
 		axisInput.flags = 0;
 		axisInput.axisId = JOYSTICK_AXIS_Y;
-		axisInput.value = -value * g_Config.fXInputAnalogSensitivity;
+		axisInput.value = -value;
 		NativeAxis(axisInput);
 	};
 	
@@ -737,7 +737,7 @@ int ToTouchID(UITouch *uiTouch, bool allowAllocate) {
 		axisInput.deviceId = DEVICE_ID_PAD_0;
 		axisInput.flags = 0;
 		axisInput.axisId = JOYSTICK_AXIS_Z;
-		axisInput.value = value * g_Config.fXInputAnalogSensitivity;
+		axisInput.value = value;
 		NativeAxis(axisInput);
 	};
 	
@@ -746,7 +746,7 @@ int ToTouchID(UITouch *uiTouch, bool allowAllocate) {
 		axisInput.deviceId = DEVICE_ID_PAD_0;
 		axisInput.flags = 0;
 		axisInput.axisId = JOYSTICK_AXIS_RZ;
-		axisInput.value = -value * g_Config.fXInputAnalogSensitivity;
+		axisInput.value = -value;
 		NativeAxis(axisInput);
 	};
 }


### PR DESCRIPTION
Previously PPSSPP analog stick mapping is done by each backend separately, with the XInput implementation being the more feature-complete one. The other ones usually have fewer features or are somewhat broken (e.g. lacking circle -> square mapping causing characters unable to run diagonally).

This PR attempts to fix that by unifying all analog stick mapping implementations to a common one.

This adds dead zone, inverse dead zone, sensitivity, and circle -> square mapping functionalities to all platforms using the `NativeAxis` abstraction.

The InverseMode option is also removed, as the "Off", "X", "Y", "X + Y" options do not quite make sense to me: "Off" can be achieved using the default values for "sensitivity" and "inverse dead zone", applying axis mapping to only one of the axes also seems not very useful.

The defaults are also set to values that represent 1-1 input mapping. Circle-to-square mapping is also enabled by default since most controllers use a [2-norm (Euclidian norm)](https://en.wikipedia.org/wiki/Norm_(mathematics)#Euclidean_norm) space. (PSP uses the [max-norm](https://en.wikipedia.org/wiki/Norm_(mathematics)#Maximum_norm_(special_case_of:_infinity_norm,_uniform_norm,_or_supremum_norm)))

Resolves https://github.com/hrydgard/ppsspp/issues/11552