### PR TITLE
Config: Don't save CPUCore unless changed

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1527,7 +1527,11 @@ bool Config::Save(const char *saveReason) {
 	}
 	if (jitForcedOff) {
 		// force JIT off again just in case Config::Save() is called without exiting PPSSPP
+#if PPSSPP_PLATFORM(IOS)
+		g_Config.iCpuCore = (int)CPUCore::IR_JIT;
+#else
 		g_Config.iCpuCore = (int)CPUCore::INTERPRETER;
+#endif
 	}
 	return true;
 }

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -29,6 +29,8 @@
 
 extern const char *PPSSPP_GIT_VERSION;
 
+extern bool jitForcedOff;
+
 enum ChatPositions {
 	BOTTOM_LEFT = 0,
 	BOTTOM_CENTER = 1,

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -770,7 +770,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 		// Just gonna force it to the IR interpreter on startup.
 		// We don't hide the option, but we make sure it's off on bootup. In case someone wants
 		// to experiment in future iOS versions or something...
-		g_Config.iCpuCore = (int)CPUCore::IR_JIT;
+		jitForcedOff = true;
 	}
 
 	auto des = GetI18NCategory("DesktopUI");


### PR DESCRIPTION
If get_debugged return false, may just cause PPSSPP is not attached by Xcode for this time, It's not means users won't attach PPSSPP by Xcode next time. So we shouldn't direct save CPUCore config as IR_JIT, make sure it behaves as in https://github.com/hrydgard/ppsspp/pull/15558.