### PR TITLE
[Libretro] Add a MAC address in 'libretro.cpp', needed to start some missions in Peace Walker

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -432,6 +432,7 @@ void retro_init(void)
    g_Config.bFragmentTestCache = true;
    g_Config.bSavedataUpgrade= true;
    g_Config.bSeparateSASThread = true;
+   g_Config.sMACAddress = "12:34:56:78:9A:BC";
 
    g_Config.iFirmwareVersion = PSP_DEFAULT_FIRMWARE;
    g_Config.iPSPModel = PSP_MODEL_SLIM;


### PR DESCRIPTION
This fixes the MGS Peace Walker issue from #13115 where it prevents from starting some missions. From unknownbrackets comment, a few games have saves tied to MAC, so it might fix these games as well?