### PR TITLE
Remote API: hle.func.removeRange added

### DIFF
--- a/Core/Debugger/WebSocket/HLESubscriber.h
+++ b/Core/Debugger/WebSocket/HLESubscriber.h
@@ -27,6 +27,7 @@ void WebSocketHLEThreadStop(DebuggerRequest &req);
 void WebSocketHLEFuncList(DebuggerRequest &req);
 void WebSocketHLEFuncAdd(DebuggerRequest &req);
 void WebSocketHLEFuncRemove(DebuggerRequest &req);
+void WebSocketHLEFuncRemoveRange(DebuggerRequest &req);
 void WebSocketHLEFuncRename(DebuggerRequest &req);
 void WebSocketHLEFuncScan(DebuggerRequest &req);
 void WebSocketHLEModuleList(DebuggerRequest &req);


### PR DESCRIPTION
This method removes functions that intersect (or lie inside) a given range. Can be used to undo hle.func.scan.