### PR TITLE
Reuse vertices between subsequent draws, if the same

### DIFF
--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -360,7 +360,7 @@ void CPUInfo::Detect() {
 		if (GetLogicalProcessorInformation(&processors[0], &len)) {
 			num_cores = 0;
 			logical_cpu_count = 0;
-			for (auto processor : processors) {
+			for (auto &processor : processors) {
 				if (processor.Relationship == RelationProcessorCore) {
 					num_cores++;
 					for (int i = 0; i < sizeof(processor.ProcessorMask) * 8; ++i) {

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -603,7 +603,7 @@ public:
 
 	void BindIndexBuffer(GLRBuffer *buffer) {  // Want to support an offset but can't in ES 2.0. We supply an offset when binding the buffers instead.
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data{ GLRRenderCommand::BIND_BUFFER};
+		GLRRenderData data{ GLRRenderCommand::BIND_BUFFER };
 		data.bind_buffer.buffer = buffer;
 		data.bind_buffer.target = GL_ELEMENT_ARRAY_BUFFER;
 		curRenderStep_->commands.push_back(data);

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -1312,6 +1312,15 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 			break;
 		}
 
+		case VKRRenderCommand::BIND_VERTEX_DATA:
+			if (c.vertexdata.vbuffer) {
+				vkCmdBindVertexBuffers(cmd, 0, 1, &c.vertexdata.vbuffer, &c.vertexdata.voffset);
+			}
+			if (c.vertexdata.ibuffer) {
+				vkCmdBindIndexBuffer(cmd, c.vertexdata.ibuffer, c.vertexdata.ioffset, c.vertexdata.indexType);
+			}
+			break;
+
 		case VKRRenderCommand::VIEWPORT:
 			if (fb != nullptr) {
 				vkCmdSetViewport(cmd, 0, 1, &c.viewport.vp);
@@ -1376,16 +1385,11 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 
 		case VKRRenderCommand::DRAW_INDEXED:
 			vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, c.drawIndexed.pipelineLayout, 0, 1, &c.drawIndexed.ds, c.drawIndexed.numUboOffsets, c.drawIndexed.uboOffsets);
-			vkCmdBindIndexBuffer(cmd, c.drawIndexed.ibuffer, c.drawIndexed.ioffset, c.drawIndexed.indexType);
-			vkCmdBindVertexBuffers(cmd, 0, 1, &c.drawIndexed.vbuffer, &c.drawIndexed.voffset);
 			vkCmdDrawIndexed(cmd, c.drawIndexed.count, c.drawIndexed.instances, 0, 0, 0);
 			break;
 
 		case VKRRenderCommand::DRAW:
 			vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, c.draw.pipelineLayout, 0, 1, &c.draw.ds, c.draw.numUboOffsets, c.draw.uboOffsets);
-			if (c.draw.vbuffer) {
-				vkCmdBindVertexBuffers(cmd, 0, 1, &c.draw.vbuffer, &c.draw.voffset);
-			}
 			vkCmdDraw(cmd, c.draw.count, 1, c.draw.offset, 0);
 			break;
 

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -28,6 +28,7 @@ enum class VKRRenderCommand : uint8_t {
 	BIND_PIPELINE,  // raw pipeline
 	BIND_GRAPHICS_PIPELINE,  // async
 	BIND_COMPUTE_PIPELINE,  // async
+	BIND_VERTEX_DATA,
 	STENCIL,
 	BLEND,
 	VIEWPORT,
@@ -59,12 +60,17 @@ struct VkRenderData {
 			VKRComputePipeline *pipeline;
 		} compute_pipeline;
 		struct {
+			VkBuffer vbuffer;
+			VkDeviceSize voffset;
+			VkBuffer ibuffer;
+			VkDeviceSize ioffset;
+			VkIndexType indexType;
+		} vertexdata;
+		struct {
 			VkPipelineLayout pipelineLayout;
 			VkDescriptorSet ds;
 			int numUboOffsets;
 			uint32_t uboOffsets[3];
-			VkBuffer vbuffer;
-			VkDeviceSize voffset;
 			uint32_t count;
 			uint32_t offset;
 		} draw;
@@ -73,13 +79,8 @@ struct VkRenderData {
 			VkDescriptorSet ds;
 			int numUboOffsets;
 			uint32_t uboOffsets[3];
-			VkBuffer vbuffer;  // might need to increase at some point
-			VkDeviceSize voffset;
-			VkBuffer ibuffer;
-			VkDeviceSize ioffset;
 			uint32_t count;
 			int16_t instances;
-			VkIndexType indexType;
 		} drawIndexed;
 		struct {
 			uint32_t clearColor;

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -363,15 +363,25 @@ public:
 
 	void Clear(uint32_t clearColor, float clearZ, int clearStencil, int clearMask);
 
-	void Draw(VkPipelineLayout layout, VkDescriptorSet descSet, int numUboOffsets, const uint32_t *uboOffsets, VkBuffer vbuffer, int voffset, int count, int offset = 0) {
+	void BindVertexData(VkBuffer vbuffer, int voffset, VkBuffer ibuffer = VK_NULL_HANDLE, int ioffset = 0, VkIndexType indexType = VkIndexType::VK_INDEX_TYPE_UINT16) {
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER && curStepHasViewport_ && curStepHasScissor_);
+		VkRenderData data{ VKRRenderCommand::BIND_VERTEX_DATA };
+		data.vertexdata.vbuffer = vbuffer;
+		data.vertexdata.voffset = voffset;
+		data.vertexdata.ibuffer = ibuffer;
+		data.vertexdata.ioffset = ioffset;
+		data.vertexdata.indexType = indexType;
+		curRenderStep_->commands.push_back(data);
+		curRenderStep_->render.numDraws++;
+	}
+
+	void Draw(VkPipelineLayout layout, VkDescriptorSet descSet, int numUboOffsets, const uint32_t *uboOffsets, int count, int offset = 0) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER && curStepHasViewport_ && curStepHasScissor_);
 		VkRenderData data{ VKRRenderCommand::DRAW };
 		data.draw.count = count;
 		data.draw.offset = offset;
 		data.draw.pipelineLayout = layout;
 		data.draw.ds = descSet;
-		data.draw.vbuffer = vbuffer;
-		data.draw.voffset = voffset;
 		data.draw.numUboOffsets = numUboOffsets;
 		_dbg_assert_(numUboOffsets <= ARRAY_SIZE(data.draw.uboOffsets));
 		for (int i = 0; i < numUboOffsets; i++)
@@ -380,22 +390,17 @@ public:
 		curRenderStep_->render.numDraws++;
 	}
 
-	void DrawIndexed(VkPipelineLayout layout, VkDescriptorSet descSet, int numUboOffsets, const uint32_t *uboOffsets, VkBuffer vbuffer, int voffset, VkBuffer ibuffer, int ioffset, int count, int numInstances, VkIndexType indexType) {
+	void DrawIndexed(VkPipelineLayout layout, VkDescriptorSet descSet, int numUboOffsets, const uint32_t *uboOffsets, int count, int numInstances) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER && curStepHasViewport_ && curStepHasScissor_);
 		VkRenderData data{ VKRRenderCommand::DRAW_INDEXED };
 		data.drawIndexed.count = count;
 		data.drawIndexed.instances = numInstances;
 		data.drawIndexed.pipelineLayout = layout;
 		data.drawIndexed.ds = descSet;
-		data.drawIndexed.vbuffer = vbuffer;
-		data.drawIndexed.voffset = voffset;
-		data.drawIndexed.ibuffer = ibuffer;
-		data.drawIndexed.ioffset = ioffset;
 		data.drawIndexed.numUboOffsets = numUboOffsets;
 		_dbg_assert_(numUboOffsets <= ARRAY_SIZE(data.drawIndexed.uboOffsets));
 		for (int i = 0; i < numUboOffsets; i++)
 			data.drawIndexed.uboOffsets[i] = uboOffsets[i];
-		data.drawIndexed.indexType = indexType;
 		curRenderStep_->commands.push_back(data);
 		curRenderStep_->render.numDraws++;
 	}

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1326,7 +1326,8 @@ void VKContext::Draw(int vertexCount, int offset) {
 
 	BindCompatiblePipeline();
 	ApplyDynamicState();
-	renderManager_.Draw(pipelineLayout_, descSet, 1, &ubo_offset, vulkanVbuf, (int)vbBindOffset + curVBufferOffsets_[0], vertexCount, offset);
+	renderManager_.BindVertexData(vulkanVbuf, (int)vbBindOffset + curVBufferOffsets_[0]);
+	renderManager_.Draw(pipelineLayout_, descSet, 1, &ubo_offset, vertexCount, offset);
 }
 
 void VKContext::DrawIndexed(int vertexCount, int offset) {
@@ -1346,7 +1347,8 @@ void VKContext::DrawIndexed(int vertexCount, int offset) {
 
 	BindCompatiblePipeline();
 	ApplyDynamicState();
-	renderManager_.DrawIndexed(pipelineLayout_, descSet, 1, &ubo_offset, vulkanVbuf, (int)vbBindOffset + curVBufferOffsets_[0], vulkanIbuf, (int)ibBindOffset + offset * sizeof(uint32_t), vertexCount, 1, VK_INDEX_TYPE_UINT16);
+	renderManager_.BindVertexData(vulkanVbuf, (int)vbBindOffset + curVBufferOffsets_[0], vulkanIbuf, (int)ibBindOffset + offset * sizeof(uint32_t), VK_INDEX_TYPE_UINT16);
+	renderManager_.DrawIndexed(pipelineLayout_, descSet, 1, &ubo_offset, vertexCount, 1);
 }
 
 void VKContext::DrawUP(const void *vdata, int vertexCount) {
@@ -1362,7 +1364,8 @@ void VKContext::DrawUP(const void *vdata, int vertexCount) {
 
 	BindCompatiblePipeline();
 	ApplyDynamicState();
-	renderManager_.Draw(pipelineLayout_, descSet, 1, &ubo_offset, vulkanVbuf, (int)vbBindOffset + curVBufferOffsets_[0], vertexCount);
+	renderManager_.BindVertexData(vulkanVbuf, (int)vbBindOffset + curVBufferOffsets_[0]);
+	renderManager_.Draw(pipelineLayout_, descSet, 1, &ubo_offset, vertexCount);
 }
 
 void VKContext::BindCompatiblePipeline() {

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -871,6 +871,7 @@ static ConfigSetting graphicsSettings[] = {
 	ConfigSetting("AnisotropyLevel", &g_Config.iAnisotropyLevel, 4, true, true),
 
 	ReportedConfigSetting("VertexDecCache", &g_Config.bVertexCache, false, true, true),
+	ReportedConfigSetting("OptimizeRepeatDraws", &g_Config.bOptimizeRepeatDraws, true, true, true),
 	ReportedConfigSetting("TextureBackoffCache", &g_Config.bTextureBackoffCache, false, true, true),
 	ReportedConfigSetting("TextureSecondaryCache", &g_Config.bTextureSecondaryCache, false, true, true),
 	ReportedConfigSetting("VertexDecJit", &g_Config.bVertexDecoderJit, &DefaultCodeGen, false),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -190,6 +190,7 @@ public:
 	float fUISaturation;
 
 	bool bVertexCache;
+	bool bOptimizeRepeatDraws;
 	bool bTextureBackoffCache;
 	bool bTextureSecondaryCache;
 	bool bVertexDecoderJit;

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -707,14 +707,12 @@ void DrawEngineCommon::SubmitPrim(void *verts, void *inds, GEPrimitiveType prim,
 	if ((vertexCount < 2 && prim > 0) || (vertexCount < 3 && prim > GE_PRIM_LINE_STRIP && prim != GE_PRIM_RECTANGLES))
 		return;
 
-	if (g_Config.bVertexCache) {
-		u32 dhash = dcid_;
-		dhash = __rotl(dhash ^ (u32)(uintptr_t)verts, 13);
-		dhash = __rotl(dhash ^ (u32)(uintptr_t)inds, 13);
-		dhash = __rotl(dhash ^ (u32)vertTypeID, 13);
-		dhash = __rotl(dhash ^ (u32)vertexCount, 13);
-		dcid_ = dhash ^ (u32)prim;
-	}
+	u32 dhash = dcid_;
+	dhash = __rotl(dhash ^ (u32)(uintptr_t)verts, 13);
+	dhash = __rotl(dhash ^ (u32)(uintptr_t)inds, 13);
+	dhash = __rotl(dhash ^ (u32)vertTypeID, 13);
+	dhash = __rotl(dhash ^ (u32)vertexCount, 13);
+	dcid_ = dhash ^ (u32)prim;
 
 	DeferredDrawCall &dc = drawCalls[numDrawCalls];
 	dc.verts = verts;

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -78,6 +78,8 @@ public:
 		DispatchFlush();
 	}
 
+	virtual void DrawSync() {}
+
 	bool TestBoundingBox(void* control_points, int vertexCount, u32 vertType, int *bytesRead);
 
 	void SubmitPrim(void *verts, void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead);
@@ -169,6 +171,7 @@ protected:
 	int decimationCounter_ = 0;
 	int decodeCounter_ = 0;
 	u32 dcid_ = 0;
+	u32 prevDcid_ = 0;
 
 	// Vertex collector state
 	IndexGenerator indexGen;

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -79,7 +79,8 @@ public:
 	}
 
 	virtual void DrawSync() {}
-	virtual void ResetPrevDraw() { prevDcid_ = 0; }
+
+	void ResetPrevDraw() { prevDcid_ = 0; }
 
 	bool TestBoundingBox(void* control_points, int vertexCount, u32 vertType, int *bytesRead);
 

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -79,6 +79,7 @@ public:
 	}
 
 	virtual void DrawSync() {}
+	virtual void ResetPrevDraw() { prevDcid_ = 0; }
 
 	bool TestBoundingBox(void* control_points, int vertexCount, u32 vertType, int *bytesRead);
 

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -371,10 +371,7 @@ void DrawEngineD3D11::DoFlush() {
 			useCache = false;
 		}
 
-		if (useCache && dcid_ == prevDcid_ && g_Config.bOptimizeRepeatDraws) {
-			reuseVertexData = true;
-			gpuStats.numRepeatDraws++;
-		} else if (useCache) {
+		if (useCache) {
 			u32 id = dcid_ ^ gstate.getUVGenMode();  // This can have an effect on which UV decoder we need to use! And hence what the decoded data will look like. See #9263
 
 			VertexArrayInfoD3D11 *vai = vai_.Get(id);

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -371,7 +371,10 @@ void DrawEngineD3D11::DoFlush() {
 			useCache = false;
 		}
 
-		if (useCache) {
+		if (useCache && dcid_ == prevDcid_ && g_Config.bOptimizeRepeatDraws) {
+			reuseVertexData = true;
+			gpuStats.numRepeatDraws++;
+		} else if (useCache) {
 			u32 id = dcid_ ^ gstate.getUVGenMode();  // This can have an effect on which UV decoder we need to use! And hence what the decoded data will look like. See #9263
 
 			VertexArrayInfoD3D11 *vai = vai_.Get(id);

--- a/GPU/D3D11/DrawEngineD3D11.h
+++ b/GPU/D3D11/DrawEngineD3D11.h
@@ -163,6 +163,8 @@ private:
 
 	ID3D11InputLayout *SetupDecFmtForDraw(D3D11VertexShader *vshader, const DecVtxFormat &decFmt, u32 pspFmt);
 
+	void DecodeVertsToPushBuffer(PushBufferD3D11 *push, uint32_t *bindOffset, ID3D11Buffer **vbuf);
+
 	void MarkUnreliable(VertexArrayInfoD3D11 *vai);
 
 	Draw::DrawContext *draw_;  // Used for framebuffer related things exclusively.
@@ -216,4 +218,8 @@ private:
 	TessellationDataTransferD3D11 *tessDataTransferD3D11;
 
 	int lastRenderStepId_ = -1;
+
+	int vertexCount = 0;
+	bool useElements = true;
+	GEPrimitiveType prevDrawPrim_;
 };

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -272,10 +272,10 @@ void DrawEngineGLES::DoFlush() {
 	GLRBuffer *vertexBuffer = nullptr;
 	GLRBuffer *indexBuffer = nullptr;
 	uint32_t vertexBufferOffset = 0;
+	// indexBufferOffset is preserved between draws.
 
 	if (vshader->UseHWTransform()) {
 		bool populateCache = false;
-
 		bool reuseVertexData = false;
 
 		if (g_Config.bSoftwareSkinning && (lastVType_ & GE_VTYPE_WEIGHT_MASK)) {

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -295,8 +295,6 @@ void DrawEngineGLES::DoFlush() {
 			}
 		}
 
-		gpuStats.numUncachedVertsDrawn += indexGen.VertexCount();
-
 		// If there's only been one primitive type, and it's either TRIANGLES, LINES or POINTS,
 		// there is no need for the index buffer we built. We can then use glDrawArrays instead
 		// for a very minor speed boost.
@@ -310,6 +308,8 @@ void DrawEngineGLES::DoFlush() {
 		} else {
 			prim = prevPrim_;
 		}
+
+		gpuStats.numUncachedVertsDrawn += vertexCount;
 
 		if (!useElements) {
 			gpuStats.numUnindexed++;

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -284,7 +284,7 @@ void DrawEngineGLES::DoFlush() {
 			u8 *dest = (u8 *)frameData.pushVertex->Push(size, &vertexBufferOffset, &vertexBuffer);
 			memcpy(dest, decoded, size);
 		} else {
-			if (dcid_ == prevDcid_) {
+			if (dcid_ == prevDcid_ && g_Config.bOptimizeRepeatDraws) {
 				// Identical draw call to the previous one! Let's just go ahead on the same bindings.
 				reuseVertexData = true;
 				gpuStats.numRepeatDraws++;

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -202,7 +202,7 @@ static inline void VertexAttribSetup(int attrib, int fmt, int stride, int offset
 	}
 }
 
-// TODO: Use VBO and get rid of the vertexData pointers - with that, we will supply only offsets
+// TODO: Use VertexBuffers where available and get rid of the vertexData pointers - with that, we will supply only offsets
 GLRInputLayout *DrawEngineGLES::SetupDecFmtForDraw(LinkedShader *program, const DecVtxFormat &decFmt) {
 	uint32_t key = decFmt.id;
 	GLRInputLayout *inputLayout = inputLayoutMap_.Get(key);
@@ -306,7 +306,7 @@ void DrawEngineGLES::DoFlush() {
 			}
 			prim = indexGen.Prim();
 		} else {
-			prim = prevPrim_;
+			prim = prevDrawPrim_;
 		}
 
 		gpuStats.numUncachedVertsDrawn += vertexCount;
@@ -346,6 +346,7 @@ void DrawEngineGLES::DoFlush() {
 			render_->Draw(glprim[prim], 0, vertexCount);
 		}
 		prevDcid_ = dcid_;
+		prevDrawPrim_ = prim;
 	} else {
 		DecodeVerts(decoded);
 		bool hasColor = (lastVType_ & GE_VTYPE_COL_MASK) != GE_VTYPE_COL_NONE;

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -176,4 +176,5 @@ private:
 	uint32_t indexBufferOffset = 0;
 	int vertexCount;
 	bool useElements;
+	GEPrimitiveType prevDrawPrim_;
 };

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -123,6 +123,10 @@ public:
 
 	bool SupportsHWTessellation() const;
 
+	void DrawSync() {
+		prevDcid_ = 0;
+	}
+
 protected:
 	bool UpdateUseHWTessellation(bool enable) override;
 	void DecimateTrackedVertexArrays() {}
@@ -167,4 +171,9 @@ private:
 
 	// Hardware tessellation
 	TessellationDataTransferGLES *tessDataTransferGLES;
+
+	// Need to save these for repeat draws as they're not captured in the bindings that we reuse.
+	uint32_t indexBufferOffset = 0;
+	int vertexCount;
+	bool useElements;
 };

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -94,7 +94,6 @@ public:
 	void BeginFrame();
 	void EndFrame();
 
-
 	// So that this can be inlined
 	void Flush() {
 		if (!numDrawCalls)
@@ -125,6 +124,7 @@ public:
 
 	void DrawSync() override {
 		prevDcid_ = 0;
+		drawHistory_.clear();
 	}
 
 protected:
@@ -177,4 +177,18 @@ private:
 	int vertexCount;
 	bool useElements;
 	GEPrimitiveType prevDrawPrim_;
+
+	// Everything we need to replicate a previous vertex bind from this frame.
+	struct DrawHistoryData {
+		u32 dcid;
+		bool useElements;
+		GLRBuffer *vertexBuffer;
+		u32 vertexBufferOffset;
+		GLRBuffer *indexBuffer;
+		u32 indexBufferOffset;
+		int vertexCount;
+		GEPrimitiveType prim;
+	};
+
+	std::vector<DrawHistoryData> drawHistory_;
 };

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -123,7 +123,7 @@ public:
 
 	bool SupportsHWTessellation() const;
 
-	void DrawSync() {
+	void DrawSync() override {
 		prevDcid_ = 0;
 	}
 

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -123,10 +123,6 @@ public:
 
 	bool SupportsHWTessellation() const;
 
-	void DrawSync() override {
-		prevDcid_ = 0;
-	}
-
 protected:
 	bool UpdateUseHWTessellation(bool enable) override;
 	void DecimateTrackedVertexArrays() {}

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -94,6 +94,7 @@ public:
 	void BeginFrame();
 	void EndFrame();
 
+
 	// So that this can be inlined
 	void Flush() {
 		if (!numDrawCalls)
@@ -124,7 +125,6 @@ public:
 
 	void DrawSync() override {
 		prevDcid_ = 0;
-		drawHistory_.clear();
 	}
 
 protected:
@@ -177,18 +177,4 @@ private:
 	int vertexCount;
 	bool useElements;
 	GEPrimitiveType prevDrawPrim_;
-
-	// Everything we need to replicate a previous vertex bind from this frame.
-	struct DrawHistoryData {
-		u32 dcid;
-		bool useElements;
-		GLRBuffer *vertexBuffer;
-		u32 vertexBufferOffset;
-		GLRBuffer *indexBuffer;
-		u32 indexBufferOffset;
-		int vertexCount;
-		GEPrimitiveType prim;
-	};
-
-	std::vector<DrawHistoryData> drawHistory_;
 };

--- a/GPU/GPU.cpp
+++ b/GPU/GPU.cpp
@@ -19,6 +19,9 @@
 
 #include "Common/TimeUtil.h"
 #include "Common/GraphicsContext.h"
+#include "Common/FramebufferManagerCommon.h"
+#include "Common/TextureCacheCommon.h"
+
 #include "Core/Core.h"
 
 #include "GPU/GPU.h"

--- a/GPU/GPU.cpp
+++ b/GPU/GPU.cpp
@@ -131,6 +131,7 @@ void GPUStatistics::ResetFrame() {
 	numCachedVertsDrawn = 0;
 	numUncachedVertsDrawn = 0;
 	numRepeatDraws = 0;
+	numHistoryDraws = 0;
 	numUnindexed = 0;
 	numTrackedVertexArrays = 0;
 	numTextureInvalidations = 0;
@@ -145,6 +146,7 @@ void GPUStatistics::ResetFrame() {
 	numReadbacks = 0;
 	numUploads = 0;
 	numClears = 0;
+	numDrawSyncs = 0;
 	msProcessingDisplayLists = 0;
 	vertexGPUCycles = 0;
 	otherGPUCycles = 0;
@@ -155,13 +157,14 @@ size_t GPUStatistics::Format(char *buffer, size_t size, FramebufferManagerCommon
 	float vertexAverageCycles = gpuStats.numVertsSubmitted > 0 ? (float)gpuStats.vertexGPUCycles / (float)gpuStats.numVertsSubmitted : 0.0f;
 	return snprintf(buffer, size,
 		"DL processing time: %0.2f ms\n"
-		"Draws: %d, flushes %d, clears %d (cached: %d, repeat: %d, unind: %d)\n"
+		"Draws: %d, flushes %d, clears %d (cached: %d, repeat: %d, history: %d, unind: %d)\n"
 		"Num Tracked Vertex Arrays: %d\n"
 		"Commands per call level: %d %d %d %d\n"
 		"Vertices: %d cached: %d uncached: %d\n"
 		"FBOs active: %d (evaluations: %d)\n"
 		"Textures: %d, dec: %d, invalidated: %d, hashed: %d kB\n"
 		"Readbacks: %d, uploads: %d\n"
+		"DrawSyncs: %d\n"
 		"GPU cycles executed: %d (%f per vertex)\n",
 		msProcessingDisplayLists * 1000.0f,
 		numDrawCalls,
@@ -169,6 +172,7 @@ size_t GPUStatistics::Format(char *buffer, size_t size, FramebufferManagerCommon
 		numClears,
 		numCachedDrawCalls,
 		numRepeatDraws,
+		numHistoryDraws,
 		numUnindexed,
 		numTrackedVertexArrays,
 		gpuCommandsAtCallLevel[0], gpuStats.gpuCommandsAtCallLevel[1], gpuStats.gpuCommandsAtCallLevel[2], gpuStats.gpuCommandsAtCallLevel[3],
@@ -183,6 +187,7 @@ size_t GPUStatistics::Format(char *buffer, size_t size, FramebufferManagerCommon
 		gpuStats.numTextureDataBytesHashed / 1024,
 		gpuStats.numReadbacks,
 		gpuStats.numUploads,
+		gpuStats.numDrawSyncs,
 		gpuStats.vertexGPUCycles + gpuStats.otherGPUCycles,
 		vertexAverageCycles
 	);

--- a/GPU/GPU.cpp
+++ b/GPU/GPU.cpp
@@ -123,3 +123,67 @@ void GPU_Shutdown() {
 	gpu = nullptr;
 	gpuDebug = nullptr;
 }
+
+void GPUStatistics::ResetFrame() {
+	numDrawCalls = 0;
+	numCachedDrawCalls = 0;
+	numVertsSubmitted = 0;
+	numCachedVertsDrawn = 0;
+	numUncachedVertsDrawn = 0;
+	numRepeatDraws = 0;
+	numUnindexed = 0;
+	numTrackedVertexArrays = 0;
+	numTextureInvalidations = 0;
+	numTextureInvalidationsByFramebuffer = 0;
+	numTexturesHashed = 0;
+	numTextureSwitches = 0;
+	numTextureDataBytesHashed = 0;
+	numShaderSwitches = 0;
+	numFlushes = 0;
+	numTexturesDecoded = 0;
+	numFramebufferEvaluations = 0;
+	numReadbacks = 0;
+	numUploads = 0;
+	numClears = 0;
+	msProcessingDisplayLists = 0;
+	vertexGPUCycles = 0;
+	otherGPUCycles = 0;
+	memset(gpuCommandsAtCallLevel, 0, sizeof(gpuCommandsAtCallLevel));
+}
+
+size_t GPUStatistics::Format(char *buffer, size_t size, FramebufferManagerCommon *framebufferManager, TextureCacheCommon *textureCache) {
+	float vertexAverageCycles = gpuStats.numVertsSubmitted > 0 ? (float)gpuStats.vertexGPUCycles / (float)gpuStats.numVertsSubmitted : 0.0f;
+	return snprintf(buffer, size,
+		"DL processing time: %0.2f ms\n"
+		"Draws: %d, flushes %d, clears %d (cached: %d, repeat: %d, unind: %d)\n"
+		"Num Tracked Vertex Arrays: %d\n"
+		"Commands per call level: %d %d %d %d\n"
+		"Vertices: %d cached: %d uncached: %d\n"
+		"FBOs active: %d (evaluations: %d)\n"
+		"Textures: %d, dec: %d, invalidated: %d, hashed: %d kB\n"
+		"Readbacks: %d, uploads: %d\n"
+		"GPU cycles executed: %d (%f per vertex)\n",
+		msProcessingDisplayLists * 1000.0f,
+		numDrawCalls,
+		numFlushes,
+		numClears,
+		numCachedDrawCalls,
+		numRepeatDraws,
+		numUnindexed,
+		numTrackedVertexArrays,
+		gpuCommandsAtCallLevel[0], gpuStats.gpuCommandsAtCallLevel[1], gpuStats.gpuCommandsAtCallLevel[2], gpuStats.gpuCommandsAtCallLevel[3],
+		numVertsSubmitted,
+		numCachedVertsDrawn,
+		numUncachedVertsDrawn,
+		(int)framebufferManager->NumVFBs(),
+		gpuStats.numFramebufferEvaluations,
+		(int)textureCache->NumLoadedTextures(),
+		gpuStats.numTexturesDecoded,
+		gpuStats.numTextureInvalidations,
+		gpuStats.numTextureDataBytesHashed / 1024,
+		gpuStats.numReadbacks,
+		gpuStats.numUploads,
+		gpuStats.vertexGPUCycles + gpuStats.otherGPUCycles,
+		vertexAverageCycles
+	);
+}

--- a/GPU/GPU.cpp
+++ b/GPU/GPU.cpp
@@ -148,6 +148,7 @@ void GPUStatistics::ResetFrame() {
 	numReadbacks = 0;
 	numUploads = 0;
 	numClears = 0;
+	numDrawSyncs = 0;
 	msProcessingDisplayLists = 0;
 	vertexGPUCycles = 0;
 	otherGPUCycles = 0;
@@ -164,7 +165,7 @@ size_t GPUStatistics::Format(char *buffer, size_t size, FramebufferManagerCommon
 		"Vertices: %d cached: %d uncached: %d\n"
 		"FBOs active: %d (evaluations: %d)\n"
 		"Textures: %d, dec: %d, invalidated: %d, hashed: %d kB\n"
-		"Readbacks: %d, uploads: %d\n"
+		"Readbacks: %d, uploads: %d, drawsyncs: %d\n"
 		"GPU cycles executed: %d (%f per vertex)\n",
 		msProcessingDisplayLists * 1000.0f,
 		numDrawCalls,
@@ -186,6 +187,7 @@ size_t GPUStatistics::Format(char *buffer, size_t size, FramebufferManagerCommon
 		gpuStats.numTextureDataBytesHashed / 1024,
 		gpuStats.numReadbacks,
 		gpuStats.numUploads,
+		gpuStats.numDrawSyncs,
 		gpuStats.vertexGPUCycles + gpuStats.otherGPUCycles,
 		vertexAverageCycles
 	);

--- a/GPU/GPU.cpp
+++ b/GPU/GPU.cpp
@@ -131,7 +131,6 @@ void GPUStatistics::ResetFrame() {
 	numCachedVertsDrawn = 0;
 	numUncachedVertsDrawn = 0;
 	numRepeatDraws = 0;
-	numHistoryDraws = 0;
 	numUnindexed = 0;
 	numTrackedVertexArrays = 0;
 	numTextureInvalidations = 0;
@@ -146,7 +145,6 @@ void GPUStatistics::ResetFrame() {
 	numReadbacks = 0;
 	numUploads = 0;
 	numClears = 0;
-	numDrawSyncs = 0;
 	msProcessingDisplayLists = 0;
 	vertexGPUCycles = 0;
 	otherGPUCycles = 0;
@@ -157,14 +155,13 @@ size_t GPUStatistics::Format(char *buffer, size_t size, FramebufferManagerCommon
 	float vertexAverageCycles = gpuStats.numVertsSubmitted > 0 ? (float)gpuStats.vertexGPUCycles / (float)gpuStats.numVertsSubmitted : 0.0f;
 	return snprintf(buffer, size,
 		"DL processing time: %0.2f ms\n"
-		"Draws: %d, flushes %d, clears %d (cached: %d, repeat: %d, history: %d, unind: %d)\n"
+		"Draws: %d, flushes %d, clears %d (cached: %d, repeat: %d, unind: %d)\n"
 		"Num Tracked Vertex Arrays: %d\n"
 		"Commands per call level: %d %d %d %d\n"
 		"Vertices: %d cached: %d uncached: %d\n"
 		"FBOs active: %d (evaluations: %d)\n"
 		"Textures: %d, dec: %d, invalidated: %d, hashed: %d kB\n"
 		"Readbacks: %d, uploads: %d\n"
-		"DrawSyncs: %d\n"
 		"GPU cycles executed: %d (%f per vertex)\n",
 		msProcessingDisplayLists * 1000.0f,
 		numDrawCalls,
@@ -172,7 +169,6 @@ size_t GPUStatistics::Format(char *buffer, size_t size, FramebufferManagerCommon
 		numClears,
 		numCachedDrawCalls,
 		numRepeatDraws,
-		numHistoryDraws,
 		numUnindexed,
 		numTrackedVertexArrays,
 		gpuCommandsAtCallLevel[0], gpuStats.gpuCommandsAtCallLevel[1], gpuStats.gpuCommandsAtCallLevel[2], gpuStats.gpuCommandsAtCallLevel[3],
@@ -187,7 +183,6 @@ size_t GPUStatistics::Format(char *buffer, size_t size, FramebufferManagerCommon
 		gpuStats.numTextureDataBytesHashed / 1024,
 		gpuStats.numReadbacks,
 		gpuStats.numUploads,
-		gpuStats.numDrawSyncs,
 		gpuStats.vertexGPUCycles + gpuStats.otherGPUCycles,
 		vertexAverageCycles
 	);

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -84,6 +84,7 @@ struct GPUStatistics {
 	int numReadbacks;
 	int numUploads;
 	int numClears;
+	int numDrawSyncs;
 	double msProcessingDisplayLists;
 	int vertexGPUCycles;
 	int otherGPUCycles;

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -72,7 +72,6 @@ struct GPUStatistics {
 	int numUncachedVertsDrawn;
 	int numUnindexed;
 	int numRepeatDraws;
-	int numHistoryDraws;
 	int numTrackedVertexArrays;
 	int numTextureInvalidations;
 	int numTextureInvalidationsByFramebuffer;
@@ -85,7 +84,6 @@ struct GPUStatistics {
 	int numReadbacks;
 	int numUploads;
 	int numClears;
-	int numDrawSyncs;
 	double msProcessingDisplayLists;
 	int vertexGPUCycles;
 	int otherGPUCycles;

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -24,6 +24,9 @@ class GPUInterface;
 class GPUDebugInterface;
 class GraphicsContext;
 
+class FramebufferManagerCommon;
+class TextureCacheCommon;
+
 enum SkipDrawReasonFlags {
 	SKIPDRAW_SKIPFRAME = 1,
 	SKIPDRAW_NON_DISPLAYED_FB = 2,   // Skip drawing to FBO:s that have not been displayed.
@@ -56,30 +59,9 @@ struct GPUStatistics {
 		memset(this, 0, sizeof(*this));
 	}
 
-	void ResetFrame() {
-		numDrawCalls = 0;
-		numCachedDrawCalls = 0;
-		numVertsSubmitted = 0;
-		numCachedVertsDrawn = 0;
-		numUncachedVertsDrawn = 0;
-		numTrackedVertexArrays = 0;
-		numTextureInvalidations = 0;
-		numTextureInvalidationsByFramebuffer = 0;
-		numTexturesHashed = 0;
-		numTextureSwitches = 0;
-		numTextureDataBytesHashed = 0;
-		numShaderSwitches = 0;
-		numFlushes = 0;
-		numTexturesDecoded = 0;
-		numFramebufferEvaluations = 0;
-		numReadbacks = 0;
-		numUploads = 0;
-		numClears = 0;
-		msProcessingDisplayLists = 0;
-		vertexGPUCycles = 0;
-		otherGPUCycles = 0;
-		memset(gpuCommandsAtCallLevel, 0, sizeof(gpuCommandsAtCallLevel));
-	}
+	void ResetFrame();
+
+	size_t Format(char *buffer, size_t size, FramebufferManagerCommon *framebufferManager, TextureCacheCommon *textureCache);
 
 	// Per frame statistics
 	int numDrawCalls;
@@ -88,6 +70,8 @@ struct GPUStatistics {
 	int numVertsSubmitted;
 	int numCachedVertsDrawn;
 	int numUncachedVertsDrawn;
+	int numUnindexed;
+	int numRepeatDraws;
 	int numTrackedVertexArrays;
 	int numTextureInvalidations;
 	int numTextureInvalidationsByFramebuffer;

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -72,6 +72,7 @@ struct GPUStatistics {
 	int numUncachedVertsDrawn;
 	int numUnindexed;
 	int numRepeatDraws;
+	int numHistoryDraws;
 	int numTrackedVertexArrays;
 	int numTextureInvalidations;
 	int numTextureInvalidationsByFramebuffer;
@@ -84,6 +85,7 @@ struct GPUStatistics {
 	int numReadbacks;
 	int numUploads;
 	int numClears;
+	int numDrawSyncs;
 	double msProcessingDisplayLists;
 	int vertexGPUCycles;
 	int otherGPUCycles;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -574,7 +574,7 @@ void GPUCommon::DumpNextFrame() {
 }
 
 u32 GPUCommon::DrawSync(int mode) {
-	drawEngineCommon_->DrawSync();
+	drawEngineCommon_->ResetPrevDraw();
 
 	if (mode < 0 || mode > 1)
 		return SCE_KERNEL_ERROR_INVALID_MODE;
@@ -624,7 +624,7 @@ void GPUCommon::CheckDrawSync() {
 }
 
 int GPUCommon::ListSync(int listid, int mode) {
-	drawEngineCommon_->DrawSync();
+	drawEngineCommon_->ResetPrevDraw();
 
 	if (listid < 0 || listid >= DisplayListMaxCount)
 		return SCE_KERNEL_ERROR_INVALID_ID;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -574,6 +574,8 @@ void GPUCommon::DumpNextFrame() {
 }
 
 u32 GPUCommon::DrawSync(int mode) {
+	gpuStats.numDrawSyncs++;
+
 	if (mode < 0 || mode > 1)
 		return SCE_KERNEL_ERROR_INVALID_MODE;
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -574,6 +574,7 @@ void GPUCommon::DumpNextFrame() {
 }
 
 u32 GPUCommon::DrawSync(int mode) {
+	gpuStats.numDrawSyncs++;
 	drawEngineCommon_->DrawSync();
 
 	if (mode < 0 || mode > 1)

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -574,6 +574,8 @@ void GPUCommon::DumpNextFrame() {
 }
 
 u32 GPUCommon::DrawSync(int mode) {
+	drawEngineCommon_->DrawSync();
+
 	if (mode < 0 || mode > 1)
 		return SCE_KERNEL_ERROR_INVALID_MODE;
 
@@ -622,6 +624,8 @@ void GPUCommon::CheckDrawSync() {
 }
 
 int GPUCommon::ListSync(int listid, int mode) {
+	drawEngineCommon_->DrawSync();
+
 	if (listid < 0 || listid >= DisplayListMaxCount)
 		return SCE_KERNEL_ERROR_INVALID_ID;
 
@@ -2961,36 +2965,5 @@ bool GPUCommon::FramebufferReallyDirty() {
 }
 
 size_t GPUCommon::FormatGPUStatsCommon(char *buffer, size_t size) {
-	float vertexAverageCycles = gpuStats.numVertsSubmitted > 0 ? (float)gpuStats.vertexGPUCycles / (float)gpuStats.numVertsSubmitted : 0.0f;
-	return snprintf(buffer, size,
-		"DL processing time: %0.2f ms\n"
-		"Draw calls: %d, flushes %d, clears %d (cached: %d)\n"
-		"Num Tracked Vertex Arrays: %d\n"
-		"Commands per call level: %i %i %i %i\n"
-		"Vertices: %d cached: %d uncached: %d\n"
-		"FBOs active: %d (evaluations: %d)\n"
-		"Textures: %d, dec: %d, invalidated: %d, hashed: %d kB\n"
-		"Readbacks: %d, uploads: %d\n"
-		"GPU cycles executed: %d (%f per vertex)\n",
-		gpuStats.msProcessingDisplayLists * 1000.0f,
-		gpuStats.numDrawCalls,
-		gpuStats.numFlushes,
-		gpuStats.numClears,
-		gpuStats.numCachedDrawCalls,
-		gpuStats.numTrackedVertexArrays,
-		gpuStats.gpuCommandsAtCallLevel[0], gpuStats.gpuCommandsAtCallLevel[1], gpuStats.gpuCommandsAtCallLevel[2], gpuStats.gpuCommandsAtCallLevel[3],
-		gpuStats.numVertsSubmitted,
-		gpuStats.numCachedVertsDrawn,
-		gpuStats.numUncachedVertsDrawn,
-		(int)framebufferManager_->NumVFBs(),
-		gpuStats.numFramebufferEvaluations,
-		(int)textureCache_->NumLoadedTextures(),
-		gpuStats.numTexturesDecoded,
-		gpuStats.numTextureInvalidations,
-		gpuStats.numTextureDataBytesHashed / 1024,
-		gpuStats.numReadbacks,
-		gpuStats.numUploads,
-		gpuStats.vertexGPUCycles + gpuStats.otherGPUCycles,
-		vertexAverageCycles
-	);
+	return gpuStats.Format(buffer, size, framebufferManager_, textureCache_);
 }

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -574,7 +574,6 @@ void GPUCommon::DumpNextFrame() {
 }
 
 u32 GPUCommon::DrawSync(int mode) {
-	gpuStats.numDrawSyncs++;
 	drawEngineCommon_->DrawSync();
 
 	if (mode < 0 || mode > 1)

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -574,8 +574,6 @@ void GPUCommon::DumpNextFrame() {
 }
 
 u32 GPUCommon::DrawSync(int mode) {
-	drawEngineCommon_->ResetPrevDraw();
-
 	if (mode < 0 || mode > 1)
 		return SCE_KERNEL_ERROR_INVALID_MODE;
 
@@ -624,8 +622,6 @@ void GPUCommon::CheckDrawSync() {
 }
 
 int GPUCommon::ListSync(int listid, int mode) {
-	drawEngineCommon_->ResetPrevDraw();
-
 	if (listid < 0 || listid >= DisplayListMaxCount)
 		return SCE_KERNEL_ERROR_INVALID_ID;
 
@@ -975,6 +971,7 @@ bool GPUCommon::InterpretList(DisplayList &list) {
 
 	if (list.state == PSP_GE_DL_STATE_PAUSED)
 		return false;
+
 	currentList = &list;
 
 	if (!list.started && list.context.IsValid()) {
@@ -1000,6 +997,10 @@ bool GPUCommon::InterpretList(DisplayList &list) {
 	// To enable breakpoints, we don't do fast matrix loads while debugger active.
 	debugRecording_ = GPUDebug::IsActive() || GPURecord::IsActive();
 	const bool useFastRunLoop = !dumpThisFrame_ && !debugRecording_;
+
+	// Reset the repeated draw detection.
+	drawEngineCommon_->ResetPrevDraw();
+
 	while (gpuState == GPUSTATE_RUNNING) {
 		{
 			if (list.pc == list.stall) {

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -745,7 +745,7 @@ void DrawEngineVulkan::DoFlush() {
 				}
 				prim = indexGen.Prim();
 			} else {
-				prim = prevPrim_;
+				prim = prevDrawPrim_;
 			}
 
 			gpuStats.numUncachedVertsDrawn += vertexCount;
@@ -842,6 +842,7 @@ void DrawEngineVulkan::DoFlush() {
 		}
 
 		prevDcid_ = dcid_;
+		prevDrawPrim_ = prim;
 	} else {
 		PROFILE_THIS_SCOPE("soft");
 		// Decode to "decoded"

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -727,7 +727,7 @@ void DrawEngineVulkan::DoFlush() {
 				u8 *dest = (u8 *)frame->pushVertex->Push(size, &vbOffset, &vbuf);
 				memcpy(dest, decoded, size);
 			} else {
-				if (dcid_ == prevDcid_) {
+				if (dcid_ == prevDcid_ && g_Config.bOptimizeRepeatDraws) {
 					reuseVertexData = true;
 					gpuStats.numRepeatDraws++;
 				} else {

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -580,7 +580,10 @@ void DrawEngineVulkan::DoFlush() {
 			useCache = false;
 		}
 
-		if (useCache) {
+		if (useCache && dcid_ == prevDcid_ && g_Config.bOptimizeRepeatDraws) {
+			reuseVertexData = true;
+			gpuStats.numRepeatDraws++;
+		} else if (useCache) {
 			PROFILE_THIS_SCOPE("vcache");
 			u32 id = dcid_ ^ gstate.getUVGenMode();  // This can have an effect on which UV decoder we need to use! And hence what the decoded data will look like. See #9263
 			VertexArrayInfoVulkan *vai = vai_.Get(id);

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -821,9 +821,11 @@ void DrawEngineVulkan::DoFlush() {
 			if (!ibuf) {
 				ibOffset = (uint32_t)frame->pushIndex->Push(decIndex, sizeof(uint16_t) * indexGen.VertexCount(), &ibuf);
 			}
-			renderManager->DrawIndexed(pipelineLayout_, ds, ARRAY_SIZE(dynamicUBOOffsets), dynamicUBOOffsets, vbuf, vbOffset, ibuf, ibOffset, vertexCount, 1, VK_INDEX_TYPE_UINT16);
+			renderManager->BindVertexData(vbuf, vbOffset, ibuf, ibOffset, VK_INDEX_TYPE_UINT16);
+			renderManager->DrawIndexed(pipelineLayout_, ds, ARRAY_SIZE(dynamicUBOOffsets), dynamicUBOOffsets, vertexCount, 1);
 		} else {
-			renderManager->Draw(pipelineLayout_, ds, ARRAY_SIZE(dynamicUBOOffsets), dynamicUBOOffsets, vbuf, vbOffset, vertexCount);
+			renderManager->BindVertexData(vbuf, vbOffset);
+			renderManager->Draw(pipelineLayout_, ds, ARRAY_SIZE(dynamicUBOOffsets), dynamicUBOOffsets, vertexCount);
 		}
 	} else {
 		PROFILE_THIS_SCOPE("soft");
@@ -958,11 +960,13 @@ void DrawEngineVulkan::DoFlush() {
 				VkBuffer vbuf, ibuf;
 				vbOffset = (uint32_t)frame->pushVertex->Push(result.drawBuffer, maxIndex * sizeof(TransformedVertex), &vbuf);
 				ibOffset = (uint32_t)frame->pushIndex->Push(inds, sizeof(short) * result.drawNumTrans, &ibuf);
-				renderManager->DrawIndexed(pipelineLayout_, ds, ARRAY_SIZE(dynamicUBOOffsets), dynamicUBOOffsets, vbuf, vbOffset, ibuf, ibOffset, result.drawNumTrans, 1, VK_INDEX_TYPE_UINT16);
+				renderManager->BindVertexData(vbuf, vbOffset, ibuf, ibOffset, VK_INDEX_TYPE_UINT16);
+				renderManager->DrawIndexed(pipelineLayout_, ds, ARRAY_SIZE(dynamicUBOOffsets), dynamicUBOOffsets, result.drawNumTrans, 1);
 			} else {
 				VkBuffer vbuf;
 				vbOffset = (uint32_t)frame->pushVertex->Push(result.drawBuffer, result.drawNumTrans * sizeof(TransformedVertex), &vbuf);
-				renderManager->Draw(pipelineLayout_, ds, ARRAY_SIZE(dynamicUBOOffsets), dynamicUBOOffsets, vbuf, vbOffset, result.drawNumTrans);
+				renderManager->BindVertexData(vbuf, vbOffset);
+				renderManager->Draw(pipelineLayout_, ds, ARRAY_SIZE(dynamicUBOOffsets), dynamicUBOOffsets, result.drawNumTrans);
 			}
 		} else if (result.action == SW_CLEAR) {
 			// Note: we won't get here if the clear is alpha but not color, or color but not alpha.

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -580,10 +580,7 @@ void DrawEngineVulkan::DoFlush() {
 			useCache = false;
 		}
 
-		if (useCache && dcid_ == prevDcid_ && g_Config.bOptimizeRepeatDraws) {
-			reuseVertexData = true;
-			gpuStats.numRepeatDraws++;
-		} else if (useCache) {
+		if (useCache) {
 			PROFILE_THIS_SCOPE("vcache");
 			u32 id = dcid_ ^ gstate.getUVGenMode();  // This can have an effect on which UV decoder we need to use! And hence what the decoded data will look like. See #9263
 			VertexArrayInfoVulkan *vai = vai_.Get(id);

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -189,6 +189,10 @@ public:
 		}
 	}
 
+	void DrawSync() override {
+		prevDcid_ = 0;
+	}
+
 private:
 	struct FrameData;
 	void ApplyDrawStateLate(VulkanRenderManager *renderManager, bool applyStencilRef, uint8_t stencilRef, bool useBlendConstant);
@@ -283,4 +287,8 @@ private:
 	TessellationDataTransferVulkan *tessDataTransferVulkan;
 
 	int lastRenderStepId_ = -1;
+
+	// Need to save these for repeat draws as they're not captured in the bindings that we reuse.
+	int vertexCount = 0;
+	bool useElements = true;
 };

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -189,10 +189,6 @@ public:
 		}
 	}
 
-	void DrawSync() override {
-		prevDcid_ = 0;
-	}
-
 private:
 	struct FrameData;
 	void ApplyDrawStateLate(VulkanRenderManager *renderManager, bool applyStencilRef, uint8_t stencilRef, bool useBlendConstant);

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -291,4 +291,5 @@ private:
 	// Need to save these for repeat draws as they're not captured in the bindings that we reuse.
 	int vertexCount = 0;
 	bool useElements = true;
+	GEPrimitiveType prevDrawPrim_;
 };

--- a/GPU/Vulkan/FramebufferManagerVulkan.cpp
+++ b/GPU/Vulkan/FramebufferManagerVulkan.cpp
@@ -227,7 +227,8 @@ void FramebufferManagerVulkan::DrawActiveTexture(float x, float y, float w, floa
 	VkBuffer vbuffer;
 	VkDeviceSize offset = push_->Push(vtx, sizeof(vtx), &vbuffer);
 	renderManager->BindPipeline(cur2DPipeline_, (PipelineFlags)0);
-	renderManager->Draw(vulkan2D_->GetPipelineLayout(), descSet, 0, nullptr, vbuffer, offset, 4);
+	renderManager->BindVertexData(vbuffer, offset);
+	renderManager->Draw(vulkan2D_->GetPipelineLayout(), descSet, 0, nullptr, 4);
 }
 
 void FramebufferManagerVulkan::Bind2DShader() {

--- a/GPU/Vulkan/StencilBufferVulkan.cpp
+++ b/GPU/Vulkan/StencilBufferVulkan.cpp
@@ -195,7 +195,7 @@ bool FramebufferManagerVulkan::NotifyStencilUpload(u32 addr, int size, StencilUp
 	uint32_t value = 0;
 	renderManager->PushConstants(vulkan2D_->GetPipelineLayout(), VK_SHADER_STAGE_VERTEX_BIT|VK_SHADER_STAGE_FRAGMENT_BIT, 0, 4, &value);
 	renderManager->SetStencilParams(0xFF, 0xFF, 0x00);
-	renderManager->BindVertexData(0, 0, VK_NULL_HANDLE);
+	renderManager->BindVertexData(VK_NULL_HANDLE, 0, VK_NULL_HANDLE);
 	renderManager->Draw(vulkan2D_->GetPipelineLayout(), descSet, 0, nullptr, 3);  // full screen triangle
 
 	for (int i = 1; i < values; i += i) {
@@ -222,7 +222,7 @@ bool FramebufferManagerVulkan::NotifyStencilUpload(u32 addr, int size, StencilUp
 		// Need to specify both VERTEX and FRAGMENT bits here since that's what we set up in the pipeline layout, and we need
 		// that for the post shaders. There's probably not really a cost to this.
 		renderManager->PushConstants(vulkan2D_->GetPipelineLayout(), VK_SHADER_STAGE_VERTEX_BIT|VK_SHADER_STAGE_FRAGMENT_BIT, 0, 4, &value);
-		renderManager->BindVertexData(0, 0, VK_NULL_HANDLE);
+		renderManager->BindVertexData(VK_NULL_HANDLE, 0, VK_NULL_HANDLE);
 		renderManager->Draw(vulkan2D_->GetPipelineLayout(), descSet, 0, nullptr, 3);  // full screen triangle
 	}
 

--- a/GPU/Vulkan/StencilBufferVulkan.cpp
+++ b/GPU/Vulkan/StencilBufferVulkan.cpp
@@ -195,7 +195,8 @@ bool FramebufferManagerVulkan::NotifyStencilUpload(u32 addr, int size, StencilUp
 	uint32_t value = 0;
 	renderManager->PushConstants(vulkan2D_->GetPipelineLayout(), VK_SHADER_STAGE_VERTEX_BIT|VK_SHADER_STAGE_FRAGMENT_BIT, 0, 4, &value);
 	renderManager->SetStencilParams(0xFF, 0xFF, 0x00);
-	renderManager->Draw(vulkan2D_->GetPipelineLayout(), descSet, 0, nullptr, VK_NULL_HANDLE, 0, 3);  // full screen triangle
+	renderManager->BindVertexData(0, 0, VK_NULL_HANDLE);
+	renderManager->Draw(vulkan2D_->GetPipelineLayout(), descSet, 0, nullptr, 3);  // full screen triangle
 
 	for (int i = 1; i < values; i += i) {
 		if (!(usedBits & i)) {
@@ -221,7 +222,8 @@ bool FramebufferManagerVulkan::NotifyStencilUpload(u32 addr, int size, StencilUp
 		// Need to specify both VERTEX and FRAGMENT bits here since that's what we set up in the pipeline layout, and we need
 		// that for the post shaders. There's probably not really a cost to this.
 		renderManager->PushConstants(vulkan2D_->GetPipelineLayout(), VK_SHADER_STAGE_VERTEX_BIT|VK_SHADER_STAGE_FRAGMENT_BIT, 0, 4, &value);
-		renderManager->Draw(vulkan2D_->GetPipelineLayout(), descSet, 0, nullptr, VK_NULL_HANDLE, 0, 3);  // full screen triangle
+		renderManager->BindVertexData(0, 0, VK_NULL_HANDLE);
+		renderManager->Draw(vulkan2D_->GetPipelineLayout(), descSet, 0, nullptr, 3);  // full screen triangle
 	}
 
 	tex->Release();

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -527,7 +527,8 @@ void TextureCacheVulkan::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 		}
 		renderManager->SetScissor(0, 0, (int)framebuffer->renderWidth, (int)framebuffer->renderHeight);
 		renderManager->SetViewport(VkViewport{ 0.f, 0.f, (float)framebuffer->renderWidth, (float)framebuffer->renderHeight, 0.f, 1.f });
-		renderManager->Draw(vulkan2D_->GetPipelineLayout(), descSet, 0, nullptr, pushed, offset, 4);
+		renderManager->BindVertexData(pushed, offset);
+		renderManager->Draw(vulkan2D_->GetPipelineLayout(), descSet, 0, nullptr, 4);
 		shaderManagerVulkan_->DirtyLastShader();
 
 		const u32 bytesPerColor = clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16);


### PR DESCRIPTION
Avoids decoding and rebinding vertex data if the current draw uses the same vertex data as the previous draw (but potentially different transform etc).

This helps performance in some games that use "instancing", like GTA and Burnout. With this, vertex cache in VK is pretty much performance neutral in these games, making the case stronger for removing it, and improves performance in GTA with GL by about 6% (measured on PC).

Vertex cache is still a (small) win in some games though - and when there are a lot of repeat, this code now makes the vertex cache path faster too by simply skipping over it on repeats.

~~Looking further back in the frame than just the previous draw and reusing decoded data can probably get even closer or even surpass vertex cache performance (due to simpler management) while pretty much eliminating the risk for bad reuse.~~  Actually, trying this, it doesn't seem all that profitable..

~~Still experimental, needs a lot of testing and also to be implemented for the other backends.~~