### PR TITLE
GPU: Log and report when region1 is non-zero

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -249,6 +249,10 @@ void GetFramebufferHeuristicInputs(FramebufferHeuristicParams *params, const GPU
 	params->regionHeight = gstate.getRegionY2() + 1;
 	params->scissorWidth = gstate.getScissorX2() + 1;
 	params->scissorHeight = gstate.getScissorY2() + 1;
+
+	if (gstate.getRegionRateX() != 0x100 || gstate.getRegionRateY() != 0x100) {
+		WARN_LOG_REPORT_ONCE(regionRate, G3D, "Drawing region rate add non-zero: %04x, %04x of %04x, %04x", gstate.getRegionRateX(), gstate.getRegionRateY(), gstate.getRegionX2(), gstate.getRegionY2());
+	}
 }
 
 VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const FramebufferHeuristicParams &params, u32 skipDrawReason) {

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -386,8 +386,8 @@ struct GPUgstate {
 	int getScissorY1() const { return (scissor1 >> 10) & 0x3FF; }
 	int getScissorX2() const { return scissor2 & 0x3FF; }
 	int getScissorY2() const { return (scissor2 >> 10) & 0x3FF; }
-	int getRegionX1() const { return region1 & 0x3FF; }
-	int getRegionY1() const { return (region1 >> 10) & 0x3FF; }
+	int getRegionRateX() const { return 0x100 + (region1 & 0x3FF); }
+	int getRegionRateY() const { return 0x100 + ((region1 >> 10) & 0x3FF); }
 	int getRegionX2() const { return (region2 & 0x3FF); }
 	int getRegionY2() const { return (region2 >> 10) & 0x3FF; }
 

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1243,16 +1243,15 @@ void DrawLine(const VertexData &v0, const VertexData &v1, const BinCoords &range
 	}
 }
 
-bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer)
-{
-	int w = gstate.getRegionX2() - gstate.getRegionX1() + 1;
-	int h = gstate.getRegionY2() - gstate.getRegionY1() + 1;
+bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer) {
+	int w = gstate.getRegionX2() + 1;
+	int h = gstate.getRegionY2() + 1;
 	buffer.Allocate(w, h, GPU_DBG_FORMAT_8BIT);
 
 	u8 *row = buffer.GetData();
-	for (int y = gstate.getRegionY1(); y <= gstate.getRegionY2(); ++y) {
-		for (int x = gstate.getRegionX1(); x <= gstate.getRegionX2(); ++x) {
-			row[x - gstate.getRegionX1()] = GetPixelStencil(gstate.FrameBufFormat(), gstate.FrameBufStride(), x, y);
+	for (int y = 0; y < w; ++y) {
+		for (int x = 0; x < h; ++x) {
+			row[x] = GetPixelStencil(gstate.FrameBufFormat(), gstate.FrameBufStride(), x, y);
 		}
 		row += w;
 	}

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -966,30 +966,26 @@ bool SoftGPU::FramebufferDirty() {
 }
 
 bool SoftGPU::GetCurrentFramebuffer(GPUDebugBuffer &buffer, GPUDebugFramebufferType type, int maxRes) {
-	int x1 = gstate.getRegionX1();
-	int y1 = gstate.getRegionY1();
-	int x2 = gstate.getRegionX2() + 1;
-	int y2 = gstate.getRegionY2() + 1;
+	int w = gstate.getRegionX2() + 1;
+	int h = gstate.getRegionY2() + 1;
 	int stride = gstate.FrameBufStride();
 	GEBufferFormat fmt = gstate.FrameBufFormat();
 
 	if (type == GPU_DBG_FRAMEBUF_DISPLAY) {
-		x1 = 0;
-		y1 = 0;
-		x2 = 480;
-		y2 = 272;
+		w = 480;
+		h = 272;
 		stride = displayStride_;
 		fmt = displayFormat_;
 	}
 
-	buffer.Allocate(x2 - x1, y2 - y1, fmt);
+	buffer.Allocate(w, h, fmt);
 
 	const int depth = fmt == GE_FORMAT_8888 ? 4 : 2;
-	const u8 *src = fb.data + stride * depth * y1;
+	const u8 *src = fb.data;
 	u8 *dst = buffer.GetData();
-	const int byteWidth = (x2 - x1) * depth;
-	for (int y = y1; y < y2; ++y) {
-		memcpy(dst, src + x1, byteWidth);
+	const int byteWidth = w * depth;
+	for (int y = 0; y < h; ++y) {
+		memcpy(dst, src, byteWidth);
 		dst += byteWidth;
 		src += stride * depth;
 	}
@@ -1000,17 +996,16 @@ bool SoftGPU::GetOutputFramebuffer(GPUDebugBuffer &buffer) {
 	return GetCurrentFramebuffer(buffer, GPU_DBG_FRAMEBUF_DISPLAY, 1);
 }
 
-bool SoftGPU::GetCurrentDepthbuffer(GPUDebugBuffer &buffer)
-{
-	const int w = gstate.getRegionX2() - gstate.getRegionX1() + 1;
-	const int h = gstate.getRegionY2() - gstate.getRegionY1() + 1;
+bool SoftGPU::GetCurrentDepthbuffer(GPUDebugBuffer &buffer) {
+	const int w = gstate.getRegionX2() + 1;
+	const int h = gstate.getRegionY2() + 1;
 	buffer.Allocate(w, h, GPU_DBG_FORMAT_16BIT);
 
 	const int depth = 2;
-	const u8 *src = depthbuf.data + gstate.DepthBufStride() * depth * gstate.getRegionY1();
+	const u8 *src = depthbuf.data;
 	u8 *dst = buffer.GetData();
-	for (int y = gstate.getRegionY1(); y <= gstate.getRegionY2(); ++y) {
-		memcpy(dst, src + gstate.getRegionX1(), (gstate.getRegionX2() + 1) * depth);
+	for (int y = 0; y < h; ++y) {
+		memcpy(dst, src, w * depth);
 		dst += w * depth;
 		src += gstate.DepthBufStride() * depth;
 	}


### PR DESCRIPTION
This doesn't fix it, but it stops using it as x1/y1 (which it's not, see notes in https://github.com/hrydgard/ppsspp/pull/15339#issuecomment-1019594070) and logs when it isn't the standard value.

I don't think I've ever seen this something other than zero, but hoping to confirm using reporting.

Should still implement in the software renderer... I think we'll have issues if we expand from 16 to 256 as the subpixel multiplier, though.  May cause overflow?

-[Unknown]