### PR TITLE
Remove DX9 namespace, other code cleanup

### DIFF
--- a/Common/GPU/D3D9/D3D9StateCache.cpp
+++ b/Common/GPU/D3D9/D3D9StateCache.cpp
@@ -2,12 +2,10 @@
 
 #include "Common/GPU/D3D9/D3D9StateCache.h"
 
-namespace DX9 {
-
 DirectXState dxstate;
 
-LPDIRECT3DDEVICE9 pD3Ddevice = nullptr;
-LPDIRECT3DDEVICE9EX pD3DdeviceEx = nullptr;
+LPDIRECT3DDEVICE9 pD3Ddevice9 = nullptr;
+LPDIRECT3DDEVICE9EX pD3DdeviceEx9 = nullptr;
 
 int DirectXState::state_count = 0;
 
@@ -61,7 +59,5 @@ void DirectXState::Restore() {
 	texAddressV.restore(); count++;
 	texAddressW.restore(); count++;
 }
-
-}  // namespace DX9
 
 #endif  // _MSC_VER

--- a/Common/GPU/D3D9/D3D9StateCache.h
+++ b/Common/GPU/D3D9/D3D9StateCache.h
@@ -4,11 +4,9 @@
 
 #include "Common/GPU/D3D9/D3D9ShaderCompiler.h"
 
-namespace DX9 {
-
 // TODO: Get rid of these somehow.
-extern LPDIRECT3DDEVICE9 pD3Ddevice;
-extern LPDIRECT3DDEVICE9EX pD3DdeviceEx;
+extern LPDIRECT3DDEVICE9 pD3Ddevice9;
+extern LPDIRECT3DDEVICE9EX pD3DdeviceEx9;
 
 class DirectXState {
 private:
@@ -44,7 +42,7 @@ private:
 			return _value;
 		}
 		void restore() {
-			pD3Ddevice->SetRenderState(cap, _value);
+			pD3Ddevice9->SetRenderState(cap, _value);
 		}
 	};
 
@@ -69,7 +67,7 @@ private:
 			p1 = old;
 		}
 		void restore() {
-			pD3Ddevice->SetRenderState(_state1, p1);
+			pD3Ddevice9->SetRenderState(_state1, p1);
 		}
 	};
 
@@ -94,7 +92,7 @@ private:
 			p1 = old;
 		}
 		void restore() {
-			pD3Ddevice->SetSamplerState(0, _state1, p1);
+			pD3Ddevice9->SetSamplerState(0, _state1, p1);
 		}
 	};
 
@@ -123,7 +121,7 @@ private:
 			p1 = old;
 		}
 		void restore() {
-			pD3Ddevice->SetSamplerState(0, _state1, p1d);
+			pD3Ddevice9->SetSamplerState(0, _state1, p1d);
 		}
 	};
 
@@ -141,11 +139,11 @@ private:
 		inline void set(DWORD newp1, DWORD newp2) {
 			if (p1 != newp1) {
 				p1 = newp1;
-				pD3Ddevice->SetRenderState(_state1, p1);
+				pD3Ddevice9->SetRenderState(_state1, p1);
 			}
 			if (p2 != newp2) {
 				p2 = newp2;
-				pD3Ddevice->SetRenderState(_state2, p2);
+				pD3Ddevice9->SetRenderState(_state2, p2);
 			}
 		}
 		void force(DWORD newp1, DWORD newp2) {
@@ -156,8 +154,8 @@ private:
 			p2 = old2;
 		}
 		void restore() {
-			pD3Ddevice->SetRenderState(_state1, p1);
-			pD3Ddevice->SetRenderState(_state2, p2);
+			pD3Ddevice9->SetRenderState(_state1, p1);
+			pD3Ddevice9->SetRenderState(_state2, p2);
 		}
 	};
 
@@ -177,15 +175,15 @@ private:
 		inline void set(DWORD newp1, DWORD newp2, DWORD newp3) {
 			if (p1 != newp1) {
 				p1 = newp1;
-				pD3Ddevice->SetRenderState(_state1, p1);
+				pD3Ddevice9->SetRenderState(_state1, p1);
 			}
 			if (p2 != newp2) {
 				p2 = newp2;
-				pD3Ddevice->SetRenderState(_state2, p2);
+				pD3Ddevice9->SetRenderState(_state2, p2);
 			}
 			if (p3 != newp3) {
 				p3 = newp3;
-				pD3Ddevice->SetRenderState(_state3, p3);
+				pD3Ddevice9->SetRenderState(_state3, p3);
 			}
 		}
 		void force(DWORD newp1, DWORD newp2, DWORD newp3) {
@@ -198,9 +196,9 @@ private:
 			p3 = old3;
 		}
 		void restore() {
-			pD3Ddevice->SetRenderState(_state1, p1);
-			pD3Ddevice->SetRenderState(_state2, p2);
-			pD3Ddevice->SetRenderState(_state3, p3);
+			pD3Ddevice9->SetRenderState(_state1, p1);
+			pD3Ddevice9->SetRenderState(_state2, p2);
+			pD3Ddevice9->SetRenderState(_state3, p3);
 		}
 	};
 
