### PR TITLE
GLES: Re-enable vertex cache

### DIFF
--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -352,9 +352,6 @@ void DrawEngineGLES::DoFlush() {
 		if (g_Config.bSoftwareSkinning && (lastVType_ & GE_VTYPE_WEIGHT_MASK))
 			useCache = false;
 
-		// TEMPORARY
-		useCache = false;
-
 		if (useCache) {
 			u32 id = dcid_ ^ gstate.getUVGenMode();  // This can have an effect on which UV decoder we need to use! And hence what the decoded data will look like. See #9263
 			vai = vai_.Get(id);


### PR DESCRIPTION
Was accidentally left disabled during GL threading effort.  See comment in #12969.

In some ways, I want to remove it, but I don't think it's an awful feature especially for 3D games...

-[Unknown]