### PR TITLE
softgpu: Flush on transfer to pending tex read

### DIFF
--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -198,6 +198,8 @@ public:
 	void Drain();
 	void Flush(const char *reason);
 	bool HasPendingWrite(uint32_t start, uint32_t stride, uint32_t w, uint32_t h);
+	// Assumes you've also checked for a write (writes are partial so are automatically reads.)
+	bool HasPendingRead(uint32_t start, uint32_t stride, uint32_t w, uint32_t h);
 
 	void GetStats(char *buffer, size_t bufsize);
 	void ResetStats();
@@ -252,6 +254,8 @@ private:
 	BinWaitable *waitable_ = nullptr;
 
 	BinDirtyRange pendingWrites_[2]{};
+	std::unordered_map<uint32_t, BinDirtyRange> pendingReads_;
+
 	bool pendingOverlap_ = false;
 
 	std::unordered_map<const char *, double> flushReasonTimes_;
@@ -262,6 +266,7 @@ private:
 	int enqueues_ = 0;
 	int mostThreads_ = 0;
 
+	void MarkPendingReads(const Rasterizer::RasterizerState &state);
 	bool HasTextureWrite(const Rasterizer::RasterizerState &state);
 	BinCoords Scissor(BinCoords range);
 	BinCoords Range(const VertexData &v0, const VertexData &v1, const VertexData &v2);

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -787,8 +787,8 @@ void SoftGPU::Execute_BlockTransferStart(u32 op, u32 diff) {
 	const uint32_t dstSize = height * dstStride * bpp;
 
 	// Need to flush both source and target, so we overwrite properly.
-	drawEngine_->transformUnit.FlushIfOverlap("blockxfer", src, srcStride, width * bpp, height);
-	drawEngine_->transformUnit.FlushIfOverlap("blockxfer", dst, dstStride, width * bpp, height);
+	drawEngine_->transformUnit.FlushIfOverlap("blockxfer", false, src, srcStride, width * bpp, height);
+	drawEngine_->transformUnit.FlushIfOverlap("blockxfer", true, dst, dstStride, width * bpp, height);
 
 	DEBUG_LOG(G3D, "Block transfer: %08x/%x -> %08x/%x, %ix%ix%i (%i,%i)->(%i,%i)", srcBasePtr, srcStride, dstBasePtr, dstStride, width, height, bpp, srcX, srcY, dstX, dstY);
 
@@ -974,7 +974,7 @@ void SoftGPU::Execute_LoadClut(u32 op, u32 diff) {
 	u32 clutTotalBytes = gstate.getClutLoadBytes();
 
 	// Might be copying drawing into the CLUT, so flush.
-	drawEngine_->transformUnit.FlushIfOverlap("loadclut", clutAddr, clutTotalBytes, clutTotalBytes, 1);
+	drawEngine_->transformUnit.FlushIfOverlap("loadclut", false, clutAddr, clutTotalBytes, clutTotalBytes, 1);
 
 	bool changed = false;
 	if (Memory::IsValidAddress(clutAddr)) {

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -797,8 +797,10 @@ void TransformUnit::GetStats(char *buffer, size_t bufsize) {
 	binner_->GetStats(buffer, bufsize);
 }
 
-void TransformUnit::FlushIfOverlap(const char *reason, uint32_t addr, uint32_t stride, uint32_t w, uint32_t h) {
+void TransformUnit::FlushIfOverlap(const char *reason, bool modifying, uint32_t addr, uint32_t stride, uint32_t w, uint32_t h) {
 	if (binner_->HasPendingWrite(addr, stride, w, h))
+		Flush(reason);
+	if (modifying && binner_->HasPendingRead(addr, stride, w, h))
 		Flush(reason);
 }
 

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -123,7 +123,7 @@ public:
 	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices);
 
 	void Flush(const char *reason);
-	void FlushIfOverlap(const char *reason, uint32_t addr, uint32_t stride, uint32_t w, uint32_t h);
+	void FlushIfOverlap(const char *reason, bool modifying, uint32_t addr, uint32_t stride, uint32_t w, uint32_t h);
 	void NotifyClutUpdate(const void *src);
 
 	void GetStats(char *buffer, size_t bufsize);


### PR DESCRIPTION
Potentially could use these for self-render, but so far we should be detecting that so leaving it alone.

Should help #15802.  Doesn't seem to have a major perf impact, which I was worried about (all the texture read tracking.)

-[Unknown]