### PR TITLE
Threading manager stresstest and fixes

### DIFF
--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -529,6 +529,7 @@
     <ClInclude Include="System\Display.h" />
     <ClInclude Include="System\NativeApp.h" />
     <ClInclude Include="System\System.h" />
+    <ClInclude Include="Thread\Barrier.h" />
     <ClInclude Include="Thread\Channel.h" />
     <ClInclude Include="Thread\Event.h" />
     <ClInclude Include="Thread\ParallelLoop.h" />

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -532,6 +532,7 @@
     <ClInclude Include="Thread\Barrier.h" />
     <ClInclude Include="Thread\Channel.h" />
     <ClInclude Include="Thread\Event.h" />
+    <ClInclude Include="Thread\Waitable.h" />
     <ClInclude Include="Thread\ParallelLoop.h" />
     <ClInclude Include="Thread\Promise.h" />
     <ClInclude Include="Thread\ThreadManager.h" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -415,6 +415,9 @@
     <ClInclude Include="GPU\Vulkan\VulkanProfiler.h">
       <Filter>GPU\Vulkan</Filter>
     </ClInclude>
+    <ClInclude Include="Thread\Barrier.h">
+      <Filter>Thread</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -418,6 +418,9 @@
     <ClInclude Include="Thread\Barrier.h">
       <Filter>Thread</Filter>
     </ClInclude>
+    <ClInclude Include="Thread\Waitable.h">
+      <Filter>Thread</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />

--- a/Common/Thread/Barrier.h
+++ b/Common/Thread/Barrier.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+
+// Similar to C++20's std::barrier
+class CountingBarrier {
+public:
+	CountingBarrier(size_t count) : threadCount_(count) {}
+
+	void Arrive() {
+		std::unique_lock<std::mutex> lk(m);
+		counter++;
+		waiting++;
+		cv.wait(lk, [&] {return counter >= threadCount_; });
+		cv.notify_one();
+		waiting--;
+		if (waiting == 0) {
+			// Reset so it can be re-used.
+			counter = 0;
+		}
+		lk.unlock();
+	}
+
+private:
+	std::mutex m;
+	std::condition_variable cv;
+	size_t counter = 0;
+	size_t waiting = 0;
+	size_t threadCount_;
+};

--- a/Common/Thread/Event.h
+++ b/Common/Thread/Event.h
@@ -12,8 +12,8 @@ public:
 	}
 
 	void Wait() override {
+		std::unique_lock<std::mutex> lock;
 		if (!triggered_) {
-			std::unique_lock<std::mutex> lock;
 			cond_.wait(lock, [&] { return triggered_.load(); });
 		}
 	}

--- a/Common/Thread/Event.h
+++ b/Common/Thread/Event.h
@@ -7,12 +7,15 @@
 
 struct Event : public Waitable {
 public:
+	Event() {
+		triggered_ = false;
+	}
+
 	void Wait() override {
-		if (triggered_) {
-			return;
+		if (!triggered_) {
+			std::unique_lock<std::mutex> lock;
+			cond_.wait(lock, [&] { return triggered_.load(); });
 		}
-		std::unique_lock<std::mutex> lock;
-		cond_.wait(lock, [&] { return !triggered_; });
 	}
 
 	void Notify() {
@@ -24,5 +27,5 @@ public:
 private:
 	std::condition_variable cond_;
 	std::mutex mutex_;
-	bool triggered_ = false;
+	std::atomic<bool> triggered_;
 };

--- a/Common/Thread/Waitable.h
+++ b/Common/Thread/Waitable.h
@@ -12,18 +12,18 @@ public:
 	}
 
 	void Wait() override {
+		std::unique_lock<std::mutex> lock(mutex_);
 		if (!triggered_) {
-			std::unique_lock<std::mutex> lock(mutex_);
 			cond_.wait(lock, [&] { return triggered_.load(); });
 		}
 	}
 
 	bool WaitFor(double budget) {
 		uint32_t us = budget > 0 ? (uint32_t)(budget * 1000000.0) : 0;
+		std::unique_lock<std::mutex> lock(mutex_);
 		if (!triggered_) {
 			if (us == 0)
 				return false;
-			std::unique_lock<std::mutex> lock(mutex_);
 			cond_.wait_for(lock, std::chrono::microseconds(us), [&] { return triggered_.load(); });
 		}
 		return triggered_;

--- a/Common/Thread/Waitable.h
+++ b/Common/Thread/Waitable.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <mutex>
+#include <condition_variable>
+
+#include "Common/Thread/ThreadManager.h"
+
+class LimitedWaitable : public Waitable {
+public:
+	LimitedWaitable() {
+		triggered_ = false;
+	}
+
+	void Wait() override {
+		if (!triggered_) {
+			std::unique_lock<std::mutex> lock(mutex_);
+			cond_.wait(lock, [&] { return !triggered_; });
+		}
+	}
+
+	bool WaitFor(double budget) {
+		uint32_t us = budget > 0 ? (uint32_t)(budget * 1000000.0) : 0;
+		if (!triggered_) {
+			if (us == 0)
+				return false;
+			std::unique_lock<std::mutex> lock(mutex_);
+			cond_.wait_for(lock, std::chrono::microseconds(us), [&] { return !triggered_; });
+		}
+		return triggered_;
+	}
+
+	void Notify() {
+		std::unique_lock<std::mutex> lock(mutex_);
+		triggered_ = true;
+		cond_.notify_all();
+	}
+
+private:
+	std::condition_variable cond_;
+	std::mutex mutex_;
+	std::atomic<bool> triggered_;
+};

--- a/Common/Thread/Waitable.h
+++ b/Common/Thread/Waitable.h
@@ -14,7 +14,7 @@ public:
 	void Wait() override {
 		if (!triggered_) {
 			std::unique_lock<std::mutex> lock(mutex_);
-			cond_.wait(lock, [&] { return !triggered_; });
+			cond_.wait(lock, [&] { return triggered_.load(); });
 		}
 	}
 
@@ -24,7 +24,7 @@ public:
 			if (us == 0)
 				return false;
 			std::unique_lock<std::mutex> lock(mutex_);
-			cond_.wait_for(lock, std::chrono::microseconds(us), [&] { return !triggered_; });
+			cond_.wait_for(lock, std::chrono::microseconds(us), [&] { return triggered_.load(); });
 		}
 		return triggered_;
 	}

