### PR TITLE
Fix depth cull in softgpu

### DIFF
--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -30,6 +30,7 @@ namespace Clipper {
 
 enum {
 	SKIP_FLAG = -1,
+	CLIP_POS_Z_BIT = 0x10,
 	CLIP_NEG_Z_BIT = 0x20,
 };
 
@@ -37,6 +38,7 @@ static inline int CalcClipMask(const ClipCoords& v)
 {
 	int mask = 0;
 	// This checks `x / w` compared to 1 or -1, skipping the division.
+	if (v.z > v.w) mask |= CLIP_POS_Z_BIT;
 	if (v.z < -v.w) mask |= CLIP_NEG_Z_BIT;
 	return mask;
 }

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -844,7 +844,7 @@ Vec3<int> AlphaBlendingResult(const Vec4<int> &source, const Vec4<int> &dst)
 }
 
 template <bool clearMode>
-inline void DrawSinglePixel(const DrawingCoords &p, u16 z, u8 fog, const Vec4<int> &color_in) {
+inline void DrawSinglePixel(const DrawingCoords &p, int z, u8 fog, const Vec4<int> &color_in) {
 	Vec4<int> prim_color = color_in.Clamp(0, 255);
 	// Depth range test - applied in clear mode, if not through mode.
 	if (!gstate.isModeThrough())
@@ -1287,7 +1287,7 @@ void DrawTriangleSlice(
 					subp.x = p.x + (i & 1);
 					subp.y = p.y + (i / 2);
 
-					DrawSinglePixel<clearMode>(subp, (u16)z[i], fog[i], prim_color[i]);
+					DrawSinglePixel<clearMode>(subp, z[i], fog[i], prim_color[i]);
 				}
 			}
 		}


### PR DESCRIPTION
This fixes the culling issue in #15054.  I changed the clip mask values only thinking about clipping, but it also guards culling.

-[Unknown]