### PR TITLE
ThreadManager: Improve waitable destruction

### DIFF
--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -170,6 +171,7 @@ protected:
 	ReplacedTextureAlpha alphaStatus_;
 	double lastUsed_ = 0.0;
 	LimitedWaitable *threadWaitable_ = nullptr;
+	std::mutex mutex_;
 	bool cancelPrepare_ = false;
 
 	friend TextureReplacer;


### PR DESCRIPTION
I can't reproduce the crash with the stress test unfortunately (see #15470), but this change is a slight optimization.

This makes `WaitFor(0)` lock-free, and reduces property access at the end of WaitFor.  Unfortunately, it's still accessing within the predicate, which could in theory be after the destructor.  I thought about relocking afterward, but it doesn't really solve that case.

Instead, I changed the texture replacement to lock on releasing the waitable, and only release it on destruct.  It'll remember it's triggered, so this just means the waitable objects live longer.  But I think this most completely closes the destruct gap.

-[Unknown]