### PR TITLE
SaveState: Ask ZSTD to include xxhash, make easier to switch to Snappy

### DIFF
--- a/Common/Serialize/Serializer.cpp
+++ b/Common/Serialize/Serializer.cpp
@@ -25,6 +25,14 @@
 #include "Common/File/FileUtil.h"
 #include "Common/StringUtils.h"
 
+enum class SerializeCompressType {
+	NONE = 0,
+	SNAPPY = 1,
+	ZSTD = 2,
+};
+
+static constexpr SerializeCompressType SAVE_TYPE = SerializeCompressType::SNAPPY;
+
 PointerWrapSection PointerWrap::Section(const char *title, int ver) {
 	return Section(title, ver, ver);
 }
@@ -289,12 +297,17 @@ CChunkFileReader::Error CChunkFileReader::LoadFile(const Path &filename, std::st
 		u8 *uncomp_buffer = new u8[header.UncompressedSize];
 		size_t uncomp_size = header.UncompressedSize;
 		bool success = false;
-		if (header.Compress == 1) {
+		if (SerializeCompressType(header.Compress) == SerializeCompressType::SNAPPY) {
 			auto status = snappy_uncompress((const char *)buffer, sz, (char *)uncomp_buffer, &uncomp_size);
 			success = status == SNAPPY_OK;
-		} else {
-			auto status = ZSTD_decompress((char *)uncomp_buffer, uncomp_size, (const char *)buffer, sz);
+		} else if (SerializeCompressType(header.Compress) == SerializeCompressType::ZSTD) {
+			size_t status = ZSTD_decompress((char *)uncomp_buffer, uncomp_size, (const char *)buffer, sz);
 			success = !ZSTD_isError(status);
+			if (success) {
+				uncomp_size = status;
+			}
+		} else {
+			ERROR_LOG(SAVESTATE, "ChunkReader: Unexpected compression type %d", header.Compress);
 		}
 		if (!success) {
 			ERROR_LOG(SAVESTATE, "ChunkReader: Failed to decompress file");
@@ -336,16 +349,40 @@ CChunkFileReader::Error CChunkFileReader::SaveFile(const Path &filename, const s
 	}
 
 	// Make sure we can allocate a buffer to compress before compressing.
-	size_t write_len = ZSTD_compressBound(sz);
-	u8 *compressed_buffer = (u8 *)malloc(write_len);
+	size_t write_len;
+	SerializeCompressType usedType = SAVE_TYPE;
+	switch (usedType) {
+	case SerializeCompressType::NONE:
+		write_len = 0;
+		break;
+	case SerializeCompressType::SNAPPY:
+		write_len = snappy_max_compressed_length(sz);
+		break;
+	case SerializeCompressType::ZSTD:
+		write_len = ZSTD_compressBound(sz);
+		break;
+	}
+	u8 *compressed_buffer = write_len == 0 ? nullptr : (u8 *)malloc(write_len);
 	u8 *write_buffer = buffer;
 	if (!compressed_buffer) {
-		ERROR_LOG(SAVESTATE, "ChunkReader: Unable to allocate compressed buffer");
+		if (write_len != 0)
+			ERROR_LOG(SAVESTATE, "ChunkReader: Unable to allocate compressed buffer");
 		// We'll save uncompressed.  Better than not saving...
 		write_len = sz;
+		usedType = SerializeCompressType::NONE;
 	} else {
-		// TODO: If free disk space is low, we could max this out to 22?
-		write_len = ZSTD_compress(compressed_buffer, write_len, buffer, sz, 1);
+		switch (usedType) {
+		case SerializeCompressType::NONE:
+			_assert_(false);
+			break;
+		case SerializeCompressType::SNAPPY:
+			snappy_compress((const char *)buffer, sz, (char *)compressed_buffer, &write_len);
+			break;
+		case SerializeCompressType::ZSTD:
+			// TODO: If free disk space is low, we could max this out to 22?
+			write_len = ZSTD_compress(compressed_buffer, write_len, buffer, sz, 1);
+			break;
+		}
 		free(buffer);
 
 		write_buffer = compressed_buffer;
@@ -353,7 +390,7 @@ CChunkFileReader::Error CChunkFileReader::SaveFile(const Path &filename, const s
 
 	// Create header
 	SChunkHeader header{};
-	header.Compress = compressed_buffer ? 2 : 0;
+	header.Compress = (int)usedType;
 	header.Revision = REVISION_CURRENT;
 	header.ExpectedSize = (u32)write_len;
 	header.UncompressedSize = (u32)sz;

--- a/Common/Serialize/Serializer.cpp
+++ b/Common/Serialize/Serializer.cpp
@@ -385,10 +385,10 @@ CChunkFileReader::Error CChunkFileReader::SaveFile(const Path &filename, const s
 				if (!ctx) {
 					success = false;
 				} else {
-					ZSTD_CCtx_setParameter(ctx, ZSTD_c_compressionLevel, 1);
+					// TODO: If free disk space is low, we could max this out to 22?
+					ZSTD_CCtx_setParameter(ctx, ZSTD_c_compressionLevel, ZSTD_CLEVEL_DEFAULT);
 					ZSTD_CCtx_setParameter(ctx, ZSTD_c_checksumFlag, 1);
 					ZSTD_CCtx_setPledgedSrcSize(ctx, sz);
-					// TODO: If free disk space is low, we could max this out to 22?
 					write_len = ZSTD_compress2(ctx, compressed_buffer, write_len, buffer, sz);
 					success = !ZSTD_isError(write_len);
 				}


### PR DESCRIPTION
Given #14564, I'm a bit worried.  We're validating both the compressed and decompressed size, but it still thinks it was successful.  It seems weird a random data corruption could cause this to "successfully" decompress to the last chunk of bytes all being NUL, so it almost has to be a ZSTD bug...

I debated switching back to Snappy, but decided to instead:
 - Set the advanced flag to include an xxhash checksum in the frame.
 - Change the compression level to the ZSTD default, which is probably most well tested.

This makes save state creation slightly slower, but based on my tests still 10s of milliseconds at worst.

Previously created ZSTD save states (i.e. without the checksum) should continue to load fine.  I added more checks, but none of these checks seem to be hit for #14564.

-[Unknown]