### PR TITLE
Optimize jits with a bit of BMI2

### DIFF
--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -255,6 +255,8 @@ void CPUInfo::Detect() {
 			if ((cpu_id[1] >> 11) & 1)
 				bRTM = true;
 		}
+
+		bBMI2_fast = bBMI2 && (vendor != VENDOR_AMD || family >= 0x19);
 	}
 	if (max_ex_fn >= 0x80000004) {
 		// Extract brand string

--- a/Common/CPUDetect.h
+++ b/Common/CPUDetect.h
@@ -54,6 +54,7 @@ struct CPUInfo {
 	bool bLZCNT;
 	bool bBMI1;
 	bool bBMI2;
+	bool bBMI2_fast;
 	bool bXOP;
 	bool bRTM;
 

--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -1458,6 +1458,7 @@ void XEmitter::WriteBMI1Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg 
 {
 	CheckFlags();
 	_assert_msg_(cpu_info.bBMI1, "Trying to use BMI1 on a system that doesn't support it.");
+	_assert_msg_(!arg.IsImm(), "Imm arg unsupported for this BMI1 instruction");
 	WriteVEXOp(size, opPrefix, op, regOp1, regOp2, arg, extrabytes);
 }
 
@@ -1465,6 +1466,7 @@ void XEmitter::WriteBMI2Op(int size, u8 opPrefix, u16 op, X64Reg regOp1, X64Reg 
 {
 	CheckFlags();
 	_assert_msg_(cpu_info.bBMI2, "Trying to use BMI2 on a system that doesn't support it.");
+	_assert_msg_(!arg.IsImm(), "Imm arg unsupported for this BMI2 instruction");
 	WriteVEXOp(size, opPrefix, op, regOp1, regOp2, arg, extrabytes);
 }
 

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -2060,6 +2060,13 @@ bool PixelJitCache::Jit_ApplyLogicOp(const PixelFuncID &id, RegCache::Reg colorR
 
 bool PixelJitCache::Jit_ConvertTo565(const PixelFuncID &id, RegCache::Reg colorReg, RegCache::Reg temp1Reg, RegCache::Reg temp2Reg) {
 	Describe("ConvertTo565");
+
+	if (cpu_info.bBMI2_fast) {
+		MOV(32, R(temp1Reg), Imm32(0x00F8FCF8));
+		PEXT(32, colorReg, colorReg, R(temp1Reg));
+		return true;
+	}
+
 	// Assemble the 565 color, starting with R...
 	MOV(32, R(temp1Reg), R(colorReg));
 	SHR(32, R(temp1Reg), Imm8(3));
@@ -2081,6 +2088,13 @@ bool PixelJitCache::Jit_ConvertTo565(const PixelFuncID &id, RegCache::Reg colorR
 
 bool PixelJitCache::Jit_ConvertTo5551(const PixelFuncID &id, RegCache::Reg colorReg, RegCache::Reg temp1Reg, RegCache::Reg temp2Reg, bool keepAlpha) {
 	Describe("ConvertTo5551");
+
+	if (cpu_info.bBMI2_fast) {
+		MOV(32, R(temp1Reg), Imm32(keepAlpha ? 0x80F8F8F8 : 0x00F8F8F8));
+		PEXT(32, colorReg, colorReg, R(temp1Reg));
+		return true;
+	}
+
 	// This is R, pretty simple.
 	MOV(32, R(temp1Reg), R(colorReg));
 	SHR(32, R(temp1Reg), Imm8(3));
@@ -2112,6 +2126,13 @@ bool PixelJitCache::Jit_ConvertTo5551(const PixelFuncID &id, RegCache::Reg color
 
 bool PixelJitCache::Jit_ConvertTo4444(const PixelFuncID &id, RegCache::Reg colorReg, RegCache::Reg temp1Reg, RegCache::Reg temp2Reg, bool keepAlpha) {
 	Describe("ConvertTo4444");
+
+	if (cpu_info.bBMI2_fast) {
+		MOV(32, R(temp1Reg), Imm32(keepAlpha ? 0xF0F0F0F0 : 0x00F0F0F0));
+		PEXT(32, colorReg, colorReg, R(temp1Reg));
+		return true;
+	}
+
 	// Shift and mask out R.
 	MOV(32, R(temp1Reg), R(colorReg));
 	SHR(32, R(temp1Reg), Imm8(4));


### PR DESCRIPTION
This does a few things:

1. Adds BMI2 shifts to the CPU jit, just because.  It does help in some cases, but of course it's small.  We don't alloc RCX, so it doesn't really save a reg on x86_64, but it can be less bytes.

2. Uses PEXT/PDEP for colors in draw pixel, which gives maybe 2% in most games (unless using 8888.)

3. Uses BMI2 in samplerjit decode and to avoid RCX special-casing, just because the "it must be RCX" for a shift annoys me.  This helps only really with nearest, because it's all SIMD for linear.

4. Uses BMI2 for DXT decode, which gave about a 5% improvement overall in a frame dump for WALL-E.

But to be honest, mostly I just wanted a reason to experiment with BMI2.

Note: PEXT/PDEP are reportedly very slow (18 ops vs 1-3) on Zen 2 and lower AMD CPUs, so this intentionally avoids using them on those CPUs based on family (0x17 = Zen 2, 0x19 = Zen 3, 0x18 = it's a mystery.)

-[Unknown]