### PR TITLE
Clean up mip size calculations

### DIFF
--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -264,11 +264,28 @@ struct BuildTexturePlan {
 	int w;
 	int h;
 
+	// Scaled (or replaced) size of the 0-mip of the final texture.
+	int createW;
+	int createH;
+
 	// Used for 3D textures only. If not a 3D texture, will be 1.
 	int depth;
 
 	// The replacement for the texture.
 	ReplacedTexture *replaced;
+
+	void GetMipSize(int level, int *w, int *h) const {
+		if (replaced->Valid()) {
+			replaced->GetSize(level, *w, *h);
+		} else if (depth == 1) {
+			*w = createW >> level;
+			*h = createH >> level;
+		} else {
+			// 3D texture, we look for layers instead of levels.
+			*w = createW;
+			*h = createH;
+		}
+	}
 };
 
 class TextureCacheCommon {

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -238,27 +238,28 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 		return;
 	}
 
-	int tw = plan.w;
-	int th = plan.h;
-
 	D3DFORMAT dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
-	if (plan.replaced->GetSize(plan.baseLevelSrc, tw, th)) {
+	if (plan.replaced->Valid()) {
 		dstFmt = ToD3D9Format(plan.replaced->Format(plan.baseLevelSrc));
 	} else if (plan.scaleFactor > 1) {
-		tw *= plan.scaleFactor;
-		th *= plan.scaleFactor;
 		dstFmt = D3DFMT_A8R8G8B8;
 	}
 
-	// We don't yet have mip generation, so clamp the number of levels to the ones we can load directly.
-	int levels = std::min(plan.levelsToCreate, plan.levelsToLoad);
+	int levels;
 
 	LPDIRECT3DBASETEXTURE9 &texture = DxTex(entry);
 	D3DPOOL pool = D3DPOOL_DEFAULT;
 	int usage = D3DUSAGE_DYNAMIC;
 
+	int tw;
+	int th;
+	plan.GetMipSize(0, &tw, &th);
+
 	HRESULT hr;
 	if (plan.depth == 1) {
+		// We don't yet have mip generation, so clamp the number of levels to the ones we can load directly.
+		levels = std::min(plan.levelsToCreate, plan.levelsToLoad);
+
 		LPDIRECT3DTEXTURE9 tex;
 		hr = device_->CreateTexture(tw, th, levels, usage, dstFmt, pool, &tex, nullptr);
 		texture = tex;
@@ -266,6 +267,8 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 		LPDIRECT3DVOLUMETEXTURE9 tex;
 		hr = device_->CreateVolumeTexture(tw, th, plan.depth, 1, usage, dstFmt, pool, &tex, nullptr);
 		texture = tex;
+
+		levels = 1;
 	}
 
 	if (FAILED(hr)) {

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -301,37 +301,36 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 		for (int i = 0; i < plan.levelsToLoad; i++) {
 			int srcLevel = i == 0 ? plan.baseLevelSrc : i;
 
-			int w = gstate.getTextureWidth(srcLevel);
-			int h = gstate.getTextureHeight(srcLevel);
+			int mipWidth;
+			int mipHeight;
+			plan.GetMipSize(i, &mipWidth, &mipHeight);
 
 			u8 *data = nullptr;
 			int stride = 0;
+			int bpp;
 
-			if (plan.replaced->GetSize(srcLevel, w, h)) {
-				int bpp = (int)Draw::DataFormatSizeInBytes(plan.replaced->Format(srcLevel));
-				stride = w * bpp;
-				data = (u8 *)AllocateAlignedMemory(stride * h, 16);
+			if (plan.replaced->Valid()) {
+				bpp = (int)Draw::DataFormatSizeInBytes(plan.replaced->Format(srcLevel));
 			} else {
 				if (plan.scaleFactor > 1) {
-					data = (u8 *)AllocateAlignedMemory(4 * (w * plan.scaleFactor) * (h * plan.scaleFactor), 16);
-					stride = w * plan.scaleFactor * 4;
+					bpp = 4;
 				} else {
-					int bpp = dstFmt == Draw::DataFormat::R8G8B8A8_UNORM ? 4 : 2;
-
-					stride = std::max(w * bpp, 4);
-					data = (u8 *)AllocateAlignedMemory(stride * h, 16);
+					bpp = dstFmt == Draw::DataFormat::R8G8B8A8_UNORM ? 4 : 2;
 				}
 			}
 
+			stride = mipWidth * bpp;
+			data = (u8 *)AllocateAlignedMemory(stride * mipHeight, 16);
+
 			if (!data) {
-				ERROR_LOG(G3D, "Ran out of RAM trying to allocate a temporary texture upload buffer (%dx%d)", w, h);
+				ERROR_LOG(G3D, "Ran out of RAM trying to allocate a temporary texture upload buffer (%dx%d)", mipWidth, mipHeight);
 				return;
 			}
 
 			LoadTextureLevel(*entry, data, stride, *plan.replaced, srcLevel, plan.scaleFactor, dstFmt, true);
 
 			// NOTE: TextureImage takes ownership of data, so we don't free it afterwards.
-			render_->TextureImage(entry->textureName, i, w * plan.scaleFactor, h * plan.scaleFactor, 1, dstFmt, data, GLRAllocType::ALIGNED);
+			render_->TextureImage(entry->textureName, i, mipWidth, mipHeight, 1, dstFmt, data, GLRAllocType::ALIGNED);
 		}
 
 		bool genMips = plan.levelsToCreate > plan.levelsToLoad;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -503,7 +503,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 	snprintf(texName, sizeof(texName), "tex_%08x_%s", entry->addr, GeTextureFormatToString((GETextureFormat)entry->format, gstate.getClutPaletteFormat()));
 	image->SetTag(texName);
 
-	bool allocSuccess = image->CreateDirect(cmdInit, plan.w * plan.scaleFactor, plan.h * plan.scaleFactor, plan.depth, plan.levelsToCreate, actualFmt, imageLayout, usage, mapping);
+	bool allocSuccess = image->CreateDirect(cmdInit, plan.createW, plan.createH, plan.depth, plan.levelsToCreate, actualFmt, imageLayout, usage, mapping);
 	if (!allocSuccess && !lowMemoryMode_) {
 		WARN_LOG_REPORT(G3D, "Texture cache ran out of GPU memory; switching to low memory mode");
 		lowMemoryMode_ = true;
@@ -519,10 +519,15 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 			host->NotifyUserMessage(err->T("Warning: Video memory FULL, switching to slow caching mode"), 2.0f);
 		}
 
+		// Turn off texture replacement for this texture.
+		plan.replaced = &replacer_.FindNone();
+
+		plan.createW /= plan.scaleFactor;
+		plan.createH /= plan.scaleFactor;
 		plan.scaleFactor = 1;
 		actualFmt = dstFmt;
 
-		allocSuccess = image->CreateDirect(cmdInit, plan.w * plan.scaleFactor, plan.h * plan.scaleFactor, plan.depth, plan.levelsToCreate, actualFmt, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, mapping);
+		allocSuccess = image->CreateDirect(cmdInit, plan.createW, plan.createH, plan.depth, plan.levelsToCreate, actualFmt, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT, mapping);
 	}
 
 	if (!allocSuccess) {
@@ -563,15 +568,14 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		int mipUnscaledWidth = gstate.getTextureWidth(i);
 		int mipUnscaledHeight = gstate.getTextureHeight(i);
 
-		int mipWidth = mipUnscaledWidth * plan.scaleFactor;
-		int mipHeight = mipUnscaledHeight * plan.scaleFactor;
-		if (plan.replaced->Valid()) {
-			plan.replaced->GetSize(plan.baseLevelSrc + i, mipWidth, mipHeight);
-		}
+		int mipWidth;
+		int mipHeight;
+		plan.GetMipSize(i, &mipWidth, &mipHeight);
 
 		int bpp = actualFmt == VULKAN_8888_FORMAT ? 4 : 2;  // output bpp
 		int stride = (mipWidth * bpp + 15) & ~15;  // output stride
-		int size = stride * mipHeight;
+		int uploadSize = stride * mipHeight;
+
 		uint32_t bufferOffset;
 		VkBuffer texBuf;
 		// NVIDIA reports a min alignment of 1 but that can't be healthy... let's align by 16 as a minimum.
@@ -594,7 +598,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		bool dataScaled = true;
 		if (plan.replaced->Valid()) {
 			// Directly load the replaced image.
-			data = drawEngine_->GetPushBufferForTextureData()->PushAligned(size, &bufferOffset, &texBuf, pushAlignment);
+			data = drawEngine_->GetPushBufferForTextureData()->PushAligned(uploadSize, &bufferOffset, &texBuf, pushAlignment);
 			double replaceStart = time_now_d();
 			plan.replaced->Load(plan.baseLevelSrc + i, data, stride);  // if it fails, it'll just be garbage data... OK for now.
 			replacementTimeThisFrame_ += time_now_d() - replaceStart;
@@ -604,7 +608,8 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 			VK_PROFILE_END(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT);
 		} else {
 			if (plan.depth != 1) {
-				loadLevel(size, i, stride, plan.scaleFactor);
+				// 3D texturing.
+				loadLevel(uploadSize, i, stride, plan.scaleFactor);
 				entry->vkTex->UploadMip(cmdInit, 0, mipWidth, mipHeight, i, texBuf, bufferOffset, stride / bpp);
 			} else if (computeUpload) {
 				int srcBpp = dstFmt == VULKAN_8888_FORMAT ? 4 : 2;
@@ -626,7 +631,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 				VK_PROFILE_END(vulkan, cmdInit, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
 				vulkan->Delete().QueueDeleteImageView(view);
 			} else {
-				loadLevel(size, i == 0 ? plan.baseLevelSrc : i, stride, plan.scaleFactor);
+				loadLevel(uploadSize, i == 0 ? plan.baseLevelSrc : i, stride, plan.scaleFactor);
 				VK_PROFILE_BEGIN(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT,
 					"Copy Upload: %dx%d", mipWidth, mipHeight);
 				entry->vkTex->UploadMip(cmdInit, i, mipWidth, mipHeight, 0, texBuf, bufferOffset, stride / bpp);


### PR DESCRIPTION
Calculating the same thing in multiple places is a recipe for bugs, so let's not.

This seems to fix some bug with texture replacement that I didn't see, but the validation layers did.