### PR TITLE
Fix libretro crash on close content after cached GPU pointer cleanup.

### DIFF
--- a/libretro/LibretroGraphicsContext.cpp
+++ b/libretro/LibretroGraphicsContext.cpp
@@ -73,10 +73,6 @@ void LibretroHWRenderContext::ContextDestroy() {
 #endif
 	}
 
-	LostBackbuffer();
-
-	gpu->DeviceLost();
-
 	if (!hw_render_.cache_context && !Libretro::useEmuThread) {
 		Shutdown();
 	}

--- a/libretro/LibretroVulkanContext.cpp
+++ b/libretro/LibretroVulkanContext.cpp
@@ -128,9 +128,6 @@ void LibretroVulkanContext::ContextReset() {
 
 void LibretroVulkanContext::ContextDestroy() {
    INFO_LOG(G3D, "LibretroVulkanContext::ContextDestroy()");
-
-   LostBackbuffer();
-   gpu->DeviceLost();
 }
 
 void LibretroVulkanContext::CreateDrawContext() {


### PR DESCRIPTION
#15142 has caused a slight regression in libretro causing it to crash on content close. The cleanup of the pointers now means that the ContextDestroy's call to DeviceLost() fully shuts down the gpu and null's out the draw_ object. The subsequent call to PSP_Shutdown() in retro_unload_game() then fails as the gpu is already completely shut down.

Tested against all rendering backends on windows 10 with no issues.