### PR TITLE
Depth blit using raster

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -269,6 +269,7 @@ D3D11DrawContext::D3D11DrawContext(ID3D11Device *device, ID3D11DeviceContext *de
 	caps_.fragmentShaderInt32Supported = true;
 	caps_.anisoSupported = true;
 	caps_.textureNPOTFullySupported = true;
+	caps_.fragmentShaderDepthWriteSupported = true;
 
 	D3D11_FEATURE_DATA_D3D11_OPTIONS options{};
 	HRESULT result = device_->CheckFeatureSupport(D3D11_FEATURE_D3D11_OPTIONS, &options, sizeof(options));

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -669,6 +669,7 @@ D3D9Context::D3D9Context(IDirect3D9 *d3d, IDirect3D9Ex *d3dEx, int adapterId, ID
 	caps_.framebufferSeparateDepthCopySupported = false;
 	caps_.texture3DSupported = true;
 	caps_.textureNPOTFullySupported = true;
+	caps_.fragmentShaderDepthWriteSupported = true;
 
 	if (d3d) {
 		D3DDISPLAYMODE displayMode;

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -560,6 +560,13 @@ OpenGLContext::OpenGLContext() {
 		gl_extensions.IsCoreContext || gl_extensions.GLES3 ||
 		gl_extensions.ARB_texture_non_power_of_two || gl_extensions.OES_texture_npot;
 
+	if (gl_extensions.IsGLES) {
+		caps_.fragmentShaderDepthWriteSupported = gl_extensions.GLES3;
+		// There's also GL_EXT_frag_depth but it's rare along with 2.0. Most chips that support it are simply 3.0 chips.
+	} else {
+		caps_.fragmentShaderDepthWriteSupported = true;
+	}
+
 	// Interesting potential hack for emulating GL_DEPTH_CLAMP (use a separate varying, force depth in fragment shader):
 	// This will induce a performance penalty on many architectures though so a blanket enable of this
 	// is probably not a good idea.

--- a/Common/GPU/ShaderWriter.h
+++ b/Common/GPU/ShaderWriter.h
@@ -36,6 +36,11 @@ struct VaryingDef {
 	const char *precision;
 };
 
+enum FSFlags {
+	FSFLAG_NONE = 0,
+	FSFLAG_WRITEDEPTH = 1,
+};
+
 class ShaderWriter {
 public:
 	ShaderWriter(char *buffer, const ShaderLanguageDesc &lang, ShaderStage stage, const char **gl_extensions, size_t num_gl_extensions) : p_(buffer), lang_(lang), stage_(stage) {
@@ -82,11 +87,11 @@ public:
 
 	// Simple shaders with no special tricks.
 	void BeginVSMain(Slice<InputDef> inputs, Slice<UniformDef> uniforms, Slice<VaryingDef> varyings);
-	void BeginFSMain(Slice<UniformDef> uniforms, Slice<VaryingDef> varyings);
+	void BeginFSMain(Slice<UniformDef> uniforms, Slice<VaryingDef> varyings, FSFlags flags);
 
 	// For simple shaders that output a single color, we can deal with this generically.
 	void EndVSMain(Slice<VaryingDef> varyings);
-	void EndFSMain(const char *vec4_color_variable);
+	void EndFSMain(const char *vec4_color_variable, FSFlags flags);
 
 
 	void Rewind(size_t offset) {

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -793,6 +793,7 @@ VKContext::VKContext(VulkanContext *vulkan, bool splitSubmit)
 	caps_.texture3DSupported = true;
 	caps_.fragmentShaderInt32Supported = true;
 	caps_.textureNPOTFullySupported = true;
+	caps_.fragmentShaderDepthWriteSupported = true;
 
 	auto deviceProps = vulkan->GetPhysicalDeviceProperties(vulkan_->GetCurrentPhysicalDeviceIndex()).properties;
 	switch (deviceProps.vendorID) {

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -541,6 +541,7 @@ struct DeviceCaps {
 	bool texture3DSupported;
 	bool fragmentShaderInt32Supported;
 	bool textureNPOTFullySupported;
+	bool fragmentShaderDepthWriteSupported;
 
 	std::string deviceName;  // The device name to use when creating the thin3d context, to get the same one.
 };

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -267,7 +267,7 @@ void GenerateDepalFs(char *buffer, const DepalConfig &config, const ShaderLangua
 	ShaderWriter writer(buffer, lang, ShaderStage::Fragment, nullptr, 0);
 	writer.DeclareSamplers(samplers);
 	writer.HighPrecisionFloat();
-	writer.BeginFSMain(Slice<UniformDef>::empty(), varyings);
+	writer.BeginFSMain(Slice<UniformDef>::empty(), varyings, FSFLAG_NONE);
 	switch (lang.shaderLanguage) {
 	case HLSL_D3D9:
 	case GLSL_1xx:
@@ -281,7 +281,7 @@ void GenerateDepalFs(char *buffer, const DepalConfig &config, const ShaderLangua
 	default:
 		_assert_msg_(false, "Depal shader language not supported: %d", (int)lang.shaderLanguage);
 	}
-	writer.EndFSMain("outColor");
+	writer.EndFSMain("outColor", FSFLAG_NONE);
 }
 
 void GenerateDepalVs(char *buffer, const ShaderLanguageDesc &lang) {

--- a/GPU/Common/Draw2D.cpp
+++ b/GPU/Common/Draw2D.cpp
@@ -83,10 +83,16 @@ void FramebufferManagerCommon::DrawStrip2D(Draw::Texture *tex, Draw2DVertex *ver
 		GenerateDraw2DVS(vsCode, shaderLanguageDesc);
 
 		draw2DFs_ = draw_->CreateShaderModule(ShaderStage::Fragment, shaderLanguageDesc.shaderLanguage, (const uint8_t *)fsCode, strlen(fsCode), "draw2d_fs");
-		draw2DFsDepth_ = draw_->CreateShaderModule(ShaderStage::Fragment, shaderLanguageDesc.shaderLanguage, (const uint8_t *)fsDepthCode, strlen(fsDepthCode), "draw2d_depth_fs");
 		draw2DVs_ = draw_->CreateShaderModule(ShaderStage::Vertex, shaderLanguageDesc.shaderLanguage, (const uint8_t *)vsCode, strlen(vsCode), "draw2d_vs");
 
-		_assert_(draw2DFs_ && draw2DVs_ && draw2DFsDepth_);
+		_assert_(draw2DFs_ && draw2DVs_);
+
+		if (draw_->GetDeviceCaps().fragmentShaderDepthWriteSupported) {
+			draw2DFsDepth_ = draw_->CreateShaderModule(ShaderStage::Fragment, shaderLanguageDesc.shaderLanguage, (const uint8_t *)fsDepthCode, strlen(fsDepthCode), "draw2d_depth_fs");
+			_assert_(draw2DFsDepth_);
+		} else {
+			draw2DFsDepth_ = nullptr;
+		}
 
 		InputLayoutDesc desc = {
 			{
@@ -124,8 +130,13 @@ void FramebufferManagerCommon::DrawStrip2D(Draw::Texture *tex, Draw2DVertex *ver
 			{ draw2DVs_, draw2DFsDepth_ },
 			inputLayout, depthWriteAlways, blendDiscard, rasterNoCull, nullptr,
 		};
-		draw2DPipelineDepth_ = draw_->CreateGraphicsPipeline(draw2DDepthPipelineDesc);
-		_assert_(draw2DPipelineDepth_);
+
+		if (draw_->GetDeviceCaps().fragmentShaderDepthWriteSupported) {
+			draw2DPipelineDepth_ = draw_->CreateGraphicsPipeline(draw2DDepthPipelineDesc);
+			_assert_(draw2DPipelineDepth_);
+		} else {
+			draw2DPipelineDepth_ = nullptr;
+		}
 
 		delete[] fsCode;
 		delete[] vsCode;
@@ -152,6 +163,10 @@ void FramebufferManagerCommon::DrawStrip2D(Draw::Texture *tex, Draw2DVertex *ver
 		descLinear.wrapU = TextureAddressMode::CLAMP_TO_EDGE;
 		descLinear.wrapV = TextureAddressMode::CLAMP_TO_EDGE;
 		draw2DSamplerNearest_ = draw_->CreateSamplerState(descNearest);
+	}
+
+	if (channel == RASTER_DEPTH && !draw2DPipelineDepth_) {
+		return;
 	}
 
 	draw_->BindPipeline(channel == RASTER_COLOR ? draw2DPipelineColor_ : draw2DPipelineDepth_);

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -283,7 +283,7 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const Frame
 		WARN_LOG_ONCE(color_equal_z, G3D, "Framebuffer bound with color addr == z addr, likely will not use Z in this pass: %08x", params.fb_address);
 	}
 
-	FramebufferRenderMode mode = FB_MODE_NORMAL;
+	RasterMode mode = RASTER_MODE_NORMAL;
 
 	// Find a matching framebuffer
 	VirtualFramebuffer *vfb = nullptr;
@@ -331,7 +331,7 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const Frame
 			// Seems impractical to use the other 16-bit formats for this due to the limited control over alpha,
 			// so we'll simply only support 565.
 			if (params.fmt == GE_FORMAT_565) {
-				mode = FB_MODE_COLOR_TO_DEPTH;
+				mode = RASTER_MODE_COLOR_TO_DEPTH;
 				break;
 			}
 		} else if (v->fb_stride == params.fb_stride && v->format == params.fmt) {
@@ -368,7 +368,7 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const Frame
 		}
 	}
 
-	if (mode == FB_MODE_COLOR_TO_DEPTH) {
+	if (mode == RASTER_MODE_COLOR_TO_DEPTH) {
 		// Lookup in the depth tracking to find which VFB has the latest version of this Z buffer.
 		// Then bind it in color-to-depth mode.
 		//

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -359,7 +359,7 @@ protected:
 	Draw::Texture *MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height);
 	void DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags);
 
-	void DrawStrip2D(Draw::Texture *tex, Draw2DVertex *verts, int vertexCount, bool linearFilter);
+	void DrawStrip2D(Draw::Texture *tex, Draw2DVertex *verts, int vertexCount, bool linearFilter, RasterChannel channel);
 
 	bool UpdateSize();
 
@@ -367,11 +367,11 @@ protected:
 	virtual void DecimateFBOs();  // keeping it virtual to let D3D do a little extra
 
 	// Used by ReadFramebufferToMemory and later framebuffer block copies
-	virtual void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp, const char *tag);
+	void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp, const char *tag);
 
 	void BlitUsingRaster(
 		Draw::Framebuffer *src, float srcX1, float srcY1, float srcX2, float srcY2,
-		Draw::Framebuffer *dest, float destX1, float destY1, float destX2, float destY2, bool linearFilter);
+		Draw::Framebuffer *dest, float destX1, float destY1, float destX2, float destY2, bool linearFilter, RasterChannel channel);
 
 	void CopyFramebufferForColorTexture(VirtualFramebuffer *dst, VirtualFramebuffer *src, int flags);
 
@@ -485,9 +485,11 @@ protected:
 	Draw::SamplerState *stencilUploadSampler_ = nullptr;
 
 	// Draw2D pipelines
-	Draw::Pipeline *draw2DPipelineLinear_ = nullptr;
+	Draw::Pipeline *draw2DPipelineColor_ = nullptr;
+	Draw::Pipeline *draw2DPipelineDepth_ = nullptr;
 	Draw::SamplerState *draw2DSamplerLinear_ = nullptr;
 	Draw::SamplerState *draw2DSamplerNearest_ = nullptr;
 	Draw::ShaderModule *draw2DVs_ = nullptr;
 	Draw::ShaderModule *draw2DFs_ = nullptr;
+	Draw::ShaderModule *draw2DFsDepth_ = nullptr;
 };

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -1018,7 +1018,7 @@ void ConvertMaskState(GenericMaskState &maskState, bool allowFramebufferRead) {
 		return;
 	}
 
-	if (gstate_c.renderMode == FB_MODE_COLOR_TO_DEPTH) {
+	if (gstate_c.renderMode == RASTER_MODE_COLOR_TO_DEPTH) {
 		// Suppress color writes entirely in this mode.
 		maskState.applyFramebufferRead = false;
 		maskState.rgba[0] = false;

--- a/GPU/Common/ReinterpretFramebuffer.cpp
+++ b/GPU/Common/ReinterpretFramebuffer.cpp
@@ -28,7 +28,7 @@ bool GenerateReinterpretFragmentShader(char *buffer, GEBufferFormat from, GEBuff
 
 	writer.DeclareSamplers(samplers);
 
-	writer.BeginFSMain(Slice<UniformDef>::empty(), varyings);
+	writer.BeginFSMain(Slice<UniformDef>::empty(), varyings, FSFLAG_NONE);
 
 	writer.C("  vec4 val = ").SampleTexture2D("tex", "v_texcoord.xy").C(";\n");
 
@@ -68,7 +68,7 @@ bool GenerateReinterpretFragmentShader(char *buffer, GEBufferFormat from, GEBuff
 		break;
 	}
 
-	writer.EndFSMain("outColor");
+	writer.EndFSMain("outColor", FSFLAG_NONE);
 	return true;
 }
 

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -264,7 +264,7 @@ void ComputeFragmentShaderID(FShaderID *id_out, const Draw::Bugs &bugs) {
 		bool doFlatShading = gstate.getShadeMode() == GE_SHADE_FLAT;
 		bool useShaderDepal = gstate_c.useShaderDepal;
 		bool colorWriteMask = IsColorWriteMaskComplex(gstate_c.allowFramebufferRead);
-		bool colorToDepth = gstate_c.renderMode == FramebufferRenderMode::FB_MODE_COLOR_TO_DEPTH;
+		bool colorToDepth = gstate_c.renderMode == RasterMode::RASTER_MODE_COLOR_TO_DEPTH;
 
 		// Note how we here recompute some of the work already done in state mapping.
 		// Not ideal! At least we share the code.

--- a/GPU/Common/StencilCommon.cpp
+++ b/GPU/Common/StencilCommon.cpp
@@ -94,7 +94,7 @@ void GenerateStencilFs(char *buffer, const ShaderLanguageDesc &lang, const Draw:
 
 	writer.C("float roundAndScaleTo255f(in float x) { return floor(x * 255.99); }\n");
 
-	writer.BeginFSMain(uniforms, varyings);
+	writer.BeginFSMain(uniforms, varyings, FSFLAG_NONE);
 
 	writer.C("  vec4 index = ").SampleTexture2D("tex", "v_texcoord.xy").C(";\n");
 	writer.C("  vec4 outColor = index.aaaa;\n");  // Only care about a.
@@ -106,7 +106,7 @@ void GenerateStencilFs(char *buffer, const ShaderLanguageDesc &lang, const Draw:
 		writer.C("  gl_FragDepth = gl_FragCoord.z;\n");
 	}
 
-	writer.EndFSMain("outColor");
+	writer.EndFSMain("outColor", FSFLAG_NONE);
 }
 
 // This can probably be shared with some other shaders, like reinterpret or the future depth upload.

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -25,6 +25,7 @@
 #include "Common/MemoryUtil.h"
 #include "Core/TextureReplacer.h"
 #include "Core/System.h"
+#include "GPU/GPU.h"
 #include "GPU/Common/GPUDebugInterface.h"
 #include "GPU/Common/TextureDecoder.h"
 #include "GPU/Common/TextureScalerCommon.h"
@@ -34,11 +35,6 @@ enum FramebufferNotification {
 	NOTIFY_FB_CREATED,
 	NOTIFY_FB_UPDATED,
 	NOTIFY_FB_DESTROYED,
-};
-
-enum FramebufferNotificationChannel {
-	NOTIFY_FB_COLOR = 0,
-	NOTIFY_FB_DEPTH = 1,
 };
 
 // Changes more frequent than this will be considered "frequent" and prevent texture scaling.
@@ -229,7 +225,7 @@ struct AttachCandidate {
 	FramebufferMatchInfo match;
 	TextureDefinition entry;
 	VirtualFramebuffer *fb;
-	FramebufferNotificationChannel channel;
+	RasterChannel channel;
 
 	std::string ToString();
 };
@@ -336,7 +332,7 @@ protected:
 	void DeleteTexture(TexCache::iterator it);
 	void Decimate(bool forcePressure = false);
 
-	void ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer, GETextureFormat texFormat, FramebufferNotificationChannel channel);
+	void ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer, GETextureFormat texFormat, RasterChannel channel);
 
 	void HandleTextureChange(TexCacheEntry *const entry, const char *reason, bool initialMatch, bool doDelete);
 	virtual void BuildTexture(TexCacheEntry *const entry) = 0;
@@ -369,7 +365,7 @@ protected:
 	SamplerCacheKey GetFramebufferSamplingParams(u16 bufferWidth, u16 bufferHeight);
 	void UpdateMaxSeenV(TexCacheEntry *entry, bool throughMode);
 
-	FramebufferMatchInfo MatchFramebuffer(const TextureDefinition &entry, VirtualFramebuffer *framebuffer, u32 texaddrOffset, FramebufferNotificationChannel channel) const;
+	FramebufferMatchInfo MatchFramebuffer(const TextureDefinition &entry, VirtualFramebuffer *framebuffer, u32 texaddrOffset, RasterChannel channel) const;
 
 	std::vector<AttachCandidate> GetFramebufferCandidates(const TextureDefinition &entry, u32 texAddrOffset);
 	int GetBestCandidateIndex(const std::vector<AttachCandidate> &candidates);

--- a/GPU/D3D11/StateMappingD3D11.cpp
+++ b/GPU/D3D11/StateMappingD3D11.cpp
@@ -293,7 +293,7 @@ void DrawEngineD3D11::ApplyDrawState(int prim) {
 		GenericStencilFuncState stencilState;
 		ConvertStencilFuncState(stencilState);
 
-		if (gstate_c.renderMode == FB_MODE_COLOR_TO_DEPTH) {
+		if (gstate_c.renderMode == RASTER_MODE_COLOR_TO_DEPTH) {
 			// Enforce plain depth writing.
 			keys_.depthStencil.value = 0;
 			keys_.depthStencil.depthTestEnable = true;

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -214,7 +214,7 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 
 		// Set Stencil/Depth
 
-		if (gstate_c.renderMode == FB_MODE_COLOR_TO_DEPTH) {
+		if (gstate_c.renderMode == RASTER_MODE_COLOR_TO_DEPTH) {
 			// Enforce plain depth writing.
 			dxstate.depthTest.enable();
 			dxstate.depthFunc.set(D3DCMP_ALWAYS);

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -251,7 +251,7 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 		GenericStencilFuncState stencilState;
 		ConvertStencilFuncState(stencilState);
 
-		if (gstate_c.renderMode == FB_MODE_COLOR_TO_DEPTH) {
+		if (gstate_c.renderMode == RASTER_MODE_COLOR_TO_DEPTH) {
 			// Enforce plain depth writing.
 			renderManager->SetStencilDisabled();
 			renderManager->SetDepth(true, true, GL_ALWAYS);

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -24,9 +24,17 @@ class GPUInterface;
 class GPUDebugInterface;
 class GraphicsContext;
 
-enum FramebufferRenderMode {
-	FB_MODE_NORMAL = 0,
-	FB_MODE_COLOR_TO_DEPTH = 1,
+enum RasterMode {
+	RASTER_MODE_NORMAL = 0,
+	RASTER_MODE_COLOR_TO_DEPTH = 1,
+};
+
+// PSP rasterization has two outputs, color and depth. Stencil is packed
+// into the alpha channel of color (if exists), so possibly RASTER_COLOR
+// should be named RASTER_COLOR_STENCIL but it gets kinda hard to read.
+enum RasterChannel {
+	RASTER_COLOR = 0,
+	RASTER_DEPTH = 1,
 };
 
 enum SkipDrawReasonFlags {

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -555,7 +555,7 @@ struct GPUStateCache {
 			Dirty(DIRTY_FRAGMENTSHADER_STATE | (is3D ? DIRTY_MIPBIAS : 0));
 		}
 	}
-	void SetFramebufferRenderMode(FramebufferRenderMode mode) {
+	void SetFramebufferRenderMode(RasterMode mode) {
 		if (mode != renderMode) {
 			// This mode modifies the fragment shader to write depth, the depth state to write without testing, and the blend state to write nothing to color.
 			// So we need to re-evaluate those states.
@@ -614,7 +614,7 @@ struct GPUStateCache {
 	bool blueToAlpha;
 
 	// Some games try to write to the Z buffer using color. Catch that and actually do the writes to the Z buffer instead.
-	FramebufferRenderMode renderMode;
+	RasterMode renderMode;
 
 	// TODO: These should be accessed from the current VFB object directly.
 	u32 curRTWidth;

--- a/GPU/Vulkan/StateMappingVulkan.cpp
+++ b/GPU/Vulkan/StateMappingVulkan.cpp
@@ -250,7 +250,7 @@ void DrawEngineVulkan::ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManag
 		GenericStencilFuncState stencilState;
 		ConvertStencilFuncState(stencilState);
 
-		if (gstate_c.renderMode == FB_MODE_COLOR_TO_DEPTH) {
+		if (gstate_c.renderMode == RASTER_MODE_COLOR_TO_DEPTH) {
 			// Enforce plain depth writing.
 			key.depthTestEnable = true;
 			key.depthWriteEnable = true;


### PR DESCRIPTION
Some platforms don't support depth copies but do support writing to the depth buffer using raster. One example is D3D9.

This fixes games like Jeanne D'Arc and Saint Seiya on D3D9.

This capability might also be useful for other backends in the future in case doing it this way is faster than a blit operation, to be determined. And also maybe for D3D11 that can't blit depth without also blitting stencil.

Also, renames `FramebufferNotificationChannel` to simply `RasterChannel` since the enum has gathered more users over time.

Currently only used when blit and copy are unavailable, but that may change in the future.