### PR TITLE
Simplify alphasum checking for DXT textures, and fix a regression

### DIFF
--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -637,7 +637,7 @@ void DecodeDXT1Block(u32 *dst, const DXT1Block *src, int pitch, int height, u32 
 	DXTDecoder dxt;
 	dxt.DecodeColors(src, false);
 	dxt.WriteColorsDXT1(dst, src, pitch, height);
-	*alpha = dxt.AnyNonFullAlpha() ? 0 : 0xFFFFFFFF;
+	*alpha &= dxt.AnyNonFullAlpha() ? 0 : 1;
 }
 
 void DecodeDXT3Block(u32 *dst, const DXT3Block *src, int pitch, int height) {


### PR DESCRIPTION
Got some weird blackness in the sky in Gran Turismo. This fixes that.