### PR TITLE
Fix wave on different dps

### DIFF
--- a/Common/Render/DrawBuffer.cpp
+++ b/Common/Render/DrawBuffer.cpp
@@ -14,11 +14,6 @@
 #include "Common/Log.h"
 #include "Common/StringUtils.h"
 
-enum {
-	// Enough?
-	MAX_VERTS = 65536,
-};
-
 DrawBuffer::DrawBuffer() : count_(0), atlas(0) {
 	verts_ = new Vertex[MAX_VERTS];
 	fontscalex = 1.0f;

--- a/Common/Render/DrawBuffer.h
+++ b/Common/Render/DrawBuffer.h
@@ -14,6 +14,11 @@
 struct Atlas;
 
 enum {
+	// Enough?
+	MAX_VERTS = 65536,
+};
+
+enum {
 	ALIGN_LEFT = 0,
 	ALIGN_RIGHT = 16,
 	ALIGN_TOP = 0,

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -89,18 +89,21 @@ public:
 		dc.Flush();
 		dc.BeginNoTex();
 
+		// Be sure to not overflow our vertex buffer
+		const float step = ceil(24*bounds.w/pixel_in_dps_x) > MAX_VERTS ? 24*bounds.w/(MAX_VERTS-48) : pixel_in_dps_x;
+
 		t *= speed;
-		for (int x = 0; x < bounds.w; ++x) {
+		for (float x = 0; x < bounds.w; x += step) {
 			float i = x * 1280/bounds.w;
 
 			float wave0 = sin(i*0.005+t*0.8)*0.05 + sin(i*0.002+t*0.25)*0.02 + sin(i*0.001+t*0.3)*0.03 + 0.625;
 			float wave1 = sin(i*0.0044+t*0.4)*0.07 + sin(i*0.003+t*0.1)*0.02 + sin(i*0.001+t*0.3)*0.01 + 0.625;
-			dc.Draw()->RectVGradient(x, wave0*bounds.h, pixel_in_dps_x, (1.0-wave0)*bounds.h, color, 0x00000000);
-			dc.Draw()->RectVGradient(x, wave1*bounds.h, pixel_in_dps_x, (1.0-wave1)*bounds.h, color, 0x00000000);
+			dc.Draw()->RectVGradient(x, wave0*bounds.h, step, (1.0-wave0)*bounds.h, color, 0x00000000);
+			dc.Draw()->RectVGradient(x, wave1*bounds.h, step, (1.0-wave1)*bounds.h, color, 0x00000000);
 
 			// Add some "antialiasing"
-			dc.Draw()->RectVGradient(x, wave0*bounds.h-3*pixel_in_dps_y, pixel_in_dps_x, 3*pixel_in_dps_y, 0x00000000, color);
-			dc.Draw()->RectVGradient(x, wave1*bounds.h-3*pixel_in_dps_y, pixel_in_dps_x, 3*pixel_in_dps_y, 0x00000000, color);
+			dc.Draw()->RectVGradient(x, wave0*bounds.h-3*pixel_in_dps_y, step, 3*pixel_in_dps_y, 0x00000000, color);
+			dc.Draw()->RectVGradient(x, wave1*bounds.h-3*pixel_in_dps_y, step, 3*pixel_in_dps_y, 0x00000000, color);
 		}
 
 		dc.Flush();


### PR DESCRIPTION
Fixes missing line when `pixel_in_dps_x` was not 1, also add a check about vertex buffer overflow (on 4k I think it could overflow the buffer, better be safe than sorry anyway).