### PR TITLE
Tweaks to thread manager enqueue and shutdown

### DIFF
--- a/Common/Thread/ThreadManager.h
+++ b/Common/Thread/ThreadManager.h
@@ -60,6 +60,8 @@ public:
 	int GetNumLooperThreads() const;
 
 private:
+	bool TeardownTask(Task *task, bool enqueue);
+
 	// This is always pointing to a context, initialized in the constructor.
 	GlobalThreadContext *global_;
 


### PR DESCRIPTION
This gives me about 1% improvement in the software renderer, reducing overhead just a bit.

It also avoids a potential hang on shutdown, and tries to delete incomplete tasks (but only if they're cancellable, which none currently are...)

-[Unknown]