### PR TITLE
softgpu: Fix compile hazard while running

### DIFF
--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -513,6 +513,9 @@ void BinManager::Flush(const char *reason) {
 	while (cluts_.Size() > 1)
 		cluts_.SkipNext();
 
+	Rasterizer::FlushJit();
+	Sampler::FlushJit();
+
 	queueRange_.x1 = 0x7FFFFFFF;
 	queueRange_.y1 = 0x7FFFFFFF;
 	queueRange_.x2 = 0;

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include <unordered_set>
 #include "GPU/Math3D.h"
 #include "GPU/Software/FuncId.h"
 #include "GPU/Software/RasterizerRegCache.h"
@@ -40,6 +41,7 @@ typedef void (SOFTRAST_CALL *SingleFunc)(int x, int y, int z, int fog, Vec4IntAr
 SingleFunc GetSingleFunc(const PixelFuncID &id, std::function<void()> flushForCompile);
 
 void Init();
+void FlushJit();
 void Shutdown();
 
 bool CheckDepthTestPassed(GEComparison func, int x, int y, int stride, u16 z);
@@ -64,10 +66,12 @@ public:
 	SingleFunc GetSingle(const PixelFuncID &id, std::function<void()> flushForCompile);
 	SingleFunc GenericSingle(const PixelFuncID &id);
 	void Clear() override;
+	void Flush();
 
 	std::string DescribeCodePtr(const u8 *ptr) override;
 
 private:
+	void Compile(const PixelFuncID &id);
 	SingleFunc CompileSingle(const PixelFuncID &id);
 
 	RegCache::Reg GetPixelID();
@@ -105,6 +109,7 @@ private:
 
 	std::unordered_map<PixelFuncID, SingleFunc> cache_;
 	std::unordered_map<PixelFuncID, const u8 *> addresses_;
+	std::unordered_set<PixelFuncID> compileQueue_;
 
 	const u8 *constBlendHalf_11_4s_ = nullptr;
 	const u8 *constBlendInvert_11_4s_ = nullptr;

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -163,7 +163,8 @@ void DrawSprite(const VertexData &v0, const VertexData &v1, const BinCoords &ran
 	uint16_t texbufw = state.texbufw[0];
 
 	// We won't flush, since we compile all samplers together.
-	Sampler::FetchFunc fetchFunc = Sampler::GetFetchFunc(state.samplerID, [] {});
+	Sampler::FetchFunc fetchFunc = Sampler::GetFetchFunc(state.samplerID, nullptr);
+	_dbg_assert_msg_(fetchFunc != nullptr, "Failed to get precompiled fetch func");
 	auto &pixelID = state.pixelID;
 	auto &samplerID = state.samplerID;
 

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -19,7 +19,9 @@
 
 #include "ppsspp_config.h"
 
+#include <functional>
 #include <unordered_map>
+#include <unordered_set>
 #include "GPU/Math3D.h"
 #include "GPU/Software/FuncId.h"
 #include "GPU/Software/RasterizerRegCache.h"
@@ -43,6 +45,7 @@ typedef Rasterizer::Vec4IntResult (SOFTRAST_CALL *LinearFunc)(float s, float t, 
 LinearFunc GetLinearFunc(SamplerID id, std::function<void()> flushForCompile);
 
 void Init();
+void FlushJit();
 void Shutdown();
 
 bool DescribeCodePtr(const u8 *ptr, std::string &name);
@@ -56,11 +59,13 @@ public:
 	LinearFunc GetLinear(const SamplerID &id, std::function<void()> flushForCompile);
 	FetchFunc GetFetch(const SamplerID &id, std::function<void()> flushForCompile);
 	void Clear() override;
+	void Flush();
 
 	std::string DescribeCodePtr(const u8 *ptr) override;
 
 private:
 	void Compile(const SamplerID &id);
+	NearestFunc GetByID(const SamplerID &id, std::function<void()> flushForCompile);
 	FetchFunc CompileFetch(const SamplerID &id);
 	NearestFunc CompileNearest(const SamplerID &id);
 	LinearFunc CompileLinear(const SamplerID &id);
@@ -123,6 +128,7 @@ private:
 
 	std::unordered_map<SamplerID, NearestFunc> cache_;
 	std::unordered_map<SamplerID, const u8 *> addresses_;
+	std::unordered_set<SamplerID> compileQueue_;
 };
 
 #if defined(__clang__) || defined(__GNUC__)


### PR DESCRIPTION
This prevents any clearing of cache while other threads may be using previously cached funcs, and avoids wx exclusive hazards.

Follow up from #16407, this fixes it a bit more properly.

-[Unknown]