### PR TITLE
Vulkan bandwidth optimizations (configure renderpass load/store better)

### DIFF
--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -121,10 +121,16 @@ enum class VKRStepType : uint8_t {
 	READBACK_IMAGE,
 };
 
+// Must be the same order as Draw::RPAction
 enum class VKRRenderPassLoadAction : uint8_t {
-	DONT_CARE,
+	KEEP,  // default. avoid when possible.
 	CLEAR,
-	KEEP,
+	DONT_CARE,
+};
+
+enum class VKRRenderPassStoreAction : uint8_t {
+	STORE,  // default. avoid when possible.
+	DONT_CARE,
 };
 
 struct TransitionRequest {
@@ -156,6 +162,9 @@ struct VKRStep {
 			VKRRenderPassLoadAction colorLoad;
 			VKRRenderPassLoadAction depthLoad;
 			VKRRenderPassLoadAction stencilLoad;
+			VKRRenderPassStoreAction colorStore;
+			VKRRenderPassStoreAction depthStore;
+			VKRRenderPassStoreAction stencilStore;
 			u8 clearStencil;
 			uint32_t clearColor;
 			float clearDepth;
@@ -232,14 +241,10 @@ public:
 		VKRRenderPassLoadAction colorLoadAction;
 		VKRRenderPassLoadAction depthLoadAction;
 		VKRRenderPassLoadAction stencilLoadAction;
+		VKRRenderPassStoreAction colorStoreAction;
+		VKRRenderPassStoreAction depthStoreAction;
+		VKRRenderPassStoreAction stencilStoreAction;
 	};
-
-	// Only call this from the render thread! Also ok during initialization (LoadCache).
-	VkRenderPass GetRenderPass(
-		VKRRenderPassLoadAction colorLoadAction, VKRRenderPassLoadAction depthLoadAction, VKRRenderPassLoadAction stencilLoadAction) {
-		RPKey key{ colorLoadAction, depthLoadAction, stencilLoadAction };
-		return GetRenderPass(key);
-	}
 
 	VkRenderPass GetRenderPass(const RPKey &key);
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -724,6 +724,9 @@ void VulkanRenderManager::BindFramebufferAsRenderTarget(VKRFramebuffer *fb, VKRR
 	step->render.colorLoad = color;
 	step->render.depthLoad = depth;
 	step->render.stencilLoad = stencil;
+	step->render.colorStore = VKRRenderPassStoreAction::STORE;
+	step->render.depthStore = VKRRenderPassStoreAction::STORE;
+	step->render.stencilStore = VKRRenderPassStoreAction::STORE;
 	step->render.clearColor = clearColor;
 	step->render.clearDepth = clearDepth;
 	step->render.clearStencil = clearStencil;

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -361,6 +361,31 @@ public:
 
 	void Clear(uint32_t clearColor, float clearZ, int clearStencil, int clearMask);
 
+	// Cheaply set that we don't care about the contents of a surface at the start of the current render pass.
+	// This set the corresponding load-op of the current render pass to DONT_CARE.
+	// Useful when we don't know at bind-time whether we will overwrite the surface or not.
+	void SetLoadDontCare(VkImageAspectFlags aspects) {
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
+		if (aspects & VK_IMAGE_ASPECT_COLOR_BIT)
+			curRenderStep_->render.colorLoad = VKRRenderPassLoadAction::DONT_CARE;
+		if (aspects & VK_IMAGE_ASPECT_DEPTH_BIT)
+			curRenderStep_->render.depthLoad = VKRRenderPassLoadAction::DONT_CARE;
+		if (aspects & VK_IMAGE_ASPECT_STENCIL_BIT)
+			curRenderStep_->render.stencilLoad = VKRRenderPassLoadAction::DONT_CARE;
+	}
+
+	// Cheaply set that we don't care about the contents of a surface at the end of the current render pass.
+	// This set the corresponding store-op of the current render pass to DONT_CARE.
+	void SetStoreDontCare(VkImageAspectFlags aspects) {
+		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
+		if (aspects & VK_IMAGE_ASPECT_COLOR_BIT)
+			curRenderStep_->render.colorStore = VKRRenderPassStoreAction::DONT_CARE;
+		if (aspects & VK_IMAGE_ASPECT_DEPTH_BIT)
+			curRenderStep_->render.depthStore = VKRRenderPassStoreAction::DONT_CARE;
+		if (aspects & VK_IMAGE_ASPECT_STENCIL_BIT)
+			curRenderStep_->render.stencilStore = VKRRenderPassStoreAction::DONT_CARE;
+	}
+
 	void Draw(VkPipelineLayout layout, VkDescriptorSet descSet, int numUboOffsets, const uint32_t *uboOffsets, VkBuffer vbuffer, int voffset, int count, int offset = 0) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER && curStepHasViewport_ && curStepHasScissor_);
 		VkRenderData data{ VKRRenderCommand::DRAW };

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -499,6 +499,8 @@ public:
 
 	void InvalidateCachedState() override;
 
+	void InvalidateFramebuffer(FBInvalidationStage stage, uint32_t channels) override;
+
 private:
 	VulkanTexture *GetNullTexture();
 	VulkanContext *vulkan_ = nullptr;
@@ -1601,6 +1603,21 @@ void VKContext::HandleEvent(Event ev, int width, int height, void *param1, void 
 	default:
 		_assert_(false);
 		break;
+	}
+}
+
+void VKContext::InvalidateFramebuffer(FBInvalidationStage stage, uint32_t channels) {
+	VkImageAspectFlags flags = 0;
+	if (channels & FBChannel::FB_COLOR_BIT)
+		flags |= VK_IMAGE_ASPECT_COLOR_BIT;
+	if (channels & FBChannel::FB_DEPTH_BIT)
+		flags |= VK_IMAGE_ASPECT_DEPTH_BIT;
+	if (channels & FBChannel::FB_STENCIL_BIT)
+		flags |= VK_IMAGE_ASPECT_STENCIL_BIT;
+	if (stage == FB_INVALIDATION_LOAD) {
+		renderManager_.SetLoadDontCare(flags);
+	} else if (stage == FB_INVALIDATION_STORE) {
+		renderManager_.SetStoreDontCare(flags);
 	}
 }
 

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -261,6 +261,11 @@ enum FBChannel {
 	FB_FORMAT_BIT = 128,  // Actually retrieves the native format instead. D3D11 only.
 };
 
