### PR TITLE
Vulkan: 4xBRZ texture upscaling shader optimizations

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -15,7 +15,8 @@
 // Mostly useful for profiling texture uploads currently, but could be useful for
 // other things as well. We also have a nice integrated render pass profiler in the queue
 // runner, but this one is more convenient for transient events.
-// #define VULKAN_PROFILER_ENABLED
+
+#define VULKAN_PROFILER_ENABLED
 
 #if defined(VULKAN_PROFILER_ENABLED)
 #define VK_PROFILE_BEGIN(vulkan, cmd, stage, message) vulkan->GetProfiler()->Begin(cmd, stage, message);

--- a/Common/GPU/Vulkan/VulkanProfiler.cpp
+++ b/Common/GPU/Vulkan/VulkanProfiler.cpp
@@ -30,6 +30,11 @@ void VulkanProfiler::BeginFrame(VulkanContext *vulkan, VkCommandBuffer firstComm
 		uint64_t timestampDiffMask = validBits == 64 ? 0xFFFFFFFFFFFFFFFFULL : ((1ULL << validBits) - 1);
 
 		static const char * const indent[4] = { "", "  ", "    ", "      " };
+
+		if (!scopes_.empty()) {
+			NOTICE_LOG(G3D, "Profiling events this frame:");
+		}
+
 		// Log it all out.
 		for (auto &scope : scopes_) {
 			if (scope.endQueryId == -1) {
@@ -45,7 +50,9 @@ void VulkanProfiler::BeginFrame(VulkanContext *vulkan, VkCommandBuffer firstComm
 
 			NOTICE_LOG(G3D, "%s%s (%0.3f ms)", indent[scope.level & 3], scope.name.c_str(), milliseconds);
 		}
+
 		scopes_.clear();
+		scopeStack_.clear();
 	}
 
 	// Only need to reset all on the first frame.

--- a/Common/GPU/Vulkan/VulkanProfiler.h
+++ b/Common/GPU/Vulkan/VulkanProfiler.h
@@ -15,8 +15,8 @@
 
 struct ProfilerScope {
 	std::string name;
-	size_t startQueryId;
-	size_t endQueryId;
+	int startQueryId;
+	int endQueryId;
 	int level;
 };
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -1239,7 +1239,6 @@ void VulkanRenderManager::BeginSubmitFrame(int frame) {
 	FrameData &frameData = frameData_[frame];
 	if (!frameData.hasBegun) {
 		// Get the index of the next available swapchain image, and a semaphore to block command buffer execution on.
-		// Now, I wonder if we should do this early in the frame or late? Right now we do it early, which should be fine.
 		VkResult res = vkAcquireNextImageKHR(vulkan_->GetDevice(), vulkan_->GetSwapchain(), UINT64_MAX, acquireSemaphore_, (VkFence)VK_NULL_HANDLE, &frameData.curSwapchainImage);
 		if (res == VK_SUBOPTIMAL_KHR) {
 			// Hopefully the resize will happen shortly. Ignore - one frame might look bad or something.

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -664,6 +664,50 @@
       <Project>{4328a62c-f1e9-47ed-b816-a1a81daf4363}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <FxCompile Include="..\assets\shaders\tex_2xbrz.csh">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </FxCompile>
+    <FxCompile Include="..\assets\shaders\tex_4xbrz.csh">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </FxCompile>
+    <FxCompile Include="..\assets\shaders\tex_mmpx.csh">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </FxCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\assets\shaders\defaultshaders.ini">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </None>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -22,6 +22,9 @@
     <Filter Include="D3D11">
       <UniqueIdentifier>{88eb5cea-ec25-4881-89da-02f9f2fa8f3f}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Shaders">
+      <UniqueIdentifier>{3a7618ae-e254-406a-8ae5-590bb077d8a1}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Math3D.h">
@@ -551,5 +554,21 @@
     <ClCompile Include="Software\RasterizerRegCache.cpp">
       <Filter>Software</Filter>
     </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <FxCompile Include="..\assets\shaders\tex_4xbrz.csh">
+      <Filter>Shaders</Filter>
+    </FxCompile>
+    <FxCompile Include="..\assets\shaders\tex_mmpx.csh">
+      <Filter>Shaders</Filter>
+    </FxCompile>
+    <FxCompile Include="..\assets\shaders\tex_2xbrz.csh">
+      <Filter>Shaders</Filter>
+    </FxCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\assets\shaders\defaultshaders.ini">
+      <Filter>Shaders</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -736,7 +736,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		VkImageLayout imageLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
 		VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
 
-		bool enableVideoUpscaling = true;
+		bool enableVideoUpscaling = false;
 
 		if (actualFmt == VULKAN_8888_FORMAT && scaleFactor > 1 && hardwareScaling && (enableVideoUpscaling || !isVideo)) {
 			if (uploadCS_ != VK_NULL_HANDLE)

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -630,7 +630,6 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 
 	VkFormat dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
 
-
 	int scaleFactor = standardScaleFactor_;
 	bool hardwareScaling = g_Config.bTexHardwareScaling && uploadCS_ != VK_NULL_HANDLE;
 	if (hardwareScaling) {
@@ -683,15 +682,21 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		maxLevel = 0;
 	}
 
-	int maxPossibleMipmaps = log2i(std::min(w * scaleFactor, h * scaleFactor));
+	int maxPossibleMipLevel = log2i(std::min(w * scaleFactor, h * scaleFactor));
+
+	bool isVideo = IsVideo(entry->addr);
+
+	if (maxPossibleMipLevel > 0 && isVideo) {
+		maxPossibleMipLevel = 0;
+	}
 
 	// TODO: Really should inspect the format capabilities.
 	if (g_Config.iTexFiltering == TEX_FILTER_AUTO_MAX_QUALITY) {
 		// Boost the number of mipmaps.
-		if (maxPossibleMipmaps > maxLevelToGenerate) {
+		if (maxPossibleMipLevel > maxLevelToGenerate) {
 			dstFmt = VK_FORMAT_R8G8B8A8_UNORM;
 		}
-		maxLevelToGenerate = maxPossibleMipmaps;
+		maxLevelToGenerate = maxPossibleMipLevel;
 	}
 
 	// Any texture scaling is gonna move away from the original 16-bit format, if any.
@@ -731,7 +736,9 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		VkImageLayout imageLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
 		VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
 
-		if (actualFmt == VULKAN_8888_FORMAT && scaleFactor > 1 && hardwareScaling && !IsVideo(entry->addr)) {
+		bool enableVideoUpscaling = true;
+
+		if (actualFmt == VULKAN_8888_FORMAT && scaleFactor > 1 && hardwareScaling && (enableVideoUpscaling || !isVideo)) {
 			if (uploadCS_ != VK_NULL_HANDLE)
 				computeUpload = true;
 		}
@@ -779,7 +786,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		replacedInfo.cachekey = entry->CacheKey();
 		replacedInfo.hash = entry->fullhash;
 		replacedInfo.addr = entry->addr;
-		replacedInfo.isVideo = IsVideo(entry->addr);
+		replacedInfo.isVideo = isVideo;
 		replacedInfo.isFinal = (entry->status & TexCacheEntry::STATUS_TO_SCALE) == 0;
 		replacedInfo.scaleFactor = scaleFactor;
 		replacedInfo.fmt = FromVulkanFormat(actualFmt);
@@ -852,7 +859,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 						data = drawEngine_->GetPushBufferForTextureData()->PushAligned(size, &bufferOffset, &texBuf, pushAlignment);
 						LoadTextureLevel(*entry, (uint8_t *)data, stride, i, scaleFactor, dstFmt);
 						VK_PROFILE_BEGIN(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT,
-							StringFromFormat("Copy Upload (replaced): %dx%d", mipWidth, mipHeight));
+							StringFromFormat("Copy Upload: %dx%d", mipWidth, mipHeight));
 						entry->vkTex->UploadMip(cmdInit, i, mipWidth, mipHeight, texBuf, bufferOffset, stride / bpp);
 						VK_PROFILE_END(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT);
 					}
@@ -1024,6 +1031,7 @@ bool TextureCacheVulkan::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int leve
 
 	if (!entry->vkTex)
 		return false;
+
 	VulkanTexture *texture = entry->vkTex;
 	VulkanRenderManager *renderManager = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -794,7 +794,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 
 	if (entry->vkTex) {
 		VK_PROFILE_BEGIN(vulkan, cmdInit, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-			StringFromFormat("Texture Upload"));
+			StringFromFormat("Texture Upload (%08x) video=%d", entry->addr, isVideo));
 
 		// NOTE: Since the level is not part of the cache key, we assume it never changes.
 		u8 level = std::max(0, gstate.getTexLevelOffset16() / 16);

--- a/assets/shaders/defaultshaders.ini
+++ b/assets/shaders/defaultshaders.ini
@@ -154,6 +154,12 @@ Name=PSP Color
 Author=hunterk, Pokefan531 (ported by jdgleaver)
 Fragment=psp_color.fsh
 Vertex=fxaa.vsh
+[Tex2xBRZ]
+Type=Texture
+Name=2xBRZ (2x)
+Author=Hyllian
+Compute=tex_2xbrz.csh
+Scale=2
 [Tex4xBRZ]
 Type=Texture
 Name=4xBRZ (4x)

--- a/assets/shaders/tex_2xbrz.csh
+++ b/assets/shaders/tex_2xbrz.csh
@@ -100,6 +100,11 @@ void applyScaling(uvec2 origxy) {
 
 	ivec4 blendResult = ivec4(BLEND_NONE);
 
+	// Preserve old alpha-ignoring behavior? Keep or delete?
+	for (int i = 0; i < 9; i++) {
+		v[i] &= 0xFFFFFF;
+	}
+
 	// Preprocess corners
 	// Pixel Tap Mapping: --|--|--|--|--
 	//                    --|--|07|08|--

--- a/assets/shaders/tex_2xbrz.csh
+++ b/assets/shaders/tex_2xbrz.csh
@@ -1,0 +1,269 @@
+// 4xBRZ shader - Copyright (C) 2014-2016 DeSmuME team (GPL2+)
+// Hyllians xBR-vertex code and texel mapping
+// Copyright (C) 2011/2016 Hyllian - sergiogdb@gmail.com
+#define BLEND_ALPHA 1
+#define BLEND_NONE 0
+#define BLEND_NORMAL 1
+#define BLEND_DOMINANT 2
+#define LUMINANCE_WEIGHT 1.0
+#define EQUAL_COLOR_TOLERANCE 30.0/255.0
+#define STEEP_DIRECTION_THRESHOLD 2.2
+#define DOMINANT_DIRECTION_THRESHOLD 3.6
+
+float reduce(vec4 color) {
+	return dot(color.rgb, vec3(65536.0, 256.0, 1.0));
+}
+
+float DistYCbCr(vec4 pixA, vec4 pixB) {
+	// https://en.wikipedia.org/wiki/YCbCr#ITU-R_BT.2020_conversion
+	const vec3 K = vec3(0.2627, 0.6780, 0.0593);
+	const mat3 MATRIX = mat3(K,
+	                         -.5 * K.r / (1.0 - K.b),  -.5 * K.g / (1.0 - K.b),  .5,
+	                         .5,                       -.5 * K.g / (1.0 - K.r),  -.5 * K.b / (1.0 - K.r));
+	vec4 diff = pixA - pixB;
+	vec3 YCbCr = diff.rgb * MATRIX;
+	YCbCr.x *= LUMINANCE_WEIGHT;
+	float d = length(YCbCr);
+	return sqrt(pixA.a * pixB.a * d * d + diff.a * diff.a);
+}
+
+bool IsPixEqual(const vec4 pixA, const vec4 pixB) {
+	return (DistYCbCr(pixA, pixB) < EQUAL_COLOR_TOLERANCE);
+}
+
+bool IsBlendingNeeded(const ivec4 blend) {
+	ivec4 diff = blend - ivec4(BLEND_NONE);
+	return diff.x != 0 || diff.y != 0 || diff.z != 0 || diff.w != 0;
+}
+
+vec4 readInput(uvec2 coord) {
+    return readColorf(uvec2(clamp(coord.x, 0, params.width - 1), clamp(coord.y, 0, params.height - 1)));
+}
+
+void applyScaling(uvec2 origxy) {
+	//    A1 B1 C1
+	// A0 A  B  C C4
+	// D0 D  E  F F4
+	// G0 G  H  I I4
+	//    G5 H5 I5
+
+	uvec4 t1 = uvec4(origxy.x - 1, origxy.x, origxy.x + 1, origxy.y - 2); // A1 B1 C1
+	uvec4 t2 = uvec4(origxy.x - 1, origxy.x, origxy.x + 1, origxy.y - 1); // A B C
+	uvec4 t3 = uvec4(origxy.x - 1, origxy.x, origxy.x + 1, origxy.y + 0); // D E F
+	uvec4 t4 = uvec4(origxy.x - 1, origxy.x, origxy.x + 1, origxy.y + 1); // G H I
+	uvec4 t5 = uvec4(origxy.x - 1, origxy.x, origxy.x + 1, origxy.y + 2); // G5 H5 I5
+	uvec4 t6 = uvec4(origxy.x - 2, origxy.y - 1, origxy.y, origxy.y + 1); // A0 D0 G0
+	uvec4 t7 = uvec4(origxy.x + 2, origxy.y - 1, origxy.y, origxy.y + 1); // C4 F4 I4
+
+	//---------------------------------------
+	// Input Pixel Mapping:    |21|22|23|
+	//                       19|06|07|08|09
+	//                       18|05|00|01|10
+	//                       17|04|03|02|11
+	//                         |15|14|13|
+
+	vec4 src[25];
+
+	src[21] = readInput(t1.xw);
+	src[22] = readInput(t1.yw);
+	src[23] = readInput(t1.zw);
+	src[ 6] = readInput(t2.xw);
+	src[ 7] = readInput(t2.yw);
+	src[ 8] = readInput(t2.zw);
+	src[ 5] = readInput(t3.xw);
+	src[ 0] = readInput(t3.yw);
+	src[ 1] = readInput(t3.zw);
+	src[ 4] = readInput(t4.xw);
+	src[ 3] = readInput(t4.yw);
+	src[ 2] = readInput(t4.zw);
+	src[15] = readInput(t5.xw);
+	src[14] = readInput(t5.yw);
+	src[13] = readInput(t5.zw);
+	src[19] = readInput(t6.xy);
+	src[18] = readInput(t6.xz);
+	src[17] = readInput(t6.xw);
+	src[ 9] = readInput(t7.xy);
+	src[10] = readInput(t7.xz);
+	src[11] = readInput(t7.xw);
+
+	float v[9];
+	v[0] = reduce(src[0]);
+	v[1] = reduce(src[1]);
+	v[2] = reduce(src[2]);
+	v[3] = reduce(src[3]);
+	v[4] = reduce(src[4]);
+	v[5] = reduce(src[5]);
+	v[6] = reduce(src[6]);
+	v[7] = reduce(src[7]);
+	v[8] = reduce(src[8]);
+
+	ivec4 blendResult = ivec4(BLEND_NONE);
+
+	// Preprocess corners
+	// Pixel Tap Mapping: --|--|--|--|--
+	//                    --|--|07|08|--
+	//                    --|05|00|01|10
+	//                    --|04|03|02|11
+	//                    --|--|14|13|--
+	// Corner (1, 1)
+	if ( ((v[0] == v[1] && v[3] == v[2]) || (v[0] == v[3] && v[1] == v[2])) == false) {
+		float dist_03_01 = DistYCbCr(src[ 4], src[ 0]) + DistYCbCr(src[ 0], src[ 8]) + DistYCbCr(src[14], src[ 2]) + DistYCbCr(src[ 2], src[10]) + (4.0 * DistYCbCr(src[ 3], src[ 1]));
+		float dist_00_02 = DistYCbCr(src[ 5], src[ 3]) + DistYCbCr(src[ 3], src[13]) + DistYCbCr(src[ 7], src[ 1]) + DistYCbCr(src[ 1], src[11]) + (4.0 * DistYCbCr(src[ 0], src[ 2]));
+		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_03_01) < dist_00_02;
+		blendResult[2] = ((dist_03_01 < dist_00_02) && (v[0] != v[1]) && (v[0] != v[3])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
+	}
+
+	// Pixel Tap Mapping: --|--|--|--|--
+	//                    --|06|07|--|--
+	//                    18|05|00|01|--
+	//                    17|04|03|02|--
+	//                    --|15|14|--|--
+	// Corner (0, 1)
+	if ( ((v[5] == v[0] && v[4] == v[3]) || (v[5] == v[4] && v[0] == v[3])) == false) {
+		float dist_04_00 = DistYCbCr(src[17], src[ 5]) + DistYCbCr(src[ 5], src[ 7]) + DistYCbCr(src[15], src[ 3]) + DistYCbCr(src[ 3], src[ 1]) + (4.0 * DistYCbCr(src[ 4], src[ 0]));
+		float dist_05_03 = DistYCbCr(src[18], src[ 4]) + DistYCbCr(src[ 4], src[14]) + DistYCbCr(src[ 6], src[ 0]) + DistYCbCr(src[ 0], src[ 2]) + (4.0 * DistYCbCr(src[ 5], src[ 3]));
+		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_05_03) < dist_04_00;
+		blendResult[3] = ((dist_04_00 > dist_05_03) && (v[0] != v[5]) && (v[0] != v[3])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
+	}
+
+	// Pixel Tap Mapping: --|--|22|23|--
+	//                    --|06|07|08|09
+	//                    --|05|00|01|10
+	//                    --|--|03|02|--
+	//                    --|--|--|--|--
+	// Corner (1, 0)
+	if ( ((v[7] == v[8] && v[0] == v[1]) || (v[7] == v[0] && v[8] == v[1])) == false) {
+		float dist_00_08 = DistYCbCr(src[ 5], src[ 7]) + DistYCbCr(src[ 7], src[23]) + DistYCbCr(src[ 3], src[ 1]) + DistYCbCr(src[ 1], src[ 9]) + (4.0 * DistYCbCr(src[ 0], src[ 8]));
+		float dist_07_01 = DistYCbCr(src[ 6], src[ 0]) + DistYCbCr(src[ 0], src[ 2]) + DistYCbCr(src[22], src[ 8]) + DistYCbCr(src[ 8], src[10]) + (4.0 * DistYCbCr(src[ 7], src[ 1]));
+		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_07_01) < dist_00_08;
+		blendResult[1] = ((dist_00_08 > dist_07_01) && (v[0] != v[7]) && (v[0] != v[1])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
+	}
+
+	// Pixel Tap Mapping: --|21|22|--|--
+	//                    19|06|07|08|--
+	//                    18|05|00|01|--
+	//                    --|04|03|--|--
+	//                    --|--|--|--|--
+	// Corner (0, 0)
+	if ( ((v[6] == v[7] && v[5] == v[0]) || (v[6] == v[5] && v[7] == v[0])) == false) {
+		float dist_05_07 = DistYCbCr(src[18], src[ 6]) + DistYCbCr(src[ 6], src[22]) + DistYCbCr(src[ 4], src[ 0]) + DistYCbCr(src[ 0], src[ 8]) + (4.0 * DistYCbCr(src[ 5], src[ 7]));
+		float dist_06_00 = DistYCbCr(src[19], src[ 5]) + DistYCbCr(src[ 5], src[ 3]) + DistYCbCr(src[21], src[ 7]) + DistYCbCr(src[ 7], src[ 1]) + (4.0 * DistYCbCr(src[ 6], src[ 0]));
+		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_05_07) < dist_06_00;
+		blendResult[0] = ((dist_05_07 < dist_06_00) && (v[0] != v[5]) && (v[0] != v[7])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
+	}
+
+	vec4 dst[16];
+	dst[ 0] = src[0];
+	dst[ 1] = src[0];
+	dst[ 2] = src[0];
+	dst[ 3] = src[0];
+	dst[ 4] = src[0];
+	dst[ 5] = src[0];
+	dst[ 6] = src[0];
+	dst[ 7] = src[0];
+	dst[ 8] = src[0];
+	dst[ 9] = src[0];
+	dst[10] = src[0];
+	dst[11] = src[0];
+	dst[12] = src[0];
+	dst[13] = src[0];
+	dst[14] = src[0];
+	dst[15] = src[0];
+
+	// Scale pixel
+	if (IsBlendingNeeded(blendResult) == true) {
+		float dist_01_04 = DistYCbCr(src[1], src[4]);
+		float dist_03_08 = DistYCbCr(src[3], src[8]);
+		bool haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[4]) && (v[5] != v[4]);
+		bool haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[8]) && (v[7] != v[8]);
+		bool needBlend = (blendResult[2] != BLEND_NONE);
+		bool doLineBlend = (  blendResult[2] >= BLEND_DOMINANT ||
+			((blendResult[1] != BLEND_NONE && !IsPixEqual(src[0], src[4])) ||
+			(blendResult[3] != BLEND_NONE && !IsPixEqual(src[0], src[8])) ||
+			(IsPixEqual(src[4], src[3]) && IsPixEqual(src[3], src[2]) && IsPixEqual(src[2], src[1]) && IsPixEqual(src[1], src[8]) && IsPixEqual(src[0], src[2]) == false) ) == false );
+
+		vec4 blendPix = ( DistYCbCr(src[0], src[1]) <= DistYCbCr(src[0], src[3]) ) ? src[1] : src[3];
+		dst[ 2] = mix(dst[ 2], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		dst[ 9] = mix(dst[ 9], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
+		dst[10] = mix(dst[10], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
+		dst[11] = mix(dst[11], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[12] = mix(dst[12], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
+		dst[13] = mix(dst[13], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[14] = mix(dst[14], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
+		dst[15] = mix(dst[15], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
+
+		dist_01_04 = DistYCbCr(src[7], src[2]);
+		dist_03_08 = DistYCbCr(src[1], src[6]);
+		haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[2]) && (v[3] != v[2]);
+		haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[6]) && (v[5] != v[6]);
+		needBlend = (blendResult[1] != BLEND_NONE);
+		doLineBlend = (  blendResult[1] >= BLEND_DOMINANT ||
+			!((blendResult[0] != BLEND_NONE && !IsPixEqual(src[0], src[2])) ||
+			(blendResult[2] != BLEND_NONE && !IsPixEqual(src[0], src[6])) ||
+			(IsPixEqual(src[2], src[1]) && IsPixEqual(src[1], src[8]) && IsPixEqual(src[8], src[7]) && IsPixEqual(src[7], src[6]) && !IsPixEqual(src[0], src[8])) ) );
+
+		blendPix = ( DistYCbCr(src[0], src[7]) <= DistYCbCr(src[0], src[1]) ) ? src[7] : src[1];
+		dst[ 1] = mix(dst[ 1], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		dst[ 6] = mix(dst[ 6], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
+		dst[ 7] = mix(dst[ 7], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
+		dst[ 8] = mix(dst[ 8], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[ 9] = mix(dst[ 9], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
+		dst[10] = mix(dst[10], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[11] = mix(dst[11], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
+		dst[12] = mix(dst[12], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
+
+		dist_01_04 = DistYCbCr(src[5], src[8]);
+		dist_03_08 = DistYCbCr(src[7], src[4]);
+		haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[8]) && (v[1] != v[8]);
+		haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[4]) && (v[3] != v[4]);
+		needBlend = (blendResult[0] != BLEND_NONE);
+		doLineBlend = (  blendResult[0] >= BLEND_DOMINANT ||
+			!((blendResult[3] != BLEND_NONE && !IsPixEqual(src[0], src[8])) ||
+			(blendResult[1] != BLEND_NONE && !IsPixEqual(src[0], src[4])) ||
+			(IsPixEqual(src[8], src[7]) && IsPixEqual(src[7], src[6]) && IsPixEqual(src[6], src[5]) && IsPixEqual(src[5], src[4]) && !IsPixEqual(src[0], src[6])) ) );
+
+		blendPix = ( DistYCbCr(src[0], src[5]) <= DistYCbCr(src[0], src[7]) ) ? src[5] : src[7];
+		dst[ 0] = mix(dst[ 0], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		dst[15] = mix(dst[15], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
+		dst[ 4] = mix(dst[ 4], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
+		dst[ 5] = mix(dst[ 5], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[ 6] = mix(dst[ 6], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
+		dst[ 7] = mix(dst[ 7], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[ 8] = mix(dst[ 8], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
+		dst[ 9] = mix(dst[ 9], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
+
+		dist_01_04 = DistYCbCr(src[3], src[6]);
+		dist_03_08 = DistYCbCr(src[5], src[2]);
+		haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[6]) && (v[7] != v[6]);
+		haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[2]) && (v[1] != v[2]);
+		needBlend = (blendResult[3] != BLEND_NONE);
+		doLineBlend = (  blendResult[3] >= BLEND_DOMINANT ||
+			!((blendResult[2] != BLEND_NONE && !IsPixEqual(src[0], src[6])) ||
+			(blendResult[0] != BLEND_NONE && !IsPixEqual(src[0], src[2])) ||
+			(IsPixEqual(src[6], src[5]) && IsPixEqual(src[5], src[4]) && IsPixEqual(src[4], src[3]) && IsPixEqual(src[3], src[2]) && !IsPixEqual(src[0], src[4])) ) );
+
+		blendPix = ( DistYCbCr(src[0], src[3]) <= DistYCbCr(src[0], src[5]) ) ? src[3] : src[5];
+		dst[ 3] = mix(dst[ 3], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		dst[12] = mix(dst[12], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
+		dst[13] = mix(dst[13], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
+		dst[14] = mix(dst[14], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[15] = mix(dst[15], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
+		dst[ 4] = mix(dst[ 4], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[ 5] = mix(dst[ 5], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
+		dst[ 6] = mix(dst[ 6], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
+	}
+
+	// Output Pixel Mapping:
+	//   06|07|08|09
+	//   05|00|01|10
+	//   04|03|02|11
+	//   15|14|13|12
+	const int order[16] = int[16](6, 7, 8, 9, 5, 0, 1, 10, 4, 3, 2, 11, 15, 14, 13, 12);
+	// Write all 16 output pixels.
+	ivec2 destXY = ivec2(origxy) * 4;
+	for (int y = 0; y < 4; y++) {
+		for (int x = 0; x < 4; x++) {
+			writeColorf(destXY + ivec2(x, y), dst[order[y * 4 + x]]);
+		}
+	}
+}

--- a/assets/shaders/tex_2xbrz.csh
+++ b/assets/shaders/tex_2xbrz.csh
@@ -18,8 +18,8 @@ float DistYCbCr(vec4 pixA, vec4 pixB) {
 	// https://en.wikipedia.org/wiki/YCbCr#ITU-R_BT.2020_conversion
 	const vec3 K = vec3(0.2627, 0.6780, 0.0593);
 	const mat3 MATRIX = mat3(K,
-	                         -.5 * K.r / (1.0 - K.b),  -.5 * K.g / (1.0 - K.b),  .5,
-	                         .5,                       -.5 * K.g / (1.0 - K.r),  -.5 * K.b / (1.0 - K.r));
+		-.5 * K.r / (1.0 - K.b), -.5 * K.g / (1.0 - K.b), .5,
+		.5, -.5 * K.g / (1.0 - K.r), -.5 * K.b / (1.0 - K.r));
 	vec4 diff = pixA - pixB;
 	vec3 YCbCr = diff.rgb * MATRIX;
 	YCbCr.x *= LUMINANCE_WEIGHT;
@@ -37,7 +37,7 @@ bool IsBlendingNeeded(const ivec4 blend) {
 }
 
 vec4 readInput(uvec2 coord) {
-    return readColorf(uvec2(clamp(coord.x, 0, params.width - 1), clamp(coord.y, 0, params.height - 1)));
+	return readColorf(uvec2(clamp(coord.x, 0, params.width - 1), clamp(coord.y, 0, params.height - 1)));
 }
 
 void applyScaling(uvec2 origxy) {
@@ -67,22 +67,22 @@ void applyScaling(uvec2 origxy) {
 	src[21] = readInput(t1.xw);
 	src[22] = readInput(t1.yw);
 	src[23] = readInput(t1.zw);
-	src[ 6] = readInput(t2.xw);
-	src[ 7] = readInput(t2.yw);
-	src[ 8] = readInput(t2.zw);
-	src[ 5] = readInput(t3.xw);
-	src[ 0] = readInput(t3.yw);
-	src[ 1] = readInput(t3.zw);
-	src[ 4] = readInput(t4.xw);
-	src[ 3] = readInput(t4.yw);
-	src[ 2] = readInput(t4.zw);
+	src[6] = readInput(t2.xw);
+	src[7] = readInput(t2.yw);
+	src[8] = readInput(t2.zw);
+	src[5] = readInput(t3.xw);
+	src[0] = readInput(t3.yw);
+	src[1] = readInput(t3.zw);
+	src[4] = readInput(t4.xw);
+	src[3] = readInput(t4.yw);
+	src[2] = readInput(t4.zw);
 	src[15] = readInput(t5.xw);
 	src[14] = readInput(t5.yw);
 	src[13] = readInput(t5.zw);
 	src[19] = readInput(t6.xy);
 	src[18] = readInput(t6.xz);
 	src[17] = readInput(t6.xw);
-	src[ 9] = readInput(t7.xy);
+	src[9] = readInput(t7.xy);
 	src[10] = readInput(t7.xz);
 	src[11] = readInput(t7.xw);
 
@@ -106,9 +106,9 @@ void applyScaling(uvec2 origxy) {
 	//                    --|04|03|02|11
 	//                    --|--|14|13|--
 	// Corner (1, 1)
-	if ( ((v[0] == v[1] && v[3] == v[2]) || (v[0] == v[3] && v[1] == v[2])) == false) {
-		float dist_03_01 = DistYCbCr(src[ 4], src[ 0]) + DistYCbCr(src[ 0], src[ 8]) + DistYCbCr(src[14], src[ 2]) + DistYCbCr(src[ 2], src[10]) + (4.0 * DistYCbCr(src[ 3], src[ 1]));
-		float dist_00_02 = DistYCbCr(src[ 5], src[ 3]) + DistYCbCr(src[ 3], src[13]) + DistYCbCr(src[ 7], src[ 1]) + DistYCbCr(src[ 1], src[11]) + (4.0 * DistYCbCr(src[ 0], src[ 2]));
+	if (((v[0] == v[1] && v[3] == v[2]) || (v[0] == v[3] && v[1] == v[2])) == false) {
+		float dist_03_01 = DistYCbCr(src[4], src[0]) + DistYCbCr(src[0], src[8]) + DistYCbCr(src[14], src[2]) + DistYCbCr(src[2], src[10]) + (4.0 * DistYCbCr(src[3], src[1]));
+		float dist_00_02 = DistYCbCr(src[5], src[3]) + DistYCbCr(src[3], src[13]) + DistYCbCr(src[7], src[1]) + DistYCbCr(src[1], src[11]) + (4.0 * DistYCbCr(src[0], src[2]));
 		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_03_01) < dist_00_02;
 		blendResult[2] = ((dist_03_01 < dist_00_02) && (v[0] != v[1]) && (v[0] != v[3])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
 	}
@@ -119,9 +119,9 @@ void applyScaling(uvec2 origxy) {
 	//                    17|04|03|02|--
 	//                    --|15|14|--|--
 	// Corner (0, 1)
-	if ( ((v[5] == v[0] && v[4] == v[3]) || (v[5] == v[4] && v[0] == v[3])) == false) {
-		float dist_04_00 = DistYCbCr(src[17], src[ 5]) + DistYCbCr(src[ 5], src[ 7]) + DistYCbCr(src[15], src[ 3]) + DistYCbCr(src[ 3], src[ 1]) + (4.0 * DistYCbCr(src[ 4], src[ 0]));
-		float dist_05_03 = DistYCbCr(src[18], src[ 4]) + DistYCbCr(src[ 4], src[14]) + DistYCbCr(src[ 6], src[ 0]) + DistYCbCr(src[ 0], src[ 2]) + (4.0 * DistYCbCr(src[ 5], src[ 3]));
+	if (((v[5] == v[0] && v[4] == v[3]) || (v[5] == v[4] && v[0] == v[3])) == false) {
+		float dist_04_00 = DistYCbCr(src[17], src[5]) + DistYCbCr(src[5], src[7]) + DistYCbCr(src[15], src[3]) + DistYCbCr(src[3], src[1]) + (4.0 * DistYCbCr(src[4], src[0]));
+		float dist_05_03 = DistYCbCr(src[18], src[4]) + DistYCbCr(src[4], src[14]) + DistYCbCr(src[6], src[0]) + DistYCbCr(src[0], src[2]) + (4.0 * DistYCbCr(src[5], src[3]));
 		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_05_03) < dist_04_00;
 		blendResult[3] = ((dist_04_00 > dist_05_03) && (v[0] != v[5]) && (v[0] != v[3])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
 	}
@@ -132,9 +132,9 @@ void applyScaling(uvec2 origxy) {
 	//                    --|--|03|02|--
 	//                    --|--|--|--|--
 	// Corner (1, 0)
-	if ( ((v[7] == v[8] && v[0] == v[1]) || (v[7] == v[0] && v[8] == v[1])) == false) {
-		float dist_00_08 = DistYCbCr(src[ 5], src[ 7]) + DistYCbCr(src[ 7], src[23]) + DistYCbCr(src[ 3], src[ 1]) + DistYCbCr(src[ 1], src[ 9]) + (4.0 * DistYCbCr(src[ 0], src[ 8]));
-		float dist_07_01 = DistYCbCr(src[ 6], src[ 0]) + DistYCbCr(src[ 0], src[ 2]) + DistYCbCr(src[22], src[ 8]) + DistYCbCr(src[ 8], src[10]) + (4.0 * DistYCbCr(src[ 7], src[ 1]));
+	if (((v[7] == v[8] && v[0] == v[1]) || (v[7] == v[0] && v[8] == v[1])) == false) {
+		float dist_00_08 = DistYCbCr(src[5], src[7]) + DistYCbCr(src[7], src[23]) + DistYCbCr(src[3], src[1]) + DistYCbCr(src[1], src[9]) + (4.0 * DistYCbCr(src[0], src[8]));
+		float dist_07_01 = DistYCbCr(src[6], src[0]) + DistYCbCr(src[0], src[2]) + DistYCbCr(src[22], src[8]) + DistYCbCr(src[8], src[10]) + (4.0 * DistYCbCr(src[7], src[1]));
 		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_07_01) < dist_00_08;
 		blendResult[1] = ((dist_00_08 > dist_07_01) && (v[0] != v[7]) && (v[0] != v[1])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
 	}
@@ -145,24 +145,24 @@ void applyScaling(uvec2 origxy) {
 	//                    --|04|03|--|--
 	//                    --|--|--|--|--
 	// Corner (0, 0)
-	if ( ((v[6] == v[7] && v[5] == v[0]) || (v[6] == v[5] && v[7] == v[0])) == false) {
-		float dist_05_07 = DistYCbCr(src[18], src[ 6]) + DistYCbCr(src[ 6], src[22]) + DistYCbCr(src[ 4], src[ 0]) + DistYCbCr(src[ 0], src[ 8]) + (4.0 * DistYCbCr(src[ 5], src[ 7]));
-		float dist_06_00 = DistYCbCr(src[19], src[ 5]) + DistYCbCr(src[ 5], src[ 3]) + DistYCbCr(src[21], src[ 7]) + DistYCbCr(src[ 7], src[ 1]) + (4.0 * DistYCbCr(src[ 6], src[ 0]));
+	if (((v[6] == v[7] && v[5] == v[0]) || (v[6] == v[5] && v[7] == v[0])) == false) {
+		float dist_05_07 = DistYCbCr(src[18], src[6]) + DistYCbCr(src[6], src[22]) + DistYCbCr(src[4], src[0]) + DistYCbCr(src[0], src[8]) + (4.0 * DistYCbCr(src[5], src[7]));
+		float dist_06_00 = DistYCbCr(src[19], src[5]) + DistYCbCr(src[5], src[3]) + DistYCbCr(src[21], src[7]) + DistYCbCr(src[7], src[1]) + (4.0 * DistYCbCr(src[6], src[0]));
 		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_05_07) < dist_06_00;
 		blendResult[0] = ((dist_05_07 < dist_06_00) && (v[0] != v[5]) && (v[0] != v[7])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
 	}
 
 	vec4 dst[16];
-	dst[ 0] = src[0];
-	dst[ 1] = src[0];
-	dst[ 2] = src[0];
-	dst[ 3] = src[0];
-	dst[ 4] = src[0];
-	dst[ 5] = src[0];
-	dst[ 6] = src[0];
-	dst[ 7] = src[0];
-	dst[ 8] = src[0];
-	dst[ 9] = src[0];
+	dst[0] = src[0];
+	dst[1] = src[0];
+	dst[2] = src[0];
+	dst[3] = src[0];
+	dst[4] = src[0];
+	dst[5] = src[0];
+	dst[6] = src[0];
+	dst[7] = src[0];
+	dst[8] = src[0];
+	dst[9] = src[0];
 	dst[10] = src[0];
 	dst[11] = src[0];
 	dst[12] = src[0];
@@ -175,16 +175,16 @@ void applyScaling(uvec2 origxy) {
 		float dist_01_04 = DistYCbCr(src[1], src[4]);
 		float dist_03_08 = DistYCbCr(src[3], src[8]);
 		bool haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[4]) && (v[5] != v[4]);
-		bool haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[8]) && (v[7] != v[8]);
+		bool haveSteepLine = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[8]) && (v[7] != v[8]);
 		bool needBlend = (blendResult[2] != BLEND_NONE);
-		bool doLineBlend = (  blendResult[2] >= BLEND_DOMINANT ||
+		bool doLineBlend = (blendResult[2] >= BLEND_DOMINANT ||
 			((blendResult[1] != BLEND_NONE && !IsPixEqual(src[0], src[4])) ||
-			(blendResult[3] != BLEND_NONE && !IsPixEqual(src[0], src[8])) ||
-			(IsPixEqual(src[4], src[3]) && IsPixEqual(src[3], src[2]) && IsPixEqual(src[2], src[1]) && IsPixEqual(src[1], src[8]) && IsPixEqual(src[0], src[2]) == false) ) == false );
+				(blendResult[3] != BLEND_NONE && !IsPixEqual(src[0], src[8])) ||
+				(IsPixEqual(src[4], src[3]) && IsPixEqual(src[3], src[2]) && IsPixEqual(src[2], src[1]) && IsPixEqual(src[1], src[8]) && IsPixEqual(src[0], src[2]) == false)) == false);
 
-		vec4 blendPix = ( DistYCbCr(src[0], src[1]) <= DistYCbCr(src[0], src[3]) ) ? src[1] : src[3];
-		dst[ 2] = mix(dst[ 2], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
-		dst[ 9] = mix(dst[ 9], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
+		vec4 blendPix = (DistYCbCr(src[0], src[1]) <= DistYCbCr(src[0], src[3])) ? src[1] : src[3];
+		dst[2] = mix(dst[2], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0 / 3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		dst[9] = mix(dst[9], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
 		dst[10] = mix(dst[10], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
 		dst[11] = mix(dst[11], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
 		dst[12] = mix(dst[12], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
@@ -195,19 +195,19 @@ void applyScaling(uvec2 origxy) {
 		dist_01_04 = DistYCbCr(src[7], src[2]);
 		dist_03_08 = DistYCbCr(src[1], src[6]);
 		haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[2]) && (v[3] != v[2]);
-		haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[6]) && (v[5] != v[6]);
+		haveSteepLine = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[6]) && (v[5] != v[6]);
 		needBlend = (blendResult[1] != BLEND_NONE);
-		doLineBlend = (  blendResult[1] >= BLEND_DOMINANT ||
+		doLineBlend = (blendResult[1] >= BLEND_DOMINANT ||
 			!((blendResult[0] != BLEND_NONE && !IsPixEqual(src[0], src[2])) ||
-			(blendResult[2] != BLEND_NONE && !IsPixEqual(src[0], src[6])) ||
-			(IsPixEqual(src[2], src[1]) && IsPixEqual(src[1], src[8]) && IsPixEqual(src[8], src[7]) && IsPixEqual(src[7], src[6]) && !IsPixEqual(src[0], src[8])) ) );
+				(blendResult[2] != BLEND_NONE && !IsPixEqual(src[0], src[6])) ||
+				(IsPixEqual(src[2], src[1]) && IsPixEqual(src[1], src[8]) && IsPixEqual(src[8], src[7]) && IsPixEqual(src[7], src[6]) && !IsPixEqual(src[0], src[8]))));
 
-		blendPix = ( DistYCbCr(src[0], src[7]) <= DistYCbCr(src[0], src[1]) ) ? src[7] : src[1];
-		dst[ 1] = mix(dst[ 1], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
-		dst[ 6] = mix(dst[ 6], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
-		dst[ 7] = mix(dst[ 7], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
-		dst[ 8] = mix(dst[ 8], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
-		dst[ 9] = mix(dst[ 9], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
+		blendPix = (DistYCbCr(src[0], src[7]) <= DistYCbCr(src[0], src[1])) ? src[7] : src[1];
+		dst[1] = mix(dst[1], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0 / 3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		dst[6] = mix(dst[6], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
+		dst[7] = mix(dst[7], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
+		dst[8] = mix(dst[8], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[9] = mix(dst[9], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
 		dst[10] = mix(dst[10], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
 		dst[11] = mix(dst[11], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
 		dst[12] = mix(dst[12], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
@@ -215,42 +215,42 @@ void applyScaling(uvec2 origxy) {
 		dist_01_04 = DistYCbCr(src[5], src[8]);
 		dist_03_08 = DistYCbCr(src[7], src[4]);
 		haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[8]) && (v[1] != v[8]);
-		haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[4]) && (v[3] != v[4]);
+		haveSteepLine = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[4]) && (v[3] != v[4]);
 		needBlend = (blendResult[0] != BLEND_NONE);
-		doLineBlend = (  blendResult[0] >= BLEND_DOMINANT ||
+		doLineBlend = (blendResult[0] >= BLEND_DOMINANT ||
 			!((blendResult[3] != BLEND_NONE && !IsPixEqual(src[0], src[8])) ||
-			(blendResult[1] != BLEND_NONE && !IsPixEqual(src[0], src[4])) ||
-			(IsPixEqual(src[8], src[7]) && IsPixEqual(src[7], src[6]) && IsPixEqual(src[6], src[5]) && IsPixEqual(src[5], src[4]) && !IsPixEqual(src[0], src[6])) ) );
+				(blendResult[1] != BLEND_NONE && !IsPixEqual(src[0], src[4])) ||
+				(IsPixEqual(src[8], src[7]) && IsPixEqual(src[7], src[6]) && IsPixEqual(src[6], src[5]) && IsPixEqual(src[5], src[4]) && !IsPixEqual(src[0], src[6]))));
 
-		blendPix = ( DistYCbCr(src[0], src[5]) <= DistYCbCr(src[0], src[7]) ) ? src[5] : src[7];
-		dst[ 0] = mix(dst[ 0], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		blendPix = (DistYCbCr(src[0], src[5]) <= DistYCbCr(src[0], src[7])) ? src[5] : src[7];
+		dst[0] = mix(dst[0], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0 / 3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
 		dst[15] = mix(dst[15], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
-		dst[ 4] = mix(dst[ 4], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
-		dst[ 5] = mix(dst[ 5], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
-		dst[ 6] = mix(dst[ 6], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
-		dst[ 7] = mix(dst[ 7], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
-		dst[ 8] = mix(dst[ 8], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
-		dst[ 9] = mix(dst[ 9], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
+		dst[4] = mix(dst[4], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
+		dst[5] = mix(dst[5], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[6] = mix(dst[6], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
+		dst[7] = mix(dst[7], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[8] = mix(dst[8], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
+		dst[9] = mix(dst[9], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
 
 		dist_01_04 = DistYCbCr(src[3], src[6]);
 		dist_03_08 = DistYCbCr(src[5], src[2]);
 		haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[6]) && (v[7] != v[6]);
-		haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[2]) && (v[1] != v[2]);
+		haveSteepLine = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[2]) && (v[1] != v[2]);
 		needBlend = (blendResult[3] != BLEND_NONE);
-		doLineBlend = (  blendResult[3] >= BLEND_DOMINANT ||
+		doLineBlend = (blendResult[3] >= BLEND_DOMINANT ||
 			!((blendResult[2] != BLEND_NONE && !IsPixEqual(src[0], src[6])) ||
-			(blendResult[0] != BLEND_NONE && !IsPixEqual(src[0], src[2])) ||
-			(IsPixEqual(src[6], src[5]) && IsPixEqual(src[5], src[4]) && IsPixEqual(src[4], src[3]) && IsPixEqual(src[3], src[2]) && !IsPixEqual(src[0], src[4])) ) );
+				(blendResult[0] != BLEND_NONE && !IsPixEqual(src[0], src[2])) ||
+				(IsPixEqual(src[6], src[5]) && IsPixEqual(src[5], src[4]) && IsPixEqual(src[4], src[3]) && IsPixEqual(src[3], src[2]) && !IsPixEqual(src[0], src[4]))));
 
-		blendPix = ( DistYCbCr(src[0], src[3]) <= DistYCbCr(src[0], src[5]) ) ? src[3] : src[5];
-		dst[ 3] = mix(dst[ 3], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		blendPix = (DistYCbCr(src[0], src[3]) <= DistYCbCr(src[0], src[5])) ? src[3] : src[5];
+		dst[3] = mix(dst[3], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0 / 3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
 		dst[12] = mix(dst[12], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
 		dst[13] = mix(dst[13], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
 		dst[14] = mix(dst[14], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
 		dst[15] = mix(dst[15], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
-		dst[ 4] = mix(dst[ 4], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
-		dst[ 5] = mix(dst[ 5], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
-		dst[ 6] = mix(dst[ 6], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
+		dst[4] = mix(dst[4], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[5] = mix(dst[5], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
+		dst[6] = mix(dst[6], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
 	}
 
 	// Output Pixel Mapping:
@@ -260,10 +260,18 @@ void applyScaling(uvec2 origxy) {
 	//   15|14|13|12
 	const int order[16] = int[16](6, 7, 8, 9, 5, 0, 1, 10, 4, 3, 2, 11, 15, 14, 13, 12);
 	// Write all 16 output pixels.
-	ivec2 destXY = ivec2(origxy) * 4;
-	for (int y = 0; y < 4; y++) {
-		for (int x = 0; x < 4; x++) {
-			writeColorf(destXY + ivec2(x, y), dst[order[y * 4 + x]]);
+	ivec2 destXY = ivec2(origxy) * 2;
+	for (int y = 0; y < 2; y++) {
+		for (int x = 0; x < 2; x++) {
+			vec4 sum = vec4(0.0);
+			int index = y * 4 + x * 2;
+			for (int iy = 0; iy < 2; iy++) {
+				for (int ix = 0; ix < 2; ix++) {
+					sum += dst[order[index + iy * 4 + ix]];
+				}
+			}
+			sum *= 0.25;
+			writeColorf(destXY + ivec2(x, y), sum);
 		}
 	}
 }

--- a/assets/shaders/tex_2xbrz.csh
+++ b/assets/shaders/tex_2xbrz.csh
@@ -67,22 +67,22 @@ void applyScaling(uvec2 origxy) {
 	src[21] = readInput(t1.xw);
 	src[22] = readInput(t1.yw);
 	src[23] = readInput(t1.zw);
-	src[6] = readInput(t2.xw);
-	src[7] = readInput(t2.yw);
-	src[8] = readInput(t2.zw);
-	src[5] = readInput(t3.xw);
-	src[0] = readInput(t3.yw);
-	src[1] = readInput(t3.zw);
-	src[4] = readInput(t4.xw);
-	src[3] = readInput(t4.yw);
-	src[2] = readInput(t4.zw);
+	src[ 6] = unpackUnorm4x8(v[6]);
+	src[ 7] = unpackUnorm4x8(v[7]);
+	src[ 8] = unpackUnorm4x8(v[8]);
+	src[ 5] = unpackUnorm4x8(v[5]);
+	src[ 0] = unpackUnorm4x8(v[0]);
+	src[ 1] = unpackUnorm4x8(v[1]);
+	src[ 4] = unpackUnorm4x8(v[4]);
+	src[ 3] = unpackUnorm4x8(v[3]);
+	src[ 2] = unpackUnorm4x8(v[2]);
 	src[15] = readInput(t5.xw);
 	src[14] = readInput(t5.yw);
 	src[13] = readInput(t5.zw);
 	src[19] = readInput(t6.xy);
 	src[18] = readInput(t6.xz);
 	src[17] = readInput(t6.xw);
-	src[9] = readInput(t7.xy);
+	src[ 9] = readInput(t7.xy);
 	src[10] = readInput(t7.xz);
 	src[11] = readInput(t7.xw);
 
@@ -106,9 +106,9 @@ void applyScaling(uvec2 origxy) {
 	//                    --|04|03|02|11
 	//                    --|--|14|13|--
 	// Corner (1, 1)
-	if (((v[0] == v[1] && v[3] == v[2]) || (v[0] == v[3] && v[1] == v[2])) == false) {
-		float dist_03_01 = DistYCbCr(src[4], src[0]) + DistYCbCr(src[0], src[8]) + DistYCbCr(src[14], src[2]) + DistYCbCr(src[2], src[10]) + (4.0 * DistYCbCr(src[3], src[1]));
-		float dist_00_02 = DistYCbCr(src[5], src[3]) + DistYCbCr(src[3], src[13]) + DistYCbCr(src[7], src[1]) + DistYCbCr(src[1], src[11]) + (4.0 * DistYCbCr(src[0], src[2]));
+	if ( ((v[0] == v[1] && v[3] == v[2]) || (v[0] == v[3] && v[1] == v[2])) == false) {
+		float dist_03_01 = DistYCbCr(src[ 4], src[ 0]) + DistYCbCr(src[ 0], src[ 8]) + DistYCbCr(src[14], src[ 2]) + DistYCbCr(src[ 2], src[10]) + (4.0 * DistYCbCr(src[ 3], src[ 1]));
+		float dist_00_02 = DistYCbCr(src[ 5], src[ 3]) + DistYCbCr(src[ 3], src[13]) + DistYCbCr(src[ 7], src[ 1]) + DistYCbCr(src[ 1], src[11]) + (4.0 * DistYCbCr(src[ 0], src[ 2]));
 		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_03_01) < dist_00_02;
 		blendResult[2] = ((dist_03_01 < dist_00_02) && (v[0] != v[1]) && (v[0] != v[3])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
 	}
@@ -119,9 +119,9 @@ void applyScaling(uvec2 origxy) {
 	//                    17|04|03|02|--
 	//                    --|15|14|--|--
 	// Corner (0, 1)
-	if (((v[5] == v[0] && v[4] == v[3]) || (v[5] == v[4] && v[0] == v[3])) == false) {
-		float dist_04_00 = DistYCbCr(src[17], src[5]) + DistYCbCr(src[5], src[7]) + DistYCbCr(src[15], src[3]) + DistYCbCr(src[3], src[1]) + (4.0 * DistYCbCr(src[4], src[0]));
-		float dist_05_03 = DistYCbCr(src[18], src[4]) + DistYCbCr(src[4], src[14]) + DistYCbCr(src[6], src[0]) + DistYCbCr(src[0], src[2]) + (4.0 * DistYCbCr(src[5], src[3]));
+	if ( ((v[5] == v[0] && v[4] == v[3]) || (v[5] == v[4] && v[0] == v[3])) == false) {
+		float dist_04_00 = DistYCbCr(src[17], src[ 5]) + DistYCbCr(src[ 5], src[ 7]) + DistYCbCr(src[15], src[ 3]) + DistYCbCr(src[ 3], src[ 1]) + (4.0 * DistYCbCr(src[ 4], src[ 0]));
+		float dist_05_03 = DistYCbCr(src[18], src[ 4]) + DistYCbCr(src[ 4], src[14]) + DistYCbCr(src[ 6], src[ 0]) + DistYCbCr(src[ 0], src[ 2]) + (4.0 * DistYCbCr(src[ 5], src[ 3]));
 		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_05_03) < dist_04_00;
 		blendResult[3] = ((dist_04_00 > dist_05_03) && (v[0] != v[5]) && (v[0] != v[3])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
 	}
@@ -132,9 +132,9 @@ void applyScaling(uvec2 origxy) {
 	//                    --|--|03|02|--
 	//                    --|--|--|--|--
 	// Corner (1, 0)
-	if (((v[7] == v[8] && v[0] == v[1]) || (v[7] == v[0] && v[8] == v[1])) == false) {
-		float dist_00_08 = DistYCbCr(src[5], src[7]) + DistYCbCr(src[7], src[23]) + DistYCbCr(src[3], src[1]) + DistYCbCr(src[1], src[9]) + (4.0 * DistYCbCr(src[0], src[8]));
-		float dist_07_01 = DistYCbCr(src[6], src[0]) + DistYCbCr(src[0], src[2]) + DistYCbCr(src[22], src[8]) + DistYCbCr(src[8], src[10]) + (4.0 * DistYCbCr(src[7], src[1]));
+	if ( ((v[7] == v[8] && v[0] == v[1]) || (v[7] == v[0] && v[8] == v[1])) == false) {
+		float dist_00_08 = DistYCbCr(src[ 5], src[ 7]) + DistYCbCr(src[ 7], src[23]) + DistYCbCr(src[ 3], src[ 1]) + DistYCbCr(src[ 1], src[ 9]) + (4.0 * DistYCbCr(src[ 0], src[ 8]));
+		float dist_07_01 = DistYCbCr(src[ 6], src[ 0]) + DistYCbCr(src[ 0], src[ 2]) + DistYCbCr(src[22], src[ 8]) + DistYCbCr(src[ 8], src[10]) + (4.0 * DistYCbCr(src[ 7], src[ 1]));
 		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_07_01) < dist_00_08;
 		blendResult[1] = ((dist_00_08 > dist_07_01) && (v[0] != v[7]) && (v[0] != v[1])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
 	}
@@ -145,24 +145,24 @@ void applyScaling(uvec2 origxy) {
 	//                    --|04|03|--|--
 	//                    --|--|--|--|--
 	// Corner (0, 0)
-	if (((v[6] == v[7] && v[5] == v[0]) || (v[6] == v[5] && v[7] == v[0])) == false) {
-		float dist_05_07 = DistYCbCr(src[18], src[6]) + DistYCbCr(src[6], src[22]) + DistYCbCr(src[4], src[0]) + DistYCbCr(src[0], src[8]) + (4.0 * DistYCbCr(src[5], src[7]));
-		float dist_06_00 = DistYCbCr(src[19], src[5]) + DistYCbCr(src[5], src[3]) + DistYCbCr(src[21], src[7]) + DistYCbCr(src[7], src[1]) + (4.0 * DistYCbCr(src[6], src[0]));
+	if ( ((v[6] == v[7] && v[5] == v[0]) || (v[6] == v[5] && v[7] == v[0])) == false) {
+		float dist_05_07 = DistYCbCr(src[18], src[ 6]) + DistYCbCr(src[ 6], src[22]) + DistYCbCr(src[ 4], src[ 0]) + DistYCbCr(src[ 0], src[ 8]) + (4.0 * DistYCbCr(src[ 5], src[ 7]));
+		float dist_06_00 = DistYCbCr(src[19], src[ 5]) + DistYCbCr(src[ 5], src[ 3]) + DistYCbCr(src[21], src[ 7]) + DistYCbCr(src[ 7], src[ 1]) + (4.0 * DistYCbCr(src[ 6], src[ 0]));
 		bool dominantGradient = (DOMINANT_DIRECTION_THRESHOLD * dist_05_07) < dist_06_00;
 		blendResult[0] = ((dist_05_07 < dist_06_00) && (v[0] != v[5]) && (v[0] != v[7])) ? ((dominantGradient) ? BLEND_DOMINANT : BLEND_NORMAL) : BLEND_NONE;
 	}
 
 	vec4 dst[16];
-	dst[0] = src[0];
-	dst[1] = src[0];
-	dst[2] = src[0];
-	dst[3] = src[0];
-	dst[4] = src[0];
-	dst[5] = src[0];
-	dst[6] = src[0];
-	dst[7] = src[0];
-	dst[8] = src[0];
-	dst[9] = src[0];
+	dst[ 0] = src[0];
+	dst[ 1] = src[0];
+	dst[ 2] = src[0];
+	dst[ 3] = src[0];
+	dst[ 4] = src[0];
+	dst[ 5] = src[0];
+	dst[ 6] = src[0];
+	dst[ 7] = src[0];
+	dst[ 8] = src[0];
+	dst[ 9] = src[0];
 	dst[10] = src[0];
 	dst[11] = src[0];
 	dst[12] = src[0];
@@ -175,16 +175,16 @@ void applyScaling(uvec2 origxy) {
 		float dist_01_04 = DistYCbCr(src[1], src[4]);
 		float dist_03_08 = DistYCbCr(src[3], src[8]);
 		bool haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[4]) && (v[5] != v[4]);
-		bool haveSteepLine = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[8]) && (v[7] != v[8]);
+		bool haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[8]) && (v[7] != v[8]);
 		bool needBlend = (blendResult[2] != BLEND_NONE);
-		bool doLineBlend = (blendResult[2] >= BLEND_DOMINANT ||
+		bool doLineBlend = (  blendResult[2] >= BLEND_DOMINANT ||
 			((blendResult[1] != BLEND_NONE && !IsPixEqual(src[0], src[4])) ||
-				(blendResult[3] != BLEND_NONE && !IsPixEqual(src[0], src[8])) ||
-				(IsPixEqual(src[4], src[3]) && IsPixEqual(src[3], src[2]) && IsPixEqual(src[2], src[1]) && IsPixEqual(src[1], src[8]) && IsPixEqual(src[0], src[2]) == false)) == false);
+			(blendResult[3] != BLEND_NONE && !IsPixEqual(src[0], src[8])) ||
+			(IsPixEqual(src[4], src[3]) && IsPixEqual(src[3], src[2]) && IsPixEqual(src[2], src[1]) && IsPixEqual(src[1], src[8]) && IsPixEqual(src[0], src[2]) == false) ) == false );
 
-		vec4 blendPix = (DistYCbCr(src[0], src[1]) <= DistYCbCr(src[0], src[3])) ? src[1] : src[3];
-		dst[2] = mix(dst[2], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0 / 3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
-		dst[9] = mix(dst[9], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
+		vec4 blendPix = ( DistYCbCr(src[0], src[1]) <= DistYCbCr(src[0], src[3]) ) ? src[1] : src[3];
+		dst[ 2] = mix(dst[ 2], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		dst[ 9] = mix(dst[ 9], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
 		dst[10] = mix(dst[10], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
 		dst[11] = mix(dst[11], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
 		dst[12] = mix(dst[12], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
@@ -195,19 +195,19 @@ void applyScaling(uvec2 origxy) {
 		dist_01_04 = DistYCbCr(src[7], src[2]);
 		dist_03_08 = DistYCbCr(src[1], src[6]);
 		haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[2]) && (v[3] != v[2]);
-		haveSteepLine = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[6]) && (v[5] != v[6]);
+		haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[6]) && (v[5] != v[6]);
 		needBlend = (blendResult[1] != BLEND_NONE);
-		doLineBlend = (blendResult[1] >= BLEND_DOMINANT ||
+		doLineBlend = (  blendResult[1] >= BLEND_DOMINANT ||
 			!((blendResult[0] != BLEND_NONE && !IsPixEqual(src[0], src[2])) ||
-				(blendResult[2] != BLEND_NONE && !IsPixEqual(src[0], src[6])) ||
-				(IsPixEqual(src[2], src[1]) && IsPixEqual(src[1], src[8]) && IsPixEqual(src[8], src[7]) && IsPixEqual(src[7], src[6]) && !IsPixEqual(src[0], src[8]))));
+			(blendResult[2] != BLEND_NONE && !IsPixEqual(src[0], src[6])) ||
+			(IsPixEqual(src[2], src[1]) && IsPixEqual(src[1], src[8]) && IsPixEqual(src[8], src[7]) && IsPixEqual(src[7], src[6]) && !IsPixEqual(src[0], src[8])) ) );
 
-		blendPix = (DistYCbCr(src[0], src[7]) <= DistYCbCr(src[0], src[1])) ? src[7] : src[1];
-		dst[1] = mix(dst[1], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0 / 3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
-		dst[6] = mix(dst[6], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
-		dst[7] = mix(dst[7], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
-		dst[8] = mix(dst[8], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
-		dst[9] = mix(dst[9], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
+		blendPix = ( DistYCbCr(src[0], src[7]) <= DistYCbCr(src[0], src[1]) ) ? src[7] : src[1];
+		dst[ 1] = mix(dst[ 1], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		dst[ 6] = mix(dst[ 6], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
+		dst[ 7] = mix(dst[ 7], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
+		dst[ 8] = mix(dst[ 8], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[ 9] = mix(dst[ 9], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
 		dst[10] = mix(dst[10], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
 		dst[11] = mix(dst[11], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
 		dst[12] = mix(dst[12], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
@@ -215,42 +215,42 @@ void applyScaling(uvec2 origxy) {
 		dist_01_04 = DistYCbCr(src[5], src[8]);
 		dist_03_08 = DistYCbCr(src[7], src[4]);
 		haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[8]) && (v[1] != v[8]);
-		haveSteepLine = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[4]) && (v[3] != v[4]);
+		haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[4]) && (v[3] != v[4]);
 		needBlend = (blendResult[0] != BLEND_NONE);
-		doLineBlend = (blendResult[0] >= BLEND_DOMINANT ||
+		doLineBlend = (  blendResult[0] >= BLEND_DOMINANT ||
 			!((blendResult[3] != BLEND_NONE && !IsPixEqual(src[0], src[8])) ||
-				(blendResult[1] != BLEND_NONE && !IsPixEqual(src[0], src[4])) ||
-				(IsPixEqual(src[8], src[7]) && IsPixEqual(src[7], src[6]) && IsPixEqual(src[6], src[5]) && IsPixEqual(src[5], src[4]) && !IsPixEqual(src[0], src[6]))));
+			(blendResult[1] != BLEND_NONE && !IsPixEqual(src[0], src[4])) ||
+			(IsPixEqual(src[8], src[7]) && IsPixEqual(src[7], src[6]) && IsPixEqual(src[6], src[5]) && IsPixEqual(src[5], src[4]) && !IsPixEqual(src[0], src[6])) ) );
 
-		blendPix = (DistYCbCr(src[0], src[5]) <= DistYCbCr(src[0], src[7])) ? src[5] : src[7];
-		dst[0] = mix(dst[0], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0 / 3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		blendPix = ( DistYCbCr(src[0], src[5]) <= DistYCbCr(src[0], src[7]) ) ? src[5] : src[7];
+		dst[ 0] = mix(dst[ 0], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
 		dst[15] = mix(dst[15], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
-		dst[4] = mix(dst[4], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
-		dst[5] = mix(dst[5], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
-		dst[6] = mix(dst[6], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
-		dst[7] = mix(dst[7], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
-		dst[8] = mix(dst[8], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
-		dst[9] = mix(dst[9], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
+		dst[ 4] = mix(dst[ 4], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
+		dst[ 5] = mix(dst[ 5], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[ 6] = mix(dst[ 6], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
+		dst[ 7] = mix(dst[ 7], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[ 8] = mix(dst[ 8], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
+		dst[ 9] = mix(dst[ 9], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
 
 		dist_01_04 = DistYCbCr(src[3], src[6]);
 		dist_03_08 = DistYCbCr(src[5], src[2]);
 		haveShallowLine = (STEEP_DIRECTION_THRESHOLD * dist_01_04 <= dist_03_08) && (v[0] != v[6]) && (v[7] != v[6]);
-		haveSteepLine = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[2]) && (v[1] != v[2]);
+		haveSteepLine   = (STEEP_DIRECTION_THRESHOLD * dist_03_08 <= dist_01_04) && (v[0] != v[2]) && (v[1] != v[2]);
 		needBlend = (blendResult[3] != BLEND_NONE);
-		doLineBlend = (blendResult[3] >= BLEND_DOMINANT ||
+		doLineBlend = (  blendResult[3] >= BLEND_DOMINANT ||
 			!((blendResult[2] != BLEND_NONE && !IsPixEqual(src[0], src[6])) ||
-				(blendResult[0] != BLEND_NONE && !IsPixEqual(src[0], src[2])) ||
-				(IsPixEqual(src[6], src[5]) && IsPixEqual(src[5], src[4]) && IsPixEqual(src[4], src[3]) && IsPixEqual(src[3], src[2]) && !IsPixEqual(src[0], src[4]))));
+			(blendResult[0] != BLEND_NONE && !IsPixEqual(src[0], src[2])) ||
+			(IsPixEqual(src[6], src[5]) && IsPixEqual(src[5], src[4]) && IsPixEqual(src[4], src[3]) && IsPixEqual(src[3], src[2]) && !IsPixEqual(src[0], src[4])) ) );
 
-		blendPix = (DistYCbCr(src[0], src[3]) <= DistYCbCr(src[0], src[5])) ? src[3] : src[5];
-		dst[3] = mix(dst[3], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0 / 3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
+		blendPix = ( DistYCbCr(src[0], src[3]) <= DistYCbCr(src[0], src[5]) ) ? src[3] : src[5];
+		dst[ 3] = mix(dst[ 3], blendPix, (needBlend && doLineBlend) ? ((haveShallowLine) ? ((haveSteepLine) ? 1.0/3.0 : 0.25) : ((haveSteepLine) ? 0.25 : 0.00)) : 0.00);
 		dst[12] = mix(dst[12], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.25 : 0.00);
 		dst[13] = mix(dst[13], blendPix, (needBlend && doLineBlend && haveSteepLine) ? 0.75 : 0.00);
 		dst[14] = mix(dst[14], blendPix, (needBlend) ? ((doLineBlend) ? ((haveSteepLine) ? 1.00 : ((haveShallowLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
 		dst[15] = mix(dst[15], blendPix, (needBlend) ? ((doLineBlend) ? 1.00 : 0.6848532563) : 0.00);
-		dst[4] = mix(dst[4], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
-		dst[5] = mix(dst[5], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
-		dst[6] = mix(dst[6], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
+		dst[ 4] = mix(dst[ 4], blendPix, (needBlend) ? ((doLineBlend) ? ((haveShallowLine) ? 1.00 : ((haveSteepLine) ? 0.75 : 0.50)) : 0.08677704501) : 0.00);
+		dst[ 5] = mix(dst[ 5], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.75 : 0.00);
+		dst[ 6] = mix(dst[ 6], blendPix, (needBlend && doLineBlend && haveShallowLine) ? 0.25 : 0.00);
 	}
 
 	// Output Pixel Mapping:

--- a/assets/shaders/tex_4xbrz.csh
+++ b/assets/shaders/tex_4xbrz.csh
@@ -100,6 +100,11 @@ void applyScaling(uvec2 origxy) {
 
 	ivec4 blendResult = ivec4(BLEND_NONE);
 
+	// Preserve old alpha-ignoring behavior? Keep or delete?
+	for (int i = 0; i < 9; i++) {
+		v[i] &= 0xFFFFFF;
+	}
+
 	// Preprocess corners
 	// Pixel Tap Mapping: --|--|--|--|--
 	//                    --|--|07|08|--

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.0.4'
     }
 }
 


### PR DESCRIPTION
According to very crude measurements, speeds up texture scaling by 30% on Adreno and 10%-20% on Mali.

Also adds a 2xBRZ mode that's just the 4xBRZ mode downsampled by two, might help on some hardware by using less bandwidth I guess.

Plus, disable texture upscaling of video textures, and a few other odds and ends.

Might help #15109 a bit, though I still don't understand why it would have slowed down from before.