### PR TITLE
Fix feature check for wrapping of non-pow-2 textures

### DIFF
--- a/Common/GPU/OpenGL/GLFeatures.cpp
+++ b/Common/GPU/OpenGL/GLFeatures.cpp
@@ -370,7 +370,7 @@ void CheckGLExtensions() {
 	gl_extensions.ARB_depth_clamp = g_set_gl_extensions.count("GL_ARB_depth_clamp") != 0;
 	gl_extensions.ARB_uniform_buffer_object = g_set_gl_extensions.count("GL_ARB_uniform_buffer_object") != 0;
 	gl_extensions.ARB_explicit_attrib_location = g_set_gl_extensions.count("GL_ARB_explicit_attrib_location") != 0;
-
+	gl_extensions.ARB_texture_non_power_of_two = g_set_gl_extensions.count("GL_ARB_texture_non_power_of_two");
 	if (gl_extensions.IsGLES) {
 		gl_extensions.EXT_blend_func_extended = g_set_gl_extensions.count("GL_EXT_blend_func_extended") != 0;
 		gl_extensions.OES_texture_npot = g_set_gl_extensions.count("GL_OES_texture_npot") != 0;

--- a/Common/GPU/OpenGL/GLFeatures.h
+++ b/Common/GPU/OpenGL/GLFeatures.h
@@ -70,6 +70,7 @@ struct GLExtensions {
 	bool ARB_cull_distance;
 	bool ARB_depth_clamp;
 	bool ARB_uniform_buffer_object;
+	bool ARB_texture_non_power_of_two;
 
 	// EXT
 	bool EXT_swap_control_tear;

--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -27,7 +27,8 @@ static bool OnRenderThread() {
 #endif
 
 GLRTexture::GLRTexture(int width, int height, int depth, int numMips) {
-	if (gl_extensions.OES_texture_npot) {
+	// Should move this check to thin3d, but really only OpenGL cares, so...
+	if (gl_extensions.IsCoreContext || gl_extensions.GLES3 || gl_extensions.ARB_texture_non_power_of_two || gl_extensions.OES_texture_npot) {
 		canWrap = true;
 	} else {
 		canWrap = isPowerOf2(width) && isPowerOf2(height);


### PR DESCRIPTION
Fixes some problems with using 3x/5x texture upscaling or 3x/5x resolution on some hardware, with OpenGL.

This fixes, in these cases, a glitch in Wipeout for example on the moving billboards, which I've noticed sometimes on Mac but never made the connection that was the 3x upscaling I had enabled, disabling texture wrapping for those render targets...