### PR TITLE
Correct vrndf2 range

### DIFF
--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -1549,10 +1549,11 @@ namespace MIPSInt
 		VectorSize sz = GetVecSize(op);
 		int n = GetNumVectorElements(sz);
 		for (int i = 0; i < n; i++) {
+			// TODO: Make more accurate, use and update RCX regs?
 			switch ((op >> 16) & 0x1f) {
 			case 1: d.u[i] = currentMIPS->rng.R32(); break;  // vrndi
-			case 2: d.f[i] = 1.0f + ((float)currentMIPS->rng.R32() / 0xFFFFFFFF); break; // vrndf1   TODO: make more accurate
-			case 3: d.f[i] = 2.0f + 2 * ((float)currentMIPS->rng.R32() / 0xFFFFFFFF); break; // vrndf2   TODO: make more accurate
+			case 2: d.u[i] = 0x3F800000 | (currentMIPS->rng.R32() & 0x007FFFFF); break; // vrndf1 (>= 1, < 2)
+			case 3: d.u[i] = 0x40000000 | (currentMIPS->rng.R32() & 0x007FFFFF); break; // vrndf2 (>= 2, < 4)
 			default: _dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			}
 		}


### PR DESCRIPTION
This seems more likely to be how the hardware works, given the range of values and seed/random.

This silences a warning and corrects the range of values, since at 0xFFFFFFFF, the floats were losing a bit of accuracy.

-[Unknown]