### PR TITLE
Fix OpenGL ES crash in blit if copies not supported, fix raster blit

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -267,6 +267,7 @@ D3D11DrawContext::D3D11DrawContext(ID3D11Device *device, ID3D11DeviceContext *de
 	caps_.framebufferSeparateDepthCopySupported = false;  // Though could be emulated with a draw.
 	caps_.texture3DSupported = true;
 	caps_.fragmentShaderInt32Supported = true;
+	caps_.anisoSupported = true;
 
 	D3D11_FEATURE_DATA_D3D11_OPTIONS options{};
 	HRESULT result = device_->CheckFeatureSupport(D3D11_FEATURE_D3D11_OPTIONS, &options, sizeof(options));

--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -268,6 +268,7 @@ D3D11DrawContext::D3D11DrawContext(ID3D11Device *device, ID3D11DeviceContext *de
 	caps_.texture3DSupported = true;
 	caps_.fragmentShaderInt32Supported = true;
 	caps_.anisoSupported = true;
+	caps_.textureNPOTFullySupported = true;
 
 	D3D11_FEATURE_DATA_D3D11_OPTIONS options{};
 	HRESULT result = device_->CheckFeatureSupport(D3D11_FEATURE_D3D11_OPTIONS, &options, sizeof(options));

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -668,6 +668,7 @@ D3D9Context::D3D9Context(IDirect3D9 *d3d, IDirect3D9Ex *d3dEx, int adapterId, ID
 	caps_.framebufferDepthCopySupported = false;
 	caps_.framebufferSeparateDepthCopySupported = false;
 	caps_.texture3DSupported = true;
+	caps_.textureNPOTFullySupported = true;
 
 	if (d3d) {
 		D3DDISPLAYMODE displayMode;

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -1344,10 +1344,12 @@ void GLQueueRunner::PerformCopy(const GLRStep &step) {
 	_assert_msg_(caps_.framebufferCopySupported, "Image copy extension expected");
 
 #if defined(USING_GLES2)
+#if !PPSSPP_PLATFORM(IOS)
 	glCopyImageSubDataOES(
 		srcTex, target, srcLevel, srcRect.x, srcRect.y, srcZ,
 		dstTex, target, dstLevel, dstPos.x, dstPos.y, dstZ,
 		srcRect.w, srcRect.h, depth);
+#endif
 #else
 	if (gl_extensions.ARB_copy_image) {
 		glCopyImageSubData(

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -43,7 +43,7 @@ GLuint g_defaultFBO = 0;
 
 void GLQueueRunner::CreateDeviceObjects() {
 	CHECK_GL_ERROR_IF_DEBUG();
-	if (gl_extensions.EXT_texture_filter_anisotropic) {
+	if (caps_.anisoSupported) {
 		glGetFloatv(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &maxAnisotropyLevel_);
 	} else {
 		maxAnisotropyLevel_ = 0.0f;
@@ -208,7 +208,7 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps, bool ski
 
 #if !defined(USING_GLES2)
 			if (step.create_program.support_dual_source) {
-				_dbg_assert_msg_(gl_extensions.ARB_blend_func_extended, "ARB_blend_func_extended required for dual src");
+				_dbg_assert_msg_(caps_.dualSourceBlend, "ARB/EXT_blend_func_extended required for dual src blend");
 				// Dual source alpha
 				glBindFragDataLocationIndexed(program->program, 0, 0, "fragColor0");
 				glBindFragDataLocationIndexed(program->program, 0, 1, "fragColor1");
@@ -1341,16 +1341,14 @@ void GLQueueRunner::PerformCopy(const GLRStep &step) {
 	_dbg_assert_(srcTex);
 	_dbg_assert_(dstTex);
 
+	_assert_msg_(caps_.framebufferCopySupported, "Image copy extension expected");
+
 #if defined(USING_GLES2)
-#if !PPSSPP_PLATFORM(IOS)
-	_assert_msg_(gl_extensions.OES_copy_image || gl_extensions.NV_copy_image || gl_extensions.EXT_copy_image, "Image copy extension expected");
 	glCopyImageSubDataOES(
 		srcTex, target, srcLevel, srcRect.x, srcRect.y, srcZ,
 		dstTex, target, dstLevel, dstPos.x, dstPos.y, dstZ,
 		srcRect.w, srcRect.h, depth);
-#endif
 #else
-	_assert_msg_(gl_extensions.ARB_copy_image || gl_extensions.NV_copy_image, "Image copy extension expected");
 	if (gl_extensions.ARB_copy_image) {
 		glCopyImageSubData(
 			srcTex, target, srcLevel, srcRect.x, srcRect.y, srcZ,

--- a/Common/GPU/OpenGL/GLQueueRunner.h
+++ b/Common/GPU/OpenGL/GLQueueRunner.h
@@ -7,7 +7,9 @@
 #include "Common/GPU/OpenGL/GLCommon.h"
 #include "Common/GPU/DataFormat.h"
 #include "Common/GPU/Shader.h"
+#include "Common/GPU/thin3d.h"
 #include "Common/Data/Collections/TinySet.h"
+
 
 struct GLRViewport {
 	float x, y, w, h, minZ, maxZ;
@@ -350,6 +352,10 @@ public:
 		errorCallbackUserData_ = userdata;
 	}
 
+	void SetDeviceCaps(const Draw::DeviceCaps &caps) {
+		caps_ = caps;
+	}
+
 	void RunInitSteps(const std::vector<GLRInitStep> &steps, bool skipGLCalls);
 
 	void RunSteps(const std::vector<GLRStep *> &steps, bool skipGLCalls);
@@ -388,14 +394,6 @@ private:
 	void PerformReadback(const GLRStep &pass);
 	void PerformReadbackImage(const GLRStep &pass);
 
-	void LogRenderPass(const GLRStep &pass);
-	void LogCopy(const GLRStep &pass);
-	void LogBlit(const GLRStep &pass);
-	void LogReadback(const GLRStep &pass);
-	void LogReadbackImage(const GLRStep &pass);
-
-	void ResizeReadbackBuffer(size_t requiredSize);
-
 	void fbo_ext_create(const GLRInitStep &step);
 	void fbo_bind_fb_target(bool read, GLuint name);
 	GLenum fbo_get_fb_target(bool read, GLuint **cached);
@@ -404,6 +402,8 @@ private:
 	GLRFramebuffer *curFB_ = nullptr;
 
 	GLuint globalVAO_ = 0;
+
+	Draw::DeviceCaps caps_{};  // For sanity checks.
 
 	int curFBWidth_ = 0;
 	int curFBHeight_ = 0;

--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -26,9 +26,8 @@ static bool OnRenderThread() {
 }
 #endif
 
-GLRTexture::GLRTexture(int width, int height, int depth, int numMips) {
-	// Should move this check to thin3d, but really only OpenGL cares, so...
-	if (gl_extensions.IsCoreContext || gl_extensions.GLES3 || gl_extensions.ARB_texture_non_power_of_two || gl_extensions.OES_texture_npot) {
+GLRTexture::GLRTexture(const Draw::DeviceCaps &caps, int width, int height, int depth, int numMips) {
+	if (caps.textureNPOTFullySupported) {
 		canWrap = true;
 	} else {
 		canWrap = isPowerOf2(width) && isPowerOf2(height);
@@ -114,12 +113,6 @@ void GLDeleter::Perform(GLRenderManager *renderManager, bool skipGLCalls) {
 		delete framebuffer;
 	}
 	framebuffers.clear();
-}
-
-GLRenderManager::GLRenderManager() {
-	for (int i = 0; i < MAX_INFLIGHT_FRAMES; i++) {
-
-	}
 }
 
 GLRenderManager::~GLRenderManager() {

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -555,6 +555,7 @@ OpenGLContext::OpenGLContext() {
 		caps_.clipDistanceSupported = gl_extensions.VersionGEThan(3, 0);
 		caps_.cullDistanceSupported = gl_extensions.ARB_cull_distance;
 	}
+	caps_.textureNPOTFullySupported = gl_extensions.IsCoreContext || gl_extensions.GLES3 || gl_extensions.ARB_texture_non_power_of_two || gl_extensions.OES_texture_npot;
 
 	// Interesting potential hack for emulating GL_DEPTH_CLAMP (use a separate varying, force depth in fragment shader):
 	// This will induce a performance penalty on many architectures though so a blanket enable of this

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -541,6 +541,8 @@ OpenGLContext::OpenGLContext() {
 		caps_.texture3DSupported = true;
 	}
 
+	caps_.dualSourceBlend = gl_extensions.ARB_blend_func_extended || gl_extensions.EXT_blend_func_extended;
+	caps_.anisoSupported = gl_extensions.EXT_texture_filter_anisotropic;
 	caps_.framebufferCopySupported = gl_extensions.OES_copy_image || gl_extensions.NV_copy_image || gl_extensions.EXT_copy_image || gl_extensions.ARB_copy_image;
 	caps_.framebufferBlitSupported = gl_extensions.NV_framebuffer_blit || gl_extensions.ARB_framebuffer_object || gl_extensions.GLES3;
 	caps_.framebufferDepthBlitSupported = caps_.framebufferBlitSupported;
@@ -701,6 +703,8 @@ OpenGLContext::OpenGLContext() {
 			shaderLanguageDesc_.lastFragData = "gl_LastFragColorARM";
 		}
 	}
+
+	renderManager_.SetDeviceCaps(caps_);
 }
 
 OpenGLContext::~OpenGLContext() {

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -555,7 +555,10 @@ OpenGLContext::OpenGLContext() {
 		caps_.clipDistanceSupported = gl_extensions.VersionGEThan(3, 0);
 		caps_.cullDistanceSupported = gl_extensions.ARB_cull_distance;
 	}
-	caps_.textureNPOTFullySupported = gl_extensions.IsCoreContext || gl_extensions.GLES3 || gl_extensions.ARB_texture_non_power_of_two || gl_extensions.OES_texture_npot;
+	caps_.textureNPOTFullySupported =
+		(!gl_extensions.IsGLES && gl_extensions.VersionGEThan(2, 0, 0)) ||
+		gl_extensions.IsCoreContext || gl_extensions.GLES3 ||
+		gl_extensions.ARB_texture_non_power_of_two || gl_extensions.OES_texture_npot;
 
 	// Interesting potential hack for emulating GL_DEPTH_CLAMP (use a separate varying, force depth in fragment shader):
 	// This will induce a performance penalty on many architectures though so a blanket enable of this

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -45,8 +45,6 @@ public:
 	VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VkRenderPass renderPass, int _width, int _height, const char *tag);
 	~VKRFramebuffer();
 
-	int numShadows = 1;  // TODO: Support this.
-
 	VkFramebuffer framebuf = VK_NULL_HANDLE;
 	VKRImage color{};
 	VKRImage depth{};

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -792,6 +792,7 @@ VKContext::VKContext(VulkanContext *vulkan, bool splitSubmit)
 	caps_.preferredDepthBufferFormat = DataFormat::D24_S8;  // TODO: Ask vulkan.
 	caps_.texture3DSupported = true;
 	caps_.fragmentShaderInt32Supported = true;
+	caps_.textureNPOTFullySupported = true;
 
 	auto deviceProps = vulkan->GetPhysicalDeviceProperties(vulkan_->GetCurrentPhysicalDeviceIndex()).properties;
 	switch (deviceProps.vendorID) {

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -540,6 +540,7 @@ struct DeviceCaps {
 	bool framebufferFetchSupported;
 	bool texture3DSupported;
 	bool fragmentShaderInt32Supported;
+	bool textureNPOTFullySupported;
 
 	std::string deviceName;  // The device name to use when creating the thin3d context, to get the same one.
 };

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2678,11 +2678,16 @@ void FramebufferManagerCommon::BlitUsingRaster(
 		{ -1.0f + 2.0f * dX * destX2, -(1.0f - 2.0f * dY * destY2), sX * srcX2, sY * srcY2 },
 	};
 
-	// Unbind the texture first to avoid the D3D11 hazard check (can't set render target to things bound as textures and vice versa, not even temporarily).
-	draw_->BindTexture(0, nullptr);
-	draw_->BindFramebufferAsRenderTarget(dest, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, "BlitUsingRaster");
+	if (dest != currentRenderVfb_->fbo) {
+		// Unbind the texture first to avoid the D3D11 hazard check (can't set render target to things bound as textures and vice versa, not even temporarily).
+		draw_->BindTexture(0, nullptr);
+		draw_->BindFramebufferAsRenderTarget(dest, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, "BlitUsingRaster");
+	}
 	draw_->BindFramebufferAsTexture(src, 0, Draw::FB_COLOR_BIT, 0);
 
+	Draw::Viewport vp{ 0.0f, 0.0f, (float)dest->Width(), (float)dest->Height(), 0.0f, 1.0f };
+	draw_->SetViewports(1, &vp);
+	draw_->SetScissorRect(0, 0, (int)dest->Width(), (int)dest->Height());
 	DrawStrip2D(nullptr, vtx, 4, linearFilter);
 
 	gstate_c.Dirty(DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_RASTER_STATE | DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_VERTEXSHADER_STATE | DIRTY_FRAGMENTSHADER_STATE);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1125,6 +1125,7 @@ void TextureCacheCommon::NotifyConfigChanged() {
 
 	if (!gstate_c.Supports(GPU_SUPPORTS_TEXTURE_NPOT)) {
 		// Reduce the scale factor to a power of two (e.g. 2 or 4) if textures must be a power of two.
+		// TODO: In addition we should probably remove these options from the UI in this case.
 		while ((scaleFactor & (scaleFactor - 1)) != 0) {
 			--scaleFactor;
 		}

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -149,12 +149,14 @@ GPU_GLES::~GPU_GLES() {
 }
 
 // Take the raw GL extension and versioning data and turn into feature flags.
+// TODO: This should use DrawContext::GetDeviceCaps() more and more, and eventually
+// this can be shared between all the backends.
 void GPU_GLES::CheckGPUFeatures() {
 	u32 features = 0;
 
 	features |= GPU_SUPPORTS_16BIT_FORMATS;
 
-	if (gl_extensions.ARB_blend_func_extended || gl_extensions.EXT_blend_func_extended) {
+	if (draw_->GetDeviceCaps().dualSourceBlend) {
 		if (!g_Config.bVendorBugChecksEnabled || !draw_->GetBugs().Has(Draw::Bugs::DUAL_SOURCE_BLENDING_BROKEN)) {
 			features |= GPU_SUPPORTS_DUALSOURCE_BLEND;
 		}
@@ -170,19 +172,19 @@ void GPU_GLES::CheckGPUFeatures() {
 	if ((gl_extensions.gpuVendor == GPU_VENDOR_NVIDIA) || (gl_extensions.gpuVendor == GPU_VENDOR_AMD))
 		features |= GPU_PREFER_REVERSE_COLOR_ORDER;
 
-	if (gl_extensions.OES_texture_npot)
+	if (draw_->GetDeviceCaps().textureNPOTFullySupported)
 		features |= GPU_SUPPORTS_TEXTURE_NPOT;
 
 	if (gl_extensions.EXT_blend_minmax)
 		features |= GPU_SUPPORTS_BLEND_MINMAX;
 
-	if (!gl_extensions.IsGLES)
+	if (draw_->GetDeviceCaps().logicOpSupported)
 		features |= GPU_SUPPORTS_LOGIC_OP;
 
 	if (gl_extensions.GLES3 || !gl_extensions.IsGLES)
 		features |= GPU_SUPPORTS_TEXTURE_LOD_CONTROL;
 
-	if (gl_extensions.EXT_texture_filter_anisotropic)
+	if (draw_->GetDeviceCaps().anisoSupported)
 		features |= GPU_SUPPORTS_ANISOTROPY;
 
 	bool canUseInstanceID = gl_extensions.EXT_draw_instanced || gl_extensions.ARB_draw_instanced;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -258,7 +258,7 @@ void GPU_Vulkan::CheckGPUFeatures() {
 	if (enabledFeatures.logicOp) {
 		features |= GPU_SUPPORTS_LOGIC_OP;
 	}
-	if (enabledFeatures.samplerAnisotropy) {
+	if (draw_->GetDeviceCaps().anisoSupported) {
 		features |= GPU_SUPPORTS_ANISOTROPY;
 	}
 


### PR DESCRIPTION
Also cleans up a bit of GPU feature detection. More to do there.

Fixes bugs in the raster blit functionality too.

Fixes #15800 , #15799
