### PR TITLE
Kernel: Respect partition param in heap funcs

### DIFF
--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -118,11 +118,6 @@ u32 GPU_D3D11::CheckGPUFeatures() const {
 		features |= GPU_USE_16BIT_FORMATS;
 	}
 
-	// The Phantasy Star hack :(
-	if (PSP_CoreParameter().compat.flags().DepthRangeHack && (features & GPU_USE_ACCURATE_DEPTH) == 0) {
-		features |= GPU_USE_DEPTH_RANGE_HACK;
-	}
-
 	return CheckGPUFeaturesLate(features);
 }
 


### PR DESCRIPTION
Not really tested, but just uses the partition ID to allocate in the right space and look up free memory in the right space.  Should fix #13021.

-[Unknown]