--- a/Common/TimeUtil.cpp
+++ b/Common/TimeUtil.cpp
@@ -66,7 +66,7 @@ void sleep_ms(int ms) {
 
 // Return the current time formatted as Minutes:Seconds:Milliseconds
 // in the form 00:00:000.
-void GetTimeFormatted(char formattedTime[11]) {
+void GetTimeFormatted(char formattedTime[13]) {
 	time_t sysTime;
 	time(&sysTime);
 

--- a/Common/TimeUtil.h
+++ b/Common/TimeUtil.h
@@ -7,3 +7,17 @@ double time_now_d();
 void sleep_ms(int ms);
 
 void GetTimeFormatted(char formattedTime[13]);
+
+// Rust-style Instant for clear and easy timing.
+class Instant {
+public:
+	static Instant Now() {
+		return Instant(time_now_d());
+	}
+	double Elapsed() const {
+		return time_now_d() - instantTime_;
+	}
+private:
+	explicit Instant(double initTime) : instantTime_(initTime) {}
+	double instantTime_;
+};

--- a/unittest/TestThreadManager.cpp
+++ b/unittest/TestThreadManager.cpp
@@ -1,10 +1,13 @@
 #include "Common/Log.h"
 #include "Common/TimeUtil.h"
+#include "Common/Thread/Barrier.h"
 #include "Common/Thread/ThreadManager.h"
 #include "Common/Thread/Channel.h"
 #include "Common/Thread/Promise.h"
 #include "Common/Thread/ParallelLoop.h"
 #include "Common/Thread/ThreadUtil.h"
+
+#include "UnitTest.h"
 
 struct ResultObject {
 	bool ok;
@@ -56,16 +59,70 @@ bool TestParallelLoop(ThreadManager *threadMan) {
 	return true;
 }
 
+// This is some ugly stuff but realistic.
+const size_t THREAD_COUNT = 6;  // Must match the number of threads in TestMultithreadedScheduling
+const size_t ITERATIONS = 100000;
+
+static std::atomic<int> g_atomicCounter;
+static ThreadManager *g_threadMan;
+static CountingBarrier g_barrier(THREAD_COUNT + 1);
+
+class IncrementTask : public Task {
+public:
+	IncrementTask(TaskType type) : type_(type) {}
+	~IncrementTask() {}
+	virtual TaskType Type() const { return type_; }
+	virtual void Run() {
+		g_atomicCounter++;
+	}
+private:
+	TaskType type_;
+};
+
+void ThreadFunc() {
+	for (int i = 0; i < ITERATIONS; i++) {
+		g_threadMan->EnqueueTask(new IncrementTask((i & 1) ? TaskType::CPU_COMPUTE : TaskType::IO_BLOCKING));
+	}
+	g_barrier.Arrive();
+}
+
+bool TestMultithreadedScheduling() {
+	g_atomicCounter = 0;
+	std::thread thread1(ThreadFunc);
+	std::thread thread2(ThreadFunc);
+	std::thread thread3(ThreadFunc);
+	std::thread thread4(ThreadFunc);
+	std::thread thread5(ThreadFunc);
+	std::thread thread6(ThreadFunc);
+
+	// Just testing the barrier
+	g_barrier.Arrive();
+	// OK, all are done.
+
+	EXPECT_EQ_INT(g_atomicCounter, THREAD_COUNT * ITERATIONS);
+
+	thread1.join();
+	thread2.join();
+	thread3.join();
+	thread4.join();
+	thread5.join();
+	thread6.join();
+
+	return true;
+}
+
 bool TestThreadManager() {
 	ThreadManager manager;
 	manager.Init(8, 1);
+
+	g_threadMan = &manager;
 
 	Promise<ResultObject *> *object(Promise<ResultObject *>::Spawn(&manager, &ResultProducer, TaskType::IO_BLOCKING));
 
 	if (!TestParallelLoop(&manager)) {
 		return false;
 	}
-	sleep_ms(1000);
+	sleep_ms(100);
 
 	ResultObject *result = object->BlockUntilReady();
 	if (result) {
@@ -75,6 +132,10 @@ bool TestThreadManager() {
 	delete object;
 
 	if (!TestMailbox()) {
+		return false;
+	}
+
+	if (!TestMultithreadedScheduling()) {
 		return false;
 	}
 

--- a/unittest/TestThreadManager.cpp
+++ b/unittest/TestThreadManager.cpp
@@ -88,6 +88,9 @@ void ThreadFunc() {
 
 bool TestMultithreadedScheduling() {
 	g_atomicCounter = 0;
+
+	auto start = Instant::Now();
+
 	std::thread thread1(ThreadFunc);
 	std::thread thread2(ThreadFunc);
 	std::thread thread3(ThreadFunc);
@@ -107,6 +110,8 @@ bool TestMultithreadedScheduling() {
 	thread4.join();
 	thread5.join();
 	thread6.join();
+
+	printf("Stress test elapsed: %0.2f", start.Elapsed());
 
 	return true;
 }

--- a/unittest/TestThreadManager.cpp
+++ b/unittest/TestThreadManager.cpp
@@ -1,3 +1,5 @@
+#include <thread>
+
 #include "Common/Log.h"
 #include "Common/TimeUtil.h"
 #include "Common/Thread/Barrier.h"
@@ -62,7 +64,7 @@ bool TestParallelLoop(ThreadManager *threadMan) {
 
 // This is some ugly stuff but realistic.
 const size_t THREAD_COUNT = 6;  // Must match the number of threads in TestMultithreadedScheduling
-const size_t ITERATIONS = 1000;
+const size_t ITERATIONS = 40000;
 
 static std::atomic<int> g_atomicCounter;
 static ThreadManager *g_threadMan;

--- a/unittest/UnitTest.h
+++ b/unittest/UnitTest.h
@@ -2,7 +2,7 @@
 
 #define EXPECT_TRUE(a) if (!(a)) { printf("%s:%i: Test Fail\n", __FUNCTION__, __LINE__); return false; }
 #define EXPECT_FALSE(a) if ((a)) { printf("%s:%i: Test Fail\n", __FUNCTION__, __LINE__); return false; }
-#define EXPECT_EQ_INT(a, b) if ((a) != (b)) { printf("%s:%i: Test Fail\n%d\nvs\n%d\n", __FUNCTION__, __LINE__, a, b); return false; }
+#define EXPECT_EQ_INT(a, b) if ((a) != (b)) { printf("%s:%i: Test Fail\n%d\nvs\n%d\n", __FUNCTION__, __LINE__, (int)(a), (int)(b)); return false; }
 #define EXPECT_EQ_HEX(a, b) if ((a) != (b)) { printf("%s:%i: Test Fail\n%x\nvs\n%x\n", __FUNCTION__, __LINE__, a, b); return false; }
 #define EXPECT_EQ_FLOAT(a, b) if ((a) != (b)) { printf("%s:%i: Test Fail\n%f\nvs\n%f\n", __FUNCTION__, __LINE__, a, b); return false; }
 #define EXPECT_APPROX_EQ_FLOAT(a, b) if (fabsf((a)-(b))>0.00001f) { printf("%s:%i: Test Fail\n%f\nvs\n%f\n", __FUNCTION__, __LINE__, a, b); /*return false;*/ }


### PR DESCRIPTION
Trying to investigate the problem from https://github.com/hrydgard/ppsspp/pull/15431 by stressing the thread manager and thread primitives. 

Turns out there was both misuse of cond.wait (the callback should return whether to stop waiting, not whether to continue to do so), and additionally there was a subtle race condition between Notify and Wait which I fixed by locking the mutex.

The old "Event" structure was also affected by these bugs.