### PR TITLE
Allow delayed loading of texture replacements

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -887,6 +887,7 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("ReplaceTextures", &g_Config.bReplaceTextures, true, true, true),
 	ReportedConfigSetting("SaveNewTextures", &g_Config.bSaveNewTextures, false, true, true),
 	ConfigSetting("IgnoreTextureFilenames", &g_Config.bIgnoreTextureFilenames, false, true, true),
+	ConfigSetting("ReplaceTexturesAllowLate", &g_Config.bReplaceTexturesAllowLate, true, true, true),
 
 	ReportedConfigSetting("TexScalingLevel", &g_Config.iTexScalingLevel, 1, true, true),
 	ReportedConfigSetting("TexScalingType", &g_Config.iTexScalingType, 0, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -197,6 +197,7 @@ public:
 	bool bReplaceTextures;
 	bool bSaveNewTextures;
 	bool bIgnoreTextureFilenames;
+	bool bReplaceTexturesAllowLate;
 	int iTexScalingLevel; // 0 = auto, 1 = off, 2 = 2x, ..., 5 = 5x
 	int iTexScalingType; // 0 = xBRZ, 1 = Hybrid
 	bool bTexDeposterize;

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -747,7 +747,7 @@ bool ReplacedTexture::IsReady(double budget) {
 	lastUsed_ = time_now_d();
 
 	if (levelData_.size() == levels_.size())
-		return true;
+		return Valid();
 	if (budget <= 0.0)
 		return false;
 

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -759,6 +759,8 @@ public:
 
 	bool WaitFor(uint32_t us) {
 		if (!triggered_) {
+			if (us == 0)
+				return false;
 			std::unique_lock<std::mutex> lock(mutex_);
 			cond_.wait_for(lock, std::chrono::microseconds(us), [&] { return !triggered_; });
 		}
@@ -795,7 +797,8 @@ private:
 bool ReplacedTexture::IsReady(double budget) {
 	lastUsed_ = time_now_d();
 	if (threadWaitable_) {
-		if (!threadWaitable_->WaitFor(budget)) {
+		uint32_t budget_us = budget > 0 ? (uint32_t)(budget * 1000000.0) : 0;
+		if (!threadWaitable_->WaitFor(budget_us)) {
 			return false;
 		} else {
 			threadWaitable_->WaitAndRelease();

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -733,6 +733,10 @@ float TextureReplacer::LookupReduceHashRange(int& w, int& h) {
 	}
 }
 
+bool ReplacedTexture::IsReady(double budget) {
+	return true;
+}
+
 bool ReplacedTexture::Load(int level, void *out, int rowPitch) {
 	_assert_msg_((size_t)level < levels_.size(), "Invalid miplevel");
 	_assert_msg_(out != nullptr && rowPitch > 0, "Invalid out/pitch");

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -781,6 +781,8 @@ public:
 
 	void Run() override {
 		for (int i = (int)tex_.levelData_.size(); i <= tex_.MaxLevel(); ++i) {
+			if (tex_.cancelPrepare_)
+				break;
 			tex_.levelData_.resize(i + 1);
 			tex_.PrepareData(i);
 		}
@@ -928,6 +930,14 @@ void ReplacedTexture::PrepareData(int level) {
 void ReplacedTexture::PurgeIfOlder(double t) {
 	if (lastUsed_ < t && !threadWaitable_) {
 		levelData_.clear();
+	}
+}
+
+ReplacedTexture::~ReplacedTexture() {
+	if (threadWaitable_) {
+		cancelPrepare_ = true;
+		threadWaitable_->WaitAndRelease();
+		threadWaitable_ = nullptr;
 	}
 }
 

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -127,6 +127,8 @@ namespace std {
 }
 
 struct ReplacedTexture {
+	~ReplacedTexture();
+
 	inline bool Valid() {
 		return !levels_.empty();
 	}
@@ -167,7 +169,8 @@ protected:
 	std::vector<std::vector<uint8_t>> levelData_;
 	ReplacedTextureAlpha alphaStatus_;
 	double lastUsed_ = 0.0;
-	LimitedWaitable * threadWaitable_ = nullptr;
+	LimitedWaitable *threadWaitable_ = nullptr;
+	bool cancelPrepare_ = false;
 
 	friend TextureReplacer;
 	friend ReplacedTextureTask;

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -195,6 +195,9 @@ public:
 
 	ReplacedTexture &FindReplacement(u64 cachekey, u32 hash, int w, int h);
 	bool FindFiltering(u64 cachekey, u32 hash, TextureFiltering *forceFiltering);
+	ReplacedTexture &None() {
+		return none_;
+	}
 
 	void NotifyTextureDecoded(const ReplacedTextureDecodeInfo &replacedInfo, const void *data, int pitch, int level, int w, int h);
 

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -153,6 +153,8 @@ struct ReplacedTexture {
 		return (u8)alphaStatus_;
 	}
 
+	bool IsReady(double budget);
+
 	bool Load(int level, void *out, int rowPitch);
 
 protected:

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -32,6 +32,8 @@
 class IniFile;
 class TextureCacheCommon;
 class TextureReplacer;
+class ReplacedTextureTask;
+class LimitedWaitable;
 
 enum class ReplacedTextureFormat {
 	F_5650,
@@ -165,8 +167,10 @@ protected:
 	std::vector<std::vector<uint8_t>> levelData_;
 	ReplacedTextureAlpha alphaStatus_;
 	double lastUsed_ = 0.0;
+	LimitedWaitable * threadWaitable_ = nullptr;
 
 	friend TextureReplacer;
+	friend ReplacedTextureTask;
 };
 
 struct ReplacedTextureDecodeInfo {

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -195,7 +195,7 @@ public:
 
 	ReplacedTexture &FindReplacement(u64 cachekey, u32 hash, int w, int h);
 	bool FindFiltering(u64 cachekey, u32 hash, TextureFiltering *forceFiltering);
-	ReplacedTexture &None() {
+	ReplacedTexture &FindNone() {
 		return none_;
 	}
 

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -162,6 +162,7 @@ struct ReplacedTexture {
 	bool Load(int level, void *out, int rowPitch);
 
 protected:
+	void Prepare();
 	void PrepareData(int level);
 	void PurgeIfOlder(double t);
 

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -158,8 +158,13 @@ struct ReplacedTexture {
 	bool Load(int level, void *out, int rowPitch);
 
 protected:
+	void PrepareData(int level);
+	void PurgeIfOlder(double t);
+
 	std::vector<ReplacedTextureLevel> levels_;
+	std::vector<std::vector<uint8_t>> levelData_;
 	ReplacedTextureAlpha alphaStatus_;
+	double lastUsed_ = 0.0;
 
 	friend TextureReplacer;
 };
@@ -192,6 +197,8 @@ public:
 	bool FindFiltering(u64 cachekey, u32 hash, TextureFiltering *forceFiltering);
 
 	void NotifyTextureDecoded(const ReplacedTextureDecodeInfo &replacedInfo, const void *data, int pitch, int level, int w, int h);
+
+	void Decimate(bool forcePressure);
 
 	static bool GenerateIni(const std::string &gameID, Path &generatedFilename);
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -473,9 +473,14 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 				reason = "scaling";
 			}
 		}
-		if (match && (entry->status & TexCacheEntry::STATUS_TO_REPLACE) && replacementTimeThisFrame_ <= replacementFrameBudget_) {
-			match = false;
-			reason = "replacing";
+		if (match && (entry->status & TexCacheEntry::STATUS_TO_REPLACE) && replacementTimeThisFrame_ < replacementFrameBudget_) {
+			int w0 = gstate.getTextureWidth(0);
+			int h0 = gstate.getTextureHeight(0);
+			ReplacedTexture &replaced = FindReplacement(entry, w0, h0);
+			if (replaced.Valid()) {
+				match = false;
+				reason = "replacing";
+			}
 		}
 
 		if (match) {
@@ -1285,6 +1290,7 @@ ReplacedTexture &TextureCacheCommon::FindReplacement(TexCacheEntry *entry, int &
 	} else if (replaced.Valid()) {
 		entry->status |= TexCacheEntry::STATUS_TO_REPLACE;
 	}
+	replacementTimeThisFrame_ += time_now_d() - replaceStart;
 	return replacer_.FindNone();
 }
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -724,6 +724,7 @@ void TextureCacheCommon::Decimate(bool forcePressure) {
 	}
 
 	DecimateVideos();
+	replacer_.Decimate(forcePressure);
 }
 
 void TextureCacheCommon::DecimateVideos() {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1285,7 +1285,7 @@ ReplacedTexture &TextureCacheCommon::FindReplacement(TexCacheEntry *entry, int &
 	} else if (replaced.Valid()) {
 		entry->status |= TexCacheEntry::STATUS_TO_REPLACE;
 	}
-	return replacer_.None();
+	return replacer_.FindNone();
 }
 
 static void ReverseColors(void *dstBuf, const void *srcBuf, GETextureFormat fmt, int numPixels, bool useBGRA) {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1275,10 +1275,13 @@ u32 TextureCacheCommon::EstimateTexMemoryUsage(const TexCacheEntry *entry) {
 }
 
 ReplacedTexture &TextureCacheCommon::FindReplacement(TexCacheEntry *entry, int &w, int &h) {
+	// Allow some delay to reduce pop-in.
+	constexpr double MAX_BUDGET_PER_TEX = 0.25 / 60.0;
+
 	double replaceStart = time_now_d();
 	u64 cachekey = replacer_.Enabled() ? entry->CacheKey() : 0;
 	ReplacedTexture &replaced = replacer_.FindReplacement(cachekey, entry->fullhash, w, h);
-	if (replaced.IsReady(replacementFrameBudget_ - replacementTimeThisFrame_)) {
+	if (replaced.IsReady(std::min(MAX_BUDGET_PER_TEX, replacementFrameBudget_ - replacementTimeThisFrame_))) {
 		if (replaced.GetSize(0, w, h)) {
 			replacementTimeThisFrame_ += time_now_d() - replaceStart;
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -472,6 +472,10 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 				reason = "scaling";
 			}
 		}
+		if (match && (entry->status & TexCacheEntry::STATUS_TO_REPLACE) && replacementTimeThisFrame_ <= replacementFrameBudget_) {
+			match = false;
+			reason = "replacing";
+		}
 
 		if (match) {
 			// got one!

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -123,16 +123,17 @@ struct TexCacheEntry {
 		STATUS_CLUT_RECHECK = 0x20,    // Another texture with same addr had a hashfail.
 		STATUS_TO_SCALE = 0x80,        // Pending texture scaling in a later frame.
 		STATUS_IS_SCALED = 0x100,      // Has been scaled (can't be replaceImages'd.)
+		STATUS_TO_REPLACE = 0x0200,    // Pending texture replacement.
 		// When hashing large textures, we optimize 512x512 down to 512x272 by default, since this
 		// is commonly the only part accessed.  If access is made above 272, we hash the entire
 		// texture, and set this flag to allow scaling the texture just once for the new hash.
-		STATUS_FREE_CHANGE = 0x200,    // Allow one change before marking "frequent".
+		STATUS_FREE_CHANGE = 0x0400,   // Allow one change before marking "frequent".
 
-		STATUS_BAD_MIPS = 0x400,       // Has bad or unusable mipmap levels.
+		STATUS_BAD_MIPS = 0x0800,      // Has bad or unusable mipmap levels.
 
-		STATUS_FRAMEBUFFER_OVERLAP = 0x800,
+		STATUS_FRAMEBUFFER_OVERLAP = 0x1000,
 
-		STATUS_FORCE_REBUILD = 0x1000,
+		STATUS_FORCE_REBUILD = 0x2000,
 	};
 
 	// Status, but int so we can zero initialize.
@@ -334,6 +335,9 @@ protected:
 	int decimationCounter_;
 	int texelsScaledThisFrame_ = 0;
 	int timesInvalidatedAllThisFrame_ = 0;
+	double replacementTimeThisFrame_ = 0;
+	// TODO: Maybe vary by FPS...
+	double replacementFrameBudget_ = 0.75 / 60.0;
 
 	TexCache cache_;
 	u32 cacheSizeEstimate_ = 0;

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -338,7 +338,7 @@ protected:
 	int timesInvalidatedAllThisFrame_ = 0;
 	double replacementTimeThisFrame_ = 0;
 	// TODO: Maybe vary by FPS...
-	double replacementFrameBudget_ = 0.75 / 60.0;
+	double replacementFrameBudget_ = 0.5 / 60.0;
 
 	TexCache cache_;
 	u32 cacheSizeEstimate_ = 0;

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -278,6 +278,7 @@ protected:
 	void DecodeTextureLevel(u8 *out, int outPitch, GETextureFormat format, GEPaletteFormat clutformat, uint32_t texaddr, int level, int bufw, bool reverseColors, bool useBGRA, bool expandTo32Bit);
 	void UnswizzleFromMem(u32 *dest, u32 destPitch, const u8 *texptr, u32 bufw, u32 height, u32 bytesPerPixel);
 	void ReadIndexedTex(u8 *out, int outPitch, int level, const u8 *texptr, int bytesPerIndex, int bufw, bool expandTo32Bit);
+	ReplacedTexture &FindReplacement(TexCacheEntry *entry, int &w, int &h);
 
 	template <typename T>
 	inline const T *GetCurrentClut() {

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -21,6 +21,7 @@
 
 #include <d3d11.h>
 
+#include "Common/TimeUtil.h"
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
 #include "GPU/ge_constants.h"
@@ -169,6 +170,7 @@ void TextureCacheD3D11::InvalidateLastTexture() {
 void TextureCacheD3D11::StartFrame() {
 	InvalidateLastTexture();
 	timesInvalidatedAllThisFrame_ = 0;
+	replacementTimeThisFrame_ = 0.0;
 
 	if (texelsScaledThisFrame_) {
 		// INFO_LOG(G3D, "Scaled %i texels", texelsScaledThisFrame_);
@@ -486,13 +488,21 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 	u64 cachekey = replacer_.Enabled() ? entry->CacheKey() : 0;
 	int w = gstate.getTextureWidth(0);
 	int h = gstate.getTextureHeight(0);
+	double replaceStart = time_now_d();
 	ReplacedTexture &replaced = replacer_.FindReplacement(cachekey, entry->fullhash, w, h);
-	if (replaced.GetSize(0, w, h)) {
-		// We're replacing, so we won't scale.
-		scaleFactor = 1;
-		entry->status |= TexCacheEntry::STATUS_IS_SCALED;
-		maxLevel = replaced.MaxLevel();
-		badMipSizes = false;
+	if (replaced.IsReady(replacementFrameBudget_ - replacementTimeThisFrame_)) {
+		if (replaced.GetSize(0, w, h)) {
+			replacementTimeThisFrame_ += time_now_d() - replaceStart;
+
+			// We're replacing, so we won't scale.
+			scaleFactor = 1;
+			entry->status |= TexCacheEntry::STATUS_IS_SCALED;
+			entry->status &= ~TexCacheEntry::STATUS_TO_REPLACE;
+			maxLevel = replaced.MaxLevel();
+			badMipSizes = false;
+		}
+	} else if (replaced.MaxLevel() >= 0) {
+		entry->status |= TexCacheEntry::STATUS_TO_REPLACE;
 	}
 
 	// Don't scale the PPGe texture.
@@ -678,7 +688,9 @@ void TextureCacheD3D11::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &
 	if (replaced.GetSize(level, w, h)) {
 		mapData = (u32 *)AllocateAlignedMemory(w * h * sizeof(u32), 16);
 		mapRowPitch = w * 4;
+		double replaceStart = time_now_d();
 		replaced.Load(level, mapData, mapRowPitch);
+		replacementTimeThisFrame_ += time_now_d() - replaceStart;
 		dstFmt = ToDXGIFormat(replaced.Format(level));
 	} else {
 		GETextureFormat tfmt = (GETextureFormat)entry.format;

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -485,24 +485,14 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 		scaleFactor = scaleFactor > 4 ? 4 : (scaleFactor > 2 ? 2 : 1);
 	}
 
-	u64 cachekey = replacer_.Enabled() ? entry->CacheKey() : 0;
 	int w = gstate.getTextureWidth(0);
 	int h = gstate.getTextureHeight(0);
-	double replaceStart = time_now_d();
-	ReplacedTexture &replaced = replacer_.FindReplacement(cachekey, entry->fullhash, w, h);
-	if (replaced.IsReady(replacementFrameBudget_ - replacementTimeThisFrame_)) {
-		if (replaced.GetSize(0, w, h)) {
-			replacementTimeThisFrame_ += time_now_d() - replaceStart;
-
-			// We're replacing, so we won't scale.
-			scaleFactor = 1;
-			entry->status |= TexCacheEntry::STATUS_IS_SCALED;
-			entry->status &= ~TexCacheEntry::STATUS_TO_REPLACE;
-			maxLevel = replaced.MaxLevel();
-			badMipSizes = false;
-		}
-	} else if (replaced.MaxLevel() >= 0) {
-		entry->status |= TexCacheEntry::STATUS_TO_REPLACE;
+	ReplacedTexture &replaced = FindReplacement(entry, w, h);
+	if (replaced.Valid()) {
+		// We're replacing, so we won't scale.
+		scaleFactor = 1;
+		maxLevel = replaced.MaxLevel();
+		badMipSizes = false;
 	}
 
 	// Don't scale the PPGe texture.

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -440,24 +440,14 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 		scaleFactor = scaleFactor > 4 ? 4 : (scaleFactor > 2 ? 2 : 1);
 	}
 
-	u64 cachekey = replacer_.Enabled() ? entry->CacheKey() : 0;
 	int w = gstate.getTextureWidth(0);
 	int h = gstate.getTextureHeight(0);
-	double replaceStart = time_now_d();
-	ReplacedTexture &replaced = replacer_.FindReplacement(cachekey, entry->fullhash, w, h);
-	if (replaced.IsReady(replacementFrameBudget_ - replacementTimeThisFrame_)) {
-		if (replaced.GetSize(0, w, h)) {
-			replacementTimeThisFrame_ += time_now_d() - replaceStart;
-
-			// We're replacing, so we won't scale.
-			scaleFactor = 1;
-			entry->status |= TexCacheEntry::STATUS_IS_SCALED;
-			entry->status &= ~TexCacheEntry::STATUS_TO_REPLACE;
-			maxLevel = replaced.MaxLevel();
-			badMipSizes = false;
-		}
-	} else if (replaced.MaxLevel() >= 0) {
-		entry->status |= TexCacheEntry::STATUS_TO_REPLACE;
+	ReplacedTexture &replaced = FindReplacement(entry, w, h);
+	if (replaced.Valid()) {
+		// We're replacing, so we won't scale.
+		scaleFactor = 1;
+		maxLevel = replaced.MaxLevel();
+		badMipSizes = false;
 	}
 
 	// Don't scale the PPGe texture.

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -504,24 +504,14 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 		scaleFactor = scaleFactor > 4 ? 4 : (scaleFactor > 2 ? 2 : 1);
 	}
 
-	u64 cachekey = replacer_.Enabled() ? entry->CacheKey() : 0;
 	int w = gstate.getTextureWidth(0);
 	int h = gstate.getTextureHeight(0);
-	double replaceStart = time_now_d();
-	ReplacedTexture &replaced = replacer_.FindReplacement(cachekey, entry->fullhash, w, h);
-	if (replaced.IsReady(replacementFrameBudget_ - replacementTimeThisFrame_)) {
-		if (replaced.GetSize(0, w, h)) {
-			replacementTimeThisFrame_ += time_now_d() - replaceStart;
-
-			// We're replacing, so we won't scale.
-			scaleFactor = 1;
-			entry->status |= TexCacheEntry::STATUS_IS_SCALED;
-			entry->status &= ~TexCacheEntry::STATUS_TO_REPLACE;
-			maxLevel = replaced.MaxLevel();
-			badMipSizes = false;
-		}
-	} else if (replaced.MaxLevel() >= 0) {
-		entry->status |= TexCacheEntry::STATUS_TO_REPLACE;
+	ReplacedTexture &replaced = FindReplacement(entry, w, h);
+	if (replaced.Valid()) {
+		// We're replacing, so we won't scale.
+		scaleFactor = 1;
+		maxLevel = replaced.MaxLevel();
+		badMipSizes = false;
 	}
 
 	// Don't scale the PPGe texture.


### PR DESCRIPTION
Delayed loading (pop in) is not really ideal, especially if replacements aren't just higher detail but have some differences (I think for more simplistic games, they can even be used to translate a game.)  But hitching is really annoying, so arguably the replaced images "hitching" in without affecting gameplay is also bad, but less bad.

This takes a very simple step and uses a frame budget to decode texture level data into RAM but avoid significant hitching.  It keeps this decoded data cached for a while, so it can skip decoding if the texture is needed again in a couple minutes.

It might be nice for this to be configurable (both whether you would allow popping, and maybe some way to balance RAM usage), but wanted to open this to allow people to experiment and see how this impacts hitching.

This doesn't move texture decoding to threads, but that wouldn't be much harder to do.  A more advanced technique (loading texture in thread until queue runner, and dynamically selecting texture and maybe shader at that point) is somewhat complex, but ultimately would probably result in *some* hitching or pop-in too, so this is an experiment to see how bad pop-in is.

Feedback on builds under Artifacts on the Checks tab appreciated.

-[Unknown]