### PR TITLE
UI: Delay between successive mapping in controls

### DIFF
--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -57,12 +57,14 @@ private:
 class KeyMappingNewKeyDialog : public PopupScreen {
 public:
 	explicit KeyMappingNewKeyDialog(int btn, bool replace, std::function<void(KeyDef)> callback, std::shared_ptr<I18NCategory> i18n)
-		: PopupScreen(i18n->T("Map Key"), "Cancel", ""), callback_(callback), mapped_(false) {
+		: PopupScreen(i18n->T("Map Key"), "Cancel", ""), callback_(callback) {
 		pspBtn_ = btn;
 	}
 
 	virtual bool key(const KeyInput &key) override;
 	virtual bool axis(const AxisInput &axis) override;
+
+	void SetDelay(float t);
 
 protected:
 	void CreatePopupContents(UI::ViewGroup *parent) override;
@@ -74,7 +76,8 @@ protected:
 private:
 	int pspBtn_;
 	std::function<void(KeyDef)> callback_;
-	bool mapped_;  // Prevent double registrations
+	bool mapped_ = false;  // Prevent double registrations
+	double delayUntil_ = 0.0f;
 };
 
 class KeyMappingNewMouseKeyDialog : public PopupScreen {
@@ -178,7 +181,7 @@ private:
 	UI::EventReturn OnMapButton(UI::EventParams &e);
 	UI::EventReturn OnBindAll(UI::EventParams &e);
 	void HandleKeyMapping(KeyDef key);
-	void MapNext();
+	void MapNext(bool successive);
 
 	MockPSP *psp_ = nullptr;
 	int nextKey_ = 0;


### PR DESCRIPTION
I'll confess I did a lot of the testing of this dialog using a keyboard, and almost none with an actual analog stick.  This is better even for bind all, enforcing a short delay after the dialog is triggered before it'll complete.

-[Unknown]