### PR TITLE
Throw some memory at the softgpu problem

### DIFF
--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -129,6 +129,13 @@ BinManager::BinManager() {
 	waitable_ = new BinWaitable();
 	for (auto &s : taskStatus_)
 		s = false;
+
+	int maxInitTasks = std::min(g_threadManager.GetNumLooperThreads(), MAX_POSSIBLE_TASKS);
+	for (int i = 0; i < maxInitTasks; ++i)
+		taskQueues_[i].Setup();
+	states_.Setup();
+	cluts_.Setup();
+	queue_.Setup();
 }
 
 BinManager::~BinManager() {

--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -58,11 +58,14 @@ struct BinItem {
 template <typename T, size_t N>
 struct BinQueue {
 	BinQueue() {
-		items_ = new T[N];
 		Reset();
 	}
 	~BinQueue() {
 		delete [] items_;
+	}
+
+	void Setup() {
+		items_ = new T[N];
 	}
 
 	void Reset() {
@@ -179,7 +182,7 @@ protected:
 	static constexpr int QUEUED_STATES = 4096;
 	// These are 1KB each, so half an MB.
 	static constexpr int QUEUED_CLUTS = 512;
-	// About 320 KB, but we have 64 of them, so 20 MB (most not likely active.)
+	// About 320 KB, but we have usually 16 or less of them, so 5 MB - 20 MB.
 	static constexpr int QUEUED_PRIMS = 1024;
 
 	typedef BinQueue<Rasterizer::RasterizerState, QUEUED_STATES> BinStateQueue;

--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <atomic>
+#include <unordered_map>
 #include "Common/Log.h"
 #include "GPU/Software/Rasterizer.h"
 
@@ -166,7 +167,10 @@ public:
 	void AddPoint(const VertexData &v0);
 
 	void Drain();
-	void Flush();
+	void Flush(const char *reason);
+
+	void GetStats(char *buffer, size_t bufsize);
+	void ResetStats();
 
 private:
 	static constexpr int MAX_POSSIBLE_TASKS = 64;
@@ -187,6 +191,10 @@ private:
 	BinQueue<BinItem, 1024> taskQueues_[MAX_POSSIBLE_TASKS];
 	std::atomic<bool> taskStatus_[MAX_POSSIBLE_TASKS];
 	BinWaitable *waitable_ = nullptr;
+
+	std::unordered_map<const char *, double> flushReasonTimes_;
+	const char *slowestFlushReason_ = nullptr;
+	double slowestFlushTime_ = 0.0;
 
 	BinCoords Scissor(BinCoords range);
 	BinCoords Range(const VertexData &v0, const VertexData &v1, const VertexData &v2);

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -900,7 +900,7 @@ void SoftGPU::FinishDeferred() {
 }
 
 void SoftGPU::GetStats(char *buffer, size_t bufsize) {
-	snprintf(buffer, bufsize, "SoftGPU: (N/A)");
+	drawEngine_->transformUnit.GetStats(buffer, bufsize);
 }
 
 void SoftGPU::InvalidateCache(u32 addr, int size, GPUInvalidationType type)

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -609,8 +609,14 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 }
 
 void TransformUnit::Flush(const char *reason) {
-	binner_->Flush();
+	binner_->Flush(reason);
 	GPUDebug::NotifyDraw();
+}
+
+void TransformUnit::GetStats(char *buffer, size_t bufsize) {
+	// TODO: More stats?
+	binner_->GetStats(buffer, bufsize);
+	binner_->ResetStats();
 }
 
 void TransformUnit::FlushIfOverlap(const char *reason, uint32_t addr, uint32_t sz) {

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -123,6 +123,8 @@ public:
 	void FlushIfOverlap(const char *reason, uint32_t addr, uint32_t sz);
 	void NotifyClutUpdate(const void *src);
 
+	void GetStats(char *buffer, size_t bufsize);
+
 private:
 	VertexData ReadVertex(VertexReader &vreader, bool &outside_range_flag);
 


### PR DESCRIPTION
Well only about 1 more megabyte, heh.

Added some metrics and found that flushing was often from running out of state slots.  Increasing that uses more RAM, but seems worth it from a perf boost perspective.  Might want to make this more dynamic...

taskQueues_ is the largest by far, at 20 MB, and doubling it does give a little more speed (we are force-draining at insertion in some games.)  That said, maybe could improve that draining just to wait for some space, instead of a full drain.

This exposes some useful stats in debug statistics.

-[Unknown]