### PR TITLE
Precompute state for vertex transform

### DIFF
--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -33,10 +33,7 @@ typedef Vec4<float> ClipCoords; // Range: -w <= x/y/z <= w
 
 struct SplinePatch;
 class BinManager;
-
-namespace Lighting {
-struct State;
-};
+struct TransformState;
 
 struct ScreenCoords
 {
@@ -130,7 +127,7 @@ public:
 	void GetStats(char *buffer, size_t bufsize);
 
 private:
-	VertexData ReadVertex(VertexReader &vreader, const Lighting::State &lstate, bool &outside_range_flag);
+	VertexData ReadVertex(VertexReader &vreader, const TransformState &lstate, bool &outside_range_flag);
 
 	u8 *decoded_ = nullptr;
 	BinManager *binner_ = nullptr;


### PR DESCRIPTION
This continues along the lines of the lighting precomputation, but with other parameters including matrix transform.

This helps a Naruto dump I was testing with by 3%, but seems to be a pretty mild improvement in most other games.  Was hoping for more... but ought to help any games with plenty of verts.

-[Unknown]