### PR TITLE
GPU: Use flags to fix triggered upload/download

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -306,7 +306,7 @@ public:
 
 	void CopyDisplayToOutput(bool reallyDirty);
 
-	bool NotifyFramebufferCopy(u32 src, u32 dest, int size, bool isMemset, u32 skipDrawReason);
+	bool NotifyFramebufferCopy(u32 src, u32 dest, int size, GPUCopyFlag flags, u32 skipDrawReason);
 	void NotifyVideoUpload(u32 addr, int size, int width, GEBufferFormat fmt);
 	void UpdateFromMemory(u32 addr, int size);
 	void ApplyClearToMemory(int x1, int y1, int x2, int y2, u32 clearColor);

--- a/GPU/Debugger/Record.cpp
+++ b/GPU/Debugger/Record.cpp
@@ -691,10 +691,11 @@ void NotifyUpload(u32 dest, u32 sz) {
 		return;
 	}
 
-	CheckEdramTrans();
-	NotifyMemcpy(dest, dest, sz);
-	if (Memory::IsVRAMAddress(dest))
+	if (Memory::IsVRAMAddress(dest)) {
+		// This also checks the edram translation value.
+		NotifyMemcpy(dest, dest, sz);
 		DirtyVRAM(dest, sz, DirtyVRAMFlag::DIRTY);
+	}
 }
 
 static bool HasDrawCommands() {

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -124,7 +124,7 @@ public:
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) override;
 	void CopyDisplayToOutput(bool reallyDirty) override = 0;
 	void InitClear() override = 0;
-	bool PerformMemoryCopy(u32 dest, u32 src, int size) override;
+	bool PerformMemoryCopy(u32 dest, u32 src, int size, GPUCopyFlag flags = GPUCopyFlag::NONE) override;
 	bool PerformMemorySet(u32 dest, u8 v, int size) override;
 	bool PerformMemoryDownload(u32 dest, int size) override;
 	bool PerformMemoryUpload(u32 dest, int size) override;

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -114,6 +114,16 @@ enum class StencilUpload {
 };
 ENUM_CLASS_BITOPS(StencilUpload);
 
+enum class GPUCopyFlag {
+	NONE = 0,
+	FORCE_SRC_MEM = 1,
+	FORCE_DST_MEM = 2,
+	// Note: implies src == dst and FORCE_SRC_MEM.
+	MEMSET = 4,
+	DEBUG_NOTIFIED = 8,
+};
+ENUM_CLASS_BITOPS(GPUCopyFlag);
+
 // Used for debug
 struct FramebufferInfo {
 	u32 fb_address;
@@ -222,7 +232,7 @@ public:
 	virtual void InvalidateCache(u32 addr, int size, GPUInvalidationType type) = 0;
 	virtual void NotifyVideoUpload(u32 addr, int size, int width, int format) = 0;
 	// Update either RAM from VRAM, or VRAM from RAM... or even VRAM from VRAM.
-	virtual bool PerformMemoryCopy(u32 dest, u32 src, int size) = 0;
+	virtual bool PerformMemoryCopy(u32 dest, u32 src, int size, GPUCopyFlag flags = GPUCopyFlag::NONE) = 0;
 	virtual bool PerformMemorySet(u32 dest, u8 v, int size) = 0;
 	virtual bool PerformMemoryDownload(u32 dest, int size) = 0;
 	virtual bool PerformMemoryUpload(u32 dest, int size) = 0;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -1265,11 +1265,11 @@ void SoftGPU::NotifyVideoUpload(u32 addr, int size, int width, int format)
 	// Ignore.
 }
 
-bool SoftGPU::PerformMemoryCopy(u32 dest, u32 src, int size)
-{
+bool SoftGPU::PerformMemoryCopy(u32 dest, u32 src, int size, GPUCopyFlag flags) {
 	// Nothing to update.
 	InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
-	GPURecord::NotifyMemcpy(dest, src, size);
+	if (!(flags & GPUCopyFlag::DEBUG_NOTIFIED))
+		GPURecord::NotifyMemcpy(dest, src, size);
 	// Let's just be safe.
 	MarkDirty(dest, size, SoftGPUVRAMDirty::DIRTY | SoftGPUVRAMDirty::REALLY_DIRTY);
 	return false;

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -139,7 +139,7 @@ public:
 	void GetStats(char *buffer, size_t bufsize) override;
 	void InvalidateCache(u32 addr, int size, GPUInvalidationType type) override;
 	void NotifyVideoUpload(u32 addr, int size, int width, int format) override;
-	bool PerformMemoryCopy(u32 dest, u32 src, int size) override;
+	bool PerformMemoryCopy(u32 dest, u32 src, int size, GPUCopyFlag flags = GPUCopyFlag::NONE) override;
 	bool PerformMemorySet(u32 dest, u8 v, int size) override;
 	bool PerformMemoryDownload(u32 dest, int size) override;
 	bool PerformMemoryUpload(u32 dest, int size) override;


### PR DESCRIPTION
Without making any more major changes, this switches to using a flag instead of a mirror hack.

No changes to frame dumps are needed, because they only call `gpu->PerformMemoryUpload()`, which will continue working as before.  Only callers of PerformMemoryCopy are affected.

I thought about also simply removing PerformMemoryUpload and PerformMemoryDownload, but it's nice to not repeat dest/src and include the flags.  This fixes speedometers in Ridge Racer, etc.

-[Unknown]
