### PR TITLE
Cleanup some cached pointers in GPU classes

### DIFF
--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -159,17 +159,14 @@ FramebufferManagerD3D11::~FramebufferManagerD3D11() {
 }
 
 void FramebufferManagerD3D11::SetTextureCache(TextureCacheD3D11 *tc) {
-	textureCacheD3D11_ = tc;
 	textureCache_ = tc;
 }
 
 void FramebufferManagerD3D11::SetShaderManager(ShaderManagerD3D11 *sm) {
-	shaderManagerD3D11_ = sm;
 	shaderManager_ = sm;
 }
 
 void FramebufferManagerD3D11::SetDrawEngine(DrawEngineD3D11 *td) {
-	drawEngineD3D11_ = td;
 	drawEngine_ = td;
 }
 

--- a/GPU/D3D11/FramebufferManagerD3D11.h
+++ b/GPU/D3D11/FramebufferManagerD3D11.h
@@ -84,8 +84,4 @@ private:
 
 	ID3D11Texture2D *nullTexture_ = nullptr;
 	ID3D11ShaderResourceView *nullTextureView_ = nullptr;
-
-	TextureCacheD3D11 *textureCacheD3D11_;
-	ShaderManagerD3D11 *shaderManagerD3D11_;
-	DrawEngineD3D11 *drawEngineD3D11_;
 };

--- a/GPU/D3D11/StencilBufferD3D11.cpp
+++ b/GPU/D3D11/StencilBufferD3D11.cpp
@@ -153,7 +153,7 @@ bool FramebufferManagerD3D11::NotifyStencilUpload(u32 addr, int size, StencilUpl
 		ASSERT_SUCCESS(device_->CreateBuffer(&desc, nullptr, &stencilValueBuffer_));
 	}
 
-	shaderManagerD3D11_->DirtyLastShader();
+	shaderManager_->DirtyLastShader();
 
 	u16 w = dstBuffer->renderWidth;
 	u16 h = dstBuffer->renderHeight;
@@ -185,8 +185,8 @@ bool FramebufferManagerD3D11::NotifyStencilUpload(u32 addr, int size, StencilUpl
 	memcpy(map.pData, coord, sizeof(float) * 4 * 5);
 	context_->Unmap(quadBuffer_, 0);
 
-	shaderManagerD3D11_->DirtyLastShader();
-	textureCacheD3D11_->ForgetLastTexture();
+	shaderManager_->DirtyLastShader();
+	textureCache_->ForgetLastTexture();
 
 	context_->OMSetBlendState(stockD3D11.blendStateDisabledWithColorMask[0], nullptr, 0xFFFFFFFF);
 	context_->IASetInputLayout(stencilUploadInputLayout_);

--- a/GPU/Directx9/FramebufferManagerDX9.cpp
+++ b/GPU/Directx9/FramebufferManagerDX9.cpp
@@ -141,17 +141,14 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 	}
 
 	void FramebufferManagerDX9::SetTextureCache(TextureCacheDX9 *tc) {
-		textureCacheDX9_ = tc;
 		textureCache_ = tc;
 	}
 
 	void FramebufferManagerDX9::SetShaderManager(ShaderManagerDX9 *sm) {
-		shaderManagerDX9_ = sm;
 		shaderManager_ = sm;
 	}
 
 	void FramebufferManagerDX9::SetDrawEngine(DrawEngineDX9 *td) {
-		drawEngineD3D9_ = td;
 		drawEngine_ = td;
 	}
 
@@ -240,7 +237,7 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 			return it->second.surface;
 		}
 
