### PR TITLE
Enable scoped storage enforcement on Android 11+.

### DIFF
--- a/Common/Data/Text/Parsers.cpp
+++ b/Common/Data/Text/Parsers.cpp
@@ -6,6 +6,23 @@
 
 #include "Common/StringUtils.h"
 
+// Not strictly a parser...
+void NiceSizeFormat(size_t size, char *out, size_t bufSize) {
+	const char *sizes[] = { "B","KB","MB","GB","TB","PB","EB" };
+	int s = 0;
+	int frac = 0;
+	while (size >= 1024) {
+		s++;
+		frac = (int)size & 1023;
+		size /= 1024;
+	}
+	float f = (float)size + ((float)frac / 1024.0f);
+	if (s == 0)
+		snprintf(out, bufSize, "%d B", (int)size);
+	else
+		snprintf(out, bufSize, "%3.1f %s", f, sizes[s]);
+}
+
 bool Version::ParseVersionString(std::string str) {
 	if (str.empty())
 		return false;

--- a/Common/Data/Text/Parsers.h
+++ b/Common/Data/Text/Parsers.h
@@ -70,3 +70,5 @@ static bool TryParse(const std::string &str, N *const output) {
 	} else
 		return false;
 }
+
+void NiceSizeFormat(size_t size, char *out, size_t bufSize);

--- a/Common/File/AndroidStorage.cpp
+++ b/Common/File/AndroidStorage.cpp
@@ -279,7 +279,9 @@ const char *Android_ErrorToString(StorageError error) {
 
 #else
 
-// This string should never appear except on Android.
+// These strings should never appear except on Android.
+// Very hacky.
 std::string g_extFilesDir = "(IF YOU SEE THIS THERE'S A BUG)";
+std::string g_externalDir = "(IF YOU SEE THIS THERE'S A BUG (2))";
 
 #endif

--- a/Common/File/AndroidStorage.h
+++ b/Common/File/AndroidStorage.h
@@ -30,11 +30,12 @@ inline StorageError StorageErrorFromInt(int ival) {
 	}
 }
 
+extern std::string g_extFilesDir;
+extern std::string g_externalDir;
+
 #if PPSSPP_PLATFORM(ANDROID) && !defined(__LIBRETRO__)
 
 #include <jni.h>
-
-extern std::string g_extFilesDir;
 
 void Android_StorageSetNativeActivity(jobject nativeActivity);
 
@@ -58,8 +59,6 @@ std::vector<File::FileInfo> Android_ListContentUri(const std::string &uri);
 void Android_RegisterStorageCallbacks(JNIEnv * env, jobject obj);
 
 #else
-
-extern std::string g_extFilesDir;
 
 // Stub out the Android Storage wrappers, so that we can avoid ifdefs everywhere.
 

