### PR TITLE
Unused lang tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ debian/ppsspp/
 
 # CMake stuff
 CMakeFiles
+
+# Clangd 
+.cache/

--- a/Tools/langtool/unused-euristic.sh
+++ b/Tools/langtool/unused-euristic.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+langfile='../../assets/lang/en_US.ini'
+folders=('../../UI/' '../../Core/' '../../Common/' '../../Windows/' '../../assets/shaders' '../../assets/themes')
+
+# reading each line
+while read line; do
+    # skip empty line, section and comment
+    if [[ ! -z "$line" && ${line::1} != "[" && ${line::1} != "#" ]]; then
+        # get everything before the = sign
+        value=${line/ =*/}
+
+        found=0
+        for folder in ${folders[@]}; do
+            # use recursive grep on the folder
+            grep -r "$value" $folder > /dev/null
+            # check return value
+            ret=$?
+            if [ $ret -eq 0 ]; then
+                found=1
+            fi
+        done
+
+        # print if not found
+        if [ $found -eq 0 ]; then
+            echo $value
+        fi
+    fi
+done < $langfile


### PR DESCRIPTION
Bash script that prints translation keys that are not present in the given folders (recursive). Should help remove old unused keys.

Right now it prints:
```
Analog Axis Sensitivity
Analog Mapper High End
Analog Mapper Low End
Analog Mapper Mode
Combo Key Setting
Combo Key Setup
DInput Analog Settings
Show right analog
X + Y
XInput Analog Settings
Enable Chat
Failed to identify file
Warning: Video memory FULL, reducing upscaling and switching to slow caching mode
Warning: Video memory FULL, switching to slow caching mode
(supersampling)
(upscaling)
Clear Speedhack
ClearSpeedhack Tip
hardware transform error - falling back to software
Internal Resolution
SoftGPU Tip
Turn off Hardware Tessellation - unsupported
Test Analogs
Auto Analog Rotation (CCW)
Auto Analog Rotation (CW)
TCP No Delay
ChangingMemstickPathNotExists
Color Theme
```