### PR TITLE
Unify the LoadTextureLevel function between three of the backends

### DIFF
--- a/Common/Thread/ParallelLoop.cpp
+++ b/Common/Thread/ParallelLoop.cpp
@@ -107,7 +107,7 @@ void ParallelRangeLoop(ThreadManager *threadMan, const std::function<void(int, i
 // NOTE: Supports a max of 2GB.
 void ParallelMemcpy(ThreadManager *threadMan, void *dst, const void *src, size_t bytes) {
 	// This threshold can probably be a lot bigger.
-	if (true || bytes < 512) {
+	if (bytes < 512) {
 		memcpy(dst, src, bytes);
 		return;
 	}

--- a/Common/Thread/ParallelLoop.cpp
+++ b/Common/Thread/ParallelLoop.cpp
@@ -107,7 +107,7 @@ void ParallelRangeLoop(ThreadManager *threadMan, const std::function<void(int, i
 // NOTE: Supports a max of 2GB.
 void ParallelMemcpy(ThreadManager *threadMan, void *dst, const void *src, size_t bytes) {
 	// This threshold can probably be a lot bigger.
-	if (bytes < 512) {
+	if (true || bytes < 512) {
 		memcpy(dst, src, bytes);
 		return;
 	}

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2143,9 +2143,11 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 	return true;
 }
 
-void TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, int stride, ReplacedTexture &replaced, int srcLevel, int scaleFactor, Draw::DataFormat dstFmt) {
+void TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, int stride, ReplacedTexture &replaced, int srcLevel, int scaleFactor, Draw::DataFormat dstFmt, bool reverseColors) {
 	int w = gstate.getTextureWidth(srcLevel);
 	int h = gstate.getTextureHeight(srcLevel);
+
+	PROFILE_THIS_SCOPE("decodetex");
 
 	if (replaced.GetSize(srcLevel, w, h)) {
 		double replaceStart = time_now_d();
@@ -2170,7 +2172,7 @@ void TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, i
 
 		bool expand32 = !gstate_c.Supports(GPU_SUPPORTS_16BIT_FORMATS) || scaleFactor > 1;
 
-		CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, srcLevel, bufw, false, expand32);
+		CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, srcLevel, bufw, reverseColors, expand32);
 		entry.SetAlphaStatus(alphaResult, srcLevel);
 
 		if (scaleFactor > 1) {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2011,6 +2011,8 @@ std::string AttachCandidate::ToString() {
 }
 
 bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEntry *entry) {
+	gpuStats.numTexturesDecoded++;
+
 	// For the estimate, we assume cluts always point to 8888 for simplicity.
 	cacheSizeEstimate_ += EstimateTexMemoryUsage(entry);
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2143,7 +2143,7 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 	return true;
 }
 
-uint8_t *TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, int stride, ReplacedTexture &replaced, int srcLevel, int scaleFactor, Draw::DataFormat dstFmt) {
+void TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, int stride, ReplacedTexture &replaced, int srcLevel, int scaleFactor, Draw::DataFormat dstFmt) {
 	int w = gstate.getTextureWidth(srcLevel);
 	int h = gstate.getTextureHeight(srcLevel);
 
@@ -2205,6 +2205,4 @@ uint8_t *TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *dat
 			replacer_.NotifyTextureDecoded(replacedInfo, pixelData, decPitch, srcLevel, w, h);
 		}
 	}
-
-	return data;
 }

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -330,7 +330,7 @@ protected:
 	ReplacedTexture &FindReplacement(TexCacheEntry *entry, int &w, int &h);
 
 	// Return value is mapData normally, but could be another buffer allocated with AllocateAlignedMemory.
-	void LoadTextureLevel(TexCacheEntry &entry, uint8_t *mapData, int mapRowPitch, ReplacedTexture &replaced, int srcLevel, int scaleFactor, Draw::DataFormat dstFmt);
+	void LoadTextureLevel(TexCacheEntry &entry, uint8_t *mapData, int mapRowPitch, ReplacedTexture &replaced, int srcLevel, int scaleFactor, Draw::DataFormat dstFmt, bool reverseColors);
 
 	template <typename T>
 	inline const T *GetCurrentClut() {

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -330,7 +330,7 @@ protected:
 	ReplacedTexture &FindReplacement(TexCacheEntry *entry, int &w, int &h);
 
 	// Return value is mapData normally, but could be another buffer allocated with AllocateAlignedMemory.
-	uint8_t *LoadTextureLevel(TexCacheEntry &entry, uint8_t *mapData, int mapRowPitch, ReplacedTexture &replaced, int srcLevel, int scaleFactor, Draw::DataFormat dstFmt);
+	void LoadTextureLevel(TexCacheEntry &entry, uint8_t *mapData, int mapRowPitch, ReplacedTexture &replaced, int srcLevel, int scaleFactor, Draw::DataFormat dstFmt);
 
 	template <typename T>
 	inline const T *GetCurrentClut() {

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -329,6 +329,9 @@ protected:
 	CheckAlphaResult ReadIndexedTex(u8 *out, int outPitch, int level, const u8 *texptr, int bytesPerIndex, int bufw, bool reverseColors, bool expandTo32Bit);
 	ReplacedTexture &FindReplacement(TexCacheEntry *entry, int &w, int &h);
 
+	// Return value is mapData normally, but could be another buffer allocated with AllocateAlignedMemory.
+	uint8_t *LoadTextureLevel(TexCacheEntry &entry, uint8_t *mapData, int mapRowPitch, ReplacedTexture &replaced, int srcLevel, int scaleFactor, Draw::DataFormat dstFmt);
+
 	template <typename T>
 	inline const T *GetCurrentClut() {
 		return (const T *)clutBuf_;

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -598,8 +598,6 @@ void TextureCacheD3D11::LoadTextureLevel(TexCacheEntry &entry, uint8_t *mapData,
 	int w = gstate.getTextureWidth(srcLevel);
 	int h = gstate.getTextureHeight(srcLevel);
 
-	gpuStats.numTexturesDecoded++;
-
 	if (replaced.GetSize(srcLevel, w, h)) {
 		double replaceStart = time_now_d();
 		replaced.Load(srcLevel, mapData, mapRowPitch);

--- a/GPU/D3D11/TextureCacheD3D11.h
+++ b/GPU/D3D11/TextureCacheD3D11.h
@@ -67,7 +67,6 @@ protected:
 	void ReleaseTexture(TexCacheEntry *entry, bool delete_them) override;
 
 private:
-	void LoadTextureLevel(TexCacheEntry &entry, uint8_t *mapData, int mapRowPitch, ReplacedTexture &replaced, int srcLevel, int scaleFactor, DXGI_FORMAT dstFmt);
 	DXGI_FORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
 	static CheckAlphaResult CheckAlpha(const u32 *pixelData, u32 dstFmt, int w);
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;

--- a/GPU/D3D11/TextureCacheD3D11.h
+++ b/GPU/D3D11/TextureCacheD3D11.h
@@ -67,7 +67,7 @@ protected:
 	void ReleaseTexture(TexCacheEntry *entry, bool delete_them) override;
 
 private:
-	void LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int srcLevel, int dstLevel, int scaleFactor, DXGI_FORMAT dstFmt);
+	void LoadTextureLevel(TexCacheEntry &entry, uint8_t *mapData, int mapRowPitch, ReplacedTexture &replaced, int srcLevel, int scaleFactor, DXGI_FORMAT dstFmt);
 	DXGI_FORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
 	static CheckAlphaResult CheckAlpha(const u32 *pixelData, u32 dstFmt, int w);
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -460,7 +460,7 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 		uint8_t *data = (uint8_t *)rect.pBits;
 		int stride = rect.Pitch;
 
-		data = LoadTextureLevel(*entry, data, stride, *plan.replaced, (i == 0) ? plan.baseLevelSrc : i, plan.scaleFactor, texFmt);
+		LoadTextureLevel(*entry, data, stride, *plan.replaced, (i == 0) ? plan.baseLevelSrc : i, plan.scaleFactor, texFmt);
 
 		texture->UnlockRect(dstLevel);
 	}

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -508,7 +508,6 @@ void TextureCacheDX9::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, int 
 	int w = gstate.getTextureWidth(level);
 	int h = gstate.getTextureHeight(level);
 
-	gpuStats.numTexturesDecoded++;
 	if (replaced.GetSize(level, w, h)) {
 		double replaceStart = time_now_d();
 		replaced.Load(level, data, stride);

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -413,23 +413,21 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 	int tw = plan.w;
 	int th = plan.h;
 
-	LPDIRECT3DTEXTURE9 &texture = DxTex(entry);
 	D3DFORMAT dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
-	D3DPOOL pool = D3DPOOL_DEFAULT;
-	int usage = D3DUSAGE_DYNAMIC;
 	if (plan.replaced->GetSize(plan.baseLevelSrc, tw, th)) {
 		dstFmt = ToD3D9Format(plan.replaced->Format(plan.baseLevelSrc));
-	} else {
+	} else if (plan.scaleFactor > 1) {
 		tw *= plan.scaleFactor;
 		th *= plan.scaleFactor;
-		if (plan.scaleFactor > 1) {
-			dstFmt = D3DFMT_A8R8G8B8;
-		}
+		dstFmt = D3DFMT_A8R8G8B8;
 	}
 
 	// We don't yet have mip generation, so clamp the number of levels to the ones we can load directly.
 	int levels = std::min(plan.levelsToCreate, plan.levelsToLoad);
 
+	LPDIRECT3DTEXTURE9 &texture = DxTex(entry);
+	D3DPOOL pool = D3DPOOL_DEFAULT;
+	int usage = D3DUSAGE_DYNAMIC;
 	HRESULT hr = device_->CreateTexture(tw, th, levels, usage, dstFmt, pool, &texture, NULL);
 
 	if (FAILED(hr)) {
@@ -460,7 +458,7 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 		uint8_t *data = (uint8_t *)rect.pBits;
 		int stride = rect.Pitch;
 
-		LoadTextureLevel(*entry, data, stride, *plan.replaced, (i == 0) ? plan.baseLevelSrc : i, plan.scaleFactor, texFmt);
+		LoadTextureLevel(*entry, data, stride, *plan.replaced, (i == 0) ? plan.baseLevelSrc : i, plan.scaleFactor, texFmt, false);
 
 		texture->UnlockRect(dstLevel);
 	}

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -61,7 +61,6 @@ protected:
 private:
 	void ApplySamplingParams(const SamplerCacheKey &key);
 
-	void LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, int stride, ReplacedTexture &replaced, int srcLevel, int scaleFactor, u32 dstFmt);
 	D3DFORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
 	static CheckAlphaResult CheckAlpha(const u32 *pixelData, u32 dstFmt, int w);
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -445,12 +445,10 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 	Draw::DataFormat dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
 	if (plan.replaced->GetSize(plan.baseLevelSrc, tw, th)) {
 		dstFmt = plan.replaced->Format(plan.baseLevelSrc);
-	} else {
+	} else if (plan.scaleFactor > 1) {
 		tw *= plan.scaleFactor;
 		th *= plan.scaleFactor;
-		if (plan.scaleFactor > 1) {
-			dstFmt = Draw::DataFormat::R8G8B8A8_UNORM;
-		}
+		dstFmt = Draw::DataFormat::R8G8B8A8_UNORM;
 	}
 
 	entry->textureName = render_->CreateTexture(GL_TEXTURE_2D, tw, tw, plan.levelsToCreate);
@@ -471,18 +469,45 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 	}
 
 	for (int i = 0; i < plan.levelsToLoad; i++) {
-		LoadTextureLevel(*entry, *plan.replaced, i == 0 ? plan.baseLevelSrc : i, i, plan.scaleFactor, dstFmt);
+		int srcLevel = i == 0 ? plan.baseLevelSrc : i;
+
+		int w = gstate.getTextureWidth(srcLevel);
+		int h = gstate.getTextureHeight(srcLevel);
+
+		u8 *data = nullptr;
+		int stride = 0;
+
+		if (plan.replaced->GetSize(srcLevel, w, h)) {
+			int bpp = (int)Draw::DataFormatSizeInBytes(plan.replaced->Format(srcLevel));
+			stride = w * bpp;
+			data = (u8 *)AllocateAlignedMemory(stride * h, 16);
+		} else {
+			if (plan.scaleFactor > 1) {
+				data = (u8 *)AllocateAlignedMemory(4 * (w * plan.scaleFactor) * (h * plan.scaleFactor), 16);
+				stride = w * plan.scaleFactor * 4;
+			} else {
+				int bpp = dstFmt == Draw::DataFormat::R8G8B8A8_UNORM ? 4 : 2;
+
+				stride = std::max(w * bpp, 4);
+				data = (u8 *)AllocateAlignedMemory(stride * h, 16);
+			}
+		}
+
+		if (!data) {
+			ERROR_LOG(G3D, "Ran out of RAM trying to allocate a temporary texture upload buffer (%dx%d)", w, h);
+			return;
+		}
+
+		LoadTextureLevel(*entry, data, stride, *plan.replaced, srcLevel, plan.scaleFactor, dstFmt, true);
+
+		// NOTE: TextureImage takes ownership of data, so we don't free it afterwards.
+		render_->TextureImage(entry->textureName, i, w * plan.scaleFactor, h * plan.scaleFactor, dstFmt, data, GLRAllocType::ALIGNED);
 	}
 
 	bool genMips = plan.levelsToCreate > plan.levelsToLoad;
 
 	render_->FinalizeTexture(entry->textureName, plan.levelsToLoad, genMips);
 
-	if (plan.levelsToLoad == 1) {
-		entry->status |= TexCacheEntry::STATUS_NO_MIPS;
-	} else {
-		entry->status &= ~TexCacheEntry::STATUS_NO_MIPS;
-	}
 	if (plan.replaced->Valid()) {
 		entry->SetAlphaStatus(TexCacheEntry::TexStatus(plan.replaced->AlphaStatus()));
 	}
@@ -522,65 +547,6 @@ CheckAlphaResult TextureCacheGLES::CheckAlpha(const uint8_t *pixelData, Draw::Da
 	default:
 		return CheckAlpha32((const u32 *)pixelData, w, 0xFF000000);  // note, the normal order here, unlike the 16-bit formats
 	}
-}
-
-void TextureCacheGLES::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int srcLevel, int dstLevel, int scaleFactor, Draw::DataFormat dstFmt) {
-	int w = gstate.getTextureWidth(srcLevel);
-	int h = gstate.getTextureHeight(srcLevel);
-	uint8_t *pixelData;
-	int decPitch = 0;
-
-	if (replaced.GetSize(srcLevel, w, h)) {
-		int bpp = (int)DataFormatSizeInBytes(replaced.Format(srcLevel));
-		
-		decPitch = w * bpp;
-		uint8_t *rearrange = (uint8_t *)AllocateAlignedMemory(decPitch * h, 16);
-		double replaceStart = time_now_d();
-		replaced.Load(srcLevel, rearrange, decPitch);
-		replacementTimeThisFrame_ += time_now_d() - replaceStart;
-		pixelData = rearrange;
-
-		dstFmt = replaced.Format(srcLevel);
-	} else {
-		GEPaletteFormat clutformat = gstate.getClutPaletteFormat();
-		u32 texaddr = gstate.getTextureAddress(srcLevel);
-		int bufw = GetTextureBufw(srcLevel, texaddr, GETextureFormat(entry.format));
-
-		int pixelSize = dstFmt == Draw::DataFormat::R8G8B8A8_UNORM ? 4 : 2;
-
-		// We leave GL_UNPACK_ALIGNMENT at 4, so this must be at least 4.
-		decPitch = std::max(w * pixelSize, 4);
-
-		pixelData = (uint8_t *)AllocateAlignedMemory(decPitch * h * pixelSize, 16);
-
-		bool expand32 = scaleFactor > 1;
-
-		CheckAlphaResult alphaStatus = DecodeTextureLevel(pixelData, decPitch, GETextureFormat(entry.format), clutformat, texaddr, srcLevel, bufw, true, expand32);
-		entry.SetAlphaStatus(alphaStatus, srcLevel);
-
-		if (scaleFactor > 1) {
-			uint8_t *rearrange = (uint8_t *)AllocateAlignedMemory(w * scaleFactor * h * scaleFactor * 4, 16);
-			scaler_.ScaleAlways((u32 *)rearrange, (u32 *)pixelData, w, h, scaleFactor);
-			FreeAlignedMemory(pixelData);
-			pixelData = rearrange;
-			decPitch = w * 4;
-		}
-
-		if (replacer_.Enabled()) {
-			ReplacedTextureDecodeInfo replacedInfo;
-			replacedInfo.cachekey = entry.CacheKey();
-			replacedInfo.hash = entry.fullhash;
-			replacedInfo.addr = entry.addr;
-			replacedInfo.isVideo = IsVideo(entry.addr);
-			replacedInfo.isFinal = (entry.status & TexCacheEntry::STATUS_TO_SCALE) == 0;
-			replacedInfo.scaleFactor = scaleFactor;
-			replacedInfo.fmt = dstFmt;
-
-			replacer_.NotifyTextureDecoded(replacedInfo, pixelData, decPitch, srcLevel, w, h);
-		}
-	}
-	
-	render_->TextureImage(entry.textureName, dstLevel, w, h, dstFmt, pixelData, GLRAllocType::ALIGNED);
 }
 
 bool TextureCacheGLES::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) {

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -530,8 +530,6 @@ void TextureCacheGLES::LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &r
 	uint8_t *pixelData;
 	int decPitch = 0;
 
-	gpuStats.numTexturesDecoded++;
-
 	if (replaced.GetSize(srcLevel, w, h)) {
 		int bpp = (int)DataFormatSizeInBytes(replaced.Format(srcLevel));
 		

--- a/GPU/GLES/TextureCacheGLES.h
+++ b/GPU/GLES/TextureCacheGLES.h
@@ -69,7 +69,6 @@ protected:
 
 private:
 	void ApplySamplingParams(const SamplerCacheKey &key);
-	void LoadTextureLevel(TexCacheEntry &entry, ReplacedTexture &replaced, int srcLevel, int dstLevel, int scaleFactor, Draw::DataFormat dstFmt);
 	Draw::DataFormat GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
 
 	static CheckAlphaResult CheckAlpha(const uint8_t *pixelData, Draw::DataFormat dstFmt, int w);

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -845,8 +845,6 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 	int w = gstate.getTextureWidth(level);
 	int h = gstate.getTextureHeight(level);
 
-	gpuStats.numTexturesDecoded++;
-
 	PROFILE_THIS_SCOPE("decodetex");
 
 	GETextureFormat tfmt = (GETextureFormat)entry.format;
@@ -858,21 +856,22 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 	int bufw = GetTextureBufw(level, texaddr, tfmt);
 	int bpp = dstFmt == VULKAN_8888_FORMAT ? 4 : 2;
 
-	u32 *pixelData = (u32 *)writePtr;
-	int decPitch = rowPitch;
+	u32 *pixelData;
+	int decPitch;
 
-	bool expand32 = !gstate_c.Supports(GPU_SUPPORTS_16BIT_FORMATS) || dstFmt == VK_FORMAT_R8G8B8A8_UNORM || scaleFactor > 1;
+	bool expand32 = !gstate_c.Supports(GPU_SUPPORTS_16BIT_FORMATS) || scaleFactor > 1;
 
 	if (scaleFactor > 1) {
 		tmpTexBufRearrange_.resize(std::max(bufw, w) * h);
 		pixelData = tmpTexBufRearrange_.data();
 		// We want to end up with a neatly packed texture for scaling.
 		decPitch = w * bpp;
+	} else {
+		pixelData = (u32 *)writePtr;
+		decPitch = rowPitch;
 	}
 
 	CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, level, bufw, false, expand32);
-
-	// WARN_LOG(G3D, "Alpha: full=%d w=%d h=%d level=%d %s/%s", (int)(alphaResult == CHECKALPHA_FULL), w, h, level, GeTextureFormatToString(tfmt), GEPaletteFormatToString(clutformat));
 	entry.SetAlphaStatus(alphaResult, level);
 
 	if (scaleFactor > 1) {

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -845,8 +845,6 @@ void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePt
 	int w = gstate.getTextureWidth(level);
 	int h = gstate.getTextureHeight(level);
 
-	PROFILE_THIS_SCOPE("decodetex");
-
 	GETextureFormat tfmt = (GETextureFormat)entry.format;
 	GEPaletteFormat clutformat = gstate.getClutPaletteFormat();
 	u32 texaddr = gstate.getTextureAddress(level);


### PR DESCRIPTION
More prep for #15727 .

This breaks out all memory management from LoadTextureLevel, at which point the function becomes identical for all three backends. Note that Vulkan is still using its own implementation of the function due to some differences that I might be able to get rid of later, but this is still a nice cleanup and does finally set the stage for enabling #15727 on the other backends.