### PR TITLE
CLUTs can be loaded from small rectangular textures. Need to linearize.

### DIFF
--- a/GPU/Common/Draw2D.cpp
+++ b/GPU/Common/Draw2D.cpp
@@ -70,6 +70,23 @@ Draw2DPipelineInfo GenerateDraw2DCopyColorFs(ShaderWriter &writer) {
 	};
 }
 
+Draw2DPipelineInfo GenerateDraw2DCopyColorRect2LinFs(ShaderWriter &writer) {
+	writer.DeclareSamplers(samplers);
+	writer.BeginFSMain(g_draw2Duniforms, varyings, FSFLAG_NONE);
+	writer.C("  vec2 tSize = texSize / scaleFactor;\n");
+	writer.C("  vec2 pixels = v_texcoord * tSize;\n");
+	writer.C("  float u = mod(floor(pixels.x), tSize.x);\n");
+	writer.C("  float v = floor(pixels.x / tSize.x);\n");
+	writer.C("  vec4 outColor = ").SampleTexture2D("tex", "vec2(u, v) / tSize").C(";\n");
+	writer.EndFSMain("outColor", FSFLAG_NONE);
+
+	return Draw2DPipelineInfo{
+		"draw2d_copy_color_rect2lin",
+		RASTER_COLOR,
+		RASTER_COLOR,
+	};
+}
+
 Draw2DPipelineInfo GenerateDraw2DCopyDepthFs(ShaderWriter &writer) {
 	writer.DeclareSamplers(samplers);
 	writer.BeginFSMain(Slice<UniformDef>::empty(), varyings, FSFLAG_WRITEDEPTH);
@@ -316,6 +333,13 @@ Draw2DPipeline *FramebufferManagerCommon::Get2DPipeline(Draw2DShader shader) {
 			draw2DPipelineColor_ = draw2D_.Create2DPipeline(&GenerateDraw2DCopyColorFs);
 		}
 		pipeline = draw2DPipelineColor_;
+		break;
+
+	case DRAW2D_COPY_COLOR_RECT2LIN:
+		if (!draw2DPipelineColorRect2Lin_) {
+			draw2DPipelineColorRect2Lin_ = draw2D_.Create2DPipeline(&GenerateDraw2DCopyColorRect2LinFs);
+		}
+		pipeline = draw2DPipelineColorRect2Lin_;
 		break;
 
 	case DRAW2D_COPY_DEPTH:

--- a/GPU/Common/Draw2D.cpp
+++ b/GPU/Common/Draw2D.cpp
@@ -75,7 +75,7 @@ Draw2DPipelineInfo GenerateDraw2DCopyColorRect2LinFs(ShaderWriter &writer) {
 	writer.BeginFSMain(g_draw2Duniforms, varyings, FSFLAG_NONE);
 	writer.C("  vec2 tSize = texSize / scaleFactor;\n");
 	writer.C("  vec2 pixels = v_texcoord * tSize;\n");
-	writer.C("  float u = mod(floor(pixels.x), tSize.x);\n");
+	writer.C("  float u = mod(pixels.x, tSize.x);\n");
 	writer.C("  float v = floor(pixels.x / tSize.x);\n");
 	writer.C("  vec4 outColor = ").SampleTexture2D("tex", "vec2(u, v) / tSize").C(";\n");
 	writer.EndFSMain("outColor", FSFLAG_NONE);

--- a/GPU/Common/Draw2D.h
+++ b/GPU/Common/Draw2D.h
@@ -16,6 +16,7 @@ enum Draw2DShader {
 	DRAW2D_COPY_DEPTH,
 	DRAW2D_565_TO_DEPTH,
 	DRAW2D_565_TO_DEPTH_DESWIZZLE,
+	DRAW2D_COPY_COLOR_RECT2LIN,
 };
 
 inline RasterChannel Draw2DSourceChannel(Draw2DShader shader) {

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2701,6 +2701,7 @@ void FramebufferManagerCommon::DeviceLost() {
 	DoRelease(stencilUploadSampler_);
 	DoRelease(stencilUploadPipeline_);
 	DoRelease(draw2DPipelineColor_);
+	DoRelease(draw2DPipelineColorRect2Lin_);
 	DoRelease(draw2DPipelineDepth_);
 	DoRelease(draw2DPipeline565ToDepth_);
 	DoRelease(draw2DPipeline565ToDepthDeswizzle_);

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -569,6 +569,7 @@ protected:
 
 	// Draw2D pipelines
 	Draw2DPipeline *draw2DPipelineColor_ = nullptr;
+	Draw2DPipeline *draw2DPipelineColorRect2Lin_ = nullptr;
 	Draw2DPipeline *draw2DPipelineDepth_ = nullptr;
 	Draw2DPipeline *draw2DPipeline565ToDepth_ = nullptr;
 	Draw2DPipeline *draw2DPipeline565ToDepthDeswizzle_ = nullptr;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1259,11 +1259,12 @@ void TextureCacheCommon::LoadClut(u32 clutAddr, u32 loadBytes) {
 					dynamicClutTemp_ = draw_->CreateFramebuffer(desc);
 				}
 
-				// Download the pixels to our temp clut, scaling down if needed.
+				// Copy the pixels to our temp clut, scaling down if needed and wrapping.
+				// TODO: Take the clutRenderOffset_ into account here.
 				framebufferManager_->BlitUsingRaster(
 					chosenFramebuffer->fbo, 0.0f, 0.0f, 512.0f * chosenFramebuffer->renderScaleFactor, 1.0f, 
 					dynamicClutTemp_, 0.0f, 0.0f, 512.0f, 1.0f, 
-					false, 1.0f, framebufferManager_->Get2DPipeline(DRAW2D_COPY_COLOR), "copy_clut_to_temp");
+					false, chosenFramebuffer->renderScaleFactor, framebufferManager_->Get2DPipeline(DRAW2D_COPY_COLOR_RECT2LIN), "copy_clut_to_temp");
 				clutRenderFormat_ = chosenFramebuffer->fb_format;
 			}
 			NotifyMemInfo(MemBlockFlags::ALLOC, clutAddr, loadBytes, "CLUT");


### PR DESCRIPTION
Fixes #8406, although technically, we should wrap by bufw, not the texture width.

~~Draft, slightly corrupts Ridge Racer speedometers.~~

Something is still wrong with D3D9, though I think unrelated to this PR.