### PR TITLE
[AdhocGameMode] An attempt to handle source port better on GameMode for further communication

### DIFF
--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -99,6 +99,7 @@ GameModeArea masterGameModeArea;
 std::vector<GameModeArea> replicaGameModeAreas;
 std::vector<SceNetEtherAddr> requiredGameModeMacs;
 std::vector<SceNetEtherAddr> gameModeMacs;
+std::map<SceNetEtherAddr, u16_le> gameModePeerPorts;
 
 int actionAfterAdhocMipsCall;
 int actionAfterMatchingMipsCall;

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -957,6 +957,7 @@ extern GameModeArea masterGameModeArea;
 extern std::vector<GameModeArea> replicaGameModeAreas;
 extern std::vector<SceNetEtherAddr> requiredGameModeMacs;
 extern std::vector<SceNetEtherAddr> gameModeMacs;
+extern std::map<SceNetEtherAddr, u16_le> gameModePeerPorts;
 // End of Aux vars
 
 enum AdhocConnectionType : int

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -7176,7 +7176,7 @@ int matchingInputThread(int matchingId) // TODO: The MatchingInput thread is usi
 	u64_le now;
 
 	static SceNetEtherAddr sendermac;
-	static uint16_t senderport;
+	static u32_le senderport;
 	static int rxbuflen;
 
 	// Log Startup


### PR DESCRIPTION
Similar to the one on AdhocMatching #14870, GameMode port's remapping possibility will also be detected and handled.

Test builds:
Win32&64: https://www.dropbox.com/s/2t3mtdhb0f045cn/PPSSPP_1.11-testbuild_Win32x64.zip?dl=0
Android(ARMv7): https://www.dropbox.com/s/b41bm43mtn1gpnn/PPSSPP_1.11-testbuild_ARMv7.apk?dl=0
Or download it from this PR's artifacts.