### PR TITLE
Reduce the size of state and vertex data in softgpu

### DIFF
--- a/Common/Data/Collections/TinySet.h
+++ b/Common/Data/Collections/TinySet.h
@@ -47,12 +47,12 @@ struct TinySet {
 		size_t otherSize = other.size();
 		if (size() + otherSize <= MaxFastSize) {
 			// Fast case
-			for (int i = 0; i < otherSize; i++) {
+			for (size_t i = 0; i < otherSize; i++) {
 				fastLookup_[fastCount + i] = other.fastLookup_[i];
 			}
 			fastCount += other.fastCount;
 		} else {
-			for (int i = 0; i < otherSize; i++) {
+			for (size_t i = 0; i < otherSize; i++) {
 				push_back(other[i]);
 			}
 		}

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -1219,7 +1219,7 @@ bool OpenGLPipeline::LinkShaders() {
 	}
 	std::vector<GLRProgram::Initializer> initialize;
 	for (int i = 0; i < MAX_TEXTURE_SLOTS; ++i) {
-		if (i < samplers_.size()) {
+		if (i < (int)samplers_.size()) {
 			initialize.push_back({ &samplerLocs_[i], 0, i });
 		} else {
 			samplerLocs_[i] = -1;

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1086,7 +1086,7 @@ Pipeline *VKContext::CreateGraphicsPipeline(const PipelineDesc &desc, const char
 	_dbg_assert_((int)input->attributes.size() == (int)input->visc.vertexAttributeDescriptionCount);
 
 	gDesc.ibd = input->bindings[0];
-	for (int i = 0; i < input->attributes.size(); i++) {
+	for (size_t i = 0; i < input->attributes.size(); i++) {
 		gDesc.attrs[i] = input->attributes[i];
 	}
 	gDesc.vis.vertexAttributeDescriptionCount = input->visc.vertexAttributeDescriptionCount;

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -57,22 +57,10 @@ inline static T VecClamp(const T &v, const T &low, const T &high)
 }
 
 template<typename T>
-class Vec2
-{
+class Vec2 {
 public:
-	union
-	{
-		struct
-		{
-			T x,y;
-		};
-#if defined(_M_SSE)
-		__m128i ivec;
-		__m128 vec;
-#elif PPSSPP_ARCH(ARM64_NEON)
-		int32x4_t ivec;
-		float32x4_t vec;
-#endif
+	struct {
+		T x,y;
 	};
 
 	T* AsArray() { return &x; }
@@ -81,15 +69,6 @@ public:
 	Vec2() {}
 	Vec2(const T a[2]) : x(a[0]), y(a[1]) {}
 	Vec2(const T& _x, const T& _y) : x(_x), y(_y) {}
-#if defined(_M_SSE)
-	Vec2(const __m128 &_vec) : vec(_vec) {}
-	Vec2(const __m128i &_ivec) : ivec(_ivec) {}
-#elif PPSSPP_ARCH(ARM64_NEON)
-	Vec2(const float32x4_t &_vec) : vec(_vec) {}
-#if !defined(_MSC_VER)
-	Vec2(const int32x4_t &_ivec) : ivec(_ivec) {}
-#endif
-#endif
 
 	template<typename T2>
 	Vec2<T2> Cast() const

--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -242,7 +242,7 @@ bool BinManager::HasTextureWrite(const RasterizerState &state) {
 	if (!state.enableTextures)
 		return false;
 
-	const int textureBits = textureBitsPerPixel[state.samplerID.texfmt];
+	const uint8_t textureBits = textureBitsPerPixel[state.samplerID.texfmt];
 	for (int i = 0; i <= state.maxTexLevel; ++i) {
 		int byteStride = (state.texbufw[i] * textureBits) / 8;
 		int byteWidth = (state.samplerID.cached.sizes[i].w * textureBits) / 8;

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -116,7 +116,7 @@ void ComputeRasterizerState(RasterizerState *state, bool throughMode) {
 		for (uint8_t i = 0; i <= state->maxTexLevel; i++) {
 			u32 texaddr = gstate.getTextureAddress(i);
 			state->texaddr[i] = texaddr;
-			state->texbufw[i] = GetTextureBufw(i, texaddr, texfmt);
+			state->texbufw[i] = (uint16_t)GetTextureBufw(i, texaddr, texfmt);
 			if (Memory::IsValidAddress(texaddr))
 				state->texptr[i] = Memory::GetPointerUnchecked(texaddr);
 			else
@@ -413,7 +413,7 @@ Vec3<int> AlphaBlendingResult(const PixelFuncID &pixelID, const Vec4<int> &sourc
 
 static inline Vec4IntResult SOFTRAST_CALL ApplyTexturing(float s, float t, int x, int y, Vec4IntArg prim_color, int texlevel, int frac_texlevel, bool bilinear, const RasterizerState &state) {
 	const u8 **tptr0 = const_cast<const u8 **>(&state.texptr[texlevel]);
-	const int *bufw0 = &state.texbufw[texlevel];
+	const uint16_t *bufw0 = &state.texbufw[texlevel];
 
 	if (!bilinear) {
 		return state.nearest(s, t, x, y, prim_color, tptr0, bufw0, texlevel, frac_texlevel, state.samplerID);
@@ -1468,7 +1468,7 @@ bool GetCurrentTexture(GPUDebugBuffer &buffer, int level)
 
 	GETextureFormat texfmt = gstate.getTextureFormat();
 	u32 texaddr = gstate.getTextureAddress(level);
-	int texbufw = GetTextureBufw(level, texaddr, texfmt);
+	u32 texbufw = GetTextureBufw(level, texaddr, texfmt);
 	int w = gstate.getTextureWidth(level);
 	int h = gstate.getTextureHeight(level);
 

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -135,9 +135,6 @@ void ComputeRasterizerState(RasterizerState *state, bool throughMode) {
 	state->throughMode = throughMode;
 	state->antialiasLines = gstate.isAntiAliasEnabled();
 
-	state->screenOffsetX = gstate.getOffsetX16();
-	state->screenOffsetY = gstate.getOffsetY16();
-
 #if defined(SOFTGPU_MEMORY_TAGGING_DETAILED) || defined(SOFTGPU_MEMORY_TAGGING_BASIC)
 	DisplayList currentList{};
 	if (gpuDebug)

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -78,14 +78,6 @@ static inline Vec3<int> Interpolate(const Vec3<int> &c0, const Vec3<int> &c1, co
 #endif
 }
 
-static inline Vec2<float> Interpolate(const Vec2<float> &c0, const Vec2<float> &c1, const Vec2<float> &c2, int w0, int w1, int w2, float wsum) {
-#if defined(_M_SSE) && !PPSSPP_ARCH(X86)
-	return Vec2<float>(Interpolate(c0.vec, c1.vec, c2.vec, w0, w1, w2, wsum));
-#else
-	return (c0 * w0 + c1 * w1 + c2 * w2) * wsum;
-#endif
-}
-
 static inline Vec4<float> Interpolate(const float &c0, const float &c1, const float &c2, const Vec4<float> &w0, const Vec4<float> &w1, const Vec4<float> &w2, const Vec4<float> &wsum_recip) {
 #if defined(_M_SSE) && !PPSSPP_ARCH(X86)
 	__m128 v = _mm_mul_ps(w0.vec, _mm_set1_ps(c0));

--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -42,8 +42,6 @@ struct RasterizerState {
 	uint16_t texbufw[8]{};
 	const u8 *texptr[8]{};
 	float textureLodSlope;
-	int screenOffsetX;
-	int screenOffsetY;
 
 	struct {
 		uint8_t maxTexLevel : 3;

--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -39,7 +39,7 @@ struct RasterizerState {
 	Sampler::LinearFunc linear;
 	Sampler::NearestFunc nearest;
 	uint32_t texaddr[8]{};
-	int texbufw[8]{};
+	uint16_t texbufw[8]{};
 	const u8 *texptr[8]{};
 	float textureLodSlope;
 	int screenOffsetX;

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -300,9 +300,9 @@ bool RectangleFastPath(const VertexData &v0, const VertexData &v1, BinManager &b
 	if (PSP_CoreParameter().compat.flags().DarkStalkersPresentHack && v0.texturecoords.x == 64.0f && v0.texturecoords.y == 16.0f && v1.texturecoords.x == 448.0f && v1.texturecoords.y == 240.0f) {
 		// check for save/load dialog.
 		if (!currentDialogActive) {
-			if (v0.screenpos.x + state.screenOffsetX == 0x7100 && v0.screenpos.y + state.screenOffsetY == 0x7780 && v1.screenpos.x + state.screenOffsetX == 0x8f00 && v1.screenpos.y + state.screenOffsetY == 0x8880) {
+			if (v0.screenpos.x + gstate.getOffsetX16() == 0x7100 && v0.screenpos.y + gstate.getOffsetY16() == 0x7780 && v1.screenpos.x + gstate.getOffsetX16() == 0x8f00 && v1.screenpos.y + gstate.getOffsetY16() == 0x8880) {
 				g_DarkStalkerStretch = DSStretch::Wide;
-			} else if (v0.screenpos.x + state.screenOffsetX == 0x7400 && v0.screenpos.y + state.screenOffsetY == 0x7780 && v1.screenpos.x + state.screenOffsetX == 0x8C00 && v1.screenpos.y + state.screenOffsetY == 0x8880) {
+			} else if (v0.screenpos.x + gstate.getOffsetX16() == 0x7400 && v0.screenpos.y + gstate.getOffsetY16() == 0x7780 && v1.screenpos.x + gstate.getOffsetX16() == 0x8C00 && v1.screenpos.y + gstate.getOffsetY16() == 0x8880) {
 				g_DarkStalkerStretch = DSStretch::Normal;
 			} else {
 				return false;

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -103,7 +103,7 @@ void DrawSprite(const VertexData &v0, const VertexData &v1, const BinCoords &ran
 	const u8 *texptr = state.texptr[0];
 
 	GETextureFormat texfmt = state.samplerID.TexFmt();
-	int texbufw = state.texbufw[0];
+	uint16_t texbufw = state.texbufw[0];
 
 	Sampler::FetchFunc fetchFunc = Sampler::GetFetchFunc(state.samplerID);
 	auto &pixelID = state.pixelID;

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -38,8 +38,8 @@ using namespace Rasterizer;
 
 namespace Sampler {
 
-static Vec4IntResult SOFTRAST_CALL SampleNearest(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 *const *tptr, const int *bufw, int level, int levelFrac, const SamplerID &samplerID);
-static Vec4IntResult SOFTRAST_CALL SampleLinear(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 *const *tptr, const int *bufw, int level, int levelFrac, const SamplerID &samplerID);
+static Vec4IntResult SOFTRAST_CALL SampleNearest(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 *const *tptr, const uint16_t *bufw, int level, int levelFrac, const SamplerID &samplerID);
+static Vec4IntResult SOFTRAST_CALL SampleLinear(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 *const *tptr, const uint16_t *bufw, int level, int levelFrac, const SamplerID &samplerID);
 static Vec4IntResult SOFTRAST_CALL SampleFetch(int u, int v, const u8 *tptr, int bufw, int level, const SamplerID &samplerID);
 
 std::mutex jitCacheLock;
@@ -281,7 +281,7 @@ struct Nearest4 {
 };
 
 template <int N>
-inline static Nearest4 SOFTRAST_CALL SampleNearest(const int u[N], const int v[N], const u8 *srcptr, int texbufw, int level, const SamplerID &samplerID) {
+inline static Nearest4 SOFTRAST_CALL SampleNearest(const int u[N], const int v[N], const u8 *srcptr, uint16_t texbufw, int level, const SamplerID &samplerID) {
 	Nearest4 res;
 	if (!srcptr) {
 		memset(res.v, 0, sizeof(res.v));
@@ -535,7 +535,7 @@ Vec4IntResult SOFTRAST_CALL GetTextureFunctionOutput(Vec4IntArg prim_color_in, V
 	return ToVec4IntResult(Vec4<int>(out_rgb, out_a));
 }
 
-static Vec4IntResult SOFTRAST_CALL SampleNearest(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 *const *tptr, const int *bufw, int level, int levelFrac, const SamplerID &samplerID) {
+static Vec4IntResult SOFTRAST_CALL SampleNearest(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 *const *tptr, const uint16_t *bufw, int level, int levelFrac, const SamplerID &samplerID) {
 	int u, v;
 
 	// Nearest filtering only.  Round texcoords.
@@ -631,7 +631,7 @@ static inline Vec4IntResult SOFTRAST_CALL GetTexelCoordinatesQuadT(int level, fl
 	return ApplyTexelClampQuadT(samplerID.clampT, base_v, height);
 }
 
-static Vec4IntResult SOFTRAST_CALL SampleLinearLevel(float s, float t, int x, int y, const u8 *const *tptr, const int *bufw, int texlevel, const SamplerID &samplerID) {
+static Vec4IntResult SOFTRAST_CALL SampleLinearLevel(float s, float t, int x, int y, const u8 *const *tptr, const uint16_t *bufw, int texlevel, const SamplerID &samplerID) {
 	int frac_u, frac_v;
 	const Vec4<int> u = GetTexelCoordinatesQuadS(texlevel, s, frac_u, x, samplerID);
 	const Vec4<int> v = GetTexelCoordinatesQuadT(texlevel, t, frac_v, y, samplerID);
@@ -646,7 +646,7 @@ static Vec4IntResult SOFTRAST_CALL SampleLinearLevel(float s, float t, int x, in
 	return ToVec4IntResult((top * (0x10 - frac_v) + bot * frac_v) / (16 * 16));
 }
 
-static Vec4IntResult SOFTRAST_CALL SampleLinear(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 *const *tptr, const int *bufw, int texlevel, int levelFrac, const SamplerID &samplerID) {
+static Vec4IntResult SOFTRAST_CALL SampleLinear(float s, float t, int x, int y, Vec4IntArg prim_color, const u8 *const *tptr, const uint16_t *bufw, int texlevel, int levelFrac, const SamplerID &samplerID) {
 	Vec4<int> c0 = SampleLinearLevel(s, t, x, y, tptr, bufw, texlevel, samplerID);
 	if (levelFrac) {
 		const Vec4<int> c1 = SampleLinearLevel(s, t, x, y, tptr + 1, bufw + 1, texlevel + 1, samplerID);

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -36,10 +36,10 @@ namespace Sampler {
 typedef Rasterizer::Vec4IntResult(SOFTRAST_CALL *FetchFunc)(int u, int v, const u8 *tptr, int bufw, int level, const SamplerID &samplerID);
 FetchFunc GetFetchFunc(SamplerID id);
 
-typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *NearestFunc)(float s, float t, int x, int y, Rasterizer::Vec4IntArg prim_color, const u8 *const *tptr, const int *bufw, int level, int levelFrac, const SamplerID &samplerID);
+typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *NearestFunc)(float s, float t, int x, int y, Rasterizer::Vec4IntArg prim_color, const u8 *const *tptr, const uint16_t *bufw, int level, int levelFrac, const SamplerID &samplerID);
 NearestFunc GetNearestFunc(SamplerID id);
 
-typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *LinearFunc)(float s, float t, int x, int y, Rasterizer::Vec4IntArg prim_color, const u8 *const *tptr, const int *bufw, int level, int levelFrac, const SamplerID &samplerID);
+typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *LinearFunc)(float s, float t, int x, int y, Rasterizer::Vec4IntArg prim_color, const u8 *const *tptr, const uint16_t *bufw, int level, int levelFrac, const SamplerID &samplerID);
 LinearFunc GetLinearFunc(SamplerID id);
 
 void Init();

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -164,6 +164,15 @@ public:
 
 	TransformUnit transformUnit;
 
+#if PPSSPP_ARCH(32BIT)
+	void *operator new(size_t s) {
+		return AllocateAlignedMemory(s, 16);
+	}
+	void operator delete(void *p) {
+		FreeAlignedMemory(p);
+	}
+#endif
+
 protected:
 	bool UpdateUseHWTessellation(bool enable) override { return false; }
 };

--- a/GPU/ge_constants.h
+++ b/GPU/ge_constants.h
@@ -374,8 +374,7 @@ enum GEMatrixType {
 	GE_MTX_TEXGEN,
 };
 
-enum GEComparison
-{
+enum GEComparison : uint8_t {
 	GE_COMP_NEVER = 0,
 	GE_COMP_ALWAYS = 1,
 	GE_COMP_EQUAL = 2,
@@ -578,8 +577,7 @@ enum GEPrimitiveType
 	GE_PRIM_INVALID = -1,
 };
 
-enum GELogicOp
-{
+enum GELogicOp : uint8_t {
 	GE_LOGIC_CLEAR = 0,
 	GE_LOGIC_AND = 1,
 	GE_LOGIC_AND_REVERSE = 2,

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -251,7 +251,7 @@ private:
 			return nullptr;
 		}
 		const auto recentIsos = g_Config.RecentIsos();
-		if (index >= recentIsos.size())
+		if (index >= (int)recentIsos.size())
 			return nullptr;
 		return g_gameInfoCache->GetInfo(dc.GetDrawContext(), Path(recentIsos[index]), GAMEINFO_WANTBG);
 	}

--- a/unittest/TestSoftwareGPUJit.cpp
+++ b/unittest/TestSoftwareGPUJit.cpp
@@ -48,7 +48,7 @@ static bool TestSamplerJit() {
 	bool header = false;
 
 	u8 **tptr = new u8 *[8];
-	int *bufw = new int[8];
+	uint16_t *bufw = new uint16_t[8];
 	u8 *clut = new u8[1024];
 	memset(clut, 0, 1024);
 


### PR DESCRIPTION
Only has a small incremental improvement to perf, but good to cleanup.  Might help mobile a bit more, perhaps.

Also fixes an alignment issue on 32-bit after moving the vertex data staging to the heap.

-[Unknown]