### PR TITLE
GLES: Use GL_LUMINANCE on GLES for indexed tex

### DIFF
--- a/Common/GPU/D3D9/D3D9StateCache.h
+++ b/Common/GPU/D3D9/D3D9StateCache.h
@@ -398,15 +398,3 @@ public:
 #undef STATE2
 
 extern DirectXState dxstate;
-
-struct GLExtensions {
-	bool OES_depth24;
-	bool OES_packed_depth_stencil;
-	bool OES_depth_texture;
-	bool EXT_discard_framebuffer;
-	bool FBO_ARB;
-};
-
-extern GLExtensions gl_extensions;
-
-void CheckGLExtensions();

--- a/Common/GPU/OpenGL/DataFormatGL.cpp
+++ b/Common/GPU/OpenGL/DataFormatGL.cpp
@@ -1,4 +1,5 @@
 #include "Common/GPU/OpenGL/DataFormatGL.h"
+#include "Common/GPU/OpenGL/GLFeatures.h"
 #include "Common/Log.h"
 
 namespace Draw {
@@ -15,8 +16,16 @@ bool Thin3DFormatToGLFormatAndType(DataFormat fmt, GLuint &internalFormat, GLuin
 		break;
 
 	case DataFormat::R8_UNORM:
-		internalFormat = GL_RGBA;
-		format = GL_RED;
+		if (gl_extensions.IsGLES) {
+			internalFormat = GL_LUMINANCE;
+			format = GL_LUMINANCE;
+		} else if (gl_extensions.VersionGEThan(3, 0)) {
+			internalFormat = GL_RED;
+			format = GL_RED;
+		} else {
+			internalFormat = GL_RGBA;
+			format = GL_RED;
+		}
 		type = GL_UNSIGNED_BYTE;
 		alignment = 1;
 		break;


### PR DESCRIPTION
See #16176, used for rendered CLUTs.

According to the spec, GL_RED has to be used with a sized internal format, I think:
https://registry.khronos.org/OpenGL-Refpages/es3/html/glTexImage2D.xhtml

Easy to repro with simulateGLES = true.  GL_LUMINANCE is supported even for GLES2, so let's use that.  This is actually the same format I used back with #8246.

Also, on desktop we can use GL_RED for the internal format for GL3+.

Fixes #16176.

-[Unknown]