### PR TITLE
softgpu: Draw top left of rectangles first

### DIFF
--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -244,10 +244,10 @@ void ProcessRect(const VertexData& v0, const VertexData& v1)
 			Rasterizer::ClearRectangle(v0, v1);
 		} else {
 			// Four triangles to do backfaces as well. Two of them will get backface culled.
-			Rasterizer::DrawTriangle(*topleft, *topright, *bottomright);
-			Rasterizer::DrawTriangle(*bottomright, *topright, *topleft);
-			Rasterizer::DrawTriangle(*bottomright, *bottomleft, *topleft);
-			Rasterizer::DrawTriangle(*topleft, *bottomleft, *bottomright);
+			Rasterizer::DrawTriangle(*topleft, *topright, *bottomleft);
+			Rasterizer::DrawTriangle(*bottomleft, *topright, *topleft);
+			Rasterizer::DrawTriangle(*topright, *bottomright, *bottomleft);
+			Rasterizer::DrawTriangle(*bottomleft, *bottomright, *topright);
 		}
 	}
 }

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -961,14 +961,21 @@ void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& 
 
 	const int MIN_LINES_PER_THREAD = 4;
 
-	if (rangeY >= 12 && rangeX >= rangeY * 4) {
+	const uint32_t renderTarget = gstate.getFrameBufAddress() & 0x0FFFFFFF;
+	bool selfRender = (gstate.getTextureAddress(0) & 0x0FFFFFFF) == renderTarget;
+	if (gstate.isMipmapEnabled()) {
+		for (int i = 0; i <= gstate.getTextureMaxLevel(); ++i)
+			selfRender = selfRender || (gstate.getTextureAddress(i) & 0x0FFFFFFF) == renderTarget;
+	}
+
+	if (rangeY >= 12 && rangeX >= rangeY * 4 && !selfRender) {
 		auto bound = [&](int a, int b) -> void {
 			int x1 = minX + a * 16 * 2;
 			int x2 = std::min(maxX, minX + b * 16 * 2 - 1);
 			drawSlice(v0, v1, v2, x1, minY, x2, maxY, pixelID, drawPixel, sampler);
 		};
 		ParallelRangeLoop(&g_threadManager, bound, 0, rangeX, MIN_LINES_PER_THREAD);
-	} else if (rangeY >= 12 && rangeX >= 12) {
+	} else if (rangeY >= 12 && rangeX >= 12 && !selfRender) {
 		auto bound = [&](int a, int b) -> void {
 			int y1 = minY + a * 16 * 2;
 			int y2 = std::min(maxY, minY + b * 16 * 2 - 1);


### PR DESCRIPTION
This actually fixes #11623.  I think it makes sense to draw from left top to bottom right, and is more likely what the PSP does anyway.

I've also made it just skip threading when rendering to self, since I don't think that'll ever be predictable.  In the case of Motorstorm, there's no impact on speed.

-[Unknown]