### PR TITLE
Vectorize texture sampling a bit, make filtering more accurate

### DIFF
--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -1735,6 +1735,9 @@ void XEmitter::PMULHW(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0xE5, des
 void XEmitter::PMULHUW(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0xE4, dest, arg);}
 void XEmitter::PMULUDQ(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0xF4, dest, arg);}
 
+void XEmitter::PMULLD(X64Reg dest, const OpArg &arg) {WriteSSE41Op(0x66, 0x3840, dest, arg);}
+void XEmitter::PMULDQ(X64Reg dest, const OpArg &arg) {WriteSSE41Op(0x66, 0x3828, dest, arg);}
+
 void XEmitter::WriteSSSE3Op(u8 opPrefix, u16 op, X64Reg regOp, OpArg arg, int extrabytes)
 {
 	_assert_msg_(cpu_info.bSSSE3, "Trying to use SSSE3 on a system that doesn't support it.");

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -850,6 +850,10 @@ public:
 	void PMULHUW(X64Reg dest, const OpArg &arg);
 	void PMULUDQ(X64Reg dest, const OpArg &arg);
 
+	// SSE4: integer multiply
+	void PMULLD(X64Reg dest, const OpArg &arg);
+	void PMULDQ(X64Reg dest, const OpArg &arg);
+
 	// SSE4: data type conversions
 	void PMOVSXBW(X64Reg dest, OpArg arg);
 	void PMOVSXBD(X64Reg dest, OpArg arg);

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -201,13 +201,12 @@ static inline Vec4IntResult SOFTRAST_CALL ApplyTexelClampQuadT(bool clamp, int v
 #endif
 }
 
-static inline void GetTexelCoordinates(int level, float s, float t, int& out_u, int& out_v)
-{
+static inline void GetTexelCoordinates(int level, float s, float t, int &out_u, int &out_v, int x, int y) {
 	int width = gstate.getTextureWidth(level);
 	int height = gstate.getTextureHeight(level);
 
-	int base_u = (int)(s * width * 256.0f + 0.375f);
-	int base_v = (int)(t * height * 256.0f + 0.375f);
+	int base_u = (int)(s * width * 256.0f) + 12 - x;
+	int base_v = (int)(t * height * 256.0f) + 12 - y;
 
 	base_u >>= 8;
 	base_v >>= 8;
@@ -607,9 +606,9 @@ static inline Vec4IntResult SOFTRAST_CALL ApplyTexturing(Sampler::Funcs sampler,
 		int u[8] = { 0 }, v[8] = { 0 };   // 1.27.4 fixed point
 
 		// Nearest filtering only.  Round texcoords.
-		GetTexelCoordinates(mayHaveMipLevels ? texlevel : 0, s, t, u[0], v[0]);
+		GetTexelCoordinates(mayHaveMipLevels ? texlevel : 0, s, t, u[0], v[0], x, y);
 		if (mayHaveMipLevels && frac_texlevel) {
-			GetTexelCoordinates(texlevel + 1, s, t, u[1], v[1]);
+			GetTexelCoordinates(texlevel + 1, s, t, u[1], v[1], x, y);
 		}
 
 		texcolor0 = Vec4<int>(sampler.nearest(u[0], v[0], tptr0, bufw0, mayHaveMipLevels ? texlevel : 0));

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -588,8 +588,7 @@ Vec3<int> AlphaBlendingResult(const PixelFuncID &pixelID, const Vec4<int> &sourc
 						::abs(source.b() - dst.b()));
 
 	default:
-		ERROR_LOG_REPORT(G3D, "Software: Unknown blend function %x", pixelID.alphaBlendEq);
-		return Vec3<int>();
+		return source.rgb();
 	}
 }
 

--- a/GPU/Software/RasterizerRegCache.h
+++ b/GPU/Software/RasterizerRegCache.h
@@ -67,6 +67,7 @@ typedef int32x4_t Vec4IntArg;
 typedef int32x4_t Vec4IntResult;
 typedef float32x4_t Vec4FloatArg;
 static inline Vec4IntArg ToVec4IntArg(const Math3D::Vec4<int> &a) { return vld1q_s32(a.AsArray()); }
+static inline Vec4IntArg ToVec4IntArg(const Vec4IntResult &a) { return a; }
 static inline Vec4IntResult ToVec4IntResult(const Math3D::Vec4<int> &a) { return vld1q_s32(a.AsArray()); }
 static inline Vec4FloatArg ToVec4FloatArg(const Math3D::Vec4<float> &a) { return vld1q_f32(a.AsArray()); }
 #elif PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
@@ -74,6 +75,7 @@ typedef __m128i Vec4IntArg;
 typedef __m128i Vec4IntResult;
 typedef __m128 Vec4FloatArg;
 static inline Vec4IntArg ToVec4IntArg(const Math3D::Vec4<int> &a) { return a.ivec; }
+static inline Vec4IntArg ToVec4IntArg(const Vec4IntResult &a) { return a; }
 static inline Vec4IntResult ToVec4IntResult(const Math3D::Vec4<int> &a) { return a.ivec; }
 static inline Vec4FloatArg ToVec4FloatArg(const Math3D::Vec4<float> &a) { return a.vec; }
 #else
@@ -124,6 +126,8 @@ struct RegCache {
 		GEN_ARG_FRAC_V = 0x018D,
 		VEC_ARG_COLOR = 0x0080,
 		VEC_ARG_MASK = 0x0081,
+		VEC_ARG_U = 0x0082,
+		VEC_ARG_V = 0x0083,
 
 		VEC_TEMP0 = 0x1000,
 		VEC_TEMP1 = 0x1001,

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -38,7 +38,7 @@ extern u32 clut[4096];
 namespace Sampler {
 
 static Vec4IntResult SOFTRAST_CALL SampleNearest(int u, int v, const u8 *tptr, int bufw, int level);
-static Vec4IntResult SOFTRAST_CALL SampleLinear(int u[4], int v[4], int frac_u, int frac_v, const u8 *tptr, int bufw, int level);
+static Vec4IntResult SOFTRAST_CALL SampleLinear(Vec4IntArg u, Vec4IntArg v, int frac_u, int frac_v, const u8 *tptr, int bufw, int level);
 
 std::mutex jitCacheLock;
 SamplerJitCache *jitCache = nullptr;
@@ -308,7 +308,7 @@ struct Nearest4 {
 };
 
 template <int N>
-inline static Nearest4 SOFTRAST_CALL SampleNearest(int u[N], int v[N], const u8 *srcptr, int texbufw, int level) {
+inline static Nearest4 SOFTRAST_CALL SampleNearest(const int u[N], const int v[N], const u8 *srcptr, int texbufw, int level) {
 	Nearest4 res;
 	if (!srcptr) {
 		memset(res.v, 0, sizeof(res.v));
@@ -414,8 +414,10 @@ static Vec4IntResult SOFTRAST_CALL SampleNearest(int u, int v, const u8 *tptr, i
 	return ToVec4IntResult(Vec4<int>::FromRGBA(c.v[0]));
 }
 
-static Vec4IntResult SOFTRAST_CALL SampleLinear(int u[4], int v[4], int frac_u, int frac_v, const u8 *tptr, int bufw, int texlevel) {
-	Nearest4 c = SampleNearest<4>(u, v, tptr, bufw, texlevel);
+static Vec4IntResult SOFTRAST_CALL SampleLinear(Vec4IntArg u_in, Vec4IntArg v_in, int frac_u, int frac_v, const u8 *tptr, int bufw, int texlevel) {
+	const Vec4<int> u = u_in;
+	const Vec4<int> v = v_in;
+	Nearest4 c = SampleNearest<4>(u.AsArray(), v.AsArray(), tptr, bufw, texlevel);
 
 	Vec4<int> texcolor_tl = Vec4<int>::FromRGBA(c.v[0]);
 	Vec4<int> texcolor_tr = Vec4<int>::FromRGBA(c.v[1]);

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -423,9 +423,9 @@ static Vec4IntResult SOFTRAST_CALL SampleLinear(Vec4IntArg u_in, Vec4IntArg v_in
 	Vec4<int> texcolor_tr = Vec4<int>::FromRGBA(c.v[1]);
 	Vec4<int> texcolor_bl = Vec4<int>::FromRGBA(c.v[2]);
 	Vec4<int> texcolor_br = Vec4<int>::FromRGBA(c.v[3]);
-	Vec4<int> t = texcolor_tl * (0x100 - frac_u) + texcolor_tr * frac_u;
-	Vec4<int> b = texcolor_bl * (0x100 - frac_u) + texcolor_br * frac_u;
-	return ToVec4IntResult((t * (0x100 - frac_v) + b * frac_v) / (256 * 256));
+	Vec4<int> t = texcolor_tl * (0x10 - frac_u) + texcolor_tr * frac_u;
+	Vec4<int> b = texcolor_bl * (0x10 - frac_u) + texcolor_br * frac_u;
+	return ToVec4IntResult((t * (0x10 - frac_v) + b * frac_v) / (16 * 16));
 }
 
 };

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -76,7 +76,7 @@ private:
 	bool Jit_ReadTextureFormat(const SamplerID &id);
 	bool Jit_GetTexData(const SamplerID &id, int bitsPerTexel);
 	bool Jit_GetTexDataSwizzled(const SamplerID &id, int bitsPerTexel);
-	bool Jit_GetTexDataSwizzled4();
+	bool Jit_GetTexDataSwizzled4(const SamplerID &id);
 	bool Jit_Decode5650();
 	bool Jit_Decode5551();
 	bool Jit_Decode4444();
@@ -84,6 +84,9 @@ private:
 	bool Jit_ReadClutColor(const SamplerID &id);
 	bool Jit_GetDXT1Color(const SamplerID &id, int blockSize, int alpha);
 	bool Jit_ApplyDXTAlpha(const SamplerID &id);
+
+	bool Jit_PrepareDataOffsets(const SamplerID &id);
+	bool Jit_PrepareDataSwizzledOffsets(const SamplerID &id, int bitsPerTexel);
 
 #if PPSSPP_ARCH(ARM64)
 	Arm64Gen::ARM64FloatEmitter fp;

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -36,7 +36,7 @@ namespace Sampler {
 typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *NearestFunc)(int u, int v, const u8 *tptr, int bufw, int level);
 NearestFunc GetNearestFunc();
 
-typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *LinearFunc)(int u[4], int v[4], int frac_u, int frac_v, const u8 *tptr, int bufw, int level);
+typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *LinearFunc)(Rasterizer::Vec4IntArg u, Rasterizer::Vec4IntArg v, int frac_u, int frac_v, const u8 *tptr, int bufw, int level);
 LinearFunc GetLinearFunc();
 
 struct Funcs {


### PR DESCRIPTION
Mipmap (auto and slope) filtering is still wrong, but from the detail level it calculates.  The fidelity after its calculation is now correct (verified to be 4 bits of fraction in both cases.)

The sampler changes give only about 2-3% improvement, generally.  That said, looking at a profile, texture sampling takes less time now.  Still fairly large, though.  I suppose I could special case some bufws, maybe.  Not really sure what more could be done for CLUT4->8888 swizzled and bilinear.  Maybe better in some cases to preprocess...

Moving texel coordinates and texture func into jit could also help, as that takes a pretty measurable amount of time (maybe 15%.)

Probably the slowest thing now is the barycentric processing...

See https://github.com/hrydgard/pspautotests/pull/217 for tests.

-[Unknown]