### PR TITLE
Add a simple compat flag to workaround the Clone Wars issue, #12949

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -95,6 +95,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "CenteredLines", &flags_.CenteredLines);
 	CheckSetting(iniFile, gameID, "MaliDepthStencilBugWorkaround", &flags_.MaliDepthStencilBugWorkaround);
 	CheckSetting(iniFile, gameID, "ZZT3SelectHack", &flags_.ZZT3SelectHack);
+	CheckSetting(iniFile, gameID, "AllowLargeFBTextureOffsets", &flags_.AllowLargeFBTextureOffsets);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -85,6 +85,7 @@ struct CompatFlags {
 	bool CenteredLines;
 	bool MaliDepthStencilBugWorkaround;
 	bool ZZT3SelectHack;
+	bool AllowLargeFBTextureOffsets;
 };
 
 class IniFile;

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1962,7 +1962,8 @@ static u32 sceMpegAvcCopyYCbCr(u32 mpeg, u32 sourceAddr, u32 YCbCrAddr)
 		return -1;
 	}
 
-	WARN_LOG(ME, "UNIMPL sceMpegAvcCopyYCbCr(%08x, %08x, %08x)", mpeg, sourceAddr, YCbCrAddr);
+	// This is very common.
+	DEBUG_LOG(ME, "UNIMPL sceMpegAvcCopyYCbCr(%08x, %08x, %08x)", mpeg, sourceAddr, YCbCrAddr);
 	return 0;
 }
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -975,7 +975,7 @@ FramebufferMatchInfo TextureCacheCommon::MatchFramebuffer(
 
 		// Trying to play it safe.  Below 0x04110000 is almost always framebuffers.
 		// TODO: Maybe we can reduce this check and find a better way above 0x04110000?
-		if (fbInfo.yOffset > MAX_SUBAREA_Y_OFFSET_SAFE && addr > 0x04110000) {
+		if (fbInfo.yOffset > MAX_SUBAREA_Y_OFFSET_SAFE && addr > 0x04110000 && !PSP_CoreParameter().compat.flags().AllowLargeFBTextureOffsets) {
 			WARN_LOG_REPORT_ONCE(subareaIgnored, G3D, "Ignoring possible texturing from framebuffer at %08x +%dx%d / %dx%d", fb_address, fbInfo.xOffset, fbInfo.yOffset, framebuffer->width, framebuffer->height);
 			return FramebufferMatchInfo{ FramebufferMatch::NO_MATCH };
 		}

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1239,3 +1239,9 @@ NPJH50907 = true
 UCAS40328 = true
 ULJS19050 = true
 NPJH50907 = true
+
+[AllowLargeFBTextureOffsets]
+# Quickfix for Clone Wars, see #12949
+ULES01284 = true
+ULES01285 = true
+ULUS10477 = true


### PR DESCRIPTION
Fixes #12949

Could probably also be fixed by changing the heuristic a bit, but since we're in heuristic land anyway and close to a release, I feel this is the safest option.

Also sneaks in a logspam reduction.