### PR TITLE
[WIP] iOS AltKit support for JIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,5 @@ debian/ppsspp/
 
 # RenderDoc
 *.rdc
+/.project
+/.settings

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "zstd"]
 	path = ext/zstd
 	url = https://github.com/facebook/zstd.git
+[submodule "ext/AltKit"]
+	path = ext/AltKit
+	url = https://github.com/jpd002/AltKit.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1038,6 +1038,14 @@ elseif(IOS)
 	add_compile_options($<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-fPIC>)
 	enable_language(Swift)
 	add_subdirectory(ext/AltKit)
+	# if(NOT TARGET AltKit)
+	# add_subdirectory(
+	# 	${CMAKE_CURRENT_SOURCE_DIR}/ext/AltKit
+	# 	${CMAKE_CURRENT_BINARY_DIR}/AltKit
+	# )
+	# endif()
+	list(APPEND PROJECT_LIBS AltKit)
+
 
 	set(nativeExtra ${nativeExtra}
 		ios/main.mm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1033,6 +1033,12 @@ if(ANDROID)
 	)
 	# No target
 elseif(IOS)
+	# AltKit
+	# TODO: Move me probably and use a flag to disable if wanted.
+	add_compile_options($<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-fPIC>)
+	enable_language(Swift)
+	add_subdirectory(ext/AltKit)
+
 	set(nativeExtra ${nativeExtra}
 		ios/main.mm
 		ios/AppDelegate.mm

--- a/cmake/Toolchains/ios.cmake
+++ b/cmake/Toolchains/ios.cmake
@@ -12,7 +12,7 @@
 # PPSSPP platform flags
 set(MOBILE_DEVICE ON)
 set(USING_GLES2 ON)
-set(IPHONEOS_DEPLOYMENT_TARGET 6.0)
+set(IPHONEOS_DEPLOYMENT_TARGET 9.0)
 add_definitions(
   -DGL_ETC1_RGB8_OES=0
   -U__STRICT_ANSI__
@@ -96,3 +96,7 @@ set(CMAKE_SYSTEM_FRAMEWORK_PATH
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 
+add_compile_options($<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-fPIC>)
+# Causes error
+# project(Common LANGUAGES C Swift)
+add_subdirectory(ext/AltKit)

--- a/cmake/Toolchains/ios.cmake
+++ b/cmake/Toolchains/ios.cmake
@@ -17,7 +17,8 @@ add_definitions(
   -DGL_ETC1_RGB8_OES=0
 )
 
-add_definitions($<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-U__STRICT_ANSI__ >)
+# TODO: Not sure how to do this, need to conditionally flag or else Swift test fails
+#add_definitions($<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-U__STRICT_ANSI__ >)
 
 set(OPENGL_LIBRARIES "-framework OpenGLES")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mios-version-min=${IPHONEOS_DEPLOYMENT_TARGET}")

--- a/cmake/Toolchains/ios.cmake
+++ b/cmake/Toolchains/ios.cmake
@@ -15,8 +15,9 @@ set(USING_GLES2 ON)
 set(IPHONEOS_DEPLOYMENT_TARGET 9.0)
 add_definitions(
   -DGL_ETC1_RGB8_OES=0
-  -U__STRICT_ANSI__
 )
+
+add_definitions($<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-U__STRICT_ANSI__ >)
 
 set(OPENGL_LIBRARIES "-framework OpenGLES")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mios-version-min=${IPHONEOS_DEPLOYMENT_TARGET}")
@@ -95,8 +96,3 @@ set(CMAKE_SYSTEM_FRAMEWORK_PATH
 # only search the iOS sdks, not the remainder of the host filesystem
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-
-add_compile_options($<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-fPIC>)
-# Causes error
-# project(Common LANGUAGES C Swift)
-add_subdirectory(ext/AltKit)

--- a/ios/AppDelegate.mm
+++ b/ios/AppDelegate.mm
@@ -7,6 +7,7 @@
 #import "Common/Log.h"
 
 #import <AVFoundation/AVFoundation.h>
+@import AltKit;
 
 @implementation AppDelegate
 
@@ -119,11 +120,38 @@
 		Audio_Init();
 	}
 	
+	[self initAltKit];
 	NativeMessageReceived("got_focus", "");	
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application {
 	exit(0);
+}
+
+#pragma mark - AltKit
+- (void)initAltKit {
+	[[ALTServerManager sharedManager] startDiscovering];
+
+	[[ALTServerManager sharedManager] autoconnectWithCompletionHandler:^(ALTServerConnection *connection, NSError *error) {
+		if (error)
+		{
+			return ERROR_LOG(SYSTEM, "Could not auto-connect to server. %@", error);
+		}
+
+		[connection enableUnsignedCodeExecutionWithCompletionHandler:^(BOOL success, NSError *error) {
+			if (success)
+			{
+				INFO_LOG(SYSTEM, "Successfully enabled JIT compilation!");
+				[[ALTServerManager sharedManager] stopDiscovering];
+			}
+			else
+			{
+				ERROR_LOG(SYSTEM, "Could not enable JIT compilation. %@", error);
+			}
+
+			[connection disconnect];
+		}];
+	}];
 }
 
 @end

--- a/ios/AppDelegate.mm
+++ b/ios/AppDelegate.mm
@@ -8,8 +8,8 @@
 
 #import <AVFoundation/AVFoundation.h>
 
-#if __has_include(<AltKit/AltKit.h>)
-#import <AltKit/AltKit.h>
+#if __has_include("AltKit-Swift.h")
+#import "AltKit-Swift.h"
 #define __HAS_ALTKIT_FRAMEWORK__
 #endif
 

--- a/ios/AppDelegate.mm
+++ b/ios/AppDelegate.mm
@@ -7,7 +7,7 @@
 #import "Common/Log.h"
 
 #import <AVFoundation/AVFoundation.h>
-@import AltKit;
+#import <AltKit/AltKit.h>
 
 @implementation AppDelegate
 

--- a/ios/AppDelegate.mm
+++ b/ios/AppDelegate.mm
@@ -7,7 +7,11 @@
 #import "Common/Log.h"
 
 #import <AVFoundation/AVFoundation.h>
+
+#if __has_include(<AltKit/AltKit.h>)
 #import <AltKit/AltKit.h>
+#define __HAS_ALTKIT_FRAMEWORK__
+#endif
 
 @implementation AppDelegate
 
@@ -120,7 +124,9 @@
 		Audio_Init();
 	}
 	
+	#ifdef __HAS_ALTKIT_FRAMEWORK__
 	[self initAltKit];
+	#endif
 	NativeMessageReceived("got_focus", "");	
 }
 
@@ -129,6 +135,7 @@
 }
 
 #pragma mark - AltKit
