### PR TITLE
Fix const pointer conversion error for RISC-V

### DIFF
--- a/Common/RiscVEmitter.cpp
+++ b/Common/RiscVEmitter.cpp
@@ -628,7 +628,7 @@ void RiscVEmitter::FlushIcache() {
 
 void RiscVEmitter::FlushIcacheSection(const u8 *start, const u8 *end) {
 #if PPSSPP_ARCH(RISCV64)
-	__builtin___clear_cache(start, end);
+	__builtin___clear_cache((void *)start, (void *)end);
 #endif
 }
 


### PR DESCRIPTION
Fixed errors:

```
[14/601] Building CXX object CMakeFiles/Common.dir/Common/RiscVEmitter.cpp.o
FAILED: CMakeFiles/Common.dir/Common/RiscVEmitter.cpp.o 
/usr/bin/c++ -DASSETS_DIR=\"/usr/local/share/ppsspp/assets/\" -DGLEW_NO_GLU -DMINIUPNPC_SET_SOCKET_TIMEOUT -DMINIUPNP_STATICLIB -DPNG_ARM_NEON_OPT=0 -DSHARED_LIBZIP -DSHARED_ZLIB -DVK_USE_PLATFORM_XLIB_KHR -DWITH_UPNP -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE=1 -D_POSIX_C_SOURCE=200112L -D_XOPEN_SOURCE=700 -D_XOPEN_SOURCE_EXTENDED -D__BSD_VISIBLE=1 -D__LIBRETRO__ -D__STDC_CONSTANT_MACROS -I/build/libretro-ppsspp/src/libretro-ppsspp/ext/glslang -I/build/libretro-ppsspp/src/libretro-ppsspp/ext/glew -I/build/libretro-ppsspp/src/libretro-ppsspp -I/build/libretro-ppsspp/src/libretro-ppsspp/Common -I/build/libretro-ppsspp/src/libretro-ppsspp/ext/cityhash -I/build/libretro-ppsspp/src/libretro-ppsspp/ext/libkirk -I/build/libretro-ppsspp/src/libretro-ppsspp/ext/sfmt19937 -I/build/libretro-ppsspp/src/libretro-ppsspp/ext/xbrz -I/build/libretro-ppsspp/src/libretro-ppsspp/ext/xxhash -I/build/libretro-ppsspp/src/build -march=rv64gc -mabi=lp64d -O2 -pipe -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -Wp,-D_GLIBCXX_ASSERTIONS -flto=auto   -Wformat -Wno-multichar -Wno-psabi -fPIC -fPIC -fno-strict-aliasing -std=gnu++11 -MD -MT CMakeFiles/Common.dir/Common/RiscVEmitter.cpp.o -MF CMakeFiles/Common.dir/Common/RiscVEmitter.cpp.o.d -o CMakeFiles/Common.dir/Common/RiscVEmitter.cpp.o -c /build/libretro-ppsspp/src/libretro-ppsspp/Common/RiscVEmitter.cpp
/build/libretro-ppsspp/src/libretro-ppsspp/Common/RiscVEmitter.cpp: In member function ‘void RiscVGen::RiscVEmitter::FlushIcacheSection(const u8*, const u8*)’:
/build/libretro-ppsspp/src/libretro-ppsspp/Common/RiscVEmitter.cpp:631:33: error: invalid conversion from ‘const void*’ to ‘void*’ [-fpermissive]
  631 |         __builtin___clear_cache(start, end);
      |                                 ^~~~~
      |                                 |
      |                                 const void*
<built-in>: note:   initializing argument 1 of ‘void __builtin___clear_cache(void*, void*)’
/build/libretro-ppsspp/src/libretro-ppsspp/Common/RiscVEmitter.cpp:631:40: error: invalid conversion from ‘const void*’ to ‘void*’ [-fpermissive]
  631 |         __builtin___clear_cache(start, end);
      |                                        ^~~
      |                                        |
      |                                        const void*
<built-in>: note:   initializing argument 2 of ‘void __builtin___clear_cache(void*, void*)’
```

~~The modifications are referenced from other architecture classes. But `ARM64XEmitter` still accepts `const` pointers and converts them internally to `void*`, IIRC this is a UB. I'm willing to fix it in the same way if you wish.~~ (See comments for updates)