### PR TITLE
Fix bug in blue-to-alpha - alpha blending could be on when it shouldn't be.

### DIFF
--- a/Common/Render/Text/draw_text_android.cpp
+++ b/Common/Render/Text/draw_text_android.cpp
@@ -77,6 +77,12 @@ std::string TextDrawerAndroid::NormalizeString(std::string str) {
 }
 
 void TextDrawerAndroid::MeasureString(const char *str, size_t len, float *w, float *h) {
+	if (!str) {
+		*w = 0.0;
+		*h = 0.0;
+		return;
+	}
+
 	CacheKey key{ std::string(str, len), fontHash_ };
 	TextMeasureEntry *entry;
 	auto iter = sizeCache_.find(key);

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -1089,9 +1089,12 @@ void ConvertBlendState(GenericBlendState &blendState, bool allowFramebufferRead,
 
 	case REPLACE_BLEND_BLUE_TO_ALPHA:
 		blueToAlpha = true;
+		blendState.enabled = gstate.isAlphaBlendEnabled();
+		// We'll later convert the color blend to blend in the alpha channel.
 		break;
 
 	case REPLACE_BLEND_COPY_FBO:
+		blendState.enabled = true;
 		blendState.applyFramebufferRead = true;
 		blendState.resetFramebufferRead = false;
 		blendState.replaceAlphaWithStencil = replaceAlphaWithStencil;
@@ -1099,16 +1102,17 @@ void ConvertBlendState(GenericBlendState &blendState, bool allowFramebufferRead,
 
 	case REPLACE_BLEND_PRE_SRC:
 	case REPLACE_BLEND_PRE_SRC_2X_ALPHA:
+		blendState.enabled = true;
 		usePreSrc = true;
 		break;
 
 	case REPLACE_BLEND_STANDARD:
 	case REPLACE_BLEND_2X_ALPHA:
 	case REPLACE_BLEND_2X_SRC:
+		blendState.enabled = true;
 		break;
 	}
 
-	blendState.enabled = true;
 	blendState.resetFramebufferRead = true;
 
 	const GEBlendMode blendFuncEq = gstate.getBlendEq();

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1102,6 +1102,7 @@ NPEH00029 = true
 ULUS10455 = true
 
 [BlueToAlpha]
+# Split/Second
 ULES01402 = true
 ULUS10513 = true
 ULJM05812 = true


### PR DESCRIPTION
Fixes #15732. (Split/Second environment mapping problem in the menu).

Also sneaks in a safety check and a comment.