### PR TITLE
Store: Make description focusable

### DIFF
--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -270,13 +270,16 @@ void ProductView::CreateViews() {
 	cancelButton_->SetVisibility(isDownloading ? V_VISIBLE : V_GONE);
 
 	// Add star rating, comments etc?
-	Add(new TextView(entry_.description, ALIGN_LEFT | FLAG_WRAP_TEXT, false));
+
+	// Draw each line separately so focusing can scroll.
+	std::vector<std::string> lines;
+	SplitString(entry_.description, '\n', lines);
+	for (auto &line : lines) {
+		Add(new TextView(line, ALIGN_LEFT | FLAG_WRAP_TEXT, false))->SetFocusable(true);
+	}
 
 	float size = entry_.size / (1024.f * 1024.f);
-	char temp[256];
-	sprintf(temp, "%s: %.2f %s", st->T("Size"), size, st->T("MB"));
-
-	Add(new TextView(temp));
+	Add(new TextView(StringFromFormat("%s: %.2f %s", st->T("Size"), size, st->T("MB"))));
 }
 
 void ProductView::Update() {


### PR DESCRIPTION
Descriptions aren't that long currently, but this allows for longer descriptions with controller/keyboard scrolling.

The scrollability is achieved by splitting on \n, but I'd argue any description with a single line/paragraph bigger than the screen is just a bad description.  None of our current descriptions are that long, anyway.

Just a quick fix for #11919.

-[Unknown]