### PR TITLE
softgpu: Tune queue push/pop to reduce overhead

### DIFF
--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -70,7 +70,7 @@ struct BinQueue {
 	}
 
 	size_t Push(const T &item) {
-		_dbg_assert_(size_ < N);
+		_dbg_assert_(size_ < N - 1);
 		size_t i = tail_++;
 		if (i + 1 == N)
 			tail_ -= N;
@@ -105,12 +105,12 @@ struct BinQueue {
 
 	// Only safe if you're the only one writing.
 	T &PeekPush() {
-		_dbg_assert_(size_ < N);
+		_dbg_assert_(size_ < N - 1);
 		return items_[tail_];
 	}
 
 	void PushPeeked() {
-		_dbg_assert_(size_ < N);
+		_dbg_assert_(size_ < N - 1);
 		size_t i = tail_++;
 		if (i + 1 == N)
 			tail_ -= N;
@@ -122,7 +122,7 @@ struct BinQueue {
 	}
 
 	bool Full() const {
-		return size_ == N;
+		return size_ == N - 1;
 	}
 
 	bool Empty() const {

--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -89,6 +89,34 @@ struct BinQueue {
 		return item;
 	}
 
+	// Only safe if you're the only one reading.
+	T &PeekNext() {
+		_dbg_assert_(!Empty());
+		return items_[head_];
+	}
+
+	void SkipNext() {
+		_dbg_assert_(!Empty());
+		size_t i = head_++;
+		if (i + 1 == N)
+			head_ -= N;
+		size_--;
+	}
+
+	// Only safe if you're the only one writing.
+	T &PeekPush() {
+		_dbg_assert_(size_ < N);
+		return items_[tail_];
+	}
+
+	void PushPeeked() {
+		_dbg_assert_(size_ < N);
+		size_t i = tail_++;
+		if (i + 1 == N)
+			tail_ -= N;
+		size_++;
+	}
+
 	size_t Size() const {
 		return size_;
 	}


### PR DESCRIPTION
These aren't safetly atomic with concurrent pushers or poppers, but as long as there's only one of each, they're still safe.  Just trying to avoid the extra copies, which aren't cheap in such numbers.

Shaves a decent % off Drain time for heavy scenes.  Overall it's just like a percent.

-[Unknown]