### PR TITLE
Reduce IO in savedata screen sorting, move to async

### DIFF
--- a/UI/SavedataScreen.h
+++ b/UI/SavedataScreen.h
@@ -46,10 +46,12 @@ public:
 	UI::Event OnChoice;
 
 private:
-	static bool ByFilename(UI::View *, UI::View *);
-	static bool BySize(UI::View *, UI::View *);
-	static bool ByDate(UI::View *, UI::View *);
-	static bool SortDone();
+	static void PrepFilename(UI::View *);
+	static void PrepSize(UI::View *);
+	static void PrepDate(UI::View *);
+	static bool ByFilename(const UI::View *, const UI::View *);
+	static bool BySize(const UI::View *, const UI::View *);
+	static bool ByDate(const UI::View *, const UI::View *);
 
 	void Refresh();
 	UI::EventReturn SavedataButtonClick(UI::EventParams &e);

--- a/UI/SavedataScreen.h
+++ b/UI/SavedataScreen.h
@@ -46,9 +46,9 @@ public:
 	UI::Event OnChoice;
 
 private:
-	static bool ByFilename(const UI::View *, const UI::View *);
-	static bool BySize(const UI::View *, const UI::View *);
-	static bool ByDate(const UI::View *, const UI::View *);
+	static bool ByFilename(UI::View *, UI::View *);
+	static bool BySize(UI::View *, UI::View *);
+	static bool ByDate(UI::View *, UI::View *);
 	static bool SortDone();
 
 	void Refresh();


### PR DESCRIPTION
Fixes #14922.

Ultimately, the biggest problem was that it was doing:

```c++
if (slowFunc(v1) > slowFunc(v2))
    return true;
if (slowFunc(v1) < slowFunc(v2))
    return false;
```

And moreover, `slowFunc(v1)` would get called for multiple possible `v2`s.  So I just moved it to the button and cached it.

That made it a lot faster, but there was still a noticeable pause with sufficient (i.e. the amount I have from all the games I've tested...) savedata, so I moved it to asynchronous pop-in.  This time, not using a thread / work info queue, so no crashing concerns.

-[Unknown]