### PR TITLE
Remove the OpenGL bFragmentTestCache ini option, autodetect instead

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -937,7 +937,6 @@ static ConfigSetting graphicsSettings[] = {
 	ConfigSetting("ShaderChainRequires60FPS", &g_Config.bShaderChainRequires60FPS, false, true, true),
 
 	ReportedConfigSetting("MemBlockTransferGPU", &g_Config.bBlockTransferGPU, true, true, true),
-	ReportedConfigSetting("FragmentTestCache", &g_Config.bFragmentTestCache, true, true, true),
 
 	ConfigSetting("GfxDebugOutput", &g_Config.bGfxDebugOutput, false, false, false),
 	ConfigSetting("LogFrameDrops", &g_Config.bLogFrameDrops, false, true, false),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -235,7 +235,6 @@ public:
 	float fGameListScrollPosition;
 	int iBloomHack; //0 = off, 1 = safe, 2 = balanced, 3 = aggressive
 	bool bBlockTransferGPU;
-	bool bFragmentTestCache;
 	int iSplineBezierQuality; // 0 = low , 1 = Intermediate , 2 = High
 	bool bHardwareTessellation;
 	bool bShaderCache;  // Hidden ini-only setting, useful for debugging shader compile times.

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -45,7 +45,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 
 	bool highpFog = false;
 	bool highpTexcoord = false;
-	bool enableFragmentTestCache = g_Config.bFragmentTestCache && ShaderLanguageIsOpenGL(compat.shaderLanguage);
+	bool enableFragmentTestCache = gstate_c.Supports(GPU_USE_FRAGMENT_TEST_CACHE);
 
 	if (compat.gles) {
 		// PowerVR needs highp to do the fog in MHU correctly.

--- a/GPU/GLES/FragmentTestCacheGLES.cpp
+++ b/GPU/GLES/FragmentTestCacheGLES.cpp
@@ -40,10 +40,6 @@ void FragmentTestCacheGLES::DeviceRestore(Draw::DrawContext *draw) {
 }
 
 void FragmentTestCacheGLES::BindTestTexture(int slot) {
-	if (!g_Config.bFragmentTestCache) {
-		return;
-	}
-
 	bool alphaNeedsTexture = gstate.isAlphaTestEnabled() && !IsAlphaTestAgainstZero() && !IsAlphaTestTriviallyTrue();
 	bool colorNeedsTexture = gstate.isColorTestEnabled() && !IsColorTestAgainstZero() && !IsColorTestTriviallyTrue();
 	if (!alphaNeedsTexture && !colorNeedsTexture) {
@@ -156,7 +152,7 @@ void FragmentTestCacheGLES::Clear(bool deleteThem) {
 		}
 	}
 	cache_.clear();
-	lastTexture_ = 0;
+	lastTexture_ = nullptr;
 }
 
 void FragmentTestCacheGLES::Decimate() {
@@ -173,5 +169,5 @@ void FragmentTestCacheGLES::Decimate() {
 		decimationCounter_ = FRAGTEST_DECIMATION_INTERVAL;
 	}
 
-	lastTexture_ = 0;
+	lastTexture_ = nullptr;
 }

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -205,6 +205,10 @@ u32 GPU_GLES::CheckGPUFeatures() const {
 		features |= GPU_USE_DEPTH_RANGE_HACK;
 	}
 
+	if (!draw_->GetShaderLanguageDesc().bitwiseOps) {
+		features |= GPU_USE_FRAGMENT_TEST_CACHE;
+	}
+
 	return features;
 }
 

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -304,7 +304,7 @@ void DrawEngineGLES::ApplyDrawStateLate(bool setStencilValue, int stencilValue) 
 
 	// At this point, we know if the vertices are full alpha or not.
 	// TODO: Set the nearest/linear here (since we correctly know if alpha/color tests are needed)?
-	if (!gstate.isModeClear()) {
+	if (!gstate.isModeClear() && gstate_c.Supports(GPU_USE_FRAGMENT_TEST_CACHE)) {
 		// Apply last, once we know the alpha params of the texture.
 		if (gstate.isAlphaTestEnabled() || gstate.isColorTestEnabled()) {
 			fragmentTestCache_->BindTestTexture(TEX_SLOT_ALPHATEST);

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -466,12 +466,14 @@ struct UVScale {
 
 #define FLAG_BIT(x) (1 << x)
 
-// Some of these are OpenGL-specific even though this file is neutral, unfortunately.
-// Might want to move this mechanism into the backend later.
+// These flags are mainly to make sure that we make decisions on code path in a single
+// location. Sometimes we need to take things into account in multiple places, it helps
+// to centralize into flags like this. They're also fast to check since the cache line
+// will be hot.
 enum {
 	GPU_SUPPORTS_DUALSOURCE_BLEND = FLAG_BIT(0),
 	GPU_USE_LIGHT_UBERSHADER = FLAG_BIT(1),
-	// Free bit: 2
+	GPU_USE_FRAGMENT_TEST_CACHE = FLAG_BIT(2),
 	GPU_SUPPORTS_VS_RANGE_CULLING = FLAG_BIT(3),
 	GPU_SUPPORTS_BLEND_MINMAX = FLAG_BIT(4),
 	GPU_SUPPORTS_LOGIC_OP = FLAG_BIT(5),

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -437,7 +437,6 @@ int main(int argc, const char* argv[])
 	g_Config.bHighQualityDepth = true;
 	g_Config.bMemStickInserted = true;
 	g_Config.iMemStickSizeGB = 16;
-	g_Config.bFragmentTestCache = true;
 	g_Config.bEnableWlan = true;
 	g_Config.sMACAddress = "12:34:56:78:9A:BC";
 	g_Config.iFirmwareVersion = PSP_DEFAULT_FIRMWARE;


### PR DESCRIPTION
Only enable the cache if the GPU doesn't support bitwise ops.

Mainly a cleanup, plus I want all the backends to take the same path as often as possible on the same GPUs.

Don't think there'll be a measurable performance difference.