### PR TITLE
Focus based moving background

### DIFF
--- a/Common/UI/Root.cpp
+++ b/Common/UI/Root.cpp
@@ -24,7 +24,6 @@ static std::mutex eventMutex_;
 static std::function<void(UISound)> soundCallback;
 static bool soundEnabled = true;
 
-
 struct DispatchQueueItem {
 	Event *e;
 	EventParams params;

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -191,6 +191,13 @@ void ScreenManager::render() {
 	processFinishDialog();
 }
 
+void ScreenManager::getFocusPosition(float &x, float &y, float &z) {
+	UI::View *v = UI::GetFocusedView();
+	x = v ? v->GetBounds().x : 0;
+	y = v ? v->GetBounds().y : 0;
+	z = stack_.size();
+}
+
 void ScreenManager::sendMessage(const char *msg, const char *value) {
 	if (!strcmp(msg, "recreateviews"))
 		RecreateAllViews();

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -4,6 +4,7 @@
 #include "Common/UI/Screen.h"
 #include "Common/UI/UI.h"
 #include "Common/UI/View.h"
+#include "Common/UI/ViewGroup.h"
 
 #include "Common/Log.h"
 #include "Common/TimeUtil.h"
@@ -192,9 +193,11 @@ void ScreenManager::render() {
 }
 
 void ScreenManager::getFocusPosition(float &x, float &y, float &z) {
+	UI::ScrollView::GetLastScrollPosition(x, y);
+
 	UI::View *v = UI::GetFocusedView();
-	x = v ? v->GetBounds().x : 0;
-	y = v ? v->GetBounds().y : 0;
+	x += v ? v->GetBounds().x : 0;
+	y += v ? v->GetBounds().y : 0;
 	z = stack_.size();
 }
 

--- a/Common/UI/Screen.h
+++ b/Common/UI/Screen.h
@@ -141,6 +141,8 @@ public:
 
 	Screen *topScreen() const;
 
+	void getFocusPosition(float &x, float &y, float &z);
+
 	std::recursive_mutex inputLock_;
 
 private:

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -1091,11 +1091,25 @@ bool ScrollView::CanScroll() const {
 	}
 }
 
+float ScrollView::lastScrollPosX = 0;
+float ScrollView::lastScrollPosY = 0;
+
+ScrollView::~ScrollView() {
+	lastScrollPosX = 0;
+	lastScrollPosY = 0;
+}
+
+void ScrollView::GetLastScrollPosition(float &x, float &y) {
+	x = lastScrollPosX;
+	y = lastScrollPosY;
+}
+
 void ScrollView::Update() {
 	if (visibility_ != V_VISIBLE) {
 		inertia_ = 0.0f;
 	}
 	ViewGroup::Update();
+	float oldPos = scrollPos_;
 
 	Gesture gesture = orientation_ == ORIENT_VERTICAL ? GESTURE_DRAG_VERTICAL : GESTURE_DRAG_HORIZONTAL;
 	gesture_.UpdateFrame();
@@ -1124,6 +1138,9 @@ void ScrollView::Update() {
 			pull_ = 0.0f;
 		}
 	}
+
+	if (oldPos != scrollPos_)
+		orientation_ == ORIENT_HORIZONTAL ? lastScrollPosX = scrollPos_ : lastScrollPosY = scrollPos_;
 }
 
 void AnchorLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert) {

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -264,6 +264,7 @@ class ScrollView : public ViewGroup {
 public:
 	ScrollView(Orientation orientation, LayoutParams *layoutParams = 0, bool rememberPosition = false)
 		: ViewGroup(layoutParams), orientation_(orientation), rememberPosition_(rememberPosition) {}
+	~ScrollView();
 
 	void Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert) override;
 	void Layout() override;
@@ -279,6 +280,9 @@ public:
 	float GetScrollPosition();
 	bool CanScroll() const;
 	void Update() override;
+
+	// Get the last moved scroll view position
+	static void GetLastScrollPosition(float &x, float &y);
 
 	// Override so that we can scroll to the active one after moving the focus.
 	bool SubviewFocused(View *view) override;
@@ -306,6 +310,9 @@ private:
 	float lastViewSize_ = 0.0f;
 	bool scrollToTopOnSizeChange_ = false;
 	bool rememberPosition_;
+
+	static float lastScrollPosX;
+	static float lastScrollPosY;
 };
 
 class ViewPager : public ScrollView {

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -129,4 +129,5 @@ enum class BackgroundAnimation {
 	FLOATING_SYMBOLS = 1,
 	RECENT_GAMES = 2,
 	WAVE = 3,
+	MOVING_BACKGROUND = 4,
 };

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -880,7 +880,7 @@ void GameSettingsScreen::CreateViews() {
 	if (backgroundChoice_ != nullptr) {
 		backgroundChoice_->OnClick.Handle(this, &GameSettingsScreen::OnChangeBackground);
 	}
-	static const char *backgroundAnimations[] = { "No animation", "Floating symbols", "Recent games", "Waves" };
+	static const char *backgroundAnimations[] = { "No animation", "Floating symbols", "Recent games", "Waves", "Moving background" };
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iBackgroundAnimation, sy->T("UI background animation"), backgroundAnimations, 0, ARRAY_SIZE(backgroundAnimations), sy->GetName(), screenManager()));
 
 	systemSettings->Add(new ItemHeader(sy->T("Help the PPSSPP team")));


### PR DESCRIPTION
Add another animation that scroll and zoom the current background image based on how you move on the menu (based on current focused view position, last scrollView moved scroll position and screenManager stack size).

There is a bug: if one view is focused and you scroll without moving the focus (e.g. scroll wheel) the 2 movement cancel one another, but working around that result in way more complex code and I think it's fine enough for an UI animation.

Preview: https://youtu.be/O8axvu6X5L0.

PS: name is kinda terrible, but I can't think of anything better...