### PR TITLE
State handling reordering in D3D11 and D3D9 backends.

### DIFF
--- a/GPU/D3D11/StateMappingD3D11.cpp
+++ b/GPU/D3D11/StateMappingD3D11.cpp
@@ -124,8 +124,6 @@ static const D3D11_LOGIC_OP logicOps[] = {
 
 void DrawEngineD3D11::ResetFramebufferRead() {
 	if (fboTexBound_) {
-		ID3D11ShaderResourceView *srv = nullptr;
-		context_->PSSetShaderResources(0, 1, &srv);
 		fboTexBound_ = false;
 	}
 }
@@ -167,6 +165,18 @@ void DrawEngineD3D11::ApplyDrawState(int prim) {
 				ApplyFramebufferRead(&fboTexNeedsBind_);
 				// The shader takes over the responsibility for blending, so recompute.
 				ApplyStencilReplaceAndLogicOpIgnoreBlend(blendState.replaceAlphaWithStencil, blendState);
+
+				if (fboTexNeedsBind_) {
+					framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY);
+					// No sampler required, we do a plain Load in the pixel shader.
+					fboTexBound_ = true;
+					fboTexNeedsBind_ = false;
+
+					framebufferManager_->RebindFramebuffer("RebindFramebuffer - ApplyDrawState");
+					// Must dirty blend state here so we re-copy next time.  Example: Lunar's spell effects.
+					gstate_c.Dirty(DIRTY_BLEND_STATE);
+				}
+
 				gstate_c.Dirty(DIRTY_FRAGMENTSHADER_STATE);
 			} else if (blendState.resetFramebufferRead) {
 				ResetFramebufferRead();
@@ -416,16 +426,6 @@ void DrawEngineD3D11::ApplyDrawState(int prim) {
 }
 
 void DrawEngineD3D11::ApplyDrawStateLate(bool applyStencilRef, uint8_t stencilRef) {
-	if (!gstate.isModeClear()) {
-		if (fboTexNeedsBind_) {
-			framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY);
-			// No sampler required, we do a plain Load in the pixel shader.
-			fboTexBound_ = true;
-			fboTexNeedsBind_ = false;
-		}
-		textureCache_->ApplyTexture();
-	}
-
 	// we go through Draw here because it automatically handles screen rotation, as needed in UWP on mobiles.
 	if (gstate_c.IsDirty(DIRTY_VIEWPORTSCISSOR_STATE)) {
 		draw_->SetViewports(1, &dynState_.viewport);
@@ -435,7 +435,7 @@ void DrawEngineD3D11::ApplyDrawStateLate(bool applyStencilRef, uint8_t stencilRe
 		context_->RSSetState(rasterState_);
 	}
 	if (gstate_c.IsDirty(DIRTY_BLEND_STATE)) {
-		// Need to do this AFTER ApplyTexture because the process of depallettization can ruin the blend state.
+		// Need to do this AFTER ApplyTexture because the process of depalettization can ruin the blend state.
 		float blendColor[4];
 		Uint8x4ToFloat4(blendColor, dynState_.blendColor);
 		if (device1_) {

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -435,16 +435,17 @@ void TextureCacheD3D11::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer,
 		CheckAlphaResult alphaStatus = CheckAlpha(clutBuf_, GetClutDestFormatD3D11(clutFormat), clutTotalColors);
 		gstate_c.SetTextureFullAlpha(alphaStatus == CHECKALPHA_FULL);
 	} else {
-		gstate_c.SetTextureFullAlpha(gstate.getTextureFormat() == GE_TFMT_5650);
 		framebufferManager_->RebindFramebuffer("RebindFramebuffer - ApplyTextureFramebuffer");
 		framebufferManager_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV | BINDFBCOLOR_APPLY_TEX_OFFSET);
+		gstate_c.SetTextureFullAlpha(gstate.getTextureFormat() == GE_TFMT_5650);
 	}
 
 	SamplerCacheKey samplerKey = GetFramebufferSamplingParams(framebuffer->bufferWidth, framebuffer->bufferHeight);
 	ID3D11SamplerState *state = samplerCache_.GetOrCreateSampler(device_, samplerKey);
 	context_->PSSetSamplers(0, 1, &state);
 
-	gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_RASTER_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_BLEND_STATE | DIRTY_FRAGMENTSHADER_STATE);
+	gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_RASTER_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_BLEND_STATE | DIRTY_FRAGMENTSHADER_STATE | DIRTY_TEXTURE_IMAGE | DIRTY_TEXTURE_PARAMS);
+	draw_->InvalidateCachedState();
 }
 
 void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -305,6 +305,8 @@ static uint32_t SwapRB(uint32_t c) {
 }
 
 void DrawEngineDX9::BeginFrame() {
+	gpuStats.numTrackedVertexArrays = (int)vai_.size();
+
 	DecimateTrackedVertexArrays();
 
 	lastRenderStepId_ = -1;
@@ -313,7 +315,6 @@ void DrawEngineDX9::BeginFrame() {
 // The inline wrapper in the header checks for numDrawCalls == 0
 void DrawEngineDX9::DoFlush() {
 	gpuStats.numFlushes++;
-	gpuStats.numTrackedVertexArrays = (int)vai_.size();
 
 	// In D3D, we're synchronous and state carries over so all we reset here on a new step is the viewport/scissor.
 	int curRenderStepId = draw_->GetCurrentStepId();
@@ -323,14 +324,23 @@ void DrawEngineDX9::DoFlush() {
 		lastRenderStepId_ = curRenderStepId;
 	}
 
-	// This is not done on every drawcall, we should collect vertex data
-	// until critical state changes. That's when we draw (flush).
+	bool textureNeedsApply = false;
+	if (gstate_c.IsDirty(DIRTY_TEXTURE_IMAGE | DIRTY_TEXTURE_PARAMS) && !gstate.isModeClear() && gstate.isTextureMapEnabled()) {
+		textureCache_->SetTexture();
+		gstate_c.Clean(DIRTY_TEXTURE_IMAGE | DIRTY_TEXTURE_PARAMS);
+		textureNeedsApply = true;
+	} else if (gstate.getTextureAddress(0) == ((gstate.getFrameBufRawAddress() | 0x04000000) & 0x3FFFFFFF)) {
+		// This catches the case of clearing a texture. (#10957)
+		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
+	}
+
 	GEPrimitiveType prim = prevPrim_;
-	ApplyDrawState(prim);
 
-	VSShader *vshader = shaderManager_->ApplyShader(CanUseHardwareTransform(prim), useHWTessellation_, lastVType_, decOptions_.expandAllWeightsToFloat);
+	// Always use software for flat shading to fix the provoking index.
+	bool tess = gstate_c.submitType == SubmitType::HW_BEZIER || gstate_c.submitType == SubmitType::HW_SPLINE;
+	bool useHWTransform = CanUseHardwareTransform(prim) && (tess || gstate.getShadeMode() != GE_SHADE_FLAT);
 
-	if (vshader->UseHWTransform()) {
+	if (useHWTransform) {
 		LPDIRECT3DVERTEXBUFFER9 vb_ = NULL;
 		LPDIRECT3DINDEXBUFFER9 ib_ = NULL;
 
@@ -500,7 +510,6 @@ rotateVBO:
 			prim = indexGen.Prim();
 		}
 
-		VERBOSE_LOG(G3D, "Flush prim %i! %i verts in one go", prim, vertexCount);
 		bool hasColor = (lastVType_ & GE_VTYPE_COL_MASK) != GE_VTYPE_COL_NONE;
 		if (gstate.isModeThrough()) {
 			gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && (hasColor || gstate.getMaterialAmbientA() == 255);
@@ -508,8 +517,14 @@ rotateVBO:
 			gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && ((hasColor && (gstate.materialupdate & 1)) || gstate.getMaterialAmbientA() == 255) && (!gstate.isLightingEnabled() || gstate.getAmbientA() == 255);
 		}
 
+		if (textureNeedsApply) {
+			textureCache_->ApplyTexture();
+		}
+
+		ApplyDrawState(prim);
 		ApplyDrawStateLate();
-		vshader = shaderManager_->ApplyShader(CanUseHardwareTransform(prim), useHWTessellation_, lastVType_, decOptions_.expandAllWeightsToFloat);
+
+		DX9::VSShader *vshader = shaderManager_->ApplyShader(true, useHWTessellation_, lastVType_, decOptions_.expandAllWeightsToFloat);
 		IDirect3DVertexDeclaration9 *pHardwareVertexDecl = SetupDecFmtForDraw(vshader, dec_->GetDecVtxFmt(), dec_->VertexType());
 
 		if (pHardwareVertexDecl) {
@@ -587,14 +602,21 @@ rotateVBO:
 		swTransform.Decode(prim, dec_->VertexType(), dec_->GetDecVtxFmt(), maxIndex, &result);
 		if (result.action == SW_NOT_READY) {
 			swTransform.DetectOffsetTexture(maxIndex);
-			swTransform.BuildDrawingParams(prim, indexGen.VertexCount(), dec_->VertexType(), inds, maxIndex, &result);
 		}
 
+		if (textureNeedsApply)
+			textureCache_->ApplyTexture();
+
+		ApplyDrawState(prim);
+
+		if (result.action == SW_NOT_READY)
+			swTransform.BuildDrawingParams(prim, indexGen.VertexCount(), dec_->VertexType(), inds, maxIndex, &result);
 		if (result.setSafeSize)
 			framebufferManager_->SetSafeSize(result.safeWidth, result.safeHeight);
 
 		ApplyDrawStateLate();
-		vshader = shaderManager_->ApplyShader(false, false, lastVType_, decOptions_.expandAllWeightsToFloat);
+
+		DX9::VSShader *vshader = shaderManager_->ApplyShader(false, false, lastVType_, decOptions_.expandAllWeightsToFloat);
 
 		if (result.action == SW_DRAW_PRIMITIVES) {
 			if (result.setStencil) {

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -547,10 +547,6 @@ void ShaderManagerDX9::DirtyLastShader() { // disables vertex arrays
 }
 
 VSShader *ShaderManagerDX9::ApplyShader(bool useHWTransform, bool useHWTessellation, u32 vertType, bool weightsAsFloat) {
-	// Always use software for flat shading to fix the provoking index.
-	bool tess = gstate_c.submitType == SubmitType::HW_BEZIER || gstate_c.submitType == SubmitType::HW_SPLINE;
-	useHWTransform = useHWTransform && (tess || gstate.getShadeMode() != GE_SHADE_FLAT);
-
 	VShaderID VSID;
 	if (gstate_c.IsDirty(DIRTY_VERTEXSHADER_STATE)) {
 		gstate_c.Clean(DIRTY_VERTEXSHADER_STATE);

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -91,14 +91,14 @@ static const D3DSTENCILOP stencilOps[] = {
 };
 
 inline void DrawEngineDX9::ResetFramebufferRead() {
-	if (fboTexBound_) {
-		device_->SetTexture(1, nullptr);
-		fboTexBound_ = false;
-	}
+	fboTexBound_ = false;
 }
 
 void DrawEngineDX9::ApplyDrawState(int prim) {
-	// TODO: All this setup is soon so expensive that we'll need dirty flags, or simply do it in the command writes where we detect dirty by xoring. Silly to do all this work on every drawcall.
+	if (!gstate_c.IsDirty(DIRTY_BLEND_STATE | DIRTY_TEXTURE_IMAGE | DIRTY_TEXTURE_PARAMS | DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_RASTER_STATE | DIRTY_DEPTHSTENCIL_STATE)) {
+		// nothing to do
+		return;
+	}
 
 	if (gstate_c.IsDirty(DIRTY_TEXTURE_IMAGE | DIRTY_TEXTURE_PARAMS) && !gstate.isModeClear() && gstate.isTextureMapEnabled()) {
 		textureCache_->SetTexture();
@@ -114,7 +114,6 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 	bool useBufferedRendering = framebufferManager_->UseBufferedRendering();
 
 	if (gstate_c.IsDirty(DIRTY_BLEND_STATE)) {
-		gstate_c.Clean(DIRTY_BLEND_STATE);
 		// Unfortunately, this isn't implemented on DX9 yet.
 		gstate_c.SetAllowFramebufferRead(false);
 		if (gstate.isModeClear()) {
@@ -140,6 +139,18 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 				ApplyFramebufferRead(&fboTexNeedsBind_);
 				// The shader takes over the responsibility for blending, so recompute.
 				ApplyStencilReplaceAndLogicOpIgnoreBlend(blendState.replaceAlphaWithStencil, blendState);
+
+				if (fboTexNeedsBind_) {
+					// Note that this is positions, not UVs, that we need the copy from.
+					framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY);
+					// If we are rendering at a higher resolution, linear is probably best for the dest color.
+					device_->SetSamplerState(1, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR);
+					device_->SetSamplerState(1, D3DSAMP_MINFILTER, D3DTEXF_LINEAR);
+					fboTexBound_ = true;
+					fboTexNeedsBind_ = false;
+					gstate_c.Dirty(DIRTY_BLEND_STATE);
+				}
+
 				gstate_c.Dirty(DIRTY_FRAGMENTSHADER_STATE);
 			} else if (blendState.resetFramebufferRead) {
 				ResetFramebufferRead();
@@ -172,7 +183,6 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 	}
 
 	if (gstate_c.IsDirty(DIRTY_RASTER_STATE)) {
-		gstate_c.Clean(DIRTY_RASTER_STATE);
 		bool wantCull = !gstate.isModeClear() && prim != GE_PRIM_RECTANGLES && prim > GE_PRIM_LINE_STRIP && gstate.isCullEnabled();
 		if (wantCull) {
 			if (gstate.getCullMode() == 1) {
@@ -192,7 +202,6 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 	}
 
 	if (gstate_c.IsDirty(DIRTY_DEPTHSTENCIL_STATE)) {
-		gstate_c.Clean(DIRTY_DEPTHSTENCIL_STATE);
 		GenericStencilFuncState stencilState;
 		ConvertStencilFuncState(stencilState);
 
@@ -254,7 +263,6 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 	}
 
 	if (gstate_c.IsDirty(DIRTY_VIEWPORTSCISSOR_STATE)) {
-		gstate_c.Clean(DIRTY_VIEWPORTSCISSOR_STATE);
 		ViewportAndScissor vpAndScissor;
 		ConvertViewportAndScissor(useBufferedRendering,
 			framebufferManager_->GetRenderWidth(), framebufferManager_->GetRenderHeight(),
@@ -275,26 +283,14 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 			gstate_c.Dirty(DIRTY_DEPTHRANGE);
 		}
 	}
+
+	gstate_c.Clean(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_RASTER_STATE | DIRTY_BLEND_STATE);
 }
 
 void DrawEngineDX9::ApplyDrawStateLate() {
 	// At this point, we know if the vertices are full alpha or not.
 	// TODO: Set the nearest/linear here (since we correctly know if alpha/color tests are needed)?
-	if (!gstate.isModeClear()) {
-		textureCache_->ApplyTexture();
 
-		if (fboTexNeedsBind_) {
-			// Note that this is positions, not UVs, that we need the copy from.
-			framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY);
-			// If we are rendering at a higher resolution, linear is probably best for the dest color.
-			device_->SetSamplerState(1, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR);
-			device_->SetSamplerState(1, D3DSAMP_MINFILTER, D3DTEXF_LINEAR);
-			fboTexBound_ = true;
-			fboTexNeedsBind_ = false;
-		}
-
-		// TODO: Test texture?
-	}
 }
 
 }

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -115,7 +115,6 @@ public:
 
 protected:
 	bool UpdateUseHWTessellation(bool enable) override;
-	void DecimateTrackedVertexArrays() {}
 
 private:
 	void InitDeviceObjects();

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -183,6 +183,7 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 				gstate_c.Dirty(DIRTY_FRAGMENTSHADER_STATE);
 			} else if (blendState.resetFramebufferRead) {
 				ResetFramebufferRead();
+				gstate_c.Dirty(DIRTY_FRAGMENTSHADER_STATE);
 			}
 
 			if (blendState.enabled) {


### PR DESCRIPTION
Plus assorted cleanups.

Preparation for #15789, merging separately to track down regressions easier. Makes the flow more similar to the GL/VK backends, which makes it easier to have a generic implementation of depal.