### PR TITLE
Correct misbehavior on uninitialized values in IR

### DIFF
--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -795,7 +795,7 @@ namespace MIPSComp {
 		bool usingTemps = false;
 		u8 tempregs[4];
 		for (int i = 0; i < n; ++i) {
-			if (!IsOverlapSafe(dregs[i], n, sregs)) {
+			if (!IsOverlapSafeAllowS(dregs[i], i, n, sregs)) {
 				usingTemps = true;
 				tempregs[i] = IRVTEMP_0 + i;
 			} else {

--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -788,7 +788,7 @@ namespace MIPSComp {
 		VectorSize sz = GetVecSize(op);
 		int n = GetNumVectorElements(sz);
 
-		u8 sregs[4], dregs[4];
+		u8 sregs[4]{}, dregs[4]{};
 		GetVectorRegsPrefixS(sregs, sz, vs);
 		GetVectorRegsPrefixD(dregs, sz, vd);
 
@@ -809,7 +809,8 @@ namespace MIPSComp {
 		case 0:  // vmov
 		case 1:  // vabs
 		case 2:  // vneg
-			canSIMD = true;
+			// Our Vec4 ops require aligned regs and sets of 4.
+			canSIMD = n == 4 && (sregs[0] & 3) == 0 && (dregs[0] & 3) == 0;
 			break;
 		}
 


### PR DESCRIPTION
Decided to clean this up more generally, but I think it was only an issue in VV2Op.  Basically, it could be convinced to use Vec4 operations on size < 4, if stack happened to have consecutive values (perhaps from a previous Vec4 operation.)

See #10650.

-[Unknown]