### PR TITLE
Merge CheckAlpha into texture decoding

### DIFF
--- a/Common/Data/Convert/ColorConv.h
+++ b/Common/Data/Convert/ColorConv.h
@@ -99,6 +99,10 @@ void convert5551_dx9(u16* data, u32* out, int width, int l, int u);
 
 // TODO: Need to revisit the naming convention of these. Seems totally backwards
 // now that we've standardized on Draw::DataFormat.
+// 
+// The functions that have the same bit width of input and output can generally
+// tolerate being called with src == dst, which is used a lot for ReverseColors
+// in the GLES backend.
 
 void ConvertBGRA8888ToRGBA8888(u32 *dst, const u32 *src, u32 numPixels);
 #define ConvertRGBA8888ToBGRA8888 ConvertBGRA8888ToRGBA8888

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -3318,7 +3318,7 @@ int RecreatePtpSocket(int ptpId) {
 					WARN_LOG(SCENET, "RecreatePtpSocket(%id) - Wrapped Port Detected: Original(%d) -> Requested(%d), Bound(%d) -> BoundOriginal(%d)", ptpId, sock->data.ptp.lport, requestedport, boundport, boundport - portOffset);
 				u16 newlport = boundport - portOffset;
 				if (newlport != sock->data.ptp.lport) {
-					WARN_LOG(SCENET, "RecreatePtpSocket(%id) - Old and New LPort is different! The port may need to be reforwarded");
+					WARN_LOG(SCENET, "RecreatePtpSocket(%id) - Old and New LPort is different! The port may need to be reforwarded", ptpId);
 					if (!sock->isClient)
 						UPnP_Add(IP_PROTOCOL_TCP, isOriPort ? newlport : newlport + portOffset, newlport + portOffset);
 				}

--- a/Core/MIPS/ARM64/Arm64CompVFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompVFPU.cpp
@@ -1792,7 +1792,7 @@ namespace MIPSComp {
 			fpr.MapRegsAndSpillLockV(sregs, sz, 0);
 			gpr.MapReg(MIPS_REG_VFPUCC);
 			for (int i = 0; i < n; i++) {
-				TSTI2R(gpr.R(MIPS_REG_VFPUCC), 1 << i);
+				TSTI2R(gpr.R(MIPS_REG_VFPUCC), 1ULL << i);
 				FixupBranch b = B(tf ? CC_NEQ : CC_EQ);
 				fp.FMOV(fpr.V(dregs[i]), fpr.V(sregs[i]));
 				SetJumpTarget(b);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1651,10 +1651,9 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 	case GE_TFMT_5650:
 		if (!swizzled) {
 			// Just a simple copy, we swizzle the color format.
+			fullAlphaMask = TfmtRawToFullAlpha(format);
 			if (reverseColors) {
 				// Just check the input's alpha to reuse code. TODO: make a specialized ReverseColors that checks as we go.
-				fullAlphaMask = TfmtRawToFullAlpha(format);
-
 				for (int y = 0; y < h; ++y) {
 					CheckMask16((const u16 *)(texptr + bufw * sizeof(u16) * y), w, &alphaSum);
 					ReverseColors(out + outPitch * y, texptr + bufw * sizeof(u16) * y, format, w, useBGRA);
@@ -1665,7 +1664,6 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 					ConvertFormatToRGBA8888(format, (u32 *)(out + outPitch * y), (const u16 *)texptr + bufw * y, w);
 				}
 			} else {
-				fullAlphaMask = TfmtRawToFullAlpha(format);
 				for (int y = 0; y < h; ++y) {
 					CopyAndSumMask16((u16 *)(out + outPitch * y), (u16 *)(texptr + bufw * sizeof(u16) * y), w, &alphaSum);
 				}
@@ -1683,22 +1681,20 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 			UnswizzleFromMem(tmpTexBuf32_.data(), bufw * 2, texptr, bufw, h, 2);
 			const u8 *unswizzled = (u8 *)tmpTexBuf32_.data();
 
+			fullAlphaMask = TfmtRawToFullAlpha(format);
 			if (reverseColors) {
 				// Just check the swizzled input's alpha to reuse code. TODO: make a specialized ReverseColors that checks as we go.
-				fullAlphaMask = TfmtRawToFullAlpha(format);
 				for (int y = 0; y < h; ++y) {
 					CheckMask16((const u16 *)(unswizzled + bufw * sizeof(u16) * y), w, &alphaSum);
 					ReverseColors(out + outPitch * y, unswizzled + bufw * sizeof(u16) * y, format, w, useBGRA);
 				}
 			} else if (expandTo32bit) {
 				// Just check the swizzled input's alpha to reuse code. TODO: make a specialized ConvertFormatToRGBA8888 that checks as we go.
-				fullAlphaMask = TfmtRawToFullAlpha(format);
 				for (int y = 0; y < h; ++y) {
 					CheckMask16((const u16 *)(unswizzled + bufw * sizeof(u16) * y), w, &alphaSum);
 					ConvertFormatToRGBA8888(format, (u32 *)(out + outPitch * y), (const u16 *)unswizzled + bufw * y, w);
 				}
 			} else {
-				fullAlphaMask = TfmtRawToFullAlpha(format);
 				for (int y = 0; y < h; ++y) {
 					CopyAndSumMask16((u16 *)(out + outPitch * y), (const u16 *)(unswizzled + bufw * sizeof(u16) * y), w, &alphaSum);
 				}
@@ -1711,14 +1707,13 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 
 	case GE_TFMT_8888:
 		if (!swizzled) {
+			fullAlphaMask = TfmtRawToFullAlpha(format);
 			if (reverseColors) {
-				fullAlphaMask = TfmtRawToFullAlpha(format);
 				for (int y = 0; y < h; ++y) {
 					CheckMask32((const u32 *)(texptr + bufw * sizeof(u32) * y), w, &alphaSum);
 					ReverseColors(out + outPitch * y, texptr + bufw * sizeof(u32) * y, format, w, useBGRA);
 				}
 			} else {
-				fullAlphaMask = TfmtRawToFullAlpha(format);
 				for (int y = 0; y < h; ++y) {
 					CopyAndSumMask32((u32 *)(out + outPitch * y), (const u32 *)(texptr + bufw * sizeof(u32) * y), w * sizeof(u32), &alphaSum);
 				}
@@ -1734,14 +1729,13 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 			UnswizzleFromMem(tmpTexBuf32_.data(), bufw * 4, texptr, bufw, h, 4);
 			const u8 *unswizzled = (u8 *)tmpTexBuf32_.data();
 
+			fullAlphaMask = TfmtRawToFullAlpha(format);
 			if (reverseColors) {
-				fullAlphaMask = TfmtRawToFullAlpha(format);
 				for (int y = 0; y < h; ++y) {
-					fullAlphaMask = TfmtRawToFullAlpha(format);
+					CheckMask32((const u32 *)(unswizzled + bufw * sizeof(u32) * y), w, &alphaSum);
 					ReverseColors(out + outPitch * y, unswizzled + bufw * sizeof(u32) * y, format, w, useBGRA);
 				}
 			} else {
-				fullAlphaMask = TfmtRawToFullAlpha(format);
 				for (int y = 0; y < h; ++y) {
 					CopyAndSumMask32((u32 *)(out + outPitch * y), (const u32 *)(unswizzled + bufw * sizeof(u32) * y), w * sizeof(u32), &alphaSum);
 				}

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1481,6 +1481,19 @@ void CopyAndSumMask32(u32 *dst, const u32 *src, int width, u32 *outMask) {
 		}
 		mask = SSEReduce32And(wideMask);
 	}
+#elif PPSSPP_ARCH(ARM_NEON)
+	if (width >= 4) {
+		uint32x4_t wideMask = vdupq_n_u32(0xFFFFFFFF);
+		while (width >= 4) {
+			uint32x4_t colors = vld1q_u32(src);
+			wideMask = vandq_u32(wideMask, colors);
+			vst1q_u32(dst, colors);
+			src += 4;
+			dst += 4;
+			width -= 4;
+		}
+		mask = NEONReduce32And(wideMask);
+	}
 #endif
 
 	for (int i = 0; i < width; i++) {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1431,7 +1431,7 @@ inline u32 TfmtRawToFullAlpha(GETextureFormat fmt) {
 }
 
 // TODO: SSE/SIMD
-// At least on x86, compiler actually parallelizes these pretty well.
+// At least on x86, compiler actually SIMDs these pretty well.
 void CopyAndSumMask16(u16 *dst, const u16 *src, int width, u32 *outMask) {
 	u16 mask = 0xFFFF;
 	for (int i = 0; i < width; i++) {
@@ -1491,7 +1491,7 @@ void TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, GETextureForm
 		case GE_CMODE_16BIT_ABGR4444:
 		{
 			if (clutAlphaLinear_ && mipmapShareClut && !expandTo32bit) {
-				// We don't bother with fullalpha here
+				// We don't bother with fullalpha here (clutAlphaLinear_)
 				// Here, reverseColors means the CLUT is already reversed.
 				if (reverseColors) {
 					for (int y = 0; y < h; ++y) {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1313,7 +1313,7 @@ static void ReverseColors(void *dstBuf, const void *srcBuf, GETextureFormat fmt,
 	case GE_TFMT_4444:
 		ConvertRGBA4444ToABGR4444((u16 *)dstBuf, (const u16 *)srcBuf, numPixels);
 		break;
-	// Final Fantasy 2 uses this heavily in animated textures.
+		// Final Fantasy 2 uses this heavily in animated textures.
 	case GE_TFMT_5551:
 		ConvertRGBA5551ToABGR1555((u16 *)dstBuf, (const u16 *)srcBuf, numPixels);
 		break;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1404,7 +1404,6 @@ static void DecodeDXTBlocks(uint8_t *out, int outPitch, uint32_t texaddr, const 
 		break;
 	}
 
-	w = (w + 3) & ~3;
 	if (reverseColors) {
 		ReverseColors(out, out, GE_TFMT_8888, outPitch32 * h, useBGRA);
 	}

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -275,9 +275,9 @@ protected:
 	virtual void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) = 0;
 	bool CheckFullHash(TexCacheEntry *entry, bool &doDelete);
 
-	void DecodeTextureLevel(u8 *out, int outPitch, GETextureFormat format, GEPaletteFormat clutformat, uint32_t texaddr, int level, int bufw, bool reverseColors, bool useBGRA, bool expandTo32Bit);
+	void DecodeTextureLevel(u8 *out, int outPitch, GETextureFormat format, GEPaletteFormat clutformat, uint32_t texaddr, int level, int bufw, bool reverseColors, bool useBGRA, bool expandTo32Bit, u32 *alphaSum, u32 *fullAlphaMask);
 	void UnswizzleFromMem(u32 *dest, u32 destPitch, const u8 *texptr, u32 bufw, u32 height, u32 bytesPerPixel);
-	void ReadIndexedTex(u8 *out, int outPitch, int level, const u8 *texptr, int bytesPerIndex, int bufw, bool expandTo32Bit);
+	void ReadIndexedTex(u8 *out, int outPitch, int level, const u8 *texptr, int bytesPerIndex, int bufw, bool expandTo32Bit, u32 *alphaSum, u32 *fullAlphaMask);
 	ReplacedTexture &FindReplacement(TexCacheEntry *entry, int &w, int &h);
 
 	template <typename T>

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -181,6 +181,13 @@ struct TexCacheEntry {
 			SetAlphaStatus(newStatus);
 		}
 	}
+	void SetAlphaStatus(CheckAlphaResult alphaResult, int level) {
+		TexStatus newStatus = (TexStatus)alphaResult;
+		// For non-level zero, only set more restrictive.
+		if (newStatus == STATUS_ALPHA_UNKNOWN || level == 0) {
+			SetAlphaStatus(newStatus);
+		}
+	}
 
 	bool Matches(u16 dim2, u8 format2, u8 maxLevel2) const;
 	u64 CacheKey() const;
@@ -275,7 +282,7 @@ protected:
 	virtual void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) = 0;
 	bool CheckFullHash(TexCacheEntry *entry, bool &doDelete);
 
-	void DecodeTextureLevel(u8 *out, int outPitch, GETextureFormat format, GEPaletteFormat clutformat, uint32_t texaddr, int level, int bufw, bool reverseColors, bool useBGRA, bool expandTo32Bit, u32 *alphaSum, u32 *fullAlphaMask);
+	CheckAlphaResult DecodeTextureLevel(u8 *out, int outPitch, GETextureFormat format, GEPaletteFormat clutformat, uint32_t texaddr, int level, int bufw, bool reverseColors, bool useBGRA, bool expandTo32Bit);
 	void UnswizzleFromMem(u32 *dest, u32 destPitch, const u8 *texptr, u32 bufw, u32 height, u32 bytesPerPixel);
 	void ReadIndexedTex(u8 *out, int outPitch, int level, const u8 *texptr, int bytesPerIndex, int bufw, bool expandTo32Bit, u32 *alphaSum, u32 *fullAlphaMask);
 	ReplacedTexture &FindReplacement(TexCacheEntry *entry, int &w, int &h);

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -284,7 +284,7 @@ protected:
 
 	CheckAlphaResult DecodeTextureLevel(u8 *out, int outPitch, GETextureFormat format, GEPaletteFormat clutformat, uint32_t texaddr, int level, int bufw, bool reverseColors, bool useBGRA, bool expandTo32Bit);
 	void UnswizzleFromMem(u32 *dest, u32 destPitch, const u8 *texptr, u32 bufw, u32 height, u32 bytesPerPixel);
-	void ReadIndexedTex(u8 *out, int outPitch, int level, const u8 *texptr, int bytesPerIndex, int bufw, bool expandTo32Bit, u32 *alphaSum, u32 *fullAlphaMask);
+	CheckAlphaResult ReadIndexedTex(u8 *out, int outPitch, int level, const u8 *texptr, int bytesPerIndex, int bufw, bool expandTo32Bit);
 	ReplacedTexture &FindReplacement(TexCacheEntry *entry, int &w, int &h);
 
 	template <typename T>

--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -630,7 +630,7 @@ void DecodeDXT1Block(u32 *dst, const DXT1Block *src, int pitch, int height, u32 
 	DXTDecoder dxt;
 	dxt.DecodeColors(src, false);
 	dxt.WriteColorsDXT1(dst, src, pitch, height);
-	*alpha = dxt.AnyNonFullAlpha() ? 0 : 1;
+	*alpha = dxt.AnyNonFullAlpha() ? 0 : 0xFFFFFFFF;
 }
 
 void DecodeDXT3Block(u32 *dst, const DXT3Block *src, int pitch, int height) {

--- a/GPU/Common/TextureDecoder.h
+++ b/GPU/Common/TextureDecoder.h
@@ -109,17 +109,21 @@ inline void DeIndexTexture(/*WRITEONLY*/ ClutT *dest, const IndexT *indexed, int
 		if (sizeof(IndexT) == 1) {
 			for (int i = 0; i < length; ++i) {
 				ClutT color = clut[*indexed++];
+				alphaSum &= color;
 				*dest++ = color;
-
 			}
 		} else {
 			for (int i = 0; i < length; ++i) {
-				*dest++ = clut[(*indexed++) & 0xFF];
+				ClutT color = (*indexed++) & 0xFF;
+				alphaSum &= color;
+				*dest++ = color;
 			}
 		}
 	} else {
 		for (int i = 0; i < length; ++i) {
-			*dest++ = clut[gstate.transformClutIndex(*indexed++)];
+			ClutT color = clut[gstate.transformClutIndex(*indexed++)];
+			alphaSum &= color;
+			*dest++ = color;
 		}
 	}
 }

--- a/GPU/Common/TextureDecoder.h
+++ b/GPU/Common/TextureDecoder.h
@@ -126,6 +126,8 @@ inline void DeIndexTexture(/*WRITEONLY*/ ClutT *dest, const IndexT *indexed, int
 			*dest++ = color;
 		}
 	}
+
+	*outAlphaSum = alphaSum;
 }
 
 template <typename IndexT, typename ClutT>

--- a/GPU/Common/TextureDecoder.h
+++ b/GPU/Common/TextureDecoder.h
@@ -127,7 +127,7 @@ inline void DeIndexTexture(/*WRITEONLY*/ ClutT *dest, const IndexT *indexed, int
 		}
 	}
 
-	*outAlphaSum = alphaSum;
+	*outAlphaSum &= (u32)alphaSum;
 }
 
 template <typename IndexT, typename ClutT>

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -708,17 +708,9 @@ void TextureCacheD3D11::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &
 		}
 
 		bool expand32 = !gstate_c.Supports(GPU_SUPPORTS_16BIT_FORMATS);
-		u32 fullAlphaMask = 0;
-		u32 alphaSum = 0xFFFFFFFF;
-		DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, false, expand32, &alphaSum, &fullAlphaMask);
 
-		// We check before scaling since scaling shouldn't invent alpha from a full alpha texture.
-		if (AlphaSumIsFull(alphaSum, fullAlphaMask)) {
-			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_FULL, level);
-		} else {
-			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_UNKNOWN, level);
-		}
-
+		CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, false, expand32);
+		entry.SetAlphaStatus(alphaResult, level);
 
 		if (scaleFactor > 1) {
 			u32 scaleFmt = (u32)dstFmt;

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -708,15 +708,17 @@ void TextureCacheD3D11::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &
 		}
 
 		bool expand32 = !gstate_c.Supports(GPU_SUPPORTS_16BIT_FORMATS);
-		DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, false, expand32);
+		u32 fullAlphaMask = 0;
+		u32 alphaSum = 0xFFFFFFFF;
+		DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, false, expand32, &alphaSum, &fullAlphaMask);
 
 		// We check before scaling since scaling shouldn't invent alpha from a full alpha texture.
-		if ((entry.status & TexCacheEntry::STATUS_CHANGE_FREQUENT) == 0) {
-			TexCacheEntry::TexStatus alphaStatus = CheckAlpha(pixelData, dstFmt, decPitch / bpp, w, h);
-			entry.SetAlphaStatus(alphaStatus, level);
+		if (AlphaSumIsFull(alphaSum, fullAlphaMask)) {
+			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_FULL, level);
 		} else {
-			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_UNKNOWN);
+			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_UNKNOWN, level);
 		}
