### PR TITLE
Fix alpha/stencil replace on Adreno when color masked

### DIFF
--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -835,7 +835,9 @@ VKContext::VKContext(VulkanContext *vulkan)
 		}
 		// Color write mask not masking write in certain scenarios with a depth test, see #10421.
 		// Known still present on driver 0x80180000 and Adreno 5xx (possibly more.)
-		bugs_.Infest(Bugs::COLORWRITEMASK_BROKEN_WITH_DEPTHTEST);
+		// Known working on driver 0x801EA000 and Adreno 620.
+		if (deviceProps.driverVersion < 0x801EA000 || deviceProps.deviceID < 0x06000000)
+			bugs_.Infest(Bugs::COLORWRITEMASK_BROKEN_WITH_DEPTHTEST);
 
 		// Trying to follow all the rules in https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#synchronization-pipeline-barriers-subpass-self-dependencies
 		// and https://registry.khronos.org/vulkan/specs/1.3/html/vkspec.html#renderpass-feedbackloop, but still it doesn't

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -1070,6 +1070,15 @@ static void ConvertMaskState(GenericMaskState &maskState, bool shaderBitOpsSuppo
 		maskState.channelMask &= ~8;
 		maskState.uniformMask &= ~0xFF000000;
 	}
+
+	// For 5551, only the top alpha bit matters.  We might even want to swizzle 4444.
+	// Alpha should correctly read as 255 from a 5551 texture.
+	if (gstate.FrameBufFormat() == GE_FORMAT_5551) {
+		if ((maskState.uniformMask & 0x80000000) != 0)
+			maskState.uniformMask |= 0xFF000000;
+		else
+			maskState.uniformMask &= ~0xFF000000;
+	}
 }
 
 // Called even if AlphaBlendEnable == false - it also deals with stencil-related blend state.

--- a/GPU/Vulkan/StateMappingVulkan.cpp
+++ b/GPU/Vulkan/StateMappingVulkan.cpp
@@ -209,10 +209,11 @@ void DrawEngineVulkan::ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManag
 			if ((gstate.pmskc & 0x00FFFFFF) == 0x00FFFFFF && g_Config.bVendorBugChecksEnabled && draw_->GetBugs().Has(Draw::Bugs::COLORWRITEMASK_BROKEN_WITH_DEPTHTEST)) {
 				key.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
 				if (!key.blendEnable) {
+					bool writeAlpha = maskState.channelMask & 8;
 					key.blendEnable = true;
 					key.blendOpAlpha = VK_BLEND_OP_ADD;
-					key.srcAlpha = VK_BLEND_FACTOR_ZERO;
-					key.destAlpha = VK_BLEND_FACTOR_ONE;
+					key.srcAlpha = writeAlpha ? VK_BLEND_FACTOR_ONE : VK_BLEND_FACTOR_ZERO;
+					key.destAlpha = writeAlpha ? VK_BLEND_FACTOR_ZERO : VK_BLEND_FACTOR_ONE;
 				}
 				key.blendOpColor = VK_BLEND_OP_ADD;
 				key.srcColor = VK_BLEND_FACTOR_ZERO;


### PR DESCRIPTION
Fixes #13391, fixes #13886 (at least for the frame dumps.)  The workaround in #10421 was activating, but didn't care about replacing alpha with stencil.  This makes it blend based on the mask.

While looking for why, I noticed that we set uniformMask to 0x7FFFFFFF when games use 5551 and specify everything but alpha masked, which is a bit wrong.  Better to write FF not 80.  In theory, could do this for 4444 as well, but I don't think it's as important there.

-[Unknown]