### PR TITLE
Split GetPointer into GetPointer and GetPointerWrite

### DIFF
--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -493,7 +493,7 @@ int ElfReader::LoadInto(u32 loadAddress, bool fromTop)
 			u32 writeAddr = segmentVAddr[i];
 
 			const u8 *src = GetSegmentPtr(i);
-			u8 *dst = Memory::GetPointer(writeAddr);
+			u8 *dst = Memory::GetPointerWrite(writeAddr);
 			u32 srcSize = p->p_filesz;
 			u32 dstSize = p->p_memsz;
 

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -407,7 +407,7 @@ int ISOFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outd
 		}
 
 		INFO_LOG(SCEIO, "sceIoIoctl: reading ISO9660 volume descriptor read");
-		blockDevice->ReadBlock(16, Memory::GetPointer(outdataPtr));
+		blockDevice->ReadBlock(16, Memory::GetPointerWriteUnchecked(outdataPtr));
 		return 0;
 
 	// Get ISO9660 path table (from open ISO9660 file.)
@@ -424,7 +424,7 @@ int ISOFileSystem::Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outd
 		} else {
 			int block = (u16)desc.firstLETableSector;
 			u32 size = Memory::ValidSize(outdataPtr, (u32)desc.pathTableLength);
-			u8 *out = Memory::GetPointer(outdataPtr);
+			u8 *out = Memory::GetPointerWrite(outdataPtr);
 
 			int blocks = size / blockDevice->GetBlockSize();
 			blockDevice->ReadBlocks(block, blocks, out);

--- a/Core/HLE/FunctionWrappers.h
+++ b/Core/HLE/FunctionWrappers.h
@@ -106,7 +106,7 @@ template<u32 func()> void WrapU_V() {
 }
 
 template<u32 func(int, void *, int)> void WrapU_IVI() {
-	u32 retval = func(PARAM(0), Memory::GetPointer(PARAM(1)), PARAM(2));
+	u32 retval = func(PARAM(0), Memory::GetPointerWrite(PARAM(1)), PARAM(2));
 	RETURN(retval);
 }
 
@@ -116,7 +116,7 @@ template<int func(const char *, int, int, u32)> void WrapI_CIIU() {
 }
 
 template<int func(int, const char *, u32, void *, void *, u32, int)> void WrapI_ICUVVUI() {
-	u32 retval = func(PARAM(0), Memory::GetCharPointer(PARAM(1)), PARAM(2), Memory::GetPointer(PARAM(3)),Memory::GetPointer(PARAM(4)), PARAM(5), PARAM(6) );
+	u32 retval = func(PARAM(0), Memory::GetCharPointer(PARAM(1)), PARAM(2), Memory::GetPointerWrite(PARAM(3)),Memory::GetPointerWrite(PARAM(4)), PARAM(5), PARAM(6) );
 	RETURN(retval);
 }
 
@@ -147,13 +147,13 @@ template<int func(int, int, int, int, int, int, u32)> void WrapI_IIIIIIU() {
 
 // Hm, do so many params get passed in registers?
 template<int func(int, int, int, int, int, int, int, int, u32)> void WrapI_IIIIIIIIU() {
-	u32 param8 = *(const u32_le *)Memory::GetPointer(currentMIPS->r[29]); //Fixed 9th parameter, thanks to Kingcom
+	u32 param8 = *(const u32_le *)Memory::GetPointerWrite(currentMIPS->r[29]); //Fixed 9th parameter, thanks to Kingcom
 	u32 retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4), PARAM(5), PARAM(6), PARAM(7), param8);
 	RETURN(retval);
 }
 
 template<u32 func(int, void *)> void WrapU_IV() {
-	u32 retval = func(PARAM(0), Memory::GetPointer(PARAM(1)));
+	u32 retval = func(PARAM(0), Memory::GetPointerWrite(PARAM(1)));
 	RETURN(retval);
 }
 
