### PR TITLE
UI: Add button to show memstick folder

### DIFF
--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -5,6 +5,7 @@
 // Qt 4.7+ / 5.0+ implementation of the framework.
 // Currently supports: Android, Linux, Windows, Mac OSX
 
+#include "ppsspp_config.h"
 #include <QApplication>
 #include <QClipboard>
 #include <QDesktopWidget>
@@ -41,6 +42,7 @@
 #include "Common/Data/Text/I18n.h"
 #include "Common/Thread/ThreadUtil.h"
 #include "Common/Data/Encoding/Utf8.h"
+#include "Common/StringUtils.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
 #include "Core/HW/Camera.h"
@@ -280,7 +282,7 @@ void Vibrate(int length_ms) {
 }
 
 void OpenDirectory(const char *path) {
-	// Unsupported
+	QDesktopServices::openUrl(QUrl::fromLocalFile(QString::fromUtf8(path)));
 }
 
 void LaunchBrowser(const char *url)

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -191,10 +191,13 @@ PermissionStatus System_GetPermissionStatus(SystemPermission permission) { retur
 
 void OpenDirectory(const char *path) {
 #if PPSSPP_PLATFORM(WINDOWS)
-	PIDLIST_ABSOLUTE pidl = ILCreateFromPath(ConvertUTF8ToWString(ReplaceAll(path, "/", "\\")).c_str());
+	SFGAOF flags;
+	PIDLIST_ABSOLUTE pidl = nullptr;
+	HRESULT hr = SHParseDisplayName(ConvertUTF8ToWString(ReplaceAll(path, "/", "\\")).c_str(), nullptr, &pidl, 0, &flags);
 	if (pidl) {
-		SHOpenFolderAndSelectItems(pidl, 0, NULL, 0);
-		ILFree(pidl);
+		if (SUCCEEDED(hr))
+			SHOpenFolderAndSelectItems(pidl, 0, NULL, 0);
+		CoTaskMemFree(pidl);
 	}
 #elif PPSSPP_PLATFORM(MAC)
 	std::string command = std::string("open ") + path;

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -190,12 +190,15 @@ void System_AskForPermission(SystemPermission permission) {}
 PermissionStatus System_GetPermissionStatus(SystemPermission permission) { return PERMISSION_STATUS_GRANTED; }
 
 void OpenDirectory(const char *path) {
-#if defined(_WIN32)
+#if PPSSPP_PLATFORM(WINDOWS)
 	PIDLIST_ABSOLUTE pidl = ILCreateFromPath(ConvertUTF8ToWString(ReplaceAll(path, "/", "\\")).c_str());
 	if (pidl) {
 		SHOpenFolderAndSelectItems(pidl, 0, NULL, 0);
 		ILFree(pidl);
 	}
+#elif PPSSPP_PLATFORM(MAC)
+	std::string command = std::string("open ") + path;
+	system(command.c_str());
 #endif
 }
 

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -168,7 +168,7 @@ void GameScreen::CreateViews() {
 	if (isRecentGame(gamePath_)) {
 		rightColumnItems->Add(AddOtherChoice(new Choice(ga->T("Remove From Recent"))))->OnClick.Handle(this, &GameScreen::OnRemoveFromRecent);
 	}
-#if (defined(USING_QT_UI) || PPSSPP_PLATFORM(WINDOWS)) && !PPSSPP_PLATFORM(UWP)
+#if (defined(USING_QT_UI) || PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(MAC)) && !PPSSPP_PLATFORM(UWP)
 	rightColumnItems->Add(AddOtherChoice(new Choice(ga->T("Show In Folder"))))->OnClick.Handle(this, &GameScreen::OnShowInFolder);
 #endif
 	if (g_Config.bEnableCheats) {

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -168,7 +168,7 @@ void GameScreen::CreateViews() {
 	if (isRecentGame(gamePath_)) {
 		rightColumnItems->Add(AddOtherChoice(new Choice(ga->T("Remove From Recent"))))->OnClick.Handle(this, &GameScreen::OnRemoveFromRecent);
 	}
-#if PPSSPP_PLATFORM(WINDOWS) && !PPSSPP_PLATFORM(UWP)
+#if (defined(USING_QT_UI) || PPSSPP_PLATFORM(WINDOWS)) && !PPSSPP_PLATFORM(UWP)
 	rightColumnItems->Add(AddOtherChoice(new Choice(ga->T("Show In Folder"))))->OnClick.Handle(this, &GameScreen::OnShowInFolder);
 #endif
 	if (g_Config.bEnableCheats) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -920,6 +920,10 @@ void GameSettingsScreen::CreateViews() {
 
 	systemSettings->Add(new ItemHeader(sy->T("PSP Memory Stick")));
 
+#if (defined(USING_QT_UI) || PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(MAC)) && !PPSSPP_PLATFORM(UWP)
+	systemSettings->Add(new Choice(sy->T("Show Memory Stick folder")))->OnClick.Handle(this, &GameSettingsScreen::OnOpenMemStick);
+#endif
+
 #if PPSSPP_PLATFORM(ANDROID)
 	memstickDisplay_ = g_Config.memStickDirectory.ToVisualString();
 	auto memstickPath = systemSettings->Add(new ChoiceWithValueDisplay(&memstickDisplay_, sy->T("Memory Stick folder", "Memory Stick folder"), (const char *)nullptr));
@@ -1152,6 +1156,11 @@ UI::EventReturn GameSettingsScreen::OnJitAffectingSetting(UI::EventParams &e) {
 
 UI::EventReturn GameSettingsScreen::OnChangeMemStickDir(UI::EventParams &e) {
 	screenManager()->push(new MemStickScreen(false));
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn GameSettingsScreen::OnOpenMemStick(UI::EventParams &e) {
+	OpenDirectory(File::ResolvePath(g_Config.memStickDirectory.ToString().c_str()).c_str());
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -109,6 +109,7 @@ private:
 	UI::EventReturn OnAudioDevice(UI::EventParams &e);
 	UI::EventReturn OnJitAffectingSetting(UI::EventParams &e);
 	UI::EventReturn OnChangeMemStickDir(UI::EventParams &e);
+	UI::EventReturn OnOpenMemStick(UI::EventParams &e);
 #if defined(_WIN32) && !PPSSPP_PLATFORM(UWP)
 	UI::EventReturn OnSavePathMydoc(UI::EventParams &e);
 	UI::EventReturn OnSavePathOther(UI::EventParams &e);

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -108,10 +108,14 @@ static std::thread inputBoxThread;
 static bool inputBoxRunning = false;
 
 void OpenDirectory(const char *path) {
-	PIDLIST_ABSOLUTE pidl = ILCreateFromPath(ConvertUTF8ToWString(ReplaceAll(path, "/", "\\")).c_str());
+	SFGAOF flags;
+	PIDLIST_ABSOLUTE pidl = nullptr;
+	HRESULT hr = SHParseDisplayName(ConvertUTF8ToWString(ReplaceAll(path, "/", "\\")).c_str(), nullptr, &pidl, 0, &flags);
+
 	if (pidl) {
-		SHOpenFolderAndSelectItems(pidl, 0, NULL, 0);
-		ILFree(pidl);
+		if (SUCCEEDED(hr))
+			SHOpenFolderAndSelectItems(pidl, 0, nullptr, 0);
+		CoTaskMemFree(pidl);
 	}
 }
 


### PR DESCRIPTION
I didn't carefully test all platforms, but this adds a button to show the memory stick folder in the UI.  This would be useful even on Windows, since people often don't notice the option under File.

It absolutely was necessary to resolve the path, since my memory stick path had a ".." in it.  `ILCreateFromPath` and `SHParseDisplayName` fail on such paths.

Although it doesn't do what was specifically requested, this resolves the real problem of #13919, so I'm going to say fixes #13919.

-[Unknown]