### PR TITLE
Handle vrot overlap and vscl/vmscl prefixes more accurately

### DIFF
--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -1185,8 +1185,8 @@ namespace MIPSComp {
 		int vt = _VT;
 		u8 sregs[4], dregs[4], treg;
 		GetVectorRegsPrefixS(sregs, sz, vs);
-		// TODO: Prefixes seem strange...
-		GetVectorRegsPrefixT(&treg, V_Single, vt);
+		// T prefixes handled by interp.
+		GetVectorRegs(&treg, V_Single, vt);
 		GetVectorRegsPrefixD(dregs, sz, vd);
 
 		bool overlap = false;

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -1607,7 +1607,24 @@ namespace MIPSInt
 		} else {
 			d[sineLane] = sine;
 		}
-		d[cosineLane] = cosine;
+
+		if (((vd >> 2) & 7) == ((vs >> 2) & 7)) {
+			u8 dregs[4]{};
+			GetVectorRegs(dregs, sz, vd);
+			// Calculate cosine based on sine/zero result.
+			bool written = false;
+			for (int i = 0; i < 4; i++) {
+				if (vs == dregs[i]) {
+					d[cosineLane] = vfpu_cos(d[i]);
+					written = true;
+					break;
+				}
+			}
+			if (!written)
+				d[cosineLane] = cosine;
+		} else {
+			d[cosineLane] = cosine;
+		}
 
 		// D prefix works, just not for x.
 		currentMIPS->vfpuCtrl[VFPU_CTRL_DPREFIX] &= 0xFFEFC;

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -540,8 +540,10 @@ namespace MIPSInt
 		ApplySwizzleS(&s[(n - 1) * 4], V_Quad);
 		// T prefix applies only for the last row, and is used per element.
 		// This is like vscl, but instead of zzzz it uses xxxx.
+		int tlane = (vt >> 5) & 3;
+		t[tlane] = t[0];
 		u32 tprefixRemove = VFPU_ANY_SWIZZLE();
-		u32 tprefixAdd = VFPU_SWIZZLE(0, 0, 0, 0);
+		u32 tprefixAdd = VFPU_SWIZZLE(tlane, tlane, tlane, tlane);
 		ApplyPrefixST(t, VFPURewritePrefix(VFPU_CTRL_TPREFIX, tprefixRemove, tprefixAdd), V_Quad);
 
 		for (int b = 0; b < n; b++) {
@@ -1518,9 +1520,10 @@ namespace MIPSInt
 
 		// T prefix forces swizzle (zzzz for some reason, so we force V_Quad.)
 		// That means negate still works, but constants are a bit weird.
-		t[2] = V(vt);
+		int tlane = (vt >> 5) & 3;
+		t[tlane] = V(vt);
 		u32 tprefixRemove = VFPU_ANY_SWIZZLE();
-		u32 tprefixAdd = VFPU_SWIZZLE(2, 2, 2, 2);
+		u32 tprefixAdd = VFPU_SWIZZLE(tlane, tlane, tlane, tlane);
 		ApplyPrefixST(t, VFPURewritePrefix(VFPU_CTRL_TPREFIX, tprefixRemove, tprefixAdd), V_Quad);
 
 		int n = GetNumVectorElements(sz);

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -343,6 +343,10 @@ void WriteMatrix(const float *rd, MatrixSize size, int reg) {
 }
 
 int GetVectorOverlap(int vec1, VectorSize size1, int vec2, VectorSize size2) {
+	// Different matrices?  Can't overlap, return early.
+	if (((vec1 >> 2) & 7) != ((vec2 >> 2) & 7))
+		return 0;
+
 	int n1 = GetNumVectorElements(size1);
 	int n2 = GetNumVectorElements(size2);
 	u8 regs1[4];


### PR DESCRIPTION
Fixes #13990 (at least the Cloud vs Laguna case), thanks @ANR2ME for figuring out it was in Int_Vscl.

Also was suspecting vrot for #10650 (because it is behaving differently on Linux), and noticed IR didn't properly consider overlap.  This handles it per hardware tests.  I'd previously asserted vrot might indicate sine and cosine were calculated together... clearly they aren't.

It's obvious from this that, like matrix instructions, cosine is just a later micro-op (thus, it doesn't get prefixes, uses previous result, etc.)  Some tests from @davidgfnet have indicated that matrix overlap also behaves this way (i.e. the way we copy the entire matrix is probably wrong.)

-[Unknown]