@@ -222,19 +220,19 @@ private:
 		inline void set(DWORD newp1, DWORD newp2, DWORD newp3, DWORD newp4) {
 			if (p1 != newp1) {
 				p1 = newp1;
-				pD3Ddevice->SetRenderState(_state1, p1);
+				pD3Ddevice9->SetRenderState(_state1, p1);
 			}
 			if (p2 != newp2) {
 				p2 = newp2;
-				pD3Ddevice->SetRenderState(_state2, p2);
+				pD3Ddevice9->SetRenderState(_state2, p2);
 			}
 			if (p3 != newp3) {
 				p3 = newp3;
-				pD3Ddevice->SetRenderState(_state3, p3);
+				pD3Ddevice9->SetRenderState(_state3, p3);
 			}
 			if (p4 != newp4) {
 				p4 = newp4;
-				pD3Ddevice->SetRenderState(_state4, p4);
+				pD3Ddevice9->SetRenderState(_state4, p4);
 			}
 		}
 		void force(DWORD newp1, DWORD newp2, DWORD newp3, DWORD newp4) {
@@ -249,10 +247,10 @@ private:
 			p4 = old4;
 		}
 		void restore() {
-			pD3Ddevice->SetRenderState(_state1, p1);
-			pD3Ddevice->SetRenderState(_state2, p2);
-			pD3Ddevice->SetRenderState(_state3, p3);
-			pD3Ddevice->SetRenderState(_state3, p4);
+			pD3Ddevice9->SetRenderState(_state1, p1);
+			pD3Ddevice9->SetRenderState(_state2, p2);
+			pD3Ddevice9->SetRenderState(_state3, p3);
+			pD3Ddevice9->SetRenderState(_state3, p4);
 		}
 	};
 
@@ -284,7 +282,7 @@ private:
 			c = old;
 		}
 		inline void restore() {
-			pD3Ddevice->SetRenderState(D3DRS_BLENDFACTOR, c);
+			pD3Ddevice9->SetRenderState(D3DRS_BLENDFACTOR, c);
 		}
 	};
 
@@ -318,7 +316,7 @@ private:
 		}
 
 		inline void restore() {
-			pD3Ddevice->SetViewport(&viewport);
+			pD3Ddevice9->SetViewport(&viewport);
 		}
 	};
 
@@ -340,7 +338,7 @@ private:
 		}
 
 		inline void restore() {
-			pD3Ddevice->SetScissorRect(&rect);
+			pD3Ddevice9->SetScissorRect(&rect);
 		}
 	};
 
