### PR TITLE
Disable auto-enable chat on ctrl-c, fix enabling

### DIFF
--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -657,7 +657,10 @@ void MainWindow::createMenus()
 	gameSettingsMenu->add(new MenuAction(this, SLOT(cheatsAct()),   QT_TR_NOOP("Enable &cheats"), Qt::CTRL + Qt::Key_T))
 		->addEventChecked(&g_Config.bEnableCheats);
 	gameSettingsMenu->addSeparator();
-	gameSettingsMenu->add(new MenuAction(this, SLOT(chatAct()),   QT_TR_NOOP("Enable chat"), Qt::CTRL + Qt::Key_C));
+	gameSettingsMenu->add(new MenuAction(this, SLOT(chatAct()),   QT_TR_NOOP("Open chat"), Qt::CTRL + Qt::Key_C))
+		->SetEnabledFunc([=]() {
+			return g_Config.bEnableNetworkChat && GetUIState() == UISTATE_INGAME;
+		});
 
 	// Help
 	MenuTree* helpMenu = new MenuTree(this, menuBar(),    QT_TR_NOOP("&Help"));

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -488,25 +488,23 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 			gstate_c.skipDrawReason &= ~SKIPDRAW_WINDOW_MINIMIZED;
 		}
 	} else if (!strcmp(message, "chat screen")) {
-		if (!chatButton_)
-			RecreateViews();
+		if (g_Config.bEnableNetworkChat) {
+			if (!chatButton_)
+				RecreateViews();
 
 #if defined(USING_WIN_UI)
-		//temporary workaround for hotkey its freeze the ui when open chat screen using hotkey and native keyboard is enable
-		if (g_Config.bBypassOSKWithKeyboard) {
-			osm.Show("Disable windows native keyboard options to use ctrl + c hotkey", 2.0f);
-		} else {
-			if (g_Config.bEnableNetworkChat) {
+			//temporary workaround for hotkey its freeze the ui when open chat screen using hotkey and native keyboard is enable
+			if (g_Config.bBypassOSKWithKeyboard) {
+				osm.Show("Disable windows native keyboard options to use ctrl + c hotkey", 2.0f);
+			} else {
 				UI::EventParams e{};
 				OnChatMenu.Trigger(e);
 			}
-		}
 #else
-		if (g_Config.bEnableNetworkChat) {
 			UI::EventParams e{};
 			OnChatMenu.Trigger(e);
-		}
 #endif
+		}
 	} else if (!strcmp(message, "app_resumed") && screenManager()->topScreen() == this) {
 		if (System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_TV) {
 			if (!KeyMap::IsKeyMapped(DEVICE_ID_PAD_0, VIRTKEY_PAUSE) || !KeyMap::IsKeyMapped(DEVICE_ID_PAD_1, VIRTKEY_PAUSE)) {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -488,6 +488,8 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 			gstate_c.skipDrawReason &= ~SKIPDRAW_WINDOW_MINIMIZED;
 		}
 	} else if (!strcmp(message, "chat screen")) {
+		if (!chatButton_)
+			RecreateViews();
 
 #if defined(USING_WIN_UI)
 		//temporary workaround for hotkey its freeze the ui when open chat screen using hotkey and native keyboard is enable

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -80,6 +80,7 @@ namespace MainWindow {
 		EnableMenuItem(menu, ID_EMULATION_STOP, menuEnable);
 		EnableMenuItem(menu, ID_EMULATION_RESET, menuEnable);
 		EnableMenuItem(menu, ID_EMULATION_SWITCH_UMD, umdSwitchEnable);
+		EnableMenuItem(menu, ID_EMULATION_CHAT, g_Config.bEnableNetworkChat ? menuInGameEnable : MF_GRAYED);
 		EnableMenuItem(menu, ID_TOGGLE_BREAK, menuEnable);
 		EnableMenuItem(menu, ID_DEBUG_LOADMAPFILE, menuEnable);
 		EnableMenuItem(menu, ID_DEBUG_SAVEMAPFILE, menuEnable);
@@ -636,10 +637,6 @@ namespace MainWindow {
 			osm.ShowOnOff(gr->T("Cheats"), g_Config.bEnableCheats);
 			break;
 		case ID_EMULATION_CHAT:
-			if (!g_Config.bEnableNetworkChat) {
-				g_Config.bEnableNetworkChat = true;
-				UpdateCommands();
-			}
 			if (GetUIState() == UISTATE_INGAME) {
 				NativeMessageReceived("chat screen", "");
 			}
@@ -1371,7 +1368,7 @@ namespace MainWindow {
 		static CoreState lastCoreState = CORE_BOOT_ERROR;
 
 		HMENU menu = GetMenu(GetHWND());
-		EnableMenuItem(menu, ID_DEBUG_LOG, !g_Config.bEnableLogging);
+		EnableMenuItem(menu, ID_DEBUG_LOG, g_Config.bEnableLogging ? MF_ENABLED : MF_GRAYED);
 		SetIngameMenuItemStates(menu, GetUIState());
 
 		if (lastGlobalUIState == GetUIState() && lastCoreState == coreState)
@@ -1382,7 +1379,6 @@ namespace MainWindow {
 
 		bool isPaused = Core_IsStepping() && GetUIState() == UISTATE_INGAME;
 		TranslateMenuItem(menu, ID_TOGGLE_BREAK, L"\tF8", isPaused ? "Run" : "Break");
-		TranslateMenuItem(menu, ID_EMULATION_CHAT, L"\tCtrl+C", g_Config.bEnableNetworkChat ? "Open Chat" : "Enable Chat");
 	}
 
 	void UpdateSwitchUMD() {

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -664,7 +664,7 @@ BEGIN
         MENUITEM "", 0, MFT_SEPARATOR
         MENUITEM "Enable Cheats",                       ID_EMULATION_CHEATS
         MENUITEM "", 0, MFT_SEPARATOR
-        MENUITEM "Enable Chat",                         ID_EMULATION_CHAT
+        MENUITEM "Open Chat",                           ID_EMULATION_CHAT
     END
 
     POPUP "Help",                                       ID_HELP_MENU


### PR DESCRIPTION
As commented in #14165, not clear this is really necessary to enable from the Windows menu or hotkey.  It wasn't working in previous stable releases, so I think it'd be good to fix this before v1.12.0.

That said, I didn't want to break Qt, so left it there.  Now it will properly update the screen and show the chat right away when enabling, which fixes #13090.

-[Unknown]