### PR TITLE
Debugger: Add reason to cpu.stepping event

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -392,6 +392,13 @@ int Core_GetSteppingCounter() {
 	return steppingCounter;
 }
 
+SteppingReason Core_GetSteppingReason() {
+	SteppingReason r;
+	r.reason = steppingReason;
+	r.relatedAddress = steppingAddress;
+	return r;
+}
+
 const char *ExceptionTypeAsString(ExceptionType type) {
 	switch (type) {
 	case ExceptionType::MEMORY: return "Invalid Memory Access";

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -41,6 +41,11 @@ void Core_UpdateSingleStep();
 void Core_ProcessStepping();
 // Changes every time we enter stepping.
 int Core_GetSteppingCounter();
+struct SteppingReason {
+	const char *reason = nullptr;
+	u32 relatedAddress = 0;
+};
+SteppingReason Core_GetSteppingReason();
 
 enum class CoreLifecycle {
 	STARTING,

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -33,7 +33,7 @@ void Core_Stop();
 void Core_SetGraphicsContext(GraphicsContext *ctx);
 
 // called from gui
-void Core_EnableStepping(bool step);
+void Core_EnableStepping(bool step, const char *reason = nullptr, u32 relatedAddress = 0);
 
 bool Core_NextFrame();
 void Core_DoSingleStep();

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -182,7 +182,7 @@ int RegisterEvent(const char *name, TimedCallback callback) {
 
 void AntiCrashCallback(u64 userdata, int cyclesLate) {
 	ERROR_LOG(SAVESTATE, "Savestate broken: an unregistered event was called.");
-	Core_EnableStepping(true);
+	Core_EnableStepping(true, "savestate.crash", 0);
 }
 
 void RestoreRegisterEvent(int &event_type, const char *name, TimedCallback callback) {

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -68,7 +68,7 @@ BreakAction MemCheck::Action(u32 addr, bool write, int size, u32 pc, const char 
 	if (cond & mask) {
 		Log(addr, write, size, pc, reason);
 		if ((result & BREAK_ACTION_PAUSE) && coreState != CORE_POWERUP) {
-			Core_EnableStepping(true);
+			Core_EnableStepping(true, "memory.breakpoint", start);
 			host->SetDebugMode(true);
 		}
 
@@ -93,7 +93,7 @@ void MemCheck::JitBeforeApply(u32 addr, bool write, int size, u32 pc) {
 void MemCheck::JitBeforeAction(u32 addr, bool write, int size, u32 pc) {
 	if (lastAddr) {
 		// We have to break to find out if it changed.
-		Core_EnableStepping(true);
+		Core_EnableStepping(true, "memory.breakpoint.check", start);
 	} else {
 		Action(addr, write, size, pc, "CPU");
 	}
@@ -367,7 +367,7 @@ BreakAction CBreakPoints::ExecBreakPoint(u32 addr) {
 			}
 		}
 		if ((info.result & BREAK_ACTION_PAUSE) && coreState != CORE_POWERUP) {
-			Core_EnableStepping(true);
+			Core_EnableStepping(true, "cpu.breakpoint", info.addr);
 			host->SetDebugMode(true);
 		}
 
@@ -640,7 +640,7 @@ void CBreakPoints::Update(u32 addr)
 		bool resume = false;
 		if (Core_IsStepping() == false)
 		{
-			Core_EnableStepping(true);
+			Core_EnableStepping(true, "cpu.breakpoint.update", addr);
 			Core_WaitInactive(200);
 			resume = true;
 		}

--- a/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp
+++ b/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp
@@ -70,7 +70,7 @@ void WebSocketCPUStepping(DebuggerRequest &req) {
 		return req.Fail("CPU not started");
 	}
 	if (!Core_IsStepping() && Core_IsActive()) {
-		Core_EnableStepping(true);
+		Core_EnableStepping(true, "cpu.stepping", 0);
 	}
 }
 

--- a/Core/Debugger/WebSocket/MemorySubscriber.cpp
+++ b/Core/Debugger/WebSocket/MemorySubscriber.cpp
@@ -53,12 +53,12 @@ struct AutoDisabledReplacements {
 };
 
 // Important: Only use keepReplacements when reading, not writing.
-static AutoDisabledReplacements LockMemoryAndCPU(bool keepReplacements) {
+static AutoDisabledReplacements LockMemoryAndCPU(uint32_t addr, bool keepReplacements) {
 	AutoDisabledReplacements result;
 	if (Core_IsStepping()) {
 		result.wasStepping = true;
 	} else {
-		Core_EnableStepping(true);
+		Core_EnableStepping(true, "memory.access", addr);
 		Core_WaitInactive();
 	}
 
@@ -92,14 +92,14 @@ AutoDisabledReplacements::~AutoDisabledReplacements() {
 // Response (same event name):
 //  - value: unsigned integer
 void WebSocketMemoryReadU8(DebuggerRequest &req) {
-	auto memLock = LockMemoryAndCPU(true);
-	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
-		return req.Fail("CPU not started");
-
 	uint32_t addr;
 	if (!req.ParamU32("address", &addr, false)) {
 		return;
 	}
+
+	auto memLock = LockMemoryAndCPU(addr, true);
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
 
 	if (!Memory::IsValidAddress(addr)) {
 		req.Fail("Invalid address");
@@ -118,14 +118,14 @@ void WebSocketMemoryReadU8(DebuggerRequest &req) {
 // Response (same event name):
 //  - value: unsigned integer
 void WebSocketMemoryReadU16(DebuggerRequest &req) {
-	auto memLock = LockMemoryAndCPU(true);
-	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
-		return req.Fail("CPU not started");
-
 	uint32_t addr;
 	if (!req.ParamU32("address", &addr, false)) {
 		return;
 	}
+
+	auto memLock = LockMemoryAndCPU(addr, true);
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
 
 	if (!Memory::IsValidAddress(addr)) {
 		req.Fail("Invalid address");
@@ -144,14 +144,14 @@ void WebSocketMemoryReadU16(DebuggerRequest &req) {
 // Response (same event name):
 //  - value: unsigned integer
 void WebSocketMemoryReadU32(DebuggerRequest &req) {
-	auto memLock = LockMemoryAndCPU(true);
-	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
-		return req.Fail("CPU not started");
-
 	uint32_t addr;
 	if (!req.ParamU32("address", &addr, false)) {
 		return;
 	}
+
+	auto memLock = LockMemoryAndCPU(addr, true);
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
 
 	if (!Memory::IsValidAddress(addr)) {
 		req.Fail("Invalid address");
@@ -182,7 +182,7 @@ void WebSocketMemoryRead(DebuggerRequest &req) {
 	if (!req.ParamBool("replacements", &replacements, DebuggerParamType::OPTIONAL))
 		return;
 
-	auto memLock = LockMemoryAndCPU(replacements);
+	auto memLock = LockMemoryAndCPU(addr, replacements);
 	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
 		return req.Fail("CPU not started");
 
@@ -219,13 +219,14 @@ void WebSocketMemoryRead(DebuggerRequest &req) {
 // Response (same event name) for 'base64':
 //  - base64: base64 encode of binary data, not including NUL.
 void WebSocketMemoryReadString(DebuggerRequest &req) {
-	auto memLock = LockMemoryAndCPU(true);
-	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
-		return req.Fail("CPU not started");
-
 	uint32_t addr;
 	if (!req.ParamU32("address", &addr))
 		return;
+
+	auto memLock = LockMemoryAndCPU(addr, true);
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
+
 	std::string type = "utf-8";
 	if (!req.ParamString("type", &type, DebuggerParamType::OPTIONAL))
 		return;
@@ -257,10 +258,6 @@ void WebSocketMemoryReadString(DebuggerRequest &req) {
 // Response (same event name):
 //  - value: new value, unsigned integer
 void WebSocketMemoryWriteU8(DebuggerRequest &req) {
-	auto memLock = LockMemoryAndCPU(true);
-	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
-		return req.Fail("CPU not started");
-
 	uint32_t addr, val;
 	if (!req.ParamU32("address", &addr, false)) {
 		return;
@@ -268,6 +265,10 @@ void WebSocketMemoryWriteU8(DebuggerRequest &req) {
 	if (!req.ParamU32("value", &val, false)) {
 		return;
 	}
+
+	auto memLock = LockMemoryAndCPU(addr, true);
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
 
 	if (!Memory::IsValidAddress(addr)) {
 		req.Fail("Invalid address");
@@ -289,10 +290,6 @@ void WebSocketMemoryWriteU8(DebuggerRequest &req) {
 // Response (same event name):
 //  - value: new value, unsigned integer
 void WebSocketMemoryWriteU16(DebuggerRequest &req) {
-	auto memLock = LockMemoryAndCPU(true);
-	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
-		return req.Fail("CPU not started");
-
 	uint32_t addr, val;
 	if (!req.ParamU32("address", &addr, false)) {
 		return;
@@ -300,6 +297,10 @@ void WebSocketMemoryWriteU16(DebuggerRequest &req) {
 	if (!req.ParamU32("value", &val, false)) {
 		return;
 	}
+
+	auto memLock = LockMemoryAndCPU(addr, true);
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
 
 	if (!Memory::IsValidAddress(addr)) {
 		req.Fail("Invalid address");
@@ -321,10 +322,6 @@ void WebSocketMemoryWriteU16(DebuggerRequest &req) {
 // Response (same event name):
 //  - value: new value, unsigned integer
 void WebSocketMemoryWriteU32(DebuggerRequest &req) {
-	auto memLock = LockMemoryAndCPU(true);
-	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
-		return req.Fail("CPU not started");
-
 	uint32_t addr, val;
 	if (!req.ParamU32("address", &addr, false)) {
 		return;
@@ -332,6 +329,10 @@ void WebSocketMemoryWriteU32(DebuggerRequest &req) {
 	if (!req.ParamU32("value", &val, false)) {
 		return;
 	}
+
+	auto memLock = LockMemoryAndCPU(addr, true);
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
 
 	if (!Memory::IsValidAddress(addr)) {
 		req.Fail("Invalid address");
@@ -352,16 +353,16 @@ void WebSocketMemoryWriteU32(DebuggerRequest &req) {
 //
 // Response (same event name) with no extra data.
 void WebSocketMemoryWrite(DebuggerRequest &req) {
-	auto memLock = LockMemoryAndCPU(true);
-	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
-		return req.Fail("CPU not started");
-
 	uint32_t addr;
 	if (!req.ParamU32("address", &addr))
 		return;
 	std::string encoded;
 	if (!req.ParamString("base64", &encoded))
 		return;
+
+	auto memLock = LockMemoryAndCPU(addr, true);
+	if (!currentDebugMIPS->isAlive() || !Memory::IsActive())
+		return req.Fail("CPU not started");
 
 	std::vector<uint8_t> value = Base64Decode(&encoded[0], encoded.size());
 	uint32_t size = (uint32_t)value.size();

--- a/Core/Debugger/WebSocket/SteppingSubscriber.cpp
+++ b/Core/Debugger/WebSocket/SteppingSubscriber.cpp
@@ -93,7 +93,7 @@ void WebSocketSteppingState::Into(DebuggerRequest &req) {
 	if (!currentDebugMIPS->isAlive())
 		return req.Fail("CPU not started");
 	if (!Core_IsStepping()) {
-		Core_EnableStepping(true);
+		Core_EnableStepping(true, "cpu.stepInto", 0);
 		return;
 	}
 

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -68,6 +68,7 @@ static int delayedResultEvent = -1;
 static int hleAfterSyscall = HLE_AFTER_NOTHING;
 static const char *hleAfterSyscallReschedReason;
 static const HLEFunction *latestSyscall = nullptr;
+static uint32_t latestSyscallPC = 0;
 static int idleOp;
 
 struct HLEMipsCallInfo {
@@ -128,6 +129,7 @@ void HLEDoState(PointerWrap &p) {
 
 	// Can't be inside a syscall, reset this so errors aren't misleading.
 	latestSyscall = nullptr;
+	latestSyscallPC = 0;
 	Do(p, delayedResultEvent);
 	CoreTiming::RestoreRegisterEvent(delayedResultEvent, "HLEDelayedResult", hleDelayResultFinish);
 
@@ -153,6 +155,7 @@ void HLEDoState(PointerWrap &p) {
 void HLEShutdown() {
 	hleAfterSyscall = HLE_AFTER_NOTHING;
 	latestSyscall = nullptr;
+	latestSyscallPC = 0;
 	moduleDB.clear();
 	enqueuedMipsCalls.clear();
 	for (auto p : mipsCallActions) {
@@ -360,7 +363,7 @@ bool hleExecuteDebugBreak(const HLEFunction &func)
 			return false;
 	}
 
-	Core_EnableStepping(true);
+	Core_EnableStepping(true, "hle.step", latestSyscallPC);
 	host->SetDebugMode(true);
 	return true;
 }
@@ -625,6 +628,7 @@ static void updateSyscallStats(int modulenum, int funcnum, double total)
 inline void CallSyscallWithFlags(const HLEFunction *info)
 {
 	latestSyscall = info;
+	latestSyscallPC = currentMIPS->pc;
 	const u32 flags = info->flags;
 
 	if (flags & HLE_CLEAR_STACK_BYTES) {
@@ -651,6 +655,7 @@ inline void CallSyscallWithFlags(const HLEFunction *info)
 inline void CallSyscallWithoutFlags(const HLEFunction *info)
 {
 	latestSyscall = info;
+	latestSyscallPC = currentMIPS->pc;
 	info->func();
 
 	if (hleAfterSyscall != HLE_AFTER_NOTHING)

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -981,7 +981,7 @@ int MIPSInterpret_RunUntil(u64 globalTicks)
 					auto cond = CBreakPoints::GetBreakPointCondition(currentMIPS->pc);
 					if (!cond || cond->Evaluate())
 					{
-						Core_EnableStepping(true);
+						Core_EnableStepping(true, "cpu.breakpoint", curMips->pc);
 						if (CBreakPoints::IsTempBreakPoint(curMips->pc))
 							CBreakPoints::RemoveBreakPoint(curMips->pc);
 						break;

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -336,14 +336,14 @@ namespace SaveState
 	void Load(const Path &filename, int slot, Callback callback, void *cbUserData)
 	{
 		if (coreState == CoreState::CORE_RUNTIME_ERROR)
-			Core_EnableStepping(true);
+			Core_EnableStepping(true, "savestate.load", 0);
 		Enqueue(Operation(SAVESTATE_LOAD, filename, slot, callback, cbUserData));
 	}
 
 	void Save(const Path &filename, int slot, Callback callback, void *cbUserData)
 	{
 		if (coreState == CoreState::CORE_RUNTIME_ERROR)
-			Core_EnableStepping(true);
+			Core_EnableStepping(true, "savestate.save", 0);
 		Enqueue(Operation(SAVESTATE_SAVE, filename, slot, callback, cbUserData));
 	}
 
@@ -355,7 +355,7 @@ namespace SaveState
 	void Rewind(Callback callback, void *cbUserData)
 	{
 		if (coreState == CoreState::CORE_RUNTIME_ERROR)
-			Core_EnableStepping(true);
+			Core_EnableStepping(true, "savestate.rewind", 0);
 		Enqueue(Operation(SAVESTATE_REWIND, Path(), -1, callback, cbUserData));
 	}
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -110,7 +110,7 @@ static void __EmuScreenVblank()
 	if (frameStep_ && lastNumFlips != gpuStats.numFlips)
 	{
 		frameStep_ = false;
-		Core_EnableStepping(true);
+		Core_EnableStepping(true, "ui.frameAdvance", 0);
 		lastNumFlips = gpuStats.numFlips;
 	}
 #ifndef MOBILE_DEVICE
@@ -611,7 +611,7 @@ void EmuScreen::onVKeyDown(int virtualKeyCode) {
 		}
 		else if (!frameStep_)
 		{
-			Core_EnableStepping(true);
+			Core_EnableStepping(true, "ui.frameAdvance", 0);
 		}
 		break;
 

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -421,7 +421,7 @@ void CtrlMemView::onChar(WPARAM wParam, LPARAM lParam)
 	}
 
 	bool active = Core_IsActive();
-	if (active) Core_EnableStepping(true);
+	if (active) Core_EnableStepping(true, "memory.access", curAddress);
 
 	if (asciiSelected)
 	{

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -420,7 +420,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					if (isRunning)
 					{
 						SetDebugMode(true, false);
-						Core_EnableStepping(true);
+						Core_EnableStepping(true, "cpu.breakpoint.add", 0);
 						Core_WaitInactive(200);
 					}
 
@@ -523,7 +523,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					{
 						ptr->setDontRedraw(false);
 						SetDebugMode(true, true);
-						Core_EnableStepping(true);
+						Core_EnableStepping(true, "ui.break", 0);
 						Sleep(1); //let cpu catch up
 						ptr->gotoPC();
 						UpdateDialog();

--- a/Windows/Debugger/DumpMemoryWindow.cpp
+++ b/Windows/Debugger/DumpMemoryWindow.cpp
@@ -81,7 +81,7 @@ INT_PTR CALLBACK DumpMemoryWindow::dlgFunc(HWND hwnd, UINT iMsg, WPARAM wParam, 
 				bool priorDumpWasStepping = Core_IsStepping();
 				if (!priorDumpWasStepping && PSP_IsInited()) {
 					// If emulator isn't paused force paused state, but wait before locking.
-					Core_EnableStepping(true);
+					Core_EnableStepping(true, "memory.access", bp->start);
 					Core_WaitInactive();
 				}
 

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -724,7 +724,7 @@ namespace MainWindow
 						if (disasmWindow)
 							SendMessage(disasmWindow->GetDlgHandle(), WM_COMMAND, IDC_STOPGO, 0);
 						else
-							Core_EnableStepping(pause);
+							Core_EnableStepping(pause, "ui.lost_focus", 0);
 					}
 				}
 

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -381,7 +381,7 @@ namespace MainWindow {
 		if (GetUIState() == UISTATE_INGAME) {
 			browsePauseAfter = Core_IsStepping();
 			if (!browsePauseAfter)
-				Core_EnableStepping(true);
+				Core_EnableStepping(true, "ui.boot", 0);
 		}
 
 		W32Util::MakeTopMost(GetHWND(), false);
@@ -601,7 +601,7 @@ namespace MainWindow {
 				if (disasmWindow)
 					SendMessage(disasmWindow->GetDlgHandle(), WM_COMMAND, IDC_STOPGO, 0);
 				else
-					Core_EnableStepping(true);
+					Core_EnableStepping(true, "ui.break", 0);
 			}
 			noFocusPause = !noFocusPause;	// If we pause, override pause on lost focus
 			break;


### PR DESCRIPTION
For example, when hitting a CPU breakpoint:

```json
{
  "event": "cpu.stepping",
  "pc": 146332904,
  "ticks": 2,
  "reason": "cpu.breakpoint",
  "relatedAddress": 146332904
}
```

This makes it easier to tie back the stepping event to why, in case stepping triggers multiple things.  It's also useful for some Ghidra integration.

-[Unknown]