### PR TITLE
Detect number of cores in build script

### DIFF
--- a/b.sh
+++ b/b.sh
@@ -83,6 +83,13 @@ else
 	BUILD_DIR="build"
 fi
 
+CORES_COUNT=4
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        CORES_COUNT="$(nproc)"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+        CORES_COUNT="$(sysctl -n hw.physicalcpu)"
+fi
+
 # Strict errors. Any non-zero return exits this script
 set -e
 
@@ -90,6 +97,5 @@ mkdir -p ${BUILD_DIR}
 pushd ${BUILD_DIR}
 
 cmake $CMAKE_ARGS ..
-
-make -j4 $MAKE_OPT
+make -j$CORES_COUNT $MAKE_OPT
 popd


### PR DESCRIPTION
I noticed that there was a hardcoded number of core used for make in `b.sh`. I changed it to autodetect via `nproc` on Linux and `sysctl` on MacOS. Default is still 4. 

What other platforms do you support and how to best detect number of cores there?

Timings before and after change. Running on M1 Air 16GB
```
# Core count 4
 ./b.sh --qtbrew  389.59s user 22.87s system 376% cpu 1:49.66 total
 
# Core count 8
./b.sh --qtbrew  535.43s user 31.62s system 624% cpu 1:30.74 total
 ```