### PR TITLE
Texture upscale shader rework (drastic perf improvement)

### DIFF
--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -342,9 +342,9 @@ void RingbufferLogListener::Log(const LogMessage &message) {
 #ifdef _WIN32
 
 void OutputDebugStringUTF8(const char *p) {
-	wchar_t temp[4096];
+	wchar_t temp[16384*4];
 
-	int len = std::min(4095, (int)strlen(p));
+	int len = std::min(16383*4, (int)strlen(p));
 	int size = (int)MultiByteToWideChar(CP_UTF8, 0, p, len, NULL, 0);
 	MultiByteToWideChar(CP_UTF8, 0, p, len, temp, size);
 	temp[size] = 0;

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -208,10 +208,11 @@ void LoadPostShaderInfo(Draw::DrawContext *draw, const std::vector<Path> &direct
 					info.section = section.name();
 					section.Get("Name", &info.name, section.name().c_str());
 					section.Get("Compute", &temp, "");
-					section.Get("MaxScale", &info.maxScale, 255);
+					section.Get("Scale", &info.scaleFactor, 0);
 					info.computeShaderFile = path / temp;
-
-					appendTextureShader(info);
+					if (info.scaleFactor >= 2 && info.scaleFactor < 8) {
+						appendTextureShader(info);
+					}
 				}
 			}
 		}

