### PR TITLE
Windows debugger: Load the dialogs on demand.

### DIFF
--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -899,7 +899,8 @@ void CDisasm::UpdateDialog(bool _bComplete)
 		_snwprintf(tempTicks, 24, L"%lld", CoreTiming::GetTicks() - lastTicks);
 		SetDlgItemText(m_hDlg, IDC_DEBUG_COUNT, tempTicks);
 	}
-	// Update Register Dialog
+
+	// Update memory window
 	if (memoryWindow)
 		memoryWindow->Update();
 

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -466,6 +466,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 				break;
 
 			case IDC_SHOWVFPU:
+				MainWindow::CreateVFPUWindow();
 				vfpudlg->Show(true);
 				break;
 

--- a/Windows/Debugger/Debugger_Lists.cpp
+++ b/Windows/Debugger/Debugger_Lists.cpp
@@ -6,6 +6,7 @@
 #include "Windows/Debugger/DebuggerShared.h"
 #include "Windows/Debugger/CtrlDisAsmView.h"
 #include "Windows/W32Util/ContextMenu.h"
+#include "Windows/MainWindow.h"
 #include "Windows/resource.h"
 #include "Windows/main.h"
 #include "Common/Data/Encoding/Utf8.h"
@@ -373,10 +374,12 @@ void CtrlBreakpointList::gotoBreakpointAddress(int itemIndex)
 
 	if (isMemory) {
 		u32 address = displayedMemChecks_[index].start;
+		MainWindow::CreateMemoryWindow();
 		if (memoryWindow)
 			memoryWindow->Goto(address);
 	} else {
 		u32 address = displayedBreakPoints_[index].addr;
+		MainWindow::CreateDisasmWindow();
 		if (disasmWindow)
 			disasmWindow->Goto(address);
 	}

--- a/Windows/Debugger/Debugger_VFPUDlg.cpp
+++ b/Windows/Debugger/Debugger_VFPUDlg.cpp
@@ -13,8 +13,6 @@
 
 #include "Core/MIPS/MIPS.h" //	BAD
 
-CVFPUDlg *vfpudlg;
-
 CVFPUDlg::CVFPUDlg(HINSTANCE _hInstance, HWND _hParent, DebugInterface *cpu_) : Dialog((LPCSTR)IDD_VFPU, _hInstance,_hParent)
 {
 	cpu = cpu_;

--- a/Windows/Debugger/Debugger_VFPUDlg.h
+++ b/Windows/Debugger/Debugger_VFPUDlg.h
@@ -20,6 +20,3 @@ private:
 	int mode;
 	BOOL DlgProc(UINT message, WPARAM wParam, LPARAM lParam);
 };
-
-
-extern CVFPUDlg *vfpudlg;

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -556,6 +556,13 @@ namespace MainWindow
 		}
 	}
 
