### PR TITLE
libkirk: Set Segher Boessenkool's original copyright notice

### DIFF
--- a/ext/libkirk/bn.c
+++ b/ext/libkirk/bn.c
@@ -1,6 +1,7 @@
-// Copyright 2007,2008,2010  Segher Boessenkool  <segher@kernel.crashing.org>
-// Licensed under the terms of the GNU GPL, version 2
-// http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+// Copyright 2007-2022  Segher Boessenkool  <segher@kernel.crashing.org>
+// Licensed under the terms of the GNU GPL, either version 2 or version 3
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+// https://www.gnu.org/licenses/gpl-3.0.html
 // Updated and simplified for use by Kirk Engine - July 2011
 
 #include <string.h>

--- a/ext/libkirk/ec.c
+++ b/ext/libkirk/ec.c
@@ -1,6 +1,7 @@
-// Copyright 2007,2008,2010  Segher Boessenkool  <segher@kernel.crashing.org>
-// Licensed under the terms of the GNU GPL, version 2
-// http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+// Copyright 2007-2022  Segher Boessenkool  <segher@kernel.crashing.org>
+// Licensed under the terms of the GNU GPL, either version 2 or version 3
+// https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+// https://www.gnu.org/licenses/gpl-3.0.html
 
 
 // Modified for Kirk engine by setting single curve and internal function


### PR DESCRIPTION
Segher Boessenkool (@segher) is the original author of libkirk's `ec.c` and `bn.c` files, which are originally for the Wii K-233.
Those files were used, and modified for KIRK.
After contacting him, I learnt his original copyright notice was somehow altered (probably years ago). 
This small PR restores his original copyright notice.