### PR TITLE
cmake: use vendor-neutral GL implementation when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1954,7 +1954,7 @@ if(WIN32)
 	set(GlslangLibs ${GlslangLibs} spirv-cross-hlsl)
 endif()
 
-if(OpenGL_OpenGL_FOUND AND NOT APPLE)
+if(OPENGL_opengl_LIBRARY AND OpenGL_GL_PREFERENCE STREQUAL GLVND AND NOT APPLE)
     set(OPENGL_LIBRARIES OpenGL::OpenGL)
 endif()
 


### PR DESCRIPTION
Otherwise, fall back to legacy GL

This should fix the libretro regression caused by #14670 