### PR TITLE
Enable logic op emulation in-shader

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -102,5 +102,10 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {
 	if (ignored_.find(option) == ignored_.end()) {
 		iniFile.Get(option, gameID.c_str(), flag, *flag);
+
+		// Shortcut for debugging, sometimes useful to globally enable compat flags.
+		bool all = false;
+		iniFile.Get(option, "ALL", &all, false);
+		*flag |= all;
 	}
 }

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -123,7 +123,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 
 	// Distinct from the logic op simulation support.
 	GELogicOp replaceLogicOpType = isModeClear ? GE_LOGIC_COPY : (GELogicOp)id.Bits(FS_BIT_REPLACE_LOGIC_OP, 4);
-	bool replaceLogicOp = replaceLogicOpType != GE_LOGIC_COPY;
+	bool replaceLogicOp = replaceLogicOpType != GE_LOGIC_COPY && compat.bitwiseOps;
 
 	bool readFramebuffer = replaceBlend == REPLACE_BLEND_READ_FRAMEBUFFER || colorWriteMask || replaceLogicOp;
 	bool readFramebufferTex = readFramebuffer && !gstate_c.Supports(GPU_SUPPORTS_ANY_FRAMEBUFFER_FETCH);

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -108,11 +108,6 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 		blueToAlpha = true;
 	}
 
-	GEBlendSrcFactor replaceBlendFuncA = (GEBlendSrcFactor)id.Bits(FS_BIT_BLENDFUNC_A, 4);
-	GEBlendDstFactor replaceBlendFuncB = (GEBlendDstFactor)id.Bits(FS_BIT_BLENDFUNC_B, 4);
-	GEBlendMode replaceBlendEq = (GEBlendMode)id.Bits(FS_BIT_BLENDEQ, 3);
-	StencilValueType replaceAlphaWithStencilType = (StencilValueType)id.Bits(FS_BIT_REPLACE_ALPHA_WITH_STENCIL_TYPE, 4);
-
 	bool isModeClear = id.Bit(FS_BIT_CLEARMODE);
 
 	const char *shading = "";
@@ -121,7 +116,16 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 
 	bool useDiscardStencilBugWorkaround = id.Bit(FS_BIT_NO_DEPTH_CANNOT_DISCARD_STENCIL);
 
-	bool readFramebuffer = replaceBlend == REPLACE_BLEND_READ_FRAMEBUFFER || colorWriteMask;
+	GEBlendSrcFactor replaceBlendFuncA = (GEBlendSrcFactor)id.Bits(FS_BIT_BLENDFUNC_A, 4);
+	GEBlendDstFactor replaceBlendFuncB = (GEBlendDstFactor)id.Bits(FS_BIT_BLENDFUNC_B, 4);
+	GEBlendMode replaceBlendEq = (GEBlendMode)id.Bits(FS_BIT_BLENDEQ, 3);
+	StencilValueType replaceAlphaWithStencilType = (StencilValueType)id.Bits(FS_BIT_REPLACE_ALPHA_WITH_STENCIL_TYPE, 4);
+
+	// Distinct from the logic op simulation support.
+	GELogicOp replaceLogicOpType = isModeClear ? GE_LOGIC_COPY : (GELogicOp)id.Bits(FS_BIT_REPLACE_LOGIC_OP, 4);
+	bool replaceLogicOp = replaceLogicOpType != GE_LOGIC_COPY;
+
+	bool readFramebuffer = replaceBlend == REPLACE_BLEND_READ_FRAMEBUFFER || colorWriteMask || replaceLogicOp;
 	bool readFramebufferTex = readFramebuffer && !gstate_c.Supports(GPU_SUPPORTS_ANY_FRAMEBUFFER_FETCH);
 
 	bool needFragCoord = readFramebuffer || gstate_c.Supports(GPU_ROUND_FRAGMENT_DEPTH_TO_16BIT);
@@ -1078,16 +1082,37 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 		return false;
 	}
 
