### PR TITLE
OpenXR - File access fix

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -47,9 +47,7 @@
         android:label="@string/app_name" 
         android:logo="@drawable/ic_banner"
         android:isGame="true"
-        android:banner="@drawable/tv_banner"
-        android:requestLegacyExternalStorage="true"
-        android:preserveLegacyExternalStorage="true">
+        android:banner="@drawable/tv_banner">
         <meta-data android:name="android.max_aspect" android:value="2.4" />
         <activity
             android:name=".PpssppActivity"

--- a/android/NormalManifest.xml
+++ b/android/NormalManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:allowBackup="true"
+        android:icon="@drawable/ic_launcher"
+        android:label="@string/app_name" 
+        android:logo="@drawable/ic_banner"
+        android:isGame="true"
+        android:banner="@drawable/tv_banner"
+        android:requestLegacyExternalStorage="true"
+        android:preserveLegacyExternalStorage="true">
+    </application>
+</manifest>

--- a/android/PicoManifest.xml
+++ b/android/PicoManifest.xml
@@ -11,8 +11,7 @@
         android:logo="@drawable/ic_banner"
         android:isGame="true"
         android:banner="@drawable/tv_banner"
-        android:requestLegacyExternalStorage="true"
-        android:preserveLegacyExternalStorage="true">
+        android:requestLegacyExternalStorage="true">
 
         <meta-data android:name="pvr.app.type" android:value="vr" />
     </application>

--- a/android/QuestManifest.xml
+++ b/android/QuestManifest.xml
@@ -11,8 +11,7 @@
         android:logo="@drawable/ic_banner"
         android:isGame="true"
         android:banner="@drawable/tv_banner"
-        android:requestLegacyExternalStorage="true"
-        android:preserveLegacyExternalStorage="true">
+        android:requestLegacyExternalStorage="true">
 
         <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
         <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2"/>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,6 @@ android {
 			}
 		}
 	}
-	compileSdkVersion 32
 	defaultConfig {
 		applicationId 'org.ppsspp.ppsspp'
 		if (androidGitVersion.name() != "unknown" && androidGitVersion.code() >= 14000000) {
@@ -60,7 +59,6 @@ android {
 		new File("versioncode.txt").write(androidGitVersion.code().toString())
 
 		minSdkVersion 9
-		targetSdkVersion 32
 		if (project.hasProperty("ANDROID_VERSION_CODE") && project.hasProperty("ANDROID_VERSION_NAME")) {
 			versionCode ANDROID_VERSION_CODE
 			versionName ANDROID_VERSION_NAME
@@ -100,7 +98,11 @@ android {
 					'../assets',
 			]
 		}
+		normal {
+			manifest.srcFile 'NormalManifest.xml'
+		}
 		gold {
+			manifest.srcFile 'NormalManifest.xml'
 			res.srcDirs = ['gold/res']
 		}
 		vr_pico {
@@ -113,6 +115,8 @@ android {
 	productFlavors {
 		normal {
 			applicationId 'org.ppsspp.ppsspp'
+			compileSdkVersion 32
+			targetSdkVersion 32
 			dimension "variant"
 			externalNativeBuild {
 				cmake {
@@ -131,6 +135,8 @@ android {
 		}
 		gold {
 			applicationId 'org.ppsspp.ppssppgold'
+			compileSdkVersion 32
+			targetSdkVersion 32
 			dimension "variant"
 			externalNativeBuild {
 				cmake {
@@ -150,6 +156,8 @@ android {
 		}
 		vr_pico {
 			applicationId 'org.ppsspp.ppsspp'
+			compileSdkVersion 29
+			targetSdkVersion 29
 			dimension "variant"
 			externalNativeBuild {
 				cmake {
@@ -170,6 +178,8 @@ android {
 		}
 		vr_quest {
 			applicationId 'org.ppsspp.ppsspp'
+			compileSdkVersion 29
+			targetSdkVersion 29
 			dimension "variant"
 			externalNativeBuild {
 				cmake {

--- a/android/src/org/ppsspp/ppsspp/ShortcutActivity.java
+++ b/android/src/org/ppsspp/ppsspp/ShortcutActivity.java
@@ -29,7 +29,7 @@ public class ShortcutActivity extends Activity {
 
 		// Show file selector dialog here. If Android version is more than or equal to 11,
 		// use the native document file browser instead of our SimpleFileChooser.
-		scoped = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R);
+		scoped = (Build.VERSION.SDK_INT >= 30);
 
 		if (scoped) {
 			try {


### PR DESCRIPTION
New headsets (Pico 4, Quest Pro) use Android 11 + but the storage behavior is not according to Google specifications.

This PR forces Android 10 SDK for VR builds to avoid the storage issues. Both Meta and Pico do not require compiling apps under specific SDKs.

Resolving issue https://github.com/hrydgard/ppsspp/issues/16317