### PR TITLE
Vulkan multiview rendering

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -94,11 +94,8 @@ public:
 	bool CopyFramebufferToMemorySync(Framebuffer *src, int channelBits, int x, int y, int w, int h, Draw::DataFormat format, void *pixels, int pixelStride, const char *tag) override;
 
 	// These functions should be self explanatory.
-	void BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) override;
-	Framebuffer *GetCurrentRenderTarget() override {
-		return curRenderTarget_;
-	}
-	void BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit) override;
+	void BindFramebufferAsRenderTarget(Framebuffer *fbo, int layer, const RenderPassInfo &rp, const char *tag) override;
+	void BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int layer) override;
 
 	void GetFramebufferDimensions(Framebuffer *fbo, int *w, int *h) override;
 
@@ -1658,7 +1655,8 @@ bool D3D11DrawContext::CopyFramebufferToMemorySync(Framebuffer *src, int channel
 	return true;
 }
 
-void D3D11DrawContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) {
+void D3D11DrawContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, int layer, const RenderPassInfo &rp, const char *tag) {
+	_dbg_assert_(layer == ALL_LAYERS || layer == 0);  // No multiple layer support on D3D
 	// TODO: deviceContext1 can actually discard. Useful on Windows Mobile.
 	if (fbo) {
 		D3D11Framebuffer *fb = (D3D11Framebuffer *)fbo;
@@ -1704,8 +1702,9 @@ void D3D11DrawContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, const Ren
 	stepId_++;
 }
 
-void D3D11DrawContext::BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit) {
-	_assert_(binding < MAX_BOUND_TEXTURES);
+void D3D11DrawContext::BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int layer) {
+	_dbg_assert_(binding < MAX_BOUND_TEXTURES);
+	_dbg_assert_(layer == ALL_LAYERS || layer == 0);  // No multiple layer support on D3D
 	D3D11Framebuffer *fb = (D3D11Framebuffer *)fbo;
 	switch (channelBit) {
 	case FBChannel::FB_COLOR_BIT:

--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -1306,35 +1306,38 @@ public:
 Framebuffer *D3D11DrawContext::CreateFramebuffer(const FramebufferDesc &desc) {
 	HRESULT hr;
 	D3D11Framebuffer *fb = new D3D11Framebuffer(desc.width, desc.height);
-	if (desc.numColorAttachments) {
-		fb->colorFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
-		D3D11_TEXTURE2D_DESC descColor{};
-		descColor.Width = desc.width;
-		descColor.Height = desc.height;
-		descColor.MipLevels = 1;
-		descColor.ArraySize = 1;
-		descColor.Format = fb->colorFormat;
-		descColor.SampleDesc.Count = 1;
-		descColor.SampleDesc.Quality = 0;
-		descColor.Usage = D3D11_USAGE_DEFAULT;
-		descColor.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
-		descColor.CPUAccessFlags = 0;
-		descColor.MiscFlags = 0;
-		hr = device_->CreateTexture2D(&descColor, nullptr, &fb->colorTex);
-		if (FAILED(hr)) {
-			delete fb;
-			return nullptr;
-		}
-		hr = device_->CreateRenderTargetView(fb->colorTex, nullptr, &fb->colorRTView);
-		if (FAILED(hr)) {
-			delete fb;
-			return nullptr;
-		}
-		hr = device_->CreateShaderResourceView(fb->colorTex, nullptr, &fb->colorSRView);
-		if (FAILED(hr)) {
-			delete fb;
-			return nullptr;
-		}
+
+	// We don't (yet?) support multiview for D3D11. Not sure if there's a way to do it.
+	// Texture arrays are supported but we don't have any other use cases yet.
+	_dbg_assert_(desc.numLayers == 1);
+
+	fb->colorFormat = DXGI_FORMAT_R8G8B8A8_UNORM;
+	D3D11_TEXTURE2D_DESC descColor{};
+	descColor.Width = desc.width;
+	descColor.Height = desc.height;
+	descColor.MipLevels = 1;
+	descColor.ArraySize = 1;
+	descColor.Format = fb->colorFormat;
+	descColor.SampleDesc.Count = 1;
+	descColor.SampleDesc.Quality = 0;
+	descColor.Usage = D3D11_USAGE_DEFAULT;
+	descColor.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+	descColor.CPUAccessFlags = 0;
+	descColor.MiscFlags = 0;
+	hr = device_->CreateTexture2D(&descColor, nullptr, &fb->colorTex);
+	if (FAILED(hr)) {
+		delete fb;
+		return nullptr;
+	}
+	hr = device_->CreateRenderTargetView(fb->colorTex, nullptr, &fb->colorRTView);
+	if (FAILED(hr)) {
+		delete fb;
+		return nullptr;
+	}
+	hr = device_->CreateShaderResourceView(fb->colorTex, nullptr, &fb->colorSRView);
+	if (FAILED(hr)) {
+		delete fb;
+		return nullptr;
 	}
 
 	if (desc.z_stencil) {

--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -101,7 +101,7 @@ public:
 
 	void InvalidateCachedState() override;
 
-	void BindTextures(int start, int count, Texture **textures) override;
+	void BindTextures(int start, int count, Texture **textures, TextureBindFlags flags) override;
 	void BindNativeTexture(int index, void *nativeTexture) override;
 	void BindSamplerStates(int start, int count, SamplerState **states) override;
 	void BindVertexBuffers(int start, int count, Buffer **buffers, const int *offsets) override;
@@ -1381,7 +1381,7 @@ Framebuffer *D3D11DrawContext::CreateFramebuffer(const FramebufferDesc &desc) {
 	return fb;
 }
 
-void D3D11DrawContext::BindTextures(int start, int count, Texture **textures) {
+void D3D11DrawContext::BindTextures(int start, int count, Texture **textures, TextureBindFlags flags) {
 	// Collect the resource views from the textures.
 	ID3D11ShaderResourceView *views[MAX_BOUND_TEXTURES];
 	_assert_(start + count <= ARRAY_SIZE(views));

--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -94,7 +94,7 @@ public:
 	bool CopyFramebufferToMemorySync(Framebuffer *src, int channelBits, int x, int y, int w, int h, Draw::DataFormat format, void *pixels, int pixelStride, const char *tag) override;
 
 	// These functions should be self explanatory.
-	void BindFramebufferAsRenderTarget(Framebuffer *fbo, int layer, const RenderPassInfo &rp, const char *tag) override;
+	void BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) override;
 	void BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int layer) override;
 
 	void GetFramebufferDimensions(Framebuffer *fbo, int *w, int *h) override;
@@ -1655,8 +1655,7 @@ bool D3D11DrawContext::CopyFramebufferToMemorySync(Framebuffer *src, int channel
 	return true;
 }
 
-void D3D11DrawContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, int layer, const RenderPassInfo &rp, const char *tag) {
-	_dbg_assert_(layer == ALL_LAYERS || layer == 0);  // No multiple layer support on D3D
+void D3D11DrawContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) {
 	// TODO: deviceContext1 can actually discard. Useful on Windows Mobile.
 	if (fbo) {
 		D3D11Framebuffer *fb = (D3D11Framebuffer *)fbo;

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -538,7 +538,7 @@ public:
 
 	void GetFramebufferDimensions(Framebuffer *fbo, int *w, int *h) override;
 
-	void BindTextures(int start, int count, Texture **textures) override;
+	void BindTextures(int start, int count, Texture **textures, TextureBindFlags flags) override;
 	void BindNativeTexture(int index, void *nativeTexture) override;
 
 	void BindSamplerStates(int start, int count, SamplerState **states) override {
@@ -912,7 +912,7 @@ Texture *D3D9Context::CreateTexture(const TextureDesc &desc) {
 	return tex;
 }
 
-void D3D9Context::BindTextures(int start, int count, Texture **textures) {
+void D3D9Context::BindTextures(int start, int count, Texture **textures, TextureBindFlags flags) {
 	_assert_(start + count <= MAX_BOUND_TEXTURES);
 	for (int i = start; i < start + count; i++) {
 		D3D9Texture *tex = static_cast<D3D9Texture *>(textures[i - start]);

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -746,7 +746,6 @@ D3D9Context::D3D9Context(IDirect3D9 *d3d, IDirect3D9Ex *d3dEx, int adapterId, ID
 	}
 
 	caps_.deviceID = identifier_.DeviceId;
-	caps_.multiViewport = false;
 	caps_.depthRangeMinusOneToOne = false;
 	caps_.preferredDepthBufferFormat = DataFormat::D24_S8;
 	caps_.dualSourceBlend = false;

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -531,7 +531,7 @@ public:
 	bool CopyFramebufferToMemorySync(Framebuffer *src, int channelBits, int x, int y, int w, int h, Draw::DataFormat format, void *pixels, int pixelStride, const char *tag) override;
 
 	// These functions should be self explanatory.
-	void BindFramebufferAsRenderTarget(Framebuffer *fbo, int layer, const RenderPassInfo &rp, const char *tag) override;
+	void BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) override;
 	void BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int layer) override;
 
 	uintptr_t GetFramebufferAPITexture(Framebuffer *fbo, int channelBits, int attachment) override;
@@ -1289,8 +1289,7 @@ D3D9Framebuffer::~D3D9Framebuffer() {
 	}
 }
 
-void D3D9Context::BindFramebufferAsRenderTarget(Framebuffer *fbo, int layer, const RenderPassInfo &rp, const char *tag) {
-	_dbg_assert_(layer == ALL_LAYERS || layer == 0);  // No stereo support
+void D3D9Context::BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) {
 	if (fbo) {
 		D3D9Framebuffer *fb = (D3D9Framebuffer *)fbo;
 		device_->SetRenderTarget(0, fb->surf);

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -531,12 +531,9 @@ public:
 	bool CopyFramebufferToMemorySync(Framebuffer *src, int channelBits, int x, int y, int w, int h, Draw::DataFormat format, void *pixels, int pixelStride, const char *tag) override;
 
 	// These functions should be self explanatory.
-	void BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) override;
-	Framebuffer *GetCurrentRenderTarget() override {
-		return curRenderTarget_;
-	}
-	void BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit) override;
-	
+	void BindFramebufferAsRenderTarget(Framebuffer *fbo, int layer, const RenderPassInfo &rp, const char *tag) override;
+	void BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int layer) override;
+
 	uintptr_t GetFramebufferAPITexture(Framebuffer *fbo, int channelBits, int attachment) override;
 
 	void GetFramebufferDimensions(Framebuffer *fbo, int *w, int *h) override;
@@ -1292,7 +1289,8 @@ D3D9Framebuffer::~D3D9Framebuffer() {
 	}
 }
 
-void D3D9Context::BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) {
+void D3D9Context::BindFramebufferAsRenderTarget(Framebuffer *fbo, int layer, const RenderPassInfo &rp, const char *tag) {
+	_dbg_assert_(layer == ALL_LAYERS || layer == 0);  // No stereo support
 	if (fbo) {
 		D3D9Framebuffer *fb = (D3D9Framebuffer *)fbo;
 		device_->SetRenderTarget(0, fb->surf);
@@ -1351,8 +1349,9 @@ uintptr_t D3D9Context::GetFramebufferAPITexture(Framebuffer *fbo, int channelBit
 	}
 }
 
-void D3D9Context::BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit) {
-	_assert_(binding < MAX_BOUND_TEXTURES);
+void D3D9Context::BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int layer) {
+	_dbg_assert_(binding < MAX_BOUND_TEXTURES);
+	_dbg_assert_(layer == ALL_LAYERS || layer == 0);  // No stereo support
 	D3D9Framebuffer *fb = (D3D9Framebuffer *)fbo;
 	switch (channelBit) {
 	case FB_DEPTH_BIT:

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -1244,6 +1244,9 @@ public:
 };
 
 Framebuffer *D3D9Context::CreateFramebuffer(const FramebufferDesc &desc) {
+	// Don't think D3D9 does array layers.
+	_dbg_assert_(desc.numLayers == 1);
+
 	static uint32_t id = 0;
 
 	D3D9Framebuffer *fbo = new D3D9Framebuffer(desc.width, desc.height);

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -354,11 +354,8 @@ public:
 	bool CopyFramebufferToMemorySync(Framebuffer *src, int channelBits, int x, int y, int w, int h, Draw::DataFormat format, void *pixels, int pixelStride, const char *tag) override;
 
 	// These functions should be self explanatory.
-	void BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) override;
-	Framebuffer *GetCurrentRenderTarget() override {
-		return curRenderTarget_;
-	}
-	void BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit) override;
+	void BindFramebufferAsRenderTarget(Framebuffer *fbo, int layer, const RenderPassInfo &rp, const char *tag) override;
+	void BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int layer) override;
 
 	void GetFramebufferDimensions(Framebuffer *fbo, int *w, int *h) override;
 
@@ -1398,7 +1395,9 @@ Framebuffer *OpenGLContext::CreateFramebuffer(const FramebufferDesc &desc) {
 	return fbo;
 }
 
-void OpenGLContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) {
+void OpenGLContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, int layer, const RenderPassInfo &rp, const char *tag) {
+	_dbg_assert_(layer == ALL_LAYERS || layer == 0);
+
 	OpenGLFramebuffer *fb = (OpenGLFramebuffer *)fbo;
 	GLRRenderPassAction color = (GLRRenderPassAction)rp.color;
 	GLRRenderPassAction depth = (GLRRenderPassAction)rp.depth;
@@ -1439,7 +1438,7 @@ bool OpenGLContext::BlitFramebuffer(Framebuffer *fbsrc, int srcX1, int srcY1, in
 	return true;
 }
 
-void OpenGLContext::BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit) {
+void OpenGLContext::BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int layer) {
 	OpenGLFramebuffer *fb = (OpenGLFramebuffer *)fbo;
 	_assert_(binding < MAX_TEXTURE_SLOTS);
 

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -1390,6 +1390,9 @@ void OpenGLInputLayout::Compile(const InputLayoutDesc &desc) {
 Framebuffer *OpenGLContext::CreateFramebuffer(const FramebufferDesc &desc) {
 	CheckGLExtensions();
 
+	// TODO: Support multiview later. (It's our only use case for multi layers).
+	_dbg_assert_(desc.numLayers == 1);
+
 	GLRFramebuffer *framebuffer = renderManager_.CreateFramebuffer(desc.width, desc.height, desc.z_stencil);
 	OpenGLFramebuffer *fbo = new OpenGLFramebuffer(&renderManager_, framebuffer);
 	return fbo;

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -397,7 +397,7 @@ public:
 			curPipeline_->depthStencil->stencilPass);
 	}
 
-	void BindTextures(int start, int count, Texture **textures) override;
+	void BindTextures(int start, int count, Texture **textures, TextureBindFlags flags) override;
 	void BindNativeTexture(int sampler, void *nativeTexture) override;
 
 	void BindPipeline(Pipeline *pipeline) override;
@@ -1127,7 +1127,7 @@ Pipeline *OpenGLContext::CreateGraphicsPipeline(const PipelineDesc &desc, const 
 	}
 }
 
-void OpenGLContext::BindTextures(int start, int count, Texture **textures) {
+void OpenGLContext::BindTextures(int start, int count, Texture **textures, TextureBindFlags flags) {
 	_assert_(start + count <= MAX_TEXTURE_SLOTS);
 	for (int i = start; i < start + count; i++) {
 		OpenGLTexture *glTex = static_cast<OpenGLTexture *>(textures[i - start]);

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -354,7 +354,7 @@ public:
 	bool CopyFramebufferToMemorySync(Framebuffer *src, int channelBits, int x, int y, int w, int h, Draw::DataFormat format, void *pixels, int pixelStride, const char *tag) override;
 
 	// These functions should be self explanatory.
-	void BindFramebufferAsRenderTarget(Framebuffer *fbo, int layer, const RenderPassInfo &rp, const char *tag) override;
+	void BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) override;
 	void BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int layer) override;
 
 	void GetFramebufferDimensions(Framebuffer *fbo, int *w, int *h) override;
@@ -1395,9 +1395,7 @@ Framebuffer *OpenGLContext::CreateFramebuffer(const FramebufferDesc &desc) {
 	return fbo;
 }
 
-void OpenGLContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, int layer, const RenderPassInfo &rp, const char *tag) {
-	_dbg_assert_(layer == ALL_LAYERS || layer == 0);
-
+void OpenGLContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) {
 	OpenGLFramebuffer *fb = (OpenGLFramebuffer *)fbo;
 	GLRRenderPassAction color = (GLRRenderPassAction)rp.color;
 	GLRRenderPassAction depth = (GLRRenderPassAction)rp.depth;

--- a/Common/GPU/Shader.h
+++ b/Common/GPU/Shader.h
@@ -4,9 +4,12 @@
 #include <cstdint>
 #include <cstddef>  // for size_t
 
+#include "Common/Common.h"
+
 // GLSL_1xx and GLSL_3xx each cover a lot of sub variants. All the little quirks
 // that differ are covered in ShaderLanguageDesc.
 // Defined as a bitmask so stuff like GetSupportedShaderLanguages can return combinations.
+// TODO: We can probably move away from this distinction soon, now that we mostly generate/translate shaders.
 enum ShaderLanguage {
 	GLSL_1xx = 1,
 	GLSL_3xx = 2,
@@ -29,7 +32,6 @@ enum class ShaderStage {
 };
 
 const char *ShaderStageAsString(ShaderStage lang);
-
 
 struct ShaderLanguageDesc {
 	ShaderLanguageDesc() {}
@@ -91,13 +93,17 @@ struct UniformDef {
 	int index;
 };
 
+enum class SamplerFlags {
+	ARRAY_ON_VULKAN = 1,
+};
+ENUM_CLASS_BITOPS(SamplerFlags);
+
 struct SamplerDef {
 	int binding;  // Might only be used by some backends.
 	const char *name;
-	bool array;
+	SamplerFlags flags;
 	// TODO: Might need unsigned samplers, 3d samplers, or other types in the future.
 };
-
 
 // For passing error messages from shader compilation (and other critical issues) back to the host.
 // This can run on any thread - be aware!

--- a/Common/GPU/Shader.h
+++ b/Common/GPU/Shader.h
@@ -94,6 +94,7 @@ struct UniformDef {
 struct SamplerDef {
 	int binding;  // Might only be used by some backends.
 	const char *name;
+	bool array;
 	// TODO: Might need unsigned samplers, 3d samplers, or other types in the future.
 };
 

--- a/Common/GPU/ShaderWriter.cpp
+++ b/Common/GPU/ShaderWriter.cpp
@@ -114,6 +114,9 @@ void ShaderWriter::Preamble(Slice<const char *> extensions) {
 	switch (lang_.shaderLanguage) {
 	case GLSL_VULKAN:
 		C("#version 450\n");
+		if (flags_ & ShaderWriterFlags::FS_AUTO_STEREO) {
+			C("#extension GL_EXT_multiview : enable\n");
+		}
 		// IMPORTANT! Extensions must be the first thing after #version.
 		for (size_t i = 0; i < extensions.size(); i++) {
 			F("%s\n", extensions[i]);
@@ -462,6 +465,15 @@ void ShaderWriter::DeclareSamplers(Slice<SamplerDef> samplers) {
 	samplerDefs_ = samplers;
 }
 
+const SamplerDef *ShaderWriter::GetSamplerDef(const char *name) const {
+	for (int i = 0; i < (int)samplers_.size(); i++) {
+		if (!strcmp(samplers_[i].name, name)) {
+			return &samplers_[i];
+		}
+	}
+	return nullptr;
+}
+
 void ShaderWriter::DeclareTexture2D(const SamplerDef &def) {
 	switch (lang_.shaderLanguage) {
 	case HLSL_D3D11:
@@ -472,7 +484,11 @@ void ShaderWriter::DeclareTexture2D(const SamplerDef &def) {
 		break;
 	case GLSL_VULKAN:
 		// In the thin3d descriptor set layout, textures start at 1 in set 0. Hence the +1.
-		F("layout(set = 0, binding = %d) uniform sampler2D %s;\n", def.binding + texBindingBase_, def.name);
+		if ((flags_ & ShaderWriterFlags::FS_AUTO_STEREO) && def.array) {
+			F("layout(set = 0, binding = %d) uniform sampler2DArray %s;\n", def.binding + texBindingBase_, def.name);
+		} else {
+			F("layout(set = 0, binding = %d) uniform sampler2D %s;\n", def.binding + texBindingBase_, def.name);
+		}
 		break;
 	default:
 		F("uniform sampler2D %s;\n", def.name);
@@ -492,6 +508,7 @@ void ShaderWriter::DeclareSampler2D(const SamplerDef &def) {
 }
 
 ShaderWriter &ShaderWriter::SampleTexture2D(const char *sampName, const char *uv) {
+	const SamplerDef *samp = GetSamplerDef(sampName);
 	switch (lang_.shaderLanguage) {
 	case HLSL_D3D11:
 		F("%s.Sample(%sSamp, %s)", sampName, sampName, uv);
@@ -501,13 +518,20 @@ ShaderWriter &ShaderWriter::SampleTexture2D(const char *sampName, const char *uv
 		break;
 	default:
 		// Note: we ignore the sampler. make sure you bound samplers to the textures correctly.
-		F("%s(%s, %s)", lang_.texture, sampName, uv);
+		if (samp && samp->array) {
+			const char *index = (flags_ & ShaderWriterFlags::FS_AUTO_STEREO) ? "float(gl_ViewIndex)" : "0.0";
+			F("%s(%s, vec3(%s, %s))", lang_.texture, sampName, uv, index);
+		} else {
+			F("%s(%s, %s)", lang_.texture, sampName, uv);
+		}
 		break;
 	}
 	return *this;
 }
 
 ShaderWriter &ShaderWriter::SampleTexture2DOffset(const char *sampName, const char *uv, int offX, int offY) {
+	const SamplerDef *samp = GetSamplerDef(sampName);
+
 	switch (lang_.shaderLanguage) {
 	case HLSL_D3D11:
 		F("%s.Sample(%sSamp, %s, int2(%d, %d))", sampName, sampName, uv, offX, offY);
@@ -518,13 +542,20 @@ ShaderWriter &ShaderWriter::SampleTexture2DOffset(const char *sampName, const ch
 		break;
 	default:
 		// Note: we ignore the sampler. make sure you bound samplers to the textures correctly.
-		F("%sOffset(%s, %s, ivec2(%d, %d))", lang_.texture, sampName, uv, offX, offY);
+		if (samp->array) {
+			const char *index = (flags_ & ShaderWriterFlags::FS_AUTO_STEREO) ? "float(gl_ViewIndex)" : "0.0";
+			F("%sOffset(%s, vec3(%s, %s), ivec3(%d, %d))", lang_.texture, sampName, uv, index, offX, offY);
+		} else {
+			F("%sOffset(%s, %s, ivec2(%d, %d))", lang_.texture, sampName, uv, offX, offY);
+		}
 		break;
 	}
 	return *this;
 }
 
 ShaderWriter &ShaderWriter::LoadTexture2D(const char *sampName, const char *uv, int level) {
+	const SamplerDef *samp = GetSamplerDef(sampName);
+
 	switch (lang_.shaderLanguage) {
 	case HLSL_D3D11:
 		F("%s.Load(ivec3(%s, %d))", sampName, uv, level);
@@ -535,7 +566,11 @@ ShaderWriter &ShaderWriter::LoadTexture2D(const char *sampName, const char *uv, 
 		break;
 	default:
 		// Note: we ignore the sampler. make sure you bound samplers to the textures correctly.
-		F("texelFetch(%s, %s, %d)", sampName, uv, level);
+		if ((flags_ & ShaderWriterFlags::FS_AUTO_STEREO) && samp->array) {
+			F("texelFetch(%s, %s, %d)", sampName, uv, level);
+		} else {
+			F("texelFetch(%s, %s, %d)", sampName, uv, level);
+		}
 		break;
 	}
 	return *this;

--- a/Common/GPU/ShaderWriter.cpp
+++ b/Common/GPU/ShaderWriter.cpp
@@ -478,7 +478,7 @@ void ShaderWriter::DeclareTexture2D(const SamplerDef &def) {
 		F("sampler %s: register(s%d);\n", def.name, def.binding);
 		break;
 	case GLSL_VULKAN:
-		// In the thin3d descriptor set layout, textures start at 1 in set 0. Hence the +1.
+		// texBindingBase_ is used for the thin3d descriptor set layout, where they start at 1.
 		if (def.flags & SamplerFlags::ARRAY_ON_VULKAN) {
 			F("layout(set = 0, binding = %d) uniform sampler2DArray %s;\n", def.binding + texBindingBase_, def.name);
 		} else {

--- a/Common/GPU/ShaderWriter.cpp
+++ b/Common/GPU/ShaderWriter.cpp
@@ -513,7 +513,7 @@ ShaderWriter &ShaderWriter::SampleTexture2D(const char *sampName, const char *uv
 		break;
 	default:
 		// Note: we ignore the sampler. make sure you bound samplers to the textures correctly.
-		if (samp && (samp->flags & SamplerFlags::ARRAY_ON_VULKAN)) {
+		if (samp && (samp->flags & SamplerFlags::ARRAY_ON_VULKAN) && lang_.shaderLanguage == GLSL_VULKAN) {
 			const char *index = (flags_ & ShaderWriterFlags::FS_AUTO_STEREO) ? "float(gl_ViewIndex)" : "0.0";
 			F("%s(%s, vec3(%s, %s))", lang_.texture, sampName, uv, index);
 		} else {
@@ -537,7 +537,7 @@ ShaderWriter &ShaderWriter::SampleTexture2DOffset(const char *sampName, const ch
 		break;
 	default:
 		// Note: we ignore the sampler. make sure you bound samplers to the textures correctly.
-		if (samp && (samp->flags & SamplerFlags::ARRAY_ON_VULKAN)) {
+		if (samp && (samp->flags & SamplerFlags::ARRAY_ON_VULKAN) && lang_.shaderLanguage == GLSL_VULKAN) {
 			const char *index = (flags_ & ShaderWriterFlags::FS_AUTO_STEREO) ? "float(gl_ViewIndex)" : "0.0";
 			F("%sOffset(%s, vec3(%s, %s), ivec2(%d, %d))", lang_.texture, sampName, uv, index, offX, offY);
 		} else {
@@ -561,7 +561,7 @@ ShaderWriter &ShaderWriter::LoadTexture2D(const char *sampName, const char *uv, 
 		break;
 	default:
 		// Note: we ignore the sampler. make sure you bound samplers to the textures correctly.
-		if (samp && (samp->flags & SamplerFlags::ARRAY_ON_VULKAN)) {
+		if (samp && (samp->flags & SamplerFlags::ARRAY_ON_VULKAN) && lang_.shaderLanguage == GLSL_VULKAN) {
 			const char *index = (flags_ & ShaderWriterFlags::FS_AUTO_STEREO) ? "gl_ViewIndex" : "0";
 			F("texelFetch(%s, vec3(%s, %s), %d)", sampName, uv, index, level);
 		} else {

--- a/Common/GPU/ShaderWriter.cpp
+++ b/Common/GPU/ShaderWriter.cpp
@@ -465,6 +465,10 @@ void ShaderWriter::DeclareSamplers(Slice<SamplerDef> samplers) {
 	samplerDefs_ = samplers;
 }
 
+void ShaderWriter::ApplySamplerMetadata(Slice<SamplerDef> samplers) {
+	samplerDefs_ = samplers;
+}
+
 void ShaderWriter::DeclareTexture2D(const SamplerDef &def) {
 	switch (lang_.shaderLanguage) {
 	case HLSL_D3D11:
@@ -535,7 +539,7 @@ ShaderWriter &ShaderWriter::SampleTexture2DOffset(const char *sampName, const ch
 		// Note: we ignore the sampler. make sure you bound samplers to the textures correctly.
 		if (samp && (samp->flags & SamplerFlags::ARRAY_ON_VULKAN)) {
 			const char *index = (flags_ & ShaderWriterFlags::FS_AUTO_STEREO) ? "float(gl_ViewIndex)" : "0.0";
-			F("%sOffset(%s, vec3(%s, %s), ivec3(%d, %d))", lang_.texture, sampName, uv, index, offX, offY);
+			F("%sOffset(%s, vec3(%s, %s), ivec2(%d, %d))", lang_.texture, sampName, uv, index, offX, offY);
 		} else {
 			F("%sOffset(%s, %s, ivec2(%d, %d))", lang_.texture, sampName, uv, offX, offY);
 		}

--- a/Common/GPU/ShaderWriter.h
+++ b/Common/GPU/ShaderWriter.h
@@ -33,7 +33,7 @@ struct VaryingDef {
 enum class ShaderWriterFlags {
 	NONE = 0,
 	FS_WRITE_DEPTH = 1,
-	FS_AUTO_STEREO = 2,
+	FS_AUTO_STEREO = 2,  // Automatically makes sampler 0 an array sampler, and samples it by gl_ViewIndex. Useful for stereo rendering.
 };
 ENUM_CLASS_BITOPS(ShaderWriterFlags);
 
@@ -119,9 +119,12 @@ private:
 
 	void Preamble(Slice<const char *> extensions);
 
+	const SamplerDef *GetSamplerDef(const char *name) const;
+
 	char *p_;
 	const ShaderLanguageDesc &lang_;
 	const ShaderStage stage_;
+	Slice<SamplerDef> samplers_;
 	ShaderWriterFlags flags_ = ShaderWriterFlags::NONE;
 	Slice<SamplerDef> samplerDefs_;
 	int texBindingBase_ = 1;

--- a/Common/GPU/ShaderWriter.h
+++ b/Common/GPU/ShaderWriter.h
@@ -40,7 +40,7 @@ ENUM_CLASS_BITOPS(ShaderWriterFlags);
 class ShaderWriter {
 public:
 	// Extensions are supported for both OpenGL ES and Vulkan (though of course, they're different).
-	ShaderWriter(char *buffer, const ShaderLanguageDesc &lang, ShaderStage stage, Slice<const char *> extensions = Slice<const char *>(), ShaderWriterFlags flags = ShaderWriterFlags::NONE) : p_(buffer), lang_(lang), stage_(stage) {
+	ShaderWriter(char *buffer, const ShaderLanguageDesc &lang, ShaderStage stage, Slice<const char *> extensions = Slice<const char *>(), ShaderWriterFlags flags = ShaderWriterFlags::NONE) : p_(buffer), lang_(lang), stage_(stage), flags_(flags) {
 		Preamble(extensions);
 	}
 	ShaderWriter(const ShaderWriter &) = delete;
@@ -78,6 +78,10 @@ public:
 
 	// NOTE: samplers must live for the rest of ShaderWriter's lifetime. No way to express that in C++ though :(
 	void DeclareSamplers(Slice<SamplerDef> samplers);
+
+	// Same as DeclareSamplers, but doesn't actually declare them.
+	// This is currently only required by FragmentShaderGenerator.
+	void ApplySamplerMetadata(Slice<SamplerDef> samplers);
 
 	void ConstFloat(const char *name, float value);
 	void SetFlags(ShaderWriterFlags flags) { flags_ |= flags; }

--- a/Common/GPU/ShaderWriter.h
+++ b/Common/GPU/ShaderWriter.h
@@ -41,6 +41,7 @@ class ShaderWriter {
 public:
 	// Extensions are supported for both OpenGL ES and Vulkan (though of course, they're different).
 	ShaderWriter(char *buffer, const ShaderLanguageDesc &lang, ShaderStage stage, Slice<const char *> extensions = Slice<const char *>(), ShaderWriterFlags flags = ShaderWriterFlags::NONE) : p_(buffer), lang_(lang), stage_(stage), flags_(flags) {
+		buffer[0] = '\0';
 		Preamble(extensions);
 	}
 	ShaderWriter(const ShaderWriter &) = delete;

--- a/Common/GPU/ShaderWriter.h
+++ b/Common/GPU/ShaderWriter.h
@@ -33,7 +33,7 @@ struct VaryingDef {
 enum class ShaderWriterFlags {
 	NONE = 0,
 	FS_WRITE_DEPTH = 1,
-	FS_AUTO_STEREO = 2,  // Automatically makes sampler 0 an array sampler, and samples it by gl_ViewIndex. Useful for stereo rendering.
+	FS_AUTO_STEREO = 2,  // Automatically indexes makes samplers tagged with `array` by gl_ViewIndex. Useful for stereo rendering.
 };
 ENUM_CLASS_BITOPS(ShaderWriterFlags);
 
@@ -118,8 +118,6 @@ private:
 	const SamplerDef *GetSamplerDef(const char *name) const;
 
 	void Preamble(Slice<const char *> extensions);
-
-	const SamplerDef *GetSamplerDef(const char *name) const;
 
 	char *p_;
 	const ShaderLanguageDesc &lang_;

--- a/Common/GPU/ShaderWriter.h
+++ b/Common/GPU/ShaderWriter.h
@@ -33,6 +33,7 @@ struct VaryingDef {
 enum class ShaderWriterFlags {
 	NONE = 0,
 	FS_WRITE_DEPTH = 1,
+	FS_AUTO_STEREO = 2,
 };
 ENUM_CLASS_BITOPS(ShaderWriterFlags);
 

--- a/Common/GPU/Vulkan/VulkanBarrier.h
+++ b/Common/GPU/Vulkan/VulkanBarrier.h
@@ -14,7 +14,7 @@ class VulkanContext;
 class VulkanBarrier {
 public:
 	void TransitionImage(
-		VkImage image, int baseMip, int numMipLevels, VkImageAspectFlags aspectMask,
+		VkImage image, int baseMip, int numMipLevels, int numLayers, VkImageAspectFlags aspectMask,
 		VkImageLayout oldImageLayout, VkImageLayout newImageLayout,
 		VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask,
 		VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask
@@ -36,7 +36,7 @@ public:
 		imageBarrier.subresourceRange.aspectMask = aspectMask;
 		imageBarrier.subresourceRange.baseMipLevel = baseMip;
 		imageBarrier.subresourceRange.levelCount = numMipLevels;
-		imageBarrier.subresourceRange.layerCount = 1;  // We never use more than one layer, and old Mali drivers have problems with VK_REMAINING_ARRAY_LAYERS/VK_REMAINING_MIP_LEVELS.
+		imageBarrier.subresourceRange.layerCount = numLayers;  // NOTE: We could usually use VK_REMAINING_ARRAY_LAYERS/VK_REMAINING_MIP_LEVELS, but really old Mali drivers have problems with those.
 		imageBarrier.subresourceRange.baseArrayLayer = 0;
 		imageBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 		imageBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
@@ -46,7 +46,7 @@ public:
 	// Automatically determines access and stage masks from layouts.
 	// Not universally usable, but works for PPSSPP's use.
 	void TransitionImageAuto(
-		VkImage image, int baseMip, int numMipLevels, VkImageAspectFlags aspectMask, VkImageLayout oldImageLayout, VkImageLayout newImageLayout
+		VkImage image, int baseMip, int numMipLevels, int numLayers, VkImageAspectFlags aspectMask, VkImageLayout oldImageLayout, VkImageLayout newImageLayout
 	) {
 		_dbg_assert_(image != VK_NULL_HANDLE);
 
@@ -104,7 +104,7 @@ public:
 		imageBarrier.subresourceRange.aspectMask = aspectMask;
 		imageBarrier.subresourceRange.baseMipLevel = baseMip;
 		imageBarrier.subresourceRange.levelCount = numMipLevels;
-		imageBarrier.subresourceRange.layerCount = 1;  // We never use more than one layer, and old Mali drivers have problems with VK_REMAINING_ARRAY_LAYERS/VK_REMAINING_MIP_LEVELS.
+		imageBarrier.subresourceRange.layerCount = numLayers;  // NOTE: We could usually use VK_REMAINING_ARRAY_LAYERS/VK_REMAINING_MIP_LEVELS, but really old Mali drivers have problems with those.
 		imageBarrier.subresourceRange.baseArrayLayer = 0;
 		imageBarrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 		imageBarrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;

--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -608,8 +608,7 @@ void VulkanContext::ChooseDevice(int physical_device) {
 	deviceFeatures_.enabled.standard.geometryShader = deviceFeatures_.available.standard.geometryShader;
 
 	deviceFeatures_.enabled.multiview = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES };
-	// Don't yet enable these.
-	// deviceFeatures_.enabled.multiview.multiview = deviceFeatures_.available.multiview.multiview;
+	deviceFeatures_.enabled.multiview.multiview = deviceFeatures_.available.multiview.multiview;
 	// deviceFeatures_.enabled.multiview.multiviewGeometryShader = deviceFeatures_.available.multiview.multiviewGeometryShader;
 
 	GetDeviceLayerExtensionList(nullptr, device_extension_properties_);
@@ -1246,7 +1245,7 @@ bool VulkanContext::CreateShaderModule(const std::vector<uint32_t> &spirv, VkSha
 	}
 }
 
-void TransitionImageLayout2(VkCommandBuffer cmd, VkImage image, int baseMip, int numMipLevels, VkImageAspectFlags aspectMask,
+void TransitionImageLayout2(VkCommandBuffer cmd, VkImage image, int baseMip, int numMipLevels, int numLayers, VkImageAspectFlags aspectMask,
 	VkImageLayout oldImageLayout, VkImageLayout newImageLayout,
 	VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
 	VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask) {
@@ -1259,7 +1258,7 @@ void TransitionImageLayout2(VkCommandBuffer cmd, VkImage image, int baseMip, int
 	image_memory_barrier.subresourceRange.aspectMask = aspectMask;
 	image_memory_barrier.subresourceRange.baseMipLevel = baseMip;
 	image_memory_barrier.subresourceRange.levelCount = numMipLevels;
-	image_memory_barrier.subresourceRange.layerCount = 1;  // We never use more than one layer, and old Mali drivers have problems with VK_REMAINING_ARRAY_LAYERS/VK_REMAINING_MIP_LEVELS.
+	image_memory_barrier.subresourceRange.layerCount = numLayers;  // We never use more than one layer, and old Mali drivers have problems with VK_REMAINING_ARRAY_LAYERS/VK_REMAINING_MIP_LEVELS.
 	image_memory_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 	image_memory_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 	vkCmdPipelineBarrier(cmd, srcStageMask, dstStageMask, 0, 0, nullptr, 0, nullptr, 1, &image_memory_barrier);

--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -222,6 +222,9 @@ public:
 			SetDebugNameImpl((uint64_t)handle, type, name);
 		}
 	}
+	bool DebugLayerEnabled() const {
+		return extensionsLookup_.EXT_debug_utils;
+	}
 
 	bool MemoryTypeFromProperties(uint32_t typeBits, VkFlags requirements_mask, uint32_t *typeIndex);
 

--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -441,7 +441,7 @@ private:
 };
 
 // Detailed control.
-void TransitionImageLayout2(VkCommandBuffer cmd, VkImage image, int baseMip, int mipLevels, VkImageAspectFlags aspectMask,
+void TransitionImageLayout2(VkCommandBuffer cmd, VkImage image, int baseMip, int mipLevels, int numLayers, VkImageAspectFlags aspectMask,
 	VkImageLayout oldImageLayout, VkImageLayout newImageLayout,
 	VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
 	VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask);

--- a/Common/GPU/Vulkan/VulkanImage.cpp
+++ b/Common/GPU/Vulkan/VulkanImage.cpp
@@ -123,6 +123,13 @@ bool VulkanTexture::CreateDirect(VkCommandBuffer cmd, int w, int h, int depth, i
 		_assert_(res == VK_ERROR_OUT_OF_HOST_MEMORY || res == VK_ERROR_OUT_OF_DEVICE_MEMORY || res == VK_ERROR_TOO_MANY_OBJECTS);
 		return false;
 	}
+
+	// Additionally, create an array view, but only if it's a 2D texture.
+	if (view_info.viewType == VK_IMAGE_VIEW_TYPE_2D) {
+		view_info.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+		res = vkCreateImageView(vulkan_->GetDevice(), &view_info, NULL, &arrayView_);
+		_assert_(res == VK_SUCCESS);
+	}
 	return true;
 }
 
@@ -244,6 +251,9 @@ VkImageView VulkanTexture::CreateViewForMip(int mip) {
 void VulkanTexture::Destroy() {
 	if (view_ != VK_NULL_HANDLE) {
 		vulkan_->Delete().QueueDeleteImageView(view_);
+	}
+	if (arrayView_ != VK_NULL_HANDLE) {
+		vulkan_->Delete().QueueDeleteImageView(arrayView_);
 	}
 	if (image_ != VK_NULL_HANDLE) {
 		_dbg_assert_(allocation_ != VK_NULL_HANDLE);

--- a/Common/GPU/Vulkan/VulkanImage.cpp
+++ b/Common/GPU/Vulkan/VulkanImage.cpp
@@ -87,7 +87,7 @@ bool VulkanTexture::CreateDirect(VkCommandBuffer cmd, int w, int h, int depth, i
 		switch (initialLayout) {
 		case VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL:
 		case VK_IMAGE_LAYOUT_GENERAL:
-			TransitionImageLayout2(cmd, image_, 0, numMips, VK_IMAGE_ASPECT_COLOR_BIT,
+			TransitionImageLayout2(cmd, image_, 0, numMips, 1, VK_IMAGE_ASPECT_COLOR_BIT,
 				VK_IMAGE_LAYOUT_UNDEFINED, initialLayout,
 				VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
 				0, VK_ACCESS_TRANSFER_WRITE_BIT);
@@ -164,7 +164,7 @@ void VulkanTexture::GenerateMips(VkCommandBuffer cmd, int firstMipToGenerate, bo
 	_assert_msg_(firstMipToGenerate < numMips_, "Can't generate levels beyond storage");
 
 	// Transition the pre-set levels to GENERAL.
-	TransitionImageLayout2(cmd, image_, 0, firstMipToGenerate, VK_IMAGE_ASPECT_COLOR_BIT,
+	TransitionImageLayout2(cmd, image_, 0, firstMipToGenerate, 1, VK_IMAGE_ASPECT_COLOR_BIT,
 		fromCompute ? VK_IMAGE_LAYOUT_GENERAL : VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
 		VK_IMAGE_LAYOUT_GENERAL,
 		fromCompute ? VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT : VK_PIPELINE_STAGE_TRANSFER_BIT, 
@@ -173,7 +173,7 @@ void VulkanTexture::GenerateMips(VkCommandBuffer cmd, int firstMipToGenerate, bo
 		VK_ACCESS_TRANSFER_READ_BIT);
 
 	// Do the same with the uninitialized levels.
-	TransitionImageLayout2(cmd, image_, firstMipToGenerate, numMips_ - firstMipToGenerate,
+	TransitionImageLayout2(cmd, image_, firstMipToGenerate, numMips_ - firstMipToGenerate, 1,
 		VK_IMAGE_ASPECT_COLOR_BIT,
 		VK_IMAGE_LAYOUT_UNDEFINED,
 		VK_IMAGE_LAYOUT_GENERAL,
@@ -206,7 +206,7 @@ void VulkanTexture::GenerateMips(VkCommandBuffer cmd, int firstMipToGenerate, bo
 
 		vkCmdBlitImage(cmd, image_, VK_IMAGE_LAYOUT_GENERAL, image_, VK_IMAGE_LAYOUT_GENERAL, 1, &blit, VK_FILTER_LINEAR);
 
-		TransitionImageLayout2(cmd, image_, mip, 1, VK_IMAGE_ASPECT_COLOR_BIT,
+		TransitionImageLayout2(cmd, image_, mip, 1, 1, VK_IMAGE_ASPECT_COLOR_BIT,
 			VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL,
 			VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
 			VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT);
@@ -214,7 +214,7 @@ void VulkanTexture::GenerateMips(VkCommandBuffer cmd, int firstMipToGenerate, bo
 }
 
 void VulkanTexture::EndCreate(VkCommandBuffer cmd, bool vertexTexture, VkPipelineStageFlags prevStage, VkImageLayout layout) {
-	TransitionImageLayout2(cmd, image_, 0, numMips_,
+	TransitionImageLayout2(cmd, image_, 0, numMips_, 1,
 		VK_IMAGE_ASPECT_COLOR_BIT,
 		layout, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
 		prevStage, vertexTexture ? VK_PIPELINE_STAGE_VERTEX_SHADER_BIT : VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,

--- a/Common/GPU/Vulkan/VulkanImage.cpp
+++ b/Common/GPU/Vulkan/VulkanImage.cpp
@@ -123,13 +123,16 @@ bool VulkanTexture::CreateDirect(VkCommandBuffer cmd, int w, int h, int depth, i
 		_assert_(res == VK_ERROR_OUT_OF_HOST_MEMORY || res == VK_ERROR_OUT_OF_DEVICE_MEMORY || res == VK_ERROR_TOO_MANY_OBJECTS);
 		return false;
 	}
+	vulkan_->SetDebugName(view_, VK_OBJECT_TYPE_IMAGE_VIEW, tag_.c_str());
 
 	// Additionally, create an array view, but only if it's a 2D texture.
 	if (view_info.viewType == VK_IMAGE_VIEW_TYPE_2D) {
 		view_info.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
 		res = vkCreateImageView(vulkan_->GetDevice(), &view_info, NULL, &arrayView_);
 		_assert_(res == VK_SUCCESS);
+		vulkan_->SetDebugName(arrayView_, VK_OBJECT_TYPE_IMAGE_VIEW, tag_.c_str());
 	}
+
 	return true;
 }
 
@@ -244,6 +247,7 @@ VkImageView VulkanTexture::CreateViewForMip(int mip) {
 	view_info.subresourceRange.layerCount = 1;
 	VkImageView view;
 	VkResult res = vkCreateImageView(vulkan_->GetDevice(), &view_info, NULL, &view);
+	vulkan_->SetDebugName(view, VK_OBJECT_TYPE_IMAGE_VIEW, "mipview");
 	_assert_(res == VK_SUCCESS);
 	return view;
 }

--- a/Common/GPU/Vulkan/VulkanImage.h
+++ b/Common/GPU/Vulkan/VulkanImage.h
@@ -51,6 +51,9 @@ public:
 	// Used for sampling, generally.
 	VkImageView GetImageView() const { return view_; }
 
+	// For use with some shaders, we might want to view it as a single entry array for convenience.
+	VkImageView GetImageArrayView() const { return arrayView_; }
+
 	int32_t GetWidth() const { return width_; }
 	int32_t GetHeight() const { return height_; }
 	int32_t GetNumMips() const { return numMips_; }
@@ -62,6 +65,7 @@ private:
 	VulkanContext *vulkan_;
 	VkImage image_ = VK_NULL_HANDLE;
 	VkImageView view_ = VK_NULL_HANDLE;
+	VkImageView arrayView_ = VK_NULL_HANDLE;
 	VmaAllocation allocation_ = VK_NULL_HANDLE;
 
 	int16_t width_ = 0;

--- a/Common/GPU/Vulkan/VulkanMemory.cpp
+++ b/Common/GPU/Vulkan/VulkanMemory.cpp
@@ -153,7 +153,7 @@ void VulkanDescSetPool::Create(VulkanContext *vulkan, const VkDescriptorPoolCrea
 	_assert_msg_(res == VK_SUCCESS, "Could not create VulkanDescSetPool %s", tag_);
 }
 
-VkDescriptorSet VulkanDescSetPool::Allocate(int n, const VkDescriptorSetLayout *layouts) {
+VkDescriptorSet VulkanDescSetPool::Allocate(int n, const VkDescriptorSetLayout *layouts, const char *tag) {
 	if (descPool_ == VK_NULL_HANDLE || usage_ + n >= info_.maxSets) {
 		// Missing or out of space, need to recreate.
 		VkResult res = Recreate(grow_);
@@ -180,9 +180,12 @@ VkDescriptorSet VulkanDescSetPool::Allocate(int n, const VkDescriptorSetLayout *
 		_assert_msg_(result == VK_SUCCESS, "Ran out of descriptor space (frag?) and failed to allocate after recreating a descriptor pool. res=%d", (int)result);
 	}
 
-	if (result == VK_SUCCESS)
-		return desc;
-	return VK_NULL_HANDLE;
+	if (result != VK_SUCCESS) {
+		return VK_NULL_HANDLE;
+	}
+
+	vulkan_->SetDebugName(desc, VK_OBJECT_TYPE_DESCRIPTOR_SET, tag);
+	return desc;
 }
 
 void VulkanDescSetPool::Reset() {

--- a/Common/GPU/Vulkan/VulkanMemory.h
+++ b/Common/GPU/Vulkan/VulkanMemory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <vector>
 
@@ -119,6 +120,15 @@ public:
 		size_t off = Allocate(size, vkbuf);
 		*bindOffset = (uint32_t)off;
 		return writePtr_ + off;
+	}
+
+	template<class T>
+	void PushUBOData(const T &data, VkDescriptorBufferInfo *info) {
+		uint32_t bindOffset;
+		void *ptr = PushAligned(sizeof(T), &bindOffset, &info->buffer, vulkan_->GetPhysicalDeviceProperties().properties.limits.minUniformBufferOffsetAlignment);
+		memcpy(ptr, &data, sizeof(T));
+		info->offset = bindOffset;
+		info->range = sizeof(T);
 	}
 
 	size_t GetTotalSize() const;

--- a/Common/GPU/Vulkan/VulkanMemory.h
+++ b/Common/GPU/Vulkan/VulkanMemory.h
@@ -163,7 +163,7 @@ public:
 	void Create(VulkanContext *vulkan, const VkDescriptorPoolCreateInfo &info, const std::vector<VkDescriptorPoolSize> &sizes);
 	// Allocate a new set, which may resize and empty the current sets.
 	// Use only for the current frame, unless in a cache cleared by clear_.
-	VkDescriptorSet Allocate(int n, const VkDescriptorSetLayout *layouts);
+	VkDescriptorSet Allocate(int n, const VkDescriptorSetLayout *layouts, const char *tag);
 	void Reset();
 	void Destroy();
 

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -1629,6 +1629,7 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 
 		default:
 			ERROR_LOG(G3D, "Unimpl queue command");
+			break;
 		}
 	}
 	vkCmdEndRenderPass(cmd);

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -1444,7 +1444,8 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 
 	const RenderPassType rpType = step.render.renderPassType;
 
-	for (const auto &c : commands) {
+	for (size_t i = 0; i < commands.size(); i++) {
+		const VkRenderData &c = commands[i];
 		switch (c.cmd) {
 		case VKRRenderCommand::REMOVED:
 			break;

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -1583,17 +1583,13 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 			vkCmdDraw(cmd, c.draw.count, 1, c.draw.offset, 0);
 			break;
 
-		case VKRRenderCommand::BIND_DESCRIPTOR_SET:
-			vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, c.bindDescSet.setIndex, 1, &c.bindDescSet.descSet, 0, nullptr);
-			break;
-
 		case VKRRenderCommand::CLEAR:
 		{
 			// If we get here, we failed to merge a clear into a render pass load op. This is bad for perf.
 			int numAttachments = 0;
 			VkClearRect rc{};
 			rc.baseArrayLayer = 0;
-			rc.layerCount = c.clear.numLayers;
+			rc.layerCount = 1;  // In multiview mode, 1 means to replicate to all the active layers.
 			rc.rect.extent.width = (uint32_t)curWidth;
 			rc.rect.extent.height = (uint32_t)curHeight;
 			VkClearAttachment attachments[2]{};

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -178,6 +178,7 @@ bool VulkanQueueRunner::CreateSwapchain(VkCommandBuffer cmdInit) {
 		// Also, turns out it's illegal to transition un-acquired images, thanks Hans-Kristian. See #11417.
 
 		res = vkCreateImageView(vulkan_->GetDevice(), &color_image_view, nullptr, &sc_buffer.view);
+		vulkan_->SetDebugName(sc_buffer.view, VK_OBJECT_TYPE_IMAGE_VIEW, "swapchain_view");
 		swapchainImages_.push_back(sc_buffer);
 		_dbg_assert_(res == VK_SUCCESS);
 	}
@@ -276,6 +277,7 @@ bool VulkanQueueRunner::InitDepthStencilBuffer(VkCommandBuffer cmd) {
 	VkDevice device = vulkan_->GetDevice();
 
 	res = vkCreateImageView(device, &depth_view_info, NULL, &depth_.view);
+	vulkan_->SetDebugName(depth_.view, VK_OBJECT_TYPE_IMAGE_VIEW, "depth_stencil_backbuffer");
 	_dbg_assert_(res == VK_SUCCESS);
 	if (res != VK_SUCCESS)
 		return false;

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -37,7 +37,6 @@ enum class VKRRenderCommand : uint8_t {
 	DRAW,
 	DRAW_INDEXED,
 	PUSH_CONSTANTS,
-	BIND_DESCRIPTOR_SET,
 	SELF_DEPENDENCY_BARRIER,
 	DEBUG_ANNOTATION,
 	NUM_RENDER_COMMANDS,
@@ -129,7 +128,6 @@ struct VkRenderData {
 			float clearZ;
 			int clearStencil;
 			int clearMask;   // VK_IMAGE_ASPECT_COLOR_BIT etc
-			int numLayers;
 		} clear;
 		struct {
 			VkViewport vp;
@@ -154,10 +152,6 @@ struct VkRenderData {
 		struct {
 			const char *annotation;
 		} debugAnnotation;
-		struct {
-			uint32_t setIndex;
-			VkDescriptorSet descSet;
-		} bindDescSet;
 	};
 };
 

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -48,17 +48,23 @@ enum class PipelineFlags {
 	USES_DEPTH_STENCIL = (1 << 2),  // Reads or writes the depth or stencil buffers.
 	USES_INPUT_ATTACHMENT = (1 << 3),
 	USES_GEOMETRY_SHADER = (1 << 4),
+	USES_MULTIVIEW = (1 << 5),  // Inherited from the render pass it was created with.
 };
 ENUM_CLASS_BITOPS(PipelineFlags);
 
 // Pipelines need to be created for the right type of render pass.
 enum RenderPassType {
-	// These four are organized so that bit 0 is DEPTH and bit 1 is INPUT, so
+	// These eight are organized so that bit 0 is DEPTH and bit 1 is INPUT and bit 2 is MULTIVIEW, so
 	// they can be OR-ed together in MergeRPTypes.
 	RP_TYPE_COLOR,
 	RP_TYPE_COLOR_DEPTH,
 	RP_TYPE_COLOR_INPUT,
 	RP_TYPE_COLOR_DEPTH_INPUT,
+
+	RP_TYPE_MULTIVIEW_COLOR,
+	RP_TYPE_MULTIVIEW_COLOR_DEPTH,
+	RP_TYPE_MULTIVIEW_COLOR_INPUT,
+	RP_TYPE_MULTIVIEW_COLOR_DEPTH_INPUT,
 
 	// This is the odd one out, and gets special handling in MergeRPTypes.
 	RP_TYPE_BACKBUFFER,  // For the backbuffer we can always use CLEAR/DONT_CARE, so bandwidth cost for a depth channel is negligible.
@@ -67,12 +73,18 @@ enum RenderPassType {
 	RP_TYPE_COUNT,
 };
 
+// Hm, soon time to exploit the bit properties in these..
+
 inline bool RenderPassTypeHasDepth(RenderPassType type) {
-	return type == RP_TYPE_BACKBUFFER || type == RP_TYPE_COLOR_DEPTH || type == RP_TYPE_COLOR_DEPTH_INPUT;
+	return type == RP_TYPE_BACKBUFFER || type == RP_TYPE_COLOR_DEPTH || type == RP_TYPE_COLOR_DEPTH_INPUT || type == RP_TYPE_MULTIVIEW_COLOR_DEPTH || type == RP_TYPE_MULTIVIEW_COLOR_DEPTH_INPUT;
 }
 
 inline bool RenderPassTypeHasInput(RenderPassType type) {
-	return type == RP_TYPE_COLOR_INPUT || type == RP_TYPE_COLOR_DEPTH_INPUT;
+	return type == RP_TYPE_COLOR_INPUT || type == RP_TYPE_COLOR_DEPTH_INPUT || type == RP_TYPE_MULTIVIEW_COLOR_INPUT || type == RP_TYPE_MULTIVIEW_COLOR_DEPTH_INPUT;
+}
+
+inline bool RenderPassTypeHasMultiView(RenderPassType type) {
+	return type == RP_TYPE_MULTIVIEW_COLOR || type == RP_TYPE_MULTIVIEW_COLOR_DEPTH || type == RP_TYPE_MULTIVIEW_COLOR_INPUT || type == RP_TYPE_MULTIVIEW_COLOR_DEPTH_INPUT;
 }
 
 struct VkRenderData {

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -129,6 +129,7 @@ struct VkRenderData {
 			float clearZ;
 			int clearStencil;
 			int clearMask;   // VK_IMAGE_ASPECT_COLOR_BIT etc
+			int numLayers;
 		} clear;
 		struct {
 			VkViewport vp;
@@ -212,7 +213,6 @@ struct VKRStep {
 			VKRRenderPassStoreAction depthStore;
 			VKRRenderPassStoreAction stencilStore;
 			u8 clearStencil;
-			s8 layer;
 			uint32_t clearColor;
 			float clearDepth;
 			int numDraws;

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -37,12 +37,13 @@ enum class VKRRenderCommand : uint8_t {
 	DRAW,
 	DRAW_INDEXED,
 	PUSH_CONSTANTS,
+	BIND_DESCRIPTOR_SET,
 	SELF_DEPENDENCY_BARRIER,
 	DEBUG_ANNOTATION,
 	NUM_RENDER_COMMANDS,
 };
 
-enum class PipelineFlags {
+enum class PipelineFlags : u8 {
 	NONE = 0,
 	USES_BLEND_CONSTANT = (1 << 1),
 	USES_DEPTH_STENCIL = (1 << 2),  // Reads or writes the depth or stencil buffers.
@@ -115,7 +116,7 @@ struct VkRenderData {
 			VkDescriptorSet ds;
 			int numUboOffsets;
 			uint32_t uboOffsets[3];
-			VkBuffer vbuffer;  // might need to increase at some point
+			VkBuffer vbuffer;
 			VkBuffer ibuffer;
 			uint32_t voffset;
 			uint32_t ioffset;
@@ -152,6 +153,10 @@ struct VkRenderData {
 		struct {
 			const char *annotation;
 		} debugAnnotation;
+		struct {
+			uint32_t setIndex;
+			VkDescriptorSet descSet;
+		} bindDescSet;
 	};
 };
 
@@ -207,6 +212,7 @@ struct VKRStep {
 			VKRRenderPassStoreAction depthStore;
 			VKRRenderPassStoreAction stencilStore;
 			u8 clearStencil;
+			s8 layer;
 			uint32_t clearColor;
 			float clearDepth;
 			int numDraws;

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -296,6 +296,7 @@ void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int 
 	ivci.subresourceRange.layerCount = numLayers;
 	ivci.subresourceRange.levelCount = 1;
 	res = vkCreateImageView(vulkan->GetDevice(), &ivci, nullptr, &img.rtView);
+	vulkan->SetDebugName(img.rtView, VK_OBJECT_TYPE_IMAGE_VIEW, tag);
 
 	_dbg_assert_(res == VK_SUCCESS);
 
@@ -306,6 +307,7 @@ void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int 
 
 	ivci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;  // layered for consistency, even if single image.
 	res = vkCreateImageView(vulkan->GetDevice(), &ivci, nullptr, &img.texAllLayersView);
+	vulkan->SetDebugName(img.texAllLayersView, VK_OBJECT_TYPE_IMAGE_VIEW, tag);
 
 	// Create 2D views for both layers.
 	// Useful when multipassing shaders that don't yet exist in a single-pass-stereo version.
@@ -314,6 +316,11 @@ void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int 
 		ivci.subresourceRange.layerCount = 1;
 		ivci.subresourceRange.baseArrayLayer = i;
 		res = vkCreateImageView(vulkan->GetDevice(), &ivci, nullptr, &img.texLayerViews[i]);
+		if (vulkan->DebugLayerEnabled()) {
+			char temp[128];
+			snprintf(temp, sizeof(temp), "%s_layer%d", tag, i);
+			vulkan->SetDebugName(img.texLayerViews[i], VK_OBJECT_TYPE_IMAGE_VIEW, temp);
+		}
 		_dbg_assert_(res == VK_SUCCESS);
 	}
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -833,7 +833,6 @@ void VulkanRenderManager::BindFramebufferAsRenderTarget(VKRFramebuffer *fb, VKRR
 				data.clear.clearZ = clearDepth;
 				data.clear.clearStencil = clearStencil;
 				data.clear.clearMask = clearMask;
-				data.clear.numLayers = curRenderStep_->render.framebuffer ? curRenderStep_->render.framebuffer->numLayers : 1;
 				curRenderStep_->commands.push_back(data);
 				curRenderArea_.SetRect(0, 0, curWidth_, curHeight_);
 			}

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -155,15 +155,14 @@ bool VKRComputePipeline::Create(VulkanContext *vulkan) {
 	return success;
 }
 
-VKRFramebuffer::VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VKRRenderPass *compatibleRenderPass, int _width, int _height, bool createDepthStencilBuffer, const char *tag) : vulkan_(vk), tag_(tag) {
-	width = _width;
-	height = _height;
+VKRFramebuffer::VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VKRRenderPass *compatibleRenderPass, int _width, int _height, int _numLayers, bool createDepthStencilBuffer, const char *tag)
+	: vulkan_(vk), tag_(tag), width(_width), height(_height), numLayers(_numLayers) {
 
 	_dbg_assert_(tag);
 
-	CreateImage(vulkan_, initCmd, color, width, height, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, true, tag);
+	CreateImage(vulkan_, initCmd, color, width, height, numLayers, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, true, tag);
 	if (createDepthStencilBuffer) {
-		CreateImage(vulkan_, initCmd, depth, width, height, vulkan_->GetDeviceInfo().preferredDepthStencilFormat, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, false, tag);
+		CreateImage(vulkan_, initCmd, depth, width, height, numLayers, vulkan_->GetDeviceInfo().preferredDepthStencilFormat, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, false, tag);
 	}
 
 	UpdateTag(tag);
@@ -243,9 +242,9 @@ VKRFramebuffer::~VKRFramebuffer() {
 	}
 }
 
-void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int width, int height, VkFormat format, VkImageLayout initialLayout, bool color, const char *tag) {
+void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int width, int height, int numLayers, VkFormat format, VkImageLayout initialLayout, bool color, const char *tag) {
 	VkImageCreateInfo ici{ VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO };
-	ici.arrayLayers = 1;
+	ici.arrayLayers = numLayers;
 	ici.mipLevels = 1;
 	ici.extent.width = width;
 	ici.extent.height = height;

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -207,10 +207,10 @@ VkFramebuffer VKRFramebuffer::Get(VKRRenderPass *compatibleRenderPass, RenderPas
 	VkImageView views[2]{};
 
 	bool hasDepth = RenderPassTypeHasDepth(rpType);
-	views[0] = (multiview || numLayers == 0) ? color.imageView : color.layerViews[layer];
+	views[0] = (multiview || numLayers == 1) ? color.imageView : color.layerViews[layer];
 	if (hasDepth) {
 		_dbg_assert_(depth.imageView != VK_NULL_HANDLE);
-		views[1] = (multiview || numLayers == 0) ? depth.imageView : depth.layerViews[layer];
+		views[1] = (multiview || numLayers == 1) ? depth.imageView : depth.layerViews[layer];
 	}
 	fbci.renderPass = compatibleRenderPass->Get(vulkan_, rpType);
 	fbci.attachmentCount = hasDepth ? 2 : 1;

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -40,17 +40,19 @@ struct VKRImage {
 	// For debugging.
 	std::string tag;
 };
-void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int width, int height, VkFormat format, VkImageLayout initialLayout, bool color, const char *tag);
+void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int width, int height, int numLayers, VkFormat format, VkImageLayout initialLayout, bool color, const char *tag);
 
 class VKRFramebuffer {
 public:
-	VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VKRRenderPass *compatibleRenderPass, int _width, int _height, bool createDepthStencilBuffer, const char *tag);
+	VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VKRRenderPass *compatibleRenderPass, int _width, int _height, int _numLayers, bool createDepthStencilBuffer, const char *tag);
 	~VKRFramebuffer();
 
 	VkFramebuffer Get(VKRRenderPass *compatibleRenderPass, RenderPassType rpType);
 
 	int width = 0;
 	int height = 0;
+	int numLayers = 0;
+
 	VKRImage color{};  // color.image is always there.
 	VKRImage depth{};  // depth.image is allowed to be VK_NULL_HANDLE.
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -270,15 +270,6 @@ public:
 		compileMutex_.unlock();
 	}
 
-	// We always pass in desc set 0 directly in draw commands. This is used only to bind higher descriptor sets.
-	void BindDescriptorSet(int index, const VkDescriptorSet descSet) {
-		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
-		VkRenderData data{ VKRRenderCommand::BIND_DESCRIPTOR_SET };
-		data.bindDescSet.setIndex = index;
-		data.bindDescSet.descSet = descSet;
-		curRenderStep_->commands.push_back(data);
-	}
-
 	void BindPipeline(VKRGraphicsPipeline *pipeline, PipelineFlags flags, VkPipelineLayout pipelineLayout) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == VKRStepType::RENDER);
 		_dbg_assert_(pipeline != nullptr);

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1314,7 +1314,8 @@ void VKContext::BindTextures(int start, int count, Texture **textures, TextureBi
 		boundTextures_[i] = static_cast<VKTexture *>(textures[i - start]);
 		boundTextureFlags_[i] = flags;
 		if (boundTextures_[i]) {
-			// NOTE: These image views are actually not used, it seems - they get overridden in GetOrCreateDescriptorSet
+			// If a texture is bound, we set these up in GetOrCreateDescriptorSet too.
+			// But we might need to set the view here anyway so it can be queried using GetNativeObject.
 			if (flags & TextureBindFlags::VULKAN_BIND_ARRAY) {
 				boundImageView_[i] = boundTextures_[i]->GetImageArrayView();
 			} else {
@@ -1589,10 +1590,6 @@ void VKContext::BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPass
 }
 
 void VKContext::BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int layer) {
-	if (layer != ALL_LAYERS) {
-		layer = layer;
-	}
-
 	VKFramebuffer *fb = (VKFramebuffer *)fbo;
 	_assert_(binding >= 0 && binding < MAX_BOUND_TEXTURES);
 

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -785,7 +785,6 @@ VKContext::VKContext(VulkanContext *vulkan)
 	caps_.anisoSupported = vulkan->GetDeviceFeatures().enabled.standard.samplerAnisotropy != 0;
 	caps_.geometryShaderSupported = vulkan->GetDeviceFeatures().enabled.standard.geometryShader != 0;
 	caps_.tesselationShaderSupported = vulkan->GetDeviceFeatures().enabled.standard.tessellationShader != 0;
-	caps_.multiViewport = vulkan->GetDeviceFeatures().enabled.standard.multiViewport != 0;
 	caps_.dualSourceBlend = vulkan->GetDeviceFeatures().enabled.standard.dualSrcBlend != 0;
 	caps_.depthClampSupported = vulkan->GetDeviceFeatures().enabled.standard.depthClamp != 0;
 	caps_.clipDistanceSupported = vulkan->GetDeviceFeatures().enabled.standard.shaderClipDistance != 0;
@@ -804,6 +803,7 @@ VKContext::VKContext(VulkanContext *vulkan)
 	caps_.fragmentShaderDepthWriteSupported = true;
 	caps_.blendMinMaxSupported = true;
 	caps_.logicOpSupported = vulkan->GetDeviceFeatures().enabled.standard.logicOp != 0;
+	caps_.multiViewSupported = vulkan->GetDeviceFeatures().enabled.multiview.multiview != 0;
 
 	auto deviceProps = vulkan->GetPhysicalDeviceProperties(vulkan_->GetCurrentPhysicalDeviceIndex()).properties;
 

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -270,6 +270,7 @@ public:
 	}
 
 	void SetDynamicUniformData(const void *data, size_t size) {
+		_dbg_assert_(size <= uboSize_);
 		memcpy(ubo_, data, size);
 	}
 

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1015,7 +1015,7 @@ VkDescriptorSet VKContext::GetOrCreateDescriptorSet(VkBuffer buf) {
 		return iter->second;
 	}
 
-	VkDescriptorSet descSet = frame->descriptorPool.Allocate(1, &descriptorSetLayout_);
+	VkDescriptorSet descSet = frame->descriptorPool.Allocate(1, &descriptorSetLayout_, "thin3d_descset");
 	if (descSet == VK_NULL_HANDLE) {
 		ERROR_LOG(G3D, "GetOrCreateDescriptorSet failed");
 		return VK_NULL_HANDLE;

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1483,6 +1483,7 @@ public:
 		_assert_msg_(fb, "Null fb in VKFramebuffer constructor");
 		width_ = fb->width;
 		height_ = fb->height;
+		layers_ = fb->numLayers;
 	}
 	~VKFramebuffer() {
 		_assert_msg_(buf_, "Null buf_ in VKFramebuffer - double delete?");

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1505,7 +1505,7 @@ private:
 
 Framebuffer *VKContext::CreateFramebuffer(const FramebufferDesc &desc) {
 	VkCommandBuffer cmd = renderManager_.GetInitCmd();
-	VKRFramebuffer *vkrfb = new VKRFramebuffer(vulkan_, cmd, renderManager_.GetQueueRunner()->GetCompatibleRenderPass(), desc.width, desc.height, desc.z_stencil, desc.tag);
+	VKRFramebuffer *vkrfb = new VKRFramebuffer(vulkan_, cmd, renderManager_.GetQueueRunner()->GetCompatibleRenderPass(), desc.width, desc.height, desc.z_stencil, desc.numLayers, desc.tag);
 	return new VKFramebuffer(vkrfb);
 }
 

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -415,9 +415,11 @@ class Framebuffer : public RefCountedObject {
 public:
 	int Width() { return width_; }
 	int Height() { return height_; }
+	int Layers() { return layers_; }
+
 	virtual void UpdateTag(const char *tag) {}
 protected:
-	int width_ = -1, height_ = -1;
+	int width_ = -1, height_ = -1, layers_ = 1;
 };
 
 class Buffer : public RefCountedObject {
@@ -593,6 +595,8 @@ struct RenderPassInfo {
 	const char *tag;
 };
 
+const int ALL_LAYERS = -1;
+
 class DrawContext {
 public:
 	virtual ~DrawContext();
@@ -654,11 +658,10 @@ public:
 
 	// These functions should be self explanatory.
 	// Binding a zero render target means binding the backbuffer.
-	virtual void BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) = 0;
-	virtual Framebuffer *GetCurrentRenderTarget() = 0;
+	virtual void BindFramebufferAsRenderTarget(Framebuffer *fbo, int layer, const RenderPassInfo &rp, const char *tag) = 0;
 
 	// binding must be < MAX_TEXTURE_SLOTS (0, 1 are okay if it's 2).
-	virtual void BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit) = 0;
+	virtual void BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int layer) = 0;
 
 	// Framebuffer fetch / input attachment support, needs to be explicit in Vulkan.
 	virtual void BindCurrentFramebufferForColorInput() {}

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -293,7 +293,7 @@ struct FramebufferDesc {
 	int width;
 	int height;
 	int depth;
-	int numColorAttachments;
+	int numLayers;
 	bool z_stencil;
 	const char *tag;  // For graphics debuggers
 };

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -548,7 +548,6 @@ struct DeviceCaps {
 	bool depthRangeMinusOneToOne;  // OpenGL style depth
 	bool geometryShaderSupported;
 	bool tesselationShaderSupported;
-	bool multiViewport;
 	bool dualSourceBlend;
 	bool logicOpSupported;
 	bool depthClampSupported;
@@ -567,6 +566,7 @@ struct DeviceCaps {
 	bool fragmentShaderDepthWriteSupported;
 	bool textureDepthSupported;
 	bool blendMinMaxSupported;
+	bool multiViewSupported;
 
 	std::string deviceName;  // The device name to use when creating the thin3d context, to get the same one.
 };

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 
+#include "Common/Common.h"
 #include "Common/GPU/DataFormat.h"
 #include "Common/GPU/Shader.h"
 #include "Common/Data/Collections/Slice.h"
@@ -598,6 +599,12 @@ struct RenderPassInfo {
 
 const int ALL_LAYERS = -1;
 
+enum class TextureBindFlags {
+	NONE = 0,
+	VULKAN_BIND_ARRAY = 1,
+};
+ENUM_CLASS_BITOPS(TextureBindFlags);
+
 class DrawContext {
 public:
 	virtual ~DrawContext();
@@ -688,7 +695,7 @@ public:
 	virtual void SetStencilParams(uint8_t refValue, uint8_t writeMask, uint8_t compareMask) = 0;
 
 	virtual void BindSamplerStates(int start, int count, SamplerState **state) = 0;
-	virtual void BindTextures(int start, int count, Texture **textures) = 0;
+	virtual void BindTextures(int start, int count, Texture **textures, TextureBindFlags flags = TextureBindFlags::NONE) = 0;
 	virtual void BindVertexBuffers(int start, int count, Buffer **buffers, const int *offsets) = 0;
 	virtual void BindIndexBuffer(Buffer *indexBuffer, int offset) = 0;
 

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -241,9 +241,10 @@ enum class NativeObject {
 	BACKBUFFER_DEPTH_TEX,
 	FEATURE_LEVEL,
 	INIT_COMMANDBUFFER,
-	BOUND_TEXTURE0_IMAGEVIEW,
-	BOUND_TEXTURE1_IMAGEVIEW,
-	BOUND_FRAMEBUFFER_COLOR_IMAGEVIEW,
+	BOUND_TEXTURE0_IMAGEVIEW,  // Layer etc depends on how you bound it...
+	BOUND_TEXTURE1_IMAGEVIEW,  // Layer etc depends on how you bound it...
+	BOUND_FRAMEBUFFER_COLOR_IMAGEVIEW_ALL_LAYERS,
+	BOUND_FRAMEBUFFER_COLOR_IMAGEVIEW_LAYER, // use an int cast to void *srcObject to specify layer.
 	RENDER_MANAGER,
 	TEXTURE_VIEW,
 	NULL_IMAGEVIEW,
@@ -658,7 +659,8 @@ public:
 
 	// These functions should be self explanatory.
 	// Binding a zero render target means binding the backbuffer.
-	virtual void BindFramebufferAsRenderTarget(Framebuffer *fbo, int layer, const RenderPassInfo &rp, const char *tag) = 0;
+	// If an fbo has two layers, we bind for stereo rendering ALWAYS. There's no rendering to one layer anymore.
+	virtual void BindFramebufferAsRenderTarget(Framebuffer *fbo, const RenderPassInfo &rp, const char *tag) = 0;
 
 	// binding must be < MAX_TEXTURE_SLOTS (0, 1 are okay if it's 2).
 	virtual void BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChannel channelBit, int layer) = 0;

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -397,6 +397,16 @@ struct AutoRef {
 	operator T *() {
 		return ptr;
 	}
+	operator bool() const {
+		return ptr != nullptr;
+	}
+
+	void clear() {
+		if (ptr) {
+			ptr->Release();
+			ptr = nullptr;
+		}
+	}
 
 	T *ptr = nullptr;
 };

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -85,7 +85,7 @@ void UIScreen::preRender() {
 	}
 	draw->BeginFrame();
 	// Bind and clear the back buffer
-	draw->BindFramebufferAsRenderTarget(nullptr, ALL_LAYERS, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, 0xFF000000 }, "UI");
+	draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, 0xFF000000 }, "UI");
 	screenManager()->getUIContext()->BeginFrame();
 
 	Draw::Viewport viewport;

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -85,7 +85,7 @@ void UIScreen::preRender() {
 	}
 	draw->BeginFrame();
 	// Bind and clear the back buffer
-	draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, 0xFF000000 }, "UI");
+	draw->BindFramebufferAsRenderTarget(nullptr, ALL_LAYERS, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, 0xFF000000 }, "UI");
 	screenManager()->getUIContext()->BeginFrame();
 
 	Draw::Viewport viewport;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -888,6 +888,8 @@ static ConfigSetting graphicsSettings[] = {
 	ReportedConfigSetting("FrameSkip", &g_Config.iFrameSkip, 0, true, true),
 	ReportedConfigSetting("FrameSkipType", &g_Config.iFrameSkipType, 0, true, true),
 	ReportedConfigSetting("AutoFrameSkip", &g_Config.bAutoFrameSkip, false, true, true),
+	ConfigSetting("StereoRendering", &g_Config.bStereoRendering, false, true, true),
+	ConfigSetting("StereoToMonoShader", &g_Config.sStereoToMonoShader, "RedBlue", true, true),
 	ConfigSetting("FrameRate", &g_Config.iFpsLimit1, 0, true, true),
 	ConfigSetting("FrameRate2", &g_Config.iFpsLimit2, -1, true, true),
 	ConfigSetting("AnalogFrameRate", &g_Config.iAnalogFpsLimit, 240, true, true),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -241,6 +241,12 @@ public:
 
 	std::vector<std::string> vPostShaderNames; // Off for chain end (only Off for no shader)
 	std::map<std::string, float> mPostShaderSetting;
+
+	// Note that this is separate from VR stereo, though it'll share some code paths.
+	bool bStereoRendering;
+	// There can only be one, unlike regular post shaders.
+	std::string sStereoToMonoShader;
+
 	bool bShaderChainRequires60FPS;
 	std::string sTextureShaderName;
 	bool bGfxDebugOutput;

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -35,7 +35,7 @@ static const InputDef vsInputs[2] = {
 
 // TODO: Deduplicate with TextureShaderCommon.cpp
 static const SamplerDef samplers[2] = {
-	{ 0, "tex" },
+	{ 0, "tex", SamplerFlags::ARRAY_ON_VULKAN },
 	{ 1, "pal" },
 };
 

--- a/GPU/Common/Draw2D.cpp
+++ b/GPU/Common/Draw2D.cpp
@@ -184,6 +184,7 @@ void Draw2D::Ensure2DResources() {
 		char *vsCode = new char[8192];
 		ShaderWriterFlags flags = ShaderWriterFlags::NONE;
 		if (gstate_c.Use(GPU_USE_SINGLE_PASS_STEREO)) {
+			// Hm, we're compiling the vertex shader here, probably don't need this...
 			flags = ShaderWriterFlags::FS_AUTO_STEREO;
 		}
 		ShaderWriter writer(vsCode, shaderLanguageDesc, ShaderStage::Vertex);
@@ -224,7 +225,11 @@ Draw2DPipeline *Draw2D::Create2DPipeline(std::function<Draw2DPipelineInfo (Shade
 	const ShaderLanguageDesc &shaderLanguageDesc = draw_->GetShaderLanguageDesc();
 
 	char *fsCode = new char[8192];
-	ShaderWriter writer(fsCode, shaderLanguageDesc, ShaderStage::Fragment);
+	ShaderWriterFlags flags = ShaderWriterFlags::NONE;
+	if (gstate_c.Use(GPU_USE_SINGLE_PASS_STEREO)) {
+		flags = ShaderWriterFlags::FS_AUTO_STEREO;
+	}
+	ShaderWriter writer(fsCode, shaderLanguageDesc, ShaderStage::Fragment, Slice<const char *>::empty(), flags);
 	Draw2DPipelineInfo info = generate(writer);
 	_assert_msg_(strlen(fsCode) < 8192, "Draw2D FS length error: %d", (int)strlen(fsCode));
 

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -648,12 +648,11 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 						}
 					} else if (arrayTexture) {
 						// Used for stereo rendering.
+						const char *arrayIndex = useStereo ? "float(gl_ViewIndex)" : "0.0";
 						if (doTextureProjection) {
-							if (doTextureProjection) {
-								WRITE(p, "  vec4 t = %sProj(tex, %s);\n", compat.texture, texcoord);
-							} else {
-								WRITE(p, "  vec4 t = %s(tex, %s.xy);\n", compat.texture, texcoord);
-							}
+							WRITE(p, "  vec4 t = %sProj(tex, vec4(%s, %s));\n", compat.texture, texcoord, arrayIndex);
+						} else {
+							WRITE(p, "  vec4 t = %s(tex, vec3(%s.xy, %s));\n", compat.texture, texcoord, arrayIndex);
 						}
 					} else {
 						if (doTextureProjection) {

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -68,6 +68,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 	}
 
 	bool texture3D = id.Bit(FS_BIT_3D_TEXTURE);
+	bool arrayTexture = id.Bit(FS_BIT_SAMPLE_ARRAY_TEXTURE);
 
 	ReplaceAlphaType stencilToAlpha = static_cast<ReplaceAlphaType>(id.Bits(FS_BIT_STENCIL_TO_ALPHA, 2));
 
@@ -93,7 +94,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 	}
 
 	ShaderWriter p(buffer, compat, ShaderStage::Fragment, extensions, flags);
-	p.ApplySamplerMetadata(useStereo ? samplersStereo : samplersMono);
+	p.ApplySamplerMetadata(arrayTexture ? samplersStereo : samplersMono);
 
 	bool lmode = id.Bit(FS_BIT_LMODE);
 	bool doTexture = id.Bit(FS_BIT_DO_TEXTURE);
@@ -108,7 +109,6 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 	bool doTextureProjection = id.Bit(FS_BIT_DO_TEXTURE_PROJ);
 	bool doTextureAlpha = id.Bit(FS_BIT_TEXALPHA);
 
-	bool arrayTexture = id.Bit(FS_BIT_SAMPLE_ARRAY_TEXTURE);
 	if (texture3D && arrayTexture) {
 		*errorString = "Invalid combination of 3D texture and array texture, shouldn't happen";
 		return false;

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -663,7 +663,10 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 						// Used for stereo rendering.
 						const char *arrayIndex = useStereo ? "float(gl_ViewIndex)" : "0.0";
 						if (doTextureProjection) {
-							WRITE(p, "  vec4 t = %sProj(tex, vec4(%s, %s));\n", compat.texture, texcoord, arrayIndex);
+							// There's no textureProj for array textures, so we need to emulate it.
+							// Should be fine on any Vulkan-compatible hardware.
+							WRITE(p, "  vec2 uv_proj = (%s.xy) / (%s.z);\n", texcoord, texcoord);
+							WRITE(p, "  vec4 t = %s(tex, vec3(uv_proj, %s));\n", compat.texture, texcoord, arrayIndex);
 						} else {
 							WRITE(p, "  vec4 t = %s(tex, vec3(%s.xy, %s));\n", compat.texture, texcoord, arrayIndex);
 						}

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -89,6 +89,9 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 	bool doTextureProjection = id.Bit(FS_BIT_DO_TEXTURE_PROJ);
 	bool doTextureAlpha = id.Bit(FS_BIT_TEXALPHA);
 
+	bool arrayTexture = id.Bit(FS_BIT_SAMPLE_ARRAY_TEXTURE);
+	bool arrayTextureFramebuffer = id.Bit(FS_BIT_FRAMEBUFFER_ARRAY_TEXTURE);
+
 	bool flatBug = bugs.Has(Draw::Bugs::BROKEN_FLAT_IN_SHADER) && g_Config.bVendorBugChecksEnabled;
 
 	bool doFlatShading = id.Bit(FS_BIT_FLATSHADE) && !flatBug;
@@ -155,11 +158,11 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 
 		WRITE(p, "layout (std140, set = 0, binding = 3) uniform baseUBO {\n%s};\n", ub_baseStr);
 		if (doTexture) {
-			WRITE(p, "layout (binding = 0) uniform %s tex;\n", texture3D ? "sampler3D" : "sampler2D");
+			WRITE(p, "layout (binding = 0) uniform %s%s tex;\n", texture3D ? "sampler3D" : "sampler2D", arrayTexture ? "array" : "");
 		}
 
 		if (readFramebufferTex) {
-			WRITE(p, "layout (binding = 1) uniform sampler2D fbotex;\n");
+			WRITE(p, "layout (binding = 1) uniform sampler2D%s fbotex;\n", arrayTextureFramebuffer ? "array" : "");
 		} else if (fetchFramebuffer) {
 			WRITE(p, "layout (input_attachment_index = 0, binding = 9) uniform subpassInput inputColor;\n");
 			if (fragmentShaderFlags) {

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -36,7 +36,6 @@
 
 #define WRITE(p, ...) p.F(__VA_ARGS__)
 
-// This is only used in stereo mode, so okay to declare "tex" as ARRAY_ON_
 static const SamplerDef samplersMono[3] = {
 	{ 0, "tex" },
 	{ 1, "fbotex", SamplerFlags::ARRAY_ON_VULKAN },
@@ -87,10 +86,6 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 			extensions.push_back("#extension GL_OES_texture_3D: enable");
 		}
 	} 
-
-	if (compat.shaderLanguage == ShaderLanguage::GLSL_VULKAN && useStereo) {
-		extensions.push_back("#extension GL_EXT_multiview : enable");
-	}
 
 	ShaderWriterFlags flags = ShaderWriterFlags::NONE;
 	if (useStereo) {

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -113,6 +113,10 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 		*errorString = "Invalid combination of 3D texture and array texture, shouldn't happen";
 		return false;
 	}
+	if (compat.shaderLanguage != ShaderLanguage::GLSL_VULKAN && arrayTexture) {
+		*errorString = "We only do array textures for framebuffers in Vulkan.";
+		return false;
+	}
 
 	bool flatBug = bugs.Has(Draw::Bugs::BROKEN_FLAT_IN_SHADER) && g_Config.bVendorBugChecksEnabled;
 
@@ -660,6 +664,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 							WRITE(p, "  vec4 t = %s(tex, vec3(%s.xy, u_mipBias));\n", compat.texture3D, texcoord);
 						}
 					} else if (arrayTexture) {
+						_dbg_assert_(compat.shaderLanguage == GLSL_VULKAN);
 						// Used for stereo rendering.
 						const char *arrayIndex = useStereo ? "float(gl_ViewIndex)" : "0.0";
 						if (doTextureProjection) {

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1140,7 +1140,7 @@ void FramebufferManagerCommon::DrawPixels(VirtualFramebuffer *vfb, int dstX, int
 
 	Draw::Texture *pixelsTex = MakePixelTexture(srcPixels, srcPixelFormat, srcStride, width, height);
 	if (pixelsTex) {
-		draw_->BindTextures(0, 1, &pixelsTex);
+		draw_->BindTextures(0, 1, &pixelsTex, Draw::TextureBindFlags::VULKAN_BIND_ARRAY);
 
 		// TODO: Replace with draw2D_.Blit() directly.
 		DrawActiveTexture(dstX, dstY, width, height, vfb->bufferWidth, vfb->bufferHeight, u0, v0, u1, v1, ROTATION_LOCKED_HORIZONTAL, flags);
@@ -3042,7 +3042,7 @@ void FramebufferManagerCommon::BlitUsingRaster(
 	draw_->BindTexture(0, nullptr);
 	// This will get optimized away in case it's already bound (in VK and GL at least..)
 	draw_->BindFramebufferAsRenderTarget(dest, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, tag ? tag : "BlitUsingRaster");
-	draw_->BindFramebufferAsTexture(src, 0, pipeline->info.readChannel == RASTER_COLOR ? Draw::FB_COLOR_BIT : Draw::FB_DEPTH_BIT, 0);
+	draw_->BindFramebufferAsTexture(src, Draw::ALL_LAYERS, pipeline->info.readChannel == RASTER_COLOR ? Draw::FB_COLOR_BIT : Draw::FB_DEPTH_BIT, 0);
 
 	if (destX1 == 0.0f && destY1 == 0.0f && destX2 >= destW && destY2 >= destH) {
 		// We overwrite the whole channel of the framebuffer, so we can invalidate the current contents.

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -3042,7 +3042,7 @@ void FramebufferManagerCommon::BlitUsingRaster(
 	draw_->BindTexture(0, nullptr);
 	// This will get optimized away in case it's already bound (in VK and GL at least..)
 	draw_->BindFramebufferAsRenderTarget(dest, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, tag ? tag : "BlitUsingRaster");
-	draw_->BindFramebufferAsTexture(src, Draw::ALL_LAYERS, pipeline->info.readChannel == RASTER_COLOR ? Draw::FB_COLOR_BIT : Draw::FB_DEPTH_BIT, 0);
+	draw_->BindFramebufferAsTexture(src, 0, pipeline->info.readChannel == RASTER_COLOR ? Draw::FB_COLOR_BIT : Draw::FB_DEPTH_BIT, Draw::ALL_LAYERS);
 
 	if (destX1 == 0.0f && destY1 == 0.0f && destX2 >= destW && destY2 >= destH) {
 		// We overwrite the whole channel of the framebuffer, so we can invalidate the current contents.

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -863,7 +863,7 @@ void FramebufferManagerCommon::CopyToColorFromOverlappingFramebuffers(VirtualFra
 
 	if (currentRenderVfb_ && dst != currentRenderVfb_ && tookActions) {
 		// Will probably just change the name of the current renderpass, since one was started by the reinterpret itself.
-		draw_->BindFramebufferAsRenderTarget(currentRenderVfb_->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, "After Reinterpret");
+		draw_->BindFramebufferAsRenderTarget(currentRenderVfb_->fbo, 0, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, "After Reinterpret");
 	}
 
 	shaderManager_->DirtyLastShader();
@@ -1011,7 +1011,7 @@ void FramebufferManagerCommon::NotifyRenderFramebufferSwitched(VirtualFramebuffe
 	if (useBufferedRendering_) {
 		if (vfb->fbo) {
 			shaderManager_->DirtyLastShader();
-			draw_->BindFramebufferAsRenderTarget(vfb->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, "FBSwitch");
+			draw_->BindFramebufferAsRenderTarget(vfb->fbo, Draw::ALL_LAYERS, {Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP}, "FBSwitch");
 		} else {
 			// This should only happen very briefly when toggling useBufferedRendering_.
 			ResizeFramebufFBO(vfb, vfb->width, vfb->height, true);
@@ -1115,7 +1115,7 @@ void FramebufferManagerCommon::DrawPixels(VirtualFramebuffer *vfb, int dstX, int
 		} else {
 			flags = DRAWTEX_LINEAR;
 		}
-		draw_->BindFramebufferAsRenderTarget(vfb->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, tag);
+		draw_->BindFramebufferAsRenderTarget(vfb->fbo, Draw::ALL_LAYERS, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, tag);
 		SetViewport2D(0, 0, vfb->renderWidth, vfb->renderHeight);
 		draw_->SetScissorRect(0, 0, vfb->renderWidth, vfb->renderHeight);
 	} else {
@@ -1153,7 +1153,7 @@ void FramebufferManagerCommon::DrawPixels(VirtualFramebuffer *vfb, int dstX, int
 	}
 }
 
-bool FramebufferManagerCommon::BindFramebufferAsColorTexture(int stage, VirtualFramebuffer *framebuffer, int flags) {
+bool FramebufferManagerCommon::BindFramebufferAsColorTexture(int stage, VirtualFramebuffer *framebuffer, int flags, int layer) {
 	if (!framebuffer->fbo || !useBufferedRendering_) {
 		draw_->BindTexture(stage, nullptr);
 		gstate_c.skipDrawReason |= SKIPDRAW_BAD_FB_TEXTURE;
@@ -1173,17 +1173,17 @@ bool FramebufferManagerCommon::BindFramebufferAsColorTexture(int stage, VirtualF
 		if (renderCopy) {
 			VirtualFramebuffer copyInfo = *framebuffer;
 			copyInfo.fbo = renderCopy;
-			CopyFramebufferForColorTexture(&copyInfo, framebuffer, flags);
+			CopyFramebufferForColorTexture(&copyInfo, framebuffer, flags, layer);
 			RebindFramebuffer("After BindFramebufferAsColorTexture");
-			draw_->BindFramebufferAsTexture(renderCopy, stage, Draw::FB_COLOR_BIT);
+			draw_->BindFramebufferAsTexture(renderCopy, stage, Draw::FB_COLOR_BIT, layer);
 			gpuStats.numCopiesForSelfTex++;
 		} else {
 			// Failed to get temp FBO? Weird.
-			draw_->BindFramebufferAsTexture(framebuffer->fbo, stage, Draw::FB_COLOR_BIT);
+			draw_->BindFramebufferAsTexture(framebuffer->fbo, stage, Draw::FB_COLOR_BIT, layer);
 		}
 		return true;
 	} else if (framebuffer != currentRenderVfb_ || (flags & BINDFBCOLOR_FORCE_SELF) != 0) {
-		draw_->BindFramebufferAsTexture(framebuffer->fbo, stage, Draw::FB_COLOR_BIT);
+		draw_->BindFramebufferAsTexture(framebuffer->fbo, stage, Draw::FB_COLOR_BIT, layer);
 		return true;
 	} else {
 		ERROR_LOG_REPORT_ONCE(selfTextureFail, G3D, "Attempting to texture from target (src=%08x / target=%08x / flags=%d)", framebuffer->fb_address, currentRenderVfb_->fb_address, flags);
@@ -1197,7 +1197,7 @@ bool FramebufferManagerCommon::BindFramebufferAsColorTexture(int stage, VirtualF
 	}
 }
 
-void FramebufferManagerCommon::CopyFramebufferForColorTexture(VirtualFramebuffer *dst, VirtualFramebuffer *src, int flags) {
+void FramebufferManagerCommon::CopyFramebufferForColorTexture(VirtualFramebuffer *dst, VirtualFramebuffer *src, int flags, int layer) {
 	int x = 0;
 	int y = 0;
 	int w = src->drawnWidth;
@@ -1369,7 +1369,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput(bool reallyDirty) {
 			DEBUG_LOG(FRAMEBUF, "Display disabled, displaying only black");
 		// No framebuffer to display! Clear to black.
 		if (useBufferedRendering_) {
-			draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR }, "CopyDisplayToOutput");
+			draw_->BindFramebufferAsRenderTarget(nullptr, 0, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR }, "CopyDisplayToOutput");
 		}
 		gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE);
 		return;
@@ -1433,7 +1433,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput(bool reallyDirty) {
 			// No framebuffer to display! Clear to black.
 			if (useBufferedRendering_) {
 				// Bind and clear the backbuffer. This should be the first time during the frame that it's bound.
-				draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR }, "CopyDisplayToOutput_NoFBO");
+				draw_->BindFramebufferAsRenderTarget(nullptr, 0, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR }, "CopyDisplayToOutput_NoFBO");
 			}
 			gstate_c.Dirty(DIRTY_VIEWPORTSCISSOR_STATE);
 			return;
@@ -1619,7 +1619,7 @@ void FramebufferManagerCommon::ResizeFramebufFBO(VirtualFramebuffer *vfb, int w,
 	shaderManager_->DirtyLastShader();
 	char tag[128];
 	size_t len = FormatFramebufferName(vfb, tag, sizeof(tag));
-	vfb->fbo = draw_->CreateFramebuffer({ vfb->renderWidth, vfb->renderHeight, 1, 1, true, tag });
+	vfb->fbo = draw_->CreateFramebuffer({ vfb->renderWidth, vfb->renderHeight, 1, GetFramebufferLayers(), true, tag });
 	if (Memory::IsVRAMAddress(vfb->fb_address) && vfb->fb_stride != 0) {
 		NotifyMemInfo(MemBlockFlags::ALLOC, vfb->fb_address, ColorBufferByteSize(vfb), tag, len);
 	}
@@ -1631,7 +1631,7 @@ void FramebufferManagerCommon::ResizeFramebufFBO(VirtualFramebuffer *vfb, int w,
 	if (old.fbo) {
 		INFO_LOG(FRAMEBUF, "Resizing FBO for %08x : %dx%dx%s", vfb->fb_address, w, h, GeBufferFormatToString(vfb->fb_format));
 		if (vfb->fbo) {
-			draw_->BindFramebufferAsRenderTarget(vfb->fbo, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR }, "ResizeFramebufFBO");
+			draw_->BindFramebufferAsRenderTarget(vfb->fbo, 0, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR }, "ResizeFramebufFBO");
 			if (!skipCopy) {
 				BlitFramebuffer(vfb, 0, 0, &old, 0, 0, std::min((u16)oldWidth, std::min(vfb->bufferWidth, vfb->width)), std::min((u16)oldHeight, std::min(vfb->height, vfb->bufferHeight)), 0, RASTER_COLOR, "BlitColor_ResizeFramebufFBO");
 			}
@@ -1640,9 +1640,9 @@ void FramebufferManagerCommon::ResizeFramebufFBO(VirtualFramebuffer *vfb, int w,
 			}
 		}
 		fbosToDelete_.push_back(old.fbo);
-		draw_->BindFramebufferAsRenderTarget(vfb->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, "ResizeFramebufFBO");
+		draw_->BindFramebufferAsRenderTarget(vfb->fbo, Draw::ALL_LAYERS, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, "ResizeFramebufFBO");
 	} else {
-		draw_->BindFramebufferAsRenderTarget(vfb->fbo, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR }, "ResizeFramebufFBO");
+		draw_->BindFramebufferAsRenderTarget(vfb->fbo, Draw::ALL_LAYERS, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR }, "ResizeFramebufFBO");
 	}
 	currentRenderVfb_ = vfb;
 
@@ -1986,7 +1986,7 @@ VirtualFramebuffer *FramebufferManagerCommon::CreateRAMFramebuffer(uint32_t fbAd
 	char name[64];
 	snprintf(name, sizeof(name), "%08x_color_RAM", vfb->fb_address);
 	textureCache_->NotifyFramebuffer(vfb, NOTIFY_FB_CREATED);
-	vfb->fbo = draw_->CreateFramebuffer({ vfb->renderWidth, vfb->renderHeight, 1, 1, true, name });
+	vfb->fbo = draw_->CreateFramebuffer({ vfb->renderWidth, vfb->renderHeight, 1, GetFramebufferLayers(), true, name });
 	vfbs_.push_back(vfb);
 
 	u32 byteSize = ColorBufferByteSize(vfb);
@@ -2407,7 +2407,8 @@ Draw::Framebuffer *FramebufferManagerCommon::GetTempFBO(TempFBO reason, u16 w, u
 	bool z_stencil = reason == TempFBO::STENCIL;
 	char name[128];
 	snprintf(name, sizeof(name), "temp_fbo_%dx%d%s", w / renderScaleFactor_, h / renderScaleFactor_, z_stencil ? "_depth" : "");
-	Draw::Framebuffer *fbo = draw_->CreateFramebuffer({ w, h, 1, 1, z_stencil, name });
+
+	Draw::Framebuffer *fbo = draw_->CreateFramebuffer({ w, h, 1, GetFramebufferLayers(), z_stencil, name });
 	if (!fbo) {
 		return nullptr;
 	}
@@ -2784,10 +2785,10 @@ void FramebufferManagerCommon::RebindFramebuffer(const char *tag) {
 	draw_->InvalidateCachedState();
 	shaderManager_->DirtyLastShader();
 	if (currentRenderVfb_ && currentRenderVfb_->fbo) {
-		draw_->BindFramebufferAsRenderTarget(currentRenderVfb_->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, tag);
+		draw_->BindFramebufferAsRenderTarget(currentRenderVfb_->fbo, Draw::ALL_LAYERS, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, tag);
 	} else {
 		// Should this even happen?  It could while debugging, but maybe we can just skip binding at all.
-		draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, "RebindFramebuffer_Bad");
+		draw_->BindFramebufferAsRenderTarget(nullptr, 0, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, "RebindFramebuffer_Bad");
 	}
 }
 
@@ -2906,7 +2907,7 @@ void FramebufferManagerCommon::BlitFramebuffer(VirtualFramebuffer *dst, int dstX
 		// This can happen if they recently switched from non-buffered.
 		if (useBufferedRendering_) {
 			// Just bind the back buffer for rendering, forget about doing anything else as we're in a weird state.
-			draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, "BlitFramebuffer");
+			draw_->BindFramebufferAsRenderTarget(nullptr, 0, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, "BlitFramebuffer");
 		}
 		return;
 	}
@@ -3029,8 +3030,8 @@ void FramebufferManagerCommon::BlitUsingRaster(
 	// Unbind the texture first to avoid the D3D11 hazard check (can't set render target to things bound as textures and vice versa, not even temporarily).
 	draw_->BindTexture(0, nullptr);
 	// This will get optimized away in case it's already bound (in VK and GL at least..)
-	draw_->BindFramebufferAsRenderTarget(dest, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, tag ? tag : "BlitUsingRaster");
-	draw_->BindFramebufferAsTexture(src, 0, pipeline->info.readChannel == RASTER_COLOR ? Draw::FB_COLOR_BIT : Draw::FB_DEPTH_BIT);
+	draw_->BindFramebufferAsRenderTarget(dest, 0, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::KEEP }, tag ? tag : "BlitUsingRaster");
+	draw_->BindFramebufferAsTexture(src, 0, pipeline->info.readChannel == RASTER_COLOR ? Draw::FB_COLOR_BIT : Draw::FB_DEPTH_BIT, 0);
 
 	if (destX1 == 0.0f && destY1 == 0.0f && destX2 >= destW && destY2 >= destH) {
 		// We overwrite the whole channel of the framebuffer, so we can invalidate the current contents.
@@ -3044,6 +3045,14 @@ void FramebufferManagerCommon::BlitUsingRaster(
 	draw2D_.Blit(pipeline, srcX1, srcY1, srcX2, srcY2, destX1, destY1, destX2, destY2, (float)srcW, (float)srcH, (float)destW, (float)destH, linearFilter, scaleFactor);
 
 	gstate_c.Dirty(DIRTY_ALL_RENDER_STATE);
+}
+
+int FramebufferManagerCommon::GetFramebufferLayers() const {
+	int layers = 1;
+	if (gstate_c.Use(GPU_USE_SINGLE_PASS_STEREO)) {
+		layers = 2;
+	}
+	return layers;
 }
 
 VirtualFramebuffer *FramebufferManagerCommon::ResolveFramebufferColorToFormat(VirtualFramebuffer *src, GEBufferFormat newFormat) {
@@ -3089,7 +3098,7 @@ VirtualFramebuffer *FramebufferManagerCommon::ResolveFramebufferColorToFormat(Vi
 
 		char tag[128];
 		FormatFramebufferName(vfb, tag, sizeof(tag));
-		vfb->fbo = draw_->CreateFramebuffer({ vfb->renderWidth, vfb->renderHeight, 1, 1, true, tag });
+		vfb->fbo = draw_->CreateFramebuffer({ vfb->renderWidth, vfb->renderHeight, 1, GetFramebufferLayers(), true, tag });
 		vfbs_.push_back(vfb);
 	}
 

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -204,8 +204,6 @@ enum class TempFBO {
 	BLIT,
 	// For copies of framebuffers (e.g. shader blending.)
 	COPY,
-	// For another type of framebuffers that can happen together with COPY (see Outrun)
-	REINTERPRET,
 	// Used to copy stencil data, means we need a stencil backing.
 	STENCIL,
 };

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -322,7 +322,7 @@ public:
 	// Otherwise it doesn't get called.
 	void NotifyBlockTransferAfter(u32 dstBasePtr, int dstStride, int dstX, int dstY, u32 srcBasePtr, int srcStride, int srcX, int srcY, int w, int h, int bpp, u32 skipDrawReason);
 
-	bool BindFramebufferAsColorTexture(int stage, VirtualFramebuffer *framebuffer, int flags);
+	bool BindFramebufferAsColorTexture(int stage, VirtualFramebuffer *framebuffer, int flags, int layer);
 	void ReadFramebufferToMemory(VirtualFramebuffer *vfb, int x, int y, int w, int h, RasterChannel channel);
 
 	void DownloadFramebufferForClut(u32 fb_address, u32 loadBytes);
@@ -460,7 +460,7 @@ protected:
 	// Used by ReadFramebufferToMemory and later framebuffer block copies
 	void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp, RasterChannel channel, const char *tag);
 
-	void CopyFramebufferForColorTexture(VirtualFramebuffer *dst, VirtualFramebuffer *src, int flags);
+	void CopyFramebufferForColorTexture(VirtualFramebuffer *dst, VirtualFramebuffer *src, int flags, int layer);
 
 	void EstimateDrawingSize(u32 fb_address, int fb_stride, GEBufferFormat fb_format, int viewport_width, int viewport_height, int region_width, int region_height, int scissor_width, int scissor_height, int &drawing_width, int &drawing_height);
 	u32 ColorBufferByteSize(const VirtualFramebuffer *vfb) const;
@@ -485,6 +485,8 @@ protected:
 	VirtualFramebuffer *CreateRAMFramebuffer(uint32_t fbAddress, int width, int height, int stride, GEBufferFormat format);
 
 	void UpdateFramebufUsage(VirtualFramebuffer *vfb);
+
+	int GetFramebufferLayers() const;
 
 	static void SetColorUpdated(VirtualFramebuffer *dstBuffer, int skipDrawReason) {
 		dstBuffer->memoryUpdated = false;

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -225,7 +225,7 @@ void LoadPostShaderInfo(Draw::DrawContext *draw, const std::vector<Path> &direct
 						appendTextureShader(info);
 					}
 				} else if (!section.name().empty()) {
-					WARN_LOG(G3D, "Unrecognized shader type '%s' or invalid shader in section '%s' : %d", shaderType.c_str(), section.name().c_str());
+					WARN_LOG(G3D, "Unrecognized shader type '%s' or invalid shader in section '%s'", shaderType.c_str(), section.name().c_str());
 				}
 			}
 		}

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -169,6 +169,7 @@ void LoadPostShaderInfo(Draw::DrawContext *draw, const std::vector<Path> &direct
 					info.vertexShaderFile = path / temp;
 					section.Get("OutputResolution", &info.outputResolution, false);
 					section.Get("Upscaling", &info.isUpscalingFilter, false);
+					section.Get("Stereo", &info.isStereo, false);
 					section.Get("SSAA", &info.SSAAFilterLevel, 0);
 					section.Get("60fps", &info.requires60fps, false);
 					section.Get("UsePreviousFrame", &info.usePreviousFrame, false);

--- a/GPU/Common/PostShader.h
+++ b/GPU/Common/PostShader.h
@@ -39,6 +39,8 @@ struct ShaderInfo {
 	bool outputResolution;
 	// Use x1 rendering res + nearest screen scaling filter
 	bool isUpscalingFilter;
+	// Is used to post-process stereo-rendering to mono, like red/blue.
+	bool isStereo;
 	// Use 2x display resolution for supersampling with blurry shaders.
 	int SSAAFilterLevel;
 	// Force constant/max refresh for animated filters

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -34,6 +34,7 @@
 #include "Core/HW/Display.h"
 #include "GPU/Common/PostShader.h"
 #include "GPU/Common/PresentationCommon.h"
+#include "GPU/GPUState.h"
 #include "Common/GPU/ShaderTranslation.h"
 
 struct Vertex {
@@ -230,7 +231,7 @@ static std::string ReadShaderSrc(const Path &filename) {
 bool PresentationCommon::UpdatePostShader() {
 	DestroyStereoShader();
 
-	if (g_Config.bStereoRendering) {
+	if (gstate_c.Use(GPU_USE_SIMPLE_STEREO_PERSPECTIVE)) {
 		const ShaderInfo *stereoShaderInfo = GetPostShaderInfo(g_Config.sStereoToMonoShader);
 		bool result = CompilePostShader(stereoShaderInfo, &stereoPipeline_);
 		if (!result) {
@@ -622,7 +623,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 	// This should auto-disable usePostShader_ and call ShowPostShaderError().
 
 	bool useNearest = flags & OutputFlags::NEAREST;
-	bool useStereo = g_Config.bStereoRendering && stereoPipeline_ != nullptr;  // TODO: Also check that the backend has support for it.
+	bool useStereo = gstate_c.Use(GPU_USE_SIMPLE_STEREO_PERSPECTIVE) && stereoPipeline_ != nullptr;  // TODO: Also check that the backend has support for it.
 
 	const bool usePostShader = usePostShader_ && !useStereo && !(flags & OutputFlags::RB_SWIZZLE);
 	const bool isFinalAtOutputResolution = usePostShader && postShaderFramebuffers_.size() < postShaderPipelines_.size();

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -566,7 +566,7 @@ void PresentationCommon::BindSource(int binding) {
 	if (srcTexture_) {
 		draw_->BindTexture(binding, srcTexture_);
 	} else if (srcFramebuffer_) {
-		draw_->BindFramebufferAsTexture(srcFramebuffer_, binding, Draw::FB_COLOR_BIT);
+		draw_->BindFramebufferAsTexture(srcFramebuffer_, binding, Draw::FB_COLOR_BIT, 0);
 	} else {
 		_assert_(false);
 	}
@@ -685,13 +685,13 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 	PostShaderUniforms uniforms;
 	const auto performShaderPass = [&](const ShaderInfo *shaderInfo, Draw::Framebuffer *postShaderFramebuffer, Draw::Pipeline *postShaderPipeline) {
 		if (postShaderOutput) {
-			draw_->BindFramebufferAsTexture(postShaderOutput, 0, Draw::FB_COLOR_BIT);
+			draw_->BindFramebufferAsTexture(postShaderOutput, 0, Draw::FB_COLOR_BIT, 0);
 		} else {
 			BindSource(0);
 		}
 		BindSource(1);
 		if (shaderInfo->usePreviousFrame)
-			draw_->BindFramebufferAsTexture(previousFramebuffer, 2, Draw::FB_COLOR_BIT);
+			draw_->BindFramebufferAsTexture(previousFramebuffer, 2, Draw::FB_COLOR_BIT, 0);
 
 		int nextWidth, nextHeight;
 		draw_->GetFramebufferDimensions(postShaderFramebuffer, &nextWidth, &nextHeight);
@@ -743,7 +743,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 				postShaderFramebuffer = previousFramebuffers_[previousIndex_];
 			}
 
-			draw_->BindFramebufferAsRenderTarget(postShaderFramebuffer, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "PostShader");
+			draw_->BindFramebufferAsRenderTarget(postShaderFramebuffer, 0, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "PostShader");
 			performShaderPass(shaderInfo, postShaderFramebuffer, postShaderPipeline);
 		}
 
@@ -764,7 +764,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 			previousIndex_ = 0;
 		Draw::Framebuffer *postShaderFramebuffer = previousFramebuffers_[previousIndex_];
 
-		draw_->BindFramebufferAsRenderTarget(postShaderFramebuffer, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "InterFrameBlit");
+		draw_->BindFramebufferAsRenderTarget(postShaderFramebuffer, 0, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "InterFrameBlit");
 		performShaderPass(shaderInfo, postShaderFramebuffer, postShaderPipeline);
 	}
 
@@ -773,13 +773,13 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 		pipeline = postShaderPipelines_.back();
 	}
 
-	draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "FinalBlit");
+	draw_->BindFramebufferAsRenderTarget(nullptr, 0, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "FinalBlit");
 	draw_->SetScissorRect(0, 0, pixelWidth_, pixelHeight_);
 
 	draw_->BindPipeline(pipeline);
 
 	if (postShaderOutput) {
-		draw_->BindFramebufferAsTexture(postShaderOutput, 0, Draw::FB_COLOR_BIT);
+		draw_->BindFramebufferAsTexture(postShaderOutput, 0, Draw::FB_COLOR_BIT, 0);
 	} else {
 		BindSource(0);
 	}

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -596,7 +596,7 @@ bool PresentationCommon::BindSource(int binding, bool bindStereo) {
 				draw_->BindFramebufferAsTexture(srcFramebuffer_, binding, Draw::FB_COLOR_BIT, Draw::ALL_LAYERS);
 				return true;
 			} else {
-				// Single layer
+				// Single layer. This might be from a post shader and those don't yet support stereo.
 				draw_->BindFramebufferAsTexture(srcFramebuffer_, binding, Draw::FB_COLOR_BIT, 0);
 				return false;
 			}

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -783,7 +783,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 				postShaderFramebuffer = previousFramebuffers_[previousIndex_];
 			}
 
-			draw_->BindFramebufferAsRenderTarget(postShaderFramebuffer, 0, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "PostShader");
+			draw_->BindFramebufferAsRenderTarget(postShaderFramebuffer, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "PostShader");
 			performShaderPass(shaderInfo, postShaderFramebuffer, postShaderPipeline);
 		}
 
@@ -804,11 +804,11 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 			previousIndex_ = 0;
 		Draw::Framebuffer *postShaderFramebuffer = previousFramebuffers_[previousIndex_];
 
-		draw_->BindFramebufferAsRenderTarget(postShaderFramebuffer, 0, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "InterFrameBlit");
+		draw_->BindFramebufferAsRenderTarget(postShaderFramebuffer, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "InterFrameBlit");
 		performShaderPass(shaderInfo, postShaderFramebuffer, postShaderPipeline);
 	}
 
-	draw_->BindFramebufferAsRenderTarget(nullptr, 0, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "FinalBlit");
+	draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "FinalBlit");
 	draw_->SetScissorRect(0, 0, pixelWidth_, pixelHeight_);
 
 	Draw::Pipeline *pipeline = (flags & OutputFlags::RB_SWIZZLE) ? texColorRBSwizzle_ : texColor_;

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -699,7 +699,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 		}
 	}
 
-	if (isFinalAtOutputResolution) {
+	if (isFinalAtOutputResolution || useStereo) {
 		// In this mode, we ignore the g_display_rot_matrix.  Apply manually.
 		if (g_display_rotation != DisplayRotation::ROTATE_0) {
 			for (int i = 0; i < 4; i++) {

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -133,10 +133,13 @@ protected:
 	Draw::Buffer *idata_ = nullptr;
 
 	std::vector<Draw::Pipeline *> postShaderPipelines_;
-	Draw::Pipeline *stereoPipeline_ = nullptr;
 	std::vector<Draw::Framebuffer *> postShaderFramebuffers_;
 	std::vector<ShaderInfo> postShaderInfo_;
 	std::vector<Draw::Framebuffer *> previousFramebuffers_;
+	
+	Draw::Pipeline *stereoPipeline_ = nullptr;
+	ShaderInfo *stereoShaderInfo_ = nullptr;
+
 	int previousIndex_ = 0;
 	PostShaderUniforms previousUniforms_{};
 

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -107,7 +107,9 @@ public:
 protected:
 	void CreateDeviceObjects();
 	void DestroyDeviceObjects();
+
 	void DestroyPostShader();
+	void DestroyStereoShader();
 
 	static void ShowPostShaderError(const std::string &errorString);
 
@@ -117,7 +119,7 @@ protected:
 	bool BuildPostShader(const ShaderInfo *shaderInfo, const ShaderInfo *next, Draw::Pipeline **outPipeline);
 	bool AllocateFramebuffer(int w, int h);
 
-	void BindSource(int binding);
+	bool BindSource(int binding, bool bindStereo);
 
 	void GetCardboardSettings(CardboardSettings *cardboardSettings) const;
 	void CalculatePostShaderUniforms(int bufferWidth, int bufferHeight, int targetWidth, int targetHeight, const ShaderInfo *shaderInfo, PostShaderUniforms *uniforms) const;
@@ -131,6 +133,7 @@ protected:
 	Draw::Buffer *idata_ = nullptr;
 
 	std::vector<Draw::Pipeline *> postShaderPipelines_;
+	Draw::Pipeline *stereoPipeline_ = nullptr;
 	std::vector<Draw::Framebuffer *> postShaderFramebuffers_;
 	std::vector<ShaderInfo> postShaderInfo_;
 	std::vector<Draw::Framebuffer *> previousFramebuffers_;

--- a/GPU/Common/ReinterpretFramebuffer.cpp
+++ b/GPU/Common/ReinterpretFramebuffer.cpp
@@ -14,14 +14,13 @@ static const VaryingDef varyings[1] = {
 };
 
 static const SamplerDef samplers[1] = {
-	{ 0, "tex" }
+	{ 0, "tex", SamplerFlags::ARRAY_ON_VULKAN }
 };
 
 // Requires full size integer math. It would be possible to make a floating point-only version with lots of
 // modulo and stuff, might do it one day.
 Draw2DPipelineInfo GenerateReinterpretFragmentShader(ShaderWriter &writer, GEBufferFormat from, GEBufferFormat to) {
 	writer.HighPrecisionFloat();
-
 	writer.DeclareSamplers(samplers);
 
 	if (writer.Lang().bitwiseOps) {

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -62,6 +62,8 @@ std::string VertexShaderDesc(const VShaderID &id) {
 	if (id.Bit(VS_BIT_NORM_REVERSE_TESS)) desc << "TessRevN ";
 	if (id.Bit(VS_BIT_VERTEX_RANGE_CULLING)) desc << "Cull ";
 
+	if (id.Bit(VS_BIT_SIMPLE_STEREO)) desc << "SimpleStereo ";
+
 	return desc.str();
 }
 
@@ -92,7 +94,7 @@ void ComputeVertexShaderID(VShaderID *id_out, u32 vertType, bool useHWTransform,
 	id.SetBit(VS_BIT_HAS_COLOR, hasColor);
 	id.SetBit(VS_BIT_VERTEX_RANGE_CULLING, vertexRangeCulling);
 
-	if (!isModeThrough && VS_BIT_SIMPLE_STEREO) {
+	if (!isModeThrough && gstate_c.Use(GPU_USE_SINGLE_PASS_STEREO)) {
 		id.SetBit(VS_BIT_SIMPLE_STEREO);
 	}
 
@@ -255,7 +257,8 @@ std::string FragmentShaderDesc(const FShaderID &id) {
 	if (id.Bit(FS_BIT_TEST_DISCARD_TO_ZERO)) desc << "TestDiscardToZero ";
 	if (id.Bit(FS_BIT_NO_DEPTH_CANNOT_DISCARD_STENCIL)) desc << "StencilDiscardWorkaround ";
 	if (id.Bits(FS_BIT_REPLACE_LOGIC_OP, 4) != GE_LOGIC_COPY) desc << "ReplaceLogic ";
-
+	if (id.Bit(FS_BIT_SAMPLE_ARRAY_TEXTURE)) desc << "TexArray ";
+	if (id.Bit(FS_BIT_STEREO)) desc << "Stereo ";
 	return desc.str();
 }
 
@@ -363,7 +366,6 @@ void ComputeFragmentShaderID(FShaderID *id_out, const ComputedPipelineState &pip
 			id.SetBits(FS_BIT_BLENDFUNC_B, 4, gstate.getBlendFuncB());
 		}
 		id.SetBit(FS_BIT_FLATSHADE, doFlatShading);
-
 		id.SetBit(FS_BIT_COLOR_WRITEMASK, colorWriteMask);
 
 		// Stereo support
@@ -372,7 +374,7 @@ void ComputeFragmentShaderID(FShaderID *id_out, const ComputedPipelineState &pip
 			if (gstate_c.arrayTexture) {
 				id.SetBit(FS_BIT_SAMPLE_ARRAY_TEXTURE);
 			}
-			id.SetBit(FS_BIT_FRAMEBUFFER_ARRAY_TEXTURE);
+			id.SetBit(FS_BIT_STEREO);
 		}
 
 		if (g_Config.bVendorBugChecksEnabled && bugs.Has(Draw::Bugs::NO_DEPTH_CANNOT_DISCARD_STENCIL)) {

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -92,6 +92,10 @@ void ComputeVertexShaderID(VShaderID *id_out, u32 vertType, bool useHWTransform,
 	id.SetBit(VS_BIT_HAS_COLOR, hasColor);
 	id.SetBit(VS_BIT_VERTEX_RANGE_CULLING, vertexRangeCulling);
 
+	if (!isModeThrough && VS_BIT_SIMPLE_STEREO) {
+		id.SetBit(VS_BIT_SIMPLE_STEREO);
+	}
+
 	if (doTexture) {
 		id.SetBit(VS_BIT_DO_TEXTURE);
 

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -362,6 +362,15 @@ void ComputeFragmentShaderID(FShaderID *id_out, const ComputedPipelineState &pip
 
 		id.SetBit(FS_BIT_COLOR_WRITEMASK, colorWriteMask);
 
+		// Stereo support
+		if (gstate_c.Use(GPU_USE_SINGLE_PASS_STEREO)) {
+			// All framebuffers are array textures in this mode.
+			if (gstate_c.arrayTexture) {
+				id.SetBit(FS_BIT_SAMPLE_ARRAY_TEXTURE);
+			}
+			id.SetBit(FS_BIT_FRAMEBUFFER_ARRAY_TEXTURE);
+		}
+
 		if (g_Config.bVendorBugChecksEnabled && bugs.Has(Draw::Bugs::NO_DEPTH_CANNOT_DISCARD_STENCIL)) {
 			bool stencilWithoutDepth = !IsStencilTestOutputDisabled() && (!gstate.isDepthTestEnabled() || !gstate.isDepthWriteEnabled());
 			if (stencilWithoutDepth) {

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -368,8 +368,8 @@ void ComputeFragmentShaderID(FShaderID *id_out, const ComputedPipelineState &pip
 		id.SetBit(FS_BIT_FLATSHADE, doFlatShading);
 		id.SetBit(FS_BIT_COLOR_WRITEMASK, colorWriteMask);
 
-		// All framebuffers are array textures now.
-		if (gstate_c.arrayTexture) {
+		// All framebuffers are array textures in Vulkan now.
+		if (gstate_c.arrayTexture && g_Config.iGPUBackend == (int)GPUBackend::VULKAN) {
 			id.SetBit(FS_BIT_SAMPLE_ARRAY_TEXTURE);
 		}
 

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -368,12 +368,13 @@ void ComputeFragmentShaderID(FShaderID *id_out, const ComputedPipelineState &pip
 		id.SetBit(FS_BIT_FLATSHADE, doFlatShading);
 		id.SetBit(FS_BIT_COLOR_WRITEMASK, colorWriteMask);
 
+		// All framebuffers are array textures now.
+		if (gstate_c.arrayTexture) {
+			id.SetBit(FS_BIT_SAMPLE_ARRAY_TEXTURE);
+		}
+
 		// Stereo support
 		if (gstate_c.Use(GPU_USE_SINGLE_PASS_STEREO)) {
-			// All framebuffers are array textures in this mode.
-			if (gstate_c.arrayTexture) {
-				id.SetBit(FS_BIT_SAMPLE_ARRAY_TEXTURE);
-			}
 			id.SetBit(FS_BIT_STEREO);
 		}
 

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -15,7 +15,7 @@ enum VShaderBit : uint8_t {
 	VS_BIT_HAS_COLOR = 3,
 	VS_BIT_DO_TEXTURE = 4,
 	VS_BIT_VERTEX_RANGE_CULLING = 5,
-	// 6 is free,
+	VS_BIT_SIMPLE_STEREO = 6,
 	// 7 is free.
 	VS_BIT_USE_HW_TRANSFORM = 8,
 	VS_BIT_HAS_NORMAL = 9,  // conditioned on hw transform

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -99,7 +99,7 @@ enum FShaderBit : uint8_t {
 	FS_BIT_REPLACE_LOGIC_OP = 51,  // 4 bits. GE_LOGIC_COPY means no-op/off.
 	FS_BIT_SHADER_DEPAL_MODE = 55,  // 2 bits (ShaderDepalMode)
 	FS_BIT_SAMPLE_ARRAY_TEXTURE = 57,  // For multiview, framebuffers are array textures and we need to sample the two layers correctly.
-	FS_BIT_FRAMEBUFFER_ARRAY_TEXTURE = 58,  // Framebuffer texture might also be stereo.
+	FS_BIT_STEREO = 58,
 };
 
 static inline FShaderBit operator +(FShaderBit bit, int i) {

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -98,6 +98,8 @@ enum FShaderBit : uint8_t {
 	FS_BIT_COLOR_WRITEMASK = 50,
 	FS_BIT_REPLACE_LOGIC_OP = 51,  // 4 bits. GE_LOGIC_COPY means no-op/off.
 	FS_BIT_SHADER_DEPAL_MODE = 55,  // 2 bits (ShaderDepalMode)
+	FS_BIT_SAMPLE_ARRAY_TEXTURE = 57,  // For multiview, framebuffers are array textures and we need to sample the two layers correctly.
+	FS_BIT_FRAMEBUFFER_ARRAY_TEXTURE = 58,  // Framebuffer texture might also be stereo.
 };
 
 static inline FShaderBit operator +(FShaderBit bit, int i) {

--- a/GPU/Common/ShaderUniforms.h
+++ b/GPU/Common/ShaderUniforms.h
@@ -131,6 +131,16 @@ static const char * const ub_vs_bonesStr =
 R"(	mat3x4 u_bone0; mat3x4 u_bone1; mat3x4 u_bone2; mat3x4 u_bone3; mat3x4 u_bone4; mat3x4 u_bone5; mat3x4 u_bone6; mat3x4 u_bone7; mat3x4 u_bone8;
 )";
 
+
+static const char * const ub_frame_globalstr =
+R"( vec4 unused;
+)";
+
+// VR stuff will go here.
+struct UB_FrameGlobal {
+	float unused[4];
+};
+
 void CalcCullRange(float minValues[4], float maxValues[4], bool flipViewport, bool hasNegZ);
 
 void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipViewport, bool useBufferedRendering);

--- a/GPU/Common/StencilCommon.cpp
+++ b/GPU/Common/StencilCommon.cpp
@@ -187,7 +187,7 @@ bool FramebufferManagerCommon::PerformWriteStencilFromMemory(u32 addr, int size,
 		// Otherwise, we can skip alpha in many cases, in which case we don't even use a shader.
 		if (flags & WriteStencil::IGNORE_ALPHA) {
 			if (dstBuffer->fbo) {
-				draw_->BindFramebufferAsRenderTarget(dstBuffer->fbo, 0, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::CLEAR }, "WriteStencilFromMemory_Clear");
+				draw_->BindFramebufferAsRenderTarget(dstBuffer->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::CLEAR }, "WriteStencilFromMemory_Clear");
 			}
 			return true;
 		}
@@ -281,9 +281,9 @@ bool FramebufferManagerCommon::PerformWriteStencilFromMemory(u32 addr, int size,
 	Draw::Framebuffer *blitFBO = nullptr;
 	if (useBlit) {
 		blitFBO = GetTempFBO(TempFBO::STENCIL, w, h);
-		draw_->BindFramebufferAsRenderTarget(blitFBO, 0, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::CLEAR }, "WriteStencilFromMemory_Blit");
+		draw_->BindFramebufferAsRenderTarget(blitFBO, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::CLEAR }, "WriteStencilFromMemory_Blit");
 	} else if (dstBuffer->fbo) {
-		draw_->BindFramebufferAsRenderTarget(dstBuffer->fbo, 0, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::CLEAR }, "WriteStencilFromMemory_NoBlit");
+		draw_->BindFramebufferAsRenderTarget(dstBuffer->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::CLEAR }, "WriteStencilFromMemory_NoBlit");
 	}
 
 	Draw::Viewport viewport = { 0.0f, 0.0f, (float)w, (float)h, 0.0f, 1.0f };

--- a/GPU/Common/StencilCommon.cpp
+++ b/GPU/Common/StencilCommon.cpp
@@ -187,7 +187,7 @@ bool FramebufferManagerCommon::PerformWriteStencilFromMemory(u32 addr, int size,
 		// Otherwise, we can skip alpha in many cases, in which case we don't even use a shader.
 		if (flags & WriteStencil::IGNORE_ALPHA) {
 			if (dstBuffer->fbo) {
-				draw_->BindFramebufferAsRenderTarget(dstBuffer->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::CLEAR }, "WriteStencilFromMemory_Clear");
+				draw_->BindFramebufferAsRenderTarget(dstBuffer->fbo, 0, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::CLEAR }, "WriteStencilFromMemory_Clear");
 			}
 			return true;
 		}
@@ -281,9 +281,9 @@ bool FramebufferManagerCommon::PerformWriteStencilFromMemory(u32 addr, int size,
 	Draw::Framebuffer *blitFBO = nullptr;
 	if (useBlit) {
 		blitFBO = GetTempFBO(TempFBO::STENCIL, w, h);
-		draw_->BindFramebufferAsRenderTarget(blitFBO, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::CLEAR }, "WriteStencilFromMemory_Blit");
+		draw_->BindFramebufferAsRenderTarget(blitFBO, 0, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::CLEAR }, "WriteStencilFromMemory_Blit");
 	} else if (dstBuffer->fbo) {
-		draw_->BindFramebufferAsRenderTarget(dstBuffer->fbo, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::CLEAR }, "WriteStencilFromMemory_NoBlit");
+		draw_->BindFramebufferAsRenderTarget(dstBuffer->fbo, 0, { Draw::RPAction::KEEP, Draw::RPAction::KEEP, Draw::RPAction::CLEAR }, "WriteStencilFromMemory_NoBlit");
 	}
 
 	Draw::Viewport viewport = { 0.0f, 0.0f, (float)w, (float)h, 0.0f, 1.0f };

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2121,7 +2121,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 			// Very icky conflation here of native and thin3d rendering. This will need careful work per backend in BindAsClutTexture.
 			BindAsClutTexture(clutTexture.texture, smoothedDepal);
 
-			framebufferManager_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV | BINDFBCOLOR_APPLY_TEX_OFFSET);
+			framebufferManager_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV | BINDFBCOLOR_APPLY_TEX_OFFSET, 0);
 			// Vulkan needs to do some extra work here to pick out the native handle from Draw.
 			BoundFramebufferTexture();
 
@@ -2191,13 +2191,13 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 		Draw::Framebuffer *depalFBO = framebufferManager_->GetTempFBO(TempFBO::DEPAL, depalWidth, framebuffer->renderHeight);
 		draw_->BindTexture(0, nullptr);
 		draw_->BindTexture(1, nullptr);
-		draw_->BindFramebufferAsRenderTarget(depalFBO, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Depal");
+		draw_->BindFramebufferAsRenderTarget(depalFBO, Draw::ALL_LAYERS, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Depal");
 		draw_->InvalidateFramebuffer(Draw::FB_INVALIDATION_STORE, Draw::FB_DEPTH_BIT | Draw::FB_STENCIL_BIT);
 		draw_->SetScissorRect(u1, v1, u2 - u1, v2 - v1);
 		Draw::Viewport vp{ 0.0f, 0.0f, (float)depalWidth, (float)framebuffer->renderHeight, 0.0f, 1.0f };
 		draw_->SetViewports(1, &vp);
 
-		draw_->BindFramebufferAsTexture(framebuffer->fbo, 0, depth ? Draw::FB_DEPTH_BIT : Draw::FB_COLOR_BIT);
+		draw_->BindFramebufferAsTexture(framebuffer->fbo, 0, depth ? Draw::FB_DEPTH_BIT : Draw::FB_COLOR_BIT, 0);
 		draw_->BindTexture(1, clutTexture.texture);
 		Draw::SamplerState *nearest = textureShaderCache_->GetSampler(false);
 		Draw::SamplerState *clutSampler = textureShaderCache_->GetSampler(smoothedDepal);
@@ -2213,7 +2213,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 		draw_->BindTexture(0, nullptr);
 		framebufferManager_->RebindFramebuffer("ApplyTextureFramebuffer");
 
-		draw_->BindFramebufferAsTexture(depalFBO, 0, Draw::FB_COLOR_BIT);
+		draw_->BindFramebufferAsTexture(depalFBO, 0, Draw::FB_COLOR_BIT, 0);
 		BoundFramebufferTexture();
 
 		const u32 bytesPerColor = clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16);
@@ -2226,7 +2226,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 		shaderManager_->DirtyLastShader();
 	} else {
 		framebufferManager_->RebindFramebuffer("ApplyTextureFramebuffer");
-		framebufferManager_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV | BINDFBCOLOR_APPLY_TEX_OFFSET);
+		framebufferManager_->BindFramebufferAsColorTexture(0, framebuffer, BINDFBCOLOR_MAY_COPY_WITH_UV | BINDFBCOLOR_APPLY_TEX_OFFSET, 0);
 		BoundFramebufferTexture();
 
 		gstate_c.SetUseShaderDepal(ShaderDepalMode::OFF);
@@ -2292,14 +2292,14 @@ void TextureCacheCommon::ApplyTextureDepal(TexCacheEntry *entry) {
 	Draw::Framebuffer *depalFBO = framebufferManager_->GetTempFBO(TempFBO::DEPAL, texWidth, texHeight);
 	draw_->BindTexture(0, nullptr);
 	draw_->BindTexture(1, nullptr);
-	draw_->BindFramebufferAsRenderTarget(depalFBO, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Depal");
+	draw_->BindFramebufferAsRenderTarget(depalFBO, 0, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Depal");
 	draw_->InvalidateFramebuffer(Draw::FB_INVALIDATION_STORE, Draw::FB_DEPTH_BIT | Draw::FB_STENCIL_BIT);
 	draw_->SetScissorRect(u1, v1, u2 - u1, v2 - v1);
 	Draw::Viewport vp{ 0.0f, 0.0f, (float)texWidth, (float)texHeight, 0.0f, 1.0f };
 	draw_->SetViewports(1, &vp);
 
 	draw_->BindNativeTexture(0, GetNativeTextureView(entry));
-	draw_->BindFramebufferAsTexture(dynamicClutFbo_, 1, Draw::FB_COLOR_BIT);
+	draw_->BindFramebufferAsTexture(dynamicClutFbo_, 1, Draw::FB_COLOR_BIT, 0);
 	Draw::SamplerState *nearest = textureShaderCache_->GetSampler(false);
 	Draw::SamplerState *clutSampler = textureShaderCache_->GetSampler(false);
 	draw_->BindSamplerStates(0, 1, &nearest);
@@ -2314,7 +2314,7 @@ void TextureCacheCommon::ApplyTextureDepal(TexCacheEntry *entry) {
 	draw_->BindTexture(0, nullptr);
 	framebufferManager_->RebindFramebuffer("ApplyTextureFramebuffer");
 
-	draw_->BindFramebufferAsTexture(depalFBO, 0, Draw::FB_COLOR_BIT);
+	draw_->BindFramebufferAsTexture(depalFBO, 0, Draw::FB_COLOR_BIT, 0);
 	BoundFramebufferTexture();
 
 	const u32 bytesPerColor = clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1295,7 +1295,7 @@ void TextureCacheCommon::LoadClut(u32 clutAddr, u32 loadBytes) {
 					desc.height = 1;
 					desc.depth = 1;
 					desc.z_stencil = false;
-					desc.numColorAttachments = 1;
+					desc.numLayers = 1;
 					desc.tag = "dynamic_clut";
 					dynamicClutFbo_ = draw_->CreateFramebuffer(desc);
 					desc.tag = "dynamic_clut_temp";

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2220,7 +2220,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 		draw_->BindTexture(0, nullptr);
 		framebufferManager_->RebindFramebuffer("ApplyTextureFramebuffer");
 
-		draw_->BindFramebufferAsTexture(depalFBO, 0, Draw::FB_COLOR_BIT, 0);
+		draw_->BindFramebufferAsTexture(depalFBO, 0, Draw::FB_COLOR_BIT, Draw::ALL_LAYERS);
 		BoundFramebufferTexture();
 
 		const u32 bytesPerColor = clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -371,7 +371,8 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 	if (!Memory::IsValidAddress(texaddr)) {
 		// Bind a null texture and return.
 		Unbind();
-		gstate_c.arrayTexture = false;
+		gstate_c.SetTextureIs3D(false);
+		gstate_c.SetTextureIsArray(false);
 		return nullptr;
 	}
 
@@ -2337,7 +2338,6 @@ void TextureCacheCommon::ApplyTextureDepal(TexCacheEntry *entry) {
 
 	// Since we've drawn using thin3d, might need these.
 	gstate_c.Dirty(DIRTY_ALL_RENDER_STATE);
-
 }
 
 void TextureCacheCommon::Clear(bool delete_them) {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2191,7 +2191,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 		Draw::Framebuffer *depalFBO = framebufferManager_->GetTempFBO(TempFBO::DEPAL, depalWidth, framebuffer->renderHeight);
 		draw_->BindTexture(0, nullptr);
 		draw_->BindTexture(1, nullptr);
-		draw_->BindFramebufferAsRenderTarget(depalFBO, Draw::ALL_LAYERS, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Depal");
+		draw_->BindFramebufferAsRenderTarget(depalFBO, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Depal");
 		draw_->InvalidateFramebuffer(Draw::FB_INVALIDATION_STORE, Draw::FB_DEPTH_BIT | Draw::FB_STENCIL_BIT);
 		draw_->SetScissorRect(u1, v1, u2 - u1, v2 - v1);
 		Draw::Viewport vp{ 0.0f, 0.0f, (float)depalWidth, (float)framebuffer->renderHeight, 0.0f, 1.0f };
@@ -2292,7 +2292,7 @@ void TextureCacheCommon::ApplyTextureDepal(TexCacheEntry *entry) {
 	Draw::Framebuffer *depalFBO = framebufferManager_->GetTempFBO(TempFBO::DEPAL, texWidth, texHeight);
 	draw_->BindTexture(0, nullptr);
 	draw_->BindTexture(1, nullptr);
-	draw_->BindFramebufferAsRenderTarget(depalFBO, 0, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Depal");
+	draw_->BindFramebufferAsRenderTarget(depalFBO, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Depal");
 	draw_->InvalidateFramebuffer(Draw::FB_INVALIDATION_STORE, Draw::FB_DEPTH_BIT | Draw::FB_STENCIL_BIT);
 	draw_->SetScissorRect(u1, v1, u2 - u1, v2 - v1);
 	Draw::Viewport vp{ 0.0f, 0.0f, (float)texWidth, (float)texHeight, 0.0f, 1.0f };

--- a/GPU/Common/TextureShaderCommon.cpp
+++ b/GPU/Common/TextureShaderCommon.cpp
@@ -34,7 +34,7 @@ static const VaryingDef varyings[1] = {
 };
 
 static const SamplerDef samplers[2] = {
-	{ 0, "tex" },
+	{ 0, "tex", SamplerFlags::ARRAY_ON_VULKAN },
 	{ 1, "pal" },
 };
 

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -126,9 +126,12 @@ static const char * const boneWeightDecl[9] = {
 	"layout(location = 3) in vec4 w1;\nlayout(location = 4) in vec4 w2;\n",
 };
 
-bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguageDesc &compat, Draw::Bugs bugs, uint32_t *attrMask, uint64_t *uniformMask, std::string *errorString) {
+bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguageDesc &compat, Draw::Bugs bugs, uint32_t *attrMask, uint64_t *uniformMask, VertexShaderFlags *vertexShaderFlags, std::string *errorString) {
 	*attrMask = 0;
 	*uniformMask = 0;
+	if (vertexShaderFlags) {
+		*vertexShaderFlags = (VertexShaderFlags)0;
+	}
 
 	bool highpFog = false;
 	bool highpTexcoord = false;

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -158,7 +158,11 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 
 	bool useSimpleStereo = id.Bit(VS_BIT_SIMPLE_STEREO);
 
-	if (compat.shaderLanguage == ShaderLanguage::GLSL_VULKAN && useSimpleStereo) {
+	if (useSimpleStereo) {
+		if (compat.shaderLanguage != ShaderLanguage::GLSL_VULKAN) {
+			*errorString = "Multiview only supported with Vulkan for now";
+			return false;
+		}
 		extensions.push_back("#extension GL_EXT_multiview : enable");
 	}
 

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1351,7 +1351,7 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 		WRITE(p, "  }\n");
 	}
 
-	if (useSimpleStereo) {
+	if (useSimpleStereo && useHWTransform) {
 		p.C("  float zFactor = 0.2 * float(gl_ViewIndex * 2 - 1);\n");
 		p.C("  float zFocus = 0.0;\n");
 		p.C("  gl_Position.x += (-gl_Position.z - zFocus) * zFactor;\n");

--- a/GPU/Common/VertexShaderGenerator.h
+++ b/GPU/Common/VertexShaderGenerator.h
@@ -25,7 +25,13 @@
 
 struct VShaderID;
 
-bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguageDesc &compat, const Draw::Bugs bugs, uint32_t *attrMask, uint64_t *uniformMask, std::string *errorString);
+// Can technically be deduced from the vertex shader ID, but this is safer.
+enum class VertexShaderFlags : u32 {
+	MULTI_VIEW = 1,
+};
+ENUM_CLASS_BITOPS(VertexShaderFlags);
+
+bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguageDesc &compat, const Draw::Bugs bugs, uint32_t *attrMask, uint64_t *uniformMask, VertexShaderFlags *vertexShaderFlags, std::string *errorString);
 
 // D3D9 constants.
 enum {

--- a/GPU/D3D11/ShaderManagerD3D11.cpp
+++ b/GPU/D3D11/ShaderManagerD3D11.cpp
@@ -212,7 +212,7 @@ void ShaderManagerD3D11::GetShaders(int prim, u32 vertType, D3D11VertexShader **
 		std::string genErrorString;
 		uint32_t attrMask;
 		uint64_t uniformMask;
-		GenerateVertexShader(VSID, codeBuffer_, draw_->GetShaderLanguageDesc(), draw_->GetBugs(), &attrMask, &uniformMask, &genErrorString);
+		GenerateVertexShader(VSID, codeBuffer_, draw_->GetShaderLanguageDesc(), draw_->GetBugs(), &attrMask, &uniformMask, nullptr, &genErrorString);
 		_assert_msg_(strlen(codeBuffer_) < CODE_BUFFER_SIZE, "VS length error: %d", (int)strlen(codeBuffer_));
 		vs = new D3D11VertexShader(device_, featureLevel_, VSID, codeBuffer_, vertType, useHWTransform);
 		vsCache_[VSID] = vs;

--- a/GPU/D3D11/StateMappingD3D11.cpp
+++ b/GPU/D3D11/StateMappingD3D11.cpp
@@ -159,7 +159,7 @@ void DrawEngineD3D11::ApplyDrawState(int prim) {
 				ApplyStencilReplaceAndLogicOpIgnoreBlend(blendState.replaceAlphaWithStencil, blendState);
 
 				if (fboTexBindState == FBO_TEX_COPY_BIND_TEX) {
-					framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY);
+					framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY, 0);
 					// No sampler required, we do a plain Load in the pixel shader.
 					fboTexBound_ = true;
 					fboTexBindState = FBO_TEX_NONE;

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -581,7 +581,7 @@ VSShader *ShaderManagerDX9::ApplyShader(bool useHWTransform, bool useHWTessellat
 		std::string genErrorString;
 		uint32_t attrMask;
 		uint64_t uniformMask;
-		if (GenerateVertexShader(VSID, codeBuffer_, draw_->GetShaderLanguageDesc(), draw_->GetBugs(), &attrMask, &uniformMask, &genErrorString)) {
+		if (GenerateVertexShader(VSID, codeBuffer_, draw_->GetShaderLanguageDesc(), draw_->GetBugs(), &attrMask, &uniformMask, nullptr, &genErrorString)) {
 			vs = new VSShader(device_, VSID, codeBuffer_, useHWTransform);
 		}
 		if (!vs || vs->Failed()) {
@@ -606,7 +606,7 @@ VSShader *ShaderManagerDX9::ApplyShader(bool useHWTransform, bool useHWTessellat
 			// Can still work with software transform.
 			uint32_t attrMask;
 			uint64_t uniformMask;
-			bool success = GenerateVertexShader(VSID, codeBuffer_, draw_->GetShaderLanguageDesc(), draw_->GetBugs(), &attrMask, &uniformMask, &genErrorString);
+			bool success = GenerateVertexShader(VSID, codeBuffer_, draw_->GetShaderLanguageDesc(), draw_->GetBugs(), &attrMask, &uniformMask, nullptr, &genErrorString);
 			_assert_(success);
 			vs = new VSShader(device_, VSID, codeBuffer_, false);
 		}

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -101,7 +101,7 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 
 		if (fboTexBindState_ = FBO_TEX_COPY_BIND_TEX) {
 			// Note that this is positions, not UVs, that we need the copy from.
-			framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY);
+			framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY, 0);
 			// If we are rendering at a higher resolution, linear is probably best for the dest color.
 			device_->SetSamplerState(1, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR);
 			device_->SetSamplerState(1, D3DSAMP_MINFILTER, D3DTEXF_LINEAR);
@@ -139,7 +139,7 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 
 				if (fboTexBindState_ == FBO_TEX_COPY_BIND_TEX) {
 					// Note that this is positions, not UVs, that we need the copy from.
-					framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY);
+					framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY, Draw::ALL_LAYERS);
 					// If we are rendering at a higher resolution, linear is probably best for the dest color.
 					device_->SetSamplerState(1, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR);
 					device_->SetSamplerState(1, D3DSAMP_MINFILTER, D3DTEXF_LINEAR);

--- a/GPU/GLES/DepthBufferGLES.cpp
+++ b/GPU/GLES/DepthBufferGLES.cpp
@@ -204,7 +204,7 @@ bool FramebufferManagerGLES::ReadbackDepthbufferSync(Draw::Framebuffer *fbo, int
 
 		shaderManager_->DirtyLastShader();
 		auto *blitFBO = GetTempFBO(TempFBO::COPY, fbo->Width(), fbo->Height());
-		draw_->BindFramebufferAsRenderTarget(blitFBO, 0, { RPAction::DONT_CARE, RPAction::DONT_CARE, RPAction::DONT_CARE }, "ReadbackDepthbufferSync");
+		draw_->BindFramebufferAsRenderTarget(blitFBO, { RPAction::DONT_CARE, RPAction::DONT_CARE, RPAction::DONT_CARE }, "ReadbackDepthbufferSync");
 		Draw::Viewport viewport = { 0.0f, 0.0f, (float)fbo->Width(), (float)fbo->Height(), 0.0f, 1.0f };
 		draw_->SetViewports(1, &viewport);
 
@@ -322,7 +322,7 @@ bool FramebufferManagerGLES::ReadbackStencilbufferSync(Draw::Framebuffer *fbo, i
 
 	shaderManager_->DirtyLastShader();
 	auto *blitFBO = GetTempFBO(TempFBO::COPY, fbo->Width(), fbo->Height());
-	draw_->BindFramebufferAsRenderTarget(blitFBO, 0, { RPAction::DONT_CARE, RPAction::DONT_CARE, RPAction::DONT_CARE }, "ReadbackStencilbufferSync");
+	draw_->BindFramebufferAsRenderTarget(blitFBO, { RPAction::DONT_CARE, RPAction::DONT_CARE, RPAction::DONT_CARE }, "ReadbackStencilbufferSync");
 	Draw::Viewport viewport = { 0.0f, 0.0f, (float)fbo->Width(), (float)fbo->Height(), 0.0f, 1.0f };
 	draw_->SetViewports(1, &viewport);
 

--- a/GPU/GLES/DepthBufferGLES.cpp
+++ b/GPU/GLES/DepthBufferGLES.cpp
@@ -204,11 +204,11 @@ bool FramebufferManagerGLES::ReadbackDepthbufferSync(Draw::Framebuffer *fbo, int
 
 		shaderManager_->DirtyLastShader();
 		auto *blitFBO = GetTempFBO(TempFBO::COPY, fbo->Width(), fbo->Height());
-		draw_->BindFramebufferAsRenderTarget(blitFBO, { RPAction::DONT_CARE, RPAction::DONT_CARE, RPAction::DONT_CARE }, "ReadbackDepthbufferSync");
+		draw_->BindFramebufferAsRenderTarget(blitFBO, 0, { RPAction::DONT_CARE, RPAction::DONT_CARE, RPAction::DONT_CARE }, "ReadbackDepthbufferSync");
 		Draw::Viewport viewport = { 0.0f, 0.0f, (float)fbo->Width(), (float)fbo->Height(), 0.0f, 1.0f };
 		draw_->SetViewports(1, &viewport);
 
-		draw_->BindFramebufferAsTexture(fbo, TEX_SLOT_PSP_TEXTURE, FB_DEPTH_BIT);
+		draw_->BindFramebufferAsTexture(fbo, TEX_SLOT_PSP_TEXTURE, FB_DEPTH_BIT, 0);
 		draw_->BindSamplerStates(TEX_SLOT_PSP_TEXTURE, 1, &depthReadbackSampler_);
 
 		// We must bind the program after starting the render pass.
@@ -322,11 +322,11 @@ bool FramebufferManagerGLES::ReadbackStencilbufferSync(Draw::Framebuffer *fbo, i
 
 	shaderManager_->DirtyLastShader();
 	auto *blitFBO = GetTempFBO(TempFBO::COPY, fbo->Width(), fbo->Height());
-	draw_->BindFramebufferAsRenderTarget(blitFBO, { RPAction::DONT_CARE, RPAction::DONT_CARE, RPAction::DONT_CARE }, "ReadbackStencilbufferSync");
+	draw_->BindFramebufferAsRenderTarget(blitFBO, 0, { RPAction::DONT_CARE, RPAction::DONT_CARE, RPAction::DONT_CARE }, "ReadbackStencilbufferSync");
 	Draw::Viewport viewport = { 0.0f, 0.0f, (float)fbo->Width(), (float)fbo->Height(), 0.0f, 1.0f };
 	draw_->SetViewports(1, &viewport);
 
-	draw_->BindFramebufferAsTexture(fbo, TEX_SLOT_PSP_TEXTURE, FB_STENCIL_BIT);
+	draw_->BindFramebufferAsTexture(fbo, TEX_SLOT_PSP_TEXTURE, FB_STENCIL_BIT, 0);
 	draw_->BindSamplerStates(TEX_SLOT_PSP_TEXTURE, 1, &stencilReadbackSampler_);
 
 	// We must bind the program after starting the render pass.

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -54,9 +54,9 @@ void FramebufferManagerGLES::UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) 
 
 	// Discard the previous contents of this buffer where possible.
 	if (gl_extensions.GLES3) {
-		draw_->BindFramebufferAsRenderTarget(nvfb->fbo, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "UpdateDownloadTempBuffer");
+		draw_->BindFramebufferAsRenderTarget(nvfb->fbo, 0, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "UpdateDownloadTempBuffer");
 	} else if (gl_extensions.IsGLES) {
-		draw_->BindFramebufferAsRenderTarget(nvfb->fbo, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR }, "UpdateDownloadTempBuffer");
+		draw_->BindFramebufferAsRenderTarget(nvfb->fbo, 0, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR }, "UpdateDownloadTempBuffer");
 		gstate_c.Dirty(DIRTY_BLEND_STATE);
 	}
 }

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -54,9 +54,9 @@ void FramebufferManagerGLES::UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) 
 
 	// Discard the previous contents of this buffer where possible.
 	if (gl_extensions.GLES3) {
-		draw_->BindFramebufferAsRenderTarget(nvfb->fbo, 0, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "UpdateDownloadTempBuffer");
+		draw_->BindFramebufferAsRenderTarget(nvfb->fbo, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "UpdateDownloadTempBuffer");
 	} else if (gl_extensions.IsGLES) {
-		draw_->BindFramebufferAsRenderTarget(nvfb->fbo, 0, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR }, "UpdateDownloadTempBuffer");
+		draw_->BindFramebufferAsRenderTarget(nvfb->fbo, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR }, "UpdateDownloadTempBuffer");
 		gstate_c.Dirty(DIRTY_BLEND_STATE);
 	}
 }

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -743,7 +743,7 @@ Shader *ShaderManagerGLES::CompileVertexShader(VShaderID VSID) {
 	uint32_t attrMask;
 	uint64_t uniformMask;
 	std::string errorString;
-	if (!GenerateVertexShader(VSID, codeBuffer_, draw_->GetShaderLanguageDesc(), draw_->GetBugs(), &attrMask, &uniformMask, &errorString)) {
+	if (!GenerateVertexShader(VSID, codeBuffer_, draw_->GetShaderLanguageDesc(), draw_->GetBugs(), &attrMask, &uniformMask, nullptr, &errorString)) {
 		ERROR_LOG(G3D, "Shader gen error: %s", errorString.c_str());
 		return nullptr;
 	}

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -158,7 +158,7 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 				// fboTexNeedsBind_ won't be set if we can read directly from the target.
 				if (fboTexBindState == FBO_TEX_COPY_BIND_TEX) {
 					// Note that this is positions, not UVs, that we need the copy from.
-					framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY);
+					framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY, 0);
 					// If we are rendering at a higher resolution, linear is probably best for the dest color.
 					renderManager->SetTextureSampler(1, GL_CLAMP_TO_EDGE, GL_CLAMP_TO_EDGE, GL_LINEAR, GL_LINEAR, 0.0f);
 					fboTexBound_ = true;

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -652,6 +652,26 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </None>
+    <None Include="..\assets\shaders\stereo_red_blue.fsh">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </None>
+    <None Include="..\assets\shaders\stereo_sbs.fsh">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </None>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -534,5 +534,11 @@
     <None Include="..\assets\shaders\defaultshaders.ini">
       <Filter>Shaders</Filter>
     </None>
+    <None Include="..\assets\shaders\stereo_red_blue.fsh">
+      <Filter>Shaders</Filter>
+    </None>
+    <None Include="..\assets\shaders\stereo_sbs.fsh">
+      <Filter>Shaders</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -583,6 +583,7 @@ struct GPUStateCache {
 
 	bool bgraTexture;
 	bool needShaderTexClamp;
+	bool arrayTexture;
 
 	float morphWeights[8];
 	u32 deferredVertTypeDirty;

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -562,6 +562,12 @@ struct GPUStateCache {
 			Dirty(DIRTY_FRAGMENTSHADER_STATE | (is3D ? DIRTY_MIPBIAS : 0));
 		}
 	}
+	void SetTextureIsArray(bool isArrayTexture) {  // VK only
+		if (arrayTexture != isArrayTexture) {
+			arrayTexture = isArrayTexture;
+			Dirty(DIRTY_FRAGMENTSHADER_STATE);
+		}
+	}
 
 	u32 useFlags;
 

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -618,7 +618,7 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 		u1 = 1.0f;
 	}
 	if (!hasImage) {
-		draw_->BindFramebufferAsRenderTarget(nullptr, 0, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "CopyToCurrentFboFromDisplayRam");
+		draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "CopyToCurrentFboFromDisplayRam");
 		return;
 	}
 

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -618,7 +618,7 @@ void SoftGPU::CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight) {
 		u1 = 1.0f;
 	}
 	if (!hasImage) {
-		draw_->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "CopyToCurrentFboFromDisplayRam");
+		draw_->BindFramebufferAsRenderTarget(nullptr, 0, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "CopyToCurrentFboFromDisplayRam");
 		return;
 	}
 

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -404,7 +404,7 @@ VkDescriptorSet DrawEngineVulkan::GetOrCreateDescriptorSet(VkImageView imageView
 
 	// Didn't find one in the frame descriptor set cache, let's make a new one.
 	// We wipe the cache on every frame.
-	VkDescriptorSet desc = frame.descPool.Allocate(1, &descriptorSetLayout_);
+	VkDescriptorSet desc = frame.descPool.Allocate(1, &descriptorSetLayout_, "game_descset");
 
 	// Even in release mode, this is bad.
 	_assert_msg_(desc != VK_NULL_HANDLE, "Ran out of descriptor space in pool. sz=%d", (int)frame.descSets.size());

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -42,6 +42,7 @@
 #include "GPU/Common/VertexDecoderCommon.h"
 #include "GPU/Common/SoftwareTransformCommon.h"
 #include "GPU/Common/DrawEngineCommon.h"
+#include "GPU/Common/ShaderUniforms.h"
 #include "GPU/Debugger/Debugger.h"
 #include "GPU/Vulkan/DrawEngineVulkan.h"
 #include "GPU/Vulkan/TextureCacheVulkan.h"
@@ -184,8 +185,9 @@ void DrawEngineVulkan::InitDeviceObjects() {
 	VkPipelineLayoutCreateInfo pl{ VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
 	pl.pPushConstantRanges = nullptr;
 	pl.pushConstantRangeCount = 0;
-	pl.setLayoutCount = 1;
-	pl.pSetLayouts = &descriptorSetLayout_;
+	VkDescriptorSetLayout layouts[1] = { descriptorSetLayout_ };
+	pl.setLayoutCount = ARRAY_SIZE(layouts);
+	pl.pSetLayouts = layouts;
 	pl.flags = 0;
 	res = vkCreatePipelineLayout(device, &pl, nullptr, &pipelineLayout_);
 	_dbg_assert_(VK_SUCCESS == res);
@@ -303,6 +305,7 @@ void DrawEngineVulkan::BeginFrame() {
 	frame->pushIndex->Reset();
 
 	VulkanContext *vulkan = (VulkanContext *)draw_->GetNativeObject(Draw::NativeObject::CONTEXT);
+
 	frame->pushUBO->Begin(vulkan);
 	frame->pushVertex->Begin(vulkan);
 	frame->pushIndex->Begin(vulkan);

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -582,10 +582,6 @@ void DrawEngineVulkan::DoFlush() {
 	// Always use software for flat shading to fix the provoking index.
 	bool useHWTransform = CanUseHardwareTransform(prim) && (tess || gstate.getShadeMode() != GE_SHADE_FLAT);
 
-	VulkanVertexShader *vshader = nullptr;
-	VulkanFragmentShader *fshader = nullptr;
-	VulkanGeometryShader *gshader = nullptr;
-
 	uint32_t ibOffset;
 	uint32_t vbOffset;
 	
@@ -779,6 +775,10 @@ void DrawEngineVulkan::DoFlush() {
 				ConvertStateToVulkanKey(*framebufferManager_, shaderManager_, prim, pipelineKey_, dynState_);
 			}
 
+			VulkanVertexShader *vshader = nullptr;
+			VulkanFragmentShader *fshader = nullptr;
+			VulkanGeometryShader *gshader = nullptr;
+
 			shaderManager_->GetShaders(prim, lastVType_, &vshader, &fshader, &gshader, pipelineState_, true, useHWTessellation_, decOptions_.expandAllWeightsToFloat);  // usehwtransform
 			if (!vshader) {
 				// We're screwed.
@@ -909,6 +909,11 @@ void DrawEngineVulkan::DoFlush() {
 				if (prim != lastPrim_ || gstate_c.IsDirty(DIRTY_BLEND_STATE | DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_RASTER_STATE | DIRTY_DEPTHSTENCIL_STATE)) {
 					ConvertStateToVulkanKey(*framebufferManager_, shaderManager_, prim, pipelineKey_, dynState_);
 				}
+
+				VulkanVertexShader *vshader = nullptr;
+				VulkanFragmentShader *fshader = nullptr;
+				VulkanGeometryShader *gshader = nullptr;
+
 				shaderManager_->GetShaders(prim, lastVType_, &vshader, &fshader, &gshader, pipelineState_, false, false, decOptions_.expandAllWeightsToFloat);  // usehwtransform
 				_dbg_assert_msg_(!vshader->UseHWTransform(), "Bad vshader");
 				VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(renderManager, pipelineLayout_, pipelineKey_, &dec_->decFmt, vshader, fshader, gshader, false, 0);

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -211,8 +211,9 @@ private:
 
 	Draw::DrawContext *draw_;
 
-	// We use a single descriptor set layout for all PSP draws.
+	// We use a shared descriptor set layout for all PSP draws.
 	VkDescriptorSetLayout descriptorSetLayout_;
+
 	VkPipelineLayout pipelineLayout_;
 	VulkanPipeline *lastPipeline_;
 	VkDescriptorSet lastDs_ = VK_NULL_HANDLE;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -340,14 +340,11 @@ void GPU_Vulkan::BuildReportingInfo() {
 	const auto &available = vulkan->GetDeviceFeatures().available;
 
 #define CHECK_BOOL_FEATURE(n) do { if (available.standard.n) { featureNames += ", " #n; } } while (false)
+#define CHECK_BOOL_FEATURE_MULTIVIEW(n) do { if (available.multiview.n) { featureNames += ", " #n; } } while (false)
 
 	std::string featureNames = "";
-	CHECK_BOOL_FEATURE(robustBufferAccess);
 	CHECK_BOOL_FEATURE(fullDrawIndexUint32);
-	CHECK_BOOL_FEATURE(imageCubeArray);
-	CHECK_BOOL_FEATURE(independentBlend);
 	CHECK_BOOL_FEATURE(geometryShader);
-	CHECK_BOOL_FEATURE(tessellationShader);
 	CHECK_BOOL_FEATURE(sampleRateShading);
 	CHECK_BOOL_FEATURE(dualSrcBlend);
 	CHECK_BOOL_FEATURE(logicOp);
@@ -355,46 +352,23 @@ void GPU_Vulkan::BuildReportingInfo() {
 	CHECK_BOOL_FEATURE(drawIndirectFirstInstance);
 	CHECK_BOOL_FEATURE(depthClamp);
 	CHECK_BOOL_FEATURE(depthBiasClamp);
-	CHECK_BOOL_FEATURE(fillModeNonSolid);
 	CHECK_BOOL_FEATURE(depthBounds);
-	CHECK_BOOL_FEATURE(alphaToOne);
-	CHECK_BOOL_FEATURE(multiViewport);
 	CHECK_BOOL_FEATURE(samplerAnisotropy);
 	CHECK_BOOL_FEATURE(textureCompressionETC2);
 	CHECK_BOOL_FEATURE(textureCompressionASTC_LDR);
 	CHECK_BOOL_FEATURE(textureCompressionBC);
 	CHECK_BOOL_FEATURE(occlusionQueryPrecise);
 	CHECK_BOOL_FEATURE(pipelineStatisticsQuery);
-	CHECK_BOOL_FEATURE(vertexPipelineStoresAndAtomics);
 	CHECK_BOOL_FEATURE(fragmentStoresAndAtomics);
 	CHECK_BOOL_FEATURE(shaderTessellationAndGeometryPointSize);
-	CHECK_BOOL_FEATURE(shaderImageGatherExtended);
-	CHECK_BOOL_FEATURE(shaderStorageImageExtendedFormats);
 	CHECK_BOOL_FEATURE(shaderStorageImageMultisample);
-	CHECK_BOOL_FEATURE(shaderStorageImageReadWithoutFormat);
-	CHECK_BOOL_FEATURE(shaderStorageImageWriteWithoutFormat);
-	CHECK_BOOL_FEATURE(shaderUniformBufferArrayDynamicIndexing);
 	CHECK_BOOL_FEATURE(shaderSampledImageArrayDynamicIndexing);
-	CHECK_BOOL_FEATURE(shaderStorageBufferArrayDynamicIndexing);
-	CHECK_BOOL_FEATURE(shaderStorageImageArrayDynamicIndexing);
 	CHECK_BOOL_FEATURE(shaderClipDistance);
 	CHECK_BOOL_FEATURE(shaderCullDistance);
-	CHECK_BOOL_FEATURE(shaderFloat64);
 	CHECK_BOOL_FEATURE(shaderInt64);
 	CHECK_BOOL_FEATURE(shaderInt16);
-	CHECK_BOOL_FEATURE(shaderResourceResidency);
-	CHECK_BOOL_FEATURE(shaderResourceMinLod);
-	CHECK_BOOL_FEATURE(sparseBinding);
-	CHECK_BOOL_FEATURE(sparseResidencyBuffer);
-	CHECK_BOOL_FEATURE(sparseResidencyImage2D);
-	CHECK_BOOL_FEATURE(sparseResidencyImage3D);
-	CHECK_BOOL_FEATURE(sparseResidency2Samples);
-	CHECK_BOOL_FEATURE(sparseResidency4Samples);
-	CHECK_BOOL_FEATURE(sparseResidency8Samples);
-	CHECK_BOOL_FEATURE(sparseResidency16Samples);
-	CHECK_BOOL_FEATURE(sparseResidencyAliased);
-	CHECK_BOOL_FEATURE(variableMultisampleRate);
-	CHECK_BOOL_FEATURE(inheritedQueries);
+	CHECK_BOOL_FEATURE_MULTIVIEW(multiview);
+	CHECK_BOOL_FEATURE_MULTIVIEW(multiviewGeometryShader);
 
 #undef CHECK_BOOL_FEATURE
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -268,12 +268,13 @@ u32 GPU_Vulkan::CheckGPUFeatures() const {
 		features |= GPU_ROUND_DEPTH_TO_16BIT;
 	}
 
-	if (g_Config.bStereoRendering) {
+	if (g_Config.bStereoRendering && draw_->GetDeviceCaps().multiViewSupported) {
 		features |= GPU_USE_SINGLE_PASS_STEREO;
+		features |= GPU_USE_SIMPLE_STEREO_PERSPECTIVE;
+
 		features &= ~GPU_USE_FRAMEBUFFER_FETCH;  // Need to figure out if this can be supported with multiview rendering
 		if (features & GPU_USE_GS_CULLING) {
 			// Many devices that support stereo and GS don't support GS during stereo.
-			// So we revert back to VS range culling.
 			features &= ~GPU_USE_GS_CULLING;
 			features |= GPU_USE_VS_RANGE_CULLING;
 		}

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -268,9 +268,15 @@ u32 GPU_Vulkan::CheckGPUFeatures() const {
 		features |= GPU_ROUND_DEPTH_TO_16BIT;
 	}
 
-	if (true) {
+	if (g_Config.bStereoRendering) {
 		features |= GPU_USE_SINGLE_PASS_STEREO;
 		features &= ~GPU_USE_FRAMEBUFFER_FETCH;  // Need to figure out if this can be supported with multiview rendering
+		if (features & GPU_USE_GS_CULLING) {
+			// Many devices that support stereo and GS don't support GS during stereo.
+			// So we revert back to VS range culling.
+			features &= ~GPU_USE_GS_CULLING;
+			features |= GPU_USE_VS_RANGE_CULLING;
+		}
 	}
 
 	return features;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -268,6 +268,11 @@ u32 GPU_Vulkan::CheckGPUFeatures() const {
 		features |= GPU_ROUND_DEPTH_TO_16BIT;
 	}
 
+	if (true) {
+		features |= GPU_USE_SINGLE_PASS_STEREO;
+		features &= ~GPU_USE_FRAMEBUFFER_FETCH;  // Need to figure out if this can be supported with multiview rendering
+	}
+
 	return features;
 }
 

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -12,6 +12,7 @@
 #include "GPU/Vulkan/PipelineManagerVulkan.h"
 #include "GPU/Vulkan/ShaderManagerVulkan.h"
 #include "GPU/Common/DrawEngineCommon.h"
+#include "GPU/Common/ShaderId.h"
 #include "Common/GPU/thin3d.h"
 #include "Common/GPU/Vulkan/VulkanRenderManager.h"
 #include "Common/GPU/Vulkan/VulkanQueueRunner.h"
@@ -296,7 +297,12 @@ static VulkanPipeline *CreateVulkanPipeline(VulkanRenderManager *renderManager, 
 
 	desc->pipelineLayout = layout;
 
-	VKRGraphicsPipeline *pipeline = renderManager->CreateGraphicsPipeline(desc, pipelineFlags, variantBitmask, "game");
+	std::string tag = "game";
+#ifdef _DEBUG
+	tag = FragmentShaderDesc(fs->GetID()) + " VS " + VertexShaderDesc(vs->GetID());
+#endif
+
+	VKRGraphicsPipeline *pipeline = renderManager->CreateGraphicsPipeline(desc, pipelineFlags, variantBitmask, tag.c_str());
 
 	vulkanPipeline->pipeline = pipeline;
 	if (useBlendConstant) {

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -336,6 +336,9 @@ VulkanPipeline *PipelineManagerVulkan::GetOrCreatePipeline(VulkanRenderManager *
 	if (fs->Flags() & FragmentShaderFlags::INPUT_ATTACHMENT) {
 		pipelineFlags |= PipelineFlags::USES_INPUT_ATTACHMENT;
 	}
+	if (vs->Flags() & VertexShaderFlags::MULTI_VIEW) {
+		pipelineFlags |= PipelineFlags::USES_MULTIVIEW;
+	}
 
 	VulkanPipeline *pipeline = CreateVulkanPipeline(
 		renderManager, pipelineCache_, layout, pipelineFlags,

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -135,8 +135,8 @@ std::string VulkanFragmentShader::GetShaderString(DebugShaderStringType type) co
 	}
 }
 
-VulkanVertexShader::VulkanVertexShader(VulkanContext *vulkan, VShaderID id, const char *code, bool useHWTransform)
-	: vulkan_(vulkan), useHWTransform_(useHWTransform), id_(id) {
+VulkanVertexShader::VulkanVertexShader(VulkanContext *vulkan, VShaderID id, VertexShaderFlags flags, const char *code, bool useHWTransform)
+	: vulkan_(vulkan), useHWTransform_(useHWTransform), flags_(flags), id_(id) {
 	source_ = code;
 	module_ = CompileShaderModuleAsync(vulkan, VK_SHADER_STAGE_VERTEX_BIT, source_.c_str(), new std::string(VertexShaderDesc(id)));
 	if (!module_) {
@@ -331,10 +331,11 @@ void ShaderManagerVulkan::GetShaders(int prim, u32 vertType, VulkanVertexShader 
 		std::string genErrorString;
 		uint64_t uniformMask = 0;  // Not used
 		uint32_t attributeMask = 0;  // Not used
-		bool success = GenerateVertexShader(VSID, codeBuffer_, compat_, draw_->GetBugs(), &attributeMask, &uniformMask, &genErrorString);
+		VertexShaderFlags flags{};
+		bool success = GenerateVertexShader(VSID, codeBuffer_, compat_, draw_->GetBugs(), &attributeMask, &uniformMask, &flags, &genErrorString);
 		_assert_msg_(success, "VS gen error: %s", genErrorString.c_str());
 		_assert_msg_(strlen(codeBuffer_) < CODE_BUFFER_SIZE, "VS length error: %d", (int)strlen(codeBuffer_));
-		vs = new VulkanVertexShader(vulkan, VSID, codeBuffer_, useHWTransform);
+		vs = new VulkanVertexShader(vulkan, VSID, flags, codeBuffer_, useHWTransform);
 		vsCache_.Insert(VSID, vs);
 	}
 
@@ -343,7 +344,7 @@ void ShaderManagerVulkan::GetShaders(int prim, u32 vertType, VulkanVertexShader 
 		// Fragment shader not in cache. Let's compile it.
 		std::string genErrorString;
 		uint64_t uniformMask = 0;  // Not used
-		FragmentShaderFlags flags;
+		FragmentShaderFlags flags{};
 		bool success = GenerateFragmentShader(FSID, codeBuffer_, compat_, draw_->GetBugs(), &uniformMask, &flags, &genErrorString);
 		_assert_msg_(success, "FS gen error: %s", genErrorString.c_str());
 		_assert_msg_(strlen(codeBuffer_) < CODE_BUFFER_SIZE, "FS length error: %d", (int)strlen(codeBuffer_));
@@ -515,11 +516,12 @@ bool ShaderManagerVulkan::LoadCache(FILE *f) {
 		std::string genErrorString;
 		uint32_t attributeMask = 0;
 		uint64_t uniformMask = 0;
-		if (!GenerateVertexShader(id, codeBuffer_, compat_, draw_->GetBugs(), &attributeMask, &uniformMask, &genErrorString)) {
+		VertexShaderFlags flags;
+		if (!GenerateVertexShader(id, codeBuffer_, compat_, draw_->GetBugs(), &attributeMask, &uniformMask, &flags, &genErrorString)) {
 			return false;
 		}
 		_assert_msg_(strlen(codeBuffer_) < CODE_BUFFER_SIZE, "VS length error: %d", (int)strlen(codeBuffer_));
-		VulkanVertexShader *vs = new VulkanVertexShader(vulkan, id, codeBuffer_, useHWTransform);
+		VulkanVertexShader *vs = new VulkanVertexShader(vulkan, id, flags, codeBuffer_, useHWTransform);
 		vsCache_.Insert(id, vs);
 	}
 	uint32_t vendorID = vulkan->GetPhysicalDeviceProperties().properties.vendorID;

--- a/GPU/Vulkan/ShaderManagerVulkan.h
+++ b/GPU/Vulkan/ShaderManagerVulkan.h
@@ -61,13 +61,14 @@ protected:
 
 class VulkanVertexShader {
 public:
-	VulkanVertexShader(VulkanContext *vulkan, VShaderID id, const char *code, bool useHWTransform);
+	VulkanVertexShader(VulkanContext *vulkan, VShaderID id, VertexShaderFlags flags, const char *code, bool useHWTransform);
 	~VulkanVertexShader();
 
 	const std::string &source() const { return source_; }
 
 	bool Failed() const { return failed_; }
-	bool UseHWTransform() const { return useHWTransform_; }
+	bool UseHWTransform() const { return useHWTransform_; }  // TODO: Roll into flags
+	VertexShaderFlags Flags() const { return flags_; }
 
 	std::string GetShaderString(DebugShaderStringType type) const;
 	Promise<VkShaderModule> *GetModule() { return module_; }
@@ -81,6 +82,7 @@ protected:
 	bool failed_ = false;
 	bool useHWTransform_;
 	VShaderID id_;
+	VertexShaderFlags flags_;
 };
 
 class VulkanGeometryShader {

--- a/GPU/Vulkan/StateMappingVulkan.cpp
+++ b/GPU/Vulkan/StateMappingVulkan.cpp
@@ -365,7 +365,7 @@ void DrawEngineVulkan::BindShaderBlendTex() {
 	// Set the nearest/linear here (since we correctly know if alpha/color tests are needed)?
 	if (!gstate.isModeClear()) {
 		if (fboTexBindState_ == FBO_TEX_COPY_BIND_TEX) {
-			bool bindResult = framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY);
+			bool bindResult = framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY, Draw::ALL_LAYERS);
 			_dbg_assert_(bindResult);
 			boundSecondary_ = (VkImageView)draw_->GetNativeObject(Draw::NativeObject::BOUND_TEXTURE1_IMAGEVIEW);
 			boundSecondaryIsInputAttachment_ = false;

--- a/GPU/Vulkan/StateMappingVulkan.cpp
+++ b/GPU/Vulkan/StateMappingVulkan.cpp
@@ -365,7 +365,8 @@ void DrawEngineVulkan::BindShaderBlendTex() {
 	// Set the nearest/linear here (since we correctly know if alpha/color tests are needed)?
 	if (!gstate.isModeClear()) {
 		if (fboTexBindState_ == FBO_TEX_COPY_BIND_TEX) {
-			bool bindResult = framebufferManager_->BindFramebufferAsColorTexture(1, framebufferManager_->GetCurrentRenderVFB(), BINDFBCOLOR_MAY_COPY, Draw::ALL_LAYERS);
+			VirtualFramebuffer *curRenderVfb = framebufferManager_->GetCurrentRenderVFB();
+			bool bindResult = framebufferManager_->BindFramebufferAsColorTexture(1, curRenderVfb, BINDFBCOLOR_MAY_COPY, Draw::ALL_LAYERS);
 			_dbg_assert_(bindResult);
 			boundSecondary_ = (VkImageView)draw_->GetNativeObject(Draw::NativeObject::BOUND_TEXTURE1_IMAGEVIEW);
 			boundSecondaryIsInputAttachment_ = false;
@@ -376,7 +377,7 @@ void DrawEngineVulkan::BindShaderBlendTex() {
 			dirtyRequiresRecheck_ |= DIRTY_BLEND_STATE;
 		} else if (fboTexBindState_ == FBO_TEX_READ_FRAMEBUFFER) {
 			draw_->BindCurrentFramebufferForColorInput();
-			boundSecondary_ = (VkImageView)draw_->GetNativeObject(Draw::NativeObject::BOUND_FRAMEBUFFER_COLOR_IMAGEVIEW);
+			boundSecondary_ = (VkImageView)draw_->GetNativeObject(Draw::NativeObject::BOUND_FRAMEBUFFER_COLOR_IMAGEVIEW_LAYER, (void *)0);
 			boundSecondaryIsInputAttachment_ = true;
 			fboTexBindState_ = FBO_TEX_NONE;
 		} else {

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -846,6 +846,6 @@ std::string TextureCacheVulkan::DebugGetSamplerString(std::string id, DebugShade
 }
 
 void *TextureCacheVulkan::GetNativeTextureView(const TexCacheEntry *entry) {
-	VkImageView view = entry->vkTex->GetImageView();
+	VkImageView view = entry->vkTex->GetImageArrayView();
 	return (void *)view;
 }

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -136,7 +136,7 @@ void VulkanComputeShaderManager::DestroyDeviceObjects() {
 VkDescriptorSet VulkanComputeShaderManager::GetDescriptorSet(VkImageView image, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize range, VkBuffer buffer2, VkDeviceSize offset2, VkDeviceSize range2) {
 	int curFrame = vulkan_->GetCurFrame();
 	FrameData &frameData = frameData_[curFrame];
-	VkDescriptorSet desc = frameData.descPool.Allocate(1, &descriptorSetLayout_);
+	VkDescriptorSet desc = frameData.descPool.Allocate(1, &descriptorSetLayout_, "compute_descset");
 	_assert_(desc != VK_NULL_HANDLE);
 
 	VkWriteDescriptorSet writes[2]{};

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1359,9 +1359,9 @@ void EmuScreen::preRender() {
 	if ((!useBufferedRendering && !g_Config.bSoftwareRendering) || Core_IsStepping()) {
 		// We need to clear here already so that drawing during the frame is done on a clean slate.
 		if (Core_IsStepping() && gpuStats.numFlips != 0) {
-			draw->BindFramebufferAsRenderTarget(nullptr, 0, { RPAction::KEEP, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_BackBuffer");
+			draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::KEEP, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_BackBuffer");
 		} else {
-			draw->BindFramebufferAsRenderTarget(nullptr, 0, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, 0xFF000000 }, "EmuScreen_BackBuffer");
+			draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, 0xFF000000 }, "EmuScreen_BackBuffer");
 		}
 
 		Viewport viewport;
@@ -1400,7 +1400,7 @@ void EmuScreen::render() {
 		// It's possible this might be set outside PSP_RunLoopFor().
 		// In this case, we need to double check it here.
 		checkPowerDown();
-		thin3d->BindFramebufferAsRenderTarget(nullptr, 0, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR }, "EmuScreen_Invalid");
+		thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR }, "EmuScreen_Invalid");
 		renderUI();
 		return;
 	}
@@ -1439,12 +1439,12 @@ void EmuScreen::render() {
 			// Clear to blue background screen
 			bool dangerousSettings = !Reporting::IsSupported();
 			uint32_t color = dangerousSettings ? 0xFF900050 : 0xFF900000;
-			thin3d->BindFramebufferAsRenderTarget(nullptr, 0, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE, color }, "EmuScreen_RuntimeError");
+			thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE, color }, "EmuScreen_RuntimeError");
 			// The info is drawn later in renderUI
 		} else {
 			// If we're stepping, it's convenient not to clear the screen entirely, so we copy display to output.
 			// This won't work in non-buffered, but that's fine.
-			thin3d->BindFramebufferAsRenderTarget(nullptr, 0, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_Stepping");
+			thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_Stepping");
 			// Just to make sure.
 			if (PSP_IsInited()) {
 				gpu->CopyDisplayToOutput(true);
@@ -1456,7 +1456,7 @@ void EmuScreen::render() {
 		// Didn't actually reach the end of the frame, ran out of the blockTicks cycles.
 		// In this case we need to bind and wipe the backbuffer, at least.
 		// It's possible we never ended up outputted anything - make sure we have the backbuffer cleared
-		thin3d->BindFramebufferAsRenderTarget(nullptr, 0, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR }, "EmuScreen_NoFrame");
+		thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR }, "EmuScreen_NoFrame");
 		break;
 	}
 
@@ -1470,7 +1470,7 @@ void EmuScreen::render() {
 
 	if (hasVisibleUI()) {
 		// In most cases, this should already be bound and a no-op.
-		thin3d->BindFramebufferAsRenderTarget(nullptr, 0, { RPAction::KEEP, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_UI");
+		thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::KEEP, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_UI");
 		cardboardDisableButton_->SetVisibility(g_Config.bEnableCardboardVR ? UI::V_VISIBLE : UI::V_GONE);
 		screenManager()->getUIContext()->BeginFrame();
 		renderUI();

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1359,9 +1359,9 @@ void EmuScreen::preRender() {
 	if ((!useBufferedRendering && !g_Config.bSoftwareRendering) || Core_IsStepping()) {
 		// We need to clear here already so that drawing during the frame is done on a clean slate.
 		if (Core_IsStepping() && gpuStats.numFlips != 0) {
-			draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::KEEP, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_BackBuffer");
+			draw->BindFramebufferAsRenderTarget(nullptr, 0, { RPAction::KEEP, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_BackBuffer");
 		} else {
-			draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, 0xFF000000 }, "EmuScreen_BackBuffer");
+			draw->BindFramebufferAsRenderTarget(nullptr, 0, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, 0xFF000000 }, "EmuScreen_BackBuffer");
 		}
 
 		Viewport viewport;
@@ -1400,7 +1400,7 @@ void EmuScreen::render() {
 		// It's possible this might be set outside PSP_RunLoopFor().
 		// In this case, we need to double check it here.
 		checkPowerDown();
-		thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR }, "EmuScreen_Invalid");
+		thin3d->BindFramebufferAsRenderTarget(nullptr, 0, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR }, "EmuScreen_Invalid");
 		renderUI();
 		return;
 	}
@@ -1439,12 +1439,12 @@ void EmuScreen::render() {
 			// Clear to blue background screen
 			bool dangerousSettings = !Reporting::IsSupported();
 			uint32_t color = dangerousSettings ? 0xFF900050 : 0xFF900000;
-			thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE, color }, "EmuScreen_RuntimeError");
+			thin3d->BindFramebufferAsRenderTarget(nullptr, 0, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE, color }, "EmuScreen_RuntimeError");
 			// The info is drawn later in renderUI
 		} else {
 			// If we're stepping, it's convenient not to clear the screen entirely, so we copy display to output.
 			// This won't work in non-buffered, but that's fine.
-			thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_Stepping");
+			thin3d->BindFramebufferAsRenderTarget(nullptr, 0, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_Stepping");
 			// Just to make sure.
 			if (PSP_IsInited()) {
 				gpu->CopyDisplayToOutput(true);
@@ -1456,7 +1456,7 @@ void EmuScreen::render() {
 		// Didn't actually reach the end of the frame, ran out of the blockTicks cycles.
 		// In this case we need to bind and wipe the backbuffer, at least.
 		// It's possible we never ended up outputted anything - make sure we have the backbuffer cleared
-		thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR }, "EmuScreen_NoFrame");
+		thin3d->BindFramebufferAsRenderTarget(nullptr, 0, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR }, "EmuScreen_NoFrame");
 		break;
 	}
 
@@ -1470,7 +1470,7 @@ void EmuScreen::render() {
 
 	if (hasVisibleUI()) {
 		// In most cases, this should already be bound and a no-op.
-		thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::KEEP, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_UI");
+		thin3d->BindFramebufferAsRenderTarget(nullptr, 0, { RPAction::KEEP, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_UI");
 		cardboardDisableButton_->SetVisibility(g_Config.bEnableCardboardVR ? UI::V_VISIBLE : UI::V_GONE);
 		screenManager()->getUIContext()->BeginFrame();
 		renderUI();

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -364,6 +364,19 @@ void GameSettingsScreen::CreateViews() {
 			screenManager()->push(procScreen);
 			return UI::EVENT_DONE;
 		});
+		const ShaderInfo *shaderInfo = GetPostShaderInfo(g_Config.sStereoToMonoShader);
+		if (shaderInfo) {
+			for (size_t i = 0; i < ARRAY_SIZE(shaderInfo->settings); ++i) {
+				auto &setting = shaderInfo->settings[i];
+				if (!setting.name.empty()) {
+					auto &value = g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderInfo->section.c_str(), i + 1)];
+					PopupSliderChoiceFloat *settingValue = graphicsSettings->Add(new PopupSliderChoiceFloat(&value, setting.minValue, setting.maxValue, ps->T(setting.name), setting.step, screenManager()));
+					settingValue->SetEnabledFunc([] {
+						return g_Config.iRenderingMode != FB_NON_BUFFERED_MODE && g_Config.bStereoRendering;
+					});
+				}
+			}
+		}
 	}
 
 	std::set<std::string> alreadyAddedShader;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -350,17 +350,18 @@ void GameSettingsScreen::CreateViews() {
 
 	graphicsSettings->Add(new ItemHeader(gr->T("Postprocessing effect")));
 
-	enableStereo_ = g_Config.bStereoRendering && draw->GetDeviceCaps().multiViewSupported;
+	bool multiViewSupported = draw->GetDeviceCaps().multiViewSupported;
+
+	auto enableStereo = [=]() -> bool {
+		return g_Config.bStereoRendering && multiViewSupported;
+	};
 
 	if (draw->GetDeviceCaps().multiViewSupported) {
-		graphicsSettings->Add(new CheckBox(&g_Config.bStereoRendering, gr->T("Stereo rendering")))->OnClick.Add([&](UI::EventParams &) -> UI::EventReturn {
-			enableStereo_ = g_Config.bStereoRendering && draw->GetDeviceCaps().multiViewSupported;
-			return UI::EVENT_DONE;
-		});
+		graphicsSettings->Add(new CheckBox(&g_Config.bStereoRendering, gr->T("Stereo rendering")));
 		std::vector<std::string> stereoShaderNames;
 
 		ChoiceWithValueDisplay *stereoShaderChoice = graphicsSettings->Add(new ChoiceWithValueDisplay(&g_Config.sStereoToMonoShader, "Stereo display shader", &PostShaderTranslateName));
-		stereoShaderChoice->SetEnabledPtr(&enableStereo_);
+		stereoShaderChoice->SetEnabledFunc(enableStereo);
 		stereoShaderChoice->OnClick.Add([=](EventParams &e) {
 			auto gr = GetI18NCategory("Graphics");
 			auto procScreen = new PostProcScreen(gr->T("Stereo display shader"), 0, true);
@@ -377,7 +378,7 @@ void GameSettingsScreen::CreateViews() {
 					auto &value = g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderInfo->section.c_str(), i + 1)];
 					PopupSliderChoiceFloat *settingValue = graphicsSettings->Add(new PopupSliderChoiceFloat(&value, setting.minValue, setting.maxValue, ps->T(setting.name), setting.step, screenManager()));
 					settingValue->SetEnabledFunc([&] {
-						return g_Config.iRenderingMode != FB_NON_BUFFERED_MODE && enableStereo_;
+						return g_Config.iRenderingMode != FB_NON_BUFFERED_MODE && enableStereo();
 					});
 				}
 			}
@@ -399,7 +400,7 @@ void GameSettingsScreen::CreateViews() {
 			return UI::EVENT_DONE;
 		});
 		postProcChoice_->SetEnabledFunc([&] {
-			return g_Config.iRenderingMode != FB_NON_BUFFERED_MODE && !enableStereo_;
+			return g_Config.iRenderingMode != FB_NON_BUFFERED_MODE && !enableStereo();
 		});
 
 		// No need for settings on the last one.
@@ -422,7 +423,7 @@ void GameSettingsScreen::CreateViews() {
 					} else {
 						PopupSliderChoiceFloat *settingValue = graphicsSettings->Add(new PopupSliderChoiceFloat(&value, setting.minValue, setting.maxValue, ps->T(setting.name), setting.step, screenManager()));
 						settingValue->SetEnabledFunc([&] {
-							return g_Config.iRenderingMode != FB_NON_BUFFERED_MODE && !enableStereo_;
+							return g_Config.iRenderingMode != FB_NON_BUFFERED_MODE && !enableStereo();
 						});
 					}
 				}

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -142,6 +142,8 @@ private:
 	bool enableReports_ = false;
 	bool enableReportsSet_ = false;
 	bool analogSpeedMapped_ = false;
+	bool enableStereo_ = false;
+
 	std::string shaderNames_[256];
 	std::string searchFilter_;
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -142,7 +142,6 @@ private:
 	bool enableReports_ = false;
 	bool enableReportsSet_ = false;
 	bool analogSpeedMapped_ = false;
-	bool enableStereo_ = false;
 
 	std::string shaderNames_[256];
 	std::string searchFilter_;

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -521,7 +521,7 @@ void PromptScreen::TriggerFinish(DialogResult result) {
 	UIDialogScreenWithBackground::TriggerFinish(result);
 }
 
-PostProcScreen::PostProcScreen(const std::string &title, int id) : ListPopupScreen(title), id_(id) { }
+PostProcScreen::PostProcScreen(const std::string &title, int id, bool showStereoShaders) : ListPopupScreen(title), id_(id), showStereoShaders_(showStereoShaders) { }
 
 void PostProcScreen::CreateViews() {
 	auto ps = GetI18NCategory("PostShaders");
@@ -530,12 +530,16 @@ void PostProcScreen::CreateViews() {
 	std::vector<std::string> items;
 	int selected = -1;
 	const std::string selectedName = id_ >= (int)g_Config.vPostShaderNames.size() ? "Off" : g_Config.vPostShaderNames[id_];
+
 	for (int i = 0; i < (int)shaders_.size(); i++) {
 		if (!shaders_[i].visible)
 			continue;
+		if (shaders_[i].isStereo != showStereoShaders_)
+			continue;
 		if (shaders_[i].section == selectedName)
-			selected = i;
+			selected = (int)indexTranslation_.size();
 		items.push_back(ps->T(shaders_[i].section.c_str(), shaders_[i].name.c_str()));
+		indexTranslation_.push_back(i);
 	}
 	adaptor_ = UI::StringVectorListAdaptor(items, selected);
 	ListPopupScreen::CreateViews();
@@ -544,11 +548,16 @@ void PostProcScreen::CreateViews() {
 void PostProcScreen::OnCompleted(DialogResult result) {
 	if (result != DR_OK)
 		return;
-	const std::string &value = shaders_[listView_->GetSelected()].section;
-	if (id_ < (int)g_Config.vPostShaderNames.size())
-		g_Config.vPostShaderNames[id_] = value;
-	else
-		g_Config.vPostShaderNames.push_back(value);
+	const std::string &value = shaders_[indexTranslation_[listView_->GetSelected()]].section;
+	// I feel this logic belongs more in the caller, but eh...
+	if (showStereoShaders_) {
+		g_Config.sStereoToMonoShader = value;
+	} else {
+		if (id_ < (int)g_Config.vPostShaderNames.size())
+			g_Config.vPostShaderNames[id_] = value;
+		else
+			g_Config.vPostShaderNames.push_back(value);
+	}
 }
 
 TextureShaderScreen::TextureShaderScreen(const std::string &title) : ListPopupScreen(title) {}

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -110,7 +110,7 @@ private:
 
 class PostProcScreen : public ListPopupScreen {
 public:
-	PostProcScreen(const std::string &title, int id);
+	PostProcScreen(const std::string &title, int id, bool showStereoShaders);
 
 	void CreateViews() override;
 
@@ -121,6 +121,8 @@ private:
 	bool ShowButtons() const override { return true; }
 	std::vector<ShaderInfo> shaders_;
 	int id_;
+	bool showStereoShaders_;
+	std::vector<int> indexTranslation_;
 };
 
 class TextureShaderScreen : public ListPopupScreen {

--- a/Windows/PPSSPP.vcxproj
+++ b/Windows/PPSSPP.vcxproj
@@ -1498,6 +1498,7 @@
     <None Include="..\android\jni\Locals.mk" />
     <None Include="..\appveyor.yml" />
     <None Include="..\assets\compat.ini" />
+    <None Include="..\assets\compatvr.ini" />
     <None Include="..\assets\knownfuncs.ini" />
     <None Include="..\assets\langregion.ini" />
     <None Include="..\atlasscript.txt" />

--- a/Windows/PPSSPP.vcxproj.filters
+++ b/Windows/PPSSPP.vcxproj.filters
@@ -711,6 +711,9 @@
     <None Include="..\SDL\buildassets.sh">
       <Filter>Other Platforms\SDL</Filter>
     </None>
+    <None Include="..\assets\compatvr.ini">
+      <Filter>Resource Files</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="ppsspp.rc">

--- a/assets/shaders/defaultshaders.ini
+++ b/assets/shaders/defaultshaders.ini
@@ -193,8 +193,13 @@ Author=Henrik Rydgård
 SettingName1=ColorPreservation
 SettingDefaultValue1=0.5
 SettingMaxValue1=1.0
-SettingMinValue1=1.0
+SettingMinValue1=0.0
 SettingStep1=0.05
+SettingName2=GreenLevel
+SettingDefaultValue2=0.5
+SettingMaxValue2=1.0
+SettingMinValue2=0.0
+SettingStep2=0.05
 Fragment=stereo_red_blue.fsh
 Vertex=fxaa.vsh
 [SideBySize]

--- a/assets/shaders/defaultshaders.ini
+++ b/assets/shaders/defaultshaders.ini
@@ -186,3 +186,20 @@ Name=MMPX (2x)
 Author=Morgan McGuire and Mara Gagiu
 Compute=tex_mmpx.csh
 Scale=2
+[RedBlue]
+Type=StereoToMono
+Name=Red/Blue glasses (anaglyph)
+Author=Henrik Rydgård
+SettingName1=ColorPreservation
+SettingDefaultValue1=0.5
+SettingMaxValue1=1.0
+SettingMinValue1=1.0
+SettingStep1=0.05
+Fragment=stereo_red_blue.fsh
+Vertex=fxaa.vsh
+[SideBySize]
+Type=StereoToMono
+Name=SideBySide Stereo
+Author=Henrik Rydgård
+Fragment=stereo_sbs.fsh
+Vertex=fxaa.vsh

--- a/assets/shaders/stereo_red_blue.fsh
+++ b/assets/shaders/stereo_red_blue.fsh
@@ -8,21 +8,20 @@ varying vec2 v_texcoord0;
 uniform vec4 u_setting;
 
 void main() {
+	float saturation = u_setting.x;
+	float greenMix = u_setting.y;
+
 	// To be adjusted. Used to desaturate colors.
 	vec3 grayDot = vec3(0.35, 0.5, 0.15);
 	// And these are the output color channels.
 	vec3 red = vec3(1.0, 0.0, 0.0);
-	vec3 blue = vec3(0.0, 0.0, 1.0);
-	// We should probably add the ability to tint the blue one between blue and green
-	// to match whatever glasses the user has. Not sure if there's any win to adjusting red.
+	vec3 blue = vec3(0.0, greenMix, 1.0);
 
 	vec3 left = texture(sampler0, vec3(v_texcoord0, 0.0)).xyz;
 	vec3 right = texture(sampler0, vec3(v_texcoord0, 1.0)).xyz;
 
 	float leftGray = dot(left, grayDot);
 	float rightGray = dot(right, grayDot);
-
-	float saturation = u_setting.x;
 
 	vec3 leftColor = mix(vec3(leftGray), left, saturation) * red;
 	vec3 rightColor = mix(vec3(rightGray), right, saturation) * blue;

--- a/assets/shaders/stereo_red_blue.fsh
+++ b/assets/shaders/stereo_red_blue.fsh
@@ -26,8 +26,6 @@ void main() {
 	vec3 leftColor = mix(vec3(leftGray), left, saturation) * red;
 	vec3 rightColor = mix(vec3(rightGray), right, saturation) * blue;
 
-	// TODO: Do something to gamma, maybe?
-
 	gl_FragColor.rgb = leftColor + rightColor;
 	gl_FragColor.a = 1.0;
 }

--- a/assets/shaders/stereo_red_blue.fsh
+++ b/assets/shaders/stereo_red_blue.fsh
@@ -1,0 +1,34 @@
+// Red/Blue glasses stereo, also known as anaglyph.
+//
+// NOTE: Will only be compiled for Vulkan so doesn't follow all the usual conventions.
+
+uniform sampler2DArray sampler0;
+varying vec2 v_texcoord0;
+
+uniform vec4 u_setting;
+
+void main() {
+	// To be adjusted. Used to desaturate colors.
+	vec3 grayDot = vec3(0.35, 0.5, 0.15);
+	// And these are the output color channels.
+	vec3 red = vec3(1.0, 0.0, 0.0);
+	vec3 blue = vec3(0.0, 0.0, 1.0);
+	// We should probably add the ability to tint the blue one between blue and green
+	// to match whatever glasses the user has. Not sure if there's any win to adjusting red.
+
+	vec3 left = texture(sampler0, vec3(v_texcoord0, 0.0)).xyz;
+	vec3 right = texture(sampler0, vec3(v_texcoord0, 1.0)).xyz;
+
+	float leftGray = dot(left, grayDot);
+	float rightGray = dot(right, grayDot);
+
+	float saturation = u_setting.x;
+
+	vec3 leftColor = mix(vec3(leftGray), left, saturation) * red;
+	vec3 rightColor = mix(vec3(rightGray), right, saturation) * blue;
+
+	// TODO: Do something to gamma, maybe?
+
+	gl_FragColor.rgb = leftColor + rightColor;
+	gl_FragColor.a = 1.0;
+}

--- a/assets/shaders/stereo_sbs.fsh
+++ b/assets/shaders/stereo_sbs.fsh
@@ -1,0 +1,18 @@
+// Side by side stereo, useful for old 3D TVs.
+//
+// NOTE: Will only be compiled for Vulkan so doesn't follow all the usual conventions.
+
+uniform sampler2DArray sampler0;
+varying vec2 v_texcoord0;
+
+uniform vec4 u_setting;
+
+void main() {
+	if (v_texcoord0.x < 0.5) {
+	  gl_FragColor.rgb = texture(sampler0, vec3(v_texcoord0.x * 2.0, v_texcoord0.y, 0.0)).xyz;
+	} else {
+	  gl_FragColor.rgb = texture(sampler0, vec3((v_texcoord0.x - 0.5) * 2.0, v_texcoord0.y, 1.0)).xyz;
+	}
+
+	gl_FragColor.a = 1.0;
+}

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -240,7 +240,7 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, const
 	PSP_EndHostFrame();
 
 	if (draw) {
-		draw->BindFramebufferAsRenderTarget(nullptr, 0, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Headless");
+		draw->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Headless");
 		// Vulkan may get angry if we don't do a final present.
 		if (gpu)
 			gpu->CopyDisplayToOutput(true);

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -240,7 +240,7 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, const
 	PSP_EndHostFrame();
 
 	if (draw) {
-		draw->BindFramebufferAsRenderTarget(nullptr, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Headless");
+		draw->BindFramebufferAsRenderTarget(nullptr, 0, { Draw::RPAction::CLEAR, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Headless");
 		// Vulkan may get angry if we don't do a final present.
 		if (gpu)
 			gpu->CopyDisplayToOutput(true);

--- a/unittest/TestShaderGenerators.cpp
+++ b/unittest/TestShaderGenerators.cpp
@@ -28,6 +28,8 @@
 static constexpr size_t CODE_BUFFER_SIZE = 32768;
 
 bool GenerateFShader(FShaderID id, char *buffer, ShaderLanguage lang, Draw::Bugs bugs, std::string *errorString) {
+	buffer[0] = '\0';
+
 	uint64_t uniformMask;
 	switch (lang) {
 	case ShaderLanguage::GLSL_VULKAN:
@@ -61,6 +63,8 @@ bool GenerateFShader(FShaderID id, char *buffer, ShaderLanguage lang, Draw::Bugs
 }
 
 bool GenerateVShader(VShaderID id, char *buffer, ShaderLanguage lang, Draw::Bugs bugs, std::string *errorString) {
+	buffer[0] = '\0';
+
 	uint32_t attrMask;
 	uint64_t uniformMask;
 	switch (lang) {
@@ -95,6 +99,8 @@ bool GenerateVShader(VShaderID id, char *buffer, ShaderLanguage lang, Draw::Bugs
 }
 
 bool GenerateGShader(GShaderID id, char *buffer, ShaderLanguage lang, Draw::Bugs bugs, std::string *errorString) {
+	buffer[0] = '\0';
+
 	errorString->clear();
 
 	switch (lang) {

--- a/unittest/TestShaderGenerators.cpp
+++ b/unittest/TestShaderGenerators.cpp
@@ -67,27 +67,27 @@ bool GenerateVShader(VShaderID id, char *buffer, ShaderLanguage lang, Draw::Bugs
 	case ShaderLanguage::GLSL_VULKAN:
 	{
 		ShaderLanguageDesc compat(ShaderLanguage::GLSL_VULKAN);
-		return GenerateVertexShader(id, buffer, compat, bugs, &attrMask, &uniformMask, errorString);
+		return GenerateVertexShader(id, buffer, compat, bugs, &attrMask, &uniformMask, nullptr, errorString);
 	}
 	case ShaderLanguage::GLSL_1xx:
 	{
 		ShaderLanguageDesc compat(ShaderLanguage::GLSL_1xx);
-		return GenerateVertexShader(id, buffer, compat, bugs, &attrMask, &uniformMask, errorString);
+		return GenerateVertexShader(id, buffer, compat, bugs, &attrMask, &uniformMask, nullptr, errorString);
 	}
 	case ShaderLanguage::GLSL_3xx:
 	{
 		ShaderLanguageDesc compat(ShaderLanguage::GLSL_3xx);
-		return GenerateVertexShader(id, buffer, compat, bugs, &attrMask, &uniformMask, errorString);
+		return GenerateVertexShader(id, buffer, compat, bugs, &attrMask, &uniformMask, nullptr, errorString);
 	}
 	case ShaderLanguage::HLSL_D3D9:
 	{
 		ShaderLanguageDesc compat(ShaderLanguage::HLSL_D3D9);
-		return GenerateVertexShader(id, buffer, compat, bugs, &attrMask, &uniformMask, errorString);
+		return GenerateVertexShader(id, buffer, compat, bugs, &attrMask, &uniformMask, nullptr, errorString);
 	}
 	case ShaderLanguage::HLSL_D3D11:
 	{
 		ShaderLanguageDesc compat(ShaderLanguage::HLSL_D3D11);
-		return GenerateVertexShader(id, buffer, compat, bugs, &attrMask, &uniformMask, errorString);
+		return GenerateVertexShader(id, buffer, compat, bugs, &attrMask, &uniformMask, nullptr, errorString);
 	}
 	default:
 		return false;


### PR DESCRIPTION
VK_KHR_multiview is a very widely supported Vulkan extension that lets you automatically and very efficiently duplicate rendering across layers in a framebuffer, and you get a convenient gl_ViewIndex variable in the shaders so you can customize matrices and so on per view.

Obviously, this is perfect for stereo rendering, such as required by VR. But can also be used for regular old stereo effects like red/blue, and it's easier to start with that, since it can be cleanly debugged with plain Renderdoc and stuff, before hooking up VR stuff. Unfortunately, this does mean that we need to handle multilayer render targets everywhere. It can be mostly abstracted away, but not entirely.

This is not by any means finished yet, but thought people might want a preview so making a draft PR.

There's plenty of work left to do all over the place, most of our shaders like reinterpret and so on are not multiview-aware. They don't really need to be, but in that case they need to loop over the layers.

So right now only games that don't do a lot of fancy framebuffer effects work.

Non-goals:

- Combine stereo with regular post-processing. Could be done, but likely not worth the trouble.

Post-goals (after this is merged):

- Improve the depth distortion function, the Z value we are using makes little sense for many games.
- Make depth distorsion and the zero depth configurable (per-game needed? Likely). This will require adding a couple of uniforms, which we now have space for
- Try to hook up VR with Vulkan using this

![image](https://user-images.githubusercontent.com/130929/197362430-e9b7d18c-f98a-4f2d-af79-0dddb13f2947.png)
