### PR TITLE
cmake: Include a default version for git-version.cmake

### DIFF
--- a/git-version.cmake
+++ b/git-version.cmake
@@ -1,5 +1,5 @@
 set(GIT_VERSION_FILE "${OUTPUT_DIR}/git-version.cpp")
-set(GIT_VERSION "unknown")
+set(GIT_VERSION "1.12.3")
 set(GIT_VERSION_UPDATE "1")
 
 find_package(Git)
@@ -9,11 +9,11 @@ if(GIT_FOUND AND EXISTS "${SOURCE_DIR}/.git/")
 		RESULT_VARIABLE exit_code
 		OUTPUT_VARIABLE GIT_VERSION)
 	if(NOT ${exit_code} EQUAL 0)
-		message(WARNING "git describe failed, unable to include version.")
+		message(WARNING "git describe failed, using version '${GIT_VERSION}'.")
 	endif()
 	string(STRIP ${GIT_VERSION} GIT_VERSION)
 else()
-	message(WARNING "git not found, unable to include version.")
+	message(WARNING "git not found, using version '${GIT_VERSION}'.")
 endif()
 
 if(EXISTS ${GIT_VERSION_FILE})


### PR DESCRIPTION
@unknownbrackets Stated:

> Just a note that some people patch this file (git-version.cpp) to prevent it from using git to lookup the version number.

https://github.com/hrydgard/ppsspp/pull/15184#issuecomment-982718132

So it might alleviate a lot of the need to patch `git-version.cpp` by having a default version in case the `git` executable or `.git` directory is missing. It would also have a more helpful version than `unknown` for any users with such a build. The downside is that it would be one more place to update the version string every release. I don't have a strong opinion on this, but I think it would be probably a good idea.