### PR TITLE
Gamedata: Cleanup install request args/validate

### DIFF
--- a/Core/Dialog/PSPGamedataInstallDialog.h
+++ b/Core/Dialog/PSPGamedataInstallDialog.h
@@ -22,7 +22,7 @@
 
 struct SceUtilityGamedataInstallParam {
 	pspUtilityDialogCommon common;
-	u32_le unknown1;
+	s32_le mode;
 	char gameName[13];
 	char ignore1[3];
 	char dataName[20];

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -744,11 +744,14 @@ static int sceUtilityGamedataInstallInitStart(u32 paramsAddr) {
 	}
 
 	ActivateDialog(UtilityDialogType::GAMEDATAINSTALL);
-	return hleLogSuccessInfoX(SCEUTILITY, gamedataInstallDialog->Init(paramsAddr));
+	int result = gamedataInstallDialog->Init(paramsAddr);
+	if (result < 0)
+		DeactivateDialog();
+	return hleLogSuccessInfoX(SCEUTILITY, result);
 }
 
 static int sceUtilityGamedataInstallShutdownStart() {
-	if (currentDialogType != UtilityDialogType::GAMEDATAINSTALL) {
+	if (!currentDialogActive || currentDialogType != UtilityDialogType::GAMEDATAINSTALL) {
 		return hleLogWarning(SCEUTILITY, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 	
@@ -757,7 +760,7 @@ static int sceUtilityGamedataInstallShutdownStart() {
 }
 
 static int sceUtilityGamedataInstallUpdate(int animSpeed) {
-	if (currentDialogType != UtilityDialogType::GAMEDATAINSTALL) {
+	if (!currentDialogActive || currentDialogType != UtilityDialogType::GAMEDATAINSTALL) {
 		return hleLogWarning(SCEUTILITY, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 	
@@ -765,8 +768,9 @@ static int sceUtilityGamedataInstallUpdate(int animSpeed) {
 }
 
 static int sceUtilityGamedataInstallGetStatus() {
-	if (currentDialogType != UtilityDialogType::GAMEDATAINSTALL) {
+	if (!currentDialogActive || currentDialogType != UtilityDialogType::GAMEDATAINSTALL) {
 		// This is called incorrectly all the time by some games. So let's not bother warning.
+		hleEatCycles(200);
 		return hleLogDebug(SCEUTILITY, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 
@@ -776,7 +780,7 @@ static int sceUtilityGamedataInstallGetStatus() {
 }
 
 static int sceUtilityGamedataInstallAbort() {
-	if (currentDialogType != UtilityDialogType::GAMEDATAINSTALL) {
+	if (!currentDialogActive || currentDialogType != UtilityDialogType::GAMEDATAINSTALL) {
 		return hleLogWarning(SCEUTILITY, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 	


### PR DESCRIPTION
See #16036.  I just checked and it was the first parameter I tried for UI/not UI.  Did a little to match PSP results for init.

It should really take longer to startup/shutdown like the other dialogs, but this at least cleans it up for the UI.

-[Unknown]