### PR TITLE
Psmf: Check for invalid stream/EP map entry counts

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -304,6 +304,11 @@ public:
 		videoHeight_ = addr[13] * 16;
 
 		const u32 EP_MAP_STRIDE = 1 + 1 + 4 + 4;
+		if (psmf->headerOffset != 0 && !Memory::IsValidRange(psmf->headerOffset, psmf->EPMapOffset + EP_MAP_STRIDE * psmf->EPMapEntriesNum)) {
+			ERROR_LOG(ME, "Invalid PSMF EP map entry count: %d", psmf->EPMapEntriesNum);
+			psmf->EPMapEntriesNum = Memory::ValidSize(psmf->headerOffset + psmf->EPMapOffset, EP_MAP_STRIDE * psmf->EPMapEntriesNum) / EP_MAP_STRIDE;
+		}
+
 		psmf->EPMap.clear();
 		for (u32 i = 0; i < psmf->EPMapEntriesNum; i++) {
 			const u8 *const entryAddr = data + psmf->EPMapOffset + EP_MAP_STRIDE * i;
@@ -377,6 +382,11 @@ Psmf::Psmf(const u8 *ptr, u32 data) {
 	currentStreamNum = -1;
 	currentStreamType = -1;
 	currentStreamChannel = -1;
+
+	if (data != 0 && !Memory::IsValidRange(data, 0x82 + numStreams * 16)) {
+		ERROR_LOG(ME, "Invalid PSMF stream count: %d", numStreams);
+		numStreams = Memory::ValidSize(data + 0x82, numStreams * 16) / 16;
+	}
 
 	for (int i = 0; i < numStreams; i++) {
 		PsmfStream *stream = 0;


### PR DESCRIPTION
Had a randomly bad network read during remote disc streaming, and got some crashes related to invalid PSMF data.  This fixed the PPSSPP crash, although the game itself still crashed due to the bad data anyway.

-[Unknown]