### PR TITLE
Dialog: Avoid crash with hacked dialog start

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -121,10 +121,12 @@ void PSPDialog::ChangeStatusInit(int delayUs) {
 }
 
 void PSPDialog::ChangeStatusShutdown(int delayUs) {
+	// If we're doing shutdown right away and skipped start, we don't run the dialog thread.
+	bool skipDialogShutdown = status == SCE_UTILITY_STATUS_NONE;
 	ChangeStatus(SCE_UTILITY_STATUS_SHUTDOWN, 0);
 
 	auto params = GetCommonParam();
-	if (params)
+	if (params && !skipDialogShutdown)
 		UtilityDialogShutdown(DialogType(), delayUs, params->accessThread);
 	else
 		ChangeStatus(SCE_UTILITY_STATUS_NONE, delayUs);

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -37,6 +37,7 @@
 #include "Core/HLE/sceKernel.h"
 #include "Core/HLE/sceKernelMemory.h"
 #include "Core/HLE/sceKernelThread.h"
+#include "Core/HLE/scePower.h"
 #include "Core/HLE/sceUtility.h"
 
 #include "Core/Dialog/PSPSaveDialog.h"
@@ -358,6 +359,11 @@ static int sceUtilitySavedataInitStart(u32 paramAddr) {
 	if (currentDialogActive && currentDialogType != UtilityDialogType::SAVEDATA) {
 		if (PSP_CoreParameter().compat.flags().YugiohSaveFix) {
 			WARN_LOG(SCEUTILITY, "Yugioh Savedata Correction");
+			if (accessThread) {
+				accessThread->Terminate();
+				// Try to unlock in case other dialog was shutting down.
+				KernelVolatileMemUnlock(0);
+			}
 		} else {
 			return hleLogWarning(SCEUTILITY, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 		}


### PR DESCRIPTION
See #14727.  If a dialog shutdown is in progress and we incorrectly allow a startup at that time, it breaks other things.  This tries to at least work around that.

I suspect the hack is just working around a bug that is hopefully gone now in the network dialog, but I don't have these games to try it.

-[Unknown]