### PR TITLE
Use a view for the chat log

### DIFF
--- a/UI/ChatScreen.cpp
+++ b/UI/ChatScreen.cpp
@@ -84,8 +84,6 @@ void ChatMenu::CreateSubviews(const Bounds &screenBounds) {
 
 		CreateContents(box_);
 	}
-	chatScreenVisible = true;
-	newChat = 0;
 
 	UpdateChat();
 }
@@ -179,6 +177,9 @@ void ChatMenu::Update() {
 		updateChatScreen = false;
 	}
 
+	chatScreenVisible = true;
+	newChat = 0;
+
 #if defined(USING_WIN_UI)
 	// Could remove the fullscreen check here, it works now.
 	if (promptInput_ && g_Config.bBypassOSKWithKeyboard && !g_Config.bFullScreen) {
@@ -197,10 +198,10 @@ bool ChatMenu::SubviewFocused(UI::View *view) {
 		return false;
 
 	promptInput_ = true;
-
 	return true;
 }
 
-ChatMenu::~ChatMenu() {
+void ChatMenu::Close() {
+	SetVisibility(UI::V_GONE);
 	chatScreenVisible = false;
 }

--- a/UI/ChatScreen.cpp
+++ b/UI/ChatScreen.cpp
@@ -15,7 +15,7 @@
 #include "Core/HLE/proAdhoc.h"
 #include "UI/ChatScreen.h"
 
-void ChatMenu::CreatePopupContents(UI::ViewGroup *parent) {
+void ChatMenu::CreateContents(UI::ViewGroup *parent) {
 	using namespace UI;
 	auto n = GetI18NCategory("Networking");
 	LinearLayout *outer = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT,400));
@@ -53,37 +53,31 @@ void ChatMenu::CreatePopupContents(UI::ViewGroup *parent) {
 	parent->Add(outer);
 }
 
-void ChatMenu::CreateViews() {
+void ChatMenu::CreateSubviews(const Bounds &screenBounds) {
 	using namespace UI;
 
 	auto n = GetI18NCategory("Networking");
-	UIContext &dc = *screenManager()->getUIContext();
-
-	AnchorLayout *anchor = new AnchorLayout(new LayoutParams(FILL_PARENT, FILL_PARENT));
-	anchor->Overflow(false);
-	root_ = anchor;
-
-	float yres = screenManager()->getUIContext()->GetBounds().h;
+	float width = 550.0f;
 
 	switch (g_Config.iChatScreenPosition) {
 	// the chat screen size is still static 280x240 need a dynamic size based on device resolution 
 	case 0:
-		box_ = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(PopupWidth(), FillVertical() ? yres - 30 : WRAP_CONTENT, 280, NONE, NONE, 240, true));
+		box_ = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(width, WRAP_CONTENT, 280, NONE, NONE, 240, true));
 		break;
 	case 1:
-		box_ = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(PopupWidth(), FillVertical() ? yres - 30 : WRAP_CONTENT, dc.GetBounds().centerX(), NONE, NONE, 240, true));
+		box_ = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(width, WRAP_CONTENT, screenBounds.centerX(), NONE, NONE, 240, true));
 		break;
 	case 2:
-		box_ = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(PopupWidth(), FillVertical() ? yres - 30 : WRAP_CONTENT, NONE, NONE, 280, 240, true));
+		box_ = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(width, WRAP_CONTENT, NONE, NONE, 280, 240, true));
 		break;
 	case 3:
-		box_ = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(PopupWidth(), FillVertical() ? yres - 30 : WRAP_CONTENT, 280, 240, NONE, NONE, true));
+		box_ = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(width, WRAP_CONTENT, 280, 240, NONE, NONE, true));
 		break;
 	case 4:
-		box_ = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(PopupWidth(), FillVertical() ? yres - 30 : WRAP_CONTENT, dc.GetBounds().centerX(), 240, NONE, NONE, true));
+		box_ = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(width, WRAP_CONTENT, screenBounds.centerX(), 240, NONE, NONE, true));
 		break;
 	case 5:
