### PR TITLE
Refactor draw pixel and hardcode another path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1580,6 +1580,8 @@ set(GPU_SOURCES
 	GPU/Math3D.h
 	GPU/Software/Clipper.cpp
 	GPU/Software/Clipper.h
+	GPU/Software/DrawPixel.cpp
+	GPU/Software/DrawPixel.h
 	GPU/Software/FuncId.cpp
 	GPU/Software/FuncId.h
 	GPU/Software/Lighting.cpp

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -453,6 +453,7 @@
     <ClInclude Include="GPUState.h" />
     <ClInclude Include="Math3D.h" />
     <ClInclude Include="Software\Clipper.h" />
+    <ClInclude Include="Software\DrawPixel.h" />
     <ClInclude Include="Software\Lighting.h" />
     <ClInclude Include="Software\FuncId.h" />
     <ClInclude Include="Software\Rasterizer.h" />
@@ -629,6 +630,7 @@
     <ClCompile Include="GPUState.cpp" />
     <ClCompile Include="Math3D.cpp" />
     <ClCompile Include="Software\Clipper.cpp" />
+    <ClCompile Include="Software\DrawPixel.cpp" />
     <ClCompile Include="Software\Lighting.cpp" />
     <ClCompile Include="Software\FuncId.cpp" />
     <ClCompile Include="Software\Rasterizer.cpp" />

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -267,6 +267,9 @@
     <ClInclude Include="Software\FuncId.h">
       <Filter>Software</Filter>
     </ClInclude>
+    <ClInclude Include="Software\DrawPixel.h">
+      <Filter>Software</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Math3D.cpp">
@@ -534,6 +537,9 @@
       <Filter>Common</Filter>
     </ClCompile>
     <ClCompile Include="Software\FuncId.cpp">
+      <Filter>Software</Filter>
+    </ClCompile>
+    <ClCompile Include="Software\DrawPixel.cpp">
       <Filter>Software</Filter>
     </ClCompile>
   </ItemGroup>

--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -1,0 +1,467 @@
+// Copyright (c) 2013- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "Common/Data/Convert/ColorConv.h"
+#include "GPU/GPUState.h"
+#include "GPU/Software/DrawPixel.h"
+#include "GPU/Software/FuncId.h"
+#include "GPU/Software/Rasterizer.h"
+#include "GPU/Software/SoftGpu.h"
+
+using namespace Math3D;
+
+namespace Rasterizer {
+
+void Init() {
+}
+
+void Shutdown() {
+}
+
+bool DescribeCodePtr(const u8 *ptr, std::string &name) {
+	return false;
+}
+
+static inline u8 GetPixelStencil(GEBufferFormat fmt, int x, int y) {
+	if (fmt == GE_FORMAT_565) {
+		// Always treated as 0 for comparison purposes.
+		return 0;
+	} else if (fmt == GE_FORMAT_5551) {
+		return ((fb.Get16(x, y, gstate.FrameBufStride()) & 0x8000) != 0) ? 0xFF : 0;
+	} else if (fmt == GE_FORMAT_4444) {
+		return Convert4To8(fb.Get16(x, y, gstate.FrameBufStride()) >> 12);
+	} else {
+		return fb.Get32(x, y, gstate.FrameBufStride()) >> 24;
+	}
+}
+
+static inline void SetPixelStencil(GEBufferFormat fmt, int x, int y, u8 value) {
+	if (fmt == GE_FORMAT_565) {
+		// Do nothing
+	} else if (fmt == GE_FORMAT_5551) {
+		if ((gstate.getStencilWriteMask() & 0x80) == 0) {
+			u16 pixel = fb.Get16(x, y, gstate.FrameBufStride()) & ~0x8000;
+			pixel |= (value & 0x80) << 8;
+			fb.Set16(x, y, gstate.FrameBufStride(), pixel);
+		}
+	} else if (fmt == GE_FORMAT_4444) {
+		const u16 write_mask = (gstate.getStencilWriteMask() << 8) | 0x0FFF;
+		u16 pixel = fb.Get16(x, y, gstate.FrameBufStride()) & write_mask;
+		pixel |= ((u16)value << 8) & ~write_mask;
+		fb.Set16(x, y, gstate.FrameBufStride(), pixel);
+	} else {
+		const u32 write_mask = (gstate.getStencilWriteMask() << 24) | 0x00FFFFFF;
+		u32 pixel = fb.Get32(x, y, gstate.FrameBufStride()) & write_mask;
+		pixel |= ((u32)value << 24) & ~write_mask;
+		fb.Set32(x, y, gstate.FrameBufStride(), pixel);
+	}
+}
+
+static inline u16 GetPixelDepth(int x, int y) {
+	return depthbuf.Get16(x, y, gstate.DepthBufStride());
+}
+
+static inline void SetPixelDepth(int x, int y, u16 value) {
+	depthbuf.Set16(x, y, gstate.DepthBufStride(), value);
+}
+
+// NOTE: These likely aren't endian safe
+static inline u32 GetPixelColor(GEBufferFormat fmt, int x, int y) {
+	switch (fmt) {
+	case GE_FORMAT_565:
+		return RGB565ToRGBA8888(fb.Get16(x, y, gstate.FrameBufStride()));
+
+	case GE_FORMAT_5551:
+		return RGBA5551ToRGBA8888(fb.Get16(x, y, gstate.FrameBufStride()));
+
+	case GE_FORMAT_4444:
+		return RGBA4444ToRGBA8888(fb.Get16(x, y, gstate.FrameBufStride()));
+
+	case GE_FORMAT_8888:
+		return fb.Get32(x, y, gstate.FrameBufStride());
+
+	default:
+		return 0;
+	}
+}
+
+static inline void SetPixelColor(GEBufferFormat fmt, int x, int y, u32 value) {
+	switch (fmt) {
+	case GE_FORMAT_565:
+		fb.Set16(x, y, gstate.FrameBufStride(), RGBA8888ToRGB565(value));
+		break;
+
+	case GE_FORMAT_5551:
+		fb.Set16(x, y, gstate.FrameBufStride(), RGBA8888ToRGBA5551(value));
+		break;
+
+	case GE_FORMAT_4444:
+		fb.Set16(x, y, gstate.FrameBufStride(), RGBA8888ToRGBA4444(value));
+		break;
+
+	case GE_FORMAT_8888:
+		fb.Set32(x, y, gstate.FrameBufStride(), value);
+		break;
+
+	default:
+		break;
+	}
+}
+
+static inline bool AlphaTestPassed(const PixelFuncID &pixelID, int alpha) {
+	const u8 ref = pixelID.alphaTestRef;
+	if (pixelID.hasAlphaTestMask)
+		alpha &= gstate.getAlphaTestMask();
+
+	switch (GEComparison(pixelID.alphaTestFunc)) {
+	case GE_COMP_NEVER:
+		return false;
+
+	case GE_COMP_ALWAYS:
+		return true;
+
+	case GE_COMP_EQUAL:
+		return (alpha == ref);
+
+	case GE_COMP_NOTEQUAL:
+		return (alpha != ref);
+
+	case GE_COMP_LESS:
+		return (alpha < ref);
+
+	case GE_COMP_LEQUAL:
+		return (alpha <= ref);
+
+	case GE_COMP_GREATER:
+		return (alpha > ref);
+
+	case GE_COMP_GEQUAL:
+		return (alpha >= ref);
+	}
+	return true;
+}
+
+static inline bool ColorTestPassed(const Vec3<int> &color) {
+	const u32 mask = gstate.getColorTestMask();
+	const u32 c = color.ToRGB() & mask;
+	const u32 ref = gstate.getColorTestRef() & mask;
+	switch (gstate.getColorTestFunction()) {
+	case GE_COMP_NEVER:
+		return false;
+
+	case GE_COMP_ALWAYS:
+		return true;
+
+	case GE_COMP_EQUAL:
+		return c == ref;
+
+	case GE_COMP_NOTEQUAL:
+		return c != ref;
+	}
+	return true;
+}
+
+static inline bool StencilTestPassed(const PixelFuncID &pixelID, u8 stencil) {
+	if (pixelID.hasStencilTestMask)
+		stencil &= gstate.getStencilTestMask();
+	u8 ref = pixelID.stencilTestRef;
+	switch (GEComparison(pixelID.stencilTestFunc)) {
+	case GE_COMP_NEVER:
+		return false;
+
+	case GE_COMP_ALWAYS:
+		return true;
+
+	case GE_COMP_EQUAL:
+		return ref == stencil;
+
+	case GE_COMP_NOTEQUAL:
+		return ref != stencil;
+
+	case GE_COMP_LESS:
+		return ref < stencil;
+
+	case GE_COMP_LEQUAL:
+		return ref <= stencil;
+
+	case GE_COMP_GREATER:
+		return ref > stencil;
+
+	case GE_COMP_GEQUAL:
+		return ref >= stencil;
+	}
+	return true;
+}
+
+static inline u8 ApplyStencilOp(GEBufferFormat fmt, GEStencilOp op, u8 old_stencil) {
+	switch (op) {
+	case GE_STENCILOP_KEEP:
+		return old_stencil;
+
+	case GE_STENCILOP_ZERO:
+		return 0;
+
+	case GE_STENCILOP_REPLACE:
+		return gstate.getStencilTestRef();
+
+	case GE_STENCILOP_INVERT:
+		return ~old_stencil;
+
+	case GE_STENCILOP_INCR:
+		switch (fmt) {
+		case GE_FORMAT_8888:
+			if (old_stencil != 0xFF) {
+				return old_stencil + 1;
+			}
+			return old_stencil;
+		case GE_FORMAT_5551:
+			return 0xFF;
+		case GE_FORMAT_4444:
+			if (old_stencil < 0xF0) {
+				return old_stencil + 0x10;
+			}
+			return old_stencil;
+		default:
+			return old_stencil;
+		}
+		break;
+
+	case GE_STENCILOP_DECR:
+		switch (fmt) {
+		case GE_FORMAT_4444:
+			if (old_stencil >= 0x10)
+				return old_stencil - 0x10;
+			break;
+		default:
+			if (old_stencil != 0)
+				return old_stencil - 1;
+			return old_stencil;
+		}
+		break;
+	}
+
+	return old_stencil;
+}
+
+static inline bool DepthTestPassed(GEComparison func, int x, int y, u16 z) {
+	u16 reference_z = GetPixelDepth(x, y);
+
+	switch (func) {
+	case GE_COMP_NEVER:
+		return false;
+
+	case GE_COMP_ALWAYS:
+		return true;
+
+	case GE_COMP_EQUAL:
+		return (z == reference_z);
+
+	case GE_COMP_NOTEQUAL:
+		return (z != reference_z);
+
+	case GE_COMP_LESS:
+		return (z < reference_z);
+
+	case GE_COMP_LEQUAL:
+		return (z <= reference_z);
+
+	case GE_COMP_GREATER:
+		return (z > reference_z);
+
+	case GE_COMP_GEQUAL:
+		return (z >= reference_z);
+
+	default:
+		return 0;
+	}
+}
+
+static inline u32 ApplyLogicOp(GELogicOp op, u32 old_color, u32 new_color) {
+	// All of the operations here intentionally preserve alpha/stencil.
+	switch (op) {
+	case GE_LOGIC_CLEAR:
+		new_color &= 0xFF000000;
+		break;
+
+	case GE_LOGIC_AND:
+		new_color = new_color & (old_color | 0xFF000000);
+		break;
+
+	case GE_LOGIC_AND_REVERSE:
+		new_color = new_color & (~old_color | 0xFF000000);
+		break;
+
+	case GE_LOGIC_COPY:
+		// No change to new_color.
+		break;
+
+	case GE_LOGIC_AND_INVERTED:
+		new_color = (~new_color & (old_color & 0x00FFFFFF)) | (new_color & 0xFF000000);
+		break;
+
+	case GE_LOGIC_NOOP:
+		new_color = (old_color & 0x00FFFFFF) | (new_color & 0xFF000000);
+		break;
+
+	case GE_LOGIC_XOR:
+		new_color = new_color ^ (old_color & 0x00FFFFFF);
+		break;
+
+	case GE_LOGIC_OR:
+		new_color = new_color | (old_color & 0x00FFFFFF);
+		break;
+
+	case GE_LOGIC_NOR:
+		new_color = (~(new_color | old_color) & 0x00FFFFFF) | (new_color & 0xFF000000);
+		break;
+
+	case GE_LOGIC_EQUIV:
+		new_color = (~(new_color ^ old_color) & 0x00FFFFFF) | (new_color & 0xFF000000);
+		break;
+
+	case GE_LOGIC_INVERTED:
+		new_color = (~old_color & 0x00FFFFFF) | (new_color & 0xFF000000);
+		break;
+
+	case GE_LOGIC_OR_REVERSE:
+		new_color = new_color | (~old_color & 0x00FFFFFF);
+		break;
+
+	case GE_LOGIC_COPY_INVERTED:
+		new_color = (~new_color & 0x00FFFFFF) | (new_color & 0xFF000000);
+		break;
+
+	case GE_LOGIC_OR_INVERTED:
+		new_color = ((~new_color | old_color) & 0x00FFFFFF) | (new_color & 0xFF000000);
+		break;
+
+	case GE_LOGIC_NAND:
+		new_color = (~(new_color & old_color) & 0x00FFFFFF) | (new_color & 0xFF000000);
+		break;
+
+	case GE_LOGIC_SET:
+		new_color |= 0x00FFFFFF;
+		break;
+	}
+
+	return new_color;
+}
+
+template <bool clearMode>
+inline void DrawSinglePixel(int x, int y, int z, int fog, const Vec4<int> &color_in, const PixelFuncID &pixelID) {
+	Vec4<int> prim_color = color_in.Clamp(0, 255);
+	// Depth range test - applied in clear mode, if not through mode.
+	if (pixelID.applyDepthRange)
+		if (z < gstate.getDepthRangeMin() || z > gstate.getDepthRangeMax())
+			return;
+
+	if (GEComparison(pixelID.alphaTestFunc) != GE_COMP_ALWAYS && !clearMode)
+		if (!AlphaTestPassed(pixelID, prim_color.a()))
+			return;
+
+	// Fog is applied prior to color test.
+	if (pixelID.applyFog && !clearMode) {
+		Vec3<int> fogColor = Vec3<int>::FromRGB(gstate.fogcolor);
+		fogColor = (prim_color.rgb() * fog + fogColor * (255 - fog)) / 255;
+		prim_color.r() = fogColor.r();
+		prim_color.g() = fogColor.g();
+		prim_color.b() = fogColor.b();
+	}
+
+	if (pixelID.colorTest && !clearMode)
+		if (!ColorTestPassed(prim_color.rgb()))
+			return;
+
+	// In clear mode, it uses the alpha color as stencil.
+	u8 stencil = clearMode ? prim_color.a() : GetPixelStencil(GEBufferFormat(pixelID.fbFormat), x, y);
+	if (clearMode) {
+		if (pixelID.depthClear)
+			SetPixelDepth(x, y, z);
+	} else if (pixelID.stencilTest) {
+		if (!StencilTestPassed(pixelID, stencil)) {
+			stencil = ApplyStencilOp(GEBufferFormat(pixelID.fbFormat), GEStencilOp(pixelID.sFail), stencil);
+			SetPixelStencil(GEBufferFormat(pixelID.fbFormat), x, y, stencil);
+			return;
+		}
+
+		// Also apply depth at the same time.  If disabled, same as passing.
+		if (pixelID.depthTestFunc != GE_COMP_ALWAYS && !DepthTestPassed(GEComparison(pixelID.depthTestFunc), x, y, z)) {
+			stencil = ApplyStencilOp(GEBufferFormat(pixelID.fbFormat), GEStencilOp(pixelID.zFail), stencil);
+			SetPixelStencil(GEBufferFormat(pixelID.fbFormat), x, y, stencil);
+			return;
+		}
+
+		stencil = ApplyStencilOp(GEBufferFormat(pixelID.fbFormat), GEStencilOp(pixelID.zPass), stencil);
+	} else {
+		if (pixelID.depthTestFunc != GE_COMP_ALWAYS && !DepthTestPassed(GEComparison(pixelID.depthTestFunc), x, y, z)) {
+			return;
+		}
+	}
+
+	if (pixelID.depthWrite && !clearMode)
+		SetPixelDepth(x, y, z);
+
+	const u32 old_color = GetPixelColor(GEBufferFormat(pixelID.fbFormat), x, y);
+	u32 new_color;
+
+	// Dithering happens before the logic op and regardless of framebuffer format or clear mode.
+	// We do it while alpha blending because it happens before clamping.
+	if (pixelID.alphaBlend && !clearMode) {
+		const Vec4<int> dst = Vec4<int>::FromRGBA(old_color);
+		Vec3<int> blended = AlphaBlendingResult(pixelID, prim_color, dst);
+		if (pixelID.dithering) {
+			blended += Vec3<int>::AssignToAll(gstate.getDitherValue(x, y));
+		}
+
+		// ToRGB() always automatically clamps.
+		new_color = blended.ToRGB();
+		new_color |= stencil << 24;
+	} else {
+		if (pixelID.dithering) {
+			// We'll discard alpha anyway.
+			prim_color += Vec4<int>::AssignToAll(gstate.getDitherValue(x, y));
+		}
+
+#if defined(_M_SSE)
+		new_color = Vec3<int>(prim_color.ivec).ToRGB();
+		new_color |= stencil << 24;
+#else
+		new_color = Vec4<int>(prim_color.r(), prim_color.g(), prim_color.b(), stencil).ToRGBA();
+#endif
+	}
+
+	// Logic ops are applied after blending (if blending is enabled.)
+	if (pixelID.applyLogicOp && !clearMode) {
+		// Logic ops don't affect stencil, which happens inside ApplyLogicOp.
+		new_color = ApplyLogicOp(gstate.getLogicOp(), old_color, new_color);
+	}
+
+	if (clearMode) {
+		new_color = (new_color & ~gstate.getClearModeColorMask()) | (old_color & gstate.getClearModeColorMask());
+	}
+	new_color = (new_color & ~gstate.getColorMask()) | (old_color & gstate.getColorMask());
+
+	SetPixelColor(GEBufferFormat(pixelID.fbFormat), x, y, new_color);
+}
+
+SingleFunc GetSingleFunc(const PixelFuncID &id) {
+	if (id.clearMode)
+		return &DrawSinglePixel<true>;
+	return &DrawSinglePixel<false>;
+}
+
+};

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2021- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "ppsspp_config.h"
+
+#include <string>
+#include <unordered_map>
+#if PPSSPP_ARCH(ARM)
+#include "Common/ArmEmitter.h"
+#elif PPSSPP_ARCH(ARM64)
+#include "Common/Arm64Emitter.h"
+#elif PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+#include "Common/x64Emitter.h"
+#elif PPSSPP_ARCH(MIPS)
+#include "Common/MipsEmitter.h"
+#else
+#include "Common/FakeEmitter.h"
+#endif
+#include "GPU/Math3D.h"
+#include "GPU/Software/FuncId.h"
+
+namespace Rasterizer {
+
+typedef void (*SingleFunc)(int x, int y, int z, int fog, const Math3D::Vec4<int> &color_in, const PixelFuncID &pixelID);
+SingleFunc GetSingleFunc(const PixelFuncID &id);
+
+void Init();
+void Shutdown();
+
+bool DescribeCodePtr(const u8 *ptr, std::string &name);
+
+};

--- a/GPU/Software/FuncId.h
+++ b/GPU/Software/FuncId.h
@@ -126,3 +126,4 @@ struct hash<SamplerID> {
 };
 
 void ComputePixelFuncID(PixelFuncID *id);
+std::string DescribePixelFuncID(const PixelFuncID &id);

--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -35,7 +35,6 @@ bool GetCurrentTexture(GPUDebugBuffer &buffer, int level);
 
 // Shared functions with RasterizerRectangle.cpp
 Vec3<int> AlphaBlendingResult(const PixelFuncID &pixelID, const Vec4<int> &source, const Vec4<int> &dst);
-void DrawSinglePixelNonClear(const DrawingCoords &p, u16 z, u8 fog, const Vec4<int> &color_in, const PixelFuncID &pixelID);
 Vec4<int> GetTextureFunctionOutput(const Vec4<int>& prim_color, const Vec4<int>& texcolor);
 
 }  // namespace Rasterizer

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -36,6 +36,7 @@
 #include "Common/Profiler/Profiler.h"
 #include "Common/GPU/thin3d.h"
 
