### PR TITLE
irjit: Fix unordered float compares

### DIFF
--- a/Core/MIPS/IR/IRCompALU.cpp
+++ b/Core/MIPS/IR/IRCompALU.cpp
@@ -118,7 +118,7 @@ void IRFrontend::Comp_RType3(MIPSOpcode op) {
 	MIPSGPReg rd = _RD;
 
 	// noop, won't write to ZERO.
-	if (rd == 0)
+	if (rd == MIPS_REG_ZERO)
 		return;
 
 	switch (op & 63) {
@@ -298,7 +298,7 @@ void IRFrontend::Comp_Allegrex2(MIPSOpcode op) {
 	MIPSGPReg rd = _RD;
 
 	// Don't change $zr.
-	if (rd == 0)
+	if (rd == MIPS_REG_ZERO)
 		return;
 
 	switch (op & 0x3ff) {

--- a/Core/MIPS/IR/IRCompFPU.cpp
+++ b/Core/MIPS/IR/IRCompFPU.cpp
@@ -118,7 +118,7 @@ void IRFrontend::Comp_FPUComp(MIPSOpcode op) {
 		break;
 	case 3:      // ueq, ngl (equal, unordered)
 		mode = IRFpCompareMode::EqualUnordered;
-		return;
+		break;
 	case 4:      // olt, lt (less than, ordered)
 		mode = IRFpCompareMode::LessOrdered;
 		break;

--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -464,6 +464,7 @@ namespace MIPSComp {
 				init = Vec4Init::AllONE;
 				break;
 			default:
+				INVALIDOP;
 				return;
 			}
 			ir.Write(IROp::Vec4Init, vec[0], (int)init);

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -881,16 +881,22 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 				break;
 			}
 			case IRFpCompareMode::EqualOrdered:
-			case IRFpCompareMode::EqualUnordered:
 				mips->fpcond = mips->f[inst->src1] == mips->f[inst->src2];
 				break;
+			case IRFpCompareMode::EqualUnordered:
+				mips->fpcond = mips->f[inst->src1] == mips->f[inst->src2] || my_isnan(mips->f[inst->src1]) || my_isnan(mips->f[inst->src2]);
+				break;
 			case IRFpCompareMode::LessEqualOrdered:
-			case IRFpCompareMode::LessEqualUnordered:
 				mips->fpcond = mips->f[inst->src1] <= mips->f[inst->src2];
 				break;
+			case IRFpCompareMode::LessEqualUnordered:
+				mips->fpcond = !(mips->f[inst->src1] > mips->f[inst->src2]);
+				break;
 			case IRFpCompareMode::LessOrdered:
-			case IRFpCompareMode::LessUnordered:
 				mips->fpcond = mips->f[inst->src1] < mips->f[inst->src2];
+				break;
+			case IRFpCompareMode::LessUnordered:
+				mips->fpcond = !(mips->f[inst->src1] >= mips->f[inst->src2]);
 				break;
 			}
 			break;

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -1629,8 +1629,9 @@ namespace MIPSInt
 			d[cosineLane] = cosine;
 		}
 
-		// D prefix works, just not for x.
-		currentMIPS->vfpuCtrl[VFPU_CTRL_DPREFIX] &= 0xFFEFC;
+		// D prefix works, just not for the cosine lane.
+		uint32_t dprefixRemove = (3 << cosineLane) | (1 << (8 + cosineLane));
+		currentMIPS->vfpuCtrl[VFPU_CTRL_DPREFIX] &= 0xFFFFF ^ dprefixRemove;
 		ApplyPrefixD(d, sz);
 		WriteVector(d, sz, vd);
 		PC += 4;


### PR DESCRIPTION
There was an accidental `return;` that was nuking `c.ueq`.  It's not exactly common, but might've been causing some weird bugs.

-[Unknown]