### PR TITLE
Framebuffer-bind sequence numbers

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2084,7 +2084,6 @@ bool FramebufferManagerCommon::GetFramebuffer(u32 fb_address, int fb_stride, GEB
 bool FramebufferManagerCommon::GetDepthbuffer(u32 fb_address, int fb_stride, u32 z_address, int z_stride, GPUDebugBuffer &buffer) {
 	VirtualFramebuffer *vfb = currentRenderVfb_;
 	if (!vfb) {
-		// TODO: This is flawed, as it looks for color buffers at the address, not depth.
 		vfb = GetVFBAt(fb_address);
 	}
 

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -120,9 +120,8 @@ VirtualFramebuffer *FramebufferManagerCommon::GetVFBAt(u32 addr) const {
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
 		VirtualFramebuffer *v = vfbs_[i];
 		if (v->fb_address == addr) {
-			// Could check w too but whatever
-			// NOTE: This gets the OLDEST image at the address - is that good?
-			if (match == nullptr || match->last_frame_render < v->last_frame_render) {
+			// Could check w too but whatever (actually, might very well make sense to do so, depending on context).
+			if (!match || v->last_frame_render > match->last_frame_render) {
 				match = v;
 			}
 		}

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -121,6 +121,7 @@ VirtualFramebuffer *FramebufferManagerCommon::GetVFBAt(u32 addr) const {
 		VirtualFramebuffer *v = vfbs_[i];
 		if (v->fb_address == addr) {
 			// Could check w too but whatever
+			// NOTE: This gets the OLDEST image at the address - is that good?
 			if (match == nullptr || match->last_frame_render < v->last_frame_render) {
 				match = v;
 			}
@@ -2083,6 +2084,7 @@ bool FramebufferManagerCommon::GetFramebuffer(u32 fb_address, int fb_stride, GEB
 bool FramebufferManagerCommon::GetDepthbuffer(u32 fb_address, int fb_stride, u32 z_address, int z_stride, GPUDebugBuffer &buffer) {
 	VirtualFramebuffer *vfb = currentRenderVfb_;
 	if (!vfb) {
+		// TODO: This is flawed, as it looks for color buffers at the address, not depth.
 		vfb = GetVFBAt(fb_address);
 	}
 

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -43,6 +43,7 @@ enum {
 	FB_USAGE_DOWNLOAD = 16,
 	FB_USAGE_DOWNLOAD_CLEAR = 32,
 	FB_USAGE_BLUE_TO_ALPHA = 64,
+	FB_USAGE_FIRST_FRAME_SAVED = 128,
 };
 
 enum {
@@ -63,48 +64,76 @@ class ShaderWriter;
 // when such a situation is detected. In order to reliably detect this, we separately track depth buffers,
 // and they know which color buffer they were used with last.
 struct VirtualFramebuffer {
+	Draw::Framebuffer *fbo;
+
 	u32 fb_address;
 	u32 z_address;  // If 0, it's a "RAM" framebuffer.
-	int fb_stride;
-	int z_stride;
-
-	GEBufferFormat format;  // virtual, in reality they are all RGBA8888 for better quality but we can reinterpret that as necessary
+	u16 fb_stride;
+	u16 z_stride;
 
 	// width/height: The detected size of the current framebuffer, in original PSP pixels.
 	u16 width;
 	u16 height;
 
 	// bufferWidth/bufferHeight: The pre-scaling size of the buffer itself. May only be bigger than or equal to width/height.
-	// Actual physical buffer is this size times the render resolution multiplier.
+	// In original PSP pixels - actual framebuffer is this size times the render resolution multiplier.
 	// The buffer may be used to render a width or height from 0 to these values without being recreated.
 	u16 bufferWidth;
 	u16 bufferHeight;
 
 	// renderWidth/renderHeight: The scaled size we render at. May be scaled to render at higher resolutions.
-	// The physical buffer may be larger than renderWidth/renderHeight.
+	// These are simply bufferWidth/Height * renderScaleFactor and are thus redundant.
 	u16 renderWidth;
 	u16 renderHeight;
 
-	float renderScaleFactor;
-
-	u16 usageFlags;
-
-	u16 newWidth;
-	u16 newHeight;
-
-	int lastFrameNewSize;
-
-	Draw::Framebuffer *fbo;
-
+	// Attempt to keep track of a bounding rectangle of what's been actually drawn. However, right now these are not
+	// used in a very detailed way (they're only ever 0 or equal to width/height)
 	u16 drawnWidth;
 	u16 drawnHeight;
-	GEBufferFormat drawnFormat;
+
+	// The dimensions at which we are confident that we can read back this buffer without stomping on irrelevant memory.
 	u16 safeWidth;
 	u16 safeHeight;
 
+	// The scale factor at which we are rendering (to achieve higher resolution).
+	u8 renderScaleFactor;
+
+	// The original PSP format of the framebuffer.
+	// In reality they are all RGBA8888 for better quality but this is what the PSP thinks it is. This is necessary
+	// when we need to interpret the bits directly (depal or buffer aliasing).
+	GEBufferFormat format;
+
+	// The configured buffer format at the time of the latest/current draw. This will change first, then
+	// if different we'll "reinterpret" the framebuffer to match 'format' as needed.
+	GEBufferFormat drawnFormat;
+
+	u16 usageFlags;
+
+	// These are used to track state to try to avoid buffer size shifting back and forth.
+	// Though that shouldn't really happen, should it, since we always grow, don't shrink?
+	u16 newWidth;
+	u16 newHeight;
+
+	// The frame number at which this was last resized.
+	int lastFrameNewSize;
+
+	// Tracking for downloads-to-CLUT.
+	u16 clutUpdatedBytes;
+	bool memoryUpdated;
+
+	// TODO: Fold into usageFlags?
 	bool dirtyAfterDisplay;
 	bool reallyDirtyAfterDisplay;  // takes frame skipping into account
 
+	// Global sequence numbers for the last time these were bound.
+	// Not based on frames at all. Can be used to determine new-ness of one framebuffer over another,
+	// can even be within a frame.
+	int colorBindSeq;
+	int depthBindSeq;
+
+	// These are mainly used for garbage collection purposes and similar.
+	// Cannot be used to determine new-ness against a similar other buffer, since they are
+	// only at frame granularity.
 	int last_frame_used;
 	int last_frame_attached;
 	int last_frame_render;
@@ -113,9 +142,6 @@ struct VirtualFramebuffer {
 	int last_frame_failed;
 	int last_frame_depth_updated;
 	int last_frame_depth_render;
-	u32 clutUpdatedBytes;
-	bool memoryUpdated;
-	bool firstFrameSaved;
 };
 
 struct TrackedDepthBuffer {
@@ -132,9 +158,9 @@ struct TrackedDepthBuffer {
 
 struct FramebufferHeuristicParams {
 	u32 fb_address;
-	int fb_stride;
 	u32 z_address;
-	int z_stride;
+	u16 fb_stride;
+	u16 z_stride;
 	GEBufferFormat fmt;
 	bool isClearingDepth;
 	bool isWritingDepth;
@@ -412,6 +438,10 @@ protected:
 			dstBuffer->reallyDirtyAfterDisplay = true;
 	}
 
+	inline int GetBindSeqCount() {
+		return fbBindSeqCount_++;
+	}
+
 	PresentationCommon *presentation_ = nullptr;
 
 	Draw::DrawContext *draw_ = nullptr;
@@ -426,6 +456,8 @@ protected:
 	u32 displayStride_ = 0;
 	GEBufferFormat displayFormat_ = GE_FORMAT_565;
 	u32 prevDisplayFramebufPtr_ = 0;
+
+	int fbBindSeqCount_ = 0;
 
 	VirtualFramebuffer *displayFramebuf_ = nullptr;
 	VirtualFramebuffer *prevDisplayFramebuf_ = nullptr;
@@ -451,7 +483,8 @@ protected:
 	// Sampled in BeginFrame/UpdateSize for safety.
 	float renderWidth_ = 0.0f;
 	float renderHeight_ = 0.0f;
-	float renderScaleFactor_ = 1.0f;
+
+	int renderScaleFactor_ = 1;
 	int pixelWidth_ = 0;
 	int pixelHeight_ = 0;
 	int bloomHack_ = 0;
@@ -481,7 +514,7 @@ protected:
 	Draw::SamplerState *reinterpretSampler_ = nullptr;
 	Draw::Buffer *reinterpretVBuf_ = nullptr;
 
-	// Common implementation of stencil buffer upload. Also not 100% optimal, but not perforamnce
+	// Common implementation of stencil buffer upload. Also not 100% optimal, but not performance
 	// critical either.
 	Draw::Pipeline *stencilUploadPipeline_ = nullptr;
 	Draw::SamplerState *stencilUploadSampler_ = nullptr;

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -334,8 +334,10 @@ public:
 	VirtualFramebuffer *GetCurrentRenderVFB() const {
 		return currentRenderVfb_;
 	}
-	// TODO: Break out into some form of FBO manager
+
+	// This only checks for the color channel.
 	VirtualFramebuffer *GetVFBAt(u32 addr) const;
+
 	VirtualFramebuffer *GetDisplayVFB() const {
 		return GetVFBAt(displayFramebufPtr_);
 	}

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -86,8 +86,8 @@ struct VirtualFramebuffer {
 	u16 renderWidth;
 	u16 renderHeight;
 
-	// Attempt to keep track of a bounding rectangle of what's been actually drawn. However, right now these are not
-	// used in a very detailed way (they're only ever 0 or equal to width/height)
+	// Attempt to keep track of a bounding rectangle of what's been actually drawn. Coarse, but might be smaller
+	// than width/height if framebuffer has been enlarged. In PSP pixels.
 	u16 drawnWidth;
 	u16 drawnHeight;
 
@@ -110,7 +110,10 @@ struct VirtualFramebuffer {
 	u16 usageFlags;
 
 	// These are used to track state to try to avoid buffer size shifting back and forth.
-	// Though that shouldn't really happen, should it, since we always grow, don't shrink?
+	// You might think that doesn't happen since we mostly grow framebuffers, but we do resize down,
+	// if the size has shrunk for a while and the framebuffer is also larger than the stride.
+	// At this point, the "safe" size is probably a lie, and we have had various issues with readbacks, so this resizes down to avoid them.
+	// An example would be a game that always uses the address 0x00154000 for temp buffers, and uses it for a full-screen effect for 3 frames, then goes back to using it for character shadows or something much smaller.
 	u16 newWidth;
 	u16 newHeight;
 

--- a/GPU/Directx9/FramebufferManagerDX9.cpp
+++ b/GPU/Directx9/FramebufferManagerDX9.cpp
@@ -327,6 +327,7 @@
 	bool FramebufferManagerDX9::GetDepthbuffer(u32 fb_address, int fb_stride, u32 z_address, int z_stride, GPUDebugBuffer &buffer) {
 		VirtualFramebuffer *vfb = currentRenderVfb_;
 		if (!vfb) {
+			// TODO: This is flawed, as it looks for color buffers at the address, not depth.
 			vfb = GetVFBAt(fb_address);
 		}
 

--- a/GPU/Directx9/FramebufferManagerDX9.cpp
+++ b/GPU/Directx9/FramebufferManagerDX9.cpp
@@ -327,7 +327,6 @@
 	bool FramebufferManagerDX9::GetDepthbuffer(u32 fb_address, int fb_stride, u32 z_address, int z_stride, GPUDebugBuffer &buffer) {
 		VirtualFramebuffer *vfb = currentRenderVfb_;
 		if (!vfb) {
-			// TODO: This is flawed, as it looks for color buffers at the address, not depth.
 			vfb = GetVFBAt(fb_address);
 		}
 

--- a/GPU/GLES/DepthBufferGLES.cpp
+++ b/GPU/GLES/DepthBufferGLES.cpp
@@ -84,7 +84,7 @@ void FramebufferManagerGLES::PackDepthbuffer(VirtualFramebuffer *vfb, int x, int
 	// Pixel size always 4 here because we always request float
 	const u32 bufSize = vfb->z_stride * (h - y) * 4;
 	const u32 z_address = vfb->z_address;
-	const int packWidth = std::min(vfb->z_stride, std::min(x + w, (int)vfb->width));
+	const int packWidth = std::min((int)vfb->z_stride, std::min(x + w, (int)vfb->width));
 
 	if (!convBuf_ || convBufSize_ < bufSize) {
 		delete[] convBuf_;

--- a/GPU/ge_constants.h
+++ b/GPU/ge_constants.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 enum GECommand {
 	GE_CMD_NOP = 0,
 	GE_CMD_VADDR = 0x1,
@@ -276,8 +278,7 @@ enum GECommand {
 	GE_CMD_NOP_FF = 0xFF,
 };
 
-enum GEBufferFormat
-{
+enum GEBufferFormat : uint8_t {
 	GE_FORMAT_565 = 0,
 	GE_FORMAT_5551 = 1,
 	GE_FORMAT_4444 = 2,


### PR DESCRIPTION
This allows us to identify which of two framebuffers was bound for rendering to the most recently, even within a frame. 

Not actually used for anything yet, but will be used in the solution for #15728 , and #15777 will be updated to update the depth sequence number separately. When we have the sequence numbers, we can possibly remove the separate vector for depth buffer tracking, and instead just loop through and get the latest.

32 bits is very likely enough for these (max 2 billion if we keep signed, say 40 binds per frame as an extreme case, and 60 frames per seconds, that's half a year of straight playtime without restarting PPSSPP).

This is a separate PR because it cleans up documentation, changes some variables to smaller types to compensate for the newly added ones in this already large struct, etc.

Better ideas about naming these will be considered, not very fond of my current choice.