### PR TITLE
softgpu: Add code for tracking GPU writes

### DIFF
--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -21,6 +21,11 @@
 #include "GPU/Software/RasterizerRegCache.h"
 #include "GPU/Software/TransformUnit.h" // for DrawingCoords
 
+#ifdef _DEBUG
+#define SOFTGPU_MEMORY_TAGGING_BASIC
+#endif
+// #define SOFTGPU_MEMORY_TAGGING_DETAILED
+
 struct GPUDebugBuffer;
 
 namespace Rasterizer {


### PR DESCRIPTION
Unfortunately, it has a pretty noticeable speed impact, even at the basic "assume everything's written" level.  Compiled off by default, but at least it's there.  I thought about maybe making it a template parameter, or something...

Doesn't account for tests (i.e. alpha test skipping write) so still not perfectly accurate.  Still, this was very useful in tracking down the Brave Story bug.

-[Unknown]