### PR TITLE
SDL: fix glew on wayland by ignore glx

### DIFF
--- a/SDL/SDLGLGraphicsContext.cpp
+++ b/SDL/SDLGLGraphicsContext.cpp
@@ -394,7 +394,9 @@ int SDLGLGraphicsContext::Init(SDL_Window *&window, int x, int y, int mode, std:
 	if (gl_extensions.IsCoreContext) {
 		glewExperimental = true;
 	}
-	if (GLEW_OK != glewInit()) {
+	GLenum glew_err = glewInit();
+	// glx is not required, igore.
+	if (glew_err != GLEW_OK && glew_err != GLEW_ERROR_NO_GLX_DISPLAY) {
 		printf("Failed to initialize glew!\n");
 		return 1;
 	}


### PR DESCRIPTION
glXGetProcAddress works on wayland if linking with x11.   
As long as we don't use glx related funcs, no_glx_error can be ignored.  
SDL should handle the no_glx_error brefore glewInit.  
Glew is only used to init gl funcs.

related:
https://github.com/nigels-com/glew/issues/172

issue:  
https://github.com/hrydgard/ppsspp/issues/16252  
https://github.com/hrydgard/ppsspp/issues/16237  