### PR TITLE
Assorted cleanup work (leaks, Vulkan)

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -1266,10 +1266,10 @@ bool GLSLtoSPV(const VkShaderStageFlagBits shader_type, const char *sourceCode, 
 
 	glslang::TProgram program;
 	const char *shaderStrings[1];
-	TBuiltInResource Resources;
+	TBuiltInResource Resources{};
 	init_resources(Resources);
 
-	int defaultVersion;
+	int defaultVersion = 0;
 	EShMessages messages;
 	EProfile profile;
 

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -1721,6 +1721,10 @@ void VulkanQueueRunner::PerformCopy(const VKRStep &step, VkCommandBuffer cmd) {
 		if (dst->depth.layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) {
 			SetupTransitionToTransferDst(dst->depth, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, &recordBarrier_);
 			_dbg_assert_(dst->depth.layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+		} else {
+			// Kingdom Hearts: Subsequent copies to the same depth buffer without any other use.
+			// Not super sure how that happens, but we need a barrier to pass sync validation.
+			SetupTransferDstWriteAfterWrite(dst->depth, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, &recordBarrier_);
 		}
 	}
 
@@ -1914,6 +1918,33 @@ void VulkanQueueRunner::SetupTransitionToTransferDst(VKRImage &img, VkImageAspec
 	);
 
 	img.layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+}
+
+void VulkanQueueRunner::SetupTransferDstWriteAfterWrite(VKRImage &img, VkImageAspectFlags aspect, VulkanBarrier *recordBarrier) {
+	VkImageAspectFlags imageAspect = aspect;
+	VkAccessFlags srcAccessMask = 0;
+	VkPipelineStageFlags srcStageMask = 0;
+	if (img.format == VK_FORMAT_D16_UNORM_S8_UINT || img.format == VK_FORMAT_D24_UNORM_S8_UINT || img.format == VK_FORMAT_D32_SFLOAT_S8_UINT) {
+		// Barrier must specify both for combined depth/stencil buffers.
+		imageAspect = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
+	} else {
+		imageAspect = aspect;
+	}
+	_dbg_assert_(img.layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
+	srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+	srcStageMask = VK_PIPELINE_STAGE_TRANSFER_BIT;
+	recordBarrier->TransitionImage(
+		img.image,
+		0,
+		1,
+		aspect,
+		VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		VK_ACCESS_TRANSFER_WRITE_BIT,
+		VK_ACCESS_TRANSFER_WRITE_BIT,
+		VK_PIPELINE_STAGE_TRANSFER_BIT,
+		VK_PIPELINE_STAGE_TRANSFER_BIT
+	);
 }
 
 void VulkanQueueRunner::PerformReadback(const VKRStep &step, VkCommandBuffer cmd) {

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -10,6 +10,16 @@ using namespace PPSSPP_VK;
 
 // Debug help: adb logcat -s DEBUG PPSSPPNativeActivity PPSSPP NativeGLView NativeRenderer NativeSurfaceView PowerSaveModeReceiver InputDeviceState
 
+static bool RenderPassTypeHasDepth(RenderPassType rpType) {
+	switch (rpType) {
+	case RP_TYPE_BACKBUFFER:
+	case RP_TYPE_COLOR_DEPTH:
+	case RP_TYPE_COLOR_DEPTH_INPUT:
+		return true;
+	}
+	return false;
+}
+
 static void MergeRenderAreaRectInto(VkRect2D *dest, VkRect2D &src) {
 	if (dest->offset.x > src.offset.x) {
 		dest->extent.width += (dest->offset.x - src.offset.x);
@@ -1591,6 +1601,9 @@ VKRRenderPass *VulkanQueueRunner::PerformBindFramebufferAsRenderTarget(const VKR
 	VkFramebuffer framebuf;
 	int w;
 	int h;
+
+	bool hasDepth = RenderPassTypeHasDepth(step.render.renderPassType);
+
 	if (step.render.framebuffer) {
 		_dbg_assert_(step.render.finalColorLayout != VK_IMAGE_LAYOUT_UNDEFINED);
 		_dbg_assert_(step.render.finalDepthStencilLayout != VK_IMAGE_LAYOUT_UNDEFINED);
@@ -1631,7 +1644,7 @@ VKRRenderPass *VulkanQueueRunner::PerformBindFramebufferAsRenderTarget(const VKR
 			Uint8x4ToFloat4(clearVal[0].color.float32, step.render.clearColor);
 			numClearVals = 1;
 		}
-		if (step.render.depthLoad == VKRRenderPassLoadAction::CLEAR || step.render.stencilLoad == VKRRenderPassLoadAction::CLEAR) {
+		if (hasDepth && (step.render.depthLoad == VKRRenderPassLoadAction::CLEAR || step.render.stencilLoad == VKRRenderPassLoadAction::CLEAR)) {
 			clearVal[1].depthStencil.depth = step.render.clearDepth;
 			clearVal[1].depthStencil.stencil = step.render.clearStencil;
 			numClearVals = 2;
@@ -1650,7 +1663,7 @@ VKRRenderPass *VulkanQueueRunner::PerformBindFramebufferAsRenderTarget(const VKR
 		h = vulkan_->GetBackbufferHeight();
 
 		Uint8x4ToFloat4(clearVal[0].color.float32, step.render.clearColor);
-		numClearVals = 2;  // We don't bother with a depth buffer here.
+		numClearVals = hasDepth ? 2 : 1;  // We might do depth-less backbuffer in the future, though doubtful of the value.
 		clearVal[1].depthStencil.depth = 0.0f;
 		clearVal[1].depthStencil.stencil = 0;
 	}

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -336,6 +336,7 @@ private:
 
 	static void SetupTransitionToTransferSrc(VKRImage &img, VkImageAspectFlags aspect, VulkanBarrier *recordBarrier);
 	static void SetupTransitionToTransferDst(VKRImage &img, VkImageAspectFlags aspect, VulkanBarrier *recordBarrier);
+	static void SetupTransferDstWriteAfterWrite(VKRImage &img, VkImageAspectFlags aspect, VulkanBarrier *recordBarrier);
 
 	static void SelfDependencyBarrier(VKRImage &img, VkImageAspectFlags aspect, VulkanBarrier *recordBarrier);
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -148,6 +148,12 @@ struct VKRComputePipelineDesc {
 
 // Wrapped pipeline. Doesn't own desc.
 struct VKRGraphicsPipeline {
+	~VKRGraphicsPipeline() {
+		for (int i = 0; i < RP_TYPE_COUNT; i++) {
+			delete pipeline[i];
+		}
+	}
+
 	bool Create(VulkanContext *vulkan, VkRenderPass compatibleRenderPass, RenderPassType rpType);
 
 	// This deletes the whole VKRGraphicsPipeline, you must remove your last pointer to it when doing this.
@@ -161,11 +167,12 @@ struct VKRGraphicsPipeline {
 };
 
 struct VKRComputePipeline {
-	VKRComputePipeline() {
-		pipeline = VK_NULL_HANDLE;
+	~VKRComputePipeline() {
+		delete pipeline;
 	}
+
 	VKRComputePipelineDesc *desc = nullptr;
-	Promise<VkPipeline> *pipeline;
+	Promise<VkPipeline> *pipeline = nullptr;
 
 	bool Create(VulkanContext *vulkan);
 	bool Pending() const {

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -976,7 +976,7 @@ void VKContext::WipeQueue() {
 }
 
 VkDescriptorSet VKContext::GetOrCreateDescriptorSet(VkBuffer buf) {
-	DescriptorSetKey key;
+	DescriptorSetKey key{};
 
 	FrameData *frame = &frame_[vulkan_->GetCurFrame()];
 

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -583,7 +583,8 @@ int ElfReader::LoadInto(u32 loadAddress, bool fromTop)
 				{
 					if (!(sections[sectionToModify].sh_flags & SHF_ALLOC))
 					{
-						ERROR_LOG_REPORT(LOADER, "Trying to relocate non-loaded section %s, ignoring", GetSectionName(sectionToModify));
+						// Generally stuff like debug info. We don't need it.
+						INFO_LOG(LOADER, "Skipping relocation of non-loaded section %s", GetSectionName(sectionToModify));
 						continue;
 					}
 				}

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -175,35 +175,35 @@ public:
 
 	int FindEPWithTimestamp(int pts) const;
 
-	u32 magic;
-	u32 version;
-	u32 streamOffset;
-	u32 streamSize;
-	u32 headerSize;
-	u32 headerOffset;
-	u32 streamType;
-	u32 streamChannel;
+	u32 magic = 0;
+	u32 version = 0;
+	u32 streamOffset = 0;
+	u32 streamSize = 0;
+	u32 headerSize = 0;
+	u32 headerOffset = 0;
+	u32 streamType = 0;
+	u32 streamChannel = 0;
 	// 0x50
-	u32 streamDataTotalSize;
-	u32 presentationStartTime;
-	u32 presentationEndTime;
-	u32 streamDataNextBlockSize;
-	u32 streamDataNextInnerBlockSize;
+	u32 streamDataTotalSize = 0;
+	u32 presentationStartTime = 0;
+	u32 presentationEndTime = 0;
+	u32 streamDataNextBlockSize = 0;
+	u32 streamDataNextInnerBlockSize = 0;
 
-	int numStreams;
-	int currentStreamNum;
-	int currentStreamType;
-	int currentStreamChannel;
+	int numStreams = 0;
+	int currentStreamNum = 0;
+	int currentStreamType = 0;
+	int currentStreamChannel = 0;
 
 	// parameters gotten from streams
 	// I guess this is the seek information?
-	u32 EPMapOffset;
-	u32 EPMapEntriesNum;
+	u32 EPMapOffset = 0;
+	u32 EPMapEntriesNum = 0;
 	// These shouldn't be here, just here for convenience with old states.
-	int videoWidth;
-	int videoHeight;
-	int audioChannels;
-	int audioFrequency;
+	int videoWidth = 0;
+	int videoHeight = 0;
+	int audioChannels = 0;
+	int audioFrequency = 0;
 	std::vector<PsmfEntry> EPMap;
 
 	PsmfStreamMap streamMap;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -152,7 +152,7 @@ static int TexLog2(float delta) {
 }
 
 SamplerCacheKey TextureCacheCommon::GetSamplingParams(int maxLevel, const TexCacheEntry *entry) {
-	SamplerCacheKey key;
+	SamplerCacheKey key{};
 
 	int minFilt = gstate.texfilter & 0x7;
 	key.minFilt = minFilt & 1;

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -381,7 +381,7 @@ VkDescriptorSet DrawEngineVulkan::GetOrCreateDescriptorSet(VkImageView imageView
 	_dbg_assert_(light != VK_NULL_HANDLE);
 	_dbg_assert_(bone != VK_NULL_HANDLE);
 
-	DescriptorSetKey key;
+	DescriptorSetKey key{};
 	key.imageView_ = imageView;
 	key.sampler_ = sampler;
 	key.secondaryImageView_ = boundSecondary_;

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -81,8 +81,8 @@ public:
 		VAI_UNRELIABLE,  // never cache
 	};
 
-	uint64_t hash;
-	u32 minihash;
+	uint64_t hash = 0;
+	u32 minihash = 0;
 
 	// These will probably always be the same, but whatever.
 	VkBuffer vb = VK_NULL_HANDLE;


### PR DESCRIPTION
I ran PPSSPP through Valgrind, Helgrind, and some additional Vulkan layers, and fixed the easy stuff (reads from uninitialized variables, mostly).

Helgrind (threading sanitizer) doesn't really understand atomics very well, so it has way too many false positives to go through easily currently (though there is silencing functionality I should probably try...).