+#include "GPU/Software/DrawPixel.h"
 #include "GPU/Software/Rasterizer.h"
 #include "GPU/Software/Sampler.h"
 #include "GPU/Software/SoftGpu.h"
@@ -66,6 +67,7 @@ SoftGPU::SoftGPU(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	displayStride_ = 512;
 	displayFormat_ = GE_FORMAT_8888;
 
+	Rasterizer::Init();
 	Sampler::Init();
 	drawEngine_ = new SoftwareDrawEngine();
 	drawEngine_->Init();
@@ -107,6 +109,7 @@ SoftGPU::~SoftGPU() {
 	}
 
 	Sampler::Shutdown();
+	Rasterizer::Shutdown();
 }
 
 void SoftGPU::SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) {
@@ -1006,6 +1009,10 @@ bool SoftGPU::DescribeCodePtr(const u8 *ptr, std::string &name) {
 	std::string subname;
 	if (Sampler::DescribeCodePtr(ptr, subname)) {
 		name = "SamplerJit:" + subname;
+		return true;
+	}
+	if (Rasterizer::DescribeCodePtr(ptr, subname)) {
+		name = "RasterizerJit:" + subname;
 		return true;
 	}
 	return false;

--- a/UWP/GPU_UWP/GPU_UWP.vcxproj
+++ b/UWP/GPU_UWP/GPU_UWP.vcxproj
@@ -426,6 +426,7 @@
     <ClInclude Include="..\..\GPU\GPUState.h" />
     <ClInclude Include="..\..\GPU\Math3D.h" />
     <ClInclude Include="..\..\GPU\Software\Clipper.h" />
+    <ClInclude Include="..\..\GPU\Software\DrawPixel.h" />
     <ClInclude Include="..\..\GPU\Software\FuncId.h" />
     <ClInclude Include="..\..\GPU\Software\Lighting.h" />
     <ClInclude Include="..\..\GPU\Software\Rasterizer.h" />
@@ -485,6 +486,7 @@
     <ClCompile Include="..\..\GPU\GPUState.cpp" />
     <ClCompile Include="..\..\GPU\Math3D.cpp" />
     <ClCompile Include="..\..\GPU\Software\Clipper.cpp" />
+    <ClCompile Include="..\..\GPU\Software\DrawPixel.cpp" />
     <ClCompile Include="..\..\GPU\Software\FuncId.cpp" />
     <ClCompile Include="..\..\GPU\Software\Lighting.cpp" />
     <ClCompile Include="..\..\GPU\Software\Rasterizer.cpp" />

--- a/UWP/GPU_UWP/GPU_UWP.vcxproj.filters
+++ b/UWP/GPU_UWP/GPU_UWP.vcxproj.filters
@@ -46,6 +46,7 @@
     <ClCompile Include="..\..\GPU\GPUState.cpp" />
     <ClCompile Include="..\..\GPU\Math3D.cpp" />
     <ClCompile Include="..\..\GPU\Software\Clipper.cpp" />
+    <ClCompile Include="..\..\GPU\Software\DrawPixel.cpp" />
     <ClCompile Include="..\..\GPU\Software\FuncId.cpp" />
     <ClCompile Include="..\..\GPU\Software\Lighting.cpp" />
     <ClCompile Include="..\..\GPU\Software\Rasterizer.cpp" />
@@ -103,6 +104,7 @@
     <ClInclude Include="..\..\GPU\GPUState.h" />
     <ClInclude Include="..\..\GPU\Math3D.h" />
     <ClInclude Include="..\..\GPU\Software\Clipper.h" />
+    <ClInclude Include="..\..\GPU\Software\DrawPixel.h" />
     <ClInclude Include="..\..\GPU\Software\FuncId.h" />
     <ClInclude Include="..\..\GPU\Software\Lighting.h" />
     <ClInclude Include="..\..\GPU\Software\Rasterizer.h" />

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -358,6 +358,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/GPU/GLES/FragmentTestCacheGLES.cpp.arm \
   $(SRC)/GPU/GLES/TextureScalerGLES.cpp \
   $(SRC)/GPU/Software/Clipper.cpp \
+  $(SRC)/GPU/Software/DrawPixel.cpp.arm \
   $(SRC)/GPU/Software/FuncId.cpp \
   $(SRC)/GPU/Software/Lighting.cpp \
   $(SRC)/GPU/Software/Rasterizer.cpp.arm \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -348,6 +348,7 @@ SOURCES_CXX += \
 	$(GPUDIR)/GPUState.cpp \
 	$(GPUDIR)/Math3D.cpp \
 	$(GPUDIR)/Software/Clipper.cpp \
+	$(GPUDIR)/Software/DrawPixel.cpp \
 	$(GPUDIR)/Software/FuncId.cpp \
 	$(GPUDIR)/Software/Lighting.cpp \
 	$(GPUDIR)/Software/Rasterizer.cpp \


### PR DESCRIPTION
This refactors the pixel drawing of the software renderer to a separate file, to more cleanly separate the part covered by PixelFuncID and the future pixel drawing jit.

Since a function pointer is now used for drawing pixels (flat perf impact, actually, was slightly worried), I went ahead and templated the framebuffer format.  This resulted in a small 5-10% perf improvement.  For example, Valkyria Chronicles 3's intro went from 35 FPS to 38 FPS, but some other areas only went from 105 FPS to 110 FPS.

Of course, a jitted pixel func can do better, but this is already a real improvement from just switching to a function pointer.

The pixelID parameter is a bit unfortunate... I think I'll have to keep it because I'd always want a "DISABLE", if you will.  My previous experiments were using __vectorcall, but I'd also messed with drawing four pixels at once which had its own tradeoffs.

-[Unknown]