### PR TITLE
Tag all the UI screens with names, improve logging of scissor errors

### DIFF
--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -170,7 +170,7 @@ void UIContext::ActivateTopScissor() {
 		int h = std::max(0.0f, ceilf(scale_y * bounds.h));
 		if (x < 0 || y < 0 || x + w > pixel_xres || y + h > pixel_yres) {
 			// This won't actually report outside a game, but we can try.
-			ERROR_LOG_REPORT(G3D, "UI scissor out of bounds: %d,%d-%d,%d / %d,%d", x, y, w, h, pixel_xres, pixel_yres);
+			ERROR_LOG_REPORT(G3D, "UI scissor out of bounds in %sScreen: %d,%d-%d,%d / %d,%d", screenTag_ ? screenTag_ : "N/A", x, y, w, h, pixel_xres, pixel_yres);
 			x = std::max(0, x);
 			y = std::max(0, y);
 			w = std::min(w, pixel_xres - x);

--- a/Common/UI/Context.h
+++ b/Common/UI/Context.h
@@ -74,7 +74,6 @@ public:
 	const UI::Theme *theme;
 
 	// Utility methods
-
 	TextDrawer *Text() const { return textDrawer_; }
 
 	void SetFontStyle(const UI::FontStyle &style);
@@ -103,6 +102,10 @@ public:
 
 	void setUIAtlas(const std::string &name);
 
+	void SetScreenTag(const char *tag) {
+		screenTag_ = tag;
+	}
+
 private:
 	Draw::DrawContext *draw_ = nullptr;
 	Bounds bounds_;
@@ -126,4 +129,6 @@ private:
 
 	std::string lastUIAtlas_;
 	std::string UIAtlas_ = "ui_atlas.zim";
+
+	const char *screenTag_ = nullptr;
 };

--- a/Common/UI/Screen.h
+++ b/Common/UI/Screen.h
@@ -71,7 +71,7 @@ public:
 	// what screen it is.
 	virtual void *dialogData() { return 0; }
 
-	virtual std::string tag() const { return std::string(""); }
+	virtual const char *tag() const = 0;
 
 	virtual bool isTransparent() const { return false; }
 	virtual bool isTopLevel() const { return false; }

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -117,6 +117,9 @@ void UIScreen::render() {
 
 	if (root_) {
 		UIContext *uiContext = screenManager()->getUIContext();
+
+		uiContext->SetScreenTag(tag());
+
 		UI::LayoutViewHierarchy(*uiContext, root_, ignoreInsets_);
 
 		uiContext->PushTransform({translation_, scale_, alpha_});

--- a/Common/UI/UIScreen.h
+++ b/Common/UI/UIScreen.h
@@ -136,7 +136,7 @@ public:
 	void SetHiddenChoices(std::set<int> hidden) {
 		hidden_ = hidden;
 	}
-	virtual std::string tag() const override { return std::string("listpopup"); }
+	const char *tag() const override { return "listpopup"; }
 
 	UI::Event OnChoice;
 
@@ -187,6 +187,8 @@ public:
 		disabled_ = *value_ < 0;
 	}
 
+	const char *tag() const { return "SliderPopup"; }
+
 	Event OnChange;
 
 private:
@@ -214,6 +216,8 @@ public:
 	: PopupScreen(title, "OK", "Cancel"), units_(units), value_(value), originalValue_(*value), minValue_(minValue), maxValue_(maxValue), step_(step), changing_(false), liveUpdate_(liveUpdate) {}
 	void CreatePopupContents(UI::ViewGroup *parent) override;
 
+	const char *tag() const { return "SliderFloatPopup"; }
+
 	Event OnChange;
 
 private:
@@ -240,6 +244,8 @@ public:
 	TextEditPopupScreen(std::string *value, const std::string &placeholder, const std::string &title, int maxLen)
 		: PopupScreen(title, "OK", "Cancel"), value_(value), placeholder_(placeholder), maxLen_(maxLen) {}
 	virtual void CreatePopupContents(ViewGroup *parent) override;
+
+	const char *tag() const { return "TextEditPopup"; }
 
 	Event OnChange;
 

--- a/UI/ComboKeyMappingScreen.cpp
+++ b/UI/ComboKeyMappingScreen.cpp
@@ -56,6 +56,8 @@ public:
 		parent->Add(scroll);
 	}
 
+	const char *tag() const override { return "ButtonShape"; }
+
 private:
 	int *setting_;
 };
