### PR TITLE
Common: unbreak build on BSDs

### DIFF
--- a/Common/ExceptionHandlerSetup.cpp
+++ b/Common/ExceptionHandlerSetup.cpp
@@ -214,6 +214,8 @@ void UninstallExceptionHandler() {
 
 #else
 
+#include <signal.h>
+
 static struct sigaction old_sa_segv;
 static struct sigaction old_sa_bus;
 


### PR DESCRIPTION
Regressed by 3ed74350129c (bisected) but `sigaltstack` was added long ago by 1fce6de8b182.

```c++
$ cmake -G Ninja -B /tmp/ppsspp_build
$ cmake --build /tmp/ppsspp_build
[...]
Common/ExceptionHandlerSetup.cpp:298:6: error: no matching constructor for initialization of 'sigaltstack'
        if (sigaltstack(&signal_stack, nullptr)) {
            ^           ~~~~~~~~~~~~~~~~~~~~~~
/usr/include/sys/signal.h:449:8: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 2 were provided
struct __stack_t {
       ^
/usr/include/sys/signal.h:434:19: note: expanded from macro '__stack_t'
#define __stack_t sigaltstack
                  ^
/usr/include/sys/signal.h:449:8: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 2 were provided
/usr/include/sys/signal.h:434:19: note: expanded from macro '__stack_t'
#define __stack_t sigaltstack
                  ^
/usr/include/sys/signal.h:449:8: note: candidate constructor (the implicit default constructor) not viable: requires 0 arguments, but 2 were provided
/usr/include/sys/signal.h:434:19: note: expanded from macro '__stack_t'
#define __stack_t sigaltstack
                  ^
Common/ExceptionHandlerSetup.cpp:298:6: error: value of type 'sigaltstack' is not contextually convertible to 'bool'
        if (sigaltstack(&signal_stack, nullptr)) {
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Common/ExceptionHandlerSetup.cpp:305:2: error: use of undeclared identifier 'sigemptyset'
        sigemptyset(&sa.sa_mask);
        ^
Common/ExceptionHandlerSetup.cpp:306:2: error: no matching constructor for initialization of 'sigaction'
        sigaction(SIGSEGV, &sa, &old_sa_segv);
        ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/sys/signal.h:376:8: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 3 were provided
struct sigaction {
       ^
/usr/include/sys/signal.h:376:8: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 3 were provided
/usr/include/sys/signal.h:376:8: note: candidate constructor (the implicit default constructor) not viable: requires 0 arguments, but 3 were provided
Common/ExceptionHandlerSetup.cpp:318:11: error: no matching constructor for initialization of 'sigaltstack'
        if (0 != sigaltstack(&signal_stack, nullptr)) {
                 ^           ~~~~~~~~~~~~~~~~~~~~~~
/usr/include/sys/signal.h:449:8: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 2 were provided
struct __stack_t {
       ^
/usr/include/sys/signal.h:434:19: note: expanded from macro '__stack_t'
#define __stack_t sigaltstack
                  ^
/usr/include/sys/signal.h:449:8: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 2 were provided
/usr/include/sys/signal.h:434:19: note: expanded from macro '__stack_t'
#define __stack_t sigaltstack
                  ^
/usr/include/sys/signal.h:449:8: note: candidate constructor (the implicit default constructor) not viable: requires 0 arguments, but 2 were provided
/usr/include/sys/signal.h:434:19: note: expanded from macro '__stack_t'
#define __stack_t sigaltstack
                  ^
Common/ExceptionHandlerSetup.cpp:318:8: error: invalid operands to binary expression ('int' and 'sigaltstack')
        if (0 != sigaltstack(&signal_stack, nullptr)) {
            ~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Common/ExceptionHandlerSetup.cpp:325:2: error: no matching constructor for initialization of 'sigaction'
        sigaction(SIGSEGV, &old_sa_segv, nullptr);
        ^         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/sys/signal.h:376:8: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 3 were provided
struct sigaction {
       ^
/usr/include/sys/signal.h:376:8: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 3 were provided
/usr/include/sys/signal.h:376:8: note: candidate constructor (the implicit default constructor) not viable: requires 0 arguments, but 3 were provided
7 errors generated.
```
