### PR TITLE
Compat: Add setting to skip compat flags

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -18,11 +18,21 @@
 #include <cstring>
 
 #include "Common/Data/Format/IniFile.h"
+#include "Common/StringUtils.h"
 #include "Core/Compatibility.h"
+#include "Core/Config.h"
 #include "Core/System.h"
 
 void Compatibility::Load(const std::string &gameID) {
 	Clear();
+
+	// Allow ignoring compat settings by name (regardless of game ID.)
+	std::vector<std::string> ignored;
+	SplitString(g_Config.sIgnoreCompatSettings, ',', ignored);
+	ignored_ = std::set<std::string>(ignored.begin(), ignored.end());
+	// If ALL, don't process any compat flags.
+	if (ignored_.find("ALL") != ignored_.end())
+		return;
 
 	{
 		IniFile compat;
@@ -83,5 +93,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {
-	iniFile.Get(option, gameID.c_str(), flag, *flag);
+	if (ignored_.find(option) != ignored_.end()) {
+		iniFile.Get(option, gameID.c_str(), flag, *flag);
+	}
 }

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <cstdint>
+#include <set>
 
 // Compatibility flags are controlled by assets/compat.ini.
 // Alternatively, if PSP/SYSTEM/compat.ini exists, it is merged on top, to enable editing
@@ -100,4 +101,5 @@ private:
 	void CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag);
 
 	CompatFlags flags_{};
+	std::set<std::string> ignored_;
 };

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -597,6 +597,8 @@ static ConfigSetting generalSettings[] = {
 	ReportedConfigSetting("MemStickInserted", &g_Config.bMemStickInserted, true, true, true),
 	ConfigSetting("EnablePlugins", &g_Config.bLoadPlugins, true, true, true),
 
+	ReportedConfigSetting("IgnoreCompatSettings", &g_Config.sIgnoreCompatSettings, "", true, true),
+
 	ConfigSetting(false),
 };
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -141,6 +141,8 @@ public:
 	std::vector<std::string> vPinnedPaths;
 	std::string sLanguageIni;
 
+	std::string sIgnoreCompatSettings;
+
 	bool bDiscordPresence;  // Enables setting the Discord presence to the current game (or menu)
 
 	// GFX


### PR DESCRIPTION
This allows configuring "ALL" to skip all, regardless of if new game IDs are added in a later stable release.

It also allows ignoring by name, without exhaustively listing all game IDs (including future) that might be added.

-[Unknown]