+enum FBInvalidationStage {
+	FB_INVALIDATION_LOAD = 1,
+	FB_INVALIDATION_STORE = 2,
+};
+
 enum FBBlitFilter {
 	FB_BLIT_NEAREST = 0,
 	FB_BLIT_LINEAR = 1,
@@ -568,9 +573,9 @@ struct TextureDesc {
 };
 
 enum class RPAction {
-	DONT_CARE,
-	CLEAR,
-	KEEP,
+	KEEP = 0,
+	CLEAR = 1,
+	DONT_CARE = 2,
 };
 
 struct RenderPassInfo {
@@ -655,8 +660,11 @@ public:
 
 	virtual void GetFramebufferDimensions(Framebuffer *fbo, int *w, int *h) = 0;
 
-	// Useful in OpenGL ES to give hints about framebuffers on tiler GPUs.
-	virtual void InvalidateFramebuffer(Framebuffer *fbo) {}
+	// Could be useful in OpenGL ES to give hints about framebuffers on tiler GPUs
+	// using glInvalidateFramebuffer, although drivers are known to botch that so we currently don't use it.
+	// In Vulkan, this sets the LOAD_OP or the STORE_OP (depending on stage) of the current render pass instance to DONT_CARE.
+	// channels is a bitwise combination of FBChannel::COLOR, DEPTH and STENCIL.
+	virtual void InvalidateFramebuffer(FBInvalidationStage stage, uint32_t channels) {}
 
 	// Dynamic state
 	virtual void SetScissorRect(int left, int top, int width, int height) = 0;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1975,6 +1975,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 		draw_->BindTexture(0, nullptr);
 		draw_->BindTexture(1, nullptr);
 		draw_->BindFramebufferAsRenderTarget(depalFBO, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Depal");
+		draw_->InvalidateFramebuffer(Draw::FB_INVALIDATION_STORE, Draw::FB_DEPTH_BIT | Draw::FB_STENCIL_BIT);
 		draw_->SetScissorRect(u1, v1, u2 - u1, v2 - v1);
 		Draw::Viewport vp{ 0.0f, 0.0f, (float)depalWidth, (float)framebuffer->renderHeight, 0.0f, 1.0f };
 		draw_->SetViewports(1, &vp);

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -358,7 +358,7 @@ VulkanFragmentShader *ShaderManagerVulkan::GetFragmentShaderFromModule(VkShaderM
 // instantaneous.
 
 #define CACHE_HEADER_MAGIC 0xff51f420 
-#define CACHE_VERSION 20
+#define CACHE_VERSION 21
 struct VulkanCacheHeader {
 	uint32_t magic;
 	uint32_t version;


### PR DESCRIPTION
This makes a few straightforward optimizations to when we load/store from framebuffers (in depal, for example, can ignore depth/stencil entirely when drawing to temp FBO, and limit the drawn rectangle in the renderpass).

In reinterpret, by adding a check for full coverage in BlitUsingRaster we know that previous contents of the framebuffer will be irrelevant so can safely set the current render pass to loadop = DONT_CARE.

There's more to be done here later, mainly we should be able to create color-only renderpasses when possible, so we don't even have to consider the depth channel.