### PR TITLE
In lazy hashing mode, assume videos never match

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -160,6 +160,13 @@ static int Replace_memcpy() {
 	NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, tag.c_str(), tag.size());
 	NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, tag.c_str(), tag.size());
 
+	// It's pretty common that games will copy video data.
+	if (tag == "ReplaceMemcpy/VideoDecode" || tag == "ReplaceMemcpy/VideoDecodeRange") {
+		if (bytes == 512 * 272 * 4) {
+			gpu->NotifyVideoUpload(destPtr, bytes, 512, GE_FORMAT_8888);
+		}
+	}
+
 	return 10 + bytes / 4;  // approximation
 }
 
@@ -202,6 +209,13 @@ static int Replace_memcpy_jak() {
 	const std::string tag = "ReplaceMemcpy/" + GetMemWriteTagAt(srcPtr, bytes);
 	NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, tag.c_str(), tag.size());
 	NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, tag.c_str(), tag.size());
+
+	// It's pretty common that games will copy video data.
+	if (tag == "ReplaceMemcpy/VideoDecode" || tag == "ReplaceMemcpy/VideoDecodeRange") {
+		if (bytes == 512 * 272 * 4) {
+			gpu->NotifyVideoUpload(destPtr, bytes, 512, GE_FORMAT_8888);
+		}
+	}
 
 	return 5 + bytes * 8 + 2;  // approximation. This is a slow memcpy - a byte copy loop..
 }

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -539,7 +539,7 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 		if (PPGeIsFontTextureAddress(texaddr)) {
 			// It's the builtin font texture.
 			entry->status = TexCacheEntry::STATUS_RELIABLE;
-		} else if (g_Config.bTextureBackoffCache) {
+		} else if (g_Config.bTextureBackoffCache && !IsVideo(texaddr)) {
 			entry->status = TexCacheEntry::STATUS_HASHING;
 		} else {
 			entry->status = TexCacheEntry::STATUS_UNRELIABLE;
@@ -1731,7 +1731,7 @@ bool TextureCacheCommon::CheckFullHash(TexCacheEntry *entry, bool &doDelete) {
 	}
 
 	if (fullhash == entry->fullhash) {
-		if (g_Config.bTextureBackoffCache) {
+		if (g_Config.bTextureBackoffCache && !IsVideo(entry->addr)) {
 			if (entry->GetHashStatus() != TexCacheEntry::STATUS_HASHING && entry->numFrames > TexCacheEntry::FRAMES_REGAIN_TRUST) {
 				// Reset to STATUS_HASHING.
 				entry->SetHashStatus(TexCacheEntry::STATUS_HASHING);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1724,6 +1724,15 @@ void TextureCacheCommon::DeleteTexture(TexCache::iterator it) {
 bool TextureCacheCommon::CheckFullHash(TexCacheEntry *entry, bool &doDelete) {
 	int w = gstate.getTextureWidth(0);
 	int h = gstate.getTextureHeight(0);
+	bool isVideo = IsVideo(entry->addr);
+
+	// Don't even check the texture, just assume it has changed.
+	if (isVideo && g_Config.bTextureBackoffCache) {
+		// Attempt to ensure the hash doesn't incorrectly match in if the video stops.
+		entry->fullhash = (entry->fullhash + 0xA535A535) * 11 + (entry->fullhash & 4);
+		return false;
+	}
+
 	u32 fullhash;
 	{
 		PROFILE_THIS_SCOPE("texhash");
@@ -1731,7 +1740,7 @@ bool TextureCacheCommon::CheckFullHash(TexCacheEntry *entry, bool &doDelete) {
 	}
 
 	if (fullhash == entry->fullhash) {
-		if (g_Config.bTextureBackoffCache && !IsVideo(entry->addr)) {
+		if (g_Config.bTextureBackoffCache && !isVideo) {
 			if (entry->GetHashStatus() != TexCacheEntry::STATUS_HASHING && entry->numFrames > TexCacheEntry::FRAMES_REGAIN_TRUST) {
 				// Reset to STATUS_HASHING.
 				entry->SetHashStatus(TexCacheEntry::STATUS_HASHING);


### PR DESCRIPTION
This should actually fix #14873 if lazy texture caching is on.  Probably better to just skip the hashing entirely.

Going based on memory tagging I think is okay, but I could imagine disagreements with.  I think it's pretty safe here.

-[Unknown]