### PR TITLE
Fix text wrap edge case

### DIFF
--- a/Common/Data/Text/WrapText.cpp
+++ b/Common/Data/Text/WrapText.cpp
@@ -119,7 +119,7 @@ void WordWrapper::AppendWord(int endIndex, bool addNewline) {
 	}
 
 	// This will include the newline.
-	if (x_ < maxW_) {
+	if (x_ <= maxW_) {
 		out_.append(str_ + lastWordStartIndex, str_ + endIndex);
 	} else {
 		scanForNewline_ = true;


### PR DESCRIPTION
Fix choice text wrap when a line was as exactly the width of the bound.

The red one was bugged while the green was was fine (same overflow happened when the size was WRAP_CONTENT rather than the fixed itemH).
![Screenshot_2021-09-24_22-57-37](https://user-images.githubusercontent.com/13517524/134741113-238e0631-6fee-4da4-8aca-18324b9c39a2.png)
