### PR TITLE
[Adhoc] Fix inconsistency issue between Windows and non-Windows

### DIFF
--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1906,7 +1906,7 @@ static std::vector<std::pair<uint32_t, uint32_t>> InitPrivateIPRanges() {
 
 bool isPrivateIP(uint32_t ip) {
 	static const std::vector<std::pair<uint32_t, uint32_t>> ip_ranges = InitPrivateIPRanges();
-	for (auto ipRange : ip_ranges) {
+	for (auto& ipRange : ip_ranges) {
 		if ((ip & ipRange.second) == (ipRange.first & ipRange.second)) // We can just use ipRange.first directly if it's already correctly formatted
 			return true;
 	}

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1795,7 +1795,7 @@ int getLocalIp(sockaddr_in* SocketAddress) {
 
 #if !PPSSPP_PLATFORM(SWITCH)
 	if (metasocket != (int)INVALID_SOCKET) {
-		struct sockaddr_in localAddr;
+		struct sockaddr_in localAddr {};
 		localAddr.sin_addr.s_addr = INADDR_ANY;
 		socklen_t addrLen = sizeof(localAddr);
 		int ret = getsockname((int)metasocket, (struct sockaddr*)&localAddr, &addrLen);
@@ -1876,7 +1876,7 @@ int getLocalIp(sockaddr_in* SocketAddress) {
 }
 
 uint32_t getLocalIp(int sock) {
-	struct sockaddr_in localAddr;
+	struct sockaddr_in localAddr {};
 	localAddr.sin_addr.s_addr = INADDR_ANY;
 	socklen_t addrLen = sizeof(localAddr);
 	getsockname(sock, (struct sockaddr*)&localAddr, &addrLen);
@@ -1887,7 +1887,7 @@ uint32_t getLocalIp(int sock) {
 }
 
 static std::vector<std::pair<uint32_t, uint32_t>> InitPrivateIPRanges() {
-	struct sockaddr_in saNet, saMask;
+	struct sockaddr_in saNet {}, saMask{};
 	std::vector<std::pair<uint32_t, uint32_t>> ip_ranges;
 
 	if (1 == inet_pton(AF_INET, "192.168.0.0", &(saNet.sin_addr)) && 1 == inet_pton(AF_INET, "255.255.0.0", &(saMask.sin_addr)))
@@ -1934,7 +1934,7 @@ void getLocalMac(SceNetEtherAddr * addr){
 }
 
 uint16_t getLocalPort(int sock) {
-	struct sockaddr_in localAddr;
+	struct sockaddr_in localAddr {};
 	localAddr.sin_port = 0;
 	socklen_t addrLen = sizeof(localAddr);
 	getsockname(sock, (struct sockaddr*)&localAddr, &addrLen);

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1989,6 +1989,15 @@ int setSockTimeout(int sock, int opt, unsigned long timeout_usec) { // opt = SO_
 	return setsockopt(sock, SOL_SOCKET, opt, (char*)&optval, sizeof(optval));
 }
 
+int getSockError(int sock) {
+	int result = 0;
+	socklen_t result_len = sizeof(result);
+	if (getsockopt(sock, SOL_SOCKET, SO_ERROR, (char*)&result, &result_len) < 0) {
+		result = errno;
+	}
+	return result;
+}
+
 int getSockNoDelay(int tcpsock) { 
 	int opt = 0;
 	socklen_t optlen = sizeof(opt);

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -294,11 +294,12 @@ typedef struct SceNetAdhocctlPeerInfo {
   SceNetAdhocctlPeerInfo * next;
   SceNetAdhocctlNickname nickname;
   SceNetEtherAddr mac_addr;
-  u16_le padding;
+  u16_le padding; // a copy of the padding(?) from SceNetAdhocctlPeerInfoEmu
   u32_le flags;
   u64_le last_recv; // Need to use the same method with sceKernelGetSystemTimeWide (ie. CoreTiming::GetGlobalTimeUsScaled) to prevent timing issue (ie. in game timeout)
   
   u32_le ip_addr; // internal use only
+  u16_le port_offset; // IP-specific port offset (internal use only)
 } PACK SceNetAdhocctlPeerInfo;
 
 // Peer Information with u32 pointers
@@ -306,7 +307,7 @@ typedef struct SceNetAdhocctlPeerInfoEmu {
   u32_le next; // Changed the pointer to u32
   SceNetAdhocctlNickname nickname;
   SceNetEtherAddr mac_addr;
-  u16_le padding; //00 00
+  u16_le padding; //00 00 // Note: Not sure whether this is really padding or reserved/unknown field
   u32_le flags; //00 04 00 00 on KHBBS and FF FF FF FF on Ys vs. Sora no Kiseki // State of the peer? Or related to sceNetAdhocAuth_CF4D9BED ?
   u64_le last_recv; // Need to use the same method with sceKernelGetSystemTimeWide (ie. CoreTiming::GetGlobalTimeUsScaled) to prevent timing issue (ie. in game timeout)
 } PACK SceNetAdhocctlPeerInfoEmu;
@@ -1448,9 +1449,10 @@ bool resolveIP(uint32_t ip, SceNetEtherAddr * mac);
  * Resolve MAC to IP
  * @param mac Peer MAC Address
  * @param ip OUT: Peer IP
+ * @param port_offset OUT: Peer IP-specific Port Offset
  * @return true on success
  */
-bool resolveMAC(SceNetEtherAddr * mac, uint32_t * ip);
+bool resolveMAC(SceNetEtherAddr* mac, uint32_t* ip, u16* port_offset = nullptr);
 
 /**
  * Check whether Network Name contains only valid symbols

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -61,6 +61,7 @@
 #undef ECONNABORTED
 #undef ECONNRESET
 #undef ECONNREFUSED
+#undef ENETUNREACH
 #undef ENOTCONN
 #undef EAGAIN
 #undef EINPROGRESS
@@ -73,6 +74,7 @@
 #define ECONNABORTED WSAECONNABORTED
 #define ECONNRESET WSAECONNRESET
 #define ECONNREFUSED WSAECONNREFUSED
+#define ENETUNREACH WSAENETUNREACH
 #define ENOTCONN WSAENOTCONN
 #define EAGAIN WSAEWOULDBLOCK
 #define EINPROGRESS WSAEWOULDBLOCK
@@ -395,6 +397,7 @@ typedef struct AdhocSocket {
 	s32 retry_count; // multiply with retry interval to be used as keepalive timeout
 	s32 attemptCount; // connect/accept attempts
 	u64 lastAttempt; // timestamp to retry again
+	bool isClient; // true if the game is using local port 0 when creating the socket
 	union {
 		SceNetAdhocPdpStat pdp;
 		SceNetAdhocPtpStat ptp;

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -1341,6 +1341,11 @@ int setSockMSS(int sock, int size);
 int setSockTimeout(int sock, int opt, unsigned long timeout_usec);
 
 /*
+ * Get Socket SO_ERROR (Requests and clears pending error information on the socket)
+ */
+int getSockError(int sock);
+
+/*
  * Get TCP Socket TCP_NODELAY (Nagle Algo)
  */
 int getSockNoDelay(int tcpsock);

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1685,7 +1685,7 @@ static int sceNetAdhocPdpSend(int id, const char *mac, u32 port, void *data, int
 								// Non-blocking
 								else {
 									// Iterate Peers
-									for (auto peer : dest.peers) {
+									for (auto& peer : dest.peers) {
 										// Fill in Target Structure
 										struct sockaddr_in target {};
 										target.sin_family = AF_INET;
@@ -4492,7 +4492,7 @@ static int sceNetAdhocGameModeUpdateReplica(int id, u32 infoAddr) {
 		gmuinfo = (GameModeUpdateInfo*)Memory::GetPointer(infoAddr);
 	}
 
-	for (auto gma : replicaGameModeAreas) {
+	for (auto& gma : replicaGameModeAreas) {
 		if (gma.id == id) {
 			if (gma.data && gma.dataUpdated) {
 				Memory::Memcpy(gma.addr, gma.data, gma.size);
@@ -6421,7 +6421,7 @@ void sendAcceptPacket(SceNetAdhocMatchingContext * context, SceNetEtherAddr * ma
 		uint32_t siblingbuflen = 0;
 
 		// Parent Mode
-		if (context->mode == PSP_ADHOC_MATCHING_MODE_PARENT) siblingbuflen = sizeof(SceNetEtherAddr) * (countConnectedPeers(context) - 2);
+		if (context->mode == PSP_ADHOC_MATCHING_MODE_PARENT) siblingbuflen = (u32)sizeof(SceNetEtherAddr) * (countConnectedPeers(context) - 2);
 
 		// Sibling Count
 		int siblingcount = siblingbuflen / sizeof(SceNetEtherAddr);

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -600,7 +600,7 @@ int DoBlockingPdpSend(int uid, AdhocSocketRequest& req, s64& result, AdhocSendTa
 	bool retry = false;
 	for (auto peer = targetPeers.peers.begin(); peer != targetPeers.peers.end(); ) {
 		// Fill in Target Structure
-		struct sockaddr_in target;
+		struct sockaddr_in target {};
 		target.sin_family = AF_INET;
 		target.sin_addr.s_addr = peer->ip;
 		target.sin_port = htons(peer->port + ((isOriPort && !isPrivateIP(peer->ip)) ? 0 : portOffset));
@@ -1379,7 +1379,7 @@ static int sceNetAdhocPdpCreate(const char *mac, int port, int bufferSize, u32 f
 					setUDPConnReset(usocket, false);
 
 					// Binding Information for local Port
-					struct sockaddr_in addr;
+					struct sockaddr_in addr {};
 					addr.sin_family = AF_INET;
 					addr.sin_addr.s_addr = INADDR_ANY;
 					if (isLocalServer) {
@@ -1577,7 +1577,7 @@ static int sceNetAdhocPdpSend(int id, const char *mac, u32 port, void *data, int
 							// Single Target
 							if (!isBroadcastMAC(daddr)) {
 								// Fill in Target Structure
-								struct sockaddr_in target;
+								struct sockaddr_in target {};
 								target.sin_family = AF_INET;
 								target.sin_port = htons(dport + portOffset);
 
@@ -1687,7 +1687,7 @@ static int sceNetAdhocPdpSend(int id, const char *mac, u32 port, void *data, int
 									// Iterate Peers
 									for (auto peer : dest.peers) {
 										// Fill in Target Structure
-										struct sockaddr_in target;
+										struct sockaddr_in target {};
 										target.sin_family = AF_INET;
 										target.sin_addr.s_addr = peer.ip;
 										target.sin_port = htons(dport + ((isOriPort && !isPrivateIP(peer.ip)) ? 0 : portOffset));
@@ -2164,7 +2164,7 @@ int NetAdhocPdp_Delete(int id, int unknown) {
 			// Valid Socket
 			if (sock != NULL && sock->type == SOCK_PDP) {
 				// Close Connection
-				struct linger sl;
+				struct linger sl {};
 				sl.l_onoff = 1;		// non-zero value enables linger option in kernel
 				sl.l_linger = 0;	// timeout interval in seconds
 				setsockopt(sock->data.pdp.id, SOL_SOCKET, SO_LINGER, (const char*)&sl, sizeof(sl));
@@ -3307,7 +3307,7 @@ static int sceNetAdhocPtpOpen(const char *srcmac, int sport, const char *dstmac,
 					setSockNoDelay(tcpsocket, 1);
 
 					// Binding Information for local Port
-					struct sockaddr_in addr;
+					struct sockaddr_in addr {};
 					// addr.sin_len = sizeof(addr);
 					addr.sin_family = AF_INET;
 					addr.sin_addr.s_addr = INADDR_ANY;
@@ -3776,7 +3776,7 @@ int NetAdhocPtp_Close(int id, int unknown) {
 			// Valid Socket
 			if (socket != NULL && socket->type == SOCK_PTP) {
 				// Close Connection
-				struct linger sl;
+				struct linger sl {};
 				sl.l_onoff = 1;		// non-zero value enables linger option in kernel
 				sl.l_linger = 0;	// timeout interval in seconds
 				setsockopt(socket->data.ptp.id, SOL_SOCKET, SO_LINGER, (const char*)&sl, sizeof(sl));
@@ -3892,7 +3892,7 @@ static int sceNetAdhocPtpListen(const char *srcmac, int sport, int bufsize, int 
 					setSockNoDelay(tcpsocket, 1);
 
 					// Binding Information for local Port
-					struct sockaddr_in addr;
+					struct sockaddr_in addr {};
 					addr.sin_family = AF_INET;
 					addr.sin_addr.s_addr = INADDR_ANY;
 					if (isLocalServer) {

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -876,13 +876,6 @@ int DoBlockingPtpFlush(int uid, AdhocSocketRequest& req, s64& result) {
 		else
 			result = ERROR_NET_ADHOC_TIMEOUT;
 	}
-	else if (isDisconnected(sockerr)) {
-		// Change Socket State. // FIXME: Does Alerted Socket should be closed too?
-		ptpsocket.state = ADHOC_PTP_STATE_CLOSED;
-
-		// Disconnected
-		result = ERROR_NET_ADHOC_DISCONNECTED;
-	}
 	
 	if (sockerr != 0) {
 		DEBUG_LOG(SCENET, "sceNetAdhocPtpFlush[%i]: Socket Error (%i)", req.id, sockerr);
@@ -4261,13 +4254,6 @@ static int sceNetAdhocPtpFlush(int id, int timeout, int nonblock) {
 					// Simulate blocking behaviour with non-blocking socket
 					u64 threadSocketId = ((u64)__KernelGetCurThread()) << 32 | ptpsocket.id;
 					return WaitBlockingAdhocSocket(threadSocketId, PTP_FLUSH, id, nullptr, nullptr, timeout, nullptr, nullptr, "ptp flush");
-				}
-				else if (isDisconnected(error)) {
-					// Change Socket State
-					ptpsocket.state = ADHOC_PTP_STATE_CLOSED;
-
-					// Disconnected
-					return hleLogError(SCENET, ERROR_NET_ADHOC_DISCONNECTED, "disconnected");
 				}
 
 				if (error != 0)

--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -45,6 +45,7 @@ struct AdhocctlRequest {
 struct AdhocSendTarget {
 	u32 ip;
 	u16 port; // original port
+	u16 portOffset; // port offset specific for this target IP
 };
 
 struct AdhocSendTargets {


### PR DESCRIPTION
This should:
- Fix disconnection issue on some games that use `sceNetAdhocPtpFlush` (mostly occurred on Linux) when the remote peer already closed the connection (ie. R-Type Command https://github.com/hrydgard/ppsspp/issues/14641#issuecomment-1059791525)
- _Might fix_ Unknown Source Port issue that occurred randomly on some games that use PDP communication (ie. MGS:PW). Test build confirmed by UltimaGamerX at discord to work better than official PPSSPP (MGS:PW co-op didn't work for him using official ppsspp). _But may need to be tested by more players who had Unknown Source Port issue to make sure, since i couldn't reproduce that issue anymore._
- _Might fix_ `sceNetAdhocPtpConnect` issue on Linux when the remote host is not listening yet on some games (ie. Taiko no Tatsujin Portable DX https://github.com/hrydgard/ppsspp/issues/14641#issuecomment-1067286995). _Need someone to test this on non-Windows._

**Test build:**
Android: https://sam.nl.tab.digital/s/EmmKP45q2PC7Sbi
iOS: https://sam.nl.tab.digital/s/c3Qst63Qw65qTE8