### PR TITLE
Android: Correct truncation behavior

### DIFF
--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -201,8 +201,10 @@ bool DirectoryFileHandle::Open(const Path &basePath, std::string &fileName, File
 			flags |= File::OPEN_APPEND;
 		if (access & FILEACCESS_CREATE)
 			flags |= File::OPEN_CREATE;
+		// Important: don't pass TRUNCATE here, the PSP truncates weirdly.  See #579.
+		// See above about truncate behavior.  Just add READ to preserve data here.
 		if (access & FILEACCESS_TRUNCATE)
-			flags |= File::OPEN_TRUNCATE;
+			flags |= File::OPEN_READ;
 
 		int fd = File::OpenFD(fullName, (File::OpenFlag)flags);
 		// Try to detect reads/writes to PSP/GAME to avoid them in replays.


### PR DESCRIPTION
Not really tested, sorry.  But this ought to fix the issue in #579 and match #5454.

The issue is that the game counts on TRUNC preserving data as long as you seek past it.  We already do all that with `ftruncate()`, so the fix is just to not tell Android to truncate on open.

-[Unknown]