### PR TITLE
SaveState: Validate size matches measured

### DIFF
--- a/Common/Serialize/Serializer.h
+++ b/Common/Serialize/Serializer.h
@@ -160,12 +160,13 @@ public:
 
 	// Expects ptr to have at least MeasurePtr bytes at ptr.
 	template<class T>
-	static Error SavePtr(u8 *ptr, T &_class)
+	static Error SavePtr(u8 *ptr, T &_class, size_t expected_size)
 	{
+		const u8 *expected_end = ptr + expected_size;
 		PointerWrap p(&ptr, PointerWrap::MODE_WRITE);
 		_class.DoState(p);
 
-		if (p.error != p.ERROR_FAILURE) {
+		if (p.error != p.ERROR_FAILURE && (expected_end == ptr || expected_size == 0)) {
 			return ERROR_NONE;
 		} else {
 			return ERROR_BROKEN_STATE;
@@ -201,7 +202,7 @@ public:
 		u8 *buffer = (u8 *)malloc(sz);
 		if (!buffer)
 			return ERROR_BAD_ALLOC;
-		Error error = SavePtr(buffer, _class);
+		Error error = SavePtr(buffer, _class, sz);
 
 		// SaveFile takes ownership of buffer
 		if (error == ERROR_NONE)

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -94,7 +94,7 @@ namespace SaveState
 		size_t sz = CChunkFileReader::MeasurePtr(state);
 		if (data.size() < sz)
 			data.resize(sz);
-		return CChunkFileReader::SavePtr(&data[0], state);
+		return CChunkFileReader::SavePtr(&data[0], state, sz);
 	}
 
 	CChunkFileReader::Error LoadFromRam(std::vector<u8> &data, std::string *errorString) {

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -877,9 +877,10 @@ bool retro_serialize(void *data, size_t size)
    if (useEmuThread)
       EmuThreadPause(); // Does nothing if already paused
 
-   assert(CChunkFileReader::MeasurePtr(state) <= size);
-   retVal = CChunkFileReader::SavePtr((u8 *)data, state) 
-      == CChunkFileReader::ERROR_NONE;
+   size_t measured = CChunkFileReader::MeasurePtr(state);
+   assert(measured <= size);
+   auto err = CChunkFileReader::SavePtr((u8 *)data, state, measured);
+   retVal = err == CChunkFileReader::ERROR_NONE;
 
    if (useEmuThread)
    {


### PR DESCRIPTION
In #14653, a save state appears to have been generated truncated.  This attempts to detect that at generation time.

It won't fix any bugs, but it'll at least show the save state operation as a failure if it generated data that won't load properly later, which is a big win.  I don't know if this is actually happening, but I'm not sure how else to explain #14653.

-[Unknown]