### PR TITLE
Clean recent ISOs on a thread

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1701,7 +1701,7 @@ void Config::RestoreDefaults() {
 	} else {
 		if (File::Exists(iniFilename_))
 			File::Delete(iniFilename_);
-		recentIsos.clear();
+		ClearRecentIsos();
 		currentDirectory = defaultCurrentDirectory;
 	}
 	Load();

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -48,6 +48,7 @@ namespace http {
 }
 
 struct UrlEncoder;
+struct ConfigPrivate;
 
 struct ConfigTouchPos {
 	float x;
@@ -550,6 +551,7 @@ private:
 	Path iniFilename_;
 	Path controllerIniFilename_;
 	Path searchPath_;
+	ConfigPrivate *private_ = nullptr;
 };
 
 std::map<std::string, std::pair<std::string, int>> GetLangValuesMapping();

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -140,7 +140,6 @@ public:
 	int iInternalScreenRotation;  // The internal screen rotation angle. Useful for vertical SHMUPs and similar.
 
 	std::string sReportHost;
-	std::vector<std::string> recentIsos;
 	std::vector<std::string> vPinnedPaths;
 	std::string sLanguageIni;
 
@@ -536,6 +535,16 @@ public:
 		return bFullScreen;
 	}
 
+	std::vector<std::string> RecentIsos() const {
+		return recentIsos;
+	}
+	bool HasRecentIsos() const {
+		return !recentIsos.empty();
+	}
+	void ClearRecentIsos() {
+		recentIsos.clear();
+	}
+
 protected:
 	void LoadStandardControllerIni();
 
@@ -543,6 +552,7 @@ private:
 	bool reload_ = false;
 	std::string gameId_;
 	std::string gameIdTitle_;
+	std::vector<std::string> recentIsos;
 	Path iniFilename_;
 	Path controllerIniFilename_;
 	Path searchPath_;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -535,15 +535,9 @@ public:
 		return bFullScreen;
 	}
 
