### PR TITLE
OpenXR - Sonic Rivals fixed

### DIFF
--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -655,7 +655,8 @@ bool Is2DVRObject(float* projMatrix, bool ortho) {
 void UpdateVRParams(float* projMatrix, float* viewMatrix) {
 
 	// Set mirroring of axes
-	if (!vrMirroring[VR_MIRRORING_UPDATED] && !IsMatrixIdentity(projMatrix) && !IsMatrixIdentity(viewMatrix)) {
+	bool identityView = PSP_CoreParameter().compat.vrCompat().IdentityViewHack && IsMatrixIdentity(viewMatrix);
+	if (!vrMirroring[VR_MIRRORING_UPDATED] && !IsMatrixIdentity(projMatrix) && !identityView) {
 		vrMirroring[VR_MIRRORING_UPDATED] = true;
 		vrMirroring[VR_MIRRORING_AXIS_X] = projMatrix[0] < 0;
 		vrMirroring[VR_MIRRORING_AXIS_Y] = projMatrix[5] < 0;
@@ -697,7 +698,7 @@ void UpdateVRView(float* leftEye, float* rightEye) {
 	for (int index = 0; index < 2; index++) {
 
 		// Validate the view matrix
-		if (IsMatrixIdentity(dst[index])) {
+		if (PSP_CoreParameter().compat.vrCompat().IdentityViewHack && IsMatrixIdentity(dst[index])) {
 			return;
 		}
 

--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -652,10 +652,10 @@ bool Is2DVRObject(float* projMatrix, bool ortho) {
 	return identity;
 }
 
-void UpdateVRParams(float* projMatrix) {
+void UpdateVRParams(float* projMatrix, float* viewMatrix) {
 
 	// Set mirroring of axes
-	if (!vrMirroring[VR_MIRRORING_UPDATED]) {
+	if (!vrMirroring[VR_MIRRORING_UPDATED] && !IsMatrixIdentity(projMatrix) && !IsMatrixIdentity(viewMatrix)) {
 		vrMirroring[VR_MIRRORING_UPDATED] = true;
 		vrMirroring[VR_MIRRORING_AXIS_X] = projMatrix[0] < 0;
 		vrMirroring[VR_MIRRORING_AXIS_Y] = projMatrix[5] < 0;

--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -644,20 +644,8 @@ bool Is2DVRObject(float* projMatrix, bool ortho) {
 		return true;
 	}
 
-	// Chceck if the projection matrix is identity
-	bool identity = true;
-	for (int i = 0; i < 4; i++) {
-		for (int j = 0; j < 4; j++) {
-			float value = projMatrix[i * 4 + j];
-
-			// Other number than zero on non-diagonale
-			if ((i != j) && (fabs(value) > EPSILON)) identity = false;
-			// Other number than one on diagonale
-			if ((i == j) && (fabs(value - 1.0f) > EPSILON)) identity = false;
-		}
-	}
-
 	// Update 3D geometry count
+	bool identity = IsMatrixIdentity(projMatrix);
 	if (!identity && !ortho) {
 		vr3DGeometryCount++;
 	}
@@ -707,6 +695,11 @@ void UpdateVRView(float* leftEye, float* rightEye) {
 	float* dst[] = {leftEye, rightEye};
 	float* matrix[] = {vrMatrix[VR_VIEW_MATRIX_LEFT_EYE], vrMatrix[VR_VIEW_MATRIX_RIGHT_EYE]};
 	for (int index = 0; index < 2; index++) {
+
+		// Validate the view matrix
+		if (IsMatrixIdentity(dst[index])) {
+			return;
+		}
 
 		// Get view matrix from the game
 		Lin::Matrix4x4 gameView = {};

--- a/Common/VR/PPSSPPVR.h
+++ b/Common/VR/PPSSPPVR.h
@@ -40,6 +40,6 @@ int GetVRPassesCount();
 bool IsMultiviewSupported();
 bool IsFlatVRScene();
 bool Is2DVRObject(float* projMatrix, bool ortho);
-void UpdateVRParams(float* projMatrix);
+void UpdateVRParams(float* projMatrix, float* viewMatrix);
 void UpdateVRProjection(float* projMatrix, float* leftEye, float* rightEye);
 void UpdateVRView(float* leftEye, float* rightEye);

--- a/Common/VR/VRMath.cpp
+++ b/Common/VR/VRMath.cpp
@@ -13,6 +13,20 @@ float ToRadians(float deg) {
 	return (float)(deg * M_PI / 180.0f);
 }
 
+bool IsMatrixIdentity(float* matrix) {
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			float value = matrix[i * 4 + j];
+
+			// Other number than zero on non-diagonale
+			if ((i != j) && (fabs(value) > EPSILON)) return false;
+			// Other number than one on diagonale
+			if ((i == j) && (fabs(value - 1.0f) > EPSILON)) return false;
+		}
+	}
+	return true;
+}
+
 /*
 ================================================================================
 

--- a/Common/VR/VRMath.h
+++ b/Common/VR/VRMath.h
@@ -9,6 +9,7 @@
 
 float ToDegrees(float rad);
 float ToRadians(float deg);
+bool IsMatrixIdentity(float* matrix);
 
 // XrPosef
 XrPosef XrPosef_Identity();

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -122,6 +122,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {
+	CheckSetting(iniFile, gameID, "IdentityViewHack", &vrCompat_.IdentityViewHack);
 	CheckSetting(iniFile, gameID, "Skyplane", &vrCompat_.Skyplane);
 	CheckSetting(iniFile, gameID, "UnitsPerMeter", &vrCompat_.UnitsPerMeter);
 

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -93,6 +93,7 @@ struct CompatFlags {
 };
 
 struct VRCompat {
+	bool IdentityViewHack;
 	bool Skyplane;
 	float UnitsPerMeter;
 };

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -411,7 +411,9 @@ void LinkedShader::UpdateUniforms(u32 vertType, const ShaderID &vsid, bool useBu
 			} else {
 				UpdateVRProjection(gstate.projMatrix, leftEyeMatrix.m, rightEyeMatrix.m);
 			}
-			UpdateVRParams(gstate.projMatrix);
+			float m4x4[16];
+			ConvertMatrix4x3To4x4Transposed(m4x4, gstate.viewMatrix);
+			UpdateVRParams(gstate.projMatrix, m4x4);
 
 			FlipProjMatrix(leftEyeMatrix, useBufferedRendering);
 			FlipProjMatrix(rightEyeMatrix, useBufferedRendering);

--- a/assets/compatvr.ini
+++ b/assets/compatvr.ini
@@ -30,6 +30,18 @@
 # ========================================================================================
 
 
+[IdentityViewHack]
+# Disables head tracking for render passes where view matrix is Identity
+
+# Sonic Rivals 1
+ULES00622 = true
+ULUS10195 = true
+
+# Sonic Rivals 2
+ULES00940 = true
+ULUS10323 = true
+
+
 [Skyplane]
 # Workaround to remove the background skyplane and add clearing framebuffer with a fog color.
 
@@ -52,6 +64,7 @@ ULJM05297 = true
 ULJM05395 = true
 ULJM05884 = true
 ULUS10160 = true
+
 
 [UnitsPerMeter]
 # Scale of game world to convert the world units into meters. This enables following VR features:


### PR DESCRIPTION
Disables head tracking for render passes where view matrix is identity. Unfortunatelly this breaks some games (e.g. Lego Batman), also I had to add it as an option into `compatvr.ini`.