### PR TITLE
(Libretro) Set base_width/base_height to sane dimensions (480x272)

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -495,8 +495,8 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
    info->timing.fps            = 60.0f / 1.001f;
    info->timing.sample_rate    = SAMPLERATE;
 
-   info->geometry.base_width   = g_Config.iInternalResolution * 480;
-   info->geometry.base_height  = g_Config.iInternalResolution * 272;
+   info->geometry.base_width   = 480;
+   info->geometry.base_height  = 272;
    info->geometry.max_width    = g_Config.iInternalResolution * 480;
    info->geometry.max_height   = g_Config.iInternalResolution * 272;
    info->geometry.aspect_ratio = 480.0 / 272.0;  // Not 16:9! But very, very close.


### PR DESCRIPTION
base_width/base_height should be set to the lowest/default PSP internal resolution, which in this case is 480x272. Setting base_width/height the same as max_width/max_height would create problems with windowed mode in RetroArch, it would try to create a huge window (often times far exceeding the desktop size).

@hrydgard @unknownbrackets The sooner this could be merged the better. This resolves a crash in windowed mode with the Direct3D 11 driver, but in general it would cause issues for OpenGL/Vulkan too.