### PR TITLE
Add Emulator to Categories in ppsspp.desktop.in

### DIFF
--- a/ppsspp.desktop.in
+++ b/ppsspp.desktop.in
@@ -4,4 +4,4 @@ Exec=@TargetBin@
 Icon=ppsspp
 Type=Application
 Comment=ppsspp (fast and portable PSP emulator)
-Categories=Game
+Categories=Game;Emulator


### PR DESCRIPTION
The XDG Menu Specification defines a list of [Additional Categories](https://specifications.freedesktop.org/menu-spec/latest/apas02.html) that allow launchers to subcategorize entries.

One of the ones which is valid for the `Game` category is `Emulator` and adding it makes things more convenient for users.