### PR TITLE
Fix various focus issues in the control mapping

### DIFF
--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -795,7 +795,7 @@ void ScrollView::Layout() {
 	scrolled.w = views_[0]->GetMeasuredWidth() - margins.horiz();
 	scrolled.h = views_[0]->GetMeasuredHeight() - margins.vert();
 
-	float layoutScrollPos = ClampedScrollPos(scrollPos_);
+	layoutScrollPos_ = ClampedScrollPos(scrollPos_);
 
 	switch (orientation_) {
 	case ORIENT_HORIZONTAL:
@@ -803,7 +803,7 @@ void ScrollView::Layout() {
 			ScrollTo(0.0f);
 			lastViewSize_ = scrolled.w;
 		}
-		scrolled.x = bounds_.x - layoutScrollPos;
+		scrolled.x = bounds_.x - layoutScrollPos_;
 		scrolled.y = bounds_.y + margins.top;
 		break;
 	case ORIENT_VERTICAL:
@@ -812,7 +812,7 @@ void ScrollView::Layout() {
 			lastViewSize_ = scrolled.h;
 		}
 		scrolled.x = bounds_.x + margins.left;
-		scrolled.y = bounds_.y - layoutScrollPos;
+		scrolled.y = bounds_.y - layoutScrollPos_;
 		break;
 	}
 
@@ -915,23 +915,25 @@ bool ScrollView::SubviewFocused(View *view) {
 	const float overscroll = std::min(view->GetBounds().h / 1.5f, GetBounds().h / 4.0f);
 
 	float pos = ClampedScrollPos(scrollPos_);
+	float visibleSize = orientation_ == ORIENT_VERTICAL ? bounds_.h : bounds_.w;
+	float visibleEnd = scrollPos_ + visibleSize;
+
+	float viewStart, viewEnd;
 	switch (orientation_) {
 	case ORIENT_HORIZONTAL:
-		if (vBounds.x2() > bounds_.x2()) {
-			ScrollTo(pos + vBounds.x2() - bounds_.x2() + overscroll);
-		}
-		if (vBounds.x < bounds_.x) {
-			ScrollTo(pos + (vBounds.x - bounds_.x) - overscroll);
-		}
+		viewStart = layoutScrollPos_ + vBounds.x - bounds_.x;
+		viewEnd = layoutScrollPos_ + vBounds.x2() - bounds_.x;
 		break;
 	case ORIENT_VERTICAL:
-		if (vBounds.y2() > bounds_.y2()) {
-			ScrollTo(pos + vBounds.y2() - bounds_.y2() + overscroll);
-		}
-		if (vBounds.y < bounds_.y) {
-			ScrollTo(pos + (vBounds.y - bounds_.y) - overscroll);
-		}
+		viewStart = layoutScrollPos_ + vBounds.y - bounds_.y;
+		viewEnd = layoutScrollPos_ + vBounds.y2() - bounds_.y;
 		break;
+	}
+
+	if (viewEnd > visibleEnd) {
+		ScrollTo(viewEnd - visibleSize + overscroll);
+	} else if (viewStart < pos) {
+		ScrollTo(viewStart - overscroll);
 	}
 
 	return true;

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -756,6 +756,8 @@ void ScrollView::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec ver
 			}
 			views_[0]->Measure(dc, MeasureSpec(UNSPECIFIED, measuredWidth_), v);
 			MeasureBySpec(layoutParams_->height, views_[0]->GetMeasuredHeight(), vert, &measuredHeight_);
+			if (layoutParams_->width == WRAP_CONTENT)
+				MeasureBySpec(layoutParams_->width, views_[0]->GetMeasuredWidth(), horiz, &measuredWidth_);
 		} else {
 			MeasureSpec h = MeasureSpec(AT_MOST, measuredWidth_ - margins.horiz());
 			if (measuredWidth_ == 0.0f && (horiz.type == UNSPECIFIED || layoutParams_->width == WRAP_CONTENT)) {
@@ -763,16 +765,16 @@ void ScrollView::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec ver
 			}
 			views_[0]->Measure(dc, h, MeasureSpec(UNSPECIFIED, measuredHeight_));
 			MeasureBySpec(layoutParams_->width, views_[0]->GetMeasuredWidth(), horiz, &measuredWidth_);
+			if (layoutParams_->height == WRAP_CONTENT)
+				MeasureBySpec(layoutParams_->height, views_[0]->GetMeasuredHeight(), vert, &measuredHeight_);
 		}
 		if (orientation_ == ORIENT_VERTICAL && vert.type != EXACTLY) {
-			if (measuredHeight_ < views_[0]->GetMeasuredHeight() && layoutParams_->height < 0.0f) {
-				measuredHeight_ = views_[0]->GetMeasuredHeight();
-			}
-			if (measuredHeight_ < views_[0]->GetBounds().h && layoutParams_->height < 0.0f) {
-				measuredHeight_ = views_[0]->GetBounds().h;
-			}
-			if (vert.type == AT_MOST && measuredHeight_ > vert.size) {
-				measuredHeight_ = vert.size;
+			float bestHeight = std::max(views_[0]->GetMeasuredHeight(), views_[0]->GetBounds().h);
+			if (vert.type == AT_MOST)
+				bestHeight = std::min(bestHeight, vert.size);
+
+			if (measuredHeight_ < bestHeight && layoutParams_->height < 0.0f) {
+				measuredHeight_ = bestHeight;
 			}
 		}
 	}

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -300,6 +300,7 @@ private:
 	float scrollTarget_ = 0.0f;
 	int scrollTouchId_ = -1;
 	bool scrollToTarget_ = false;