-		box_ = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(PopupWidth(), FillVertical() ? yres - 30 : WRAP_CONTENT, NONE, 240, 280, NONE, true));
+		box_ = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(width, WRAP_CONTENT, NONE, 240, 280, NONE, true));
 		break;
 	default:
 		box_ = nullptr;
@@ -91,33 +85,19 @@ void ChatMenu::CreateViews() {
 	}
 
 	if (box_) {
-		root_->Add(box_);
+		Add(box_);
 		box_->SetBG(UI::Drawable(0x99303030));
 		box_->SetHasDropShadow(false);
 
 		View *title = new PopupHeader(n->T("Chat"));
 		box_->Add(title);
 
-		CreatePopupContents(box_);
-#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI) || defined(SDL)
-		UI::EnableFocusMovement(true);
-		root_->SetDefaultFocusView(box_);
-		box_->SubviewFocused(chatEdit_);
-		root_->SetFocus();
-#else
-		//root_->SetDefaultFocusView(box_);
-		//box_->SubviewFocused(scroll_);
-		//root_->SetFocus();
-#endif
+		CreateContents(box_);
 	}
 	chatScreenVisible = true;
 	newChat = 0;
 
 	UpdateChat();
-}
-
-void ChatMenu::dialogFinished(const Screen *dialog, DialogResult result) {
-	UpdateUIState(UISTATE_INGAME);
 }
 
 UI::EventReturn ChatMenu::OnSubmit(UI::EventParams &e) {
@@ -195,20 +175,8 @@ void ChatMenu::UpdateChat() {
 	}
 }
 
