### PR TITLE
Disable texture ini creation on creation

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1828,18 +1828,19 @@ void DeveloperToolsScreen::CreateViews() {
 
 	Choice *createTextureIni = list->Add(new Choice(dev->T("Create/Open textures.ini file for current game")));
 	createTextureIni->OnClick.Handle(this, &DeveloperToolsScreen::OnOpenTexturesIniFile);
+	createTextureIni->SetEnabledFunc([] {
+		if (!PSP_IsInited())
+			return false;
 
-	// Disable the choice to Open/Create if the textures.ini file already exists, and we can't open it due to platform support limitations.
-	if (!System_GetPropertyBool(SYSPROP_SUPPORTS_OPEN_FILE_IN_EDITOR)) {
-		std::string gameID = g_paramSFO.GetDiscID();
-		if (TextureReplacer::IniExists(gameID)) {
-			createTextureIni->SetEnabled(false);
+		// Disable the choice to Open/Create if the textures.ini file already exists, and we can't open it due to platform support limitations.
+		if (!System_GetPropertyBool(SYSPROP_SUPPORTS_OPEN_FILE_IN_EDITOR)) {
+			std::string gameID = g_paramSFO.GetDiscID();
+			if (TextureReplacer::IniExists(gameID)) {
+				return false;
+			}
 		}
-	}
-
-	if (!PSP_IsInited()) {
-		createTextureIni->SetEnabled(false);
-	}
+		return true;
+	});
 }
 
 void DeveloperToolsScreen::onFinish(DialogResult result) {


### PR DESCRIPTION
Before pressing create texture ini would not update the button properly.

Not sure if you had any concern about performance, but given it's just a menu it should not be that bad I hope.