### PR TITLE
Build: Enable ccache for GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,63 +120,75 @@ jobs:
           cc: clang
           cxx: clang++
           args: ./b.sh --headless --unittest
+          id: clang
         - os: ubuntu-latest
           cc: gcc
           cxx: g++
           args: ./b.sh --headless --unittest
+          id: gcc
 
         - os: ubuntu-latest
           extra: android
           cc: clang
           cxx: clang++
           args: cd android && ./ab.sh -j2 APP_ABI=arm64-v8a UNITTEST=1 HEADLESS=1
+          id: android-arm64
         - os: ubuntu-latest
           extra: android
           cc: clang
           cxx: clang++
           args: cd android && ./ab.sh -j2 APP_ABI=armeabi-v7a UNITTEST=1 HEADLESS=1
+          id: android-arm32
         - os: ubuntu-latest
           extra: android
           cc: clang
           cxx: clang++
           args: cd android && ./ab.sh -j2 APP_ABI=x86 UNITTEST=1 HEADLESS=1
+          id: android-x86_32
         - os: ubuntu-latest
           extra: android
           cc: clang
           cxx: clang++
           args: cd android && ./ab.sh -j2 APP_ABI=x86_64 UNITTEST=1 HEADLESS=1
+          id: android-x86_64
         - os: ubuntu-latest
           extra: android
           cc: clang
           cxx: clang++
           args: ./b.sh --libretro_android ppsspp_libretro
+          id: android-libretro
 
         - os: ubuntu-latest
           extra: qt
           cc: gcc
           cxx: g++
           args: ./b.sh --qt
+          id: qt
         - os: ubuntu-latest
           extra: libretro
           cc: gcc
           cxx: g++
           args: ./b.sh --libretro
+          id: gcc-libretro
         - os: ubuntu-latest
           extra: libretro
           cc: clang
           cxx: clang++
           args: ./b.sh --libretro
+          id: clang-libretro
 
         - os: macos-latest
           extra: test
           cc: clang
           cxx: clang++
           args: ./b.sh --headless --unittest --fat --no-png --no-sdl2
+          id: macos
         - os: macos-latest
           extra: ios
           cc: clang
           cxx: clang++
           args: ./b.sh --ios
+          id: ios
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -223,12 +235,20 @@ jobs:
         echo "const char *PPSSPP_GIT_VERSION = \"${GITHUB_REF##*/}\";" > git-version.cpp
         echo "#define PPSSPP_GIT_VERSION_NO_UPDATE 1" >> git-version.cpp
 
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        key: ${{ matrix.id }}
+
     - name: Execute build
       env:
         CC: ${{ matrix.cc }}
         CXX: ${{ matrix.cxx }}
         NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
-      run: ${{ matrix.args }}
+        NDK_CCACHE: ccache
+      run: |
+        export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        ${{ matrix.args }}
 
     - name: Package build
       if: matrix.extra == 'test'


### PR DESCRIPTION
macOS/iOS builds have been getting slower.  I initially had a problem setting up the ccache, so skipped it.  I don't remember what the problem was before, but now it's working fine.

It seems like ccache recently added support for msvc, but I didn't try to make it work.  The action I'm using doesn't support it.

Seems to significantly reduce total time (it won't be faster until the second run.)

-[Unknown]