### PR TITLE
Fix intermittent crashes when closing content in libretro under vulkan

### DIFF
--- a/libretro/LibretroVulkanContext.cpp
+++ b/libretro/LibretroVulkanContext.cpp
@@ -125,6 +125,13 @@ void LibretroVulkanContext::ContextReset() {
    LibretroHWRenderContext::ContextReset();
 }
 
+void LibretroVulkanContext::ContextDestroy() {
+   INFO_LOG(G3D, "LibretroVulkanContext::ContextDestroy()");
+
+   LostBackbuffer();
+   gpu->DeviceLost();
+}
+
 void LibretroVulkanContext::CreateDrawContext() {
    vk->ReinitSurface();
 

--- a/libretro/LibretroVulkanContext.h
+++ b/libretro/LibretroVulkanContext.h
@@ -5,7 +5,7 @@
 class LibretroVulkanContext : public LibretroHWRenderContext {
 public:
 	LibretroVulkanContext();
-	~LibretroVulkanContext() override {}
+   ~LibretroVulkanContext() override { Shutdown(); }
 	bool Init() override;
 	void Shutdown() override;
 	void SwapBuffers() override;
@@ -14,6 +14,7 @@ public:
 	void CreateDrawContext() override;
 
    void ContextReset() override;
+   void ContextDestroy() override;
 
 	GPUCore GetGPUCore() override { return GPUCORE_VULKAN; }
 	const char *Ident() override { return "Vulkan"; }


### PR DESCRIPTION
Due to an api quirk in libretro the code for destroying hardware render contexts is actually executed before the game or core shutdown logic. This had the unfortunate side effect of nulling the vulkan context object and invalidating the pointer that was in use in ppsspp's renderer.
This decouples the libretro renderer context and vulkan context shutdown leaving the object live so that ppsspp can gracefully exit.