### PR TITLE
Miscellaneous control/gamepad fixes

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1300,12 +1300,12 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	LogManager::GetInstance()->LoadConfig(log, debugDefaults);
 
 	Section *recent = iniFile.GetOrCreateSection("Recent");
-	recent->Get("MaxRecent", &iMaxRecent, 30);
+	recent->Get("MaxRecent", &iMaxRecent, 60);
 
 	// Fix issue from switching from uint (hex in .ini) to int (dec)
 	// -1 is okay, though. We'll just ignore recent stuff if it is.
 	if (iMaxRecent == 0)
-		iMaxRecent = 30;
+		iMaxRecent = 60;
 
 	if (iMaxRecent > 0) {
 		recentIsos.clear();

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -211,22 +211,26 @@ static const DefMappingStruct defaultMOQI7SKeyMap[] = {
 };
 
 static const DefMappingStruct defaultPadMap[] = {
-#if defined(__ANDROID__)
+#if PPSSPP_PLATFORM(ANDROID)
 	{CTRL_CROSS          , NKCODE_BUTTON_A},
 	{CTRL_CIRCLE         , NKCODE_BUTTON_B},
 	{CTRL_SQUARE         , NKCODE_BUTTON_X},
 	{CTRL_TRIANGLE       , NKCODE_BUTTON_Y},
 	// The hat for DPAD is standard for bluetooth pads, which is the most likely pads on Android I think.
 	{CTRL_LEFT           , JOYSTICK_AXIS_HAT_X, -1},
+	{CTRL_LEFT           , NKCODE_DPAD_LEFT},
 	{CTRL_RIGHT          , JOYSTICK_AXIS_HAT_X, +1},
+	{CTRL_RIGHT          , NKCODE_DPAD_RIGHT},
 	{CTRL_UP             , JOYSTICK_AXIS_HAT_Y, -1},
+	{CTRL_UP             , NKCODE_DPAD_UP},
 	{CTRL_DOWN           , JOYSTICK_AXIS_HAT_Y, +1},
+	{CTRL_DOWN           , NKCODE_DPAD_DOWN},
 	{CTRL_START          , NKCODE_BUTTON_START},
-	{CTRL_SELECT         , NKCODE_BUTTON_SELECT},
+	{CTRL_SELECT         , NKCODE_BACK},
 	{CTRL_LTRIGGER       , NKCODE_BUTTON_L1},
 	{CTRL_RTRIGGER       , NKCODE_BUTTON_R1},
 	{VIRTKEY_UNTHROTTLE  , NKCODE_BUTTON_R2},
-	{VIRTKEY_PAUSE       , NKCODE_BUTTON_THUMBR},
+	{VIRTKEY_PAUSE       , JOYSTICK_AXIS_LTRIGGER, +1},
 	{VIRTKEY_SPEED_TOGGLE, NKCODE_BUTTON_L2},
 	{VIRTKEY_AXIS_X_MIN, JOYSTICK_AXIS_X, -1},
 	{VIRTKEY_AXIS_X_MAX, JOYSTICK_AXIS_X, +1},
@@ -249,6 +253,7 @@ static const DefMappingStruct defaultPadMap[] = {
 	{VIRTKEY_AXIS_X_MAX, JOYSTICK_AXIS_X, +1},
 	{VIRTKEY_AXIS_Y_MIN, JOYSTICK_AXIS_Y, +1},
 	{VIRTKEY_AXIS_Y_MAX, JOYSTICK_AXIS_Y, -1},
+	{VIRTKEY_PAUSE       , JOYSTICK_AXIS_LTRIGGER, +1},
 #endif
 };
 
@@ -936,17 +941,17 @@ void RestoreDefault() {
 	// Autodetect a few common (and less common) devices
 	std::string name = System_GetProperty(SYSPROP_NAME);
 	if (IsNvidiaShield(name) || IsNvidiaShieldTV(name)) {
-		SetDefaultKeyMap(DEFAULT_MAPPING_SHIELD, true);
+		SetDefaultKeyMap(DEFAULT_MAPPING_SHIELD, false);
 	} else if (IsOuya(name)) {
-		SetDefaultKeyMap(DEFAULT_MAPPING_OUYA, true);
+		SetDefaultKeyMap(DEFAULT_MAPPING_OUYA, false);
 	} else if (IsXperiaPlay(name)) {
-		SetDefaultKeyMap(DEFAULT_MAPPING_XPERIA_PLAY, true);
+		SetDefaultKeyMap(DEFAULT_MAPPING_XPERIA_PLAY, false);
 	} else if (IsMOQII7S(name)) {
 		INFO_LOG(SYSTEM, "MOQI pad map");
-		SetDefaultKeyMap(DEFAULT_MAPPING_MOQI_I7S, true);
+		SetDefaultKeyMap(DEFAULT_MAPPING_MOQI_I7S, false);
 	} else {
 		INFO_LOG(SYSTEM, "Default pad map");
-		SetDefaultKeyMap(DEFAULT_MAPPING_PAD, true);
+		SetDefaultKeyMap(DEFAULT_MAPPING_PAD, false);
 	}
 #else
 	SetDefaultKeyMap(DEFAULT_MAPPING_KEYBOARD, true);
@@ -1037,11 +1042,13 @@ void NotifyPadConnected(const std::string &name) {
 }
 
 void AutoConfForPad(const std::string &name) {
+	g_controllerMap.clear();
+
 	INFO_LOG(SYSTEM, "Autoconfiguring pad for '%s'", name.c_str());
 	if (name == "Xbox 360 Pad") {
-		SetDefaultKeyMap(DEFAULT_MAPPING_X360, true);
+		SetDefaultKeyMap(DEFAULT_MAPPING_X360, false);
 	} else {
-		SetDefaultKeyMap(DEFAULT_MAPPING_PAD, true);
+		SetDefaultKeyMap(DEFAULT_MAPPING_PAD, false);
 	}
 
 #ifndef MOBILE_DEVICE

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -905,6 +905,17 @@ void RemoveButtonMapping(int btn) {
 	}
 }
 
+bool IsKeyMapped(int device, int key) {
+	for (auto &iter : g_controllerMap) {
+		for (auto &mappedKey : iter.second) {
+			if (mappedKey == KeyDef(device, key)) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 void SetKeyMapping(int btn, KeyDef key, bool replace) {
 	if (key.keyCode < 0)
 		return;

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -163,4 +163,6 @@ namespace KeyMap {
 
 	const std::set<std::string> &GetSeenPads();
 	void AutoConfForPad(const std::string &name);
+
+	bool IsKeyMapped(int device, int key);
 }

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -107,17 +107,20 @@ void SingleControlMapper::Refresh() {
 
 	float itemH = 45;
 
-	LinearLayout *root = Add(new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(550, WRAP_CONTENT)));
+	float leftColumnWidth = 200;
+	float rightColumnWidth = 250;  // TODO: Should be flexible somehow. Maybe we need to implement Measure.
+
+	LinearLayout *root = Add(new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 	root->SetSpacing(3.0f);
 
 	auto iter = keyImages.find(keyName_);
 	// First, look among images.
 	if (iter != keyImages.end()) {
-		Choice *c = root->Add(new Choice(iter->second, new LinearLayoutParams(200, itemH)));
+		Choice *c = root->Add(new Choice(iter->second, new LinearLayoutParams(leftColumnWidth, itemH)));
 		c->OnClick.Handle(this, &SingleControlMapper::OnReplaceAll);
 	} else {
 		// No image? Let's translate.
-		Choice *c = new Choice(mc->T(keyName_.c_str()), new LinearLayoutParams(200, itemH));
+		Choice *c = new Choice(mc->T(keyName_.c_str()), new LinearLayoutParams(leftColumnWidth, itemH));
 		c->SetCentered(true);
 		root->Add(c)->OnClick.Handle(this, &SingleControlMapper::OnReplaceAll);
 	}
@@ -129,7 +132,7 @@ void SingleControlMapper::Refresh() {
 		p->OnClick.Handle(this, &SingleControlMapper::OnAddMouse);
 	}
 
-	LinearLayout *rightColumn = root->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f)));
+	LinearLayout *rightColumn = root->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(rightColumnWidth, WRAP_CONTENT)));
 	rightColumn->SetSpacing(2.0f);
 	std::vector<KeyDef> mappings;
 	KeyMap::KeyFromPspButton(pspKey_, &mappings, false);
@@ -141,9 +144,10 @@ void SingleControlMapper::Refresh() {
 		LinearLayout *row = rightColumn->Add(new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 		row->SetSpacing(1.0f);
 
-		Choice *c = row->Add(new Choice(deviceName + "." + keyName, new LinearLayoutParams(FILL_PARENT, itemH, 1.0f)));
 		char tagbuf[16];
-		sprintf(tagbuf, "%i", (int)i);
+		sprintf(tagbuf, "%d", (int)i);
+
+		Choice *c = row->Add(new Choice(deviceName + "." + keyName, new LinearLayoutParams(FILL_PARENT, itemH, 1.0f)));
 		c->SetTag(tagbuf);
 		c->OnClick.Handle(this, &SingleControlMapper::OnReplace);
 
@@ -244,7 +248,7 @@ void ControlMappingScreen::CreateViews() {
 	rightScroll_ = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(1.0f));
 	rightScroll_->SetTag("ControlMapping");
 	rightScroll_->SetScrollToTop(false);
-	LinearLayout *rightColumn = new LinearLayoutList(ORIENT_VERTICAL, new LinearLayoutParams(1.0f));
+	LinearLayout *rightColumn = new LinearLayoutList(ORIENT_VERTICAL);
 	rightScroll_->Add(rightColumn);
 
 	root_->Add(leftColumn);
@@ -252,7 +256,9 @@ void ControlMappingScreen::CreateViews() {
 
 	std::vector<KeyMap::KeyMap_IntStrPair> mappableKeys = KeyMap::GetMappableKeys();
 	for (size_t i = 0; i < mappableKeys.size(); i++) {
-		SingleControlMapper *mapper = rightColumn->Add(new SingleControlMapper(this, mappableKeys[i].key, mappableKeys[i].name, screenManager(), new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+		SingleControlMapper *mapper = rightColumn->Add(
+			new SingleControlMapper(this, mappableKeys[i].key, mappableKeys[i].name, screenManager(),
+				                    new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 		mappers_.push_back(mapper);
 	}
 }

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -480,7 +480,12 @@ void SystemInfoScreen::CreateViews() {
 #endif
 
 	deviceSpecs->Add(new ItemHeader(si->T("CPU Information")));
-	deviceSpecs->Add(new InfoItem(si->T("CPU Name", "Name"), cpu_info.brand_string));
+
+	// Don't bother showing the CPU name if we don't have one.
+	if (cpu_info.brand_string != "Unknown") {
+		deviceSpecs->Add(new InfoItem(si->T("CPU Name", "Name"), cpu_info.brand_string));
+	}
+
 	int totalThreads = cpu_info.num_cores * cpu_info.logical_cpu_count;
 	std::string cores = StringFromFormat(si->T("%d (%d per core, %d cores)"), totalThreads, cpu_info.logical_cpu_count, cpu_info.num_cores);
 	deviceSpecs->Add(new InfoItem(si->T("Threads"), cores));

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -506,10 +506,14 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 		}
 #endif
 	} else if (!strcmp(message, "app_resumed") && screenManager()->topScreen() == this) {
-		// If there's no back button mapped, use this as the way to get into the menu.
+		if (System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_TV) {
+			if (!KeyMap::IsKeyMapped(DEVICE_ID_PAD_0, VIRTKEY_PAUSE) || !KeyMap::IsKeyMapped(DEVICE_ID_PAD_1, VIRTKEY_PAUSE)) {
+				// If it's a TV (so no built-in back button), and there's no back button mapped to a pad,
+				// use this as the fallback way to get into the menu.
 
-		// TODO: Check mappings.
-		screenManager()->push(new GamePauseScreen(gamePath_));
+				screenManager()->push(new GamePauseScreen(gamePath_));
+			}
+		}
 	}
 }
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -505,6 +505,11 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 			OnChatMenu.Trigger(e);
 		}
 #endif
+	} else if (!strcmp(message, "app_resumed") && screenManager()->topScreen() == this) {
+		// If there's no back button mapped, use this as the way to get into the menu.
+
+		// TODO: Check mappings.
+		screenManager()->push(new GamePauseScreen(gamePath_));
 	}
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -679,17 +679,18 @@ void GameSettingsScreen::CreateViews() {
 	controlsSettings->Add(new CheckBox(&g_Config.bGamepadOnlyFocused, co->T("Ignore gamepads when not focused")));
 #endif
 
-#if defined(MOBILE_DEVICE)
-	controlsSettings->Add(new CheckBox(&g_Config.bHapticFeedback, co->T("HapticFeedback", "Haptic Feedback (vibration)")));
-	static const char *tiltTypes[] = { "None (Disabled)", "Analog Stick", "D-PAD", "PSP Action Buttons", "L/R Trigger Buttons" };
-	controlsSettings->Add(new PopupMultiChoice(&g_Config.iTiltInputType, co->T("Tilt Input Type"), tiltTypes, 0, ARRAY_SIZE(tiltTypes), co->GetName(), screenManager()))->OnClick.Handle(this, &GameSettingsScreen::OnTiltTypeChange);
+	if (System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_MOBILE) {
+		controlsSettings->Add(new CheckBox(&g_Config.bHapticFeedback, co->T("HapticFeedback", "Haptic Feedback (vibration)")));
 
-	Choice *customizeTilt = controlsSettings->Add(new Choice(co->T("Customize tilt")));
-	customizeTilt->OnClick.Handle(this, &GameSettingsScreen::OnTiltCustomize);
-	customizeTilt->SetEnabledFunc([] {
-		return g_Config.iTiltInputType != 0;
-	});
-#endif
+		static const char *tiltTypes[] = { "None (Disabled)", "Analog Stick", "D-PAD", "PSP Action Buttons", "L/R Trigger Buttons" };
+		controlsSettings->Add(new PopupMultiChoice(&g_Config.iTiltInputType, co->T("Tilt Input Type"), tiltTypes, 0, ARRAY_SIZE(tiltTypes), co->GetName(), screenManager()))->OnClick.Handle(this, &GameSettingsScreen::OnTiltTypeChange);
+
+		Choice *customizeTilt = controlsSettings->Add(new Choice(co->T("Customize tilt")));
+		customizeTilt->OnClick.Handle(this, &GameSettingsScreen::OnTiltCustomize);
+		customizeTilt->SetEnabledFunc([] {
+			return g_Config.iTiltInputType != 0;
+		});
+	}
 
 	// TVs don't have touch control, at least not yet.
 	if (System_GetPropertyInt(SYSPROP_DEVICE_TYPE) != DEVICE_TYPE_TV) {

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -790,6 +790,8 @@ bool audioRecording_State() {
 extern "C" void Java_org_ppsspp_ppsspp_NativeApp_resume(JNIEnv *, jclass) {
 	INFO_LOG(SYSTEM, "NativeApp.resume() - resuming audio");
 	AndroidAudio_Resume(g_audioState);
+
+	NativeMessageReceived("app_resumed", "");
 }
 
 extern "C" void Java_org_ppsspp_ppsspp_NativeApp_pause(JNIEnv *, jclass) {

--- a/android/src/org/ppsspp/ppsspp/InputDeviceState.java
+++ b/android/src/org/ppsspp/ppsspp/InputDeviceState.java
@@ -12,7 +12,7 @@ import android.view.MotionEvent;
 public class InputDeviceState {
 	private static final String TAG = "InputDeviceState";
 
-	private static final int deviceId = NativeApp.DEVICE_ID_PAD_0;
+	public static final int deviceId = NativeApp.DEVICE_ID_PAD_0;
 
 	private InputDevice mDevice;
 	private int[] mAxes;

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -968,27 +968,27 @@ public abstract class NativeActivity extends Activity {
 
 			int sources = event.getSource();
 
+			// Is this really only for the Xperia Play special handling in OnKeyDown?
+			// And if so, can we just handle it here instead?
 			switch (event.getKeyCode()) {
 			case KeyEvent.KEYCODE_BACK:
-			case KeyEvent.KEYCODE_MENU:
 				passThrough = true;
-				Log.i(TAG, "Passing through key, source = " + sources);
 				break;
 			default:
 				break;
 			}
 
-			// Don't passthrough back or menu button if from gamepad.
+			// Don't passthrough back button if from gamepad.
 			// XInput device on Android returns source 1281 or 0x501, which equals GAMEPAD | KEYBOARD.
 			// Shield Remote returns 769 or 0x301 which equals DPAD | KEYBOARD.
 
-			if ((sources & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD ||
+			// Don't disable passthrough if app at top level.
+			if (((sources & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD ||
 					(sources & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK ||
-					(sources & InputDevice.SOURCE_DPAD) == InputDevice.SOURCE_DPAD)
+					(sources & InputDevice.SOURCE_DPAD) == InputDevice.SOURCE_DPAD))
 			{
 				passThrough = false;
 			}
-			Log.i(TAG, "Input event device sources: " + sources);
 
 			if (!passThrough) {
 				switch (event.getAction()) {
@@ -1064,7 +1064,7 @@ public abstract class NativeActivity extends Activity {
 			if (event.isAltPressed()) {
 				NativeApp.keyDown(InputDeviceState.deviceId, 1004, repeat); // special custom keycode for the O button on Xperia Play
 			} else if (NativeApp.isAtTopLevel()) {
- 				Log.i(TAG, "IsAtTopLevel returned true.");
+				Log.i(TAG, "IsAtTopLevel returned true.");
 				// Pass through the back event.
 				return super.onKeyDown(keyCode, event);
 			} else {


### PR DESCRIPTION
A bit of everything:

* Fix bug where BACK always got device ID 0
* If it's an Android TV and no gamepad is mapped to Pause, pause on app switch
* Improve default controller mappings on Android. LTrigger is now pause, and back is select as expected.
* Minor UI tweaks

Also throws in a MaxRecent bump to 60, improving #14707 