### PR TITLE
http: Fix timeout mid request

### DIFF
--- a/Common/Net/NetBuffer.cpp
+++ b/Common/Net/NetBuffer.cpp
@@ -73,12 +73,16 @@ bool Buffer::ReadAllWithProgress(int fd, int knownSize, float *progress, float *
 			return true;
 		} else if (retval < 0) {
 #if PPSSPP_PLATFORM(WINDOWS)
-			if (WSAGetLastError() != WSAEWOULDBLOCK)
+			if (WSAGetLastError() != WSAEWOULDBLOCK) {
 #else
-			if (errno != EWOULDBLOCK)
+			if (errno != EWOULDBLOCK) {
 #endif
 				ERROR_LOG(IO, "Error reading from buffer: %i", retval);
-			return false;
+				return false;
+			}
+
+			// Just try again on a would block error, not a real error.
+			continue;
 		}
 		char *p = Append((size_t)retval);
 		memcpy(p, &buf[0], retval);


### PR DESCRIPTION
Sometimes we think a socket is ready, and it isn't.  We shouldn't fail the whole read just because of this.

Noticed this happening when testing a proxy of the web debugger.  It could've been affecting the version download, etc. as well.

I'm guessing this was broken in #14424, so this would be a regression.

-[Unknown]