### PR TITLE
GE Debugger: Add option to track pixel in preview

### DIFF
--- a/Core/Screenshot.h
+++ b/Core/Screenshot.h
@@ -39,5 +39,8 @@ const u8 *ConvertBufferToScreenshot(const GPUDebugBuffer &buf, bool alpha, u8 *&
 
 // Can only be used while in game.
 bool TakeGameScreenshot(const Path &filename, ScreenshotFormat fmt, ScreenshotType type, int *width = nullptr, int *height = nullptr, int maxRes = -1);
+
 bool Save888RGBScreenshot(const Path &filename, ScreenshotFormat fmt, const u8 *bufferRGB888, int w, int h);
 bool Save8888RGBAScreenshot(const Path &filename, const u8 *bufferRGBA8888, int w, int h);
+// Overallocate bufferPNG for better encoding speed.
+bool Save8888RGBAScreenshot(std::vector<uint8_t> &bufferPNG, const u8 *bufferRGBA8888, int w, int h);

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -281,12 +281,13 @@ void CGEDebugger::SetupPreviews() {
 		primaryWindow->SetHoverCallback([&] (int x, int y) {
 			PrimaryPreviewHover(x, y);
 		});
-		primaryWindow->SetRightClickMenu(ContextMenuID::GEDBG_PREVIEW, [&] (int cmd) {
+		primaryWindow->SetRightClickMenu(ContextMenuID::GEDBG_PREVIEW, [&] (int cmd, int x, int y) {
 			HMENU subMenu = GetContextMenu(ContextMenuID::GEDBG_PREVIEW);
 			switch (cmd) {
 			case 0:
 				// Setup.
 				CheckMenuItem(subMenu, ID_GEDBG_ENABLE_PREVIEW, MF_BYCOMMAND | ((previewsEnabled_ & 1) ? MF_CHECKED : MF_UNCHECKED));
+				EnableMenuItem(subMenu, ID_GEDBG_TRACK_PIXEL_STOP, primaryTrackX_ == 0xFFFFFFFF ? MF_GRAYED : MF_ENABLED);
 				break;
 			case ID_GEDBG_EXPORT_IMAGE:
 				PreviewExport(primaryBuffer_);
@@ -296,6 +297,14 @@ void CGEDebugger::SetupPreviews() {
 				break;
 			case ID_GEDBG_COPY_IMAGE_ALPHA:
 				PreviewToClipboard(primaryBuffer_, true);
+				break;
+			case ID_GEDBG_TRACK_PIXEL:
+				primaryTrackX_ = x;
+				primaryTrackY_ = y;
+				break;
+			case ID_GEDBG_TRACK_PIXEL_STOP:
+				primaryTrackX_ = 0xFFFFFFFF;
+				primaryTrackX_ = 0xFFFFFFFF;
 				break;
 			case ID_GEDBG_ENABLE_PREVIEW:
 				previewsEnabled_ ^= 1;
@@ -317,12 +326,13 @@ void CGEDebugger::SetupPreviews() {
 		secondWindow->SetHoverCallback([&] (int x, int y) {
 			SecondPreviewHover(x, y);
 		});
-		secondWindow->SetRightClickMenu(ContextMenuID::GEDBG_PREVIEW, [&] (int cmd) {
+		secondWindow->SetRightClickMenu(ContextMenuID::GEDBG_PREVIEW, [&] (int cmd, int x, int y) {
 			HMENU subMenu = GetContextMenu(ContextMenuID::GEDBG_PREVIEW);
 			switch (cmd) {
 			case 0:
 				// Setup.
 				CheckMenuItem(subMenu, ID_GEDBG_ENABLE_PREVIEW, MF_BYCOMMAND | ((previewsEnabled_ & 2) ? MF_CHECKED : MF_UNCHECKED));
+				EnableMenuItem(subMenu, ID_GEDBG_TRACK_PIXEL_STOP, secondTrackX_ == 0xFFFFFFFF ? MF_GRAYED : MF_ENABLED);
 				break;
 			case ID_GEDBG_EXPORT_IMAGE:
 				PreviewExport(secondBuffer_);
@@ -332,6 +342,14 @@ void CGEDebugger::SetupPreviews() {
 				break;
 			case ID_GEDBG_COPY_IMAGE_ALPHA:
 				PreviewToClipboard(secondBuffer_, true);
+				break;
+			case ID_GEDBG_TRACK_PIXEL:
+				secondTrackX_ = x;
+				secondTrackY_ = y;
+				break;
+			case ID_GEDBG_TRACK_PIXEL_STOP:
+				secondTrackX_ = 0xFFFFFFFF;
+				secondTrackX_ = 0xFFFFFFFF;
 				break;
 			case ID_GEDBG_ENABLE_PREVIEW:
 				previewsEnabled_ ^= 2;
@@ -350,6 +368,12 @@ void CGEDebugger::SetupPreviews() {
 }
 
 void CGEDebugger::DescribePrimaryPreview(const GPUgstate &state, char desc[256]) {
+	if (primaryTrackX_ < primaryBuffer_->GetStride() && primaryTrackY_ < primaryBuffer_->GetHeight()) {
+		u32 pix = primaryBuffer_->GetRawPixel(primaryTrackX_, primaryTrackY_);
+		DescribePixel(pix, primaryBuffer_->GetFormat(), primaryTrackX_, primaryTrackY_, desc);
+		return;
+	}
+
 	if (showClut_) {
 		// In this case, we're showing the texture here.
 		snprintf(desc, 256, "Texture L%d: 0x%08x (%dx%d)", textureLevel_, state.getTextureAddress(textureLevel_), state.getTextureWidth(textureLevel_), state.getTextureHeight(textureLevel_));
@@ -374,6 +398,22 @@ void CGEDebugger::DescribePrimaryPreview(const GPUgstate &state, char desc[256])
 }
 
 void CGEDebugger::DescribeSecondPreview(const GPUgstate &state, char desc[256]) {
+	if (secondTrackX_ != 0xFFFFFFFF) {
+		uint32_t x = secondTrackX_;
+		uint32_t y = secondTrackY_;
+		if (showClut_) {
+			uint32_t clutWidth = secondBuffer_->GetStride() / 16;
+			x = y * clutWidth + x;
+			y = 0;
+		}
+
+		if (x < secondBuffer_->GetStride() && y < secondBuffer_->GetHeight()) {
+			u32 pix = secondBuffer_->GetRawPixel(x, y);
+			DescribePixel(pix, secondBuffer_->GetFormat(), x, y, desc);
+			return;
+		}
+	}
+
 	if (showClut_) {
 		snprintf(desc, 256, "CLUT: 0x%08x (%d)", state.getClutAddress(), state.getClutPaletteFormat());
 	} else {

--- a/Windows/GEDebugger/GEDebugger.h
+++ b/Windows/GEDebugger/GEDebugger.h
@@ -113,6 +113,7 @@ private:
 	void PrimaryPreviewHover(int x, int y);
 	void SecondPreviewHover(int x, int y);
 	void PreviewExport(const GPUDebugBuffer *buffer);
+	void PreviewToClipboard(const GPUDebugBuffer *buffer);
 	static void DescribePixel(u32 pix, GPUDebugBufferFormat fmt, int x, int y, char desc[256]);
 	static void DescribePixelRGBA(u32 pix, GPUDebugBufferFormat fmt, int x, int y, char desc[256]);
 	void UpdateMenus();

--- a/Windows/GEDebugger/GEDebugger.h
+++ b/Windows/GEDebugger/GEDebugger.h
@@ -140,6 +140,11 @@ private:
 	const GPUDebugBuffer *primaryBuffer_ = nullptr;
 	const GPUDebugBuffer *secondBuffer_ = nullptr;
 
+	uint32_t primaryTrackX_ = 0xFFFFFFFF;
+	uint32_t primaryTrackY_ = 0xFFFFFFFF;
+	uint32_t secondTrackX_ = 0xFFFFFFFF;
+	uint32_t secondTrackY_ = 0xFFFFFFFF;
+
 	bool updating_ = false;
 	int previewsEnabled_ = 3;
 	int minWidth_;

--- a/Windows/GEDebugger/GEDebugger.h
+++ b/Windows/GEDebugger/GEDebugger.h
@@ -113,7 +113,7 @@ private:
 	void PrimaryPreviewHover(int x, int y);
 	void SecondPreviewHover(int x, int y);
 	void PreviewExport(const GPUDebugBuffer *buffer);
-	void PreviewToClipboard(const GPUDebugBuffer *buffer);
+	void PreviewToClipboard(const GPUDebugBuffer *buffer, bool saveAlpha);
 	static void DescribePixel(u32 pix, GPUDebugBufferFormat fmt, int x, int y, char desc[256]);
 	static void DescribePixelRGBA(u32 pix, GPUDebugBufferFormat fmt, int x, int y, char desc[256]);
 	void UpdateMenus();

--- a/Windows/GEDebugger/SimpleGLWindow.h
+++ b/Windows/GEDebugger/SimpleGLWindow.h
@@ -117,7 +117,7 @@ struct SimpleGLWindow {
 	}
 
 	// Called first with 0 that it's opening, then the selected item.
-	void SetRightClickMenu(ContextMenuID menu, std::function<void(int)> callback) {
+	void SetRightClickMenu(ContextMenuID menu, std::function<void(int, int, int)> callback) {
 		rightClickCallback_ = callback;
 		rightClickMenu_ = menu;
 	}
@@ -136,6 +136,7 @@ protected:
 	bool Leave();
 	bool RightClick(int mouseX, int mouseY);
 	bool ToggleZoom();
+	POINT PosFromMouse(int mouseX, int mouseY);
 	const u8 *Reformat(const u8 *data, Format fmt, u32 numPixels);
 
 	HWND hWnd_;
@@ -173,6 +174,6 @@ protected:
 
 	std::function<void()> redrawCallback_;
 	std::function<void(int, int)> hoverCallback_;
-	std::function<void(int)> rightClickCallback_;
+	std::function<void(int, int, int)> rightClickCallback_;
 	ContextMenuID rightClickMenu_;
 };

--- a/Windows/W32Util/Misc.cpp
+++ b/Windows/W32Util/Misc.cpp
@@ -59,7 +59,8 @@ namespace W32Util
 	}
 
 	BOOL CopyTextToClipboard(HWND hwnd, const std::wstring &wtext) {
-		OpenClipboard(hwnd);
+		if (!OpenClipboard(hwnd))
+			return FALSE;
 		EmptyClipboard();
 		HANDLE hglbCopy = GlobalAlloc(GMEM_MOVEABLE, (wtext.size() + 1) * sizeof(wchar_t));
 		if (hglbCopy == NULL) {

--- a/Windows/W32Util/Misc.cpp
+++ b/Windows/W32Util/Misc.cpp
@@ -157,6 +157,31 @@ namespace W32Util
 		}
 		ShellExecute(nullptr, nullptr, moduleFilename.c_str(), cmdline, workingDirectory.c_str(), SW_SHOW);
 	}
+
+	ClipboardData::ClipboardData(const char *format, size_t sz) {
+		format_ = RegisterClipboardFormatA(format);
+		handle_ = format_ != 0 ? GlobalAlloc(GHND, sz) : 0;
+		data = handle_ != 0 ? GlobalLock(handle_) : nullptr;
+	}
+
+	ClipboardData::ClipboardData(UINT format, size_t sz) {
+		format_ = format;
+		handle_ = GlobalAlloc(GHND, sz);
+		data = handle_ != 0 ? GlobalLock(handle_) : nullptr;
+	}
+
+	ClipboardData::~ClipboardData() {
+		if (handle_ != 0) {
+			GlobalUnlock(handle_);
+			GlobalFree(handle_);
+		}
+	}
+
+	void ClipboardData::Set() {
+		if (format_ == 0 || handle_ == 0 || data == 0)
+			return;
+		SetClipboardData(format_, handle_);
+	}
 }
 
 static constexpr UINT_PTR IDT_UPDATE = 0xC0DE0042;

--- a/Windows/W32Util/Misc.h
+++ b/Windows/W32Util/Misc.h
@@ -14,6 +14,22 @@ namespace W32Util
 	void ExitAndRestart(bool overrideArgs = false, const std::string &args = "");
 	void SpawnNewInstance(bool overrideArgs = false, const std::string &args = "");
 	void GetSelfExecuteParams(std::wstring &workingDirectory, std::wstring &moduleFilename);
+
+	struct ClipboardData {
+		ClipboardData(const char *format, size_t sz);
+		ClipboardData(UINT format, size_t sz);
+		~ClipboardData();
+
+		void Set();
+
+		operator bool() {
+			return data != nullptr;
+		}
+
+		UINT format_;
+		HANDLE handle_;
+		void *data;
+	};
 }
 
 struct GenericListViewColumn

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -785,6 +785,7 @@ BEGIN
     BEGIN
         MENUITEM "Export Image...",            ID_GEDBG_EXPORT_IMAGE
         MENUITEM "Copy Opaque Image",          ID_GEDBG_COPY_IMAGE
+        MENUITEM "Copy Image With Alpha",      ID_GEDBG_COPY_IMAGE_ALPHA
         MENUITEM "Show Prim Preview",          ID_GEDBG_ENABLE_PREVIEW
     END
     POPUP "matrixoptions"

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -784,6 +784,7 @@ BEGIN
     POPUP "gepreviewoptions"
     BEGIN
         MENUITEM "Export Image...",            ID_GEDBG_EXPORT_IMAGE
+        MENUITEM "Copy Opaque Image",          ID_GEDBG_COPY_IMAGE
         MENUITEM "Show Prim Preview",          ID_GEDBG_ENABLE_PREVIEW
     END
     POPUP "matrixoptions"

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -786,6 +786,8 @@ BEGIN
         MENUITEM "Export Image...",            ID_GEDBG_EXPORT_IMAGE
         MENUITEM "Copy Opaque Image",          ID_GEDBG_COPY_IMAGE
         MENUITEM "Copy Image With Alpha",      ID_GEDBG_COPY_IMAGE_ALPHA
+        MENUITEM "Track Pixel",                ID_GEDBG_TRACK_PIXEL
+        MENUITEM "Stop Tracking Pixel",        ID_GEDBG_TRACK_PIXEL_STOP
         MENUITEM "Show Prim Preview",          ID_GEDBG_ENABLE_PREVIEW
     END
     POPUP "matrixoptions"

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -335,6 +335,8 @@
 #define ID_GEDBG_SETCOND                 40223
 #define ID_GEDBG_COPY_IMAGE              40224
 #define ID_GEDBG_COPY_IMAGE_ALPHA        40225
+#define ID_GEDBG_TRACK_PIXEL             40226
+#define ID_GEDBG_TRACK_PIXEL_STOP        40227
 
 
 // Dummy option to let the buffered rendering hotkey cycle through all the options.
@@ -348,7 +350,7 @@
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        256
-#define _APS_NEXT_COMMAND_VALUE         40226
+#define _APS_NEXT_COMMAND_VALUE         40228
 #define _APS_NEXT_CONTROL_VALUE         1202
 #define _APS_NEXT_SYMED_VALUE           101
 #endif

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -334,6 +334,7 @@
 #define IDC_GEDBG_STEPVSYNC              40222
 #define ID_GEDBG_SETCOND                 40223
 #define ID_GEDBG_COPY_IMAGE              40224
+#define ID_GEDBG_COPY_IMAGE_ALPHA        40225
 
 
 // Dummy option to let the buffered rendering hotkey cycle through all the options.
@@ -347,7 +348,7 @@
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        256
-#define _APS_NEXT_COMMAND_VALUE         40225
+#define _APS_NEXT_COMMAND_VALUE         40226
 #define _APS_NEXT_CONTROL_VALUE         1202
 #define _APS_NEXT_SYMED_VALUE           101
 #endif

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -333,6 +333,7 @@
 #define ID_GEDBG_SHOWONTOPRIGHT          40221
 #define IDC_GEDBG_STEPVSYNC              40222
 #define ID_GEDBG_SETCOND                 40223
+#define ID_GEDBG_COPY_IMAGE              40224
 
 
 // Dummy option to let the buffered rendering hotkey cycle through all the options.
@@ -346,7 +347,7 @@
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        256
-#define _APS_NEXT_COMMAND_VALUE         40224
+#define _APS_NEXT_COMMAND_VALUE         40225
 #define _APS_NEXT_CONTROL_VALUE         1202
 #define _APS_NEXT_SYMED_VALUE           101
 #endif


### PR DESCRIPTION
Also allow copying the image directly from the preview, not just saving to a file.  I added copy with alpha as well, but many apps don't support it...

-[Unknown]