### PR TITLE
jit: Ignore zero byte icache invalidates

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -233,8 +233,9 @@ static int Replace_memcpy16() {
 	bool skip = false;
 
 	// Some games use memcpy on executable code.  We need to flush emuhack ops.
-	currentMIPS->InvalidateICache(srcPtr, bytes);
-	if ((skipGPUReplacements & (int)GPUReplacementSkip::MEMCPY) == 0) {
+	if (bytes != 0)
+		currentMIPS->InvalidateICache(srcPtr, bytes);
+	if ((skipGPUReplacements & (int)GPUReplacementSkip::MEMCPY) == 0 && bytes != 0) {
 		if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(srcPtr)) {
 			skip = gpu->PerformMemoryCopy(destPtr, srcPtr, bytes);
 		}
@@ -305,7 +306,7 @@ static int Replace_memmove() {
 	bool skip = false;
 
 	// Some games use memcpy on executable code.  We need to flush emuhack ops.
-	if ((skipGPUReplacements & (int)GPUReplacementSkip::MEMMOVE) == 0) {
+	if ((skipGPUReplacements & (int)GPUReplacementSkip::MEMMOVE) == 0 && bytes != 0) {
 		currentMIPS->InvalidateICache(srcPtr, bytes);
 		if (Memory::IsVRAMAddress(destPtr) || Memory::IsVRAMAddress(srcPtr)) {
 			skip = gpu->PerformMemoryCopy(destPtr, srcPtr, bytes);

--- a/Core/HLE/sceDmac.cpp
+++ b/Core/HLE/sceDmac.cpp
@@ -49,7 +49,7 @@ static int __DmacMemcpy(u32 dst, u32 src, u32 size) {
 	if (Memory::IsVRAMAddress(src) || Memory::IsVRAMAddress(dst)) {
 		skip = gpu->PerformMemoryCopy(dst, src, size);
 	}
-	if (!skip) {
+	if (!skip && size != 0) {
 		currentMIPS->InvalidateICache(src, size);
 		if (MemBlockInfoDetailed(size)) {
 			const std::string tag = GetMemWriteTagAt("DmacMemcpy/", src, size);

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -392,7 +392,8 @@ int sceKernelDcacheInvalidateRange(u32 addr, int size)
 
 int sceKernelIcacheInvalidateRange(u32 addr, int size) {
 	DEBUG_LOG(CPU, "sceKernelIcacheInvalidateRange(%08x, %i)", addr, size);
-	currentMIPS->InvalidateICache(addr, size);
+	if (size != 0)
+		currentMIPS->InvalidateICache(addr, size);
 	return 0;
 }
 

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -624,7 +624,8 @@ static u32 sceKernelMemcpy(u32 dst, u32 src, u32 size)
 	DEBUG_LOG(SCEKERNEL, "sceKernelMemcpy(dest=%08x, src=%08x, size=%i)", dst, src, size);
 
 	// Some games copy from executable code.  We need to flush emuhack ops.
-	currentMIPS->InvalidateICache(src, size);
+	if (size != 0)
+		currentMIPS->InvalidateICache(src, size);
 
 	bool skip = false;
 	if (Memory::IsVRAMAddress(src) || Memory::IsVRAMAddress(dst)) {

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -182,9 +182,10 @@ void ArmJit::ClearCache()
 	GenerateFixedCode();
 }
 
-void ArmJit::InvalidateCacheAt(u32 em_address, int length)
-{
-	blocks.InvalidateICache(em_address, length);
+void ArmJit::InvalidateCacheAt(u32 em_address, int length) {
+	if (blocks.RangeMayHaveEmuHacks(em_address, em_address + length)) {
+		blocks.InvalidateICache(em_address, length);
+	}
 }
 
 void ArmJit::EatInstruction(MIPSOpcode op) {

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -180,7 +180,9 @@ void Arm64Jit::ClearCache() {
 }
 
 void Arm64Jit::InvalidateCacheAt(u32 em_address, int length) {
-	blocks.InvalidateICache(em_address, length);
+	if (blocks.RangeMayHaveEmuHacks(em_address, em_address + length)) {
+		blocks.InvalidateICache(em_address, length);
+	}
 }
 
 void Arm64Jit::EatInstruction(MIPSOpcode op) {

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -366,14 +366,15 @@ void MIPSState::ProcessPendingClears() {
 void MIPSState::InvalidateICache(u32 address, int length) {
 	// Only really applies to jit.
 	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
-	if (MIPSComp::jit) {
-		if (coreState == CORE_RUNNING || insideJit) {
-			pendingClears.emplace_back(address, length);
-			hasPendingClears = true;
-			CoreTiming::ForceCheck();
-		} else {
-			MIPSComp::jit->InvalidateCacheAt(address, length);
-		}
+	if (!MIPSComp::jit || length == 0)
+		return;
+
+	if (coreState == CORE_RUNNING || insideJit) {
+		pendingClears.emplace_back(address, length);
+		hasPendingClears = true;
+		CoreTiming::ForceCheck();
+	} else {
+		MIPSComp::jit->InvalidateCacheAt(address, length);
 	}
 }
 

--- a/Core/MIPS/MIPS/MipsJit.cpp
+++ b/Core/MIPS/MIPS/MipsJit.cpp
@@ -97,9 +97,10 @@ void MipsJit::ClearCache()
 	//GenerateFixedCode();
 }
 
-void MipsJit::InvalidateCacheAt(u32 em_address, int length)
-{
-	blocks.InvalidateICache(em_address, length);
+void MipsJit::InvalidateCacheAt(u32 em_address, int length) {
+	if (blocks.RangeMayHaveEmuHacks(em_address, em_address + length)) {
+		blocks.InvalidateICache(em_address, length);
+	}
 }
 
 void MipsJit::EatInstruction(MIPSOpcode op) {

--- a/Core/MIPS/fake/FakeJit.cpp
+++ b/Core/MIPS/fake/FakeJit.cpp
@@ -98,9 +98,10 @@ void FakeJit::ClearCache()
 	//GenerateFixedCode();
 }
 
-void FakeJit::InvalidateCacheAt(u32 em_address, int length)
-{
-	blocks.InvalidateICache(em_address, length);
+void FakeJit::InvalidateCacheAt(u32 em_address, int length) {
+	if (blocks.RangeMayHaveEmuHacks(em_address, em_address + length)) {
+		blocks.InvalidateICache(em_address, length);
+	}
 }
 
 void FakeJit::EatInstruction(MIPSOpcode op) {


### PR DESCRIPTION
This was causing poor performance in LittleBigPlanet, because it was doing a `memmove(nullptr, src, 0);`.  We enqueued this (since it's in replace and could modify its jit return address), but then executed it as a full clear instead of a no-op.  Oops, I should've thought to filter these out.

-[Unknown]