### PR TITLE
Vulkan: Add support for listing all the available surface formats in system info.

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -171,6 +171,7 @@ public:
 	int GetBestPhysicalDevice();
 	int GetPhysicalDeviceByName(std::string name);
 	void ChooseDevice(int physical_device);
+	bool EnableInstanceExtension(const char *extension);
 	bool EnableDeviceExtension(const char *extension);
 	VkResult CreateDevice();
 
@@ -338,6 +339,10 @@ public:
 		return allocator_;
 	}
 
+	const std::vector<VkSurfaceFormatKHR> &SurfaceFormats() {
+		return surfFormats_;
+	}
+
 private:
 	bool ChooseQueue();
 
@@ -420,6 +425,7 @@ private:
 	PhysicalDeviceFeatures deviceFeatures_;
 
 	VkSurfaceCapabilitiesKHR surfCapabilities_{};
+	std::vector<VkSurfaceFormatKHR> surfFormats_{};
 
 	std::vector<VkCommandBuffer> cmdQueue_;
 
@@ -445,6 +451,9 @@ enum class GLSLVariant {
 bool GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *sourceCode, GLSLVariant variant, std::vector<uint32_t> &spirv, std::string *errorMessage);
 
 const char *VulkanResultToString(VkResult res);
+const char *VulkanColorSpaceToString(VkColorSpaceKHR colorSpace);
+const char *VulkanFormatToString(VkFormat format);
+
 std::string FormatDriverVersion(const VkPhysicalDeviceProperties &props);
 
 // Simple heuristic.

--- a/Common/GPU/Vulkan/VulkanLoader.h
+++ b/Common/GPU/Vulkan/VulkanLoader.h
@@ -238,6 +238,7 @@ struct VulkanExtensions {
 	bool KHR_get_physical_device_properties2;
 	bool KHR_depth_stencil_resolve;
 	bool EXT_shader_stencil_export;
+	bool EXT_swapchain_colorspace;
 	// bool EXT_depth_range_unrestricted;  // Allows depth outside [0.0, 1.0] in 32-bit float depth buffers.
 };
 

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1395,20 +1395,6 @@ void AddFeature(std::vector<std::string> &features, const char *name, VkBool32 a
 	features.push_back(buf);
 }
 
-// Limited to depth buffer formats as that's what we need right now.
-static const char *VulkanFormatToString(VkFormat fmt) {
-	switch (fmt) {
-	case VkFormat::VK_FORMAT_D24_UNORM_S8_UINT: return "D24S8";
-	case VkFormat::VK_FORMAT_D16_UNORM: return "D16";
-	case VkFormat::VK_FORMAT_D16_UNORM_S8_UINT: return "D16S8";
-	case VkFormat::VK_FORMAT_D32_SFLOAT: return "D32f";
-	case VkFormat::VK_FORMAT_D32_SFLOAT_S8_UINT: return "D32fS8";
-	case VkFormat::VK_FORMAT_S8_UINT: return "S8";
-	case VkFormat::VK_FORMAT_UNDEFINED: return "UNDEFINED (BAD!)";
-	default: return "UNKNOWN";
-	}
-}
-
 std::vector<std::string> VKContext::GetFeatureList() const {
 	const VkPhysicalDeviceFeatures &available = vulkan_->GetDeviceFeatures().available;
 	const VkPhysicalDeviceFeatures &enabled = vulkan_->GetDeviceFeatures().enabled;

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -15,6 +15,13 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+// Hack around name collisions between UI and xlib
+// Only affects this file.
+#undef VK_USE_PLATFORM_XLIB_KHR
+#undef VK_USE_PLATFORM_XCB_KHR
+#undef VK_USE_PLATFORM_DIRECTFB_EXT
+#undef VK_USE_PLATFORM_XLIB_XRANDR_EXT
+
 #include <algorithm>
 #include <cstring>
 

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -24,6 +24,7 @@
 #include "Common/System/NativeApp.h"
 #include "Common/System/System.h"
 #include "Common/GPU/OpenGL/GLFeatures.h"
+#include "Common/GPU/Vulkan/VulkanContext.h"
 #include "Common/File/AndroidStorage.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Net/HTTPClient.h"
@@ -54,6 +55,7 @@
 #include "UI/MainScreen.h"
 #include "UI/ControlMappingScreen.h"
 #include "UI/GameSettingsScreen.h"
+
 
 #ifdef _WIN32
 #include "Common/CommonWindows.h"
@@ -720,6 +722,18 @@ void SystemInfoScreen::CreateViews() {
 		for (auto &feature : features) {
 			gpuExtensions->Add(new TextView(feature, new LayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetFocusable(true);
 		}
+		
+		// Vulkan specific code here, can't be bothered to abstract.
+		gpuExtensions->Add(new ItemHeader(si->T("Display Color Formats")));
+		VulkanContext *vk = (VulkanContext *)draw->GetNativeObject(Draw::NativeObject::CONTEXT);
+		if (vk) {
+			for (auto &format : vk->SurfaceFormats()) {
+				std::string line = StringFromFormat("%s : %s", VulkanFormatToString(format.format), VulkanColorSpaceToString(format.colorSpace));
+				gpuExtensions->Add(new TextView(line,
+					new LayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetFocusable(true);
+			}
+		}
+
 		gpuExtensions->Add(new ItemHeader(si->T("Vulkan Extensions")));
 		std::vector<std::string> extensions = draw->GetExtensionList();
 		for (auto &extension : extensions) {

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -31,7 +31,10 @@
 #include "Common/System/NativeApp.h"
 #include "Common/System/System.h"
 #include "Common/GPU/OpenGL/GLFeatures.h"
+
+#if !PPSSPP_PLATFORM(UWP)
 #include "Common/GPU/Vulkan/VulkanContext.h"
+#endif
 #include "Common/File/AndroidStorage.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Net/HTTPClient.h"
@@ -730,7 +733,10 @@ void SystemInfoScreen::CreateViews() {
 			gpuExtensions->Add(new TextView(feature, new LayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetFocusable(true);
 		}
 		
+#if !PPSSPP_PLATFORM(UWP)
+
 		// Vulkan specific code here, can't be bothered to abstract.
+		// OK because of above check.
 		gpuExtensions->Add(new ItemHeader(si->T("Display Color Formats")));
 		VulkanContext *vk = (VulkanContext *)draw->GetNativeObject(Draw::NativeObject::CONTEXT);
 		if (vk) {
@@ -740,6 +746,7 @@ void SystemInfoScreen::CreateViews() {
 					new LayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetFocusable(true);
 			}
 		}
+#endif
 
 		gpuExtensions->Add(new ItemHeader(si->T("Vulkan Extensions")));
 		std::vector<std::string> extensions = draw->GetExtensionList();


### PR DESCRIPTION
Enabling the [EXT_swapchain_colorspace ](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VK_EXT_swapchain_colorspace.html) extension lets the driver expose all the formats it really supports.

Used this to discover that my Galaxy S21 supports Apple's Display-P3 color space, which is a wider gamut than sRGB. Might be able to do some color boosting mode for fun. Or, use this stuff to play around with HDR? Dunno.

(Yeah, this is not really very useful for emulation, but again, might be possible to do some interesting/fun things on modern displays).