### PR TITLE
Improve softgpu lighting accuracy and speed

### DIFF
--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -883,7 +883,8 @@ float vectorGetByIndex(__m128 v) {
 #endif
 
 #if defined(_M_SSE)
-inline __m128 MATH3D_CALL Vec3ByMatrix43(__m128 x, __m128 y, __m128 z, const float m[12]) {
+// x, y, and z should be broadcast.  Should only be used through Vec3f version.
+inline __m128 MATH3D_CALL Vec3ByMatrix43Internal(__m128 x, __m128 y, __m128 z, const float m[12]) {
 	__m128 col0 = _mm_loadu_ps(m);
 	__m128 col1 = _mm_loadu_ps(m + 3);
 	__m128 col2 = _mm_loadu_ps(m + 6);
@@ -894,7 +895,7 @@ inline __m128 MATH3D_CALL Vec3ByMatrix43(__m128 x, __m128 y, __m128 z, const flo
 	return sum;
 }
 #elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
-inline float32x4_t Vec3ByMatrix43(float32x4_t vec, const float m[16]) {
+inline float32x4_t Vec3ByMatrix43Internal(float32x4_t vec, const float m[16]) {
 	float32x4_t col0 = vld1q_f32(m);
 	float32x4_t col1 = vld1q_f32(m + 3);
 	float32x4_t col2 = vld1q_f32(m + 6);
@@ -912,14 +913,14 @@ inline void Vec3ByMatrix43(float vecOut[3], const float v[3], const float m[12])
 	__m128 x = _mm_set1_ps(v[0]);
 	__m128 y = _mm_set1_ps(v[1]);
 	__m128 z = _mm_set1_ps(v[2]);
-	__m128 sum = Vec3ByMatrix43(x, y, z, m);
+	__m128 sum = Vec3ByMatrix43Internal(x, y, z, m);
 	// Not sure what the best way to store 3 elements is. Ideally, we should
 	// probably store all four.
 	vecOut[0] = _mm_cvtss_f32(sum);
 	vecOut[1] = vectorGetByIndex<1>(sum);
 	vecOut[2] = vectorGetByIndex<2>(sum);
 #elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
-	float32x4_t sum = Vec3ByMatrix43(vld1q_f32(v), m);
+	float32x4_t sum = Vec3ByMatrix43Internal(vld1q_f32(v), m);
 	vecOut[0] = vgetq_lane_f32(sum, 0);
 	vecOut[1] = vgetq_lane_f32(sum, 1);
 	vecOut[2] = vgetq_lane_f32(sum, 2);
@@ -935,9 +936,9 @@ inline Vec3f MATH3D_CALL Vec3ByMatrix43(const Vec3f v, const float m[12]) {
 	__m128 x = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(0, 0, 0, 0));
 	__m128 y = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(1, 1, 1, 1));
 	__m128 z = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(2, 2, 2, 2));
-	return Vec3ByMatrix43(x, y, z, m);
+	return Vec3ByMatrix43Internal(x, y, z, m);
 #elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
-	return Vec3ByMatrix43(v.vec, m);
+	return Vec3ByMatrix43Internal(v.vec, m);
 #else
 	Vec3f vecOut;
 	Vec3ByMatrix43(vecOut.AsArray(), v.AsArray(), m);
@@ -946,7 +947,8 @@ inline Vec3f MATH3D_CALL Vec3ByMatrix43(const Vec3f v, const float m[12]) {
 }
 
 #if defined(_M_SSE)
-inline __m128 MATH3D_CALL Vec3ByMatrix44(__m128 x, __m128 y, __m128 z, const float m[16]) {
+// x, y, and z should be broadcast.  Should only be used through Vec3f version.
+inline __m128 MATH3D_CALL Vec3ByMatrix44Internal(__m128 x, __m128 y, __m128 z, const float m[16]) {
 	__m128 col0 = _mm_loadu_ps(m);
 	__m128 col1 = _mm_loadu_ps(m + 4);
 	__m128 col2 = _mm_loadu_ps(m + 8);
@@ -957,7 +959,7 @@ inline __m128 MATH3D_CALL Vec3ByMatrix44(__m128 x, __m128 y, __m128 z, const flo
 	return sum;
 }
 #elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
-inline float32x4_t Vec3ByMatrix44(float32x4_t vec, const float m[16]) {
+inline float32x4_t Vec3ByMatrix44Internal(float32x4_t vec, const float m[16]) {
 	float32x4_t col0 = vld1q_f32(m);
 	float32x4_t col1 = vld1q_f32(m + 4);
 	float32x4_t col2 = vld1q_f32(m + 8);
@@ -974,10 +976,10 @@ inline void Vec3ByMatrix44(float vecOut[4], const float v[3], const float m[16])
 	__m128 x = _mm_set1_ps(v[0]);
 	__m128 y = _mm_set1_ps(v[1]);
 	__m128 z = _mm_set1_ps(v[2]);
-	__m128 sum = Vec3ByMatrix44(x, y, z, m);
+	__m128 sum = Vec3ByMatrix44Internal(x, y, z, m);
 	_mm_storeu_ps(vecOut, sum);
 #elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
-	float32x4_t sum = Vec3ByMatrix44(vld1q_f32(v), m);
+	float32x4_t sum = Vec3ByMatrix44Internal(vld1q_f32(v), m);
 	vst1q_f32(vecOut, sum);
 #else
 	vecOut[0] = v[0] * m[0] + v[1] * m[4] + v[2] * m[8] + m[12];
@@ -992,9 +994,9 @@ inline Vec4f MATH3D_CALL Vec3ByMatrix44(const Vec3f v, const float m[16]) {
 	__m128 x = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(0, 0, 0, 0));
 	__m128 y = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(1, 1, 1, 1));
 	__m128 z = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(2, 2, 2, 2));
-	return Vec3ByMatrix44(x, y, z, m);
+	return Vec3ByMatrix44Internal(x, y, z, m);
 #elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
-	return Vec3ByMatrix44(v.vec, m);
+	return Vec3ByMatrix44Internal(v.vec, m);
 #else
 	Vec4f vecOut;
 	Vec3ByMatrix44(vecOut.AsArray(), v.AsArray(), m);
@@ -1003,7 +1005,8 @@ inline Vec4f MATH3D_CALL Vec3ByMatrix44(const Vec3f v, const float m[16]) {
 }
 
 #if defined(_M_SSE)
-inline __m128 MATH3D_CALL Norm3ByMatrix43(__m128 x, __m128 y, __m128 z, const float m[12]) {
+// x, y, and z should be broadcast.  Should only be used through Vec3f version.
+inline __m128 MATH3D_CALL Norm3ByMatrix43Internal(__m128 x, __m128 y, __m128 z, const float m[12]) {
 	__m128 col0 = _mm_loadu_ps(m);
 	__m128 col1 = _mm_loadu_ps(m + 3);
 	__m128 col2 = _mm_loadu_ps(m + 6);
@@ -1013,7 +1016,7 @@ inline __m128 MATH3D_CALL Norm3ByMatrix43(__m128 x, __m128 y, __m128 z, const fl
 	return sum;
 }
 #elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
-inline float32x4_t Norm3ByMatrix43(float32x4_t vec, const float m[16]) {
+inline float32x4_t Norm3ByMatrix43Internal(float32x4_t vec, const float m[16]) {
 	float32x4_t col0 = vld1q_f32(m);
 	float32x4_t col1 = vld1q_f32(m + 3);
 	float32x4_t col2 = vld1q_f32(m + 6);
@@ -1029,12 +1032,12 @@ inline void Norm3ByMatrix43(float vecOut[3], const float v[3], const float m[12]
 	__m128 x = _mm_set1_ps(v[0]);
 	__m128 y = _mm_set1_ps(v[1]);
 	__m128 z = _mm_set1_ps(v[2]);
-	__m128 sum = Norm3ByMatrix43(x, y, z, m);
+	__m128 sum = Norm3ByMatrix43Internal(x, y, z, m);
 	vecOut[0] = _mm_cvtss_f32(sum);
 	vecOut[1] = vectorGetByIndex<1>(sum);
 	vecOut[2] = vectorGetByIndex<2>(sum);
 #elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
-	float32x4_t sum = Norm3ByMatrix43(vld1q_f32(v), m);
+	float32x4_t sum = Norm3ByMatrix43Internal(vld1q_f32(v), m);
 	vecOut[0] = vgetq_lane_f32(sum, 0);
 	vecOut[1] = vgetq_lane_f32(sum, 1);
 	vecOut[2] = vgetq_lane_f32(sum, 2);
@@ -1050,9 +1053,9 @@ inline Vec3f MATH3D_CALL Norm3ByMatrix43(const Vec3f v, const float m[12]) {
 	__m128 x = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(0, 0, 0, 0));
 	__m128 y = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(1, 1, 1, 1));
 	__m128 z = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(2, 2, 2, 2));
-	return Norm3ByMatrix43(x, y, z, m);
+	return Norm3ByMatrix43Internal(x, y, z, m);
 #elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
-	return Norm3ByMatrix43(v.vec, m);
+	return Norm3ByMatrix43Internal(v.vec, m);
 #else
 	Vec3f vecOut;
 	Norm3ByMatrix43(vecOut.AsArray(), v.AsArray(), m);

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -38,6 +38,12 @@
 #endif
 #endif
 
+#if PPSSPP_PLATFORM(WINDOWS) && (defined(_MSC_VER) || defined(__clang__) || defined(__INTEL_COMPILER))
+#define MATH3D_CALL __vectorcall
+#else
+#define MATH3D_CALL
+#endif
+
 namespace Math3D {
 
 // Helper for Vec classes to clamp values.
@@ -913,6 +919,38 @@ inline void Vec3ByMatrix43(float vecOut[3], const float v[3], const float m[12])
 #endif
 }
 
+inline Vec3f MATH3D_CALL Vec3ByMatrix43(const Vec3f v, const float m[12]) {
+#if defined(_M_SSE)
+	__m128 col0 = _mm_loadu_ps(m);
+	__m128 col1 = _mm_loadu_ps(m + 3);
+	__m128 col2 = _mm_loadu_ps(m + 6);
+	__m128 col3 = _mm_loadu_ps(m + 9);
+	__m128 x = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(0, 0, 0, 0));
+	__m128 y = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(1, 1, 1, 1));
+	__m128 z = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(2, 2, 2, 2));
+	__m128 sum = _mm_add_ps(
+		_mm_add_ps(_mm_mul_ps(col0, x), _mm_mul_ps(col1, y)),
+		_mm_add_ps(_mm_mul_ps(col2, z), col3));
+	return sum;
+#elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
+	float32x4_t col0 = vld1q_f32(m);
+	float32x4_t col1 = vld1q_f32(m + 3);
+	float32x4_t col2 = vld1q_f32(m + 6);
+	float32x4_t col3 = vld1q_f32(m + 9);
+	float32x4_t vec = v.vec;
+	float32x4_t sum = vaddq_f32(
+		vaddq_f32(vmulq_laneq_f32(col0, vec, 0), vmulq_laneq_f32(col1, vec, 1)),
+		vaddq_f32(vmulq_laneq_f32(col2, vec, 2), col3));
+	return sum;
+#else
+	Vec3f vecOut;
+	vecOut[0] = v[0] * m[0] + v[1] * m[3] + v[2] * m[6] + m[9];
+	vecOut[1] = v[0] * m[1] + v[1] * m[4] + v[2] * m[7] + m[10];
+	vecOut[2] = v[0] * m[2] + v[1] * m[5] + v[2] * m[8] + m[11];
+	return vecOut;
+#endif
+}
+
 inline void Vec3ByMatrix44(float vecOut[4], const float v[3], const float m[16])
 {
 #if defined(_M_SSE)
@@ -945,11 +983,74 @@ inline void Vec3ByMatrix44(float vecOut[4], const float v[3], const float m[16])
 #endif
 }
 
+inline Vec4f MATH3D_CALL Vec3ByMatrix44(const Vec3f v, const float m[16]) {
+#if defined(_M_SSE)
+	__m128 col0 = _mm_loadu_ps(m);
+	__m128 col1 = _mm_loadu_ps(m + 4);
+	__m128 col2 = _mm_loadu_ps(m + 8);
+	__m128 col3 = _mm_loadu_ps(m + 12);
+	__m128 x = _mm_set1_ps(v[0]);
+	__m128 y = _mm_set1_ps(v[1]);
+	__m128 z = _mm_set1_ps(v[2]);
+	__m128 sum = _mm_add_ps(
+		_mm_add_ps(_mm_mul_ps(col0, x), _mm_mul_ps(col1, y)),
+		_mm_add_ps(_mm_mul_ps(col2, z), col3));
+	return sum;
+#elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
+	float32x4_t col0 = vld1q_f32(m);
+	float32x4_t col1 = vld1q_f32(m + 4);
+	float32x4_t col2 = vld1q_f32(m + 8);
+	float32x4_t col3 = vld1q_f32(m + 12);
+	float32x4_t vec = v.vec;
+	float32x4_t sum = vaddq_f32(
+		vaddq_f32(vmulq_laneq_f32(col0, vec, 0), vmulq_laneq_f32(col1, vec, 1)),
+		vaddq_f32(vmulq_laneq_f32(col2, vec, 2), col3));
+	return sum;
+#else
+	Vec4f vecOut;
+	vecOut[0] = v[0] * m[0] + v[1] * m[4] + v[2] * m[8] + m[12];
+	vecOut[1] = v[0] * m[1] + v[1] * m[5] + v[2] * m[9] + m[13];
+	vecOut[2] = v[0] * m[2] + v[1] * m[6] + v[2] * m[10] + m[14];
+	vecOut[3] = v[0] * m[3] + v[1] * m[7] + v[2] * m[11] + m[15];
+	return vecOut;
+#endif
+}
+
 inline void Norm3ByMatrix43(float vecOut[3], const float v[3], const float m[12])
 {
 	vecOut[0] = v[0] * m[0] + v[1] * m[3] + v[2] * m[6];
 	vecOut[1] = v[0] * m[1] + v[1] * m[4] + v[2] * m[7];
 	vecOut[2] = v[0] * m[2] + v[1] * m[5] + v[2] * m[8];
+}
+
+inline Vec3f MATH3D_CALL Norm3ByMatrix43(const Vec3f v, const float m[12]) {
+#if defined(_M_SSE)
+	__m128 col0 = _mm_loadu_ps(m);
+	__m128 col1 = _mm_loadu_ps(m + 3);
+	__m128 col2 = _mm_loadu_ps(m + 6);
+	__m128 x = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(0, 0, 0, 0));
+	__m128 y = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(1, 1, 1, 1));
+	__m128 z = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(2, 2, 2, 2));
+	__m128 sum = _mm_add_ps(
+		_mm_add_ps(_mm_mul_ps(col0, x), _mm_mul_ps(col1, y)),
+		_mm_mul_ps(col2, z));
+	return sum;
+#elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
+	float32x4_t col0 = vld1q_f32(m);
+	float32x4_t col1 = vld1q_f32(m + 3);
+	float32x4_t col2 = vld1q_f32(m + 6);
+	float32x4_t vec = v.vec;
+	float32x4_t sum = vaddq_f32(
+		vaddq_f32(vmulq_laneq_f32(col0, vec, 0), vmulq_laneq_f32(col1, vec, 1)),
+		vmulq_laneq_f32(col2, vec, 2));
+	return sum;
+#else
+	Vec3f vecOut;
+	vecOut[0] = v[0] * m[0] + v[1] * m[3] + v[2] * m[6];
+	vecOut[1] = v[0] * m[1] + v[1] * m[4] + v[2] * m[7];
+	vecOut[2] = v[0] * m[2] + v[1] * m[5] + v[2] * m[8];
+	return vecOut;
+#endif
 }
 
 inline void Matrix4ByMatrix4(float out[16], const float a[16], const float b[16]) {

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -882,33 +882,44 @@ float vectorGetByIndex(__m128 v) {
 }
 #endif
 
-// v and vecOut must point to different memory.
-inline void Vec3ByMatrix43(float vecOut[3], const float v[3], const float m[12]) {
 #if defined(_M_SSE)
+inline __m128 MATH3D_CALL Vec3ByMatrix43(__m128 x, __m128 y, __m128 z, const float m[12]) {
 	__m128 col0 = _mm_loadu_ps(m);
 	__m128 col1 = _mm_loadu_ps(m + 3);
 	__m128 col2 = _mm_loadu_ps(m + 6);
 	__m128 col3 = _mm_loadu_ps(m + 9);
-	__m128 x = _mm_set1_ps(v[0]);
-	__m128 y = _mm_set1_ps(v[1]);
-	__m128 z = _mm_set1_ps(v[2]);
 	__m128 sum = _mm_add_ps(
 		_mm_add_ps(_mm_mul_ps(col0, x), _mm_mul_ps(col1, y)),
 		_mm_add_ps(_mm_mul_ps(col2, z), col3));
+	return sum;
+}
+#elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
+inline float32x4_t Vec3ByMatrix43(float32x4_t vec, const float m[16]) {
+	float32x4_t col0 = vld1q_f32(m);
+	float32x4_t col1 = vld1q_f32(m + 3);
+	float32x4_t col2 = vld1q_f32(m + 6);
+	float32x4_t col3 = vld1q_f32(m + 9);
+	float32x4_t sum = vaddq_f32(
+		vaddq_f32(vmulq_laneq_f32(col0, vec, 0), vmulq_laneq_f32(col1, vec, 1)),
+		vaddq_f32(vmulq_laneq_f32(col2, vec, 2), col3));
+	return sum;
+}
+#endif
+
+// v and vecOut must point to different memory.
+inline void Vec3ByMatrix43(float vecOut[3], const float v[3], const float m[12]) {
+#if defined(_M_SSE)
+	__m128 x = _mm_set1_ps(v[0]);
+	__m128 y = _mm_set1_ps(v[1]);
+	__m128 z = _mm_set1_ps(v[2]);
+	__m128 sum = Vec3ByMatrix43(x, y, z, m);
 	// Not sure what the best way to store 3 elements is. Ideally, we should
 	// probably store all four.
 	vecOut[0] = _mm_cvtss_f32(sum);
 	vecOut[1] = vectorGetByIndex<1>(sum);
 	vecOut[2] = vectorGetByIndex<2>(sum);
 #elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
-	float32x4_t col0 = vld1q_f32(m);
-	float32x4_t col1 = vld1q_f32(m + 3);
-	float32x4_t col2 = vld1q_f32(m + 6);
-	float32x4_t col3 = vld1q_f32(m + 9);
-	float32x4_t vec = vld1q_f32(v);
-	float32x4_t sum = vaddq_f32(
-		vaddq_f32(vmulq_laneq_f32(col0, vec, 0), vmulq_laneq_f32(col1, vec, 1)),
-		vaddq_f32(vmulq_laneq_f32(col2, vec, 2), col3));
+	float32x4_t sum = Vec3ByMatrix43(vld1q_f32(v), m);
 	vecOut[0] = vgetq_lane_f32(sum, 0);
 	vecOut[1] = vgetq_lane_f32(sum, 1);
 	vecOut[2] = vgetq_lane_f32(sum, 2);
@@ -921,59 +932,52 @@ inline void Vec3ByMatrix43(float vecOut[3], const float v[3], const float m[12])
 
 inline Vec3f MATH3D_CALL Vec3ByMatrix43(const Vec3f v, const float m[12]) {
 #if defined(_M_SSE)
-	__m128 col0 = _mm_loadu_ps(m);
-	__m128 col1 = _mm_loadu_ps(m + 3);
-	__m128 col2 = _mm_loadu_ps(m + 6);
-	__m128 col3 = _mm_loadu_ps(m + 9);
 	__m128 x = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(0, 0, 0, 0));
 	__m128 y = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(1, 1, 1, 1));
 	__m128 z = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(2, 2, 2, 2));
-	__m128 sum = _mm_add_ps(
-		_mm_add_ps(_mm_mul_ps(col0, x), _mm_mul_ps(col1, y)),
-		_mm_add_ps(_mm_mul_ps(col2, z), col3));
-	return sum;
+	return Vec3ByMatrix43(x, y, z, m);
 #elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
-	float32x4_t col0 = vld1q_f32(m);
-	float32x4_t col1 = vld1q_f32(m + 3);
-	float32x4_t col2 = vld1q_f32(m + 6);
-	float32x4_t col3 = vld1q_f32(m + 9);
-	float32x4_t vec = v.vec;
-	float32x4_t sum = vaddq_f32(
-		vaddq_f32(vmulq_laneq_f32(col0, vec, 0), vmulq_laneq_f32(col1, vec, 1)),
-		vaddq_f32(vmulq_laneq_f32(col2, vec, 2), col3));
-	return sum;
+	return Vec3ByMatrix43(v.vec, m);
 #else
 	Vec3f vecOut;
-	vecOut[0] = v[0] * m[0] + v[1] * m[3] + v[2] * m[6] + m[9];
-	vecOut[1] = v[0] * m[1] + v[1] * m[4] + v[2] * m[7] + m[10];
-	vecOut[2] = v[0] * m[2] + v[1] * m[5] + v[2] * m[8] + m[11];
+	Vec3ByMatrix43(vecOut.AsArray(), v.AsArray(), m);
 	return vecOut;
 #endif
 }
 
-inline void Vec3ByMatrix44(float vecOut[4], const float v[3], const float m[16])
-{
 #if defined(_M_SSE)
+inline __m128 MATH3D_CALL Vec3ByMatrix44(__m128 x, __m128 y, __m128 z, const float m[16]) {
 	__m128 col0 = _mm_loadu_ps(m);
 	__m128 col1 = _mm_loadu_ps(m + 4);
 	__m128 col2 = _mm_loadu_ps(m + 8);
 	__m128 col3 = _mm_loadu_ps(m + 12);
-	__m128 x = _mm_set1_ps(v[0]);
-	__m128 y = _mm_set1_ps(v[1]);
-	__m128 z = _mm_set1_ps(v[2]);
 	__m128 sum = _mm_add_ps(
 		_mm_add_ps(_mm_mul_ps(col0, x), _mm_mul_ps(col1, y)),
 		_mm_add_ps(_mm_mul_ps(col2, z), col3));
-	_mm_storeu_ps(vecOut, sum);
+	return sum;
+}
 #elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
+inline float32x4_t Vec3ByMatrix44(float32x4_t vec, const float m[16]) {
 	float32x4_t col0 = vld1q_f32(m);
 	float32x4_t col1 = vld1q_f32(m + 4);
 	float32x4_t col2 = vld1q_f32(m + 8);
 	float32x4_t col3 = vld1q_f32(m + 12);
-	float32x4_t vec = vld1q_f32(v);
 	float32x4_t sum = vaddq_f32(
 		vaddq_f32(vmulq_laneq_f32(col0, vec, 0), vmulq_laneq_f32(col1, vec, 1)),
 		vaddq_f32(vmulq_laneq_f32(col2, vec, 2), col3));
+	return sum;
+}
+#endif
+
+inline void Vec3ByMatrix44(float vecOut[4], const float v[3], const float m[16]) {
+#if defined(_M_SSE)
+	__m128 x = _mm_set1_ps(v[0]);
+	__m128 y = _mm_set1_ps(v[1]);
+	__m128 z = _mm_set1_ps(v[2]);
+	__m128 sum = Vec3ByMatrix44(x, y, z, m);
+	_mm_storeu_ps(vecOut, sum);
+#elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
+	float32x4_t sum = Vec3ByMatrix44(vld1q_f32(v), m);
 	vst1q_f32(vecOut, sum);
 #else
 	vecOut[0] = v[0] * m[0] + v[1] * m[4] + v[2] * m[8] + m[12];
@@ -985,70 +989,73 @@ inline void Vec3ByMatrix44(float vecOut[4], const float v[3], const float m[16])
 
 inline Vec4f MATH3D_CALL Vec3ByMatrix44(const Vec3f v, const float m[16]) {
 #if defined(_M_SSE)
-	__m128 col0 = _mm_loadu_ps(m);
-	__m128 col1 = _mm_loadu_ps(m + 4);
-	__m128 col2 = _mm_loadu_ps(m + 8);
-	__m128 col3 = _mm_loadu_ps(m + 12);
-	__m128 x = _mm_set1_ps(v[0]);
-	__m128 y = _mm_set1_ps(v[1]);
-	__m128 z = _mm_set1_ps(v[2]);
-	__m128 sum = _mm_add_ps(
-		_mm_add_ps(_mm_mul_ps(col0, x), _mm_mul_ps(col1, y)),
-		_mm_add_ps(_mm_mul_ps(col2, z), col3));
-	return sum;
+	__m128 x = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(0, 0, 0, 0));
+	__m128 y = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(1, 1, 1, 1));
+	__m128 z = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(2, 2, 2, 2));
+	return Vec3ByMatrix44(x, y, z, m);
 #elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
-	float32x4_t col0 = vld1q_f32(m);
-	float32x4_t col1 = vld1q_f32(m + 4);
-	float32x4_t col2 = vld1q_f32(m + 8);
-	float32x4_t col3 = vld1q_f32(m + 12);
-	float32x4_t vec = v.vec;
-	float32x4_t sum = vaddq_f32(
-		vaddq_f32(vmulq_laneq_f32(col0, vec, 0), vmulq_laneq_f32(col1, vec, 1)),
-		vaddq_f32(vmulq_laneq_f32(col2, vec, 2), col3));
-	return sum;
+	return Vec3ByMatrix44(v.vec, m);
 #else
 	Vec4f vecOut;
-	vecOut[0] = v[0] * m[0] + v[1] * m[4] + v[2] * m[8] + m[12];
-	vecOut[1] = v[0] * m[1] + v[1] * m[5] + v[2] * m[9] + m[13];
-	vecOut[2] = v[0] * m[2] + v[1] * m[6] + v[2] * m[10] + m[14];
-	vecOut[3] = v[0] * m[3] + v[1] * m[7] + v[2] * m[11] + m[15];
+	Vec3ByMatrix44(vecOut.AsArray(), v.AsArray(), m);
 	return vecOut;
 #endif
 }
 
-inline void Norm3ByMatrix43(float vecOut[3], const float v[3], const float m[12])
-{
-	vecOut[0] = v[0] * m[0] + v[1] * m[3] + v[2] * m[6];
-	vecOut[1] = v[0] * m[1] + v[1] * m[4] + v[2] * m[7];
-	vecOut[2] = v[0] * m[2] + v[1] * m[5] + v[2] * m[8];
-}
-
-inline Vec3f MATH3D_CALL Norm3ByMatrix43(const Vec3f v, const float m[12]) {
 #if defined(_M_SSE)
+inline __m128 MATH3D_CALL Norm3ByMatrix43(__m128 x, __m128 y, __m128 z, const float m[12]) {
 	__m128 col0 = _mm_loadu_ps(m);
 	__m128 col1 = _mm_loadu_ps(m + 3);
 	__m128 col2 = _mm_loadu_ps(m + 6);
-	__m128 x = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(0, 0, 0, 0));
-	__m128 y = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(1, 1, 1, 1));
-	__m128 z = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(2, 2, 2, 2));
 	__m128 sum = _mm_add_ps(
 		_mm_add_ps(_mm_mul_ps(col0, x), _mm_mul_ps(col1, y)),
 		_mm_mul_ps(col2, z));
 	return sum;
