### PR TITLE
Debugger: Fast path write tag lookup

### DIFF
--- a/Core/Debugger/MemBlockInfo.cpp
+++ b/Core/Debugger/MemBlockInfo.cpp
@@ -461,7 +461,8 @@ std::vector<MemBlockInfo> FindMemInfoByFlag(MemBlockFlags flags, uint32_t start,
 std::string GetMemWriteTagAt(uint32_t start, uint32_t size) {
 	std::vector<MemBlockInfo> memRangeInfo = FindMemInfoByFlag(MemBlockFlags::WRITE, start, size);
 	for (auto range : memRangeInfo) {
-		return range.tag;
+		if (range.tag != "MemInit")
+			return range.tag;
 	}
 
 	// Fall back to alloc and texture, especially for VRAM.  We prefer write above.
@@ -469,7 +470,7 @@ std::string GetMemWriteTagAt(uint32_t start, uint32_t size) {
 	for (auto range : memRangeInfo) {
 		return range.tag;
 	}
-	return "none";
+	return StringFromFormat("%08x_size_%08x", start, size);
 }
 
 void MemBlockInfoInit() {

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1038,7 +1038,7 @@ void DrawPoint(const VertexData &v0, const BinCoords &range, const RasterizerSta
 	auto &pixelID = state.pixelID;
 	auto &samplerID = state.samplerID;
 
-	if (state.enableTextures && !pixelID.clearMode) {
+	if (state.enableTextures) {
 		float s = v0.texturecoords.s();
 		float t = v0.texturecoords.t();
 		if (state.throughMode) {
@@ -1064,7 +1064,7 @@ void DrawPoint(const VertexData &v0, const BinCoords &range, const RasterizerSta
 	u16 z = pos.z;
 
 	u8 fog = 255;
-	if (pixelID.applyFog && !pixelID.clearMode) {
+	if (pixelID.applyFog) {
 		fog = ClampFogDepth(v0.fogdepth);
 	}
 
@@ -1315,7 +1315,7 @@ void DrawLine(const VertexData &v0, const VertexData &v1, const BinCoords &range
 			}
 
 			u8 fog = 255;
-			if (pixelID.applyFog && !pixelID.clearMode) {
+			if (pixelID.applyFog) {
 				fog = ClampFogDepth((v0.fogdepth * (float)(steps - i) + v1.fogdepth * (float)i) / steps1);
 			}
 
@@ -1325,7 +1325,7 @@ void DrawLine(const VertexData &v0, const VertexData &v1, const BinCoords &range
 				prim_color.a() = 0x7F;
 			}
 
-			if (state.enableTextures && !pixelID.clearMode) {
+			if (state.enableTextures) {
 				float s, s1;
 				float t, t1;
 				if (state.throughMode) {


### PR DESCRIPTION
There's on area of the GoW demo that this improves by 3% in Vulkan on PC.

This also improves the quality of tag info by skipping MemInit (if no write yet) to use the allocation instead in that scenario.

-[Unknown]