### PR TITLE
CI: fix tag regex to match also shorter tags like v1.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     # For testing.
     - actions
     tags:
-      - "v*.*.*"
+      - "v*.*"
     paths-ignore:
     - '*.{txt,md}'
     - 'Tools/**'

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -7,7 +7,7 @@ on:
       - created
   push:
     tags:
-      - "v*.*.*"
+      - "v*.*"
 
 jobs:
   build:


### PR DESCRIPTION
the previous tag regex matched only tagnames with 2 dots in them,
that's why the build.yml didn't run for the v1.13 tag.

addressing https://github.com/hrydgard/ppsspp/issues/15737