### PR TITLE
Implement a jit for drawing pixels in the software renderer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1393,6 +1393,7 @@ list(APPEND CoreExtra
 	Core/MIPS/x86/RegCacheFPU.cpp
 	Core/MIPS/x86/RegCacheFPU.h
 	GPU/Common/VertexDecoderX86.cpp
+	GPU/Software/DrawPixelX86.cpp
 	GPU/Software/SamplerX86.cpp
 )
 

--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -1819,8 +1819,13 @@ void XEmitter::PCMPGTB(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0x64, dest, ar
 void XEmitter::PCMPGTW(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0x65, dest, arg);}
 void XEmitter::PCMPGTD(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0x66, dest, arg);}
 
-void XEmitter::PEXTRW(X64Reg dest, OpArg arg, u8 subreg)    {WriteSSEOp(0x66, 0xC5, dest, arg, 1); Write8(subreg);}
+void XEmitter::PEXTRW(X64Reg dest, X64Reg arg, u8 subreg)   {WriteSSEOp(0x66, 0xC5, dest, R(arg), 1); Write8(subreg);}
 void XEmitter::PINSRW(X64Reg dest, OpArg arg, u8 subreg)    {WriteSSEOp(0x66, 0xC4, dest, arg, 1); Write8(subreg);}
+void XEmitter::PEXTRB(OpArg dest, X64Reg arg, u8 subreg)    {WriteSSE41Op(0x66, 0x3A14, arg, dest, 1); Write8(subreg);}
+void XEmitter::PEXTRW(OpArg dest, X64Reg arg, u8 subreg)    {WriteSSE41Op(0x66, 0x3A15, arg, dest, 1); Write8(subreg);}
+void XEmitter::PEXTRD(OpArg dest, X64Reg arg, u8 subreg)    {WriteSSE41Op(0x66, 0x3A16, arg, dest, 1); Write8(subreg);}
+void XEmitter::PINSRB(X64Reg dest, OpArg arg, u8 subreg)    {WriteSSE41Op(0x66, 0x3A20, dest, arg, 1); Write8(subreg);}
+void XEmitter::PINSRD(X64Reg dest, OpArg arg, u8 subreg)    {WriteSSE41Op(0x66, 0x3A22, dest, arg, 1); Write8(subreg);}
 
 void XEmitter::PMADDWD(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0xF5, dest, arg); }
 void XEmitter::PSADBW(X64Reg dest, OpArg arg)   {WriteSSEOp(0x66, 0xF6, dest, arg);}

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -798,8 +798,14 @@ public:
 	void PCMPGTW(X64Reg dest, OpArg arg);
 	void PCMPGTD(X64Reg dest, OpArg arg);
 
-	void PEXTRW(X64Reg dest, OpArg arg, u8 subreg);
+	void PEXTRW(X64Reg dest, X64Reg arg, u8 subreg);
 	void PINSRW(X64Reg dest, OpArg arg, u8 subreg);
