### PR TITLE
Fix the UI setting "Buffer graphics commands". Was off by 1.

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -469,7 +469,7 @@ void GameSettingsScreen::CreateViews() {
 
 	if (GetGPUBackend() == GPUBackend::VULKAN || GetGPUBackend() == GPUBackend::OPENGL) {
 		static const char *bufferOptions[] = { "No buffer", "Up to 1", "Up to 2" };
-		PopupMultiChoice *inflightChoice = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iInflightFrames, gr->T("Buffer graphics commands (faster, input lag)"), bufferOptions, 0, ARRAY_SIZE(bufferOptions), gr->GetName(), screenManager()));
+		PopupMultiChoice *inflightChoice = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iInflightFrames, gr->T("Buffer graphics commands (faster, input lag)"), bufferOptions, 1, ARRAY_SIZE(bufferOptions), gr->GetName(), screenManager()));
 		inflightChoice->OnChoice.Handle(this, &GameSettingsScreen::OnInflightFramesChoice);
 	}
 


### PR DESCRIPTION
The default value is correct at 3, but there was no way to get back to it, since the maximum choice was 2 - well, you could pick 0 which was an invalid option and would result in 3.

Discovered this using my new timeline profiler, separate PR tomorrow. Didn't see the expected 3 frame types.

Now, looks better:

![image](https://user-images.githubusercontent.com/130929/190931418-aabd134d-3eda-4333-9623-4fbe1c194ce9.png)

(I do realize the UI is not super legible on top of that background, or at all. Will improve).


