### PR TITLE
UI: Fix game installer extension check

### DIFF
--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -378,7 +378,6 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 
 	Path full_path = fileLoader->GetPath();
 	std::string path = full_path.GetDirectory();
-	std::string extension = full_path.GetFileExtension();
 	std::string file = full_path.GetFilename();
 
 	size_t pos = path.find("PSP/GAME/");

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -290,7 +290,7 @@ bool GameManager::InstallGame(Path url, Path fileName, bool deleteAfter) {
 
 	std::string extension = url.GetFileExtension();
 	// Examine the URL to guess out what we're installing.
-	if (extension == "cso" || extension == "iso") {
+	if (extension == ".cso" || extension == ".iso") {
 		// It's a raw ISO or CSO file. We just copy it to the destination.
 		std::string shortFilename = url.GetFilename();
 		return InstallRawISO(fileName, shortFilename, deleteAfter);


### PR DESCRIPTION
Oops, `GetFileExtension()` includes the dot now.

-[Unknown]