### PR TITLE
Libretro buildfixes on Mac/ARM64

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -16,9 +16,7 @@ ifeq (,$(TARGET_ARCH))
 	TARGET_ARCH = $(shell uname -m)
 endif
 
-ifneq (,$(findstring 64,$(TARGET_ARCH)))
-   TARGET_ARCH := x86_64
-else ifneq (,$(findstring 86,$(TARGET_ARCH)))
+ifneq (,$(findstring 86,$(TARGET_ARCH)))
    TARGET_ARCH := x86
 endif
 
@@ -143,7 +141,7 @@ else ifneq (,$(findstring osx,$(platform)))
 	FFMPEGINCFLAGS += -I$(FFMPEGDIR)/macosx/universal/include
 	FFMPEGLIBDIR := $(FFMPEGDIR)/macosx/universal/lib
 	FFMPEGLDFLAGS += -liconv -L$(FFMPEGLIBDIR) -lavformat -lavcodec -lavutil -lswresample -lswscale
-	PLATCFLAGS += -D__MACOSX__
+	PLATCFLAGS += -D__MACOSX__ -Wno-pointer-sign -Wno-nullability-completeness
 	GL_LIB := -framework OpenGL
 	PLATFORM_EXT = darwin
 

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -664,15 +664,11 @@ ifeq ($(WITH_DYNAREC),1)
 		     $(COREDIR)/Util/DisArm64.cpp \
 		     $(GPUCOMMONDIR)/VertexDecoderArm64.cpp
 
-		ifeq ($(HAVE_NEON),1)
 			SOURCES_CXX   += \
 					 $(COREDIR)/MIPS/ARM/ArmCompVFPUNEON.cpp \
 					 $(COREDIR)/MIPS/ARM/ArmCompVFPUNEONUtil.cpp
-
 			SOURCES_C += $(EXTDIR)/libpng17/arm/arm_init.c \
 				     $(EXTDIR)/libpng17/arm/filter_neon_intrinsics.c
-			ASMFILES   += $(EXTDIR)/libpng17/arm/filter_neon.S
-		endif
    else
 	ifneq (,$(findstring msvc,$(platform)))
 	ifeq (,$(findstring x64,$(platform)))

--- a/libretro/README_MACOS.txt
+++ b/libretro/README_MACOS.txt
@@ -1,0 +1,4 @@
+To test-build CI for MacOS on ARM, use the following bag of tricks:
+
+TARGET_ARCH=arm LIBRETRO_APPLE_PLATFORM=arm64-apple-macos10.15 CROSS_COMPILE=1 LIBRETRO_APPLE_ISYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk  make -C . -f Makefile
+


### PR DESCRIPTION
* Makes it possible to build locally for libretro on mac/arm64. If it was possible before, I don't see how.
  - Additionally, this seems wrong, surely that platform line should be `arm64`: https://git.libretro.com/libretro-infrastructure/ci-templates/-/blob/master/osx-arm64.yml#L20

(Previously included #16322, too).