### PR TITLE
GPU: Add a small error-compensation to depth clip

### DIFF
--- a/GPU/Common/GeometryShaderGenerator.cpp
+++ b/GPU/Common/GeometryShaderGenerator.cpp
@@ -123,7 +123,8 @@ bool GenerateGeometryShader(const GShaderID &id, char *buffer, const ShaderLangu
 	if (!gstate_c.Use(GPU_USE_CLIP_DISTANCE)) {
 		// This is basically the same value as gl_ClipDistance would take, z + w.
 		if (vertexRangeCulling) {
-			p.C("    clip0[i] = projZ * outPos.w + outPos.w;\n");
+			// We add a small amount to prevent error as in #15816 (PSP Z is only 16-bit fixed point, anyway.)
+			p.F("    clip0[i] = projZ * outPos.w + outPos.w + %f;\n", 0.0625 / 65536.0);
 		} else {
 			// Let's not complicate the code overly for this case.  We'll clipClampedDepth.
 			p.C("    clip0[i] = 0.0;\n");
@@ -290,7 +291,8 @@ bool GenerateGeometryShader(const GShaderID &id, char *buffer, const ShaderLangu
 			p.F("    gl_ClipDistance%s = projZ * outPos.w + outPos.w;\n", clipSuffix1);
 		} else {
 			// We shouldn't need to worry about rectangles-as-triangles here, since we don't use geometry shaders for that.
-			p.F("    gl_ClipDistance%s = projZ * outPos.w + outPos.w;\n", clipSuffix0);
+			// We add a small amount to prevent error as in #15816 (PSP Z is only 16-bit fixed point, anyway.)
+			p.F("    gl_ClipDistance%s = projZ * outPos.w + outPos.w + %f;\n", clipSuffix0, 0.0625 / 65536.0);
 		}
 		p.C("    gl_Position = outPos;\n");
 		if (gstate_c.Use(GPU_USE_CLIP_DISTANCE)) {

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1328,7 +1328,8 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 		const char *cull1 = compat.shaderLanguage == HLSL_D3D11 ? ".y" : "[1]";
 		if (gstate_c.Use(GPU_USE_CLIP_DISTANCE)) {
 			// TODO: Ignore triangles from GE_PRIM_RECTANGLES in transform mode, which should not clip to neg z.
-			WRITE(p, "  %sgl_ClipDistance%s = projZ * outPos.w + outPos.w;\n", compat.vsOutPrefix, vertexRangeClipSuffix);
+			// We add a small amount to prevent error as in #15816 (PSP Z is only 16-bit fixed point, anyway.)
+			WRITE(p, "  %sgl_ClipDistance%s = projZ * outPos.w + outPos.w + %f;\n", compat.vsOutPrefix, vertexRangeClipSuffix, 0.0625 / 65536.0);
 		}
 		if (gstate_c.Use(GPU_USE_CULL_DISTANCE)) {
 			// Cull any triangle fully outside in the same direction when depth clamp enabled.


### PR DESCRIPTION
This was causing a depth that should've calculated as zero to be clipped, because the multiply and division resulted in a value that was off by about 2 / pow(2, 24) in the negative direction.  Fixes #15816.  I think this small a value should just be safe, and might fix other similar cases.

Using 1/16 of 1/65536, but keeping the terms separate for clarity since PSP depth is 65536.

-[Unknown]