### PR TITLE
Vulkan: Fix use-after-free on shutdown

### DIFF
--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -449,7 +449,7 @@ void VulkanRenderManager::CompileThreadFunc() {
 		if (!run_) {
 			break;
 		}
-		for (auto entry : toCompile) {
+		for (auto &entry : toCompile) {
 			switch (entry.type) {
 			case CompileQueueEntry::Type::GRAPHICS:
 				entry.graphics->Create(vulkan_);

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -37,7 +37,10 @@ void PipelineManagerVulkan::Clear() {
 		if (value->pipeline) {
 			VkPipeline pipeline = value->pipeline->pipeline;
 			vulkan_->Delete().QueueDeletePipeline(pipeline);
-			delete value->pipeline;
+			vulkan_->Delete().QueueCallback([](void *p) {
+				VKRGraphicsPipeline *pipeline = (VKRGraphicsPipeline *)p;
+				delete pipeline;
+			}, value->pipeline);
 		} else {
 			// Something went wrong.
 			ERROR_LOG(G3D, "Null pipeline found in PipelineManagerVulkan::Clear - didn't wait for asyncs?");


### PR DESCRIPTION
Because the pipeline's atomics and etc. are accessed by the queue runner, we can't delete it until its last usage on the queue.

I'd previously thought this crash was some timing issue with compilation, but it was all about deletion.  This fixes the random crash on `vkCmdBindPipeline()` during shutdown.

-[Unknown]