### PR TITLE
Vulkan: Create depth/stencil buffers on demand

### DIFF
--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -1611,7 +1611,7 @@ VKRRenderPass *VulkanQueueRunner::PerformBindFramebufferAsRenderTarget(const VKR
 		renderPass = GetRenderPass(key);
 
 		VKRFramebuffer *fb = step.render.framebuffer;
-		framebuf = fb->Get(renderPass, step.render.renderPassType);
+		framebuf = fb->Get(renderPass, step.render.renderPassType, cmd);
 		w = fb->width;
 		h = fb->height;
 
@@ -1799,7 +1799,8 @@ void VulkanQueueRunner::PerformBlit(const VKRStep &step, VkCommandBuffer cmd) {
 	// We can't copy only depth or only stencil unfortunately.
 	if (step.blit.aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) {
 		_dbg_assert_(src->depth.image != VK_NULL_HANDLE);
-		_dbg_assert_(dst->depth.image != VK_NULL_HANDLE);
+
+		dst->EnsureDepthImage(cmd);
 
 		if (src->depth.layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL) {
 			SetupTransitionToTransferSrc(src->depth, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, &recordBarrier_);

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -46,7 +46,10 @@ public:
 	VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VKRRenderPass *compatibleRenderPass, int _width, int _height, bool createDepthStencilBuffer, const char *tag);
 	~VKRFramebuffer();
 
-	VkFramebuffer Get(VKRRenderPass *compatibleRenderPass, RenderPassType rpType);
+	void EnsureDepthImage(VkCommandBuffer initCmd);
+
+	// Needs a command buffer in case it need to initialize the depth buffer on-demand.
+	VkFramebuffer Get(VKRRenderPass *compatibleRenderPass, RenderPassType rpType, VkCommandBuffer initCmd);
 
 	int width = 0;
 	int height = 0;

--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -170,7 +170,7 @@ void UIContext::ActivateTopScissor() {
 		int h = std::max(0.0f, ceilf(scale_y * bounds.h));
 		if (x < 0 || y < 0 || x + w > pixel_xres || y + h > pixel_yres) {
 			// This won't actually report outside a game, but we can try.
-			ERROR_LOG_REPORT(G3D, "UI scissor out of bounds in %sScreen: %d,%d-%d,%d / %d,%d", screenTag_ ? screenTag_ : "N/A", x, y, w, h, pixel_xres, pixel_yres);
+			WARN_LOG(G3D, "UI scissor out of bounds in %sScreen: %d,%d-%d,%d / %d,%d", screenTag_ ? screenTag_ : "N/A", x, y, w, h, pixel_xres, pixel_yres);
 			x = std::max(0, x);
 			y = std::max(0, y);
 			w = std::min(w, pixel_xres - x);


### PR DESCRIPTION
Just a minor video memory optimization, made easy by the big renderpass/framebuffer refactor.

Will do some extra testing soon once I've finished some validation layer cleanup, so marking as draft.