### PR TITLE
ext/SPIRV-Cross-build: Update cmake version

### DIFF
--- a/ext/SPIRV-Cross-build/CMakeLists.txt
+++ b/ext/SPIRV-Cross-build/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 project(SPIRV-Cross)
 enable_testing()
 


### PR DESCRIPTION
This matches the upstream SPIRV-Cross CMakeLists.txt.

https://github.com/KhronosGroup/SPIRV-Cross/blob/37dfb3f45f4fc47c841f81e618c602f6f3de0f17/CMakeLists.txt#L22

Also silences a warning.
```
CMake Deprecation Warning at ext/SPIRV-Cross-build/CMakeLists.txt:15 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```