### PR TITLE
Reduce IO primarily during save operations

### DIFF
--- a/Common/File/AndroidStorage.h
+++ b/Common/File/AndroidStorage.h
@@ -55,7 +55,7 @@ int64_t Android_GetFreeSpaceByFilePath(const std::string &filePath);
 bool Android_IsExternalStoragePreservedLegacy();
 const char *Android_ErrorToString(StorageError error);
 
-std::vector<File::FileInfo> Android_ListContentUri(const std::string &uri);
+std::vector<File::FileInfo> Android_ListContentUri(const std::string &uri, bool *exists);
 
 void Android_RegisterStorageCallbacks(JNIEnv * env, jobject obj);
 
@@ -78,7 +78,8 @@ inline int64_t Android_GetFreeSpaceByContentUri(const std::string &uri) { return
 inline int64_t Android_GetFreeSpaceByFilePath(const std::string &filePath) { return -1; }
 inline bool Android_IsExternalStoragePreservedLegacy() { return false; }
 inline const char *Android_ErrorToString(StorageError error) { return ""; }
-inline std::vector<File::FileInfo> Android_ListContentUri(const std::string &uri) {
+inline std::vector<File::FileInfo> Android_ListContentUri(const std::string &uri, bool *exists) {
+	*exists = false;
 	return std::vector<File::FileInfo>();
 }
 

--- a/Common/File/DirListing.cpp
+++ b/Common/File/DirListing.cpp
@@ -171,10 +171,11 @@ std::vector<File::FileInfo> ApplyFilter(std::vector<File::FileInfo> files, const
 
 bool GetFilesInDir(const Path &directory, std::vector<FileInfo> *files, const char *filter, int flags) {
 	if (directory.Type() == PathType::CONTENT_URI) {
-		std::vector<File::FileInfo> fileList = Android_ListContentUri(directory.ToString());
+		bool exists = false;
+		std::vector<File::FileInfo> fileList = Android_ListContentUri(directory.ToString(), &exists);
 		*files = ApplyFilter(fileList, filter);
 		std::sort(files->begin(), files->end());
-		return true;
+		return exists;
 	}
 
 	std::set<std::string> filters;

--- a/Common/File/DirListing.cpp
+++ b/Common/File/DirListing.cpp
@@ -220,7 +220,7 @@ bool GetFilesInDir(const Path &directory, std::vector<FileInfo> *files, const ch
 	HANDLE hFind = FindFirstFileEx((directory.ToWString() + L"\\*").c_str(), FindExInfoStandard, &ffd, FindExSearchNameMatch, NULL, 0);
 #endif
 	if (hFind == INVALID_HANDLE_VALUE) {
-		return 0;
+		return false;
 	}
 	do {
 		const std::string virtualName = ConvertWStringToUTF8(ffd.cFileName);
@@ -267,7 +267,7 @@ bool GetFilesInDir(const Path &directory, std::vector<FileInfo> *files, const ch
 	struct dirent *result = NULL;
 	DIR *dirp = opendir(directory.c_str());
 	if (!dirp)
-		return 0;
+		return false;
 	while ((result = readdir(dirp))) {
 		const std::string virtualName(result->d_name);
 		// check for "." and ".."

--- a/Core/Dialog/PSPGamedataInstallDialog.cpp
+++ b/Core/Dialog/PSPGamedataInstallDialog.cpp
@@ -206,12 +206,9 @@ void PSPGamedataInstallDialog::CloseCurrentFile() {
 void PSPGamedataInstallDialog::WriteSfoFile() {
 	ParamSFOData sfoFile;
 	std::string sfopath = GetGameDataInstallFileName(&request, SFO_FILENAME);
-	PSPFileInfo sfoInfo = pspFileSystem.GetFileInfo(sfopath);
-	if (sfoInfo.exists) {
-		std::vector<u8> sfoData;
-		if (pspFileSystem.ReadEntireFile(sfopath, sfoData) >= 0) {
-			sfoFile.ReadSFO(sfoData);
-		}
+	std::vector<u8> sfoFileData;
+	if (pspFileSystem.ReadEntireFile(sfopath, sfoFileData) >= 0) {
+		sfoFile.ReadSFO(sfoFileData);
 	}
 
 	// Update based on the just-saved data.

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -111,6 +111,7 @@ int PSPSaveDialog::Init(int paramAddr)
 	Memory::Memcpy(&originalRequest, requestAddr, size);
 
 	param.SetIgnoreTextures(IsNotVisibleAction((SceUtilitySavedataType)(u32)request.mode));
+	param.ClearCaches();
 	int retval = param.SetPspParam(&request);
 
 	const u32 mode = (u32)param.GetPspParam()->mode;
@@ -263,6 +264,7 @@ int PSPSaveDialog::Init(int paramAddr)
 		ChangeStatusInit(SAVEDATA_INIT_DELAY_US);
 	}
 
+	param.ClearCaches();
 	UpdateButtons();
 	StartFade(true);
 
@@ -642,6 +644,7 @@ int PSPSaveDialog::Update(int animSpeed)
 		param.SetPspParam(&request);
 	}
 
+	param.ClearCaches();
 	UpdateButtons();
 	UpdateFade(animSpeed);
 
@@ -1059,11 +1062,13 @@ int PSPSaveDialog::Update(int animSpeed)
 
 	if (ReadStatus() == SCE_UTILITY_STATUS_FINISHED || pendingStatus == SCE_UTILITY_STATUS_FINISHED)
 		Memory::Memcpy(requestAddr, &request, request.common.size, "SaveDialogParam");
+	param.ClearCaches();
 	
 	return 0;
 }
 
 void PSPSaveDialog::ExecuteIOAction() {
+	param.ClearCaches();
 	auto &result = param.GetPspParam()->common.result;
 	std::lock_guard<std::mutex> guard(paramLock);
 	switch (display) {
@@ -1102,9 +1107,11 @@ void PSPSaveDialog::ExecuteIOAction() {
 	}
 
 	ioThreadStatus = SAVEIO_DONE;
+	param.ClearCaches();
 }
 
 void PSPSaveDialog::ExecuteNotVisibleIOAction() {
+	param.ClearCaches();
 	auto &result = param.GetPspParam()->common.result;
 
 	switch ((SceUtilitySavedataType)(u32)param.GetPspParam()->mode) {
@@ -1185,6 +1192,8 @@ void PSPSaveDialog::ExecuteNotVisibleIOAction() {
 	default:
 		break;
 	}
+
+	param.ClearCaches();
 }
 
 void PSPSaveDialog::JoinIOThread() {
@@ -1222,6 +1231,7 @@ int PSPSaveDialog::Shutdown(bool force) {
 		ChangeStatusShutdown(SAVEDATA_SHUTDOWN_DELAY_US);
 	}
 	param.SetPspParam(0);
+	param.ClearCaches();
 
 	return 0;
 }

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -56,6 +56,29 @@ const static int SAVEDATA_DIALOG_SIZE_V1 = 1480;
 const static int SAVEDATA_DIALOG_SIZE_V2 = 1500;
 const static int SAVEDATA_DIALOG_SIZE_V3 = 1536;
 
+static bool IsNotVisibleAction(SceUtilitySavedataType type) {
+	switch (type) {
+	case SCE_UTILITY_SAVEDATA_TYPE_AUTOLOAD:
+	case SCE_UTILITY_SAVEDATA_TYPE_AUTOSAVE:
+	case SCE_UTILITY_SAVEDATA_TYPE_SIZES:
+	case SCE_UTILITY_SAVEDATA_TYPE_LIST:
+	case SCE_UTILITY_SAVEDATA_TYPE_FILES:
+	case SCE_UTILITY_SAVEDATA_TYPE_GETSIZE:
+	case SCE_UTILITY_SAVEDATA_TYPE_MAKEDATASECURE:
+	case SCE_UTILITY_SAVEDATA_TYPE_MAKEDATA:
+	case SCE_UTILITY_SAVEDATA_TYPE_WRITEDATASECURE:
+	case SCE_UTILITY_SAVEDATA_TYPE_WRITEDATA:
+	case SCE_UTILITY_SAVEDATA_TYPE_READDATASECURE:
+	case SCE_UTILITY_SAVEDATA_TYPE_READDATA:
+	case SCE_UTILITY_SAVEDATA_TYPE_DELETEDATA:
+	case SCE_UTILITY_SAVEDATA_TYPE_AUTODELETE:
+		return true;
+
+	default:
+		break;
+	}
+	return false;
+}
 
 PSPSaveDialog::PSPSaveDialog(UtilityDialogType type) : PSPDialog(type) {
 	param.SetPspParam(0);
@@ -87,6 +110,7 @@ int PSPSaveDialog::Init(int paramAddr)
 	Memory::Memcpy(&request, requestAddr, size);
 	Memory::Memcpy(&originalRequest, requestAddr, size);
 
+	param.SetIgnoreTextures(IsNotVisibleAction((SceUtilitySavedataType)(u32)request.mode));
 	int retval = param.SetPspParam(&request);
 
 	const u32 mode = (u32)param.GetPspParam()->mode;
@@ -345,7 +369,7 @@ void PSPSaveDialog::DisplaySaveList(bool canMove) {
 		PPGeImageStyle imageStyle = FadedImageStyle();
 		auto fileInfo = param.GetFileInfo(displayCount);
 
-		if (fileInfo.size == 0 && fileInfo.texture != NULL)
+		if (fileInfo.size == 0 && fileInfo.texture && fileInfo.texture->IsValid())
 			imageStyle.color = CalcFadedColor(0xFF777777);
 
 		// Calc save image position on screen
@@ -370,7 +394,7 @@ void PSPSaveDialog::DisplaySaveList(bool canMove) {
 			continue;
 
 		int pad = 0;
-		if (fileInfo.texture != nullptr) {
+		if (fileInfo.texture != nullptr && fileInfo.texture->IsValid()) {
 			fileInfo.texture->SetTexture();
 			int tw = fileInfo.texture->Width();
 			int th = fileInfo.texture->Height();
@@ -420,7 +444,7 @@ void PSPSaveDialog::DisplaySaveIcon(bool checkExists)
 
 	int tw = 256;
 	int th = 256;
-	if (curSave.texture != NULL) {
+	if (curSave.texture != nullptr && curSave.texture->IsValid()) {
 		curSave.texture->SetTexture();
 		tw = curSave.texture->Width();
 		th = curSave.texture->Height();

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -17,8 +17,12 @@
 
 #pragma once
 
+#include <memory>
+#include <mutex>
 #include <set>
+#include <unordered_map>
 #include "Common/CommonTypes.h"
+#include "Core/ELF/ParamSFO.h"
 #include "Core/MemMap.h"
 #include "Core/HLE/sceRtc.h"
 #include "Core/Dialog/PSPDialog.h"
@@ -351,6 +355,8 @@ public:
 
 	bool wouldHasMultiSaveName(SceUtilitySavedataParam* param);
 
+	void ClearCaches();
+
 	void DoState(PointerWrap &p);
 
 private:
@@ -376,6 +382,8 @@ private:
 	std::set<std::string> GetSecureFileNames(const std::string &dirPath);
 	bool GetExpectedHash(const std::string &dirPath, const std::string &filename, u8 hash[16]);
 
+	std::shared_ptr<ParamSFOData> LoadCachedSFO(const std::string &path, bool orCreate = false);
+
 	SceUtilitySavedataParam* pspParam = nullptr;
 	int selectedSave = 0;
 	SaveFileInfo *saveDataList = nullptr;
@@ -383,4 +391,8 @@ private:
 	int saveDataListCount = 0;
 	int saveNameListDataCount = 0;
 	bool ignoreTextures_ = false;
+
+	// Cleared before returning to PSP, no need to save state.
+	std::mutex cacheLock_;
+	std::unordered_map<std::string, std::shared_ptr<ParamSFOData>> sfoCache_;
 };

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -324,6 +324,9 @@ public:
 
 	static std::string GetSpaceText(u64 size, bool roundUp);
 
+	void SetIgnoreTextures(bool state) {
+		ignoreTextures_ = state;
+	}
 	int SetPspParam(SceUtilitySavedataParam* param);
 	SceUtilitySavedataParam *GetPspParam();
 	const SceUtilitySavedataParam *GetPspParam() const;
@@ -379,4 +382,5 @@ private:
 	SaveFileInfo *noSaveIcon = nullptr;
 	int saveDataListCount = 0;
 	int saveNameListDataCount = 0;
+	bool ignoreTextures_ = false;
 };

--- a/Core/FileSystems/BlobFileSystem.cpp
+++ b/Core/FileSystems/BlobFileSystem.cpp
@@ -30,9 +30,11 @@ void BlobFileSystem::DoState(PointerWrap &p) {
 	// Not used in real emulation.
 }
 
-std::vector<PSPFileInfo> BlobFileSystem::GetDirListing(std::string path) {
+std::vector<PSPFileInfo> BlobFileSystem::GetDirListing(const std::string &path, bool *exists) {
 	std::vector<PSPFileInfo> listing;
 	listing.push_back(GetFileInfo(alias_));
+	if (exists)
+		*exists = true;
 	return listing;
 }
 

--- a/Core/FileSystems/BlobFileSystem.h
+++ b/Core/FileSystems/BlobFileSystem.h
@@ -34,7 +34,7 @@ public:
 	~BlobFileSystem();
 
 	void DoState(PointerWrap &p) override;
-	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
+	std::vector<PSPFileInfo> GetDirListing(const std::string &path, bool *exists = nullptr) override;
 	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override;
 	void     CloseFile(u32 handle) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override;

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -65,7 +65,7 @@ public:
 	void CloseAll();
 
 	void DoState(PointerWrap &p) override;
-	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
+	std::vector<PSPFileInfo> GetDirListing(const std::string &path, bool *exists = nullptr) override;
 	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override;
 	void     CloseFile(u32 handle) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override;
@@ -111,7 +111,7 @@ public:
 	~VFSFileSystem();
 
 	void DoState(PointerWrap &p) override;
-	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
+	std::vector<PSPFileInfo> GetDirListing(const std::string &path, bool *exists = nullptr) override;
 	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override;
 	void     CloseFile(u32 handle) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override;

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -118,7 +118,7 @@ public:
 	virtual ~IFileSystem() {}
 
 	virtual void DoState(PointerWrap &p) = 0;
-	virtual std::vector<PSPFileInfo> GetDirListing(std::string path) = 0;
+	virtual std::vector<PSPFileInfo> GetDirListing(const std::string &path, bool *exists = nullptr) = 0;
 	virtual int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) = 0;
 	virtual void     CloseFile(u32 handle) = 0;
 	virtual size_t   ReadFile(u32 handle, u8 *pointer, s64 size) = 0;
@@ -143,7 +143,12 @@ public:
 class EmptyFileSystem : public IFileSystem {
 public:
 	virtual void DoState(PointerWrap &p) override {}
-	std::vector<PSPFileInfo> GetDirListing(std::string path) override {std::vector<PSPFileInfo> vec; return vec;}
+	std::vector<PSPFileInfo> GetDirListing(const std::string &path, bool *exists = nullptr) override {
+		if (exists)
+			*exists = false;
+		std::vector<PSPFileInfo> vec;
+		return vec;
+	}
 	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override {return SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND;}
 	void     CloseFile(u32 handle) override {}
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override {return 0;}

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -631,11 +631,14 @@ PSPFileInfo ISOFileSystem::GetFileInfo(std::string filename) {
 	return x;
 }
 
-std::vector<PSPFileInfo> ISOFileSystem::GetDirListing(std::string path) {
+std::vector<PSPFileInfo> ISOFileSystem::GetDirListing(const std::string &path, bool *exists) {
 	std::vector<PSPFileInfo> myVector;
 	TreeEntry *entry = GetFromPath(path);
-	if (!entry)
+	if (!entry) {
+		if (exists)
+			*exists = false;
 		return myVector;
+	}
 
 	const std::string dot(".");
 	const std::string dotdot("..");
@@ -651,6 +654,7 @@ std::vector<PSPFileInfo> ISOFileSystem::GetDirListing(std::string path) {
 		x.name = e->name;
 		// Strangely, it seems to be executable even for files.
 		x.access = 0555;
+		x.exists = true;
 		x.size = e->size;
 		x.type = e->isDirectory ? FILETYPE_DIRECTORY : FILETYPE_NORMAL;
 		x.isOnSectorSystem = true;
@@ -659,6 +663,8 @@ std::vector<PSPFileInfo> ISOFileSystem::GetDirListing(std::string path) {
 		x.numSectors = (u32)((e->size + sectorSize - 1) / sectorSize);
 		myVector.push_back(x);
 	}
+	if (exists)
+		*exists = true;
 	return myVector;
 }
 

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -33,7 +33,7 @@ public:
 	~ISOFileSystem();
 
 	void DoState(PointerWrap &p) override;
-	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
+	std::vector<PSPFileInfo> GetDirListing(const std::string &path, bool *exists = nullptr) override;
 	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override;
 	void     CloseFile(u32 handle) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override;
@@ -110,7 +110,11 @@ public:
 		isoFileSystem_->DoState(p);
 	}
 
-	std::vector<PSPFileInfo> GetDirListing(std::string path) override { return std::vector<PSPFileInfo>(); }
+	std::vector<PSPFileInfo> GetDirListing(const std::string &path, bool *exists = nullptr) override {
+		if (exists)
+			*exists = true;
+		return std::vector<PSPFileInfo>();
+	}
 	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override {
 		return isoFileSystem_->OpenFile("", access, devicename);
 	}

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -369,19 +369,17 @@ PSPFileInfo MetaFileSystem::GetFileInfo(std::string filename)
 	}
 }
 
-std::vector<PSPFileInfo> MetaFileSystem::GetDirListing(std::string path)
-{
+std::vector<PSPFileInfo> MetaFileSystem::GetDirListing(const std::string &path, bool *exists) {
 	std::lock_guard<std::recursive_mutex> guard(lock);
 	std::string of;
 	IFileSystem *system;
 	int error = MapFilePath(path, of, &system);
-	if (error == 0)
-	{
-		return system->GetDirListing(of);
-	}
-	else
-	{
+	if (error == 0) {
+		return system->GetDirListing(of, exists);
+	} else {
 		std::vector<PSPFileInfo> empty;
+		if (exists)
+			*exists = false;
 		return empty;
 	}
 }

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -593,7 +593,7 @@ int MetaFileSystem::ReadEntireFile(const std::string &filename, std::vector<u8> 
 	SeekFile(handle, 0, FILEMOVE_BEGIN);
 	data.resize(dataSize);
 
-	size_t result = ReadFile(handle, (u8 *)&data[0], dataSize);
+	size_t result = ReadFile(handle, data.data(), dataSize);
 	CloseFile(handle);
 
 	if (result != dataSize)

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -103,7 +103,7 @@ public:
 
 	std::string NormalizePrefix(std::string prefix) const;
 
-	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
+	std::vector<PSPFileInfo> GetDirListing(const std::string &path, bool *exists = nullptr) override;
 	int      OpenFile(std::string filename, FileAccess access, const char *devicename = nullptr) override;
 	void     CloseFile(u32 handle) override;
 	size_t   ReadFile(u32 handle, u8 *pointer, s64 size) override;

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -661,8 +661,7 @@ static void tmFromFiletime(tm &dest, FILETIME &src)
 }
 #endif
 
-std::vector<PSPFileInfo> VirtualDiscFileSystem::GetDirListing(std::string path)
-{
+std::vector<PSPFileInfo> VirtualDiscFileSystem::GetDirListing(const std::string &path, bool *exists) {
 	std::vector<PSPFileInfo> myVector;
 
 	// TODO(scoped): Switch this over to GetFilesInDir!
@@ -681,8 +680,13 @@ std::vector<PSPFileInfo> VirtualDiscFileSystem::GetDirListing(std::string path)
 	hFind = FindFirstFileEx(w32path.c_str(), FindExInfoStandard, &findData, FindExSearchNameMatch, NULL, 0);
 #endif
 	if (hFind == INVALID_HANDLE_VALUE) {
+		if (exists)
+			*exists = false;
 		return myVector; //the empty list
 	}
+
+	if (exists)
+		*exists = true;
 
 	for (BOOL retval = 1; retval; retval = FindNextFile(hFind, &findData)) {
 		if (!wcscmp(findData.cFileName, L"..") || !wcscmp(findData.cFileName, L".")) {
@@ -697,6 +701,7 @@ std::vector<PSPFileInfo> VirtualDiscFileSystem::GetDirListing(std::string path)
 		}
 
 		entry.access = 0555;
+		entry.exists = true;
 		entry.size = findData.nFileSizeLow | ((u64)findData.nFileSizeHigh<<32);
 		entry.name = ConvertWStringToUTF8(findData.cFileName);
 		tmFromFiletime(entry.atime, findData.ftLastAccessTime);
@@ -717,17 +722,23 @@ std::vector<PSPFileInfo> VirtualDiscFileSystem::GetDirListing(std::string path)
 	DIR *dp = opendir(localPath.c_str());
 
 #if HOST_IS_CASE_SENSITIVE
-	if(dp == NULL && FixPathCase(basePath, path, FPC_FILE_MUST_EXIST)) {
+	std::string fixedPath = path;
+	if(dp == NULL && FixPathCase(basePath, fixedPath, FPC_FILE_MUST_EXIST)) {
 		// May have failed due to case sensitivity, try again
-		localPath = GetLocalPath(path);
+		localPath = GetLocalPath(fixedPath);
 		dp = opendir(localPath.c_str());
 	}
 #endif
 
 	if (dp == NULL) {
 		ERROR_LOG(FILESYS,"Error opening directory %s\n", path.c_str());
+		if (exists)
+			*exists = false;
 		return myVector;
 	}
+
+	if (exists)
+		*exists = true;
 
 	while ((dirp = readdir(dp)) != NULL) {
 		if (!strcmp(dirp->d_name, "..") || !strcmp(dirp->d_name, ".")) {
@@ -736,13 +747,14 @@ std::vector<PSPFileInfo> VirtualDiscFileSystem::GetDirListing(std::string path)
 
 		PSPFileInfo entry;
 		struct stat s;
-		std::string fullName = (GetLocalPath(path) / std::string(dirp->d_name)).ToString();
+		std::string fullName = (localPath / std::string(dirp->d_name)).ToString();
 		stat(fullName.c_str(), &s);
 		if (S_ISDIR(s.st_mode))
 			entry.type = FILETYPE_DIRECTORY;
 		else
 			entry.type = FILETYPE_NORMAL;
 		entry.access = 0555;
+		entry.exists = true;
 		entry.name = dirp->d_name;
 		entry.size = s.st_size;
 		localtime_r((time_t*)&s.st_atime,&entry.atime);

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -40,7 +40,7 @@ public:
 	bool     OwnsHandle(u32 handle) override;
 	int      Ioctl(u32 handle, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) override;
 	PSPDevType DevType(u32 handle) override;
-	std::vector<PSPFileInfo> GetDirListing(std::string path) override;
+	std::vector<PSPFileInfo> GetDirListing(const std::string &path, bool *exists = nullptr) override;
 	FileSystemFlags Flags() override { return FileSystemFlags::UMD; }
 	u64  FreeSpace(const std::string &path) override { return 0; }
 

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -858,22 +858,21 @@ static void __LoadInternalFonts() {
 	}
 	const std::string fontPath = "flash0:/font/";
 	const std::string fontOverridePath = "ms0:/PSP/flash0/font/";
-	const std::string userfontPath = "disc0:/PSP_GAME/USRDIR/";
-	
+	const std::string gameFontPath = "disc0:/PSP_GAME/USRDIR/";
+
 	if (!pspFileSystem.GetFileInfo(fontPath).exists) {
 		pspFileSystem.MkDir(fontPath);
 	}
 	if ((pspFileSystem.GetFileInfo("disc0:/PSP_GAME/USRDIR/zh_gb.pgf").exists) && (pspFileSystem.GetFileInfo("disc0:/PSP_GAME/USRDIR/oldfont.prx").exists)) {
 		for (size_t i = 0; i < ARRAY_SIZE(fontRegistry); i++) {
 			const FontRegistryEntry &entry = fontRegistry[i];
-			std::string fontFilename = userfontPath + entry.fileName;
-			PSPFileInfo info = pspFileSystem.GetFileInfo(fontFilename);
-			DEBUG_LOG(SCEFONT, "Loading internal font %s (%i bytes)", fontFilename.c_str(), (int)info.size);
+			std::string fontFilename = gameFontPath + entry.fileName;
 			std::vector<u8> buffer;
 			if (pspFileSystem.ReadEntireFile(fontFilename, buffer) < 0) {
-				ERROR_LOG(SCEFONT, "Failed opening font");
+				ERROR_LOG(SCEFONT, "Failed opening font %s", fontFilename.c_str());
 				continue;
 			}
+			DEBUG_LOG(SCEFONT, "Loading internal font %s (%i bytes)", fontFilename.c_str(), (int)buffer.size());
 			internalFonts.push_back(new Font(buffer, entry));
 			DEBUG_LOG(SCEFONT, "Loaded font %s", fontFilename.c_str());
 			return;
@@ -882,29 +881,26 @@ static void __LoadInternalFonts() {
 
 	for (size_t i = 0; i < ARRAY_SIZE(fontRegistry); i++) {
 		const FontRegistryEntry &entry = fontRegistry[i];
-		std::string fontFilename = userfontPath + entry.fileName;
-		PSPFileInfo info = pspFileSystem.GetFileInfo(fontFilename);
+		std::vector<u8> buffer;
+		bool bufferRead = false;
 
-		if (!info.exists) {
-			// No user font, let's try override path.
+		std::string fontFilename = gameFontPath + entry.fileName;
+		bufferRead = pspFileSystem.ReadEntireFile(fontFilename, buffer) >= 0;
+
+		if (!bufferRead) {
+			// No game font, let's try override path.
 			fontFilename = fontOverridePath + entry.fileName;
-			info = pspFileSystem.GetFileInfo(fontFilename);
+			bufferRead = pspFileSystem.ReadEntireFile(fontFilename, buffer) >= 0;
 		}
 
-		if (!info.exists) {
+		if (!bufferRead) {
 			// No override, let's use the default path.
 			fontFilename = fontPath + entry.fileName;
-			info = pspFileSystem.GetFileInfo(fontFilename);
+			bufferRead = pspFileSystem.ReadEntireFile(fontFilename, buffer) >= 0;
 		}
 
-		if (info.exists) {
-			DEBUG_LOG(SCEFONT, "Loading internal font %s (%i bytes)", fontFilename.c_str(), (int)info.size);
-			std::vector<u8> buffer;
-			if (pspFileSystem.ReadEntireFile(fontFilename, buffer) < 0) {
-				ERROR_LOG(SCEFONT, "Failed opening font");
-				continue;
-			}
-			
+		if (bufferRead) {
+			DEBUG_LOG(SCEFONT, "Loading internal font %s (%i bytes)", fontFilename.c_str(), (int)buffer.size());
 			internalFonts.push_back(new Font(buffer, entry));
 
 			DEBUG_LOG(SCEFONT, "Loaded font %s", fontFilename.c_str());

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2336,16 +2336,19 @@ public:
 static u32 sceIoDopen(const char *path) {
 	DEBUG_LOG(SCEIO, "sceIoDopen(\"%s\")", path);
 
-	if (!pspFileSystem.GetFileInfo(path).exists) {
+	double startTime = time_now_d();
+
+	bool listingExists = false;
+	auto listing = pspFileSystem.GetDirListing(path, &listingExists);
+
+	if (!listingExists) {
 		return SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND;
 	}
 
 	DirListing *dir = new DirListing();
 	SceUID id = kernelObjects.Create(dir);
 
-	double startTime = time_now_d();
-
-	dir->listing = pspFileSystem.GetDirListing(path);
+	dir->listing = listing;
 	dir->index = 0;
 	dir->name = std::string(path);
 

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -230,6 +230,17 @@ public:
 		return pendingAsyncResult || hasAsyncResult;
 	}
 
+	const PSPFileInfo &FileInfo() {
+		if (!infoReady) {
+			info = pspFileSystem.GetFileInfo(fullpath);
+			if (!info.exists) {
+				ERROR_LOG(IO, "File %s no longer exists when reading info", fullpath.c_str());
+			}
+			infoReady = true;
+		}
+		return info;
+	}
+
 	void DoState(PointerWrap &p) override {
 		auto s = p.Section("FileNode", 1, 3);
 		if (!s)
@@ -246,6 +257,9 @@ public:
 		Do(p, closePending);
 		Do(p, info);
 		Do(p, openMode);
+		if (p.mode == p.MODE_READ) {
+			infoReady = info.exists;
+		}
 
 		Do(p, npdrm);
 		Do(p, pgd_offset);
@@ -285,6 +299,7 @@ public:
 	// TODO: Use an enum instead?
 	bool closePending = false;
 
+	bool infoReady = false;
 	PSPFileInfo info;
 	u32 openMode = 0;
 
@@ -1356,7 +1371,7 @@ static s64 __IoLseekDest(FileNode *f, s64 offset, int whence, FileMove &seek) {
 		seek = FILEMOVE_CURRENT;
 		break;
 	case 2:
-		newPos = f->info.size + offset;
+		newPos = f->FileInfo().size + offset;
 		seek = FILEMOVE_END;
 		break;
 	default:
@@ -1489,8 +1504,6 @@ static FileNode *__IoOpen(int &error, const char *filename, int flags, int mode)
 
 		isTTY = true;
 	} else {
-		info = pspFileSystem.GetFileInfo(filename);
-
 		h = pspFileSystem.OpenFile(filename, (FileAccess)access);
 		if (h < 0) {
 			error = h;
@@ -1504,7 +1517,10 @@ static FileNode *__IoOpen(int &error, const char *filename, int flags, int mode)
 	f->handle = h;
 	f->fullpath = filename;
 	f->asyncResult = h;
-	f->info = info;
+	if (isTTY) {
+		f->info = info;
+		f->infoReady = true;
+	}
 	f->openMode = access;
 	f->isTTY = isTTY;
 
@@ -2528,7 +2544,7 @@ static int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, 
 		if(f->pgdInfo)
 			return f->pgdInfo->data_size;
 		else
-			return (int)f->info.size;
+			return (int)f->FileInfo().size;
 		break;
 
 	// Get UMD sector size
@@ -2571,7 +2587,7 @@ static int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, 
 			const auto seekInfo = PSPPointer<SeekInfo>::Create(indataPtr);
 			FileMove seek;
 			s64 newPos = __IoLseekDest(f, seekInfo->offset, seekInfo->whence, seek);
-			if (newPos < 0 || newPos > f->info.size) {
+			if (newPos < 0 || newPos > f->FileInfo().size) {
 				// Not allowed to seek past the end of the file with this API.
 				return ERROR_ERRNO_IO_ERROR;
 			}
@@ -2587,7 +2603,7 @@ static int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, 
 		// TODO: Should probably move this to something common between ISOFileSystem and VirtualDiscSystem.
 		INFO_LOG(SCEIO, "sceIoIoctl: Asked for start sector of file %i", id);
 		if (Memory::IsValidAddress(outdataPtr) && outlen >= 4) {
-			Memory::Write_U32(f->info.startSector, outdataPtr);
+			Memory::Write_U32(f->FileInfo().startSector, outdataPtr);
 		} else {
 			return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
 		}
@@ -2599,7 +2615,7 @@ static int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, 
 		// TODO: Should probably move this to something common between ISOFileSystem and VirtualDiscSystem.
 		INFO_LOG(SCEIO, "sceIoIoctl: Asked for size of file %i", id);
 		if (Memory::IsValidAddress(outdataPtr) && outlen >= 8) {
-			Memory::Write_U64(f->info.size, outdataPtr);
+			Memory::Write_U64(f->FileInfo().size, outdataPtr);
 		} else {
 			return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
 		}
@@ -2676,7 +2692,7 @@ static int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, 
 			FileMove seek;
 			s64 newPos = __IoLseekDest(f, seekInfo->offset, seekInfo->whence, seek);
 			// Position is in sectors, don't forget.
-			if (newPos < 0 || newPos > f->info.size) {
+			if (newPos < 0 || newPos > f->FileInfo().size) {
 				// Not allowed to seek past the end of the file with this API.
 				return SCE_KERNEL_ERROR_ERRNO_INVALID_FILE_SIZE;
 			}

--- a/Core/Util/PPGeDraw.h
+++ b/Core/Util/PPGeDraw.h
@@ -122,6 +122,7 @@ public:
 	// Does not normally need to be called (except to force preloading.)
 	bool Load();
 	void Free();
+	bool IsValid();
 
 	void DoState(PointerWrap &p);
 
@@ -147,11 +148,12 @@ private:
 	u32 png_;
 	size_t size_;
 
-	u32 texture_;
+	u32 texture_ = 0;
 	int width_;
 	int height_;
 
 	int lastFrame_;
+	bool loadFailed_ = false;
 };
 
 void PPGeDrawRect(float x1, float y1, float x2, float y2, u32 color);

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -273,15 +273,13 @@ public class PpssppActivity extends NativeActivity {
 			// Is ArrayList weird or what?
 			String[] strings = new String[listing.size()];
 			return listing.toArray(strings);
-		}
-		catch (IllegalArgumentException e) {
+		} catch (IllegalArgumentException e) {
 			// Due to sloppy exception handling in resolver.query, we get this wrapping
 			// a FileNotFoundException if the directory doesn't exist.
-			return new String[]{};
-		}
-		catch (Exception e) {
+			return new String[]{ "X" };
+		} catch (Exception e) {
 			Log.e(TAG, "listContentUriDir exception: " + e.toString());
-			return new String[]{};
+			return new String[]{ "X" };
 		} finally {
 			if (c != null) {
 				c.close();


### PR DESCRIPTION
This reduces cases of GetFileListing or OpenFile combined with GetFileInfo, reduces duplicate file open/close cycles, and avoids some loads that weren't necessary.

This is just intended to improve the performance penalty of scoped storage on Android when dealing with save data.

-[Unknown]