### PR TITLE
In jits, protect and unprotect using better estimates

### DIFF
--- a/Common/CodeBlock.h
+++ b/Common/CodeBlock.h
@@ -95,7 +95,22 @@ public:
 		// In case the last block made the current page exec/no-write, let's fix that.
 		if (PlatformIsWXExclusive()) {
 			writeStart_ = GetCodePtr();
+			if (writeStart_ + sizeEstimate - region > (ptrdiff_t)region_size)
+				sizeEstimate = region_size - (writeStart_ - region);
+			writeEstimated_ = sizeEstimate;
 			ProtectMemoryPages(writeStart_, sizeEstimate, MEM_PROT_READ | MEM_PROT_WRITE);
+		}
+	}
+
+	// In case you now know your original estimate is wrong.
+	void ContinueWrite(size_t sizeEstimate = 1) {
+		_dbg_assert_msg_(writeStart_, "Must have already called BeginWrite()");
+		if (PlatformIsWXExclusive()) {
+			const uint8_t *pos = GetCodePtr();
+			if (pos + sizeEstimate - region > (ptrdiff_t)region_size)
+				sizeEstimate = region_size - (pos - region);
+			writeEstimated_ = pos - writeStart_ + sizeEstimate;
+			ProtectMemoryPages(pos, sizeEstimate, MEM_PROT_READ | MEM_PROT_WRITE);
 		}
 	}
 
@@ -103,7 +118,14 @@ public:
 		// OK, we're done. Re-protect the memory we touched.
 		if (PlatformIsWXExclusive() && writeStart_ != nullptr) {
 			const uint8_t *end = GetCodePtr();
-			ProtectMemoryPages(writeStart_, end - writeStart_, MEM_PROT_READ | MEM_PROT_EXEC);
+			size_t sz = end - writeStart_;
+			if (sz > writeEstimated_)
+				WARN_LOG(JIT, "EndWrite(): Estimated %d bytes, wrote %d", (int)writeEstimated_, (int)sz);
+			// If we protected and wrote less, we may need to unprotect.
+			// Especially if we're linking blocks or similar.
+			if (sz < writeEstimated_)
+				sz = writeEstimated_;
+			ProtectMemoryPages(writeStart_, sz, MEM_PROT_READ | MEM_PROT_EXEC);
 			writeStart_ = nullptr;
 		}
 	}
@@ -150,5 +172,6 @@ private:
 	// Note: this is a readable pointer.
 	const uint8_t *writeStart_ = nullptr;
 	uint8_t *writableRegion = nullptr;
+	size_t writeEstimated_ = 0;
 };
 

--- a/Common/CodeBlock.h
+++ b/Common/CodeBlock.h
@@ -80,7 +80,7 @@ public:
 		// If not WX Exclusive, no need to call ProtectMemoryPages because we never change the protection from RWX.
 		PoisonMemory(offset);
 		ResetCodePtr(offset);
