### PR TITLE
Correct texture projection issues, mainly in softgpu

### DIFF
--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -372,7 +372,7 @@ void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVt
 						break;
 
 					case GE_PROJMAP_NORMALIZED_NORMAL: // Use normalized normal as source
-						source = normal.NormalizedOr001(cpu_info.bSSE4_1);
+						source = normal.Normalized(cpu_info.bSSE4_1);
 						if (!reader.hasNormal()) {
 							ERROR_LOG_REPORT(G3D, "Normal projection mapping without normal?");
 						}

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -168,6 +168,29 @@ void SoftwareTransform::SetProjMatrix(float mtx[14], bool invertedX, bool invert
 	projMatrix_.translateAndScale(trans, scale);
 }
 
+static void ReadWeightedNormal(Vec3f &source, VertexReader &reader, u32 vertType, bool skinningEnabled) {
+	if (reader.hasNormal())
+		reader.ReadNrm(source.AsArray());
+	if (skinningEnabled) {
+		float weights[8];
+		reader.ReadWeights(weights);
+
+		// Have to recalculate this, unfortunately.  Please use software skinning...
+		Vec3f nsum(0, 0, 0);
+		for (int i = 0; i < vertTypeGetNumBoneWeights(vertType); i++) {
+			if (weights[i] != 0.0f) {
+				Vec3f norm;
+				Norm3ByMatrix43(norm.AsArray(), source.AsArray(), gstate.boneMatrix + i * 12);
+				nsum += norm * weights[i];
+			}
+		}
+
+		source = nsum;
+	}
+	if (gstate.areNormalsReversed())
+		source = -source;
+}
+
 void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVtxFormat, int maxIndex, SoftwareTransformResult *result) {
 	u8 *decoded = params_.decoded;
 	TransformedVertex *transformed = params_.transformed;
@@ -284,7 +307,7 @@ void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVt
 				}
 			} else {
 				float weights[8];
-				// TODO: For flat, are weights from the provoking used for color/normal?
+				// For flat, we need the vertex weights.
 				reader.Goto(index);
 				reader.ReadWeights(weights);
 
@@ -358,10 +381,8 @@ void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVt
 
 			case GE_TEXMAP_TEXTURE_MATRIX:
 				{
-					// TODO: What's the correct behavior with flat shading?  Provoked normal or real normal?
-
 					// Projection mapping
-					Vec3f source;
+					Vec3f source(0.0f, 0.0f, 1.0f);
 					switch (gstate.getUVProjMode())	{
 					case GE_PROJMAP_POSITION: // Use model space XYZ as source
 						source = pos;
@@ -372,14 +393,28 @@ void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVt
 						break;
 
 					case GE_PROJMAP_NORMALIZED_NORMAL: // Use normalized normal as source
-						source = normal.Normalized(cpu_info.bSSE4_1);
+						// Flat uses the vertex normal, not provoking.
+						if (provokeIndOffset == 0) {
+							source = normal.Normalized(cpu_info.bSSE4_1);
+						} else {
+							reader.Goto(index);
+							ReadWeightedNormal(source, reader, vertType, skinningEnabled);
+							source.Normalize();
+						}
 						if (!reader.hasNormal()) {
 							ERROR_LOG_REPORT(G3D, "Normal projection mapping without normal?");
 						}
 						break;
 
 					case GE_PROJMAP_NORMAL: // Use non-normalized normal as source!
-						source = normal;
+						// Flat uses the vertex normal, not provoking.
+						if (provokeIndOffset == 0) {
+							source = normal;
+						} else {
+							// Need to read the normal for this vertex and weight it again..
+							reader.Goto(index);
+							ReadWeightedNormal(source, reader, vertType, skinningEnabled);
+						}
 						if (!reader.hasNormal()) {
 							ERROR_LOG_REPORT(G3D, "Normal projection mapping without normal?");
 						}

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1231,9 +1231,9 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 						break;
 					case GE_PROJMAP_NORMALIZED_NORMAL:  // Use normalized transformed normal as source
 						if ((doBezier || doSpline) && hasNormalTess)
-							temp_tc = StringFromFormat("length(tess.nrm) == 0.0 ? vec4(0.0, 0.0, 1.0, 1.0) : vec4(normalize(%stess.nrm), 1.0)", flipNormalTess ? "-" : "");
+							temp_tc = StringFromFormat("length(tess.nrm) == 0.0 ? vec4(0.0, 0.0, 0.0, 1.0) : vec4(normalize(%stess.nrm), 1.0)", flipNormalTess ? "-" : "");
 						else if (hasNormal)
-							temp_tc = StringFromFormat("length(normal) == 0.0 ? vec4(0.0, 0.0, 1.0, 1.0) : vec4(normalize(%snormal), 1.0)", flipNormal ? "-" : "");
+							temp_tc = StringFromFormat("length(normal) == 0.0 ? vec4(0.0, 0.0, 0.0, 1.0) : vec4(normalize(%snormal), 1.0)", flipNormal ? "-" : "");
 						else
 							temp_tc = "vec4(0.0, 0.0, 1.0, 1.0)";
 						break;

--- a/GPU/Software/Clipper.h
+++ b/GPU/Software/Clipper.h
@@ -26,9 +26,9 @@ class BinManager;
 
 namespace Clipper {
 
-void ProcessPoint(const VertexData &v0, BinManager &binner);
-void ProcessLine(const VertexData &v0, const VertexData &v1, BinManager &binner);
-void ProcessTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2, const VertexData &provoking, BinManager &binner);
-void ProcessRect(const VertexData &v0, const VertexData &v1, BinManager &binner);
+void ProcessPoint(const ClipVertexData &v0, BinManager &binner);
+void ProcessLine(const ClipVertexData &v0, const ClipVertexData &v1, BinManager &binner);
+void ProcessTriangle(const ClipVertexData &v0, const ClipVertexData &v1, const ClipVertexData &v2, const ClipVertexData &provoking, BinManager &binner);
+void ProcessRect(const ClipVertexData &v0, const ClipVertexData &v1, BinManager &binner);
 
 }

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -227,8 +227,8 @@ static inline void GetTextureCoordinates(const VertexData& v0, const VertexData&
 	// All UV gen modes, by the time they get here, behave the same.
 
 	// Note that for environment mapping, texture coordinates have been calculated during lighting
-	float q0 = 1.f / v0.clippos.w;
-	float q1 = 1.f / v1.clippos.w;
+	float q0 = 1.f / v0.clipw;
+	float q1 = 1.f / v1.clipw;
 	float wq0 = p * q0;
 	float wq1 = (1.0f - p) * q1;
 
@@ -241,9 +241,9 @@ static inline void GetTextureCoordinates(const VertexData &v0, const VertexData 
 	// All UV gen modes, by the time they get here, behave the same.
 
 	// Note that for environment mapping, texture coordinates have been calculated during lighting.
-	float q0 = 1.f / v0.clippos.w;
-	float q1 = 1.f / v1.clippos.w;
-	float q2 = 1.f / v2.clippos.w;
+	float q0 = 1.f / v0.clipw;
+	float q1 = 1.f / v1.clipw;
+	float q2 = 1.f / v2.clipw;
 	Vec4<float> wq0 = w0.Cast<float>() * q0;
 	Vec4<float> wq1 = w1.Cast<float>() * q1;
 	Vec4<float> wq2 = w2.Cast<float>() * q2;

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -233,6 +233,7 @@ static inline void GetTextureCoordinates(const VertexData& v0, const VertexData&
 	float wq1 = (1.0f - p) * q1;
 
 	float q_recip = 1.0f / (wq0 + wq1);
+	// TODO: Handle projection.
 	s = (v0.texturecoords.s() * wq0 + v1.texturecoords.s() * wq1) * q_recip;
 	t = (v0.texturecoords.t() * wq0 + v1.texturecoords.t() * wq1) * q_recip;
 }
@@ -249,6 +250,7 @@ static inline void GetTextureCoordinates(const VertexData &v0, const VertexData 
 	Vec4<float> wq2 = w2.Cast<float>() * q2;
 
 	Vec4<float> q_recip = (wq0 + wq1 + wq2).Reciprocal();
+	// TODO: Handle projection.
 	s = Interpolate(v0.texturecoords.s(), v1.texturecoords.s(), v2.texturecoords.s(), wq0, wq1, wq2, q_recip);
 	t = Interpolate(v0.texturecoords.t(), v1.texturecoords.t(), v2.texturecoords.t(), wq0, wq1, wq2, q_recip);
 }
@@ -770,8 +772,9 @@ void DrawRectangle(const VertexData &v0, const VertexData &v1, const BinCoords &
 	Vec2f stx(0.0f, 0.0f);
 	Vec2f sty(0.0f, 0.0f);
 	if (state.enableTextures) {
-		Vec2f tc0 = v0.texturecoords;
-		Vec2f tc1 = v1.texturecoords;
+		// TODO: Handle projection.
+		Vec2f tc0 = v0.texturecoords.uv();
+		Vec2f tc1 = v1.texturecoords.uv();
 		if (state.throughMode) {
 			// For levels > 0, mipmapping is always based on level 0.  Simpler to scale first.
 			tc0.s() *= 1.0f / (float)(1 << state.samplerID.width0Shift);
@@ -1268,8 +1271,8 @@ void DrawLine(const VertexData &v0, const VertexData &v1, const BinCoords &range
 				float s, s1;
 				float t, t1;
 				if (state.throughMode) {
-					Vec2<float> tc = (v0.texturecoords * (float)(steps - i) + v1.texturecoords * (float)i) / steps1;
-					Vec2<float> tc1 = (v0.texturecoords * (float)(steps - i - 1) + v1.texturecoords * (float)(i + 1)) / steps1;
+					Vec2<float> tc = (v0.texturecoords.uv() * (float)(steps - i) + v1.texturecoords.uv() * (float)i) / steps1;
+					Vec2<float> tc1 = (v0.texturecoords.uv() * (float)(steps - i - 1) + v1.texturecoords.uv() * (float)(i + 1)) / steps1;
 
 					s = tc.s() * (1.0f / (float)(1 << state.samplerID.width0Shift));
 					s1 = tc1.s() * (1.0f / (float)(1 << state.samplerID.width0Shift));

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -802,7 +802,7 @@ void DrawRectangle(const VertexData &v0, const VertexData &v1, const BinCoords &
 	Vec2f stx(0.0f, 0.0f);
 	Vec2f sty(0.0f, 0.0f);
 	if (state.enableTextures) {
-		// TODO: Handle projection.
+		// Note: texture projection is not handled here, those always turn into triangles.
 		Vec2f tc0 = v0.texturecoords.uv();
 		Vec2f tc1 = v1.texturecoords.uv();
 		if (state.throughMode) {

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -226,7 +226,6 @@ static inline u8 ClampFogDepth(float fogdepth) {
 static inline void GetTextureCoordinates(const VertexData& v0, const VertexData& v1, const float p, float &s, float &t) {
 	// All UV gen modes, by the time they get here, behave the same.
 
-	// TODO: What happens if vertex has no texture coordinates?
 	// Note that for environment mapping, texture coordinates have been calculated during lighting
 	float q0 = 1.f / v0.clippos.w;
 	float q1 = 1.f / v1.clippos.w;
@@ -241,7 +240,6 @@ static inline void GetTextureCoordinates(const VertexData& v0, const VertexData&
 static inline void GetTextureCoordinates(const VertexData &v0, const VertexData &v1, const VertexData &v2, const Vec4<int> &w0, const Vec4<int> &w1, const Vec4<int> &w2, const Vec4<float> &wsum_recip, Vec4<float> &s, Vec4<float> &t) {
 	// All UV gen modes, by the time they get here, behave the same.
 
-	// TODO: What happens if vertex has no texture coordinates?
 	// Note that for environment mapping, texture coordinates have been calculated during lighting.
 	float q0 = 1.f / v0.clippos.w;
 	float q1 = 1.f / v1.clippos.w;

--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -54,6 +54,7 @@ struct RasterizerState {
 		bool minFilt : 1;
 		bool magFilt : 1;
 		bool antialiasLines : 1;
+		bool textureProj : 1;
 	};
 
 #if defined(SOFTGPU_MEMORY_TAGGING_DETAILED) || defined(SOFTGPU_MEMORY_TAGGING_BASIC)

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -393,16 +393,16 @@ bool RectangleFastPath(const VertexData &v0, const VertexData &v1, BinManager &b
 	return false;
 }
 
-static bool AreCoordsRectangleCompatible(const RasterizerState &state, const VertexData &data0, const VertexData &data1) {
-	if (data1.color0 != data0.color0)
+static bool AreCoordsRectangleCompatible(const RasterizerState &state, const ClipVertexData &data0, const ClipVertexData &data1) {
+	if (data1.v.color0 != data0.v.color0)
 		return false;
-	if (data1.screenpos.z != data0.screenpos.z) {
+	if (data1.v.screenpos.z != data0.v.screenpos.z) {
 		// Sometimes, we don't actually care about z.
 		if (state.pixelID.depthWrite || state.pixelID.DepthTestFunc() != GE_COMP_ALWAYS)
 			return false;
 	}
 	if (!state.throughMode) {
-		if (data1.color1 != data0.color1)
+		if (data1.v.color1 != data0.v.color1)
 			return false;
 		// This means it should be culled, outside range.
 		if (data1.OutsideRange() || data0.OutsideRange())
@@ -414,26 +414,26 @@ static bool AreCoordsRectangleCompatible(const RasterizerState &state, const Ver
 			if (data1.clippos.w - halftexel > data0.clippos.w || data1.clippos.w + halftexel < data0.clippos.w)
 				return false;
 		}
-		if (state.pixelID.applyFog && data1.fogdepth != data0.fogdepth) {
+		if (state.pixelID.applyFog && data1.v.fogdepth != data0.v.fogdepth) {
 			// Similar to w, this only matters if they're farther apart than 1/255.
 			static constexpr float foghalfstep = 0.5f / 255.0f;
-			if (data1.fogdepth - foghalfstep > data0.fogdepth || data1.fogdepth + foghalfstep < data0.fogdepth)
+			if (data1.v.fogdepth - foghalfstep > data0.v.fogdepth || data1.v.fogdepth + foghalfstep < data0.v.fogdepth)
 				return false;
 		}
 	}
 	return true;
 }
 
-bool DetectRectangleFromStrip(const RasterizerState &state, const VertexData data[4], int *tlIndex, int *brIndex) {
+bool DetectRectangleFromStrip(const RasterizerState &state, const ClipVertexData data[4], int *tlIndex, int *brIndex) {
 	// Color and Z must be flat.  Also find the TL and BR meanwhile.
 	int tl = 0, br = 0;
 	for (int i = 1; i < 4; ++i) {
 		if (!AreCoordsRectangleCompatible(state, data[i], data[0]))
 			return false;
 
-		if (data[i].screenpos.x <= data[tl].screenpos.x && data[i].screenpos.y <= data[tl].screenpos.y)
+		if (data[i].v.screenpos.x <= data[tl].v.screenpos.x && data[i].v.screenpos.y <= data[tl].v.screenpos.y)
 			tl = i;
-		if (data[i].screenpos.x >= data[br].screenpos.x && data[i].screenpos.y >= data[br].screenpos.y)
+		if (data[i].v.screenpos.x >= data[br].v.screenpos.x && data[i].v.screenpos.y >= data[br].v.screenpos.y)
 			br = i;
 	}
 
@@ -442,36 +442,36 @@ bool DetectRectangleFromStrip(const RasterizerState &state, const VertexData dat
 
 	// OK, now let's look at data to detect rectangles. There are a few possibilities
 	// but we focus on Darkstalkers for now.
-	if (data[0].screenpos.x == data[1].screenpos.x &&
-		data[0].screenpos.y == data[2].screenpos.y &&
-		data[2].screenpos.x == data[3].screenpos.x &&
-		data[1].screenpos.y == data[3].screenpos.y) {
+	if (data[0].v.screenpos.x == data[1].v.screenpos.x &&
+		data[0].v.screenpos.y == data[2].v.screenpos.y &&
+		data[2].v.screenpos.x == data[3].v.screenpos.x &&
+		data[1].v.screenpos.y == data[3].v.screenpos.y) {
 		// Okay, this is in the shape of a rectangle, but what about texture?
 		if (!state.enableTextures)
 			return true;
 
-		if (data[0].texturecoords.x == data[1].texturecoords.x &&
-			data[0].texturecoords.y == data[2].texturecoords.y &&
-			data[2].texturecoords.x == data[3].texturecoords.x &&
-			data[1].texturecoords.y == data[3].texturecoords.y) {
+		if (data[0].v.texturecoords.x == data[1].v.texturecoords.x &&
+			data[0].v.texturecoords.y == data[2].v.texturecoords.y &&
+			data[2].v.texturecoords.x == data[3].v.texturecoords.x &&
+			data[1].v.texturecoords.y == data[3].v.texturecoords.y) {
 			// It's a rectangle!
 			return true;
 		}
 		return false;
 	}
 	// There's the other vertex order too...
-	if (data[0].screenpos.x == data[2].screenpos.x &&
-		data[0].screenpos.y == data[1].screenpos.y &&
-		data[1].screenpos.x == data[3].screenpos.x &&
-		data[2].screenpos.y == data[3].screenpos.y) {
+	if (data[0].v.screenpos.x == data[2].v.screenpos.x &&
+		data[0].v.screenpos.y == data[1].v.screenpos.y &&
+		data[1].v.screenpos.x == data[3].v.screenpos.x &&
+		data[2].v.screenpos.y == data[3].v.screenpos.y) {
 		// Okay, this is in the shape of a rectangle, but what about texture?
 		if (!state.enableTextures)
 			return true;
 
-		if (data[0].texturecoords.x == data[2].texturecoords.x &&
-			data[0].texturecoords.y == data[1].texturecoords.y &&
-			data[1].texturecoords.x == data[3].texturecoords.x &&
-			data[2].texturecoords.y == data[3].texturecoords.y) {
+		if (data[0].v.texturecoords.x == data[2].v.texturecoords.x &&
+			data[0].v.texturecoords.y == data[1].v.texturecoords.y &&
+			data[1].v.texturecoords.x == data[3].v.texturecoords.x &&
+			data[2].v.texturecoords.y == data[3].v.texturecoords.y) {
 			// It's a rectangle!
 			return true;
 		}
@@ -480,7 +480,7 @@ bool DetectRectangleFromStrip(const RasterizerState &state, const VertexData dat
 	return false;
 }
 
-bool DetectRectangleFromFan(const RasterizerState &state, const VertexData *data, int c, int *tlIndex, int *brIndex) {
+bool DetectRectangleFromFan(const RasterizerState &state, const ClipVertexData *data, int c, int *tlIndex, int *brIndex) {
 	// Color and Z must be flat.
 	for (int i = 1; i < c; ++i) {
 		if (!AreCoordsRectangleCompatible(state, data[i], data[0]))
@@ -489,8 +489,8 @@ bool DetectRectangleFromFan(const RasterizerState &state, const VertexData *data
 
 	// Check for the common case: a single TL-TR-BR-BL.
 	if (c == 4) {
-		const auto &pos0 = data[0].screenpos, &pos1 = data[1].screenpos;
-		const auto &pos2 = data[2].screenpos, &pos3 = data[3].screenpos;
+		const auto &pos0 = data[0].v.screenpos, &pos1 = data[1].v.screenpos;
+		const auto &pos2 = data[2].v.screenpos, &pos3 = data[3].v.screenpos;
 		if (pos0.x == pos3.x && pos1.x == pos2.x && pos0.y == pos1.y && pos3.y == pos2.y) {
 			// Looking like yes.  Set TL/BR based on y order first...
 			*tlIndex = pos0.y > pos3.y ? 2 : 0;
@@ -505,13 +505,13 @@ bool DetectRectangleFromFan(const RasterizerState &state, const VertexData *data
 			if (!state.enableTextures)
 				return true;
 
-			const auto &textl = data[*tlIndex].texturecoords, &textr = data[*tlIndex ^ 1].texturecoords;
-			const auto &texbl = data[*brIndex ^ 1].texturecoords, &texbr = data[*brIndex].texturecoords;
+			const auto &textl = data[*tlIndex].v.texturecoords, &textr = data[*tlIndex ^ 1].v.texturecoords;
+			const auto &texbl = data[*brIndex ^ 1].v.texturecoords, &texbr = data[*brIndex].v.texturecoords;
 
 			if (textl.x == texbl.x && textr.x == texbr.x && textl.y == textr.y && texbl.y == texbr.y) {
 				// Okay, the texture is also good, but let's avoid rotation issues.
-				const auto &postl = data[*tlIndex].screenpos;
-				const auto &posbr = data[*brIndex].screenpos;
+				const auto &postl = data[*tlIndex].v.screenpos;
+				const auto &posbr = data[*brIndex].v.screenpos;
 				return textl.y < texbr.y && postl.y < posbr.y && textl.x < texbr.x && postl.x < posbr.x;
 			}
 		}
@@ -520,26 +520,26 @@ bool DetectRectangleFromFan(const RasterizerState &state, const VertexData *data
 	return false;
 }
 
-bool DetectRectangleFromPair(const RasterizerState &state, const VertexData data[6], int *tlIndex, int *brIndex) {
+bool DetectRectangleFromPair(const RasterizerState &state, const ClipVertexData data[6], int *tlIndex, int *brIndex) {
 	// Color and Z must be flat.  Also find the TL and BR meanwhile.
 	int tl = 0, br = 0;
 	for (int i = 1; i < 6; ++i) {
 		if (!AreCoordsRectangleCompatible(state, data[i], data[0]))
 			return false;
 
-		if (data[i].screenpos.x <= data[tl].screenpos.x && data[i].screenpos.y <= data[tl].screenpos.y)
+		if (data[i].v.screenpos.x <= data[tl].v.screenpos.x && data[i].v.screenpos.y <= data[tl].v.screenpos.y)
 			tl = i;
-		if (data[i].screenpos.x >= data[br].screenpos.x && data[i].screenpos.y >= data[br].screenpos.y)
+		if (data[i].v.screenpos.x >= data[br].v.screenpos.x && data[i].v.screenpos.y >= data[br].v.screenpos.y)
 			br = i;
 	}
 
 	*tlIndex = tl;
 	*brIndex = br;
 
-	auto xat = [&](int i) { return data[i].screenpos.x; };
-	auto yat = [&](int i) { return data[i].screenpos.y; };
-	auto uat = [&](int i) { return data[i].texturecoords.x; };
-	auto vat = [&](int i) { return data[i].texturecoords.y; };
+	auto xat = [&](int i) { return data[i].v.screenpos.x; };
+	auto yat = [&](int i) { return data[i].v.screenpos.y; };
+	auto uat = [&](int i) { return data[i].v.texturecoords.x; };
+	auto vat = [&](int i) { return data[i].v.texturecoords.y; };
 
 	// A likely order would be: TL, TR, BR, TL, BR, BL.  We'd have the last index of each.
 	// TODO: Make more generic.
@@ -567,12 +567,12 @@ bool DetectRectangleFromPair(const RasterizerState &state, const VertexData data
 	return false;
 }
 
-bool DetectRectangleThroughModeSlices(const RasterizerState &state, const VertexData data[4]) {
+bool DetectRectangleThroughModeSlices(const RasterizerState &state, const ClipVertexData data[4]) {
 	// Color and Z must be flat.
 	for (int i = 1; i < 4; ++i) {
-		if (!(data[i].color0 == data[0].color0))
+		if (!(data[i].v.color0 == data[0].v.color0))
 			return false;
-		if (!(data[i].screenpos.z == data[0].screenpos.z)) {
+		if (!(data[i].v.screenpos.z == data[0].v.screenpos.z)) {
 			// Sometimes, we don't actually care about z.
 			if (state.pixelID.depthWrite || state.pixelID.DepthTestFunc() != GE_COMP_ALWAYS)
 				return false;
@@ -580,15 +580,15 @@ bool DetectRectangleThroughModeSlices(const RasterizerState &state, const Vertex
 	}
 
 	// Games very commonly use vertical strips of rectangles.  Detect and combine.
-	const auto &tl1 = data[0].screenpos, &br1 = data[1].screenpos;
-	const auto &tl2 = data[2].screenpos, &br2 = data[3].screenpos;
+	const auto &tl1 = data[0].v.screenpos, &br1 = data[1].v.screenpos;
+	const auto &tl2 = data[2].v.screenpos, &br2 = data[3].v.screenpos;
 	if (tl1.y == tl2.y && br1.y == br2.y && br1.y > tl1.y) {
 		if (br1.x == tl2.x && tl1.x < br1.x && tl2.x < br2.x) {
 			if (!state.enableTextures)
 				return true;
 
-			const auto &textl1 = data[0].texturecoords, &texbr1 = data[1].texturecoords;
-			const auto &textl2 = data[2].texturecoords, &texbr2 = data[3].texturecoords;
+			const auto &textl1 = data[0].v.texturecoords, &texbr1 = data[1].v.texturecoords;
+			const auto &textl2 = data[2].v.texturecoords, &texbr2 = data[3].v.texturecoords;
 			if (textl1.y != textl2.y || texbr1.y != texbr2.y || textl1.y > texbr1.y)
 				return false;
 			if (texbr1.x != textl2.x || textl1.x > texbr1.x || textl2.x > texbr2.x)

--- a/GPU/Software/RasterizerRectangle.h
+++ b/GPU/Software/RasterizerRectangle.h
@@ -20,8 +20,8 @@ namespace Rasterizer {
 	bool RectangleFastPath(const VertexData &v0, const VertexData &v1, BinManager &binner);
 	void DrawSprite(const VertexData &v0, const VertexData &v1, const BinCoords &range, const RasterizerState &state);
 
-	bool DetectRectangleFromStrip(const RasterizerState &state, const VertexData data[4], int *tlIndex, int *brIndex);
-	bool DetectRectangleFromFan(const RasterizerState &state, const VertexData *data, int c, int *tlIndex, int *brIndex);
-	bool DetectRectangleFromPair(const RasterizerState &state, const VertexData data[6], int *tlIndex, int *brIndex);
-	bool DetectRectangleThroughModeSlices(const RasterizerState &state, const VertexData data[4]);
+	bool DetectRectangleFromStrip(const RasterizerState &state, const ClipVertexData data[4], int *tlIndex, int *brIndex);
+	bool DetectRectangleFromFan(const RasterizerState &state, const ClipVertexData *data, int c, int *tlIndex, int *brIndex);
+	bool DetectRectangleFromPair(const RasterizerState &state, const ClipVertexData data[6], int *tlIndex, int *brIndex);
+	bool DetectRectangleThroughModeSlices(const RasterizerState &state, const ClipVertexData data[4]);
 }

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -160,7 +160,7 @@ const SoftwareCommandTableEntry softgpuCommandTable[] = {
 	{ GE_CMD_LOGICOP, 0, SoftDirty::PIXEL_BASIC | SoftDirty::PIXEL_CACHED },
 	{ GE_CMD_LOGICOPENABLE, 0, SoftDirty::PIXEL_BASIC | SoftDirty::PIXEL_CACHED },
 
-	{ GE_CMD_TEXMAPMODE, 0, SoftDirty::TRANSFORM_BASIC },
+	{ GE_CMD_TEXMAPMODE, 0, SoftDirty::TRANSFORM_BASIC | SoftDirty::RAST_TEX },
 
 	// These are read on every SubmitPrim, no need for dirtying or flushing.
 	{ GE_CMD_TEXSCALEU },

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -102,22 +102,22 @@ void SoftwareDrawEngine::DispatchSubmitImm(GEPrimitiveType prim, TransformedVert
 		transformUnit.SubmitPrimitive(nullptr, nullptr, prim, 0, vertTypeID, nullptr, this);
 
 	for (int i = 0; i < vertexCount; i++) {
-		VertexData vert;
+		ClipVertexData vert;
 		vert.clippos = ClipCoords(buffer[i].pos);
-		vert.texturecoords.x = buffer[i].u;
-		vert.texturecoords.y = buffer[i].v;
+		vert.v.texturecoords.x = buffer[i].u;
+		vert.v.texturecoords.y = buffer[i].v;
 		if (gstate.isModeThrough()) {
-			vert.texturecoords.x *= gstate.getTextureWidth(0);
-			vert.texturecoords.y *= gstate.getTextureHeight(0);
+			vert.v.texturecoords.x *= gstate.getTextureWidth(0);
+			vert.v.texturecoords.y *= gstate.getTextureHeight(0);
 		} else {
 			vert.clippos.z *= 1.0f / 65535.0f;
 		}
-		vert.color0 = buffer[i].color0_32;
-		vert.color1 = gstate.isUsingSecondaryColor() && !gstate.isModeThrough() ? buffer[i].color1_32 : 0;
-		vert.fogdepth = buffer[i].fog;
-		vert.screenpos.x = (int)(buffer[i].x * 16.0f);
-		vert.screenpos.y = (int)(buffer[i].y * 16.0f);
-		vert.screenpos.z = (u16)(u32)buffer[i].z;
+		vert.v.color0 = buffer[i].color0_32;
+		vert.v.color1 = gstate.isUsingSecondaryColor() && !gstate.isModeThrough() ? buffer[i].color1_32 : 0;
+		vert.v.fogdepth = buffer[i].fog;
+		vert.v.screenpos.x = (int)(buffer[i].x * 16.0f);
+		vert.v.screenpos.y = (int)(buffer[i].y * 16.0f);
+		vert.v.screenpos.z = (u16)(u32)buffer[i].z;
 
 		transformUnit.SubmitImmVertex(vert, this);
 	}
@@ -315,10 +315,10 @@ void ComputeTransformState(TransformState *state, const VertexReader &vreader) {
 		state->roundToScreen = &ClipToScreenInternal<false, true>;
 }
 
-VertexData TransformUnit::ReadVertex(VertexReader &vreader, const TransformState &state) {
+ClipVertexData TransformUnit::ReadVertex(VertexReader &vreader, const TransformState &state) {
 	PROFILE_THIS_SCOPE("read_vert");
 	// If we ever thread this, we'll have to change this.
-	VertexData vertex;
+	ClipVertexData vertex;
 
 	ModelCoords pos;
 	// VertexDecoder normally scales z, but we want it unscaled.
@@ -326,10 +326,10 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, const TransformState
 
 	static Vec2f lastTC;
 	if (state.readUV) {
-		vreader.ReadUV(vertex.texturecoords.AsArray());
-		lastTC = vertex.texturecoords;
+		vreader.ReadUV(vertex.v.texturecoords.AsArray());
+		lastTC = vertex.v.texturecoords;
 	} else {
-		vertex.texturecoords = lastTC;
+		vertex.v.texturecoords = lastTC;
 	}
 
 	Vec3f normal;
@@ -366,12 +366,12 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, const TransformState
 	}
 
 	if (vreader.hasColor0()) {
-		vreader.ReadColor0_8888((u8 *)&vertex.color0);
+		vreader.ReadColor0_8888((u8 *)&vertex.v.color0);
 	} else {
-		vertex.color0 = gstate.getMaterialAmbientRGBA();
+		vertex.v.color0 = gstate.getMaterialAmbientRGBA();
 	}
 
-	vertex.color1 = 0;
+	vertex.v.color1 = 0;
 
 	if (state.enableTransform) {
 		WorldCoords worldpos;
@@ -396,18 +396,19 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, const TransformState
 		screenScaled = vertex.clippos.xyz() * state.screenScale / vertex.clippos.w + state.screenAdd;
 #endif
 		bool outside_range_flag = false;
-		vertex.screenpos = state.roundToScreen(screenScaled, vertex.clippos, &outside_range_flag);
+		vertex.v.screenpos = state.roundToScreen(screenScaled, vertex.clippos, &outside_range_flag);
 		if (outside_range_flag) {
 			// We use this, essentially, as the flag.
-			vertex.screenpos.x = 0x7FFFFFFF;
+			vertex.v.screenpos.x = 0x7FFFFFFF;
 			return vertex;
 		}
 
 		if (state.enableFog) {
-			vertex.fogdepth = Dot(state.posToFog, Vec4f(pos, 1.0f));
+			vertex.v.fogdepth = Dot(state.posToFog, Vec4f(pos, 1.0f));
 		} else {
-			vertex.fogdepth = 1.0f;
+			vertex.v.fogdepth = 1.0f;
 		}
+		vertex.v.clipw = vertex.clippos.w;
 
 		Vec3<float> worldnormal;
 		if (vreader.hasNormal()) {
@@ -426,7 +427,7 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, const TransformState
 				break;
 
 			case GE_PROJMAP_UV:
-				source = Vec3f(vertex.texturecoords, 0.0f);
+				source = Vec3f(vertex.v.texturecoords, 0.0f);
 				break;
 
 			case GE_PROJMAP_NORMALIZED_NORMAL:
@@ -444,23 +445,23 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, const TransformState
 				break;
 			}
 
-			// TODO: What about uv scale and offset?
+			// Note that UV scale/offset are not used in this mode.
 			Vec3<float> stq = Vec3ByMatrix43(source, gstate.tgenMatrix);
 			float z_recip = 1.0f / stq.z;
-			vertex.texturecoords = Vec2f(stq.x * z_recip, stq.y * z_recip);
+			vertex.v.texturecoords = Vec2f(stq.x * z_recip, stq.y * z_recip);
 		} else if (state.uvGenMode == GE_TEXMAP_ENVIRONMENT_MAP) {
-			Lighting::GenerateLightST(vertex, worldnormal);
+			Lighting::GenerateLightST(vertex.v, worldnormal);
 		}
 
 		PROFILE_THIS_SCOPE("light");
 		if (state.enableLighting)
-			Lighting::Process(vertex, worldpos, worldnormal, state.lightingState);
+			Lighting::Process(vertex.v, worldpos, worldnormal, state.lightingState);
 	} else {
-		vertex.screenpos.x = (int)(pos[0] * SCREEN_SCALE_FACTOR);
-		vertex.screenpos.y = (int)(pos[1] * SCREEN_SCALE_FACTOR);
-		vertex.screenpos.z = pos[2];
-		vertex.clippos.w = 1.f;
-		vertex.fogdepth = 1.f;
+		vertex.v.screenpos.x = (int)(pos[0] * SCREEN_SCALE_FACTOR);
+		vertex.v.screenpos.y = (int)(pos[1] * SCREEN_SCALE_FACTOR);
+		vertex.v.screenpos.z = pos[2];
+		vertex.v.clipw = 1.0f;
+		vertex.v.fogdepth = 1.0f;
 	}
 
 	return vertex;
@@ -511,7 +512,7 @@ public:
 		}
 	}
 
-	inline VertexData Read(int vtx) {
+	inline ClipVertexData Read(int vtx) {
 		if (useIndices_) {
 			if (useCache_) {
 				return cached_[conv_(vtx) - lowerBound_];
@@ -531,13 +532,13 @@ protected:
 	TransformUnit &transform_;
 	uint16_t lowerBound_;
 	uint16_t upperBound_;
-	static std::vector<VertexData> cached_;
+	static std::vector<ClipVertexData> cached_;
 	bool useIndices_ = false;
 	bool useCache_ = false;
 };
 
 // Static to reduce allocations mid-frame.
-std::vector<VertexData> SoftwareVertexReader::cached_;
+std::vector<ClipVertexData> SoftwareVertexReader::cached_;
 
 void TransformUnit::SubmitPrimitive(const void* vertices, const void* indices, GEPrimitiveType prim_type, int vertex_count, u32 vertex_type, int *bytesRead, SoftwareDrawEngine *drawEngine)
 {
@@ -580,7 +581,7 @@ void TransformUnit::SubmitPrimitive(const void* vertices, const void* indices, G
 	if (vreader.IsThrough() && cullType == CullType::OFF && prim_type == GE_PRIM_TRIANGLES && data_index_ == 0 && vertex_count >= 6 && ((vertex_count) % 6) == 0) {
 		// Some games send rectangles as a series of regular triangles.
 		// We look for this, but only in throughmode.
-		VertexData buf[6];
+		ClipVertexData buf[6];
 		int buf_index = data_index_;
 		for (int i = 0; i < data_index_; ++i) {
 			buf[i] = data_[i];
@@ -831,7 +832,7 @@ void TransformUnit::SubmitPrimitive(const void* vertices, const void* indices, G
 	}
 }
 
-void TransformUnit::SubmitImmVertex(const VertexData &vert, SoftwareDrawEngine *drawEngine) {
+void TransformUnit::SubmitImmVertex(const ClipVertexData &vert, SoftwareDrawEngine *drawEngine) {
 	// Where we put it is different for STRIP/FAN types.
 	switch (prev_prim_) {
 	case GE_PRIM_POINTS:
@@ -872,7 +873,7 @@ void TransformUnit::SubmitImmVertex(const VertexData &vert, SoftwareDrawEngine *
 	isImmDraw_ = false;
 }
 
-void TransformUnit::SendTriangle(CullType cullType, const VertexData *verts, int provoking) {
+void TransformUnit::SendTriangle(CullType cullType, const ClipVertexData *verts, int provoking) {
 	if (cullType == CullType::OFF) {
 		Clipper::ProcessTriangle(verts[0], verts[1], verts[2], verts[provoking], *binner_);
 		Clipper::ProcessTriangle(verts[2], verts[1], verts[0], verts[provoking], *binner_);

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -261,6 +261,8 @@ void ComputeTransformState(TransformState *state, const VertexReader &vreader) {
 	state->negateNormals = gstate.areNormalsReversed();
 
 	state->uvGenMode = gstate.getUVGenMode();
+	if (state->uvGenMode == GE_TEXMAP_UNKNOWN)
+		state->uvGenMode = GE_TEXMAP_TEXTURE_COORDS;
 
 	if (state->enableTransform) {
 		bool canSkipWorldPos = true;
@@ -441,17 +443,11 @@ ClipVertexData TransformUnit::ReadVertex(VertexReader &vreader, const TransformS
 			case GE_PROJMAP_NORMAL:
 				source = normal;
 				break;
-
-			default:
-				source = Vec3f::AssignToAll(0.0f);
-				ERROR_LOG_REPORT(G3D, "Software: Unsupported UV projection mode %x", gstate.getUVProjMode());
-				break;
 			}
 
 			// Note that UV scale/offset are not used in this mode.
 			Vec3<float> stq = Vec3ByMatrix43(source, gstate.tgenMatrix);
-			float z_recip = 1.0f / stq.z;
-			vertex.v.texturecoords = Vec3Packedf(stq.x * z_recip, stq.y * z_recip, 1.0f);
+			vertex.v.texturecoords = Vec3Packedf(stq.x, stq.y, stq.z);
 		} else if (state.uvGenMode == GE_TEXMAP_ENVIRONMENT_MAP) {
 			Lighting::GenerateLightST(vertex.v, worldnormal);
 		}

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -430,7 +430,8 @@ VertexData TransformUnit::ReadVertex(VertexReader &vreader, const TransformState
 				break;
 
 			case GE_PROJMAP_NORMALIZED_NORMAL:
-				source = normal.NormalizedOr001(cpu_info.bSSE4_1);
+				// This does not use 0, 0, 1 if length is zero.
+				source = normal.Normalized(cpu_info.bSSE4_1);
 				break;
 
 			case GE_PROJMAP_NORMAL:

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -317,24 +317,31 @@ void ComputeTransformState(TransformState *state, const VertexReader &vreader) {
 
 VertexData TransformUnit::ReadVertex(VertexReader &vreader, const TransformState &state) {
 	PROFILE_THIS_SCOPE("read_vert");
+	// If we ever thread this, we'll have to change this.
 	VertexData vertex;
 
 	ModelCoords pos;
 	// VertexDecoder normally scales z, but we want it unscaled.
 	vreader.ReadPosThroughZ16(pos.AsArray());
 
+	static Vec2f lastTC;
 	if (state.readUV) {
 		vreader.ReadUV(vertex.texturecoords.AsArray());
+		lastTC = vertex.texturecoords;
 	} else {
-		vertex.texturecoords.SetZero();
+		vertex.texturecoords = lastTC;
 	}
 
-	Vec3<float> normal;
+	Vec3f normal;
+	static Vec3f lastnormal;
 	if (vreader.hasNormal()) {
 		vreader.ReadNrm(normal.AsArray());
+		lastnormal = normal;
 
 		if (state.negateNormals)
 			normal = -normal;
+	} else {
+		normal = lastnormal;
 	}
 
 	if (state.readWeights) {

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -79,12 +79,12 @@ struct DrawingCoords {
 };
 
 struct alignas(16) VertexData {
-	Vec2<float> texturecoords;
+	Vec3Packedf texturecoords;
+	float clipw;
 	uint32_t color0;
 	uint32_t color1;
 	ScreenCoords screenpos;
 	float fogdepth;
-	float clipw;
 };
 
 struct ClipVertexData {


### PR DESCRIPTION
This includes q in the interpolated stq to properly project coordinates, which wasn't being done before.  Fixes the ground in TOCA (from a frame dump.)

Along the way, this also fixes texture projection with flat shading (outside GL/GLES), as well as what (0, 0, 0) normalizes to for the purposes of texture projection.  These are probably very rare cases, though.

Did some other confirmations:
 * Processing when UV or normal not in vertex type (it uses whatever value was most recently specified.)  Implemented, but in software renderer only.
 * Confirmed texture projection doesn't happen in through, but does happen for transformed rectangles.
 * Confirmed UV scale/offset does not apply to the texgen result, regardless of source.
 * Confirmed weights do apply to the texgen source (i.e. normals, etc.)

Tried to do this carefully so there's neutral impact to performance for the common cases.

See also https://github.com/hrydgard/pspautotests/pull/226 (doesn't exactly pass these tests, due to some precision issues.)

-[Unknown]