### PR TITLE
Color format cleanups

### DIFF
--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -635,50 +635,13 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 
 	SimpleBuf<u32> saveBuf;
 
-	// Since we're copying, change the format meanwhile.  Not much extra cost.
-	if (replacedInfo.fmt != ReplacedTextureFormat::F_8888) {
-		saveBuf.resize((pitch * h) / sizeof(u16));
-		switch (replacedInfo.fmt) {
-		case ReplacedTextureFormat::F_5650:
-			ConvertRGB565ToRGBA8888(saveBuf.data(), (const u16 *)data, (pitch * h) / sizeof(u16));
-			break;
-		case ReplacedTextureFormat::F_5551:
-			ConvertRGBA5551ToRGBA8888(saveBuf.data(), (const u16 *)data, (pitch * h) / sizeof(u16));
-			break;
-		case ReplacedTextureFormat::F_4444:
-			ConvertRGBA4444ToRGBA8888(saveBuf.data(), (const u16 *)data, (pitch * h) / sizeof(u16));
-			break;
-		case ReplacedTextureFormat::F_0565_ABGR:
-			ConvertBGR565ToRGBA8888(saveBuf.data(), (const u16 *)data, (pitch * h) / sizeof(u16));
-			break;
-		case ReplacedTextureFormat::F_1555_ABGR:
-			ConvertABGR1555ToRGBA8888(saveBuf.data(), (const u16 *)data, (pitch * h) / sizeof(u16));
-			break;
-		case ReplacedTextureFormat::F_4444_ABGR:
-			ConvertABGR4444ToRGBA8888(saveBuf.data(), (const u16 *)data, (pitch * h) / sizeof(u16));
-			break;
-		case ReplacedTextureFormat::F_8888_BGRA:
-			ConvertBGRA8888ToRGBA8888(saveBuf.data(), (const u32 *)data, (pitch * h) / sizeof(u32));
-			break;
-		case ReplacedTextureFormat::F_8888:
-			// Impossible.  Just so we can get warnings on other missed formats.
-			break;
-		}
-
-		data = saveBuf.data();
-		if (replacedInfo.fmt != ReplacedTextureFormat::F_8888_BGRA) {
-			// We doubled our pitch.
-			pitch *= 2;
-		}
-	} else {
-		// Copy data to a buffer so we can send it to the thread. Might as well compact-away the pitch
-		// while we're at it.
-		saveBuf.resize(w * h);
-		for (int y = 0; y < h; y++) {
-			memcpy((u8 *)saveBuf.data() + y * w * 4, (const u8 *)data + y * pitch, w * sizeof(u32));
-		}
-		pitch = w * 4;
+	// Copy data to a buffer so we can send it to the thread. Might as well compact-away the pitch
+	// while we're at it.
+	saveBuf.resize(w * h);
+	for (int y = 0; y < h; y++) {
+		memcpy((u8 *)saveBuf.data() + y * w * 4, (const u8 *)data + y * pitch, w * sizeof(u32));
 	}
+	pitch = w * 4;
 
 	TextureSaveTask *task = new TextureSaveTask(std::move(saveBuf));
 	// Should probably do a proper move constructor but this'll work.

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -410,7 +410,7 @@ void TextureReplacer::PopulateReplacement(ReplacedTexture *result, u64 cachekey,
 		}
 
 		ReplacedTextureLevel level;
-		level.fmt = ReplacedTextureFormat::F_8888;
+		level.fmt = Draw::DataFormat::R8G8B8A8_UNORM;
 		level.file = filename;
 		bool good = PopulateLevel(level);
 
@@ -657,7 +657,7 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 	// Remember that we've saved this for next time.
 	// Should be OK that the actual disk write may not be finished yet.
 	ReplacedTextureLevel saved;
-	saved.fmt = ReplacedTextureFormat::F_8888;
+	saved.fmt = Draw::DataFormat::R8G8B8A8_UNORM;
 	saved.file = filename;
 	saved.w = w;
 	saved.h = h;

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -36,14 +36,9 @@ class ReplacedTextureTask;
 class LimitedWaitable;
 
 enum class ReplacedTextureFormat {
-	F_5650,
-	F_5551,
-	F_4444,
 	F_8888,
-	F_0565_ABGR,
-	F_1555_ABGR,
-	F_4444_ABGR,
-	F_8888_BGRA,
+	// Might add compressed formats here later, maybe universal ones like Basis.
+	// We don't bother with the 16-bit formats for replacement storage, they're not commonly used these days.
 };
 
 // These must match the constants in TextureCacheCommon.

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -25,6 +25,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/MemoryUtil.h"
 #include "Common/File/Path.h"
+#include "Common/GPU/DataFormat.h"
 
 #include "GPU/Common/TextureDecoder.h"
 #include "GPU/ge_constants.h"
@@ -34,12 +35,6 @@ class TextureCacheCommon;
 class TextureReplacer;
 class ReplacedTextureTask;
 class LimitedWaitable;
-
-enum class ReplacedTextureFormat {
-	F_8888,
-	// Might add compressed formats here later, maybe universal ones like Basis.
-	// We don't bother with the 16-bit formats for replacement storage, they're not commonly used these days.
-};
 
 // These must match the constants in TextureCacheCommon.
 enum class ReplacedTextureAlpha {
@@ -57,7 +52,7 @@ enum class ReplacedTextureHash {
 struct ReplacedTextureLevel {
 	int w;
 	int h;
-	ReplacedTextureFormat fmt;
+	Draw::DataFormat fmt;  // NOTE: Right now, the only supported format is Draw::DataFormat::R8G8B8A8_UNORM.
 	Path file;
 };
 
@@ -141,11 +136,11 @@ struct ReplacedTexture {
 		return (int)levels_.size() - 1;
 	}
 
-	ReplacedTextureFormat Format(int level) {
+	Draw::DataFormat Format(int level) {
 		if ((size_t)level < levels_.size()) {
 			return levels_[level].fmt;
 		}
-		return ReplacedTextureFormat::F_8888;
+		return Draw::DataFormat::R8G8B8A8_UNORM;
 	}
 
 	u8 AlphaStatus() {
@@ -180,7 +175,7 @@ struct ReplacedTextureDecodeInfo {
 	bool isVideo;
 	bool isFinal;
 	int scaleFactor;
-	ReplacedTextureFormat fmt;
+	Draw::DataFormat fmt;
 };
 
 enum class ReplacerDecimateMode {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1319,7 +1319,7 @@ ReplacedTexture &TextureCacheCommon::FindReplacement(TexCacheEntry *entry, int &
 
 // This is only used in the GLES backend, where we don't point these to video memory.
 // So we shouldn't add a check for dstBuf != srcBuf, as long as the functions we call can handle that.
-static void ReverseColors(void *dstBuf, const void *srcBuf, GETextureFormat fmt, int numPixels, bool useBGRA) {
+static void ReverseColors(void *dstBuf, const void *srcBuf, GETextureFormat fmt, int numPixels) {
 	switch (fmt) {
 	case GE_TFMT_4444:
 		ConvertRGBA4444ToABGR4444((u16 *)dstBuf, (const u16 *)srcBuf, numPixels);
@@ -1332,12 +1332,9 @@ static void ReverseColors(void *dstBuf, const void *srcBuf, GETextureFormat fmt,
 		ConvertRGB565ToBGR565((u16 *)dstBuf, (const u16 *)srcBuf, numPixels);
 		break;
 	default:
-		if (useBGRA) {
-			ConvertRGBA8888ToBGRA8888((u32 *)dstBuf, (const u32 *)srcBuf, numPixels);
-		} else {
-			// No need to convert RGBA8888, right order already
-			if (dstBuf != srcBuf)
-				memcpy(dstBuf, srcBuf, numPixels * sizeof(u32));
+		// No need to convert RGBA8888, right order already
+		if (dstBuf != srcBuf) {
+			memcpy(dstBuf, srcBuf, numPixels * sizeof(u32));
 		}
 		break;
 	}
@@ -1367,7 +1364,7 @@ static inline void ConvertFormatToRGBA8888(GEPaletteFormat format, u32 *dst, con
 
 template <typename DXTBlock, int n>
 static CheckAlphaResult DecodeDXTBlocks(uint8_t *out, int outPitch, uint32_t texaddr, const uint8_t *texptr,
-	int w, int h, int bufw, bool reverseColors, bool useBGRA) {
+	int w, int h, int bufw, bool reverseColors) {
 
 	int minw = std::min(bufw, w);
 	uint32_t *dst = (uint32_t *)out;
@@ -1403,7 +1400,7 @@ static CheckAlphaResult DecodeDXTBlocks(uint8_t *out, int outPitch, uint32_t tex
 	}
 
 	if (reverseColors) {
-		ReverseColors(out, out, GE_TFMT_8888, outPitch32 * h, useBGRA);
+		ReverseColors(out, out, GE_TFMT_8888, outPitch32 * h);
 	}
 
 	if (n == 1) {
@@ -1549,7 +1546,7 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 				// Just check the input's alpha to reuse code. TODO: make a specialized ReverseColors that checks as we go.
 				for (int y = 0; y < h; ++y) {
 					CheckMask16((const u16 *)(texptr + bufw * sizeof(u16) * y), w, &alphaSum);
-					ReverseColors(out + outPitch * y, texptr + bufw * sizeof(u16) * y, format, w, false);
+					ReverseColors(out + outPitch * y, texptr + bufw * sizeof(u16) * y, format, w);
 				}
 			} else if (expandTo32bit) {
 				for (int y = 0; y < h; ++y) {
@@ -1579,7 +1576,7 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 				// Just check the swizzled input's alpha to reuse code. TODO: make a specialized ReverseColors that checks as we go.
 				for (int y = 0; y < h; ++y) {
 					CheckMask16((const u16 *)(unswizzled + bufw * sizeof(u16) * y), w, &alphaSum);
-					ReverseColors(out + outPitch * y, unswizzled + bufw * sizeof(u16) * y, format, w, false);
+					ReverseColors(out + outPitch * y, unswizzled + bufw * sizeof(u16) * y, format, w);
 				}
 			} else if (expandTo32bit) {
 				// Just check the swizzled input's alpha to reuse code. TODO: make a specialized ConvertFormatToRGBA8888 that checks as we go.
@@ -1604,7 +1601,7 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 			if (reverseColors) {
 				for (int y = 0; y < h; ++y) {
 					CheckMask32((const u32 *)(texptr + bufw * sizeof(u32) * y), w, &alphaSum);
-					ReverseColors(out + outPitch * y, texptr + bufw * sizeof(u32) * y, format, w, false);
+					ReverseColors(out + outPitch * y, texptr + bufw * sizeof(u32) * y, format, w);
 				}
 			} else {
 				for (int y = 0; y < h; ++y) {
@@ -1626,7 +1623,7 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 			if (reverseColors) {
 				for (int y = 0; y < h; ++y) {
 					CheckMask32((const u32 *)(unswizzled + bufw * sizeof(u32) * y), w, &alphaSum);
-					ReverseColors(out + outPitch * y, unswizzled + bufw * sizeof(u32) * y, format, w, false);
+					ReverseColors(out + outPitch * y, unswizzled + bufw * sizeof(u32) * y, format, w);
 				}
 			} else {
 				for (int y = 0; y < h; ++y) {
@@ -1637,13 +1634,13 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 		break;
 
 	case GE_TFMT_DXT1:
-		return DecodeDXTBlocks<DXT1Block, 1>(out, outPitch, texaddr, texptr, w, h, bufw, reverseColors, false);
+		return DecodeDXTBlocks<DXT1Block, 1>(out, outPitch, texaddr, texptr, w, h, bufw, reverseColors);
 
 	case GE_TFMT_DXT3:
-		return DecodeDXTBlocks<DXT3Block, 3>(out, outPitch, texaddr, texptr, w, h, bufw, reverseColors, false);
+		return DecodeDXTBlocks<DXT3Block, 3>(out, outPitch, texaddr, texptr, w, h, bufw, reverseColors);
 
 	case GE_TFMT_DXT5:
-		return DecodeDXTBlocks<DXT5Block, 5>(out, outPitch, texaddr, texptr, w, h, bufw, reverseColors, false);
+		return DecodeDXTBlocks<DXT5Block, 5>(out, outPitch, texaddr, texptr, w, h, bufw, reverseColors);
 
 	default:
 		ERROR_LOG_REPORT(G3D, "Unknown Texture Format %d!!!", format);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1434,7 +1434,7 @@ inline u32 TfmtRawToFullAlpha(GETextureFormat fmt) {
 	}
 }
 
-CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, GETextureFormat format, GEPaletteFormat clutformat, uint32_t texaddr, int level, int bufw, bool reverseColors, bool useBGRA, bool expandTo32bit) {
+CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, GETextureFormat format, GEPaletteFormat clutformat, uint32_t texaddr, int level, int bufw, bool reverseColors, bool expandTo32bit) {
 	u32 alphaSum = 0xFFFFFFFF;
 	u32 fullAlphaMask = 0x0;
 
@@ -1549,7 +1549,7 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 				// Just check the input's alpha to reuse code. TODO: make a specialized ReverseColors that checks as we go.
 				for (int y = 0; y < h; ++y) {
 					CheckMask16((const u16 *)(texptr + bufw * sizeof(u16) * y), w, &alphaSum);
-					ReverseColors(out + outPitch * y, texptr + bufw * sizeof(u16) * y, format, w, useBGRA);
+					ReverseColors(out + outPitch * y, texptr + bufw * sizeof(u16) * y, format, w, false);
 				}
 			} else if (expandTo32bit) {
 				for (int y = 0; y < h; ++y) {
@@ -1579,7 +1579,7 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 				// Just check the swizzled input's alpha to reuse code. TODO: make a specialized ReverseColors that checks as we go.
 				for (int y = 0; y < h; ++y) {
 					CheckMask16((const u16 *)(unswizzled + bufw * sizeof(u16) * y), w, &alphaSum);
-					ReverseColors(out + outPitch * y, unswizzled + bufw * sizeof(u16) * y, format, w, useBGRA);
+					ReverseColors(out + outPitch * y, unswizzled + bufw * sizeof(u16) * y, format, w, false);
 				}
 			} else if (expandTo32bit) {
 				// Just check the swizzled input's alpha to reuse code. TODO: make a specialized ConvertFormatToRGBA8888 that checks as we go.
@@ -1604,7 +1604,7 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 			if (reverseColors) {
 				for (int y = 0; y < h; ++y) {
 					CheckMask32((const u32 *)(texptr + bufw * sizeof(u32) * y), w, &alphaSum);
-					ReverseColors(out + outPitch * y, texptr + bufw * sizeof(u32) * y, format, w, useBGRA);
+					ReverseColors(out + outPitch * y, texptr + bufw * sizeof(u32) * y, format, w, false);
 				}
 			} else {
 				for (int y = 0; y < h; ++y) {
@@ -1626,7 +1626,7 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 			if (reverseColors) {
 				for (int y = 0; y < h; ++y) {
 					CheckMask32((const u32 *)(unswizzled + bufw * sizeof(u32) * y), w, &alphaSum);
-					ReverseColors(out + outPitch * y, unswizzled + bufw * sizeof(u32) * y, format, w, useBGRA);
+					ReverseColors(out + outPitch * y, unswizzled + bufw * sizeof(u32) * y, format, w, false);
 				}
 			} else {
 				for (int y = 0; y < h; ++y) {
@@ -1637,13 +1637,13 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 		break;
 
 	case GE_TFMT_DXT1:
-		return DecodeDXTBlocks<DXT1Block, 1>(out, outPitch, texaddr, texptr, w, h, bufw, reverseColors, useBGRA);
+		return DecodeDXTBlocks<DXT1Block, 1>(out, outPitch, texaddr, texptr, w, h, bufw, reverseColors, false);
 
 	case GE_TFMT_DXT3:
-		return DecodeDXTBlocks<DXT3Block, 3>(out, outPitch, texaddr, texptr, w, h, bufw, reverseColors, useBGRA);
+		return DecodeDXTBlocks<DXT3Block, 3>(out, outPitch, texaddr, texptr, w, h, bufw, reverseColors, false);
 
 	case GE_TFMT_DXT5:
-		return DecodeDXTBlocks<DXT5Block, 5>(out, outPitch, texaddr, texptr, w, h, bufw, reverseColors, useBGRA);
+		return DecodeDXTBlocks<DXT5Block, 5>(out, outPitch, texaddr, texptr, w, h, bufw, reverseColors, false);
 
 	default:
 		ERROR_LOG_REPORT(G3D, "Unknown Texture Format %d!!!", format);

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -283,7 +283,7 @@ protected:
 	virtual void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) = 0;
 	bool CheckFullHash(TexCacheEntry *entry, bool &doDelete);
 
-	CheckAlphaResult DecodeTextureLevel(u8 *out, int outPitch, GETextureFormat format, GEPaletteFormat clutformat, uint32_t texaddr, int level, int bufw, bool reverseColors, bool useBGRA, bool expandTo32Bit);
+	CheckAlphaResult DecodeTextureLevel(u8 *out, int outPitch, GETextureFormat format, GEPaletteFormat clutformat, uint32_t texaddr, int level, int bufw, bool reverseColors, bool expandTo32Bit);
 	void UnswizzleFromMem(u32 *dest, u32 destPitch, const u8 *texptr, u32 bufw, u32 height, u32 bytesPerPixel);
 	CheckAlphaResult ReadIndexedTex(u8 *out, int outPitch, int level, const u8 *texptr, int bytesPerIndex, int bufw, bool reverseColors, bool expandTo32Bit);
 	ReplacedTexture &FindReplacement(TexCacheEntry *entry, int &w, int &h);

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -696,7 +696,7 @@ void TextureCacheD3D11::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &
 
 		bool expand32 = !gstate_c.Supports(GPU_SUPPORTS_16BIT_FORMATS);
 
-		CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, false, expand32);
+		CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, expand32);
 		entry.SetAlphaStatus(alphaResult, level);
 
 		if (scaleFactor > 1) {

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -605,6 +605,8 @@ CheckAlphaResult TextureCacheD3D11::CheckAlpha(const u32 *pixelData, u32 dstFmt,
 	}
 }
 
+// NOTE: In the D3D backends, we flip R and B in the shaders, so while these look wrong, they're OK.
+
 Draw::DataFormat FromD3D11Format(u32 fmt) {
 	switch (fmt) {
 	case DXGI_FORMAT_B8G8R8A8_UNORM: default: return Draw::DataFormat::R8G8B8A8_UNORM;

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -605,15 +605,15 @@ CheckAlphaResult TextureCacheD3D11::CheckAlpha(const u32 *pixelData, u32 dstFmt,
 	}
 }
 
-ReplacedTextureFormat FromD3D11Format(u32 fmt) {
+Draw::DataFormat FromD3D11Format(u32 fmt) {
 	switch (fmt) {
-	case DXGI_FORMAT_B8G8R8A8_UNORM: default: return ReplacedTextureFormat::F_8888;
+	case DXGI_FORMAT_B8G8R8A8_UNORM: default: return Draw::DataFormat::R8G8B8A8_UNORM;
 	}
 }
 
-DXGI_FORMAT ToDXGIFormat(ReplacedTextureFormat fmt) {
+DXGI_FORMAT ToDXGIFormat(Draw::DataFormat fmt) {
 	switch (fmt) {
-	case ReplacedTextureFormat::F_8888: default: return DXGI_FORMAT_B8G8R8A8_UNORM;
+	case Draw::DataFormat::R8G8B8A8_UNORM: default: return DXGI_FORMAT_B8G8R8A8_UNORM;
 	}
 }
 

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -607,18 +607,12 @@ CheckAlphaResult TextureCacheD3D11::CheckAlpha(const u32 *pixelData, u32 dstFmt,
 
 ReplacedTextureFormat FromD3D11Format(u32 fmt) {
 	switch (fmt) {
-	case DXGI_FORMAT_B5G6R5_UNORM: return ReplacedTextureFormat::F_5650;
-	case DXGI_FORMAT_B5G5R5A1_UNORM: return ReplacedTextureFormat::F_5551;
-	case DXGI_FORMAT_B4G4R4A4_UNORM: return ReplacedTextureFormat::F_4444;
 	case DXGI_FORMAT_B8G8R8A8_UNORM: default: return ReplacedTextureFormat::F_8888;
 	}
 }
 
 DXGI_FORMAT ToDXGIFormat(ReplacedTextureFormat fmt) {
 	switch (fmt) {
-	case ReplacedTextureFormat::F_5650: return DXGI_FORMAT_B5G6R5_UNORM;
-	case ReplacedTextureFormat::F_5551: return DXGI_FORMAT_B5G5R5A1_UNORM;
-	case ReplacedTextureFormat::F_4444: return DXGI_FORMAT_B4G4R4A4_UNORM;
 	case ReplacedTextureFormat::F_8888: default: return DXGI_FORMAT_B8G8R8A8_UNORM;
 	}
 }

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -621,7 +621,7 @@ void TextureCacheDX9::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &re
 			decPitch = w * bpp;
 		}
 
-		CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, false, false);
+		CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, false);
 		entry.SetAlphaStatus(alphaResult, level);
 
 		if (scaleFactor > 1) {

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -539,6 +539,8 @@ CheckAlphaResult TextureCacheDX9::CheckAlpha(const u32 *pixelData, u32 dstFmt, i
 	}
 }
 
+// NOTE: In the D3D backends, we flip R and B in the shaders, so while these look wrong, they're OK.
+
 Draw::DataFormat FromD3D9Format(u32 fmt) {
 	switch (fmt) {
 	case D3DFMT_A8R8G8B8: default: return Draw::DataFormat::R8G8B8A8_UNORM;

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -541,18 +541,12 @@ CheckAlphaResult TextureCacheDX9::CheckAlpha(const u32 *pixelData, u32 dstFmt, i
 
 ReplacedTextureFormat FromD3D9Format(u32 fmt) {
 	switch (fmt) {
-	case D3DFMT_R5G6B5: return ReplacedTextureFormat::F_5650;
-	case D3DFMT_A1R5G5B5: return ReplacedTextureFormat::F_5551;
-	case D3DFMT_A4R4G4B4: return ReplacedTextureFormat::F_4444;
 	case D3DFMT_A8R8G8B8: default: return ReplacedTextureFormat::F_8888;
 	}
 }
 
 D3DFORMAT ToD3D9Format(ReplacedTextureFormat fmt) {
 	switch (fmt) {
-	case ReplacedTextureFormat::F_5650: return D3DFMT_R5G6B5;
-	case ReplacedTextureFormat::F_5551: return D3DFMT_A1R5G5B5;
-	case ReplacedTextureFormat::F_4444: return D3DFMT_A4R4G4B4;
 	case ReplacedTextureFormat::F_8888: default: return D3DFMT_A8R8G8B8;
 	}
 }

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -539,15 +539,15 @@ CheckAlphaResult TextureCacheDX9::CheckAlpha(const u32 *pixelData, u32 dstFmt, i
 	}
 }
 
-ReplacedTextureFormat FromD3D9Format(u32 fmt) {
+Draw::DataFormat FromD3D9Format(u32 fmt) {
 	switch (fmt) {
-	case D3DFMT_A8R8G8B8: default: return ReplacedTextureFormat::F_8888;
+	case D3DFMT_A8R8G8B8: default: return Draw::DataFormat::R8G8B8A8_UNORM;
 	}
 }
 
-D3DFORMAT ToD3D9Format(ReplacedTextureFormat fmt) {
+D3DFORMAT ToD3D9Format(Draw::DataFormat fmt) {
 	switch (fmt) {
-	case ReplacedTextureFormat::F_8888: default: return D3DFMT_A8R8G8B8;
+	case Draw::DataFormat::R8G8B8A8_UNORM: default: return D3DFMT_A8R8G8B8;
 	}
 }
 

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -649,7 +649,7 @@ void TextureCacheGLES::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &r
 
 		pixelData = (uint8_t *)AllocateAlignedMemory(decPitch * h * pixelSize, 16);
 
-		CheckAlphaResult alphaStatus = DecodeTextureLevel(pixelData, decPitch, GETextureFormat(entry.format), clutformat, texaddr, level, bufw, true, false, false);
+		CheckAlphaResult alphaStatus = DecodeTextureLevel(pixelData, decPitch, GETextureFormat(entry.format), clutformat, texaddr, level, bufw, true, false);
 		entry.SetAlphaStatus(alphaStatus, level);
 
 		if (scaleFactor > 1) {

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -428,18 +428,12 @@ void TextureCacheGLES::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer, 
 ReplacedTextureFormat FromDataFormat(Draw::DataFormat fmt) {
 	// TODO: 16-bit formats are incorrect, since swizzled.
 	switch (fmt) {
-	case Draw::DataFormat::R5G6B5_UNORM_PACK16: return ReplacedTextureFormat::F_0565_ABGR;
-	case Draw::DataFormat::R5G5B5A1_UNORM_PACK16: return ReplacedTextureFormat::F_1555_ABGR;
-	case Draw::DataFormat::R4G4B4A4_UNORM_PACK16: return ReplacedTextureFormat::F_4444_ABGR;
 	case Draw::DataFormat::R8G8B8A8_UNORM: default: return ReplacedTextureFormat::F_8888;
 	}
 }
 
 Draw::DataFormat ToDataFormat(ReplacedTextureFormat fmt) {
 	switch (fmt) {
-	case ReplacedTextureFormat::F_5650: return Draw::DataFormat::R5G6B5_UNORM_PACK16;
-	case ReplacedTextureFormat::F_5551: return Draw::DataFormat::R5G5B5A1_UNORM_PACK16;
-	case ReplacedTextureFormat::F_4444: return Draw::DataFormat::R4G4B4A4_UNORM_PACK16;
 	case ReplacedTextureFormat::F_8888: default: return Draw::DataFormat::R8G8B8A8_UNORM;
 	}
 }

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -999,7 +999,7 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 
 		bool expand32 = !gstate_c.Supports(GPU_SUPPORTS_16BIT_FORMATS) || dstFmt == VK_FORMAT_R8G8B8A8_UNORM;
 
-		CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, false, expand32);
+		CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, expand32);
 
 		// WARN_LOG(G3D, "Alpha: full=%d w=%d h=%d level=%d %s/%s", (int)(alphaResult == CHECKALPHA_FULL), w, h, level, GeTextureFormatToString(tfmt), GEPaletteFormatToString(clutformat));
 		entry.SetAlphaStatus(alphaResult, level);

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -564,15 +564,15 @@ void TextureCacheVulkan::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 	curSampler_ = samplerCache_.GetOrCreateSampler(samplerKey);
 }
 
-ReplacedTextureFormat FromVulkanFormat(VkFormat fmt) {
+static Draw::DataFormat FromVulkanFormat(VkFormat fmt) {
 	switch (fmt) {
-	case VULKAN_8888_FORMAT: default: return ReplacedTextureFormat::F_8888;
+	case VULKAN_8888_FORMAT: default: return Draw::DataFormat::R8G8B8A8_UNORM;
 	}
 }
 
-VkFormat ToVulkanFormat(ReplacedTextureFormat fmt) {
+static VkFormat ToVulkanFormat(Draw::DataFormat fmt) {
 	switch (fmt) {
-	case ReplacedTextureFormat::F_8888: default: return VULKAN_8888_FORMAT;
+	case Draw::DataFormat::R8G8B8A8_UNORM: default: return VULKAN_8888_FORMAT;
 	}
 }
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -566,18 +566,12 @@ void TextureCacheVulkan::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 
 ReplacedTextureFormat FromVulkanFormat(VkFormat fmt) {
 	switch (fmt) {
-	case VULKAN_565_FORMAT: return ReplacedTextureFormat::F_5650;
-	case VULKAN_1555_FORMAT: return ReplacedTextureFormat::F_5551;
-	case VULKAN_4444_FORMAT: return ReplacedTextureFormat::F_4444;
 	case VULKAN_8888_FORMAT: default: return ReplacedTextureFormat::F_8888;
 	}
 }
 
 VkFormat ToVulkanFormat(ReplacedTextureFormat fmt) {
 	switch (fmt) {
-	case ReplacedTextureFormat::F_5650: return VULKAN_565_FORMAT;
-	case ReplacedTextureFormat::F_5551: return VULKAN_1555_FORMAT;
-	case ReplacedTextureFormat::F_4444: return VULKAN_4444_FORMAT;
 	case ReplacedTextureFormat::F_8888: default: return VULKAN_8888_FORMAT;
 	}
 }


### PR DESCRIPTION
I'm on a deep [yak shaving](https://americanexpress.io/yak-shaving/#:~:text=But%20what%20is%20yak%20shaving,going%20down%20the%20rabbit%20hole.%E2%80%9D) quest here. The origin was the 3D texture thing (#15727 ), then when trying to expand that to more backends than Vulkan, I found I needed to refactor texture loading (#15743), which spawned a number of cleanup tasks when I ran into things that were silly and/or outdated.

This one removes the ReplaceTextureFormat enum (which had 7 unused members) and their related code, keeping only the case we are currently actively using. Then I found out that some parameters were always false these days now that we switch R/B in the shaders for the D3D backends, so cleaned up more stuff. Good to get in separately.