### PR TITLE
Fixes for Silent Hill: Origins (depth buffer reassignment, eliminate readback)

### DIFF
--- a/Common/GPU/Vulkan/VulkanProfiler.cpp
+++ b/Common/GPU/Vulkan/VulkanProfiler.cpp
@@ -34,13 +34,13 @@ void VulkanProfiler::BeginFrame(VulkanContext *vulkan, VkCommandBuffer firstComm
 		static const char * const indent[4] = { "", "  ", "    ", "      " };
 
 		if (!scopes_.empty()) {
-			NOTICE_LOG(G3D, "Profiling events this frame:");
+			INFO_LOG(G3D, "Profiling events this frame:");
 		}
 
 		// Log it all out.
 		for (auto &scope : scopes_) {
 			if (scope.endQueryId == -1) {
-				NOTICE_LOG(G3D, "Unclosed scope: %s", scope.name.c_str());
+				WARN_LOG(G3D, "Unclosed scope: %s", scope.name.c_str());
 				continue;
 			}
 			uint64_t startTime = results[scope.startQueryId];
@@ -50,7 +50,7 @@ void VulkanProfiler::BeginFrame(VulkanContext *vulkan, VkCommandBuffer firstComm
 
 			double milliseconds = (double)delta * timestampConversionFactor;
 
-			NOTICE_LOG(G3D, "%s%s (%0.3f ms)", indent[scope.level & 3], scope.name.c_str(), milliseconds);
+			INFO_LOG(G3D, "%s%s (%0.3f ms)", indent[scope.level & 3], scope.name.c_str(), milliseconds);
 		}
 
 		scopes_.clear();

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -167,11 +167,11 @@ void VKRFramebuffer::UpdateTag(const char *newTag) {
 	char name[128];
 	snprintf(name, sizeof(name), "fb_color_%s", tag_.c_str());
 	vulkan_->SetDebugName(color.image, VK_OBJECT_TYPE_IMAGE, name);
-	vulkan_->SetDebugName(color.image, VK_OBJECT_TYPE_IMAGE_VIEW, name);
+	vulkan_->SetDebugName(color.imageView, VK_OBJECT_TYPE_IMAGE_VIEW, name);
 	if (depth.image) {
 		snprintf(name, sizeof(name), "fb_depth_%s", tag_.c_str());
 		vulkan_->SetDebugName(depth.image, VK_OBJECT_TYPE_IMAGE, name);
-		vulkan_->SetDebugName(depth.image, VK_OBJECT_TYPE_IMAGE_VIEW, name);
+		vulkan_->SetDebugName(depth.imageView, VK_OBJECT_TYPE_IMAGE_VIEW, name);
 	}
 	for (int rpType = 0; rpType < RP_TYPE_COUNT; rpType++) {
 		if (framebuf[rpType]) {

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -153,14 +153,32 @@ VKRFramebuffer::VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VKRRe
 	_dbg_assert_(tag);
 
 	CreateImage(vulkan_, initCmd, color, width, height, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, true, tag);
-	vulkan_->SetDebugName(color.image, VK_OBJECT_TYPE_IMAGE, StringFromFormat("fb_color_%s", tag).c_str());
 	if (createDepthStencilBuffer) {
 		CreateImage(vulkan_, initCmd, depth, width, height, vulkan_->GetDeviceInfo().preferredDepthStencilFormat, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, false, tag);
-		vulkan_->SetDebugName(depth.image, VK_OBJECT_TYPE_IMAGE, StringFromFormat("fb_depth_%s", tag).c_str());
 	}
+
+	UpdateTag(tag);
 
 	// We create the actual framebuffer objects on demand, because some combinations might not make sense.
 	// Framebuffer objects are just pointers to a set of images, so no biggie.
+}
+
+void VKRFramebuffer::UpdateTag(const char *newTag) {
+	char name[128];
+	snprintf(name, sizeof(name), "fb_color_%s", tag_.c_str());
+	vulkan_->SetDebugName(color.image, VK_OBJECT_TYPE_IMAGE, name);
+	vulkan_->SetDebugName(color.image, VK_OBJECT_TYPE_IMAGE_VIEW, name);
+	if (depth.image) {
+		snprintf(name, sizeof(name), "fb_depth_%s", tag_.c_str());
+		vulkan_->SetDebugName(depth.image, VK_OBJECT_TYPE_IMAGE, name);
+		vulkan_->SetDebugName(depth.image, VK_OBJECT_TYPE_IMAGE_VIEW, name);
+	}
+	for (int rpType = 0; rpType < RP_TYPE_COUNT; rpType++) {
+		if (framebuf[rpType]) {
+			snprintf(name, sizeof(name), "fb_%s", tag_.c_str());
+			vulkan_->SetDebugName(framebuf[(int)rpType], VK_OBJECT_TYPE_FRAMEBUFFER, name);
+		}
+	}
 }
 
 VkFramebuffer VKRFramebuffer::Get(VKRRenderPass *compatibleRenderPass, RenderPassType rpType) {

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -57,6 +57,8 @@ public:
 		return tag_.c_str();
 	}
 
+	void UpdateTag(const char *newTag);
+
 	// TODO: Hide.
 	VulkanContext *vulkan_;
 private:

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1490,6 +1490,9 @@ public:
 		buf_ = nullptr;
 	}
 	VKRFramebuffer *GetFB() const { return buf_; }
+	void UpdateTag(const char *newTag) override {
+		buf_->UpdateTag(newTag);
+	}
 private:
 	VKRFramebuffer *buf_;
 };

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -411,6 +411,7 @@ class Framebuffer : public RefCountedObject {
 public:
 	int Width() { return width_; }
 	int Height() { return height_; }
+	virtual void UpdateTag(const char *tag) {}
 protected:
 	int width_ = -1, height_ = -1;
 };

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -709,6 +709,14 @@ ULUS10428 = true
 ULES01375 = true
 ULUS10429 = true
 
+# Silent Hill: Origins
+# Avoids readback.
+ULES00869 = true
+ULUS10285 = true
+ULKS46161 = true
+ULJM05281 = true
+NPJH50051 = true
+
 [IntraVRAMBlockTransferAllowCreateFB]
 # Final Fantasy - Type 0
 ULJM05900 = true


### PR DESCRIPTION
If a framebuffer starts using a different depth buffer address than before, re-point. This fixes an issue where the wrong depth buffer was  being copied from in Silent Hill Origins, causing weird artifacts like this:

![image](https://user-images.githubusercontent.com/130929/192750582-c58f76da-72cb-4be6-82b4-16d9c7de0ab0.png)

Ideally we should copy off the depth buffer to another framebuffer that's still pointed at that depth buffer, but in practice this is not very likely to be needed. We'll implement it if we find it is.

Plus, use a compat setting to eliminate readbacks (to improve performance), and reduce some logging.

(This does not fix shadows, that's a separate problem)

See issue #16126