### PR TITLE
jit: Run invalidates immediately

### DIFF
--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -365,15 +365,10 @@ void MIPSState::ProcessPendingClears() {
 
 void MIPSState::InvalidateICache(u32 address, int length) {
 	// Only really applies to jit.
+	// Note that the backend is responsible for ensuring native code can still be returned to.
 	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 	if (MIPSComp::jit) {
-		if (coreState == CORE_RUNNING || insideJit) {
-			pendingClears.emplace_back(address, length);
-			hasPendingClears = true;
-			CoreTiming::ForceCheck();
-		} else {
-			MIPSComp::jit->InvalidateCacheAt(address, length);
-		}
+		MIPSComp::jit->InvalidateCacheAt(address, length);
 	}
 }
 


### PR DESCRIPTION
Previously, I thought we might clear native code when invalidating - we don't.  We only do that when clearing.

So we only really need to enqueue clears, but I'll leave the mechanics for enqueuing separately.  Sorry, my mistake.

-[Unknown]