### PR TITLE
Scoped storage fixes

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1490,7 +1490,6 @@ bool Config::Save(const char *saveReason) {
 
 		if (!iniFile.Save(iniFilename_)) {
 			ERROR_LOG(LOADER, "Error saving config (%s)- can't write ini '%s'", saveReason, iniFilename_.c_str());
-			System_SendMessage("toast", "Failed to save settings!\nCheck permissions, or try to restart the device.");
 			return false;
 		}
 		INFO_LOG(LOADER, "Config saved (%s): '%s'", saveReason, iniFilename_.c_str());

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1232,7 +1232,10 @@ void GameSettingsScreen::onFinish(DialogResult result) {
 
 	Reporting::Enable(enableReports_, "report.ppsspp.org");
 	Reporting::UpdateConfig();
-	g_Config.Save("GameSettingsScreen::onFinish");
+	if (!g_Config.Save("GameSettingsScreen::onFinish")) {
+		System_SendMessage("toast", "Failed to save settings!\nCheck permissions, or try to restart the device.");
+	}
+
 	if (editThenRestore_) {
 		// In case we didn't have the title yet before, try again.
 		std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(nullptr, gamePath_, 0);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1409,7 +1409,9 @@ UI::EventReturn MainScreen::OnForums(UI::EventParams &e) {
 
 UI::EventReturn MainScreen::OnExit(UI::EventParams &e) {
 	// Let's make sure the config was saved, since it may not have been.
-	g_Config.Save("MainScreen::OnExit");
+	if (!g_Config.Save("MainScreen::OnExit")) {
+		System_SendMessage("toast", "Failed to save settings!\nCheck permissions, or try to restart the device.");
+	}
 
 	// Request the framework to exit cleanly.
 	System_SendMessage("finish", "");

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -19,8 +19,11 @@
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
+    <!-- I tried using android:maxSdkVersion="29" on WRITE/READ_EXTERNAL_STORAGE, but that made
+    <it so that in legacy mode, you can't ask for permission anymore. So removed that. -->
+
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="archos.permission.FULLSCREEN.FULL" />


### PR DESCRIPTION
Hopefully fixes issue with requesting permission while in legacy storage mode from an old install, as reported by nassau-tk in #13847. Also removes the unnecessary popup Gamemulatorer saw.