### PR TITLE
Vulkan: "Acquire" the image from the swapchain as late as possible in the frame

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -623,6 +623,8 @@ add_library(Common STATIC
 	Common/GPU/Vulkan/VulkanRenderManager.h
 	Common/GPU/Vulkan/VulkanQueueRunner.cpp
 	Common/GPU/Vulkan/VulkanQueueRunner.h
+	Common/GPU/Vulkan/VulkanFrameData.cpp
+	Common/GPU/Vulkan/VulkanFrameData.h
 	Common/Input/GestureDetector.cpp
 	Common/Input/GestureDetector.h
 	Common/Input/KeyCodes.h

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -441,6 +441,7 @@
     <ClInclude Include="GPU\Vulkan\VulkanBarrier.h" />
     <ClInclude Include="GPU\Vulkan\VulkanContext.h" />
     <ClInclude Include="GPU\Vulkan\VulkanDebug.h" />
+    <ClInclude Include="GPU\Vulkan\VulkanFrameData.h" />
     <ClInclude Include="GPU\Vulkan\VulkanImage.h" />
     <ClInclude Include="GPU\Vulkan\VulkanLoader.h" />
     <ClInclude Include="GPU\Vulkan\VulkanMemory.h" />
@@ -861,6 +862,7 @@
     <ClCompile Include="GPU\Vulkan\VulkanBarrier.cpp" />
     <ClCompile Include="GPU\Vulkan\VulkanContext.cpp" />
     <ClCompile Include="GPU\Vulkan\VulkanDebug.cpp" />
+    <ClCompile Include="GPU\Vulkan\VulkanFrameData.cpp" />
     <ClCompile Include="GPU\Vulkan\VulkanImage.cpp" />
     <ClCompile Include="GPU\Vulkan\VulkanLoader.cpp" />
     <ClCompile Include="GPU\Vulkan\VulkanMemory.cpp" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -419,6 +419,9 @@
       <Filter>GPU\Vulkan</Filter>
     </ClInclude>
     <ClInclude Include="RiscVEmitter.h" />
+    <ClInclude Include="GPU\Vulkan\VulkanFrameData.h">
+      <Filter>GPU\Vulkan</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />
@@ -791,6 +794,9 @@
       <Filter>GPU\Vulkan</Filter>
     </ClCompile>
     <ClCompile Include="RiscVEmitter.cpp" />
+    <ClCompile Include="GPU\Vulkan\VulkanFrameData.cpp">
+      <Filter>GPU\Vulkan</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Crypto">

--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -579,7 +579,6 @@ void GLRenderManager::EndSubmitFrame(int frame) {
 void GLRenderManager::Run(int frame) {
 	BeginSubmitFrame(frame);
 
-
 	FrameData &frameData = frameData_[frame];
 
 	auto &stepsOnThread = frameData_[frame].steps;

--- a/Common/GPU/Vulkan/VulkanFrameData.cpp
+++ b/Common/GPU/Vulkan/VulkanFrameData.cpp
@@ -1,0 +1,15 @@
+#include "VulkanFrameData.h"
+
+void FrameData::AcquireNextImage(VulkanContext *vulkan) {
+	// Get the index of the next available swapchain image, and a semaphore to block command buffer execution on.
+	VkResult res = vkAcquireNextImageKHR(vulkan->GetDevice(), vulkan->GetSwapchain(), UINT64_MAX, acquireSemaphore, (VkFence)VK_NULL_HANDLE, &curSwapchainImage);
+	if (res == VK_SUBOPTIMAL_KHR) {
+		// Hopefully the resize will happen shortly. Ignore - one frame might look bad or something.
+		WARN_LOG(G3D, "VK_SUBOPTIMAL_KHR returned - ignoring");
+	} else if (res == VK_ERROR_OUT_OF_DATE_KHR) {
+		WARN_LOG(G3D, "VK_ERROR_OUT_OF_DATE_KHR returned - processing the frame, but not presenting");
+		skipSwap = true;
+	} else {
+		_assert_msg_(res == VK_SUCCESS, "vkAcquireNextImageKHR failed! result=%s", VulkanResultToString(res));
+	}
+}

--- a/Common/GPU/Vulkan/VulkanFrameData.h
+++ b/Common/GPU/Vulkan/VulkanFrameData.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstdint>
+
+#include <mutex>
+#include <condition_variable>
+
+#include "Common/GPU/Vulkan/VulkanContext.h"
+
+struct VKRStep;
+
+enum class VKRRunType {
+	END,
+	SYNC,
+};
+
+struct QueueProfileContext {
+	VkQueryPool queryPool;
+	std::vector<std::string> timestampDescriptions;
+	std::string profileSummary;
+	double cpuStartTime;
+	double cpuEndTime;
+};
+
+// Per-frame data, round-robin so we can overlap submission with execution of the previous frame.
+struct FrameData {
+	std::mutex push_mutex;
+	std::condition_variable push_condVar;
+
+	std::mutex pull_mutex;
+	std::condition_variable pull_condVar;
+
+	bool readyForFence = true;
+	bool readyForRun = false;
+	bool skipSwap = false;
+	VKRRunType type = VKRRunType::END;
+
+	VkFence fence;
+	VkFence readbackFence;  // Strictly speaking we might only need one of these.
+	bool readbackFenceUsed = false;
+
+	// These are on different threads so need separate pools.
+	VkCommandPool cmdPoolInit;  // Written to from main thread
+	VkCommandPool cmdPoolMain;  // Written to from render thread, which also submits
+
+	VkCommandBuffer initCmd;
+	VkCommandBuffer mainCmd;
+	VkCommandBuffer presentCmd;
+
+	bool hasInitCommands = false;
+	bool hasPresentCommands = false;
+
+	std::vector<VKRStep *> steps;
+
+	// Swapchain.
+	bool hasBegun = false;
+	uint32_t curSwapchainImage = -1;
+	VkSemaphore acquireSemaphore;  // Not owned, shared between all FrameData.
+
+	// Profiling.
+	QueueProfileContext profile;
+	bool profilingEnabled_;
+
+	void AcquireNextImage(VulkanContext *vulkan);
+};

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -1129,7 +1129,6 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 		}
 	}
 
-	
 	// Don't execute empty renderpasses that keep the contents.
 	if (step.commands.empty() && step.render.colorLoad == VKRRenderPassLoadAction::KEEP && step.render.depthLoad == VKRRenderPassLoadAction::KEEP && step.render.stencilLoad == VKRRenderPassLoadAction::KEEP) {
 		// Flush the pending barrier
@@ -1179,6 +1178,7 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 
 	// This reads the layout of the color and depth images, and chooses a render pass using them that
 	// will transition to the desired final layout.
+	//
 	// NOTE: Flushes recordBarrier_.
 	VKRRenderPass *renderPass = PerformBindFramebufferAsRenderTarget(step, cmd);
 

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -141,6 +141,171 @@ void VulkanQueueRunner::DestroyDeviceObjects() {
 	renderPasses_.Clear();
 }
 
+bool VulkanQueueRunner::CreateSwapchain(VkCommandBuffer cmdInit) {
+	VkResult res = vkGetSwapchainImagesKHR(vulkan_->GetDevice(), vulkan_->GetSwapchain(), &swapchainImageCount_, nullptr);
+	_dbg_assert_(res == VK_SUCCESS);
+
+	VkImage *swapchainImages = new VkImage[swapchainImageCount_];
+	res = vkGetSwapchainImagesKHR(vulkan_->GetDevice(), vulkan_->GetSwapchain(), &swapchainImageCount_, swapchainImages);
+	if (res != VK_SUCCESS) {
+		ERROR_LOG(G3D, "vkGetSwapchainImagesKHR failed");
+		delete[] swapchainImages;
+		return false;
+	}
+
+	for (uint32_t i = 0; i < swapchainImageCount_; i++) {
+		SwapchainImageData sc_buffer{};
+		sc_buffer.image = swapchainImages[i];
+
+		VkImageViewCreateInfo color_image_view = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
+		color_image_view.format = vulkan_->GetSwapchainFormat();
+		color_image_view.components.r = VK_COMPONENT_SWIZZLE_IDENTITY;
+		color_image_view.components.g = VK_COMPONENT_SWIZZLE_IDENTITY;
+		color_image_view.components.b = VK_COMPONENT_SWIZZLE_IDENTITY;
+		color_image_view.components.a = VK_COMPONENT_SWIZZLE_IDENTITY;
+		color_image_view.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		color_image_view.subresourceRange.baseMipLevel = 0;
+		color_image_view.subresourceRange.levelCount = 1;
+		color_image_view.subresourceRange.baseArrayLayer = 0;
+		color_image_view.subresourceRange.layerCount = 1;
+		color_image_view.viewType = VK_IMAGE_VIEW_TYPE_2D;
+		color_image_view.flags = 0;
+		color_image_view.image = sc_buffer.image;
+
+		// We leave the images as UNDEFINED, there's no need to pre-transition them as
+		// the backbuffer renderpass starts out with them being auto-transitioned from UNDEFINED anyway.
+		// Also, turns out it's illegal to transition un-acquired images, thanks Hans-Kristian. See #11417.
+
+		res = vkCreateImageView(vulkan_->GetDevice(), &color_image_view, nullptr, &sc_buffer.view);
+		swapchainImages_.push_back(sc_buffer);
+		_dbg_assert_(res == VK_SUCCESS);
+	}
+	delete[] swapchainImages;
+
+	// Must be before InitBackbufferRenderPass.
+	if (InitDepthStencilBuffer(cmdInit)) {
+		InitBackbufferFramebuffers(vulkan_->GetBackbufferWidth(), vulkan_->GetBackbufferHeight());
+	}
+	return true;
+}
+
+
+bool VulkanQueueRunner::InitBackbufferFramebuffers(int width, int height) {
+	VkResult res;
+	// We share the same depth buffer but have multiple color buffers, see the loop below.
+	VkImageView attachments[2] = { VK_NULL_HANDLE, depth_.view };
+
+	VkFramebufferCreateInfo fb_info = { VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO };
+	fb_info.renderPass = GetCompatibleRenderPass()->Get(vulkan_, RP_TYPE_BACKBUFFER);
+	fb_info.attachmentCount = 2;
+	fb_info.pAttachments = attachments;
+	fb_info.width = width;
+	fb_info.height = height;
+	fb_info.layers = 1;
+
+	framebuffers_.resize(swapchainImageCount_);
+
+	for (uint32_t i = 0; i < swapchainImageCount_; i++) {
+		attachments[0] = swapchainImages_[i].view;
+		res = vkCreateFramebuffer(vulkan_->GetDevice(), &fb_info, nullptr, &framebuffers_[i]);
+		_dbg_assert_(res == VK_SUCCESS);
+		if (res != VK_SUCCESS) {
+			framebuffers_.clear();
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool VulkanQueueRunner::InitDepthStencilBuffer(VkCommandBuffer cmd) {
+	const VkFormat depth_format = vulkan_->GetDeviceInfo().preferredDepthStencilFormat;
+	int aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+	VkImageCreateInfo image_info = { VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
+	image_info.imageType = VK_IMAGE_TYPE_2D;
+	image_info.format = depth_format;
+	image_info.extent.width = vulkan_->GetBackbufferWidth();
+	image_info.extent.height = vulkan_->GetBackbufferHeight();
+	image_info.extent.depth = 1;
+	image_info.mipLevels = 1;
+	image_info.arrayLayers = 1;
+	image_info.samples = VK_SAMPLE_COUNT_1_BIT;
+	image_info.queueFamilyIndexCount = 0;
+	image_info.pQueueFamilyIndices = nullptr;
+	image_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+	image_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+	image_info.flags = 0;
+
+	depth_.format = depth_format;
+
+	VmaAllocationCreateInfo allocCreateInfo{};
+	VmaAllocationInfo allocInfo{};
+
+	allocCreateInfo.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+
+	VkResult res = vmaCreateImage(vulkan_->Allocator(), &image_info, &allocCreateInfo, &depth_.image, &depth_.alloc, &allocInfo);
+	_dbg_assert_(res == VK_SUCCESS);
+	if (res != VK_SUCCESS)
+		return false;
+
+	vulkan_->SetDebugName(depth_.image, VK_OBJECT_TYPE_IMAGE, "BackbufferDepth");
+
+	TransitionImageLayout2(cmd, depth_.image, 0, 1,
+		aspectMask,
+		VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL,
+		VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+		VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+		0, VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+
+	VkImageViewCreateInfo depth_view_info = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
+	depth_view_info.image = depth_.image;
+	depth_view_info.format = depth_format;
+	depth_view_info.components.r = VK_COMPONENT_SWIZZLE_IDENTITY;
+	depth_view_info.components.g = VK_COMPONENT_SWIZZLE_IDENTITY;
+	depth_view_info.components.b = VK_COMPONENT_SWIZZLE_IDENTITY;
+	depth_view_info.components.a = VK_COMPONENT_SWIZZLE_IDENTITY;
+	depth_view_info.subresourceRange.aspectMask = aspectMask;
+	depth_view_info.subresourceRange.baseMipLevel = 0;
+	depth_view_info.subresourceRange.levelCount = 1;
+	depth_view_info.subresourceRange.baseArrayLayer = 0;
+	depth_view_info.subresourceRange.layerCount = 1;
+	depth_view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+	depth_view_info.flags = 0;
+
+	VkDevice device = vulkan_->GetDevice();
+
+	res = vkCreateImageView(device, &depth_view_info, NULL, &depth_.view);
+	_dbg_assert_(res == VK_SUCCESS);
+	if (res != VK_SUCCESS)
+		return false;
+
+	return true;
+}
+
+
+void VulkanQueueRunner::DestroyBackBuffers() {
+	for (auto &image : swapchainImages_) {
+		vulkan_->Delete().QueueDeleteImageView(image.view);
+	}
+	swapchainImages_.clear();
+
+	if (depth_.view) {
+		vulkan_->Delete().QueueDeleteImageView(depth_.view);
+	}
+	if (depth_.image) {
+		_dbg_assert_(depth_.alloc);
+		vulkan_->Delete().QueueDeleteImageAllocation(depth_.image, depth_.alloc);
+	}
+	depth_ = {};
+	for (uint32_t i = 0; i < framebuffers_.size(); i++) {
+		_dbg_assert_(framebuffers_[i] != VK_NULL_HANDLE);
+		vulkan_->Delete().QueueDeleteFramebuffer(framebuffers_[i]);
+	}
+	framebuffers_.clear();
+
+	INFO_LOG(G3D, "Backbuffers destroyed");
+}
+
 static VkAttachmentLoadOp ConvertLoadAction(VKRRenderPassLoadAction action) {
 	switch (action) {
 	case VKRRenderPassLoadAction::CLEAR:     return VK_ATTACHMENT_LOAD_OP_CLEAR;
@@ -399,6 +564,8 @@ void VulkanQueueRunner::RunSteps(FrameData &frameData) {
 				_dbg_assert_(!frameData.hasPresentCommands);
 				if (!frameData.hasPresentCommands) {
 					frameData.hasPresentCommands = true;
+					frameData.AcquireNextImage(vulkan_);
+					SetBackbuffer(framebuffers_[frameData.curSwapchainImage], swapchainImages_[frameData.curSwapchainImage].image);
 					VkCommandBufferBeginInfo begin{ VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
 					begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
 					vkBeginCommandBuffer(frameData.presentCmd, &begin);

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -17,6 +17,7 @@ class VKRFramebuffer;
 struct VKRGraphicsPipeline;
 struct VKRComputePipeline;
 struct VKRImage;
+struct FrameData;
 
 enum {
 	QUEUE_HACK_MGS2_ACID = 1,
@@ -250,7 +251,7 @@ public:
 	}
 
 	void PreprocessSteps(std::vector<VKRStep *> &steps);
-	void RunSteps(VkCommandBuffer cmd, VkCommandBuffer presentCmd, bool *hasPresentCommands, std::vector<VKRStep *> &steps, QueueProfileContext *profile);
+	void RunSteps(FrameData &frameData);
 	void LogSteps(const std::vector<VKRStep *> &steps, bool verbose);
 
 	std::string StepToString(const VKRStep &step) const;

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -257,7 +257,7 @@ public:
 	}
 
 	void PreprocessSteps(std::vector<VKRStep *> &steps);
-	void RunSteps(VkCommandBuffer cmd, std::vector<VKRStep *> &steps, QueueProfileContext *profile);
+	void RunSteps(VkCommandBuffer cmd, VkCommandBuffer presentCmd, bool *hasPresentCommands, std::vector<VKRStep *> &steps, QueueProfileContext *profile);
 	void LogSteps(const std::vector<VKRStep *> &steps, bool verbose);
 
 	std::string StepToString(const VKRStep &step) const;

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -259,6 +259,14 @@ public:
 	void CreateDeviceObjects();
 	void DestroyDeviceObjects();
 
+	// Swapchain
+	void DestroyBackBuffers();
+	bool CreateSwapchain(VkCommandBuffer cmdInit);
+
+	bool HasBackbuffers() const {
+		return !framebuffers_.empty();
+	}
+
 	// Get a render pass that's compatible with all our framebuffers.
 	// Note that it's precached, cannot look up in the map as this might be on another thread.
 	VKRRenderPass *GetCompatibleRenderPass() const {
@@ -298,6 +306,9 @@ public:
 	}
 
 private:
+	bool InitBackbufferFramebuffers(int width, int height);
+	bool InitDepthStencilBuffer(VkCommandBuffer cmd);  // Used for non-buffered rendering.
+
 	VKRRenderPass *PerformBindFramebufferAsRenderTarget(const VKRStep &pass, VkCommandBuffer cmd);
 	void PerformRenderPass(const VKRStep &pass, VkCommandBuffer cmd);
 	void PerformCopy(const VKRStep &pass, VkCommandBuffer cmd);
@@ -352,4 +363,20 @@ private:
 	// Stored here to help reuse the allocation.
 
 	VulkanBarrier recordBarrier_;
+
+	// Swap chain management
+	struct SwapchainImageData {
+		VkImage image;
+		VkImageView view;
+	};
+	std::vector<VkFramebuffer> framebuffers_;
+	std::vector<SwapchainImageData> swapchainImages_;
+	uint32_t swapchainImageCount_ = 0;
+	struct DepthBufferInfo {
+		VkFormat format = VK_FORMAT_UNDEFINED;
+		VkImage image = VK_NULL_HANDLE;
+		VmaAllocation alloc = VK_NULL_HANDLE;
+		VkImageView view = VK_NULL_HANDLE;
+	};
+	DepthBufferInfo depth_;
 };

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -8,6 +8,7 @@
 #include "Common/Data/Collections/Hashmaps.h"
 #include "Common/GPU/Vulkan/VulkanContext.h"
 #include "Common/GPU/Vulkan/VulkanBarrier.h"
+#include "Common/GPU/Vulkan/VulkanFrameData.h"
 #include "Common/Data/Convert/SmallDataConvert.h"
 #include "Common/Data/Collections/TinySet.h"
 #include "Common/GPU/DataFormat.h"
@@ -147,14 +148,6 @@ struct TransitionRequest {
 	VKRFramebuffer *fb;
 	VkImageAspectFlags aspect;  // COLOR or DEPTH
 	VkImageLayout targetLayout;
-};
-
-struct QueueProfileContext {
-	VkQueryPool queryPool;
-	std::vector<std::string> timestampDescriptions;
-	std::string profileSummary;
-	double cpuStartTime;
-	double cpuEndTime;
 };
 
 class VKRRenderPass;

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -1433,7 +1433,6 @@ void VulkanRenderManager::Run(int frame) {
 void VulkanRenderManager::EndSyncFrame(int frame) {
 	FrameData &frameData = frameData_[frame];
 
-	_dbg_assert_(!frameData.hasPresentCommands);
 	frameData.readbackFenceUsed = true;
 
 	// The submit will trigger the readbackFence.

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -1562,12 +1562,10 @@ void VulkanRenderManager::Run(int frame) {
 	BeginSubmitFrame(frame);
 
 	FrameData &frameData = frameData_[frame];
-	auto &stepsOnThread = frameData_[frame].steps;
 	VkCommandBuffer cmd = frameData.mainCmd;
-	queueRunner_.PreprocessSteps(stepsOnThread);
+	queueRunner_.PreprocessSteps(frameData_[frame].steps);
 	//queueRunner_.LogSteps(stepsOnThread, false);
-	queueRunner_.RunSteps(cmd, frameData.presentCmd, &frameData.hasPresentCommands, stepsOnThread, frameData.profilingEnabled_ ? &frameData.profile : nullptr);
-	stepsOnThread.clear();
+	queueRunner_.RunSteps(frameData);
 
 	switch (frameData.type) {
 	case VKRRunType::END:

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -507,10 +507,14 @@ private:
 		// These are on different threads so need separate pools.
 		VkCommandPool cmdPoolInit;  // Written to from main thread
 		VkCommandPool cmdPoolMain;  // Written to from render thread, which also submits
+
 		VkCommandBuffer initCmd;
 		VkCommandBuffer mainCmd;
+		VkCommandBuffer presentCmd;
 
 		bool hasInitCommands = false;
+		bool hasPresentCommands = false;
+
 		std::vector<VKRStep *> steps;
 
 		// Swapchain.

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -65,11 +65,6 @@ private:
 	std::string tag_;
 };
 
-enum class VKRRunType {
-	END,
-	SYNC,
-};
-
 enum {
 	MAX_TIMESTAMP_QUERIES = 128,
 };
@@ -486,45 +481,6 @@ private:
 	// Permanent objects
 	VkSemaphore acquireSemaphore_;
 	VkSemaphore renderingCompleteSemaphore_;
-
-	// Per-frame data, round-robin so we can overlap submission with execution of the previous frame.
-	struct FrameData {
-		std::mutex push_mutex;
-		std::condition_variable push_condVar;
-
-		std::mutex pull_mutex;
-		std::condition_variable pull_condVar;
-
-		bool readyForFence = true;
-		bool readyForRun = false;
-		bool skipSwap = false;
-		VKRRunType type = VKRRunType::END;
-
-		VkFence fence;
-		VkFence readbackFence;  // Strictly speaking we might only need one of these.
-		bool readbackFenceUsed = false;
-
-		// These are on different threads so need separate pools.
-		VkCommandPool cmdPoolInit;  // Written to from main thread
-		VkCommandPool cmdPoolMain;  // Written to from render thread, which also submits
-
-		VkCommandBuffer initCmd;
-		VkCommandBuffer mainCmd;
-		VkCommandBuffer presentCmd;
-
-		bool hasInitCommands = false;
-		bool hasPresentCommands = false;
-
-		std::vector<VKRStep *> steps;
-
-		// Swapchain.
-		bool hasBegun = false;
-		uint32_t curSwapchainImage = -1;
-
-		// Profiling.
-		QueueProfileContext profile;
-		bool profilingEnabled_;
-	};
 
 	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES];
 	int newInflightFrames_ = -1;

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -445,10 +445,6 @@ public:
 		return !framebuffers_.empty();
 	}
 
-	void SetSplitSubmit(bool split) {
-		splitSubmit_ = split;
-	}
-
 	void SetInflightFrames(int f) {
 		newInflightFrames_ = f < 1 || f > VulkanContext::MAX_INFLIGHT_FRAMES ? VulkanContext::MAX_INFLIGHT_FRAMES : f;
 	}
@@ -479,6 +475,7 @@ private:
 	void BeginSubmitFrame(int frame);
 	void EndSubmitFrame(int frame);
 	void Submit(int frame, bool triggerFence);
+	void SubmitInitCommands(int frame);
 
 	// Bad for performance but sometimes necessary for synchronous CPU readbacks (screenshots and whatnot).
 	void FlushSync();
@@ -508,10 +505,11 @@ private:
 		bool readbackFenceUsed = false;
 
 		// These are on different threads so need separate pools.
-		VkCommandPool cmdPoolInit;
-		VkCommandPool cmdPoolMain;
+		VkCommandPool cmdPoolInit;  // Written to from main thread
+		VkCommandPool cmdPoolMain;  // Written to from render thread, which also submits
 		VkCommandBuffer initCmd;
 		VkCommandBuffer mainCmd;
+
 		bool hasInitCommands = false;
 		std::vector<VKRStep *> steps;
 
@@ -550,7 +548,6 @@ private:
 	BoundingRect curRenderArea_;
 
 	std::vector<VKRStep *> steps_;
-	bool splitSubmit_ = false;
 
 	// Execution time state
 	bool run_ = true;

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -437,7 +437,7 @@ public:
 	void DestroyBackbuffers();
 
 	bool HasBackbuffers() {
-		return !framebuffers_.empty();
+		return queueRunner_.HasBackbuffers();
 	}
 
 	void SetInflightFrames(int f) {
@@ -463,8 +463,6 @@ public:
 	}
 
 private:
-	bool InitBackbufferFramebuffers(int width, int height);
-	bool InitDepthStencilBuffer(VkCommandBuffer cmd);  // Used for non-buffered rendering.
 	void EndCurRenderStep();
 
 	void BeginSubmitFrame(int frame);
@@ -528,22 +526,5 @@ private:
 	// pipelines to check and possibly create at the end of the current render pass.
 	std::vector<VKRGraphicsPipeline *> pipelinesToCheck_;
 
-	// Swap chain management
-	struct SwapchainImageData {
-		VkImage image;
-		VkImageView view;
-	};
-	std::vector<VkFramebuffer> framebuffers_;
-	std::vector<SwapchainImageData> swapchainImages_;
-	uint32_t swapchainImageCount_ = 0;
-	struct DepthBufferInfo {
-		VkFormat format = VK_FORMAT_UNDEFINED;
-		VkImage image = VK_NULL_HANDLE;
-		VmaAllocation alloc = VK_NULL_HANDLE;
-		VkImageView view = VK_NULL_HANDLE;
-	};
-	DepthBufferInfo depth_;
-
-	// This works great - except see issue #10097. WTF?
 	bool useThread_ = true;
 };

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -361,7 +361,7 @@ class VKFramebuffer;
 
 class VKContext : public DrawContext {
 public:
-	VKContext(VulkanContext *vulkan, bool splitSubmit);
+	VKContext(VulkanContext *vulkan);
 	virtual ~VKContext();
 
 	const DeviceCaps &GetDeviceCaps() const override {
@@ -762,7 +762,7 @@ bool VKTexture::Create(VkCommandBuffer cmd, VulkanPushBuffer *push, const Textur
 	return true;
 }
 
-VKContext::VKContext(VulkanContext *vulkan, bool splitSubmit)
+VKContext::VKContext(VulkanContext *vulkan)
 	: vulkan_(vulkan), renderManager_(vulkan) {
 	shaderLanguageDesc_.Init(GLSL_VULKAN);
 
@@ -914,8 +914,6 @@ VKContext::VKContext(VulkanContext *vulkan, bool splitSubmit)
 	VkPipelineCacheCreateInfo pc{ VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO };
 	res = vkCreatePipelineCache(vulkan_->GetDevice(), &pc, nullptr, &pipelineCache_);
 	_assert_(VK_SUCCESS == res);
-
-	renderManager_.SetSplitSubmit(splitSubmit);
 }
 
 VKContext::~VKContext() {
@@ -1395,8 +1393,8 @@ void VKContext::Clear(int clearMask, uint32_t colorval, float depthVal, int sten
 	renderManager_.Clear(colorval, depthVal, stencilVal, mask);
 }
 
-DrawContext *T3DCreateVulkanContext(VulkanContext *vulkan, bool split) {
-	return new VKContext(vulkan, split);
+DrawContext *T3DCreateVulkanContext(VulkanContext *vulkan) {
+	return new VKContext(vulkan);
 }
 
 void AddFeature(std::vector<std::string> &features, const char *name, VkBool32 available, VkBool32 enabled) {

--- a/Common/GPU/thin3d_create.h
+++ b/Common/GPU/thin3d_create.h
@@ -31,6 +31,6 @@ DrawContext *T3DCreateDX9Context(IDirect3D9 *d3d, IDirect3D9Ex *d3dEx, int adapt
 DrawContext *T3DCreateD3D11Context(ID3D11Device *device, ID3D11DeviceContext *context, ID3D11Device1 *device1, ID3D11DeviceContext1 *context1, D3D_FEATURE_LEVEL featureLevel, HWND hWnd, std::vector<std::string> adapterNames);
 #endif
 
-DrawContext *T3DCreateVulkanContext(VulkanContext *context, bool splitSubmit);
+DrawContext *T3DCreateVulkanContext(VulkanContext *context);
 
 }  // namespace Draw

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -938,7 +938,6 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("FragmentTestCache", &g_Config.bFragmentTestCache, true, true, true),
 
 	ConfigSetting("GfxDebugOutput", &g_Config.bGfxDebugOutput, false, false, false),
-	ConfigSetting("GfxDebugSplitSubmit", &g_Config.bGfxDebugSplitSubmit, false, false, false),
 	ConfigSetting("LogFrameDrops", &g_Config.bLogFrameDrops, false, true, false),
 
 	ConfigSetting("InflightFrames", &g_Config.iInflightFrames, 3, true, false),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -176,6 +176,7 @@ public:
 	bool bSustainedPerformanceMode;  // Android: Slows clocks down to avoid overheating/speed fluctuations.
 	bool bIgnoreScreenInsets;  // Android: Center screen disregarding insets if this is enabled.
 	bool bVSync;
+
 	int iFrameSkip;
 	int iFrameSkipType;
 	int iFastForwardMode; // See FastForwardMode in ConfigValues.h.
@@ -242,7 +243,6 @@ public:
 	bool bShaderChainRequires60FPS;
 	std::string sTextureShaderName;
 	bool bGfxDebugOutput;
-	bool bGfxDebugSplitSubmit;
 	int iInflightFrames;
 	bool bRenderDuplicateFrames;
 

--- a/SDL/SDLVulkanGraphicsContext.cpp
+++ b/SDL/SDLVulkanGraphicsContext.cpp
@@ -116,7 +116,7 @@ bool SDLVulkanGraphicsContext::Init(SDL_Window *&window, int x, int y, int mode,
 		return false;
 	}
 
-	draw_ = Draw::T3DCreateVulkanContext(vulkan_, false);
+	draw_ = Draw::T3DCreateVulkanContext(vulkan_);
 	SetGPUBackend(GPUBackend::VULKAN);
 	bool success = draw_->CreatePresets();
 	_assert_(success);

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -131,9 +131,7 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 		return false;
 	}
 
-	bool splitSubmit = g_Config.bGfxDebugSplitSubmit;
-
-	draw_ = Draw::T3DCreateVulkanContext(vulkan_, splitSubmit);
+	draw_ = Draw::T3DCreateVulkanContext(vulkan_);
 	SetGPUBackend(GPUBackend::VULKAN, vulkan_->GetPhysicalDeviceProperties(deviceNum).properties.deviceName);
 	bool success = draw_->CreatePresets();
 	_assert_msg_(success, "Failed to compile preset shaders");

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -51,6 +51,7 @@ VULKAN_FILES := \
   $(SRC)/Common/GPU/Vulkan/thin3d_vulkan.cpp \
   $(SRC)/Common/GPU/Vulkan/VulkanQueueRunner.cpp \
   $(SRC)/Common/GPU/Vulkan/VulkanRenderManager.cpp \
+  $(SRC)/Common/GPU/Vulkan/VulkanFrameData.cpp \
   $(SRC)/Common/GPU/Vulkan/VulkanLoader.cpp \
   $(SRC)/Common/GPU/Vulkan/VulkanContext.cpp \
   $(SRC)/Common/GPU/Vulkan/VulkanDebug.cpp \

--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -101,7 +101,7 @@ bool AndroidVulkanContext::InitFromRenderThread(ANativeWindow *wnd, int desiredB
 
 	bool success = true;
 	if (g_Vulkan->InitSwapchain()) {
-		draw_ = Draw::T3DCreateVulkanContext(g_Vulkan, g_Config.bGfxDebugSplitSubmit);
+		draw_ = Draw::T3DCreateVulkanContext(g_Vulkan);
 		SetGPUBackend(GPUBackend::VULKAN);
 		success = draw_->CreatePresets();  // Doesn't fail, we ship the compiler.
 		_assert_msg_(success, "Failed to compile preset shaders");

--- a/libretro/LibretroVulkanContext.cpp
+++ b/libretro/LibretroVulkanContext.cpp
@@ -137,7 +137,7 @@ void LibretroVulkanContext::CreateDrawContext() {
       return;
    }
 
-   draw_ = Draw::T3DCreateVulkanContext(vk, false);
+   draw_ = Draw::T3DCreateVulkanContext(vk);
    ((VulkanRenderManager*)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER))->SetInflightFrames(g_Config.iInflightFrames);
    SetGPUBackend(GPUBackend::VULKAN);
 }

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -253,6 +253,7 @@ SOURCES_CXX += \
 	$(COMMONDIR)/GPU/Vulkan/thin3d_vulkan.cpp \
 	$(COMMONDIR)/GPU/Vulkan/VulkanQueueRunner.cpp \
 	$(COMMONDIR)/GPU/Vulkan/VulkanRenderManager.cpp \
+	$(COMMONDIR)/GPU/Vulkan/VulkanFrameData.cpp \
 	$(COMMONDIR)/GPU/Vulkan/VulkanLoader.cpp \
 	$(COMMONDIR)/GPU/Vulkan/VulkanContext.cpp \
 	$(COMMONDIR)/GPU/Vulkan/VulkanDebug.cpp \


### PR DESCRIPTION
This is good for CPU/GPU parallelism, although does open for even slightly more latency (though probably hardly noticeable). That point I plan to address with some automatic regulation of the queue length between the CPU and GPU later.

To do this, we've now split frame submission into three command buffers, from previous two:

init, main, present.

So we can now submit both init and main to the GPU before acquiring the image (which might take a short while on Android). In the meantime the GPU can do work. Also we now submit init before starting to encode the main command buffer.

~Will test a bit on mobile before merge.~ Seems to work perfectly.