### PR TITLE
Process verts within a draw call in binned threads within softgpu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1583,6 +1583,8 @@ set(GPU_SOURCES
 	GPU/GPUState.h
 	GPU/Math3D.cpp
 	GPU/Math3D.h
+	GPU/Software/BinManager.cpp
+	GPU/Software/BinManager.h
 	GPU/Software/Clipper.cpp
 	GPU/Software/Clipper.h
 	GPU/Software/DrawPixel.cpp

--- a/Common/Thread/ThreadManager.cpp
+++ b/Common/Thread/ThreadManager.cpp
@@ -258,13 +258,13 @@ void ThreadManager::EnqueueTask(Task *task) {
 	chosenThread->cond.notify_one();
 }
 
-void ThreadManager::EnqueueTaskOnThread(int threadNum, Task *task) {
+void ThreadManager::EnqueueTaskOnThread(int threadNum, Task *task, bool enforceSequence) {
 	_assert_msg_(threadNum >= 0 && threadNum < (int)global_->threads_.size(), "Bad threadnum or not initialized");
 	ThreadContext *thread = global_->threads_[threadNum];
 
 	// Try first atomically, as highest priority.
 	Task *expected = nullptr;
-	bool queued = thread->private_single.compare_exchange_weak(expected, task);
+	bool queued = !enforceSequence && thread->private_single.compare_exchange_weak(expected, task);
 	// Whether we got that or will have to wait, increase the queue counter.
 	thread->queue_size++;
 

--- a/Common/Thread/ThreadManager.h
+++ b/Common/Thread/ThreadManager.h
@@ -46,7 +46,8 @@ public:
 	// just ignore it and let the OS handle it.
 	void Init(int numCores, int numLogicalCoresPerCpu);
 	void EnqueueTask(Task *task);
-	void EnqueueTaskOnThread(int threadNum, Task *task);
+	// Use enforceSequence if this must run after all previously queued tasks.
+	void EnqueueTaskOnThread(int threadNum, Task *task, bool enforceSequence = false);
 	void Teardown();
 
 	bool IsInitialized() const;

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -452,6 +452,7 @@
     <ClInclude Include="GPUInterface.h" />
     <ClInclude Include="GPUState.h" />
     <ClInclude Include="Math3D.h" />
+    <ClInclude Include="Software\BinManager.h" />
     <ClInclude Include="Software\Clipper.h" />
     <ClInclude Include="Software\DrawPixel.h" />
     <ClInclude Include="Software\Lighting.h" />
@@ -630,6 +631,7 @@
     <ClCompile Include="GPUCommon.cpp" />
     <ClCompile Include="GPUState.cpp" />
     <ClCompile Include="Math3D.cpp" />
+    <ClCompile Include="Software\BinManager.cpp" />
     <ClCompile Include="Software\Clipper.cpp" />
     <ClCompile Include="Software\DrawPixel.cpp" />
     <ClCompile Include="Software\DrawPixelX86.cpp" />

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -276,6 +276,9 @@
     <ClInclude Include="Software\RasterizerRegCache.h">
       <Filter>Software</Filter>
     </ClInclude>
+    <ClInclude Include="Software\BinManager.h">
+      <Filter>Software</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Math3D.cpp">
@@ -552,6 +555,9 @@
       <Filter>Software</Filter>
     </ClCompile>
     <ClCompile Include="Software\RasterizerRegCache.cpp">
+      <Filter>Software</Filter>
+    </ClCompile>
+    <ClCompile Include="Software\BinManager.cpp">
       <Filter>Software</Filter>
     </ClCompile>
   </ItemGroup>

--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -15,21 +15,110 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include "Common/Thread/ThreadManager.h"
 #include "GPU/Software/BinManager.h"
 #include "GPU/Software/Rasterizer.h"
 #include "GPU/Software/RasterizerRectangle.h"
+
+using namespace Rasterizer;
+
+struct BinWaitable : public Waitable {
+public:
+	BinWaitable() {
+		count_ = 0;
+	}
+
+	void Fill() {
+		count_++;
+	}
+
+	void Drain() {
+		int result = --count_;
+		if (result == 0) {
+			// We were the last one to increment.
+			std::unique_lock<std::mutex> lock(mutex_);
+			cond_.notify_all();
+		}
+	}
+
+	void Wait() override {
+		std::unique_lock<std::mutex> lock(mutex_);
+		while (count_ != 0) {
+			cond_.wait(lock);
+		}
+	}
+
+	std::atomic<int> count_;
+	std::mutex mutex_;
+	std::condition_variable cond_;
+};
+
+static inline void DrawBinItem(const BinItem &item, const RasterizerState &state) {
+	switch (item.type) {
+	case BinItemType::TRIANGLE:
+		DrawTriangle(item.v0, item.v1, item.v2, item.range, state);
+		break;
+
+	case BinItemType::CLEAR_RECT:
+		ClearRectangle(item.v0, item.v1, item.range, state);
+		break;
+
+	case BinItemType::SPRITE:
+		DrawSprite(item.v0, item.v1, item.range, state);
+		break;
+
+	case BinItemType::LINE:
+		DrawLine(item.v0, item.v1, item.range, state);
+		break;
+
+	case BinItemType::POINT:
+		DrawPoint(item.v0, item.range, state);
+		break;
+	}
+}
+
+class DrawBinItemTask : public Task {
+public:
+	DrawBinItemTask(BinWaitable *notify, const BinItem &item, const BinCoords &range, const RasterizerState &state)
+		: notify_(notify), item_(item), state_(state) {
+		item_.range = range;
+	}
+
+	TaskType Type() const override {
+		return TaskType::CPU_COMPUTE;
+	}
+
+	void Run() override {
+		DrawBinItem(item_, state_);
+		notify_->Drain();
+	}
+
+	BinWaitable *notify_;
+	BinItem item_;
+	const RasterizerState &state_;
+};
 
 BinManager::BinManager() {
 	queueRange_.x1 = 0x7FFFFFFF;
 	queueRange_.y1 = 0x7FFFFFFF;
 	queueRange_.x2 = 0;
 	queueRange_.y2 = 0;
+
+	waitable_ = new BinWaitable();
+}
+
+BinManager::~BinManager() {
+	delete waitable_;
 }
 
 void BinManager::UpdateState() {
-	stateIndex_ = (int)states_.size();
-	states_.resize(states_.size() + 1);
-	ComputeRasterizerState(&states_.back());
+	if (states_.Full())
+		Flush();
+	stateIndex_ = (int)states_.Push(RasterizerState());
+	ComputeRasterizerState(&states_[stateIndex_]);
 
 	DrawingCoords scissorTL(gstate.getScissorX1(), gstate.getScissorY1(), 0);
 	DrawingCoords scissorBR(gstate.getScissorX2(), gstate.getScissorY2(), 0);
@@ -40,6 +129,20 @@ void BinManager::UpdateState() {
 	scissor_.y1 = screenScissorTL.y;
 	scissor_.x2 = screenScissorBR.x + 15;
 	scissor_.y2 = screenScissorBR.y + 15;
+
+	// Disallow threads when rendering to target.
+	const uint32_t renderTarget = gstate.getFrameBufAddress() & 0x0FFFFFFF;
+	bool selfRender = (gstate.getTextureAddress(0) & 0x0FFFFFFF) == renderTarget;
+	if (gstate.isMipmapEnabled()) {
+		for (int i = 0; i <= gstate.getTextureMaxLevel(); ++i)
+			selfRender = selfRender || (gstate.getTextureAddress(i) & 0x0FFFFFFF) == renderTarget;
+	}
+
+	int newMaxTasks = selfRender ? 1 : g_threadManager.GetNumLooperThreads();
+	if (maxTasks_ != newMaxTasks) {
+		maxTasks_ = newMaxTasks;
+		tasksSplit_ = false;
+	}
 }
 
 void BinManager::AddTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2) {
@@ -56,76 +159,118 @@ void BinManager::AddTriangle(const VertexData &v0, const VertexData &v1, const V
 
 	// Was it fully outside the scissor?
 	const BinCoords range = Range(v0, v1, v2);
-	if (range.x2 < range.x1 || range.y2 < range.y1)
+	if (range.Invalid())
 		return;
 
-	queue_.push_back(BinItem{ BinItemType::TRIANGLE, stateIndex_, range, v0, v1, v2 });
+	if (queue_.Full())
+		Drain();
+	queue_.Push(BinItem{ BinItemType::TRIANGLE, stateIndex_, range, v0, v1, v2 });
 	Expand(range);
 }
 
 void BinManager::AddClearRect(const VertexData &v0, const VertexData &v1) {
 	const BinCoords range = Range(v0, v1);
-	if (range.x2 < range.x1 || range.y2 < range.y1)
+	if (range.Invalid())
 		return;
 
-	queue_.push_back(BinItem{ BinItemType::CLEAR_RECT, stateIndex_, range, v0, v1 });
+	if (queue_.Full())
+		Drain();
+	queue_.Push(BinItem{ BinItemType::CLEAR_RECT, stateIndex_, range, v0, v1 });
 	Expand(range);
 }
 
 void BinManager::AddSprite(const VertexData &v0, const VertexData &v1) {
 	const BinCoords range = Range(v0, v1);
-	if (range.x2 < range.x1 || range.y2 < range.y1)
+	if (range.Invalid())
 		return;
 
-	queue_.push_back(BinItem{ BinItemType::SPRITE, stateIndex_, range, v0, v1 });
+	if (queue_.Full())
+		Drain();
+	queue_.Push(BinItem{ BinItemType::SPRITE, stateIndex_, range, v0, v1 });
 	Expand(range);
 }
 
 void BinManager::AddLine(const VertexData &v0, const VertexData &v1) {
 	const BinCoords range = Range(v0, v1);
-	if (range.x2 < range.x1 || range.y2 < range.y1)
+	if (range.Invalid())
 		return;
 
-	queue_.push_back(BinItem{ BinItemType::LINE, stateIndex_, range, v0, v1 });
+	if (queue_.Full())
+		Drain();
+	queue_.Push(BinItem{ BinItemType::LINE, stateIndex_, range, v0, v1 });
 	Expand(range);
 }
 
 void BinManager::AddPoint(const VertexData &v0) {
 	const BinCoords range = Range(v0);
-	if (range.x2 < range.x1 || range.y2 < range.y1)
+	if (range.Invalid())
 		return;
 
-	queue_.push_back(BinItem{ BinItemType::POINT, stateIndex_, range, v0 });
+	if (queue_.Full())
+		Drain();
+	queue_.Push(BinItem{ BinItemType::POINT, stateIndex_, range, v0 });
 	Expand(range);
 }
 
-void BinManager::Flush() {
-	for (const BinItem &item : queue_) {
-		switch (item.type) {
-		case BinItemType::TRIANGLE:
-			Rasterizer::DrawTriangle(item.v0, item.v1, item.v2, item.range, states_[item.stateIndex]);
-			break;
+void BinManager::Drain() {
+	// TODO: Could redecide here if waitable is all drained.
+	if (!tasksSplit_) {
+		int w2 = (queueRange_.x2 - queueRange_.x1 + 31) / 32;
+		int h2 = (queueRange_.y2 - queueRange_.y1 + 31) / 32;
 
-		case BinItemType::CLEAR_RECT:
-			Rasterizer::ClearRectangle(item.v0, item.v1, item.range, states_[item.stateIndex]);
-			break;
+		// Always bin the entire possible range, but focus on the drawn area.
+		ScreenCoords tl = TransformUnit::DrawingToScreen(DrawingCoords(0, 0, 0));
+		ScreenCoords br = TransformUnit::DrawingToScreen(DrawingCoords(1024, 1024, 0));
 
-		case BinItemType::SPRITE:
-			Rasterizer::DrawSprite(item.v0, item.v1, item.range, states_[item.stateIndex]);
-			break;
+		if (h2 >= 12 && w2 >= h2 * 4) {
+			int bin_w = std::max(4, (w2 + maxTasks_ - 1) / maxTasks_) * 32;
+			taskRanges_.push_back(BinCoords{ tl.x, tl.y, queueRange_.x1 + bin_w - 1, br.y - 1 });
+			for (int x = queueRange_.x1 + bin_w; x <= queueRange_.x2; x += bin_w) {
+				int x2 = x + bin_w > queueRange_.x2 ? br.x : x + bin_w;
+				taskRanges_.push_back(BinCoords{ x, tl.y, x2 - 1, br.y - 1 });
+			}
+		} else if (h2 >= 12 && w2 >= 12) {
+			int bin_h = std::max(4, (h2 + maxTasks_ - 1) / maxTasks_) * 32;
+			taskRanges_.push_back(BinCoords{ tl.x, tl.y, br.x - 1, queueRange_.y1 + bin_h - 1 });
+			for (int y = queueRange_.y1 + bin_h; y <= queueRange_.y2; y += bin_h) {
+				int y2 = y + bin_h > queueRange_.y2 ? br.y : y + bin_h;
+				taskRanges_.push_back(BinCoords{ tl.x, y, br.x - 1, y2 - 1 });
+			}
+		}
 
-		case BinItemType::LINE:
-			Rasterizer::DrawLine(item.v0, item.v1, item.range, states_[item.stateIndex]);
-			break;
+		tasksSplit_ = true;
+	}
 
-		case BinItemType::POINT:
-			Rasterizer::DrawPoint(item.v0, item.range, states_[item.stateIndex]);
-			break;
+	while (!queue_.Empty()) {
+		const BinItem item = queue_.Pop();
+
+		if (taskRanges_.size() <= 1) {
+			DrawBinItem(item, states_[item.stateIndex]);
+			continue;
+		}
+
+		for (int i = 0; i < (int)taskRanges_.size(); ++i) {
+			const BinCoords &taskRange = taskRanges_[i];
+			const BinCoords range = taskRange.Intersect(item.range);
+			if (range.Invalid())
+				continue;
+
+			waitable_->Fill();
+			DrawBinItemTask *task = new DrawBinItemTask(waitable_, item, range, states_[item.stateIndex]);
+			g_threadManager.EnqueueTaskOnThread(i, task);
 		}
 	}
-	queue_.clear();
-	states_.clear();
-	stateIndex_ = -1;
+}
+
+void BinManager::Flush() {
+	Drain();
+	waitable_->Wait();
+	taskRanges_.clear();
+	tasksSplit_ = false;
+
+	queue_.Reset();
+	while (states_.Size() > 1)
+		states_.Pop();
 
 	queueRange_.x1 = 0x7FFFFFFF;
 	queueRange_.y1 = 0x7FFFFFFF;
@@ -133,12 +278,17 @@ void BinManager::Flush() {
 	queueRange_.y2 = 0;
 }
 
+inline BinCoords BinCoords::Intersect(const BinCoords &range) const {
+	BinCoords sub;
+	sub.x1 = std::max(x1, range.x1);
+	sub.y1 = std::max(y1, range.y1);
+	sub.x2 = std::min(x2, range.x2);
+	sub.y2 = std::min(y2, range.y2);
+	return sub;
+}
+
 BinCoords BinManager::Scissor(BinCoords range) {
-	range.x1 = std::max(range.x1, scissor_.x1);
-	range.y1 = std::max(range.y1, scissor_.y1);
-	range.x2 = std::min(range.x2, scissor_.x2);
-	range.y2 = std::min(range.y2, scissor_.y2);
-	return range;
+	return range.Intersect(scissor_);
 }
 
 BinCoords BinManager::Range(const VertexData &v0, const VertexData &v1, const VertexData &v2) {
@@ -173,4 +323,8 @@ void BinManager::Expand(const BinCoords &range) {
 	queueRange_.y1 = std::min(queueRange_.y1, range.y1);
 	queueRange_.x2 = std::max(queueRange_.x2, range.x2);
 	queueRange_.y2 = std::max(queueRange_.y2, range.y2);
+
+	if (maxTasks_ == 1 || queueRange_.y2 - queueRange_.y1 >= 224 * 16) {
+		Drain();
+	}
 }

--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2022- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "GPU/Software/BinManager.h"
+#include "GPU/Software/Rasterizer.h"
+#include "GPU/Software/RasterizerRectangle.h"
+
+void BinManager::AddTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2) {
+	Vec2<int> d01((int)v0.screenpos.x - (int)v1.screenpos.x, (int)v0.screenpos.y - (int)v1.screenpos.y);
+	Vec2<int> d02((int)v0.screenpos.x - (int)v2.screenpos.x, (int)v0.screenpos.y - (int)v2.screenpos.y);
+	Vec2<int> d12((int)v1.screenpos.x - (int)v2.screenpos.x, (int)v1.screenpos.y - (int)v2.screenpos.y);
+
+	// Drop primitives which are not in CCW order by checking the cross product.
+	if (d01.x * d02.y - d01.y * d02.x < 0)
+		return;
+	// If all points have identical coords, we'll have 0 weights and not skip properly, so skip here.
+	if (d01.x == 0 && d01.y == 0 && d02.x == 0 && d02.y == 0)
+		return;
+
+	// TODO
+	Rasterizer::DrawTriangle(v0, v1, v2, enqueueState_);
+}
+
+void BinManager::AddClearRect(const VertexData &v0, const VertexData &v1) {
+	// TODO
+	Rasterizer::ClearRectangle(v0, v1, enqueueState_);
+}
+
+void BinManager::AddSprite(const VertexData &v0, const VertexData &v1) {
+	// TODO
+	Rasterizer::DrawSprite(v0, v1, enqueueState_);
+}
+
+void BinManager::AddLine(const VertexData &v0, const VertexData &v1) {
+	// TODO
+	Rasterizer::DrawLine(v0, v1, enqueueState_);
+}
+
+void BinManager::AddPoint(const VertexData &v0) {
+	// TODO
+	Rasterizer::DrawPoint(v0, enqueueState_);
+}
+
+void BinManager::Flush() {
+	// TODO
+}

--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -257,7 +257,7 @@ void BinManager::Drain() {
 
 			waitable_->Fill();
 			DrawBinItemTask *task = new DrawBinItemTask(waitable_, item, range, states_[item.stateIndex]);
-			g_threadManager.EnqueueTaskOnThread(i, task);
+			g_threadManager.EnqueueTaskOnThread(i, task, true);
 		}
 	}
 }

--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -19,14 +19,38 @@
 
 #include "GPU/Software/Rasterizer.h"
 
+enum class BinItemType {
+	TRIANGLE,
+	CLEAR_RECT,
+	SPRITE,
+	LINE,
+	POINT,
+};
+
+struct BinCoords {
+	int x1;
+	int y1;
+	int x2;
+	int y2;
+};
+
+struct BinItem {
+	BinItemType type;
+	int stateIndex;
+	BinCoords range;
+	VertexData v0;
+	VertexData v1;
+	VertexData v2;
+};
+
 class BinManager {
 public:
-	void SetEnqueueState(const Rasterizer::RasterizerState &state) {
-		enqueueState_ = state;
-	}
+	BinManager();
+
+	void UpdateState();
 
 	const Rasterizer::RasterizerState &State() {
-		return enqueueState_;
+		return states_.back();
 	}
 
 	void AddTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2);
@@ -38,5 +62,15 @@ public:
 	void Flush();
 
 private:
-	Rasterizer::RasterizerState enqueueState_;
+	std::vector<Rasterizer::RasterizerState> states_;
+	int stateIndex_;
+	BinCoords scissor_;
+	std::vector<BinItem> queue_;
+	BinCoords queueRange_;
+
+	BinCoords Scissor(BinCoords range);
+	BinCoords Range(const VertexData &v0, const VertexData &v1, const VertexData &v2);
+	BinCoords Range(const VertexData &v0, const VertexData &v1);
+	BinCoords Range(const VertexData &v0);
+	void Expand(const BinCoords &range);
 };

--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2013- PPSSPP Project.
+// Copyright (c) 2022- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -17,18 +17,26 @@
 
 #pragma once
 
-#include "TransformUnit.h"
+#include "GPU/Software/Rasterizer.h"
 
-struct PixelFuncID;
-struct SamplerID;
+class BinManager {
+public:
+	void SetEnqueueState(const Rasterizer::RasterizerState &state) {
+		enqueueState_ = state;
+	}
 
-class BinManager;
+	const Rasterizer::RasterizerState &State() {
+		return enqueueState_;
+	}
 
-namespace Clipper {
+	void AddTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2);
+	void AddClearRect(const VertexData &v0, const VertexData &v1);
+	void AddSprite(const VertexData &v0, const VertexData &v1);
+	void AddLine(const VertexData &v0, const VertexData &v1);
+	void AddPoint(const VertexData &v0);
 
-void ProcessPoint(VertexData &v0, BinManager &binner);
-void ProcessLine(VertexData &v0, VertexData &v1, BinManager &binner);
-void ProcessTriangle(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, BinManager &binner);
-void ProcessRect(const VertexData &v0, const VertexData &v1, BinManager &binner);
+	void Flush();
 
-}
+private:
+	Rasterizer::RasterizerState enqueueState_;
+};

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -970,17 +970,6 @@ void DrawTriangleSlice(
 void DrawTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2, const RasterizerState &state) {
 	PROFILE_THIS_SCOPE("draw_tri");
 
-	Vec2<int> d01((int)v0.screenpos.x - (int)v1.screenpos.x, (int)v0.screenpos.y - (int)v1.screenpos.y);
-	Vec2<int> d02((int)v0.screenpos.x - (int)v2.screenpos.x, (int)v0.screenpos.y - (int)v2.screenpos.y);
-	Vec2<int> d12((int)v1.screenpos.x - (int)v2.screenpos.x, (int)v1.screenpos.y - (int)v2.screenpos.y);
-
-	// Drop primitives which are not in CCW order by checking the cross product
-	if (d01.x * d02.y - d01.y * d02.x < 0)
-		return;
-	// If all points have identical coords, we'll have 0 weights and not skip properly, so skip here.
-	if (d01.x == 0 && d01.y == 0 && d02.x == 0 && d02.y == 0)
-		return;
-
 	int minX = std::min(std::min(v0.screenpos.x, v1.screenpos.x), v2.screenpos.x) & ~0xF;
 	int minY = std::min(std::min(v0.screenpos.y, v1.screenpos.y), v2.screenpos.y) & ~0xF;
 	int maxX = std::max(std::max(v0.screenpos.x, v1.screenpos.x), v2.screenpos.x) | 0xF;

--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -29,6 +29,7 @@
 // #define SOFTGPU_MEMORY_TAGGING_DETAILED
 
 struct GPUDebugBuffer;
+struct BinCoords;
 
 namespace Rasterizer {
 
@@ -65,10 +66,10 @@ struct RasterizerState {
 void ComputeRasterizerState(RasterizerState *state);
 
 // Draws a triangle if its vertices are specified in counter-clockwise order
-void DrawTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2, const RasterizerState &state);
-void DrawPoint(const VertexData &v0, const RasterizerState &state);
-void DrawLine(const VertexData &v0, const VertexData &v1, const RasterizerState &state);
-void ClearRectangle(const VertexData &v0, const VertexData &v1, const RasterizerState &state);
+void DrawTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2, const BinCoords &range, const RasterizerState &state);
+void DrawPoint(const VertexData &v0, const BinCoords &range, const RasterizerState &state);
+void DrawLine(const VertexData &v0, const VertexData &v1, const BinCoords &range, const RasterizerState &state);
+void ClearRectangle(const VertexData &v0, const VertexData &v1, const BinCoords &range, const RasterizerState &state);
 
 bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);
 bool GetCurrentTexture(GPUDebugBuffer &buffer, int level);

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -78,7 +78,7 @@ static inline Vec4IntResult SOFTRAST_CALL ModulateRGBA(Vec4IntArg prim_in, Vec4I
 	return ToVec4IntResult(out);
 }
 
-void DrawSprite(const VertexData &v0, const VertexData &v1, const RasterizerState &state) {
+void DrawSprite(const VertexData &v0, const VertexData &v1, const BinCoords &range, const RasterizerState &state) {
 	const u8 *texptr = state.texptr[0];
 
 	GETextureFormat texfmt = state.samplerID.TexFmt();
@@ -93,8 +93,8 @@ void DrawSprite(const VertexData &v0, const VertexData &v1, const RasterizerStat
 	// Include the ending pixel based on its center, not start.
 	DrawingCoords pos1 = TransformUnit::ScreenToDrawing(v1.screenpos + ScreenCoords(7, 7, 0));
 
-	DrawingCoords scissorTL(gstate.getScissorX1(), gstate.getScissorY1(), 0);
-	DrawingCoords scissorBR(gstate.getScissorX2(), gstate.getScissorY2(), 0);
+	DrawingCoords scissorTL = TransformUnit::ScreenToDrawing(ScreenCoords(range.x1, range.y1, 0));
+	DrawingCoords scissorBR = TransformUnit::ScreenToDrawing(ScreenCoords(range.x2, range.y2, 0));
 
 	int z = pos0.z;
 	int fog = 255;

--- a/GPU/Software/RasterizerRectangle.h
+++ b/GPU/Software/RasterizerRectangle.h
@@ -13,11 +13,12 @@
 // the JIT will then be able to eliminate UV interpolation.
 
 class BinManager;
+struct BinCoords;
 
 namespace Rasterizer {
 	// Returns true if the normal path should be skipped.
 	bool RectangleFastPath(const VertexData &v0, const VertexData &v1, BinManager &binner);
-	void DrawSprite(const VertexData &v0, const VertexData &v1, const RasterizerState &state);
+	void DrawSprite(const VertexData &v0, const VertexData &v1, const BinCoords &range, const RasterizerState &state);
 
 	bool DetectRectangleFromThroughModeStrip(const VertexData data[4]);
 	bool DetectRectangleFromThroughModeFan(const VertexData *data, int c, int *tlIndex, int *brIndex);

--- a/GPU/Software/RasterizerRectangle.h
+++ b/GPU/Software/RasterizerRectangle.h
@@ -12,9 +12,12 @@
 // sense to specifically detect rectangles that do 1:1 texture mapping (like a sprite), because
 // the JIT will then be able to eliminate UV interpolation.
 
+class BinManager;
+
 namespace Rasterizer {
 	// Returns true if the normal path should be skipped.
-	bool RectangleFastPath(const VertexData &v0, const VertexData &v1, const RasterizerState &state);
+	bool RectangleFastPath(const VertexData &v0, const VertexData &v1, BinManager &binner);
+	void DrawSprite(const VertexData &v0, const VertexData &v1, const RasterizerState &state);
 
 	bool DetectRectangleFromThroughModeStrip(const VertexData data[4]);
 	bool DetectRectangleFromThroughModeFan(const VertexData *data, int c, int *tlIndex, int *brIndex);

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -343,7 +343,7 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 	// TODO: Do this in two passes - first process the vertices (before indexing/stripping),
 	// then resolve the indices. This lets us avoid transforming shared vertices twice.
 
-	BinManager binner;
+	static BinManager binner;
 	binner.UpdateState();
 
 	bool outside_range_flag = false;

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -343,11 +343,8 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 	// TODO: Do this in two passes - first process the vertices (before indexing/stripping),
 	// then resolve the indices. This lets us avoid transforming shared vertices twice.
 
-	Rasterizer::RasterizerState state;
-	ComputeRasterizerState(&state);
-
 	BinManager binner;
-	binner.SetEnqueueState(state);
+	binner.UpdateState();
 
 	bool outside_range_flag = false;
 	switch (prim_type) {

--- a/UWP/GPU_UWP/GPU_UWP.vcxproj
+++ b/UWP/GPU_UWP/GPU_UWP.vcxproj
@@ -425,6 +425,7 @@
     <ClInclude Include="..\..\GPU\GPUInterface.h" />
     <ClInclude Include="..\..\GPU\GPUState.h" />
     <ClInclude Include="..\..\GPU\Math3D.h" />
+    <ClInclude Include="..\..\GPU\Software\BinManager.h" />
     <ClInclude Include="..\..\GPU\Software\Clipper.h" />
     <ClInclude Include="..\..\GPU\Software\DrawPixel.h" />
     <ClInclude Include="..\..\GPU\Software\FuncId.h" />
@@ -486,6 +487,7 @@
     <ClCompile Include="..\..\GPU\GPUCommon.cpp" />
     <ClCompile Include="..\..\GPU\GPUState.cpp" />
     <ClCompile Include="..\..\GPU\Math3D.cpp" />
+    <ClCompile Include="..\..\GPU\Software\BinManager.cpp" />
     <ClCompile Include="..\..\GPU\Software\Clipper.cpp" />
     <ClCompile Include="..\..\GPU\Software\DrawPixel.cpp" />
     <ClCompile Include="..\..\GPU\Software\FuncId.cpp" />

--- a/UWP/GPU_UWP/GPU_UWP.vcxproj.filters
+++ b/UWP/GPU_UWP/GPU_UWP.vcxproj.filters
@@ -45,6 +45,7 @@
     <ClCompile Include="..\..\GPU\GPUCommon.cpp" />
     <ClCompile Include="..\..\GPU\GPUState.cpp" />
     <ClCompile Include="..\..\GPU\Math3D.cpp" />
+    <ClCompile Include="..\..\GPU\Software\BinManager.cpp" />
     <ClCompile Include="..\..\GPU\Software\Clipper.cpp" />
     <ClCompile Include="..\..\GPU\Software\DrawPixel.cpp" />
     <ClCompile Include="..\..\GPU\Software\FuncId.cpp" />
@@ -104,6 +105,7 @@
     <ClInclude Include="..\..\GPU\GPUInterface.h" />
     <ClInclude Include="..\..\GPU\GPUState.h" />
     <ClInclude Include="..\..\GPU\Math3D.h" />
+    <ClInclude Include="..\..\GPU\Software\BinManager.h" />
     <ClInclude Include="..\..\GPU\Software\Clipper.h" />
     <ClInclude Include="..\..\GPU\Software\DrawPixel.h" />
     <ClInclude Include="..\..\GPU\Software\FuncId.h" />

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -364,6 +364,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/GPU/GLES/ShaderManagerGLES.cpp.arm \
   $(SRC)/GPU/GLES/FragmentTestCacheGLES.cpp.arm \
   $(SRC)/GPU/GLES/TextureScalerGLES.cpp \
+  $(SRC)/GPU/Software/BinManager.cpp \
   $(SRC)/GPU/Software/Clipper.cpp \
   $(SRC)/GPU/Software/DrawPixel.cpp.arm \
   $(SRC)/GPU/Software/FuncId.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -351,6 +351,7 @@ SOURCES_CXX += \
 	$(GPUDIR)/GPU.cpp \
 	$(GPUDIR)/GPUState.cpp \
 	$(GPUDIR)/Math3D.cpp \
+	$(GPUDIR)/Software/BinManager.cpp \
 	$(GPUDIR)/Software/Clipper.cpp \
 	$(GPUDIR)/Software/DrawPixel.cpp \
 	$(GPUDIR)/Software/FuncId.cpp \


### PR DESCRIPTION
On as 12 thread CPU, this provides often between 20-100% gains in FPS.

There's still some things that could be made more optimal, but this specifically:
 * Doesn't yet deal with concurrent triangles using entirely different state (flushes within a prim call currently)
 * Decides bin sizes case by case, which initial testing indicated was necessary for good perf.
 * Has theoretical support for concurrent states.

There's currently a lot of overhead lost on newing the task, and on waiting and locking for the enqueue.  I think the decisions on bin sizes could be smarter too.  But this should be a good start.

I also still think we need to make the actual barycentric processing loop faster, for triangles.  But I'm not really sure the best options there...

-[Unknown]