### PR TITLE
TexCache: Fix 16->32 colors with CLUT start pos

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1683,7 +1683,12 @@ CheckAlphaResult TextureCacheCommon::DecodeTextureLevel(u8 *out, int outPitch, G
 					// We simply expand the CLUT to 32-bit, then we deindex as usual. Probably the fastest way.
 					const u16 *clut = GetCurrentRawClut<u16>() + clutSharingOffset;
 					const int clutStart = gstate.getClutIndexStartPos();
-					ConvertFormatToRGBA8888(clutformat, expandClut_ + clutStart, clut + clutStart, 16);
+					if (gstate.getClutIndexShift() == 0 || gstate.getClutIndexMask() <= 16) {
+						ConvertFormatToRGBA8888(clutformat, expandClut_ + clutStart, clut + clutStart, 16);
+					} else {
+						// To be safe for shifts and wrap around, convert the entire CLUT.
+						ConvertFormatToRGBA8888(clutformat, expandClut_, clut, 512);
+					}
 					fullAlphaMask = 0xFF000000;
 					for (int y = 0; y < h; ++y) {
 						DeIndexTexture4<u32>((u32 *)(out + outPitch * y), texptr + (bufw * y) / 2, w, expandClut_, &alphaSum);

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -507,7 +507,7 @@ protected:
 
 	bool isBgraBackend_ = false;
 
-	u32 expandClut_[256];
+	u32 *expandClut_;
 };
 
 inline bool TexCacheEntry::Matches(u16 dim2, u8 format2, u8 maxLevel2) const {


### PR DESCRIPTION
When converting a texture from 16-bit to 32-bit (i.e. to save textures or for a GPU that lacks 16-bit texture support), we were expanding the CLUT to a buffer, and then using that directly, for efficiency.

This expansion failed to consider the start pos, so had uninitialized values or previous CLUT values in it.  Additionally, the buffer was not large enough for large start pos values, which could cause invalid accesses or other bad things.

This expands the buffer, aligns it (so color conv uses SIMD - it was usually at +4 before), and expands the portion of it pointed to by the start index (and shift.)

Fixes #16331, fixes #12188 (finally - must've been a device without 16-bit format support.)

-[Unknown]