### PR TITLE
softgpu: Use threads on self-render if safe

### DIFF
--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -273,6 +273,7 @@ private:
 	void MarkPendingReads(const Rasterizer::RasterizerState &state);
 	void MarkPendingWrites(const Rasterizer::RasterizerState &state);
 	bool HasTextureWrite(const Rasterizer::RasterizerState &state);
+	bool IsExactSelfRender(const Rasterizer::RasterizerState &state, const BinItem &item);
 	BinCoords Scissor(BinCoords range);
 	BinCoords Range(const VertexData &v0, const VertexData &v1, const VertexData &v2);
 	BinCoords Range(const VertexData &v0, const VertexData &v1);


### PR DESCRIPTION
Some games, such as Prince of Persia, self-render 1:1 to colorize, rather than to scale or blur.  We can still use threads in these cases.

This improves Prince of Persia - Rival Swords performance by almost 10% (63% -> 69% speed.)  It'd be safe to avoid flushing here too, but that's harder since we have to recalculate on each if it's safe.

This might not help games that use tiny tiles as well unless we recognize and combine them, which we might already be doing.

-[Unknown]