### PR TITLE
Fix black screen on multiple libretro content loads.

### DIFF
--- a/Common/Thread/ThreadManager.cpp
+++ b/Common/Thread/ThreadManager.cpp
@@ -98,10 +98,6 @@ static void WorkerThreadFunc(GlobalThreadContext *global, ThreadContext *thread)
 }
 
 void ThreadManager::Init(int numRealCores, int numLogicalCoresPerCpu) {
-	if (!global_->threads_.empty()) {
-		Teardown();
-	}
-
 	numComputeThreads_ = std::min(numRealCores * numLogicalCoresPerCpu, MAX_CORES_TO_USE);
 	int numThreads = numComputeThreads_ + EXTRA_THREADS;
 	numThreads_ = numThreads;

--- a/Common/Thread/ThreadManager.cpp
+++ b/Common/Thread/ThreadManager.cpp
@@ -98,6 +98,10 @@ static void WorkerThreadFunc(GlobalThreadContext *global, ThreadContext *thread)
 }
 
 void ThreadManager::Init(int numRealCores, int numLogicalCoresPerCpu) {
+	if (!global_->threads_.empty()) {
+		Teardown();
+	}
+
 	numComputeThreads_ = std::min(numRealCores * numLogicalCoresPerCpu, MAX_CORES_TO_USE);
 	int numThreads = numComputeThreads_ + EXTRA_THREADS;
 	numThreads_ = numThreads;

--- a/Common/Thread/ThreadManager.h
+++ b/Common/Thread/ThreadManager.h
@@ -46,6 +46,7 @@ public:
 	void Init(int numCores, int numLogicalCoresPerCpu);
 	void EnqueueTask(Task *task, TaskType taskType);
 	void EnqueueTaskOnThread(int threadNum, Task *task, TaskType taskType);
+	void Teardown();
 
 	// Currently does nothing. It will always be best-effort - maybe it cancels,
 	// maybe it doesn't. Note that the id is the id() returned by the task. You need to make that
@@ -57,8 +58,6 @@ public:
 	int GetNumLooperThreads() const;
 
 private:
-	void Teardown();
-
 	GlobalThreadContext *global_ = nullptr;
 
 	int numThreads_ = 0;

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -675,6 +675,8 @@ void retro_unload_game(void)
 	delete ctx;
 	ctx = nullptr;
 	PSP_CoreParameter().graphicsContext = nullptr;
+
+   g_threadManager.Teardown();
 }
 
 void retro_reset(void)


### PR DESCRIPTION
Moves ThreadPool teardown to retro_unload_game. Gives ThreadPool threads some breathing room to terminate before game load starts spamming it with tasks.

Should fix #14572 outside of pathological start stop behaviour.
