### PR TITLE
Add additional rescaps for UWP port

### DIFF
--- a/UWP/PackageGold.appxmanifest
+++ b/UWP/PackageGold.appxmanifest
@@ -33,7 +33,7 @@
     <Capability Name="codeGeneration" />
     <Capability Name="internetClient" />
     <uap:Capability Name="removableStorage" />
-		<rescap:Capability Name="runFullTrust"/>
+    <rescap:Capability Name="runFullTrust"/>
     <rescap:Capability Name="broadFileSystemAccess" />
     <rescap:Capability Name="expandedResources" />
   </Capabilities>

--- a/UWP/PackageGold.appxmanifest
+++ b/UWP/PackageGold.appxmanifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp rescap">
 <Identity Name="32617401-c880-44d1-ba5a-c0b46feba525" Publisher="CN=Henrik" Version="1.8.0.3" />
   <mp:PhoneIdentity PhoneProductId="32617401-c880-44d1-ba5a-c0b46feba525" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -33,5 +33,8 @@
     <Capability Name="codeGeneration" />
     <Capability Name="internetClient" />
     <uap:Capability Name="removableStorage" />
+		<rescap:Capability Name="runFullTrust"/>
+    <rescap:Capability Name="broadFileSystemAccess" />
+    <rescap:Capability Name="expandedResources" />
   </Capabilities>
 </Package>

--- a/UWP/PackageNormal.appxmanifest
+++ b/UWP/PackageNormal.appxmanifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" IgnorableNamespaces="uap mp rescap">
   <Identity Name="0ad29e1a-1069-4cf5-8c97-620892505f0c" Publisher="CN=Henrik" Version="1.0.0.0" />
   <mp:PhoneIdentity PhoneProductId="0ad29e1a-1069-4cf5-8c97-620892505f0c" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
@@ -29,5 +29,8 @@
     <Capability Name="codeGeneration" />
     <Capability Name="internetClient" />
     <uap:Capability Name="removableStorage" />
+		<rescap:Capability Name="runFullTrust"/>
+    <rescap:Capability Name="broadFileSystemAccess" />
+    <rescap:Capability Name="expandedResources" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
added runFullTrust, broadFileSystemAccess and  expandedResources rescaps
The first two expands what devices the port can access whilst running on Xbox.
expandedResources improves performance on Xbox by giving the app access to more system resources.