### PR TITLE
softgpu: Skip sample lookup if masked

### DIFF
--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -549,7 +549,7 @@ static inline void CalculateSamplingParams(const float ds, const float dt, const
 	}
 }
 
-static inline void ApplyTexturing(Sampler::Funcs sampler, Vec4<int> *prim_color, const Vec4<float> &s, const Vec4<float> &t, int maxTexLevel, u8 *texptr[], int texbufw[], int x, int y) {
+static inline void ApplyTexturing(Sampler::Funcs sampler, Vec4<int> *prim_color, const Vec4<int> &mask, const Vec4<float> &s, const Vec4<float> &t, int maxTexLevel, u8 *texptr[], int texbufw[], int x, int y) {
 	float ds = s[1] - s[0];
 	float dt = t[2] - t[0];
 
@@ -560,7 +560,8 @@ static inline void ApplyTexturing(Sampler::Funcs sampler, Vec4<int> *prim_color,
 
 	PROFILE_THIS_SCOPE("sampler");
 	for (int i = 0; i < 4; ++i) {
-		prim_color[i] = ApplyTexturing(s[i], t[i], ((x & 15) + 1) / 2, ((y & 15) + 1) / 2, ToVec4IntArg(prim_color[i]), texptr, texbufw, level, levelFrac, bilinear, sampler);
+		if (mask[i] >= 0)
+			prim_color[i] = ApplyTexturing(s[i], t[i], ((x & 15) + 1) / 2, ((y & 15) + 1) / 2, ToVec4IntArg(prim_color[i]), texptr, texbufw, level, levelFrac, bilinear, sampler);
 	}
 }
 
@@ -731,7 +732,8 @@ void DrawTriangleSlice(
 				if (!flatColor0) {
 					// Does the PSP do perspective-correct color interpolation? The GC doesn't.
 					for (int i = 0; i < 4; ++i) {
-						prim_color[i] = Interpolate(v0.color0, v1.color0, v2.color0, w0[i], w1[i], w2[i], wsum_recip[i]);
+						if (mask[i] >= 0)
+							prim_color[i] = Interpolate(v0.color0, v1.color0, v2.color0, w0[i], w1[i], w2[i], wsum_recip[i]);
 					}
 				} else {
 					for (int i = 0; i < 4; ++i) {
@@ -741,7 +743,8 @@ void DrawTriangleSlice(
 				Vec3<int> sec_color[4];
 				if (!flatColor1) {
 					for (int i = 0; i < 4; ++i) {
-						sec_color[i] = Interpolate(v0.color1, v1.color1, v2.color1, w0[i], w1[i], w2[i], wsum_recip[i]);
+						if (mask[i] >= 0)
+							sec_color[i] = Interpolate(v0.color1, v1.color1, v2.color1, w0[i], w1[i], w2[i], wsum_recip[i]);
 					}
 				} else {
 					for (int i = 0; i < 4; ++i) {

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -21,6 +21,7 @@
 #include "Common/CPUDetect.h"
 #include "Common/Math/math_util.h"
 #include "Common/MemoryUtil.h"
+#include "Common/Profiler/Profiler.h"
 #include "Core/Config.h"
 #include "GPU/GPUState.h"
 #include "GPU/Common/DrawEngineCommon.h"
@@ -157,6 +158,7 @@ ScreenCoords TransformUnit::DrawingToScreen(const DrawingCoords& coords)
 }
 
 VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_flag) {
+	PROFILE_THIS_SCOPE("read_vert");
 	VertexData vertex;
 
 	float pos[3];
@@ -277,6 +279,7 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 			vertex.texturecoords = Vec2f(stq.x * z_recip, stq.y * z_recip);
 		}
 
+		PROFILE_THIS_SCOPE("light");
 		Lighting::Process(vertex, vreader.hasColor0());
 	} else {
 		vertex.screenpos.x = (int)(pos[0] * 16) + gstate.getOffsetX16();


### PR DESCRIPTION
I'd been hoping that by jitting sample lookup, we'd get to a place where it'd be faster to just go, rather than branching here.

That hasn't played out - even with VPGATHER on a fairly simple sample overall, this is still a good win.  Helps especially for rectangles-as-triangles that can't be fast pathed.

-[Unknown]