### PR TITLE
Improve Freedesktop integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2513,6 +2513,8 @@ if(UNIX AND NOT ANDROID AND NOT APPLE)
 		DIRECTORY "${CMAKE_BINARY_DIR}/assets"
 		DESTINATION "${CMAKE_INSTALL_DATADIR}/ppsspp"
 		PATTERN ".git*" EXCLUDE
+		PATTERN "mime" EXCLUDE
+		PATTERN "lang/README.md" EXCLUDE
 	)
 	install(
 		FILES "${CMAKE_BINARY_DIR}/ppsspp.desktop"
@@ -2525,7 +2527,11 @@ if(UNIX AND NOT ANDROID AND NOT APPLE)
 	)
 	install(
 		FILES "${CMAKE_SOURCE_DIR}/icons/icon-512.svg"
-		DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pixmaps"
-		RENAME ppsspp.svg
+		DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps"
+		RENAME "ppsspp.svg"
+	)
+	install(
+		FILES "${CMAKE_SOURCE_DIR}/assets/mime/ppsspp.xml"
+		DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/mime/packages"
 	)
 endif()

--- a/assets/mime/ppsspp.xml
+++ b/assets/mime/ppsspp.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="application/x-compressed-iso">
+    <glob pattern="*.cso"/>
+    <magic>
+      <match type="little32" offset="0" value="0x4F534943"/>
+    </magic>
+    <comment>Compressed ISO Image</comment>
+    <comment xml:lang="de">Komprimiertes ISO&#x2011;Abbild</comment>
+    <comment xml:lang="pl">Skomprymowany obraz ISO</comment>
+    <acronym>CSO</acronym>
+    <generic-icon name="media-optical"/>
+  </mime-type>
+</mime-info>

--- a/ppsspp.desktop.in
+++ b/ppsspp.desktop.in
@@ -4,4 +4,6 @@ Exec=@TargetBin@
 Icon=ppsspp
 Type=Application
 Comment=ppsspp (fast and portable PSP emulator)
-Categories=Game;Emulator
+Keywords=Sony;PlayStation;Portable;PSP;handheld;console;
+Categories=Game;Emulator;
+MimeType=application/x-cd-image;application/x-iso9660-image;application/x-compressed-iso;application/zip;


### PR DESCRIPTION
* Move scalable icon install from `${prefix}/share/pixmaps` (`pixmaps` has been deprecated long time ago) to `${prefix}/share/icons/hicolor/scalable/apps`
* Add `Keywords`, `Categories`, and `MimeType` keys to `.desktop` file
* Add shared MIME-info on [`application/x-compressed-iso`](https://en.wikipedia.org/wiki/.CSO "Compressed ISO") MIME type