### PR TITLE
softgpu: Fix PixelFuncID size

### DIFF
--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -127,7 +127,7 @@ static inline bool AlphaTestPassed(const PixelFuncID &pixelID, int alpha) {
 	if (pixelID.hasAlphaTestMask)
 		alpha &= gstate.getAlphaTestMask();
 
-	switch (GEComparison(pixelID.alphaTestFunc)) {
+	switch (pixelID.AlphaTestFunc()) {
 	case GE_COMP_NEVER:
 		return false;
 
@@ -369,7 +369,7 @@ inline void DrawSinglePixel(int x, int y, int z, int fog, const Vec4<int> &color
 		if (z < gstate.getDepthRangeMin() || z > gstate.getDepthRangeMax())
 			return;
 
-	if (GEComparison(pixelID.alphaTestFunc) != GE_COMP_ALWAYS && !clearMode)
+	if (pixelID.AlphaTestFunc() != GE_COMP_ALWAYS && !clearMode)
 		if (!AlphaTestPassed(pixelID, prim_color.a()))
 			return;
 
@@ -389,7 +389,7 @@ inline void DrawSinglePixel(int x, int y, int z, int fog, const Vec4<int> &color
 	// In clear mode, it uses the alpha color as stencil.
 	u8 stencil = clearMode ? prim_color.a() : GetPixelStencil(fbFormat, x, y);
 	if (clearMode) {
-		if (pixelID.depthClear)
+		if (pixelID.DepthClear())
 			SetPixelDepth(x, y, z);
 	} else if (pixelID.stencilTest) {
 		if (!StencilTestPassed(pixelID, stencil)) {
@@ -399,7 +399,7 @@ inline void DrawSinglePixel(int x, int y, int z, int fog, const Vec4<int> &color
 		}
 
 		// Also apply depth at the same time.  If disabled, same as passing.
-		if (pixelID.depthTestFunc != GE_COMP_ALWAYS && !DepthTestPassed(GEComparison(pixelID.depthTestFunc), x, y, z)) {
+		if (pixelID.DepthTestFunc() != GE_COMP_ALWAYS && !DepthTestPassed(pixelID.DepthTestFunc(), x, y, z)) {
 			stencil = ApplyStencilOp(fbFormat, GEStencilOp(pixelID.zFail), stencil);
 			SetPixelStencil(fbFormat, x, y, stencil);
 			return;
@@ -407,7 +407,7 @@ inline void DrawSinglePixel(int x, int y, int z, int fog, const Vec4<int> &color
 
 		stencil = ApplyStencilOp(fbFormat, GEStencilOp(pixelID.zPass), stencil);
 	} else {
-		if (pixelID.depthTestFunc != GE_COMP_ALWAYS && !DepthTestPassed(GEComparison(pixelID.depthTestFunc), x, y, z)) {
+		if (pixelID.DepthTestFunc() != GE_COMP_ALWAYS && !DepthTestPassed(pixelID.DepthTestFunc(), x, y, z)) {
 			return;
 		}
 	}
@@ -460,7 +460,7 @@ inline void DrawSinglePixel(int x, int y, int z, int fog, const Vec4<int> &color
 
 SingleFunc GetSingleFunc(const PixelFuncID &id) {
 	if (id.clearMode) {
-		switch (id.fbFormat) {
+		switch (id.FBFormat()) {
 		case GE_FORMAT_565:
 			return &DrawSinglePixel<true, GE_FORMAT_565>;
 		case GE_FORMAT_5551:
@@ -471,7 +471,7 @@ SingleFunc GetSingleFunc(const PixelFuncID &id) {
 			return &DrawSinglePixel<true, GE_FORMAT_8888>;
 		}
 	}
-	switch (id.fbFormat) {
+	switch (id.FBFormat()) {
 	case GE_FORMAT_565:
 		return &DrawSinglePixel<false, GE_FORMAT_565>;
 	case GE_FORMAT_5551:

--- a/GPU/Software/FuncId.h
+++ b/GPU/Software/FuncId.h
@@ -31,18 +31,12 @@ struct PixelFuncID {
 		uint64_t fullKey{};
 		struct {
 			bool clearMode : 1;
-			union {
-				bool colorTest : 1;
-				bool colorClear : 1;
-			};
-			union {
-				bool stencilTest : 1;
-				bool stencilClear : 1;
-			};
-			union {
-				bool depthWrite : 1;
-				bool depthClear : 1;
-			};
+			// Reused as ColorClear.
+			bool colorTest : 1;
+			// Reused as StencilClear.
+			bool stencilTest : 1;
+			// Reused as DepthClear.
+			bool depthWrite : 1;
 			bool applyDepthRange : 1;
 			// If alpha testing is disabled, set to GE_COMP_ALWAYS.
 			uint8_t alphaTestFunc : 3;
@@ -77,6 +71,50 @@ struct PixelFuncID {
 		};
 	};
 
+	bool ColorClear() const {
+		return colorTest;
+	}
+	bool StencilClear() const {
+		return stencilTest;
+	}
+	bool DepthClear() const {
+		return depthWrite;
+	}
+
+	GEComparison AlphaTestFunc() const {
+		return GEComparison(alphaTestFunc);
+	}
+	GEComparison DepthTestFunc() const {
+		return GEComparison(depthTestFunc);
+	}
+	GEComparison StencilTestFunc() const {
+		return GEComparison(stencilTestFunc);
+	}
+
+	GEBufferFormat FBFormat() const {
+		return GEBufferFormat(fbFormat);
+	}
+
+	GEBlendMode AlphaBlendEq() const {
+		return GEBlendMode(alphaBlendEq);
+	}
+	GEBlendSrcFactor AlphaBlendSrc() const {
+		return GEBlendSrcFactor(alphaBlendSrc);
+	}
+	GEBlendDstFactor AlphaBlendDst() const {
+		return GEBlendDstFactor(alphaBlendDst);
+	}
+
+	GEStencilOp SFail() const {
+		return GEStencilOp(sFail);
+	}
+	GEStencilOp ZFail() const {
+		return GEStencilOp(zFail);
+	}
+	GEStencilOp ZPass() const {
+		return GEStencilOp(zPass);
+	}
+
 	bool operator == (const PixelFuncID &other) const {
 		return fullKey == other.fullKey;
 	}
@@ -101,6 +139,14 @@ struct SamplerID {
 			bool linear : 1;
 		};
 	};
+
+	GETextureFormat TexFmt() const {
+		return GETextureFormat(texfmt);
+	}
+
+	GEPaletteFormat ClutFmt() const {
+		return GEPaletteFormat(clutfmt);
+	}
 
 	bool operator == (const SamplerID &other) const {
 		return fullKey == other.fullKey;

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -467,10 +467,10 @@ static inline Vec3<int> GetDestFactor(GEBlendDstFactor factor, const Vec4<int> &
 Vec3<int> AlphaBlendingResult(const PixelFuncID &pixelID, const Vec4<int> &source, const Vec4<int> &dst)
 {
 	// Note: These factors cannot go below 0, but they can go above 255 when doubling.
-	Vec3<int> srcfactor = GetSourceFactor(GEBlendSrcFactor(pixelID.alphaBlendSrc), source, dst);
-	Vec3<int> dstfactor = GetDestFactor(GEBlendDstFactor(pixelID.alphaBlendDst), source, dst);
+	Vec3<int> srcfactor = GetSourceFactor(pixelID.AlphaBlendSrc(), source, dst);
+	Vec3<int> dstfactor = GetDestFactor(pixelID.AlphaBlendDst(), source, dst);
 
-	switch (GEBlendMode(pixelID.alphaBlendEq)) {
+	switch (pixelID.AlphaBlendEq()) {
 	case GE_BLENDMODE_MUL_AND_ADD:
 	{
 #if defined(_M_SSE)

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -133,19 +133,19 @@ void DrawSprite(const VertexData& v0, const VertexData& v1) {
 		}
 
 		if (!pixelID.stencilTest &&
-			pixelID.depthTestFunc == GE_COMP_ALWAYS &&
+			pixelID.DepthTestFunc() == GE_COMP_ALWAYS &&
 			!pixelID.applyLogicOp &&
 			!pixelID.colorTest &&
 			!pixelID.dithering &&
 			// TODO: Safe?
-			pixelID.alphaTestFunc != GE_COMP_ALWAYS &&
+			pixelID.AlphaTestFunc() != GE_COMP_ALWAYS &&
 			pixelID.alphaTestRef == 0 &&
 			!pixelID.hasAlphaTestMask &&
 			pixelID.alphaBlend &&
 			gstate.isTextureAlphaUsed() &&
 			gstate.getTextureFunction() == GE_TEXFUNC_MODULATE &&
 			!pixelID.applyColorWriteMask &&
-			pixelID.fbFormat == GE_FORMAT_5551) {
+			pixelID.FBFormat() == GE_FORMAT_5551) {
 			if (isWhite) {
 				ParallelRangeLoop(&g_threadManager, [=](int y1, int y2) {
 					int t = t_start + (y1 - pos0.y) * dt;
@@ -206,19 +206,19 @@ void DrawSprite(const VertexData& v0, const VertexData& v1) {
 		if (pos0.x < scissorTL.x) pos0.x = scissorTL.x;
 		if (pos0.y < scissorTL.y) pos0.y = scissorTL.y;
 		if (!pixelID.stencilTest &&
-			pixelID.depthTestFunc == GE_COMP_ALWAYS &&
+			pixelID.DepthTestFunc() == GE_COMP_ALWAYS &&
 			!pixelID.applyLogicOp &&
 			!pixelID.colorTest &&
 			!pixelID.dithering &&
 			// TODO: Safe?
-			pixelID.alphaTestFunc != GE_COMP_ALWAYS &&
+			pixelID.AlphaTestFunc() != GE_COMP_ALWAYS &&
 			pixelID.alphaTestRef == 0 &&
 			!pixelID.hasAlphaTestMask &&
 			pixelID.alphaBlend &&
 			gstate.isTextureAlphaUsed() &&
 			gstate.getTextureFunction() == GE_TEXFUNC_MODULATE &&
 			!pixelID.applyColorWriteMask &&
-			pixelID.fbFormat == GE_FORMAT_5551) {
+			pixelID.FBFormat() == GE_FORMAT_5551) {
 			if (v1.color0.a() == 0)
 				return;
 

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -133,7 +133,7 @@ void SamplerJitCache::ComputeSamplerID(SamplerID *id_out, bool linear) {
 
 std::string SamplerJitCache::DescribeSamplerID(const SamplerID &id) {
 	std::string name;
-	switch ((GETextureFormat)id.texfmt) {
+	switch (id.TexFmt()) {
 	case GE_TFMT_5650: name = "5650"; break;
 	case GE_TFMT_5551: name = "5551"; break;
 	case GE_TFMT_4444: name = "4444"; break;
@@ -146,9 +146,9 @@ std::string SamplerJitCache::DescribeSamplerID(const SamplerID &id) {
 	case GE_TFMT_DXT3: name = "DXT3"; break;
 	case GE_TFMT_DXT5: name = "DXT5"; break;
 	}
-	switch ((GEPaletteFormat)id.clutfmt) {
+	switch (id.ClutFmt()) {
 	case GE_CMODE_16BIT_BGR5650:
-		switch ((GETextureFormat)id.texfmt) {
+		switch (id.TexFmt()) {
 		case GE_TFMT_CLUT4:
 		case GE_TFMT_CLUT8:
 		case GE_TFMT_CLUT16:

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -285,7 +285,7 @@ LinearFunc SamplerJitCache::CompileLinear(const SamplerID &id) {
 }
 
 bool SamplerJitCache::Jit_ReadTextureFormat(const SamplerID &id) {
-	GETextureFormat fmt = (GETextureFormat)id.texfmt;
+	GETextureFormat fmt = id.TexFmt();
 	bool success = true;
 	switch (fmt) {
 	case GE_TFMT_5650:
@@ -547,7 +547,7 @@ bool SamplerJitCache::Jit_GetDXT1Color(const SamplerID &id, int blockSize, int a
 }
 
 bool SamplerJitCache::Jit_ApplyDXTAlpha(const SamplerID &id) {
-	GETextureFormat fmt = (GETextureFormat)id.texfmt;
+	GETextureFormat fmt = id.TexFmt();
 	if (fmt == GE_TFMT_DXT3) {
 		MOVZX(32, 16, tempReg1, MComplex(srcReg, vReg, SCALE_2, 8));
 		LEA(32, RCX, MScaled(uReg, SCALE_4, 0));
@@ -891,7 +891,7 @@ bool SamplerJitCache::Jit_Decode4444() {
 }
 
 bool SamplerJitCache::Jit_TransformClutIndex(const SamplerID &id, int bitsPerIndex) {
-	GEPaletteFormat fmt = (GEPaletteFormat)id.clutfmt;
+	GEPaletteFormat fmt = id.ClutFmt();
 	if (!id.hasClutShift && !id.hasClutMask && !id.hasClutOffset) {
 		// This is simple - just mask if necessary.
 		if (bitsPerIndex > 8) {
@@ -967,7 +967,7 @@ bool SamplerJitCache::Jit_ReadClutColor(const SamplerID &id) {
 
 	MOV(PTRBITS, R(tempReg1), ImmPtr(clut));
 
-	switch ((GEPaletteFormat)id.clutfmt) {
+	switch (id.ClutFmt()) {
 	case GE_CMODE_16BIT_BGR5650:
 		MOVZX(32, 16, resultReg, MComplex(tempReg1, resultReg, SCALE_2, 0));
 		return Jit_Decode5650();


### PR DESCRIPTION
Oops, can't use unions in bitfields (it just made those aligned bytes it seemed.)  Also improve typesafety.

This was causing fullKey to not fully cover the struct, and more importantly not clear the higher bits when set to zero.

-[Unknown]