### PR TITLE
GPU: Fix SSE4 Vec3f normalize

### DIFF
--- a/GPU/Math3D.cpp
+++ b/GPU/Math3D.cpp
@@ -121,7 +121,8 @@ __m128 SSENormalizeMultiplierSSE2(__m128 v)
 #endif
 __m128 SSENormalizeMultiplierSSE4(__m128 v)
 {
-	return _mm_rsqrt_ps(_mm_dp_ps(v, v, 0xFF));
+	// This is only used for Vec3f, so ignore the 4th component, might be garbage.
+	return _mm_rsqrt_ps(_mm_dp_ps(v, v, 0x77));
 }
 
 __m128 SSENormalizeMultiplier(bool useSSE4, __m128 v)


### PR DESCRIPTION
Was sometimes adding in garbage data, which could create NANs.

This isn't the Ridge Racer thing (probably), but I realized this when checking some texgen stuff - was getting NAN for normalized normal and realized this was happening.

-[Unknown]