### PR TITLE
Bezier/Spline: Fix logical error

### DIFF
--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -74,6 +74,10 @@ void ComputeVertexShaderID(VShaderID *id_out, u32 vertType, bool useHWTransform,
 	bool doBezier = gstate_c.submitType == SubmitType::HW_BEZIER;
 	bool doSpline = gstate_c.submitType == SubmitType::HW_SPLINE;
 
+	if (doBezier || doSpline) {
+		_assert_(hasNormal);
+	}
+
 	bool enableFog = gstate.isFogEnabled() && !isModeThrough && !gstate.isModeClear();
 	bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled() && !isModeThrough;
 	bool vertexRangeCulling = gstate_c.Supports(GPU_SUPPORTS_VS_RANGE_CULLING) &&

--- a/GPU/Common/SplineCommon.cpp
+++ b/GPU/Common/SplineCommon.cpp
@@ -492,7 +492,6 @@ template void DrawEngineCommon::SubmitCurve<SplineSurface>(const void *control_p
 template<class Surface>
 void DrawEngineCommon::SubmitCurve(const void *control_points, const void *indices, Surface &surface, u32 vertType, int *bytesRead, const char *scope) {
 	PROFILE_THIS_SCOPE(scope);
-	DispatchFlush();
 
 	// Real hardware seems to draw nothing when given < 4 either U or V.
 	// This would result in num_patches_u / num_patches_v being 0.

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1826,6 +1826,9 @@ void GPUCommon::Execute_Bezier(u32 op, u32 diff) {
 		DEBUG_LOG_REPORT(G3D, "Unusual bezier/spline vtype: %08x, morph: %d, bones: %d", gstate.vertType, (gstate.vertType & GE_VTYPE_MORPHCOUNT_MASK) >> GE_VTYPE_MORPHCOUNT_SHIFT, vertTypeGetNumBoneWeights(gstate.vertType));
 	}
 
+	// Can't flush after setting gstate_c.submitType below since it'll be a mess - it must be done already.
+	drawEngineCommon_->DispatchFlush();
+
 	Spline::BezierSurface surface;
 	surface.tess_u = gstate.getPatchDivisionU();
 	surface.tess_v = gstate.getPatchDivisionV();
@@ -1890,6 +1893,9 @@ void GPUCommon::Execute_Spline(u32 op, u32 diff) {
 	if (vertTypeIsSkinningEnabled(gstate.vertType)) {
 		DEBUG_LOG_REPORT(G3D, "Unusual bezier/spline vtype: %08x, morph: %d, bones: %d", gstate.vertType, (gstate.vertType & GE_VTYPE_MORPHCOUNT_MASK) >> GE_VTYPE_MORPHCOUNT_SHIFT, vertTypeGetNumBoneWeights(gstate.vertType));
 	}
+
+	// Can't flush after setting gstate_c.submitType below since it'll be a mess - it must be done already.
+	drawEngineCommon_->DispatchFlush();
 
 	Spline::SplineSurface surface;
 	surface.tess_u = gstate.getPatchDivisionU();

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -266,7 +266,7 @@ void ShaderManagerVulkan::GetShaders(int prim, u32 vertType, VulkanVertexShader 
 		uint64_t uniformMask = 0;  // Not used
 		uint32_t attributeMask = 0;  // Not used
 		bool success = GenerateVertexShader(VSID, codeBuffer_, compat_, draw_->GetBugs(), &attributeMask, &uniformMask, &genErrorString);
-		_assert_(success);
+		_assert_msg_(success, "VS gen error: %s", genErrorString.c_str());
 		vs = new VulkanVertexShader(vulkan_, VSID, codeBuffer_, useHWTransform);
 		vsCache_.Insert(VSID, vs);
 	}
@@ -279,7 +279,7 @@ void ShaderManagerVulkan::GetShaders(int prim, u32 vertType, VulkanVertexShader 
 		std::string genErrorString;
 		uint64_t uniformMask = 0;  // Not used
 		bool success = GenerateFragmentShader(FSID, codeBuffer_, compat_, draw_->GetBugs(), &uniformMask, &genErrorString);
-		_assert_(success);
+		_assert_msg_(success, "FS gen error: %s", genErrorString.c_str());
 		fs = new VulkanFragmentShader(vulkan_, FSID, codeBuffer_);
 		fsCache_.Insert(FSID, fs);
 	}


### PR DESCRIPTION
Must flush buffered data before we modify submitType. Otherwise it'll compute a bogus vertex shader ID during that flush.

Should fix #14774.

Really I want to refactor away gstate_c and pass around state objects, but ...