### PR TITLE
softgpu: Heuristic to avoid over-draining

### DIFF
--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -211,6 +211,9 @@ private:
 	std::unordered_map<const char *, double> lastFlushReasonTimes_;
 	const char *slowestFlushReason_ = nullptr;
 	double slowestFlushTime_ = 0.0;
+	int lastFlipstats_ = 0;
+	int enqueues_ = 0;
+	int mostThreads_ = 0;
 
 	BinCoords Scissor(BinCoords range);
 	BinCoords Range(const VertexData &v0, const VertexData &v1, const VertexData &v2);

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -689,7 +689,7 @@ void SoftGPU::ExecuteOp(u32 op, u32 diff) {
 	case GE_CMD_TEXSIZE5:
 	case GE_CMD_TEXSIZE6:
 	case GE_CMD_TEXSIZE7:
-		drawEngine_->transformUnit.FlushIfOverlap("texbufw", gstate.getTextureAddress(cmd - GE_CMD_TEXSIZE0), 4 * gstate.getTextureWidth(cmd - GE_CMD_TEXSIZE0) * gstate.getTextureHeight(cmd - GE_CMD_TEXSIZE0));
+		drawEngine_->transformUnit.FlushIfOverlap("texsize", gstate.getTextureAddress(cmd - GE_CMD_TEXSIZE0), 4 * gstate.getTextureWidth(cmd - GE_CMD_TEXSIZE0) * gstate.getTextureHeight(cmd - GE_CMD_TEXSIZE0));
 		break;
 
 	case GE_CMD_ZBUFPTR:

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -620,7 +620,6 @@ void TransformUnit::Flush(const char *reason) {
 void TransformUnit::GetStats(char *buffer, size_t bufsize) {
 	// TODO: More stats?
 	binner_->GetStats(buffer, bufsize);
-	binner_->ResetStats();
 }
 
 void TransformUnit::FlushIfOverlap(const char *reason, uint32_t addr, uint32_t sz) {


### PR DESCRIPTION
Some games (i.e. VC3) benefit from an early drain, since they get more done while processing more verts.  Others finish the draw quickly, and then cause significant overhead in queuing new threads.

This attempts to balance the two, and improves Call of Duty and Blade Dancer by about 10% (all overhead from enqueue.)

-[Unknown]