### PR TITLE
MIPS: Fix non standard layout offsets

### DIFF
--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -267,7 +267,6 @@ public:
 
 	void ClearJitCache();
 
-protected:
 	void ProcessPendingClears();
 
 	// Doesn't need save stating.


### PR DESCRIPTION
This quiets a warning during compile.  Oops.

-[Unknown]