### PR TITLE
cmake: Generate git-version.cpp in the build dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1978,7 +1978,7 @@ add_library(${CoreLibName} ${CoreLinkType}
 	${CORE_NEON}
 	${GPU_SOURCES}
 	ext/disarm.cpp
-	git-version.cpp
+	${CMAKE_CURRENT_BINARY_DIR}/git-version.cpp
 )
 
 if(ANDROID)
@@ -2126,10 +2126,11 @@ endif()
 
 add_custom_command(OUTPUT something_that_never_exists
 	COMMAND ${CMAKE_COMMAND} -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+		-DOUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}
 		-P ${CMAKE_CURRENT_SOURCE_DIR}/git-version.cmake
 	${WIN_VERSION_CMD})
 
-set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/git-version.cpp
+set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/git-version.cpp
 	PROPERTIES GENERATED TRUE
 	SKIP_AUTOMOC ON)
 add_dependencies(${CoreLibName} GitVersion)

--- a/git-version.cmake
+++ b/git-version.cmake
@@ -1,4 +1,4 @@
-set(GIT_VERSION_FILE "${SOURCE_DIR}/git-version.cpp")
+set(GIT_VERSION_FILE "${OUTPUT_DIR}/git-version.cpp")
 set(GIT_VERSION "unknown")
 set(GIT_VERSION_UPDATE "1")
 


### PR DESCRIPTION
Its nice to not generate files in the working source tree when using an out of tree build. Its plausible there may be cases where the source directory is not writable and only the build directory is.