### PR TITLE
Fix race condition in replacement texture loading

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2360,11 +2360,13 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 
 	if (plan.isVideo || isPPGETexture) {
 		plan.replaced = &replacer_.FindNone();
+		plan.replaceValid = false;
 	} else {
 		plan.replaced = &FindReplacement(entry, plan.w, plan.h, plan.depth);
+		plan.replaceValid = plan.replaced->Valid();
 	}
 
-	if (plan.replaced->Valid()) {
+	if (plan.replaceValid) {
 		// We're replacing, so we won't scale.
 		plan.scaleFactor = 1;
 		plan.levelsToLoad = plan.replaced->NumLevels();

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -273,9 +273,11 @@ struct BuildTexturePlan {
 
 	// The replacement for the texture.
 	ReplacedTexture *replaced;
+	// Need to only check once since it can change during the load!
+	bool replaceValid;
 
 	void GetMipSize(int level, int *w, int *h) const {
-		if (replaced->Valid()) {
+		if (replaceValid) {
 			replaced->GetSize(level, *w, *h);
 		} else if (depth == 1) {
 			*w = createW >> level;

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -277,7 +277,7 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 	}
 
 	DXGI_FORMAT dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
-	if (plan.replaced->Valid()) {
+	if (plan.replaceValid) {
 		dstFmt = ToDXGIFormat(plan.replaced->Format(plan.baseLevelSrc));
 	} else if (plan.scaleFactor > 1) {
 		dstFmt = DXGI_FORMAT_B8G8R8A8_UNORM;
@@ -347,7 +347,7 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 
 		// For UpdateSubresource, we can't decode directly into the texture so we allocate a buffer :(
 		// NOTE: Could reuse it between levels or textures!
-		if (plan.replaced->Valid()) {
+		if (plan.replaceValid) {
 			bpp = (int)Draw::DataFormatSizeInBytes(plan.replaced->Format(srcLevel));
 		} else {
 			if (plan.scaleFactor > 1) {
@@ -390,7 +390,7 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 		entry->status &= ~TexCacheEntry::STATUS_NO_MIPS;
 	}
 
-	if (plan.replaced->Valid()) {
+	if (plan.replaceValid) {
 		entry->SetAlphaStatus(TexCacheEntry::TexStatus(plan.replaced->AlphaStatus()));
 	}
 }

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -239,7 +239,7 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 	}
 
 	D3DFORMAT dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
-	if (plan.replaced->Valid()) {
+	if (plan.replaceValid) {
 		dstFmt = ToD3D9Format(plan.replaced->Format(plan.baseLevelSrc));
 	} else if (plan.scaleFactor > 1) {
 		dstFmt = D3DFMT_A8R8G8B8;
@@ -325,7 +325,7 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 		entry->status |= TexCacheEntry::STATUS_3D;
 	}
 
-	if (plan.replaced->Valid()) {
+	if (plan.replaceValid) {
 		entry->SetAlphaStatus(TexCacheEntry::TexStatus(plan.replaced->AlphaStatus()));
 	}
 }

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -309,7 +309,7 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 			int stride = 0;
 			int bpp;
 
-			if (plan.replaced->Valid()) {
+			if (plan.replaceValid) {
 				bpp = (int)Draw::DataFormatSizeInBytes(plan.replaced->Format(srcLevel));
 			} else {
 				if (plan.scaleFactor > 1) {
@@ -358,7 +358,7 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 		render_->FinalizeTexture(entry->textureName, 1, false);
 	}
 
-	if (plan.replaced->Valid()) {
+	if (plan.replaceValid) {
 		entry->SetAlphaStatus(TexCacheEntry::TexStatus(plan.replaced->AlphaStatus()));
 	}
 }


### PR DESCRIPTION
The texture could become valid during the load, causing an inconsistent state within the texture loading. So can only check for valid-ness once.

Fixes the problem mentioned in #15928 .