### PR TITLE
Config: Don't save --fullscreen unless changed

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -195,6 +195,7 @@ public:
 	bool bVertexDecoderJit;
 	bool bFullScreen;
 	bool bFullScreenMulti;
+	int iForceFullScreen = -1; // -1 = nope, 0 = force off, 1 = force on (not saved.)
 	int iInternalResolution;  // 0 = Auto (native), 1 = 1x (480x272), 2 = 2x, 3 = 3x, 4 = 4x and so on.
 	int iAnisotropyLevel;  // 0 - 5, powers of 2: 0 = 1x = no aniso
 	int bHighQualityDepth;
@@ -521,6 +522,12 @@ public:
 	bool IsPortrait() const;
 	int NextValidBackend();
 	bool IsBackendEnabled(GPUBackend backend, bool validate = true);
+
+	bool UseFullScreen() const {
+		if (iForceFullScreen != -1)
+			return iForceFullScreen == 1;
+		return bFullScreen;
+	}
 
 protected:
 	void LoadStandardControllerIni();

--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -51,16 +51,16 @@ void MainWindow::newFrame()
 {
 	if (lastUIState != GetUIState()) {
 		lastUIState = GetUIState();
-		if (lastUIState == UISTATE_INGAME && g_Config.bFullScreen && !QApplication::overrideCursor() && !g_Config.bShowTouchControls)
+		if (lastUIState == UISTATE_INGAME && g_Config.UseFullScreen() && !QApplication::overrideCursor() && !g_Config.bShowTouchControls)
 			QApplication::setOverrideCursor(QCursor(Qt::BlankCursor));
-		if (lastUIState != UISTATE_INGAME && g_Config.bFullScreen && QApplication::overrideCursor())
+		if (lastUIState != UISTATE_INGAME && g_Config.UseFullScreen() && QApplication::overrideCursor())
 			QApplication::restoreOverrideCursor();
 
 		updateMenus();
 	}
 
-	if (g_Config.bFullScreen != isFullScreen())
-		SetFullScreen(g_Config.bFullScreen);
+	if (g_Config.UseFullScreen() != isFullScreen())
+		SetFullScreen(g_Config.UseFullScreen());
 
 	std::unique_lock<std::mutex> lock(msgMutex_);
 	while (!msgQueue_.empty()) {
@@ -398,6 +398,7 @@ void MainWindow::fullscrAct()
 {
 	// Toggle the current state.
 	g_Config.bFullScreen = !isFullScreen();
+	g_Config.iForceFullScreen = -1;
 	SetFullScreen(g_Config.bFullScreen);
 
 	QTimer::singleShot(1000, this, SLOT(raiseTopMost()));

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -650,7 +650,7 @@ int main(int argc, char *argv[]) {
 	if (mode & SDL_WINDOW_FULLSCREEN_DESKTOP) {
 		pixel_xres = g_DesktopWidth;
 		pixel_yres = g_DesktopHeight;
-		g_Config.bFullScreen = true;
+		g_Config.iForceFullScreen = 1;
 	} else {
 		// set a sensible default resolution (2x)
 		pixel_xres = 480 * 2 * set_scale;
@@ -658,7 +658,7 @@ int main(int argc, char *argv[]) {
 		if (portrait) {
 			std::swap(pixel_xres, pixel_yres);
 		}
-		g_Config.bFullScreen = false;
+		g_Config.iForceFullScreen = 0;
 	}
 
 	set_dpi = 1.0f / set_dpi;
@@ -715,7 +715,7 @@ int main(int argc, char *argv[]) {
 	NativeInit(remain_argc, (const char **)remain_argv, path, external_dir, nullptr);
 
 	// Use the setting from the config when initing the window.
-	if (g_Config.bFullScreen)
+	if (g_Config.UseFullScreen())
 		mode |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 
 	int x = SDL_WINDOWPOS_UNDEFINED_DISPLAY(getDisplayNumber());
@@ -869,7 +869,10 @@ int main(int argc, char *argv[]) {
 					UpdateScreenScale(new_width, new_height);
 
 					// Set variable here in case fullscreen was toggled by hotkey
-					g_Config.bFullScreen = fullscreen;
+					if (g_Config.UseFullScreen() != fullscreen) {
+						g_Config.bFullScreen = fullscreen;
+						g_Config.iForceFullScreen = -1;
+					}
 
 					// Hide/Show cursor correctly toggling fullscreen
 					if (lastUIState == UISTATE_INGAME && fullscreen && !g_Config.bShowTouchControls) {
@@ -1139,9 +1142,9 @@ int main(int argc, char *argv[]) {
 #if !defined(MOBILE_DEVICE)
 		if (lastUIState != GetUIState()) {
 			lastUIState = GetUIState();
-			if (lastUIState == UISTATE_INGAME && g_Config.bFullScreen && !g_Config.bShowTouchControls)
+			if (lastUIState == UISTATE_INGAME && g_Config.UseFullScreen() && !g_Config.bShowTouchControls)
 				SDL_ShowCursor(SDL_DISABLE);
-			if (lastUIState != UISTATE_INGAME || !g_Config.bFullScreen)
+			if (lastUIState != UISTATE_INGAME || !g_Config.UseFullScreen())
 				SDL_ShowCursor(SDL_ENABLE);
 		}
 #endif

--- a/UI/ChatScreen.cpp
+++ b/UI/ChatScreen.cpp
@@ -179,7 +179,7 @@ void ChatMenu::Update() {
 
 #if defined(USING_WIN_UI)
 	// Could remove the fullscreen check here, it works now.
-	if (promptInput_ && g_Config.bBypassOSKWithKeyboard && !g_Config.bFullScreen) {
+	if (promptInput_ && g_Config.bBypassOSKWithKeyboard && !g_Config.UseFullScreen()) {
 		System_InputBoxGetString(n->T("Chat"), n->T("Chat Here"), [](bool result, const std::string &value) {
 			if (result) {
 				sendChat(value);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -388,8 +388,10 @@ void GameSettingsScreen::CreateViews() {
 	graphicsSettings->Add(new CheckBox(&g_Config.bFullScreen, gr->T("FullScreen", "Full Screen")))->OnClick.Handle(this, &GameSettingsScreen::OnFullscreenChange);
 	if (System_GetPropertyInt(SYSPROP_DISPLAY_COUNT) > 1) {
 		CheckBox *fullscreenMulti = new CheckBox(&g_Config.bFullScreenMulti, gr->T("Use all displays"));
-		fullscreenMulti->SetEnabledPtr(&g_Config.bFullScreen);
-		graphicsSettings->Add(fullscreenMulti)->OnClick.Handle(this, &GameSettingsScreen::OnFullscreenChange);
+		fullscreenMulti->SetEnabledFunc([] {
+			return g_Config.UseFullScreen();
+		});
+		graphicsSettings->Add(fullscreenMulti)->OnClick.Handle(this, &GameSettingsScreen::OnFullscreenMultiChange);
 	}
 #endif
 	// Display Layout Editor: To avoid overlapping touch controls on large tablets, meet geeky demands for integer zoom/unstretched image etc.
@@ -1257,7 +1259,13 @@ UI::EventReturn GameSettingsScreen::OnChangeBackground(UI::EventParams &e) {
 }
 
 UI::EventReturn GameSettingsScreen::OnFullscreenChange(UI::EventParams &e) {
-	System_SendMessage("toggle_fullscreen", g_Config.bFullScreen ? "1" : "0");
+	g_Config.iForceFullScreen = -1;
+	System_SendMessage("toggle_fullscreen", g_Config.UseFullScreen() ? "1" : "0");
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn GameSettingsScreen::OnFullscreenMultiChange(UI::EventParams &e) {
+	System_SendMessage("toggle_fullscreen", g_Config.UseFullScreen() ? "1" : "0");
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -104,6 +104,7 @@ private:
 	UI::EventReturn OnChangeMacAddress(UI::EventParams &e);
 	UI::EventReturn OnChangeBackground(UI::EventParams &e);
 	UI::EventReturn OnFullscreenChange(UI::EventParams &e);
+	UI::EventReturn OnFullscreenMultiChange(UI::EventParams &e);
 	UI::EventReturn OnDisplayLayoutEditor(UI::EventParams &e);
 	UI::EventReturn OnResolutionChange(UI::EventParams &e);
 	UI::EventReturn OnHwScaleChange(UI::EventParams &e);

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1107,9 +1107,10 @@ void MainScreen::CreateViews() {
 	logos->Add(new ImageView(ImageID("I_LOGO"), "PPSSPP", IS_DEFAULT, new AnchorLayoutParams(180, 64, 64, -5.0f, NONE, NONE, false)));
 
 #if !defined(MOBILE_DEVICE)
-	if (!g_Config.bFullScreen) {
+	if (!g_Config.UseFullScreen()) {
 		auto gr = GetI18NCategory("Graphics");
-		fullscreenButton_ = logos->Add(new Button(gr->T("FullScreen", "Full Screen"), ImageID(g_Config.bFullScreen ? "I_RESTORE" : "I_FULLSCREEN"), new AnchorLayoutParams(48, 48, NONE, 0, 0, NONE, false)));
+		ImageID icon(g_Config.UseFullScreen() ? "I_RESTORE" : "I_FULLSCREEN");
+		fullscreenButton_ = logos->Add(new Button(gr->T("FullScreen", "Full Screen"), icon, new AnchorLayoutParams(48, 48, NONE, 0, 0, NONE, false)));
 		fullscreenButton_->SetIgnoreText(true);
 		fullscreenButton_->OnClick.Handle(this, &MainScreen::OnFullScreenToggle);
 	}
@@ -1261,8 +1262,10 @@ UI::EventReturn MainScreen::OnLoadFile(UI::EventParams &e) {
 }
 
 UI::EventReturn MainScreen::OnFullScreenToggle(UI::EventParams &e) {
+	if (g_Config.iForceFullScreen != -1)
+		g_Config.bFullScreen = g_Config.UseFullScreen();
 	if (fullscreenButton_) {
-		fullscreenButton_->SetImageID(ImageID(!g_Config.bFullScreen ? "I_RESTORE" : "I_FULLSCREEN"));
+		fullscreenButton_->SetImageID(ImageID(!g_Config.UseFullScreen() ? "I_RESTORE" : "I_FULLSCREEN"));
 	}
 #if !defined(MOBILE_DEVICE)
 	g_Config.bFullScreen = !g_Config.bFullScreen;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -672,11 +672,11 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 				if (!strncmp(argv[i], "--pause-menu-exit", strlen("--pause-menu-exit")))
 					g_Config.bPauseMenuExitsEmulator = true;
 				if (!strcmp(argv[i], "--fullscreen")) {
-					g_Config.bFullScreen = true;
+					g_Config.iForceFullScreen = 1;
 					System_SendMessage("toggle_fullscreen", "1");
 				}
 				if (!strcmp(argv[i], "--windowed")) {
-					g_Config.bFullScreen = false;
+					g_Config.iForceFullScreen = 0;
 					System_SendMessage("toggle_fullscreen", "0");
 				}
 				if (!strcmp(argv[i], "--touchscreentest"))
@@ -849,7 +849,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	isOuya = KeyMap::IsOuya(sysName);
 
 #if !defined(MOBILE_DEVICE) && defined(USING_QT_UI)
-	MainWindow *mainWindow = new MainWindow(nullptr, g_Config.bFullScreen);
+	MainWindow *mainWindow = new MainWindow(nullptr, g_Config.UseFullScreen());
 	mainWindow->show();
 	if (host == nullptr) {
 		host = new QtHost(mainWindow);

--- a/UWP/App.cpp
+++ b/UWP/App.cpp
@@ -219,9 +219,10 @@ void App::OnActivated(CoreApplicationView^ applicationView, IActivatedEventArgs^
 	// Run() won't start until the CoreWindow is activated.
 	CoreWindow::GetForCurrentThread()->Activate();
 	// On mobile, we force-enter fullscreen mode.
-	if (m_isPhone) g_Config.bFullScreen = true;
+	if (m_isPhone)
+		g_Config.iForceFullScreen = 1;
 
-	if (g_Config.bFullScreen)
+	if (g_Config.UseFullScreen())
 		Windows::UI::ViewManagement::ApplicationView::GetForCurrentView()->TryEnterFullScreenMode();
 }
 
@@ -252,6 +253,7 @@ void App::OnResuming(Platform::Object^ sender, Platform::Object^ args) {
 void App::OnWindowSizeChanged(CoreWindow^ sender, WindowSizeChangedEventArgs^ args) {
 	auto view = Windows::UI::ViewManagement::ApplicationView::GetForCurrentView();
 	g_Config.bFullScreen = view->IsFullScreenMode;
+	g_Config.iForceFullScreen = -1;
 
 	float width = sender->Bounds.Width;
 	float height = sender->Bounds.Height;

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -189,7 +189,7 @@ namespace MainWindow
 	}
 
 	void SavePosition() {
-		if (g_Config.bFullScreen || inFullscreenResize)
+		if (g_Config.UseFullScreen() || inFullscreenResize)
 			return;
 
 		WINDOWPLACEMENT placement;
@@ -239,7 +239,7 @@ namespace MainWindow
 	}
 
 	void CorrectCursor() {
-		bool autoHide = ((g_Config.bFullScreen && !mouseButtonDown) || (g_Config.bMouseControl && trapMouse)) && GetUIState() == UISTATE_INGAME;
+		bool autoHide = ((g_Config.UseFullScreen() && !mouseButtonDown) || (g_Config.bMouseControl && trapMouse)) && GetUIState() == UISTATE_INGAME;
 		if (autoHide && (hideCursor || g_Config.bMouseControl)) {
 			while (cursorCounter >= 0) {
 				cursorCounter = ShowCursor(FALSE);
@@ -303,7 +303,7 @@ namespace MainWindow
 		}
 
 		// Don't save the window state if fullscreen.
-		if (!g_Config.bFullScreen) {
+		if (!g_Config.UseFullScreen()) {
 			g_WindowState = newSizingType;
 		}
 	}
@@ -353,7 +353,10 @@ namespace MainWindow
 		// Remove the menu bar. This can trigger WM_SIZE
 		::SetMenu(hWnd, goingFullscreen ? NULL : menu);
 
-		g_Config.bFullScreen = goingFullscreen;
+		if (g_Config.UseFullScreen() != goingFullscreen) {
+			g_Config.bFullScreen = goingFullscreen;
+			g_Config.iForceFullScreen = -1;
+		}
 		g_isFullscreen = goingFullscreen;
 
 		g_IgnoreWM_SIZE = false;
@@ -414,7 +417,7 @@ namespace MainWindow
 		bool resetPositionX = true;
 		bool resetPositionY = true;
 
-		if (g_Config.iWindowWidth > 0 && g_Config.iWindowHeight > 0 && !g_Config.bFullScreen) {
+		if (g_Config.iWindowWidth > 0 && g_Config.iWindowHeight > 0 && !g_Config.UseFullScreen()) {
 			bool visibleHorizontally = ((g_Config.iWindowX + g_Config.iWindowWidth) >= virtualScreenX) &&
 				((g_Config.iWindowX + g_Config.iWindowWidth) < (virtualScreenWidth + g_Config.iWindowWidth));
 
@@ -522,7 +525,7 @@ namespace MainWindow
 		hideCursor = true;
 		SetTimer(hwndMain, TIMER_CURSORUPDATE, CURSORUPDATE_INTERVAL_MS, 0);
 
-		ToggleFullscreen(hwndMain, g_Config.bFullScreen);
+		ToggleFullscreen(hwndMain, g_Config.UseFullScreen());
 
 		W32Util::MakeTopMost(hwndMain, g_Config.bTopMost);
 
@@ -654,7 +657,7 @@ namespace MainWindow
 				double now = time_now_d();
 				if ((now - lastMouseDown) < 0.001 * GetDoubleClickTime()) {
 					if (!g_Config.bShowTouchControls && !g_Config.bMouseControl && GetUIState() == UISTATE_INGAME && g_Config.bFullscreenOnDoubleclick) {
-						SendToggleFullscreen(!g_Config.bFullScreen);
+						SendToggleFullscreen(!g_Config.UseFullScreen());
 					}
 					lastMouseDown = 0.0;
 				} else {

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -955,7 +955,7 @@ namespace MainWindow {
 			break;
 
 		case ID_OPTIONS_FULLSCREEN:
-			SendToggleFullscreen(!g_Config.bFullScreen);
+			SendToggleFullscreen(!g_Config.UseFullScreen());
 			break;
 
 		case ID_OPTIONS_VERTEXCACHE:

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -671,7 +671,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	if (iCmdShow == SW_MAXIMIZE) {
 		// Consider this to mean --fullscreen.
-		g_Config.bFullScreen = true;
+		g_Config.iForceFullScreen = 1;
 	}
 
 	// Consider at least the following cases before changing this code:


### PR DESCRIPTION
This makes --fullscreen and --windowed temporary by using a separate setting.  If the setting is changed explicitly, it begins saving it again.  This seemed like the simplest way - don't change the setting, actually.

Note that the full screen checkbox will be *unchecked* in settings (even while full screen) in this state.  It could show checked instead, but I felt like it was clearer for this to reflect the setting rather than the current state.  Could be convinced otherwise, though.

Fixes #15557.

-[Unknown]