### PR TITLE
Detect framebuffers that live in the "stride gap" of others, fix size

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -225,15 +225,17 @@ void FramebufferManagerCommon::EstimateDrawingSize(u32 fb_address, int fb_stride
 		if (fb_address > vfb->fb_address && fb_address < vfb->fb_address + vfb_stride_in_bytes) {
 			// Candidate!
 			if (vfb->height == drawing_height) {
-				// Definitely got a margin texture! Fix the drawing width.
+				// Might have a margin texture! Fix the drawing width if it's too large.
 				int width_in_bytes = vfb->fb_address + vfb_stride_in_bytes - fb_address;
 				int width_in_pixels = width_in_bytes / BufferFormatBytesPerPixel(fb_format);
 
-				drawing_width = width_in_pixels;
-				margin = true;
-
-				// Don't really need to keep looking.
-				break;
+				// Final check
+				if (width_in_pixels <= 32) {
+					drawing_width = std::min(drawing_width, width_in_pixels);
+					margin = true;
+					// Don't really need to keep looking.
+					break;
+				}
 			}
 		}
 	}

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -363,7 +363,6 @@ public:
 	const std::vector<VirtualFramebuffer *> &Framebuffers() const {
 		return vfbs_;
 	}
-	void ReinterpretFramebuffer(VirtualFramebuffer *vfb, GEBufferFormat oldFormat, GEBufferFormat newFormat);
 
 	Draw2D *GetDraw2D() {
 		return &draw2D_;

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -398,7 +398,7 @@ protected:
 
 	void CopyFramebufferForColorTexture(VirtualFramebuffer *dst, VirtualFramebuffer *src, int flags);
 
-	void EstimateDrawingSize(u32 fb_address, GEBufferFormat fb_format, int viewport_width, int viewport_height, int region_width, int region_height, int scissor_width, int scissor_height, int fb_stride, int &drawing_width, int &drawing_height);
+	void EstimateDrawingSize(u32 fb_address, int fb_stride, GEBufferFormat fb_format, int viewport_width, int viewport_height, int region_width, int region_height, int scissor_width, int scissor_height, int &drawing_width, int &drawing_height);
 	u32 ColorBufferByteSize(const VirtualFramebuffer *vfb) const;
 
 	void NotifyRenderFramebufferCreated(VirtualFramebuffer *vfb);


### PR DESCRIPTION
Some games, including the ones mentioned in #15898, place a small buffer in the vertical gap, created between a 480px wide main framebuffer, and a stride of 512 pixels. For some reason 512 is regarded as a better stride than 480, so many games size their buffers that way, leaving the gap.

This detects such buffers in a pretty safe and strict way, and make sure that their drawing_width is set accordingly, leading to less memory use and a slightly more sane debugging experience.

This does not solve #15898, but is a small, separate step on the way so let's get it in for testing.