### PR TITLE
softgpu: Allow binning across prim calls

### DIFF
--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -124,6 +124,8 @@ BinManager::BinManager() {
 	queueRange_.y2 = 0;
 
 	waitable_ = new BinWaitable();
+	for (auto &s : taskStatus_)
+		s = false;
 }
 
 BinManager::~BinManager() {

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -65,6 +65,7 @@ public:
 	void CheckGPUFeatures() override {}
 	void InitClear() override {}
 	void ExecuteOp(u32 op, u32 diff) override;
+	void FinishDeferred() override;
 
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) override;
 	void CopyDisplayToOutput(bool reallyDirty) override;

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -32,6 +32,7 @@ typedef Vec3<float> ViewCoords;
 typedef Vec4<float> ClipCoords; // Range: -w <= x/y/z <= w
 
 struct SplinePatch;
+class BinManager;
 
 struct ScreenCoords
 {
@@ -117,9 +118,14 @@ public:
 	void SubmitPrimitive(void* vertices, void* indices, GEPrimitiveType prim_type, int vertex_count, u32 vertex_type, int *bytesRead, SoftwareDrawEngine *drawEngine);
 
 	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices);
+
+	void Flush();
+
+private:
 	VertexData ReadVertex(VertexReader &vreader, bool &outside_range_flag);
 
-	u8 *decoded_;
+	u8 *decoded_ = nullptr;
+	BinManager *binner_ = nullptr;
 };
 
 class SoftwareDrawEngine : public DrawEngineCommon {


### PR DESCRIPTION
This improves FPS further, 2+ core only.  So far, this much looks pretty good.  Could use further testing in more games.  This step here was pretty easy, once all the state changes were done.

I have some more changes, especially to prevent flushing on CLUT load and texture swap, which are working well in most games (with a good further win in FPS.)  However, I found an issue in Brave Story that's pretty weird.  Will have to investigate that a bit more later...

Have already found that including CLUT in rasterization state is definitely worthwhile.

-[Unknown]