### PR TITLE
softjit: Centralize argument register allocation

### DIFF
--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -608,6 +608,7 @@ bool PixelJitCache::Jit_StencilAndDepthTest(const PixelFuncID &id) {
 	success = success && Jit_ApplyStencilOp(id, id.ZPass(), stencilReg);
 
 	// At this point, stencilReg can't be spilled.  It contains the updated value.
+	regCache_.Unlock(stencilReg, RegCache::GEN_STENCIL);
 	regCache_.ForceRetain(RegCache::GEN_STENCIL);
 
 	return success;

--- a/GPU/Software/RasterizerRegCache.h
+++ b/GPU/Software/RasterizerRegCache.h
@@ -144,15 +144,28 @@ struct RegCache {
 		bool forceRetained = false;
 	};
 
+	// Note: Assumes __vectorcall on Windows.
+	// Keep in mind, some args won't fit in regs, this ignores stack and tracks what's in regs.
+	void SetupABI(const std::vector<Purpose> &args, bool forceRetain = true);
+	// Reset after compile complete, pass false for validate if compile failed.
 	void Reset(bool validate);
+	// Add register to cache for tracking with initial purpose (won't be locked or force retained.)
 	void Add(Reg r, Purpose p);
+	// Find registers with one purpose and change to the other.
 	void Change(Purpose history, Purpose destiny);
+	// Release a previously found or allocated register, setting purpose to invalid.
 	void Release(Reg &r, Purpose p);
+	// Unlock a previously found or allocated register, but try to retain it.
 	void Unlock(Reg &r, Purpose p);
+	// Check if the purpose is currently in a register.
 	bool Has(Purpose p);
+	// Return the register for a given purpose (check with Has() first if not certainly there.)
 	Reg Find(Purpose p);
+	// Allocate a new register for the given purpose.
 	Reg Alloc(Purpose p);
+	// Force a register to be retained, even if we run short on regs.
 	void ForceRetain(Purpose p);
+	// Reverse ForceRetain, and release the register back to invalid.
 	void ForceRelease(Purpose p);
 
 	// For getting a specific reg.  WARNING: May return a locked reg, so you have to check.

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -395,6 +395,7 @@ int main(int argc, const char* argv[])
 	g_Config.bEnableLogging = fullLog;
 	g_Config.bSoftwareSkinning = true;
 	g_Config.bVertexDecoderJit = true;
+	g_Config.bSoftwareRenderingJit = true;
 	g_Config.bBlockTransferGPU = true;
 	g_Config.iSplineBezierQuality = 2;
 	g_Config.bHighQualityDepth = true;


### PR DESCRIPTION
This makes it easier to apply ABI register allocation rules automatically: just pass an array of args, and they're assigned for you.

-[Unknown]