### PR TITLE
GPU: Correct Draw2D::DeviceRestore()

### DIFF
--- a/GPU/Common/Draw2D.cpp
+++ b/GPU/Common/Draw2D.cpp
@@ -144,10 +144,11 @@ void Draw2D::DeviceLost() {
 	DoRelease(draw2DVs_);
 	DoRelease(draw2DSamplerLinear_);
 	DoRelease(draw2DSamplerNearest_);
+	draw_ = nullptr;
 }
 
 void Draw2D::DeviceRestore(Draw::DrawContext *draw) {
-
+	draw_ = draw;
 }
 
 void Draw2D::Ensure2DResources() {

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2437,7 +2437,7 @@ void FramebufferManagerCommon::DeviceLost() {
 void FramebufferManagerCommon::DeviceRestore(Draw::DrawContext *draw) {
 	draw_ = draw;
 	draw2D_.DeviceRestore(draw_);
-	presentation_->DeviceRestore(draw);
+	presentation_->DeviceRestore(draw_);
 }
 
 void FramebufferManagerCommon::DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags) {

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -393,6 +393,7 @@ void PresentationCommon::ShowPostShaderError(const std::string &errorString) {
 
 void PresentationCommon::DeviceLost() {
 	DestroyDeviceObjects();
+	draw_ = nullptr;
 }
 
 void PresentationCommon::DeviceRestore(Draw::DrawContext *draw) {

--- a/GPU/Common/TextureShaderCommon.cpp
+++ b/GPU/Common/TextureShaderCommon.cpp
@@ -50,6 +50,7 @@ void TextureShaderCache::DeviceRestore(Draw::DrawContext *draw) {
 
 void TextureShaderCache::DeviceLost() {
 	Clear();
+	draw_ = nullptr;
 }
 
 ClutTexture TextureShaderCache::GetClutTexture(GEPaletteFormat clutFormat, const u32 clutHash, u32 *rawClut) {

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -91,6 +91,8 @@ DrawEngineGLES::~DrawEngineGLES() {
 
 void DrawEngineGLES::DeviceLost() {
 	DestroyDeviceObjects();
+	draw_ = nullptr;
+	render_ = nullptr;
 }
 
 void DrawEngineGLES::DeviceRestore(Draw::DrawContext *draw) {

--- a/GPU/GLES/FragmentTestCacheGLES.h
+++ b/GPU/GLES/FragmentTestCacheGLES.h
@@ -69,6 +69,7 @@ public:
 
 	void DeviceLost() {
 		Clear(false);
+		render_ = nullptr;
 	}
 	void DeviceRestore(Draw::DrawContext *draw);
 	void Clear(bool deleteThem = true);

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -620,6 +620,8 @@ void ShaderManagerGLES::ClearCache(bool deleteThem) {
 
 void ShaderManagerGLES::DeviceLost() {
 	Clear();
+	render_ = nullptr;
+	draw_ = nullptr;
 }
 
 void ShaderManagerGLES::DeviceRestore(Draw::DrawContext *draw) {

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -534,7 +534,7 @@ void GPU_Vulkan::DeviceLost() {
 	drawEngine_.DeviceLost();
 	pipelineManager_->DeviceLost();
 	textureCacheVulkan_->DeviceLost();
-	shaderManagerVulkan_->ClearShaders();
+	shaderManagerVulkan_->DeviceLost();
 
 	GPUCommon::DeviceLost();
 }

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -26,6 +26,7 @@ PipelineManagerVulkan::~PipelineManagerVulkan() {
 	Clear();
 	if (pipelineCache_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeletePipelineCache(pipelineCache_);
+	vulkan_ = nullptr;
 }
 
 void PipelineManagerVulkan::Clear() {
@@ -55,6 +56,7 @@ void PipelineManagerVulkan::DeviceLost() {
 	Clear();
 	if (pipelineCache_ != VK_NULL_HANDLE)
 		vulkan_->Delete().QueueDeletePipelineCache(pipelineCache_);
+	vulkan_ = nullptr;
 }
 
 void PipelineManagerVulkan::DeviceRestore(VulkanContext *vulkan) {

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -160,6 +160,10 @@ ShaderManagerVulkan::~ShaderManagerVulkan() {
 	delete[] codeBuffer_;
 }
 
+void ShaderManagerVulkan::DeviceLost() {
+	draw_ = nullptr;
+}
+
 void ShaderManagerVulkan::DeviceRestore(Draw::DrawContext *draw) {
 	VulkanContext *vulkan = (VulkanContext *)draw->GetNativeObject(Draw::NativeObject::CONTEXT);
 	draw_ = draw;

--- a/GPU/Vulkan/ShaderManagerVulkan.h
+++ b/GPU/Vulkan/ShaderManagerVulkan.h
@@ -86,6 +86,7 @@ public:
 	ShaderManagerVulkan(Draw::DrawContext *draw);
 	~ShaderManagerVulkan();
 
+	void DeviceLost();
 	void DeviceRestore(Draw::DrawContext *draw);
 
 	void GetShaders(int prim, u32 vertType, VulkanVertexShader **vshader, VulkanFragmentShader **fshader, bool useHWTransform, bool useHWTessellation, bool weightsAsFloat);

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -168,6 +168,7 @@ void SamplerCache::DeviceLost() {
 		vulkan_->Delete().QueueDeleteSampler(sampler);
 	});
 	cache_.Clear();
+	vulkan_ = nullptr;
 }
 
 void SamplerCache::DeviceRestore(VulkanContext *vulkan) {


### PR DESCRIPTION
See #15891.  While there, clear more `draw_` pointers in `DeviceLost()`, which I think is better.

In some ways, maybe we should AddRef/Release draw_, and assert that it went down to zero after Lost.  But that'd be a bigger change and probably not necessary.

-[Unknown]