### PR TITLE
Implement shader depal for D3D11, texture match refactorings

### DIFF
--- a/Common/GPU/ShaderWriter.cpp
+++ b/Common/GPU/ShaderWriter.cpp
@@ -24,6 +24,7 @@ const char * const hlsl_preamble_fs =
 "#define vec4 float4\n"
 "#define uvec3 uint3\n"
 "#define uvec4 uint4\n"
+"#define ivec2 int2\n"
 "#define ivec3 int3\n"
 "#define ivec4 int4\n"
 "#define mat4 float4x4\n"
@@ -419,6 +420,40 @@ ShaderWriter &ShaderWriter::SampleTexture2D(const char *sampName, const char *uv
 	default:
 		// Note: we ignore the sampler. make sure you bound samplers to the textures correctly.
 		F("%s(%s, %s)", lang_.texture, sampName, uv);
+		break;
+	}
+	return *this;
+}
+
+ShaderWriter &ShaderWriter::SampleTexture2DOffset(const char *sampName, const char *uv, int offX, int offY) {
+	switch (lang_.shaderLanguage) {
+	case HLSL_D3D11:
+		F("%s.Sample(%sSamp, %s, int2(%d, %d))", sampName, sampName, uv, offX, offY);
+		break;
+	case HLSL_D3D9:
+		// Not supported, we do a normal sample here to not crash or something
+		F("tex2D(%s, %s)", sampName, uv);
+		break;
+	default:
+		// Note: we ignore the sampler. make sure you bound samplers to the textures correctly.
+		F("%sOffset(%s, %s, ivec2(%d, %d))", lang_.texture, sampName, uv, offX, offY);
+		break;
+	}
+	return *this;
+}
+
+ShaderWriter &ShaderWriter::LoadTexture2D(const char *sampName, const char *uv, int level) {
+	switch (lang_.shaderLanguage) {
+	case HLSL_D3D11:
+		F("%s.Load(ivec3(%s, %d))", sampName, uv, level);
+		break;
+	case HLSL_D3D9:
+		// Not supported, we return a bad value
+		C("float4(1.0, 0.0, 1.0, 1.0)");
+		break;
+	default:
+		// Note: we ignore the sampler. make sure you bound samplers to the textures correctly.
+		F("texelFetch(%s, %s, %d)", lang_.texture, sampName, uv, level);
 		break;
 	}
 	return *this;

--- a/Common/GPU/ShaderWriter.cpp
+++ b/Common/GPU/ShaderWriter.cpp
@@ -453,7 +453,7 @@ ShaderWriter &ShaderWriter::LoadTexture2D(const char *sampName, const char *uv, 
 		break;
 	default:
 		// Note: we ignore the sampler. make sure you bound samplers to the textures correctly.
-		F("texelFetch(%s, %s, %d)", lang_.texture, sampName, uv, level);
+		F("texelFetch(%s, %s, %d)", sampName, uv, level);
 		break;
 	}
 	return *this;

--- a/Common/GPU/ShaderWriter.h
+++ b/Common/GPU/ShaderWriter.h
@@ -78,6 +78,8 @@ public:
 	void ConstFloat(const char *name, float value);
 
 	ShaderWriter &SampleTexture2D(const char *texName, const char *uv);
+	ShaderWriter &SampleTexture2DOffset(const char *texName, const char *uv, int offX, int offY);
+	ShaderWriter &LoadTexture2D(const char *texName, const char *integer_uv, int level);
 	ShaderWriter &GetTextureSize(const char *szVariable, const char *texName);
 
 	// Simple shaders with no special tricks.

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -96,7 +96,10 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 	if (texture3D) {
 		shaderDepalMode = ShaderDepalMode::OFF;
 	}
-
+	if (!compat.bitwiseOps && shaderDepalMode != ShaderDepalMode::OFF) {
+		*errorString = "depal requires bitwise ops";
+		return false;
+	}
 	bool bgraTexture = id.Bit(FS_BIT_BGRA_TEXTURE);
 	bool colorWriteMask = id.Bit(FS_BIT_COLOR_WRITEMASK) && compat.bitwiseOps;
 
@@ -732,7 +735,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 				break;
 			case ShaderDepalMode::CLUT8_8888:
 				// Not yet implemented.
-				WRITE(p, "    t = vec4(0.0, 0.0, 0.0, 0.0);\n");
+				WRITE(p, "    vec4 t = vec4(0.0, 0.0, 0.0, 0.0);\n");
 				break;
 			}
 

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -148,6 +148,7 @@ struct VirtualFramebuffer {
 
 	// Convenience methods
 	inline int WidthInBytes() const { return width * BufferFormatBytesPerPixel(fb_format); }
+	inline int BufferWidthInBytes() const { return bufferWidth * BufferFormatBytesPerPixel(fb_format); }
 	inline int FbStrideInBytes() const { return fb_stride * BufferFormatBytesPerPixel(fb_format); }
 	inline int ZStrideInBytes() const { return z_stride * 2; }
 };

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -180,8 +180,12 @@ std::string FragmentShaderDesc(const FShaderID &id) {
 	if (id.Bit(FS_BIT_COLOR_DOUBLE)) desc << "2x ";
 	if (id.Bit(FS_BIT_FLATSHADE)) desc << "Flat ";
 	if (id.Bit(FS_BIT_BGRA_TEXTURE)) desc << "BGRA ";
-	if (id.Bit(FS_BIT_SHADER_DEPAL)) desc << "Depal ";
-	if (id.Bit(FS_BIT_SHADER_SMOOTHED_DEPAL)) desc << "SmoothDepal ";
+	switch ((ShaderDepalMode)id.Bit(FS_BIT_SHADER_DEPAL_MODE)) {
+	case ShaderDepalMode::OFF: break;
+	case ShaderDepalMode::NORMAL: desc << "Depal ";  break;
+	case ShaderDepalMode::SMOOTHED: desc << "SmoothDepal "; break;
+	case ShaderDepalMode::CLUT8_8888: desc << "CLUT8From8888Depal"; break;
+	}
 	if (id.Bit(FS_BIT_COLOR_WRITEMASK)) desc << "WriteMask ";
 	if (id.Bit(FS_BIT_SHADER_TEX_CLAMP)) {
 		desc << "TClamp";
@@ -261,8 +265,9 @@ void ComputeFragmentShaderID(FShaderID *id_out, const ComputedPipelineState &pip
 		bool doTextureProjection = (gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX && MatrixNeedsProjection(gstate.tgenMatrix));
 		bool doTextureAlpha = gstate.isTextureAlphaUsed();
 		bool doFlatShading = gstate.getShadeMode() == GE_SHADE_FLAT;
-		bool useShaderDepal = gstate_c.useShaderDepal;
-		bool useSmoothedDepal = gstate_c.useSmoothedShaderDepal;
+
+		ShaderDepalMode shaderDepalMode = gstate_c.shaderDepalMode;
+
 		bool colorWriteMask = pipelineState.maskState.applyFramebufferRead;
 
 		ReplaceBlendType replaceBlend = pipelineState.blendState.replaceBlend;
@@ -289,8 +294,7 @@ void ComputeFragmentShaderID(FShaderID *id_out, const ComputedPipelineState &pip
 				id.SetBit(FS_BIT_TEXTURE_AT_OFFSET, textureAtOffset);
 			}
 			id.SetBit(FS_BIT_BGRA_TEXTURE, gstate_c.bgraTexture);
-			id.SetBit(FS_BIT_SHADER_DEPAL, useShaderDepal);
-			id.SetBit(FS_BIT_SHADER_SMOOTHED_DEPAL, useSmoothedDepal);
+			id.SetBits(FS_BIT_SHADER_DEPAL_MODE, 2, (int)shaderDepalMode);
 			id.SetBit(FS_BIT_3D_TEXTURE, gstate_c.curTextureIs3D);
 		}
 

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -66,7 +66,7 @@ enum FShaderBit : uint8_t {
 	FS_BIT_DO_TEXTURE = 1,
 	FS_BIT_TEXFUNC = 2,  // 3 bits
 	FS_BIT_TEXALPHA = 5,
-	FS_BIT_SHADER_DEPAL = 6,
+	FS_BIT_3D_TEXTURE = 6,
 	FS_BIT_SHADER_TEX_CLAMP = 7,
 	FS_BIT_CLAMP_S = 8,
 	FS_BIT_CLAMP_T = 9,
@@ -93,9 +93,8 @@ enum FShaderBit : uint8_t {
 	FS_BIT_TEST_DISCARD_TO_ZERO = 48,
 	FS_BIT_NO_DEPTH_CANNOT_DISCARD_STENCIL = 49,
 	FS_BIT_COLOR_WRITEMASK = 50,
-	FS_BIT_3D_TEXTURE = 51,
-	FS_BIT_SHADER_SMOOTHED_DEPAL = 52,
-	FS_BIT_REPLACE_LOGIC_OP = 53,  // 4 bits. GE_LOGIC_COPY means no-op/off.
+	FS_BIT_REPLACE_LOGIC_OP = 51,  // 4 bits. GE_LOGIC_COPY means no-op/off.
+	FS_BIT_SHADER_DEPAL_MODE = 55,  // 2 bits (ShaderDepalMode)
 };
 
 static inline FShaderBit operator +(FShaderBit bit, int i) {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1956,7 +1956,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 
 			// Since we started/ended render passes, might need these.
 			gstate_c.Dirty(DIRTY_DEPAL);
-			gstate_c.SetUseShaderDepal(true, smoothedDepal);
+			gstate_c.SetUseShaderDepal(smoothedDepal ? ShaderDepalMode::SMOOTHED : ShaderDepalMode::NORMAL);
 			gstate_c.depalFramebufferFormat = framebuffer->fb_format;
 
 			const u32 bytesPerColor = clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16);
@@ -1972,7 +1972,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 		depthUpperBits = (depth && framebuffer->fb_format == GE_FORMAT_8888) ? ((gstate.getTextureAddress(0) & 0x600000) >> 20) : 0;
 
 		textureShader = textureShaderCache_->GetDepalettizeShader(clutMode, texFormat, depth ? GE_FORMAT_DEPTH16 : framebuffer->fb_format, smoothedDepal, depthUpperBits);
-		gstate_c.SetUseShaderDepal(false, false);
+		gstate_c.SetUseShaderDepal(ShaderDepalMode::OFF);
 	}
 
 	if (textureShader) {
@@ -2045,7 +2045,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 		framebufferManager_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV | BINDFBCOLOR_APPLY_TEX_OFFSET);
 		BoundFramebufferTexture();
 
-		gstate_c.SetUseShaderDepal(false, false);
+		gstate_c.SetUseShaderDepal(ShaderDepalMode::OFF);
 		gstate_c.SetTextureFullAlpha(gstate.getTextureFormat() == GE_TFMT_5650);
 	}
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -952,8 +952,7 @@ bool TextureCacheCommon::MatchFramebuffer(
 			(fb_format == GE_FORMAT_DEPTH16 && entry.format == GE_TFMT_CLUT16) ||
 			(fb_format == GE_FORMAT_DEPTH16 && entry.format == GE_TFMT_5650) ||
 			(fb_format == GE_FORMAT_8888 && entry.format == GE_TFMT_CLUT32) ||
-			(fb_format != GE_FORMAT_8888 && entry.format == GE_TFMT_CLUT16) ||
-			(fb_format == GE_FORMAT_8888 && entry.format == GE_TFMT_CLUT8);  // Mixed byte size, format, reinterpret in depal!
+			(fb_format != GE_FORMAT_8888 && entry.format == GE_TFMT_CLUT16);
 
 		const int texBitsPerPixel = std::max(1U, (u32)textureBitsPerPixel[entry.format]);
 		const int byteOffset = texaddr - addr;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1924,7 +1924,6 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 
 	// TODO: Implement shader depal in the fragment shader generator for D3D11 at least.
 	switch (draw_->GetShaderLanguageDesc().shaderLanguage) {
-	case ShaderLanguage::HLSL_D3D11:
 	case ShaderLanguage::HLSL_D3D9:
 		useShaderDepal = false;
 		break;

--- a/GPU/D3D11/D3D11Util.cpp
+++ b/GPU/D3D11/D3D11Util.cpp
@@ -26,13 +26,14 @@ std::vector<uint8_t> CompileShaderToBytecodeD3D11(const char *code, size_t codeS
 	std::string errors;
 	if (errorMsgs) {
 		errors = std::string((const char *)errorMsgs->GetBufferPointer(), errorMsgs->GetBufferSize());
+		std::string numberedCode = LineNumberString(code);
 		if (SUCCEEDED(result)) {
 			WARN_LOG(G3D, "%s: %s", "warnings", errors.c_str());
 		} else {
-			ERROR_LOG(G3D, "%s: %s", "errors", errors.c_str());
+			ERROR_LOG(G3D, "%s: %s\n\n%s", "errors", errors.c_str(), numberedCode.c_str());
 		}
-		OutputDebugStringA(LineNumberString(code).c_str());
 		OutputDebugStringA(errors.c_str());
+		OutputDebugStringA(numberedCode.c_str());
 		errorMsgs->Release();
 	}
 	if (compiledCode) {

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -180,8 +180,8 @@ void TextureCacheD3D11::ReleaseTexture(TexCacheEntry *entry, bool delete_them) {
 void TextureCacheD3D11::ForgetLastTexture() {
 	InvalidateLastTexture();
 
-	ID3D11ShaderResourceView *nullTex[2]{};
-	context_->PSSetShaderResources(0, 2, nullTex);
+	ID3D11ShaderResourceView *nullTex[4]{};
+	context_->PSSetShaderResources(0, 4, nullTex);
 }
 
 void TextureCacheD3D11::InvalidateLastTexture() {
@@ -258,6 +258,7 @@ void TextureCacheD3D11::BindTexture(TexCacheEntry *entry) {
 	SamplerCacheKey samplerKey = GetSamplingParams(maxLevel, entry);
 	ID3D11SamplerState *state = samplerCache_.GetOrCreateSampler(device_, samplerKey);
 	context_->PSSetSamplers(0, 1, &state);
+	gstate_c.SetUseShaderDepal(false, false);
 }
 
 void TextureCacheD3D11::ApplySamplingParams(const SamplerCacheKey &key) {

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -258,7 +258,7 @@ void TextureCacheD3D11::BindTexture(TexCacheEntry *entry) {
 	SamplerCacheKey samplerKey = GetSamplingParams(maxLevel, entry);
 	ID3D11SamplerState *state = samplerCache_.GetOrCreateSampler(device_, samplerKey);
 	context_->PSSetSamplers(0, 1, &state);
-	gstate_c.SetUseShaderDepal(false, false);
+	gstate_c.SetUseShaderDepal(ShaderDepalMode::OFF);
 }
 
 void TextureCacheD3D11::ApplySamplingParams(const SamplerCacheKey &key) {

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -184,13 +184,13 @@ LinkedShader::LinkedShader(GLRenderManager *render, VShaderID VSID, Shader *vs, 
 	availableUniforms = vs->GetUniformMask() | fs->GetUniformMask();
 
 	std::vector<GLRProgram::Initializer> initialize;
-	initialize.push_back({ &u_tex,          0, 0 });
-	initialize.push_back({ &u_fbotex,       0, 1 });
-	initialize.push_back({ &u_testtex,      0, 2 });
-	initialize.push_back({ &u_pal,          0, 3 }); // CLUT
-	initialize.push_back({ &u_tess_points,  0, 4 }); // Control Points
-	initialize.push_back({ &u_tess_weights_u, 0, 5 });
-	initialize.push_back({ &u_tess_weights_v, 0, 6 });
+	initialize.push_back({ &u_tex,          0, TEX_SLOT_PSP_TEXTURE });
+	initialize.push_back({ &u_fbotex,       0, TEX_SLOT_SHADERBLEND_SRC });
+	initialize.push_back({ &u_testtex,      0, TEX_SLOT_ALPHATEST });
+	initialize.push_back({ &u_pal,          0, TEX_SLOT_CLUT }); // CLUT
+	initialize.push_back({ &u_tess_points,  0, TEX_SLOT_SPLINE_POINTS }); // Control Points
+	initialize.push_back({ &u_tess_weights_u, 0, TEX_SLOT_SPLINE_WEIGHTS_U });
+	initialize.push_back({ &u_tess_weights_v, 0, TEX_SLOT_SPLINE_WEIGHTS_V });
 
 	bool useDualSource = (gstate_c.featureFlags & GPU_SUPPORTS_DUALSOURCE_BLEND) != 0;
 	bool useClip0 = VSID.Bit(VS_BIT_VERTEX_RANGE_CULLING) && gstate_c.Supports(GPU_SUPPORTS_CLIP_DISTANCE);

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -230,7 +230,7 @@ void TextureCacheGLES::BindTexture(TexCacheEntry *entry) {
 	int maxLevel = (entry->status & TexCacheEntry::STATUS_NO_MIPS) ? 0 : entry->maxLevel;
 	SamplerCacheKey samplerKey = GetSamplingParams(maxLevel, entry);
 	ApplySamplingParams(samplerKey);
-	gstate_c.SetUseShaderDepal(false, false);
+	gstate_c.SetUseShaderDepal(ShaderDepalMode::OFF);
 }
 
 void TextureCacheGLES::Unbind() {

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -40,6 +40,13 @@ enum SkipDrawReasonFlags {
 	SKIPDRAW_WINDOW_MINIMIZED = 8, // Don't draw when the host window is minimized.
 };
 
+enum class ShaderDepalMode {
+	OFF = 0,
+	NORMAL = 1,
+	SMOOTHED = 2,
+	CLUT8_8888 = 3,  // Read 8888 framebuffer as 8-bit CLUT.
+};
+
 // Global GPU-related utility functions. 
 // Nothing directly Ge-related in here.
 

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -529,10 +529,9 @@ struct GPUStateCache {
 	bool IsDirty(u64 what) const {
 		return (dirty & what) != 0ULL;
 	}
-	void SetUseShaderDepal(bool depal, bool smoothed) {
-		if (depal != useShaderDepal) {
-			useShaderDepal = depal;
-			useSmoothedShaderDepal = smoothed;
+	void SetUseShaderDepal(ShaderDepalMode mode) {
+		if (mode != shaderDepalMode) {
+			shaderDepalMode = mode;
 			Dirty(DIRTY_FRAGMENTSHADER_STATE);
 		}
 	}
@@ -628,8 +627,7 @@ struct GPUStateCache {
 	SubmitType submitType;
 	int spline_num_points_u;
 
-	bool useShaderDepal;
-	bool useSmoothedShaderDepal;
+	ShaderDepalMode shaderDepalMode;
 	GEBufferFormat depalFramebufferFormat;
 
 	u32 getRelativeAddress(u32 data) const;

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -371,7 +371,7 @@ VulkanFragmentShader *ShaderManagerVulkan::GetFragmentShaderFromModule(VkShaderM
 // instantaneous.
 
 #define CACHE_HEADER_MAGIC 0xff51f420 
-#define CACHE_VERSION 25
+#define CACHE_VERSION 26
 struct VulkanCacheHeader {
 	uint32_t magic;
 	uint32_t version;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -403,7 +403,7 @@ void TextureCacheVulkan::BindTexture(TexCacheEntry *entry) {
 	curSampler_ = samplerCache_.GetOrCreateSampler(samplerKey);
 	imageView_ = entry->vkTex->GetImageView();
 	drawEngine_->SetDepalTexture(VK_NULL_HANDLE, false);
-	gstate_c.SetUseShaderDepal(false, false);
+	gstate_c.SetUseShaderDepal(ShaderDepalMode::OFF);
 }
 
 void TextureCacheVulkan::ApplySamplingParams(const SamplerCacheKey &key) {

--- a/unittest/TestShaderGenerators.cpp
+++ b/unittest/TestShaderGenerators.cpp
@@ -402,7 +402,6 @@ bool TestFragmentShaders() {
 
 		// bits we don't need to test because they are irrelevant on d3d11
 		id.SetBit(FS_BIT_NO_DEPTH_CANNOT_DISCARD_STENCIL, false);
-		id.SetBit(FS_BIT_SHADER_DEPAL, false);
 
 		// DX9 disabling:
 		if (static_cast<ReplaceAlphaType>(id.Bits(FS_BIT_STENCIL_TO_ALPHA, 2)) == ReplaceAlphaType::REPLACE_ALPHA_DUALSOURCE)


### PR DESCRIPTION
Might as well, good to have going before I start refactoring it a little bit. Also switches to an enum for shader depal mode (though doesn't implement the new case yet).

Gives a small performance boost in games that do nasty framebuffer tricks like Sonic Rivals and Test Drive.

Additionally, does some small refactorings to texture matching to prepare for what's to come - we need to do offset calculations in bytes and only convert to texels at the final moment, so that we can get the correct coordinates when matching CLUT8 against 8888, for example. (We definitely want to use shader depal instead of traditional depal here btw - the game only reads a single texel, no point in converting the whole texture).