### PR TITLE
GPU: Hook Sol Trigger func to flush texture

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -1325,6 +1325,19 @@ static int Hook_openseason_data_decode() {
 	return 0;
 }
 
+static int Hook_soltrigger_render_ucschar() {
+	u32 targetInfoPtrPtr = currentMIPS->r[MIPS_REG_A2];
+	u32 targetInfoPtr = Memory::IsValidRange(targetInfoPtrPtr, 4) ? Memory::ReadUnchecked_U32(targetInfoPtrPtr) : 0;
+	if (Memory::IsValidRange(targetInfoPtr, 32)) {
+		u32 targetPtr = Memory::Read_U32(targetInfoPtr + 8);
+		u32 targetByteStride = Memory::Read_U32(targetInfoPtr + 16);
+
+		// We don't know the height specifically.
+		gpu->InvalidateCache(targetPtr, targetByteStride * 512, GPU_INVALIDATE_HINT);
+	}
+	return 0;
+}
+
 #define JITFUNC(f) (&MIPSComp::MIPSFrontendInterface::f)
 
 // Can either replace with C functions or functions emitted in Asm/ArmAsm.
@@ -1440,6 +1453,7 @@ static const ReplacementTableEntry entries[] = {
 	{ "motorstorm_pixel_read", &Hook_motorstorm_pixel_read, 0, REPFLAG_HOOKENTER, 0 },
 	{ "worms_copy_normalize_alpha", &Hook_worms_copy_normalize_alpha, 0, REPFLAG_HOOKENTER, 0x0CC },
 	{ "openseason_data_decode", &Hook_openseason_data_decode, 0, REPFLAG_HOOKENTER, 0x2F0 },
+	{ "soltrigger_render_ucschar", &Hook_soltrigger_render_ucschar, 0, REPFLAG_HOOKENTER, 0 },
 	{}
 };
 

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -156,6 +156,7 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0x1f53eac122f96b37, 224, "cosf", },
 	{ 0x2097a8b75c8fe651, 436, "atan2", },
 	{ 0x21411b3c860822c0, 36, "matrix_scale_q_t", },
+	{ 0x2161ea81a06bcacd, 1032, "soltrigger_render_ucschar", }, // Sol Trigger
 	{ 0x24d82a8675800808, 220, "ceilf", },
 	{ 0x26cc90cb25af9d27, 476, "log10", },
 	{ 0x275c79791a2bab83, 116, "rezel_cross_download_frame", }, // Rezel Cross


### PR DESCRIPTION
This makes sure the hardware renderer reuploads a texture modified during stall, which they normally skip as an optimization (see #10967, #9449.)  To note, I already checked that software rendering handles this accurately without any hook.

Fixes Sol Trigger for me, and it seems like Last Ranker may be using the same func (or else a very similar one), so worth testing if someone can verify that.

I don't have any information on Naruto Heroes 3, I think it has a different developer so unlikely this helps that one.

-[Unknown]