### PR TITLE
Vulkan buffer binding optimizations during draw

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -131,7 +131,7 @@ public:
 
 	void EndFrame() override;
 
-	void Draw(int vertexCount, int offset) override;
+	void Draw(int vertexCount) override;
 	void DrawIndexed(int vertexCount, int offset) override;
 	void DrawUP(const void *vdata, int vertexCount) override;
 	void Clear(int mask, uint32_t colorval, float depthVal, int stencilVal) override;
@@ -1227,9 +1227,9 @@ void D3D11DrawContext::BindIndexBuffer(Buffer *indexBuffer, int offset) {
 	nextIndexBufferOffset_ = buf ? offset : 0;
 }
 
-void D3D11DrawContext::Draw(int vertexCount, int offset) {
+void D3D11DrawContext::Draw(int vertexCount) {
 	ApplyCurrentState();
-	context_->Draw(vertexCount, offset);
+	context_->Draw(vertexCount, 0);
 }
 
 void D3D11DrawContext::DrawIndexed(int indexCount, int offset) {
@@ -1244,8 +1244,7 @@ void D3D11DrawContext::DrawUP(const void *vdata, int vertexCount) {
 
 	UpdateBuffer(upBuffer_, (const uint8_t *)vdata, 0, byteSize, Draw::UPDATE_DISCARD);
 	BindVertexBuffers(0, 1, &upBuffer_, nullptr);
-	int offset = 0;
-	Draw(vertexCount, offset);
+	Draw(vertexCount);
 }
 
 uint32_t D3D11DrawContext::GetDataFormatSupport(DataFormat fmt) const {

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -570,7 +570,7 @@ public:
 	void SetStencilParams(uint8_t refValue, uint8_t writeMask, uint8_t compareMask) override;
 
 	void ApplyDynamicState();
-	void Draw(int vertexCount, int offset) override;
+	void Draw(int vertexCount) override;
 	void DrawIndexed(int vertexCount, int offset) override;
 	void DrawUP(const void *vdata, int vertexCount) override;
 	void Clear(int mask, uint32_t colorval, float depthVal, int stencilVal) override;
@@ -1108,12 +1108,12 @@ inline int D3DPrimCount(D3DPRIMITIVETYPE prim, int size) {
 	return (size / D3DPRIMITIVEVERTEXCOUNT[prim][0]) - D3DPRIMITIVEVERTEXCOUNT[prim][1];
 }
 
-void D3D9Context::Draw(int vertexCount, int offset) {
+void D3D9Context::Draw(int vertexCount) {
 	device_->SetStreamSource(0, curVBuffers_[0]->vbuffer_, curVBufferOffsets_[0], curPipeline_->inputLayout->GetStride(0));
 	curPipeline_->inputLayout->Apply(device_);
 	curPipeline_->Apply(device_, stencilRef_, stencilWriteMask_, stencilCompareMask_);
 	ApplyDynamicState();
-	device_->DrawPrimitive(curPipeline_->prim, offset, D3DPrimCount(curPipeline_->prim, vertexCount));
+	device_->DrawPrimitive(curPipeline_->prim, 0, D3DPrimCount(curPipeline_->prim, vertexCount));
 }
 
 void D3D9Context::DrawIndexed(int vertexCount, int offset) {

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -418,8 +418,7 @@ public:
 
 	void UpdateDynamicUniformBuffer(const void *ub, size_t size) override;
 
-	// TODO: Add more sophisticated draws.
-	void Draw(int vertexCount, int offset) override;
+	void Draw(int vertexCount) override;
 	void DrawIndexed(int vertexCount, int offset) override;
 	void DrawUP(const void *vdata, int vertexCount) override;
 
@@ -1279,13 +1278,13 @@ void OpenGLContext::UpdateDynamicUniformBuffer(const void *ub, size_t size) {
 	}
 }
 
-void OpenGLContext::Draw(int vertexCount, int offset) {
+void OpenGLContext::Draw(int vertexCount) {
 	_dbg_assert_msg_(curVBuffers_[0] != nullptr, "Can't call Draw without a vertex buffer");
 	ApplySamplers();
 	if (curPipeline_->inputLayout) {
 		renderManager_.BindVertexBuffer(curPipeline_->inputLayout->inputLayout_, curVBuffers_[0]->buffer_, curVBufferOffsets_[0]);
 	}
-	renderManager_.Draw(curPipeline_->prim, offset, vertexCount);
+	renderManager_.Draw(curPipeline_->prim, 0, vertexCount);
 }
 
 void OpenGLContext::DrawIndexed(int vertexCount, int offset) {

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -1571,7 +1571,7 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 				VkDeviceSize voffset = c.draw.voffset;
 				vkCmdBindVertexBuffers(cmd, 0, 1, &c.draw.vbuffer, &voffset);
 			}
-			vkCmdDraw(cmd, c.draw.count, 1, c.draw.offset, 0);
+			vkCmdDraw(cmd, c.draw.count, 1, 0, 0);
 			break;
 		}
 

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -96,7 +96,6 @@ struct VkRenderData {
 			VkBuffer vbuffer;
 			VkDeviceSize voffset;
 			uint32_t count;
-			uint32_t offset;
 		} draw;
 		struct {
 			VkDescriptorSet ds;

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -80,6 +80,10 @@ bool VKRGraphicsPipeline::Create(VulkanContext *vulkan, VkRenderPass compatibleR
 	pipe.basePipelineIndex = 0;
 	pipe.subpass = 0;
 
+	if (desc->vis.vertexBindingDescriptionCount == 1) {
+		vertexStride = desc->vis.pVertexBindingDescriptions[0].stride;
+	}
+
 	double start = time_now_d();
 	VkPipeline vkpipeline;
 	VkResult result = vkCreateGraphicsPipelines(vulkan->GetDevice(), desc->pipelineCache, 1, &pipe, nullptr, &vkpipeline);

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -391,11 +391,10 @@ public:
 			curRenderStep_->render.stencilStore = VKRRenderPassStoreAction::DONT_CARE;
 	}
 
-	void Draw(VkDescriptorSet descSet, int numUboOffsets, const uint32_t *uboOffsets, VkBuffer vbuffer, int voffset, int count, int offset = 0) {
+	void Draw(VkDescriptorSet descSet, int numUboOffsets, const uint32_t *uboOffsets, VkBuffer vbuffer, int voffset, int count) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER && curStepHasViewport_ && curStepHasScissor_);
 		VkRenderData data{ VKRRenderCommand::DRAW };
 		data.draw.count = count;
-		data.draw.offset = offset;
 		data.draw.ds = descSet;
 		data.draw.vbuffer = vbuffer;
 		data.draw.voffset = voffset;

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -166,6 +166,7 @@ struct VKRGraphicsPipeline {
 
 	VKRGraphicsPipelineDesc *desc = nullptr;  // not owned!
 	Promise<VkPipeline> *pipeline[RP_TYPE_COUNT]{};
+	uint32_t vertexStride = 0;
 	std::string tag;
 };
 

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -761,6 +761,7 @@ bool VKTexture::Create(VkCommandBuffer cmd, VulkanPushBuffer *push, const Textur
 			layout = VK_IMAGE_LAYOUT_GENERAL;
 		}
 	}
+
 	vkTex_->EndCreate(cmd, false, VK_PIPELINE_STAGE_TRANSFER_BIT, layout);
 	return true;
 }

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -440,7 +440,7 @@ public:
 	void UpdateDynamicUniformBuffer(const void *ub, size_t size) override;
 
 	// TODO: Add more sophisticated draws.
-	void Draw(int vertexCount, int offset) override;
+	void Draw(int vertexCount) override;
 	void DrawIndexed(int vertexCount, int offset) override;
 	void DrawUP(const void *vdata, int vertexCount) override;
 
@@ -1324,7 +1324,7 @@ void VKContext::ApplyDynamicState() {
 	}
 }
 
-void VKContext::Draw(int vertexCount, int offset) {
+void VKContext::Draw(int vertexCount) {
 	VKBuffer *vbuf = curVBuffers_[0];
 
 	VkBuffer vulkanVbuf;
@@ -1340,7 +1340,7 @@ void VKContext::Draw(int vertexCount, int offset) {
 
 	BindCurrentPipeline();
 	ApplyDynamicState();
-	renderManager_.Draw(descSet, 1, &ubo_offset, vulkanVbuf, (int)vbBindOffset + curVBufferOffsets_[0], vertexCount, offset);
+	renderManager_.Draw(descSet, 1, &ubo_offset, vulkanVbuf, (int)vbBindOffset + curVBufferOffsets_[0], vertexCount);
 }
 
 void VKContext::DrawIndexed(int vertexCount, int offset) {

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -708,7 +708,7 @@ public:
 
 	virtual void BindPipeline(Pipeline *pipeline) = 0;
 
-	virtual void Draw(int vertexCount, int offset) = 0;
+	virtual void Draw(int vertexCount) = 0;
 	virtual void DrawIndexed(int vertexCount, int offset) = 0;  // Always 16-bit indices.
 	virtual void DrawUP(const void *vdata, int vertexCount) = 0;
 	


### PR DESCRIPTION
Avoid a large amount of buffer binding calls in the vulkan draw queue runner with some simple math, we now use the offset parameters of vkCmdDraw/vkCmdDrawIndexed whenever possible. Unfortunately this takes a division/modulo per draw, but I think that's still a lot faster than entering the driver.

Should help some less-optimized VK drivers a bit.