### PR TITLE
Tweak grid and scrollview handling

### DIFF
--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -307,6 +307,7 @@ enum LayoutParamsType {
 	LP_PLAIN = 0,
 	LP_LINEAR = 1,
 	LP_ANCHOR = 2,
+	LP_GRID = 3,
 };
 
 // Need a virtual destructor so vtables are created, otherwise RTTI can't work

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -1246,7 +1246,9 @@ void GridLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec ver
 		views_[i]->Measure(dc, MeasureSpec(measureType, settings_.columnWidth), MeasureSpec(measureType, settings_.rowHeight));
 	}
 
-	MeasureBySpec(layoutParams_->width, 0.0f, horiz, &measuredWidth_);
+	// Use the max possible width so AT_MOST gives us the full size.
+	float maxWidth = (settings_.columnWidth + settings_.spacing) * views_.size() + settings_.spacing;
+	MeasureBySpec(layoutParams_->width, maxWidth, horiz, &measuredWidth_);
 
 	// Okay, got the width we are supposed to adjust to. Now we can calculate the number of columns.
 	numColumns_ = (measuredWidth_ - settings_.spacing) / (settings_.columnWidth + settings_.spacing);
@@ -1263,7 +1265,9 @@ void GridLayout::Layout() {
 	int x = 0;
 	int count = 0;
 	for (size_t i = 0; i < views_.size(); i++) {
+		const GridLayoutParams *lp = views_[i]->GetLayoutParams()->As<GridLayoutParams>();
 		Bounds itemBounds, innerBounds;
+		Gravity grav = lp ? lp->gravity : G_CENTER;
 
 		itemBounds.x = bounds_.x + x;
 		itemBounds.y = bounds_.y + y;
@@ -1272,7 +1276,7 @@ void GridLayout::Layout() {
 
 		ApplyGravity(itemBounds, Margins(0.0f),
 			views_[i]->GetMeasuredWidth(), views_[i]->GetMeasuredHeight(),
-			G_HCENTER | G_VCENTER, innerBounds);
+			grav, innerBounds);
 
 		views_[i]->SetBounds(innerBounds);
 		views_[i]->Layout();

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -765,10 +765,10 @@ void ScrollView::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec ver
 			MeasureBySpec(layoutParams_->width, views_[0]->GetMeasuredWidth(), horiz, &measuredWidth_);
 		}
 		if (orientation_ == ORIENT_VERTICAL && vert.type != EXACTLY) {
-			if (measuredHeight_ < views_[0]->GetMeasuredHeight()) {
+			if (measuredHeight_ < views_[0]->GetMeasuredHeight() && layoutParams_->height < 0.0f) {
 				measuredHeight_ = views_[0]->GetMeasuredHeight();
 			}
-			if (measuredHeight_ < views_[0]->GetBounds().h) {
+			if (measuredHeight_ < views_[0]->GetBounds().h && layoutParams_->height < 0.0f) {
 				measuredHeight_ = views_[0]->GetBounds().h;
 			}
 			if (vert.type == AT_MOST && measuredHeight_ > vert.size) {

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -222,6 +222,21 @@ struct GridLayoutSettings {
 	bool fillCells;
 };
 
+class GridLayoutParams : public LayoutParams {
+public:
+	GridLayoutParams()
+		: LayoutParams(LP_GRID), gravity(G_CENTER) {}
+	explicit GridLayoutParams(Gravity grav)
+		: LayoutParams(LP_GRID), gravity(grav) {
+	}
+
+	Gravity gravity;
+
+	static LayoutParamsType StaticType() {
+		return LP_GRID;
+	}
+};
+
 class GridLayout : public ViewGroup {
 public:
 	GridLayout(GridLayoutSettings settings, LayoutParams *layoutParams = 0);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1535,7 +1535,7 @@ void GridSettingsScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	auto di = GetI18NCategory("Dialog");
 	auto sy = GetI18NCategory("System");
 
-	ScrollView *scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, 50, 1.0f));
+	ScrollView *scroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f));
 	LinearLayout *items = new LinearLayoutList(ORIENT_VERTICAL);
 
 	items->Add(new CheckBox(&g_Config.bGridView1, sy->T("Display Recent on a grid")));


### PR DESCRIPTION
I made some changes to put a grid inside a scroll view that isn't full height, and otherwise allow fixed-height scrollviews (which we don't really seem to use elsewhere.)  Also made it possible to control gravity on items.

I realize we of course use a grid on the main screen, but that isn't using AT_MOST as other places generally use.

May still use these changes for the control mapping but haven't looked at #14778 yet, and don't want these changes to get lost.  These are things I originally thought would just work, so better to avoid surprises in other customizations.

-[Unknown]