+#ifdef __HAS_ALTKIT_FRAMEWORK__
 - (void)initAltKit {
 	[[ALTServerManager sharedManager] startDiscovering];
 
@@ -153,5 +160,5 @@
 		}];
 	}];
 }
-
+#endif
 @end

--- a/ios/PPSSPP-Info.plist
+++ b/ios/PPSSPP-Info.plist
@@ -202,5 +202,11 @@
 			</dict>
 		</dict>
 	</array>
+	<key>NSBonjourServices</key>
+	<array>
+    	<string>_altserver._tcp</string>
+	</array>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>PPSSPP uses the local network to find and communicate with AltServer.</string>
 </dict>
 </plist>

--- a/ios/PPSSPP-Info.plist
+++ b/ios/PPSSPP-Info.plist
@@ -208,5 +208,7 @@
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>PPSSPP uses the local network to find and communicate with AltServer.</string>
+	<key>ALTDeviceID</key>
+	<string></string>
 </dict>
 </plist>


### PR DESCRIPTION
refs #14570 

## Overview

- Add AltKit CMake (currently a custom branch until https://github.com/rileytestut/AltKit/pull/1 is merged)
- Update Info.plist for bonjour usage string
- Add basic code to connect to AltKit
- Conditionally import AltKit in AppDelegate.mm

Build instructions I'm using;
```sh
cmake -DCMAKE_TOOLCHAIN_FILE=./cmake/Toolchains/ios.cmake -DIOS_PLATFORM=OS -DCMAKE_IOS_SDK_ROOT=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk -H. -Bbuild.ios -GXcode
```

## References

https://github.com/jpd002/Play-/issues/1078
https://github.com/jpd002/AltKit/tree/cmake_poc

## Todo

- [ ] Activate/Disable JIT in PPSSPP on success/failure callbacks
- [ ] Fix import AltKit (how to do in CMake?)
- [x] Fix CMake error  `CMake Error at ext/AltKit/CMakeLists.txt:3 (project):
  Language 'C' is currently being enabled.  Recursive call not allowed.`
  
  
## Discussion

I wanted to test JIT in AltKit for another project, and PPSSPP seemed like a good project to test since I don't have JIT code active in my other project.

I'm a CMake noob, I couldn't figure out the AddLanguage error, so I'm posting this WIP PR to see if anyone else wants to take a stab or give some feedback/help.

Thanks

ping @lonkle 