### PR TITLE
Make the Vulkan GPU log profiler a runtime developer setting

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -16,15 +16,8 @@
 // other things as well. We also have a nice integrated render pass profiler in the queue
 // runner, but this one is more convenient for transient events.
 
-// #define VULKAN_PROFILER_ENABLED
-
-#if defined(VULKAN_PROFILER_ENABLED)
 #define VK_PROFILE_BEGIN(vulkan, cmd, stage, ...) vulkan->GetProfiler()->Begin(cmd, stage, __VA_ARGS__);
 #define VK_PROFILE_END(vulkan, cmd, stage) vulkan->GetProfiler()->End(cmd, stage);
-#else
-#define VK_PROFILE_BEGIN(vulkan, cmd, stage, ...)
-#define VK_PROFILE_END(vulkan, cmd, stage)
-#endif
 
 enum {
 	VULKAN_FLAG_VALIDATE = 1,
@@ -319,6 +312,12 @@ public:
 	}
 	VkFormat GetSwapchainFormat() const {
 		return swapchainFormat_;
+	}
+
+	void SetProfilerEnabledPtr(bool *enabled) {
+		for (auto &frame : frame_) {
+			frame.profiler.SetEnabledPtr(enabled);
+		}
 	}
 
 	// 1 for no frame overlap and thus minimal latency but worst performance.

--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -19,10 +19,10 @@
 // #define VULKAN_PROFILER_ENABLED
 
 #if defined(VULKAN_PROFILER_ENABLED)
-#define VK_PROFILE_BEGIN(vulkan, cmd, stage, message) vulkan->GetProfiler()->Begin(cmd, stage, message);
+#define VK_PROFILE_BEGIN(vulkan, cmd, stage, ...) vulkan->GetProfiler()->Begin(cmd, stage, __VA_ARGS__);
 #define VK_PROFILE_END(vulkan, cmd, stage) vulkan->GetProfiler()->End(cmd, stage);
 #else
-#define VK_PROFILE_BEGIN(vulkan, cmd, stage, message)
+#define VK_PROFILE_BEGIN(vulkan, cmd, stage, ...)
 #define VK_PROFILE_END(vulkan, cmd, stage)
 #endif
 

--- a/Common/GPU/Vulkan/VulkanProfiler.cpp
+++ b/Common/GPU/Vulkan/VulkanProfiler.cpp
@@ -60,12 +60,14 @@ void VulkanProfiler::BeginFrame(VulkanContext *vulkan, VkCommandBuffer firstComm
 		numQueries_ = MAX_QUERY_COUNT;
 		firstFrame_ = false;
 	}
