### PR TITLE
Wire inflight frames config setting to render managers.

### DIFF
--- a/libretro/LibretroGLCoreContext.cpp
+++ b/libretro/LibretroGLCoreContext.cpp
@@ -28,6 +28,9 @@ void LibretroGLCoreContext::CreateDrawContext() {
 	}
 	draw_ = Draw::T3DCreateGLContext();
 	renderManager_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+	renderManager_->SetInflightFrames(g_Config.iInflightFrames);
+	SetGPUBackend(GPUBackend::OPENGL);
+	draw_->CreatePresets();
 }
 
 void LibretroGLCoreContext::DestroyDrawContext() {

--- a/libretro/LibretroVulkanContext.cpp
+++ b/libretro/LibretroVulkanContext.cpp
@@ -11,6 +11,7 @@
 
 #include "libretro/LibretroVulkanContext.h"
 #include "libretro/libretro_vulkan.h"
+#include <GPU/Vulkan/VulkanRenderManager.h>
 
 static VulkanContext *vk;
 
@@ -140,6 +141,8 @@ void LibretroVulkanContext::CreateDrawContext() {
    }
 
    draw_ = Draw::T3DCreateVulkanContext(vk, false);
+   ((VulkanRenderManager*)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER))->SetInflightFrames(g_Config.iInflightFrames);
+   SetGPUBackend(GPUBackend::VULKAN);
 }
 
 void LibretroVulkanContext::Shutdown() {


### PR DESCRIPTION
Inflight frames was only wired into the libretro gl context . Adds missing set calls for glcore and vulkan.