### PR TITLE
Move post processing settings to the Display Layout Editor

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -107,14 +107,15 @@ bool FramebufferManagerCommon::UpdateRenderSize() {
 	return newRender || newSettings;
 }
 
-void FramebufferManagerCommon::BeginFrame() {
-	DecimateFBOs();
-
-	// Might have a new post shader - let's compile it.
+void FramebufferManagerCommon::CheckPostShaders() {
 	if (updatePostShaders_) {
 		presentation_->UpdatePostShader();
 		updatePostShaders_ = false;
 	}
+}
+
+void FramebufferManagerCommon::BeginFrame() {
+	DecimateFBOs();
 
 	currentRenderVfb_ = nullptr;
 }
@@ -2380,6 +2381,10 @@ void FramebufferManagerCommon::NotifyRenderResized() {
 		ShowScreenResolution();
 	}
 #endif
+}
+
+void FramebufferManagerCommon::NotifyConfigChanged() {
+	updatePostShaders_ = true;
 }
 
 void FramebufferManagerCommon::DestroyAllFBOs() {

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -398,8 +398,11 @@ public:
 	}
 	void SetSafeSize(u16 w, u16 h);
 
-	virtual void NotifyRenderResized();
+	void NotifyRenderResized();
 	virtual void NotifyDisplayResized();
