### PR TITLE
libpng: Patch out 100% opaque optimization

### DIFF
--- a/ext/libpng17/pngread.c
+++ b/ext/libpng17/pngread.c
@@ -3997,8 +3997,7 @@ png_image_read_direct(png_voidp argument)
 #  endif
 
       /* This is actually an internal error. */
-      // HACK to prevent crash: See issue #14628
-      // affirm(out_format == format /* else unimplemented transformations */);
+      affirm(out_format == format /* else unimplemented transformations */);
    }
 
    /* Now read the rows.  If do_local_compose is set then it is necessary to use

--- a/ext/libpng17/pngrtran.c
+++ b/ext/libpng17/pngrtran.c
@@ -6603,7 +6603,9 @@ check_tRNS_for_alpha(png_structrp png_ptr)
    }
 
    /* All entries opaque; remove the tRNS data: */
-   png_ptr->num_trans = 0U;
+   // TODO: This optimization doesn't handle adding it back if RGBA is requested.
+   // See PPSSPP issue #14628.
+   //png_ptr->num_trans = 0U;
 }
 #endif /* READ_tRNS */
 


### PR DESCRIPTION
This optimization seems to work fine if you want RGB, but if you want RGBA, it forgets to add the fixed values back.  I'm not sure we ever ask for RGB anyway.

See #14628 for details.  Fixes #14628 (the image renders correctly.)

-[Unknown]