-		textureCacheDX9_->ForgetLastTexture();
+		textureCache_->ForgetLastTexture();
 		LPDIRECT3DSURFACE9 offscreen = nullptr;
 		HRESULT hr = device_->CreateOffscreenPlainSurface(w, h, fmt, D3DPOOL_SYSTEMMEM, &offscreen, NULL);
 		if (FAILED(hr) || !offscreen) {

--- a/GPU/Directx9/FramebufferManagerDX9.h
+++ b/GPU/Directx9/FramebufferManagerDX9.h
@@ -82,10 +82,6 @@ private:
 	bool stencilUploadFailed_ = false;
 
 	LPDIRECT3DTEXTURE9 nullTex_ = nullptr;
-
-	TextureCacheDX9 *textureCacheDX9_;
-	ShaderManagerDX9 *shaderManagerDX9_;
-	DrawEngineDX9 *drawEngineD3D9_;
 	
 	struct OffscreenSurface {
 		LPDIRECT3DSURFACE9 surface;

--- a/GPU/Directx9/StencilBufferDX9.cpp
+++ b/GPU/Directx9/StencilBufferDX9.cpp
@@ -179,7 +179,7 @@ bool FramebufferManagerDX9::NotifyStencilUpload(u32 addr, int size, StencilUploa
 		return false;
 	}
 
-	shaderManagerDX9_->DirtyLastShader();
+	shaderManager_->DirtyLastShader();
 
 	dxstate.colorMask.set(false, false, false, true);
 	dxstate.stencilTest.enable();
@@ -221,8 +221,8 @@ bool FramebufferManagerDX9::NotifyStencilUpload(u32 addr, int size, StencilUploa
 
 	draw_->BindTextures(0, 1, &tex);
 
-	shaderManagerDX9_->DirtyLastShader();
-	textureCacheDX9_->ForgetLastTexture();
+	shaderManager_->DirtyLastShader();
+	textureCache_->ForgetLastTexture();
 
 	for (int i = 1; i < values; i += i) {
 		if (!(usedBits & i)) {

--- a/GPU/GLES/DepthBufferGLES.cpp
+++ b/GPU/GLES/DepthBufferGLES.cpp
@@ -125,7 +125,7 @@ void FramebufferManagerGLES::PackDepthbuffer(VirtualFramebuffer *vfb, int x, int
 			}
 		}
 
-		shaderManagerGL_->DirtyLastShader();
+		shaderManager_->DirtyLastShader();
 		auto *blitFBO = GetTempFBO(TempFBO::COPY, vfb->renderWidth, vfb->renderHeight);
 		draw_->BindFramebufferAsRenderTarget(blitFBO, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "PackDepthbuffer");
 		render_->SetViewport({ 0, 0, (float)vfb->renderWidth, (float)vfb->renderHeight, 0.0f, 1.0f });
@@ -156,7 +156,7 @@ void FramebufferManagerGLES::PackDepthbuffer(VirtualFramebuffer *vfb, int x, int
 
 		draw_->CopyFramebufferToMemorySync(blitFBO, Draw::FB_COLOR_BIT, 0, y, packWidth, h, Draw::DataFormat::R8G8B8A8_UNORM, convBuf_, vfb->z_stride, "PackDepthbuffer");
 
-		textureCacheGL_->ForgetLastTexture();
+		textureCache_->ForgetLastTexture();
 		// TODO: Use 4444 so we can copy lines directly?
 		format16Bit = true;
 	} else {

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -113,12 +113,10 @@ void FramebufferManagerGLES::Init() {
 }
 
 void FramebufferManagerGLES::SetTextureCache(TextureCacheGLES *tc) {
-	textureCacheGL_ = tc;
 	textureCache_ = tc;
 }
 
 void FramebufferManagerGLES::SetShaderManager(ShaderManagerGLES *sm) {
-	shaderManagerGL_ = sm;
 	shaderManager_ = sm;
 }
 
@@ -325,7 +323,7 @@ void FramebufferManagerGLES::BlitFramebuffer(VirtualFramebuffer *dst, int dstX, 
 		float srcH = src->bufferHeight;
 		render_->BindProgram(draw2dprogram_);
 		DrawActiveTexture(dstX1, dstY1, w * dstXFactor, h * dstYFactor, dst->bufferWidth, dst->bufferHeight, srcX1 / srcW, srcY1 / srcH, srcX2 / srcW, srcY2 / srcH, ROTATION_LOCKED_HORIZONTAL, DRAWTEX_NEAREST);
-		textureCacheGL_->ForgetLastTexture();
+		textureCache_->ForgetLastTexture();
 	}
 
 	gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_BLEND_STATE | DIRTY_RASTER_STATE);

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -89,8 +89,6 @@ private:
 	// Cached uniform locs
 	int u_draw2d_tex = -1;
 
-	TextureCacheGLES *textureCacheGL_ = nullptr;
-	ShaderManagerGLES *shaderManagerGL_ = nullptr;
 	DrawEngineGLES *drawEngineGL_ = nullptr;
 
 	struct Simple2DVertex {

--- a/GPU/GLES/StencilBufferGLES.cpp
+++ b/GPU/GLES/StencilBufferGLES.cpp
@@ -120,7 +120,7 @@ bool FramebufferManagerGLES::NotifyStencilUpload(u32 addr, int size, StencilUplo
 			// Common when creating buffers, it's already 0.  We're done.
 			return false;
 		}
-		shaderManagerGL_->DirtyLastShader();
+		shaderManager_->DirtyLastShader();
 
 		// Let's not bother with the shader if it's just zero.
 		if (dstBuffer->fbo) {
@@ -156,7 +156,7 @@ bool FramebufferManagerGLES::NotifyStencilUpload(u32 addr, int size, StencilUplo
 		}
 	}
 
-	shaderManagerGL_->DirtyLastShader();
+	shaderManager_->DirtyLastShader();
 
 	bool useBlit = gstate_c.Supports(GPU_SUPPORTS_FRAMEBUFFER_BLIT);
 
@@ -179,7 +179,7 @@ bool FramebufferManagerGLES::NotifyStencilUpload(u32 addr, int size, StencilUplo
 
 	float u1 = 1.0f;
 	float v1 = 1.0f;
-	textureCacheGL_->ForgetLastTexture();
+	textureCache_->ForgetLastTexture();
 	Draw::Texture *tex = MakePixelTexture(src, dstBuffer->format, dstBuffer->fb_stride, dstBuffer->width, dstBuffer->height, u1, v1);
 	if (!tex)
 		return false;

--- a/GPU/Vulkan/DepalettizeShaderVulkan.h
+++ b/GPU/Vulkan/DepalettizeShaderVulkan.h
@@ -48,10 +48,10 @@ class VulkanPushBuffer;
 // Could even avoid bothering with palette texture and just use uniform data...
 class DepalShaderCacheVulkan : public DepalShaderCacheCommon {
 public:
-	DepalShaderCacheVulkan(Draw::DrawContext *draw, VulkanContext *vulkan);
+	DepalShaderCacheVulkan(Draw::DrawContext *draw);
 	~DepalShaderCacheVulkan();
 	void DeviceLost();
-	void DeviceRestore(Draw::DrawContext *draw, VulkanContext *vulkan);
+	void DeviceRestore(Draw::DrawContext *draw);
 
 	// This also uploads the palette and binds the correct texture.
 	DepalShaderVulkan *GetDepalettizeShader(uint32_t clutMode, GEBufferFormat pixelFormat);
@@ -66,7 +66,6 @@ public:
 
 private:
 	Draw::DrawContext *draw_ = nullptr;
-	VulkanContext *vulkan_ = nullptr;
 	VulkanPushBuffer *push_ = nullptr;
 	VulkanDeviceAllocator *alloc_ = nullptr;
 	VkShaderModule vshader_ = VK_NULL_HANDLE;

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -123,7 +123,7 @@ private:
 // Handles transform, lighting and drawing.
 class DrawEngineVulkan : public DrawEngineCommon {
 public:
-	DrawEngineVulkan(VulkanContext *vulkan, Draw::DrawContext *draw);
+	DrawEngineVulkan(Draw::DrawContext *draw);
 	virtual ~DrawEngineVulkan();
 
 	void SetShaderManager(ShaderManagerVulkan *shaderManager) {
@@ -140,7 +140,7 @@ public:
 	}
 
 	void DeviceLost();
-	void DeviceRestore(VulkanContext *vulkan, Draw::DrawContext *draw);
+	void DeviceRestore(Draw::DrawContext *draw);
 
 	// So that this can be inlined
 	void Flush() {
@@ -174,12 +174,12 @@ public:
 	}
 
 	VulkanPushBuffer *GetPushBufferForTextureData() {
-		return frame_[vulkan_->GetCurFrame()].pushUBO;
+		return GetCurFrame().pushUBO;
 	}
 
 	// Only use Allocate on this one.
 	VulkanPushBuffer *GetPushBufferLocal() {
-		return frame_[vulkan_->GetCurFrame()].pushLocal;
+		return GetCurFrame().pushLocal;
 	}
 
 	const DrawEngineVulkanStats &GetStats() const {
@@ -208,10 +208,10 @@ private:
 
 	void DoFlush();
 	void UpdateUBOs(FrameData *frame);
+	FrameData &GetCurFrame();
 
 	VkDescriptorSet GetOrCreateDescriptorSet(VkImageView imageView, VkSampler sampler, VkBuffer base, VkBuffer light, VkBuffer bone, bool tess);
 
-	VulkanContext *vulkan_;
 	Draw::DrawContext *draw_;
 
 	// We use a single descriptor set layout for all PSP draws.

--- a/GPU/Vulkan/FramebufferManagerVulkan.cpp
+++ b/GPU/Vulkan/FramebufferManagerVulkan.cpp
@@ -90,17 +90,14 @@ FramebufferManagerVulkan::~FramebufferManagerVulkan() {
 }
 
 void FramebufferManagerVulkan::SetTextureCache(TextureCacheVulkan *tc) {
-	textureCacheVulkan_ = tc;
 	textureCache_ = tc;
 }
 
 void FramebufferManagerVulkan::SetShaderManager(ShaderManagerVulkan *sm) {
-	shaderManagerVulkan_ = sm;
 	shaderManager_ = sm;
 }
 
 void FramebufferManagerVulkan::SetDrawEngine(DrawEngineVulkan *td) {
-	drawEngineVulkan_ = td;
 	drawEngine_ = td;
 }
 

--- a/GPU/Vulkan/FramebufferManagerVulkan.h
+++ b/GPU/Vulkan/FramebufferManagerVulkan.h
@@ -72,9 +72,6 @@ private:
 
 	// Used to keep track of command buffers here but have moved all that into Thin3D.
 
-	TextureCacheVulkan *textureCacheVulkan_ = nullptr;
-	ShaderManagerVulkan *shaderManagerVulkan_ = nullptr;
-	DrawEngineVulkan *drawEngineVulkan_ = nullptr;
 	VulkanPushBuffer *push_;
 
 	enum {

--- a/GPU/Vulkan/FramebufferManagerVulkan.h
+++ b/GPU/Vulkan/FramebufferManagerVulkan.h
@@ -34,7 +34,7 @@ class VulkanPushBuffer;
 
 class FramebufferManagerVulkan : public FramebufferManagerCommon {
 public:
-	FramebufferManagerVulkan(Draw::DrawContext *draw, VulkanContext *vulkan);
+	FramebufferManagerVulkan(Draw::DrawContext *draw);
 	~FramebufferManagerVulkan();
 
 	void SetTextureCache(TextureCacheVulkan *tc);
@@ -67,8 +67,6 @@ protected:
 private:
 	void InitDeviceObjects();
 	void DestroyDeviceObjects();
-
-	VulkanContext *vulkan_;
 
 	// Used to keep track of command buffers here but have moved all that into Thin3D.
 

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -89,7 +89,6 @@ private:
 	void LoadCache(const Path &filename);
 	void SaveCache(const Path &filename);
 
-	VulkanContext *vulkan_;
 	FramebufferManagerVulkan *framebufferManagerVulkan_;
 	TextureCacheVulkan *textureCacheVulkan_;
 	DepalShaderCacheVulkan depalShaderCache_;

--- a/GPU/Vulkan/ShaderManagerVulkan.h
+++ b/GPU/Vulkan/ShaderManagerVulkan.h
@@ -83,10 +83,10 @@ class VulkanPushBuffer;
 
 class ShaderManagerVulkan : public ShaderManagerCommon {
 public:
-	ShaderManagerVulkan(Draw::DrawContext *draw, VulkanContext *vulkan);
+	ShaderManagerVulkan(Draw::DrawContext *draw);
 	~ShaderManagerVulkan();
 
-	void DeviceRestore(VulkanContext *vulkan, Draw::DrawContext *draw);
+	void DeviceRestore(Draw::DrawContext *draw);
 
 	void GetShaders(int prim, u32 vertType, VulkanVertexShader **vshader, VulkanFragmentShader **fshader, bool useHWTransform, bool useHWTessellation, bool weightsAsFloat);
 	void ClearShaders();
@@ -130,7 +130,6 @@ public:
 private:
 	void Clear();
 
-	VulkanContext *vulkan_;
 	ShaderLanguageDesc compat_;
 
 	typedef DenseHashMap<FShaderID, VulkanFragmentShader *, nullptr> FSCache;

--- a/GPU/Vulkan/StencilBufferVulkan.cpp
+++ b/GPU/Vulkan/StencilBufferVulkan.cpp
@@ -160,8 +160,8 @@ bool FramebufferManagerVulkan::NotifyStencilUpload(u32 addr, int size, StencilUp
 
 	VulkanRenderManager *renderManager = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 
-	shaderManagerVulkan_->DirtyLastShader();
-	textureCacheVulkan_->ForgetLastTexture();
+	shaderManager_->DirtyLastShader();
+	textureCache_->ForgetLastTexture();
 
 	u16 w = dstBuffer->renderWidth;
 	u16 h = dstBuffer->renderHeight;

--- a/GPU/Vulkan/StencilBufferVulkan.cpp
+++ b/GPU/Vulkan/StencilBufferVulkan.cpp
@@ -147,14 +147,16 @@ bool FramebufferManagerVulkan::NotifyStencilUpload(u32 addr, int size, StencilUp
 
 	std::string error;
 	if (!stencilVs_) {
+		VulkanContext *vulkan = (VulkanContext *)draw_->GetNativeObject(Draw::NativeObject::CONTEXT);
+
 		const char *stencil_fs_source = stencil_fs;
 		// See comment above the stencil_fs_adreno definition.
-		u32 vendorID = vulkan_->GetPhysicalDeviceProperties().properties.vendorID;
+		u32 vendorID = vulkan->GetPhysicalDeviceProperties().properties.vendorID;
 		if (g_Config.bVendorBugChecksEnabled && (draw_->GetBugs().Has(Draw::Bugs::NO_DEPTH_CANNOT_DISCARD_STENCIL) || vendorID == VULKAN_VENDOR_ARM))
 			stencil_fs_source = stencil_fs_adreno;
 
-		stencilVs_ = CompileShaderModule(vulkan_, VK_SHADER_STAGE_VERTEX_BIT, stencil_vs, &error);
-		stencilFs_ = CompileShaderModule(vulkan_, VK_SHADER_STAGE_FRAGMENT_BIT, stencil_fs_source, &error);
+		stencilVs_ = CompileShaderModule(vulkan, VK_SHADER_STAGE_VERTEX_BIT, stencil_vs, &error);
+		stencilFs_ = CompileShaderModule(vulkan, VK_SHADER_STAGE_FRAGMENT_BIT, stencil_fs_source, &error);
 	}
 	VkRenderPass rp = (VkRenderPass)draw_->GetNativeObject(Draw::NativeObject::FRAMEBUFFER_RENDERPASS);
 

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -66,7 +66,7 @@ public:
 	void EndFrame();
 
 	void DeviceLost();
-	void DeviceRestore(VulkanContext *vulkan, Draw::DrawContext *draw);
+	void DeviceRestore(Draw::DrawContext *draw);
 
 	void SetFramebufferManager(FramebufferManagerVulkan *fbManager);
 	void SetDepalShaderCache(DepalShaderCacheVulkan *dpCache) {
@@ -118,7 +118,6 @@ private:
 
 	void CompileScalingShader();
 
-	VulkanContext *vulkan_ = nullptr;
 	VulkanDeviceAllocator *allocator_ = nullptr;
 	VulkanPushBuffer *push_ = nullptr;
 
@@ -128,7 +127,6 @@ private:
 
 	TextureScalerVulkan scaler;
 
-	FramebufferManagerVulkan *framebufferManagerVulkan_;
 	DepalShaderCacheVulkan *depalShaderCache_;
 	ShaderManagerVulkan *shaderManagerVulkan_;
 	DrawEngineVulkan *drawEngine_;


### PR DESCRIPTION
Mainly Vulkan, this gets rid of some `vulkan_` pointers when we already have `draw_`.  Given lost/restore, I think it's better to keep to one pointer.

Elsewhere, mainly just removed specialized pointers that weren't doing anything terribly useful.

-[Unknown]