### PR TITLE
softgpu: Clamp/wrap textures at 512 pixels

### DIFF
--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1401,7 +1401,11 @@ bool GetCurrentTexture(GPUDebugBuffer &buffer, int level)
 	int w = gstate.getTextureWidth(level);
 	int h = gstate.getTextureHeight(level);
 
-	if (!texaddr || !Memory::IsValidRange(texaddr, (textureBitsPerPixel[texfmt] * texbufw * h) / 8))
+	u32 sizeInBits = textureBitsPerPixel[texfmt] * (texbufw * (h - 1) + w);
+	if (!texaddr || !Memory::IsValidRange(texaddr, sizeInBits / 8))
+		return false;
+	// We'll break trying to allocate this much.
+	if (w >= 0x8000 && h >= 0x8000)
 		return false;
 
 	buffer.Allocate(w, h, GE_FORMAT_8888, false);

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -265,6 +265,10 @@ bool g_needsClearAfterDialog = false;
 static inline bool NoClampOrWrap(const RasterizerState &state, const Vec2f &tc) {
 	if (tc.x < 0 || tc.y < 0)
 		return false;
+	if (state.samplerID.cached.sizes[0].w > 512 || state.samplerID.cached.sizes[0].h > 512)
+		return false;
+	if (!state.throughMode)
+		return tc.x <= 1.0f && tc.y <= 1.0f;
 	return tc.x <= state.samplerID.cached.sizes[0].w && tc.y <= state.samplerID.cached.sizes[0].h;
 }
 

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -383,13 +383,15 @@ inline static Nearest4 SOFTRAST_CALL SampleNearest(const int u[N], const int v[N
 static inline int ClampUV(int v, int height) {
 	if (v >= height - 1)
 		return height - 1;
+	if (v >= 511)
+		return 511;
 	else if (v < 0)
 		return 0;
 	return v;
 }
 
 static inline int WrapUV(int v, int height) {
-	return v & (height - 1);
+	return v & (height - 1) & 511;
 }
 
 template <int N>

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -114,6 +114,7 @@ private:
 	const u8 *constVNext_ = nullptr;
 	const u8 *constOnes32_ = nullptr;
 	const u8 *constOnes16_ = nullptr;
+	const u8 *constMaxTexel32_ = nullptr;
 	const u8 *const10All16_ = nullptr;
 	const u8 *const10Low_ = nullptr;
 	const u8 *const10All8_ = nullptr;


### PR DESCRIPTION
This almost passes https://github.com/hrydgard/pspautotests/pull/222, but doesn't quite because the minification (512 or more texels to 256 pixels) in the test seems to be slightly off.  Still, it fixes the >= 512 sized texture behavior which might have some interesting effects.

Luckily, it's fairly cheap to do so.

-[Unknown]