### PR TITLE
On Android 11 and later, let's not fallback to OpenGL on init crashes.

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -389,6 +389,15 @@ static void CheckFailedGPUBackends() {
 	return;
 #endif
 
+#if PPSSPP_PLATFORM(ANDROID)
+	if (System_GetPropertyInt(SYSPROP_SYSTEMVERSION) >= 30) {
+		// In Android 11 or later, Vulkan is as stable as OpenGL, so let's not even bother.
+		// Have also seen unexplained issues with random fallbacks to OpenGL for no good reason,
+		// especially when debugging.
+		return;
+	}
+#endif
+
 	// We only want to do this once per process run and backend, to detect process crashes.
 	// If NativeShutdown is called before we finish, we might call this multiple times.
 	static int lastBackend = -1;


### PR DESCRIPTION
Not meaningful since basic Vulkan is at least as stable and widely used now and we really don't do anything crazy when drawing the menu. If we crash, falling back to OpenGL is no longer likely to fix anything.

See #15079

It's still unclear why I've gotten the occasional random fallbacks I've seen. Have not been able to reproduce consistently (although I haven't tried all that hard yet).