### PR TITLE
Core: Show exception on misaligned jump

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -487,16 +487,19 @@ void Core_ExecException(u32 address, u32 pc, ExecExceptionType type) {
 	e.exec_type = type;
 	e.address = address;
 	e.pc = pc;
-	Core_EnableStepping(true, "cpu.exception", pc);
+	// This just records the closest value that could be useful as reference.
+	e.ra = currentMIPS->r[MIPS_REG_RA];
+	Core_EnableStepping(true, "cpu.exception", address);
 }
 
-void Core_Break() {
+void Core_Break(u32 pc) {
 	ERROR_LOG(CPU, "BREAK!");
 
 	ExceptionInfo &e = g_exceptionInfo;
 	e = {};
 	e.type = ExceptionType::BREAK;
 	e.info = "";
+	e.pc = pc;
 
 	if (!g_Config.bIgnoreBadMemAccess) {
 		Core_EnableStepping(true, "cpu.breakInstruction", currentMIPS->pc);

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -106,7 +106,7 @@ void Core_MemoryException(u32 address, u32 pc, MemoryExceptionType type);
 void Core_MemoryExceptionInfo(u32 address, u32 pc, MemoryExceptionType type, std::string additionalInfo);
 
 void Core_ExecException(u32 address, u32 pc, ExecExceptionType type);
-void Core_Break();
+void Core_Break(u32 pc);
 // Call when loading save states, etc.
 void Core_ResetException();
 
@@ -125,6 +125,7 @@ struct ExceptionInfo {
 	MemoryExceptionType memory_type;
 	uint32_t pc;
 	uint32_t address;
+	uint32_t ra = 0;
 
 	// Reuses pc and address from memory type, where address is the failed destination.
 	ExecExceptionType exec_type;

--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -466,7 +466,7 @@ void ArmJit::Comp_Jump(MIPSOpcode op) {
 	u32 targetAddr = (GetCompilerPC() & 0xF0000000) | off;
 
 	// Might be a stubbed address or something?
-	if (!Memory::IsValidAddress(targetAddr)) {
+	if (!Memory::IsValidAddress(targetAddr) || (targetAddr & 3) != 0) {
 		if (js.nextExit == 0) {
 			ERROR_LOG_REPORT(JIT, "Jump to invalid address: %08x", targetAddr);
 		} else {

--- a/Core/MIPS/ARM64/Arm64CompBranch.cpp
+++ b/Core/MIPS/ARM64/Arm64CompBranch.cpp
@@ -481,7 +481,7 @@ void Arm64Jit::Comp_Jump(MIPSOpcode op) {
 	u32 targetAddr = (GetCompilerPC() & 0xF0000000) | off;
 
 	// Might be a stubbed address or something?
-	if (!Memory::IsValidAddress(targetAddr)) {
+	if (!Memory::IsValidAddress(targetAddr) || (targetAddr & 3) != 0) {
 		if (js.nextExit == 0) {
 			ERROR_LOG_REPORT(JIT, "Jump to invalid address: %08x", targetAddr);
 		} else {

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -998,7 +998,7 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 		}
 
 		case IROp::Break:
-			Core_Break();
+			Core_Break(mips->pc);
 			return mips->pc + 4;
 
 		case IROp::SetCtrlVFPU:

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -227,9 +227,10 @@ void IRJit::RunLoopUntil(u64 globalticks) {
 			if (opcode == MIPS_EMUHACK_OPCODE) {
 				u32 data = inst & 0xFFFFFF;
 				IRBlock *block = blocks_.GetBlock(data);
+				u32 startPC = mips_->pc;
 				mips_->pc = IRInterpret(mips_, block->GetInstructions(), block->GetNumInstructions());
-				if (!Memory::IsValidAddress(mips_->pc)) {
-					Core_ExecException(mips_->pc, mips_->pc, ExecExceptionType::JUMP);
+				if (!Memory::IsValidAddress(mips_->pc) || (mips_->pc & 3) != 0) {
+					Core_ExecException(mips_->pc, startPC, ExecExceptionType::JUMP);
 					break;
 				}
 			} else {

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -57,8 +57,7 @@
 
 static inline void DelayBranchTo(u32 where)
 {
-	if (!Memory::IsValidAddress(where)) {
-		// TODO: What about misaligned?
+	if (!Memory::IsValidAddress(where) || (where & 3) != 0) {
 		Core_ExecException(where, PC, ExecExceptionType::JUMP);
 	}
 	PC += 4;

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -157,7 +157,7 @@ namespace MIPSInt
 	void Int_Break(MIPSOpcode op)
 	{
 		Reporting::ReportMessage("BREAK instruction hit");
-		Core_Break();
+		Core_Break(PC);
 		PC += 4;
 	}
 

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -612,7 +612,7 @@ void Jit::Comp_Jump(MIPSOpcode op) {
 	u32 targetAddr = (GetCompilerPC() & 0xF0000000) | off;
 
 	// Might be a stubbed address or something?
-	if (!Memory::IsValidAddress(targetAddr)) {
+	if (!Memory::IsValidAddress(targetAddr) || (targetAddr & 3) != 0) {
 		if (js.nextExit == 0) {
 			ERROR_LOG_REPORT(JIT, "Jump to invalid address: %08x PC %08x LR %08x", targetAddr, GetCompilerPC(), currentMIPS->r[MIPS_REG_RA]);
 		} else {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1209,16 +1209,25 @@ PC: %08x
 	} else if (info.type == ExceptionType::BAD_EXEC_ADDR) {
 		snprintf(statbuf, sizeof(statbuf), R"(
 Destination: %s to %08x
-PC: %08x)",
+PC: %08x
+RA: %08x)",
 			ExecExceptionTypeAsString(info.exec_type),
 			info.address,
-			info.pc);
+			info.pc,
+			info.ra);
+		ctx->Draw()->DrawTextShadow(ubuntu24, statbuf, x, y, 0xFFFFFFFF);
+		y += 180;
+	} else if (info.type == ExceptionType::BREAK) {
+		snprintf(statbuf, sizeof(statbuf), R"(
+BREAK
+PC: %08x
+)", info.pc);
 		ctx->Draw()->DrawTextShadow(ubuntu24, statbuf, x, y, 0xFFFFFFFF);
 		y += 180;
 	} else {
 		snprintf(statbuf, sizeof(statbuf), R"(
-BREAK
-)");
+Invalid / Unknown (%d)
+)", (int)info.type);
 		ctx->Draw()->DrawTextShadow(ubuntu24, statbuf, x, y, 0xFFFFFFFF);
 		y += 180;
 	}


### PR DESCRIPTION
Along with #15879, I also just realized that the same goes for CPU jumps.  Might as well just always validate alignment for those.

This also shows an RA when there's a bad jump.  I'm too often seeing from/to PC being VRAM and the same value in screenshots, so I'm hoping this helps give more context on the errors.

-[Unknown]