### PR TITLE
Replacement: Allow texture dump without replace

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1778,7 +1778,7 @@ void DeveloperToolsScreen::CreateViews() {
 	list->Add(new Choice(dev->T("Load language ini")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLoadLanguageIni);
 	list->Add(new Choice(dev->T("Save language ini")))->OnClick.Handle(this, &DeveloperToolsScreen::OnSaveLanguageIni);
 	list->Add(new ItemHeader(dev->T("Texture Replacement")));
-	list->Add(new CheckBox(&g_Config.bSaveNewTextures, dev->T("Save new textures")))->SetEnabledPtr(&g_Config.bReplaceTextures);
+	list->Add(new CheckBox(&g_Config.bSaveNewTextures, dev->T("Save new textures")));
 	list->Add(new CheckBox(&g_Config.bReplaceTextures, dev->T("Replace textures")));
 
 	// Makes it easy to get savestates out of an iOS device. The file listing shown in MacOS doesn't allow


### PR DESCRIPTION
This was my mistake before.  I thought it wasn't working properly, but I'd just made a mistake.

I'd originally meant for this to be allowed intentionally, and forgot.  Someone pointed out that it was no longer allowed by the UI but used to work and still does if you check/uncheck to get around the disable limitation.

-[Unknown]