### PR TITLE
Build: Use cinttypes not inttypes.h

### DIFF
--- a/Common/File/DiskFree.cpp
+++ b/Common/File/DiskFree.cpp
@@ -16,7 +16,7 @@
 #include <ctype.h>
 #include <fcntl.h>
 #endif
-#include <inttypes.h>
+#include <cinttypes>
 
 #include "Common/Log.h"
 #include "Common/File/Path.h"


### PR DESCRIPTION
Apparently this helps webOS, see #15604.

Maybe some toolchain bug, but using the C++ style header is probably better anyway.

-[Unknown]