### PR TITLE
GPU: Respect world matrix and reverse flag w/o normals

### DIFF
--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -869,7 +869,7 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 				if (hasNormalTess) {
 					WRITE(p, "  mediump vec3 worldnormal = normalizeOr001(mul(vec4(%stess.nrm, 0.0), u_world).xyz);\n", flipNormalTess ? "-" : "");
 				} else {
-					WRITE(p, "  mediump vec3 worldnormal = vec3(0.0, 0.0, 1.0);\n");
+					WRITE(p, "  mediump vec3 worldnormal = normalizeOr001(mul(vec4(0.0, 0.0, %s1.0, 0.0), u_world).xyz);\n", flipNormalTess ? "-" : "");
 				}
 			} else {
 				// No skinning, just standard T&L.
@@ -877,7 +877,7 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 				if (hasNormal)
 					WRITE(p, "  mediump vec3 worldnormal = normalizeOr001(mul(vec4(%snormal, 0.0), u_world).xyz);\n", flipNormal ? "-" : "");
 				else
-					WRITE(p, "  mediump vec3 worldnormal = vec3(0.0, 0.0, 1.0);\n");
+					WRITE(p, "  mediump vec3 worldnormal = normalizeOr001(mul(vec4(0.0, 0.0, %s1.0, 0.0), u_world).xyz);\n", flipNormal ? "-" : "");
 			}
 		} else {
 			static const char *rescale[4] = {"", " * 1.9921875", " * 1.999969482421875", ""}; // 2*127.5f/128.f, 2*32767.5f/32768.f, 1.0f};

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -411,11 +411,9 @@ ClipVertexData TransformUnit::ReadVertex(VertexReader &vreader, const TransformS
 		vertex.v.clipw = vertex.clippos.w;
 
 		Vec3<float> worldnormal;
-		if (vreader.hasNormal()) {
+		if (state.enableLighting || state.uvGenMode == GE_TEXMAP_ENVIRONMENT_MAP) {
 			worldnormal = TransformUnit::ModelToWorldNormal(normal);
 			worldnormal.NormalizeOr001();
-		} else {
-			worldnormal = Vec3<float>(0.0f, 0.0f, 1.0f);
 		}
 
 		// Time to generate some texture coords.  Lighting will handle shade mapping.

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -337,17 +337,12 @@ ClipVertexData TransformUnit::ReadVertex(VertexReader &vreader, const TransformS
 		vertex.v.texturecoords = lastTC;
 	}
 
-	Vec3f normal;
 	static Vec3f lastnormal;
-	if (vreader.hasNormal()) {
-		vreader.ReadNrm(normal.AsArray());
-		lastnormal = normal;
-
-		if (state.negateNormals)
-			normal = -normal;
-	} else {
-		normal = lastnormal;
-	}
+	if (vreader.hasNormal())
+		vreader.ReadNrm(lastnormal.AsArray());
+	Vec3f normal = lastnormal;
+	if (state.negateNormals)
+		normal = -normal;
 
 	if (state.readWeights) {
 		float W[8] = { 1.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f };


### PR DESCRIPTION
Per some hardware tests, the reverse flag is definitely still applied, and multiplication by the world matrix also happens.

This doesn't explain the Ridge Racer issue, but at least it answers one question.

This is why the jump smoke cloud was colored wrong here:
https://github.com/hrydgard/ppsspp/issues/14223#issuecomment-1272682687

This corrects that in hardware and software renderers.

-[Unknown]