### PR TITLE
Reporting: Disable when debugger methods used

### DIFF
--- a/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp
+++ b/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp
@@ -24,6 +24,7 @@
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSDebugInterface.h"
+#include "Core/Reporting.h"
 
 DebuggerSubscriber *WebSocketCPUCoreInit(DebuggerEventHandlerMap &map) {
 	// No need to bind or alloc state, these are all global.
@@ -364,6 +365,8 @@ void WebSocketCPUSetReg(DebuggerRequest &req) {
 		// Error response already sent.
 		return;
 	}
+
+	Reporting::NotifyDebugger();
 
 	JsonWriter &json = req.Respond();
 	// Repeat it back just to avoid confusion on how it parsed.

--- a/Core/Debugger/WebSocket/DisasmSubscriber.cpp
+++ b/Core/Debugger/WebSocket/DisasmSubscriber.cpp
@@ -29,6 +29,7 @@
 #include "Core/MemMap.h"
 #include "Core/MIPS/MIPSAsm.h"
 #include "Core/MIPS/MIPSDebugInterface.h"
+#include "Core/Reporting.h"
 
 class WebSocketDisasmState : public DebuggerSubscriber {
 public:
@@ -261,6 +262,7 @@ void WebSocketDisasmState::WriteBranchGuide(JsonWriter &json, const BranchLine &
 //  - addressHex: string indicating base address in hexadecimal (may be 64 bit.)
 void WebSocketDisasmState::Base(DebuggerRequest &req) {
 	JsonWriter &json = req.Respond();
+	Reporting::NotifyDebugger();
 	json.writeString("addressHex", StringFromFormat("%016llx", (uintptr_t)Memory::base));
 }
 
@@ -483,5 +485,6 @@ void WebSocketDisasmState::Assemble(DebuggerRequest &req) {
 		return req.Fail(StringFromFormat("Could not assemble: %s", ConvertWStringToUTF8(MIPSAsm::GetAssembleError()).c_str()));
 
 	JsonWriter &json = req.Respond();
+	Reporting::NotifyDebugger();
 	json.writeUint("encoding", Memory::Read_Instruction(address).encoding);
 }

--- a/Core/Debugger/WebSocket/HLESubscriber.cpp
+++ b/Core/Debugger/WebSocket/HLESubscriber.cpp
@@ -26,6 +26,7 @@
 #include "Core/MIPS/MIPSDebugInterface.h"
 #include "Core/MIPS/MIPSStackWalk.h"
 #include "Core/HLE/sceKernelThread.h"
+#include "Core/Reporting.h"
 
 DebuggerSubscriber *WebSocketHLEInit(DebuggerEventHandlerMap &map) {
 	map["hle.thread.list"] = &WebSocketHLEThreadList;
@@ -146,6 +147,8 @@ void WebSocketHLEThreadWake(DebuggerRequest &req) {
 		return req.Fail("Cannot force run thread based on current status");
 	}
 
+	Reporting::NotifyDebugger();
+
 	JsonWriter &json = req.Respond();
 	json.writeUint("thread", threadInfo.id);
 	json.writeString("status", "ready");
@@ -181,6 +184,8 @@ void WebSocketHLEThreadStop(DebuggerRequest &req) {
 		return;
 	if ((threadInfo.status & THREADSTATUS_DORMANT) == 0)
 		return req.Fail("Failed to stop thread");
+
+	Reporting::NotifyDebugger();
 
 	JsonWriter &json = req.Respond();
 	json.writeUint("thread", threadInfo.id);

--- a/Core/Debugger/WebSocket/MemorySubscriber.cpp
+++ b/Core/Debugger/WebSocket/MemorySubscriber.cpp
@@ -21,12 +21,13 @@
 #include "Common/Data/Encoding/Base64.h"
 #include "Common/StringUtils.h"
 #include "Core/Core.h"
+#include "Core/Debugger/WebSocket/MemorySubscriber.h"
+#include "Core/Debugger/WebSocket/WebSocketUtils.h"
 #include "Core/HLE/ReplaceTables.h"
 #include "Core/MemMap.h"
 #include "Core/MIPS/MIPSDebugInterface.h"
+#include "Core/Reporting.h"
 #include "Core/System.h"
-#include "Core/Debugger/WebSocket/MemorySubscriber.h"
-#include "Core/Debugger/WebSocket/WebSocketUtils.h"
 
 DebuggerSubscriber *WebSocketMemoryInit(DebuggerEventHandlerMap &map) {
 	// No need to bind or alloc state, these are all global.
@@ -279,6 +280,7 @@ void WebSocketMemoryWriteU8(DebuggerRequest &req) {
 	}
 	currentMIPS->InvalidateICache(addr, 1);
 	Memory::Write_U8(val, addr);
+	Reporting::NotifyDebugger();
 
 	JsonWriter &json = req.Respond();
 	json.writeUint("value", Memory::Read_U8(addr));
@@ -311,6 +313,7 @@ void WebSocketMemoryWriteU16(DebuggerRequest &req) {
 	}
 	currentMIPS->InvalidateICache(addr, 2);
 	Memory::Write_U16(val, addr);
+	Reporting::NotifyDebugger();
 
 	JsonWriter &json = req.Respond();
 	json.writeUint("value", Memory::Read_U16(addr));
@@ -343,6 +346,7 @@ void WebSocketMemoryWriteU32(DebuggerRequest &req) {
 	}
 	currentMIPS->InvalidateICache(addr, 4);
 	Memory::Write_U32(val, addr);
+	Reporting::NotifyDebugger();
 
 	JsonWriter &json = req.Respond();
 	json.writeUint("value", Memory::Read_U32(addr));
@@ -377,5 +381,6 @@ void WebSocketMemoryWrite(DebuggerRequest &req) {
 
 	currentMIPS->InvalidateICache(addr, size);
 	Memory::MemcpyUnchecked(addr, &value[0], size);
+	Reporting::NotifyDebugger();
 	req.Respond();
 }

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -390,6 +390,11 @@ namespace Reporting
 			everUnsupported = true;
 	}
 
+	void NotifyDebugger() {
+		currentSupported = false;
+		everUnsupported = true;
+	}
+
 	std::string CurrentGameID()
 	{
 		// TODO: Maybe ParamSFOData shouldn't include nulls in std::strings?  Don't work to break savedata, though...

--- a/Core/Reporting.h
+++ b/Core/Reporting.h
@@ -38,6 +38,9 @@ namespace Reporting
 	// Should be called whenever the game configuration changes.
 	void UpdateConfig();
 
+	// Should be called when debugging APIs are used in a way that could make the game crash.
+	void NotifyDebugger();
+
 	// Returns whether or not the reporting system is currently enabled.
 	bool IsEnabled();
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2649,6 +2649,7 @@ void GPUCommon::ResetListPC(int listID, u32 pc) {
 		return;
 	}
 
+	Reporting::NotifyDebugger();
 	dls[listID].pc = pc;
 	downcount = 0;
 }
@@ -2659,6 +2660,7 @@ void GPUCommon::ResetListStall(int listID, u32 stall) {
 		return;
 	}
 
+	Reporting::NotifyDebugger();
 	dls[listID].stall = stall;
 	downcount = 0;
 }
@@ -2669,6 +2671,7 @@ void GPUCommon::ResetListState(int listID, DisplayListState state) {
 		return;
 	}
 
+	Reporting::NotifyDebugger();
 	dls[listID].state = state;
 	downcount = 0;
 }
@@ -2726,6 +2729,7 @@ void GPUCommon::SetCmdValue(u32 op) {
 	u32 cmd = op >> 24;
 	u32 diff = op ^ gstate.cmdmem[cmd];
 
+	Reporting::NotifyDebugger();
 	PreExecuteOp(op, diff);
 	gstate.cmdmem[cmd] = op;
 	ExecuteOp(op, diff);

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -12,12 +12,13 @@
 #include "Core/MIPS/MIPSAsm.h"
 #include "Core/MIPS/MIPSAnalyst.h"
 #include "Core/Config.h"
+#include "Core/Debugger/SymbolMap.h"
+#include "Core/Reporting.h"
 #include "Common/StringUtils.h"
 #include "Windows/Debugger/CtrlDisAsmView.h"
 #include "Windows/Debugger/Debugger_MemoryDlg.h"
 #include "Windows/Debugger/DebuggerShared.h"
 #include "Windows/Debugger/BreakpointWindow.h"
-#include "Core/Debugger/SymbolMap.h"
 #include "Windows/main.h"
 
 #include "Common/CommonWindows.h"
@@ -303,6 +304,7 @@ void CtrlDisAsmView::assembleOpcode(u32 address, std::string defaultText)
 					if (strcasecmp(debugger->GetRegName(cat,reg),registerName.c_str()) == 0)
 					{
 						debugger->SetRegValue(cat,reg,value);
+						Reporting::NotifyDebugger();
 						SendMessage(GetParent(wnd),WM_DEB_UPDATE,0,0);
 						return;
 					}
@@ -314,6 +316,7 @@ void CtrlDisAsmView::assembleOpcode(u32 address, std::string defaultText)
 	}
 
 	result = MIPSAsm::MipsAssembleOpcode(op.c_str(),debugger,address);
+	Reporting::NotifyDebugger();
 	if (result == true)
 	{
 		scanFunctions();

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -6,12 +6,13 @@
 #include <iomanip>
 #include "ext/xxhash.h"
 #include "Core/Config.h"
-#include "Windows/resource.h"
 #include "Core/MemMap.h"
+#include "Core/Reporting.h"
 #include "Windows/W32Util/ContextMenu.h"
 #include "Windows/W32Util/Misc.h"
 #include "Windows/InputBox.h"
 #include "Windows/main.h"
+#include "Windows/resource.h"
 #include "Common/System/Display.h"
 
 #include "Debugger_Disasm.h"
@@ -462,6 +463,7 @@ void CtrlMemView::onChar(WPARAM wParam, LPARAM lParam)
 		}
 	}
 
+	Reporting::NotifyDebugger();
 	if (active) Core_EnableStepping(false);
 }
 

--- a/Windows/Debugger/CtrlRegisterList.cpp
+++ b/Windows/Debugger/CtrlRegisterList.cpp
@@ -5,16 +5,17 @@
 
 #include "Common/System/Display.h"
 #include "Common/Data/Encoding/Utf8.h"
-#include "Windows/resource.h"
+#include "Core/Config.h"
 #include "Core/MemMap.h"
+#include "Core/Reporting.h"
 #include "Windows/W32Util/ContextMenu.h"
 #include "Windows/W32Util/Misc.h"
 #include "Windows/InputBox.h"
+#include "Windows/resource.h"
 
 #include "CtrlRegisterList.h"
 #include "Debugger_MemoryDlg.h"
 
-#include "Core/Config.h"
 #include "Debugger_Disasm.h"
 #include "DebuggerShared.h"
 
@@ -443,6 +444,7 @@ void CtrlRegisterList::editRegisterValue()
 				cpu->SetRegValue(category, reg, val);
 				break;
 			}
+			Reporting::NotifyDebugger();
 			redraw();
 			SendMessage(GetParent(wnd),WM_DEB_UPDATE,0,0);	// registers changed -> disassembly needs to be updated
 		}

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -49,6 +49,7 @@
 #include "Core/KeyMap.h"
 #include "Core/MIPS/JitCommon/JitCommon.h"
 #include "Core/MIPS/JitCommon/JitBlockCache.h"
+#include "Core/Reporting.h"
 #include "Windows/InputBox.h"
 #include "Windows/InputDevice.h"
 #if PPSSPP_API(ANY_GL)
@@ -739,6 +740,7 @@ namespace MainWindow
 			break;
 
 		case WM_USER_GET_BASE_POINTER:
+			Reporting::NotifyDebugger();
 			switch (lParam) {
 			case 0:
 				return (u32)(u64)Memory::base;


### PR DESCRIPTION
This won't catch all means of hacking memory, but will catch some.  Trying to reduce noise in reporting from debugging.

It's treated the same as if you enable a cheat or change the CPU clock or something.

-[Unknown]