### PR TITLE
Kernel: Adjust timings of LwMutex and EventFlag

### DIFF
--- a/Core/HLE/sceKernelEventFlag.cpp
+++ b/Core/HLE/sceKernelEventFlag.cpp
@@ -254,6 +254,7 @@ u32 sceKernelCancelEventFlag(SceUID uid, u32 pattern, u32 numWaitThreadsPtr) {
 		if (__KernelClearEventFlagThreads(e, SCE_KERNEL_ERROR_WAIT_CANCEL))
 			hleReSchedule("event flag canceled");
 
+		hleEatCycles(580);
 		return hleLogSuccessI(SCEKERNEL, 0);
 	} else {
 		return hleLogDebug(SCEKERNEL, error, "invalid event flag");
@@ -405,7 +406,7 @@ int sceKernelWaitEventFlag(SceUID id, u32 bits, u32 wait, u32 outBitsPtr, u32 ti
 			(void)hleLogSuccessI(SCEKERNEL, 0);
 		}
 
-		hleEatCycles(600);
+		hleEatCycles(500);
 		return 0;
 	} else {
 		return hleLogDebug(SCEKERNEL, error, "invalid event flag");
@@ -473,6 +474,7 @@ int sceKernelWaitEventFlagCB(SceUID id, u32 bits, u32 wait, u32 outBitsPtr, u32 
 			hleCheckCurrentCallbacks();
 		}
 
+		hleEatCycles(500);
 		return 0;
 	} else {
 		return hleLogDebug(SCEKERNEL, error, "invalid event flag");
@@ -491,6 +493,8 @@ int sceKernelPollEventFlag(SceUID id, u32 bits, u32 wait, u32 outBitsPtr) {
 	if (bits == 0) {
 		return hleLogDebug(SCEKERNEL, SCE_KERNEL_ERROR_EVF_ILPAT, "bad pattern");
 	}
+
+	hleEatCycles(360);
 
 	u32 error;
 	EventFlag *e = kernelObjects.Get<EventFlag>(id, error);

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -933,6 +933,7 @@ int sceKernelTryLockLwMutex(u32 workareaPtr, int count)
 	}
 
 	auto workarea = PSPPointer<NativeLwMutexWorkarea>::Create(workareaPtr);
+	hleEatCycles(24);
 
 	u32 error = 0;
 	if (__KernelLockLwMutex(workarea, count, error))
@@ -954,6 +955,7 @@ int sceKernelTryLockLwMutex_600(u32 workareaPtr, int count)
 	}
 
 	auto workarea = PSPPointer<NativeLwMutexWorkarea>::Create(workareaPtr);
+	hleEatCycles(24);
 
 	u32 error = 0;
 	if (__KernelLockLwMutex(workarea, count, error))
@@ -974,6 +976,7 @@ int sceKernelLockLwMutex(u32 workareaPtr, int count, u32 timeoutPtr)
 	}
 
 	auto workarea = PSPPointer<NativeLwMutexWorkarea>::Create(workareaPtr);
+	hleEatCycles(48);
 
 	u32 error = 0;
 	if (__KernelLockLwMutex(workarea, count, error))
@@ -1010,6 +1013,7 @@ int sceKernelLockLwMutexCB(u32 workareaPtr, int count, u32 timeoutPtr)
 	}
 
 	auto workarea = PSPPointer<NativeLwMutexWorkarea>::Create(workareaPtr);
+	hleEatCycles(48);
 
 	u32 error = 0;
 	if (__KernelLockLwMutex(workarea, count, error))
@@ -1046,6 +1050,7 @@ int sceKernelUnlockLwMutex(u32 workareaPtr, int count)
 	}
 
 	auto workarea = PSPPointer<NativeLwMutexWorkarea>::Create(workareaPtr);
+	hleEatCycles(28);
 
 	if (workarea->uid == -1)
 		return PSP_LWMUTEX_ERROR_NO_SUCH_LWMUTEX;


### PR DESCRIPTION
This better matches tests on real firmware.  These funcs are sometimes often used.  See #15348 - Corpse Party.

I suspect 89ms of sceKernelLockLwMutexCB means there was a bit of a stall even on a PSP, but this should encourage more thread switching and help audio/etc. run smoother.  Not tested with the actual game.

-[Unknown]