### PR TITLE
Vulkan: Turn off all 16-bit formats if B5G6R5 format is not available.

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -565,33 +565,16 @@ void VulkanContext::ChooseDevice(int physical_device) {
 	}
 
 	deviceFeatures_.enabled = {};
-
 	// Enable a few safe ones if they are available.
-	if (deviceFeatures_.available.dualSrcBlend) {
-		deviceFeatures_.enabled.dualSrcBlend = true;
-	}
-	if (deviceFeatures_.available.largePoints) {
-		deviceFeatures_.enabled.largePoints = true;
-	}
-	if (deviceFeatures_.available.wideLines) {
-		deviceFeatures_.enabled.wideLines = true;
-	}
-	if (deviceFeatures_.available.logicOp) {
-		deviceFeatures_.enabled.logicOp = true;
-	}
-	if (deviceFeatures_.available.depthClamp) {
-		deviceFeatures_.enabled.depthClamp = true;
-	}
-	if (deviceFeatures_.available.depthBounds) {
-		deviceFeatures_.enabled.depthBounds = true;
-	}
-	if (deviceFeatures_.available.samplerAnisotropy) {
-		deviceFeatures_.enabled.samplerAnisotropy = true;
-	}
+	deviceFeatures_.enabled.dualSrcBlend = deviceFeatures_.available.dualSrcBlend;
+	deviceFeatures_.enabled.largePoints = deviceFeatures_.available.largePoints;
+	deviceFeatures_.enabled.wideLines = deviceFeatures_.available.wideLines;
+	deviceFeatures_.enabled.logicOp = deviceFeatures_.available.logicOp;
+	deviceFeatures_.enabled.depthClamp = deviceFeatures_.available.depthClamp;
+	deviceFeatures_.enabled.depthBounds = deviceFeatures_.available.depthBounds;
+	deviceFeatures_.enabled.samplerAnisotropy = deviceFeatures_.available.samplerAnisotropy;
 	// For easy wireframe mode, someday.
-	if (deviceFeatures_.available.fillModeNonSolid) {
-		deviceFeatures_.enabled.fillModeNonSolid = true;
-	}
+	deviceFeatures_.enabled.fillModeNonSolid = deviceFeatures_.available.fillModeNonSolid;
 
 	GetDeviceLayerExtensionList(nullptr, device_extension_properties_);
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -258,7 +258,11 @@ void GPU_Vulkan::CheckGPUFeatures() {
 
 	uint32_t fmt4444 = draw_->GetDataFormatSupport(Draw::DataFormat::B4G4R4A4_UNORM_PACK16);
 	uint32_t fmt1555 = draw_->GetDataFormatSupport(Draw::DataFormat::A1R5G5B5_UNORM_PACK16);
-	uint32_t fmt565 = draw_->GetDataFormatSupport(Draw::DataFormat::R5G6B5_UNORM_PACK16);
+
+	// Note that we are (accidentally) using B5G6R5 instead of the mandatory R5G6B5.
+	// Support is almost as widespread, but not quite. So let's just not use any 16-bit formats
+	// if it's not available, for simplicity.
+	uint32_t fmt565 = draw_->GetDataFormatSupport(Draw::DataFormat::B5G6R5_UNORM_PACK16);
 	if ((fmt4444 & Draw::FMT_TEXTURE) && (fmt565 & Draw::FMT_TEXTURE) && (fmt1555 & Draw::FMT_TEXTURE)) {
 		features |= GPU_SUPPORTS_16BIT_FORMATS;
 	} else {


### PR DESCRIPTION
Works around #14602 for now.

Also minor code cleanup.