### PR TITLE
GPU: Allow range cull on Mali/etc.

### DIFF
--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -134,7 +134,7 @@ void GPU_D3D11::CheckGPUFeatures() {
 		// When supported, we can do the depth side of range culling more correctly.
 		const bool supported = draw_->GetDeviceCaps().clipDistanceSupported && draw_->GetDeviceCaps().cullDistanceSupported;
 		const bool disabled = PSP_CoreParameter().compat.flags().DisableRangeCulling;
-		if (supported && !disabled) {
+		if (supported || !disabled) {
 			features |= GPU_SUPPORTS_VS_RANGE_CULLING;
 		}
 	}

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -231,7 +231,7 @@ void GPU_GLES::CheckGPUFeatures() {
 		// When supported, we can do the depth side of range culling more correctly.
 		const bool supported = draw_->GetDeviceCaps().clipDistanceSupported && draw_->GetDeviceCaps().cullDistanceSupported;
 		const bool disabled = PSP_CoreParameter().compat.flags().DisableRangeCulling;
-		if (supported && !disabled) {
+		if (supported || !disabled) {
 			features |= GPU_SUPPORTS_VS_RANGE_CULLING;
 		}
 	}

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -249,7 +249,7 @@ void GPU_Vulkan::CheckGPUFeatures() {
 		// When supported, we can do the depth side of range culling more correctly.
 		const bool supported = draw_->GetDeviceCaps().clipDistanceSupported && draw_->GetDeviceCaps().cullDistanceSupported;
 		const bool disabled = PSP_CoreParameter().compat.flags().DisableRangeCulling;
-		if (supported && !disabled) {
+		if (supported || !disabled) {
 			features |= GPU_SUPPORTS_VS_RANGE_CULLING;
 		}
 	}


### PR DESCRIPTION
Previously had been disabled when cullDistance/clipDistance were unsupported, but it's still helpful without those.  See #15049.

Should've just changed it to this in #15043.

-[Unknown]