### PR TITLE
Mask some part of public IP in the logs for security reason.

### DIFF
--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -170,10 +170,13 @@ bool isPTPPortInUse(uint16_t port, bool forListen, SceNetEtherAddr* dstmac, uint
 }
 
 // Replacement for inet_ntoa since it's getting deprecated
-std::string ip2str(in_addr in) {
+std::string ip2str(in_addr in, bool maskPublicIP) {
 	char str[INET_ADDRSTRLEN] = "...";
 	u8* ipptr = (u8*)&in;
-	snprintf(str, sizeof(str), "%u.%u.%u.%u", ipptr[0], ipptr[1], ipptr[2], ipptr[3]);
+	if (maskPublicIP && !isPrivateIP(in.s_addr))
+		snprintf(str, sizeof(str), "%u.%u.xx.%u", ipptr[0], ipptr[1], ipptr[3]);
+	else
+		snprintf(str, sizeof(str), "%u.%u.%u.%u", ipptr[0], ipptr[1], ipptr[2], ipptr[3]);
 	return std::string(str);
 }
 

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -1014,7 +1014,7 @@ bool isPDPPortInUse(uint16_t port);
 bool isPTPPortInUse(uint16_t port, bool forListen, SceNetEtherAddr* dstmac = nullptr, uint16_t dstport = 0);
 
 // Convert IPv4 address to string (Replacement for inet_ntoa since it's getting deprecated)
-std::string ip2str(in_addr in);
+std::string ip2str(in_addr in, bool maskPublicIP = true);
 
 // Convert MAC address to string
 std::string mac2str(SceNetEtherAddr* mac);


### PR DESCRIPTION
Masked like `123.234.xx.111`, since most people submitting/uploading their logs to the internet without editing their public IP first.

PS: i probably won't mask IP resolved from a DNS query in the future when infrastructure have been implemented, since they're usually known public servers.