### PR TITLE
Add OSM progress display for GamedataInstall

### DIFF
--- a/Core/Dialog/PSPGamedataInstallDialog.cpp
+++ b/Core/Dialog/PSPGamedataInstallDialog.cpp
@@ -25,6 +25,8 @@
 #include "Core/System.h"
 #include "Core/FileSystems/MetaFileSystem.h"
 #include "Core/Dialog/PSPGamedataInstallDialog.h"
+#include "Common/Data/Text/I18n.h"
+#include "UI/OnScreenDisplay.h"
 
 std::string saveBasePath = "ms0:/PSP/SAVEDATA/";
 
@@ -250,7 +252,9 @@ void PSPGamedataInstallDialog::UpdateProgress() {
 		progressValue = (int)((allReadSize * 100) / allFilesSize);
 	else 
 		progressValue = 100;
-
+	auto di = GetI18NCategory("Dialog");
+	std::string temp = di->T("Save");
+	osm.Show(temp + " "  + std::to_string(progressValue) + " / 100", 0.5f);
 	param->progress = progressValue;
 	param.NotifyWrite("DialogResult");
 }


### PR DESCRIPTION
fix #14688
![1](https://user-images.githubusercontent.com/2177532/190859222-f8f9fe8b-824b-4028-b800-237da109001a.png)
