### PR TITLE
samplerjit: Use SSSE3/SSE4 in linear filtering

### DIFF
--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -1851,6 +1851,7 @@ void XEmitter::PINSRB(X64Reg dest, OpArg arg, u8 subreg)    {WriteSSE41Op(0x66, 
 void XEmitter::PINSRD(X64Reg dest, OpArg arg, u8 subreg)    {WriteSSE41Op(0x66, 0x3A22, dest, arg, 1); Write8(subreg);}
 
 void XEmitter::PMADDWD(X64Reg dest, OpArg arg)  {WriteSSEOp(0x66, 0xF5, dest, arg); }
+void XEmitter::PMADDUBSW(X64Reg dest, OpArg arg) {WriteSSSE3Op(0x66, 0x3804, dest, arg);}
 void XEmitter::PSADBW(X64Reg dest, OpArg arg)   {WriteSSEOp(0x66, 0xF6, dest, arg);}
 
 void XEmitter::PMAXSW(X64Reg dest, OpArg arg)   {WriteSSEOp(0x66, 0xEE, dest, arg); }

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -820,6 +820,7 @@ public:
 	void PINSRD(X64Reg dest, OpArg arg, u8 subreg);
 
 	void PMADDWD(X64Reg dest, OpArg arg);
+	void PMADDUBSW(X64Reg dest, OpArg arg);
 	void PSADBW(X64Reg dest, OpArg arg);
 
 	void PMAXSW(X64Reg dest, OpArg arg);

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -113,8 +113,9 @@ private:
 	const u8 *constVNext_ = nullptr;
 	const u8 *constOnes32_ = nullptr;
 	const u8 *constOnes16_ = nullptr;
+	const u8 *const10All16_ = nullptr;
 	const u8 *const10Low_ = nullptr;
-	const u8 *const10All_ = nullptr;
+	const u8 *const10All8_ = nullptr;
 
 	std::unordered_map<SamplerID, NearestFunc> cache_;
 	std::unordered_map<SamplerID, const u8 *> addresses_;


### PR DESCRIPTION
This gained about a percent in some areas overall.  Cuts down on the total multiplies pretty well.

Wondering if I should just `return nullptr;` at the top without SSE4.1/etc., and remove all the conditional SSE2 code.  Not sure how many people are going to be using the software renderer with only SSE2... but I guess the code is there and it's not causing problems.

Also tried a few things with AVX but they were a bit disappointing.  I'd like to use GATHER but it's a bit complicated to use from here.  Ought to be doable, though, and I'm hoping it'll be pretty positive.  But otherwise, three-op etc. is probably already getting reordered in micro-ops anyway, based on how little it helps.

-[Unknown]