### PR TITLE
Mpeg: Correct YUV order from decode

### DIFF
--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -2199,25 +2199,17 @@ static int __MpegAvcConvertToYuv420(const void *data, u32 bufferOutputAddr, int 
 	return (width << 16) | height;
 }
 
-static int sceMpegAvcConvertToYuv420(u32 mpeg, u32 bufferOutputAddr, u32 unknown1, int unknown2)
-{
-	if (!Memory::IsValidAddress(bufferOutputAddr)) {
-		ERROR_LOG(ME, "sceMpegAvcConvertToYuv420(%08x, %08x, %08x, %08x): invalid addresses", mpeg, bufferOutputAddr, unknown1, unknown2);
-		return -1;
-	}
+static int sceMpegAvcConvertToYuv420(u32 mpeg, u32 bufferOutputAddr, u32 bufferAddr, int unknown2) {
+	if (!Memory::IsValidAddress(bufferOutputAddr))
+		return hleLogError(ME, ERROR_MPEG_INVALID_VALUE, "invalid addresses");
 
 	MpegContext *ctx = getMpegCtx(mpeg);
-	if (!ctx) {
-		WARN_LOG(ME, "sceMpegAvcConvertToYuv420(%08x, %08x, %08x, %08x): bad mpeg handle", mpeg, bufferOutputAddr, unknown1, unknown2);
-		return -1;
-	}
+	if (!ctx)
+		return hleLogWarning(ME, -1, "bad mpeg handle");
 
-	if (ctx->mediaengine->m_buffer == 0){
-		WARN_LOG(ME, "sceMpegAvcConvertToYuv420(%08x, %08x, %08x, %08x): m_buffer is zero ", mpeg, bufferOutputAddr, unknown1, unknown2);
-		return ERROR_MPEG_AVC_INVALID_VALUE;
-	}
+	if (ctx->mediaengine->m_buffer == 0)
+		return hleLogWarning(ME, ERROR_MPEG_AVC_INVALID_VALUE, "m_buffer is zero");
 
-	DEBUG_LOG(ME, "sceMpegAvcConvertToYuv420(%08x, %08x, %08x, %08x)", mpeg, bufferOutputAddr, unknown1, unknown2);
 	const u8 *data = ctx->mediaengine->getFrameImage();
 	int width = ctx->mediaengine->m_desWidth;
 	int height = ctx->mediaengine->m_desHeight;
@@ -2225,7 +2217,7 @@ static int sceMpegAvcConvertToYuv420(u32 mpeg, u32 bufferOutputAddr, u32 unknown
 	if (data) {
 		__MpegAvcConvertToYuv420(data, bufferOutputAddr, width, height);
 	}
-	return 0;
+	return hleLogSuccessX(ME, (width << 16) | height);
 }
 
 static int sceMpegGetUserdataAu(u32 mpeg, u32 streamUid, u32 auAddr, u32 resultAddr)
@@ -2397,7 +2389,7 @@ const HLEFunction sceMpeg[] =
 	{0X8160A2FE, &WrapU_U<sceMpegAvcResourceFinish>,           "sceMpegAvcResourceFinish",           'x', "x"      },
 	{0XAF26BB01, &WrapU_U<sceMpegAvcResourceGetAvcEsBuf>,      "sceMpegAvcResourceGetAvcEsBuf",      'x', "x"      },
 	{0XFCBDB5AD, &WrapU_U<sceMpegAvcResourceInit>,             "sceMpegAvcResourceInit",             'x', "x"      },
-	{0XF5E7EA31, &WrapI_UUUI<sceMpegAvcConvertToYuv420>,       "sceMpegAvcConvertToYuv420",          'i', "xxxi"   },
+	{0XF5E7EA31, &WrapI_UUUI<sceMpegAvcConvertToYuv420>,       "sceMpegAvcConvertToYuv420",          'x', "xxxi"   },
 	{0X01977054, &WrapI_UUUU<sceMpegGetUserdataAu>,            "sceMpegGetUserdataAu",               'i', "xxxx"   },
 	{0X3C37A7A6, &WrapU_UU<sceMpegNextAvcRpAu>,                "sceMpegNextAvcRpAu",                 'x', "xx"     },
 	{0X11F95CF1, &WrapU_U<sceMpegGetAvcNalAu>,                 "sceMpegGetAvcNalAu",                 'x', "x"      },

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -2173,28 +2173,26 @@ static int __MpegAvcConvertToYuv420(const void *data, u32 bufferOutputAddr, int 
 	u8 *Cb = Y + sizeY;
 	u8 *Cr = Cb + sizeCb;
 
-	for (int y = 0; y < height; ++y) {
-		for (int x = 0; x < width; x += 4) {
-			u32 abgr0 = imageBuffer[x + 0];
-			u32 abgr1 = imageBuffer[x + 1];
-			u32 abgr2 = imageBuffer[x + 2];
-			u32 abgr3 = imageBuffer[x + 3];
+	for (int y = 0; y < height; y += 2) {
+		for (int x = 0; x < width; x += 2) {
+			u32 abgr0 = imageBuffer[width * (y + 0) + x + 0];
+			u32 abgr1 = imageBuffer[width * (y + 0) + x + 1];
+			u32 abgr2 = imageBuffer[width * (y + 1) + x + 0];
+			u32 abgr3 = imageBuffer[width * (y + 1) + x + 1];
 
 			u32 yCbCr0 = convertABGRToYCbCr(abgr0);
 			u32 yCbCr1 = convertABGRToYCbCr(abgr1);
 			u32 yCbCr2 = convertABGRToYCbCr(abgr2);
 			u32 yCbCr3 = convertABGRToYCbCr(abgr3);
 			
-			Y[x + 0] = (yCbCr0 >> 16) & 0xFF;
-			Y[x + 1] = (yCbCr1 >> 16) & 0xFF;
-			Y[x + 2] = (yCbCr2 >> 16) & 0xFF;
-			Y[x + 3] = (yCbCr3 >> 16) & 0xFF;
+			Y[width * (y + 0) + x + 0] = (yCbCr0 >> 16) & 0xFF;
+			Y[width * (y + 0) + x + 1] = (yCbCr1 >> 16) & 0xFF;
+			Y[width * (y + 1) + x + 0] = (yCbCr2 >> 16) & 0xFF;
+			Y[width * (y + 1) + x + 1] = (yCbCr3 >> 16) & 0xFF;
 
-			*Cb++ = (yCbCr0 >> 8) & 0xFF;
-			*Cr++ = yCbCr0 & 0xFF;
+			Cb[(width >> 1) * (y >> 1) + (x >> 1)] = (yCbCr0 >> 8) & 0xFF;
+			Cr[(width >> 1) * (y >> 1) + (x >> 1)] = yCbCr0 & 0xFF;
 		}
-		imageBuffer += width;
-		Y += width ;
 	}
 	return (width << 16) | height;
 }


### PR DESCRIPTION
Some quick tests seem to confirm the previous order was wrong and was probably just to match sceJpeg.  This should actually improve the quality of the video compared to before.  Fixes #16360 (at least in the MH3 demo, which does call the same funcs.)

This also fixes the return value, which looks like it's intended to be passed right to sceJpegCsc.  Might fix something if a game does that, since previously it was returning a width/height of 0.

-[Unknown]