### PR TITLE
Debugger: Avoid scroll on breakpoint add

### DIFF
--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -211,9 +211,9 @@ COLORREF scaleColor(COLORREF color, float factor)
 	unsigned char g = (color >> 8) & 0xFF;
 	unsigned char b = (color >> 16) & 0xFF;
 
-	r = min(255,max((int)(r*factor),0));
-	g = min(255,max((int)(g*factor),0));
-	b = min(255,max((int)(b*factor),0));
+	r = std::min(255, std::max((int)(r * factor), 0));
+	g = std::min(255, std::max((int)(g * factor), 0));
+	b = std::min(255, std::max((int)(b * factor), 0));
 
 	return (color & 0xFF000000) | (b << 16) | (g << 8) | r;
 }
@@ -559,7 +559,7 @@ void CtrlDisAsmView::onPaint(WPARAM wParam, LPARAM lParam)
 		if (CBreakPoints::IsAddressBreakPoint(address,&enabled))
 		{
 			if (enabled) textColor = 0x0000FF;
-			int yOffset = max(-1,(rowHeight-14+1)/2);
+			int yOffset = std::max(-1, (rowHeight - 14 + 1) / 2);
 			if (!enabled) yOffset++;
 			DrawIconEx(hdc,2,rowY1+1+yOffset,enabled ? breakPoint : breakPointDisable,32,32,0,0,DI_NORMAL);
 		}

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -120,6 +120,8 @@ public:
 
 	void gotoAddr(unsigned int addr)
 	{
+		if (positionLocked_ != 0)
+			return;
 		u32 windowEnd = manager.getNthNextAddress(windowStart,visibleRows);
 		u32 newAddress = manager.getStartAddress(addr);
 
@@ -170,6 +172,15 @@ public:
 		updateStatusBarText();
 	}
 
+	void LockPosition() {
+		positionLocked_++;
+	}
+	void UnlockPosition() {
+		positionLocked_--;
+		_assert_(positionLocked_ >= 0);
+	}
+
 private:
 	bool redrawScheduled_ = false;
+	int positionLocked_ = 0;
 };

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -18,16 +18,12 @@
 //To get a class instance to be able to access it, just use 
 //  CtrlDisAsmView::getFrom(GetDlgItem(yourdialog, IDC_yourid)).
 
-#include "../../Core/Debugger/DebugInterface.h"
-#include "../../Core/Debugger/DisassemblyManager.h"
-
-
-#include "Common/CommonWindows.h"
 #include <vector>
 #include <algorithm>
-
-using std::min;
-using std::max;
+#include "Common/CommonWindows.h"
+#include "Common/Log.h"
+#include "Core/Debugger/DebugInterface.h"
+#include "Core/Debugger/DisassemblyManager.h"
 
 class CtrlDisAsmView
 {

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -7,11 +7,12 @@
 
 #include "Core/Debugger/Breakpoints.h"
 #include "Core/Debugger/SymbolMap.h"
+#include "Windows/Debugger/BreakpointWindow.h"
+#include "Windows/Debugger/CtrlDisAsmView.h"
 #include "Windows/Debugger/Debugger_MemoryDlg.h"
 #include "Windows/Debugger/Debugger_Disasm.h"
 #include "Windows/Debugger/Debugger_VFPUDlg.h"
 #include "Windows/Debugger/DebuggerShared.h"
-#include "Windows/Debugger/BreakpointWindow.h"
 
 #include "Windows/main.h"
 #include "Windows/Debugger/CtrlRegisterList.h"
@@ -125,7 +126,7 @@ CDisasm::CDisasm(HINSTANCE _hInstance, HWND _hParent, DebugInterface *_cpu) : Di
 	SendMessage(statusBarWnd, SB_SETPARTS, (WPARAM) 2, (LPARAM) parts);
 
 	// init other controls
-	CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg,IDC_DISASMVIEW));
+	CtrlDisAsmView *ptr = DisAsmView();
 	ptr->setDebugger(cpu);
 	ptr->gotoAddr(0x00000000);
 
@@ -201,7 +202,7 @@ void CDisasm::stepInto()
 		return;
 	}
 
-	CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg,IDC_DISASMVIEW));
+	CtrlDisAsmView *ptr = DisAsmView();
 	lastTicks = CoreTiming::GetTicks();
 	u32 currentPc = cpu->GetPC();
 
@@ -249,7 +250,7 @@ void CDisasm::stepOver()
 		return;
 	}
 	
-	CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg,IDC_DISASMVIEW));
+	CtrlDisAsmView *ptr = DisAsmView();
 	lastTicks = CoreTiming::GetTicks();
 
 	// If the current PC is on a breakpoint, the user doesn't want to do nothing.
@@ -318,7 +319,7 @@ void CDisasm::stepOut()
 	// If the current PC is on a breakpoint, the user doesn't want to do nothing.
 	CBreakPoints::SetSkipFirst(currentMIPS->pc);
 	
-	CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg,IDC_DISASMVIEW));
+	CtrlDisAsmView *ptr = DisAsmView();
 	ptr->setDontRedraw(true);
 
 	CBreakPoints::AddBreakPoint(breakpointAddress,true);
@@ -334,7 +335,7 @@ void CDisasm::runToLine()
 		return;
 	}
 
-	CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg,IDC_DISASMVIEW));
+	CtrlDisAsmView *ptr = DisAsmView();
 	u32 pos = ptr->getSelection();
 
 	lastTicks = CoreTiming::GetTicks();
