### PR TITLE
Cleanup some crashes in GE debugger or with large textures

### DIFF
--- a/Common/GPU/Vulkan/VulkanImage.cpp
+++ b/Common/GPU/Vulkan/VulkanImage.cpp
@@ -36,6 +36,10 @@ bool VulkanTexture::CreateDirect(VkCommandBuffer cmd, int w, int h, int depth, i
 		ERROR_LOG(G3D, "Can't create a zero-size VulkanTexture");
 		return false;
 	}
+	if (w > 4096 || h > 4096) {
+		ERROR_LOG(G3D, "Can't create a texture this large");
+		return false;
+	}
 
 	Wipe();
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2271,12 +2271,6 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 	// For the estimate, we assume cluts always point to 8888 for simplicity.
 	cacheSizeEstimate_ += EstimateTexMemoryUsage(entry);
 
-	if ((entry->bufw == 0 || (gstate.texbufwidth[0] & 0xf800) != 0) && entry->addr >= PSP_GetKernelMemoryEnd()) {
-		ERROR_LOG_REPORT(G3D, "Texture with unexpected bufw (full=%d)", gstate.texbufwidth[0] & 0xffff);
-		// Proceeding here can cause a crash.
-		return false;
-	}
-
 	plan.badMipSizes = false;
 	// maxLevel here is the max level to upload. Not the count.
 	plan.levelsToLoad = entry->maxLevel + 1;

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -300,6 +300,10 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 	int tw;
 	int th;
 	plan.GetMipSize(0, &tw, &th);
+	if (tw > 16384)
+		tw = 16384;
+	if (th > 16384)
+		th = 16384;
 
 	if (plan.depth == 1) {
 		// We don't yet have mip generation, so clamp the number of levels to the ones we can load directly.

--- a/GPU/Debugger/Breakpoints.cpp
+++ b/GPU/Debugger/Breakpoints.cpp
@@ -29,6 +29,9 @@
 
 namespace GPUBreakpoints {
 
+static void NothingToDo(bool) {
+}
+
 struct BreakpointInfo {
 	bool isConditional = false;
 	PostfixExpression expression;
@@ -45,7 +48,7 @@ static std::set<u32> breakRenderTargets;
 static size_t breakPCsCount = 0;
 static size_t breakTexturesCount = 0;
 static size_t breakRenderTargetsCount = 0;
-static std::function<void(bool)> notifyBreakpoints;
+static std::function<void(bool)> notifyBreakpoints = &NothingToDo;
 
 // If these are set, the above are also, but they should be temporary.
 static bool breakCmdsTemp[256];

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -389,13 +389,12 @@ void TextureCacheVulkan::UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutB
 }
 
 void TextureCacheVulkan::BindTexture(TexCacheEntry *entry) {
-	if (!entry) {
+	if (!entry || !entry->vkTex) {
 		imageView_ = VK_NULL_HANDLE;
 		curSampler_ = VK_NULL_HANDLE;
 		return;
 	}
 
-	_dbg_assert_(entry->vkTex);
 	entry->vkTex->Touch();
 
 	int maxLevel = (entry->status & TexCacheEntry::STATUS_NO_MIPS) ? 0 : entry->maxLevel;

--- a/Windows/GEDebugger/TabState.cpp
+++ b/Windows/GEDebugger/TabState.cpp
@@ -63,6 +63,7 @@ enum CmdFormatType {
 	CMD_FMT_XY,
 	CMD_FMT_XYXY,
 	CMD_FMT_XYZ,
+	CMD_FMT_XYPLUS1,
 	CMD_FMT_TEXSIZE,
 	CMD_FMT_F16_XY,
 	CMD_FMT_VERTEXTYPE,
@@ -233,7 +234,7 @@ static const TabStateRow stateSettingsRows[] = {
 	{ L"Transfer src pos",     GE_CMD_TRANSFERSRCPOS,          CMD_FMT_XY },
 	{ L"Transfer dst",         GE_CMD_TRANSFERDST,             CMD_FMT_PTRWIDTH, 0, GE_CMD_TRANSFERDSTW },
 	{ L"Transfer dst pos",     GE_CMD_TRANSFERDSTPOS,          CMD_FMT_XY },
-	{ L"Transfer size",        GE_CMD_TRANSFERSIZE,            CMD_FMT_XY },
+	{ L"Transfer size",        GE_CMD_TRANSFERSIZE,            CMD_FMT_XYPLUS1 },
 	{ L"Vertex type",          GE_CMD_VERTEXTYPE,              CMD_FMT_VERTEXTYPE },
 	{ L"Offset addr",          GE_CMD_OFFSETADDR,              CMD_FMT_OFFSETADDR },
 	{ L"Vertex addr",          GE_CMD_VADDR,                   CMD_FMT_VADDR },
@@ -373,6 +374,14 @@ void FormatStateRow(wchar_t *dest, const TabStateRow &info, u32 value, bool enab
 			int x = value & 0x3FF;
 			int y = value >> 10;
 			swprintf(dest, 255, L"%d,%d", x, y);
+		}
+		break;
+
+	case CMD_FMT_XYPLUS1:
+		{
+			int x = value & 0x3FF;
+			int y = value >> 10;
+			swprintf(dest, 255, L"%d,%d", x + 1, y + 1);
 		}
 		break;
 


### PR DESCRIPTION
From quick checks of https://github.com/hrydgard/pspautotests/pull/222, just to make sure it doesn't crash.

-[Unknown]