### PR TITLE
softgpu: Correct accuracy of fog calculation

### DIFF
--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -228,11 +228,11 @@ public:
 
 	Vec3() {}
 	Vec3(const T a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
-	Vec3(const T& _x, const T& _y, const T& _z) : x(_x), y(_y), z(_z) {}
+	constexpr Vec3(const T& _x, const T& _y, const T& _z) : x(_x), y(_y), z(_z) {}
 	Vec3(const Vec2<T>& _xy, const T& _z) : x(_xy.x), y(_xy.y), z(_z) {}
 #if defined(_M_SSE)
-	Vec3(const __m128 &_vec) : vec(_vec) {}
-	Vec3(const __m128i &_ivec) : ivec(_ivec) {}
+	constexpr Vec3(const __m128 &_vec) : vec(_vec) {}
+	constexpr Vec3(const __m128i &_ivec) : ivec(_ivec) {}
 	Vec3(const Vec3Packed<T> &_xyz) {
 		vec = _mm_loadu_ps(_xyz.AsArray());
 	}
@@ -249,7 +249,7 @@ public:
 #endif
 
 	template<typename T2>
-	Vec3<T2> Cast() const
+	constexpr Vec3<T2> Cast() const
 	{
 		return Vec3<T2>((T2)x, (T2)y, (T2)z);
 	}
@@ -258,7 +258,7 @@ public:
 	static Vec3 FromRGB(unsigned int rgb);
 	unsigned int ToRGB() const; // alpha bits set to zero
 
-	static Vec3 AssignToAll(const T& f)
+	static constexpr Vec3 AssignToAll(const T& f)
 	{
 		return Vec3<T>(f, f, f);
 	}

--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -550,8 +550,6 @@ void PixelJitCache::Clear() {
 
 	constBlendHalf_11_4s_ = nullptr;
 	constBlendInvert_11_4s_ = nullptr;
-	const255_16s_ = nullptr;
-	constBy255i_ = nullptr;
 }
 
 std::string PixelJitCache::DescribeCodePtr(const u8 *ptr) {

--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -415,7 +415,9 @@ void SOFTRAST_CALL DrawSinglePixel(int x, int y, int z, int fog, Vec4IntArg colo
 	// Fog is applied prior to color test.
 	if (pixelID.applyFog && !clearMode) {
 		Vec3<int> fogColor = Vec3<int>::FromRGB(pixelID.cached.fogColor);
-		fogColor = (prim_color.rgb() * fog + fogColor * (255 - fog)) / 255;
+		// This is very similar to the BLEND texfunc, and simply always rounds up.
+		static constexpr Vec3<int> roundup = Vec3<int>::AssignToAll(255);
+		fogColor = (prim_color.rgb() * fog + fogColor * (255 - fog) + roundup) / 256;
 		prim_color.r() = fogColor.r();
 		prim_color.g() = fogColor.g();
 		prim_color.b() = fogColor.b();

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -106,8 +106,6 @@ private:
 
 	const u8 *constBlendHalf_11_4s_ = nullptr;
 	const u8 *constBlendInvert_11_4s_ = nullptr;
-	const u8 *const255_16s_ = nullptr;
-	const u8 *constBy255i_ = nullptr;
 
 #if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 	void Discard();

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -348,7 +348,7 @@ Vec3<int> AlphaBlendingResult(const PixelFuncID &pixelID, const Vec4<int> &sourc
 
 		return Vec3<int>(_mm_unpacklo_epi16(_mm_adds_epi16(s, d), _mm_setzero_si128()));
 #else
-		Vec3<int> half = Vec3<int>::AssignToAll(1);
+		static constexpr Vec3<int> half = Vec3<int>::AssignToAll(1);
 		Vec3<int> lhs = ((source.rgb() * 2 + half) * (srcfactor * 2 + half)) / 1024;
 		Vec3<int> rhs = ((dst.rgb() * 2 + half) * (dstfactor * 2 + half)) / 1024;
 		return lhs + rhs;
@@ -370,7 +370,7 @@ Vec3<int> AlphaBlendingResult(const PixelFuncID &pixelID, const Vec4<int> &sourc
 
 		return Vec3<int>(_mm_unpacklo_epi16(_mm_max_epi16(_mm_subs_epi16(s, d), _mm_setzero_si128()), _mm_setzero_si128()));
 #else
-		Vec3<int> half = Vec3<int>::AssignToAll(1);
+		static constexpr Vec3<int> half = Vec3<int>::AssignToAll(1);
 		Vec3<int> lhs = ((source.rgb() * 2 + half) * (srcfactor * 2 + half)) / 1024;
 		Vec3<int> rhs = ((dst.rgb() * 2 + half) * (dstfactor * 2 + half)) / 1024;
 		return lhs - rhs;
@@ -392,7 +392,7 @@ Vec3<int> AlphaBlendingResult(const PixelFuncID &pixelID, const Vec4<int> &sourc
 
 		return Vec3<int>(_mm_unpacklo_epi16(_mm_max_epi16(_mm_subs_epi16(d, s), _mm_setzero_si128()), _mm_setzero_si128()));
 #else
-		Vec3<int> half = Vec3<int>::AssignToAll(1);
+		static constexpr Vec3<int> half = Vec3<int>::AssignToAll(1);
 		Vec3<int> lhs = ((source.rgb() * 2 + half) * (srcfactor * 2 + half)) / 1024;
 		Vec3<int> rhs = ((dst.rgb() * 2 + half) * (dstfactor * 2 + half)) / 1024;
 		return rhs - lhs;

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -267,8 +267,6 @@ static inline bool NoClampOrWrap(const RasterizerState &state, const Vec2f &tc) 
 		return false;
 	if (state.samplerID.cached.sizes[0].w > 512 || state.samplerID.cached.sizes[0].h > 512)
 		return false;
-	if (!state.throughMode)
-		return tc.x <= 1.0f && tc.y <= 1.0f;
 	return tc.x <= state.samplerID.cached.sizes[0].w && tc.y <= state.samplerID.cached.sizes[0].h;
 }
 
@@ -288,7 +286,7 @@ bool RectangleFastPath(const VertexData &v0, const VertexData &v1, BinManager &b
 	// Currently only works for TL/BR, which is the most common but not required.
 	bool orient_check = xdiff >= 0 && ydiff >= 0;
 	// We already have a fast path for clear in ClearRectangle.
-	bool state_check = !state.pixelID.clearMode && !state.samplerID.hasAnyMips && NoClampOrWrap(state, v0.texturecoords) && NoClampOrWrap(state, v1.texturecoords);
+	bool state_check = state.throughMode && !state.pixelID.clearMode && !state.samplerID.hasAnyMips && NoClampOrWrap(state, v0.texturecoords) && NoClampOrWrap(state, v1.texturecoords);
 	// This doesn't work well with offset drawing, see #15876.  Through never has a subpixel offset.
 	bool subpixel_check = ((v0.screenpos.x | v0.screenpos.y | v1.screenpos.x | v1.screenpos.y) & 0xF) == 0;
 	if ((coord_check || !state.enableTextures) && orient_check && state_check && subpixel_check) {

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -136,6 +136,12 @@ private:
 
 	u8 *decoded_ = nullptr;
 	BinManager *binner_ = nullptr;
+
+	// Normally max verts per prim is 3, but we temporarily need 4 to detect rectangles from strips.
+	VertexData data_[4];
+	// This is the index of the next vert in data (or higher, may need modulus.)
+	int data_index_ = 0;
+	GEPrimitiveType prev_prim_ = GE_PRIM_POINTS;
 };
 
 class SoftwareDrawEngine : public DrawEngineCommon {


### PR DESCRIPTION
Having figured out how to directly specify the 8-bit fog factor in #15978, I was able to directly verify the fog blending equation on hardware (without Z interpolation and floating point handling questions getting in the way.)

It's the same as the BLEND tex func, i.e. divide by 256 but round up.  No halves, no dividing by 255, simple.

I had to do some ugly hacking to get the fog values from imm to the actual verts (not included here, and only working for some prims.)  This matches a test of many values/factors exactly,. bit-for-bit.  The test included every possible source color + every possible factor + a couple fog colors chosen to catch rounding problems.

-[Unknown]