### PR TITLE
Fix crash setting breakpoints while in GE debugger

### DIFF
--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -648,16 +648,11 @@ void CBreakPoints::Update(u32 addr) {
 			resume = true;
 		}
 
-		{
-			std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
-			if (MIPSComp::jit) {
-				// In case this is a delay slot, clear the previous instruction too.
-				if (addr != 0)
-					MIPSComp::jit->InvalidateCacheAt(addr - 4, 8);
-				else
-					MIPSComp::jit->ClearCache();
-			}
-		}
+		// In case this is a delay slot, clear the previous instruction too.
+		if (addr != 0)
+			mipsr4k.InvalidateICache(addr - 4, 8);
+		else
+			mipsr4k.ClearJitCache();
 
 		if (resume)
 			Core_EnableStepping(false);

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <limits>
 #include <mutex>
+#include <utility>
 
 #include "Common/Math/math_util.h"
 
@@ -334,7 +335,11 @@ int MIPSState::RunLoopUntil(u64 globalTicks) {
 			// We must get out of the delay slot before going into jit.
 			SingleStep();
 		}
+		insideJit = true;
+		if (hasPendingClears)
+			ProcessPendingClears();
 		MIPSComp::jit->RunLoopUntil(globalTicks);
+		insideJit = false;
 		break;
 
 	case CPUCore::INTERPRETER:
@@ -343,15 +348,44 @@ int MIPSState::RunLoopUntil(u64 globalTicks) {
 	return 1;
 }
 
+// Kept outside MIPSState to avoid header pollution (MIPS.h doesn't even have vector, and is used widely.)
+static std::vector<std::pair<u32, int>> pendingClears;
+
+void MIPSState::ProcessPendingClears() {
+	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
+	for (auto &p : pendingClears) {
+		if (p.first == 0 && p.second == 0)
+			MIPSComp::jit->ClearCache();
+		else
+			MIPSComp::jit->InvalidateCacheAt(p.first, p.second);
+	}
+	pendingClears.clear();
+	hasPendingClears = false;
+}
+
 void MIPSState::InvalidateICache(u32 address, int length) {
 	// Only really applies to jit.
 	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
-	if (MIPSComp::jit)
-		MIPSComp::jit->InvalidateCacheAt(address, length);
+	if (MIPSComp::jit) {
+		if (coreState == CORE_RUNNING || insideJit) {
+			pendingClears.emplace_back(address, length);
+			hasPendingClears = true;
+			CoreTiming::ForceCheck();
+		} else {
+			MIPSComp::jit->InvalidateCacheAt(address, length);
+		}
+	}
 }
 
 void MIPSState::ClearJitCache() {
 	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
-	if (MIPSComp::jit)
-		MIPSComp::jit->ClearCache();
+	if (MIPSComp::jit) {
+		if (coreState == CORE_RUNNING || insideJit) {
+			pendingClears.emplace_back(0, 0);
+			hasPendingClears = true;
+			CoreTiming::ForceCheck();
+		} else {
+			MIPSComp::jit->ClearCache();
+		}
+	}
 }

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -266,6 +266,13 @@ public:
 	void InvalidateICache(u32 address, int length = 4);
 
 	void ClearJitCache();
+
+protected:
+	void ProcessPendingClears();
+
+	// Doesn't need save stating.
+	volatile bool insideJit = false;
+	volatile bool hasPendingClears = false;
 };
 
 

--- a/Core/MIPS/MIPSAsm.cpp
+++ b/Core/MIPS/MIPSAsm.cpp
@@ -40,9 +40,7 @@ public:
 		Memory::Memcpy((u32)address, data, (u32)length, "Debugger");
 		
 		// In case this is a delay slot or combined instruction, clear cache above it too.
-		std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
-		if (MIPSComp::jit)
-			MIPSComp::jit->InvalidateCacheAt((u32)(address - 4),(int)length+4);
+		mipsr4k.InvalidateICache((u32)(address - 4), (int)length + 4);
 
 		address += length;
 		return true;

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -1067,6 +1067,8 @@ BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 				UpdatePreviews();
 				lastCounter = GPUStepping::GetSteppingCounter();
 			}
+		} else if (!PSP_IsInited() && primaryBuffer_) {
+			SendMessage(m_hDlg, WM_COMMAND, IDC_GEDBG_RESUME, 0);
 		}
 		break;
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -132,6 +132,11 @@ void Vibrate(int length_ms) {
 	// Ignore on PC
 }
 
+static void AddDebugRestartArgs() {
+	if (LogManager::GetInstance()->GetConsoleListener()->IsOpen())
+		restartArgs += " -l";
+}
+
 // Adapted mostly as-is from http://www.gamedev.net/topic/495075-how-to-retrieve-info-about-videocard/?view=findpost&p=4229170
 // so credit goes to that post's author, and in turn, the author of the site mentioned in that post (which seems to be down?).
 std::string GetVideoCardDriverVersion() {
@@ -352,6 +357,8 @@ void System_SendMessage(const char *command, const char *parameter) {
 		}
 	} else if (!strcmp(command, "graphics_restart")) {
 		restartArgs = parameter == nullptr ? "" : parameter;
+		if (!restartArgs.empty())
+			AddDebugRestartArgs();
 		if (IsDebuggerPresent()) {
 			PostMessage(MainWindow::GetHWND(), MainWindow::WM_USER_RESTART_EMUTHREAD, 0, 0);
 		} else {


### PR DESCRIPTION
I've run into this a few times, but didn't make the connection previously.

Reproduction case is simple:
 * Open GE Debugger and hit step prim.
 * Say, "oh, hmm" and add a memory breakpoint in the Dissasembly (while still stepping the GE.)
 * Resume from the GE debugger.

Previously, it was clearing the jit cache during stepping, and then you'd return from the sceGe func into INT3/BKPT/etc.  This makes it queue up invalidations while running for later.

I suspect cheats or other things could've fallen into this trap too, but not sure.

Also some smaller changes.

-[Unknown]