### PR TITLE
Little fix to logo screen

### DIFF
--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -707,7 +707,7 @@ void LogoScreen::sendMessage(const char *message, const char *value) {
 }
 
 bool LogoScreen::key(const KeyInput &key) {
-	if (key.deviceId != DEVICE_ID_MOUSE) {
+	if (key.deviceId != DEVICE_ID_MOUSE && (key.flags & KEY_DOWN)) {
 		Next();
 		return true;
 	}


### PR DESCRIPTION
Basically `MemStickScreen` get created with `LogoScreen` below in the `ScreenManager` stack:
https://github.com/hrydgard/ppsspp/blob/e6a2da69c5dde977fecb468cc7906addfca1fb3e/UI/NativeApp.cpp#L803-L804

But `KEY_UP` get send to all layer:
https://github.com/hrydgard/ppsspp/blob/e6a2da69c5dde977fecb468cc7906addfca1fb3e/Common/UI/Screen.cpp#L97-L101

So `LogoScreen` was triggering the "skip code" and went to `MainScreen` on key up (hard to notice with a touch screen tho').