### PR TITLE
Debugger: Correct GE frame dump VRAM dirty flag

### DIFF
--- a/Common/Net/HTTPHeaders.cpp
+++ b/Common/Net/HTTPHeaders.cpp
@@ -154,7 +154,7 @@ void RequestHeader::ParseHeaders(net::InputSink *sink) {
 	}
 
 	VERBOSE_LOG(IO, "finished parsing request.");
-	ok = line_count > 1;
+	ok = line_count > 1 && resource != nullptr;
 }
 
 }  // namespace http

--- a/GPU/Debugger/RecordFormat.h
+++ b/GPU/Debugger/RecordFormat.h
@@ -34,7 +34,8 @@ static const char *HEADER_MAGIC = "PPSSPPGE";
 // Version 3: Adds FRAMEBUF0-FRAMEBUF9
 // Version 4: Expanded header with game ID
 // Version 5: Uses zstd
-static const int VERSION = 5;
+// Version 6: Corrects dirty VRAM flag
+static const int VERSION = 6;
 static const int MIN_VERSION = 2;
 
 enum class CommandType : u8 {


### PR DESCRIPTION
Some recent dumps have shown incorrectly and I wondered why.  Then I realized it was this VRAM dirty flag logic misbehaving.

I must've forgotten to finish testing and thought I was done... I have no excuse.  It wasn't actually doing anything before, except sometimes reading outside the valid array.  Now it actually marks dirty VRAM properly to avoid excessive recopying of texture data.

-[Unknown]