### PR TITLE
[Adhoc] Updated PdpCreate, PdpSend, PdpRecv, GetPdpStat, GetPtpStat

### DIFF
--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1941,7 +1941,8 @@ uint16_t getLocalPort(int sock) {
 u_long getAvailToRecv(int sock, int udpBufferSize) {
 	u_long n = 0; // Typical MTU size is 1500
 	int err = -1;
-#if defined(_WIN32) // May not be available on all platform
+	// Note: FIONREAD may have different behavior depends on the platform, according to https://stackoverflow.com/questions/9278189/how-do-i-get-amount-of-queued-data-for-udp-socket/9296481#9296481
+#if defined(_WIN32)
 	err = ioctlsocket(sock, FIONREAD, &n);
 #else
 	err = ioctl(sock, FIONREAD, &n);
@@ -1950,6 +1951,7 @@ u_long getAvailToRecv(int sock, int udpBufferSize) {
 		return 0;
 
 	if (udpBufferSize > 0 && n > 0) {
+		// TODO: May need to filter out packets from an IP that can't be translated to MAC address
 		// TODO: Cap number of bytes of full DGRAM message(s) up to buffer size, but may cause Warriors Orochi 2 to get FPS drops
 	}
 	return n;

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -53,7 +53,7 @@
 #define INADDR_NONE 0xFFFFFFFF
 #endif
 
-static bool netInited;
+bool netInited;
 bool netInetInited;
 
 u32 netDropRate = 0;

--- a/Core/HLE/sceNet.h
+++ b/Core/HLE/sceNet.h
@@ -309,6 +309,7 @@ private:
 	u32_le argsAddr = 0;
 };
 
+extern bool netInited;
 extern bool netInetInited;
 extern bool netApctlInited;
 extern u32 netApctlState;

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1289,6 +1289,9 @@ static int sceNetAdhocPdpCreate(const char *mac, int port, int bufferSize, u32 f
 		return -1;
 	}
 
+	if (!netInited)
+		return 0x800201CA; //PSP_LWMUTEX_ERROR_NO_SUCH_LWMUTEX;
+
 	// Library is initialized
 	SceNetEtherAddr * saddr = (SceNetEtherAddr *)mac;
 	if (netAdhocInited) {

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1508,7 +1508,7 @@ static int sceNetAdhocPdpSend(int id, const char *mac, u32 port, void *data, int
 					// Valid Data Buffer
 					if (data != NULL) {
 						// Valid Destination Address
-						if (daddr != NULL) {
+						if (daddr != NULL && !isZeroMAC(daddr)) {
 							// Log Destination
 							// Schedule Timeout Removal
 							//if (flag) timeout = 0;
@@ -1580,7 +1580,8 @@ static int sceNetAdhocPdpSend(int id, const char *mac, u32 port, void *data, int
 									// Does PDP can Timeout? There is no concept of Timeout when sending UDP due to no ACK, but might happen if the socket buffer is full, not sure about PDP since some games did use the timeout arg
 									return hleLogDebug(SCENET, ERROR_NET_ADHOC_TIMEOUT, "timeout?"); // ERROR_NET_ADHOC_INVALID_ADDR;
 								}
-								//VERBOSE_LOG(SCENET, "sceNetAdhocPdpSend[%i:%u]: Unknown Target Peer %s:%u\n", id, getLocalPort(pdpsocket.id), mac2str(daddr, tmpmac), ntohs(target.sin_port));
+								VERBOSE_LOG(SCENET, "sceNetAdhocPdpSend[%i:%u]: Unknown Target Peer %s:%u (faking success)\n", id, getLocalPort(pdpsocket.id), mac2str(daddr).c_str(), ntohs(target.sin_port));
+								return 0; // faking success
 							}
 
 							// Broadcast Target


### PR DESCRIPTION
- Added another returned error code on PdpCreate
- Allow Sending to non-existing MAC address (except invalid/zero MAC). Fixes one of the issue i found while investigating NBA Ballers Rebound https://github.com/hrydgard/ppsspp/issues/15042#issuecomment-949454995
- Discard packets from an IP that can't be translated/resolved into player's MAC address (simple version) to prevent confusing the game, since the source MAC can't be updated, thus may contains invalid/wrong MAC. Also added a TODO to handle unresolvable packets properly.
- Updated GetPdpStat and GetPtpStat due to a possibility for FIONREAD to return 0 even when there is a data that can be received (according to stackoverflow)