### PR TITLE
Display: Prevent lock around listener calls

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -371,15 +371,23 @@ void __DisplayForgetFlip(FlipCallback callback, void *userdata) {
 }
 
 static void DisplayFireVblank() {
-	std::lock_guard<std::mutex> guard(listenersLock);
-	for (VblankCallback cb : vblankListeners) {
+	std::vector<VblankCallback> toCall = []{
+		std::lock_guard<std::mutex> guard(listenersLock);
+		return vblankListeners;
+	}();
+
+	for (VblankCallback cb : toCall) {
 		cb();
 	}
 }
 
 static void DisplayFireFlip() {
-	std::lock_guard<std::mutex> guard(listenersLock);
-	for (auto cb : flipListeners) {
+	std::vector<FlipListener> toCall = [] {
+		std::lock_guard<std::mutex> guard(listenersLock);
+		return flipListeners;
+	}();
+
+	for (FlipListener cb : toCall) {
 		cb.first(cb.second);
 	}
 }


### PR DESCRIPTION
Fixes #15123, crash in Bleach: Soul Carnival 2.  At least it fixes the demo, but I'm sure based on the commit range it must be the same issue.

-[Unknown]