### PR TITLE
Vulkan barrier optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -579,6 +579,8 @@ add_library(Common STATIC
 	Common/GPU/OpenGL/GLQueueRunner.h
 	Common/GPU/OpenGL/DataFormatGL.cpp
 	Common/GPU/OpenGL/DataFormatGL.h
+	Common/GPU/Vulkan/VulkanBarrier.cpp
+	Common/GPU/Vulkan/VulkanBarrier.h
 	Common/GPU/Vulkan/VulkanDebug.cpp
 	Common/GPU/Vulkan/VulkanDebug.h
 	Common/GPU/Vulkan/VulkanContext.cpp

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -438,6 +438,7 @@
     <ClInclude Include="GPU\thin3d.h" />
     <ClInclude Include="GPU\thin3d_create.h" />
     <ClInclude Include="GPU\Vulkan\VulkanAlloc.h" />
+    <ClInclude Include="GPU\Vulkan\VulkanBarrier.h" />
     <ClInclude Include="GPU\Vulkan\VulkanContext.h" />
     <ClInclude Include="GPU\Vulkan\VulkanDebug.h" />
     <ClInclude Include="GPU\Vulkan\VulkanImage.h" />
@@ -857,6 +858,7 @@
     <ClCompile Include="GPU\ShaderWriter.cpp" />
     <ClCompile Include="GPU\thin3d.cpp" />
     <ClCompile Include="GPU\Vulkan\thin3d_vulkan.cpp" />
+    <ClCompile Include="GPU\Vulkan\VulkanBarrier.cpp" />
     <ClCompile Include="GPU\Vulkan\VulkanContext.cpp" />
     <ClCompile Include="GPU\Vulkan\VulkanDebug.cpp" />
     <ClCompile Include="GPU\Vulkan\VulkanImage.cpp" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -418,6 +418,9 @@
     <ClInclude Include="Thread\Waitable.h">
       <Filter>Thread</Filter>
     </ClInclude>
+    <ClInclude Include="GPU\Vulkan\VulkanBarrier.h">
+      <Filter>GPU\Vulkan</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />
@@ -790,6 +793,9 @@
       <Filter>ext\vma</Filter>
     </ClCompile>
     <ClCompile Include="GPU\Vulkan\VulkanProfiler.cpp">
+      <Filter>GPU\Vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="GPU\Vulkan\VulkanBarrier.cpp">
       <Filter>GPU\Vulkan</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Common/GPU/Vulkan/VulkanBarrier.cpp
+++ b/Common/GPU/Vulkan/VulkanBarrier.cpp
@@ -3,8 +3,13 @@
 #include "VulkanBarrier.h"
 
 void VulkanBarrier::Flush(VkCommandBuffer cmd) {
+	if (!imageBarriers_.empty()) {
+		if (imageBarriers_.size() >= 3) {
+			NOTICE_LOG(G3D, "barriers: %d", (int)imageBarriers_.size());
+		}
+		vkCmdPipelineBarrier(cmd, srcStageMask_, dstStageMask_, 0, 0, nullptr, 0, nullptr, (uint32_t)imageBarriers_.size(), imageBarriers_.data());
+	}
 	imageBarriers_.clear();
 	srcStageMask_ = 0;
 	dstStageMask_ = 0;
-	vkCmdPipelineBarrier(cmd, srcStageMask_, dstStageMask_, 0, 0, nullptr, 0, nullptr, 1, imageBarriers_.data());
 }

--- a/Common/GPU/Vulkan/VulkanBarrier.cpp
+++ b/Common/GPU/Vulkan/VulkanBarrier.cpp
@@ -1,0 +1,10 @@
+#include "VulkanLoader.h"
+#include "VulkanContext.h"
+#include "VulkanBarrier.h"
+
+void VulkanBarrier::Flush(VkCommandBuffer cmd) {
+	imageBarriers_.clear();
+	srcStageMask_ = 0;
+	dstStageMask_ = 0;
+	vkCmdPipelineBarrier(cmd, srcStageMask_, dstStageMask_, 0, 0, nullptr, 0, nullptr, 1, imageBarriers_.data());
+}

--- a/Common/GPU/Vulkan/VulkanBarrier.cpp
+++ b/Common/GPU/Vulkan/VulkanBarrier.cpp
@@ -4,9 +4,6 @@
 
 void VulkanBarrier::Flush(VkCommandBuffer cmd) {
 	if (!imageBarriers_.empty()) {
-		if (imageBarriers_.size() >= 3) {
-			NOTICE_LOG(G3D, "barriers: %d", (int)imageBarriers_.size());
-		}
 		vkCmdPipelineBarrier(cmd, srcStageMask_, dstStageMask_, 0, 0, nullptr, 0, nullptr, (uint32_t)imageBarriers_.size(), imageBarriers_.data());
 	}
 	imageBarriers_.clear();

--- a/Common/GPU/Vulkan/VulkanBarrier.h
+++ b/Common/GPU/Vulkan/VulkanBarrier.h
@@ -3,7 +3,8 @@
 #include <string>
 #include <vector>
 
-#include "VulkanLoader.h"
+#include "Common/Log.h"
+#include "Common/GPU/Vulkan/VulkanLoader.h"
 
 class VulkanContext;
 
@@ -15,11 +16,77 @@ public:
 	void TransitionImage(
 		VkImage image, int baseMip, int numMipLevels, VkImageAspectFlags aspectMask,
 		VkImageLayout oldImageLayout, VkImageLayout newImageLayout,
-		VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
-		VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask) {
-
+		VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask,
+		VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask
+	) {
 		srcStageMask_ |= srcStageMask;
 		dstStageMask_ |= dstStageMask;
+
+		VkImageMemoryBarrier imageBarrier;
+		imageBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+		imageBarrier.pNext = nullptr;
+		imageBarrier.srcAccessMask = srcAccessMask;
+		imageBarrier.dstAccessMask = dstAccessMask;
+		imageBarrier.oldLayout = oldImageLayout;
+		imageBarrier.newLayout = newImageLayout;
+		imageBarrier.image = image;
+		imageBarrier.subresourceRange.aspectMask = aspectMask;
+		imageBarrier.subresourceRange.baseMipLevel = baseMip;
+		imageBarrier.subresourceRange.levelCount = numMipLevels;
+		imageBarrier.subresourceRange.layerCount = 1;  // We never use more than one layer, and old Mali drivers have problems with VK_REMAINING_ARRAY_LAYERS/VK_REMAINING_MIP_LEVELS.
+		imageBarrier.subresourceRange.baseArrayLayer = 0;
+		imageBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		imageBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		imageBarriers_.push_back(imageBarrier);
+	}
+
+	// Automatically determines access and stage masks from layouts.
+	// Not universally usable, but works for PPSSPP's use.
+	void TransitionImageAuto(
+		VkImage image, int baseMip, int numMipLevels, VkImageAspectFlags aspectMask, VkImageLayout oldImageLayout, VkImageLayout newImageLayout
+	) {
+		VkAccessFlags srcAccessMask = 0;
+		VkAccessFlags dstAccessMask = 0;
+		switch (oldImageLayout) {
+		case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
+			// Assert aspect here?
+			srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
+			srcStageMask_ |= VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+			break;
+		case VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL:
+			// Assert aspect here?
+			srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
+			srcStageMask_ |= VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+			break;
+		case VK_IMAGE_LAYOUT_UNDEFINED:
+			// Actually this seems wrong?
+			if (aspectMask == VK_IMAGE_ASPECT_COLOR_BIT) {
+				srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
+				srcStageMask_ |= VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+			}
+			break;
+		case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
+			srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+			srcStageMask_ |= VK_PIPELINE_STAGE_TRANSFER_BIT;
+			break;
+		case VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL:
+			srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+			srcStageMask_ |= VK_PIPELINE_STAGE_TRANSFER_BIT;
+			break;
+		default:
+			_assert_msg_(false, "Unexpected oldLayout: %d", (int)oldImageLayout);
+			break;
+		}
+
+		switch (newImageLayout) {
+		case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+			dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+			dstStageMask_ |= VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+			break;
+		default:
+			_assert_msg_(false, "Unexpected newLayout: %d", (int)newImageLayout);
+			break;
+		}
 
 		VkImageMemoryBarrier imageBarrier;
 		imageBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;

--- a/Common/GPU/Vulkan/VulkanBarrier.h
+++ b/Common/GPU/Vulkan/VulkanBarrier.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "VulkanLoader.h"
+
+class VulkanContext;
+
+// Collects multiple barriers into one, then flushes it.
+// Reusable after a flush, in case you want to reuse the allocation made by the vector.
+// However, not thread safe in any way!
+class VulkanBarrier {
+public:
+	void TransitionImage(
+		VkImage image, int baseMip, int numMipLevels, VkImageAspectFlags aspectMask,
+		VkImageLayout oldImageLayout, VkImageLayout newImageLayout,
+		VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
+		VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask) {
+
+		srcStageMask_ |= srcStageMask;
+		dstStageMask_ |= dstStageMask;
+
+		VkImageMemoryBarrier imageBarrier;
+		imageBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+		imageBarrier.pNext = nullptr;
+		imageBarrier.srcAccessMask = srcAccessMask;
+		imageBarrier.dstAccessMask = dstAccessMask;
+		imageBarrier.oldLayout = oldImageLayout;
+		imageBarrier.newLayout = newImageLayout;
+		imageBarrier.image = image;
+		imageBarrier.subresourceRange.aspectMask = aspectMask;
+		imageBarrier.subresourceRange.baseMipLevel = baseMip;
+		imageBarrier.subresourceRange.levelCount = numMipLevels;
+		imageBarrier.subresourceRange.layerCount = 1;  // We never use more than one layer, and old Mali drivers have problems with VK_REMAINING_ARRAY_LAYERS/VK_REMAINING_MIP_LEVELS.
+		imageBarrier.subresourceRange.baseArrayLayer = 0;
+		imageBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		imageBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+		imageBarriers_.push_back(imageBarrier);
+	}
+
+	void Flush(VkCommandBuffer cmd);
+
+private:
+	VkPipelineStageFlags srcStageMask_ = 0;
+	VkPipelineStageFlags dstStageMask_ = 0;
+	std::vector<VkImageMemoryBarrier> imageBarriers_;
+};

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -289,8 +289,8 @@ private:
 	void ApplySonicHack(std::vector<VKRStep *> &steps);
 	void ApplyRenderPassMerge(std::vector<VKRStep *> &steps);
 
-	static void SetupTransitionToTransferSrc(VKRImage &img, VkImageMemoryBarrier &barrier, VkPipelineStageFlags &stage, VkImageAspectFlags aspect);
-	static void SetupTransitionToTransferDst(VKRImage &img, VkImageMemoryBarrier &barrier, VkPipelineStageFlags &stage, VkImageAspectFlags aspect);
+	static void SetupTransitionToTransferSrc(VKRImage &img, VkImageAspectFlags aspect, VulkanBarrier *recordBarrier);
+	static void SetupTransitionToTransferDst(VKRImage &img, VkImageAspectFlags aspect, VulkanBarrier *recordBarrier);
 
 	VulkanContext *vulkan_;
 

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -7,6 +7,7 @@
 
 #include "Common/Data/Collections/Hashmaps.h"
 #include "Common/GPU/Vulkan/VulkanContext.h"
+#include "Common/GPU/Vulkan/VulkanBarrier.h"
 #include "Common/Data/Convert/SmallDataConvert.h"
 #include "Common/Data/Collections/TinySet.h"
 #include "Common/GPU/DataFormat.h"
@@ -318,4 +319,9 @@ private:
 	// Compile done notifications.
 	std::mutex compileDoneMutex_;
 	std::condition_variable compileDone_;
+
+	// Image barrier helper used during command buffer record (PerformRenderPass etc).
+	// Stored here to help reuse the allocation.
+
+	VulkanBarrier recordBarrier_;
 };

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -133,7 +133,12 @@ VkSampler SamplerCache::GetOrCreateSampler(const SamplerCacheKey &key) {
 		samp.maxAnisotropy = 1.0f;
 		samp.anisotropyEnable = false;
 	}
-	samp.maxLod = (float)(int32_t)key.maxLevel * (1.0f / 256.0f);
+	if (key.maxLevel == 9 * 256) {
+		// No max level needed.
+		samp.maxLod = VK_LOD_CLAMP_NONE;
+	} else {
+		samp.maxLod = (float)(int32_t)key.maxLevel * (1.0f / 256.0f);
+	}
 	samp.minLod = (float)(int32_t)key.minLevel * (1.0f / 256.0f);
 	samp.mipLodBias = (float)(int32_t)key.lodBias * (1.0f / 256.0f);
 

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -126,6 +126,7 @@ VULKAN_FILES := \
   $(SRC)/Common/GPU/Vulkan/VulkanImage.cpp \
   $(SRC)/Common/GPU/Vulkan/VulkanMemory.cpp \
   $(SRC)/Common/GPU/Vulkan/VulkanProfiler.cpp \
+  $(SRC)/Common/GPU/Vulkan/VulkanBarrier.cpp \
   $(SRC)/GPU/Vulkan/DrawEngineVulkan.cpp \
   $(SRC)/GPU/Vulkan/FramebufferManagerVulkan.cpp \
   $(SRC)/GPU/Vulkan/GPU_Vulkan.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -263,6 +263,7 @@ SOURCES_CXX += \
 	$(COMMONDIR)/GPU/Vulkan/VulkanImage.cpp \
 	$(COMMONDIR)/GPU/Vulkan/VulkanMemory.cpp \
 	$(COMMONDIR)/GPU/Vulkan/VulkanProfiler.cpp \
+	$(COMMONDIR)/GPU/Vulkan/VulkanBarrier.cpp \
 	$(COMMONDIR)/Input/GestureDetector.cpp \
 	$(COMMONDIR)/Input/InputState.cpp \
 	$(COMMONDIR)/Math/curves.cpp \


### PR DESCRIPTION
Combine image memory barriers in cases where it's easy. Can't hurt, and was recommended by the AMD best-practices validation layer. Also simplifies some code.

Throw in a minor best-practices optimization too.

(We also have a huge opportunity to combine barriers during texture upload when multiple textures are uploaded in the same frame though this PR doesn't take care of that)