### PR TITLE
OpenXR - Add an option to disable 72Hz update

### DIFF
--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -111,8 +111,6 @@ void InitVROnAndroid(void* vm, void* activity, int version, const char* name) {
 	java.AppVersion = version;
 	strcpy(java.AppName, name);
 	VR_Init(java, useVulkan);
-
-	__DisplaySetFramerate(72);
 }
 #endif
 
@@ -376,6 +374,7 @@ bool StartVRRender() {
 		}
 
 		// Set customizations
+		__DisplaySetFramerate(g_Config.bForce72Hz ? 72 : 60);
 		VR_SetConfig(VR_CONFIG_6DOF_ENABLED, g_Config.bEnable6DoF);
 		VR_SetConfig(VR_CONFIG_CAMERA_DISTANCE, g_Config.fCameraDistance * 1000);
 		VR_SetConfig(VR_CONFIG_CAMERA_HEIGHT, g_Config.fCameraHeight * 1000);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1208,6 +1208,7 @@ static ConfigSetting vrSettings[] = {
 	ConfigSetting("VREnable", &g_Config.bEnableVR, true),
 	ConfigSetting("VREnable6DoF", &g_Config.bEnable6DoF, true),
 	ConfigSetting("VREnableStereo", &g_Config.bEnableStereo, false),
+	ConfigSetting("VRbForce72Hz", &g_Config.bForce72Hz, true),
 	ConfigSetting("VRCameraDistance", &g_Config.fCameraDistance, 0.0f),
 	ConfigSetting("VRCameraHeight", &g_Config.fCameraHeight, 0.0f),
 	ConfigSetting("VRCameraSide", &g_Config.fCameraSide, 0.0f),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -463,6 +463,7 @@ public:
 	bool bEnableVR;
 	bool bEnable6DoF;
 	bool bEnableStereo;
+	bool bForce72Hz;
 	float fCameraDistance;
 	float fCameraHeight;
 	float fCameraSide;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1162,6 +1162,7 @@ void GameSettingsScreen::CreateViews() {
 		CheckBox *vr6DoF = vrSettings->Add(new CheckBox(&g_Config.bEnable6DoF, vr->T("6DoF movement")));
 		vr6DoF->SetEnabledPtr(&g_Config.bEnableVR);
 		vrSettings->Add(new CheckBox(&g_Config.bEnableStereo, vr->T("Stereoscopic vision (Experimental)")));
+		vrSettings->Add(new CheckBox(&g_Config.bForce72Hz, vr->T("Force 72Hz update")));
 
 		vrSettings->Add(new ItemHeader(vr->T("VR camera")));
 		vrSettings->Add(new PopupSliderChoiceFloat(&g_Config.fCameraDistance, -10.0f, 10.0f, vr->T("Camera distance adjust", "Camera distance adjust"), 1.0f, screenManager(), ""));


### PR DESCRIPTION
Add an option to disable 72Hz update.

72Hz update is needed to resolve laggy VR experience on Oculus Quest. In non-VR and on Pico headsets this problem doesn't exist. And I found that in SImpsons cutscenes 72Hz makes audio/video out of sync.