### PR TITLE
Thread: improve BSD compatibility

### DIFF
--- a/Common/Thread/ThreadUtil.cpp
+++ b/Common/Thread/ThreadUtil.cpp
@@ -33,7 +33,7 @@
 #include <sys/syscall.h>
 #endif
 
-#if defined(__DragonFly__) || defined(__FreeBSD__)
+#if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <pthread_np.h>
 #elif defined(__NetBSD__)
 #include <lwp.h>
@@ -125,6 +125,10 @@ void SetCurrentThreadName(const char* threadName) {
 	pthread_setname_np(pthread_self(), threadName);
 #elif defined(__APPLE__)
 	pthread_setname_np(threadName);
+#elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+	pthread_set_name_np(pthread_self(), threadName);
+#elif defined(__NetBSD__)
+	pthread_setname_np(pthread_self(), "%s", (void*)threadName);
 #endif
 
 	// Do nothing

--- a/Common/Thread/ThreadUtil.cpp
+++ b/Common/Thread/ThreadUtil.cpp
@@ -33,6 +33,12 @@
 #include <sys/syscall.h>
 #endif
 
+#if defined(__DragonFly__) || defined(__FreeBSD__)
+#include <pthread_np.h>
+#elif defined(__NetBSD__)
+#include <lwp.h>
+#endif
+
 #ifdef TLS_SUPPORTED
 static thread_local const char *curThreadName;
 #endif
@@ -144,7 +150,7 @@ int GetCurrentThreadIdForDebug() {
 	return 1;
 #elif PPSSPP_PLATFORM(WINDOWS)
 	return (int)GetCurrentThreadId();
-#elif PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS) || defined(__OpenBSD__) || defined(__FreeBSD__)
+#elif PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS)
 	uint64_t tid = 0;
 	pthread_threadid_np(NULL, &tid);
 	return (int)tid;
@@ -152,6 +158,12 @@ int GetCurrentThreadIdForDebug() {
 	// See issue 14545
 	return (int)syscall(__NR_gettid);
 	// return (int)gettid();
+#elif defined(__DragonFly__) || defined(__FreeBSD__)
+	return pthread_getthreadid_np();
+#elif defined(__NetBSD__)
+	return _lwp_self();
+#elif defined(__OpenBSD__)
+	return getthrid();
 #else
 	return 1;
 #endif


### PR DESCRIPTION
Regressed by #14391. From [error log](https://github.com/hrydgard/ppsspp/files/6963522/ppsspp-1.11.3.1096.log):
```
Common/Thread/ThreadUtil.cpp:149:2: error: use of undeclared identifier 'pthread_threadid_np'
        pthread_threadid_np(NULL, &tid);
        ^
```

For parity with desktop Linux after #10411 let's also enable thread names e.g.,
```
$ procstat -t $(pgrep ppsspp)
  PID    TID COMM                TDNAME              CPU  PRI STATE   WCHAN
50842 116220 ppsspp              -                    -1  121 sleep   nanslp
50842 129974 ppsspp              -                    -1  120 sleep   kqread
50842 129975 ppsspp              PoolWorker 0         -1  121 sleep   uwait
50842 129976 ppsspp              PoolWorker 1         -1  121 sleep   uwait
50842 129977 ppsspp              PoolWorker 2         -1  121 sleep   uwait
50842 129978 ppsspp              PoolWorker 3         -1  121 sleep   uwait
50842 129979 ppsspp              PoolWorker 4         -1  121 sleep   uwait
50842 129980 ppsspp              PoolWorker 5         -1  121 sleep   uwait
50842 129981 ppsspp              PoolWorker 6         -1  121 sleep   uwait
50842 129982 ppsspp              PoolWorker 7         -1  121 sleep   uwait
50842 129983 ppsspp              PoolWorker 8         -1  120 sleep   uwait
50842 129984 ppsspp              PoolWorker 9         -1  128 sleep   uwait
50842 129985 ppsspp              PoolWorker 10        -1  128 sleep   uwait
50842 129986 ppsspp              PoolWorker 11        -1  130 sleep   uwait
50842 129987 ppsspp              ppsspp:disk$0        -1  140 sleep   uwait
50842 129988 ppsspp              ppsspp:sh0           -1  140 sleep   uwait
50842 129989 ppsspp              ppsspp:sh1           -1  140 sleep   uwait
50842 129990 ppsspp              ppsspp:sh2           -1  140 sleep   uwait
50842 129991 ppsspp              ppsspp:sh3           -1  140 sleep   uwait
50842 129992 ppsspp              ppsspp:sh4           -1  140 sleep   uwait
50842 129993 ppsspp              ppsspp:sh5           -1  140 sleep   uwait
50842 129995 ppsspp              ppsspp:gdrv0         -1  121 sleep   uwait
50842 129996 ppsspp              SDLAudioP2           -1   92 sleep   pcmwrv
50842 129997 ppsspp              Emu                  -1  123 sleep   uwait
50842 130001 ppsspp              IO                   -1  121 sleep   uwait
50842 130004 ppsspp              UPnPService          -1  120 sleep   nanslp
```
