### PR TITLE
softgpu: Correct line early z checks

### DIFF
--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1365,7 +1365,7 @@ void DrawLine(const VertexData &v0, const VertexData &v1, const BinCoords &range
 						maskOK = false;
 				}
 
-				if (!CheckDepthTestPassed(pixelID.DepthTestFunc(), x, y, pixelID.cached.depthbufStride, z)) {
+				if (!CheckDepthTestPassed(pixelID.DepthTestFunc(), p.x, p.y, pixelID.cached.depthbufStride, z)) {
 					maskOK = false;
 				}
 			}


### PR DESCRIPTION
Stupid mistake.  Was looking at completely wrong pixels, x/y are with subpixel and p.x/p.y are without.

Can be seen in the frame dump from #11216, was allowing the grid to go outside the map circle.

-[Unknown]