### PR TITLE
Allow to change atlas per theme

### DIFF
--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -10,7 +10,6 @@
 #include "Common/UI/Context.h"
 #include "Common/Render/DrawBuffer.h"
 #include "Common/Render/Text/draw_text.h"
-
 #include "Common/Log.h"
 #include "UI/TextureUtil.h"
 
@@ -36,10 +35,14 @@ void UIContext::Init(Draw::DrawContext *thin3d, Draw::Pipeline *uipipe, Draw::Pi
 	textDrawer_ = TextDrawer::Create(thin3d);  // May return nullptr if no implementation is available for this platform.
 }
 
+void UIContext::setUIAtlas(const std::string &name) {
+	UIAtlas_ = name;
+}
+
 void UIContext::BeginFrame() {
-	if (!uitexture_) {
-		uitexture_ = CreateTextureFromFile(draw_, "ui_atlas.zim", ImageFileType::ZIM, false);
-		_dbg_assert_msg_(uitexture_, "Failed to load ui_atlas.zim.\n\nPlace it in the directory \"assets\" under your PPSSPP directory.");
+	if (!uitexture_ || UIAtlas_ != lastUIAtlas_) {
+		uitexture_ = CreateTextureFromFile(draw_, UIAtlas_.c_str(), ImageFileType::ZIM, false);
+		lastUIAtlas_ = UIAtlas_;
 		if (!fontTexture_) {
 #if PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(ANDROID)
 			// Don't bother with loading font_atlas.zim

--- a/Common/UI/Context.h
+++ b/Common/UI/Context.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 #include <cstdint>
+#include <string>
 
 #include "Common/Math/geom2d.h"
 #include "Common/Math/lin/vec3.h"
@@ -100,6 +101,8 @@ public:
 	void PopTransform();
 	Bounds TransformBounds(const Bounds &bounds);
 
+	void setUIAtlas(const std::string &name);
+
 private:
 	Draw::DrawContext *draw_ = nullptr;
 	Bounds bounds_;
@@ -120,4 +123,7 @@ private:
 
 	std::vector<Bounds> scissorStack_;
 	std::vector<UITransform> transformStack_;
+
+	std::string lastUIAtlas_;
+	std::string UIAtlas_ = "ui_atlas.zim";
 };

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -885,9 +885,9 @@ void GameSettingsScreen::CreateViews() {
 		backgroundChoice_->OnClick.Handle(this, &GameSettingsScreen::OnChangeBackground);
 	}
 
-	PopupMultiChoiceDynamic *theme = systemSettings->Add(new PopupMultiChoiceDynamic(&g_Config.sThemeName, sy->T("Color Theme"), GetThemeInfoNames(), th->GetName(), screenManager()));
+	PopupMultiChoiceDynamic *theme = systemSettings->Add(new PopupMultiChoiceDynamic(&g_Config.sThemeName, sy->T("Theme"), GetThemeInfoNames(), th->GetName(), screenManager()));
 	theme->OnChoice.Add([=](EventParams &e) {
-		UpdateTheme();
+		UpdateTheme(screenManager()->getUIContext());
 
 		return UI::EVENT_CONTINUE;
 	});

--- a/UI/Theme.h
+++ b/UI/Theme.h
@@ -21,9 +21,12 @@
 #include <vector>
 
 #include "Common/UI/Context.h"
+#include "Common/Render/TextureAtlas.h"
 
 void ReloadAllThemeInfo();
 
 std::vector<std::string> GetThemeInfoNames();
-void UpdateTheme();
+void UpdateTheme(UIContext *ctx);
+Atlas *GetFontAtlas();
+Atlas *GetUIAtlas();
 UI::Theme *GetTheme();


### PR DESCRIPTION
In the theme ini: `UIAtlas = ui_atlas_name` (without extension, code will add `.meta` and `.zim` as appropriate).

Font atlas can't be changed as I don't think it's worth changing it.