### PR TITLE
Simplify constant writes, reduce prolog/epilog in softjit/samplerjit

### DIFF
--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -59,22 +59,15 @@ public:
 	// Returns a pointer to the code to run.
 	SingleFunc GetSingle(const PixelFuncID &id);
 	SingleFunc GenericSingle(const PixelFuncID &id);
-	void Clear();
+	void Clear() override;
 
-	std::string DescribeCodePtr(const u8 *ptr);
+	std::string DescribeCodePtr(const u8 *ptr) override;
 
 private:
 	SingleFunc CompileSingle(const PixelFuncID &id);
 
-	void Describe(const std::string &message);
-
-#if PPSSPP_ARCH(ARM64)
-	Arm64Gen::ARM64FloatEmitter fp;
-#endif
-
 	RegCache::Reg GetPixelID();
 	void UnlockPixelID(RegCache::Reg &r);
-	RegCache::Reg GetZeroVec();
 	// Note: these may require a temporary reg.
 	RegCache::Reg GetColorOff(const PixelFuncID &id);
 	RegCache::Reg GetDepthOff(const PixelFuncID &id);
@@ -108,8 +101,6 @@ private:
 
 	std::unordered_map<PixelFuncID, SingleFunc> cache_;
 	std::unordered_map<PixelFuncID, const u8 *> addresses_;
-	std::unordered_map<const u8 *, std::string> descriptions_;
-	RegCache regCache_;
 
 	const u8 *constBlendHalf_11_4s_ = nullptr;
 	const u8 *constBlendInvert_11_4s_ = nullptr;

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -140,15 +140,6 @@ void PixelJitCache::UnlockPixelID(RegCache::Reg &r) {
 		regCache_.Unlock(r, RegCache::GEN_ID);
 }
 
