### PR TITLE
UI: Add analog speed limit mapping

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -867,6 +867,8 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("AutoFrameSkip", &g_Config.bAutoFrameSkip, false, true, true),
 	ConfigSetting("FrameRate", &g_Config.iFpsLimit1, 0, true, true),
 	ConfigSetting("FrameRate2", &g_Config.iFpsLimit2, -1, true, true),
+	ConfigSetting("AnalogFrameRate", &g_Config.iAnalogFpsLimit, 240, true, true),
+	ConfigSetting("AnalogFrameRateMode", &g_Config.iAnalogFpsMode, 0, true, true),
 	ConfigSetting("UnthrottlingMode", &g_Config.iFastForwardMode, &DefaultFastForwardMode, &FastForwardModeToString, &FastForwardModeFromString, true, true),
 #if defined(USING_WIN_UI)
 	ConfigSetting("RestartRequired", &g_Config.bRestartRequired, false, false),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -214,6 +214,8 @@ public:
 	bool bTexHardwareScaling;
 	int iFpsLimit1;
 	int iFpsLimit2;
+	int iAnalogFpsLimit;
+	int iAnalogFpsMode; // 0 = auto, 1 = single direction, 2 = mapped to opposite
 	int iMaxRecent;
 	int iCurrentStateSlot;
 	int iRewindFlipFrequency;

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -134,5 +134,5 @@ enum class BackgroundAnimation {
 enum class AnalogFpsMode {
 	AUTO = 0,
 	MAPPED_DIRECTION = 1,
-	MAPPED_TO_OPPOSITE = 2,
+	MAPPED_DIR_TO_OPPOSITE_DIR = 2,
 };

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -130,3 +130,9 @@ enum class BackgroundAnimation {
 	WAVE = 3,
 	MOVING_BACKGROUND = 4,
 };
+
+enum class AnalogFpsMode {
+	AUTO = 0,
+	MAPPED_DIRECTION = 1,
+	MAPPED_TO_OPPOSITE = 2,
+};

--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -388,6 +388,9 @@ void ControlMapper::processAxis(const AxisInput &axis, int direction) {
 }
 
 void ControlMapper::ProcessAnalogSpeed(const AxisInput &axis, bool opposite) {
+	static constexpr float DEADZONE_THRESHOLD = 0.15f;
+	static constexpr float DEADZONE_SCALE = 1.0f / (1.0f - DEADZONE_THRESHOLD);
+
 	FPSLimit &limitMode = PSP_CoreParameter().fpsLimit;
 	// If we're using an alternate speed already, let that win.
 	if (limitMode != FPSLimit::NORMAL && limitMode != FPSLimit::ANALOG)
@@ -430,6 +433,9 @@ void ControlMapper::ProcessAnalogSpeed(const AxisInput &axis, bool opposite) {
 			value = -value;
 		value = 0.5f - value * 0.5f;
 	}
+
+	// Apply a small deadzone (against the resting position.)
+	value = std::max(0.0f, (value - DEADZONE_THRESHOLD) * DEADZONE_SCALE);
 
 	// If target is above 60, value is how much to speed up over 60.  Otherwise, it's how much slower.
 	// So normalize the target.

--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -7,6 +7,8 @@
 #include "Core/KeyMap.h"
 #include "Core/ControlMapper.h"
 #include "Core/Config.h"
+#include "Core/CoreParameter.h"
+#include "Core/System.h"
 
 static float MapAxisValue(float v) {
 	const float deadzone = g_Config.fAnalogDeadzone;
@@ -334,11 +336,20 @@ void ControlMapper::processAxis(const AxisInput &axis, int direction) {
 		case VIRTKEY_AXIS_RIGHT_Y_MAX:
 			SetPSPAxis('Y', value, CTRL_STICK_RIGHT);
 			break;
+
+		case VIRTKEY_SPEED_ANALOG:
+			ProcessAnalogSpeed(axis, false);
+			break;
 		}
 	}
 
 	std::vector<int> resultsOpposite;
 	KeyMap::AxisToPspButton(axis.deviceId, axis.axisId, -direction, &resultsOpposite);
+
+	for (int result : resultsOpposite) {
+		if (result == VIRTKEY_SPEED_ANALOG)
+			ProcessAnalogSpeed(axis, true);
+	}
 
 	int axisState = 0;
 	float threshold = axis.deviceId == DEVICE_ID_MOUSE ? AXIS_BIND_THRESHOLD_MOUSE : AXIS_BIND_THRESHOLD;
@@ -374,4 +385,56 @@ void ControlMapper::processAxis(const AxisInput &axis, int direction) {
 			}
 		}
 	}