+
 
 		if (scaleFactor > 1) {
 			u32 scaleFmt = (u32)dstFmt;

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -634,16 +634,8 @@ void TextureCacheDX9::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &re
 			decPitch = w * bpp;
 		}
 
-		u32 fullAlphaMask = 0;
-		u32 alphaSum = 0xFFFFFFFF;
-		DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, false, false, &alphaSum, &fullAlphaMask);
-
-		// We check before scaling since scaling shouldn't invent alpha from a full alpha texture.
-		if (AlphaSumIsFull(alphaSum, fullAlphaMask)) {
-			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_FULL, level);
-		} else {
-			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_UNKNOWN, level);
-		}
+		CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, false, false);
+		entry.SetAlphaStatus(alphaResult, level);
 
 		if (scaleFactor > 1) {
 			scaler.ScaleAlways((u32 *)rect.pBits, pixelData, dstFmt, w, h, scaleFactor);

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -634,14 +634,15 @@ void TextureCacheDX9::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &re
 			decPitch = w * bpp;
 		}
 
-		DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, false, false);
+		u32 fullAlphaMask = 0;
+		u32 alphaSum = 0xFFFFFFFF;
+		DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, false, false, &alphaSum, &fullAlphaMask);
 
 		// We check before scaling since scaling shouldn't invent alpha from a full alpha texture.
