### PR TITLE
GPU: Dirty params when converting viewport state for sw transform

### DIFF
--- a/GPU/Common/GPUStateUtils.h
+++ b/GPU/Common/GPUStateUtils.h
@@ -75,10 +75,16 @@ struct ViewportAndScissor {
 	float viewportH;
 	float depthRangeMin;
 	float depthRangeMax;
-	bool dirtyProj;
-	bool dirtyDepth;
+	float widthScale;
+	float heightScale;
+	float depthScale;
+	float xOffset;
+	float yOffset;
+	float zOffset;
+	bool throughMode;
 };
 void ConvertViewportAndScissor(bool useBufferedRendering, float renderWidth, float renderHeight, int bufferWidth, int bufferHeight, ViewportAndScissor &out);
+void UpdateCachedViewportState(const ViewportAndScissor &vpAndScissor);
 float ToScaledDepthFromIntegerScale(float z);
 
 struct DepthScaleFactors {

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -617,13 +617,7 @@ rotateVBO:
 				framebufferManager_->GetRenderWidth(), framebufferManager_->GetRenderHeight(),
 				framebufferManager_->GetTargetBufferWidth(), framebufferManager_->GetTargetBufferHeight(),
 				vpAndScissor);
-
-			if (vpAndScissor.dirtyProj) {
-				gstate_c.Dirty(DIRTY_PROJMATRIX);
-			}
-			if (vpAndScissor.dirtyDepth) {
-				gstate_c.Dirty(DIRTY_DEPTHRANGE);
-			}
+			UpdateCachedViewportState(vpAndScissor);
 		}
 
 		int maxIndex = indexGen.MaxIndex();

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -617,6 +617,13 @@ rotateVBO:
 				framebufferManager_->GetRenderWidth(), framebufferManager_->GetRenderHeight(),
 				framebufferManager_->GetTargetBufferWidth(), framebufferManager_->GetTargetBufferHeight(),
 				vpAndScissor);
+
+			if (vpAndScissor.dirtyProj) {
+				gstate_c.Dirty(DIRTY_PROJMATRIX);
+			}
+			if (vpAndScissor.dirtyDepth) {
+				gstate_c.Dirty(DIRTY_DEPTHRANGE);
+			}
 		}
 
 		int maxIndex = indexGen.MaxIndex();

--- a/GPU/D3D11/StateMappingD3D11.cpp
+++ b/GPU/D3D11/StateMappingD3D11.cpp
@@ -374,15 +374,13 @@ void DrawEngineD3D11::ApplyDrawState(int prim) {
 			framebufferManager_->GetRenderWidth(), framebufferManager_->GetRenderHeight(),
 			framebufferManager_->GetTargetBufferWidth(), framebufferManager_->GetTargetBufferHeight(),
 			vpAndScissor);
+		UpdateCachedViewportState(vpAndScissor);
 
 		float depthMin = vpAndScissor.depthRangeMin;
 		float depthMax = vpAndScissor.depthRangeMax;
 
 		if (depthMin < 0.0f) depthMin = 0.0f;
 		if (depthMax > 1.0f) depthMax = 1.0f;
-		if (vpAndScissor.dirtyDepth) {
-			gstate_c.Dirty(DIRTY_DEPTHRANGE);
-		}
 
 		Draw::Viewport &vp = dynState_.viewport;
 		vp.TopLeftX = vpAndScissor.viewportX;
@@ -391,10 +389,6 @@ void DrawEngineD3D11::ApplyDrawState(int prim) {
 		vp.Height = vpAndScissor.viewportH;
 		vp.MinDepth = depthMin;
 		vp.MaxDepth = depthMax;
-
-		if (vpAndScissor.dirtyProj) {
-			gstate_c.Dirty(DIRTY_PROJMATRIX);
-		}
 
 		D3D11_RECT &scissor = dynState_.scissor;
 		scissor.left = vpAndScissor.scissorX;

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -582,13 +582,7 @@ rotateVBO:
 				framebufferManager_->GetRenderWidth(), framebufferManager_->GetRenderHeight(),
 				framebufferManager_->GetTargetBufferWidth(), framebufferManager_->GetTargetBufferHeight(),
 				vpAndScissor);
