### PR TITLE
Support Android file intents with up to 3 dots in path

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -70,37 +70,28 @@
 				
 				<category android:name="android.intent.category.DEFAULT" />
 				<category android:name="android.intent.category.BROWSABLE" />
-				
-				<data
-					android:host="*"
-					android:mimeType="*/*"
-					android:pathPattern=".*\\.iso"
-					android:scheme="file" />
-				<data
-					android:host="*"
-					android:mimeType="*/*"
-					android:pathPattern=".*\\.cso"
-					android:scheme="file" />
-				<data
-					android:host="*"
-					android:mimeType="*/*"
-					android:pathPattern=".*\\.elf"
-					android:scheme="file" />
-				<data
-					android:host="*"
-					android:mimeType="*/*"
-					android:pathPattern=".*\\.ISO"
-					android:scheme="file" />
-				<data
-					android:host="*"
-					android:mimeType="*/*"
-					android:pathPattern=".*\\.CSO"
-					android:scheme="file" />
-				<data
-					android:host="*"
-					android:mimeType="*/*"
-					android:pathPattern=".*\\.ELF"
-					android:scheme="file" />
+
+				<data android:scheme="file" />
+				<data android:mimeType="*/*" />
+				<data android:host="*" />
+				<data android:pathPattern=".*\\.iso" />
+				<data android:pathPattern=".*\\..*\\.iso" />
+				<data android:pathPattern=".*\\..*\\..*\\.iso" />
+				<data android:pathPattern=".*\\.cso" />
+				<data android:pathPattern=".*\\..*\\.cso" />
+				<data android:pathPattern=".*\\..*\\..*\\.cso" />
+				<data android:pathPattern=".*\\.elf" />
+				<data android:pathPattern=".*\\..*\\.elf" />
+				<data android:pathPattern=".*\\..*\\..*\\.elf" />
+				<data android:pathPattern=".*\\.ISO" />
+				<data android:pathPattern=".*\\..*\\.ISO" />
+				<data android:pathPattern=".*\\..*\\..*\\.ISO" />
+				<data android:pathPattern=".*\\.CSO" />
+				<data android:pathPattern=".*\\..*\\.CSO" />
+				<data android:pathPattern=".*\\..*\\..*\\.CSO" />
+				<data android:pathPattern=".*\\.ELF" />
+				<data android:pathPattern=".*\\..*\\.ELF" />
+				<data android:pathPattern=".*\\..*\\..*\\.ELF" />
 			</intent-filter>
         </activity>
         <meta-data android:name="isGame" android:value="true" />


### PR DESCRIPTION
The file intent doesn't support paths with more than one dot in path. That means e.g. this path is not resolved (because of a dot in version number): `file:///storage/emulated/0/PSP/GTA - Chinatown Wars (v1.01).iso`

This PR adds support up to three dots in the path.