@@ -83,6 +85,8 @@ public:
 		scroll->Add(items);
 		parent->Add(scroll);
 	}
+
+	const char *tag() const override { return "ButtonIcon"; }
 
 private:
 	int *setting_;

--- a/UI/ComboKeyMappingScreen.h
+++ b/UI/ComboKeyMappingScreen.h
@@ -28,6 +28,8 @@ class ComboKeyScreen : public UIDialogScreenWithBackground {
 public:
 	ComboKeyScreen(int id): id_(id) {}
 
+	const char *tag() const override { return "ComboKey"; }
+
 	void CreateViews() override;
 	void onFinish(DialogResult result) override;
 

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -35,7 +35,7 @@ class SingleControlMapper;
 class ControlMappingScreen : public UIDialogScreenWithBackground {
 public:
 	ControlMappingScreen() {}
-	std::string tag() const override { return "control mapping"; }
+	const char *tag() const override { return "ControlMapping"; }
 
 protected:
 	void CreateViews() override;
@@ -47,7 +47,7 @@ private:
 	UI::EventReturn OnAutoConfigure(UI::EventParams &params);
 	UI::EventReturn OnVisualizeMapping(UI::EventParams &params);
 
-	virtual void dialogFinished(const Screen *dialog, DialogResult result) override;
+	void dialogFinished(const Screen *dialog, DialogResult result) override;
 
 	UI::ScrollView *rightScroll_;
 	std::vector<SingleControlMapper *> mappers_;
@@ -61,17 +61,19 @@ public:
 		pspBtn_ = btn;
 	}
 
-	virtual bool key(const KeyInput &key) override;
-	virtual bool axis(const AxisInput &axis) override;
+	const char *tag() const override { return "KeyMappingNewKey"; }
+
+	bool key(const KeyInput &key) override;
+	bool axis(const AxisInput &axis) override;
 
 	void SetDelay(float t);
 
 protected:
 	void CreatePopupContents(UI::ViewGroup *parent) override;
 
-	virtual bool FillVertical() const override { return false; }
-	virtual bool ShowButtons() const override { return true; }
-	virtual void OnCompleted(DialogResult result) override {}
+	bool FillVertical() const override { return false; }
+	bool ShowButtons() const override { return true; }
+	void OnCompleted(DialogResult result) override {}
 
 private:
 	int pspBtn_;
@@ -86,6 +88,8 @@ public:
 		: PopupScreen(i18n->T("Map Mouse"), "", ""), callback_(callback), mapped_(false) {
 		pspBtn_ = btn;
 	}
+
+	const char *tag() const override { return "KeyMappingNewMouseKey"; }
 
 	bool key(const KeyInput &key) override;
 	bool axis(const AxisInput &axis) override;
@@ -113,6 +117,8 @@ public:
 	bool axis(const AxisInput &axis) override;
 
 	void update() override;
+
+	const char *tag() const override { return "AnalogSetup"; }
 
 protected:
 	void CreateViews() override;
@@ -144,6 +150,8 @@ public:
 	bool key(const KeyInput &key) override;
 	bool axis(const AxisInput &axis) override;
 
+	const char *tag() const override { return "TouchTest"; }
+
 protected:
 	struct TrackedTouch {
 		int id;
@@ -170,6 +178,8 @@ class MockPSP;
 class VisualMappingScreen : public UIDialogScreenWithBackground {
 public:
 	VisualMappingScreen() {}
+
+	const char *tag() const override { return "VisualMapping"; }
 
 protected:
 	void CreateViews() override;

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -41,6 +41,8 @@ public:
 	void update() override;
 	void onFinish(DialogResult result) override;
 
+	const char *tag() const override { return "CwCheat"; }
+
 protected:
 	void CreateViews() override;
 

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -85,7 +85,7 @@ static const char *logLevelList[] = {
 	"Verb."
 };
 
-void DevMenu::CreatePopupContents(UI::ViewGroup *parent) {
+void DevMenuScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	using namespace UI;
 	auto dev = GetI18NCategory("Developer");
 	auto sy = GetI18NCategory("System");
@@ -94,25 +94,25 @@ void DevMenu::CreatePopupContents(UI::ViewGroup *parent) {
 	LinearLayout *items = new LinearLayout(ORIENT_VERTICAL);
 
 #if !defined(MOBILE_DEVICE)
-	items->Add(new Choice(dev->T("Log View")))->OnClick.Handle(this, &DevMenu::OnLogView);
+	items->Add(new Choice(dev->T("Log View")))->OnClick.Handle(this, &DevMenuScreen::OnLogView);
 #endif
-	items->Add(new Choice(dev->T("Logging Channels")))->OnClick.Handle(this, &DevMenu::OnLogConfig);
-	items->Add(new Choice(sy->T("Developer Tools")))->OnClick.Handle(this, &DevMenu::OnDeveloperTools);
-	items->Add(new Choice(dev->T("Jit Compare")))->OnClick.Handle(this, &DevMenu::OnJitCompare);
-	items->Add(new Choice(dev->T("Shader Viewer")))->OnClick.Handle(this, &DevMenu::OnShaderView);
+	items->Add(new Choice(dev->T("Logging Channels")))->OnClick.Handle(this, &DevMenuScreen::OnLogConfig);
+	items->Add(new Choice(sy->T("Developer Tools")))->OnClick.Handle(this, &DevMenuScreen::OnDeveloperTools);
+	items->Add(new Choice(dev->T("Jit Compare")))->OnClick.Handle(this, &DevMenuScreen::OnJitCompare);
+	items->Add(new Choice(dev->T("Shader Viewer")))->OnClick.Handle(this, &DevMenuScreen::OnShaderView);
 	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN) {
 		// TODO: Make a new allocator visualizer for VMA.
 		// items->Add(new CheckBox(&g_Config.bShowAllocatorDebug, dev->T("Allocator Viewer")));
 		items->Add(new CheckBox(&g_Config.bShowGpuProfile, dev->T("GPU Profile")));
 	}
-	items->Add(new Choice(dev->T("Toggle Freeze")))->OnClick.Handle(this, &DevMenu::OnFreezeFrame);
-	items->Add(new Choice(dev->T("Dump Frame GPU Commands")))->OnClick.Handle(this, &DevMenu::OnDumpFrame);
-	items->Add(new Choice(dev->T("Toggle Audio Debug")))->OnClick.Handle(this, &DevMenu::OnToggleAudioDebug);
+	items->Add(new Choice(dev->T("Toggle Freeze")))->OnClick.Handle(this, &DevMenuScreen::OnFreezeFrame);
+	items->Add(new Choice(dev->T("Dump Frame GPU Commands")))->OnClick.Handle(this, &DevMenuScreen::OnDumpFrame);
+	items->Add(new Choice(dev->T("Toggle Audio Debug")))->OnClick.Handle(this, &DevMenuScreen::OnToggleAudioDebug);
 #ifdef USE_PROFILER
 	items->Add(new CheckBox(&g_Config.bShowFrameProfiler, dev->T("Frame Profiler"), ""));
 #endif
 	items->Add(new CheckBox(&g_Config.bDrawFrameGraph, dev->T("Draw Frametimes Graph")));
-	items->Add(new Choice(dev->T("Reset limited logging")))->OnClick.Handle(this, &DevMenu::OnResetLimitedLogging);
+	items->Add(new Choice(dev->T("Reset limited logging")))->OnClick.Handle(this, &DevMenuScreen::OnResetLimitedLogging);
 
 	scroll->Add(items);
 	parent->Add(scroll);
@@ -123,48 +123,48 @@ void DevMenu::CreatePopupContents(UI::ViewGroup *parent) {
 	}
 }
 
-UI::EventReturn DevMenu::OnToggleAudioDebug(UI::EventParams &e) {
+UI::EventReturn DevMenuScreen::OnToggleAudioDebug(UI::EventParams &e) {
 	g_Config.bShowAudioDebug = !g_Config.bShowAudioDebug;
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn DevMenu::OnResetLimitedLogging(UI::EventParams &e) {
+UI::EventReturn DevMenuScreen::OnResetLimitedLogging(UI::EventParams &e) {
 	Reporting::ResetCounts();
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn DevMenu::OnLogView(UI::EventParams &e) {
+UI::EventReturn DevMenuScreen::OnLogView(UI::EventParams &e) {
 	UpdateUIState(UISTATE_PAUSEMENU);
 	screenManager()->push(new LogScreen());
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn DevMenu::OnLogConfig(UI::EventParams &e) {
+UI::EventReturn DevMenuScreen::OnLogConfig(UI::EventParams &e) {
 	UpdateUIState(UISTATE_PAUSEMENU);
 	screenManager()->push(new LogConfigScreen());
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn DevMenu::OnDeveloperTools(UI::EventParams &e) {
+UI::EventReturn DevMenuScreen::OnDeveloperTools(UI::EventParams &e) {
 	UpdateUIState(UISTATE_PAUSEMENU);
 	screenManager()->push(new DeveloperToolsScreen());
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn DevMenu::OnJitCompare(UI::EventParams &e) {
+UI::EventReturn DevMenuScreen::OnJitCompare(UI::EventParams &e) {
 	UpdateUIState(UISTATE_PAUSEMENU);
 	screenManager()->push(new JitCompareScreen());
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn DevMenu::OnShaderView(UI::EventParams &e) {
+UI::EventReturn DevMenuScreen::OnShaderView(UI::EventParams &e) {
 	UpdateUIState(UISTATE_PAUSEMENU);
 	if (gpu)  // Avoid crashing if chosen while the game is being loaded.
 		screenManager()->push(new ShaderListScreen());
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn DevMenu::OnFreezeFrame(UI::EventParams &e) {
+UI::EventReturn DevMenuScreen::OnFreezeFrame(UI::EventParams &e) {
 	if (PSP_CoreParameter().frozen) {
 		PSP_CoreParameter().frozen = false;
 	} else {
@@ -173,12 +173,12 @@ UI::EventReturn DevMenu::OnFreezeFrame(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn DevMenu::OnDumpFrame(UI::EventParams &e) {
+UI::EventReturn DevMenuScreen::OnDumpFrame(UI::EventParams &e) {
 	gpu->DumpNextFrame();
 	return UI::EVENT_DONE;
 }
 
-void DevMenu::dialogFinished(const Screen *dialog, DialogResult result) {
+void DevMenuScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 	UpdateUIState(UISTATE_INGAME);
 	// Close when a subscreen got closed.
 	// TODO: a bug in screenmanager causes this not to work here.

--- a/UI/DevScreens.h
+++ b/UI/DevScreens.h
@@ -28,9 +28,11 @@
 #include "UI/MiscScreens.h"
 #include "GPU/Common/ShaderCommon.h"
 
-class DevMenu : public PopupScreen {
+class DevMenuScreen : public PopupScreen {
 public:
-	DevMenu(std::shared_ptr<I18NCategory> i18n) : PopupScreen(i18n->T("Dev Tools")) {}
+	DevMenuScreen(std::shared_ptr<I18NCategory> i18n) : PopupScreen(i18n->T("Dev Tools")) {}
+
+	const char *tag() const override { return "DevMenu"; }
 
 	void CreatePopupContents(UI::ViewGroup *parent) override;
 	void dialogFinished(const Screen *dialog, DialogResult result) override;
@@ -50,7 +52,9 @@ protected:
 class JitDebugScreen : public UIDialogScreenWithBackground {
 public:
 	JitDebugScreen() {}
-	virtual void CreateViews() override;
+	void CreateViews() override;
+
+	const char *tag() const override { return "JitDebug"; }
 
 private:
 	UI::EventReturn OnEnableAll(UI::EventParams &e);
@@ -60,7 +64,9 @@ private:
 class LogConfigScreen : public UIDialogScreenWithBackground {
 public:
 	LogConfigScreen() {}
-	virtual void CreateViews() override;
+	void CreateViews() override;
+
+	const char *tag() const override { return "LogConfig"; }
 
 private:
 	UI::EventReturn OnToggleAll(UI::EventParams &e);
@@ -76,6 +82,8 @@ public:
 	void CreateViews() override;
 	void update() override;
 
+	const char *tag() const override { return "Log"; }
+
 private:
 	void UpdateLog();
 	UI::EventReturn OnSubmit(UI::EventParams &e);
@@ -89,6 +97,8 @@ class LogLevelScreen : public ListPopupScreen {
 public:
 	LogLevelScreen(const std::string &title);
 
+	const char *tag() const override { return "LogLevel"; }
+
 private:
 	virtual void OnCompleted(DialogResult result);
 
@@ -96,7 +106,8 @@ private:
 
 class SystemInfoScreen : public UIDialogScreenWithBackground {
 public:
-	SystemInfoScreen() {}
+	const char *tag() const override { return "SystemInfo"; }
+
 	void CreateViews() override;
 };
 
@@ -106,13 +117,15 @@ public:
 		memset(buttons_, 0, sizeof(buttons_));
 	}
 
-	virtual bool key(const KeyInput &key) override;
+	const char *tag() const override { return "AddressPrompt"; }
+
+	bool key(const KeyInput &key) override;
 
 	UI::Event OnChoice;
 
 protected:
-	virtual void CreatePopupContents(UI::ViewGroup *parent) override;
-	virtual void OnCompleted(DialogResult result) override;
+	void CreatePopupContents(UI::ViewGroup *parent) override;
+	void OnCompleted(DialogResult result) override;
 	UI::EventReturn OnDigitButton(UI::EventParams &e);
 	UI::EventReturn OnBackspace(UI::EventParams &e);
 
@@ -128,8 +141,9 @@ private:
 
 class JitCompareScreen : public UIDialogScreenWithBackground {
 public:
-	JitCompareScreen() : currentBlock_(-1) {}
-	virtual void CreateViews() override;
+	void CreateViews() override;
+
+	const char *tag() const override { return "JitCompare"; }
 
 private:
 	void UpdateDisasm();
@@ -146,7 +160,7 @@ private:
 	UI::EventReturn OnAddressChange(UI::EventParams &e);
 	UI::EventReturn OnShowStats(UI::EventParams &e);
 
-	int currentBlock_;
+	int currentBlock_ = -1;
 
 	UI::TextView *blockName_;
 	UI::TextEdit *blockAddr_;
@@ -158,8 +172,9 @@ private:
 
 class ShaderListScreen : public UIDialogScreenWithBackground {
 public:
-	ShaderListScreen() {}
 	void CreateViews() override;
+
+	const char *tag() const override { return "ShaderList"; }
 
 private:
 	int ListShaders(DebugShaderType shaderType, UI::LinearLayout *view);
@@ -175,6 +190,9 @@ public:
 		: id_(id), type_(type) {}
 
 	void CreateViews() override;
+
+	const char *tag() const override { return "ShaderView"; }
+
 private:
 	std::string id_;
 	DebugShaderType type_;
@@ -187,6 +205,8 @@ public:
 
 	void CreateViews() override;
 	void update() override;
+
+	const char *tag() const override { return "FrameDumpTest"; }
 
 private:
 	UI::EventReturn OnLoadDump(UI::EventParams &e);

--- a/UI/DisplayLayoutScreen.h
+++ b/UI/DisplayLayoutScreen.h
@@ -31,7 +31,7 @@ public:
 	virtual void dialogFinished(const Screen *dialog, DialogResult result) override;
 	virtual void onFinish(DialogResult reason) override;
 	virtual void resized() override;
-	std::string tag() const override { return "display layout screen"; }
+	const char *tag() const override { return "DisplayLayout"; }
 	
 protected:
 	virtual UI::EventReturn OnCenter(UI::EventParams &e);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -955,7 +955,7 @@ void EmuScreen::CreateViews() {
 
 UI::EventReturn EmuScreen::OnDevTools(UI::EventParams &params) {
 	auto dev = GetI18NCategory("Developer");
-	DevMenu *devMenu = new DevMenu(dev);
+	DevMenuScreen *devMenu = new DevMenuScreen(dev);
 	if (params.v)
 		devMenu->SetPopupOrigin(params.v);
 	screenManager()->push(devMenu);

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -40,6 +40,8 @@ public:
 	EmuScreen(const Path &filename);
 	~EmuScreen();
 
+	const char *tag() const override { return "Emu"; }
+
 	void update() override;
 	void render() override;
 	void preRender() override;

--- a/UI/GPUDriverTestScreen.h
+++ b/UI/GPUDriverTestScreen.h
@@ -17,6 +17,8 @@ public:
 	void CreateViews() override;
 	void render() override;
 
+	const char *tag() const override { return "GPUDriverTest"; }
+
 private:
 	void DiscardTest();
 	void ShaderTest();

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -443,6 +443,7 @@ UI::EventReturn GameScreen::OnRemoveFromRecent(UI::EventParams &e) {
 class SetBackgroundPopupScreen : public PopupScreen {
 public:
 	SetBackgroundPopupScreen(const std::string &title, const Path &gamePath);
+	const char *tag() const override { return "SetBackgroundPopup"; }
 
 protected:
 	bool FillVertical() const override { return false; }

--- a/UI/GameScreen.h
+++ b/UI/GameScreen.h
@@ -38,7 +38,7 @@ public:
 
 	void render() override;
 
-	std::string tag() const override { return "game"; }
+	const char *tag() const override { return "Game"; }
 
 protected:
 	void CreateViews() override;

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -32,7 +32,7 @@ public:
 
 	void update() override;
 	void onFinish(DialogResult result) override;
-	std::string tag() const override { return "settings"; }
+	const char *tag() const override { return "GameSettings"; }
 
 protected:
 	void sendMessage(const char *message, const char *value) override;
@@ -157,9 +157,10 @@ private:
 
 class DeveloperToolsScreen : public UIDialogScreenWithBackground {
 public:
-	DeveloperToolsScreen() {}
 	void update() override;
 	void onFinish(DialogResult result) override;
+
+	const char *tag() const override { return "DeveloperTools"; }
 
 protected:
 	void CreateViews() override;
@@ -205,6 +206,8 @@ public:
 
 	void CreatePopupContents(UI::ViewGroup *parent) override;
 
+	const char *tag() const override { return "HostnameSelect"; }
+
 protected:
 	void OnCompleted(DialogResult result) override;
 	bool CanComplete(DialogResult result) override;
@@ -247,4 +250,6 @@ private:
 class GestureMappingScreen : public UIDialogScreenWithBackground {
 public:
 	void CreateViews() override;
+
+	const char *tag() const override { return "GestureMapping"; }
 };

--- a/UI/InstallZipScreen.h
+++ b/UI/InstallZipScreen.h
@@ -30,6 +30,8 @@ public:
 	virtual void update() override;
 	virtual bool key(const KeyInput &key) override;
 
+	const char *tag() const { return "install_zip"; }
+
 protected:
 	virtual void CreateViews() override;
 

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -102,6 +102,8 @@ public:
 
 	bool isTopLevel() const override { return true; }
 
+	const char *tag() const override { return "Main"; }
+
 	// Horrible hack to show the demos & homebrew tab after having installed a game from a zip file.
 	static bool showHomebrewTab;
 
@@ -153,7 +155,7 @@ protected:
 
 class UmdReplaceScreen : public UIDialogScreenWithBackground {
 public:
-	UmdReplaceScreen() {}
+	const char *tag() const override { return "UmdReplace"; }
 
 protected:
 	void CreateViews() override;
@@ -173,6 +175,8 @@ public:
 	GridSettingsScreen(std::string label) : PopupScreen(label) {}
 	void CreatePopupContents(UI::ViewGroup *parent) override;
 	UI::Event OnRecentChanged;
+
+	const char *tag() const override { return "GridSettings"; }
 
 private:
 	UI::EventReturn GridPlusClick(UI::EventParams &e);

--- a/UI/MemStickScreen.h
+++ b/UI/MemStickScreen.h
@@ -36,7 +36,7 @@ public:
 	MemStickScreen(bool initialSetup);
 	~MemStickScreen() {}
 
-	std::string tag() const override { return "game"; }
+	const char *tag() const override { return "memstick"; }
 
 	enum Choice {
 		CHOICE_BROWSE_FOLDER,
@@ -112,6 +112,9 @@ class ConfirmMemstickMoveScreen : public UIDialogScreenWithBackground {
 public:
 	ConfirmMemstickMoveScreen(Path newMemstickFolder, bool initialSetup);
 	~ConfirmMemstickMoveScreen();
+
+	const char *tag() const override { return "ConfirmMemstickMove"; }
+
 protected:
 	void update() override;
 	void CreateViews() override;

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -82,6 +82,8 @@ public:
 
 	void TriggerFinish(DialogResult result) override;
 
+	const char *tag() const override { return "Prompt"; }
+
 private:
 	UI::EventReturn OnYes(UI::EventParams &e);
 	UI::EventReturn OnNo(UI::EventParams &e);
@@ -95,6 +97,8 @@ private:
 class NewLanguageScreen : public ListPopupScreen {
 public:
 	NewLanguageScreen(const std::string &title);
+
+	const char *tag() const override { return "NewLanguage"; }
 
 private:
 	void OnCompleted(DialogResult result) override;
@@ -110,6 +114,8 @@ public:
 
 	void CreateViews() override;
 
+	const char *tag() const override { return "PostProc"; }
+
 private:
 	void OnCompleted(DialogResult result) override;
 	bool ShowButtons() const override { return true; }
@@ -122,6 +128,8 @@ public:
 	TextureShaderScreen(const std::string &title);
 
 	void CreateViews() override;
+
+	const char *tag() const override { return "TextureShader"; }
 
 private:
 	void OnCompleted(DialogResult result) override;
@@ -146,6 +154,8 @@ public:
 	void sendMessage(const char *message, const char *value) override;
 	void CreateViews() override {}
 
+	const char *tag() const override { return "Logo"; }
+
 private:
 	void Next();
 	int frames_ = 0;
@@ -161,6 +171,8 @@ public:
 	void render() override;
 
 	void CreateViews() override;
+
+	const char *tag() const override { return "Credits"; }
 
 private:
 	UI::EventReturn OnOK(UI::EventParams &e);

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -172,9 +172,7 @@ public:
 		return slot_;
 	}
 
-	std::string tag() const override {
-		return "screenshot";
-	}
+	const char *tag() const override { return "screenshot_view"; }
 
 protected:
 	bool FillVertical() const override { return false; }

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -33,6 +33,8 @@ public:
 
 	virtual void dialogFinished(const Screen *dialog, DialogResult dr) override;
 
+	const char *tag() const override { return "GamePause"; }
+
 protected:
 	virtual void CreateViews() override;
 	virtual void update() override;

--- a/UI/RemoteISOScreen.h
+++ b/UI/RemoteISOScreen.h
@@ -29,6 +29,8 @@ class RemoteISOScreen : public UIScreenWithBackground {
 public:
 	RemoteISOScreen();
 
+	const char *tag() const override { return "RemoteISO"; }
+
 protected:
 	void update() override;
 	void CreateViews() override;
@@ -57,6 +59,8 @@ public:
 	RemoteISOConnectScreen();
 	~RemoteISOConnectScreen() override;
 
+	const char *tag() const override { return "RemoteISOConnect"; }
+
 protected:
 	void update() override;
 	void CreateViews() override;
@@ -83,6 +87,8 @@ class RemoteISOBrowseScreen : public MainScreen {
 public:
 	RemoteISOBrowseScreen(const std::string &url, const std::vector<Path> &games);
 
+	const char *tag() const override { return "RemoteISOBrowse"; }
+
 protected:
 	void CreateViews() override;
 
@@ -93,6 +99,8 @@ protected:
 class RemoteISOSettingsScreen : public UIDialogScreenWithBackground {
 public:
 	RemoteISOSettingsScreen();
+
+	const char *tag() const override { return "RemoteISOSettings"; }
 
 	UI::EventReturn OnClickRemoteISOSubdir(UI::EventParams &e);
 	UI::EventReturn OnClickRemoteServer(UI::EventParams &e);

--- a/UI/ReportScreen.h
+++ b/UI/ReportScreen.h
@@ -37,6 +37,8 @@ class ReportScreen : public UIDialogScreenWithGameBackground {
 public:
 	ReportScreen(const Path &gamePath);
 
+	const char *tag() const override { return "Report"; }
+
 protected:
 	void postRender() override;
 	void update() override;
@@ -74,6 +76,8 @@ protected:
 class ReportFinishScreen : public UIDialogScreenWithGameBackground {
 public:
 	ReportFinishScreen(const Path &gamePath, ReportingOverallScore score);
+
+	const char *tag() const override { return "ReportFinish"; }
 
 protected:
 	void update() override;

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -78,8 +78,9 @@ static std::string TrimString(const std::string &str) {
 
 class SavedataPopupScreen : public PopupScreen {
 public:
-	SavedataPopupScreen(std::string savePath, std::string title) : PopupScreen(TrimString(title)), savePath_(savePath) {
-	}
+	SavedataPopupScreen(std::string savePath, std::string title) : PopupScreen(TrimString(title)), savePath_(savePath) { }
+
+	const char *tag() const override { return "SavedataPopup"; }
 
 	void CreatePopupContents(UI::ViewGroup *parent) override {
 		using namespace UI;

--- a/UI/SavedataScreen.h
+++ b/UI/SavedataScreen.h
@@ -74,6 +74,8 @@ public:
 	void dialogFinished(const Screen *dialog, DialogResult result) override;
 	void sendMessage(const char *message, const char *value) override;
 
+	const char *tag() const override { return "Savedata"; }
+
 protected:
 	UI::EventReturn OnSavedataButtonClick(UI::EventParams &e);
 	UI::EventReturn OnSortClick(UI::EventParams &e);

--- a/UI/Store.h
+++ b/UI/Store.h
@@ -67,7 +67,7 @@ public:
 	~StoreScreen();
 
 	void update() override;
-	std::string tag() const override { return "store"; }
+	const char *tag() const override { return "Store"; }
 
 protected:
 	void CreateViews() override;

--- a/UI/TiltAnalogSettingsScreen.h
+++ b/UI/TiltAnalogSettingsScreen.h
@@ -27,6 +27,8 @@ public:
 	void CreateViews() override;
 	bool axis(const AxisInput &axis) override;
 
+	const char *tag() const override { return "TiltAnalogSettings"; }
+
 private:
 	UI::EventReturn OnCalibrate(UI::EventParams &e);
 	float currentTiltX_ = 0.0f;

--- a/UI/TouchControlLayoutScreen.h
+++ b/UI/TouchControlLayoutScreen.h
@@ -33,6 +33,8 @@ public:
 	virtual void update() override;
 	virtual void resized() override;
 
+	const char *tag() const override { return "TouchControlLayout"; }
+
 protected:
 	virtual UI::EventReturn OnReset(UI::EventParams &e);
 	virtual UI::EventReturn OnVisibility(UI::EventParams &e);

--- a/UI/TouchControlVisibilityScreen.h
+++ b/UI/TouchControlVisibilityScreen.h
@@ -36,6 +36,8 @@ public:
 	void CreateViews() override;
 	void onFinish(DialogResult result) override;
 
+	const char *tag() const override { return "TouchControlVisibility"; }
+
 protected:
 	UI::EventReturn OnToggleAll(UI::EventParams &e);
 
@@ -47,4 +49,6 @@ private:
 class RightAnalogMappingScreen : public UIDialogScreenWithBackground {
 public:
 	void CreateViews() override;
+
+	const char *tag() const override { return "RightAnalogMapping"; }
 };


### PR DESCRIPTION
Wow, we have a lot of screens these days... Insane.

Anyway, I added this to try to debug #15773 .  Unfortunately, only found the following kind-of-false positives (though should probably be fixed):

 * `[G3D] UI scissor out of bounds in SavedataScreen: 2200,709-0,136 / 2116,1080`  (when switching tabs in SaveDataScreen)
 * `[G3D] UI scissor out of bounds in MainScreen: 0,89-1530,991 / 1080,2116` during exit on Android (looks like for a frame we think we are in portrait)