### PR TITLE
Vulkan: Expand 16-bit textures to generate mips

### DIFF
--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -757,8 +757,10 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 	if (g_Config.iTexFiltering == TEX_FILTER_AUTO_MAX_QUALITY) {
 		// Boost the number of mipmaps.
 		int maxPossibleMipmaps = log2i(std::min(gstate.getTextureWidth(0), gstate.getTextureHeight(0)));
-		maxLevelToGenerate = maxPossibleMipmaps;
-		dstFmt = VK_FORMAT_R8G8B8A8_UNORM;
+		if (maxPossibleMipmaps > maxLevelToGenerate) {
+			maxLevelToGenerate = maxPossibleMipmaps;
+			dstFmt = VK_FORMAT_R8G8B8A8_UNORM;
+		}
 	}
 
 	int scaleFactor = standardScaleFactor_;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -754,10 +754,11 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 	VkFormat dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
 
 	// TODO: Really should inspect the format capabilities.
-	if (g_Config.iTexFiltering == TEX_FILTER_AUTO_MAX_QUALITY && dstFmt == VK_FORMAT_R8G8B8A8_UNORM) {
+	if (g_Config.iTexFiltering == TEX_FILTER_AUTO_MAX_QUALITY) {
 		// Boost the number of mipmaps.
 		int maxPossibleMipmaps = log2i(std::min(gstate.getTextureWidth(0), gstate.getTextureHeight(0)));
 		maxLevelToGenerate = maxPossibleMipmaps;
+		dstFmt = VK_FORMAT_R8G8B8A8_UNORM;
 	}
 
 	int scaleFactor = standardScaleFactor_;
@@ -1092,7 +1093,7 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 			decPitch = w * bpp;
 		}
 
-		bool expand32 = !gstate_c.Supports(GPU_SUPPORTS_16BIT_FORMATS);
+		bool expand32 = !gstate_c.Supports(GPU_SUPPORTS_16BIT_FORMATS) || dstFmt == VK_FORMAT_R8G8B8A8_UNORM;
 		DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, false, expand32);
 		gpuStats.numTexturesDecoded++;
 


### PR DESCRIPTION
When using "Auto Max Quality", we can't use 16-bit formats.  See #14804.

I know disabling was a quick fix, but allowing them and converting to 32 bit isn't hard either.  The TODO still applies as far as checking format support to allow 16-bit.

-[Unknown]