### PR TITLE
Expose texture shader core option in libretro

### DIFF
--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -81,10 +81,10 @@ void LoadPostShaderInfo(const std::vector<Path> &directories) {
 
 	for (size_t d = 0; d < directories.size(); d++) {
 		std::vector<File::FileInfo> fileInfo;
-		File::GetFilesInDir(directories[d], &fileInfo, "ini:");
+		VFSGetFileListing(directories[d].c_str(), &fileInfo, "ini:");
 
 		if (fileInfo.size() == 0) {
-			VFSGetFileListing(directories[d].c_str(), &fileInfo, "ini:");
+			File::GetFilesInDir(directories[d], &fileInfo, "ini:");
 		}
 
 		for (size_t f = 0; f < fileInfo.size(); f++) {


### PR DESCRIPTION
Exposes the shader upscaler to libretro. Had to move the ordering of the VFS and native file lookup in PostShader.cpp as retroarch's root directory already has a non empty shaders directory and that confused the scaler shader loading. 
Dropping a "shaders/oops" directory into the appliaction root on standalone also triggers the bug and no postprocessing shaders load up. The ordering change fixes both.