-bool ChatMenu::touch(const TouchInput &touch) {
-	if (!box_ || (touch.flags & TOUCH_DOWN) == 0) {
-		return UIDialogScreen::touch(touch);
-	}
-
-	if (!box_->GetBounds().Contains(touch.x, touch.y)){
-		screenManager()->finishDialog(this, DR_BACK);
-	}
-
-	return UIDialogScreen::touch(touch);
-}
-
-void ChatMenu::update() {
-	PopupScreen::update();
+void ChatMenu::Update() {
+	AnchorLayout::Update();
 	if (scroll_ && toBottom_) {
 		toBottom_ = false;
 		scroll_->ScrollToBottom();

--- a/UI/ChatScreen.h
+++ b/UI/ChatScreen.h
@@ -10,6 +10,7 @@ public:
 	}
 	~ChatMenu();
 	void Update() override;
+	bool SubviewFocused(UI::View *view) override;
 
 	bool Contains(float x, float y) const {
 		if (box_)
@@ -37,4 +38,5 @@ private:
 	UI::ViewGroup *box_ = nullptr;
 
 	bool toBottom_ = true;
+	bool promptInput_ = false;
 };

--- a/UI/ChatScreen.h
+++ b/UI/ChatScreen.h
@@ -3,20 +3,25 @@
 #include "ppsspp_config.h"
 #include "Common/UI/UIScreen.h"
 
-class ChatMenu : public PopupScreen {
+class ChatMenu : public UI::AnchorLayout {
 public:
-	ChatMenu(): PopupScreen("Chat") {}
+	ChatMenu(const Bounds &screenBounds, UI::LayoutParams *lp = nullptr): UI::AnchorLayout(lp) {
+		CreateSubviews(screenBounds);
+	}
 	~ChatMenu();
-	void CreatePopupContents(UI::ViewGroup *parent) override;
-	void CreateViews() override;
-	void dialogFinished(const Screen *dialog, DialogResult result) override;
-	bool touch(const TouchInput &touch) override;
-	void update() override;
-	void UpdateChat();
+	void Update() override;
 
-	bool toBottom_ = true;
+	bool Contains(float x, float y) const {
+		if (box_)
+			return box_->GetBounds().Contains(x, y);
+		return false;
+	}
 
 private:
+	void CreateSubviews(const Bounds &screenBounds);
+	void CreateContents(UI::ViewGroup *parent);
+	void UpdateChat();
+
 	UI::EventReturn OnSubmit(UI::EventParams &e);
 	UI::EventReturn OnQuickChat1(UI::EventParams &e);
 	UI::EventReturn OnQuickChat2(UI::EventParams &e);
@@ -30,4 +35,6 @@ private:
 	UI::ScrollView *scroll_ = nullptr;
 	UI::LinearLayout *chatVert_ = nullptr;
 	UI::ViewGroup *box_ = nullptr;
+
+	bool toBottom_ = true;
 };

--- a/UI/ChatScreen.h
+++ b/UI/ChatScreen.h
@@ -8,9 +8,10 @@ public:
 	ChatMenu(const Bounds &screenBounds, UI::LayoutParams *lp = nullptr): UI::AnchorLayout(lp) {
 		CreateSubviews(screenBounds);
 	}
-	~ChatMenu();
 	void Update() override;
 	bool SubviewFocused(UI::View *view) override;
+
+	void Close();
 
 	bool Contains(float x, float y) const {
 		if (box_)

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -542,7 +542,7 @@ bool EmuScreen::touch(const TouchInput &touch) {
 	Core_NotifyActivity();
 
 	if (chatMenu_ && (touch.flags & TOUCH_DOWN) != 0 && !chatMenu_->Contains(touch.x, touch.y)) {
-		chatMenu_->SetVisibility(UI::V_GONE);
+		chatMenu_->Close();
 		if (chatButton_)
 			chatButton_->SetVisibility(UI::V_VISIBLE);
 		UI::EnableFocusMovement(false);
@@ -738,7 +738,7 @@ bool EmuScreen::key(const KeyInput &key) {
 	if (UI::IsFocusMovementEnabled()) {
 		if ((key.flags & KEY_DOWN) != 0 && UI::IsEscapeKey(key)) {
 			if (chatMenu_)
-				chatMenu_->SetVisibility(UI::V_GONE);
+				chatMenu_->Close();
 			if (chatButton_)
 				chatButton_->SetVisibility(UI::V_VISIBLE);
 			UI::EnableFocusMovement(false);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -728,6 +728,12 @@ void EmuScreen::onVKeyUp(int virtualKeyCode) {
 bool EmuScreen::key(const KeyInput &key) {
 	Core_NotifyActivity();
 
+	if (UI::IsFocusMovementEnabled()) {
+		if (UIScreen::key(key)) {
+			return true;
+		}
+	}
+
 	return controlMapper_.Key(key, &pauseTrigger_);
 }
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -952,7 +952,12 @@ UI::EventReturn EmuScreen::OnChat(UI::EventParams &params) {
 #if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI) || defined(SDL)
 		UI::EnableFocusMovement(true);
 		root_->SetDefaultFocusView(chatMenu_);
+
 		chatMenu_->SetFocus();
+		UI::View *focused = UI::GetFocusedView();
+		if (focused) {
+			root_->SubviewFocused(focused);
+		}
 #endif
 	}
 	return UI::EVENT_DONE;

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -33,6 +33,7 @@ struct AxisInput;
 
 class AsyncImageFileView;
 class OnScreenMessagesView;
+class ChatMenu;
 
 class EmuScreen : public UIScreen {
 public:
@@ -101,6 +102,7 @@ private:
 	UI::Button *resumeButton_ = nullptr;
 	UI::Button *resetButton_ = nullptr;
 	UI::View *chatButton_ = nullptr;
+	ChatMenu *chatMenu_ = nullptr;
 
 	UI::Button *cardboardDisableButton_ = nullptr;
 	OnScreenMessagesView *onScreenMessagesView_ = nullptr;


### PR DESCRIPTION
This changes the chat log from a popup screen to a view.  This probably makes more sense, since it will interfere with EmuScreen likely less, and it had already overridden a lot of PopupScreen anyway.

I couldn't reproduce #14723 (tried some display layout editor changes, etc. but didn't spend a lot of time trying), but I could imagine problems due to the preRender/etc. pairing for pop ups.  This seems safer.  Maybe the bug is caused by rotation or something.

-[Unknown]