### PR TITLE
vertexjit: Clamp through float pos during decode

### DIFF
--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -136,7 +136,6 @@ static const JitLookup jitLookup[] = {
 
 	{&VertexDecoder::Step_PosS8Through, &VertexDecoderJitCache::Jit_PosS8Through},
 	{&VertexDecoder::Step_PosS16Through, &VertexDecoderJitCache::Jit_PosS16Through},
-	{&VertexDecoder::Step_PosFloatThrough, &VertexDecoderJitCache::Jit_PosFloat},
 
 	{&VertexDecoder::Step_PosS8, &VertexDecoderJitCache::Jit_PosS8},
 	{&VertexDecoder::Step_PosS16, &VertexDecoderJitCache::Jit_PosS16},
@@ -882,7 +881,7 @@ void VertexDecoderJitCache::Jit_PosS8Through() {
 	// TODO: SIMD
 	LDRSB(tempReg1, srcReg, dec_->posoff);
 	LDRSB(tempReg2, srcReg, dec_->posoff + 1);
-	LDRSB(tempReg3, srcReg, dec_->posoff + 2);  // signed?
+	LDRB(tempReg3, srcReg, dec_->posoff + 2);
 	static const ARMReg tr[3] = { tempReg1, tempReg2, tempReg3 };
 	static const ARMReg fr[3] = { fpScratchReg, fpScratchReg2, fpScratchReg3 };
 	ADD(scratchReg, dstReg, dec_->decFmt.posoff);

--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -113,7 +113,7 @@ static const JitLookup jitLookup[] = {
 
 	{&VertexDecoder::Step_PosS8Through, &VertexDecoderJitCache::Jit_PosS8Through},
 	{&VertexDecoder::Step_PosS16Through, &VertexDecoderJitCache::Jit_PosS16Through},
-	{&VertexDecoder::Step_PosFloatThrough, &VertexDecoderJitCache::Jit_PosFloat},
+	{&VertexDecoder::Step_PosFloatThrough, &VertexDecoderJitCache::Jit_PosFloatThrough},
 
 	{&VertexDecoder::Step_PosS8, &VertexDecoderJitCache::Jit_PosS8},
 	{&VertexDecoder::Step_PosS16, &VertexDecoderJitCache::Jit_PosS16},
@@ -670,7 +670,7 @@ void VertexDecoderJitCache::Jit_PosFloat() {
 void VertexDecoderJitCache::Jit_PosS8Through() {
 	LDRSB(INDEX_UNSIGNED, tempReg1, srcReg, dec_->posoff);
 	LDRSB(INDEX_UNSIGNED, tempReg2, srcReg, dec_->posoff + 1);
-	LDRSB(INDEX_UNSIGNED, tempReg3, srcReg, dec_->posoff + 2);  // signed?
+	LDRB(INDEX_UNSIGNED, tempReg3, srcReg, dec_->posoff + 2);
 	fp.SCVTF(fpScratchReg, tempReg1);
 	fp.SCVTF(fpScratchReg2, tempReg2);
 	fp.SCVTF(fpScratchReg3, tempReg3);
@@ -689,6 +689,25 @@ void VertexDecoderJitCache::Jit_PosS16Through() {
 	LDRH(INDEX_UNSIGNED, tempReg3, srcReg, dec_->posoff + 4);
 	fp.SCVTF(src[1], tempReg3);
 	STR(INDEX_UNSIGNED, src[1], dstReg, dec_->decFmt.posoff + 8);
+}
+
+void VertexDecoderJitCache::Jit_PosFloatThrough() {
+	// Instead of just copying 12 bytes, we copy 8 and clamp Z.
+	if ((dec_->posoff & 7) == 0 && (dec_->decFmt.posoff & 7) == 0) {
+		LDR(INDEX_UNSIGNED, EncodeRegTo64(tempReg1), srcReg, dec_->posoff);
+		STR(INDEX_UNSIGNED, EncodeRegTo64(tempReg1), dstReg, dec_->decFmt.posoff);
+	} else {
+		LDP(INDEX_SIGNED, tempReg1, tempReg2, srcReg, dec_->posoff);
+		STP(INDEX_SIGNED, tempReg1, tempReg2, dstReg, dec_->decFmt.posoff);
+	}
+
+	fp.LDUR(32, neonScratchRegD, srcReg, dec_->posoff + 8);
+	fp.FCVTZU(32, neonScratchRegD, neonScratchRegD);
+	// Narrow to 16 bit, saturating meanwhile.
+	fp.UQXTN(16, neonScratchRegD, neonScratchRegD);
+	fp.UXTL(16, neonScratchRegD, neonScratchRegD);
+	fp.UCVTF(32, neonScratchRegD, neonScratchRegD);
+	fp.STUR(32, neonScratchRegD, dstReg, dec_->decFmt.posoff + 8);
 }
 
 void VertexDecoderJitCache::Jit_NormalS8() {

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -1264,6 +1264,8 @@ void VertexDecoder::SetVertexType(u32 fmt, const VertexDecoderOptions &options, 
 		ERROR_LOG_REPORT(G3D, "Vertices without position found: (%08x) %s", fmt_, temp);
 	}
 
+	_assert_msg_(decFmt.posfmt == DEC_FLOAT_3, "Reader only supports float pos");
+
 	// Attempt to JIT as well. But only do that if the main CPU JIT is enabled, in order to aid
 	// debugging attempts - if the main JIT doesn't work, this one won't do any better, probably.
 	if (jitCache && g_Config.bVertexDecoderJit && g_Config.iCpuCore == (int)CPUCore::JIT) {

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -776,10 +776,11 @@ void VertexDecoder::Step_PosFloatSkin() const
 void VertexDecoder::Step_PosS8Through() const
 {
 	float *v = (float *)(decoded_ + decFmt.posoff);
-	const s8 *sv = (const s8*)(ptr_ + posoff);
+	const s8 *sv = (const s8 *)(ptr_ + posoff);
+	const u8 *uv = (const u8 *)(ptr_ + posoff);
 	v[0] = sv[0];
 	v[1] = sv[1];
-	v[2] = sv[2];
+	v[2] = uv[2];
 }
 
 void VertexDecoder::Step_PosS16Through() const
@@ -794,9 +795,10 @@ void VertexDecoder::Step_PosS16Through() const
 
 void VertexDecoder::Step_PosFloatThrough() const
 {
-	u8 *v = (u8 *)(decoded_ + decFmt.posoff);
-	const u8 *fv = (const u8 *)(ptr_ + posoff);
-	memcpy(v, fv, 12);
+	float *v = (float *)(decoded_ + decFmt.posoff);
+	const float *fv = (const float *)(ptr_ + posoff);
+	memcpy(v, fv, 8);
+	v[2] = fv[2] > 65535.0f ? 65535.0f : (fv[2] < 0.0f ? 0.0f : fv[2]);
 }
 
 void VertexDecoder::Step_PosS8Morph() const

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -1265,6 +1265,7 @@ void VertexDecoder::SetVertexType(u32 fmt, const VertexDecoderOptions &options, 
 	}
 
 	_assert_msg_(decFmt.posfmt == DEC_FLOAT_3, "Reader only supports float pos");
+	_assert_msg_(decFmt.uvfmt == DEC_FLOAT_2 || decFmt.uvfmt == DEC_NONE, "Reader only supports float UV");
 
 	// Attempt to JIT as well. But only do that if the main CPU JIT is enabled, in order to aid
 	// debugging attempts - if the main JIT doesn't work, this one won't do any better, probably.

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -121,100 +121,22 @@ public:
 	VertexReader(u8 *base, const DecVtxFormat &decFmt, int vtype) : base_(base), data_(base), decFmt_(decFmt), vtype_(vtype) {}
 
 	void ReadPos(float pos[3]) const {
-		switch (decFmt_.posfmt) {
-		case DEC_FLOAT_3:
-			{
-				const float *f = (const float *)(data_ + decFmt_.posoff);
-				pos[0] = f[0];
-				pos[1] = f[1];
-				if (!isThrough()) {
-					pos[2] = f[2];
-				} else {
-					// Integer value passed in a float. Clamped to 0, 65535.
-					pos[2] = (int)f[2] * (1.0f / 65535.0f);
-				}
-			}
-			break;
-		case DEC_S16_3:
-			{
-				// X and Y are signed 16 bit, Z is unsigned 16 bit
-				const s16 *s = (const s16 *)(data_ + decFmt_.posoff);
-				const u16 *u = (const u16 *)(data_ + decFmt_.posoff);
-				if (isThrough()) {
-					for (int i = 0; i < 2; i++)
-						pos[i] = s[i];
-					pos[2] = u[2] * (1.0f / 65535.0f);
-				} else {
-					for (int i = 0; i < 3; i++)
-						pos[i] = s[i] * (1.0f / 32768.0f);
-				}
-			}
-			break;
-		case DEC_S8_3:
-			{
-				// X and Y are signed 8 bit, Z is unsigned 8 bit
-				const s8 *b = (const s8 *)(data_ + decFmt_.posoff);
-				const u8 *u = (const u8 *)(data_ + decFmt_.posoff);
-				if (isThrough()) {
-					for (int i = 0; i < 2; i++)
-						pos[i] = b[i];
-					pos[2] = u[2] * (1.0f / 255.0f);
-				} else {
-					for (int i = 0; i < 3; i++)
-						pos[i] = b[i] * (1.0f / 128.0f);
-				}
-			}
-			break;
-		default:
-			ERROR_LOG_REPORT_ONCE(fmtpos, G3D, "Reader: Unsupported Pos Format %d", decFmt_.posfmt);
-			memset(pos, 0, sizeof(float) * 3);
-			break;
+		// Only DEC_FLOAT_3 is supported.
+		const float *f = (const float *)(data_ + decFmt_.posoff);
+		pos[0] = f[0];
+		pos[1] = f[1];
+		if (!isThrough()) {
+			pos[2] = f[2];
+		} else {
+			// Integer value passed in a float. Clamped to 0, 65535.
+			pos[2] = (int)f[2] * (1.0f / 65535.0f);
 		}
 	}
 
 	void ReadPosThroughZ16(float pos[3]) const {
-		switch (decFmt_.posfmt) {
-		case DEC_FLOAT_3:
-			{
-				const float *f = (const float *)(data_ + decFmt_.posoff);
-				memcpy(pos, f, 12);
-			}
-			break;
-		case DEC_S16_3:
-			{
-				// X and Y are signed 16 bit, Z is unsigned 16 bit
-				const s16 *s = (const s16 *)(data_ + decFmt_.posoff);
-				const u16 *u = (const u16 *)(data_ + decFmt_.posoff);
-				if (isThrough()) {
-					for (int i = 0; i < 2; i++)
-						pos[i] = s[i];
-					pos[2] = u[2];
-				} else {
-					for (int i = 0; i < 3; i++)
-						pos[i] = s[i] * (1.0f / 32768.0f);
-				}
-			}
-			break;
-		case DEC_S8_3:
-			{
-				// X and Y are signed 8 bit, Z is unsigned 8 bit
-				const s8 *b = (const s8 *)(data_ + decFmt_.posoff);
-				const u8 *u = (const u8 *)(data_ + decFmt_.posoff);
-				if (isThrough()) {
-					for (int i = 0; i < 2; i++)
-						pos[i] = b[i];
-					pos[2] = u[2];
-				} else {
-					for (int i = 0; i < 3; i++)
-						pos[i] = b[i] * (1.0f / 128.0f);
-				}
-			}
-			break;
-		default:
-			ERROR_LOG_REPORT_ONCE(fmtz16, G3D, "Reader: Unsupported Pos Format %d", decFmt_.posfmt);
-			memset(pos, 0, sizeof(float) * 3);
-			break;
-		}
+		// Only DEC_FLOAT_3 is supported.
+		const float *f = (const float *)(data_ + decFmt_.posoff);
+		memcpy(pos, f, 12);
 	}
 
 	void ReadNrm(float nrm[3]) const {

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -171,36 +171,10 @@ public:
 	}
 
 	void ReadUV(float uv[2]) const {
-		switch (decFmt_.uvfmt) {
-		case DEC_U8_2:
-			{
-				const u8 *b = (const u8 *)(data_ + decFmt_.uvoff);
-				uv[0] = b[0] * (1.f / 128.f);
-				uv[1] = b[1] * (1.f / 128.f);
-			}
-			break;
-
-		case DEC_U16_2:
-			{
-				const u16 *s = (const u16 *)(data_ + decFmt_.uvoff);
-				uv[0] = s[0] * (1.f / 32768.f);
-				uv[1] = s[1] * (1.f / 32768.f);
-			}
-			break;
-
-		case DEC_FLOAT_2:
-			{
-				const float *f = (const float *)(data_ + decFmt_.uvoff);
-				uv[0] = f[0];
-				uv[1] = f[1];
-			}
-			break;
-
-		default:
-			ERROR_LOG_REPORT_ONCE(fmtuv, G3D, "Reader: Unsupported UV Format %d", decFmt_.uvfmt);
-			memset(uv, 0, sizeof(float) * 2);
-			break;
-		}
+		// Only DEC_FLOAT_2 is supported.
+		const float *f = (const float *)(data_ + decFmt_.uvoff);
+		uv[0] = f[0];
+		uv[1] = f[1];
 	}
 
 	void ReadColor0(float color[4]) const {

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -131,8 +131,7 @@ public:
 					pos[2] = f[2];
 				} else {
 					// Integer value passed in a float. Clamped to 0, 65535.
-					const float z = (int)f[2] * (1.0f / 65535.0f);
-					pos[2] = z > 1.0f ? 1.0f : (z < 0.0f ? 0.0f : z);
+					pos[2] = (int)f[2] * (1.0f / 65535.0f);
 				}
 			}
 			break;
@@ -179,11 +178,6 @@ public:
 			{
 				const float *f = (const float *)(data_ + decFmt_.posoff);
 				memcpy(pos, f, 12);
-				if (isThrough()) {
-					// Integer value passed in a float. Clamped to 0, 65535.
-					const float z = (int)pos[2];
-					pos[2] = z > 65535.0f ? 65535.0f : (z < 0.0f ? 0.0f : z);
-				}
 			}
 			break;
 		case DEC_S16_3:
@@ -666,6 +660,7 @@ public:
 	void Jit_PosFloat();
 	void Jit_PosS8Through();
 	void Jit_PosS16Through();
+	void Jit_PosFloatThrough();
 
 	void Jit_PosS8Skin();
 	void Jit_PosS16Skin();

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -138,7 +138,7 @@ static const JitLookup jitLookup[] = {
 
 	{&VertexDecoder::Step_PosS8Through, &VertexDecoderJitCache::Jit_PosS8Through},
 	{&VertexDecoder::Step_PosS16Through, &VertexDecoderJitCache::Jit_PosS16Through},
-	{&VertexDecoder::Step_PosFloatThrough, &VertexDecoderJitCache::Jit_PosFloat},
+	{&VertexDecoder::Step_PosFloatThrough, &VertexDecoderJitCache::Jit_PosFloatThrough},
 
 	{&VertexDecoder::Step_PosS8, &VertexDecoderJitCache::Jit_PosS8},
 	{&VertexDecoder::Step_PosS16, &VertexDecoderJitCache::Jit_PosS16},
@@ -1348,7 +1348,10 @@ void VertexDecoderJitCache::Jit_PosS8Through() {
 	DEBUG_LOG_REPORT_ONCE(vertexS8Through, G3D, "Using S8 positions in throughmode");
 	// SIMD doesn't really matter since this isn't useful on hardware.
 	for (int i = 0; i < 3; i++) {
-		MOVSX(32, 8, tempReg1, MDisp(srcReg, dec_->posoff + i));
+		if (i == 2)
+			MOVZX(32, 8, tempReg1, MDisp(srcReg, dec_->posoff + i));
+		else
+			MOVSX(32, 8, tempReg1, MDisp(srcReg, dec_->posoff + i));
 		CVTSI2SS(fpScratchReg, R(tempReg1));
 		MOVSS(MDisp(dstReg, dec_->decFmt.posoff + i * 4), fpScratchReg);
 	}
@@ -1375,6 +1378,29 @@ void VertexDecoderJitCache::Jit_PosS16Through() {
 		CVTSI2SS(fpScratchReg, R(tempReg3));
 		MOVSS(MDisp(dstReg, dec_->decFmt.posoff + 8), fpScratchReg);
 	}
+}
+
+void VertexDecoderJitCache::Jit_PosFloatThrough() {
+	PXOR(fpScratchReg2, R(fpScratchReg2));
+	if (cpu_info.Mode64bit) {
+		MOV(64, R(tempReg1), MDisp(srcReg, dec_->posoff));
+		MOVSS(fpScratchReg, MDisp(srcReg, dec_->posoff + 8));
+		MOV(64, MDisp(dstReg, dec_->decFmt.posoff), R(tempReg1));
+	} else {
+		MOV(32, R(tempReg1), MDisp(srcReg, dec_->posoff));
+		MOV(32, R(tempReg2), MDisp(srcReg, dec_->posoff + 4));
+		MOVSS(fpScratchReg, MDisp(srcReg, dec_->posoff + 8));
+		MOV(32, MDisp(dstReg, dec_->decFmt.posoff), R(tempReg1));
+		MOV(32, MDisp(dstReg, dec_->decFmt.posoff + 4), R(tempReg2));
+	}
+
+	CVTTPS2DQ(fpScratchReg, R(fpScratchReg));
+	// Use pack to saturate to 0,65535.
+	PACKUSDW(fpScratchReg, R(fpScratchReg));
+	PUNPCKLWD(fpScratchReg, R(fpScratchReg2));
+	CVTDQ2PS(fpScratchReg, R(fpScratchReg));
+
+	MOVSS(MDisp(dstReg, dec_->decFmt.posoff + 8), fpScratchReg);
 }
 
 void VertexDecoderJitCache::Jit_PosS8() {

--- a/unittest/TestVertexJit.cpp
+++ b/unittest/TestVertexJit.cpp
@@ -400,7 +400,7 @@ static bool TestVertexFloatThrough() {
 		dec.Execute(vtype, 0, jit == 1);
 		dec.AssertFloat("TestVertexFloatThrough-TC", 1.0f, -1.0f);
 		dec.AssertFloat("TestVertexFloatThrough-Nrm", 1.0f, 0.5f, -1.0f);
-		dec.AssertFloat("TestVertexFloatThrough-Pos", 1.0f, 0.5f, -1.0f);
+		dec.AssertFloat("TestVertexFloatThrough-Pos", 1.0f, 0.5f, 0.0f);
 	}
 
 	return !dec.HasFailed();


### PR DESCRIPTION
This is a very minor tweak that I had mostly-finished laying around in another branch.

Basically, this just moves the clamping to the decode step, which means there's no needless clamping done on (common) 16-bit positions in through.  It also removes a couple conditionals on through in the softgpu path, since they're unused.

I changed PosS8Through to match (before it would've been 0-127, now it's 0-255), though it hardly matters since that doesn't properly draw on a PSP anyway.

Could probably also scale by 65535 too, but mostly concerned about softgpu here.

Doesn't make a huge impact to perf but I think it makes more sense.

-[Unknown]