### PR TITLE
Workaround ARM32 forcecheck issue

### DIFF
--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -585,6 +585,8 @@ void ForceCheck()
 	int cyclesExecuted = slicelength - currentMIPS->downcount;
 	globalTimer += cyclesExecuted;
 	// This will cause us to check for new events immediately.
+	// NOTE: This causes problems on ARM32 in certain contexts due to jo.downcountInRegister.
+	// Not 100% sure what's going on there yet.
 	currentMIPS->downcount = -1;
 	// But let's not eat a bunch more time in Advance() because of this.
 	slicelength = -1;

--- a/Core/MIPS/JitCommon/JitState.cpp
+++ b/Core/MIPS/JitCommon/JitState.cpp
@@ -37,7 +37,7 @@ namespace MIPSComp {
 
 		// ARM only
 		downcountInRegister = true;
-		useNEONVFPU = false;  // true
+		useNEONVFPU = false;
 		if (Disabled(JitDisable::SIMD))
 			useNEONVFPU = false;
 

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -370,7 +370,9 @@ void MIPSState::InvalidateICache(u32 address, int length) {
 		if (coreState == CORE_RUNNING || insideJit) {
 			pendingClears.emplace_back(address, length);
 			hasPendingClears = true;
+#if !PPSSPP_ARCH(ARM) // See comment in ForceCheck
 			CoreTiming::ForceCheck();
+#endif
 		} else {
 			MIPSComp::jit->InvalidateCacheAt(address, length);
 		}
@@ -383,7 +385,9 @@ void MIPSState::ClearJitCache() {
 		if (coreState == CORE_RUNNING || insideJit) {
 			pendingClears.emplace_back(0, 0);
 			hasPendingClears = true;
+#if !PPSSPP_ARCH(ARM) // See comment in ForceCheck
 			CoreTiming::ForceCheck();
+#endif
 		} else {
 			MIPSComp::jit->ClearCache();
 		}

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1270,6 +1270,7 @@ Draw::Texture *FramebufferManagerCommon::MakePixelTexture(const u8 *srcPixels, G
 				break;
 
 			case GE_FORMAT_INVALID:
+			case GE_FORMAT_CLUT8:
 				// Bad
 				break;
 			}
@@ -1685,7 +1686,7 @@ bool FramebufferManagerCommon::NotifyFramebufferCopy(u32 src, u32 dst, int size,
 		const int vfb_byteWidth = vfb->width * vfb_bpp;
 
 		// Heuristic to try to prevent potential glitches with video playback.
-		if (!ignoreDstBuffer && vfb_address == dst && (size == 0x44000 && vfb_size == 0x88000 || size == 0x88000 && vfb_size == 0x44000)) {
+		if (!ignoreDstBuffer && vfb_address == dst && ((size == 0x44000 && vfb_size == 0x88000) || (size == 0x88000 && vfb_size == 0x44000))) {
 			// Not likely to be a correct color format copy for this buffer. Ignore it, there will either be RAM
 			// that can be displayed from, or another matching buffer with the right format if rendering is going on.
 			WARN_LOG_N_TIMES(notify_copy_2x, 5, G3D, "Framebuffer size %08x conspicuously not matching copy size %08x in NotifyFramebufferCopy. Ignoring.", size, vfb_size);


### PR DESCRIPTION
Disables "ForceCheck" on jit invalidation on ARM32, introduced in https://github.com/hrydgard/ppsspp/pull/16194


I'm not sure if we should call it at all here, but at least this makes games work again on ARM32. Will need more investigation.