### PR TITLE
UI: Avoid math on calculated value width

### DIFF
--- a/Common/Render/Text/draw_text_android.cpp
+++ b/Common/Render/Text/draw_text_android.cpp
@@ -125,8 +125,8 @@ void TextDrawerAndroid::MeasureStringRect(const char *str, size_t len, const Bou
 	auto env = getEnv();
 	std::vector<std::string> lines;
 	SplitString(toMeasure, '\n', lines);
-	float total_w = 0.0f;
-	float total_h = 0.0f;
+	int total_w = 0;
+	int total_h = 0;
 	for (size_t i = 0; i < lines.size(); i++) {
 		CacheKey key{ lines[i], fontHash_ };
 
@@ -148,13 +148,13 @@ void TextDrawerAndroid::MeasureStringRect(const char *str, size_t len, const Bou
 		}
 		entry->lastUsedFrame = frameCount_;
 
-		if (total_w < entry->width * fontScaleX_) {
-			total_w = entry->width * fontScaleX_;
+		if (total_w < entry->width) {
+			total_w = entry->width;
 		}
-		total_h += entry->height * fontScaleY_;
+		total_h += entry->height;
 	}
-	*w = total_w * dpiScale_;
-	*h = total_h * dpiScale_;
+	*w = total_w * fontScaleX_ * dpiScale_;
+	*h = total_h * fontScaleY_ * dpiScale_;
 }
 
 void TextDrawerAndroid::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, const char *str, int align) {

--- a/Common/Render/Text/draw_text_uwp.cpp
+++ b/Common/Render/Text/draw_text_uwp.cpp
@@ -264,8 +264,8 @@ void TextDrawerUWP::MeasureStringRect(const char *str, size_t len, const Bounds 
 
 	std::vector<std::string> lines;
 	SplitString(toMeasure, '\n', lines);
-	float total_w = 0.0f;
-	float total_h = 0.0f;
+	int total_w = 0;
+	int total_h = 0;
 	for (size_t i = 0; i < lines.size(); i++) {
 		CacheKey key{ lines[i], fontHash_ };
 
@@ -304,13 +304,13 @@ void TextDrawerUWP::MeasureStringRect(const char *str, size_t len, const Bounds 
 		}
 		entry->lastUsedFrame = frameCount_;
 
-		if (total_w < entry->width * fontScaleX_) {
-			total_w = entry->width * fontScaleX_;
+		if (total_w < entry->width) {
+			total_w = entry->width;
 		}
-		total_h += entry->height * fontScaleY_;
+		total_h += entry->height;
 	}
-	*w = total_w * dpiScale_;
-	*h = total_h * dpiScale_;
+	*w = total_w * fontScaleX_ * dpiScale_;
+	*h = total_h * fontScaleY_ * dpiScale_;
 }
 
 void TextDrawerUWP::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, const char *str, int align) {

--- a/Common/Render/Text/draw_text_win.cpp
+++ b/Common/Render/Text/draw_text_win.cpp
@@ -166,8 +166,8 @@ void TextDrawerWin32::MeasureStringRect(const char *str, size_t len, const Bound
 
 	std::vector<std::string> lines;
 	SplitString(toMeasure, '\n', lines);
-	float total_w = 0.0f;
-	float total_h = 0.0f;
+	int total_w = 0;
+	int total_h = 0;
 	for (size_t i = 0; i < lines.size(); i++) {
 		CacheKey key{ lines[i], fontHash_ };
 
@@ -187,15 +187,15 @@ void TextDrawerWin32::MeasureStringRect(const char *str, size_t len, const Bound
 		}
 		entry->lastUsedFrame = frameCount_;
 
-		if (total_w < entry->width * fontScaleX_) {
-			total_w = entry->width * fontScaleX_;
+		if (total_w < entry->width) {
+			total_w = entry->width;
 		}
 		int h = i == lines.size() - 1 ? entry->height : metrics.tmHeight + metrics.tmExternalLeading;
-		total_h += h * fontScaleY_;
+		total_h += h;
 	}
 
-	*w = total_w * dpiScale_;
-	*h = total_h * dpiScale_;
+	*w = total_w * fontScaleX_ * dpiScale_;
+	*h = total_h * fontScaleY_ * dpiScale_;
 }
 
 void TextDrawerWin32::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, const char *str, int align) {

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -830,14 +830,14 @@ void AbstractChoiceWithValueDisplay::Draw(UIContext &dc) {
 	float availWidth = (bounds_.w - paddingX * 2) * 0.8f;
 	float scale = CalculateValueScale(dc, valueText, availWidth);
 
-	float ignore;
+	float w, h;
 	Bounds availBounds(0, 0, availWidth, bounds_.h);
-	dc.MeasureTextRect(dc.theme->uiFont, scale, scale, valueText.c_str(), (int)valueText.size(), availBounds, &textPadding_.right, &ignore, ALIGN_RIGHT | ALIGN_VCENTER | FLAG_WRAP_TEXT);
-	textPadding_.right += paddingX;
+	dc.MeasureTextRect(dc.theme->uiFont, scale, scale, valueText.c_str(), (int)valueText.size(), availBounds, &w, &h, ALIGN_RIGHT | ALIGN_VCENTER | FLAG_WRAP_TEXT);
+	textPadding_.right = w + paddingX;
 
 	Choice::Draw(dc);
 	dc.SetFontScale(scale, scale);
-	Bounds valueBounds(bounds_.x2() - textPadding_.right, bounds_.y, textPadding_.right - paddingX, bounds_.h);
+	Bounds valueBounds(bounds_.x2() - textPadding_.right, bounds_.y, w, bounds_.h);
 	dc.DrawTextRect(valueText.c_str(), valueBounds, style.fgColor, ALIGN_RIGHT | ALIGN_VCENTER | FLAG_WRAP_TEXT);
 	dc.SetFontScale(1.0f, 1.0f);
 }


### PR DESCRIPTION
Fixes the one-letter-off wrapping noted in #14925.  We ended up with a very slightly lower bounds.w (by less than 0.01.)

-[Unknown]