### PR TITLE
Improve rectangle fast path checks in softgpu

### DIFF
--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -272,7 +272,9 @@ bool RectangleFastPath(const VertexData &v0, const VertexData &v1, BinManager &b
 	bool orient_check = xdiff >= 0 && ydiff >= 0;
 	// We already have a fast path for clear in ClearRectangle.
 	bool state_check = !state.pixelID.clearMode && !state.samplerID.hasAnyMips && NoClampOrWrap(state, v0.texturecoords) && NoClampOrWrap(state, v1.texturecoords);
-	if ((coord_check || !state.enableTextures) && orient_check && state_check) {
+	// This doesn't work well with offset drawing, see #15876.  Through never has a subpixel offset.
+	bool subpixel_check = ((v0.screenpos.x | v0.screenpos.y | v1.screenpos.x | v1.screenpos.y) & 0xF) != 0;
+	if ((coord_check || !state.enableTextures) && orient_check && state_check && subpixel_check) {
 		binner.AddSprite(v0, v1);
 		return true;
 	}

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -225,8 +225,6 @@ void DrawSprite(const VertexData &v0, const VertexData &v1, const BinCoords &ran
 			!pixelID.dithering &&
 			pixelID.alphaBlend &&
 			AlphaTestIsNeedless(pixelID) &&
-			samplerID.useTextureAlpha &&
-			samplerID.TexFunc() == GE_TEXFUNC_MODULATE &&
 			!pixelID.applyColorWriteMask &&
 			pixelID.FBFormat() == GE_FORMAT_5551) {
 			if (v1.color0.a() == 0)


### PR DESCRIPTION
Fixes #15876.  Should still activate in throughmode just fine.  Also cleans up some slightly unsafe checks for avoiding drawPixel.

-[Unknown]