### PR TITLE
Vulkan: Use the very same view as input attachment and color attachment, not just the same image

### DIFF
--- a/Common/GPU/Vulkan/VulkanDebug.cpp
+++ b/Common/GPU/Vulkan/VulkanDebug.cpp
@@ -42,9 +42,10 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDebugUtilsCallback(
 		// UNASSIGNED
 		return false;
 	}
-	if (messageCode == 606910136) {
+	if (messageCode == 606910136 || messageCode == -392708513) {
 		// VUID-vkCmdDraw-None-02686
-		// Seems to be a bug in the validation layers, in the check that the input attachment is bound to a descriptor.
+		// Kinda false positive, or at least very unnecessary, now that I solved the real issue.
+		// See https://github.com/hrydgard/ppsspp/pull/16354
 		return false;
 	}
 

--- a/Common/GPU/Vulkan/VulkanDebug.cpp
+++ b/Common/GPU/Vulkan/VulkanDebug.cpp
@@ -42,6 +42,11 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDebugUtilsCallback(
 		// UNASSIGNED
 		return false;
 	}
+	if (messageCode == 606910136) {
+		// VUID-vkCmdDraw-None-02686
+		// Seems to be a bug in the validation layers, in the check that the input attachment is bound to a descriptor.
+		return false;
+	}
 
 	if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) {
 		message << "ERROR(";

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1703,11 +1703,8 @@ uint64_t VKContext::GetNativeObject(NativeObject obj, void *srcObject) {
 		return (uint64_t)(((VKTexture *)srcObject)->GetImageView());
 	case NativeObject::BOUND_FRAMEBUFFER_COLOR_IMAGEVIEW_ALL_LAYERS:
 		return (uint64_t)curFramebuffer_->GetFB()->color.texAllLayersView;
-	case NativeObject::BOUND_FRAMEBUFFER_COLOR_IMAGEVIEW_LAYER: {
-		size_t layer = (size_t)srcObject;
-		_dbg_assert_(layer < curFramebuffer_->Layers());
-		return (uint64_t)curFramebuffer_->GetFB()->color.texLayerViews[layer];
-	}
+	case NativeObject::BOUND_FRAMEBUFFER_COLOR_IMAGEVIEW_RT:
+		return (uint64_t)curFramebuffer_->GetFB()->color.rtView;
 	case NativeObject::FRAME_DATA_DESC_SET_LAYOUT:
 		return (uint64_t)frameDescSetLayout_;
 	case NativeObject::THIN3D_PIPELINE_LAYOUT:

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -245,7 +245,7 @@ enum class NativeObject {
 	BOUND_TEXTURE0_IMAGEVIEW,  // Layer etc depends on how you bound it...
 	BOUND_TEXTURE1_IMAGEVIEW,  // Layer etc depends on how you bound it...
 	BOUND_FRAMEBUFFER_COLOR_IMAGEVIEW_ALL_LAYERS,
-	BOUND_FRAMEBUFFER_COLOR_IMAGEVIEW_LAYER, // use an int cast to void *srcObject to specify layer.
+	BOUND_FRAMEBUFFER_COLOR_IMAGEVIEW_RT,
 	RENDER_MANAGER,
 	TEXTURE_VIEW,
 	NULL_IMAGEVIEW,

--- a/GPU/Vulkan/StateMappingVulkan.cpp
+++ b/GPU/Vulkan/StateMappingVulkan.cpp
@@ -381,6 +381,7 @@ void DrawEngineVulkan::BindShaderBlendTex() {
 			boundSecondaryIsInputAttachment_ = true;
 			fboTexBindState_ = FBO_TEX_NONE;
 		} else {
+			boundSecondaryIsInputAttachment_ = false;
 			boundSecondary_ = VK_NULL_HANDLE;
 		}
 	}

--- a/GPU/Vulkan/StateMappingVulkan.cpp
+++ b/GPU/Vulkan/StateMappingVulkan.cpp
@@ -377,7 +377,7 @@ void DrawEngineVulkan::BindShaderBlendTex() {
 			dirtyRequiresRecheck_ |= DIRTY_BLEND_STATE;
 		} else if (fboTexBindState_ == FBO_TEX_READ_FRAMEBUFFER) {
 			draw_->BindCurrentFramebufferForColorInput();
-			boundSecondary_ = (VkImageView)draw_->GetNativeObject(Draw::NativeObject::BOUND_FRAMEBUFFER_COLOR_IMAGEVIEW_LAYER, (void *)0);
+			boundSecondary_ = (VkImageView)draw_->GetNativeObject(Draw::NativeObject::BOUND_FRAMEBUFFER_COLOR_IMAGEVIEW_RT, (void *)0);
 			boundSecondaryIsInputAttachment_ = true;
 			fboTexBindState_ = FBO_TEX_NONE;
 		} else {


### PR DESCRIPTION
Fixes most of the new validation errors seen in #16351, though one remains.

I believe that to be a bug in the validation layers, will investigate later.