### PR TITLE
Common: Fix conversion of 4444 to BGRA

### DIFF
--- a/Common/Data/Convert/ColorConv.cpp
+++ b/Common/Data/Convert/ColorConv.cpp
@@ -504,8 +504,7 @@ void ConvertABGR4444ToRGBA8888(u32 *dst32, const u16 *src, u32 numPixels) {
 	}
 }
 
-void ConvertRGBA4444ToBGRA8888(u32 *dst32, const u16 *src, u32 numPixels) {
-	u8 *dst = (u8 *)dst32;
+void ConvertRGBA4444ToBGRA8888(u32 *dst, const u16 *src, u32 numPixels) {
 	for (u32 x = 0; x < numPixels; x++) {
 		u16 c = src[x];
 		u32 r = Convert4To8(c & 0x000f);

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1989,9 +1989,9 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 		case 0x20: // EMULATOR_DEVCTL__EMIT_SCREENSHOT
 		{
 			PSPPointer<u8> topaddr;
-			u32 linesize, pixelFormat;
+			u32 linesize;
 
-			__DisplayGetFramebuf(&topaddr, &linesize, &pixelFormat, 0);
+			__DisplayGetFramebuf(&topaddr, &linesize, nullptr, 0);
 			// TODO: Convert based on pixel format / mode / something?
 			host->SendDebugScreenshot(topaddr, linesize, 272);
 			return 0;


### PR DESCRIPTION
This was affecting tests emitting screenshots in 4444 as well as Direct3D backends (anywhere they did a draw pixels upload to the framebuffer from 4444...)

I was wondering why the gpu/rendertarget/rendertarget was 100% wrong in the software renderer.  Now there's just a few pixels wrong, on the edges of the primitives.

-[Unknown]