### PR TITLE
ThreadManager: Use separate pool for IO blocking

### DIFF
--- a/Common/Thread/ParallelLoop.cpp
+++ b/Common/Thread/ParallelLoop.cpp
@@ -9,6 +9,10 @@ public:
 	LoopRangeTask(WaitableCounter *counter, const std::function<void(int, int)> &loop, int lower, int upper)
 		: counter_(counter), loop_(loop), lower_(lower), upper_(upper) {}
 
+	TaskType Type() const override {
+		return TaskType::CPU_COMPUTE;
+	}
+
 	void Run() override {
 		loop_(lower_, upper_);
 		counter_->Count();
@@ -34,7 +38,7 @@ WaitableCounter *ParallelRangeLoopWaitable(ThreadManager *threadMan, const std::
 	} else if (range <= minSize) {
 		// Single background task.
 		WaitableCounter *waitableCounter = new WaitableCounter(1);
-		threadMan->EnqueueTaskOnThread(0, new LoopRangeTask(waitableCounter, loop, lower, upper), TaskType::CPU_COMPUTE);
+		threadMan->EnqueueTaskOnThread(0, new LoopRangeTask(waitableCounter, loop, lower, upper));
 		return waitableCounter;
 	} else {
 		// Split the range between threads. Allow for some fractional bits.
@@ -61,7 +65,7 @@ WaitableCounter *ParallelRangeLoopWaitable(ThreadManager *threadMan, const std::
 				// Let's do the stragglers on the current thread.
 				break;
 			}
-			threadMan->EnqueueTaskOnThread(i, new LoopRangeTask(waitableCounter, loop, start, end), TaskType::CPU_COMPUTE);
+			threadMan->EnqueueTaskOnThread(i, new LoopRangeTask(waitableCounter, loop, start, end));
 			counter += delta;
 			if ((counter >> fractionalBits) >= upper) {
 				break;

--- a/Common/Thread/Promise.h
+++ b/Common/Thread/Promise.h
@@ -9,11 +9,15 @@
 template<class T>
 class PromiseTask : public Task {
 public:
-	PromiseTask(std::function<T ()> fun, Mailbox<T> *tx) : fun_(fun), tx_(tx) {
+	PromiseTask(std::function<T ()> fun, Mailbox<T> *tx, TaskType t) : fun_(fun), tx_(tx), type_(t) {
 		tx_->AddRef();
 	}
 	~PromiseTask() {
 		tx_->Release();
+	}
+
+	TaskType Type() const override {
+		return type_;
 	}
 
 	void Run() override {
@@ -23,6 +27,7 @@ public:
 
 	std::function<T ()> fun_;
 	Mailbox<T> *tx_;
+	TaskType type_;
 };
 
 // Represents pending or actual data.
@@ -38,8 +43,8 @@ public:
 		Promise<T> *promise = new Promise<T>();
 		promise->rx_ = mailbox;
 
-		PromiseTask<T> *task = new PromiseTask<T>(fun, mailbox);
-		threadman->EnqueueTask(task, taskType);
+		PromiseTask<T> *task = new PromiseTask<T>(fun, mailbox, taskType);
+		threadman->EnqueueTask(task);
 		return promise;
 	}
 

--- a/Common/Thread/ThreadManager.cpp
+++ b/Common/Thread/ThreadManager.cpp
@@ -172,12 +172,12 @@ void ThreadManager::Init(int numRealCores, int numLogicalCoresPerCpu) {
 	}
 }
 
-void ThreadManager::EnqueueTask(Task *task, TaskType taskType) {
+void ThreadManager::EnqueueTask(Task *task) {
 	_assert_msg_(IsInitialized(), "ThreadManager not initialized");
 
 	int maxThread;
 	int threadOffset = 0;
-	if (taskType == TaskType::CPU_COMPUTE) {
+	if (task->Type() == TaskType::CPU_COMPUTE) {
 		// only the threads reserved for heavy compute.
 		maxThread = numComputeThreads_;
 		threadOffset = 0;
@@ -219,7 +219,7 @@ void ThreadManager::EnqueueTask(Task *task, TaskType taskType) {
 	chosenThread->cond.notify_one();
 }
 
-void ThreadManager::EnqueueTaskOnThread(int threadNum, Task *task, TaskType taskType) {
+void ThreadManager::EnqueueTaskOnThread(int threadNum, Task *task) {
 	_assert_msg_(threadNum >= 0 && threadNum < (int)global_->threads_.size(), "Bad threadnum or not initialized");
 	ThreadContext *thread = global_->threads_[threadNum];
 

--- a/Common/Thread/ThreadManager.h
+++ b/Common/Thread/ThreadManager.h
@@ -14,6 +14,7 @@ enum class TaskType {
 class Task {
 public:
 	virtual ~Task() {}
+	virtual TaskType Type() const = 0;
 	virtual void Run() = 0;
 	virtual bool Cancellable() { return false; }
 	virtual void Cancel() {}
@@ -44,8 +45,8 @@ public:
 	// It gets even trickier when you think about mobile chips with BIG/LITTLE, but we'll
 	// just ignore it and let the OS handle it.
 	void Init(int numCores, int numLogicalCoresPerCpu);
-	void EnqueueTask(Task *task, TaskType taskType);
-	void EnqueueTaskOnThread(int threadNum, Task *task, TaskType taskType);
+	void EnqueueTask(Task *task);
+	void EnqueueTaskOnThread(int threadNum, Task *task);
 	void Teardown();
 
 	bool IsInitialized() const;

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -785,6 +785,10 @@ public:
 	ReplacedTextureTask(ReplacedTexture &tex, LimitedWaitable *w) : tex_(tex), waitable_(w) {
 	}
 
+	TaskType Type() const override {
+		return TaskType::IO_BLOCKING;
+	}
+
 	void Run() override {
 		tex_.Prepare();
 		waitable_->Notify();
@@ -815,7 +819,7 @@ bool ReplacedTexture::IsReady(double budget) {
 
 	if (g_Config.bReplaceTexturesAllowLate) {
 		threadWaitable_ = new LimitedWaitable();
-		g_threadManager.EnqueueTask(new ReplacedTextureTask(*this, threadWaitable_), TaskType::IO_BLOCKING);
+		g_threadManager.EnqueueTask(new ReplacedTextureTask(*this, threadWaitable_));
 
 		if (threadWaitable_->WaitFor(budget)) {
 			threadWaitable_->WaitAndRelease();

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -340,6 +340,10 @@ public:
 		info_->readyEvent.Notify();
 	}
 
+	TaskType Type() const override {
+		return TaskType::IO_BLOCKING;
+	}
+
 	void Run() override {
 		// An early-return will result in the destructor running, where we can set
 		// flags like working and pending.
@@ -738,7 +742,7 @@ std::shared_ptr<GameInfo> GameInfoCache::GetInfo(Draw::DrawContext *draw, const 
 	}
 
 	GameInfoWorkItem *item = new GameInfoWorkItem(gamePath, info);
-	g_threadManager.EnqueueTask(item, TaskType::IO_BLOCKING);
+	g_threadManager.EnqueueTask(item);
 
 	// Don't re-insert if we already have it.
 	if (info_.find(pathStr) == info_.end())


### PR DESCRIPTION
Previously, the thread manager has one pool of threads, plus a small extra pool of threads that IO blocking tasks can spill into, if needed.  That pattern makes sense for a compute-heavy workload that occasionally gets a small number of IO blocking tasks, to most efficiently reuse the thread pool.

Unfortunately, our usage is the opposite: on startup (and even, perhaps, at runtime with replacements etc.) we have a bunch of IO blocking tasks.  And we end up with surges of compute tasks, each earmarked for *specific threads*, but otherwise these are outnumbered by IO blocking tasks.

The earmarked surges mean that even a single IO blocking thread can completely put what was meant to be a fast compute operation (say, copying a large amount of RAM for a save state) on hold, until that IO blocking operation completes.

As such, this moves blocking operations to their own dedicated part of the pool.  It's no longer allowed for IO blocking tasks to take up valuable space in the compute thread pool.  In exchange, the IO blocking pool has been increased to match the size of the compute thread pool.  Of course, this does mean a slight loss in threading efficiency - perhaps we could set the IO blocking threads at lower priority using the native handle...

I suspect that #15188 is because some prioritization was changed, and now a slow IO operation is interfering with compute operations.  Or in the worst case, a cross dependency (a blocking IO operation waiting for a compute parallel loop to finish.)  This would also fix a cross dependency, although I didn't find one.

-[Unknown]