### PR TITLE
Clean up Memstick screen a bit

### DIFF
--- a/UI/MemStickScreen.h
+++ b/UI/MemStickScreen.h
@@ -55,13 +55,24 @@ protected:
 	}
 
 private:
+	void Browse();
+	void UseInternalStorage();
+	void UseStorageRoot();
+	void SetFolderManually();
+
 	// Event handlers
-	UI::EventReturn OnBrowse(UI::EventParams &e);
-	UI::EventReturn OnUseInternalStorage(UI::EventParams &params);
-	UI::EventReturn OnUseStorageRoot(UI::EventParams &params);
-	UI::EventReturn OnSetFolderManually(UI::EventParams &params);
+	UI::EventReturn OnChoiceClick(UI::EventParams &e);
+	UI::EventReturn OnContinueClick(UI::EventParams &e);
 
 	SettingInfoMessage *settingInfo_ = nullptr;
+
+	struct ChoiceStruct {
+		std::function<void()> func;
+		UI::LinearLayout *info;
+	};
+
+	std::map<UI::StickyChoice *, ChoiceStruct> choices_;
+	UI::StickyChoice *selected_ = nullptr;
 
 	bool initialSetup_;
 	bool done_ = false;


### PR DESCRIPTION
Show only the info for the current selected one, make text wrap when is too long and move the continue/back below to give more space on the side on small device (on long screen phone may be better on the side tho', not really sure).

Few previews (ignore the space on the left, just notch doing thing):
![Screenshot_20210917-011707_PPSSPP](https://user-images.githubusercontent.com/13517524/133701278-a18cb862-6869-489c-a207-0467f2152915.jpg)
![Screenshot_20210917-011717_PPSSPP](https://user-images.githubusercontent.com/13517524/133701280-a8df869c-7738-4930-a378-4693820390fc.jpg)
![Screenshot_20210917-011723_PPSSPP](https://user-images.githubusercontent.com/13517524/133701283-0784c2f4-6d69-451c-9bb6-4c94445898b2.jpg)
![Screenshot_20210917-011753_PPSSPP](https://user-images.githubusercontent.com/13517524/133701284-a26985fa-3416-4fa8-a9ad-8b89f0a9d104.jpg)

About implementation: I wanted to try to show the info right below the selected one but was really weird in the end, with this design we could use ChoiceStrip more maybe, but I gotta admit I'm bit worried about all the "choice number" code path there, probably nothing too scary but may be more bug prone (given where the choice count change a lot), not sure what's better...