### PR TITLE
Reporting: Avoid crash if socket connect fails

### DIFF
--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -280,9 +280,11 @@ namespace Reporting
 			return false;
 
 		if (http.Resolve(serverHost, ServerPort())) {
-			http.Connect();
-			int result = http.POST(http::RequestParams(uri), data, mimeType, output, &progress);
-			http.Disconnect();
+			int result = -1;
+			if (http.Connect()) {
+				result = http.POST(http::RequestParams(uri), data, mimeType, output, &progress);
+				http.Disconnect();
+			}
 
 			return result >= 200 && result < 300;
 		} else {


### PR DESCRIPTION
Oops.  FD_SET() was crashing because sock was negative.

(setting this to v1.13.1, but if there's nothing major we can just reassign to v1.14.0.)

-[Unknown]