### PR TITLE
GE Debugger: Highlight changed state values

### DIFF
--- a/GPU/Debugger/Stepping.h
+++ b/GPU/Debugger/Stepping.h
@@ -22,6 +22,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/Core.h"
 #include "GPU/Common/GPUDebugInterface.h"
+#include "GPU/GPUState.h"
 
 namespace GPUStepping {
 	// Should be called from the emu thread.
@@ -42,4 +43,6 @@ namespace GPUStepping {
 
 	void ResumeFromStepping();
 	void ForceUnpause();
+
+	GPUgstate LastState();
 };

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -361,17 +361,17 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 			leftTabs->HandleNotify(lParam);
 			break;
 		case IDC_BREAKPOINTLIST:
-			breakpointList->HandleNotify(lParam);
-			break;
+			SetWindowLongPtr(m_hDlg, DWLP_MSGRESULT, breakpointList->HandleNotify(lParam));
+			return TRUE;
 		case IDC_THREADLIST:
-			threadList->HandleNotify(lParam);
-			break;
+			SetWindowLongPtr(m_hDlg, DWLP_MSGRESULT, threadList->HandleNotify(lParam));
+			return TRUE;
 		case IDC_STACKFRAMES:
-			stackTraceView->HandleNotify(lParam);
-			break;
+			SetWindowLongPtr(m_hDlg, DWLP_MSGRESULT, stackTraceView->HandleNotify(lParam));
+			return TRUE;
 		case IDC_MODULELIST:
-			moduleList->HandleNotify(lParam);
-			break;
+			SetWindowLongPtr(m_hDlg, DWLP_MSGRESULT, moduleList->HandleNotify(lParam));
+			return TRUE;
 		case IDC_DEBUG_BOTTOMTABS:
 			bottomTabs->HandleNotify(lParam);
 			break;

--- a/Windows/GEDebugger/TabDisplayLists.cpp
+++ b/Windows/GEDebugger/TabDisplayLists.cpp
@@ -258,11 +258,11 @@ BOOL TabDisplayLists::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 		switch (wParam)
 		{
 		case IDC_GEDBG_LISTS_STACK:
-			stack->HandleNotify(lParam);
-			break;
+			SetWindowLongPtr(m_hDlg, DWLP_MSGRESULT, stack->HandleNotify(lParam));
+			return TRUE;
 		case IDC_GEDBG_LISTS_ALLLISTS:
-			allLists->HandleNotify(lParam);
-			break;
+			SetWindowLongPtr(m_hDlg, DWLP_MSGRESULT, allLists->HandleNotify(lParam));
+			return TRUE;
 		}
 		break;
 

--- a/Windows/GEDebugger/TabState.cpp
+++ b/Windows/GEDebugger/TabState.cpp
@@ -15,8 +15,10 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <commctrl.h>
 #include "Common/CommonFuncs.h"
 #include "Common/CommonTypes.h"
+#include "Common/Log.h"
 #include "Common/Data/Text/Parsers.h"
 #include "Common/StringUtils.h"
 #include "Windows/resource.h"
@@ -28,6 +30,7 @@
 #include "GPU/GeDisasm.h"
 #include "GPU/Common/GPUDebugInterface.h"
 #include "GPU/Debugger/Breakpoints.h"
+#include "GPU/Debugger/Stepping.h"
 
 using namespace GPUBreakpoints;
 
@@ -1009,9 +1012,34 @@ void CtrlStateValues::OnRightClick(int row, int column, const POINT &point) {
 	}
 }
 
+bool CtrlStateValues::OnRowPrePaint(int row, LPNMLVCUSTOMDRAW msg) {
+	if (RowValuesChanged(row)) {
+		msg->clrText = RGB(255, 0, 0);
+		return true;
+	}
+	return false;
+}
+
 void CtrlStateValues::SetCmdValue(u32 op) {
 	SendMessage(GetParent(GetParent(GetHandle())), WM_GEDBG_SETCMDWPARAM, op, NULL);
 	Update();
+}
+
+bool CtrlStateValues::RowValuesChanged(int row) {
+	_assert_(gpuDebug != nullptr && row >= 0 && row < rowCount_);
+
+	const auto info = rows_[row];
+	const auto state = gpuDebug->GetGState();
+	const auto lastState = GPUStepping::LastState();
+
+	if (state.cmdmem[info.cmd] != lastState.cmdmem[info.cmd])
+		return true;
+	if (info.otherCmd && state.cmdmem[info.otherCmd] != lastState.cmdmem[info.otherCmd])
+		return true;
+	if (info.otherCmd2 && state.cmdmem[info.otherCmd2] != lastState.cmdmem[info.otherCmd2])
+		return true;
+
+	return false;
 }
 
 TabStateValues::TabStateValues(const TabStateRow *rows, int rowCount, LPCSTR dialogID, HINSTANCE _hInstance, HWND _hParent)

--- a/Windows/GEDebugger/TabState.cpp
+++ b/Windows/GEDebugger/TabState.cpp
@@ -1054,8 +1054,8 @@ BOOL TabStateValues::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 		switch (wParam)
 		{
 		case IDC_GEDBG_VALUES:
-			values->HandleNotify(lParam);
-			break;
+			SetWindowLongPtr(m_hDlg, DWLP_MSGRESULT, values->HandleNotify(lParam));
+			return TRUE;
 		}
 		break;
 	}

--- a/Windows/GEDebugger/TabState.h
+++ b/Windows/GEDebugger/TabState.h
@@ -41,7 +41,11 @@ protected:
 	void OnDoubleClick(int row, int column) override;
 	void OnRightClick(int row, int column, const POINT& point) override;
 
