### PR TITLE
Add compatibility flag for loading pixels on framebuffer create using nearest filtering

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -109,6 +109,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "SplitFramebufferMargin", &flags_.SplitFramebufferMargin);
 	CheckSetting(iniFile, gameID, "ForceLowerResolutionForEffectsOn", &flags_.ForceLowerResolutionForEffectsOn);
 	CheckSetting(iniFile, gameID, "AllowDownloadCLUT", &flags_.AllowDownloadCLUT);
+	CheckSetting(iniFile, gameID, "NearestFilteringOnFramebufferCreate", &flags_.NearestFilteringOnFramebufferCreate);
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -89,6 +89,7 @@ struct CompatFlags {
 	bool SplitFramebufferMargin;
 	bool ForceLowerResolutionForEffectsOn;
 	bool AllowDownloadCLUT;
+	bool NearestFilteringOnFramebufferCreate;
 };
 
 struct VRCompat {

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1061,7 +1061,11 @@ void FramebufferManagerCommon::DrawPixels(VirtualFramebuffer *vfb, int dstX, int
 
 	DrawTextureFlags flags;
 	if (useBufferedRendering_ && vfb && vfb->fbo) {
-		flags = channel == RASTER_COLOR ? DRAWTEX_LINEAR : DRAWTEX_NEAREST;
+		if (channel == RASTER_DEPTH || PSP_CoreParameter().compat.flags().NearestFilteringOnFramebufferCreate) {
+			flags = DRAWTEX_NEAREST;
+		} else {
+			flags = DRAWTEX_LINEAR;
+		}
 		draw_->BindFramebufferAsRenderTarget(vfb->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, tag);
 		SetViewport2D(0, 0, vfb->renderWidth, vfb->renderHeight);
 		draw_->SetScissorRect(0, 0, vfb->renderWidth, vfb->renderHeight);

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1283,6 +1283,27 @@ ULJM05494 = true
 NPJH50143 = true
 ULJM05738 = true
 
+[NearestFilteringOnFramebufferCreate]
+# Ridge Racer speedometer dynamic CLUT problem - they rely on some palette entries
+# from memory, and render to the rest of the palette. The palette entries loaded from memory
+# must not be blurred by filtering, so nearest it is. See issue #8509
+
+# Ridge Racer
+ULJS00001 = true
+ULUS10001 = true
+UCKS45002 = true
+UCES00002 = true
+ULJS19002 = true
+UCKS45053 = true
+NPJH50140 = true
+
+# Ridge Racer 2
+ULJS00080 = true
+UCKS45032 = true
+UCES00422 = true
+UCAS40273 = true
+NPJH50366 = true
+
 [AllowDownloadCLUT]
 # Temporary compatibility option, while working on the GPU CLUT-from-framebuffer path.
 # Not required for any games now that it works, but might be useful for development.


### PR DESCRIPTION
Solves the last problem with the Ridge Racer speedometers - so we can finally say: Fixes #8509

Render-to-CLUT for speedometers renders on top of an image that just comes from the underlying memory, so it's been drawn to the framebuffer with DrawPixels. That adds filtering so at higher resolutions, there's some blurring of the CLUT, causing artifacts.  We can solve this two ways: either we force on lower-resolution-for-effects for Ridge Racer games, or we use nearest filtering when doing DrawPixels of the memory under a framebuffer. For best result, we do the latter, on a per-game basis, for now at least.

(The speedometers look even better with nearest filtering, but that's a more general issue of UI looking better that way).