### PR TITLE
GPU: Skip fb create upload when clearing

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -469,7 +469,8 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(const Frame
 		vfbs_.push_back(vfb);
 		currentRenderVfb_ = vfb;
 
-		if (useBufferedRendering_ && !g_Config.bDisableSlowFramebufEffects) {
+		// Assume that if we're clearing right when switching to a new framebuffer, we don't need to upload.
+		if (useBufferedRendering_ && !g_Config.bDisableSlowFramebufEffects && params.isDrawing) {
 			gpu->PerformMemoryUpload(params.fb_address, byteSize);
 			// Alpha was already done by PerformMemoryUpload.
 			PerformStencilUpload(params.fb_address, byteSize, StencilUpload::STENCIL_IS_ZERO | StencilUpload::IGNORE_ALPHA);


### PR DESCRIPTION
This doesn't verify it's a full screen clear, but on a new framebuffer that's very very common.

I realized a bit before that we could probably skip this, it's probably the most common case of a stencil upload in most games, and in many we can skip it.

-[Unknown]