### PR TITLE
UI: Fix reset of alt speed options in settings

### DIFF
--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -523,7 +523,7 @@ namespace Reporting
 		// Don't report from games without a version ID (i.e. random hashed homebrew IDs.)
 		// The problem is, these aren't useful because the hashes end up different for different people.
 		// TODO: Should really hash the ELF instead of the path, but then that affects savestates/cheats.
-		if (g_paramSFO.GetValueString("DISC_VERSION").empty())
+		if (PSP_IsInited() && g_paramSFO.GetValueString("DISC_VERSION").empty())
 			return false;
 
 		// Some users run the exe from a zip or something, and don't have fonts.

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1218,9 +1218,6 @@ UI::EventReturn GameSettingsScreen::OnDumpNextFrameToLog(UI::EventParams &e) {
 void GameSettingsScreen::update() {
 	UIScreen::update();
 
-	g_Config.iFpsLimit1 = iAlternateSpeedPercent1_ < 0 ? -1 : (iAlternateSpeedPercent1_ * 60) / 100;
-	g_Config.iFpsLimit2 = iAlternateSpeedPercent2_ < 0 ? -1 : (iAlternateSpeedPercent2_ * 60) / 100;
-
 	bool vertical = UseVerticalLayout();
 	if (vertical != lastVertical_) {
 		RecreateViews();
@@ -1266,6 +1263,9 @@ void GameSettingsScreen::sendMessage(const char *message, const char *value) {
 
 void GameSettingsScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 	if (result == DialogResult::DR_OK) {
+		g_Config.iFpsLimit1 = iAlternateSpeedPercent1_ < 0 ? -1 : (iAlternateSpeedPercent1_ * 60) / 100;
+		g_Config.iFpsLimit2 = iAlternateSpeedPercent2_ < 0 ? -1 : (iAlternateSpeedPercent2_ * 60) / 100;
+
 		RecreateViews();
 	}
 }


### PR DESCRIPTION
See #13211.  RecreateViews() was reverting the value before update (inside `UIScreen::update()`.)

-[Unknown]