### PR TITLE
Allow to append some configs

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -567,6 +567,8 @@ public:
 	void ClearRecentIsos();
 
 	const std::map<std::string, std::pair<std::string, int>> &GetLangValuesMapping();
+	bool LoadAppendedConfig();
+	void SetAppendedConfigIni(const Path &path);
 
 protected:
 	void LoadStandardControllerIni();
@@ -585,6 +587,9 @@ private:
 	Path iniFilename_;
 	Path controllerIniFilename_;
 	Path searchPath_;
+	Path appendedConfigFileName_;
+	// A set make more sense, but won't have many entry, and I dont want to include the whole std::set header here
+	std::vector<std::string> appendedConfigUpdatedGames_;
 	ConfigPrivate *private_ = nullptr;
 };
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -665,6 +665,10 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 					gotoTouchScreenTest = true;
 				if (!strcmp(argv[i], "--gamesettings"))
 					gotoGameSettings = true;
+				if (!strncmp(argv[i], "--appendconfig=", strlen("--appendconfig=")) && strlen(argv[i]) > strlen("--appendconfig=")) {
+					g_Config.SetAppendedConfigIni(Path(std::string(argv[i] + strlen("--appendconfig="))));
+					g_Config.LoadAppendedConfig();
+				}
 				break;
 			}
 		} else {


### PR DESCRIPTION
Fixes #16129.

It will update config on start up and every time a new different game with specific setting is loaded. This should allow to change the setting once loaded with no problem.

Tested on Linux only, should work on Windows too :)