### PR TITLE
Remove alpha ignore in xbrz texture shaders.

### DIFF
--- a/assets/shaders/tex_2xbrz.csh
+++ b/assets/shaders/tex_2xbrz.csh
@@ -100,11 +100,6 @@ void applyScaling(uvec2 origxy) {
 
 	ivec4 blendResult = ivec4(BLEND_NONE);
 
-	// Preserve old alpha-ignoring behavior? Keep or delete?
-	for (int i = 0; i < 9; i++) {
-		v[i] &= 0xFFFFFF;
-	}
-
 	// Preprocess corners
 	// Pixel Tap Mapping: --|--|--|--|--
 	//                    --|--|07|08|--

--- a/assets/shaders/tex_4xbrz.csh
+++ b/assets/shaders/tex_4xbrz.csh
@@ -100,11 +100,6 @@ void applyScaling(uvec2 origxy) {
 
 	ivec4 blendResult = ivec4(BLEND_NONE);
 
-	// Preserve old alpha-ignoring behavior? Keep or delete?
-	for (int i = 0; i < 9; i++) {
-		v[i] &= 0xFFFFFF;
-	}
-
 	// Preprocess corners
 	// Pixel Tap Mapping: --|--|--|--|--
 	//                    --|--|07|08|--


### PR DESCRIPTION
Gpu scaling ignores texture alpha and this is resulting in some upscaled but unfiltered textures. This tends to be mostly hud items but some ui elements can have a mix of filtered and unfiltered elements and it can be quite jarring. Just a small change to roll back an earlier commit that unifies the behaviour accross the two implementations.

Master:
![UCES00422_00002](https://user-images.githubusercontent.com/8155719/192727888-a3e02c95-f14a-4dc1-9259-166d0be2ea12.jpg)
PR:
![UCES00422_00001](https://user-images.githubusercontent.com/8155719/192727990-8ce6a380-4789-42ea-9565-6647e10be828.jpg)

Master CPU:
![UCES00422_00000](https://user-images.githubusercontent.com/8155719/192727789-6bb0b930-fc9a-43cb-97b8-92f18015b0c4.jpg)

Master:
![ULES00111_00002](https://user-images.githubusercontent.com/8155719/192728745-5808256c-c3c9-4a61-a9b5-4db9e85b5e1a.jpg)
PR:
![ULES00111_00001](https://user-images.githubusercontent.com/8155719/192728819-6292ba2d-2b57-4db0-9358-afeb69983255.jpg)
Master CPU:
![ULES00111_00000](https://user-images.githubusercontent.com/8155719/192728852-a1c9b365-5c80-4e87-a861-ae22ad76baea.jpg)
