### PR TITLE
Build: allow using system zstd library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ option(USE_SYSTEM_FFMPEG "Dynamically link against system FFMPEG" ${USE_SYSTEM_F
 option(USE_SYSTEM_LIBZIP "Dynamically link against system libzip" ${USE_SYSTEM_LIBZIP})
 option(USE_SYSTEM_LIBSDL2 "Dynamically link against system SDL2" ON)
 option(USE_SYSTEM_LIBPNG "Dynamically link against system libpng" ON)
+option(USE_SYSTEM_ZSTD "Dynamically link against system zstd" ${USE_SYSTEM_ZSTD})
 option(USE_ASAN "Use address sanitizer" OFF)
 option(USE_UBSAN "Use undefined behaviour sanitizer" OFF)
 
@@ -1976,8 +1977,7 @@ if(ANDROID)
 	endif()
 endif()
 
-set(CoreExtraLibs ${CoreExtraLibs} armips libzstd_static)
-include_directories(ext/zstd/lib)
+set(CoreExtraLibs ${CoreExtraLibs} armips)
 
 # needed for VK_USE_PLATFORM_XCB_KHR only
 #if(VULKAN AND NOT WIN32)
@@ -1995,7 +1995,18 @@ if(WIN32)
 endif()
 
 if(OPENGL_opengl_LIBRARY AND OpenGL_GL_PREFERENCE STREQUAL GLVND AND NOT APPLE)
-    set(OPENGL_LIBRARIES OpenGL::OpenGL)
+	set(OPENGL_LIBRARIES OpenGL::OpenGL)
+endif()
+
+if(USE_SYSTEM_ZSTD)
+	find_package(ZSTD REQUIRED)
+	target_include_directories(${CoreLibName} PRIVATE ${ZSTD_INCLUDE_DIR})
+	target_link_libraries(${CoreLibName} ${ZSTD_LIBRARY})
+else()
+	set(ZSTD_BUILD_PROGRAMS OFF CACHE BOOL "we don't need zstd programs" FORCE)
+	add_subdirectory(ext/zstd/build/cmake EXCLUDE_FROM_ALL)
+	set(CoreExtraLibs ${CoreExtraLibs} libzstd_static)
+	include_directories(ext/zstd/lib)
 endif()
 
 target_link_libraries(${CoreLibName} Common native kirk cityhash sfmt19937 xbrz xxhash ${GlslangLibs}

--- a/cmake/Modules/FindZSTD.cmake
+++ b/cmake/Modules/FindZSTD.cmake
@@ -1,0 +1,93 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying file COPYING-CMAKE-SCRIPTS or
+# https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindZSTD
+--------
+
+Find the ZSTD library
+
+Zstandard C/C++ library is built with CMake. So this find module
+should be removed when ZStandard library export cmake config files
+as distribution. Unfortunately ZStandard does not export it,
+we need to prepare find module.
+
+IMPORTED targets
+^^^^^^^^^^^^^^^^
+
+This module defines the following :prop_tgt:`IMPORTED` target: ``ZSTD::zstd``
+
+Result variables
+^^^^^^^^^^^^^^^^
+
+This module will set the following variables if found:
+
+``ZSTD_INCLUDE_DIRS`` - where to find zstd.h, etc.
+``ZSTD_LIBRARIES`` - the libraries to link against to use ZSTD.
+``ZSTD_VERSION`` - version of the ZSTD library found
+``ZSTD_FOUND`` - TRUE if found
+
+::
+
+  ``ZSTD_VERSION_MAJOR``  - The major version of zstd
+  ``ZSTD_VERSION_MINOR``  - The minor version of zstd
+  ``ZSTD_VERSION_RELEASE``  - The release version of zstd
+
+#]=======================================================================]
+
+find_package(PkgConfig)
+pkg_check_modules(PC_ZSTD QUIET libzstd)
+
+find_path(
+  ZSTD_INCLUDE_DIR
+  NAMES zstd.h
+  PATHS ${PC_ZSTD_INCLUDE_DIRS}
+)
+find_library(
+  ZSTD_LIBRARY
+  NAMES zstd
+  PATHS ${PC_ZSTD_LIBRARY_DIRS}
+)
+
+# Extract version information from the header file
+if(EXISTS "${ZSTD_INCLUDE_DIR}/zstd.h")
+  file(STRINGS "${ZSTD_INCLUDE_DIR}/zstd.h"
+       _ZSTD_VERSION_MAJOR REGEX "^#define ZSTD_VERSION_MAJOR")
+  string(REGEX MATCH "[0-9]+" ZSTD_VERSION_MAJOR ${_ZSTD_VERSION_MAJOR})
+  file(STRINGS "${ZSTD_INCLUDE_DIR}/zstd.h"
+       _ZSTD_VERSION_MINOR REGEX "^#define ZSTD_VERSION_MINOR")
+  string(REGEX MATCH "[0-9]+" ZSTD_VERSION_MINOR ${_ZSTD_VERSION_MINOR} )
+  file(STRINGS "${ZSTD_INCLUDE_DIR}/zstd.h"
+       _ZSTD_VERSION_RELEASE REGEX "^#define ZSTD_VERSION_RELEASE")
+  string(REGEX MATCH "[0-9]+" ZSTD_VERSION_RELEASE ${_ZSTD_VERSION_RELEASE} )
+  set(ZSTD_VERSION ${ZSTD_VERSION_MAJOR}.${ZSTD_VERSION_MINOR}.${ZSTD_VERSION_RELEASE})
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  ZSTD
+  FOUND_VAR ZSTD_FOUND
+  REQUIRED_VARS ZSTD_LIBRARY ZSTD_INCLUDE_DIR
+  VERSION_VAR ZSTD_VERSION
+  HANDLE_COMPONENTS)
+mark_as_advanced(ZSTD_INCLUDE_DIR ZSTD_LIBRARY)
+
+include(FeatureSummary)
+set_package_properties(
+  ZSTD PROPERTIES
+  DESCRIPTION "Zstandard - Fast real-time compression algorithm"
+  URL "https://github.com/facebook/zstd")
+
+if(ZSTD_FOUND)
+  set(ZSTD_INCLUDE_DIRS ${ZSTD_INCLUDE_DIR})
+  set(ZSTD_LIBRARIES ${ZSTD_LIBRARY})
+  set(ZSTD_DEFINITIONS ${PC_ZSTD_CFLAGS_OTHER})
+  if(NOT TARGET ZSTD::zstd)
+    add_library(ZSTD::zstd UNKNOWN IMPORTED)
+    set_target_properties(ZSTD::zstd PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${ZSTD_INCLUDE_DIR})
+    if(EXISTS "${ZSTD_LIBRARY}")
+      set_target_properties(ZSTD::zstd PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
+        IMPORTED_LOCATION "${ZSTD_LIBRARY}")
+    endif()
+  endif()
+endif()

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -8,7 +8,6 @@ endif()
 set(ENABLE_GLSLANG_BINARIES OFF CACHE BOOL "let's not build binaries we don't need" FORCE)
 set(SPIRV_CROSS_EXCEPTIONS_TO_ASSERTIONS ON CACHE BOOL "let's not use exceptions" FORCE)
 set(ENABLE_SPVREMAPPER OFF CACHE BOOL "we don't need spvremapper" FORCE)
-set(ZSTD_BUILD_PROGRAMS OFF CACHE BOOL "we don't need zstd programs" FORCE)
 
 # This is really a workaround for an NDK 20 compiler issue (PPSSPP issue #12105), but shouldn't hurt.
 if(ANDROID)
@@ -22,4 +21,3 @@ add_subdirectory(SPIRV-Cross-build)
 if(USE_DISCORD AND NOT IOS AND NOT LIBRETRO)
 	add_subdirectory(discord-rpc-build)
 endif()
-add_subdirectory(zstd/build/cmake EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Many Linux distros have provided and installed zstd package by default. We can allow Linux ( and macOS ) users use system zstd library like what we did for other 3rd party libraries.