### PR TITLE
Vulkan: Avoid desc set error in tests

### DIFF
--- a/Common/GPU/Vulkan/VulkanMemory.cpp
+++ b/Common/GPU/Vulkan/VulkanMemory.cpp
@@ -194,6 +194,8 @@ void VulkanDescSetPool::Destroy() {
 
 	if (descPool_ != VK_NULL_HANDLE) {
 		vulkan_->Delete().QueueDeleteDescriptorPool(descPool_);
+		clear_();
+		usage_ = 0;
 	}
 }
 

--- a/Common/GPU/Vulkan/VulkanMemory.cpp
+++ b/Common/GPU/Vulkan/VulkanMemory.cpp
@@ -133,3 +133,90 @@ void VulkanPushBuffer::Unmap() {
 	vmaUnmapMemory(vulkan_->Allocator(), buffers_[buf_].allocation);
 	writePtr_ = nullptr;
 }
+
+VulkanDescSetPool::~VulkanDescSetPool() {
+	_assert_msg_(descPool_ == VK_NULL_HANDLE, "VulkanDescSetPool %s never destroyed", tag_);
+}
+
+void VulkanDescSetPool::Create(VulkanContext *vulkan, const VkDescriptorPoolCreateInfo &info, const std::vector<VkDescriptorPoolSize> &sizes) {
+	_assert_msg_(descPool_ == VK_NULL_HANDLE, "VulkanDescSetPool::Create when already exists");
+
+	vulkan_ = vulkan;
+	info_ = info;
+	sizes_ = sizes;
+
+	VkResult res = Recreate(false);
+	_assert_msg_(res == VK_SUCCESS, "Could not create VulkanDescSetPool %s", tag_);
+}
+
+VkDescriptorSet VulkanDescSetPool::Allocate(int n, const VkDescriptorSetLayout *layouts) {
+	if (descPool_ == VK_NULL_HANDLE || usage_ + n >= info_.maxSets) {
+		// Missing or out of space, need to recreate.
+		VkResult res = Recreate(grow_);
+		_assert_msg_(res == VK_SUCCESS, "Could not grow VulkanDescSetPool %s on usage %d", tag_, (int)usage_);
+	}
+
+	VkDescriptorSet desc;
+	VkDescriptorSetAllocateInfo descAlloc{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO };
+	descAlloc.descriptorPool = descPool_;
+	descAlloc.descriptorSetCount = n;
+	descAlloc.pSetLayouts = layouts;
+	VkResult result = vkAllocateDescriptorSets(vulkan_->GetDevice(), &descAlloc, &desc);
+
+	if (result == VK_ERROR_FRAGMENTED_POOL || result < 0) {
+		// There seems to have been a spec revision. Here we should apparently recreate the descriptor pool,
+		// so let's do that. See https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkAllocateDescriptorSets.html
+		// Fragmentation shouldn't really happen though since we wipe the pool every frame.
+		VkResult res = Recreate(false);
+		_assert_msg_(res == VK_SUCCESS, "Ran out of descriptor space (frag?) and failed to recreate a descriptor pool. sz=%d res=%d", usage_, (int)res);
+
+		// Need to update this pointer since we have allocated a new one.
+		descAlloc.descriptorPool = descPool_;
+		result = vkAllocateDescriptorSets(vulkan_->GetDevice(), &descAlloc, &desc);
+		_assert_msg_(result == VK_SUCCESS, "Ran out of descriptor space (frag?) and failed to allocate after recreating a descriptor pool. res=%d", (int)result);
+	}
+
+	if (result == VK_SUCCESS)
+		return desc;
+	return VK_NULL_HANDLE;
+}
+
+void VulkanDescSetPool::Reset() {
+	_assert_msg_(descPool_ != VK_NULL_HANDLE, "VulkanDescSetPool::Reset without valid pool");
+	vkResetDescriptorPool(vulkan_->GetDevice(), descPool_, 0);
+
+	clear_();
+	usage_ = 0;
+}
+
+void VulkanDescSetPool::Destroy() {
+	_assert_msg_(vulkan_ != nullptr, "VulkanDescSetPool::Destroy without VulkanContext");
+
+	if (descPool_ != VK_NULL_HANDLE) {
+		vulkan_->Delete().QueueDeleteDescriptorPool(descPool_);
+	}
+}
+
+VkResult VulkanDescSetPool::Recreate(bool grow) {
+	_assert_msg_(vulkan_ != nullptr, "VulkanDescSetPool::Recreate without VulkanContext");
+
+	uint32_t prevSize = info_.maxSets;
+	if (grow) {
+		info_.maxSets *= 2;
+		for (auto &size : sizes_)
+			size.descriptorCount *= 2;
+	}
+
+	// Delete the pool if it already exists.
+	if (descPool_ != VK_NULL_HANDLE) {
+		DEBUG_LOG(G3D, "Reallocating %s desc pool from %d to %d", tag_, prevSize, info_.maxSets);
+		vulkan_->Delete().QueueDeleteDescriptorPool(descPool_);
+		clear_();
+		usage_ = 0;
+	}
+
+	info_.pPoolSizes = &sizes_[0];
+	info_.poolSizeCount = (uint32_t)sizes_.size();
+
+	return vkCreateDescriptorPool(vulkan_->GetDevice(), &info_, nullptr, &descPool_);
+}

