### PR TITLE
Trim username on join as well

### DIFF
--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1591,8 +1591,9 @@ int friendFinder(){
 						}
 
 						// Update HUD User Count
+						name = (char*)packet->name.data;
 						incoming = "";
-						incoming.append((char*)packet->name.data);
+						incoming.append(name.substr(0, 8));
 						incoming.append(" Joined ");
 						//do we need ip?
 						//joined.append((char *)packet->ip);


### PR DESCRIPTION
Fixes #14643, we was already truncating to 8 char in chat, but not for the join message.