### PR TITLE
GPU: Allow relative jumps and calls

### DIFF
--- a/GPU/Debugger/Stepping.cpp
+++ b/GPU/Debugger/Stepping.cpp
@@ -159,7 +159,7 @@ bool SingleStep() {
 
 bool EnterStepping() {
 	std::unique_lock<std::mutex> guard(pauseLock);
-	if (coreState != CORE_RUNNING && coreState != CORE_NEXTFRAME) {
+	if (coreState != CORE_RUNNING && coreState != CORE_NEXTFRAME && coreState != CORE_STEPPING) {
 		// Shutting down, don't try to step.
 		actionComplete = true;
 		actionWait.notify_all();


### PR DESCRIPTION
These are tested in gpu/signals/jumps, so they ought to work.  Doesn't seem like games generally use them, though - nothing in reports that doesn't look like garbage.

The test still fails, but it's due to very slight timing differences (one thread overwriting a pointer after the other modified it, etc.)  That's really separate from these changes, and trickier to fix properly.  But this generally makes that test work.

-[Unknown]