### PR TITLE
Vulkan texture mip level load fix

### DIFF
--- a/Common/DbgNew.h
+++ b/Common/DbgNew.h
@@ -3,6 +3,8 @@
 // Utility file for using the MS CRT's memory tracking.
 // crtdbg.h overloads malloc with malloc_dbg etc, but does not catch new. So here we go.
 
+// To add a full check of memory overruns, throw in a _CrtCheckMemory(). Useful to narrow things down.
+
 #include <crtdbg.h>
 
 #if defined(_DEBUG)

--- a/Common/GPU/Vulkan/VulkanImage.h
+++ b/Common/GPU/Vulkan/VulkanImage.h
@@ -60,7 +60,7 @@ private:
 	VulkanContext *vulkan_;
 	VkImage image_ = VK_NULL_HANDLE;
 	VkImageView view_ = VK_NULL_HANDLE;
-	VmaAllocation allocation_;
+	VmaAllocation allocation_ = VK_NULL_HANDLE;
 
 	int32_t width_ = 0;
 	int32_t height_ = 0;

--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -236,7 +236,7 @@ void *AllocateMemoryPages(size_t size, uint32_t memProtFlags) {
 
 void *AllocateAlignedMemory(size_t size, size_t alignment) {
 #ifdef _WIN32
-	void* ptr = _aligned_malloc(size,alignment);
+	void* ptr = _aligned_malloc(size, alignment);
 #else
 	void* ptr = NULL;
 #ifdef __ANDROID__

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -549,8 +549,7 @@ public:
 			}
 		}
 
-		png_image png;
-		memset(&png, 0, sizeof(png));
+		png_image png{};
 		png.version = PNG_IMAGE_VERSION;
 		png.format = PNG_FORMAT_RGBA;
 		png.width = w;


### PR DESCRIPTION
Found memory corruption caused by the wrong mip level being loaded when investigating #13015 , but that one is an OpenGL issue so likely entirely unrelated.