@@ -796,16 +796,16 @@ template <int func(int, const char *, int)> void WrapI_ICI() {
 }
 
 template<int func(int, void *, void *, void *, void *, u32, int)> void WrapI_IVVVVUI(){
-  u32 retval = func(PARAM(0), Memory::GetPointer(PARAM(1)), Memory::GetPointer(PARAM(2)), Memory::GetPointer(PARAM(3)), Memory::GetPointer(PARAM(4)), PARAM(5), PARAM(6) );
+  u32 retval = func(PARAM(0), Memory::GetPointerWrite(PARAM(1)), Memory::GetPointerWrite(PARAM(2)), Memory::GetPointerWrite(PARAM(3)), Memory::GetPointerWrite(PARAM(4)), PARAM(5), PARAM(6) );
   RETURN(retval);
 }
 
 template<int func(int, const char *, u32, void *, int, int, int)> void WrapI_ICUVIII(){
-  u32 retval = func(PARAM(0), Memory::GetCharPointer(PARAM(1)), PARAM(2), Memory::GetPointer(PARAM(3)), PARAM(4), PARAM(5), PARAM(6));
+  u32 retval = func(PARAM(0), Memory::GetCharPointer(PARAM(1)), PARAM(2), Memory::GetPointerWrite(PARAM(3)), PARAM(4), PARAM(5), PARAM(6));
   RETURN(retval);
 }
 
 template<int func(void *, u32, int)> void WrapI_VUI(){
-	u32 retval = func(Memory::GetPointer(PARAM(0)), PARAM(1), PARAM(2));
+	u32 retval = func(Memory::GetPointerWrite(PARAM(0)), PARAM(1), PARAM(2));
 	RETURN(retval);
 }

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -138,7 +138,7 @@ static int Replace_memcpy() {
 		}
 	}
 	if (!skip && bytes != 0) {
-		u8 *dst = Memory::GetPointer(destPtr);
+		u8 *dst = Memory::GetPointerWrite(destPtr);
 		const u8 *src = Memory::GetPointer(srcPtr);
 
 		if (!dst || !src) {
@@ -190,7 +190,7 @@ static int Replace_memcpy_jak() {
 		}
 	}
 	if (!skip && bytes != 0) {
-		u8 *dst = Memory::GetPointer(destPtr);
+		u8 *dst = Memory::GetPointerWrite(destPtr);
 		const u8 *src = Memory::GetPointer(srcPtr);
 
 		if (!dst || !src) {
@@ -240,7 +240,7 @@ static int Replace_memcpy16() {
 		}
 	}
 	if (!skip && bytes != 0) {
-		u8 *dst = Memory::GetPointer(destPtr);
+		u8 *dst = Memory::GetPointerWrite(destPtr);
 		const u8 *src = Memory::GetPointer(srcPtr);
 		if (dst && src) {
 			memmove(dst, src, bytes);
@@ -267,7 +267,7 @@ static int Replace_memcpy_swizzled() {
 			gpu->PerformMemoryDownload(srcPtr, pitch * h);
 		}
 	}
-	u8 *dstp = Memory::GetPointer(destPtr);
+	u8 *dstp = Memory::GetPointerWrite(destPtr);
 	const u8 *srcp = Memory::GetPointer(srcPtr);
 
 	if (dstp && srcp) {
@@ -312,7 +312,7 @@ static int Replace_memmove() {
 		}
 	}
 	if (!skip && bytes != 0) {
-		u8 *dst = Memory::GetPointer(destPtr);
+		u8 *dst = Memory::GetPointerWrite(destPtr);
 		const u8 *src = Memory::GetPointer(srcPtr);
 		if (dst && src) {
 			memmove(dst, src, bytes);
@@ -338,7 +338,7 @@ static int Replace_memset() {
 		skip = gpu->PerformMemorySet(destPtr, value, bytes);
 	}
 	if (!skip && bytes != 0) {
-		u8 *dst = Memory::GetPointer(destPtr);
+		u8 *dst = Memory::GetPointerWrite(destPtr);
 		if (dst) {
 			memset(dst, value, bytes);
 		}
@@ -365,7 +365,7 @@ static int Replace_memset_jak() {
 		skip = gpu->PerformMemorySet(destPtr, value, bytes);
 	}
 	if (!skip && bytes != 0) {
-		u8 *dst = Memory::GetPointer(destPtr);
+		u8 *dst = Memory::GetPointerWrite(destPtr);
 		if (dst) {
 			memset(dst, value, bytes);
 		}

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1263,7 +1263,7 @@ void notifyMatchingHandler(SceNetAdhocMatchingContext * context, ThreadMessage *
 	MatchingArgs argsNew = { 0 };
 	u32_le dataBufLen = msg->optlen + 8; //max(bufLen, msg->optlen + 8);
 	u32_le dataBufAddr = userMemory.Alloc(dataBufLen); // We will free this memory after returning from mipscall. FIXME: Are these buffers supposed to be taken/pre-allocated from the memory pool during sceNetAdhocMatchingInit?
-	uint8_t * dataPtr = Memory::GetPointer(dataBufAddr);
+	uint8_t * dataPtr = Memory::GetPointerWrite(dataBufAddr);
 	if (dataPtr) {
 		memcpy(dataPtr, &msg->mac, sizeof(msg->mac));
 		if (msg->optlen > 0)

--- a/Core/HLE/sceAdler.cpp
+++ b/Core/HLE/sceAdler.cpp
@@ -33,7 +33,7 @@ static u32 sceAdler32(u32 adler, u32 data, u32 datalen) {
 	}
 	INFO_LOG(SCEMISC, "sceAdler32(adler=%08x, data=%08x, datalen=%08x)", adler, data, datalen);
 
-	u8 *buf = Memory::GetPointerUnchecked(data);
+	u8 *buf = Memory::GetPointerWriteUnchecked(data);
 	u32 ret = adler32(adler, buf, datalen);
 
 	return ret;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -480,7 +480,7 @@ struct Atrac {
 	}
 
 	u8 *BufferStart() {
-		return ignoreDataBuf_ ? Memory::GetPointer(first_.addr) : dataBuf_;
+		return ignoreDataBuf_ ? Memory::GetPointerWrite(first_.addr) : dataBuf_;
 	}
 
 	void SeekToSample(int sample) {
@@ -1345,7 +1345,7 @@ static u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 
 	u32 numSamples = 0;
 	u32 finish = 0;
 	int remains = 0;
-	int ret = _AtracDecodeData(atracID, Memory::GetPointer(outAddr), outAddr, &numSamples, &finish, &remains);
+	int ret = _AtracDecodeData(atracID, Memory::GetPointerWrite(outAddr), outAddr, &numSamples, &finish, &remains);
 	if (ret != (int)ATRAC_ERROR_BAD_ATRACID && ret != (int)ATRAC_ERROR_NO_DATA) {
 		if (Memory::IsValidAddress(numSamplesAddr))
 			Memory::Write_U32(numSamples, numSamplesAddr);

--- a/Core/HLE/sceAudiocodec.cpp
+++ b/Core/HLE/sceAudiocodec.cpp
@@ -116,7 +116,7 @@ static int sceAudiocodecDecode(u32 ctxPtr, int codec) {
 
 		if (decoder != NULL) {
 			// Decode audio
-			decoder->Decode(Memory::GetPointer(ctx->inDataPtr), ctx->inDataSize, Memory::GetPointer(ctx->outDataPtr), &outbytes);
+			decoder->Decode(Memory::GetPointer(ctx->inDataPtr), ctx->inDataSize, Memory::GetPointerWrite(ctx->outDataPtr), &outbytes);
 		}
 		DEBUG_LOG(ME, "sceAudiocodecDec(%08x, %i (%s))", ctxPtr, codec, GetCodecName(codec));
 		return 0;

--- a/Core/HLE/sceChnnlsv.cpp
+++ b/Core/HLE/sceChnnlsv.cpp
@@ -218,7 +218,7 @@ static int sceSdGetLastIndex(u32 addressCtx, u32 addressHash, u32 addressKey)
 {
 	pspChnnlsvContext1 ctx;
 	Memory::ReadStruct(addressCtx, &ctx);
-	int res = sceSdGetLastIndex_(ctx, Memory::GetPointer(addressHash), Memory::GetPointer(addressKey));
+	int res = sceSdGetLastIndex_(ctx, Memory::GetPointerWrite(addressHash), Memory::GetPointerWrite(addressKey));
 	Memory::WriteStruct(addressCtx, &ctx);
 	return res;
 }
@@ -348,7 +348,7 @@ static int sceSdRemoveValue(u32 addressCtx, u32 addressData, int length)
 {
 	pspChnnlsvContext1 ctx;
 	Memory::ReadStruct(addressCtx, &ctx);
-	int res = sceSdRemoveValue_(ctx, Memory::GetPointer(addressData), length);
+	int res = sceSdRemoveValue_(ctx, Memory::GetPointerWrite(addressData), length);
 	Memory::WriteStruct(addressCtx, &ctx);
 
 	return res;
@@ -400,8 +400,8 @@ static int sceSdCreateList(u32 ctx2Addr, int mode, int unkwn, u32 dataAddr, u32 
 {
 	pspChnnlsvContext2 ctx2;
 	Memory::ReadStruct(ctx2Addr, &ctx2);
-	u8* data = Memory::GetPointer(dataAddr);
-	u8* cryptkey = Memory::GetPointer(cryptkeyAddr);
+	u8* data = Memory::GetPointerWrite(dataAddr);
+	u8* cryptkey = Memory::GetPointerWrite(cryptkeyAddr);
 
 	int res = sceSdCreateList_(ctx2, mode, unkwn, data, cryptkey);
 
@@ -468,7 +468,7 @@ static int sceSdSetMember(u32 ctxAddr, u32 dataAddr, int alignedLen)
 {
 	pspChnnlsvContext2 ctx;
 	Memory::ReadStruct(ctxAddr, &ctx);
-	u8* data = Memory::GetPointer(dataAddr);
+	u8* data = Memory::GetPointerWrite(dataAddr);
 
 	int res = sceSdSetMember_(ctx, data, alignedLen);
 

--- a/Core/HLE/sceDeflt.cpp
+++ b/Core/HLE/sceDeflt.cpp
@@ -36,7 +36,7 @@ static int CommonDecompress(int windowBits, u32 OutBuffer, int OutBufferLength, 
 	}
 
 	z_stream stream{};
-	u8 *outBufferPtr = Memory::GetPointer(OutBuffer);
+	u8 *outBufferPtr = Memory::GetPointerWrite(OutBuffer);
 	stream.next_in = (Bytef*)Memory::GetPointer(InBuffer);
 	// We don't know the available length, just let it use as much as it wants.
 	stream.avail_in = (uInt)Memory::ValidSize(InBuffer, Memory::g_MemorySize);

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1042,7 +1042,7 @@ static bool __IoRead(int &result, int id, u32 data_addr, int size, int &us) {
 		} else if (Memory::IsValidAddress(data_addr)) {
 			const std::string tag = "IoRead/" + IODetermineFilename(f);
 			NotifyMemInfo(MemBlockFlags::WRITE, data_addr, size, tag.c_str(), tag.size());
-			u8 *data = (u8 *)Memory::GetPointer(data_addr);
+			u8 *data = (u8 *)Memory::GetPointerUnchecked(data_addr);
 			u32 validSize = Memory::ValidSize(data_addr, size);
 			if (f->npdrm) {
 				result = npdrmRead(f, data, validSize);
@@ -2482,7 +2482,7 @@ static int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, 
 		u8 pgd_magic[4] = {0x00, 0x50, 0x47, 0x44};
 
 		if (Memory::IsValidAddress(indataPtr) && inlen == 16) {
-			memcpy(keybuf, Memory::GetPointer(indataPtr), 16);
+			memcpy(keybuf, Memory::GetPointerUnchecked(indataPtr), 16);
 			key_ptr = keybuf;
 		}else{
 			key_ptr = NULL;

--- a/Core/HLE/sceJpeg.cpp
+++ b/Core/HLE/sceJpeg.cpp
@@ -133,7 +133,7 @@ static u32 convertARGBtoABGR(u32 argb) {
 }
 
 static int __DecodeJpeg(u32 jpegAddr, int jpegSize, u32 imageAddr) {
-	u8 *buf = Memory::GetPointer(jpegAddr);
+	const u8 *buf = Memory::GetPointer(jpegAddr);
 	int width, height, actual_components;
 	unsigned char *jpegBuf = jpgd::decompress_jpeg_image_from_memory(buf, jpegSize, &width, &height, &actual_components, 3);
 
@@ -219,7 +219,7 @@ static int getYCbCrBufferSize(int w, int h) {
 }
 
 static int __JpegGetOutputInfo(u32 jpegAddr, int jpegSize, u32 colourInfoAddr) {
-	u8 *buf = Memory::GetPointer(jpegAddr);
+	const u8 *buf = Memory::GetPointer(jpegAddr);
 	int width, height, actual_components;
 	unsigned char *jpegBuf = jpgd::decompress_jpeg_image_from_memory(buf, jpegSize, &width, &height, &actual_components, 3);
 
@@ -325,7 +325,7 @@ static int __JpegConvertRGBToYCbCr (const void *data, u32 bufferOutputAddr, int 
 }
 
 static int __JpegDecodeMJpegYCbCr(u32 jpegAddr, int jpegSize, u32 yCbCrAddr) {
-	u8 *buf = Memory::GetPointer(jpegAddr);
+	const u8 *buf = Memory::GetPointer(jpegAddr);
 	int width, height, actual_components;
 	unsigned char *jpegBuf = jpgd::decompress_jpeg_image_from_memory(buf, jpegSize, &width, &height, &actual_components, 3);
 

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -634,8 +634,8 @@ static u32 sceKernelMemcpy(u32 dst, u32 src, u32 size)
 	// Technically should crash if these are invalid and size > 0...
 	if (!skip && Memory::IsValidAddress(dst) && Memory::IsValidAddress(src) && Memory::IsValidAddress(dst + size - 1) && Memory::IsValidAddress(src + size - 1))
 	{
-		u8 *dstp = Memory::GetPointerUnchecked(dst);
-		u8 *srcp = Memory::GetPointerUnchecked(src);
+		u8 *dstp = Memory::GetPointerWriteUnchecked(dst);
+		const u8 *srcp = Memory::GetPointerUnchecked(src);
 
 		// If it's non-overlapping, just do it in one go.
 		if (dst + size < src || src + size < dst)
@@ -688,7 +688,7 @@ const HLEFunction Kernel_Library[] =
 
 static u32 sysclib_memcpy(u32 dst, u32 src, u32 size) {	
 	if (Memory::IsValidRange(dst, size) && Memory::IsValidRange(src, size)) {
-		memcpy(Memory::GetPointer(dst), Memory::GetPointer(src), size);
+		memcpy(Memory::GetPointerWriteUnchecked(dst), Memory::GetPointerUnchecked(src), size);
 	}
 	if (MemBlockInfoDetailed(size)) {
 		const std::string tag = "KernelMemcpy/" + GetMemWriteTagAt(src, size);
@@ -701,7 +701,7 @@ static u32 sysclib_memcpy(u32 dst, u32 src, u32 size) {
 static u32 sysclib_strcat(u32 dst, u32 src) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_strcat(dest=%08x, src=%08x)", dst, src);
 	if (Memory::IsValidAddress(dst) && Memory::IsValidAddress(src)) {
-		strcat((char *)Memory::GetPointer(dst), (char *)Memory::GetPointer(src));
+		strcat((char *)Memory::GetPointerWriteUnchecked(dst), (const char *)Memory::GetPointerUnchecked(src));
 	}
 	return dst;
 }
@@ -709,7 +709,7 @@ static u32 sysclib_strcat(u32 dst, u32 src) {
 static int sysclib_strcmp(u32 dst, u32 src) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_strcmp(dest=%08x, src=%08x)", dst, src);
 	if (Memory::IsValidAddress(dst) && Memory::IsValidAddress(src)) {
-		return strcmp((char *)Memory::GetPointer(dst), (char *)Memory::GetPointer(src));
+		return strcmp((const char *)Memory::GetPointerUnchecked(dst), (const char *)Memory::GetPointerUnchecked(src));
 	} else {
 		// What to do? Crash, probably.
 		return 0;
@@ -719,7 +719,7 @@ static int sysclib_strcmp(u32 dst, u32 src) {
 static u32 sysclib_strcpy(u32 dst, u32 src) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_strcpy(dest=%08x, src=%08x)", dst, src);
 	if (Memory::IsValidAddress(dst) && Memory::IsValidAddress(src)) {
-		strcpy((char *)Memory::GetPointer(dst), (char *)Memory::GetPointer(src));
+		strcpy((char *)Memory::GetPointerWriteUnchecked(dst), (const char *)Memory::GetPointerUnchecked(src));
 	}
 	return dst;
 }
@@ -758,7 +758,7 @@ static int sysclib_sprintf(u32 dst, u32 fmt) {
 static u32 sysclib_memset(u32 destAddr, int data, int size) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_memset(dest=%08x, data=%d ,size=%d)", destAddr, data, size);
 	if (Memory::IsValidRange(destAddr, size)) {
-		memset(Memory::GetPointer(destAddr), data, size);
+		memset(Memory::GetPointerWriteUnchecked(destAddr), data, size);
 	}
 	NotifyMemInfo(MemBlockFlags::WRITE, destAddr, size, "KernelMemset");
 	return 0;
@@ -791,7 +791,7 @@ static int sysclib_strncmp(u32 s1, u32 s2, u32 size) {
 static u32 sysclib_memmove(u32 dst, u32 src, u32 size) {
 	ERROR_LOG(SCEKERNEL, "Untested sysclib_memmove(%08x, %08x, %08x)", dst, src, size);
 	if (Memory::IsValidRange(dst, size) && Memory::IsValidRange(src, size)) {
-		memmove(Memory::GetPointer(dst), Memory::GetPointer(src), size);
+		memmove(Memory::GetPointerWriteUnchecked(dst), Memory::GetPointerUnchecked(src), size);
 	}
 	if (MemBlockInfoDetailed(size)) {
 		const std::string tag = "KernelMemmove/" + GetMemWriteTagAt(src, size);
@@ -810,7 +810,7 @@ static u32 sysclib_strncpy(u32 dest, u32 src, u32 size) {
 	u32 i = 0;
 	u32 srcSize = Memory::ValidSize(src, size);
 	const u8 *srcp = Memory::GetPointer(src);
-	u8 *destp = Memory::GetPointer(dest);
+	u8 *destp = Memory::GetPointerWrite(dest);
 	for (i = 0; i < srcSize; ++i) {
 		u8 c = *srcp++;
 		if (c == 0)

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -432,7 +432,7 @@ void __KernelMemoryInit()
 	MemBlockInfoInit();
 	kernelMemory.Init(PSP_GetKernelMemoryBase(), PSP_GetKernelMemoryEnd() - PSP_GetKernelMemoryBase(), false);
 	userMemory.Init(PSP_GetUserMemoryBase(), PSP_GetUserMemoryEnd() - PSP_GetUserMemoryBase(), false);
-	ParallelMemset(&g_threadManager, Memory::GetPointer(PSP_GetKernelMemoryBase()), 0, PSP_GetUserMemoryEnd() - PSP_GetKernelMemoryBase());
+	ParallelMemset(&g_threadManager, Memory::GetPointerWrite(PSP_GetKernelMemoryBase()), 0, PSP_GetUserMemoryEnd() - PSP_GetKernelMemoryBase());
 	NotifyMemInfo(MemBlockFlags::WRITE, PSP_GetKernelMemoryBase(), PSP_GetUserMemoryEnd() - PSP_GetKernelMemoryBase(), "MemInit");
 	INFO_LOG(SCEKERNEL, "Kernel and user memory pools initialized");
 

--- a/Core/HLE/sceKernelMsgPipe.cpp
+++ b/Core/HLE/sceKernelMsgPipe.cpp
@@ -218,7 +218,7 @@ struct MsgPipe : public KernelObject
 			// Receive as much as possible, even if it's not enough to wake up.
 			u32 bytesToSend = std::min(thread->freeSize, GetUsedSize());
 
-			u8* ptr = Memory::GetPointer(buffer);
+			u8* ptr = Memory::GetPointerWrite(buffer);
 			thread->WriteBuffer(buffer, bytesToSend);
 			// Put the unused data at the start of the buffer.
 			nmp.freeSize += bytesToSend;
@@ -494,7 +494,7 @@ static int __KernelReceiveMsgPipe(MsgPipe *m, u32 receiveBufAddr, u32 receiveSiz
 			{
 				Memory::Memcpy(curReceiveAddr, m->buffer, bytesToReceive, "MsgPipeReceive");
 				m->nmp.freeSize += bytesToReceive;
-				memmove(Memory::GetPointer(m->buffer), Memory::GetPointer(m->buffer) + bytesToReceive, m->GetUsedSize());
+				memmove(Memory::GetPointerWrite(m->buffer), Memory::GetPointer(m->buffer) + bytesToReceive, m->GetUsedSize());
 				curReceiveAddr += bytesToReceive;
 				receiveSize -= bytesToReceive;
 

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -466,8 +466,8 @@ int sceKernelPollSema(SceUID id, int wantedCount)
 
 static u32 sceUtilsBufferCopyWithRange(u32 outAddr, int outSize, u32 inAddr, int inSize, int cmd)
 {
-	u8 *outAddress = Memory::IsValidRange(outAddr, outSize) ? Memory::GetPointer(outAddr) : nullptr;
-	const u8 *inAddress = Memory::IsValidRange(inAddr, inSize) ? Memory::GetPointer(inAddr) : nullptr;
+	u8 *outAddress = Memory::IsValidRange(outAddr, outSize) ? Memory::GetPointerWriteUnchecked(outAddr) : nullptr;
+	const u8 *inAddress = Memory::IsValidRange(inAddr, inSize) ? Memory::GetPointerUnchecked(inAddr) : nullptr;
 	int temp = kirk_sceUtilsBufferCopyWithRange(outAddress, outSize, inAddress, inSize, cmd);
 	if (temp != 0) {
 		ERROR_LOG(SCEKERNEL, "hleUtilsBufferCopyWithRange: Failed with %d", temp);
@@ -478,8 +478,8 @@ static u32 sceUtilsBufferCopyWithRange(u32 outAddr, int outSize, u32 inAddr, int
 // Note sure what difference there is between this and sceUtilsBufferCopyWithRange.
 static int sceUtilsBufferCopyByPollingWithRange(u32 outAddr, int outSize, u32 inAddr, int inSize, int cmd)
 {
-	u8 *outAddress = Memory::IsValidRange(outAddr, outSize) ? Memory::GetPointer(outAddr) : nullptr;
-	const u8 *inAddress = Memory::IsValidRange(inAddr, inSize) ? Memory::GetPointer(inAddr) : nullptr;
+	u8 *outAddress = Memory::IsValidRange(outAddr, outSize) ? Memory::GetPointerWriteUnchecked(outAddr) : nullptr;
+	const u8 *inAddress = Memory::IsValidRange(inAddr, inSize) ? Memory::GetPointerUnchecked(inAddr) : nullptr;
 	return kirk_sceUtilsBufferCopyWithRange(outAddress, outSize, inAddress, inSize, cmd);
 }
 

--- a/Core/HLE/sceMd5.cpp
+++ b/Core/HLE/sceMd5.cpp
@@ -32,7 +32,7 @@ u32 sceKernelUtilsMt19937Init(u32 ctx, u32 seed) {
 	DEBUG_LOG(HLE, "sceKernelUtilsMt19937Init(%08x, %08x)", ctx, seed);
 	if (!Memory::IsValidAddress(ctx))
 		return -1;
-	void *ptr = Memory::GetPointer(ctx);
+	void *ptr = Memory::GetPointerWrite(ctx);
 	// This is made to match the memory layout of a PSP MT structure exactly.
 	// Let's just construct it in place with placement new. Elite C++ hackery FTW.
 	new (ptr) MersenneTwister(seed);
@@ -43,7 +43,7 @@ u32 sceKernelUtilsMt19937UInt(u32 ctx) {
 	VERBOSE_LOG(HLE, "sceKernelUtilsMt19937UInt(%08x)", ctx);
 	if (!Memory::IsValidAddress(ctx))
 		return -1;
-	MersenneTwister *mt = (MersenneTwister *)Memory::GetPointer(ctx);
+	MersenneTwister *mt = (MersenneTwister *)Memory::GetPointerUnchecked(ctx);
 	return mt->R32();
 }
 
@@ -57,7 +57,7 @@ static int sceMd5Digest(u32 dataAddr, u32 len, u32 digestAddr) {
 	if (!Memory::IsValidAddress(dataAddr) || !Memory::IsValidAddress(digestAddr))
 		return -1;
 
-	md5(Memory::GetPointer(dataAddr), (int)len, Memory::GetPointer(digestAddr));
+	md5(Memory::GetPointerWriteUnchecked(dataAddr), (int)len, Memory::GetPointerWriteUnchecked(digestAddr));
 	return 0;
 }
 
@@ -78,7 +78,7 @@ static int sceMd5BlockUpdate(u32 ctxAddr, u32 dataPtr, u32 len) {
 	if (!Memory::IsValidAddress(ctxAddr) || !Memory::IsValidAddress(dataPtr))
 		return -1;
 	
-	md5_update(&md5_ctx, Memory::GetPointer(dataPtr), (int)len);
+	md5_update(&md5_ctx, Memory::GetPointerWriteUnchecked(dataPtr), (int)len);
 	return 0;
 }
 
@@ -87,7 +87,7 @@ static int sceMd5BlockResult(u32 ctxAddr, u32 digestAddr) {
 	if (!Memory::IsValidAddress(ctxAddr) || !Memory::IsValidAddress(digestAddr))
 		return -1;
 
-	md5_finish(&md5_ctx, Memory::GetPointer(digestAddr));
+	md5_finish(&md5_ctx, Memory::GetPointerWriteUnchecked(digestAddr));
 	return 0;
 }
 
@@ -97,7 +97,7 @@ int sceKernelUtilsMd5Digest(u32 dataAddr, int len, u32 digestAddr) {
 	if (!Memory::IsValidAddress(dataAddr) || !Memory::IsValidAddress(digestAddr))
 		return -1;
 
-	md5(Memory::GetPointer(dataAddr), (int)len, Memory::GetPointer(digestAddr));
+	md5(Memory::GetPointerWriteUnchecked(dataAddr), (int)len, Memory::GetPointerWriteUnchecked(digestAddr));
 	return 0;
 }
 
@@ -118,7 +118,7 @@ int sceKernelUtilsMd5BlockUpdate(u32 ctxAddr, u32 dataPtr, int len) {
 	if (!Memory::IsValidAddress(ctxAddr) || !Memory::IsValidAddress(dataPtr))
 		return -1;
 
-	md5_update(&md5_ctx, Memory::GetPointer(dataPtr), (int)len);
+	md5_update(&md5_ctx, Memory::GetPointerWriteUnchecked(dataPtr), (int)len);
 	return 0;
 }
 
@@ -127,7 +127,7 @@ int sceKernelUtilsMd5BlockResult(u32 ctxAddr, u32 digestAddr) {
 	if (!Memory::IsValidAddress(ctxAddr) || !Memory::IsValidAddress(digestAddr))
 		return -1;
 
-	md5_finish(&md5_ctx, Memory::GetPointer(digestAddr));
+	md5_finish(&md5_ctx, Memory::GetPointerWriteUnchecked(digestAddr));
 	return 0;
 }
 
@@ -140,7 +140,7 @@ int sceKernelUtilsSha1Digest(u32 dataAddr, int len, u32 digestAddr) {
 	if (!Memory::IsValidAddress(dataAddr) || !Memory::IsValidAddress(digestAddr))
 		return -1;
 
-	sha1(Memory::GetPointer(dataAddr), (int)len, Memory::GetPointer(digestAddr));
+	sha1(Memory::GetPointerWriteUnchecked(dataAddr), (int)len, Memory::GetPointerWriteUnchecked(digestAddr));
 	return 0;
 }
 
@@ -162,7 +162,7 @@ int sceKernelUtilsSha1BlockUpdate(u32 ctxAddr, u32 dataAddr, int len) {
 	if (!Memory::IsValidAddress(ctxAddr) || !Memory::IsValidAddress(dataAddr))
 		return -1;
 
-	sha1_update(&sha1_ctx, Memory::GetPointer(dataAddr), (int)len);
+	sha1_update(&sha1_ctx, Memory::GetPointerWriteUnchecked(dataAddr), (int)len);
 	return 0;
 }
 
@@ -171,7 +171,7 @@ int sceKernelUtilsSha1BlockResult(u32 ctxAddr, u32 digestAddr) {
 	if (!Memory::IsValidAddress(ctxAddr) || !Memory::IsValidAddress(digestAddr))
 		return -1;
 
-	sha1_finish(&sha1_ctx, Memory::GetPointer(digestAddr));
+	sha1_finish(&sha1_ctx, Memory::GetPointerWriteUnchecked(digestAddr));
 	return 0;
 }
 

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -364,7 +364,7 @@ static int CalculateMp3SamplesPerFrame(int versionBits, int layerBits) {
 static int FindMp3Header(AuCtx *ctx, int &header, int end) {
 	u32 addr = ctx->AuBuf + ctx->AuStreamWorkareaSize();
 	if (Memory::IsValidRange(addr, end)) {
-		u8 *ptr = Memory::GetPointerUnchecked(addr);
+		const u8 *ptr = Memory::GetPointerUnchecked(addr);
 		for (int offset = 0; offset < end; ++offset) {
 			// If we hit valid sync bits, then we've found a header.
 			if (ptr[offset] == 0xFF && (ptr[offset + 1] & 0xC0) == 0xC0) {
@@ -689,11 +689,11 @@ static u32 sceMp3LowLevelDecode(u32 mp3, u32 sourceAddr, u32 sourceBytesConsumed
 		return -1;
 	}
 
-	auto inbuff = Memory::GetPointer(sourceAddr);
-	auto outbuff = Memory::GetPointer(samplesAddr);
+	auto inbuff = Memory::GetPointerWriteUnchecked(sourceAddr);
+	auto outbuff = Memory::GetPointerWriteUnchecked(samplesAddr);
 	
 	int outpcmbytes = 0;
-	ctx->decoder->Decode((void*)inbuff, 4096, outbuff, &outpcmbytes);
+	ctx->decoder->Decode(inbuff, 4096, outbuff, &outpcmbytes);
 	NotifyMemInfo(MemBlockFlags::WRITE, samplesAddr, outpcmbytes, "Mp3LowLevelDecode");
 	
 	Memory::Write_U32(ctx->decoder->GetSourcePos(), sourceBytesConsumedAddr);

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -628,7 +628,7 @@ static int sceMpegQueryStreamOffset(u32 mpeg, u32 bufferAddr, u32 offsetAddr)
 	DEBUG_LOG(ME, "sceMpegQueryStreamOffset(%08x, %08x, %08x)", mpeg, bufferAddr, offsetAddr);
 
 	// Kinda destructive, no?
-	AnalyzeMpeg(Memory::GetPointer(bufferAddr), Memory::ValidSize(bufferAddr, 32768), ctx);
+	AnalyzeMpeg(Memory::GetPointerWriteUnchecked(bufferAddr), Memory::ValidSize(bufferAddr, 32768), ctx);
 
 	if (ctx->mpegMagic != PSMF_MAGIC) {
 		ERROR_LOG(ME, "sceMpegQueryStreamOffset: Bad PSMF magic");
@@ -660,7 +660,7 @@ static u32 sceMpegQueryStreamSize(u32 bufferAddr, u32 sizeAddr)
 	MpegContext ctx;
 	ctx.mediaengine = 0;
 
-	AnalyzeMpeg(Memory::GetPointer(bufferAddr), Memory::ValidSize(bufferAddr, 32768), &ctx);
+	AnalyzeMpeg(Memory::GetPointerWriteUnchecked(bufferAddr), Memory::ValidSize(bufferAddr, 32768), &ctx);
 
 	if (ctx.mpegMagic != PSMF_MAGIC) {
 		ERROR_LOG(ME, "sceMpegQueryStreamSize: Bad PSMF magic");
@@ -965,7 +965,7 @@ static bool decodePmpVideo(PSPPointer<SceMpegRingBuffer> ringbuffer, u32 pmpctxA
 		for (int i = 0; i < pmp_nBlocks; i++){
 			auto lli = PSPPointer<SceMpegLLI>::Create(pmp_videoSource);
 			// add source block into pmpframes
-			pmpframes->add(Memory::GetPointer(lli->pSrc), lli->iSize);
+			pmpframes->add(Memory::GetPointerWrite(lli->pSrc), lli->iSize);
 			// get next block
 			pmp_videoSource += sizeof(SceMpegLLI);
 		}

--- a/Core/HLE/sceMt19937.cpp
+++ b/Core/HLE/sceMt19937.cpp
@@ -30,7 +30,7 @@ static u32 sceMt19937Init(u32 mt19937Addr, u32 seed)
 {
 	if (!Memory::IsValidAddress(mt19937Addr))
 		return hleLogError(HLE, -1);
-	void *ptr = Memory::GetPointer(mt19937Addr);
+	void *ptr = Memory::GetPointerWriteUnchecked(mt19937Addr);
 	// This is made to match the memory layout of a PSP MT structure exactly.
 	// Let's just construct it in place with placement new. Elite C++ hackery FTW.
 	new (ptr) MersenneTwister(seed);

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -684,7 +684,7 @@ static u32 sceWlanGetEtherAddr(u32 addrAddr) {
 		return hleLogError(SCENET, SCE_KERNEL_ERROR_ILLEGAL_ADDR, "illegal address");
 	}
 
-	u8 *addr = Memory::GetPointer(addrAddr);
+	u8 *addr = Memory::GetPointerWriteUnchecked(addrAddr);
 	if (PPSSPP_ID > 1) {
 		Memory::Memset(addrAddr, PPSSPP_ID, 6);
 		// Making sure the 1st 2-bits on the 1st byte of OUI are zero to prevent issue with some games (ie. Gran Turismo)
@@ -722,8 +722,8 @@ static void sceNetEtherNtostr(u32 macPtr, u32 bufferPtr) {
 	DEBUG_LOG(SCENET, "sceNetEtherNtostr(%08x, %08x) at %08x", macPtr, bufferPtr, currentMIPS->pc);
 
 	if (Memory::IsValidAddress(bufferPtr) && Memory::IsValidAddress(macPtr)) {
-		char *buffer = (char *)Memory::GetPointer(bufferPtr);
-		const u8 *mac = Memory::GetPointer(macPtr);
+		char *buffer = (char *)Memory::GetPointerWriteUnchecked(bufferPtr);
+		const u8 *mac = Memory::GetPointerUnchecked(macPtr);
 
 		// MAC address is always 6 bytes / 48 bits.
 		sprintf(buffer, "%02x:%02x:%02x:%02x:%02x:%02x",
@@ -748,8 +748,8 @@ static void sceNetEtherStrton(u32 bufferPtr, u32 macPtr) {
 	DEBUG_LOG(SCENET, "sceNetEtherStrton(%08x, %08x)", bufferPtr, macPtr);
 
 	if (Memory::IsValidAddress(bufferPtr) && Memory::IsValidAddress(macPtr)) {
-		const char *buffer = (char *)Memory::GetPointer(bufferPtr);
-		u8 *mac = Memory::GetPointer(macPtr);
+		const char *buffer = (const char *)Memory::GetPointerUnchecked(bufferPtr);
+		u8 *mac = Memory::GetPointerWrite(macPtr);
 
 		// MAC address is always 6 pairs of hex digits.
 		// TODO: Funny stuff happens if it's too short.
@@ -896,7 +896,7 @@ static int sceNetApctlGetInfo(int code, u32 pInfoAddr) {
 	if (!Memory::IsValidAddress(pInfoAddr))
 		return hleLogError(SCENET, -1, "apctl invalid arg");
 
-	u8* info = Memory::GetPointer(pInfoAddr); // FIXME: Points to a union instead of a struct thus each field have the same address
+	u8* info = Memory::GetPointerWrite(pInfoAddr); // FIXME: Points to a union instead of a struct thus each field have the same address
 
 	switch (code) {
 	case PSP_NET_APCTL_INFO_PROFILE_NAME:

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -5120,7 +5120,7 @@ static int sceNetAdhocMatchingSelectTarget(int matchingId, const char *macAddres
 						if ((optLen == 0) || (optLen > 0 && optDataPtr != 0))
 						{
 							void * opt = NULL;
-							if (Memory::IsValidAddress(optDataPtr)) opt = Memory::GetPointer(optDataPtr);
+							if (Memory::IsValidAddress(optDataPtr)) opt = Memory::GetPointerWriteUnchecked(optDataPtr);
 							// Host Mode
 							if (context->mode == PSP_ADHOC_MATCHING_MODE_PARENT)
 							{
@@ -5247,7 +5247,7 @@ int NetAdhocMatching_CancelTargetWithOpt(int matchingId, const char* macAddress,
 	{
 		SceNetEtherAddr* target = (SceNetEtherAddr*)macAddress;
 		void* opt = NULL;
-		if (Memory::IsValidAddress(optDataPtr)) opt = Memory::GetPointer(optDataPtr);
+		if (Memory::IsValidAddress(optDataPtr)) opt = Memory::GetPointerWriteUnchecked(optDataPtr);
 
 		// Valid Arguments
 		if (target != NULL && ((optLen == 0) || (optLen > 0 && opt != NULL)))
@@ -5351,7 +5351,7 @@ int sceNetAdhocMatchingGetHelloOpt(int matchingId, u32 optLenAddr, u32 optDataAd
 		// Get OptData
 		*optlen = item->hellolen;
 		if ((*optlen > 0) && Memory::IsValidAddress(optDataAddr)) {
-			uint8_t * optdata = Memory::GetPointer(optDataAddr);
+			uint8_t * optdata = Memory::GetPointerWriteUnchecked(optDataAddr);
 			memcpy(optdata, item->hello, *optlen);
 		}
 		//else return ERROR_NET_ADHOC_MATCHING_INVALID_ARG;
@@ -5666,7 +5666,7 @@ int sceNetAdhocMatchingSendData(int matchingId, const char *mac, int dataLen, u3
 						return hleLogError(SCENET, ERROR_NET_ADHOC_MATCHING_INVALID_DATALEN, "invalid datalen");
 
 					void* data = NULL;
-					if (Memory::IsValidAddress(dataAddr)) data = Memory::GetPointer(dataAddr);
+					if (Memory::IsValidAddress(dataAddr)) data = Memory::GetPointerWriteUnchecked(dataAddr);
 
 					// Lock the peer
 					std::lock_guard<std::recursive_mutex> peer_guard(peerlock);

--- a/Core/HLE/sceNp.cpp
+++ b/Core/HLE/sceNp.cpp
@@ -267,7 +267,7 @@ static int sceNpAuthGetTicket(u32 requestId, u32 bufferAddr, u32 length)
 	// Dummy Login ticket returned as Login response. Dummy ticket contents were taken from https://www.psdevwiki.com/ps3/X-I-5-Ticket
 	ticket.header.version = TICKET_VER_2_1;
 	ticket.header.size = 0xF0; // size excluding the header
-	u8* buf = Memory::GetPointer(bufferAddr + sizeof(ticket));
+	u8* buf = Memory::GetPointerWrite(bufferAddr + sizeof(ticket));
 	int ofs = 0;
 	ofs += writeTicketParam(buf, PARAM_TYPE_STRING_ASCII, "\x4c\x47\x56\x3b\x81\x39\x4a\x22\xd8\x6b\xc1\x57\x71\x6e\xfd\xb8\xab\x63\xcc\x51", 20); // 20 random letters, token key?
 	ofs += writeTicketU32Param(buf + ofs, PARAM_TYPE_INT, 0x0100); // a flags?

--- a/Core/HLE/scePauth.cpp
+++ b/Core/HLE/scePauth.cpp
@@ -29,7 +29,7 @@
 
 static int scePauth_F7AA47F6(u32 srcPtr, int srcLength, u32 destLengthPtr, u32 workArea)
 {
-	auto src = Memory::GetPointer(srcPtr);
+	auto src = Memory::GetPointerWrite(srcPtr);
 	auto key = Memory::GetPointer(workArea);
 
 	const auto decryptResult = pspDecryptPRX(src, src, srcLength, key);
@@ -46,7 +46,7 @@ static int scePauth_F7AA47F6(u32 srcPtr, int srcLength, u32 destLengthPtr, u32 w
 
 static int scePauth_98B83B5D(u32 srcPtr, int srcLength, u32 destLengthPtr, u32 workArea)
 {
-	auto src = Memory::GetPointer(srcPtr);
+	auto src = Memory::GetPointerWrite(srcPtr);
 	auto key = Memory::GetPointer(workArea);
 
 	const auto decryptResult = pspDecryptPRX(src, src, srcLength, key);

--- a/Core/HLE/sceSha256.cpp
+++ b/Core/HLE/sceSha256.cpp
@@ -29,10 +29,10 @@ static int sceSha256Digest(u32 data, int dataLen, u32 digestPtr) {
 	INFO_LOG(HLE, "sceSha256Digest(data=%08x, len=%d, digest=%08x)", data, dataLen, digestPtr);
 
 	// Already checked above...
-	u8 *digest = Memory::GetPointerUnchecked(digestPtr);
+	u8 *digest = Memory::GetPointerWriteUnchecked(digestPtr);
 	sha256_context ctx;
 	sha256_starts(&ctx);
-	sha256_update(&ctx, Memory::GetPointerUnchecked(data), dataLen);
+	sha256_update(&ctx, Memory::GetPointerWriteUnchecked(data), dataLen);
 	sha256_finish(&ctx, digest);
 
 	return 0;

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -805,7 +805,7 @@ int MediaEngine::writeVideoImage(u32 bufferPtr, int frameWidth, int videoPixelMo
 		return 0;
 	}
 
-	u8 *buffer = Memory::GetPointer(bufferPtr);
+	u8 *buffer = Memory::GetPointerWrite(bufferPtr);
 
 #ifdef USE_FFMPEG
 	if (!m_pFrame || !m_pFrameRGB)
@@ -895,7 +895,7 @@ int MediaEngine::writeVideoImageWithRange(u32 bufferPtr, int frameWidth, int vid
 		return 0;
 	}
 
-	u8 *buffer = Memory::GetPointer(bufferPtr);
+	u8 *buffer = Memory::GetPointerWrite(bufferPtr);
 
 #ifdef USE_FFMPEG
 	if (!m_pFrame || !m_pFrameRGB)
@@ -1032,7 +1032,7 @@ int MediaEngine::getAudioSamples(u32 bufferPtr) {
 		ERROR_LOG_REPORT(ME, "Ignoring bad audio decode address %08x during video playback", bufferPtr);
 	}
 
-	u8 *buffer = Memory::GetPointer(bufferPtr);
+	u8 *buffer = Memory::GetPointerWrite(bufferPtr);
 	if (!m_demux) {
 		return 0;
 	}

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -64,13 +64,13 @@ void VagDecoder::Start(u32 data, u32 vagSize, bool loopEnabled) {
 	s_2 = 0;
 }
 
-void VagDecoder::DecodeBlock(u8 *&read_pointer) {
+void VagDecoder::DecodeBlock(const u8 *&read_pointer) {
 	if (curBlock_ == numBlocks_ - 1) {
 		end_ = true;
 		return;
 	}
 
-	u8 *readp = read_pointer;
+	const u8 *readp = read_pointer;
 	int predict_nr = *readp++;
 	int shift_factor = predict_nr & 0xf;
 	predict_nr >>= 4;
@@ -124,8 +124,8 @@ void VagDecoder::GetSamples(s16 *outSamples, int numSamples) {
 		WARN_LOG(SASMIX, "Bad VAG samples address?");
 		return;
 	}
-	u8 *readp = Memory::GetPointerUnchecked(read_);
-	u8 *origp = readp;
+	const u8 *readp = Memory::GetPointerUnchecked(read_);
+	const u8 *origp = readp;
 
 	for (int i = 0; i < numSamples; i++) {
 		if (curSample == 28) {

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -102,7 +102,7 @@ public:
 
 	void GetSamples(s16 *outSamples, int numSamples);
 
-	void DecodeBlock(u8 *&readp);
+	void DecodeBlock(const u8 *&readp);
 	bool End() const { return end_; }
 
 	void DoState(PointerWrap &p);

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -177,7 +177,7 @@ bool SimpleAudio::IsOK() const {
 #endif
 }
 
-bool SimpleAudio::Decode(void *inbuf, int inbytes, uint8_t *outbuf, int *outbytes) {
+bool SimpleAudio::Decode(const uint8_t *inbuf, int inbytes, uint8_t *outbuf, int *outbytes) {
 #ifdef USE_FFMPEG
 	if (!codecOpen_) {
 		OpenCodec(inbytes);
@@ -185,7 +185,7 @@ bool SimpleAudio::Decode(void *inbuf, int inbytes, uint8_t *outbuf, int *outbyte
 
 	AVPacket packet;
 	av_init_packet(&packet);
-	packet.data = static_cast<uint8_t *>(inbuf);
+	packet.data = (uint8_t *)(inbuf);
 	packet.size = inbytes;
 
 	int got_frame = 0;
@@ -338,7 +338,7 @@ size_t AuCtx::FindNextMp3Sync() {
 // return output pcm size, <0 error
 u32 AuCtx::AuDecode(u32 pcmAddr) {
 	u32 outptr = PCMBuf + nextOutputHalf * PCMBufSize / 2;
-	auto outbuf = Memory::GetPointer(outptr);
+	auto outbuf = Memory::GetPointerWrite(outptr);
 	int outpcmbufsize = 0;
 
 	if (pcmAddr)

--- a/Core/HW/SimpleAudioDec.h
+++ b/Core/HW/SimpleAudioDec.h
@@ -45,7 +45,7 @@ public:
 	SimpleAudio(int audioType, int sample_rate = 44100, int channels = 2);
 	~SimpleAudio();
 
-	bool Decode(void* inbuf, int inbytes, uint8_t *outbuf, int *outbytes);
+	bool Decode(const uint8_t* inbuf, int inbytes, uint8_t *outbuf, int *outbytes);
 	bool IsOK() const;
 
 	int GetOutSamples();

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -245,7 +245,7 @@ namespace MIPSInt
 				_dbg_assert_msg_( 0, "Misaligned lv.q at %08x (pc = %08x)", addr, PC);
 			}
 #ifndef COMMON_BIG_ENDIAN
-			f = reinterpret_cast<float *>(Memory::GetPointer(addr));
+			f = reinterpret_cast<float *>(Memory::GetPointerWrite(addr));
 			if (f)
 				WriteVector(f, V_Quad, vt);
 #else
@@ -294,7 +294,7 @@ namespace MIPSInt
 				_dbg_assert_msg_( 0, "Misaligned sv.q at %08x (pc = %08x)", addr, PC);
 			}
 #ifndef COMMON_BIG_ENDIAN
-			f = reinterpret_cast<float *>(Memory::GetPointer(addr));
+			f = reinterpret_cast<float *>(Memory::GetPointerWrite(addr));
 			if (f)
 				ReadVector(f, V_Quad, vt);
 #else

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -312,7 +312,7 @@ void Reinit() {
 }
 
 static void DoMemoryVoid(PointerWrap &p, uint32_t start, uint32_t size) {
-	uint8_t *d = GetPointer(start);
+	uint8_t *d = GetPointerWrite(start);
 	uint8_t *&storage = *p.ptr;
 
 	// We only handle aligned data and sizes.
@@ -479,7 +479,7 @@ void Write_Opcode_JIT(const u32 _Address, const Opcode& _Value)
 
 void Memset(const u32 _Address, const u8 _iValue, const u32 _iLength, const char *tag) {
 	if (IsValidRange(_Address, _iLength)) {
-		uint8_t *ptr = GetPointerUnchecked(_Address);
+		uint8_t *ptr = GetPointerWriteUnchecked(_Address);
 		memset(ptr, _iValue, _iLength);
 	} else {
 		for (size_t i = 0; i < _iLength; i++)

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -140,11 +140,19 @@ u16 Read_U16(const u32 _Address);
 u32 Read_U32(const u32 _Address);
 u64 Read_U64(const u32 _Address);
 
-inline u8* GetPointerUnchecked(const u32 address) {
+inline u8* GetPointerWriteUnchecked(const u32 address) {
 #ifdef MASKED_PSP_MEMORY
 	return (u8 *)(base + (address & MEMVIEW32_MASK));
 #else
 	return (u8 *)(base + address);
+#endif
+}
+
+inline const u8* GetPointerUnchecked(const u32 address) {
+#ifdef MASKED_PSP_MEMORY
+	return (const u8 *)(base + (address & MEMVIEW32_MASK));
+#else
+	return (const u8 *)(base + address);
 #endif
 }
 
@@ -236,7 +244,8 @@ inline void Write_Float(float f, u32 address)
 	Write_U32(u, address);
 }
 
-u8* GetPointer(const u32 address);
+u8* GetPointerWrite(const u32 address);
+const u8* GetPointer(const u32 address);
 bool IsRAMAddress(const u32 address);
 inline bool IsVRAMAddress(const u32 address) {
 	return ((address & 0x3F800000) == 0x04000000);
@@ -272,11 +281,11 @@ inline void MemcpyUnchecked(void *to_data, const u32 from_address, const u32 len
 }
 
 inline void MemcpyUnchecked(const u32 to_address, const void *from_data, const u32 len) {
-	memcpy(GetPointerUnchecked(to_address), from_data, len);
+	memcpy(GetPointerWriteUnchecked(to_address), from_data, len);
 }
 
 inline void MemcpyUnchecked(const u32 to_address, const u32 from_address, const u32 len) {
-	MemcpyUnchecked(GetPointer(to_address), from_address, len);
+	MemcpyUnchecked(GetPointerWrite(to_address), from_address, len);
 }
 
 inline bool IsValidAddress(const u32 address) {

--- a/Core/MemMapFunctions.cpp
+++ b/Core/MemMapFunctions.cpp
@@ -28,19 +28,19 @@
 
 namespace Memory {
 
-u8 *GetPointer(const u32 address) {
+u8 *GetPointerWrite(const u32 address) {
 	if ((address & 0x3E000000) == 0x08000000) {
 		// RAM
-		return GetPointerUnchecked(address);
+		return GetPointerWriteUnchecked(address);
 	} else if ((address & 0x3F800000) == 0x04000000) {
 		// VRAM
-		return GetPointerUnchecked(address);
+		return GetPointerWriteUnchecked(address);
 	} else if ((address & 0xBFFFC000) == 0x00010000) {
 		// Scratchpad
-		return GetPointerUnchecked(address);
+		return GetPointerWriteUnchecked(address);
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
 		// More RAM (remasters, etc.)
-		return GetPointerUnchecked(address);
+		return GetPointerWriteUnchecked(address);
 	} else {
 		static bool reported = false;
 		if (!reported) {
@@ -50,6 +50,10 @@ u8 *GetPointer(const u32 address) {
 		Core_MemoryException(address, currentMIPS->pc, MemoryExceptionType::WRITE_BLOCK);
 		return nullptr;
 	}
+}
+
+const u8 *GetPointer(const u32 address) {
+	return (const u8 *)GetPointerWrite(address);
 }
 
 template <typename T>

--- a/Core/MemMapHelpers.h
+++ b/Core/MemMapHelpers.h
@@ -31,7 +31,7 @@ namespace Memory
 {
 
 inline void Memcpy(const u32 to_address, const void *from_data, const u32 len, const char *tag, size_t tagLen) {
-	u8 *to = GetPointer(to_address);
+	u8 *to = GetPointerWrite(to_address);
 	if (to) {
 		memcpy(to, from_data, len);
 		if (!tag) {
@@ -57,7 +57,7 @@ inline void Memcpy(void *to_data, const u32 from_address, const u32 len, const c
 }
 
 inline void Memcpy(const u32 to_address, const u32 from_address, const u32 len, const char *tag, size_t tagLen) {
-	u8 *to = GetPointer(to_address);
+	u8 *to = GetPointerWrite(to_address);
 	// If not, GetPointer will log.
 	if (!to)
 		return;

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -192,7 +192,7 @@ u32 DrawEngineCommon::NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr,
 //
 // It does the simplest and safest test possible: If all points of a bbox is outside a single of
 // our clipping planes, we reject the box. Tighter bounds would be desirable but would take more calculations.
-bool DrawEngineCommon::TestBoundingBox(void* control_points, int vertexCount, u32 vertType, int *bytesRead) {
+bool DrawEngineCommon::TestBoundingBox(const void* control_points, int vertexCount, u32 vertType, int *bytesRead) {
 	SimpleVertex *corners = (SimpleVertex *)(decoded + 65536 * 12);
 	float *verts = (float *)(decoded + 65536 * 18);
 
@@ -217,7 +217,7 @@ bool DrawEngineCommon::TestBoundingBox(void* control_points, int vertexCount, u3
 		// Simplify away bones and morph before proceeding
 		u8 *temp_buffer = decoded + 65536 * 24;
 		int vertexSize = 0;
-		NormalizeVertices((u8 *)corners, temp_buffer, (u8 *)control_points, 0, vertexCount, vertType, &vertexSize);
+		NormalizeVertices((u8 *)corners, temp_buffer, (const u8 *)control_points, 0, vertexCount, vertType, &vertexSize);
 		for (int i = 0; i < vertexCount; i++) {
 			verts[i * 3] = corners[i].pos.x;
 			verts[i * 3 + 1] = corners[i].pos.y;
@@ -663,7 +663,7 @@ uint64_t DrawEngineCommon::ComputeHash() {
 }
 
 // vertTypeID is the vertex type but with the UVGen mode smashed into the top bits.
-void DrawEngineCommon::SubmitPrim(void *verts, void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead) {
+void DrawEngineCommon::SubmitPrim(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead) {
 	if (!indexGen.PrimCompatible(prevPrim_, prim) || numDrawCalls >= MAX_DEFERRED_DRAW_CALLS || vertexCountInDrawCalls_ + vertexCount > VERTEX_BUFFER_MAX) {
 		DispatchFlush();
 	}

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -69,18 +69,18 @@ public:
 	// This would seem to be unnecessary now, but is still required for splines/beziers to work in the software backend since SubmitPrim
 	// is different. Should probably refactor that.
 	// Note that vertTypeID should be computed using GetVertTypeID().
-	virtual void DispatchSubmitPrim(void *verts, void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead) {
+	virtual void DispatchSubmitPrim(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead) {
 		SubmitPrim(verts, inds, prim, vertexCount, vertTypeID, cullMode, bytesRead);
 	}
 
-	virtual void DispatchSubmitImm(void *verts, void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead) {
+	virtual void DispatchSubmitImm(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead) {
 		SubmitPrim(verts, inds, prim, vertexCount, vertTypeID, cullMode, bytesRead);
 		DispatchFlush();
 	}
 
-	bool TestBoundingBox(void* control_points, int vertexCount, u32 vertType, int *bytesRead);
+	bool TestBoundingBox(const void* control_points, int vertexCount, u32 vertType, int *bytesRead);
 
-	void SubmitPrim(void *verts, void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead);
+	void SubmitPrim(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead);
 	template<class Surface>
 	void SubmitCurve(const void *control_points, const void *indices, Surface &surface, u32 vertType, int *bytesRead, const char *scope);
 	void ClearSplineBezierWeights();
@@ -150,8 +150,8 @@ protected:
 
 	// Defer all vertex decoding to a "Flush" (except when software skinning)
 	struct DeferredDrawCall {
-		void *verts;
-		void *inds;
+		const void *verts;
+		const void *inds;
 		u32 vertexCount;
 		u8 indexType;
 		s8 prim;

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1694,7 +1694,7 @@ void FramebufferManagerCommon::ApplyClearToMemory(int x1, int y1, int x2, int y2
 		return;
 	}
 
-	u8 *addr = Memory::GetPointerUnchecked(gstate.getFrameBufAddress());
+	u8 *addr = Memory::GetPointerWriteUnchecked(gstate.getFrameBufAddress());
 	const int bpp = gstate_c.framebufFormat == GE_FORMAT_8888 ? 4 : 2;
 
 	u32 clearBits = clearColor;
@@ -2033,7 +2033,7 @@ bool FramebufferManagerCommon::GetFramebuffer(u32 fb_address, int fb_stride, GEB
 		if (!Memory::IsValidAddress(fb_address))
 			return false;
 		// If there's no vfb and we're drawing there, must be memory?
-		buffer = GPUDebugBuffer(Memory::GetPointer(fb_address), fb_stride, 512, format);
+		buffer = GPUDebugBuffer(Memory::GetPointerWriteUnchecked(fb_address), fb_stride, 512, format);
 		return true;
 	}
 
@@ -2090,7 +2090,7 @@ bool FramebufferManagerCommon::GetDepthbuffer(u32 fb_address, int fb_stride, u32
 		if (!Memory::IsValidAddress(z_address))
 			return false;
 		// If there's no vfb and we're drawing there, must be memory?
-		buffer = GPUDebugBuffer(Memory::GetPointer(z_address), z_stride, 512, GPU_DBG_FORMAT_16BIT);
+		buffer = GPUDebugBuffer(Memory::GetPointerWriteUnchecked(z_address), z_stride, 512, GPU_DBG_FORMAT_16BIT);
 		return true;
 	}
 
@@ -2128,7 +2128,7 @@ bool FramebufferManagerCommon::GetStencilbuffer(u32 fb_address, int fb_stride, G
 			return false;
 		// If there's no vfb and we're drawing there, must be memory?
 		// TODO: Actually get the stencil.
-		buffer = GPUDebugBuffer(Memory::GetPointer(fb_address), fb_stride, 512, GPU_DBG_FORMAT_8888);
+		buffer = GPUDebugBuffer(Memory::GetPointerWrite(fb_address), fb_stride, 512, GPU_DBG_FORMAT_8888);
 		return true;
 	}
 
@@ -2193,7 +2193,7 @@ void FramebufferManagerCommon::PackFramebufferSync_(VirtualFramebuffer *vfb, int
 		return;
 	}
 
-	u8 *destPtr = Memory::GetPointer(fb_address + dstByteOffset);
+	u8 *destPtr = Memory::GetPointerWriteUnchecked(fb_address + dstByteOffset);
 
 	// We always need to convert from the framebuffer native format.
 	// Right now that's always 8888.

--- a/GPU/Directx9/FramebufferManagerDX9.cpp
+++ b/GPU/Directx9/FramebufferManagerDX9.cpp
@@ -369,7 +369,7 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 					// TODO: Handle the other formats?  We don't currently create them, I think.
 					const int dstByteOffset = (y * vfb->fb_stride + x) * dstBpp;
 					// Pixel size always 4 here because we always request BGRA8888.
-					ConvertFromBGRA8888(Memory::GetPointer(fb_address + dstByteOffset), (u8 *)locked.pBits, vfb->fb_stride, locked.Pitch / 4, w, h, vfb->format);
+					ConvertFromBGRA8888(Memory::GetPointerWrite(fb_address + dstByteOffset), (u8 *)locked.pBits, vfb->fb_stride, locked.Pitch / 4, w, h, vfb->format);
 					offscreen->UnlockRect();
 				} else {
 					ERROR_LOG_REPORT(G3D, "Unable to lock rect from %08x: %d,%d %dx%d of %dx%d", fb_address, (int)rect.left, (int)rect.top, (int)rect.right, (int)rect.bottom, vfb->renderWidth, vfb->renderHeight);
@@ -464,7 +464,7 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 			if (!Memory::IsValidAddress(fb_address))
 				return false;
 			// If there's no vfb and we're drawing there, must be memory?
-			buffer = GPUDebugBuffer(Memory::GetPointer(fb_address), fb_stride, 512, fb_format);
+			buffer = GPUDebugBuffer(Memory::GetPointerWrite(fb_address), fb_stride, 512, fb_format);
 			return true;
 		}
 		LPDIRECT3DSURFACE9 renderTarget = vfb->fbo ? (LPDIRECT3DSURFACE9)draw_->GetFramebufferAPITexture(vfb->fbo, Draw::FB_COLOR_BIT | Draw::FB_SURFACE_BIT, 0) : nullptr;
@@ -541,7 +541,7 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 
 		if (!vfb) {
 			// If there's no vfb and we're drawing there, must be memory?
-			buffer = GPUDebugBuffer(Memory::GetPointer(z_address), z_stride, 512, GPU_DBG_FORMAT_16BIT);
+			buffer = GPUDebugBuffer(Memory::GetPointerWrite(z_address), z_stride, 512, GPU_DBG_FORMAT_16BIT);
 			return true;
 		}
 
@@ -579,7 +579,7 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 
 		if (!vfb) {
 			// If there's no vfb and we're drawing there, must be memory?
-			buffer = GPUDebugBuffer(Memory::GetPointer(vfb->z_address), vfb->z_stride, 512, GPU_DBG_FORMAT_16BIT);
+			buffer = GPUDebugBuffer(Memory::GetPointerWrite(vfb->z_address), vfb->z_stride, 512, GPU_DBG_FORMAT_16BIT);
 			return true;
 		}
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1677,8 +1677,8 @@ void GPUCommon::Execute_Prim(u32 op, u32 diff) {
 		return;
 	}
 
-	void *verts = Memory::GetPointerUnchecked(gstate_c.vertexAddr);
-	void *inds = nullptr;
+	const void *verts = Memory::GetPointerUnchecked(gstate_c.vertexAddr);
+	const void *inds = nullptr;
 	u32 vertexType = gstate.vertType;
 	if ((vertexType & GE_VTYPE_IDX_MASK) != GE_VTYPE_IDX_NONE) {
 		u32 indexAddr = gstate_c.indexAddr;
@@ -1886,8 +1886,8 @@ void GPUCommon::Execute_Bezier(u32 op, u32 diff) {
 		return;
 	}
 
-	void *control_points = Memory::GetPointerUnchecked(gstate_c.vertexAddr);
-	void *indices = NULL;
+	const void *control_points = Memory::GetPointerUnchecked(gstate_c.vertexAddr);
+	const void *indices = NULL;
 	if ((gstate.vertType & GE_VTYPE_IDX_MASK) != GE_VTYPE_IDX_NONE) {
 		if (!Memory::IsValidAddress(gstate_c.indexAddr)) {
 			ERROR_LOG_REPORT(G3D, "Bad index address %08x!", gstate_c.indexAddr);
@@ -1956,8 +1956,8 @@ void GPUCommon::Execute_Spline(u32 op, u32 diff) {
 		return;
 	}
 
-	void *control_points = Memory::GetPointerUnchecked(gstate_c.vertexAddr);
-	void *indices = NULL;
+	const void *control_points = Memory::GetPointerUnchecked(gstate_c.vertexAddr);
+	const void *indices = NULL;
 	if ((gstate.vertType & GE_VTYPE_IDX_MASK) != GE_VTYPE_IDX_NONE) {
 		if (!Memory::IsValidAddress(gstate_c.indexAddr)) {
 			ERROR_LOG_REPORT(G3D, "Bad index address %08x!", gstate_c.indexAddr);
@@ -2018,7 +2018,7 @@ void GPUCommon::Execute_BoundingBox(u32 op, u32 diff) {
 		return;
 	}
 	if (((count & 7) == 0) && count <= 64) {  // Sanity check
-		void *control_points = Memory::GetPointer(gstate_c.vertexAddr);
+		const void *control_points = Memory::GetPointer(gstate_c.vertexAddr);
 		if (!control_points) {
 			ERROR_LOG_REPORT_ONCE(boundingbox, G3D, "Invalid verts in bounding box check");
 			currentList->bboxResult = true;
@@ -2795,7 +2795,7 @@ void GPUCommon::DoBlockTransfer(u32 skipDrawReason) {
 			u32 srcLineStartAddr = srcBasePtr + (srcY * srcStride + srcX) * bpp;
 			u32 dstLineStartAddr = dstBasePtr + (dstY * dstStride + dstX) * bpp;
 			const u8 *src = Memory::GetPointerUnchecked(srcLineStartAddr);
-			u8 *dst = Memory::GetPointerUnchecked(dstLineStartAddr);
+			u8 *dst = Memory::GetPointerWriteUnchecked(dstLineStartAddr);
 			memcpy(dst, src, width * height * bpp);
 			GPURecord::NotifyMemcpy(dstLineStartAddr, srcLineStartAddr, width * height * bpp);
 		} else {
@@ -2804,7 +2804,7 @@ void GPUCommon::DoBlockTransfer(u32 skipDrawReason) {
 				u32 dstLineStartAddr = dstBasePtr + ((y + dstY) * dstStride + dstX) * bpp;
 
 				const u8 *src = Memory::GetPointerUnchecked(srcLineStartAddr);
-				u8 *dst = Memory::GetPointerUnchecked(dstLineStartAddr);
+				u8 *dst = Memory::GetPointerWriteUnchecked(dstLineStartAddr);
 				memcpy(dst, src, width * bpp);
 				GPURecord::NotifyMemcpy(dstLineStartAddr, srcLineStartAddr, width * bpp);
 			}

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1412,7 +1412,7 @@ bool GetCurrentTexture(GPUDebugBuffer &buffer, int level)
 
 	Sampler::FetchFunc sampler = Sampler::GetFetchFunc(id);
 
-	u8 *texptr = Memory::GetPointer(texaddr);
+	u8 *texptr = Memory::GetPointerWrite(texaddr);
 	u32 *row = (u32 *)buffer.GetData();
 	for (int y = 0; y < h; ++y) {
 		for (int x = 0; x < w; ++x) {

--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -40,7 +40,7 @@ struct RasterizerState {
 	Sampler::NearestFunc nearest;
 	uint32_t texaddr[8]{};
 	int texbufw[8]{};
-	u8 *texptr[8]{};
+	const u8 *texptr[8]{};
 	float textureLodSlope;
 	int screenOffsetX;
 	int screenOffsetY;

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -65,12 +65,12 @@ void SoftwareDrawEngine::DispatchFlush() {
 	transformUnit.Flush("debug");
 }
 
-void SoftwareDrawEngine::DispatchSubmitPrim(void *verts, void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead) {
+void SoftwareDrawEngine::DispatchSubmitPrim(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead) {
 	_assert_msg_(cullMode == gstate.getCullMode(), "Mixed cull mode not supported.");
 	transformUnit.SubmitPrimitive(verts, inds, prim, vertexCount, vertTypeID, bytesRead, this);
 }
 
-void SoftwareDrawEngine::DispatchSubmitImm(void *verts, void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead) {
+void SoftwareDrawEngine::DispatchSubmitImm(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead) {
 	_assert_msg_(cullMode == gstate.getCullMode(), "Mixed cull mode not supported.");
 	// TODO: For now, just setting all dirty.
 	transformUnit.SetDirty(SoftDirty(-1));
@@ -449,7 +449,7 @@ enum class CullType {
 	OFF,
 };
 
-void TransformUnit::SubmitPrimitive(void* vertices, void* indices, GEPrimitiveType prim_type, int vertex_count, u32 vertex_type, int *bytesRead, SoftwareDrawEngine *drawEngine)
+void TransformUnit::SubmitPrimitive(const void* vertices, const void* indices, GEPrimitiveType prim_type, int vertex_count, u32 vertex_type, int *bytesRead, SoftwareDrawEngine *drawEngine)
 {
 	VertexDecoder &vdecoder = *drawEngine->FindVertexDecoder(vertex_type);
 	const DecVtxFormat &vtxfmt = vdecoder.GetDecVtxFmt();

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -118,7 +118,7 @@ public:
 	}
 	static ScreenCoords DrawingToScreen(const DrawingCoords &coords, u16 z);
 
-	void SubmitPrimitive(void* vertices, void* indices, GEPrimitiveType prim_type, int vertex_count, u32 vertex_type, int *bytesRead, SoftwareDrawEngine *drawEngine);
+	void SubmitPrimitive(const void* vertices, const void* indices, GEPrimitiveType prim_type, int vertex_count, u32 vertex_type, int *bytesRead, SoftwareDrawEngine *drawEngine);
 
 	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices);
 
@@ -144,8 +144,8 @@ public:
 	~SoftwareDrawEngine();
 
 	void DispatchFlush() override;
-	void DispatchSubmitPrim(void *verts, void *inds, GEPrimitiveType prim, int vertexCount, u32 vertType, int cullMode, int *bytesRead) override;
-	void DispatchSubmitImm(void *verts, void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead) override;
+	void DispatchSubmitPrim(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, u32 vertType, int cullMode, int *bytesRead) override;
+	void DispatchSubmitImm(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead) override;
 
 	VertexDecoder *FindVertexDecoder(u32 vtype);
 

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -779,7 +779,7 @@ std::vector<u32> CtrlMemView::searchString(const std::string &searchQuery) {
 				return searchResAddrs;
 			}
 
-			u8 *ptr = Memory::GetPointerUnchecked(pos);
+			const u8 *ptr = Memory::GetPointerUnchecked(pos);
 			if (memcmp(ptr, searchData.data(), searchData.size()) == 0) {
 				searchResAddrs.push_back(pos);
 			}
@@ -798,7 +798,7 @@ void CtrlMemView::search(bool continueSearch)
 	u32 searchAddress = 0;
 	u32 segmentStart = 0;
 	u32 segmentEnd = 0;
-	u8* dataPointer = 0;
+	const u8* dataPointer = 0;
 	if (continueSearch == false || searchQuery.empty())
 	{
 		if (InputBox_GetString(GetModuleHandle(NULL), wnd, L"Search for", searchQuery, searchQuery) == false)

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1409,7 +1409,7 @@ bool retro_unserialize(const void *data, size_t size)
 void *retro_get_memory_data(unsigned id)
 {
    if ( id == RETRO_MEMORY_SYSTEM_RAM )
-      return Memory::GetPointerUnchecked(PSP_GetKernelMemoryBase()) ;
+      return Memory::GetPointerWriteUnchecked(PSP_GetKernelMemoryBase()) ;
    return NULL;
 }
 


### PR DESCRIPTION
GetPointer now returns a const u8*, use GetPointerWrite instead when you really intend to write to memory.

Just a small step towards better memory handling that I've wanted to get in for a while. Lots more to do later (like more use of IsValidAddressRange instead of IsValidAddress, find a way to enforce checking IsValidAddressRange before GetPointer, etc).

A lot of it can be improved, there are uses of GetPointerWrite that should not be necessary here and there. Easier to find them now though...