### PR TITLE
SDL: Respect inflight frames setting in GL

### DIFF
--- a/SDL/SDLGLGraphicsContext.cpp
+++ b/SDL/SDLGLGraphicsContext.cpp
@@ -414,6 +414,7 @@ int SDLGLGraphicsContext::Init(SDL_Window *&window, int x, int y, int mode, std:
 	CheckGLExtensions();
 	draw_ = Draw::T3DCreateGLContext();
 	renderManager_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+	renderManager_->SetInflightFrames(g_Config.iInflightFrames);
 	SetGPUBackend(GPUBackend::OPENGL);
 	bool success = draw_->CreatePresets();
 	_assert_(success);


### PR DESCRIPTION
Has this in a branch for a little while.  [Other](https://github.com/hrydgard/ppsspp/blob/0c40e918c92b897f745abee0d09cf033a1572337/SDL/SDLVulkanGraphicsContext.cpp#L126) [contexts](https://github.com/hrydgard/ppsspp/blob/0c40e918c92b897f745abee0d09cf033a1572337/Windows/GPU/WindowsGLContext.cpp#L433) similarly set this, but SDL was missing.

Not tested.

-[Unknown]