### PR TITLE
Debugger: Fix game.reset by adding a reboot status

### DIFF
--- a/Core/Debugger/WebSocket.cpp
+++ b/Core/Debugger/WebSocket.cpp
@@ -97,6 +97,10 @@ static void UpdateConnected(int delta) {
 }
 
 static void WebSocketNotifyLifecycle(CoreLifecycle stage) {
+	// We'll likely already be locked during the reboot.
+	if (PSP_IsRebooting())
+		return;
+
 	switch (stage) {
 	case CoreLifecycle::STARTING:
 	case CoreLifecycle::STOPPING:

--- a/Core/Debugger/WebSocket/GameBroadcaster.cpp
+++ b/Core/Debugger/WebSocket/GameBroadcaster.cpp
@@ -86,7 +86,7 @@ void GameBroadcaster::Broadcast(net::WebSocketServer *ws) {
 		} else if (state == UISTATE_INGAME && PSP_IsInited()) {
 			ws->Send(GameStatusEvent{"game.start"});
 			prevState_ = state;
-		} else if (state == UISTATE_MENU && !PSP_IsInited() && !PSP_IsQuitting()) {
+		} else if (state == UISTATE_MENU && !PSP_IsInited() && !PSP_IsQuitting() && !PSP_IsRebooting()) {
 			ws->Send(GameStatusEvent{"game.quit"});
 			prevState_ = state;
 		}

--- a/Core/Debugger/WebSocket/GameSubscriber.cpp
+++ b/Core/Debugger/WebSocket/GameSubscriber.cpp
@@ -49,9 +49,8 @@ void WebSocketGameReset(DebuggerRequest &req) {
 	if (needBreak)
 		PSP_CoreParameter().startBreak = true;
 
-	PSP_Shutdown();
 	std::string resetError;
-	if (!PSP_Init(PSP_CoreParameter(), &resetError)) {
+	if (!PSP_Reboot(&resetError)) {
 		ERROR_LOG(BOOT, "Error resetting: %s", resetError.c_str());
 		return req.Fail("Could not reset");
 	}

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -114,6 +114,7 @@ static std::string gpuBackendDevice;
 static volatile bool pspIsInited = false;
 static volatile bool pspIsIniting = false;
 static volatile bool pspIsQuitting = false;
+static volatile bool pspIsRebooting = false;
 
 void ResetUIState() {
 	globalUIState = UISTATE_MENU;
@@ -448,6 +449,7 @@ bool PSP_InitStart(const CoreParameter &coreParam, std::string *error_string) {
 	bool success = !g_CoreParameter.fileToStart.empty();
 	if (!success) {
 		Core_NotifyLifecycle(CoreLifecycle::START_COMPLETE);
+		pspIsRebooting = false;
 		// In this case, we must call shutdown since the caller won't know to.
 		// It must've partially started since CPU_Init returned true.
 		PSP_Shutdown();
@@ -475,6 +477,7 @@ bool PSP_InitUpdate(std::string *error_string) {
 		}
 	}
 	if (!success) {
+		pspIsRebooting = false;
 		PSP_Shutdown();
 		return true;
 	}
@@ -483,6 +486,7 @@ bool PSP_InitUpdate(std::string *error_string) {
 	pspIsIniting = !pspIsInited;
 	if (pspIsInited) {
 		Core_NotifyLifecycle(CoreLifecycle::START_COMPLETE);
+		pspIsRebooting = false;
 	}
 	return pspIsInited;
 }
@@ -501,7 +505,11 @@ bool PSP_IsIniting() {
 }
 
 bool PSP_IsInited() {
-	return pspIsInited && !pspIsQuitting;
+	return pspIsInited && !pspIsQuitting && !pspIsRebooting;
+}
+
+bool PSP_IsRebooting() {
+	return pspIsRebooting;
 }
 
 bool PSP_IsQuitting() {
@@ -515,7 +523,7 @@ void PSP_Shutdown() {
 	}
 
 	// Make sure things know right away that PSP memory, etc. is going away.
-	pspIsQuitting = true;
+	pspIsQuitting = !pspIsRebooting;
 	if (coreState == CORE_RUNNING)
 		Core_Stop();
 
@@ -538,6 +546,18 @@ void PSP_Shutdown() {
 	pspIsQuitting = false;
 	g_Config.unloadGameConfig();
 	Core_NotifyLifecycle(CoreLifecycle::STOPPED);
+}
+
+bool PSP_Reboot(std::string *error_string) {
+	if (!pspIsInited || pspIsQuitting)
+		return false;
+
+	pspIsRebooting = true;
+	Core_Stop();
+	Core_WaitInactive();
+	PSP_Shutdown();
+	std::string resetError;
+	return PSP_Init(PSP_CoreParameter(), error_string);
 }
 
 void PSP_BeginHostFrame() {

--- a/Core/System.h
+++ b/Core/System.h
@@ -75,8 +75,10 @@ bool PSP_InitStart(const CoreParameter &coreParam, std::string *error_string);
 bool PSP_InitUpdate(std::string *error_string);
 bool PSP_IsIniting();
 bool PSP_IsInited();
+bool PSP_IsRebooting();
 bool PSP_IsQuitting();
 void PSP_Shutdown();
+bool PSP_Reboot(std::string *error_string);
 
 void PSP_BeginHostFrame();
 void PSP_EndHostFrame();

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1097,7 +1097,7 @@ void EmuScreen::update() {
 }
 
 void EmuScreen::checkPowerDown() {
-	if (coreState == CORE_POWERDOWN && !PSP_IsIniting()) {
+	if (coreState == CORE_POWERDOWN && !PSP_IsIniting() && !PSP_IsRebooting()) {
 		if (PSP_IsInited()) {
 			PSP_Shutdown();
 		}


### PR DESCRIPTION
We don't want EmuScreen to auto-exit, and we don't want to double-lock the debugger lifecycle lock.  Let's just handle reboot specifically.

-[Unknown]