### PR TITLE
Vulkan: Switch RenderPassType to be a "proper" bitfield enum.

### DIFF
--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -32,12 +32,12 @@ static void MergeRenderAreaRectInto(VkRect2D *dest, VkRect2D &src) {
 RenderPassType MergeRPTypes(RenderPassType a, RenderPassType b) {
 	// Either both are backbuffer type, or neither are.
 	// These can't merge with other renderpasses
-	if (a == RP_TYPE_BACKBUFFER || b == RP_TYPE_BACKBUFFER) {
+	if (a == RenderPassType::BACKBUFFER || b == RenderPassType::BACKBUFFER) {
 		_dbg_assert_(a == b);
 		return a;
 	}
 
-	_dbg_assert_((a & RP_TYPE_MULTIVIEW_COLOR) == (b & RP_TYPE_MULTIVIEW_COLOR));
+	_dbg_assert_((a & RenderPassType::MULTIVIEW) == (b & RenderPassType::MULTIVIEW));
 
 	// The rest we can just OR together to get the maximum feature set.
 	return (RenderPassType)((u32)a | (u32)b);
@@ -198,7 +198,7 @@ bool VulkanQueueRunner::InitBackbufferFramebuffers(int width, int height) {
 	VkImageView attachments[2] = { VK_NULL_HANDLE, depth_.view };
 
 	VkFramebufferCreateInfo fb_info = { VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO };
-	fb_info.renderPass = GetCompatibleRenderPass()->Get(vulkan_, RP_TYPE_BACKBUFFER);
+	fb_info.renderPass = GetCompatibleRenderPass()->Get(vulkan_, RenderPassType::BACKBUFFER);
 	fb_info.attachmentCount = 2;
 	fb_info.pAttachments = attachments;
 	fb_info.width = width;
@@ -331,7 +331,7 @@ static VkAttachmentStoreOp ConvertStoreAction(VKRRenderPassStoreAction action) {
 
 VkRenderPass CreateRenderPass(VulkanContext *vulkan, const RPKey &key, RenderPassType rpType) {
 	bool selfDependency = RenderPassTypeHasInput(rpType);
-	bool isBackbuffer = rpType == RP_TYPE_BACKBUFFER;
+	bool isBackbuffer = rpType == RenderPassType::BACKBUFFER;
 	bool hasDepth = RenderPassTypeHasDepth(rpType);
 	bool multiview = RenderPassTypeHasMultiView(rpType);
 
@@ -898,6 +898,18 @@ const char *AspectToString(VkImageAspectFlags aspect) {
 	}
 }
 
+static const char *rpTypeDebugNames[] = {
+	"RENDER",
+	"RENDER_DEPTH",
+	"RENDER_INPUT",
+	"RENDER_DEPTH_INPUT",
+	"MV_RENDER",
+	"MV_RENDER_DEPTH",
+	"MV_RENDER_INPUT",
+	"MV_RENDER_DEPTH_INPUT",
+	"BACKBUF",
+};
+
 std::string VulkanQueueRunner::StepToString(const VKRStep &step) const {
 	char buffer[256];
 	switch (step.stepType) {
@@ -907,19 +919,7 @@ std::string VulkanQueueRunner::StepToString(const VKRStep &step) const {
 		int h = step.render.framebuffer ? step.render.framebuffer->height : vulkan_->GetBackbufferHeight();
 		int actual_w = step.render.renderArea.extent.width;
 		int actual_h = step.render.renderArea.extent.height;
-		const char *renderCmd;
-		switch (step.render.renderPassType) {
-		case RP_TYPE_BACKBUFFER: renderCmd = "BACKBUF"; break;
-		case RP_TYPE_COLOR: renderCmd = "RENDER"; break;
-		case RP_TYPE_COLOR_DEPTH: renderCmd = "RENDER_DEPTH"; break;
-		case RP_TYPE_COLOR_INPUT: renderCmd = "RENDER_INPUT"; break;
-		case RP_TYPE_COLOR_DEPTH_INPUT: renderCmd = "RENDER_DEPTH_INPUT"; break;
-		case RP_TYPE_MULTIVIEW_COLOR: renderCmd = "MV_RENDER"; break;
-		case RP_TYPE_MULTIVIEW_COLOR_DEPTH: renderCmd = "MV_RENDER_DEPTH"; break;
-		case RP_TYPE_MULTIVIEW_COLOR_INPUT: renderCmd = "MV_RENDER_INPUT"; break;
-		case RP_TYPE_MULTIVIEW_COLOR_DEPTH_INPUT: renderCmd = "MV_RENDER_DEPTH_INPUT"; break;
-		default: renderCmd = "N/A";
-		}
+		const char *renderCmd = rpTypeDebugNames[(size_t)step.render.renderPassType];
 		snprintf(buffer, sizeof(buffer), "%s %s %s (draws: %d, %dx%d/%dx%d)", renderCmd, step.tag, step.render.framebuffer ? step.render.framebuffer->Tag() : "", step.render.numDraws, actual_w, actual_h, w, h);
 		break;
 	}
@@ -1459,17 +1459,17 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 		{
 			VKRGraphicsPipeline *graphicsPipeline = c.graphics_pipeline.pipeline;
 			if (graphicsPipeline != lastGraphicsPipeline) {
-				if (!graphicsPipeline->pipeline[rpType]) {
+				if (!graphicsPipeline->pipeline[(size_t)rpType]) {
 					// NOTE: If render steps got merged, it can happen that, as they ended during recording,
 					// they didn't know their final render pass type so they created the wrong pipelines in EndCurRenderStep().
 					// Unfortunately I don't know if we can fix it in any more sensible place than here.
 					// Maybe a middle pass. But let's try to just block and compile here for now, this doesn't
 					// happen all that much.
-					graphicsPipeline->pipeline[rpType] = Promise<VkPipeline>::CreateEmpty();
+					graphicsPipeline->pipeline[(size_t)rpType] = Promise<VkPipeline>::CreateEmpty();
 					graphicsPipeline->Create(vulkan_, renderPass->Get(vulkan_, rpType), rpType);
 				}
 
-				VkPipeline pipeline = graphicsPipeline->pipeline[rpType]->BlockUntilReady();
+				VkPipeline pipeline = graphicsPipeline->pipeline[(size_t)rpType]->BlockUntilReady();
 				if (pipeline != VK_NULL_HANDLE) {
 					vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
 					pipelineLayout = c.pipeline.pipelineLayout;

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -54,7 +54,7 @@ enum class PipelineFlags : u8 {
 ENUM_CLASS_BITOPS(PipelineFlags);
 
 // Pipelines need to be created for the right type of render pass.
-// TODO: Rename to RenderPassType? It is currently a bitfield.
+// TODO: Rename to RenderPassFlags?
 // When you add more flags, don't forget to update rpTypeDebugNames[].
 enum class RenderPassType {
 	DEFAULT = 0,
@@ -73,8 +73,6 @@ enum class RenderPassType {
 	TYPE_COUNT = BACKBUFFER + 1,
 };
 ENUM_CLASS_BITOPS(RenderPassType);
-
-// Hm, soon time to exploit the bit properties in these..
 
 inline bool RenderPassTypeHasDepth(RenderPassType type) {
 	return (type & RenderPassType::HAS_DEPTH) || type == RenderPassType::BACKBUFFER;

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -77,7 +77,7 @@ public:
 	// TODO: Hide.
 	VulkanContext *vulkan_;
 private:
-	VkFramebuffer framebuf[RP_TYPE_COUNT]{};
+	VkFramebuffer framebuf[(size_t)RenderPassType::TYPE_COUNT]{};
 
 	std::string tag_;
 };
@@ -167,7 +167,7 @@ struct VKRComputePipelineDesc {
 // Wrapped pipeline. Doesn't own desc.
 struct VKRGraphicsPipeline {
 	~VKRGraphicsPipeline() {
-		for (int i = 0; i < RP_TYPE_COUNT; i++) {
+		for (size_t i = 0; i < (size_t)RenderPassType::TYPE_COUNT; i++) {
 			delete pipeline[i];
 		}
 	}
@@ -180,7 +180,7 @@ struct VKRGraphicsPipeline {
 	u32 GetVariantsBitmask() const;
 
 	VKRGraphicsPipelineDesc *desc = nullptr;  // not owned!
-	Promise<VkPipeline> *pipeline[RP_TYPE_COUNT]{};
+	Promise<VkPipeline> *pipeline[(size_t)RenderPassType::TYPE_COUNT]{};
 	std::string tag;
 };
 
@@ -201,7 +201,7 @@ struct VKRComputePipeline {
 struct CompileQueueEntry {
 	CompileQueueEntry(VKRGraphicsPipeline *p, VkRenderPass _compatibleRenderPass, RenderPassType _renderPassType)
 		: type(Type::GRAPHICS), graphics(p), compatibleRenderPass(_compatibleRenderPass), renderPassType(_renderPassType) {}
-	CompileQueueEntry(VKRComputePipeline *p) : type(Type::COMPUTE), compute(p), renderPassType(RP_TYPE_COLOR_DEPTH) {}
+	CompileQueueEntry(VKRComputePipeline *p) : type(Type::COMPUTE), compute(p), renderPassType(RenderPassType::HAS_DEPTH) {}  // renderpasstype here shouldn't matter
 	enum class Type {
 		GRAPHICS,
 		COMPUTE,

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1178,7 +1178,7 @@ Pipeline *VKContext::CreateGraphicsPipeline(const PipelineDesc &desc, const char
 	VkPipelineRasterizationStateCreateInfo rs{ VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO };
 	raster->ToVulkan(&gDesc.rs);
 
-	pipeline->pipeline = renderManager_.CreateGraphicsPipeline(&gDesc, pipelineFlags, 1 << RP_TYPE_BACKBUFFER, tag ? tag : "thin3d");
+	pipeline->pipeline = renderManager_.CreateGraphicsPipeline(&gDesc, pipelineFlags, 1 << (size_t)RenderPassType::BACKBUFFER, tag ? tag : "thin3d");
 
 	if (desc.uniformDesc) {
 		pipeline->dynamicUniformSize = (int)desc.uniformDesc->uniformBufferSize;


### PR DESCRIPTION
Just a little cleanup thing that's nice to get in separately from other stuff.