### PR TITLE
Compute func IDs and get func pointers once per prim call

### DIFF
--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -127,7 +127,7 @@ static void RotateUVThrough(const VertexData &tl, const VertexData &br, VertexDa
 	}
 }
 
-void ProcessTriangleInternal(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, bool fromRectangle);
+void ProcessTriangleInternal(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, const PixelFuncID &pixelID, const SamplerID &samplerID, bool fromRectangle);
 
 static inline bool CheckOutsideZ(ClipCoords p, int &pos, int &neg) {
 	constexpr float outsideValue = 1.000030517578125f;
@@ -143,8 +143,7 @@ static inline bool CheckOutsideZ(ClipCoords p, int &pos, int &neg) {
 	return false;
 }
 
-void ProcessRect(const VertexData& v0, const VertexData& v1)
-{
+void ProcessRect(const VertexData &v0, const VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID) {
 	if (!gstate.isModeThrough()) {
 		// We may discard the entire rect based on depth values.
 		int outsidePos = 0, outsideNeg = 0;
@@ -192,14 +191,14 @@ void ProcessRect(const VertexData& v0, const VertexData& v1)
 		}
 
 		// Four triangles to do backfaces as well. Two of them will get backface culled.
-		ProcessTriangleInternal(*topleft, *topright, *bottomright, buf[3], true);
-		ProcessTriangleInternal(*bottomright, *topright, *topleft, buf[3], true);
-		ProcessTriangleInternal(*bottomright, *bottomleft, *topleft, buf[3], true);
-		ProcessTriangleInternal(*topleft, *bottomleft, *bottomright, buf[3], true);
+		ProcessTriangleInternal(*topleft, *topright, *bottomright, buf[3], pixelID, samplerID, true);
+		ProcessTriangleInternal(*bottomright, *topright, *topleft, buf[3], pixelID, samplerID, true);
+		ProcessTriangleInternal(*bottomright, *bottomleft, *topleft, buf[3], pixelID, samplerID, true);
+		ProcessTriangleInternal(*topleft, *bottomleft, *bottomright, buf[3], pixelID, samplerID, true);
 	} else {
 		// through mode handling
 
-		if (Rasterizer::RectangleFastPath(v0, v1)) {
+		if (Rasterizer::RectangleFastPath(v0, v1, pixelID, samplerID)) {
 			return;
 		}
 
@@ -241,28 +240,26 @@ void ProcessRect(const VertexData& v0, const VertexData& v1)
 		RotateUVThrough(v0, v1, *topright, *bottomleft);
 
 		if (gstate.isModeClear()) {
-			Rasterizer::ClearRectangle(v0, v1);
+			Rasterizer::ClearRectangle(v0, v1, pixelID, samplerID);
 		} else {
 			// Four triangles to do backfaces as well. Two of them will get backface culled.
-			Rasterizer::DrawTriangle(*topleft, *topright, *bottomleft);
-			Rasterizer::DrawTriangle(*bottomleft, *topright, *topleft);
-			Rasterizer::DrawTriangle(*topright, *bottomright, *bottomleft);
-			Rasterizer::DrawTriangle(*bottomleft, *bottomright, *topright);
+			Rasterizer::DrawTriangle(*topleft, *topright, *bottomleft, pixelID, samplerID);
+			Rasterizer::DrawTriangle(*bottomleft, *topright, *topleft, pixelID, samplerID);
+			Rasterizer::DrawTriangle(*topright, *bottomright, *bottomleft, pixelID, samplerID);
+			Rasterizer::DrawTriangle(*bottomleft, *bottomright, *topright, pixelID, samplerID);
 		}
 	}
 }
 
-void ProcessPoint(VertexData& v0)
-{
+void ProcessPoint(VertexData &v0, const PixelFuncID &pixelID, const SamplerID &samplerID) {
 	// Points need no clipping. Will be bounds checked in the rasterizer (which seems backwards?)
-	Rasterizer::DrawPoint(v0);
+	Rasterizer::DrawPoint(v0, pixelID, samplerID);
 }
 
-void ProcessLine(VertexData& v0, VertexData& v1)
-{
+void ProcessLine(VertexData &v0, VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID) {
 	if (gstate.isModeThrough()) {
 		// Actually, should clip this one too so we don't need to do bounds checks in the rasterizer.
-		Rasterizer::DrawLine(v0, v1);
+		Rasterizer::DrawLine(v0, v1, pixelID, samplerID);
 		return;
 	}
 
@@ -289,19 +286,19 @@ void ProcessLine(VertexData& v0, VertexData& v1)
 	VertexData data[2] = { *Vertices[0], *Vertices[1] };
 	data[0].screenpos = TransformUnit::ClipToScreen(data[0].clippos);
 	data[1].screenpos = TransformUnit::ClipToScreen(data[1].clippos);
-	Rasterizer::DrawLine(data[0], data[1]);
+	Rasterizer::DrawLine(data[0], data[1], pixelID, samplerID);
 }
 
-void ProcessTriangleInternal(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, bool fromRectangle) {
+void ProcessTriangleInternal(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, const PixelFuncID &pixelID, const SamplerID &samplerID, bool fromRectangle) {
 	if (gstate.isModeThrough()) {
 		// In case of cull reordering, make sure the right color is on the final vertex.
 		if (gstate.getShadeMode() == GE_SHADE_FLAT) {
 			VertexData corrected2 = v2;
 			corrected2.color0 = provoking.color0;
 			corrected2.color1 = provoking.color1;
-			Rasterizer::DrawTriangle(v0, v1, corrected2);
+			Rasterizer::DrawTriangle(v0, v1, corrected2, pixelID, samplerID);
 		} else {
-			Rasterizer::DrawTriangle(v0, v1, v2);
+			Rasterizer::DrawTriangle(v0, v1, v2, pixelID, samplerID);
 		}
 		return;
 	}
@@ -385,13 +382,13 @@ void ProcessTriangleInternal(VertexData &v0, VertexData &v1, VertexData &v2, con
 				data[2].color1 = provoking.color1;
 			}
 
-			Rasterizer::DrawTriangle(data[0], data[1], data[2]);
+			Rasterizer::DrawTriangle(data[0], data[1], data[2], pixelID, samplerID);
 		}
 	}
 }
 
-void ProcessTriangle(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking) {
-	ProcessTriangleInternal(v0, v1, v2, provoking, false);
+void ProcessTriangle(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, const PixelFuncID &pixelID, const SamplerID &samplerID) {
+	ProcessTriangleInternal(v0, v1, v2, provoking, pixelID, samplerID, false);
 }
 
 } // namespace

--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -127,7 +127,7 @@ static void RotateUVThrough(const VertexData &tl, const VertexData &br, VertexDa
 	}
 }
 
-void ProcessTriangleInternal(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, const PixelFuncID &pixelID, const SamplerID &samplerID, bool fromRectangle);
+void ProcessTriangleInternal(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, const Rasterizer::RasterizerState &state, bool fromRectangle);
 
 static inline bool CheckOutsideZ(ClipCoords p, int &pos, int &neg) {
 	constexpr float outsideValue = 1.000030517578125f;
@@ -143,7 +143,7 @@ static inline bool CheckOutsideZ(ClipCoords p, int &pos, int &neg) {
 	return false;
 }
 
-void ProcessRect(const VertexData &v0, const VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID) {
+void ProcessRect(const VertexData &v0, const VertexData &v1, const Rasterizer::RasterizerState &state) {
 	if (!gstate.isModeThrough()) {
 		// We may discard the entire rect based on depth values.
 		int outsidePos = 0, outsideNeg = 0;
@@ -191,14 +191,14 @@ void ProcessRect(const VertexData &v0, const VertexData &v1, const PixelFuncID &
 		}
 
 		// Four triangles to do backfaces as well. Two of them will get backface culled.
-		ProcessTriangleInternal(*topleft, *topright, *bottomright, buf[3], pixelID, samplerID, true);
-		ProcessTriangleInternal(*bottomright, *topright, *topleft, buf[3], pixelID, samplerID, true);
-		ProcessTriangleInternal(*bottomright, *bottomleft, *topleft, buf[3], pixelID, samplerID, true);
-		ProcessTriangleInternal(*topleft, *bottomleft, *bottomright, buf[3], pixelID, samplerID, true);
+		ProcessTriangleInternal(*topleft, *topright, *bottomright, buf[3], state, true);
+		ProcessTriangleInternal(*bottomright, *topright, *topleft, buf[3], state, true);
+		ProcessTriangleInternal(*bottomright, *bottomleft, *topleft, buf[3], state, true);
+		ProcessTriangleInternal(*topleft, *bottomleft, *bottomright, buf[3], state, true);
 	} else {
 		// through mode handling
 
-		if (Rasterizer::RectangleFastPath(v0, v1, pixelID, samplerID)) {
+		if (Rasterizer::RectangleFastPath(v0, v1, state)) {
 			return;
 		}
 
@@ -240,26 +240,26 @@ void ProcessRect(const VertexData &v0, const VertexData &v1, const PixelFuncID &
 		RotateUVThrough(v0, v1, *topright, *bottomleft);
 
 		if (gstate.isModeClear()) {
-			Rasterizer::ClearRectangle(v0, v1, pixelID, samplerID);
+			Rasterizer::ClearRectangle(v0, v1, state);
 		} else {
 			// Four triangles to do backfaces as well. Two of them will get backface culled.
-			Rasterizer::DrawTriangle(*topleft, *topright, *bottomleft, pixelID, samplerID);
-			Rasterizer::DrawTriangle(*bottomleft, *topright, *topleft, pixelID, samplerID);
-			Rasterizer::DrawTriangle(*topright, *bottomright, *bottomleft, pixelID, samplerID);
-			Rasterizer::DrawTriangle(*bottomleft, *bottomright, *topright, pixelID, samplerID);
+			Rasterizer::DrawTriangle(*topleft, *topright, *bottomleft, state);
+			Rasterizer::DrawTriangle(*bottomleft, *topright, *topleft, state);
+			Rasterizer::DrawTriangle(*topright, *bottomright, *bottomleft, state);
+			Rasterizer::DrawTriangle(*bottomleft, *bottomright, *topright, state);
 		}
 	}
 }
 
-void ProcessPoint(VertexData &v0, const PixelFuncID &pixelID, const SamplerID &samplerID) {
+void ProcessPoint(VertexData &v0, const Rasterizer::RasterizerState &state) {
 	// Points need no clipping. Will be bounds checked in the rasterizer (which seems backwards?)
-	Rasterizer::DrawPoint(v0, pixelID, samplerID);
+	Rasterizer::DrawPoint(v0, state);
 }
 
-void ProcessLine(VertexData &v0, VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID) {
+void ProcessLine(VertexData &v0, VertexData &v1, const Rasterizer::RasterizerState &state) {
 	if (gstate.isModeThrough()) {
 		// Actually, should clip this one too so we don't need to do bounds checks in the rasterizer.
-		Rasterizer::DrawLine(v0, v1, pixelID, samplerID);
+		Rasterizer::DrawLine(v0, v1, state);
 		return;
 	}
 
@@ -286,19 +286,19 @@ void ProcessLine(VertexData &v0, VertexData &v1, const PixelFuncID &pixelID, con
 	VertexData data[2] = { *Vertices[0], *Vertices[1] };
 	data[0].screenpos = TransformUnit::ClipToScreen(data[0].clippos);
 	data[1].screenpos = TransformUnit::ClipToScreen(data[1].clippos);
-	Rasterizer::DrawLine(data[0], data[1], pixelID, samplerID);
+	Rasterizer::DrawLine(data[0], data[1], state);
 }
 
-void ProcessTriangleInternal(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, const PixelFuncID &pixelID, const SamplerID &samplerID, bool fromRectangle) {
+void ProcessTriangleInternal(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, const Rasterizer::RasterizerState &state, bool fromRectangle) {
 	if (gstate.isModeThrough()) {
 		// In case of cull reordering, make sure the right color is on the final vertex.
 		if (gstate.getShadeMode() == GE_SHADE_FLAT) {
 			VertexData corrected2 = v2;
 			corrected2.color0 = provoking.color0;
 			corrected2.color1 = provoking.color1;
-			Rasterizer::DrawTriangle(v0, v1, corrected2, pixelID, samplerID);
+			Rasterizer::DrawTriangle(v0, v1, corrected2, state);
 		} else {
-			Rasterizer::DrawTriangle(v0, v1, v2, pixelID, samplerID);
+			Rasterizer::DrawTriangle(v0, v1, v2, state);
 		}
 		return;
 	}
@@ -382,13 +382,13 @@ void ProcessTriangleInternal(VertexData &v0, VertexData &v1, VertexData &v2, con
 				data[2].color1 = provoking.color1;
 			}
 
-			Rasterizer::DrawTriangle(data[0], data[1], data[2], pixelID, samplerID);
+			Rasterizer::DrawTriangle(data[0], data[1], data[2], state);
 		}
 	}
 }
 
-void ProcessTriangle(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, const PixelFuncID &pixelID, const SamplerID &samplerID) {
-	ProcessTriangleInternal(v0, v1, v2, provoking, pixelID, samplerID, false);
+void ProcessTriangle(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, const Rasterizer::RasterizerState &state) {
+	ProcessTriangleInternal(v0, v1, v2, provoking, state, false);
 }
 
 } // namespace

--- a/GPU/Software/Clipper.h
+++ b/GPU/Software/Clipper.h
@@ -22,11 +22,15 @@
 struct PixelFuncID;
 struct SamplerID;
 
+namespace Rasterizer {
+struct RasterizerState;
+};
+
 namespace Clipper {
 
-void ProcessPoint(VertexData &v0, const PixelFuncID &pixelID, const SamplerID &samplerID);
-void ProcessLine(VertexData &v0, VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID);
-void ProcessTriangle(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, const PixelFuncID &pixelID, const SamplerID &samplerID);
-void ProcessRect(const VertexData &v0, const VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID);
+void ProcessPoint(VertexData &v0, const Rasterizer::RasterizerState &state);
+void ProcessLine(VertexData &v0, VertexData &v1, const Rasterizer::RasterizerState &state);
+void ProcessTriangle(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, const Rasterizer::RasterizerState &state);
+void ProcessRect(const VertexData &v0, const VertexData &v1, const Rasterizer::RasterizerState &state);
 
 }

--- a/GPU/Software/Clipper.h
+++ b/GPU/Software/Clipper.h
@@ -19,11 +19,14 @@
 
 #include "TransformUnit.h"
 
+struct PixelFuncID;
+struct SamplerID;
+
 namespace Clipper {
 
-void ProcessPoint(VertexData& v0);
-void ProcessLine(VertexData& v0, VertexData& v1);
-void ProcessTriangle(VertexData& v0, VertexData& v1, VertexData& v2, const VertexData &provoking);
-void ProcessRect(const VertexData& v0, const VertexData& v1);
+void ProcessPoint(VertexData &v0, const PixelFuncID &pixelID, const SamplerID &samplerID);
+void ProcessLine(VertexData &v0, VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID);
+void ProcessTriangle(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, const PixelFuncID &pixelID, const SamplerID &samplerID);
+void ProcessRect(const VertexData &v0, const VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID);
 
 }

--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -185,8 +185,10 @@ static inline bool ColorTestPassed(const Vec3<int> &color) {
 
 	case GE_COMP_NOTEQUAL:
 		return c != ref;
+
+	default:
+		return true;
 	}
-	return true;
 }
 
 static inline bool StencilTestPassed(const PixelFuncID &pixelID, u8 stencil) {

--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -31,10 +31,10 @@ struct GPUDebugBuffer;
 namespace Rasterizer {
 
 // Draws a triangle if its vertices are specified in counter-clockwise order
-void DrawTriangle(const VertexData& v0, const VertexData& v1, const VertexData& v2);
-void DrawPoint(const VertexData &v0);
-void DrawLine(const VertexData &v0, const VertexData &v1);
-void ClearRectangle(const VertexData &v0, const VertexData &v1);
+void DrawTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2, const PixelFuncID &pixelID, const SamplerID &samplerID);
+void DrawPoint(const VertexData &v0, const PixelFuncID &pixelID, const SamplerID &samplerID);
+void DrawLine(const VertexData &v0, const VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID);
+void ClearRectangle(const VertexData &v0, const VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID);
 
 bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);
 bool GetCurrentTexture(GPUDebugBuffer &buffer, int level);

--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -17,8 +17,10 @@
 
 #pragma once
 
+#include "GPU/Software/DrawPixel.h"
 #include "GPU/Software/FuncId.h"
 #include "GPU/Software/RasterizerRegCache.h"
+#include "GPU/Software/Sampler.h"
 #include "GPU/Software/TransformUnit.h" // for DrawingCoords
 
 #ifdef _DEBUG
@@ -30,11 +32,19 @@ struct GPUDebugBuffer;
 
 namespace Rasterizer {
 
+struct RasterizerState {
+	PixelFuncID pixelID;
+	SamplerID samplerID;
+	SingleFunc drawPixel;
+	Sampler::LinearFunc linear;
+	Sampler::NearestFunc nearest;
+};
+
 // Draws a triangle if its vertices are specified in counter-clockwise order
-void DrawTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2, const PixelFuncID &pixelID, const SamplerID &samplerID);
-void DrawPoint(const VertexData &v0, const PixelFuncID &pixelID, const SamplerID &samplerID);
-void DrawLine(const VertexData &v0, const VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID);
-void ClearRectangle(const VertexData &v0, const VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID);
+void DrawTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2, const RasterizerState &state);
+void DrawPoint(const VertexData &v0, const RasterizerState &state);
+void DrawLine(const VertexData &v0, const VertexData &v1, const RasterizerState &state);
+void ClearRectangle(const VertexData &v0, const VertexData &v1, const RasterizerState &state);
 
 bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);
 bool GetCurrentTexture(GPUDebugBuffer &buffer, int level);

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -47,7 +47,7 @@ inline void DrawSinglePixel5551(u16 *pixel, const u32 color_in, const PixelFuncI
 	*pixel = RGBA8888ToRGBA5551(new_color);
 }
 
-static inline Vec4IntResult SOFTRAST_CALL ModulateRGBA(Vec4IntArg prim_in, Vec4IntArg texcolor_in) {
+static inline Vec4IntResult SOFTRAST_CALL ModulateRGBA(Vec4IntArg prim_in, Vec4IntArg texcolor_in, const SamplerID &samplerID) {
 	Vec4<int> out;
 	Vec4<int> prim_color = prim_in;
 	Vec4<int> texcolor = texcolor_in;
@@ -57,7 +57,7 @@ static inline Vec4IntResult SOFTRAST_CALL ModulateRGBA(Vec4IntArg prim_in, Vec4I
 	const __m128i p = _mm_slli_epi16(_mm_packs_epi32(prim_color.ivec, prim_color.ivec), 4);
 	const __m128i pboost = _mm_add_epi16(p, _mm_set1_epi16(1 << 4));
 	__m128i t = _mm_slli_epi16(_mm_packs_epi32(texcolor.ivec, texcolor.ivec), 4);
-	if (gstate.isColorDoublingEnabled()) {
+	if (samplerID.useColorDoubling) {
 		const __m128i amask = _mm_set_epi16(-1, 0, 0, 0, -1, 0, 0, 0);
 		const __m128i a = _mm_and_si128(t, amask);
 		const __m128i rgb = _mm_andnot_si128(amask, t);
@@ -66,7 +66,7 @@ static inline Vec4IntResult SOFTRAST_CALL ModulateRGBA(Vec4IntArg prim_in, Vec4I
 	const __m128i b = _mm_mulhi_epi16(pboost, t);
 	out.ivec = _mm_unpacklo_epi16(b, _mm_setzero_si128());
 #else
-	if (gstate.isColorDoublingEnabled()) {
+	if (samplerID.useColorDoubling) {
 		Vec4<int> tex = texcolor * Vec4<int>(2, 2, 2, 1);
 		out = ((prim_color + Vec4<int>::AssignToAll(1)) * tex) / 256;
 	} else {
@@ -77,19 +77,19 @@ static inline Vec4IntResult SOFTRAST_CALL ModulateRGBA(Vec4IntArg prim_in, Vec4I
 	return ToVec4IntResult(out);
 }
 
-void DrawSprite(const VertexData &v0, const VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID) {
+void DrawSprite(const VertexData &v0, const VertexData &v1, const RasterizerState &state) {
 	const u8 *texptr = nullptr;
 
-	GETextureFormat texfmt = samplerID.TexFmt();
+	GETextureFormat texfmt = state.samplerID.TexFmt();
 	u32 texaddr = gstate.getTextureAddress(0);
 	int texbufw = GetTextureBufw(0, texaddr, texfmt);
 	if (Memory::IsValidAddress(texaddr))
 		texptr = Memory::GetPointerUnchecked(texaddr);
 
 	ScreenCoords pprime(v0.screenpos.x, v0.screenpos.y, 0);
-	Sampler::FetchFunc fetchFunc = Sampler::GetFetchFunc(samplerID);
-	Sampler::NearestFunc nearestFunc = Sampler::GetNearestFunc(samplerID);
-	Rasterizer::SingleFunc drawPixel = Rasterizer::GetSingleFunc(pixelID);
+	Sampler::FetchFunc fetchFunc = Sampler::GetFetchFunc(state.samplerID);
+	auto &pixelID = state.pixelID;
+	auto &samplerID = state.samplerID;
 
 	DrawingCoords pos0 = TransformUnit::ScreenToDrawing(v0.screenpos);
 	// Include the ending pixel based on its center, not start.
@@ -172,7 +172,7 @@ void DrawSprite(const VertexData &v0, const VertexData &v1, const PixelFuncID &p
 						for (int x = pos0.x; x < pos1.x; x++) {
 							Vec4<int> prim_color = v1.color0;
 							Vec4<int> tex_color = fetchFunc(s, t, texptr, texbufw, 0);
-							prim_color = Vec4<int>(ModulateRGBA(ToVec4IntArg(prim_color), ToVec4IntArg(tex_color)));
+							prim_color = Vec4<int>(ModulateRGBA(ToVec4IntArg(prim_color), ToVec4IntArg(tex_color), state.samplerID));
 							if (prim_color.a() > 0) {
 								DrawSinglePixel5551(pixel, prim_color.ToRGBA(), pixelID);
 							}
@@ -198,8 +198,8 @@ void DrawSprite(const VertexData &v0, const VertexData &v1, const PixelFuncID &p
 					float s = sf_start;
 					// Not really that fast but faster than triangle.
 					for (int x = pos0.x; x < pos1.x; x++) {
-						Vec4<int> prim_color = nearestFunc(s, t, xoff, yoff, ToVec4IntArg(v1.color0), &texptr, &texbufw, 0, 0);
-						drawPixel(x, y, z, 255, ToVec4IntArg(prim_color), pixelID);
+						Vec4<int> prim_color = state.nearest(s, t, xoff, yoff, ToVec4IntArg(v1.color0), &texptr, &texbufw, 0, 0);
+						state.drawPixel(x, y, z, 255, ToVec4IntArg(prim_color), pixelID);
 						s += dsf;
 					}
 					t += dtf;
@@ -243,7 +243,7 @@ void DrawSprite(const VertexData &v0, const VertexData &v1, const PixelFuncID &p
 				for (int y = y1; y < y2; y++) {
 					for (int x = pos0.x; x < pos1.x; x++) {
 						Vec4<int> prim_color = v1.color0;
-						drawPixel(x, y, z, fog, ToVec4IntArg(prim_color), pixelID);
+						state.drawPixel(x, y, z, fog, ToVec4IntArg(prim_color), pixelID);
 					}
 				}
 			}, pos0.y, pos1.y, MIN_LINES_PER_THREAD);
@@ -279,7 +279,7 @@ static inline bool NoClampOrWrap(const Vec2f &tc) {
 }
 
 // Returns true if the normal path should be skipped.
-bool RectangleFastPath(const VertexData &v0, const VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID) {
+bool RectangleFastPath(const VertexData &v0, const VertexData &v1, const RasterizerState &state) {
 	g_DarkStalkerStretch = DSStretch::Off;
 	// Check for 1:1 texture mapping. In that case we can call DrawSprite.
 	int xdiff = v1.screenpos.x - v0.screenpos.x;
@@ -292,10 +292,10 @@ bool RectangleFastPath(const VertexData &v0, const VertexData &v1, const PixelFu
 	// Currently only works for TL/BR, which is the most common but not required.
 	bool orient_check = xdiff >= 0 && ydiff >= 0;
 	// We already have a fast path for clear in ClearRectangle.
-	bool state_check = !pixelID.clearMode && NoClampOrWrap(v0.texturecoords) && NoClampOrWrap(v1.texturecoords);
+	bool state_check = !state.pixelID.clearMode && NoClampOrWrap(v0.texturecoords) && NoClampOrWrap(v1.texturecoords);
 	// TODO: No mipmap levels?  Might be a font at level 1...
 	if ((coord_check || !gstate.isTextureMapEnabled()) && orient_check && state_check) {
-		Rasterizer::DrawSprite(v0, v1, pixelID, samplerID);
+		Rasterizer::DrawSprite(v0, v1, state);
 		return true;
 	}
 
@@ -317,7 +317,7 @@ bool RectangleFastPath(const VertexData &v0, const VertexData &v1, const PixelFu
 				gstate.textureMapEnable &= ~1;
 				VertexData newV1 = v1;
 				newV1.color0 = Vec4<int>(0, 0, 0, 255);
-				Rasterizer::DrawSprite(v0, newV1, pixelID, samplerID);
+				Rasterizer::DrawSprite(v0, newV1, state);
 				gstate.textureMapEnable |= 1;
 			}
 			return true;

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -77,7 +77,7 @@ static inline Vec4IntResult SOFTRAST_CALL ModulateRGBA(Vec4IntArg prim_in, Vec4I
 	return ToVec4IntResult(out);
 }
 
-void DrawSprite(const VertexData& v0, const VertexData& v1) {
+void DrawSprite(const VertexData &v0, const VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID) {
 	const u8 *texptr = nullptr;
 
 	GETextureFormat texfmt = gstate.getTextureFormat();
@@ -85,12 +85,6 @@ void DrawSprite(const VertexData& v0, const VertexData& v1) {
 	int texbufw = GetTextureBufw(0, texaddr, texfmt);
 	if (Memory::IsValidAddress(texaddr))
 		texptr = Memory::GetPointerUnchecked(texaddr);
-
-	// These look at gstate.
-	SamplerID samplerID;
-	ComputeSamplerID(&samplerID);
-	PixelFuncID pixelID;
-	ComputePixelFuncID(&pixelID);
 
 	ScreenCoords pprime(v0.screenpos.x, v0.screenpos.y, 0);
 	Sampler::FetchFunc fetchFunc = Sampler::GetFetchFunc(samplerID);
@@ -285,7 +279,7 @@ static inline bool NoClampOrWrap(const Vec2f &tc) {
 }
 
 // Returns true if the normal path should be skipped.
-bool RectangleFastPath(const VertexData &v0, const VertexData &v1) {
+bool RectangleFastPath(const VertexData &v0, const VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID) {
 	g_DarkStalkerStretch = DSStretch::Off;
 	// Check for 1:1 texture mapping. In that case we can call DrawSprite.
 	int xdiff = v1.screenpos.x - v0.screenpos.x;
@@ -301,7 +295,7 @@ bool RectangleFastPath(const VertexData &v0, const VertexData &v1) {
 	bool state_check = !gstate.isModeClear() && NoClampOrWrap(v0.texturecoords) && NoClampOrWrap(v1.texturecoords);
 	// TODO: No mipmap levels?  Might be a font at level 1...
 	if ((coord_check || !gstate.isTextureMapEnabled()) && orient_check && state_check) {
-		Rasterizer::DrawSprite(v0, v1);
+		Rasterizer::DrawSprite(v0, v1, pixelID, samplerID);
 		return true;
 	}
 
@@ -323,7 +317,7 @@ bool RectangleFastPath(const VertexData &v0, const VertexData &v1) {
 				gstate.textureMapEnable &= ~1;
 				VertexData newV1 = v1;
 				newV1.color0 = Vec4<int>(0, 0, 0, 255);
-				Rasterizer::DrawSprite(v0, newV1);
+				Rasterizer::DrawSprite(v0, newV1, pixelID, samplerID);
 				gstate.textureMapEnable |= 1;
 			}
 			return true;

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -80,7 +80,7 @@ static inline Vec4IntResult SOFTRAST_CALL ModulateRGBA(Vec4IntArg prim_in, Vec4I
 void DrawSprite(const VertexData &v0, const VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID) {
 	const u8 *texptr = nullptr;
 
-	GETextureFormat texfmt = gstate.getTextureFormat();
+	GETextureFormat texfmt = samplerID.TexFmt();
 	u32 texaddr = gstate.getTextureAddress(0);
 	int texbufw = GetTextureBufw(0, texaddr, texfmt);
 	if (Memory::IsValidAddress(texaddr))
@@ -142,8 +142,8 @@ void DrawSprite(const VertexData &v0, const VertexData &v1, const PixelFuncID &p
 			pixelID.alphaTestRef == 0 &&
 			!pixelID.hasAlphaTestMask &&
 			pixelID.alphaBlend &&
-			gstate.isTextureAlphaUsed() &&
-			gstate.getTextureFunction() == GE_TEXFUNC_MODULATE &&
+			samplerID.useTextureAlpha &&
+			samplerID.TexFunc() == GE_TEXFUNC_MODULATE &&
 			!pixelID.applyColorWriteMask &&
 			pixelID.FBFormat() == GE_FORMAT_5551) {
 			if (isWhite) {
@@ -221,8 +221,8 @@ void DrawSprite(const VertexData &v0, const VertexData &v1, const PixelFuncID &p
 			pixelID.alphaTestRef == 0 &&
 			!pixelID.hasAlphaTestMask &&
 			pixelID.alphaBlend &&
-			gstate.isTextureAlphaUsed() &&
-			gstate.getTextureFunction() == GE_TEXFUNC_MODULATE &&
+			samplerID.useTextureAlpha &&
+			samplerID.TexFunc() == GE_TEXFUNC_MODULATE &&
 			!pixelID.applyColorWriteMask &&
 			pixelID.FBFormat() == GE_FORMAT_5551) {
 			if (v1.color0.a() == 0)
@@ -292,7 +292,7 @@ bool RectangleFastPath(const VertexData &v0, const VertexData &v1, const PixelFu
 	// Currently only works for TL/BR, which is the most common but not required.
 	bool orient_check = xdiff >= 0 && ydiff >= 0;
 	// We already have a fast path for clear in ClearRectangle.
-	bool state_check = !gstate.isModeClear() && NoClampOrWrap(v0.texturecoords) && NoClampOrWrap(v1.texturecoords);
+	bool state_check = !pixelID.clearMode && NoClampOrWrap(v0.texturecoords) && NoClampOrWrap(v1.texturecoords);
 	// TODO: No mipmap levels?  Might be a font at level 1...
 	if ((coord_check || !gstate.isTextureMapEnabled()) && orient_check && state_check) {
 		Rasterizer::DrawSprite(v0, v1, pixelID, samplerID);

--- a/GPU/Software/RasterizerRectangle.h
+++ b/GPU/Software/RasterizerRectangle.h
@@ -14,7 +14,7 @@
 
 namespace Rasterizer {
 	// Returns true if the normal path should be skipped.
-	bool RectangleFastPath(const VertexData &v0, const VertexData &v1);
+	bool RectangleFastPath(const VertexData &v0, const VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID);
 
 	bool DetectRectangleFromThroughModeStrip(const VertexData data[4]);
 	bool DetectRectangleFromThroughModeFan(const VertexData *data, int c, int *tlIndex, int *brIndex);

--- a/GPU/Software/RasterizerRectangle.h
+++ b/GPU/Software/RasterizerRectangle.h
@@ -14,7 +14,7 @@
 
 namespace Rasterizer {
 	// Returns true if the normal path should be skipped.
-	bool RectangleFastPath(const VertexData &v0, const VertexData &v1, const PixelFuncID &pixelID, const SamplerID &samplerID);
+	bool RectangleFastPath(const VertexData &v0, const VertexData &v1, const RasterizerState &state);
 
 	bool DetectRectangleFromThroughModeStrip(const VertexData data[4]);
 	bool DetectRectangleFromThroughModeFan(const VertexData *data, int c, int *tlIndex, int *brIndex);

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -42,19 +42,6 @@ NearestFunc GetNearestFunc(SamplerID id);
 typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *LinearFunc)(float s, float t, int x, int y, Rasterizer::Vec4IntArg prim_color, const u8 *const *tptr, const int *bufw, int level, int levelFrac);
 LinearFunc GetLinearFunc(SamplerID id);
 
-struct Funcs {
-	NearestFunc nearest;
-	LinearFunc linear;
-};
-static inline Funcs GetFuncs() {
-	Funcs f;
-	SamplerID id;
-	ComputeSamplerID(&id);
-	f.nearest = GetNearestFunc(id);
-	f.linear = GetLinearFunc(id);
-	return f;
-}
-
 void Init();
 void Shutdown();
 


### PR DESCRIPTION
This moves the computation up the chain, some of which was happening on each thread and had some locking.  This is more or less necessary for future threading improvements.

It also improves performance by around 1-3%, especially in complex areas.  LittleBigPlanet is at ~99% speed or so now (on a powerful CPU.)

-[Unknown]