### PR TITLE
Crash fix of Gran Turismo on Quest 2

### DIFF
--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -179,7 +179,7 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps, bool ski
 		case GLRInitStepType::CREATE_TEXTURE:
 		{
 			GLRTexture *tex = step.create_texture.texture;
-			glGenTextures(1, &tex->texture);
+			tex->GenerateTexture();
 			glBindTexture(tex->target, tex->texture);
 			boundTexture = tex->texture;
 			CHECK_GL_ERROR_IF_DEBUG();
@@ -492,7 +492,7 @@ void GLQueueRunner::InitCreateFramebuffer(const GLRInitStep &step) {
 	CHECK_GL_ERROR_IF_DEBUG();
 
 	auto initFBOTexture = [&](GLRTexture &tex, GLint internalFormat, GLenum format, GLenum type, bool linear) {
-		glGenTextures(1, &tex.texture);
+		tex.GenerateTexture();
 		tex.target = GL_TEXTURE_2D;
 		tex.maxLod = 0.0f;
 

--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -37,6 +37,7 @@ GLRTexture::GLRTexture(const Draw::DeviceCaps &caps, int width, int height, int 
 GLRTexture::~GLRTexture() {
 	if (texture) {
 		glDeleteTextures(1, &texture);
+		texture = 0;
 	}
 }
 

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -27,6 +27,7 @@ class GLRTexture {
 public:
 	GLRTexture(const Draw::DeviceCaps &caps, int width, int height, int depth, int numMips);
 	~GLRTexture();
+	void GenerateTexture();
 
 	GLuint texture = 0;
 	uint16_t w;


### PR DESCRIPTION
I wasn't able to figure out why is this happening but it seems the destructor of a texture is called twice.

This PR prevents that the second destruction causes a crash.