-	vkCmdResetQueryPool(firstCommandBuf, queryPool_, 0, numQueries_);
+	if (numQueries_ > 0) {
+		vkCmdResetQueryPool(firstCommandBuf, queryPool_, 0, numQueries_);
+	}
 	numQueries_ = 0;
 }
 
 void VulkanProfiler::Begin(VkCommandBuffer cmdBuf, VkPipelineStageFlagBits stageFlags, const char *fmt, ...) {
-	if (numQueries_ >= MAX_QUERY_COUNT - 1) {
+	if ((enabledPtr_ && !*enabledPtr_) || numQueries_ >= MAX_QUERY_COUNT - 1) {
 		return;
 	}
 
@@ -89,7 +91,7 @@ void VulkanProfiler::Begin(VkCommandBuffer cmdBuf, VkPipelineStageFlagBits stage
 }
 
 void VulkanProfiler::End(VkCommandBuffer cmdBuf, VkPipelineStageFlagBits stageFlags) {
-	if (numQueries_ >= MAX_QUERY_COUNT - 1) {
+	if ((enabledPtr_ && !*enabledPtr_) || numQueries_ >= MAX_QUERY_COUNT - 1) {
 		return;
 	}
 

--- a/Common/GPU/Vulkan/VulkanProfiler.cpp
+++ b/Common/GPU/Vulkan/VulkanProfiler.cpp
@@ -1,3 +1,5 @@
+#include <stdarg.h>
+
 #include "VulkanProfiler.h"
 #include "VulkanContext.h"
 

--- a/Common/GPU/Vulkan/VulkanProfiler.cpp
+++ b/Common/GPU/Vulkan/VulkanProfiler.cpp
@@ -64,13 +64,19 @@ void VulkanProfiler::BeginFrame(VulkanContext *vulkan, VkCommandBuffer firstComm
 	numQueries_ = 0;
 }
 
-void VulkanProfiler::Begin(VkCommandBuffer cmdBuf, VkPipelineStageFlagBits stageFlags, std::string scopeName) {
+void VulkanProfiler::Begin(VkCommandBuffer cmdBuf, VkPipelineStageFlagBits stageFlags, const char *fmt, ...) {
 	if (numQueries_ >= MAX_QUERY_COUNT - 1) {
 		return;
 	}
 
+	va_list args;
+	va_start(args, fmt);
+	char temp[512];
+	vsnprintf(temp, sizeof(temp), fmt, args);
+	va_end(args);
+
 	ProfilerScope scope;
-	scope.name = scopeName;
+	scope.name = temp;
 	scope.startQueryId = numQueries_;
 	scope.endQueryId = -1;
 	scope.level = (int)scopeStack_.size();

--- a/Common/GPU/Vulkan/VulkanProfiler.h
+++ b/Common/GPU/Vulkan/VulkanProfiler.h
@@ -30,7 +30,11 @@ public:
 
 	void BeginFrame(VulkanContext *vulkan, VkCommandBuffer firstCommandBuffer);
 
-	void Begin(VkCommandBuffer cmdBuf, VkPipelineStageFlagBits stage, std::string scopeName);
+	void Begin(VkCommandBuffer cmdBuf, VkPipelineStageFlagBits stage, const char *fmt, ...)
+#ifdef __GNUC__
+		__attribute__((format(printf, 3, 4)))
+#endif
+		;
 	void End(VkCommandBuffer cmdBuf, VkPipelineStageFlagBits stage);
 
 private:

--- a/Common/GPU/Vulkan/VulkanProfiler.h
+++ b/Common/GPU/Vulkan/VulkanProfiler.h
@@ -37,6 +37,9 @@ public:
 		;
 	void End(VkCommandBuffer cmdBuf, VkPipelineStageFlagBits stage);
 
+	void SetEnabledPtr(bool *enabledPtr) {
+		enabledPtr_ = enabledPtr;
+	}
 private:
 	VulkanContext *vulkan_;
 
@@ -44,6 +47,7 @@ private:
 	std::vector<ProfilerScope> scopes_;
 	int numQueries_ = 0;
 	bool firstFrame_ = true;
+	bool *enabledPtr_ = nullptr;
 
 	std::vector<size_t> scopeStack_;
 

--- a/Common/GPU/Vulkan/VulkanProfiler.h
+++ b/Common/GPU/Vulkan/VulkanProfiler.h
@@ -32,7 +32,7 @@ public:
 
 	void Begin(VkCommandBuffer cmdBuf, VkPipelineStageFlagBits stage, const char *fmt, ...)
 #ifdef __GNUC__
-		__attribute__((format(printf, 3, 4)))
+		__attribute__((format(printf, 4, 5)))
 #endif
 		;
 	void End(VkCommandBuffer cmdBuf, VkPipelineStageFlagBits stage);

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -516,7 +516,7 @@ void VulkanRenderManager::ThreadFunc() {
 	VLOG("PULL: Quitting");
 }
 
-void VulkanRenderManager::BeginFrame(bool enableProfiling) {
+void VulkanRenderManager::BeginFrame(bool enableProfiling, bool enableLogProfiler) {
 	VLOG("BeginFrame");
 	VkDevice device = vulkan_->GetDevice();
 
@@ -584,11 +584,7 @@ void VulkanRenderManager::BeginFrame(bool enableProfiling) {
 		WARN_LOG(G3D, "BeginFrame while !run_!");
 	}
 
-#if defined(VULKAN_PROFILER_ENABLED)
-	vulkan_->BeginFrame(GetInitCmd());
-#else
-	vulkan_->BeginFrame(VK_NULL_HANDLE);
-#endif
+	vulkan_->BeginFrame(enableLogProfiler ? GetInitCmd() : VK_NULL_HANDLE);
 
 	insideFrame_ = true;
 	renderStepOffset_ = 0;

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -187,7 +187,7 @@ public:
 	void DrainCompileQueue();
 
 	// Makes sure that the GPU has caught up enough that we can start writing buffers of this frame again.
-	void BeginFrame(bool enableProfiling);
+	void BeginFrame(bool enableProfiling, bool enableLogProfiler);
 	// Can run on a different thread!
 	void Finish();
 	void Run(int frame);

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -906,7 +906,8 @@ VKContext::~VKContext() {
 }
 
 void VKContext::BeginFrame() {
-	renderManager_.BeginFrame(g_Config.bShowGpuProfile);
+	// TODO: Bad dependency on g_Config here!
+	renderManager_.BeginFrame(g_Config.bShowGpuProfile, g_Config.bGpuLogProfiler);
 
 	FrameData &frame = frame_[vulkan_->GetCurFrame()];
 	push_ = frame.pushBuffer;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -916,6 +916,7 @@ static ConfigSetting graphicsSettings[] = {
 	ConfigSetting("RenderDuplicateFrames", &g_Config.bRenderDuplicateFrames, false, true, true),
 
 	ConfigSetting("ShaderCache", &g_Config.bShaderCache, true, false, false),  // Doesn't save. Ini-only.
+	ConfigSetting("GpuLogProfiler", &g_Config.bGpuLogProfiler, false, true, false),
 
 	ConfigSetting(false),
 };

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -495,6 +495,7 @@ public:
 
 	// Volatile development settings
 	bool bShowFrameProfiler;
+	bool bGpuLogProfiler; // Controls the Vulkan logging profiler (profiles textures uploads etc).
 
 	// Various directories. Autoconfigured, not read from ini.
 	Path currentDirectory;  // The directory selected in the game browsing window.

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -59,6 +59,9 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	CheckGPUFeatures();
 
 	VulkanContext *vulkan = (VulkanContext *)gfxCtx->GetAPIContext();
+
+	vulkan->SetProfilerEnabledPtr(&g_Config.bGpuLogProfiler);
+
 	shaderManagerVulkan_ = new ShaderManagerVulkan(draw);
 	pipelineManager_ = new PipelineManagerVulkan(vulkan);
 	framebufferManagerVulkan_ = new FramebufferManagerVulkan(draw);

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -807,7 +807,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 
 	if (entry->vkTex) {
 		VK_PROFILE_BEGIN(vulkan, cmdInit, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-			StringFromFormat("Texture Upload (%08x) video=%d", entry->addr, isVideo));
+			"Texture Upload (%08x) video=%d", entry->addr, isVideo);
 
 		// NOTE: Since the level is not part of the cache key, we assume it never changes.
 		u8 level = std::max(0, gstate.getTexLevelOffset16() / 16);
@@ -838,7 +838,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 				replaced.Load(i, data, stride);  // if it fails, it'll just be garbage data... OK for now.
 				replacementTimeThisFrame_ += time_now_d() - replaceStart;
 				VK_PROFILE_BEGIN(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT,
-					StringFromFormat("Copy Upload (replaced): %dx%d", mipWidth, mipHeight));
+					"Copy Upload (replaced): %dx%d", mipWidth, mipHeight);
 				entry->vkTex->UploadMip(cmdInit, i, mipWidth, mipHeight, texBuf, bufferOffset, stride / bpp);
 				VK_PROFILE_END(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT);
 			} else {
@@ -861,7 +861,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 						VkDescriptorSet descSet = computeShaderManager_.GetDescriptorSet(view, texBuf, bufferOffset, srcSize);
 						struct Params { int x; int y; } params{ mipUnscaledWidth, mipUnscaledHeight };
 						VK_PROFILE_BEGIN(vulkan, cmdInit, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-							StringFromFormat("Compute Upload: %dx%d->%dx%d", mipUnscaledWidth, mipUnscaledHeight, mipWidth, mipHeight));
+							"Compute Upload: %dx%d->%dx%d", mipUnscaledWidth, mipUnscaledHeight, mipWidth, mipHeight);
 						vkCmdBindPipeline(cmdInit, VK_PIPELINE_BIND_POINT_COMPUTE, computeShaderManager_.GetPipeline(uploadCS_));
 						vkCmdBindDescriptorSets(cmdInit, VK_PIPELINE_BIND_POINT_COMPUTE, computeShaderManager_.GetPipelineLayout(), 0, 1, &descSet, 0, nullptr);
 						vkCmdPushConstants(cmdInit, computeShaderManager_.GetPipelineLayout(), VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(params), &params);
@@ -872,7 +872,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 						data = drawEngine_->GetPushBufferForTextureData()->PushAligned(size, &bufferOffset, &texBuf, pushAlignment);
 						LoadTextureLevel(*entry, (uint8_t *)data, stride, i, scaleFactor, dstFmt);
 						VK_PROFILE_BEGIN(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT,
-							StringFromFormat("Copy Upload: %dx%d", mipWidth, mipHeight));
+							"Copy Upload: %dx%d", mipWidth, mipHeight);
 						entry->vkTex->UploadMip(cmdInit, i, mipWidth, mipHeight, texBuf, bufferOffset, stride / bpp);
 						VK_PROFILE_END(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT);
 					}
@@ -892,7 +892,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		// Generate any additional mipmap levels.
 		// This will transition the whole stack to GENERAL if it wasn't already.
 		if (maxLevel != maxLevelToGenerate) {
-			VK_PROFILE_BEGIN(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT, StringFromFormat("Mipgen up to level %d", maxLevelToGenerate));
+			VK_PROFILE_BEGIN(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT, "Mipgen up to level %d", maxLevelToGenerate);
 			entry->vkTex->GenerateMips(cmdInit, maxLevel + 1, computeUpload);
 			layout = VK_IMAGE_LAYOUT_GENERAL;
 			prevStage = VK_PIPELINE_STAGE_TRANSFER_BIT;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1774,6 +1774,9 @@ void DeveloperToolsScreen::CreateViews() {
 
 	list->Add(new CheckBox(&g_Config.bShowOnScreenMessages, dev->T("Show on-screen messages")));
 	list->Add(new CheckBox(&g_Config.bEnableLogging, dev->T("Enable Logging")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLoggingChanged);
+	if (GetGPUBackend() == GPUBackend::VULKAN) {
+		list->Add(new CheckBox(&g_Config.bGpuLogProfiler, gr->T("GPU log profiler")));
+	}
 	list->Add(new CheckBox(&g_Config.bLogFrameDrops, dev->T("Log Dropped Frame Statistics")));
 	list->Add(new Choice(dev->T("Logging Channels")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLogConfig);
 	list->Add(new ItemHeader(dev->T("Language")));


### PR DESCRIPTION
I keep forgetting to disable the define on commit, this is a better solution.