-		if (PlatformIsWXExclusive()) {
+		if (PlatformIsWXExclusive() && offset != 0) {
 			// Need to re-protect the part we didn't clear.
 			ProtectMemoryPages(region, offset, MEM_PROT_READ | MEM_PROT_EXEC);
 		}

--- a/Common/Thunk.cpp
+++ b/Common/Thunk.cpp
@@ -43,7 +43,7 @@ void ThunkManager::Init()
 #endif
 
 	AllocCodeSpace(THUNK_ARENA_SIZE);
-	BeginWrite();
+	BeginWrite(512);
 	save_regs = GetCodePtr();
 #if PPSSPP_ARCH(AMD64)
 	for (int i = 2; i < ABI_GetNumXMMRegs(); i++)
@@ -151,7 +151,7 @@ const void *ThunkManager::ProtectFunction(const void *function, int num_params) 
 
 	_assert_msg_(region != nullptr, "Can't protect functions before the emu is started.");
 
-	BeginWrite();
+	BeginWrite(128);
 	const u8 *call_point = GetCodePtr();
 	Enter(this, true);
 

--- a/Core/MIPS/ARM/ArmAsm.cpp
+++ b/Core/MIPS/ARM/ArmAsm.cpp
@@ -71,8 +71,8 @@ namespace MIPSComp {
 using namespace ArmJitConstants;
 
 void ArmJit::GenerateFixedCode() {
+	BeginWrite(GetMemoryProtectPageSize());
 	const u8 *start = AlignCodePage();
-	BeginWrite();
 
 	// LR == SCRATCHREG2 on ARM32 so it needs to be pushed.
 	restoreRoundingMode = AlignCode16(); {

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -234,7 +234,7 @@ void ArmJit::Compile(u32 em_address) {
 		ClearCache();
 	}
 
-	BeginWrite();
+	BeginWrite(JitBlockCache::MAX_BLOCK_INSTRUCTIONS * 16);
 
 	int block_num = blocks.AllocateBlock(em_address);
 	JitBlock *b = blocks.GetBlock(block_num);

--- a/Core/MIPS/ARM64/Arm64Asm.cpp
+++ b/Core/MIPS/ARM64/Arm64Asm.cpp
@@ -97,8 +97,8 @@ namespace MIPSComp {
 using namespace Arm64JitConstants;
 
 void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
+	BeginWrite(GetMemoryProtectPageSize());
 	const u8 *start = AlignCodePage();
-	BeginWrite();
 
 	if (jo.useStaticAlloc) {
 		saveStaticRegisters = AlignCode16();

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -230,7 +230,7 @@ void Arm64Jit::Compile(u32 em_address) {
 		ClearCache();
 	}
 
-	BeginWrite(4);
+	BeginWrite(JitBlockCache::MAX_BLOCK_INSTRUCTIONS * 16);
 
 	int block_num = blocks.AllocateBlock(em_address);
 	JitBlock *b = blocks.GetBlock(block_num);

--- a/Core/MIPS/x86/Asm.cpp
+++ b/Core/MIPS/x86/Asm.cpp
@@ -66,8 +66,8 @@ void ImHere() {
 }
 
 void Jit::GenerateFixedCode(JitOptions &jo) {
+	BeginWrite(GetMemoryProtectPageSize());
 	AlignCodePage();
-	BeginWrite();
 
 	restoreRoundingMode = AlignCode16(); {
 		STMXCSR(MIPSSTATE_VAR(temp));

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -281,7 +281,8 @@ void Jit::Compile(u32 em_address) {
 		return;
 	}
 
-	BeginWrite();
+	// Sometimes we compile fairly large blocks, although it's uncommon.
+	BeginWrite(JitBlockCache::MAX_BLOCK_INSTRUCTIONS * 16);
 
 	int block_num = blocks.AllocateBlock(em_address);
 	JitBlock *b = blocks.GetBlock(block_num);

--- a/Core/MIPS/x86/JitSafeMem.cpp
+++ b/Core/MIPS/x86/JitSafeMem.cpp
@@ -462,7 +462,7 @@ void JitSafeMemFuncs::Init(ThunkManager *thunks) {
 	AllocCodeSpace(FUNCS_ARENA_SIZE);
 	thunks_ = thunks;
 
-	BeginWrite();
+	BeginWrite(1024);
 	readU32 = GetCodePtr();
 	CreateReadFunc(32, (const void *)&Memory::Read_U32);
 	readU16 = GetCodePtr();

--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -161,7 +161,7 @@ static const JitLookup jitLookup[] = {
 
 JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int32_t *jittedSize) {
 	dec_ = &dec;
-	BeginWrite();
+	BeginWrite(4096);
 	const u8 *start = AlignCode16();
 
 	bool prescaleStep = false;

--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -143,7 +143,7 @@ static const JitLookup jitLookup[] = {
 JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int32_t *jittedSize) {
 	dec_ = &dec;
 
-	BeginWrite();
+	BeginWrite(4096);
 	const u8 *start = AlignCode16();
 
 	bool prescaleStep = false;

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -164,7 +164,7 @@ static const JitLookup jitLookup[] = {
 
 JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int32_t *jittedSize) {
 	dec_ = &dec;
-	BeginWrite();
+	BeginWrite(4096);
 	const u8 *start = this->AlignCode16();
 
 #if PPSSPP_ARCH(X86)

--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -167,7 +167,10 @@ void BinManager::UpdateState() {
 		if (states_.Full())
 			Flush("states");
 		stateIndex_ = (uint16_t)states_.Push(RasterizerState());
-		ComputeRasterizerState(&states_[stateIndex_]);
+		// When new funcs are compiled, we need to flush if WX exclusive.
+		ComputeRasterizerState(&states_[stateIndex_], [&]() {
+			Flush("compile");
+		});
 		states_[stateIndex_].samplerID.cached.clut = cluts_[clutIndex_].readable;
 
 		ClearDirty(SoftDirty::PIXEL_ALL | SoftDirty::SAMPLER_ALL | SoftDirty::RAST_ALL);

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -19,6 +19,7 @@
 
 #include "ppsspp_config.h"
 
+#include <functional>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -36,7 +37,7 @@ namespace Rasterizer {
 #endif
 
 typedef void (SOFTRAST_CALL *SingleFunc)(int x, int y, int z, int fog, Vec4IntArg color_in, const PixelFuncID &pixelID);
-SingleFunc GetSingleFunc(const PixelFuncID &id);
+SingleFunc GetSingleFunc(const PixelFuncID &id, std::function<void()> flushForCompile);
 
 void Init();
 void Shutdown();
@@ -60,7 +61,7 @@ public:
 	PixelJitCache();
 
 	// Returns a pointer to the code to run.
-	SingleFunc GetSingle(const PixelFuncID &id);
+	SingleFunc GetSingle(const PixelFuncID &id, std::function<void()> flushForCompile);
 	SingleFunc GenericSingle(const PixelFuncID &id);
 	void Clear() override;
 

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -42,11 +42,12 @@ SingleFunc PixelJitCache::CompileSingle(const PixelFuncID &id) {
 		RegCache::GEN_ARG_ID,
 	});
 
-	BeginWrite();
+	BeginWrite(64);
 	Describe("Init");
 	WriteConstantPool(id);
 
 	const u8 *resetPos = AlignCode16();
+	EndWrite();
 	bool success = true;
 
 #if PPSSPP_PLATFORM(WINDOWS)

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -93,15 +93,15 @@ static inline Vec4<float> Interpolate(const float &c0, const float &c1, const fl
 	return Interpolate(c0, c1, c2, w0.Cast<float>(), w1.Cast<float>(), w2.Cast<float>(), wsum_recip);
 }
 
-void ComputeRasterizerState(RasterizerState *state) {
+void ComputeRasterizerState(RasterizerState *state, std::function<void()> flushForCompile) {
 	ComputePixelFuncID(&state->pixelID);
-	state->drawPixel = Rasterizer::GetSingleFunc(state->pixelID);
+	state->drawPixel = Rasterizer::GetSingleFunc(state->pixelID, flushForCompile);
 
 	state->enableTextures = gstate.isTextureMapEnabled() && !state->pixelID.clearMode;
 	if (state->enableTextures) {
 		ComputeSamplerID(&state->samplerID);
-		state->linear = Sampler::GetLinearFunc(state->samplerID);
-		state->nearest = Sampler::GetNearestFunc(state->samplerID);
+		state->linear = Sampler::GetLinearFunc(state->samplerID, flushForCompile);
+		state->nearest = Sampler::GetNearestFunc(state->samplerID, flushForCompile);
 
 		// Since the definitions are the same, just force this setting using the func pointer.
 		if (g_Config.iTexFiltering == TEX_FILTER_FORCE_LINEAR) {
@@ -153,6 +153,11 @@ void ComputeRasterizerState(RasterizerState *state) {
 RasterizerState OptimizeFlatRasterizerState(RasterizerState state, const VertexData &v1) {
 	uint8_t alpha = v1.color0 >> 24;
 
+	// TODO: Problematic to potentially execute-protect blocks at runtime.
+	// This might actually be a very slight risk anyway, since it could clear the codespace?
+	if (PlatformIsWXExclusive())
+		return state;
+
 	bool changedPixelID = false;
 	bool changedSamplerID = false;
 	if (!state.pixelID.clearMode) {
@@ -197,10 +202,10 @@ RasterizerState OptimizeFlatRasterizerState(RasterizerState state, const VertexD
 	}
 
 	if (changedPixelID)
-		state.drawPixel = Rasterizer::GetSingleFunc(state.pixelID);
+		state.drawPixel = Rasterizer::GetSingleFunc(state.pixelID, [] {});
 	if (changedSamplerID) {
-		state.linear = Sampler::GetLinearFunc(state.samplerID);
-		state.nearest = Sampler::GetNearestFunc(state.samplerID);
+		state.linear = Sampler::GetLinearFunc(state.samplerID, [] {});
+		state.nearest = Sampler::GetNearestFunc(state.samplerID, [] {});
 
 		// Since the definitions are the same, just force this setting using the func pointer.
 		if (g_Config.iTexFiltering == TEX_FILTER_FORCE_LINEAR)
@@ -1417,7 +1422,10 @@ bool GetCurrentTexture(GPUDebugBuffer &buffer, int level)
 	ComputeSamplerID(&id);
 	id.cached.clut = clut;
 
-	Sampler::FetchFunc sampler = Sampler::GetFetchFunc(id);
+	Sampler::FetchFunc sampler = Sampler::GetFetchFunc(id, [] {
+		if (gpuDebug)
+			gpuDebug->DispatchFlush();
+	});
 
 	u8 *texptr = Memory::GetPointerWrite(texaddr);
 	u32 *row = (u32 *)buffer.GetData();

--- a/GPU/Software/Rasterizer.h
+++ b/GPU/Software/Rasterizer.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <functional>
 #include "GPU/Software/DrawPixel.h"
 #include "GPU/Software/FuncId.h"
 #include "GPU/Software/Sampler.h"
@@ -66,7 +67,7 @@ struct RasterizerState {
 	}
 };
 
-void ComputeRasterizerState(RasterizerState *state);
+void ComputeRasterizerState(RasterizerState *state, std::function<void()> flushForCompile);
 
 // Draws a triangle if its vertices are specified in counter-clockwise order
 void DrawTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2, const BinCoords &range, const RasterizerState &state);

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -162,7 +162,8 @@ void DrawSprite(const VertexData &v0, const VertexData &v1, const BinCoords &ran
 	GETextureFormat texfmt = state.samplerID.TexFmt();
 	uint16_t texbufw = state.texbufw[0];
 
-	Sampler::FetchFunc fetchFunc = Sampler::GetFetchFunc(state.samplerID);
+	// We won't flush, since we compile all samplers together.
+	Sampler::FetchFunc fetchFunc = Sampler::GetFetchFunc(state.samplerID, [] {});
 	auto &pixelID = state.pixelID;
 	auto &samplerID = state.samplerID;
 

--- a/GPU/Software/RasterizerRegCache.cpp
+++ b/GPU/Software/RasterizerRegCache.cpp
@@ -420,7 +420,7 @@ int CodeBlock::WriteProlog(int extraStack, const std::vector<RegCache::Reg> &vec
 #if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 	using namespace Gen;
 
-	BeginWrite();
+	BeginWrite(32768);
 	AlignCode16();
 	lastPrologStart_ = GetWritableCodePtr();
 

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -34,13 +34,13 @@ namespace Sampler {
 #endif
 
 typedef Rasterizer::Vec4IntResult(SOFTRAST_CALL *FetchFunc)(int u, int v, const u8 *tptr, int bufw, int level, const SamplerID &samplerID);
-FetchFunc GetFetchFunc(SamplerID id);
+FetchFunc GetFetchFunc(SamplerID id, std::function<void()> flushForCompile);
 
 typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *NearestFunc)(float s, float t, Rasterizer::Vec4IntArg prim_color, const u8 *const *tptr, const uint16_t *bufw, int level, int levelFrac, const SamplerID &samplerID);
-NearestFunc GetNearestFunc(SamplerID id);
+NearestFunc GetNearestFunc(SamplerID id, std::function<void()> flushForCompile);
 
 typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *LinearFunc)(float s, float t, Rasterizer::Vec4IntArg prim_color, const u8 *const *tptr, const uint16_t *bufw, int level, int levelFrac, const SamplerID &samplerID);
-LinearFunc GetLinearFunc(SamplerID id);
+LinearFunc GetLinearFunc(SamplerID id, std::function<void()> flushForCompile);
 
 void Init();
 void Shutdown();
@@ -52,9 +52,9 @@ public:
 	SamplerJitCache();
 
 	// Returns a pointer to the code to run.
-	NearestFunc GetNearest(const SamplerID &id);
-	LinearFunc GetLinear(const SamplerID &id);
-	FetchFunc GetFetch(const SamplerID &id);
+	NearestFunc GetNearest(const SamplerID &id, std::function<void()> flushForCompile);
+	LinearFunc GetLinear(const SamplerID &id, std::function<void()> flushForCompile);
+	FetchFunc GetFetch(const SamplerID &id, std::function<void()> flushForCompile);
 	void Clear() override;
 
 	std::string DescribeCodePtr(const u8 *ptr) override;

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -45,7 +45,7 @@ FetchFunc SamplerJitCache::CompileFetch(const SamplerID &id) {
 	regCache_.ForceRetain(RegCache::GEN_RESULT);
 	regCache_.ChangeReg(XMM0, RegCache::VEC_RESULT);
 
-	BeginWrite();
+	BeginWrite(2048);
 	Describe("Init");
 	const u8 *start = AlignCode16();
 
@@ -122,7 +122,7 @@ FetchFunc SamplerJitCache::CompileFetch(const SamplerID &id) {
 
 NearestFunc SamplerJitCache::CompileNearest(const SamplerID &id) {
 	_assert_msg_(!id.fetch && !id.linear, "Fetch and linear should be cleared on sampler id");
-	BeginWrite();
+	BeginWrite(2048);
 	Describe("Init");
 
 	// Let's drop some helpful constants here.
@@ -438,7 +438,7 @@ NearestFunc SamplerJitCache::CompileNearest(const SamplerID &id) {
 
 LinearFunc SamplerJitCache::CompileLinear(const SamplerID &id) {
 	_assert_msg_(id.linear && !id.fetch, "Only linear should be set on sampler id");
-	BeginWrite();
+	BeginWrite(2048);
 	Describe("Init");
 
 	// We don't use stackArgPos_ here, this is just for DXT.

--- a/unittest/TestSoftwareGPUJit.cpp
+++ b/unittest/TestSoftwareGPUJit.cpp
@@ -29,17 +29,17 @@ static bool TestSamplerJit() {
 	auto GetLinear = [&](SamplerID &id) {
 		id.linear = true;
 		id.fetch = false;
-		return cache->GetLinear(id);
+		return cache->GetLinear(id, [] {});
 	};
 	auto GetNearest = [&](SamplerID &id) {
 		id.linear = false;
 		id.fetch = false;
-		return cache->GetNearest(id);
+		return cache->GetNearest(id, [] {});
 	};
 	auto GetFetch = [&](SamplerID &id) {
 		id.linear = false;
 		id.fetch = true;
-		return cache->GetFetch(id);
+		return cache->GetFetch(id, [] {});
 	};
 
 	GMRng rng;
@@ -134,7 +134,7 @@ static bool TestPixelJit() {
 			continue;
 		i++;
 
-		SingleFunc func = cache->GetSingle(id);
+		SingleFunc func = cache->GetSingle(id, [] {});
 		SingleFunc genericFunc = cache->GenericSingle(id);
 		if (func != genericFunc) {
 			successes++;


### PR DESCRIPTION
Estimates are informed by nearby sizes, and shouldn't be that far off.  This does mean possibly multiple pages after the current write position may be protected as executable, but I think it's better to manage it this way especially when we do things like block linking - see `Arm64Jit::LinkBlock()`.

I added a `ContinueWrite()` but didn't end up using it... I still think it's useful so leaving it.

This also makes softgpu's jits hopefully work on WX exclusive (should just be BSD.)

See #16406.  Not actually validated on an arm64 WX exclusive platform, though.

-[Unknown]