### PR TITLE
Debugger: Fix crash in software renderer

### DIFF
--- a/GPU/Software/FuncId.h
+++ b/GPU/Software/FuncId.h
@@ -174,9 +174,9 @@ struct SamplerID {
 		uint32_t texBlendColor;
 		uint32_t clutFormat;
 		union {
-			uint8_t *clut;
-			uint16_t *clut16;
-			uint32_t *clut32;
+			const uint8_t *clut;
+			const uint16_t *clut16;
+			const uint32_t *clut32;
 		};
 	} cached;
 

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1277,6 +1277,8 @@ bool GetCurrentTexture(GPUDebugBuffer &buffer, int level)
 
 	SamplerID id;
 	ComputeSamplerID(&id);
+	id.cached.clut = (const u8 *)clut;
+
 	Sampler::FetchFunc sampler = Sampler::GetFetchFunc(id);
 
 	u8 *texptr = Memory::GetPointer(texaddr);


### PR DESCRIPTION
The clut isn't set by sampler state, it's set normally by the binner.

-[Unknown]