### PR TITLE
Fix logging warning issue.

### DIFF
--- a/Common/StringUtils.cpp
+++ b/Common/StringUtils.cpp
@@ -55,6 +55,10 @@ void truncate_cpy(char *dest, size_t destSize, const char *src) {
 	}
 }
 
+const char* safe_string(const char* s) {
+	return s ? s : "(null)";
+}
+
 long parseHexLong(std::string s) {
 	long value = 0;
 

--- a/Common/StringUtils.h
+++ b/Common/StringUtils.h
@@ -84,6 +84,8 @@ inline void truncate_cpy(char(&out)[Count], const char *src) {
 	truncate_cpy(out, Count, src);
 }
 
+const char* safe_string(const char* s);
+
 long parseHexLong(std::string s);
 long parseLong(std::string s);
 std::string StringFromFormat(const char* format, ...);

--- a/Core/HLE/sceNp.cpp
+++ b/Core/HLE/sceNp.cpp
@@ -487,7 +487,7 @@ int sceNpAuthGetTicketParam(u32 ticketBufPtr, int ticketLen, int paramNum, u32 b
 		SceNpTicketParamData* ticketParam = (SceNpTicketParamData*)Memory::GetPointer(inbuf);
 		u32 sz = (u32)sizeof(SceNpTicketParamData) + ticketParam->length;
 		Memory::Memcpy(outbuf, inbuf, sz);
-		DEBUG_LOG(SCENET, "%s - Param #%d: Type = %04hx, Length = %u", __FUNCTION__, i, static_cast<unsigned short>(ticketParam->type), static_cast<unsigned int>(ticketParam->length));
+		DEBUG_LOG(SCENET, "%s - Param #%d: Type = %04x, Length = %u", __FUNCTION__, i, static_cast<unsigned int>(ticketParam->type), static_cast<unsigned int>(ticketParam->length));
 		outbuf += sz;
 		inbuf += sz;
 		if (outbuf - bufferPtr >= PARAM_BUFFER_MAX_SIZE || inbuf - ticketBufPtr >= (u32)ticketLen)

--- a/Core/HLE/sceNp.cpp
+++ b/Core/HLE/sceNp.cpp
@@ -207,8 +207,8 @@ static int sceNpGetAccountRegion(u32 countryCodePtr, u32 regionCodePtr)
 	SceNpCountryCode dummyRegionCode{};
 	memcpy(dummyRegionCode.data, npRegionCode, sizeof(dummyRegionCode.data));
 
-	INFO_LOG(SCENET, "%s - Country Code: %d", __FUNCTION__, dummyCountryCode.data);
-	INFO_LOG(SCENET, "%s - Region? Code: %d", __FUNCTION__, dummyRegionCode.data);
+	INFO_LOG(SCENET, "%s - Country Code: %s", __FUNCTION__, dummyCountryCode.data);
+	INFO_LOG(SCENET, "%s - Region? Code: %s", __FUNCTION__, dummyRegionCode.data);
 
 	Memory::WriteStruct(countryCodePtr, &dummyCountryCode);
 	Memory::WriteStruct(regionCodePtr, &dummyRegionCode);
@@ -487,7 +487,7 @@ int sceNpAuthGetTicketParam(u32 ticketBufPtr, int ticketLen, int paramNum, u32 b
 		SceNpTicketParamData* ticketParam = (SceNpTicketParamData*)Memory::GetPointer(inbuf);
 		u32 sz = (u32)sizeof(SceNpTicketParamData) + ticketParam->length;
 		Memory::Memcpy(outbuf, inbuf, sz);
-		DEBUG_LOG(SCENET, "%s - Param #%d: Type = %04x, Length = %u", __FUNCTION__, i, ticketParam->type, static_cast<unsigned int>(ticketParam->length));
+		DEBUG_LOG(SCENET, "%s - Param #%d: Type = %04hx, Length = %u", __FUNCTION__, i, static_cast<unsigned short>(ticketParam->type), static_cast<unsigned int>(ticketParam->length));
 		outbuf += sz;
 		inbuf += sz;
 		if (outbuf - bufferPtr >= PARAM_BUFFER_MAX_SIZE || inbuf - ticketBufPtr >= (u32)ticketLen)

--- a/Core/HLE/sceNp2.cpp
+++ b/Core/HLE/sceNp2.cpp
@@ -80,7 +80,7 @@ static int sceNpMatching2Term()
 
 static int sceNpMatching2CreateContext(u32 communicationIdPtr, u32 passPhrasePtr, u32 ctxIdPtr, int unknown)
 {
-	ERROR_LOG(SCENET, "UNIMPL %s(%08x[%s], %08x[%08x], %08x[%hu], %i) at %08x", __FUNCTION__, communicationIdPtr, Memory::GetCharPointer(communicationIdPtr), passPhrasePtr, Memory::Read_U32(passPhrasePtr), ctxIdPtr, Memory::Read_U16(ctxIdPtr), unknown, currentMIPS->pc);
+	ERROR_LOG(SCENET, "UNIMPL %s(%08x[%s], %08x[%08x], %08x[%hu], %i) at %08x", __FUNCTION__, communicationIdPtr, safe_string(Memory::GetCharPointer(communicationIdPtr)), passPhrasePtr, Memory::Read_U32(passPhrasePtr), ctxIdPtr, Memory::Read_U16(ctxIdPtr), unknown, currentMIPS->pc);
 	if (!npMatching2Inited)
 		return hleLogError(SCENET, SCE_NP_MATCHING2_ERROR_NOT_INITIALIZED);
 

--- a/Core/HLE/sceNp2.cpp
+++ b/Core/HLE/sceNp2.cpp
@@ -80,7 +80,7 @@ static int sceNpMatching2Term()
 
 static int sceNpMatching2CreateContext(u32 communicationIdPtr, u32 passPhrasePtr, u32 ctxIdPtr, int unknown)
 {
-	ERROR_LOG(SCENET, "UNIMPL %s(%08x[%s], %08x[%08x], %08x[%d], %d) at %08x", __FUNCTION__, communicationIdPtr, Memory::GetCharPointer(communicationIdPtr), passPhrasePtr, Memory::Read_U32(passPhrasePtr), ctxIdPtr, Memory::Read_U16(ctxIdPtr), unknown, currentMIPS->pc);
+	ERROR_LOG(SCENET, "UNIMPL %s(%08x[%s], %08x[%08x], %08x[%hu], %i) at %08x", __FUNCTION__, communicationIdPtr, Memory::GetCharPointer(communicationIdPtr), passPhrasePtr, Memory::Read_U32(passPhrasePtr), ctxIdPtr, Memory::Read_U16(ctxIdPtr), unknown, currentMIPS->pc);
 	if (!npMatching2Inited)
 		return hleLogError(SCENET, SCE_NP_MATCHING2_ERROR_NOT_INITIALIZED);
 


### PR DESCRIPTION
Fixes some of the logging warnings mentioned at https://github.com/hrydgard/ppsspp/issues/15792

But it still have some warnings i couldn't figured out what was the main issue, like why `%s` was marked for warning while `Memory::GetCharPointer(communicationIdPtr)` returns a `const char*` which should be valid for `%s`.

Anyone know what was the main cause?