### PR TITLE
Use BlueToAlpha in more games instead of ReinterpretFramebuffers/ShaderColorBitmask

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1107,6 +1107,20 @@ ULES01402 = true
 ULUS10513 = true
 ULJM05812 = true
 NPJH50371 = true
+
+# Colin McRae's DiRT 2 - issue #13012 (car lighting)
+# Previously used ReinterpretFramebuffers + ShaderColorBitmask
+ULUS10471 = true
+ULJM05533 = true
+NPJH50006 = true
+ULES01301 = true
+
+# Outrun 2006: Coast to Coast - issue #11358 (car reflections)
+# Previously used ReinterpretFramebuffers + ShaderColorBitmask
+ULES00262 = true
+ULUS10064 = true
+ULKS46087 = true
+
 # Some games render first to RGB of a 4444 texture, then they switch to 565 and render masked to blue,
 # just to be able to render to the alpha channel of the 4444. We can detect that and reroute rendering
 # to avoid problems.
@@ -1119,17 +1133,6 @@ NPEZ00198 = true
 # This setting will go away in the near future, hopefully we can enable it
 # for all or most games.
 [ReinterpretFramebuffers]
-# Outrun 2006: Coast to Coast - issue #11358 (car reflections)
-ULES00262 = true
-ULUS10064 = true
-ULKS46087 = true
-
-# Colin McRae's DiRT 2 - issue #13012 (car lighting)
-ULUS10471 = true
-ULJM05533 = true
-NPJH50006 = true
-ULES01301 = true
-
 # Ultimate Ghosts & Goblins
 ULJM05147 = true
 ULUS10105 = true
@@ -1146,29 +1149,8 @@ ULES01441 = true
 ULJM05600 = true
 ULJM05775 = true
 
-# Split/Second now uses BlueToAlpha instead.
-# ULES01402 = true
-# ULUS10513 = true
-# ULJM05812 = true
-# NPJH50371 = true
-
 [ShaderColorBitmask]
-# Outrun 2006: Coast to Coast - issue #11358
-ULES00262 = true
-ULUS10064 = true
-ULKS46087 = true
-
-# Colin McRae's DiRT 2 - issue #13012 (car lighting)
-ULUS10471 = true
-ULJM05533 = true
-NPJH50006 = true
-ULES01301 = true
-
-# Split/Second now uses BlueToAlpha instead.
-#ULES01402 = true
-#ULUS10513 = true
-#ULJM05812 = true
-#NPJH50371 = true
+# No users right now, but keeping it around as a more accurate option than BlueToAlpha, for debugging mainly Outrun.
 
 [DisableFirstFrameReadback]
 # Wipeout Pure: Temporary workaround for lens flare flicker. See #13344


### PR DESCRIPTION
Switches over Outrun and DiRT 2 to use this newer method.

See https://github.com/hrydgard/ppsspp/issues/11358#issuecomment-720160221 for technical details of the "blue to alpha" problem.

Makes for better performance and removes some ugly color banding.