### PR TITLE
Android: Create default folders in custom path

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -518,7 +518,6 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	} else {
 		g_Config.memStickDirectory = Path(external_dir);
 		g_Config.defaultCurrentDirectory = Path(external_dir);
-		CreateDirectoriesAndroid();
 	}
 
 	// Might also add an option to move it to internal / non-visible storage, but there's
@@ -546,6 +545,11 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 		}
 	} else {
 		INFO_LOG(SYSTEM, "No memstick directory file found (tried to open '%s')", memstickDirFile.c_str());
+	}
+
+	// Attempt to create directories after reading the path.
+	if (!System_GetPropertyBool(SYSPROP_ANDROID_SCOPED_STORAGE)) {
+		CreateDirectoriesAndroid();
 	}
 
 #elif PPSSPP_PLATFORM(IOS)


### PR DESCRIPTION
If scoped storage is off and the memstick directory was customized, load it before pre-creating default folders.

I didn't actually test this with non-scoped-storage permissions, but I'm pretty sure this is the problem in #14893.

-[Unknown]