### PR TITLE
softgpu: Reduce some flushing / flushing cost

### DIFF
--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -326,7 +326,7 @@ void BinManager::AddTriangle(const VertexData &v0, const VertexData &v1, const V
 	if (d01.x * d02.y - d01.y * d02.x < 0)
 		return;
 	// If all points have identical coords, we'll have 0 weights and not skip properly, so skip here.
-	if (d01.x == 0 && d01.y == 0 && d02.x == 0 && d02.y == 0)
+	if ((d01.x == 0 && d02.x == 0) || (d01.y == 0 && d02.y == 0))
 		return;
 
 	// Was it fully outside the scissor?

--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -474,6 +474,9 @@ void BinManager::Drain() {
 }
 
 void BinManager::Flush(const char *reason) {
+	if (queueRange_.x1 == 0x7FFFFFFF)
+		return;
+
 	double st;
 	if (coreCollectDebugStats)
 		st = time_now_d();

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -1006,19 +1006,24 @@ void SoftGPU::Execute_LoadClut(u32 op, u32 diff) {
 
 void SoftGPU::Execute_FramebufPtr(u32 op, u32 diff) {
 	// We assume fb.data won't change while we're drawing.
-	drawEngine_->transformUnit.Flush("framebuf");
-	fb.data = Memory::GetPointerWrite(gstate.getFrameBufAddress());
+	if (diff) {
+		drawEngine_->transformUnit.Flush("framebuf");
+		fb.data = Memory::GetPointerWrite(gstate.getFrameBufAddress());
+	}
 }
 
 void SoftGPU::Execute_FramebufFormat(u32 op, u32 diff) {
 	// We should flush, because ranges within bins may change.
-	drawEngine_->transformUnit.Flush("framebuf");
+	if (diff)
+		drawEngine_->transformUnit.Flush("framebuf");
 }
 
 void SoftGPU::Execute_ZbufPtr(u32 op, u32 diff) {
 	// We assume depthbuf.data won't change while we're drawing.
-	drawEngine_->transformUnit.Flush("depthbuf");
-	depthbuf.data = Memory::GetPointerWrite(gstate.getDepthBufAddress());
+	if (diff) {
+		drawEngine_->transformUnit.Flush("depthbuf");
+		depthbuf.data = Memory::GetPointerWrite(gstate.getDepthBufAddress());
+	}
 }
 
 void SoftGPU::Execute_VertexType(u32 op, u32 diff) {


### PR DESCRIPTION
Just some small changes to reduce flushing a bit in some games.  The benefit is small but goes from say 93% -> 94% in a Split/Second frame dump.

-[Unknown]