--- a/GPU/Common/PostShader.h
+++ b/GPU/Common/PostShader.h
@@ -72,7 +72,9 @@ struct TextureShaderInfo {
 	std::string name;
 
 	Path computeShaderFile;
-	int maxScale;
+
+	// Upscaling shaders have a fixed scale factor.
+	int scaleFactor;
 
 	bool operator == (const std::string &other) {
 		return name == other;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -653,7 +653,6 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 	int scaleFactor = standardScaleFactor_;
 	bool hardwareScaling = g_Config.bTexHardwareScaling && uploadCS_ != VK_NULL_HANDLE;
 	if (hardwareScaling) {
-		_assert_(shaderScaleFactor_ != 0);
 		scaleFactor = shaderScaleFactor_;
 		dstFmt = VK_FORMAT_R8G8B8A8_UNORM;
 	}

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -708,7 +708,6 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 	}
 
 	bool computeUpload = false;
-	bool computeCopy = false;
 	VkCommandBuffer cmdInit = (VkCommandBuffer)draw_->GetNativeObject(Draw::NativeObject::INIT_COMMANDBUFFER);
 
 	{

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -57,85 +57,6 @@ using namespace PPSSPP_VK;
 #define TEXCACHE_MAX_SLAB_SIZE (32 * 1024 * 1024)
 #define TEXCACHE_SLAB_PRESSURE 4
 
-const char *copyShader = R"(
-#version 450
-#extension GL_ARB_separate_shader_objects : enable
-
-// No idea what's optimal here...
-#define WORKGROUP_SIZE 16
-layout (local_size_x = WORKGROUP_SIZE, local_size_y = WORKGROUP_SIZE, local_size_z = 1) in;
-
-layout(std430, binding = 1) buffer Buf1 {
-	uint data[];
-} buf1;
-
-layout(std430, binding = 2) buffer Buf2 {
-	uint data[];
-} buf2;
-
-layout(push_constant) uniform Params {
-	int width;
-	int height;
-	int scale;
-	int fmt;
-} params;
-
-uint readColoru(uvec2 p) {
-	// Note that if the pixels are packed, we can do multiple stores
-	// and only launch this compute shader for every N pixels,
-	// by slicing the width in half and multiplying x by 2, for example.
-	if (params.fmt == 0) {
-		return buf1.data[p.y * params.width + p.x];
-	} else {
-		uint offset = p.y * params.width + p.x;
-		uint data = buf1.data[offset / 2];
-		if ((offset & 1) != 0) {
-			data = data >> 16;
-		}
-		if (params.fmt == 6) {
-			uint r = ((data << 3) & 0xF8) | ((data >> 2) & 0x07);
-			uint g = ((data >> 3) & 0xFC) | ((data >> 9) & 0x03);
-			uint b = ((data >> 8) & 0xF8) | ((data >> 13) & 0x07);
-			return 0xFF000000 | (b << 16) | (g << 8) | r;
-		} else if (params.fmt == 5) {
-			uint r = ((data << 3) & 0xF8) | ((data >> 2) & 0x07);
-			uint g = ((data >> 2) & 0xF8) | ((data >> 7) & 0x07);
-			uint b = ((data >> 7) & 0xF8) | ((data >> 12) & 0x07);
-			uint a = ((data >> 15) & 0x01) == 0 ? 0x00 : 0xFF;
-			return (a << 24) | (b << 16) | (g << 8) | r;
-		} else if (params.fmt == 4) {
-			uint r = (data & 0x0F) | ((data << 4) & 0xF0);
-			uint g = (data & 0xF0) | ((data >> 4) & 0x0F);
-			uint b = ((data >> 8) & 0x0F) | ((data >> 4) & 0xF0);
-			uint a = ((data >> 12) & 0x0F) | ((data >> 8) & 0xF0);
-			return (a << 24) | (b << 16) | (g << 8) | r;
-		}
-	}
-}
-
-vec4 readColorf(uvec2 p) {
-	return unpackUnorm4x8(readColoru(p));
-}
-
-%s
-
-void main() {
-	uvec2 xy = gl_GlobalInvocationID.xy;
-	// Kill off any out-of-image threads to avoid stray writes.
-	// Should only happen on the tiniest mipmaps as PSP textures are power-of-2,
-	// and we use a 16x16 workgroup size.
-	if (xy.x >= params.width || xy.y >= params.height)
-		return;
-
-	uvec2 origxy = xy / params.scale;
-	if (params.scale == 1) {
-		buf2.data[xy.y * params.width + xy.x] = readColoru(origxy);
-	} else {
-		buf2.data[xy.y * params.width + xy.x] = applyScalingu(origxy, xy);
-	}
-}
-)";
-
 const char *uploadShader = R"(
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
@@ -158,9 +79,6 @@ layout(push_constant) uniform Params {
 } params;
 
 uint readColoru(uvec2 p) {
-	// Note that if the pixels are packed, we can do multiple stores
-	// and only launch this compute shader for every N pixels,
-	// by slicing the width in half and multiplying x by 2, for example.
 	if (params.fmt == 0) {
 		return buf.data[p.y * params.width + p.x];
 	} else {
@@ -192,8 +110,7 @@ uint readColoru(uvec2 p) {
 
 vec4 readColorf(uvec2 p) {
 	// Unpack the color (we could look it up in a CLUT here if we wanted...)
-	// It's a bit silly that we need to unpack to float and then have imageStore repack,
-	// but the alternative is to store to a buffer, and then launch a vkCmdCopyBufferToImage instead.
+	// The imageStore repack is free.
 	return unpackUnorm4x8(readColoru(p));
 }
 
@@ -331,8 +248,6 @@ void TextureCacheVulkan::DeviceLost() {
 
 	if (uploadCS_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeleteShaderModule(uploadCS_);
-	if (copyCS_ != VK_NULL_HANDLE)
-		vulkan_->Delete().QueueDeleteShaderModule(copyCS_);
 
 	computeShaderManager_.DeviceLost();
 
@@ -383,14 +298,13 @@ void TextureCacheVulkan::CompileScalingShader() {
 	if (!g_Config.bTexHardwareScaling || g_Config.sTextureShaderName != textureShader_) {
 		if (uploadCS_ != VK_NULL_HANDLE)
 			vulkan_->Delete().QueueDeleteShaderModule(uploadCS_);
-		if (copyCS_ != VK_NULL_HANDLE)
-			vulkan_->Delete().QueueDeleteShaderModule(copyCS_);
 		textureShader_.clear();
 		maxScaleFactor_ = 255;
-	} else if (uploadCS_ || copyCS_) {
+	} else if (uploadCS_) {
 		// No need to recreate.
 		return;
 	}
+
 	if (!g_Config.bTexHardwareScaling)
 		return;
 
@@ -401,13 +315,10 @@ void TextureCacheVulkan::CompileScalingShader() {
 
 	std::string shaderSource = ReadShaderSrc(shaderInfo->computeShaderFile);
 	std::string fullUploadShader = StringFromFormat(uploadShader, shaderSource.c_str());
-	std::string fullCopyShader = StringFromFormat(copyShader, shaderSource.c_str());
 
 	std::string error;
 	uploadCS_ = CompileShaderModule(vulkan_, VK_SHADER_STAGE_COMPUTE_BIT, fullUploadShader.c_str(), &error);
 	_dbg_assert_msg_(uploadCS_ != VK_NULL_HANDLE, "failed to compile upload shader");
-	copyCS_ = CompileShaderModule(vulkan_, VK_SHADER_STAGE_COMPUTE_BIT, fullCopyShader.c_str(), &error);
-	_dbg_assert_msg_(copyCS_ != VK_NULL_HANDLE, "failed to compile copy shader");
 
 	textureShader_ = g_Config.sTextureShaderName;
 	maxScaleFactor_ = shaderInfo->maxScale;
@@ -785,7 +696,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		badMipSizes = false;
 	}
 
-	bool hardwareScaling = g_Config.bTexHardwareScaling && (uploadCS_ != VK_NULL_HANDLE || copyCS_ != VK_NULL_HANDLE);
+	bool hardwareScaling = g_Config.bTexHardwareScaling && uploadCS_ != VK_NULL_HANDLE;
 
 	// Don't scale the PPGe texture.
 	if (entry->addr > 0x05000000 && entry->addr < PSP_GetKernelMemoryEnd())
@@ -852,11 +763,8 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 
 		// Compute experiment
 		if (actualFmt == VULKAN_8888_FORMAT && scaleFactor > 1 && hardwareScaling) {
-			// Enable the experiment you want.
 			if (uploadCS_ != VK_NULL_HANDLE)
 				computeUpload = true;
-			else if (copyCS_ != VK_NULL_HANDLE)
-				computeCopy = true;
 		}
 
 		if (computeUpload) {
@@ -927,7 +835,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 			int size = stride * mipHeight;
 			uint32_t bufferOffset;
 			VkBuffer texBuf;
-			// nvidia returns 1 but that can't be healthy... let's align by 16 as a minimum.
+			// NVIDIA reports a min alignment of 1 but that can't be healthy... let's align by 16 as a minimum.
 			int pushAlignment = std::max(16, (int)vulkan_->GetPhysicalDeviceProperties().properties.limits.optimalBufferCopyOffsetAlignment);
 			void *data;
 			bool dataScaled = true;
@@ -941,12 +849,16 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 			} else {
 				auto dispatchCompute = [&](VkDescriptorSet descSet) {
 					struct Params { int x; int y; int s; int fmt; } params{ mipWidth, mipHeight, scaleFactor, 0 };
-					if (dstFmt == VULKAN_4444_FORMAT) {
+					switch (dstFmt) {
+					case VULKAN_4444_FORMAT:
 						params.fmt = 4;
-					} else if (dstFmt == VULKAN_1555_FORMAT) {
+						break;
+					case VULKAN_1555_FORMAT:
 						params.fmt = 5;
-					} else if (dstFmt == VULKAN_565_FORMAT) {
+						break;
+					case VULKAN_565_FORMAT:
 						params.fmt = 6;
+						break;
 					}
 					vkCmdBindDescriptorSets(cmdInit, VK_PIPELINE_BIND_POINT_COMPUTE, computeShaderManager_.GetPipelineLayout(), 0, 1, &descSet, 0, nullptr);
 					vkCmdPushConstants(cmdInit, computeShaderManager_.GetPipelineLayout(), VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(params), &params);
@@ -969,35 +881,6 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 						vkCmdBindPipeline(cmdInit, VK_PIPELINE_BIND_POINT_COMPUTE, computeShaderManager_.GetPipeline(uploadCS_));
 						dispatchCompute(descSet);
 						vulkan_->Delete().QueueDeleteImageView(view);
-					} else if (computeCopy) {
-						data = drawEngine_->GetPushBufferForTextureData()->PushAligned(srcSize, &bufferOffset, &texBuf, pushAlignment);
-						dataScaled = false;
-						LoadTextureLevel(*entry, (uint8_t *)data, srcStride, i, 1, dstFmt);
-						// Simple test of using a "copy shader" before the upload. This one could unswizzle or whatever
-						// and will work for any texture format including 16-bit as long as the shader is written to pack it into int32 size bits
-						// which is the smallest possible write.
-						VkBuffer localBuf;
-						uint32_t localOffset;
-						uint32_t localSize = size;
-						localOffset = (uint32_t)drawEngine_->GetPushBufferLocal()->Allocate(localSize, &localBuf);
-
-						VkDescriptorSet descSet = computeShaderManager_.GetDescriptorSet(VK_NULL_HANDLE, texBuf, bufferOffset, srcSize, localBuf, localOffset, localSize);
-						vkCmdBindPipeline(cmdInit, VK_PIPELINE_BIND_POINT_COMPUTE, computeShaderManager_.GetPipeline(copyCS_));
-						dispatchCompute(descSet);
-
-						// After the compute, before the copy, we need a memory barrier.
-						VkBufferMemoryBarrier barrier{ VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER };
-						barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
-						barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-						barrier.buffer = localBuf;
-						barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-						barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-						barrier.offset = localOffset;
-						barrier.size = localSize;
-						vkCmdPipelineBarrier(cmdInit, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
-							0, 0, nullptr, 1, &barrier, 0, nullptr);
-
-						entry->vkTex->UploadMip(cmdInit, i, mipWidth, mipHeight, localBuf, localOffset, stride / bpp);
 					} else {
 						data = drawEngine_->GetPushBufferForTextureData()->PushAligned(size, &bufferOffset, &texBuf, pushAlignment);
 						LoadTextureLevel(*entry, (uint8_t *)data, stride, i, scaleFactor, dstFmt);

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -135,7 +135,7 @@ private:
 	Vulkan2D *vulkan2D_;
 
 	std::string textureShader_;
-	int maxScaleFactor_ = 255;
+	int shaderScaleFactor_ = 0;
 	VkShaderModule uploadCS_ = VK_NULL_HANDLE;
 
 	// Bound state to emulate an API similar to the others

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -137,7 +137,6 @@ private:
 	std::string textureShader_;
 	int maxScaleFactor_ = 255;
 	VkShaderModule uploadCS_ = VK_NULL_HANDLE;
-	VkShaderModule copyCS_ = VK_NULL_HANDLE;
 
 	// Bound state to emulate an API similar to the others
 	VkImageView imageView_ = VK_NULL_HANDLE;

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -385,6 +385,7 @@ VkShaderModule CompileShaderModule(VulkanContext *vulkan, VkShaderStageFlagBits 
 		ERROR_LOG(G3D, "Shader source:\n%s", LineNumberString(code).c_str());
 		OutputDebugStringUTF8("Messages:\n");
 		OutputDebugStringUTF8(error->c_str());
+		OutputDebugStringUTF8(LineNumberString(code).c_str());
 		return VK_NULL_HANDLE;
 	} else {
 		VkShaderModule module;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -533,6 +533,11 @@ void GameSettingsScreen::CreateViews() {
 	static const char *texScaleLevels[] = {"Off", "2x", "3x"};
 #endif
 
+	static const char *texScaleAlgos[] = { "xBRZ", "Hybrid", "Bicubic", "Hybrid + Bicubic", };
+	PopupMultiChoice *texScalingType = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTexScalingType, gr->T("Upscale Type"), texScaleAlgos, 0, ARRAY_SIZE(texScaleAlgos), gr->GetName(), screenManager()));
+	texScalingType->SetEnabledFunc([]() {
+		return !g_Config.bSoftwareRendering && !UsingHardwareTextureScaling();
+	});
 	PopupMultiChoice *texScalingChoice = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTexScalingLevel, gr->T("Upscale Level"), texScaleLevels, 1, ARRAY_SIZE(texScaleLevels), gr->GetName(), screenManager()));
 	// TODO: Better check?  When it won't work, it scales down anyway.
 	if (!gl_extensions.OES_texture_npot && GetGPUBackend() == GPUBackend::OPENGL) {
@@ -545,11 +550,7 @@ void GameSettingsScreen::CreateViews() {
 		}
 		return UI::EVENT_CONTINUE;
 	});
-	texScalingChoice->SetDisabledPtr(&g_Config.bSoftwareRendering);
-
-	static const char *texScaleAlgos[] = { "xBRZ", "Hybrid", "Bicubic", "Hybrid + Bicubic", };
-	PopupMultiChoice *texScalingType = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iTexScalingType, gr->T("Upscale Type"), texScaleAlgos, 0, ARRAY_SIZE(texScaleAlgos), gr->GetName(), screenManager()));
-	texScalingType->SetEnabledFunc([]() {
+	texScalingChoice->SetEnabledFunc([]() {
 		return !g_Config.bSoftwareRendering && !UsingHardwareTextureScaling();
 	});
 

--- a/assets/shaders/defaultshaders.ini
+++ b/assets/shaders/defaultshaders.ini
@@ -151,13 +151,14 @@ Fragment=psp_color.fsh
 Vertex=fxaa.vsh
 [Tex4xBRZ]
 Type=Texture
-Name=4xBRZ
+Name=4xBRZ (4x)
 Author=Hyllian
 Compute=tex_4xbrz.csh
 VendorBlacklist=ARM
+Scale=4
 [TexMMPX]
 Type=Texture
-Name=MMPX
+Name=MMPX (2x)
 Author=Morgan McGuire and Mara Gagiu
 Compute=tex_mmpx.csh
-MaxScale=2
+Scale=2

--- a/assets/shaders/defaultshaders.ini
+++ b/assets/shaders/defaultshaders.ini
@@ -154,7 +154,6 @@ Type=Texture
 Name=4xBRZ (4x)
 Author=Hyllian
 Compute=tex_4xbrz.csh
-VendorBlacklist=ARM
 Scale=4
 [TexMMPX]
 Type=Texture

--- a/assets/shaders/tex_4xbrz.csh
+++ b/assets/shaders/tex_4xbrz.csh
@@ -253,17 +253,12 @@ void applyScaling(uvec2 origxy) {
 		dst[ 6] = mix(dst[ 6], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
 	}
 
-	// Output Pixel Mapping: 20|21|22|23|24|25
-	//                       19|06|07|08|09|26
-	//                       18|05|00|01|10|27
-	//                       17|04|03|02|11|28
-	//                       16|15|14|13|12|29
-	//                       35|34|33|32|31|30
-
-	// int order [] = int[16](5, 6, 10, 9, 8, 4, 0, 1, 2, 3, 7, 11, 15, 14, 13, 12);
-
+	// Output Pixel Mapping:
+	//   06|07|08|09
+	//   05|00|01|10
+	//   04|03|02|11
+	//   15|14|13|12
 	const int order[16] = int[16](6, 7, 8, 9, 5, 0, 1, 10, 4, 3, 2, 11, 15, 14, 13, 12);
-
 	// Write all 16 output pixels.
 	ivec2 destXY = ivec2(origxy) * 4;
 	for (int y = 0; y < 4; y++) {

--- a/assets/shaders/tex_4xbrz.csh
+++ b/assets/shaders/tex_4xbrz.csh
@@ -36,6 +36,10 @@ bool IsBlendingNeeded(const ivec4 blend) {
 	return diff.x != 0 || diff.y != 0 || diff.z != 0 || diff.w != 0;
 }
 
+vec4 readInput(uvec2 coord) {
+    return readColorf(uvec2(clamp(coord.x, 0, params.width - 1), clamp(coord.y, 0, params.height - 1)));
+}
+
 void applyScaling(uvec2 origxy) {
 	//    A1 B1 C1
 	// A0 A  B  C C4
@@ -60,27 +64,27 @@ void applyScaling(uvec2 origxy) {
 
 	vec4 src[25];
 
-	src[21] = readColorf(t1.xw);
-	src[22] = readColorf(t1.yw);
-	src[23] = readColorf(t1.zw);
-	src[ 6] = readColorf(t2.xw);
-	src[ 7] = readColorf(t2.yw);
-	src[ 8] = readColorf(t2.zw);
-	src[ 5] = readColorf(t3.xw);
-	src[ 0] = readColorf(t3.yw);
-	src[ 1] = readColorf(t3.zw);
-	src[ 4] = readColorf(t4.xw);
-	src[ 3] = readColorf(t4.yw);
-	src[ 2] = readColorf(t4.zw);
-	src[15] = readColorf(t5.xw);
-	src[14] = readColorf(t5.yw);
-	src[13] = readColorf(t5.zw);
-	src[19] = readColorf(t6.xy);
-	src[18] = readColorf(t6.xz);
-	src[17] = readColorf(t6.xw);
-	src[ 9] = readColorf(t7.xy);
-	src[10] = readColorf(t7.xz);
-	src[11] = readColorf(t7.xw);
+	src[21] = readInput(t1.xw);
+	src[22] = readInput(t1.yw);
+	src[23] = readInput(t1.zw);
+	src[ 6] = readInput(t2.xw);
+	src[ 7] = readInput(t2.yw);
+	src[ 8] = readInput(t2.zw);
+	src[ 5] = readInput(t3.xw);
+	src[ 0] = readInput(t3.yw);
+	src[ 1] = readInput(t3.zw);
+	src[ 4] = readInput(t4.xw);
+	src[ 3] = readInput(t4.yw);
+	src[ 2] = readInput(t4.zw);
+	src[15] = readInput(t5.xw);
+	src[14] = readInput(t5.yw);
+	src[13] = readInput(t5.zw);
+	src[19] = readInput(t6.xy);
+	src[18] = readInput(t6.xz);
+	src[17] = readInput(t6.xw);
+	src[ 9] = readInput(t7.xy);
+	src[10] = readInput(t7.xz);
+	src[11] = readInput(t7.xw);
 
 	float v[9];
 	v[0] = reduce(src[0]);

--- a/assets/shaders/tex_mmpx.csh
+++ b/assets/shaders/tex_mmpx.csh
@@ -101,7 +101,7 @@ void applyScaling(uvec2 xy) {
         } // F !== D
     } // not constant
 
-    // TODO: Write four pixels at once.  For now, 1/4x speed.
+    // Write four pixels at once.
     ivec2 destXY = ivec2(xy) * 2;
     writeColorf(destXY, unpackUnorm4x8(J));
     writeColorf(destXY + ivec2(1, 0), unpackUnorm4x8(K));

--- a/assets/shaders/tex_mmpx.csh
+++ b/assets/shaders/tex_mmpx.csh
@@ -1,5 +1,5 @@
 /* MMPX.glc
-   Copyright 2020 Morgan McGuire & Mara Gagiu. 
+   Copyright 2020 Morgan McGuire & Mara Gagiu.
    Provided under the Open Source MIT license https://opensource.org/licenses/MIT
 
    See js-demo.html for the commented source code.
@@ -9,6 +9,8 @@
 
 #define ABGR8 uint
 
+// If we took an image as input, we could use a sampler to do the clamping. But we decode
+// low-bpp texture data directly, so...
 ABGR8 src(int x, int y) {
     return readColoru(uvec2(clamp(x, 0, params.width - 1), clamp(y, 0, params.height - 1)));
 }
@@ -42,9 +44,9 @@ bool none_eq4(ABGR8 B, ABGR8 A0, ABGR8 A1, ABGR8 A2, ABGR8 A3) {
     return B != A0 && B != A1 && B != A2 && B != A3;
 }
 
-uint applyScalingu(uvec2 origxy, uvec2 xy) {
-    int srcX = int(origxy.x);
-    int srcY = int(origxy.y);
+void applyScaling(uvec2 xy) {
+    int srcX = int(xy.x);
+    int srcY = int(xy.y);
 
     ABGR8 A = src(srcX - 1, srcY - 1), B = src(srcX, srcY - 1), C = src(srcX + 1, srcY - 1);
     ABGR8 D = src(srcX - 1, srcY + 0), E = src(srcX, srcY + 0), F = src(srcX + 1, srcY + 0);
@@ -74,25 +76,25 @@ uint applyScalingu(uvec2 origxy, uvec2 xy) {
         if (Dl < El && all_eq4(E, C, F, I, R) && none_eq4(E, B, A, G, H)) J = L = D;
 
         // 2:1 slope rules
-        if (H != B) { 
+        if (H != B) {
             if (H != A && H != E && H != C) {
                 if (all_eq3(H, G, F, R) && none_eq2(H, D, src(srcX + 2, srcY - 1))) L = M;
                 if (all_eq3(H, I, D, Q) && none_eq2(H, F, src(srcX - 2, srcY - 1))) M = L;
             }
-            
+
             if (B != I && B != G && B != E) {
                 if (all_eq3(B, A, F, R) && none_eq2(B, D, src(srcX + 2, srcY + 1))) J = K;
                 if (all_eq3(B, C, D, Q) && none_eq2(B, F, src(srcX - 2, srcY + 1))) K = J;
             }
         } // H !== B
-        
-        if (F != D) { 
+
+        if (F != D) {
             if (D != I && D != E && D != C) {
                 if (all_eq3(D, A, H, S) && none_eq2(D, B, src(srcX + 1, srcY + 2))) J = L;
                 if (all_eq3(D, G, B, P) && none_eq2(D, H, src(srcX + 1, srcY - 2))) L = J;
             }
-            
-            if (F != E && F != A && F != G) {    
+
+            if (F != E && F != A && F != G) {
                 if (all_eq3(F, C, H, S) && none_eq2(F, B, src(srcX - 1, srcY + 2))) K = M;
                 if (all_eq3(F, I, B, P) && none_eq2(F, H, src(srcX - 1, srcY - 2))) M = K;
             }
@@ -100,18 +102,9 @@ uint applyScalingu(uvec2 origxy, uvec2 xy) {
     } // not constant
 
     // TODO: Write four pixels at once.  For now, 1/4x speed.
-    if ((xy.y & 1u) == 0u) {
-        if ((xy.x & 1u) == 0u) {
-            return J;
-        }
-        return K;
-    }
-    if ((xy.x & 1u) == 0u) {
-        return L;
-    }
-    return M;
-}
-
-vec4 applyScalingf(uvec2 origxy, uvec2 xy) {
-	return unpackUnorm4x8(applyScalingu(origxy, xy));
+    ivec2 destXY = ivec2(xy) * 2;
+    writeColorf(destXY, unpackUnorm4x8(J));
+    writeColorf(destXY + ivec2(1, 0), unpackUnorm4x8(K));
+    writeColorf(destXY + ivec2(0, 1), unpackUnorm4x8(L));
+    writeColorf(destXY + ivec2(1, 1), unpackUnorm4x8(M));
 }


### PR DESCRIPTION
This drastically improves the performance of (Vulkan-only) compute-shader based texture upscaling, making it perform stutter-free on much more lower end GPUs.

Texture upscale shaders now each have a fixed scale factor, and instead of computing each 2x2 or 4x4 for every pixel and sampling from that, each individual thread of the compute shader writes all four or sixteen pixels that it computes anyway.

This does mean that we now only have these two variants of compute shader upscaling, but more can be added:

- MMPX: 2x for pixel art
- 4xBRZ: 4x upscaler, more generic

It also fixes #13679 and #15094, and removes a bunch of unused code.

Verified on NV, Intel, Adreno and Mali GPUs, plus Apple through MoltenVK.