### PR TITLE
Add rendered CLUT handling to D3D9

### DIFF
--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -201,11 +201,19 @@ public:
 	D3DTEXTUREFILTERTYPE magFilt, minFilt, mipFilt;
 
 	void Apply(LPDIRECT3DDEVICE9 device, int index) {
-		dxstate.texAddressU.set(wrapS);
-		dxstate.texAddressV.set(wrapT);
-		dxstate.texMagFilter.set(magFilt);
-		dxstate.texMinFilter.set(minFilt);
-		dxstate.texMipFilter.set(mipFilt);
+		if (index == 0) {
+			dxstate.texAddressU.set(wrapS);
+			dxstate.texAddressV.set(wrapT);
+			dxstate.texMagFilter.set(magFilt);
+			dxstate.texMinFilter.set(minFilt);
+			dxstate.texMipFilter.set(mipFilt);
+		} else {
+			pD3Ddevice9->SetSamplerState(index, D3DSAMP_ADDRESSU, wrapS);
+			pD3Ddevice9->SetSamplerState(index, D3DSAMP_ADDRESSV, wrapT);
+			pD3Ddevice9->SetSamplerState(index, D3DSAMP_MAGFILTER, magFilt);
+			pD3Ddevice9->SetSamplerState(index, D3DSAMP_MINFILTER, minFilt);
+			pD3Ddevice9->SetSamplerState(index, D3DSAMP_MIPFILTER, mipFilt);
+		}
 	}
 };
 

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -174,7 +174,10 @@ void GenerateDepalShaderFloat(ShaderWriter &writer, const DepalConfig &config) {
 	case GE_FORMAT_CLUT8:
 		if (shift == 0 && mask == 0xFF) {
 			// Easy peasy.
-			sprintf(lookupMethod, "index.r");
+			if (writer.Lang().shaderLanguage == HLSL_D3D9)
+				sprintf(lookupMethod, "index.a");
+			else
+				sprintf(lookupMethod, "index.r");
 			formatOK = true;
 		} else {
 			// Deal with this if we find it.
@@ -302,6 +305,10 @@ void GenerateDepalShaderFloat(ShaderWriter &writer, const DepalConfig &config) {
 	// Offset by half a texel (plus clutBase) to turn NEAREST filtering into FLOOR.
 	// Technically, the clutBase should be |'d, not added, but that's hard with floats.
 	float texel_offset = ((float)config.startPos + 0.5f) / texturePixels;
+	if (writer.Lang().shaderLanguage == HLSL_D3D9) {
+		// Seems to need a half-pixel offset fix?  Might mean it was rendered wrong...
+		texel_offset += 0.5f / texturePixels;
+	}
 	char offset[128] = "";
 	sprintf(offset, " + %f", texel_offset);
 

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -47,6 +47,8 @@ Draw::DataFormat FromD3D9Format(u32 fmt) {
 		return Draw::DataFormat::A1R5G5B5_UNORM_PACK16;
 	case D3DFMT_R5G6B5:
 		return Draw::DataFormat::R5G6B5_UNORM_PACK16;
+	case D3DFMT_A8:
+		return Draw::DataFormat::R8_UNORM;
 	case D3DFMT_A8R8G8B8:
 	default:
 		return Draw::DataFormat::R8G8B8A8_UNORM;
@@ -251,6 +253,8 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 		dstFmt = ToD3D9Format(plan.replaced->Format(plan.baseLevelSrc));
 	} else if (plan.scaleFactor > 1 || plan.saveTexture) {
 		dstFmt = D3DFMT_A8R8G8B8;
+	} else if (plan.decodeToClut8) {
+		dstFmt = D3DFMT_A8;
 	}
 
 	int levels;


### PR DESCRIPTION
Was missing in #16014, causing Brave Story to look bad.

The half-pixel offset thing doesn't look right, though, but it seems to work okay for Brave Story and just aiming for this to not be glitchy broken as it was before (wasn't decoding the texture correctly.)

Frame dump:
[#6754_ULUS10279_brave_story_rabbits_new.zip](https://github.com/hrydgard/ppsspp/files/9740375/6754_ULUS10279_brave_story_rabbits_new.zip)

-[Unknown]