-	// Final color computed - apply color write mask.
-	// TODO: Maybe optimize to only do math on the affected channels?
-	// Or .. meh. That would require more shader bits. Though we could
-	// of course optimize for the common mask 0xF00000, though again, blue-to-alpha
-	// does a better job with that.
-	if (colorWriteMask) {
+	// Final color computed - apply logic ops and bitwise color write mask, through shader blending, if specified.
+	if (colorWriteMask || replaceLogicOp) {
 		WRITE(p, "  highp uint v32 = packUnorm4x8(%s);\n", compat.fragColor0);
 		WRITE(p, "  highp uint d32 = packUnorm4x8(destColor);\n");
-		// Note that the mask has been flipped to the PC way - 1 means write.
-		WRITE(p, "  v32 = (v32 & u_colorWriteMask) | (d32 & ~u_colorWriteMask);\n");
+
+		// v32 is both the "s" to the logical operation, and the value that we'll merge to the destination with masking later.
+		// d32 is the "d" to the logical operation.
+		// TODO: Do logical ops work on just RGB or also A on the PSP?
+		switch (replaceLogicOpType) {
+		case GE_LOGIC_CLEAR:         p.C("  v32 = 0;\n"); break;
+		case GE_LOGIC_AND:           p.C("  v32 = v32 & d32;\n"); break;
+		case GE_LOGIC_AND_REVERSE:   p.C("  v32 = v32 & ~d32;\n"); break;
+		case GE_LOGIC_COPY: break;  // source to dest, do nothing. Will be set to this, if not used.
+		case GE_LOGIC_AND_INVERTED:  p.C("  v32 = ~v32 & d32;\n"); break;
+		case GE_LOGIC_NOOP:          p.C("  v32 = d32;\n"); break;
+		case GE_LOGIC_XOR:           p.C("  v32 = v32 ^ d32;\n"); break;
+		case GE_LOGIC_OR:            p.C("  v32 = v32 | d32;\n"); break;
+		case GE_LOGIC_NOR:           p.C("  v32 = ~(v32 | d32);\n"); break;
+		case GE_LOGIC_EQUIV:         p.C("  v32 = ~(v32 ^ d32);\n"); break;
+		case GE_LOGIC_INVERTED:      p.C("  v32 = ~d32;\n"); break;
+		case GE_LOGIC_OR_REVERSE:    p.C("  v32 = v32 | ~d32;\n"); break;
+		case GE_LOGIC_COPY_INVERTED: p.C("  v32 = ~v32;\n"); break;
+		case GE_LOGIC_OR_INVERTED:   p.C("  v32 = (~v32) | d32;\n"); break;
+		case GE_LOGIC_NAND:          p.C("  v32 = ~(v32 & d32);\n"); break;
+		case GE_LOGIC_SET:           p.C("  v32 = 0xFFFFFFFF;\n"); break;
+		}
+
+		// Note that the mask has already been flipped to the PC way - 1 means write.
+		if (colorWriteMask) {
+			WRITE(p, "  v32 = (v32 & u_colorWriteMask) | (d32 & ~u_colorWriteMask);\n");
+		}
 		WRITE(p, "  %s = unpackUnorm4x8(v32);\n", compat.fragColor0);
 	}
 

--- a/GPU/Common/GPUStateUtils.h
+++ b/GPU/Common/GPUStateUtils.h
@@ -184,7 +184,6 @@ struct GenericBlendState {
 	void Log();
 };
 
-void ConvertBlendState(GenericBlendState &blendState, bool forceReplaceBlend);
 void ApplyStencilReplaceAndLogicOpIgnoreBlend(ReplaceAlphaType replaceAlphaWithStencil, GenericBlendState &blendState);
 
 struct GenericMaskState {
@@ -203,8 +202,6 @@ struct GenericMaskState {
 
 	void Log();
 };
-
-void ConvertMaskState(GenericMaskState &maskState, bool shaderBitOpsSupported);
 
 struct GenericStencilFuncState {
 	bool enabled;
@@ -239,8 +236,6 @@ struct GenericLogicState {
 
 	void Log();
 };
-
-void ConvertLogicOpState(GenericLogicState &logicOpState, bool logicSupported, bool shaderBitOpsSupported);
 
 struct ComputedPipelineState {
 	GenericBlendState blendState;

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -268,7 +268,7 @@ void ComputeFragmentShaderID(FShaderID *id_out, const ComputedPipelineState &pip
 		ReplaceBlendType replaceBlend = pipelineState.blendState.replaceBlend;
 		ReplaceAlphaType stencilToAlpha = pipelineState.blendState.replaceAlphaWithStencil;
 		SimulateLogicOpType simulateLogicOpType = pipelineState.blendState.simulateLogicOpType;
-		GELogicOp replaceLogicOpType = GE_LOGIC_COPY;
+		GELogicOp replaceLogicOpType = pipelineState.logicState.applyFramebufferRead ? pipelineState.logicState.logicOp : GE_LOGIC_COPY;
 
 		// All texfuncs except replace are the same for RGB as for RGBA with full alpha.
 		// Note that checking this means that we must dirty the fragment shader ID whenever textureFullAlpha changes.

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -268,6 +268,7 @@ void ComputeFragmentShaderID(FShaderID *id_out, const ComputedPipelineState &pip
 		ReplaceBlendType replaceBlend = pipelineState.blendState.replaceBlend;
 		ReplaceAlphaType stencilToAlpha = pipelineState.blendState.replaceAlphaWithStencil;
 		SimulateLogicOpType simulateLogicOpType = pipelineState.blendState.simulateLogicOpType;
+		GELogicOp replaceLogicOpType = GE_LOGIC_COPY;
 
 		// All texfuncs except replace are the same for RGB as for RGBA with full alpha.
 		// Note that checking this means that we must dirty the fragment shader ID whenever textureFullAlpha changes.
@@ -324,6 +325,9 @@ void ComputeFragmentShaderID(FShaderID *id_out, const ComputedPipelineState &pip
 
 		// 2 bits.
 		id.SetBits(FS_BIT_SIMULATE_LOGIC_OP_TYPE, 2, simulateLogicOpType);
+
+		// 4 bits. Set to GE_LOGIC_COPY if not used, which does nothing in the shader generator.
+		id.SetBits(FS_BIT_REPLACE_LOGIC_OP, 4, (int)replaceLogicOpType);
 
 		// If replaceBlend == REPLACE_BLEND_STANDARD (or REPLACE_BLEND_NO) nothing is done, so we kill these bits.
 		if (replaceBlend == REPLACE_BLEND_BLUE_TO_ALPHA) {

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -95,6 +95,7 @@ enum FShaderBit : uint8_t {
 	FS_BIT_COLOR_WRITEMASK = 50,
 	FS_BIT_3D_TEXTURE = 51,
 	FS_BIT_SHADER_SMOOTHED_DEPAL = 52,
+	FS_BIT_REPLACE_LOGIC_OP = 53,  // 4 bits. GE_LOGIC_COPY means no-op/off.
 };
 
 static inline FShaderBit operator +(FShaderBit bit, int i) {

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -370,7 +370,7 @@ VulkanFragmentShader *ShaderManagerVulkan::GetFragmentShaderFromModule(VkShaderM
 // instantaneous.
 
 #define CACHE_HEADER_MAGIC 0xff51f420 
-#define CACHE_VERSION 21
+#define CACHE_VERSION 22
 struct VulkanCacheHeader {
 	uint32_t magic;
 	uint32_t version;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1120,14 +1120,12 @@ ULJM05812 = true
 NPJH50371 = true
 
 # Colin McRae's DiRT 2 - issue #13012 (car lighting)
-# Previously used ReinterpretFramebuffers + ShaderColorBitmask
 ULUS10471 = true
 ULJM05533 = true
 NPJH50006 = true
 ULES01301 = true
 
 # Outrun 2006: Coast to Coast - issue #11358 (car reflections)
-# Previously used ReinterpretFramebuffers + ShaderColorBitmask
 ULES00262 = true
 ULUS10064 = true
 ULKS46087 = true
@@ -1138,7 +1136,16 @@ NPUZ00043 = true
 NPEZ00198 = true
 
 [ShaderColorBitmask]
-# No users right now, but keeping it around as a more accurate option than BlueToAlpha, for debugging mainly Outrun.
+# Colin McRae's DiRT 2 - issue #13012 (water)
+ULUS10471 = true
+ULJM05533 = true
+NPJH50006 = true
+ULES01301 = true
+
+# Outrun 2006: Coast to Coast - issue #11358 (car reflections), #11928 (water)
+ULES00262 = true
+ULUS10064 = true
+ULKS46087 = true
 
 [DisableFirstFrameReadback]
 # Wipeout Pure: Temporary workaround for lens flare flicker. See #13344


### PR DESCRIPTION
There was a problem with the combination of shader bitmasking and logic ops - even if some bits were masked away through shader trickery, since we used hardware logic ops where available, they would apply to all bits, not just the masked ones. This fixes that by moving logic operations into the shader in that case.

Requires integer ops in fragment shader, so will not work on old OpenGL ES devices or DX9. Also doesn't yet work in D3D11, but I'll fix that in a followup (need to force on logic-op-in-shader in some additional cases, as there are no native logic ops in D3D11).

Fixes #11928 (water effects in Outrun)
Fixes #13012 (water effects in DiRT 2)

~~Neither is fully fixed though, some precision or logic issue still causes us to miss some pixels, it's close though:~~  
Scratch that, it's actually perfect at 1x resolution (or with "lower resolution for effects", which I guess we'll need to enforce here):

![ULES00262_00023](https://user-images.githubusercontent.com/130929/188308022-09283aa5-a5f2-418a-91c2-6e9e315b907e.jpg)

2x res with texture upscaling:

![image](https://user-images.githubusercontent.com/130929/188307504-525163d6-91f9-4663-8fab-2321a1fbbdda.png)

GE dump: [outrun water.zip](https://github.com/hrydgard/ppsspp/files/9484423/outrun.water.zip)
