### PR TITLE
ARM32: Remove a lot of non-NEON fallback paths

### DIFF
--- a/Common/Math/fast/fast_math.c
+++ b/Common/Math/fast/fast_math.c
@@ -1,14 +1,12 @@
 #include "ppsspp_config.h"
+
 #include "fast_math.h"
 #include "fast_matrix.h"
 
-void InitFastMath(int enableNEON) {
-	// Every architecture has its own define. This needs to be added to.
-	if (enableNEON) {
+void InitFastMath() {
 #ifndef _MSC_VER
 #if PPSSPP_ARCH(ARM_NEON) && !PPSSPP_ARCH(ARM64)
 		fast_matrix_mul_4x4 = &fast_matrix_mul_4x4_neon;
 #endif
 #endif
-	}
 }

--- a/Common/Math/fast/fast_math.h
+++ b/Common/Math/fast/fast_math.h
@@ -14,7 +14,7 @@ extern "C" {
 
 // See fast_matrix.h for the first set of functions.
 
-void InitFastMath(int enableNEON);
+void InitFastMath();
 
 #ifdef __cplusplus
 }

--- a/Core/MIPS/ARM/ArmAsm.cpp
+++ b/Core/MIPS/ARM/ArmAsm.cpp
@@ -138,9 +138,7 @@ void ArmJit::GenerateFixedCode() {
 	// consumed by CALL.
 	SUB(R_SP, R_SP, 4);
 	// Now we are correctly aligned and plan to stay that way.
-	if (cpu_info.bNEON) {
-		VPUSH(D8, 8);
-	}
+	VPUSH(D8, 8);
 
 	// Fixed registers, these are always kept when in Jit context.
 	// R8 is used to hold flags during delay slots. Not always needed.
@@ -244,10 +242,7 @@ void ArmJit::GenerateFixedCode() {
 	SaveDowncount();
 	RestoreRoundingMode(true);
 
-	// Doing this above the downcount for better pipelining (slightly.)
-	if (cpu_info.bNEON) {
-		VPOP(D8, 8);
-	}
+	VPOP(D8, 8);
 
 	ADD(R_SP, R_SP, 4);
 

--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -1132,10 +1132,6 @@ namespace MIPSComp
 			DISABLE;
 		}
 
-		if (!cpu_info.bNEON) {
-			DISABLE;
-		}
-
 		// This multi-VCVT.F32.F16 is only available in the VFPv4 extension.
 		// The VFPv3 one is VCVTB, VCVTT which we don't yet have support for.
 		if (!(cpu_info.bHalf && cpu_info.bVFPv4)) {
@@ -1596,10 +1592,6 @@ namespace MIPSComp
 		NEON_IF_AVAILABLE(CompNEON_Vi2x);
 		CONDITIONAL_DISABLE(VFPU_VEC);
 		if (js.HasUnknownPrefix()) {
-			DISABLE;
-		}
-
-		if (!cpu_info.bNEON) {
 			DISABLE;
 		}
 

--- a/Core/MIPS/ARM/ArmRegCacheFPU.h
+++ b/Core/MIPS/ARM/ArmRegCacheFPU.h
@@ -127,7 +127,7 @@ public:
 	// VFPU registers as single VFP registers.
 	ArmGen::ARMReg V(int vreg) { return R(vreg + 32); }
 	 
-	int FlushGetSequential(int a, int maxArmReg);
+	int FlushGetSequential(int a);
 	void FlushAll();
 
 	// This one is allowed at any point.
@@ -180,7 +180,6 @@ private:
 	}
 	// This one WILL get a free quad as long as you haven't spill-locked them all.
 	int QGetFreeQuad(int start, int count, const char *reason);
-	int GetNumARMFPURegs();
 
 	void SetupInitialRegs();
 
@@ -189,24 +188,23 @@ private:
 	MIPSComp::JitState *js_;
 	MIPSComp::JitOptions *jo_;
 
-	int numARMFpuReg_;
 	int qTime_;
 
 	enum {
 		// With NEON, we have 64 S = 32 D = 16 Q registers. Only the first 32 S registers
 		// are individually mappable though.
-		MAX_ARMFPUREG = 32,
-		MAX_ARMQUADS = 16,
+		NUM_ARMFPUREG = 32,
+		NUM_ARMQUADS = 16,
 		NUM_MIPSFPUREG = ArmJitConstants::TOTAL_MAPPABLE_MIPSFPUREGS,
 	};
 
-	FPURegARM ar[MAX_ARMFPUREG];
+	FPURegARM ar[NUM_ARMFPUREG];
 	FPURegMIPS mr[NUM_MIPSFPUREG];
-	FPURegQuad qr[MAX_ARMQUADS];
+	FPURegQuad qr[NUM_ARMQUADS];
 	FPURegMIPS *vr;
 
 	bool pendingFlush;
 	bool initialReady = false;
-	FPURegARM arInitial[MAX_ARMFPUREG];
+	FPURegARM arInitial[NUM_ARMFPUREG];
 	FPURegMIPS mrInitial[NUM_MIPSFPUREG];
 };

--- a/Core/MIPS/JitCommon/JitState.cpp
+++ b/Core/MIPS/JitCommon/JitState.cpp
@@ -38,7 +38,7 @@ namespace MIPSComp {
 		// ARM only
 		downcountInRegister = true;
 		useNEONVFPU = false;  // true
-		if (!cpu_info.bNEON || Disabled(JitDisable::SIMD))
+		if (Disabled(JitDisable::SIMD))
 			useNEONVFPU = false;
 
 		//ARM64

--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -901,9 +901,7 @@ CheckAlphaResult CheckAlphaRGBA8888Basic(const u32 *pixelData, int stride, int w
 #ifdef _M_SSE
 		return CheckAlphaRGBA8888SSE2(pixelData, stride, w, h);
 #elif PPSSPP_ARCH(ARM_NEON)
-		if (cpu_info.bNEON) {
-			return CheckAlphaRGBA8888NEON(pixelData, stride, w, h);
-		}
+		return CheckAlphaRGBA8888NEON(pixelData, stride, w, h);
 #endif
 	}
 
@@ -931,9 +929,7 @@ CheckAlphaResult CheckAlphaABGR4444Basic(const u32 *pixelData, int stride, int w
 #ifdef _M_SSE
 		return CheckAlphaABGR4444SSE2(pixelData, stride, w, h);
 #elif PPSSPP_ARCH(ARM_NEON)
-		if (cpu_info.bNEON) {
-			return CheckAlphaABGR4444NEON(pixelData, stride, w, h);
-		}
+		return CheckAlphaABGR4444NEON(pixelData, stride, w, h);
 #endif
 	}
 
@@ -964,9 +960,7 @@ CheckAlphaResult CheckAlphaABGR1555Basic(const u32 *pixelData, int stride, int w
 #ifdef _M_SSE
 		return CheckAlphaABGR1555SSE2(pixelData, stride, w, h);
 #elif PPSSPP_ARCH(ARM_NEON)
-		if (cpu_info.bNEON) {
-			return CheckAlphaABGR1555NEON(pixelData, stride, w, h);
-		}
+		return CheckAlphaABGR1555NEON(pixelData, stride, w, h);
 #endif
 	}
 
@@ -996,9 +990,7 @@ CheckAlphaResult CheckAlphaRGBA4444Basic(const u32 *pixelData, int stride, int w
 #ifdef _M_SSE
 		return CheckAlphaRGBA4444SSE2(pixelData, stride, w, h);
 #elif PPSSPP_ARCH(ARM_NEON)
-		if (cpu_info.bNEON) {
-			return CheckAlphaRGBA4444NEON(pixelData, stride, w, h);
-		}
+		return CheckAlphaRGBA4444NEON(pixelData, stride, w, h);
 #endif
 	}
 
@@ -1029,9 +1021,7 @@ CheckAlphaResult CheckAlphaRGBA5551Basic(const u32 *pixelData, int stride, int w
 #ifdef _M_SSE
 		return CheckAlphaRGBA5551SSE2(pixelData, stride, w, h);
 #elif PPSSPP_ARCH(ARM_NEON)
-		if (cpu_info.bNEON) {
-			return CheckAlphaRGBA5551NEON(pixelData, stride, w, h);
-		}
+		return CheckAlphaRGBA5551NEON(pixelData, stride, w, h);
 #endif
 	}
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -464,7 +464,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 
 	ShaderTranslationInit();
 
-	InitFastMath(cpu_info.bNEON);
+	InitFastMath();
 	g_threadManager.Init(cpu_info.num_cores, cpu_info.logical_cpu_count);
 
 	g_Discord.SetPresenceMenu();


### PR DESCRIPTION
As mentioned in https://github.com/hrydgard/ppsspp/pull/15476 we no longer support ARM without NEON, so remove a lot of obsolete code that was written for that situation.