### PR TITLE
Debugger: Don't try to hash invalid RAM

### DIFF
--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -88,10 +88,14 @@ bool IsLikelyStringAt(uint32_t addr) {
 
 static HashType computeHash(u32 address, u32 size)
 {
+	if (!Memory::IsValidAddress(address))
+		return 0;
+
+	size = Memory::ValidSize(address, size);
 #if PPSSPP_ARCH(AMD64)
-	return XXH3_64bits(Memory::GetPointer(address), size);
+	return XXH3_64bits(Memory::GetPointerUnchecked(address), size);
 #else
-	return XXH3_64bits(Memory::GetPointer(address), size) & 0xFFFFFFFF;
+	return XXH3_64bits(Memory::GetPointerUnchecked(address), size) & 0xFFFFFFFF;
 #endif
 }
 


### PR DESCRIPTION
Should avoid the direct cause of the crash in #15245.  But I think this means the disassembly tried to parse out address 0, which I hope doesn't mean the game jumped to a null pointer...

Not reproduced.

-[Unknown]