+	void CreateVFPUWindow() {
+		if (!vfpudlg) {
+			vfpudlg = new CVFPUDlg(MainWindow::GetHInstance(), MainWindow::GetHWND(), currentDebugMIPS);
+			DialogManager::AddDlg(vfpudlg);
+		}
+	}
+
 	void DestroyDebugWindows() {
 		DialogManager::RemoveDlg(disasmWindow);
 		if (disasmWindow)
@@ -573,6 +580,11 @@ namespace MainWindow
 		if (memoryWindow)
 			delete memoryWindow;
 		memoryWindow = nullptr;
+
+		DialogManager::RemoveDlg(vfpudlg);
+		if (vfpudlg)
+			delete vfpudlg;
+		vfpudlg = nullptr;
 	}
 
 	LRESULT CALLBACK DisplayProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -541,12 +541,12 @@ namespace MainWindow
 	}
 
 	void CreateGeDebuggerWindow() {
-		if (!geDebuggerWindow) {
 #if PPSSPP_API(ANY_GL)
+		if (!geDebuggerWindow) {
 			geDebuggerWindow = new CGEDebugger(MainWindow::GetHInstance(), MainWindow::GetHWND());
 			DialogManager::AddDlg(geDebuggerWindow);
-#endif
 		}
+#endif
 	}
 
 	void CreateMemoryWindow() {

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -533,36 +533,46 @@ namespace MainWindow
 		return TRUE;
 	}
 
-	void CreateDebugWindows() {
-		disasmWindow = new CDisasm(MainWindow::GetHInstance(), MainWindow::GetHWND(), currentDebugMIPS);
-		DialogManager::AddDlg(disasmWindow);
-		disasmWindow->Show(g_Config.bShowDebuggerOnLoad, false);
+	void CreateDisasmWindow() {
+		if (!disasmWindow) {
+			disasmWindow = new CDisasm(MainWindow::GetHInstance(), MainWindow::GetHWND(), currentDebugMIPS);
+			DialogManager::AddDlg(disasmWindow);
+		}
+	}
 
+	void CreateGeDebuggerWindow() {
+		if (!geDebuggerWindow) {
 #if PPSSPP_API(ANY_GL)
-		geDebuggerWindow = new CGEDebugger(MainWindow::GetHInstance(), MainWindow::GetHWND());
-		DialogManager::AddDlg(geDebuggerWindow);
+			geDebuggerWindow = new CGEDebugger(MainWindow::GetHInstance(), MainWindow::GetHWND());
+			DialogManager::AddDlg(geDebuggerWindow);
 #endif
-		memoryWindow = new CMemoryDlg(MainWindow::GetHInstance(), MainWindow::GetHWND(), currentDebugMIPS);
-		DialogManager::AddDlg(memoryWindow);
+		}
+	}
+
+	void CreateMemoryWindow() {
+		if (!memoryWindow) {
+			memoryWindow = new CMemoryDlg(MainWindow::GetHInstance(), MainWindow::GetHWND(), currentDebugMIPS);
+			DialogManager::AddDlg(memoryWindow);
+		}
 	}
 
 	void DestroyDebugWindows() {
 		DialogManager::RemoveDlg(disasmWindow);
 		if (disasmWindow)
 			delete disasmWindow;
-		disasmWindow = 0;
+		disasmWindow = nullptr;
 
 #if PPSSPP_API(ANY_GL)
 		DialogManager::RemoveDlg(geDebuggerWindow);
 		if (geDebuggerWindow)
 			delete geDebuggerWindow;
-		geDebuggerWindow = 0;
+		geDebuggerWindow = nullptr;
 #endif
 
 		DialogManager::RemoveDlg(memoryWindow);
 		if (memoryWindow)
 			delete memoryWindow;
-		memoryWindow = 0;
+		memoryWindow = nullptr;
 	}
 
 	LRESULT CALLBACK DisplayProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam) {
@@ -928,7 +938,6 @@ namespace MainWindow
 				disasmWindow->NotifyMapLoaded();
 			if (memoryWindow)
 				memoryWindow->NotifyMapLoaded();
-
 			if (disasmWindow)
 				disasmWindow->UpdateDialog();
 			break;

--- a/Windows/MainWindow.h
+++ b/Windows/MainWindow.h
@@ -61,9 +61,10 @@ namespace MainWindow
 
 	void Init(HINSTANCE hInstance);
 	BOOL Show(HINSTANCE hInstance);
-	void CreateDebugWindows();
+	void CreateDisasmWindow();
+	void CreateGeDebuggerWindow();
+	void CreateMemoryWindow();
 	void DestroyDebugWindows();
-	void Close();
 	void UpdateMenus(bool isMenuSelect = false);
 	void UpdateCommands();
 	void UpdateSwitchUMD();

--- a/Windows/MainWindow.h
+++ b/Windows/MainWindow.h
@@ -64,6 +64,7 @@ namespace MainWindow
 	void CreateDisasmWindow();
 	void CreateGeDebuggerWindow();
 	void CreateMemoryWindow();
+	void CreateVFPUWindow();
 	void DestroyDebugWindows();
 	void UpdateMenus(bool isMenuSelect = false);
 	void UpdateCommands();

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -896,18 +896,21 @@ namespace MainWindow {
 			break;
 
 		case ID_DEBUG_DISASSEMBLY:
+			CreateDisasmWindow();
 			if (disasmWindow)
 				disasmWindow->Show(true);
 			break;
 
 		case ID_DEBUG_GEDEBUGGER:
 #if PPSSPP_API(ANY_GL)
+			CreateGeDebuggerWindow();
 			if (geDebuggerWindow)
 				geDebuggerWindow->Show(true);
 #endif
 			break;
 
 		case ID_DEBUG_MEMORYVIEW:
+			CreateMemoryWindow();
 			if (memoryWindow)
 				memoryWindow->Show(true);
 			break;

--- a/Windows/W32Util/DialogManager.cpp
+++ b/Windows/W32Util/DialogManager.cpp
@@ -76,6 +76,9 @@ void DialogManager::AddDlg(Dialog *dialog)
 
 void DialogManager::RemoveDlg(Dialog *dialog)
 {
+	if (!dialog) {
+		return;
+	}
 	dialogs.erase(std::remove(dialogs.begin(), dialogs.end(), dialog), dialogs.end());
 }
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -686,7 +686,10 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 #endif
 	DialogManager::AddDlg(vfpudlg = new CVFPUDlg(_hInstance, hwndMain, currentDebugMIPS));
 
-	MainWindow::CreateDebugWindows();
+	if (g_Config.bShowDebuggerOnLoad) {
+		MainWindow::CreateDisasmWindow();
+		disasmWindow->Show(g_Config.bShowDebuggerOnLoad, false);
+	}
 
 	const bool minimized = iCmdShow == SW_MINIMIZE || iCmdShow == SW_SHOWMINIMIZED || iCmdShow == SW_SHOWMINNOACTIVE;
 	if (minimized) {

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -95,6 +95,7 @@ CGEDebugger* geDebuggerWindow = nullptr;
 
 CDisasm *disasmWindow = nullptr;
 CMemoryDlg *memoryWindow = nullptr;
+CVFPUDlg *vfpudlg = nullptr;
 
 static std::string langRegion;
 static std::string osName;
@@ -684,7 +685,6 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 #if PPSSPP_API(ANY_GL)
 	CGEDebugger::Init();
 #endif
-	DialogManager::AddDlg(vfpudlg = new CVFPUDlg(_hInstance, hwndMain, currentDebugMIPS));
 
 	if (g_Config.bShowDebuggerOnLoad) {
 		MainWindow::CreateDisasmWindow();

--- a/Windows/main.h
+++ b/Windows/main.h
@@ -19,12 +19,16 @@
 #pragma once
 
 #include "ppsspp_config.h"
+
 #include "Debugger/Debugger_Disasm.h"
 #include "Debugger/Debugger_MemoryDlg.h"
+#include "Debugger/Debugger_VFPUDlg.h"
+
 #include "Common/CommonWindows.h"
 
 extern CDisasm *disasmWindow;
 extern CMemoryDlg *memoryWindow;
+extern CVFPUDlg *vfpudlg;
 
 #if PPSSPP_API(ANY_GL)
 #include "Windows/GEDebugger/GEDebugger.h"


### PR DESCRIPTION
I think this is especially good for the GeDebugger dialog since we now can avoid initializing that extra GL context unless you open the dialog.

This actually saves as much as a second of startup time on Windows. Maybe doesn't seem important, but when developing and iterating on stuff, the less you have to wait the better.

Additionally, optimizes CleanRecent for an extra 150ms savings (in my testing).

See #15137 