### PR TITLE
jit: More atomically update pointer

### DIFF
--- a/Core/Debugger/WebSocket/MemorySubscriber.cpp
+++ b/Core/Debugger/WebSocket/MemorySubscriber.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <mutex>
 #include "Common/Data/Encoding/Base64.h"
 #include "Common/StringUtils.h"
 #include "Core/Core.h"
@@ -67,6 +68,7 @@ static AutoDisabledReplacements LockMemoryAndCPU(uint32_t addr, bool keepReplace
 		result.saved = true;
 		// Okay, save so we can restore later.
 		result.replacements = SaveAndClearReplacements();
+		std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 		if (MIPSComp::jit)
 			result.emuhacks = MIPSComp::jit->SaveAndClearEmuHackOps();
 	}
@@ -75,6 +77,7 @@ static AutoDisabledReplacements LockMemoryAndCPU(uint32_t addr, bool keepReplace
 
 AutoDisabledReplacements::~AutoDisabledReplacements() {
 	if (saved) {
+		std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 		if (MIPSComp::jit)
 			MIPSComp::jit->RestoreSavedEmuHackOps(emuhacks);
 		RestoreSavedReplacements(replacements);

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1476,6 +1476,7 @@ void __KernelLoadContext(PSPThreadContext *ctx, bool vfpuEnabled) {
 	}
 
 	memcpy(currentMIPS->other, ctx->other, sizeof(ctx->other));
+	// Not locking here, we assume the jit isn't switched during execution.
 	if (MIPSComp::jit) {
 		// When thread switching, we must update the rounding mode if cached in the jit.
 		MIPSComp::jit->UpdateFCR31();

--- a/Core/MIPS/JitCommon/JitCommon.h
+++ b/Core/MIPS/JitCommon/JitCommon.h
@@ -17,8 +17,9 @@
 
 #pragma once
 
-#include <vector>
+#include <mutex>
 #include <string>
+#include <vector>
 
 #include "Common/Common.h"
 #include "Common/CommonTypes.h"
@@ -154,6 +155,7 @@ namespace MIPSComp {
 	typedef int (MIPSFrontendInterface::*MIPSReplaceFunc)();
 
 	extern JitInterface *jit;
+	extern std::recursive_mutex jitLock;
 
 	void DoDummyJitState(PointerWrap &p);
 

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -917,6 +917,7 @@ skip:
 
 	void PrecompileFunction(u32 startAddr, u32 length) {
 		// Direct calls to this ignore the bPreloadFunctions flag, since it's just for stubs.
+		std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 		if (MIPSComp::jit) {
 			MIPSComp::jit->CompileFunction(startAddr, length);
 		}

--- a/Core/MIPS/MIPSAsm.cpp
+++ b/Core/MIPS/MIPSAsm.cpp
@@ -38,6 +38,7 @@ public:
 		Memory::Memcpy((u32)address, data, (u32)length, "Debugger");
 		
 		// In case this is a delay slot or combined instruction, clear cache above it too.
+		std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 		if (MIPSComp::jit)
 			MIPSComp::jit->InvalidateCacheAt((u32)(address - 4),(int)length+4);
 

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -105,7 +105,8 @@ namespace MIPSInt
 		switch (func) {
 		// Icache
 		case 8:
-			// Invalidate the instruction cache at this address
+			// Invalidate the instruction cache at this address.
+			// We assume the CPU won't be reset during this, so no locking.
 			if (MIPSComp::jit) {
 				MIPSComp::jit->InvalidateCacheAt(addr, 0x40);
 			}
@@ -515,6 +516,7 @@ namespace MIPSInt
 				if (fs == 31) {
 					currentMIPS->fcr31 = value & 0x0181FFFF;
 					currentMIPS->fpcond = (value >> 23) & 1;
+					// Don't bother locking, assuming the CPU can't be reset now anyway.
 					if (MIPSComp::jit) {
 						// In case of DISABLE, we need to tell jit we updated FCR31.
 						MIPSComp::jit->UpdateFCR31();

--- a/Core/MemFault.cpp
+++ b/Core/MemFault.cpp
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <unordered_set>
+#include <mutex>
 
 #include "Common/MachineContext.h"
 
@@ -88,6 +89,8 @@ static bool DisassembleNativeAt(const uint8_t *codePtr, int instructionSize, std
 bool HandleFault(uintptr_t hostAddress, void *ctx) {
 	SContext *context = (SContext *)ctx;
 	const uint8_t *codePtr = (uint8_t *)(context->CTX_PC);
+
+	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 
 	// We set this later if we think it can be resumed from.
 	g_lastCrashAddress = nullptr;

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -413,6 +413,7 @@ __forceinline static Opcode Read_Instruction(u32 address, bool resolveReplacemen
 		return inst;
 	}
 
+	// No mutex on jit access here, but we assume the caller has locked, if necessary.
 	if (MIPS_IS_RUNBLOCK(inst.encoding) && MIPSComp::jit) {
 		inst = MIPSComp::jit->GetOriginalOp(inst);
 		if (resolveReplacements && MIPS_IS_REPLACEMENT(inst)) {
@@ -461,6 +462,7 @@ Opcode ReadUnchecked_Instruction(u32 address, bool resolveReplacements)
 Opcode Read_Opcode_JIT(u32 address)
 {
 	Opcode inst = Opcode(Read_U32(address));
+	// No mutex around jit access here, but we assume caller has if necessary.
 	if (MIPS_IS_RUNBLOCK(inst.encoding) && MIPSComp::jit) {
 		return MIPSComp::jit->GetOriginalOp(inst);
 	} else {

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -136,6 +136,7 @@ void CwCheatScreen::onFinish(DialogResult result) {
 	if (result != DR_BACK) // This only works for BACK here.
 		return;
 
+	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 	if (MIPSComp::jit) {
 		MIPSComp::jit->ClearCache();
 	}
@@ -167,6 +168,7 @@ UI::EventReturn CwCheatScreen::OnAddCheat(UI::EventParams &params) {
 
 UI::EventReturn CwCheatScreen::OnEditCheatFile(UI::EventParams &params) {
 	g_Config.bReloadCheats = true;
+	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 	if (MIPSComp::jit) {
 		MIPSComp::jit->ClearCache();
 	}

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -910,6 +910,7 @@ void JitCompareScreen::UpdateDisasm() {
 }
 
 UI::EventReturn JitCompareScreen::OnAddressChange(UI::EventParams &e) {
+	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 	if (!MIPSComp::jit) {
 		return UI::EVENT_DONE;
 	}
@@ -929,6 +930,7 @@ UI::EventReturn JitCompareScreen::OnAddressChange(UI::EventParams &e) {
 }
 
 UI::EventReturn JitCompareScreen::OnShowStats(UI::EventParams &e) {
+	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 	if (!MIPSComp::jit) {
 		return UI::EVENT_DONE;
 	}
@@ -976,6 +978,7 @@ UI::EventReturn JitCompareScreen::OnNextBlock(UI::EventParams &e) {
 }
 
 UI::EventReturn JitCompareScreen::OnBlockAddress(UI::EventParams &e) {
+	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 	if (!MIPSComp::jit) {
 		return UI::EVENT_DONE;
 	}
@@ -994,6 +997,7 @@ UI::EventReturn JitCompareScreen::OnBlockAddress(UI::EventParams &e) {
 }
 
 UI::EventReturn JitCompareScreen::OnRandomBlock(UI::EventParams &e) {
+	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 	if (!MIPSComp::jit) {
 		return UI::EVENT_DONE;
 	}
@@ -1021,6 +1025,7 @@ UI::EventReturn JitCompareScreen::OnRandomFPUBlock(UI::EventParams &e) {
 }
 
 void JitCompareScreen::OnRandomBlock(int flag) {
+	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 	if (!MIPSComp::jit) {
 		return;
 	}
@@ -1056,6 +1061,7 @@ void JitCompareScreen::OnRandomBlock(int flag) {
 }
 
 UI::EventReturn JitCompareScreen::OnCurrentBlock(UI::EventParams &e) {
+	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 	if (!MIPSComp::jit) {
 		return UI::EVENT_DONE;
 	}

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -376,13 +376,13 @@ void DrawGameBackground(UIContext &dc, const Path &gamePath, float x, float y, f
 void HandleCommonMessages(const char *message, const char *value, ScreenManager *manager, Screen *activeScreen) {
 	bool isActiveScreen = manager->topScreen() == activeScreen;
 
-	if (!strcmp(message, "clear jit")) {
-		if (MIPSComp::jit && PSP_IsInited()) {
-			MIPSComp::jit->ClearCache();
+	if (!strcmp(message, "clear jit") && PSP_IsInited()) {
+		if (MIPSComp::jit) {
+			std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+			if (MIPSComp::jit)
+				MIPSComp::jit->ClearCache();
 		}
-		if (PSP_IsInited()) {
-			currentMIPS->UpdateCore((CPUCore)g_Config.iCpuCore);
-		}
+		currentMIPS->UpdateCore((CPUCore)g_Config.iCpuCore);
 	} else if (!strcmp(message, "control mapping") && isActiveScreen && activeScreen->tag() != "control mapping") {
 		UpdateUIState(UISTATE_MENU);
 		manager->push(new ControlMappingScreen());

--- a/Windows/Debugger/DumpMemoryWindow.cpp
+++ b/Windows/Debugger/DumpMemoryWindow.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cstdio>
+#include <mutex>
 #include "Common/Data/Encoding/Utf8.h"
 #include "Core/Core.h"
 #include "Core/HLE/ReplaceTables.h"
@@ -102,6 +103,7 @@ INT_PTR CALLBACK DumpMemoryWindow::dlgFunc(HWND hwnd, UINT iMsg, WPARAM wParam, 
 					fwrite(Memory::GetPointer(bp->start), 1, bp->size, output);
 				} else {
 					auto savedReplacements = SaveAndClearReplacements();
+					std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 					if (MIPSComp::jit) {
 						auto savedBlocks = MIPSComp::jit->SaveAndClearEmuHackOps();
 						fwrite(Memory::GetPointer(bp->start), 1, bp->size, output);

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -895,6 +895,7 @@ namespace MainWindow
 					const u8 *ptr = (const u8 *)info->addr;
 					std::string name;
 
+					std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 					if (MIPSComp::jit && MIPSComp::jit->DescribeCodePtr(ptr, name)) {
 						swprintf_s(info->name, L"Jit::%S", name.c_str());
 						return TRUE;


### PR DESCRIPTION
Was profiling during "toggle freeze", and got crashes because `MIPSComp::jit` was in the middle of being deleted while it was reporting symbol name information.  This was enough to prevent crashes.

-[Unknown]