### PR TITLE
Viewport fixes

### DIFF
--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -664,6 +664,12 @@ void ConvertViewportAndScissor(bool useBufferedRendering, float renderWidth, flo
 				left += overageLeft;
 				right -= overageRight;
 
+				// Protect against the viewport being entirely outside the scissor.
+				// Emit a tiny but valid viewport. Really, we should probably emit a flag to ignore draws.
+				if (right <= left) {
+					right = left + 1.0f;
+				}
+
 				wScale = vpWidth / (right - left);
 				xOffset = drift / (right - left);
 			}
@@ -686,6 +692,12 @@ void ConvertViewportAndScissor(bool useBufferedRendering, float renderWidth, flo
 			if (overageTop != 0.0f || overageBottom != 0.0f) {
 				top += overageTop;
 				bottom -= overageBottom;
+
+				// Protect against the viewport being entirely outside the scissor.
+				// Emit a tiny but valid  viewport. Really, we should probably emit a flag to ignore draws.
+				if (bottom <= top) {
+					bottom = top + 1.0f;
+				}
 
 				hScale = vpHeight / (bottom - top);
 				yOffset = drift / (bottom - top);

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -575,9 +575,6 @@ void ConvertViewportAndScissor(bool useBufferedRendering, float renderWidth, flo
 		renderHeightFactor = renderHeight / 272.0f;
 	}
 
-	_assert_(renderWidthFactor > 0.0);
-	_assert_(renderHeightFactor > 0.0);
-
 	renderX = gstate_c.curRTOffsetX;
 
 	// Scissor
@@ -697,11 +694,8 @@ void ConvertViewportAndScissor(bool useBufferedRendering, float renderWidth, flo
 
 		out.viewportX = left * renderWidthFactor + displayOffsetX;
 		out.viewportY = top * renderHeightFactor + displayOffsetY;
-
-		// The calculations should end up with zero or positive values, but let's protect against any
-		// precision issues. See #13921.
-		out.viewportW = std::max(0.0f, (right - left) * renderWidthFactor);
-		out.viewportH = std::max(0.0f, (bottom - top) * renderHeightFactor);
+		out.viewportW = (right - left) * renderWidthFactor;
+		out.viewportH = (bottom - top) * renderHeightFactor;
 
 		// The depth viewport parameters are the same, but we handle it a bit differently.
 		// When clipping is enabled, depth is clamped to [0, 65535].  And minz/maxz discard.


### PR DESCRIPTION
New attempt at fixing #13921.

The viewport clipping logic can result in negative or zero values if the viewport is outside the scissor.

At least Vulkan rejects 0-sized viewports so let's simply set the dimension to 1px in this case, which already should result in no drawing due to being outside the scissor.

@Panderner can you check if Gradius Collection is okay when this is in?