### PR TITLE
Vulkan: Cleanup pipeline var shadowing

### DIFF
--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -1277,14 +1277,14 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 		case VKRRenderCommand::BIND_GRAPHICS_PIPELINE:
 		{
 			VKRGraphicsPipeline *pipeline = c.graphics_pipeline.pipeline;
-			if (!pipeline->pipeline) {
+			if (pipeline->Pending()) {
 				// Stall processing, waiting for the compile queue to catch up.
 				std::unique_lock<std::mutex> lock(compileDoneMutex_);
 				while (!pipeline->pipeline) {
 					compileDone_.wait(lock);
 				}
 			}
-			if (pipeline->pipeline != lastGraphicsPipeline) {
+			if (pipeline->pipeline != lastGraphicsPipeline && pipeline->pipeline != VK_NULL_HANDLE) {
 				vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline->pipeline);
 				lastGraphicsPipeline = pipeline->pipeline;
 				// Reset dynamic state so it gets refreshed with the new pipeline.
@@ -1298,14 +1298,14 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 		case VKRRenderCommand::BIND_COMPUTE_PIPELINE:
 		{
 			VKRComputePipeline *pipeline = c.compute_pipeline.pipeline;
-			if (!pipeline->pipeline) {
+			if (pipeline->Pending()) {
 				// Stall processing, waiting for the compile queue to catch up.
 				std::unique_lock<std::mutex> lock(compileDoneMutex_);
 				while (!pipeline->pipeline) {
 					compileDone_.wait(lock);
 				}
 			}
-			if (pipeline->pipeline != lastComputePipeline) {
+			if (pipeline->pipeline != lastComputePipeline && pipeline->pipeline != VK_NULL_HANDLE) {
 				vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline->pipeline);
 				lastComputePipeline = pipeline->pipeline;
 			}

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -29,25 +29,28 @@ bool VKRGraphicsPipeline::Create(VulkanContext *vulkan) {
 		// Already failed to create this one.
 		return false;
 	}
-	VkPipeline pipeline;
-	VkResult result = vkCreateGraphicsPipelines(vulkan->GetDevice(), desc->pipelineCache, 1, &desc->pipe, nullptr, &pipeline);
-	this->pipeline = pipeline;
-	delete desc;
-	desc = nullptr;
+	VkPipeline vkpipeline;
+	VkResult result = vkCreateGraphicsPipelines(vulkan->GetDevice(), desc->pipelineCache, 1, &desc->pipe, nullptr, &vkpipeline);
+
+	bool success = true;
 	if (result == VK_INCOMPLETE) {
 		// Bad (disallowed by spec) return value seen on Adreno in Burnout :(  Try to ignore?
 		// Would really like to log more here, we could probably attach more info to desc.
 		//
 		// At least create a null placeholder to avoid creating over and over if something is broken.
 		pipeline = VK_NULL_HANDLE;
-		return true;
+		success = false;
 	} else if (result != VK_SUCCESS) {
 		pipeline = VK_NULL_HANDLE;
 		ERROR_LOG(G3D, "Failed creating graphics pipeline! result='%s'", VulkanResultToString(result));
-		return false;
+		success = false;
 	} else {
-		return true;
+		pipeline = vkpipeline;
 	}
+
+	delete desc;
+	desc = nullptr;
+	return success;
 }
 
 bool VKRComputePipeline::Create(VulkanContext *vulkan) {
@@ -55,17 +58,21 @@ bool VKRComputePipeline::Create(VulkanContext *vulkan) {
 		// Already failed to create this one.
 		return false;
 	}
-	VkPipeline pipeline;
-	VkResult result = vkCreateComputePipelines(vulkan->GetDevice(), desc->pipelineCache, 1, &desc->pipe, nullptr, &pipeline);
-	this->pipeline = pipeline;
-	delete desc;
-	desc = nullptr;
+	VkPipeline vkpipeline;
+	VkResult result = vkCreateComputePipelines(vulkan->GetDevice(), desc->pipelineCache, 1, &desc->pipe, nullptr, &vkpipeline);
+
+	bool success = true;
 	if (result != VK_SUCCESS) {
 		pipeline = VK_NULL_HANDLE;
 		ERROR_LOG(G3D, "Failed creating compute pipeline! result='%s'", VulkanResultToString(result));
-		return false;
+		success = false;
+	} else {
+		pipeline = vkpipeline;
 	}
-	return true;
+
+	delete desc;
+	desc = nullptr;
+	return success;
 }
 
 VKRFramebuffer::VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VkRenderPass renderPass, int _width, int _height, const char *tag) : vulkan_(vk) {

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -147,6 +147,9 @@ struct VKRGraphicsPipeline {
 	std::atomic<VkPipeline> pipeline;
 
 	bool Create(VulkanContext *vulkan);
+	bool Pending() const {
+		return pipeline == VK_NULL_HANDLE && desc != nullptr;
+	}
 };
 
 struct VKRComputePipeline {
@@ -157,6 +160,9 @@ struct VKRComputePipeline {
 	std::atomic<VkPipeline> pipeline;
 
 	bool Create(VulkanContext *vulkan);
+	bool Pending() const {
+		return pipeline == VK_NULL_HANDLE && desc != nullptr;
+	}
 };
 
 struct CompileQueueEntry {


### PR DESCRIPTION
I've been getting some random crashes, mainly on shutdown, in Vulkan recently.  I'm hoping this is the cause, because when I caught it in a debugger it was within vkCmdBindPipeline().

`pipeline = VK_NULL_HANDLE` was a dead store due to shadowing.  I renamed the shadow to `vkpipeline` for clarity.

Also tried to prevent a case I imagined of hanging on a previously-failed pipeline.

-[Unknown]