### PR TITLE
Add a crude way to blacklist post/texture shaders from certain vendors.

### DIFF
--- a/GPU/Common/PostShader.h
+++ b/GPU/Common/PostShader.h
@@ -82,7 +82,7 @@ struct TextureShaderInfo {
 	}
 };
 
-void ReloadAllPostShaderInfo();
+void ReloadAllPostShaderInfo(Draw::DrawContext *draw);
 
 const ShaderInfo *GetPostShaderInfo(const std::string &name);
 std::vector<const ShaderInfo *> GetPostShaderChain(const std::string &name);

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -218,7 +218,7 @@ static std::string ReadShaderSrc(const Path &filename) {
 bool PresentationCommon::UpdatePostShader() {
 	std::vector<const ShaderInfo *> shaderInfo;
 	if (!g_Config.vPostShaderNames.empty()) {
-		ReloadAllPostShaderInfo();
+		ReloadAllPostShaderInfo(draw_);
 		shaderInfo = GetFullPostShadersChain(g_Config.vPostShaderNames);
 	}
 
@@ -810,7 +810,7 @@ void PresentationCommon::CalculateRenderResolution(int *width, int *height, int 
 	// Check if postprocessing shader is doing upscaling as it requires native resolution
 	std::vector<const ShaderInfo *> shaderInfo;
 	if (!g_Config.vPostShaderNames.empty()) {
-		ReloadAllPostShaderInfo();
+		ReloadAllPostShaderInfo(draw_);
 		shaderInfo = GetFullPostShadersChain(g_Config.vPostShaderNames);
 	}
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -393,7 +393,7 @@ void TextureCacheVulkan::CompileScalingShader() {
 	if (!g_Config.bTexHardwareScaling)
 		return;
 
-	ReloadAllPostShaderInfo();
+	ReloadAllPostShaderInfo(draw_);
 	const TextureShaderInfo *shaderInfo = GetTextureShaderInfo(g_Config.sTextureShaderName);
 	if (!shaderInfo || shaderInfo->computeShaderFile.empty())
 		return;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -190,7 +190,7 @@ bool PathToVisualUsbPath(Path path, std::string &outPath) {
 }
 
 void GameSettingsScreen::CreateViews() {
-	ReloadAllPostShaderInfo();
+	ReloadAllPostShaderInfo(screenManager()->getDrawContext());
 
 	if (editThenRestore_) {
 		std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(nullptr, gamePath_, 0);

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -520,9 +520,11 @@ void PromptScreen::TriggerFinish(DialogResult result) {
 	UIDialogScreenWithBackground::TriggerFinish(result);
 }
 
-PostProcScreen::PostProcScreen(const std::string &title, int id) : ListPopupScreen(title), id_(id) {
+PostProcScreen::PostProcScreen(const std::string &title, int id) : ListPopupScreen(title), id_(id) { }
+
+void PostProcScreen::CreateViews() {
 	auto ps = GetI18NCategory("PostShaders");
-	ReloadAllPostShaderInfo();
+	ReloadAllPostShaderInfo(screenManager()->getDrawContext());
 	shaders_ = GetAllPostShaderInfo();
 	std::vector<std::string> items;
 	int selected = -1;
@@ -535,6 +537,7 @@ PostProcScreen::PostProcScreen(const std::string &title, int id) : ListPopupScre
 		items.push_back(ps->T(shaders_[i].section.c_str(), shaders_[i].name.c_str()));
 	}
 	adaptor_ = UI::StringVectorListAdaptor(items, selected);
+	ListPopupScreen::CreateViews();
 }
 
 void PostProcScreen::OnCompleted(DialogResult result) {
@@ -547,9 +550,11 @@ void PostProcScreen::OnCompleted(DialogResult result) {
 		g_Config.vPostShaderNames.push_back(value);
 }
 
-TextureShaderScreen::TextureShaderScreen(const std::string &title) : ListPopupScreen(title) {
+TextureShaderScreen::TextureShaderScreen(const std::string &title) : ListPopupScreen(title) {}
+
+void TextureShaderScreen::CreateViews() {
 	auto ps = GetI18NCategory("TextureShaders");
-	ReloadAllPostShaderInfo();
+	ReloadAllPostShaderInfo(screenManager()->getDrawContext());
 	shaders_ = GetAllTextureShaderInfo();
 	std::vector<std::string> items;
 	int selected = -1;
@@ -559,6 +564,8 @@ TextureShaderScreen::TextureShaderScreen(const std::string &title) : ListPopupSc
 		items.push_back(ps->T(shaders_[i].section.c_str(), shaders_[i].name.c_str()));
 	}
 	adaptor_ = UI::StringVectorListAdaptor(items, selected);
+
+	ListPopupScreen::CreateViews();
 }
 
 void TextureShaderScreen::OnCompleted(DialogResult result) {

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -108,6 +108,8 @@ class PostProcScreen : public ListPopupScreen {
 public:
 	PostProcScreen(const std::string &title, int id);
 
+	void CreateViews() override;
+
 private:
 	void OnCompleted(DialogResult result) override;
 	bool ShowButtons() const override { return true; }
@@ -118,6 +120,8 @@ private:
 class TextureShaderScreen : public ListPopupScreen {
 public:
 	TextureShaderScreen(const std::string &title);
+
+	void CreateViews() override;
 
 private:
 	void OnCompleted(DialogResult result) override;

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -175,7 +175,9 @@ namespace MainWindow {
 
 		// We only reload this initially and when a menu is actually opened.
 		if (!menuShaderInfoLoaded) {
-			ReloadAllPostShaderInfo();
+			// This is on Windows where we don't currently blacklist any vendors, or similar.
+			// TODO: Figure out how to have the GPU data while reloading the post shader info.
+			ReloadAllPostShaderInfo(nullptr);
 			menuShaderInfoLoaded = true;
 		}
 

--- a/assets/shaders/defaultshaders.ini
+++ b/assets/shaders/defaultshaders.ini
@@ -154,6 +154,7 @@ Type=Texture
 Name=4xBRZ
 Author=Hyllian
 Compute=tex_4xbrz.csh
+VendorBlacklist=ARM
 [TexMMPX]
 Type=Texture
 Name=MMPX


### PR DESCRIPTION
Use it to work around #14530 for now.

Not pretty, but works, until I can rework how upscaling compute shaders work (they really should each have a fixed scale, without that resampling thingy at the end that runs the algorithm multiple times).