### PR TITLE
samplerjit: Simplify AVX shift-copies

### DIFF
--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -1683,25 +1683,50 @@ void XEmitter::PUNPCKHWD(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0x69, 
 void XEmitter::PUNPCKHDQ(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0x6A, dest, arg);}
 void XEmitter::PUNPCKHQDQ(X64Reg dest, const OpArg &arg) {WriteSSEOp(0x66, 0x6D, dest, arg);}
 
-void XEmitter::PSRLW(X64Reg reg, int shift)
-{
+void XEmitter::PSRLW(X64Reg dest, X64Reg reg, int shift) {
+	if (dest != reg) {
+		if (cpu_info.bAVX) {
+			VPSRLW(128, dest, reg, shift);
+			return;
+		}
+		MOVDQA(dest, R(reg));
+	}
 	WriteSSEOp(0x66, 0x71, (X64Reg)2, R(reg));
 	Write8(shift);
 }
 
-void XEmitter::PSRLD(X64Reg reg, int shift)
-{
+void XEmitter::PSRLD(X64Reg dest, X64Reg reg, int shift) {
+	if (dest != reg) {
+		if (cpu_info.bAVX) {
+			VPSRLD(128, dest, reg, shift);
+			return;
+		}
+		MOVDQA(dest, R(reg));
+	}
 	WriteSSEOp(0x66, 0x72, (X64Reg)2, R(reg));
 	Write8(shift);
 }
 
-void XEmitter::PSRLQ(X64Reg reg, int shift)
-{
+void XEmitter::PSRLQ(X64Reg dest, X64Reg reg, int shift) {
+	if (dest != reg) {
+		if (cpu_info.bAVX) {
+			VPSRLQ(128, dest, reg, shift);
+			return;
+		}
+		MOVDQA(dest, R(reg));
+	}
 	WriteSSEOp(0x66, 0x73, (X64Reg)2, R(reg));
 	Write8(shift);
 }
 
-void XEmitter::PSRLDQ(X64Reg reg, int shift) {
+void XEmitter::PSRLDQ(X64Reg dest, X64Reg reg, int shift) {
+	if (dest != reg) {
+		if (cpu_info.bAVX) {
+			VPSRLDQ(128, dest, reg, shift);
+			return;
+		}
+		MOVDQA(dest, R(reg));
+	}
 	WriteSSEOp(0x66, 0x73, (X64Reg)3, R(reg));
 	Write8(shift);
 }
@@ -1710,25 +1735,50 @@ void XEmitter::PSRLW(X64Reg reg, OpArg arg) { WriteSSEOp(0x66, 0xD1, reg, arg); 
 void XEmitter::PSRLD(X64Reg reg, OpArg arg) { WriteSSEOp(0x66, 0xD2, reg, arg); }
 void XEmitter::PSRLQ(X64Reg reg, OpArg arg) { WriteSSEOp(0x66, 0xD3, reg, arg); }
 
-void XEmitter::PSLLW(X64Reg reg, int shift)
-{
+void XEmitter::PSLLW(X64Reg dest, X64Reg reg, int shift) {
+	if (dest != reg) {
+		if (cpu_info.bAVX) {
+			VPSLLW(128, dest, reg, shift);
+			return;
+		}
+		MOVDQA(dest, R(reg));
+	}
 	WriteSSEOp(0x66, 0x71, (X64Reg)6, R(reg));
 	Write8(shift);
 }
 
-void XEmitter::PSLLD(X64Reg reg, int shift)
-{
+void XEmitter::PSLLD(X64Reg dest, X64Reg reg, int shift) {
+	if (dest != reg) {
+		if (cpu_info.bAVX) {
+			VPSLLD(128, dest, reg, shift);
+			return;
+		}
+		MOVDQA(dest, R(reg));
+	}
 	WriteSSEOp(0x66, 0x72, (X64Reg)6, R(reg));
 	Write8(shift);
 }
 
-void XEmitter::PSLLQ(X64Reg reg, int shift)
-{
+void XEmitter::PSLLQ(X64Reg dest, X64Reg reg, int shift) {
+	if (dest != reg) {
+		if (cpu_info.bAVX) {
+			VPSLLQ(128, dest, reg, shift);
+			return;
+		}
+		MOVDQA(dest, R(reg));
+	}
 	WriteSSEOp(0x66, 0x73, (X64Reg)6, R(reg));
 	Write8(shift);
 }
 
-void XEmitter::PSLLDQ(X64Reg reg, int shift) {
+void XEmitter::PSLLDQ(X64Reg dest, X64Reg reg, int shift) {
+	if (dest != reg) {
+		if (cpu_info.bAVX) {
+			VPSLLDQ(128, dest, reg, shift);
+			return;
+		}
+		MOVDQA(dest, R(reg));
+	}
 	WriteSSEOp(0x66, 0x73, (X64Reg)7, R(reg));
 	Write8(shift);
 }
@@ -1737,14 +1787,26 @@ void XEmitter::PSLLW(X64Reg reg, OpArg arg) { WriteSSEOp(0x66, 0xF1, reg, arg); 
 void XEmitter::PSLLD(X64Reg reg, OpArg arg) { WriteSSEOp(0x66, 0xF2, reg, arg); }
 void XEmitter::PSLLQ(X64Reg reg, OpArg arg) { WriteSSEOp(0x66, 0xF3, reg, arg); }
 
-void XEmitter::PSRAW(X64Reg reg, int shift)
-{
+void XEmitter::PSRAW(X64Reg dest, X64Reg reg, int shift) {
+	if (dest != reg) {
+		if (cpu_info.bAVX) {
+			VPSRAW(128, dest, reg, shift);
+			return;
+		}
+		MOVDQA(dest, R(reg));
+	}
 	WriteSSEOp(0x66, 0x71, (X64Reg)4, R(reg));
 	Write8(shift);
 }
 
-void XEmitter::PSRAD(X64Reg reg, int shift)
-{
+void XEmitter::PSRAD(X64Reg dest, X64Reg reg, int shift) {
+	if (dest != reg) {
+		if (cpu_info.bAVX) {
+			VPSRAD(128, dest, reg, shift);
+			return;
+		}
+		MOVDQA(dest, R(reg));
+	}
 	WriteSSEOp(0x66, 0x72, (X64Reg)4, R(reg));
 	Write8(shift);
 }

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -844,10 +844,14 @@ public:
 	void PSHUFLW(X64Reg dest, OpArg arg, u8 shuffle);
 	void PSHUFHW(X64Reg dest, OpArg arg, u8 shuffle);
 
-	void PSRLW(X64Reg reg, int shift);
-	void PSRLD(X64Reg reg, int shift);
-	void PSRLQ(X64Reg reg, int shift);
-	void PSRLDQ(X64Reg reg, int shift);
+	void PSRLW(X64Reg dest, X64Reg reg, int shift);
+	void PSRLW(X64Reg reg, int shift) { PSRLW(reg, reg, shift); }
+	void PSRLD(X64Reg dest, X64Reg reg, int shift);
+	void PSRLD(X64Reg reg, int shift) { PSRLD(reg, reg, shift); }
+	void PSRLQ(X64Reg dest, X64Reg reg, int shift);
+	void PSRLQ(X64Reg reg, int shift) { PSRLQ(reg, reg, shift); }
+	void PSRLDQ(X64Reg dest, X64Reg reg, int shift);
+	void PSRLDQ(X64Reg reg, int shift) { PSRLDQ(reg, reg, shift); }
 	// Note: all values shifted by lowest 64-bit in XMM arg.
 	void PSRLW(X64Reg reg, OpArg arg);
 	// Note: all values shifted by lowest 64-bit in XMM arg.
@@ -855,10 +859,14 @@ public:
 	// Note: both values shifted by lowest 64-bit in XMM arg.
 	void PSRLQ(X64Reg reg, OpArg arg);
 
-	void PSLLW(X64Reg reg, int shift);
-	void PSLLD(X64Reg reg, int shift);
-	void PSLLQ(X64Reg reg, int shift);
-	void PSLLDQ(X64Reg reg, int shift);
+	void PSLLW(X64Reg dest, X64Reg reg, int shift);
+	void PSLLW(X64Reg reg, int shift) { PSLLW(reg, reg, shift); }
+	void PSLLD(X64Reg dest, X64Reg reg, int shift);
+	void PSLLD(X64Reg reg, int shift) { PSLLD(reg, reg, shift); }
+	void PSLLQ(X64Reg dest, X64Reg reg, int shift);
+	void PSLLQ(X64Reg reg, int shift) { PSLLQ(reg, reg, shift); }
+	void PSLLDQ(X64Reg dest, X64Reg reg, int shift);
+	void PSLLDQ(X64Reg reg, int shift) { PSLLDQ(reg, reg, shift); }
 	// Note: all values shifted by lowest 64-bit in XMM arg.
 	void PSLLW(X64Reg reg, OpArg arg);
 	// Note: all values shifted by lowest 64-bit in XMM arg.
@@ -866,8 +874,10 @@ public:
 	// Note: both values shifted by lowest 64-bit in XMM arg.
 	void PSLLQ(X64Reg reg, OpArg arg);
 
-	void PSRAW(X64Reg reg, int shift);
-	void PSRAD(X64Reg reg, int shift);
+	void PSRAW(X64Reg dest, X64Reg reg, int shift);
+	void PSRAW(X64Reg reg, int shift) { PSRAW(reg, reg, shift); }
+	void PSRAD(X64Reg dest, X64Reg reg, int shift);
+	void PSRAD(X64Reg reg, int shift) { PSRAD(reg, reg, shift); }
 	// Note: all values shifted by lowest 64-bit in XMM arg.
 	void PSRAW(X64Reg reg, OpArg arg);
 	// Note: all values shifted by lowest 64-bit in XMM arg.


### PR DESCRIPTION
These have been the most common and the fallback is safe.  Let's just add a helper.

I had thought about making a compat mode using `0` as bits for the V ones, but there's some complexity there.  In practice, adding it to these is helpful and simplifies code (even if we only cared about SSE4.1.)

-[Unknown]