+}
+
+void ControlMapper::ProcessAnalogSpeed(const AxisInput &axis, bool opposite) {
+	FPSLimit &limitMode = PSP_CoreParameter().fpsLimit;
+	// If we're using an alternate speed already, let that win.
+	if (limitMode != FPSLimit::NORMAL && limitMode != FPSLimit::ANALOG)
+		return;
+	// Don't even try if the limit is invalid.
+	if (g_Config.iAnalogFpsLimit <= 0)
+		return;
+
+	AnalogFpsMode mode = (AnalogFpsMode)g_Config.iAnalogFpsMode;
+	float value = axis.value;
+	if (mode == AnalogFpsMode::AUTO) {
+		// TODO: Consider the pad name for better auto?  KeyMap::PadName(axis.deviceId);
+		switch (axis.axisId) {
+		case JOYSTICK_AXIS_X:
+		case JOYSTICK_AXIS_Y:
+		case JOYSTICK_AXIS_Z:
+		case JOYSTICK_AXIS_RX:
+		case JOYSTICK_AXIS_RY:
+		case JOYSTICK_AXIS_RZ:
+			// These, at least on directinput, can be used for triggers that go from mapped to opposite.
+			mode = AnalogFpsMode::MAPPED_TO_OPPOSITE;
+			break;
+
+		default:
+			// Other axises probably don't go from negative to positive.
+			mode = AnalogFpsMode::MAPPED_DIRECTION;
+			break;
+		}
+	}
+
+	// Okay, now let's map it as appropriate.
+	if (mode == AnalogFpsMode::MAPPED_DIRECTION) {
+		value = fabsf(value);
+		if (opposite)
+			return;
+	} else if (mode == AnalogFpsMode::MAPPED_TO_OPPOSITE) {
+		value = fabsf(value);
+		if (opposite)
+			value = -value;
+		value = 0.5f - value * 0.5f;
+	}
+
+	// If target is above 60, value is how much to speed up over 60.  Otherwise, it's how much slower.
+	// So normalize the target.
+	int target = g_Config.iAnalogFpsLimit - 60;
+	PSP_CoreParameter().analogFpsLimit = 60 + (int)(target * value);
+
+	// If we've reset back to normal, turn it off.
+	limitMode = PSP_CoreParameter().analogFpsLimit == 60 ? FPSLimit::NORMAL : FPSLimit::ANALOG;
 }

