### PR TITLE
Change default adhoc server

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -983,7 +983,7 @@ static ConfigSetting controlSettings[] = {
 static ConfigSetting networkSettings[] = {
 	ConfigSetting("EnableWlan", &g_Config.bEnableWlan, false, true, true),
 	ConfigSetting("EnableAdhocServer", &g_Config.bEnableAdhocServer, false, true, true),
-	ConfigSetting("proAdhocServer", &g_Config.proAdhocServer, "myneighborsushicat.com", true, true),
+	ConfigSetting("proAdhocServer", &g_Config.proAdhocServer, "socom.cc", true, true),
 	ConfigSetting("PortOffset", &g_Config.iPortOffset, 0, true, true),
 	ConfigSetting("MinTimeout", &g_Config.iMinTimeout, 0, true, true),
 	ConfigSetting("TCPNoDelay", &g_Config.bTCPNoDelay, true, true, true),

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1811,7 +1811,7 @@ void HostnameSelectScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	buttonsRow2->Add(new Button(di->T("Toggle List")))->OnClick.Handle(this, &HostnameSelectScreen::OnShowIPListClick);
 	buttonsRow2->Add(new Spacer(new LinearLayoutParams(1.0, G_RIGHT)));
 
-	std::vector<std::string> listIP = {"myneighborsushicat.com", "socom.cc", "localhost"}; // TODO: Add some saved recent history too?
+	std::vector<std::string> listIP = {"socom.cc", "myneighborsushicat.com", "localhost"}; // TODO: Add some saved recent history too?
 	net::GetIPList(listIP);
 	ipRows_ = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0));
 	ScrollView* scrollView = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));


### PR DESCRIPTION
myneighborsushicat.com has been offline for awhile now and seems to have a shaky uptime track record.

Reasons for using the socom.cc adhoc server:
- Server is fast, and uptime is stable
- The web status page, as well as the Discord bot, shows the connected players names
- Better cross region compatibility with games
- The adhoc server running gets improved over time with new features(port offset on web page in future?)

### Changes

- Make `socom.cc` the default adhoc server.