### PR TITLE
Replacement: Clear cache on disable

### DIFF
--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -859,6 +859,8 @@ bool ReplacedTexture::IsReady(double budget) {
 		return false;
 
 	if (g_Config.bReplaceTexturesAllowLate) {
+		if (threadWaitable_)
+			delete threadWaitable_;
 		threadWaitable_ = new LimitedWaitable();
 		g_threadManager.EnqueueTask(new ReplacedTextureTask(*this, threadWaitable_));
 

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -62,6 +62,7 @@ void TextureReplacer::Init() {
 void TextureReplacer::NotifyConfigChanged() {
 	gameID_ = g_paramSFO.GetDiscID();
 
+	bool wasEnabled = enabled_;
 	enabled_ = g_Config.bReplaceTextures || g_Config.bSaveNewTextures;
 	if (enabled_) {
 		basePath_ = GetSysDirectory(DIRECTORY_TEXTURES) / gameID_;
@@ -75,6 +76,8 @@ void TextureReplacer::NotifyConfigChanged() {
 		}
 
 		enabled_ = File::Exists(basePath_) && File::IsDirectory(basePath_);
+	} else if (wasEnabled) {
+		Decimate(ReplacerDecimateMode::ALL);
 	}
 
 	if (enabled_) {
@@ -698,9 +701,14 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 	savedCache_[replacementKey] = std::make_pair(saved, now);
 }
 
-void TextureReplacer::Decimate(bool forcePressure) {
+void TextureReplacer::Decimate(ReplacerDecimateMode mode) {
 	// Allow replacements to be cached for a long time, although they're large.
-	const double age = forcePressure ? 90.0 : 1800.0;
+	double age = 1800.0;
+	if (mode == ReplacerDecimateMode::FORCE_PRESSURE)
+		age = 90.0;
+	else if (mode == ReplacerDecimateMode::ALL)
+		age = 0.0;
+
 	const double threshold = time_now_d() - age;
 	for (auto &item : cache_) {
 		item.second.PurgeIfOlder(threshold);

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -188,6 +188,12 @@ struct ReplacedTextureDecodeInfo {
 	ReplacedTextureFormat fmt;
 };
 
+enum class ReplacerDecimateMode {
+	NEW_FRAME,
+	FORCE_PRESSURE,
+	ALL,
+};
+
 class TextureReplacer {
 public:
 	TextureReplacer();
@@ -214,7 +220,7 @@ public:
 	// Notify that a new texture was decoded.  May already be upscaled, saves the data passed.
 	void NotifyTextureDecoded(const ReplacedTextureDecodeInfo &replacedInfo, const void *data, int pitch, int level, int w, int h);
 
-	void Decimate(bool forcePressure);
+	void Decimate(ReplacerDecimateMode mode);
 
 	static bool GenerateIni(const std::string &gameID, Path &generatedFilename);
 	static bool IniExists(const std::string &gameID);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -743,7 +743,7 @@ void TextureCacheCommon::Decimate(bool forcePressure) {
 	}
 
 	DecimateVideos();
-	replacer_.Decimate(forcePressure);
+	replacer_.Decimate(forcePressure ? ReplacerDecimateMode::FORCE_PRESSURE : ReplacerDecimateMode::NEW_FRAME);
 }
 
 void TextureCacheCommon::DecimateVideos() {


### PR DESCRIPTION
I didn't test this carefully as far as reloading, but this should make it easier to reload texture replacements.

-[Unknown]