### PR TITLE
Correct D3D viewport offset sign in sw transform

### DIFF
--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -623,7 +623,7 @@ rotateVBO:
 		int maxIndex = indexGen.MaxIndex();
 		SoftwareTransform swTransform(params);
 
-		const Lin::Vec3 trans(gstate_c.vpXOffset, gstate_c.vpYOffset, gstate_c.vpZOffset * 0.5f + 0.5f);
+		const Lin::Vec3 trans(gstate_c.vpXOffset, -gstate_c.vpYOffset, gstate_c.vpZOffset * 0.5f + 0.5f);
 		const Lin::Vec3 scale(gstate_c.vpWidthScale, -gstate_c.vpHeightScale, gstate_c.vpDepthScale * 0.5f);
 		swTransform.SetProjMatrix(gstate.projMatrix, gstate_c.vpWidth < 0, gstate_c.vpHeight < 0, trans, scale);
 

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -589,12 +589,10 @@ rotateVBO:
 		SoftwareTransform swTransform(params);
 
 		// Half pixel offset hack.
-		float xScale = gstate_c.vpWidth < 0 ? -1.0f : 1.0f;
 		float xOffset = -1.0f / gstate_c.curRTRenderWidth;
-		float yScale = gstate_c.vpHeight > 0 ? -1.0f : 1.0f;
 		float yOffset = 1.0f / gstate_c.curRTRenderHeight;
 
-		const Lin::Vec3 trans(gstate_c.vpXOffset * xScale + xOffset, gstate_c.vpYOffset * yScale + yOffset, gstate_c.vpZOffset * 0.5f + 0.5f);
+		const Lin::Vec3 trans(gstate_c.vpXOffset + xOffset, -gstate_c.vpYOffset + yOffset, gstate_c.vpZOffset * 0.5f + 0.5f);
 		const Lin::Vec3 scale(gstate_c.vpWidthScale, gstate_c.vpHeightScale, gstate_c.vpDepthScale * 0.5f);
 		swTransform.SetProjMatrix(gstate.projMatrix, gstate_c.vpWidth < 0, gstate_c.vpHeight > 0, trans, scale);
 


### PR DESCRIPTION
D3D11 was simply wrong in 159eab51419347dd4328f8c700aaef00397ff6d7.  And I must've gotten the other from the various invertedX/invertedY logic in D3D9, but I don't see why it wouldn't be the same as D3D11.  This fixes #15767.

-[Unknown]