### PR TITLE
CI: also upload release source tarball on tag push

### DIFF
--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -5,6 +5,9 @@ on:
   release:
     types:
       - created
+  push:
+    tags:
+      - "v*.*.*"
 
 jobs:
   build:
@@ -19,7 +22,9 @@ jobs:
     - name: archive
       id: archive
       run: |
-        VERSION=$(printf "%s\n" ${{ github.event.release.tag_name }} | sed 's/^v//')
+        VERSION=${GITHUB_REF##*/}
+        test -z "$VERSION" && VERSION=${{ github.event.release.tag_name }}
+        VERSION=$(printf "%s\n" "$VERSION" | sed 's/^v//')
         PKGNAME="ppsspp-$VERSION"
         mkdir -p /tmp/$PKGNAME
         mv * /tmp/$PKGNAME
@@ -38,11 +43,7 @@ jobs:
         echo "::set-output name=tarball::$TARBALL"
 
     - name: upload tarball
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: softprops/action-gh-release@v1
       with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./${{ steps.archive.outputs.tarball }}
-        asset_name: ${{ steps.archive.outputs.tarball }}
-        asset_content_type: application/x-xz
+       files: ${{ steps.archive.outputs.tarball }}
+       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -45,5 +45,5 @@ jobs:
     - name: upload tarball
       uses: softprops/action-gh-release@v1
       with:
-       files: ${{ steps.archive.outputs.tarball }}
-       token: ${{ secrets.GITHUB_TOKEN }}
+        files: ${{ steps.archive.outputs.tarball }}
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
the mac os build action uses an action that automatically creates
a release from a tag push, which circumvents triggering the regular
release actions.

also switch from the unmaintained actions/upload-release-asset@v1
to the active softprops/action-gh-release@v1 action.

closes #15761