### PR TITLE
[AdhocMatching] Fix timing issue

### DIFF
--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1241,7 +1241,7 @@ void notifyMatchingHandler(SceNetAdhocMatchingContext * context, ThreadMessage *
 	// Don't share buffer address space with other mipscall in the queue since mipscalls aren't immediately executed
 	MatchingArgs argsNew = { 0 };
 	u32_le dataBufLen = msg->optlen + 8; //max(bufLen, msg->optlen + 8);
-	u32_le dataBufAddr = userMemory.Alloc(dataBufLen); // We will free this memory after returning from mipscall
+	u32_le dataBufAddr = userMemory.Alloc(dataBufLen); // We will free this memory after returning from mipscall. FIXME: Are these buffers supposed to be taken/pre-allocated from the memory pool during sceNetAdhocMatchingInit?
 	uint8_t * dataPtr = Memory::GetPointer(dataBufAddr);
 	if (dataPtr) {
 		memcpy(dataPtr, &msg->mac, sizeof(msg->mac));
@@ -1255,6 +1255,7 @@ void notifyMatchingHandler(SceNetAdhocMatchingContext * context, ThreadMessage *
 	}
 	else {
 		argsNew.data[1] = PSP_ADHOC_MATCHING_EVENT_ERROR; // not sure where to put the error code for EVENT_ERROR tho
+		//argsNew.data[2] = dataBufAddr; // FIXME: Is the MAC address mandatory (ie. can't be null pointer) even for EVENT_ERROR? Where should we put this MAC data in the case we failed to allocate the memory? may be on the memory pool?
 	}
 	argsNew.data[0] = context->id;	
 	argsNew.data[5] = context->handler.entryPoint; //not part of callback argument, just borrowing a space to store callback address so i don't need to search the context first later

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -732,7 +732,7 @@ enum {
 #define PSP_ADHOC_MATCHING_MODE_P2P				3
 
 // Matching Events
-#define PSP_ADHOC_MATCHING_EVENT_HELLO			1
+#define PSP_ADHOC_MATCHING_EVENT_HELLO			1	// Should be ignored when Join Request is in progress ?
 #define PSP_ADHOC_MATCHING_EVENT_REQUEST		2
 #define PSP_ADHOC_MATCHING_EVENT_LEAVE			3
 #define PSP_ADHOC_MATCHING_EVENT_DENY			4

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -4674,7 +4674,7 @@ int sceNetAdhocMatchingDelete(int matchingId) {
 }
 
 int sceNetAdhocMatchingInit(u32 memsize) {
-	WARN_LOG(SCENET, "sceNetAdhocMatchingInit(%d) at %08x", memsize, currentMIPS->pc);
+	WARN_LOG_REPORT_ONCE(sceNetAdhocMatchingInit, SCENET, "sceNetAdhocMatchingInit(%d) at %08x", memsize, currentMIPS->pc);
 	
 	// Uninitialized Library
 	if (netAdhocMatchingInited) 

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -5746,7 +5746,10 @@ void __NetMatchingCallbacks() //(int matchingId)
 {
 	std::lock_guard<std::recursive_mutex> adhocGuard(adhocEvtMtx);
 	hleSkipDeadbeef();
-	int delayus = adhocDefaultDelay;
+	// Note: Super Pocket Tennis / Thrillville Off the Rails seems to have a very short timeout (ie. ~5ms) while waiting for the event to arrived on the callback handler, but Lord of Arcana may not work well with 5ms (~3m or ~10ms seems to be good)
+	// Games with 4-players or more (ie. Gundam: Senjou No Kizuna Portable) will also need lower delay/latency (ie. ~3ms seems to be good, 2ms or lower doesn't work well) so MatchingEvents can be processed faster, thus won't be piling up in the queue.
+	// Using 3ms seems to fix Player list issue on StarWars The Force Unleashed.
+	int delayus = 3000;
 
 	auto params = matchingEvents.begin();
 	if (params != matchingEvents.end()) {
@@ -5766,7 +5769,6 @@ void __NetMatchingCallbacks() //(int matchingId)
 			after->SetData(args[0], args[1], args[2]);
 			hleEnqueueCall(args[5], 5, args, after);
 			matchingEvents.pop_front();
-			delayus = adhocMatchingEventDelay; // Add extra delay to prevent I/O Timing method from causing disconnection, but delaying too long may cause matchingEvents to pile up, and Super Pocket Tennis didn't like to wait for more than 5ms
 		}
 		else {
 			DEBUG_LOG(SCENET, "AdhocMatching - Discarding Callback: [ID=%i][EVENT=%i][%s]", args[0], args[1], mac2str((SceNetEtherAddr*)Memory::GetPointer(args[2])).c_str());

--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -24,7 +24,7 @@
 #pragma pack(push,1)
 #endif
 typedef struct MatchingArgs {
-	u32_le data[6]; //ContextID, Opcode, bufAddr[ to MAC], OptLen, OptAddr[, EntryPoint]
+	u32_le data[6]; // ContextID, EventID, bufAddr[ to MAC], OptLen, OptAddr[, EntryPoint]
 } PACK MatchingArgs;
 
 typedef struct SceNetAdhocDiscoverParam {


### PR DESCRIPTION
This should fix timing issue that may occurred between lobby and the initial synchronization when multiplayer quest/mission being started on some games.

- Fix joining issue on Super Pocket Tennis https://github.com/hrydgard/ppsspp/issues/14641#issuecomment-986079216
- Fix joining issue on Thrillville Off the Rails https://github.com/hrydgard/ppsspp/issues/15160
- Fix joining issue with 4-players (or more? haven't tested with 8 players tho) on Gundam: Senjou No Kizuna Portable https://github.com/hrydgard/ppsspp/issues/14172
- Fix invalid address issue when starting the quest on Lord of Arcana
- Fix player list issue on StarWars The Force Unleashed

PS: These games were tested on localhost using simulated 50ms latency using [clumsy](https://github.com/jagt/clumsy), with **Force real clock sync** Enabled, and Simulate UMD delays on **I/O Timing Method**
PPS: Other games that use AdhocMatching library will also need to be retested in case some of them became broken due to timing changes. (will need feedback from players for this)

This timing may also need to be adjusted again after changing Matching threads into PSPThread in the future. (i'll create a separated PR for this, need to test AdhocMatching behavior on a homebrew first).
But i think timing issue can be avoided by blocking current thread during AdhocMatching syscalls while waiting for related events (based on some games behavior which cancels a join request when an unexpected event's callback being executed, due to the expected event was far behind at the end of the queue), i'll create a separated PR for this.