### PR TITLE
Shrink our main uniform buffer by 32 bytes

### DIFF
--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -459,8 +459,8 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 	}
 
 	if (compat.bitwiseOps && enableColorTest) {
-		p.C("ivec3 unpackIVec3(highp uint x) {\n");
-		p.C("  return ivec3(x & 0xFF, (x >> 8) & 0xFF, (x >> 16) & 0xFF);\n");
+		p.C("uvec3 unpackUVec3(highp uint x) {\n");
+		p.C("  return uvec3(x & 0xFF, (x >> 8) & 0xFF, (x >> 16) & 0xFF);\n");
 		p.C("}\n");
 	}
 
@@ -938,7 +938,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 					if (compat.shaderLanguage == HLSL_D3D11) {
 						const char *test = colorTestFuncs[colorTestFunc];
 						WRITE(p, "  uvec3 v_scaled = roundAndScaleTo255iv(v.rgb);\n");
-						WRITE(p, "  uvec3 colormask = unpackIVec3(u_alphacolormask);\n");
+						WRITE(p, "  uvec3 colormask = unpackUVec3(u_alphacolormask);\n");
 						WRITE(p, "  uvec3 v_masked = v_scaled & colormask;\n");
 						WRITE(p, "  uvec3 colorTestRef = u_alphacolorref.rgb & colormask;\n");
 						// We have to test the components separately, or we get incorrect results.  See #10629.

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -183,7 +183,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 			WRITE(p, "int roundAndScaleTo255i(in highp float x) { return int(floor(x * 255.0 + 0.5)); }\n");
 		}
 		if (enableColorTest && !colorTestAgainstZero) {
-			WRITE(p, "ivec3 roundAndScaleTo255iv(in highp vec3 x) { return ivec3(floor(x * 255.0 + 0.5)); }\n");
+			WRITE(p, "uvec3 roundAndScaleTo255iv(in highp vec3 x) { return uvec3(floor(x * 255.0 + 0.5)); }\n");
 		}
 
 		WRITE(p, "layout (location = 0, index = 0) out vec4 fragColor0;\n");
