### PR TITLE
OpenXR - Ensure the app gets unloaded when killed by OS

### DIFF
--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -789,6 +789,11 @@ public abstract class NativeActivity extends Activity {
 			initialized = false;
 		}
 		navigationCallbackView = null;
+
+		// Workaround for VR issues PPSSPP restart
+		if (isVRDevice()) {
+			System.exit(0);
+		}
 	}
 
 	@Override

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -790,7 +790,7 @@ public abstract class NativeActivity extends Activity {
 		}
 		navigationCallbackView = null;
 
-		// Workaround for VR issues PPSSPP restart
+		// Workaround for VR issues when PPSSPP restarts
 		if (isVRDevice()) {
 			System.exit(0);
 		}


### PR DESCRIPTION
When the user kills the app using system UI, the native library doesn't get unloaded properly and that causes in the next start issues e.g. with controller or bad performance.

This PR fixes that problem.