### PR TITLE
Common: Reduce some log levels

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1767,7 +1767,7 @@ bool Config::loadGameConfig(const std::string &pGameId, const std::string &title
 	Path iniFileNameFull = getGameConfigFile(pGameId);
 
 	if (!hasGameConfig(pGameId)) {
-		INFO_LOG(LOADER, "Failed to read %s. No game-specific settings found, using global defaults.", iniFileNameFull.c_str());
+		DEBUG_LOG(LOADER, "No game-specific settings found in %s. Using global defaults.", iniFileNameFull.c_str());
 		return false;
 	}
 

--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -80,7 +80,7 @@ bool ControlMapper::Key(const KeyInput &key, bool *pauseTrigger) {
 		pspKey(pspKeys[i], key.flags);
 	}
 
-	INFO_LOG(SYSTEM, "Key: %d DeviceId: %d", key.keyCode, key.deviceId);
+	DEBUG_LOG(SYSTEM, "Key: %d DeviceId: %d", key.keyCode, key.deviceId);
 
 	if (!pspKeys.size() || key.deviceId == DEVICE_ID_DEFAULT) {
 		if ((key.flags & KEY_DOWN) && key.keyCode == NKCODE_BACK) {

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -210,7 +210,7 @@ void __NetInit() {
 
 	SceNetEtherAddr mac;
 	getLocalMac(&mac);
-	NOTICE_LOG(SCENET, "LocalHost IP will be %s [%s]", ip2str(g_localhostIP.in.sin_addr).c_str(), mac2str(&mac).c_str());
+	INFO_LOG(SCENET, "LocalHost IP will be %s [%s]", ip2str(g_localhostIP.in.sin_addr).c_str(), mac2str(&mac).c_str());
 	
 	// TODO: May be we should initialize & cleanup somewhere else than here for PortManager to be used as general purpose for whatever port forwarding PPSSPP needed
 	__UPnPInit();

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -187,7 +187,7 @@ namespace Reporting
 				crcCond.wait(guard);
 			}
 		} else {
-			INFO_LOG(SYSTEM, "no CRC pending");
+			DEBUG_LOG(SYSTEM, "No CRC pending");
 		}
 
 		if (crcThread.joinable())

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -787,7 +787,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 		});
 	}
 
-	INFO_LOG(SYSTEM, "ScreenManager!");
+	DEBUG_LOG(SYSTEM, "ScreenManager!");
 	screenManager = new ScreenManager();
 	if (g_Config.memStickDirectory.empty()) {
 		INFO_LOG(SYSTEM, "No memstick directory! Asking for one to be configured.");

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -230,7 +230,7 @@ void MainThreadFunc() {
 		NativeResized();
 	}
 
-	INFO_LOG(BOOT, "Done.");
+	DEBUG_LOG(BOOT, "Done.");
 
 	if (coreState == CORE_POWERDOWN) {
 		INFO_LOG(BOOT, "Exit before core loop.");


### PR DESCRIPTION
Take off a few messages during startup and shutdown.

We've accumulated some INFO and higher messages that are starting to get a bit noisy during basic use, including the keypress in #14764.  Nothing drastic, but toned it down a bit here.

-[Unknown]