### PR TITLE
Various scale fixes/workarounds

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -97,6 +97,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "AtracLoopHack", &flags_.AtracLoopHack);
 	CheckSetting(iniFile, gameID, "DeswizzleDepth", &flags_.DeswizzleDepth);
 	CheckSetting(iniFile, gameID, "SplitFramebufferMargin", &flags_.SplitFramebufferMargin);
+	CheckSetting(iniFile, gameID, "ForceLowerResolutionForEffectsOn", &flags_.ForceLowerResolutionForEffectsOn);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -87,6 +87,7 @@ struct CompatFlags {
 	bool AtracLoopHack;
 	bool DeswizzleDepth;
 	bool SplitFramebufferMargin;
+	bool ForceLowerResolutionForEffectsOn;
 };
 
 class IniFile;

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -84,14 +84,17 @@ void FramebufferManagerCommon::Init() {
 
 bool FramebufferManagerCommon::UpdateSize() {
 	const bool newRender = renderWidth_ != (float)PSP_CoreParameter().renderWidth || renderHeight_ != (float)PSP_CoreParameter().renderHeight;
-	const bool newSettings = bloomHack_ != g_Config.iBloomHack || useBufferedRendering_ != (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
+
+	const int effectiveBloomHack = PSP_CoreParameter().compat.flags().ForceLowerResolutionForEffectsOn ? 3 : g_Config.iBloomHack;
+
+	const bool newSettings = bloomHack_ != effectiveBloomHack || useBufferedRendering_ != (g_Config.iRenderingMode != FB_NON_BUFFERED_MODE);
 
 	renderWidth_ = (float)PSP_CoreParameter().renderWidth;
 	renderHeight_ = (float)PSP_CoreParameter().renderHeight;
 	renderScaleFactor_ = (float)PSP_CoreParameter().renderScaleFactor;
 	pixelWidth_ = PSP_CoreParameter().pixelWidth;
 	pixelHeight_ = PSP_CoreParameter().pixelHeight;
-	bloomHack_ = g_Config.iBloomHack;
+	bloomHack_ = effectiveBloomHack;
 	useBufferedRendering_ = g_Config.iRenderingMode != FB_NON_BUFFERED_MODE;
 
 	presentation_->UpdateSize(pixelWidth_, pixelHeight_, renderWidth_, renderHeight_);

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -441,7 +441,10 @@ protected:
 
 	void BlitUsingRaster(
 		Draw::Framebuffer *src, float srcX1, float srcY1, float srcX2, float srcY2,
-		Draw::Framebuffer *dest, float destX1, float destY1, float destX2, float destY2, bool linearFilter, Draw2DPipeline *pipeline, const char *tag);
+		Draw::Framebuffer *dest, float destX1, float destY1, float destX2, float destY2,
+		bool linearFilter,
+		int scaleFactor,  // usually unused, except for swizzle...
+		Draw2DPipeline *pipeline, const char *tag);
 
 	void CopyFramebufferForColorTexture(VirtualFramebuffer *dst, VirtualFramebuffer *src, int flags);
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2348,6 +2348,12 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 		plan.scaleFactor = 1;
 	}
 
+	if (PSP_CoreParameter().compat.flags().ForceLowerResolutionForEffectsOn && gstate.FrameBufStride() < 0x1E0) {
+		// A bit of an esoteric workaround - force off upscaling for static textures that participate directly in small-resolution framebuffer effects.
+		// This fixes the water in Outrun/DiRT 2 with upscaling enabled.
+		plan.scaleFactor = 1;
+	}
+
 	if ((entry->status & TexCacheEntry::STATUS_CHANGE_FREQUENT) != 0 && plan.scaleFactor != 1 && plan.slowScaler) {
 		// Remember for later that we /wanted/ to scale this texture.
 		entry->status |= TexCacheEntry::STATUS_TO_SCALE;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1269,3 +1269,17 @@ UCUS98646 = true
 UCET00278 = true
 UCUS98670 = true
 UCUS98646 = true
+
+[ForceLowerResolutionForEffectsOn]
+# The water effect of DiRT 2 and Outrun doesn't work in higher resolutions.
+
+# Colin McRae's DiRT 2 - issue #13012 (water)
+ULUS10471 = true
+ULJM05533 = true
+NPJH50006 = true
+ULES01301 = true
+
+# Outrun 2006: Coast to Coast - issue #11358 (car reflections), #11928 (water)
+ULES00262 = true
+ULUS10064 = true
+ULKS46087 = true


### PR DESCRIPTION
Fixes:

* Particles effects in Ratchet & Clank when `Lower resolution for effects` is on
* Water effect in Outrun/DiRT 2 when `Lower resolution for effects` is off
* Water effect in Outrun/DiRT 2 when texture upscaling is on

So with this, you can play Outrun with texture upscaling and high resolution and the water effect still works (it's very sensitive to filtering and upscaling), which is what you'd expect.