### PR TITLE
d3d9: Correct decode of 16-bit textures

### DIFF
--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -59,7 +59,15 @@ static const D3D11_INPUT_ELEMENT_DESC g_QuadVertexElements[] = {
 
 Draw::DataFormat FromD3D11Format(u32 fmt) {
 	switch (fmt) {
-	case DXGI_FORMAT_B8G8R8A8_UNORM: default: return Draw::DataFormat::R8G8B8A8_UNORM;
+	case DXGI_FORMAT_B4G4R4A4_UNORM:
+		return Draw::DataFormat::A4R4G4B4_UNORM_PACK16;
+	case DXGI_FORMAT_B5G5R5A1_UNORM:
+		return Draw::DataFormat::A1R5G5B5_UNORM_PACK16;
+	case DXGI_FORMAT_B5G6R5_UNORM:
+		return Draw::DataFormat::R5G6B5_UNORM_PACK16;
+	case DXGI_FORMAT_B8G8R8A8_UNORM:
+	default:
+		return Draw::DataFormat::R8G8B8A8_UNORM;
 	}
 }
 

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -41,7 +41,15 @@
 
 Draw::DataFormat FromD3D9Format(u32 fmt) {
 	switch (fmt) {
-	case D3DFMT_A8R8G8B8: default: return Draw::DataFormat::R8G8B8A8_UNORM;
+	case D3DFMT_A4R4G4B4:
+		return Draw::DataFormat::B4G4R4A4_UNORM_PACK16;
+	case D3DFMT_A1R5G5B5:
+		return Draw::DataFormat::A1R5G5B5_UNORM_PACK16;
+	case D3DFMT_R5G6B5:
+		return Draw::DataFormat::R5G6B5_UNORM_PACK16;
+	case D3DFMT_A8R8G8B8:
+	default:
+		return Draw::DataFormat::R8G8B8A8_UNORM;
 	}
 }
 


### PR DESCRIPTION
Was causing crashes since we assumed this func could handle non-replaced formats.

Broken in #15760, I think.  See crash in #15970 (this may be the actual cause of that issue.)

-[Unknown]