### PR TITLE
Fix sceKernelUnlockMutex timing

### DIFF
--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -657,8 +657,10 @@ int sceKernelUnlockMutex(SceUID id, int count)
 
 	if (mutex->nm.lockLevel == 0)
 	{
-		if (__KernelUnlockMutex(mutex, error))
+		if (__KernelUnlockMutex(mutex, error)) {
 			hleReSchedule("mutex unlocked");
+			return hleDelayResult(0, "unlock", 150);
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
Fix https://github.com/hrydgard/ppsspp/issues/6557

Match Real PSP log

20:29:15.097838 user_main - -> sceKernelUnlockMutex 0x3EFE17F, 0x1 = 0x0
20:29:15.097979 user_main - <- sceKernelUnlockMutex 0x3EFE17F, 0x1 = 0x0