### PR TITLE
Vulkan: Avoid crash in headless on finish

### DIFF
--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -1269,7 +1269,10 @@ void VulkanRenderManager::Run(int frame) {
 	BeginSubmitFrame(frame);
 
 	FrameData &frameData = frameData_[frame];
-	queueRunner_.PreprocessSteps(frameData_[frame].steps);
+	queueRunner_.PreprocessSteps(frameData.steps);
+	// Likely during shutdown, happens in headless.
+	if (frameData.steps.empty() && !frameData.hasAcquired)
+		frameData.skipSwap = true;
 	//queueRunner_.LogSteps(stepsOnThread, false);
 	queueRunner_.RunSteps(frameData, frameDataShared_);
 


### PR DESCRIPTION
Sometimes we end up running a frame that never had any render commands added to it, so it never acquires.  This happens in headless on shutdown.

So this change fixes it so we no longer crash with `--graphics=vulkan`.

-[Unknown]