### PR TITLE
GE Debugger: Correct UV display with prescale

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -3204,6 +3204,7 @@ std::vector<FramebufferInfo> GPUCommon::GetFramebufferList() const {
 }
 
 bool GPUCommon::GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices) {
+	UpdateUVScaleOffset();
 	return drawEngineCommon_->GetCurrentSimpleVertices(count, vertices, indices);
 }
 

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -1423,8 +1423,8 @@ bool SoftGPU::GetCurrentClut(GPUDebugBuffer &buffer)
 	return true;
 }
 
-bool SoftGPU::GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices)
-{
+bool SoftGPU::GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices) {
+	UpdateUVScaleOffset();
 	return drawEngine_->transformUnit.GetCurrentSimpleVertices(count, vertices, indices);
 }
 

--- a/test.py
+++ b/test.py
@@ -192,6 +192,7 @@ tests_good = [
   "gpu/textures/mipmap",
   "gpu/textures/rotate",
   "gpu/vertices/colors",
+  "gpu/vertices/morph",
   "gpu/vertices/texcoords",
   "hash/hash",
   "hle/check_not_used_uids",


### PR DESCRIPTION
Sometimes these weren't flushed yet, and it made the texture preview and vertices confusing and wrong (using old factors, not just no factors.)

Also add https://github.com/hrydgard/pspautotests/pull/232 as a passing test.

-[Unknown]