### PR TITLE
[Adhoc] Fix threading issue when exiting PPSSPP due to unjoined AdhocServer thread

### DIFF
--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1300,8 +1300,8 @@ void sendChat(std::string chatString) {
 			std::string message = chatString.substr(0, 60); // 64 return chat variable corrupted is it out of memory?
 			strcpy(chat.message, message.c_str());
 			//Send Chat Messages
-			if (IsSocketReady(metasocket, false, true) > 0) {
-				int chatResult = send(metasocket, (const char*)&chat, sizeof(chat), MSG_NOSIGNAL);
+			if (IsSocketReady((int)metasocket, false, true) > 0) {
+				int chatResult = send((int)metasocket, (const char*)&chat, sizeof(chat), MSG_NOSIGNAL);
 				NOTICE_LOG(SCENET, "Send Chat %s to Adhoc Server", chat.message);
 				std::string name = g_Config.sNickName.c_str();
 
@@ -1396,8 +1396,8 @@ int friendFinder(){
 				} 
 				else {
 					networkInited = false;
-					shutdown(metasocket, SD_BOTH);
-					closesocket(metasocket);
+					shutdown((int)metasocket, SD_BOTH);
+					closesocket((int)metasocket);
 					metasocket = (int)INVALID_SOCKET;
 				}
 			}
@@ -1414,16 +1414,16 @@ int friendFinder(){
 				uint8_t opcode = OPCODE_PING;
 
 				// Send Ping to Server, may failed with socket error 10054/10053 if someone else with the same IP already connected to AdHoc Server (the server might need to be modified to differentiate MAC instead of IP)
-				if (IsSocketReady(metasocket, false, true) > 0) {
-					int iResult = send(metasocket, (const char*)&opcode, 1, MSG_NOSIGNAL);
+				if (IsSocketReady((int)metasocket, false, true) > 0) {
+					int iResult = send((int)metasocket, (const char*)&opcode, 1, MSG_NOSIGNAL);
 					int error = errno;
 					// KHBBS seems to be getting error 10053 often
 					if (iResult == SOCKET_ERROR) {
 						ERROR_LOG(SCENET, "FriendFinder: Socket Error (%i) when sending OPCODE_PING", error);
 						if (error != EAGAIN && error != EWOULDBLOCK) {
 							networkInited = false;
-							shutdown(metasocket, SD_BOTH);
-							closesocket(metasocket);
+							shutdown((int)metasocket, SD_BOTH);
+							closesocket((int)metasocket);
 							metasocket = (int)INVALID_SOCKET;
 							host->NotifyUserMessage(std::string(n->T("Disconnected from AdhocServer")) + " (" + std::string(n->T("Error")) + ": " + std::to_string(error) + ")", 2.0, 0x0000ff);
 							// Mark all friends as timedout since we won't be able to detects disconnected friends anymore without being connected to Adhoc Server
@@ -1441,8 +1441,8 @@ int friendFinder(){
 			}
 
 			// Check for Incoming Data
-			if (IsSocketReady(metasocket, true, false) > 0) {
-				int received = recv(metasocket, (char*)(rx + rxpos), sizeof(rx) - rxpos, MSG_NOSIGNAL);
+			if (IsSocketReady((int)metasocket, true, false) > 0) {
+				int received = recv((int)metasocket, (char*)(rx + rxpos), sizeof(rx) - rxpos, MSG_NOSIGNAL);
 
 				// Free Network Lock
 				//_freeNetworkLock();
@@ -1795,7 +1795,7 @@ int getLocalIp(sockaddr_in* SocketAddress) {
 		struct sockaddr_in localAddr;
 		localAddr.sin_addr.s_addr = INADDR_ANY;
 		socklen_t addrLen = sizeof(localAddr);
-		int ret = getsockname(metasocket, (struct sockaddr*)&localAddr, &addrLen);
+		int ret = getsockname((int)metasocket, (struct sockaddr*)&localAddr, &addrLen);
 		if (SOCKET_ERROR != ret) {
 			SocketAddress->sin_addr = localAddr.sin_addr;
 			return 0;
@@ -2152,23 +2152,23 @@ int initNetwork(SceNetAdhocctlAdhocId *adhoc_id){
 		ERROR_LOG(SCENET, "Invalid socket");
 		return SOCKET_ERROR;
 	}
-	setSockKeepAlive(metasocket, true);
+	setSockKeepAlive((int)metasocket, true);
 	// Disable Nagle Algo to prevent delaying small packets
-	setSockNoDelay(metasocket, 1);
+	setSockNoDelay((int)metasocket, 1);
 	// Switch to Nonblocking Behaviour
-	changeBlockingMode(metasocket, 1);
+	changeBlockingMode((int)metasocket, 1);
 
 	// If Server is at localhost Try to Bind socket to specific adapter before connecting to prevent 2nd instance being recognized as already existing 127.0.0.1 by AdhocServer
 	// (may not works in WinXP/2003 for IPv4 due to "Weak End System" model)
 	if (isLoopbackIP(g_adhocServerIP.in.sin_addr.s_addr)) { 
 		int on = 1;
 		// Not sure what is this SO_DONTROUTE supposed to fix, but i do remembered there were issue related to multiple-instances without SO_DONTROUTE, but forgot how to reproduce it :(
-		setsockopt(metasocket, SOL_SOCKET, SO_DONTROUTE, (const char*)&on, sizeof(on));
-		setSockReuseAddrPort(metasocket);
+		setsockopt((int)metasocket, SOL_SOCKET, SO_DONTROUTE, (const char*)&on, sizeof(on));
+		setSockReuseAddrPort((int)metasocket);
 
 		g_localhostIP.in.sin_port = 0;
 		// Bind Local Address to Socket
-		iResult = bind(metasocket, &g_localhostIP.addr, sizeof(g_localhostIP.addr));
+		iResult = bind((int)metasocket, &g_localhostIP.addr, sizeof(g_localhostIP.addr));
 		if (iResult == SOCKET_ERROR) {
 			ERROR_LOG(SCENET, "Bind to alternate localhost[%s] failed(%i).", ip2str(g_localhostIP.in.sin_addr).c_str(), iResult);
 			host->NotifyUserMessage(std::string(n->T("Failed to Bind Localhost IP")) + " " + ip2str(g_localhostIP.in.sin_addr).c_str(), 2.0, 0x0000ff);
@@ -2199,18 +2199,18 @@ int initNetwork(SceNetAdhocctlAdhocId *adhoc_id){
 	// Connect to Adhoc Server
 	int errorcode = 0;
 	int cnt = 0;
-	iResult = connect(metasocket, &g_adhocServerIP.addr, sizeof(g_adhocServerIP));
+	iResult = connect((int)metasocket, &g_adhocServerIP.addr, sizeof(g_adhocServerIP));
 	errorcode = errno;
 
 	if (iResult == SOCKET_ERROR && errorcode != EISCONN) {
 		u64 startTime = (u64)(time_now_d() * 1000000.0);
-		while (IsSocketReady(metasocket, false, true) <= 0) {
+		while (IsSocketReady((int)metasocket, false, true) <= 0) {
 			u64 now = (u64)(time_now_d() * 1000000.0);
 			if (coreState == CORE_POWERDOWN) return iResult;
 			if (now - startTime > adhocDefaultTimeout) break;
 			sleep_ms(10);
 		}
-		if (IsSocketReady(metasocket, false, true) <= 0) {
+		if (IsSocketReady((int)metasocket, false, true) <= 0) {
 			ERROR_LOG(SCENET, "Socket error (%i) when connecting to AdhocServer [%s/%s:%u]", errorcode, g_Config.proAdhocServer.c_str(), ip2str(g_adhocServerIP.in.sin_addr).c_str(), ntohs(g_adhocServerIP.in.sin_port));
 			host->NotifyUserMessage(std::string(n->T("Failed to connect to Adhoc Server")) + " (" + std::string(n->T("Error")) + ": " + std::to_string(errorcode) + ")", 1.0f, 0x0000ff);
 			return iResult;
@@ -2227,12 +2227,12 @@ int initNetwork(SceNetAdhocctlAdhocId *adhoc_id){
 	packet.name.data[ADHOCCTL_NICKNAME_LEN - 1] = 0;
 	memcpy(packet.game.data, adhoc_id->data, ADHOCCTL_ADHOCID_LEN);
 
-	IsSocketReady(metasocket, false, true, nullptr, adhocDefaultTimeout);
-	int sent = send(metasocket, (char*)&packet, sizeof(packet), MSG_NOSIGNAL);
+	IsSocketReady((int)metasocket, false, true, nullptr, adhocDefaultTimeout);
+	int sent = send((int)metasocket, (char*)&packet, sizeof(packet), MSG_NOSIGNAL);
 	if (sent > 0) {
 		socklen_t addrLen = sizeof(LocalIP);
 		memset(&LocalIP, 0, addrLen);
-		getsockname(metasocket, &LocalIP, &addrLen);
+		getsockname((int)metasocket, &LocalIP, &addrLen);
 		host->NotifyUserMessage(n->T("Network Initialized"), 1.0);
 		return 0;
 	}

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -40,6 +40,7 @@
 
 #include <thread>
 #include <mutex>
+#include <atomic>
 
 #include "Common/Net/Resolve.h"
 #include "Common/Serialize/Serializer.h"

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -915,7 +915,7 @@ extern int actionAfterMatchingMipsCall;
 #define SOCK_PDP	1
 #define SOCK_PTP	2
 // Aux vars
-extern int metasocket;
+extern std::atomic<int> metasocket;
 extern SceNetAdhocctlParameter parameter;
 extern SceNetAdhocctlAdhocId product_code;
 extern std::thread friendFinderThread;
@@ -941,7 +941,7 @@ extern SceNetAdhocMatchingContext * contexts;
 extern char* dummyPeekBuf64k;
 extern int dummyPeekBuf64kSize;
 extern int one;                 
-extern bool friendFinderRunning;
+extern std::atomic<bool> friendFinderRunning;
 extern SceNetAdhocctlPeerInfo * friends;
 extern SceNetAdhocctlScanInfo * networks;
 extern u64 adhocctlStartTime;

--- a/Core/HLE/proAdhocServer.cpp
+++ b/Core/HLE/proAdhocServer.cpp
@@ -80,8 +80,7 @@ SceNetAdhocctlUserNode * _db_user = NULL;
 SceNetAdhocctlGameNode * _db_game = NULL;
 
 // Server Status
-//int _status = 0;
-bool adhocServerRunning = false;
+std::atomic<bool> adhocServerRunning(false);
 std::thread adhocServerThread;
 
 // Crosslink database for cross region Adhoc play

--- a/Core/HLE/proAdhocServer.h
+++ b/Core/HLE/proAdhocServer.h
@@ -369,5 +369,5 @@ void update_status();
 int proAdhocServerThread(int port); // (int argc, char * argv[])
 
 //extern int _status;
-extern bool adhocServerRunning;
+extern std::atomic<bool> adhocServerRunning;
 extern std::thread adhocServerThread;

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -118,12 +118,11 @@ static int sceNetAdhocPdpRecv(int id, void* addr, void* port, void* buf, void* d
 
 void __NetAdhocShutdown() {
 	// Kill AdhocServer Thread
-	if (adhocServerRunning) {
-		adhocServerRunning = false;
-		if (adhocServerThread.joinable()) {
-			adhocServerThread.join();
-		}
+	adhocServerRunning = false;
+	if (adhocServerThread.joinable()) {
+		adhocServerThread.join();
 	}
+
 	// Checks to avoid confusing logspam
 	if (netAdhocMatchingInited) {
 		NetAdhocMatching_Term();
@@ -1180,8 +1179,8 @@ void __NetAdhocInit() {
 	__AdhocServerInit();
 
 	// Create built-in AdhocServer Thread
+	adhocServerRunning = false;
 	if (g_Config.bEnableWlan && g_Config.bEnableAdhocServer) {
-		adhocServerRunning = true;
 		adhocServerThread = std::thread(proAdhocServerThread, SERVER_PORT);
 	}
 }

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -2364,7 +2364,7 @@ u32 NetAdhocctl_Disconnect() {
 		int us = adhocDefaultDelay * 3;
 		hleEatMicro(1000);
 
-		if (isAdhocctlBusy) {
+		if (isAdhocctlBusy && CoreTiming::IsScheduled(adhocctlNotifyEvent)) {
 			return ERROR_NET_ADHOCCTL_BUSY;
 		}
 

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -336,8 +336,8 @@ static void __AdhocctlNotify(u64 userdata, int cyclesLate) {
 			ret = SOCKET_ERROR;
 			sockerr = EAGAIN;
 			// Don't send anything yet if connection to Adhoc Server is still in progress
-			if (!isAdhocctlNeedLogin && IsSocketReady(metasocket, false, true) > 0) {
-				ret = send(metasocket, (const char*)&packet, len, MSG_NOSIGNAL);
+			if (!isAdhocctlNeedLogin && IsSocketReady((int)metasocket, false, true) > 0) {
+				ret = send((int)metasocket, (const char*)&packet, len, MSG_NOSIGNAL);
 				sockerr = errno;
 				// Successfully Sent or Connection has been closed or Connection failure occurred
 				if (ret >= 0 || (ret == SOCKET_ERROR && sockerr != EAGAIN && sockerr != EWOULDBLOCK)) {
@@ -403,7 +403,7 @@ static void __AdhocctlState(u64 userdata, int cyclesLate) {
 
 // Used to simulate blocking on metasocket when send OP code to AdhocServer
 int WaitBlockingAdhocctlSocket(AdhocctlRequest request, int usec, const char* reason) {
-	int uid = (metasocket <= 0) ? 1 : metasocket;
+	int uid = (metasocket <= 0) ? 1 : (int)metasocket;
 
 	if (adhocctlRequests.find(uid) != adhocctlRequests.end()) {
 		WARN_LOG(SCENET, "sceNetAdhocctl - WaitID[%d] already existed, Socket is busy!", uid);
@@ -2383,7 +2383,7 @@ u32 NetAdhocctl_Disconnect() {
 			//_acquireNetworkLock();
 
 			// Send Disconnect Request Packet
-			iResult = send(metasocket, (const char*)&opcode, 1, MSG_NOSIGNAL);
+			iResult = send((int)metasocket, (const char*)&opcode, 1, MSG_NOSIGNAL);
 			error = errno;
 
 			// Sending may get socket error 10053 if the AdhocServer is already shutted down
@@ -2500,8 +2500,8 @@ int NetAdhocctl_Term() {
 		adhocctlHandlers.clear();
 		// Free stuff here
 		networkInited = false;
-		shutdown(metasocket, SD_BOTH);
-		closesocket(metasocket);
+		shutdown((int)metasocket, SD_BOTH);
+		closesocket((int)metasocket);
 		metasocket = (int)INVALID_SOCKET;
 		// Delete fake PSP Thread. 
 		// kernelObjects may already been cleared early during a Shutdown, thus trying to access it may generates Warning/Error in the log

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1230,7 +1230,6 @@ static u32 sceNetAdhocctlInit(int stackSize, int prio, u32 productAddr) {
 
 	// TODO: Merging friendFinder (real) thread to AdhocThread (fake) thread on PSP side
 	if (!friendFinderRunning) {
-		friendFinderRunning = true;
 		friendFinderThread = std::thread(friendFinder);
 	}
 	


### PR DESCRIPTION
I bumped this issue when AdhocServer failed to bind with socket error 10013 (probably blocked by firewall or the port reserved by hyper-v) during Initialization and exited the AdhocServer thread immediately, thus the condition to join it failed to meet upon Shutdown, and causing a popup window to appears on Debug build.