### PR TITLE
VK: Move the rarely used "u_rotation" uniform to the frame uniform buffer.

### DIFF
--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -72,6 +72,10 @@ void CalcCullRange(float minValues[4], float maxValues[4], bool flipViewport, bo
 	maxValues[3] = NAN;
 }
 
+void FrameUpdateUniforms(UB_Frame *ub, bool useBufferedRendering) {
+	ub->rotation = useBufferedRendering ? 0 : (float)g_display_rotation;
+}
+
 void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipViewport, bool useBufferedRendering) {
 	if (dirtyUniforms & DIRTY_TEXENV) {
 		Uint8x3ToFloat3(ub->texEnvColor, gstate.texenvcolor);
@@ -139,7 +143,6 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 			flippedMatrix = flippedMatrix * g_display_rot_matrix;
 		}
 		CopyMatrix4x4(ub->proj, flippedMatrix.getReadPtr());
-		ub->rotation = useBufferedRendering ? 0 : (float)g_display_rotation;
 	}
 
 	if (dirtyUniforms & DIRTY_PROJTHROUGHMATRIX) {
@@ -160,7 +163,6 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 		}
 
 		CopyMatrix4x4(ub->proj_through, proj_through.getReadPtr());
-		ub->rotation = useBufferedRendering ? 0 : (float)g_display_rotation;
 	}
 
 	// Transform

--- a/GPU/Common/ShaderUniforms.h
+++ b/GPU/Common/ShaderUniforms.h
@@ -27,7 +27,6 @@ struct alignas(16) UB_VS_FS_Base {
 	float tex[12];
 	float uvScaleOffset[4];
 	float depthRange[4];
-	// Rotation is used only for software transform.
 	float matAmbient[4];
 	float cullRangeMin[4];
 	float cullRangeMax[4];
@@ -37,7 +36,7 @@ struct alignas(16) UB_VS_FS_Base {
 	float fogColor[3]; uint32_t alphaColorRef;
 	float texEnvColor[3]; uint32_t colorTestMask;
 	float blendFixA[3]; float stencil;
-	float blendFixB[3]; float rotation;
+	float blendFixB[3]; float padUnused;
 	float texClamp[4];
 	float texClampOffset[2]; float fogCoef[2];
 	// VR stuff is to go here, later. For normal drawing, we can then get away
@@ -62,7 +61,7 @@ R"(  mat4 u_proj;
   vec3 u_fogcolor;  uint u_alphacolorref;
   vec3 u_texenv;    uint u_alphacolormask;
   vec3 u_blendFixA; float u_stencilReplaceValue;
-  vec3 u_blendFixB; float u_rotation;
+  vec3 u_blendFixB; float u_padUnused;
   vec4 u_texclamp;
   vec2 u_texclampoff;
   vec2 u_fogcoef;
@@ -132,13 +131,14 @@ R"(	mat3x4 u_bone0; mat3x4 u_bone1; mat3x4 u_bone2; mat3x4 u_bone3; mat3x4 u_bon
 )";
 
 
-static const char * const ub_frame_globalstr =
-R"( vec4 stereoParams;
+static const char * const ub_frameStr =
+R"(
+    float u_rotation;
 )";
 
 // Frame-global uniforms.
-struct UB_FrameGlobal {
-	float stereoParams[4];
+struct UB_Frame {
+	float rotation;  // This is only used when using software transform, and non-buffered, to support native screen rotation.
 };
 
 void CalcCullRange(float minValues[4], float maxValues[4], bool flipViewport, bool hasNegZ);
@@ -146,5 +146,6 @@ void CalcCullRange(float minValues[4], float maxValues[4], bool flipViewport, bo
 void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipViewport, bool useBufferedRendering);
 void LightUpdateUniforms(UB_VS_Lights *ub, uint64_t dirtyUniforms);
 void BoneUpdateUniforms(UB_VS_Bones *ub, uint64_t dirtyUniforms);
+void FrameUpdateUniforms(UB_Frame *ub, bool useBufferedRendering);
 
 uint32_t PackLightControlBits();

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -851,7 +851,7 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 			// The proj_through matrix already has the rotation, if needed.
 			WRITE(p, "  vec4 outPos = mul(u_proj_through, vec4(position.xyz, 1.0));\n");
 		} else {
-			if (compat.shaderLanguage == GLSL_VULKAN || compat.shaderLanguage == HLSL_D3D11) {
+			if (compat.shaderLanguage == GLSL_VULKAN) {
 				// Apply rotation from the uniform.
 				WRITE(p, "  mat2 displayRotation = mat2(\n");
 				WRITE(p, "    u_rotation == 0.0 ? 1.0 : (u_rotation == 2.0 ? -1.0 : 0.0), u_rotation == 1.0 ? 1.0 : (u_rotation == 3.0 ? -1.0 : 0.0),\n");

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -249,6 +249,11 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 
 	if (compat.shaderLanguage == GLSL_VULKAN) {
 		WRITE(p, "\n");
+
+		if (!useHWTransform) {
+			WRITE(p, "layout (std140, set = 0, binding = 0) uniform frameVars {\n%s};\n", ub_frameStr);
+		}
+
 		WRITE(p, "layout (std140, set = 1, binding = 3) uniform baseVars {\n%s};\n", ub_baseStr);
 		if (enableLighting || doShadeMapping)
 			WRITE(p, "layout (std140, set = 1, binding = 4) uniform lightVars {\n%s};\n", ub_vs_lightsStr);

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -1021,7 +1021,9 @@ void DrawEngineVulkan::DoFlush() {
 void DrawEngineVulkan::UpdateUBOs(FrameData *frame) {
 	if (!frame->frameDescSetUpdated) {
 		// Push frame global constants.
-		UB_FrameGlobal frameConstants{};
+		UB_Frame frameConstants{};
+		FrameUpdateUniforms(&frameConstants, framebufferManager_->UseBufferedRendering());
+
 		VkDescriptorBufferInfo frameConstantsBufInfo;
 		frame->pushUBO->PushUBOData(frameConstants, &frameConstantsBufInfo);
 


### PR DESCRIPTION
This uniform has been used in two cases:

* Non-buffered rendering in Vulkan, software transform
* Non-buffered rendering in D3D11 level 9 on Windows Phone, software transform
  - which I don't think anyone builds for anymore

We don't expose this new frame-global uniform buffer in D3D11, which might have been an issue if it weren't for the second point above. The other anticipated uses (stereo/VR) will also not be supported in D3D11, otherwise might have to add some support there.

Nice to not have it in the main uniform buffer, but mainly a demonstrator/test of moving stuff to the new frame-global buffer, and setting up the infrastructure.