### PR TITLE
Make sure to not leave cull distance uninitialized in other paths

### DIFF
--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1135,7 +1135,10 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 			WRITE(p, "  if (u_cullRangeMin.w > 0.0) {\n");
 			WRITE(p, "    %sgl_CullDistance%s = projPos.z - u_cullRangeMin.z;\n", compat.vsOutPrefix, cull0);
 			WRITE(p, "    %sgl_CullDistance%s = u_cullRangeMax.z - projPos.z;\n", compat.vsOutPrefix, cull1);
-			WRITE(p, "  }\n");
+			WRITE(p, "  } else {\n");
+			WRITE(p, "    %sgl_CullDistance%s = 0.0;\n", compat.vsOutPrefix, cull0);
+			WRITE(p, "    %sgl_CullDistance%s = 0.0;\n", compat.vsOutPrefix, cull1);
+			WRITE(p, "  }");
 		}
 	}
 


### PR DESCRIPTION
Make sure to not leave cull distance uninitialized in other paths if we do write to it in some path.

Hopefully might fix those cull distance glitches we've seen recently, like #15056 .