### PR TITLE
[AdhocMatching] Fix race condition issue

### DIFF
--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -2252,7 +2252,7 @@ bool resolveIP(uint32_t ip, SceNetEtherAddr * mac) {
 	}
 
 	// Multithreading Lock
-	peerlock.lock();
+	std::lock_guard<std::recursive_mutex> peer_guard(peerlock);
 
 	// Peer Reference
 	SceNetAdhocctlPeerInfo * peer = friends;
@@ -2264,16 +2264,10 @@ bool resolveIP(uint32_t ip, SceNetEtherAddr * mac) {
 			// Copy Data
 			*mac = peer->mac_addr;
 
-			// Multithreading Unlock
-			peerlock.unlock();
-
 			// Return Success
 			return true;
 		}
 	}
-
-	// Multithreading Unlock
-	peerlock.unlock();
 
 	// Peer not found
 	return false;
@@ -2293,7 +2287,7 @@ bool resolveMAC(SceNetEtherAddr * mac, uint32_t * ip) {
 	}
 
 	// Multithreading Lock
-	std::lock_guard<std::recursive_mutex> guard(peerlock);
+	std::lock_guard<std::recursive_mutex> peer_guard(peerlock);
 
 	// Peer Reference
 	SceNetAdhocctlPeerInfo * peer = friends;


### PR DESCRIPTION
The locks can be removed from AdhocMatching context later after changing AdhocMatching Input & Event threads from real thread to PSPThread.

For the meantime, this PR should be able to avoid race condition i bumped into while testing Gundam: Senjou No Kizuna Portable (the game it self have many more issue on AdhocMatching) #14172