### PR TITLE
OpenXR - Stereo for most games fixed

### DIFF
--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -230,7 +230,8 @@ bool StartVRRender() {
 
 		// Decide if the scene is 3D or not
 		if (g_Config.bEnableVR && !VR_GetConfig(VR_CONFIG_FORCE_2D) && (VR_GetConfig(VR_CONFIG_3D_GEOMETRY_COUNT) > 15)) {
-			VR_SetConfig(VR_CONFIG_MODE, g_Config.bEnableStereo ? VR_MODE_STEREO_6DOF : VR_MODE_MONO_6DOF);
+			bool stereo = VR_GetConfig(VR_CONFIG_6DOF_PRECISE) && g_Config.bEnableStereo;
+			VR_SetConfig(VR_CONFIG_MODE, stereo ? VR_MODE_STEREO_6DOF : VR_MODE_MONO_6DOF);
 		} else {
 			VR_SetConfig(VR_CONFIG_MODE, VR_MODE_FLAT_SCREEN);
 		}


### PR DESCRIPTION
This fixes an issue where testers reported that for some games the stereo works only if they put headset upside-down.

I also disabled the stereo for games where is not defined world scale (that produced a broken stereo separation).