### PR TITLE
Show grid setting in recent game tab too, slider for grid icon size

### DIFF
--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -1321,16 +1321,22 @@ std::string GridLayoutList::DescribeText() const {
 TabHolder::TabHolder(Orientation orientation, float stripSize, LayoutParams *layoutParams)
 	: LinearLayout(Opposite(orientation), layoutParams), stripSize_(stripSize) {
 	SetSpacing(0.0f);
+
+	choiceStrip_ = new LinearLayout(orientation, new LayoutParams(WRAP_CONTENT, WRAP_CONTENT));
+	choiceStrip_->SetSpacing(0.0f);
+
 	if (orientation == ORIENT_HORIZONTAL) {
 		tabStrip_ = new ChoiceStrip(orientation, new LayoutParams(WRAP_CONTENT, WRAP_CONTENT));
 		tabStrip_->SetTopTabs(true);
 		tabScroll_ = new ScrollView(orientation, new LayoutParams(FILL_PARENT, WRAP_CONTENT));
-		tabScroll_->Add(tabStrip_);
+		choiceStrip_->Add(tabStrip_);
+		tabScroll_->Add(choiceStrip_);
 		Add(tabScroll_);
 	} else {
 		tabStrip_ = new ChoiceStrip(orientation, new LayoutParams(stripSize, WRAP_CONTENT));
 		tabStrip_->SetTopTabs(true);
-		Add(tabStrip_);
+		choiceStrip_->Add(tabStrip_);
+		Add(choiceStrip_);
 	}
 	tabStrip_->OnChoice.Handle(this, &TabHolder::OnTabClick);
 

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -361,6 +361,11 @@ public:
 		return tabContents;
 	}
 
+	// Add a custom choice next to tab switching strip (current only used for main screen setting).
+	Choice *AddChoice(Choice *c) {
+		return choiceStrip_->Add(c);
+	}
+
 	void SetCurrentTab(int tab, bool skipTween = false);
 
 	int GetCurrentTab() const { return currentTab_; }
@@ -375,6 +380,7 @@ private:
 	ChoiceStrip *tabStrip_ = nullptr;
 	ScrollView *tabScroll_ = nullptr;
 	AnchorLayout *contents_ = nullptr;
+	LinearLayout *choiceStrip_ = nullptr;
 
 	float stripSize_;
 	int currentTab_ = 0;

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1541,10 +1541,7 @@ void GridSettingsScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	items->Add(new CheckBox(&g_Config.bGridView1, sy->T("Display Recent on a grid")));
 	items->Add(new CheckBox(&g_Config.bGridView2, sy->T("Display Games on a grid")));
 	items->Add(new CheckBox(&g_Config.bGridView3, sy->T("Display Homebrew on a grid")));
-
-	items->Add(new ItemHeader(sy->T("Grid icon size")));
-	items->Add(new Choice(sy->T("Increase size")))->OnClick.Handle(this, &GridSettingsScreen::GridPlusClick);
-	items->Add(new Choice(sy->T("Decrease size")))->OnClick.Handle(this, &GridSettingsScreen::GridMinusClick);
+	items->Add(new PopupSliderChoiceFloat(&g_Config.fGameGridScale, 0.8, 3.0, sy->T("Grid icon size"), 0.1,screenManager()));
 
 	items->Add(new ItemHeader(sy->T("Display Extra Info")));
 	items->Add(new CheckBox(&g_Config.bShowIDOnGameIcon, sy->T("Show ID")));
@@ -1557,16 +1554,6 @@ void GridSettingsScreen::CreatePopupContents(UI::ViewGroup *parent) {
 
 	scroll->Add(items);
 	parent->Add(scroll);
-}
-
-UI::EventReturn GridSettingsScreen::GridPlusClick(UI::EventParams &e) {
-	g_Config.fGameGridScale = std::min(g_Config.fGameGridScale*1.25f, MAX_GAME_GRID_SCALE);
-	return UI::EVENT_DONE;
-}
-
-UI::EventReturn GridSettingsScreen::GridMinusClick(UI::EventParams &e) {
-	g_Config.fGameGridScale = std::max(g_Config.fGameGridScale/1.25f, MIN_GAME_GRID_SCALE);
-	return UI::EVENT_DONE;
 }
 
 UI::EventReturn GridSettingsScreen::OnRecentClearClick(UI::EventParams &e) {

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -175,9 +175,5 @@ public:
 	UI::Event OnRecentChanged;
 
 private:
-	UI::EventReturn GridPlusClick(UI::EventParams &e);
-	UI::EventReturn GridMinusClick(UI::EventParams &e);
 	UI::EventReturn OnRecentClearClick(UI::EventParams &e);
-	const float MAX_GAME_GRID_SCALE = 3.0f;
-	const float MIN_GAME_GRID_SCALE = 0.8f;
 };

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -76,8 +76,6 @@ private:
 	UI::EventReturn StorageClick(UI::EventParams &e);
 	UI::EventReturn OnHomeClick(UI::EventParams &e);
 	UI::EventReturn PinToggleClick(UI::EventParams &e);
-	UI::EventReturn GridSettingsClick(UI::EventParams &e);
-	UI::EventReturn OnRecentClear(UI::EventParams &e);
 	UI::EventReturn OnHomebrewStore(UI::EventParams &e);
 
 	UI::ViewGroup *gameList_ = nullptr;
@@ -130,6 +128,8 @@ protected:
 	UI::EventReturn OnDismissUpgrade(UI::EventParams &e);
 	UI::EventReturn OnAllowStorage(UI::EventParams &e);
 	UI::EventReturn OnFullScreenToggle(UI::EventParams &e);
+	UI::EventReturn OnGridSettings(UI::EventParams &e);
+	UI::EventReturn OnRecentClear(UI::EventParams &e);
 
 	UI::LinearLayout *upgradeBar_ = nullptr;
 	UI::TabHolder *tabHolder_ = nullptr;
@@ -143,6 +143,7 @@ protected:
 	float highlightProgress_ = 0.0f;
 	float prevHighlightProgress_ = 0.0f;
 	bool backFromStore_ = false;
+	bool recreateViewOnDialogFinish_ = false;
 	bool lockBackgroundAudio_ = false;
 	bool lastVertical_;
 	bool confirmedTemporary_ = false;


### PR DESCRIPTION
Move the setting button in the tab holder and show it in recent tab too (I kinda like it more with no spacing like this, but I don't really have a strong opinion on this).
![Screenshot_2021-09-26_14-33-40](https://user-images.githubusercontent.com/13517524/134808306-c29807cb-ae56-48ae-9fab-38f5df3f8a59.png)

Also use a slider rather than 2 button (this add support for unlimited stacks of popup rather than just 1).