### PR TITLE
Draw: Atomically release objects

### DIFF
--- a/Common/GPU/thin3d.cpp
+++ b/Common/GPU/thin3d.cpp
@@ -69,30 +69,20 @@ bool DataFormatIsDepthStencil(DataFormat fmt) {
 
 bool RefCountedObject::Release() {
 	if (refcount_ > 0 && refcount_ < 10000) {
-		refcount_--;
-		if (refcount_ == 0) {
+		if (--refcount_ == 0) {
 			delete this;
 			return true;
 		}
-	}
-	else {
-		_dbg_assert_msg_(false, "Refcount (%d) invalid for object %p - corrupt?", refcount_, this);
+	} else {
+		_dbg_assert_msg_(false, "Refcount (%d) invalid for object %p - corrupt?", refcount_.load(), this);
 	}
 	return false;
 }
 
 bool RefCountedObject::ReleaseAssertLast() {
-	_dbg_assert_msg_(refcount_ == 1, "RefCountedObject: Expected to be the last reference, but isn't!");
-	if (refcount_ > 0 && refcount_ < 10000) {
-		refcount_--;
-		if (refcount_ == 0) {
-			delete this;
-			return true;
-		}
-	} else {
-		ERROR_LOG(G3D, "Refcount (%d) invalid for object %p - corrupt?", refcount_, this);
-	}
-	return false;
+	bool released = Release();
+	_dbg_assert_msg_(released, "RefCountedObject: Expected to be the last reference, but isn't!");
+	return released;
 }
 
 

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdint>
 #include <cstddef>
 #include <functional>
@@ -324,7 +325,9 @@ protected:
 
 class RefCountedObject {
 public:
-	RefCountedObject() : refcount_(1) {}
+	RefCountedObject() {
+		refcount_ = 1;
+	}
 	virtual ~RefCountedObject() {}
 
 	void AddRef() { refcount_++; }
@@ -332,7 +335,7 @@ public:
 	bool ReleaseAssertLast();
 
 private:
-	int refcount_;
+	std::atomic<int> refcount_;
 };
 
 template <typename T>

--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -597,9 +597,10 @@ std::shared_ptr<Download> Downloader::StartDownloadWithCallback(
 void Downloader::Update() {
 	restart:
 	for (size_t i = 0; i < downloads_.size(); i++) {
-		if (downloads_[i]->Progress() == 1.0f || downloads_[i]->Failed()) {
-			downloads_[i]->RunCallback();
-			downloads_[i]->Join();
+		auto &dl = downloads_[i];
+		if (dl->Done()) {
+			dl->RunCallback();
+			dl->Join();
 			downloads_.erase(downloads_.begin() + i);
 			goto restart;
 		}


### PR DESCRIPTION
There may be scenarios where we release objects from separate threads, just make them safe.

This is my best guess for the double free in #14981.  Even if it's not the problem, I think this is safer.  The scenario I'm imagining is:
1. Draw is freed by another thread than the UI thread.
2. UI is freed at the same time.
3. Both see `refcount_ == 0` at the same time.

That said, I don't think that would've been the issue in #14981 (since it's in finish dialog), but I'm not certain it can't be.

Also made DownloadManager check Done(), since that's intentionally set last and has a comment asserting that all should check Done().

-[Unknown]