### PR TITLE
CLUT download: Replace the backwards block transfer check with a new compat flag

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -98,6 +98,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "DeswizzleDepth", &flags_.DeswizzleDepth);
 	CheckSetting(iniFile, gameID, "SplitFramebufferMargin", &flags_.SplitFramebufferMargin);
 	CheckSetting(iniFile, gameID, "ForceLowerResolutionForEffectsOn", &flags_.ForceLowerResolutionForEffectsOn);
+	CheckSetting(iniFile, gameID, "AllowDownloadCLUT", &flags_.AllowDownloadCLUT);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -88,6 +88,7 @@ struct CompatFlags {
 	bool DeswizzleDepth;
 	bool SplitFramebufferMargin;
 	bool ForceLowerResolutionForEffectsOn;
+	bool AllowDownloadCLUT;
 };
 
 class IniFile;

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2552,6 +2552,11 @@ void FramebufferManagerCommon::DownloadFramebufferForClut(u32 fb_address, u32 lo
 		int w = std::min(pixels % vfb->fb_stride, (int)vfb->width);
 		int h = std::min((pixels + vfb->fb_stride - 1) / vfb->fb_stride, (int)vfb->height);
 
+		if (w == 0 || h > 1) {
+			// Exactly aligned, or more than one row.
+			w = std::min(vfb->fb_stride, vfb->width);
+		}
+
 		// We might still have a pending draw to the fb in question, flush if so.
 		FlushBeforeCopy();
 

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1294,3 +1294,6 @@ ULES01301 = true
 ULES00262 = true
 ULUS10064 = true
 ULKS46087 = true
+
+[AllowDownloadCLUT]
+# Temporary compatibility option, while developing a GPU CLUT-from-framebuffer path.


### PR DESCRIPTION
This compat flag is intended to be temporary until we've implemented a readback-free path for CLUTs from framebuffers, both when texturing from static textures and other framebuffers.

No games turn it on by default. But it's useful to turn it on manually for debugging games that use these techniques, while fixing other things that are blocking them from working - this part can be done last.


Some examples of CLUT-from-framebuffer:


* #8509
* #15923 - likely multiple cases, Burnout Dominator confirmed
* Brave Story colored enemies this way...