### PR TITLE
GPU: Default vertex cache to off

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -795,10 +795,6 @@ bool Config::IsBackendEnabled(GPUBackend backend, bool validate) {
 	return true;
 }
 
-static bool DefaultVertexCache() {
-	return DefaultGPUBackend() == (int)GPUBackend::OPENGL;
-}
-
 template <typename T, std::string (*FTo)(T), T (*FFrom)(const std::string &)>
 struct ConfigTranslator {
 	static std::string To(int v) {
@@ -875,7 +871,7 @@ static ConfigSetting graphicsSettings[] = {
 	// Most low-performance (and many high performance) mobile GPUs do not support aniso anyway so defaulting to 4 is fine.
 	ConfigSetting("AnisotropyLevel", &g_Config.iAnisotropyLevel, 4, true, true),
 
-	ReportedConfigSetting("VertexDecCache", &g_Config.bVertexCache, &DefaultVertexCache, true, true),
+	ReportedConfigSetting("VertexDecCache", &g_Config.bVertexCache, false, true, true),
 	ReportedConfigSetting("TextureBackoffCache", &g_Config.bTextureBackoffCache, false, true, true),
 	ReportedConfigSetting("TextureSecondaryCache", &g_Config.bTextureSecondaryCache, false, true, true),
 	ReportedConfigSetting("VertexDecJit", &g_Config.bVertexDecoderJit, &DefaultCodeGen, false),

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -381,7 +381,7 @@ int main(int argc, const char* argv[])
 	g_Config.iRenderingMode = FB_BUFFERED_MODE;
 	g_Config.bHardwareTransform = true;
 	g_Config.iAnisotropyLevel = 0;  // When testing mipmapping we really don't want this.
-	g_Config.bVertexCache = true;
+	g_Config.bVertexCache = false;
 	g_Config.iLanguage = PSP_SYSTEMPARAM_LANGUAGE_ENGLISH;
 	g_Config.iTimeFormat = PSP_SYSTEMPARAM_TIME_FORMAT_24HR;
 	g_Config.bEncryptSave = true;


### PR DESCRIPTION
Previously, it was defaulted on only for OpenGL, where it didn't work.  I don't think that makes a lot of sense, and it makes sense to just default it off for everyone.

It's definitely a source of glitches when on.

-[Unknown]