### PR TITLE
Fix vma assert on libretro content close

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -573,7 +573,7 @@ ifeq ($(DEBUG), 1)
 	endif
 	CPUOPTS += -D_DEBUG
 else
-	CPUOPTS += -O2 -D_NDEBUG
+	CPUOPTS += -O2 -DNDEBUG
 endif
 
 ifeq (,$(findstring msvc,$(platform)))


### PR DESCRIPTION
The recent vma integration is causing an assert on content close due to a potential memory leak in the vulkan memory allocation. Let's build libretro with the same release NDEBUG defintion as standalone and sidestep the hard assert to keep things running until a proper root cause analysis is done.