### PR TITLE
Convert more verts to rects, fix strip/fan skew on clip

### DIFF
--- a/GPU/Software/Clipper.h
+++ b/GPU/Software/Clipper.h
@@ -26,9 +26,9 @@ class BinManager;
 
 namespace Clipper {
 
-void ProcessPoint(VertexData &v0, BinManager &binner);
-void ProcessLine(VertexData &v0, VertexData &v1, BinManager &binner);
-void ProcessTriangle(VertexData &v0, VertexData &v1, VertexData &v2, const VertexData &provoking, BinManager &binner);
+void ProcessPoint(const VertexData &v0, BinManager &binner);
+void ProcessLine(const VertexData &v0, const VertexData &v1, BinManager &binner);
+void ProcessTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2, const VertexData &provoking, BinManager &binner);
 void ProcessRect(const VertexData &v0, const VertexData &v1, BinManager &binner);
 
 }

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -765,9 +765,9 @@ void DrawTriangleSlice(
 			if (AnyMask<useSSE4>(mask)) {
 				Vec4<float> wsum_recip = EdgeRecip(w0, w1, w2);
 
+				// Color interpolation is not perspective corrected on the PSP.
 				Vec4<int> prim_color[4];
 				if (!flatColor0) {
-					// Does the PSP do perspective-correct color interpolation? The GC doesn't.
 					for (int i = 0; i < 4; ++i) {
 						if (mask[i] >= 0)
 							prim_color[i] = Interpolate(v0.color0, v1.color0, v2.color0, w0[i], w1[i], w2[i], wsum_recip[i]);
@@ -831,7 +831,7 @@ void DrawTriangleSlice(
 				if (flatZ) {
 					z = Vec4<int>::AssignToAll(v2.screenpos.z);
 				} else {
-					// TODO: Is that the correct way to interpolate?
+					// Z is interpolated pretty much directly.
 					Vec4<float> zfloats = w0.Cast<float>() * v0.screenpos.z + w1.Cast<float>() * v1.screenpos.z + w2.Cast<float>() * v2.screenpos.z;
 					z = (zfloats * wsum_recip).Cast<int>();
 				}

--- a/GPU/Software/RasterizerRectangle.h
+++ b/GPU/Software/RasterizerRectangle.h
@@ -20,7 +20,7 @@ namespace Rasterizer {
 	bool RectangleFastPath(const VertexData &v0, const VertexData &v1, BinManager &binner);
 	void DrawSprite(const VertexData &v0, const VertexData &v1, const BinCoords &range, const RasterizerState &state);
 
-	bool DetectRectangleFromThroughModeStrip(const RasterizerState &state, const VertexData data[4]);
+	bool DetectRectangleFromThroughModeStrip(const RasterizerState &state, const VertexData data[4], int *tlIndex, int *brIndex);
 	bool DetectRectangleFromThroughModeFan(const RasterizerState &state, const VertexData *data, int c, int *tlIndex, int *brIndex);
 	bool DetectRectangleSlices(const RasterizerState &state, const VertexData data[4]);
 }

--- a/GPU/Software/RasterizerRectangle.h
+++ b/GPU/Software/RasterizerRectangle.h
@@ -20,7 +20,7 @@ namespace Rasterizer {
 	bool RectangleFastPath(const VertexData &v0, const VertexData &v1, BinManager &binner);
 	void DrawSprite(const VertexData &v0, const VertexData &v1, const BinCoords &range, const RasterizerState &state);
 
-	bool DetectRectangleFromThroughModeStrip(const VertexData data[4]);
-	bool DetectRectangleFromThroughModeFan(const VertexData *data, int c, int *tlIndex, int *brIndex);
-	bool DetectRectangleSlices(const VertexData data[4]);
+	bool DetectRectangleFromThroughModeStrip(const RasterizerState &state, const VertexData data[4]);
+	bool DetectRectangleFromThroughModeFan(const RasterizerState &state, const VertexData *data, int c, int *tlIndex, int *brIndex);
+	bool DetectRectangleSlices(const RasterizerState &state, const VertexData data[4]);
 }

--- a/GPU/Software/RasterizerRectangle.h
+++ b/GPU/Software/RasterizerRectangle.h
@@ -20,7 +20,7 @@ namespace Rasterizer {
 	bool RectangleFastPath(const VertexData &v0, const VertexData &v1, BinManager &binner);
 	void DrawSprite(const VertexData &v0, const VertexData &v1, const BinCoords &range, const RasterizerState &state);
 
-	bool DetectRectangleFromThroughModeStrip(const RasterizerState &state, const VertexData data[4], int *tlIndex, int *brIndex);
-	bool DetectRectangleFromThroughModeFan(const RasterizerState &state, const VertexData *data, int c, int *tlIndex, int *brIndex);
-	bool DetectRectangleSlices(const RasterizerState &state, const VertexData data[4]);
+	bool DetectRectangleFromStrip(const RasterizerState &state, const VertexData data[4], int *tlIndex, int *brIndex);
+	bool DetectRectangleFromFan(const RasterizerState &state, const VertexData *data, int c, int *tlIndex, int *brIndex);
+	bool DetectRectangleThroughModeSlices(const RasterizerState &state, const VertexData data[4]);
 }

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -593,7 +593,7 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 			}
 
 			if (data_index == 4 && gstate.isModeThrough() && cullType == CullType::OFF) {
-				if (Rasterizer::DetectRectangleSlices(binner_->State(), data)) {
+				if (Rasterizer::DetectRectangleThroughModeSlices(binner_->State(), data)) {
 					data[1] = data[3];
 					data_index = 2;
 				}
@@ -649,7 +649,7 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 
 			// If index count == 4, check if we can convert to a rectangle.
 			// This is for Darkstalkers (and should speed up many 2D games).
-			if (data_index == 0 && vertex_count == 4 && gstate.isModeThrough() && cullType == CullType::OFF) {
+			if (data_index == 0 && vertex_count == 4 && cullType == CullType::OFF) {
 				for (int vtx = 0; vtx < 4; ++vtx) {
 					if (indices) {
 						vreader.Goto(ConvertIndex(vtx) - index_lower_bound);
@@ -662,7 +662,7 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 
 				// If a strip is effectively a rectangle, draw it as such!
 				int tl = -1, br = -1;
-				if (!outside_range_flag && Rasterizer::DetectRectangleFromThroughModeStrip(binner_->State(), data, &tl, &br)) {
+				if (!outside_range_flag && Rasterizer::DetectRectangleFromStrip(binner_->State(), data, &tl, &br)) {
 					Clipper::ProcessRect(data[tl], data[br], *binner_);
 					break;
 				}
@@ -727,7 +727,7 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 					break;
 			}
 
-			if (data_index == 1 && vertex_count == 4 && gstate.isModeThrough() && cullType == CullType::OFF) {
+			if (data_index == 1 && vertex_count == 4 && cullType == CullType::OFF) {
 				for (int vtx = start_vtx; vtx < vertex_count; ++vtx) {
 					if (indices) {
 						vreader.Goto(ConvertIndex(vtx) - index_lower_bound);
@@ -738,7 +738,7 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 				}
 
 				int tl = -1, br = -1;
-				if (!outside_range_flag && Rasterizer::DetectRectangleFromThroughModeFan(binner_->State(), data, vertex_count, &tl, &br)) {
+				if (!outside_range_flag && Rasterizer::DetectRectangleFromFan(binner_->State(), data, vertex_count, &tl, &br)) {
 					Clipper::ProcessRect(data[tl], data[br], *binner_);
 					break;
 				}

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -593,7 +593,7 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 			}
 
 			if (data_index == 4 && gstate.isModeThrough() && cullType == CullType::OFF) {
-				if (Rasterizer::DetectRectangleSlices(data)) {
+				if (Rasterizer::DetectRectangleSlices(binner_->State(), data)) {
 					data[1] = data[3];
 					data_index = 2;
 				}
@@ -661,7 +661,7 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 				}
 
 				// If a strip is effectively a rectangle, draw it as such!
-				if (!outside_range_flag && Rasterizer::DetectRectangleFromThroughModeStrip(data)) {
+				if (!outside_range_flag && Rasterizer::DetectRectangleFromThroughModeStrip(binner_->State(), data)) {
 					Clipper::ProcessRect(data[0], data[3], *binner_);
 					break;
 				}
@@ -737,7 +737,7 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 				}
 
 				int tl = -1, br = -1;
-				if (!outside_range_flag && Rasterizer::DetectRectangleFromThroughModeFan(data, vertex_count, &tl, &br)) {
+				if (!outside_range_flag && Rasterizer::DetectRectangleFromThroughModeFan(binner_->State(), data, vertex_count, &tl, &br)) {
 					Clipper::ProcessRect(data[tl], data[br], *binner_);
 					break;
 				}

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -661,8 +661,9 @@ void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveTy
 				}
 
 				// If a strip is effectively a rectangle, draw it as such!
-				if (!outside_range_flag && Rasterizer::DetectRectangleFromThroughModeStrip(binner_->State(), data)) {
-					Clipper::ProcessRect(data[0], data[3], *binner_);
+				int tl = -1, br = -1;
+				if (!outside_range_flag && Rasterizer::DetectRectangleFromThroughModeStrip(binner_->State(), data, &tl, &br)) {
+					Clipper::ProcessRect(data[tl], data[br], *binner_);
 					break;
 				}
 			}


### PR DESCRIPTION
Validated that the PSP doesn't perspective correct colors, so removed those comments.

When triangles are used to draw rectangles, sometimes z isn't even written.  This happens in Valkyrie Profile.  With these changes, more goes through the rectangle path.  This even allows some transform triangles to convert to rectangles, which will be useful when rectangles have an almost-fast-path for non-through.

This gives a 4% speed improvement for dialog in Valkyrie Profile.

-[Unknown]