### PR TITLE
Fix chat

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -948,6 +948,7 @@ UI::EventReturn EmuScreen::OnChat(UI::EventParams &params) {
 	}
 	if (chatMenu_ != nullptr) {
 		chatMenu_->SetVisibility(UI::V_VISIBLE);
+		updateChatScreen = true;
 
 #if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI) || defined(SDL)
 		UI::EnableFocusMovement(true);


### PR DESCRIPTION
`updateChatScreen` is set by `proAdHoc` only if chat screen is visible.

Before #14841 when pressing chat button a new popup was created and so the chat was updated anyway, but after that it just change it's visibility so when you open the chat screen it never get the update.

I wonder if this was the cause of https://github.com/hrydgard/ppsspp/issues/14723#issuecomment-919301846.