### PR TITLE
GE Debugger: Save current clut in frame dumps

### DIFF
--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -34,6 +34,7 @@
 #include "Common/System/Display.h"
 #include "Common/System/NativeApp.h"
 #include "Common/System/System.h"
+#include "Common/File/FileUtil.h"
 #include "Common/File/VFS/VFS.h"
 #include "Common/File/VFS/AssetReader.h"
 #include "Common/Data/Text/I18n.h"
@@ -109,9 +110,12 @@ static std::thread inputBoxThread;
 static bool inputBoxRunning = false;
 
 void OpenDirectory(const char *path) {
+	// SHParseDisplayName can't handle relative paths, so normalize first.
+	std::string resolved = ReplaceAll(File::ResolvePath(path), "/", "\\");
+
 	SFGAOF flags;
 	PIDLIST_ABSOLUTE pidl = nullptr;
-	HRESULT hr = SHParseDisplayName(ConvertUTF8ToWString(ReplaceAll(path, "/", "\\")).c_str(), nullptr, &pidl, 0, &flags);
+	HRESULT hr = SHParseDisplayName(ConvertUTF8ToWString(resolved).c_str(), nullptr, &pidl, 0, &flags);
 
 	if (pidl) {
 		if (SUCCEEDED(hr))


### PR DESCRIPTION
See #14465.  I'm not sure about the actual graphic bug, but the frame dump initially seemed to use entirely transparent textures.  I quickly realized it never loads a CLUT anywhere in that frame dump.

Ideally, when a framebuffer is being used for CLUT, `TextureCacheCommon::GetCurrentClutBuffer()` should download from it... I suppose `framebufferManager_->DownloadFramebufferForClut()` would need to change to take a pointer.

-[Unknown]