### PR TITLE
Gradle upgrade, lock NDK version

### DIFF
--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -103,7 +103,7 @@ bool IsVRBuild() {
 }
 
 #if PPSSPP_PLATFORM(ANDROID)
-void InitVROnAndroid(void* vm, void* activity, const char* system, int version, char* name) {
+void InitVROnAndroid(void* vm, void* activity, const char* system, int version, const char* name) {
 
 	//Get device vendor (uppercase)
 	char vendor[64];

--- a/Common/VR/PPSSPPVR.h
+++ b/Common/VR/PPSSPPVR.h
@@ -21,7 +21,7 @@ enum VRCompatFlag {
 
 // VR app flow integration
 bool IsVRBuild();
-void InitVROnAndroid(void* vm, void* activity, const char* system, int version, char* name);
+void InitVROnAndroid(void* vm, void* activity, const char* system, int version, const char* name);
 void EnterVR(bool firstStart, void* vulkanContext);
 void GetVRResolutionPerEye(int* width, int* height);
 void UpdateVRInput(bool(*NativeKey)(const KeyInput &key), bool(*NativeTouch)(const TouchInput &touch), bool haptics, float dp_xscale, float dp_yscale);
@@ -50,7 +50,7 @@ void UpdateVRView(float* leftEye, float* rightEye);
 
 // VR app flow integration
 inline bool IsVRBuild() { return false; }
-inline void InitVROnAndroid(void* vm, void* activity, const char* system, int version, char* name) {}
+inline void InitVROnAndroid(void* vm, void* activity, const char* system, int version, const char* name) {}
 inline void EnterVR(bool firstTime, void* vulkanContext) {}
 inline void GetVRResolutionPerEye(int* width, int* height) {}
 inline void UpdateVRInput(bool(*NativeKey)(const KeyInput &key), bool(*NativeTouch)(const TouchInput &touch), bool haptics, float dp_xscale, float dp_yscale) {}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,8 @@ android {
 		}
 	}
 	compileSdkVersion 32
+	ndkVersion "21.4.7075529"
+
 	defaultConfig {
 		applicationId 'org.ppsspp.ppsspp'
 		if (androidGitVersion.name() != "unknown" && androidGitVersion.code() >= 14000000) {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,6 +3,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
Newer NDK versions create linking errors with our precompiled ffmpeg (which we really need to deal with...), so locking to 21.4.

Also fix a compiler warning.

