### PR TITLE
Io: Correct access field on dir listings

### DIFF
--- a/Common/File/AndroidStorage.cpp
+++ b/Common/File/AndroidStorage.cpp
@@ -160,7 +160,9 @@ static bool ParseFileInfo(const std::string &line, File::FileInfo *fileInfo) {
 	fileInfo->exists = true;
 	sscanf(parts[1].c_str(), "%" PRIu64, &fileInfo->size);
 	fileInfo->isWritable = true;  // TODO: Should be passed as part of the string.
-	fileInfo->access = fileInfo->isDirectory ? 0666 : 0777;  // TODO: For read-only mappings, reflect that here, similarly as with isWritable.
+	// TODO: For read-only mappings, reflect that here, similarly as with isWritable.
+	// Directories are normally executable (0111) which means they're traversable.
+	fileInfo->access = fileInfo->isDirectory ? 0777 : 0666;
 
 	uint64_t lastModifiedMs = 0;
 	sscanf(parts[3].c_str(), "%" PRIu64, &lastModifiedMs);

--- a/Common/File/DirListing.cpp
+++ b/Common/File/DirListing.cpp
@@ -242,6 +242,14 @@ bool GetFilesInDir(const Path &directory, std::vector<FileInfo> *files, const ch
 		info.atime = FiletimeToStatTime(ffd.ftLastAccessTime);
 		info.mtime = FiletimeToStatTime(ffd.ftLastWriteTime);
 		info.ctime = FiletimeToStatTime(ffd.ftCreationTime);
+		if (ffd.dwFileAttributes & FILE_ATTRIBUTE_READONLY) {
+			info.access = 0444;  // Read
+		} else {
+			info.access = 0666;  // Read/Write
+		}
+		if (ffd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+			info.access |= 0111;  // Execute
+		}
 		if (!info.isDirectory) {
 			std::string ext = info.fullName.GetFileExtension();
 			if (!ext.empty()) {


### PR DESCRIPTION
Fixes #15685.  The access field wasn't even being set, so was always zero on Windows.  It was also wrong on Android.

Not well tested but seems likely based on reverting access helping.

-[Unknown]