### PR TITLE
Android: Prioritize PAD devices

### DIFF
--- a/android/src/org/ppsspp/ppsspp/InputDeviceState.java
+++ b/android/src/org/ppsspp/ppsspp/InputDeviceState.java
@@ -28,13 +28,15 @@ public class InputDeviceState {
 
 	public InputDeviceState(InputDevice device) {
 		int sources = device.getSources();
-		if ((sources & InputDevice.SOURCE_KEYBOARD) == InputDevice.SOURCE_KEYBOARD && device.getKeyboardType() == InputDevice.KEYBOARD_TYPE_ALPHABETIC) {
+		// First, anything that's a gamepad is a gamepad, even if it has a keyboard or pointer.
+		if ((sources & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD) {
+			this.deviceId = NativeApp.DEVICE_ID_PAD_0;
+		} else if ((sources & InputDevice.SOURCE_KEYBOARD) == InputDevice.SOURCE_KEYBOARD && device.getKeyboardType() == InputDevice.KEYBOARD_TYPE_ALPHABETIC) {
 			this.deviceId = NativeApp.DEVICE_ID_KEYBOARD;
 		} else if ((sources & InputDevice.SOURCE_CLASS_POINTER) == InputDevice.SOURCE_CLASS_POINTER) {
 			this.deviceId = NativeApp.DEVICE_ID_MOUSE;
-		} else if (((sources & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD ||
-				(sources & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK ||
-				(sources & InputDevice.SOURCE_DPAD) == InputDevice.SOURCE_DPAD)) {
+		} else if ((sources & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK ||
+				(sources & InputDevice.SOURCE_DPAD) == InputDevice.SOURCE_DPAD) {
 			this.deviceId = NativeApp.DEVICE_ID_PAD_0;
 		} else {
 			// Built-in buttons like Back etc.


### PR DESCRIPTION
It makes sense that we might flag something as a keyboard or mouse now with the changed logic, and that's probably wrong.  The docs say a "keyboard" is potentially anything with buttons, so presumably many gamepads also call themselves keyboards.

This is a simple priority change, there might be more, but I think it makes sense to just move SOURCE_GAMEPAD up.

See #15000.

-[Unknown]