### PR TITLE
[AdhocDiscover] An attempt to implement AdhocDiscover

### DIFF
--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -26,6 +26,13 @@
 typedef struct MatchingArgs {
 	u32_le data[6]; //ContextID, Opcode, bufAddr[ to MAC], OptLen, OptAddr[, EntryPoint]
 } PACK MatchingArgs;
+
+typedef struct SceNetAdhocDiscoverParam {
+	u32_le unknown1; // SleepMode? (ie. 0 on on Legend Of The Dragon, 1 on Dissidia 012)
+	char   groupName[ADHOCCTL_GROUPNAME_LEN];
+	u32_le unknown2; // size of something? (ie. 0x3c on Legend Of The Dragon, 0x14 on Dissidia 012) // Note: the param size is 0x14 may be it can contains extra data too?
+	u32_le result; // inited to 0?
+} PACK SceNetAdhocDiscoverParam;
 #ifdef _MSC_VER
 #pragma pack(pop)
 #endif
@@ -68,6 +75,22 @@ enum AdhocSocketRequestType : int
 	PDP_RECV = 6,
 	ADHOC_POLL_SOCKET = 7,
 };
+
+enum AdhocDiscoverStatus : int
+{
+	NET_ADHOC_DISCOVER_STATUS_NONE = 0,
+	NET_ADHOC_DISCOVER_STATUS_IN_PROGRESS = 1,
+	NET_ADHOC_DISCOVER_STATUS_COMPLETED = 2,
+};
+
+enum AdhocDiscoverResult : int
+{
+	NET_ADHOC_DISCOVER_RESULT_NO_PEER_FOUND = 0, // Initial value
+	NET_ADHOC_DISCOVER_RESULT_CANCELED = 1, // CANCELED or STOPPED?
+	NET_ADHOC_DISCOVER_RESULT_PEER_FOUND = 2,
+	NET_ADHOC_DISCOVER_RESULT_ABORTED = 3, // Internal Error occured?
+};
+
 
 class PointerWrap;
 


### PR DESCRIPTION
An attempt to implement AdhocDiscover, doesn't fully working yet to be a success, but at least we can cancel the waiting process properly now, instead of stuck forever and unable to go back to previous menu.

~~Please don't merge this yet, since i only~~ tested this on 2 games Digivice Ver. Portable and Legend of the Dragon #14557
~~I need to test this on~~ other games that seems to use AdhocDiscover too, such as: 
- Dissidia 012
- Monster Hunter 2nd
- Got Eater 2

I believe there will be more games appeared in this list that use AdhocDiscover syscalls in the future https://report.ppsspp.org/logs/kinds/

PS: These are based on JPCSP HLE (which didn't work there, and still stuck) along with some information from LLE to improve it (JPCSP LLE didn't work either, but can be canceled properly), also added some information/code based on decompiled pspnet_adhoc_discover.prx