### PR TITLE
softgpu: Skip zero size triangles

### DIFF
--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -861,7 +861,7 @@ bool PixelJitCache::Jit_ApplyStencilOp(const PixelFuncID &id, GEStencilOp op, Re
 bool PixelJitCache::Jit_WriteStencilOnly(const PixelFuncID &id, RegCache::Reg stencilReg) {
 	_assert_(stencilReg != INVALID_REG);
 
-	// It's okay to destory stencilReg here, we know we're the last writing it.
+	// It's okay to destroy stencilReg here, we know we're the last writing it.
 	X64Reg colorOffReg = GetColorOff(id);
 	if (id.applyColorWriteMask) {
 		X64Reg gstateReg = GetGState();

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -873,6 +873,9 @@ void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& 
 	// Drop primitives which are not in CCW order by checking the cross product
 	if (d01.x * d02.y - d01.y * d02.x < 0)
 		return;
+	// If all points have identical coords, we'll have 0 weights and not skip properly, so skip here.
+	if (d01.x == 0 && d01.y == 0 && d02.x == 0 && d02.y == 0)
+		return;
 
 	int minX = std::min(std::min(v0.screenpos.x, v1.screenpos.x), v2.screenpos.x) & ~0xF;
 	int minY = std::min(std::min(v0.screenpos.y, v1.screenpos.y), v2.screenpos.y) & ~0xF;

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -733,7 +733,7 @@ bool SamplerJitCache::Jit_ApplyTextureFunc(const SamplerID &id) {
 		if (!id.useTextureAlpha) {
 			useAlphaFrom(primColorReg);
 		} else if (id.useColorDoubling) {
-			// We still need to finish dividing alpha, it's currently doubled (frmo the 7 above.)
+			// We still need to finish dividing alpha, it's currently doubled (from the 7 above.)
 			MOVDQA(primColorReg, R(resultReg));
 			PSRLW(primColorReg, 1);
 			useAlphaFrom(primColorReg);


### PR DESCRIPTION
These were drawing before, incorrectly, which caused artifacts.  Noticeable in Blade Dancer.

We were hitting nans for the wsum_recip and various not great things were happening.

-[Unknown]