### PR TITLE
softgpu: Avoid double calculating screenpos

### DIFF
--- a/GPU/Software/FuncId.cpp
+++ b/GPU/Software/FuncId.cpp
@@ -23,11 +23,7 @@
 #include "GPU/Software/FuncId.h"
 
 static_assert(sizeof(SamplerID) == sizeof(SamplerID::fullKey), "Bad sampler ID size");
-#ifdef SOFTPIXEL_USE_CACHE
 static_assert(sizeof(PixelFuncID) == sizeof(PixelFuncID::fullKey) + sizeof(PixelFuncID::cached), "Bad pixel func ID size");
-#else
-static_assert(sizeof(PixelFuncID) == sizeof(PixelFuncID::fullKey), "Bad pixel func ID size");
-#endif
 
 static inline GEComparison OptimizeRefByteCompare(GEComparison func, u8 ref) {
 	// Not equal tests are easier.
@@ -169,7 +165,6 @@ void ComputePixelFuncID(PixelFuncID *id) {
 		id->applyFog = gstate.isFogEnabled() && !gstate.isModeThrough();
 	}
 
-#ifdef SOFTPIXEL_USE_CACHE
 	// Cache some values for later convenience.
 	if (id->dithering) {
 		for (int y = 0; y < 4; ++y) {
@@ -201,7 +196,6 @@ void ComputePixelFuncID(PixelFuncID *id) {
 			break;
 		}
 	}
-#endif
 }
 
 std::string DescribePixelFuncID(const PixelFuncID &id) {

--- a/GPU/Software/FuncId.h
+++ b/GPU/Software/FuncId.h
@@ -23,8 +23,6 @@
 
 #include "GPU/ge_constants.h"
 
-#define SOFTPIXEL_USE_CACHE 1
-
 // 0-10 match GEBlendSrcFactor/GEBlendDstFactor.
 enum class PixelBlendFactor {
 	OTHERCOLOR,
@@ -49,13 +47,11 @@ struct PixelFuncID {
 	PixelFuncID() {
 	}
 
-#ifdef SOFTPIXEL_USE_CACHE
 	struct {
 		// Warning: these are not hashed or compared for equal.  Just cached values.
 		uint32_t colorWriteMask{};
 		int8_t ditherMatrix[16]{};
 	} cached;
-#endif
 
 	union {
 		uint64_t fullKey{};


### PR DESCRIPTION
Calculating this is kinda slow, so it doesn't seem helpful not to store it.  That said, we usually don't end up clipping, and we were always recalculating screenpos in those cases.  This avoids that, improving a percent or so (in scenes with many verts.)

-[Unknown]