### PR TITLE
Cleanup some issues in word wrapping

### DIFF
--- a/Common/Data/Text/WrapText.cpp
+++ b/Common/Data/Text/WrapText.cpp
@@ -98,6 +98,9 @@ bool WordWrapper::WrapBeforeWord() {
 		if (x_ + wordWidth_ > maxW_ && !hasEllipsis) {
 			AddEllipsis();
 			skipNextWord_ = true;
+			if ((flags_ & FLAG_WRAP_TEXT) == 0) {
+				scanForNewline_ = true;
+			}
 		}
 	}
 	return false;
@@ -250,6 +253,9 @@ void WordWrapper::Wrap() {
 				AppendWord(lastEllipsisIndex_, -1, false);
 				AddEllipsis();
 				skipNextWord_ = true;
+				if ((flags_ & FLAG_WRAP_TEXT) == 0) {
+					scanForNewline_ = true;
+				}
 				continue;
 			}
 
@@ -281,6 +287,9 @@ void WordWrapper::Wrap() {
 				AddEllipsis();
 				forceEarlyWrap_ = false;
 				skipNextWord_ = true;
+				if ((flags_ & FLAG_WRAP_TEXT) == 0) {
+					scanForNewline_ = true;
+				}
 				continue;
 			}
 		}

--- a/Common/Data/Text/WrapText.cpp
+++ b/Common/Data/Text/WrapText.cpp
@@ -93,17 +93,21 @@ bool WordWrapper::WrapBeforeWord() {
 	if (flags_ & FLAG_ELLIPSIZE_TEXT) {
 		const bool hasEllipsis = out_.size() > 3 && out_.substr(out_.size() - 3) == "...";
 		if (x_ + wordWidth_ > maxW_ && !hasEllipsis) {
-			if (!out_.empty() && IsSpace(out_[out_.size() - 1])) {
-				out_[out_.size() - 1] = '.';
-				out_ += "..";
-			} else {
-				out_ += "...";
-			}
-			x_ += ellipsisWidth_;
+			AddEllipsis();
 			skipNextWord_ = true;
 		}
 	}
 	return false;
+}
+
+void WordWrapper::AddEllipsis() {
+	if (!out_.empty() && IsSpace(out_[out_.size() - 1])) {
+		out_[out_.size() - 1] = '.';
+		out_ += "..";
+	} else {
+		out_ += "...";
+	}
+	x_ += ellipsisWidth_;
 }
 
 void WordWrapper::AppendWord(int endIndex, bool addNewline) {
@@ -120,8 +124,14 @@ void WordWrapper::AppendWord(int endIndex, bool addNewline) {
 		}
 	}
 
+	lastEllipsisIndex_ = -1;
+	if (skipNextWord_) {
+		lastIndex_ = endIndex;
+		return;
+	}
+
 	// This will include the newline.
