### PR TITLE
softgpu: Plug bad leak of bin queue data

### DIFF
--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -831,7 +831,7 @@ void VulkanQueueRunner::LogRenderPass(const VKRStep &pass, bool verbose) {
 
 	INFO_LOG(G3D, "RENDER %s Begin(%s, draws: %d, %dx%d, %s, %s, %s)", pass.tag, framebuf, r.numDraws, w, h, RenderPassActionName(r.color), RenderPassActionName(r.depth), RenderPassActionName(r.stencil));
 	// TODO: Log these in detail.
-	for (int i = 0; i < pass.preTransitions.size(); i++) {
+	for (int i = 0; i < (int)pass.preTransitions.size(); i++) {
 		INFO_LOG(G3D, "  PRETRANSITION: %s %s -> %s", pass.preTransitions[i].fb->tag.c_str(), AspectToString(pass.preTransitions[i].aspect), ImageLayoutToString(pass.preTransitions[i].targetLayout));
 	}
 

--- a/Common/Thread/ThreadManager.cpp
+++ b/Common/Thread/ThreadManager.cpp
@@ -221,7 +221,7 @@ void ThreadManager::EnqueueTask(Task *task) {
 	}
 
 	// Find a thread with no outstanding work.
-	_assert_(maxThread <= global_->threads_.size());
+	_assert_(maxThread <= (int)global_->threads_.size());
 	for (int threadNum = minThread; threadNum < maxThread; threadNum++) {
 		ThreadContext *thread = global_->threads_[threadNum];
 		if (thread->queue_size.load() == 0) {

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -192,7 +192,7 @@ void RestoreRegisterEvent(int &event_type, const char *name, TimedCallback callb
 		event_type = -1;
 	if (event_type == -1)
 		event_type = nextEventTypeRestoreId++;
-	if (event_type >= event_types.size()) {
+	if (event_type >= (int)event_types.size()) {
 		// Give it any unused event id starting from the end.
 		// Older save states with messed up ids have gaps near the end.
 		for (int i = (int)event_types.size() - 1; i >= 0; --i) {
@@ -202,7 +202,7 @@ void RestoreRegisterEvent(int &event_type, const char *name, TimedCallback callb
 			}
 		}
 	}
-	_assert_msg_(event_type >= 0 && event_type < event_types.size(), "Invalid event type %d", event_type);
+	_assert_msg_(event_type >= 0 && event_type < (int)event_types.size(), "Invalid event type %d", event_type);
 	event_types[event_type] = EventType{ callback, name };
 	usedEventTypes.insert(event_type);
 	restoredEventTypes.insert(event_type);

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -186,7 +186,7 @@ void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo, bool hasOK) {
 
 	// Without the scrollbar, we have 390 total pixels.
 	float WRAP_WIDTH = 340.0f;
-	if (UTF8StringNonASCIICount(text.c_str()) >= text.size() / 4) {
+	if ((size_t)UTF8StringNonASCIICount(text.c_str()) >= text.size() / 4) {
 		WRAP_WIDTH = 376.0f;
 		if (text.size() > 12) {
 			messageStyle.scale = 0.6f;

--- a/Core/FileLoaders/DiskCachingFileLoader.cpp
+++ b/Core/FileLoaders/DiskCachingFileLoader.cpp
@@ -91,7 +91,7 @@ size_t DiskCachingFileLoader::ReadAt(s64 absolutePos, size_t bytes, void *data, 
 	if (absolutePos >= filesize_) {
 		bytes = 0;
 	} else if (absolutePos + (s64)bytes >= filesize_) {
-		bytes = filesize_ - absolutePos;
+		bytes = (size_t)(filesize_ - absolutePos);
 	}
 
 	if (cache_ && cache_->IsValid() && (flags & Flags::HINT_UNCACHED) == 0) {
@@ -226,13 +226,13 @@ size_t DiskCachingFileLoaderCache::ReadFromCache(s64 pos, size_t bytes, void *da
 		return 0;
 	}
 
-	s64 cacheStartPos = pos / blockSize_;
-	s64 cacheEndPos = (pos + bytes - 1) / blockSize_;
+	size_t cacheStartPos = (size_t)(pos / blockSize_);
+	size_t cacheEndPos = (size_t)((pos + bytes - 1) / blockSize_);
 	size_t readSize = 0;
 	size_t offset = (size_t)(pos - (cacheStartPos * (u64)blockSize_));
 	u8 *p = (u8 *)data;
 
-	for (s64 i = cacheStartPos; i <= cacheEndPos; ++i) {
+	for (size_t i = cacheStartPos; i <= cacheEndPos; ++i) {
 		auto &info = index_[i];
 		if (info.block == INVALID_BLOCK) {
 			return readSize;
@@ -262,14 +262,14 @@ size_t DiskCachingFileLoaderCache::SaveIntoCache(FileLoader *backend, s64 pos, s
 		return backend->ReadAt(pos, bytes, data, flags);
 	}
 
-	s64 cacheStartPos = pos / blockSize_;
-	s64 cacheEndPos = (pos + bytes - 1) / blockSize_;
+	size_t cacheStartPos = (size_t)(pos / blockSize_);
+	size_t cacheEndPos = (size_t)((pos + bytes - 1) / blockSize_);
 	size_t readSize = 0;
 	size_t offset = (size_t)(pos - (cacheStartPos * (u64)blockSize_));
 	u8 *p = (u8 *)data;
 
 	size_t blocksToRead = 0;
-	for (s64 i = cacheStartPos; i <= cacheEndPos; ++i) {
+	for (size_t i = cacheStartPos; i <= cacheEndPos; ++i) {
 		auto &info = index_[i];
 		if (info.block != INVALID_BLOCK) {
 			break;
@@ -572,7 +572,7 @@ void DiskCachingFileLoaderCache::LoadCacheIndex() {
 		return;
 	}
 
-	indexCount_ = (filesize_ + blockSize_ - 1) / blockSize_;
+	indexCount_ = (size_t)((filesize_ + blockSize_ - 1) / blockSize_);
 	index_.resize(indexCount_);
 	blockIndexLookup_.resize(maxBlocks_);
 	memset(&blockIndexLookup_[0], INVALID_INDEX, maxBlocks_ * sizeof(blockIndexLookup_[0]));
@@ -646,7 +646,7 @@ void DiskCachingFileLoaderCache::CreateCacheFile(const Path &path) {
 		return;
 	}
 
-	indexCount_ = (filesize_ + blockSize_ - 1) / blockSize_;
+	indexCount_ = (size_t)((filesize_ + blockSize_ - 1) / blockSize_);
 	index_.clear();
 	index_.resize(indexCount_);
 	blockIndexLookup_.resize(maxBlocks_);

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -599,7 +599,7 @@ bool IsKeyMapped(int device, int key) {
 
 bool ReplaceSingleKeyMapping(int btn, int index, KeyDef key) {
 	// Check for duplicate
-	for (int i = 0; i < g_controllerMap[btn].size(); ++i) {
+	for (int i = 0; i < (int)g_controllerMap[btn].size(); ++i) {
 		if (i != index && g_controllerMap[btn][i] == key) {
 			g_controllerMap[btn].erase(g_controllerMap[btn].begin()+index);
 			g_controllerMapGeneration++;

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -228,7 +228,7 @@ bool PresentationCommon::UpdatePostShader() {
 
 	bool usePreviousFrame = false;
 	bool usePreviousAtOutputResolution = false;
-	for (int i = 0; i < shaderInfo.size(); ++i) {
+	for (size_t i = 0; i < shaderInfo.size(); ++i) {
 		const ShaderInfo *next = i + 1 < shaderInfo.size() ? shaderInfo[i + 1] : nullptr;
 		if (!BuildPostShader(shaderInfo[i], next)) {
 			DestroyPostShader();
@@ -712,7 +712,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 				// This is the last pass and we're going direct to the backbuffer after this.
 				// Redirect output to a separate framebuffer to keep the previous frame.
 				previousIndex_++;
-				if (previousIndex_ >= previousFramebuffers_.size())
+				if (previousIndex_ >= (int)previousFramebuffers_.size())
 					previousIndex_ = 0;
 				postShaderFramebuffer = previousFramebuffers_[previousIndex_];
 			}
@@ -734,7 +734,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 
 		// Pick the next to render to.
 		previousIndex_++;
-		if (previousIndex_ >= previousFramebuffers_.size())
+		if (previousIndex_ >= (int)previousFramebuffers_.size())
 			previousIndex_ = 0;
 		Draw::Framebuffer *postShaderFramebuffer = previousFramebuffers_[previousIndex_];
 

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "ppsspp_config.h"
 #include <cmath>
 
 #include "Common/Common.h"
@@ -874,7 +875,7 @@ typedef Math3D::Vec4<float> Vec4f;
 
 #if defined(_M_SSE)
 template<unsigned i>
-float vectorGetByIndex(__m128 v) {
+float MATH3D_CALL vectorGetByIndex(__m128 v) {
 	// shuffle V so that the element that we want is moved to the bottom
 	return _mm_cvtss_f32(_mm_shuffle_ps(v, v, _MM_SHUFFLE(i, i, i, i)));
 }
@@ -930,7 +931,7 @@ inline void Vec3ByMatrix43(float vecOut[3], const float v[3], const float m[12])
 }
 
 inline Vec3f MATH3D_CALL Vec3ByMatrix43(const Vec3f v, const float m[12]) {
-#if defined(_M_SSE)
+#if defined(_M_SSE) && PPSSPP_ARCH(64BIT)
 	__m128 x = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(0, 0, 0, 0));
 	__m128 y = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(1, 1, 1, 1));
 	__m128 z = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(2, 2, 2, 2));
@@ -988,7 +989,7 @@ inline void Vec3ByMatrix44(float vecOut[4], const float v[3], const float m[16])
 }
 
 inline Vec4f MATH3D_CALL Vec3ByMatrix44(const Vec3f v, const float m[16]) {
-#if defined(_M_SSE)
+#if defined(_M_SSE) && PPSSPP_ARCH(64BIT)
 	__m128 x = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(0, 0, 0, 0));
 	__m128 y = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(1, 1, 1, 1));
 	__m128 z = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(2, 2, 2, 2));
@@ -1047,7 +1048,7 @@ inline void Norm3ByMatrix43(float vecOut[3], const float v[3], const float m[12]
 }
 
 inline Vec3f MATH3D_CALL Norm3ByMatrix43(const Vec3f v, const float m[12]) {
-#if defined(_M_SSE)
+#if defined(_M_SSE) && PPSSPP_ARCH(64BIT)
 	__m128 x = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(0, 0, 0, 0));
 	__m128 y = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(1, 1, 1, 1));
 	__m128 z = _mm_shuffle_ps(v.vec, v.vec, _MM_SHUFFLE(2, 2, 2, 2));
@@ -1203,7 +1204,11 @@ template<>
 __forceinline unsigned int Vec3<float>::ToRGB() const
 {
 #if defined(_M_SSE)
+#if PPSSPP_ARCH(64BIT)
 	__m128i c = _mm_cvtps_epi32(_mm_mul_ps(vec, _mm_set_ps1(255.0f)));
+#else
+	__m128i c = _mm_cvtps_epi32(_mm_mul_ps(_mm_loadu_ps((float *)&vec), _mm_set_ps1(255.0f)));
+#endif
 	__m128i c16 = _mm_packs_epi32(c, c);
 	return _mm_cvtsi128_si32(_mm_packus_epi16(c16, c16)) & 0x00FFFFFF;
 #else
@@ -1217,7 +1222,11 @@ template<>
 __forceinline unsigned int Vec3<int>::ToRGB() const
 {
 #if defined(_M_SSE)
+#if PPSSPP_ARCH(64BIT)
 	__m128i c16 = _mm_packs_epi32(ivec, ivec);
+#else
+	__m128i c16 = _mm_packs_epi32(_mm_loadu_si128(&ivec), _mm_setzero_si128());
+#endif
 	return _mm_cvtsi128_si32(_mm_packus_epi16(c16, c16)) & 0x00FFFFFF;
 #else
 	return clamp_u8(r()) | (clamp_u8(g()) << 8) | (clamp_u8(b()) << 16);
@@ -1263,7 +1272,11 @@ template<>
 __forceinline unsigned int Vec4<float>::ToRGBA() const
 {
 #if defined(_M_SSE)
+#if PPSSPP_ARCH(64BIT)
 	__m128i c = _mm_cvtps_epi32(_mm_mul_ps(vec, _mm_set_ps1(255.0f)));
+#else
+	__m128i c = _mm_cvtps_epi32(_mm_mul_ps(_mm_loadu_ps((float *)&vec), _mm_set_ps1(255.0f)));
+#endif
 	__m128i c16 = _mm_packs_epi32(c, c);
 	return _mm_cvtsi128_si32(_mm_packus_epi16(c16, c16));
 #else
@@ -1278,7 +1291,11 @@ template<>
 __forceinline unsigned int Vec4<int>::ToRGBA() const
 {
 #if defined(_M_SSE)
+#if PPSSPP_ARCH(64BIT)
 	__m128i c16 = _mm_packs_epi32(ivec, ivec);
+#else
+	__m128i c16 = _mm_packs_epi32(_mm_loadu_si128(&ivec), _mm_setzero_si128());
+#endif
 	return _mm_cvtsi128_si32(_mm_packus_epi16(c16, c16));
 #else
 	return clamp_u8(r()) | (clamp_u8(g()) << 8) | (clamp_u8(b()) << 16) | (clamp_u8(a()) << 24);

--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -216,7 +216,12 @@ public:
 	}
 
 protected:
+#if PPSSPP_ARCH(32BIT)
+	// Use less memory and less address space.  We're unlikely to have 32 cores on a 32-bit CPU.
+	static constexpr int MAX_POSSIBLE_TASKS = 16;
+#else
 	static constexpr int MAX_POSSIBLE_TASKS = 64;
+#endif
 	// This is about 1MB of state data.
 	static constexpr int QUEUED_STATES = 4096;
 	// These are 1KB each, so half an MB.

--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -61,11 +61,11 @@ struct BinQueue {
 		Reset();
 	}
 	~BinQueue() {
-		delete [] items_;
+		FreeAlignedMemory(items_);
 	}
 
 	void Setup() {
-		items_ = new T[N];
+		items_ = (T *)AllocateAlignedMemory(sizeof(T) * N, 16);
 	}
 
 	void Reset() {

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -472,9 +472,8 @@ SoftGPU::~SoftGPU() {
 		fbTex = nullptr;
 	}
 
-	if (presentation_) {
-		delete presentation_;
-	}
+	delete presentation_;
+	delete drawEngine_;
 
 	Sampler::Shutdown();
 	Rasterizer::Shutdown();


### PR DESCRIPTION
There were some possible crashes/issues remaining on 32-bit with the new software renderer queues, which this fixes.

More importantly, it turns out the draw engine for softgpu was never getting freed, which meant a lot of things attached to that never got freed either.  This made memory usage steadily rise while running automated tests, and is likely the cause of #15434.

Fixes #15434 (at least builds from Visual Studio.)

-[Unknown]