### PR TITLE
GE Debugger: Correct cond break removal warnings

### DIFF
--- a/Windows/GEDebugger/TabState.cpp
+++ b/Windows/GEDebugger/TabState.cpp
@@ -910,7 +910,7 @@ void CtrlStateValues::OnDoubleClick(int row, int column) {
 
 	if (column == STATEVALUES_COL_BREAKPOINT) {
 		bool proceed = true;
-		if (IsCmdBreakpoint(info.cmd)) {
+		if (GetCmdBreakpointCond(info.cmd, nullptr)) {
 			int ret = MessageBox(GetHandle(), L"This breakpoint has a custom condition.\nDo you want to remove it?", L"Confirmation", MB_YESNO);
 			proceed = ret == IDYES;
 		}
@@ -993,7 +993,7 @@ void CtrlStateValues::OnRightClick(int row, int column, const POINT &point) {
 	{
 	case ID_DISASM_TOGGLEBREAKPOINT: {
 		bool proceed = true;
-		if (IsCmdBreakpoint(info.cmd)) {
+		if (GetCmdBreakpointCond(info.cmd, nullptr)) {
 			int ret = MessageBox(GetHandle(), L"This breakpoint has a custom condition.\nDo you want to remove it?", L"Confirmation", MB_YESNO);
 			proceed = ret == IDYES;
 		}

--- a/Windows/GEDebugger/TabVertices.cpp
+++ b/Windows/GEDebugger/TabVertices.cpp
@@ -571,9 +571,11 @@ void CtrlMatrixList::ToggleBreakpoint(int row) {
 	if (state) {
 		GPUBreakpoints::AddCmdBreakpoint(info->cmd);
 	} else {
-		int ret = MessageBox(GetHandle(), L"This breakpoint has a custom condition.\nDo you want to remove it?", L"Confirmation", MB_YESNO);
-		if (ret != IDYES)
-			return;
+		if (GPUBreakpoints::GetCmdBreakpointCond(info->cmd, nullptr)) {
+			int ret = MessageBox(GetHandle(), L"This breakpoint has a custom condition.\nDo you want to remove it?", L"Confirmation", MB_YESNO);
+			if (ret != IDYES)
+				return;
+		}
 		GPUBreakpoints::RemoveCmdBreakpoint(info->cmd);
 	}
 


### PR DESCRIPTION
Oops, they were just always confirming.  Must've forgotten to put `GetCmdBreakpointCond()` in these calls after initially marking what needed them...

-[Unknown]