--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -408,7 +408,7 @@ void ControlMapper::ProcessAnalogSpeed(const AxisInput &axis, bool opposite) {
 		case JOYSTICK_AXIS_RY:
 		case JOYSTICK_AXIS_RZ:
 			// These, at least on directinput, can be used for triggers that go from mapped to opposite.
-			mode = AnalogFpsMode::MAPPED_TO_OPPOSITE;
+			mode = AnalogFpsMode::MAPPED_DIR_TO_OPPOSITE_DIR;
 			break;
 
 		default:
@@ -421,9 +421,10 @@ void ControlMapper::ProcessAnalogSpeed(const AxisInput &axis, bool opposite) {
 	// Okay, now let's map it as appropriate.
 	if (mode == AnalogFpsMode::MAPPED_DIRECTION) {
 		value = fabsf(value);
+		// Clamp to 0 in this case if we're processing the opposite direction.
 		if (opposite)
-			return;
-	} else if (mode == AnalogFpsMode::MAPPED_TO_OPPOSITE) {
+			value = 0.0f;
+	} else if (mode == AnalogFpsMode::MAPPED_DIR_TO_OPPOSITE_DIR) {
 		value = fabsf(value);
 		if (opposite)
 			value = -value;

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -33,6 +33,7 @@ private:
 	void setVKeyAnalog(char axis, int stick, int virtualKeyMin, int virtualKeyMax, bool setZero = true);
 
 	void SetPSPAxis(char axis, float value, int stick);
+	void ProcessAnalogSpeed(const AxisInput &axis, bool opposite);
 
 	void onVKeyDown(int vkey);
 	void onVKeyUp(int vkey);

--- a/Core/CoreParameter.h
+++ b/Core/CoreParameter.h
@@ -33,6 +33,7 @@ enum class FPSLimit {
 	NORMAL = 0,
 	CUSTOM1 = 1,
 	CUSTOM2 = 2,
+	ANALOG = 3,
 };
 
 class FileLoader;
@@ -76,6 +77,7 @@ struct CoreParameter {
 	// Can be modified at runtime.
 	bool fastForward = false;
 	FPSLimit fpsLimit = FPSLimit::NORMAL;
+	int analogFpsLimit = 0;
 
 	bool updateRecent = true;
 

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -354,6 +354,8 @@ static int FrameTimingLimit() {
 		return g_Config.iFpsLimit1;
 	if (PSP_CoreParameter().fpsLimit == FPSLimit::CUSTOM2)
 		return g_Config.iFpsLimit2;
+	if (PSP_CoreParameter().fpsLimit == FPSLimit::ANALOG)
+		return PSP_CoreParameter().analogFpsLimit;
 	if (PSP_CoreParameter().fastForward)
 		return 0;
 	return 60;

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -40,6 +40,7 @@ KeyMapping g_controllerMap;
 // Incremented on modification, so we know when to update menus.
 int g_controllerMapGeneration = 0;
 std::set<std::string> g_seenPads;
+std::map<int, std::string> g_padNames;
 std::set<int> g_seenDeviceIds;
 
 bool g_swapped_keys = false;
@@ -762,8 +763,9 @@ bool HasBuiltinController(const std::string &name) {
 	return IsOuya(name) || IsXperiaPlay(name) || IsNvidiaShield(name) || IsMOQII7S(name) || IsRetroid(name);
 }
 
-void NotifyPadConnected(const std::string &name) {
+void NotifyPadConnected(int deviceId, const std::string &name) {
 	g_seenPads.insert(name);
+	g_padNames[deviceId] = name;
 }
 
 void AutoConfForPad(const std::string &name) {

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -369,6 +369,7 @@ const KeyMap_IntStrPair psp_button_names[] = {
 	{VIRTKEY_SPEED_TOGGLE, "SpeedToggle"},
 	{VIRTKEY_SPEED_CUSTOM1, "Alt speed 1"},
 	{VIRTKEY_SPEED_CUSTOM2, "Alt speed 2"},
+	{VIRTKEY_SPEED_ANALOG, "Analog speed"},
 	{VIRTKEY_PAUSE, "Pause"},
 #ifndef MOBILE_DEVICE
 	{VIRTKEY_FRAME_ADVANCE, "Frame Advance"},
@@ -543,8 +544,10 @@ bool AxisFromPspButton(int btn, int *deviceId, int *axisId, int *direction) {
 	for (auto iter = g_controllerMap.begin(); iter != g_controllerMap.end(); ++iter) {
 		for (auto iter2 = iter->second.begin(); iter2 != iter->second.end(); ++iter2) {
 			if (iter->first == btn && iter2->keyCode >= AXIS_BIND_NKCODE_START) {
-				*deviceId = iter2->deviceId;
-				*axisId = TranslateKeyCodeToAxis(iter2->keyCode, *direction);
+				if (deviceId)
+					*deviceId = iter2->deviceId;
+				if (axisId)
+					*axisId = TranslateKeyCodeToAxis(iter2->keyCode, *direction);
 				return true;
 			}
 		}
@@ -796,6 +799,13 @@ void AutoConfForPad(const std::string &name) {
 
 const std::set<std::string> &GetSeenPads() {
 	return g_seenPads;
+}
+
+std::string PadName(int deviceId) {
+	auto it = g_padNames.find(deviceId);
+	if (it != g_padNames.end())
+		return it->second;
+	return "";
 }
 
 // Swap direction buttons and left analog axis

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -67,6 +67,7 @@ enum {
 	VIRTKEY_SCREEN_ROTATION_VERTICAL180 = 0x40000021,
 	VIRTKEY_SCREEN_ROTATION_HORIZONTAL = 0x40000022,
 	VIRTKEY_SCREEN_ROTATION_HORIZONTAL180 = 0x40000023,
+	VIRTKEY_SPEED_ANALOG = 0x40000024,
 	VIRTKEY_LAST,
 	VIRTKEY_COUNT = VIRTKEY_LAST - VIRTKEY_FIRST
 };
@@ -163,6 +164,7 @@ namespace KeyMap {
 	bool HasBuiltinController(const std::string &name);
 
 	const std::set<std::string> &GetSeenPads();
+	std::string PadName(int deviceId);
 	void AutoConfForPad(const std::string &name);
 
 	bool IsKeyMapped(int device, int key);

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -153,7 +153,7 @@ namespace KeyMap {
 	void SwapAxis();
 	void UpdateNativeMenuKeys();
 
-	void NotifyPadConnected(const std::string &name);
+	void NotifyPadConnected(int deviceId, const std::string &name);
 	bool IsNvidiaShield(const std::string &name);
 	bool IsNvidiaShieldTV(const std::string &name);
 	bool IsXperiaPlay(const std::string &name);

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -505,7 +505,14 @@ void GPUCommon::UpdateVsyncInterval(bool force) {
 		desiredVSyncInterval = 0;
 	}
 	if (PSP_CoreParameter().fpsLimit != FPSLimit::NORMAL) {
-		int limit = PSP_CoreParameter().fpsLimit == FPSLimit::CUSTOM1 ? g_Config.iFpsLimit1 : g_Config.iFpsLimit2;
+		int limit;
+		if (PSP_CoreParameter().fpsLimit == FPSLimit::CUSTOM1)
+			limit = g_Config.iFpsLimit1;
+		else if (PSP_CoreParameter().fpsLimit == FPSLimit::CUSTOM2)
+			limit = g_Config.iFpsLimit2;
+		else
+			limit = PSP_CoreParameter().analogFpsLimit;
+
 		// For an alternative speed that is a clean factor of 60, the user probably still wants vsync.
 		if (limit == 0 || (limit >= 0 && limit != 15 && limit != 30 && limit != 60)) {
 			desiredVSyncInterval = 0;

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -338,13 +338,13 @@ bool KeyMappingNewKeyDialog::key(const KeyInput &key) {
 			return true;
 		}
 		// Only map analog values to this mapping.
-		if (pspBtn_ == VIRTKEY_SPEED_ANALOG)
+		if (pspBtn_ == VIRTKEY_SPEED_ANALOG && !UI::IsEscapeKey(key))
 			return true;
 
 		mapped_ = true;
 		KeyDef kdf(key.deviceId, key.keyCode);
 		TriggerFinish(DR_YES);
-		if (callback_)
+		if (callback_ && pspBtn_ != VIRTKEY_SPEED_ANALOG)
 			callback_(kdf);
 	}
 	return true;

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -337,6 +337,9 @@ bool KeyMappingNewKeyDialog::key(const KeyInput &key) {
 		if (key.keyCode == NKCODE_EXT_MOUSEBUTTON_1) {
 			return true;
 		}
+		// Only map analog values to this mapping.
+		if (pspBtn_ == VIRTKEY_SPEED_ANALOG)
+			return true;
 
 		mapped_ = true;
 		KeyDef kdf(key.deviceId, key.keyCode);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -585,10 +585,10 @@ void EmuScreen::onVKeyDown(int virtualKeyCode) {
 		if (PSP_CoreParameter().fpsLimit == FPSLimit::NORMAL && g_Config.iFpsLimit1 >= 0) {
 			PSP_CoreParameter().fpsLimit = FPSLimit::CUSTOM1;
 			osm.Show(sc->T("fixed", "Speed: alternate"), 1.0);
-		} else if (PSP_CoreParameter().fpsLimit != FPSLimit::CUSTOM2 && g_Config.iFpsLimit2 >= 0) {
+		} else if (PSP_CoreParameter().fpsLimit == FPSLimit::CUSTOM1 && g_Config.iFpsLimit2 >= 0) {
 			PSP_CoreParameter().fpsLimit = FPSLimit::CUSTOM2;
 			osm.Show(sc->T("SpeedCustom2", "Speed: alternate 2"), 1.0);
-		} else if (PSP_CoreParameter().fpsLimit != FPSLimit::NORMAL) {
+		} else if (PSP_CoreParameter().fpsLimit == FPSLimit::CUSTOM1 || PSP_CoreParameter().fpsLimit == FPSLimit::CUSTOM2) {
 			PSP_CoreParameter().fpsLimit = FPSLimit::NORMAL;
 			osm.Show(sc->T("standard", "Speed: standard"), 1.0);
 		}

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -201,6 +201,7 @@ void GameSettingsScreen::CreateViews() {
 
 	iAlternateSpeedPercent1_ = g_Config.iFpsLimit1 < 0 ? -1 : (g_Config.iFpsLimit1 * 100) / 60;
 	iAlternateSpeedPercent2_ = g_Config.iFpsLimit2 < 0 ? -1 : (g_Config.iFpsLimit2 * 100) / 60;
+	iAlternateSpeedPercentAnalog_ = (g_Config.iAnalogFpsLimit * 100) / 60;
 
 	bool vertical = UseVerticalLayout();
 
@@ -334,6 +335,11 @@ void GameSettingsScreen::CreateViews() {
 	altSpeed2->SetFormat("%i%%");
 	altSpeed2->SetZeroLabel(gr->T("Unlimited"));
 	altSpeed2->SetNegativeDisable(gr->T("Disabled"));
+
+	if (KeyMap::AxisFromPspButton(VIRTKEY_SPEED_ANALOG, nullptr, nullptr, nullptr)) {
+		PopupSliderChoice *analogSpeed = graphicsSettings->Add(new PopupSliderChoice(&iAlternateSpeedPercentAnalog_, 1, 1000, gr->T("Analog Alternative Speed", "Analog alternative speed (in %)"), 5, screenManager(), gr->T("%")));
+		altSpeed2->SetFormat("%i%%");
+	}
 
 	graphicsSettings->Add(new ItemHeader(gr->T("Postprocessing effect")));
 
@@ -1402,6 +1408,7 @@ void GameSettingsScreen::dialogFinished(const Screen *dialog, DialogResult resul
 	if (result == DialogResult::DR_OK) {
 		g_Config.iFpsLimit1 = iAlternateSpeedPercent1_ < 0 ? -1 : (iAlternateSpeedPercent1_ * 60) / 100;
 		g_Config.iFpsLimit2 = iAlternateSpeedPercent2_ < 0 ? -1 : (iAlternateSpeedPercent2_ * 60) / 100;
+		g_Config.iAnalogFpsLimit = (iAlternateSpeedPercentAnalog_ * 60) / 100;
 
 		RecreateViews();
 	}

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -93,6 +93,7 @@ GameSettingsScreen::GameSettingsScreen(const Path &gamePath, std::string gameID,
 	: UIDialogScreenWithGameBackground(gamePath), gameID_(gameID), editThenRestore_(editThenRestore) {
 	lastVertical_ = UseVerticalLayout();
 	prevInflightFrames_ = g_Config.iInflightFrames;
+	analogSpeedMapped_ = KeyMap::AxisFromPspButton(VIRTKEY_SPEED_ANALOG, nullptr, nullptr, nullptr);
 }
 
 bool GameSettingsScreen::UseVerticalLayout() const {
@@ -336,7 +337,7 @@ void GameSettingsScreen::CreateViews() {
 	altSpeed2->SetZeroLabel(gr->T("Unlimited"));
 	altSpeed2->SetNegativeDisable(gr->T("Disabled"));
 
-	if (KeyMap::AxisFromPspButton(VIRTKEY_SPEED_ANALOG, nullptr, nullptr, nullptr)) {
+	if (analogSpeedMapped_) {
 		PopupSliderChoice *analogSpeed = graphicsSettings->Add(new PopupSliderChoice(&iAlternateSpeedPercentAnalog_, 1, 1000, gr->T("Analog Alternative Speed", "Analog alternative speed (in %)"), 5, screenManager(), gr->T("%")));
 		altSpeed2->SetFormat("%i%%");
 	}
@@ -1410,6 +1411,12 @@ void GameSettingsScreen::dialogFinished(const Screen *dialog, DialogResult resul
 		g_Config.iFpsLimit2 = iAlternateSpeedPercent2_ < 0 ? -1 : (iAlternateSpeedPercent2_ * 60) / 100;
 		g_Config.iAnalogFpsLimit = (iAlternateSpeedPercentAnalog_ * 60) / 100;
 
+		RecreateViews();
+	}
+
+	bool mapped = KeyMap::AxisFromPspButton(VIRTKEY_SPEED_ANALOG, nullptr, nullptr, nullptr);
+	if (mapped != analogSpeedMapped_) {
+		analogSpeedMapped_ = mapped;
 		RecreateViews();
 	}
 }

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -141,6 +141,7 @@ private:
 	int prevInflightFrames_;
 	bool enableReports_ = false;
 	bool enableReportsSet_ = false;
+	bool analogSpeedMapped_ = false;
 	std::string shaderNames_[256];
 	std::string searchFilter_;
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -137,6 +137,7 @@ private:
 	// Temporaries to convert setting types, cache enabled, etc.
 	int iAlternateSpeedPercent1_;
 	int iAlternateSpeedPercent2_;
+	int iAlternateSpeedPercentAnalog_;
 	int prevInflightFrames_;
 	bool enableReports_ = false;
 	bool enableReportsSet_ = false;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1176,8 +1176,12 @@ void NativeRender(GraphicsContext *graphicsContext) {
 }
 
 void HandleGlobalMessage(const std::string &msg, const std::string &value) {
+	int nextInputDeviceID = -1;
+	if (msg == "inputDeviceConnectedID") {
+		nextInputDeviceID = parseLong(value);
+	}
 	if (msg == "inputDeviceConnected") {
-		KeyMap::NotifyPadConnected(value);
+		KeyMap::NotifyPadConnected(nextInputDeviceID, value);
 	}
 	if (msg == "bgImage_updated") {
 		if (!value.empty()) {
@@ -1419,7 +1423,6 @@ bool NativeAxis(const AxisInput &axis) {
 }
 
 void NativeMessageReceived(const char *message, const char *value) {
-	// We can only have one message queued.
 	std::lock_guard<std::mutex> lock(pendingMutex);
 	PendingMessage pendingMessage;
 	pendingMessage.msg = message;

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -23,6 +23,7 @@
 
 #include "Common/Input/InputState.h"
 #include "Common/Input/KeyCodes.h"
+#include "Common/StringUtils.h"
 #include "Common/System/NativeApp.h"
 #include "Core/Config.h"
 #include "Core/HLE/sceCtrl.h"
@@ -56,8 +57,6 @@ static const int dinput_buttons[] = {
 	NKCODE_BUTTON_15,
 	NKCODE_BUTTON_16,
 };
-
-static float NormalizedDeadzoneFilter(short value);
 
 #define DIFF  (JOY_POVRIGHT - JOY_POVFORWARD) / 2
 #define JOY_POVFORWARD_RIGHT	JOY_POVFORWARD + DIFF
@@ -150,6 +149,11 @@ DinputDevice::DinputDevice(int devnum) {
 	if ( (devnum >= (int)devices.size()) || FAILED(getPDI()->CreateDevice(devices.at(devnum).guidInstance, &pJoystick, NULL)))
 	{
 		return;
+	}
+
+	wchar_t guid[64];
+	if (StringFromGUID2(devices.at(devnum).guidProduct, guid, ARRAY_SIZE(guid)) != 0) {
+		KeyMap::NotifyPadConnected(DEVICE_ID_PAD_0 + pDevNum, StringFromFormat("%S: %S", devices.at(devnum).tszProductName, guid));
 	}
 
 	if (FAILED(pJoystick->SetDataFormat(&c_dfDIJoystick2))) {

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -205,10 +205,14 @@ void XinputDevice::UpdatePad(int pad, const XINPUT_STATE &state, XINPUT_VIBRATIO
 	static bool notified[XUSER_MAX_COUNT]{};
 	if (!notified[pad]) {
 		notified[pad] = true;
+#if !PPSSPP_PLATFORM(UWP)
 		XINPUT_CAPABILITIES_EX caps;
 		if (PPSSPP_XInputGetCapabilitiesEx != nullptr && PPSSPP_XInputGetCapabilitiesEx(1, pad, 0, &caps) == ERROR_SUCCESS) {
 			KeyMap::NotifyPadConnected(DEVICE_ID_XINPUT_0 + pad, StringFromFormat("Xbox 360 Pad: %d/%d", caps.vendorId, caps.productId));
 		} else {
+#else
+		{
+#endif
 			KeyMap::NotifyPadConnected(DEVICE_ID_XINPUT_0 + pad, "Xbox 360 Pad");
 		}
 	}

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -4,13 +4,14 @@
 #include <algorithm>
 
 #include "Common/System/NativeApp.h"
-#include "Core/Config.h"
 #include "Common/CommonWindows.h"
 #include "Common/Log.h"
+#include "Common/StringUtils.h"
 #include "Common/TimeUtil.h"
 #include "Common/Input/InputState.h"
 #include "Common/Input/KeyCodes.h"
 #include "XinputDevice.h"
+#include "Core/Config.h"
 #include "Core/Core.h"
 #include "Core/KeyMap.h"
 #include "Core/HLE/sceCtrl.h"
@@ -21,11 +22,21 @@ static double newVibrationTime = 0.0;
 
 #if !PPSSPP_PLATFORM(UWP)
 
+struct XINPUT_CAPABILITIES_EX {
+	XINPUT_CAPABILITIES Capabilities;
+	WORD vendorId;
+	WORD productId;
+	WORD revisionId;
+	DWORD a4; //unknown
+};
+
 typedef DWORD (WINAPI *XInputGetState_t) (DWORD dwUserIndex, XINPUT_STATE* pState);
 typedef DWORD (WINAPI *XInputSetState_t) (DWORD dwUserIndex, XINPUT_VIBRATION* pVibration);
+typedef DWORD (WINAPI *XInputGetCapabilitiesEx_t) (DWORD unknown, DWORD dwUserIndex, DWORD flags, XINPUT_CAPABILITIES_EX *pCapabilities);
 
 static XInputGetState_t PPSSPP_XInputGetState = nullptr;
 static XInputSetState_t PPSSPP_XInputSetState = nullptr;
+static XInputGetCapabilitiesEx_t PPSSPP_XInputGetCapabilitiesEx = nullptr;
 static DWORD PPSSPP_XInputVersion = 0;
 static HMODULE s_pXInputDLL = 0;
 static int s_XInputDLLRefCount = 0;
@@ -81,6 +92,10 @@ static int LoadXInputDLL() {
 	if (!PPSSPP_XInputSetState) {
 		UnloadXInputDLL();
 		return -1;
+	}
+
+	if (PPSSPP_XInputVersion >= ((1 << 16) | 4)) {
+		PPSSPP_XInputGetCapabilitiesEx = (XInputGetCapabilitiesEx_t)GetProcAddress((HMODULE)s_pXInputDLL, (LPCSTR)108);
 	}
 
 	return 0;
@@ -187,10 +202,15 @@ int XinputDevice::UpdateState() {
 }
 
 void XinputDevice::UpdatePad(int pad, const XINPUT_STATE &state, XINPUT_VIBRATION &vibration) {
-	static bool notified = false;
-	if (!notified) {
-		notified = true;
-		KeyMap::NotifyPadConnected("Xbox 360 Pad");
+	static bool notified[XUSER_MAX_COUNT]{};
+	if (!notified[pad]) {
+		notified[pad] = true;
+		XINPUT_CAPABILITIES_EX caps;
+		if (PPSSPP_XInputGetCapabilitiesEx != nullptr && PPSSPP_XInputGetCapabilitiesEx(1, pad, 0, &caps) == ERROR_SUCCESS) {
+			KeyMap::NotifyPadConnected(DEVICE_ID_XINPUT_0 + pad, StringFromFormat("Xbox 360 Pad: %d/%d", caps.vendorId, caps.productId));
+		} else {
+			KeyMap::NotifyPadConnected(DEVICE_ID_XINPUT_0 + pad, "Xbox 360 Pad");
+		}
 	}
 	ApplyButtons(pad, state);
 	ApplyVibration(pad, vibration);

--- a/android/src/org/ppsspp/ppsspp/InputDeviceState.java
+++ b/android/src/org/ppsspp/ppsspp/InputDeviceState.java
@@ -128,6 +128,7 @@ public class InputDeviceState {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
 			logAdvanced(device);
 		}
+		NativeApp.sendMessage("inputDeviceConnectedID", String.valueOf(this.deviceId));
 		NativeApp.sendMessage("inputDeviceConnected", device.getName());
 	}
 

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -31,6 +31,7 @@
 
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
+#include "Core/KeyMap.h"
 #include "Core/System.h"
 #include "Core/HLE/sceUsbCam.h"
 #include "Core/HLE/sceUsbGps.h"
@@ -94,6 +95,7 @@ static float dp_yscale = 1.0f;
 static double lastSelectPress = 0.0f;
 static double lastStartPress = 0.0f;
 static bool simulateAnalog = false;
+static bool iCadeConnectNotified = false;
 static bool threadEnabled = true;
 static bool threadStopped = false;
 static UITouch *g_touches[10];
@@ -507,6 +509,11 @@ int ToTouchID(UITouch *uiTouch, bool allowAllocate) {
 
 - (void)buttonUp:(iCadeState)button
 {
+	if (!iCadeConnectNotified) {
+		iCadeConnectNotified = true;
+		KeyMap::NotifyPadConnected(DEVICE_ID_PAD_0, "iCade");
+	}
+
 	if (button == iCadeButtonA) {
 		// Pressing Select twice within 1 second toggles the DPad between
 		//     normal operation and simulating the Analog stick.


### PR DESCRIPTION
This makes it possible to map an analog (most especially, a trigger) to an alternate speed.  The FPS is then limited based on how much the analog is pressed, linearly.  It can slow down or speed up, depending on what the limit is configured to, but it can't do both.

One trick is that on my DirectInput controllers, the trigger ends up mapped from negative to positive whereas XInput just has a linear positive mapping.  I'm a bit concerned there might be other weird results for other controllers, so I added better auto-detection of pad identifiers.  For now, kept it to axis ID which *might* just work.

The auto detection could probably allow better auto-configuration logic for buttons too.

-[Unknown]