### PR TITLE
Make the pause screen "transparent"

### DIFF
--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -160,14 +160,7 @@ void GPU_D3D11::InitClear() {
 void GPU_D3D11::BeginHostFrame() {
 	GPUCommon::BeginHostFrame();
 	UpdateCmdInfo();
-	if (resized_) {
-		gstate_c.useFlags = CheckGPUFeatures();
-		framebufferManager_->Resized();
-		drawEngine_.NotifyConfigChanged();
-		textureCache_->NotifyConfigChanged();
-		shaderManagerD3D11_->DirtyLastShader();
-		resized_ = false;
-	}
+	CheckResized();
 }
 
 void GPU_D3D11::ReapplyGfxState() {

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -66,7 +66,7 @@ private:
 	}
 	// void ApplyDrawState(int prim);
 	void CheckFlushOp(int cmd, u32 diff);
-	void BuildReportingInfo();
+	void BuildReportingInfo() override;
 
 	void InitClear() override;
 	void BeginFrame() override;

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -150,14 +150,7 @@ void GPU_DX9::InitClear() {
 void GPU_DX9::BeginHostFrame() {
 	GPUCommon::BeginHostFrame();
 	UpdateCmdInfo();
-	if (resized_) {
-		gstate_c.useFlags = CheckGPUFeatures();
-		framebufferManager_->Resized();
-		drawEngine_.NotifyConfigChanged();
-		textureCache_->NotifyConfigChanged();
-		shaderManagerDX9_->DirtyShader();
-		resized_ = false;
-	}
+	CheckResized();
 }
 
 void GPU_DX9::ReapplyGfxState() {

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -63,7 +63,7 @@ private:
 		drawEngine_.Flush();
 	}
 	void CheckFlushOp(int cmd, u32 diff);
-	void BuildReportingInfo();
+	void BuildReportingInfo() override;
 
 	void InitClear() override;
 	void BeginFrame() override;

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -268,14 +268,7 @@ void GPU_GLES::InitClear() {
 void GPU_GLES::BeginHostFrame() {
 	GPUCommon::BeginHostFrame();
 	UpdateCmdInfo();
-	if (resized_) {
-		gstate_c.useFlags = CheckGPUFeatures();
-		framebufferManager_->Resized();
-		drawEngine_.NotifyConfigChanged();
-		textureCache_->NotifyConfigChanged();
-		shaderManagerGL_->DirtyShader();
-		resized_ = false;
-	}
+	CheckResized();
 
 	drawEngine_.BeginFrame();
 }

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -73,7 +73,7 @@ private:
 		drawEngine_.Flush();
 	}
 	void CheckFlushOp(int cmd, u32 diff);
-	void BuildReportingInfo();
+	void BuildReportingInfo() override;
 
 	void InitClear() override;
 	void BeginFrame() override;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -611,6 +611,20 @@ void GPUCommon::Resized() {
 	resized_ = true;
 }
 
+// Called once per frame. Might also get called during the pause screen
+// if "transparent".
+void GPUCommon::CheckResized() {
+	if (resized_) {
+		gstate_c.useFlags = CheckGPUFeatures();
+		BuildReportingInfo();
+		framebufferManager_->Resized();
+		drawEngineCommon_->NotifyConfigChanged();
+		textureCache_->NotifyConfigChanged();
+		shaderManager_->DirtyLastShader();
+		resized_ = false;
+	}
+}
+
 void GPUCommon::DumpNextFrame() {
 	dumpNextFrame_ = true;
 }

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -77,6 +77,7 @@ public:
 		return draw_;
 	}
 	virtual u32 CheckGPUFeatures() const;
+	void CheckResized() override;
 
 	void UpdateCmdInfo();
 
@@ -308,6 +309,8 @@ protected:
 	}
 
 	size_t FormatGPUStatsCommon(char *buf, size_t size);
+
+	virtual void BuildReportingInfo() = 0;
 
 	FramebufferManagerCommon *framebufferManager_ = nullptr;
 	TextureCacheCommon *textureCache_ = nullptr;

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -197,6 +197,7 @@ public:
 	// Frame managment
 	virtual void BeginHostFrame() = 0;
 	virtual void EndHostFrame() = 0;
+	virtual void CheckResized() = 0;
 
 	// Draw queue management
 	virtual DisplayList* getList(int listid) = 0;

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -205,6 +205,8 @@ protected:
 	void CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight);
 	void ConvertTextureDescFrom16(Draw::TextureDesc &desc, int srcwidth, int srcheight, const uint16_t *overrideData = nullptr);
 
