### PR TITLE
Replacement: Move IO checks to saving thread

### DIFF
--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -512,20 +512,50 @@ public:
 	int h = 0;
 	int pitch = 0;  // bytes
 
-	Path path;
+	Path basePath;
+	std::string hashfile;
 	u32 replacedInfoHash;
+
+	bool skipIfExists = false;
 
 	TextureSaveTask(SimpleBuf<u32> _data) : data(std::move(_data)) {}
 
 	TaskType Type() const override { return TaskType::CPU_COMPUTE; }  // Also I/O blocking but dominated by compute
 	void Run() override {
+		const Path filename = basePath / hashfile;
+		const Path saveFilename = basePath / NEW_TEXTURE_DIR / hashfile;
+
+		// Should we skip writing if the newly saved data already exists?
+		// We do this on the thread due to slow IO.
+		if (skipIfExists && File::Exists(saveFilename))
+			return;
+
+		// And we always skip if the replace file already exists.
+		if (hashfile.empty() || File::Exists(filename))
+			return;
+
+		// Create subfolder as needed.
+#ifdef _WIN32
+		size_t slash = hashfile.find_last_of("/\\");
+#else
+		size_t slash = hashfile.find_last_of("/");
+#endif
+		if (slash != hashfile.npos) {
+			// Create any directory structure as needed.
+			const Path saveDirectory = basePath / NEW_TEXTURE_DIR / hashfile.substr(0, slash);
+			if (!File::Exists(saveDirectory)) {
+				File::CreateFullPath(saveDirectory);
+				File::CreateEmptyFile(saveDirectory / ".nomedia");
+			}
+		}
+
 		png_image png;
 		memset(&png, 0, sizeof(png));
 		png.version = PNG_IMAGE_VERSION;
 		png.format = PNG_FORMAT_RGBA;
 		png.width = w;
 		png.height = h;
-		bool success = WriteTextureToPNG(&png, path, 0, data.data(), pitch, nullptr);
+		bool success = WriteTextureToPNG(&png, saveFilename, 0, data.data(), pitch, nullptr);
 		png_image_free(&png);
 		if (png.warning_or_error >= 2) {
 			ERROR_LOG(COMMON, "Saving screenshot to PNG produced errors.");
@@ -535,58 +565,50 @@ public:
 	}
 };
 
