### PR TITLE
Savedata: Allow no key when not using SECURE modes

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -403,7 +403,7 @@ int SavedataParam::Save(SceUtilitySavedataParam* param, const std::string &saveD
 		ERROR_LOG_REPORT(SCEUTILITY, "Savedata version requested on save: %d", param->secureVersion);
 		return SCE_UTILITY_SAVEDATA_ERROR_SAVE_PARAM;
 	} else if (param->secureVersion != 0) {
-		if (param->secureVersion != 1 && !HasKey(param)) {
+		if (param->secureVersion != 1 && !HasKey(param) && secureMode) {
 			ERROR_LOG_REPORT(SCEUTILITY, "Savedata version with missing key on save: %d", param->secureVersion);
 			return SCE_UTILITY_SAVEDATA_ERROR_SAVE_PARAM;
 		}
@@ -638,7 +638,7 @@ int SavedataParam::LoadSaveData(SceUtilitySavedataParam *param, const std::strin
 		ERROR_LOG_REPORT(SCEUTILITY, "Savedata version requested: %d", param->secureVersion);
 		return SCE_UTILITY_SAVEDATA_ERROR_LOAD_PARAM;
 	} else if (param->secureVersion != 0) {
-		if (param->secureVersion != 1 && !HasKey(param)) {
+		if (param->secureVersion != 1 && !HasKey(param) && secureMode) {
 			ERROR_LOG_REPORT(SCEUTILITY, "Savedata version with missing key: %d", param->secureVersion);
 			return SCE_UTILITY_SAVEDATA_ERROR_LOAD_PARAM;
 		}


### PR DESCRIPTION
For example, MAKEDATA with no key but explicit secureVersion is fine and does create data.  However, it should still mark the version in SAVEDATA_PARAMS, which currently we're failing to do.  Load then does some form of validation of this version (but it's not an exact check weirdly.)

This doesn't fix the load version checking, but does allow saving/loading without a key when using the non-secure modes.

See #15068.  Hoping it helps this game.

-[Unknown]