### PR TITLE
GPU: Simplify depth clamped clip planes

### DIFF
--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1189,37 +1189,34 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 			WRITE(p, "  %sv_fogdepth = (viewPos.z + u_fogcoef.x) * u_fogcoef.y;\n", compat.vsOutPrefix);
 	}
 
-	if (clipClampedDepth || (vertexRangeCulling && !IsVRBuild())) {
-		WRITE(p, "  vec3 projPos = outPos.xyz / outPos.w;\n");
-	}
-
 	if (clipClampedDepth) {
 		const char *clip0 = compat.shaderLanguage == HLSL_D3D11 ? ".x" : "[0]";
 		const char *clip1 = compat.shaderLanguage == HLSL_D3D11 ? ".y" : "[1]";
-		WRITE(p, "  mediump float integerZ = projPos.z * u_depthRange.x + u_depthRange.y;\n");
 
 		// This should clip against minz, but only when it's above zero.
 		if (ShaderLanguageIsOpenGL(compat.shaderLanguage)) {
 			// On OpenGL/GLES, these values account for the -1 -> 1 range.
 			WRITE(p, "  if (u_depthRange.y - u_depthRange.x >= 1.0) {\n");
+			WRITE(p, "    %sgl_ClipDistance%s = outPos.w + outPos.z;\n", compat.vsOutPrefix, clip0);
 		} else {
 			// Everywhere else, it's 0 -> 1, simpler.
 			WRITE(p, "  if (u_depthRange.y >= 1.0) {\n");
+			WRITE(p, "    %sgl_ClipDistance%s = outPos.z;\n", compat.vsOutPrefix, clip0);
 		}
-		WRITE(p, "    %sgl_ClipDistance%s = integerZ * outPos.w;\n", compat.vsOutPrefix, clip0);
 		WRITE(p, "  } else {\n");
 		WRITE(p, "    %sgl_ClipDistance%s = 0.0;\n", compat.vsOutPrefix, clip0);
 		WRITE(p, "  }\n");
 
 		// This is similar, but for maxz when it's below 65535.0.  -1/0 don't matter here.
 		WRITE(p, "  if (u_depthRange.x + u_depthRange.y <= 65534.0) {\n");
-		WRITE(p, "    %sgl_ClipDistance%s = (65535.0 - integerZ) * outPos.w;\n", compat.vsOutPrefix, clip1);
+		WRITE(p, "    %sgl_ClipDistance%s = outPos.w - outPos.z;\n", compat.vsOutPrefix, clip1);
 		WRITE(p, "  } else {\n");
 		WRITE(p, "    %sgl_ClipDistance%s = 0.0;\n", compat.vsOutPrefix, clip1);
 		WRITE(p, "  }\n");
 	}
 
 	if (vertexRangeCulling && !IsVRBuild()) {
+		WRITE(p, "  vec3 projPos = outPos.xyz / outPos.w;\n");
 		WRITE(p, "  float projZ = (projPos.z - u_depthRange.z) * u_depthRange.w;\n");
 		// Vertex range culling doesn't happen when Z clips, note sign of w is important.
 		WRITE(p, "  if (u_cullRangeMin.w <= 0.0 || projZ * outPos.w > -outPos.w) {\n");


### PR DESCRIPTION
Sorry, after #16068 I realized this could be simpler with less constants, probably more efficient and more likely to avoid math errors.  This makes more sense when thinking about w.

There's no need to think about the scaled Z if we're using w anyway, just use the existing Z clipping range to avoid clamp.

-[Unknown]