+bool TextureReplacer::WillSave(const ReplacedTextureDecodeInfo &replacedInfo) {
+	_assert_msg_(enabled_, "Replacement not enabled");
+	if (!g_Config.bSaveNewTextures)
+		return false;
+	// Don't save the PPGe texture.
+	if (replacedInfo.addr > 0x05000000 && replacedInfo.addr < PSP_GetKernelMemoryEnd())
+		return false;
+	if (replacedInfo.isVideo && !allowVideo_)
+		return false;
+
+	return true;
+}
 
 void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &replacedInfo, const void *data, int pitch, int level, int w, int h) {
 	_assert_msg_(enabled_, "Replacement not enabled");
-	if (!g_Config.bSaveNewTextures) {
+	if (!WillSave(replacedInfo)) {
 		// Ignore.
 		return;
-	}
-	if (replacedInfo.addr > 0x05000000 && replacedInfo.addr < PSP_GetKernelMemoryEnd()) {
-		// Don't save the PPGe texture.
-		return;
-	}
-	if (replacedInfo.isVideo && !allowVideo_) {
-		return;
-	}
-	u64 cachekey = replacedInfo.cachekey;
-	if (ignoreAddress_) {
-		cachekey = cachekey & 0xFFFFFFFFULL;
 	}
 	if (ignoreMipmap_ && level > 0) {
 		return;
 	}
 
+	u64 cachekey = replacedInfo.cachekey;
+	if (ignoreAddress_) {
+		cachekey = cachekey & 0xFFFFFFFFULL;
+	}
+
 	std::string hashfile = LookupHashFile(cachekey, replacedInfo.hash, level);
 	const Path filename = basePath_ / hashfile;
-	const Path saveFilename = basePath_ / NEW_TEXTURE_DIR / hashfile;
 
 	// If it's empty, it's an ignored hash, we intentionally don't save.
-	if (hashfile.empty() || File::Exists(filename)) {
+	if (hashfile.empty()) {
 		// If it exists, must've been decoded and saved as a new texture already.
 		return;
 	}
 
 	ReplacementCacheKey replacementKey(cachekey, replacedInfo.hash);
 	auto it = savedCache_.find(replacementKey);
-	if (it != savedCache_.end() && File::Exists(saveFilename)) {
+	bool skipIfExists = false;
+	if (it != savedCache_.end()) {
 		// We've already saved this texture.  Let's only save if it's bigger (e.g. scaled now.)
 		if (it->second.w >= w && it->second.h >= h) {
-			return;
-		}
-	}
-
-#ifdef _WIN32
-	size_t slash = hashfile.find_last_of("/\\");
-#else
-	size_t slash = hashfile.find_last_of("/");
-#endif
-	if (slash != hashfile.npos) {
-		// Create any directory structure as needed.
-		const Path saveDirectory = basePath_ / NEW_TEXTURE_DIR / hashfile.substr(0, slash);
-		if (!File::Exists(saveDirectory)) {
-			File::CreateFullPath(saveDirectory);
-			File::CreateEmptyFile(saveDirectory / ".nomedia");
+			skipIfExists = true;
 		}
 	}
 
@@ -651,8 +673,10 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 	task->w = w;
 	task->h = h;
 	task->pitch = pitch;
-	task->path = saveFilename;
+	task->basePath = basePath_;
+	task->hashfile = hashfile;
 	task->replacedInfoHash = replacedInfo.hash;
+	task->skipIfExists = skipIfExists;
 	g_threadManager.EnqueueTask(task);  // We don't care about waiting for the task. It'll be fine.
 
 	// Remember that we've saved this for next time.

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -628,8 +628,7 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 
 	SimpleBuf<u32> saveBuf;
 
-	// TODO: Move the color conversion to the thread as well.
-	// Actually may be better to re-decode using expand32?
+	// Since we're copying, change the format meanwhile.  Not much extra cost.
 	if (replacedInfo.fmt != ReplacedTextureFormat::F_8888) {
 		saveBuf.resize((pitch * h) / sizeof(u16));
 		switch (replacedInfo.fmt) {

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -208,6 +208,7 @@ public:
 		return none_;
 	}
 
+	// Notify that a new texture was decoded.  May already be upscaled, saves the data passed.
 	void NotifyTextureDecoded(const ReplacedTextureDecodeInfo &replacedInfo, const void *data, int pitch, int level, int w, int h);
 
 	void Decimate(bool forcePressure);

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -208,6 +208,9 @@ public:
 		return none_;
 	}
 
+	// Check if a NotifyTextureDecoded for this texture is desired (used to avoid reads from write-combined memory.)
+	bool WillSave(const ReplacedTextureDecodeInfo &replacedInfo);
+
 	// Notify that a new texture was decoded.  May already be upscaled, saves the data passed.
 	void NotifyTextureDecoded(const ReplacedTextureDecodeInfo &replacedInfo, const void *data, int pitch, int level, int w, int h);
 

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -249,5 +249,5 @@ protected:
 
 	ReplacedTexture none_;
 	std::unordered_map<ReplacementCacheKey, ReplacedTexture> cache_;
-	std::unordered_map<ReplacementCacheKey, ReplacedTextureLevel> savedCache_;
+	std::unordered_map<ReplacementCacheKey, std::pair<ReplacedTextureLevel, double>> savedCache_;
 };

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -845,7 +845,6 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 					data = drawEngine_->GetPushBufferForTextureData()->PushAligned(size, &bufferOffset, &texBuf, pushAlignment);
 					LoadTextureLevel(*entry, (uint8_t *)data, stride, level, scaleFactor, dstFmt);
 					entry->vkTex->UploadMip(cmdInit, 0, mipWidth, mipHeight, texBuf, bufferOffset, stride / bpp);
-					break;
 				} else {
 					if (computeUpload) {
 						int srcBpp = dstFmt == VULKAN_8888_FORMAT ? 4 : 2;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1778,7 +1778,7 @@ void DeveloperToolsScreen::CreateViews() {
 	list->Add(new Choice(dev->T("Load language ini")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLoadLanguageIni);
 	list->Add(new Choice(dev->T("Save language ini")))->OnClick.Handle(this, &DeveloperToolsScreen::OnSaveLanguageIni);
 	list->Add(new ItemHeader(dev->T("Texture Replacement")));
-	list->Add(new CheckBox(&g_Config.bSaveNewTextures, dev->T("Save new textures")));
+	list->Add(new CheckBox(&g_Config.bSaveNewTextures, dev->T("Save new textures")))->SetEnabledPtr(&g_Config.bReplaceTextures);
 	list->Add(new CheckBox(&g_Config.bReplaceTextures, dev->T("Replace textures")));
 
 	// Makes it easy to get savestates out of an iOS device. The file listing shown in MacOS doesn't allow


### PR DESCRIPTION
Didn't check perf on Android, just that saving still works on Windows.  For me, under Vulkan, saving worked fine with upscale (didn't reproduce #15488), but maybe that's other backends.

This fixes saving "fake mipmaps" that force a constant texture level to 0, and moves IO onto the thread.  It does allow retrying saves every 5s, because before it intentionally repopulated deleted files.  Even if this queues up a bunch of tasks, I expect it to be much lighter than before.  That said, perhaps CPU_COMPUTE is a lie moreso now...

Further, on Vulkan, this moves decoding to a temporary buffer when saving texture data.  For simplicity, this buffer matches the target decode aligned stride, and maybe could `std::move()` to the thread as a later optimization (I'm sure the IO and PNG encode are a more significant part of performance, though.)

This also disables the save checkbox if not replacing, which was already how it actually worked.

I didn't look at Direct3D 11, but it could probably have something similar done to avoid reading from the upload buffer.  I think it's useful to save the upscaled data (at least when CPU upscaling), so I'd rather we not re-decode.  That sounds messy and wasteful for performance, anyway.

Likely to help #15478.

-[Unknown]