### PR TITLE
[AdhocMatching] Fix assertion issue when playing Cars over public adhoc server.

### DIFF
--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -5063,7 +5063,8 @@ static int sceNetAdhocMatchingStart(int matchingId, int evthPri, int evthStack, 
 
 	int retval = NetAdhocMatching_Start(matchingId, evthPri, USER_PARTITION_ID, evthStack, inthPri, USER_PARTITION_ID, inthStack, optLen, optDataAddr);
 	// Give a little time to make sure matching Threads are ready before the game use the next sceNet functions, should've checked for status instead of guessing the time?
-	return hleDelayResult(retval, "give some time", adhocMatchingEventDelay);
+	hleEatMicro(adhocMatchingEventDelay);
+	return retval;
 }
 
 // With params for Partition ID for the event & input handler stack
@@ -5074,7 +5075,8 @@ static int sceNetAdhocMatchingStart2(int matchingId, int evthPri, int evthPartit
 
 	int retval = NetAdhocMatching_Start(matchingId, evthPri, evthPartitionId, evthStack, inthPri, inthPartitionId, inthStack, optLen, optDataAddr);
 	// Give a little time to make sure matching Threads are ready before the game use the next sceNet functions, should've checked for status instead of guessing the time?
-	return hleDelayResult(retval, "give some time", adhocMatchingEventDelay);
+	hleEatMicro(adhocMatchingEventDelay);
+	return retval;
 }
 
 


### PR DESCRIPTION
This fixes the assertion where current thread getting `nullptr` when playing Cars (ULUS10073) over public adhoc server.
![image](https://user-images.githubusercontent.com/7974720/191994632-a2222fb4-030c-4ac5-ac4d-6c4b0d982ce5.png)

PS: It's strange that i can only reproduce this when using public adhoc server, localhost and VPN didn't have this issue according to @MojoJojoDojo , so it might be affected by the latency between 1P -> AdhocServer -> 2P, since localhost and VPN use built-in AdhocServer that have minimum latency on one of them (eg. similar to 1P -> 2P), compared to a distant public AdhocServer.