### PR TITLE
GPU: Use an empty vertex buf for reinterpret

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -87,7 +87,7 @@ public:
 
 	void BindTextures(int start, int count, Texture **textures) override;
 	void BindSamplerStates(int start, int count, SamplerState **states) override;
-	void BindVertexBuffers(int start, int count, Buffer **buffers, int *offsets) override;
+	void BindVertexBuffers(int start, int count, Buffer **buffers, const int *offsets) override;
 	void BindIndexBuffer(Buffer *indexBuffer, int offset) override;
 	void BindPipeline(Pipeline *pipeline) override;
 
@@ -1163,7 +1163,7 @@ void D3D11DrawContext::UpdateBuffer(Buffer *buffer, const uint8_t *data, size_t 
 	context_->UpdateSubresource(buf->buf, 0, &box, data, 0, 0);
 }
 
-void D3D11DrawContext::BindVertexBuffers(int start, int count, Buffer **buffers, int *offsets) {
+void D3D11DrawContext::BindVertexBuffers(int start, int count, Buffer **buffers, const int *offsets) {
 	_assert_(start + count <= ARRAY_SIZE(nextVertexBuffers_));
 	// Lazy application
 	for (int i = 0; i < count; i++) {

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -533,7 +533,7 @@ public:
 			s->Apply(device_, start + i);
 		}
 	}
-	void BindVertexBuffers(int start, int count, Buffer **buffers, int *offsets) override {
+	void BindVertexBuffers(int start, int count, Buffer **buffers, const int *offsets) override {
 		_assert_(start + count <= ARRAY_SIZE(curVBuffers_));
 		for (int i = 0; i < count; i++) {
 			curVBuffers_[i + start] = (D3D9Buffer *)buffers[i];

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -399,7 +399,7 @@ public:
 
 	void BindTextures(int start, int count, Texture **textures) override;
 	void BindPipeline(Pipeline *pipeline) override;
-	void BindVertexBuffers(int start, int count, Buffer **buffers, int *offsets) override {
+	void BindVertexBuffers(int start, int count, Buffer **buffers, const int *offsets) override {
 		_assert_(start + count <= ARRAY_SIZE(curVBuffers_));
 		for (int i = 0; i < count; i++) {
 			curVBuffers_[i + start] = (OpenGLBuffer *)buffers[i];

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -415,7 +415,7 @@ public:
 	}
 
 	// TODO: Make VKBuffers proper buffers, and do a proper binding model. This is just silly.
-	void BindVertexBuffers(int start, int count, Buffer **buffers, int *offsets) override {
+	void BindVertexBuffers(int start, int count, Buffer **buffers, const int *offsets) override {
 		_assert_(start + count <= ARRAY_SIZE(curVBuffers_));
 		for (int i = 0; i < count; i++) {
 			curVBuffers_[i + start] = (VKBuffer *)buffers[i];

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -643,7 +643,7 @@ public:
 
 	virtual void BindSamplerStates(int start, int count, SamplerState **state) = 0;
 	virtual void BindTextures(int start, int count, Texture **textures) = 0;
-	virtual void BindVertexBuffers(int start, int count, Buffer **buffers, int *offsets) = 0;
+	virtual void BindVertexBuffers(int start, int count, Buffer **buffers, const int *offsets) = 0;
 	virtual void BindIndexBuffer(Buffer *indexBuffer, int offset) = 0;
 
 	// Only supports a single dynamic uniform buffer, for maximum compatibility with the old APIs and ease of emulation.

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -445,4 +445,5 @@ protected:
 	Draw::Pipeline *reinterpretFromTo_[3][3]{};
 	Draw::ShaderModule *reinterpretVS_ = nullptr;
 	Draw::SamplerState *reinterpretSampler_ = nullptr;
+	Draw::Buffer *reinterpretVBuf_ = nullptr;
 };


### PR DESCRIPTION
See #14552.  I think Vulkan requires one bound, and just works sometimes because there's an old vbuf bound from a previous draw.

-[Unknown]