### PR TITLE
UI: Fix measuring width constrained choices

### DIFF
--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -440,6 +440,8 @@ void Choice::GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, 
 			// Let it have as much space as it needs.
 			availWidth = MAX_ITEM_SIZE;
 		}
+		if (horiz.type != EXACTLY && layoutParams_->width > 0.0f && availWidth > layoutParams_->width)
+			availWidth = layoutParams_->width;
 		float scale = CalculateTextScale(dc, availWidth);
 		Bounds availBounds(0, 0, availWidth, vert.size);
 		dc.MeasureTextRect(dc.theme->uiFont, scale, scale, text_.c_str(), (int)text_.size(), availBounds, &w, &h, FLAG_WRAP_TEXT);


### PR DESCRIPTION
Tried to keep this as safe as possible.  The width was previously always whatever the parent was wanting, ignoring the layout params.

This meant, if a Choice was in an anchor layout, or was in a linear layout without weight, it would calculate text wrapping height based only off of the parent's width.  Then it would shrink that width afterward in `MeasureBySpec`.

-[Unknown]