### PR TITLE
GPU: Enable new guardband culling again

### DIFF
--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -131,9 +131,10 @@ void GPU_D3D11::CheckGPUFeatures() {
 		features |= GPU_SUPPORTS_CULL_DISTANCE;
 	if (!draw_->GetBugs().Has(Draw::Bugs::BROKEN_NAN_IN_CONDITIONAL)) {
 		// Ignore the compat setting if clip and cull are both enabled.
+		// When supported, we can do the depth side of range culling more correctly.
 		const bool supported = draw_->GetDeviceCaps().clipDistanceSupported && draw_->GetDeviceCaps().cullDistanceSupported;
 		const bool disabled = PSP_CoreParameter().compat.flags().DisableRangeCulling;
-		if (!supported && !disabled) {
+		if (supported && !disabled) {
 			features |= GPU_SUPPORTS_VS_RANGE_CULLING;
 		}
 	}

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -228,9 +228,10 @@ void GPU_GLES::CheckGPUFeatures() {
 		features |= GPU_SUPPORTS_CULL_DISTANCE;
 	if (!draw_->GetBugs().Has(Draw::Bugs::BROKEN_NAN_IN_CONDITIONAL)) {
 		// Ignore the compat setting if clip and cull are both enabled.
+		// When supported, we can do the depth side of range culling more correctly.
 		const bool supported = draw_->GetDeviceCaps().clipDistanceSupported && draw_->GetDeviceCaps().cullDistanceSupported;
 		const bool disabled = PSP_CoreParameter().compat.flags().DisableRangeCulling;
-		if (!supported && !disabled) {
+		if (supported && !disabled) {
 			features |= GPU_SUPPORTS_VS_RANGE_CULLING;
 		}
 	}

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -246,9 +246,10 @@ void GPU_Vulkan::CheckGPUFeatures() {
 	}
 	if (!draw_->GetBugs().Has(Draw::Bugs::BROKEN_NAN_IN_CONDITIONAL)) {
 		// Ignore the compat setting if clip and cull are both enabled.
+		// When supported, we can do the depth side of range culling more correctly.
 		const bool supported = draw_->GetDeviceCaps().clipDistanceSupported && draw_->GetDeviceCaps().cullDistanceSupported;
 		const bool disabled = PSP_CoreParameter().compat.flags().DisableRangeCulling;
-		if (!supported && !disabled) {
+		if (supported && !disabled) {
 			features |= GPU_SUPPORTS_VS_RANGE_CULLING;
 		}
 	}


### PR DESCRIPTION
The comment in #15035 sounded right but I just let myself forget - this isn't "new style", this is just handling range cull correctly.

With the range cull supports flag off, we don't use clip or cull range anyway.  So now, that new code is all force disabled whenever it's supported.  Reversing it back to how it should be.

The clip/cull distance stuff just discards triangles fully outside one direction or the other of Z.  However, even a triangle that is partially inside will still be culled if any of its X, Y coordinates are fully outside.  This is not handled by cull distance, because cull distance is only for all verts.

To explain better:
1. If all three points are below -1 Z or above +1 Z, they are culled.  This is the new functionality.
2. If depth clamp is off, and ANY Z is outside [-1, 1], then the triangle is culled.  This happened before, but based on wrong Z.  This has been fixed (does not require clip/cull.)
3. If depth clamp is on, clipping occurs only against -1 Z.  This wasn't being done before and is new functionality.
4. If clipping does not occur, then ANY X/Y outside the frustrum will cause the triangle to be culled.  This happened before.

The `GPU_SUPPORTS_VS_RANGE_CULLING` flag enables all of the above functionality.  `GPU_SUPPORTS_CULL_DISTANCE` and `GPU_SUPPORTS_CLIP_DISTANCE` enable subsets of it only.  The X/Y culling is not replaced by cull distance.

-[Unknown]