### PR TITLE
Rectangle fast path tweaks for softgpu

### DIFF
--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -289,6 +289,10 @@ public:
 		*this = *this / f;
 	}
 
+	bool operator ==(const Vec3 &other) const {
+		return x == other.x && y == other.y && z == other.z;
+	}
+
 	T Length2() const
 	{
 		return x*x + y*y + z*z;

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1451,26 +1451,35 @@ void ClearRectangle(const VertexData &v0, const VertexData &v1)
 	minY = std::max(minY, (int)TransformUnit::DrawingToScreen(scissorTL).y);
 	maxY = std::max(0, std::min(maxY, (int)TransformUnit::DrawingToScreen(scissorBR).y + 16));
 
+	constexpr int MIN_LINES_PER_THREAD = 8 * 16;
+
 	const int w = (maxX - minX) / 16;
 	if (w <= 0)
 		return;
 
 	if (gstate.isClearModeDepthMask()) {
-		ScreenCoords pprime(minX, minY, 0);
 		const u16 z = v1.screenpos.z;
 		const int stride = gstate.DepthBufStride();
 
-		for (pprime.y = minY; pprime.y < maxY; pprime.y += 16) {
-			DrawingCoords p = TransformUnit::ScreenToDrawing(pprime);
-
-			if ((z & 0xFF) == (z >> 8)) {
-				u16 *row = &depthbuf.as16[p.x + p.y * stride];
-				memset(row, z, w * 2);
-			} else {
-				for (int x = 0; x < w; ++x) {
-					SetPixelDepth(p.x + x, p.y, z);
+		if ((z & 0xFF) == (z >> 8)) {
+			ParallelRangeLoop(&g_threadManager, [=](int y1, int y2) {
+				ScreenCoords pprime(minX, y1, 0);
+				for (pprime.y = y1; pprime.y < y2; pprime.y += 16) {
+					DrawingCoords p = TransformUnit::ScreenToDrawing(pprime);
+					u16 *row = &depthbuf.as16[p.x + p.y * stride];
+					memset(row, z, w * 2);
 				}
-			}
+			}, minY, maxY, MIN_LINES_PER_THREAD);
+		} else {
+			ParallelRangeLoop(&g_threadManager, [=](int y1, int y2) {
+				ScreenCoords pprime(minX, y1, 0);
+				for (pprime.y = y1; pprime.y < y2; pprime.y += 16) {
+					DrawingCoords p = TransformUnit::ScreenToDrawing(pprime);
+					for (int x = 0; x < w; ++x) {
+						SetPixelDepth(p.x + x, p.y, z);
+					}
+				}
+			}, minY, maxY, MIN_LINES_PER_THREAD);
 		}
 	}
 
@@ -1512,56 +1521,66 @@ void ClearRectangle(const VertexData &v0, const VertexData &v1)
 	}
 
 	if (keepOldMask == 0) {
-		ScreenCoords pprime(minX, minY, 0);
 		const int stride = gstate.FrameBufStride();
 
 		if (gstate.FrameBufFormat() == GE_FORMAT_8888) {
-			for (pprime.y = minY; pprime.y < maxY; pprime.y += 16) {
-				DrawingCoords p = TransformUnit::ScreenToDrawing(pprime);
-				if ((new_color & 0xFF) == (new_color >> 8) && (new_color & 0xFFFF) == (new_color >> 16)) {
-					u32 *row = &fb.as32[p.x + p.y * stride];
-					memset(row, new_color, w * 4);
-				} else {
-					for (int x = 0; x < w; ++x) {
-						fb.Set32(p.x + x, p.y, stride, new_color);
+			ParallelRangeLoop(&g_threadManager, [=](int y1, int y2) {
+				ScreenCoords pprime(minX, y1, 0);
+				for (pprime.y = y1; pprime.y < y2; pprime.y += 16) {
+					DrawingCoords p = TransformUnit::ScreenToDrawing(pprime);
+					if ((new_color & 0xFF) == (new_color >> 8) && (new_color & 0xFFFF) == (new_color >> 16)) {
+						u32 *row = &fb.as32[p.x + p.y * stride];
+						memset(row, new_color, w * 4);
+					} else {
+						for (int x = 0; x < w; ++x) {
+							fb.Set32(p.x + x, p.y, stride, new_color);
+						}
 					}
 				}
-			}
+			}, minY, maxY, MIN_LINES_PER_THREAD);
 		} else {
-			for (pprime.y = minY; pprime.y < maxY; pprime.y += 16) {
-				DrawingCoords p = TransformUnit::ScreenToDrawing(pprime);
-				if ((new_color16 & 0xFF) == (new_color16 >> 8)) {
-					u16 *row = &fb.as16[p.x + p.y * stride];
-					memset(row, new_color16, w * 2);
-				} else {
-					for (int x = 0; x < w; ++x) {
-						fb.Set16(p.x + x, p.y, stride, new_color16);
+			ParallelRangeLoop(&g_threadManager, [=](int y1, int y2) {
+				ScreenCoords pprime(minX, y1, 0);
+				for (pprime.y = y1; pprime.y < y2; pprime.y += 16) {
+					DrawingCoords p = TransformUnit::ScreenToDrawing(pprime);
+					if ((new_color16 & 0xFF) == (new_color16 >> 8)) {
+						u16 *row = &fb.as16[p.x + p.y * stride];
+						memset(row, new_color16, w * 2);
+					} else {
+						for (int x = 0; x < w; ++x) {
+							fb.Set16(p.x + x, p.y, stride, new_color16);
+						}
 					}
 				}
-			}
+			}, minY, maxY, MIN_LINES_PER_THREAD);
 		}
 	} else if (keepOldMask != 0xFFFFFFFF) {
-		ScreenCoords pprime(minX, minY, 0);
 		const int stride = gstate.FrameBufStride();
 
 		if (gstate.FrameBufFormat() == GE_FORMAT_8888) {
-			for (pprime.y = minY; pprime.y < maxY; pprime.y += 16) {
-				DrawingCoords p = TransformUnit::ScreenToDrawing(pprime);
-				for (int x = 0; x < w; ++x) {
-					const u32 old_color = fb.Get32(p.x + x, p.y, stride);
-					const u32 c = (old_color & keepOldMask) | (new_color & ~keepOldMask);
-					fb.Set32(p.x + x, p.y, stride, c);
+			ParallelRangeLoop(&g_threadManager, [=](int y1, int y2) {
+				ScreenCoords pprime(minX, y1, 0);
+				for (pprime.y = y1; pprime.y < y2; pprime.y += 16) {
+					DrawingCoords p = TransformUnit::ScreenToDrawing(pprime);
+					for (int x = 0; x < w; ++x) {
+						const u32 old_color = fb.Get32(p.x + x, p.y, stride);
+						const u32 c = (old_color & keepOldMask) | (new_color & ~keepOldMask);
+						fb.Set32(p.x + x, p.y, stride, c);
+					}
 				}
-			}
+			}, minY, maxY, MIN_LINES_PER_THREAD);
 		} else {
-			for (pprime.y = minY; pprime.y < maxY; pprime.y += 16) {
-				DrawingCoords p = TransformUnit::ScreenToDrawing(pprime);
-				for (int x = 0; x < w; ++x) {
-					const u16 old_color = fb.Get16(p.x + x, p.y, stride);
-					const u16 c = (old_color & keepOldMask) | (new_color16 & ~keepOldMask);
-					fb.Set16(p.x + x, p.y, stride, c);
+			ParallelRangeLoop(&g_threadManager, [=](int y1, int y2) {
+				ScreenCoords pprime(minX, y1, 0);
+				for (pprime.y = y1; pprime.y < y2; pprime.y += 16) {
+					DrawingCoords p = TransformUnit::ScreenToDrawing(pprime);
+					for (int x = 0; x < w; ++x) {
+						const u16 old_color = fb.Get16(p.x + x, p.y, stride);
+						const u16 c = (old_color & keepOldMask) | (new_color16 & ~keepOldMask);
+						fb.Set16(p.x + x, p.y, stride, c);
+					}
 				}
-			}
+			}, minY, maxY, MIN_LINES_PER_THREAD);
 		}
 	}
 }

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1451,7 +1451,7 @@ void ClearRectangle(const VertexData &v0, const VertexData &v1)
 	minY = std::max(minY, (int)TransformUnit::DrawingToScreen(scissorTL).y);
 	maxY = std::max(0, std::min(maxY, (int)TransformUnit::DrawingToScreen(scissorBR).y + 16));
 
-	constexpr int MIN_LINES_PER_THREAD = 8 * 16;
+	constexpr int MIN_LINES_PER_THREAD = 32 * 16;
 
 	const int w = (maxX - minX) / 16;
 	if (w <= 0)

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -5,6 +5,7 @@
 
 #include "Common/Data/Convert/ColorConv.h"
 #include "Common/Profiler/Profiler.h"
+#include "Common/Thread/ParallelLoop.h"
 
 #include "Core/Config.h"
 #include "Core/MemMap.h"
@@ -97,6 +98,8 @@ void DrawSprite(const VertexData& v0, const VertexData& v1) {
 
 	bool isWhite = v1.color0 == Vec4<int>(255, 255, 255, 255);
 
+	constexpr int MIN_LINES_PER_THREAD = 8;
+
 	if (gstate.isTextureMapEnabled()) {
 		// 1:1 (but with mirror support) texture mapping!
 		int s_start = v0.texturecoords.x;
@@ -137,48 +140,60 @@ void DrawSprite(const VertexData& v0, const VertexData& v1) {
 			gstate.getTextureFunction() == GE_TEXFUNC_MODULATE &&
 			gstate.getColorMask() == 0x000000 &&
 			gstate.FrameBufFormat() == GE_FORMAT_5551) {
-			int t = t_start;
-			for (int y = pos0.y; y < pos1.y; y++) {
-				int s = s_start;
-				u16 *pixel = fb.Get16Ptr(pos0.x, y, gstate.FrameBufStride());
-				if (isWhite) {
-					for (int x = pos0.x; x < pos1.x; x++) {
-						u32 tex_color = nearestFunc(s, t, texptr, texbufw, 0);
-						if (tex_color & 0xFF000000) {
-							DrawSinglePixel5551(pixel, tex_color);
+			if (isWhite) {
+				ParallelRangeLoop(&g_threadManager, [=](int y1, int y2) {
+					int t = t_start + (y1 - pos0.y) * dt;
+					for (int y = y1; y < y2; y++) {
+						int s = s_start;
+						u16 *pixel = fb.Get16Ptr(pos0.x, y, gstate.FrameBufStride());
+						for (int x = pos0.x; x < pos1.x; x++) {
+							u32 tex_color = nearestFunc(s, t, texptr, texbufw, 0);
+							if (tex_color & 0xFF000000) {
+								DrawSinglePixel5551(pixel, tex_color);
+							}
+							s += ds;
+							pixel++;
 						}
-						s += ds;
-						pixel++;
+						t += dt;
 					}
-				} else {
+				}, pos0.y, pos1.y, MIN_LINES_PER_THREAD);
+			} else {
+				ParallelRangeLoop(&g_threadManager, [=](int y1, int y2) {
+					int t = t_start + (y1 - pos0.y) * dt;
+					for (int y = y1; y < y2; y++) {
+						int s = s_start;
+						u16 *pixel = fb.Get16Ptr(pos0.x, y, gstate.FrameBufStride());
+						for (int x = pos0.x; x < pos1.x; x++) {
+							Vec4<int> prim_color = v1.color0;
+							Vec4<int> tex_color = Vec4<int>::FromRGBA(nearestFunc(s, t, texptr, texbufw, 0));
+							prim_color = ModulateRGBA(prim_color, tex_color);
+							if (prim_color.a() > 0) {
+								DrawSinglePixel5551(pixel, prim_color.ToRGBA());
+							}
+							s += ds;
+							pixel++;
+						}
+						t += dt;
+					}
+				}, pos0.y, pos1.y, MIN_LINES_PER_THREAD);
+			}
+		} else {
+			ParallelRangeLoop(&g_threadManager, [=](int y1, int y2) {
+				int t = t_start + (y1 - pos0.y) * dt;
+				for (int y = y1; y < y2; y++) {
+					int s = s_start;
+					// Not really that fast but faster than triangle.
 					for (int x = pos0.x; x < pos1.x; x++) {
 						Vec4<int> prim_color = v1.color0;
 						Vec4<int> tex_color = Vec4<int>::FromRGBA(nearestFunc(s, t, texptr, texbufw, 0));
-						prim_color = ModulateRGBA(prim_color, tex_color);
-						if (prim_color.a() > 0) {
-							DrawSinglePixel5551(pixel, prim_color.ToRGBA());
-						}
+						prim_color = GetTextureFunctionOutput(prim_color, tex_color);
+						DrawingCoords pos(x, y, z);
+						DrawSinglePixelNonClear(pos, (u16)z, 1.0f, prim_color);
 						s += ds;
-						pixel++;
 					}
+					t += dt;
 				}
-				t += dt;
-			}
-		} else {
-			int t = t_start;
-			for (int y = pos0.y; y < pos1.y; y++) {
-				int s = s_start;
-				// Not really that fast but faster than triangle.
-				for (int x = pos0.x; x < pos1.x; x++) {
-					Vec4<int> prim_color = v1.color0;
-					Vec4<int> tex_color = Vec4<int>::FromRGBA(nearestFunc(s, t, texptr, texbufw, 0));
-					prim_color = GetTextureFunctionOutput(prim_color, tex_color);
-					DrawingCoords pos(x, y, z);
-					DrawSinglePixelNonClear(pos, (u16)z, 1.0f, prim_color);
-					s += ds;
-				}
-				t += dt;
-			}
+			}, pos0.y, pos1.y, MIN_LINES_PER_THREAD);
 		}
 	} else {
 		if (pos1.x > scissorBR.x) pos1.x = scissorBR.x + 1;
@@ -201,22 +216,26 @@ void DrawSprite(const VertexData& v0, const VertexData& v1) {
 			if (v1.color0.a() == 0)
 				return;
 
-			for (int y = pos0.y; y < pos1.y; y++) {
-				u16 *pixel = fb.Get16Ptr(pos0.x, y, gstate.FrameBufStride());
-				for (int x = pos0.x; x < pos1.x; x++) {
-					Vec4<int> prim_color = v1.color0;
-					DrawSinglePixel5551(pixel, prim_color.ToRGBA());
-					pixel++;
+			ParallelRangeLoop(&g_threadManager, [=](int y1, int y2) {
+				for (int y = y1; y < y2; y++) {
+					u16 *pixel = fb.Get16Ptr(pos0.x, y, gstate.FrameBufStride());
+					for (int x = pos0.x; x < pos1.x; x++) {
+						Vec4<int> prim_color = v1.color0;
+						DrawSinglePixel5551(pixel, prim_color.ToRGBA());
+						pixel++;
+					}
 				}
-			}
+			}, pos0.y, pos1.y, MIN_LINES_PER_THREAD);
 		} else {
-			for (int y = pos0.y; y < pos1.y; y++) {
-				for (int x = pos0.x; x < pos1.x; x++) {
-					Vec4<int> prim_color = v1.color0;
-					DrawingCoords pos(x, y, z);
-					DrawSinglePixelNonClear(pos, (u16)z, fog, prim_color);
+			ParallelRangeLoop(&g_threadManager, [=](int y1, int y2) {
+				for (int y = y1; y < y2; y++) {
+					for (int x = pos0.x; x < pos1.x; x++) {
+						Vec4<int> prim_color = v1.color0;
+						DrawingCoords pos(x, y, z);
+						DrawSinglePixelNonClear(pos, (u16)z, fog, prim_color);
+					}
 				}
-			}
+			}, pos0.y, pos1.y, MIN_LINES_PER_THREAD);
 		}
 	}
 }

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -98,7 +98,7 @@ void DrawSprite(const VertexData& v0, const VertexData& v1) {
 
 	bool isWhite = v1.color0 == Vec4<int>(255, 255, 255, 255);
 
-	constexpr int MIN_LINES_PER_THREAD = 8;
+	constexpr int MIN_LINES_PER_THREAD = 32;
 
 	if (gstate.isTextureMapEnabled()) {
 		// 1:1 (but with mirror support) texture mapping!

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -279,44 +279,58 @@ bool RectangleFastPath(const VertexData &v0, const VertexData &v1) {
 }
 
 bool DetectRectangleFromThroughModeStrip(const VertexData data[4]) {
+	// We'll only do this when the color is flat.
+	if (!(data[0].color0 == data[1].color0))
+		return false;
+	if (!(data[1].color0 == data[2].color0))
+		return false;
+	if (!(data[2].color0 == data[3].color0))
+		return false;
+
 	// OK, now let's look at data to detect rectangles. There are a few possibilities
 	// but we focus on Darkstalkers for now.
 	if (data[0].screenpos.x == data[1].screenpos.x &&
 		data[0].screenpos.y == data[2].screenpos.y &&
 		data[2].screenpos.x == data[3].screenpos.x &&
 		data[1].screenpos.y == data[3].screenpos.y &&
-		data[1].screenpos.y > data[0].screenpos.y &&  // Avoid rotation handling
-		data[2].screenpos.x > data[0].screenpos.x &&
-		data[0].texturecoords.x == data[1].texturecoords.x &&
-		data[0].texturecoords.y == data[2].texturecoords.y &&
-		data[2].texturecoords.x == data[3].texturecoords.x &&
-		data[1].texturecoords.y == data[3].texturecoords.y &&
-		data[1].texturecoords.y > data[0].texturecoords.y &&
-		data[2].texturecoords.x > data[0].texturecoords.x &&
-		data[0].color0 == data[1].color0 &&
-		data[1].color0 == data[2].color0 &&
-		data[2].color0 == data[3].color0) {
-		// It's a rectangle!
-		return true;
+		data[1].screenpos.y > data[0].screenpos.y &&
+		data[2].screenpos.x > data[0].screenpos.x) {
+		// Okay, this is in the shape of a triangle, but what about rotation/texture?
+		if (!gstate.isTextureMapEnabled())
+			return true;
+
+		if (data[0].texturecoords.x == data[1].texturecoords.x &&
+			data[0].texturecoords.y == data[2].texturecoords.y &&
+			data[2].texturecoords.x == data[3].texturecoords.x &&
+			data[1].texturecoords.y == data[3].texturecoords.y &&
+			data[1].texturecoords.y > data[0].texturecoords.y &&
+			data[2].texturecoords.x > data[0].texturecoords.x) {
+			// It's a rectangle!
+			return true;
+		}
+		return false;
 	}
 	// There's the other vertex order too...
 	if (data[0].screenpos.x == data[2].screenpos.x &&
 		data[0].screenpos.y == data[1].screenpos.y &&
 		data[1].screenpos.x == data[3].screenpos.x &&
 		data[2].screenpos.y == data[3].screenpos.y &&
-		data[2].screenpos.y > data[0].screenpos.y &&  // Avoid rotation handling
-		data[1].screenpos.x > data[0].screenpos.x &&
-		data[0].texturecoords.x == data[2].texturecoords.x &&
-		data[0].texturecoords.y == data[1].texturecoords.y &&
-		data[1].texturecoords.x == data[3].texturecoords.x &&
-		data[2].texturecoords.y == data[3].texturecoords.y &&
-		data[2].texturecoords.y > data[0].texturecoords.y &&
-		data[1].texturecoords.x > data[0].texturecoords.x &&
-		data[0].color0 == data[1].color0 &&
-		data[1].color0 == data[2].color0 &&
-		data[2].color0 == data[3].color0) {
-		// It's a rectangle!
-		return true;
+		data[2].screenpos.y > data[0].screenpos.y &&
+		data[1].screenpos.x > data[0].screenpos.x) {
+		// Okay, this is in the shape of a triangle, but what about rotation/texture?
+		if (!gstate.isTextureMapEnabled())
+			return true;
+
+		if (data[0].texturecoords.x == data[2].texturecoords.x &&
+			data[0].texturecoords.y == data[1].texturecoords.y &&
+			data[1].texturecoords.x == data[3].texturecoords.x &&
+			data[2].texturecoords.y == data[3].texturecoords.y &&
+			data[2].texturecoords.y > data[0].texturecoords.y &&
+			data[1].texturecoords.x > data[0].texturecoords.x) {
+			// It's a rectangle!
+			return true;
+		}
+		return false;
 	}
 	return false;
 }

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -287,6 +287,14 @@ bool DetectRectangleFromThroughModeStrip(const VertexData data[4]) {
 	if (!(data[2].color0 == data[3].color0))
 		return false;
 
+	// And the depth must also be flat.
+	if (!(data[0].screenpos.z == data[1].screenpos.z))
+		return false;
+	if (!(data[1].screenpos.z == data[2].screenpos.z))
+		return false;
+	if (!(data[2].screenpos.z == data[3].screenpos.z))
+		return false;
+
 	// OK, now let's look at data to detect rectangles. There are a few possibilities
 	// but we focus on Darkstalkers for now.
 	if (data[0].screenpos.x == data[1].screenpos.x &&

--- a/GPU/Software/RasterizerRectangle.h
+++ b/GPU/Software/RasterizerRectangle.h
@@ -18,4 +18,5 @@ namespace Rasterizer {
 
 	bool DetectRectangleFromThroughModeStrip(const VertexData data[4]);
 	bool DetectRectangleFromThroughModeFan(const VertexData *data, int c, int *tlIndex, int *brIndex);
+	bool DetectRectangleSlices(const VertexData data[4]);
 }

--- a/GPU/Software/RasterizerRectangle.h
+++ b/GPU/Software/RasterizerRectangle.h
@@ -17,4 +17,5 @@ namespace Rasterizer {
 	bool RectangleFastPath(const VertexData &v0, const VertexData &v1);
 
 	bool DetectRectangleFromThroughModeStrip(const VertexData data[4]);
+	bool DetectRectangleFromThroughModeFan(const VertexData *data, int c, int *tlIndex, int *brIndex);
 }

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -48,6 +48,10 @@ struct FormatBuffer {
 	inline u16 *Get16Ptr(int x, int y, int stride) {
 		return &as16[x + y * stride];
 	}
+
+	inline u32 *Get32Ptr(int x, int y, int stride) {
+		return &as32[x + y * stride];
+	}
 };
 
 class PresentationCommon;

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -457,7 +457,7 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 				}
 
 				// If a strip is effectively a rectangle, draw it as such!
-				if (Rasterizer::DetectRectangleFromThroughModeStrip(data)) {
+				if (!outside_range_flag && Rasterizer::DetectRectangleFromThroughModeStrip(data)) {
 					Clipper::ProcessRect(data[0], data[3]);
 					break;
 				}
@@ -516,7 +516,12 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 				data[0] = ReadVertex(vreader, outside_range_flag);
 				data_index++;
 				start_vtx = 1;
+
+				// If the central vertex is outside range, all the points are toast.
+				if (outside_range_flag)
+					break;
 			}
+
 			if (data_index == 1 && vertex_count == 4 && gstate.isModeThrough()) {
 				for (int vtx = start_vtx; vtx < vertex_count; ++vtx) {
 					if (indices) {
@@ -528,7 +533,7 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 				}
 
 				int tl = -1, br = -1;
-				if (Rasterizer::DetectRectangleFromThroughModeFan(data, vertex_count, &tl, &br)) {
+				if (!outside_range_flag && Rasterizer::DetectRectangleFromThroughModeFan(data, vertex_count, &tl, &br)) {
 					Clipper::ProcessRect(data[tl], data[br]);
 					break;
 				}

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -425,6 +425,13 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 				}
 			}
 
+			if (data_index == 4 && gstate.isModeThrough()) {
+				if (Rasterizer::DetectRectangleSlices(data)) {
+					data[1] = data[3];
+					data_index = 2;
+				}
+			}
+
 			if (data_index == 4) {
 				Clipper::ProcessRect(data[0], data[1]);
 				Clipper::ProcessRect(data[2], data[3]);

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -132,10 +132,9 @@ public:
 	void SubmitPrimitive(void* vertices, void* indices, GEPrimitiveType prim_type, int vertex_count, u32 vertex_type, int *bytesRead, SoftwareDrawEngine *drawEngine);
 
 	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices);
-	VertexData ReadVertex(VertexReader& vreader);
+	VertexData ReadVertex(VertexReader &vreader, bool &outside_range_flag);
 
-	bool outside_range_flag = false;
-	u8 *buf;
+	u8 *decoded_;
 };
 
 class SoftwareDrawEngine : public DrawEngineCommon {


### PR DESCRIPTION
A few rectangle fast path related changes:
 * Fixes a bug where some verts would incorrectly be culled after a rectangle fast path, affecting FF4 menus.
 * Uses threads for fast path rectangles, which helped a good bit in some areas.
 * Detects triangle fans used to draw a trivial rectangle and sends to fast path, which helped Legend of Heroes III noticeably.
 * Allows fast path for non-textured rectangles (sometimes used for fills with clear off.)
 * Requires flat Z for fast path rectangles.
 * Corrects some range cull handling with fast paths.
 * Combines sliced rectangles (mainly clears) into one rectangle.

Personally, I think threading rectangles is a much smarter case than triangles, because they've got even width in our fast path cases.  Seeing 90 FPS -> 120 FPS in some areas of a few games.

-[Unknown]