### PR TITLE
UI: Reset ZIP install errors for new ZIPs

### DIFF
--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -391,7 +391,6 @@ bool GameManager::DetectTexturePackDest(struct zip *z, int iniIndex, Path &dest)
 
 void GameManager::SetInstallError(const std::string &err) {
 	installProgress_ = 0.0f;
-	installInProgress_ = false;
 	installError_ = err;
 	InstallDone();
 }
@@ -597,12 +596,11 @@ bool GameManager::InstallMemstickGame(struct zip *z, const Path &zipfile, const 
 	zip_close(z);
 	z = nullptr;
 	installProgress_ = 1.0f;
-	installError_ = "";
 	if (deleteAfter) {
 		File::Delete(zipfile);
 	}
 	InstallDone();
-	installInProgress_ = false;
+	ResetInstallError();
 	return true;
 
 bail:
@@ -647,9 +645,8 @@ bool GameManager::InstallZippedISO(struct zip *z, int isoFileIndex, const Path &
 
 	z = 0;
 	installProgress_ = 1.0f;
-	installError_ = "";
 	InstallDone();
-	installInProgress_ = false;
+	ResetInstallError();
 	return true;
 }
 
@@ -670,12 +667,18 @@ bool GameManager::InstallRawISO(const Path &file, const std::string &originalNam
 		}
 	}
 	installProgress_ = 1.0f;
-	installError_ = "";
 	InstallDone();
-	installInProgress_ = false;
+	ResetInstallError();
 	return true;
 }
 
+void GameManager::ResetInstallError() {
+	if (!installInProgress_) {
+		installError_ = "";
+	}
+}
+
 void GameManager::InstallDone() {
+	installInProgress_ = false;
 	installDonePending_ = true;
 }

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -68,6 +68,7 @@ public:
 	float GetCurrentInstallProgressPercentage() const {
 		return installProgress_;
 	}
+	void ResetInstallError();
 	std::string GetInstallError() const {
 		return installError_;
 	}

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -25,6 +25,10 @@
 #include "UI/InstallZipScreen.h"
 #include "UI/MainScreen.h"
 
+InstallZipScreen::InstallZipScreen(const Path &zipPath) : zipPath_(zipPath) {
+	g_GameManager.ResetInstallError();
+}
+
 void InstallZipScreen::CreateViews() {
 	using namespace UI;
 

--- a/UI/InstallZipScreen.h
+++ b/UI/InstallZipScreen.h
@@ -26,7 +26,7 @@
 
 class InstallZipScreen : public UIDialogScreenWithBackground {
 public:
-	InstallZipScreen(const Path &zipPath) : zipPath_(zipPath) {}
+	InstallZipScreen(const Path &zipPath);
 	virtual void update() override;
 	virtual bool key(const KeyInput &key) override;
 


### PR DESCRIPTION
If you select a new file, it just shows the error from the previous file.  This resets it when creating a new zip install screen.

-[Unknown]