### PR TITLE
Cleanup debugger memory reference usage, API validation bug

### DIFF
--- a/Core/Debugger/WebSocket/InputSubscriber.cpp
+++ b/Core/Debugger/WebSocket/InputSubscriber.cpp
@@ -227,7 +227,7 @@ static bool AnalogValue(DebuggerRequest &req, float *value, const char *name) {
 	}
 
 	double val = node->value.toNumber();
-	if (val < 1.0 || val > 1.0) {
+	if (val < -1.0 || val > 1.0) {
 		req.Fail(StringFromFormat("Parameter '%s' must be between -1.0 and 1.0", name));
 		return false;
 	}

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -1652,7 +1652,8 @@ std::map<u32, u32> SaveAndClearReplacements() {
 	std::map<u32, u32> saved;
 	for (auto it = replacedInstructions.begin(), end = replacedInstructions.end(); it != end; ++it) {
 		const u32 addr = it->first;
-		const u32 curInstr = Memory::Read_U32(addr);
+		// This will not retain jit blocks.
+		const u32 curInstr = Memory::Read_Opcode_JIT(addr).encoding;
 		if (MIPS_IS_REPLACEMENT(curInstr)) {
 			saved[addr] = curInstr;
 			Memory::Write_U32(it->second, addr);

--- a/Core/MIPS/MIPSDebugInterface.cpp
+++ b/Core/MIPS/MIPSDebugInterface.cpp
@@ -159,37 +159,25 @@ public:
 		return EXPR_TYPE_UINT;
 	}
 	
-	bool getMemoryValue(uint32_t address, int size, uint32_t& dest, char* error) override
-	{
-		switch (size)
-		{
-		case 1: case 2: case 4:
-			break;
-		default:
-			sprintf(error,"Invalid memory access size %d",size);
-			return false;
-		}
+	bool getMemoryValue(uint32_t address, int size, uint32_t& dest, char* error) override {
+		// We allow, but ignore, bad access.
+		// If we didn't, log/condition statements that reference registers couldn't be configured.
+		bool valid = Memory::IsValidRange(address, size);
 
-		if (address % size)
-		{
-			sprintf(error,"Invalid memory access (unaligned)");
-			return false;
-		}
-
-		switch (size)
-		{
+		switch (size) {
 		case 1:
-			dest = Memory::Read_U8(address);
-			break;
+			dest = valid ? Memory::Read_U8(address) : 0;
+			return true;
 		case 2:
-			dest = Memory::Read_U16(address);
-			break;
+			dest = valid ? Memory::Read_U16(address) : 0;
+			return true;
 		case 4:
-			dest = Memory::Read_U32(address);
-			break;
+			dest = valid ? Memory::Read_U32(address) : 0;
+			return true;
 		}
 
-		return true;
+		sprintf(error, "Unexpected memory access size %d", size);
+		return false;
 	}
 
 private:

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -591,7 +591,7 @@ void Jit::Comp_ReplacementFunc(MIPSOpcode op) {
 	// Not sure about the cause.
 	Memory::Opcode origInstruction = Memory::Read_Instruction(GetCompilerPC(), true);
 	if (origInstruction.encoding == op.encoding) {
-		ERROR_LOG(HLE, "Replacement broken (savestate problem?): %08x", op.encoding);
+		ERROR_LOG(HLE, "Replacement broken (savestate problem?): %08x at %08x", op.encoding, GetCompilerPC());
 		return;
 	}
 

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -316,7 +316,11 @@ namespace SaveState
 		} else {
 			Memory::DoState(p);
 		}
-		RestoreSavedReplacements(savedReplacements);
+
+		// Don't bother restoring if reading, we'll deal with that in KernelModuleDoState.
+		// In theory, different functions might have been runtime loaded in the state.
+		if (p.mode != p.MODE_READ)
+			RestoreSavedReplacements(savedReplacements);
 
 		MemoryStick_DoState(p);
 		currentMIPS->DoState(p);

--- a/GPU/Common/GPUDebugInterface.cpp
+++ b/GPU/Common/GPUDebugInterface.cpp
@@ -916,20 +916,19 @@ ExpressionType GEExpressionFunctions::getFieldType(GECmdFormat fmt, GECmdField f
 }
 
 bool GEExpressionFunctions::getMemoryValue(uint32_t address, int size, uint32_t &dest, char *error) {
-	if (!Memory::IsValidRange(address, size)) {
-		sprintf(error, "Invalid address or size %08x + %d", address, size);
-		return false;
-	}
+	// We allow, but ignore, bad access.
+	// If we didn't, log/condition statements that reference registers couldn't be configured.
+	bool valid = Memory::IsValidRange(address, size);
 
 	switch (size) {
 	case 1:
-		dest = Memory::Read_U8(address);
+		dest = valid ? Memory::Read_U8(address) : 0;
 		return true;
 	case 2:
-		dest = Memory::Read_U16(address);
+		dest = valid ? Memory::Read_U16(address) : 0;
 		return true;
 	case 4:
-		dest = Memory::Read_U32(address);
+		dest = valid ? Memory::Read_U32(address) : 0;
 		return true;
 	}
 


### PR DESCRIPTION
Also ran into an issue when checking if replacements were causing a bug, because they got restored wrong.  Replacements wasn't willing to overwrite a jit emuhack, but jit was willing to restore one to a replacement.  This caused replacement emuhacks to be retained in save states.

-[Unknown]