### PR TITLE
Add LI and compressed instructions for RISC-V

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2348,6 +2348,7 @@ if(UNITTEST)
 		unittest/TestIRPassSimplify.cpp
 		unittest/TestX64Emitter.cpp
 		unittest/TestVertexJit.cpp
+		unittest/TestRiscVEmitter.cpp
 		unittest/TestSoftwareGPUJit.cpp
 		unittest/TestThreadManager.cpp
 		unittest/JitHarness.cpp

--- a/Common/RiscVEmitter.cpp
+++ b/Common/RiscVEmitter.cpp
@@ -873,13 +873,21 @@ void RiscVEmitter::SD(RiscVReg rs2, RiscVReg rs1, s32 simm12) {
 }
 
 void RiscVEmitter::ADDIW(RiscVReg rd, RiscVReg rs1, s32 simm12) {
-	_assert_msg_(BitsSupported() >= 64, "%s is only valid with R64I", __func__);
+	if (BitsSupported() == 32) {
+		ADDI(rd, rs1, simm12);
+		return;
+	}
+
 	_assert_msg_(rd != R_ZERO, "%s write to zero is a HINT", __func__);
 	Write32(EncodeGI(Opcode32::OP_IMM_32, rd, Funct3::ADD, rs1, simm12));
 }
 
 void RiscVEmitter::SLLIW(RiscVReg rd, RiscVReg rs1, u32 shamt) {
-	_assert_msg_(BitsSupported() >= 64, "%s is only valid with R64I", __func__);
+	if (BitsSupported() == 32) {
+		SLLI(rd, rs1, shamt);
+		return;
+	}
+
 	_assert_msg_(rd != R_ZERO, "%s write to zero is a HINT", __func__);
 	// Not sure if shamt=0 is legal or not, let's play it safe.
 	_assert_msg_(shamt > 0 && shamt < 32, "Shift out of range");
@@ -887,7 +895,11 @@ void RiscVEmitter::SLLIW(RiscVReg rd, RiscVReg rs1, u32 shamt) {
 }
 
 void RiscVEmitter::SRLIW(RiscVReg rd, RiscVReg rs1, u32 shamt) {
-	_assert_msg_(BitsSupported() >= 64, "%s is only valid with R64I", __func__);
+	if (BitsSupported() == 32) {
+		SRLI(rd, rs1, shamt);
+		return;
+	}
+
 	_assert_msg_(rd != R_ZERO, "%s write to zero is a HINT", __func__);
 	// Not sure if shamt=0 is legal or not, let's play it safe.
 	_assert_msg_(shamt > 0 && shamt < 32, "Shift out of range");
@@ -895,7 +907,11 @@ void RiscVEmitter::SRLIW(RiscVReg rd, RiscVReg rs1, u32 shamt) {
 }
 
 void RiscVEmitter::SRAIW(RiscVReg rd, RiscVReg rs1, u32 shamt) {
-	_assert_msg_(BitsSupported() >= 64, "%s is only valid with R64I", __func__);
+	if (BitsSupported() == 32) {
+		SRAI(rd, rs1, shamt);
+		return;
+	}
+
 	_assert_msg_(rd != R_ZERO, "%s write to zero is a HINT", __func__);
 	// Not sure if shamt=0 is legal or not, let's play it safe.
 	_assert_msg_(shamt > 0 && shamt < 32, "Shift out of range");
@@ -903,31 +919,51 @@ void RiscVEmitter::SRAIW(RiscVReg rd, RiscVReg rs1, u32 shamt) {
 }
 
 void RiscVEmitter::ADDW(RiscVReg rd, RiscVReg rs1, RiscVReg rs2) {
-	_assert_msg_(BitsSupported() >= 64, "%s is only valid with R64I", __func__);
+	if (BitsSupported() == 32) {
+		ADD(rd, rs1, rs2);
+		return;
+	}
+
 	_assert_msg_(rd != R_ZERO, "%s write to zero is a HINT", __func__);
 	Write32(EncodeGR(Opcode32::OP_32, rd, Funct3::ADD, rs1, rs2, Funct7::ZERO));
 }
 
 void RiscVEmitter::SUBW(RiscVReg rd, RiscVReg rs1, RiscVReg rs2) {
-	_assert_msg_(BitsSupported() >= 64, "%s is only valid with R64I", __func__);
+	if (BitsSupported() == 32) {
+		SUB(rd, rs1, rs2);
+		return;
+	}
+
 	_assert_msg_(rd != R_ZERO, "%s write to zero is a HINT", __func__);
 	Write32(EncodeGR(Opcode32::OP_32, rd, Funct3::ADD, rs1, rs2, Funct7::SUB));
 }
 
 void RiscVEmitter::SLLW(RiscVReg rd, RiscVReg rs1, RiscVReg rs2) {
-	_assert_msg_(BitsSupported() >= 64, "%s is only valid with R64I", __func__);
+	if (BitsSupported() == 32) {
+		SLL(rd, rs1, rs2);
+		return;
+	}
+
 	_assert_msg_(rd != R_ZERO, "%s write to zero is a HINT", __func__);
 	Write32(EncodeGR(Opcode32::OP_32, rd, Funct3::SLL, rs1, rs2, Funct7::ZERO));
 }
 
 void RiscVEmitter::SRLW(RiscVReg rd, RiscVReg rs1, RiscVReg rs2) {
-	_assert_msg_(BitsSupported() >= 64, "%s is only valid with R64I", __func__);
+	if (BitsSupported() == 32) {
+		SRL(rd, rs1, rs2);
+		return;
+	}
+
 	_assert_msg_(rd != R_ZERO, "%s write to zero is a HINT", __func__);
 	Write32(EncodeGR(Opcode32::OP_32, rd, Funct3::SRL, rs1, rs2, Funct7::ZERO));
 }
 
 void RiscVEmitter::SRAW(RiscVReg rd, RiscVReg rs1, RiscVReg rs2) {
-	_assert_msg_(BitsSupported() >= 64, "%s is only valid with R64I", __func__);
+	if (BitsSupported() == 32) {
+		SRA(rd, rs1, rs2);
+		return;
+	}
+
 	_assert_msg_(rd != R_ZERO, "%s write to zero is a HINT", __func__);
 	Write32(EncodeGR(Opcode32::OP_32, rd, Funct3::SRL, rs1, rs2, Funct7::SRA));
 }

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -721,11 +721,13 @@ ifeq ($(UNITTEST),1)
     TESTARMEMITTER_FILE = \
       $(SRC)/Common/ArmEmitter.cpp \
       $(SRC)/Common/Arm64Emitter.cpp \
+      $(SRC)/Common/RiscVEmitter.cpp \
       $(SRC)/Core/MIPS/ARM/ArmRegCacheFPU.cpp \
       $(SRC)/Core/Util/DisArm64.cpp \
       $(SRC)/ext/disarm.cpp \
       $(SRC)/unittest/TestArmEmitter.cpp \
       $(SRC)/unittest/TestArm64Emitter.cpp \
+      $(SRC)/unittest/TestRiscVEmitter.cpp \
       $(SRC)/unittest/TestX64Emitter.cpp
   endif
 

--- a/unittest/TestRiscVEmitter.cpp
+++ b/unittest/TestRiscVEmitter.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2022- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include <cstdio>
+#include "Common/CPUDetect.h"
+#include "Common/RiscVEmitter.h"
+#include "UnitTest.h"
+
+bool TestRiscVEmitter() {
+	using namespace RiscVGen;
+
+	// TODO: Set cpu_info flags.
+
+	u32 code[1024];
+	RiscVEmitter emitter((u8 *)code, (u8 *)code);
+
+	emitter.SetAutoCompress(false);
+	emitter.LUI(X1, 0xFFFFF000);
+	emitter.AUIPC(X2, 0x70051000);
+	emitter.JAL(X3, code);
+	emitter.JALR(X1, X2, -12);
+	FixupBranch b1 = emitter.JAL(X4);
+	emitter.SetJumpTarget(b1);
+	emitter.BEQ(X5, X6, code);
+	emitter.LB(X7, X8, 42);
+	emitter.SB(X9, X10, 1337);
+	emitter.ADDI(X11, X12, 42);
+	emitter.SLLI(X13, X14, 3);
+	emitter.ADD(X15, X16, X17);
+	emitter.FENCE(Fence::RW, Fence::RW);
+
+	static constexpr uint32_t expected[] = {
+		0xfffff0b7,
+		0x70051117,
+		0xff9ff1ef,
+		0xff4100e7,
+		0x0040026f,
+		0xfe6286e3,
+		0x02a40383,
+		0x52950ca3,
+		0x02a60593,
+		0x00371693,
+		0x011807b3,
+		0x0330000f,
+	};
+
+	ptrdiff_t len = (u32 *)emitter.GetWritableCodePtr() - code;
+	EXPECT_EQ_INT(len, ARRAY_SIZE(expected));
+
+	for (ptrdiff_t i = 0; i < len; ++i) {
+		EXPECT_EQ_HEX(code[i], expected[i]);
+	}
+
+	return true;
+}

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -754,6 +754,7 @@ struct TestItem {
 bool TestArmEmitter();
 bool TestArm64Emitter();
 bool TestX64Emitter();
+bool TestRiscVEmitter();
 bool TestShaderGenerators();
 bool TestSoftwareGPUJit();
 bool TestIRPassSimplify();
@@ -768,6 +769,9 @@ TestItem availableTests[] = {
 #endif
 #if PPSSPP_ARCH(AMD64) || PPSSPP_ARCH(X86)
 	TEST_ITEM(X64Emitter),
+#endif
+#if PPSSPP_ARCH(AMD64) || PPSSPP_ARCH(X86) || PPSSPP_ARCH(RISCV64)
+	TEST_ITEM(RiscVEmitter),
 #endif
 	TEST_ITEM(VertexJit),
 	TEST_ITEM(Asin),

--- a/unittest/UnitTests.vcxproj
+++ b/unittest/UnitTests.vcxproj
@@ -383,6 +383,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="TestIRPassSimplify.cpp" />
+    <ClCompile Include="TestRiscVEmitter.cpp" />
     <ClCompile Include="TestShaderGenerators.cpp" />
     <ClCompile Include="TestSoftwareGPUJit.cpp" />
     <ClCompile Include="TestThreadManager.cpp" />

--- a/unittest/UnitTests.vcxproj.filters
+++ b/unittest/UnitTests.vcxproj.filters
@@ -15,6 +15,7 @@
     <ClCompile Include="TestThreadManager.cpp" />
     <ClCompile Include="TestSoftwareGPUJit.cpp" />
     <ClCompile Include="TestIRPassSimplify.cpp" />
+    <ClCompile Include="TestRiscVEmitter.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="JitHarness.h" />


### PR DESCRIPTION
Wanted to mess with this a little more, so added support for the compressed instruction set (which seems to be commonly supported, but not part of G.)

This also adds an immediate builder, which I realized I forgot to add before.  Also a quick unit test just to be sure I didn't break anything obvious, verified with a quick disassembler (not adding one here, though.)

-[Unknown]