### PR TITLE
Fix setting info on multi choice

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -218,6 +218,11 @@ void GameSettingsScreen::CreateViews() {
 	settingInfo_->SetBottomCutoff(dp_yres - 200.0f);
 	root_->Add(settingInfo_);
 
+	// Show it again if we recreated the view
+	if (oldSettingInfo_ != "") {
+		settingInfo_->Show(oldSettingInfo_, nullptr);
+	}
+
 	// TODO: These currently point to global settings, not game specific ones.
 
 	// Graphics
@@ -1271,6 +1276,11 @@ void GameSettingsScreen::dialogFinished(const Screen *dialog, DialogResult resul
 
 		RecreateViews();
 	}
+}
+
+void GameSettingsScreen::RecreateViews() {
+	oldSettingInfo_ = settingInfo_->GetText();
+	UIScreen::RecreateViews();
 }
 
 void GameSettingsScreen::CallbackMemstickFolder(bool yes) {

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -44,6 +44,7 @@ protected:
 	void CallbackMemstickFolder(bool yes);
 	bool UseVerticalLayout() const;
 	void dialogFinished(const Screen *dialog, DialogResult result) override;
+	void RecreateViews() override;
 
 private:
 	void TriggerRestart(const char *why);
@@ -137,6 +138,9 @@ private:
 
 	// Android-only
 	std::string pendingMemstickFolder_;
+
+	// If we recreate the views while this is active we show it again
+	std::string oldSettingInfo_;
 };
 
 class DeveloperToolsScreen : public UIDialogScreenWithBackground {

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -1086,4 +1086,9 @@ void SettingInfoMessage::Draw(UIContext &dc) {
 
 	text_->SetTextColor(whiteAlpha(alpha));
 	ViewGroup::Draw(dc);
+	showing_ = sinceShow <= timeToShow; // Don't consider fade time
+}
+
+std::string SettingInfoMessage::GetText() const {
+	return showing_ && text_ ? text_->GetText() : "";
 }

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -175,9 +175,11 @@ public:
 	void Show(const std::string &text, UI::View *refView = nullptr);
 
 	void Draw(UIContext &dc);
+	std::string GetText() const;
 
 private:
 	UI::TextView *text_ = nullptr;
 	double timeShown_ = 0.0;
 	float cutOffY_;
+	bool showing_ = false;
 };


### PR DESCRIPTION
After f51b8116a08e8346a5aa1b3e80a76afd99459912 we recreate the view on dialog finish, this broke setting info for popup like buffered rendering.