### PR TITLE
Crash: Recover from unaligned CPU access

### DIFF
--- a/Core/MemFault.cpp
+++ b/Core/MemFault.cpp
@@ -111,15 +111,17 @@ bool HandleFault(uintptr_t hostAddress, void *ctx) {
 #endif
 
 	// Check whether hostAddress is within the PSP memory space, which (likely) means it was a guest executable that did the bad access.
+	bool invalidHostAddress = hostAddress == (uintptr_t)0xFFFFFFFFFFFFFFFFULL;
 	if (hostAddress < baseAddress || hostAddress >= baseAddress + addressSpaceSize) {
 		// Host address outside - this was a different kind of crash.
-		return false;
+		if (!invalidHostAddress)
+			return false;
 	}
 
 
 	// OK, a guest executable did a bad access. Take care of it.
 
-	uint32_t guestAddress = (uint32_t)(hostAddress - baseAddress);
+	uint32_t guestAddress = invalidHostAddress ? 0xFFFFFFFFUL : (uint32_t)(hostAddress - baseAddress);
 
 	// TODO: Share the struct between the various analyzers, that will allow us to share most of
 	// the implementations here.


### PR DESCRIPTION
On Windows, this catches SIMD accesses that are unaligned.  See #15523.

Not sure why they come through as an access violation with a bad address, I first tried EXCEPTION_DATATYPE_MISALIGNMENT but it doesn't seem to trip (guessing it's ARM only perhaps?)

-[Unknown]