### PR TITLE
GLES: Explicitly enable ARB_cull_distance

### DIFF
--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -147,6 +147,9 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 		if (gl_extensions.APPLE_clip_distance && id.Bit(VS_BIT_VERTEX_RANGE_CULLING)) {
 			gl_exts.push_back("#extension GL_APPLE_clip_distance : enable");
 		}
+		if (gl_extensions.ARB_cull_distance && id.Bit(VS_BIT_VERTEX_RANGE_CULLING)) {
+			gl_exts.push_back("#extension GL_ARB_cull_distance : enable");
+		}
 	}
 	ShaderWriter p(buffer, compat, ShaderStage::Vertex, gl_exts.data(), gl_exts.size());
 


### PR DESCRIPTION
In reporting, I saw an error that gl_CullDistance wasn't defined on a nouveau driver.  I'm hoping this might help, and I see some people requiring the extension elsewhere.

-[Unknown]