-		if ((entry.status & TexCacheEntry::STATUS_CHANGE_FREQUENT) == 0) {
-			TexCacheEntry::TexStatus alphaStatus = CheckAlpha(pixelData, dstFmt, decPitch / bpp, w, h);
-			entry.SetAlphaStatus(alphaStatus, level);
+		if (AlphaSumIsFull(alphaSum, fullAlphaMask)) {
+			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_FULL, level);
 		} else {
-			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_UNKNOWN);
+			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_UNKNOWN, level);
 		}
 
 		if (scaleFactor > 1) {

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -675,16 +675,9 @@ void TextureCacheGLES::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &r
 		decPitch = std::max(w * pixelSize, 4);
 
 		pixelData = (uint8_t *)AllocateAlignedMemory(decPitch * h * pixelSize, 16);
-		u32 fullAlphaMask = 0;
-		u32 alphaSum = 0xFFFFFFFF;
-		DecodeTextureLevel(pixelData, decPitch, GETextureFormat(entry.format), clutformat, texaddr, level, bufw, true, false, false, &alphaSum, &fullAlphaMask);
 
-		// We check before scaling since scaling shouldn't invent alpha from a full alpha texture.
-		if (AlphaSumIsFull(alphaSum, fullAlphaMask)) {
-			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_FULL, level);
-		} else {
-			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_UNKNOWN, level);
-		}
+		CheckAlphaResult alphaStatus = DecodeTextureLevel(pixelData, decPitch, GETextureFormat(entry.format), clutformat, texaddr, level, bufw, true, false, false);
+		entry.SetAlphaStatus(alphaStatus, level);
 
 		if (scaleFactor > 1) {
 			uint8_t *rearrange = (uint8_t *)AllocateAlignedMemory(w * scaleFactor * h * scaleFactor * 4, 16);

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -675,14 +675,15 @@ void TextureCacheGLES::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &r
 		decPitch = std::max(w * pixelSize, 4);
 
 		pixelData = (uint8_t *)AllocateAlignedMemory(decPitch * h * pixelSize, 16);
-		DecodeTextureLevel(pixelData, decPitch, GETextureFormat(entry.format), clutformat, texaddr, level, bufw, true, false, false);
+		u32 fullAlphaMask = 0;
+		u32 alphaSum = 0xFFFFFFFF;
+		DecodeTextureLevel(pixelData, decPitch, GETextureFormat(entry.format), clutformat, texaddr, level, bufw, true, false, false, &alphaSum, &fullAlphaMask);
 
 		// We check before scaling since scaling shouldn't invent alpha from a full alpha texture.
-		if ((entry.status & TexCacheEntry::STATUS_CHANGE_FREQUENT) == 0) {
-			TexCacheEntry::TexStatus alphaStatus = CheckAlpha(pixelData, dstFmt, decPitch / pixelSize, w, h);
-			entry.SetAlphaStatus(alphaStatus, level);
+		if (AlphaSumIsFull(alphaSum, fullAlphaMask)) {
+			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_FULL, level);
 		} else {
-			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_UNKNOWN);
+			entry.SetAlphaStatus(TexCacheEntry::STATUS_ALPHA_UNKNOWN, level);
 		}
 
 		if (scaleFactor > 1) {

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -11,10 +11,6 @@
 #include <atomic>
 #endif
 
-#if defined(_M_SSE)
-#include <emmintrin.h>
-#endif
-
 class FramebufferManagerCommon;
 class TextureCacheCommon;
 class DrawEngineCommon;
@@ -218,20 +214,7 @@ public:
 	GPUgstate GetGState() override;
 	void SetCmdValue(u32 op) override;
 
-	void UpdateUVScaleOffset() {
-#ifdef _M_SSE
-		__m128i values = _mm_slli_epi32(_mm_load_si128((const __m128i *)&gstate.texscaleu), 8);
-		_mm_storeu_si128((__m128i *)&gstate_c.uv, values);
-#elif PPSSPP_PLATFORM(ARM_NEON)
-		const uint32x4_t values = vshlq_n_u32(vld1q_u32(&gstate.texscaleu), 8);
-		vst1q_u32(&gstate_c.uv, values);
-#else
-		gstate_c.uv.uScale = getFloat24(gstate.texscaleu);
-		gstate_c.uv.vScale = getFloat24(gstate.texscalev);
-		gstate_c.uv.uOff = getFloat24(gstate.texoffsetu);
-		gstate_c.uv.vOff = getFloat24(gstate.texoffsetv);
-#endif
-	}
+	void UpdateUVScaleOffset();
 
 	DisplayList* getList(int listid) override {
 		return &dls[listid];

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -985,7 +985,7 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 
 		CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, false, expand32);
 
-		WARN_LOG(G3D, "Alpha: full=%d w=%d h=%d level=%d %s/%s", (int)(alphaResult == CHECKALPHA_FULL), w, h, level, GeTextureFormatToString(tfmt), GEPaletteFormatToString(clutformat));
+		// WARN_LOG(G3D, "Alpha: full=%d w=%d h=%d level=%d %s/%s", (int)(alphaResult == CHECKALPHA_FULL), w, h, level, GeTextureFormatToString(tfmt), GEPaletteFormatToString(clutformat));
 		entry.SetAlphaStatus(alphaResult, level);
 
 		if (scaleFactor > 1) {

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -984,6 +984,8 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 		bool expand32 = !gstate_c.Supports(GPU_SUPPORTS_16BIT_FORMATS) || dstFmt == VK_FORMAT_R8G8B8A8_UNORM;
 
 		CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, false, expand32);
+
+		WARN_LOG(G3D, "Alpha: full=%d w=%d h=%d level=%d %s/%s", (int)(alphaResult == CHECKALPHA_FULL), w, h, level, GeTextureFormatToString(tfmt), GEPaletteFormatToString(clutformat));
 		entry.SetAlphaStatus(alphaResult, level);
 
 		if (scaleFactor > 1) {


### PR DESCRIPTION
Fixes a recently discovered performance issue with CheckAlpha - on Vulkan and D3D we write decoded texture data directly to video memory, which can be super slow to read from, depending on driver, platform, phase of moon, etc.

This changes the code to "sum up" (AND together) the colors, and then check against the full alpha mask at the end.

Since we can remove CheckAlpha entirely this should improve performance despite the slight extra checking. And even so, it doesn't increase memory traffic, just some extra arithmetic which rarely is the bottleneck in modern out-of-order CPUs.

Disabled the optimization to deswizzle raw textures directly to VRAM, but no big deal as they're not that common and it's pretty fast anyway. Also, I check the input separately in a few cases to avoid writing more special case functions, so there's still room for minor optimizations. 