-
-			if (vpAndScissor.dirtyProj) {
-				gstate_c.Dirty(DIRTY_PROJMATRIX);
-			}
-			if (vpAndScissor.dirtyDepth) {
-				gstate_c.Dirty(DIRTY_DEPTHRANGE);
-			}
+			UpdateCachedViewportState(vpAndScissor);
 		}
 
 		int maxIndex = indexGen.MaxIndex();

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -582,6 +582,13 @@ rotateVBO:
 				framebufferManager_->GetRenderWidth(), framebufferManager_->GetRenderHeight(),
 				framebufferManager_->GetTargetBufferWidth(), framebufferManager_->GetTargetBufferHeight(),
 				vpAndScissor);
+
+			if (vpAndScissor.dirtyProj) {
+				gstate_c.Dirty(DIRTY_PROJMATRIX);
+			}
+			if (vpAndScissor.dirtyDepth) {
+				gstate_c.Dirty(DIRTY_DEPTHRANGE);
+			}
 		}
 
 		int maxIndex = indexGen.MaxIndex();

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -260,6 +260,7 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 			framebufferManager_->GetRenderWidth(), framebufferManager_->GetRenderHeight(),
 			framebufferManager_->GetTargetBufferWidth(), framebufferManager_->GetTargetBufferHeight(),
 			vpAndScissor);
+		UpdateCachedViewportState(vpAndScissor);
 
 		dxstate.scissorTest.enable();
 		dxstate.scissorRect.set(vpAndScissor.scissorX, vpAndScissor.scissorY, vpAndScissor.scissorX + vpAndScissor.scissorW, vpAndScissor.scissorY + vpAndScissor.scissorH);
@@ -268,12 +269,6 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 		float depthMax = vpAndScissor.depthRangeMax;
 
 		dxstate.viewport.set(vpAndScissor.viewportX, vpAndScissor.viewportY, vpAndScissor.viewportW, vpAndScissor.viewportH, depthMin, depthMax);
-		if (vpAndScissor.dirtyProj) {
-			gstate_c.Dirty(DIRTY_PROJMATRIX);
-		}
-		if (vpAndScissor.dirtyDepth) {
-			gstate_c.Dirty(DIRTY_DEPTHRANGE);
-		}
 	}
 
 	gstate_c.Clean(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_DEPTHSTENCIL_STATE | DIRTY_RASTER_STATE | DIRTY_BLEND_STATE);

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -364,13 +364,7 @@ void DrawEngineGLES::DoFlush() {
 				framebufferManager_->GetRenderWidth(), framebufferManager_->GetRenderHeight(),
 				framebufferManager_->GetTargetBufferWidth(), framebufferManager_->GetTargetBufferHeight(),
 				vpAndScissor);
-
-			if (vpAndScissor.dirtyProj) {
-				gstate_c.Dirty(DIRTY_PROJMATRIX);
-			}
-			if (vpAndScissor.dirtyDepth) {
-				gstate_c.Dirty(DIRTY_DEPTHRANGE);
-			}
+			UpdateCachedViewportState(vpAndScissor);
 		}
 
 		int maxIndex = indexGen.MaxIndex();

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -364,6 +364,13 @@ void DrawEngineGLES::DoFlush() {
 				framebufferManager_->GetRenderWidth(), framebufferManager_->GetRenderHeight(),
 				framebufferManager_->GetTargetBufferWidth(), framebufferManager_->GetTargetBufferHeight(),
 				vpAndScissor);
+
+			if (vpAndScissor.dirtyProj) {
+				gstate_c.Dirty(DIRTY_PROJMATRIX);
+			}
+			if (vpAndScissor.dirtyDepth) {
+				gstate_c.Dirty(DIRTY_DEPTHRANGE);
+			}
 		}
 
 		int maxIndex = indexGen.MaxIndex();

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -276,19 +276,13 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 			framebufferManager_->GetRenderWidth(), framebufferManager_->GetRenderHeight(),
 			framebufferManager_->GetTargetBufferWidth(), framebufferManager_->GetTargetBufferHeight(),
 			vpAndScissor);
