### PR TITLE
Fix disassembly of vmfvc and vmtvc

### DIFF
--- a/Core/MIPS/MIPSDisVFPU.cpp
+++ b/Core/MIPS/MIPSDisVFPU.cpp
@@ -138,12 +138,20 @@ namespace MIPSDis
 		sprintf(out, "%s%s\t%s, %s",name,vr>127?"c":"", RN(rt), VN(vr, V_Single));
 	}
 
-	void Dis_Vmftvc(MIPSOpcode op, char *out)
+	void Dis_Vmfvc(MIPSOpcode op, char *out)
 	{
-		int vr = op & 0xFF;
+		int vd = _VD;
+		int vr = (op >> 8) & 0x7F;
+		const char* name = MIPSGetName(op);
+		sprintf(out, "%s\t%s, %s", name, VN(vd, V_Single), VN(vr + 128, V_Single));
+	}
+
+	void Dis_Vmtvc(MIPSOpcode op, char *out)
+	{
+		int vr = op & 0x7F;
 		int vs = _VS;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t%s, %s", name, VN(vs, V_Single), VN(vr, V_Single));
+		sprintf(out, "%s\t%s, %s", name, VN(vs, V_Single), VN(vr + 128, V_Single));
 	}
 
 	void Dis_VPFXST(MIPSOpcode op, char *out)

--- a/Core/MIPS/MIPSDisVFPU.h
+++ b/Core/MIPS/MIPSDisVFPU.h
@@ -24,7 +24,8 @@ extern u32 disPC;
 namespace MIPSDis
 {
 	void Dis_Mftv(MIPSOpcode op, char *out);
-	void Dis_Vmftvc(MIPSOpcode op, char *out);
+	void Dis_Vmfvc(MIPSOpcode op, char *out);
+	void Dis_Vmtvc(MIPSOpcode op, char *out);
 
 	void Dis_SV(MIPSOpcode op, char *out);
 	void Dis_SVQ(MIPSOpcode op, char *out);

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -746,8 +746,8 @@ const MIPSInstruction tableVFPU9[32] = // 110100 00010 xxxxx . ....... . .......
 	INVALID,
 
 	//16
-	INSTR("vmfvc", JITFUNC(Comp_Vmfvc), Dis_Vmftvc, Int_Vmfvc, IN_OTHER|IN_VFPU_CC|OUT_OTHER|IS_VFPU),
-	INSTR("vmtvc", JITFUNC(Comp_Vmtvc), Dis_Vmftvc, Int_Vmtvc, IN_OTHER|OUT_VFPU_CC|OUT_OTHER|IS_VFPU),
+	INSTR("vmfvc", JITFUNC(Comp_Vmfvc), Dis_Vmfvc, Int_Vmfvc, IN_OTHER|IN_VFPU_CC|OUT_OTHER|IS_VFPU),
+	INSTR("vmtvc", JITFUNC(Comp_Vmtvc), Dis_Vmtvc, Int_Vmtvc, IN_OTHER|OUT_VFPU_CC|OUT_OTHER|IS_VFPU),
 	INVALID,
 	INVALID,
 


### PR DESCRIPTION
After 5749ae09d0447d2c84c8ec5bd3bee09b23c49875 and b881a689c41791dfc8a0979fe50647d2cfb3eb39 disassembling `vmfvc` and `vmtvc` gives wrong results. This is a fix for this.

I'm unsure what's the proper register order for `Dis_Vmtvc`, I can change it to first show `vr` then `vs`. Those `move*` instruction on MIPS always have first GPR register then coprocessor register but this is a pretty special case where both registers are from the coprocessor so I don't know...