-	std::vector<std::string> RecentIsos() const {
-		return recentIsos;
-	}
-	bool HasRecentIsos() const {
-		return !recentIsos.empty();
-	}
-	void ClearRecentIsos() {
-		recentIsos.clear();
-	}
+	std::vector<std::string> RecentIsos() const;
+	bool HasRecentIsos() const;
+	void ClearRecentIsos();
 
 protected:
 	void LoadStandardControllerIni();

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -375,7 +375,7 @@ bool GameManager::DetectTexturePackDest(struct zip *z, int iniIndex, Path &dest)
 	std::string gameID = games.begin()->first;
 	if (games.size() > 1) {
 		// Check for any supported game on their recent list and use that instead.
-		for (const std::string &path : g_Config.recentIsos) {
+		for (const std::string &path : g_Config.RecentIsos()) {
 			std::string recentID = GetGameID(Path(path));
 			if (games.find(recentID) != games.end()) {
 				gameID = recentID;

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -150,7 +150,7 @@ static std::string RemotePathForRecent(const std::string &filename) {
 }
 
 static Path LocalFromRemotePath(const std::string &path) {
-	for (const std::string &filename : g_Config.recentIsos) {
+	for (const std::string &filename : g_Config.RecentIsos()) {
 		std::string basename = RemotePathForRecent(filename);
 		if (basename == path) {
 			return Path(filename);
@@ -216,7 +216,7 @@ static void HandleListing(const http::Request &request) {
 	request.Out()->Printf("/\n");
 	if (serverFlags & (int)WebServerFlags::DISCS) {
 		// List the current discs in their recent order.
-		for (const std::string &filename : g_Config.recentIsos) {
+		for (const std::string &filename : g_Config.RecentIsos()) {
 			std::string basename = RemotePathForRecent(filename);
 			if (!basename.empty()) {
 				request.Out()->Printf("%s\n", basename.c_str());

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -426,8 +426,8 @@ bool GameScreen::isRecentGame(const Path &gamePath) {
 		return false;
 
 	const std::string resolved = File::ResolvePath(gamePath.ToString());
-	for (auto it = g_Config.recentIsos.begin(); it != g_Config.recentIsos.end(); ++it) {
-		const std::string recent = File::ResolvePath(*it);
+	for (auto iso : g_Config.RecentIsos()) {
+		const std::string recent = File::ResolvePath(iso);
 		if (resolved == recent)
 			return true;
 	}

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -587,7 +587,7 @@ bool GameBrowser::DisplayTopBar() {
 bool GameBrowser::HasSpecialFiles(std::vector<Path> &filenames) {
 	if (path_.GetPath().ToString() == "!RECENT") {
 		filenames.clear();
-		for (auto &str : g_Config.recentIsos) {
+		for (auto &str : g_Config.RecentIsos()) {
 			filenames.push_back(Path(str));
 		}
 		return true;
@@ -986,7 +986,7 @@ void MainScreen::CreateViews() {
 		System_GetPermissionStatus(SYSTEM_PERMISSION_STORAGE) == PERMISSION_STATUS_GRANTED;
 	bool storageIsTemporary = IsTempPath(GetSysDirectory(DIRECTORY_SAVEDATA)) && !confirmedTemporary_;
 	if (showRecent && !hasStorageAccess) {
-		showRecent = !g_Config.recentIsos.empty();
+		showRecent = g_Config.HasRecentIsos();
 	}
 
 	if (showRecent) {
@@ -1036,7 +1036,7 @@ void MainScreen::CreateViews() {
 		tabAllGames->OnHighlight.Handle(this, &MainScreen::OnGameHighlight);
 		tabHomebrew->OnHighlight.Handle(this, &MainScreen::OnGameHighlight);
 
-		if (g_Config.recentIsos.size() > 0) {
+		if (g_Config.HasRecentIsos()) {
 			tabHolder_->SetCurrentTab(0, true);
 		} else if (g_Config.iMaxRecent > 0) {
 			tabHolder_->SetCurrentTab(1, true);
@@ -1490,7 +1490,7 @@ void UmdReplaceScreen::CreateViews() {
 	rightColumnItems->Add(new Choice(di->T("Cancel")))->OnClick.Handle(this, &UmdReplaceScreen::OnCancel);
 	rightColumnItems->Add(new Choice(mm->T("Game Settings")))->OnClick.Handle(this, &UmdReplaceScreen::OnGameSettings);
 
-	if (g_Config.recentIsos.size() > 0) {
+	if (g_Config.HasRecentIsos()) {
 		leftColumn->SetCurrentTab(0, true);
 	} else if (g_Config.iMaxRecent > 0) {
 		leftColumn->SetCurrentTab(1, true);
@@ -1569,7 +1569,7 @@ UI::EventReturn GridSettingsScreen::GridMinusClick(UI::EventParams &e) {
 }
 
 UI::EventReturn GridSettingsScreen::OnRecentClearClick(UI::EventParams &e) {
-	g_Config.recentIsos.clear();
+	g_Config.ClearRecentIsos();
 	OnRecentChanged.Trigger(e);
 	return UI::EVENT_DONE;
 }

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -203,7 +203,7 @@ public:
 			lastIndex_ = nextIndex_;
 		}
 
-		if (!g_Config.recentIsos.empty()) {
+		if (g_Config.HasRecentIsos()) {
 			std::shared_ptr<GameInfo> lastInfo = GetInfo(dc, lastIndex_);
 			std::shared_ptr<GameInfo> nextInfo = GetInfo(dc, nextIndex_);
 			dc.Flush();
@@ -220,12 +220,12 @@ public:
 
 private:
 	void CheckNext(UIContext &dc, double t) {
-		if (g_Config.recentIsos.empty()) {
+		if (!g_Config.HasRecentIsos()) {
 			return;
 		}
 
 		for (int index = lastIndex_ + 1; index != lastIndex_; ++index) {
-			if (index < 0 || index >= (int)g_Config.recentIsos.size()) {
+			if (index < 0 || index >= (int)g_Config.RecentIsos().size()) {
 				if (lastIndex_ == -1)
 					break;
 				index = 0;
@@ -250,7 +250,10 @@ private:
 		if (index < 0) {
 			return nullptr;
 		}
-		return g_gameInfoCache->GetInfo(dc.GetDrawContext(), Path(g_Config.recentIsos[index]), GAMEINFO_WANTBG);
+		const auto recentIsos = g_Config.RecentIsos();
+		if (index >= recentIsos.size())
+			return nullptr;
+		return g_gameInfoCache->GetInfo(dc.GetDrawContext(), Path(recentIsos[index]), GAMEINFO_WANTBG);
 	}
 
 	void DrawTex(UIContext &dc, std::shared_ptr<GameInfo> &ginfo, float amount) {


### PR DESCRIPTION
This uses a thread to check if the ISOs exist and resolve paths.

I initially started to do remove and add also, but then got worried there'd be some UI update race condition.  Should be fine with just CleanRecent.

I'd consider this fixes #15137.

-[Unknown]