### PR TITLE
Add confirmation dialog when generating a new Mac address

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1637,7 +1637,17 @@ UI::EventReturn GameSettingsScreen::OnChangeproAdhocServerAddress(UI::EventParam
 }
 
 UI::EventReturn GameSettingsScreen::OnChangeMacAddress(UI::EventParams &e) {
-	g_Config.sMACAddress = CreateRandMAC();
+	auto n = GetI18NCategory("Networking");
+	auto di = GetI18NCategory("Dialog");
+
+	auto confirmScreen = new PromptScreen(
+		n->T("Change Mac Address"), di->T("Yes"), di->T("No"),
+		[&](bool success) {
+		if (success) {
+			g_Config.sMACAddress = CreateRandMAC();
+		}}
+	);
+	screenManager()->push(confirmScreen);
 
 	return UI::EVENT_DONE;
 }


### PR DESCRIPTION
This is just to quickly patch over the horrible usability issue (since changing the mac address can invalidate some save games, having it happen automatically by just clicking this setting is not great), while not needing any new translated strings. Will make the confirmation box nicer sometime after the 1.13.x release process.