### PR TITLE
Fix chat here position and jumpy ip resolve feedback

### DIFF
--- a/UI/ChatScreen.cpp
+++ b/UI/ChatScreen.cpp
@@ -19,7 +19,7 @@ void ChatMenu::CreateContents(UI::ViewGroup *parent) {
 	using namespace UI;
 	auto n = GetI18NCategory("Networking");
 	LinearLayout *outer = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT,400));
-	scroll_ = outer->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(1.0)));
+	scroll_ = outer->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT, 1.0)));
 	LinearLayout *bottom = outer->Add(new LinearLayout(ORIENT_HORIZONTAL, new LayoutParams(FILL_PARENT, WRAP_CONTENT)));
 #if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI) || defined(SDL)
 	chatEdit_ = bottom->Add(new TextEdit("", n->T("Chat message"), n->T("Chat Here"), new LinearLayoutParams(1.0)));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1858,12 +1858,8 @@ void HostnameSelectScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	parent->Add(ipRows_);
 	listIP.clear(); listIP.shrink_to_fit();
 
-	errorView_ = parent->Add(new TextView(n->T("Invalid IP or hostname"), ALIGN_HCENTER, false, new LinearLayoutParams(Margins(0, 10, 0, 0))));
-	errorView_->SetTextColor(0xFF3030FF);
-	errorView_->SetVisibility(V_GONE);
-
 	progressView_ = parent->Add(new TextView(n->T("Validating address..."), ALIGN_HCENTER, false, new LinearLayoutParams(Margins(0, 10, 0, 0))));
-	progressView_->SetVisibility(V_GONE);
+	progressView_->SetVisibility(V_INVISIBLE);
 }
 
 void HostnameSelectScreen::SendEditKey(int keyCode, int flags) {
@@ -1950,6 +1946,8 @@ void HostnameSelectScreen::ResolverThread() {
 }
 
 bool HostnameSelectScreen::CanComplete(DialogResult result) {
+	auto n = GetI18NCategory("Networking");
+
 	if (result != DR_OK)
 		return true;
 
@@ -1981,12 +1979,12 @@ bool HostnameSelectScreen::CanComplete(DialogResult result) {
 			lastResolvedResult_ = toResolveResult_;
 
 			if (lastResolvedResult_) {
-				errorView_->SetVisibility(UI::V_GONE);
+				progressView_->SetVisibility(UI::V_INVISIBLE);
 			} else {
-				errorView_->SetVisibility(UI::V_VISIBLE);
+				progressView_->SetText(n->T("Invalid IP or hostname"));
+				progressView_->SetTextColor(0xFF3030FF);
+				progressView_->SetVisibility(UI::V_VISIBLE);
 			}
-			progressView_->SetVisibility(UI::V_GONE);
-
 			return true;
 		}
 
@@ -1998,8 +1996,9 @@ bool HostnameSelectScreen::CanComplete(DialogResult result) {
 	toResolve_ = value;
 	resolverCond_.notify_one();
 
+	progressView_->SetText(n->T("Validating address..."));
+	progressView_->SetTextColor(0xFFFFFFFF);
 	progressView_->SetVisibility(UI::V_VISIBLE);
-	errorView_->SetVisibility(UI::V_GONE);
 
 	return false;
 }

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -213,7 +213,6 @@ private:
 
 	std::string *value_;
 	UI::TextEdit *addrView_ = nullptr;
-	UI::TextView *errorView_ = nullptr;
 	UI::TextView *progressView_ = nullptr;
 	UI::LinearLayout *ipRows_ = nullptr;
 


### PR DESCRIPTION
Chat input used to be at the bottom of the chat, probably got broken when ScrollView got fixed.

Also when setting IP address the progress and and error view was making all the popup resize and was kinda bad to hit the button with touch screen as they move.