### PR TITLE
Fix and further improve line drawing in Echochrome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ asciifont_atlas.zim.png
 ppge_atlas.zim.png
 local.properties
 r.sh
+Windows/compileData*
 
 # For vim
 *.swp

--- a/Common/TimeUtil.cpp
+++ b/Common/TimeUtil.cpp
@@ -19,6 +19,8 @@
 #endif
 #include <ctime>
 
+// TODO: https://github.com/floooh/sokol/blob/9a6237fcdf213e6da48e4f9201f144bcb2dcb46f/sokol_time.h#L229-L248
+
 static double curtime = 0;
 
 #ifdef _WIN32

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -80,6 +80,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "DisableRangeCulling", &flags_.DisableRangeCulling);
 	CheckSetting(iniFile, gameID, "MpegAvcWarmUp", &flags_.MpegAvcWarmUp);
 	CheckSetting(iniFile, gameID, "BlueToAlpha", &flags_.BlueToAlpha);
+	CheckSetting(iniFile, gameID, "CenteredLines", &flags_.CenteredLines);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -79,6 +79,7 @@ struct CompatFlags {
 	bool DisableRangeCulling;
 	bool MpegAvcWarmUp;
 	bool BlueToAlpha;
+	bool CenteredLines;
 };
 
 class IniFile;

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -758,8 +758,8 @@ void SoftwareTransform::ExpandLines(int vertexCount, int &maxIndex, u16 *&inds, 
 	u16 *newInds = inds + vertexCount;
 	u16 *indsOut = newInds;
 
-	float dx = 1.0f * gstate_c.vpWidthScale * (1.0f / gstate.getViewportXScale());
-	float dy = 1.0f * gstate_c.vpHeightScale * (1.0f / gstate.getViewportYScale());
+	float dx = 1.0f * gstate_c.vpWidthScale * (1.0f / fabsf(gstate.getViewportXScale()));
+	float dy = 1.0f * gstate_c.vpHeightScale * (1.0f / fabsf(gstate.getViewportYScale()));
 	float du = 1.0f / gstate_c.curTextureWidth;
 	float dv = 1.0f / gstate_c.curTextureHeight;
 
@@ -779,8 +779,8 @@ void SoftwareTransform::ExpandLines(int vertexCount, int &maxIndex, u16 *&inds, 
 		const TransformedVertex &transVtxR = transVtx1.x <= transVtx2.x ? transVtx2 : transVtx1;
 
 		// Sort the points so our perpendicular will bias the right direction.
-		const TransformedVertex &transVtxTL = transVtxT.y != transVtxB.y || transVtxT.x > transVtxB.x ? transVtxT : transVtxB;
-		const TransformedVertex &transVtxBL = transVtxT.y != transVtxB.y || transVtxT.x > transVtxB.x ? transVtxB : transVtxT;
+		const TransformedVertex &transVtxTL = (transVtxT.y != transVtxB.y || transVtxT.x > transVtxB.x) ? transVtxT : transVtxB;
+		const TransformedVertex &transVtxBL = (transVtxT.y != transVtxB.y || transVtxT.x > transVtxB.x) ? transVtxB : transVtxT;
 
 		// Okay, let's calculate the perpendicular.
 		float horizontal = transVtxTL.x - transVtxBL.x;

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -786,33 +786,17 @@ void SoftwareTransform::ExpandLines(int vertexCount, int &maxIndex, u16 *&inds, 
 			float vertical = transVtx2.y - transVtx1.y;
 			Vec2f addWidth = Vec2f(-vertical, horizontal).Normalized();
 
+			float xoff = addWidth.x * dx;
+			float yoff = addWidth.y * dy;
+
 			// bottom right
-			trans[0] = transVtx2;
-			trans[0].x += addWidth.x * dx;
-			trans[0].y += addWidth.y * dy;
-			trans[0].u += addWidth.x * du;
-			trans[0].v += addWidth.y * dv;
-
+			trans[0].CopyFromWithOffset(transVtx2, xoff, yoff);
 			// top right
-			trans[1] = transVtx1;
-			trans[1].x += addWidth.x * dx;
-			trans[1].y += addWidth.y * dy;
-			trans[1].u += addWidth.x * du;
-			trans[1].v += addWidth.y * dv;
-
+			trans[1].CopyFromWithOffset(transVtx1, xoff, yoff);
 			// top left
-			trans[2] = transVtx1;
-			trans[2].x -= addWidth.x * dx;
-			trans[2].y -= addWidth.y * dy;
-			trans[2].u -= addWidth.x * du;
-			trans[2].v -= addWidth.y * dv;
-
+			trans[2].CopyFromWithOffset(transVtx1, -xoff, -yoff);
 			// bottom left
-			trans[3] = transVtx2;
-			trans[3].x -= addWidth.x * dx;
-			trans[3].y -= addWidth.y * dy;
-			trans[3].u -= addWidth.x * du;
-			trans[3].v -= addWidth.y * dv;
+			trans[3].CopyFromWithOffset(transVtx2, -xoff, -yoff);
 
 			// Triangle: BR-TR-TL
 			indsOut[0] = i * 2 + 0;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -57,6 +57,13 @@ struct TransformedVertex {
 		u8 color1[4];   // prelit
 		u32 color1_32;
 	};
+
+
+	void CopyFromWithOffset(const TransformedVertex &other, float xoff, float yoff) {
+		this->x = other.x + xoff;
+		this->y = other.y + yoff;
+		memcpy(&this->z, &other.z, sizeof(*this) - sizeof(float) * 2);
+	}
 };
 
 class GPUCommon : public GPUInterface, public GPUDebugInterface {

--- a/GPU/Math3D.cpp
+++ b/GPU/Math3D.cpp
@@ -23,6 +23,7 @@ namespace Math3D {
 template<>
 float Vec2<float>::Length() const
 {
+	// Doubt this is worth it for a vec2 :/
 #if defined(_M_SSE)
 	float ret;
 	__m128 xy = _mm_loadu_ps(&x);

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1110,3 +1110,12 @@ ULUS10107 = true
 ULJM05101 = true
 ULES00724 = true
 ULJM05320 = true
+
+[CenteredLines]
+# Echochrome looks better with these. Related: #15556
+UCES01011 = true
+UCAS40197 = true
+NPEG00006 = true
+NPUG80135 = true
+
+UCES

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:7.2.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,6 +3,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
I think it makes sense to take the absolute value of the computed pixel sizes. Once that's done, the rest of the math will be correct no matter the space. This fixes the squished lines.

Additionally, centering the thickened lines looks considerably better in this game, so let's add a special compat mode for that, it's not that much code.

We can enable it for any other games that use 3D lines. Doesn't make much sense for upscaled 2D lines though, which is the most common use of lines.

Fixes #15556 

Also sneaks in a couple of minor things (gradle upgrade, TODO added)