### PR TITLE
Revert on-demand depth buffer creation. Also adds a couple new debugging utils

### DIFF
--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -1579,6 +1579,15 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 			}
 			break;
 		}
+
+		case VKRRenderCommand::DEBUG_ANNOTATION:
+			if (vulkan_->Extensions().EXT_debug_utils) {
+				VkDebugUtilsLabelEXT labelInfo{ VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT };
+				labelInfo.pLabelName = c.debugAnnotation.annotation;
+				vkCmdInsertDebugUtilsLabelEXT(cmd, &labelInfo);
+			}
+			break;
+
 		default:
 			ERROR_LOG(G3D, "Unimpl queue command");
 		}

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -1624,7 +1624,7 @@ VKRRenderPass *VulkanQueueRunner::PerformBindFramebufferAsRenderTarget(const VKR
 		renderPass = GetRenderPass(key);
 
 		VKRFramebuffer *fb = step.render.framebuffer;
-		framebuf = fb->Get(renderPass, step.render.renderPassType, cmd);
+		framebuf = fb->Get(renderPass, step.render.renderPassType);
 		w = fb->width;
 		h = fb->height;
 
@@ -1739,8 +1739,6 @@ void VulkanQueueRunner::PerformCopy(const VKRStep &step, VkCommandBuffer cmd) {
 	if (step.copy.aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) {
 		_dbg_assert_(src->depth.image != VK_NULL_HANDLE);
 
-		dst->EnsureDepthImage(cmd);
-
 		if (src->depth.layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL) {
 			SetupTransitionToTransferSrc(src->depth, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, &recordBarrier_);
 		}
@@ -1816,8 +1814,7 @@ void VulkanQueueRunner::PerformBlit(const VKRStep &step, VkCommandBuffer cmd) {
 	// We can't copy only depth or only stencil unfortunately.
 	if (step.blit.aspectMask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) {
 		_dbg_assert_(src->depth.image != VK_NULL_HANDLE);
-
-		dst->EnsureDepthImage(cmd);
+		_dbg_assert_(dst->depth.image != VK_NULL_HANDLE);
 
 		if (src->depth.layout != VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL) {
 			SetupTransitionToTransferSrc(src->depth, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, &recordBarrier_);

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -38,6 +38,7 @@ enum class VKRRenderCommand : uint8_t {
 	DRAW_INDEXED,
 	PUSH_CONSTANTS,
 	SELF_DEPENDENCY_BARRIER,
+	DEBUG_ANNOTATION,
 	NUM_RENDER_COMMANDS,
 };
 
@@ -136,6 +137,9 @@ struct VkRenderData {
 			uint8_t size;
 			uint8_t data[40];  // Should be enough for now.
 		} push;
+		struct {
+			const char *annotation;
+		} debugAnnotation;
 	};
 };
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -161,6 +161,9 @@ VKRFramebuffer::VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VKRRe
 	_dbg_assert_(tag);
 
 	CreateImage(vulkan_, initCmd, color, width, height, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, true, tag);
+	if (createDepthStencilBuffer) {
+		CreateImage(vulkan_, initCmd, depth, width, height, vulkan_->GetDeviceInfo().preferredDepthStencilFormat, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, false, tag);
+	}
 
 	UpdateTag(tag);
 
@@ -169,7 +172,6 @@ VKRFramebuffer::VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VKRRe
 }
 
 void VKRFramebuffer::UpdateTag(const char *newTag) {
-	tag_ = newTag;
 	char name[128];
 	snprintf(name, sizeof(name), "fb_color_%s", tag_.c_str());
 	vulkan_->SetDebugName(color.image, VK_OBJECT_TYPE_IMAGE, name);
@@ -187,14 +189,7 @@ void VKRFramebuffer::UpdateTag(const char *newTag) {
 	}
 }
 
-void VKRFramebuffer::EnsureDepthImage(VkCommandBuffer initCmd) {
-	if (!depth.image) {
-		CreateImage(vulkan_, initCmd, depth, width, height, vulkan_->GetDeviceInfo().preferredDepthStencilFormat, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, false, tag_.c_str());
-		UpdateTag(tag_.c_str());
-	}
-}
-
-VkFramebuffer VKRFramebuffer::Get(VKRRenderPass *compatibleRenderPass, RenderPassType rpType, VkCommandBuffer initCmd) {
+VkFramebuffer VKRFramebuffer::Get(VKRRenderPass *compatibleRenderPass, RenderPassType rpType) {
 	if (framebuf[(int)rpType]) {
 		return framebuf[(int)rpType];
 	}
@@ -206,8 +201,7 @@ VkFramebuffer VKRFramebuffer::Get(VKRRenderPass *compatibleRenderPass, RenderPas
 
 	views[0] = color.imageView;
 	if (hasDepth) {
-		// Make sure there's a depth buffer!
-		EnsureDepthImage(initCmd);
+		_dbg_assert_(depth.imageView != VK_NULL_HANDLE);
 		views[1] = depth.imageView;
 	}
 	fbci.renderPass = compatibleRenderPass->Get(vulkan_, rpType);

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -429,6 +429,13 @@ public:
 		curRenderStep_->render.numDraws++;
 	}
 
+	// These can be useful both when inspecting in RenderDoc, and when manually inspecting recorded commands
+	// in the debugger.
+	void DebugAnnotate(const char *annotation) {
+		VkRenderData data{ VKRRenderCommand::DEBUG_ANNOTATION };
+		data.debugAnnotation.annotation = annotation;
+	}
+
 	VkCommandBuffer GetInitCmd();
 
 	// Gets a frame-unique ID of the current step being recorded. Can be used to figure out

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -47,10 +47,7 @@ public:
 	VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VKRRenderPass *compatibleRenderPass, int _width, int _height, bool createDepthStencilBuffer, const char *tag);
 	~VKRFramebuffer();
 
-	void EnsureDepthImage(VkCommandBuffer initCmd);
-
-	// Needs a command buffer in case it need to initialize the depth buffer on-demand.
-	VkFramebuffer Get(VKRRenderPass *compatibleRenderPass, RenderPassType rpType, VkCommandBuffer initCmd);
+	VkFramebuffer Get(VKRRenderPass *compatibleRenderPass, RenderPassType rpType);
 
 	int width = 0;
 	int height = 0;

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -367,6 +367,8 @@ public:
 	VKContext(VulkanContext *vulkan);
 	virtual ~VKContext();
 
+	void DebugAnnotate(const char *annotation) override;
+
 	const DeviceCaps &GetDeviceCaps() const override {
 		return caps_;
 	}
@@ -1010,6 +1012,8 @@ VkDescriptorSet VKContext::GetOrCreateDescriptorSet(VkBuffer buf) {
 		return VK_NULL_HANDLE;
 	}
 
+	vulkan_->SetDebugName(descSet, VK_OBJECT_TYPE_DESCRIPTOR_SET, "(thin3d desc set)");
+
 	VkDescriptorBufferInfo bufferDesc;
 	bufferDesc.buffer = buf;
 	bufferDesc.offset = 0;
@@ -1649,6 +1653,10 @@ uint64_t VKContext::GetNativeObject(NativeObject obj, void *srcObject) {
 		Crash();
 		return 0;
 	}
+}
+
+void VKContext::DebugAnnotate(const char *annotation) {
+	renderManager_.DebugAnnotate(annotation);
 }
 
 }  // namespace Draw

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -616,6 +616,8 @@ public:
 
 	virtual void SetErrorCallback(ErrorCallbackFn callback, void *userdata) {}
 
+	virtual void DebugAnnotate(const char *annotation) {}
+
 	// Partial pipeline state, used to create pipelines. (in practice, in d3d11 they'll use the native state objects directly).
 	// TODO: Possibly ditch these and just put the descs directly in PipelineDesc since only D3D11 benefits.
 	virtual DepthStencilState *CreateDepthStencilState(const DepthStencilStateDesc &desc) = 0;

--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -170,7 +170,7 @@ void UIContext::ActivateTopScissor() {
 		int h = std::max(0.0f, ceilf(scale_y * bounds.h));
 		if (x < 0 || y < 0 || x + w > pixel_xres || y + h > pixel_yres) {
 			// This won't actually report outside a game, but we can try.
-			WARN_LOG(G3D, "UI scissor out of bounds in %sScreen: %d,%d-%d,%d / %d,%d", screenTag_ ? screenTag_ : "N/A", x, y, w, h, pixel_xres, pixel_yres);
+			ERROR_LOG_REPORT(G3D, "UI scissor out of bounds in %sScreen: %d,%d-%d,%d / %d,%d", screenTag_ ? screenTag_ : "N/A", x, y, w, h, pixel_xres, pixel_yres);
 			x = std::max(0, x);
 			y = std::max(0, y);
 			w = std::min(w, pixel_xres - x);

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -120,8 +120,9 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 	bool isModeClear = id.Bit(FS_BIT_CLEARMODE);
 
 	const char *shading = "";
-	if (compat.glslES30 || compat.shaderLanguage == ShaderLanguage::GLSL_VULKAN)
+	if (compat.glslES30 || compat.shaderLanguage == ShaderLanguage::GLSL_VULKAN) {
 		shading = doFlatShading ? "flat" : "";
+	}
 
 	bool useDiscardStencilBugWorkaround = id.Bit(FS_BIT_NO_DEPTH_CANNOT_DISCARD_STENCIL);
 

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -284,3 +284,6 @@ std::string FragmentShaderDesc(const FShaderID &id);
 
 void ComputeGeometryShaderID(GShaderID *id, const Draw::Bugs &bugs, int prim);
 std::string GeometryShaderDesc(const GShaderID &id);
+
+// For sanity checking.
+bool FragmentIdNeedsFramebufferRead(const FShaderID &id);


### PR DESCRIPTION
Fixes some recent Vulkan validation errors that have popped up, by reverting #16152. One case was when we resize an fbo - the depth copy from the old to the new happened during raster, and nothing ensured that there existed either source or dest depth buffers yet. This led us to try to bind a null texture, which isn't allowed.

Possible to solve but not super trivially. Intend do a second attempt at a later point in time, but it really isn't a very important optimization so might take a while.

Adds a couple of debug functions that I used tracking it down but aren't actually used anywhere now, but I still want them around.