### PR TITLE
D3D11: Use right state in flush before output

### DIFF
--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -242,10 +242,11 @@ void GPU_D3D11::SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat f
 }
 
 void GPU_D3D11::CopyDisplayToOutput(bool reallyDirty) {
+	// Flush anything left over.
+	drawEngine_.Flush();
+
 	float blendColor[4]{};
 	context_->OMSetBlendState(stockD3D11.blendStateDisabledWithColorMask[0xF], blendColor, 0xFFFFFFFF);
-
-	drawEngine_.Flush();
 
 	framebufferManagerD3D11_->CopyDisplayToOutput(reallyDirty);
 	framebufferManagerD3D11_->EndFrame();


### PR DESCRIPTION
We were accidentally changing the blend state for the final draw in a frame.  This could cause apparently random issues if a game didn't align drawing with vblanks (but more predictable glitches in other games.)

Fixes #13152.

-[Unknown]