### PR TITLE
Make breakpoints work better in interpreter

### DIFF
--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -646,10 +646,12 @@ const std::vector<BreakPoint> CBreakPoints::GetBreakpoints()
 	return breakPoints_;
 }
 
-bool CBreakPoints::HasMemChecks()
-{
-	std::lock_guard<std::mutex> guard(memCheckMutex_);
-	return !memChecks_.empty();
+bool CBreakPoints::HasBreakPoints() {
+	return anyBreakPoints_;
+}
+
+bool CBreakPoints::HasMemChecks() {
+	return anyMemChecks_;
 }
 
 void CBreakPoints::Update(u32 addr) {

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -31,6 +31,7 @@
 #include "Core/MIPS/JitCommon/JitCommon.h"
 #include "Core/CoreTiming.h"
 
+std::atomic<bool> anyBreakPoints_(false);
 std::atomic<bool> anyMemChecks_(false);
 
 static std::mutex breakPointsMutex_;
@@ -160,6 +161,8 @@ size_t CBreakPoints::FindMemCheck(u32 start, u32 end)
 
 bool CBreakPoints::IsAddressBreakPoint(u32 addr)
 {
+	if (!anyBreakPoints_)
+		return false;
 	std::lock_guard<std::mutex> guard(breakPointsMutex_);
 	size_t bp = FindBreakpoint(addr);
 	return bp != INVALID_BREAKPOINT && breakPoints_[bp].result != BREAK_ACTION_IGNORE;
@@ -167,6 +170,8 @@ bool CBreakPoints::IsAddressBreakPoint(u32 addr)
 
 bool CBreakPoints::IsAddressBreakPoint(u32 addr, bool* enabled)
 {
+	if (!anyBreakPoints_)
+		return false;
 	std::lock_guard<std::mutex> guard(breakPointsMutex_);
 	size_t bp = FindBreakpoint(addr);
 	if (bp == INVALID_BREAKPOINT) return false;
@@ -184,6 +189,8 @@ bool CBreakPoints::IsTempBreakPoint(u32 addr)
 
 bool CBreakPoints::RangeContainsBreakPoint(u32 addr, u32 size)
 {
+	if (!anyBreakPoints_)
+		return false;
 	std::lock_guard<std::mutex> guard(breakPointsMutex_);
 	const u32 end = addr + size;
 	for (const auto &bp : breakPoints_)
@@ -207,6 +214,7 @@ void CBreakPoints::AddBreakPoint(u32 addr, bool temp)
 		pt.addr = addr;
 
 		breakPoints_.push_back(pt);
+		anyBreakPoints_ = true;
 		guard.unlock();
 		Update(addr);
 	}
@@ -232,6 +240,7 @@ void CBreakPoints::RemoveBreakPoint(u32 addr)
 		if (bp != INVALID_BREAKPOINT)
 			breakPoints_.erase(breakPoints_.begin() + bp);
 
+		anyBreakPoints_ = !breakPoints_.empty();
 		guard.unlock();
 		Update(addr);
 	}
@@ -267,6 +276,8 @@ void CBreakPoints::ChangeBreakPoint(u32 addr, BreakAction result)
 
 void CBreakPoints::ClearAllBreakPoints()
 {
+	if (!anyBreakPoints_)
+		return;
 	std::unique_lock<std::mutex> guard(breakPointsMutex_);
 	if (!breakPoints_.empty())
 	{
@@ -278,9 +289,9 @@ void CBreakPoints::ClearAllBreakPoints()
 
 void CBreakPoints::ClearTemporaryBreakPoints()
 {
-	std::unique_lock<std::mutex> guard(breakPointsMutex_);
-	if (breakPoints_.empty())
+	if (!anyBreakPoints_)
 		return;
+	std::unique_lock<std::mutex> guard(breakPointsMutex_);
 
 	bool update = false;
 	for (int i = (int)breakPoints_.size()-1; i >= 0; --i)
@@ -342,6 +353,8 @@ void CBreakPoints::ChangeBreakPointLogFormat(u32 addr, const std::string &fmt) {
 }
 
 BreakAction CBreakPoints::ExecBreakPoint(u32 addr) {
+	if (!anyBreakPoints_)
+		return BREAK_ACTION_IGNORE;
 	std::unique_lock<std::mutex> guard(breakPointsMutex_);
 	size_t bp = FindBreakpoint(addr, false);
 	if (bp != INVALID_BREAKPOINT) {

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -167,6 +167,7 @@ public:
 	static const std::vector<MemCheck> GetMemChecks();
 	static const std::vector<BreakPoint> GetBreakpoints();
 
+	static bool HasBreakPoints();
 	static bool HasMemChecks();
 
 	static void Update(u32 addr = 0);

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -115,7 +115,7 @@ struct MemCheck {
 
 // BreakPoints cannot overlap, only one is allowed per address.
 // MemChecks can overlap, as long as their ends are different.
-// WARNING: MemChecks are not used in the interpreter or HLE currently.
+// WARNING: MemChecks are not always tracked in HLE currently.
 class CBreakPoints
 {
 public:

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -709,22 +709,8 @@ void DisassemblyFunction::load()
 				case 0x2B:	// sw
 					macro = new DisassemblyMacro(opAddress);
 					
-					int dataSize;
-					switch (nextInfo & MEMTYPE_MASK) {
-					case MEMTYPE_BYTE:
-						dataSize = 1;
-						break;
-					case MEMTYPE_HWORD:
-						dataSize = 2;
-						break;
-					case MEMTYPE_WORD:
-					case MEMTYPE_FLOAT:
-						dataSize = 4;
-						break;
-					case MEMTYPE_VQUAD:
-						dataSize = 16;
-						break;
-					default:
+					int dataSize = MIPSGetMemoryAccessSize(next);
+					if (dataSize == 0) {
 						delete macro;
 						return;
 					}

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -611,25 +611,7 @@ namespace MIPSAnalyst {
 
 	int OpMemoryAccessSize(u32 pc) {
 		const auto op = Memory::Read_Instruction(pc, true);
-		MIPSInfo info = MIPSGetInfo(op);
-		if ((info & (IN_MEM | OUT_MEM)) == 0) {
-			return 0;
-		}
-
-		// TODO: Verify lwl/lwr/etc.?
-		switch (info & MEMTYPE_MASK) {
-		case MEMTYPE_BYTE:
-			return 1;
-		case MEMTYPE_HWORD:
-			return 2;
-		case MEMTYPE_WORD:
-		case MEMTYPE_FLOAT:
-			return 4;
-		case MEMTYPE_VQUAD:
-			return 16;
-		}
-
-		return 0;
+		return MIPSGetMemoryAccessSize(op);
 	}
 
 	bool IsOpMemoryWrite(u32 pc) {
@@ -1553,21 +1535,7 @@ skip:
 		// lw, sh, ...
 		if (!IsSyscall(op) && (opInfo & (IN_MEM | OUT_MEM)) != 0) {
 			info.isDataAccess = true;
-			switch (opInfo & MEMTYPE_MASK) {
-			case MEMTYPE_BYTE:
-				info.dataSize = 1;
-				break;
-			case MEMTYPE_HWORD:
-				info.dataSize = 2;
-				break;
-			case MEMTYPE_WORD:
-			case MEMTYPE_FLOAT:
-				info.dataSize = 4;
-				break;
-
-			case MEMTYPE_VQUAD:
-				info.dataSize = 16;
-			}
+			info.dataSize = MIPSGetMemoryAccessSize(op);
 
 			u32 rs = cpu->GetRegValue(0, (int)MIPS_GET_RS(op));
 			s16 imm16 = op & 0xFFFF;

--- a/Core/MIPS/MIPSInt.h
+++ b/Core/MIPS/MIPSInt.h
@@ -23,8 +23,6 @@ int MIPS_SingleStep();
 
 namespace MIPSInt
 {
-	void Int_Unknown(MIPSOpcode op);
-	void Int_Unimpl(MIPSOpcode op);
 	void Int_Syscall(MIPSOpcode op);
 
 	void Int_mxc1(MIPSOpcode op);

--- a/Core/MIPS/MIPSIntVFPU.h
+++ b/Core/MIPS/MIPSIntVFPU.h
@@ -26,7 +26,6 @@ namespace MIPSInt
 	void Int_SV(MIPSOpcode op);
 	void Int_SVQ(MIPSOpcode op);
 	void Int_Mftv(MIPSOpcode op);
-	void Int_MatrixSet(MIPSOpcode op);
 	void Int_VecDo3(MIPSOpcode op);
 	void Int_Vcst(MIPSOpcode op);
 	void Int_VMatrixInit(MIPSOpcode op);

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -1081,6 +1081,27 @@ int MIPSGetInstructionCycleEstimate(MIPSOpcode op)
 	return GetInstructionCycleEstimate(instr);
 }
 
+int MIPSGetMemoryAccessSize(MIPSOpcode op) {
+	MIPSInfo info = MIPSGetInfo(op);
+	if ((info & (IN_MEM | OUT_MEM)) == 0) {
+		return 0;
+	}
+
+	switch (info & MEMTYPE_MASK) {
+	case MEMTYPE_BYTE:
+		return 1;
+	case MEMTYPE_HWORD:
+		return 2;
+	case MEMTYPE_WORD:
+	case MEMTYPE_FLOAT:
+		return 4;
+	case MEMTYPE_VQUAD:
+		return 16;
+	}
+
+	return 0;
+}
+
 const char *MIPSDisasmAt(u32 compilerPC) {
 	static char temp[256];
 	MIPSDisAsm(Memory::Read_Instruction(compilerPC), 0, temp);

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -976,8 +976,7 @@ int MIPSInterpret_RunUntil(u64 globalTicks)
 
 		//2: check for breakpoint (VERY SLOW)
 #if defined(_DEBUG)
-				if (CBreakPoints::IsAddressBreakPoint(curMips->pc))
-				{
+				if (CBreakPoints::IsAddressBreakPoint(curMips->pc) && CBreakPoints::CheckSkipFirst() != curMips->pc) {
 					auto cond = CBreakPoints::GetBreakPointCondition(currentMIPS->pc);
 					if (!cond || cond->Evaluate())
 					{

--- a/Core/MIPS/MIPSTables.h
+++ b/Core/MIPS/MIPSTables.h
@@ -130,5 +130,6 @@ int MIPSInterpret_RunUntil(u64 globalTicks);
 MIPSInterpretFunc MIPSGetInterpretFunc(MIPSOpcode op);
 
 int MIPSGetInstructionCycleEstimate(MIPSOpcode op);
+int MIPSGetMemoryAccessSize(MIPSOpcode op);
 const char *MIPSGetName(MIPSOpcode op);
 const char *MIPSDisasmAt(u32 compilerPC);


### PR DESCRIPTION
This runs any CPU or memory breakpoints from the interpreter in a separate runloop, so there's not that much speed impact, and enables them in release.  It does seem to be about 2-3% slower, but it seems to vary by the whims of the CPU a lot, I got less common timings that were faster by about 2% even.

Most people will be using IR or jit, so won't matter much anyway, I suppose.  I guess this is good for completeness and comparing with IR or jit, especially the memory breakpoints.

Fixes #16311.

-[Unknown]