### PR TITLE
Allow binding depth as 565 by going through depal

### DIFF
--- a/Common/GPU/ShaderWriter.cpp
+++ b/Common/GPU/ShaderWriter.cpp
@@ -423,3 +423,19 @@ ShaderWriter &ShaderWriter::SampleTexture2D(const char *sampName, const char *uv
 	}
 	return *this;
 }
+
+ShaderWriter &ShaderWriter::GetTextureSize(const char *szVariable, const char *texName) {
+	switch (lang_.shaderLanguage) {
+	case HLSL_D3D11:
+		F("  float2 %s; %s.GetDimensions(%s.x, %s.y);", szVariable, texName, szVariable, szVariable);
+		break;
+	case HLSL_D3D9:
+		F("  float2 %s; %s.GetDimensions(%s.x, %s.y);", szVariable, texName, szVariable, szVariable);
+		break;
+	default:
+		// Note: we ignore the sampler. make sure you bound samplers to the textures correctly.
+		F("vec2 %s = textureSize(%s, 0);", szVariable, texName);
+		break;
+	}
+	return *this;
+}

--- a/Common/GPU/ShaderWriter.h
+++ b/Common/GPU/ShaderWriter.h
@@ -83,7 +83,8 @@ public:
 
 	void ConstFloat(const char *name, float value);
 
-	ShaderWriter &SampleTexture2D(const char *sampName, const char *uv);
+	ShaderWriter &SampleTexture2D(const char *texName, const char *uv);
+	ShaderWriter &GetTextureSize(const char *szVariable, const char *texName);
 
 	// Simple shaders with no special tricks.
 	void BeginVSMain(Slice<InputDef> inputs, Slice<UniformDef> uniforms, Slice<VaryingDef> varyings);

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -97,6 +97,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ZZT3SelectHack", &flags_.ZZT3SelectHack);
 	CheckSetting(iniFile, gameID, "AllowLargeFBTextureOffsets", &flags_.AllowLargeFBTextureOffsets);
 	CheckSetting(iniFile, gameID, "AtracLoopHack", &flags_.AtracLoopHack);
+	CheckSetting(iniFile, gameID, "DeswizzleDepth", &flags_.DeswizzleDepth);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -87,6 +87,7 @@ struct CompatFlags {
 	bool ZZT3SelectHack;
 	bool AllowLargeFBTextureOffsets;
 	bool AtracLoopHack;
+	bool DeswizzleDepth;
 };
 
 class IniFile;

