### PR TITLE
samplerjit: Fix alpha for 565 in linear lookup

### DIFF
--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -236,7 +236,10 @@ Vec4IntResult SOFTRAST_CALL GetTextureFunctionOutput(Vec4IntArg prim_color_in, V
 			else
 				out_rgb /= 256;
 		} else {
-			out_rgb = texcolor.rgb();
+			if (gstate.isColorDoublingEnabled())
+				out_rgb = texcolor.rgb() * 2;
+			else
+				out_rgb = texcolor.rgb();
 		}
 		out_a = prim_color.a();
 		break;

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -88,9 +88,9 @@ private:
 	bool Jit_GetTexData(const SamplerID &id, int bitsPerTexel);
 	bool Jit_GetTexDataSwizzled(const SamplerID &id, int bitsPerTexel);
 	bool Jit_GetTexDataSwizzled4(const SamplerID &id);
-	bool Jit_Decode5650();
-	bool Jit_Decode5551();
-	bool Jit_Decode4444();
+	bool Jit_Decode5650(const SamplerID &id);
+	bool Jit_Decode5551(const SamplerID &id);
+	bool Jit_Decode4444(const SamplerID &id);
 	bool Jit_TransformClutIndex(const SamplerID &id, int bitsPerIndex);
 	bool Jit_ReadClutColor(const SamplerID &id);
 	bool Jit_GetDXT1Color(const SamplerID &id, int blockSize, int alpha);

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -1578,6 +1578,8 @@ bool SamplerJitCache::Jit_ApplyTextureFunc(const SamplerID &id) {
 				PSRLW(resultReg, 7);
 			else
 				PSRLW(resultReg, 8);
+		} else if (id.useColorDoubling) {
+			PSLLW(resultReg, 1);
 		}
 		useAlphaFrom(primColorReg);
 		break;

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -3087,8 +3087,15 @@ bool SamplerJitCache::Jit_Decode5650Quad(const SamplerID &id, Rasterizer::RegCac
 	// Now shift and mask temp2 for swizzle.
 	PSRLD(temp2Reg, 6);
 	PAND(temp2Reg, M(const5650Swizzle_));
-	// And then OR that in too.  We're done.
+	// And then OR that in too.  Only alpha left now.
 	POR(quadReg, R(temp2Reg));
+
+	if (id.useTextureAlpha) {
+		// Just put a fixed FF in.  Maybe we could even avoid this and act like it's FF later...
+		PCMPEQD(temp2Reg, R(temp2Reg));
+		PSLLD(temp2Reg, 24);
+		POR(quadReg, R(temp2Reg));
+	}
 
 	regCache_.Release(temp1Reg, RegCache::VEC_TEMP1);
 	regCache_.Release(temp2Reg, RegCache::VEC_TEMP2);


### PR DESCRIPTION
Noticed this when checking some frame dumps - oops.  Also cleaned up a bit of other alpha handling.  Good example of this bug was #4109.

-[Unknown]