### PR TITLE
Expose networking options in libretro core

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -689,7 +689,7 @@ static void check_variables(CoreParameter &coreParam)
    ppsspp_enable_builtin_pro_ad_hoc_server.Update(&g_Config.bEnableAdhocServer);
 
    ppsspp_chat_button_position.Update(&g_Config.iChatButtonPosition);
-   ppsspp_chat_screen_position.Update(&g_Config.iChatButtonPosition);
+   ppsspp_chat_screen_position.Update(&g_Config.iChatScreenPosition);
    ppsspp_upnp_use_original_port.Update(&g_Config.bUPnPUseOriginalPort);
    ppsspp_port_offset.Update(&g_Config.iPortOffset);
    ppsspp_minimum_timeout.Update(&g_Config.iMinTimeout);

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -428,7 +428,6 @@ static RetroOption<std::string> ppsspp_change_mac_address[] = {
     {"ppsspp_change_mac_address12", "MAC address Pt 12: --:--:--:--:--:-X", MAC_INITIALIZER_LIST}
 };
 static RetroOption<int> ppsspp_wlan_channel("ppsspp_wlan_channel", "WLAN channel", {{"Auto", 0}, {"1", 1}, {"6", 6}, {"11", 11}} );
-static RetroOption<bool> ppsspp_discord_presence("ppsspp_discord_presence", "Send Discord \"Rich Presence\" information", true);
 static RetroOption<bool> ppsspp_enable_builtin_pro_ad_hoc_server("ppsspp_enable_builtin_pro_ad_hoc_server", "Enable built-in PRO ad hoc server", false);
 static RetroOption<std::string> ppsspp_change_pro_ad_hoc_server_address("ppsspp_change_pro_ad_hoc_server_address", "Change PRO ad hoc server IP address (localhost = multiple instances)", {
     {"socom.cc", "socom.cc"},
@@ -540,7 +539,6 @@ void retro_set_environment(retro_environment_t cb)
    for (int i = 0; i < 12; ++i)
       vars.push_back(ppsspp_change_mac_address[i].GetOptions());
    vars.push_back(ppsspp_wlan_channel.GetOptions());
-   vars.push_back(ppsspp_discord_presence.GetOptions());
    vars.push_back(ppsspp_enable_builtin_pro_ad_hoc_server.GetOptions());
    vars.push_back(ppsspp_change_pro_ad_hoc_server_address.GetOptions());
    for (int i = 0; i < 12; ++i)
@@ -696,7 +694,6 @@ static void check_variables(CoreParameter &coreParam)
 
    ppsspp_enable_wlan.Update(&g_Config.bEnableWlan);
    ppsspp_wlan_channel.Update(&g_Config.iWlanAdhocChannel);
-   ppsspp_discord_presence.Update(&g_Config.bDiscordPresence);
    ppsspp_enable_builtin_pro_ad_hoc_server.Update(&g_Config.bEnableAdhocServer);
 
    ppsspp_upnp_use_original_port.Update(&g_Config.bUPnPUseOriginalPort);
@@ -805,6 +802,7 @@ void retro_init(void)
    g_Config.flash0Directory = retro_base_dir / "flash0";
    g_Config.internalDataDirectory = retro_base_dir;
    g_Config.bEnableNetworkChat = false;
+   g_Config.bDiscordPresence = false;
 
    VFSRegister("", new DirectoryAssetReader(retro_base_dir));
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -452,28 +452,6 @@ static RetroOption<int> ppsspp_pro_ad_hoc_ipv4[] = {
 };
 static RetroOption<bool> ppsspp_enable_upnp("ppsspp_enable_upnp", "Enable UPnP (need a few seconds to detect)", false);
 static RetroOption<bool> ppsspp_upnp_use_original_port("ppsspp_upnp_use_original_port", "UPnP use original port (enabled = PSP compatibility)", true);
-static RetroOption<bool> ppsspp_enable_network_chat("ppsspp_enable_network_chat", "Enable network chat", true);
-static RetroOption<int> ppsspp_chat_button_position("ppsspp_chat_button_position", "Chat button position", {
-    {"Bottom left", BOTTOM_LEFT},
-    {"Bottom center", BOTTOM_CENTER},
-    {"Bottom right", BOTOM_RIGHT},
-    {"Top left", TOP_LEFT},
-    {"Top center", TOP_CENTER},
-    {"Top right", TOP_RIGHT},
-    {"Center left", CENTER_LEFT},
-    {"Center right", CENTER_RIGHT},
-    {"None", 8}
-});
-static RetroOption<int> ppsspp_chat_screen_position("ppsspp_chat_screen_position", "Chat screen position", {
-    {"Bottom left", BOTTOM_LEFT},
-    {"Bottom center", BOTTOM_CENTER},
-    {"Bottom right", BOTOM_RIGHT},
-    {"Top left", TOP_LEFT},
-    {"Top center", TOP_CENTER},
-    {"Top right", TOP_RIGHT},
-    {"Center left", CENTER_LEFT},
-    {"Center right", CENTER_RIGHT}
-});
 static RetroOption<int> ppsspp_port_offset("ppsspp_port_offset", "Port offset (0 = PSP compatibility)", {{"0", 0}, {"5000", 5000}, {"10000", 10000}, {"15000", 15000}});
 static RetroOption<int> ppsspp_minimum_timeout("ppsspp_minimum timeout", "Minimum timeout (override in ms, 0 = default))", 0, 15000, 100);
 static RetroOption<bool> ppsspp_forced_first_connect("ppsspp_forced_first_connect", "Forced first connect (faster connect)", false);
@@ -514,12 +492,6 @@ static bool set_variable_visibility(void)
       updated = true;
 
     ppsspp_upnp_use_original_port.Show(g_Config.bEnableUPnP);
-
-   if (ppsspp_enable_network_chat.Update(&g_Config.bEnableNetworkChat))
-       updated = true;
-
-   ppsspp_chat_button_position.Show(g_Config.bEnableNetworkChat);
-   ppsspp_chat_screen_position.Show(g_Config.bEnableNetworkChat);
 
    return updated;
 }
@@ -575,9 +547,6 @@ void retro_set_environment(retro_environment_t cb)
       vars.push_back(ppsspp_pro_ad_hoc_ipv4[i].GetOptions());
    vars.push_back(ppsspp_enable_upnp.GetOptions());
    vars.push_back(ppsspp_upnp_use_original_port.GetOptions());
-   vars.push_back(ppsspp_enable_network_chat.GetOptions());
-   vars.push_back(ppsspp_chat_button_position.GetOptions());
-   vars.push_back(ppsspp_chat_screen_position.GetOptions());
    vars.push_back(ppsspp_port_offset.GetOptions());
    vars.push_back(ppsspp_minimum_timeout.GetOptions());
    vars.push_back(ppsspp_forced_first_connect.GetOptions());
@@ -730,8 +699,6 @@ static void check_variables(CoreParameter &coreParam)
    ppsspp_discord_presence.Update(&g_Config.bDiscordPresence);
    ppsspp_enable_builtin_pro_ad_hoc_server.Update(&g_Config.bEnableAdhocServer);
 
-   ppsspp_chat_button_position.Update(&g_Config.iChatButtonPosition);
-   ppsspp_chat_screen_position.Update(&g_Config.iChatScreenPosition);
    ppsspp_upnp_use_original_port.Update(&g_Config.bUPnPUseOriginalPort);
    ppsspp_port_offset.Update(&g_Config.iPortOffset);
    ppsspp_minimum_timeout.Update(&g_Config.iMinTimeout);
@@ -837,6 +804,7 @@ void retro_init(void)
    g_Config.memStickDirectory = retro_save_dir;
    g_Config.flash0Directory = retro_base_dir / "flash0";
    g_Config.internalDataDirectory = retro_base_dir;
+   g_Config.bEnableNetworkChat = false;
 
    VFSRegister("", new DirectoryAssetReader(retro_base_dir));
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -344,10 +344,8 @@ template <typename T> class RetroOption
 
       void Show(bool show)
       {
-       struct retro_core_option_display optionDisplay;
-	optionDisplay.key = id_;
-	optionDisplay.visible = show;
-	environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &optionDisplay);
+      struct retro_core_option_display optionDisplay{id_, show};
+      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &optionDisplay);
       }
 
    private:
