### PR TITLE
Fix depal bounds with dynamic CLUT. Fixes lens flare glitches in Ridge Racer

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2242,10 +2242,11 @@ void TextureCacheCommon::ApplyTextureDepal(TexCacheEntry *entry) {
 	float u2 = texWidth;
 	float v2 = texHeight;
 	if (bounds.minV < bounds.maxV) {
-		u1 = (bounds.minU + gstate_c.curTextureXOffset) * texWidth;
-		v1 = (bounds.minV + gstate_c.curTextureYOffset) * texHeight;
-		u2 = (bounds.maxU + gstate_c.curTextureXOffset) * texWidth;
-		v2 = (bounds.maxV + gstate_c.curTextureYOffset) * texHeight;
+		// These are already in pixel coords! Doesn't seem like we should multiply by texwidth/height.
+		u1 = bounds.minU + gstate_c.curTextureXOffset;
+		v1 = bounds.minV + gstate_c.curTextureYOffset;
+		u2 = bounds.maxU + gstate_c.curTextureXOffset;
+		v2 = bounds.maxV + gstate_c.curTextureYOffset;
 		// We need to reapply the texture next time since we cropped UV.
 		gstate_c.Dirty(DIRTY_TEXTURE_PARAMS);
 	}


### PR DESCRIPTION
Though doesn't fully fix the lens flare, see below and issue #16083.

With this wrong, we ended up drawing pixels that came from a DONT_CARE init of the depal temp buffer, which was a pile of garbage on Android and blank on PC.

Now, we seem to end up not drawing anything because the depal operation results in transparent black instead of whatever is actually intended, but at least the screen isn't full of glitches when the sun is visible on Adreno.