### PR TITLE
Fix controls layout opacity

### DIFF
--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -99,10 +99,8 @@ public:
 	}
 
 	void Draw(UIContext &dc) override {
-		float opacity = g_Config.iTouchButtonOpacity / 100.0f;
-
-		uint32_t colorBg = colorAlpha(GetButtonColor(), opacity);
-		uint32_t color = colorAlpha(0xFFFFFF, opacity);
+		uint32_t colorBg = colorAlpha(GetButtonColor(), GetButtonOpacity());
+		uint32_t color = colorAlpha(0xFFFFFF, GetButtonOpacity());
 
 		int centerX = bounds_.centerX();
 		int centerY = bounds_.centerY();
@@ -160,10 +158,8 @@ public:
 	}
 
 	void Draw(UIContext &dc) override {
-		float opacity = g_Config.iTouchButtonOpacity / 100.0f;
-
-		uint32_t colorBg = colorAlpha(GetButtonColor(), opacity);
-		uint32_t color = colorAlpha(0xFFFFFF, opacity);
+		uint32_t colorBg = colorAlpha(GetButtonColor(), GetButtonOpacity());
+		uint32_t color = colorAlpha(0xFFFFFF, GetButtonOpacity());
 
 		static const float xoff[4] = {1, 0, -1, 0};
 		static const float yoff[4] = {0, 1, 0, -1};


### PR DESCRIPTION
DPad and action buttons now have a min of 50% opacity in the layout screen (same as all other button).

Reported on Discord by ASKUT_KRIMSON.