--- a/Common/GPU/Vulkan/VulkanMemory.h
+++ b/Common/GPU/Vulkan/VulkanMemory.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+#include <functional>
 #include <vector>
 #include <unordered_map>
 
@@ -133,4 +135,31 @@ private:
 	size_t size_ = 0;
 	uint8_t *writePtr_ = nullptr;
 	VkBufferUsageFlags usage_;
+};
+
+class VulkanDescSetPool {
+public:
+	VulkanDescSetPool(const char *tag, bool grow) : tag_(tag), grow_(grow) {
+	}
+	~VulkanDescSetPool();
+
+	void Setup(const std::function<void()> &clear) {
+		clear_ = clear;
+	}
+	void Create(VulkanContext *vulkan, const VkDescriptorPoolCreateInfo &info, const std::vector<VkDescriptorPoolSize> &sizes);
+	VkDescriptorSet Allocate(int n, const VkDescriptorSetLayout *layouts);
+	void Reset();
+	void Destroy();
+
+private:
+	VkResult Recreate(bool grow);
+
+	const char *tag_;
+	VulkanContext *vulkan_ = nullptr;
+	VkDescriptorPool descPool_ = VK_NULL_HANDLE;
+	VkDescriptorPoolCreateInfo info_;
+	std::vector<VkDescriptorPoolSize> sizes_;
+	std::function<void()> clear_;
+	uint32_t usage_ = 0;
+	bool grow_;
 };

--- a/Common/GPU/Vulkan/VulkanMemory.h
+++ b/Common/GPU/Vulkan/VulkanMemory.h
@@ -137,16 +137,20 @@ private:
 	VkBufferUsageFlags usage_;
 };
 
