### PR TITLE
Reduce GE Debugger overhead a bit

### DIFF
--- a/GPU/Debugger/Breakpoints.h
+++ b/GPU/Debugger/Breakpoints.h
@@ -20,7 +20,7 @@
 #include "Common/CommonTypes.h"
 
 namespace GPUBreakpoints {
-	void Init();
+	void Init(void (*hasBreakpoints)(bool flag));
 
 	bool IsBreakpoint(u32 pc, u32 op);
 

--- a/GPU/Debugger/Debugger.cpp
+++ b/GPU/Debugger/Debugger.cpp
@@ -29,6 +29,7 @@ static bool active = false;
 static bool inited = false;
 static BreakNext breakNext = BreakNext::NONE;
 static int breakAtCount = -1;
+static bool hasBreakpoints = false;
 
 static int primsLastFrame = 0;
 static int primsThisFrame = 0;
@@ -39,7 +40,9 @@ static std::string restrictPrimRule;
 
 static void Init() {
 	if (!inited) {
-		GPUBreakpoints::Init();
+		GPUBreakpoints::Init([](bool flag) {
+			hasBreakpoints = flag;
+		});
 		Core_ListenStopRequest(&GPUStepping::ForceUnpause);
 		inited = true;
 	}
@@ -90,9 +93,10 @@ static bool IsBreakpoint(u32 pc, u32 op) {
 		return true;
 	} else if (breakNext == BreakNext::COUNT) {
 		return primsThisFrame == breakAtCount;
-	} else {
+	} else if (hasBreakpoints) {
 		return GPUBreakpoints::IsBreakpoint(pc, op);
 	}
+	return false;
 }
 
 bool NotifyCommand(u32 pc) {


### PR DESCRIPTION
When playing back GE frame dumps or running with the GE debugger open, there's some overhead that was easy to skip.

I was running a frame capture and noticed with no draws, it still maxed at 1200 FPS.  This raises that to 1500 FPS.  It's nice to avoid the overheads so we get closer to real performance for testing.

-[Unknown]