### PR TITLE
Remove Memory::WriteStruct() and ReadStruct()

### DIFF
--- a/Core/Dialog/PSPGamedataInstallDialog.cpp
+++ b/Core/Dialog/PSPGamedataInstallDialog.cpp
@@ -116,9 +116,9 @@ int PSPGamedataInstallDialog::Update(int animSpeed) {
 		WriteSfoFile();
 
 		// TODO: What is this?  Should one of these update per file or anything?
-		request.unknownResult1 = readFiles;
-		request.unknownResult2 = readFiles;
-		Memory::WriteStruct(param.ptr, &request);
+		param->unknownResult1 = readFiles;
+		param->unknownResult2 = readFiles;
+		param.NotifyWrite("DialogResult");
 
 		ChangeStatus(SCE_UTILITY_STATUS_FINISHED, 0);
 	}
@@ -250,8 +250,9 @@ void PSPGamedataInstallDialog::UpdateProgress() {
 		progressValue = (int)((allReadSize * 100) / allFilesSize);
 	else 
 		progressValue = 100;
-	request.progress = progressValue;
-	Memory::WriteStruct(param.ptr, &request);
+
+	param->progress = progressValue;
+	param.NotifyWrite("DialogResult");
 }
 
 void PSPGamedataInstallDialog::DoState(PointerWrap &p) {

--- a/Core/HLE/sceChnnlsv.cpp
+++ b/Core/HLE/sceChnnlsv.cpp
@@ -214,13 +214,12 @@ static int sub_17A8(u8* data)
 	return -261;
 }
 
-static int sceSdGetLastIndex(u32 addressCtx, u32 addressHash, u32 addressKey)
-{
-	pspChnnlsvContext1 ctx;
-	Memory::ReadStruct(addressCtx, &ctx);
-	int res = sceSdGetLastIndex_(ctx, Memory::GetPointerWrite(addressHash), Memory::GetPointerWrite(addressKey));
-	Memory::WriteStruct(addressCtx, &ctx);
-	return res;
+static int sceSdGetLastIndex(u32 addressCtx, u32 addressHash, u32 addressKey) {
+	auto ctx = PSPPointer<pspChnnlsvContext1>::Create(addressCtx);
+	u8 *hash = Memory::GetPointerWrite(addressHash);
+	if (!ctx.IsValid() || !hash)
+		return hleLogError(SCEMISC, 0, "Invalid pointer");
+	return hleLogSuccessI(SCEMISC, sceSdGetLastIndex_(*ctx, hash, Memory::GetPointerWrite(addressKey)));
 }
 
 int sceSdGetLastIndex_(pspChnnlsvContext1& ctx, u8* in_hash, u8* in_key)
@@ -325,13 +324,11 @@ int sceSdGetLastIndex_(pspChnnlsvContext1& ctx, u8* in_hash, u8* in_key)
 	return 0;
 }
 
-static int sceSdSetIndex(u32 addressCtx, int value)
-{
-	pspChnnlsvContext1 ctx;
-	Memory::ReadStruct(addressCtx,&ctx);
-	int res = sceSdSetIndex_(ctx, value);
-	Memory::WriteStruct(addressCtx,&ctx);
-	return res;
+static int sceSdSetIndex(u32 addressCtx, int value) {
+	auto ctx = PSPPointer<pspChnnlsvContext1>::Create(addressCtx);
+	if (!ctx.IsValid())
+		return hleLogError(SCEMISC, 0, "Invalid pointer");
+	return hleLogSuccessI(SCEMISC, sceSdSetIndex_(*ctx, value));
 }
 
 int sceSdSetIndex_(pspChnnlsvContext1& ctx, int value)
@@ -344,14 +341,11 @@ int sceSdSetIndex_(pspChnnlsvContext1& ctx, int value)
 }
 
 
-static int sceSdRemoveValue(u32 addressCtx, u32 addressData, int length)
-{
-	pspChnnlsvContext1 ctx;
-	Memory::ReadStruct(addressCtx, &ctx);
-	int res = sceSdRemoveValue_(ctx, Memory::GetPointerWrite(addressData), length);
-	Memory::WriteStruct(addressCtx, &ctx);
-
-	return res;
+static int sceSdRemoveValue(u32 addressCtx, u32 addressData, int length) {
+	auto ctx = PSPPointer<pspChnnlsvContext1>::Create(addressCtx);
+	if (!ctx.IsValid() || !Memory::IsValidAddress(addressData))
+		return hleLogError(SCEMISC, 0, "Invalid pointer");
+	return hleLogSuccessI(SCEMISC, sceSdRemoveValue_(*ctx, Memory::GetPointerWrite(addressData), length));
 }
 
 int sceSdRemoveValue_(pspChnnlsvContext1& ctx, u8* data, int length)
@@ -396,18 +390,14 @@ int sceSdRemoveValue_(pspChnnlsvContext1& ctx, u8* data, int length)
 	return 0;
 }
 
