### PR TITLE
Vulkan: Submit main command buffer before acquiring the swapchain image

### DIFF
--- a/Common/GPU/Vulkan/VulkanFrameData.cpp
+++ b/Common/GPU/Vulkan/VulkanFrameData.cpp
@@ -126,16 +126,16 @@ void FrameData::SubmitPending(VulkanContext *vulkan, FrameSubmitType type, Frame
 		hasInitCommands = false;
 	}
 
+	if ((hasMainCommands || hasPresentCommands) && type == FrameSubmitType::Sync) {
+		fenceToTrigger = readbackFence;
+	}
+
 	if (hasMainCommands) {
 		VkResult res = vkEndCommandBuffer(mainCmd);
 		_assert_msg_(res == VK_SUCCESS, "vkEndCommandBuffer failed (main)! result=%s", VulkanResultToString(res));
 
 		cmdBufs[numCmdBufs++] = mainCmd;
 		hasMainCommands = false;
-
-		if (type == FrameSubmitType::Sync) {
-			fenceToTrigger = readbackFence;
-		}
 	}
 
 	if (hasPresentCommands) {

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -563,6 +563,8 @@ void VulkanQueueRunner::RunSteps(FrameData &frameData, FrameDataShared &frameDat
 		switch (step.stepType) {
 		case VKRStepType::RENDER:
 			if (!step.render.framebuffer) {
+				frameData.SubmitPending(vulkan_, FrameSubmitType::Pending, frameDataShared);
+
 				// When stepping in the GE debugger, we can end up here multiple times in a "frame".
 				// So only acquire once.
 				if (!frameData.hasAcquired) {
@@ -570,6 +572,7 @@ void VulkanQueueRunner::RunSteps(FrameData &frameData, FrameDataShared &frameDat
 					SetBackbuffer(framebuffers_[frameData.curSwapchainImage], swapchainImages_[frameData.curSwapchainImage].image);
 				}
 
+				_dbg_assert_(!frameData.hasPresentCommands);
 				// A RENDER step rendering to the backbuffer is normally the last step that happens in a frame,
 				// unless taking a screenshot, in which case there might be a READBACK_IMAGE after it.
 				// This is why we have to switch cmd to presentCmd, in this case.

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -231,6 +231,7 @@ StencilValueType ReplaceAlphaWithStencilType() {
 	case GE_FORMAT_8888:
 	case GE_FORMAT_INVALID:
 	case GE_FORMAT_DEPTH16:
+	case GE_FORMAT_CLUT8:
 		switch (gstate.getStencilOpZPass()) {
 		case GE_STENCILOP_REPLACE:
 			// TODO: Could detect zero here and force ZERO - less uniform updates?

--- a/GPU/Common/StencilCommon.cpp
+++ b/GPU/Common/StencilCommon.cpp
@@ -171,6 +171,7 @@ bool FramebufferManagerCommon::PerformStencilUpload(u32 addr, int size, StencilU
 		break;
 	case GE_FORMAT_INVALID:
 	case GE_FORMAT_DEPTH16:
+	case GE_FORMAT_CLUT8:
 		// Inconceivable.
 		_assert_(false);
 		break;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1997,6 +1997,9 @@ static bool CanDepalettize(GETextureFormat texFormat, GEBufferFormat bufferForma
 				return true;
 			}
 			break;
+		case GE_FORMAT_CLUT8:
+			// Shouldn't happen here.
+			return false;
 		}
 		WARN_LOG(G3D, "Invalid CLUT/framebuffer combination: %s vs %s", GeTextureFormatToString(texFormat), GeBufferFormatToString(bufferFormat));
 		return false;

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1235,6 +1235,7 @@ void ClearRectangle(const VertexData &v0, const VertexData &v1, const BinCoords 
 
 	case GE_FORMAT_INVALID:
 	case GE_FORMAT_DEPTH16:
+	case GE_FORMAT_CLUT8:
 		_dbg_assert_msg_(false, "Software: invalid framebuf format.");
 		break;
 	}

--- a/UI/DevScreens.h
+++ b/UI/DevScreens.h
@@ -100,8 +100,7 @@ public:
 	const char *tag() const override { return "LogLevel"; }
 
 private:
-	virtual void OnCompleted(DialogResult result);
-
+	void OnCompleted(DialogResult result) override;
 };
 
 class SystemInfoScreen : public UIDialogScreenWithBackground {


### PR DESCRIPTION
Especially on Android, acquiring the swapchain image can take a little bit of time, and during that time we might as well have the work we've recorded so far submitted to the GPU. I meant to do this in a previous PR but had to pull it out due to issues. With my latest refactorings this was not so hard to get working.

Normally, though, the GPU and CPU won't be tightly synced enough for this to matter, but if my planned idea to minimize latency pans out, this might actually help somewhat.

Also fixes a bug where the screenshot command would be recorded on the wrong commandbuffer, causing it to possibly save an old frame. This was surfaced by submitting early.