-	if (x_ <= maxW_ && !skipNextWord_) {
+	if (x_ <= maxW_) {
 		out_.append(str_ + lastWordStartIndex, str_ + endIndex);
 	} else {
 		scanForNewline_ = true;
@@ -130,14 +140,23 @@ void WordWrapper::AppendWord(int endIndex, bool addNewline) {
 		out_ += "\n";
 		lastLineStart_ = out_.size();
 		scanForNewline_ = false;
+		x_ = 0.0f;
 	} else {
 		// We may have appended a newline - check.
 		size_t pos = out_.substr(lastLineStart_).find_last_of("\n");
 		if (pos != out_.npos) {
 			lastLineStart_ += pos;
 		}
+
+		if (lastLineStart_ != out_.size()) {
+			// To account for kerning around spaces, we recalculate the entire line width.
+			x_ = MeasureWidth(out_.c_str() + lastLineStart_, out_.size() - lastLineStart_);
+		} else {
+			x_ = 0.0f;
+		}
 	}
 	lastIndex_ = endIndex;
+	wordWidth_ = 0.0f;
 }
 
 void WordWrapper::Wrap() {
@@ -168,11 +187,10 @@ void WordWrapper::Wrap() {
 		if (c == '\n') {
 			// This will include the newline character.
 			AppendWord(afterIndex, false);
-			x_ = 0.0f;
-			wordWidth_ = 0.0f;
 			// We wrapped once, so stop forcing.
 			forceEarlyWrap_ = false;
 			scanForNewline_ = false;
+			skipNextWord_ = false;
 			continue;
 		}
 
@@ -188,16 +206,41 @@ void WordWrapper::Wrap() {
 		// Is this the end of a word (space)?
 		if (wordWidth_ > 0.0f && IsSpace(c)) {
 			AppendWord(afterIndex, false);
-			// To account for kerning around spaces, we recalculate the entire line width.
-			x_ = MeasureWidth(out_.c_str() + lastLineStart_, out_.size() - lastLineStart_);
-			wordWidth_ = 0.0f;
+			skipNextWord_ = false;
 			continue;
+		}
+
+		// We're scanning for the next word.
+		if (skipNextWord_)
+			continue;
+
+		if ((flags_ & FLAG_ELLIPSIZE_TEXT) != 0 && wordWidth_ > 0.0f && lastEllipsisIndex_ == -1) {
+			float checkX = x_;
+			// If we allow wrapping, assume we'll wrap as needed.
+			if ((flags_ & FLAG_WRAP_TEXT) != 0 && x_ >= maxW_) {
+				checkX = 0;
+			}
+
+			// If we can only fit an ellipsis, time to output and skip ahead.
+			// Ignore x for newWordWidth, because we might wrap.
+			if (checkX + wordWidth_ + ellipsisWidth_ <= maxW_ && newWordWidth + ellipsisWidth_ > maxW_) {
+				lastEllipsisIndex_ = beforeIndex;
+				continue;
+			}
 		}
 
 		// Can the word fit on a line even all by itself so far?
 		if (wordWidth_ > 0.0f && newWordWidth > maxW_) {
-			// Nope.  Let's drop what's there so far onto its own line.
-			if (x_ > 0.0f && x_ + wordWidth_ > maxW_ && beforeIndex > lastIndex_) {
+			// If we had a good place for an ellipsis, let's do that.
+			if (lastEllipsisIndex_ != -1) {
+				AppendWord(lastEllipsisIndex_, false);
+				AddEllipsis();
+				skipNextWord_ = true;
+				continue;
+			}
+
+			// Doesn't fit.  Let's drop what's there so far onto its own line.
+			if (x_ > 0.0f && x_ + wordWidth_ > maxW_ && beforeIndex > lastIndex_ && (flags_ & FLAG_WRAP_TEXT) != 0) {
 				// Let's put as many characters as will fit on the previous line.
 				// This word can't fit on one line even, so it's going to be cut into pieces anyway.
 				// Better to avoid huge gaps, in that case.
@@ -212,12 +255,6 @@ void WordWrapper::Wrap() {
 			}
 			// Now, add the word so far (without this latest character) and break.
 			AppendWord(beforeIndex, true);
-			if (lastLineStart_ != out_.size()) {
-				x_ = MeasureWidth(out_.c_str() + lastLineStart_, out_.size() - lastLineStart_);
-			} else {
-				x_ = 0.0f;
-			}
-			wordWidth_ = 0.0f;
 			forceEarlyWrap_ = false;
 			// The current character will be handled as part of the next word.
 			continue;
@@ -226,15 +263,10 @@ void WordWrapper::Wrap() {
 		if ((flags_ & FLAG_ELLIPSIZE_TEXT) && wordWidth_ > 0.0f && x_ + newWordWidth + ellipsisWidth_ > maxW_) {
 			if ((flags_ & FLAG_WRAP_TEXT) == 0 && x_ + wordWidth_ + ellipsisWidth_ <= maxW_) {
 				// Now, add the word so far (without this latest character) and show the ellipsis.
-				AppendWord(beforeIndex, true);
-				if (lastLineStart_ != out_.size()) {
-					x_ = MeasureWidth(out_.c_str() + lastLineStart_, out_.size() - lastLineStart_);
-				} else {
-					x_ = 0.0f;
-				}
-				wordWidth_ = 0.0f;
+				AppendWord(lastEllipsisIndex_ != -1 ? lastEllipsisIndex_ : beforeIndex, false);
+				AddEllipsis();
 				forceEarlyWrap_ = false;
-				// The current character will be handled as part of the next word.
+				skipNextWord_ = true;
 				continue;
 			}
 		}
@@ -245,8 +277,6 @@ void WordWrapper::Wrap() {
 		if (wordWidth_ > 0.0f && (IsCJK(c) || IsPunctuation(c) || forceEarlyWrap_)) {
 			// CJK doesn't require spaces, so we treat each letter as its own word.
 			AppendWord(afterIndex, false);
-			x_ += wordWidth_;
-			wordWidth_ = 0.0f;
 		}
 	}
 

--- a/Common/Data/Text/WrapText.cpp
+++ b/Common/Data/Text/WrapText.cpp
@@ -153,9 +153,9 @@ void WordWrapper::AppendWord(int endIndex, int lastChar, bool addNewline) {
 		x_ = 0.0f;
 	} else {
 		// We may have appended a newline - check.
-		size_t pos = out_.substr(lastLineStart_).find_last_of("\n");
+		size_t pos = out_.find_last_of("\n");
 		if (pos != out_.npos) {
-			lastLineStart_ += pos;
+			lastLineStart_ = pos + 1;
 		}
 
 		if (lastChar == -1 && !out_.empty()) {
@@ -202,12 +202,15 @@ void WordWrapper::Wrap() {
 
 		// Is this a newline character, hard wrapping?
 		if (c == '\n') {
+			if (skipNextWord_) {
+				lastIndex_ = beforeIndex;
+				skipNextWord_ = false;
+			}
 			// This will include the newline character.
 			AppendWord(afterIndex, c, false);
 			// We wrapped once, so stop forcing.
 			forceEarlyWrap_ = false;
 			scanForNewline_ = false;
-			skipNextWord_ = false;
 			continue;
 		}
 

--- a/Common/Data/Text/WrapText.cpp
+++ b/Common/Data/Text/WrapText.cpp
@@ -91,14 +91,16 @@ bool WordWrapper::WrapBeforeWord() {
 		}
 	}
 	if (flags_ & FLAG_ELLIPSIZE_TEXT) {
-		if (x_ + wordWidth_ > maxW_) {
+		const bool hasEllipsis = out_.size() > 3 && out_.substr(out_.size() - 3) == "...";
+		if (x_ + wordWidth_ > maxW_ && !hasEllipsis) {
 			if (!out_.empty() && IsSpace(out_[out_.size() - 1])) {
 				out_[out_.size() - 1] = '.';
 				out_ += "..";
 			} else {
 				out_ += "...";
 			}
-			x_ = maxW_;
+			x_ += ellipsisWidth_;
+			skipNextWord_ = true;
 		}
 	}
 	return false;
@@ -119,7 +121,7 @@ void WordWrapper::AppendWord(int endIndex, bool addNewline) {
 	}
 
 	// This will include the newline.
-	if (x_ <= maxW_) {
+	if (x_ <= maxW_ && !skipNextWord_) {
 		out_.append(str_ + lastWordStartIndex, str_ + endIndex);
 	} else {
 		scanForNewline_ = true;
@@ -222,7 +224,7 @@ void WordWrapper::Wrap() {
 		}
 
 		if ((flags_ & FLAG_ELLIPSIZE_TEXT) && wordWidth_ > 0.0f && x_ + newWordWidth + ellipsisWidth_ > maxW_) {
-			if ((flags_ & FLAG_WRAP_TEXT) == 0) {
+			if ((flags_ & FLAG_WRAP_TEXT) == 0 && x_ + wordWidth_ + ellipsisWidth_ <= maxW_) {
 				// Now, add the word so far (without this latest character) and show the ellipsis.
 				AppendWord(beforeIndex, true);
 				if (lastLineStart_ != out_.size()) {

--- a/Common/Data/Text/WrapText.cpp
+++ b/Common/Data/Text/WrapText.cpp
@@ -119,7 +119,7 @@ void WordWrapper::AppendWord(int endIndex, bool addNewline) {
 	}
 
 	// This will include the newline.
-	if (x_ < maxW_) {
+	if (x_ <= maxW_) {
 		out_.append(str_ + lastWordStartIndex, str_ + endIndex);
 	} else {
 		scanForNewline_ = true;

--- a/Common/Data/Text/WrapText.h
+++ b/Common/Data/Text/WrapText.h
@@ -40,4 +40,6 @@ protected:
 	bool forceEarlyWrap_ = false;
 	// Skip all characters until the next newline.
 	bool scanForNewline_ = false;
+	// Skip the next word, replaced with ellipsis.
+	bool skipNextWord_ = false;
 };

--- a/Common/Data/Text/WrapText.h
+++ b/Common/Data/Text/WrapText.h
@@ -14,13 +14,16 @@ protected:
 	virtual float MeasureWidth(const char *str, size_t bytes) = 0;
 	void Wrap();
 	bool WrapBeforeWord();
-	void AppendWord(int endIndex, bool addNewline);
+	void AppendWord(int endIndex, int lastChar, bool addNewline);
 	void AddEllipsis();
 
 	static bool IsCJK(uint32_t c);
 	static bool IsPunctuation(uint32_t c);
 	static bool IsSpace(uint32_t c);
 	static bool IsShy(uint32_t c);
+	static bool IsSpaceOrShy(uint32_t c) {
+		return IsSpace(c) || IsShy(c);
+	}
 
 	const char *const str_;
 	const float maxW_;
@@ -33,6 +36,8 @@ protected:
 	int lastEllipsisIndex_ = -1;
 	// Index of last line start.
 	size_t lastLineStart_ = 0;
+	// Last character written to out_.
+	int lastChar_ = 0;
 	// Position the current word starts at.
 	float x_ = 0.0f;
 	// Most recent width of word since last index.

--- a/Common/Data/Text/WrapText.h
+++ b/Common/Data/Text/WrapText.h
@@ -15,6 +15,7 @@ protected:
 	void Wrap();
 	bool WrapBeforeWord();
 	void AppendWord(int endIndex, bool addNewline);
+	void AddEllipsis();
 
 	static bool IsCJK(uint32_t c);
 	static bool IsPunctuation(uint32_t c);
@@ -28,6 +29,8 @@ protected:
 
 	// Index of last output / start of current word.
 	int lastIndex_ = 0;
+	// Ideal place to put an ellipsis if we run out of space.
+	int lastEllipsisIndex_ = -1;
 	// Index of last line start.
 	size_t lastLineStart_ = 0;
 	// Position the current word starts at.

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -731,6 +731,12 @@ static bool TestWrapText() {
 	EXPECT_WORDWRAP_EQ_STR(shyTestString.c_str(), 10, FLAG_ELLIPSIZE_TEXT, "Very...");
 	EXPECT_WORDWRAP_EQ_STR(shyTestString.c_str(), 10, FLAG_WRAP_TEXT | FLAG_ELLIPSIZE_TEXT, "Very-\nlong");
 
+	// Newlines should not be removed and should influence wrapping.
+	EXPECT_WORDWRAP_EQ_STR("Hello\ngoodbye yes\nno", 14, 0, "Hello\ngoodbye ");
+	EXPECT_WORDWRAP_EQ_STR("Hello\ngoodbye yes\nno", 14, FLAG_WRAP_TEXT, "Hello\ngoodbye \nyes\nno");
+	EXPECT_WORDWRAP_EQ_STR("Hello\ngoodbye yes\nno", 14, FLAG_ELLIPSIZE_TEXT, "Hello\ngoodb...\nno");
+	EXPECT_WORDWRAP_EQ_STR("Hello\ngoodbye yes\nno", 14, FLAG_WRAP_TEXT | FLAG_ELLIPSIZE_TEXT, "Hello\ngoodbye \nyes\nno");
+
 	return true;
 }
 

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -712,6 +712,12 @@ static bool TestWrapText() {
 	EXPECT_WORDWRAP_EQ_STR("Hello goodbye", 14, FLAG_ELLIPSIZE_TEXT, "Hello...");
 	EXPECT_WORDWRAP_EQ_STR("Hello goodbye", 14, FLAG_WRAP_TEXT | FLAG_ELLIPSIZE_TEXT, "Hello \ngoodbye");
 
+	// Multiple words with something short after...
+	EXPECT_WORDWRAP_EQ_STR("Hello goodbye yes", 14, 0, "Hello goodbye ");
+	EXPECT_WORDWRAP_EQ_STR("Hello goodbye yes", 14, FLAG_WRAP_TEXT, "Hello \ngoodbye \nyes");
+	EXPECT_WORDWRAP_EQ_STR("Hello goodbye yes", 14, FLAG_ELLIPSIZE_TEXT, "Hello...");
+	EXPECT_WORDWRAP_EQ_STR("Hello goodbye yes", 14, FLAG_WRAP_TEXT | FLAG_ELLIPSIZE_TEXT, "Hello \ngoodbye \nyes");
+
 	// Now, multiple words, but only the first fits.
 	EXPECT_WORDWRAP_EQ_STR("Hello goodbye", 10, 0, "Hello ");
 	EXPECT_WORDWRAP_EQ_STR("Hello goodbye", 10, FLAG_WRAP_TEXT, "Hello \ngoodb\nye");


### PR DESCRIPTION
This corrects a few issues, mainly with Unicode handling and ellipsis insertion.

Now there's a unit test to validate the behavior.

-[Unknown]