### PR TITLE
Cleanup UI touch controls button handling

### DIFF
--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -608,6 +608,38 @@ std::string ItemHeader::DescribeText() const {
 	return ReplaceAll(u->T("%1 heading"), "%1", text_);
 }
 
+void BorderView::Draw(UIContext &dc) {
+	Color color = 0xFFFFFFFF;
+	if (style_ == BorderStyle::HEADER_FG)
+		color = dc.theme->headerStyle.fgColor;
+	else if (style_ == BorderStyle::ITEM_DOWN_BG)
+		color = dc.theme->itemDownStyle.background.color;
+
+	if (borderFlags_ & BORDER_TOP)
+		dc.Draw()->DrawImageCenterTexel(dc.theme->whiteImage, bounds_.x, bounds_.y, bounds_.x2(), bounds_.y + size_, color);
+	if (borderFlags_ & BORDER_LEFT)
+		dc.Draw()->DrawImageCenterTexel(dc.theme->whiteImage, bounds_.x, bounds_.y, bounds_.x + size_, bounds_.y2(), color);
+	if (borderFlags_ & BORDER_BOTTOM)
+		dc.Draw()->DrawImageCenterTexel(dc.theme->whiteImage, bounds_.x, bounds_.y2() - size_, bounds_.x2(), bounds_.y2(), color);
+	if (borderFlags_ & BORDER_RIGHT)
+		dc.Draw()->DrawImageCenterTexel(dc.theme->whiteImage, bounds_.x2() - size_, bounds_.y, bounds_.x2(), bounds_.y2(), color);
+}
+
+void BorderView::GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const {
+	Bounds bounds(0, 0, layoutParams_->width, layoutParams_->height);
+	if (bounds.w < 0) {
+		// If there's no size, let's grow as big as we want.
+		bounds.w = horiz.size == 0 ? MAX_ITEM_SIZE : horiz.size;
+	}
+	if (bounds.h < 0) {
+		bounds.h = vert.size == 0 ? MAX_ITEM_SIZE : vert.size;
+	}
+	ApplyBoundsBySpec(bounds, horiz, vert);
+	// If we have vertical borders, grow to width so they're spaced apart.
+	w = (borderFlags_ & BORDER_VERT) != 0 ? bounds.w : 0;
+	h = (borderFlags_ & BORDER_HORIZ) != 0 ? bounds.h : 0;
+}
+
 void PopupHeader::Draw(UIContext &dc) {
 	const float paddingHorizontal = 12;
 	const float availableWidth = bounds_.w - paddingHorizontal * 2;

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -162,6 +162,24 @@ enum Gravity {
 	G_VERTMASK = 3 << 2,
 };
 
+enum Borders {
+	BORDER_NONE = 0,
+
+	BORDER_TOP = 0x0001,
+	BORDER_LEFT = 0x0002,
+	BORDER_BOTTOM = 0x0004,
+	BORDER_RIGHT = 0x0008,
+
+	BORDER_HORIZ = BORDER_LEFT | BORDER_RIGHT,
+	BORDER_VERT = BORDER_TOP | BORDER_BOTTOM,
+	BORDER_ALL = BORDER_TOP | BORDER_LEFT | BORDER_BOTTOM | BORDER_RIGHT,
+};
+
+enum class BorderStyle {
+	HEADER_FG,
+	ITEM_DOWN_BG,
+};
+
 typedef float Size;  // can also be WRAP_CONTENT or FILL_PARENT.
 
 enum Orientation {
@@ -867,6 +885,21 @@ public:
 	std::string DescribeText() const override { return ""; }
 
 private:
+	float size_ = 0.0f;
+};
+
+class BorderView : public InertView {
+public:
+	BorderView(Borders borderFlags, BorderStyle style, float size = 2.0f, LayoutParams *layoutParams = nullptr)
+		: InertView(layoutParams), borderFlags_(borderFlags), style_(style), size_(size) {
+	}
+	void GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const override;
+	void Draw(UIContext &dc) override;
+	std::string DescribeText() const override { return ""; }
+
+private:
+	Borders borderFlags_;
+	BorderStyle style_;
 	float size_;
 };
 

--- a/UI/TiltAnalogSettingsScreen.cpp
+++ b/UI/TiltAnalogSettingsScreen.cpp
@@ -54,7 +54,7 @@ void TiltAnalogSettingsScreen::CreateViews() {
 	settings->Add(calibrate);
 
 	root_->Add(settings);
-	settings->Add(new ItemHeader(""));
+	settings->Add(new BorderView(BORDER_BOTTOM, BorderStyle::HEADER_FG, 2.0f, new LayoutParams(FILL_PARENT, 40.0f)));
 	settings->Add(new Choice(di->T("Back")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
 }
 

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -606,6 +606,8 @@ void TouchControlLayoutScreen::update() {
 }
 
 void TouchControlLayoutScreen::CreateViews() {
+	using namespace UI;
+
 	// setup g_Config for button layout
 	const Bounds &bounds = screenManager()->getUIContext()->GetBounds();
 	InitPadLayout(bounds.w, bounds.h);
@@ -613,52 +615,31 @@ void TouchControlLayoutScreen::CreateViews() {
 	const float leftColumnWidth = 140.0f;
 	layoutAreaScale = 1.0-(leftColumnWidth+10)/bounds.w;
 
-	using namespace UI;
-
 	auto co = GetI18NCategory("Controls");
 	auto di = GetI18NCategory("Dialog");
 
 	root_ = new AnchorLayout(new LayoutParams(FILL_PARENT, FILL_PARENT));
 
-	Choice *reset = new Choice(di->T("Reset"), "", false, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 84));
-	Choice *back = new Choice(di->T("Back"), "", false, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 10));
-	Choice *visibility = new Choice(co->T("Customize"), "", false, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 298));
-	// controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fButtonScale, 0.80, 2.0, co->T("Button Scaling"), screenManager()))
-	// 	->OnChange.Handle(this, &GameSettingsScreen::OnChangeControlScaling);
+	ScrollView *leftColumnScroll = root_->Add(new ScrollView(ORIENT_VERTICAL, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 10)));
+	LinearLayout *leftColumn = leftColumnScroll->Add(new LinearLayout(ORIENT_VERTICAL));
 
-	CheckBox *snap = new CheckBox(&g_Config.bTouchSnapToGrid, di->T("Snap"), "", new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 228));
-	PopupSliderChoice *gridSize = new PopupSliderChoice(&g_Config.iTouchSnapGridSize, 2, 256, di->T("Grid"), screenManager(), "", new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 158));
-	gridSize->SetEnabledPtr(&g_Config.bTouchSnapToGrid);
-
-	mode_ = new ChoiceStrip(ORIENT_VERTICAL, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 140 + 158 + 64 + 10));
+	mode_ = new ChoiceStrip(ORIENT_VERTICAL);
 	mode_->AddChoice(di->T("Move"));
 	mode_->AddChoice(di->T("Resize"));
 	mode_->SetSelection(0, false);
 	mode_->OnChoice.Handle(this, &TouchControlLayoutScreen::OnMode);
 
