### PR TITLE
Debounce debugger window updates

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -447,7 +447,6 @@ void Core_MemoryException(u32 address, u32 pc, MemoryExceptionType type) {
 		e.address = address;
 		e.pc = pc;
 		Core_EnableStepping(true, "memory.exception", address);
-		host->SetDebugMode(true);
 	}
 }
 
@@ -469,7 +468,6 @@ void Core_MemoryExceptionInfo(u32 address, u32 pc, MemoryExceptionType type, std
 		e.address = address;
 		e.pc = pc;
 		Core_EnableStepping(true, "memory.exception", address);
-		host->SetDebugMode(true);
 	}
 }
 
@@ -485,7 +483,6 @@ void Core_ExecException(u32 address, u32 pc, ExecExceptionType type) {
 	e.address = address;
 	e.pc = pc;
 	Core_EnableStepping(true, "cpu.exception", pc);
-	host->SetDebugMode(true);
 }
 
 void Core_Break() {
@@ -498,7 +495,6 @@ void Core_Break() {
 
 	if (!g_Config.bIgnoreBadMemAccess) {
 		Core_EnableStepping(true, "cpu.breakInstruction", currentMIPS->pc);
-		host->SetDebugMode(true);
 	}
 }
 

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -69,7 +69,6 @@ BreakAction MemCheck::Action(u32 addr, bool write, int size, u32 pc, const char 
 		Log(addr, write, size, pc, reason);
 		if ((result & BREAK_ACTION_PAUSE) && coreState != CORE_POWERUP) {
 			Core_EnableStepping(true, "memory.breakpoint", start);
-			host->SetDebugMode(true);
 		}
 
 		return result;
@@ -125,8 +124,6 @@ void MemCheck::JitCleanup(bool changed)
 		CBreakPoints::SetSkipFirst(lastPC);
 		Core_EnableStepping(false);
 	}
-	else
-		host->SetDebugMode(true);
 }
 
 // Note: must lock while calling this.
@@ -368,7 +365,6 @@ BreakAction CBreakPoints::ExecBreakPoint(u32 addr) {
 		}
 		if ((info.result & BREAK_ACTION_PAUSE) && coreState != CORE_POWERUP) {
 			Core_EnableStepping(true, "cpu.breakpoint", info.addr);
-			host->SetDebugMode(true);
 		}
 
 		return info.result;

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -364,7 +364,6 @@ bool hleExecuteDebugBreak(const HLEFunction &func)
 	}
 
 	Core_EnableStepping(true, "hle.step", latestSyscallPC);
-	host->SetDebugMode(true);
 	return true;
 }
 

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -110,7 +110,7 @@ static void JitBranchLogMismatch(MIPSOpcode op, u32 pc)
 	char temp[256];
 	MIPSDisAsm(op, pc, temp, true);
 	ERROR_LOG(JIT, "Bad jump: %s - int:%08x jit:%08x", temp, currentMIPS->intBranchExit, currentMIPS->jitBranchExit);
-	host->SetDebugMode(true);
+	Core_EnableStepping(true, "jit.branchdebug", pc);
 }
 
 void Jit::BranchLog(MIPSOpcode op)

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -173,4 +173,7 @@ public:
 		selectRangeEnd = extend ? std::max(selectRangeEnd, after) : after;
 		updateStatusBarText();
 	}
+
+private:
+	bool redrawScheduled_ = false;
 };

--- a/Windows/Debugger/CtrlMemView.h
+++ b/Windows/Debugger/CtrlMemView.h
@@ -106,4 +106,7 @@ public:
 	void toggleOffsetScale(CommonToggles toggle);
 	void toggleStringSearch(CommonToggles toggle);
 	void setHighlightType(MemBlockFlags flags);
+
+private:
+	bool redrawScheduled_ = false;
 };

--- a/Windows/Debugger/CtrlRegisterList.h
+++ b/Windows/Debugger/CtrlRegisterList.h
@@ -76,4 +76,7 @@ public:
 	{
 		return cpu;
 	}
