### PR TITLE
Add a visual means of control mapping

### DIFF
--- a/Common/Render/DrawBuffer.h
+++ b/Common/Render/DrawBuffer.h
@@ -116,6 +116,7 @@ public:
 		DrawImageStretch(atlas_image, bounds.x, bounds.y, bounds.x2(), bounds.y2(), color);
 	}
 	void DrawImageRotated(ImageID atlas_image, float x, float y, float scale, float angle, Color color = COLOR(0xFFFFFF), bool mirror_h = false);	// Always centers
+	void DrawImageRotatedStretch(ImageID atlas_image, const Bounds &bounds, float scales[2], float angle, Color color = COLOR(0xFFFFFF), bool mirror_h = false);
 	void DrawTexRect(float x1, float y1, float x2, float y2, float u1, float v1, float u2, float v2, Color color);
 	void DrawTexRect(const Bounds &bounds, float u1, float v1, float u2, float v2, Color color) {
 		DrawTexRect(bounds.x, bounds.y, bounds.x2(), bounds.y2(), u1, v1, u2, v2, color);

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -296,6 +296,10 @@ void PopupScreen::SetPopupOrigin(const UI::View *view) {
 	popupOrigin_ = view->GetBounds().Center();
 }
 
+void PopupScreen::SetPopupOffset(float y) {
+	offsetY_ = y;
+}
+
 void PopupScreen::TriggerFinish(DialogResult result) {
 	if (CanComplete(result)) {
 		finishFrame_ = frames_;
@@ -320,7 +324,7 @@ void PopupScreen::CreateViews() {
 	float yres = screenManager()->getUIContext()->GetBounds().h;
 
 	box_ = new LinearLayout(ORIENT_VERTICAL,
-		new AnchorLayoutParams(PopupWidth(), FillVertical() ? yres - 30 : WRAP_CONTENT, dc.GetBounds().centerX(), dc.GetBounds().centerY(), NONE, NONE, true));
+		new AnchorLayoutParams(PopupWidth(), FillVertical() ? yres - 30 : WRAP_CONTENT, dc.GetBounds().centerX(), dc.GetBounds().centerY() + offsetY_, NONE, NONE, true));
 
 	root_->Add(box_);
 	box_->SetBG(dc.theme->popupStyle.background);

--- a/Common/UI/UIScreen.h
+++ b/Common/UI/UIScreen.h
@@ -81,6 +81,7 @@ public:
 	virtual void TriggerFinish(DialogResult result) override;
 
 	void SetPopupOrigin(const UI::View *view);
+	void SetPopupOffset(float y);
 
 protected:
 	virtual bool FillVertical() const { return false; }
@@ -109,6 +110,7 @@ private:
 	DialogResult finishResult_;
 	bool hasPopupOrigin_ = false;
 	Point popupOrigin_;
+	float offsetY_ = 0.0f;
 };
 
 class ListPopupScreen : public PopupScreen {

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -1197,7 +1197,8 @@ void AnchorLayout::Layout() {
 		if (vBounds.w > bounds_.w) vBounds.w = bounds_.w;
 		if (vBounds.h > bounds_.h) vBounds.h = bounds_.h;
 
-		float left = 0, top = 0, right = 0, bottom = 0, center = false;
+		float left = 0, top = 0, right = 0, bottom = 0;
+		bool center = false;
 		if (params) {
 			left = params->left;
 			top = params->top;

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -43,7 +43,8 @@ namespace KeyMap {
 KeyDef AxisDef(int deviceId, int axisId, int direction);
 
 KeyMapping g_controllerMap;
-int g_controllerMapGeneration = 0;  // Just used to check if we need to update the Windows menu or not.
+// Incremented on modification, so we know when to update menus.
+int g_controllerMapGeneration = 0;
 std::set<std::string> g_seenPads;
 std::set<int> g_seenDeviceIds;
 
@@ -622,6 +623,7 @@ void SetAxisMapping(int btn, int deviceId, int axisId, int direction, bool repla
 
 void RestoreDefault() {
 	g_controllerMap.clear();
+	g_controllerMapGeneration++;
 #if PPSSPP_PLATFORM(WINDOWS)
 	SetDefaultKeyMap(DEFAULT_MAPPING_KEYBOARD, true);
 	SetDefaultKeyMap(DEFAULT_MAPPING_XINPUT, false);
@@ -763,6 +765,14 @@ const std::set<std::string> &GetSeenPads() {
 // Swap direction buttons and left analog axis
 void SwapAxis() {
 	g_swapped_keys = !g_swapped_keys;
+}
+
+bool HasChanged(int &prevGeneration) {
+	if (prevGeneration != g_controllerMapGeneration) {
+		prevGeneration = g_controllerMapGeneration;
+		return true;
+	}
+	return false;
 }
 
 }  // KeyMap

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -158,4 +158,6 @@ namespace KeyMap {
 	void AutoConfForPad(const std::string &name);
 
 	bool IsKeyMapped(int device, int key);
+
+	bool HasChanged(int &prevGeneration);
 }

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -264,17 +264,26 @@ void ControlMappingScreen::CreateViews() {
 				                    new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 		mappers_.push_back(mapper);
 	}
+
+	keyMapGeneration_ = KeyMap::g_controllerMapGeneration;
+}
+
+void ControlMappingScreen::update() {
+	if (KeyMap::HasChanged(keyMapGeneration_)) {
+		RecreateViews();
+	}
+
+	UIDialogScreenWithBackground::update();
 }
 
 UI::EventReturn ControlMappingScreen::OnClearMapping(UI::EventParams &params) {
 	KeyMap::g_controllerMap.clear();
-	RecreateViews();
+	KeyMap::g_controllerMapGeneration++;
 	return UI::EVENT_DONE;
 }
 
 UI::EventReturn ControlMappingScreen::OnDefaultMapping(UI::EventParams &params) {
 	KeyMap::RestoreDefault();
-	RecreateViews();
 	return UI::EVENT_DONE;
 }
 
@@ -302,7 +311,6 @@ void ControlMappingScreen::dialogFinished(const Screen *dialog, DialogResult res
 	if (result == DR_OK && dialog->tag() == "listpopup") {
 		ListPopupScreen *popup = (ListPopupScreen *)dialog;
 		KeyMap::AutoConfForPad(popup->GetChoiceString());
-		RecreateViews();
 	}
 }
 
@@ -1126,6 +1134,7 @@ void VisualMappingScreen::CreateViews() {
 }
 
 void VisualMappingScreen::resized() {
+	UIDialogScreenWithBackground::resized();
 	RecreateViews();
 }
 

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -334,7 +334,7 @@ bool KeyMappingNewKeyDialog::key(const KeyInput &key) {
 
 		mapped_ = true;
 		KeyDef kdf(key.deviceId, key.keyCode);
-		TriggerFinish(DR_OK);
+		TriggerFinish(DR_YES);
 		if (callback_)
 			callback_(kdf);
 	}
@@ -361,7 +361,7 @@ bool KeyMappingNewMouseKeyDialog::key(const KeyInput &key) {
 
 		mapped_ = true;
 		KeyDef kdf(key.deviceId, key.keyCode);
-		TriggerFinish(DR_OK);
+		TriggerFinish(DR_YES);
 		g_Config.bMapMouse = false;
 		if (callback_)
 			callback_(kdf);
@@ -399,7 +399,7 @@ bool KeyMappingNewKeyDialog::axis(const AxisInput &axis) {
 	if (axis.value > AXIS_BIND_THRESHOLD) {
 		mapped_ = true;
 		KeyDef kdf(axis.deviceId, KeyMap::TranslateKeyCodeFromAxis(axis.axisId, 1));
-		TriggerFinish(DR_OK);
+		TriggerFinish(DR_YES);
 		if (callback_)
 			callback_(kdf);
 	}
@@ -407,7 +407,7 @@ bool KeyMappingNewKeyDialog::axis(const AxisInput &axis) {
 	if (axis.value < -AXIS_BIND_THRESHOLD) {
 		mapped_ = true;
 		KeyDef kdf(axis.deviceId, KeyMap::TranslateKeyCodeFromAxis(axis.axisId, -1));
-		TriggerFinish(DR_OK);
+		TriggerFinish(DR_YES);
 		if (callback_)
 			callback_(kdf);
 	}
@@ -423,7 +423,7 @@ bool KeyMappingNewMouseKeyDialog::axis(const AxisInput &axis) {
 	if (axis.value > AXIS_BIND_THRESHOLD) {
 		mapped_ = true;
 		KeyDef kdf(axis.deviceId, KeyMap::TranslateKeyCodeFromAxis(axis.axisId, 1));
-		TriggerFinish(DR_OK);
+		TriggerFinish(DR_YES);
 		if (callback_)
 			callback_(kdf);
 	}
@@ -431,7 +431,7 @@ bool KeyMappingNewMouseKeyDialog::axis(const AxisInput &axis) {
 	if (axis.value < -AXIS_BIND_THRESHOLD) {
 		mapped_ = true;
 		KeyDef kdf(axis.deviceId, KeyMap::TranslateKeyCodeFromAxis(axis.axisId, -1));
-		TriggerFinish(DR_OK);
+		TriggerFinish(DR_YES);
 		if (callback_)
 			callback_(kdf);
 	}
@@ -939,7 +939,7 @@ public:
 
 	void Draw(UIContext &dc) override {
 		uint32_t c = 0xFFFFFFFF;
-		if (HasFocus())
+		if (HasFocus() || Selected())
 			c = dc.theme->buttonFocusedStyle.background.color;
 
 		float scales[2]{};
@@ -968,76 +968,121 @@ public:
 		return this;
 	}
 
+	MockButton *SetSelectedButton(int *s) {
+		selectedButton_ = s;
+		return this;
+	}
+
+	bool Selected() {
+		return selectedButton_ && *selectedButton_ == button_;
+	}
+
 	int Button() {
 		return button_;
 	}
 
-protected:
+private:
 	int button_;
 	ImageID img_;
 	ImageID bgImg_;
 	float angle_;
 	float scale_ = 1.0f;
-	float flipHBG_ = false;
 	float offsetX_ = 0.0f;
 	float offsetY_ = 0.0f;
+	bool flipHBG_ = false;
+	int *selectedButton_ = nullptr;
 };
 
 class MockPSP : public UI::AnchorLayout {
 public:
 	static constexpr float SCALE = 1.4f;
 
-	MockPSP(UI::LayoutParams *layoutParams = nullptr) : AnchorLayout(layoutParams) {
-		Add(new Backplate(SCALE));
-		Add(new MockScreen(LayoutAt(99.0f, 13.0f, 97.0f, 33.0f)));
-
-		// Left side.
-		AddButton(0, ImageID("I_STICK_LINE"), ImageID("I_STICK_BG_LINE"), 0.0f, LayoutSize(34.0f, 34.0f, 35.0f, 133.0f));
-		AddButton(CTRL_LEFT, ImageID("I_ARROW"), ImageID("I_DIR_LINE"), M_PI * 0.0f, LayoutSize(28.0f, 20.0f, 14.0f, 75.0f))->SetOffset(-4.0f * SCALE, 0.0f);
-		AddButton(CTRL_UP, ImageID("I_ARROW"), ImageID("I_DIR_LINE"), M_PI * 0.5f, LayoutSize(20.0f, 28.0f, 40.0f, 50.0f))->SetOffset(0.0f, -4.0f * SCALE);
-		AddButton(CTRL_RIGHT, ImageID("I_ARROW"), ImageID("I_DIR_LINE"), M_PI * 1.0f, LayoutSize(28.0f, 20.0f, 58.0f, 75.0f))->SetOffset(4.0f * SCALE, 0.0f);
-		AddButton(CTRL_DOWN, ImageID("I_ARROW"), ImageID("I_DIR_LINE"), M_PI * 1.5f, LayoutSize(20.0f, 28.0f, 40.0f, 92.0f))->SetOffset(0.0f, 4.0f * SCALE);
-
-		// Top.
-		AddButton(CTRL_LTRIGGER, ImageID("I_L"), ImageID("I_SHOULDER_LINE"), 0.0f, LayoutSize(50.0f, 16.0f, 29.0f, 0.0f));
-		AddButton(CTRL_RTRIGGER, ImageID("I_R"), ImageID("I_SHOULDER_LINE"), 0.0f, LayoutSize(50.0f, 16.0f, 397.0f, 0.0f))->SetFlipHBG(true);
-
-		// Bottom.
-		AddButton(CTRL_HOME, ImageID("I_ICON"), ImageID("I_RECT_LINE"), 0.0f, LayoutSize(28.0f, 14.0f, 88.0f, 181.0f))->SetScale(0.4f);
-		AddButton(CTRL_SELECT, ImageID("I_SELECT"), ImageID("I_RECT_LINE"), 0.0f, LayoutSize(28.0f, 14.0f, 330.0f, 181.0f));
-		AddButton(CTRL_START, ImageID("I_START"), ImageID("I_RECT_LINE"), 0.0f, LayoutSize(28.0f, 14.0f, 361.0f, 181.0f));
-
-		// Right side.
-		AddButton(CTRL_TRIANGLE, ImageID("I_TRIANGLE"), ImageID("I_ROUND_LINE"), 0.0f, LayoutSize(23.0f, 23.0f, 419.0f, 46.0f))->SetScale(0.7f)->SetOffset(0.0f, -1.0f * SCALE);
-		AddButton(CTRL_CIRCLE, ImageID("I_CIRCLE"), ImageID("I_ROUND_LINE"), 0.0f, LayoutSize(23.0f, 23.0f, 446.0f, 74.0f))->SetScale(0.7f);
-		AddButton(CTRL_CROSS, ImageID("I_CROSS"), ImageID("I_ROUND_LINE"), 0.0f, LayoutSize(23.0f, 23.0f, 419.0f, 102.0f))->SetScale(0.7f);
-		AddButton(CTRL_SQUARE, ImageID("I_SQUARE"), ImageID("I_ROUND_LINE"), 0.0f, LayoutSize(23.0f, 23.0f, 392.0f, 74.0f))->SetScale(0.7f);
-	}
+	MockPSP(UI::LayoutParams *layoutParams = nullptr);
+	void SelectButton(int btn);
 
 	UI::Event ButtonClick;
 
 private:
-	UI::AnchorLayoutParams *LayoutAt(float l, float t, float r, float b) {
-		return new UI::AnchorLayoutParams(l * SCALE, t * SCALE, r * SCALE, b * SCALE);
-	}
-	UI::AnchorLayoutParams *LayoutSize(float w, float h, float l, float t) {
-		return new UI::AnchorLayoutParams(w * SCALE, h * SCALE, l * SCALE, t * SCALE, UI::NONE, UI::NONE);
-	}
+	UI::AnchorLayoutParams *LayoutAt(float l, float t, float r, float b);
+	UI::AnchorLayoutParams *LayoutSize(float w, float h, float l, float t);
+	MockButton *AddButton(int button, ImageID img, ImageID bg, float angle, UI::LayoutParams *lp);
 
-	MockButton *AddButton(int button, ImageID img, ImageID bg, float angle, UI::LayoutParams *lp) {
-		MockButton *view = Add(new MockButton(button, img, bg, angle, lp));
-		view->OnClick.Handle(this, &MockPSP::OnSelectButton);
-		buttons_[button] = view;
-		return view;
-	}
-
-	UI::EventReturn OnSelectButton(UI::EventParams &e) {
-		auto view = (MockButton *)e.v;
-		e.a = view->Button();
-		return ButtonClick.Dispatch(e);
-	}
+	UI::EventReturn OnSelectButton(UI::EventParams &e);
 
 	std::unordered_map<int, MockButton *> buttons_;
+	int selectedButton_ = 0;
+};
+
+MockPSP::MockPSP(UI::LayoutParams *layoutParams) : AnchorLayout(layoutParams) {
+	Add(new Backplate(SCALE));
+	Add(new MockScreen(LayoutAt(99.0f, 13.0f, 97.0f, 33.0f)));
+
+	// Left side.
+	AddButton(VIRTKEY_AXIS_Y_MAX, ImageID("I_STICK_LINE"), ImageID("I_STICK_BG_LINE"), 0.0f, LayoutSize(34.0f, 34.0f, 35.0f, 133.0f));
+	AddButton(CTRL_LEFT, ImageID("I_ARROW"), ImageID("I_DIR_LINE"), M_PI * 0.0f, LayoutSize(28.0f, 20.0f, 14.0f, 75.0f))->SetOffset(-4.0f * SCALE, 0.0f);
+	AddButton(CTRL_UP, ImageID("I_ARROW"), ImageID("I_DIR_LINE"), M_PI * 0.5f, LayoutSize(20.0f, 28.0f, 40.0f, 50.0f))->SetOffset(0.0f, -4.0f * SCALE);
+	AddButton(CTRL_RIGHT, ImageID("I_ARROW"), ImageID("I_DIR_LINE"), M_PI * 1.0f, LayoutSize(28.0f, 20.0f, 58.0f, 75.0f))->SetOffset(4.0f * SCALE, 0.0f);
+	AddButton(CTRL_DOWN, ImageID("I_ARROW"), ImageID("I_DIR_LINE"), M_PI * 1.5f, LayoutSize(20.0f, 28.0f, 40.0f, 92.0f))->SetOffset(0.0f, 4.0f * SCALE);
+
+	// Top.
+	AddButton(CTRL_LTRIGGER, ImageID("I_L"), ImageID("I_SHOULDER_LINE"), 0.0f, LayoutSize(50.0f, 16.0f, 29.0f, 0.0f));
+	AddButton(CTRL_RTRIGGER, ImageID("I_R"), ImageID("I_SHOULDER_LINE"), 0.0f, LayoutSize(50.0f, 16.0f, 397.0f, 0.0f))->SetFlipHBG(true);
+
+	// Bottom.
+	AddButton(CTRL_HOME, ImageID("I_ICON"), ImageID("I_RECT_LINE"), 0.0f, LayoutSize(28.0f, 14.0f, 88.0f, 181.0f))->SetScale(0.4f);
+	AddButton(CTRL_SELECT, ImageID("I_SELECT"), ImageID("I_RECT_LINE"), 0.0f, LayoutSize(28.0f, 14.0f, 330.0f, 181.0f));
+	AddButton(CTRL_START, ImageID("I_START"), ImageID("I_RECT_LINE"), 0.0f, LayoutSize(28.0f, 14.0f, 361.0f, 181.0f));
+
+	// Right side.
+	AddButton(CTRL_TRIANGLE, ImageID("I_TRIANGLE"), ImageID("I_ROUND_LINE"), 0.0f, LayoutSize(23.0f, 23.0f, 419.0f, 46.0f))->SetScale(0.7f)->SetOffset(0.0f, -1.0f * SCALE);
+	AddButton(CTRL_CIRCLE, ImageID("I_CIRCLE"), ImageID("I_ROUND_LINE"), 0.0f, LayoutSize(23.0f, 23.0f, 446.0f, 74.0f))->SetScale(0.7f);
+	AddButton(CTRL_CROSS, ImageID("I_CROSS"), ImageID("I_ROUND_LINE"), 0.0f, LayoutSize(23.0f, 23.0f, 419.0f, 102.0f))->SetScale(0.7f);
+	AddButton(CTRL_SQUARE, ImageID("I_SQUARE"), ImageID("I_ROUND_LINE"), 0.0f, LayoutSize(23.0f, 23.0f, 392.0f, 74.0f))->SetScale(0.7f);
+}
+
+void MockPSP::SelectButton(int btn) {
+	selectedButton_ = btn;
+}
+
+UI::AnchorLayoutParams *MockPSP::LayoutAt(float l, float t, float r, float b) {
+	return new UI::AnchorLayoutParams(l * SCALE, t * SCALE, r * SCALE, b * SCALE);
+}
+UI::AnchorLayoutParams *MockPSP::LayoutSize(float w, float h, float l, float t) {
+	return new UI::AnchorLayoutParams(w * SCALE, h * SCALE, l * SCALE, t * SCALE, UI::NONE, UI::NONE);
+}
+
+MockButton *MockPSP::AddButton(int button, ImageID img, ImageID bg, float angle, UI::LayoutParams *lp) {
+	MockButton *view = Add(new MockButton(button, img, bg, angle, lp));
+	view->OnClick.Handle(this, &MockPSP::OnSelectButton);
+	view->SetSelectedButton(&selectedButton_);
+	buttons_[button] = view;
+	return view;
+}
+
+UI::EventReturn MockPSP::OnSelectButton(UI::EventParams &e) {
+	auto view = (MockButton *)e.v;
+	e.a = view->Button();
+	return ButtonClick.Dispatch(e);
+}
+
+static std::vector<int> bindAllOrder{
+	CTRL_LTRIGGER,
+	CTRL_RTRIGGER,
+	CTRL_UP,
+	CTRL_DOWN,
+	CTRL_LEFT,
+	CTRL_RIGHT,
+	VIRTKEY_AXIS_Y_MAX,
+	VIRTKEY_AXIS_Y_MIN,
+	VIRTKEY_AXIS_X_MIN,
+	VIRTKEY_AXIS_X_MAX,
+	CTRL_HOME,
+	CTRL_SELECT,
+	CTRL_START,
+	CTRL_CROSS,
+	CTRL_CIRCLE,
+	CTRL_TRIANGLE,
+	CTRL_SQUARE,
 };
 
 void VisualMappingScreen::CreateViews() {
@@ -1049,6 +1094,8 @@ void VisualMappingScreen::CreateViews() {
 
 	constexpr float leftColumnWidth = 200.0f;
 	LinearLayout *leftColumn = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(leftColumnWidth, FILL_PARENT, Margins(10, 0, 0, 10)));
+	leftColumn->Add(new Choice(km->T("Bind All")))->OnClick.Handle(this, &VisualMappingScreen::OnBindAll);
+	leftColumn->Add(new CheckBox(&replace_, km->T("Replace"), ""));
 
 	leftColumn->Add(new Spacer(new LinearLayoutParams(1.0f)));
 	AddStandardBack(leftColumn);
@@ -1058,8 +1105,8 @@ void VisualMappingScreen::CreateViews() {
 	bounds.w -= leftColumnWidth + 10.0f;
 
 	AnchorLayout *rightColumn = new AnchorLayout(new LinearLayoutParams(bounds.w, FILL_PARENT, 1.0f));
-	MockPSP *psp = rightColumn->Add(new MockPSP(new AnchorLayoutParams(bounds.centerX(), bounds.centerY(), NONE, NONE, true)));
-	psp->ButtonClick.Handle(this, &VisualMappingScreen::OnMapButton);
+	psp_ = rightColumn->Add(new MockPSP(new AnchorLayoutParams(bounds.centerX(), bounds.centerY(), NONE, NONE, true)));
+	psp_->ButtonClick.Handle(this, &VisualMappingScreen::OnMapButton);
 
 	root_->Add(leftColumn);
 	root_->Add(rightColumn);
@@ -1069,33 +1116,54 @@ UI::EventReturn VisualMappingScreen::OnMapButton(UI::EventParams &e) {
 	auto km = GetI18NCategory("KeyMapping");
 
 	nextKey_ = e.a;
-	if (e.a == 0) {
-		nextKey_ = VIRTKEY_AXIS_Y_MAX;
-	}
+	psp_->SelectButton(nextKey_);
+
+	screenManager()->push(new KeyMappingNewKeyDialog(nextKey_, true, std::bind(&VisualMappingScreen::HandleKeyMapping, this, std::placeholders::_1), km));
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn VisualMappingScreen::OnBindAll(UI::EventParams &e) {
+	auto km = GetI18NCategory("KeyMapping");
+
+	bindAll_ = 0;
+	nextKey_ = bindAllOrder[bindAll_];
+	psp_->SelectButton(nextKey_);
+
 	screenManager()->push(new KeyMappingNewKeyDialog(nextKey_, true, std::bind(&VisualMappingScreen::HandleKeyMapping, this, std::placeholders::_1), km));
 	return UI::EVENT_DONE;
 }
 
 void VisualMappingScreen::HandleKeyMapping(KeyDef key) {
-	KeyMap::SetKeyMapping(nextKey_, key, false);
+	KeyMap::SetKeyMapping(nextKey_, key, replace_);
 
-	// For analog, we do each direction in a row.
-	if (nextKey_ == VIRTKEY_AXIS_Y_MAX)
-		nextKey_ = VIRTKEY_AXIS_Y_MIN;
-	else if (nextKey_ == VIRTKEY_AXIS_Y_MIN)
-		nextKey_ = VIRTKEY_AXIS_X_MIN;
-	else if (nextKey_ == VIRTKEY_AXIS_X_MIN)
-		nextKey_ = VIRTKEY_AXIS_X_MAX;
-	else
+	if (bindAll_ < 0) {
+		// For analog, we do each direction in a row.
+		if (nextKey_ == VIRTKEY_AXIS_Y_MAX)
+			nextKey_ = VIRTKEY_AXIS_Y_MIN;
+		else if (nextKey_ == VIRTKEY_AXIS_Y_MIN)
+			nextKey_ = VIRTKEY_AXIS_X_MIN;
+		else if (nextKey_ == VIRTKEY_AXIS_X_MIN)
+			nextKey_ = VIRTKEY_AXIS_X_MAX;
+		else
+			nextKey_ = 0;
+	} else if ((size_t)bindAll_ + 1 < bindAllOrder.size()) {
+		bindAll_++;
+		nextKey_ = bindAllOrder[bindAll_];
+	} else {
+		bindAll_ = -1;
 		nextKey_ = 0;
+	}
 }
 
 void VisualMappingScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 	auto km = GetI18NCategory("KeyMapping");
 
-	if (result == DR_OK && nextKey_ != 0) {
+	if (result == DR_YES && nextKey_ != 0) {
 		screenManager()->push(new KeyMappingNewKeyDialog(nextKey_, true, std::bind(&VisualMappingScreen::HandleKeyMapping, this, std::placeholders::_1), km));
 	} else {
 		nextKey_ = 0;
+		bindAll_ = -1;
+		psp_->SelectButton(0);
 	}
+
 }

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -166,4 +166,7 @@ public:
 
 protected:
 	void CreateViews() override;
+
+private:
+	UI::EventReturn OnMapButton(UI::EventParams &e);
 };

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -39,7 +39,9 @@ public:
 	std::string tag() const override { return "control mapping"; }
 
 protected:
-	virtual void CreateViews() override;
+	void CreateViews() override;
+	void update() override;
+
 private:
 	UI::EventReturn OnDefaultMapping(UI::EventParams &params);
 	UI::EventReturn OnClearMapping(UI::EventParams &params);
@@ -50,6 +52,7 @@ private:
 
 	UI::ScrollView *rightScroll_;
 	std::vector<SingleControlMapper *> mappers_;
+	int keyMapGeneration_ = -1;
 };
 
 class KeyMappingNewKeyDialog : public PopupScreen {

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -167,6 +167,11 @@ public:
 protected:
 	void CreateViews() override;
 
+	void dialogFinished(const Screen *dialog, DialogResult result) override;
+
 private:
 	UI::EventReturn OnMapButton(UI::EventParams &e);
+	void HandleKeyMapping(KeyDef key);
+
+	int nextKey_ = 0;
 };

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -44,6 +44,7 @@ private:
 	UI::EventReturn OnDefaultMapping(UI::EventParams &params);
 	UI::EventReturn OnClearMapping(UI::EventParams &params);
 	UI::EventReturn OnAutoConfigure(UI::EventParams &params);
+	UI::EventReturn OnVisualizeMapping(UI::EventParams &params);
 
 	virtual void dialogFinished(const Screen *dialog, DialogResult result) override;
 
@@ -157,4 +158,12 @@ protected:
 	UI::EventReturn OnImmersiveModeChange(UI::EventParams &e);
 	UI::EventReturn OnRenderingBackend(UI::EventParams &e);
 	UI::EventReturn OnRecreateActivity(UI::EventParams &e);
+};
+
+class VisualMappingScreen : public UIDialogScreenWithBackground {
+public:
+	VisualMappingScreen() {}
+
+protected:
+	void CreateViews() override;
 };

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -170,11 +170,13 @@ protected:
 	void CreateViews() override;
 
 	void dialogFinished(const Screen *dialog, DialogResult result) override;
+	void resized() override;
 
 private:
 	UI::EventReturn OnMapButton(UI::EventParams &e);
 	UI::EventReturn OnBindAll(UI::EventParams &e);
 	void HandleKeyMapping(KeyDef key);
+	void MapNext();
 
 	MockPSP *psp_ = nullptr;
 	int nextKey_ = 0;

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -160,6 +160,8 @@ protected:
 	UI::EventReturn OnRecreateActivity(UI::EventParams &e);
 };
 
+class MockPSP;
+
 class VisualMappingScreen : public UIDialogScreenWithBackground {
 public:
 	VisualMappingScreen() {}
@@ -171,7 +173,11 @@ protected:
 
 private:
 	UI::EventReturn OnMapButton(UI::EventParams &e);
+	UI::EventReturn OnBindAll(UI::EventParams &e);
 	void HandleKeyMapping(KeyDef key);
 
+	MockPSP *psp_ = nullptr;
 	int nextKey_ = 0;
+	int bindAll_ = -1;
+	bool replace_ = false;
 };

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -351,7 +351,7 @@ namespace MainWindow {
 		bool changed = false;
 
 		const std::string curLanguageID = i18nrepo.LanguageID();
-		if (curLanguageID != menuLanguageID || menuKeymapGeneration != KeyMap::g_controllerMapGeneration) {
+		if (curLanguageID != menuLanguageID || KeyMap::HasChanged(menuKeymapGeneration)) {
 			DoTranslateMenus(hWnd, menu);
 			menuLanguageID = curLanguageID;
 			changed = true;


### PR DESCRIPTION
This shows a PSP-shaped shadow, and buttons on top to help you map correctly.

I don't always immediately remember what controllers look like for various systems, and it's nice to see the original layout when mapping.  Here's what it looks like:

![Control mapping screen](https://user-images.githubusercontent.com/191233/131232473-7e9bb628-1696-4e32-8ded-0548f48682d7.png)

One issue currently is that the buttons don't look so good at 1x PSP resolution, seems like texture filtering isn't playing nice.  Didn't dig into that, but I think this is still a useful interface for many users.

Also adds a "Bind All" button that lets you bind each button in a row, which is common in other emulators.  Fixes #9302.

Could've added volume/etc. buttons but we didn't have icons and I don't think they're important buttons.  But this makes it easy to add them if we want to.

-[Unknown]