### PR TITLE
UI: Abandon focus movement on returning from pause

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -943,7 +943,7 @@ int PSPOskDialog::Update(int animSpeed) {
 	// Windows: Fall back to the OSK/continue normally if we're in fullscreen.
 	// The dialog box doesn't work right if in fullscreen.
 	if (System_GetPropertyBool(SYSPROP_HAS_KEYBOARD)) {
-		if (g_Config.bBypassOSKWithKeyboard && !g_Config.bFullScreen)
+		if (g_Config.bBypassOSKWithKeyboard && !g_Config.UseFullScreen())
 			return NativeKeyboard();
 	}
 #endif

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -414,6 +414,9 @@ void EmuScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 		System_SendMessage("event", "exitgame");
 		quit_ = false;
 	}
+	// Returning to the PauseScreen, unless we're stepping, means we should go back to controls.
+	if (Core_IsActive())
+		UI::EnableFocusMovement(false);
 	RecreateViews();
 }
 


### PR DESCRIPTION
See #15530.  I expect this to fix that, although I'm not sure what's going on with the timing aspect so I didn't say "fixes".

Also sorry for the fullscreen miss, used `git add -p` and forgot to double check that file.

-[Unknown]