+		UpdateCachedViewportState(vpAndScissor);
 
 		renderManager->SetScissor(GLRect2D{ vpAndScissor.scissorX, vpAndScissor.scissorY, vpAndScissor.scissorW, vpAndScissor.scissorH });
 		renderManager->SetViewport({
 			vpAndScissor.viewportX, vpAndScissor.viewportY,
 			vpAndScissor.viewportW, vpAndScissor.viewportH,
 			vpAndScissor.depthRangeMin, vpAndScissor.depthRangeMax });
-
-		if (vpAndScissor.dirtyProj) {
-			gstate_c.Dirty(DIRTY_PROJMATRIX);
-		}
-		if (vpAndScissor.dirtyDepth) {
-			gstate_c.Dirty(DIRTY_DEPTHRANGE);
-		}
 	}
 }
 

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -856,6 +856,13 @@ void DrawEngineVulkan::DoFlush() {
 				framebufferManager_->GetRenderWidth(), framebufferManager_->GetRenderHeight(),
 				framebufferManager_->GetTargetBufferWidth(), framebufferManager_->GetTargetBufferHeight(),
 				vpAndScissor);
+
+			if (vpAndScissor.dirtyProj) {
+				gstate_c.Dirty(DIRTY_PROJMATRIX);
+			}
+			if (vpAndScissor.dirtyDepth) {
+				gstate_c.Dirty(DIRTY_DEPTHRANGE);
+			}
 		}
 
 		int maxIndex = indexGen.MaxIndex();

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -856,13 +856,7 @@ void DrawEngineVulkan::DoFlush() {
 				framebufferManager_->GetRenderWidth(), framebufferManager_->GetRenderHeight(),
 				framebufferManager_->GetTargetBufferWidth(), framebufferManager_->GetTargetBufferHeight(),
 				vpAndScissor);
-
-			if (vpAndScissor.dirtyProj) {
-				gstate_c.Dirty(DIRTY_PROJMATRIX);
-			}
-			if (vpAndScissor.dirtyDepth) {
-				gstate_c.Dirty(DIRTY_DEPTHRANGE);
-			}
+			UpdateCachedViewportState(vpAndScissor);
 		}
 
 		int maxIndex = indexGen.MaxIndex();

--- a/GPU/Vulkan/StateMappingVulkan.cpp
+++ b/GPU/Vulkan/StateMappingVulkan.cpp
@@ -318,15 +318,13 @@ void DrawEngineVulkan::ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManag
 			fbManager.GetRenderWidth(), fbManager.GetRenderHeight(),
 			fbManager.GetTargetBufferWidth(), fbManager.GetTargetBufferHeight(),
 			vpAndScissor);
+		UpdateCachedViewportState(vpAndScissor);
 
 		float depthMin = vpAndScissor.depthRangeMin;
 		float depthMax = vpAndScissor.depthRangeMax;
 
 		if (depthMin < 0.0f) depthMin = 0.0f;
 		if (depthMax > 1.0f) depthMax = 1.0f;
-		if (vpAndScissor.dirtyDepth) {
-			gstate_c.Dirty(DIRTY_DEPTHRANGE);
-		}
 
 		VkViewport &vp = dynState.viewport;
 		vp.x = vpAndScissor.viewportX;
@@ -335,10 +333,6 @@ void DrawEngineVulkan::ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManag
 		vp.height = vpAndScissor.viewportH;
 		vp.minDepth = vpAndScissor.depthRangeMin;
 		vp.maxDepth = vpAndScissor.depthRangeMax;
-
-		if (vpAndScissor.dirtyProj) {
-			gstate_c.Dirty(DIRTY_PROJMATRIX);
-		}
 
 		ScissorRect &scissor = dynState.scissor;
 		scissor.x = vpAndScissor.scissorX;


### PR DESCRIPTION
Fixes #15856, a regression in 1.13.x from #15069.

The problem is essentially solved in the first commit (the dirty out flags weren't being applied.)  That said, I made the function more pure (it still updates vpWidth and vpHeight, but unconditionally) by separating the dirty handling to `UpdateCachedViewportState()`.  This makes it clearer that `UpdateCachedViewportState()` has one-time side effects.

-[Unknown]