### PR TITLE
Postshader: Avoid treating directories as files

### DIFF
--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -96,6 +96,9 @@ void LoadPostShaderInfo(Draw::DrawContext *draw, const std::vector<Path> &direct
 		for (size_t f = 0; f < fileInfo.size(); f++) {
 			IniFile ini;
 			bool success = false;
+			if (fileInfo[f].isDirectory)
+				continue;
+
 			Path name = fileInfo[f].fullName;
 			Path path = directories[d];
 			// Hack around Android VFS path bug. really need to redesign this.


### PR DESCRIPTION
Fixes a crash seen on Linux when a folder is inside assets/shaders/.  Maybe could recurse...

-[Unknown]