### PR TITLE
Various Android shortcut fixes

### DIFF
--- a/Common/Thread/ThreadManager.cpp
+++ b/Common/Thread/ThreadManager.cpp
@@ -98,7 +98,7 @@ static void WorkerThreadFunc(GlobalThreadContext *global, ThreadContext *thread)
 }
 
 void ThreadManager::Init(int numRealCores, int numLogicalCoresPerCpu) {
-	if (!global_->threads_.empty()) {
+	if (IsInitialized()) {
 		Teardown();
 	}
 
@@ -118,6 +118,8 @@ void ThreadManager::Init(int numRealCores, int numLogicalCoresPerCpu) {
 }
 
 void ThreadManager::EnqueueTask(Task *task, TaskType taskType) {
+	_assert_msg_(IsInitialized(), "ThreadManager not initialized");
+
 	int maxThread;
 	int threadOffset = 0;
 	if (taskType == TaskType::CPU_COMPUTE) {
@@ -158,7 +160,7 @@ void ThreadManager::EnqueueTask(Task *task, TaskType taskType) {
 }
 
 void ThreadManager::EnqueueTaskOnThread(int threadNum, Task *task, TaskType taskType) {
-	_assert_(threadNum >= 0 && threadNum < (int)global_->threads_.size());
+	_assert_msg_(threadNum >= 0 && threadNum < (int)global_->threads_.size(), "Bad threadnum or not initialized");
 	ThreadContext *thread = global_->threads_[threadNum];
 	{
 		std::unique_lock<std::mutex> lock(thread->mutex);
@@ -172,5 +174,9 @@ int ThreadManager::GetNumLooperThreads() const {
 }
 
 void ThreadManager::TryCancelTask(uint64_t taskID) {
-	// Do nothing
+	// Do nothing for now, just let it finish.
+}
+
+bool ThreadManager::IsInitialized() const {
+	return !global_->threads_.empty();
 }

--- a/Common/Thread/ThreadManager.h
+++ b/Common/Thread/ThreadManager.h
@@ -48,6 +48,8 @@ public:
 	void EnqueueTaskOnThread(int threadNum, Task *task, TaskType taskType);
 	void Teardown();
 
+	bool IsInitialized() const;
+
 	// Currently does nothing. It will always be best-effort - maybe it cancels,
 	// maybe it doesn't. Note that the id is the id() returned by the task. You need to make that
 	// something meaningful yourself.
@@ -58,7 +60,8 @@ public:
 	int GetNumLooperThreads() const;
 
 private:
-	GlobalThreadContext *global_ = nullptr;
+	// This is always pointing to a context, initialized in the constructor.
+	GlobalThreadContext *global_;
 
 	int numThreads_ = 0;
 	int numComputeThreads_ = 0;

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -71,7 +71,7 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader, std::string *errorStrin
 	}
 
 	if (!fileLoader->Exists()) {
-		*errorString = "IdentifyFile: File doesn't exist" + fileLoader->GetPath().ToString();
+		*errorString = "IdentifyFile: File doesn't exist: " + fileLoader->GetPath().ToString();
 		return IdentifiedFileType::ERROR_IDENTIFYING;
 	}
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -46,6 +46,7 @@
 
 #include "Common/Net/HTTPClient.h"
 #include "Common/Net/Resolve.h"
+#include "Common/Net/URL.h"
 #include "Common/Render/TextureAtlas.h"
 #include "Common/Render/Text/draw_text.h"
 #include "Common/GPU/OpenGL/GLFeatures.h"
@@ -683,7 +684,14 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 					}
 				}
 				if (okToLoad) {
-					boot_filename = Path(std::string(argv[i]));
+					std::string str = std::string(argv[i]);
+					// Handle file:/// URIs, since you get those when creating shortcuts on some Android systems.
+					if (startsWith(str, "file:///")) {
+						str = UriDecode(str.substr(7));
+						INFO_LOG(IO, "Decoding '%s' to '%s'", argv[i], str.c_str());
+					}
+
+					boot_filename = Path(str);
 					skipLogo = true;
 				}
 				if (okToLoad && okToCheck) {

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -98,7 +98,7 @@ public class PpssppActivity extends NativeActivity {
 		// String action = intent.getAction();
 		Uri data = intent.getData();
 		if (data != null) {
-			String path = intent.getData().getPath();
+			String path = data.toString();
 			Log.i(TAG, "Found Shortcut Parameter in data: " + path);
 			super.setShortcutParam("\"" + path.replace("\\", "\\\\").replace("\"", "\\\"") + "\"");
 			// Toast.makeText(getApplicationContext(), path, Toast.LENGTH_SHORT).show();

--- a/android/src/org/ppsspp/ppsspp/ShortcutActivity.java
+++ b/android/src/org/ppsspp/ppsspp/ShortcutActivity.java
@@ -5,6 +5,7 @@ import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.Intent.ShortcutIconResource;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Looper;
@@ -18,31 +19,68 @@ import java.io.File;
 public class ShortcutActivity extends Activity {
 	private static final String TAG = "PPSSPP";
 
+	private boolean scoped = false;
+	private static final int RESULT_OPEN_DOCUMENT = 2;
+
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 
-		// Show file selector dialog here.
-		SimpleFileChooser fileDialog = new SimpleFileChooser(this, Environment.getExternalStorageDirectory(), onFileSelectedListener);
-		fileDialog.showDialog();
+		// Show file selector dialog here. If Android version is more than or equal to 11,
+		// use the native file browser instead of our SimpleFileChooser.
+		scoped = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q);
+
+		if (scoped) {
+			try {
+				Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+				intent.addCategory(Intent.CATEGORY_OPENABLE);
+				intent.setType("*/*");
+				intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+				// Possible alternative approach:
+				// String[] mimeTypes = {"application/octet-stream", "/x-iso9660-image"};
+				// intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes);
+				startActivityForResult(intent, RESULT_OPEN_DOCUMENT);
+				// intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, pickerInitialUri);
+			} catch (Exception e) {
+				Log.e(TAG, e.toString());
+			}
+		} else {
+			SimpleFileChooser fileDialog = new SimpleFileChooser(this, Environment.getExternalStorageDirectory(), onFileSelectedListener);
+			fileDialog.showDialog();
+		}
+	}
+
+	// Respond to native file dialog.
+	@Override
+	protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+		if (resultCode == RESULT_OPEN_DOCUMENT) {
+			Uri selectedFile = data.getData();
+			if (selectedFile != null) {
+				// Grab permanent permission so we can show it in recents list etc.
+				if (Build.VERSION.SDK_INT >= 19) {
+					getContentResolver().takePersistableUriPermission(selectedFile, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+				}
+				Log.i(TAG, "Browse file finished:" + selectedFile.toString());
+
+			}
+		}
 	}
 
 	public static native String queryGameName(String path);
 
 	// Create shortcut as response for ACTION_CREATE_SHORTCUT intent.
-	private void respondToShortcutRequest(String path) {
+	private void respondToShortcutRequest(Uri uri) {
 		// This is Intent that will be sent when user execute our shortcut on
 		// homescreen. Set our app as target Context. Set Main activity as
 		// target class. Add any parameter as data.
 		Intent shortcutIntent = new Intent(this, PpssppActivity.class);
-		Uri uri = Uri.fromFile(new File(path));
 		Log.i(TAG, "Shortcut URI: " + uri.toString());
 		shortcutIntent.setData(uri);
 
 		shortcutIntent.putExtra(PpssppActivity.SHORTCUT_EXTRA_KEY, path);
 
 		PpssppActivity.CheckABIAndLoadLibrary();
-		String name = queryGameName(path);
+		String name = queryGameName(uri.toString());
 		if (name.equals("")) {
 			showBadGameMessage();
 			return;
@@ -89,7 +127,8 @@ public class ShortcutActivity extends Activity {
 		@Override
 		public void onFileSelected(File file) {
 			// create shortcut using file path
-			respondToShortcutRequest(file.getAbsolutePath());
+			Uri uri = Uri.fromFile(new File(file.getAbsolutePath()));
+			respondToShortcutRequest(uri);
 		}
 	};
 }

--- a/android/src/org/ppsspp/ppsspp/ShortcutActivity.java
+++ b/android/src/org/ppsspp/ppsspp/ShortcutActivity.java
@@ -103,6 +103,12 @@ public class ShortcutActivity extends Activity {
 			} catch (Exception e) {
 				Log.i(TAG, "Exception getting name: " + e);
 			}
+		} else if (path.startsWith("file:///")) {
+			try {
+				pathStr = java.net.URLDecoder.decode(path.substring(7), StandardCharsets.UTF_8.name());
+			} catch (Exception e) {
+				Log.i(TAG, "Exception getting name: " + e);
+			}
 		} else {
 			pathStr = path;
 		}
@@ -111,6 +117,8 @@ public class ShortcutActivity extends Activity {
 		name = pathSegments[pathSegments.length - 1];
 
 		/*
+		// No longer working for various reasons.
+
 		PpssppActivity.CheckABIAndLoadLibrary();
 		String name = queryGameName(path);
 		if (name.equals("")) {
@@ -119,7 +127,7 @@ public class ShortcutActivity extends Activity {
 			return;
 		}*/
 
-		Log.i(TAG, "Game name: " + name + " : Creating shortcut to " + path);
+		Log.i(TAG, "Game name: " + name + " : Creating shortcut to " + uri.toString());
 
 		// This is Intent that will be returned by this method, as response to
 		// ACTION_CREATE_SHORTCUT. Wrap shortcut intent inside this intent.

--- a/android/src/org/ppsspp/ppsspp/ShortcutActivity.java
+++ b/android/src/org/ppsspp/ppsspp/ShortcutActivity.java
@@ -81,7 +81,9 @@ public class ShortcutActivity extends Activity {
 		// This is Intent that will be sent when user execute our shortcut on
 		// homescreen. Set our app as target Context. Set Main activity as
 		// target class. Add any parameter as data.
-		Intent shortcutIntent = new Intent(this, PpssppActivity.class);
+		Intent shortcutIntent = new Intent(getApplicationContext(), PpssppActivity.class);
+		shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+		shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 		Log.i(TAG, "Shortcut URI: " + uri.toString());
 		shortcutIntent.setData(uri);
 		String path = uri.toString();


### PR DESCRIPTION
Fixes #14797 

Just an evening of hacking shortcuts to work on both slightly older Android and on Android 12.

To clarify, these are the shortcuts you can create by creating a PPSSPP "Widget" in your launcher. It will launch a file selector where you can choose a PSP file to launch when clicking the new shortcut you create.

Basically, uses the newfangled file selectors on Android 11+ where we know they work, and the old one on older devices.

Then, avoid calling into the C++ code when creating the shortcut because we're in a weird context and nothing works due to some shortsighted decisions that would take far too much work to undo. This means that we have to guess the game title just from the filename for now, but that's better than crashing.