### PR TITLE
softjit: Fix dst blend shift

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2363,7 +2363,8 @@ void GPUCommon::Execute_TgenMtxNum(u32 op, u32 diff) {
 			if (dst[i] != newVal) {
 				Flush();
 				dst[i] = newVal;
-				gstate_c.Dirty(DIRTY_TEXMATRIX);
+				// We check the matrix to see if we need projection.
+				gstate_c.Dirty(DIRTY_TEXMATRIX | DIRTY_FRAGMENTSHADER_STATE);
 			}
 			if (++i >= end) {
 				break;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -780,6 +780,9 @@ void GPUCommon::ResetMatrices() {
 		matrixVisible.proj[i] = toFloat24(gstate.projMatrix[i]);
 	for (size_t i = 0; i < ARRAY_SIZE(gstate.tgenMatrix); ++i)
 		matrixVisible.tgen[i] = toFloat24(gstate.tgenMatrix[i]);
+
+	// Assume all the matrices changed, so dirty things related to them.
+	gstate_c.Dirty(DIRTY_WORLDMATRIX | DIRTY_VIEWMATRIX | DIRTY_PROJMATRIX | DIRTY_TEXMATRIX | DIRTY_FRAGMENTSHADER_STATE | DIRTY_BONE_UNIFORMS);
 }
 
 u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<PspGeListArgs> args, bool head) {
@@ -1341,7 +1344,8 @@ void GPUCommon::Execute_Iaddr(u32 op, u32 diff) {
 }
 
 void GPUCommon::Execute_Origin(u32 op, u32 diff) {
-	gstate_c.offsetAddr = currentList->pc;
+	if (currentList)
+		gstate_c.offsetAddr = currentList->pc;
 }
 
 void GPUCommon::Execute_Jump(u32 op, u32 diff) {
@@ -2175,6 +2179,11 @@ void GPUCommon::Execute_BlockTransferStart(u32 op, u32 diff) {
 }
 
 void GPUCommon::Execute_WorldMtxNum(u32 op, u32 diff) {
+	if (!currentList) {
+		gstate.worldmtxnum = (GE_CMD_WORLDMATRIXNUMBER << 24) | (op & 0xF);
+		return;
+	}
+
 	// This is almost always followed by GE_CMD_WORLDMATRIXDATA.
 	const u32_le *src = (const u32_le *)Memory::GetPointerUnchecked(currentList->pc + 4);
 	u32 *dst = (u32 *)(gstate.worldMatrix + (op & 0xF));
@@ -2225,6 +2234,11 @@ void GPUCommon::Execute_WorldMtxData(u32 op, u32 diff) {
 }
 
 void GPUCommon::Execute_ViewMtxNum(u32 op, u32 diff) {
+	if (!currentList) {
+		gstate.viewmtxnum = (GE_CMD_VIEWMATRIXNUMBER << 24) | (op & 0xF);
+		return;
+	}
+
 	// This is almost always followed by GE_CMD_VIEWMATRIXDATA.
 	const u32_le *src = (const u32_le *)Memory::GetPointerUnchecked(currentList->pc + 4);
 	u32 *dst = (u32 *)(gstate.viewMatrix + (op & 0xF));
@@ -2273,6 +2287,11 @@ void GPUCommon::Execute_ViewMtxData(u32 op, u32 diff) {
 }
 
 void GPUCommon::Execute_ProjMtxNum(u32 op, u32 diff) {
+	if (!currentList) {
+		gstate.projmtxnum = (GE_CMD_PROJMATRIXNUMBER << 24) | (op & 0xF);
+		return;
+	}
+
 	// This is almost always followed by GE_CMD_PROJMATRIXDATA.
 	const u32_le *src = (const u32_le *)Memory::GetPointerUnchecked(currentList->pc + 4);
 	u32 *dst = (u32 *)(gstate.projMatrix + (op & 0xF));
@@ -2322,6 +2341,11 @@ void GPUCommon::Execute_ProjMtxData(u32 op, u32 diff) {
 }
 
 void GPUCommon::Execute_TgenMtxNum(u32 op, u32 diff) {
+	if (!currentList) {
+		gstate.texmtxnum = (GE_CMD_TGENMATRIXNUMBER << 24) | (op & 0xF);
+		return;
+	}
+
 	// This is almost always followed by GE_CMD_TGENMATRIXDATA.
 	const u32_le *src = (const u32_le *)Memory::GetPointerUnchecked(currentList->pc + 4);
 	u32 *dst = (u32 *)(gstate.tgenMatrix + (op & 0xF));
@@ -2370,6 +2394,11 @@ void GPUCommon::Execute_TgenMtxData(u32 op, u32 diff) {
 }
 
 void GPUCommon::Execute_BoneMtxNum(u32 op, u32 diff) {
+	if (!currentList) {
+		gstate.boneMatrixNumber = (GE_CMD_BONEMATRIXNUMBER << 24) | (op & 0x7F);
+		return;
+	}
+
 	// This is almost always followed by GE_CMD_BONEMATRIXDATA.
 	const u32_le *src = (const u32_le *)Memory::GetPointerUnchecked(currentList->pc + 4);
 	u32 *dst = (u32 *)(gstate.boneMatrix + (op & 0x7F));

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -1159,7 +1159,7 @@ bool PixelJitCache::Jit_AlphaBlend(const PixelFuncID &id) {
 			if (id.AlphaBlendEq() == GE_BLENDMODE_MUL_AND_SUBTRACT_REVERSE)
 				PXOR(dstReg, R(dstReg));
 		} else if (id.AlphaBlendDst() == PixelBlendFactor::ONE) {
-			if (blendState.dstColorAsFactor)
+			if (blendState.dstColorAsFactor || blendState.usesDstAlpha)
 				PSRLW(dstReg, 4);
 		}
 

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -130,6 +130,12 @@ void ComputeRasterizerState(RasterizerState *state) {
 		state->minFilt = gstate.isMinifyFilteringEnabled();
 		state->magFilt = gstate.isMagnifyFilteringEnabled();
 		state->textureProj = gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX;
+		if (state->textureProj) {
+			// We may be able to optimize this off.  This is actually kinda common.
+			if (gstate.tgenMatrix[2] == 0.0f && gstate.tgenMatrix[5] == 0.0f && gstate.tgenMatrix[8] == 0.0f && gstate.tgenMatrix[11] == 1.0f) {
+				state->textureProj = false;
+			}
+		}
 	}
 
 	state->shadeGouraud = gstate.getShadeMode() == GE_SHADE_GOURAUD;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -1196,6 +1196,11 @@ bool SoftGPU::GetMatrix24(GEMatrixType type, u32_le *result, u32 cmdbits) {
 	return true;
 }
 
+void SoftGPU::ResetMatrices() {
+	GPUCommon::ResetMatrices();
+	dirtyFlags_ |= SoftDirty::TRANSFORM_MATRIX;
+}
+
 void SoftGPU::Execute_ImmVertexAlphaPrim(u32 op, u32 diff) {
 	GPUCommon::Execute_ImmVertexAlphaPrim(op, diff);
 	// We won't flush as often as hardware renderers, so we want to flush right away.

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -1127,8 +1127,11 @@ void SoftGPU::Execute_TgenMtxData(u32 op, u32 diff) {
 	if (num < 12) {
 		u32 *target = (u32 *)&gstate.tgenMatrix[num];
 		u32 newVal = op << 8;
-		// No dirtying, read during vertex read.
-		*target = newVal;
+		if (newVal != *target) {
+			*target = newVal;
+			// This is mainly used in vertex read, but also affects if we enable texture projection.
+			dirtyFlags_ |= SoftDirty::RAST_TEX;
+		}
 	}
 
 	// Doesn't wrap to any other matrix.
@@ -1198,7 +1201,7 @@ bool SoftGPU::GetMatrix24(GEMatrixType type, u32_le *result, u32 cmdbits) {
 
 void SoftGPU::ResetMatrices() {
 	GPUCommon::ResetMatrices();
-	dirtyFlags_ |= SoftDirty::TRANSFORM_MATRIX;
+	dirtyFlags_ |= SoftDirty::TRANSFORM_MATRIX | SoftDirty::RAST_TEX;
 }
 
 void SoftGPU::Execute_ImmVertexAlphaPrim(u32 op, u32 diff) {

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -194,6 +194,7 @@ public:
 	void Execute_BoneMtxData(u32 op, u32 diff);
 
 	bool GetMatrix24(GEMatrixType type, u32_le *result, u32 cmdbits) override;
+	void ResetMatrices() override;
 
 	void Execute_ImmVertexAlphaPrim(u32 op, u32 diff);
 


### PR DESCRIPTION
Silly mistake in a recent change, fixes the ocean in #16131.

Also, while I was looking at it I optimized a case of `0, 0, 0, 1` matrix values for q a bit.  While so doing, I realized we don't actually dirty matrix uniforms in `gstate.Restore()`.  Initially I went to change this to setting cmds for shared dirty handling, but I figured it's safer to just dirty in ResetMatrices() due to currentList access.

Also noticed that tgen wasn't properly dirtying the fragment shader ID, so this also fixes that.

Not sure how many games use the save/restore of contexts for matrix state, but better to be safe.

-[Unknown]