### PR TITLE
[Adhoc] Workaround for a more cross-platform behavior on PtpConnect (but inaccurate)

### DIFF
--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -3615,9 +3615,13 @@ int NetAdhocPtp_Connect(int id, int timeout, int flag, bool allowForcedConnect) 
 								return hleLogDebug(SCENET, ERROR_NET_ADHOC_WOULD_BLOCK, "would block");
 							}
 						}
-						// No connection could be made because the target device actively refused it.
+						// No connection could be made because the target device actively refused it (on Windows/Linux/Android), or no one listening on the remote address (on Linux/Android).
 						else if (errorcode == ECONNREFUSED) {
-							return hleLogError(SCENET, ERROR_NET_ADHOC_CONNECTION_REFUSED, "connection refused");
+							// Workaround for ERROR_NET_ADHOC_CONNECTION_REFUSED to be more cross-platform, since there is no way to simulate ERROR_NET_ADHOC_CONNECTION_REFUSED properly on Windows
+							if (flag)
+								return hleLogError(SCENET, ERROR_NET_ADHOC_WOULD_BLOCK, "connection refused workaround");
+							else
+								return hleLogError(SCENET, ERROR_NET_ADHOC_TIMEOUT, "connection refused workaround");
 						}
 					}
 				}

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -795,11 +795,12 @@ int DoBlockingPtpConnect(int uid, AdhocSocketRequest& req, s64& result) {
 			if (sock->nonblocking)
 				result = ERROR_NET_ADHOC_WOULD_BLOCK;
 			else
-				result = ERROR_NET_ADHOC_TIMEOUT;
+				result = ERROR_NET_ADHOC_TIMEOUT; // FIXME: PSP never returned ERROR_NET_ADHOC_TIMEOUT on PtpConnect? or only returned ERROR_NET_ADHOC_TIMEOUT when the host is too busy? Seems to be returning ERROR_NET_ADHOC_CONNECTION_REFUSED on timedout instead (if the other side in not listening yet).
 		}
 	}
+	// Select was interrupted or contains invalid args?
 	else
-		result = ERROR_NET_ADHOC_CONNECTION_REFUSED; // ERROR_NET_ADHOC_TIMEOUT;
+		result = ERROR_NET_ADHOC_EXCEPTION_EVENT; // ERROR_NET_ADHOC_INVALID_ARG;
 
 	if (ret == SOCKET_ERROR)
 		DEBUG_LOG(SCENET, "sceNetAdhocPtpConnect[%i]: Socket Error (%i)", req.id, sockerr);


### PR DESCRIPTION
This is a workaround to solves different behavior between Windows and non-Windows as mentioned at https://github.com/hrydgard/ppsspp/issues/14554#issuecomment-934432824

**On Windows:** a non-blocking `connect` will keeps returning `EWOULDBLOCK` when the other side is not `listen`ing yet
**On Linux/Android(probably Unix/BSD too):** have similar behavior to PSP, which return `EWOULDBLOCK`/`EAGAIN` for a short while and then became `ECONNREFUSED` for the rest of `connect` attempts on the same socket when no body is listening.

Since there is no way to implement `ERROR_NET_ADHOC_CONNECTION_REFUSED` properly using non-blocking socket on Windows, this PR will do the opposite, which is making non-Windows platform to behave the same with Windows by using `ERROR_NET_ADHOC_WOULD_BLOCK` instead (which might be an inaccurate error code)

This should have a side effect of making some games to work when they're not supposed to work due to timings issue, because `ERROR_NET_ADHOC_WOULD_BLOCK` will trigger the game to try again, while `ERROR_NET_ADHOC_CONNECTION_REFUSED` will cause the game to stop trying.

PS: i haven't tested this yet since i only have 1 android device, so we'll need to wait for feedback first.
Android test build: https://www.dropbox.com/s/qtqpn3iv4uc4sae/PPSSPP_1.11_kenshin2test.apk?dl=0