### PR TITLE
softgpu: Store vertex colors as packed RGBA8

### DIFF
--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -166,7 +166,7 @@ void BinManager::UpdateState(bool throughMode) {
 	if (HasDirty(SoftDirty::PIXEL_ALL | SoftDirty::SAMPLER_ALL | SoftDirty::RAST_ALL)) {
 		if (states_.Full())
 			Flush("states");
-		stateIndex_ = (int)states_.Push(RasterizerState());
+		stateIndex_ = (uint16_t)states_.Push(RasterizerState());
 		ComputeRasterizerState(&states_[stateIndex_], throughMode);
 		states_[stateIndex_].samplerID.cached.clut = cluts_[clutIndex_].readable;
 
@@ -312,7 +312,7 @@ void BinManager::UpdateClut(const void *src) {
 	PROFILE_THIS_SCOPE("bin_clut");
 	if (cluts_.Full())
 		Flush("cluts");
-	clutIndex_ = (int)cluts_.Push(BinClut());
+	clutIndex_ = (uint16_t)cluts_.Push(BinClut());
 	memcpy(cluts_[clutIndex_].readable, src, sizeof(BinClut));
 }
 

--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -24,7 +24,7 @@
 struct BinWaitable;
 class DrawBinItemsTask;
 
-enum class BinItemType {
+enum class BinItemType : uint8_t {
 	TRIANGLE,
 	CLEAR_RECT,
 	RECT,
@@ -48,7 +48,7 @@ struct BinCoords {
 
 struct BinItem {
 	BinItemType type;
-	int stateIndex;
+	uint16_t stateIndex;
 	BinCoords range;
 	VertexData v0;
 	VertexData v1;
@@ -237,9 +237,9 @@ protected:
 
 private:
 	BinStateQueue states_;
-	int stateIndex_;
 	BinClutQueue cluts_;
-	int clutIndex_;
+	uint16_t stateIndex_;
+	uint16_t clutIndex_;
 	BinCoords scissor_;
 	BinItemQueue queue_;
 	BinCoords queueRange_;

--- a/GPU/Software/Lighting.cpp
+++ b/GPU/Software/Lighting.cpp
@@ -276,12 +276,12 @@ void Process(VertexData &vertex, const WorldCoords &worldpos, const WorldCoords 
 	}
 
 	if (state.setColor1) {
-		vertex.color0 = final_color.Clamp(0, 255);
-		vertex.color1 = specular_color.Clamp(0, 255).rgb();
+		vertex.color0 = final_color.Clamp(0, 255).ToRGBA();
+		vertex.color1 = specular_color.Clamp(0, 255).rgb().ToRGB();
 	} else if (state.addColor1) {
-		vertex.color0 = (final_color + specular_color).Clamp(0, 255);
+		vertex.color0 = (final_color + specular_color).Clamp(0, 255).ToRGBA();
 	} else {
-		vertex.color0 = final_color.Clamp(0, 255);
+		vertex.color0 = final_color.Clamp(0, 255).ToRGBA();
 	}
 }
 

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -317,24 +317,12 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, const TransformState
 	}
 
 	if (vreader.hasColor0()) {
-#ifdef _M_SSE
-		vreader.ReadColor0_8888((u8 *)vertex.color0.AsArray());
-		vertex.color0.ivec = _mm_unpacklo_epi8(vertex.color0.ivec, _mm_setzero_si128());
-		vertex.color0.ivec = _mm_unpacklo_epi16(vertex.color0.ivec, _mm_setzero_si128());
-#else
-		float col[4];
-		vreader.ReadColor0(col);
-		vertex.color0 = Vec4<int>(col[0]*255, col[1]*255, col[2]*255, col[3]*255);
-#endif
+		vreader.ReadColor0_8888((u8 *)&vertex.color0);
 	} else {
-		vertex.color0 = Vec4<int>::FromRGBA(gstate.getMaterialAmbientRGBA());
+		vertex.color0 = gstate.getMaterialAmbientRGBA();
 	}
 
-#ifdef _M_SSE
-	vertex.color1 = _mm_setzero_si128();
-#else
-	vertex.color1 = Vec3<int>(0, 0, 0);
-#endif
+	vertex.color1 = 0;
 
 	if (state.enableTransform) {
 		WorldCoords worldpos;

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -79,15 +79,15 @@ struct VertexData {
 		texturecoords = ::Lerp(a.texturecoords, b.texturecoords, t);
 		fogdepth = ::Lerp(a.fogdepth, b.fogdepth, t);
 
-		u16 t_int = (u16)(t*256);
-		color0 = LerpInt<Vec4<int>,256>(a.color0, b.color0, t_int);
-		color1 = LerpInt<Vec3<int>,256>(a.color1, b.color1, t_int);
+		u16 t_int = (u16)(t * 256);
+		color0 = LerpInt<Vec4<int>, 256>(Vec4<int>::FromRGBA(a.color0), Vec4<int>::FromRGBA(b.color0), t_int).ToRGBA();
+		color1 = LerpInt<Vec3<int>, 256>(Vec3<int>::FromRGB(a.color1), Vec3<int>::FromRGB(b.color1), t_int).ToRGB();
 	}
 
 	ClipCoords clippos;
 	Vec2<float> texturecoords;
-	Vec4<int> color0;
-	Vec3<int> color1;
+	uint32_t color0;
+	uint32_t color1;
 	ScreenCoords screenpos; // TODO: Shouldn't store this ?
 	float fogdepth;
 };


### PR DESCRIPTION
Also, some smaller tweaks as well, such as fixing a few cases where early Z tests were not done but could have been.

Reducing the struct size doesn't give a huge boost on PC, but I think it's still good to do as it does help a bit.

-[Unknown]