+	// SSE4 inserts and extracts.
+	void PEXTRB(OpArg dest, X64Reg arg, u8 subreg);
+	void PEXTRW(OpArg dest, X64Reg arg, u8 subreg);
+	void PEXTRD(OpArg dest, X64Reg arg, u8 subreg);
+	void PINSRB(X64Reg dest, OpArg arg, u8 subreg);
+	void PINSRD(X64Reg dest, OpArg arg, u8 subreg);
 
 	void PMADDWD(X64Reg dest, OpArg arg);
 	void PSADBW(X64Reg dest, OpArg arg);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -847,6 +847,7 @@ static ConfigSetting graphicsSettings[] = {
 	ConfigSetting("VendorBugChecksEnabled", &g_Config.bVendorBugChecksEnabled, true, false, false),
 	ReportedConfigSetting("RenderingMode", &g_Config.iRenderingMode, 1, true, true),
 	ConfigSetting("SoftwareRenderer", &g_Config.bSoftwareRendering, false, true, true),
+	ConfigSetting("SoftwareRendererJit", &g_Config.bSoftwareRenderingJit, true, true, true),
 	ReportedConfigSetting("HardwareTransform", &g_Config.bHardwareTransform, true, true, true),
 	ReportedConfigSetting("SoftwareSkinning", &g_Config.bSoftwareSkinning, true, true, true),
 	ReportedConfigSetting("TextureFiltering", &g_Config.iTexFiltering, 1, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -155,6 +155,7 @@ public:
 	std::string sMicDevice;
 
 	bool bSoftwareRendering;
+	bool bSoftwareRenderingJit;
 	bool bHardwareTransform; // only used in the GLES backend
 	bool bSoftwareSkinning;  // may speed up some games
 	bool bVendorBugChecksEnabled;

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -631,6 +631,7 @@
     <ClCompile Include="Math3D.cpp" />
     <ClCompile Include="Software\Clipper.cpp" />
     <ClCompile Include="Software\DrawPixel.cpp" />
+    <ClCompile Include="Software\DrawPixelX86.cpp" />
     <ClCompile Include="Software\Lighting.cpp" />
     <ClCompile Include="Software\FuncId.cpp" />
     <ClCompile Include="Software\Rasterizer.cpp" />

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -542,5 +542,8 @@
     <ClCompile Include="Software\DrawPixel.cpp">
       <Filter>Software</Filter>
     </ClCompile>
+    <ClCompile Include="Software\DrawPixelX86.cpp">
+      <Filter>Software</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -580,6 +580,7 @@ void PixelRegCache::Release(PixelRegCache::Reg r, PixelRegCache::Type t, PixelRe
 	for (auto &reg : regs) {
 		if (reg.reg == r && reg.type == t) {
 			_assert_msg_(reg.locked > 0, "softjit Release() reg that isn't locked");
+			_assert_msg_(!reg.forceLocked, "softjit Release() reg that is force locked");
 			reg.purpose = p;
 			reg.locked--;
 			return;

--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -696,6 +696,9 @@ PixelRegCache::Reg PixelRegCache::Alloc(PixelRegCache::Purpose p, PixelRegCache:
 			best = &reg;
 			break;
 		}
+		// But also prefer a lower priority reg.
+		if (reg.purpose < best->purpose)
+			best = &reg;
 	}
 
 	if (best) {

--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -377,8 +377,8 @@ static inline u32 ApplyLogicOp(GELogicOp op, u32 old_color, u32 new_color) {
 }
 
 template <bool clearMode, GEBufferFormat fbFormat>
-inline void DrawSinglePixel(int x, int y, int z, int fog, const Vec4<int> &color_in, const PixelFuncID &pixelID) {
-	Vec4<int> prim_color = color_in.Clamp(0, 255);
+void SOFTPIXEL_CALL DrawSinglePixel(int x, int y, int z, int fog, SOFTPIXEL_VEC4I color_in, const PixelFuncID &pixelID) {
+	Vec4<int> prim_color = Vec4<int>(color_in).Clamp(0, 255);
 	// Depth range test - applied in clear mode, if not through mode.
 	if (pixelID.applyDepthRange)
 		if (z < gstate.getDepthRangeMin() || z > gstate.getDepthRangeMax())

--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -590,18 +590,11 @@ void ComputePixelBlendState(PixelBlendState &state, const PixelFuncID &id) {
 
 	if (state.usesFactors) {
 		switch (id.AlphaBlendSrc()) {
-		case GE_SRCBLEND_SRCALPHA:
-		case GE_SRCBLEND_INVSRCALPHA:
-		case GE_SRCBLEND_DOUBLESRCALPHA:
-		case GE_SRCBLEND_DOUBLEINVSRCALPHA:
-			state.srcFactorUsesSrcAlpha = true;
-			break;
-
 		case GE_SRCBLEND_DSTALPHA:
 		case GE_SRCBLEND_INVDSTALPHA:
 		case GE_SRCBLEND_DOUBLEDSTALPHA:
 		case GE_SRCBLEND_DOUBLEINVDSTALPHA:
-			state.srcFactorUsesDstAlpha = true;
+			state.usesDstAlpha = true;
 			break;
 
 		default:
@@ -609,18 +602,30 @@ void ComputePixelBlendState(PixelBlendState &state, const PixelFuncID &id) {
 		}
 
 		switch (id.AlphaBlendDst()) {
-		case GE_DSTBLEND_SRCALPHA:
 		case GE_DSTBLEND_INVSRCALPHA:
-		case GE_DSTBLEND_DOUBLESRCALPHA:
+			state.dstFactorIsInverse = id.AlphaBlendSrc() == GE_SRCBLEND_SRCALPHA;
+			break;
+
 		case GE_DSTBLEND_DOUBLEINVSRCALPHA:
-			state.dstFactorUsesSrcAlpha = true;
+			state.dstFactorIsInverse = id.AlphaBlendSrc() == GE_SRCBLEND_DOUBLESRCALPHA;
 			break;
 
 		case GE_DSTBLEND_DSTALPHA:
+			state.usesDstAlpha = true;
+			break;
+
 		case GE_DSTBLEND_INVDSTALPHA:
+			state.dstFactorIsInverse = id.AlphaBlendSrc() == GE_SRCBLEND_DSTALPHA;
+			state.usesDstAlpha = true;
+			break;
+
 		case GE_DSTBLEND_DOUBLEDSTALPHA:
+			state.usesDstAlpha = true;
+			break;
+
 		case GE_DSTBLEND_DOUBLEINVDSTALPHA:
-			state.dstFactorUsesDstAlpha = true;
+			state.dstFactorIsInverse = id.AlphaBlendSrc() == GE_SRCBLEND_DOUBLEDSTALPHA;
+			state.usesDstAlpha = true;
 			break;
 
 		default:

--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -515,7 +515,8 @@ PixelJitCache::PixelJitCache()
 	: fp(this)
 #endif
 {
-	AllocCodeSpace(1024 * 256 * 4);
+	// 256k should be plenty of space for plenty of variations.
+	AllocCodeSpace(1024 * 64 * 4);
 
 	// Add some random code to "help" MSVC's buggy disassembler :(
 #if defined(_WIN32) && (PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)) && !PPSSPP_PLATFORM(UWP)
@@ -558,7 +559,7 @@ SingleFunc PixelJitCache::GetSingle(const PixelFuncID &id) {
 		return it->second;
 	}
 
-	// TODO: What should be the min size?  Can we even hit this?
+	// x64 is typically 200-500 bytes, but let's be safe.
 	if (GetSpaceLeft() < 65536) {
 		Clear();
 	}

--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -17,6 +17,7 @@
 
 #include <mutex>
 #include "Common/Data/Convert/ColorConv.h"
+#include "Core/Config.h"
 #include "GPU/GPUState.h"
 #include "GPU/Software/DrawPixel.h"
 #include "GPU/Software/FuncId.h"
@@ -563,13 +564,14 @@ SingleFunc PixelJitCache::GetSingle(const PixelFuncID &id) {
 	}
 
 #if PPSSPP_ARCH(AMD64) && !PPSSPP_PLATFORM(UWP)
-	addresses_[id] = GetCodePointer();
-	SingleFunc func = CompileSingle(id);
-	cache_[id] = func;
-	return func;
-#else
-	return nullptr;
+	if (g_Config.bSoftwareRenderingJit) {
+		addresses_[id] = GetCodePointer();
+		SingleFunc func = CompileSingle(id);
+		cache_[id] = func;
+		return func;
+	}
 #endif
+	return nullptr;
 }
 
 void PixelRegCache::Reset() {

--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -574,6 +574,61 @@ SingleFunc PixelJitCache::GetSingle(const PixelFuncID &id) {
 	return nullptr;
 }
 
+void ComputePixelBlendState(PixelBlendState &state, const PixelFuncID &id) {
+	switch (id.AlphaBlendEq()) {
+	case GE_BLENDMODE_MUL_AND_ADD:
+	case GE_BLENDMODE_MUL_AND_SUBTRACT:
+	case GE_BLENDMODE_MUL_AND_SUBTRACT_REVERSE:
+		state.usesFactors = true;
+		break;
+
+	case GE_BLENDMODE_MIN:
+	case GE_BLENDMODE_MAX:
+	case GE_BLENDMODE_ABSDIFF:
+		break;
+	}
+
+	if (state.usesFactors) {
+		switch (id.AlphaBlendSrc()) {
+		case GE_SRCBLEND_SRCALPHA:
+		case GE_SRCBLEND_INVSRCALPHA:
+		case GE_SRCBLEND_DOUBLESRCALPHA:
+		case GE_SRCBLEND_DOUBLEINVSRCALPHA:
+			state.srcFactorUsesSrcAlpha = true;
+			break;
+
+		case GE_SRCBLEND_DSTALPHA:
+		case GE_SRCBLEND_INVDSTALPHA:
+		case GE_SRCBLEND_DOUBLEDSTALPHA:
+		case GE_SRCBLEND_DOUBLEINVDSTALPHA:
+			state.srcFactorUsesDstAlpha = true;
+			break;
+
+		default:
+			break;
+		}
+
+		switch (id.AlphaBlendDst()) {
+		case GE_DSTBLEND_SRCALPHA:
+		case GE_DSTBLEND_INVSRCALPHA:
+		case GE_DSTBLEND_DOUBLESRCALPHA:
+		case GE_DSTBLEND_DOUBLEINVSRCALPHA:
+			state.dstFactorUsesSrcAlpha = true;
+			break;
+
+		case GE_DSTBLEND_DSTALPHA:
+		case GE_DSTBLEND_INVDSTALPHA:
+		case GE_DSTBLEND_DOUBLEDSTALPHA:
+		case GE_DSTBLEND_DOUBLEINVDSTALPHA:
+			state.dstFactorUsesDstAlpha = true;
+			break;
+
+		default:
+			break;
+		}
+	}
+}
+
 void PixelRegCache::Reset() {
 	regs.clear();
 }

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -63,10 +63,10 @@ bool DescribeCodePtr(const u8 *ptr, std::string &name);
 struct PixelRegCache {
 	enum Purpose {
 		INVALID,
+		ZERO,
+		SRC_ALPHA,
 		GSTATE,
 		CONST_BASE,
-		SRC_ALPHA,
-		DST_ALPHA,
 		STENCIL,
 		COLOR_OFF,
 		DEPTH_OFF,
@@ -155,6 +155,7 @@ private:
 
 	PixelRegCache::Reg GetGState();
 	PixelRegCache::Reg GetConstBase();
+	PixelRegCache::Reg GetZeroVec();
 	// Note: these may require a temporary reg.
 	PixelRegCache::Reg GetColorOff(const PixelFuncID &id);
 	PixelRegCache::Reg GetDepthOff(const PixelFuncID &id);

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -135,9 +135,19 @@ private:
 	PixelRegCache::Reg GetGState();
 	PixelRegCache::Reg GetConstBase();
 
+	bool Jit_ApplyDepthRange(const PixelFuncID &id);
+	bool Jit_AlphaTest(const PixelFuncID &id);
+	bool Jit_ApplyFog(const PixelFuncID &id);
+
 	std::unordered_map<PixelFuncID, SingleFunc> cache_;
 	std::unordered_map<PixelFuncID, const u8 *> addresses_;
 	PixelRegCache regCache_;
+
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+	void Discard(Gen::CCFlags cc);
+
+	std::vector<Gen::FixupBranch> discards_;
+#endif
 };
 
 };

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -37,7 +37,21 @@
 
 namespace Rasterizer {
 
-typedef void (*SingleFunc)(int x, int y, int z, int fog, const Math3D::Vec4<int> &color_in, const PixelFuncID &pixelID);
+#if PPSSPP_ARCH(AMD64) && PPSSPP_PLATFORM(WINDOWS) && (defined(_MSC_VER) || defined(__clang__))
+#define SOFTPIXEL_CALL __vectorcall
+#define SOFTPIXEL_VEC4I __m128i
+#define SOFTPIXEL_TO_VEC4I(x) (x).ivec
+#elif PPSSPP_ARCH(AMD64)
+#define SOFTPIXEL_CALL
+#define SOFTPIXEL_VEC4I __m128i
+#define SOFTPIXEL_TO_VEC4I(x) (x).ivec
+#else
+#define SOFTPIXEL_CALL
+#define SOFTPIXEL_VEC4I const Math3D::Vec4<int> &
+#define SOFTPIXEL_TO_VEC4I(x) (x)
+#endif
+
+typedef void (SOFTPIXEL_CALL *SingleFunc)(int x, int y, int z, int fog, SOFTPIXEL_VEC4I color_in, const PixelFuncID &pixelID);
 SingleFunc GetSingleFunc(const PixelFuncID &id);
 
 void Init();

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -138,6 +138,7 @@ private:
 	bool Jit_ApplyDepthRange(const PixelFuncID &id);
 	bool Jit_AlphaTest(const PixelFuncID &id);
 	bool Jit_ApplyFog(const PixelFuncID &id);
+	bool Jit_ColorTest(const PixelFuncID &id);
 
 	std::unordered_map<PixelFuncID, SingleFunc> cache_;
 	std::unordered_map<PixelFuncID, const u8 *> addresses_;

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -45,4 +45,35 @@ void Shutdown();
 
 bool DescribeCodePtr(const u8 *ptr, std::string &name);
 
+#if PPSSPP_ARCH(ARM)
+class PixelJitCache : public ArmGen::ARMXCodeBlock {
+#elif PPSSPP_ARCH(ARM64)
+class PixelJitCache : public Arm64Gen::ARM64CodeBlock {
+#elif PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+class PixelJitCache : public Gen::XCodeBlock {
+#elif PPSSPP_ARCH(MIPS)
+class PixelJitCache : public MIPSGen::MIPSCodeBlock {
+#else
+class PixelJitCache : public FakeGen::FakeXCodeBlock {
+#endif
+public:
+	PixelJitCache();
+
+	// Returns a pointer to the code to run.
+	SingleFunc GetSingle(const PixelFuncID &id);
+	void Clear();
+
+	std::string DescribeCodePtr(const u8 *ptr);
+
+private:
+	SingleFunc CompileSingle(const PixelFuncID &id);
+
+#if PPSSPP_ARCH(ARM64)
+	Arm64Gen::ARM64FloatEmitter fp;
+#endif
+
+	std::unordered_map<PixelFuncID, SingleFunc> cache_;
+	std::unordered_map<PixelFuncID, const u8 *> addresses_;
+};
+
 };

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -66,6 +66,7 @@ struct PixelRegCache {
 		GSTATE,
 		CONST_BASE,
 		ALPHA,
+		STENCIL,
 		COLOR_OFF,
 		DEPTH_OFF,
 
@@ -142,17 +143,26 @@ private:
 	// Note: these may require a temporary reg.
 	PixelRegCache::Reg GetColorOff(const PixelFuncID &id);
 	PixelRegCache::Reg GetDepthOff(const PixelFuncID &id);
+	PixelRegCache::Reg GetDestStencil(const PixelFuncID &id);
 
 	bool Jit_ApplyDepthRange(const PixelFuncID &id);
 	bool Jit_AlphaTest(const PixelFuncID &id);
 	bool Jit_ApplyFog(const PixelFuncID &id);
 	bool Jit_ColorTest(const PixelFuncID &id);
+	bool Jit_StencilAndDepthTest(const PixelFuncID &id);
+	bool Jit_StencilTest(const PixelFuncID &id, PixelRegCache::Reg stencilReg, PixelRegCache::Reg maskedReg);
+	bool Jit_DepthTestForStencil(const PixelFuncID &id, PixelRegCache::Reg stencilReg);
+	bool Jit_ApplyStencilOp(const PixelFuncID &id, GEStencilOp op, PixelRegCache::Reg stencilReg);
+	bool Jit_WriteStencilOnly(const PixelFuncID &id, PixelRegCache::Reg stencilReg);
+	bool Jit_DepthTest(const PixelFuncID &id);
+	bool Jit_WriteDepth(const PixelFuncID &id);
 
 	std::unordered_map<PixelFuncID, SingleFunc> cache_;
 	std::unordered_map<PixelFuncID, const u8 *> addresses_;
 	PixelRegCache regCache_;
 
 #if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+	void Discard();
 	void Discard(Gen::CCFlags cc);
 
 	std::vector<Gen::FixupBranch> discards_;

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -76,6 +76,7 @@ struct PixelRegCache {
 		TEMP3,
 		TEMP4,
 		TEMP5,
+		TEMP_HELPER,
 	};
 	enum Type {
 		T_GEN,
@@ -138,6 +139,9 @@ private:
 
 	PixelRegCache::Reg GetGState();
 	PixelRegCache::Reg GetConstBase();
+	// Note: these may require a temporary reg.
+	PixelRegCache::Reg GetColorOff(const PixelFuncID &id);
+	PixelRegCache::Reg GetDepthOff(const PixelFuncID &id);
 
 	bool Jit_ApplyDepthRange(const PixelFuncID &id);
 	bool Jit_AlphaTest(const PixelFuncID &id);

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -106,7 +106,12 @@ struct PixelRegCache {
 	Reg Alloc(Purpose p, Type t);
 	void ForceLock(Purpose p, Type t, bool state = true);
 
+	// For getting a specific reg.  WARNING: May return a locked reg, so you have to check.
+	void GrabReg(Reg r, Purpose p, Type t, bool &needsSwap, Reg swapReg);
+
 private:
+	RegStatus *FindReg(Reg r, Type t);
+
 	std::vector<RegStatus> regs;
 };
 
@@ -156,6 +161,8 @@ private:
 	bool Jit_WriteStencilOnly(const PixelFuncID &id, PixelRegCache::Reg stencilReg);
 	bool Jit_DepthTest(const PixelFuncID &id);
 	bool Jit_WriteDepth(const PixelFuncID &id);
+	bool Jit_AlphaBlend(const PixelFuncID &id);
+	bool Jit_Dither(const PixelFuncID &id);
 
 	std::unordered_map<PixelFuncID, SingleFunc> cache_;
 	std::unordered_map<PixelFuncID, const u8 *> addresses_;

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -164,6 +164,7 @@ private:
 	bool Jit_AlphaBlend(const PixelFuncID &id);
 	bool Jit_Dither(const PixelFuncID &id);
 	bool Jit_WriteColor(const PixelFuncID &id);
+	bool Jit_ApplyLogicOp(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg maskReg);
 	bool Jit_ConvertTo565(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg temp1Reg, PixelRegCache::Reg temp2Reg);
 	bool Jit_ConvertTo5551(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg temp1Reg, PixelRegCache::Reg temp2Reg, bool keepAlpha);
 	bool Jit_ConvertTo4444(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg temp1Reg, PixelRegCache::Reg temp2Reg, bool keepAlpha);
@@ -176,7 +177,10 @@ private:
 	void Discard();
 	void Discard(Gen::CCFlags cc);
 
+	// Used for any test failure.
 	std::vector<Gen::FixupBranch> discards_;
+	// Used in Jit_ApplyLogicOp() to skip the standard MOV/OR write.
+	std::vector<Gen::FixupBranch> skipStandardWrites_;
 #endif
 };
 

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -66,6 +66,8 @@ struct PixelRegCache {
 		GSTATE,
 		CONST_BASE,
 		ALPHA,
+		COLOR_OFF,
+		DEPTH_OFF,
 
 		// Above this can only be temps.
 		TEMP0,
@@ -90,15 +92,17 @@ struct PixelRegCache {
 		Reg reg;
 		Purpose purpose;
 		Type type;
-		bool locked = false;
+		uint8_t locked = 0;
+		bool forceLocked = false;
 	};
 
 	void Reset();
-	void Release(Reg r, Type t);
+	void Release(Reg r, Type t, Purpose p = INVALID);
 	void Unlock(Reg r, Type t);
 	bool Has(Purpose p, Type t);
 	Reg Find(Purpose p, Type t);
 	Reg Alloc(Purpose p, Type t);
+	void ForceLock(Purpose p, Type t, bool state = true);
 
 private:
 	std::vector<RegStatus> regs;

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -195,6 +195,7 @@ private:
 	std::vector<Gen::FixupBranch> discards_;
 	// Used in Jit_ApplyLogicOp() to skip the standard MOV/OR write.
 	std::vector<Gen::FixupBranch> skipStandardWrites_;
+	bool colorIs16Bit_ = false;
 #endif
 };
 

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -163,6 +163,7 @@ private:
 	bool Jit_WriteDepth(const PixelFuncID &id);
 	bool Jit_AlphaBlend(const PixelFuncID &id);
 	bool Jit_Dither(const PixelFuncID &id);
+	bool Jit_WriteColor(const PixelFuncID &id);
 
 	std::unordered_map<PixelFuncID, SingleFunc> cache_;
 	std::unordered_map<PixelFuncID, const u8 *> addresses_;

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -118,10 +118,8 @@ private:
 
 struct PixelBlendState {
 	bool usesFactors = false;
-	bool srcFactorUsesSrcAlpha = false;
-	bool srcFactorUsesDstAlpha = false;
-	bool dstFactorUsesSrcAlpha = false;
-	bool dstFactorUsesDstAlpha = false;
+	bool usesDstAlpha = false;
+	bool dstFactorIsInverse = false;
 };
 void ComputePixelBlendState(PixelBlendState &state, const PixelFuncID &id);
 
@@ -173,7 +171,8 @@ private:
 	bool Jit_DepthTest(const PixelFuncID &id);
 	bool Jit_WriteDepth(const PixelFuncID &id);
 	bool Jit_AlphaBlend(const PixelFuncID &id);
-	bool Jit_BlendFactor(const PixelFuncID &id, PixelRegCache::Reg factorReg, PixelRegCache::Reg dstReg, GEBlendSrcFactor factor, bool useDstFactor);
+	bool Jit_BlendFactor(const PixelFuncID &id, PixelRegCache::Reg factorReg, PixelRegCache::Reg dstReg, GEBlendSrcFactor factor);
+	bool Jit_DstBlendFactor(const PixelFuncID &id, PixelRegCache::Reg srcFactorReg, PixelRegCache::Reg dstFactorReg, PixelRegCache::Reg dstReg);
 	bool Jit_Dither(const PixelFuncID &id);
 	bool Jit_WriteColor(const PixelFuncID &id);
 	bool Jit_ApplyLogicOp(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg maskReg);

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -65,7 +65,8 @@ struct PixelRegCache {
 		INVALID,
 		GSTATE,
 		CONST_BASE,
-		ALPHA,
+		SRC_ALPHA,
+		DST_ALPHA,
 		STENCIL,
 		COLOR_OFF,
 		DEPTH_OFF,
@@ -114,6 +115,15 @@ private:
 
 	std::vector<RegStatus> regs;
 };
+
+struct PixelBlendState {
+	bool usesFactors = false;
+	bool srcFactorUsesSrcAlpha = false;
+	bool srcFactorUsesDstAlpha = false;
+	bool dstFactorUsesSrcAlpha = false;
+	bool dstFactorUsesDstAlpha = false;
+};
+void ComputePixelBlendState(PixelBlendState &state, const PixelFuncID &id);
 
 #if PPSSPP_ARCH(ARM)
 class PixelJitCache : public ArmGen::ARMXCodeBlock {
@@ -168,6 +178,9 @@ private:
 	bool Jit_ConvertTo565(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg temp1Reg, PixelRegCache::Reg temp2Reg);
 	bool Jit_ConvertTo5551(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg temp1Reg, PixelRegCache::Reg temp2Reg, bool keepAlpha);
 	bool Jit_ConvertTo4444(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg temp1Reg, PixelRegCache::Reg temp2Reg, bool keepAlpha);
+	bool Jit_ConvertFrom565(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg temp1Reg, PixelRegCache::Reg temp2Reg);
+	bool Jit_ConvertFrom5551(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg temp1Reg, PixelRegCache::Reg temp2Reg, bool keepAlpha);
+	bool Jit_ConvertFrom4444(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg temp1Reg, PixelRegCache::Reg temp2Reg, bool keepAlpha);
 
 	std::unordered_map<PixelFuncID, SingleFunc> cache_;
 	std::unordered_map<PixelFuncID, const u8 *> addresses_;

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -173,6 +173,7 @@ private:
 	bool Jit_DepthTest(const PixelFuncID &id);
 	bool Jit_WriteDepth(const PixelFuncID &id);
 	bool Jit_AlphaBlend(const PixelFuncID &id);
+	bool Jit_BlendFactor(const PixelFuncID &id, PixelRegCache::Reg factorReg, PixelRegCache::Reg dstReg, GEBlendSrcFactor factor, bool useDstFactor);
 	bool Jit_Dither(const PixelFuncID &id);
 	bool Jit_WriteColor(const PixelFuncID &id);
 	bool Jit_ApplyLogicOp(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg maskReg);

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -164,6 +164,9 @@ private:
 	bool Jit_AlphaBlend(const PixelFuncID &id);
 	bool Jit_Dither(const PixelFuncID &id);
 	bool Jit_WriteColor(const PixelFuncID &id);
+	bool Jit_ConvertTo565(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg temp1Reg, PixelRegCache::Reg temp2Reg);
+	bool Jit_ConvertTo5551(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg temp1Reg, PixelRegCache::Reg temp2Reg, bool keepAlpha);
+	bool Jit_ConvertTo4444(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg temp1Reg, PixelRegCache::Reg temp2Reg, bool keepAlpha);
 
 	std::unordered_map<PixelFuncID, SingleFunc> cache_;
 	std::unordered_map<PixelFuncID, const u8 *> addresses_;

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -29,7 +29,43 @@ using namespace Gen;
 
 namespace Rasterizer {
 
+#if PPSSPP_PLATFORM(WINDOWS)
+static const X64Reg argXReg = RCX;
+static const X64Reg argYReg = RDX;
+static const X64Reg argZReg = R8;
+static const X64Reg argFogReg = R9;
+static const X64Reg argColorReg = XMM4;
+
+// Must save: RBX, RSP, RBP, RDI, RSI, R12-R15, XMM6-15
+#else
+static const X64Reg argXReg = RDI;
+static const X64Reg argYReg = RSI;
+static const X64Reg argZReg = RDX;
+static const X64Reg argFogReg = RCX;
+static const X64Reg argColorReg = XMM0;
+
+// Must save: RBX, RSP, RBP, R12-R15
+#endif
+
 SingleFunc PixelJitCache::CompileSingle(const PixelFuncID &id) {
+	// Setup the reg cache.
+	regCache_.Reset();
+	regCache_.Release(RAX, PixelRegCache::T_GEN);
+	regCache_.Release(R10, PixelRegCache::T_GEN);
+	regCache_.Release(R11, PixelRegCache::T_GEN);
+	regCache_.Release(XMM1, PixelRegCache::T_VEC);
+	regCache_.Release(XMM2, PixelRegCache::T_VEC);
+	regCache_.Release(XMM3, PixelRegCache::T_VEC);
+	regCache_.Release(XMM5, PixelRegCache::T_VEC);
+
+#if !PPSSPP_PLATFORM(WINDOWS)
+	regCache_.Release(R8, PixelRegCache::T_GEN);
+	regCache_.Release(R9, PixelRegCache::T_GEN);
+	regCache_.Release(XMM4, PixelRegCache::T_VEC);
+#else
+	regCache_.Release(XMM0, PixelRegCache::T_VEC);
+#endif
+
 	return nullptr;
 }
 

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -953,7 +953,7 @@ bool PixelJitCache::Jit_Dither(const PixelFuncID &id) {
 
 	// Load the row dither matrix entry (will still need to get the X.)
 	MOV(32, R(valueReg), R(argYReg));
-	AND(8, R(valueReg), Imm8(3));
+	AND(32, R(valueReg), Imm8(3));
 	MOVZX(32, 16, valueReg, MComplex(gstateReg, valueReg, 4, offsetof(GPUgstate, dithmtx)));
 	regCache_.Unlock(gstateReg, PixelRegCache::T_GEN);
 
@@ -990,6 +990,7 @@ bool PixelJitCache::Jit_Dither(const PixelFuncID &id) {
 
 	// Now we need to make 0-7 positive, 8-F negative.. so sign extend.
 	SHL(32, R(valueReg), Imm8(4));
+	MOVSX(32, 8, valueReg, R(valueReg));
 	SAR(8, R(valueReg), Imm8(4));
 
 	// Copy that value into a vec to add to the color.

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -1072,7 +1072,7 @@ bool PixelJitCache::Jit_Dither(const PixelFuncID &id) {
 		regCache_.GrabReg(RCX, PixelRegCache::TEMP1, PixelRegCache::T_GEN, needsSwap, argXReg);
 
 		if (needsSwap) {
-			XCHG(PTRBITS, R(RCX), R(argXReg));
+			XCHG(PTRBITS, R(argXReg), R(RCX));
 			if (valueReg == RCX)
 				valueReg = argXReg;
 		} else {

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -21,6 +21,7 @@
 #include <emmintrin.h>
 #include "Common/x64Emitter.h"
 #include "Common/CPUDetect.h"
+#include "Core/Reporting.h"
 #include "GPU/GPUState.h"
 #include "GPU/Software/DrawPixel.h"
 #include "GPU/Software/SoftGpu.h"
@@ -133,6 +134,8 @@ SingleFunc PixelJitCache::CompileSingle(const PixelFuncID &id) {
 	discards_.clear();
 
 	if (!success) {
+		ERROR_LOG_REPORT(G3D, "Could not compile pixel func: %s", DescribePixelFuncID(id).c_str());
+
 		EndWrite();
 		ResetCodePtr(GetOffset(start));
 		return nullptr;
@@ -816,7 +819,7 @@ bool PixelJitCache::Jit_ApplyStencilOp(const PixelFuncID &id, GEStencilOp op, Pi
 		break;
 	}
 
-	return false;
+	return true;
 }
 
 bool PixelJitCache::Jit_WriteStencilOnly(const PixelFuncID &id, PixelRegCache::Reg stencilReg) {
@@ -1111,7 +1114,7 @@ bool PixelJitCache::Jit_AlphaBlend(const PixelFuncID &id) {
 	regCache_.Release(tempReg, PixelRegCache::T_VEC);
 	regCache_.Release(dstReg, PixelRegCache::T_VEC);
 
-	return true;
+	return success;
 }
 
 

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -182,7 +182,7 @@ PixelRegCache::Reg PixelJitCache::GetColorOff(const PixelFuncID &id) {
 		MOVZX(32, 16, r, MDisp(gstateReg, offsetof(GPUgstate, fbwidth)));
 		regCache_.Unlock(gstateReg, PixelRegCache::T_GEN);
 
-		AND(32, R(r), Imm32(0x000007FC));
+		AND(16, R(r), Imm16(0x07FC));
 		IMUL(32, r, R(argYReg));
 		ADD(32, R(r), R(argXReg));
 
@@ -211,7 +211,7 @@ PixelRegCache::Reg PixelJitCache::GetDepthOff(const PixelFuncID &id) {
 		MOVZX(32, 16, r, MDisp(gstateReg, offsetof(GPUgstate, zbwidth)));
 		regCache_.Unlock(gstateReg, PixelRegCache::T_GEN);
 
-		AND(32, R(r), Imm32(0x000007FC));
+		AND(16, R(r), Imm16(0x07FC));
 		IMUL(32, r, R(argYReg));
 		ADD(32, R(r), R(argXReg));
 
@@ -366,15 +366,15 @@ bool PixelJitCache::Jit_ColorTest(const PixelFuncID &id) {
 
 	// Now that we're setup, get the func and follow it.
 	MOVZX(32, 8, funcReg, MDisp(gstateReg, offsetof(GPUgstate, colortest)));
-	AND(32, R(funcReg), Imm32(3));
+	AND(8, R(funcReg), Imm8(3));
 	regCache_.Unlock(gstateReg, PixelRegCache::T_GEN);
 
-	CMP(32, R(funcReg), Imm32(GE_COMP_ALWAYS));
+	CMP(8, R(funcReg), Imm8(GE_COMP_ALWAYS));
 	// Discard for GE_COMP_NEVER...
 	Discard(CC_B);
 	FixupBranch skip = J_CC(CC_E);
 
-	CMP(32, R(funcReg), Imm32(GE_COMP_EQUAL));
+	CMP(8, R(funcReg), Imm8(GE_COMP_EQUAL));
 	FixupBranch doEqual = J_CC(CC_E);
 	regCache_.Release(funcReg, PixelRegCache::T_GEN);
 

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2017- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "ppsspp_config.h"
+#if PPSSPP_ARCH(AMD64)
+
+#include <emmintrin.h>
+#include "Common/x64Emitter.h"
+#include "Common/CPUDetect.h"
+#include "GPU/GPUState.h"
+#include "GPU/Software/DrawPixel.h"
+#include "GPU/ge_constants.h"
+
+using namespace Gen;
+
+namespace Rasterizer {
+
+SingleFunc PixelJitCache::CompileSingle(const PixelFuncID &id) {
+	return nullptr;
+}
+
+};
+
+#endif

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -344,10 +344,10 @@ bool PixelJitCache::Jit_AlphaTest(const PixelFuncID &id) {
 
 	// Load alpha into its own general reg.
 	X64Reg alphaReg;
-	if (regCache_.Has(PixelRegCache::ALPHA, PixelRegCache::T_GEN)) {
-		alphaReg = regCache_.Find(PixelRegCache::ALPHA, PixelRegCache::T_GEN);
+	if (regCache_.Has(PixelRegCache::SRC_ALPHA, PixelRegCache::T_GEN)) {
+		alphaReg = regCache_.Find(PixelRegCache::SRC_ALPHA, PixelRegCache::T_GEN);
 	} else {
-		alphaReg = regCache_.Alloc(PixelRegCache::ALPHA, PixelRegCache::T_GEN);
+		alphaReg = regCache_.Alloc(PixelRegCache::SRC_ALPHA, PixelRegCache::T_GEN);
 		MOVD_xmm(R(alphaReg), argColorReg);
 		SHR(32, R(alphaReg), Imm8(24));
 	}
@@ -499,10 +499,10 @@ bool PixelJitCache::Jit_ApplyFog(const PixelFuncID &id) {
 
 	// Save A so we can put it back, we don't "fog" A.
 	X64Reg alphaReg;
-	if (regCache_.Has(PixelRegCache::ALPHA, PixelRegCache::T_GEN)) {
-		alphaReg = regCache_.Find(PixelRegCache::ALPHA, PixelRegCache::T_GEN);
+	if (regCache_.Has(PixelRegCache::SRC_ALPHA, PixelRegCache::T_GEN)) {
+		alphaReg = regCache_.Find(PixelRegCache::SRC_ALPHA, PixelRegCache::T_GEN);
 	} else {
-		alphaReg = regCache_.Alloc(PixelRegCache::ALPHA, PixelRegCache::T_GEN);
+		alphaReg = regCache_.Alloc(PixelRegCache::SRC_ALPHA, PixelRegCache::T_GEN);
 		PEXTRW(alphaReg, argColorReg, 3);
 	}
 
@@ -951,8 +951,97 @@ bool PixelJitCache::Jit_AlphaBlend(const PixelFuncID &id) {
 	if (!id.alphaBlend)
 		return true;
 
-	// TODO: Will need old color in some cases, too.
-	return false;
+	// Check if we need to load and prep factors.
+	PixelBlendState blendState;
+	ComputePixelBlendState(blendState, id);
+
+	bool success = true;
+
+	// Step 1: Load and expand dest color.
+	X64Reg dstReg = regCache_.Alloc(PixelRegCache::TEMP0, PixelRegCache::T_VEC);
+	X64Reg colorOff = GetColorOff(id);
+	if (id.FBFormat() == GE_FORMAT_8888) {
+		MOVD_xmm(dstReg, MatR(colorOff));
+		regCache_.Unlock(colorOff, PixelRegCache::T_GEN);
+	} else {
+		X64Reg dstGenReg = regCache_.Alloc(PixelRegCache::TEMP0, PixelRegCache::T_GEN);
+		MOVZX(32, 16, dstGenReg, MatR(colorOff));
+		regCache_.Unlock(colorOff, PixelRegCache::T_GEN);
+
+		bool keepAlpha = blendState.srcFactorUsesDstAlpha || blendState.dstFactorUsesDstAlpha;
+		X64Reg temp1Reg = regCache_.Alloc(PixelRegCache::TEMP1, PixelRegCache::T_GEN);
+		X64Reg temp2Reg = regCache_.Alloc(PixelRegCache::TEMP2, PixelRegCache::T_GEN);
+
+		switch (id.fbFormat) {
+		case GE_FORMAT_565:
+			success = success && Jit_ConvertFrom565(id, dstGenReg, temp1Reg, temp2Reg);
+			break;
+
+		case GE_FORMAT_5551:
+			success = success && Jit_ConvertFrom5551(id, dstGenReg, temp1Reg, temp2Reg, keepAlpha);
+			break;
+
+		case GE_FORMAT_4444:
+			success = success && Jit_ConvertFrom4444(id, dstGenReg, temp1Reg, temp2Reg, keepAlpha);
+
+			break;
+
+		case GE_FORMAT_8888:
+			break;
+		}
+
+		MOVD_xmm(dstReg, R(dstGenReg));
+
+		regCache_.Release(temp1Reg, PixelRegCache::T_GEN);
+		regCache_.Release(temp2Reg, PixelRegCache::T_GEN);
+		regCache_.Release(dstGenReg, PixelRegCache::T_GEN);
+	}
+
+	// Step 2: Load and apply factors.
+	if (blendState.usesFactors) {
+		return false;
+	}
+
+	// Step 3: Apply equation.
+	// Note: below, we completely ignore what happens to the alpha bits.
+	// It won't matter, since we'll replace those with stencil anyway.
+	X64Reg tempReg = regCache_.Alloc(PixelRegCache::TEMP1, PixelRegCache::T_VEC);
+	switch (id.AlphaBlendEq()) {
+	case GE_BLENDMODE_MUL_AND_ADD:
+		// TODO
+		break;
+
+	case GE_BLENDMODE_MUL_AND_SUBTRACT:
+		// TODO
+		break;
+
+	case GE_BLENDMODE_MUL_AND_SUBTRACT_REVERSE:
+		// TODO
+		break;
+
+	case GE_BLENDMODE_MIN:
+		PMINUB(argColorReg, R(dstReg));
+		break;
+
+	case GE_BLENDMODE_MAX:
+		PMAXUB(argColorReg, R(dstReg));
+		break;
+
+	case GE_BLENDMODE_ABSDIFF:
+		// Calculate A=(dst-src < 0 ? 0 : dst-src) and B=(src-dst < 0 ? 0 : src-dst)...
+		MOVDQA(tempReg, R(dstReg));
+		PSUBUSB(tempReg, R(argColorReg));
+		PSUBUSB(argColorReg, R(dstReg));
+
+		// Now, one of those must be zero, and the other one is the result (could also be zero.)
+		POR(argColorReg, R(tempReg));
+		break;
+	}
+
+	regCache_.Release(tempReg, PixelRegCache::T_VEC);
+	regCache_.Release(dstReg, PixelRegCache::T_VEC);
+
+	return true;
 }
 
 bool PixelJitCache::Jit_Dither(const PixelFuncID &id) {
@@ -1651,6 +1740,113 @@ bool PixelJitCache::Jit_ConvertTo4444(const PixelFuncID &id, PixelRegCache::Reg 
 	if (keepAlpha)
 		OR(32, R(colorReg), R(temp2Reg));
 
+	return true;
+}
+
+bool PixelJitCache::Jit_ConvertFrom565(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg temp1Reg, PixelRegCache::Reg temp2Reg) {
+	// Filter out red only into temp1.
+	MOV(32, R(temp1Reg), R(colorReg));
+	AND(16, R(temp1Reg), Imm16(0x1F << 0));
+	// Move it left to the top of the 8 bits.
+	SHL(32, R(temp1Reg), Imm8(3));
+
+	// Now we bring in blue, since it's also 5 like red.
+	MOV(32, R(temp2Reg), R(colorReg));
+	AND(16, R(temp2Reg), Imm16(0x1F << 11));
+	// Shift blue into place, 8 left (at 19), and merge back to temp1.
+	SHL(32, R(temp2Reg), Imm8(8));
+	OR(32, R(temp1Reg), R(temp2Reg));
+
+	// Make a copy back in temp2, and shift left 1 so we can swizzle together with G.
+	OR(32, R(temp2Reg), R(temp1Reg));
+	SHL(32, R(temp2Reg), Imm8(1));
+
+	// We go to green last because it's the different one.  Put it in place.
+	AND(16, R(colorReg), Imm16(0x3F << 5));
+	SHL(32, R(colorReg), Imm8(5));
+	// Combine with temp2 (for swizzling), then merge in temp1 (R+B pre-swizzle.)
+	OR(32, R(temp2Reg), R(colorReg));
+	OR(32, R(colorReg), R(temp1Reg));
+
+	// Now shift and mask temp2 for swizzle.
+	SHR(32, R(temp2Reg), Imm8(6));
+	AND(32, R(temp2Reg), Imm32(0x00070307));
+	// And then OR that in too.  We're done.
+	OR(32, R(colorReg), R(temp2Reg));
+
+	return true;
+}
+
+bool PixelJitCache::Jit_ConvertFrom5551(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg temp1Reg, PixelRegCache::Reg temp2Reg, bool keepAlpha) {
+	// Filter out red only into temp1.
+	MOV(32, R(temp1Reg), R(colorReg));
+	AND(16, R(temp1Reg), Imm16(0x1F << 0));
+	// Move it left to the top of the 8 bits.
+	SHL(32, R(temp1Reg), Imm8(3));
+
+	// Add in green and shift into place (top bits.)
+	MOV(32, R(temp2Reg), R(colorReg));
+	AND(16, R(temp2Reg), Imm16(0x1F << 5));
+	SHL(32, R(temp2Reg), Imm8(6));
+	OR(32, R(temp1Reg), R(temp2Reg));
+
+	if (keepAlpha) {
+		// Now take blue and alpha together.
+		AND(16, R(colorReg), Imm16(0x8000 | (0x1F << 10)));
+		// We move all the way left, then sign extend right to expand alpha.
+		SHL(32, R(colorReg), Imm8(16));
+		SAR(32, R(colorReg), Imm8(7));
+	} else {
+		AND(16, R(colorReg), Imm16(0x1F << 10));
+		SHL(32, R(colorReg), Imm8(9));
+	}
+
+	// Combine both together, we still need to swizzle.
+	OR(32, R(colorReg), R(temp1Reg));
+	OR(32, R(temp1Reg), R(colorReg));
+	// Now for swizzle, we'll mask carefully to avoid overflow.
+	SHR(32, R(temp1Reg), Imm8(5));
+	AND(32, R(temp1Reg), Imm32(0x00070707));
+
+	// Then finally merge in the swizzle bits.
+	OR(32, R(colorReg), R(temp1Reg));
+	return true;
+}
+
+bool PixelJitCache::Jit_ConvertFrom4444(const PixelFuncID &id, PixelRegCache::Reg colorReg, PixelRegCache::Reg temp1Reg, PixelRegCache::Reg temp2Reg, bool keepAlpha) {
+	// Move red into position within temp1.
+	MOV(32, R(temp1Reg), R(colorReg));
+	AND(16, R(temp1Reg), Imm16(0xF << 0));
+	SHL(32, R(temp1Reg), Imm8(4));
+
+	// Green is just as simple.
+	MOV(32, R(temp2Reg), R(colorReg));
+	AND(16, R(temp2Reg), Imm16(0xF << 4));
+	SHL(32, R(temp2Reg), Imm8(8));
+	OR(32, R(temp1Reg), R(temp2Reg));
+
+	// Blue isn't last this time, but it's next.
+	MOV(32, R(temp2Reg), R(colorReg));
+	AND(16, R(temp2Reg), Imm16(0xF << 8));
+	SHL(32, R(temp2Reg), Imm8(12));
+	OR(32, R(temp1Reg), R(temp2Reg));
+
+	if (keepAlpha) {
+		// Last but not least, alpha.
+		AND(16, R(colorReg), Imm16(0xF << 12));
+		SHL(32, R(colorReg), Imm8(16));
+		OR(32, R(colorReg), R(temp1Reg));
+
+		// Copy to temp1 again for swizzling.
+		OR(32, R(temp1Reg), R(colorReg));
+	} else {
+		// Overwrite colorReg (we need temp1 as a copy anyway.)
+		MOV(32, R(colorReg), R(temp1Reg));
+	}
+
+	// Masking isn't necessary here since everything is 4 wide.
+	SHR(32, R(temp1Reg), Imm8(4));
+	OR(32, R(colorReg), R(temp1Reg));
 	return true;
 }
 

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -47,6 +47,24 @@ static const X64Reg argColorReg = XMM0;
 // Must save: RBX, RSP, RBP, R12-R15
 #endif
 
+// This one is the const base.  Also a set of 255s.
+alignas(16) static const uint16_t const255_16s[8] = { 255, 255, 255, 255, 255, 255, 255, 255 };
+// This is used for a multiply that divides by 255 with shifting.
+alignas(16) static const uint16_t by255i[8] = { 0x8081, 0x8081, 0x8081, 0x8081, 0x8081, 0x8081, 0x8081, 0x8081 };
+
+template <typename T>
+static bool ConstAccessible(const T *t) {
+	ptrdiff_t diff = (const uint8_t *)&const255_16s[0] - (const uint8_t *)t;
+	return diff > -0x7FFFFFE0 && diff < 0x7FFFFFE0;
+}
+
+template <typename T>
+static OpArg MConstDisp(X64Reg r, const T *t) {
+	_assert_(ConstAccessible(t));
+	ptrdiff_t diff = (const uint8_t *)&const255_16s[0] - (const uint8_t *)t;
+	return MDisp(r, (int)diff);
+}
+
 SingleFunc PixelJitCache::CompileSingle(const PixelFuncID &id) {
 	// Setup the reg cache.
 	regCache_.Reset();
@@ -66,7 +84,166 @@ SingleFunc PixelJitCache::CompileSingle(const PixelFuncID &id) {
 	regCache_.Release(XMM0, PixelRegCache::T_VEC);
 #endif
 
-	return nullptr;
+	BeginWrite();
+	const u8 *start = AlignCode16();
+	bool success = true;
+
+	// Start with the depth range.
+	success = success && Jit_ApplyDepthRange(id);
+
+	// Next, let's clamp the color (might affect alpha test, and everything expects it clamped.)
+	// We simply convert to 4x8-bit to clamp.  Everything else expects color in this format.
+	PACKSSDW(argColorReg, R(argColorReg));
+	PACKUSWB(argColorReg, R(argColorReg));
+
+	success = success && Jit_AlphaTest(id);
+	// Fog is applied prior to color test.  Maybe before alpha test too, but it doesn't affect it...
+	success = success && Jit_ApplyFog(id);
+
+	// TODO: There's more...
+	success = false;
+
+	for (auto &fixup : discards_) {
+		SetJumpTarget(fixup);
+	}
+	discards_.clear();
+
+	if (!success) {
+		EndWrite();
+		ResetCodePtr(GetOffset(start));
+		return nullptr;
+	}
+
+	EndWrite();
+	return (SingleFunc)start;
+}
+
+PixelRegCache::Reg PixelJitCache::GetGState() {
+	if (!regCache_.Has(PixelRegCache::GSTATE, PixelRegCache::T_GEN)) {
+		X64Reg r = regCache_.Alloc(PixelRegCache::GSTATE, PixelRegCache::T_GEN);
+		MOV(PTRBITS, R(r), ImmPtr(&gstate.nop));
+		return r;
+	}
+	return regCache_.Find(PixelRegCache::GSTATE, PixelRegCache::T_GEN);
+}
+
+PixelRegCache::Reg PixelJitCache::GetConstBase() {
+	if (!regCache_.Has(PixelRegCache::CONST_BASE, PixelRegCache::T_GEN)) {
+		X64Reg r = regCache_.Alloc(PixelRegCache::CONST_BASE, PixelRegCache::T_GEN);
+		MOV(PTRBITS, R(r), ImmPtr(&const255_16s[0]));
+		return r;
+	}
+	return regCache_.Find(PixelRegCache::CONST_BASE, PixelRegCache::T_GEN);
+}
+
+void PixelJitCache::Discard(Gen::CCFlags cc) {
+	discards_.push_back(J_CC(cc, true));
+}
+
+bool PixelJitCache::Jit_ApplyDepthRange(const PixelFuncID &id) {
+	if (id.applyDepthRange) {
+		X64Reg gstateReg = GetGState();
+		X64Reg minReg = regCache_.Alloc(PixelRegCache::TEMP0, PixelRegCache::T_GEN);
+		X64Reg maxReg = regCache_.Alloc(PixelRegCache::TEMP1, PixelRegCache::T_GEN);
+
+		// Only load the lowest 16 bits of each.
+		MOVZX(32, 16, minReg, MDisp(gstateReg, offsetof(GPUgstate, minz)));
+		MOVZX(32, 16, maxReg, MDisp(gstateReg, offsetof(GPUgstate, maxz)));
+
+		CMP(32, R(argZReg), R(minReg));
+		Discard(CC_L);
+		CMP(32, R(argZReg), R(maxReg));
+		Discard(CC_G);
+
+		regCache_.Unlock(gstateReg, PixelRegCache::T_GEN);
+		regCache_.Release(minReg, PixelRegCache::T_GEN);
+		regCache_.Release(maxReg, PixelRegCache::T_GEN);
+	}
+
+	// Since this is early on, try to free up the z reg if we don't need it anymore.
+	if (id.clearMode && !id.DepthClear())
+		regCache_.Release(argZReg, PixelRegCache::T_GEN);
+	else if (!id.clearMode && !id.depthWrite && id.DepthTestFunc() == GE_COMP_ALWAYS)
+		regCache_.Release(argZReg, PixelRegCache::T_GEN);
+
+	return true;
+}
+
+bool PixelJitCache::Jit_AlphaTest(const PixelFuncID &id) {
+	if (id.AlphaTestFunc() == GE_COMP_ALWAYS) {
+		return true;
+	}
+
+	// TODO: Discard(!AlphaTestPassed(pixelID, prim_color.a()));
+	return false;
+}
+
+bool PixelJitCache::Jit_ApplyFog(const PixelFuncID &id) {
+	if (!id.applyFog) {
+		// Okay, anyone can use the fog register then.
+		regCache_.Release(argFogReg, PixelRegCache::T_GEN);
+		return true;
+	}
+
+	// Load fog and expand to 16 bit.  Ignore the high 8 bits, which'll match up with A.
+	X64Reg zeroReg = regCache_.Alloc(PixelRegCache::TEMP0, PixelRegCache::T_VEC);
+	X64Reg fogColorReg = regCache_.Alloc(PixelRegCache::TEMP1, PixelRegCache::T_VEC);
+	PXOR(zeroReg, R(zeroReg));
+	X64Reg gstateReg = GetGState();
+	MOVD_xmm(fogColorReg, MDisp(gstateReg, offsetof(GPUgstate, fogcolor)));
+	regCache_.Unlock(gstateReg, PixelRegCache::T_GEN);
+	PUNPCKLBW(fogColorReg, R(zeroReg));
+
+	// Load a set of 255s at 16 bit into a reg for later...
+	X64Reg invertReg = regCache_.Alloc(PixelRegCache::TEMP2, PixelRegCache::T_VEC);
+	X64Reg constReg = GetConstBase();
+	MOVDQA(invertReg, MConstDisp(constReg, &const255_16s[0]));
+	regCache_.Unlock(constReg, PixelRegCache::T_GEN);
+
+	// Expand (we clamped) color to 16 bit as well, so we can multiply with fog.
+	PUNPCKLBW(argColorReg, R(zeroReg));
+	regCache_.Release(zeroReg, PixelRegCache::T_VEC);
+
+	// Save A so we can put it back, we don't "fog" A.
+	X64Reg alphaReg;
+	if (regCache_.Has(PixelRegCache::ALPHA, PixelRegCache::T_GEN)) {
+		alphaReg = regCache_.Find(PixelRegCache::ALPHA, PixelRegCache::T_GEN);
+	} else {
+		alphaReg = regCache_.Alloc(PixelRegCache::ALPHA, PixelRegCache::T_GEN);
+		PEXTRW(alphaReg, R(argColorReg), 3);
+	}
+
+	// Okay, let's broadcast fog to an XMM.
+	X64Reg fogMultReg = regCache_.Alloc(PixelRegCache::TEMP3, PixelRegCache::T_VEC);
+	MOVD_xmm(fogMultReg, R(argFogReg));
+	PSHUFLW(fogMultReg, R(fogMultReg), _MM_SHUFFLE(0, 0, 0, 0));
+	// We can free up the actual fog reg now.
+	regCache_.Release(argFogReg, PixelRegCache::T_GEN);
+
+	// Now we multiply the existing color by fog...
+	PMULLW(argColorReg, R(fogMultReg));
+	// And then inverse the fog value using those 255s we loaded, and multiply by fog color.
+	PSUBUSW(invertReg, R(fogMultReg));
+	PMULLW(fogColorReg, R(invertReg));
+	// At this point, argColorReg and fogColorReg are multiplied at 16-bit, so we need to sum.
+	PADDUSW(argColorReg, R(fogColorReg));
+	regCache_.Release(fogColorReg, PixelRegCache::T_VEC);
+	regCache_.Release(fogMultReg, PixelRegCache::T_VEC);
+	regCache_.Release(invertReg, PixelRegCache::T_VEC);
+
+	// Now to divide by 255, we use bit tricks: multiply by 0x8081, and shift right by 16+7.
+	constReg = GetConstBase();
+	PMULHUW(argColorReg, MConstDisp(constReg, &by255i));
+	regCache_.Unlock(constReg, PixelRegCache::T_GEN);
+	// Now shift right by 7 (PMULHUW already did 16 of the shift.)
+	PSRLW(argColorReg, 7);
+
+	// Okay, put A back in and shrink to 8888 again.
+	PINSRW(argColorReg, R(alphaReg), 3);
+	PACKUSWB(argColorReg, R(argColorReg));
+	regCache_.Unlock(alphaReg, PixelRegCache::T_GEN);
+
+	return true;
 }
 
 };

--- a/GPU/Software/FuncId.cpp
+++ b/GPU/Software/FuncId.cpp
@@ -15,12 +15,17 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "Common/Data/Convert/ColorConv.h"
 #include "Common/StringUtils.h"
 #include "GPU/Software/FuncId.h"
 #include "GPU/GPUState.h"
 
 static_assert(sizeof(SamplerID) == sizeof(SamplerID::fullKey), "Bad sampler ID size");
+#ifdef SOFTPIXEL_USE_CACHE
+static_assert(sizeof(PixelFuncID) == sizeof(PixelFuncID::fullKey) + sizeof(PixelFuncID::cached), "Bad pixel func ID size");
+#else
 static_assert(sizeof(PixelFuncID) == sizeof(PixelFuncID::fullKey), "Bad pixel func ID size");
+#endif
 
 void ComputePixelFuncID(PixelFuncID *id) {
 	id->fullKey = 0;
@@ -92,6 +97,38 @@ void ComputePixelFuncID(PixelFuncID *id) {
 
 		id->applyLogicOp = gstate.isLogicOpEnabled() && gstate.getLogicOp() != GE_LOGIC_COPY;
 		id->applyFog = gstate.isFogEnabled() && !gstate.isModeThrough();
+	}
+
+	// Cache some values for later convenience.
+	if (id->dithering) {
+		for (int y = 0; y < 4; ++y) {
+			for (int x = 0; x < 4; ++x)
+				id->cached.ditherMatrix[y * 4 + x] = gstate.getDitherValue(x, y);
+		}
+	}
+	if (id->applyColorWriteMask) {
+		uint32_t mask = gstate.getColorMask();
+		// This flag means stencil clear or stencil test, basically whether writing to stencil.
+		if (!id->stencilTest)
+			mask |= 0xFF000000;
+
+		switch (id->fbFormat) {
+		case GE_FORMAT_565:
+			id->cached.colorWriteMask = RGBA8888ToRGB565(mask);
+			break;
+
+		case GE_FORMAT_5551:
+			id->cached.colorWriteMask = RGBA8888ToRGBA5551(mask);
+			break;
+
+		case GE_FORMAT_4444:
+			id->cached.colorWriteMask = RGBA8888ToRGBA4444(mask);
+			break;
+
+		case GE_FORMAT_8888:
+			id->cached.colorWriteMask = mask;
+			break;
+		}
 	}
 }
 

--- a/GPU/Software/FuncId.cpp
+++ b/GPU/Software/FuncId.cpp
@@ -99,6 +99,7 @@ void ComputePixelFuncID(PixelFuncID *id) {
 		id->applyFog = gstate.isFogEnabled() && !gstate.isModeThrough();
 	}
 
+#ifdef SOFTPIXEL_USE_CACHE
 	// Cache some values for later convenience.
 	if (id->dithering) {
 		for (int y = 0; y < 4; ++y) {
@@ -130,6 +131,7 @@ void ComputePixelFuncID(PixelFuncID *id) {
 			break;
 		}
 	}
+#endif
 }
 
 std::string DescribePixelFuncID(const PixelFuncID &id) {

--- a/GPU/Software/FuncId.cpp
+++ b/GPU/Software/FuncId.cpp
@@ -36,7 +36,7 @@ void ComputePixelFuncID(PixelFuncID *id) {
 	id->clearMode = gstate.isModeClear();
 	if (id->clearMode) {
 		id->colorTest = gstate.isClearModeColorMask();
-		id->stencilTest = gstate.isClearModeAlphaMask();
+		id->stencilTest = gstate.isClearModeAlphaMask() && gstate.FrameBufFormat() != GE_FORMAT_565;
 		id->depthWrite = gstate.isClearModeDepthMask();
 		id->depthTestFunc = GE_COMP_ALWAYS;
 		id->alphaTestFunc = GE_COMP_ALWAYS;

--- a/GPU/Software/FuncId.h
+++ b/GPU/Software/FuncId.h
@@ -23,9 +23,21 @@
 
 #include "GPU/ge_constants.h"
 
+#define SOFTPIXEL_USE_CACHE 1
+
+#pragma pack(push, 1)
+
 struct PixelFuncID {
 	PixelFuncID() {
 	}
+
+#ifdef SOFTPIXEL_USE_CACHE
+	struct {
+		// Warning: these are not hashed or compared for equal.  Just cached values.
+		uint32_t colorWriteMask{};
+		int16_t ditherMatrix[16]{};
+	} cached;
+#endif
 
 	union {
 		uint64_t fullKey{};
@@ -119,6 +131,8 @@ struct PixelFuncID {
 		return fullKey == other.fullKey;
 	}
 };
+
+#pragma pack(pop)
 
 struct SamplerID {
 	SamplerID() : fullKey(0) {

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -906,7 +906,7 @@ void DrawTriangleSlice(
 					subp.x = p.x + (i & 1);
 					subp.y = p.y + (i / 2);
 
-					drawPixel(subp.x, subp.y, z[i], fog[i], prim_color[i], pixelID);
+					drawPixel(subp.x, subp.y, z[i], fog[i], SOFTPIXEL_TO_VEC4I(prim_color[i]), pixelID);
 				}
 			}
 		}
@@ -1054,7 +1054,7 @@ void DrawPoint(const VertexData &v0)
 		fog = ClampFogDepth(v0.fogdepth);
 	}
 
-	drawPixel(p.x, p.y, z, fog, prim_color, pixelID);
+	drawPixel(p.x, p.y, z, fog, SOFTPIXEL_TO_VEC4I(prim_color), pixelID);
 }
 
 void ClearRectangle(const VertexData &v0, const VertexData &v1)
@@ -1344,7 +1344,7 @@ void DrawLine(const VertexData &v0, const VertexData &v1)
 			ScreenCoords pprime = ScreenCoords((int)x, (int)y, (int)z);
 
 			DrawingCoords p = TransformUnit::ScreenToDrawing(pprime);
-			drawPixel(p.x, p.y, z, fog, prim_color, pixelID);
+			drawPixel(p.x, p.y, z, fog, SOFTPIXEL_TO_VEC4I(prim_color), pixelID);
 		}
 
 		x += xinc;

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -193,7 +193,7 @@ void DrawSprite(const VertexData& v0, const VertexData& v1) {
 						Vec4<int> prim_color = v1.color0;
 						Vec4<int> tex_color = Vec4<int>::FromRGBA(nearestFunc(s, t, texptr, texbufw, 0));
 						prim_color = GetTextureFunctionOutput(prim_color, tex_color);
-						drawPixel(x, y, z, 255, prim_color, pixelID);
+						drawPixel(x, y, z, 255, SOFTPIXEL_TO_VEC4I(prim_color), pixelID);
 						s += ds;
 					}
 					t += dt;
@@ -237,7 +237,7 @@ void DrawSprite(const VertexData& v0, const VertexData& v1) {
 				for (int y = y1; y < y2; y++) {
 					for (int x = pos0.x; x < pos1.x; x++) {
 						Vec4<int> prim_color = v1.color0;
-						drawPixel(x, y, z, fog, prim_color, pixelID);
+						drawPixel(x, y, z, fog, SOFTPIXEL_TO_VEC4I(prim_color), pixelID);
 					}
 				}
 			}, pos0.y, pos1.y, MIN_LINES_PER_THREAD);

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -19,6 +19,7 @@
 #include <unordered_map>
 #include <mutex>
 #include "Common/Data/Convert/ColorConv.h"
+#include "Core/Config.h"
 #include "Core/Reporting.h"
 #include "GPU/Common/TextureDecoder.h"
 #include "GPU/GPUState.h"
@@ -216,13 +217,14 @@ NearestFunc SamplerJitCache::GetNearest(const SamplerID &id) {
 	}
 
 #if PPSSPP_ARCH(AMD64) && !PPSSPP_PLATFORM(UWP)
-	addresses_[id] = GetCodePointer();
-	NearestFunc func = Compile(id);
-	cache_[id] = func;
-	return func;
-#else
-	return nullptr;
+	if (g_Config.bSoftwareRenderingJit) {
+		addresses_[id] = GetCodePointer();
+		NearestFunc func = Compile(id);
+		cache_[id] = func;
+		return func;
+	}
 #endif
+	return nullptr;
 }
 
 LinearFunc SamplerJitCache::GetLinear(const SamplerID &id) {

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -493,7 +493,7 @@ bool SamplerJitCache::Jit_GetDXT1Color(const SamplerID &id, int blockSize, int a
 	// Let's swap the regs in that case.
 	CMP(32, R(tempReg1), Imm32(2));
 	FixupBranch skipSwap23 = J_CC(CC_E);
-	XCHG(32, R(bufwReg), R(tempReg2));
+	XCHG(32, R(tempReg2), R(bufwReg));
 	SetJumpTarget(skipSwap23);
 
 	// Start off with R, adding together first...

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -30,6 +30,7 @@ ARCH_FILES := \
   $(SRC)/Core/MIPS/x86/RegCache.cpp \
   $(SRC)/Core/MIPS/x86/RegCacheFPU.cpp \
   $(SRC)/GPU/Common/VertexDecoderX86.cpp \
+  $(SRC)/GPU/Software/DrawPixelX86.cpp \
   $(SRC)/GPU/Software/SamplerX86.cpp
 endif
 
@@ -52,6 +53,7 @@ ARCH_FILES := \
   $(SRC)/Core/MIPS/x86/RegCache.cpp \
   $(SRC)/Core/MIPS/x86/RegCacheFPU.cpp \
   $(SRC)/GPU/Common/VertexDecoderX86.cpp \
+  $(SRC)/GPU/Software/DrawPixelX86.cpp \
   $(SRC)/GPU/Software/SamplerX86.cpp
 endif
 

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -679,7 +679,7 @@ ifeq ($(WITH_DYNAREC),1)
             CPUFLAGS += -m32
          endif
       endif
-	   SOURCES_CXX += $(GPUDIR)/Software/SamplerX86.cpp
+	   SOURCES_CXX += $(GPUDIR)/Software/DrawPixelX86.cpp $(GPUDIR)/Software/SamplerX86.cpp
 	   SOURCES_CXX += $(COMMONDIR)/x64Emitter.cpp \
 						$(COMMONDIR)/x64Analyzer.cpp \
 						$(COMMONDIR)/ABI.cpp \


### PR DESCRIPTION
This is not yet battle tested or anything, but implements a jit on x64 only for the software renderer.  I created a very simple reg cache for it, which I tried to design with arm64 in mind too.

I didn't test Linux at all, though I did attempt to support it.

Currently, seeing 50-80% improvement in some games, most notably Cave Story.  ~~Alpha blending is not yet implemented (I want to check its accuracy more), which is the main thing preventing it from running in most games.~~

I had previously messed with drawing 4 pixels simultaneously with a mask.  I didn't go nearly as far with it, but there were some complexities and it was initially seeming like it wouldn't be faster based on changing C++ first.  I'm still not sure.  To do that would mean z and fog would be vec4s, and color would be packed 16x8 (4x4x8.)  Mask would be passed additionally.  That could still be interesting, but I wanted to try this for now.

There's probably still some areas to improve, I've only looked a little at the produced assembly to weed out silly patterns.

Also: not currently well tested.  Pretty much just wrote out all the code until "softjit: Initial color write" without any good way to test, but it worked with only a few small fixes, actually.

-[Unknown]