### PR TITLE
ThreadManager: Check for exchange failure

### DIFF
--- a/Common/Thread/ThreadManager.cpp
+++ b/Common/Thread/ThreadManager.cpp
@@ -264,11 +264,11 @@ void ThreadManager::EnqueueTaskOnThread(int threadNum, Task *task) {
 
 	// Try first atomically, as highest priority.
 	Task *expected = nullptr;
-	thread->private_single.compare_exchange_weak(expected, task);
+	bool queued = thread->private_single.compare_exchange_weak(expected, task);
 	// Whether we got that or will have to wait, increase the queue counter.
 	thread->queue_size++;
 
-	if (expected == nullptr) {
+	if (queued) {
 		std::unique_lock<std::mutex> lock(thread->mutex);
 		thread->cond.notify_one();
 	} else {


### PR DESCRIPTION
Even if expected stays null, since it's weak assume it can fail.

I suppose if it's from d15af6e9, it has to be this or similar?

-[Unknown]