### PR TITLE
GE Debugger: Try harder to identify unchanged VRAM

### DIFF
--- a/GPU/Debugger/Playback.cpp
+++ b/GPU/Debugger/Playback.cpp
@@ -46,6 +46,7 @@
 namespace GPURecord {
 
 static std::string lastExecFilename;
+static uint32_t lastExecVersion;
 static std::vector<Command> lastExecCommands;
 static std::vector<u8> lastExecPushbuf;
 static std::mutex executeLock;
@@ -761,6 +762,7 @@ static void ReplayStop() {
 	lastExecFilename.clear();
 	lastExecCommands.clear();
 	lastExecPushbuf.clear();
+	lastExecVersion = 0;
 }
 
 bool RunMountedReplay(const std::string &filename) {
@@ -769,7 +771,7 @@ bool RunMountedReplay(const std::string &filename) {
 	std::lock_guard<std::mutex> guard(executeLock);
 	Core_ListenStopRequest(&ReplayStop);
 
-	uint32_t version = 0;
+	uint32_t version = lastExecVersion;
 	if (lastExecFilename != filename) {
 		PROFILE_THIS_SCOPE("ReplayLoad");
 		u32 fp = pspFileSystem.OpenFile(filename, FILEACCESS_READ);
@@ -812,6 +814,7 @@ bool RunMountedReplay(const std::string &filename) {
 		}
 
 		lastExecFilename = filename;
+		lastExecVersion = version;
 	}
 
 	DumpExecute executor(lastExecPushbuf, lastExecCommands, version);

--- a/GPU/Debugger/Record.cpp
+++ b/GPU/Debugger/Record.cpp
@@ -420,9 +420,12 @@ static void FlushPrimState(int vcount) {
 	// We re-flush textures always in case the game changed them... kinda expensive.
 	// TODO: Dirty textures on transfer/stall/etc. somehow?
 	// TODO: Or maybe de-dup by validating if it has changed?
+	bool textureEnabled = gstate.isTextureMapEnabled() || gstate.isAntiAliasEnabled();
+	// Play it safe and allow texture coords to emit data too.
+	bool textureCoords = (gstate.vertType & GE_VTYPE_TC_MASK) != 0;
 	for (int level = 0; level < 8; ++level) {
 		u32 texaddr = gstate.getTextureAddress(level);
-		if (texaddr) {
+		if (texaddr && (textureEnabled || textureCoords)) {
 			EmitTextureData(level, texaddr);
 		}
 	}

--- a/GPU/Debugger/Record.cpp
+++ b/GPU/Debugger/Record.cpp
@@ -123,10 +123,10 @@ static void DirtyVRAM(u32 start, u32 sz, DirtyVRAMFlag flag) {
 }
 
 static void DirtyDrawnVRAM() {
-	int w = std::max(gstate.getScissorX2(), gstate.getRegionX2()) + 1;
-	int h = std::max(gstate.getScissorY2(), gstate.getRegionY2()) + 1;
+	int w = std::min(gstate.getScissorX2(), gstate.getRegionX2()) + 1;
+	int h = std::min(gstate.getScissorY2(), gstate.getRegionY2()) + 1;
 
-	bool drawZ = gstate.isDepthWriteEnabled() && gstate.isDepthTestEnabled();
+	bool drawZ = !gstate.isModeClear() && gstate.isDepthWriteEnabled() && gstate.isDepthTestEnabled();
 	bool clearZ = gstate.isModeClear() && gstate.isClearModeDepthMask();
 	if (drawZ || clearZ) {
 		int bytes = 2 * gstate.DepthBufStride() * h;


### PR DESCRIPTION
This attempts to improve the performance issue seen in #16307:
 * It dumped a CLUT8 segment of the texture that was bound during a clear, so let's skip that.
 * It dumped the texture as changed every time, which I suspect means each single pixel line was separated by a stall to the CPU.  Let's actually memcmp() with a shadow VRAM to see if it's really dirty.

This makes creating a frame dump (uncommon operation) take 2MB more RAM and slower, but avoids making weird performance issues in the playback.

-[Unknown]