### PR TITLE
Add contributed data about a couple of prototypes to auto-expand memory to 64MB

### DIFF
--- a/Core/HDRemaster.cpp
+++ b/Core/HDRemaster.cpp
@@ -29,13 +29,21 @@ extern const struct HDRemaster g_HDRemasters[] = {
 	{ "ULJM05170", 0x04000000, true, "ULJM-05170|55C069C631B22685|0001|G" }, // Eiyuu Densetsu Sora no Kiseki FC Kai HD Edition
 	{ "ULJM05277", 0x04C00000, true, "ULJM-05277|0E8D71AFAA4F62D8|0001|G" }, // Eiyuu Densetsu: Sora no Kiseki SC Kai HD Edition
 	{ "ULJM05353", 0x04C00000, true, "ULJM-05353|0061DA67EBD6B9C6|0001|G" }, // Eiyuu Densetsu: Sora no Kiseki 3rd Kai HD Edition
-	{ "ULUS12345", 0x04000000, false, "ULUS-12345|6E197A8FB304B3DB|0001|G" }, // Saints Row 2 / Undercover - alpha (needs extra ram, not a remaster)
-	{ "UCUS12345", 0x04000000, false, "UCUS-12345|909D53E8B45B4B4A|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 09062006 (needs extra ram, not a remaster)
-	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|BC7AE2442B7CD085|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 21112006 (needs extra ram, not a remaster)
-	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|6035DE628DC1C924|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 31012007 (needs extra ram, not a remaster)
-	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|BBE65F2837A488C2|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 01022007 (needs extra ram, not a remaster)
-	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|55BE9ADC13B14D65|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 27042007 (needs extra ram, not a remaster)
-	{ "PETR00010", 0x04000000, false, "PETR-00010|0C274C92FF78330E|0001|G" }, // Melodie - alpha (needs extra ram, not a remaster)
+
+	// Prototypes
+	// These are not HD remasters, but need extra memory for various reasons (such as only ever running on a devkit, generally).
+
+	{ "ULUS12345", 0x04000000, false, "ULUS-12345|6E197A8FB304B3DB|0001|G" }, // Saints Row 2 / Undercover - alpha
+	{ "UCUS12345", 0x04000000, false, "UCUS-12345|909D53E8B45B4B4A|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 09062006
+	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|BC7AE2442B7CD085|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 21112006
+	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|6035DE628DC1C924|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 31012007
+	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|BBE65F2837A488C2|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 01022007
+	{ "ABCD01234561", 0x04000000, false, "UCUS-00000|55BE9ADC13B14D65|0001|G" }, // The Elder Scrolls Travels Oblivion USA Beta - 27042007
+	{ "PETR00010", 0x04000000, false, "PETR-00010|0C274C92FF78330E|0001|G" }, // Melodie - alpha
+
+	// Strangely there's actually a dash in this game's ID.
+	{ "ULES-01391", 0x04000000, false, "DEMO-12345|9A7EDE8DD786D82F|0001|G" },  // Duke Nukem: Critical Mass prototype
+	{ "NPEZ00324", 0x04000000, false, "NPEZ-00324|36AF3DDA099499CF|0001|G" },  // Extraction Point: Alien Shootout prototype (same engine as Duke, different IP)
 };
 
 const size_t g_HDRemastersCount = ARRAY_SIZE(g_HDRemasters);


### PR DESCRIPTION
They were probably only ever running on devkits, that had more memory than retail consoles.

Also simplifies the comments for the earlier prototypes.

Reported in #15453 (doesn't fix that issue though)