### PR TITLE
Compat: Ignore DisableRangeCulling with clip/cull

### DIFF
--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -107,9 +107,6 @@ GPU_D3D11::~GPU_D3D11() {
 void GPU_D3D11::CheckGPUFeatures() {
 	u32 features = 0;
 
-	if (!PSP_CoreParameter().compat.flags().DisableRangeCulling) {
-		features |= GPU_SUPPORTS_VS_RANGE_CULLING;
-	}
 	features |= GPU_SUPPORTS_BLEND_MINMAX;
 
 	// Accurate depth is required because the Direct3D API does not support inverse Z.
@@ -132,6 +129,15 @@ void GPU_D3D11::CheckGPUFeatures() {
 		features |= GPU_SUPPORTS_CLIP_DISTANCE;
 	if (draw_->GetDeviceCaps().cullDistanceSupported)
 		features |= GPU_SUPPORTS_CULL_DISTANCE;
+	if (!draw_->GetBugs().Has(Draw::Bugs::BROKEN_NAN_IN_CONDITIONAL)) {
+		// Ignore the compat setting if clip and cull are both enabled.
+		const bool supported = draw_->GetDeviceCaps().clipDistanceSupported && draw_->GetDeviceCaps().cullDistanceSupported;
+		const bool disabled = PSP_CoreParameter().compat.flags().DisableRangeCulling;
+		if (!supported && !disabled) {
+			features |= GPU_SUPPORTS_VS_RANGE_CULLING;
+		}
+	}
+
 	features |= GPU_SUPPORTS_COPY_IMAGE;
 	features |= GPU_SUPPORTS_TEXTURE_FLOAT;
 	features |= GPU_SUPPORTS_INSTANCE_RENDERING;

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -149,12 +149,6 @@ void GPU_GLES::CheckGPUFeatures() {
 
 	features |= GPU_SUPPORTS_16BIT_FORMATS;
 
-	if (!draw_->GetBugs().Has(Draw::Bugs::BROKEN_NAN_IN_CONDITIONAL)) {
-		if (!PSP_CoreParameter().compat.flags().DisableRangeCulling) {
-			features |= GPU_SUPPORTS_VS_RANGE_CULLING;
-		}
-	}
-
 	if (gl_extensions.ARB_blend_func_extended || gl_extensions.EXT_blend_func_extended) {
 		if (!g_Config.bVendorBugChecksEnabled || !draw_->GetBugs().Has(Draw::Bugs::DUAL_SOURCE_BLENDING_BROKEN)) {
 			features |= GPU_SUPPORTS_DUALSOURCE_BLEND;
@@ -182,7 +176,7 @@ void GPU_GLES::CheckGPUFeatures() {
 			features |= GPU_SUPPORTS_ANY_FRAMEBUFFER_FETCH;
 		}
 	}
-	
+
 	if (gl_extensions.ARB_framebuffer_object || gl_extensions.NV_framebuffer_blit || gl_extensions.GLES3) {
 		features |= GPU_SUPPORTS_FRAMEBUFFER_BLIT | GPU_SUPPORTS_FRAMEBUFFER_BLIT_TO_DEPTH;
 	}
@@ -232,6 +226,14 @@ void GPU_GLES::CheckGPUFeatures() {
 		features |= GPU_SUPPORTS_CLIP_DISTANCE;
 	if (draw_->GetDeviceCaps().cullDistanceSupported)
 		features |= GPU_SUPPORTS_CULL_DISTANCE;
+	if (!draw_->GetBugs().Has(Draw::Bugs::BROKEN_NAN_IN_CONDITIONAL)) {
+		// Ignore the compat setting if clip and cull are both enabled.
+		const bool supported = draw_->GetDeviceCaps().clipDistanceSupported && draw_->GetDeviceCaps().cullDistanceSupported;
+		const bool disabled = PSP_CoreParameter().compat.flags().DisableRangeCulling;
+		if (!supported && !disabled) {
+			features |= GPU_SUPPORTS_VS_RANGE_CULLING;
+		}
+	}
 
 	// If we already have a 16-bit depth buffer, we don't need to round.
 	bool prefer24 = draw_->GetDeviceCaps().preferredDepthBufferFormat == Draw::DataFormat::D24_S8;


### PR DESCRIPTION
As long as we support these things and the NAN issue isn't there, we should be able to safely enable regardless.  Related to #14833.

This may improve graphics in games where the feature was forced off (correctly culling what should be culled), but shouldn't affect the devices which don't yet support clip and cull.

-[Unknown]