### PR TITLE
Improve and simplify stencil buffer support in thin3d

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -571,6 +571,8 @@ ID3D11DepthStencilState *D3D11DrawContext::GetCachedDepthStencilState(D3D11Depth
 	d3ddesc.DepthWriteMask = state->desc.depthWriteEnabled ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO;
 	d3ddesc.DepthFunc = compareToD3D11[(int)state->desc.depthCompare];
 	d3ddesc.StencilEnable = state->desc.stencilEnabled;
+	d3ddesc.StencilReadMask = stencilCompareMask;
+	d3ddesc.StencilWriteMask = stencilWriteMask;
 	if (d3ddesc.StencilEnable) {
 		CopyStencilSide(d3ddesc.FrontFace, state->desc.stencil);
 		CopyStencilSide(d3ddesc.BackFace, state->desc.stencil);
@@ -1023,8 +1025,9 @@ Pipeline *D3D11DrawContext::CreateGraphicsPipeline(const PipelineDesc &desc) {
 		dPipeline->dynamicUniformsSize = desc.uniformDesc->uniformBufferSize;
 		D3D11_BUFFER_DESC bufdesc{};
 		bufdesc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
-		bufdesc.ByteWidth = (UINT)dPipeline->dynamicUniformsSize;
-		bufdesc.StructureByteStride = (UINT)dPipeline->dynamicUniformsSize;
+		// We just round up to 16 here. If we get some garbage, that's fine.
+		bufdesc.ByteWidth = ((UINT)dPipeline->dynamicUniformsSize + 15) & ~15;
+		bufdesc.StructureByteStride = bufdesc.ByteWidth;
 		bufdesc.Usage = D3D11_USAGE_DYNAMIC;
 		bufdesc.BindFlags = D3D11_BIND_CONSTANT_BUFFER;
 		HRESULT hr = device_->CreateBuffer(&bufdesc, nullptr, &dPipeline->dynamicUniforms);

--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -487,7 +487,7 @@ static D3D11_PRIMITIVE_TOPOLOGY primToD3D11[] = {
 	D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP_ADJ,
 };
 
-inline void CopyStencilSide(D3D11_DEPTH_STENCILOP_DESC &side, const StencilSide &input) {
+inline void CopyStencilSide(D3D11_DEPTH_STENCILOP_DESC &side, const StencilSetup &input) {
 	side.StencilFunc = compareToD3D11[(int)input.compareOp];
 	side.StencilDepthFailOp = stencilOpToD3D11[(int)input.depthFailOp];
 	side.StencilFailOp = stencilOpToD3D11[(int)input.failOp];
@@ -501,8 +501,8 @@ DepthStencilState *D3D11DrawContext::CreateDepthStencilState(const DepthStencilS
 	d3ddesc.DepthWriteMask = desc.depthWriteEnabled ? D3D11_DEPTH_WRITE_MASK_ALL : D3D11_DEPTH_WRITE_MASK_ZERO;
 	d3ddesc.DepthFunc = compareToD3D11[(int)desc.depthCompare];
 	d3ddesc.StencilEnable = desc.stencilEnabled;
-	CopyStencilSide(d3ddesc.FrontFace, desc.front);
-	CopyStencilSide(d3ddesc.BackFace, desc.back);
+	CopyStencilSide(d3ddesc.FrontFace, desc.stencil);
+	CopyStencilSide(d3ddesc.BackFace, desc.stencil);
 	if (SUCCEEDED(device_->CreateDepthStencilState(&d3ddesc, &ds->dss)))
 		return ds;
 	delete ds;

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -556,9 +556,7 @@ public:
 	void SetScissorRect(int left, int top, int width, int height) override;
 	void SetViewports(int count, Viewport *viewports) override;
 	void SetBlendFactor(float color[4]) override;
-	void SetStencilRef(uint8_t ref) override {
-		stencilRef_ = ref;
-	}
+	void SetStencilParams(uint8_t refValue, uint8_t writeMask, uint8_t compareMask) override;
 
 	void Draw(int vertexCount, int offset) override;
 	void DrawIndexed(int vertexCount, int offset) override;
@@ -734,8 +732,6 @@ DepthStencilState *D3D9Context::CreateDepthStencilState(const DepthStencilStateD
 	ds->stencilPass = stencilOpToD3D9[(int)desc.stencil.passOp];
 	ds->stencilFail = stencilOpToD3D9[(int)desc.stencil.failOp];
 	ds->stencilZFail = stencilOpToD3D9[(int)desc.stencil.depthFailOp];
-	ds->stencilWriteMask = desc.stencil.writeMask;
-	ds->stencilCompareMask = desc.stencil.compareMask;
 	return ds;
 }
 

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -730,12 +730,12 @@ DepthStencilState *D3D9Context::CreateDepthStencilState(const DepthStencilStateD
 	ds->depthWriteEnabled = desc.depthWriteEnabled;
 	ds->depthCompare = compareToD3D9[(int)desc.depthCompare];
 	ds->stencilEnabled = desc.stencilEnabled;
-	ds->stencilCompareOp = compareToD3D9[(int)desc.front.compareOp];
-	ds->stencilPass = stencilOpToD3D9[(int)desc.front.passOp];
-	ds->stencilFail = stencilOpToD3D9[(int)desc.front.failOp];
-	ds->stencilZFail = stencilOpToD3D9[(int)desc.front.depthFailOp];
-	ds->stencilWriteMask = desc.front.writeMask;
-	ds->stencilCompareMask = desc.front.compareMask;
+	ds->stencilCompareOp = compareToD3D9[(int)desc.stencil.compareOp];
+	ds->stencilPass = stencilOpToD3D9[(int)desc.stencil.passOp];
+	ds->stencilFail = stencilOpToD3D9[(int)desc.stencil.failOp];
+	ds->stencilZFail = stencilOpToD3D9[(int)desc.stencil.depthFailOp];
+	ds->stencilWriteMask = desc.stencil.writeMask;
+	ds->stencilCompareMask = desc.stencil.compareMask;
 	return ds;
 }
 

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -163,9 +163,7 @@ public:
 	D3DSTENCILOP stencilPass;
 	D3DCMPFUNC stencilCompareOp;
 
-	uint8_t stencilCompareMask;
-	uint8_t stencilWriteMask;
-	void Apply(LPDIRECT3DDEVICE9 device, uint8_t stencilRef) {
+	void Apply(LPDIRECT3DDEVICE9 device, uint8_t stencilRef, uint8_t stencilWriteMask, uint8_t stencilCompareMask) {
 		using namespace DX9;
 		dxstate.depthTest.set(depthTestEnabled);
 		if (depthTestEnabled) {
@@ -289,7 +287,7 @@ public:
 	AutoRef<D3D9RasterState> raster;
 	UniformBufferDesc dynamicUniforms;
 
-	void Apply(LPDIRECT3DDEVICE9 device, uint8_t stencilRef);
+	void Apply(LPDIRECT3DDEVICE9 device, uint8_t stencilRef, uint8_t stencilWriteMask, uint8_t stencilCompareMask);
 };
 
 class D3D9Texture : public Texture {
@@ -558,6 +556,7 @@ public:
 	void SetBlendFactor(float color[4]) override;
 	void SetStencilParams(uint8_t refValue, uint8_t writeMask, uint8_t compareMask) override;
 
+	void ApplyDynamicState();
 	void Draw(int vertexCount, int offset) override;
 	void DrawIndexed(int vertexCount, int offset) override;
 	void DrawUP(const void *vdata, int vertexCount) override;
@@ -615,6 +614,10 @@ private:
 	AutoRef<D3D9Buffer> curIBuffer_;
 	int curIBufferOffset_ = 0;
 	AutoRef<Framebuffer> curRenderTarget_;
+
+	u8 stencilRefValue_ = 0;
+	u8 stencilCompareMask_ = 0xFF;
+	u8 stencilWriteMask_ = 0xFF;
 
 	// Framebuffer state
 	LPDIRECT3DSURFACE9 deviceRTsurf = 0;
@@ -952,32 +955,44 @@ void D3D9Context::UpdateBuffer(Buffer *buffer, const uint8_t *data, size_t offse
 	}
 }
 
-void D3D9Pipeline::Apply(LPDIRECT3DDEVICE9 device, uint8_t stencilRef) {
+void D3D9Pipeline::Apply(LPDIRECT3DDEVICE9 device, uint8_t stencilRef, uint8_t stencilWriteMask, uint8_t stencilCompareMask) {
 	vshader->Apply(device);
 	pshader->Apply(device);
 	blend->Apply(device);
-	depthStencil->Apply(device, stencilRef);
+	depthStencil->Apply(device, stencilRef, stencilWriteMask, stencilCompareMask);
 	raster->Apply(device);
+}
+
+void D3D9Context::ApplyDynamicState() {
+	// Apply dynamic state.
+	if (curPipeline_->depthStencil->stencilEnabled) {
+		device_->SetRenderState(D3DRS_STENCILREF, (DWORD)stencilRefValue_);
+		device_->SetRenderState(D3DRS_STENCILWRITEMASK, (DWORD)stencilWriteMask_);
+		device_->SetRenderState(D3DRS_STENCILMASK, (DWORD)stencilCompareMask_);
+	}
 }
 
 void D3D9Context::Draw(int vertexCount, int offset) {
 	device_->SetStreamSource(0, curVBuffers_[0]->vbuffer_, curVBufferOffsets_[0], curPipeline_->inputLayout->GetStride(0));
-	curPipeline_->Apply(device_, stencilRef_);
 	curPipeline_->inputLayout->Apply(device_);
+	curPipeline_->Apply(device_, stencilRef_, stencilWriteMask_, stencilCompareMask_);
+	ApplyDynamicState();
 	device_->DrawPrimitive(curPipeline_->prim, offset, vertexCount / 3);
 }
 
 void D3D9Context::DrawIndexed(int vertexCount, int offset) {
-	curPipeline_->Apply(device_, stencilRef_);
 	curPipeline_->inputLayout->Apply(device_);
+	curPipeline_->Apply(device_, stencilRef_, stencilWriteMask_, stencilCompareMask_);
+	ApplyDynamicState();
 	device_->SetStreamSource(0, curVBuffers_[0]->vbuffer_, curVBufferOffsets_[0], curPipeline_->inputLayout->GetStride(0));
 	device_->SetIndices(curIBuffer_->ibuffer_);
 	device_->DrawIndexedPrimitive(curPipeline_->prim, 0, 0, vertexCount, offset, vertexCount / curPipeline_->primDivisor);
 }
 
 void D3D9Context::DrawUP(const void *vdata, int vertexCount) {
-	curPipeline_->Apply(device_, stencilRef_);
 	curPipeline_->inputLayout->Apply(device_);
+	curPipeline_->Apply(device_, stencilRef_, stencilWriteMask_, stencilCompareMask_);
+	ApplyDynamicState();
 	device_->DrawPrimitiveUP(curPipeline_->prim, vertexCount / 3, vdata, curPipeline_->inputLayout->GetStride(0));
 }
 
@@ -1019,6 +1034,12 @@ void D3D9Context::SetBlendFactor(float color[4]) {
 	uint32_t a = (uint32_t)(color[3] * 255.0f);
 	using namespace DX9;
 	dxstate.blendColor.set(color);
+}
+
+void D3D9Context::SetStencilParams(uint8_t refValue, uint8_t writeMask, uint8_t compareMask) {
+	stencilRefValue_ = refValue;
+	stencilWriteMask_ = writeMask;
+	stencilCompareMask_ = compareMask;
 }
 
 bool D3D9ShaderModule::Compile(LPDIRECT3DDEVICE9 device, const uint8_t *data, size_t size) {

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -936,12 +936,12 @@ DepthStencilState *OpenGLContext::CreateDepthStencilState(const DepthStencilStat
 	ds->depthWriteEnabled = desc.depthWriteEnabled;
 	ds->depthComp = compToGL[(int)desc.depthCompare];
 	ds->stencilEnabled = desc.stencilEnabled;
-	ds->stencilCompareOp = compToGL[(int)desc.front.compareOp];
-	ds->stencilPass = stencilOpToGL[(int)desc.front.passOp];
-	ds->stencilFail = stencilOpToGL[(int)desc.front.failOp];
-	ds->stencilZFail = stencilOpToGL[(int)desc.front.depthFailOp];
-	ds->stencilWriteMask = desc.front.writeMask;
-	ds->stencilCompareMask = desc.front.compareMask;
+	ds->stencilCompareOp = compToGL[(int)desc.stencil.compareOp];
+	ds->stencilPass = stencilOpToGL[(int)desc.stencil.passOp];
+	ds->stencilFail = stencilOpToGL[(int)desc.stencil.failOp];
+	ds->stencilZFail = stencilOpToGL[(int)desc.stencil.depthFailOp];
+	ds->stencilWriteMask = desc.stencil.writeMask;
+	ds->stencilCompareMask = desc.stencil.compareMask;
 	return ds;
 }
 

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -175,10 +175,8 @@ public:
 	GLuint stencilZFail;
 	GLuint stencilPass;
 	GLuint stencilCompareOp;
-	uint8_t stencilCompareMask;
-	uint8_t stencilWriteMask;
 
-	void Apply(GLRenderManager *render, uint8_t stencilRef) {
+	void Apply(GLRenderManager *render, uint8_t stencilRef, uint8_t stencilWriteMask, uint8_t stencilCompareMask) {
 		render->SetDepth(depthTestEnabled, depthWriteEnabled, depthComp);
 		render->SetStencilFunc(stencilEnabled, stencilCompareOp, stencilRef, stencilCompareMask);
 		render->SetStencilOp(stencilWriteMask, stencilFail, stencilZFail, stencilPass);
@@ -388,13 +386,21 @@ public:
 		renderManager_.SetBlendFactor(color);
 	}
 
-	void SetStencilRef(uint8_t ref) override {
-		stencilRef_ = ref;
+	void SetStencilParams(uint8_t refValue, uint8_t writeMask, uint8_t compareMask) override {
+		stencilRef_ = refValue;
+		stencilWriteMask_ = writeMask;
+		stencilCompareMask_ = compareMask;
+		// Do we need to update on the fly here?
 		renderManager_.SetStencilFunc(
 			curPipeline_->depthStencil->stencilEnabled,
 			curPipeline_->depthStencil->stencilCompareOp,
-			ref,
-			curPipeline_->depthStencil->stencilCompareMask);
+			refValue,
+			compareMask);
+		renderManager_.SetStencilOp(
+			writeMask,
+			curPipeline_->depthStencil->stencilFail,
+			curPipeline_->depthStencil->stencilZFail,
+			curPipeline_->depthStencil->stencilPass);
 	}
 
 	void BindTextures(int start, int count, Texture **textures) override;
@@ -491,6 +497,8 @@ private:
 	AutoRef<Framebuffer> curRenderTarget_;
 
 	uint8_t stencilRef_ = 0;
+	uint8_t stencilWriteMask_ = 0;
+	uint8_t stencilCompareMask_ = 0;
 
 	// Frames in flight is not such a strict concept as with Vulkan until we start using glBufferStorage and fences.
 	// But might as well have the structure ready, and can't hurt to rotate buffers.
@@ -940,8 +948,6 @@ DepthStencilState *OpenGLContext::CreateDepthStencilState(const DepthStencilStat
 	ds->stencilPass = stencilOpToGL[(int)desc.stencil.passOp];
 	ds->stencilFail = stencilOpToGL[(int)desc.stencil.failOp];
 	ds->stencilZFail = stencilOpToGL[(int)desc.stencil.depthFailOp];
-	ds->stencilWriteMask = desc.stencil.writeMask;
-	ds->stencilCompareMask = desc.stencil.compareMask;
 	return ds;
 }
 
@@ -1185,7 +1191,7 @@ void OpenGLContext::BindPipeline(Pipeline *pipeline) {
 		return;
 	}
 	curPipeline_->blend->Apply(&renderManager_);
-	curPipeline_->depthStencil->Apply(&renderManager_, stencilRef_);
+	curPipeline_->depthStencil->Apply(&renderManager_, stencilRef_, stencilWriteMask_, stencilCompareMask_);
 	curPipeline_->raster->Apply(&renderManager_);
 	renderManager_.BindProgram(curPipeline_->program_);
 }

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -407,7 +407,7 @@ public:
 	void SetScissorRect(int left, int top, int width, int height) override;
 	void SetViewports(int count, Viewport *viewports) override;
 	void SetBlendFactor(float color[4]) override;
-	void SetStencilRef(uint8_t stencilRef) override;
+	void SetStencilParams(uint8_t refValue, uint8_t writeMask, uint8_t compareMask) override;
 
 	void BindSamplerStates(int start, int count, SamplerState **state) override;
 	void BindTextures(int start, int count, Texture **textures) override;
@@ -554,6 +554,8 @@ private:
 	DeviceCaps caps_{};
 
 	uint8_t stencilRef_ = 0;
+	uint8_t stencilWriteMask_ = 0xFF;
+	uint8_t stencilCompareMask_ = 0xFF;
 };
 
 static int GetBpp(VkFormat format) {
@@ -1160,10 +1162,12 @@ void VKContext::SetBlendFactor(float color[4]) {
 	renderManager_.SetBlendFactor(col);
 }
 
-void VKContext::SetStencilRef(uint8_t stencilRef) {
+void VKContext::SetStencilParams(uint8_t refValue, uint8_t writeMask, uint8_t compareMask) {
 	if (curPipeline_->usesStencil)
-		renderManager_.SetStencilParams(curPipeline_->stencilWriteMask, curPipeline_->stencilTestMask, stencilRef);
-	stencilRef_ = stencilRef;
+		renderManager_.SetStencilParams(writeMask, compareMask, refValue);
+	stencilRef_ = refValue;
+	stencilWriteMask_ = refValue;
+	stencilCompareMask_ = refValue;
 }
 
 InputLayout *VKContext::CreateInputLayout(const InputLayoutDesc &desc) {
@@ -1208,8 +1212,6 @@ Texture *VKContext::CreateTexture(const TextureDesc &desc) {
 }
 
 static inline void CopySide(VkStencilOpState &dest, const StencilSetup &src) {
-	dest.compareMask = src.compareMask;
-	dest.writeMask = src.writeMask;
 	dest.compareOp = compToVK[(int)src.compareOp];
 	dest.failOp = stencilOpToVK[(int)src.failOp];
 	dest.passOp = stencilOpToVK[(int)src.passOp];

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -283,8 +283,6 @@ public:
 	int dynamicUniformSize = 0;
 
 	bool usesStencil = false;
-	uint8_t stencilWriteMask = 0xFF;
-	uint8_t stencilTestMask = 0xFF;
 
 private:
 	VulkanContext *vulkan_;
@@ -1133,8 +1131,6 @@ Pipeline *VKContext::CreateGraphicsPipeline(const PipelineDesc &desc) {
 	}
 	if (depth->info.stencilTestEnable) {
 		pipeline->usesStencil = true;
-		pipeline->stencilTestMask = depth->info.front.compareMask;
-		pipeline->stencilWriteMask = depth->info.front.writeMask;
 	}
 	return pipeline;
 }
@@ -1166,8 +1162,8 @@ void VKContext::SetStencilParams(uint8_t refValue, uint8_t writeMask, uint8_t co
 	if (curPipeline_->usesStencil)
 		renderManager_.SetStencilParams(writeMask, compareMask, refValue);
 	stencilRef_ = refValue;
-	stencilWriteMask_ = refValue;
-	stencilCompareMask_ = refValue;
+	stencilWriteMask_ = writeMask;
+	stencilCompareMask_ = compareMask;
 }
 
 InputLayout *VKContext::CreateInputLayout(const InputLayoutDesc &desc) {
@@ -1315,7 +1311,7 @@ void VKContext::UpdateDynamicUniformBuffer(const void *ub, size_t size) {
 void VKContext::ApplyDynamicState() {
 	// TODO: blend constants, stencil, viewports should be here, after bindpipeline..
 	if (curPipeline_->usesStencil) {
-		renderManager_.SetStencilParams(curPipeline_->stencilWriteMask, curPipeline_->stencilTestMask, stencilRef_);
+		renderManager_.SetStencilParams(stencilWriteMask_, stencilCompareMask_, stencilRef_);
 	}
 }
 

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1207,7 +1207,7 @@ Texture *VKContext::CreateTexture(const TextureDesc &desc) {
 	}
 }
 
-static inline void CopySide(VkStencilOpState &dest, const StencilSide &src) {
+static inline void CopySide(VkStencilOpState &dest, const StencilSetup &src) {
 	dest.compareMask = src.compareMask;
 	dest.writeMask = src.writeMask;
 	dest.compareOp = compToVK[(int)src.compareOp];
@@ -1224,8 +1224,8 @@ DepthStencilState *VKContext::CreateDepthStencilState(const DepthStencilStateDes
 	ds->info.stencilTestEnable = desc.stencilEnabled;
 	ds->info.depthBoundsTestEnable = false;
 	if (ds->info.stencilTestEnable) {
-		CopySide(ds->info.front, desc.front);
-		CopySide(ds->info.back, desc.back);
+		CopySide(ds->info.front, desc.stencil);
+		CopySide(ds->info.back, desc.stencil);
 	}
 	return ds;
 }

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -453,7 +453,7 @@ public:
 
 class RasterState : public RefCountedObject {};
 
-struct StencilSide {
+struct StencilSetup {
 	StencilOp failOp;
 	StencilOp passOp;
 	StencilOp depthFailOp;
@@ -467,8 +467,7 @@ struct DepthStencilStateDesc {
 	bool depthWriteEnabled;
 	Comparison depthCompare;
 	bool stencilEnabled;
-	StencilSide front;
-	StencilSide back;
+	StencilSetup stencil;
 };
 
 struct BlendStateDesc {

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -458,8 +458,6 @@ struct StencilSetup {
 	StencilOp passOp;
 	StencilOp depthFailOp;
 	Comparison compareOp;
-	uint8_t compareMask;
-	uint8_t writeMask;
 };
 
 struct DepthStencilStateDesc {
@@ -651,7 +649,7 @@ public:
 	virtual void SetScissorRect(int left, int top, int width, int height) = 0;
 	virtual void SetViewports(int count, Viewport *viewports) = 0;
 	virtual void SetBlendFactor(float color[4]) = 0;
-	virtual void SetStencilRef(uint8_t ref) = 0;
+	virtual void SetStencilParams(uint8_t refValue, uint8_t writeMask, uint8_t compareMask) = 0;
 
 	virtual void BindSamplerStates(int start, int count, SamplerState **state) = 0;
 	virtual void BindTextures(int start, int count, Texture **textures) = 0;

--- a/UI/GPUDriverTestScreen.cpp
+++ b/UI/GPUDriverTestScreen.cpp
@@ -329,13 +329,12 @@ void GPUDriverTestScreen::DiscardTest() {
 		dsDesc.depthWriteEnabled = true;
 		dsDesc.depthCompare = Comparison::ALWAYS;
 		dsDesc.stencilEnabled = true;
-		dsDesc.front.compareMask = 0xFF;
-		dsDesc.front.compareOp = Comparison::ALWAYS;
-		dsDesc.front.passOp = StencilOp::REPLACE;
-		dsDesc.front.failOp = StencilOp::REPLACE;  // These two shouldn't matter, because the test that fails is discard, not stencil.
-		dsDesc.front.depthFailOp = StencilOp::REPLACE;
-		dsDesc.front.writeMask = 0xFF;
-		dsDesc.back = dsDesc.front;
+		dsDesc.stencil.compareMask = 0xFF;
+		dsDesc.stencil.compareOp = Comparison::ALWAYS;
+		dsDesc.stencil.passOp = StencilOp::REPLACE;
+		dsDesc.stencil.failOp = StencilOp::REPLACE;  // These two shouldn't matter, because the test that fails is discard, not stencil.
+		dsDesc.stencil.depthFailOp = StencilOp::REPLACE;
+		dsDesc.stencil.writeMask = 0xFF;
 		DepthStencilState *depthStencilWrite = draw->CreateDepthStencilState(dsDesc);
 
 		// Write only depth.
@@ -353,33 +352,28 @@ void GPUDriverTestScreen::DiscardTest() {
 		dsDesc.depthTestEnabled = true;
 		dsDesc.stencilEnabled = true;
 		dsDesc.depthCompare = Comparison::ALWAYS;
-		dsDesc.front.compareOp = Comparison::EQUAL;
-		dsDesc.front.failOp = StencilOp::KEEP;
-		dsDesc.front.depthFailOp = StencilOp::KEEP;
-		dsDesc.front.writeMask = 0x0;
-		dsDesc.back = dsDesc.front;
+		dsDesc.stencil.compareOp = Comparison::EQUAL;
+		dsDesc.stencil.failOp = StencilOp::KEEP;
+		dsDesc.stencil.depthFailOp = StencilOp::KEEP;
+		dsDesc.stencil.writeMask = 0x0;
 		DepthStencilState *stencilEqualDepthAlways = draw->CreateDepthStencilState(dsDesc);
 
 		dsDesc.depthTestEnabled = false;
-		dsDesc.front.compareOp = Comparison::EQUAL;
-		dsDesc.back = dsDesc.front;
+		dsDesc.stencil.compareOp = Comparison::EQUAL;
 		DepthStencilState *stencilEqual = draw->CreateDepthStencilState(dsDesc);
 
 		dsDesc.depthTestEnabled = true;
 		dsDesc.depthCompare = Comparison::ALWAYS;
-		dsDesc.front.compareOp = Comparison::NOT_EQUAL;
-		dsDesc.back = dsDesc.front;
+		dsDesc.stencil.compareOp = Comparison::NOT_EQUAL;
 		DepthStencilState *stenciNotEqualDepthAlways = draw->CreateDepthStencilState(dsDesc);
 
 		dsDesc.depthTestEnabled = false;
-		dsDesc.front.compareOp = Comparison::NOT_EQUAL;
-		dsDesc.back = dsDesc.front;
+		dsDesc.stencil.compareOp = Comparison::NOT_EQUAL;
 		DepthStencilState *stencilNotEqual = draw->CreateDepthStencilState(dsDesc);
 
 		dsDesc.stencilEnabled = true;
 		dsDesc.depthTestEnabled = true;
-		dsDesc.front.compareOp = Comparison::ALWAYS;
-		dsDesc.back = dsDesc.front;
+		dsDesc.stencil.compareOp = Comparison::ALWAYS;
 		dsDesc.depthCompare = Comparison::LESS_EQUAL;
 		DepthStencilState *stencilAlwaysDepthTestLessEqual = draw->CreateDepthStencilState(dsDesc);
 		dsDesc.depthCompare = Comparison::GREATER;

--- a/UI/GPUDriverTestScreen.cpp
+++ b/UI/GPUDriverTestScreen.cpp
@@ -329,12 +329,10 @@ void GPUDriverTestScreen::DiscardTest() {
 		dsDesc.depthWriteEnabled = true;
 		dsDesc.depthCompare = Comparison::ALWAYS;
 		dsDesc.stencilEnabled = true;
-		dsDesc.stencil.compareMask = 0xFF;
 		dsDesc.stencil.compareOp = Comparison::ALWAYS;
 		dsDesc.stencil.passOp = StencilOp::REPLACE;
 		dsDesc.stencil.failOp = StencilOp::REPLACE;  // These two shouldn't matter, because the test that fails is discard, not stencil.
 		dsDesc.stencil.depthFailOp = StencilOp::REPLACE;
-		dsDesc.stencil.writeMask = 0xFF;
 		DepthStencilState *depthStencilWrite = draw->CreateDepthStencilState(dsDesc);
 
 		// Write only depth.
@@ -355,7 +353,6 @@ void GPUDriverTestScreen::DiscardTest() {
 		dsDesc.stencil.compareOp = Comparison::EQUAL;
 		dsDesc.stencil.failOp = StencilOp::KEEP;
 		dsDesc.stencil.depthFailOp = StencilOp::KEEP;
-		dsDesc.stencil.writeMask = 0x0;
 		DepthStencilState *stencilEqualDepthAlways = draw->CreateDepthStencilState(dsDesc);
 
 		dsDesc.depthTestEnabled = false;
@@ -500,27 +497,28 @@ void GPUDriverTestScreen::DiscardTest() {
 
 			dc.BeginPipeline(writePipelines[j], samplerNearest_);
 			// Draw the rectangle with stencil value 0, depth 0.1f and the text with stencil 0xFF, depth 0.9. Then set 0xFF as the stencil value and draw the rectangles at depth 0.5.
-			draw->SetStencilRef(0x0);
+
+			draw->SetStencilParams(0, 0xFF, 0xFF);
 			dc.SetCurZ(0.1f);
 			dc.FillRect(UI::Drawable(bgColorBAD), bounds);
 			// test bounds
 			dc.Flush();
 
-			draw->SetStencilRef(0xff);
+			draw->SetStencilParams(0xff, 0xFF, 0xFF);
 			dc.SetCurZ(0.9f);
 			dc.DrawTextRect("TEST OK", bounds, textColorBAD, ALIGN_HCENTER | ALIGN_VCENTER | FLAG_DYNAMIC_ASCII);
 			dc.Flush();
 
 			// Draw rectangle that should result in the text
 			dc.BeginPipeline(testPipeline1[i], samplerNearest_);
-			draw->SetStencilRef(0xff);
+			draw->SetStencilParams(0xff, 0, 0xFF);
 			dc.SetCurZ(0.5f);
 			dc.FillRect(UI::Drawable(textColorOK), bounds);
 			dc.Flush();
 
 			// Draw rectangle that should result in the bg
 			dc.BeginPipeline(testPipeline2[i], samplerNearest_);
-			draw->SetStencilRef(0xff);
+			draw->SetStencilParams(0xff, 0, 0xFF);
 			dc.SetCurZ(0.5f);
 			dc.FillRect(UI::Drawable(bgColorOK), bounds);
 			dc.Flush();


### PR DESCRIPTION
"thin3d" is the little API wrapper we use for UI and for backend-independent operations, to avoid having to duplicate too much code.

I want to port more internal "shader effects" like stencil upload (see Star Ocean) to use thin3d so we don't need multiple implementations, and that work will also make it easier to add more like depth upload, and to do that, thin3d needs some more functionality, of which this adds some.

This adds support for setting more stencil parameters dynamically (which requires some emulation in the d3d11 backend, but worth it), but also removes dual-sided stencil since we don't have any use for that functionality, and I don't expect we will.