### PR TITLE
Implement depth culling in software transform

### DIFF
--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -213,7 +213,7 @@ void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVt
 			// TODO: Write to a flexible buffer, we don't always need all four components.
 			TransformedVertex &vert = transformed[index];
 			reader.ReadPos(vert.pos);
-			vert.posw = 1.0f;
+			vert.pos_w = 1.0f;
 
 			if (reader.hasColor0()) {
 				if (provokeIndOffset != 0 && index + provokeIndOffset < maxIndex) {

--- a/GPU/Common/SoftwareTransformCommon.h
+++ b/GPU/Common/SoftwareTransformCommon.h
@@ -57,6 +57,7 @@ struct SoftwareTransformParams {
 	bool allowSeparateAlphaClear;
 	bool provokeFlatFirst;
 	bool flippedY;
+	bool usesHalfZ;
 };
 
 class SoftwareTransform {

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -588,6 +588,7 @@ rotateVBO:
 		params.allowSeparateAlphaClear = false;  // D3D11 doesn't support separate alpha clears
 		params.provokeFlatFirst = true;
 		params.flippedY = false;
+		params.usesHalfZ = true;
 
 		// We need correct viewport values in gstate_c already.
 		if (gstate_c.IsDirty(DIRTY_VIEWPORTSCISSOR_STATE)) {

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -557,6 +557,7 @@ rotateVBO:
 		params.allowSeparateAlphaClear = false;
 		params.provokeFlatFirst = true;
 		params.flippedY = false;
+		params.usesHalfZ = true;
 
 		// We need correct viewport values in gstate_c already.
 		if (gstate_c.IsDirty(DIRTY_VIEWPORTSCISSOR_STATE)) {

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -565,6 +565,7 @@ void DrawEngineGLES::DoFlush() {
 		params.allowSeparateAlphaClear = true;
 		params.provokeFlatFirst = false;
 		params.flippedY = framebufferManager_->UseBufferedRendering();
+		params.usesHalfZ = false;
 
 		// We need correct viewport values in gstate_c already.
 		if (gstate_c.IsDirty(DIRTY_VIEWPORTSCISSOR_STATE)) {

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2259,10 +2259,10 @@ void GPUCommon::Execute_ImmVertexAlphaPrim(u32 op, u32 diff) {
 	v.x = ((gstate.imm_vscx & 0xFFFFFF) - offsetX) / 16.0f;
 	v.y = ((gstate.imm_vscy & 0xFFFFFF) - offsetY) / 16.0f;
 	v.z = gstate.imm_vscz & 0xFFFF;
-	v.posw = 1.0f;
+	v.pos_w = 1.0f;
 	v.u = getFloat24(gstate.imm_vtcs);
 	v.v = getFloat24(gstate.imm_vtct);
-	v.w = getFloat24(gstate.imm_vtcq);
+	v.uv_w = getFloat24(gstate.imm_vtcq);
 	v.color0_32 = (gstate.imm_cv & 0xFFFFFF) | (gstate.imm_ap << 24);
 	v.fog = 0.0f; // we have no information about the scale here
 	v.color1_32 = gstate.imm_scv & 0xFFFFFF;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -43,13 +43,13 @@ enum {
 struct TransformedVertex {
 	union {
 		struct {
-			float x, y, z, posw;     // in case of morph, preblend during decode
+			float x, y, z, pos_w;     // in case of morph, preblend during decode
 		};
 		float pos[4];
 	};
 	union {
 		struct {
-			float u; float v; float w;   // scaled by uscale, vscale, if there
+			float u; float v; float uv_w;   // scaled by uscale, vscale, if there
 		};
 		float uv[3];
 	};

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -910,6 +910,7 @@ void DrawEngineVulkan::DoFlush() {
 		params.allowSeparateAlphaClear = false;
 		params.provokeFlatFirst = true;
 		params.flippedY = true;
+		params.usesHalfZ = true;
 
 		// We need to update the viewport early because it's checked for flipping in SoftwareTransform.
 		// We don't have a "DrawStateEarly" in vulkan, so...


### PR DESCRIPTION
Closes #15037.

This doesn't process all of range culling (which could potentially be done for BROKEN_NAN_IN_CONDITIONAL), but only the depth part.  There's still clipping and X/Y culling, but those are supported on a lot more devices anyway.

-[Unknown]