### PR TITLE
Add Zettai Zetsumei Toshi 3 bypass for softlock

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -94,6 +94,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "BlueToAlpha", &flags_.BlueToAlpha);
 	CheckSetting(iniFile, gameID, "CenteredLines", &flags_.CenteredLines);
 	CheckSetting(iniFile, gameID, "MaliDepthStencilBugWorkaround", &flags_.MaliDepthStencilBugWorkaround);
+	CheckSetting(iniFile, gameID, "ZZT3SelectHack", &flags_.ZZT3SelectHack);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -84,6 +84,7 @@ struct CompatFlags {
 	bool BlueToAlpha;
 	bool CenteredLines;
 	bool MaliDepthStencilBugWorkaround;
+	bool ZZT3SelectHack;
 };
 
 class IniFile;

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -1361,6 +1361,15 @@ static int Hook_gow_vortex_hack() {
 	return 0;
 }
 
+static int Hook_ZZT3_select_hack() {
+	if (PSP_CoreParameter().compat.flags().ZZT3SelectHack) {
+		if (currentMIPS->r[MIPS_REG_V0] == 0) {
+			currentMIPS->r[MIPS_REG_V0] = 1;
+		}
+	}
+	return 0;
+}
+
 #define JITFUNC(f) (&MIPSComp::MIPSFrontendInterface::f)
 
 // Can either replace with C functions or functions emitted in Asm/ArmAsm.
@@ -1479,6 +1488,7 @@ static const ReplacementTableEntry entries[] = {
 	{ "soltrigger_render_ucschar", &Hook_soltrigger_render_ucschar, 0, REPFLAG_HOOKENTER, 0 },
 	{ "gow_fps_hack", &Hook_gow_fps_hack, 0, REPFLAG_HOOKEXIT , 0 },
 	{ "gow_vortex_hack", &Hook_gow_vortex_hack, 0, REPFLAG_HOOKENTER, 0x60 },
+	{ "ZZT3_select_hack", &Hook_ZZT3_select_hack, 0, REPFLAG_HOOKENTER, 0xC4 },
 	{}
 };
 

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -508,7 +508,8 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0xffc8f5f8f946152c, 192, "dl_write_light_color", },
 	{ 0x249a3c5981c73480, 1472, "openseason_data_decode", },  // Open Season
 	{ 0x795d940ad0a605f8, 40, "gow_fps_hack", }, // God of War (all)
-	{ 0x4c75043b7b0c643b, 512, "gow_vortex_hack", } // God of War: Ghost of Sparta vortex timer hack, avoids softlock #8299
+	{ 0x4c75043b7b0c643b, 512, "gow_vortex_hack", }, // God of War: Ghost of Sparta vortex timer hack, avoids softlock #8299
+	{ 0x7624dde603717640, 288, "ZZT3_select_hack", }, // Zettai Zetsumei Toshi 3 - bypasses softlock on character select screen #4901
 };
 
 namespace MIPSAnalyst {

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1228,3 +1228,14 @@ UCES01011 = true
 UCAS40197 = true
 NPEG00006 = true
 NPUG80135 = true
+
+[ZZT3SelectHack]
+# Bypass softlock on Zettai Zetsumei Toshi 3 character select screen #4901
+# This problem affects the game also on PS3
+ULJS00191 = true
+UCAS40252 = true
+UCKS45119 = true
+NPJH50907 = true
+UCAS40328 = true
+ULJS19050 = true
+NPJH50907 = true


### PR DESCRIPTION
Fixes #4901

 I couldn't figure out the actual issue, pretty sure it's timing issue of some sort as the problem happens on PS3 following it's compatibility list.

 Trying to push this fix as the game might become very popular in the next few days due to [english translation releasing this month](https://gbatemp.net/threads/zettai-zetsumei-toshi-3-translation-project.368872/) and while I shared a workaround for it already, I think having it playable out of the box would be a better experience for typical user using an emulator just because english translation.