### PR TITLE
Fix the new logic-op-in-shader on OpenGL ES and D3D11

### DIFF
--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -1103,7 +1103,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 		case GE_LOGIC_EQUIV:         p.C("  v32 = (~(v32 ^ d32) & 0x00FFFFFFu) | (v32 & 0xFF000000u);\n"); break;
 		case GE_LOGIC_INVERTED:      p.C("  v32 = (~d32 & 0x00FFFFFFu) | (v32 & 0xFF000000u);\n"); break;
 		case GE_LOGIC_OR_REVERSE:    p.C("  v32 = v32 | (~d32 & 0x00FFFFFFu);\n"); break;
-		case GE_LOGIC_COPY_INVERTED: p.C("  v32 = (~v32 & 0x00FFFFFFu) | (v32 &0xFF000000u);\n"); break;
+		case GE_LOGIC_COPY_INVERTED: p.C("  v32 = (~v32 & 0x00FFFFFFu) | (v32 & 0xFF000000u);\n"); break;
 		case GE_LOGIC_OR_INVERTED:   p.C("  v32 = ((~v32 | d32) & 0x00FFFFFFu) | (v32 & 0xFF000000u);\n"); break;
 		case GE_LOGIC_NAND:          p.C("  v32 = (~(v32 & d32) & 0x00FFFFFFu) | (v32 & 0xFF000000u);\n"); break;
 		case GE_LOGIC_SET:           p.C("  v32 |= 0x00FFFFFF;\n"); break;

--- a/GPU/Common/GPUStateUtils.h
+++ b/GPU/Common/GPUStateUtils.h
@@ -243,6 +243,10 @@ struct ComputedPipelineState {
 	GenericLogicState logicState;
 
 	void Convert(bool shaderBitOpsSupported);
+
+	bool FramebufferRead() const {
+		return blendState.applyFramebufferRead;
+	}
 };
 
 // See issue #15898

--- a/GPU/D3D11/StateMappingD3D11.cpp
+++ b/GPU/D3D11/StateMappingD3D11.cpp
@@ -152,7 +152,7 @@ void DrawEngineD3D11::ApplyDrawState(int prim) {
 			GenericBlendState &blendState = pipelineState_.blendState;
 			// We ignore the logicState on D3D since there's no support, the emulation of it is blend-and-shader only.
 
-			if (blendState.applyFramebufferRead || maskState.applyFramebufferRead) {
+			if (pipelineState_.FramebufferRead()) {
 				bool fboTexNeedsBind = false;
 				ApplyFramebufferRead(&fboTexNeedsBind);
 				// The shader takes over the responsibility for blending, so recompute.

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -132,7 +132,7 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 			GenericBlendState &blendState = pipelineState_.blendState;
 			// We ignore the logicState on D3D since there's no support, the emulation of it is blend-and-shader only.
 
-			if (blendState.applyFramebufferRead || maskState.applyFramebufferRead) {
+			if (pipelineState_.FramebufferRead()) {
 				bool fboTexNeedsBind = false;
 				ApplyFramebufferRead(&fboTexNeedsBind);
 				// The shader takes over the responsibility for blending, so recompute.

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -148,7 +148,7 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 			GenericBlendState &blendState = pipelineState_.blendState;
 			GenericLogicState &logicState = pipelineState_.logicState;
 
-			if (blendState.applyFramebufferRead || maskState.applyFramebufferRead) {
+			if (pipelineState_.FramebufferRead()) {
 				bool fboTexNeedsBind = false;
 				ApplyFramebufferRead(&fboTexNeedsBind);
 				// The shader takes over the responsibility for blending, so recompute.

--- a/GPU/Vulkan/StateMappingVulkan.cpp
+++ b/GPU/Vulkan/StateMappingVulkan.cpp
@@ -152,7 +152,7 @@ void DrawEngineVulkan::ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManag
 			GenericBlendState &blendState = pipelineState_.blendState;
 			GenericLogicState &logicState = pipelineState_.logicState;
 
-			if (blendState.applyFramebufferRead || maskState.applyFramebufferRead) {
+			if (pipelineState_.FramebufferRead()) {
 				ApplyFramebufferRead(&fboTexNeedsBind_);
 				// The shader takes over the responsibility for blending, so recompute.
 				// We might still end up using blend to write something to alpha.

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1119,17 +1119,6 @@ ULUS10513 = true
 ULJM05812 = true
 NPJH50371 = true
 
-# Colin McRae's DiRT 2 - issue #13012 (car lighting)
-ULUS10471 = true
-ULJM05533 = true
-NPJH50006 = true
-ULES01301 = true
-
-# Outrun 2006: Coast to Coast - issue #11358 (car reflections)
-ULES00262 = true
-ULUS10064 = true
-ULKS46087 = true
-
 [DateLimited]
 # Car Jack Streets - issue #12698
 NPUZ00043 = true


### PR DESCRIPTION
Followup to #15960

Further fixes these for D3D11 and OpenGL ES:  #13012, `#11928 

These APIs don't have logic op support, and we weren't using it anyway for this, we just broke if it wasn't there - need to have checks so we don't activate the old fallbacks in this case. Also better propagation of the "applyFramebufferRead" (run-in-shader) flag, that probably should be better named.

Also disable BlueToAlpha for now for Outrun and DiRT 2, it breaks the water effect somehow. Will come back to it later.