### PR TITLE
Better contrast theme

### DIFF
--- a/assets/themes/defaultthemes.ini
+++ b/assets/themes/defaultthemes.ini
@@ -15,3 +15,7 @@ PopupTitleStyleFg = 0xffe3be59
 PopupStyleFg = 0xffffffff
 PopupStyleBg = 0xff303030
 BackgroundColor = 0xff754d24
+[HighContrast]
+Name = High Contrast
+ItemFocusedStyleBg = 0xff712f00
+ItemDownStyleBg = 0xff621100


### PR DESCRIPTION
Default theme have abysmal contrast rateo on focused UI element.

For reference:
![0](https://user-images.githubusercontent.com/13517524/171657394-b0e197ec-33e3-4ae6-8c58-888311d31502.png)
![1](https://user-images.githubusercontent.com/13517524/171657402-e93a1f68-68de-4e21-b364-c09a32db3350.png)
![2](https://user-images.githubusercontent.com/13517524/171657407-8b83e9c3-f1c6-487f-a55c-d6cd2a2687ee.png)
![3](https://user-images.githubusercontent.com/13517524/171657410-2e3dd0da-51b9-4829-bcae-279d490c030d.png)

WCAG contrast:

Down from 3.24 to 16.71
Focused from 2.04 to 12.71