### PR TITLE
More flexible texture matching, bias matching by the bind sequence counters

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -632,6 +632,7 @@ std::vector<AttachCandidate> TextureCacheCommon::GetFramebufferCandidates(const 
 		if (MatchFramebuffer(entry, framebuffer, texAddrOffset, RASTER_COLOR, &match)) {
 			candidates.push_back(AttachCandidate{ match, entry, framebuffer, RASTER_COLOR, framebuffer->colorBindSeq });
 		}
+		match = {};
 		if (gstate_c.Supports(GPU_SUPPORTS_DEPTH_TEXTURE) && MatchFramebuffer(entry, framebuffer, texAddrOffset, RASTER_DEPTH, &match)) {
 			candidates.push_back(AttachCandidate{ match, entry, framebuffer, RASTER_DEPTH, framebuffer->depthBindSeq });
 		}
@@ -893,28 +894,6 @@ bool TextureCacheCommon::MatchFramebuffer(
 
 	if (texInVRAM) {
 		const u32 mirrorMask = 0x00600000;
-
-		// This bit controls swizzle. The swizzles at 0x00200000 and 0x00600000 are designed
-		// to perfectly match reading depth as color (which one to use I think might be related
-		// to the bpp of the color format used when rendering to it).
-		// It's fairly unlikely that games would screw this up since the result will be garbage so
-		// we use it to filter out unlikely matches.
-		switch (entry.addr & mirrorMask) {
-		case 0x00000000:
-		case 0x00400000:
-			// Don't match the depth channel with these addresses when texturing.
-			if (channel == RasterChannel::RASTER_DEPTH) {
-				return false;
-			}
-			break;
-		case 0x00200000:
-		case 0x00600000:
-			// Don't match the color channel with these addresses when texturing.
-			if (channel == RasterChannel::RASTER_COLOR) {
-				return false;
-			}
-			break;
-		}
 
 		addr &= ~mirrorMask;
 		texaddr &= ~mirrorMask;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -669,22 +669,22 @@ int TextureCacheCommon::GetBestCandidateIndex(const std::vector<AttachCandidate>
 	// a comparison function.
 	for (int i = 0; i < (int)candidates.size(); i++) {
 		const AttachCandidate &candidate = candidates[i];
-		int relevancy = 1000;
+		int relevancy = candidate.seqCount;
 
 		// Bonus point for matching stride.
 		if (candidate.channel == RASTER_COLOR && candidate.fb->fb_stride == candidate.entry.bufw) {
-			relevancy += 100;
+			relevancy += 1000;
 		}
 
 		// Bonus points for no offset.
 		if (candidate.match.xOffset == 0 && candidate.match.yOffset == 0) {
-			relevancy += 10;
+			relevancy += 100;
 		}
 
 		if (candidate.channel == RASTER_COLOR && candidate.fb->last_frame_render == gpuStats.numFlips) {
-			relevancy += 5;
+			relevancy += 50;
 		} else if (candidate.channel == RASTER_DEPTH && candidate.fb->last_frame_depth_render == gpuStats.numFlips) {
-			relevancy += 5;
+			relevancy += 50;
 		}
 
 		if (relevancy > bestRelevancy) {
@@ -867,7 +867,7 @@ bool TextureCacheCommon::MatchFramebuffer(
 	static const u32 MAX_SUBAREA_Y_OFFSET_SAFE = 32;
 
 	uint32_t fb_address = channel == RASTER_DEPTH ? framebuffer->z_address : framebuffer->fb_address;
-	uint32_t fb_stride = channel == RASTER_DEPTH ? framebuffer->z_stride : framebuffer->z_address;
+	uint32_t fb_stride = channel == RASTER_DEPTH ? framebuffer->z_stride : framebuffer->fb_stride;
 
 	if (channel == RASTER_DEPTH && framebuffer->z_address == framebuffer->fb_address) {
 		// Try to avoid silly matches to somewhat malformed buffers.
@@ -909,7 +909,7 @@ bool TextureCacheCommon::MatchFramebuffer(
 	// If they match "exactly", it's non-CLUT and from the top left.
 	if (exactMatch) {
 		if (fb_stride != entry.bufw) {
-			WARN_LOG_ONCE(diffStrides1, G3D, "Texturing from framebuffer with different strides %d != %d", entry.bufw, fb_stride);
+			WARN_LOG_ONCE(diffStrides1, G3D, "Texturing from framebuffer with different strides %d != %d", entry.bufw, (int)fb_stride);
 		}
 		// NOTE: This check is okay because the first texture formats are the same as the buffer formats.
 		if (IsTextureFormatBufferCompatible(entry.format)) {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -636,7 +636,7 @@ std::vector<AttachCandidate> TextureCacheCommon::GetFramebufferCandidates(const 
 	for (VirtualFramebuffer *framebuffer : framebuffers) {
 		FramebufferMatchInfo match{};
 		if (MatchFramebuffer(entry, framebuffer, texAddrOffset, channel, &match)) {
-			candidates.push_back(AttachCandidate{ match, entry, framebuffer, channel });
+			candidates.push_back(AttachCandidate{ match, entry, framebuffer, channel, channel == RASTER_COLOR ? framebuffer->colorBindSeq : framebuffer->depthBindSeq });
 		}
 	}
 
@@ -2150,8 +2150,8 @@ void TextureCacheCommon::ClearNextFrame() {
 	clearCacheNextFrame_ = true;
 }
 
-std::string AttachCandidate::ToString() {
-	return StringFromFormat("[C:%08x/%d Z:%08x/%d X:%d Y:%d reint: %s]", this->fb->fb_address, this->fb->fb_stride, this->fb->z_address, this->fb->z_stride, this->match.xOffset, this->match.yOffset, this->match.reinterpret ? "true" : "false");
+std::string AttachCandidate::ToString() const {
+	return StringFromFormat("[%s seq:%d C:%08x/%d Z:%08x/%d X:%d Y:%d reint: %s]", this->channel == RASTER_COLOR ? "COLOR" : "DEPTH", this->seqCount, this->fb->fb_address, this->fb->fb_stride, this->fb->z_address, this->fb->z_stride, this->match.xOffset, this->match.yOffset, this->match.reinterpret ? "true" : "false");
 }
 
 bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEntry *entry) {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -641,15 +641,13 @@ std::vector<AttachCandidate> TextureCacheCommon::GetFramebufferCandidates(const 
 	}
 
 	if (candidates.size() > 1) {
-		bool depth = channel == RasterChannel::RASTER_DEPTH;
-
 		std::string cands;
 		for (auto &candidate : candidates) {
 			cands += candidate.ToString() + " ";
 		}
 
-		WARN_LOG_REPORT_ONCE(multifbcandidate, G3D, "GetFramebufferCandidates(%s): Multiple (%d) candidate framebuffers. First will be chosen. texaddr: %08x offset: %d (%dx%d stride %d, %s):\n%s",
-			depth ? "DEPTH" : "COLOR", (int)candidates.size(),
+		WARN_LOG_REPORT_ONCE(multifbcandidate, G3D, "GetFramebufferCandidates: Multiple (%d) candidate framebuffers. texaddr: %08x offset: %d (%dx%d stride %d, %s):\n%s",
+			(int)candidates.size(),
 			entry.addr, texAddrOffset, dimWidth(entry.dim), dimHeight(entry.dim), entry.bufw, GeTextureFormatToString(entry.format),
 			cands.c_str()
 		);
@@ -875,6 +873,13 @@ bool TextureCacheCommon::MatchFramebuffer(
 
 	if (channel == RASTER_DEPTH && framebuffer->z_address == framebuffer->fb_address) {
 		// Try to avoid silly matches to somewhat malformed buffers.
+		return false;
+	}
+
+	switch (entry.format) {
+	case GE_TFMT_DXT1:
+	case GE_TFMT_DXT3:
+	case GE_TFMT_DXT5:
 		return false;
 	}
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -625,18 +625,15 @@ std::vector<AttachCandidate> TextureCacheCommon::GetFramebufferCandidates(const 
 
 	std::vector<AttachCandidate> candidates;
 
-	RasterChannel channel = Memory::IsDepthTexVRAMAddress(entry.addr) ? RasterChannel::RASTER_DEPTH : RasterChannel::RASTER_COLOR;
-	if (channel == RasterChannel::RASTER_DEPTH && !gstate_c.Supports(GPU_SUPPORTS_DEPTH_TEXTURE)) {
-		// Depth texture not supported. Don't try to match it, fall back to the memory behind..
-		return std::vector<AttachCandidate>();
-	}
-
 	const std::vector<VirtualFramebuffer *> &framebuffers = framebufferManager_->Framebuffers();
 
 	for (VirtualFramebuffer *framebuffer : framebuffers) {
 		FramebufferMatchInfo match{};
-		if (MatchFramebuffer(entry, framebuffer, texAddrOffset, channel, &match)) {
-			candidates.push_back(AttachCandidate{ match, entry, framebuffer, channel, channel == RASTER_COLOR ? framebuffer->colorBindSeq : framebuffer->depthBindSeq });
+		if (MatchFramebuffer(entry, framebuffer, texAddrOffset, RASTER_COLOR, &match)) {
+			candidates.push_back(AttachCandidate{ match, entry, framebuffer, RASTER_COLOR, framebuffer->colorBindSeq });
+		}
+		if (gstate_c.Supports(GPU_SUPPORTS_DEPTH_TEXTURE) && MatchFramebuffer(entry, framebuffer, texAddrOffset, RASTER_DEPTH, &match)) {
+			candidates.push_back(AttachCandidate{ match, entry, framebuffer, RASTER_DEPTH, framebuffer->depthBindSeq });
 		}
 	}
 

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -206,15 +206,7 @@ typedef std::map<u64, std::unique_ptr<TexCacheEntry>> TexCache;
 #undef IGNORE
 #endif
 
-enum class FramebufferMatch {
-	// Valid, exact match.
-	VALID = 0,
-	// Not a match, remove if currently attached.
-	NO_MATCH,
-};
-
 struct FramebufferMatchInfo {
-	FramebufferMatch match;
 	u32 xOffset;
 	u32 yOffset;
 	bool reinterpret;
@@ -365,7 +357,7 @@ protected:
 	SamplerCacheKey GetFramebufferSamplingParams(u16 bufferWidth, u16 bufferHeight);
 	void UpdateMaxSeenV(TexCacheEntry *entry, bool throughMode);
 
-	FramebufferMatchInfo MatchFramebuffer(const TextureDefinition &entry, VirtualFramebuffer *framebuffer, u32 texaddrOffset, RasterChannel channel) const;
+	bool MatchFramebuffer(const TextureDefinition &entry, VirtualFramebuffer *framebuffer, u32 texaddrOffset, RasterChannel channel, FramebufferMatchInfo *matchInfo) const;
 
 	std::vector<AttachCandidate> GetFramebufferCandidates(const TextureDefinition &entry, u32 texAddrOffset);
 	int GetBestCandidateIndex(const std::vector<AttachCandidate> &candidates);

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -218,8 +218,9 @@ struct AttachCandidate {
 	TextureDefinition entry;
 	VirtualFramebuffer *fb;
 	RasterChannel channel;
+	int seqCount;
 
-	std::string ToString();
+	std::string ToString() const;
 };
 
 class FramebufferManagerCommon;


### PR DESCRIPTION
Since we now have the bind sequence numbers, which should almost on its own be a fairly solid way of picking the right framebuffer (or its depth buffer) to texture from, I originally intended to simplify things a lot more, but decided to let the pile of heuristics in MatchFramebuffer live on for now, at least until we get deferred depth copies (and some will still be needed).

In addition to adding a match bias from the sequence number (so the most recent texture is more likely to be chosen if two are very similar), this always tries to match against both color and depth, instead of deciding based on the "depth swizzle" bits in the address. Turns out that games like Kuroyou will texture color from a "depth address" in order to apply the depth swizzle. Since we just ignore swizzle entirely, that's just a copy for us, but it still needs to happen. Some more details [here](https://github.com/hrydgard/ppsspp/pull/15777#issuecomment-1218301167).

The reason I want this in first is that without it, I can't fully test #15777 with the dumps from the game - and splitting it out will make bisection easier, as usual.