### PR TITLE
softgpu: Better approximate slope mip level mode

### DIFF
--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -332,7 +332,7 @@ static int TexLog2(float delta) {
 	return useful - 127 * 16;
 }
 
-static inline void CalculateSamplingParams(const float ds, const float dt, const RasterizerState &state, int &level, int &levelFrac, bool &filt) {
+static inline void CalculateSamplingParams(const float ds, const float dt, float w, const RasterizerState &state, int &level, int &levelFrac, bool &filt) {
 	const int width = 1 << state.samplerID.width0Shift;
 	const int height = 1 << state.samplerID.height0Shift;
 
@@ -344,7 +344,7 @@ static inline void CalculateSamplingParams(const float ds, const float dt, const
 		break;
 	case GE_TEXLEVEL_MODE_SLOPE:
 		// This is always offset by an extra texlevel.
-		detail = 1 * 16 + TexLog2(state.textureLodSlope);
+		detail = TexLog2(2.0f * w * state.textureLodSlope);
 		break;
 	case GE_TEXLEVEL_MODE_CONST:
 	default:
@@ -377,14 +377,14 @@ static inline void CalculateSamplingParams(const float ds, const float dt, const
 		filt = state.magFilt;
 }
 
-static inline void ApplyTexturing(const RasterizerState &state, Vec4<int> *prim_color, const Vec4<int> &mask, const Vec4<float> &s, const Vec4<float> &t) {
+static inline void ApplyTexturing(const RasterizerState &state, Vec4<int> *prim_color, const Vec4<int> &mask, const Vec4<float> &s, const Vec4<float> &t, float w) {
 	float ds = s[1] - s[0];
 	float dt = t[2] - t[0];
 
 	int level;
 	int levelFrac;
 	bool bilinear;
-	CalculateSamplingParams(ds, dt, state, level, levelFrac, bilinear);
+	CalculateSamplingParams(ds, dt, w, state, level, levelFrac, bilinear);
 
 	PROFILE_THIS_SCOPE("sampler");
 	for (int i = 0; i < 4; ++i) {
@@ -717,7 +717,13 @@ void DrawTriangleSlice(
 						GetTextureCoordinates(v0, v1, v2, w0, w1, w2, wsum_recip, s, t);
 					}
 
-					ApplyTexturing(state, prim_color, mask, s, t);
+					if (state.TexLevelMode() == GE_TEXLEVEL_MODE_SLOPE) {
+						// Not sure what's right, but we need one value for the slope.
+						float clipw = (v0.clipw * w0.x + v1.clipw * w1.x + v2.clipw * w2.x) * wsum_recip.x;
+						ApplyTexturing(state, prim_color, mask, s, t, clipw);
+					} else {
+						ApplyTexturing(state, prim_color, mask, s, t, 0.0f);
+					}
 				}
 
 				if (!clearMode) {
@@ -923,7 +929,7 @@ void DrawRectangle(const VertexData &v0, const VertexData &v1, const BinCoords &
 				s = Vec4<float>::AssignToAll(st.s()) + sto4;
 				t = Vec4<float>::AssignToAll(st.t()) + tto4;
 
-				ApplyTexturing(state, prim_color, mask, s, t);
+				ApplyTexturing(state, prim_color, mask, s, t, v1.clipw);
 			}
 
 			if (!state.pixelID.clearMode) {
@@ -1014,7 +1020,7 @@ void DrawPoint(const VertexData &v0, const BinCoords &range, const RasterizerSta
 		int texLevel;
 		int texLevelFrac;
 		bool bilinear;
-		CalculateSamplingParams(0.0f, 0.0f, state, texLevel, texLevelFrac, bilinear);
+		CalculateSamplingParams(0.0f, 0.0f, v0.clipw, state, texLevel, texLevelFrac, bilinear);
 		PROFILE_THIS_SCOPE("sampler");
 		prim_color = ApplyTexturingSingle(s, t, ToVec4IntArg(prim_color), texLevel, texLevelFrac, bilinear, state);
 	}
@@ -1342,11 +1348,12 @@ void DrawLine(const VertexData &v0, const VertexData &v1, const BinCoords &range
 				// If inc is 0, force the delta to zero.
 				float ds = xinc == 0.0 ? 0.0f : (s1 - s) * (float)SCREEN_SCALE_FACTOR * (1.0f / xinc);
 				float dt = yinc == 0.0 ? 0.0f : (t1 - t) * (float)SCREEN_SCALE_FACTOR * (1.0f / yinc);
+				float w = (v0.clipw * (float)(steps - i) + v1.clipw * (float)i) / steps1;
 
 				int texLevel;
 				int texLevelFrac;
 				bool texBilinear;
-				CalculateSamplingParams(ds, dt, state, texLevel, texLevelFrac, texBilinear);
+				CalculateSamplingParams(ds, dt, w, state, texLevel, texLevelFrac, texBilinear);
 
 				if (state.antialiasLines) {
 					// TODO: This is a naive and wrong implementation.

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -340,7 +340,7 @@ static inline void CalculateSamplingParams(const float ds, const float dt, float
 	int detail;
 	switch (state.TexLevelMode()) {
 	case GE_TEXLEVEL_MODE_AUTO:
-		detail = TexLog2(std::max(ds * width, dt * height));
+		detail = TexLog2(std::max(std::abs(ds * width), std::abs(dt * height)));
 		break;
 	case GE_TEXLEVEL_MODE_SLOPE:
 		// This is always offset by an extra texlevel.

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -245,9 +245,6 @@ void DrawSprite(const VertexData &v0, const VertexData &v1, const BinCoords &ran
 				}
 			}
 		} else {
-			int xoff = ((v0.screenpos.x & 15) + 1) / 2;
-			int yoff = ((v0.screenpos.y & 15) + 1) / 2;
-
 			float dsf = ds * (1.0f / (float)(1 << state.samplerID.width0Shift));
 			float dtf = dt * (1.0f / (float)(1 << state.samplerID.height0Shift));
 			float sf_start = s_start * (1.0f / (float)(1 << state.samplerID.width0Shift));
@@ -261,7 +258,7 @@ void DrawSprite(const VertexData &v0, const VertexData &v1, const BinCoords &ran
 					// Not really that fast but faster than triangle.
 					for (int x = pos0.x; x < pos1.x; x++) {
 						if (CheckDepthTestPassed(pixelID.DepthTestFunc(), x, y, pixelID.cached.depthbufStride, z)) {
-							Vec4<int> prim_color = state.nearest(s, t, xoff, yoff, ToVec4IntArg(c0), &texptr, &texbufw, 0, 0, state.samplerID);
+							Vec4<int> prim_color = state.nearest(s, t, ToVec4IntArg(c0), &texptr, &texbufw, 0, 0, state.samplerID);
 							state.drawPixel(x, y, z, fog, ToVec4IntArg(prim_color), pixelID);
 						}
 
@@ -274,7 +271,7 @@ void DrawSprite(const VertexData &v0, const VertexData &v1, const BinCoords &ran
 					float s = sf_start;
 					// Not really that fast but faster than triangle.
 					for (int x = pos0.x; x < pos1.x; x++) {
-						Vec4<int> prim_color = state.nearest(s, t, xoff, yoff, ToVec4IntArg(c0), &texptr, &texbufw, 0, 0, state.samplerID);
+						Vec4<int> prim_color = state.nearest(s, t, ToVec4IntArg(c0), &texptr, &texbufw, 0, 0, state.samplerID);
 						state.drawPixel(x, y, z, fog, ToVec4IntArg(prim_color), pixelID);
 						s += dsf;
 					}

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -36,10 +36,10 @@ namespace Sampler {
 typedef Rasterizer::Vec4IntResult(SOFTRAST_CALL *FetchFunc)(int u, int v, const u8 *tptr, int bufw, int level, const SamplerID &samplerID);
 FetchFunc GetFetchFunc(SamplerID id);
 
-typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *NearestFunc)(float s, float t, int x, int y, Rasterizer::Vec4IntArg prim_color, const u8 *const *tptr, const uint16_t *bufw, int level, int levelFrac, const SamplerID &samplerID);
+typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *NearestFunc)(float s, float t, Rasterizer::Vec4IntArg prim_color, const u8 *const *tptr, const uint16_t *bufw, int level, int levelFrac, const SamplerID &samplerID);
 NearestFunc GetNearestFunc(SamplerID id);
 
-typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *LinearFunc)(float s, float t, int x, int y, Rasterizer::Vec4IntArg prim_color, const u8 *const *tptr, const uint16_t *bufw, int level, int levelFrac, const SamplerID &samplerID);
+typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *LinearFunc)(float s, float t, Rasterizer::Vec4IntArg prim_color, const u8 *const *tptr, const uint16_t *bufw, int level, int levelFrac, const SamplerID &samplerID);
 LinearFunc GetLinearFunc(SamplerID id);
 
 void Init();

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -133,8 +133,6 @@ NearestFunc SamplerJitCache::CompileNearest(const SamplerID &id) {
 	regCache_.SetupABI({
 		RegCache::VEC_ARG_S,
 		RegCache::VEC_ARG_T,
-		RegCache::GEN_ARG_X,
-		RegCache::GEN_ARG_Y,
 		RegCache::VEC_ARG_COLOR,
 		RegCache::GEN_ARG_TEXPTR_PTR,
 		RegCache::GEN_ARG_BUFW_PTR,
@@ -144,16 +142,16 @@ NearestFunc SamplerJitCache::CompileNearest(const SamplerID &id) {
 	});
 
 #if PPSSPP_PLATFORM(WINDOWS)
-	// RET + shadow space + 8 byte space for color arg (the Win32 ABI is kinda ugly.)
-	stackArgPos_ = 8 + 32 + 8;
+	// RET + shadow space.
+	stackArgPos_ = 8 + 32;
 
-	// Positions: stackArgPos_+0=src, stackArgPos_+8=bufw, stackArgPos_+16=level, stackArgPos_+24=levelFrac
-	stackIDOffset_ = 32;
-	stackLevelOffset_ = 16;
+	// Positions: stackArgPos_+0=bufwptr, stackArgPos_+8=level, stackArgPos_+16=levelFrac
+	stackIDOffset_ = 24;
+	stackLevelOffset_ = 8;
 #else
 	stackArgPos_ = 0;
-	// This is the only arg that went to the stack, it's after the RET.
-	stackIDOffset_ = 8;
+	// No args on the stack.
+	stackIDOffset_ = -1;
 	stackLevelOffset_ = -1;
 #endif
 
@@ -182,23 +180,20 @@ NearestFunc SamplerJitCache::CompileNearest(const SamplerID &id) {
 	if (!id.hasAnyMips && regCache_.Has(RegCache::GEN_ARG_LEVELFRAC))
 		regCache_.ForceRelease(RegCache::GEN_ARG_LEVELFRAC);
 
-	if (regCache_.Has(RegCache::GEN_ARG_BUFW_PTR)) {
-		// On Linux, RCX is currently bufwptr, but we'll need it for other things.
+	if (regCache_.Has(RegCache::GEN_ARG_LEVELFRAC)) {
+		// On Linux, RCX is currently levelFrac, but we'll need it for other things.
 		if (!cpu_info.bBMI2) {
-			X64Reg bufwReg = regCache_.Find(RegCache::GEN_ARG_BUFW_PTR);
-			MOV(64, R(R15), R(bufwReg));
-			regCache_.Unlock(bufwReg, RegCache::GEN_ARG_BUFW_PTR);
-			regCache_.ForceRelease(RegCache::GEN_ARG_BUFW_PTR);
-			regCache_.ChangeReg(R15, RegCache::GEN_ARG_BUFW_PTR);
-			regCache_.ForceRetain(RegCache::GEN_ARG_BUFW_PTR);
+			X64Reg levelFracReg = regCache_.Find(RegCache::GEN_ARG_LEVELFRAC);
+			MOV(64, R(R15), R(levelFracReg));
+			regCache_.Unlock(levelFracReg, RegCache::GEN_ARG_LEVELFRAC);
+			regCache_.ForceRelease(RegCache::GEN_ARG_LEVELFRAC);
+			regCache_.ChangeReg(R15, RegCache::GEN_ARG_LEVELFRAC);
+			regCache_.ForceRetain(RegCache::GEN_ARG_LEVELFRAC);
 		}
-	} else {
-		// Let's load bufwptr/texptrptr into regs.  Match Linux just for consistency - RDX is free.
+	} else if (!regCache_.Has(RegCache::GEN_ARG_BUFW_PTR)) {
+		// Let's load bufwptr into regs.  RDX is free.
 		MOV(64, R(RDX), MDisp(RSP, stackArgPos_ + 0));
-		MOV(64, R(R15), MDisp(RSP, stackArgPos_ + 8));
-		regCache_.ChangeReg(RDX, RegCache::GEN_ARG_TEXPTR_PTR);
-		regCache_.ChangeReg(R15, RegCache::GEN_ARG_BUFW_PTR);
-		regCache_.ForceRetain(RegCache::GEN_ARG_TEXPTR_PTR);
+		regCache_.ChangeReg(RDX, RegCache::GEN_ARG_BUFW_PTR);
 		regCache_.ForceRetain(RegCache::GEN_ARG_BUFW_PTR);
 	}
 	// Okay, now lock RCX as a shifting reg.
@@ -284,7 +279,7 @@ NearestFunc SamplerJitCache::CompileNearest(const SamplerID &id) {
 			CMP(8, R(levelFracReg), Imm8(0));
 			regCache_.Unlock(levelFracReg, RegCache::GEN_ARG_LEVELFRAC);
 		} else {
-			CMP(8, MDisp(RSP, stackArgPos_ + 24), Imm8(0));
+			CMP(8, MDisp(RSP, stackArgPos_ + 16), Imm8(0));
 		}
 		FixupBranch skip = J_CC(CC_Z, true);
 
@@ -295,7 +290,7 @@ NearestFunc SamplerJitCache::CompileNearest(const SamplerID &id) {
 			regCache_.Unlock(levelReg, RegCache::GEN_ARG_LEVEL);
 		} else {
 			// It's fine to just modify this in place.
-			ADD(32, MDisp(RSP, stackArgPos_ + 16), Imm8(1));
+			ADD(32, MDisp(RSP, stackArgPos_ + stackLevelOffset_), Imm8(1));
 		}
 
 		// This is inside the conditional, but it's okay because we throw it away after.
@@ -357,7 +352,7 @@ NearestFunc SamplerJitCache::CompileNearest(const SamplerID &id) {
 		Describe("BlendMips");
 		if (!regCache_.Has(RegCache::GEN_ARG_LEVELFRAC)) {
 			X64Reg levelFracReg = regCache_.Alloc(RegCache::GEN_ARG_LEVELFRAC);
-			MOVZX(32, 8, levelFracReg, MDisp(RSP, stackArgPos_ + 24));
+			MOVZX(32, 8, levelFracReg, MDisp(RSP, stackArgPos_ + 16));
 			regCache_.Unlock(levelFracReg, RegCache::GEN_ARG_LEVELFRAC);
 			regCache_.ForceRetain(RegCache::GEN_ARG_LEVELFRAC);
 		}
@@ -413,6 +408,8 @@ NearestFunc SamplerJitCache::CompileNearest(const SamplerID &id) {
 	}
 
 	regCache_.ForceRelease(RegCache::VEC_RESULT);
+	if (regCache_.Has(RegCache::GEN_ARG_ID))
+		regCache_.ForceRelease(RegCache::GEN_ARG_ID);
 
 	if (!success) {
 		regCache_.Reset(false);
@@ -525,8 +522,6 @@ LinearFunc SamplerJitCache::CompileLinear(const SamplerID &id) {
 	regCache_.SetupABI({
 		RegCache::VEC_ARG_S,
 		RegCache::VEC_ARG_T,
-		RegCache::GEN_ARG_X,
-		RegCache::GEN_ARG_Y,
 		RegCache::VEC_ARG_COLOR,
 		RegCache::GEN_ARG_TEXPTR_PTR,
 		RegCache::GEN_ARG_BUFW_PTR,
@@ -536,22 +531,21 @@ LinearFunc SamplerJitCache::CompileLinear(const SamplerID &id) {
 	});
 
 #if PPSSPP_PLATFORM(WINDOWS)
-	// RET + shadow space + 8 byte space for color arg (the Win32 ABI is kinda ugly.)
-	stackArgPos_ = 8 + 32 + 8;
+	// RET + shadow space.
+	stackArgPos_ = 8 + 32;
 	// Free up some more vector regs on Windows too, where we're a bit tight.
 	stackArgPos_ += WriteProlog(0, { XMM6, XMM7, XMM8, XMM9, XMM10, XMM11, XMM12 }, { R15, R14, R13, R12 });
 
-	// Positions: stackArgPos_+0=src, stackArgPos_+8=bufw, stackArgPos_+16=level, stackArgPos_+24=levelFrac
-	stackIDOffset_ = 32;
-	stackLevelOffset_ = 16;
+	// Positions: stackArgPos_+0=bufwptr, stackArgPos_+8=level, stackArgPos_+16=levelFrac
+	stackIDOffset_ = 24;
+	stackLevelOffset_ = 8;
 
-	// If needed, we could store UV1 data in shadow space, but we no longer due.
+	// If needed, we could store UV1 data in shadow space, but we no longer do.
 	stackUV1Offset_ = -8;
 #else
 	stackArgPos_ = 0;
 	stackArgPos_ += WriteProlog(0, {}, { R15, R14, R13, R12 });
-	// Just after the RET.
-	stackIDOffset_ = 8;
+	stackIDOffset_ = -1;
 	stackLevelOffset_ = -1;
 
 	// Use the red zone.
@@ -591,8 +585,7 @@ LinearFunc SamplerJitCache::CompileLinear(const SamplerID &id) {
 	}
 
 	// We also want to save src and bufw for later.  Might be in a reg already.
-	if (regCache_.Has(RegCache::GEN_ARG_TEXPTR_PTR)) {
-		_assert_(regCache_.Has(RegCache::GEN_ARG_BUFW_PTR));
+	if (regCache_.Has(RegCache::GEN_ARG_TEXPTR_PTR) && regCache_.Has(RegCache::GEN_ARG_BUFW_PTR)) {
 		X64Reg srcReg = regCache_.Find(RegCache::GEN_ARG_TEXPTR_PTR);
 		X64Reg bufwReg = regCache_.Find(RegCache::GEN_ARG_BUFW_PTR);
 		MOV(64, R(R14), R(srcReg));
@@ -601,6 +594,12 @@ LinearFunc SamplerJitCache::CompileLinear(const SamplerID &id) {
 		regCache_.Unlock(bufwReg, RegCache::GEN_ARG_BUFW_PTR);
 		regCache_.ForceRelease(RegCache::GEN_ARG_TEXPTR_PTR);
 		regCache_.ForceRelease(RegCache::GEN_ARG_BUFW_PTR);
+	} else if (regCache_.Has(RegCache::GEN_ARG_TEXPTR_PTR)) {
+		X64Reg srcReg = regCache_.Find(RegCache::GEN_ARG_TEXPTR_PTR);
+		MOV(64, R(R14), R(srcReg));
+		regCache_.Unlock(srcReg, RegCache::GEN_ARG_TEXPTR_PTR);
+		regCache_.ForceRelease(RegCache::GEN_ARG_TEXPTR_PTR);
+		MOV(64, R(R15), MDisp(RSP, stackArgPos_ + 0));
 	} else {
 		MOV(64, R(R14), MDisp(RSP, stackArgPos_ + 0));
 		MOV(64, R(R15), MDisp(RSP, stackArgPos_ + 8));
@@ -608,9 +607,11 @@ LinearFunc SamplerJitCache::CompileLinear(const SamplerID &id) {
 
 	// Okay, and now remember we moved to R14/R15.
 	regCache_.ChangeReg(R14, RegCache::GEN_ARG_TEXPTR_PTR);
-	regCache_.ChangeReg(R15, RegCache::GEN_ARG_BUFW_PTR);
 	regCache_.ForceRetain(RegCache::GEN_ARG_TEXPTR_PTR);
-	regCache_.ForceRetain(RegCache::GEN_ARG_BUFW_PTR);
+	if (!regCache_.Has(RegCache::GEN_ARG_BUFW_PTR)) {
+		regCache_.ChangeReg(R15, RegCache::GEN_ARG_BUFW_PTR);
+		regCache_.ForceRetain(RegCache::GEN_ARG_BUFW_PTR);
+	}
 
 	bool success = true;
 
@@ -758,7 +759,7 @@ LinearFunc SamplerJitCache::CompileLinear(const SamplerID &id) {
 			CMP(8, R(levelFracReg), Imm8(0));
 			regCache_.Unlock(levelFracReg, RegCache::GEN_ARG_LEVELFRAC);
 		} else {
-			CMP(8, MDisp(RSP, stackArgPos_ + 24), Imm8(0));
+			CMP(8, MDisp(RSP, stackArgPos_ + 16), Imm8(0));
 		}
 		FixupBranch skip = J_CC(CC_Z, true);
 
@@ -769,7 +770,7 @@ LinearFunc SamplerJitCache::CompileLinear(const SamplerID &id) {
 			regCache_.Unlock(levelReg, RegCache::GEN_ARG_LEVEL);
 		} else {
 			// It's fine to just modify this in place.
-			ADD(32, MDisp(RSP, stackArgPos_ + 16), Imm8(1));
+			ADD(32, MDisp(RSP, stackArgPos_ + stackLevelOffset_), Imm8(1));
 		}
 
 		if (nearest != nullptr) {
@@ -808,7 +809,7 @@ LinearFunc SamplerJitCache::CompileLinear(const SamplerID &id) {
 		Describe("BlendMips");
 		if (!regCache_.Has(RegCache::GEN_ARG_LEVELFRAC)) {
 			X64Reg levelFracReg = regCache_.Alloc(RegCache::GEN_ARG_LEVELFRAC);
-			MOVZX(32, 8, levelFracReg, MDisp(RSP, stackArgPos_ + 24));
+			MOVZX(32, 8, levelFracReg, MDisp(RSP, stackArgPos_ + 16));
 			regCache_.Unlock(levelFracReg, RegCache::GEN_ARG_LEVELFRAC);
 			regCache_.ForceRetain(RegCache::GEN_ARG_LEVELFRAC);
 		}
@@ -870,6 +871,8 @@ LinearFunc SamplerJitCache::CompileLinear(const SamplerID &id) {
 	}
 
 	regCache_.ForceRelease(RegCache::VEC_RESULT);
+	if (regCache_.Has(RegCache::GEN_ARG_ID))
+		regCache_.ForceRelease(RegCache::GEN_ARG_ID);
 
 	if (!success) {
 		regCache_.Reset(false);
@@ -1223,9 +1226,9 @@ bool SamplerJitCache::Jit_ReadClutQuad(const SamplerID &id, bool level1) {
 		} else {
 #if PPSSPP_PLATFORM(WINDOWS)
 			if (cpu_info.bAVX2) {
-				VPBROADCASTD(128, vecLevelReg, MDisp(RSP, stackArgPos_ + 16));
+				VPBROADCASTD(128, vecLevelReg, MDisp(RSP, stackArgPos_ + stackLevelOffset_));
 			} else {
-				MOVD_xmm(vecLevelReg, MDisp(RSP, stackArgPos_ + 16));
+				MOVD_xmm(vecLevelReg, MDisp(RSP, stackArgPos_ + stackLevelOffset_));
 				PSHUFD(vecLevelReg, R(vecLevelReg), _MM_SHUFFLE(0, 0, 0, 0));
 			}
 #else
@@ -2583,11 +2586,6 @@ bool SamplerJitCache::Jit_GetTexDataSwizzled(const SamplerID &id, int bitsPerTex
 bool SamplerJitCache::Jit_GetTexelCoords(const SamplerID &id) {
 	Describe("Texel");
 
-	// First, adjust X and Y...
-	// TODO: Shouldn't do this in the sampler, need to get s/t right.
-	regCache_.ForceRelease(RegCache::GEN_ARG_X);
-	regCache_.ForceRelease(RegCache::GEN_ARG_Y);
-
 	X64Reg uReg = regCache_.Alloc(RegCache::GEN_ARG_U);
 	X64Reg vReg = regCache_.Alloc(RegCache::GEN_ARG_V);
 	X64Reg sReg = regCache_.Find(RegCache::VEC_ARG_S);
@@ -2602,7 +2600,7 @@ bool SamplerJitCache::Jit_GetTexelCoords(const SamplerID &id) {
 			levelReg = regCache_.Find(RegCache::GEN_ARG_LEVEL);
 		} else {
 			levelReg = regCache_.Alloc(RegCache::GEN_ARG_LEVEL);
-			MOV(32, R(levelReg), MDisp(RSP, stackArgPos_ + 16));
+			MOV(32, R(levelReg), MDisp(RSP, stackArgPos_ + stackLevelOffset_));
 		}
 
 		// We'll multiply these at the same time, so it's nice to put together.
@@ -2774,7 +2772,7 @@ bool SamplerJitCache::Jit_GetTexelCoordsQuad(const SamplerID &id) {
 		} else {
 			releaseLevelReg = true;
 			levelReg = regCache_.Alloc(RegCache::GEN_ARG_LEVEL);
-			MOV(32, R(levelReg), MDisp(RSP, stackArgPos_ + 16));
+			MOV(32, R(levelReg), MDisp(RSP, stackArgPos_ + stackLevelOffset_));
 		}
 
 		// This will load the current and next level's sizes, 16x4.
@@ -2826,8 +2824,6 @@ bool SamplerJitCache::Jit_GetTexelCoordsQuad(const SamplerID &id) {
 	PSLLD(tempXYReg, 7);
 	PADDD(sReg, R(tempXYReg));
 	regCache_.Release(tempXYReg, RegCache::VEC_TEMP0);
-	regCache_.ForceRelease(RegCache::GEN_ARG_X);
-	regCache_.ForceRelease(RegCache::GEN_ARG_Y);
 
 	// We do want the fraction, though, so extract that to an XMM for later.
 	X64Reg allFracReg = INVALID_REG;

--- a/unittest/TestSoftwareGPUJit.cpp
+++ b/unittest/TestSoftwareGPUJit.cpp
@@ -89,8 +89,8 @@ static bool TestSamplerJit() {
 
 		// Try running each to make sure they don't trivially crash.
 		const auto primArg = Rasterizer::ToVec4IntArg(Math3D::Vec4<int>(127, 127, 127, 127));
-		linearFunc(0.0f, 0.0f, 0, 0, primArg, tptr, bufw, 1, 7, id);
-		nearestFunc(0.0f, 0.0f, 0, 0, primArg, tptr, bufw, 1, 7, id);
+		linearFunc(0.0f, 0.0f, primArg, tptr, bufw, 1, 7, id);
+		nearestFunc(0.0f, 0.0f, primArg, tptr, bufw, 1, 7, id);
 		fetchFunc(0, 0, tptr[0], bufw[0], 1, id);
 	}
 


### PR DESCRIPTION
This just implements the change noted in #9772, which seems to match tests for how slope actually works.  The frame dump looks pretty close with this change.

Also as some cleanup, had previously passed in x/y trying to use them to make linear filtering more accurate, but that was wrong and I removed it in #15410.  This actually removes the unnecessary parameters.

Doesn't touch slope usage in hardware rendering.

-[Unknown]