+}
 #elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
+inline float32x4_t Norm3ByMatrix43(float32x4_t vec, const float m[16]) {
 	float32x4_t col0 = vld1q_f32(m);
 	float32x4_t col1 = vld1q_f32(m + 3);
 	float32x4_t col2 = vld1q_f32(m + 6);
-	float32x4_t vec = v.vec;
 	float32x4_t sum = vaddq_f32(
 		vaddq_f32(vmulq_laneq_f32(col0, vec, 0), vmulq_laneq_f32(col1, vec, 1)),
 		vmulq_laneq_f32(col2, vec, 2));
 	return sum;
+}
+#endif
+
+inline void Norm3ByMatrix43(float vecOut[3], const float v[3], const float m[12]) {
+#if defined(_M_SSE)
+	__m128 x = _mm_set1_ps(v[0]);
+	__m128 y = _mm_set1_ps(v[1]);
+	__m128 z = _mm_set1_ps(v[2]);
+	__m128 sum = Norm3ByMatrix43(x, y, z, m);
+	vecOut[0] = _mm_cvtss_f32(sum);
+	vecOut[1] = vectorGetByIndex<1>(sum);
+	vecOut[2] = vectorGetByIndex<2>(sum);
+#elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
+	float32x4_t sum = Norm3ByMatrix43(vld1q_f32(v), m);
+	vecOut[0] = vgetq_lane_f32(sum, 0);
+	vecOut[1] = vgetq_lane_f32(sum, 1);
+	vecOut[2] = vgetq_lane_f32(sum, 2);
 #else
-	Vec3f vecOut;
 	vecOut[0] = v[0] * m[0] + v[1] * m[3] + v[2] * m[6];
 	vecOut[1] = v[0] * m[1] + v[1] * m[4] + v[2] * m[7];
 	vecOut[2] = v[0] * m[2] + v[1] * m[5] + v[2] * m[8];
+#endif
+}
+
+inline Vec3f MATH3D_CALL Norm3ByMatrix43(const Vec3f v, const float m[12]) {
+#if defined(_M_SSE)
+	__m128 x = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(0, 0, 0, 0));
+	__m128 y = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(1, 1, 1, 1));
+	__m128 z = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(2, 2, 2, 2));
+	return Norm3ByMatrix43(x, y, z, m);
+#elif PPSSPP_ARCH(ARM_NEON) && PPSSPP_ARCH(ARM64)
+	return Norm3ByMatrix43(v.vec, m);
+#else
+	Vec3f vecOut;
+	Norm3ByMatrix43(vecOut.AsArray(), v.AsArray(), m);
 	return vecOut;
 #endif
 }

