### PR TITLE
softgpu: Optimize rectangle sampling/blending used in bloom

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2797,7 +2797,7 @@ CheckAlphaResult TextureCacheCommon::CheckCLUTAlpha(const uint8_t *pixelData, GE
 		// Never has any alpha.
 		return CHECKALPHA_FULL;
 	default:
-		return CheckAlpha32((const u32 *)pixelData, w, 0xFF000000);  // note, the normal order here, unlike the 16-bit formats
+		return CheckAlpha32((const u32 *)pixelData, w, 0xFF000000);
 	}
 }
 

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -453,20 +453,6 @@ DXGI_FORMAT TextureCacheD3D11::GetDestFormat(GETextureFormat format, GEPaletteFo
 	}
 }
 
-CheckAlphaResult TextureCacheD3D11::CheckAlpha(const u32 *pixelData, u32 dstFmt, int w) {
-	switch (dstFmt) {
-	case DXGI_FORMAT_B4G4R4A4_UNORM:
-		return CheckAlpha16((const u16 *)pixelData, w, 0xF000);
-	case DXGI_FORMAT_B5G5R5A1_UNORM:
-		return CheckAlpha16((const u16 *)pixelData, w, 0x8000);
-	case DXGI_FORMAT_B5G6R5_UNORM:
-		// Never has any alpha.
-		return CHECKALPHA_FULL;
-	default:
-		return CheckAlpha32((const u32 *)pixelData, w, 0xFF000000);
-	}
-}
-
 bool TextureCacheD3D11::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) {
 	SetTexture();
 	if (!nextTexture_) {

--- a/GPU/D3D11/TextureCacheD3D11.h
+++ b/GPU/D3D11/TextureCacheD3D11.h
@@ -65,7 +65,6 @@ protected:
 
 private:
 	DXGI_FORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
-	static CheckAlphaResult CheckAlpha(const u32 *pixelData, u32 dstFmt, int w);
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;
 
 	void BuildTexture(TexCacheEntry *const entry) override;

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -358,20 +358,6 @@ D3DFORMAT TextureCacheDX9::GetDestFormat(GETextureFormat format, GEPaletteFormat
 	}
 }
 
-CheckAlphaResult TextureCacheDX9::CheckAlpha(const u32 *pixelData, u32 dstFmt, int w) {
-	switch (dstFmt) {
-	case D3DFMT_A4R4G4B4:
-		return CheckAlpha16((const u16 *)pixelData, w, 0xF000);
-	case D3DFMT_A1R5G5B5:
-		return CheckAlpha16((const u16 *)pixelData, w, 0x8000);
-	case D3DFMT_R5G6B5:
-		// Never has any alpha.
-		return CHECKALPHA_FULL;
-	default:
-		return CheckAlpha32(pixelData, w, 0xFF000000);
-	}
-}
-
 bool TextureCacheDX9::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level) {
 	SetTexture();
 	ApplyTexture();

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -56,7 +56,6 @@ private:
 	void ApplySamplingParams(const SamplerCacheKey &key) override;
 
 	D3DFORMAT GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
-	static CheckAlphaResult CheckAlpha(const u32 *pixelData, u32 dstFmt, int w);
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;
 
 	void BuildTexture(TexCacheEntry *const entry) override;

--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -673,11 +673,13 @@ void ComputePixelBlendState(PixelBlendState &state, const PixelFuncID &id) {
 			state.srcColorAsFactor = true;
 			break;
 
+		case PixelBlendFactor::ZERO:
+			state.readsDstPixel = state.dstColorAsFactor || state.usesDstAlpha;
+			break;
+
 		default:
 			break;
 		}
-
-		state.dstColorAsFactor = state.dstColorAsFactor || state.usesDstAlpha;
 	}
 }
 

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -51,6 +51,7 @@ struct PixelBlendState {
 	bool dstFactorIsInverse = false;
 	bool srcColorAsFactor = false;
 	bool dstColorAsFactor = false;
+	bool readsDstPixel = true;
 };
 void ComputePixelBlendState(PixelBlendState &state, const PixelFuncID &id);
 

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -1047,7 +1047,13 @@ bool PixelJitCache::Jit_AlphaBlend(const PixelFuncID &id) {
 
 	// Step 1: Load and expand dest color.
 	X64Reg dstReg = regCache_.Alloc(RegCache::VEC_TEMP0);
-	if (id.FBFormat() == GE_FORMAT_8888) {
+	if (!blendState.readsDstPixel) {
+		// Let's load colorOff just for registers to be consistent.
+		X64Reg colorOff = GetColorOff(id);
+		regCache_.Unlock(colorOff, RegCache::GEN_COLOR_OFF);
+
+		PXOR(dstReg, R(dstReg));
+	} else if (id.FBFormat() == GE_FORMAT_8888) {
 		X64Reg colorOff = GetColorOff(id);
 		Describe("AlphaBlend");
 		MOVD_xmm(dstReg, MatR(colorOff));
@@ -1073,7 +1079,6 @@ bool PixelJitCache::Jit_AlphaBlend(const PixelFuncID &id) {
 
 		case GE_FORMAT_4444:
 			success = success && Jit_ConvertFrom4444(id, dstGenReg, temp1Reg, temp2Reg, blendState.usesDstAlpha);
-
 			break;
 
 		case GE_FORMAT_8888:
@@ -1115,7 +1120,7 @@ bool PixelJitCache::Jit_AlphaBlend(const PixelFuncID &id) {
 		// We also need to add a half bit later, so this gives us space.
 		if (multiplySrc || blendState.srcColorAsFactor)
 			PSLLW(argColorReg, 4);
-		if (multiplyDst || blendState.dstColorAsFactor)
+		if (multiplyDst || blendState.dstColorAsFactor || blendState.usesDstAlpha)
 			PSLLW(dstReg, 4);
 
 		// Okay, now grab our factors.  Don't bother if they're known values.
@@ -1218,7 +1223,6 @@ bool PixelJitCache::Jit_AlphaBlend(const PixelFuncID &id) {
 
 	return success;
 }
-
 
 bool PixelJitCache::Jit_BlendFactor(const PixelFuncID &id, RegCache::Reg factorReg, RegCache::Reg dstReg, PixelBlendFactor factor) {
 	X64Reg idReg = INVALID_REG;

--- a/GPU/Software/FuncId.cpp
+++ b/GPU/Software/FuncId.cpp
@@ -168,6 +168,14 @@ void ComputePixelFuncID(PixelFuncID *id) {
 				id->alphaBlendDst = (uint8_t)OptimizeAlphaFactor(gstate.getFixB());
 		}
 
+		if (id->colorTest && gstate.getColorTestFunction() == GE_COMP_NOTEQUAL && gstate.getColorTestRef() == 0 && gstate.getColorTestMask() == 0xFFFFFF) {
+			if (!id->depthWrite && !id->stencilTest && id->alphaBlend && id->AlphaBlendEq() == GE_BLENDMODE_MUL_AND_ADD) {
+				// Might be a pointless color test (seen in Ridge Racer, for example.)
+				if (id->AlphaBlendDst() == PixelBlendFactor::ONE)
+					id->colorTest = false;
+			}
+		}
+
 		id->applyLogicOp = gstate.isLogicOpEnabled() && gstate.getLogicOp() != GE_LOGIC_COPY;
 		id->applyFog = gstate.isFogEnabled() && !gstate.isModeThrough();
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -709,20 +709,6 @@ VkFormat TextureCacheVulkan::GetDestFormat(GETextureFormat format, GEPaletteForm
 	}
 }
 
-CheckAlphaResult TextureCacheVulkan::CheckAlpha(const u32 *pixelData, VkFormat dstFmt, int w) {
-	switch (dstFmt) {
-	case VULKAN_4444_FORMAT:
-		return CheckAlpha16((const u16 *)pixelData, w, 0xF000);
-	case VULKAN_1555_FORMAT:
-		return CheckAlpha16((const u16 *)pixelData, w, 0x8000);
-	case VULKAN_565_FORMAT:
-		// Never has any alpha.
-		return CHECKALPHA_FULL;
-	default:
-		return CheckAlpha32(pixelData, w, 0xFF000000);
-	}
-}
-
 void TextureCacheVulkan::LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePtr, int rowPitch, int level, int scaleFactor, VkFormat dstFmt) {
 	int w = gstate.getTextureWidth(level);
 	int h = gstate.getTextureHeight(level);

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -102,7 +102,6 @@ protected:
 private:
 	void LoadTextureLevel(TexCacheEntry &entry, uint8_t *writePtr, int rowPitch,  int level, int scaleFactor, VkFormat dstFmt);
 	VkFormat GetDestFormat(GETextureFormat format, GEPaletteFormat clutFormat) const;
-	static CheckAlphaResult CheckAlpha(const u32 *pixelData, VkFormat dstFmt, int w);
 	void UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) override;
 
 	void BuildTexture(TexCacheEntry *const entry) override;


### PR DESCRIPTION
These are fairly small gains but they help us skip steps in larger draws and bloom situations.  Only gives a percent or so, but I think worth it.

-[Unknown]