-RegCache::Reg PixelJitCache::GetZeroVec() {
-	if (!regCache_.Has(RegCache::VEC_ZERO)) {
-		X64Reg r = regCache_.Alloc(RegCache::VEC_ZERO);
-		PXOR(r, R(r));
-		return r;
-	}
-	return regCache_.Find(RegCache::VEC_ZERO);
-}
-
 RegCache::Reg PixelJitCache::GetColorOff(const PixelFuncID &id) {
 	if (!regCache_.Has(RegCache::GEN_COLOR_OFF)) {
 		Describe("GetColorOff");

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -327,32 +327,16 @@ void PixelJitCache::Discard(Gen::CCFlags cc) {
 
 void PixelJitCache::WriteConstantPool(const PixelFuncID &id) {
 	// This is used to add a fixed point 0.5 (as s.11.4) for blend factors to multiply accurately.
-	if (constBlendHalf_11_4s_ == nullptr) {
-		constBlendHalf_11_4s_ = AlignCode16();
-		for (int i = 0; i < 8; ++i)
-			Write16(1 << 3);
-	}
+	WriteSimpleConst8x16(constBlendHalf_11_4s_, 1 << 3);
 
 	// This is used for shifted blend factors, to inverse them.
-	if (constBlendInvert_11_4s_ == nullptr) {
-		constBlendInvert_11_4s_ = AlignCode16();
-		for (int i = 0; i < 8; ++i)
-			Write16(0xFF << 4);
-	}
+	WriteSimpleConst8x16(constBlendInvert_11_4s_, 0xFF << 4);
 
 	// A set of 255s, used to inverse fog.
-	if (const255_16s_ == nullptr) {
-		const255_16s_ = AlignCode16();
-		for (int i = 0; i < 8; ++i)
-			Write16(0xFF);
-	}
+	WriteSimpleConst8x16(const255_16s_, 0xFF);
 
 	// This is used for a multiply that divides by 255 with shifting.
-	if (constBy255i_ == nullptr) {
-		constBy255i_ = AlignCode16();
-		for (int i = 0; i < 8; ++i)
-			Write16(0x8081);
-	}
+	WriteSimpleConst8x16(constBy255i_, 0x8081);
 }
 
 bool PixelJitCache::Jit_ApplyDepthRange(const PixelFuncID &id) {

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -63,9 +63,9 @@ SingleFunc PixelJitCache::CompileSingle(const PixelFuncID &id) {
 	bool success = true;
 
 #if PPSSPP_PLATFORM(WINDOWS)
-	// Windows reserves space to save args, 1 xmm + 4 ints before the id.
+	// RET + Windows reserves space to save args, half of 1 xmm + 4 ints before the id.
 	_assert_(!regCache_.Has(RegCache::GEN_ARG_ID));
-	stackIDOffset_ = 1 * 16 + 4 * PTRBITS / 8;
+	stackIDOffset_ = 8 + 8 + 4 * PTRBITS / 8;
 #else
 	_assert_(regCache_.Has(RegCache::GEN_ARG_ID));
 	stackIDOffset_ = -1;

--- a/GPU/Software/RasterizerRegCache.cpp
+++ b/GPU/Software/RasterizerRegCache.cpp
@@ -424,4 +424,49 @@ void CodeBlock::Clear() {
 	descriptions_.clear();
 }
 
+void CodeBlock::WriteSimpleConst16x8(const u8 *&ptr, uint8_t value) {
+	if (ptr == nullptr)
+		WriteDynamicConst16x8(ptr, value);
+}
+
+void CodeBlock::WriteSimpleConst8x16(const u8 *&ptr, uint16_t value) {
+	if (ptr == nullptr)
+		WriteDynamicConst8x16(ptr, value);
+}
+
+void CodeBlock::WriteSimpleConst4x32(const u8 *&ptr, uint32_t value) {
+	if (ptr == nullptr)
+		WriteDynamicConst4x32(ptr, value);
+}
+
+void CodeBlock::WriteDynamicConst16x8(const u8 *&ptr, uint8_t value) {
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+	ptr = AlignCode16();
+	for (int i = 0; i < 16; ++i)
+		Write8(value);
+#else
+	_assert_msg_(false, "Not yet implemented");
+#endif
+}
+
+void CodeBlock::WriteDynamicConst8x16(const u8 *&ptr, uint16_t value) {
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+	ptr = AlignCode16();
+	for (int i = 0; i < 8; ++i)
+		Write16(value);
+#else
+	_assert_msg_(false, "Not yet implemented");
+#endif
+}
+
+void CodeBlock::WriteDynamicConst4x32(const u8 *&ptr, uint32_t value) {
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+	ptr = AlignCode16();
+	for (int i = 0; i < 4; ++i)
+		Write32(value);
+#else
+	_assert_msg_(false, "Not yet implemented");
+#endif
+}
+
 };

--- a/GPU/Software/RasterizerRegCache.h
+++ b/GPU/Software/RasterizerRegCache.h
@@ -227,6 +227,13 @@ protected:
 
 	void Describe(const std::string &message);
 
+	void WriteSimpleConst16x8(const u8 *&ptr, uint8_t value);
+	void WriteSimpleConst8x16(const u8 *&ptr, uint16_t value);
+	void WriteSimpleConst4x32(const u8 *&ptr, uint32_t value);
+	void WriteDynamicConst16x8(const u8 *&ptr, uint8_t value);
+	void WriteDynamicConst8x16(const u8 *&ptr, uint16_t value);
+	void WriteDynamicConst4x32(const u8 *&ptr, uint32_t value);
+
 #if PPSSPP_ARCH(ARM64)
 	Arm64Gen::ARM64FloatEmitter fp;
 #endif

--- a/GPU/Software/RasterizerRegCache.h
+++ b/GPU/Software/RasterizerRegCache.h
@@ -178,6 +178,7 @@ struct RegCache {
 		Purpose purpose;
 		uint8_t locked = 0;
 		bool forceRetained = false;
+		bool everLocked = false;
 	};
 
 	// Note: Assumes __vectorcall on Windows.
@@ -208,6 +209,8 @@ struct RegCache {
 	void GrabReg(Reg r, Purpose p, bool &needsSwap, Reg swapReg, Purpose swapPurpose);
 	// For setting the purpose of a specific reg.  Returns false if it is locked.
 	bool ChangeReg(Reg r, Purpose p);
+	// Retrieves whether reg was ever used.
+	bool UsedReg(Reg r, Purpose flag);
 
 private:
 	RegStatus *FindReg(Reg r, Purpose p);
@@ -226,6 +229,10 @@ protected:
 	RegCache::Reg GetZeroVec();
 
 	void Describe(const std::string &message);
+	// Returns amount of stack space used.
+	int WriteProlog(int extraStack, const std::vector<RegCache::Reg> &vec, const std::vector<RegCache::Reg> &gen);
+	// Returns updated function start position, modifies prolog and finishes writing.
+	const u8 *WriteFinalizedEpilog();
 
 	void WriteSimpleConst16x8(const u8 *&ptr, uint8_t value);
 	void WriteSimpleConst8x16(const u8 *&ptr, uint16_t value);
@@ -240,6 +247,14 @@ protected:
 
 	std::unordered_map<const u8 *, std::string> descriptions_;
 	Rasterizer::RegCache regCache_;
+
+private:
+	u8 *lastPrologStart_ = nullptr;
+	u8 *lastPrologEnd_ = nullptr;
+	int savedStack_;
+	int firstVecStack_;
+	std::vector<RegCache::Reg> prologVec_;
+	std::vector<RegCache::Reg> prologGen_;
 };
 
 };

--- a/GPU/Software/RasterizerRegCache.h
+++ b/GPU/Software/RasterizerRegCache.h
@@ -20,6 +20,8 @@
 #include "ppsspp_config.h"
 
 #include <cstdint>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
 #if defined(_M_SSE)
@@ -50,15 +52,15 @@ namespace Rasterizer {
 
 // While not part of the reg cache proper, this is the type it is built for.
 #if PPSSPP_ARCH(ARM)
-typedef ArmGen::ARMXCodeBlock CodeBlock;
+typedef ArmGen::ARMXCodeBlock BaseCodeBlock;
 #elif PPSSPP_ARCH(ARM64)
-typedef Arm64Gen::ARM64CodeBlock CodeBlock;
+typedef Arm64Gen::ARM64CodeBlock BaseCodeBlock;
 #elif PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
-typedef Gen::XCodeBlock CodeBlock;
+typedef Gen::XCodeBlock BaseCodeBlock;
 #elif PPSSPP_ARCH(MIPS)
-typedef MIPSGen::MIPSCodeBlock CodeBlock;
+typedef MIPSGen::MIPSCodeBlock BaseCodeBlock;
 #else
-typedef FakeGen::FakeXCodeBlock CodeBlock;
+typedef FakeGen::FakeXCodeBlock BaseCodeBlock;
 #endif
 
 // We also have the types of things that end up in regs.
@@ -211,6 +213,26 @@ private:
 	RegStatus *FindReg(Reg r, Purpose p);
 
 	std::vector<RegStatus> regs;
+};
+
+class CodeBlock : public BaseCodeBlock {
+public:
+	virtual std::string DescribeCodePtr(const u8 *ptr);
+	virtual void Clear();
+
+protected:
+	CodeBlock(int size);
+
+	RegCache::Reg GetZeroVec();
+
+	void Describe(const std::string &message);
+
+#if PPSSPP_ARCH(ARM64)
+	Arm64Gen::ARM64FloatEmitter fp;
+#endif
+
+	std::unordered_map<const u8 *, std::string> descriptions_;
+	Rasterizer::RegCache regCache_;
 };
 
 };

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -55,18 +55,15 @@ public:
 	NearestFunc GetNearest(const SamplerID &id);
 	LinearFunc GetLinear(const SamplerID &id);
 	FetchFunc GetFetch(const SamplerID &id);
-	void Clear();
+	void Clear() override;
 
-	std::string DescribeCodePtr(const u8 *ptr);
+	std::string DescribeCodePtr(const u8 *ptr) override;
 
 private:
 	FetchFunc CompileFetch(const SamplerID &id);
 	NearestFunc CompileNearest(const SamplerID &id);
 	LinearFunc CompileLinear(const SamplerID &id);
 
-	void Describe(const std::string &message);
-
-	Rasterizer::RegCache::Reg GetZeroVec();
 	Rasterizer::RegCache::Reg GetSamplerID();
 	void UnlockSamplerID(Rasterizer::RegCache::Reg &r);
 
@@ -101,9 +98,7 @@ private:
 
 	bool Jit_ApplyTextureFunc(const SamplerID &id);
 
-#if PPSSPP_ARCH(ARM64)
-	Arm64Gen::ARM64FloatEmitter fp;
-#elif PPSSPP_ARCH(AMD64) || PPSSPP_ARCH(X86)
+#if PPSSPP_ARCH(AMD64) || PPSSPP_ARCH(X86)
 	int stackArgPos_ = 0;
 	int stackIDOffset_ = -1;
 	int stackFracUV1Offset_ = 0;
@@ -125,8 +120,6 @@ private:
 
 	std::unordered_map<SamplerID, NearestFunc> cache_;
 	std::unordered_map<SamplerID, const u8 *> addresses_;
-	std::unordered_map<const u8 *, std::string> descriptions_;
-	Rasterizer::RegCache regCache_;
 };
 
 #if defined(__clang__) || defined(__GNUC__)

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -937,15 +937,6 @@ void SamplerJitCache::WriteConstantPool(const SamplerID &id) {
 	}
 }
 
