### PR TITLE
Headless: Cleanup unused/leak warnings

### DIFF
--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -580,7 +580,7 @@ public:
 	u32 currentMipscallId = -1;
 	SceUID currentCallbackId = -1;
 
-	PSPThreadContext context;
+	PSPThreadContext context{};
 	KernelThreadDebugInterface debug;
 
 	std::vector<SceUID> callbacks;

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -527,6 +527,8 @@ int main(int argc, const char* argv[])
 	timeEndPeriod(1);
 #endif
 
+	g_threadManager.Teardown();
+
 	if (!failedTests.empty() && !teamCityMode)
 		return 1;
 	return 0;


### PR DESCRIPTION
Some of the context information can get logged without being initialized (i.e. if thread never started.)  Also, thread manager wasn't ever torn down in headless.

-[Unknown]