### PR TITLE
Destroy backbuffer when shutting down libretro vulkan context.

### DIFF
--- a/libretro/LibretroVulkanContext.cpp
+++ b/libretro/LibretroVulkanContext.cpp
@@ -143,23 +143,28 @@ void LibretroVulkanContext::CreateDrawContext() {
 }
 
 void LibretroVulkanContext::Shutdown() {
-	LibretroHWRenderContext::Shutdown();
+   if (!vk) {
+      return;
+   }
 
-	if (!vk) {
-		return;
-	}
+   if (draw_)
+      draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, vk->GetBackbufferWidth(), vk->GetBackbufferHeight());
 
-	vk->WaitUntilQueueIdle();
+   delete draw_;
+   draw_ = nullptr;
 
-	vk->DestroySwapchain();
-	vk->DestroySurface();
-	vk->DestroyDevice();
-	vk->DestroyInstance();
-	delete vk;
-	vk = nullptr;
+   vk->WaitUntilQueueIdle();
 
-	finalize_glslang();
-	vk_libretro_shutdown();
+   vk->DestroySwapchain();
+   vk->DestroySurface();
+   vk->DestroyDevice();
+   vk->DestroyInstance();
+
+   delete vk;
+   vk = nullptr;
+
+   finalize_glslang();
+   vk_libretro_shutdown();
 }
 
 void *LibretroVulkanContext::GetAPIContext() { return vk; }

--- a/libretro/LibretroVulkanContext.cpp
+++ b/libretro/LibretroVulkanContext.cpp
@@ -150,8 +150,7 @@ void LibretroVulkanContext::Shutdown() {
    if (draw_)
       draw_->HandleEvent(Draw::Event::LOST_BACKBUFFER, vk->GetBackbufferWidth(), vk->GetBackbufferHeight());
 
-   delete draw_;
-   draw_ = nullptr;
+   LibretroHWRenderContext::Shutdown();
 
    vk->WaitUntilQueueIdle();
 


### PR DESCRIPTION
Fixes memory leak papered over by #15166 
The backbuffer was still live while the shutdown was invoked leading to the vma leak assert. Libreto vulkan context shutdown destroys the backbuffer before the rest of the teardown calls and is in line with the other GraphicsContext shutdown implementations.