### PR TITLE
Add a cache for memory stick usage

### DIFF
--- a/Core/HW/MemoryStick.h
+++ b/Core/HW/MemoryStick.h
@@ -51,3 +51,4 @@ void MemoryStick_SetFatState(MemStickFatState state);
 
 u64 MemoryStick_SectorSize();
 u64 MemoryStick_FreeSpace();
+void MemoryStick_NotifyWrite();

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -95,6 +95,7 @@
 #include "Core/HLE/sceUsbCam.h"
 #include "Core/HLE/sceUsbGps.h"
 #include "Core/HLE/proAdhoc.h"
+#include "Core/HW/MemoryStick.h"
 #include "Core/Util/GameManager.h"
 #include "Core/Util/AudioFormat.h"
 #include "Core/WebServer.h"
@@ -1259,6 +1260,10 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 		g_Config.Reload();
 		PostLoadConfig();
 		g_Config.iGPUBackend = gpuBackend;
+	}
+	if (msg == "app_resumed" || msg == "got_focus") {
+		// Assume that the user may have modified things.
+		MemoryStick_NotifyWrite();
 	}
 }
 


### PR DESCRIPTION
See #13847 - this will at least reduce how often we recalculate the size of SAVEDATA, by caching it between writes.

Flushes this cache on any write to the memory stick (not just savedata, for simplicity and durability), and also when resuming/focusing the app.  This is to make sure external deletions work in a mostly sane way to reduce usage.

-[Unknown]