### PR TITLE
softgpu: Avoid waiting for a thread to drain

### DIFF
--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -132,6 +132,10 @@ struct BinQueue {
 		return size_ == N - 1;
 	}
 
+	bool NearFull() const {
+		return size_ >= N - 2;
+	}
+
 	bool Empty() const {
 		return size_ == 0;
 	}
@@ -195,7 +199,7 @@ public:
 	void AddLine(const VertexData &v0, const VertexData &v1);
 	void AddPoint(const VertexData &v0);
 
-	void Drain();
+	void Drain(bool flushing = false);
 	void Flush(const char *reason);
 	bool HasPendingWrite(uint32_t start, uint32_t stride, uint32_t w, uint32_t h);
 	// Assumes you've also checked for a write (writes are partial so are automatically reads.)

--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -228,8 +228,8 @@ protected:
 	static constexpr int QUEUED_STATES = 4096;
 	// These are 1KB each, so half an MB.
 	static constexpr int QUEUED_CLUTS = 512;
-	// About 320 KB, but we have usually 16 or less of them, so 5 MB - 20 MB.
-	static constexpr int QUEUED_PRIMS = 1024;
+	// About 360 KB, but we have usually 16 or less of them, so 5 MB - 22 MB.
+	static constexpr int QUEUED_PRIMS = 2048;
 
 	typedef BinQueue<Rasterizer::RasterizerState, QUEUED_STATES> BinStateQueue;
 	typedef BinQueue<BinClut, QUEUED_CLUTS> BinClutQueue;


### PR DESCRIPTION
Sometimes we have so many triangles, it fills up our queue and we have to stall to wait for the thread to have space, which is slow.  It doesn't happen that often, but it happens in some heavier games.

This increases the queue size (there's a limit; too large and it just gets slower), and also tries to avoid complete drains from the main queue onto the threads.  This seems to avoid the syncs sometimes and increases some cases by a couple percent.

There's probably better heuristics here.  It's tricky though, everything I change in binning has significant and hard to predict effects.  I think ideal tuning of it is one of the areas that could lead to the most gain in performance left (much more than this change), though.

-[Unknown]