### PR TITLE
Small optimizations to raster and sampler, lighting optimization

### DIFF
--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -538,18 +538,35 @@ void PixelJitCache::Clear() {
 	addresses_.clear();
 }
 
-std::string PixelJitCache::DescribeCodePtr(const u8 *ptr) {
-	ptrdiff_t dist = 0x7FFFFFFF;
-	PixelFuncID found{};
-	for (const auto &it : addresses_) {
-		ptrdiff_t it_dist = ptr - it.second;
-		if (it_dist >= 0 && it_dist < dist) {
-			found = it.first;
-			dist = it_dist;
-		}
-	}
+void PixelJitCache::Describe(const std::string &message) {
+	descriptions_[GetCodePointer()] = message;
+}
 
-	return DescribePixelFuncID(found);
+std::string PixelJitCache::DescribeCodePtr(const u8 *ptr) {
+	constexpr bool USE_IDS = false;
+	ptrdiff_t dist = 0x7FFFFFFF;
+	if (USE_IDS) {
+		PixelFuncID found{};
+		for (const auto &it : addresses_) {
+			ptrdiff_t it_dist = ptr - it.second;
+			if (it_dist >= 0 && it_dist < dist) {
+				found = it.first;
+				dist = it_dist;
+			}
+		}
+
+		return DescribePixelFuncID(found);
+	} else {
+		std::string found;
+		for (const auto &it : descriptions_) {
+			ptrdiff_t it_dist = ptr - it.first;
+			if (it_dist >= 0 && it_dist < dist) {
+				found = it.second;
+				dist = it_dist;
+			}
+		}
+		return found;
+	}
 }
 
 SingleFunc PixelJitCache::GetSingle(const PixelFuncID &id) {

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -66,6 +66,8 @@ public:
 private:
 	SingleFunc CompileSingle(const PixelFuncID &id);
 
+	void Describe(const std::string &message);
+
 #if PPSSPP_ARCH(ARM64)
 	Arm64Gen::ARM64FloatEmitter fp;
 #endif
@@ -104,6 +106,7 @@ private:
 
 	std::unordered_map<PixelFuncID, SingleFunc> cache_;
 	std::unordered_map<PixelFuncID, const u8 *> addresses_;
+	std::unordered_map<const u8 *, std::string> descriptions_;
 	RegCache regCache_;
 
 #if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)

--- a/GPU/Software/FuncId.h
+++ b/GPU/Software/FuncId.h
@@ -169,7 +169,7 @@ struct SamplerID {
 			bool hasClutShift : 1;
 			bool hasClutOffset : 1;
 			bool hasInvalidPtr : 1;
-			bool linear : 1;
+			bool overReadSafe : 1;
 			bool useStandardBufw : 1;
 			uint8_t width0Shift : 4;
 			uint8_t height0Shift : 4;
@@ -177,7 +177,7 @@ struct SamplerID {
 			bool useTextureAlpha : 1;
 			bool useColorDoubling : 1;
 			bool hasAnyMips : 1;
-			bool overReadSafe : 1;
+			bool linear : 1;
 			bool fetch : 1;
 		};
 	};

--- a/GPU/Software/Lighting.cpp
+++ b/GPU/Software/Lighting.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include "Common/CPUDetect.h"
 #include "GPU/GPUState.h"
 #include "GPU/Software/Lighting.h"
@@ -22,7 +23,13 @@
 namespace Lighting {
 
 static inline Vec3f GetLightVec(u32 lparams[12], int light) {
+#if defined(_M_SSE) && !PPSSPP_ARCH(X86)
+	__m128i values = _mm_loadu_si128((__m128i *)&lparams[3 * light]);
+	__m128i from24 = _mm_slli_epi32(values, 8);
+	return _mm_castsi128_ps(from24);
+#else
 	return Vec3<float>(getFloat24(lparams[3 * light]), getFloat24(lparams[3 * light + 1]), getFloat24(lparams[3 * light + 2]));
+#endif
 }
 
 static inline float pspLightPow(float v, float e) {


### PR DESCRIPTION
The biggest change here is lighting.  Overall, together these give between a 2-5% improvement in performance in many cases.

Comparing to #15275, VC3 at ~48 FPS, LBP at ~58 (so close), KHBBS at ~78.

Probably need to add some tests for lighting accuracy, making it accurate may make it slower... I doubt the alpha blend by dividing out 255.

-[Unknown]