### PR TITLE
Split the main framebuffer in Killzone, to avoid texturing-from-current-rendertarget

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -96,6 +96,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "AllowLargeFBTextureOffsets", &flags_.AllowLargeFBTextureOffsets);
 	CheckSetting(iniFile, gameID, "AtracLoopHack", &flags_.AtracLoopHack);
 	CheckSetting(iniFile, gameID, "DeswizzleDepth", &flags_.DeswizzleDepth);
+	CheckSetting(iniFile, gameID, "SplitFramebufferMargin", &flags_.SplitFramebufferMargin);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -86,6 +86,7 @@ struct CompatFlags {
 	bool AllowLargeFBTextureOffsets;
 	bool AtracLoopHack;
 	bool DeswizzleDepth;
+	bool SplitFramebufferMargin;
 };
 
 class IniFile;

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -823,7 +823,10 @@ u32 sceDisplaySetFramebuf(u32 topaddr, int linesize, int pixelformat, int sync) 
 
 	s64 delayCycles = 0;
 	// Don't count transitions between display off and display on.
-	if (topaddr != 0 && topaddr != framebuf.topaddr && framebuf.topaddr != 0 && PSP_CoreParameter().compat.flags().ForceMax60FPS) {
+	if (topaddr != 0 &&
+		(topaddr != framebuf.topaddr || PSP_CoreParameter().compat.flags().SplitFramebufferMargin) &&
+		framebuf.topaddr != 0 &&
+		PSP_CoreParameter().compat.flags().ForceMax60FPS) {
 		// sceDisplaySetFramebuf() isn't supposed to delay threads at all.  This is a hack.
 		// So let's only delay when it's more than 1ms.
 		const s64 FLIP_DELAY_CYCLES_MIN = usToCycles(1000);

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -679,7 +679,8 @@ void FramebufferManagerCommon::CopyToColorFromOverlappingFramebuffers(VirtualFra
 				// This will result in reinterpret later, if both formats are 16-bit.
 				sources.push_back(CopySource{ src, RASTER_COLOR, 0, 0 });
 			} else {
-				// Likely irrelevant or old, if the game is changing color depth for example.
+				// This shouldn't happen anymore. I think when it happened last, we still had
+				// lax stride checking when video was incoming, and a resize happened causing a duplicate.
 			}
 		} else if (src->fb_stride == dst->fb_stride && src->fb_format == dst->fb_format) {
 			u32 bytesPerPixel = BufferFormatBytesPerPixel(src->fb_format);

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -279,7 +279,7 @@ public:
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format);
 	void DestroyFramebuf(VirtualFramebuffer *v);
 
-	VirtualFramebuffer *DoSetRenderFrameBuffer(const FramebufferHeuristicParams &params, u32 skipDrawReason);
+	VirtualFramebuffer *DoSetRenderFrameBuffer(FramebufferHeuristicParams &params, u32 skipDrawReason);
 	VirtualFramebuffer *SetRenderFrameBuffer(bool framebufChanged, int skipDrawReason) {
 		// Inlining this part since it's so frequent.
 		if (!framebufChanged && currentRenderVfb_) {

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -581,8 +581,9 @@ void ConvertViewportAndScissor(bool useBufferedRendering, float renderWidth, flo
 		renderHeightFactor = renderHeight / 272.0f;
 	}
 
-	renderX = gstate_c.curRTOffsetX;
-	renderY = gstate_c.curRTOffsetY;
+	// negative offsets we take care of in the projection matrix.
+	renderX = std::max(gstate_c.curRTOffsetX, 0);
+	renderY = std::max(gstate_c.curRTOffsetY, 0);
 
 	// Scissor
 	int scissorX1 = gstate.getScissorX1();
@@ -609,6 +610,9 @@ void ConvertViewportAndScissor(bool useBufferedRendering, float renderWidth, flo
 	float offsetY = gstate.getOffsetY();
 
 	if (out.throughMode) {
+		// If renderX/renderY are offset to compensate for a split framebuffer,
+		// applying the offset to the viewport isn't enough, since the viewport clips.
+		// We need to apply either directly to the vertices, or to the "through" projection matrix.
 		out.viewportX = renderX * renderWidthFactor + displayOffsetX;
 		out.viewportY = renderY * renderHeightFactor + displayOffsetY;
 		out.viewportW = curRTWidth * renderWidthFactor;

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -581,7 +581,9 @@ void ConvertViewportAndScissor(bool useBufferedRendering, float renderWidth, flo
 		renderHeightFactor = renderHeight / 272.0f;
 	}
 
-	// negative offsets we take care of in the projection matrix.
+	// We take care negative offsets of in the projection matrix.
+	// These come from split framebuffers (Killzone).
+	// TODO: Might be safe to do get rid of this here and do the same for positive offsets?
 	renderX = std::max(gstate_c.curRTOffsetX, 0);
 	renderY = std::max(gstate_c.curRTOffsetY, 0);
 

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -152,10 +152,11 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 		if (!useBufferedRendering && g_display_rotation != DisplayRotation::ROTATE_0) {
 			proj_through = proj_through * g_display_rot_matrix;
 		}
+
+		// Negative RT offsets come from split framebuffers (Killzone)
 		if (gstate_c.curRTOffsetX < 0 || gstate_c.curRTOffsetY < 0) {
-			Matrix4x4 xlate;
-			xlate.setTranslation(Lin::Vec3(2.0f * gstate_c.curRTOffsetX / (int)gstate_c.curRTWidth, 2.0f * gstate_c.curRTOffsetY / (int)gstate_c.curRTHeight, 0.0f));
-			proj_through = proj_through * xlate;
+			proj_through.wx += 2.0f * (float)gstate_c.curRTOffsetX / (float)gstate_c.curRTWidth;
+			proj_through.wy += 2.0f * (float)gstate_c.curRTOffsetY / (float)gstate_c.curRTHeight;
 		}
 
 		CopyMatrix4x4(ub->proj_through, proj_through.getReadPtr());

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -152,6 +152,12 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 		if (!useBufferedRendering && g_display_rotation != DisplayRotation::ROTATE_0) {
 			proj_through = proj_through * g_display_rot_matrix;
 		}
+		if (gstate_c.curRTOffsetX < 0 || gstate_c.curRTOffsetY < 0) {
+			Matrix4x4 xlate;
+			xlate.setTranslation(Lin::Vec3(2.0f * gstate_c.curRTOffsetX / (int)gstate_c.curRTWidth, 2.0f * gstate_c.curRTOffsetY / (int)gstate_c.curRTHeight, 0.0f));
+			proj_through = proj_through * xlate;
+		}
+
 		CopyMatrix4x4(ub->proj_through, proj_through.getReadPtr());
 		ub->rotation = useBufferedRendering ? 0 : (float)g_display_rotation;
 	}

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -664,6 +664,8 @@ int TextureCacheCommon::GetBestCandidateIndex(const std::vector<AttachCandidate>
 	int bestRelevancy = -1;
 	int bestIndex = -1;
 
+	bool kzCompat = PSP_CoreParameter().compat.flags().SplitFramebufferMargin;
+
 	// We simply use the sequence counter as relevancy nowadays.
 	for (int i = 0; i < (int)candidates.size(); i++) {
 		const AttachCandidate &candidate = candidates[i];
@@ -677,7 +679,10 @@ int TextureCacheCommon::GetBestCandidateIndex(const std::vector<AttachCandidate>
 			relevancy -= 2;
 		}
 
-		if (candidate.fb == framebufferManager_->GetCurrentRenderVFB()) {
+		// Avoid binding as texture the framebuffer we're rendering to.
+		// In Killzone, we split the framebuffer but the matching algorithm can still pick the wrong one,
+		// which this avoids completely.
+		if (kzCompat && candidate.fb == framebufferManager_->GetCurrentRenderVFB()) {
 			continue;
 		}
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -952,7 +952,12 @@ bool TextureCacheCommon::MatchFramebuffer(
 			}
 		}
 
-		if (matchInfo->yOffset + minSubareaHeight >= framebuffer->height) {
+		if (matchInfo->yOffset > 0 && matchInfo->yOffset + minSubareaHeight >= framebuffer->height) {
+			// Can't be inside the framebuffer.
+			return false;
+		}
+
+		if (matchInfo->yOffset < 0 && matchInfo->yOffset - minSubareaHeight <= 0) {
 			// Can't be inside the framebuffer.
 			return false;
 		}

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -209,8 +209,8 @@ typedef std::map<u64, std::unique_ptr<TexCacheEntry>> TexCache;
 #endif
 
 struct FramebufferMatchInfo {
-	u32 xOffset;
-	u32 yOffset;
+	int xOffset;
+	int yOffset;
 	bool reinterpret;
 	GEBufferFormat reinterpretTo;
 };

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1686,6 +1686,11 @@ void GPUCommon::Execute_Prim(u32 op, u32 diff) {
 		}
 	}
 
+	if ((gstate.vertType & 0xFFFFFF) == 0x00800102 && PSP_CoreParameter().compat.flags().SplitFramebufferMargin) {
+		// Need to re-check the framebuffer every draw.
+		gstate_c.Dirty(DIRTY_FRAMEBUF);
+	}
+
 	// This also makes skipping drawing very effective.
 	VirtualFramebuffer *vfb = framebufferManager_->SetRenderFrameBuffer(gstate_c.IsDirty(DIRTY_FRAMEBUF), gstate_c.skipDrawReason);
 	if (blueToAlpha) {

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -625,7 +625,7 @@ struct GPUStateCache {
 		if (xoff != curRTOffsetX || yoff != curRTOffsetY) {
 			curRTOffsetX = xoff;
 			curRTOffsetY = yoff;
-			Dirty(DIRTY_VIEWPORTSCISSOR_STATE);
+			Dirty(DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_PROJTHROUGHMATRIX);
 		}
 	}
 	int curRTOffsetX;

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -621,15 +621,15 @@ struct GPUStateCache {
 	u32 curRTRenderWidth;
 	u32 curRTRenderHeight;
 
-	void SetCurRTOffset(u32 xoff, u32 yoff) {
+	void SetCurRTOffset(int xoff, int yoff) {
 		if (xoff != curRTOffsetX || yoff != curRTOffsetY) {
 			curRTOffsetX = xoff;
 			curRTOffsetY = yoff;
 			Dirty(DIRTY_VIEWPORTSCISSOR_STATE);
 		}
 	}
-	u32 curRTOffsetX;
-	u32 curRTOffsetY;
+	int curRTOffsetX;
+	int curRTOffsetY;
 
 	// Set if we are doing hardware bezier/spline.
 	SubmitType submitType;

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -592,8 +592,8 @@ struct GPUStateCache {
 	u32 curTextureHeight;
 	u32 actualTextureHeight;
 	// Only applied when needShaderTexClamp = true.
-	u32 curTextureXOffset;
-	u32 curTextureYOffset;
+	int curTextureXOffset;
+	int curTextureYOffset;
 	bool curTextureIs3D;
 
 	float vpWidth;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1256,3 +1256,12 @@ UCKS45048 = true
 UCJS18030 = true
 UCJS18047 = true
 NPJG00015 = true
+
+[SplitFramebufferMargin]
+# Killzone: Liberation (see issue #6207)
+UCES00279 = true
+UCKS45041 = true
+UCUS98646 = true
+UCET00278 = true
+UCUS98670 = true
+UCUS98646 = true

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1004,6 +1004,14 @@ ULUS10317 = true
 ULUS10598 = true
 ULES01578 = true
 
+# Killzone: Liberation (see issue #6207)
+UCES00279 = true
+UCKS45041 = true
+UCUS98646 = true
+UCET00278 = true
+UCUS98670 = true
+UCUS98646 = true
+
 [JitInvalidationHack]
 # This is an absolutely awful hack that somehow prevents issues when clearing the JIT,
 # if the game has copied code with EmuHack opcodes or something. Hopefully will be able


### PR DESCRIPTION
Fixes #6207 

Work-in-progress, need to verify that it's actually doing the effect right, and maybe can do the checks better.

There's no way around a compat.ini hack for this game, we just can't practically detect this situation in a generic way. But this approach does appear to work fine.

Additionally, tweaks ForceMax60Fps to work for the game and enables it, for more speed. Not sure if I should make a separate compat.ini flag for the tweak there.