### PR TITLE
UI: Keep scroll position on async load

### DIFF
--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -1017,15 +1017,11 @@ void ScrollView::PersistData(PersistStatus status, std::string anonId, PersistMa
 void ScrollView::SetVisibility(Visibility visibility) {
 	ViewGroup::SetVisibility(visibility);
 
-	if (visibility == V_GONE && !rememberPosition_) {
+	if (visibility == V_GONE && !rememberPos_) {
 		// Since this is no longer shown, forget the scroll position.
 		// For example, this happens when switching tabs.
 		ScrollTo(0.0f);
 	}
-}
-
-float ScrollView::GetScrollPosition() {
-	return scrollPos_;
 }
 
 void ScrollView::ScrollTo(float newScrollPos) {
@@ -1141,6 +1137,8 @@ void ScrollView::Update() {
 
 	if (oldPos != scrollPos_)
 		orientation_ == ORIENT_HORIZONTAL ? lastScrollPosX = scrollPos_ : lastScrollPosY = scrollPos_;
+	if (rememberPos_)
+		*rememberPos_ = scrollPos_;
 }
 
 void AnchorLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert) {

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -800,9 +800,7 @@ void ScrollView::Layout() {
 	switch (orientation_) {
 	case ORIENT_HORIZONTAL:
 		if (scrolled.w != lastViewSize_) {
-			if (scrollToTopOnSizeChange_)
-				ScrollTo(0.0f);
-			else if (rememberPos_)
+			if (rememberPos_)
 				scrollPos_ = *rememberPos_;
 			lastViewSize_ = scrolled.w;
 		}
@@ -811,9 +809,7 @@ void ScrollView::Layout() {
 		break;
 	case ORIENT_VERTICAL:
 		if (scrolled.h != lastViewSize_) {
-			if (scrollToTopOnSizeChange_)
-				ScrollTo(0.0f);
-			else if (rememberPos_)
+			if (rememberPos_)
 				scrollPos_ = *rememberPos_;
 			lastViewSize_ = scrolled.h;
 		}

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -800,15 +800,21 @@ void ScrollView::Layout() {
 	switch (orientation_) {
 	case ORIENT_HORIZONTAL:
 		if (scrolled.w != lastViewSize_) {
-			ScrollTo(0.0f);
+			if (scrollToTopOnSizeChange_)
+				ScrollTo(0.0f);
+			else if (rememberPos_)
+				scrollPos_ = *rememberPos_;
 			lastViewSize_ = scrolled.w;
 		}
 		scrolled.x = bounds_.x - layoutScrollPos_;
 		scrolled.y = bounds_.y + margins.top;
 		break;
 	case ORIENT_VERTICAL:
-		if (scrolled.h != lastViewSize_ && scrollToTopOnSizeChange_) {
-			ScrollTo(0.0f);
+		if (scrolled.h != lastViewSize_) {
+			if (scrollToTopOnSizeChange_)
+				ScrollTo(0.0f);
+			else if (rememberPos_)
+				scrollPos_ = *rememberPos_;
 			lastViewSize_ = scrolled.h;
 		}
 		scrolled.x = bounds_.x + margins.left;
@@ -1137,8 +1143,11 @@ void ScrollView::Update() {
 
 	if (oldPos != scrollPos_)
 		orientation_ == ORIENT_HORIZONTAL ? lastScrollPosX = scrollPos_ : lastScrollPosY = scrollPos_;
-	if (rememberPos_)
+
+	// We load some lists asynchronously, so don't update the position until it's loaded.
+	if (rememberPos_ && ClampedScrollPos(scrollPos_) != ClampedScrollPos(*rememberPos_)) {
 		*rememberPos_ = scrollPos_;
+	}
 }
 
 void AnchorLayout::Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert) {

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -295,9 +295,6 @@ public:
 
 	NeighborResult FindScrollNeighbor(View *view, const Point &target, FocusDirection direction, NeighborResult best) override;
 
-	// Quick hack to prevent scrolling to top in some lists
-	void SetScrollToTop(bool t) { scrollToTopOnSizeChange_ = t; }
-
 private:
 	float ClampedScrollPos(float pos);
 
@@ -312,7 +309,6 @@ private:
 	float inertia_ = 0.0f;
 	float pull_ = 0.0f;
 	float lastViewSize_ = 0.0f;
-	bool scrollToTopOnSizeChange_ = false;
 	float *rememberPos_ = nullptr;
 
 	static float lastScrollPosX;

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -262,8 +262,8 @@ public:
 // A scrollview usually contains just a single child - a linear layout or similar.
 class ScrollView : public ViewGroup {
 public:
-	ScrollView(Orientation orientation, LayoutParams *layoutParams = 0, bool rememberPosition = false)
-		: ViewGroup(layoutParams), orientation_(orientation), rememberPosition_(rememberPosition) {}
+	ScrollView(Orientation orientation, LayoutParams *layoutParams = 0)
+		: ViewGroup(layoutParams), orientation_(orientation) {}
 	~ScrollView();
 
 	void Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert) override;
@@ -277,9 +277,13 @@ public:
 	void ScrollTo(float newScrollPos);
 	void ScrollToBottom();
 	void ScrollRelative(float distance);
-	float GetScrollPosition();
 	bool CanScroll() const;
 	void Update() override;
+
+	void RememberPosition(float *pos) {
+		rememberPos_ = pos;
+		ScrollTo(*pos);
+	}
 
 	// Get the last moved scroll view position
 	static void GetLastScrollPosition(float &x, float &y);
@@ -309,7 +313,7 @@ private:
 	float pull_ = 0.0f;
 	float lastViewSize_ = 0.0f;
 	bool scrollToTopOnSizeChange_ = false;
-	bool rememberPosition_;
+	float *rememberPos_ = nullptr;
 
 	static float lastScrollPosX;
 	static float lastScrollPosY;

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -250,7 +250,6 @@ void ControlMappingScreen::CreateViews() {
 
 	rightScroll_ = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(1.0f));
 	rightScroll_->SetTag("ControlMapping");
-	rightScroll_->SetScrollToTop(false);
 	LinearLayout *rightColumn = new LinearLayoutList(ORIENT_VERTICAL);
 	rightScroll_->Add(rightColumn);
 

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -96,7 +96,6 @@ void CwCheatScreen::CreateViews() {
 
 	rightScroll_ = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT, 0.5f));
 	rightScroll_->SetTag("CwCheats");
-	rightScroll_->SetScrollToTop(false);
 	rightScroll_->RememberPosition(&g_Config.fCwCheatScrollPosition);
 	LinearLayout *rightColumn = new LinearLayoutList(ORIENT_VERTICAL, new LinearLayoutParams(200, FILL_PARENT, actionMenuMargins));
 	rightScroll_->Add(rightColumn);

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -97,7 +97,7 @@ void CwCheatScreen::CreateViews() {
 	rightScroll_ = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, FILL_PARENT, 0.5f));
 	rightScroll_->SetTag("CwCheats");
 	rightScroll_->SetScrollToTop(false);
-	rightScroll_->ScrollTo(g_Config.fCwCheatScrollPosition);
+	rightScroll_->RememberPosition(&g_Config.fCwCheatScrollPosition);
 	LinearLayout *rightColumn = new LinearLayoutList(ORIENT_VERTICAL, new LinearLayoutParams(200, FILL_PARENT, actionMenuMargins));
 	rightScroll_->Add(rightColumn);
 
@@ -140,7 +140,6 @@ void CwCheatScreen::onFinish(DialogResult result) {
 	if (MIPSComp::jit) {
 		MIPSComp::jit->ClearCache();
 	}
-	g_Config.fCwCheatScrollPosition = rightScroll_->GetScrollPosition();
 }
 
 UI::EventReturn CwCheatScreen::OnEnableAll(UI::EventParams &params) {

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1007,7 +1007,7 @@ void MainScreen::CreateViews() {
 
 	Button *focusButton = nullptr;
 	if (hasStorageAccess) {
-		scrollAllGames_ = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT), true);
+		scrollAllGames_ = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		scrollAllGames_->SetTag("MainScreenAllGames");
 		ScrollView *scrollHomebrew = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		scrollHomebrew->SetTag("MainScreenHomebrew");
@@ -1026,7 +1026,7 @@ void MainScreen::CreateViews() {
 
 		tabHolder_->AddTab(mm->T("Games"), scrollAllGames_);
 		tabHolder_->AddTab(mm->T("Homebrew & Demos"), scrollHomebrew);
-		scrollAllGames_->ScrollTo(g_Config.fGameListScrollPosition);
+		scrollAllGames_->RememberPosition(&g_Config.fGameListScrollPosition);
 
 		tabAllGames->OnChoice.Handle(this, &MainScreen::OnGameSelectedInstant);
 		tabHomebrew->OnChoice.Handle(this, &MainScreen::OnGameSelectedInstant);
@@ -1247,9 +1247,6 @@ void MainScreen::update() {
 	if (vertical != lastVertical_) {
 		RecreateViews();
 		lastVertical_ = vertical;
-	}
-	if (scrollAllGames_) {
-		g_Config.fGameListScrollPosition = scrollAllGames_->GetScrollPosition();
 	}
 }
 


### PR DESCRIPTION
Fixes #14710, which is really a regression from previous release.  #13710 was in v1.11.x.

-[Unknown]