### PR TITLE
Implement the option for auto audio devices switching for Windows too 

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -634,15 +634,19 @@ void GameSettingsScreen::CreateViews() {
 		MicChoice->OnChoice.Handle(this, &GameSettingsScreen::OnMicDeviceChange);
 	}
 
+	bool sdlAudio = false;
 #if defined(SDL)
 	std::vector<std::string> audioDeviceList;
 	SplitString(System_GetProperty(SYSPROP_AUDIO_DEVICE_LIST), '\0', audioDeviceList);
 	audioDeviceList.insert(audioDeviceList.begin(), a->T("Auto"));
 	PopupMultiChoiceDynamic *audioDevice = audioSettings->Add(new PopupMultiChoiceDynamic(&g_Config.sAudioDevice, a->T("Device"), audioDeviceList, nullptr, screenManager()));
 	audioDevice->OnChoice.Handle(this, &GameSettingsScreen::OnAudioDevice);
-
-	audioSettings->Add(new CheckBox(&g_Config.bAutoAudioDevice, a->T("Switch on new audio device")));
+	sdlAudio = true;
 #endif
+
+	if (sdlAudio || g_Config.iAudioBackend == AUDIO_BACKEND_WASAPI) {
+		audioSettings->Add(new CheckBox(&g_Config.bAutoAudioDevice, a->T("Use new audio devices automatically")));
+	}
 
 #if defined(__ANDROID__)
 	CheckBox *extraAudio = audioSettings->Add(new CheckBox(&g_Config.bExtraAudioBuffering, a->T("AudioBufferingForBluetooth", "Bluetooth-friendly buffer (slower)")));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -627,13 +627,6 @@ void GameSettingsScreen::CreateViews() {
 	}
 #endif
 
-	std::vector<std::string> micList = Microphone::getDeviceList();
-	if (!micList.empty()) {
-		audioSettings->Add(new ItemHeader(a->T("Microphone")));
-		PopupMultiChoiceDynamic *MicChoice = audioSettings->Add(new PopupMultiChoiceDynamic(&g_Config.sMicDevice, a->T("Microphone Device"), micList, nullptr, screenManager()));
-		MicChoice->OnChoice.Handle(this, &GameSettingsScreen::OnMicDeviceChange);
-	}
-
 	bool sdlAudio = false;
 #if defined(SDL)
 	std::vector<std::string> audioDeviceList;
@@ -658,6 +651,13 @@ void GameSettingsScreen::CreateViews() {
 		audioSettings->Add(new InfoItem(a->T("Audio Error"), audioErrorStr));
 	}
 #endif
+
+	std::vector<std::string> micList = Microphone::getDeviceList();
+	if (!micList.empty()) {
+		audioSettings->Add(new ItemHeader(a->T("Microphone")));
+		PopupMultiChoiceDynamic *MicChoice = audioSettings->Add(new PopupMultiChoiceDynamic(&g_Config.sMicDevice, a->T("Microphone Device"), micList, nullptr, screenManager()));
+		MicChoice->OnChoice.Handle(this, &GameSettingsScreen::OnMicDeviceChange);
+	}
 
 	// Control
 	ViewGroup *controlsSettingsScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT));

--- a/Windows/WASAPIStream.cpp
+++ b/Windows/WASAPIStream.cpp
@@ -59,7 +59,7 @@ public:
 		deviceChanged_ = false;
 	}
 
-	bool HasDeviceChanged() {
+	bool HasDefaultDeviceChanged() const {
 		return deviceChanged_;
 	}
 
@@ -529,7 +529,7 @@ void WASAPIAudioThread::Run() {
 		}
 
 		// Check if we should use a new device.
-		if (notificationClient_ && notificationClient_->HasDeviceChanged()) {
+		if (notificationClient_ && notificationClient_->HasDefaultDeviceChanged() && g_Config.bAutoAudioDevice) {
 			hresult = audioInterface_->Stop();
 			ShutdownAudioDevice();
 


### PR DESCRIPTION
Previously SDL-only (though slightly different, that's not when the default device changes but when a new device appears).

Also fixes an ordering issue in the settings (the microphone setting could end up intermingled with other audio settings, which looked weird due to the title).

Related: #14597