### PR TITLE
GLES: Use EXT not GLES3 for dualsrc blend support

### DIFF
--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -210,7 +210,7 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps, bool ski
 				glBindFragDataLocation(program->program, 0, "fragColor0");
 			}
 #elif !PPSSPP_PLATFORM(IOS)
-			if (gl_extensions.GLES3 && step.create_program.support_dual_source) {
+			if (gl_extensions.EXT_blend_func_extended && step.create_program.support_dual_source) {
 				glBindFragDataLocationIndexedEXT(program->program, 0, 0, "fragColor0");
 				glBindFragDataLocationIndexedEXT(program->program, 0, 1, "fragColor1");
 			}


### PR DESCRIPTION
See #15413, thanks icecream95.

This extension can work on GLES2 and isn't necessarily available with GLES3.  We wouldn't have set `support_dual_source` without the extension, so it was fine before, just only used with GLES3.

We already have DUAL_SOURCE_BLENDING_BROKEN to force disable it below 3.0, so we should keep it to that.

-[Unknown]