-	reset->OnClick.Handle(this, &TouchControlLayoutScreen::OnReset);
-	back->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
-	visibility->OnClick.Handle(this, &TouchControlLayoutScreen::OnVisibility);
-	root_->Add(mode_);
-	root_->Add(visibility);
-	root_->Add(snap);
-	root_->Add(gridSize);
-	root_->Add(reset);
-	root_->Add(back);
+	CheckBox *snap = new CheckBox(&g_Config.bTouchSnapToGrid, di->T("Snap"));
+	PopupSliderChoice *gridSize = new PopupSliderChoice(&g_Config.iTouchSnapGridSize, 2, 256, di->T("Grid"), screenManager(), "", new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10, NONE, NONE, 158));
+	gridSize->SetEnabledPtr(&g_Config.bTouchSnapToGrid);
 
-	TabHolder *tabHolder = new TabHolder(ORIENT_VERTICAL, leftColumnWidth, new AnchorLayoutParams(10, 0, 10, 0, false));
-	tabHolder->SetTag("TouchControlLayout");
-	root_->Add(tabHolder);
+	leftColumn->Add(mode_);
+	leftColumn->Add(new Choice(co->T("Customize")))->OnClick.Handle(this, &TouchControlLayoutScreen::OnVisibility);
+	leftColumn->Add(snap);
+	leftColumn->Add(gridSize);
+	leftColumn->Add(new Choice(di->T("Reset")))->OnClick.Handle(this, &TouchControlLayoutScreen::OnReset);
+	leftColumn->Add(new Choice(di->T("Back")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
 
 	root_->Add(new ItemHeader("", new AnchorLayoutParams(leftColumnWidth + 10, bounds.h*(1.0-layoutAreaScale)-40, NONE, NONE, false)));
 	layoutView_ = root_->Add(new ControlLayoutView(new AnchorLayoutParams(leftColumnWidth + 10, bounds.h*(1.0-layoutAreaScale), 0.0f, 0.0f, false)));
-
-	// this is more for show than anything else. It's used to provide a boundary
-	// so that buttons like back can be placed within the boundary.
-	// serves no other purpose.
-	// AnchorLayout *controlsHolder = new AnchorLayout(new LayoutParams(FILL_PARENT, FILL_PARENT));
-
-	auto ms = GetI18NCategory("MainSettings");
-
-	//tabHolder->AddTab(ms->T("Controls"), controlsHolder);
 }

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -640,6 +640,7 @@ void TouchControlLayoutScreen::CreateViews() {
 	leftColumn->Add(new Choice(di->T("Reset")))->OnClick.Handle(this, &TouchControlLayoutScreen::OnReset);
 	leftColumn->Add(new Choice(di->T("Back")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
 
-	root_->Add(new ItemHeader("", new AnchorLayoutParams(leftColumnWidth + 10, bounds.h*(1.0-layoutAreaScale)-40, NONE, NONE, false)));
-	layoutView_ = root_->Add(new ControlLayoutView(new AnchorLayoutParams(leftColumnWidth + 10, bounds.h*(1.0-layoutAreaScale), 0.0f, 0.0f, false)));
+	root_->Add(new BorderView(BORDER_BOTTOM, BorderStyle::ITEM_DOWN_BG, 4.0f, new AnchorLayoutParams(leftColumnWidth + 10, bounds.h * (1.0f - layoutAreaScale), 0.0f, NONE, false)));
+	root_->Add(new BorderView(BORDER_RIGHT, BorderStyle::ITEM_DOWN_BG, 4.0f, new AnchorLayoutParams(leftColumnWidth + 10, 0.0f, NONE, 0.0f, false)));
+	layoutView_ = root_->Add(new ControlLayoutView(new AnchorLayoutParams(leftColumnWidth + 10, bounds.h * (1.0 - layoutAreaScale), 0.0f, 0.0f, false)));
 }


### PR DESCRIPTION
This helps #14913 by laying out the buttons in a more standard way.  Shouldn't conflict with #14924, it probably needs more width - just handling whatever space is there better.

Also tweaks the border color to blue (to match the left side), and cleans up abusing tab strips and item headers for visual effects.

This is what it looks like in Japanese now:
![Screenshot showing buttons with text wrapping inside boxes instead of outside](https://user-images.githubusercontent.com/191233/135004601-04aaeecb-d661-4882-a193-f3fe4c2b7061.png)

A small problem is that if it does scroll, the scroll bar won't be visible (as it will be covered by the left blue border.)  I didn't want to reduce the choice button widths even further here, but they should probably be 2 less than the leftColumnWidth.  But this is still better than current master, with its overlapping buttons.

-[Unknown]