### PR TITLE
Dialog: Lock volatile when the access thread runs

### DIFF
--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -276,21 +276,22 @@ void __UtilityShutdown() {
 void UtilityDialogInitialize(UtilityDialogType type, int delayUs, int priority) {
 	int partDelay = delayUs / 4;
 	const u32_le insts[] = {
-		// Make sure we don't discard/deadbeef 'em.
+		// Make sure we don't discard/deadbeef a0.
 		(u32_le)MIPS_MAKE_ORI(MIPS_REG_S0, MIPS_REG_A0, 0),
-		(u32_le)MIPS_MAKE_SYSCALL("sceUtility", "__UtilityWorkUs"),
-		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A0, MIPS_REG_S0, 0),
-		(u32_le)MIPS_MAKE_SYSCALL("sceUtility", "__UtilityWorkUs"),
-		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A0, MIPS_REG_S0, 0),
-		(u32_le)MIPS_MAKE_SYSCALL("sceUtility", "__UtilityWorkUs"),
-		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A0, MIPS_REG_S0, 0),
-		(u32_le)MIPS_MAKE_SYSCALL("sceUtility", "__UtilityWorkUs"),
 
-		// Now actually lock the volatile memory.  Maybe this should be earlier...
 		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A0, MIPS_REG_ZERO, 0),
 		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A1, MIPS_REG_ZERO, 0),
 		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A2, MIPS_REG_ZERO, 0),
 		(u32_le)MIPS_MAKE_SYSCALL("sceSuspendForUser", "sceKernelVolatileMemLock"),
+
+		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A0, MIPS_REG_S0, 0),
+		(u32_le)MIPS_MAKE_SYSCALL("sceUtility", "__UtilityWorkUs"),
+		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A0, MIPS_REG_S0, 0),
+		(u32_le)MIPS_MAKE_SYSCALL("sceUtility", "__UtilityWorkUs"),
+		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A0, MIPS_REG_S0, 0),
+		(u32_le)MIPS_MAKE_SYSCALL("sceUtility", "__UtilityWorkUs"),
+		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A0, MIPS_REG_S0, 0),
+		(u32_le)MIPS_MAKE_SYSCALL("sceUtility", "__UtilityWorkUs"),
 
 		(u32_le)MIPS_MAKE_ORI(MIPS_REG_A0, MIPS_REG_ZERO, (int)type),
 		(u32_le)MIPS_MAKE_JR_RA(),


### PR DESCRIPTION
Further tests show that this should be locked first thing before the delays, it just depends on the thread priorities involved.

This feels a bit dangerous because of timing issues we've seen in some games, and I tried several games with it without problems.  It matches my tests on firmware (it really seems to lock the moment that thread runs), and I think it would fix the behavior shown in the logs on #14647.

-[Unknown]