### PR TITLE
softjit: Throw away regs allocated in conditionals

### DIFF
--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -631,6 +631,10 @@ bool PixelJitCache::Jit_StencilTest(const PixelFuncID &id, RegCache::Reg stencil
 		case GE_COMP_GREATER: fixedResult = id.stencilTestRef != 0; break;
 		case GE_COMP_GEQUAL: fixedResult = true; break;
 		}
+	} else if (id.StencilTestFunc() == GE_COMP_ALWAYS) {
+		// Fairly common, skip the CMP.
+		hasFixedResult = true;
+		fixedResult = true;
 	} else {
 		// Reversed here because of the imm, so tests below are reversed.
 		CMP(8, R(maskedReg), Imm8(id.stencilTestRef));
@@ -641,8 +645,7 @@ bool PixelJitCache::Jit_StencilTest(const PixelFuncID &id, RegCache::Reg stencil
 			break;
 
 		case GE_COMP_ALWAYS:
-			hasFixedResult = true;
-			fixedResult = true;
+			_assert_(false);
 			break;
 
 		case GE_COMP_EQUAL:

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -676,6 +676,9 @@ bool PixelJitCache::Jit_StencilTest(const PixelFuncID &id, RegCache::Reg stencil
 		return true;
 	}
 
+	bool hadGStateReg = regCache_.Has(RegCache::GEN_GSTATE);
+	bool hadColorOffReg = regCache_.Has(RegCache::GEN_COLOR_OFF);
+
 	bool success = true;
 	if (stencilReg != INVALID_REG && (!hasFixedResult || !fixedResult)) {
 		// This is the fail path.
@@ -684,6 +687,12 @@ bool PixelJitCache::Jit_StencilTest(const PixelFuncID &id, RegCache::Reg stencil
 
 		Discard();
 	}
+
+	// If we allocated either gstate or colorOff in the conditional, forget.
+	if (!hadGStateReg && regCache_.Has(RegCache::GEN_GSTATE))
+		regCache_.Change(RegCache::GEN_GSTATE, RegCache::GEN_INVALID);
+	if (!hadColorOffReg && regCache_.Has(RegCache::GEN_COLOR_OFF))
+		regCache_.Change(RegCache::GEN_COLOR_OFF, RegCache::GEN_INVALID);
 
 	if (!hasFixedResult)
 		SetJumpTarget(toPass);
@@ -741,10 +750,19 @@ bool PixelJitCache::Jit_DepthTestForStencil(const PixelFuncID &id, RegCache::Reg
 		break;
 	}
 
+	bool hadGStateReg = regCache_.Has(RegCache::GEN_GSTATE);
+	bool hadColorOffReg = regCache_.Has(RegCache::GEN_COLOR_OFF);
+
 	bool success = true;
 	success = success && Jit_ApplyStencilOp(id, id.ZFail(), stencilReg);
 	success = success && Jit_WriteStencilOnly(id, stencilReg);
 	Discard();
+
+	// If we allocated either gstate or colorOff in the conditional, forget.
+	if (!hadGStateReg && regCache_.Has(RegCache::GEN_GSTATE))
+		regCache_.Change(RegCache::GEN_GSTATE, RegCache::GEN_INVALID);
+	if (!hadColorOffReg && regCache_.Has(RegCache::GEN_COLOR_OFF))
+		regCache_.Change(RegCache::GEN_COLOR_OFF, RegCache::GEN_INVALID);
 
 	SetJumpTarget(skip);
 


### PR DESCRIPTION
This was a silly mistake, should've thought of it.

Ideally we'll already have these beforehand, so won't throw away anything.  But if we allocate inside a conditional we can't trust it beyond the conditional.  Technically was accidentally fixed in the branchless vectorized version, but unfortunately that wasn't really faster...

-[Unknown]