### PR TITLE
Vulkan: Better debug names for RENDER passes.

### DIFF
--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -559,7 +559,13 @@ void VulkanQueueRunner::RunSteps(std::vector<VKRStep *> &steps, FrameData &frame
 
 		if (emitLabels) {
 			VkDebugUtilsLabelEXT labelInfo{ VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT };
-			labelInfo.pLabelName = step.tag;
+			char temp[128];
+			if (step.stepType == VKRStepType::RENDER && step.render.framebuffer) {
+				snprintf(temp, sizeof(temp), "%s: %s", step.tag, step.render.framebuffer->Tag());
+				labelInfo.pLabelName = temp;
+			} else {
+				labelInfo.pLabelName = step.tag;
+			}
 			vkCmdBeginDebugUtilsLabelEXT(frameData.mainCmd, &labelInfo);
 		}
 

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -964,7 +964,7 @@ void FramebufferManagerCommon::NotifyRenderFramebufferSwitched(VirtualFramebuffe
 	if (useBufferedRendering_) {
 		if (vfb->fbo) {
 			shaderManager_->DirtyLastShader();
-			draw_->BindFramebufferAsRenderTarget(vfb->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, "FramebufferSwitch");
+			draw_->BindFramebufferAsRenderTarget(vfb->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, "FBSwitch");
 		} else {
 			// This should only happen very briefly when toggling useBufferedRendering_.
 			ResizeFramebufFBO(vfb, vfb->width, vfb->height, true);


### PR DESCRIPTION
Fairly trivial, but quite nice in RenderDoc:

![image](https://user-images.githubusercontent.com/130929/192641026-3b247100-3f99-43b6-9039-e0bd3e306ba1.png)

Previously, all you got on each line (without expanding and looking at the individual render targets) was "FramebufferSwitch".