### PR TITLE
Detect ISO files from file contents if extensions are wrong.

### DIFF
--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -37,6 +37,7 @@ enum class IdentifiedFileType {
 
 	UNKNOWN_BIN,
 	UNKNOWN_ELF,
+	UNKNOWN_ISO,
 
 	// Try to reduce support emails...
 	ARCHIVE_RAR,

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -83,6 +83,7 @@ bool GameInfo::Delete() {
 	case IdentifiedFileType::PSP_ELF:
 	case IdentifiedFileType::UNKNOWN_BIN:
 	case IdentifiedFileType::UNKNOWN_ELF:
+	case IdentifiedFileType::UNKNOWN_ISO:
 	case IdentifiedFileType::ARCHIVE_RAR:
 	case IdentifiedFileType::ARCHIVE_ZIP:
 	case IdentifiedFileType::ARCHIVE_7Z:


### PR DESCRIPTION
On older Android versions (that still support Android Storage Framework), filenames are not always preserved in Content URIs, they can look like `.../msf:342` and things like that. 

So let's identify a few more file types by content if filename identification fails.