+
+private:
+	bool redrawScheduled_ = false;
 };

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -909,6 +909,6 @@ void CDisasm::UpdateDialog(bool _bComplete)
 
 	// repaint windows at the bottom. only the memory view needs to be forced to
 	// redraw. all others are updated manually
-	InvalidateRect (GetDlgItem(m_hDlg, IDC_DEBUGMEMVIEW), NULL, TRUE);
-	UpdateWindow (GetDlgItem(m_hDlg, IDC_DEBUGMEMVIEW));
+	CtrlMemView *memview = CtrlMemView::getFrom(GetDlgItem(m_hDlg, IDC_DEBUGMEMVIEW));
+	memview->redraw();
 }

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -286,7 +286,6 @@ void CDisasm::stepOver()
 		ptr->scrollStepping(breakpointAddress);
 	}
 
-	SetDebugMode(false, true);
 	CBreakPoints::AddBreakPoint(breakpointAddress,true);
 	Core_EnableStepping(false);
 	Sleep(1);
@@ -324,7 +323,6 @@ void CDisasm::stepOut()
 	CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg,IDC_DISASMVIEW));
 	ptr->setDontRedraw(true);
 
-	SetDebugMode(false, true);
 	CBreakPoints::AddBreakPoint(breakpointAddress,true);
 	Core_EnableStepping(false);
 	Sleep(1);
@@ -343,7 +341,6 @@ void CDisasm::runToLine()
 
 	lastTicks = CoreTiming::GetTicks();
 	ptr->setDontRedraw(true);
-	SetDebugMode(false, true);
 	CBreakPoints::AddBreakPoint(pos,true);
 	Core_EnableStepping(false);
 }
@@ -420,7 +417,6 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					bool isRunning = Core_IsActive();
 					if (isRunning)
 					{
-						SetDebugMode(true, false);
 						Core_EnableStepping(true, "cpu.breakpoint.add", 0);
 						Core_WaitInactive(200);
 					}
@@ -429,10 +425,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					if (bpw.exec()) bpw.addBreakpoint();
 
 					if (isRunning)
-					{
-						SetDebugMode(false, false);
 						Core_EnableStepping(false);
-					}
 					keepStatusBarText = false;
 				}
 				break;
@@ -524,7 +517,6 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					if (!Core_IsStepping())		// stop
 					{
 						ptr->setDontRedraw(false);
-						SetDebugMode(true, true);
 						Core_EnableStepping(true, "ui.break", 0);
 						Sleep(1); //let cpu catch up
 						ptr->gotoPC();
@@ -537,7 +529,6 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 						// If the current PC is on a breakpoint, the user doesn't want to do nothing.
 						CBreakPoints::SetSkipFirst(currentMIPS->pc);
 
-						SetDebugMode(false, true);
 						Core_EnableStepping(false);
 					}
 				}
@@ -565,7 +556,6 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					CBreakPoints::SetSkipFirst(currentMIPS->pc);
 
 					hleDebugBreak();
-					SetDebugMode(false, true);
 					Core_EnableStepping(false);
 				}
 				break;

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -32,9 +32,6 @@
 #include <windowsx.h>
 #include <commctrl.h>
 
-// How long (max) to wait for Core to pause before clearing temp breakpoints.
-static const int TEMP_BREAKPOINT_WAIT_MS = 100;
-
 static FAR WNDPROC DefGotoEditProc;
 
 LRESULT CALLBACK GotoEditProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
@@ -782,10 +779,9 @@ void CDisasm::SetDebugMode(bool _bDebug, bool switchPC)
 	HWND hDlg = m_hDlg;
 	bool ingame = (GetUIState() == UISTATE_INGAME || GetUIState() == UISTATE_EXCEPTION) && PSP_IsInited();
 