-RegCache::Reg SamplerJitCache::GetZeroVec() {
-	if (!regCache_.Has(RegCache::VEC_ZERO)) {
-		X64Reg r = regCache_.Alloc(RegCache::VEC_ZERO);
-		PXOR(r, R(r));
-		return r;
-	}
-	return regCache_.Find(RegCache::VEC_ZERO);
-}
-
 RegCache::Reg SamplerJitCache::GetSamplerID() {
 	if (regCache_.Has(RegCache::GEN_ARG_ID))
 		return regCache_.Find(RegCache::GEN_ARG_ID);

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -856,11 +856,8 @@ LinearFunc SamplerJitCache::CompileLinear(const SamplerID &id) {
 
 void SamplerJitCache::WriteConstantPool(const SamplerID &id) {
 	// We reuse constants in any pool, because our code space is small.
-	if (const10All16_ == nullptr) {
-		const10All16_ = AlignCode16();
-		for (int i = 0; i < 8; ++i)
-			Write16(0x10);
-	}
+	WriteSimpleConst8x16(const10All16_, 0x10);
+	WriteSimpleConst16x8(const10All8_, 0x10);
 
 	if (const10Low_ == nullptr) {
 		const10Low_ = AlignCode16();
@@ -870,23 +867,8 @@ void SamplerJitCache::WriteConstantPool(const SamplerID &id) {
 			Write16(0);
 	}
 
-	if (const10All8_ == nullptr) {
-		const10All8_ = AlignCode16();
-		for (int i = 0; i < 16; ++i)
-			Write8(0x10);
-	}
-
-	if (constOnes32_ == nullptr) {
-		constOnes32_ = AlignCode16();
-		for (int i = 0; i < 4; ++i)
-			Write32(1);
-	}
-
-	if (constOnes16_ == nullptr) {
-		constOnes16_ = AlignCode16();
-		for (int i = 0; i < 8; ++i)
-			Write16(1);
-	}
+	WriteSimpleConst4x32(constOnes32_, 1);
+	WriteSimpleConst8x16(constOnes16_, 1);
 
 	if (constUNext_ == nullptr) {
 		constUNext_ = AlignCode16();
@@ -898,37 +880,18 @@ void SamplerJitCache::WriteConstantPool(const SamplerID &id) {
 		Write32(0); Write32(0); Write32(1); Write32(1);
 	}
 
-	if (const5551Swizzle_ == nullptr) {
-		const5551Swizzle_ = AlignCode16();
-		for (int i = 0; i < 4; ++i)
-			Write32(0x00070707);
-	}
-
-	if (const5650Swizzle_ == nullptr) {
-		const5650Swizzle_ = AlignCode16();
-		for (int i = 0; i < 4; ++i)
-			Write32(0x00070307);
-	}
+	WriteSimpleConst4x32(const5551Swizzle_, 0x00070707);
+	WriteSimpleConst4x32(const5650Swizzle_, 0x00070307);
 
 	// These are unique to the sampler ID.
 	if (!id.hasAnyMips) {
-		constWidth256f_ = AlignCode16();
 		float w256f = (1 << id.width0Shift) * 256;
-		Write32(*(uint32_t *)&w256f); Write32(*(uint32_t *)&w256f);
-		Write32(*(uint32_t *)&w256f); Write32(*(uint32_t *)&w256f);
-
-		constHeight256f_ = AlignCode16();
+		WriteDynamicConst4x32(constWidth256f_, *(uint32_t *)&w256f);
 		float h256f = (1 << id.height0Shift) * 256;
-		Write32(*(uint32_t *)&h256f); Write32(*(uint32_t *)&h256f);
-		Write32(*(uint32_t *)&h256f); Write32(*(uint32_t *)&h256f);
+		WriteDynamicConst4x32(constHeight256f_, *(uint32_t *)&h256f);
 
-		constWidthMinus1i_ = AlignCode16();
-		Write32((1 << id.width0Shift) - 1); Write32((1 << id.width0Shift) - 1);
-		Write32((1 << id.width0Shift) - 1); Write32((1 << id.width0Shift) - 1);
-
-		constHeightMinus1i_ = AlignCode16();
-		Write32((1 << id.height0Shift) - 1); Write32((1 << id.height0Shift) - 1);
-		Write32((1 << id.height0Shift) - 1); Write32((1 << id.height0Shift) - 1);
+		WriteDynamicConst4x32(constWidthMinus1i_, (1 << id.width0Shift) - 1);
+		WriteDynamicConst4x32(constHeightMinus1i_, (1 << id.height0Shift) - 1);
 	} else {
 		constWidth256f_ = nullptr;
 		constHeight256f_ = nullptr;


### PR DESCRIPTION
This cleans up constants a bit, and also adds tracking to see if regs were ever used.  This way, we can avoid pushing them if we don't need them.

Part of this is, I tried the vectorized draw pixel again, and with some tweaks it does seem faster.  But it also needs a lot of regs for alpha blend/etc. and I want a simple way to not push all those XMMs if not needed.

Anyway, even alone this seems to give about a 0.5-1% improvement (although varies) just for the samplerjit reduction.  It can commonly avoid the 4 XMMs.

The idea is this:
1. Start by writing a worst-case prolog.
2. Generate the code.
3. Based on actual regs needed, generate an epilog for what was used.
4. Replace the prolog with what was needed too.
5. Adjust the func start position forward by the bytes saved in the new prolog.

-[Unknown]