### PR TITLE
Vulkan: Avoid crash on two backbuffer steps

### DIFF
--- a/Common/GPU/Vulkan/VulkanFrameData.cpp
+++ b/Common/GPU/Vulkan/VulkanFrameData.cpp
@@ -141,7 +141,7 @@ void FrameData::SubmitPending(VulkanContext *vulkan, FrameSubmitType type, Frame
 		hasMainCommands = false;
 	}
 
-	if (hasPresentCommands) {
+	if (hasPresentCommands && type != FrameSubmitType::Pending) {
 		VkResult res = vkEndCommandBuffer(presentCmd);
 		_assert_msg_(res == VK_SUCCESS, "vkEndCommandBuffer failed (present)! result=%s", VulkanResultToString(res));
 

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -585,14 +585,15 @@ void VulkanQueueRunner::RunSteps(std::vector<VKRStep *> &steps, FrameData &frame
 					SetBackbuffer(framebuffers_[frameData.curSwapchainImage], swapchainImages_[frameData.curSwapchainImage].image);
 				}
 
-				_dbg_assert_(!frameData.hasPresentCommands);
-				// A RENDER step rendering to the backbuffer is normally the last step that happens in a frame,
-				// unless taking a screenshot, in which case there might be a READBACK_IMAGE after it.
-				// This is why we have to switch cmd to presentCmd, in this case.
-				VkCommandBufferBeginInfo begin{ VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
-				begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
-				vkBeginCommandBuffer(frameData.presentCmd, &begin);
-				frameData.hasPresentCommands = true;
+				if (!frameData.hasPresentCommands) {
+					// A RENDER step rendering to the backbuffer is normally the last step that happens in a frame,
+					// unless taking a screenshot, in which case there might be a READBACK_IMAGE after it.
+					// This is why we have to switch cmd to presentCmd, in this case.
+					VkCommandBufferBeginInfo begin{ VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
+					begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+					vkBeginCommandBuffer(frameData.presentCmd, &begin);
+					frameData.hasPresentCommands = true;
+				}
 				cmd = frameData.presentCmd;
 			}
 			PerformRenderPass(step, cmd);

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -864,6 +864,8 @@ void hleDoLogInternal(LogTypes::LOG_TYPE t, LogTypes::LOG_LEVELS level, u64 res,
 
 		funcName = latestSyscall->name;
 		funcFlags = latestSyscall->flags;
+	} else {
+		strcpy(formatted_args, "?");
 	}
 
 	const char *fmt;


### PR DESCRIPTION
Happens when resuming from stepping, sometimes: first EmuScreen_BackBuffer, which is done so UI is functional during stepping, and then the actual blit (because it has resumed.)

In this situation, we submit `presentCmd` in `SubmitPending()`, and then we try to begin it again right away (before it has completed.)  This is what causes the crash.

Since this is an uncommon case, let's just allow it by reusing the presentCmd instead of submitting it early.  This is more or less the intent of `VkCommandBuffer cmd = frameData.hasPresentCommands ? frameData.presentCmd : frameData.mainCmd;`.

I also thought about nuking the step (it actually ends up having all REMOVED commands), but since it's uncommon I didn't want to add a bunch of code to check for the case in any common paths.

-[Unknown]