### PR TITLE
More scoped storage support work

### DIFF
--- a/Common/File/AndroidStorage.cpp
+++ b/Common/File/AndroidStorage.cpp
@@ -11,6 +11,7 @@ static jmethodID openContentUri;
 static jmethodID listContentUriDir;
 static jmethodID contentUriCreateFile;
 static jmethodID contentUriCreateDirectory;
+static jmethodID contentUriCopyFile;
 static jmethodID contentUriRemoveFile;
 static jmethodID contentUriRenameFileTo;
 static jmethodID contentUriGetFileInfo;
@@ -33,6 +34,8 @@ void Android_RegisterStorageCallbacks(JNIEnv * env, jobject obj) {
 	_dbg_assert_(contentUriCreateDirectory);
 	contentUriCreateFile = env->GetMethodID(env->GetObjectClass(obj), "contentUriCreateFile", "(Ljava/lang/String;Ljava/lang/String;)Z");
 	_dbg_assert_(contentUriCreateFile);
+	contentUriCopyFile = env->GetMethodID(env->GetObjectClass(obj), "contentUriCopyFile", "(Ljava/lang/String;Ljava/lang/String;)Z");
+	_dbg_assert_(contentUriCopyFile);
 	contentUriRemoveFile = env->GetMethodID(env->GetObjectClass(obj), "contentUriRemoveFile", "(Ljava/lang/String;)Z");
 	_dbg_assert_(contentUriRemoveFile);
 	contentUriRenameFileTo = env->GetMethodID(env->GetObjectClass(obj), "contentUriRenameFileTo", "(Ljava/lang/String;Ljava/lang/String;)Z");
@@ -95,6 +98,16 @@ bool Android_CreateFile(const std::string &parentTreeUri, const std::string &fil
 	return env->CallBooleanMethod(g_nativeActivity, contentUriCreateFile, paramRoot, paramFileName);
 }
 
+bool Android_CopyFile(const std::string &fileUri, const std::string &destParentUri) {
+	if (!g_nativeActivity) {
+		return false;
+	}
+	auto env = getEnv();
+	jstring paramFileName = env->NewStringUTF(fileUri.c_str());
+	jstring paramDestParentUri = env->NewStringUTF(destParentUri.c_str());
+	return env->CallBooleanMethod(g_nativeActivity, contentUriCopyFile, paramFileName, paramDestParentUri);
+}
+
 bool Android_RemoveFile(const std::string &fileUri) {
 	if (!g_nativeActivity) {
 		return false;
@@ -130,7 +143,7 @@ static bool ParseFileInfo(const std::string &line, File::FileInfo *fileInfo) {
 	fileInfo->access = fileInfo->isDirectory ? 0666 : 0777;  // TODO: For read-only mappings, reflect that here, similarly as with isWritable.
 
 	uint64_t lastModifiedMs = 0;
-	sscanf(parts[4].c_str(), "%" PRIu64, &lastModifiedMs);
+	sscanf(parts[3].c_str(), "%" PRIu64, &lastModifiedMs);
 
 	// Convert from milliseconds
 	uint32_t lastModified = lastModifiedMs / 1000;

--- a/Common/File/AndroidStorage.h
+++ b/Common/File/AndroidStorage.h
@@ -25,6 +25,7 @@ bool Android_IsContentUri(const std::string &uri);
 int Android_OpenContentUriFd(const std::string &uri, const Android_OpenContentUriMode mode);
 bool Android_CreateDirectory(const std::string &parentTreeUri, const std::string &dirName);
 bool Android_CreateFile(const std::string &parentTreeUri, const std::string &fileName);
+bool Android_CopyFile(const std::string &fileUri, const std::string &destParentUri);
 bool Android_RemoveFile(const std::string &fileUri);
 bool Android_RenameFileTo(const std::string &fileUri, const std::string &newName);
 bool Android_GetFileInfo(const std::string &fileUri, File::FileInfo *info);
@@ -44,6 +45,7 @@ inline bool Android_IsContentUri(const std::string &uri) { return false; }
 inline int Android_OpenContentUriFd(const std::string &uri, const Android_OpenContentUriMode mode) { return -1; }
 inline bool Android_CreateDirectory(const std::string &parentTreeUri, const std::string &dirName) { return false; }
 inline bool Android_CreateFile(const std::string &parentTreeUri, const std::string &fileName) { return false; }
+inline bool Android_CopyFile(const std::string &fileUri, const std::string &destParentUri) { return false; }
 inline bool Android_RemoveFile(const std::string &fileUri) { return false; }
 inline bool Android_RenameFileTo(const std::string &fileUri, const std::string &newName) { return false; }
 inline bool Android_GetFileInfo(const std::string &fileUri, File::FileInfo *info) { return false; }

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -203,7 +203,6 @@ bool DirectoryFileHandle::Open(const Path &basePath, std::string &fileName, File
 #endif
 
 	Path fullName = GetLocalPath(basePath, fileName);
-	INFO_LOG(FILESYS, "Actually opening %s", fullName.c_str());
 
 	// On the PSP, truncating doesn't lose data.  If you seek later, you'll recover it.
 	// This is abnormal, so we deviate from the PSP's behavior and truncate on write/close.
@@ -301,8 +300,6 @@ bool DirectoryFileHandle::Open(const Path &basePath, std::string &fileName, File
 			return false;
 		}
 	}
-
-	INFO_LOG(FILESYS, "Opening '%s' straight", fullName.c_str());
 
 	int flags = 0;
 	if (access & FILEACCESS_APPEND) {


### PR DESCRIPTION
Extracted a bunch more commits from #14619 , to be able to reduce the size of that PR again (and thus, increase reviewability).

This improves Android storage-api file access performance by using DocumentsContract more instead of the slow DocumentFile wrapper. Also fixes querying free space.