### PR TITLE
More I/O optimizations

### DIFF
--- a/Common/File/AndroidStorage.cpp
+++ b/Common/File/AndroidStorage.cpp
@@ -273,7 +273,7 @@ int64_t Android_ComputeRecursiveDirectorySize(const std::string &uri) {
 	int64_t size = env->CallLongMethod(g_nativeActivity, computeRecursiveDirectorySize, param);
 	double elapsed = time_now_d() - start;
 
-	ERROR_LOG(IO, "ComputeRecursiveDirectorySize(%s) in %0.3f s", uri.c_str(), elapsed);
+	INFO_LOG(IO, "ComputeRecursiveDirectorySize(%s) in %0.3f s", uri.c_str(), elapsed);
 	return size;
 }
 

--- a/Common/File/AndroidStorage.cpp
+++ b/Common/File/AndroidStorage.cpp
@@ -268,7 +268,13 @@ int64_t Android_ComputeRecursiveDirectorySize(const std::string &uri) {
 	auto env = getEnv();
 
 	jstring param = env->NewStringUTF(uri.c_str());
-	return env->CallLongMethod(g_nativeActivity, computeRecursiveDirectorySize, param);
+
+	double start = time_now_d();
+	int64_t size = env->CallLongMethod(g_nativeActivity, computeRecursiveDirectorySize, param);
+	double elapsed = time_now_d() - start;
+
+	ERROR_LOG(IO, "ComputeRecursiveDirectorySize(%s) in %0.3f s", uri.c_str(), elapsed);
+	return size;
 }
 
 bool Android_IsExternalStoragePreservedLegacy() {

--- a/Common/File/AndroidStorage.cpp
+++ b/Common/File/AndroidStorage.cpp
@@ -20,6 +20,7 @@ static jmethodID contentUriFileExists;
 static jmethodID contentUriGetFreeStorageSpace;
 static jmethodID filePathGetFreeStorageSpace;
 static jmethodID isExternalStoragePreservedLegacy;
+static jmethodID computeRecursiveDirectorySize;
 
 static jobject g_nativeActivity;
 
@@ -54,6 +55,8 @@ void Android_RegisterStorageCallbacks(JNIEnv * env, jobject obj) {
 	_dbg_assert_(filePathGetFreeStorageSpace);
 	isExternalStoragePreservedLegacy = env->GetMethodID(env->GetObjectClass(obj), "isExternalStoragePreservedLegacy", "()Z");
 	_dbg_assert_(isExternalStoragePreservedLegacy);
+	computeRecursiveDirectorySize = env->GetMethodID(env->GetObjectClass(obj), "computeRecursiveDirectorySize", "(Ljava/lang/String;)J");
+	_dbg_assert_(computeRecursiveDirectorySize);
 }
 
 bool Android_IsContentUri(const std::string &filename) {
@@ -256,6 +259,16 @@ int64_t Android_GetFreeSpaceByFilePath(const std::string &filePath) {
 
 	jstring param = env->NewStringUTF(filePath.c_str());
 	return env->CallLongMethod(g_nativeActivity, filePathGetFreeStorageSpace, param);
+}
+
+int64_t Android_ComputeRecursiveDirectorySize(const std::string &uri) {
+	if (!g_nativeActivity) {
+		return false;
+	}
+	auto env = getEnv();
+
+	jstring param = env->NewStringUTF(uri.c_str());
+	return env->CallLongMethod(g_nativeActivity, computeRecursiveDirectorySize, param);
 }
 
 bool Android_IsExternalStoragePreservedLegacy() {

--- a/Common/File/AndroidStorage.h
+++ b/Common/File/AndroidStorage.h
@@ -73,7 +73,7 @@ inline StorageError Android_RemoveFile(const std::string &fileUri) { return Stor
 inline StorageError Android_RenameFileTo(const std::string &fileUri, const std::string &newName) { return StorageError::UNKNOWN; }
 inline bool Android_GetFileInfo(const std::string &fileUri, File::FileInfo *info) { return false; }
 inline bool Android_FileExists(const std::string &fileUri) { return false; }
-inline int64_t Android_GetRecursiveDirectorySize(const std::string &fileUri) { return -1; }
+inline int64_t Android_ComputeRecursiveDirectorySize(const std::string &fileUri) { return -1; }
 inline int64_t Android_GetFreeSpaceByContentUri(const std::string &uri) { return -1; }
 inline int64_t Android_GetFreeSpaceByFilePath(const std::string &filePath) { return -1; }
 inline bool Android_IsExternalStoragePreservedLegacy() { return false; }

--- a/Common/File/AndroidStorage.h
+++ b/Common/File/AndroidStorage.h
@@ -49,6 +49,7 @@ StorageError Android_RemoveFile(const std::string &fileUri);
 StorageError Android_RenameFileTo(const std::string &fileUri, const std::string &newName);
 bool Android_GetFileInfo(const std::string &fileUri, File::FileInfo *info);
 bool Android_FileExists(const std::string &fileUri);
+int64_t Android_ComputeRecursiveDirectorySize(const std::string &fileUri);
 int64_t Android_GetFreeSpaceByContentUri(const std::string &uri);
 int64_t Android_GetFreeSpaceByFilePath(const std::string &filePath);
 bool Android_IsExternalStoragePreservedLegacy();
@@ -72,6 +73,7 @@ inline StorageError Android_RemoveFile(const std::string &fileUri) { return Stor
 inline StorageError Android_RenameFileTo(const std::string &fileUri, const std::string &newName) { return StorageError::UNKNOWN; }
 inline bool Android_GetFileInfo(const std::string &fileUri, File::FileInfo *info) { return false; }
 inline bool Android_FileExists(const std::string &fileUri) { return false; }
+inline int64_t Android_GetRecursiveDirectorySize(const std::string &fileUri) { return -1; }
 inline int64_t Android_GetFreeSpaceByContentUri(const std::string &uri) { return -1; }
 inline int64_t Android_GetFreeSpaceByFilePath(const std::string &filePath) { return -1; }
 inline bool Android_IsExternalStoragePreservedLegacy() { return false; }

--- a/Common/File/DirListing.cpp
+++ b/Common/File/DirListing.cpp
@@ -285,19 +285,6 @@ bool GetFilesInDir(const Path &directory, std::vector<FileInfo> *files, const ch
 	return true;
 }
 
-int64_t GetDirectoryRecursiveSize(const Path &path, const char *filter, int flags) {
-	std::vector<FileInfo> fileInfo;
-	GetFilesInDir(path, &fileInfo, filter, flags);
-	int64_t sizeSum = 0;
-	for (const auto &finfo : fileInfo) {
-		if (!finfo.isDirectory)
-			sizeSum += finfo.size;
-		else
-			sizeSum += GetDirectoryRecursiveSize(finfo.fullName, filter, flags);
-	}
-	return sizeSum;
-}
-
 #if PPSSPP_PLATFORM(WINDOWS)
 // Returns a vector with the device names
 std::vector<std::string> GetWindowsDrives()

--- a/Common/File/DirListing.cpp
+++ b/Common/File/DirListing.cpp
@@ -289,10 +289,7 @@ int64_t GetDirectoryRecursiveSize(const Path &path, const char *filter, int flag
 	std::vector<FileInfo> fileInfo;
 	GetFilesInDir(path, &fileInfo, filter, flags);
 	int64_t sizeSum = 0;
-	// Note: GetFilesInDir does not fill in fileSize.
-	for (size_t i = 0; i < fileInfo.size(); i++) {
-		FileInfo finfo;
-		GetFileInfo(fileInfo[i].fullName, &finfo);
+	for (const auto &finfo : fileInfo) {
 		if (!finfo.isDirectory)
 			sizeSum += finfo.size;
 		else

--- a/Common/File/DirListing.h
+++ b/Common/File/DirListing.h
@@ -35,7 +35,6 @@ enum {
 };
 
 bool GetFilesInDir(const Path &directory, std::vector<FileInfo> *files, const char *filter = nullptr, int flags = 0);
-int64_t GetDirectoryRecursiveSize(const Path &path, const char *filter = nullptr, int flags = 0);
 std::vector<File::FileInfo> ApplyFilter(std::vector<File::FileInfo> files, const char *filter);
 
 #ifdef _WIN32

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -327,20 +327,18 @@ std::string ResolvePath(const std::string &path) {
 static int64_t RecursiveSize(const Path &path) {
 	// TODO: Some file systems can optimize this.
 	std::vector<FileInfo> fileInfo;
-	if (!GetFilesInDir(path, &fileInfo)) {
+	if (!GetFilesInDir(path, &fileInfo, nullptr, GETFILES_GETHIDDEN)) {
 		return -1;
 	}
-	int64_t result = 0;
+	int64_t sizeSum = 0;
 	for (const auto &file : fileInfo) {
-		if (file.name == "." || file.name == "..")
-			continue;
 		if (file.isDirectory) {
-			result += RecursiveSize(file.fullName);
+			sizeSum += RecursiveSize(file.fullName);
 		} else {
-			result += file.size;
+			sizeSum += file.size;
 		}
 	}
-	return result;
+	return sizeSum;
 }
 
 uint64_t ComputeRecursiveDirectorySize(const Path &path) {

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -324,6 +324,34 @@ std::string ResolvePath(const std::string &path) {
 #endif
 }
 
+static int64_t RecursiveSize(const Path &path) {
+	// TODO: Some file systems can optimize this.
+	std::vector<FileInfo> fileInfo;
+	if (!GetFilesInDir(path, &fileInfo)) {
+		return -1;
+	}
+	int64_t result = 0;
+	for (const auto &file : fileInfo) {
+		if (file.name == "." || file.name == "..")
+			continue;
+		if (file.isDirectory) {
+			result += RecursiveSize(file.fullName);
+		} else {
+			result += file.size;
+		}
+	}
+	return result;
+}
+
+uint64_t ComputeRecursiveDirectorySize(const Path &path) {
+	if (path.Type() == PathType::CONTENT_URI) {
+		return Android_ComputeRecursiveDirectorySize(path.ToString());
+	}
+
+	// Generic solution.
+	return RecursiveSize(path);
+}
+
 // Returns true if file filename exists. Will return true on directories.
 bool ExistsInDir(const Path &path, const std::string &filename) {
 	return Exists(path / filename);

--- a/Common/File/FileUtil.h
+++ b/Common/File/FileUtil.h
@@ -79,6 +79,9 @@ uint64_t GetFileSize(const Path &filename);
 // Overloaded GetSize, accepts FILE*
 uint64_t GetFileSize(FILE *f);
 
+// Computes the recursive size of a directory. Warning: Might be slow!
+uint64_t ComputeRecursiveDirectorySize(const Path &path);
+
 // Returns true if successful, or path already exists.
 bool CreateDir(const Path &filename);
 

--- a/Core/FileSystems/BlobFileSystem.h
+++ b/Core/FileSystems/BlobFileSystem.h
@@ -54,6 +54,8 @@ public:
 	bool RemoveFile(const std::string &filename) override;
 	u64 FreeSpace(const std::string &path) override;
 
+	bool ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) override { return false; }
+
 private:
 	// File positions.
 	std::map<u32, s64> entries_;

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -878,6 +878,18 @@ static std::string SimulateVFATBug(std::string filename) {
 	return filename;
 }
 
+bool DirectoryFileSystem::ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) {
+	Path localPath = GetLocalPath(path);
+
+	int64_t sizeTemp = File::ComputeRecursiveDirectorySize(localPath);
+	if (sizeTemp >= 0) {
+		*size = sizeTemp;
+		return true;
+	} else {
+		return false;
+	}
+}
+
 std::vector<PSPFileInfo> DirectoryFileSystem::GetDirListing(std::string path) {
 	std::vector<PSPFileInfo> myVector;
 

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -115,6 +115,9 @@ public:
 	FileSystemFlags Flags() override { return flags; }
 	u64 FreeSpace(const std::string &path) override;
 
+	// TODO: Replace with optimized implementation.
+	bool ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) override { return false; }
+
 private:
 	struct OpenFileEntry {
 		DirectoryFileHandle hFile;
@@ -158,6 +161,8 @@ public:
 	bool RemoveFile(const std::string &filename) override;
 	FileSystemFlags Flags() override { return FileSystemFlags::FLASH; }
 	u64 FreeSpace(const std::string &path) override { return 0; }
+
+	bool ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) override { return false; }
 
 private:
 	struct OpenFileEntry {

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -116,7 +116,7 @@ public:
 	u64 FreeSpace(const std::string &path) override;
 
 	// TODO: Replace with optimized implementation.
-	bool ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) override { return false; }
+	bool ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) override;
 
 private:
 	struct OpenFileEntry {

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -115,7 +115,6 @@ public:
 	FileSystemFlags Flags() override { return flags; }
 	u64 FreeSpace(const std::string &path) override;
 
-	// TODO: Replace with optimized implementation.
 	bool ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) override;
 
 private:

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -136,11 +136,11 @@ public:
 	virtual PSPDevType DevType(u32 handle) = 0;
 	virtual FileSystemFlags Flags() = 0;
 	virtual u64      FreeSpace(const std::string &path) = 0;
+	virtual bool     ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) = 0;
 };
 
 
-class EmptyFileSystem : public IFileSystem
-{
+class EmptyFileSystem : public IFileSystem {
 public:
 	virtual void DoState(PointerWrap &p) override {}
 	std::vector<PSPFileInfo> GetDirListing(std::string path) override {std::vector<PSPFileInfo> vec; return vec;}
@@ -161,6 +161,7 @@ public:
 	virtual PSPDevType DevType(u32 handle) override { return PSPDevType::INVALID; }
 	virtual FileSystemFlags Flags() override { return FileSystemFlags::NONE; }
 	virtual u64 FreeSpace(const std::string &path) override { return 0; }
+	bool ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) override { return false; }
 };
 
 

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -54,6 +54,8 @@ public:
 	int  RenameFile(const std::string &from, const std::string &to) override { return -1; }
 	bool RemoveFile(const std::string &filename) override { return false; }
 
+	bool ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) override { return false; }
+
 private:
 	struct TreeEntry {
 		~TreeEntry();
@@ -149,6 +151,8 @@ public:
 	bool RmDir(const std::string &dirname) override { return false; }
 	int  RenameFile(const std::string &from, const std::string &to) override { return -1; }
 	bool RemoveFile(const std::string &filename) override { return false; }
+
+	bool ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) override { return false; }
 
 private:
 	std::shared_ptr<IFileSystem> isoFileSystem_;

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -136,5 +136,19 @@ public:
 		startingDirectory = dir;
 	}
 
-	u64 getDirSize(const std::string &dirPath);
+	int64_t ComputeRecursiveDirectorySize(const std::string &dirPath);
+
+	// Shouldn't ever be called, but meh.
+	bool ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) override {
+		int64_t sizeTemp = ComputeRecursiveDirectorySize(path);
+		if (sizeTemp >= 0) {
+			*size = sizeTemp;
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+private:
+	int64_t RecursiveSize(const std::string &dirPath);
 };

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -52,6 +52,8 @@ public:
 	int  RenameFile(const std::string &from, const std::string &to) override;
 	bool RemoveFile(const std::string &filename) override;
 
+	bool ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) override { return false; }
+
 private:
 	void LoadFileListIndex();
 	// Warning: modifies input string.

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2331,7 +2331,7 @@ static u32 sceIoDopen(const char *path) {
 	double listTime = time_now_d() - startTime;
 
 	if (listTime > 0.01) {
-		ERROR_LOG(IO, "Dir listing '%s' took %0.3f", path, listTime);
+		INFO_LOG(IO, "Dir listing '%s' took %0.3f", path, listTime);
 	}
 
 	// Blacklist some directories that games should not be able to find out about.

--- a/Core/HW/MemoryStick.cpp
+++ b/Core/HW/MemoryStick.cpp
@@ -96,7 +96,7 @@ static void MemoryStick_CalcInitialFree() {
 	std::unique_lock<std::mutex> guard(freeCalcMutex);
 	freeCalcStatus = FreeCalcStatus::RUNNING;
 	freeCalcThread = std::thread([] {
-		memstickInitialFree = pspFileSystem.FreeSpace("ms0:/") + pspFileSystem.getDirSize("ms0:/PSP/SAVEDATA/");
+		memstickInitialFree = pspFileSystem.FreeSpace("ms0:/") + pspFileSystem.ComputeRecursiveDirectorySize("ms0:/PSP/SAVEDATA/");
 
 		std::unique_lock<std::mutex> guard(freeCalcMutex);
 		freeCalcStatus = FreeCalcStatus::DONE;
@@ -127,7 +127,7 @@ u64 MemoryStick_FreeSpace() {
 
 	// Assume the memory stick is only used to store savedata.
 	if (!memstickCurrentUseValid) {
-		memstickCurrentUse = pspFileSystem.getDirSize("ms0:/PSP/SAVEDATA/");
+		memstickCurrentUse = pspFileSystem.ComputeRecursiveDirectorySize("ms0:/PSP/SAVEDATA/");
 		memstickCurrentUseValid = true;
 	}
 

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -343,13 +343,11 @@ public:
 	void Run() override {
 		// An early-return will result in the destructor running, where we can set
 		// flags like working and pending.
-
 		if (!info_->LoadFromPath(gamePath_)) {
 			return;
 		}
 
 		// In case of a remote file, check if it actually exists before locking.
-		// This is likely not necessary at a
 		if (!info_->GetFileLoader()->Exists()) {
 			return;
 		}

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -114,7 +114,7 @@ u64 GameInfo::GetGameSizeInBytes() {
 	switch (fileType) {
 	case IdentifiedFileType::PSP_PBP_DIRECTORY:
 	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY:
-		return File::GetDirectoryRecursiveSize(ResolvePBPDirectory(filePath_), nullptr, File::GETFILES_GETHIDDEN);
+		return File::ComputeRecursiveDirectorySize(ResolvePBPDirectory(filePath_));
 
 	default:
 		return GetFileLoader()->FileSize();

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -430,8 +430,7 @@ static time_t GetTotalSize(const SavedataButton *b) {
 	switch (Identify_File(fileLoader.get(), &errorString)) {
 	case IdentifiedFileType::PSP_PBP_DIRECTORY:
 	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY:
-		return File::GetDirectoryRecursiveSize(ResolvePBPDirectory(b->GamePath()), nullptr, File::GETFILES_GETHIDDEN);
-
+		return File::ComputeRecursiveDirectorySize(ResolvePBPDirectory(b->GamePath()));
 	default:
 		return fileLoader->FileSize();
 	}

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -236,7 +236,6 @@ public class PpssppActivity extends NativeActivity {
 		try {
 			Uri uri = Uri.parse(uriString);
 			long totalSize = directorySizeRecursion(uri);
-			Log.i(TAG, "directorySizeRecursion(" + uriString + ") returned " + totalSize);
 			return totalSize;
 		}
 		catch (Exception e) {


### PR DESCRIPTION
Adds a Java-native function that computes the recursive size of a directory, and adds the plumbing to use it. I think there are still some possible optimizations there by avoiding some DocumentId lookups.

Adds back the sceIoDOpen logging which is useful while we work on this, might remove it again later.

Adds a hack that prevents directories like PSP/GAME from also showing up at the root if we strip /PSP from the path due to the user having chosen a directory called PSP as the root. This can probably be handled more elegantly elsewhere but don't really want to go digging into that right now.

Should help #13847 .