### PR TITLE
Pause menu background: Remove complicated transparency tricks

### DIFF
--- a/Common/UI/Context.h
+++ b/Common/UI/Context.h
@@ -71,7 +71,6 @@ public:
 
 	DrawBuffer *Draw() const { return uidrawbuffer_; }
 	DrawBuffer *DrawTop() const { return uidrawbufferTop_; }
-	const UI::Theme *theme;
 
 	// Utility methods
 	TextDrawer *Text() const { return textDrawer_; }
@@ -94,6 +93,9 @@ public:
 	const Bounds &GetBounds() const { return bounds_; }
 	Bounds GetLayoutBounds() const;
 	Draw::DrawContext *GetDrawContext() { return draw_; }
+	const UI::Theme &GetTheme() const {
+		return *theme;
+	}
 	void SetCurZ(float curZ);
 
 	void PushTransform(const UITransform &transform);
@@ -105,6 +107,9 @@ public:
 	void SetScreenTag(const char *tag) {
 		screenTag_ = tag;
 	}
+
+	// TODO: Move to private.
+	const UI::Theme *theme;
 
 private:
 	Draw::DrawContext *draw_ = nullptr;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1392,30 +1392,6 @@ void EmuScreen::render() {
 	if (!thin3d)
 		return;  // shouldn't really happen but I've seen a suspicious stack trace..
 
-	// We can still render behind the pause screen.
-	bool paused = screenManager()->topScreen() != this;
-
-	if (paused && screenManager()->topScreen()->isTransparent()) {
-		// If we're paused and PauseScreen is transparent (will only be in buffered rendering mode), we just copy display to output.
-		thin3d->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_Paused");
-		if (PSP_IsInited()) {
-			gpu->CheckDisplayResized();
-			gpu->CopyDisplayToOutput(true);
-		}
-
-		screenManager()->getUIContext()->BeginFrame();
-		DrawContext *draw = screenManager()->getDrawContext();
-		Viewport viewport;
-		viewport.TopLeftX = 0;
-		viewport.TopLeftY = 0;
-		viewport.Width = pixel_xres;
-		viewport.Height = pixel_yres;
-		viewport.MaxDepth = 1.0;
-		viewport.MinDepth = 0.0;
-		draw->SetViewports(1, &viewport);
-		return;
-	}
-
 	if (invalid_) {
 		// Loading, or after shutdown?
 		if (loadingTextView_->GetVisibility() == UI::V_VISIBLE)

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -51,6 +51,8 @@ public:
 	void sendMessage(const char *message, const char *value) override;
 protected:
 	Path gamePath_;
+
+	bool darkenGameBackground_ = false;
 };
 
 class UIDialogScreenWithBackground : public UIDialogScreen {

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -256,24 +256,6 @@ GamePauseScreen::~GamePauseScreen() {
 	__DisplaySetWasPaused();
 }
 
-bool GamePauseScreen::isTransparent() const {
-	// We don't support transparent pause screen in skipbuffereffects mode.
-	return !g_Config.bSkipBufferEffects && !IsVREnabled();
-}
-
-void GamePauseScreen::DrawBackground(UIContext &dc) {
-	if (isTransparent()) {
-		// Darken the game screen coming from below, so the UI on top stands out.
-		dc.Flush();
-		uint32_t color = blackAlpha(0.45f);
-		dc.FillRect(UI::Drawable(color), dc.GetBounds());
-		dc.Flush();
-		return;
-	}
-
-	UIDialogScreenWithGameBackground::DrawBackground(dc);
-}
-
 void GamePauseScreen::CreateViews() {
 	static const int NUM_SAVESLOTS = 5;
 

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -44,9 +44,6 @@ protected:
 	void update() override;
 	void CallbackDeleteConfig(bool yes);
 
-	bool isTransparent() const override;
-	void DrawBackground(UIContext &dc) override;
-
 private:
 	UI::EventReturn OnGameSettings(UI::EventParams &e);
 	UI::EventReturn OnExitToMenu(UI::EventParams &e);


### PR DESCRIPTION
Instead draw game as part of background.

This makes the game visible through many menu screens if in-game, not just the pause screen.