### PR TITLE
softgpu: Fix off-by-one rendering after half-pixel

### DIFF
--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -893,7 +893,7 @@ void DrawRectangle(const VertexData &v0, const VertexData &v1, const BinCoords &
 #endif
 
 	for (int64_t curY = minY; curY <= maxY; curY += SCREEN_SCALE_FACTOR * 2, rowST += sty) {
-		DrawingCoords p = TransformUnit::ScreenToDrawing(range.x1, curY);
+		DrawingCoords p = TransformUnit::ScreenToDrawing(minX, curY);
 
 		int scissorY2 = curY + SCREEN_SCALE_FACTOR > maxY ? -1 : 0;
 		Vec4<int> scissor_mask = Vec4<int>(0, maxX - minX - SCREEN_SCALE_FACTOR, scissorY2, (maxX - minX - SCREEN_SCALE_FACTOR) | scissorY2);


### PR DESCRIPTION
If the X is after the center of a pixel, the first pixel we draw is the next one.  This wasn't being accounted for properly in one place which resulted in the actual bytes written to the screen being off.

See #16131 - Beyond the Milky Way example.

-[Unknown]