### PR TITLE
TextureCache "BuildTexture" refactor and cleanup

### DIFF
--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -376,9 +376,9 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps, bool ski
 				boundTexture = tex->texture;
 			}
 			if (!gl_extensions.IsGLES || gl_extensions.GLES3) {
-				glTexParameteri(tex->target, GL_TEXTURE_MAX_LEVEL, step.texture_finalize.maxLevel);
+				glTexParameteri(tex->target, GL_TEXTURE_MAX_LEVEL, step.texture_finalize.loadedLevels - 1);
 			}
-			tex->maxLod = (float)step.texture_finalize.maxLevel;
+			tex->maxLod = (float)step.texture_finalize.loadedLevels - 1;
 			if (step.texture_finalize.genMips) {
 				glGenerateMipmap(tex->target);
 			}

--- a/Common/GPU/OpenGL/GLQueueRunner.h
+++ b/Common/GPU/OpenGL/GLQueueRunner.h
@@ -267,7 +267,7 @@ struct GLRInitStep {
 		} texture_image;
 		struct {
 			GLRTexture *texture;
-			int maxLevel;
+			int loadedLevels;
 			bool genMips;
 		} texture_finalize;
 	};

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -565,10 +565,10 @@ public:
 		curRenderStep_->commands.push_back(_data);
 	}
 