--- a/Core/CoreParameter.h
+++ b/Core/CoreParameter.h
@@ -66,7 +66,7 @@ struct CoreParameter {
 	bool headLess;   // Try to avoid messageboxes etc
 
 	// Internal PSP rendering resolution and scale factor.
-	int renderScaleFactor;
+	int renderScaleFactor = 1;
 	int renderWidth;
 	int renderHeight;
 

--- a/GPU/Common/DepalettizeCommon.cpp
+++ b/GPU/Common/DepalettizeCommon.cpp
@@ -147,10 +147,10 @@ Draw::SamplerState *DepalShaderCache::GetSampler() {
 	return nearestSampler_;
 }
 
-DepalShader *DepalShaderCache::GetDepalettizeShader(uint32_t clutMode, GEBufferFormat pixelFormat) {
+DepalShader *DepalShaderCache::GetDepalettizeShader(uint32_t clutMode, GETextureFormat textureFormat, GEBufferFormat bufferFormat) {
 	using namespace Draw;
 
-	u32 id = GenerateShaderID(clutMode, pixelFormat);
+	u32 id = GenerateShaderID(clutMode, textureFormat, bufferFormat);
 
 	auto shader = cache_.find(id);
 	if (shader != cache_.end()) {
@@ -171,7 +171,8 @@ DepalShader *DepalShaderCache::GetDepalettizeShader(uint32_t clutMode, GEBufferF
 	config.startPos = gstate.getClutIndexStartPos();
 	config.shift = gstate.getClutIndexShift();
 	config.mask = gstate.getClutIndexMask();
-	config.pixelFormat = pixelFormat;
+	config.bufferFormat = bufferFormat;
+	config.textureFormat = textureFormat;
 
 	GenerateDepalFs(buffer, config, draw_->GetShaderLanguageDesc());
 	

--- a/GPU/Common/DepalettizeCommon.cpp
+++ b/GPU/Common/DepalettizeCommon.cpp
@@ -173,6 +173,7 @@ DepalShader *DepalShaderCache::GetDepalettizeShader(uint32_t clutMode, GETexture
 	config.mask = gstate.getClutIndexMask();
 	config.bufferFormat = bufferFormat;
 	config.textureFormat = textureFormat;
+	config.resolutionScale = 3;
 
 	GenerateDepalFs(buffer, config, draw_->GetShaderLanguageDesc());
 	

--- a/GPU/Common/DepalettizeCommon.cpp
+++ b/GPU/Common/DepalettizeCommon.cpp
@@ -173,7 +173,6 @@ DepalShader *DepalShaderCache::GetDepalettizeShader(uint32_t clutMode, GETexture
 	config.mask = gstate.getClutIndexMask();
 	config.bufferFormat = bufferFormat;
 	config.textureFormat = textureFormat;
-	config.resolutionScale = 3;
 
 	GenerateDepalFs(buffer, config, draw_->GetShaderLanguageDesc());
 	

--- a/GPU/Common/DepalettizeCommon.h
+++ b/GPU/Common/DepalettizeCommon.h
@@ -49,7 +49,7 @@ public:
 	~DepalShaderCache();
 
 	// This also uploads the palette and binds the correct texture.
-	DepalShader *GetDepalettizeShader(uint32_t clutMode, GEBufferFormat pixelFormat);
+	DepalShader *GetDepalettizeShader(uint32_t clutMode, GETextureFormat texFormat, GEBufferFormat pixelFormat);
 	Draw::Texture *GetClutTexture(GEPaletteFormat clutFormat, const u32 clutHash, u32 *rawClut);
 
 	Draw::SamplerState *GetSampler();
@@ -63,8 +63,8 @@ public:
 	void DeviceRestore(Draw::DrawContext *draw);
 
 private:
-	static uint32_t GenerateShaderID(uint32_t clutMode, GEBufferFormat pixelFormat) {
-		return (clutMode & 0xFFFFFF) | (pixelFormat << 24);
+	static uint32_t GenerateShaderID(uint32_t clutMode, GETextureFormat texFormat, GEBufferFormat pixelFormat) {
+		return (clutMode & 0xFFFFFF) | (pixelFormat << 24) | (texFormat << 28);
 	}
 
 	static uint32_t GetClutID(GEPaletteFormat clutFormat, uint32_t clutHash) {

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -49,7 +49,7 @@ void GenerateDepalShader300(ShaderWriter &writer, const DepalConfig &config, con
 	const int shift = config.shift;
 	const int mask = config.mask;
 
-	if (config.pixelFormat == GE_FORMAT_DEPTH16) {
+	if (config.bufferFormat == GE_FORMAT_DEPTH16) {
 		DepthScaleFactors factors = GetDepthScaleFactors();
 		writer.ConstFloat("z_scale", factors.scale);
 		writer.ConstFloat("z_offset", factors.offset);
@@ -71,7 +71,7 @@ void GenerateDepalShader300(ShaderWriter &writer, const DepalConfig &config, con
 	writer.C("  vec4 color = ").SampleTexture2D("tex", "v_texcoord").C(";\n");
 
 	int shiftedMask = mask << shift;
-	switch (config.pixelFormat) {
+	switch (config.bufferFormat) {
 	case GE_FORMAT_8888:
 		if (shiftedMask & 0xFF) writer.C("  int r = int(color.r * 255.99);\n"); else writer.C("  int r = 0;\n");
 		if (shiftedMask & 0xFF00) writer.C("  int g = int(color.g * 255.99);\n"); else writer.C("  int g = 0;\n");
@@ -102,6 +102,17 @@ void GenerateDepalShader300(ShaderWriter &writer, const DepalConfig &config, con
 	case GE_FORMAT_DEPTH16:
 		// Remap depth buffer.
 		writer.C("  float depth = (color.x - z_offset) * z_scale;\n");
+
+		if (config.bufferFormat == GE_FORMAT_DEPTH16 && config.textureFormat == GE_TFMT_5650) {
+			// Convert depth to 565, without going through a CLUT.
+			writer.C("  int idepth = int(clamp(depth, 0.0, 65535.0));\n");
+			writer.C("  float r = (idepth & 31) / 31.0f;\n");
+			writer.C("  float g = ((idepth >> 5) & 63) / 63.0f;\n");
+			writer.C("  float b = ((idepth >> 11) & 31) / 31.0f;\n");
+			writer.C("  vec4 outColor = vec4(r, g, b, 1.0);\n");
+			return;
+		}
+
 		writer.C("  int index = int(clamp(depth, 0.0, 65535.0));\n");
 		break;
 	default:
@@ -135,7 +146,7 @@ void GenerateDepalShaderFloat(ShaderWriter &writer, const DepalConfig &config, c
 	const int shift = config.shift;
 	const int mask = config.mask;
 
-	if (config.pixelFormat == GE_FORMAT_DEPTH16) {
+	if (config.bufferFormat == GE_FORMAT_DEPTH16) {
 		DepthScaleFactors factors = GetDepthScaleFactors();
 		writer.ConstFloat("z_scale", factors.scale);
 		writer.ConstFloat("z_offset", factors.offset);
@@ -144,7 +155,7 @@ void GenerateDepalShaderFloat(ShaderWriter &writer, const DepalConfig &config, c
 	float index_multiplier = 1.0f;
 	// pixelformat is the format of the texture we are sampling.
 	bool formatOK = true;
-	switch (config.pixelFormat) {
+	switch (config.bufferFormat) {
 	case GE_FORMAT_8888:
 		if ((mask & (mask + 1)) == 0) {
 			// If the value has all bits contiguous (bitmask check above), we can mod by it + 1.
@@ -249,7 +260,7 @@ void GenerateDepalShaderFloat(ShaderWriter &writer, const DepalConfig &config, c
 	// index_multiplier -= 0.01f / texturePixels;
 
 	if (!formatOK) {
-		ERROR_LOG_REPORT_ONCE(depal, G3D, "%s depal unsupported: shift=%d mask=%02x offset=%d", GeBufferFormatToString(config.pixelFormat), shift, mask, config.startPos);
+		ERROR_LOG_REPORT_ONCE(depal, G3D, "%s depal unsupported: shift=%d mask=%02x offset=%d", GeBufferFormatToString(config.bufferFormat), shift, mask, config.startPos);
 	}
 
 	// Offset by half a texel (plus clutBase) to turn NEAREST filtering into FLOOR.

--- a/GPU/Common/DepalettizeShaderCommon.h
+++ b/GPU/Common/DepalettizeShaderCommon.h
@@ -31,6 +31,7 @@ struct DepalConfig {
 	GEPaletteFormat clutFormat;
 	GETextureFormat textureFormat;
 	GEBufferFormat bufferFormat;
+	int resolutionScale;
 };
 
 void GenerateDepalFs(char *buffer, const DepalConfig &config, const ShaderLanguageDesc &lang);

--- a/GPU/Common/DepalettizeShaderCommon.h
+++ b/GPU/Common/DepalettizeShaderCommon.h
@@ -29,7 +29,8 @@ struct DepalConfig {
 	int shift;
 	u32 startPos;
 	GEPaletteFormat clutFormat;
-	GEBufferFormat pixelFormat;
+	GETextureFormat textureFormat;
+	GEBufferFormat bufferFormat;
 };
 
 void GenerateDepalFs(char *buffer, const DepalConfig &config, const ShaderLanguageDesc &lang);

--- a/GPU/Common/DepalettizeShaderCommon.h
+++ b/GPU/Common/DepalettizeShaderCommon.h
@@ -31,7 +31,6 @@ struct DepalConfig {
 	GEPaletteFormat clutFormat;
 	GETextureFormat textureFormat;
 	GEBufferFormat bufferFormat;
-	int resolutionScale;
 };
 
 void GenerateDepalFs(char *buffer, const DepalConfig &config, const ShaderLanguageDesc &lang);

--- a/GPU/Common/Draw2D.cpp
+++ b/GPU/Common/Draw2D.cpp
@@ -73,6 +73,29 @@ RasterChannel GenerateDraw2D565ToDepthFs(ShaderWriter &writer) {
 	return RASTER_DEPTH;
 }
 
+// ugly way to get the scale into the function
+static float g_scale;
+
+RasterChannel GenerateDraw2D565ToDepthDeswizzleFs(ShaderWriter &writer) {
+	writer.DeclareSamplers(samplers);
+	writer.BeginFSMain(Slice<UniformDef>::empty(), varyings, FSFLAG_WRITEDEPTH);
+	writer.C("  vec4 outColor = vec4(0.0, 0.0, 0.0, 0.0);\n");
+	// Unlike when just copying a depth buffer, here we're generating new depth values so we'll
+	// have to apply the scaling.
+	DepthScaleFactors factors = GetDepthScaleFactors();
+	writer.C("  vec2 tsize = vec2(textureSize(tex, 0));\n");
+	writer.C("  vec2 coord = v_texcoord * tsize;\n");
+	writer.F("  float strip = 4.0 * %f;\n", g_scale);
+	writer.C("  float in_strip = mod(coord.y, strip);\n");
+	writer.C("  coord.y = coord.y - in_strip + strip - in_strip;\n");
+	writer.C("  coord /= tsize;\n");
+	writer.C("  vec3 rgb = ").SampleTexture2D("tex", "coord").C(".xyz;\n");
+	writer.F("  highp float depthValue = (floor(rgb.x * 31.99) + floor(rgb.y * 63.99) * 32.0 + floor(rgb.z * 31.99) * 2048.0); \n");
+	writer.F("  gl_FragDepth = (depthValue / %f) + %f;\n", factors.scale, factors.offset);
+	writer.EndFSMain("outColor", FSFLAG_WRITEDEPTH);
+	return RASTER_DEPTH;
+}
+
 void GenerateDraw2DVS(ShaderWriter &writer) {
 	writer.BeginVSMain(inputs, Slice<UniformDef>::empty(), varyings);
 
@@ -211,6 +234,19 @@ void FramebufferManagerCommon::DrawStrip2D(Draw::Texture *tex, Draw2DVertex *ver
 			linearFilter = false;
 		}
 		draw_->BindPipeline(draw2DPipeline565ToDepth_);
+		break;
+
+	case DRAW2D_565_TO_DEPTH_DESWIZZLE:
+		if (!draw_->GetDeviceCaps().fragmentShaderDepthWriteSupported) {
+			// Can't do it
+			return;
+		}
+		if (!draw2DPipeline565ToDepthDeswizzle_) {
+			g_scale = renderScaleFactor_;
+			draw2DPipeline565ToDepthDeswizzle_ = Create2DPipeline(&GenerateDraw2D565ToDepthDeswizzleFs);
+			linearFilter = false;
+		}
+		draw_->BindPipeline(draw2DPipeline565ToDepthDeswizzle_);
 		break;
 	}
 

--- a/GPU/Common/Draw2D.cpp
+++ b/GPU/Common/Draw2D.cpp
@@ -70,6 +70,7 @@ RasterChannel GenerateDraw2D565ToDepthFs(ShaderWriter &writer) {
 	writer.F("  highp float depthValue = (floor(rgb.x * 31.99) + floor(rgb.y * 63.99) * 32.0 + floor(rgb.z * 31.99) * 2048.0); \n");
 	writer.F("  gl_FragDepth = (depthValue / %f) + %f;\n", factors.scale, factors.offset);
 	writer.EndFSMain("outColor", FSFLAG_WRITEDEPTH);
+
 	return RASTER_DEPTH;
 }
 
@@ -83,7 +84,7 @@ RasterChannel GenerateDraw2D565ToDepthDeswizzleFs(ShaderWriter &writer) {
 	// Unlike when just copying a depth buffer, here we're generating new depth values so we'll
 	// have to apply the scaling.
 	DepthScaleFactors factors = GetDepthScaleFactors();
-	writer.C("  vec2 tsize = vec2(textureSize(tex, 0));\n");
+	writer.GetTextureSize("tsize", "tex").C("\n");
 	writer.C("  vec2 coord = v_texcoord * tsize;\n");
 	writer.F("  float strip = 4.0 * %f;\n", g_scale);
 	writer.C("  float in_strip = mod(coord.y, strip);\n");
@@ -255,4 +256,8 @@ void FramebufferManagerCommon::DrawStrip2D(Draw::Texture *tex, Draw2DVertex *ver
 	}
 	draw_->BindSamplerStates(TEX_SLOT_PSP_TEXTURE, 1, linearFilter ? &draw2DSamplerLinear_ : &draw2DSamplerNearest_);
 	draw_->DrawUP(verts, vertexCount);
+
+	draw_->InvalidateCachedState();
+
+	gstate_c.Dirty(DIRTY_FRAGMENTSHADER_STATE | DIRTY_VERTEXSHADER_STATE);
 }

--- a/GPU/Common/Draw2D.h
+++ b/GPU/Common/Draw2D.h
@@ -14,6 +14,7 @@ enum Draw2DShader {
 	DRAW2D_COPY_COLOR,
 	DRAW2D_COPY_DEPTH,
 	DRAW2D_565_TO_DEPTH,
+	DRAW2D_565_TO_DEPTH_DESWIZZLE,
 };
 
 inline RasterChannel Draw2DSourceChannel(Draw2DShader shader) {
@@ -22,6 +23,7 @@ inline RasterChannel Draw2DSourceChannel(Draw2DShader shader) {
 		return RASTER_DEPTH;
 	case DRAW2D_COPY_COLOR:
 	case DRAW2D_565_TO_DEPTH:
+	case DRAW2D_565_TO_DEPTH_DESWIZZLE:
 	default:
 		return RASTER_COLOR;
 	}

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1906,6 +1906,13 @@ void FramebufferManagerCommon::Resized() {
 	// Might have a new post shader - let's compile it.
 	presentation_->UpdatePostShader();
 
+	// Reset all shaders that might have resolution compiled-in.
+	if (draw2DPipeline565ToDepthDeswizzle_) {
+		draw2DPipeline565ToDepthDeswizzle_->Release();
+		draw2DPipeline565ToDepthDeswizzle_ = nullptr;
+	}
+
+
 #ifdef _WIN32
 	// Seems related - if you're ok with numbers all the time, show some more :)
 	if (g_Config.iShowFPSCounter != 0) {

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -560,11 +560,14 @@ void FramebufferManagerCommon::CopyToDepthFromOverlappingFramebuffers(VirtualFra
 			dest->last_frame_depth_updated = gpuStats.numFlips;
 		} else if (source.channel == RASTER_COLOR) {
 			VirtualFramebuffer *src = source.vfb;
-			// Copying color to depth.
 			if (src->drawnFormat != GE_FORMAT_565) {
 				WARN_LOG_ONCE(not565, G3D, "Drawn format of buffer at %08x not 565 as expected", src->fb_address);
 			}
-			BlitUsingRaster(src->fbo, 0.0f, 0.0f, src->renderWidth, src->renderHeight, dest->fbo, 0.0f, 0.0f, dest->renderWidth, dest->renderHeight, false, DRAW2D_565_TO_DEPTH, "565_to_depth");
+			// Copying color to depth.
+			BlitUsingRaster(
+				src->fbo, 0.0f, 0.0f, src->renderWidth, src->renderHeight,
+				dest->fbo, 0.0f, 0.0f, src->renderWidth, src->renderHeight,
+				false, DRAW2D_565_TO_DEPTH_DESWIZZLE, "565_to_depth");
 		}
 	}
 
@@ -2343,6 +2346,7 @@ void FramebufferManagerCommon::DeviceLost() {
 	DoRelease(draw2DPipelineColor_);
 	DoRelease(draw2DPipelineDepth_);
 	DoRelease(draw2DPipeline565ToDepth_);
+	DoRelease(draw2DPipeline565ToDepthDeswizzle_);
 
 	draw_ = nullptr;
 }

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1941,7 +1941,7 @@ Draw::Framebuffer *FramebufferManagerCommon::GetTempFBO(TempFBO reason, u16 w, u
 
 	bool z_stencil = reason == TempFBO::STENCIL;
 	char name[128];
-	snprintf(name, sizeof(name), "temp_fbo_%dx%d%s", w, h, z_stencil ? "_depth" : "");
+	snprintf(name, sizeof(name), "temp_fbo_%dx%d%s", w / renderScaleFactor_, h / renderScaleFactor_, z_stencil ? "_depth" : "");
 	Draw::Framebuffer *fbo = draw_->CreateFramebuffer({ w, h, 1, 1, z_stencil, name });
 	if (!fbo) {
 		return nullptr;

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1908,13 +1908,6 @@ void FramebufferManagerCommon::Resized() {
 	// Might have a new post shader - let's compile it.
 	presentation_->UpdatePostShader();
 
-	// Reset all shaders that might have resolution compiled-in.
-	if (draw2DPipeline565ToDepthDeswizzle_) {
-		draw2DPipeline565ToDepthDeswizzle_->Release();
-		draw2DPipeline565ToDepthDeswizzle_ = nullptr;
-	}
-
-
 #ifdef _WIN32
 	// Seems related - if you're ok with numbers all the time, show some more :)
 	if (g_Config.iShowFPSCounter != 0) {

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2566,7 +2566,7 @@ void FramebufferManagerCommon::BlitUsingRaster(
 	Draw::Viewport vp{ 0.0f, 0.0f, (float)dest->Width(), (float)dest->Height(), 0.0f, 1.0f };
 	draw_->SetViewports(1, &vp);
 	draw_->SetScissorRect(0, 0, (int)dest->Width(), (int)dest->Height());
-	DrawStrip2D(nullptr, vtx, 4, linearFilter, shader);
+	DrawStrip2D(nullptr, vtx, 4, linearFilter, shader, src->Width(), src->Height());
 
 	gstate_c.Dirty(DIRTY_BLEND_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_RASTER_STATE | DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_VERTEXSHADER_STATE | DIRTY_FRAGMENTSHADER_STATE);
 }

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -552,6 +552,8 @@ void FramebufferManagerCommon::CopyToDepthFromOverlappingFramebuffers(VirtualFra
 
 	// for (auto &source : sources) {
 	if (!sources.empty()) {
+		draw_->InvalidateCachedState();
+
 		auto &source = sources.back();
 		if (source.channel == RASTER_DEPTH) {
 			// Good old depth->depth copy.

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -551,7 +551,7 @@ void FramebufferManagerCommon::CopyToDepthFromOverlappingFramebuffers(VirtualFra
 	// For now, let's just do the last thing, if there are multiple.
 
 	// for (auto &source : sources) {
-	if (sources.size()) {
+	if (!sources.empty()) {
 		auto &source = sources.back();
 		if (source.channel == RASTER_DEPTH) {
 			// Good old depth->depth copy.
@@ -563,11 +563,19 @@ void FramebufferManagerCommon::CopyToDepthFromOverlappingFramebuffers(VirtualFra
 			if (src->drawnFormat != GE_FORMAT_565) {
 				WARN_LOG_ONCE(not565, G3D, "Drawn format of buffer at %08x not 565 as expected", src->fb_address);
 			}
+
+			// Really hate to do this, but tracking the depth swizzle state across multiple
+			// copies is not easy.
+			Draw2DShader shader = DRAW2D_565_TO_DEPTH;
+			if (PSP_CoreParameter().compat.flags().DeswizzleDepth) {
+				shader = DRAW2D_565_TO_DEPTH_DESWIZZLE;
+			}
+
 			// Copying color to depth.
 			BlitUsingRaster(
 				src->fbo, 0.0f, 0.0f, src->renderWidth, src->renderHeight,
 				dest->fbo, 0.0f, 0.0f, src->renderWidth, src->renderHeight,
-				false, DRAW2D_565_TO_DEPTH_DESWIZZLE, "565_to_depth");
+				false, shader, "565_to_depth");
 		}
 	}
 

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -560,7 +560,7 @@ void FramebufferManagerCommon::CopyToDepthFromOverlappingFramebuffers(VirtualFra
 			BlitFramebufferDepth(source.vfb, dest);
 			gpuStats.numDepthCopies++;
 			dest->last_frame_depth_updated = gpuStats.numFlips;
-		} else if (source.channel == RASTER_COLOR) {
+		} else if (source.channel == RASTER_COLOR && draw_->GetDeviceCaps().fragmentShaderDepthWriteSupported) {
 			VirtualFramebuffer *src = source.vfb;
 			if (src->drawnFormat != GE_FORMAT_565) {
 				WARN_LOG_ONCE(not565, G3D, "Drawn format of buffer at %08x not 565 as expected", src->fb_address);

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -511,6 +511,7 @@ protected:
 	Draw::Pipeline *draw2DPipelineColor_ = nullptr;
 	Draw::Pipeline *draw2DPipelineDepth_ = nullptr;
 	Draw::Pipeline *draw2DPipeline565ToDepth_ = nullptr;
+	Draw::Pipeline *draw2DPipeline565ToDepthDeswizzle_ = nullptr;
 	Draw::SamplerState *draw2DSamplerLinear_ = nullptr;
 	Draw::SamplerState *draw2DSamplerNearest_ = nullptr;
 	Draw::ShaderModule *draw2DVs_ = nullptr;

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -375,7 +375,7 @@ protected:
 	Draw::Texture *MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height);
 	void DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags);
 
-	void DrawStrip2D(Draw::Texture *tex, Draw2DVertex *verts, int vertexCount, bool linearFilter, Draw2DShader channel);
+	void DrawStrip2D(Draw::Texture *tex, Draw2DVertex *verts, int vertexCount, bool linearFilter, Draw2DShader channel, float texW = 0.0f, float texH = 0.0f);
 	void Ensure2DResources();
 	Draw::Pipeline *Create2DPipeline(RasterChannel (*generate)(ShaderWriter &));
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1838,9 +1838,15 @@ bool CanDepalettize(GETextureFormat texFormat, GEBufferFormat bufferFormat) {
 		case GE_FORMAT_565:
 		case GE_FORMAT_5551:
 		case GE_FORMAT_DEPTH16:
-			return texFormat == GE_TFMT_CLUT16;
+			if (texFormat == GE_TFMT_CLUT16) {
+				return true;
+			}
+			break;
 		case GE_FORMAT_8888:
-			return texFormat == GE_TFMT_CLUT32;
+			if (texFormat == GE_TFMT_CLUT32) {
+				return true;
+			}
+			break;
 		}
 		WARN_LOG(G3D, "Invalid CLUT/framebuffer combination: %s vs %s", GeTextureFormatToString(texFormat), GeBufferFormatToString(bufferFormat));
 		return false;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -525,10 +525,6 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 	def.format = format;
 	def.bufw = bufw;
 
-	if (texaddr == 0x04710000) {
-		texaddr = texaddr;
-	}
-
 	std::vector<AttachCandidate> candidates = GetFramebufferCandidates(def, 0);
 	if (candidates.size() > 0) {
 		int index = GetBestCandidateIndex(candidates);
@@ -978,8 +974,6 @@ bool TextureCacheCommon::MatchFramebuffer(
 		if (matchingClutFormat) {
 			if (!noOffset) {
 				WARN_LOG_ONCE(subareaClut, G3D, "Texturing from framebuffer (%s) using %s with offset at %08x +%dx%d", channel == RASTER_DEPTH ? "DEPTH" : "COLOR", GeTextureFormatToString(entry.format), fb_address, matchInfo->xOffset, matchInfo->yOffset);
-			} else {
-				WARN_LOG_ONCE(subareaClut, G3D, "Texturing from framebuffer (%s) using %s at %08x", channel == RASTER_DEPTH ? "DEPTH" : "COLOR", GeTextureFormatToString(entry.format), fb_address);
 			}
 			return true;
 		} else if (IsClutFormat((GETextureFormat)(entry.format)) || IsDXTFormat((GETextureFormat)(entry.format))) {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1863,7 +1863,6 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 	// TODO: Implement shader depal in the fragment shader generator for D3D11 at least.
 	if (!draw_->GetDeviceCaps().fragmentShaderInt32Supported) {
 		useShaderDepal = false;
-		depth = false;  // Can't support this
 	}
 
 	switch (draw_->GetShaderLanguageDesc().shaderLanguage) {

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -160,6 +160,7 @@ void GPU_DX9::CheckGPUFeatures() {
 	u32 features = 0;
 	features |= GPU_SUPPORTS_16BIT_FORMATS;
 	features |= GPU_SUPPORTS_BLEND_MINMAX;
+	features |= GPU_SUPPORTS_DEPTH_TEXTURE;
 	features |= GPU_SUPPORTS_TEXTURE_LOD_CONTROL;
 
 	// Accurate depth is required because the Direct3D API does not support inverse Z.

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1102,6 +1102,10 @@ NPEH00029 = true
 ULUS10455 = true
 
 [BlueToAlpha]
+# Some games render first to RGB of a 4444 texture, then they switch to 565 and render masked to blue,
+# just to be able to render to the alpha channel of the 4444. We can detect that and reroute rendering
+# to avoid problems.
+
 # Split/Second
 ULES01402 = true
 ULUS10513 = true
@@ -1120,10 +1124,6 @@ ULES01301 = true
 ULES00262 = true
 ULUS10064 = true
 ULKS46087 = true
-
-# Some games render first to RGB of a 4444 texture, then they switch to 565 and render masked to blue,
-# just to be able to render to the alpha channel of the 4444. We can detect that and reroute rendering
-# to avoid problems.
 
 [DateLimited]
 # Car Jack Streets - issue #12698

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1266,3 +1266,13 @@ ULES00618 = true
 # Silver Fall
 ULES00808 = true
 ULUS10270 = true
+
+[DeswizzleDepth]
+UCUS98633 = true
+UCAS40145 = true
+UCES00420 = true
+UCJS10052 = true
+UCKS45048 = true
+UCJS18030 = true
+UCJS18047 = true
+NPJG00015 = true

--- a/unittest/TestShaderGenerators.cpp
+++ b/unittest/TestShaderGenerators.cpp
@@ -309,7 +309,8 @@ bool TestDepalShaders() {
 		config.shift = 8;
 		config.startPos = 64;
 		config.mask = 0xFF;
-		config.pixelFormat = GE_FORMAT_8888;
+		config.bufferFormat = GE_FORMAT_8888;
+		config.textureFormat = GE_TFMT_CLUT32;
 
 		GenerateDepalFs(buffer, config, desc);
 		if (!TestCompileShader(buffer, languages[k], ShaderStage::Fragment, &errorMessage)) {


### PR DESCRIPTION
Fixes #6105 

Details: https://github.com/hrydgard/ppsspp/issues/6105#issuecomment-433733039

This is an attempt at a fix for #6105 (Ratchet & Clank particles visible through things).

But there's still weird glitchiness, if we don't apply a bit of deswizzling, same as seen with the software renderer. There's a pass during rendering that scrambles the mini depth buffer by using a triangle mesh. But it doesn't really look like a swizzle... It just flips portions of the image so that after downsacling, each set of 4 lines (at original resolution) is upside down. Maybe that's somehow the difference between depth swizzle and color swizzle? ~~Plus there's some horizontal stretch somewhere that's not quite right.~~

Things left to fix:

- [ ] See if we can avoid the compat flag in some reasonable way (it only controls swizzle, the rest is solidly compat-flag-free). (I really don't see how... and emulating swizzle properly would be difficult and possibly not possible at high res)
- [x] In-game resolution change doesn't work (breaks the deswizzle)

Normally when games use color as depth they texture with a swizzle flag in the address but this doesn't, so it indeed seems like swizzle compensation. We undo it during color->depth conversion (a special version of the color->depth copy shader).

![image](https://user-images.githubusercontent.com/130929/185366382-5c86c076-7eca-48cb-8e66-0d570b82c592.png)

After conversion to depth, it looks like this:

![image](https://user-images.githubusercontent.com/130929/185367650-cdc2b107-6270-49b0-aaf1-8e1e04fec5d0.png)

This results in weird artifacts like this:

![image](https://user-images.githubusercontent.com/130929/185366572-51b3f70b-9490-4f30-9b88-183053683723.png)

With the latest changes here that applies a deswizzle operation:

![image](https://user-images.githubusercontent.com/130929/185507494-dd4c1eda-cbcb-4255-b460-ee3f9995e24c.png)
