### PR TITLE
Save textures on background tasks when texture dumping is enabled.

### DIFF
--- a/Common/MemoryUtil.h
+++ b/Common/MemoryUtil.h
@@ -45,15 +45,20 @@ void FreeAlignedMemory(void* ptr);
 
 int GetMemoryProtectPageSize();
 
+// A simple buffer that bypasses the libc memory allocator. As a result the buffer is always page-aligned.
 template <typename T>
 class SimpleBuf {
 public:
-	SimpleBuf() : buf_(0), size_(0) {
-	}
+	SimpleBuf() : buf_(0), size_(0) {}
 
 	SimpleBuf(size_t size) : buf_(0) {
 		resize(size);
 	}
+
+	SimpleBuf(const SimpleBuf &o) : buf_(o.buf_), size_(o.size_) {}
+
+	// Move constructor
+	SimpleBuf(SimpleBuf &&o) noexcept : buf_(o.buf_), size_(o.size_) { o.buf_ = nullptr; o.size_ = 0; }
 
 	~SimpleBuf() {
 		if (buf_ != 0) {

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -227,7 +227,6 @@ protected:
 	void PopulateReplacement(ReplacedTexture *result, u64 cachekey, u32 hash, int w, int h);
 	bool PopulateLevel(ReplacedTextureLevel &level);
 
-	SimpleBuf<u32> saveBuf;
 	bool enabled_ = false;
 	bool allowVideo_ = false;
 	bool ignoreAddress_ = false;

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -736,6 +736,7 @@ void TextureCacheD3D11::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &
 			replacedInfo.scaleFactor = scaleFactor;
 			replacedInfo.fmt = FromD3D11Format(dstFmt);
 
+			// NOTE: Reading the decoded texture here may be very slow, if we just wrote it to write-combined memory.
 			replacer_.NotifyTextureDecoded(replacedInfo, pixelData, decPitch, level, w, h);
 		}
 	}

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -880,6 +880,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 					// When hardware texture scaling is enabled, this saves the original.
 					int w = dataScaled ? mipWidth : mipUnscaledWidth;
 					int h = dataScaled ? mipHeight : mipUnscaledHeight;
+					// NOTE: Reading the decoded texture here may be very slow, if we just wrote it to write-combined memory.
 					replacer_.NotifyTextureDecoded(replacedInfo, data, stride, i, w, h);
 				}
 			}


### PR DESCRIPTION
Should help #15478, at least a bit.

While doing this, found out that texture dumping is broken when texture scaling is enabled. Filing [separate issue](https://github.com/hrydgard/ppsspp/issues/15488).