### PR TITLE
Vulkan: Avoid crash on double DeviceLost

### DIFF
--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -226,7 +226,7 @@ void DrawEngineVulkan::FrameData::Destroy(VulkanContext *vulkan) {
 }
 
 void DrawEngineVulkan::DestroyDeviceObjects() {
-	VulkanContext *vulkan = (VulkanContext *)draw_->GetNativeObject(Draw::NativeObject::CONTEXT);
+	VulkanContext *vulkan = draw_ ? (VulkanContext *)draw_->GetNativeObject(Draw::NativeObject::CONTEXT) : nullptr;
 
 	delete tessDataTransferVulkan;
 	tessDataTransfer = nullptr;
@@ -258,6 +258,7 @@ void DrawEngineVulkan::DestroyDeviceObjects() {
 void DrawEngineVulkan::DeviceLost() {
 	DestroyDeviceObjects();
 	DirtyAllUBOs();
+	draw_ = nullptr;
 }
 
 void DrawEngineVulkan::DeviceRestore(Draw::DrawContext *draw) {

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -200,7 +200,7 @@ void TextureCacheVulkan::SetVulkan2D(Vulkan2D *vk2d) {
 }
 
 void TextureCacheVulkan::DeviceLost() {
-	VulkanContext *vulkan = (VulkanContext *)draw_->GetNativeObject(Draw::NativeObject::CONTEXT);
+	VulkanContext *vulkan = draw_ ? (VulkanContext *)draw_->GetNativeObject(Draw::NativeObject::CONTEXT) : nullptr;
 
 	Clear(true);
 
@@ -215,6 +215,7 @@ void TextureCacheVulkan::DeviceLost() {
 	computeShaderManager_.DeviceLost();
 
 	nextTexture_ = nullptr;
+	draw_ = nullptr;
 }
 
 void TextureCacheVulkan::DeviceRestore(Draw::DrawContext *draw) {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1048,12 +1048,12 @@ bool CreateGlobalPipelines() {
 }
 
 void NativeShutdownGraphics() {
+	INFO_LOG(SYSTEM, "NativeShutdownGraphics");
+
 	screenManager->deviceLost();
 
 	if (gpu)
 		gpu->DeviceLost();
-
-	INFO_LOG(SYSTEM, "NativeShutdownGraphics");
 
 #if PPSSPP_PLATFORM(WINDOWS)
 	delete winAudioBackend;


### PR DESCRIPTION
This caused Android to crash when switching to OpenGL, because the destructor would try to deinit again.  There weren't any objects, but draw_ was no longer valid.

Fixes #15258.

-[Unknown]