### PR TITLE
Unix: Use shm_open in case not /dev/shm/

### DIFF
--- a/Common/MemArena.h
+++ b/Common/MemArena.h
@@ -53,6 +53,6 @@ private:
 	size_t vm_size;
 	vm_address_t vm_mem;  // same type as vm_address_t
 #else
-	int fd;
+	int fd = -1;
 #endif
 };


### PR DESCRIPTION
Still falls back to the old behavior if that fails.  Using shm_open should ensure we use shm and no disk io on more systems.

Someone had suggested a concern that someone playing two instances locally might use a script/frontend to start multiple instances at nearly the same time.  This should atomically open a separate file in that case.

-[Unknown]