@@ -412,5 +410,3 @@ struct GLExtensions {
 extern GLExtensions gl_extensions;
 
 void CheckGLExtensions();
-
-};

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -152,7 +152,6 @@ public:
 	D3DCMPFUNC stencilCompareOp;
 
 	void Apply(LPDIRECT3DDEVICE9 device, uint8_t stencilRef, uint8_t stencilWriteMask, uint8_t stencilCompareMask) {
-		using namespace DX9;
 		dxstate.depthTest.set(depthTestEnabled);
 		if (depthTestEnabled) {
 			dxstate.depthWrite.set(depthWriteEnabled);
@@ -174,7 +173,6 @@ public:
 	DWORD cullMode;   // D3DCULL_*
 
 	void Apply(LPDIRECT3DDEVICE9 device) {
-		using namespace DX9;
 		dxstate.cullMode.set(cullMode);
 		dxstate.scissorTest.enable();
 	}
@@ -188,7 +186,6 @@ public:
 	uint32_t colorMask;
 
 	void Apply(LPDIRECT3DDEVICE9 device) {
-		using namespace DX9;
 		dxstate.blend.set(enabled);
 		dxstate.blendFunc.set(srcCol, dstCol, srcAlpha, dstAlpha);
 		dxstate.blendEquation.set(eqCol, eqAlpha);
@@ -202,7 +199,6 @@ public:
 	D3DTEXTUREFILTERTYPE magFilt, minFilt, mipFilt;
 
 	void Apply(LPDIRECT3DDEVICE9 device, int index) {
-		using namespace DX9;
 		dxstate.texAddressU.set(wrapS);
 		dxstate.texAddressV.set(wrapT);
 		dxstate.texMagFilter.set(magFilt);
@@ -689,7 +685,7 @@ D3D9Context::D3D9Context(IDirect3D9 *d3d, IDirect3D9Ex *d3dEx, int adapterId, ID
 
 	shaderLanguageDesc_.Init(HLSL_D3D9);
 
-	DX9::dxstate.Restore();
+	dxstate.Restore();
 }
 
 D3D9Context::~D3D9Context() {
@@ -1037,15 +1033,11 @@ void D3D9Context::Clear(int mask, uint32_t colorval, float depthVal, int stencil
 }
 
 void D3D9Context::SetScissorRect(int left, int top, int width, int height) {
-	using namespace DX9;
-
 	dxstate.scissorRect.set(left, top, left + width, top + height);
 	dxstate.scissorTest.set(true);
 }
 
 void D3D9Context::SetViewports(int count, Viewport *viewports) {
-	using namespace DX9;
-
 	int x = (int)viewports[0].TopLeftX;
 	int y = (int)viewports[0].TopLeftY;
 	int w = (int)viewports[0].Width;
@@ -1058,7 +1050,6 @@ void D3D9Context::SetBlendFactor(float color[4]) {
 	uint32_t g = (uint32_t)(color[1] * 255.0f);
 	uint32_t b = (uint32_t)(color[2] * 255.0f);
 	uint32_t a = (uint32_t)(color[3] * 255.0f);
-	using namespace DX9;
 	dxstate.blendColor.set(color);
 }
 
@@ -1179,7 +1170,6 @@ D3D9Framebuffer::~D3D9Framebuffer() {
 }
 
 void D3D9Context::BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) {
-	using namespace DX9;
 	if (fbo) {
 		D3D9Framebuffer *fb = (D3D9Framebuffer *)fbo;
 		device_->SetRenderTarget(0, fb->surf);

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -47,7 +47,7 @@
 #include "GPU/GPUState.h"
 
 FramebufferManagerCommon::FramebufferManagerCommon(Draw::DrawContext *draw)
-	: draw_(draw), displayFormat_(GE_FORMAT_565) {
+	: draw_(draw) {
 	presentation_ = new PresentationCommon(draw);
 }
 

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -55,6 +55,7 @@ namespace Draw {
 }
 
 class VulkanFBO;
+class ShaderWriter;
 
 // We have to track VFBs and depth buffers together, since bits are shared between the color alpha channel
 // and the stencil buffer on the PSP.
@@ -362,6 +363,7 @@ protected:
 
 	void DrawStrip2D(Draw::Texture *tex, Draw2DVertex *verts, int vertexCount, bool linearFilter, RasterChannel channel);
 	void Ensure2DResources();
+	Draw::Pipeline *Create2DPipeline(void (*generate)(ShaderWriter &));
 
 	bool UpdateSize();
 
@@ -422,7 +424,7 @@ protected:
 
 	u32 displayFramebufPtr_ = 0;
 	u32 displayStride_ = 0;
-	GEBufferFormat displayFormat_;
+	GEBufferFormat displayFormat_ = GE_FORMAT_565;
 	u32 prevDisplayFramebufPtr_ = 0;
 
 	VirtualFramebuffer *displayFramebuf_ = nullptr;
@@ -450,8 +452,8 @@ protected:
 	float renderWidth_ = 0.0f;
 	float renderHeight_ = 0.0f;
 	float renderScaleFactor_ = 1.0f;
-	int pixelWidth_;
-	int pixelHeight_;
+	int pixelWidth_ = 0;
+	int pixelHeight_ = 0;
 	int bloomHack_ = 0;
 
 	Draw::DataFormat preferredPixelsFormat_ = Draw::DataFormat::R8G8B8A8_UNORM;

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -42,8 +42,6 @@
 #include "GPU/Directx9/ShaderManagerDX9.h"
 #include "GPU/Directx9/GPU_DX9.h"
 
-namespace DX9 {
-
 static const D3DPRIMITIVETYPE d3d_prim[8] = {
 	// Points, which are expanded to triangles.
 	D3DPT_TRIANGLELIST,
@@ -248,7 +246,7 @@ void DrawEngineDX9::MarkUnreliable(VertexArrayInfoDX9 *vai) {
 }
 
 void DrawEngineDX9::ClearTrackedVertexArrays() {
-	vai_.Iterate([&](uint32_t hash, DX9::VertexArrayInfoDX9 *vai) {
+	vai_.Iterate([&](uint32_t hash, VertexArrayInfoDX9 *vai) {
 		delete vai;
 	});
 	vai_.Clear();
@@ -264,7 +262,7 @@ void DrawEngineDX9::DecimateTrackedVertexArrays() {
 	const int threshold = gpuStats.numFlips - VAI_KILL_AGE;
 	const int unreliableThreshold = gpuStats.numFlips - VAI_UNRELIABLE_KILL_AGE;
 	int unreliableLeft = VAI_UNRELIABLE_KILL_MAX;
-	vai_.Iterate([&](uint32_t hash, DX9::VertexArrayInfoDX9 *vai) {
+	vai_.Iterate([&](uint32_t hash, VertexArrayInfoDX9 *vai) {
 		bool kill;
 		if (vai->status == VertexArrayInfoDX9::VAI_UNRELIABLE) {
 			// We limit killing unreliable so we don't rehash too often.
@@ -524,7 +522,7 @@ rotateVBO:
 		ApplyDrawState(prim);
 		ApplyDrawStateLate();
 
-		DX9::VSShader *vshader = shaderManager_->ApplyShader(true, useHWTessellation_, lastVType_, decOptions_.expandAllWeightsToFloat);
+		VSShader *vshader = shaderManager_->ApplyShader(true, useHWTessellation_, lastVType_, decOptions_.expandAllWeightsToFloat);
 		IDirect3DVertexDeclaration9 *pHardwareVertexDecl = SetupDecFmtForDraw(vshader, dec_->GetDecVtxFmt(), dec_->VertexType());
 
 		if (pHardwareVertexDecl) {
@@ -616,7 +614,7 @@ rotateVBO:
 
 		ApplyDrawStateLate();
 
-		DX9::VSShader *vshader = shaderManager_->ApplyShader(false, false, lastVType_, decOptions_.expandAllWeightsToFloat);
+		VSShader *vshader = shaderManager_->ApplyShader(false, false, lastVType_, decOptions_.expandAllWeightsToFloat);
 
 		if (result.action == SW_DRAW_PRIMITIVES) {
 			if (result.setStencil) {
@@ -686,5 +684,3 @@ rotateVBO:
 void TessellationDataTransferDX9::SendDataToShader(const SimpleVertex *const *points, int size_u, int size_v, u32 vertType, const Spline::Weight2D &weights) {
 	// TODO
 }
-
-}  // namespace

--- a/GPU/Directx9/DrawEngineDX9.h
+++ b/GPU/Directx9/DrawEngineDX9.h
@@ -30,8 +30,6 @@
 struct DecVtxFormat;
 struct UVScale;
 
-namespace DX9 {
-
 class VSShader;
 class ShaderManagerDX9;
 class TextureCacheDX9;
@@ -175,5 +173,3 @@ private:
 
 	int lastRenderStepId_ = -1;
 };
-
-}  // namespace

--- a/GPU/Directx9/FramebufferManagerDX9.cpp
+++ b/GPU/Directx9/FramebufferManagerDX9.cpp
@@ -45,7 +45,7 @@
 #include <emmintrin.h>
 #endif
 
-namespace DX9 {
+// TODO: De-indent, the day we move all this readback stuff to GPU/Common
 
 	FramebufferManagerDX9::FramebufferManagerDX9(Draw::DrawContext *draw)
 		: FramebufferManagerCommon(draw) {
@@ -396,5 +396,3 @@ namespace DX9 {
 
 		return success;
 	}
-
-}  // namespace DX9

--- a/GPU/Directx9/FramebufferManagerDX9.cpp
+++ b/GPU/Directx9/FramebufferManagerDX9.cpp
@@ -223,9 +223,6 @@ namespace DX9 {
 		}
 	}
 
-	void FramebufferManagerDX9::EndFrame() {
-	}
-
 	void FramebufferManagerDX9::DecimateFBOs() {
 		FramebufferManagerCommon::DecimateFBOs();
 		for (auto it = offscreenSurfaces_.begin(); it != offscreenSurfaces_.end(); ) {

--- a/GPU/Directx9/FramebufferManagerDX9.h
+++ b/GPU/Directx9/FramebufferManagerDX9.h
@@ -28,8 +28,6 @@
 #include "GPU/GPUCommon.h"
 #include "GPU/Common/FramebufferManagerCommon.h"
 
-namespace DX9 {
-
 class TextureCacheDX9;
 class DrawEngineDX9;
 class ShaderManagerDX9;
@@ -67,5 +65,3 @@ private:
 
 	std::unordered_map<u64, OffscreenSurface> offscreenSurfaces_;
 };
-
-}  // namespace

--- a/GPU/Directx9/FramebufferManagerDX9.h
+++ b/GPU/Directx9/FramebufferManagerDX9.h
@@ -41,8 +41,6 @@ public:
 
 	void DestroyAllFBOs() override;
 
-	void EndFrame();
-
 	bool GetFramebuffer(u32 fb_address, int fb_stride, GEBufferFormat format, GPUDebugBuffer &buffer, int maxRes) override;
 	bool GetDepthbuffer(u32 fb_address, int fb_stride, u32 z_address, int z_stride, GPUDebugBuffer &buffer) override;
 	bool GetStencilbuffer(u32 fb_address, int fb_stride, GPUDebugBuffer &buffer) override;
@@ -70,4 +68,4 @@ private:
 	std::unordered_map<u64, OffscreenSurface> offscreenSurfaces_;
 };
 
-}
+}  // namespace

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -49,8 +49,6 @@
 #include "Core/HLE/sceKernelInterrupt.h"
 #include "Core/HLE/sceGe.h"
 
-namespace DX9 {
-
 GPU_DX9::GPU_DX9(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	: GPUCommon(gfxCtx, draw),
 	  drawEngine_(draw) {
@@ -393,5 +391,3 @@ std::string GPU_DX9::DebugGetShaderString(std::string id, DebugShaderType type, 
 		return shaderManagerDX9_->DebugGetShaderString(id, type, stringType);
 	}
 }
-
-}  // namespace DX9

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -299,9 +299,7 @@ void GPU_DX9::CopyDisplayToOutput(bool reallyDirty) {
 	drawEngine_.Flush();
 
 	framebufferManagerDX9_->CopyDisplayToOutput(reallyDirty);
-	framebufferManagerDX9_->EndFrame();
 
-	// shaderManager_->EndFrame();
 	shaderManagerDX9_->DirtyLastShader();
 
 	gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -26,8 +26,6 @@
 #include "GPU/Common/DepalettizeCommon.h"
 #include "GPU/Common/VertexDecoderCommon.h"
 
-namespace DX9 {
-
 class ShaderManagerDX9;
 class LinkedShaderDX9;
 class TextureCacheDX9;
@@ -80,7 +78,3 @@ private:
 	DrawEngineDX9 drawEngine_;
 	ShaderManagerDX9 *shaderManagerDX9_;
 };
-
-}  // namespace DX9
-
-typedef DX9::GPU_DX9 DIRECTX9_GPU;

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -49,8 +49,6 @@
 
 using namespace Lin;
 
-namespace DX9 {
-
 PSShader::PSShader(LPDIRECT3DDEVICE9 device, FShaderID id, const char *code) : id_(id) {
 	source_ = code;
 #ifdef SHADERLOG
@@ -702,5 +700,3 @@ std::string ShaderManagerDX9::DebugGetShaderString(std::string id, DebugShaderTy
 		return "N/A";
 	}
 }
-
-}  // namespace

--- a/GPU/Directx9/ShaderManagerDX9.h
+++ b/GPU/Directx9/ShaderManagerDX9.h
@@ -27,8 +27,6 @@
 #include "GPU/Common/ShaderId.h"
 #include "Common/Math/lin/matrix4x4.h"
 
-namespace DX9 {
-
 class PSShader;
 class VSShader;
 
@@ -125,6 +123,4 @@ private:
 
 	typedef std::map<VShaderID, VSShader *> VSCache;
 	VSCache vsCache_;
-};
-
 };

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -32,8 +32,6 @@
 #include "GPU/Directx9/TextureCacheDX9.h"
 #include "GPU/Directx9/FramebufferManagerDX9.h"
 
-namespace DX9 {
-
 static const D3DBLEND dxBlendFactorLookup[(size_t)BlendFactor::COUNT] = {
 	D3DBLEND_ZERO,
 	D3DBLEND_ONE,
@@ -297,6 +295,4 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 void DrawEngineDX9::ApplyDrawStateLate() {
 	// At this point, we know if the vertices are full alpha or not.
 	// TODO: Set the nearest/linear here (since we correctly know if alpha/color tests are needed)?
-}
-
 }

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -51,8 +51,6 @@ D3DFORMAT ToD3D9Format(Draw::DataFormat fmt) {
 	}
 }
 
-namespace DX9 {
-
 #define INVALID_TEX (LPDIRECT3DTEXTURE9)(-1)
 
 static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
@@ -443,5 +441,3 @@ bool TextureCacheDX9::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) 
 
 	return success;
 }
-
-};

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -26,8 +26,6 @@
 struct VirtualFramebuffer;
 class DepalShaderCache;
 
-namespace DX9 {
-
 class FramebufferManagerDX9;
 class ShaderManagerDX9;
 
@@ -78,5 +76,3 @@ private:
 };
 
 D3DFORMAT getClutDestFormat(GEPaletteFormat format);
-
-};

--- a/GPU/GLES/DepthBufferGLES.cpp
+++ b/GPU/GLES/DepthBufferGLES.cpp
@@ -97,6 +97,8 @@ void FramebufferManagerGLES::PackDepthbuffer(VirtualFramebuffer *vfb, int x, int
 	const bool useColorPath = gl_extensions.IsGLES;
 	bool format16Bit = false;
 
+	GLRenderManager *render = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+
 	if (useColorPath) {
 		if (!depthDownloadProgram_) {
 			std::string errorString;
@@ -104,8 +106,8 @@ void FramebufferManagerGLES::PackDepthbuffer(VirtualFramebuffer *vfb, int x, int
 			vs_code = ApplyGLSLPrelude(depth_vs, GL_VERTEX_SHADER);
 			fs_code = ApplyGLSLPrelude(depth_dl_fs, GL_FRAGMENT_SHADER);
 			std::vector<GLRShader *> shaders;
-			shaders.push_back(render_->CreateShader(GL_VERTEX_SHADER, vs_code, "depth_dl"));
-			shaders.push_back(render_->CreateShader(GL_FRAGMENT_SHADER, fs_code, "depth_dl"));
+			shaders.push_back(render->CreateShader(GL_VERTEX_SHADER, vs_code, "depth_dl"));
+			shaders.push_back(render->CreateShader(GL_FRAGMENT_SHADER, fs_code, "depth_dl"));
 			std::vector<GLRProgram::Semantic> semantics;
 			semantics.push_back({ 0, "a_position" });
 			semantics.push_back({ 1, "a_texcoord0" });
@@ -116,9 +118,9 @@ void FramebufferManagerGLES::PackDepthbuffer(VirtualFramebuffer *vfb, int x, int
 			queries.push_back({ &u_depthDownloadTo8, "u_depthTo8" });
 			std::vector<GLRProgram::Initializer> inits;
 			inits.push_back({ &u_depthDownloadTex, 0, TEX_SLOT_PSP_TEXTURE });
-			depthDownloadProgram_ = render_->CreateProgram(shaders, semantics, queries, inits, false, false);
+			depthDownloadProgram_ = render->CreateProgram(shaders, semantics, queries, inits, false, false);
 			for (auto iter : shaders) {
-				render_->DeleteShader(iter);
+				render->DeleteShader(iter);
 			}
 			if (!depthDownloadProgram_) {
 				ERROR_LOG_REPORT(G3D, "Failed to compile depthDownloadProgram! This shouldn't happen.\n%s", errorString.c_str());
@@ -128,26 +130,26 @@ void FramebufferManagerGLES::PackDepthbuffer(VirtualFramebuffer *vfb, int x, int
 		shaderManager_->DirtyLastShader();
 		auto *blitFBO = GetTempFBO(TempFBO::COPY, vfb->renderWidth, vfb->renderHeight);
 		draw_->BindFramebufferAsRenderTarget(blitFBO, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "PackDepthbuffer");
-		render_->SetViewport({ 0, 0, (float)vfb->renderWidth, (float)vfb->renderHeight, 0.0f, 1.0f });
+		render->SetViewport({ 0, 0, (float)vfb->renderWidth, (float)vfb->renderHeight, 0.0f, 1.0f });
 
 		// We must bind the program after starting the render pass, and set the color mask after clearing.
-		render_->SetScissor({ 0, 0, vfb->renderWidth, vfb->renderHeight });
-		render_->SetDepth(false, false, GL_ALWAYS);
-		render_->SetRaster(false, GL_CCW, GL_FRONT, GL_FALSE, GL_FALSE);
-		render_->BindProgram(depthDownloadProgram_);
+		render->SetScissor({ 0, 0, vfb->renderWidth, vfb->renderHeight });
+		render->SetDepth(false, false, GL_ALWAYS);
+		render->SetRaster(false, GL_CCW, GL_FRONT, GL_FALSE, GL_FALSE);
+		render->BindProgram(depthDownloadProgram_);
 
 		if (!gstate_c.Supports(GPU_SUPPORTS_ACCURATE_DEPTH)) {
 			float factors[] = { 0.0f, 1.0f };
-			render_->SetUniformF(&u_depthDownloadFactor, 2, factors);
+			render->SetUniformF(&u_depthDownloadFactor, 2, factors);
 		} else {
 			const float factor = DepthSliceFactor();
 			float factors[] = { -0.5f * (factor - 1.0f) * (1.0f / factor), factor };
-			render_->SetUniformF(&u_depthDownloadFactor, 2, factors);
+			render->SetUniformF(&u_depthDownloadFactor, 2, factors);
 		}
 		float shifts[] = { 16777215.0f, 16777215.0f / 256.0f, 16777215.0f / 65536.0f, 16777215.0f / 16777216.0f };
-		render_->SetUniformF(&u_depthDownloadShift, 4, shifts);
+		render->SetUniformF(&u_depthDownloadShift, 4, shifts);
 		float to8[] = { 1.0f / 255.0f, 1.0f / 255.0f, 1.0f / 255.0f, 1.0f / 255.0f };
-		render_->SetUniformF(&u_depthDownloadTo8, 4, to8);
+		render->SetUniformF(&u_depthDownloadTo8, 4, to8);
 
 		draw_->BindFramebufferAsTexture(vfb->fbo, TEX_SLOT_PSP_TEXTURE, Draw::FB_DEPTH_BIT, 0);
 		float u1 = 1.0f;

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -38,9 +38,8 @@
 #include "GPU/GLES/TextureCacheGLES.h"
 #include "GPU/GLES/ShaderManagerGLES.h"
 
-FramebufferManagerGLES::FramebufferManagerGLES(Draw::DrawContext *draw, GLRenderManager *render) :
-	FramebufferManagerCommon(draw),
-	render_(render)
+FramebufferManagerGLES::FramebufferManagerGLES(Draw::DrawContext *draw) :
+	FramebufferManagerCommon(draw)
 {
 	needBackBufferYSwap_ = true;
 	presentation_->SetLanguage(draw_->GetShaderLanguageDesc().shaderLanguage);
@@ -48,10 +47,6 @@ FramebufferManagerGLES::FramebufferManagerGLES(Draw::DrawContext *draw, GLRender
 
 FramebufferManagerGLES::~FramebufferManagerGLES() {
 	delete[] convBuf_;
-}
-
-void FramebufferManagerGLES::Init() {
-	FramebufferManagerCommon::Init();
 }
 
 void FramebufferManagerGLES::UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) {
@@ -66,26 +61,19 @@ void FramebufferManagerGLES::UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) 
 	}
 }
 
-void FramebufferManagerGLES::EndFrame() {
-}
-
 void FramebufferManagerGLES::DeviceLost() {
 	FramebufferManagerCommon::DeviceLost();
 	if (depthDownloadProgram_) {
-		render_->DeleteProgram(depthDownloadProgram_);
+		GLRenderManager *render = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+		render->DeleteProgram(depthDownloadProgram_);
 		depthDownloadProgram_ = nullptr;
 	}
 }
 
-void FramebufferManagerGLES::DeviceRestore(Draw::DrawContext *draw) {
-	FramebufferManagerCommon::DeviceRestore(draw);
-	render_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
-}
-
 void FramebufferManagerGLES::Resized() {
 	FramebufferManagerCommon::Resized();
-
-	render_->Resize(PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
+	GLRenderManager *render = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+	render->Resize(PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
 }
 
 bool FramebufferManagerGLES::GetOutputFramebuffer(GPUDebugBuffer &buffer) {

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -18,30 +18,21 @@
 #pragma once
 
 #include "Common/GPU/thin3d.h"
-// Keeps track of allocated FBOs.
-// Also provides facilities for drawing and later converting raw
-// pixel data.
-
 #include "GPU/GPUCommon.h"
 #include "GPU/Common/FramebufferManagerCommon.h"
-#include "Common/GPU/OpenGL/GLRenderManager.h"
 
-struct GLSLProgram;
 class TextureCacheGLES;
 class DrawEngineGLES;
 class ShaderManagerGLES;
+class GLRProgram;
 
 class FramebufferManagerGLES : public FramebufferManagerCommon {
 public:
-	FramebufferManagerGLES(Draw::DrawContext *draw, GLRenderManager *render);
+	FramebufferManagerGLES(Draw::DrawContext *draw);
 	~FramebufferManagerGLES();
 
-	virtual void Init() override;
-	void EndFrame();
 	void Resized() override;
-
 	void DeviceLost() override;
-	void DeviceRestore(Draw::DrawContext *draw) override;
 
 	bool GetOutputFramebuffer(GPUDebugBuffer &buffer) override;
 
@@ -50,8 +41,6 @@ protected:
 
 private:
 	void PackDepthbuffer(VirtualFramebuffer *vfb, int x, int y, int w, int h);
-
-	GLRenderManager *render_;
 
 	u8 *convBuf_ = nullptr;
 	u32 convBufSize_ = 0;

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -57,10 +57,8 @@ GPU_GLES::GPU_GLES(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	UpdateVsyncInterval(true);
 	CheckGPUFeatures();
 
-	GLRenderManager *render = (GLRenderManager *)draw->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
-
 	shaderManagerGL_ = new ShaderManagerGLES(draw);
-	framebufferManagerGL_ = new FramebufferManagerGLES(draw, render);
+	framebufferManagerGL_ = new FramebufferManagerGLES(draw);
 	framebufferManager_ = framebufferManagerGL_;
 	textureCacheGL_ = new TextureCacheGLES(draw);
 	textureCache_ = textureCacheGL_;
@@ -375,7 +373,6 @@ void GPU_GLES::CopyDisplayToOutput(bool reallyDirty) {
 	shaderManagerGL_->DirtyLastShader();
 
 	framebufferManagerGL_->CopyDisplayToOutput(reallyDirty);
-	framebufferManagerGL_->EndFrame();
 }
 
 void GPU_GLES::FinishDeferred() {

--- a/GPU/GPU.cpp
+++ b/GPU/GPU.cpp
@@ -83,7 +83,7 @@ bool GPU_Init(GraphicsContext *ctx, Draw::DrawContext *draw) {
 		break;
 	case GPUCORE_DIRECTX9:
 #if PPSSPP_API(D3D9)
-		SetGPU(new DIRECTX9_GPU(ctx, draw));
+		SetGPU(new GPU_DX9(ctx, draw));
 		break;
 #else
 		return false;

--- a/GPU/Vulkan/FramebufferManagerVulkan.cpp
+++ b/GPU/Vulkan/FramebufferManagerVulkan.cpp
@@ -79,18 +79,3 @@ void FramebufferManagerVulkan::NotifyClear(bool clearColor, bool clearAlpha, boo
 		SetDepthUpdated();
 	}
 }
-
-void FramebufferManagerVulkan::BeginFrameVulkan() {
-	BeginFrame();
-}
-
-void FramebufferManagerVulkan::EndFrame() {
-}
-
-void FramebufferManagerVulkan::DeviceLost() {
-	FramebufferManagerCommon::DeviceLost();
-}
-
-void FramebufferManagerVulkan::DeviceRestore(Draw::DrawContext *draw) {
-	FramebufferManagerCommon::DeviceRestore(draw);
-}

--- a/GPU/Vulkan/FramebufferManagerVulkan.h
+++ b/GPU/Vulkan/FramebufferManagerVulkan.h
@@ -36,12 +36,6 @@ public:
 	FramebufferManagerVulkan(Draw::DrawContext *draw);
 	~FramebufferManagerVulkan();
 
-	void BeginFrameVulkan();  // there's a BeginFrame in the base class, which this calls
-	void EndFrame();
-
-	void DeviceLost() override;
-	void DeviceRestore(Draw::DrawContext *draw) override;
-
 	// If within a render pass, this will just issue a regular clear. If beginning a new render pass,
 	// do that.
 	void NotifyClear(bool clearColor, bool clearAlpha, bool clearDepth, uint32_t color, float depth);

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -317,7 +317,7 @@ void GPU_Vulkan::BeginHostFrame() {
 	frame.push_->Reset();
 	frame.push_->Begin(vulkan);
 
-	framebufferManagerVulkan_->BeginFrameVulkan();
+	framebufferManagerVulkan_->BeginFrame();
 	textureCacheVulkan_->SetPushBuffer(frameData_[curFrame].push_);
 
 	shaderManagerVulkan_->DirtyShader();
@@ -339,7 +339,6 @@ void GPU_Vulkan::EndHostFrame() {
 	frame.push_->End();
 
 	drawEngine_.EndFrame();
-	framebufferManagerVulkan_->EndFrame();
 	textureCacheVulkan_->EndFrame();
 
 	draw_->InvalidateCachedState();

--- a/Windows/GPU/D3D9Context.cpp
+++ b/Windows/GPU/D3D9Context.cpp
@@ -160,8 +160,8 @@ bool D3D9Context::Init(HINSTANCE hInst, HWND wnd, std::string *error_message) {
 	}
 
 	device_->BeginScene();
-	DX9::pD3Ddevice = device_;
-	DX9::pD3DdeviceEx = deviceEx_;
+	pD3Ddevice9 = device_;
+	pD3DdeviceEx9 = deviceEx_;
 
 	if (deviceEx_ && IsWin7OrHigher()) {
 		// TODO: This makes it slower?
@@ -212,8 +212,8 @@ void D3D9Context::Shutdown() {
 	device_->Release();
 	d3d_->Release();
 	UnloadD3DCompiler();
-	DX9::pD3Ddevice = nullptr;
-	DX9::pD3DdeviceEx = nullptr;
+	pD3Ddevice9 = nullptr;
+	pD3DdeviceEx9 = nullptr;
 	device_ = nullptr;
 	hWnd_ = nullptr;
 	FreeLibrary(hD3D9_);


### PR DESCRIPTION
Removes the old DX9 namespace, inconsistent to only have that one, and it gets in the way from time to time.

Also slight refactoring in framebuffermanager.