### PR TITLE
softgpu: Apply region x2/y2 as a scissor

### DIFF
--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -179,7 +179,7 @@ void BinManager::UpdateState() {
 
 	if (HasDirty(SoftDirty::BINNER_RANGE)) {
 		DrawingCoords scissorTL(gstate.getScissorX1(), gstate.getScissorY1());
-		DrawingCoords scissorBR(gstate.getScissorX2(), gstate.getScissorY2());
+		DrawingCoords scissorBR(std::min(gstate.getScissorX2(), gstate.getRegionX2()), std::min(gstate.getScissorY2(), gstate.getRegionY2()));
 		ScreenCoords screenScissorTL = TransformUnit::DrawingToScreen(scissorTL, 0);
 		ScreenCoords screenScissorBR = TransformUnit::DrawingToScreen(scissorBR, 0);
 

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -208,19 +208,6 @@ static inline void SetPixelDepth(int x, int y, int stride, u16 value) {
 	depthbuf.Set16(x, y, stride, value);
 }
 
-static inline u8 GetPixelStencil(GEBufferFormat fmt, int fbStride, int x, int y) {
-	if (fmt == GE_FORMAT_565) {
-		// Always treated as 0 for comparison purposes.
-		return 0;
-	} else if (fmt == GE_FORMAT_5551) {
-		return ((fb.Get16(x, y, fbStride) & 0x8000) != 0) ? 0xFF : 0;
-	} else if (fmt == GE_FORMAT_4444) {
-		return Convert4To8(fb.Get16(x, y, fbStride) >> 12);
-	} else {
-		return fb.Get32(x, y, fbStride) >> 24;
-	}
-}
-
 static inline bool IsRightSideOrFlatBottomLine(const Vec2<int>& vertex, const Vec2<int>& line1, const Vec2<int>& line2)
 {
 	if (line1.y == line2.y) {
@@ -1245,21 +1232,6 @@ void DrawLine(const VertexData &v0, const VertexData &v1, const BinCoords &range
 		y += yinc;
 		z += zinc;
 	}
-}
-
-bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer) {
-	int w = gstate.getRegionX2() + 1;
-	int h = gstate.getRegionY2() + 1;
-	buffer.Allocate(w, h, GPU_DBG_FORMAT_8BIT);
-
-	u8 *row = buffer.GetData();
-	for (int y = 0; y < w; ++y) {
-		for (int x = 0; x < h; ++x) {
-			row[x] = GetPixelStencil(gstate.FrameBufFormat(), gstate.FrameBufStride(), x, y);
-		}
-		row += w;
-	}
-	return true;
 }
 
 bool GetCurrentTexture(GPUDebugBuffer &buffer, int level)

--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -75,7 +75,6 @@ void DrawPoint(const VertexData &v0, const BinCoords &range, const RasterizerSta
 void DrawLine(const VertexData &v0, const VertexData &v1, const BinCoords &range, const RasterizerState &state);
 void ClearRectangle(const VertexData &v0, const VertexData &v1, const BinCoords &range, const RasterizerState &state);
 
-bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer);
 bool GetCurrentTexture(GPUDebugBuffer &buffer, int level);
 
 // Shared functions with RasterizerRectangle.cpp

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -235,9 +235,9 @@ const SoftwareCommandTableEntry softgpuCommandTable[] = {
 	{ GE_CMD_MAXZ, 0, SoftDirty::PIXEL_BASIC | SoftDirty::PIXEL_CACHED },
 
 	// Region doesn't seem to affect scissor or anything.
-	// TODO: Double check, the registers are always set so they ought to... do something?
-	{ GE_CMD_REGION1 },
-	{ GE_CMD_REGION2 },
+	// As long as REGION1 is zero, REGION2 is effectively another scissor.
+	{ GE_CMD_REGION1, 0, SoftDirty::BINNER_RANGE },
+	{ GE_CMD_REGION2, 0, SoftDirty::BINNER_RANGE },
 
 	// Scissor, only used by the binner.
 	{ GE_CMD_SCISSOR1, 0, SoftDirty::BINNER_RANGE },


### PR DESCRIPTION
As long as the region rate register is 0, this effectively acts as a scissor correctly.

When driving in Ridge Racer, I experienced some color corruption and it seemed like some unexpected VRAM had been overwritten causing CLUTs to have weird colors.  I didn't have a clear cause, but after making this change I didn't reproduce in a full race.

Also adjusts debugger preview range a bit.

-[Unknown]