### PR TITLE
Switch headless screenshot error to MSE, add benchmarking

### DIFF
--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -128,13 +128,9 @@ int printUsage(const char *progname, const char *reason)
 	fprintf(stderr, "  -l, --log             full log output, not just emulated printfs\n");
 	fprintf(stderr, " --debugger=PORT        enable websocket debugger and break at start\n");
 
-#if defined(HEADLESSHOST_CLASS)
-	{
-		fprintf(stderr, "  --graphics=BACKEND    use the full gpu backend (slower)\n");
-		fprintf(stderr, "                        options: gles, software, directx9, etc.\n");
-		fprintf(stderr, "  --screenshot=FILE     compare against a screenshot\n");
-	}
-#endif
+	fprintf(stderr, "  --graphics=BACKEND    use a different gpu backend\n");
+	fprintf(stderr, "                        options: gles, software, directx9, etc.\n");
+	fprintf(stderr, "  --screenshot=FILE     compare against a screenshot\n");
 	fprintf(stderr, "  --timeout=SECONDS     abort test it if takes longer than SECONDS\n");
 
 	fprintf(stderr, "  -v, --verbose         show the full passed/failed result\n");
@@ -161,13 +157,18 @@ static HeadlessHost *getHost(GPUCore gpuCore) {
 	}
 }
 
-bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool autoCompare, bool verbose, double timeout)
-{
+struct AutoTestOptions {
+	double timeout;
+	bool compare : 1;
+	bool verbose : 1;
+};
+
+bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, const AutoTestOptions &opt) {
 	// Kinda ugly, trying to guesstimate the test name from filename...
 	currentTestName = GetTestName(coreParameter.fileToStart);
 
 	std::string output;
-	if (autoCompare)
+	if (opt.compare)
 		coreParameter.collectEmuLog = &output;
 
 	std::string error_string;
@@ -183,7 +184,7 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool 
 
 	host->BootDone();
 
-	if (autoCompare)
+	if (opt.compare)
 		headlessHost->SetComparisonScreenshot(ExpectedScreenshotFromFilename(coreParameter.fileToStart));
 
 	while (!PSP_InitUpdate(&error_string))
@@ -196,8 +197,7 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool 
 	}
 
 	bool passed = true;
-	double deadline;
-	deadline = time_now_d() + timeout;
+	double deadline = time_now_d() + opt.timeout;
 
 	Core_UpdateDebugStats(g_Config.bShowDebugStats || g_Config.bLogFrameDrops);
 
@@ -239,8 +239,8 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, bool 
 
 	headlessHost->FlushDebugOutput();
 
-	if (autoCompare && passed)
-		passed = CompareOutput(coreParameter.fileToStart, output, verbose);
+	if (opt.compare && passed)
+		passed = CompareOutput(coreParameter.fileToStart, output, opt.verbose);
 
 	TeamCityPrint("testFinished name='%s'", currentTestName.c_str());
 
@@ -263,9 +263,9 @@ int main(int argc, const char* argv[])
 	_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 #endif
 
+	AutoTestOptions testOptions{};
+	testOptions.timeout = std::numeric_limits<double>::infinity();
 	bool fullLog = false;
-	bool autoCompare = false;
-	bool verbose = false;
 	const char *stateToLoad = 0;
 	GPUCore gpuCore = GPUCORE_SOFTWARE;
 	CPUCore cpuCore = CPUCore::JIT;
@@ -275,7 +275,6 @@ int main(int argc, const char* argv[])
 	const char *mountIso = nullptr;
 	const char *mountRoot = nullptr;
 	const char *screenshotFilename = nullptr;
