### PR TITLE
Serve local web debugger from assets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,7 @@
 [submodule "SDL/macOS"]
 	path = SDL/macOS
 	url = https://github.com/hrydgard/ppsspp-mac-sdl
+[submodule "ppsspp-debugger"]
+	path = assets/debugger
+	url = https://github.com/unknownbrackets/ppsspp-debugger.git
+	branch = bundled

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2219,6 +2219,7 @@ endif()
 set(NativeAssets
 	android/assets/ui_atlas.zim
 	android/assets/ui_atlas.meta
+	assets/debugger
 	assets/lang
 	assets/shaders
 	assets/Roboto-Condensed.ttf
@@ -2324,18 +2325,20 @@ if(TargetBin)
 		file(GLOB_RECURSE FLASH0_FILES assets/flash0/*)
 		file(GLOB_RECURSE LANG_FILES assets/lang/*)
 		file(GLOB_RECURSE SHADER_FILES assets/shaders/*)
+		file(GLOB_RECURSE DEBUGGER_FILES assets/debugger/*)
 
 		if(NOT IOS)
 			set_source_files_properties(${NativeAssets} PROPERTIES MACOSX_PACKAGE_LOCATION "MacOS/assets")
 			set_source_files_properties(${FLASH0_FILES} PROPERTIES MACOSX_PACKAGE_LOCATION "MacOS/assets/flash0/font")
 			set_source_files_properties(${LANG_FILES} PROPERTIES MACOSX_PACKAGE_LOCATION "MacOS/assets/lang")
 			set_source_files_properties(${SHADER_FILES} PROPERTIES MACOSX_PACKAGE_LOCATION "MacOS/assets/shaders")
+			set_source_files_properties(${DEBUGGER_FILES} PROPERTIES MACOSX_PACKAGE_LOCATION "MacOS/assets/debugger")
 		endif()
 
 		if(IOS)
-			add_executable(${TargetBin} MACOSX_BUNDLE ${ICON_PATH_ABS} ${NativeAssets} ${SHADER_FILES} ${FLASH0_FILES} ${LANG_FILES} ${NativeAppSource} "ios/Settings.bundle" "ios/Launch Screen.storyboard" "ext/vulkan/iOS/Frameworks")
+			add_executable(${TargetBin} MACOSX_BUNDLE ${ICON_PATH_ABS} ${NativeAssets} ${SHADER_FILES} ${DEBUGGER_FILES} ${FLASH0_FILES} ${LANG_FILES} ${NativeAppSource} "ios/Settings.bundle" "ios/Launch Screen.storyboard" "ext/vulkan/iOS/Frameworks")
 		else()
-			add_executable(${TargetBin} MACOSX_BUNDLE ${ICON_PATH_ABS} ${NativeAssets} ${SHADER_FILES} ${FLASH0_FILES} ${LANG_FILES} ${NativeAppSource})
+			add_executable(${TargetBin} MACOSX_BUNDLE ${ICON_PATH_ABS} ${NativeAssets} ${SHADER_FILES} ${DEBUGGER_FILES} ${FLASH0_FILES} ${LANG_FILES} ${NativeAppSource})
 			file(INSTALL "${CMAKE_SOURCE_DIR}/ext/vulkan/macOS/Frameworks/libMoltenVK.dylib" DESTINATION "${CMAKE_BINARY_DIR}/PPSSPPSDL.app/Contents/Frameworks/")
 			if(TARGET SDL2::SDL2 AND NOT USING_QT_UI)
 				add_custom_command(TARGET ${TargetBin} POST_BUILD COMMAND /bin/bash "${CMAKE_SOURCE_DIR}/SDL/macbundle.sh" "${CMAKE_BINARY_DIR}/PPSSPPSDL.app")

--- a/android/ab.sh
+++ b/android/ab.sh
@@ -1,6 +1,7 @@
 cp -r ../assets/flash0 assets/
 cp -r ../assets/lang assets/
 cp -r ../assets/shaders assets/
+cp -r ../assets/debugger assets/
 cp ../assets/langregion.ini assets/langregion.ini
 cp ../assets/compat.ini assets/compat.ini
 cp ../assets/Roboto-Condensed.ttf assets/Roboto-Condensed.ttf

--- a/ppsspp.iss
+++ b/ppsspp.iss
@@ -74,6 +74,7 @@ Source: "README.md"; DestName: "README.txt"; DestDir: "{app}"; Flags: isreadme
 Source: "notinstalled.txt"; DestName: "installed.txt"; DestDir: "{app}";
 Source: "assets\*.*"; DestDir: "{app}\assets"
 Source: "assets\shaders\*.*"; DestDir: "{app}\assets\shaders"
+Source: "assets\debugger\*"; DestDir: "{app}\assets\debugger"; Flags: recursesubdirs
 Source: "assets\lang\*.ini"; DestDir: "{app}\assets\lang"
 Source: "assets\flash0\font\*.*"; DestDir: "{app}\assets\flash0\font"
 Source: "dx9sdk\8.1\Redist\D3D\x64\d3dcompiler_47.dll"; DestDir: "{app}"


### PR DESCRIPTION
This packages the debugger at https://github.com/unknownbrackets/ppsspp-debugger into assets, and serves it from PPSSPP itself when remote debugger is enabled.

Web browsers are going to be restricting public web URLs from accessing anything determined as internal, which would include PPSSPP's API.  Serving from PPSSPP should avoid this restriction for now, although currently there's no automatic way to know the URL.

Of course, updates to the web debugger will require the submodule to be updated.  Importantly, this is tracking an orphan branch that has the built files output (rather than the source files, since there's a compilation process.)  The build process is in the README and also in GitHub Actions, which adds a commit to the `bundled` branch on every merge to master for ppsspp-debugger.

Only tested this on Windows for now.

-[Unknown]