### PR TITLE
UI: Reduce IO for texture ini on dev settings

### DIFF
--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -181,6 +181,12 @@ private:
 
 	bool allowDebugger_ = false;
 	bool canAllowDebugger_ = true;
+	enum class HasIni {
+		NO,
+		YES,
+		MAYBE,
+	};
+	HasIni hasTexturesIni_ = HasIni::MAYBE;
 };
 
 class HostnameSelectScreen : public PopupScreen {


### PR DESCRIPTION
Sorry just being paranoid with scoped storage perf issues.

(enabledFunc_ would be evaluated quite often and is not cached.)

-[Unknown]