### PR TITLE
Reporting: Always report hleReportDebug

### DIFF
--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -189,7 +189,7 @@ T hleDoLog(LogTypes::LOG_TYPE t, LogTypes::LOG_LEVELS level, T res, const char *
 
 template <typename T>
 T hleDoLog(LogTypes::LOG_TYPE t, LogTypes::LOG_LEVELS level, T res, const char *file, int line, const char *reportTag, char retmask) {
-	if (level > MAX_LOGLEVEL || !GenericLogEnabled(level, t)) {
+	if ((level > MAX_LOGLEVEL || !GenericLogEnabled(level, t)) && !reportTag) {
 		return res;
 	}
 

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -434,7 +434,8 @@ namespace Reporting
 	void AddGameplayInfo(UrlEncoder &postdata)
 	{
 		// Just to get an idea of how long they played.
-		postdata.Add("ticks", (const uint64_t)CoreTiming::GetTicks());
+		if (PSP_IsInited())
+			postdata.Add("ticks", (const uint64_t)CoreTiming::GetTicks());
 
 		float vps, fps;
 		__DisplayGetAveragedFPS(&vps, &fps);


### PR DESCRIPTION
Also avoid accessing CoreTiming::GetTicks() when PSP_IsInited() is not true.

-[Unknown]