### PR TITLE
Correct accuracy of texture functions in software rendering

### DIFF
--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -243,7 +243,7 @@ void ComputeFragmentShaderID(FShaderID *id_out, const Draw::Bugs &bugs) {
 		bool enableFog = gstate.isFogEnabled() && !isModeThrough;
 		bool enableAlphaTest = gstate.isAlphaTestEnabled() && !IsAlphaTestTriviallyTrue();
 		bool enableColorTest = gstate.isColorTestEnabled() && !IsColorTestTriviallyTrue();
-		bool enableColorDoubling = gstate.isColorDoublingEnabled() && gstate.isTextureMapEnabled() && gstate.getTextureFunction() == GE_TEXFUNC_MODULATE;
+		bool enableColorDoubling = gstate.isColorDoublingEnabled() && gstate.isTextureMapEnabled();
 		bool doTextureProjection = (gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX && MatrixNeedsProjection(gstate.tgenMatrix));
 		bool doTextureAlpha = gstate.isTextureAlphaUsed();
 		bool doFlatShading = gstate.getShadeMode() == GE_SHADE_FLAT;

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -341,10 +341,7 @@ Vec4IntResult SOFTRAST_CALL GetTextureFunctionOutput(Vec4IntArg prim_color_in, V
 		else
 			out_rgb /= 256;
 
-		if (rgba)
-			out_a = ((prim_color.a() + 1) * texcolor.a()) / 256;
-		else
-			out_a = prim_color.a();
+		out_a = (rgba) ? ((prim_color.a() + 1) * texcolor.a() / 256) : prim_color.a();
 		break;
 	}
 
@@ -357,17 +354,17 @@ Vec4IntResult SOFTRAST_CALL GetTextureFunctionOutput(Vec4IntArg prim_color_in, V
 		break;
 
 	case GE_TEXFUNC_ADD:
+	case GE_TEXFUNC_UNKNOWN1:
+	case GE_TEXFUNC_UNKNOWN2:
+	case GE_TEXFUNC_UNKNOWN3:
+		// Don't need to clamp afterward, we always clamp before tests.
 		out_rgb = prim_color.rgb() + texcolor.rgb();
-		if (out_rgb.r() > 255) out_rgb.r() = 255;
-		if (out_rgb.g() > 255) out_rgb.g() = 255;
-		if (out_rgb.b() > 255) out_rgb.b() = 255;
-		out_a = prim_color.a() * ((rgba) ? texcolor.a() : 255) / 255;
-		break;
+		if (gstate.isColorDoublingEnabled())
+			out_rgb *= 2;
 
-	default:
-		ERROR_LOG_REPORT(G3D, "Software: Unknown texture function %x", gstate.getTextureFunction());
-		out_rgb = Vec3<int>::AssignToAll(0);
-		out_a = 0;
+		// Alpha is still blended the common way.
+		out_a = (rgba) ? ((prim_color.a() + 1) * texcolor.a() / 256) : prim_color.a();
+		break;
 	}
 
 	return ToVec4IntResult(Vec4<int>(out_rgb, out_a));


### PR DESCRIPTION
These now produce correct results (in isolation), bit-for-bit, just like alpha blending.

It's interesting that these don't simply match the alpha blending logic of `((A + 0.5) * (B + 0.5) + (C + 0.5) * (D + 0.5)) / 256`, but generally one side is biased as in `((A + 1) * B) / 256`.  BLEND is the odd one out, as it seems to do a pretty accurate ceiling, and is the only one that uses texenv.

-[Unknown]