### PR TITLE
Rebind framebuffer after LoadCLUT-from-framebuffer

### DIFF
--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -50,10 +50,6 @@ struct VKRImage {
 	std::string tag;
 };
 
-// NOTE: If numLayers > 1, it will create an array texture, rather than a normal 2D texture.
-// This requires a different sampling path!
-void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int width, int height, int numLayers, VkFormat format, VkImageLayout initialLayout, bool color, const char *tag);
-
 class VKRFramebuffer {
 public:
 	VKRFramebuffer(VulkanContext *vk, VkCommandBuffer initCmd, VKRRenderPass *compatibleRenderPass, int _width, int _height, int _numLayers, bool createDepthStencilBuffer, const char *tag);
@@ -74,9 +70,15 @@ public:
 
 	void UpdateTag(const char *newTag);
 
+	bool HasDepth() const {
+		return depth.image != VK_NULL_HANDLE;
+	}
+
 	// TODO: Hide.
 	VulkanContext *vulkan_;
 private:
+	static void CreateImage(VulkanContext *vulkan, VkCommandBuffer cmd, VKRImage &img, int width, int height, int numLayers, VkFormat format, VkImageLayout initialLayout, bool color, const char *tag);
+
 	VkFramebuffer framebuf[(size_t)RenderPassType::TYPE_COUNT]{};
 
 	std::string tag_;
@@ -295,6 +297,10 @@ public:
 		pipelinesToCheck_.push_back(pipeline);
 		data.graphics_pipeline.pipeline = pipeline;
 		data.graphics_pipeline.pipelineLayout = pipelineLayout;
+		// This can be used to debug cases where depth/stencil rendering is used on color-only framebuffers.
+		// if ((flags & PipelineFlags::USES_DEPTH_STENCIL) && curRenderStep_->render.framebuffer && !curRenderStep_->render.framebuffer->HasDepth()) {
+		//     DebugBreak();
+		// }
 		curPipelineFlags_ |= flags;
 		curRenderStep_->commands.push_back(data);
 	}

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1308,6 +1308,8 @@ void TextureCacheCommon::LoadClut(u32 clutAddr, u32 loadBytes) {
 					chosenFramebuffer->fbo, 0.0f, 0.0f, 512.0f * chosenFramebuffer->renderScaleFactor, 1.0f, 
 					dynamicClutTemp_, 0.0f, 0.0f, 512.0f, 1.0f, 
 					false, chosenFramebuffer->renderScaleFactor, framebufferManager_->Get2DPipeline(DRAW2D_COPY_COLOR_RECT2LIN), "copy_clut_to_temp");
+
+				framebufferManager_->RebindFramebuffer("after_copy_clut_to_temp");
 				clutRenderFormat_ = chosenFramebuffer->fb_format;
 			}
 			NotifyMemInfo(MemBlockFlags::ALLOC, clutAddr, loadBytes, "CLUT");


### PR DESCRIPTION
Should fix at least some of the problems in #15956 . 

Also adds some sanity checking to the Vulkan backend.