### PR TITLE
Correct size and YUV order for jpeg decoding

### DIFF
--- a/Core/HLE/sceJpeg.cpp
+++ b/Core/HLE/sceJpeg.cpp
@@ -34,6 +34,8 @@
 // #define JPEG_DEBUG
 #ifdef JPEG_DEBUG
 #include "ext/xxhash.h"
+#include "Common/File/FileUtil.h"
+#include "Common/StringUtils.h"
 #endif
 
 struct u24_be {
@@ -396,14 +398,14 @@ static int JpegGetOutputInfo(u32 jpegAddr, int jpegSize, u32 colourInfoAddr) {
 	}
 
 #ifdef JPEG_DEBUG
-		char jpeg_fname[256];
 		const u8 *jpegDumpBuf = Memory::GetPointer(jpegAddr);
 		u32 jpeg_xxhash = XXH32((const char *)jpegDumpBuf, jpegSize, 0xC0108888);
-		sprintf(jpeg_fname, "Jpeg\\%X.jpg", jpeg_xxhash);
-		FILE *wfp = fopen(jpeg_fname, "wb");
+		Path jpegDir("Jpeg");
+		Path jpegFile = jpegDir / StringFromFormat("%X.jpg", jpeg_xxhash);
+		FILE *wfp = File::OpenCFile(jpegFile, "wb");
 		if (!wfp) {
-			_wmkdir(L"Jpeg\\");
-			wfp = fopen(jpeg_fname, "wb");
+			File::CreateDir(jpegDir);
+			wfp = File::OpenCFile(jpegFile, "wb");
 		}
 		fwrite(jpegDumpBuf, 1, jpegSize, wfp);
 		fclose(wfp);

--- a/Core/HLE/sceJpeg.cpp
+++ b/Core/HLE/sceJpeg.cpp
@@ -322,7 +322,7 @@ static int DecodeJpeg(u32 jpegAddr, int jpegSize, u32 imageAddr, int &usec) {
 	}
 
 	free(jpegBuf);
-	return hleLogSuccessI(ME, getWidthHeight(width, height));
+	return hleLogSuccessX(ME, getWidthHeight(width, height));
 }
 
 static int sceJpegDecodeMJpeg(u32 jpegAddr, int jpegSize, u32 imageAddr, int dhtMode) {
@@ -413,7 +413,7 @@ static int JpegGetOutputInfo(u32 jpegAddr, int jpegSize, u32 colourInfoAddr) {
 		fclose(wfp);
 #endif //JPEG_DEBUG
 
-	return hleLogSuccessI(ME, getYCbCrBufferSize(width, height));
+	return hleLogSuccessX(ME, getYCbCrBufferSize(width, height));
 }
 
 static int sceJpegGetOutputInfo(u32 jpegAddr, int jpegSize, u32 colourInfoAddr, int dhtMode) {
@@ -523,7 +523,7 @@ static int JpegDecodeMJpegYCbCr(u32 jpegAddr, int jpegSize, u32 yCbCrAddr, int y
 
 	// Rough estimate based on observed timing.
 	usec += (width * height) / 14;
-	return hleLogSuccessI(ME, getWidthHeight(width, height));
+	return hleLogSuccessX(ME, getWidthHeight(width, height));
 }
 
 static int sceJpegDecodeMJpegYCbCr(u32 jpegAddr, int jpegSize, u32 yCbCrAddr, int yCbCrSize, int dhtMode) {
@@ -623,14 +623,14 @@ const HLEFunction sceJpeg[] =
 {
 	{0X0425B986, &WrapI_V<sceJpegDecompressAllImage>,               "sceJpegDecompressAllImage",           'i', ""     },
 	{0X04B5AE02, &WrapI_UUII<sceJpegMJpegCsc>,                      "sceJpegMJpegCsc",                     'i', "xxxi" },
-	{0X04B93CEF, &WrapI_UIUI<sceJpegDecodeMJpeg>,                   "sceJpegDecodeMJpeg",                  'i', "xixi" },
-	{0X227662D7, &WrapI_UIUII<sceJpegDecodeMJpegYCbCrSuccessively>, "sceJpegDecodeMJpegYCbCrSuccessively", 'i', "xixii"},
+	{0X04B93CEF, &WrapI_UIUI<sceJpegDecodeMJpeg>,                   "sceJpegDecodeMJpeg",                  'x', "xixi" },
+	{0X227662D7, &WrapI_UIUII<sceJpegDecodeMJpegYCbCrSuccessively>, "sceJpegDecodeMJpegYCbCrSuccessively", 'x', "xixii"},
 	{0X48B602B7, &WrapI_V<sceJpegDeleteMJpeg>,                      "sceJpegDeleteMJpeg",                  'i', ""     },
-	{0X64B6F978, &WrapI_UIUI<sceJpegDecodeMJpegSuccessively>,       "sceJpegDecodeMJpegSuccessively",      'i', "xixi" },
+	{0X64B6F978, &WrapI_UIUI<sceJpegDecodeMJpegSuccessively>,       "sceJpegDecodeMJpegSuccessively",      'x', "xixi" },
 	{0X67F0ED84, &WrapI_UUIII<sceJpegCsc>,                          "sceJpegCsc",                          'i', "xxxix"},
 	{0X7D2F3D7F, &WrapI_V<sceJpegFinishMJpeg>,                      "sceJpegFinishMJpeg",                  'i', ""     },
 	{0X8F2BB012, &WrapI_UIUI<sceJpegGetOutputInfo>,                 "sceJpegGetOutputInfo",                'x', "xipi" },
-	{0X91EED83C, &WrapI_UIUII<sceJpegDecodeMJpegYCbCr>,             "sceJpegDecodeMJpegYCbCr",             'i', "xixii"},
+	{0X91EED83C, &WrapI_UIUII<sceJpegDecodeMJpegYCbCr>,             "sceJpegDecodeMJpegYCbCr",             'x', "xixii"},
 	{0X9B36444C, &WrapI_V<sceJpeg_9B36444C>,                        "sceJpeg_9B36444C",                    'i', ""     },
 	{0X9D47469C, &WrapI_II<sceJpegCreateMJpeg>,                     "sceJpegCreateMJpeg",                  'i', "ii"   },
 	{0XAC9E70E6, &WrapI_V<sceJpegInitMJpeg>,                        "sceJpegInitMJpeg",                    'i', ""     },

--- a/Core/HLE/sceJpeg.cpp
+++ b/Core/HLE/sceJpeg.cpp
@@ -442,6 +442,13 @@ static int sceJpegDecompressAllImage() {
 	return 0;
 }
 
+void JpegNotifyLoadStatus(int state) {
+	if (state == -1) {
+		// Reset our state on unload.
+		__JpegInit();
+	}
+}
+
 const HLEFunction sceJpeg[] =
 {
 	{0X0425B986, &WrapI_V<sceJpegDecompressAllImage>,               "sceJpegDecompressAllImage",           'i', ""     },

--- a/Core/HLE/sceJpeg.h
+++ b/Core/HLE/sceJpeg.h
@@ -19,6 +19,8 @@
 
 class PointerWrap;
 
+void JpegNotifyLoadStatus(int state);
+
 void Register_sceJpeg();
 void __JpegInit();
 void __JpegDoState(PointerWrap &p);

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -32,7 +32,6 @@ enum {
 	ERROR_MPEG_NOT_YET_INIT                             = 0x80618009,
 	ERROR_MPEG_AVC_INVALID_VALUE                        = 0x806201fe,
 	ERROR_MPEG_AVC_DECODE_FATAL                         = 0x80628002,
-	ERROR_JPEG_INVALID_VALUE                            = 0x80650051,
 };
 
 // MPEG statics.

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -34,6 +34,7 @@
 #include "Core/Reporting.h"
 #include "Core/System.h"
 
+#include "Core/HLE/sceJpeg.h"
 #include "Core/HLE/sceKernel.h"
 #include "Core/HLE/sceKernelInterrupt.h"
 #include "Core/HLE/sceKernelMemory.h"
@@ -79,15 +80,20 @@ static const int mpegBaseModuleDeps[] = {0x0300, 0};
 static const int mp4ModuleDeps[] = {0x0300, 0};
 
 struct ModuleLoadInfo {
-	ModuleLoadInfo(int m, u32 s) : mod(m), size(s), dependencies(noDeps) {
+	ModuleLoadInfo(int m, u32 s, void(*n)(int) = nullptr) : mod(m), size(s), dependencies(noDeps), notify(n) {
 	}
-	ModuleLoadInfo(int m, u32 s, const int *d) : mod(m), size(s), dependencies(d) {
+	ModuleLoadInfo(int m, u32 s, const int *d, void(*n)(int) = nullptr) : mod(m), size(s), dependencies(d), notify(n) {
 	}
 
 	const int mod;
 	const u32 size;
 	const int *const dependencies;
+	void (*notify)(int state);
 };
+
+static void NotifyLoadStatusAvcodec(int state) {
+	JpegNotifyLoadStatus(state);
+}
 
 static const ModuleLoadInfo moduleLoadInfo[] = {
 	ModuleLoadInfo(0x0100, 0x00014000),
@@ -104,7 +110,7 @@ static const ModuleLoadInfo moduleLoadInfo[] = {
 	ModuleLoadInfo(0x0202, 0x00000000),
 	ModuleLoadInfo(0x0203, 0x00000000),
 	ModuleLoadInfo(0x02ff, 0x00000000),
-	ModuleLoadInfo(0x0300, 0x00000000),
+	ModuleLoadInfo(0x0300, 0x00000000, &NotifyLoadStatusAvcodec),
 	ModuleLoadInfo(0x0301, 0x00000000),
 	ModuleLoadInfo(0x0302, 0x00008000, atrac3PlusModuleDeps),
 	ModuleLoadInfo(0x0303, 0x0000c000, mpegBaseModuleDeps),
@@ -470,12 +476,16 @@ static u32 sceUtilityLoadAvModule(u32 module)
 	}
 	
 	INFO_LOG(SCEUTILITY, "0=sceUtilityLoadAvModule(%i)", module);
+	if (module == 0)
+		JpegNotifyLoadStatus(1);
 	return hleDelayResult(0, "utility av module loaded", 25000);
 }
 
 static u32 sceUtilityUnloadAvModule(u32 module)
 {
 	INFO_LOG(SCEUTILITY,"0=sceUtilityUnloadAvModule(%i)", module);
+	if (module == 0)
+		JpegNotifyLoadStatus(-1);
 	return hleDelayResult(0, "utility av module unloaded", 800);
 }
 
@@ -516,6 +526,9 @@ static u32 sceUtilityLoadModule(u32 module) {
 		currentlyLoadedModules[module] = 0;
 	}
 
+	if (info->notify)
+		info->notify(1);
+
 	// TODO: Each module has its own timing, technically, but this is a low-end.
 	if (module == 0x3FF)
 		return hleDelayResult(hleLogSuccessInfoI(SCEUTILITY, 0), "utility module loaded", 130);
@@ -536,6 +549,9 @@ static u32 sceUtilityUnloadModule(u32 module) {
 		userMemory.Free(currentlyLoadedModules[module]);
 	}
 	currentlyLoadedModules.erase(module);
+
+	if (info->notify)
+		info->notify(-1);
 
 	// TODO: Each module has its own timing, technically, but this is a low-end.
 	if (module == 0x3FF)


### PR DESCRIPTION
Fixes #9931, it turns out the stride is part of the `sceJpegCreateMJpeg()` function call, which should keep #9760 working (does for another play view.)  See tests in https://github.com/hrydgard/pspautotests/pull/229 which validate this functionality.

I think this may help #16157 as some logs indicated it uses sceJpeg (and sceJpeg was not logging read/write in the debugger.)  It would make more sense than a download to VRAM using the wrong stride.

This also corrects the swizzle for sceJpegCsc, which I'm hoping will help #9457 as well.

Other changes:
 * Most of these functions should reschedule (I believe they run on the ME), and now do.  Timing is rough.
 * Error codes are much better, although not perfect for invalid data.
 * Grayscale JPEGs now work consistently (before, they did not decode), although the PSP seems to fail to decode grayscale so maybe they shouldn't (note: incorrectly allowing grayscale decode currently causes test failures.)
 * Pointers are validated, fixing what would've previously crashed with bad parameters.
 * Debugger knows about reads and writes now.
 * Stride for colorspace conversion behaves more correctly (although sceJpegMJpegCsc has some weird behavior, causing test failures.)

Notably, the jpeg decoding and colorspace conversions are not bit accurate to the PSP, so the colors are still slightly off.  Didn't really touch the RGBA/YCbCr conversion.  Currently our JPEG decoder goes to RGB, and then we go back to YCbCr, which adds error.

There's some weird behavior with `sceJpegMJpegCsc()`, which is no less broken than before.  Changing Cb or Cr values doesn't affect the pixels I'd expect, I think it might be upside-down and swizzled or something.  `sceJpegDecodeMJpegYCbCr()` is probably using a similarly wrong order.  Since they match, it shouldn't cause real problems, but it's not currently accurate.

-[Unknown]