### PR TITLE
Control layout grid fix

### DIFF
--- a/Common/Render/DrawBuffer.cpp
+++ b/Common/Render/DrawBuffer.cpp
@@ -123,15 +123,15 @@ void DrawBuffer::Rect(float x, float y, float w, float h, uint32_t color, int al
 }
 
 void DrawBuffer::hLine(float x1, float y, float x2, uint32_t color) {
+	// Round Y to the closest full pixel, since we're making it 1-pixel-thin.
+	y -= fmodf(y, pixel_in_dps_y);
 	Rect(x1, y, x2 - x1, pixel_in_dps_y, color);
 }
 
 void DrawBuffer::vLine(float x, float y1, float y2, uint32_t color) {
+	// Round X to the closest full pixel, since we're making it 1-pixel-thin.
+	x -= fmodf(x, pixel_in_dps_x);
 	Rect(x, y1, pixel_in_dps_x, y2 - y1, color);
-}
-
-void DrawBuffer::vLineAlpha50(float x, float y1, float y2, uint32_t color) {
-	Rect(x, y1, pixel_in_dps_x, y2 - y1, (color | 0xFF000000) & 0x7F000000);
 }
 
 void DrawBuffer::RectVGradient(float x, float y, float w, float h, uint32_t colorTop, uint32_t colorBottom) {

--- a/Common/Render/DrawBuffer.h
+++ b/Common/Render/DrawBuffer.h
@@ -73,7 +73,6 @@ public:
 	void Rect(float x, float y, float w, float h, uint32_t color, int align = ALIGN_TOPLEFT);
 	void hLine(float x1, float y, float x2, uint32_t color);
 	void vLine(float x, float y1, float y2, uint32_t color);
-	void vLineAlpha50(float x, float y1, float y2, uint32_t color);
 
 	void Line(ImageID atlas_image, float x1, float y1, float x2, float y2, float thickness, uint32_t color);
 

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -130,7 +130,7 @@ void SingleControlMapper::Refresh() {
 	std::vector<KeyDef> mappings;
 	KeyMap::KeyFromPspButton(pspKey_, &mappings, false);
 
-	rows_.empty();
+	rows_.clear();
 	for (size_t i = 0; i < mappings.size(); i++) {
 		std::string deviceName = GetDeviceName(mappings[i].deviceId);
 		std::string keyName = KeyMap::GetKeyOrAxisName(mappings[i].keyCode);

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,6 @@ android {
 		}
 	}
 	compileSdkVersion 30
-	buildToolsVersion '30.0.0'
 	defaultConfig {
 		applicationId 'org.ppsspp.ppsspp'
 		if (androidGitVersion.name() != "unknown" && androidGitVersion.code() >= 14000000) {


### PR DESCRIPTION
Fixes #14204, I think - at least I can't repro.

Also a couple other minor things (gradle no longer need to specify build tools version, fix a wrong use of vector.empty()).