### PR TITLE
Dialog: Prevent reschedule on shutdown start

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -122,7 +122,7 @@ void PSPDialog::ChangeStatusInit(int delayUs) {
 
 void PSPDialog::ChangeStatusShutdown(int delayUs) {
 	// If we're doing shutdown right away and skipped start, we don't run the dialog thread.
-	bool skipDialogShutdown = status == SCE_UTILITY_STATUS_NONE;
+	bool skipDialogShutdown = status == SCE_UTILITY_STATUS_NONE && pendingStatus == SCE_UTILITY_STATUS_NONE;
 	ChangeStatus(SCE_UTILITY_STATUS_SHUTDOWN, 0);
 
 	auto params = GetCommonParam();

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -697,9 +697,13 @@ void *GetQuickSyscallFunc(MIPSOpcode op) {
 }
 
 static double hleSteppingTime = 0.0;
-void hleSetSteppingTime(double t)
-{
+void hleSetSteppingTime(double t) {
 	hleSteppingTime += t;
+}
+
+static double hleFlipTime = 0.0;
+void hleSetFlipTime(double t) {
+	hleFlipTime = t;
 }
 
 void CallSyscall(MIPSOpcode op)
@@ -734,8 +738,11 @@ void CallSyscall(MIPSOpcode op)
 		int funcnum = callno & 0xFFF;
 		int modulenum = (callno & 0xFF000) >> 12;
 		double total = time_now_d() - start - hleSteppingTime;
+		if (total >= hleFlipTime)
+			total -= hleFlipTime;
 		_dbg_assert_msg_(total >= 0.0, "Time spent in syscall became negative");
 		hleSteppingTime = 0.0;
+		hleFlipTime = 0.0;
 		updateSyscallStats(modulenum, funcnum, total);
 	}
 }

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -117,6 +117,8 @@ void hleDebugBreak();
 void hleSkipDeadbeef();
 // Set time spent in debugger (for more useful debug stats while debugging.)
 void hleSetSteppingTime(double t);
+// Set time spent in realtime sync.
+void hleSetFlipTime(double t);
 // Check if the current syscall context is kernel.
 bool hleIsKernelMode();
 // Enqueue a MIPS function to be called after this HLE call finishes.

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -972,8 +972,13 @@ void __DisplaySetFramebuf(u32 topaddr, int linesize, int pixelFormat, int sync) 
 		// IMMEDIATE means that the buffer is fine. We can just flip immediately.
 		// Doing it in non-buffered though creates problems (black screen) on occasion though
 		// so let's not.
-		if (!flippedThisFrame && g_Config.iRenderingMode != FB_NON_BUFFERED_MODE)
+		if (!flippedThisFrame && g_Config.iRenderingMode != FB_NON_BUFFERED_MODE) {
+			double before_flip = time_now_d();
 			__DisplayFlip(0);
+			double after_flip = time_now_d();
+			// Ignore for debug stats.
+			hleSetFlipTime(after_flip - before_flip);
+		}
 	} else {
 		// Delay the write until vblank
 		latchedFramebuf = fbstate;

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -390,6 +390,8 @@ static u32 sceGeDrawSync(u32 mode) {
 	//wait/check entire drawing state
 	if (PSP_CoreParameter().compat.flags().DrawSyncEatCycles)
 		hleEatCycles(500000); //HACK(?) : Potential fix for Crash Tag Team Racing and a few Gundam games
+	else
+		hleEatCycles(1240);
 	DEBUG_LOG(SCEGE, "sceGeDrawSync(mode=%d)  (0=wait for completion, 1=peek)", mode);
 	return gpu->DrawSync(mode);
 }

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -40,10 +40,6 @@
 #include "GPU/GPUCommon.h"
 #include "GPU/GPUState.h"
 
-void __DisableInterrupts();
-void __EnableInterrupts();
-bool __InterruptsEnabled();
-
 // Seems like some > 16 are taken but not available.  Probably kernel only?
 static const u32 PSP_NUMBER_SUBINTERRUPTS = 32;
 

--- a/Core/HLE/sceKernelInterrupt.h
+++ b/Core/HLE/sceKernelInterrupt.h
@@ -128,6 +128,8 @@ private:
 	std::map<int, SubIntrHandler> subIntrHandlers;
 };
 
+void __DisableInterrupts();
+void __EnableInterrupts();
 bool __InterruptsEnabled();
 bool __IsInInterrupt();
 void __InterruptsInit();

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2063,7 +2063,8 @@ int __KernelStartThread(SceUID threadToStartID, int argSize, u32 argBlockPtr, bo
 			Core_ExecException(startThread->context.pc, currentMIPS->pc, ExecExceptionType::THREAD);
 		}
 		__KernelChangeReadyState(cur, currentThread, true);
-		hleReSchedule("thread started");
+		if (__InterruptsEnabled())
+			hleReSchedule("thread started");
 	}
 
 	// Starting a thread automatically resumes the dispatch thread if the new thread has worse priority.

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -35,6 +35,7 @@
 #include "Core/System.h"
 
 #include "Core/HLE/sceKernel.h"
+#include "Core/HLE/sceKernelInterrupt.h"
 #include "Core/HLE/sceKernelMemory.h"
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/HLE/scePower.h"
@@ -325,8 +326,12 @@ void UtilityDialogShutdown(UtilityDialogType type, int delayUs, int priority) {
 
 	CleanupDialogThreads();
 	_assert_(accessThread == nullptr);
+	bool prevInterrupts = __InterruptsEnabled();
+	__DisableInterrupts();
 	accessThread = new HLEHelperThread("ScePafJob", insts, (uint32_t)ARRAY_SIZE(insts), priority, 0x200);
 	accessThread->Start(partDelay, 0);
+	if (prevInterrupts)
+		__EnableInterrupts();
 }
 
 static int UtilityWorkUs(int us) {


### PR DESCRIPTION
This is a bit strange, but tests seem to suggest this is correct.

A worse priority thread won't run before savedata shutdown hits 0, but the thread that initiated shutdown runs before shutdown completes.

In GTA, right after shutdown it quits the current thread, and then another (worse priority than the caller) thread does a try lock on volatile memory, but even if it fails it assumes it worked and breaks if it was a lie.

But in Freakout, right after shutdown it checks the status, which must still be 4 (even though all threads are better priority) or it will hang.

In tests, I can replicate both behaviors: status is immediately 4 and volatile is still locked, but no other worse priority thread will run before both of those conditions change.

-[Unknown]