### PR TITLE
GPU: Sort line verts to correct bias

### DIFF
--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -792,17 +792,22 @@ void SoftwareTransform::ExpandLines(int vertexCount, int &maxIndex, u16 *&inds, 
 
 	maxIndex = 4 * (vertexCount / 2);
 	for (int i = 0; i < vertexCount; i += 2) {
-		const TransformedVertex &transVtxTL = transformed[indsIn[i + 0]];
-		TransformedVertex transVtxBL = transformed[indsIn[i + 1]];
+		const TransformedVertex &transVtx1 = transformed[indsIn[i + 0]];
+		const TransformedVertex &transVtx2 = transformed[indsIn[i + 1]];
 
-		// Okay, let's calculate the perpendicular biased toward the bottom right.
+		const TransformedVertex &transVtxT = transVtx1.y <= transVtx2.y ? transVtx1 : transVtx2;
+		const TransformedVertex &transVtxB = transVtx1.y <= transVtx2.y ? transVtx2 : transVtx1;
+		const TransformedVertex &transVtxL = transVtx1.x <= transVtx2.x ? transVtx1 : transVtx2;
+		const TransformedVertex &transVtxR = transVtx1.x <= transVtx2.x ? transVtx2 : transVtx1;
+
+		// Sort the points so our perpendicular will bias the right direction.
+		const TransformedVertex &transVtxTL = transVtxT.y != transVtxB.y || transVtxT.x > transVtxB.x ? transVtxT : transVtxB;
+		const TransformedVertex &transVtxBL = transVtxT.y != transVtxB.y || transVtxT.x > transVtxB.x ? transVtxB : transVtxT;
+
+		// Okay, let's calculate the perpendicular.
 		float horizontal = transVtxTL.x - transVtxBL.x;
 		float vertical = transVtxTL.y - transVtxBL.y;
 		Vec2f addWidth = Vec2f(-vertical, horizontal).Normalized();
-		// We'll bias mostly straight lines and try to keep diagonal lines at 90 degrees.
-		if (fabsf(addWidth.y) < fabsf(addWidth.x / 16.0f)) {
-			addWidth.x = -addWidth.x;
-		}
 
 		// bottom right
 		trans[0] = transVtxBL;


### PR DESCRIPTION
We want it to consistently go down and right.  This improves Persona 2 UI significantly (see #3332.)

It's still not exactly right and may need more work (so will the software renderer.)  Problems:
1. Diagonal lines (45°) are overly wide in my tests at 1x.
2. On the PSP, a horizontal line of width 1000 with y2 == y1 + 1 is actually still perfectly straight.
3. However, a horizontal line of width 1000 with y2 == y1 + 2 goes down one pixel at 500 (exactly half.)
4. Further, y2 == y1 + 3 goes down one a third of the way, then two thirds.

The y2/y1 behavior is ultimately the cause of #3871.  I suspect it also goes for vertical but didn't explicitly test.  I assume it's a factor of the line drawing algorithm it uses.

In softgpu, we're closer to this because of how we handle delta x/y, but we are off in several cases.

Nevertheless, this pull at least makes Persona 2 look a lot better (compare to https://github.com/hrydgard/ppsspp/issues/3332#issuecomment-957142906):

![Persona 2 lines all lined up without gaps or overhangs](https://user-images.githubusercontent.com/191233/140012420-3bdbc530-c160-47d9-9c87-aeafb5e56ecb.png)

-[Unknown]