### PR TITLE
Vulkan: fix wayland swapchain size 1x1

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <utility>
+#include <functional>
 
 #include "Common/Log.h"
 #include "Common/GPU/Vulkan/VulkanLoader.h"
@@ -190,6 +191,7 @@ public:
 	VkResult ReinitSurface();
 
 	bool InitSwapchain();
+	void SetCbGetDrawSize(std::function<VkExtent2D()>);
 
 	void DestroySwapchain();
 	void DestroySurface();
@@ -363,6 +365,7 @@ private:
 	// that we really don't want in everything that uses VulkanContext.
 	void *winsysData1_;
 	void *winsysData2_;
+	std::function<VkExtent2D()> cbGetDrawSize_;
 
 	VkInstance instance_ = VK_NULL_HANDLE;
 	VkDevice device_ = VK_NULL_HANDLE;

--- a/SDL/SDLVulkanGraphicsContext.cpp
+++ b/SDL/SDLVulkanGraphicsContext.cpp
@@ -10,6 +10,7 @@
 #include "Common/Data/Text/Parsers.h"
 
 #include "Core/System.h"
+#include "SDL_vulkan.h"
 #include "SDLVulkanGraphicsContext.h"
 
 #if defined(VK_USE_PLATFORM_METAL_EXT)
@@ -71,6 +72,12 @@ bool SDLVulkanGraphicsContext::Init(SDL_Window *&window, int x, int y, int mode,
 		vulkan_ = nullptr;
 		return false;
 	}
+
+	vulkan_->SetCbGetDrawSize([window]() {
+		int w=1,h=1;
+		SDL_Vulkan_GetDrawableSize(window, &w, &h);
+		return VkExtent2D {(uint32_t)w, (uint32_t)h};
+	});
 
 	SDL_SysWMinfo sys_info{};
 	SDL_VERSION(&sys_info.version); //Set SDL version


### PR DESCRIPTION
From Vulkan spec,  
surfaceCapabilities.currentExtent can be 0xFFFFFFFF(-1)  

Define a callback to get drawsize from window creator  

relate:  
https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSurfaceCapabilitiesKHR.html  
https://github.com/KhronosGroup/Vulkan-Docs/issues/590#issuecomment-347932321  

issue:  
https://github.com/hrydgard/ppsspp/issues/16163  
https://github.com/hrydgard/ppsspp/issues/13845