### PR TITLE
irjit: Validate alignment in slow memory mode

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -419,6 +419,7 @@ const char *MemoryExceptionTypeAsString(MemoryExceptionType type) {
 	case MemoryExceptionType::WRITE_WORD: return "Write Word";
 	case MemoryExceptionType::READ_BLOCK: return "Read Block";
 	case MemoryExceptionType::WRITE_BLOCK: return "Read/Write Block";
+	case MemoryExceptionType::ALIGNMENT: return "Alignment";
 	default:
 		return "N/A";
 	}

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -93,6 +93,7 @@ enum class MemoryExceptionType {
 	WRITE_WORD,
 	READ_BLOCK,
 	WRITE_BLOCK,
+	ALIGNMENT,
 };
 enum class ExecExceptionType {
 	JUMP,

--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -330,6 +330,8 @@ namespace MIPSComp {
 				ir.Write(IROp::LoadVec4, vregs[0], rs, ir.AddConstant(imm));
 			} else {
 				// Let's not even bother with "vertical" loads for now.
+				if (!g_Config.bFastMemory)
+					ir.Write({ IROp::ValidateAddress128, { 0 }, (u8)rs, 0, (u32)imm });
 				ir.Write(IROp::LoadFloat, vregs[0], rs, ir.AddConstant(imm));
 				ir.Write(IROp::LoadFloat, vregs[1], rs, ir.AddConstant(imm + 4));
 				ir.Write(IROp::LoadFloat, vregs[2], rs, ir.AddConstant(imm + 8));
@@ -342,6 +344,8 @@ namespace MIPSComp {
 				ir.Write(IROp::StoreVec4, vregs[0], rs, ir.AddConstant(imm));
 			} else {
 				// Let's not even bother with "vertical" stores for now.
+				if (!g_Config.bFastMemory)
+					ir.Write({ IROp::ValidateAddress128, { 0 }, (u8)rs, 1, (u32)imm });
 				ir.Write(IROp::StoreFloat, vregs[0], rs, ir.AddConstant(imm));
 				ir.Write(IROp::StoreFloat, vregs[1], rs, ir.AddConstant(imm + 4));
 				ir.Write(IROp::StoreFloat, vregs[2], rs, ir.AddConstant(imm + 8));

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -260,11 +260,11 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, u32 &m
 	IRWriter *code = &ir;
 	if (!js.hadBreakpoints) {
 		static const IRPassFunc passes[] = {
+			&ApplyMemoryValidation,
 			&RemoveLoadStoreLeftRight,
 			&OptimizeFPMoves,
 			&PropagateConstants,
 			&PurgeTemps,
-			&ApplyMemoryValidation,
 			// &ReorderLoadStore,
 			// &MergeLoadStore,
 			// &ThreeOpToTwoOp,

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -264,6 +264,7 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, u32 &m
 			&OptimizeFPMoves,
 			&PropagateConstants,
 			&PurgeTemps,
+			&ApplyMemoryValidation,
 			// &ReorderLoadStore,
 			// &MergeLoadStore,
 			// &ThreeOpToTwoOp,

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -163,6 +163,11 @@ static const IRMeta irMeta[] = {
 	{ IROp::Breakpoint, "Breakpoint", "", IRFLAG_EXIT },
 	{ IROp::MemoryCheck, "MemoryCheck", "_GC", IRFLAG_EXIT },
 
+	{ IROp::ValidateAddress8, "ValidAddr8", "_GC", IRFLAG_EXIT },
+	{ IROp::ValidateAddress16, "ValidAddr16", "_GC", IRFLAG_EXIT },
+	{ IROp::ValidateAddress32, "ValidAddr32", "_GC", IRFLAG_EXIT },
+	{ IROp::ValidateAddress128, "ValidAddr128", "_GC", IRFLAG_EXIT },
+
 	{ IROp::RestoreRoundingMode, "RestoreRoundingMode", "" },
 	{ IROp::ApplyRoundingMode, "ApplyRoundingMode", "" },
 	{ IROp::UpdateRoundingMode, "UpdateRoundingMode", "" },

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -213,8 +213,15 @@ enum class IROp : u8 {
 	SetPCConst,  // hack to make replacement know PC
 	CallReplacement,
 	Break,
+
+	// Debugging breakpoints.
 	Breakpoint,
 	MemoryCheck,
+
+	ValidateAddress8,
+	ValidateAddress16,
+	ValidateAddress32,
+	ValidateAddress128,
 };
 
 enum IRComparison {

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -79,6 +79,19 @@ u32 RunMemCheck(u32 pc, u32 addr) {
 	return coreState != CORE_RUNNING ? 1 : 0;
 }
 
+template <uint32_t alignment>
+u32 RunValidateAddress(u32 pc, u32 addr) {
+	if (!Memory::IsValidRange(addr, alignment)) {
+		Core_MemoryException(addr, pc, MemoryExceptionType::UNKNOWN);
+		return coreState != CORE_RUNNING ? 1 : 0;
+	}
+	if (alignment > 1 && (addr & (alignment - 1)) != 0) {
+		Core_MemoryException(addr, pc, MemoryExceptionType::UNKNOWN);
+		return coreState != CORE_RUNNING ? 1 : 0;
+	}
+	return 0;
+}
+
 // We cannot use NEON on ARM32 here until we make it a hard dependency. We can, however, on ARM64.
 u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 	const IRInst *end = inst + count;
@@ -140,6 +153,31 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 			break;
 		case IROp::ReverseBits:
 			mips->r[inst->dest] = ReverseBits32(mips->r[inst->src1]);
+			break;
+
+		case IROp::ValidateAddress8:
+			if (RunValidateAddress<1>(mips->pc, mips->r[inst->src1] + inst->constant)) {
+				CoreTiming::ForceCheck();
+				return mips->pc;
+			}
+		break;
+		case IROp::ValidateAddress16:
+			if (RunValidateAddress<2>(mips->pc, mips->r[inst->src1] + inst->constant)) {
+				CoreTiming::ForceCheck();
+				return mips->pc;
+			}
+			break;
+		case IROp::ValidateAddress32:
+			if (RunValidateAddress<4>(mips->pc, mips->r[inst->src1] + inst->constant)) {
+				CoreTiming::ForceCheck();
+				return mips->pc;
+			}
+			break;
+		case IROp::ValidateAddress128:
+			if (RunValidateAddress<16>(mips->pc, mips->r[inst->src1] + inst->constant)) {
+				CoreTiming::ForceCheck();
+				return mips->pc;
+			}
 			break;
 
 		case IROp::Load8:

--- a/Core/MIPS/IR/IRPassSimplify.h
+++ b/Core/MIPS/IR/IRPassSimplify.h
@@ -14,3 +14,4 @@ bool ThreeOpToTwoOp(const IRWriter &in, IRWriter &out, const IROptions &opts);
 bool OptimizeFPMoves(const IRWriter &in, IRWriter &out, const IROptions &opts);
 bool ReorderLoadStore(const IRWriter &in, IRWriter &out, const IROptions &opts);
 bool MergeLoadStore(const IRWriter &in, IRWriter &out, const IROptions &opts);
+bool ApplyMemoryValidation(const IRWriter &in, IRWriter &out, const IROptions &opts);


### PR DESCRIPTION
This adds checks for memory access (size and alignment) in irjit, dynamically as a separate op.  This makes it mostly free when off.

Essentially implements #7340, but IR only.  Doesn't actually force IR to recover from bad memory access, only makes it possible to show the exceptions if it would crash.

-[Unknown]