### PR TITLE
GE Debugger: Avoid crash on Step Draw with flush

### DIFF
--- a/GPU/Debugger/Debugger.cpp
+++ b/GPU/Debugger/Debugger.cpp
@@ -139,7 +139,7 @@ bool NotifyCommand(u32 pc) {
 void NotifyDraw() {
 	if (!active)
 		return;
-	if (breakNext == BreakNext::DRAW) {
+	if (breakNext == BreakNext::DRAW && !GPUStepping::IsStepping()) {
 		NOTICE_LOG(G3D, "Waiting at a draw");
 		GPUStepping::EnterStepping();
 	}


### PR DESCRIPTION
If we're already stepping, we shouldn't try to re-enter stepping.

-[Unknown]