### PR TITLE
Net: Ignore SIGPIPE errors on POSIX systems

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -32,3 +32,7 @@ charset = utf-8
 [libretro/**.{cpp,h}]
 indent_style = space
 indent_size = 3
+
+[SDL/SDLMain.mm]
+indent_style = space
+indent_size = 4

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -48,6 +48,7 @@
 #include "Core/ConfigValues.h"
 #include "Core/HW/Camera.h"
 
+#include <signal.h>
 #include <string.h>
 
 MainUI *emugl = nullptr;
@@ -708,6 +709,11 @@ int main(int argc, char *argv[])
 			printf("%s\n", PPSSPP_GIT_VERSION);
 			return 0;
 		}
+	}
+
+	// Ignore sigpipe.
+	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+		perror("Unable to ignore SIGPIPE");
 	}
 
 	PROFILE_INIT();

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -18,6 +18,7 @@ SDLJoystick *joystick = NULL;
 #include <atomic>
 #include <algorithm>
 #include <cmath>
+#include <csignal>
 #include <thread>
 #include <locale>
 
@@ -519,6 +520,11 @@ int main(int argc, char *argv[]) {
 #ifdef HAVE_LIBNX
 	socketInitializeDefault();
 	nxlinkStdio();
+#else // HAVE_LIBNX
+	// Ignore sigpipe.
+	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+		perror("Unable to ignore SIGPIPE");
+	}
 #endif // HAVE_LIBNX
 
 	PROFILE_INIT();

--- a/SDL/SDLMain.mm
+++ b/SDL/SDLMain.mm
@@ -8,6 +8,7 @@
 #include "SDL.h"
 #include "SDLMain.h"
 #include "Common/Profiler/Profiler.h"
+#include <signal.h>
 #include <sys/param.h> /* for MAXPATHLEN */
 #include <unistd.h>
 
@@ -373,6 +374,11 @@ int main (int argc, char **argv)
     }
 
     PROFILE_INIT();
+
+    // Ignore sigpipe.
+    if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+        perror("Unable to ignore SIGPIPE");
+    }
 
 #if SDL_USE_NIB_FILE
     NSApplicationMain (argc, argv);

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -17,6 +17,8 @@
 #include "Common/CommonWindows.h"
 #if PPSSPP_PLATFORM(WINDOWS)
 #include <timeapi.h>
+#else
+#include <csignal>
 #endif
 #include "Common/CPUDetect.h"
 #include "Common/File/VFS/VFS.h"
@@ -246,6 +248,11 @@ int main(int argc, const char* argv[])
 	PROFILE_INIT();
 #if PPSSPP_PLATFORM(WINDOWS)
 	timeBeginPeriod(1);
+#else
+	// Ignore sigpipe.
+	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+		perror("Unable to ignore SIGPIPE");
+	}
 #endif
 
 #if defined(_DEBUG) && defined(_MSC_VER)

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -4,6 +4,7 @@
 #import <dlfcn.h>
 #import <mach/mach.h>
 #import <pthread.h>
+#import <signal.h>
 #import <string>
 #import <stdio.h>
 #import <stdlib.h>
@@ -269,6 +270,11 @@ int main(int argc, char *argv[])
 */
 
 	PROFILE_INIT();
+
+	// Ignore sigpipe.
+	if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+		perror("Unable to ignore SIGPIPE");
+	}
 
 	@autoreleasepool {
 		return UIApplicationMain(argc, argv, NSStringFromClass([PPSSPPUIApplication class]), NSStringFromClass([AppDelegate class]));


### PR DESCRIPTION
This should work on BSD/macOS/Linux/iOS/similar.

Not well tested on all these platforms, but should take care of #15459.

-[Unknown]