### PR TITLE
softgpu: Cache reused indexed verts

### DIFF
--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -161,7 +161,7 @@ BinManager::~BinManager() {
 	}
 }
 
-void BinManager::UpdateState(bool throughMode) {
+void BinManager::UpdateState() {
 	PROFILE_THIS_SCOPE("bin_state");
 	if (HasDirty(SoftDirty::PIXEL_ALL | SoftDirty::SAMPLER_ALL | SoftDirty::RAST_ALL)) {
 		if (states_.Full())

--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -181,7 +181,7 @@ public:
 	BinManager();
 	~BinManager();
 
-	void UpdateState(bool throughMode);
+	void UpdateState();
 	void UpdateClut(const void *src);
 
 	const Rasterizer::RasterizerState &State() {

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -530,7 +530,7 @@ void TransformUnit::SubmitPrimitive(const void* vertices, const void* indices, G
 	// TODO: Do this in two passes - first process the vertices (before indexing/stripping),
 	// then resolve the indices. This lets us avoid transforming shared vertices twice.
 
-	binner_->UpdateState(vreader.isThrough());
+	binner_->UpdateState();
 	hasDraws_ = true;
 
 	static TransformState transformState;

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -105,6 +105,7 @@ struct VertexData {
 class VertexReader;
 
 class SoftwareDrawEngine;
+class SoftwareVertexReader;
 
 class TransformUnit {
 public:
@@ -156,6 +157,8 @@ private:
 	GEPrimitiveType prev_prim_ = GE_PRIM_POINTS;
 	bool hasDraws_ = false;
 	bool isImmDraw_ = false;
+
+	friend SoftwareVertexReader;
 };
 
 class SoftwareDrawEngine : public DrawEngineCommon {


### PR DESCRIPTION
This reduces the cost of ReadVertex() some, which can be especially heavy with curves.  Improves the FPS of a frame dump from Metal Gear Ac!D 2 from ~30% to ~54%.  The volume of triangles is still significant, so a lot of overhead is spent just clipping, queuing, etc. them.

This should improve other drawing that uses indices to reuse vertices, though likely not nearly to the same degree.

-[Unknown]