### PR TITLE
Draw rectangles always using a specialized path in softgpu

### DIFF
--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -74,6 +74,10 @@ static inline void DrawBinItem(const BinItem &item, const RasterizerState &state
 		ClearRectangle(item.v0, item.v1, item.range, state);
 		break;
 
+	case BinItemType::RECT:
+		DrawRectangle(item.v0, item.v1, item.range, state);
+		break;
+
 	case BinItemType::SPRITE:
 		DrawSprite(item.v0, item.v1, item.range, state);
 		break;
@@ -313,6 +317,17 @@ void BinManager::AddClearRect(const VertexData &v0, const VertexData &v1) {
 	if (queue_.Full())
 		Drain();
 	queue_.Push(BinItem{ BinItemType::CLEAR_RECT, stateIndex_, range, v0, v1 });
+	Expand(range);
+}
+
+void BinManager::AddRect(const VertexData &v0, const VertexData &v1) {
+	const BinCoords range = Range(v0, v1);
+	if (range.Invalid())
+		return;
+
+	if (queue_.Full())
+		Drain();
+	queue_.Push(BinItem{ BinItemType::RECT, stateIndex_, range, v0, v1 });
 	Expand(range);
 }
 

--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -27,6 +27,7 @@ class DrawBinItemsTask;
 enum class BinItemType {
 	TRIANGLE,
 	CLEAR_RECT,
+	RECT,
 	SPRITE,
 	LINE,
 	POINT,
@@ -189,6 +190,7 @@ public:
 
 	void AddTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2);
 	void AddClearRect(const VertexData &v0, const VertexData &v1);
+	void AddRect(const VertexData &v0, const VertexData &v1);
 	void AddSprite(const VertexData &v0, const VertexData &v1);
 	void AddLine(const VertexData &v0, const VertexData &v1);
 	void AddPoint(const VertexData &v0);

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -893,8 +893,8 @@ void DrawRectangle(const VertexData &v0, const VertexData &v1, const BinCoords &
 	int entireY1 = std::min(v0.screenpos.y, v1.screenpos.y);
 	int entireX2 = std::max(v0.screenpos.x, v1.screenpos.x) - 1;
 	int entireY2 = std::max(v0.screenpos.y, v1.screenpos.y) - 1;
-	int minX = std::max(entireX1, range.x1);
-	int minY = std::max(entireY1, range.y1);
+	int minX = std::max(entireX1, range.x1) | (SCREEN_SCALE_FACTOR / 2 - 1);
+	int minY = std::max(entireY1, range.y1) | (SCREEN_SCALE_FACTOR / 2 - 1);
 	int maxX = std::min(entireX2, range.x2);
 	int maxY = std::min(entireY2, range.y2);
 
@@ -927,7 +927,7 @@ void DrawRectangle(const VertexData &v0, const VertexData &v1, const BinCoords &
 			} else {
 				// BL to TR, rotated.  We start at TL still.
 				// X moves T (not S) toward v1, and Y moves S away from v1.
-				rowST = Vec2f(tc1.s() - diffS / diffY, tc0.t());
+				rowST = Vec2f(tc1.s(), tc0.t());
 				stx = Vec2f(0.0f, 2.0f * diffT / diffX);
 				sty = Vec2f(2.0f * -diffS / diffY, 0.0f);
 			}
@@ -935,12 +935,12 @@ void DrawRectangle(const VertexData &v0, const VertexData &v1, const BinCoords &
 			if (v0.screenpos.y < v1.screenpos.y) {
 				// TR to BL.  Like BL to TR, rotated.
 				// X moves T (not s) away from v1, and Y moves S toward v1.
-				rowST = Vec2f(tc0.s(), tc1.t() - diffT / diffX);
+				rowST = Vec2f(tc0.s(), tc1.t());
 				stx = Vec2f(0.0f, 2.0f * -diffT / diffX);
 				sty = Vec2f(2.0f * diffS / diffY, 0.0f);
 			} else {
 				// BR to TL, just inverse of TL to BR.
-				rowST = Vec2f(tc1.s() - diffS / diffX, tc1.t() - diffT / diffY);
+				rowST = Vec2f(tc1.s(), tc1.t());
 				stx = Vec2f(2.0f * -diffS / diffX, 0.0f);
 				sty = Vec2f(0.0f, 2.0f * -diffT / diffY);
 			}

--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -71,6 +71,7 @@ void ComputeRasterizerState(RasterizerState *state);
 
 // Draws a triangle if its vertices are specified in counter-clockwise order
 void DrawTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2, const BinCoords &range, const RasterizerState &state);
+void DrawRectangle(const VertexData &v0, const VertexData &v1, const BinCoords &range, const RasterizerState &state);
 void DrawPoint(const VertexData &v0, const BinCoords &range, const RasterizerState &state);
 void DrawLine(const VertexData &v0, const VertexData &v1, const BinCoords &range, const RasterizerState &state);
 void ClearRectangle(const VertexData &v0, const VertexData &v1, const BinCoords &range, const RasterizerState &state);

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -2626,7 +2626,7 @@ bool SamplerJitCache::Jit_GetTexelCoords(const SamplerID &id) {
 		CVTTPS2DQ(sReg, R(sReg));
 		regCache_.Release(sizesReg, RegCache::VEC_TEMP0);
 
-		PSRLD(sReg, 8);
+		PSRAD(sReg, 8);
 
 		// Reuse tempXYReg for the level1 values.
 		if (!cpu_info.bSSE4_1)
@@ -2685,7 +2685,7 @@ bool SamplerJitCache::Jit_GetTexelCoords(const SamplerID &id) {
 		MULPS(sReg, M(constWidthHeight256f_));
 		CVTTPS2DQ(sReg, R(sReg));
 		// Great, shift out the fraction.
-		PSRLD(sReg, 8);
+		PSRAD(sReg, 8);
 
 		// Square textures are kinda common.
 		bool clampApplied = false;


### PR DESCRIPTION
For cases where textures aren't 1:1, there's rotation, or similar - this uses a rectangle path rather than sending triangles.  This also tries to convert more triangle strips/fans/etc. into rectangles to take advantage of this.

While there, I also noticed that we could clip verts that were used for other triangles in fans/strips, which must've been wrong.

In some games, like Persona 3, Valkyria Chronicles 3, Naruto, or Vampire Chronicle, this gives around 6-9%.  Valkyrie Profile gains around 14%.  Other games like Kingdom Hearts, Call of Duty (even though it has bloom that's affected), or God of War gain almost nothing.

Found this opportunity using the GE debugger prim filter to try to narrow down the slowest draws.

-[Unknown]