### PR TITLE
softgpu: Check depth test early on simple stencil

### DIFF
--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -41,6 +41,8 @@ SingleFunc GetSingleFunc(const PixelFuncID &id);
 void Init();
 void Shutdown();
 
+bool CheckDepthTestPassed(GEComparison func, int x, int y, int stride, u16 z);
+
 bool DescribeCodePtr(const u8 *ptr, std::string &name);
 
 struct PixelBlendState {

--- a/GPU/Software/FuncId.cpp
+++ b/GPU/Software/FuncId.cpp
@@ -163,6 +163,13 @@ void ComputePixelFuncID(PixelFuncID *id, bool throughMode) {
 
 		id->applyLogicOp = gstate.isLogicOpEnabled() && gstate.getLogicOp() != GE_LOGIC_COPY;
 		id->applyFog = gstate.isFogEnabled() && !throughMode;
+
+		id->earlyZChecks = id->DepthTestFunc() != GE_COMP_ALWAYS;
+		if (id->stencilTest && id->earlyZChecks) {
+			// Can't do them early if stencil might need to write.
+			if (id->SFail() != GE_STENCILOP_KEEP || id->ZFail() != GE_STENCILOP_KEEP)
+				id->earlyZChecks = false;
+		}
 	}
 
 	// Cache some values for later convenience.

--- a/GPU/Software/FuncId.h
+++ b/GPU/Software/FuncId.h
@@ -107,7 +107,8 @@ struct PixelFuncID {
 			uint8_t sFail : 3;
 			uint8_t zFail : 3;
 			uint8_t zPass : 3;
-			// 60 bits, 4 free.
+			bool earlyZChecks : 1;
+			// 61 bits, 3 free.
 		};
 	};
 


### PR DESCRIPTION
If we don't need to write stencil on sfail/zfail, we can do the depthtest early, which allows us to more often skip texture sampling.

This gives a good improvement in Chains of Olympus' title screen - combined with #15998, I'm seeing close to ~88-90%.

-[Unknown]