### PR TITLE
GE Debugger: Correct base accounting in playback

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -266,7 +266,7 @@ bool DrawEngineCommon::GetCurrentSimpleVertices(int count, std::vector<GPUDebugV
 	u16 indexLowerBound = 0;
 	u16 indexUpperBound = count - 1;
 
-	if (!Memory::IsValidAddress(gstate_c.vertexAddr))
+	if (!Memory::IsValidAddress(gstate_c.vertexAddr) || count == 0)
 		return false;
 
 	bool savedVertexFullAlpha = gstate_c.vertexFullAlpha;

--- a/GPU/Debugger/Playback.cpp
+++ b/GPU/Debugger/Playback.cpp
@@ -367,6 +367,7 @@ bool DumpExecute::SubmitCmds(const void *p, u32 sz) {
 		Memory::Write_U32((GE_CMD_JUMP << 24) | (execListBuf & 0x00FFFFFF), execListPos + 4);
 
 		execListPos = execListBuf;
+		lastBase_ = execListBuf & 0xFF000000;
 
 		// Don't continue until we've stalled.
 		SyncStall();
@@ -450,9 +451,9 @@ void DumpExecute::Vertices(u32 ptr, u32 sz) {
 		return;
 	}
 
-	if (lastBase_ != (psp & 0x0FF000000)) {
+	if (lastBase_ != (psp & 0xFF000000)) {
 		execListQueue.push_back((GE_CMD_BASE << 24) | ((psp >> 8) & 0x00FF0000));
-		lastBase_ = psp & 0x0FF000000;
+		lastBase_ = psp & 0xFF000000;
 	}
 	execListQueue.push_back((GE_CMD_VADDR << 24) | (psp & 0x00FFFFFF));
 }
@@ -464,9 +465,9 @@ void DumpExecute::Indices(u32 ptr, u32 sz) {
 		return;
 	}
 
-	if (lastBase_ != (psp & 0x0FF000000)) {
+	if (lastBase_ != (psp & 0xFF000000)) {
 		execListQueue.push_back((GE_CMD_BASE << 24) | ((psp >> 8) & 0x00FF0000));
-		lastBase_ = psp & 0x0FF000000;
+		lastBase_ = psp & 0xFF000000;
 	}
 	execListQueue.push_back((GE_CMD_IADDR << 24) | (psp & 0x00FFFFFF));
 }

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -813,6 +813,9 @@ bool TransformUnit::GetCurrentSimpleVertices(int count, std::vector<GPUDebugVert
 	u16 indexLowerBound = 0;
 	u16 indexUpperBound = count - 1;
 
+	if (!Memory::IsValidAddress(gstate_c.vertexAddr) || count == 0)
+		return false;
+
 	if (count > 0 && (gstate.vertType & GE_VTYPE_IDX_MASK) != GE_VTYPE_IDX_NONE) {
 		const u8 *inds = Memory::GetPointer(gstate_c.indexAddr);
 		const u16_le *inds16 = (const u16_le *)inds;


### PR DESCRIPTION
Broke this in #15376, looks like.  The original intent was to stop outputting so many noise commands between draws so that you mostly had the original commands.

See frame dump in #9850 which reproduced this bug.

-[Unknown]