### PR TITLE
Build: Fix Windows unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
 
     - name: Execute unit tests
       working-directory: ${{ env.GITHUB_WORKSPACE }}
-      run: ppsspp\\PPSSPPHeadless.exe ALL
+      run: ppsspp\\UnitTest.exe ALL
 
     - name: Execute headless tests
       working-directory: ${{ env.GITHUB_WORKSPACE }}


### PR DESCRIPTION
Oops, since it didn't have --compare either, it didn't return an exit code.

-[Unknown]