### PR TITLE
GPU: Clip clamped depth accounting for perspective

### DIFF
--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1206,14 +1206,14 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 			// Everywhere else, it's 0 -> 1, simpler.
 			WRITE(p, "  if (u_depthRange.y >= 1.0) {\n");
 		}
-		WRITE(p, "    %sgl_ClipDistance%s = integerZ;\n", compat.vsOutPrefix, clip0);
+		WRITE(p, "    %sgl_ClipDistance%s = integerZ * outPos.w;\n", compat.vsOutPrefix, clip0);
 		WRITE(p, "  } else {\n");
 		WRITE(p, "    %sgl_ClipDistance%s = 0.0;\n", compat.vsOutPrefix, clip0);
 		WRITE(p, "  }\n");
 
 		// This is similar, but for maxz when it's below 65535.0.  -1/0 don't matter here.
 		WRITE(p, "  if (u_depthRange.x + u_depthRange.y <= 65534.0) {\n");
-		WRITE(p, "    %sgl_ClipDistance%s = 65535.0 - integerZ;\n", compat.vsOutPrefix, clip1);
+		WRITE(p, "    %sgl_ClipDistance%s = (65535.0 - integerZ) * outPos.w;\n", compat.vsOutPrefix, clip1);
 		WRITE(p, "  } else {\n");
 		WRITE(p, "    %sgl_ClipDistance%s = 0.0;\n", compat.vsOutPrefix, clip1);
 		WRITE(p, "  }\n");


### PR DESCRIPTION
Thinking about it, it'd need to account for w in order to properly clip, so this makes sense.  It was not at all obvious from the GL or Vulkan clip distance documentation.

The range cull is already based on w (it's z < -w after all), so I think it needs no change.  In theory, cull distance shouldn't need to care about w, since it's just if all verts are below zero.

This fixes the Toca frame dump without breaking the Pursuit Force frame dump.

-[Unknown]