### PR TITLE
Optimize software renderer handling of common bloom operations

### DIFF
--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -517,6 +517,7 @@ PixelJitCache::PixelJitCache()
 {
 	// 256k should be plenty of space for plenty of variations.
 	AllocCodeSpace(1024 * 64 * 4);
+	ClearCodeSpace(0);
 
 	// Add some random code to "help" MSVC's buggy disassembler :(
 #if defined(_WIN32) && (PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)) && !PPSSPP_PLATFORM(UWP)

--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -591,11 +591,23 @@ void ComputePixelBlendState(PixelBlendState &state, const PixelFuncID &id) {
 
 	if (state.usesFactors) {
 		switch (id.AlphaBlendSrc()) {
-		case GE_SRCBLEND_DSTALPHA:
-		case GE_SRCBLEND_INVDSTALPHA:
-		case GE_SRCBLEND_DOUBLEDSTALPHA:
-		case GE_SRCBLEND_DOUBLEINVDSTALPHA:
+		case PixelBlendFactor::DSTALPHA:
+		case PixelBlendFactor::INVDSTALPHA:
+		case PixelBlendFactor::DOUBLEDSTALPHA:
+		case PixelBlendFactor::DOUBLEINVDSTALPHA:
 			state.usesDstAlpha = true;
+			break;
+
+		case PixelBlendFactor::OTHERCOLOR:
+		case PixelBlendFactor::INVOTHERCOLOR:
+			state.dstColorAsFactor = true;
+			break;
+
+		case PixelBlendFactor::SRCALPHA:
+		case PixelBlendFactor::INVSRCALPHA:
+		case PixelBlendFactor::DOUBLESRCALPHA:
+		case PixelBlendFactor::DOUBLEINVSRCALPHA:
+			state.srcColorAsFactor = true;
 			break;
 
 		default:
@@ -603,35 +615,49 @@ void ComputePixelBlendState(PixelBlendState &state, const PixelFuncID &id) {
 		}
 
 		switch (id.AlphaBlendDst()) {
-		case GE_DSTBLEND_INVSRCALPHA:
-			state.dstFactorIsInverse = id.AlphaBlendSrc() == GE_SRCBLEND_SRCALPHA;
+		case PixelBlendFactor::INVSRCALPHA:
+			state.dstFactorIsInverse = id.AlphaBlendSrc() == PixelBlendFactor::SRCALPHA;
+			state.srcColorAsFactor = true;
 			break;
 
-		case GE_DSTBLEND_DOUBLEINVSRCALPHA:
-			state.dstFactorIsInverse = id.AlphaBlendSrc() == GE_SRCBLEND_DOUBLESRCALPHA;
+		case PixelBlendFactor::DOUBLEINVSRCALPHA:
+			state.dstFactorIsInverse = id.AlphaBlendSrc() == PixelBlendFactor::DOUBLESRCALPHA;
+			state.srcColorAsFactor = true;
 			break;
 
-		case GE_DSTBLEND_DSTALPHA:
+		case PixelBlendFactor::DSTALPHA:
 			state.usesDstAlpha = true;
 			break;
 
-		case GE_DSTBLEND_INVDSTALPHA:
-			state.dstFactorIsInverse = id.AlphaBlendSrc() == GE_SRCBLEND_DSTALPHA;
+		case PixelBlendFactor::INVDSTALPHA:
+			state.dstFactorIsInverse = id.AlphaBlendSrc() == PixelBlendFactor::DSTALPHA;
 			state.usesDstAlpha = true;
 			break;
 
-		case GE_DSTBLEND_DOUBLEDSTALPHA:
+		case PixelBlendFactor::DOUBLEDSTALPHA:
 			state.usesDstAlpha = true;
 			break;
 
-		case GE_DSTBLEND_DOUBLEINVDSTALPHA:
-			state.dstFactorIsInverse = id.AlphaBlendSrc() == GE_SRCBLEND_DOUBLEDSTALPHA;
+		case PixelBlendFactor::DOUBLEINVDSTALPHA:
+			state.dstFactorIsInverse = id.AlphaBlendSrc() == PixelBlendFactor::DOUBLEDSTALPHA;
 			state.usesDstAlpha = true;
+			break;
+
+		case PixelBlendFactor::OTHERCOLOR:
+		case PixelBlendFactor::INVOTHERCOLOR:
+			state.dstColorAsFactor = true;
+			break;
+
+		case PixelBlendFactor::SRCALPHA:
+		case PixelBlendFactor::DOUBLESRCALPHA:
+			state.srcColorAsFactor = true;
 			break;
 
 		default:
 			break;
 		}
+
+		state.dstColorAsFactor = state.dstColorAsFactor || state.usesDstAlpha;
 	}
 }
 

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -47,6 +47,8 @@ struct PixelBlendState {
 	bool usesFactors = false;
 	bool usesDstAlpha = false;
 	bool dstFactorIsInverse = false;
+	bool srcColorAsFactor = false;
+	bool dstColorAsFactor = false;
 };
 void ComputePixelBlendState(PixelBlendState &state, const PixelFuncID &id);
 
@@ -88,7 +90,7 @@ private:
 	bool Jit_DepthTest(const PixelFuncID &id);
 	bool Jit_WriteDepth(const PixelFuncID &id);
 	bool Jit_AlphaBlend(const PixelFuncID &id);
-	bool Jit_BlendFactor(const PixelFuncID &id, RegCache::Reg factorReg, RegCache::Reg dstReg, GEBlendSrcFactor factor);
+	bool Jit_BlendFactor(const PixelFuncID &id, RegCache::Reg factorReg, RegCache::Reg dstReg, PixelBlendFactor factor);
 	bool Jit_DstBlendFactor(const PixelFuncID &id, RegCache::Reg srcFactorReg, RegCache::Reg dstFactorReg, RegCache::Reg dstReg);
 	bool Jit_Dither(const PixelFuncID &id);
 	bool Jit_WriteColor(const PixelFuncID &id);

--- a/GPU/Software/FuncId.h
+++ b/GPU/Software/FuncId.h
@@ -25,6 +25,24 @@
 
 #define SOFTPIXEL_USE_CACHE 1
 
+// 0-10 match GEBlendSrcFactor/GEBlendDstFactor.
+enum class PixelBlendFactor {
+	OTHERCOLOR,
+	INVOTHERCOLOR,
+	SRCALPHA,
+	INVSRCALPHA,
+	DSTALPHA,
+	INVDSTALPHA,
+	DOUBLESRCALPHA,
+	DOUBLEINVSRCALPHA,
+	DOUBLEDSTALPHA,
+	DOUBLEINVDSTALPHA,
+	FIX,
+	// These are invented, but common FIX values.
+	ZERO,
+	ONE,
+};
+
 #pragma pack(push, 1)
 
 struct PixelFuncID {
@@ -110,11 +128,11 @@ struct PixelFuncID {
 	GEBlendMode AlphaBlendEq() const {
 		return GEBlendMode(alphaBlendEq);
 	}
-	GEBlendSrcFactor AlphaBlendSrc() const {
-		return GEBlendSrcFactor(alphaBlendSrc);
+	PixelBlendFactor AlphaBlendSrc() const {
+		return PixelBlendFactor(alphaBlendSrc);
 	}
-	GEBlendDstFactor AlphaBlendDst() const {
-		return GEBlendDstFactor(alphaBlendDst);
+	PixelBlendFactor AlphaBlendDst() const {
+		return PixelBlendFactor(alphaBlendDst);
 	}
 
 	GEStencilOp SFail() const {

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -379,8 +379,8 @@ static inline Vec3<int> GetDestFactor(GEBlendDstFactor factor, const Vec4<int> &
 Vec3<int> AlphaBlendingResult(const PixelFuncID &pixelID, const Vec4<int> &source, const Vec4<int> &dst)
 {
 	// Note: These factors cannot go below 0, but they can go above 255 when doubling.
-	Vec3<int> srcfactor = GetSourceFactor(pixelID.AlphaBlendSrc(), source, dst);
-	Vec3<int> dstfactor = GetDestFactor(pixelID.AlphaBlendDst(), source, dst);
+	Vec3<int> srcfactor = GetSourceFactor(GEBlendSrcFactor(pixelID.AlphaBlendSrc()), source, dst);
+	Vec3<int> dstfactor = GetDestFactor(GEBlendDstFactor(pixelID.AlphaBlendDst()), source, dst);
 
 	switch (pixelID.AlphaBlendEq()) {
 	case GE_BLENDMODE_MUL_AND_ADD:

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -92,6 +92,7 @@ void DrawSprite(const VertexData& v0, const VertexData& v1) {
 
 	ScreenCoords pprime(v0.screenpos.x, v0.screenpos.y, 0);
 	Sampler::FetchFunc fetchFunc = Sampler::GetFetchFunc(samplerID);
+	Sampler::NearestFunc nearestFunc = Sampler::GetNearestFunc(samplerID);
 	Rasterizer::SingleFunc drawPixel = Rasterizer::GetSingleFunc(pixelID);
 
 	DrawingCoords pos0 = TransformUnit::ScreenToDrawing(v0.screenpos);
@@ -187,19 +188,25 @@ void DrawSprite(const VertexData& v0, const VertexData& v1) {
 				}, pos0.y, pos1.y, MIN_LINES_PER_THREAD);
 			}
 		} else {
+			int xoff = ((v0.screenpos.x & 15) + 1) / 2;
+			int yoff = ((v0.screenpos.y & 15) + 1) / 2;
+
+			float dsf = 1.0f / (float)gstate.getTextureWidth(0);
+			float dtf = 1.0f / (float)gstate.getTextureHeight(0);
+			float sf_start = s_start * dsf;
+			float tf_start = t_start * dtf;
+
 			ParallelRangeLoop(&g_threadManager, [=](int y1, int y2) {
-				int t = t_start + (y1 - pos0.y) * dt;
+				float t = tf_start + (y1 - pos0.y) * dtf;
 				for (int y = y1; y < y2; y++) {
-					int s = s_start;
+					float s = sf_start;
 					// Not really that fast but faster than triangle.
 					for (int x = pos0.x; x < pos1.x; x++) {
-						Vec4<int> prim_color = v1.color0;
-						Vec4<int> tex_color = fetchFunc(s, t, texptr, texbufw, 0);
-						prim_color = GetTextureFunctionOutput(ToVec4IntArg(prim_color), ToVec4IntArg(tex_color));
+						Vec4<int> prim_color = nearestFunc(s, t, xoff, yoff, ToVec4IntArg(v1.color0), &texptr, &texbufw, 0, 0);
 						drawPixel(x, y, z, 255, ToVec4IntArg(prim_color), pixelID);
-						s += ds;
+						s += dsf;
 					}
-					t += dt;
+					t += dtf;
 				}
 			}, pos0.y, pos1.y, MIN_LINES_PER_THREAD);
 		}
@@ -271,6 +278,7 @@ bool RectangleFastPath(const VertexData &v0, const VertexData &v1) {
 	bool orient_check = xdiff >= 0 && ydiff >= 0;
 	// We already have a fast path for clear in ClearRectangle.
 	bool state_check = !gstate.isModeClear() && NoClampOrWrap(v0.texturecoords) && NoClampOrWrap(v1.texturecoords);
+	// TODO: No mipmap levels?  Might be a font at level 1...
 	if ((coord_check || !gstate.isTextureMapEnabled()) && orient_check && state_check) {
 		Rasterizer::DrawSprite(v0, v1);
 		return true;

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -101,6 +101,7 @@ SamplerJitCache::SamplerJitCache()
 {
 	// 256k should be enough.
 	AllocCodeSpace(1024 * 64 * 4);
+	ClearCodeSpace(0);
 
 	// Add some random code to "help" MSVC's buggy disassembler :(
 #if defined(_WIN32) && (PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)) && !PPSSPP_PLATFORM(UWP)

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -39,8 +39,8 @@ extern u32 clut[4096];
 
 namespace Sampler {
 
-static Vec4IntResult SOFTRAST_CALL SampleNearest(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 **tptr, const int *bufw, int level, int levelFrac);
-static Vec4IntResult SOFTRAST_CALL SampleLinear(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 **tptr, const int *bufw, int level, int levelFrac);
+static Vec4IntResult SOFTRAST_CALL SampleNearest(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 *const *tptr, const int *bufw, int level, int levelFrac);
+static Vec4IntResult SOFTRAST_CALL SampleLinear(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 *const *tptr, const int *bufw, int level, int levelFrac);
 static Vec4IntResult SOFTRAST_CALL SampleFetch(int u, int v, const u8 *tptr, int bufw, int level);
 
 std::mutex jitCacheLock;
@@ -441,7 +441,7 @@ static inline void GetTexelCoordinates(int level, float s, float t, int &out_u, 
 	ApplyTexelClamp<1>(&out_u, &out_v, &base_u, &base_v, width, height);
 }
 
-static Vec4IntResult SOFTRAST_CALL SampleNearest(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 **tptr, const int *bufw, int level, int levelFrac) {
+static Vec4IntResult SOFTRAST_CALL SampleNearest(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 *const *tptr, const int *bufw, int level, int levelFrac) {
 	int u, v;
 
 	// Nearest filtering only.  Round texcoords.
@@ -537,7 +537,7 @@ static inline Vec4IntResult SOFTRAST_CALL GetTexelCoordinatesQuadT(int level, fl
 	return ApplyTexelClampQuadT(gstate.isTexCoordClampedT(), base_v, height);
 }
 
-static Vec4IntResult SOFTRAST_CALL SampleLinearLevel(float s, float t, int x, int y, const u8 **tptr, const int *bufw, int texlevel) {
+static Vec4IntResult SOFTRAST_CALL SampleLinearLevel(float s, float t, int x, int y, const u8 *const *tptr, const int *bufw, int texlevel) {
 	int frac_u, frac_v;
 	const Vec4<int> u = GetTexelCoordinatesQuadS(texlevel, s, frac_u, x);
 	const Vec4<int> v = GetTexelCoordinatesQuadT(texlevel, t, frac_v, y);
@@ -552,7 +552,7 @@ static Vec4IntResult SOFTRAST_CALL SampleLinearLevel(float s, float t, int x, in
 	return ToVec4IntResult((top * (0x10 - frac_v) + bot * frac_v) / (16 * 16));
 }
 
-static Vec4IntResult SOFTRAST_CALL SampleLinear(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 **tptr, const int *bufw, int texlevel, int levelFrac) {
+static Vec4IntResult SOFTRAST_CALL SampleLinear(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 *const *tptr, const int *bufw, int texlevel, int levelFrac) {
 	Vec4<int> c0 = SampleLinearLevel(s, t, x, y, tptr, bufw, texlevel);
 	if (levelFrac) {
 		const Vec4<int> c1 = SampleLinearLevel(s, t, x, y, tptr + 1, bufw + 1, texlevel + 1);

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -36,10 +36,10 @@ namespace Sampler {
 typedef Rasterizer::Vec4IntResult(SOFTRAST_CALL *FetchFunc)(int u, int v, const u8 *tptr, int bufw, int level);
 FetchFunc GetFetchFunc(SamplerID id);
 
-typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *NearestFunc)(float s, float t, int x, int y, Rasterizer::Vec4IntArg prim_color, const u8 **tptr, const int *bufw, int level, int levelFrac);
+typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *NearestFunc)(float s, float t, int x, int y, Rasterizer::Vec4IntArg prim_color, const u8 *const *tptr, const int *bufw, int level, int levelFrac);
 NearestFunc GetNearestFunc(SamplerID id);
 
-typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *LinearFunc)(float s, float t, int x, int y, Rasterizer::Vec4IntArg prim_color, const u8 **tptr, const int *bufw, int level, int levelFrac);
+typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *LinearFunc)(float s, float t, int x, int y, Rasterizer::Vec4IntArg prim_color, const u8 *const *tptr, const int *bufw, int level, int levelFrac);
 LinearFunc GetLinearFunc(SamplerID id);
 
 struct Funcs {


### PR DESCRIPTION
This makes a few changes, focused on optimizing bloom handling in games.  Specifically:

 * Introduces two "fake" blend factors, ONE and ZERO.  These allow skipping the multiply, and are very commonly used during bloom.
 * Skips the add/sub if bloom is only multiplying (i.e. SRC * DST + DST * ZERO.)
 * Uses the nearest jit func for the fast path case where it was previously calling GetTextureFunctionOutput - that's now inlined.

While there, I also fixed poisoning memory (since I was busy looking at the generated assembly and noticed it wasn't poisoned.)  Also made some things skip a temp reg if rip accessible to reduce codesize a bit.

-[Unknown]