### PR TITLE
Generate Docker Layer for PPSSPPHeadless

### DIFF
--- a/.github/workflows/generateDockerLayer.yml
+++ b/.github/workflows/generateDockerLayer.yml
@@ -1,0 +1,37 @@
+name: Generate Docker Layer
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+  
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Extract DOCKER_TAG using tag name
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        echo "DOCKER_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+    
+    - name: Use default DOCKER_TAG
+      if: startsWith(github.ref, 'refs/tags/') != true
+      run: |
+        echo "DOCKER_TAG=latest" >> $GITHUB_ENV
+      
+    - name: Login to Github registry
+      uses: docker/login-action@v1 
+      with:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        registry: ghcr.io
+    
+    - uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: ghcr.io/${{ github.repository }}:${{ env.DOCKER_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# First stage
+FROM alpine:latest
+
+COPY . /src
+
+
+RUN apk add build-base wget git bash cmake python3 glu-dev
+
+# Installing SDL2 from source because current SDL2 package in alpine
+# has some tricks that make PPSSPP compilation to fail
+ENV SDL_VERSION=2.0.20
+RUN wget https://github.com/libsdl-org/SDL/archive/refs/tags/release-${SDL_VERSION}.tar.gz && \
+    tar -xf release-${SDL_VERSION}.tar.gz && cd SDL-release-${SDL_VERSION} && mkdir build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release .. && \
+    make -j$(getconf _NPROCESSORS_ONLN) clean && \
+    make -j$(getconf _NPROCESSORS_ONLN) && \
+    make -j$(getconf _NPROCESSORS_ONLN) install
+
+RUN cd src/ffmpeg && ./linux_x86-64.sh
+RUN cd src && ./b.sh --headless
+
+# Second stage
+FROM alpine:latest
+
+# Install required dependencies to make headless to work
+RUN apk add --no-cache sdl2 libstdc++ glu-dev
+
+# Copy minimal things to make headless to work
+COPY --from=0 src/build/PPSSPPHeadless usr/local/bin/
+
+RUN PPSSPPHeadless || true


### PR DESCRIPTION
## Description

This PR basically creates a docker layer image base in `Alpine` where we compile and expose `PPSSPPHeadless`.
It uses `Docker file multistage` and then just install the required dependencies for making `PPSSPPHeadless` to work,  getting the smallest docker layer size possible.

So far for making `PPSSPP` works I have just copied the executable it-self, but I don't know if there are other resources or files that must be included, please tell me, and I will copy them as well.

This PR will also make to upload the generated docker image to the GitHub Actions Registry Container, with the name:
```bash
ghcr.io/hrydgard/ppsspp:latest
```

Additionally whenever a new tag is created starting by `v*` it will also generate a docker image. Example:
If tag `v1.20.1` is created, then it will generate a docker image called: `ghcr.io/hrydgard/ppsspp:v.1.20.1`

Thanks