### PR TITLE
D3D9: Correct scissor state cache in Draw

### DIFF
--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -1318,6 +1318,7 @@ void D3D9Context::BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPa
 	}
 
 	dxstate.scissorRect.restore();
+	dxstate.scissorTest.restore();
 	dxstate.viewport.restore();
 	stepId_++;
 }


### PR DESCRIPTION
Gets reset when updating the render target.  This fixes UI scissors, which has been annoying me any time I test anything in D3D9 as my recent list has a bunch of GE frame dumps.

-[Unknown]