### PR TITLE
Detect CwCheat file UTF-8 BOM sequence and ignore it

### DIFF
--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -98,6 +98,9 @@ bool CheatFileParser::Parse() {
 		if (!tempLine)
 			continue;
 
+		// Detect UTF-8 BOM sequence, and ignore it.
+		if (line_ == 1 && memcmp(tempLine, "\xEF\xBB\xBF", 3) == 0)
+			tempLine += 3;
 		std::string line = TrimString(tempLine);
 
 		// Minimum length 5 is shortest possible _ lines name of the game "_G N+"


### PR DESCRIPTION
This *explicity* detects and ignores the UTF-8 BOM sequence in a cwcheat file.

See also issue #14635