### PR TITLE
softgpu: Implement matrix data wrap-around

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -565,8 +565,32 @@ static int sceGeGetMtx(int type, u32 matrixPtr) {
 
 static u32 sceGeGetCmd(int cmd) {
 	if (cmd >= 0 && cmd < (int)ARRAY_SIZE(gstate.cmdmem)) {
-		// Does not mask away the high bits.
-		return hleLogSuccessInfoX(SCEGE, gstate.cmdmem[cmd]);
+		// Does not mask away the high bits.  But matrix regs don't read back.
+		u32 val = gstate.cmdmem[cmd];
+		switch (cmd) {
+		case GE_CMD_BONEMATRIXDATA:
+		case GE_CMD_WORLDMATRIXDATA:
+		case GE_CMD_VIEWMATRIXDATA:
+		case GE_CMD_PROJMATRIXDATA:
+		case GE_CMD_TGENMATRIXDATA:
+			val &= 0xFF000000;
+			break;
+
+		case GE_CMD_BONEMATRIXNUMBER:
+			val &= 0xFF00007F;
+			break;
+
+		case GE_CMD_WORLDMATRIXNUMBER:
+		case GE_CMD_VIEWMATRIXNUMBER:
+		case GE_CMD_PROJMATRIXNUMBER:
+		case GE_CMD_TGENMATRIXNUMBER:
+			val &= 0xFF00000F;
+			break;
+
+		default:
+			break;
+		}
+		return hleLogSuccessInfoX(SCEGE, val);
 	}
 	return hleLogError(SCEGE, SCE_KERNEL_ERROR_INVALID_INDEX);
 }

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2143,6 +2143,7 @@ void GPUCommon::Execute_WorldMtxData(u32 op, u32 diff) {
 	}
 	num++;
 	gstate.worldmtxnum = (GE_CMD_WORLDMATRIXNUMBER << 24) | (num & 0xF);
+	gstate.worldmtxdata = GE_CMD_WORLDMATRIXDATA << 24;
 }
 
 void GPUCommon::Execute_ViewMtxNum(u32 op, u32 diff) {
@@ -2190,6 +2191,7 @@ void GPUCommon::Execute_ViewMtxData(u32 op, u32 diff) {
 	}
 	num++;
 	gstate.viewmtxnum = (GE_CMD_VIEWMATRIXNUMBER << 24) | (num & 0xF);
+	gstate.viewmtxdata = GE_CMD_VIEWMATRIXDATA << 24;
 }
 
 void GPUCommon::Execute_ProjMtxNum(u32 op, u32 diff) {
@@ -2238,6 +2240,7 @@ void GPUCommon::Execute_ProjMtxData(u32 op, u32 diff) {
 	num++;
 	if (num <= 16)
 		gstate.projmtxnum = (GE_CMD_PROJMATRIXNUMBER << 24) | (num & 0xF);
+	gstate.projmtxdata = GE_CMD_PROJMATRIXDATA << 24;
 }
 
 void GPUCommon::Execute_TgenMtxNum(u32 op, u32 diff) {
@@ -2285,6 +2288,7 @@ void GPUCommon::Execute_TgenMtxData(u32 op, u32 diff) {
 	}
 	num++;
 	gstate.texmtxnum = (GE_CMD_TGENMATRIXNUMBER << 24) | (num & 0xF);
+	gstate.texmtxdata = GE_CMD_TGENMATRIXDATA << 24;
 }
 
 void GPUCommon::Execute_BoneMtxNum(u32 op, u32 diff) {
@@ -2356,6 +2360,7 @@ void GPUCommon::Execute_BoneMtxData(u32 op, u32 diff) {
 	}
 	num++;
 	gstate.boneMatrixNumber = (GE_CMD_BONEMATRIXNUMBER << 24) | (num & 0x7F);
+	gstate.boneMatrixData = GE_CMD_BONEMATRIXDATA << 24;
 }
 
 void GPUCommon::Execute_MorphWeight(u32 op, u32 diff) {

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -1033,57 +1033,79 @@ void SoftGPU::Execute_VertexType(u32 op, u32 diff) {
 
 void SoftGPU::Execute_WorldMtxData(u32 op, u32 diff) {
 	int num = gstate.worldmtxnum & 0xF;
+	u32 *target = num < 12 ? (u32 *)&gstate.worldMatrix[num] : (u32 *)&gstate.viewMatrix[num - 12];
 	u32 newVal = op << 8;
-	if (num < 12 && newVal != ((const u32 *)gstate.worldMatrix)[num]) {
-		((u32 *)gstate.worldMatrix)[num] = newVal;
+	if (newVal != *target) {
+		*target = newVal;
 		dirtyFlags_ |= SoftDirty::TRANSFORM_MATRIX;
 	}
 	num++;
 	gstate.worldmtxnum = (GE_CMD_WORLDMATRIXNUMBER << 24) | (num & 0xF);
+	gstate.worldmtxdata = GE_CMD_WORLDMATRIXDATA << 24;
 }
 
 void SoftGPU::Execute_ViewMtxData(u32 op, u32 diff) {
 	int num = gstate.viewmtxnum & 0xF;
+	u32 *target = num < 12 ? (u32 *)&gstate.viewMatrix[num] : (u32 *)&gstate.projMatrix[num - 12];
 	u32 newVal = op << 8;
-	if (num < 12 && newVal != ((const u32 *)gstate.viewMatrix)[num]) {
-		((u32 *)gstate.viewMatrix)[num] = newVal;
+	if (newVal != *target) {
+		*target = newVal;
 		dirtyFlags_ |= SoftDirty::TRANSFORM_MATRIX;
 	}
 	num++;
 	gstate.viewmtxnum = (GE_CMD_VIEWMATRIXNUMBER << 24) | (num & 0xF);
+	gstate.viewmtxdata = GE_CMD_VIEWMATRIXDATA << 24;
 }
 
 void SoftGPU::Execute_ProjMtxData(u32 op, u32 diff) {
-	// NOTE: Changed from 0xF to catch overflows.
-	int num = gstate.projmtxnum & 0x1F;
+	int num = gstate.projmtxnum & 0xF;
+	u32 *target = (u32 *)&gstate.projMatrix[num];
 	u32 newVal = op << 8;
-	if (num < 0x10 && newVal != ((const u32 *)gstate.projMatrix)[num]) {
-		((u32 *)gstate.projMatrix)[num] = newVal;
+	if (newVal != *target) {
+		*target = newVal;
 		dirtyFlags_ |= SoftDirty::TRANSFORM_MATRIX;
 	}
 	num++;
-	if (num <= 16)
-		gstate.projmtxnum = (GE_CMD_PROJMATRIXNUMBER << 24) | (num & 0xF);
+	gstate.projmtxnum = (GE_CMD_PROJMATRIXNUMBER << 24) | (num & 0xF);
+	gstate.projmtxdata = GE_CMD_PROJMATRIXDATA << 24;
 }
 
 void SoftGPU::Execute_TgenMtxData(u32 op, u32 diff) {
 	int num = gstate.texmtxnum & 0xF;
 	u32 newVal = op << 8;
+	// Doesn't wrap to any other matrix.
 	if (num < 12 && newVal != ((const u32 *)gstate.tgenMatrix)[num]) {
 		((u32 *)gstate.tgenMatrix)[num] = newVal;
+		// No dirtying, read during vertex read.
 	}
 	num++;
 	gstate.texmtxnum = (GE_CMD_TGENMATRIXNUMBER << 24) | (num & 0xF);
+	gstate.texmtxdata = GE_CMD_TGENMATRIXDATA << 24;
 }
 
 void SoftGPU::Execute_BoneMtxData(u32 op, u32 diff) {
 	int num = gstate.boneMatrixNumber & 0x7F;
+	u32 *target;
+	if (num < 96) {
+		target = (u32 *)&gstate.boneMatrix[num];
+	} else if (num < 96 + 12) {
+		target = (u32 *)&gstate.worldMatrix[num - 96];
+	} else if (num < 96 + 12 + 12) {
+		target = (u32 *)&gstate.viewMatrix[num - 96 - 12];
+	} else {
+		target = (u32 *)&gstate.projMatrix[num - 96 - 12 - 12];
+	}
+
 	u32 newVal = op << 8;
-	if (num < 96 && newVal != ((const u32 *)gstate.boneMatrix)[num]) {
-		((u32 *)gstate.boneMatrix)[num] = newVal;
+	if (newVal != *target) {
+		*target = newVal;
+		// Dirty if it overflowed.  We read bone data during vertex read.
+		if (num >= 96)
+			dirtyFlags_ |= SoftDirty::TRANSFORM_MATRIX;
 	}
 	num++;
 	gstate.boneMatrixNumber = (GE_CMD_BONEMATRIXNUMBER << 24) | (num & 0x7F);
+	gstate.boneMatrixData  = GE_CMD_BONEMATRIXDATA << 24;
 }
 
 void SoftGPU::Execute_Call(u32 op, u32 diff) {


### PR DESCRIPTION
This implements matrix data register wrap-around, which seems to reproduce on hardware.  This, however, does not make Red Star render correctly without the hack in #9136.

But at least it matches tests for what matrix values are updated.  Could be interesting if this helps something, but I'm currently not aware of any games relying on this.

-[Unknown]