### PR TITLE
UI: Disable focus movement on game start

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -185,6 +185,10 @@ EmuScreen::EmuScreen(const Path &filename)
 
 	OnDevMenu.Handle(this, &EmuScreen::OnDevTools);
 	OnChatMenu.Handle(this, &EmuScreen::OnChat);
+
+	// Usually, we don't want focus movement enabled on this screen, so disable on start.
+	// Only if you open chat or dev tools do we want it to start working.
+	UI::EnableFocusMovement(false);
 }
 
 bool EmuScreen::bootAllowStorage(const Path &filename) {


### PR DESCRIPTION
Otherwise, dev tools or chat remain usable while trying to play the game.  This was an unintentional bug from chat UI refactoring.

Fixes #14991.

-[Unknown]