### PR TITLE
Correct breakpoints in delay slots

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1192,7 +1192,7 @@ bool SavedataParam::GetList(SceUtilitySavedataParam *param)
 		for (size_t i = 0; i < validDir.size(); ++i) {
 			// GetFileName(param) == NUll here
 			// so use sfo files to set the date.
-			sfoFile = pspFileSystem.GetFileInfo(savePath + validDir[i].name + "/" + "PARAM.SFO");
+			sfoFile = pspFileSystem.GetFileInfo(savePath + validDir[i].name + "/" + SFO_FILENAME);
 			sfoFiles.push_back(sfoFile);
 		}
 
@@ -1262,7 +1262,7 @@ int SavedataParam::GetFilesList(SceUtilitySavedataParam *param)
 	fileList->resultNumNormalEntries = 0;
 	fileList->resultNumSystemEntries = 0;
 
-	// We need PARAMS.SFO's SAVEDATA_FILE_LIST to determine which entries are secure.
+	// We need PARAM.SFO's SAVEDATA_FILE_LIST to determine which entries are secure.
 	PSPFileInfo sfoFileInfo = pspFileSystem.GetFileInfo(dirPath + "/" + SFO_FILENAME);
 	std::set<std::string> secureFilenames;
 

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -72,12 +72,12 @@ void DisassembleArm(const u8 *data, int size) {
 	}
 }
 
-static u32 JitBreakpoint() {
+static u32 JitBreakpoint(uint32_t addr) {
 	// Should we skip this breakpoint?
-	if (CBreakPoints::CheckSkipFirst() == currentMIPS->pc)
+	if (CBreakPoints::CheckSkipFirst() == currentMIPS->pc || CBreakPoints::CheckSkipFirst() == addr)
 		return 0;
 
-	BreakAction result = CBreakPoints::ExecBreakPoint(currentMIPS->pc);
+	BreakAction result = CBreakPoints::ExecBreakPoint(addr);
 	if ((result & BREAK_ACTION_PAUSE) == 0)
 		return 0;
 
@@ -746,7 +746,8 @@ bool ArmJit::CheckJitBreakpoint(u32 addr, int downcountOffset) {
 		MOVI2R(SCRATCHREG1, GetCompilerPC());
 		MovToPC(SCRATCHREG1);
 		RestoreRoundingMode();
-		QuickCallFunction(SCRATCHREG1, &JitBreakpoint);
+		MOVI2R(R0, addr);
+		QuickCallFunction(SCRATCHREG2, &JitBreakpoint);
 
 		// If 0, the conditional breakpoint wasn't taken.
 		CMPI2R(R0, 0, SCRATCHREG2);

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -36,9 +36,6 @@ class PointerWrap;
 
 namespace MIPSComp {
 
-// This is called when Jit hits a breakpoint.  Returns 1 when hit.
-u32 JitBreakpoint();
-
 struct RegCacheState {
 	GPRRegCacheState gpr;
 	FPURegCacheState fpr;


### PR DESCRIPTION
I think this must've broken a while ago.  I'm pretty sure it used to work, but I always avoid breakpoints in delay slots anyway, so I haven't really noticed.  That said, it's confusing for people learning MIPS/PSP debugging.

Also noticed we weren't saving static registers on arm64, not sure how that wasn't more broken... that said, I haven't tested the ARM changes (though they definitely won't affect you if you're not using the debugger.)

-[Unknown]