### PR TITLE
softgpu: Avoid fast path for clamp/wrap cases

### DIFF
--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -223,6 +223,12 @@ void DrawSprite(const VertexData& v0, const VertexData& v1) {
 
 bool g_needsClearAfterDialog = false;
 
+static inline bool NoClampOrWrap(const Vec2f &tc) {
+	if (tc.x < 0 || tc.y < 0)
+		return false;
+	return tc.x < gstate.getTextureWidth(0) && tc.y < gstate.getTextureHeight(0);
+}
+
 // Returns true if the normal path should be skipped.
 bool RectangleFastPath(const VertexData &v0, const VertexData &v1) {
 	g_DarkStalkerStretch = DSStretch::Off;
@@ -236,7 +242,8 @@ bool RectangleFastPath(const VertexData &v0, const VertexData &v1) {
 		(ydiff == vdiff || ydiff == -vdiff);
 	// Currently only works for TL/BR, which is the most common but not required.
 	bool orient_check = xdiff >= 0 && ydiff >= 0;
-	bool state_check = !gstate.isModeClear();  // TODO: Add support for clear modes in Rasterizer::DrawSprite.
+	// We already have a fast path for clear in ClearRectangle.
+	bool state_check = !gstate.isModeClear() && NoClampOrWrap(v0.texturecoords) && NoClampOrWrap(v1.texturecoords);
 	if ((coord_check || !gstate.isTextureMapEnabled()) && orient_check && state_check) {
 		Rasterizer::DrawSprite(v0, v1);
 		return true;


### PR DESCRIPTION
It doesn't clamp or wrap, and those are uncommon for the fast path.  Fixes #14951.

-[Unknown]