### PR TITLE
Block transfer code refactor

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1531,6 +1531,8 @@ bool FramebufferManagerCommon::NotifyFramebufferCopy(u32 src, u32 dst, int size,
 	dst &= 0x3FFFFFFF;
 	src &= 0x3FFFFFFF;
 
+	// TODO: Merge the below into FindTransferFramebuffer
+
 	VirtualFramebuffer *dstBuffer = 0;
 	VirtualFramebuffer *srcBuffer = 0;
 	u32 dstY = (u32)-1;
@@ -1670,6 +1672,7 @@ void FramebufferManagerCommon::FindTransferFramebuffer(VirtualFramebuffer *&buff
 			bool match = memYOffset < yOffset && (int)memYOffset <= (int)vfb->bufferHeight - height;
 			if (match && vfb_byteStride != byteStride) {
 				// Grand Knights History copies with a mismatching stride but a full line at a time.
+				// That's why we multiply by height, not width - this copy is a rectangle with the wrong stride but a line with the correct one.
 				// Makes it hard to detect the wrong transfers in e.g. God of War.
 				if (transferWidth != stride || (byteStride * transferHeight != vfb_byteStride && byteStride * transferHeight != vfb_byteWidth)) {
 					if (destination) {

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1664,6 +1664,9 @@ void FramebufferManagerCommon::FindTransferFramebuffer(VirtualFramebuffer *&buff
 			// Some games use mismatching bitdepths. But make sure the stride matches.
 			// If it doesn't, generally this means we detected the framebuffer with too large a height.
 			// Use bufferHeight in case of buffers that resize up and down often per frame (Valkyrie Profile.)
+
+			// TODO: Surely this first comparison should be <= ?
+			// Or does the exact match (byteOffset == 0) case get handled elsewhere?
 			bool match = memYOffset < yOffset && (int)memYOffset <= (int)vfb->bufferHeight - height;
 			if (match && vfb_byteStride != byteStride) {
 				// Grand Knights History copies with a mismatching stride but a full line at a time.
@@ -1902,7 +1905,7 @@ bool FramebufferManagerCommon::NotifyBlockTransferBefore(u32 dstBasePtr, int dst
 	int dstWidth = width;
 	int dstHeight = height;
 
-	// This looks at the compat flags BlockTransferAllowCreateFB*.
+	// These modify the X/Y/W/H parameters depending on the memory offset of the base pointers from the actual buffers.
 	FindTransferFramebuffer(srcBuffer, srcBasePtr, srcStride, srcX, srcY, srcWidth, srcHeight, bpp, false);
 	FindTransferFramebuffer(dstBuffer, dstBasePtr, dstStride, dstX, dstY, dstWidth, dstHeight, bpp, true);
 

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1641,8 +1641,8 @@ bool FramebufferManagerCommon::NotifyFramebufferCopy(u32 src, u32 dst, int size,
 }
 
 void FramebufferManagerCommon::FindTransferFramebufferSrc(VirtualFramebuffer *&srcBuffer, u32 basePtr, int stride, int &x, int &y, int &width, int &height, int bpp) {
-	u32 srcYOffset = -1;
-	u32 srcXOffset = -1;
+	u32 yOffset = -1;
+	u32 xOffset = -1;
 	int transferWidth = width;
 	int transferHeight = height;
 
@@ -1659,8 +1659,8 @@ void FramebufferManagerCommon::FindTransferFramebufferSrc(VirtualFramebuffer *&s
 		if (vfb_address <= basePtr && basePtr < vfb_address + vfb_size) {
 			const u32 byteOffset = basePtr - vfb_address;
 			const u32 byteStride = stride * bpp;
-			const u32 yOffset = byteOffset / byteStride;
-			bool match = yOffset < srcYOffset && (int)yOffset <= (int)vfb->bufferHeight - height;
+			const u32 memYOffset = byteOffset / byteStride;
+			bool match = memYOffset < yOffset && (int)memYOffset <= (int)vfb->bufferHeight - height;
 			if (match && vfb_byteStride != byteStride) {
 				if (transferWidth != stride || (byteStride * transferHeight != vfb_byteStride && byteStride * transferHeight != vfb_byteWidth)) {
 					match = false;
@@ -1673,22 +1673,22 @@ void FramebufferManagerCommon::FindTransferFramebufferSrc(VirtualFramebuffer *&s
 				height = transferHeight;
 			}
 			if (match) {
-				srcYOffset = yOffset;
-				srcXOffset = stride == 0 ? 0 : (byteOffset / bpp) % stride;
+				yOffset = memYOffset;
+				xOffset = stride == 0 ? 0 : (byteOffset / bpp) % stride;
 				srcBuffer = vfb;
 			}
 		}
 	}
 
-	if (srcYOffset != (u32)-1) {
-		y += srcYOffset;
-		x += srcXOffset;
+	if (yOffset != (u32)-1) {
+		y += yOffset;
+		x += xOffset;
 	}
 }
 
 void FramebufferManagerCommon::FindTransferFramebufferDst(VirtualFramebuffer *&dstBuffer, u32 basePtr, int stride, int &x, int &y, int &width, int &height, int bpp) {
-	u32 dstYOffset = -1;
-	u32 dstXOffset = -1;
+	u32 yOffset = -1;
+	u32 xOffset = -1;
 	int transferWidth = width;
 	int transferHeight = height;
 
@@ -1709,12 +1709,12 @@ void FramebufferManagerCommon::FindTransferFramebufferDst(VirtualFramebuffer *&d
 		if (vfb_address <= basePtr && basePtr < vfb_address + vfb_size) {
 			const u32 byteOffset = basePtr - vfb_address;
 			const u32 byteStride = stride * bpp;
-			const u32 yOffset = byteOffset / byteStride;
+			const u32 memYOffset = byteOffset / byteStride;
 
 			// Some games use mismatching bitdepths. But make sure the stride matches.
 			// If it doesn't, generally this means we detected the framebuffer with too large a height.
 			// Use bufferHeight in case of buffers that resize up and down often per frame (Valkyrie Profile.)
-			bool match = yOffset < dstYOffset && (int)yOffset <= (int)vfb->bufferHeight - height;
+			bool match = memYOffset < yOffset && (int)memYOffset <= (int)vfb->bufferHeight - height;
 			if (match && vfb_byteStride != byteStride) {
 				// Grand Knights History copies with a mismatching stride but a full line at a time.
 				// Makes it hard to detect the wrong transfers in e.g. God of War.
@@ -1735,16 +1735,16 @@ void FramebufferManagerCommon::FindTransferFramebufferDst(VirtualFramebuffer *&d
 				height = transferHeight;
 			}
 			if (match) {
-				dstYOffset = yOffset;
-				dstXOffset = stride == 0 ? 0 : (byteOffset / bpp) % stride;
+				yOffset = memYOffset;
+				xOffset = stride == 0 ? 0 : (byteOffset / bpp) % stride;
 				dstBuffer = vfb;
 			}
 		}
 	}
 
-	if (dstYOffset != (u32)-1) {
-		y += dstYOffset;
-		x += dstXOffset;
+	if (yOffset != (u32)-1) {
+		y += yOffset;
+		x += xOffset;
 	}
 }
 

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -275,10 +275,15 @@ public:
 	void UpdateFromMemory(u32 addr, int size, bool safe);
 	void ApplyClearToMemory(int x1, int y1, int x2, int y2, u32 clearColor);
 	bool PerformStencilUpload(u32 addr, int size, StencilUpload flags);
+
 	// Returns true if it's sure this is a direct FBO->FBO transfer and it has already handle it.
 	// In that case we hardly need to actually copy the bytes in VRAM, they will be wrong anyway (unless
 	// read framebuffers is on, in which case this should always return false).
+	// If this returns false, a memory copy will happen and NotifyBlockTransferAfter will be called.
 	bool NotifyBlockTransferBefore(u32 dstBasePtr, int dstStride, int dstX, int dstY, u32 srcBasePtr, int srcStride, int srcX, int srcY, int w, int h, int bpp, u32 skipDrawReason);
+
+	// This gets called after the memory copy, in case NotifyBlockTransferBefore returned false.
+	// Otherwise it doesn't get called.
 	void NotifyBlockTransferAfter(u32 dstBasePtr, int dstStride, int dstX, int dstY, u32 srcBasePtr, int srcStride, int srcX, int srcY, int w, int h, int bpp, u32 skipDrawReason);
 
 	bool BindFramebufferAsColorTexture(int stage, VirtualFramebuffer *framebuffer, int flags);

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -412,7 +412,10 @@ protected:
 
 	bool ShouldDownloadFramebuffer(const VirtualFramebuffer *vfb) const;
 	void DownloadFramebufferOnSwitch(VirtualFramebuffer *vfb);
-	void FindTransferFramebuffers(VirtualFramebuffer *&dstBuffer, VirtualFramebuffer *&srcBuffer, u32 dstBasePtr, int dstStride, int &dstX, int &dstY, u32 srcBasePtr, int srcStride, int &srcX, int &srcY, int &srcWidth, int &srcHeight, int &dstWidth, int &dstHeight, int bpp);
+
+	void FindTransferFramebufferSrc(VirtualFramebuffer *&srcBuffer, u32 srcBasePtr, int srcStride, int &srcX, int &srcY, int &srcWidth, int &srcHeight, int bpp);
+	void FindTransferFramebufferDst(VirtualFramebuffer *&dstBuffer, u32 dstBasePtr, int dstStride, int &dstX, int &dstY, int &dstWidth, int &dstHeight, int bpp);
+
 	VirtualFramebuffer *FindDownloadTempBuffer(VirtualFramebuffer *vfb);
 	virtual void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) {}
 

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -413,8 +413,7 @@ protected:
 	bool ShouldDownloadFramebuffer(const VirtualFramebuffer *vfb) const;
 	void DownloadFramebufferOnSwitch(VirtualFramebuffer *vfb);
 
-	void FindTransferFramebufferSrc(VirtualFramebuffer *&srcBuffer, u32 srcBasePtr, int srcStride, int &srcX, int &srcY, int &srcWidth, int &srcHeight, int bpp);
-	void FindTransferFramebufferDst(VirtualFramebuffer *&dstBuffer, u32 dstBasePtr, int dstStride, int &dstX, int &dstY, int &dstWidth, int &dstHeight, int bpp);
+	void FindTransferFramebuffer(VirtualFramebuffer *&srcBuffer, u32 srcBasePtr, int srcStride, int &srcX, int &srcY, int &srcWidth, int &srcHeight, int bpp, bool destination);
 
 	VirtualFramebuffer *FindDownloadTempBuffer(VirtualFramebuffer *vfb);
 	virtual void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) {}

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2773,15 +2773,6 @@ void GPUCommon::SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat f
 }
 
 void GPUCommon::DoBlockTransfer(u32 skipDrawReason) {
-	// TODO: This is used a lot to copy data around between render targets and textures,
-	// and also to quickly load textures from RAM to VRAM. So we should do checks like the following:
-	//  * Does dstBasePtr point to an existing texture? If so maybe reload it immediately.
-	//
-	//  * Does srcBasePtr point to a render target, and dstBasePtr to a texture? If so
-	//    either copy between rt and texture or reassign the texture to point to the render target
-	//
-	// etc....
-
 	u32 srcBasePtr = gstate.getTransferSrcAddress();
 	u32 srcStride = gstate.getTransferSrcStride();
 


### PR DESCRIPTION
Splits up FindTransferFrameBuffers (which had internal duplication), and then merges the two parts back again into one function, called twice.

Nothing should change, except that the code gets a bit easier to improve in the next PR.

Some comments are also brought up-to-date.