### PR TITLE
Decouple chat presentation and tracking

### DIFF
--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -115,8 +115,6 @@ std::vector<std::string> chatLog;
 std::string name = "";
 std::string incoming = "";
 std::string message = "";
-bool chatScreenVisible = false;
-int newChat = 0;
 bool isOriPort = false;
 bool isLocalServer = false;
 SockAddrIN4 g_adhocServerIP;
@@ -125,6 +123,7 @@ sockaddr LocalIP;
 int defaultWlanChannel = PSP_SYSTEMPARAM_ADHOC_CHANNEL_11; // Don't put 0(Auto) here, it needed to be a valid/actual channel number
 
 static int chatMessageGeneration = 0;
+static int chatMessageCount = 0;
 
 bool isMacMatch(const SceNetEtherAddr* addr1, const SceNetEtherAddr* addr2) {
 	// Ignoring the 1st byte since there are games (ie. Gran Turismo) who tamper with the 1st byte of OUI to change the unicast/multicast bit
@@ -1325,6 +1324,10 @@ int GetChatChangeID() {
 	return chatMessageGeneration;
 }
 
+int GetChatMessageCount() {
+	return chatMessageCount;
+}
+
 int friendFinder(){
 	SetCurrentThreadName("FriendFinder");
 	auto n = GetI18NCategory("Networking");
@@ -1522,11 +1525,7 @@ int friendFinder(){
 						incoming.append((char*)packet->base.message);
 						chatLog.push_back(incoming);
 						chatMessageGeneration++;
-						if (!chatScreenVisible) {
-							if (newChat < 50) {
-								newChat += 1;
-							}
-						}
+						chatMessageCount++;
 
 						// Move RX Buffer
 						memmove(rx, rx + sizeof(SceNetAdhocctlChatPacketS2C), sizeof(rx) - sizeof(SceNetAdhocctlChatPacketS2C));

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -116,7 +116,6 @@ std::string name = "";
 std::string incoming = "";
 std::string message = "";
 bool chatScreenVisible = false;
-bool updateChatScreen = false;
 int newChat = 0;
 bool isOriPort = false;
 bool isLocalServer = false;
@@ -124,6 +123,8 @@ SockAddrIN4 g_adhocServerIP;
 SockAddrIN4 g_localhostIP;
 sockaddr LocalIP;
 int defaultWlanChannel = PSP_SYSTEMPARAM_ADHOC_CHANNEL_11; // Don't put 0(Auto) here, it needed to be a valid/actual channel number
+
+static int chatMessageGeneration = 0;
 
 bool isMacMatch(const SceNetEtherAddr* addr1, const SceNetEtherAddr* addr2) {
 	// Ignoring the 1st byte since there are games (ie. Gran Turismo) who tamper with the 1st byte of OUI to change the unicast/multicast bit
@@ -1290,8 +1291,7 @@ void sendChat(std::string chatString) {
 	auto n = GetI18NCategory("Networking");
 	chat.base.opcode = OPCODE_CHAT;
 	//TODO check network inited, check send success or not, chatlog.pushback error on failed send, pushback error on not connected
-	if (friendFinderRunning)
-	{
+	if (friendFinderRunning) {
 		// Send Chat to Server 
 		if (!chatString.empty()) {
 			//maximum char allowed is 64 character for compability with original server (pro.coldbird.net)
@@ -1303,17 +1303,12 @@ void sendChat(std::string chatString) {
 				NOTICE_LOG(SCENET, "Send Chat %s to Adhoc Server", chat.message);
 				name = g_Config.sNickName.c_str();
 				chatLog.push_back(name.substr(0, 8) + ": " + chat.message);
-				if (chatScreenVisible) {
-					updateChatScreen = true;
-				}
+				chatMessageGeneration++;
 			}
 		}
-	}
-	else {
+	} else {
 		chatLog.push_back(n->T("You're in Offline Mode, go to lobby or online hall"));
-		if (chatScreenVisible) {
-			updateChatScreen = true;
-		}
+		chatMessageGeneration++;
 	}
 }
 
@@ -1324,6 +1319,10 @@ std::vector<std::string> getChatLog() {
 		chatLog.erase(chatLog.begin(), chatLog.begin() + 40);
 	}
 	return chatLog;
+}
+
+int GetChatChangeID() {
+	return chatMessageGeneration;
 }
 
 int friendFinder(){
@@ -1522,11 +1521,8 @@ int friendFinder(){
 						incoming.append(": ");
 						incoming.append((char*)packet->base.message);
 						chatLog.push_back(incoming);
-						//im new to pointer btw :( doesn't know its safe or not this should update the chat screen when data coming
-						if (chatScreenVisible) {
-							updateChatScreen = true;
-						}
-						else {
+						chatMessageGeneration++;
+						if (!chatScreenVisible) {
 							if (newChat < 50) {
 								newChat += 1;
 							}
@@ -1598,10 +1594,7 @@ int friendFinder(){
 						//do we need ip?
 						//joined.append((char *)packet->ip);
 						chatLog.push_back(incoming);
-						//im new to pointer btw :( doesn't know its safe or not this should update the chat screen when data coming
-						if (chatScreenVisible) {
-							updateChatScreen = true;
-						}
+						chatMessageGeneration++;
 
 #ifdef LOCALHOST_AS_PEER
 						setUserCount(getActivePeerCount());

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -1016,9 +1016,7 @@ void addFriend(SceNetAdhocctlConnectPacketS2C * packet);
 void sendChat(std::string chatString);
 std::vector<std::string> getChatLog();
 int GetChatChangeID();
-
-extern bool chatScreenVisible;
-extern int newChat;
+int GetChatMessageCount();
 
 /*
  * Find a Peer/Friend by MAC address

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -1015,8 +1015,9 @@ void addFriend(SceNetAdhocctlConnectPacketS2C * packet);
 */
 void sendChat(std::string chatString);
 std::vector<std::string> getChatLog();
+int GetChatChangeID();
+
 extern bool chatScreenVisible;
-extern bool updateChatScreen;
 extern int newChat;
 
 /*

--- a/UI/ChatScreen.cpp
+++ b/UI/ChatScreen.cpp
@@ -172,9 +172,9 @@ void ChatMenu::Update() {
 		scroll_->ScrollToBottom();
 	}
 
-	if (updateChatScreen) {
+	if (chatChangeID_ != GetChatChangeID()) {
+		chatChangeID_ = GetChatChangeID();
 		UpdateChat();
-		updateChatScreen = false;
 	}
 
 	chatScreenVisible = true;

--- a/UI/ChatScreen.cpp
+++ b/UI/ChatScreen.cpp
@@ -177,9 +177,6 @@ void ChatMenu::Update() {
 		UpdateChat();
 	}
 
-	chatScreenVisible = true;
-	newChat = 0;
-
 #if defined(USING_WIN_UI)
 	// Could remove the fullscreen check here, it works now.
 	if (promptInput_ && g_Config.bBypassOSKWithKeyboard && !g_Config.bFullScreen) {
@@ -203,5 +200,4 @@ bool ChatMenu::SubviewFocused(UI::View *view) {
 
 void ChatMenu::Close() {
 	SetVisibility(UI::V_GONE);
-	chatScreenVisible = false;
 }

--- a/UI/ChatScreen.h
+++ b/UI/ChatScreen.h
@@ -38,6 +38,7 @@ private:
 	UI::LinearLayout *chatVert_ = nullptr;
 	UI::ViewGroup *box_ = nullptr;
 
+	int chatChangeID_ = 0;
 	bool toBottom_ = true;
 	bool promptInput_ = false;
 };

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -862,7 +862,7 @@ void EmuScreen::CreateViews() {
 			break;
 		}
 
-		ChoiceWithValueDisplay *btn = new ChoiceWithValueDisplay(&newChat, n->T("Chat"), layoutParams);
+		ChoiceWithValueDisplay *btn = new ChoiceWithValueDisplay(&newChatMessages_, n->T("Chat"), layoutParams);
 		root_->Add(btn)->OnClick.Handle(this, &EmuScreen::OnChat);
 		chatButton_ = btn;
 		chatMenu_ = root_->Add(new ChatMenu(screenManager()->getUIContext()->GetBounds(), new LayoutParams(FILL_PARENT, FILL_PARENT)));
@@ -986,6 +986,18 @@ void EmuScreen::update() {
 	onScreenMessagesView_->SetVisibility(g_Config.bShowOnScreenMessages ? V_VISIBLE : V_GONE);
 	resumeButton_->SetVisibility(coreState == CoreState::CORE_RUNTIME_ERROR && Memory::MemFault_MayBeResumable() ? V_VISIBLE : V_GONE);
 	resetButton_->SetVisibility(coreState == CoreState::CORE_RUNTIME_ERROR ? V_VISIBLE : V_GONE);
+
+	if (chatButton_ && chatMenu_) {
+		if (chatMenu_->GetVisibility() != V_GONE) {
+			chatMessages_ = GetChatMessageCount();
+			newChatMessages_ = 0;
+		} else {
+			int diff = GetChatMessageCount() - chatMessages_;
+			chatMessages_ += diff;
+			// Cap the count at 50.
+			newChatMessages_ = diff > 50 ? 50 : diff;
+		}
+	}
 
 	if (bootPending_) {
 		bootGame(gamePath_);

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -86,6 +86,10 @@ private:
 	// If set, pauses at the end of the frame.
 	bool pauseTrigger_ = false;
 
+	// The last read chat message count, and how many new ones there are.
+	int chatMessages_ = 0;
+	int newChatMessages_ = 0;
+
 	// In-memory save state used for freezeFrame, which is useful for debugging.
 	std::vector<u8> freezeState_;
 


### PR DESCRIPTION
A few benefits to this model:
 * Possibly multiple parts of the UI could listen to chat messages - for example, an audio cue or app badge, etc.
 * There seemed to be threading concerns depending on when exactly people chat before, this cleans that up.
 * UI visibility no longer part of the equation for the tracking side - less likely to have bugs like #14723 in the future.

Alternative to #14854 (sorry), but good catch on the cause, thanks.  Closes #14854.

-[Unknown]