### PR TITLE
softgpu: Allow almost flat rectangles to go fast

### DIFF
--- a/GPU/GeDisasm.cpp
+++ b/GPU/GeDisasm.cpp
@@ -605,7 +605,7 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer, int bufsize) {
 		{
 			int w = 1 << (data & 0xf);
 			int h = 1 << ((data>>8) & 0xf);
-			if ((data & ~0x0F0F) && w <= 512 && h <= 512)
+			if ((data & ~0x0F0F) == 0 && w <= 512 && h <= 512)
 				snprintf(buffer, bufsize, "Texture size %d: %dx%d", cmd - GE_CMD_TEXSIZE0, w, h);
 			else
 				snprintf(buffer, bufsize, "Texture size %d: %dx%d (extra %06x)", cmd - GE_CMD_TEXSIZE0, w, h, data);

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -435,7 +435,9 @@ bool DetectRectangleFromFan(const RasterizerState &state, const VertexData *data
 
 			if (textl.x == texbl.x && textr.x == texbr.x && textl.y == textr.y && texbl.y == texbr.y) {
 				// Okay, the texture is also good, but let's avoid rotation issues.
-				return textl.y < texbr.y && textl.x < texbr.x;
+				const auto &postl = data[*tlIndex].screenpos;
+				const auto &posbr = data[*brIndex].screenpos;
+				return textl.y < texbr.y && postl.y < posbr.y && textl.x < texbr.x && postl.x < posbr.x;
 			}
 		}
 	}

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -414,14 +414,14 @@ bool DetectRectangleFromFan(const RasterizerState &state, const VertexData *data
 
 	// Check for the common case: a single TL-TR-BR-BL.
 	if (c == 4) {
-		const auto &tl = data[0].screenpos, &tr = data[1].screenpos;
-		const auto &bl = data[3].screenpos, &br = data[2].screenpos;
-		if (tl.x == bl.x && tr.x == br.x && tl.y == tr.y && bl.y == br.y) {
+		const auto &pos0 = data[0].screenpos, &pos1 = data[1].screenpos;
+		const auto &pos2 = data[2].screenpos, &pos3 = data[3].screenpos;
+		if (pos0.x == pos3.x && pos1.x == pos2.x && pos0.y == pos1.y && pos3.y == pos2.y) {
 			// Looking like yes.  Set TL/BR based on y order first...
-			*tlIndex = tl.y > bl.y ? 2 : 0;
-			*brIndex = tl.y > bl.y ? 0 : 2;
+			*tlIndex = pos0.y > pos3.y ? 2 : 0;
+			*brIndex = pos0.y > pos3.y ? 0 : 2;
 			// And if it's horizontally flipped, trade to the actual TL/BR.
-			if (tl.x > tr.x) {
+			if (pos0.x > pos1.x) {
 				*tlIndex ^= 1;
 				*brIndex ^= 1;
 			}

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -838,7 +838,7 @@ void SoftGPU::Execute_Prim(u32 op, u32 diff) {
 		return;
 	}
 
-	const void *verts = Memory::GetPointer(gstate_c.vertexAddr);
+	const void *verts = Memory::GetPointerUnchecked(gstate_c.vertexAddr);
 	const void *indices = NULL;
 	if ((gstate.vertType & GE_VTYPE_IDX_MASK) != GE_VTYPE_IDX_NONE) {
 		if (!Memory::IsValidAddress(gstate_c.indexAddr)) {


### PR DESCRIPTION
Improves Chains of Olympus performance by around 12% on the title screen (from ~64% to ~72%, or so, maybe a bit better.)  This allows us to skip the (slow) triangle interpolation and also avoid going over the rectangle twice for each half.

-[Unknown]