### PR TITLE
Debugger: Correct delayed symbol listbox updates

### DIFF
--- a/Windows/Debugger/Debugger_MemoryDlg.cpp
+++ b/Windows/Debugger/Debugger_MemoryDlg.cpp
@@ -134,7 +134,9 @@ void CMemoryDlg::searchBoxRedraw(std::vector<u32> results) {
 void CMemoryDlg::NotifyMapLoaded() {
 	if (m_hDlg && g_symbolMap)
 		g_symbolMap->FillSymbolListBox(symListHdl, ST_DATA);
-	Update(); 
+	else
+		mapLoadPending_ = true;
+	Update();
 }
 
 BOOL CMemoryDlg::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
@@ -219,6 +221,10 @@ BOOL CMemoryDlg::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 	}
 
 	case WM_DEB_UPDATE:
+		if (mapLoadPending_ && m_hDlg && g_symbolMap) {
+			g_symbolMap->FillSymbolListBox(symListHdl, ST_DATA);
+			mapLoadPending_ = false;
+		}
 		Update();
 		return TRUE;
 

--- a/Windows/Debugger/Debugger_MemoryDlg.h
+++ b/Windows/Debugger/Debugger_MemoryDlg.h
@@ -39,6 +39,9 @@ public:
 	void NotifySearchCompleted();
 
 	void Size(void);
+
+private:
+	bool mapLoadPending_ = false;
 };
 
 

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -134,6 +134,9 @@ namespace MainWindow
 	static bool hasFocus = true;
 	static bool g_isFullscreen = false;
 
+	static bool disasmMapLoadPending = false;
+	static bool memoryMapLoadPending = false;
+
 	// gross hack
 	bool noFocusPause = false;	// TOGGLE_PAUSE state to override pause on lost focus
 	bool trapMouse = true; // Handles some special cases(alt+tab, win menu) when game is running and mouse is confined
@@ -538,6 +541,9 @@ namespace MainWindow
 			disasmWindow = new CDisasm(MainWindow::GetHInstance(), MainWindow::GetHWND(), currentDebugMIPS);
 			DialogManager::AddDlg(disasmWindow);
 		}
+		if (disasmMapLoadPending)
+			disasmWindow->NotifyMapLoaded();
+		disasmMapLoadPending = false;
 	}
 
 	void CreateGeDebuggerWindow() {
@@ -554,6 +560,9 @@ namespace MainWindow
 			memoryWindow = new CMemoryDlg(MainWindow::GetHInstance(), MainWindow::GetHWND(), currentDebugMIPS);
 			DialogManager::AddDlg(memoryWindow);
 		}
+		if (memoryMapLoadPending)
+			memoryWindow->NotifyMapLoaded();
+		memoryMapLoadPending = false;
 	}
 
 	void CreateVFPUWindow() {
@@ -561,6 +570,15 @@ namespace MainWindow
 			vfpudlg = new CVFPUDlg(MainWindow::GetHInstance(), MainWindow::GetHWND(), currentDebugMIPS);
 			DialogManager::AddDlg(vfpudlg);
 		}
+	}
+
+	void NotifyDebuggerMapLoaded() {
+		disasmMapLoadPending = disasmWindow == nullptr;
+		memoryMapLoadPending = memoryWindow == nullptr;
+		if (!disasmMapLoadPending)
+			disasmWindow->NotifyMapLoaded();
+		if (!memoryMapLoadPending)
+			memoryWindow->NotifyMapLoaded();
 	}
 
 	void DestroyDebugWindows() {
@@ -947,10 +965,7 @@ namespace MainWindow
 			break;
 
 		case WM_USER + 1:
-			if (disasmWindow)
-				disasmWindow->NotifyMapLoaded();
-			if (memoryWindow)
-				memoryWindow->NotifyMapLoaded();
+			NotifyDebuggerMapLoaded();
 			if (disasmWindow)
 				disasmWindow->UpdateDialog();
 			break;

--- a/Windows/MainWindow.h
+++ b/Windows/MainWindow.h
@@ -65,6 +65,7 @@ namespace MainWindow
 	void CreateGeDebuggerWindow();
 	void CreateMemoryWindow();
 	void CreateVFPUWindow();
+	void NotifyDebuggerMapLoaded();
 	void DestroyDebugWindows();
 	void UpdateMenus(bool isMenuSelect = false);
 	void UpdateCommands();

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -854,12 +854,7 @@ namespace MainWindow {
 		case ID_DEBUG_LOADMAPFILE:
 			if (W32Util::BrowseForFileName(true, hWnd, L"Load .ppmap", 0, L"Maps\0*.ppmap\0All files\0*.*\0\0", L"ppmap", fn)) {
 				g_symbolMap->LoadSymbolMap(Path(fn));
-
-				if (disasmWindow)
-					disasmWindow->NotifyMapLoaded();
-
-				if (memoryWindow)
-					memoryWindow->NotifyMapLoaded();
+				NotifyDebuggerMapLoaded();
 			}
 			break;
 
@@ -871,12 +866,7 @@ namespace MainWindow {
 		case ID_DEBUG_LOADSYMFILE:
 			if (W32Util::BrowseForFileName(true, hWnd, L"Load .sym", 0, L"Symbols\0*.sym\0All files\0*.*\0\0", L"sym", fn)) {
 				g_symbolMap->LoadNocashSym(Path(fn));
-
-				if (disasmWindow)
-					disasmWindow->NotifyMapLoaded();
-
-				if (memoryWindow)
-					memoryWindow->NotifyMapLoaded();
+				NotifyDebuggerMapLoaded();
 			}
 			break;
 
@@ -887,12 +877,7 @@ namespace MainWindow {
 
 		case ID_DEBUG_RESETSYMBOLTABLE:
 			g_symbolMap->Clear();
-
-			if (disasmWindow)
-				disasmWindow->NotifyMapLoaded();
-
-			if (memoryWindow)
-				memoryWindow->NotifyMapLoaded();
+			NotifyDebuggerMapLoaded();
 			break;
 
 		case ID_DEBUG_DISASSEMBLY:


### PR DESCRIPTION
With the dialogs no longer created on start, this message wasn't coming through.  Most noticeable in the memory viewer.

-[Unknown]