### PR TITLE
Minor optimizations in software transform

### DIFF
--- a/Common/GPU/ShaderWriter.cpp
+++ b/Common/GPU/ShaderWriter.cpp
@@ -56,6 +56,7 @@ const char *hlsl_preamble_vs =
 "#define vec4 float4\n"
 "#define ivec2 int2\n"
 "#define ivec4 int4\n"
+"#define mat2 float2x2\n"
 "#define mat4 float4x4\n"
 "#define mat3x4 float4x3\n"  // note how the conventions are backwards
 "#define splat3(x) vec3(x, x, x)\n"

--- a/Core/MIPS/ARM64/Arm64CompBranch.cpp
+++ b/Core/MIPS/ARM64/Arm64CompBranch.cpp
@@ -438,7 +438,7 @@ void Arm64Jit::BranchVFPUFlag(MIPSOpcode op, CCFlags cc, bool likely) {
 			ptr = TBNZ(ar, imm3);
 		}
 	} else {
-		TSTI2R(gpr.R(MIPS_REG_VFPUCC), 1 << imm3, SCRATCH1);
+		TSTI2R(gpr.R(MIPS_REG_VFPUCC), 1ULL << imm3, SCRATCH1);
 		CompileDelaySlot(DELAYSLOT_SAFE_FLUSH);
 		ptr = B(cc);
 	}

--- a/Core/MIPS/ARM64/Arm64CompVFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompVFPU.cpp
@@ -1627,10 +1627,10 @@ namespace MIPSComp {
 					if (n == 1) {
 						MOVI2R(SCRATCH1, 0x31);
 					} else {
-						MOVI2R(SCRATCH1, 1 << i);
+						MOVI2R(SCRATCH1, 1ULL << i);
 					}
 				} else {
-					ORRI2R(SCRATCH1, SCRATCH1, 1 << i);
+					ORRI2R(SCRATCH1, SCRATCH1, 1ULL << i);
 				}
 				break;
 
@@ -1723,7 +1723,7 @@ namespace MIPSComp {
 						MOVI2R(SCRATCH1, 1);  // 1 << i, but i == 0
 					}
 				} else {
-					ORRI2R(SCRATCH1, SCRATCH1, 1 << i);
+					ORRI2R(SCRATCH1, SCRATCH1, 1ULL << i);
 				}
 				SetJumpTarget(b);
 			}
@@ -1779,7 +1779,7 @@ namespace MIPSComp {
 			fpr.MapRegsAndSpillLockV(dregs, sz, MAP_DIRTY);
 			fpr.MapRegsAndSpillLockV(sregs, sz, 0);
 			gpr.MapReg(MIPS_REG_VFPUCC);
-			TSTI2R(gpr.R(MIPS_REG_VFPUCC), 1 << imm3);
+			TSTI2R(gpr.R(MIPS_REG_VFPUCC), 1ULL << imm3);
 			// TODO: Use fsel?
 			FixupBranch b = B(tf ? CC_NEQ : CC_EQ);
 			for (int i = 0; i < n; i++) {

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -863,7 +863,7 @@ inline void Vec3ByMatrix43(float vecOut[3], const float v[3], const float m[12])
 	vecOut[0] = _mm_cvtss_f32(sum);
 	vecOut[1] = vectorGetByIndex<1>(sum);
 	vecOut[2] = vectorGetByIndex<2>(sum);
-#elif PPSSPP_ARCH(ARM_NEON)
+#elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
 	float32x4_t col0 = vld1q_f32(m);
 	float32x4_t col1 = vld1q_f32(m + 3);
 	float32x4_t col2 = vld1q_f32(m + 6);
@@ -896,7 +896,7 @@ inline void Vec3ByMatrix44(float vecOut[4], const float v[3], const float m[16])
 		_mm_add_ps(_mm_mul_ps(col0, x), _mm_mul_ps(col1, y)),
 		_mm_add_ps(_mm_mul_ps(col2, z), col3));
 	_mm_storeu_ps(vecOut, sum);
-#elif PPSSPP_ARCH(ARM_NEON)
+#elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
 	float32x4_t col0 = vld1q_f32(m);
 	float32x4_t col1 = vld1q_f32(m + 4);
 	float32x4_t col2 = vld1q_f32(m + 8);

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.0.3'
     }
 }
 


### PR DESCRIPTION
For best speed, we'd need a JIT of course. But this optimizes a few common matrix operations a bit with NEON/SSE.

Plus, shrinks the screen rotation to a 2x2 matrix operation in the shader.