### PR TITLE
Vulkan: Fix frame ordering issue with postprocessing shaders

### DIFF
--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -612,9 +612,9 @@ void VulkanRenderManager::BeginFrame(bool enableProfiling, bool enableLogProfile
 	// Must be after the fence - this performs deletes.
 	VLOG("PUSH: BeginFrame %d", curFrame);
 
+	insideFrame_ = true;
 	vulkan_->BeginFrame(enableLogProfiler ? GetInitCmd() : VK_NULL_HANDLE);
 
-	insideFrame_ = true;
 	renderStepOffset_ = 0;
 
 	frameData.profile.timestampDescriptions.clear();

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -108,6 +108,13 @@ bool FramebufferManagerCommon::UpdateSize() {
 
 void FramebufferManagerCommon::BeginFrame() {
 	DecimateFBOs();
+
+	// Might have a new post shader - let's compile it.
+	if (updatePostShaders_) {
+		presentation_->UpdatePostShader();
+		updatePostShaders_ = false;
+	}
+
 	currentRenderVfb_ = nullptr;
 }
 
@@ -2349,8 +2356,9 @@ void FramebufferManagerCommon::Resized() {
 		DestroyAllFBOs();
 	}
 
-	// Might have a new post shader - let's compile it.
-	presentation_->UpdatePostShader();
+	// No drawing is allowed here. This includes anything that might potentially touch a command buffer, like creating images!
+	// So we need to defer the post processing initialization.
+	updatePostShaders_ = true;
 
 #ifdef _WIN32
 	// Seems related - if you're ok with numbers all the time, show some more :)

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -544,6 +544,7 @@ protected:
 	int pixelWidth_ = 0;
 	int pixelHeight_ = 0;
 	int bloomHack_ = 0;
+	bool updatePostShaders_ = false;
 
 	Draw::DataFormat preferredPixelsFormat_ = Draw::DataFormat::R8G8B8A8_UNORM;
 


### PR DESCRIPTION
Requested an init command buffer outside the frame, which is dangerous and caused validation problems with command pool resets.

Would like to assert on insideFrame in GetInitCmd, but we use it from some init code where it does work correctly. Might clean that up at some point.