### PR TITLE
D3D11: Correct depth readback

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2649,7 +2649,7 @@ void FramebufferManagerCommon::ReadbackDepthbufferSync(VirtualFramebuffer *vfb, 
 	Draw::DataFormat destFormat = GEFormatToThin3D(GE_FORMAT_DEPTH16);
 	const int dstByteOffset = (y * vfb->z_stride + x) * 2;
 	u8 *destPtr = Memory::GetPointerWriteUnchecked(vfb->z_address + dstByteOffset);
-	if (!draw_->CopyFramebufferToMemorySync(vfb->fbo, Draw::FB_DEPTH_BIT, x, y, w, h, destFormat, destPtr, vfb->fb_stride, "ReadbackDepthbufferSync")) {
+	if (!draw_->CopyFramebufferToMemorySync(vfb->fbo, Draw::FB_DEPTH_BIT, x, y, w, h, destFormat, destPtr, vfb->z_stride, "ReadbackDepthbufferSync")) {
 		WARN_LOG(G3D, "ReadbackDepthbufferSync failed");
 	}
 }


### PR DESCRIPTION
And it was already fixed in Vulkan by some previous change, I guess, or I was just wrong.  It's working on all backends now.

I didn't test when depth clamp is unsupported, but it might actually work for the Gods Eater Burst case, since it only cares if non-zero.  Obviously would be best to fix for anything else that reads depth from the CPU.

-[Unknown]