+	void BuildReportingInfo() override {}
+
 private:
 	void MarkDirty(uint32_t addr, uint32_t stride, uint32_t height, GEBufferFormat fmt, SoftGPUVRAMDirty value);
 	void MarkDirty(uint32_t addr, uint32_t bytes, SoftGPUVRAMDirty value);

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -275,15 +275,7 @@ void GPU_Vulkan::BeginHostFrame() {
 	drawEngine_.BeginFrame();
 	UpdateCmdInfo();
 
-	if (resized_) {
-		gstate_c.useFlags = CheckGPUFeatures();
-		// In case the GPU changed.
-		BuildReportingInfo();
-		framebufferManager_->Resized();
-		drawEngine_.NotifyConfigChanged();
-		textureCache_->NotifyConfigChanged();
-		resized_ = false;
-	}
+	CheckResized();
 
 	textureCacheVulkan_->StartFrame();
 

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -77,7 +77,7 @@ private:
 		drawEngine_.Flush();
 	}
 	void CheckFlushOp(int cmd, u32 diff);
-	void BuildReportingInfo();
+	void BuildReportingInfo() override;
 	void InitClear() override;
 	void CopyDisplayToOutput(bool reallyDirty) override;
 	void Reinitialize() override;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1398,8 +1398,20 @@ void EmuScreen::render() {
 		// If we're paused and PauseScreen is transparent (will only be in buffered rendering mode), we just copy display to output.
 		thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_Paused");
 		if (PSP_IsInited()) {
+			gpu->CheckResized();
 			gpu->CopyDisplayToOutput(true);
 		}
+
+		screenManager()->getUIContext()->BeginFrame();
+		DrawContext *draw = screenManager()->getDrawContext();
+		Viewport viewport;
+		viewport.TopLeftX = 0;
+		viewport.TopLeftY = 0;
+		viewport.Width = pixel_xres;
+		viewport.Height = pixel_yres;
+		viewport.MaxDepth = 1.0;
+		viewport.MinDepth = 0.0;
+		draw->SetViewports(1, &viewport);
 		return;
 	}
 

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -364,6 +364,24 @@ GamePauseScreen::~GamePauseScreen() {
 	__DisplaySetWasPaused();
 }
 
+bool GamePauseScreen::isTransparent() const {
+	// We don't support transparent pause screen in skipbuffereffects mode.
+	return !g_Config.bSkipBufferEffects && !IsVREnabled();
+}
+
+void GamePauseScreen::DrawBackground(UIContext &dc) {
+	if (isTransparent()) {
+		// Darken the game screen coming from below, so the UI on top stands out.
+		dc.Flush();
+		uint32_t color = blackAlpha(0.45f);
+		dc.FillRect(UI::Drawable(color), dc.GetBounds());
+		dc.Flush();
+		return;
+	}
+
+	UIDialogScreenWithGameBackground::DrawBackground(dc);
+}
+
 void GamePauseScreen::CreateViews() {
 	static const int NUM_SAVESLOTS = 5;
 

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -31,14 +31,17 @@ public:
 	GamePauseScreen(const Path &filename) : UIDialogScreenWithGameBackground(filename), gamePath_(filename) {}
 	virtual ~GamePauseScreen();
 
-	virtual void dialogFinished(const Screen *dialog, DialogResult dr) override;
+	void dialogFinished(const Screen *dialog, DialogResult dr) override;
 
 	const char *tag() const override { return "GamePause"; }
 
 protected:
-	virtual void CreateViews() override;
-	virtual void update() override;
+	void CreateViews() override;
+	void update() override;
 	void CallbackDeleteConfig(bool yes);
+
+	bool isTransparent() const override;
+	void DrawBackground(UIContext &dc) override;
 
 private:
 	UI::EventReturn OnGameSettings(UI::EventParams &e);


### PR DESCRIPTION
When paused (ESC or back), you now see the paused game below, darkened, instead of the usual menu background.

Not enabled in VR mode for now because it could get weird. Also not trivial in skip-buffered mode (would require taking a screenshot) so disabled in that case too.

Part of #13016 

~~EDIT: Hm, there's a weird issue where resizing the window during the pause screen doesn't work properly in this mode...~~

![image](https://user-images.githubusercontent.com/130929/202899459-fa503cf8-6f0c-4ac4-9096-0e4593decda2.png)
