### PR TITLE
Detect more triangles as rectangles in softgpu

### DIFF
--- a/GPU/Software/FuncId.cpp
+++ b/GPU/Software/FuncId.cpp
@@ -279,6 +279,8 @@ std::string DescribePixelFuncID(const PixelFuncID &id) {
 		desc = "INVALID:" + desc;
 	}
 
+	if (id.earlyZChecks)
+		desc += "ZEarly:";
 	if (id.DepthTestFunc() != GE_COMP_ALWAYS) {
 		if (id.clearMode)
 			desc = "INVALID:" + desc;

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -447,6 +447,53 @@ bool DetectRectangleFromFan(const RasterizerState &state, const VertexData *data
 	return false;
 }
 
+bool DetectRectangleFromPair(const RasterizerState &state, const VertexData data[6], int *tlIndex, int *brIndex) {
+	// Color and Z must be flat.  Also find the TL and BR meanwhile.
+	int tl = 0, br = 0;
+	for (int i = 1; i < 6; ++i) {
+		if (!AreCoordsRectangleCompatible(state, data[i], data[0]))
+			return false;
+
+		if (data[i].screenpos.x <= data[tl].screenpos.x && data[i].screenpos.y <= data[tl].screenpos.y)
+			tl = i;
+		if (data[i].screenpos.x >= data[br].screenpos.x && data[i].screenpos.y >= data[br].screenpos.y)
+			br = i;
+	}
+
+	*tlIndex = tl;
+	*brIndex = br;
+
+	auto xat = [&](int i) { return data[i].screenpos.x; };
+	auto yat = [&](int i) { return data[i].screenpos.y; };
+	auto uat = [&](int i) { return data[i].texturecoords.x; };
+	auto vat = [&](int i) { return data[i].texturecoords.y; };
+
+	// A likely order would be: TL, TR, BR, TL, BR, BL.  We'd have the last index of each.
+	// TODO: Make more generic.
+	if (tl == 3 && br == 4) {
+		bool x1_match = xat(0) == xat(3) && xat(0) == xat(5);
+		bool x2_match = xat(1) == xat(2) && xat(1) == xat(4);
+		bool y1_match = yat(0) == yat(1) && yat(0) == yat(3);
+		bool y2_match = yat(2) == yat(4) && yat(2) == yat(5);
+		if (x1_match && y1_match && x2_match && y2_match) {
+			// Do we need to think about rotation or UVs?
+			if (!state.enableTextures)
+				return true;
+
+			x1_match = uat(0) == uat(3) && uat(0) == uat(5);
+			x2_match = uat(1) == uat(2) && uat(1) == uat(4);
+			y1_match = vat(0) == vat(1) && vat(0) == vat(3);
+			y2_match = vat(2) == vat(4) && vat(2) == vat(5);
+			if (x1_match && y1_match && x2_match && y2_match) {
+				// Double check rotation direction.
+				return vat(tl) < vat(br) && yat(tl) < yat(br) && uat(tl) < uat(br) && xat(tl) < xat(br);
+			}
+		}
+	}
+
+	return false;
+}
+
 bool DetectRectangleThroughModeSlices(const RasterizerState &state, const VertexData data[4]) {
 	// Color and Z must be flat.
 	for (int i = 1; i < 4; ++i) {

--- a/GPU/Software/RasterizerRectangle.h
+++ b/GPU/Software/RasterizerRectangle.h
@@ -22,5 +22,6 @@ namespace Rasterizer {
 
 	bool DetectRectangleFromStrip(const RasterizerState &state, const VertexData data[4], int *tlIndex, int *brIndex);
 	bool DetectRectangleFromFan(const RasterizerState &state, const VertexData *data, int c, int *tlIndex, int *brIndex);
+	bool DetectRectangleFromPair(const RasterizerState &state, const VertexData data[6], int *tlIndex, int *brIndex);
 	bool DetectRectangleThroughModeSlices(const RasterizerState &state, const VertexData data[4]);
 }

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -37,6 +37,12 @@ typedef Vec4<float> ClipCoords; // Range: -w <= x/y/z <= w
 class BinManager;
 struct TransformState;
 
+enum class CullType {
+	CW = 0,
+	CCW = 1,
+	OFF = 2,
+};
+
 struct ScreenCoords
 {
 	ScreenCoords() {}
@@ -133,6 +139,7 @@ public:
 
 private:
 	VertexData ReadVertex(VertexReader &vreader, const TransformState &lstate, bool &outside_range_flag);
+	void SendTriangle(CullType cullType, const VertexData *verts, int provoking = 2);
 
 	u8 *decoded_ = nullptr;
 	BinManager *binner_ = nullptr;


### PR DESCRIPTION
This detects rectangles made of regular triangles in throughmode, which some games use.  It also detects multiple rectangles from triangle strips, which many games use to draw rectangle strips as triangles too.

-[Unknown]