### PR TITLE
Headless: Fix comparison for oversized buffers

### DIFF
--- a/headless/Compare.cpp
+++ b/headless/Compare.cpp
@@ -326,7 +326,7 @@ std::vector<u32> TranslateDebugBufferToCompare(const GPUDebugBuffer *buffer, u32
 	int outStride = buffer->GetStride();
 	if (!buffer->GetFlipped()) {
 		// Bitmaps are flipped, so we have to compare backwards in this case.
-		int toLastRow = outStride * (buffer->GetHeight() - 1);
+		int toLastRow = outStride * (h > buffer->GetHeight() ? buffer->GetHeight() - 1 : h - 1);
 		pixels32 += toLastRow;
 		pixels16 += toLastRow;
 		outStride = -outStride;

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -416,6 +416,7 @@ int main(int argc, const char* argv[])
 	g_Config.bEnableLogging = fullLog;
 	g_Config.bSoftwareSkinning = true;
 	g_Config.bVertexDecoderJit = true;
+	g_Config.bSoftwareRendering = coreParameter.gpuCore == GPUCORE_SOFTWARE;
 	g_Config.bSoftwareRenderingJit = true;
 	g_Config.bBlockTransferGPU = true;
 	g_Config.iSplineBezierQuality = 2;


### PR DESCRIPTION
Should've thought about this harder with #15286.  Example frame dump in #15878.

-[Unknown]