### PR TITLE
Build: Another attempt to fix libretro

### DIFF
--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -801,7 +801,8 @@ SOURCES_C +=   $(ZSTDDIR)/common/debug.c \
                $(ZSTDDIR)/dictBuilder/fastcover.c \
                $(ZSTDDIR)/dictBuilder/zdict.c
 
-ifneq (,$(findstring msvc,$(platform)))
+# zstd only uses asm for Linux/macOS and GNUC.
+ifneq ($(PLATFORM_EXT), win32)
 ifeq ($(TARGET_ARCH),x86_64)
 SOURCES_C +=   $(ZSTDDIR)/decompress/huf_decompress_amd64.S
 endif


### PR DESCRIPTION
As per lib/common/portability_macros.h in zstd:
https://github.com/facebook/zstd/blob/930b5cecaa033c3aa6017b246bb804ef576942b4/lib/common/portability_macros.h#L102

Previous change was only including this file for msvc, which seems backwards.  That said, strangely it worked on Windows so I don't trust this msvc check.

-[Unknown]