### PR TITLE
Remove reinterpret compat flag

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -86,7 +86,6 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ReportSmallMemstick", &flags_.ReportSmallMemstick);
 	CheckSetting(iniFile, gameID, "MemstickFixedFree", &flags_.MemstickFixedFree);
 	CheckSetting(iniFile, gameID, "DateLimited", &flags_.DateLimited);
-	CheckSetting(iniFile, gameID, "ReinterpretFramebuffers", &flags_.ReinterpretFramebuffers);
 	CheckSetting(iniFile, gameID, "ShaderColorBitmask", &flags_.ShaderColorBitmask);
 	CheckSetting(iniFile, gameID, "DisableFirstFrameReadback", &flags_.DisableFirstFrameReadback);
 	CheckSetting(iniFile, gameID, "DisableRangeCulling", &flags_.DisableRangeCulling);

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -76,7 +76,6 @@ struct CompatFlags {
 	bool ReportSmallMemstick;
 	bool MemstickFixedFree;
 	bool DateLimited;
-	bool ReinterpretFramebuffers;
 	bool ShaderColorBitmask;
 	bool DisableFirstFrameReadback;
 	bool DisableRangeCulling;

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1050,6 +1050,8 @@ bool FramebufferManagerCommon::BindFramebufferAsColorTexture(int stage, VirtualF
 
 	// Currently rendering to this framebuffer. Need to make a copy.
 	if (!skipCopy && framebuffer == currentRenderVfb_) {
+		// Self-texturing, need a copy currently (some backends can potentially support it though).
+		WARN_LOG_REPORT_ONCE(selfTextureCopy, G3D, "Attempting to texture from current render target (src=%08x / target=%08x / flags=%d), making a copy", framebuffer->fb_address, currentRenderVfb_->fb_address, flags);
 		// TODO: Maybe merge with bvfbs_?  Not sure if those could be packing, and they're created at a different size.
 		Draw::Framebuffer *renderCopy = GetTempFBO(TempFBO::COPY, framebuffer->renderWidth, framebuffer->renderHeight);
 		if (renderCopy) {
@@ -1058,7 +1060,9 @@ bool FramebufferManagerCommon::BindFramebufferAsColorTexture(int stage, VirtualF
 			CopyFramebufferForColorTexture(&copyInfo, framebuffer, flags);
 			RebindFramebuffer("After BindFramebufferAsColorTexture");
 			draw_->BindFramebufferAsTexture(renderCopy, stage, Draw::FB_COLOR_BIT, 0);
+			gpuStats.numCopiesForSelfTex++;
 		} else {
+			// Failed to get temp FBO? Weird.
 			draw_->BindFramebufferAsTexture(framebuffer->fbo, stage, Draw::FB_COLOR_BIT, 0);
 		}
 		return true;
@@ -1066,7 +1070,7 @@ bool FramebufferManagerCommon::BindFramebufferAsColorTexture(int stage, VirtualF
 		draw_->BindFramebufferAsTexture(framebuffer->fbo, stage, Draw::FB_COLOR_BIT, 0);
 		return true;
 	} else {
-		ERROR_LOG_REPORT_ONCE(vulkanSelfTexture, G3D, "Attempting to texture from target (src=%08x / target=%08x / flags=%d)", framebuffer->fb_address, currentRenderVfb_->fb_address, flags);
+		ERROR_LOG_REPORT_ONCE(selfTextureFail, G3D, "Attempting to texture from target (src=%08x / target=%08x / flags=%d)", framebuffer->fb_address, currentRenderVfb_->fb_address, flags);
 		// To do this safely in Vulkan, we need to use input attachments.
 		// Actually if the texture region and render regions don't overlap, this is safe, but we need
 		// to transition to GENERAL image layout which will take some trickery.

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -746,7 +746,7 @@ void FramebufferManagerCommon::CopyToColorFromOverlappingFramebuffers(VirtualFra
 				gpuStats.numColorCopies++;
 				pipeline = Get2DPipeline(DRAW2D_COPY_COLOR);
 				pass_name = "copy_color";
-			} else if (PSP_CoreParameter().compat.flags().ReinterpretFramebuffers) {
+			} else {
 				if (PSP_CoreParameter().compat.flags().BlueToAlpha) {
 					WARN_LOG_ONCE(bta, G3D, "WARNING: Reinterpret encountered with BlueToAlpha on");
 				}
@@ -777,22 +777,6 @@ void FramebufferManagerCommon::CopyToColorFromOverlappingFramebuffers(VirtualFra
 				}
 
 				gpuStats.numReinterpretCopies++;
-			} else if (IsBufferFormat16Bit(src->fb_format) && IsBufferFormat16Bit(dst->fb_format)) {
-				// Fake reinterpret - just clear the way we always did on Vulkan. Just clear color and stencil.
-				if (src->fb_format == GE_FORMAT_565) {
-					// We have to bind here instead of clear, since it can be that no framebuffer is bound.
-					// The backend can sometimes directly optimize it to a clear.
-
-					// Games that are marked as doing reinterpret just ignore this - better to keep the data than to clear.
-					// Fixes #13717.
-					if (!PSP_CoreParameter().compat.flags().ReinterpretFramebuffers && !PSP_CoreParameter().compat.flags().BlueToAlpha) {
-						draw_->BindFramebufferAsRenderTarget(dst->fbo, { Draw::RPAction::CLEAR, Draw::RPAction::KEEP, Draw::RPAction::CLEAR }, "FakeReinterpret");
-						// Need to dirty anything that has command buffer dynamic state, in case we started a new pass above.
-						// Should find a way to feed that information back, maybe... Or simply correct the issue in the rendermanager.
-						gstate_c.Dirty(DIRTY_DEPTHSTENCIL_STATE | DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_BLEND_STATE);
-						tookActions = true;
-					}
-				}
 			}
 			
 			if (pipeline) {

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -88,6 +88,7 @@ struct GPUStatistics {
 		numReinterpretCopies = 0;
 		numColorCopies = 0;
 		numCopiesForShaderBlend = 0;
+		numCopiesForSelfTex = 0;
 		msProcessingDisplayLists = 0;
 		vertexGPUCycles = 0;
 		otherGPUCycles = 0;
@@ -118,6 +119,7 @@ struct GPUStatistics {
 	int numReinterpretCopies;
 	int numColorCopies;
 	int numCopiesForShaderBlend;
+	int numCopiesForSelfTex;
 	double msProcessingDisplayLists;
 	int vertexGPUCycles;
 	int otherGPUCycles;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -3061,8 +3061,8 @@ size_t GPUCommon::FormatGPUStatsCommon(char *buffer, size_t size) {
 		"Vertices: %d cached: %d uncached: %d\n"
 		"FBOs active: %d (evaluations: %d)\n"
 		"Textures: %d, dec: %d, invalidated: %d, hashed: %d kB\n"
-		"Readbacks: %d, uploads: %d, depal: %d\n"
-		"Copies: depth %d, color %d, reint: %d, sh_blend: %d\n"
+		"readbacks %d, uploads %d, depal %d\n"
+		"Copies: depth %d, color %d, reint %d, blend %d, selftex %d\n"
 		"GPU cycles executed: %d (%f per vertex)\n",
 		gpuStats.msProcessingDisplayLists * 1000.0f,
 		gpuStats.numDrawCalls,
@@ -3087,6 +3087,7 @@ size_t GPUCommon::FormatGPUStatsCommon(char *buffer, size_t size) {
 		gpuStats.numColorCopies,
 		gpuStats.numReinterpretCopies,
 		gpuStats.numCopiesForShaderBlend,
+		gpuStats.numCopiesForSelfTex,
 		gpuStats.vertexGPUCycles + gpuStats.otherGPUCycles,
 		vertexAverageCycles
 	);

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1136,65 +1136,6 @@ ULKS46087 = true
 NPUZ00043 = true
 NPEZ00198 = true
 
-# This setting will go away in the near future, hopefully we can enable it
-# for all or most games.
-[ReinterpretFramebuffers]
-# Ultimate Ghosts & Goblins
-ULJM05147 = true
-ULUS10105 = true
-ULES00419 = true
-NPJH50235 = true
-ULAS42073 = true
-# Goku Makai-Mura Kai (variant of Ultimate Ghosts & Goblins)
-ULJM05265 = true
-ULJM05366 = true
-
-# Kingdom Hearts (see #11223)
-ULUS10505 = true
-ULES01441 = true
-ULJM05600 = true
-ULJM05775 = true
-
-# Spongebob - The Yellow Avenger (see #15898)
-ULUS10092 = true
-ULES00280 = true
-
-# MX vs ATV Reflex
-ULES01375 = true
-ULUS10429 = true
-
-# MX vs ATV Untamed
-ULES00993 = true
-ULES00994 = true
-ULUS10330 = true
-
-# Cars race-o-rama
-ULES01333 = true
-ULUS10428 = true
-
-# God of War: Chains of Olympus
-# The old hack for the shadows isn't working anymore since the framebuffers don't match.
-# This is nicer anyway.
-UCUS98653 = true
-UCES00842 = true
-UCKS45084 = true
-UCUS98705 = true	
-ULJM05348 = true
-ULJM05438 = true
-NPUG80325 = true
-NPEG00023 = true
-NPHG00028 = true
-
-# God of War: Ghost of Sparta
-UCUS98737 = true
-UCAS40323 = true
-UCKS45161 = true
-NPHG00092 = true
-NPEG00044 = true
-UCJS10114 = true
-UCES01401 = true
-NPJG00120 = true
-
 [ShaderColorBitmask]
 # No users right now, but keeping it around as a more accurate option than BlueToAlpha, for debugging mainly Outrun.
 


### PR DESCRIPTION
Removes the `[ReinterpretFramebuffers]` compatibility flag, we now always do it (it's more efficient now than it used to be, plus, I'm not seeing it erroneously activated all that much).

See #15919 

Also adds one more GPU stat (counts the copies caused by self-texturing).

Currently on top of #15921 but will rebase when that is in.