### PR TITLE
Debugger: Track unchanged VRAM to avoid copy

### DIFF
--- a/GPU/Debugger/Playback.cpp
+++ b/GPU/Debugger/Playback.cpp
@@ -564,8 +564,10 @@ void DumpExecute::Framebuf(int level, u32 ptr, u32 sz) {
 	u32 headerSize = (u32)sizeof(FramebufData);
 	u32 pspSize = sz - headerSize;
 	const bool isTarget = (framebuf->flags & 1) != 0;
+	const bool unchangedVRAM = (framebuf->flags & 2) != 0;
+	// TODO: Could use drawnVRAM flag, but it can be wrong.
 	// Could potentially always skip if !isTarget, but playing it safe for offset texture behavior.
-	if (Memory::IsValidRange(framebuf->addr, pspSize) && (!isTarget || !g_Config.bSoftwareRendering)) {
+	if (Memory::IsValidRange(framebuf->addr, pspSize) && !unchangedVRAM && (!isTarget || !g_Config.bSoftwareRendering)) {
 		// Intentionally don't trigger an upload here.
 		Memory::MemcpyUnchecked(framebuf->addr, pushbuf_.data() + ptr + headerSize, pspSize);
 	}

--- a/GPU/Debugger/Record.h
+++ b/GPU/Debugger/Record.h
@@ -37,5 +37,6 @@ void NotifyMemset(u32 dest, int v, u32 sz);
 void NotifyUpload(u32 dest, u32 sz);
 void NotifyDisplay(u32 addr, int stride, int fmt);
 void NotifyFrame();
+void NotifyCPU();
 
 };

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1021,6 +1021,8 @@ bool GPUCommon::InterpretList(DisplayList &list) {
 	}
 
 	FinishDeferred();
+	if (debugRecording_)
+		GPURecord::NotifyCPU();
 
 	// We haven't run the op at list.pc, so it shouldn't count.
 	if (cycleLastPC != list.pc) {


### PR DESCRIPTION
See #15251, the framedump here reused a VRAM texture for many draws, and this caused it to recopy the texture over and over again.  Use a flag to skip if possible.

The data is still in the frame dump either way, so we can still force copy while debugging if we think the tracking is wrong.

-[Unknown]