### PR TITLE
GPU: Restrict mip CLUT enhancement a bit

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1666,7 +1666,9 @@ CheckAlphaResult TextureCacheCommon::ReadIndexedTex(u8 *out, int outPitch, int l
 		texptr = (u8 *)tmpTexBuf32_.data();
 	}
 
-	const bool mipmapShareClut = gstate.isClutSharedForMipmaps();
+	// Misshitsu no Sacrifice has separate CLUT data, this is a hack to allow it.
+	// Normally separate CLUTs are not allowed for 8-bit or higher indices.
+	const bool mipmapShareClut = gstate.isClutSharedForMipmaps() && gstate.getClutLoadBlocks() == 0x40;
 	const int clutSharingOffset = mipmapShareClut ? 0 : (level & 1) * 256;
 
 	GEPaletteFormat palFormat = (GEPaletteFormat)gstate.getClutPaletteFormat();

--- a/GPU/Debugger/Record.cpp
+++ b/GPU/Debugger/Record.cpp
@@ -454,7 +454,9 @@ static void EmitTransfer(u32 op) {
 
 static void EmitClut(u32 op) {
 	u32 addr = gstate.getClutAddress();
-	u32 bytes = (op & 0x3F) * 32;
+	// Actually should only be 0x3F, but we allow enhanced CLUTs.  See #15727.
+	u32 blocks = (op & 0x7F) == 0x40 ? 0x40 : (op & 0x3F);
+	u32 bytes = blocks * 32;
 	bytes = Memory::ValidSize(addr, bytes);
 
 	if (bytes != 0) {

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -300,8 +300,14 @@ struct GPUgstate {
 	bool isTextureFormatIndexed() const { return (texformat & 4) != 0; } // GE_TFMT_CLUT4 - GE_TFMT_CLUT32 are 0b1xx.
 	int getTextureEnvColRGB() const { return texenvcolor & 0x00FFFFFF; }
 	u32 getClutAddress() const { return (clutaddr & 0x00FFFFF0) | ((clutaddrupper << 8) & 0x0F000000); }
-	int getClutLoadBytes() const { return (loadclut & 0x7F) * 32; }
-	int getClutLoadBlocks() const { return (loadclut & 0x7F); }
+	int getClutLoadBytes() const { return getClutLoadBlocks() * 32; }
+	int getClutLoadBlocks() const {
+		// The PSP only supports 0x3F, but Misshitsu no Sacrifice has extra color data (see #15727.)
+		// 0x40 would be 0, which would be a no-op, so we allow it.
+		if ((loadclut & 0x7F) == 0x40)
+			return 0x40;
+		return loadclut & 0x3F;
+	}
 	GEPaletteFormat getClutPaletteFormat() const { return static_cast<GEPaletteFormat>(clutformat & 3); }
 	int getClutIndexShift() const { return (clutformat >> 2) & 0x1F; }
 	int getClutIndexMask() const { return (clutformat >> 8) & 0xFF; }

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1408,7 +1408,7 @@ bool GetCurrentTexture(GPUDebugBuffer &buffer, int level)
 
 	SamplerID id;
 	ComputeSamplerID(&id);
-	id.cached.clut = (const u8 *)clut;
+	id.cached.clut = clut;
 
 	Sampler::FetchFunc sampler = Sampler::GetFetchFunc(id);
 

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -52,7 +52,7 @@
 const int FB_WIDTH = 480;
 const int FB_HEIGHT = 272;
 
-u32 clut[4096];
+uint8_t clut[1024];
 FormatBuffer fb;
 FormatBuffer depthbuf;
 
@@ -971,7 +971,10 @@ void SoftGPU::Execute_Spline(u32 op, u32 diff) {
 
 void SoftGPU::Execute_LoadClut(u32 op, u32 diff) {
 	u32 clutAddr = gstate.getClutAddress();
-	u32 clutTotalBytes = gstate.getClutLoadBytes();
+	// Avoid the hack in getClutLoadBytes() to inaccurately allow more palette data.
+	u32 clutTotalBytes = (gstate.getClutLoadBlocks() & 0x3F) * 32;
+	if (clutTotalBytes > 1024)
+		clutTotalBytes = 1024;
 
 	// Might be copying drawing into the CLUT, so flush.
 	drawEngine_->transformUnit.FlushIfOverlap("loadclut", clutAddr, clutTotalBytes, clutTotalBytes, 1);

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -216,7 +216,7 @@ private:
 };
 
 // TODO: These shouldn't be global.
-extern u32 clut[4096];
+extern uint8_t clut[1024];
 extern FormatBuffer fb;
 extern FormatBuffer depthbuf;
 


### PR DESCRIPTION
This makes the "second CLUT" from #15727 not trigger in most cases, except the safe case replicated by Misshitsu no Sacrifice.  See #6357.

It also changes the GE frame dump so it'll include the extended CLUT data, and cleans up softgpu a bit so it won't try to load the extra data.

-[Unknown]