+	float layoutScrollPos_ = 0.0f;
 	float inertia_ = 0.0f;
 	float pull_ = 0.0f;
 	float lastViewSize_ = 0.0f;

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -1009,6 +1009,7 @@ public:
 
 	MockPSP(UI::LayoutParams *layoutParams = nullptr);
 	void SelectButton(int btn);
+	void FocusButton(int btn);
 	float GetPopupOffset();
 
 	UI::Event ButtonClick;
@@ -1053,6 +1054,12 @@ MockPSP::MockPSP(UI::LayoutParams *layoutParams) : AnchorLayout(layoutParams) {
 
 void MockPSP::SelectButton(int btn) {
 	selectedButton_ = btn;
+}
+
+void MockPSP::FocusButton(int btn) {
+	MockButton *view = buttons_[selectedButton_];
+	if (view)
+		view->SetFocus();
 }
 
 float MockPSP::GetPopupOffset() {
@@ -1164,8 +1171,13 @@ void VisualMappingScreen::HandleKeyMapping(KeyDef key) {
 			nextKey_ = VIRTKEY_AXIS_X_MIN;
 		else if (nextKey_ == VIRTKEY_AXIS_X_MIN)
 			nextKey_ = VIRTKEY_AXIS_X_MAX;
-		else
+		else {
+			if (nextKey_ == VIRTKEY_AXIS_X_MAX)
+				psp_->FocusButton(VIRTKEY_AXIS_Y_MAX);
+			else
+				psp_->FocusButton(nextKey_);
 			nextKey_ = 0;
+		}
 	} else if ((size_t)bindAll_ + 1 < bindAllOrder.size()) {
 		bindAll_++;
 		nextKey_ = bindAllOrder[bindAll_];
@@ -1179,6 +1191,9 @@ void VisualMappingScreen::dialogFinished(const Screen *dialog, DialogResult resu
 	if (result == DR_YES && nextKey_ != 0) {
 		MapNext();
 	} else {
+		// This means they canceled.
+		if (nextKey_ != 0)
+			psp_->FocusButton(nextKey_);
 		nextKey_ = 0;
 		bindAll_ = -1;
 		psp_->SelectButton(0);

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -48,8 +48,8 @@ class SingleControlMapper : public UI::LinearLayout {
 public:
 	SingleControlMapper(int pspKey, std::string keyName, ScreenManager *scrm, UI::LinearLayoutParams *layoutParams = nullptr);
 
-	void Update() override;
 	int GetPspKey() const { return pspKey_; }
+
 private:
 	void Refresh();
 
@@ -76,20 +76,11 @@ private:
 	int pspKey_;
 	std::string keyName_;
 	ScreenManager *scrm_;
-	bool refresh_ = false;
 };
 
 SingleControlMapper::SingleControlMapper(int pspKey, std::string keyName, ScreenManager *scrm, UI::LinearLayoutParams *layoutParams)
 	: UI::LinearLayout(UI::ORIENT_VERTICAL, layoutParams), pspKey_(pspKey), keyName_(keyName), scrm_(scrm) {
 	Refresh();
-}
-
-void SingleControlMapper::Update() {
-	if (refresh_) {
-		refresh_ = false;
-		Refresh();
-		host->UpdateUI();
-	}
 }
 
 void SingleControlMapper::Refresh() {
@@ -187,8 +178,6 @@ void SingleControlMapper::MappedCallback(KeyDef kdf) {
 		break;
 	}
 	g_Config.bMapMouse = false;
-	refresh_ = true;
-	// After this, we do not exist any more. So the refresh_ = true is probably irrelevant.
 }
 
 UI::EventReturn SingleControlMapper::OnReplace(UI::EventParams &params) {
@@ -224,7 +213,6 @@ UI::EventReturn SingleControlMapper::OnDelete(UI::EventParams &params) {
 	int index = atoi(params.v->Tag().c_str());
 	KeyMap::g_controllerMap[pspKey_].erase(KeyMap::g_controllerMap[pspKey_].begin() + index);
 	KeyMap::g_controllerMapGeneration++;
-	refresh_ = true;
 
 	if (index + 1 < rows_.size())
 		rows_[index]->SetFocus();

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -35,7 +35,6 @@ class SingleControlMapper;
 class ControlMappingScreen : public UIDialogScreenWithBackground {
 public:
 	ControlMappingScreen() {}
-	void KeyMapped(int pspkey);  // Notification to let us refocus the same one after recreating views.
 	std::string tag() const override { return "control mapping"; }
 
 protected:


### PR DESCRIPTION
Fixes #14780.

This simplifies it to just use our standard PersistData means of focus preservation, without any coupling between the view and screen.  Also keeps tags unique since that's how focus persists.  While doing, I made it stay focused nearer the button you pressed.

There was also a focus scrolling issue on recreate, since the layout didn't yet match the new desired scroll position.

I also threw in a fix for scroll views respecting WRAP_CONTENT for height/width, which before they ignored (snapping to any AT_MOST size because they were measured against the AT_MOST size as the content size.)

-[Unknown]