@@ -392,22 +390,22 @@ static RetroOption<bool> ppsspp_enable_wlan("ppsspp_enable_wlan", "Enable Networ
 static RetroOption<int> ppsspp_wlan_channel("ppsspp_wlan_channel", "WLAN channel", {{"Auto", 0}, {"1", 1}, {"6", 6}, {"11", 11}} );
 static RetroOption<bool> ppsspp_discord_presence("ppsspp_discord_presence", "Send Discord \"Rich Presence\" information", true);
 static RetroOption<bool> ppsspp_enable_builtin_pro_ad_hoc_server("ppsspp_enable_builtin_pro_ad_hoc_server", "Enable built-in PRO ad hoc server", false);
-static RetroOption<std::string> ppsspp_change_pro_ad_hoc_server_address("ppsspp_change_pro_ad_hoc_server_address", "Change PRO ad hoc server", {
+static RetroOption<std::string> ppsspp_change_pro_ad_hoc_server_address("ppsspp_change_pro_ad_hoc_server_address", "Change PRO ad hoc server IP address (localhost = multiple instances)", {
     {"socom.cc", "socom.cc"},
     {"myneighborsushicat.com", "myneighborsushicat.com"},
     {"localhost", "localhost"},
     {"IP address", "IP address"}
 });
 static RetroOption<int> ppsspp_pro_ad_hoc_ipv4[] = {
-   {"ppsspp_pro_ad_hoc_server_address1", "PRO ad hoc server IP address Pt  1: x--.---.---.--- ", 0, 10, 1},
-   {"ppsspp_pro_ad_hoc_server_address2", "PRO ad hoc server IP address Pt  2: -x-.---.---.--- ", 0, 10, 1},
-   {"ppsspp_pro_ad_hoc_server_address3", "PRO ad hoc server IP address Pt  3: --x.---.---.--- ", 0, 10, 1},
-   {"ppsspp_pro_ad_hoc_server_address4", "PRO ad hoc server IP address Pt  4: ---.x--.---.--- ", 0, 10, 1},
-   {"ppsspp_pro_ad_hoc_server_address5", "PRO ad hoc server IP address Pt  5: ---.-x-.---.--- ", 0, 10, 1},
-   {"ppsspp_pro_ad_hoc_server_address6", "PRO ad hoc server IP address Pt  6: ---.--x.---.--- ", 0, 10, 1},
-   {"ppsspp_pro_ad_hoc_server_address7", "PRO ad hoc server IP address Pt  7: ---.---.x--.--- ", 0, 10, 1},
-   {"ppsspp_pro_ad_hoc_server_address8", "PRO ad hoc server IP address Pt  8: ---.---.-x-.--- ", 0, 10, 1},
-   {"ppsspp_pro_ad_hoc_server_address9", "PRO ad hoc server IP address Pt  9: ---.---.--x.--- ", 0, 10, 1},
+   {"ppsspp_pro_ad_hoc_server_address01", "PRO ad hoc server IP address Pt  1: x--.---.---.--- ", 0, 10, 1},
+   {"ppsspp_pro_ad_hoc_server_address02", "PRO ad hoc server IP address Pt  2: -x-.---.---.--- ", 0, 10, 1},
+   {"ppsspp_pro_ad_hoc_server_address03", "PRO ad hoc server IP address Pt  3: --x.---.---.--- ", 0, 10, 1},
+   {"ppsspp_pro_ad_hoc_server_address04", "PRO ad hoc server IP address Pt  4: ---.x--.---.--- ", 0, 10, 1},
+   {"ppsspp_pro_ad_hoc_server_address05", "PRO ad hoc server IP address Pt  5: ---.-x-.---.--- ", 0, 10, 1},
+   {"ppsspp_pro_ad_hoc_server_address06", "PRO ad hoc server IP address Pt  6: ---.--x.---.--- ", 0, 10, 1},
+   {"ppsspp_pro_ad_hoc_server_address07", "PRO ad hoc server IP address Pt  7: ---.---.x--.--- ", 0, 10, 1},
+   {"ppsspp_pro_ad_hoc_server_address08", "PRO ad hoc server IP address Pt  8: ---.---.-x-.--- ", 0, 10, 1},
+   {"ppsspp_pro_ad_hoc_server_address09", "PRO ad hoc server IP address Pt  9: ---.---.--x.--- ", 0, 10, 1},
    {"ppsspp_pro_ad_hoc_server_address10", "PRO ad hoc server IP address Pt 10: ---.---.---.x-- ", 0, 10, 1},
    {"ppsspp_pro_ad_hoc_server_address11", "PRO ad hoc server IP address Pt 11: ---.---.---.-x- ", 0, 10, 1},
    {"ppsspp_pro_ad_hoc_server_address12", "PRO ad hoc server IP address Pt 12: ---.---.---.--x ", 0, 10, 1}

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -452,7 +452,7 @@ static RetroOption<int> ppsspp_pro_ad_hoc_ipv4[] = {
 };
 static RetroOption<bool> ppsspp_enable_upnp("ppsspp_enable_upnp", "Enable UPnP (need a few seconds to detect)", false);
 static RetroOption<bool> ppsspp_upnp_use_original_port("ppsspp_upnp_use_original_port", "UPnP use original port (enabled = PSP compatibility)", true);
-static RetroOption<int> ppsspp_port_offset("ppsspp_port_offset", "Port offset (0 = PSP compatibility)", {{"0", 0}, {"5000", 5000}, {"10000", 10000}, {"15000", 15000}});
+static RetroOption<int> ppsspp_port_offset("ppsspp_port_offset", "Port offset (0 = PSP compatibility)", 0, 65001, 1000);
 static RetroOption<int> ppsspp_minimum_timeout("ppsspp_minimum timeout", "Minimum timeout (override in ms, 0 = default))", 0, 15000, 100);
 static RetroOption<bool> ppsspp_forced_first_connect("ppsspp_forced_first_connect", "Forced first connect (faster connect)", false);
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -452,7 +452,7 @@ static RetroOption<int> ppsspp_pro_ad_hoc_ipv4[] = {
 static RetroOption<bool> ppsspp_enable_upnp("ppsspp_enable_upnp", "Enable UPnP (need a few seconds to detect)", false);
 static RetroOption<bool> ppsspp_upnp_use_original_port("ppsspp_upnp_use_original_port", "UPnP use original port (enabled = PSP compatibility)", true);
 static RetroOption<int> ppsspp_port_offset("ppsspp_port_offset", "Port offset (0 = PSP compatibility)", 0, 65001, 1000);
-static RetroOption<int> ppsspp_minimum_timeout("ppsspp_minimum timeout", "Minimum timeout (override in ms, 0 = default))", 0, 15000, 100);
+static RetroOption<int> ppsspp_minimum_timeout("ppsspp_minimum timeout", "Minimum timeout (override in ms, 0 = default))", 0, 5001, 100);
 static RetroOption<bool> ppsspp_forced_first_connect("ppsspp_forced_first_connect", "Forced first connect (faster connect)", false);
 
 static bool set_variable_visibility(void)

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -410,7 +410,7 @@ static RetroOption<int> ppsspp_pro_ad_hoc_ipv4[] = {
    {"ppsspp_pro_ad_hoc_server_address11", "PRO ad hoc server IP address Pt 11: ---.---.---.-x- ", 0, 10, 1},
    {"ppsspp_pro_ad_hoc_server_address12", "PRO ad hoc server IP address Pt 12: ---.---.---.--x ", 0, 10, 1}
 };
-static RetroOption<bool> ppsspp_enable_upnp("ppsspp_enable_upnp", "Enable UPnP (need a few seconds to detect)", true);
+static RetroOption<bool> ppsspp_enable_upnp("ppsspp_enable_upnp", "Enable UPnP (need a few seconds to detect)", false);
 static RetroOption<bool> ppsspp_upnp_use_original_port("ppsspp_upnp_use_original_port", "UPnP use original port (enabled = PSP compatibility)", true);
 static RetroOption<bool> ppsspp_enable_network_chat("ppsspp_enable_network_chat", "Enable network chat", true);
 static RetroOption<int> ppsspp_chat_button_position("ppsspp_chat_button_position", "Chat button position", {


### PR DESCRIPTION
This was inspired by #15461 and the fact that I wanted to play Soulcalibur Broken Destiny on my LAN.

I have been able to play a network game with the Libretro core on my Pi against PPSSPPQt standalone on my desktop. So there is added value. Network games between PPSSPP Libretro cores work as well.

<strike>I have not been able to play network games with the Libretro core on my Pi against another Libretro core on my desktop. The systems see each other, however when you challenge the other player, the challenge never arrives and nothing happens.</strike>

Some of these options might not make any sense for the Libretro core, however I can't judge that. I'm open to suggestions for improving this PR.

The idea of how to enter the IP address was borrowed from the Gambatte Libretro Core. Also I looked at Flycast for inspiration about hiding and showing menu items.