### PR TITLE
Add Reset button on crash screen, allow load state and related

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -86,7 +86,7 @@ void Core_ListenLifecycle(CoreLifecycleFunc func) {
 
 void Core_NotifyLifecycle(CoreLifecycle stage) {
 	if (stage == CoreLifecycle::STARTING) {
-		g_exceptionInfo.type = ExceptionType::NONE;
+		Core_ResetException();
 	}
 
 	for (auto func : lifecycleFuncs) {
@@ -99,7 +99,7 @@ void Core_ListenStopRequest(CoreStopRequestFunc func) {
 }
 
 void Core_Stop() {
-	g_exceptionInfo.type = ExceptionType::NONE;
+	Core_ResetException();
 	Core_UpdateState(CORE_POWERDOWN);
 	for (auto func : stopFuncs) {
 		func();
@@ -267,7 +267,7 @@ void Core_UpdateSingleStep() {
 }
 
 void Core_SingleStep() {
-	g_exceptionInfo.type = ExceptionType::NONE;
+	Core_ResetException();
 	currentMIPS->SingleStep();
 	if (coreState == CORE_STEPPING)
 		steppingCounter++;
@@ -366,7 +366,7 @@ void Core_EnableStepping(bool step) {
 	} else {
 		host->SetDebugMode(false);
 		// Clear the exception if we resume.
-		g_exceptionInfo.type = ExceptionType::NONE;
+		Core_ResetException();
 		coreState = CORE_RUNNING;
 		coreStatePending = false;
 		m_StepCond.notify_all();
@@ -487,6 +487,10 @@ void Core_Break() {
 		Core_EnableStepping(true);
 		host->SetDebugMode(true);
 	}
+}
+
+void Core_ResetException() {
+	g_exceptionInfo.type = ExceptionType::NONE;
 }
 
 const ExceptionInfo &Core_GetExceptionInfo() {

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -85,6 +85,10 @@ void Core_ListenLifecycle(CoreLifecycleFunc func) {
 }
 
 void Core_NotifyLifecycle(CoreLifecycle stage) {
+	if (stage == CoreLifecycle::STARTING) {
+		g_exceptionInfo.type = ExceptionType::NONE;
+	}
+
 	for (auto func : lifecycleFuncs) {
 		func(stage);
 	}

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -101,6 +101,8 @@ void Core_MemoryExceptionInfo(u32 address, u32 pc, MemoryExceptionType type, std
 
 void Core_ExecException(u32 address, u32 pc, ExecExceptionType type);
 void Core_Break();
+// Call when loading save states, etc.
+void Core_ResetException();
 
 enum class ExceptionType {
 	NONE,

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -335,11 +335,15 @@ namespace SaveState
 
 	void Load(const Path &filename, int slot, Callback callback, void *cbUserData)
 	{
+		if (coreState == CoreState::CORE_RUNTIME_ERROR)
+			Core_EnableStepping(true);
 		Enqueue(Operation(SAVESTATE_LOAD, filename, slot, callback, cbUserData));
 	}
 
 	void Save(const Path &filename, int slot, Callback callback, void *cbUserData)
 	{
+		if (coreState == CoreState::CORE_RUNTIME_ERROR)
+			Core_EnableStepping(true);
 		Enqueue(Operation(SAVESTATE_SAVE, filename, slot, callback, cbUserData));
 	}
 
@@ -350,6 +354,8 @@ namespace SaveState
 
 	void Rewind(Callback callback, void *cbUserData)
 	{
+		if (coreState == CoreState::CORE_RUNTIME_ERROR)
+			Core_EnableStepping(true);
 		Enqueue(Operation(SAVESTATE_REWIND, Path(), -1, callback, cbUserData));
 	}
 
@@ -866,6 +872,7 @@ namespace SaveState
 					callbackMessage = op.slot != LOAD_UNDO_SLOT ? sc->T("Loaded State") : sc->T("State load undone");
 					callbackResult = TriggerLoadWarnings(callbackMessage);
 					hasLoadedState = true;
+					Core_ResetException();
 
 					if (!slot_prefix.empty())
 						callbackMessage = slot_prefix + callbackMessage;
@@ -944,6 +951,7 @@ namespace SaveState
 					callbackMessage = sc->T("Loaded State");
 					callbackResult = Status::SUCCESS;
 					hasLoadedState = true;
+					Core_ResetException();
 				} else if (result == CChunkFileReader::ERROR_BROKEN_STATE) {
 					// Cripes.  Good news is, we might have more.  Let's try those too, better than a reset.
 					if (HandleLoadFailure()) {
@@ -951,6 +959,7 @@ namespace SaveState
 						callbackMessage = sc->T("Loaded State");
 						callbackResult = Status::SUCCESS;
 						hasLoadedState = true;
+						Core_ResetException();
 					} else {
 						callbackMessage = std::string(i18nLoadFailure) + ": " + errorString;
 						callbackResult = Status::FAILURE;

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -131,6 +131,7 @@ void UpdateUIState(GlobalUIState newState) {
 		case UISTATE_INGAME: state = "ingame"; break;
 		case UISTATE_MENU: state = "menu"; break;
 		case UISTATE_PAUSEMENU: state = "pausemenu"; break;
+		case UISTATE_EXCEPTION: state = "exception"; break;
 		}
 		if (state) {
 			System_SendMessage("uistate", state);

--- a/Core/System.h
+++ b/Core/System.h
@@ -33,6 +33,7 @@ enum GlobalUIState {
 	UISTATE_PAUSEMENU,
 	UISTATE_INGAME,
 	UISTATE_EXIT,
+	UISTATE_EXCEPTION,
 };
 
 // Use these in conjunction with GetSysDirectory.

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -952,8 +952,8 @@ void EmuScreen::update() {
 	PSP_CoreParameter().pixelHeight = pixel_yres * bounds.h / dp_yres;
 #endif
 
-	if (!invalid_ && coreState != CORE_RUNTIME_ERROR) {
-		UpdateUIState(UISTATE_INGAME);
+	if (!invalid_) {
+		UpdateUIState(coreState != CORE_RUNTIME_ERROR ? UISTATE_INGAME : UISTATE_EXCEPTION);
 	}
 
 	if (errorMessage_.size()) {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -779,9 +779,18 @@ void EmuScreen::CreateViews() {
 	if (g_Config.bShowDeveloperMenu) {
 		root_->Add(new Button(dev->T("DevMenu")))->OnClick.Handle(this, &EmuScreen::OnDevTools);
 	}
-	resumeButton_ = root_->Add(new Button(dev->T("Resume"), new AnchorLayoutParams(bounds.centerX(), NONE, NONE, 60, true)));
+
+	LinearLayout *buttons = new LinearLayout(Orientation::ORIENT_HORIZONTAL, new AnchorLayoutParams(bounds.centerX(), NONE, NONE, 60, true));
+	buttons->SetSpacing(20.0f);
+	root_->Add(buttons);
+
+	resumeButton_ = buttons->Add(new Button(dev->T("Resume")));
 	resumeButton_->OnClick.Handle(this, &EmuScreen::OnResume);
 	resumeButton_->SetVisibility(V_GONE);
+
+	resetButton_ = buttons->Add(new Button(dev->T("Reset")));
+	resetButton_->OnClick.Handle(this, &EmuScreen::OnReset);
+	resetButton_->SetVisibility(V_GONE);
 
 	cardboardDisableButton_ = root_->Add(new Button(sc->T("Cardboard VR OFF"), new AnchorLayoutParams(bounds.centerX(), NONE, NONE, 30, true)));
 	cardboardDisableButton_->OnClick.Handle(this, &EmuScreen::OnDisableCardboard);
@@ -914,12 +923,20 @@ UI::EventReturn EmuScreen::OnResume(UI::EventParams &params) {
 	return UI::EVENT_DONE;
 }
 
+UI::EventReturn EmuScreen::OnReset(UI::EventParams &params) {
+	if (coreState == CoreState::CORE_RUNTIME_ERROR) {
+		NativeMessageReceived("reset", "");
+	}
+	return UI::EVENT_DONE;
+}
+
 void EmuScreen::update() {
 	using namespace UI;
 
 	UIScreen::update();
 	onScreenMessagesView_->SetVisibility(g_Config.bShowOnScreenMessages ? V_VISIBLE : V_GONE);
 	resumeButton_->SetVisibility(coreState == CoreState::CORE_RUNTIME_ERROR && Memory::MemFault_MayBeResumable() ? V_VISIBLE : V_GONE);
+	resetButton_->SetVisibility(coreState == CoreState::CORE_RUNTIME_ERROR ? V_VISIBLE : V_GONE);
 
 	if (bootPending_) {
 		bootGame(gamePath_);

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -57,6 +57,7 @@ private:
 	UI::EventReturn OnDisableCardboard(UI::EventParams &params);
 	UI::EventReturn OnChat(UI::EventParams &params);
 	UI::EventReturn OnResume(UI::EventParams &params);
+	UI::EventReturn OnReset(UI::EventParams &params);
 
 	void bootGame(const Path &filename);
 	bool bootAllowStorage(const Path &filename);
@@ -98,6 +99,7 @@ private:
 	UI::Spinner *loadingSpinner_ = nullptr;
 	UI::TextView *loadingTextView_ = nullptr;
 	UI::Button *resumeButton_ = nullptr;
+	UI::Button *resetButton_ = nullptr;
 	UI::View *chatButton_ = nullptr;
 
 	UI::Button *cardboardDisableButton_ = nullptr;

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -791,9 +791,10 @@ void CDisasm::SavePosition()
 void CDisasm::SetDebugMode(bool _bDebug, bool switchPC)
 {
 	HWND hDlg = m_hDlg;
+	bool ingame = (GetUIState() == UISTATE_INGAME || GetUIState() == UISTATE_EXCEPTION) && PSP_IsInited();
 
 	// Update Dialog Windows
-	if (_bDebug && GetUIState() == UISTATE_INGAME && PSP_IsInited())
+	if (_bDebug && ingame)
 	{
 		Core_WaitInactive(TEMP_BREAKPOINT_WAIT_MS);
 		breakpointList->reloadBreakpoints();
@@ -827,7 +828,7 @@ void CDisasm::SetDebugMode(bool _bDebug, bool switchPC)
 	{
 		updateThreadLabel(true);
 		
-		if (GetUIState() == UISTATE_INGAME && PSP_IsInited())
+		if (ingame)
 		{
 			SetDlgItemText(m_hDlg, IDC_STOPGO, L"Break");
 			EnableWindow(GetDlgItem(hDlg, IDC_STOPGO), TRUE);

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -68,7 +68,8 @@ namespace MainWindow {
 	LRESULT CALLBACK About(HWND, UINT, WPARAM, LPARAM);
 
 	void SetIngameMenuItemStates(HMENU menu, const GlobalUIState state) {
-		UINT menuEnable = state == UISTATE_INGAME ? MF_ENABLED : MF_GRAYED;
+		UINT menuEnable = state == UISTATE_INGAME || state == UISTATE_EXCEPTION ? MF_ENABLED : MF_GRAYED;
+		UINT menuInGameEnable = state == UISTATE_INGAME ? MF_ENABLED : MF_GRAYED;
 		UINT umdSwitchEnable = state == UISTATE_INGAME && getUMDReplacePermit() ? MF_ENABLED : MF_GRAYED;
 
 		EnableMenuItem(menu, ID_FILE_SAVESTATEFILE, menuEnable);
@@ -86,7 +87,7 @@ namespace MainWindow {
 		EnableMenuItem(menu, ID_DEBUG_SAVESYMFILE, menuEnable);
 		EnableMenuItem(menu, ID_DEBUG_RESETSYMBOLTABLE, menuEnable);
 		EnableMenuItem(menu, ID_DEBUG_TAKESCREENSHOT, menuEnable);
-		EnableMenuItem(menu, ID_DEBUG_SHOWDEBUGSTATISTICS, menuEnable);
+		EnableMenuItem(menu, ID_DEBUG_SHOWDEBUGSTATISTICS, menuInGameEnable);
 		EnableMenuItem(menu, ID_DEBUG_EXTRACTFILE, menuEnable);
 
 		// While playing, this pop up doesn't work - and probably doesn't make sense.
@@ -394,7 +395,7 @@ namespace MainWindow {
 				Core_EnableStepping(false);
 			}
 		} else {
-			if (GetUIState() == UISTATE_INGAME || GetUIState() == UISTATE_PAUSEMENU) {
+			if (GetUIState() == UISTATE_INGAME || GetUIState() == UISTATE_EXCEPTION || GetUIState() == UISTATE_PAUSEMENU) {
 				Core_EnableStepping(false);
 			}
 


### PR DESCRIPTION
Previously, on a crash you could return to the pause screen (via button press), but the load state option wouldn't actually work - it'd go through the motions but stay crashed.  Options in the Windows menu were disabled as well.

This enables load and save state, as well as rewind.  It also makes the Stop and Reset options in the menu work.  Fixes #14584.

Additionally, it adds a "Reset" button next to the "Resume" button (or alone, if you can't resume) as another way out.  If a game crashed on a real PSP, it would actually reset the entire device automatically as far as I know (though not the game, to be fair.)

I've seen people post screenshots in game with a phatom Resume button visible on top of everything else.  Not sure what that's about, don't see any potential for that... maybe it was a bug we already fixed, though.

-[Unknown]