### PR TITLE
Early-out in texture replacement code, if replacement disabled

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1277,6 +1277,13 @@ u32 TextureCacheCommon::EstimateTexMemoryUsage(const TexCacheEntry *entry) {
 }
 
 ReplacedTexture &TextureCacheCommon::FindReplacement(TexCacheEntry *entry, int &w, int &h) {
+	// Short circuit the non-enabled case.
+	// Otherwise, due to bReplaceTexturesAllowLate, we'll still spawn tasks looking for replacements
+	// that then won't be used.
+	if (!replacer_.Enabled()) {
+		return replacer_.FindNone();
+	}
+
 	// Allow some delay to reduce pop-in.
 	constexpr double MAX_BUDGET_PER_TEX = 0.25 / 60.0;
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2771,9 +2771,12 @@ void GPUCommon::DoBlockTransfer(u32 skipDrawReason) {
 		framebufferManager_->NotifyBlockTransferAfter(dstBasePtr, dstStride, dstX, dstY, srcBasePtr, srcStride, srcX, srcY, width, height, bpp, skipDrawReason);
 	}
 
+	const uint32_t numBytes = width * height * bpp;
 	const uint32_t srcSize = height * srcStride * bpp;
 	const uint32_t dstSize = height * dstStride * bpp;
-	if (MemBlockInfoDetailed(srcSize, dstSize)) {
+	// We do the check here on the number of bytes to avoid marking really tiny images.
+	// Helps perf in GT menu which does insane amounts of these, one for each text character per frame.
+	if (MemBlockInfoDetailed(numBytes, numBytes)) {
 		const uint32_t src = srcBasePtr + (srcY * srcStride + srcX) * bpp;
 		const uint32_t dst = dstBasePtr + (dstY * dstStride + dstX) * bpp;
 		const std::string tag = "GPUBlockTransfer/" + GetMemWriteTagAt(src, srcSize);

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -657,7 +657,6 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		badMipSizes = false;
 	}
 
-
 	// Don't scale the PPGe texture.
 	if (entry->addr > 0x05000000 && entry->addr < PSP_GetKernelMemoryEnd()) {
 		scaleFactor = 1;


### PR DESCRIPTION
Quick work-around for a crash reported on Discord by Azuka and .QrTa, in the case of texture replacement disabled. Bug still seems to exist though, likely some race condition in the threadmanager, or similar.

Without this, due to bReplaceTexturesAllowLate, every single texture creation ends up spawning a task and waiting for it, whether replacement is enabled or not.

Reproduces easiest in the main menu of Gran Turismo when lots of text is showing.

QrTa narrowed the crash down to 1.12.324-1.12.389, so will look at that next. Which is aa12c9b39..aa12c9b39 . Between those are two thread-manager releated PRs, #15178 and #15205. The first one had a race condition that we later fixed that only happened on ARM - there might be more gremlins there.

![image](https://user-images.githubusercontent.com/130929/157317830-71b4f7d2-ecb1-4a91-9b75-d5f0935fa802.png)
