### PR TITLE
Savedata: Respect IO timing method setting

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -1018,6 +1018,10 @@ int PSPSaveDialog::Update(int animSpeed)
 			case SAVEIO_PENDING:
 			case SAVEIO_DONE:
 				// To make sure there aren't any timing variations, we sync the next frame.
+				if (g_Config.iIOTimingMethod == IOTIMING_HOST && ioThreadStatus == SAVEIO_PENDING) {
+					// ... except in Host IO timing, where we wait as long as needed.
+					break;
+				}
 				JoinIOThread();
 				ChangeStatus(SCE_UTILITY_STATUS_FINISHED, 0);
 				break;


### PR DESCRIPTION
With this, configuring IO timing method = Host will probably dodge any stutters on scoped storage save/load, but may be more hazardous if there's some game that expects specific timing.  See #13847.

The current timing (always completes in one frame) is definitely wrong, but this is a quick change to validate my assumption that changes here could be an improvement.  We should improve it, but that seems a bit more dangerous right now than extending this setting (which already has possible instability) to savedata, which it really should've always included.

-[Unknown]