### PR TITLE
Correct level bug in samplerjit, minor SSE4 opt

### DIFF
--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -1781,6 +1781,10 @@ void XEmitter::PBLENDVB(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3810, dest
 void XEmitter::BLENDVPS(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3814, dest, arg);}
 void XEmitter::BLENDVPD(X64Reg dest, OpArg arg) {WriteSSE41Op(0x66, 0x3815, dest, arg);}
 
+void XEmitter::PBLENDW(X64Reg dest, OpArg arg, u8 mask) {WriteSSE41Op(0x66, 0x3A0E, dest, arg, 1); Write8(mask);}
+void XEmitter::BLENDPS(X64Reg dest, OpArg arg, u8 mask) {WriteSSE41Op(0x66, 0x3A0C, dest, arg, 1); Write8(mask);}
+void XEmitter::BLENDPD(X64Reg dest, OpArg arg, u8 mask) {WriteSSE41Op(0x66, 0x3A0D, dest, arg, 1); Write8(mask);}
+
 void XEmitter::ROUNDSS(X64Reg dest, OpArg arg, u8 mode) {WriteSSE41Op(0x66, 0x3A0A, dest, arg, 1); Write8(mode);}
 void XEmitter::ROUNDSD(X64Reg dest, OpArg arg, u8 mode) {WriteSSE41Op(0x66, 0x3A0B, dest, arg, 1); Write8(mode);}
 void XEmitter::ROUNDPS(X64Reg dest, OpArg arg, u8 mode) {WriteSSE41Op(0x66, 0x3A08, dest, arg, 1); Write8(mode);}

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -873,6 +873,11 @@ public:
 	void BLENDVPS(X64Reg dest, OpArg arg);
 	void BLENDVPD(X64Reg dest, OpArg arg);
 
+	// SSE4: constant blend instructions
+	void PBLENDW(X64Reg dest, OpArg arg, u8 mask);
+	void BLENDPS(X64Reg dest, OpArg arg, u8 mask);
+	void BLENDPD(X64Reg dest, OpArg arg, u8 mask);
+
 	// SSE4: rounding (see FloatRound for mode or use ROUNDNEARSS, etc. helpers.)
 	void ROUNDSS(X64Reg dest, OpArg arg, u8 mode);
 	void ROUNDSD(X64Reg dest, OpArg arg, u8 mode);

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -250,18 +250,35 @@ std::string SamplerJitCache::DescribeSamplerID(const SamplerID &id) {
 	return name;
 }
 
-std::string SamplerJitCache::DescribeCodePtr(const u8 *ptr) {
-	ptrdiff_t dist = 0x7FFFFFFF;
-	SamplerID found{};
-	for (const auto &it : addresses_) {
-		ptrdiff_t it_dist = ptr - it.second;
-		if (it_dist >= 0 && it_dist < dist) {
-			found = it.first;
-			dist = it_dist;
-		}
-	}
+void SamplerJitCache::Describe(const std::string &message) {
+	descriptions_[GetCodePointer()] = message;
+}
 
-	return DescribeSamplerID(found);
+std::string SamplerJitCache::DescribeCodePtr(const u8 *ptr) {
+	constexpr bool USE_IDS = false;
+	ptrdiff_t dist = 0x7FFFFFFF;
+	if (USE_IDS) {
+		SamplerID found{};
+		for (const auto &it : addresses_) {
+			ptrdiff_t it_dist = ptr - it.second;
+			if (it_dist >= 0 && it_dist < dist) {
+				found = it.first;
+				dist = it_dist;
+			}
+		}
+
+		return DescribeSamplerID(found);
+	} else {
+		std::string found;
+		for (const auto &it : descriptions_) {
+			ptrdiff_t it_dist = ptr - it.first;
+			if (it_dist >= 0 && it_dist < dist) {
+				found = it.second;
+				dist = it_dist;
+			}
+		}
+		return found;
+	}
 }
 
 NearestFunc SamplerJitCache::GetNearest(const SamplerID &id) {

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -73,6 +73,8 @@ private:
 	NearestFunc Compile(const SamplerID &id);
 	LinearFunc CompileLinear(const SamplerID &id);
 
+	void Describe(const std::string &message);
+
 	Rasterizer::RegCache::Reg GetZeroVec();
 	Rasterizer::RegCache::Reg GetGState();
 
@@ -116,6 +118,7 @@ private:
 
 	std::unordered_map<SamplerID, NearestFunc> cache_;
 	std::unordered_map<SamplerID, const u8 *> addresses_;
+	std::unordered_map<const u8 *, std::string> descriptions_;
 	Rasterizer::RegCache regCache_;
 };
 

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -2313,7 +2313,8 @@ bool SamplerJitCache::Jit_ReadClutColor(const SamplerID &id) {
 		} else {
 #if PPSSPP_PLATFORM(WINDOWS)
 			if (id.linear) {
-				MOV(32, R(temp2Reg), MDisp(RSP, stackArgPos_ + 16));
+				// Extra 8 to account for call.
+				MOV(32, R(temp2Reg), MDisp(RSP, stackArgPos_ + 8 + 16));
 			} else {
 				// The argument was saved on the stack.
 				MOV(32, R(temp2Reg), MDisp(RSP, 40));


### PR DESCRIPTION
This uses PBLENDW to simplify a case, and uses PEXTRD/PINSRD to save some cycles.  Didn't end up saving that much overall, maybe a percent or so.

-[Unknown]