### PR TITLE
GPU: Correct depal CLUT texture for 5551/565

### DIFF
--- a/GPU/Common/DepalettizeCommon.cpp
+++ b/GPU/Common/DepalettizeCommon.cpp
@@ -80,11 +80,11 @@ Draw::Texture *DepalShaderCache::GetClutTexture(GEPaletteFormat clutFormat, cons
 		desc.initData.push_back((const uint8_t *)rawClut);
 		break;
 	case GEPaletteFormat::GE_CMODE_16BIT_BGR5650:
-		ConvertRGBA5551ToRGBA8888((u32 *)convTemp, (const u16 *)rawClut, texturePixels);
+		ConvertRGB565ToRGBA8888((u32 *)convTemp, (const u16 *)rawClut, texturePixels);
 		desc.initData.push_back(convTemp);
 		break;
 	case GEPaletteFormat::GE_CMODE_16BIT_ABGR5551:
-		ConvertRGB565ToRGBA8888((u32 *)convTemp, (const u16 *)rawClut, texturePixels);
+		ConvertRGBA5551ToRGBA8888((u32 *)convTemp, (const u16 *)rawClut, texturePixels);
 		desc.initData.push_back(convTemp);
 		break;
 	case GEPaletteFormat::GE_CMODE_16BIT_ABGR4444:

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -649,11 +649,13 @@ void CGEDebugger::SecondPreviewHover(int x, int y) {
 		}
 		DescribeSecondPreview(state, desc);
 	} else {
-		u32 pix = secondBuffer_->GetRawPixel(x, y);
 		if (showClut_) {
-			// Show the clut index, rather than coords.
-			DescribePixel(pix, secondBuffer_->GetFormat(), y * 16 + x, 0, desc);
+			// Use the clut index, rather than coords.
+			uint32_t clutWidth = secondBuffer_->GetStride() / 16;
+			u32 pix = secondBuffer_->GetRawPixel(y * clutWidth + x, 0);
+			DescribePixel(pix, secondBuffer_->GetFormat(), y * clutWidth + x, 0, desc);
 		} else {
+			u32 pix = secondBuffer_->GetRawPixel(x, y);
 			DescribePixel(pix, secondBuffer_->GetFormat(), x, y, desc);
 		}
 	}


### PR DESCRIPTION
Fixes #15823.  These cases were transposed in #15789.

Also correct some CLUT preview wonkiness in the GE debugger I found while looking at that.

-[Unknown]