### PR TITLE
Use AVX2 gather for samplerjit

### DIFF
--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -2240,20 +2240,20 @@ void XEmitter::VGATHERQPD(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2) {
 	_assert_msg_(regOp1 != regOp2 && !arg.IsIndexedReg(regOp1) && !arg.IsIndexedReg(regOp2), "VGATHER cannot have overlapped registers");
 	WriteAVX2Op(bits, 0x66, 0x3893, regOp1, regOp2, arg);
 }
-void XEmitter::VGATHERDD(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2) {
-	_assert_msg_(regOp1 != regOp2 && !arg.IsIndexedReg(regOp1) && !arg.IsIndexedReg(regOp2), "VGATHER cannot have overlapped registers");
+void XEmitter::VPGATHERDD(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2) {
+	_assert_msg_(regOp1 != regOp2 && !arg.IsIndexedReg(regOp1) && !arg.IsIndexedReg(regOp2), "VPGATHER cannot have overlapped registers");
 	WriteAVX2Op(bits, 0x66, 0x3890, regOp1, regOp2, arg);
 }
-void XEmitter::VGATHERQD(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2) {
-	_assert_msg_(regOp1 != regOp2 && !arg.IsIndexedReg(regOp1) && !arg.IsIndexedReg(regOp2), "VGATHER cannot have overlapped registers");
+void XEmitter::VPGATHERQD(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2) {
+	_assert_msg_(regOp1 != regOp2 && !arg.IsIndexedReg(regOp1) && !arg.IsIndexedReg(regOp2), "VPGATHER cannot have overlapped registers");
 	WriteAVX2Op(bits, 0x66, 0x3891, regOp1, regOp2, arg);
 }
-void XEmitter::VGATHERDQ(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2) {
-	_assert_msg_(regOp1 != regOp2 && !arg.IsIndexedReg(regOp1) && !arg.IsIndexedReg(regOp2), "VGATHER cannot have overlapped registers");
+void XEmitter::VPGATHERDQ(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2) {
+	_assert_msg_(regOp1 != regOp2 && !arg.IsIndexedReg(regOp1) && !arg.IsIndexedReg(regOp2), "VPGATHER cannot have overlapped registers");
 	WriteAVX2Op(bits, 0x66, 0x3890, regOp1, regOp2, arg, 0, 1);
 }
-void XEmitter::VGATHERQQ(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2) {
-	_assert_msg_(regOp1 != regOp2 && !arg.IsIndexedReg(regOp1) && !arg.IsIndexedReg(regOp2), "VGATHER cannot have overlapped registers");
+void XEmitter::VPGATHERQQ(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2) {
+	_assert_msg_(regOp1 != regOp2 && !arg.IsIndexedReg(regOp1) && !arg.IsIndexedReg(regOp2), "VPGATHER cannot have overlapped registers");
 	WriteAVX2Op(bits, 0x66, 0x3891, regOp1, regOp2, arg, 0, 1);
 }
 

--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -1701,15 +1701,14 @@ void XEmitter::PSRLQ(X64Reg reg, int shift)
 	Write8(shift);
 }
 
-void XEmitter::PSRLQ(X64Reg reg, OpArg arg)
-{
-	WriteSSEOp(0x66, 0xd3, reg, arg);
-}
-
 void XEmitter::PSRLDQ(X64Reg reg, int shift) {
 	WriteSSEOp(0x66, 0x73, (X64Reg)3, R(reg));
 	Write8(shift);
 }
+
+void XEmitter::PSRLW(X64Reg reg, OpArg arg) { WriteSSEOp(0x66, 0xD1, reg, arg); }
+void XEmitter::PSRLD(X64Reg reg, OpArg arg) { WriteSSEOp(0x66, 0xD2, reg, arg); }
+void XEmitter::PSRLQ(X64Reg reg, OpArg arg) { WriteSSEOp(0x66, 0xD3, reg, arg); }
 
 void XEmitter::PSLLW(X64Reg reg, int shift)
 {
@@ -1734,6 +1733,10 @@ void XEmitter::PSLLDQ(X64Reg reg, int shift) {
 	Write8(shift);
 }
 
+void XEmitter::PSLLW(X64Reg reg, OpArg arg) { WriteSSEOp(0x66, 0xF1, reg, arg); }
+void XEmitter::PSLLD(X64Reg reg, OpArg arg) { WriteSSEOp(0x66, 0xF2, reg, arg); }
+void XEmitter::PSLLQ(X64Reg reg, OpArg arg) { WriteSSEOp(0x66, 0xF3, reg, arg); }
+
 void XEmitter::PSRAW(X64Reg reg, int shift)
 {
 	WriteSSEOp(0x66, 0x71, (X64Reg)4, R(reg));
@@ -1745,6 +1748,9 @@ void XEmitter::PSRAD(X64Reg reg, int shift)
 	WriteSSEOp(0x66, 0x72, (X64Reg)4, R(reg));
 	Write8(shift);
 }
+
+void XEmitter::PSRAW(X64Reg reg, OpArg arg) { WriteSSEOp(0x66, 0xE1, reg, arg); }
+void XEmitter::PSRAD(X64Reg reg, OpArg arg) { WriteSSEOp(0x66, 0xE2, reg, arg); }
 
 void XEmitter::PMULLW(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0xD5, dest, arg);}
 void XEmitter::PMULHW(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0xE5, dest, arg);}

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -847,16 +847,31 @@ public:
 	void PSRLW(X64Reg reg, int shift);
 	void PSRLD(X64Reg reg, int shift);
 	void PSRLQ(X64Reg reg, int shift);
-	void PSRLQ(X64Reg reg, OpArg arg);
 	void PSRLDQ(X64Reg reg, int shift);
+	// Note: all values shifted by lowest 64-bit in XMM arg.
+	void PSRLW(X64Reg reg, OpArg arg);
+	// Note: all values shifted by lowest 64-bit in XMM arg.
+	void PSRLD(X64Reg reg, OpArg arg);
+	// Note: both values shifted by lowest 64-bit in XMM arg.
+	void PSRLQ(X64Reg reg, OpArg arg);
 
 	void PSLLW(X64Reg reg, int shift);
 	void PSLLD(X64Reg reg, int shift);
 	void PSLLQ(X64Reg reg, int shift);
 	void PSLLDQ(X64Reg reg, int shift);
+	// Note: all values shifted by lowest 64-bit in XMM arg.
+	void PSLLW(X64Reg reg, OpArg arg);
+	// Note: all values shifted by lowest 64-bit in XMM arg.
+	void PSLLD(X64Reg reg, OpArg arg);
+	// Note: both values shifted by lowest 64-bit in XMM arg.
+	void PSLLQ(X64Reg reg, OpArg arg);
 
 	void PSRAW(X64Reg reg, int shift);
 	void PSRAD(X64Reg reg, int shift);
+	// Note: all values shifted by lowest 64-bit in XMM arg.
+	void PSRAW(X64Reg reg, OpArg arg);
+	// Note: all values shifted by lowest 64-bit in XMM arg.
+	void PSRAD(X64Reg reg, OpArg arg);
 
 	void PMULLW(X64Reg dest, const OpArg &arg);
 	void PMULHW(X64Reg dest, const OpArg &arg);

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -1239,10 +1239,10 @@ public:
 	void VGATHERDPD(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
 	void VGATHERQPS(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
 	void VGATHERQPD(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
-	void VGATHERDD(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
-	void VGATHERQD(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
-	void VGATHERDQ(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
-	void VGATHERQQ(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
+	void VPGATHERDD(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
+	void VPGATHERQD(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
+	void VPGATHERDQ(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
+	void VPGATHERQQ(int bits, X64Reg regOp1, OpArg arg, X64Reg regOp2);
 
 	void VPSLLVD(int bits, X64Reg regOp1, X64Reg regOp2, OpArg arg);
 	void VPSLLVQ(int bits, X64Reg regOp1, X64Reg regOp2, OpArg arg);

--- a/GPU/Software/FuncId.h
+++ b/GPU/Software/FuncId.h
@@ -176,8 +176,8 @@ struct SamplerID {
 			uint8_t texFunc : 3;
 			bool useTextureAlpha : 1;
 			bool useColorDoubling : 1;
-			bool hasStandardMips : 1;
 			bool hasAnyMips : 1;
+			bool overReadSafe : 1;
 			bool fetch : 1;
 		};
 	};

--- a/GPU/Software/RasterizerRegCache.h
+++ b/GPU/Software/RasterizerRegCache.h
@@ -103,6 +103,7 @@ struct RegCache {
 		VEC_RESULT1 = 0x0002,
 		VEC_U1 = 0x0003,
 		VEC_V1 = 0x0004,
+		VEC_INDEX = 0x0005,
 
 		GEN_SRC_ALPHA = 0x0100,
 		GEN_GSTATE = 0x0101,

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -101,6 +101,8 @@ private:
 	bool Jit_PrepareDataOffsets(const SamplerID &id, Rasterizer::RegCache::Reg uReg, Rasterizer::RegCache::Reg vReg, bool level1);
 	bool Jit_PrepareDataDirectOffsets(const SamplerID &id, Rasterizer::RegCache::Reg uReg, Rasterizer::RegCache::Reg vReg, bool level1, int bitsPerTexel);
 	bool Jit_PrepareDataSwizzledOffsets(const SamplerID &id, Rasterizer::RegCache::Reg uReg, Rasterizer::RegCache::Reg vReg, bool level1, int bitsPerTexel);
+	bool Jit_ReadQuad(const SamplerID &id, bool level1, bool *doFallback);
+	bool Jit_ReadClutQuad(const SamplerID &id, bool level1);
 	bool Jit_BlendQuad(const SamplerID &id, bool level1);
 	bool Jit_DecodeQuad(const SamplerID &id, bool level1);
 	bool Jit_Decode5650Quad(const SamplerID &id, Rasterizer::RegCache::Reg quadReg);

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -101,7 +101,7 @@ private:
 	bool Jit_PrepareDataOffsets(const SamplerID &id, Rasterizer::RegCache::Reg uReg, Rasterizer::RegCache::Reg vReg, bool level1);
 	bool Jit_PrepareDataDirectOffsets(const SamplerID &id, Rasterizer::RegCache::Reg uReg, Rasterizer::RegCache::Reg vReg, bool level1, int bitsPerTexel);
 	bool Jit_PrepareDataSwizzledOffsets(const SamplerID &id, Rasterizer::RegCache::Reg uReg, Rasterizer::RegCache::Reg vReg, bool level1, int bitsPerTexel);
-	bool Jit_FetchQuad(const SamplerID &id, bool level1, bool *doFallback);
+	bool Jit_FetchQuad(const SamplerID &id, bool level1);
 	bool Jit_GetDataQuad(const SamplerID &id, bool level1, int bitsPerTexel);
 	bool Jit_TransformClutIndexQuad(const SamplerID &id, int bitsPerIndex);
 	bool Jit_ReadClutQuad(const SamplerID &id, bool level1);

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -102,6 +102,7 @@ private:
 	bool Jit_PrepareDataDirectOffsets(const SamplerID &id, Rasterizer::RegCache::Reg uReg, Rasterizer::RegCache::Reg vReg, bool level1, int bitsPerTexel);
 	bool Jit_PrepareDataSwizzledOffsets(const SamplerID &id, Rasterizer::RegCache::Reg uReg, Rasterizer::RegCache::Reg vReg, bool level1, int bitsPerTexel);
 	bool Jit_ReadQuad(const SamplerID &id, bool level1, bool *doFallback);
+	bool Jit_TransformClutIndexQuad(const SamplerID &id, int bitsPerIndex);
 	bool Jit_ReadClutQuad(const SamplerID &id, bool level1);
 	bool Jit_BlendQuad(const SamplerID &id, bool level1);
 	bool Jit_DecodeQuad(const SamplerID &id, bool level1);

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -101,7 +101,8 @@ private:
 	bool Jit_PrepareDataOffsets(const SamplerID &id, Rasterizer::RegCache::Reg uReg, Rasterizer::RegCache::Reg vReg, bool level1);
 	bool Jit_PrepareDataDirectOffsets(const SamplerID &id, Rasterizer::RegCache::Reg uReg, Rasterizer::RegCache::Reg vReg, bool level1, int bitsPerTexel);
 	bool Jit_PrepareDataSwizzledOffsets(const SamplerID &id, Rasterizer::RegCache::Reg uReg, Rasterizer::RegCache::Reg vReg, bool level1, int bitsPerTexel);
-	bool Jit_ReadQuad(const SamplerID &id, bool level1, bool *doFallback);
+	bool Jit_FetchQuad(const SamplerID &id, bool level1, bool *doFallback);
+	bool Jit_GetDataQuad(const SamplerID &id, bool level1, int bitsPerTexel);
 	bool Jit_TransformClutIndexQuad(const SamplerID &id, int bitsPerIndex);
 	bool Jit_ReadClutQuad(const SamplerID &id, bool level1);
 	bool Jit_BlendQuad(const SamplerID &id, bool level1);


### PR DESCRIPTION
Although VPGATHERDD is high latency, it's still much better than manually assembling the values, and especially than the old way with CALL.

This had some nice gains in several areas on an AVX2 supporting PC.  VC3 in game is now at ~46 FPS, LBP at ~56 FPS, and KHBBS is ~74 FPS.  The VC3 logo screen improved a lot though, up to ~99 FPS from ~93.

Didn't heavily test the non-AVX2 paths, though.

-[Unknown]