@@ -379,7 +380,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 		break;
 	case WM_COMMAND:
 		{
-			CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg,IDC_DISASMVIEW));
+			CtrlDisAsmView *ptr = DisAsmView();
 			switch (LOWORD(wParam)) {
 			case ID_TOGGLE_BREAK:
 				SendMessage(MainWindow::GetHWND(), WM_COMMAND, ID_TOGGLE_BREAK, 0);
@@ -588,7 +589,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 
 	case WM_DEB_GOTOWPARAM:
 	{
-		CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg,IDC_DISASMVIEW));
+		CtrlDisAsmView *ptr = DisAsmView();
 		ptr->gotoAddr(wParam);
 		SetFocus(GetDlgItem(m_hDlg,IDC_DISASMVIEW));
 		break;
@@ -599,7 +600,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 				break;
 			}
 			wchar_t szBuffer[256];
-			CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg,IDC_DISASMVIEW));
+			CtrlDisAsmView *ptr = DisAsmView();
 			GetWindowText(GetDlgItem(m_hDlg,IDC_ADDRESS),szBuffer,256);
 
 			u32 addr;
@@ -726,7 +727,7 @@ void CDisasm::UpdateSize(WORD width, WORD height)
 		topHeightOffset = (windowRect.bottom-windowRect.top);
 	}
 	
-	CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg,IDC_DISASMVIEW));
+	CtrlDisAsmView *ptr = DisAsmView();
 	int disassemblyRowHeight = ptr->getRowHeight();
 
 	// disassembly
@@ -803,7 +804,7 @@ void CDisasm::SetDebugMode(bool _bDebug, bool switchPC)
 		EnableWindow(GetDlgItem(hDlg, IDC_STEPOUT), TRUE);
 		EnableWindow(GetDlgItem(hDlg, IDC_GOTOPC), TRUE);
 		EnableWindow(GetDlgItem(hDlg, IDC_GOTOLR), TRUE);
-		CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg,IDC_DISASMVIEW));
+		CtrlDisAsmView *ptr = DisAsmView();
 		ptr->setDontRedraw(false);
 		if (switchPC)
 			ptr->gotoPC();
@@ -845,14 +846,14 @@ void CDisasm::NotifyMapLoaded() {
 	} else {
 		deferredSymbolFill_ = true;
 	}
-	CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg, IDC_DISASMVIEW));
+	CtrlDisAsmView *ptr = DisAsmView();
 	ptr->clearFunctions();
 	ptr->redraw();
 }
 
 void CDisasm::Goto(u32 addr)
 {
-	CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg, IDC_DISASMVIEW));
+	CtrlDisAsmView *ptr = DisAsmView();
 	ptr->gotoAddr(addr);
 	SetFocus(GetDlgItem(m_hDlg, IDC_DISASMVIEW));
 	ptr->redraw();
@@ -865,7 +866,7 @@ void CDisasm::UpdateDialog() {
 	}
 
 	// Since these update on a delay, it's okay to do them immediately.
-	CtrlDisAsmView *ptr = CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg, IDC_DISASMVIEW));
+	CtrlDisAsmView *ptr = DisAsmView();
 	ptr->redraw();
 	CtrlRegisterList *rl = CtrlRegisterList::getFrom(GetDlgItem(m_hDlg, IDC_REGLIST));
 	rl->redraw();
@@ -910,4 +911,8 @@ void CDisasm::ProcessUpdateDialog() {
 	}
 
 	updateThreadLabel(!ingame || !Core_IsStepping());
+}
+
+CtrlDisAsmView *CDisasm::DisAsmView() {
+	return CtrlDisAsmView::getFrom(GetDlgItem(m_hDlg, IDC_DISASMVIEW));
 }

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -412,7 +412,9 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 
 			case ID_DEBUG_ADDBREAKPOINT:
 				{
+					CtrlDisAsmView *view = DisAsmView();
 					keepStatusBarText = true;
+					view->LockPosition();
 					bool isRunning = Core_IsActive();
 					if (isRunning)
 					{
@@ -425,6 +427,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 
 					if (isRunning)
 						Core_EnableStepping(false);
+					view->UnlockPosition();
 					keepStatusBarText = false;
 				}
 				break;

--- a/Windows/Debugger/Debugger_Disasm.h
+++ b/Windows/Debugger/Debugger_Disasm.h
@@ -4,7 +4,6 @@
 
 #include "Windows/W32Util/DialogManager.h"
 #include "Windows/W32Util/TabControl.h"
-#include "Windows/Debugger/CtrlDisAsmView.h"
 #include "Windows/Debugger/Debugger_Lists.h"
 #include "Core/Core.h"
 #include "Core/MIPS/MIPSDebugInterface.h"
@@ -12,6 +11,8 @@
 #include <vector>
 
 #include "Common/CommonWindows.h"
+
+class CtrlDisAsmView;
 
 class CDisasm : public Dialog
 {
@@ -63,6 +64,7 @@ public:
 	void NotifyMapLoaded();
 
 private:
+	CtrlDisAsmView *DisAsmView();
 	void ProcessUpdateDialog();
 
 	bool updateDialogScheduled_ = false;

--- a/Windows/GEDebugger/TabDisplayLists.cpp
+++ b/Windows/GEDebugger/TabDisplayLists.cpp
@@ -201,7 +201,7 @@ void TabDisplayLists::UpdateSize(WORD width, WORD height)
 	positions[0].x = borderMargin;
 	positions[0].y = borderMargin;
 	positions[0].w = width*2/3;
-	positions[0].h = min(height*2/5,200);
+	positions[0].h = std::min(height * 2 / 5, 200);
 
 	// Stack
 	positions[1].x = positions[0].x+positions[0].w+betweenControlsMargin;

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -1,4 +1,5 @@
 #include "ppsspp_config.h"
+#include <algorithm>
 #include <string>
 #include <sstream>
 #include <unordered_map>


### PR DESCRIPTION
Fixes #15017 for me, at least.  It was only when opening the dialog.

Also a tiny bit of cleanup.

-[Unknown]