### PR TITLE
Twinbee Portable: Add compat flag to avoid game bug with some languages

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -119,6 +119,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "AllowDownloadCLUT", &flags_.AllowDownloadCLUT);
 	CheckSetting(iniFile, gameID, "NearestFilteringOnFramebufferCreate", &flags_.NearestFilteringOnFramebufferCreate);
 	CheckSetting(iniFile, gameID, "SecondaryTextureCache", &flags_.SecondaryTextureCache);
+	CheckSetting(iniFile, gameID, "EnglishOrJapaneseOnly", &flags_.EnglishOrJapaneseOnly);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -90,6 +90,7 @@ struct CompatFlags {
 	bool AllowDownloadCLUT;
 	bool NearestFilteringOnFramebufferCreate;
 	bool SecondaryTextureCache;
+	bool EnglishOrJapaneseOnly;
 };
 
 struct VRCompat {

--- a/Core/HLE/sceImpose.cpp
+++ b/Core/HLE/sceImpose.cpp
@@ -24,6 +24,7 @@
 #include "Core/MIPS/MIPS.h"
 #include "Core/Config.h"
 #include "Core/MemMap.h"
+#include "Core/System.h"
 
 const int PSP_UMD_POPUP_DISABLE = 0;
 const int PSP_UMD_POPUP_ENABLE = 1;
@@ -40,6 +41,11 @@ static u32 backlightOffTime;
 void __ImposeInit()
 {
 	language = g_Config.iLanguage;
+	if (PSP_CoreParameter().compat.flags().EnglishOrJapaneseOnly) {
+		if (language != PSP_SYSTEMPARAM_LANGUAGE_ENGLISH && language != PSP_SYSTEMPARAM_LANGUAGE_JAPANESE) {
+			language = PSP_SYSTEMPARAM_LANGUAGE_ENGLISH;
+		}
+	}
 	buttonValue = g_Config.iButtonPreference;
 	umdPopup = PSP_UMD_POPUP_DISABLE;
 	backlightOffTime = 0;

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -886,6 +886,11 @@ static u32 sceUtilityGetSystemParamInt(u32 id, u32 destaddr)
 		break;
 	case PSP_SYSTEMPARAM_ID_INT_LANGUAGE:
 		param = g_Config.iLanguage;
+		if (PSP_CoreParameter().compat.flags().EnglishOrJapaneseOnly) {
+			if (param != PSP_SYSTEMPARAM_LANGUAGE_ENGLISH && param != PSP_SYSTEMPARAM_LANGUAGE_JAPANESE) {
+				param = PSP_SYSTEMPARAM_LANGUAGE_ENGLISH;
+			}
+		}
 		break;
 	case PSP_SYSTEMPARAM_ID_INT_BUTTON_PREFERENCE:
 		param = g_Config.iButtonPreference;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1264,3 +1264,9 @@ ULES00850 = true
 ULUS10297 = true
 ULJM05516 = true
 NPJH50408 = true
+
+[EnglishOrJapaneseOnly]
+# Twinbee Portable, see issue #16382
+ULAS42089 = true
+ULJM05221 = true
+ULJM05323 = true


### PR DESCRIPTION
Blind fix (untested), enforcing English if language is not set to English or Japanese. Compat flag is easily motivated by the game crashing if the "wrong" language is set due to a bug in the game.

See issue #16382