### PR TITLE
Debugger: Centralize context menu handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2174,6 +2174,8 @@ set(WindowsFiles
 	Windows/InputBox.h
 	Windows/InputDevice.cpp
 	Windows/InputDevice.h
+	Windows/W32Util/ContextMenu.h
+	Windows/W32Util/ContextMenu.h
 	Windows/W32Util/DialogManager.cpp
 	Windows/W32Util/DialogManager.h
 	Windows/W32Util/Misc.cpp

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -3,6 +3,7 @@
 #include "Windows/resource.h"
 #include "Core/MemMap.h"
 #include "Core/MIPS/JitCommon/JitCommon.h"
+#include "Windows/W32Util/ContextMenu.h"
 #include "Windows/W32Util/Misc.h"
 #include "Windows/W32Util/ShellUtil.h"
 #include "Windows/MainWindow.h"
@@ -29,8 +30,6 @@
 #include <set>
 
 TCHAR CtrlDisAsmView::szClassName[] = _T("CtrlDisAsmView");
-constexpr int POPUP_SUBMENU_ID_DISASM = 1;
-extern HMENU g_hPopupMenus;
 
 void CtrlDisAsmView::init()
 {
@@ -927,11 +926,7 @@ void CtrlDisAsmView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 	}
 	else if (button == 2)
 	{
-		//popup menu?
-		POINT pt;
-		GetCursorPos(&pt);
-		HMENU menu = GetSubMenu(g_hPopupMenus, POPUP_SUBMENU_ID_DISASM);
-		switch (TrackPopupMenuEx(menu, TPM_RIGHTBUTTON | TPM_RETURNCMD, pt.x, pt.y, wnd, 0))
+		switch (TriggerContextMenu(ContextMenuID::DISASM, wnd, ContextPoint::FromEvent(lParam)))
 		{
 		case ID_DISASM_GOTOINMEMORYVIEW:
 			SendMessage(GetParent(wnd),WM_DEB_GOTOHEXEDIT,curAddress,0);

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -7,6 +7,7 @@
 #include "Core/Config.h"
 #include "Windows/resource.h"
 #include "Core/MemMap.h"
+#include "Windows/W32Util/ContextMenu.h"
 #include "Windows/W32Util/Misc.h"
 #include "Windows/InputBox.h"
 #include "Windows/main.h"
@@ -18,8 +19,6 @@
 #include "DumpMemoryWindow.h"
 
 wchar_t CtrlMemView::szClassName[] = L"CtrlMemView";
-constexpr int POPUP_SUBMENU_ID_MEMVIEW = 0;
-extern HMENU g_hPopupMenus;
 
 CtrlMemView::CtrlMemView(HWND _wnd)
 {
@@ -476,18 +475,14 @@ void CtrlMemView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 {
 	if (button==2)
 	{
-		//popup menu?
-		POINT pt;
-		GetCursorPos(&pt);
-
 		bool enable16 = !asciiSelected && (curAddress % 2) == 0;
 		bool enable32 = !asciiSelected && (curAddress % 4) == 0;
 
-		HMENU menu = GetSubMenu(g_hPopupMenus, POPUP_SUBMENU_ID_MEMVIEW);
+		HMENU menu = GetContextMenu(ContextMenuID::MEMVIEW);
 		EnableMenuItem(menu,ID_MEMVIEW_COPYVALUE_16,enable16 ? MF_ENABLED : MF_GRAYED);
 		EnableMenuItem(menu,ID_MEMVIEW_COPYVALUE_32,enable32 ? MF_ENABLED : MF_GRAYED);
 
-		switch (TrackPopupMenuEx(menu,TPM_RIGHTBUTTON|TPM_RETURNCMD,pt.x,pt.y,wnd,0))
+		switch (TriggerContextMenu(ContextMenuID::MEMVIEW, wnd, ContextPoint::FromEvent(lParam)))
 		{
 		case ID_MEMVIEW_DUMP:
 			{

--- a/Windows/Debugger/CtrlRegisterList.cpp
+++ b/Windows/Debugger/CtrlRegisterList.cpp
@@ -7,6 +7,7 @@
 #include "Common/Data/Encoding/Utf8.h"
 #include "Windows/resource.h"
 #include "Core/MemMap.h"
+#include "Windows/W32Util/ContextMenu.h"
 #include "Windows/W32Util/Misc.h"
 #include "Windows/InputBox.h"
 
@@ -19,12 +20,9 @@
 
 #include "Windows/main.h"
 
-extern HMENU g_hPopupMenus;
-
 enum { REGISTER_PC = 32, REGISTER_HI, REGISTER_LO, REGISTERS_END };
 
 TCHAR CtrlRegisterList::szClassName[] = _T("CtrlRegisterList");
-constexpr int POPUP_SUBMENU_ID_REGLIST = 2;
 
 void CtrlRegisterList::init()
 {
@@ -510,10 +508,8 @@ void CtrlRegisterList::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 		{
 			return;
 		}
-		POINT pt;
-		GetCursorPos(&pt);
-		HMENU menu = GetSubMenu(g_hPopupMenus, POPUP_SUBMENU_ID_REGLIST);
-		switch (TrackPopupMenuEx(menu, TPM_RIGHTBUTTON | TPM_RETURNCMD, pt.x, pt.y, wnd, 0))
+
+		switch (TriggerContextMenu(ContextMenuID::REGLIST, wnd, ContextPoint::FromEvent(lParam)))
 		{
 		case ID_REGLIST_GOTOINMEMORYVIEW:
 			SendMessage(GetParent(wnd),WM_DEB_GOTOHEXEDIT,val,0);

--- a/Windows/Debugger/DebuggerShared.h
+++ b/Windows/Debugger/DebuggerShared.h
@@ -2,8 +2,6 @@
 #include "Common/CommonWindows.h"
 #include "Core/Debugger/DebugInterface.h"
 
-extern HMENU g_hPopupMenus;
-
 enum { WM_DEB_GOTOWPARAM = WM_USER+2,
 	WM_DEB_GOTOADDRESSEDIT,
 	WM_DEB_MAPLOADED,

--- a/Windows/Debugger/Debugger_Lists.cpp
+++ b/Windows/Debugger/Debugger_Lists.cpp
@@ -2,13 +2,14 @@
 #include "Common/CommonWindows.h"
 #include <windowsx.h>
 #include <commctrl.h>
+#include "Windows/Debugger/BreakpointWindow.h"
 #include "Windows/Debugger/DebuggerShared.h"
 #include "Windows/Debugger/CtrlDisAsmView.h"
+#include "Windows/W32Util/ContextMenu.h"
 #include "Windows/resource.h"
 #include "Windows/main.h"
-#include "BreakpointWindow.h"
-#include "../../Core/HLE/sceKernelThread.h"
 #include "Common/Data/Encoding/Utf8.h"
+#include "Core/HLE/sceKernelThread.h"
 
 enum { TL_NAME, TL_PROGRAMCOUNTER, TL_ENTRYPOINT, TL_PRIORITY, TL_STATE, TL_WAITTYPE, TL_COLUMNCOUNT };
 enum { BPL_ENABLED, BPL_TYPE, BPL_OFFSET, BPL_SIZELABEL, BPL_OPCODE, BPL_CONDITION, BPL_HITS, BPL_COLUMNCOUNT };
@@ -66,10 +67,6 @@ GenericListViewDef moduleListDef = {
 	moduleListColumns,	ARRAY_SIZE(moduleListColumns),	NULL,	false
 };
 
-const int POPUP_SUBMENU_ID_BREAKPOINTLIST = 3;
-const int POPUP_SUBMENU_ID_THREADLIST = 4;
-const int POPUP_SUBMENU_ID_NEWBREAKPOINT = 5;
-
 //
 // CtrlThreadList
 //
@@ -114,10 +111,7 @@ void CtrlThreadList::showMenu(int itemIndex, const POINT &pt)
 	if (Core_IsActive())
 		return;
 
-	POINT screenPt(pt);
-	ClientToScreen(GetHandle(), &screenPt);
-
-	HMENU subMenu = GetSubMenu(g_hPopupMenus, POPUP_SUBMENU_ID_THREADLIST);
+	HMENU subMenu = GetContextMenu(ContextMenuID::THREADLIST);
 	switch (threadInfo.status) {
 	case THREADSTATUS_DEAD:
 	case THREADSTATUS_DORMANT:
@@ -138,7 +132,7 @@ void CtrlThreadList::showMenu(int itemIndex, const POINT &pt)
 		break;
 	}
 
-	switch (TrackPopupMenuEx(subMenu, TPM_RIGHTBUTTON | TPM_RETURNCMD, screenPt.x, screenPt.y, GetHandle(), 0))
+	switch (TriggerContextMenu(ContextMenuID::THREADLIST, GetHandle(), ContextPoint::FromClient(pt)))
 	{
 	case ID_DISASM_THREAD_FORCERUN:
 		__KernelResumeThreadFromWait(threadInfo.id, 0);
@@ -569,16 +563,11 @@ void CtrlBreakpointList::OnToggle(int item, bool newValue)
 
 void CtrlBreakpointList::showBreakpointMenu(int itemIndex, const POINT &pt)
 {
-	POINT screenPt(pt);
-	ClientToScreen(GetHandle(), &screenPt);
-
 	bool isMemory;
 	int index = getBreakpointIndex(itemIndex, isMemory);
 	if (index == -1)
 	{
-		HMENU subMenu = GetSubMenu(g_hPopupMenus, POPUP_SUBMENU_ID_NEWBREAKPOINT);
-		
-		switch (TrackPopupMenuEx(subMenu, TPM_RIGHTBUTTON | TPM_RETURNCMD, screenPt.x, screenPt.y, GetHandle(), 0))
+		switch (TriggerContextMenu(ContextMenuID::NEWBREAKPOINT, GetHandle(), ContextPoint::FromClient(pt)))
 		{
 		case ID_DISASM_ADDNEWBREAKPOINT:
 			{		
@@ -596,14 +585,14 @@ void CtrlBreakpointList::showBreakpointMenu(int itemIndex, const POINT &pt)
 			bpPrev = displayedBreakPoints_[index];
 		}
 
-		HMENU subMenu = GetSubMenu(g_hPopupMenus, POPUP_SUBMENU_ID_BREAKPOINTLIST);
+		HMENU subMenu = GetContextMenu(ContextMenuID::BREAKPOINTLIST);
 		if (isMemory) {
 			CheckMenuItem(subMenu, ID_DISASM_DISABLEBREAKPOINT, MF_BYCOMMAND | (mcPrev.IsEnabled() ? MF_CHECKED : MF_UNCHECKED));
 		} else {
 			CheckMenuItem(subMenu, ID_DISASM_DISABLEBREAKPOINT, MF_BYCOMMAND | (bpPrev.IsEnabled() ? MF_CHECKED : MF_UNCHECKED));
 		}
 
-		switch (TrackPopupMenuEx(subMenu, TPM_RIGHTBUTTON | TPM_RETURNCMD, screenPt.x, screenPt.y, GetHandle(), 0))
+		switch (TriggerContextMenu(ContextMenuID::BREAKPOINTLIST, GetHandle(), ContextPoint::FromClient(pt)))
 		{
 		case ID_DISASM_DISABLEBREAKPOINT:
 			if (isMemory) {

--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -4,15 +4,13 @@
 #include "Windows/GEDebugger/CtrlDisplayListView.h"
 #include "Windows/GEDebugger/GEDebugger.h"
 #include "Windows/InputBox.h"
+#include "Windows/W32Util/ContextMenu.h"
 #include "Windows/main.h"
 #include "Core/Config.h"
 #include "GPU/Debugger/Breakpoints.h"
 #include "GPU/GPUState.h"
 
 LPCTSTR CtrlDisplayListView::windowClass = _T("CtrlDisplayListView");
-
-const int POPUP_SUBMENU_ID_DISPLAYLISTVIEW = 6;
-extern HMENU g_hPopupMenus;
 
 void CtrlDisplayListView::registerClass()
 {
@@ -298,10 +296,7 @@ void CtrlDisplayListView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 {
 	if (button == 2)
 	{
-		//popup menu?
-		POINT pt;
-		GetCursorPos(&pt);
-		switch(TrackPopupMenuEx(GetSubMenu(g_hPopupMenus,POPUP_SUBMENU_ID_DISPLAYLISTVIEW),TPM_RIGHTBUTTON|TPM_RETURNCMD,pt.x,pt.y,wnd,0))
+		switch (TriggerContextMenu(ContextMenuID::DISPLAYLISTVIEW, wnd, ContextPoint::FromEvent(lParam)))
 		{
 		case ID_DISASM_GOTOINMEMORYVIEW:
 			if (memoryWindow)

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -33,6 +33,7 @@
 #include "Windows/GEDebugger/TabDisplayLists.h"
 #include "Windows/GEDebugger/TabState.h"
 #include "Windows/GEDebugger/TabVertices.h"
+#include "Windows/W32Util/ContextMenu.h"
 #include "Windows/W32Util/ShellUtil.h"
 #include "Windows/InputBox.h"
 #include "Windows/MainWindow.h"
@@ -47,8 +48,6 @@
 #include "GPU/Debugger/Stepping.h"
 #include <windowsx.h>
 #include <commctrl.h>
-
-const int POPUP_SUBMENU_ID_GEDBG_PREVIEW = 8;
 
 using namespace GPUBreakpoints;
 using namespace GPUDebug;
@@ -211,15 +210,13 @@ CGEDebugger::~CGEDebugger() {
 
 void CGEDebugger::SetupPreviews() {
 	if (primaryWindow == nullptr) {
-		HMENU subMenu = GetSubMenu(g_hPopupMenus, POPUP_SUBMENU_ID_GEDBG_PREVIEW);
-
 		primaryWindow = SimpleGLWindow::GetFrom(GetDlgItem(m_hDlg, IDC_GEDBG_FRAME));
 		primaryWindow->Initialize(SimpleGLWindow::ALPHA_IGNORE | SimpleGLWindow::RESIZE_SHRINK_CENTER);
 		primaryWindow->SetHoverCallback([&] (int x, int y) {
 			PrimaryPreviewHover(x, y);
 		});
-		primaryWindow->SetRightClickMenu(subMenu, [&] (int cmd) {
-			HMENU subMenu = GetSubMenu(g_hPopupMenus, POPUP_SUBMENU_ID_GEDBG_PREVIEW);
+		primaryWindow->SetRightClickMenu(ContextMenuID::GEDBG_PREVIEW, [&] (int cmd) {
+			HMENU subMenu = GetContextMenu(ContextMenuID::GEDBG_PREVIEW);
 			switch (cmd) {
 			case 0:
 				// Setup.
@@ -243,15 +240,13 @@ void CGEDebugger::SetupPreviews() {
 		primaryWindow->Clear();
 	}
 	if (secondWindow == nullptr) {
-		HMENU subMenu = GetSubMenu(g_hPopupMenus, POPUP_SUBMENU_ID_GEDBG_PREVIEW);
-
 		secondWindow = SimpleGLWindow::GetFrom(GetDlgItem(m_hDlg, IDC_GEDBG_TEX));
 		secondWindow->Initialize(SimpleGLWindow::ALPHA_BLEND | SimpleGLWindow::RESIZE_SHRINK_CENTER);
 		secondWindow->SetHoverCallback([&] (int x, int y) {
 			SecondPreviewHover(x, y);
 		});
-		secondWindow->SetRightClickMenu(subMenu, [&] (int cmd) {
-			HMENU subMenu = GetSubMenu(g_hPopupMenus, POPUP_SUBMENU_ID_GEDBG_PREVIEW);
+		secondWindow->SetRightClickMenu(ContextMenuID::GEDBG_PREVIEW, [&] (int cmd) {
+			HMENU subMenu = GetContextMenu(ContextMenuID::GEDBG_PREVIEW);
 			switch (cmd) {
 			case 0:
 				// Setup.

--- a/Windows/GEDebugger/SimpleGLWindow.cpp
+++ b/Windows/GEDebugger/SimpleGLWindow.cpp
@@ -23,6 +23,7 @@
 #include "Common/Common.h"
 #include "Common/Log.h"
 #include "Windows/GEDebugger/SimpleGLWindow.h"
+#include "Windows/W32Util/ContextMenu.h"
 
 const wchar_t *SimpleGLWindow::windowClass = L"SimpleGLWindow";
 
@@ -563,11 +564,10 @@ bool SimpleGLWindow::RightClick(int mouseX, int mouseY) {
 	}
 
 	POINT pt{mouseX, mouseY};
-	ClientToScreen(hWnd_, &pt);
 
 	rightClickCallback_(0);
-	int result = TrackPopupMenuEx(rightClickMenu_, TPM_RIGHTBUTTON | TPM_RETURNCMD, pt.x, pt.y, hWnd_, 0);
-	if (result != 0) {
+	int result = TriggerContextMenu(rightClickMenu_, hWnd_, ContextPoint::FromClient(pt));
+	if (result > 0) {
 		rightClickCallback_(result);
 	}
 

--- a/Windows/GEDebugger/SimpleGLWindow.h
+++ b/Windows/GEDebugger/SimpleGLWindow.h
@@ -22,6 +22,7 @@
 
 #include "Common/GPU/OpenGL/GLSLProgram.h"
 #include "Common/CommonWindows.h"
+#include "Windows/W32Util/ContextMenu.h"
 
 struct SimpleGLWindow {
 	static const wchar_t *windowClass;
@@ -116,7 +117,7 @@ struct SimpleGLWindow {
 	}
 
 	// Called first with 0 that it's opening, then the selected item.
-	void SetRightClickMenu(HMENU menu, std::function<void(int)> callback) {
+	void SetRightClickMenu(ContextMenuID menu, std::function<void(int)> callback) {
 		rightClickCallback_ = callback;
 		rightClickMenu_ = menu;
 	}
@@ -173,5 +174,5 @@ protected:
 	std::function<void()> redrawCallback_;
 	std::function<void(int, int)> hoverCallback_;
 	std::function<void(int)> rightClickCallback_;
-	HMENU rightClickMenu_;
+	ContextMenuID rightClickMenu_;
 };

--- a/Windows/GEDebugger/TabState.cpp
+++ b/Windows/GEDebugger/TabState.cpp
@@ -17,18 +17,16 @@
 
 #include "Common/Common.h"
 #include "Windows/resource.h"
-#include "Windows/main.h"
 #include "Windows/InputBox.h"
 #include "Windows/GEDebugger/GEDebugger.h"
 #include "Windows/GEDebugger/TabState.h"
+#include "Windows/W32Util/ContextMenu.h"
 #include "GPU/GPUState.h"
 #include "GPU/GeDisasm.h"
 #include "GPU/Common/GPUDebugInterface.h"
 #include "GPU/Debugger/Breakpoints.h"
 
 using namespace GPUBreakpoints;
-
-const int POPUP_SUBMENU_ID_GEDBG_STATE = 7;
 
 // TODO: Show an icon or something for breakpoints, toggle.
 static const GenericListViewColumn stateValuesCols[] = {
@@ -876,7 +874,7 @@ void CtrlStateValues::OnRightClick(int row, int column, const POINT &point) {
 	POINT screenPt(point);
 	ClientToScreen(GetHandle(), &screenPt);
 
-	HMENU subMenu = GetSubMenu(g_hPopupMenus, POPUP_SUBMENU_ID_GEDBG_STATE);
+	HMENU subMenu = GetContextMenu(ContextMenuID::GEDBG_STATE);
 	SetMenuDefaultItem(subMenu, ID_REGLIST_CHANGE, FALSE);
 
 	// Ehh, kinda ugly.
@@ -886,7 +884,7 @@ void CtrlStateValues::OnRightClick(int row, int column, const POINT &point) {
 		ModifyMenu(subMenu, ID_GEDBG_WATCH, MF_BYCOMMAND | MF_STRING, ID_GEDBG_WATCH, L"Add Watch");
 	}
 
-	switch (TrackPopupMenuEx(subMenu, TPM_RIGHTBUTTON | TPM_RETURNCMD, screenPt.x, screenPt.y, GetHandle(), 0))
+	switch (TriggerContextMenu(ContextMenuID::GEDBG_STATE, GetHandle(), ContextPoint::FromClient(point)))
 	{
 	case ID_DISASM_TOGGLEBREAKPOINT:
 		if (IsCmdBreakpoint(info.cmd)) {

--- a/Windows/PPSSPP.vcxproj
+++ b/Windows/PPSSPP.vcxproj
@@ -936,6 +936,7 @@
     <ClCompile Include="RawInput.cpp" />
     <ClCompile Include="TouchInputHandler.cpp" />
     <ClCompile Include="GPU\WindowsVulkanContext.cpp" />
+    <ClCompile Include="W32Util\ContextMenu.cpp" />
     <ClCompile Include="W32Util\DialogManager.cpp" />
     <ClCompile Include="W32Util\Misc.cpp">
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)%(Filename)2.obj</ObjectFileName>
@@ -1471,6 +1472,7 @@
     <ClInclude Include="RawInput.h" />
     <ClInclude Include="TouchInputHandler.h" />
     <ClInclude Include="GPU\WindowsVulkanContext.h" />
+    <ClInclude Include="W32Util\ContextMenu.h" />
     <ClInclude Include="W32Util\DialogManager.h" />
     <ClInclude Include="W32Util\Misc.h" />
     <ClInclude Include="W32Util\ShellUtil.h" />

--- a/Windows/PPSSPP.vcxproj.filters
+++ b/Windows/PPSSPP.vcxproj.filters
@@ -268,6 +268,9 @@
     <ClCompile Include="..\android\jni\OpenSLContext.cpp">
       <Filter>Other Platforms\Android</Filter>
     </ClCompile>
+    <ClCompile Include="W32Util\ContextMenu.cpp">
+      <Filter>Windows\W32Util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Debugger\CtrlDisAsmView.h">
@@ -534,6 +537,9 @@
     </ClInclude>
     <ClInclude Include="..\android\jni\AndroidContentURI.h">
       <Filter>Other Platforms\Android</Filter>
+    </ClInclude>
+    <ClInclude Include="W32Util\ContextMenu.h">
+      <Filter>Windows\W32Util</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Windows/W32Util/ContextMenu.cpp
+++ b/Windows/W32Util/ContextMenu.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2021- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "Windows/W32Util/ContextMenu.h"
+#include "Windows/main.h"
+
+ContextPoint ContextPoint::FromCursor() {
+	ContextPoint result;
+	GetCursorPos(&result.pos_);
+	return result;
+}
+
+ContextPoint ContextPoint::FromClient(const POINT &clientPoint) {
+	ContextPoint result;
+	result.pos_ = clientPoint;
+	result.isClient_ = true;
+	return result;
+}
+
+ContextPoint ContextPoint::FromEvent(LPARAM lParam) {
+	ContextPoint result;
+	result.pos_.x = LOWORD(lParam);
+	result.pos_.y = HIWORD(lParam);
+	result.isClient_ = true;
+	return result;
+}
+
+HMENU GetContextMenu(ContextMenuID which) {
+	return GetSubMenu(g_hPopupMenus, (int)which);
+}
+
+int TriggerContextMenu(ContextMenuID which, HWND wnd, const ContextPoint &pt) {
+	POINT pos = pt.pos_;
+	if (pt.isClient_) {
+		ClientToScreen(wnd, &pos);
+	}
+
+	HMENU menu = GetContextMenu(which);
+	if (!menu)
+		return -1;
+
+	return TrackPopupMenuEx(menu, TPM_RIGHTBUTTON | TPM_RETURNCMD, pos.x, pos.y, wnd, 0);
+}

--- a/Windows/W32Util/ContextMenu.cpp
+++ b/Windows/W32Util/ContextMenu.cpp
@@ -16,7 +16,13 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "Windows/W32Util/ContextMenu.h"
-#include "Windows/main.h"
+#include "Windows/resource.h"
+
+static HMENU g_hPopupMenus;
+
+void ContextMenuInit(HINSTANCE inst) {
+	g_hPopupMenus = LoadMenu(inst, (LPCWSTR)IDR_POPUPMENUS);
+}
 
 ContextPoint ContextPoint::FromCursor() {
 	ContextPoint result;

--- a/Windows/W32Util/ContextMenu.h
+++ b/Windows/W32Util/ContextMenu.h
@@ -41,5 +41,7 @@ struct ContextPoint {
 	bool isClient_ = false;
 };
 
+void ContextMenuInit(HINSTANCE inst);
+
 HMENU GetContextMenu(ContextMenuID);
 int TriggerContextMenu(ContextMenuID which, HWND wnd, const ContextPoint &pt);

--- a/Windows/W32Util/ContextMenu.h
+++ b/Windows/W32Util/ContextMenu.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2021- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "Common/CommonWindows.h"
+
+// Must match the order in ppsspp.rc.
+enum class ContextMenuID {
+	MEMVIEW = 0,
+	DISASM = 1,
+	REGLIST = 2,
+	BREAKPOINTLIST = 3,
+	THREADLIST = 4,
+	NEWBREAKPOINT = 5,
+	DISPLAYLISTVIEW = 6,
+	GEDBG_STATE = 7,
+	GEDBG_PREVIEW = 8,
+};
+
+struct ContextPoint {
+	static ContextPoint FromCursor();
+	static ContextPoint FromClient(const POINT &clientPoint);
+	static ContextPoint FromEvent(LPARAM lParam);
+
+	POINT pos_{};
+	bool isClient_ = false;
+};
+
+HMENU GetContextMenu(ContextMenuID);
+int TriggerContextMenu(ContextMenuID which, HWND wnd, const ContextPoint &pt);

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -65,6 +65,7 @@
 #if PPSSPP_API(ANY_GL)
 #include "Windows/GEDebugger/GEDebugger.h"
 #endif
+#include "Windows/W32Util/ContextMenu.h"
 #include "Windows/W32Util/DialogManager.h"
 #include "Windows/W32Util/ShellUtil.h"
 
@@ -101,7 +102,6 @@ static std::string gpuDriverVersion;
 
 static std::string restartArgs;
 
-HMENU g_hPopupMenus;
 int g_activeWindow = 0;
 
 static std::thread inputBoxThread;
@@ -665,10 +665,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	timeBeginPeriod(1);  // TODO: Evaluate if this makes sense to keep.
 
+	ContextMenuInit(_hInstance);
 	MainWindow::Init(_hInstance);
-
-	g_hPopupMenus = LoadMenu(_hInstance, (LPCWSTR)IDR_POPUPMENUS);
-
 	MainWindow::Show(_hInstance);
 
 	HWND hwndMain = MainWindow::GetHWND();

--- a/Windows/main.h
+++ b/Windows/main.h
@@ -31,7 +31,6 @@ extern CMemoryDlg *memoryWindow;
 extern CGEDebugger* geDebuggerWindow;
 #endif
 
-extern HMENU g_hPopupMenus;
 extern int g_activeWindow;
 
 enum { WINDOW_MAINWINDOW, WINDOW_CPUDEBUGGER, WINDOW_GEDEBUGGER };


### PR DESCRIPTION
This moves tracking of context menu definitions to a single file, and simplifies some repeated code.  I think it's better to put all the IDs in one place.

-[Unknown]