### PR TITLE
UI: Install textures as a zip if supported

### DIFF
--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -642,10 +642,10 @@ bool TextureReplacer::PopulateLevelFromZip(ReplacedTextureLevel &level, bool ign
 		if (zsize != INVALID_ZIP_SIZE)
 			pngdata.resize(zsize);
 		if (!pngdata.empty()) {
-			pngdata.resize(zip_fread(zf, pngdata.data(), pngdata.size()));
+			pngdata.resize(zip_fread(zf, &pngdata[0], pngdata.size()));
 		}
 
-		if (png_image_begin_read_from_memory(&png, pngdata.data(), pngdata.size())) {
+		if (png_image_begin_read_from_memory(&png, &pngdata[0], pngdata.size())) {
 			// We pad files that have been hashrange'd so they are the same texture size.
 			level.w = png.width;
 			level.h = png.height;
@@ -1168,10 +1168,10 @@ void ReplacedTexture::PrepareData(int level) {
 			if (zsize != INVALID_ZIP_SIZE)
 				pngdata.resize(zsize);
 			if (!pngdata.empty()) {
-				pngdata.resize(zip_fread(zf, pngdata.data(), pngdata.size()));
+				pngdata.resize(zip_fread(zf, &pngdata[0], pngdata.size()));
 			}
 
-			if (!png_image_begin_read_from_memory(&png, pngdata.data(), pngdata.size())) {
+			if (!png_image_begin_read_from_memory(&png, &pngdata[0], pngdata.size())) {
 				ERROR_LOG(G3D, "Could not load texture replacement info: %s - %s (zip)", info.file.c_str(), png.message);
 				cleanup();
 				return;

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -79,6 +79,7 @@ public:
 private:
 	bool InstallGame(Path url, Path tempFileName, bool deleteAfter);
 	bool InstallMemstickGame(struct zip *z, const Path &zipFile, const Path &dest, const ZipFileInfo &info, bool allowRoot, bool deleteAfter);
+	bool InstallMemstickZip(struct zip *z, const Path &zipFile, const Path &dest, const ZipFileInfo &info, bool deleteAfter);
 	bool InstallZippedISO(struct zip *z, int isoFileIndex, const Path &zipfile, bool deleteAfter);
 	bool InstallRawISO(const Path &zipFile, const std::string &originalName, bool deleteAfter);
 	void InstallDone();


### PR DESCRIPTION
This makes the zip installer copy a textures.zip file into place without extracting it.

To use:
 * Make sure the textures.zip file contains the textures.ini file on the root (not inside a folder.)
 * Make sure all the PNG or ZIM files are also inside the zip.  It should contain the entire texture pack.
 * Make sure the textures.ini contains `[games]` and has an entry such as `ULUS12345 = textures.ini` for your game (you can also use region-specific ini files if you wish, but using `= textures.ini` makes them all use the same ini.)
 * Simply browse to the zip file within PPSSPP, and try to open it as a game.
 * Note: if your texture pack supports multiple games, it will install for whatever game is in the recently played history or else the first game listed.

Also fixes #16313.

-[Unknown]