### PR TITLE
Better default control config for the Retroid handheld Android console

### DIFF
--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -655,6 +655,8 @@ void RestoreDefault() {
 	SetDefaultKeyMap(DEFAULT_MAPPING_PAD, false);
 #elif PPSSPP_PLATFORM(ANDROID)
 	// Autodetect a few common (and less common) devices
+	// Note that here we check the device name, not the controller name. We don't get
+	// the controller name until a button has been pressed so can't use it to set defaults.
 	std::string name = System_GetProperty(SYSPROP_NAME);
 	if (IsNvidiaShield(name)) {
 		SetDefaultKeyMap(DEFAULT_MAPPING_SHIELD, false);
@@ -663,10 +665,10 @@ void RestoreDefault() {
 	} else if (IsXperiaPlay(name)) {
 		SetDefaultKeyMap(DEFAULT_MAPPING_XPERIA_PLAY, false);
 	} else if (IsMOQII7S(name)) {
-		INFO_LOG(SYSTEM, "MOQI pad map");
 		SetDefaultKeyMap(DEFAULT_MAPPING_MOQI_I7S, false);
+	} else if (IsRetroid(name)) {
+		SetDefaultKeyMap(DEFAULT_MAPPING_RETRO_STATION_CONTROLLER, false);
 	} else {
-		INFO_LOG(SYSTEM, "Default pad map");
 		SetDefaultKeyMap(DEFAULT_MAPPING_ANDROID_PAD, false);
 	}
 #else
@@ -737,6 +739,12 @@ bool IsNvidiaShield(const std::string &name) {
 	return name == "NVIDIA:SHIELD";
 }
 
+bool IsRetroid(const std::string &name) {
+	// TODO: Not sure if there are differences between different Retroid devices.
+	// The one I have is a "Retroid Pocket 2+".
+	return startsWith(name, "Retroid:");
+}
+
 bool IsNvidiaShieldTV(const std::string &name) {
 	return name == "NVIDIA:SHIELD Android TV";
 }
@@ -750,7 +758,7 @@ bool IsMOQII7S(const std::string &name) {
 }
 
 bool HasBuiltinController(const std::string &name) {
-	return IsOuya(name) || IsXperiaPlay(name) || IsNvidiaShield(name) || IsMOQII7S(name);
+	return IsOuya(name) || IsXperiaPlay(name) || IsNvidiaShield(name) || IsMOQII7S(name) || IsRetroid(name);
 }
 
 void NotifyPadConnected(const std::string &name) {
@@ -765,8 +773,8 @@ void AutoConfForPad(const std::string &name) {
 #if PPSSPP_PLATFORM(ANDROID)
 	if (name.find("Xbox") != std::string::npos) {
 		SetDefaultKeyMap(DEFAULT_MAPPING_ANDROID_XBOX, false);
-	} else {
-		SetDefaultKeyMap(DEFAULT_MAPPING_ANDROID_PAD, false);
+	} else if (name == "Retro Station Controller") {
+		SetDefaultKeyMap(DEFAULT_MAPPING_RETRO_STATION_CONTROLLER, false);
 	}
 #else
 	// TODO: Should actually check for XInput?

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -159,6 +159,7 @@ namespace KeyMap {
 	bool IsXperiaPlay(const std::string &name);
 	bool IsOuya(const std::string &name);
 	bool IsMOQII7S(const std::string &name);
+	bool IsRetroid(const std::string &name);
 	bool HasBuiltinController(const std::string &name);
 
 	const std::set<std::string> &GetSeenPads();

--- a/Core/KeyMapDefaults.cpp
+++ b/Core/KeyMapDefaults.cpp
@@ -194,6 +194,31 @@ static const DefMappingStruct defaultAndroidXboxControllerMap[] = {
 	{VIRTKEY_AXIS_Y_MAX, JOYSTICK_AXIS_Y, -1},
 };
 
+// Retroid reports its controller as "Retro Station Controller".
+// It's very similar to the Android Xbox mapping, just with main buttons swapped around.
+static const DefMappingStruct defaultRetroStationControllerMap[] = {
+	{CTRL_CROSS          , NKCODE_BUTTON_B},
+	{CTRL_CIRCLE         , NKCODE_BUTTON_A},
+	{CTRL_SQUARE         , NKCODE_BUTTON_Y},
+	{CTRL_TRIANGLE       , NKCODE_BUTTON_X},
+	// The hat for DPAD is standard for bluetooth pads, which is the most likely pads on Android I think.
+	{CTRL_LEFT           , NKCODE_DPAD_LEFT},
+	{CTRL_RIGHT          , NKCODE_DPAD_RIGHT},
+	{CTRL_UP             , NKCODE_DPAD_UP},
+	{CTRL_DOWN           , NKCODE_DPAD_DOWN},
+	{CTRL_START          , NKCODE_BUTTON_START},
+	{CTRL_SELECT         , NKCODE_BACK},
+	{CTRL_LTRIGGER       , NKCODE_BUTTON_L1},
+	{CTRL_RTRIGGER       , NKCODE_BUTTON_R1},
+	{VIRTKEY_FASTFORWARD , JOYSTICK_AXIS_RTRIGGER, +1},
+	{VIRTKEY_PAUSE       , JOYSTICK_AXIS_LTRIGGER, +1},
+	{VIRTKEY_AXIS_X_MIN, JOYSTICK_AXIS_X, -1},
+	{VIRTKEY_AXIS_X_MAX, JOYSTICK_AXIS_X, +1},
+	{VIRTKEY_AXIS_Y_MIN, JOYSTICK_AXIS_Y, +1},
+	{VIRTKEY_AXIS_Y_MAX, JOYSTICK_AXIS_Y, -1},
+};
+
+
 static const DefMappingStruct defaultPadMapAndroid[] = {
 	{CTRL_CROSS          , NKCODE_BUTTON_A},
 	{CTRL_CIRCLE         , NKCODE_BUTTON_B},
@@ -336,6 +361,9 @@ void SetDefaultKeyMap(DefaultMaps dmap, bool replace) {
 		break;
 	case DEFAULT_MAPPING_ANDROID_XBOX:
 		SetDefaultKeyMap(DEVICE_ID_PAD_0, defaultAndroidXboxControllerMap, ARRAY_SIZE(defaultAndroidXboxControllerMap), replace);
+		break;
+	case DEFAULT_MAPPING_RETRO_STATION_CONTROLLER:
+		SetDefaultKeyMap(DEVICE_ID_PAD_0, defaultRetroStationControllerMap, ARRAY_SIZE(defaultRetroStationControllerMap), replace);
 		break;
 	}
 

--- a/Core/KeyMapDefaults.h
+++ b/Core/KeyMapDefaults.h
@@ -12,8 +12,9 @@ enum DefaultMaps {
 	DEFAULT_MAPPING_OUYA,
 	DEFAULT_MAPPING_XPERIA_PLAY,
 	DEFAULT_MAPPING_MOQI_I7S,
+	DEFAULT_MAPPING_RETRO_STATION_CONTROLLER,
 };
 
 void SetDefaultKeyMap(DefaultMaps dmap, bool replace);
 
-}
+}  // namespace


### PR DESCRIPTION
They sent me one, so why not do this little fix. Apart from this minor tweak, PPSSPP seems to work just fine on the machine as-is, which is good.