### PR TITLE
Remove bool that was always true in state mapping.

### DIFF
--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -592,7 +592,6 @@ void ConvertViewportAndScissor(bool useBufferedRendering, float renderWidth, flo
 	int scissorX2 = gstate.getScissorX2() + 1;
 	int scissorY2 = gstate.getScissorY2() + 1;
 
-	out.scissorEnable = true;
 	if (scissorX2 < scissorX1 || scissorY2 < scissorY1) {
 		out.scissorX = 0;
 		out.scissorY = 0;

--- a/GPU/Common/GPUStateUtils.h
+++ b/GPU/Common/GPUStateUtils.h
@@ -65,7 +65,6 @@ LogicOpReplaceType ReplaceLogicOpType();
 
 // Common representation, should be able to set this directly with any modern API.
 struct ViewportAndScissor {
-	bool scissorEnable;
 	int scissorX;
 	int scissorY;
 	int scissorW;

--- a/GPU/D3D11/StateMappingD3D11.cpp
+++ b/GPU/D3D11/StateMappingD3D11.cpp
@@ -393,17 +393,10 @@ void DrawEngineD3D11::ApplyDrawState(int prim) {
 		}
 
 		D3D11_RECT &scissor = dynState_.scissor;
-		if (vpAndScissor.scissorEnable) {
-			scissor.left = vpAndScissor.scissorX;
-			scissor.top = vpAndScissor.scissorY;
-			scissor.right = vpAndScissor.scissorX + std::max(0, vpAndScissor.scissorW);
-			scissor.bottom = vpAndScissor.scissorY + std::max(0, vpAndScissor.scissorH);
-		} else {
-			scissor.left = 0;
-			scissor.top = 0;
-			scissor.right = framebufferManager_->GetRenderWidth();
-			scissor.bottom = framebufferManager_->GetRenderHeight();
-		}
+		scissor.left = vpAndScissor.scissorX;
+		scissor.top = vpAndScissor.scissorY;
+		scissor.right = vpAndScissor.scissorX + std::max(0, vpAndScissor.scissorW);
+		scissor.bottom = vpAndScissor.scissorY + std::max(0, vpAndScissor.scissorH);
 	}
 
 	if (gstate_c.IsDirty(DIRTY_TEXTURE_IMAGE | DIRTY_TEXTURE_PARAMS) && !gstate.isModeClear() && gstate.isTextureMapEnabled()) {

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -239,12 +239,8 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 			framebufferManager_->GetTargetBufferWidth(), framebufferManager_->GetTargetBufferHeight(),
 			vpAndScissor);
 
-		if (vpAndScissor.scissorEnable) {
-			dxstate.scissorTest.enable();
-			dxstate.scissorRect.set(vpAndScissor.scissorX, vpAndScissor.scissorY, vpAndScissor.scissorX + vpAndScissor.scissorW, vpAndScissor.scissorY + vpAndScissor.scissorH);
-		} else {
-			dxstate.scissorTest.disable();
-		}
+		dxstate.scissorTest.enable();
+		dxstate.scissorRect.set(vpAndScissor.scissorX, vpAndScissor.scissorY, vpAndScissor.scissorX + vpAndScissor.scissorW, vpAndScissor.scissorY + vpAndScissor.scissorH);
 
 		float depthMin = vpAndScissor.depthRangeMin;
 		float depthMax = vpAndScissor.depthRangeMax;

--- a/GPU/Vulkan/StateMappingVulkan.cpp
+++ b/GPU/Vulkan/StateMappingVulkan.cpp
@@ -347,17 +347,10 @@ void DrawEngineVulkan::ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManag
 		}
 
 		ScissorRect &scissor = dynState.scissor;
-		if (vpAndScissor.scissorEnable) {
-			scissor.x = vpAndScissor.scissorX;
-			scissor.y = vpAndScissor.scissorY;
-			scissor.width = std::max(0, vpAndScissor.scissorW);
-			scissor.height = std::max(0, vpAndScissor.scissorH);
-		} else {
-			scissor.x = 0;
-			scissor.y = 0;
-			scissor.width = framebufferManager_->GetRenderWidth();
-			scissor.height = framebufferManager_->GetRenderHeight();
-		}
+		scissor.x = vpAndScissor.scissorX;
+		scissor.y = vpAndScissor.scissorY;
+		scissor.width = std::max(0, vpAndScissor.scissorW);
+		scissor.height = std::max(0, vpAndScissor.scissorH);
 	}
 }
 


### PR DESCRIPTION
Simple cleanup. We removed the use of the scissor test flag when we added the Vulkan backend because it has no way to disable scissor...