### PR TITLE
Build: Update deprecated actions & fix ccache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,12 +34,12 @@ jobs:
 
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v1.1
 
     - name: Build Windows
       working-directory: ${{ env.GITHUB_WORKSPACE }}
@@ -63,7 +63,7 @@ jobs:
       run: cp Windows/Release/*.exe ppsspp/
 
     - name: Upload build
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: Windows ${{ matrix.platform }} build
         path: ppsspp/
@@ -71,12 +71,12 @@ jobs:
   build-uwp:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v1.1
 
     - name: Build UWP
       working-directory: ${{ env.GITHUB_WORKSPACE }}
@@ -87,7 +87,7 @@ jobs:
     needs: build-windows
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: false
 
@@ -97,7 +97,7 @@ jobs:
       run: git submodule update --init pspautotests assets/lang
 
     - name: Download build
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: Windows x64 build
         path: ppsspp/
@@ -192,7 +192,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 
@@ -202,19 +202,11 @@ jobs:
       run: |
         git fetch --deepen=15000 --no-recurse-submodules --tags || exit 0
 
-    - name: Cache Qt
-      uses: actions/cache@v1
-      if: matrix.extra == 'qt'
-      id: cache-qt
-      with:
-        path: ${{ runner.workspace }}/Qt
-        key: ${{ runner.os }}-QtCache
-
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v3
       if: matrix.extra == 'qt'
       with:
-        cached: ${{ steps.cache-qt.outputs.cache-hit }}
+        cache: true
 
     - uses: nttld/setup-ndk@v1
       if: matrix.extra == 'android'
@@ -236,7 +228,7 @@ jobs:
         echo "#define PPSSPP_GIT_VERSION_NO_UPDATE 1" >> git-version.cpp
 
     - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@v1.2
       with:
         key: ${{ matrix.id }}
 
@@ -279,7 +271,7 @@ jobs:
         fi
 
     - name: Upload build
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       if: matrix.extra == 'test'
       with:
         name: ${{ matrix.os }} build
@@ -313,7 +305,7 @@ jobs:
     needs: build
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: false
 
@@ -335,7 +327,7 @@ jobs:
         git submodule update --init SDL/macOS
 
     - name: Download build
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: ${{ matrix.os }} build
         path: ppsspp/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,8 +238,20 @@ jobs:
         CXX: ${{ matrix.cxx }}
         NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
         NDK_CCACHE: ccache
+        USE_CCACHE: 1
       run: |
         export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+        export CCACHE_SLOPPINESS=clang_index_store,ivfsoverlay,include_file_ctime,include_file_mtime,modules,system_headers,time_macros
+        if [ "${{ matrix.extra }}" == "android" ]; then
+          export CCACHE_FILECLONE=true
+          export CCACHE_DEPEND=true
+          export CCACHE_COMPILERCHECK=content
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          export CCACHE_SLOPPINESS=pch_defines,$CCACHE_SLOPPINESS
+          export CCACHE_FILECLONE=true
+          export CCACHE_DEPEND=true
+          export CCACHE_COMPILERCHECK=content
+        fi
         ${{ matrix.args }}
 
     - name: Package build

--- a/.github/workflows/generateDockerLayer.yml
+++ b/.github/workflows/generateDockerLayer.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
   
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Extract DOCKER_TAG using tag name
       if: startsWith(github.ref, 'refs/tags/')
@@ -25,13 +25,13 @@ jobs:
         echo "DOCKER_TAG=latest" >> $GITHUB_ENV
       
     - name: Login to Github registry
-      uses: docker/login-action@v1 
+      uses: docker/login-action@v2
       with:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
         registry: ghcr.io
     
-    - uses: docker/build-push-action@v2
+    - uses: docker/build-push-action@v3
       with:
         push: true
         tags: ghcr.io/${{ github.repository }}:${{ env.DOCKER_TAG }}

--- a/.github/workflows/manual_generate_apk.yml
+++ b/.github/workflows/manual_generate_apk.yml
@@ -19,14 +19,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive
         
       - name: Setup JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: '11'
         
       #- name: Setup SDK
@@ -54,7 +55,7 @@ jobs:
           fi
 
       - name: Upload APK
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: android-${{ github.event.inputs.buildVariant }} build
           path: ppsspp/

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
 
@@ -40,7 +40,7 @@ jobs:
         sed -i "s;unknown;${VERSION};" $PKGNAME/git-version.cmake || true
         TARBALL=$PKGNAME.tar.xz
         tar cJf $TARBALL $PKGNAME
-        echo "::set-output name=tarball::$TARBALL"
+        echo "tarball=$TARBALL" >> $GITHUB_OUTPUT
 
     - name: upload tarball
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Up to now, ccache has not been working on macOS agents or for Android builds.  This fixes that - had to enable some "sloppiness" settings.  Most flags are for Xcode.  I think NDK headers are ending up with a `__TIME__` or something in them.

The pch change was only needed for macOS and seemed potentially more dangerous, but probably still safe for us.

This also upgrades most of the actions.  This means improvements to caching (using zstd now), etc. but more importantly means we're no longer using deprecated features for pull requests:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Unfortunately, the release action was unmaintained when it was added and is still unmaintained, but this was apparently considered a [benefit back then](https://github.com/hrydgard/ppsspp/pull/15390#discussion_r804695455).  Seems like it will stop working 2023-06-01 if it doesn't magically start getting maintained, but that's still quite some months away.

-[Unknown]