--- a/GPU/Software/Lighting.cpp
+++ b/GPU/Software/Lighting.cpp
@@ -131,7 +131,9 @@ void Process(VertexData& vertex, bool hasColor) {
 		}
 
 		if (diffuse_factor > 0.0f) {
-			int diffuse_attspot = (int)ceilf(attspot * diffuse_factor + 1);
+			int diffuse_attspot = (int)ceilf(256 * 2 * att * spot * diffuse_factor + 1);
+			if (diffuse_attspot > 512)
+				diffuse_attspot = 512;
 			Vec4<int> ldc = Vec4<int>::FromRGBA(gstate.getDiffuseColor(light));
 			Vec4<int> mdc = (materialupdate & 2) ? vertex.color0 : Vec4<int>::FromRGBA(gstate.getMaterialDiffuse());
 			Vec4<int> ldiffuse = ((ldc * 2 + ones) * (mdc * 2 + ones) * diffuse_attspot) / (1024 * 512);
@@ -145,8 +147,8 @@ void Process(VertexData& vertex, bool hasColor) {
 			float k = gstate.getMaterialSpecularCoef();
 			specular_factor = pspLightPow(specular_factor, k);
 
-			if (specular_factor > 0.f) {
-				int specular_attspot = (int)ceilf(attspot * specular_factor + 1);
+			if (specular_factor > 0.0f) {
+				int specular_attspot = (int)ceilf(256 * 2 * att * spot * specular_factor + 1);
 				if (specular_attspot > 512)
 					specular_attspot = 512;
 				Vec4<int> lsc = Vec4<int>::FromRGBA(gstate.getSpecularColor(light));

--- a/GPU/Software/Lighting.cpp
+++ b/GPU/Software/Lighting.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "ppsspp_config.h"
+#include <cmath>
 #include "Common/CPUDetect.h"
 #include "GPU/GPUState.h"
 #include "GPU/Software/Lighting.h"
@@ -95,16 +96,20 @@ void Process(VertexData& vertex, bool hasColor) {
 				att = 1.0f;
 		}
 
-		float spot = 1.f;
+		float spot = 1.0f;
 		if (gstate.isSpotLight(light)) {
 			Vec3<float> dir = GetLightVec(gstate.ldir, light);
-			float rawSpot = Dot(dir.NormalizedOr001(cpu_info.bSSE4_1), L);
+			float rawSpot = Dot(dir.Normalized(cpu_info.bSSE4_1), L);
+			if (isnan(rawSpot))
+				rawSpot = 1.0f;
 			float cutoff = getFloat24(gstate.lcutoff[light]);
 			if (rawSpot >= cutoff) {
 				float conv = getFloat24(gstate.lconv[light]);
 				spot = pspLightPow(rawSpot, conv);
+				if (isnan(spot))
+					spot = 0.0f;
 			} else {
-				spot = 0.f;
+				spot = 0.0f;
 			}
 		}
 

--- a/GPU/Software/Lighting.cpp
+++ b/GPU/Software/Lighting.cpp
@@ -86,11 +86,13 @@ void Process(VertexData& vertex, bool hasColor) {
 		// TODO: Should this normalize (0, 0, 0) to (0, 0, 1)?
 		float d = L.NormalizeOr001();
 
-		float att = 1.f;
+		float att = 1.0f;
 		if (!gstate.isDirectionalLight(light)) {
-			att = 1.f / Dot(GetLightVec(gstate.latt, light), Vec3f(1.0f, d, d * d));
-			if (att > 1.f) att = 1.f;
-			if (att < 0.f) att = 0.f;
+			att = 1.0f / Dot(GetLightVec(gstate.latt, light), Vec3f(1.0f, d, d * d));
+			if (!(att > 0.0f))
+				att = 0.0f;
+			else if (att > 1.0f)
+				att = 1.0f;
 		}
 
 		float spot = 1.f;

--- a/GPU/Software/Lighting.h
+++ b/GPU/Software/Lighting.h
@@ -21,6 +21,7 @@
 
 namespace Lighting {
 
+void GenerateLightST(VertexData &vertex);
 void Process(VertexData& vertex, bool hasColor);
 
 }

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -277,10 +277,13 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 			Vec3<float> stq = tgen * source + Vec3<float>(gstate.tgenMatrix[9], gstate.tgenMatrix[10], gstate.tgenMatrix[11]);
 			float z_recip = 1.0f / stq.z;
 			vertex.texturecoords = Vec2f(stq.x * z_recip, stq.y * z_recip);
+		} else if (gstate.getUVGenMode() == GE_TEXMAP_ENVIRONMENT_MAP) {
+			Lighting::GenerateLightST(vertex);
 		}
 
 		PROFILE_THIS_SCOPE("light");
-		Lighting::Process(vertex, vreader.hasColor0());
+		if (gstate.isLightingEnabled())
+			Lighting::Process(vertex, vreader.hasColor0());
 	} else {
 		vertex.screenpos.x = (int)(pos[0] * 16) + gstate.getOffsetX16();
 		vertex.screenpos.y = (int)(pos[1] * 16) + gstate.getOffsetY16();

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -227,7 +227,8 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 		vertex.screenpos = ClipToScreenInternal(vertex.clippos, &outside_range_flag);
 
 		if (vreader.hasNormal()) {
-			vertex.worldnormal = TransformUnit::ModelToWorldNormal(vertex.normal).NormalizedOr001(cpu_info.bSSE4_1);
+			vertex.worldnormal = TransformUnit::ModelToWorldNormal(vertex.normal);
+			vertex.worldnormal.NormalizeOr001();
 		} else {
 			vertex.worldnormal = Vec3<float>(0.0f, 0.0f, 1.0f);
 		}

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -227,7 +227,7 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 		vertex.screenpos = ClipToScreenInternal(vertex.clippos, &outside_range_flag);
 
 		if (vreader.hasNormal()) {
-			vertex.worldnormal = TransformUnit::ModelToWorldNormal(vertex.normal).Normalized(cpu_info.bSSE4_1);
+			vertex.worldnormal = TransformUnit::ModelToWorldNormal(vertex.normal).NormalizedOr001(cpu_info.bSSE4_1);
 		} else {
 			vertex.worldnormal = Vec3<float>(0.0f, 0.0f, 1.0f);
 		}

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -67,29 +67,20 @@ VertexDecoder *SoftwareDrawEngine::FindVertexDecoder(u32 vtype) {
 	return DrawEngineCommon::GetVertexDecoder(vertTypeID);
 }
 
-WorldCoords TransformUnit::ModelToWorld(const ModelCoords& coords)
-{
-	Mat3x3<float> world_matrix(gstate.worldMatrix);
-	return WorldCoords(world_matrix * coords) + Vec3<float>(gstate.worldMatrix[9], gstate.worldMatrix[10], gstate.worldMatrix[11]);
+WorldCoords TransformUnit::ModelToWorld(const ModelCoords &coords) {
+	return Vec3ByMatrix43(coords, gstate.worldMatrix);
 }
 
-WorldCoords TransformUnit::ModelToWorldNormal(const ModelCoords& coords)
-{
-	Mat3x3<float> world_matrix(gstate.worldMatrix);
-	return WorldCoords(world_matrix * coords);
+WorldCoords TransformUnit::ModelToWorldNormal(const ModelCoords &coords) {
+	return Norm3ByMatrix43(coords, gstate.worldMatrix);
 }
 
-ViewCoords TransformUnit::WorldToView(const WorldCoords& coords)
-{
-	Mat3x3<float> view_matrix(gstate.viewMatrix);
-	return ViewCoords(view_matrix * coords) + Vec3<float>(gstate.viewMatrix[9], gstate.viewMatrix[10], gstate.viewMatrix[11]);
+ViewCoords TransformUnit::WorldToView(const WorldCoords &coords) {
+	return Vec3ByMatrix43(coords, gstate.viewMatrix);
 }
 
-ClipCoords TransformUnit::ViewToClip(const ViewCoords& coords)
-{
-	Vec4<float> coords4(coords.x, coords.y, coords.z, 1.0f);
-	Mat4x4<float> projection_matrix(gstate.projMatrix);
-	return ClipCoords(projection_matrix * coords4);
+ClipCoords TransformUnit::ViewToClip(const ViewCoords &coords) {
+	return Vec3ByMatrix44(coords, gstate.projMatrix);
 }
 
 static inline ScreenCoords ClipToScreenInternal(const ClipCoords& coords, bool *outside_range_flag) {
@@ -161,20 +152,16 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 	PROFILE_THIS_SCOPE("read_vert");
 	VertexData vertex;
 
-	float pos[3];
+	ModelCoords pos;
 	// VertexDecoder normally scales z, but we want it unscaled.
-	vreader.ReadPosThroughZ16(pos);
+	vreader.ReadPosThroughZ16(pos.AsArray());
 
 	if (!gstate.isModeClear() && gstate.isTextureMapEnabled() && vreader.hasUV()) {
-		float uv[2];
-		vreader.ReadUV(uv);
-		vertex.texturecoords = Vec2<float>(uv[0], uv[1]);
+		vreader.ReadUV(vertex.texturecoords.AsArray());
 	}
 
 	if (vreader.hasNormal()) {
-		float normal[3];
-		vreader.ReadNrm(normal);
-		vertex.normal = Vec3<float>(normal[0], normal[1], normal[2]);
+		vreader.ReadNrm(vertex.normal.AsArray());
 
 		if (gstate.areNormalsReversed())
 			vertex.normal = -vertex.normal;
@@ -188,15 +175,15 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 		Vec3<float> tmpnrm(0.f, 0.f, 0.f);
 
 		for (int i = 0; i < vertTypeGetNumBoneWeights(gstate.vertType); ++i) {
-			Mat3x3<float> bone(&gstate.boneMatrix[12*i]);
-			tmppos += (bone * ModelCoords(pos[0], pos[1], pos[2]) + Vec3<float>(gstate.boneMatrix[12*i+9], gstate.boneMatrix[12*i+10], gstate.boneMatrix[12*i+11])) * W[i];
-			if (vreader.hasNormal())
-				tmpnrm += (bone * vertex.normal) * W[i];
+			Vec3<float> step = Vec3ByMatrix43(pos, gstate.boneMatrix + i * 12);
+			tmppos += step * W[i];
+			if (vreader.hasNormal()) {
+				step = Norm3ByMatrix43(vertex.normal, gstate.boneMatrix + i * 12);
+				tmpnrm += step * W[i];
+			}
 		}
 
-		pos[0] = tmppos.x;
-		pos[1] = tmppos.y;
-		pos[2] = tmppos.z;
+		pos = tmppos;
 		if (vreader.hasNormal())
 			vertex.normal = tmpnrm;
 	}
@@ -206,7 +193,7 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 		vreader.ReadColor0(col);
 		vertex.color0 = Vec4<int>(col[0]*255, col[1]*255, col[2]*255, col[3]*255);
 	} else {
-		vertex.color0 = Vec4<int>(gstate.getMaterialAmbientR(), gstate.getMaterialAmbientG(), gstate.getMaterialAmbientB(), gstate.getMaterialAmbientA());
+		vertex.color0 = Vec4<int>::FromRGBA(gstate.getMaterialAmbientRGBA());
 	}
 
 	if (vreader.hasColor1()) {
@@ -218,7 +205,7 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 	}
 
 	if (!gstate.isModeThrough()) {
-		vertex.modelpos = ModelCoords(pos[0], pos[1], pos[2]);
+		vertex.modelpos = pos;
 		vertex.worldpos = WorldCoords(TransformUnit::ModelToWorld(vertex.modelpos));
 		ModelCoords viewpos = TransformUnit::WorldToView(vertex.worldpos);
 		vertex.clippos = ClipCoords(TransformUnit::ViewToClip(viewpos));
@@ -240,8 +227,7 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 		vertex.screenpos = ClipToScreenInternal(vertex.clippos, &outside_range_flag);
 
 		if (vreader.hasNormal()) {
-			vertex.worldnormal = TransformUnit::ModelToWorldNormal(vertex.normal);
-			vertex.worldnormal /= vertex.worldnormal.Length();
+			vertex.worldnormal = TransformUnit::ModelToWorldNormal(vertex.normal).Normalized(cpu_info.bSSE4_1);
 		} else {
 			vertex.worldnormal = Vec3<float>(0.0f, 0.0f, 1.0f);
 		}
@@ -273,8 +259,7 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 			}
 
 			// TODO: What about uv scale and offset?
-			Mat3x3<float> tgen(gstate.tgenMatrix);
-			Vec3<float> stq = tgen * source + Vec3<float>(gstate.tgenMatrix[9], gstate.tgenMatrix[10], gstate.tgenMatrix[11]);
+			Vec3<float> stq = Vec3ByMatrix43(source, gstate.tgenMatrix);
 			float z_recip = 1.0f / stq.z;
 			vertex.texturecoords = Vec2f(stq.x * z_recip, stq.y * z_recip);
 		} else if (gstate.getUVGenMode() == GE_TEXMAP_ENVIRONMENT_MAP) {


### PR DESCRIPTION
This improved ingame (while targeting an enemy) of Valkyria Chronicles 3 by around 2%, generally 1-2% gains.

I'm pretty confident from hardware tests about the color blending, largely from using maxed out factors and multiplying the colors together.  I tried to improve accuracy of the factors, but they're still not always correct.  The powered ones are especially inaccurate - it's clearly calculating pow in some shortcut inaccurate way.

Aside from my new tests, this also passes a lot more of gpu/commands/light.

I'm not confident MATH3D_CALL is doing anything, as compilers have seemed unwilling to consider Vec3f an HVA, but I figured I'd drop on in the hopes it forces inlining.  I did make sure x86 wasn't crashing.

-[Unknown]