### PR TITLE
Double binding fix

### DIFF
--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -603,6 +603,25 @@ bool IsKeyMapped(int device, int key) {
 	return false;
 }
 
+bool ReplaceSingleKeyMapping(int btn, int index, KeyDef key) {
+	// Check for duplicate
+	for (int i = 0; i < g_controllerMap[btn].size(); ++i) {
+		if (i != index && g_controllerMap[btn][i] == key) {
+			g_controllerMap[btn].erase(g_controllerMap[btn].begin()+index);
+			g_controllerMapGeneration++;
+
+			UpdateNativeMenuKeys();
+			return false;
+		}
+	}
+	KeyMap::g_controllerMap[btn][index] = key;
+	g_controllerMapGeneration++;
+
+	g_seenDeviceIds.insert(key.deviceId);
+	UpdateNativeMenuKeys();
+	return true;
+}
+
 void SetKeyMapping(int btn, KeyDef key, bool replace) {
 	if (key.keyCode < 0)
 		return;

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -128,6 +128,8 @@ namespace KeyMap {
 	// Configure the key mapping.
 	// Any configuration will be saved to the Core config.
 	void SetKeyMapping(int psp_key, KeyDef key, bool replace);
+	// Return false if bind was a duplicate and got removed
+	bool ReplaceSingleKeyMapping(int btn, int index, KeyDef key);
 
 	// Configure an axis mapping, saves the configuration.
 	// Direction is negative or positive.

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -166,13 +166,17 @@ void SingleControlMapper::MappedCallback(KeyDef kdf) {
 		replaceAllButton_->SetFocus();
 		break;
 	case REPLACEONE:
-		KeyMap::g_controllerMap[pspKey_][actionIndex_] = kdf;
-		KeyMap::g_controllerMapGeneration++;
-		if (actionIndex_ < rows_.size())
+	{
+		bool success = KeyMap::ReplaceSingleKeyMapping(pspKey_, actionIndex_, kdf);
+		if (!success) {
+			replaceAllButton_->SetFocus(); // Last got removed as a duplicate
+		} else if (actionIndex_ < rows_.size()) {
 			rows_[actionIndex_]->SetFocus();
-		else
+		} else {
 			SetFocus();
+		}
 		break;
+	}
 	default:
 		SetFocus();
 		break;


### PR DESCRIPTION
Replacing a key allowed to have the same button bind to do same key twice, this add a check to avoid that.

Also take care of calling `g_seenDeviceIds.insert(key.deviceId);` and `UpdateNativeMenuKeys();` when replacing a bind.