### PR TITLE
Hide directories games should not know about

### DIFF
--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -654,7 +654,6 @@ u64 MetaFileSystem::getDirSize(const std::string &dirPath) {
 	for (auto file : allFiles) {
 		if (file.name == "." || file.name == "..")
 			continue;
-		_assert_(!file.name.empty());
 		if (file.type == FILETYPE_DIRECTORY) {
 			result += getDirSize(dirPath + file.name);
 		} else {

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2339,6 +2339,7 @@ static u32 sceIoDopen(const char *path) {
 			"SCREENSHOT",
 			"TEXTURES",
 			"DUMP",
+			"SHADERS",
 		};
 		std::vector<PSPFileInfo> filtered;
 		for (const auto &entry : dir->listing) {

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -21,7 +21,6 @@
 #include <memory>
 
 #include "Common/Thread/ThreadUtil.h"
-#include "Common/TimeUtil.h"
 #include "Common/Profiler/Profiler.h"
 
 #include "Common/File/FileUtil.h"

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -21,6 +21,7 @@
 #include <memory>
 
 #include "Common/Thread/ThreadUtil.h"
+#include "Common/TimeUtil.h"
 #include "Common/Profiler/Profiler.h"
 
 #include "Common/File/FileUtil.h"
@@ -2321,9 +2322,47 @@ static u32 sceIoDopen(const char *path) {
 	DirListing *dir = new DirListing();
 	SceUID id = kernelObjects.Create(dir);
 
+	double time = time_now_d();
 	dir->listing = pspFileSystem.GetDirListing(path);
 	dir->index = 0;
 	dir->name = std::string(path);
+
+	// Blacklist some directories that games should not be able to find out about.
+	// Speeds up directory iteration on slow Android Scoped Storage implementations :(
+	// Might also want to filter out PSP/GAME if not a homebrew, maybe also irrelevant directories
+	// in PSP/SAVEDATA, though iffy to know which ones are irrelevant..
+	if (!strcmp(path, "ms0:/PSP")) {
+		static const char *const pspFolderBlacklist[] = {
+			"CHEATS",
+			"PPSSPP_STATE",
+			"PLUGINS",
+			"SYSTEM",
+			"SCREENSHOT",
+			"TEXTURES",
+			"DUMP",
+		};
+		std::vector<PSPFileInfo> filtered;
+		for (const auto &entry : dir->listing) {
+			bool blacklisted = false;
+			for (auto black : pspFolderBlacklist) {
+				if (!strcasecmp(entry.name.c_str(), black)) {
+					blacklisted = true;
+					break;
+				}
+			}
+
+			if (!blacklisted) {
+				filtered.push_back(entry);
+			}
+		}
+
+		dir->listing = filtered;
+	}
+	
+	double diff = time_now_d() - time;
+	//if (diff > 0.01) {
+		ERROR_LOG(IO, "sceIoDopen(%s) took %0.3f seconds", path, diff);
+	//}
 
 	// TODO: The result is delayed only from the memstick, it seems.
 	return id;
@@ -2349,7 +2388,7 @@ static u32 sceIoDread(int id, u32 dirent_addr) {
 		SceIoDirEnt *entry = (SceIoDirEnt*) Memory::GetPointer(dirent_addr);
 
 		if (dir->index == (int) dir->listing.size()) {
-			DEBUG_LOG(SCEIO, "sceIoDread( %d %08x ) - end of the line", id, dirent_addr);
+			DEBUG_LOG(SCEIO, "sceIoDread( %d %08x ) - end", id, dirent_addr);
 			entry->d_name[0] = '\0';
 			return 0;
 		}

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2322,7 +2322,6 @@ static u32 sceIoDopen(const char *path) {
 	DirListing *dir = new DirListing();
 	SceUID id = kernelObjects.Create(dir);
 
-	double time = time_now_d();
 	dir->listing = pspFileSystem.GetDirListing(path);
 	dir->index = 0;
 	dir->name = std::string(path);
@@ -2359,11 +2358,6 @@ static u32 sceIoDopen(const char *path) {
 		dir->listing = filtered;
 	}
 	
-	double diff = time_now_d() - time;
-	//if (diff > 0.01) {
-		ERROR_LOG(IO, "sceIoDopen(%s) took %0.3f seconds", path, diff);
-	//}
-
 	// TODO: The result is delayed only from the memstick, it seems.
 	return id;
 }

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -176,12 +176,11 @@ u64 GameInfo::GetInstallDataSizeInBytes() {
 	for (size_t j = 0; j < saveDataDir.size(); j++) {
 		std::vector<File::FileInfo> fileInfo;
 		File::GetFilesInDir(saveDataDir[j], &fileInfo);
-		// Note: GetFilesInDir does not fill in fileSize properly.
-		for (size_t i = 0; i < fileInfo.size(); i++) {
-			File::FileInfo finfo;
-			File::GetFileInfo(fileInfo[i].fullName, &finfo);
-			if (!finfo.isDirectory)
-				filesSizeInDir += finfo.size;
+		for (auto const &file : fileInfo) {
+			// TODO: Might want to recurse here? Don't know games that use directories
+			// for install-data though.
+			if (!file.isDirectory)
+				filesSizeInDir += file.size;
 		}
 		if (filesSizeInDir >= 0xA00000) { 
 			// HACK: Generally the savedata size in a dir shouldn't be more than 10MB.

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -152,12 +152,9 @@ u64 GameInfo::GetSaveDataSizeInBytes() {
 	for (size_t j = 0; j < saveDataDir.size(); j++) {
 		std::vector<File::FileInfo> fileInfo;
 		File::GetFilesInDir(saveDataDir[j], &fileInfo);
-		// Note: GetFilesInDir does not fill in fileSize properly.
-		for (size_t i = 0; i < fileInfo.size(); i++) {
-			File::FileInfo finfo;
-			File::GetFileInfo(fileInfo[i].fullName, &finfo);
-			if (!finfo.isDirectory)
-				filesSizeInDir += finfo.size;
+		for (auto const &file : fileInfo) {
+			if (!file.isDirectory)
+				filesSizeInDir += file.size;
 		}
 		if (filesSizeInDir < 0xA00000) {
 			// HACK: Generally the savedata size in a dir shouldn't be more than 10MB.
@@ -351,7 +348,9 @@ public:
 		if (!info_->LoadFromPath(gamePath_)) {
 			return;
 		}
+
 		// In case of a remote file, check if it actually exists before locking.
+		// This is likely not necessary at a
 		if (!info_->GetFileLoader()->Exists()) {
 			return;
 		}


### PR DESCRIPTION
Stops some games from spending lots of time iterating over files they should not care about. 

Helps the scoped storage performance issues in #13847 quite a bit.

Also added some optimizations for the game info screen.