@@ -408,7 +408,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 			}
 			if (enableColorTest && !colorTestAgainstZero) {
 				if (compat.bitwiseOps) {
-					WRITE(p, "ivec3 roundAndScaleTo255iv(in vec3 x) { return ivec3(floor(x * 255.0 + 0.5)); }\n");
+					WRITE(p, "uvec3 roundAndScaleTo255iv(in vec3 x) { return uvec3(floor(x * 255.0 + 0.5)); }\n");
 				} else if (gl_extensions.gpuVendor == GPU_VENDOR_IMGTEC) {
 					WRITE(p, "vec3 roundTo255thv(in vec3 x) { vec3 y = x + (0.5/255.0); return y - fract(y * 255.0) * (1.0 / 255.0); }\n");
 				} else {
@@ -949,8 +949,8 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 						WRITE(p, "  vec3 colortest = roundAndScaleTo255v(v.rgb);\n");
 						WRITE(p, "  if ((colortest.r %s u_alphacolorref.r) && (colortest.g %s u_alphacolorref.g) && (colortest.b %s u_alphacolorref.b)) %s\n", test, test, test, discardStatement);
 					} else if (compat.bitwiseOps) {
-						WRITE(p, "  ivec3 v_scaled = roundAndScaleTo255iv(v.rgb);\n");
-						WRITE(p, "  uvec3 colormask = unpackIVec3(u_alphacolormask);\n");
+						WRITE(p, "  uvec3 v_scaled = roundAndScaleTo255iv(v.rgb);\n");
+						WRITE(p, "  uvec3 colormask = unpackUVec3(u_alphacolormask);\n");
 						if (compat.shaderLanguage == GLSL_VULKAN) {
 							// Apparently GLES3 does not support vector bitwise ops, but Vulkan does?
 							WRITE(p, "  if ((v_scaled & colormask) %s (u_alphacolorref.rgb & colormask)) %s\n", colorTestFuncs[colorTestFunc], discardStatement);

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -183,7 +183,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 			WRITE(p, "int roundAndScaleTo255i(in highp float x) { return int(floor(x * 255.0 + 0.5)); }\n");
 		}
 		if (enableColorTest && !colorTestAgainstZero) {
-			WRITE(p, "uvec3 roundAndScaleTo255iv(in highp vec3 x) { return uvec3(floor(x * 255.0 + 0.5)); }\n");
+			WRITE(p, "uint roundAndScaleTo8x4(in highp vec3 x) { uvec3 u = uvec3(floor(x * 255.0 + 0.5)); return u.r | (u.g << 8) | (u.b << 16); }\n");
 		}
 
 		WRITE(p, "layout (location = 0, index = 0) out vec4 fragColor0;\n");
@@ -262,7 +262,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 		}
 		if (enableColorTest) {
 			if (compat.shaderLanguage == HLSL_D3D11) {
-				WRITE(p, "uvec3 roundAndScaleTo255iv(float3 x) { return (floor(x * 255.0f + 0.5f)); }\n");
+				WRITE(p, "uint roundAndScaleTo8x4(float3 x) { uvec3 u = (floor(x * 255.0f + 0.5f)); return u.r | (u.g << 8) | (u.b << 16); }\n");
 			} else {
 				WRITE(p, "vec3 roundAndScaleTo255v(float3 x) { return floor(x * 255.0f + 0.5f); }\n");
 			}
@@ -408,7 +408,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 			}
 			if (enableColorTest && !colorTestAgainstZero) {
 				if (compat.bitwiseOps) {
-					WRITE(p, "uvec3 roundAndScaleTo255iv(in vec3 x) { return uvec3(floor(x * 255.0 + 0.5)); }\n");
+					WRITE(p, "uint roundAndScaleTo8x4(in vec3 x) { uvec3 u = uvec3(floor(x * 255.0 + 0.5)); return u.r | (u.g << 8) | (u.b << 16); }\n");
 				} else if (gl_extensions.gpuVendor == GPU_VENDOR_IMGTEC) {
 					WRITE(p, "vec3 roundTo255thv(in vec3 x) { vec3 y = x + (0.5/255.0); return y - fract(y * 255.0) * (1.0 / 255.0); }\n");
 				} else {
@@ -933,36 +933,22 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 				}
 			} else {
 				const char *colorTestFuncs[] = { "#", "#", " != ", " == " };
-				if (colorTestFuncs[colorTestFunc][0] != '#') {
+				const char *test = colorTestFuncs[colorTestFunc];
+				if (test[0] != '#') {
 					// TODO: Unify these paths better.
-					if (compat.shaderLanguage == HLSL_D3D11) {
-						const char *test = colorTestFuncs[colorTestFunc];
-						WRITE(p, "  uvec3 v_scaled = roundAndScaleTo255iv(v.rgb);\n");
-						WRITE(p, "  uvec3 colormask = unpackUVec3(u_alphacolormask);\n");
-						WRITE(p, "  uvec3 v_masked = v_scaled & colormask;\n");
-						WRITE(p, "  uvec3 colorTestRef = u_alphacolorref.rgb & colormask;\n");
-						// We have to test the components separately, or we get incorrect results.  See #10629.
-						WRITE(p, "  if (v_masked.r %s colorTestRef.r && v_masked.g %s colorTestRef.g && v_masked.b %s colorTestRef.b) %s\n", test, test, test, discardStatement);
-					} else if (compat.shaderLanguage == HLSL_D3D9) {
-						const char *test = colorTestFuncs[colorTestFunc];
+					if (compat.shaderLanguage == HLSL_D3D9) {
 						// TODO: Use a texture to lookup bitwise ops instead?
 						WRITE(p, "  vec3 colortest = roundAndScaleTo255v(v.rgb);\n");
 						WRITE(p, "  if ((colortest.r %s u_alphacolorref.r) && (colortest.g %s u_alphacolorref.g) && (colortest.b %s u_alphacolorref.b)) %s\n", test, test, test, discardStatement);
 					} else if (compat.bitwiseOps) {
-						WRITE(p, "  uvec3 v_scaled = roundAndScaleTo255iv(v.rgb);\n");
-						WRITE(p, "  uvec3 colormask = unpackUVec3(u_alphacolormask);\n");
-						if (compat.shaderLanguage == GLSL_VULKAN) {
-							// Apparently GLES3 does not support vector bitwise ops, but Vulkan does?
-							WRITE(p, "  if ((v_scaled & colormask) %s (u_alphacolorref.rgb & colormask)) %s\n", colorTestFuncs[colorTestFunc], discardStatement);
-						} else {
-							const char *maskedFragColor = "ivec3(v_scaled.r & colormask.r, v_scaled.g & colormask.g, v_scaled.b & colormask.b)";
-							const char *maskedColorRef = "ivec3(int(u_alphacolorref.r) & colormask.r, int(u_alphacolorref.g) & colormask.g, int(u_alphacolorref.b) & colormask.b)";
-							WRITE(p, "  if (%s %s %s) %s\n", maskedFragColor, colorTestFuncs[colorTestFunc], maskedColorRef, discardStatement);
-						}
+						WRITE(p, "  uint v_uint = roundAndScaleTo8x4(v.rgb);\n");
+						WRITE(p, "  uint v_masked = v_uint & u_alphacolormask;\n");
+						WRITE(p, "  uint colorTestRef = roundAndScaleTo8x4(u_alphacolorref.rgb) & u_alphacolormask;\n");
+						WRITE(p, "  if (v_masked %s colorTestRef) %s\n", test, discardStatement);
 					} else if (gl_extensions.gpuVendor == GPU_VENDOR_IMGTEC) {
-						WRITE(p, "  if (roundTo255thv(v.rgb) %s u_alphacolorref.rgb) %s\n", colorTestFuncs[colorTestFunc], discardStatement);
+						WRITE(p, "  if (roundTo255thv(v.rgb) %s u_alphacolorref.rgb) %s\n", test, discardStatement);
 					} else {
-						WRITE(p, "  if (roundAndScaleTo255v(v.rgb) %s u_alphacolorref.rgb) %s\n", colorTestFuncs[colorTestFunc], discardStatement);
+						WRITE(p, "  if (roundAndScaleTo255v(v.rgb) %s u_alphacolorref.rgb) %s\n", test, discardStatement);
 					}
 				} else {
 					WRITE(p, "  %s\n", discardStatement);

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -80,7 +80,7 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 		Uint8x3ToInt4_Alpha(ub->alphaColorRef, gstate.getColorTestRef(), gstate.getAlphaTestRef() & gstate.getAlphaTestMask());
 	}
 	if (dirtyUniforms & DIRTY_ALPHACOLORMASK) {
-		Uint8x3ToInt4_Alpha(ub->colorTestMask, gstate.getColorTestMask(), gstate.getAlphaTestMask());
+		ub->colorTestMask = gstate.getColorTestMask() | (gstate.getAlphaTestMask() << 24);
 	}
 	if (dirtyUniforms & DIRTY_FOGCOLOR) {
 		Uint8x3ToFloat4(ub->fogColor, gstate.fogcolor);

--- a/GPU/Common/ShaderUniforms.h
+++ b/GPU/Common/ShaderUniforms.h
@@ -36,10 +36,10 @@ struct UB_VS_FS_Base {
 	uint32_t spline_counts; uint32_t depal_mask_shift_off_fmt;  // 4 params packed into one.
 	uint32_t colorWriteMask; float mipBias;
 	// Fragment data
-	float fogColor[4];
-	float texEnvColor[4];  // .w is unused
+	float fogColor[4];     // .w is unused
+	float texEnvColor[3];
+	uint32_t colorTestMask;
 	int alphaColorRef[4];
-	int colorTestMask[4];
 	float blendFixA[4];  // .w is unused
 	float blendFixB[4];  // .w is unused
 	float texClamp[4];
@@ -66,8 +66,8 @@ R"(  mat4 u_proj;
   float u_mipBias;
   vec3 u_fogcolor;
   vec3 u_texenv;
+  uint u_alphacolormask;
   ivec4 u_alphacolorref;
-  ivec4 u_alphacolormask;
   vec3 u_blendFixA;
   vec3 u_blendFixB;
   vec4 u_texclamp;

--- a/GPU/Common/ShaderUniforms.h
+++ b/GPU/Common/ShaderUniforms.h
@@ -20,7 +20,8 @@ enum : uint64_t {
 // TODO: Split into two structs, one for software transform and one for hardware transform, to save space.
 // Currently 512 bytes. Probably can't get to 256 (nVidia's UBO alignment).
 // Every line here is a 4-float.
-struct UB_VS_FS_Base {
+
+struct alignas(16) UB_VS_FS_Base {
 	float proj[16];
 	float proj_through[16];
 	float view[12];
@@ -29,7 +30,6 @@ struct UB_VS_FS_Base {
 	float uvScaleOffset[4];
 	float depthRange[4];
 	// Rotation is used only for software transform.
-	float fogCoef[2]; float stencil; float rotation;
 	float matAmbient[4];
 	float cullRangeMin[4];
 	float cullRangeMax[4];
@@ -40,10 +40,11 @@ struct UB_VS_FS_Base {
 	float texEnvColor[3];
 	uint32_t colorTestMask;
 	int alphaColorRef[4];
-	float blendFixA[4];  // .w is unused
-	float blendFixB[4];  // .w is unused
+	float blendFixA[3]; float stencil;
+	float blendFixB[3]; float rotation;
 	float texClamp[4];
-	float texClampOffset[4];  // .zw are unused
+	float texClampOffset[2];  // .zw are unused
+	float fogCoef[2];
 };
 
 static const char * const ub_baseStr =
@@ -54,9 +55,6 @@ R"(  mat4 u_proj;
   mat3x4 u_texmtx;
   vec4 u_uvscaleoffset;
   vec4 u_depthRange;
-  vec2 u_fogcoef;
-  float u_stencilReplaceValue;
-  float u_rotation;
   vec4 u_matambientalpha;
   vec4 u_cullRangeMin;
   vec4 u_cullRangeMax;
@@ -68,15 +66,16 @@ R"(  mat4 u_proj;
   vec3 u_texenv;
   uint u_alphacolormask;
   ivec4 u_alphacolorref;
-  vec3 u_blendFixA;
-  vec3 u_blendFixB;
+  vec3 u_blendFixA; float u_stencilReplaceValue;
+  vec3 u_blendFixB; float u_rotation;
   vec4 u_texclamp;
   vec2 u_texclampoff;
+  vec2 u_fogcoef;
 )";
 
 // 512 bytes. Would like to shrink more. Some colors only have 8-bit precision and we expand
 // them to float unnecessarily, could just as well expand in the shader.
-struct UB_VS_Lights {
+struct alignas(16) UB_VS_Lights {
 	float ambientColor[4];
 	float materialDiffuse[4];
 	float materialSpecular[4];
@@ -129,7 +128,7 @@ R"(	vec4 u_ambient;
 
 // With some cleverness, we could get away with uploading just half this when only the four or five first
 // bones are being used. This is 384b.
-struct UB_VS_Bones {
+struct alignas(16) UB_VS_Bones {
 	float bones[8][12];
 };
 

--- a/GPU/Common/ShaderUniforms.h
+++ b/GPU/Common/ShaderUniforms.h
@@ -17,10 +17,8 @@ enum : uint64_t {
 	DIRTY_MATDIFFUSE | DIRTY_MATSPECULAR | DIRTY_MATEMISSIVE | DIRTY_AMBIENT,
 };
 
-// TODO: Split into two structs, one for software transform and one for hardware transform, to save space.
-// Currently 512 bytes. Probably can't get to 256 (nVidia's UBO alignment).
+// Currently 480 bytes. Probably can't get to 256 (nVidia's UBO alignment, also common in other vendors).
 // Every line here is a 4-float.
-
 struct alignas(16) UB_VS_FS_Base {
 	float proj[16];
 	float proj_through[16];
@@ -37,14 +35,12 @@ struct alignas(16) UB_VS_FS_Base {
 	uint32_t colorWriteMask; float mipBias;
 	// Fragment data
 	float fogColor[4];     // .w is unused
-	float texEnvColor[3];
-	uint32_t colorTestMask;
+	float texEnvColor[3]; uint32_t colorTestMask;
 	int alphaColorRef[4];
 	float blendFixA[3]; float stencil;
 	float blendFixB[3]; float rotation;
 	float texClamp[4];
-	float texClampOffset[2];  // .zw are unused
-	float fogCoef[2];
+	float texClampOffset[2]; float fogCoef[2];
 };
 
 static const char * const ub_baseStr =

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -448,7 +448,7 @@ void LinkedShader::UpdateUniforms(u32 vertType, const ShaderID &vsid, bool useBu
 		SetColorUniform3Alpha255(render_, &u_alphacolorref, gstate.getColorTestRef(), gstate.getAlphaTestRef() & gstate.getAlphaTestMask());
 	}
 	if (dirty & DIRTY_ALPHACOLORMASK) {
-		SetColorUniform3iAlpha(render_, &u_alphacolormask, gstate.colortestmask, gstate.getAlphaTestMask());
+		render_->SetUniformUI1(&u_alphacolormask, gstate.getColorTestMask() | (gstate.getAlphaTestMask() << 24));
 	}
 	if (dirty & DIRTY_COLORWRITEMASK) {
 		render_->SetUniformUI1(&u_colorWriteMask, ~((gstate.pmska << 24) | (gstate.pmskc & 0xFFFFFF)));

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -91,6 +91,8 @@ DrawEngineVulkan::DrawEngineVulkan(Draw::DrawContext *draw)
 	indexGen.Setup(decIndex);
 
 	InitDeviceObjects();
+
+	INFO_LOG(G3D, "sizeof(UB_VS_FS_Base) = %d", (int)sizeof(UB_VS_FS_Base));
 }
 
 void DrawEngineVulkan::InitDeviceObjects() {

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -91,8 +91,6 @@ DrawEngineVulkan::DrawEngineVulkan(Draw::DrawContext *draw)
 	indexGen.Setup(decIndex);
 
 	InitDeviceObjects();
-
-	INFO_LOG(G3D, "sizeof(UB_VS_FS_Base) = %d", (int)sizeof(UB_VS_FS_Base));
 }
 
 void DrawEngineVulkan::InitDeviceObjects() {


### PR DESCRIPTION
That's half a 4x4 matrix, we're down to 480 bytes now.

Ideally I'd like to be able to squeeze two VR eye matrices in here without exceeding 512 bytes... but starting to look impossible. Though if we'd merge the two proj matrices, which should be doable, we'd get closer.

There are a bunch of float4 colors that could be easily squeezed into 32 bits each (fog color etc) but not sure how those will affect performance on old hardware. I guess the rarer ones like blendFixA/B would be fine.. There's value too in keeping uniforms as similar to GL as possible.

There's a reason we want to stay below 512 bytes, because the next step up is 768 on a lot of hardware as they can only align uniform buffers on 256-byte boundaries. Whether it actually makes much of a performance difference in practice, probably not hugely...

Another way to go would be to dynamically generate uniform buffers with just the constants that each pipeline needs, but the complexity would be huge. Very likely not worth it.