### PR TITLE
Build: Use Makefile for libretro

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,13 +168,13 @@ jobs:
           extra: libretro
           cc: gcc
           cxx: g++
-          args: ./b.sh --libretro
+          args: make -C libretro -f Makefile -j2
           id: gcc-libretro
         - os: ubuntu-latest
           extra: libretro
           cc: clang
           cxx: clang++
-          args: ./b.sh --libretro
+          args: make -C libretro -f Makefile -j2
           id: clang-libretro
 
         - os: macos-latest


### PR DESCRIPTION
Based on the comment in #16323, I'm assuming this is a more reasonable way to test than running cmake, which isn't used.  I didn't bother looking at what flags are needed for Android, so leaving that as it was.

(the X on the commit is because I tested on my fork, then canceled when libretro passed to not waste GitHub's macOS cycles.)

-[Unknown]