+	bool ListenRowPrePaint() override { return true; }
+	bool OnRowPrePaint(int row, LPNMLVCUSTOMDRAW msg) override;
+
 private:
+	bool RowValuesChanged(int row);
 	void SetCmdValue(u32 op);
 
 	const TabStateRow *rows_;

--- a/Windows/GEDebugger/TabVertices.cpp
+++ b/Windows/GEDebugger/TabVertices.cpp
@@ -355,8 +355,8 @@ BOOL TabVertices::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 		switch (wParam)
 		{
 		case IDC_GEDBG_VERTICES:
-			values->HandleNotify(lParam);
-			break;
+			SetWindowLongPtr(m_hDlg, DWLP_MSGRESULT, values->HandleNotify(lParam));
+			return TRUE;
 		}
 		break;
 	}
@@ -652,8 +652,8 @@ BOOL TabMatrices::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 		switch (wParam)
 		{
 		case IDC_GEDBG_MATRICES:
-			values->HandleNotify(lParam);
-			break;
+			SetWindowLongPtr(m_hDlg, DWLP_MSGRESULT, values->HandleNotify(lParam));
+			return TRUE;
 		}
 		break;
 	}

--- a/Windows/GEDebugger/TabVertices.h
+++ b/Windows/GEDebugger/TabVertices.h
@@ -83,8 +83,12 @@ protected:
 	void OnDoubleClick(int row, int column) override;
 	void OnRightClick(int row, int column, const POINT &point) override;
 
+	bool ListenColPrePaint() override { return true; }
+	bool OnColPrePaint(int row, int col, LPNMLVCUSTOMDRAW msg) override;
+
 private:
-	bool GetValue(int row, int col, float &val);
+	bool GetValue(const GPUgstate &state, int row, int col, float &val);
+	bool ColChanged(const GPUgstate &lastState, const GPUgstate &state, int row, int col);
 	void ToggleBreakpoint(int row);
 };
 

--- a/Windows/W32Util/Misc.cpp
+++ b/Windows/W32Util/Misc.cpp
@@ -234,7 +234,7 @@ int GenericListControl::HandleNotify(LPARAM lParam) {
 		return 0;
 	}
 
-	if (mhdr->code == NM_CUSTOMDRAW && ListenRowPrePaint()) {
+	if (mhdr->code == NM_CUSTOMDRAW && (ListenRowPrePaint() || ListenColPrePaint())) {
 		LPNMLVCUSTOMDRAW msg = (LPNMLVCUSTOMDRAW)lParam;
 		switch (msg->nmcd.dwDrawStage) {
 		case CDDS_PREPAINT:
@@ -242,6 +242,12 @@ int GenericListControl::HandleNotify(LPARAM lParam) {
 
 		case CDDS_ITEMPREPAINT:
 			if (OnRowPrePaint((int)msg->nmcd.dwItemSpec, msg)) {
+				return CDRF_NEWFONT;
+			}
+			return ListenColPrePaint() ? CDRF_NOTIFYSUBITEMDRAW : CDRF_DODEFAULT;
+
+		case CDDS_SUBITEM | CDDS_ITEMPREPAINT:
+			if (OnColPrePaint((int)msg->nmcd.dwItemSpec, msg->iSubItem, msg)) {
 				return CDRF_NEWFONT;
 			}
 			return CDRF_DODEFAULT;

--- a/Windows/W32Util/Misc.h
+++ b/Windows/W32Util/Misc.h
@@ -64,7 +64,9 @@ protected:
 	virtual void OnToggle(int item, bool newValue) { };
 
 	virtual bool ListenRowPrePaint() { return false; }
+	virtual bool ListenColPrePaint() { return false; }
 	virtual bool OnRowPrePaint(int row, LPNMLVCUSTOMDRAW msg) { return false; }
+	virtual bool OnColPrePaint(int row, int col, LPNMLVCUSTOMDRAW msg) { return false; }
 
 private:
 	static LRESULT CALLBACK wndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);

--- a/Windows/W32Util/Misc.h
+++ b/Windows/W32Util/Misc.h
@@ -33,6 +33,7 @@ struct GenericListViewDef
 
 #define GLVC_CENTERED		1
 
+typedef struct tagNMLVCUSTOMDRAW *LPNMLVCUSTOMDRAW;
 
 // the most significant bit states whether the key is currently down.
 // simply checking if it's != 0 is not enough, as bit0 is set if
@@ -44,7 +45,7 @@ class GenericListControl
 public:
 	GenericListControl(HWND hwnd, const GenericListViewDef& def);
 	virtual ~GenericListControl();
-	void HandleNotify(LPARAM lParam);
+	int HandleNotify(LPARAM lParam);
 	void Update();
 	int GetSelectedIndex();
 	HWND GetHandle() { return handle; };
@@ -61,6 +62,9 @@ protected:
 	virtual void OnRightClick(int itemIndex, int column, const POINT& point) { };
 	virtual void CopyRows(int start, int size);
 	virtual void OnToggle(int item, bool newValue) { };
+
+	virtual bool ListenRowPrePaint() { return false; }
+	virtual bool OnRowPrePaint(int row, LPNMLVCUSTOMDRAW msg) { return false; }
 
 private:
 	static LRESULT CALLBACK wndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
Similar to the register list for the CPU debugger, this highlights changed GE registers and matrix values in red.

I intentionally did not do this for vertices, which it doesn't really seem useful for.

-[Unknown]