+// Only appropriate for use in a per-frame pool.
 class VulkanDescSetPool {
 public:
 	VulkanDescSetPool(const char *tag, bool grow) : tag_(tag), grow_(grow) {
 	}
 	~VulkanDescSetPool();
 
+	// Must call this before use: defines how to clear cache of ANY returned values from Allocate().
 	void Setup(const std::function<void()> &clear) {
 		clear_ = clear;
 	}
 	void Create(VulkanContext *vulkan, const VkDescriptorPoolCreateInfo &info, const std::vector<VkDescriptorPoolSize> &sizes);
+	// Allocate a new set, which may resize and empty the current sets.
+	// Use only for the current frame, unless in a cache cleared by clear_.
 	VkDescriptorSet Allocate(int n, const VkDescriptorSetLayout *layouts);
 	void Reset();
 	void Destroy();

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -142,10 +142,27 @@ void DrawEngineVulkan::InitDeviceObjects() {
 	VkResult res = vkCreateDescriptorSetLayout(device, &dsl, nullptr, &descriptorSetLayout_);
 	_dbg_assert_(VK_SUCCESS == res);
 
+	static constexpr int DEFAULT_DESC_POOL_SIZE = 512;
+	std::vector<VkDescriptorPoolSize> dpTypes;
+	dpTypes.resize(3);
+	dpTypes[0].descriptorCount = DEFAULT_DESC_POOL_SIZE * 3;
+	dpTypes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
+	dpTypes[1].descriptorCount = DEFAULT_DESC_POOL_SIZE * 3;  // Don't use these for tess anymore, need max three per set.
+	dpTypes[1].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+	dpTypes[2].descriptorCount = DEFAULT_DESC_POOL_SIZE * 3;  // TODO: Use a separate layout when no spline stuff is needed to reduce the need for these.
+	dpTypes[2].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+
+	VkDescriptorPoolCreateInfo dp{ VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
+	// Don't want to mess around with individually freeing these.
+	// We zap the whole pool every few frames.
+	dp.flags = 0;
+	dp.maxSets = DEFAULT_DESC_POOL_SIZE;
+
 	// We are going to use one-shot descriptors in the initial implementation. Might look into caching them
 	// if creating and updating them turns out to be expensive.
 	for (int i = 0; i < VulkanContext::MAX_INFLIGHT_FRAMES; i++) {
-		// We now create descriptor pools on demand, so removed from here.
+		frame_[i].descPool.Create(vulkan, dp, dpTypes);
+
 		// Note that pushUBO is also used for tessellation data (search for SetPushBuffer), and to upload
 		// the null texture. This should be cleaned up...
 		frame_[i].pushUBO = new VulkanPushBuffer(vulkan, 8 * 1024 * 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT, PushBufferType::CPU_TO_GPU);
@@ -189,9 +206,7 @@ DrawEngineVulkan::~DrawEngineVulkan() {
 }
 
 void DrawEngineVulkan::FrameData::Destroy(VulkanContext *vulkan) {
-	if (descPool != VK_NULL_HANDLE) {
-		vulkan->Delete().QueueDeleteDescriptorPool(descPool);
-	}
+	descPool.Destroy();
 
 	if (pushUBO) {
 		pushUBO->Destroy(vulkan);
@@ -290,10 +305,7 @@ void DrawEngineVulkan::BeginFrame() {
 	vertexCache_->BeginNoReset();
 
 	if (--descDecimationCounter_ <= 0) {
-		if (frame->descPool != VK_NULL_HANDLE)
-			vkResetDescriptorPool(vulkan->GetDevice(), frame->descPool, 0);
-		frame->descSets.Clear();
-		frame->descCount = 0;
+		frame->descPool.Reset();
 		descDecimationCounter_ = DESCRIPTORSET_DECIMATION_INTERVAL;
 	}
 
@@ -343,38 +355,6 @@ void DrawEngineVulkan::DecodeVertsToPushBuffer(VulkanPushBuffer *push, uint32_t 
 	DecodeVerts(dest);
 }
 
-VkResult DrawEngineVulkan::RecreateDescriptorPool(FrameData &frame, int newSize) {
-	VulkanContext *vulkan = (VulkanContext *)draw_->GetNativeObject(Draw::NativeObject::CONTEXT);
-
-	// Reallocate this desc pool larger, and "wipe" the cache. We might lose a tiny bit of descriptor set reuse but
-	// only for this frame.
-	if (frame.descPool) {
-		DEBUG_LOG(G3D, "Reallocating desc pool from %d to %d", frame.descPoolSize, newSize);
-		vulkan->Delete().QueueDeleteDescriptorPool(frame.descPool);
-		frame.descSets.Clear();
-		frame.descCount = 0;
-	}
-	frame.descPoolSize = newSize;
-
-	VkDescriptorPoolSize dpTypes[3];
-	dpTypes[0].descriptorCount = frame.descPoolSize * 3;
-	dpTypes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
-	dpTypes[1].descriptorCount = frame.descPoolSize * 3;  // Don't use these for tess anymore, need max three per set.
-	dpTypes[1].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-	dpTypes[2].descriptorCount = frame.descPoolSize * 3;  // TODO: Use a separate layout when no spline stuff is needed to reduce the need for these.
-	dpTypes[2].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-
-	VkDescriptorPoolCreateInfo dp{ VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
-	dp.flags = 0;   // Don't want to mess around with individually freeing these.
-									// We zap the whole pool every few frames.
-	dp.maxSets = frame.descPoolSize;
-	dp.pPoolSizes = dpTypes;
-	dp.poolSizeCount = ARRAY_SIZE(dpTypes);
-
-	VkResult res = vkCreateDescriptorPool(vulkan->GetDevice(), &dp, nullptr, &frame.descPool);
-	return res;
-}
-
 VkDescriptorSet DrawEngineVulkan::GetOrCreateDescriptorSet(VkImageView imageView, VkSampler sampler, VkBuffer base, VkBuffer light, VkBuffer bone, bool tess) {
 	_dbg_assert_(base != VK_NULL_HANDLE);
 	_dbg_assert_(light != VK_NULL_HANDLE);
@@ -397,35 +377,12 @@ VkDescriptorSet DrawEngineVulkan::GetOrCreateDescriptorSet(VkImageView imageView
 			return d;
 	}
 
-	if (!frame.descPool || frame.descPoolSize < frame.descCount + 1) {
-		VkResult res = RecreateDescriptorPool(frame, frame.descPoolSize * 2);
-		_dbg_assert_(res == VK_SUCCESS);
-	}
-
 	// Didn't find one in the frame descriptor set cache, let's make a new one.
 	// We wipe the cache on every frame.
-
-	VulkanContext *vulkan = (VulkanContext *)draw_->GetNativeObject(Draw::NativeObject::CONTEXT);
-	VkDescriptorSet desc;
-	VkDescriptorSetAllocateInfo descAlloc{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO };
-	descAlloc.pSetLayouts = &descriptorSetLayout_;
-	descAlloc.descriptorPool = frame.descPool;
-	descAlloc.descriptorSetCount = 1;
-	VkResult result = vkAllocateDescriptorSets(vulkan->GetDevice(), &descAlloc, &desc);
-
-	if (result == VK_ERROR_FRAGMENTED_POOL || result < 0) {
-		// There seems to have been a spec revision. Here we should apparently recreate the descriptor pool,
-		// so let's do that. See https://www.khronos.org/registry/vulkan/specs/1.0/man/html/vkAllocateDescriptorSets.html
-		// Fragmentation shouldn't really happen though since we wipe the pool every frame..
-		VkResult res = RecreateDescriptorPool(frame, frame.descPoolSize);
-		_assert_msg_(res == VK_SUCCESS, "Ran out of descriptor space (frag?) and failed to recreate a descriptor pool. sz=%d res=%d", (int)frame.descSets.size(), (int)res);
-		descAlloc.descriptorPool = frame.descPool;  // Need to update this pointer since we have allocated a new one.
-		result = vkAllocateDescriptorSets(vulkan->GetDevice(), &descAlloc, &desc);
-		_assert_msg_(result == VK_SUCCESS, "Ran out of descriptor space (frag?) and failed to allocate after recreating a descriptor pool. res=%d", (int)result);
-	}
+	VkDescriptorSet desc = frame.descPool.Allocate(1, &descriptorSetLayout_);
 
 	// Even in release mode, this is bad.
-	_assert_msg_(result == VK_SUCCESS, "Ran out of descriptor space in pool. sz=%d res=%d", (int)frame.descSets.size(), (int)result);
+	_assert_msg_(desc != VK_NULL_HANDLE, "Ran out of descriptor space in pool. sz=%d", (int)frame.descSets.size());
 
 	// We just don't write to the slots we don't care about, which is fine.
 	VkWriteDescriptorSet writes[9]{};
@@ -535,11 +492,11 @@ VkDescriptorSet DrawEngineVulkan::GetOrCreateDescriptorSet(VkImageView imageView
 		n++;
 	}
 
+	VulkanContext *vulkan = (VulkanContext *)draw_->GetNativeObject(Draw::NativeObject::CONTEXT);
 	vkUpdateDescriptorSets(vulkan->GetDevice(), n, writes, 0, nullptr);
 
 	if (!tess) // Again, avoid caching when HW tessellation.
 		frame.descSets.Insert(key, desc);
-	frame.descCount++;
 	return desc;
 }
 

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -32,6 +32,7 @@
 // won't get any bone data, etc.
 
 #include "Common/Data/Collections/Hashmaps.h"
+#include "Common/GPU/Vulkan/VulkanMemory.h"
 
 #include "GPU/Vulkan/VulkanUtil.h"
 
@@ -199,7 +200,6 @@ private:
 	void DestroyDeviceObjects();
 
 	void DecodeVertsToPushBuffer(VulkanPushBuffer *push, uint32_t *bindOffset, VkBuffer *vkbuf);
-	VkResult RecreateDescriptorPool(FrameData &frame, int newSize);
 
 	void DoFlush();
 	void UpdateUBOs(FrameData *frame);
@@ -235,11 +235,11 @@ private:
 
 	// We alternate between these.
 	struct FrameData {
-		FrameData() : descSets(512) {}
+		FrameData() : descSets(512), descPool("DrawEngine", true) {
+			descPool.Setup([this] { descSets.Clear(); });
+		}
 
-		VkDescriptorPool descPool = VK_NULL_HANDLE;
-		int descCount = 0;
-		int descPoolSize = 256;  // We double this before we allocate so we initialize this to half the size we want.
+		VulkanDescSetPool descPool;
 
 		VulkanPushBuffer *pushUBO = nullptr;
 		VulkanPushBuffer *pushVertex = nullptr;

--- a/GPU/Vulkan/VulkanUtil.h
+++ b/GPU/Vulkan/VulkanUtil.h
@@ -22,8 +22,9 @@
 
 #include "Common/Data/Collections/Hashmaps.h"
 #include "Common/GPU/Vulkan/VulkanContext.h"
-#include "Common/GPU/Vulkan/VulkanLoader.h"
 #include "Common/GPU/Vulkan/VulkanImage.h"
+#include "Common/GPU/Vulkan/VulkanLoader.h"
+#include "Common/GPU/Vulkan/VulkanMemory.h"
 
 extern const VkComponentMapping VULKAN_4444_SWIZZLE;
 extern const VkComponentMapping VULKAN_1555_SWIZZLE;
@@ -126,15 +127,15 @@ private:
 	};
 
 	struct FrameData {
-		VkDescriptorPool descPool;
-		int descPoolSize = 0;
+		FrameData() : descPool("Vulkan2D", true) {
+			descPool.Setup([this] { descSets.clear(); });
+		}
+
+		VulkanDescSetPool descPool;
 		std::map<DescriptorSetKey, VkDescriptorSet> descSets;
 	};
 
 	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES];
-
-	bool RecreateDescriptorPool(FrameData &frame, int newSize);
-
 	std::map<PipelineKey, VkPipeline> pipelines_;
 	std::vector<VkPipeline> keptPipelines_;
 };
@@ -173,10 +174,13 @@ private:
 	VkPipelineCache pipelineCache_ = VK_NULL_HANDLE;
 
 	struct FrameData {
-		VkDescriptorPool descPool;
-		int numDescriptors;
+		FrameData() : descPool("VulkanComputeShaderManager", true) {
+			descPool.Setup([this] { });
+		}
+
+		VulkanDescSetPool descPool;
 	};
-	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES]{};
+	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES];
 
 	struct PipelineKey {
 		VkShaderModule module;

--- a/GPU/Vulkan/VulkanUtil.h
+++ b/GPU/Vulkan/VulkanUtil.h
@@ -127,10 +127,13 @@ private:
 
 	struct FrameData {
 		VkDescriptorPool descPool;
+		int descPoolSize = 0;
 		std::map<DescriptorSetKey, VkDescriptorSet> descSets;
 	};
 
 	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES];
+
+	bool RecreateDescriptorPool(FrameData &frame, int newSize);
 
 	std::map<PipelineKey, VkPipeline> pipelines_;
 	std::vector<VkPipeline> keptPipelines_;


### PR DESCRIPTION
This requires quite a few DrawActiveTextures, but some pspautotests were triggering it.

Additionally, we had a few copies of this logic so I refactored to common handling of recreating desc set pools.  This now more consistently clears cached desc sets on device lost.

-[Unknown]