### PR TITLE
Move focus when scrolling with page up/down or home/end

### DIFF
--- a/Common/UI/Root.cpp
+++ b/Common/UI/Root.cpp
@@ -195,11 +195,23 @@ static std::set<HeldKey> heldKeys;
 const double repeatDelay = 15 * (1.0 / 60.0f);  // 15 frames like before.
 const double repeatInterval = 5 * (1.0 / 60.0f);  // 5 frames like before.
 
+bool IsScrollKey(const KeyInput &input) {
+	switch (input.keyCode) {
+	case NKCODE_PAGE_UP:
+	case NKCODE_PAGE_DOWN:
+	case NKCODE_MOVE_HOME:
+	case NKCODE_MOVE_END:
+		return true;
+	default:
+		return false;
+	}
+}
+
 bool KeyEvent(const KeyInput &key, ViewGroup *root) {
 	bool retval = false;
 	// Ignore repeats for focus moves.
 	if ((key.flags & (KEY_DOWN | KEY_IS_REPEAT)) == KEY_DOWN) {
-		if (IsDPadKey(key)) {
+		if (IsDPadKey(key) || IsScrollKey(key)) {
 			// Let's only repeat DPAD initially.
 			HeldKey hk;
 			hk.key = key.keyCode;
@@ -399,6 +411,10 @@ void UpdateViewHierarchy(ViewGroup *root) {
 				case NKCODE_DPAD_RIGHT: MoveFocus(root, FOCUS_RIGHT); break;
 				case NKCODE_DPAD_UP: MoveFocus(root, FOCUS_UP); break;
 				case NKCODE_DPAD_DOWN: MoveFocus(root, FOCUS_DOWN); break;
+				case NKCODE_PAGE_UP: MoveFocus(root, FOCUS_PREV_PAGE); break;
+				case NKCODE_PAGE_DOWN: MoveFocus(root, FOCUS_NEXT_PAGE); break;
+				case NKCODE_MOVE_HOME: MoveFocus(root, FOCUS_FIRST); break;
+				case NKCODE_MOVE_END: MoveFocus(root, FOCUS_LAST); break;
 				}
 			}
 		}

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -448,6 +448,7 @@ public:
 
 	// Fake RTTI
 	virtual bool IsViewGroup() const { return false; }
+	virtual bool ContainsSubview(const View *view) const { return false; }
 
 	Point GetFocusPosition(FocusDirection dir);
 

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -128,6 +128,10 @@ enum FocusDirection {
 	FOCUS_RIGHT,
 	FOCUS_NEXT,
 	FOCUS_PREV,
+	FOCUS_FIRST,
+	FOCUS_LAST,
+	FOCUS_PREV_PAGE,
+	FOCUS_NEXT_PAGE,
 };
 
 enum {
@@ -177,6 +181,10 @@ inline FocusDirection Opposite(FocusDirection d) {
 	case FOCUS_RIGHT: return FOCUS_LEFT;
 	case FOCUS_PREV: return FOCUS_NEXT;
 	case FOCUS_NEXT: return FOCUS_PREV;
+	case FOCUS_FIRST: return FOCUS_LAST;
+	case FOCUS_LAST: return FOCUS_FIRST;
+	case FOCUS_PREV_PAGE: return FOCUS_NEXT_PAGE;
+	case FOCUS_NEXT_PAGE: return FOCUS_PREV_PAGE;
 	}
 	return d;
 }

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -980,7 +980,11 @@ NeighborResult ScrollView::FindScrollNeighbor(View *view, const Point &target, F
 				targetPos.x += mult * bounds_.x;
 
 			// Okay, which subview is closest to that?
-			return vg->FindScrollNeighbor(view, targetPos, direction, best);
+			best = vg->FindScrollNeighbor(view, targetPos, direction, best);
+			// Avoid reselecting the same view.
+			if (best.view == view)
+				best.view = nullptr;
+			return best;
 		}
 	}
 

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -63,9 +63,11 @@ public:
 
 	// Assumes that layout has taken place.
 	NeighborResult FindNeighbor(View *view, FocusDirection direction, NeighborResult best);
+	virtual NeighborResult FindScrollNeighbor(View *view, const Point &target, FocusDirection direction, NeighborResult best);
 
-	virtual bool CanBeFocused() const override { return false; }
-	virtual bool IsViewGroup() const override { return true; }
+	bool CanBeFocused() const override { return false; }
+	bool IsViewGroup() const override { return true; }
+	bool ContainsSubview(const View *view) const override;
 
 	virtual void SetBG(const Drawable &bg) { bg_ = bg; }
 
@@ -267,6 +269,8 @@ public:
 	bool SubviewFocused(View *view) override;
 	void PersistData(PersistStatus status, std::string anonId, PersistMap &storage) override;
 	void SetVisibility(Visibility visibility) override;
+
+	NeighborResult FindScrollNeighbor(View *view, const Point &target, FocusDirection direction, NeighborResult best) override;
 
 	// Quick hack to prevent scrolling to top in some lists
 	void SetScrollToTop(bool t) { scrollToTopOnSizeChange_ = t; }


### PR DESCRIPTION
Fixes #14618.  We previously would scroll, but keep focus where it was which made things feel very awkward.

This improves keyboard navigation in the game list, settings, etc.  A change is that now, when you are focused outside a scrollable list, page up or down does nothing.  You have to move inside it first.  This is also less awkward.

I decided for the game list to keep page up/down strictly at the direction (i.e. if you are on the top row, but second item, and press page up - it doesn't move you to the first item.)  This felt a bit odd but seemed like it made the most sense with vertical or horizontal views.

-[Unknown]