### PR TITLE
Fix an issue in GE frame dump recording

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1960,7 +1960,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 		switch (cmd) {
 		case 1:	// EMULATOR_DEVCTL__GET_HAS_DISPLAY
 			if (Memory::IsValidAddress(outPtr))
-				Memory::Write_U32(0, outPtr);	 // TODO: Make a headless mode for running tests!
+				Memory::Write_U32(PSP_CoreParameter().headLess ? 0 : 1, outPtr);
 			return 0;
 		case 2:	// EMULATOR_DEVCTL__SEND_OUTPUT
 			{


### PR DESCRIPTION
In Persona 2, for some reason it calls sceDisplaySetFramebuf twice at the start of a frame, and this causes it to end frame dumping.  This instead waits until we have something useful before ending.

It's still detecting the wrong display buffer, but at least the drawing is all correctly captured.

Also, while messing with debugger-related stuff, set HAS_DISPLAY based on the headless core parameter.  Used this to make a test wait for a button press on a PSP and within PPSSPP (to try out resolution scaling.)

-[Unknown]