### PR TITLE
fix overlinking of OpenGL libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1954,6 +1954,10 @@ if(WIN32)
 	set(GlslangLibs ${GlslangLibs} spirv-cross-hlsl)
 endif()
 
+if(OpenGL_OpenGL_FOUND AND NOT APPLE)
+    set(OPENGL_LIBRARIES OpenGL::OpenGL)
+endif()
+
 target_link_libraries(${CoreLibName} Common native kirk cityhash sfmt19937 xbrz xxhash ${GlslangLibs}
 	${CoreExtraLibs} ${OPENGL_LIBRARIES} ${X11_LIBRARIES} ${CMAKE_DL_LIBS})
 


### PR DESCRIPTION
In CMake, FindOpenGL recommends linking to one of ~~GLX~~libGL (CMP0072 LEGACY) or GLX / libOpenGL (CMP0072 GLVND), not both. See https://cmake.org/cmake/help/latest/module/FindOpenGL.html.

We should prefer the libOpenGL where possible and fall back to GLX if not.

As always, Apple is a special snowflake and it links to OpenGL.framework, so skip the library selection logic in that case.