### PR TITLE
GPU: Correct geometry shader culling

### DIFF
--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -267,7 +267,6 @@ public:
 		return buf->PushAligned(ubo_, uboSize_, vulkan->GetPhysicalDeviceProperties().properties.limits.minUniformBufferOffsetAlignment, vkbuf);
 	}
 
-	int GetUniformLoc(const char *name);
 	int GetUBOSize() const {
 		return uboSize_;
 	}
@@ -1322,17 +1321,6 @@ ShaderModule *VKContext::CreateShaderModule(ShaderStage stage, ShaderLanguage la
 		shader->Release();
 		return nullptr;
 	}
-}
-
-int VKPipeline::GetUniformLoc(const char *name) {
-	int loc = -1;
-
-	// HACK! As we only use one uniform we hardcode it.
-	if (!strcmp(name, "WorldViewProj")) {
-		return 0;
-	}
-
-	return loc;
 }
 
 void VKContext::UpdateDynamicUniformBuffer(const void *ub, size_t size) {


### PR DESCRIPTION
There still seem to be other problems, though.  When I run the dump in https://github.com/hrydgard/ppsspp/issues/11578#issuecomment-447648231, it shows the problem as noted - not sure if there's some issue with clip distance, as I think that was clipping.

Are we guaranteed `gl_ClipDistance` in the geometry shader?  Wouldn't it run on the vertex shader anyway?

The interesting thing, though, is when I step using the GE debugger through using "Step Draw", then it draws properly.  The issue only shows when running the whole frame.

Still, this is at least an incremental improvement.  Many of the cull frame dumps look right with this.

-[Unknown]