-static int sceSdCreateList(u32 ctx2Addr, int mode, int unkwn, u32 dataAddr, u32 cryptkeyAddr)
-{
-	pspChnnlsvContext2 ctx2;
-	Memory::ReadStruct(ctx2Addr, &ctx2);
+static int sceSdCreateList(u32 ctx2Addr, int mode, int unkwn, u32 dataAddr, u32 cryptkeyAddr) {
+	auto ctx2 = PSPPointer<pspChnnlsvContext2>::Create(ctx2Addr);
 	u8* data = Memory::GetPointerWrite(dataAddr);
 	u8* cryptkey = Memory::GetPointerWrite(cryptkeyAddr);
+	if (!ctx2.IsValid() || !data)
+		return hleLogError(SCEMISC, 0, "Invalid pointer");
 
-	int res = sceSdCreateList_(ctx2, mode, unkwn, data, cryptkey);
-
-	Memory::WriteStruct(ctx2Addr, &ctx2);
-
-	return res;
+	return hleLogSuccessI(SCEMISC, sceSdCreateList_(*ctx2, mode, unkwn, data, cryptkey));
 }
 
 int sceSdCreateList_(pspChnnlsvContext2& ctx2, int mode, int uknw, u8* data, u8* cryptkey)
@@ -464,17 +454,13 @@ int sceSdCreateList_(pspChnnlsvContext2& ctx2, int mode, int uknw, u8* data, u8*
 	return 0;
 }
 
-static int sceSdSetMember(u32 ctxAddr, u32 dataAddr, int alignedLen)
-{
-	pspChnnlsvContext2 ctx;
-	Memory::ReadStruct(ctxAddr, &ctx);
-	u8* data = Memory::GetPointerWrite(dataAddr);
+static int sceSdSetMember(u32 ctxAddr, u32 dataAddr, int alignedLen) {
+	auto ctx = PSPPointer<pspChnnlsvContext2>::Create(ctxAddr);
+	u8 *data = Memory::GetPointerWrite(dataAddr);
+	if (!ctx.IsValid() || !data)
+		return hleLogError(SCEMISC, 0, "Invalid pointer");
 
-	int res = sceSdSetMember_(ctx, data, alignedLen);
-
-	Memory::WriteStruct(ctxAddr, &ctx);
-
-	return res;
+	return hleLogSuccessI(SCEMISC, sceSdSetMember_(*ctx, data, alignedLen));
 }
 
 int sceSdSetMember_(pspChnnlsvContext2& ctx, u8* data, int alignedLen)
@@ -511,15 +497,11 @@ int sceSdSetMember_(pspChnnlsvContext2& ctx, u8* data, int alignedLen)
 	return res;
 }
 
-static int sceChnnlsv_21BE78B4(u32 ctxAddr)
-{
-	pspChnnlsvContext2 ctx;
-	Memory::ReadStruct(ctxAddr, &ctx);
-
-	int res = sceChnnlsv_21BE78B4_(ctx);
-
-	Memory::WriteStruct(ctxAddr, &ctx);
-	return res;
+static int sceChnnlsv_21BE78B4(u32 ctxAddr) {
+	auto ctx = PSPPointer<pspChnnlsvContext2>::Create(ctxAddr);
+	if (!ctx.IsValid())
+		return hleLogError(SCEMISC, 0, "Invalid pointer");
+	return hleLogSuccessI(SCEMISC, sceChnnlsv_21BE78B4_(*ctx));
 }
 
 int sceChnnlsv_21BE78B4_(pspChnnlsvContext2& ctx)

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -486,8 +486,8 @@ public:
 		// For save states only.
 	}
 
-	FontLib(u32 paramPtr, u32 errorCodePtr) {
-		Memory::ReadStruct(paramPtr, &params_);
+	FontLib(FontNewLibParams *params, u32 errorCodePtr) {
+		params_ = *params;
 		if (params_.numFonts > 9) {
 			params_.numFonts = 9;
 		}
@@ -998,7 +998,7 @@ static u32 sceFontNewLib(u32 paramPtr, u32 errorCodePtr) {
 	INFO_LOG(SCEFONT, "sceFontNewLib(%08x, %08x)", paramPtr, errorCodePtr);
 	*errorCode = 0;
 
-	FontLib *newLib = new FontLib(paramPtr, errorCodePtr);
+	FontLib *newLib = new FontLib(params, errorCodePtr);
 	fontLibList.push_back(newLib);
 	// The game should never see this value, the return value is replaced
 	// by the action. Except if we disable the alloc, in this case we return

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -646,12 +646,12 @@ struct SystemStatus {
 
 static int sceKernelReferSystemStatus(u32 statusPtr) {
 	DEBUG_LOG(SCEKERNEL, "sceKernelReferSystemStatus(%08x)", statusPtr);
-	if (Memory::IsValidAddress(statusPtr)) {
-		SystemStatus status;
-		memset(&status, 0, sizeof(SystemStatus));
-		status.size = sizeof(SystemStatus);
+	auto status = PSPPointer<SystemStatus>::Create(statusPtr);
+	if (status.IsValid()) {
+		memset((SystemStatus *)status, 0, sizeof(SystemStatus));
+		status->size = sizeof(SystemStatus);
 		// TODO: Fill in the struct!
-		Memory::WriteStruct(statusPtr, &status);
+		status.NotifyWrite("SystemStatus");
 	}
 	return 0;
 }
@@ -684,11 +684,11 @@ static u32 sceKernelReferThreadProfiler(u32 statusPtr) {
 
 	// Can we confirm that the struct above is the right struct?
 	// If so, re-enable this code.
-	//DebugProfilerRegs regs;
-	//memset(&regs, 0, sizeof(regs));
+	//auto regs = PSPPointer<DebugProfilerRegs>::Create(statusPtr);
 	// TODO: fill the struct.
-	//if (Memory::IsValidAddress(statusPtr)) {
-	//	Memory::WriteStruct(statusPtr, &regs);
+	//if (regs.IsValid()) {
+	//	memset((DebugProfilerRegs *)regs, 0, sizeof(DebugProfilerRegs));
+	//	regs.NotifyWrite("ThreadProfiler");
 	//}
 	return 0;
 }
@@ -715,14 +715,14 @@ const HLEFunction ThreadManForUser[] =
 	{0XD6DA4BA1, &WrapI_CUIIU<sceKernelCreateSema>,                  "sceKernelCreateSema",                       'i', "sxiix"   },
 	{0X28B6489C, &WrapI_I<sceKernelDeleteSema>,                      "sceKernelDeleteSema",                       'i', "i"       },
 	{0X58B1F937, &WrapI_II<sceKernelPollSema>,                       "sceKernelPollSema",                         'i', "ii"      },
-	{0XBC6FEBC5, &WrapI_IU<sceKernelReferSemaStatus>,                "sceKernelReferSemaStatus",                  'i', "ix"      },
+	{0XBC6FEBC5, &WrapI_IU<sceKernelReferSemaStatus>,                "sceKernelReferSemaStatus",                  'i', "ip"      },
 	{0X3F53E640, &WrapI_II<sceKernelSignalSema>,                     "sceKernelSignalSema",                       'i', "ii"      },
 	{0X4E3A1105, &WrapI_IIU<sceKernelWaitSema>,                      "sceKernelWaitSema",                         'i', "iix",    HLE_NOT_IN_INTERRUPT | HLE_NOT_DISPATCH_SUSPENDED },
 	{0X6D212BAC, &WrapI_IIU<sceKernelWaitSemaCB>,                    "sceKernelWaitSemaCB",                       'i', "iix",    HLE_NOT_IN_INTERRUPT | HLE_NOT_DISPATCH_SUSPENDED },
 
 	{0X60107536, &WrapI_U<sceKernelDeleteLwMutex>,                   "sceKernelDeleteLwMutex",                    'i', "x"       },
 	{0X19CFF145, &WrapI_UCUIU<sceKernelCreateLwMutex>,               "sceKernelCreateLwMutex",                    'i', "xsxix"   },
-	{0X4C145944, &WrapI_IU<sceKernelReferLwMutexStatusByID>,         "sceKernelReferLwMutexStatusByID",           'i', "ix"      },
+	{0X4C145944, &WrapI_IU<sceKernelReferLwMutexStatusByID>,         "sceKernelReferLwMutexStatusByID",           'i', "xp"      },
 	// NOTE: LockLwMutex, UnlockLwMutex, and ReferLwMutexStatus are in Kernel_Library, see sceKernelInterrupt.cpp.
 	// The below should not be called directly.
 	//{0x71040D5C, nullptr,                                            "_sceKernelTryLockLwMutex",                  '?', ""        },
@@ -736,7 +736,7 @@ const HLEFunction ThreadManForUser[] =
 	{0X6B30100F, &WrapI_II<sceKernelUnlockMutex>,                    "sceKernelUnlockMutex",                      'i', "ii"      },
 	{0XB7D098C6, &WrapI_CUIU<sceKernelCreateMutex>,                  "sceKernelCreateMutex",                      'i', "sxix"    },
 	{0X0DDCD2C9, &WrapI_II<sceKernelTryLockMutex>,                   "sceKernelTryLockMutex",                     'i', "ii"      },
-	{0XA9C2CB9A, &WrapI_IU<sceKernelReferMutexStatus>,               "sceKernelReferMutexStatus",                 'i', "ix"      },
+	{0XA9C2CB9A, &WrapI_IU<sceKernelReferMutexStatus>,               "sceKernelReferMutexStatus",                 'i', "ip"      },
 	{0X87D9223C, &WrapI_IIU<sceKernelCancelMutex>,                   "sceKernelCancelMutex",                      'i', "iix"     },
 
 	{0XFCCFAD26, &WrapI_I<sceKernelCancelWakeupThread>,              "sceKernelCancelWakeupThread",               'i', "i"       },
@@ -818,7 +818,7 @@ const HLEFunction ThreadManForUser[] =
 	{0XF3986382, &WrapI_IUU<sceKernelReceiveMbxCB>,                  "sceKernelReceiveMbxCB",                     'i', "ixx",    HLE_NOT_IN_INTERRUPT | HLE_NOT_DISPATCH_SUSPENDED },
 	{0X0D81716A, &WrapI_IU<sceKernelPollMbx>,                        "sceKernelPollMbx",                          'i', "ix"      },
 	{0X87D4DD36, &WrapI_IU<sceKernelCancelReceiveMbx>,               "sceKernelCancelReceiveMbx",                 'i', "ix"      },
-	{0XA8E8C846, &WrapI_IU<sceKernelReferMbxStatus>,                 "sceKernelReferMbxStatus",                   'i', "ix"      },
+	{0XA8E8C846, &WrapI_IU<sceKernelReferMbxStatus>,                 "sceKernelReferMbxStatus",                   'i', "ip"      },
 
 	{0X7C0DC2A0, &WrapI_CIUUU<sceKernelCreateMsgPipe>,               "sceKernelCreateMsgPipe",                    'i', "sixxx"   },
 	{0XF0B7DA1C, &WrapI_I<sceKernelDeleteMsgPipe>,                   "sceKernelDeleteMsgPipe",                    'i', "i"       },
@@ -829,7 +829,7 @@ const HLEFunction ThreadManForUser[] =
 	{0XFBFA697D, &WrapI_IUUUUU<sceKernelReceiveMsgPipeCB>,           "sceKernelReceiveMsgPipeCB",                 'i', "ixxxxx"  },
 	{0XDF52098F, &WrapI_IUUUU<sceKernelTryReceiveMsgPipe>,           "sceKernelTryReceiveMsgPipe",                'i', "ixxxx"   },
 	{0X349B864D, &WrapI_IUU<sceKernelCancelMsgPipe>,                 "sceKernelCancelMsgPipe",                    'i', "ixx"     },
-	{0X33BE4024, &WrapI_IU<sceKernelReferMsgPipeStatus>,             "sceKernelReferMsgPipeStatus",               'i', "ix"      },
+	{0X33BE4024, &WrapI_IU<sceKernelReferMsgPipeStatus>,             "sceKernelReferMsgPipeStatus",               'i', "ip"      },
 
 	{0X56C039B5, &WrapI_CIUUU<sceKernelCreateVpl>,                   "sceKernelCreateVpl",                        'i', "sixxx"   },
 	{0X89B3D48C, &WrapI_I<sceKernelDeleteVpl>,                       "sceKernelDeleteVpl",                        'i', "i"       },
@@ -838,7 +838,7 @@ const HLEFunction ThreadManForUser[] =
 	{0XAF36D708, &WrapI_IUU<sceKernelTryAllocateVpl>,                "sceKernelTryAllocateVpl",                   'i', "ixx"     },
 	{0XB736E9FF, &WrapI_IU<sceKernelFreeVpl>,                        "sceKernelFreeVpl",                          'i', "ix"      },
 	{0X1D371B8A, &WrapI_IU<sceKernelCancelVpl>,                      "sceKernelCancelVpl",                        'i', "ix"      },
-	{0X39810265, &WrapI_IU<sceKernelReferVplStatus>,                 "sceKernelReferVplStatus",                   'i', "ix"      },
+	{0X39810265, &WrapI_IU<sceKernelReferVplStatus>,                 "sceKernelReferVplStatus",                   'i', "ip"      },
 
 	{0XC07BB470, &WrapI_CUUUUU<sceKernelCreateFpl>,                  "sceKernelCreateFpl",                        'i', "sxxxxx"  },
 	{0XED1410E0, &WrapI_I<sceKernelDeleteFpl>,                       "sceKernelDeleteFpl",                        'i', "i"       },
@@ -847,7 +847,7 @@ const HLEFunction ThreadManForUser[] =
 	{0X623AE665, &WrapI_IU<sceKernelTryAllocateFpl>,                 "sceKernelTryAllocateFpl",                   'i', "ix"      },
 	{0XF6414A71, &WrapI_IU<sceKernelFreeFpl>,                        "sceKernelFreeFpl",                          'i', "ix"      },
 	{0XA8AA591F, &WrapI_IU<sceKernelCancelFpl>,                      "sceKernelCancelFpl",                        'i', "ix"      },
-	{0XD8199E4C, &WrapI_IU<sceKernelReferFplStatus>,                 "sceKernelReferFplStatus",                   'i', "ix"      },
+	{0XD8199E4C, &WrapI_IU<sceKernelReferFplStatus>,                 "sceKernelReferFplStatus",                   'i', "ip"      },
 
 	{0X20FFF560, &WrapU_CU<sceKernelCreateVTimer>,                   "sceKernelCreateVTimer",                     'x', "sx",     HLE_NOT_IN_INTERRUPT },
 	{0X328F9E52, &WrapU_I<sceKernelDeleteVTimer>,                    "sceKernelDeleteVTimer",                     'x', "i",      HLE_NOT_IN_INTERRUPT },
@@ -866,7 +866,7 @@ const HLEFunction ThreadManForUser[] =
 
 	{0X8DAFF657, &WrapI_CUUUUU<sceKernelCreateTlspl>,                "sceKernelCreateTlspl",                      'i', "sxxxxx"  },
 	{0X32BF938E, &WrapI_I<sceKernelDeleteTlspl>,                     "sceKernelDeleteTlspl",                      'i', "i"       },
-	{0X721067F3, &WrapI_IU<sceKernelReferTlsplStatus>,               "sceKernelReferTlsplStatus",                 'i', "ix"      },
+	{0X721067F3, &WrapI_IU<sceKernelReferTlsplStatus>,               "sceKernelReferTlsplStatus",                 'i', "xp"      },
 	// Not completely certain about args.
 	{0X4A719FB2, &WrapI_I<sceKernelFreeTlspl>,                       "sceKernelFreeTlspl",                        'i', "i"       },
 	// Internal.  Takes (uid, &addr) as parameters... probably.
@@ -931,7 +931,7 @@ const HLEFunction ThreadManForKernel[] =
 	{0xF3986382, &WrapI_IUU<sceKernelReceiveMbxCB>,                  "sceKernelReceiveMbxCB",                     'i', "ixx",    HLE_KERNEL_SYSCALL | HLE_NOT_IN_INTERRUPT | HLE_NOT_DISPATCH_SUSPENDED },
 	{0x0D81716A, &WrapI_IU<sceKernelPollMbx>,                        "sceKernelPollMbx",                          'i', "ix",     HLE_KERNEL_SYSCALL },
 	{0x87D4DD36, &WrapI_IU<sceKernelCancelReceiveMbx>,               "sceKernelCancelReceiveMbx",                 'i', "ix",     HLE_KERNEL_SYSCALL },
-	{0xA8E8C846, &WrapI_IU<sceKernelReferMbxStatus>,                 "sceKernelReferMbxStatus",                   'i', "ix",     HLE_KERNEL_SYSCALL },
+	{0xA8E8C846, &WrapI_IU<sceKernelReferMbxStatus>,                 "sceKernelReferMbxStatus",                   'i', "ip",     HLE_KERNEL_SYSCALL },
 	{0x56C039B5, &WrapI_CIUUU<sceKernelCreateVpl>,                   "sceKernelCreateVpl",                        'i', "sixxx",  HLE_KERNEL_SYSCALL },
 	{0x89B3D48C, &WrapI_I<sceKernelDeleteVpl>,                       "sceKernelDeleteVpl",                        'i', "i",      HLE_KERNEL_SYSCALL },
 	{0xBED27435, &WrapI_IUUU<sceKernelAllocateVpl>,                  "sceKernelAllocateVpl",                      'i', "ixxx",   HLE_KERNEL_SYSCALL | HLE_NOT_IN_INTERRUPT | HLE_NOT_DISPATCH_SUSPENDED },
@@ -939,7 +939,7 @@ const HLEFunction ThreadManForKernel[] =
 	{0xAF36D708, &WrapI_IUU<sceKernelTryAllocateVpl>,                "sceKernelTryAllocateVpl",                   'i', "ixx",    HLE_KERNEL_SYSCALL },
 	{0xB736E9FF, &WrapI_IU<sceKernelFreeVpl>,                        "sceKernelFreeVpl",                          'i', "ix",     HLE_KERNEL_SYSCALL },
 	{0x1D371B8A, &WrapI_IU<sceKernelCancelVpl>,                      "sceKernelCancelVpl",                        'i', "ix",     HLE_KERNEL_SYSCALL },
-	{0x39810265, &WrapI_IU<sceKernelReferVplStatus>,                 "sceKernelReferVplStatus",                   'i', "ix",     HLE_KERNEL_SYSCALL },
+	{0x39810265, &WrapI_IU<sceKernelReferVplStatus>,                 "sceKernelReferVplStatus",                   'i', "ip",     HLE_KERNEL_SYSCALL },
 };
 
 void Register_ThreadManForUser()

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -677,7 +677,7 @@ const HLEFunction Kernel_Library[] =
 	{0XBEA46419, &WrapI_UIU<sceKernelLockLwMutex>,             "sceKernelLockLwMutex",                'i', "xix", HLE_NOT_IN_INTERRUPT | HLE_NOT_DISPATCH_SUSPENDED },
 	{0X1FC64E09, &WrapI_UIU<sceKernelLockLwMutexCB>,           "sceKernelLockLwMutexCB",              'i', "xix", HLE_NOT_IN_INTERRUPT | HLE_NOT_DISPATCH_SUSPENDED },
 	{0X15B6446B, &WrapI_UI<sceKernelUnlockLwMutex>,            "sceKernelUnlockLwMutex",              'i', "xi"   },
-	{0XC1734599, &WrapI_UU<sceKernelReferLwMutexStatus>,       "sceKernelReferLwMutexStatus",         'i', "xx"   },
+	{0XC1734599, &WrapI_UU<sceKernelReferLwMutexStatus>,       "sceKernelReferLwMutexStatus",         'i', "xp"   },
 	{0X293B45B8, &WrapI_V<sceKernelGetThreadId>,               "sceKernelGetThreadId",                'i', ""     },
 	{0XD13BDE95, &WrapI_V<sceKernelCheckThreadStack>,          "sceKernelCheckThreadStack",           'i', ""     },
 	{0X1839852A, &WrapU_UUU<sceKernelMemcpy>,                  "sceKernelMemcpy",                     'x', "xxx"  },

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2902,13 +2902,14 @@ int sceKernelGetCallbackCount(SceUID cbId)
 	}
 }
 
-int sceKernelReferCallbackStatus(SceUID cbId, u32 statusAddr)
-{
+int sceKernelReferCallbackStatus(SceUID cbId, u32 statusAddr) {
 	u32 error;
 	PSPCallback *c = kernelObjects.Get<PSPCallback>(cbId, error);
 	if (c) {
-		if (Memory::IsValidAddress(statusAddr) && Memory::Read_U32(statusAddr) != 0) {
-			Memory::WriteStruct(statusAddr, &c->nc);
+		auto status = PSPPointer<NativeCallback>::Create(statusAddr);
+		if (status.IsValid() && status->size != 0) {
+			*status = c->nc;
+			status.NotifyWrite("CallbackStatus");
 			return hleLogSuccessI(SCEKERNEL, 0);
 		} else {
 			return hleLogDebug(SCEKERNEL, 0, "struct size was 0");
@@ -3789,8 +3790,10 @@ int sceKernelReferThreadEventHandlerStatus(SceUID uid, u32 infoPtr) {
 		return hleReportError(SCEKERNEL, error, "bad handler id");
 	}
 
-	if (Memory::IsValidAddress(infoPtr) && Memory::Read_U32(infoPtr) != 0) {
-		Memory::WriteStruct(infoPtr, &teh->nteh);
+	auto info = PSPPointer<NativeThreadEventHandler>::Create(infoPtr);
+	if (info.IsValid() && info->size != 0) {
+		*info = teh->nteh;
+		info.NotifyWrite("ThreadEventHandlerStatus");
 		return hleLogSuccessI(SCEKERNEL, 0);
 	} else {
 		return hleLogDebug(SCEKERNEL, 0, "struct size was 0");

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -125,7 +125,7 @@ struct SceMpegLLI
 };
 
 void SceMpegAu::read(u32 addr) {
-	Memory::ReadStruct(addr, this);
+	Memory::Memcpy(this, addr, sizeof(this), "SceMpegAu");
 	pts = (pts & 0xFFFFFFFFULL) << 32 | (((u64)pts) >> 32);
 	dts = (dts & 0xFFFFFFFFULL) << 32 | (((u64)dts) >> 32);
 }
@@ -133,7 +133,7 @@ void SceMpegAu::read(u32 addr) {
 void SceMpegAu::write(u32 addr) {
 	pts = (pts & 0xFFFFFFFFULL) << 32 | (((u64)pts) >> 32);
 	dts = (dts & 0xFFFFFFFFULL) << 32 | (((u64)dts) >> 32);
-	Memory::WriteStruct(addr, this);
+	Memory::Memcpy(addr, this, sizeof(this), "SceMpegAu");
 }
 
 /*
@@ -2410,15 +2410,15 @@ static u32 sceMpegBasePESpacketCopy(u32 p)
 {
 	pmp_videoSource = p;
 	pmp_nBlocks = 0;
-	SceMpegLLI lli;
-	while (1){
-		Memory::ReadStruct(p, &lli);
+
+	auto lli = PSPPointer<SceMpegLLI>::Create(p);
+	while (lli.IsValid()) {
 		pmp_nBlocks++;
 		// lli.Next ==0 for last block
-		if (lli.Next == 0){
+		if (lli->Next == 0){
 			break;
 		}
-		p = p + sizeof(SceMpegLLI);
+		++lli;
 	}
 	
 	DEBUG_LOG(ME, "sceMpegBasePESpacketCopy(%08x), received %d block(s)", pmp_videoSource, pmp_nBlocks);

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -785,11 +785,12 @@ static void sceNetEtherStrton(u32 bufferPtr, u32 macPtr) {
 // Write static data since we don't actually manage any memory for sceNet* yet.
 static int sceNetGetMallocStat(u32 statPtr) {
 	VERBOSE_LOG(SCENET, "UNTESTED sceNetGetMallocStat(%x) at %08x", statPtr, currentMIPS->pc);
-	if(Memory::IsValidAddress(statPtr))
-		Memory::WriteStruct(statPtr, &netMallocStat);
-	else
-		ERROR_LOG(SCENET, "UNTESTED sceNetGetMallocStat(%x): tried to request invalid address!", statPtr);
+	auto stat = PSPPointer<SceNetMallocStat>::Create(statPtr);
+	if (!stat.IsValid())
+		return hleLogError(SCENET, 0, "invalid address");
 
+	*stat = netMallocStat;
+	stat.NotifyWrite("sceNetGetMallocStat");
 	return 0;
 }
 
@@ -893,77 +894,128 @@ static int sceNetApctlGetInfo(int code, u32 pInfoAddr) {
 	if (!netApctlInited)
 		return hleLogError(SCENET, ERROR_NET_APCTL_NOT_IN_BSS, "apctl not in bss"); // Only have valid info after joining an AP and got an IP, right?
 
-	if (!Memory::IsValidAddress(pInfoAddr))
-		return hleLogError(SCENET, -1, "apctl invalid arg");
-
-	u8* info = Memory::GetPointerWrite(pInfoAddr); // FIXME: Points to a union instead of a struct thus each field have the same address
-
 	switch (code) {
 	case PSP_NET_APCTL_INFO_PROFILE_NAME:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.name);
+		if (!Memory::IsValidRange(pInfoAddr, APCTL_PROFILENAME_MAXLEN))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::MemcpyUnchecked(pInfoAddr, netApctlInfo.name, APCTL_PROFILENAME_MAXLEN);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, APCTL_PROFILENAME_MAXLEN, "NetApctlGetInfo");
 		DEBUG_LOG(SCENET, "ApctlInfo - ProfileName: %s", netApctlInfo.name);
 		break;
 	case PSP_NET_APCTL_INFO_BSSID:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.bssid);
+		if (!Memory::IsValidRange(pInfoAddr, ETHER_ADDR_LEN))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::MemcpyUnchecked(pInfoAddr, netApctlInfo.bssid, ETHER_ADDR_LEN);
 		DEBUG_LOG(SCENET, "ApctlInfo - BSSID: %s", mac2str((SceNetEtherAddr*)&netApctlInfo.bssid).c_str());
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, ETHER_ADDR_LEN, "NetApctlGetInfo");
 		break;
 	case PSP_NET_APCTL_INFO_SSID:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.ssid);
+		if (!Memory::IsValidRange(pInfoAddr, APCTL_SSID_MAXLEN))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::MemcpyUnchecked(pInfoAddr, netApctlInfo.ssid, APCTL_SSID_MAXLEN);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, APCTL_SSID_MAXLEN, "NetApctlGetInfo");
 		DEBUG_LOG(SCENET, "ApctlInfo - SSID: %s", netApctlInfo.ssid);
 		break;
 	case PSP_NET_APCTL_INFO_SSID_LENGTH:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.ssidLength);
+		if (!Memory::IsValidRange(pInfoAddr, 4))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::WriteUnchecked_U32(netApctlInfo.ssidLength, pInfoAddr);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, 4, "NetApctlGetInfo");
 		break;
 	case PSP_NET_APCTL_INFO_SECURITY_TYPE:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.securityType);
+		if (!Memory::IsValidRange(pInfoAddr, 4))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::WriteUnchecked_U32(netApctlInfo.securityType, pInfoAddr);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, 4, "NetApctlGetInfo");
 		break;
 	case PSP_NET_APCTL_INFO_STRENGTH:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.strength);
+		if (!Memory::IsValidRange(pInfoAddr, 1))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::WriteUnchecked_U8(netApctlInfo.strength, pInfoAddr);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, 1, "NetApctlGetInfo");
 		break;
 	case PSP_NET_APCTL_INFO_CHANNEL:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.channel);
+		if (!Memory::IsValidRange(pInfoAddr, 1))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::WriteUnchecked_U8(netApctlInfo.channel, pInfoAddr);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, 1, "NetApctlGetInfo");
 		break;
 	case PSP_NET_APCTL_INFO_POWER_SAVE:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.powerSave);
+		if (!Memory::IsValidRange(pInfoAddr, 1))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::WriteUnchecked_U8(netApctlInfo.powerSave, pInfoAddr);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, 1, "NetApctlGetInfo");
 		break;
 	case PSP_NET_APCTL_INFO_IP:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.ip);
+		if (!Memory::IsValidRange(pInfoAddr, APCTL_IPADDR_MAXLEN))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::MemcpyUnchecked(pInfoAddr, netApctlInfo.ip, APCTL_IPADDR_MAXLEN);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, APCTL_IPADDR_MAXLEN, "NetApctlGetInfo");
 		DEBUG_LOG(SCENET, "ApctlInfo - IP: %s", netApctlInfo.ip);
 		break;
 	case PSP_NET_APCTL_INFO_SUBNETMASK:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.subNetMask);
+		if (!Memory::IsValidRange(pInfoAddr, APCTL_IPADDR_MAXLEN))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::MemcpyUnchecked(pInfoAddr, netApctlInfo.subNetMask, APCTL_IPADDR_MAXLEN);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, APCTL_IPADDR_MAXLEN, "NetApctlGetInfo");
 		DEBUG_LOG(SCENET, "ApctlInfo - SubNet Mask: %s", netApctlInfo.subNetMask);
 		break;
 	case PSP_NET_APCTL_INFO_GATEWAY:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.gateway);
+		if (!Memory::IsValidRange(pInfoAddr, APCTL_IPADDR_MAXLEN))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::MemcpyUnchecked(pInfoAddr, netApctlInfo.gateway, APCTL_IPADDR_MAXLEN);
 		DEBUG_LOG(SCENET, "ApctlInfo - Gateway IP: %s", netApctlInfo.gateway);
 		break;
 	case PSP_NET_APCTL_INFO_PRIMDNS:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.primaryDns);
+		if (!Memory::IsValidRange(pInfoAddr, APCTL_IPADDR_MAXLEN))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::MemcpyUnchecked(pInfoAddr, netApctlInfo.primaryDns, APCTL_IPADDR_MAXLEN);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, APCTL_IPADDR_MAXLEN, "NetApctlGetInfo");
 		DEBUG_LOG(SCENET, "ApctlInfo - Primary DNS: %s", netApctlInfo.primaryDns);
 		break;
 	case PSP_NET_APCTL_INFO_SECDNS:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.secondaryDns);
+		if (!Memory::IsValidRange(pInfoAddr, APCTL_IPADDR_MAXLEN))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::MemcpyUnchecked(pInfoAddr, netApctlInfo.secondaryDns, APCTL_IPADDR_MAXLEN);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, APCTL_IPADDR_MAXLEN, "NetApctlGetInfo");
 		DEBUG_LOG(SCENET, "ApctlInfo - Secondary DNS: %s", netApctlInfo.secondaryDns);
 		break;
 	case PSP_NET_APCTL_INFO_USE_PROXY:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.useProxy);
+		if (!Memory::IsValidRange(pInfoAddr, 4))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::WriteUnchecked_U32(netApctlInfo.useProxy, pInfoAddr);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, 4, "NetApctlGetInfo");
 		break;
 	case PSP_NET_APCTL_INFO_PROXY_URL:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.proxyUrl);
+		if (!Memory::IsValidRange(pInfoAddr, APCTL_URL_MAXLEN))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::MemcpyUnchecked(pInfoAddr, netApctlInfo.proxyUrl, APCTL_URL_MAXLEN);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, APCTL_URL_MAXLEN, "NetApctlGetInfo");
 		DEBUG_LOG(SCENET, "ApctlInfo - Proxy URL: %s", netApctlInfo.proxyUrl);
 		break;
 	case PSP_NET_APCTL_INFO_PROXY_PORT:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.proxyPort);
+		if (!Memory::IsValidRange(pInfoAddr, 2))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::WriteUnchecked_U16(netApctlInfo.proxyPort, pInfoAddr);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, 2, "NetApctlGetInfo");
 		break;
 	case PSP_NET_APCTL_INFO_8021_EAP_TYPE:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.eapType);
+		if (!Memory::IsValidRange(pInfoAddr, 4))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::WriteUnchecked_U32(netApctlInfo.eapType, pInfoAddr);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, 4, "NetApctlGetInfo");
 		break;
 	case PSP_NET_APCTL_INFO_START_BROWSER:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.startBrowser);
+		if (!Memory::IsValidRange(pInfoAddr, 4))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::WriteUnchecked_U32(netApctlInfo.startBrowser, pInfoAddr);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, 4, "NetApctlGetInfo");
 		break;
 	case PSP_NET_APCTL_INFO_WIFISP:
-		Memory::WriteStruct(pInfoAddr, &netApctlInfo.wifisp);
+		if (!Memory::IsValidRange(pInfoAddr, 4))
+			return hleLogError(SCENET, -1, "apctl invalid arg");
+		Memory::WriteUnchecked_U32(netApctlInfo.wifisp, pInfoAddr);
+		NotifyMemInfo(MemBlockFlags::WRITE, pInfoAddr, 4, "NetApctlGetInfo");
 		break;
 	default:
 		return hleLogError(SCENET, ERROR_NET_APCTL_INVALID_CODE, "apctl invalid code");
@@ -1234,28 +1286,28 @@ int NetApctl_GetBSSDescEntryUser(int entryId, int infoId, u32 resultAddr) {
 	switch (infoId) {
 	case PSP_NET_APCTL_DESC_IBSS: // IBSS, 6 bytes
 		if (entryId == 0)
-			Memory::WriteStruct(resultAddr, &netApctlInfo.bssid);
+			Memory::Memcpy(resultAddr, netApctlInfo.bssid, sizeof(netApctlInfo.bssid), "GetBSSDescEntryUser");
 		else {
 			// Generate a BSSID/MAC address
 			char dummyMAC[ETHER_ADDR_LEN];
 			memset(dummyMAC, entryId, sizeof(dummyMAC));
 			// Making sure the 1st 2-bits on the 1st byte of OUI are zero to prevent issue with some games (ie. Gran Turismo)
 			dummyMAC[0] &= 0xfc;
-			Memory::WriteStruct(resultAddr, &dummyMAC);
+			Memory::Memcpy(resultAddr, dummyMAC, sizeof(dummyMAC), "GetBSSDescEntryUser");
 		}
 		break;
 	case PSP_NET_APCTL_DESC_SSID_NAME:
 		// Return 32 bytes
 		if (entryId == 0)
-			Memory::WriteStruct(resultAddr, &netApctlInfo.ssid);
+			Memory::Memcpy(resultAddr, netApctlInfo.ssid, sizeof(netApctlInfo.ssid), "GetBSSDescEntryUser");
 		else {
-			Memory::WriteStruct(resultAddr, &dummySSID);
+			Memory::Memcpy(resultAddr, dummySSID, sizeof(dummySSID), "GetBSSDescEntryUser");
 		}
 		break;
 	case PSP_NET_APCTL_DESC_SSID_NAME_LENGTH:
 		// Return one 32-bit value
 		if (entryId == 0)
-			Memory::WriteStruct(resultAddr, &netApctlInfo.ssidLength);
+			Memory::Write_U32(netApctlInfo.ssidLength, resultAddr);
 		else {
 			// Calculate the SSID length
 			Memory::Write_U32((u32)strlen(dummySSID), resultAddr);
@@ -1264,7 +1316,7 @@ int NetApctl_GetBSSDescEntryUser(int entryId, int infoId, u32 resultAddr) {
 	case PSP_NET_APCTL_DESC_CHANNEL:
 		// FIXME: Return one 1 byte value or may be 32-bit if this is not a channel?
 		if (entryId == 0)
-			Memory::WriteStruct(resultAddr, &netApctlInfo.channel);
+			Memory::Write_U8(netApctlInfo.channel, resultAddr);
 		else {
 			// Generate channel for testing purposes, not even sure whether this is channel or not, MGS:PW seems to treat the data as u8
 			Memory::Write_U8(entryId, resultAddr);
@@ -1273,7 +1325,7 @@ int NetApctl_GetBSSDescEntryUser(int entryId, int infoId, u32 resultAddr) {
 	case PSP_NET_APCTL_DESC_SIGNAL_STRENGTH:
 		// Return 1 byte
 		if (entryId == 0)
-			Memory::WriteStruct(resultAddr, &netApctlInfo.strength);
+			Memory::Write_U8(netApctlInfo.strength, resultAddr);
 		else {
 			// Randomize signal strength between 1%~99% since games like MGS:PW are using signal strength to determine the strength of the recruit
 			Memory::Write_U8((int)(((float)rand() / (float)RAND_MAX) * 99.0 + 1.0), resultAddr);
@@ -1281,7 +1333,7 @@ int NetApctl_GetBSSDescEntryUser(int entryId, int infoId, u32 resultAddr) {
 		break;
 	case PSP_NET_APCTL_DESC_SECURITY:
 		// Return one 32-bit value
-		Memory::WriteStruct(resultAddr, &netApctlInfo.securityType);
+		Memory::Write_U32(netApctlInfo.securityType, resultAddr);
 		break;
 	default:
 		return hleLogError(SCENET, ERROR_NET_APCTL_INVALID_CODE, "unknown info id");
@@ -1432,7 +1484,7 @@ const HLEFunction sceNet[] = {
 	{0XD27961C9, &WrapV_UU<sceNetEtherStrton>,       "sceNetEtherStrton",               'v', "xx"   },
 	{0X0BF0A3AE, &WrapU_U<sceNetGetLocalEtherAddr>,  "sceNetGetLocalEtherAddr",         'x', "x"    },
 	{0X50647530, &WrapI_I<sceNetFreeThreadinfo>,     "sceNetFreeThreadinfo",            'i', "i"    },
-	{0XCC393E48, &WrapI_U<sceNetGetMallocStat>,      "sceNetGetMallocStat",             'i', "x"    },
+	{0XCC393E48, &WrapI_U<sceNetGetMallocStat>,      "sceNetGetMallocStat",             'i', "p"    },
 	{0XAD6844C6, &WrapI_I<sceNetThreadAbort>,        "sceNetThreadAbort",               'i', "i"    },
 };
 

--- a/Core/HLE/sceNp2.cpp
+++ b/Core/HLE/sceNp2.cpp
@@ -280,10 +280,12 @@ static int sceNpMatching2GetMemoryStat(u32 memStatPtr)
 	if (!npMatching2Inited)
 		return hleLogError(SCENET, SCE_NP_MATCHING2_ERROR_NOT_INITIALIZED);
 
-	if (!Memory::IsValidAddress(memStatPtr))
+	auto memStat = PSPPointer<SceNpAuthMemoryStat>::Create(memStatPtr);
+	if (!memStat.IsValid())
 		return hleLogError(SCENET, SCE_NP_MATCHING2_ERROR_INVALID_ARGUMENT);
 
-	Memory::WriteStruct(memStatPtr, &npMatching2MemStat);
+	*memStat = npMatching2MemStat;
+	memStat.NotifyWrite("NpMatching2GetMemoryStat");
 
 	return 0;
 }

--- a/Core/HLE/sceOpenPSID.cpp
+++ b/Core/HLE/sceOpenPSID.cpp
@@ -38,9 +38,10 @@ static int sceOpenPSIDGetOpenPSID(u32 OpenPSIDPtr)
 {
 	WARN_LOG(HLE, "UNTESTED %s(%08x)", __FUNCTION__, OpenPSIDPtr);
 
-	if (Memory::IsValidAddress(OpenPSIDPtr))
-	{
-		Memory::WriteStruct(OpenPSIDPtr, &dummyOpenPSID);
+	auto ptr = PSPPointer<SceOpenPSID>::Create(OpenPSIDPtr);
+	if (ptr.IsValid()) {
+		*ptr = dummyOpenPSID;
+		ptr.NotifyWrite("OpenPSIDGetOpenPSID");
 	}
 	return 0;
 }
@@ -49,9 +50,10 @@ static int sceOpenPSIDGetPSID(u32 OpenPSIDPtr,u32 unknown)
 {
 	WARN_LOG(HLE, "UNTESTED %s(%08x, %08x)", __FUNCTION__, OpenPSIDPtr, unknown);
 
-	if (Memory::IsValidAddress(OpenPSIDPtr))
-	{
-		Memory::WriteStruct(OpenPSIDPtr, &dummyOpenPSID);
+	auto ptr = PSPPointer<SceOpenPSID>::Create(OpenPSIDPtr);
+	if (ptr.IsValid()) {
+		*ptr = dummyOpenPSID;
+		ptr.NotifyWrite("OpenPSIDGetPSID");
 	}
 	return 0;
 }

--- a/Core/HLE/sceUsbCam.cpp
+++ b/Core/HLE/sceUsbCam.cpp
@@ -113,11 +113,12 @@ static int getCameraResolution(Camera::ConfigType type, int *width, int *height)
 
 
 static int sceUsbCamSetupMic(u32 paramAddr, u32 workareaAddr, int wasize) {
-	INFO_LOG(HLE, "sceUsbCamSetupMic");
-	if (Memory::IsValidRange(paramAddr, sizeof(PspUsbCamSetupMicParam))) {
-		Memory::ReadStruct(paramAddr, &config->micParam);
+	auto param = PSPPointer<PspUsbCamSetupMicParam>::Create(paramAddr);
+	if (param.IsValid()) {
+		config->micParam = *param;
+		param.NotifyRead("UsbCamSetupMic");
 	}
-	return 0;
+	return hleLogSuccessInfoI(SCEMISC, 0);
 }
 
 static int sceUsbCamStartMic() {
@@ -155,16 +156,20 @@ static int sceUsbCamGetMicDataLength() {
 }
 
 static int sceUsbCamSetupVideo(u32 paramAddr, u32 workareaAddr, int wasize) {
-	if (Memory::IsValidRange(paramAddr, sizeof(PspUsbCamSetupVideoParam))) {
-		Memory::ReadStruct(paramAddr, &config->videoParam);
+	auto param = PSPPointer<PspUsbCamSetupVideoParam>::Create(paramAddr);
+	if (param.IsValid()) {
+		config->videoParam = *param;
+		param.NotifyRead("UsbCamSetupVideo");
 	}
 	config->type = Camera::ConfigType::CfVideo;
 	return 0;
 }
 
 static int sceUsbCamSetupVideoEx(u32 paramAddr, u32 workareaAddr, int wasize) {
-	if (Memory::IsValidRange(paramAddr, sizeof(PspUsbCamSetupVideoExParam))) {
-		Memory::ReadStruct(paramAddr, &config->videoExParam);
+	auto param = PSPPointer<PspUsbCamSetupVideoExParam>::Create(paramAddr);
+	if (param.IsValid()) {
+		config->videoExParam = *param;
+		param.NotifyRead("UsbCamSetupVideoEx");
 	}
 	config->type = Camera::ConfigType::CfVideoEx;
 	return 0;
@@ -222,8 +227,10 @@ static int sceUsbCamPollReadVideoFrameEnd() {
 
 static int sceUsbCamSetupStill(u32 paramAddr) {
 	INFO_LOG(HLE, "UNIMPL sceUsbCamSetupStill");
-	if (Memory::IsValidRange(paramAddr, sizeof(PspUsbCamSetupStillParam))) {
-		Memory::ReadStruct(paramAddr, &config->stillParam);
+	auto param = PSPPointer<PspUsbCamSetupStillParam>::Create(paramAddr);
+	if (param.IsValid()) {
+		config->stillParam = *param;
+		param.NotifyRead("UsbCamSetupStill");
 	}
 	config->type = Camera::ConfigType::CfStill;
 	return 0;
@@ -231,8 +238,10 @@ static int sceUsbCamSetupStill(u32 paramAddr) {
 
 static int sceUsbCamSetupStillEx(u32 paramAddr) {
 	INFO_LOG(HLE, "UNIMPL sceUsbCamSetupStillEx");
-	if (Memory::IsValidRange(paramAddr, sizeof(PspUsbCamSetupStillExParam))) {
-		Memory::ReadStruct(paramAddr, &config->stillExParam);
+	auto param = PSPPointer<PspUsbCamSetupStillExParam>::Create(paramAddr);
+	if (param.IsValid()) {
+		config->stillExParam = *param;
+		param.NotifyRead("UsbCamSetupStillEx");
 	}
 	config->type = Camera::ConfigType::CfStillEx;
 	return 0;

--- a/Core/HLE/sceUsbGps.cpp
+++ b/Core/HLE/sceUsbGps.cpp
@@ -59,8 +59,8 @@ static int sceUsbGpsGetInitDataLocation(u32 addr) {
 }
 
 static int sceUsbGpsGetState(u32 stateAddr) {
-	if (Memory::IsValidAddress(stateAddr)) {
-		Memory::Write_U32(gpsStatus, stateAddr);
+	if (Memory::IsValidRange(stateAddr, 4)) {
+		Memory::WriteUnchecked_U32(gpsStatus, stateAddr);
 	}
 	return 0;
 }
@@ -81,11 +81,15 @@ static int sceUsbGpsClose() {
 }
 
 static int sceUsbGpsGetData(u32 gpsDataAddr, u32 satDataAddr) {
-	if (Memory::IsValidRange(gpsDataAddr, sizeof(GpsData))) {
-		Memory::WriteStruct(gpsDataAddr, GPS::getGpsData());
+	auto gpsData = PSPPointer<GpsData>::Create(gpsDataAddr);
+	if (gpsData.IsValid()) {
+		*gpsData = *GPS::getGpsData();
+		gpsData.NotifyWrite("UsbGpsGetData");
 	}
-	if (Memory::IsValidRange(satDataAddr, sizeof(SatData))) {
-		Memory::WriteStruct(satDataAddr, GPS::getSatData());
+	auto satData = PSPPointer<SatData>::Create(satDataAddr);
+	if (satData.IsValid()) {
+		*satData = *GPS::getSatData();
+		gpsData.NotifyWrite("UsbGpsGetData");
 	}
 	return 0;
 }

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -490,3 +490,12 @@ void Memset(const u32 _Address, const u8 _iValue, const u32 _iLength, const char
 }
 
 } // namespace
+
+void PSPPointerNotifyRW(int rw, uint32_t ptr, uint32_t bytes, const char * tag, size_t tagLen) {
+	if (MemBlockInfoDetailed(bytes)) {
+		if (rw & 1)
+			NotifyMemInfo(MemBlockFlags::WRITE, ptr, bytes, tag, tagLen);
+		if (rw & 2)
+			NotifyMemInfo(MemBlockFlags::READ, ptr, bytes, tag, tagLen);
+	}
+}

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -328,6 +328,9 @@ inline bool IsValidRange(const u32 address, const u32 size) {
 
 }  // namespace Memory
 
+// Avoiding a global include for NotifyMemInfo.
+void PSPPointerNotifyRW(int rw, uint32_t ptr, uint32_t bytes, const char *tag, size_t tagLen);
+
 template <typename T>
 struct PSPPointer
 {
@@ -440,7 +443,17 @@ struct PSPPointer
 
 	bool IsValid() const
 	{
-		return Memory::IsValidAddress(ptr);
+		return Memory::IsValidRange(ptr, (u32)sizeof(T));
+	}
+
+	template <size_t tagLen>
+	void NotifyWrite(const char(&tag)[tagLen]) const {
+		PSPPointerNotifyRW(1, (uint32_t)ptr, (uint32_t)sizeof(T), tag, tagLen - 1);
+	}
+
+	template <size_t tagLen>
+	void NotifyRead(const char(&tag)[tagLen]) const {
+		PSPPointerNotifyRW(2, (uint32_t)ptr, (uint32_t)sizeof(T), tag, tagLen - 1);
 	}
 
 	static PSPPointer<T> Create(u32 ptr) {

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -441,9 +441,20 @@ struct PSPPointer
 #endif
 	}
 
-	bool IsValid() const
-	{
+	bool IsValid() const {
 		return Memory::IsValidRange(ptr, (u32)sizeof(T));
+	}
+
+	T *PtrOrNull() {
+		if (IsValid())
+			return (T *)*this;
+		return nullptr;
+	}
+
+	const T *PtrOrNull() const {
+		if (IsValid())
+			return (const T *)*this;
+		return nullptr;
 	}
 
 	template <size_t tagLen>

--- a/Core/MemMapHelpers.h
+++ b/Core/MemMapHelpers.h
@@ -109,31 +109,4 @@ inline void Memcpy(const u32 to_address, const u32 from_address, const u32 len) 
 
 void Memset(const u32 _Address, const u8 _Data, const u32 _iLength, const char *tag = "Memset");
 
-template<class T>
-void ReadStruct(u32 address, T *ptr)
-{
-	const u32 sz = (u32)sizeof(*ptr);
-	Memcpy(ptr, address, sz);
-}
-
-template<class T>
-void ReadStructUnchecked(u32 address, T *ptr)
-{
-	const u32 sz = (u32)sizeof(*ptr);
-	MemcpyUnchecked(ptr, address, sz);
-}
-
-template<class T>
-void WriteStruct(u32 address, T *ptr)
-{
-	const u32 sz = (u32)sizeof(*ptr);
-	Memcpy(address, ptr, sz);
-}
-
-template<class T>
-void WriteStructUnchecked(u32 address, T *ptr)
-{
-	const u32 sz = (u32)sizeof(*ptr);
-	MemcpyUnchecked(address, ptr, sz);
-}
 }

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -178,18 +178,16 @@ static void BeginVertexData() {
 
 static void Vertex(float x, float y, float u, float v, int tw, int th, u32 color = 0xFFFFFFFF) {
 	if (g_RemasterMode) {
-		PPGeRemasterVertex vtx;
-		vtx.x = x; vtx.y = y; vtx.z = 0;
-		vtx.u = u * tw; vtx.v = v * th;
-		vtx.color = color;
-		Memory::WriteStruct(dataWritePtr, &vtx);
+		auto vtx = PSPPointer<PPGeRemasterVertex>::Create(dataWritePtr);
+		vtx->x = x; vtx->y = y; vtx->z = 0;
+		vtx->u = u * tw; vtx->v = v * th;
+		vtx->color = color;
 		dataWritePtr += sizeof(vtx);
 	} else {
-		PPGeVertex vtx;
-		vtx.x = x; vtx.y = y; vtx.z = 0;
-		vtx.u = u * tw; vtx.v = v * th;
-		vtx.color = color;
-		Memory::WriteStruct(dataWritePtr, &vtx);
+		auto vtx = PSPPointer<PPGeVertex>::Create(dataWritePtr);
+		vtx->x = x; vtx->y = y; vtx->z = 0;
+		vtx->u = u * tw; vtx->v = v * th;
+		vtx->color = color;
 		dataWritePtr += sizeof(vtx);
 	}
 	_dbg_assert_(dataWritePtr <= dataPtr + dataSize);
@@ -197,8 +195,11 @@ static void Vertex(float x, float y, float u, float v, int tw, int th, u32 color
 }
 
 static void EndVertexDataAndDraw(int prim) {
+	_assert_msg_(vertexStart != 0, "Missing matching call to BeginVertexData()");
+	NotifyMemInfo(MemBlockFlags::WRITE, vertexStart, dataWritePtr - vertexStart, "PPGe Vertex");
 	WriteCmdAddrWithBase(GE_CMD_VADDR, vertexStart);
 	WriteCmd(GE_CMD_PRIM, (prim << 16) | vertexCount);
+	vertexStart = 0;
 }
 
 bool PPGeIsFontTextureAddress(u32 addr) {
@@ -272,6 +273,7 @@ void __PPGeInit() {
 		int val = i;
 		palette[i] = (val << 12) | 0xFFF;
 	}
+	NotifyMemInfo(MemBlockFlags::WRITE, palette.ptr, 16 * sizeof(u16_le), "PPGe Palette");
 
 	const u32_le *imagePtr = (u32_le *)imageData[0];
 	u8 *ramPtr = atlasPtr == 0 ? nullptr : (u8 *)Memory::GetPointer(atlasPtr);
@@ -286,7 +288,10 @@ void __PPGeInit() {
 		u8 cval = (a2 << 4) | a1;
 		ramPtr[i] = cval;
 	}
-	atlasHash = XXH3_64bits(ramPtr, atlasWidth * atlasHeight / 2);
+	if (atlasPtr != 0) {
+		atlasHash = XXH3_64bits(ramPtr, atlasSize);
+		NotifyMemInfo(MemBlockFlags::WRITE, atlasPtr, atlasSize, "PPGe Atlas");
+	}
 
 	free(imageData[0]);
 
@@ -457,6 +462,7 @@ void PPGeEnd()
 	if (dataWritePtr > dataPtr) {
 		// We actually drew something
 		gpu->EnableInterrupts(false);
+		NotifyMemInfo(MemBlockFlags::WRITE, dlPtr, dlWritePtr - dlPtr, "PPGe ListCmds");
 		u32 list = sceGeListEnQueue(dlPtr, dlWritePtr, -1, listArgs.ptr);
 		DEBUG_LOG(SCEGE, "PPGe enqueued display list %i", list);
 		gpu->EnableInterrupts(true);


### PR DESCRIPTION
I think it's better to use typed pointers, which can also more accurately check memory validity (the previous funcs didn't check the full range.)  Been meaning to get rid of these for a little while.

This also makes the PSPPointer `IsValid()` return false if the entire value is not valid (i.e. if it's a pointer to 32 bits but points to the last byte of VRAM.)

-[Unknown]