--- a/Common/File/DiskFree.cpp
+++ b/Common/File/DiskFree.cpp
@@ -41,9 +41,11 @@ bool free_disk_space(const Path &path, int64_t &space) {
 	int res = statvfs(path.c_str(), &diskstat);
 
 	if (res == 0) {
+		// Not sure why we're excluding Android here anyway...
 #ifndef __ANDROID__
 		if (diskstat.f_flag & ST_RDONLY) {
-			space = -1;
+			// No space to write.
+			space = 0;
 			return true;
 		}
 #endif

--- a/Common/File/DiskFree.cpp
+++ b/Common/File/DiskFree.cpp
@@ -23,7 +23,7 @@
 #include "Common/File/AndroidStorage.h"
 #include "Common/Data/Encoding/Utf8.h"
 
-bool free_disk_space(const Path &path, uint64_t &space) {
+bool free_disk_space(const Path &path, int64_t &space) {
 #ifdef _WIN32
 	ULARGE_INTEGER free;
 	if (GetDiskFreeSpaceExW(path.ToWString().c_str(), &free, nullptr, nullptr)) {
@@ -43,7 +43,7 @@ bool free_disk_space(const Path &path, uint64_t &space) {
 	if (res == 0) {
 #ifndef __ANDROID__
 		if (diskstat.f_flag & ST_RDONLY) {
-			space = 0;
+			space = -1;
 			return true;
 		}
 #endif

--- a/Common/File/DiskFree.h
+++ b/Common/File/DiskFree.h
@@ -4,4 +4,5 @@
 
 #include "Common/File/Path.h"
 
-bool free_disk_space(const Path &path, uint64_t &space);
+// If this fails, false is returned and space is negative.
+bool free_disk_space(const Path &path, int64_t &space);

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -510,7 +510,10 @@ bool CreateFullPath(const Path &path) {
 
 	Path root = path.GetRootVolume();
 
-	std::string diff = root.PathTo(path);  // always with forward slashes
+	std::string diff;
+	if (!root.ComputePathTo(path, diff)) {
+		return false;
+	}
 
 	std::vector<std::string> parts;
 	SplitString(diff, '/', parts);

--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -236,7 +236,6 @@ bool Path::CanNavigateUp() const {
 	if (type_ == PathType::CONTENT_URI) {
 		return AndroidContentURI(path_).CanNavigateUp();
 	}
-
 	if (path_ == "/" || path_ == "") {
 		return false;
 	}

--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -299,27 +299,32 @@ bool Path::IsAbsolute() const {
 		return false;
 }
 
-std::string Path::PathTo(const Path &other) const {
+bool Path::ComputePathTo(const Path &other, std::string &path) const {
 	if (!other.StartsWith(*this)) {
 		// Can't do this. Should return an error.
-		return std::string();
+		return false;
+	}
+
+	if (*this == other) {
+		// Equal, the path is empty.
+		path.clear();
+		return true;
 	}
 
 	std::string diff;
-
 	if (type_ == PathType::CONTENT_URI) {
 		AndroidContentURI a(path_);
 		AndroidContentURI b(other.path_);
 		if (a.RootPath() != b.RootPath()) {
 			// No common root, can't do anything
-			return std::string();
+			return false;
 		}
-		diff = a.PathTo(b);
+		return a.ComputePathTo(b, path);
 	} else if (path_ == "/") {
-		diff = other.path_.substr(1);
+		path = other.path_.substr(1);
+		return true;
 	} else {
-		diff = other.path_.substr(path_.size() + 1);
+		path = other.path_.substr(path_.size() + 1);
+		return true;
 	}
-
-	return diff;
 }

--- a/Common/File/Path.h
+++ b/Common/File/Path.h
@@ -82,7 +82,7 @@ public:
 	// For Android directory trees, navigates to the root of the tree.
 	Path GetRootVolume() const;
 
-	std::string PathTo(const Path &child) const;
+	bool ComputePathTo(const Path &other, std::string &path) const;
 
 	bool operator ==(const Path &other) const {
 		return path_ == other.path_ && type_ == other.type_;

--- a/Common/File/PathBrowser.cpp
+++ b/Common/File/PathBrowser.cpp
@@ -144,10 +144,13 @@ void PathBrowser::HandlePath() {
 
 		std::unique_lock<std::mutex> guard(pendingLock_);
 		std::vector<File::FileInfo> results;
-		Path lastPath;
+		Path lastPath("NONSENSE THAT WONT EQUAL A PATH");
 		while (!pendingStop_) {
 			while (lastPath == pendingPath_ && !pendingCancel_) {
 				pendingCond_.wait(guard);
+			}
+			if (pendingStop_) {
+				break;
 			}
 			lastPath = pendingPath_;
 			bool success = false;
@@ -156,6 +159,9 @@ void PathBrowser::HandlePath() {
 				results.clear();
 				success = LoadRemoteFileList(lastPath, &pendingCancel_, results);
 				guard.lock();
+			} else if (lastPath.empty()) {
+				results.clear();
+				success = true;
 			} else {
 				guard.unlock();
 				results.clear();

--- a/Common/File/PathBrowser.h
+++ b/Common/File/PathBrowser.h
@@ -35,6 +35,10 @@ public:
 	}
 	std::string GetFriendlyPath() const;
 
+	bool empty() const {
+		return path_.empty();
+	}
+
 private:
 	void HandlePath();
 	void ResetPending();

--- a/Common/System/NativeApp.h
+++ b/Common/System/NativeApp.h
@@ -89,3 +89,5 @@ void NativeSetMixer(void* mixer);
 // Main thread.
 void NativeShutdownGraphics();
 void NativeShutdown();
+
+void PostLoadConfig();

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -163,6 +163,8 @@ void ScreenManager::render() {
 				iter--;
 				Layer backback = *iter;
 
+				_assert_(backback.screen);
+
 				// TODO: Make really sure that this "mismatched" pre/post only happens
 				// when screens are "compatible" (both are UIScreens, for example).
 				backback.screen->preRender();
@@ -174,6 +176,7 @@ void ScreenManager::render() {
 				break;
 			}
 		default:
+			_assert_(stack_.back().screen);
 			stack_.back().screen->preRender();
 			stack_.back().screen->render();
 			if (postRenderCb_)

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1412,12 +1412,14 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	INFO_LOG(LOADER, "Config loaded: '%s'", iniFilename_.c_str());
 }
 
-void Config::Save(const char *saveReason) {
+bool Config::Save(const char *saveReason) {
 	if (!IsFirstInstance()) {
 		// TODO: Should we allow saving config if started from a different directory?
 		// How do we tell?
 		WARN_LOG(LOADER, "Not saving config - secondary instances don't.");
-		return;
+
+		// Don't want to retry or something.
+		return true;
 	}
 
 	if (jitForcedOff) {
@@ -1488,7 +1490,7 @@ void Config::Save(const char *saveReason) {
 		if (!iniFile.Save(iniFilename_)) {
 			ERROR_LOG(LOADER, "Error saving config (%s)- can't write ini '%s'", saveReason, iniFilename_.c_str());
 			System_SendMessage("toast", "Failed to save settings!\nCheck permissions, or try to restart the device.");
-			return;
+			return false;
 		}
 		INFO_LOG(LOADER, "Config saved (%s): '%s'", saveReason, iniFilename_.c_str());
 
@@ -1501,7 +1503,7 @@ void Config::Save(const char *saveReason) {
 			KeyMap::SaveToIni(controllerIniFile);
 			if (!controllerIniFile.Save(controllerIniFilename_)) {
 				ERROR_LOG(LOADER, "Error saving config - can't write ini '%s'", controllerIniFilename_.c_str());
-				return;
+				return false;
 			}
 			INFO_LOG(LOADER, "Controller config saved: %s", controllerIniFilename_.c_str());
 		}
@@ -1512,6 +1514,7 @@ void Config::Save(const char *saveReason) {
 		// force JIT off again just in case Config::Save() is called without exiting PPSSPP
 		g_Config.iCpuCore = (int)CPUCore::INTERPRETER;
 	}
+	return true;
 }
 
 // Use for debugging the version check without messing with the server

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -490,7 +490,7 @@ public:
 	std::string dismissedVersion;
 
 	void Load(const char *iniFileName = nullptr, const char *controllerIniFilename = nullptr);
-	void Save(const char *saveReason);
+	bool Save(const char *saveReason);
 	void Reload();
 	void RestoreDefaults();
 

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1045,11 +1045,11 @@ int SavedataParam::BuildHash(unsigned char *output,
 	return 0;
 }
 
+// TODO: Merge with NiceSizeFormat? That one has a decimal though.
 std::string SavedataParam::GetSpaceText(u64 size, bool roundUp)
 {
-	static const char *suffixes[] = {"B", "KB", "MB", "GB"};
 	char text[50];
-
+	static const char *suffixes[] = {"B", "KB", "MB", "GB"};
 	for (size_t i = 0; i < ARRAY_SIZE(suffixes); ++i)
 	{
 		if (size < 1024)
@@ -1063,7 +1063,6 @@ std::string SavedataParam::GetSpaceText(u64 size, bool roundUp)
 			size /= 1024;
 		}
 	}
-
 	snprintf(text, sizeof(text), "%llu TB", size);
 	return std::string(text);
 }

--- a/Core/FileLoaders/DiskCachingFileLoader.cpp
+++ b/Core/FileLoaders/DiskCachingFileLoader.cpp
@@ -754,9 +754,9 @@ u64 DiskCachingFileLoaderCache::FreeDiskSpace() {
 		dir = GetSysDirectory(DIRECTORY_CACHE);
 	}
 
-	uint64_t result = 0;
+	int64_t result = 0;
 	if (free_disk_space(dir, result)) {
-		return result;
+		return (u64)result;
 	}
 
 	// We can't know for sure how much is free, so we have to assume none.

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -925,9 +925,9 @@ std::vector<PSPFileInfo> DirectoryFileSystem::GetDirListing(std::string path) {
 }
 
 u64 DirectoryFileSystem::FreeSpace(const std::string &path) {
-	uint64_t result = 0;
+	int64_t result = 0;
 	if (free_disk_space(GetLocalPath(path), result)) {
-		return ReplayApplyDisk64(ReplayAction::FREESPACE, result, CoreTiming::GetGlobalTimeUs());
+		return ReplayApplyDisk64(ReplayAction::FREESPACE, (uint64_t)result, CoreTiming::GetGlobalTimeUs());
 	}
 
 #if HOST_IS_CASE_SENSITIVE

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -501,7 +501,8 @@ static int sceCtrlReadBufferNegative(u32 ctrlDataPtr, u32 nBufs)
 static int sceCtrlPeekBufferPositive(u32 ctrlDataPtr, u32 nBufs)
 {
 	int done = __CtrlReadBuffer(ctrlDataPtr, nBufs, false, true);
-	DEBUG_LOG(SCECTRL, "%d=sceCtrlPeekBufferPositive(%08x, %i)", done, ctrlDataPtr, nBufs);
+	// Some homebrew call this in a tight loop - so VERBOSE it is.
+	VERBOSE_LOG(SCECTRL, "%d=sceCtrlPeekBufferPositive(%08x, %i)", done, ctrlDataPtr, nBufs);
 	hleEatCycles(330);
 	return done;
 }
@@ -509,7 +510,8 @@ static int sceCtrlPeekBufferPositive(u32 ctrlDataPtr, u32 nBufs)
 static int sceCtrlPeekBufferNegative(u32 ctrlDataPtr, u32 nBufs)
 {
 	int done = __CtrlReadBuffer(ctrlDataPtr, nBufs, true, true);
-	DEBUG_LOG(SCECTRL, "%d=sceCtrlPeekBufferNegative(%08x, %i)", done, ctrlDataPtr, nBufs);
+	// Some homebrew call this in a tight loop - so VERBOSE it is.
+	VERBOSE_LOG(SCECTRL, "%d=sceCtrlPeekBufferNegative(%08x, %i)", done, ctrlDataPtr, nBufs);
 	hleEatCycles(330);
 	return done;
 }

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -558,13 +558,6 @@ static void __IoAsyncEndCallback(SceUID threadID, SceUID prevCallbackId) {
 	}
 }
 
-static DirectoryFileSystem *exdataSystem = nullptr;
-#if defined(USING_WIN_UI) || defined(APPLE)
-static DirectoryFileSystem *flash0System = nullptr;
-#else
-static VFSFileSystem *flash0System = nullptr;
-#endif
-
 static void __IoManagerThread() {
 	SetCurrentThreadName("IO");
 	while (ioManagerThreadEnabled && coreState != CORE_BOOT_ERROR && coreState != CORE_RUNTIME_ERROR && coreState != CORE_POWERDOWN) {

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -23,6 +23,7 @@
 #include "Common/System/NativeApp.h"
 #include "Common/System/System.h"
 #include "Common/GPU/OpenGL/GLFeatures.h"
+#include "Common/File/AndroidStorage.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Net/HTTPClient.h"
 #include "Common/UI/Context.h"
@@ -59,11 +60,7 @@
 int GetD3DCompilerVersion();
 #endif
 
-#if PPSSPP_PLATFORM(ANDROID)
-
 #include "android/jni/app-android.h"
-
-#endif
 
 static const char *logLevelList[] = {
 	"Notice",
@@ -595,6 +592,7 @@ void SystemInfoScreen::CreateViews() {
 	if (System_GetPropertyBool(SYSPROP_ANDROID_SCOPED_STORAGE)) {
 		storage->Add(new InfoItem("Scoped Storage", di->T("Yes")));
 	}
+	storage->Add(new InfoItem("IsStoragePreservedLegacy", Android_IsExternalStoragePreservedLegacy() ? di->T("Yes") : di->T("No")));
 #endif
 
 	ViewGroup *buildConfigScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -589,10 +589,12 @@ void SystemInfoScreen::CreateViews() {
 
 #if PPSSPP_PLATFORM(ANDROID)
 	storage->Add(new InfoItem("ExtFilesDir", g_extFilesDir));
-	if (System_GetPropertyBool(SYSPROP_ANDROID_SCOPED_STORAGE)) {
-		storage->Add(new InfoItem("Scoped Storage", di->T("Yes")));
+	bool scoped = System_GetPropertyBool(SYSPROP_ANDROID_SCOPED_STORAGE);
+	storage->Add(new InfoItem("Scoped Storage Enabled", scoped ? di->T("Yes") : di->T("No")));
+	if (System_GetPropertyInt(SYSPROP_SYSTEMVERSION) >= 30) {
+		// This flag is only relevant on Android API 30+.
+		storage->Add(new InfoItem("IsStoragePreservedLegacy", Android_IsExternalStoragePreservedLegacy() ? di->T("Yes") : di->T("No")));
 	}
-	storage->Add(new InfoItem("IsStoragePreservedLegacy", Android_IsExternalStoragePreservedLegacy() ? di->T("Yes") : di->T("No")));
 #endif
 
 	ViewGroup *buildConfigScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1097,7 +1097,7 @@ UI::EventReturn GameSettingsScreen::OnJitAffectingSetting(UI::EventParams &e) {
 }
 
 UI::EventReturn GameSettingsScreen::OnChangeMemStickDir(UI::EventParams &e) {
-	screenManager()->push(new MemStickScreen());
+	screenManager()->push(new MemStickScreen(false));
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1257,6 +1257,12 @@ void GameSettingsScreen::sendMessage(const char *message, const char *value) {
 	}
 }
 
+void GameSettingsScreen::dialogFinished(const Screen *dialog, DialogResult result) {
+	if (result == DialogResult::DR_OK) {
+		RecreateViews();
+	}
+}
+
 void GameSettingsScreen::CallbackMemstickFolder(bool yes) {
 	auto sy = GetI18NCategory("System");
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -903,9 +903,6 @@ void GameSettingsScreen::CreateViews() {
 
 	systemSettings->Add(new ItemHeader(sy->T("PSP Memory Stick")));
 
-	systemSettings->Add(new CheckBox(&g_Config.bMemStickInserted, sy->T("Memory Stick inserted")));
-	systemSettings->Add(new PopupSliderChoice(&g_Config.iMemStickSizeGB, 1, 32, sy->T("Change Memory Stick Size", "Memory Stick Size (GB)"), screenManager(), "GB"));
-
 #if PPSSPP_PLATFORM(ANDROID)
 	memstickDisplay_ = g_Config.memStickDirectory.ToVisualString();
 	auto memstickPath = systemSettings->Add(new ChoiceWithValueDisplay(&memstickDisplay_, sy->T("Change Memory Stick folder", "Memory Stick folder"), (const char *)nullptr));
@@ -955,6 +952,9 @@ void GameSettingsScreen::CreateViews() {
 		}
 	}
 #endif
+	systemSettings->Add(new CheckBox(&g_Config.bMemStickInserted, sy->T("Memory Stick inserted")));
+	systemSettings->Add(new PopupSliderChoice(&g_Config.iMemStickSizeGB, 1, 32, sy->T("Change Memory Stick Size", "Memory Stick Size (GB)"), screenManager(), "GB"));
+
 	systemSettings->Add(new ItemHeader(sy->T("General")));
 
 #if PPSSPP_PLATFORM(ANDROID)

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -43,6 +43,7 @@ protected:
 	void CallbackInflightFrames(bool yes);
 	void CallbackMemstickFolder(bool yes);
 	bool UseVerticalLayout() const;
+	void dialogFinished(const Screen *dialog, DialogResult result) override;
 
 private:
 	void TriggerRestart(const char *why);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -816,13 +816,17 @@ void GameBrowser::Refresh() {
 	}
 
 	// Show a button to toggle pinning at the very end.
-	if (browseFlags_ & BrowseFlags::PIN) {
+	if ((browseFlags_ & BrowseFlags::PIN) && !path_.GetPath().empty()) {
 		std::string caption = IsCurrentPathPinned() ? "-" : "+";
 		if (!*gridStyle_) {
 			caption = IsCurrentPathPinned() ? mm->T("UnpinPath", "Unpin") : mm->T("PinPath", "Pin");
 		}
 		gameList_->Add(new UI::Button(caption, new UI::LinearLayoutParams(UI::FILL_PARENT, UI::FILL_PARENT)))->
 			OnClick.Handle(this, &GameBrowser::PinToggleClick);
+	}
+
+	if (path_.GetPath().empty()) {
+		Add(new TextView(mm->T("UseBrowseOrLoad", "Use Browse to choose a folder, or Load to choose a file.")));
 	}
 
 	if (!lastText_.empty() && gameButtons.empty()) {

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -978,7 +978,8 @@ void MainScreen::CreateViews() {
 	tabHolder_->SetClip(true);
 
 	bool showRecent = g_Config.iMaxRecent > 0;
-	bool hasStorageAccess = System_GetPermissionStatus(SYSTEM_PERMISSION_STORAGE) == PERMISSION_STATUS_GRANTED;
+	bool hasStorageAccess = !System_GetPropertyBool(SYSPROP_SUPPORTS_PERMISSIONS) ||
+		System_GetPermissionStatus(SYSTEM_PERMISSION_STORAGE) == PERMISSION_STATUS_GRANTED;
 	bool storageIsTemporary = IsTempPath(GetSysDirectory(DIRECTORY_SAVEDATA)) && !confirmedTemporary_;
 	if (showRecent && !hasStorageAccess) {
 		showRecent = !g_Config.recentIsos.empty();

--- a/UI/MemStickScreen.cpp
+++ b/UI/MemStickScreen.cpp
@@ -25,23 +25,26 @@
 #include "Common/UI/ViewGroup.h"
 
 #include "Common/StringUtils.h"
-#include "Common/File/FileUtil.h"
-#include "Common/File/Path.h"
 #include "Common/System/System.h"
 #include "Common/System/NativeApp.h"
-#include "Common/Data/Text/I18n.h"
 #include "Common/System/Display.h"
+#include "Common/Data/Text/I18n.h"
+
+#include "Common/File/AndroidStorage.h"
+#include "Common/File/FileUtil.h"
+#include "Common/File/Path.h"
 
 #include "Core/Util/GameManager.h"
 #include "Core/System.h"
+#include "Core/Config.h"
 
 #include "UI/MemStickScreen.h"
 #include "UI/MainScreen.h"
 #include "UI/MiscScreens.h"
 
-#include "Core/Config.h"
-
-MemStickScreen::~MemStickScreen() { }
+MemStickScreen::~MemStickScreen() {
+	pendingMemStickFolder_ = g_Config.memStickDirectory;
+}
 
 void MemStickScreen::CreateViews() {
 	using namespace UI;
@@ -51,45 +54,68 @@ void MemStickScreen::CreateViews() {
 
 	Margins actionMenuMargins(15, 15, 15, 0);
 
-	root_ = new AnchorLayout();
+	root_ = new LinearLayout(ORIENT_HORIZONTAL, new AnchorLayoutParams(FILL_PARENT, FILL_PARENT));
 
-	ViewGroup *columns = new LinearLayout(ORIENT_HORIZONTAL, new AnchorLayoutParams(FILL_PARENT, FILL_PARENT));
-	root_->Add(columns);
-
-	ViewGroup *leftColumn = new AnchorLayout(new LinearLayoutParams(1.0));
+	Spacer *spacerColumn = new Spacer(new LinearLayoutParams(20.0, FILL_PARENT, 0.0f));
+	ViewGroup *leftColumn = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0));
 	ViewGroup *rightColumnItems = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(300, FILL_PARENT, actionMenuMargins));
-	columns->Add(leftColumn);
-	columns->Add(rightColumnItems);
+	root_->Add(spacerColumn);
+	root_->Add(leftColumn);
+	root_->Add(rightColumnItems);
 
-	Path path = g_Config.memStickDirectory;
-	int64_t freeSpaceAtMemStick = -1;
-#if PPSSPP_PLATFORM(ANDROID)
-	if (Android_IsContentUri(path.ToString())) {
-		freeSpaceAtMemStick = Android_GetFreeSpaceByContentUri(path.ToString());
-	} else {
-		freeSpaceAtMemStick = Android_GetFreeSpaceByFilePath(path.ToString());
+	if (initialSetup_) {
+		leftColumn->Add(new TextView(iz->T("Welcome to PPSSPP!"), ALIGN_LEFT, false));
+		leftColumn->Add(new Spacer(new LinearLayoutParams(FILL_PARENT, 12.0f, 0.0f)));
+	}
+
+	leftColumn->Add(new TextView(iz->T("MemoryStickDescription", "Choose PSP data storage (Memory Stick)"), ALIGN_LEFT, false));
+
+#if !PPSSPP_PLATFORM(WINDOWS)
+	if (!pendingMemStickFolder_.empty()) {
+		int64_t freeSpaceAtMemStick = -1;
+		if (Android_IsContentUri(pendingMemStickFolder_.ToString())) {
+			freeSpaceAtMemStick = Android_GetFreeSpaceByContentUri(pendingMemStickFolder_.ToString());
+		} else {
+			freeSpaceAtMemStick = Android_GetFreeSpaceByFilePath(pendingMemStickFolder_.ToString());
+		}
+
+		leftColumn->Add(new TextView(pendingMemStickFolder_.ToVisualString(), ALIGN_LEFT, false));
+		std::string freeSpaceText = "Free space: N/A";
+		if (freeSpaceAtMemStick >= 0) {
+			freeSpaceText = StringFromFormat("free space: %lld MB", freeSpaceAtMemStick / (1024 * 1024));
+			leftColumn->Add(new TextView(freeSpaceText, ALIGN_LEFT, false));
+		}
+	}
+
+	if (!g_Config.memStickDirectory.empty()) {
+		TextView *view = leftColumn->Add(new TextView(g_Config.memStickDirectory.ToVisualString(), ALIGN_LEFT, false));
+		view->SetShadow(true);
 	}
 #endif
 
-	int leftSide = 100;
-	settingInfo_ = new SettingInfoMessage(ALIGN_CENTER | FLAG_WRAP_TEXT, new AnchorLayoutParams(dp_xres - leftSide - 40.0f, WRAP_CONTENT, leftSide, dp_yres - 80.0f - 40.0f, NONE, NONE));
-	settingInfo_->SetBottomCutoff(dp_yres - 200.0f);
+	leftColumn->Add(new Choice(iz->T("Create or Choose a PSP folder")))->OnClick.Handle(this, &MemStickScreen::OnBrowse);
+	leftColumn->Add(new TextView(iz->T("ChooseFolderDesc", "* Data will stay even if you uninstall PPSSPP.\n* Data can be shared with PPSSPP Gold\n* Easy USB access"), ALIGN_LEFT, false));
 
-	root_->Add(settingInfo_);
+	leftColumn->Add(new Choice(iz->T("Use App Private Directory")))->OnClick.Handle(this, &MemStickScreen::OnUseInternalStorage);
+	leftColumn->Add(new TextView(iz->T("InternalStorageDesc", "* Warning! Data will be deleted if you uninstall PPSSPP!\n* Data cannot be shared with PPSSPP Gold\n* USB access through Android/data/org.ppsspp.ppsspp/files"), ALIGN_LEFT, false));
 
-	leftColumn->Add(new TextView(iz->T("Memory Stick Storage"), ALIGN_LEFT, false, new AnchorLayoutParams(10, 10, NONE, NONE)));
-	leftColumn->Add(new TextView(iz->T("MemoryStickDescription", "Choose where your PSP memory stick data (savegames, etc) is stored"), ALIGN_LEFT, false, new AnchorLayoutParams(10, 50, NONE, NONE)));
-	leftColumn->Add(new TextView(g_Config.memStickDirectory.ToVisualString(), ALIGN_LEFT, false, new AnchorLayoutParams(10, 140, NONE, NONE)));
+	leftColumn->Add(new Spacer(new LinearLayoutParams(FILL_PARENT, 12.0f, 0.0f)));
 
-	std::string freeSpaceText = "Free space: N/A";
-	if (freeSpaceAtMemStick >= 0) {
-		freeSpaceText = StringFromFormat("free space: %lld MB", freeSpaceAtMemStick / (1024 * 1024));
+	Choice *confirmButton = rightColumnItems->Add(new Choice(iz->T("Confirm")));
+	confirmButton->OnClick.Handle(this, &MemStickScreen::OnConfirm);
+	confirmButton->SetEnabled(!pendingMemStickFolder_.empty());
+
+	if (!initialSetup_) {
+		rightColumnItems->Add(new CheckBox(&moveData_, iz->T("Move Data")));
+		rightColumnItems->Add(new Choice(di->T("Back")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnOK);
 	}
 
-	leftColumn->Add(new TextView(freeSpaceText, ALIGN_LEFT, false, new AnchorLayoutParams(10, 240, NONE, NONE)));
+	INFO_LOG(SYSTEM, "MemStickScreen: initialSetup=%d", (int)initialSetup_);
+}
 
-	rightColumnItems->Add(new Choice(iz->T("Browse")))->OnClick.Handle(this, &MemStickScreen::OnBrowse);
-	rightColumnItems->Add(new Choice(di->T("Back")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnOK);
+UI::EventReturn MemStickScreen::OnUseInternalStorage(UI::EventParams &params) {
+	pendingMemStickFolder_ = Path(g_extFilesDir);
+	return UI::EVENT_DONE;
 }
 
 UI::EventReturn MemStickScreen::OnBrowse(UI::EventParams &params) {
@@ -108,48 +134,52 @@ void MemStickScreen::sendMessage(const char *message, const char *value) {
 			filename = value;
 			INFO_LOG(SYSTEM, "Got folder: '%s'", filename.c_str());
 			pendingMemStickFolder_ = Path(filename);
-			CallbackMemStickFolder(true);
+			RecreateViews();
 		}
 	}
 }
 
-void MemStickScreen::CallbackMemStickFolder(bool yes) {
+UI::EventReturn MemStickScreen::OnConfirm(UI::EventParams &params) {
 	auto sy = GetI18NCategory("System");
 
-	if (yes) {
-		Path memStickDirFile = g_Config.internalDataDirectory / "memstick_dir.txt";
-		Path testWriteFile = pendingMemStickFolder_ / ".write_verify_file";
+	Path memStickDirFile = g_Config.internalDataDirectory / "memstick_dir.txt";
+	Path testWriteFile = pendingMemStickFolder_ / ".write_verify_file";
 
-		// Doesn't already exist, create.
-		// Should this ever happen?
-		if (pendingMemStickFolder_.Type() == PathType::NATIVE) {
-			if (!File::Exists(pendingMemStickFolder_)) {
-				File::CreateFullPath(pendingMemStickFolder_);
-			}
-			if (!File::WriteDataToFile(true, "1", 1, testWriteFile)) {
-				settingInfo_->Show(sy->T("ChangingMemstickPathInvalid", "That path couldn't be used to save Memory Stick files."), nullptr);
-				return;
-			}
-			File::Delete(testWriteFile);
-		} else {
-			// TODO: Do the same but with scoped storage? Not really necessary, right? If it came from a browse
-			// for folder, we can assume it exists, barring wacky race conditions like the user being connected
-			// by USB and deleting it.
+	// Doesn't already exist, create.
+	// Should this ever happen?
+	if (pendingMemStickFolder_.Type() == PathType::NATIVE) {
+		if (!File::Exists(pendingMemStickFolder_)) {
+			File::CreateFullPath(pendingMemStickFolder_);
 		}
-
-		// This doesn't need the storage API - this path is accessible the normal way.
-		std::string str = pendingMemStickFolder_.ToString();
-		if (!File::WriteDataToFile(true, str.c_str(), (unsigned int)str.size(), memStickDirFile)) {
-			ERROR_LOG(SYSTEM, "Failed to write memstick path '%s' to '%s'", pendingMemStickFolder_.c_str(), memStickDirFile.c_str());
-			// Not sure what to do if this file.
+		if (!File::WriteDataToFile(true, "1", 1, testWriteFile)) {
+			// settingInfo_->Show(sy->T("ChangingMemstickPathInvalid", "That path couldn't be used to save Memory Stick files."), nullptr);
+			return UI::EVENT_DONE;
 		}
-
-		// Save so the settings, at least, are transferred.
-		g_Config.memStickDirectory = pendingMemStickFolder_;
-		g_Config.SetSearchPath(GetSysDirectory(DIRECTORY_SYSTEM));
-		g_Config.UpdateIniLocation();
-
-		g_Config.Save("MemstickPathChanged");
-		screenManager()->RecreateAllViews();
+		File::Delete(testWriteFile);
+	} else {
+		// TODO: Do the same but with scoped storage? Not really necessary, right? If it came from a browse
+		// for folder, we can assume it exists and is writable, barring wacky race conditions like the user
+		// being connected by USB and deleting it.
 	}
+
+	// This doesn't need the storage API - this path is accessible the normal way.
+	std::string str = pendingMemStickFolder_.ToString();
+	if (!File::WriteDataToFile(true, str.c_str(), (unsigned int)str.size(), memStickDirFile)) {
+		ERROR_LOG(SYSTEM, "Failed to write memstick path '%s' to '%s'", pendingMemStickFolder_.c_str(), memStickDirFile.c_str());
+		// Not sure what to do if this file.
+	}
+
+	// Save so the settings, at least, are transferred.
+	g_Config.memStickDirectory = pendingMemStickFolder_;
+	g_Config.SetSearchPath(GetSysDirectory(DIRECTORY_SYSTEM));
+	g_Config.UpdateIniLocation();
+
+	if (g_Config.Save("MemstickPathChanged")) {
+		TriggerFinish(DialogResult::DR_OK);
+	} else {
+		error_ = sy->T("Failed to save config");
+		RecreateViews();
+	}
+
+	return UI::EVENT_DONE;
 }

--- a/UI/MemStickScreen.cpp
+++ b/UI/MemStickScreen.cpp
@@ -29,6 +29,7 @@
 #include "Common/System/NativeApp.h"
 #include "Common/System/Display.h"
 #include "Common/Data/Text/I18n.h"
+#include "Common/Data/Text/Parsers.h"
 
 #include "Common/File/AndroidStorage.h"
 #include "Common/File/FileUtil.h"
@@ -91,8 +92,9 @@ static bool SwitchMemstickFolderTo(Path newMemstickFolder) {
 
 static std::string FormatSpaceString(int64_t space) {
 	if (space >= 0) {
-		// TODO: Smarter display (MB, GB as appropriate). Don't we have one of these somewhere?
-		return StringFromFormat("%lld MB", space / (1024 * 1024));
+		char buffer[50];
+		NiceSizeFormat(space, buffer, sizeof(buffer));
+		return buffer;
 	} else {
 		return "N/A";
 	}

--- a/UI/MemStickScreen.cpp
+++ b/UI/MemStickScreen.cpp
@@ -216,7 +216,10 @@ void MemStickScreen::sendMessage(const char *message, const char *value) {
 
 			if (pendingMemStickFolder == g_Config.memStickDirectory) {
 				auto iz = GetI18NCategory("MemStick");
+#if PPSSPP_PLATFORM(ANDROID)
 				SystemToast(iz->T("That's the folder being used!"));
+#endif
+				return;
 			}
 
 			bool existingFiles = FolderSeemsToBeUsed(pendingMemStickFolder);

--- a/UI/MemStickScreen.h
+++ b/UI/MemStickScreen.h
@@ -30,19 +30,27 @@
 // Currently only useful for Android.
 class MemStickScreen : public UIDialogScreenWithBackground {
 public:
-	MemStickScreen() {}
+	MemStickScreen(bool initialSetup)
+		: initialSetup_(initialSetup) {}
     virtual ~MemStickScreen();
 
 	std::string tag() const override { return "game"; }
+	void CreateViews() override;
 
 protected:
-	void CreateViews() override;
-	void CallbackMemStickFolder(bool yes);
 	void sendMessage(const char *message, const char *value) override;
 
 private:
 	// Event handlers
 	UI::EventReturn OnBrowse(UI::EventParams &e);
+	UI::EventReturn OnConfirm(UI::EventParams &params);
+	UI::EventReturn OnUseInternalStorage(UI::EventParams &params);
+
 	Path pendingMemStickFolder_;
-	SettingInfoMessage *settingInfo_;
+	SettingInfoMessage *settingInfo_ = nullptr;
+
+	std::string error_;
+
+	bool initialSetup_;
+	bool moveData_ = true;
 };

--- a/UI/MemStickScreen.h
+++ b/UI/MemStickScreen.h
@@ -40,6 +40,15 @@ protected:
 	void sendMessage(const char *message, const char *value) override;
 	void dialogFinished(const Screen *dialog, DialogResult result) override;
 	void update() override;
+	void render() override {
+		// Simple anti-flicker due to delayed finish.
+		if (!done_) {
+			// render as usual.
+			UIDialogScreenWithBackground::render();
+		} else {
+			// no render. black frame insertion is better than flicker.
+		}
+	}
 
 private:
 	// Event handlers

--- a/UI/MemStickScreen.h
+++ b/UI/MemStickScreen.h
@@ -34,9 +34,10 @@ public:
 	~MemStickScreen() {}
 
 	std::string tag() const override { return "game"; }
-	void CreateViews() override;
 
 protected:
+	void CreateViews() override;
+
 	void sendMessage(const char *message, const char *value) override;
 	void dialogFinished(const Screen *dialog, DialogResult result) override;
 	void update() override;
@@ -67,6 +68,7 @@ class ConfirmMemstickMoveScreen : public UIDialogScreenWithBackground {
 public:
 	ConfirmMemstickMoveScreen(Path newMemstickFolder, bool initialSetup);
 
+protected:
 	void CreateViews() override;
 
 private:

--- a/UI/MemStickScreen.h
+++ b/UI/MemStickScreen.h
@@ -30,27 +30,43 @@
 // Currently only useful for Android.
 class MemStickScreen : public UIDialogScreenWithBackground {
 public:
-	MemStickScreen(bool initialSetup)
-		: initialSetup_(initialSetup) {}
-    virtual ~MemStickScreen();
+	MemStickScreen(bool initialSetup);
+	~MemStickScreen() {}
 
 	std::string tag() const override { return "game"; }
 	void CreateViews() override;
 
 protected:
 	void sendMessage(const char *message, const char *value) override;
+	void dialogFinished(const Screen *dialog, DialogResult result) override;
+	void update() override;
 
 private:
 	// Event handlers
 	UI::EventReturn OnBrowse(UI::EventParams &e);
-	UI::EventReturn OnConfirm(UI::EventParams &params);
 	UI::EventReturn OnUseInternalStorage(UI::EventParams &params);
 
+	// TODO: probably not necessary to store here, we just forward to the confirmation dialog.
 	Path pendingMemStickFolder_;
 	SettingInfoMessage *settingInfo_ = nullptr;
 
-	std::string error_;
-
 	bool initialSetup_;
+	bool done_ = false;
+};
+
+class ConfirmMemstickMoveScreen : public UIDialogScreenWithBackground {
+public:
+	ConfirmMemstickMoveScreen(Path newMemstickFolder, bool initialSetup);
+
+	void CreateViews() override;
+
+private:
+	UI::EventReturn OnConfirm(UI::EventParams &params);
+
+	Path newMemstickFolder_;
+	bool existingFilesInNewFolder_;
 	bool moveData_ = true;
+	bool initialSetup_;
+
+	std::string error_;
 };

--- a/UI/MemStickScreen.h
+++ b/UI/MemStickScreen.h
@@ -58,9 +58,8 @@ private:
 	// Event handlers
 	UI::EventReturn OnBrowse(UI::EventParams &e);
 	UI::EventReturn OnUseInternalStorage(UI::EventParams &params);
+	UI::EventReturn OnUseStorageRoot(UI::EventParams &params);
 
-	// TODO: probably not necessary to store here, we just forward to the confirmation dialog.
-	Path pendingMemStickFolder_;
 	SettingInfoMessage *settingInfo_ = nullptr;
 
 	bool initialSetup_;

--- a/UI/MemStickScreen.h
+++ b/UI/MemStickScreen.h
@@ -92,6 +92,7 @@ protected:
 	void CreateViews() override;
 
 private:
+	UI::EventReturn OnMoveDataClick(UI::EventParams &params);
 	void FinishFolderMove();
 
 	UI::EventReturn OnConfirm(UI::EventParams &params);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -322,7 +322,9 @@ static bool CheckFontIsUsable(const wchar_t *fontFace) {
 }
 #endif
 
-static void PostLoadConfig() {
+bool CreateDirectoriesAndroid();
+
+void PostLoadConfig() {
 	// On Windows, we deal with currentDirectory in InitSysDirectories().
 #if !PPSSPP_PLATFORM(WINDOWS)
 	if (g_Config.currentDirectory.empty()) {
@@ -339,11 +341,14 @@ static void PostLoadConfig() {
 		i18nrepo.LoadIni(g_Config.sLanguageIni);
 	else
 		i18nrepo.LoadIni(g_Config.sLanguageIni, langOverridePath);
+
+#if PPSSPP_PLATFORM(ANDROID)
+	CreateDirectoriesAndroid();
+#endif
 }
 
-static bool CreateDirectoriesAndroid() {
-	// On Android, create a PSP directory tree in the external_dir,
-	// to hopefully reduce confusion a bit.
+bool CreateDirectoriesAndroid() {
+	// TODO: Really not sure why this code is Android-exclusive, except the ".nomedia" part.
 
 	Path pspDir = g_Config.memStickDirectory;
 	if (pspDir.GetFilename() != "PSP") {
@@ -530,9 +535,9 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 			} else {
 				ERROR_LOG(SYSTEM, "Couldn't read directory '%s' specified by memstick_dir.txt.", memstickDir.c_str());
 				if (System_GetPropertyBool(SYSPROP_ANDROID_SCOPED_STORAGE)) {
-				    // Ask the user to configure a memstick directory.
-                    INFO_LOG(SYSTEM, "Asking the user.");
-                    g_Config.memStickDirectory.clear();
+					// Ask the user to configure a memstick directory.
+					INFO_LOG(SYSTEM, "Asking the user.");
+					g_Config.memStickDirectory.clear();
 				}
 			}
 		}
@@ -785,7 +790,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	screenManager = new ScreenManager();
 	if (g_Config.memStickDirectory.empty()) {
 		INFO_LOG(SYSTEM, "No memstick directory! Asking for one to be configured.");
-		screenManager->switchScreen(new MainScreen());
+		screenManager->switchScreen(new LogoScreen(false));
 		screenManager->push(new MemStickScreen(true));
 	} else if (gotoGameSettings) {
 		screenManager->switchScreen(new LogoScreen(true));

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -348,7 +348,7 @@ void PostLoadConfig() {
 }
 
 bool CreateDirectoriesAndroid() {
-	// TODO: Really not sure why this code is Android-exclusive, except the ".nomedia" part.
+	// TODO: We should probably simply use this as the shared function to create memstick directories.
 
 	Path pspDir = g_Config.memStickDirectory;
 	if (pspDir.GetFilename() != "PSP") {

--- a/Windows/W32Util/Misc.cpp
+++ b/Windows/W32Util/Misc.cpp
@@ -53,24 +53,6 @@ namespace W32Util
 		MoveWindow(hwnd, x, y, width, height, FALSE);
 	}
  
-	void NiceSizeFormat(size_t size, char *out)
-	{
-		const char *sizes[] = {"B","KB","MB","GB","TB","PB","EB"};
-		int s = 0;
-		int frac = 0;
-		while (size>=1024)
-		{
-			s++;
-			frac = (int)size & 1023;
-			size /= 1024;
-		}
-		float f = (float)size + ((float)frac / 1024.0f);
-		if (s==0)
-			sprintf(out, "%d B", (int)size);
-		else
-			sprintf(out, "%3.1f %s", f, sizes[s]);
-	}
-
 	BOOL CopyTextToClipboard(HWND hwnd, const char *text) {
 		std::wstring wtext = ConvertUTF8ToWString(text);
 		return CopyTextToClipboard(hwnd, wtext);

--- a/Windows/W32Util/Misc.h
+++ b/Windows/W32Util/Misc.h
@@ -6,8 +6,6 @@
 namespace W32Util
 {
 	void CenterWindow(HWND hwnd);
-	HBITMAP CreateBitmapFromARGB(HWND someHwnd, DWORD *image, int w, int h);
-	void NiceSizeFormat(size_t size, char *out);
 	BOOL CopyTextToClipboard(HWND hwnd, const char *text);
 	BOOL CopyTextToClipboard(HWND hwnd, const std::wstring &wtext);
 	void MakeTopMost(HWND hwnd, bool topMost);

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -19,8 +19,8 @@
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="archos.permission.FULLSCREEN.FULL" />
@@ -45,7 +45,9 @@
         android:logo="@drawable/ic_banner"
         android:isGame="true"
         android:banner="@drawable/tv_banner"
-        android:requestLegacyExternalStorage="true">
+        android:requestLegacyExternalStorage="true"
+		android:preserveLegacyExternalStorage="true"
+		>
         <meta-data android:name="android.max_aspect" android:value="2.4" />
         <activity
             android:name=".PpssppActivity"

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -46,8 +46,7 @@
         android:isGame="true"
         android:banner="@drawable/tv_banner"
         android:requestLegacyExternalStorage="true"
-		android:preserveLegacyExternalStorage="true"
-		>
+        android:preserveLegacyExternalStorage="true">
         <meta-data android:name="android.max_aspect" android:value="2.4" />
         <activity
             android:name=".PpssppActivity"

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -19,8 +19,8 @@
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="archos.permission.FULLSCREEN.FULL" />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,8 +44,8 @@ android {
 			}
 		}
 	}
-	compileSdkVersion 29
-	buildToolsVersion '29.0.3'
+	compileSdkVersion 30
+	buildToolsVersion '30.0.0'
 	defaultConfig {
 		applicationId 'org.ppsspp.ppsspp'
 		if (androidGitVersion.name() != "unknown" && androidGitVersion.code() >= 14000000) {
@@ -61,7 +61,7 @@ android {
 		new File("versioncode.txt").write(androidGitVersion.code().toString())
 
 		minSdkVersion 9
-		targetSdkVersion 29
+		targetSdkVersion 30
 		if (project.hasProperty("ANDROID_VERSION_CODE") && project.hasProperty("ANDROID_VERSION_NAME")) {
 			versionCode ANDROID_VERSION_CODE
 			versionName ANDROID_VERSION_NAME

--- a/android/jni/AndroidContentURI.h
+++ b/android/jni/AndroidContentURI.h
@@ -112,8 +112,16 @@ public:
 	}
 
 	// Only goes downwards in hierarchies. No ".." will ever be generated.
-	std::string PathTo(const AndroidContentURI &other) const {
-		return other.FilePath().substr(FilePath().size() + 1);
+	bool ComputePathTo(const AndroidContentURI &other, std::string &path) const {
+		size_t offset = FilePath().size() + 1;
+		std::string otherFilePath = other.FilePath();
+		if (offset >= otherFilePath.size()) {
+			ERROR_LOG(SYSTEM, "Bad call to PathTo. '%s' -> '%s'", FilePath().c_str(), other.FilePath().c_str());
+			return false;
+		}
+
+		path = other.FilePath().substr(FilePath().size() + 1);
+		return true;
 	}
 
 	std::string GetFileExtension() const {

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -128,7 +128,8 @@ std::string langRegion;
 std::string mogaVersion;
 std::string boardName;
 
-std::string g_extFilesDir;
+std::string g_externalDir;  // Original external dir (root of Android storage).
+std::string g_extFilesDir;  // App private external dir.
 
 std::vector<std::string> g_additionalStorageDirs;
 
@@ -637,6 +638,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_init
 	std::string additionalStorageDirsString = GetJavaString(env, jadditionalStorageDirs);
 	std::string externalFilesDir = GetJavaString(env, jexternalFilesDir);
 
+	g_externalDir = externalStorageDir;
 	g_extFilesDir = externalFilesDir;
 
 	if (!additionalStorageDirsString.empty()) {

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Environment;
 import android.os.Looper;
 import android.os.ParcelFileDescriptor;
 import android.util.Log;

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -607,8 +607,14 @@ static bool TestPath() {
 	EXPECT_EQ_STR(Path("C:\\Yo\\Lo").GetDirectory(), std::string("C:/Yo"));
 	EXPECT_EQ_STR(Path("C:\\Yo\\Lo").GetFilename(), std::string("Lo"));
 
-	EXPECT_EQ_STR(Path("/a/b").PathTo(Path("/a/b/c/d/e")), std::string("c/d/e"));
-	EXPECT_EQ_STR(Path("/").PathTo(Path("/home/foo/bar")), std::string("home/foo/bar"));
+	std::string computedPath;
+
+	EXPECT_TRUE(Path("/a/b").ComputePathTo(Path("/a/b/c/d/e"), computedPath));
+
+	EXPECT_EQ_STR(computedPath, std::string("c/d/e"));
+
+	EXPECT_TRUE(Path("/").ComputePathTo(Path("/home/foo/bar"), computedPath));
+	EXPECT_EQ_STR(computedPath, std::string("home/foo/bar"));
 
 	return true;
 }
@@ -639,7 +645,8 @@ static bool TestAndroidContentURI() {
 
 	EXPECT_EQ_STR(fileURI.ToString(), std::string(directoryURIString));
 
-	std::string diff = dirURI.PathTo(fileURI);
+	std::string diff;
+	EXPECT_TRUE(dirURI.ComputePathTo(fileURI, diff));
 	EXPECT_EQ_STR(diff, std::string("Tekken 6.iso"));
 
 	return true;


### PR DESCRIPTION
Targets Android SDK 30, so scoped storage gets turned on for real on Android 11+ devices, see #11997.

~~This has a number of UX issues and bugs we need to work through, but at least games start up. ~~ Upgrades are handled smoothly by keeping existing storage access until you uninstall. After a reinstall, you'll need to re-select your old PSP directory manually in settings :(

We need to merge this soon, since after August we can no longer release new PPSSPP updates on Google Play without doing this. Most people should not be badly affected once this is in, just a new procedure to learn to give PPSSPP permissions to the folders you want to access on first startup.

We absolutely need to merge this AND release a new PPSSPP version with it before whenever Android 12 releases in September, October or November, and the old ways will no longer work for new installs.

This will take care of #11997 once done. Again, do not merge yet!

## Sub-issues discovered and fixed:

- /PSP as content URI:
  - [x] Save states not saving
  - [x] Save state thumbnails not showing
  - [x] In-game saves not working (game tested: Wipeout Pulse)
- Other
  - [x] File listing performance
  - [x] The code for determining free storage space is broken
  - [x] File move not implemented
  - [x] File append not working, probably some other edge cases
  - [x] Add support for returning error codes
  - [ ] Actually catch exceptions and provide proper error codes for things like disk full
  - [x] Make things work as expected when the memstick folder is named PSP 
- Planned features
  - [x] On first run, ask the user where they want their PSP folder. 
    - [x] Get it working
    - [ ] Make it pretty and make sure the user understands the choice
  - [x] Ability to auto-migrate your data when changing your PSP folder
  - [x] Threaded file move with progress bar
  - [ ] Set correct MIME types? Worth the trouble?

## Setup screen
If we find no folder configured and scoped storage enabled (first boot, or reinstall on Android11+) we will pop up a screen that gives the user two options, along with some advice:

* Choose or create a folder (browse button)
  - Choose if you had an old PPSSPP version and thus an old PSP folder
  - Allows sharing data between PPSSPP Regular and PPSSPP Gold

* Default PSP folder location
  - Will be removed if you uninstall PPSSPP

Not sure what else to say. There seem to be little reason to use the default folder location really, now that performance is pretty good in both cases...

