### PR TITLE
Improve the speed of headless tests

### DIFF
--- a/Core/Debugger/MemBlockInfo.cpp
+++ b/Core/Debugger/MemBlockInfo.cpp
@@ -345,8 +345,11 @@ void MemSlabMap::FillHeads(Slab *slab) {
 	}
 
 	// Now replace all the rest - we definitely cover the start of them.
-	for (uint32_t i = slice + 1; i <= endSlice; ++i) {
-		heads_[i] = slab;
+	Slab **next = &heads_[slice + 1];
+	// We want to set slice + 1 through endSlice, inclusive.
+	size_t c = endSlice - slice;
+	for (size_t i = 0; i < c; ++i) {
+		next[i] = slab;
 	}
 }
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -685,7 +685,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 		LogManager::GetInstance()->SetAllLogLevels(LogTypes::LDEBUG);
 	}
 
-	timeBeginPeriod(1);  // TODO: Evaluate if this makes sense to keep.
+	// This still seems to improve performance noticeably.
+	timeBeginPeriod(1);
 
 	ContextMenuInit(_hInstance);
 	MainWindow::Init(_hInstance);

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -14,6 +14,10 @@
 #include "Common/System/NativeApp.h"
 #include "Common/System/System.h"
 
+#include "Common/CommonWindows.h"
+#if PPSSPP_PLATFORM(WINDOWS)
+#include <timeapi.h>
+#endif
 #include "Common/CPUDetect.h"
 #include "Common/File/VFS/VFS.h"
 #include "Common/File/VFS/AssetReader.h"
@@ -240,6 +244,9 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool 
 int main(int argc, const char* argv[])
 {
 	PROFILE_INIT();
+#if PPSSPP_PLATFORM(WINDOWS)
+	timeBeginPeriod(1);
+#endif
 
 #if defined(_DEBUG) && defined(_MSC_VER)
 	_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
@@ -508,6 +515,10 @@ int main(int argc, const char* argv[])
 	VFSShutdown();
 	LogManager::Shutdown();
 	delete printfLogger;
+
+#if PPSSPP_PLATFORM(WINDOWS)
+	timeEndPeriod(1);
+#endif
 
 	if (!failedTests.empty() && !teamCityMode)
 		return 1;


### PR DESCRIPTION
This improves the runtime of `test.py -g` on Windows by about 40%.  In a Linux VM, I got almost 10% from the first two commits, but more like 1-2% on Windows.  `timeBeginPeriod` was a very clear improvement, about 38-39% reduction in overall time.

Running some tests, like thread/vpl/create, in a loop, did show a 6% improvement from the memblock change alone on MSVC.  In practice within games expecting much less, but still worth doing.

-[Unknown]