### PR TITLE
Fix reload of replaced textures after decimate

### DIFF
--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -970,6 +970,7 @@ void ReplacedTexture::PrepareData(int level) {
 void ReplacedTexture::PurgeIfOlder(double t) {
 	if (lastUsed_ < t && (!threadWaitable_ || threadWaitable_->WaitFor(0.0))) {
 		levelData_.clear();
+		initDone_ = false;
 	}
 }
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2380,7 +2380,7 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 		}
 	}
 
-	if (plan.isVideo || isPPGETexture) {
+	if (isPPGETexture) {
 		plan.replaced = &replacer_.FindNone();
 		plan.replaceValid = false;
 	} else {

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -628,7 +628,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 				entry->vkTex->UploadMip(cmdInit, i, mipWidth, mipHeight, 0, texBuf, bufferOffset, stride / bpp);
 				VK_PROFILE_END(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT);
 			}
-			if (replacer_.Enabled()) {
+			if (replacer_.Enabled() && plan.replaced->IsInvalid()) {
 				// When hardware texture scaling is enabled, this saves the original.
 				int w = dataScaled ? mipWidth : mipUnscaledWidth;
 				int h = dataScaled ? mipHeight : mipUnscaledHeight;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -508,7 +508,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 	image->SetTag(texName);
 
 	bool allocSuccess = image->CreateDirect(cmdInit, plan.createW, plan.createH, plan.depth, plan.levelsToCreate, actualFmt, imageLayout, usage, mapping);
-	if (!allocSuccess && !lowMemoryMode_ && !replacer_.Enabled()) {
+	if (!allocSuccess && !lowMemoryMode_) {
 		WARN_LOG_REPORT(G3D, "Texture cache ran out of GPU memory; switching to low memory mode");
 		lowMemoryMode_ = true;
 		decimationCounter_ = 0;
@@ -628,7 +628,8 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 				entry->vkTex->UploadMip(cmdInit, i, mipWidth, mipHeight, 0, texBuf, bufferOffset, stride / bpp);
 				VK_PROFILE_END(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT);
 			}
-			if (replacer_.Enabled() && plan.replaced->IsInvalid()) {
+			// Format might be wrong in lowMemoryMode_, so don't save.
+			if (replacer_.Enabled() && plan.replaced->IsInvalid() && !lowMemoryMode_) {
 				// When hardware texture scaling is enabled, this saves the original.
 				int w = dataScaled ? mipWidth : mipUnscaledWidth;
 				int h = dataScaled ? mipHeight : mipUnscaledHeight;


### PR DESCRIPTION
Oops, missed clearing the initDone_ flag after undoing init.  That seems to be the cause of #15931 (I actually reproduced much wilder flickering than just black textures by decimating.)

-[Unknown]