+	void NotifyConfigChanged();
+
+	void CheckPostShaders();
 
 	virtual void DestroyAllFBOs();
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -633,11 +633,13 @@ void GPUCommon::CheckConfigChanged() {
 	if (configChanged_) {
 		gstate_c.useFlags = CheckGPUFeatures();
 		drawEngineCommon_->NotifyConfigChanged();
-		shaderManager_->DirtyLastShader();  // Don't think this is needed, at all.
 		textureCache_->NotifyConfigChanged();
+		framebufferManager_->NotifyConfigChanged();
 		BuildReportingInfo();
 		configChanged_ = false;
 	}
+
+	framebufferManager_->CheckPostShaders();
 }
 
 void GPUCommon::CheckDisplayResized() {

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -639,7 +639,10 @@ void GPUCommon::CheckConfigChanged() {
 		configChanged_ = false;
 	}
 
-	framebufferManager_->CheckPostShaders();
+	// Check needed when running tests.
+	if (framebufferManager_) {
+		framebufferManager_->CheckPostShaders();
+	}
 }
 
 void GPUCommon::CheckDisplayResized() {

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -79,6 +79,7 @@ public:
 	virtual u32 CheckGPUFeatures() const;
 
 	void CheckDisplayResized() override;
+	void CheckConfigChanged() override;
 
 	void UpdateCmdInfo();
 
@@ -266,7 +267,6 @@ protected:
 	void DeviceLost() override;
 	void DeviceRestore() override;
 
-	void CheckConfigChanged();
 	void CheckRenderResized();
 
 	// Add additional common features dependent on other features, which may be backend-determined.

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -199,6 +199,7 @@ public:
 	virtual void EndHostFrame() = 0;
 
 	virtual void CheckDisplayResized() = 0;
+	virtual void CheckConfigChanged() = 0;
 
 	// Draw queue management
 	virtual DisplayList* getList(int listid) = 0;

--- a/UI/ComboKeyMappingScreen.h
+++ b/UI/ComboKeyMappingScreen.h
@@ -24,9 +24,9 @@ namespace UI {
 	class CheckBox;
 }
 
-class ComboKeyScreen : public UIDialogScreenWithBackground {
+class ComboKeyScreen : public UIDialogScreenWithGameBackground {
 public:
-	ComboKeyScreen(int id): id_(id) {}
+	ComboKeyScreen(const Path &gamePath, int id) : UIDialogScreenWithGameBackground(gamePath), id_(id) {}
 
 	const char *tag() const override { return "ComboKey"; }
 

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -279,7 +279,7 @@ void ControlMappingScreen::update() {
 		RecreateViews();
 	}
 
-	UIDialogScreenWithBackground::update();
+	UIDialogScreenWithGameBackground::update();
 	SetVRAppMode(VRAppMode::VR_MENU_MODE);
 }
 
@@ -309,7 +309,7 @@ UI::EventReturn ControlMappingScreen::OnAutoConfigure(UI::EventParams &params) {
 }
 
 UI::EventReturn ControlMappingScreen::OnVisualizeMapping(UI::EventParams &params) {
-	VisualMappingScreen *visualMapping = new VisualMappingScreen();
+	VisualMappingScreen *visualMapping = new VisualMappingScreen(gamePath_);
 	screenManager()->push(visualMapping);
 	return UI::EVENT_DONE;
 }
@@ -581,7 +581,7 @@ void JoystickHistoryView::Update() {
 	}
 }
 
-AnalogSetupScreen::AnalogSetupScreen() {
+AnalogSetupScreen::AnalogSetupScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {
 	mapper_.SetCallbacks([](int vkey) {}, [](int vkey) {}, [&](int stick, float x, float y) {
 		analogX_[stick] = x;
 		analogY_[stick] = y;
@@ -673,7 +673,7 @@ UI::EventReturn AnalogSetupScreen::OnResetToDefaults(UI::EventParams &e) {
 }
 
 bool TouchTestScreen::touch(const TouchInput &touch) {
-	UIDialogScreenWithBackground::touch(touch);
+	UIDialogScreenWithGameBackground::touch(touch);
 	if (touch.flags & TOUCH_DOWN) {
 		bool found = false;
 		for (int i = 0; i < MAX_TOUCH_POINTS; i++) {
@@ -802,7 +802,7 @@ bool TouchTestScreen::axis(const AxisInput &axis) {
 }
 
 void TouchTestScreen::render() {
-	UIDialogScreenWithBackground::render();
+	UIDialogScreenWithGameBackground::render();
 	UIContext *ui_context = screenManager()->getUIContext();
 	Bounds bounds = ui_context->GetLayoutBounds();
 
@@ -1161,7 +1161,7 @@ void VisualMappingScreen::CreateViews() {
 }
 
 void VisualMappingScreen::resized() {
-	UIDialogScreenWithBackground::resized();
+	UIDialogScreenWithGameBackground::resized();
 	RecreateViews();
 }
 

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -32,9 +32,9 @@
 
 class SingleControlMapper;
 
-class ControlMappingScreen : public UIDialogScreenWithBackground {
+class ControlMappingScreen : public UIDialogScreenWithGameBackground {
 public:
-	ControlMappingScreen() {}
+	ControlMappingScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {}
 	const char *tag() const override { return "ControlMapping"; }
 
 protected:
@@ -84,7 +84,7 @@ private:
 
 class KeyMappingNewMouseKeyDialog : public PopupScreen {
 public:
-	explicit KeyMappingNewMouseKeyDialog(int btn, bool replace, std::function<void(KeyDef)> callback, std::shared_ptr<I18NCategory> i18n)
+	KeyMappingNewMouseKeyDialog(int btn, bool replace, std::function<void(KeyDef)> callback, std::shared_ptr<I18NCategory> i18n)
 		: PopupScreen(i18n->T("Map Mouse"), "", ""), callback_(callback), mapped_(false) {
 		pspBtn_ = btn;
 	}
@@ -109,9 +109,9 @@ private:
 
 class JoystickHistoryView;
 
-class AnalogSetupScreen : public UIDialogScreenWithBackground {
+class AnalogSetupScreen : public UIDialogScreenWithGameBackground {
 public:
-	AnalogSetupScreen();
+	AnalogSetupScreen(const Path &gamePath);
 
 	bool key(const KeyInput &key) override;
 	bool axis(const AxisInput &axis) override;
@@ -136,9 +136,9 @@ private:
 	JoystickHistoryView *stickView_[2]{};
 };
 
-class TouchTestScreen : public UIDialogScreenWithBackground {
+class TouchTestScreen : public UIDialogScreenWithGameBackground {
 public:
-	TouchTestScreen() {
+	TouchTestScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {
 		for (int i = 0; i < MAX_TOUCH_POINTS; i++) {
 			touches_[i].id = -1;
 		}
@@ -175,9 +175,9 @@ protected:
 
 class MockPSP;
 
-class VisualMappingScreen : public UIDialogScreenWithBackground {
+class VisualMappingScreen : public UIDialogScreenWithGameBackground {
 public:
-	VisualMappingScreen() {}
+	VisualMappingScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {}
 
 	const char *tag() const override { return "VisualMapping"; }
 

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -35,8 +35,7 @@
 static const int FILE_CHECK_FRAME_INTERVAL = 53;
 
 CwCheatScreen::CwCheatScreen(const Path &gamePath)
-	: UIDialogScreenWithBackground() {
-	gamePath_ = gamePath;
+	: UIDialogScreenWithGameBackground(gamePath) {
 }
 
 CwCheatScreen::~CwCheatScreen() {
@@ -129,7 +128,7 @@ void CwCheatScreen::update() {
 		fileCheckCounter_ = 0;
 	}
 
-	UIDialogScreenWithBackground::update();
+	UIDialogScreenWithGameBackground::update();
 }
 
 void CwCheatScreen::onFinish(DialogResult result) {

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -26,7 +26,7 @@
 struct CheatFileInfo;
 class CWCheatEngine;
 
-class CwCheatScreen : public UIDialogScreenWithBackground {
+class CwCheatScreen : public UIDialogScreenWithGameBackground {
 public:
 	CwCheatScreen(const Path &gamePath);
 	~CwCheatScreen();
@@ -56,7 +56,6 @@ private:
 	UI::ScrollView *rightScroll_ = nullptr;
 	CWCheatEngine *engine_ = nullptr;
 	std::vector<CheatFileInfo> fileInfo_;
-	Path gamePath_;
 	std::string gameID_;
 	int fileCheckCounter_ = 0;
 	uint64_t fileCheckHash_;

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -147,7 +147,7 @@ UI::EventReturn DevMenuScreen::OnLogConfig(UI::EventParams &e) {
 
 UI::EventReturn DevMenuScreen::OnDeveloperTools(UI::EventParams &e) {
 	UpdateUIState(UISTATE_PAUSEMENU);
-	screenManager()->push(new DeveloperToolsScreen());
+	screenManager()->push(new DeveloperToolsScreen(gamePath_));
 	return UI::EVENT_DONE;
 }
 

--- a/UI/DevScreens.h
+++ b/UI/DevScreens.h
@@ -30,7 +30,7 @@
 
 class DevMenuScreen : public PopupScreen {
 public:
-	DevMenuScreen(std::shared_ptr<I18NCategory> i18n) : PopupScreen(i18n->T("Dev Tools")) {}
+	DevMenuScreen(const Path &gamePath, std::shared_ptr<I18NCategory> i18n) : PopupScreen(i18n->T("Dev Tools")), gamePath_(gamePath) {}
 
 	const char *tag() const override { return "DevMenu"; }
 
@@ -47,6 +47,9 @@ protected:
 	UI::EventReturn OnDeveloperTools(UI::EventParams &e);
 	UI::EventReturn OnToggleAudioDebug(UI::EventParams &e);
 	UI::EventReturn OnResetLimitedLogging(UI::EventParams &e);
+
+private:
+	Path gamePath_;
 };
 
 class JitDebugScreen : public UIDialogScreenWithBackground {

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -25,6 +25,8 @@
 #include "Common/UI/View.h"
 #include "Common/Math/math_util.h"
 #include "Common/System/Display.h"
+#include "Common/System/NativeApp.h"
+#include "Common/StringUtils.h"
 
 #include "Common/Data/Color/RGBAUtil.h"
 #include "Common/Data/Text/I18n.h"
@@ -34,6 +36,7 @@
 #include "Core/System.h"
 #include "GPU/Common/FramebufferManagerCommon.h"
 #include "GPU/Common/PresentationCommon.h"
+#include "GPU/Common/PostShader.h"
 
 static const int leftColumnWidth = 200;
 static const float orgRatio = 1.764706f;  // 480.0 / 272.0
@@ -158,16 +161,36 @@ void DisplayLayoutScreen::dialogFinished(const Screen *dialog, DialogResult resu
 	RecreateViews();
 }
 
-// Stealing StickyChoice's layout and text rendering.
-class HighlightLabel : public UI::StickyChoice {
-public:
-	HighlightLabel(const std::string &text, UI::LayoutParams *layoutParams)
-		: UI::StickyChoice(text, "", layoutParams) {
-		Press();
-	}
+UI::EventReturn DisplayLayoutScreen::OnPostProcShaderChange(UI::EventParams &e) {
+	g_Config.vPostShaderNames.erase(std::remove(g_Config.vPostShaderNames.begin(), g_Config.vPostShaderNames.end(), "Off"), g_Config.vPostShaderNames.end());
 
-	bool CanBeFocused() const override { return false; }
-};
+	NativeMessageReceived("gpu_configChanged", "");
+	NativeMessageReceived("gpu_renderResized", "");  // To deal with shaders that can change render resolution like upscaling.
+	NativeMessageReceived("postshader_updated", "");
+
+	if (gpu) {
+		gpu->NotifyConfigChanged();
+	}
+	return UI::EVENT_DONE;
+}
+
+static std::string PostShaderTranslateName(const char *value) {
+	auto ps = GetI18NCategory("PostShaders");
+	const ShaderInfo *info = GetPostShaderInfo(value);
+	if (info) {
+		return ps->T(value, info ? info->name.c_str() : value);
+	} else {
+		return value;
+	}
+}
+
+void DisplayLayoutScreen::sendMessage(const char *message, const char *value) {
+	UIDialogScreenWithGameBackground::sendMessage(message, value);
+	if (!strcmp(message, "postshader_updated")) {
+		g_Config.bShaderChainRequires60FPS = PostShaderChainRequires60FPS(GetFullPostShadersChain(g_Config.vPostShaderNames));
+		RecreateViews();
+	}
+}
 
 void DisplayLayoutScreen::CreateViews() {
 	const Bounds &bounds = screenManager()->getUIContext()->GetBounds();
@@ -177,8 +200,12 @@ void DisplayLayoutScreen::CreateViews() {
 	auto di = GetI18NCategory("Dialog");
 	auto gr = GetI18NCategory("Graphics");
 	auto co = GetI18NCategory("Controls");
+	auto ps = GetI18NCategory("PostShaders");
 
 	root_ = new AnchorLayout(new LayoutParams(FILL_PARENT, FILL_PARENT));
+
+	ViewGroup *rightColumn = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(300.0f, FILL_PARENT, NONE, 10.f, 10.0f, 10.0f, false));
+	root_->Add(rightColumn);
 
 	// We manually implement insets here for the buttons. This file defied refactoring :(
 	float leftInset = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_LEFT);
@@ -189,11 +216,9 @@ void DisplayLayoutScreen::CreateViews() {
 		bRotated_ = true;
 	}
 
-	HighlightLabel *label = nullptr;
 	mode_ = nullptr;
 	if (g_Config.iSmallDisplayZoomType >= (int)SmallDisplayZoom::AUTO) { // Scaling
 		if (g_Config.iSmallDisplayZoomType == (int)SmallDisplayZoom::AUTO) {
-			label = new HighlightLabel(gr->T("Auto Scaling"), new AnchorLayoutParams(WRAP_CONTENT, 64.0f, bounds.w / 2.0f, bounds.h / 2.0f, NONE, NONE, true));
 			float autoBound = bounds.h / 270.0f;
 			// Case of screen rotated ~ only works with buffered rendering
 			if (bRotated_) {
@@ -229,7 +254,6 @@ void DisplayLayoutScreen::CreateViews() {
 			mode_->SetSelection(0, false);
 		}
 	} else { // Stretching
-		label = new HighlightLabel(gr->T("Stretching"), new AnchorLayoutParams(WRAP_CONTENT, 64.0f, bounds.w / 2.0f, bounds.h / 2.0f, NONE, NONE, true));
 		float width = bounds.w;
 		float height = bounds.h;
 		if (g_Config.iSmallDisplayZoomType != (int)SmallDisplayZoom::STRETCH) {
@@ -252,23 +276,76 @@ void DisplayLayoutScreen::CreateViews() {
 	if (mode_) {
 		root_->Add(mode_);
 	}
-	if (label) {
-		root_->Add(label);
-	}
 
 	static const char *zoomLevels[] = { "Stretching", "Partial Stretch", "Auto Scaling", "Manual Scaling" };
 	auto zoom = new PopupMultiChoice(&g_Config.iSmallDisplayZoomType, di->T("Options"), zoomLevels, 0, ARRAY_SIZE(zoomLevels), gr->GetName(), screenManager(), new AnchorLayoutParams(400, WRAP_CONTENT, bounds.w / 2.0f - 200.0f, NONE, NONE, 10));
 	zoom->OnChoice.Handle(this, &DisplayLayoutScreen::OnZoomTypeChange);
-	root_->Add(zoom);
+	rightColumn->Add(zoom);
 
 	static const char *displayRotation[] = { "Landscape", "Portrait", "Landscape Reversed", "Portrait Reversed" };
-	auto rotation = new PopupMultiChoice(&g_Config.iInternalScreenRotation, gr->T("Rotation"), displayRotation, 1, ARRAY_SIZE(displayRotation), co->GetName(), screenManager(), new AnchorLayoutParams(400, WRAP_CONTENT, bounds.w / 2.0f - 200.0f, 10, NONE, bounds.h - 64 - 10));
+	auto rotation = new PopupMultiChoice(&g_Config.iInternalScreenRotation, gr->T("Rotation"), displayRotation, 1, ARRAY_SIZE(displayRotation), co->GetName(), screenManager());
 	rotation->SetEnabledFunc([] {
 		return !g_Config.bSkipBufferEffects || g_Config.bSoftwareRendering;
 	});
-	root_->Add(rotation);
+	rightColumn->Add(rotation);
 
-	Choice *back = new Choice(di->T("Back"), "", false, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10 + leftInset, NONE, NONE, 10));
+	rightColumn->Add(new ItemHeader(gr->T("Postprocessing effect")));
+
+	Draw::DrawContext *draw = screenManager()->getDrawContext();
+
+	bool multiViewSupported = draw->GetDeviceCaps().multiViewSupported;
+
+	auto enableStereo = [=]() -> bool {
+		return g_Config.bStereoRendering && multiViewSupported;
+	};
+
+	std::set<std::string> alreadyAddedShader;
+	for (int i = 0; i < (int)g_Config.vPostShaderNames.size() + 1 && i < ARRAY_SIZE(shaderNames_); ++i) {
+		// Vector element pointer get invalidated on resize, cache name to have always a valid reference in the rendering thread
+		shaderNames_[i] = i == g_Config.vPostShaderNames.size() ? "Off" : g_Config.vPostShaderNames[i];
+		postProcChoice_ = rightColumn->Add(new ChoiceWithValueDisplay(&shaderNames_[i], StringFromFormat("%s #%d", gr->T("Postprocessing Shader"), i + 1), &PostShaderTranslateName));
+		postProcChoice_->OnClick.Add([=](EventParams &e) {
+			auto gr = GetI18NCategory("Graphics");
+			auto procScreen = new PostProcScreen(gr->T("Postprocessing Shader"), i, false);
+			procScreen->OnChoice.Handle(this, &DisplayLayoutScreen::OnPostProcShaderChange);
+			if (e.v)
+				procScreen->SetPopupOrigin(e.v);
+			screenManager()->push(procScreen);
+			return UI::EVENT_DONE;
+		});
+		postProcChoice_->SetEnabledFunc([=] {
+			return !g_Config.bSkipBufferEffects && !enableStereo();
+		});
+
+		// No need for settings on the last one.
+		if (i == g_Config.vPostShaderNames.size())
+			continue;
+
+		auto shaderChain = GetPostShaderChain(g_Config.vPostShaderNames[i]);
+		for (auto shaderInfo : shaderChain) {
+			// Disable duplicated shader slider
+			bool duplicated = alreadyAddedShader.find(shaderInfo->section) != alreadyAddedShader.end();
+			alreadyAddedShader.insert(shaderInfo->section);
+			for (size_t i = 0; i < ARRAY_SIZE(shaderInfo->settings); ++i) {
+				auto &setting = shaderInfo->settings[i];
+				if (!setting.name.empty()) {
+					auto &value = g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderInfo->section.c_str(), i + 1)];
+					if (duplicated) {
+						auto sliderName = StringFromFormat("%s %s", ps->T(setting.name), ps->T("(duplicated setting, previous slider will be used)"));
+						PopupSliderChoiceFloat *settingValue = rightColumn->Add(new PopupSliderChoiceFloat(&value, setting.minValue, setting.maxValue, sliderName, setting.step, screenManager()));
+						settingValue->SetEnabled(false);
+					} else {
+						PopupSliderChoiceFloat *settingValue = rightColumn->Add(new PopupSliderChoiceFloat(&value, setting.minValue, setting.maxValue, ps->T(setting.name), setting.step, screenManager()));
+						settingValue->SetEnabledFunc([=] {
+							return !g_Config.bSkipBufferEffects && !enableStereo();
+						});
+					}
+				}
+			}
+		}
+	}
+
+	Choice *back = new Choice(di->T("Back"), "", false);
 	back->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
-	root_->Add(back);
+	rightColumn->Add(back);
 }

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -204,8 +204,8 @@ void DisplayLayoutScreen::CreateViews() {
 
 	root_ = new AnchorLayout(new LayoutParams(FILL_PARENT, FILL_PARENT));
 
-	ScrollView *rightScrollView = new ScrollView(ORIENT_VERTICAL, new AnchorLayoutParams(300.0f, FILL_PARENT, NONE, 10.f, 10.0f, 10.0f, false));
-	ViewGroup *rightColumn = new LinearLayout(ORIENT_VERTICAL); // , new AnchorLayoutParams(300.0f, FILL_PARENT, NONE, 10.f, 10.0f, 10.0f, false));
+	ScrollView *rightScrollView = new ScrollView(ORIENT_VERTICAL, new AnchorLayoutParams(300.0f, FILL_PARENT, NONE, 10.f, 10.f, 10.f, false));
+	ViewGroup *rightColumn = new LinearLayout(ORIENT_VERTICAL);
 	rightScrollView->Add(rightColumn);
 	root_->Add(rightScrollView);
 
@@ -245,33 +245,12 @@ void DisplayLayoutScreen::CreateViews() {
 			center->OnClick.Handle(this, &DisplayLayoutScreen::OnCenter);
 			root_->Add(center);
 			float minZoom = 1.0f;
-			if (g_dpi_scale_x > 1.0f) {
-				minZoom /= g_dpi_scale_x;
-			}
 			PopupSliderChoiceFloat *zoomlvl = new PopupSliderChoiceFloat(&g_Config.fSmallDisplayZoomLevel, minZoom, 10.0f, di->T("Zoom"), 1.0f, screenManager(), di->T("* PSP res"), new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10 + leftInset, NONE, NONE, 10 + 64 + 64));
 			root_->Add(zoomlvl);
 			mode_ = new ChoiceStrip(ORIENT_VERTICAL, new AnchorLayoutParams(leftColumnWidth, WRAP_CONTENT, 10 + leftInset, NONE, NONE, 158 + 64 + 10));
 			mode_->AddChoice(di->T("Move"));
 			mode_->AddChoice(di->T("Resize"));
 			mode_->SetSelection(0, false);
-		}
-	} else { // Stretching
-		float width = bounds.w;
-		float height = bounds.h;
-		if (g_Config.iSmallDisplayZoomType != (int)SmallDisplayZoom::STRETCH) {
-			float origRatio = !bRotated_ ? 480.0f / 272.0f : 272.0f / 480.0f;
-			float frameRatio = width / height;
-			if (origRatio > frameRatio) {
-				height = width / origRatio;
-				if (!bRotated_ && g_Config.iSmallDisplayZoomType == (int)SmallDisplayZoom::PARTIAL_STRETCH) {
-					height = (272.0f + height) / 2.0f;
-				}
-			} else {
-				width = height * origRatio;
-				if (bRotated_ && g_Config.iSmallDisplayZoomType == (int)SmallDisplayZoom::PARTIAL_STRETCH) {
-					width = (272.0f + height) / 2.0f;
-				}
-			}
 		}
 	}
 

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -204,8 +204,10 @@ void DisplayLayoutScreen::CreateViews() {
 
 	root_ = new AnchorLayout(new LayoutParams(FILL_PARENT, FILL_PARENT));
 
-	ViewGroup *rightColumn = new LinearLayout(ORIENT_VERTICAL, new AnchorLayoutParams(300.0f, FILL_PARENT, NONE, 10.f, 10.0f, 10.0f, false));
-	root_->Add(rightColumn);
+	ScrollView *rightScrollView = new ScrollView(ORIENT_VERTICAL, new AnchorLayoutParams(300.0f, FILL_PARENT, NONE, 10.f, 10.0f, 10.0f, false));
+	ViewGroup *rightColumn = new LinearLayout(ORIENT_VERTICAL); // , new AnchorLayoutParams(300.0f, FILL_PARENT, NONE, 10.f, 10.0f, 10.0f, false));
+	rightScrollView->Add(rightColumn);
+	root_->Add(rightScrollView);
 
 	// We manually implement insets here for the buttons. This file defied refactoring :(
 	float leftInset = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_LEFT);
@@ -278,7 +280,7 @@ void DisplayLayoutScreen::CreateViews() {
 	}
 
 	static const char *zoomLevels[] = { "Stretching", "Partial Stretch", "Auto Scaling", "Manual Scaling" };
-	auto zoom = new PopupMultiChoice(&g_Config.iSmallDisplayZoomType, di->T("Options"), zoomLevels, 0, ARRAY_SIZE(zoomLevels), gr->GetName(), screenManager(), new AnchorLayoutParams(400, WRAP_CONTENT, bounds.w / 2.0f - 200.0f, NONE, NONE, 10));
+	auto zoom = new PopupMultiChoice(&g_Config.iSmallDisplayZoomType, gr->T("Mode"), zoomLevels, 0, ARRAY_SIZE(zoomLevels), gr->GetName(), screenManager(), new AnchorLayoutParams(400, WRAP_CONTENT, bounds.w / 2.0f - 200.0f, NONE, NONE, 10));
 	zoom->OnChoice.Handle(this, &DisplayLayoutScreen::OnZoomTypeChange);
 	rightColumn->Add(zoom);
 

--- a/UI/DisplayLayoutScreen.h
+++ b/UI/DisplayLayoutScreen.h
@@ -41,8 +41,15 @@ protected:
 	virtual UI::EventReturn OnCenter(UI::EventParams &e);
 	virtual UI::EventReturn OnZoomTypeChange(UI::EventParams &e);
 
+	UI::EventReturn OnPostProcShaderChange(UI::EventParams &e);
+
+	void sendMessage(const char *message, const char *value) override;
+
 private:
 	UI::ChoiceStrip *mode_ = nullptr;
+	UI::Choice *postProcChoice_ = nullptr;
+	std::string shaderNames_[256];
+
 	bool dragging_ = false;
 	bool bRotated_ = false;
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -486,7 +486,7 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 		RecreateViews();
 	} else if (!strcmp(message, "control mapping") && screenManager()->topScreen() == this) {
 		UpdateUIState(UISTATE_PAUSEMENU);
-		screenManager()->push(new ControlMappingScreen());
+		screenManager()->push(new ControlMappingScreen(gamePath_));
 	} else if (!strcmp(message, "display layout editor") && screenManager()->topScreen() == this) {
 		UpdateUIState(UISTATE_PAUSEMENU);
 		screenManager()->push(new DisplayLayoutScreen(gamePath_));
@@ -968,7 +968,7 @@ void EmuScreen::CreateViews() {
 
 UI::EventReturn EmuScreen::OnDevTools(UI::EventParams &params) {
 	auto dev = GetI18NCategory("Developer");
-	DevMenuScreen *devMenu = new DevMenuScreen(dev);
+	DevMenuScreen *devMenu = new DevMenuScreen(gamePath_, dev);
 	if (params.v)
 		devMenu->SetPopupOrigin(params.v);
 	screenManager()->push(devMenu);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -366,7 +366,7 @@ void GameSettingsScreen::CreateViews() {
 		return UI::EVENT_CONTINUE;
 	});
 
-	graphicsSettings->Add(new ItemHeader(gr->T("Postprocessing effect")));
+	graphicsSettings->Add(new ItemHeader(gr->T("Stereo rendering")));
 
 	bool multiViewSupported = draw->GetDeviceCaps().multiViewSupported;
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -792,7 +792,7 @@ void GameSettingsScreen::CreateViews() {
 		style->SetEnabledPtr(&g_Config.bShowTouchControls);
 		Choice *gesture = controlsSettings->Add(new Choice(co->T("Gesture mapping")));
 		gesture->OnClick.Add([=](EventParams &e) {
-			screenManager()->push(new GestureMappingScreen());
+			screenManager()->push(new GestureMappingScreen(gamePath_));
 			return UI::EVENT_DONE;
 		});
 		gesture->SetEnabledPtr(&g_Config.bShowTouchControls);
@@ -1739,7 +1739,7 @@ UI::EventReturn GameSettingsScreen::OnTextureShaderChange(UI::EventParams &e) {
 }
 
 UI::EventReturn GameSettingsScreen::OnDeveloperTools(UI::EventParams &e) {
-	screenManager()->push(new DeveloperToolsScreen());
+	screenManager()->push(new DeveloperToolsScreen(gamePath_));
 	return UI::EVENT_DONE;
 }
 
@@ -1749,17 +1749,17 @@ UI::EventReturn GameSettingsScreen::OnRemoteISO(UI::EventParams &e) {
 }
 
 UI::EventReturn GameSettingsScreen::OnControlMapping(UI::EventParams &e) {
-	screenManager()->push(new ControlMappingScreen());
+	screenManager()->push(new ControlMappingScreen(gamePath_));
 	return UI::EVENT_DONE;
 }
 
 UI::EventReturn GameSettingsScreen::OnCalibrateAnalogs(UI::EventParams &e) {
-	screenManager()->push(new AnalogSetupScreen());
+	screenManager()->push(new AnalogSetupScreen(gamePath_));
 	return UI::EVENT_DONE;
 }
 
 UI::EventReturn GameSettingsScreen::OnTouchControlLayout(UI::EventParams &e) {
-	screenManager()->push(new TouchControlLayoutScreen());
+	screenManager()->push(new TouchControlLayoutScreen(gamePath_));
 	return UI::EVENT_DONE;
 }
 
@@ -1991,7 +1991,7 @@ UI::EventReturn DeveloperToolsScreen::OnFramedumpTest(UI::EventParams &e) {
 }
 
 UI::EventReturn DeveloperToolsScreen::OnTouchscreenTest(UI::EventParams &e) {
-	screenManager()->push(new TouchTestScreen());
+	screenManager()->push(new TouchTestScreen(gamePath_));
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -155,8 +155,10 @@ private:
 	std::string oldSettingInfo_;
 };
 
-class DeveloperToolsScreen : public UIDialogScreenWithBackground {
+class DeveloperToolsScreen : public UIDialogScreenWithGameBackground {
 public:
+	DeveloperToolsScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {}
+
 	void update() override;
 	void onFinish(DialogResult result) override;
 
@@ -247,8 +249,9 @@ private:
 };
 
 
-class GestureMappingScreen : public UIDialogScreenWithBackground {
+class GestureMappingScreen : public UIDialogScreenWithGameBackground {
 public:
+	GestureMappingScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {}
 	void CreateViews() override;
 
 	const char *tag() const override { return "GestureMapping"; }

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -55,7 +55,6 @@ private:
 	bool lastVertical_;
 	UI::CheckBox *enableReportsCheckbox_;
 	UI::Choice *layoutEditorChoice_;
-	UI::Choice *postProcChoice_;
 	UI::Choice *displayEditor_;
 	UI::Choice *backgroundChoice_ = nullptr;
 	UI::PopupMultiChoice *resolutionChoice_;
@@ -142,7 +141,6 @@ private:
 	bool enableReportsSet_ = false;
 	bool analogSpeedMapped_ = false;
 
-	std::string shaderNames_[256];
 	std::string searchFilter_;
 
 	//edit the game-specific settings and restore the global settings after exiting

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -362,6 +362,7 @@ void DrawGameBackground(UIContext &dc, const Path &gamePath, float x, float y, f
 
 	if (PSP_IsInited() && !g_Config.bSkipBufferEffects) {
 		gpu->CheckDisplayResized();
+		gpu->CheckConfigChanged();
 		gpu->CopyDisplayToOutput(true);
 
 		DrawContext *draw = dc.GetDrawContext();

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -416,7 +416,7 @@ void HandleCommonMessages(const char *message, const char *value, ScreenManager 
 		currentMIPS->UpdateCore((CPUCore)g_Config.iCpuCore);
 	} else if (!strcmp(message, "control mapping") && isActiveScreen && std::string(activeScreen->tag()) != "ControlMapping") {
 		UpdateUIState(UISTATE_MENU);
-		manager->push(new ControlMappingScreen());
+		manager->push(new ControlMappingScreen(Path()));
 	} else if (!strcmp(message, "display layout editor") && isActiveScreen && std::string(activeScreen->tag()) != "DisplayLayout") {
 		UpdateUIState(UISTATE_MENU);
 		manager->push(new DisplayLayoutScreen(Path()));

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -826,7 +826,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 		screenManager->switchScreen(new LogoScreen(AfterLogoScreen::TO_GAME_SETTINGS));
 	} else if (gotoTouchScreenTest) {
 		screenManager->switchScreen(new MainScreen());
-		screenManager->push(new TouchTestScreen());
+		screenManager->push(new TouchTestScreen(Path()));
 	} else if (skipLogo) {
 		screenManager->switchScreen(new EmuScreen(boot_filename));
 	} else {

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -557,8 +557,6 @@ DragDropButton *ControlLayoutView::getPickedControl(const int x, const int y) {
 	return bestMatch;
 }
 
-TouchControlLayoutScreen::TouchControlLayoutScreen() {}
-
 void TouchControlLayoutScreen::resized() {
 	RecreateViews();
 }
@@ -568,7 +566,7 @@ void TouchControlLayoutScreen::onFinish(DialogResult reason) {
 }
 
 UI::EventReturn TouchControlLayoutScreen::OnVisibility(UI::EventParams &e) {
-	screenManager()->push(new TouchControlVisibilityScreen());
+	screenManager()->push(new TouchControlVisibilityScreen(gamePath_));
 	return UI::EVENT_DONE;
 }
 

--- a/UI/TouchControlLayoutScreen.h
+++ b/UI/TouchControlLayoutScreen.h
@@ -23,9 +23,9 @@
 
 class ControlLayoutView;
 
-class TouchControlLayoutScreen : public UIDialogScreenWithBackground {
+class TouchControlLayoutScreen : public UIDialogScreenWithGameBackground {
 public:
-	TouchControlLayoutScreen();
+	TouchControlLayoutScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {}
 
 	virtual void CreateViews() override;
 	virtual void dialogFinished(const Screen *dialog, DialogResult result) override;

--- a/UI/TouchControlVisibilityScreen.cpp
+++ b/UI/TouchControlVisibilityScreen.cpp
@@ -84,48 +84,48 @@ void TouchControlVisibilityScreen::CreateViews() {
 	toggles_.push_back({ "Dpad", &g_Config.touchDpad.show, ImageID::invalid(), nullptr });
 	toggles_.push_back({ "Analog Stick", &g_Config.touchAnalogStick.show, ImageID::invalid(), nullptr });
 	toggles_.push_back({ "Right Analog Stick", &g_Config.touchRightAnalogStick.show, ImageID::invalid(), [=](EventParams &e) {
-		screenManager()->push(new RightAnalogMappingScreen());
+		screenManager()->push(new RightAnalogMappingScreen(gamePath_));
 		return UI::EVENT_DONE;
 	}});
 	toggles_.push_back({ "Fast-forward", &g_Config.touchFastForwardKey.show, ImageID::invalid(), nullptr });
 	toggles_.push_back({ "Custom 1", &g_Config.touchCombo0.show, ImageID::invalid(), [=](EventParams &e) {
-		screenManager()->push(new ComboKeyScreen(0));
+		screenManager()->push(new ComboKeyScreen(gamePath_, 0));
 		return UI::EVENT_DONE;
 	}});
 	toggles_.push_back({ "Custom 2", &g_Config.touchCombo1.show, ImageID::invalid(), [=](EventParams &e) {
-		screenManager()->push(new ComboKeyScreen(1));
+		screenManager()->push(new ComboKeyScreen(gamePath_, 1));
 		return UI::EVENT_DONE;
 	}});
 	toggles_.push_back({ "Custom 3", &g_Config.touchCombo2.show, ImageID::invalid(), [=](EventParams &e) {
-		screenManager()->push(new ComboKeyScreen(2));
+		screenManager()->push(new ComboKeyScreen(gamePath_, 2));
 		return UI::EVENT_DONE;
 	}});
 	toggles_.push_back({ "Custom 4", &g_Config.touchCombo3.show, ImageID::invalid(), [=](EventParams &e) {
-		screenManager()->push(new ComboKeyScreen(3));
+		screenManager()->push(new ComboKeyScreen(gamePath_, 3));
 		return UI::EVENT_DONE;
 	}});
 	toggles_.push_back({ "Custom 5", &g_Config.touchCombo4.show, ImageID::invalid(), [=](EventParams &e) {
-		screenManager()->push(new ComboKeyScreen(4));
+		screenManager()->push(new ComboKeyScreen(gamePath_, 4));
 		return UI::EVENT_DONE;
 	}});
 	toggles_.push_back({ "Custom 6", &g_Config.touchCombo5.show, ImageID::invalid(), [=](EventParams &e) {
-		screenManager()->push(new ComboKeyScreen(5));
+		screenManager()->push(new ComboKeyScreen(gamePath_, 5));
 		return UI::EVENT_DONE;
 	}});
 	toggles_.push_back({ "Custom 7", &g_Config.touchCombo6.show, ImageID::invalid(), [=](EventParams &e) {
-		screenManager()->push(new ComboKeyScreen(6));
+		screenManager()->push(new ComboKeyScreen(gamePath_, 6));
 		return UI::EVENT_DONE;
 	}});
 	toggles_.push_back({ "Custom 8", &g_Config.touchCombo7.show, ImageID::invalid(), [=](EventParams &e) {
-		screenManager()->push(new ComboKeyScreen(7));
+		screenManager()->push(new ComboKeyScreen(gamePath_, 7));
 		return UI::EVENT_DONE;
 	}});
 	toggles_.push_back({ "Custom 9", &g_Config.touchCombo8.show, ImageID::invalid(), [=](EventParams &e) {
-		screenManager()->push(new ComboKeyScreen(8));
+		screenManager()->push(new ComboKeyScreen(gamePath_, 8));
 		return UI::EVENT_DONE;
 	}});
 	toggles_.push_back({ "Custom 10", &g_Config.touchCombo9.show, ImageID::invalid(), [=](EventParams &e) {
-		screenManager()->push(new ComboKeyScreen(9));
+		screenManager()->push(new ComboKeyScreen(gamePath_, 9));
 		return UI::EVENT_DONE;
 	}});
 

--- a/UI/TouchControlVisibilityScreen.h
+++ b/UI/TouchControlVisibilityScreen.h
@@ -31,8 +31,9 @@ struct TouchButtonToggle {
 	std::function<UI::EventReturn(UI::EventParams&)> handle;
 };
 
-class TouchControlVisibilityScreen : public UIDialogScreenWithBackground {
+class TouchControlVisibilityScreen : public UIDialogScreenWithGameBackground {
 public:
+	TouchControlVisibilityScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {}
 	void CreateViews() override;
 	void onFinish(DialogResult result) override;
 
@@ -46,8 +47,9 @@ private:
 	bool nextToggleAll_ = true;
 };
 
-class RightAnalogMappingScreen : public UIDialogScreenWithBackground {
+class RightAnalogMappingScreen : public UIDialogScreenWithGameBackground {
 public:
+	RightAnalogMappingScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {}
 	void CreateViews() override;
 
 	const char *tag() const override { return "RightAnalogMapping"; }

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -1,6 +1,8 @@
 // Headless version of PPSSPP, for testing using http://code.google.com/p/pspautotests/ .
 // See headless.txt.
 // To build on non-windows systems, just run CMake in the SDL directory, it will build both a normal ppsspp and the headless version.
+// Example command line to run a test in the VS debugger (useful to debug failures):
+// > --root pspautotests/tests/../ --compare --timeout=5 --graphics=software pspautotests/tests/cpu/cpu_alu/cpu_alu.prx
 
 #include "ppsspp_config.h"
 #include <cstdio>


### PR DESCRIPTION
The post processing chain can now be directly tweaked on the Display Layout Editor screen, getting instant feedback.

The Display Layout Editor should probably be renamed now... Display setup? Just "Display"?

Also makes the game show through more screens, and minor tweaks.

Not sure whether stereo rendering also belongs here, getting the effect of toggling it will require running a frame...