### PR TITLE
OpenXR - Enable camera movement and stereo in flatscreen mode

### DIFF
--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -453,22 +453,7 @@ bool Is2DVRObject(float* projMatrix, bool ortho) {
 	return identity;
 }
 
-void UpdateVRProjection(float* projMatrix, float* leftEye, float* rightEye) {
-
-	// Update project matrices
-	float* dst[] = {leftEye, rightEye};
-	VRMatrix enums[] = {VR_PROJECTION_MATRIX_LEFT_EYE, VR_PROJECTION_MATRIX_RIGHT_EYE};
-	for (int index = 0; index < 2; index++) {
-		ovrMatrix4f hmdProjection = VR_GetMatrix(enums[index]);
-		for (int i = 0; i < 4; i++) {
-			for (int j = 0; j < 4; j++) {
-				if ((hmdProjection.M[i][j] > 0) != (projMatrix[i * 4 + j] > 0)) {
-					hmdProjection.M[i][j] *= -1.0f;
-				}
-			}
-		}
-		memcpy(dst[index], hmdProjection.M, 16 * sizeof(float));
-	}
+void UpdateVRParams(float* projMatrix) {
 
 	// Set mirroring of axes
 	if (!VR_GetConfig(VR_CONFIG_MIRROR_UPDATED)) {
@@ -504,6 +489,22 @@ void UpdateVRProjection(float* projMatrix, float* leftEye, float* rightEye) {
 		VR_SetConfig(VR_CONFIG_6DOF_PRECISE, false);
 	}
 	VR_SetConfig(VR_CONFIG_6DOF_SCALE, (int)(scale * 1000000));
+}
+
+void UpdateVRProjection(float* projMatrix, float* leftEye, float* rightEye) {
+	float* dst[] = {leftEye, rightEye};
+	VRMatrix enums[] = {VR_PROJECTION_MATRIX_LEFT_EYE, VR_PROJECTION_MATRIX_RIGHT_EYE};
+	for (int index = 0; index < 2; index++) {
+		ovrMatrix4f hmdProjection = VR_GetMatrix(enums[index]);
+		for (int i = 0; i < 4; i++) {
+			for (int j = 0; j < 4; j++) {
+				if ((hmdProjection.M[i][j] > 0) != (projMatrix[i * 4 + j] > 0)) {
+					hmdProjection.M[i][j] *= -1.0f;
+				}
+			}
+		}
+		memcpy(dst[index], hmdProjection.M, 16 * sizeof(float));
+	}
 }
 
 void UpdateVRView(float* leftEye, float* rightEye) {

--- a/Common/VR/PPSSPPVR.h
+++ b/Common/VR/PPSSPPVR.h
@@ -42,6 +42,7 @@ int GetVRPassesCount();
 bool IsMultiviewSupported();
 bool IsFlatVRScene();
 bool Is2DVRObject(float* projMatrix, bool ortho);
+void UpdateVRParams(float* projMatrix);
 void UpdateVRProjection(float* projMatrix, float* leftEye, float* rightEye);
 void UpdateVRView(float* leftEye, float* rightEye);
 
@@ -70,6 +71,7 @@ inline int GetVRPassesCount() { return 1; }
 inline bool IsMultiviewSupported() { return false; }
 inline bool IsFlatVRScene() { return true; }
 inline bool Is2DVRObject(float* projMatrix, bool ortho) { return false; }
+inline void UpdateVRParams(float* projMatrix) {}
 inline void UpdateVRProjection(float* projMatrix, float* leftEye, float* rightEye) {}
 inline void UpdateVRView(float* leftEye, float* rightEye) {}
 

--- a/Common/VR/VRRenderer.cpp
+++ b/Common/VR/VRRenderer.cpp
@@ -306,7 +306,13 @@ bool VR_InitFrame( engine_t* engine ) {
 			float nearPlane = (float)vrConfig[VR_CONFIG_FOV_SCALE] / 200.0f;
 			vrMatrix[matrix] = ovrMatrix4f_CreateProjectionFov(fov.angleLeft, fov.angleRight, fov.angleUp, fov.angleDown, nearPlane, 0.0f );
 		} else if ((matrix == VR_VIEW_MATRIX_LEFT_EYE) || (matrix == VR_VIEW_MATRIX_RIGHT_EYE)) {
+			bool flatScreen = false;
 			XrPosef invView = invViewTransform[0];
+			int vrMode = vrConfig[VR_CONFIG_MODE];
+			if ((vrMode == VR_MODE_MONO_SCREEN) || (vrMode == VR_MODE_STEREO_SCREEN)) {
+				invView = XrPosef_Identity();
+				flatScreen = true;
+			}
 
 			// get axis mirroring configuration
 			float mx = vrConfig[VR_CONFIG_MIRROR_PITCH] ? -1 : 1;
@@ -333,7 +339,7 @@ bool VR_InitFrame( engine_t* engine ) {
 
 			vrMatrix[matrix] = ovrMatrix4f_CreateFromQuaternion(&invView.orientation);
 			float scale = (float)VR_GetConfig(VR_CONFIG_6DOF_SCALE) * 0.000001f;
-			if (vrConfig[VR_CONFIG_6DOF_ENABLED]) {
+			if (!flatScreen && vrConfig[VR_CONFIG_6DOF_ENABLED]) {
 				vrMatrix[matrix].M[0][3] -= hmdposition.x * (vrConfig[VR_CONFIG_MIRROR_AXIS_X] ? -1.0f : 1.0f) * scale;
 				vrMatrix[matrix].M[1][3] -= hmdposition.y * (vrConfig[VR_CONFIG_MIRROR_AXIS_Y] ? -1.0f : 1.0f) * scale;
 				vrMatrix[matrix].M[2][3] -= hmdposition.z * (vrConfig[VR_CONFIG_MIRROR_AXIS_Z] ? -1.0f : 1.0f) * scale;

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -411,6 +411,7 @@ void LinkedShader::UpdateUniforms(u32 vertType, const ShaderID &vsid, bool useBu
 			} else {
 				UpdateVRProjection(gstate.projMatrix, leftEyeMatrix.m, rightEyeMatrix.m);
 			}
+			UpdateVRParams(gstate.projMatrix);
 
 			FlipProjMatrix(leftEyeMatrix, useBufferedRendering);
 			FlipProjMatrix(rightEyeMatrix, useBufferedRendering);
@@ -542,7 +543,7 @@ void LinkedShader::UpdateUniforms(u32 vertType, const ShaderID &vsid, bool useBu
 			float rightEyeView[16];
 			ConvertMatrix4x3To4x4Transposed(leftEyeView, gstate.viewMatrix);
 			ConvertMatrix4x3To4x4Transposed(rightEyeView, gstate.viewMatrix);
-			if (!flatScreen && !is2D) {
+			if (!is2D) {
 				UpdateVRView(leftEyeView, rightEyeView);
 			}
 			render_->SetUniformM4x4Stereo("u_view", &u_view, leftEyeView, rightEyeView);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1161,8 +1161,7 @@ void GameSettingsScreen::CreateViews() {
 		vrSettings->Add(new CheckBox(&g_Config.bEnableVR, vr->T("Virtual reality")));
 		CheckBox *vr6DoF = vrSettings->Add(new CheckBox(&g_Config.bEnable6DoF, vr->T("6DoF movement")));
 		vr6DoF->SetEnabledPtr(&g_Config.bEnableVR);
-		CheckBox *vrStereo = vrSettings->Add(new CheckBox(&g_Config.bEnableStereo, vr->T("Stereoscopic vision (Experimental)")));
-		vrStereo->SetEnabledPtr(&g_Config.bEnableVR);
+		vrSettings->Add(new CheckBox(&g_Config.bEnableStereo, vr->T("Stereoscopic vision (Experimental)")));
 
 		vrSettings->Add(new ItemHeader(vr->T("VR camera")));
 		vrSettings->Add(new PopupSliderChoiceFloat(&g_Config.fCameraDistance, -10.0f, 10.0f, vr->T("Camera distance adjust", "Camera distance adjust"), 1.0f, screenManager(), ""));


### PR DESCRIPTION
Enable camera movement and stereo in flatscreen mode.

It was much easier than I thought. 6DoF would be also possible with flatscreen but it feels weird (like being in cinema and manipulate the scene by own movement).