### PR TITLE
GE Debugger: Allow search by state name

### DIFF
--- a/Windows/W32Util/Misc.h
+++ b/Windows/W32Util/Misc.h
@@ -68,6 +68,8 @@ protected:
 	virtual bool OnRowPrePaint(int row, LPNMLVCUSTOMDRAW msg) { return false; }
 	virtual bool OnColPrePaint(int row, int col, LPNMLVCUSTOMDRAW msg) { return false; }
 
+	virtual int OnIncrementalSearch(int startRow, const wchar_t *str, bool wrap, bool partial);
+
 private:
 	static LRESULT CALLBACK wndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 	void ProcessUpdate();


### PR DESCRIPTION
This has been bugging me, sometimes I want to look at the vertex type and finding it in the list is annoying.  I realized it stopped working because we added the breakpoint as the first column.

This handles the search and simply applies it to each column (trying all rows for the leftmost column before going to the next column.)  Affects the other lists in the debugger, but not really in a bad way.

-[Unknown]