-	void FinalizeTexture(GLRTexture *texture, int maxLevels, bool genMips) {
+	void FinalizeTexture(GLRTexture *texture, int loadedLevels, bool genMips) {
 		GLRInitStep step{ GLRInitStepType::TEXTURE_FINALIZE };
 		step.texture_finalize.texture = texture;
-		step.texture_finalize.maxLevel = maxLevels;
+		step.texture_finalize.loadedLevels = loadedLevels;
 		step.texture_finalize.genMips = genMips;
 		initSteps_.push_back(step);
 	}

--- a/Common/GPU/Vulkan/VulkanImage.cpp
+++ b/Common/GPU/Vulkan/VulkanImage.cpp
@@ -155,6 +155,7 @@ void VulkanTexture::ClearMip(VkCommandBuffer cmd, int mip, uint32_t value) {
 // Low-quality mipmap generation by bilinear blit, but works okay.
 void VulkanTexture::GenerateMips(VkCommandBuffer cmd, int firstMipToGenerate, bool fromCompute) {
 	_assert_msg_(firstMipToGenerate > 0, "Cannot generate the first level");
+	_assert_msg_(firstMipToGenerate < numMips_, "Can't generate levels beyond storage");
 
 	// Transition the pre-set levels to GENERAL.
 	TransitionImageLayout2(cmd, image_, 0, firstMipToGenerate, VK_IMAGE_ASPECT_COLOR_BIT,

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -845,8 +845,8 @@ void ReplacedTexture::Prepare() {
 	if (cancelPrepare_)
 		return;
 
-	levelData_.resize(MaxLevel() + 1);
-	for (int i = 0; i <= MaxLevel(); ++i) {
+	levelData_.resize(NumLevels());
+	for (int i = 0; i < NumLevels(); ++i) {
 		if (cancelPrepare_)
 			break;
 		PrepareData(i);

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -60,8 +60,7 @@ struct ReplacementCacheKey {
 	u64 cachekey;
 	u32 hash;
 
-	ReplacementCacheKey(u64 c, u32 h) : cachekey(c), hash(h) {
-	}
+	ReplacementCacheKey(u64 c, u32 h) : cachekey(c), hash(h) { }
 
 	bool operator ==(const ReplacementCacheKey &k) const {
 		return k.cachekey == cachekey && k.hash == hash;
@@ -85,8 +84,7 @@ struct ReplacementAliasKey {
 		};
 	};
 
-	ReplacementAliasKey(u64 c, u32 h, u32 l) : cachekey(c), level(l), hash(h) {
-	}
+	ReplacementAliasKey(u64 c, u32 h, u32 l) : cachekey(c), level(l), hash(h) { }
 
 	bool operator ==(const ReplacementAliasKey &k) const {
 		return k.cachekey == cachekey && k.hashAndLevel == hashAndLevel;
@@ -119,11 +117,11 @@ namespace std {
 struct ReplacedTexture {
 	~ReplacedTexture();
 
-	inline bool Valid() {
+	inline bool Valid() const {
 		return !levels_.empty();
 	}
 
-	bool GetSize(int level, int &w, int &h) {
+	bool GetSize(int level, int &w, int &h) const {
 		if ((size_t)level < levels_.size()) {
 			w = levels_[level].w;
 			h = levels_[level].h;
@@ -132,18 +130,18 @@ struct ReplacedTexture {
 		return false;
 	}
 
-	int MaxLevel() {
-		return (int)levels_.size() - 1;
+	int NumLevels() const {
+		return (int)levels_.size();
 	}
 
-	Draw::DataFormat Format(int level) {
+	Draw::DataFormat Format(int level) const {
 		if ((size_t)level < levels_.size()) {
 			return levels_[level].fmt;
 		}
 		return Draw::DataFormat::R8G8B8A8_UNORM;
 	}
 
-	u8 AlphaStatus() {
+	u8 AlphaStatus() const {
 		return (u8)alphaStatus_;
 	}
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2099,14 +2099,17 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 		plan.maxLevel = 0;
 	}
 
+	plan.levels = plan.scaleFactor == 1 ? (plan.maxLevel + 1) : 1;
+
 	// Always load base level texture here 
 	plan.srcLevel = 0;
 	if (IsFakeMipmapChange()) {
 		// NOTE: Since the level is not part of the cache key, we assume it never changes.
 		plan.srcLevel = std::max(0, gstate.getTexLevelOffset16() / 16);
+		plan.levels = 1;
 	}
 
-	if (plan.maxLevel == 0) {
+	if (plan.levels == 1) {
 		entry->status |= TexCacheEntry::STATUS_BAD_MIPS;
 	} else {
 		entry->status &= ~TexCacheEntry::STATUS_BAD_MIPS;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -757,9 +757,9 @@ void TextureCacheCommon::DecimateVideos() {
 	}
 }
 
-bool TextureCacheCommon::IsVideo(u32 texaddr) {
+bool TextureCacheCommon::IsVideo(u32 texaddr) const {
 	texaddr &= 0x3FFFFFFF;
-	for (auto info : videos_) {
+	for (auto &info : videos_) {
 		if (texaddr < info.addr) {
 			continue;
 		}
@@ -2104,7 +2104,7 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 		}
 	}
 
-	bool isVideo = IsVideo(entry->addr);
+	plan.isVideo = IsVideo(entry->addr);
 
 	// TODO: Support reading actual mip levels for upscaled images, instead of just generating them.
 	// Maybe can just remove this check?
@@ -2113,7 +2113,7 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 
 		bool enableVideoUpscaling = false;
 
-		if (!enableVideoUpscaling && isVideo) {
+		if (!enableVideoUpscaling && plan.isVideo) {
 			plan.scaleFactor = 1;
 			plan.levelsToCreate = 1;
 		}

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -240,14 +240,12 @@ struct BuildTexturePlan {
 	// However, we still respect baseLevelSrc.
 	bool badMipSizes;
 
-	// Set if we can autogenerate mipmaps. Probably redundant.
-	bool canAutoGen;
+	// Number of mip levels to load from PSP memory (or replacement).
+	int levelsToLoad;
 
-	// Highest index of a level to load.
-	int maxLevelToLoad;
-
-	// The number of levels in total to create. If more than maxLevelToLoad,
-	// the backend is expected to either generate the levels, or limit itself to maxLevelToLoad.
+	// The number of levels in total to create.
+	// If greater than maxLevelToLoad, the backend is expected to either generate
+	// the missing levels, or limit itself to levelsToLoad levels.
 	int levelsToCreate;
 
 	// Load the 0-mip from this PSP texture level instead of 0.

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -255,6 +255,9 @@ struct BuildTexturePlan {
 	// The scale factor of the final texture.
 	int scaleFactor;
 
+	// Whether it's a video texture or not. Some decisions might depend on this.
+	bool isVideo;
+
 	// Unscaled size of the 0-mip of the original texture.
 	// Don't really need to have it here, but convenient.
 	int w;
@@ -344,7 +347,7 @@ protected:
 	void SetTextureFramebuffer(const AttachCandidate &candidate);
 
 	void DecimateVideos();
-	bool IsVideo(u32 texaddr);
+	bool IsVideo(u32 texaddr) const;
 
 	inline u32 QuickTexHash(TextureReplacer &replacer, u32 addr, int bufw, int w, int h, GETextureFormat format, TexCacheEntry *entry) const {
 		if (replacer.Enabled()) {

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -129,7 +129,7 @@ struct TexCacheEntry {
 		// texture, and set this flag to allow scaling the texture just once for the new hash.
 		STATUS_FREE_CHANGE = 0x0400,   // Allow one change before marking "frequent".
 
-		STATUS_BAD_MIPS = 0x0800,      // Has bad or unusable mipmap levels.
+		STATUS_NO_MIPS = 0x0800,      // Has bad or unusable mipmap levels.
 
 		STATUS_FRAMEBUFFER_OVERLAP = 0x1000,
 
@@ -234,15 +234,35 @@ struct BuildTexturePlan {
 	bool hardwareScaling = false;
 	bool slowScaler = true;
 
+	// Set if the PSP software specified an unusual mip chain,
+	// such as the same size throughout, or anything else that doesn't divide by
+	// two on each level. If this is set, we won't generate mips nor use any.
+	// However, we still respect baseLevelSrc.
 	bool badMipSizes;
+
+	// Set if we can autogenerate mipmaps. Probably redundant.
 	bool canAutoGen;
-	int maxLevel;
-	int maxLevelToGenerate;
-	int levels;
-	int srcLevel;
+
+	// Highest index of a level to load.
+	int maxLevelToLoad;
+
+	// The number of levels in total to create. If more than maxLevelToLoad,
+	// the backend is expected to either generate the levels, or limit itself to maxLevelToLoad.
+	int levelsToCreate;
+
+	// Load the 0-mip from this PSP texture level instead of 0.
+	// If non-zero, we are only loading one level.
+	int baseLevelSrc;
+
+	// The scale factor of the final texture.
 	int scaleFactor;
+
+	// Unscaled size of the 0-mip of the original texture.
+	// Don't really need to have it here, but convenient.
 	int w;
 	int h;
+
+	// The replacement for the texture.
 	ReplacedTexture *replaced;
 };
 

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -230,11 +230,16 @@ struct AttachCandidate {
 class FramebufferManagerCommon;
 
 struct BuildTexturePlan {
+	// Inputs
+	bool hardwareScaling = false;
+	bool slowScaler = true;
+
 	bool badMipSizes;
 	bool canAutoGen;
 	int maxLevel;
-	int srcLevel;
+	int maxLevelToGenerate;
 	int levels;
+	int srcLevel;
 	int scaleFactor;
 	int w;
 	int h;
@@ -398,6 +403,7 @@ protected:
 	u16 clutAlphaLinearColor_;
 
 	int standardScaleFactor_;
+	int shaderScaleFactor_ = 0;
 
 	const char *nextChangeReason_;
 	bool nextNeedsRehash_;

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -229,6 +229,17 @@ struct AttachCandidate {
 
 class FramebufferManagerCommon;
 
+struct BuildTexturePlan {
+	bool badMipSizes;
+	bool canAutoGen;
+	int maxLevel;
+	int srcLevel;
+	int scaleFactor;
+	int w;
+	int h;
+	ReplacedTexture *replaced;
+};
+
 class TextureCacheCommon {
 public:
 	TextureCacheCommon(Draw::DrawContext *draw);
@@ -270,6 +281,8 @@ public:
 	virtual bool GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) { return false; }
 
 protected:
+	bool PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEntry *entry);
+
 	virtual void BindTexture(TexCacheEntry *entry) = 0;
 	virtual void Unbind() = 0;
 	virtual void ReleaseTexture(TexCacheEntry *entry, bool delete_them) = 0;

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -234,6 +234,7 @@ struct BuildTexturePlan {
 	bool canAutoGen;
 	int maxLevel;
 	int srcLevel;
+	int levels;
 	int scaleFactor;
 	int w;
 	int h;

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -518,15 +518,14 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 		maxLevel = 0;
 	}
 
-	DXGI_FORMAT dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
-
+	int level = 0;
 	if (IsFakeMipmapChange()) {
 		// NOTE: Since the level is not part of the cache key, we assume it never changes.
-		u8 level = std::max(0, gstate.getTexLevelOffset16() / 16);
-		LoadTextureLevel(*entry, replaced, level, maxLevel, scaleFactor, dstFmt);
-	} else {
-		LoadTextureLevel(*entry, replaced, 0, maxLevel, scaleFactor, dstFmt);
+		level = std::max(0, gstate.getTexLevelOffset16() / 16);
 	}
+
+	DXGI_FORMAT dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
+	LoadTextureLevel(*entry, replaced, level, maxLevel, scaleFactor, dstFmt);
 
 	ID3D11ShaderResourceView *textureView = DxView(entry);
 	if (!textureView) {

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -454,7 +454,8 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 		return;
 	}
 
-	int tw = plan.w, th = plan.h;
+	int tw = plan.w;
+	int th = plan.h;
 
 	DXGI_FORMAT dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
 	ID3D11ShaderResourceView *view;

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -527,7 +527,6 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 		}
 	}
 
-	// Seems to cause problems in Tactics Ogre.
 	if (badMipSizes) {
 		maxLevel = 0;
 	}
@@ -575,11 +574,6 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 	entry->textureView = view;
 
 	LoadTextureLevel(*entry, replaced, srcLevel, 0, maxLevel, scaleFactor, dstFmt);
-
-	ID3D11ShaderResourceView *textureView = DxView(entry);
-	if (!textureView) {
-		return;
-	}
 
 	// Mipmapping is only enabled when texture scaling is disabled.
 	if (maxLevel > 0 && scaleFactor == 1) {

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -644,8 +644,6 @@ void TextureCacheD3D11::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &
 	int w = gstate.getTextureWidth(srcLevel);
 	int h = gstate.getTextureHeight(srcLevel);
 
-	ID3D11Texture2D *texture = DxTex(&entry);
-
 	gpuStats.numTexturesDecoded++;
 	// For UpdateSubresource, we can't decode directly into the texture so we allocate a buffer :(
 	u32 *mapData = nullptr;
@@ -656,7 +654,6 @@ void TextureCacheD3D11::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &
 		double replaceStart = time_now_d();
 		replaced.Load(srcLevel, mapData, mapRowPitch);
 		replacementTimeThisFrame_ += time_now_d() - replaceStart;
-		dstFmt = ToDXGIFormat(replaced.Format(srcLevel));
 	} else {
 		GETextureFormat tfmt = (GETextureFormat)entry.format;
 		GEPaletteFormat clutformat = gstate.getClutPaletteFormat();
@@ -725,6 +722,7 @@ void TextureCacheD3D11::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &
 		}
 	}
 
+	ID3D11Texture2D *texture = DxTex(&entry);
 	context_->UpdateSubresource(texture, dstLevel, nullptr, mapData, mapRowPitch, 0);
 	FreeAlignedMemory(mapData);
 }

--- a/GPU/D3D11/TextureCacheD3D11.h
+++ b/GPU/D3D11/TextureCacheD3D11.h
@@ -68,7 +68,7 @@ protected:
 	void ReleaseTexture(TexCacheEntry *entry, bool delete_them) override;
 
 private:
-	void LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int level, int maxLevel, int scaleFactor, DXGI_FORMAT dstFmt);
+	void LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int srcLevel, int dstLevel, int maxLevel, int scaleFactor, DXGI_FORMAT dstFmt);
 	DXGI_FORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
 	static CheckAlphaResult CheckAlpha(const u32 *pixelData, u32 dstFmt, int w);
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;

--- a/GPU/D3D11/TextureCacheD3D11.h
+++ b/GPU/D3D11/TextureCacheD3D11.h
@@ -68,7 +68,7 @@ protected:
 	void ReleaseTexture(TexCacheEntry *entry, bool delete_them) override;
 
 private:
-	void LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int srcLevel, int dstLevel, int maxLevel, int scaleFactor, DXGI_FORMAT dstFmt);
+	void LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int srcLevel, int dstLevel, int scaleFactor, DXGI_FORMAT dstFmt);
 	DXGI_FORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
 	static CheckAlphaResult CheckAlpha(const u32 *pixelData, u32 dstFmt, int w);
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -463,6 +463,7 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 	// Don't scale the PPGe texture.
 	if (entry->addr > 0x05000000 && entry->addr < PSP_GetKernelMemoryEnd())
 		scaleFactor = 1;
+
 	if ((entry->status & TexCacheEntry::STATUS_CHANGE_FREQUENT) != 0 && scaleFactor != 1) {
 		// Remember for later that we /wanted/ to scale this texture.
 		entry->status |= TexCacheEntry::STATUS_TO_SCALE;

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -428,7 +428,10 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 		}
 	}
 
-	HRESULT hr = device_->CreateTexture(tw, th, plan.levelsToCreate, usage, tfmt, pool, &texture, NULL);
+	// We don't yet have mip generation, so clamp the number of levels to the ones we can load directly.
+	int levels = std::min(plan.levelsToCreate, plan.levelsToLoad);
+
+	HRESULT hr = device_->CreateTexture(tw, th, levels, usage, tfmt, pool, &texture, NULL);
 
 	if (FAILED(hr)) {
 		INFO_LOG(G3D, "Failed to create D3D texture: %dx%d", tw, th);
@@ -442,7 +445,7 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 	}
 
 	// Mipmapping is only enabled when texture scaling is disabled.
-	for (int i = 0; i < plan.levelsToCreate; i++) {
+	for (int i = 0; i < levels; i++) {
 		int dstLevel = i;
 		HRESULT result;
 		uint32_t lockFlag = dstLevel == 0 ? D3DLOCK_DISCARD : 0;  // Can only discard the top level

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -210,7 +210,7 @@ void TextureCacheDX9::BindTexture(TexCacheEntry *entry) {
 		device_->SetTexture(0, texture);
 		lastBoundTexture = texture;
 	}
-	int maxLevel = (entry->status & TexCacheEntry::STATUS_BAD_MIPS) ? 0 : entry->maxLevel;
+	int maxLevel = (entry->status & TexCacheEntry::STATUS_NO_MIPS) ? 0 : entry->maxLevel;
 	SamplerCacheKey samplerKey = GetSamplingParams(maxLevel, entry);
 	ApplySamplingParams(samplerKey);
 }
@@ -418,8 +418,8 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 	D3DPOOL pool = D3DPOOL_DEFAULT;
 	D3DFORMAT tfmt = (D3DFORMAT)(dstFmt);
 	int usage = D3DUSAGE_DYNAMIC;
-	if (plan.replaced->GetSize(plan.srcLevel, tw, th)) {
-		tfmt = ToD3D9Format(plan.replaced->Format(plan.srcLevel));
+	if (plan.replaced->GetSize(plan.baseLevelSrc, tw, th)) {
+		tfmt = ToD3D9Format(plan.replaced->Format(plan.baseLevelSrc));
 	} else {
 		tw *= plan.scaleFactor;
 		th *= plan.scaleFactor;
@@ -428,7 +428,7 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 		}
 	}
 
-	HRESULT hr = device_->CreateTexture(tw, th, plan.levels, usage, tfmt, pool, &texture, NULL);
+	HRESULT hr = device_->CreateTexture(tw, th, plan.levelsToCreate, usage, tfmt, pool, &texture, NULL);
 
 	if (FAILED(hr)) {
 		INFO_LOG(G3D, "Failed to create D3D texture: %dx%d", tw, th);
@@ -442,7 +442,7 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 	}
 
 	// Mipmapping is only enabled when texture scaling is disabled.
-	for (int i = 0; i < plan.levels; i++) {
+	for (int i = 0; i < plan.levelsToCreate; i++) {
 		int dstLevel = i;
 		HRESULT result;
 		uint32_t lockFlag = dstLevel == 0 ? D3DLOCK_DISCARD : 0;  // Can only discard the top level
@@ -456,7 +456,7 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 		uint8_t *data = (uint8_t *)rect.pBits;
 		int stride = rect.Pitch;
 
-		LoadTextureLevel(*entry, data, stride, *plan.replaced, (i == 0) ? plan.srcLevel : i, plan.scaleFactor, dstFmt);
+		LoadTextureLevel(*entry, data, stride, *plan.replaced, (i == 0) ? plan.baseLevelSrc : i, plan.scaleFactor, dstFmt);
 
 		texture->UnlockRect(dstLevel);
 	}

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -598,7 +598,6 @@ void TextureCacheDX9::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, int 
 		double replaceStart = time_now_d();
 		replaced.Load(level, data, stride);
 		replacementTimeThisFrame_ += time_now_d() - replaceStart;
-		dstFmt = ToD3D9Format(replaced.Format(level));
 	} else {
 		GETextureFormat tfmt = (GETextureFormat)entry.format;
 		GEPaletteFormat clutformat = gstate.getClutPaletteFormat();

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -474,11 +474,12 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 		maxLevel = 0;
 	}
 
-	u8 level = 0;
+	int level = 0;
 	if (IsFakeMipmapChange()) {
 		// NOTE: Since the level is not part of the cache key, we assume it never changes.
 		level = std::max(0, gstate.getTexLevelOffset16() / 16);
 	}
+
 	LoadTextureLevel(*entry, replaced, level, maxLevel, scaleFactor, dstFmt);
 
 	LPDIRECT3DTEXTURE9 &texture = DxTex(entry);

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -62,7 +62,7 @@ protected:
 private:
 	void ApplySamplingParams(const SamplerCacheKey &key);
 
-	void LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int level, int maxLevel, int scaleFactor, u32 dstFmt);
+	void LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int srcLevel, int dstLevel, int maxLevel, int scaleFactor, u32 dstFmt);
 	D3DFORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
 	static CheckAlphaResult CheckAlpha(const u32 *pixelData, u32 dstFmt, int w);
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -62,7 +62,7 @@ protected:
 private:
 	void ApplySamplingParams(const SamplerCacheKey &key);
 
-	void LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int srcLevel, int dstLevel, int maxLevel, int scaleFactor, u32 dstFmt);
+	void LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, int stride, ReplacedTexture &replaced, int srcLevel, int scaleFactor, u32 dstFmt);
 	D3DFORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
 	static CheckAlphaResult CheckAlpha(const u32 *pixelData, u32 dstFmt, int w);
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -521,11 +521,12 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 	// be as good quality as the game's own (might even be better in some cases though).
 
 	// Always load base level texture here 
-	u8 level = 0;
+	int level = 0;
 	if (IsFakeMipmapChange()) {
 		// NOTE: Since the level is not part of the cache key, we assume it never changes.
 		level = std::max(0, gstate.getTexLevelOffset16() / 16);
 	}
+
 	LoadTextureLevel(*entry, replaced, level, scaleFactor, dstFmt);
 
 	// Mipmapping is only enabled when texture scaling is disabled.
@@ -560,6 +561,8 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 		texMaxLevel = 0;
 	}
 
+	render_->FinalizeTexture(entry->textureName, texMaxLevel, genMips);
+
 	if (maxLevel == 0) {
 		entry->status |= TexCacheEntry::STATUS_BAD_MIPS;
 	} else {
@@ -568,8 +571,6 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 	if (replaced.Valid()) {
 		entry->SetAlphaStatus(TexCacheEntry::TexStatus(replaced.AlphaStatus()));
 	}
-
-	render_->FinalizeTexture(entry->textureName, texMaxLevel, genMips);
 }
 
 Draw::DataFormat TextureCacheGLES::GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const {

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -635,9 +635,8 @@ void TextureCacheGLES::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &r
 	gpuStats.numTexturesDecoded++;
 
 	if (replaced.GetSize(srcLevel, w, h)) {
-		PROFILE_THIS_SCOPE("replacetex");
-
 		int bpp = (int)DataFormatSizeInBytes(replaced.Format(srcLevel));
+		
 		decPitch = w * bpp;
 		uint8_t *rearrange = (uint8_t *)AllocateAlignedMemory(decPitch * h, 16);
 		double replaceStart = time_now_d();
@@ -647,8 +646,6 @@ void TextureCacheGLES::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &r
 
 		dstFmt = replaced.Format(srcLevel);
 	} else {
-		PROFILE_THIS_SCOPE("decodetex");
-
 		GEPaletteFormat clutformat = gstate.getClutPaletteFormat();
 		u32 texaddr = gstate.getTextureAddress(srcLevel);
 		int bufw = GetTextureBufw(srcLevel, texaddr, GETextureFormat(entry.format));
@@ -686,7 +683,6 @@ void TextureCacheGLES::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &r
 		}
 	}
 	
-	PROFILE_THIS_SCOPE("loadtex");
 	render_->TextureImage(entry.textureName, dstLevel, w, h, dstFmt, pixelData, GLRAllocType::ALIGNED);
 }
 

--- a/GPU/GLES/TextureCacheGLES.h
+++ b/GPU/GLES/TextureCacheGLES.h
@@ -70,7 +70,7 @@ protected:
 
 private:
 	void ApplySamplingParams(const SamplerCacheKey &key);
-	void LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int level, int scaleFactor, Draw::DataFormat dstFmt);
+	void LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int srcLevel, int dstLevel, int scaleFactor, Draw::DataFormat dstFmt);
 	Draw::DataFormat GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
 
 	static CheckAlphaResult CheckAlpha(const uint8_t *pixelData, Draw::DataFormat dstFmt, int w);

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -1014,7 +1014,6 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 		uint8_t *rearrange = (uint8_t *)AllocateAlignedMemory(w * scaleFactor * h * scaleFactor * 4, 16);
 		scaler.ScaleAlways((u32 *)rearrange, pixelData, fmt, w, h, scaleFactor);
 		pixelData = (u32 *)writePtr;
-		dstFmt = (VkFormat)fmt;
 
 		// We always end up at 8888.  Other parts assume this.
 		_assert_(dstFmt == VULKAN_8888_FORMAT);

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -649,7 +649,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 	if (replaced.Valid()) {
 		// We're replacing, so we won't scale.
 		scaleFactor = 1;
-		maxLevel = replaced.MaxLevel();
+		maxLevel = replaced.NumLevels() - 1;
 		badMipSizes = false;
 	}
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -392,7 +392,7 @@ void TextureCacheVulkan::BindTexture(TexCacheEntry *entry) {
 
 	entry->vkTex->Touch();
 	imageView_ = entry->vkTex->GetImageView();
-	int maxLevel = (entry->status & TexCacheEntry::STATUS_BAD_MIPS) ? 0 : entry->maxLevel;
+	int maxLevel = (entry->status & TexCacheEntry::STATUS_NO_MIPS) ? 0 : entry->maxLevel;
 	SamplerCacheKey samplerKey = GetSamplingParams(maxLevel, entry);
 	curSampler_ = samplerCache_.GetOrCreateSampler(samplerKey);
 	drawEngine_->SetDepalTexture(VK_NULL_HANDLE);
@@ -915,9 +915,9 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 	VK_PROFILE_END(vulkan, cmdInit, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
 
 	if (maxLevel == 0) {
-		entry->status |= TexCacheEntry::STATUS_BAD_MIPS;
+		entry->status |= TexCacheEntry::STATUS_NO_MIPS;
 	} else {
-		entry->status &= ~TexCacheEntry::STATUS_BAD_MIPS;
+		entry->status &= ~TexCacheEntry::STATUS_NO_MIPS;
 	}
 	if (replaced.Valid()) {
 		entry->SetAlphaStatus(TexCacheEntry::TexStatus(replaced.AlphaStatus()));

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -916,6 +916,8 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 			prevStage = VK_PIPELINE_STAGE_TRANSFER_BIT;
 			VK_PROFILE_END(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT);
 		}
+		entry->vkTex->EndCreate(cmdInit, false, computeUpload ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+		VK_PROFILE_END(vulkan, cmdInit, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
 
 		if (maxLevel == 0) {
 			entry->status |= TexCacheEntry::STATUS_BAD_MIPS;
@@ -925,8 +927,6 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		if (replaced.Valid()) {
 			entry->SetAlphaStatus(TexCacheEntry::TexStatus(replaced.AlphaStatus()));
 		}
-		entry->vkTex->EndCreate(cmdInit, false, prevStage, layout);
-		VK_PROFILE_END(vulkan, cmdInit, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
 	}
 }
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -974,9 +974,9 @@ CheckAlphaResult TextureCacheVulkan::CheckAlpha(const u32 *pixelData, VkFormat d
 	}
 }
 
-void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePtr, int rowPitch, int srcLevel, int scaleFactor, VkFormat dstFmt) {
-	int w = gstate.getTextureWidth(srcLevel);
-	int h = gstate.getTextureHeight(srcLevel);
+void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePtr, int rowPitch, int level, int scaleFactor, VkFormat dstFmt) {
+	int w = gstate.getTextureWidth(level);
+	int h = gstate.getTextureHeight(level);
 
 	gpuStats.numTexturesDecoded++;
 
@@ -984,11 +984,11 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 
 	GETextureFormat tfmt = (GETextureFormat)entry.format;
 	GEPaletteFormat clutformat = gstate.getClutPaletteFormat();
-	u32 texaddr = gstate.getTextureAddress(srcLevel);
+	u32 texaddr = gstate.getTextureAddress(level);
 
 	_assert_msg_(texaddr != 0, "Can't load a texture from address null")
 
-	int bufw = GetTextureBufw(srcLevel, texaddr, tfmt);
+	int bufw = GetTextureBufw(level, texaddr, tfmt);
 	int bpp = dstFmt == VULKAN_8888_FORMAT ? 4 : 2;
 
 	u32 *pixelData = (u32 *)writePtr;
@@ -1003,11 +1003,10 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 		decPitch = w * bpp;
 	}
 
-	CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, srcLevel, bufw, false, expand32);
-	gpuStats.numTexturesDecoded++;
+	CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, expand32);
 
 	// WARN_LOG(G3D, "Alpha: full=%d w=%d h=%d level=%d %s/%s", (int)(alphaResult == CHECKALPHA_FULL), w, h, level, GeTextureFormatToString(tfmt), GEPaletteFormatToString(clutformat));
-	entry.SetAlphaStatus(alphaResult, srcLevel);
+	entry.SetAlphaStatus(alphaResult, level);
 
 	if (scaleFactor > 1) {
 		u32 fmt = dstFmt;


### PR DESCRIPTION
Refactor the various BuildTexture implementations to be more similar to each other, and then unifying a bunch of shared code into a utility function.

There will be more, the goal is to share the inner function `LoadTextureLevel` and also make the feature set a bit more uniform between the backends, but there's some distance left to go. This is a good step forward though.

This partially also lays the groundwork for implementing #15727 in more backends, though there's a little more work too first.