### PR TITLE
Deferred depth buffer copies

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -425,8 +425,6 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const Frame
 
 	// None found? Create one.
 	if (!vfb) {
-		gstate_c.usingDepth = false;  // reset depth buffer tracking
-
 		vfb = new VirtualFramebuffer{};
 		vfb->fbo = nullptr;
 		vfb->fb_address = params.fb_address;
@@ -469,6 +467,12 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const Frame
 			PerformStencilUpload(params.fb_address, byteSize, StencilUpload::STENCIL_IS_ZERO | StencilUpload::IGNORE_ALPHA);
 			// TODO: Is it worth trying to upload the depth buffer (only if it wasn't copied above..?)
 		}
+
+		// We don't try to optimize depth buffer tracking on the frame a framebuffer is created.
+		// See #7810
+		gstate_c.usingDepth = true;
+		gstate_c.clearingDepth = false;
+		SetDepthFrameBuffer();
 
 		// Let's check for depth buffer overlap.  Might be interesting.
 		bool sharingReported = false;

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -248,6 +248,8 @@ public:
 			return vfb;
 		}
 	}
+	void SetDepthFrameBuffer();
+
 	void RebindFramebuffer(const char *tag);
 	std::vector<FramebufferInfo> GetFramebufferList();
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1685,6 +1685,14 @@ void GPUCommon::Execute_Prim(u32 op, u32 diff) {
 		return;
 	}
 
+	bool isClearingDepth = gstate.isModeClear() && gstate.isClearModeDepthMask();;
+
+	if (!gstate_c.usingDepth && (gstate.isDepthTestEnabled() || isClearingDepth)) {
+		gstate_c.usingDepth = true;
+		gstate_c.clearingDepth = isClearingDepth;
+		framebufferManager_->SetDepthFrameBuffer();
+	}
+
 	const void *verts = Memory::GetPointerUnchecked(gstate_c.vertexAddr);
 	const void *inds = nullptr;
 	u32 vertexType = gstate.vertType;

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -572,6 +572,9 @@ struct GPUStateCache {
 
 	uint64_t dirty;
 
+	bool usingDepth;  // For deferred depth copies.
+	bool clearingDepth;
+
 	bool textureFullAlpha;
 	bool vertexFullAlpha;
 


### PR DESCRIPTION
Due to the fact that the PSP overlaps stencil with color alpha, and PC interleaves stencil with depth instead, to get the semantics right we often have to copy the depth buffer from a previously bound framebuffer.

This avoids doing that if we never use depth after binding a color buffer, before binding the next one. This results in eliminated depth copies in several and perhaps many games, including God of War, saving some GPU performance.

This was made possible after #15700 and was @unknownbrackets 's idea (see comments in the issue) so cred goes to him.

Don't really have any numbers for the improvement, but eliminating unnecessary operations is always good. There is some extra checking per draw though.. wonder if there's a way to reduce that.

NOTE: This is draft because it doesn't avoid splitting render passes on OpenGL yet, in case the depth draw is not the first in a pass. That probably doesn't happen very often though.

EDIT: Regressions found during testing, check off once fixed:

- [ ] #7810 breaks again
- [ ] Some new issue with Kuroyuo

EDIT: There's problem with the pass injection. It's too aggressive, it should not happen when we are on the first draw on a new framebuffer.