### PR TITLE
Expose new texture filtering mode in libretro

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -212,7 +212,7 @@ static RetroOption<bool> ppsspp_block_transfer_gpu("ppsspp_block_transfer_gpu", 
 static RetroOption<int> ppsspp_inflight_frames("ppsspp_inflight_frames", "Buffered frames (Slower, less lag, restart)", { { "Up to 2", 2 }, { "Up to 1", 1 }, { "No buffer", 0 }, });
 static RetroOption<int> ppsspp_texture_scaling_level("ppsspp_texture_scaling_level", "Texture Scaling Level", { { "Off", 1 }, { "2x", 2 }, { "3x", 3 }, { "4x", 4 }, { "5x", 5 }, { "Auto", 0 } });
 static RetroOption<int> ppsspp_texture_scaling_type("ppsspp_texture_scaling_type", "Texture Scaling Type", { { "xbrz", TextureScalerCommon::XBRZ }, { "hybrid", TextureScalerCommon::HYBRID }, { "bicubic", TextureScalerCommon::BICUBIC }, { "hybrid_bicubic", TextureScalerCommon::HYBRID_BICUBIC } });
-static RetroOption<int> ppsspp_texture_filtering("ppsspp_texture_filtering", "Texture Filtering", { { "Auto", 1 }, { "Nearest", 2 }, { "Linear", 3 } });
+static RetroOption<int> ppsspp_texture_filtering("ppsspp_texture_filtering", "Texture Filtering", { { "Auto", 1 }, { "Nearest", 2 }, { "Linear", 3 }, {"Auto max quality", 4}});
 static RetroOption<int> ppsspp_texture_anisotropic_filtering("ppsspp_texture_anisotropic_filtering", "Anisotropic Filtering", { "off", "2x", "4x", "8x", "16x" });
 static RetroOption<int> ppsspp_lower_resolution_for_effects("ppsspp_lower_resolution_for_effects", "Lower resolution for effects", { {"Off", 0}, {"Safe", 1}, {"Balanced", 2}, {"Aggressive", 3} });
 static RetroOption<bool> ppsspp_texture_deposterize("ppsspp_texture_deposterize", "Texture Deposterize", false);
@@ -404,10 +404,16 @@ static void check_variables(CoreParameter &coreParam)
    coreParam.fastForward = isFastForwarding;
 
    if (ppsspp_texture_scaling_type.Update(&g_Config.iTexScalingType) && gpu)
+   {
       gpu->ClearCacheNextFrame();
+      gpu->Resized();
+   }
 
    if (ppsspp_texture_scaling_level.Update(&g_Config.iTexScalingLevel) && gpu)
+   {
       gpu->ClearCacheNextFrame();
+      gpu->Resized();
+   }
 }
 
 void retro_set_audio_sample_batch(retro_audio_sample_batch_t cb) { audio_batch_cb = cb; }


### PR DESCRIPTION
Presents the new texture filtering mode to the user. Also has minor fix for changing texture upscale mode. Old implmementation would not change the scaling mode at runtime. Added in the Resized() call to match the main build's call path for changing this option and behaviour is correct now.