### PR TITLE
Shader uniforms (VK/D3D11): Fix issue where we could overwrite values in the fourth component padding.

### DIFF
--- a/Common/Data/Convert/SmallDataConvert.h
+++ b/Common/Data/Convert/SmallDataConvert.h
@@ -82,6 +82,20 @@ inline void Uint8x3ToFloat4(float f[4], uint32_t u) {
 #endif
 }
 
+inline void Uint8x3ToFloat3(float f[4], uint32_t u) {
+#if defined(_M_SSE) || PPSSPP_ARCH(ARM_NEON)
+	float temp[3];
+	Uint8x4ToFloat4(temp, u & 0xFFFFFF);
+	f[0] = temp[0];
+	f[1] = temp[1];
+	f[2] = temp[2];
+#else
+	f[0] = ((u >> 0) & 0xFF) * (1.0f / 255.0f);
+	f[1] = ((u >> 8) & 0xFF) * (1.0f / 255.0f);
+	f[2] = ((u >> 16) & 0xFF) * (1.0f / 255.0f);
+#endif
+}
+
 inline void Uint8x3ToInt4(int i[4], uint32_t u) {
 	i[0] = ((u >> 0) & 0xFF);
 	i[1] = ((u >> 8) & 0xFF);

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -74,7 +74,7 @@ void CalcCullRange(float minValues[4], float maxValues[4], bool flipViewport, bo
 
 void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipViewport, bool useBufferedRendering) {
 	if (dirtyUniforms & DIRTY_TEXENV) {
-		Uint8x3ToFloat4(ub->texEnvColor, gstate.texenvcolor);
+		Uint8x3ToFloat3(ub->texEnvColor, gstate.texenvcolor);
 	}
 	if (dirtyUniforms & DIRTY_ALPHACOLORREF) {
 		Uint8x3ToInt4_Alpha(ub->alphaColorRef, gstate.getColorTestRef(), gstate.getAlphaTestRef() & gstate.getAlphaTestMask());
@@ -86,8 +86,8 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 		Uint8x3ToFloat4(ub->fogColor, gstate.fogcolor);
 	}
 	if (dirtyUniforms & DIRTY_SHADERBLEND) {
-		Uint8x3ToFloat4(ub->blendFixA, gstate.getFixA());
-		Uint8x3ToFloat4(ub->blendFixB, gstate.getFixB());
+		Uint8x3ToFloat3(ub->blendFixA, gstate.getFixA());
+		Uint8x3ToFloat3(ub->blendFixB, gstate.getFixB());
 	}
 	if (dirtyUniforms & DIRTY_TEXCLAMP) {
 		const float invW = 1.0f / (float)gstate_c.curTextureWidth;
@@ -303,9 +303,7 @@ void LightUpdateUniforms(UB_VS_Lights *ub, uint64_t dirtyUniforms) {
 	}
 	if (dirtyUniforms & DIRTY_MATEMISSIVE) {
 		// We're not touching the fourth f32 here, because we store an u32 of control bits in it.
-		float temp[4];
-		Uint8x3ToFloat4(temp, gstate.materialemissive);
-		memcpy(ub->materialEmissive, temp, 12);
+		Uint8x3ToFloat3(ub->materialEmissive, gstate.materialemissive);
 	}
 	if (dirtyUniforms & DIRTY_LIGHT_CONTROL) {
 		ub->lightControl = PackLightControlBits();


### PR DESCRIPTION
Several potential bugs here, things seems to have worked by some luck.