-	// Update Dialog Windows
-	if (_bDebug && ingame)
-	{
-		Core_WaitInactive(TEMP_BREAKPOINT_WAIT_MS);
+	// If we're stepping, update debugging windows.
+	// This is called potentially asynchronously, so state might've changed.
+	if (Core_IsStepping() && ingame) {
 		breakpointList->reloadBreakpoints();
 		threadList->reloadThreads();
 		stackTraceView->loadStackTrace();

--- a/Windows/Debugger/Debugger_Disasm.h
+++ b/Windows/Debugger/Debugger_Disasm.h
@@ -52,14 +52,18 @@ public:
 	void Show(bool bShow, bool includeToTop = true) override;
 
 	void Update() override {
-		UpdateDialog(true);
+		UpdateDialog();
 		SetDebugMode(Core_IsStepping(), false);
 		breakpointList->reloadBreakpoints();
 	};
-	void UpdateDialog(bool _bComplete = false);
-	// SetDebugMode 
+	void UpdateDialog();
 	void SetDebugMode(bool _bDebug, bool switchPC);
 
 	void Goto(u32 addr);
 	void NotifyMapLoaded();
+
+private:
+	void ProcessUpdateDialog();
+
+	bool updateDialogScheduled_ = false;
 };

--- a/Windows/Debugger/Debugger_Lists.cpp
+++ b/Windows/Debugger/Debugger_Lists.cpp
@@ -401,11 +401,11 @@ void CtrlBreakpointList::removeBreakpoint(int itemIndex)
 	}
 }
 
-int CtrlBreakpointList::getTotalBreakpointCount()
-{
-	int count = (int)CBreakPoints::GetMemChecks().size();
-	for (size_t i = 0; i < CBreakPoints::GetBreakpoints().size(); i++) {
-		if (!displayedBreakPoints_[i].temporary) count++;
+int CtrlBreakpointList::getTotalBreakpointCount() {
+	int count = (int)displayedMemChecks_.size();
+	for (auto bp : displayedBreakPoints_) {
+		if (!bp.temporary)
+			++count;
 	}
 
 	return count;

--- a/Windows/W32Util/Misc.cpp
+++ b/Windows/W32Util/Misc.cpp
@@ -255,8 +255,10 @@ void GenericListControl::HandleNotify(LPARAM lParam)
 }
 
 void GenericListControl::Update() {
-	SetTimer(handle, IDT_UPDATE, UPDATE_DELAY, nullptr);
-	updateScheduled_ = true;
+	if (!updateScheduled_) {
+		SetTimer(handle, IDT_UPDATE, UPDATE_DELAY, nullptr);
+		updateScheduled_ = true;
+	}
 }
 
 void GenericListControl::ProcessUpdate() {

--- a/Windows/W32Util/Misc.h
+++ b/Windows/W32Util/Misc.h
@@ -56,8 +56,10 @@ protected:
 	virtual void OnRightClick(int itemIndex, int column, const POINT& point) { };
 	virtual void CopyRows(int start, int size);
 	virtual void OnToggle(int item, bool newValue) { };
+
 private:
 	static LRESULT CALLBACK wndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+	void ProcessUpdate();
 	void ResizeColumns();
 	void ProcessCopy();
 	void SelectAll();
@@ -72,4 +74,5 @@ private:
 	// Used for hacky workaround to fix a rare hang (see issue #5184)
 	volatile bool inResizeColumns;
 	volatile bool updating;
+	bool updateScheduled_ = false;
 };


### PR DESCRIPTION
This makes a few changes, which overall greatly improve the responsiveness of PPSSPP when scripting debugger breakpoint handling.

1. Ensures the debugger updates based on current state, not the old state (which may be wrong due to asynchronous processing of messages.)
2. Reduces duplicate debugger window update messages (we most often sent it twice.)
3. Delays most debugger window updates so they happen at most sixty times a second.  This helps catch other duplicates to reduce duplicate repaints (especially if stepping is very briefly enabled via API.)
4. Fixes a thread locking hazard in one of the updates.

When testing this, I did run into something that looked very much like - sometimes - we were going into stepping AFTER processing a delay slot, but then re-running the delay slot.  In some cases, this can cause a crash.  I didn't find the source, though, but I think it's not caused by these changes.

-[Unknown]