### PR TITLE
Path: Check for PSP case insensitively

### DIFF
--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -1,4 +1,6 @@
 #include "ppsspp_config.h"
+#include <algorithm>
+#include <cctype>
 #include <cstring>
 
 #include "Common/File/Path.h"
@@ -216,14 +218,17 @@ std::string Path::GetDirectory() const {
 	return path_;
 }
 
-bool Path::FilePathContains(const std::string &needle) const {
+bool Path::FilePathContainsNoCase(const std::string &needle) const {
 	std::string haystack;
 	if (type_ == PathType::CONTENT_URI) {
 		haystack = AndroidContentURI(path_).FilePath();
 	} else {
 		haystack = path_;
 	}
-	return haystack.find(needle) != std::string::npos;
+
+	auto pred = [](char ch1, char ch2) { return std::toupper(ch1) == std::toupper(ch2); };
+	auto found = std::search(haystack.begin(), haystack.end(), needle.begin(), needle.end(), pred);
+	return found != haystack.end();
 }
 
 bool Path::StartsWith(const Path &other) const {

--- a/Common/File/Path.h
+++ b/Common/File/Path.h
@@ -111,7 +111,7 @@ public:
 		return path_ != other.path_ || type_ != other.type_;
 	}
 
-	bool FilePathContains(const std::string &needle) const;
+	bool FilePathContainsNoCase(const std::string &needle) const;
 
 	bool StartsWith(const Path &other) const;
 

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -85,7 +85,7 @@ Path DirectoryFileHandle::GetLocalPath(const Path &basePath, std::string localpa
 		localpath.erase(0, 1);
 
 	if (fileSystemFlags_ & FileSystemFlags::STRIP_PSP) {
-		if (startsWith(localpath, "PSP/")) {
+		if (startsWithNoCase(localpath, "PSP/")) {
 			localpath = localpath.substr(4);
 		}
 	}
@@ -101,7 +101,7 @@ Path DirectoryFileSystem::GetLocalPath(std::string internalPath) const {
 		internalPath.erase(0, 1);
 
 	if (flags & FileSystemFlags::STRIP_PSP) {
-		if (startsWith(internalPath, "PSP/")) {
+		if (startsWithNoCase(internalPath, "PSP/")) {
 			internalPath = internalPath.substr(4);
 		}
 	}
@@ -206,7 +206,7 @@ bool DirectoryFileHandle::Open(const Path &basePath, std::string &fileName, File
 
 		int fd = File::OpenFD(fullName, (File::OpenFlag)flags);
 		// Try to detect reads/writes to PSP/GAME to avoid them in replays.
-		if (fullName.FilePathContains("PSP/GAME/")) {
+		if (fullName.FilePathContainsNoCase("PSP/GAME/")) {
 			inGameDir_ = true;
 		}
 		hFile = fd;
@@ -287,7 +287,7 @@ bool DirectoryFileHandle::Open(const Path &basePath, std::string &fileName, File
 #endif
 
 	// Try to detect reads/writes to PSP/GAME to avoid them in replays.
-	if (fullName.FilePathContains("PSP/GAME/")) {
+	if (fullName.FilePathContainsNoCase("PSP/GAME/")) {
 		inGameDir_ = true;
 	}
 	if (access & (FILEACCESS_APPEND | FILEACCESS_CREATE | FILEACCESS_WRITE)) {

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -180,7 +180,7 @@ IdentifiedFileType Identify_File(FileLoader *fileLoader, std::string *errorStrin
 		// Let's check if we got pointed to a PBP within such a directory.
 		// If so we just move up and return the directory itself as the game.
 		// If loading from memstick...
-		if (fileLoader->GetPath().FilePathContains("PSP/GAME/")) {
+		if (fileLoader->GetPath().FilePathContainsNoCase("PSP/GAME/")) {
 			return IdentifiedFileType::PSP_PBP_DIRECTORY;
 		}
 		return IdentifiedFileType::PSP_PBP;

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -596,9 +596,9 @@ CoreParameter &PSP_CoreParameter() {
 }
 
 Path GetSysDirectory(PSPDirectories directoryType) {
-	Path memStickDirectory = g_Config.memStickDirectory;
+	const Path &memStickDirectory = g_Config.memStickDirectory;
 	Path pspDirectory;
-	if (memStickDirectory.GetFilename() == "PSP") {
+	if (!strcasecmp(memStickDirectory.GetFilename().c_str(), "PSP")) {
 		// Let's strip this off, to easily allow choosing a root directory named "PSP" on Android.
 		pspDirectory = memStickDirectory;
 	} else {

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -50,7 +50,7 @@ void CwCheatScreen::LoadCheatInfo() {
 		gameID = info->paramSFO.GetValueString("DISC_ID");
 	}
 	if ((info->id.empty() || !info->disc_total)
-		&& gamePath_.FilePathContains("PSP/GAME/")) {
+		&& gamePath_.FilePathContainsNoCase("PSP/GAME/")) {
 		gameID = g_paramSFO.GenerateFakeID(gamePath_.ToString());
 	}
 

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -390,7 +390,7 @@ public:
 
 					// Assuming PSP_PBP_DIRECTORY without ID or with disc_total < 1 in GAME dir must be homebrew
 					if ((info_->id.empty() || !info_->disc_total)
-						&& gamePath_.FilePathContains("PSP/GAME/")
+						&& gamePath_.FilePathContainsNoCase("PSP/GAME/")
 						&& info_->fileType == IdentifiedFileType::PSP_PBP_DIRECTORY) {
 						info_->id = g_paramSFO.GenerateFakeID(gamePath_.ToString());
 						info_->id_version = info_->id + "_1.00";

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -348,7 +348,7 @@ UI::EventReturn GameScreen::OnGameSettings(UI::EventParams &e) {
 	std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(NULL, gamePath_, GAMEINFO_WANTBG | GAMEINFO_WANTSIZE);
 	if (info && info->paramSFOLoaded) {
 		std::string discID = info->paramSFO.GetValueString("DISC_ID");
-		if ((discID.empty() || !info->disc_total) && gamePath_.FilePathContains("PSP/GAME/"))
+		if ((discID.empty() || !info->disc_total) && gamePath_.FilePathContainsNoCase("PSP/GAME/"))
 			discID = g_paramSFO.GenerateFakeID(gamePath_.ToString());
 		screenManager()->push(new GameSettingsScreen(gamePath_, discID, true));
 	}


### PR DESCRIPTION
This allows a game to look up ms0:/psp/ even with the PSP special case path handling.

Not super well tested, but may help #15206.

EDIT(hrydgard): Also see #15236

-[Unknown]