### PR TITLE
Correct DXT5 alpha calculation

### DIFF
--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -375,20 +375,19 @@ void DXTDecoder::DecodeColors(const DXT1Block *src, bool ignore1bitAlpha) {
 }
 
 static inline u8 lerp8(const DXT5Block *src, int n) {
-	// These weights translate alpha1/alpha2 to fixed 8.8 point, pre-divided by 7.
-	int weight1 = ((7 - n) << 8) / 7;
-	int weight2 = (n << 8) / 7;
-	return (u8)((src->alpha1 * weight1 + src->alpha2 * weight2 + 255) >> 8);
+	// These weights multiple alpha1/alpha2 to fixed 8.8 point.
+	int alpha1 = (src->alpha1 * ((7 - n) << 8)) / 7;
+	int alpha2 = (src->alpha2 * (n << 8)) / 7;
+	return (u8)((alpha1 + alpha2 + 31) >> 8);
 }
 
 static inline u8 lerp6(const DXT5Block *src, int n) {
-	int weight1 = ((5 - n) << 8) / 5;
-	int weight2 = (n << 8) / 5;
-	return (u8)((src->alpha1 * weight1 + src->alpha2 * weight2 + 255) >> 8);
+	int alpha1 = (src->alpha1 * ((5 - n) << 8)) / 5;
+	int alpha2 = (src->alpha2 * (n << 8)) / 5;
+	return (u8)((alpha1 + alpha2 + 31) >> 8);
 }
 
 void DXTDecoder::DecodeAlphaDXT5(const DXT5Block *src) {
-	// TODO: Check if alpha is still not 100% correct.
 	alpha_[0] = src->alpha1;
 	alpha_[1] = src->alpha2;
 	if (alpha_[0] > alpha_[1]) {
@@ -460,7 +459,6 @@ void DecodeDXT3Block(u32 *dst, const DXT3Block *src, int pitch, int height) {
 	dxt.WriteColorsDXT3(dst, src, pitch, height);
 }
 
-// The alpha channel is not 100% correct 
 void DecodeDXT5Block(u32 *dst, const DXT5Block *src, int pitch, int height) {
 	DXTDecoder dxt;
 	dxt.DecodeColors(&src->color, true);

--- a/GPU/Common/TextureDecoder.h
+++ b/GPU/Common/TextureDecoder.h
@@ -92,6 +92,10 @@ void DecodeDXT1Block(u32 *dst, const DXT1Block *src, int pitch, int height, bool
 void DecodeDXT3Block(u32 *dst, const DXT3Block *src, int pitch, int height);
 void DecodeDXT5Block(u32 *dst, const DXT5Block *src, int pitch, int height);
 
+uint32_t GetDXT1Texel(const DXT1Block *src, int x, int y);
+uint32_t GetDXT3Texel(const DXT3Block *src, int x, int y);
+uint32_t GetDXT5Texel(const DXT5Block *src, int x, int y);
+
 static const u8 textureBitsPerPixel[16] = {
 	16,  //GE_TFMT_5650,
 	16,  //GE_TFMT_5551,

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -379,27 +379,21 @@ inline static Nearest4 SampleNearest(int u[N], int v[N], const u8 *srcptr, int t
 	case GE_TFMT_DXT1:
 		for (int i = 0; i < N; ++i) {
 			const DXT1Block *block = (const DXT1Block *)srcptr + (v[i] / 4) * (texbufw / 4) + (u[i] / 4);
-			u32 data[4 * 4];
-			DecodeDXT1Block(data, block, 4, 4, false);
-			res.v[i] = data[4 * (v[i] % 4) + (u[i] % 4)];
+			res.v[i] = GetDXT1Texel(block, u[i] % 4, v[i] % 4);
 		}
 		return res;
 
 	case GE_TFMT_DXT3:
 		for (int i = 0; i < N; ++i) {
 			const DXT3Block *block = (const DXT3Block *)srcptr + (v[i] / 4) * (texbufw / 4) + (u[i] / 4);
-			u32 data[4 * 4];
-			DecodeDXT3Block(data, block, 4, 4);
-			res.v[i] = data[4 * (v[i] % 4) + (u[i] % 4)];
+			res.v[i] = GetDXT3Texel(block, u[i] % 4, v[i] % 4);
 		}
 		return res;
 
 	case GE_TFMT_DXT5:
 		for (int i = 0; i < N; ++i) {
 			const DXT5Block *block = (const DXT5Block *)srcptr + (v[i] / 4) * (texbufw / 4) + (u[i] / 4);
-			u32 data[4 * 4];
-			DecodeDXT5Block(data, block, 4, 4);
-			res.v[i] = data[4 * (v[i] % 4) + (u[i] % 4)];
+			res.v[i] = GetDXT5Texel(block, u[i] % 4, v[i] % 4);
 		}
 		return res;
 


### PR DESCRIPTION
For a while, alpha values have been slightly wrong (typically just off by one) for some DXT5 textures.

More of a correctness fix, but this adjusts the weighting to match PSP texture decoding per tests.  Also made softgpu decode one pixel at a time, which improved #14168 from 25% to 30% (could still implement in samplerjit now that it's accurate.)

-[Unknown]