### PR TITLE
Update target Android version from 11 to 12. (API 30 to 31).

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -55,8 +55,8 @@
             android:name=".PpssppActivity"
             android:configChanges="locale|keyboard|keyboardHidden|navigation|uiMode"
             android:label="@string/app_name"
-            android:theme="@style/ppsspp_style">
-
+            android:theme="@style/ppsspp_style"
+            android:exported="true">
             <!-- android:screenOrientation="landscape" -->
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -106,7 +106,8 @@
         <meta-data android:name="isGame" android:value="true" />
         <activity
             android:name=".ShortcutActivity"
-            android:label="@string/shortcut_name" >
+            android:label="@string/shortcut_name"
+            android:exported="true">
             <intent-filter>
                 <category android:name="android.intent.category.DEFAULT" />
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ android {
 			}
 		}
 	}
-	compileSdkVersion 30
+	compileSdkVersion 31
 	defaultConfig {
 		applicationId 'org.ppsspp.ppsspp'
 		if (androidGitVersion.name() != "unknown" && androidGitVersion.code() >= 14000000) {
@@ -60,7 +60,7 @@ android {
 		new File("versioncode.txt").write(androidGitVersion.code().toString())
 
 		minSdkVersion 9
-		targetSdkVersion 30
+		targetSdkVersion 31
 		if (project.hasProperty("ANDROID_VERSION_CODE") && project.hasProperty("ANDROID_VERSION_NAME")) {
 			versionCode ANDROID_VERSION_CODE
 			versionName ANDROID_VERSION_NAME


### PR DESCRIPTION
We just updated from 10 to 11 which enabled scoped storage, but now that 12 is final, we might as well target that. Some new APIs are available that might be useful, like a crash dump API and more refresh rate control.

For after all the 1.12.x updates.