### PR TITLE
Need for Speed screen blinking fixed

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -356,8 +356,6 @@ public:
 	bool MayIntersectFramebuffer(u32 start) const {
 		// Clear the cache/kernel bits.
 		start &= 0x3FFFFFFF;
-		if (Memory::IsVRAMAddress(start))
-			start &= 0x041FFFFF;
 		// Most games only have two framebuffers at the start.
 		if (start >= framebufRangeEnd_ || start < PSP_GetVidMemBase()) {
 			return false;


### PR DESCRIPTION
This PR is just a revert of code change causing screen blinking on some GPUs. The code was introduced in https://github.com/hrydgard/ppsspp/pull/16150.

After merging the PR, we can close https://github.com/hrydgard/ppsspp/issues/16175.

Affected game is NFS Pro street.