### PR TITLE
Debugger: Fix submenu offsets from removing unused

### DIFF
--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -29,6 +29,7 @@
 #include <set>
 
 TCHAR CtrlDisAsmView::szClassName[] = _T("CtrlDisAsmView");
+constexpr int POPUP_SUBMENU_ID_DISASM = 1;
 extern HMENU g_hPopupMenus;
 
 void CtrlDisAsmView::init()
@@ -929,7 +930,8 @@ void CtrlDisAsmView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 		//popup menu?
 		POINT pt;
 		GetCursorPos(&pt);
-		switch(TrackPopupMenuEx(GetSubMenu(g_hPopupMenus,1),TPM_RIGHTBUTTON|TPM_RETURNCMD,pt.x,pt.y,wnd,0))
+		HMENU menu = GetSubMenu(g_hPopupMenus, POPUP_SUBMENU_ID_DISASM);
+		switch (TrackPopupMenuEx(menu, TPM_RIGHTBUTTON | TPM_RETURNCMD, pt.x, pt.y, wnd, 0))
 		{
 		case ID_DISASM_GOTOINMEMORYVIEW:
 			SendMessage(GetParent(wnd),WM_DEB_GOTOHEXEDIT,curAddress,0);

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -18,6 +18,7 @@
 #include "DumpMemoryWindow.h"
 
 wchar_t CtrlMemView::szClassName[] = L"CtrlMemView";
+constexpr int POPUP_SUBMENU_ID_MEMVIEW = 0;
 extern HMENU g_hPopupMenus;
 
 CtrlMemView::CtrlMemView(HWND _wnd)
@@ -482,7 +483,7 @@ void CtrlMemView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 		bool enable16 = !asciiSelected && (curAddress % 2) == 0;
 		bool enable32 = !asciiSelected && (curAddress % 4) == 0;
 
-		HMENU menu = GetSubMenu(g_hPopupMenus,0);
+		HMENU menu = GetSubMenu(g_hPopupMenus, POPUP_SUBMENU_ID_MEMVIEW);
 		EnableMenuItem(menu,ID_MEMVIEW_COPYVALUE_16,enable16 ? MF_ENABLED : MF_GRAYED);
 		EnableMenuItem(menu,ID_MEMVIEW_COPYVALUE_32,enable32 ? MF_ENABLED : MF_GRAYED);
 

--- a/Windows/Debugger/CtrlRegisterList.cpp
+++ b/Windows/Debugger/CtrlRegisterList.cpp
@@ -24,6 +24,7 @@ extern HMENU g_hPopupMenus;
 enum { REGISTER_PC = 32, REGISTER_HI, REGISTER_LO, REGISTERS_END };
 
 TCHAR CtrlRegisterList::szClassName[] = _T("CtrlRegisterList");
+constexpr int POPUP_SUBMENU_ID_REGLIST = 2;
 
 void CtrlRegisterList::init()
 {
@@ -511,7 +512,8 @@ void CtrlRegisterList::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 		}
 		POINT pt;
 		GetCursorPos(&pt);
-		switch(TrackPopupMenuEx(GetSubMenu(g_hPopupMenus,3),TPM_RIGHTBUTTON|TPM_RETURNCMD,pt.x,pt.y,wnd,0))
+		HMENU menu = GetSubMenu(g_hPopupMenus, POPUP_SUBMENU_ID_REGLIST);
+		switch (TrackPopupMenuEx(menu, TPM_RIGHTBUTTON | TPM_RETURNCMD, pt.x, pt.y, wnd, 0))
 		{
 		case ID_REGLIST_GOTOINMEMORYVIEW:
 			SendMessage(GetParent(wnd),WM_DEB_GOTOHEXEDIT,val,0);

--- a/Windows/Debugger/Debugger_Lists.cpp
+++ b/Windows/Debugger/Debugger_Lists.cpp
@@ -66,9 +66,9 @@ GenericListViewDef moduleListDef = {
 	moduleListColumns,	ARRAY_SIZE(moduleListColumns),	NULL,	false
 };
 
-const int POPUP_SUBMENU_ID_BREAKPOINTLIST = 5;
-const int POPUP_SUBMENU_ID_THREADLIST = 6;
-const int POPUP_SUBMENU_ID_NEWBREAKPOINT = 7;
+const int POPUP_SUBMENU_ID_BREAKPOINTLIST = 3;
+const int POPUP_SUBMENU_ID_THREADLIST = 4;
+const int POPUP_SUBMENU_ID_NEWBREAKPOINT = 5;
 
 //
 // CtrlThreadList

--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -11,7 +11,7 @@
 
 LPCTSTR CtrlDisplayListView::windowClass = _T("CtrlDisplayListView");
 
-const int POPUP_SUBMENU_ID_DISPLAYLISTVIEW = 8;
+const int POPUP_SUBMENU_ID_DISPLAYLISTVIEW = 6;
 extern HMENU g_hPopupMenus;
 
 void CtrlDisplayListView::registerClass()

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -48,7 +48,7 @@
 #include <windowsx.h>
 #include <commctrl.h>
 
-const int POPUP_SUBMENU_ID_GEDBG_PREVIEW = 10;
+const int POPUP_SUBMENU_ID_GEDBG_PREVIEW = 8;
 
 using namespace GPUBreakpoints;
 using namespace GPUDebug;

--- a/Windows/GEDebugger/TabState.cpp
+++ b/Windows/GEDebugger/TabState.cpp
@@ -28,7 +28,7 @@
 
 using namespace GPUBreakpoints;
 
-const int POPUP_SUBMENU_ID_GEDBG_STATE = 9;
+const int POPUP_SUBMENU_ID_GEDBG_STATE = 7;
 
 // TODO: Show an icon or something for breakpoints, toggle.
 static const GenericListViewColumn stateValuesCols[] = {


### PR DESCRIPTION
The wrong menus were showing in several places, especially the GE debugger.

Fixes #14979, broken in 882c22a.

-[Unknown]