### PR TITLE
Audio: Correct protection against time skew

### DIFF
--- a/Core/HW/StereoResampler.cpp
+++ b/Core/HW/StereoResampler.cpp
@@ -283,7 +283,7 @@ void StereoResampler::PushSamples(const s32 *samples, unsigned int numSamples) {
 	}
 
 	// Check if we need to roll over to the start of the buffer during the copy.
-	int indexW_left_samples = m_maxBufsize * 2 - (indexW & INDEX_MASK);
+	unsigned int indexW_left_samples = m_maxBufsize * 2 - (indexW & INDEX_MASK);
 	if (numSamples * 2 > indexW_left_samples) {
 		ClampBufferToS16WithVolume(&m_buffer[indexW & INDEX_MASK], samples, indexW_left_samples);
 		ClampBufferToS16WithVolume(&m_buffer[0], samples + indexW_left_samples, numSamples * 2 - indexW_left_samples);

--- a/UI/BackgroundAudio.cpp
+++ b/UI/BackgroundAudio.cpp
@@ -345,7 +345,7 @@ int BackgroundAudio::Play() {
 
 	double now = time_now_d();
 	int sz = 44100 / 60;
-	if (lastPlaybackTime_ > 0.0 && lastPlaybackTime_ >= now) {
+	if (lastPlaybackTime_ > 0.0 && lastPlaybackTime_ <= now) {
 		sz = (int)((now - lastPlaybackTime_) * 44100);
 	}
 	sz = std::min(BUFSIZE / 2, sz);


### PR DESCRIPTION
I made a stupid mistake in #14998 - sorry.  Not sure if it's worth a v1.12.3 or not, but the bg audio plays at a wrong speed because of this.

Refactored a ternary and flipped a condition wrong, didn't bother to retest... stupid mistake.

Also fix a related warning.

-[Unknown]