### PR TITLE
GPU: Fix simulating logicop with blend and shader

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1073,7 +1073,7 @@ bool FramebufferManagerCommon::BindFramebufferAsColorTexture(int stage, VirtualF
 
 	// currentRenderVfb_ will always be set when this is called, except from the GE debugger.
 	// Let's just not bother with the copy in that case.
-	bool skipCopy = !(flags & BINDFBCOLOR_MAY_COPY) || GPUStepping::IsStepping();
+	bool skipCopy = !(flags & BINDFBCOLOR_MAY_COPY);
 
 	// Currently rendering to this framebuffer. Need to make a copy.
 	if (!skipCopy && framebuffer == currentRenderVfb_) {

--- a/GPU/Common/GPUStateUtils.h
+++ b/GPU/Common/GPUStateUtils.h
@@ -226,6 +226,7 @@ struct GenericLogicState {
 	// Hardware and shader generation
 	GELogicOp logicOp;
 
+	void ApplyToBlendState(GenericBlendState &blendState);
 	void ConvertToShaderBlend() {
 		if (logicOp != GE_LOGIC_COPY) {
 			logicOpEnabled = false;


### PR DESCRIPTION
In Brave Story, we would set up a subtract blend for the logic op simulation... and then decide to not simulate just using blending, but instead decide to use the shader.  However, this left the subtract blending and made things weird.

This moves changes to the blend state to the end, after we've made the final decision.

-[Unknown]