### PR TITLE
OpenXR - Ensure the head pose is locked during frame rendering

### DIFF
--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -236,6 +236,9 @@ bool GLRenderManager::ThreadFrame() {
 			INFO_LOG(G3D, "Running first frame (%d)", threadFrame_);
 			firstFrame = false;
 		}
+
+		// Creation of OpenXR frame. This updates user's head pose and VR timestamps.
+		// For fluent rendering, the time between PreVRRender and PostVRRender must be really short.
 		if (IsVRBuild() && !vrlock) {
 			if (PreVRRender()) {
 				vrlock = true;
@@ -243,11 +246,14 @@ bool GLRenderManager::ThreadFrame() {
 				return false;
 			}
 		}
+
+		// Render the scene.
 		Run(threadFrame_);
 
 		VLOG("PULL: Finished frame %d", threadFrame_);
 	} while (!nextFrame);
 
+	// Post OpenXR frame on a screen.
 	if (IsVRBuild() && vrlock) {
 		PostVRRender();
 	}

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -1041,6 +1041,7 @@ private:
 
 	bool nextFrame = false;
 	bool firstFrame = true;
+	bool vrRenderStarted = false;
 
 	GLDeleter deleter_;
 	bool skipGLCalls_ = false;

--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -220,7 +220,7 @@ void BindVRFramebuffer() {
 	VR_BindFramebuffer(VR_GetEngine());
 }
 
-bool PreVRRender() {
+bool StartVRRender() {
 	if (!VR_GetConfig(VR_CONFIG_VIEWPORT_VALID)) {
 		VR_InitRenderer(VR_GetEngine(), IsMultiviewSupported());
 		VR_SetConfig(VR_CONFIG_VIEWPORT_VALID, true);
@@ -245,7 +245,7 @@ bool PreVRRender() {
 	return false;
 }
 
-void PostVRRender() {
+void FinishVRRender() {
 	VR_FinishFrame(VR_GetEngine());
 }
 

--- a/Common/VR/PPSSPPVR.h
+++ b/Common/VR/PPSSPPVR.h
@@ -15,8 +15,8 @@ void UpdateVRScreenKey(const KeyInput &key);
 
 // VR rendering integration
 void BindVRFramebuffer();
-bool PreVRRender();
-void PostVRRender();
+bool StartVRRender();
+void FinishVRRender();
 void PreVRFrameRender(int fboIndex);
 void PostVRFrameRender();
 int GetVRFBOIndex();
@@ -38,8 +38,8 @@ inline void UpdateVRScreenKey(const KeyInput &key) {}
 
 // VR rendering integration
 inline void BindVRFramebuffer() {}
-inline bool PreVRRender() { return false; }
-inline void PostVRRender() {}
+inline bool StartVRRender() { return false; }
+inline void FinishVRRender() {}
 inline void PreVRFrameRender(int fboIndex) {}
 inline void PostVRFrameRender() {}
 inline int GetVRFBOIndex() { return 0; }


### PR DESCRIPTION
There is an issue that during rendering one frame multiple head positions are used. This PR ensures there is just one head pose in a single rendered frame.