### PR TITLE
irjit: Correct prefix validation

### DIFF
--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -117,8 +117,9 @@ namespace MIPSComp {
 			int abs = (prefix >> (8 + i)) & 1;
 			int negate = (prefix >> (16 + i)) & 1;
 			int constants = (prefix >> (12 + i)) & 1;
-			if (regnum < n || abs || negate || constants) {
-				return false;
+			if (regnum >= n && !constants) {
+				if (abs || negate || regnum != i)
+					return false;
 			}
 		}
 
@@ -472,7 +473,7 @@ namespace MIPSComp {
 
 	void IRFrontend::Comp_VHdp(MIPSOpcode op) {
 		CONDITIONAL_DISABLE(VFPU_VEC);
-		if (js.HasUnknownPrefix() || !IsPrefixWithinSize(js.prefixS, op) || !IsPrefixWithinSize(js.prefixT, op)) {
+		if (js.HasUnknownPrefix() || js.HasSPrefix() || !IsPrefixWithinSize(js.prefixT, op)) {
 			DISABLE;
 		}
 
@@ -754,8 +755,15 @@ namespace MIPSComp {
 
 	void IRFrontend::Comp_VV2Op(MIPSOpcode op) {
 		CONDITIONAL_DISABLE(VFPU_VEC);
-		if (js.HasUnknownPrefix() || !IsPrefixWithinSize(js.prefixS, op) || !IsPrefixWithinSize(js.prefixT, op))
-			DISABLE;
+		int optype = (op >> 16) & 0x1f;
+		if (optype == 0) {
+			if (js.HasUnknownPrefix() || !IsPrefixWithinSize(js.prefixS, op))
+				DISABLE;
+		} else {
+			// Many of these apply the D prefix strangely or override parts of the S prefix.
+			if (!js.HasNoPrefix())
+				DISABLE;
+		}
 
 		// Vector unary operation
 		// d[N] = OP(s[N]) (see below)
@@ -763,7 +771,6 @@ namespace MIPSComp {
 		int vs = _VS;
 		int vd = _VD;
 
-		int optype = (op >> 16) & 0x1f;
 		if (optype >= 16 && !js.HasNoPrefix()) {
 			DISABLE;
 		} else if ((optype == 1 || optype == 2) && js.HasSPrefix()) {
@@ -1458,7 +1465,7 @@ namespace MIPSComp {
 
 	void IRFrontend::Comp_VDet(MIPSOpcode op) {
 		CONDITIONAL_DISABLE(VFPU_VEC);
-		if (js.HasUnknownPrefix() || !IsPrefixWithinSize(js.prefixS, op) || (js.prefixT & 0x000CFCF0) != 0x000E0) {
+		if (js.HasUnknownPrefix() || !IsPrefixWithinSize(js.prefixS, op) || js.HasTPrefix()) {
 			DISABLE;
 		}
 
@@ -1903,7 +1910,7 @@ namespace MIPSComp {
 
 	void IRFrontend::Comp_Vsgn(MIPSOpcode op) {
 		CONDITIONAL_DISABLE(VFPU_VEC);
-		if (js.HasUnknownPrefix() || !IsPrefixWithinSize(js.prefixS, op) || !IsPrefixWithinSize(js.prefixT, op)) {
+		if (js.HasUnknownPrefix() || !IsPrefixWithinSize(js.prefixS, op) || js.HasTPrefix()) {
 			DISABLE;
 		}
 
@@ -1999,7 +2006,7 @@ namespace MIPSComp {
 
 	void IRFrontend::Comp_Vbfy(MIPSOpcode op) {
 		CONDITIONAL_DISABLE(VFPU_VEC);
-		if (js.HasUnknownPrefix() || !IsPrefixWithinSize(js.prefixS, op) || js.HasTPrefix()) {
+		if (js.HasUnknownPrefix() || !IsPrefixWithinSize(js.prefixS, op) || js.HasTPrefix() || (js.prefixS & VFPU_NEGATE(1, 1, 1, 1)) != 0) {
 			DISABLE;
 		}
 


### PR DESCRIPTION
Some vcmps, etc. were perfectly valid but were forcing to interp. This also catches more cases that should go to interp correctly.

I must've not finished the old check and then not noticed?  Not really sure.  Didn't make sense as it was.

-[Unknown]