### PR TITLE
TexCache: Cleanup BGRA flag dirtying

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -423,11 +423,7 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 	gstate_c.skipDrawReason &= ~SKIPDRAW_BAD_FB_TEXTURE;
 
 	bool isBgraTexture = isBgraBackend_ && !hasClutGPU;
-
-	if (gstate_c.bgraTexture != isBgraTexture) {
-		gstate_c.Dirty(DIRTY_FRAGMENTSHADER_STATE);
-	}
-	gstate_c.bgraTexture = isBgraTexture;
+	gstate_c.SetTextureIsBGRA(isBgraTexture);
 
 	if (entryIter != cache_.end()) {
 		entry = entryIter->second.get();
@@ -1093,12 +1089,10 @@ void TextureCacheCommon::SetTextureFramebuffer(const AttachCandidate &candidate)
 			gstate_c.curTextureWidth = RoundUpToPowerOf2(gstate_c.curTextureWidth);
 		}
 
-		if (gstate_c.bgraTexture) {
-			gstate_c.Dirty(DIRTY_FRAGMENTSHADER_STATE);
-		} else if ((gstate_c.curTextureXOffset == 0) != (fbInfo.xOffset == 0) || (gstate_c.curTextureYOffset == 0) != (fbInfo.yOffset == 0)) {
+		if ((gstate_c.curTextureXOffset == 0) != (fbInfo.xOffset == 0) || (gstate_c.curTextureYOffset == 0) != (fbInfo.yOffset == 0)) {
 			gstate_c.Dirty(DIRTY_FRAGMENTSHADER_STATE);
 		}
-		gstate_c.bgraTexture = false;
+		gstate_c.SetTextureIsBGRA(false);
 		gstate_c.curTextureXOffset = fbInfo.xOffset;
 		gstate_c.curTextureYOffset = fbInfo.yOffset;
 		u32 texW = (u32)gstate.getTextureWidth(0);

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -568,6 +568,12 @@ struct GPUStateCache {
 			Dirty(DIRTY_FRAGMENTSHADER_STATE);
 		}
 	}
+	void SetTextureIsBGRA(bool isBGRA) {
+		if (bgraTexture != isBGRA) {
+			bgraTexture = isBGRA;
+			Dirty(DIRTY_FRAGMENTSHADER_STATE);
+		}
+	}
 
 	u32 useFlags;
 


### PR DESCRIPTION
While looking at #16331, and not finding any cause for a BGRA swap, I figured this flag should dirty the same way as the others.

-[Unknown]