### PR TITLE
Remove a redundant mutex lock in logging.

### DIFF
--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -234,7 +234,6 @@ void LogManager::Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, const 
 			file = fileshort + 1;
 	}
 
-	std::lock_guard<std::mutex> lk(log_lock_);
 	GetTimeFormatted(message.timestamp);
 
 	if (hleCurrentThreadName) {

--- a/Common/LogManager.h
+++ b/Common/LogManager.h
@@ -122,7 +122,6 @@ private:
 	RingbufferLogListener *ringLog_ = nullptr;
 	static LogManager *logManager_;  // Singleton. Ugh.
 
-	std::mutex log_lock_;
 	std::mutex listeners_lock_;
 	std::vector<LogListener*> listeners_;
 


### PR DESCRIPTION
Really can't see any purpose at all... Weird.