### PR TITLE
Display edit mode - initial prototype

### DIFF
--- a/Common/VR/VRRenderer.cpp
+++ b/Common/VR/VRRenderer.cpp
@@ -317,7 +317,7 @@ void VR_EndFrame( engine_t* engine ) {
 		int x = vrConfig[VR_CONFIG_MOUSE_X];
 		int y = vrConfig[VR_CONFIG_MOUSE_Y];
 		int sx = vrConfig[VR_CONFIG_MOUSE_SIZE];
-		int sy = sx * VR_GetConfigFloat(VR_CONFIG_CANVAS_ASPECT);
+		int sy = (int)((float)sx * VR_GetConfigFloat(VR_CONFIG_CANVAS_ASPECT));
 		ovrRenderer_MouseCursor(&engine->appState.Renderer, x, y, sx, sy);
 	}
 

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -86,11 +86,10 @@ void FramebufferManagerCommon::Init() {
 	Resized();
 }
 
-bool FramebufferManagerCommon::UpdateSize() {
+bool FramebufferManagerCommon::UpdateRenderSize() {
 	const bool newRender = renderWidth_ != (float)PSP_CoreParameter().renderWidth || renderHeight_ != (float)PSP_CoreParameter().renderHeight;
 
 	const int effectiveBloomHack = PSP_CoreParameter().compat.flags().ForceLowerResolutionForEffectsOn ? 3 : g_Config.iBloomHack;
-
 
 	bool newBuffered = !g_Config.bSkipBufferEffects;
 	const bool newSettings = bloomHack_ != effectiveBloomHack || useBufferedRendering_ != newBuffered;
@@ -98,13 +97,11 @@ bool FramebufferManagerCommon::UpdateSize() {
 	renderWidth_ = (float)PSP_CoreParameter().renderWidth;
 	renderHeight_ = (float)PSP_CoreParameter().renderHeight;
 	renderScaleFactor_ = (float)PSP_CoreParameter().renderScaleFactor;
-	pixelWidth_ = PSP_CoreParameter().pixelWidth;
-	pixelHeight_ = PSP_CoreParameter().pixelHeight;
+
 	bloomHack_ = effectiveBloomHack;
 	useBufferedRendering_ = newBuffered;
 
-	presentation_->UpdateSize(pixelWidth_, pixelHeight_, renderWidth_, renderHeight_);
-
+	presentation_->UpdateRenderSize(renderWidth_, renderHeight_);
 	return newRender || newSettings;
 }
 
@@ -2342,7 +2339,11 @@ void FramebufferManagerCommon::Resized() {
 	PSP_CoreParameter().renderHeight = h;
 	PSP_CoreParameter().renderScaleFactor = scaleFactor;
 
-	if (UpdateSize()) {
+	pixelWidth_ = PSP_CoreParameter().pixelWidth;
+	pixelHeight_ = PSP_CoreParameter().pixelHeight;
+	presentation_->UpdateDisplaySize(pixelWidth_, pixelHeight_);
+
+	if (UpdateRenderSize()) {
 		DestroyAllFBOs();
 	}
 

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -83,7 +83,8 @@ FramebufferManagerCommon::~FramebufferManagerCommon() {
 
 void FramebufferManagerCommon::Init() {
 	// We may need to override the render size if the shader is upscaling or SSAA.
-	Resized();
+	NotifyDisplayResized();
+	NotifyRenderResized();
 }
 
 bool FramebufferManagerCommon::UpdateRenderSize() {
@@ -2330,7 +2331,17 @@ void FramebufferManagerCommon::SetSafeSize(u16 w, u16 h) {
 	}
 }
 
-void FramebufferManagerCommon::Resized() {
+void FramebufferManagerCommon::NotifyDisplayResized() {
+	pixelWidth_ = PSP_CoreParameter().pixelWidth;
+	pixelHeight_ = PSP_CoreParameter().pixelHeight;
+	presentation_->UpdateDisplaySize(pixelWidth_, pixelHeight_);
+
+	// No drawing is allowed here. This includes anything that might potentially touch a command buffer, like creating images!
+	// So we need to defer the post processing initialization.
+	updatePostShaders_ = true;
+}
+
+void FramebufferManagerCommon::NotifyRenderResized() {
 	gstate_c.skipDrawReason &= ~SKIPDRAW_NON_DISPLAYED_FB;
 
 	int w, h, scaleFactor;
@@ -2338,10 +2349,6 @@ void FramebufferManagerCommon::Resized() {
 	PSP_CoreParameter().renderWidth = w;
 	PSP_CoreParameter().renderHeight = h;
 	PSP_CoreParameter().renderScaleFactor = scaleFactor;
-
-	pixelWidth_ = PSP_CoreParameter().pixelWidth;
-	pixelHeight_ = PSP_CoreParameter().pixelHeight;
-	presentation_->UpdateDisplaySize(pixelWidth_, pixelHeight_);
 
 	if (UpdateRenderSize()) {
 		DestroyAllFBOs();

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -450,7 +450,7 @@ protected:
 	void CopyToColorFromOverlappingFramebuffers(VirtualFramebuffer *dest);
 	void CopyToDepthFromOverlappingFramebuffers(VirtualFramebuffer *dest);
 
-	bool UpdateSize();
+	bool UpdateRenderSize();
 
 	void FlushBeforeCopy();
 	virtual void DecimateFBOs();  // keeping it virtual to let D3D do a little extra

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -398,7 +398,9 @@ public:
 	}
 	void SetSafeSize(u16 w, u16 h);
 
-	virtual void Resized();
+	virtual void NotifyRenderResized();
+	virtual void NotifyDisplayResized();
+
 	virtual void DestroyAllFBOs();
 
 	virtual void DeviceLost();

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -78,9 +78,11 @@ public:
 	PresentationCommon(Draw::DrawContext *draw);
 	~PresentationCommon();
 
-	void UpdateSize(int w, int h, int rw, int rh) {
+	void UpdateDisplaySize(int w, int h) {
 		pixelWidth_ = w;
 		pixelHeight_ = h;
+	}
+	void UpdateRenderSize(int rw, int rh) {
 		renderWidth_ = rw;
 		renderHeight_ = rh;
 	}

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1200,6 +1200,7 @@ bool TextureCacheCommon::GetCurrentFramebufferTextureDebug(GPUDebugBuffer &buffe
 }
 
 void TextureCacheCommon::NotifyConfigChanged() {
+	clearCacheNextFrame_ = true;
 	int scaleFactor = g_Config.iTexScalingLevel;
 
 	if (!gstate_c.Use(GPU_USE_TEXTURE_NPOT)) {
@@ -2552,10 +2553,6 @@ void TextureCacheCommon::InvalidateAll(GPUInvalidationType /*unused*/) {
 		}
 		iter->second->invalidHint++;
 	}
-}
-
-void TextureCacheCommon::ClearNextFrame() {
-	clearCacheNextFrame_ = true;
 }
 
 std::string AttachCandidate::ToString() const {

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -323,7 +323,6 @@ public:
 	bool SetOffsetTexture(u32 yOffset);
 	void Invalidate(u32 addr, int size, GPUInvalidationType type);
 	void InvalidateAll(GPUInvalidationType type);
-	void ClearNextFrame();
 
 	TextureShaderCache *GetTextureShaderCache() { return textureShaderCache_; }
 

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -228,10 +228,6 @@ void GPU_D3D11::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_D3D11::ClearCacheNextFrame() {
-	textureCacheD3D11_->ClearNextFrame();
-}
-
 void GPU_D3D11::ClearShaderCache() {
 	shaderManagerD3D11_->ClearShaders();
 	drawEngine_.ClearInputLayoutMap();

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -157,23 +157,6 @@ void GPU_D3D11::InitClear() {
 	}
 }
 
-void GPU_D3D11::BeginHostFrame() {
-	GPUCommon::BeginHostFrame();
-	UpdateCmdInfo();
-	CheckResized();
-}
-
-void GPU_D3D11::ReapplyGfxState() {
-	GPUCommon::ReapplyGfxState();
-
-	// TODO: Dirty our caches for depth states etc
-}
-
-void GPU_D3D11::EndHostFrame() {
-	// Probably not really necessary.
-	draw_->InvalidateCachedState();
-}
-
 void GPU_D3D11::BeginFrame() {
 	GPUCommon::BeginFrame();
 

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -41,7 +41,6 @@ public:
 	void ExecuteOp(u32 op, u32 diff) override;
 
 	void GetStats(char *buffer, size_t bufsize) override;
-	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -40,7 +40,6 @@ public:
 	void PreExecuteOp(u32 op, u32 diff) override;
 	void ExecuteOp(u32 op, u32 diff) override;
 
-	void ReapplyGfxState() override;
 	void GetStats(char *buffer, size_t bufsize) override;
 	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
@@ -53,9 +52,6 @@ public:
 	// Using string because it's generic - makes no assumptions on the size of the shader IDs of this backend.
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType shader) override;
 	std::string DebugGetShaderString(std::string id, DebugShaderType shader, DebugShaderStringType stringType) override;
-
-	void BeginHostFrame() override;
-	void EndHostFrame() override;
 
 protected:
 	void FinishDeferred() override;

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -147,12 +147,6 @@ void GPU_DX9::InitClear() {
 	}
 }
 
-void GPU_DX9::BeginHostFrame() {
-	GPUCommon::BeginHostFrame();
-	UpdateCmdInfo();
-	CheckResized();
-}
-
 void GPU_DX9::ReapplyGfxState() {
 	dxstate.Restore();
 	GPUCommon::ReapplyGfxState();

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -220,10 +220,6 @@ void GPU_DX9::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_DX9::ClearCacheNextFrame() {
-	textureCacheDX9_->ClearNextFrame();
-}
-
 void GPU_DX9::ClearShaderCache() {
 	shaderManagerDX9_->ClearCache(true);
 }

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -41,7 +41,6 @@ public:
 
 	void ReapplyGfxState() override;
 	void GetStats(char *buffer, size_t bufsize) override;
-	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -53,8 +53,6 @@ public:
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType shader) override;
 	std::string DebugGetShaderString(std::string id, DebugShaderType shader, DebugShaderStringType stringType) override;
 
-	void BeginHostFrame() override;
-
 protected:
 	void FinishDeferred() override;
 

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -70,8 +70,9 @@ void FramebufferManagerGLES::DeviceLost() {
 	}
 }
 
-void FramebufferManagerGLES::Resized() {
-	FramebufferManagerCommon::Resized();
+void FramebufferManagerGLES::NotifyDisplayResized() {
+	FramebufferManagerCommon::NotifyDisplayResized();
+
 	GLRenderManager *render = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 	render->Resize(PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
 }

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -31,7 +31,7 @@ public:
 	FramebufferManagerGLES(Draw::DrawContext *draw);
 	~FramebufferManagerGLES();
 
-	void Resized() override;
+	void NotifyDisplayResized() override;
 	void DeviceLost() override;
 
 	bool GetOutputFramebuffer(GPUDebugBuffer &buffer) override;

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -353,10 +353,6 @@ void GPU_GLES::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_GLES::ClearCacheNextFrame() {
-	textureCacheGL_->ClearNextFrame();
-}
-
 void GPU_GLES::ClearShaderCache() {
 	shaderManagerGL_->ClearCache(true);
 }

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -267,9 +267,6 @@ void GPU_GLES::InitClear() {
 
 void GPU_GLES::BeginHostFrame() {
 	GPUCommon::BeginHostFrame();
-	UpdateCmdInfo();
-	CheckResized();
-
 	drawEngine_.BeginFrame();
 }
 

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -49,7 +49,6 @@ public:
 	void ReapplyGfxState() override;
 	void GetStats(char *buffer, size_t bufsize) override;
 
-	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -629,7 +629,6 @@ void GPUCommon::NotifyDisplayResized() {
 // if "transparent".
 void GPUCommon::CheckConfigChanged() {
 	if (configChanged_) {
-		ClearCacheNextFrame();
 		gstate_c.useFlags = CheckGPUFeatures();
 		drawEngineCommon_->NotifyConfigChanged();
 		shaderManager_->DirtyLastShader();  // Don't think this is needed, at all.

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -482,10 +482,14 @@ void GPUCommon::BeginHostFrame() {
 
 	// TODO: Assume config may have changed - maybe move to resize.
 	gstate_c.Dirty(DIRTY_ALL);
+
+	UpdateCmdInfo();
+	CheckResized();
 }
 
 void GPUCommon::EndHostFrame() {
-
+	// Probably not necessary.
+	draw_->InvalidateCachedState();
 }
 
 void GPUCommon::Reinitialize() {

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -484,7 +484,9 @@ void GPUCommon::BeginHostFrame() {
 	gstate_c.Dirty(DIRTY_ALL);
 
 	UpdateCmdInfo();
-	CheckResized();
+	CheckConfigChanged();
+	CheckDisplayResized();
+	CheckRenderResized();
 }
 
 void GPUCommon::EndHostFrame() {
@@ -625,7 +627,7 @@ void GPUCommon::NotifyDisplayResized() {
 
 // Called once per frame. Might also get called during the pause screen
 // if "transparent".
-void GPUCommon::CheckResized() {
+void GPUCommon::CheckConfigChanged() {
 	if (configChanged_) {
 		ClearCacheNextFrame();
 		gstate_c.useFlags = CheckGPUFeatures();
@@ -635,12 +637,16 @@ void GPUCommon::CheckResized() {
 		BuildReportingInfo();
 		configChanged_ = false;
 	}
+}
 
+void GPUCommon::CheckDisplayResized() {
 	if (displayResized_) {
 		framebufferManager_->NotifyDisplayResized();
 		displayResized_ = false;
 	}
+}
 
+void GPUCommon::CheckRenderResized() {
 	if (renderResized_) {
 		framebufferManager_->NotifyRenderResized();
 		renderResized_ = false;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -617,7 +617,8 @@ void GPUCommon::CheckResized() {
 	if (resized_) {
 		gstate_c.useFlags = CheckGPUFeatures();
 		BuildReportingInfo();
-		framebufferManager_->Resized();
+		framebufferManager_->NotifyDisplayResized();
+		framebufferManager_->NotifyRenderResized();
 		drawEngineCommon_->NotifyConfigChanged();
 		textureCache_->NotifyConfigChanged();
 		shaderManager_->DirtyLastShader();

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -491,7 +491,9 @@ void GPUCommon::BeginHostFrame() {
 
 void GPUCommon::EndHostFrame() {
 	// Probably not necessary.
-	draw_->InvalidateCachedState();
+	if (draw_) {
+		draw_->InvalidateCachedState();
+	}
 }
 
 void GPUCommon::Reinitialize() {

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -77,7 +77,8 @@ public:
 		return draw_;
 	}
 	virtual u32 CheckGPUFeatures() const;
-	void CheckResized() override;
+
+	void CheckDisplayResized() override;
 
 	void UpdateCmdInfo();
 
@@ -264,6 +265,9 @@ public:
 protected:
 	void DeviceLost() override;
 	void DeviceRestore() override;
+
+	void CheckConfigChanged();
+	void CheckRenderResized();
 
 	// Add additional common features dependent on other features, which may be backend-determined.
 	u32 CheckGPUFeaturesLate(u32 features) const;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -97,7 +97,10 @@ public:
 		interruptsEnabled_ = enable;
 	}
 
-	void Resized() override;
+	void NotifyDisplayResized() override;
+	void NotifyRenderResized() override;
+	void NotifyConfigChanged() override;
+
 	void DumpNextFrame() override;
 
 	void ExecuteOp(u32 op, u32 diff) override;
@@ -357,7 +360,9 @@ protected:
 	bool dumpThisFrame_ = false;
 	bool debugRecording_;
 	bool interruptsEnabled_;
-	bool resized_ = false;
+	bool displayResized_ = false;
+	bool renderResized_ = false;
+	bool configChanged_ = false;
 	bool sawExactEqualDepth_ = false;
 	DrawType lastDraw_ = DRAW_UNKNOWN;
 	GEPrimitiveType lastPrim_ = GE_PRIM_INVALID;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -84,8 +84,7 @@ public:
 	bool IsReady() override {
 		return true;
 	}
-	void CancelReady() override {
-	}
+	void CancelReady() override {}
 	void Reinitialize() override;
 
 	void BeginHostFrame() override;

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -197,7 +197,8 @@ public:
 	// Frame managment
 	virtual void BeginHostFrame() = 0;
 	virtual void EndHostFrame() = 0;
-	virtual void CheckResized() = 0;
+
+	virtual void CheckDisplayResized() = 0;
 
 	// Draw queue management
 	virtual DisplayList* getList(int listid) = 0;

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -244,9 +244,6 @@ public:
 	virtual bool PerformWriteColorFromMemory(u32 dest, int size) = 0;
 	virtual bool PerformWriteStencilFromMemory(u32 dest, int size, WriteStencil flags = WriteStencil::NEEDS_CLEAR) = 0;
 
-	// Will cause the texture cache to be cleared at the start of the next frame.
-	virtual void ClearCacheNextFrame() = 0;
-
 	// Internal hack to avoid interrupts from "PPGe" drawing (utility UI, etc)
 	virtual void EnableInterrupts(bool enable) = 0;
 

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -255,7 +255,10 @@ public:
 	virtual void DoState(PointerWrap &p) = 0;
 
 	// Called by the window system if the window size changed. This will be reflected in PSPCoreParam.pixel*.
-	virtual void Resized() = 0;
+	virtual void NotifyDisplayResized() = 0;
+	virtual void NotifyRenderResized() = 0;
+	virtual void NotifyConfigChanged() = 0;
+
 	virtual void ClearShaderCache() = 0;
 	virtual void CleanupBeforeUI() = 0;
 	virtual bool FramebufferDirty() = 0;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -712,7 +712,8 @@ void SoftGPU::Resized() {
 	}
 
 	if (presentation_) {
-		presentation_->UpdateSize(PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight, PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
+		presentation_->UpdateDisplaySize(PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
+		presentation_->UpdateRenderSize(PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
 		presentation_->UpdatePostShader();
 	}
 }

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -445,7 +445,10 @@ SoftGPU::SoftGPU(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 		presentation_ = new PresentationCommon(draw_);
 		presentation_->SetLanguage(draw_->GetShaderLanguageDesc().shaderLanguage);
 	}
-	Resized();
+
+	NotifyConfigChanged();
+	NotifyRenderResized();
+	NotifyDisplayResized();
 }
 
 void SoftGPU::DeviceLost() {
@@ -701,7 +704,7 @@ bool SoftGPU::ClearDirty(uint32_t addr, uint32_t bytes, SoftGPUVRAMDirty value) 
 	return result;
 }
 
-void SoftGPU::Resized() {
+void SoftGPU::NotifyRenderResized() {
 	// Force the render params to 480x272 so other things work.
 	if (g_Config.IsPortrait()) {
 		PSP_CoreParameter().renderWidth = 272;
@@ -710,13 +713,17 @@ void SoftGPU::Resized() {
 		PSP_CoreParameter().renderWidth = 480;
 		PSP_CoreParameter().renderHeight = 272;
 	}
+}
 
+void SoftGPU::NotifyDisplayResized() {
 	if (presentation_) {
 		presentation_->UpdateDisplaySize(PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
 		presentation_->UpdateRenderSize(PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
 		presentation_->UpdatePostShader();
 	}
 }
+
+void SoftGPU::NotifyConfigChanged() {}
 
 void SoftGPU::FastRunLoop(DisplayList &list) {
 	PROFILE_THIS_SCOPE("soft_runloop");

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -149,7 +149,10 @@ public:
 	void DeviceLost() override;
 	void DeviceRestore() override;
 
-	void Resized() override;
+	void NotifyRenderResized() override;
+	void NotifyDisplayResized() override;
+	void NotifyConfigChanged() override;
+
 	void GetReportingInfo(std::string &primaryInfo, std::string &fullInfo) override {
 		primaryInfo = "Software";
 		fullInfo = "Software";

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -144,7 +144,6 @@ public:
 	bool PerformReadbackToMemory(u32 dest, int size) override;
 	bool PerformWriteColorFromMemory(u32 dest, int size) override;
 	bool PerformWriteStencilFromMemory(u32 dest, int size, WriteStencil flags) override;
-	void ClearCacheNextFrame() override {}
 
 	void DeviceLost() override;
 	void DeviceRestore() override;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -272,11 +272,9 @@ u32 GPU_Vulkan::CheckGPUFeatures() const {
 }
 
 void GPU_Vulkan::BeginHostFrame() {
+	GPUCommon::BeginHostFrame();
+
 	drawEngine_.BeginFrame();
-	UpdateCmdInfo();
-
-	CheckResized();
-
 	textureCacheVulkan_->StartFrame();
 
 	VulkanContext *vulkan = (VulkanContext *)draw_->GetNativeObject(Draw::NativeObject::CONTEXT);
@@ -310,7 +308,7 @@ void GPU_Vulkan::EndHostFrame() {
 	drawEngine_.EndFrame();
 	textureCacheVulkan_->EndFrame();
 
-	draw_->InvalidateCachedState();
+	GPUCommon::EndHostFrame();
 }
 
 // Needs to be called on GPU thread, not reporting thread.

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -513,10 +513,6 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_Vulkan::ClearCacheNextFrame() {
-	textureCacheVulkan_->ClearNextFrame();
-}
-
 void GPU_Vulkan::ClearShaderCache() {
 	// TODO
 }

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -51,7 +51,6 @@ public:
 	void ExecuteOp(u32 op, u32 diff) override;
 
 	void GetStats(char *buffer, size_t bufsize) override;
-	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -418,7 +418,7 @@ QString MainUI::InputBoxGetQString(QString title, QString defaultValue) {
 
 void MainUI::resizeGL(int w, int h) {
 	if (UpdateScreenScale(w, h)) {
-		NativeMessageReceived("gpu_resized", "");
+		NativeMessageReceived("gpu_displayResized", "");
 	}
 	xscale = w / this->width();
 	yscale = h / this->height();

--- a/Qt/mainwindow.h
+++ b/Qt/mainwindow.h
@@ -119,25 +119,26 @@ private slots:
 	void moreSettingsAct() { NativeMessageReceived("settings", ""); }
 
 	void bufferRenderAct() {
-		NativeMessageReceived("gpu_resized", "");
+		NativeMessageReceived("gpu_renderResized", "");
+		NativeMessageReceived("gpu_configChanged", "");
 	}
 	void linearAct() { g_Config.iTexFiltering = (g_Config.iTexFiltering != 0) ? 0 : 3; }
 
 	void renderingResolutionGroup_triggered(QAction *action) {
 		g_Config.iInternalResolution = action->data().toInt();
-		NativeMessageReceived("gpu_resized", "");
+		NativeMessageReceived("gpu_renderResized", "");
 	}
 	void windowGroup_triggered(QAction *action) { SetWindowScale(action->data().toInt()); }
 
 	void displayLayoutGroup_triggered(QAction *action) {
 		g_Config.iSmallDisplayZoomType = action->data().toInt();
-		NativeMessageReceived("gpu_resized", "");
+		NativeMessageReceived("gpu_displayResized", "");
 	}
 	void autoframeskipAct() {
 		g_Config.bAutoFrameSkip = !g_Config.bAutoFrameSkip;
 		if (g_Config.bSkipBufferEffects) {
 			g_Config.bSkipBufferEffects = false;
-			NativeMessageReceived("gpu_resized", "");
+			NativeMessageReceived("gpu_configChanged", "");
 		}
 	}
 	void frameSkippingGroup_triggered(QAction *action) { g_Config.iFrameSkip = action->data().toInt(); }
@@ -146,19 +147,19 @@ private slots:
 	void screenScalingFilterGroup_triggered(QAction *action) { g_Config.iBufFilter = action->data().toInt(); }
 	void textureScalingLevelGroup_triggered(QAction *action) {
 		g_Config.iTexScalingLevel = action->data().toInt();
-		NativeMessageReceived("gpu_clearCache", "");
+		NativeMessageReceived("gpu_configChanged", "");
 	}
 	void textureScalingTypeGroup_triggered(QAction *action) {
 		g_Config.iTexScalingType = action->data().toInt();
-		NativeMessageReceived("gpu_clearCache", "");
+		NativeMessageReceived("gpu_configChanged", "");
 	}
 	void deposterizeAct() {
 		g_Config.bTexDeposterize = !g_Config.bTexDeposterize;
-		NativeMessageReceived("gpu_clearCache", "");
+		NativeMessageReceived("gpu_configChanged", "");
 	}
 	void transformAct() {
 		g_Config.bHardwareTransform = !g_Config.bHardwareTransform;
-		NativeMessageReceived("gpu_resized", "");
+		NativeMessageReceived("gpu_configChanged", "");
 	}
 	void vertexCacheAct() { g_Config.bVertexCache = !g_Config.bVertexCache; }
 	void frameskipAct() { g_Config.iFrameSkip = !g_Config.iFrameSkip; }

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1399,7 +1399,7 @@ void EmuScreen::render() {
 		// If we're paused and PauseScreen is transparent (will only be in buffered rendering mode), we just copy display to output.
 		thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_Paused");
 		if (PSP_IsInited()) {
-			gpu->CheckResized();
+			gpu->CheckDisplayResized();
 			gpu->CopyDisplayToOutput(true);
 		}
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -661,7 +661,7 @@ void EmuScreen::onVKeyDown(int virtualKeyCode) {
 		if (g_Config.bDumpFrames == g_Config.bDumpAudio) {
 			g_Config.bDumpFrames = !g_Config.bDumpFrames;
 			g_Config.bDumpAudio = !g_Config.bDumpAudio;
-		} else { 
+		} else {
 			// This hotkey should always toggle both audio and video together.
 			// So let's make sure that's the only outcome even if video OR audio was already being dumped.
 			if (g_Config.bDumpFrames) {
@@ -706,7 +706,7 @@ void EmuScreen::onVKeyDown(int virtualKeyCode) {
 		g_Config.bSaveNewTextures = !g_Config.bSaveNewTextures;
 		if (g_Config.bSaveNewTextures) {
 			osm.Show(sc->T("saveNewTextures_true", "Textures will now be saved to your storage"), 2.0);
-			NativeMessageReceived("gpu_clearCache", "");
+			NativeMessageReceived("gpu_configChanged", "");
 		} else {
 			osm.Show(sc->T("saveNewTextures_false", "Texture saving was disabled"), 2.0);
 		}
@@ -717,7 +717,7 @@ void EmuScreen::onVKeyDown(int virtualKeyCode) {
 			osm.Show(sc->T("replaceTextures_true", "Texture replacement enabled"), 2.0);
 		else
 			osm.Show(sc->T("replaceTextures_false", "Textures no longer are being replaced"), 2.0);
-		NativeMessageReceived("gpu_clearCache", "");
+		NativeMessageReceived("gpu_configChanged", "");
 		break;
 	case VIRTKEY_RAPID_FIRE:
 		__CtrlSetRapidFire(true);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1391,8 +1391,8 @@ void GameSettingsScreen::onFinish(DialogResult result) {
 	KeyMap::UpdateNativeMenuKeys();
 
 	// Wipe some caches after potentially changing settings.
-	NativeMessageReceived("gpu_resized", "");
-	NativeMessageReceived("gpu_clearCache", "");
+	// Let's not send resize messages here, handled elsewhere.
+	NativeMessageReceived("gpu_configChanged", "");
 }
 
 void GameSettingsScreen::sendMessage(const char *message, const char *value) {
@@ -1717,7 +1717,8 @@ UI::EventReturn GameSettingsScreen::OnLanguageChange(UI::EventParams &e) {
 UI::EventReturn GameSettingsScreen::OnPostProcShaderChange(UI::EventParams &e) {
 	g_Config.vPostShaderNames.erase(std::remove(g_Config.vPostShaderNames.begin(), g_Config.vPostShaderNames.end(), "Off"), g_Config.vPostShaderNames.end());
 
-	NativeMessageReceived("gpu_resized", "");
+	NativeMessageReceived("gpu_configChanged", "");
+	NativeMessageReceived("gpu_renderResized", "");  // To deal with shaders that can change render resolution like upscaling.
 	NativeMessageReceived("postshader_updated", "");
 	return UI::EVENT_DONE;
 }
@@ -1733,7 +1734,7 @@ UI::EventReturn GameSettingsScreen::OnTextureShader(UI::EventParams &e) {
 }
 
 UI::EventReturn GameSettingsScreen::OnTextureShaderChange(UI::EventParams &e) {
-	NativeMessageReceived("gpu_resized", "");
+	NativeMessageReceived("gpu_configChanged", "");
 	RecreateViews(); // Update setting name
 	g_Config.bTexHardwareScaling = g_Config.sTextureShaderName != "Off";
 	return UI::EVENT_DONE;
@@ -1903,7 +1904,7 @@ void DeveloperToolsScreen::CreateViews() {
 
 void DeveloperToolsScreen::onFinish(DialogResult result) {
 	g_Config.Save("DeveloperToolsScreen::onFinish");
-	NativeMessageReceived("gpu_resized", "");
+	NativeMessageReceived("gpu_configChanged", "");
 }
 
 void GameSettingsScreen::CallbackRestoreDefaults(bool yes) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -463,7 +463,10 @@ void GameSettingsScreen::CreateViews() {
 #endif
 		// Display Layout Editor: To avoid overlapping touch controls on large tablets, meet geeky demands for integer zoom/unstretched image etc.
 		displayEditor_ = graphicsSettings->Add(new Choice(gr->T("Display layout editor")));
-		displayEditor_->OnClick.Handle(this, &GameSettingsScreen::OnDisplayLayoutEditor);
+		displayEditor_->OnClick.Add([&](EventParams &params) {
+			screenManager()->push(new DisplayLayoutScreen());
+			return UI::EVENT_DONE;
+		});
 
 #if PPSSPP_PLATFORM(ANDROID)
 		// Hide insets option if no insets, or OS too old.
@@ -1331,11 +1334,6 @@ UI::EventReturn GameSettingsScreen::OnFullscreenMultiChange(UI::EventParams &e) 
 	System_SendMessage("toggle_fullscreen", g_Config.UseFullScreen() ? "1" : "0");
 	return UI::EVENT_DONE;
 }
-
-UI::EventReturn GameSettingsScreen::OnDisplayLayoutEditor(UI::EventParams &e) {
-	screenManager()->push(new DisplayLayoutScreen());
-	return UI::EVENT_DONE;
-};
 
 UI::EventReturn GameSettingsScreen::OnResolutionChange(UI::EventParams &e) {
 	if (g_Config.iAndroidHwScale == 1) {

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -105,7 +105,6 @@ private:
 	UI::EventReturn OnChangeBackground(UI::EventParams &e);
 	UI::EventReturn OnFullscreenChange(UI::EventParams &e);
 	UI::EventReturn OnFullscreenMultiChange(UI::EventParams &e);
-	UI::EventReturn OnDisplayLayoutEditor(UI::EventParams &e);
 	UI::EventReturn OnResolutionChange(UI::EventParams &e);
 	UI::EventReturn OnHwScaleChange(UI::EventParams &e);
 	UI::EventReturn OnRestoreDefaultSettings(UI::EventParams &e);

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -48,6 +48,8 @@ protected:
 	void DrawBackground(UIContext &dc) override;
 
 private:
+	void CreateDisplaySettingsViews();
+
 	UI::EventReturn OnGameSettings(UI::EventParams &e);
 	UI::EventReturn OnExitToMenu(UI::EventParams &e);
 	UI::EventReturn OnReportFeedback(UI::EventParams &e);

--- a/UWP/App.cpp
+++ b/UWP/App.cpp
@@ -57,20 +57,20 @@ void App::Initialize(CoreApplicationView^ applicationView) {
 	CoreApplication::Resuming +=
 		ref new EventHandler<Platform::Object^>(this, &App::OnResuming);
 
-	// At this point we have access to the device. 
+	// At this point we have access to the device.
 	// We can create the device-dependent resources.
 	m_deviceResources = std::make_shared<DX::DeviceResources>();
 }
 
 // Called when the CoreWindow object is created (or re-created).
 void App::SetWindow(CoreWindow^ window) {
-	window->SizeChanged += 
+	window->SizeChanged +=
 		ref new TypedEventHandler<CoreWindow^, WindowSizeChangedEventArgs^>(this, &App::OnWindowSizeChanged);
 
 	window->VisibilityChanged +=
 		ref new TypedEventHandler<CoreWindow^, VisibilityChangedEventArgs^>(this, &App::OnVisibilityChanged);
 
-	window->Closed += 
+	window->Closed +=
 		ref new TypedEventHandler<CoreWindow^, CoreWindowEventArgs^>(this, &App::OnWindowClosed);
 
 	DisplayInformation^ currentDisplayInformation = DisplayInformation::GetForCurrentView();
@@ -267,7 +267,7 @@ void App::OnWindowSizeChanged(CoreWindow^ sender, WindowSizeChangedEventArgs^ ar
 	PSP_CoreParameter().pixelWidth = (int)(width * scale);
 	PSP_CoreParameter().pixelHeight = (int)(height * scale);
 	if (UpdateScreenScale((int)width, (int)height)) {
-		NativeMessageReceived("gpu_resized", "");
+		NativeMessageReceived("gpu_displayResized", "");
 	}
 }
 

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -238,7 +238,7 @@ namespace MainWindow
 				g_Config.iInternalResolution = 0;
 		}
 
-		NativeMessageReceived("gpu_resized", "");
+		NativeMessageReceived("gpu_renderResized", "");
 	}
 
 	void CorrectCursor() {
@@ -302,7 +302,8 @@ namespace MainWindow
 		DEBUG_LOG(SYSTEM, "Pixel width/height: %dx%d", PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
 
 		if (UpdateScreenScale(width, height)) {
-			NativeMessageReceived("gpu_resized", "");
+			NativeMessageReceived("gpu_displayResized", "");
+			NativeMessageReceived("gpu_renderResized", "");
 		}
 
 		// Don't save the window state if fullscreen.

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -472,7 +472,7 @@ namespace MainWindow {
 	// not static
 	void setTexScalingMultiplier(int level) {
 		g_Config.iTexScalingLevel = level;
-		NativeMessageReceived("gpu_clearCache", "");
+		NativeMessageReceived("gpu_configChanged", "");
 	}
 
 	static void setTexFiltering(int type) {
@@ -485,12 +485,12 @@ namespace MainWindow {
 
 	static void setTexScalingType(int type) {
 		g_Config.iTexScalingType = type;
-		NativeMessageReceived("gpu_clearCache", "");
+		NativeMessageReceived("gpu_configChanged", "");
 	}
 
 	static void setSkipBufferEffects(bool skip) {
 		g_Config.bSkipBufferEffects = skip;
-		NativeMessageReceived("gpu_resized", "");
+		NativeMessageReceived("gpu_configChanged", "");
 	}
 
 	static void setFrameSkipping(int framesToSkip = -1) {
@@ -744,7 +744,7 @@ namespace MainWindow {
 			g_Config.bAutoFrameSkip = !g_Config.bAutoFrameSkip;
 			if (g_Config.bAutoFrameSkip && g_Config.bSkipBufferEffects) {
 				g_Config.bSkipBufferEffects = false;
-				NativeMessageReceived("gpu_resized", "");
+				NativeMessageReceived("gpu_configChanged", "");
 			}
 			break;
 
@@ -761,7 +761,7 @@ namespace MainWindow {
 
 		case ID_TEXTURESCALING_DEPOSTERIZE:
 			g_Config.bTexDeposterize = !g_Config.bTexDeposterize;
-			NativeMessageReceived("gpu_clearCache", "");
+			NativeMessageReceived("gpu_configChanged", "");
 			break;
 
 		case ID_OPTIONS_DIRECT3D9:
@@ -790,7 +790,7 @@ namespace MainWindow {
 
 		case ID_OPTIONS_SKIP_BUFFER_EFFECTS:
 			g_Config.bSkipBufferEffects = !g_Config.bSkipBufferEffects;
-			NativeMessageReceived("gpu_resized", "");
+			NativeMessageReceived("gpu_configChanged", "");
 			osm.ShowOnOff(gr->T("Skip Buffer Effects"), g_Config.bSkipBufferEffects);
 			break;
 
@@ -801,7 +801,7 @@ namespace MainWindow {
 
 		case ID_OPTIONS_HARDWARETRANSFORM:
 			g_Config.bHardwareTransform = !g_Config.bHardwareTransform;
-			NativeMessageReceived("gpu_resized", "");
+			NativeMessageReceived("gpu_configChanged", "");
 			osm.ShowOnOff(gr->T("Hardware Transform"), g_Config.bHardwareTransform);
 			break;
 
@@ -1045,7 +1045,7 @@ namespace MainWindow {
 					g_Config.vPostShaderNames.push_back(availableShaders[index]);
 				g_Config.bShaderChainRequires60FPS = PostShaderChainRequires60FPS(GetFullPostShadersChain(g_Config.vPostShaderNames));
 
-				NativeMessageReceived("gpu_resized", "");
+				NativeMessageReceived("gpu_renderResized", "");
 				NativeMessageReceived("postshader_updated", "");
 				break;
 			}

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1095,8 +1095,7 @@ static void check_variables(CoreParameter &coreParam)
          || g_Config.iTexScalingLevel != iTexScalingLevel_prev
          || g_Config.sTextureShaderName != sTextureShaderName_prev))
    {
-      gpu->ClearCacheNextFrame();
-      gpu->Resized();
+      gpu->NotifyConfigChanged();
    }
 
    if (g_Config.iLanguage < 0)
@@ -1131,7 +1130,7 @@ static void check_variables(CoreParameter &coreParam)
          retro_get_system_av_info(&avInfo);
          environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &avInfo);
          updateAvInfo = false;
-         gpu->Resized();
+         gpu->NotifyDisplayResized();
       }
    }
 


### PR DESCRIPTION
Currently contains some commits from other PRs, will rebase when #16409 is in.

This adds a "Display settings" button to the in-game pause screen, which switches it to a mode where we can see the game screen fully, and (currently) just change the aspect ratio between Stretch and the other modes. More controls will be added.

This will eventually be able to fully replace the somewhat confusing "Display layout editor".

Transparency notes:

Screen stack examples:

* Popup - transparent, visible
* Graphics settings - transparent, visible
* Pause screen - transparent, not visible
* Emu screen - opaque, visible
* Main screen - opaque, not visible

Example 2:

* Popup - transparent, visible
* Pause screen - transparent, visible
* Emu screen - opaque, visible
* Main screen - opaque, not visible

I think the rules are, for the background visibility I want:

* Popups don't affect transparency of below. Only a single non-popup transparent screen is drawn, on top of the first opaque screen.