-	float timeout = std::numeric_limits<float>::infinity();
 
 	for (int i = 1; i < argc; i++)
 	{
@@ -300,9 +299,9 @@ int main(int argc, const char* argv[])
 		else if (!strcmp(argv[i], "--ir"))
 			cpuCore = CPUCore::IR_JIT;
 		else if (!strcmp(argv[i], "-c") || !strcmp(argv[i], "--compare"))
-			autoCompare = true;
+			testOptions.compare = true;
 		else if (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--verbose"))
-			verbose = true;
+			testOptions.verbose = true;
 		else if (!strncmp(argv[i], "--graphics=", strlen("--graphics=")) && strlen(argv[i]) > strlen("--graphics="))
 		{
 			const char *gpuName = argv[i] + strlen("--graphics=");
@@ -330,7 +329,7 @@ int main(int argc, const char* argv[])
 		} else if (!strncmp(argv[i], "--screenshot=", strlen("--screenshot=")) && strlen(argv[i]) > strlen("--screenshot="))
 			screenshotFilename = argv[i] + strlen("--screenshot=");
 		else if (!strncmp(argv[i], "--timeout=", strlen("--timeout=")) && strlen(argv[i]) > strlen("--timeout="))
-			timeout = (float)strtod(argv[i] + strlen("--timeout="), NULL);
+			testOptions.timeout = strtod(argv[i] + strlen("--timeout="), nullptr);
 		else if (!strncmp(argv[i], "--debugger=", strlen("--debugger=")) && strlen(argv[i]) > strlen("--debugger="))
 			debuggerPort = (int)strtoul(argv[i] + strlen("--debugger="), NULL, 10);
 		else if (!strcmp(argv[i], "--teamcity"))
@@ -388,7 +387,7 @@ int main(int argc, const char* argv[])
 	coreParameter.mountIso = mountIso ? Path(std::string(mountIso)) : Path();
 	coreParameter.mountRoot = mountRoot ? Path(std::string(mountRoot)) : Path();
 	coreParameter.startBreak = false;
-	coreParameter.printfEmuLog = !autoCompare;
+	coreParameter.printfEmuLog = !testOptions.compare;
 	coreParameter.headLess = true;
 	coreParameter.renderScaleFactor = 1;
 	coreParameter.renderWidth = 480;
@@ -487,11 +486,10 @@ int main(int argc, const char* argv[])
 	for (size_t i = 0; i < testFilenames.size(); ++i)
 	{
 		coreParameter.fileToStart = Path(testFilenames[i]);
-		if (autoCompare)
+		if (testOptions.compare)
 			printf("%s:\n", coreParameter.fileToStart.c_str());
-		bool passed = RunAutoTest(headlessHost, coreParameter, autoCompare, verbose, timeout);
-		if (autoCompare)
-		{
+		bool passed = RunAutoTest(headlessHost, coreParameter, testOptions);
+		if (testOptions.compare) {
 			std::string testName = GetTestName(coreParameter.fileToStart);
 			if (passed)
 			{
@@ -503,8 +501,7 @@ int main(int argc, const char* argv[])
 		}
 	}
 
-	if (autoCompare)
-	{
+	if (testOptions.compare) {
 		printf("%d tests passed, %d tests failed.\n", (int)passedTests.size(), (int)failedTests.size());
 		if (!failedTests.empty())
 		{

--- a/headless/StubHost.cpp
+++ b/headless/StubHost.cpp
@@ -57,7 +57,7 @@ void HeadlessHost::SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h) {
 	if (errors > maxScreenshotError_)
 		SendOrCollectDebugOutput(StringFromFormat("Screenshot MSE: %f\n", errors));
 
-	if (errors > maxScreenshotError_ && !teamCityMode && !getenv("GITHUB_ACTIONS")) {
+	if (errors > maxScreenshotError_ && writeFailureScreenshot_) {
 		if (comparer.SaveActualBitmap(Path("__testfailure.bmp")))
 			SendOrCollectDebugOutput("Actual output written to: __testfailure.bmp\n");
 		comparer.SaveVisualComparisonPNG(Path("__testcompare.png"));

--- a/headless/StubHost.cpp
+++ b/headless/StubHost.cpp
@@ -54,10 +54,10 @@ void HeadlessHost::SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h) {
 	if (errors < 0)
 		SendOrCollectDebugOutput(comparer.GetError() + "\n");
 
-	if (errors > 0)
+	if (errors > maxScreenshotError_)
 		SendOrCollectDebugOutput(StringFromFormat("Screenshot MSE: %f\n", errors));
 
-	if (errors > 0 && !teamCityMode && !getenv("GITHUB_ACTIONS")) {
+	if (errors > maxScreenshotError_ && !teamCityMode && !getenv("GITHUB_ACTIONS")) {
 		if (comparer.SaveActualBitmap(Path("__testfailure.bmp")))
 			SendOrCollectDebugOutput("Actual output written to: __testfailure.bmp\n");
 		comparer.SaveVisualComparisonPNG(Path("__testcompare.png"));

--- a/headless/StubHost.cpp
+++ b/headless/StubHost.cpp
@@ -55,7 +55,7 @@ void HeadlessHost::SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h) {
 		SendOrCollectDebugOutput(comparer.GetError() + "\n");
 
 	if (errors > 0)
-		SendOrCollectDebugOutput(StringFromFormat("Screenshot error: %f%%\n", errors * 100.0f));
+		SendOrCollectDebugOutput(StringFromFormat("Screenshot MSE: %f\n", errors));
 
 	if (errors > 0 && !teamCityMode && !getenv("GITHUB_ACTIONS")) {
 		if (comparer.SaveActualBitmap(Path("__testfailure.bmp")))

--- a/headless/StubHost.h
+++ b/headless/StubHost.h
@@ -68,8 +68,9 @@ public:
 		}
 	}
 
-	virtual void SetComparisonScreenshot(const Path &filename) {
+	void SetComparisonScreenshot(const Path &filename, double maxError) {
 		comparisonScreenshot_ = filename;
+		maxScreenshotError_ = maxError;
 	}
 
 	void SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h) override;
@@ -83,6 +84,7 @@ protected:
 	void SendOrCollectDebugOutput(const std::string &output);
 
 	Path comparisonScreenshot_;
+	double maxScreenshotError_ = 0.0;
 	std::string debugOutputBuffer_;
 	GPUCore gpuCore_;
 	GraphicsContext *gfx_ = nullptr;

--- a/headless/StubHost.h
+++ b/headless/StubHost.h
@@ -72,6 +72,9 @@ public:
 		comparisonScreenshot_ = filename;
 		maxScreenshotError_ = maxError;
 	}
+	void SetWriteFailureScreenshot(bool flag) {
+		writeFailureScreenshot_ = flag;
+	}
 
 	void SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h) override;
 
@@ -88,4 +91,5 @@ protected:
 	std::string debugOutputBuffer_;
 	GPUCore gpuCore_;
 	GraphicsContext *gfx_ = nullptr;
+	bool writeFailureScreenshot_ = true;
 };


### PR DESCRIPTION
This allows you to run a frame dump or test to get an average time taken, which can be convenient for comparing the relative performance of two changes.

It also returns screenshot differences as mean squared error instead of the previous simple % of pixels that are not exact matches.  I considered PSNR, but I feel like the output is less obvious for what a "pass" means.  There's also an option to tolerate a certain amount of MSE, which can be helpful when comparing things that might have small differences (i.e. hardware rendering.)

-[Unknown]