### PR TITLE
Build: Include all zstd files in libretro

### DIFF
--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -775,11 +775,8 @@ SOURCES_C +=   $(ZSTDDIR)/common/debug.c \
                $(ZSTDDIR)/common/error_private.c \
                $(ZSTDDIR)/common/fse_decompress.c \
                $(ZSTDDIR)/common/pool.c \
-               $(ZSTDDIR)/common/threading.c
-
-#SOURCES_C +=   $(ZSTDDIR)/common/xxhash.c
-
-SOURCES_C +=   \
+               $(ZSTDDIR)/common/threading.c \
+               $(ZSTDDIR)/common/xxhash.c \
                $(ZSTDDIR)/common/zstd_common.c \
                $(ZSTDDIR)/compress/fse_compress.c \
                $(ZSTDDIR)/compress/hist.c \


### PR DESCRIPTION
This was previously commented out, and was intentionally changed in zstd so you could use a different xxhash.

-[Unknown]