### PR TITLE
Fix BlueToAlpha mode, re-enable it for Outrun and DiRT

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1676,7 +1676,7 @@ void GPUCommon::Execute_Prim(u32 op, u32 diff) {
 	// See the documentation for gstate_c.blueToAlpha.
 	bool blueToAlpha = false;
 	if (PSP_CoreParameter().compat.flags().BlueToAlpha) {
-		if (gstate_c.framebufFormat == GEBufferFormat::GE_FORMAT_565 && gstate.getColorMask() == 0x0FFFFF) {
+		if (gstate_c.framebufFormat == GEBufferFormat::GE_FORMAT_565 && gstate.getColorMask() == 0x0FFFFF && !gstate.isLogicOpEnabled()) {
 			blueToAlpha = true;
 			gstate_c.framebufFormat = GEBufferFormat::GE_FORMAT_4444;
 		}

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1119,6 +1119,17 @@ ULUS10513 = true
 ULJM05812 = true
 NPJH50371 = true
 
+# Colin McRae's DiRT 2 - issue #13012 (car reflections)
+ULUS10471 = true
+ULJM05533 = true
+NPJH50006 = true
+ULES01301 = true
+
+# Outrun 2006: Coast to Coast - issue #11358 (car reflections)
+ULES00262 = true
+ULUS10064 = true
+ULKS46087 = true
+
 [DateLimited]
 # Car Jack Streets - issue #12698
 NPUZ00043 = true


### PR DESCRIPTION
For better color precision in reflections.

Need to check for logic op, as if both BlueToAlpha and logicop are enabled, weird thing happen.