### PR TITLE
GPU: Hook Gods Eater Burst avatar read

### DIFF
--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -289,6 +289,7 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0x70a6152b265228e8, 296, "unendingbloodycall_download_frame", }, // unENDing Bloody Call
 	{ 0x7245b74db370ae72, 64, "vmmul_q_transp3", },
 	{ 0x7259d52b21814a5a, 40, "vtfm_t_transp", },
+	{ 0x730f59cc6c0f5732, 452, "godseaterburst_depthmask_5551", }, // Gods Eater Burst (US)
 	{ 0x7354fd206796d817, 864, "flowers_download_frame", }, // Flowers
 	{ 0x736b34ebc702d873, 104, "vmmul_q_transp", },
 	{ 0x73a614c08f777d52, 792, "danganronpa2_2_download_frame", }, // Danganronpa 2

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2605,7 +2605,7 @@ void FramebufferManagerCommon::PackFramebufferSync(VirtualFramebuffer *vfb, int 
 	const int dstByteOffset = (y * stride + x) * dstBpp;
 	// Leave the gap between the end of the last line and the full stride.
 	// This is only used for the NotifyMemInfo range.
-	const int dstSize = (h * stride + w - 1) * dstBpp;
+	const int dstSize = ((h - 1) * stride + w) * dstBpp;
 
 	if (!Memory::IsValidRange(fb_address + dstByteOffset, dstSize)) {
 		ERROR_LOG_REPORT(G3D, "PackFramebufferSync would write outside of memory, ignoring");

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -442,6 +442,8 @@ public:
 
 protected:
 	virtual void PackFramebufferSync(VirtualFramebuffer *vfb, int x, int y, int w, int h, RasterChannel channel);
+	// Used for when a shader is required, such as GLES.
+	virtual void PackDepthbuffer(VirtualFramebuffer *vfb, int x, int y, int w, int h);
 	void SetViewport2D(int x, int y, int w, int h);
 	Draw::Texture *MakePixelTexture(const u8 *srcPixels, GEBufferFormat srcPixelFormat, int srcStride, int width, int height);
 	void DrawActiveTexture(float x, float y, float w, float h, float destW, float destH, float u0, float v0, float u1, float v1, int uvRotation, int flags);

--- a/GPU/Directx9/FramebufferManagerDX9.h
+++ b/GPU/Directx9/FramebufferManagerDX9.h
@@ -49,10 +49,10 @@ public:
 
 protected:
 	void DecimateFBOs() override;
+	void PackDepthbuffer(VirtualFramebuffer *vfb, int x, int y, int w, int h) override;
 
 private:
 	void PackFramebufferSync(VirtualFramebuffer *vfb, int x, int y, int w, int h, RasterChannel channel) override;
-	void PackDepthbuffer(VirtualFramebuffer *vfb, int x, int y, int w, int h);
 	bool GetRenderTargetFramebuffer(LPDIRECT3DSURFACE9 renderTarget, LPDIRECT3DSURFACE9 offscreen, int w, int h, GPUDebugBuffer &buffer);
 
 	LPDIRECT3DDEVICE9 device_;

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -38,10 +38,9 @@ public:
 
 protected:
 	void UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) override;
+	void PackDepthbuffer(VirtualFramebuffer *vfb, int x, int y, int w, int h) override;
 
 private:
-	void PackDepthbuffer(VirtualFramebuffer *vfb, int x, int y, int w, int h);
-
 	u8 *convBuf_ = nullptr;
 	u32 convBufSize_ = 0;
 

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -120,7 +120,8 @@ enum class GPUCopyFlag {
 	FORCE_DST_MEM = 2,
 	// Note: implies src == dst and FORCE_SRC_MEM.
 	MEMSET = 4,
-	DEBUG_NOTIFIED = 8,
+	DEPTH_REQUESTED = 8,
+	DEBUG_NOTIFIED = 16,
 };
 ENUM_CLASS_BITOPS(GPUCopyFlag);
 


### PR DESCRIPTION
When you start a new game of Gods Eater Burst, it draws your customized character, and makes a screenshot.  This character shows on the loading screen, on the right side.

This has up to now only worked in the software renderer.  This hooks the function so we know to download the color buffer and depth buffer (yes) it requires.  It uses depth to "stencil out" and set the alpha in the image it saves (although... it saves as a JPEG so I didn't check where the alpha goes... it does 5551 in this func.  But it definitely needs it, or it's transparent and not shown when loading.)

This uses the depth download from #11676 to make that work.  Note that the character's colors look a bit funny without #16179.

Currently only works in GLES - the depth download just gets zeros elsewhere, so it doesn't work.  Should work on mobile GLES, though.

-[Unknown]