### PR TITLE
Framebuffer settings and block transfer speedup

### DIFF
--- a/Common/Data/Collections/TinySet.h
+++ b/Common/Data/Collections/TinySet.h
@@ -3,10 +3,12 @@
 #include <vector>
 
 // Insert-only small-set implementation. Performs no allocation unless MaxFastSize is exceeded.
+// Can also be used as a small vector, then use push_back (or push_in_place) instead of insert.
+// Duplicates are thus allowed if you use that, but not if you exclusively use insert.
 template <class T, int MaxFastSize>
 struct TinySet {
 	~TinySet() { delete slowLookup_; }
-	inline void insert(T t) {
+	inline void insert(const T &t) {
 		// Fast linear scan.
 		for (int i = 0; i < fastCount; i++) {
 			if (fastLookup_[i] == t)
@@ -19,6 +21,27 @@ struct TinySet {
 		}
 		// Fall back to slow path.
 		insertSlow(t);
+	}
+	inline void push_back(const T &t) {
+		if (fastCount < MaxFastSize) {
+			fastLookup_[fastCount++] = t;
+			return;
+		}
+		if (!slowLookup_) {
+			slowLookup_ = new std::vector<T>();
+		}
+		slowLookup_->push_back(t);
+	}
+	inline T *add_back() {
+		if (fastCount < MaxFastSize) {
+			return &fastLookup_[fastCount++];
+		}
+		if (!slowLookup_) {
+			slowLookup_ = new std::vector<T>();
+		}
+		T t;
+		slowLookup_->push_back(t);
+		return slowLookup_->back();
 	}
 	bool contains(T t) const {
 		for (int i = 0; i < fastCount; i++) {
@@ -51,6 +74,23 @@ struct TinySet {
 		delete slowLookup_;
 		slowLookup_ = nullptr;
 		fastCount = 0;
+	}
+	bool empty() const {
+		return fastCount == 0;
+	}
+	size_t size() const {
+		if (fastCount <= MaxFastSize) {
+			return fastCount;
+		} else {
+			return slowLookup_->size() + MaxFastSize;
+		}
+	}
+	const T &operator[] (size_t index) const {
+		if (index < MaxFastSize) {
+			return fastLookup_[index];
+		} else {
+			return (*slowLookup_)[index - MaxFastSize];
+		}
 	}
 
 private:

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -934,7 +934,7 @@ static ConfigSetting graphicsSettings[] = {
 	ConfigSetting("ShaderChainRequires60FPS", &g_Config.bShaderChainRequires60FPS, false, true, true),
 
 	ReportedConfigSetting("MemBlockTransferGPU", &g_Config.bBlockTransferGPU, true, true, true),
-	ReportedConfigSetting("DisableSlowFramebufEffects", &g_Config.bDisableSlowFramebufEffects, false, true, true),
+	ReportedConfigSetting("DisableSlowFramebufEffects", &g_Config.bDisableShaderBlending, false, true, true),
 	ReportedConfigSetting("FragmentTestCache", &g_Config.bFragmentTestCache, true, true, true),
 
 	ConfigSetting("GfxDebugOutput", &g_Config.bGfxDebugOutput, false, false, false),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -232,7 +232,7 @@ public:
 	float fGameListScrollPosition;
 	int iBloomHack; //0 = off, 1 = safe, 2 = balanced, 3 = aggressive
 	bool bBlockTransferGPU;
-	bool bDisableSlowFramebufEffects;
+	bool bDisableShaderBlending;
 	bool bFragmentTestCache;
 	int iSplineBezierQuality; // 0 = low , 1 = Intermediate , 2 = High
 	bool bHardwareTessellation;

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -21,6 +21,7 @@
 
 #include "Common/GPU/thin3d.h"
 #include "Common/GPU/OpenGL/GLFeatures.h"
+#include "Common/Data/Collections/TinySet.h"
 #include "Common/Data/Convert/ColorConv.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Math/lin/matrix4x4.h"
@@ -1677,7 +1678,7 @@ bool FramebufferManagerCommon::FindTransferFramebuffer(u32 basePtr, int stride_p
 	int x_bytes = x_pixels * bpp;
 	int w_bytes = w_pixels * bpp;
 
-	std::vector<BlockTransferRect> candidates;
+	TinySet<BlockTransferRect, 4> candidates;
 
 	// We work entirely in bytes when we do the matching, because games don't consistently use bpps that match
 	// that of their buffers. Then after matching we try to map the copy to the simplest operation that does
@@ -1752,20 +1753,27 @@ bool FramebufferManagerCommon::FindTransferFramebuffer(u32 basePtr, int stride_p
 		candidates.push_back(candidate);
 	}
 
+	const BlockTransferRect *best = nullptr;
 	// Sort candidates by just recency for now, we might add other.
-	std::sort(candidates.begin(), candidates.end());
+	for (size_t i = 0; i < candidates.size(); i++) {
+		const BlockTransferRect *candidate = &candidates[i];
+		if (!best || candidate->vfb->colorBindSeq > best->vfb->colorBindSeq) {
+			best = candidate;
+		}
+	}
 
 	if (candidates.size() > 1) {
-		std::string log;
-		for (auto &candidate : candidates) {
-			log += " - " + candidate.ToString() + "\n";
+		if (Reporting::ShouldLogNTimes("mulblock", 5)) {
+			std::string log;
+			for (size_t i = 0; i < candidates.size(); i++) {
+				log += " - " + candidates[i].ToString() + "\n";
+			}
+			WARN_LOG(G3D, "Multiple framebuffer candidates for %08x/%d/%d %d,%d %dx%d (dest = %d):\n%s", basePtr, stride_pixels, bpp, x_pixels, y, w_pixels, h, (int)destination, log.c_str());
 		}
-		WARN_LOG_N_TIMES(mulblock, 5, G3D, "Multiple framebuffer candidates for %08x/%d/%d %d,%d %dx%d (dest = %d):\n%s", basePtr, stride_pixels, bpp, x_pixels, y, w_pixels, h, (int)destination, log.c_str());
 	}
 
 	if (!candidates.empty()) {
-		// Pick the last candidate.
-		*rect = candidates.back();
+		*rect = *best;
 		return true;
 	} else {
 		if (Memory::IsVRAMAddress(basePtr) && destination && h >= 128) {

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -494,7 +494,7 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(Framebuffer
 		currentRenderVfb_ = vfb;
 
 		// Assume that if we're clearing right when switching to a new framebuffer, we don't need to upload.
-		if (useBufferedRendering_ && !g_Config.bDisableSlowFramebufEffects && params.isDrawing) {
+		if (useBufferedRendering_ && params.isDrawing) {
 			gpu->PerformMemoryUpload(params.fb_address, byteSize);
 			// Alpha was already done by PerformMemoryUpload.
 			PerformStencilUpload(params.fb_address, byteSize, StencilUpload::STENCIL_IS_ZERO | StencilUpload::IGNORE_ALPHA);
@@ -1233,7 +1233,7 @@ void FramebufferManagerCommon::DownloadFramebufferOnSwitch(VirtualFramebuffer *v
 		// Some games will draw to some memory once, and use it as a render-to-texture later.
 		// To support this, we save the first frame to memory when we have a safe w/h.
 		// Saving each frame would be slow.
-		if (!g_Config.bDisableSlowFramebufEffects && !PSP_CoreParameter().compat.flags().DisableFirstFrameReadback) {
+		if (g_Config.bBlockTransferGPU && !PSP_CoreParameter().compat.flags().DisableFirstFrameReadback) {
 			ReadFramebufferToMemory(vfb, 0, 0, vfb->safeWidth, vfb->safeHeight, RASTER_COLOR);
 			vfb->usageFlags = (vfb->usageFlags | FB_USAGE_DOWNLOAD | FB_USAGE_FIRST_FRAME_SAVED) & ~FB_USAGE_DOWNLOAD_CLEAR;
 			vfb->safeWidth = 0;

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -245,10 +245,6 @@ struct BlockTransferRect {
 	int x_pixels() const {
 		return x_bytes / BufferFormatBytesPerPixel(vfb->fb_format);
 	}
-
-	bool operator < (const BlockTransferRect &other) const {
-		return vfb->colorBindSeq < other.vfb->colorBindSeq;
-	}
 };
 
 namespace Draw {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1193,7 +1193,7 @@ void TextureCacheCommon::LoadClut(u32 clutAddr, u32 loadBytes) {
 
 		// It's possible for a game to (successfully) access outside valid memory.
 		u32 bytes = Memory::ValidSize(clutAddr, loadBytes);
-		if (clutRenderAddress_ != 0xFFFFFFFF && !g_Config.bDisableSlowFramebufEffects) {
+		if (clutRenderAddress_ != 0xFFFFFFFF && !g_Config.bBlockTransferGPU) {
 			framebufferManager_->DownloadFramebufferForClut(clutRenderAddress_, clutRenderOffset_ + bytes);
 			Memory::MemcpyUnchecked(clutBufRaw_, clutAddr, bytes);
 			if (bytes < loadBytes) {
@@ -1932,7 +1932,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 	bool smoothedDepal = false;
 	u32 depthUpperBits = 0;
 
-	if (need_depalettize && !g_Config.bDisableSlowFramebufEffects) {
+	if (need_depalettize) {
 		clutTexture = textureShaderCache_->GetClutTexture(clutFormat, clutHash_, clutBufRaw_);
 		smoothedDepal = CanUseSmoothDepal(gstate, framebuffer->fb_format, clutTexture.rampLength);
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -532,21 +532,17 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 	def.format = texFormat;
 	def.bufw = bufw;
 
-	std::vector<AttachCandidate> candidates = GetFramebufferCandidates(def, 0);
-	if (candidates.size() > 0) {
-		int index = GetBestCandidateIndex(candidates);
-		if (index != -1) {
-			// If we had a texture entry here, let's get rid of it.
-			if (entryIter != cache_.end()) {
-				DeleteTexture(entryIter);
-			}
-
-			const AttachCandidate &candidate = candidates[index];
-			nextTexture_ = nullptr;
-			nextNeedsRebuild_ = false;
-			SetTextureFramebuffer(candidate);  // sets curTexture3D
-			return nullptr;
+	AttachCandidate bestCandidate;
+	if (GetBestFramebufferCandidate(def, 0, &bestCandidate)) {
+		// If we had a texture entry here, let's get rid of it.
+		if (entryIter != cache_.end()) {
+			DeleteTexture(entryIter);
 		}
+
+		nextTexture_ = nullptr;
+		nextNeedsRebuild_ = false;
+		SetTextureFramebuffer(bestCandidate);  // sets curTexture3D
+		return nullptr;
 	}
 
 	// Didn't match a framebuffer, keep going.
@@ -617,7 +613,7 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 	return entry;
 }
 
-std::vector<AttachCandidate> TextureCacheCommon::GetFramebufferCandidates(const TextureDefinition &entry, u32 texAddrOffset) {
+bool TextureCacheCommon::GetBestFramebufferCandidate(const TextureDefinition &entry, u32 texAddrOffset, AttachCandidate *bestCandidate) const {
 	gpuStats.numFramebufferEvaluations++;
 
 	std::vector<AttachCandidate> candidates;
@@ -635,29 +631,24 @@ std::vector<AttachCandidate> TextureCacheCommon::GetFramebufferCandidates(const 
 		}
 	}
 
-	if (candidates.size() > 1) {
-		if (Reporting::ShouldLogNTimes("multifbcandidate", 5)) {
-			std::string cands;
-				for (auto &candidate : candidates) {
-					cands += candidate.ToString() + "\n";
-				}
-
-			WARN_LOG_N_TIMES(multifbcandidate, 5, G3D, "GetFramebufferCandidates: Multiple (%d) candidate framebuffers. texaddr: %08x offset: %d (%dx%d stride %d, %s):\n%s",
-				(int)candidates.size(),
-				entry.addr, texAddrOffset, dimWidth(entry.dim), dimHeight(entry.dim), entry.bufw, GeTextureFormatToString(entry.format),
-				cands.c_str()
-			);
-		}
+	if (candidates.size() == 0) {
+		return false;
+	} else if (candidates.size() == 1) {
+		*bestCandidate = candidates[0];
+		return true;
 	}
 
-	return candidates;
-}
+	if (Reporting::ShouldLogNTimes("multifbcandidate", 5)) {
+		std::string cands;
+			for (auto &candidate : candidates) {
+				cands += candidate.ToString() + "\n";
+			}
 
-int TextureCacheCommon::GetBestCandidateIndex(const std::vector<AttachCandidate> &candidates) {
-	_dbg_assert_(!candidates.empty());
-
-	if (candidates.size() == 1) {
-		return 0;
+		WARN_LOG_N_TIMES(multifbcandidate, 5, G3D, "GetFramebufferCandidates: Multiple (%d) candidate framebuffers. texaddr: %08x offset: %d (%dx%d stride %d, %s):\n%s",
+			(int)candidates.size(),
+			entry.addr, texAddrOffset, dimWidth(entry.dim), dimHeight(entry.dim), entry.bufw, GeTextureFormatToString(entry.format),
+			cands.c_str()
+		);
 	}
 
 	// OK, multiple possible candidates. Will need to figure out which one is the most relevant.
@@ -692,7 +683,12 @@ int TextureCacheCommon::GetBestCandidateIndex(const std::vector<AttachCandidate>
 		}
 	}
 
-	return bestIndex;
+	if (bestIndex != -1) {
+		*bestCandidate = candidates[bestIndex];
+		return true;
+	} else {
+		return false;
+	}
 }
 
 // Removes old textures.
@@ -1111,15 +1107,13 @@ bool TextureCacheCommon::SetOffsetTexture(u32 yOffset) {
 	def.bufw = GetTextureBufw(0, texaddr, fmt);
 	def.dim = gstate.getTextureDimension(0);
 
-	std::vector<AttachCandidate> candidates = GetFramebufferCandidates(def, texaddrOffset);
-	if (candidates.size() > 0) {
-		int index = GetBestCandidateIndex(candidates);
-		if (index != -1) {
-			SetTextureFramebuffer(candidates[index]);
-			return true;
-		}
+	AttachCandidate bestCandidate;
+	if (GetBestFramebufferCandidate(def, texaddrOffset, &bestCandidate)) {
+		SetTextureFramebuffer(bestCandidate);
+		return true;
+	} else {
+		return false;
 	}
-	return false;
 }
 
 void TextureCacheCommon::NotifyConfigChanged() {

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -381,8 +381,7 @@ protected:
 
 	bool MatchFramebuffer(const TextureDefinition &entry, VirtualFramebuffer *framebuffer, u32 texaddrOffset, RasterChannel channel, FramebufferMatchInfo *matchInfo) const;
 
-	std::vector<AttachCandidate> GetFramebufferCandidates(const TextureDefinition &entry, u32 texAddrOffset);
-	int GetBestCandidateIndex(const std::vector<AttachCandidate> &candidates);
+	bool GetBestFramebufferCandidate(const TextureDefinition &entry, u32 texAddrOffset, AttachCandidate *bestCandidate) const;
 
 	void SetTextureFramebuffer(const AttachCandidate &candidate);
 

--- a/GPU/D3D11/StateMappingD3D11.cpp
+++ b/GPU/D3D11/StateMappingD3D11.cpp
@@ -142,7 +142,7 @@ void DrawEngineD3D11::ApplyDrawState(int prim) {
 	bool useBufferedRendering = framebufferManager_->UseBufferedRendering();
 	// Blend
 	if (gstate_c.IsDirty(DIRTY_BLEND_STATE)) {
-		gstate_c.SetAllowFramebufferRead(!g_Config.bDisableSlowFramebufEffects);
+		gstate_c.SetAllowFramebufferRead(!g_Config.bDisableShaderBlending);
 		if (gstate.isModeClear()) {
 			keys_.blend.value = 0;  // full wipe
 			keys_.blend.blendEnable = false;

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -119,7 +119,7 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 	bool useBufferedRendering = framebufferManager_->UseBufferedRendering();
 
 	if (gstate_c.IsDirty(DIRTY_BLEND_STATE)) {
-		gstate_c.SetAllowFramebufferRead(!g_Config.bDisableSlowFramebufEffects);
+		gstate_c.SetAllowFramebufferRead(!g_Config.bDisableShaderBlending);
 		if (gstate.isModeClear()) {
 			dxstate.blend.disable();
 			// Color Mask

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -145,7 +145,7 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 	bool useBufferedRendering = framebufferManager_->UseBufferedRendering();
 
 	if (gstate_c.IsDirty(DIRTY_BLEND_STATE)) {
-		gstate_c.SetAllowFramebufferRead(!g_Config.bDisableSlowFramebufEffects);
+		gstate_c.SetAllowFramebufferRead(!g_Config.bDisableShaderBlending);
 
 		if (gstate.isModeClear()) {
 			// Color Test

--- a/GPU/Vulkan/StateMappingVulkan.cpp
+++ b/GPU/Vulkan/StateMappingVulkan.cpp
@@ -136,7 +136,7 @@ void DrawEngineVulkan::ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManag
 	bool useBufferedRendering = framebufferManager_->UseBufferedRendering();
 
 	if (gstate_c.IsDirty(DIRTY_BLEND_STATE)) {
-		gstate_c.SetAllowFramebufferRead(!g_Config.bDisableSlowFramebufEffects);
+		gstate_c.SetAllowFramebufferRead(!g_Config.bDisableShaderBlending);
 		if (gstate.isModeClear()) {
 			key.logicOpEnable = false;
 			key.logicOp = VK_LOGIC_OP_CLEAR;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -507,7 +507,7 @@ void GameSettingsScreen::CreateViews() {
 	});
 	texSecondary_->SetDisabledPtr(&g_Config.bSoftwareRendering);
 
-	CheckBox *framebufferSlowEffects = graphicsSettings->Add(new CheckBox(&g_Config.bDisableSlowFramebufEffects, gr->T("Disable slower effects (speedup)")));
+	CheckBox *framebufferSlowEffects = graphicsSettings->Add(new CheckBox(&g_Config.bDisableShaderBlending, gr->T("Disable slower effects (speedup)")));
 	framebufferSlowEffects->SetDisabledPtr(&g_Config.bSoftwareRendering);
 
 	// Seems solid, so we hide the setting.

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -528,7 +528,7 @@ ULJM08033 = true
 NPJH50373 = true
 NPUH10191 = true
 NPUH10197 = true
-# Grand Knights History need it to fix blackboxes on characters and flickering texture . See issues #2135 , #6099
+# Grand Knights History need it to fix blackboxes on characters and flickering texture . See issues #2135, #6099
 ULJS00394 = true
 ULJS19068 = true	
 NPJH50518 = true

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -563,7 +563,7 @@ static RetroOption<bool> ppsspp_lazy_texture_caching("ppsspp_lazy_texture_cachin
 static RetroOption<bool> ppsspp_retain_changed_textures("ppsspp_retain_changed_textures", "Retain changed textures (Speedup, mem hog)", false);
 static RetroOption<bool> ppsspp_force_lag_sync("ppsspp_force_lag_sync", "Force real clock sync (Slower, less lag)", false);
 static RetroOption<int> ppsspp_spline_quality("ppsspp_spline_quality", "Spline/Bezier curves quality", { {"Low", 0}, {"Medium", 1}, {"High", 2} });
-static RetroOption<bool> ppsspp_disable_slow_framebuffer_effects("ppsspp_disable_slow_framebuffer_effects", "Disable slower effects (Speedup)", false);
+static RetroOption<bool> ppsspp_disable_shader_blending("ppsspp_disable_slow_framebuffer_effects", "Disable shader blending (speedup)", false);
 static RetroOption<bool> ppsspp_enable_wlan("ppsspp_enable_wlan", "Enable Networking/WLAN (beta, may break games)", false);
 static RetroOption<std::string> ppsspp_change_mac_address[] = {
     {"ppsspp_change_mac_address01", "MAC address Pt  1: X-:--:--:--:--:--", MAC_INITIALIZER_LIST},
@@ -699,7 +699,7 @@ void retro_set_environment(retro_environment_t cb)
    vars.push_back(ppsspp_lazy_texture_caching.GetOptions());
    vars.push_back(ppsspp_retain_changed_textures.GetOptions());
    vars.push_back(ppsspp_force_lag_sync.GetOptions());
-   vars.push_back(ppsspp_disable_slow_framebuffer_effects.GetOptions());
+   vars.push_back(ppsspp_disable_shader_blending.GetOptions());
    vars.push_back(ppsspp_lower_resolution_for_effects.GetOptions());
    vars.push_back(ppsspp_texture_scaling_level.GetOptions());
    vars.push_back(ppsspp_texture_scaling_type.GetOptions());
@@ -831,7 +831,7 @@ static void check_variables(CoreParameter &coreParam)
    ppsspp_retain_changed_textures.Update(&g_Config.bTextureSecondaryCache);
    ppsspp_force_lag_sync.Update(&g_Config.bForceLagSync);
    ppsspp_spline_quality.Update(&g_Config.iSplineBezierQuality);
-   ppsspp_disable_slow_framebuffer_effects.Update(&g_Config.bDisableSlowFramebufEffects);
+   ppsspp_disable_shader_blending.Update(&g_Config.bDisableShaderBlending);
    ppsspp_inflight_frames.Update(&g_Config.iInflightFrames);
    const bool do_scaling_type_update = ppsspp_texture_scaling_type.Update(&g_Config.iTexScalingType);
    const bool do_scaling_level_update = ppsspp_texture_scaling_level.Update(&g_Config.iTexScalingLevel);


### PR DESCRIPTION
The two settings "Disable slow framebuf effects" and "Enable block transfers" were kind of mixed up.

Now "Enable block transfers" is effectively "Enable color readbacks",. while "Disable slow framebuf effects" disables shader blending. Depal is now always enabled.

Considering maybe removing the shader blending flag entirely - the really slow thing is color readbacks, the others are not that interesting to selectively disable/enable, unless you're really trying to tweak for some low power device or you're dealing with some pathological game that we should solve in a better way anyway.

The new block transfer matching code was a little heavy with its debug logging. Optimize.

Not changing the translatable strings yet, will do after some more reorganization, it'll be clearer what make sense then maybe.