### PR TITLE
softgpu: Enqueue batches of prims when binning

### DIFF
--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -84,28 +84,6 @@ static inline void DrawBinItem(const BinItem &item, const RasterizerState &state
 	}
 }
 
-class DrawBinItemTask : public Task {
-public:
-	DrawBinItemTask(BinWaitable *notify, const BinItem &item, const BinCoords &range, const RasterizerState &state)
-		: notify_(notify), item_(item), state_(state) {
-		item_.range = range;
-	}
-
-	TaskType Type() const override {
-		return TaskType::CPU_COMPUTE;
-	}
-
-	void Run() override {
-		DrawBinItem(item_, state_);
-		notify_->Drain();
-	}
-
-private:
-	BinWaitable *notify_;
-	BinItem item_;
-	const RasterizerState &state_;
-};
-
 class DrawBinItemsTask : public Task {
 public:
 	DrawBinItemsTask(BinWaitable *notify, BinQueue<BinItem, 1024> &items, std::atomic<bool> &status, const BinQueue<RasterizerState, 32> &states)

--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -70,20 +70,20 @@ struct BinQueue {
 	}
 
 	size_t Push(const T &item) {
-		_assert_(size_ < N);
+		_dbg_assert_(size_ < N);
 		size_t i = tail_++;
-		if (tail_ == N)
-			tail_ = 0;
+		if (i + 1 == N)
+			tail_ -= N;
 		items_[i] = item;
 		size_++;
 		return i;
 	}
 
 	T Pop() {
-		_assert_(!Empty());
+		_dbg_assert_(!Empty());
 		size_t i = head_++;
-		if (head_ == N)
-			head_ = 0;
+		if (i + 1 == N)
+			head_ -= N;
 		T item = items_[i];
 		size_--;
 		return item;

--- a/GPU/Software/Lighting.h
+++ b/GPU/Software/Lighting.h
@@ -21,7 +21,7 @@
 
 namespace Lighting {
 
-void GenerateLightST(VertexData &vertex);
-void Process(VertexData& vertex, bool hasColor);
+void GenerateLightST(VertexData &vertex, const WorldCoords &worldnormal);
+void Process(VertexData &vertex, const WorldCoords &worldpos, const WorldCoords &worldnormal, bool hasColor);
 
 }

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -164,11 +164,12 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 		vreader.ReadUV(vertex.texturecoords.AsArray());
 	}
 
+	Vec3<float> normal;
 	if (vreader.hasNormal()) {
-		vreader.ReadNrm(vertex.normal.AsArray());
+		vreader.ReadNrm(normal.AsArray());
 
 		if (gstate.areNormalsReversed())
-			vertex.normal = -vertex.normal;
+			normal = -normal;
 	}
 
 	if (vertTypeIsSkinningEnabled(gstate.vertType) && !gstate.isModeThrough()) {
@@ -182,14 +183,14 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 			Vec3<float> step = Vec3ByMatrix43(pos, gstate.boneMatrix + i * 12);
 			tmppos += step * W[i];
 			if (vreader.hasNormal()) {
-				step = Norm3ByMatrix43(vertex.normal, gstate.boneMatrix + i * 12);
+				step = Norm3ByMatrix43(normal, gstate.boneMatrix + i * 12);
 				tmpnrm += step * W[i];
 			}
 		}
 
 		pos = tmppos;
 		if (vreader.hasNormal())
-			vertex.normal = tmpnrm;
+			normal = tmpnrm;
 	}
 
 	if (vreader.hasColor0()) {
@@ -210,8 +211,8 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 
 	if (!gstate.isModeThrough()) {
 		vertex.modelpos = pos;
-		vertex.worldpos = WorldCoords(TransformUnit::ModelToWorld(vertex.modelpos));
-		ModelCoords viewpos = TransformUnit::WorldToView(vertex.worldpos);
+		WorldCoords worldpos = WorldCoords(TransformUnit::ModelToWorld(vertex.modelpos));
+		ModelCoords viewpos = TransformUnit::WorldToView(worldpos);
 		vertex.clippos = ClipCoords(TransformUnit::ViewToClip(viewpos));
 		if (gstate.isFogEnabled()) {
 			float fog_end = getFloat24(gstate.fog1);
@@ -230,11 +231,12 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 		}
 		vertex.screenpos = ClipToScreenInternal(vertex.clippos, &outside_range_flag);
 
+		Vec3<float> worldnormal;
 		if (vreader.hasNormal()) {
-			vertex.worldnormal = TransformUnit::ModelToWorldNormal(vertex.normal);
-			vertex.worldnormal.NormalizeOr001();
+			worldnormal = TransformUnit::ModelToWorldNormal(normal);
+			worldnormal.NormalizeOr001();
 		} else {
-			vertex.worldnormal = Vec3<float>(0.0f, 0.0f, 1.0f);
+			worldnormal = Vec3<float>(0.0f, 0.0f, 1.0f);
 		}
 
 		// Time to generate some texture coords.  Lighting will handle shade mapping.
@@ -250,11 +252,11 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 				break;
 
 			case GE_PROJMAP_NORMALIZED_NORMAL:
-				source = vertex.normal.NormalizedOr001(cpu_info.bSSE4_1);
+				source = normal.NormalizedOr001(cpu_info.bSSE4_1);
 				break;
 
 			case GE_PROJMAP_NORMAL:
-				source = vertex.normal;
+				source = normal;
 				break;
 
 			default:
@@ -268,12 +270,12 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 			float z_recip = 1.0f / stq.z;
 			vertex.texturecoords = Vec2f(stq.x * z_recip, stq.y * z_recip);
 		} else if (gstate.getUVGenMode() == GE_TEXMAP_ENVIRONMENT_MAP) {
-			Lighting::GenerateLightST(vertex);
+			Lighting::GenerateLightST(vertex, worldnormal);
 		}
 
 		PROFILE_THIS_SCOPE("light");
 		if (gstate.isLightingEnabled())
-			Lighting::Process(vertex, vreader.hasColor0());
+			Lighting::Process(vertex, worldpos, worldnormal, vreader.hasColor0());
 	} else {
 		vertex.screenpos.x = (int)(pos[0] * 16) + gstate.getOffsetX16();
 		vertex.screenpos.y = (int)(pos[1] * 16) + gstate.getOffsetY16();

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -210,8 +210,7 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 	}
 
 	if (!gstate.isModeThrough()) {
-		vertex.modelpos = pos;
-		WorldCoords worldpos = WorldCoords(TransformUnit::ModelToWorld(vertex.modelpos));
+		WorldCoords worldpos = WorldCoords(TransformUnit::ModelToWorld(pos));
 		ModelCoords viewpos = TransformUnit::WorldToView(worldpos);
 		vertex.clippos = ClipCoords(TransformUnit::ViewToClip(viewpos));
 		if (gstate.isFogEnabled()) {
@@ -244,7 +243,7 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, bool &outside_range_
 			Vec3f source;
 			switch (gstate.getUVProjMode()) {
 			case GE_PROJMAP_POSITION:
-				source = vertex.modelpos;
+				source = pos;
 				break;
 
 			case GE_PROJMAP_UV:

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -82,17 +82,12 @@ struct DrawingCoords
 	}
 };
 
-struct VertexData
-{
-	void Lerp(float t, const VertexData& a, const VertexData& b)
-	{
-		// World coords only needed for lighting, so we don't Lerp those
-
+struct VertexData {
+	void Lerp(float t, const VertexData &a, const VertexData &b) {
 		modelpos = ::Lerp(a.modelpos, b.modelpos, t);
 		clippos = ::Lerp(a.clippos, b.clippos, t);
 		screenpos = ::Lerp(a.screenpos, b.screenpos, t);  // TODO: Should use a LerpInt (?)
 		texturecoords = ::Lerp(a.texturecoords, b.texturecoords, t);
-		normal = ::Lerp(a.normal, b.normal, t);
 		fogdepth = ::Lerp(a.fogdepth, b.fogdepth, t);
 
 		u16 t_int = (u16)(t*256);
@@ -101,12 +96,9 @@ struct VertexData
 	}
 
 	ModelCoords modelpos;
-	WorldCoords worldpos; // TODO: Storing this is dumb, should transform the light to clip space instead
 	ClipCoords clippos;
 	ScreenCoords screenpos; // TODO: Shouldn't store this ?
 	Vec2<float> texturecoords;
-	Vec3<float> normal;
-	WorldCoords worldnormal;
 	Vec4<int> color0;
 	Vec3<int> color1;
 	float fogdepth;

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -84,9 +84,8 @@ struct DrawingCoords
 
 struct VertexData {
 	void Lerp(float t, const VertexData &a, const VertexData &b) {
-		modelpos = ::Lerp(a.modelpos, b.modelpos, t);
 		clippos = ::Lerp(a.clippos, b.clippos, t);
-		screenpos = ::Lerp(a.screenpos, b.screenpos, t);  // TODO: Should use a LerpInt (?)
+		// Ignore screenpos because Lerp() is only used pre-calculation of screenpos.
 		texturecoords = ::Lerp(a.texturecoords, b.texturecoords, t);
 		fogdepth = ::Lerp(a.fogdepth, b.fogdepth, t);
 
@@ -95,7 +94,6 @@ struct VertexData {
 		color1 = LerpInt<Vec3<int>,256>(a.color1, b.color1, t_int);
 	}
 
-	ModelCoords modelpos;
 	ClipCoords clippos;
 	ScreenCoords screenpos; // TODO: Shouldn't store this ?
 	Vec2<float> texturecoords;


### PR DESCRIPTION
This mostly is small, like 5-8% in some 3D areas, but in some cases it's as high as 27%.  Reducing VertexData helped more evenly, while the batching seemed to help only some games/areas.

-[Unknown]