### PR TITLE
Vulkan: Use stencil export when available

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -268,6 +268,7 @@ D3D11DrawContext::D3D11DrawContext(ID3D11Device *device, ID3D11DeviceContext *de
 	caps_.anisoSupported = true;
 	caps_.textureNPOTFullySupported = true;
 	caps_.fragmentShaderDepthWriteSupported = true;
+	caps_.fragmentShaderStencilWriteSupported = false;
 	caps_.blendMinMaxSupported = true;
 
 	D3D11_FEATURE_DATA_D3D11_OPTIONS options{};

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -758,6 +758,7 @@ D3D9Context::D3D9Context(IDirect3D9 *d3d, IDirect3D9Ex *d3dEx, int adapterId, ID
 	caps_.framebufferSeparateDepthCopySupported = false;
 	caps_.texture3DSupported = true;
 	caps_.fragmentShaderDepthWriteSupported = true;
+	caps_.fragmentShaderStencilWriteSupported = false;
 	caps_.blendMinMaxSupported = true;
 
 	if ((caps.RasterCaps & D3DPRASTERCAPS_ANISOTROPY) != 0 && caps.MaxAnisotropy > 1) {

--- a/Common/GPU/DataFormat.h
+++ b/Common/GPU/DataFormat.h
@@ -65,6 +65,7 @@ enum class DataFormat : uint8_t {
 
 	S8,
 	D16,
+	D16_S8,
 	D24_S8,
 	D32F,
 	D32F_S8,

--- a/Common/GPU/OpenGL/GLFeatures.cpp
+++ b/Common/GPU/OpenGL/GLFeatures.cpp
@@ -371,6 +371,7 @@ void CheckGLExtensions() {
 	gl_extensions.ARB_uniform_buffer_object = g_set_gl_extensions.count("GL_ARB_uniform_buffer_object") != 0;
 	gl_extensions.ARB_explicit_attrib_location = g_set_gl_extensions.count("GL_ARB_explicit_attrib_location") != 0;
 	gl_extensions.ARB_texture_non_power_of_two = g_set_gl_extensions.count("GL_ARB_texture_non_power_of_two") != 0;
+	gl_extensions.ARB_shader_stencil_export = g_set_gl_extensions.count("GL_ARB_shader_stencil_export") != 0;
 	if (gl_extensions.IsGLES) {
 		gl_extensions.EXT_blend_func_extended = g_set_gl_extensions.count("GL_EXT_blend_func_extended") != 0;
 		gl_extensions.OES_texture_npot = g_set_gl_extensions.count("GL_OES_texture_npot") != 0;

--- a/Common/GPU/OpenGL/GLFeatures.h
+++ b/Common/GPU/OpenGL/GLFeatures.h
@@ -72,6 +72,7 @@ struct GLExtensions {
 	bool ARB_uniform_buffer_object;
 	bool ARB_texture_non_power_of_two;
 	bool ARB_stencil_texturing;
+	bool ARB_shader_stencil_export;
 
 	// EXT
 	bool EXT_swap_control_tear;

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -575,6 +575,7 @@ OpenGLContext::OpenGLContext() {
 	} else {
 		caps_.fragmentShaderDepthWriteSupported = true;
 	}
+	caps_.fragmentShaderStencilWriteSupported = gl_extensions.ARB_shader_stencil_export;
 
 	// GLES has no support for logic framebuffer operations. There doesn't even seem to exist any such extensions.
 	caps_.logicOpSupported = !gl_extensions.IsGLES;

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -809,6 +809,7 @@ VKContext::VKContext(VulkanContext *vulkan)
 	caps_.fragmentShaderInt32Supported = true;
 	caps_.textureNPOTFullySupported = true;
 	caps_.fragmentShaderDepthWriteSupported = true;
+	caps_.fragmentShaderStencilWriteSupported = vulkan->Extensions().EXT_shader_stencil_export;
 	caps_.blendMinMaxSupported = true;
 	caps_.logicOpSupported = vulkan->GetDeviceFeatures().enabled.standard.logicOp != 0;
 	caps_.multiViewSupported = vulkan->GetDeviceFeatures().enabled.multiview.multiview != 0;

--- a/Common/GPU/thin3d.cpp
+++ b/Common/GPU/thin3d.cpp
@@ -46,6 +46,7 @@ size_t DataFormatSizeInBytes(DataFormat fmt) {
 
 	case DataFormat::S8: return 1;
 	case DataFormat::D16: return 2;
+	case DataFormat::D16_S8: return 3;
 	case DataFormat::D24_S8: return 4;
 	case DataFormat::D32F: return 4;
 	// Or maybe 8...
@@ -68,6 +69,7 @@ const char *DataFormatToString(DataFormat fmt) {
 
 	case DataFormat::S8: return "S8";
 	case DataFormat::D16: return "D16";
+	case DataFormat::D16_S8: return "D16_S8";
 	case DataFormat::D24_S8: return "D24_S8";
 	case DataFormat::D32F: return "D32F";
 	case DataFormat::D32F_S8: return "D32F_S8";
@@ -80,6 +82,7 @@ const char *DataFormatToString(DataFormat fmt) {
 bool DataFormatIsDepthStencil(DataFormat fmt) {
 	switch (fmt) {
 	case DataFormat::D16:
+	case DataFormat::D16_S8:
 	case DataFormat::D24_S8:
 	case DataFormat::S8:
 	case DataFormat::D32F:

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -570,6 +570,7 @@ struct DeviceCaps {
 	bool fragmentShaderInt32Supported;
 	bool textureNPOTFullySupported;
 	bool fragmentShaderDepthWriteSupported;
+	bool fragmentShaderStencilWriteSupported;
 	bool textureDepthSupported;
 	bool blendMinMaxSupported;
 	bool multiViewSupported;

--- a/GPU/Common/StencilCommon.cpp
+++ b/GPU/Common/StencilCommon.cpp
@@ -135,10 +135,11 @@ bool FramebufferManagerCommon::PerformWriteStencilFromMemory(u32 addr, int size,
 		return false;
 	}
 
-	VirtualFramebuffer *dstBuffer = 0;
+	VirtualFramebuffer *dstBuffer = nullptr;
 	for (size_t i = 0; i < vfbs_.size(); ++i) {
 		VirtualFramebuffer *vfb = vfbs_[i];
-		if (vfb->fb_address == addr) {
+		// TODO: Maybe we should broadcast to all?  Most of the time, there's only one.
+		if (vfb->fb_address == addr && (!dstBuffer || dstBuffer->colorBindSeq < vfb->colorBindSeq)) {
 			dstBuffer = vfb;
 		}
 	}

--- a/GPU/Common/StencilCommon.cpp
+++ b/GPU/Common/StencilCommon.cpp
@@ -58,6 +58,34 @@ static u8 StencilBits8888(const u8 *ptr8, u32 numPixels) {
 	return bits >> 24;
 }
 
+static bool CheckStencilBits(const u8 *src, const VirtualFramebuffer *dstBuffer, int &values, u8 &usedBits) {
+	switch (dstBuffer->fb_format) {
+	case GE_FORMAT_565:
+		// Well, this doesn't make much sense.
+		return false;
+	case GE_FORMAT_5551:
+		usedBits = StencilBits5551(src, dstBuffer->fb_stride * dstBuffer->bufferHeight);
+		values = 2;
+		break;
+	case GE_FORMAT_4444:
+		usedBits = StencilBits4444(src, dstBuffer->fb_stride * dstBuffer->bufferHeight);
+		values = 16;
+		break;
+	case GE_FORMAT_8888:
+		usedBits = StencilBits8888(src, dstBuffer->fb_stride * dstBuffer->bufferHeight);
+		values = 256;
+		break;
+	case GE_FORMAT_INVALID:
+	case GE_FORMAT_DEPTH16:
+	case GE_FORMAT_CLUT8:
+		// Inconceivable.
+		_assert_(false);
+		return false;
+	}
+
+	return true;
+}
+
 struct StencilUB {
 	float stencilValue;
 };
@@ -83,8 +111,12 @@ static const SamplerDef samplers[1] = {
 	{ 0, "tex" },
 };
 
-void GenerateStencilFs(char *buffer, const ShaderLanguageDesc &lang, const Draw::Bugs &bugs) {
-	ShaderWriter writer(buffer, lang, ShaderStage::Fragment);
+void GenerateStencilFs(char *buffer, const ShaderLanguageDesc &lang, const Draw::Bugs &bugs, bool useExport) {
+	std::vector<const char *> extensions;
+	if (useExport)
+		extensions.push_back("#extension GL_ARB_shader_stencil_export : require");
+
+	ShaderWriter writer(buffer, lang, ShaderStage::Fragment, extensions);
 	writer.HighPrecisionFloat();
 	writer.DeclareSamplers(samplers);
 
@@ -98,9 +130,13 @@ void GenerateStencilFs(char *buffer, const ShaderLanguageDesc &lang, const Draw:
 
 	writer.C("  vec4 index = ").SampleTexture2D("tex", "v_texcoord.xy").C(";\n");
 	writer.C("  vec4 outColor = index.aaaa;\n");  // Only care about a.
-	writer.C("  float shifted = roundAndScaleTo255f(index.a) / roundAndScaleTo255f(stencilValue);\n");
-	// Bitwise operations on floats, ugh.
-	writer.C("  if (mod(floor(shifted), 2.0) < 0.99) DISCARD;\n");
+	if (useExport) {
+		writer.C("  gl_FragStencilRefARB = int(roundAndScaleTo255f(index.a));\n");
+	} else {
+		writer.C("  float shifted = roundAndScaleTo255f(index.a) / roundAndScaleTo255f(stencilValue);\n");
+		// Bitwise operations on floats, ugh.
+		writer.C("  if (mod(floor(shifted), 2.0) < 0.99) DISCARD;\n");
+	}
 
 	if (bugs.Has(Draw::Bugs::NO_DEPTH_CANNOT_DISCARD_STENCIL)) {
 		writer.C("  gl_FragDepth = gl_FragCoord.z;\n");
@@ -149,34 +185,15 @@ bool FramebufferManagerCommon::PerformWriteStencilFromMemory(u32 addr, int size,
 
 	int values = 0;
 	u8 usedBits = 0;
+	bool useExportShader = draw_->GetDeviceCaps().fragmentShaderStencilWriteSupported;
 
 	const u8 *src = Memory::GetPointer(addr);
 	if (!src)
 		return false;
 
-	switch (dstBuffer->fb_format) {
-	case GE_FORMAT_565:
-		// Well, this doesn't make much sense.
+	// Could skip this when doing useExportShader, but then we couldn't optimize usedBits == 0.
+	if (!CheckStencilBits(src, dstBuffer, values, usedBits))
 		return false;
-	case GE_FORMAT_5551:
-		usedBits = StencilBits5551(src, dstBuffer->fb_stride * dstBuffer->bufferHeight);
-		values = 2;
-		break;
-	case GE_FORMAT_4444:
-		usedBits = StencilBits4444(src, dstBuffer->fb_stride * dstBuffer->bufferHeight);
-		values = 16;
-		break;
-	case GE_FORMAT_8888:
-		usedBits = StencilBits8888(src, dstBuffer->fb_stride * dstBuffer->bufferHeight);
-		values = 256;
-		break;
-	case GE_FORMAT_INVALID:
-	case GE_FORMAT_DEPTH16:
-	case GE_FORMAT_CLUT8:
-		// Inconceivable.
-		_assert_(false);
-		break;
-	}
 
 	if (usedBits == 0) {
 		if (flags & WriteStencil::STENCIL_IS_ZERO) {
@@ -202,7 +219,7 @@ bool FramebufferManagerCommon::PerformWriteStencilFromMemory(u32 addr, int size,
 
 		char *fsCode = new char[8192];
 		char *vsCode = new char[8192];
-		GenerateStencilFs(fsCode, shaderLanguageDesc, draw_->GetBugs());
+		GenerateStencilFs(fsCode, shaderLanguageDesc, draw_->GetBugs(), useExportShader);
 		GenerateStencilVs(vsCode, shaderLanguageDesc);
 
 		_assert_msg_(strlen(fsCode) < 8192, "StenFS length error: %d", (int)strlen(fsCode));
@@ -304,24 +321,32 @@ bool FramebufferManagerCommon::PerformWriteStencilFromMemory(u32 addr, int size,
 	draw_->SetScissorRect(0, 0, w, h);
 	draw_->BindPipeline(stencilWritePipeline_);
 
-	for (int i = 1; i < values; i += i) {
-		if (!(usedBits & i)) {
-			// It's already zero, let's skip it.
-			continue;
-		}
+	if (useExportShader) {
+		// We only need to do one pass if using an export shader.
 		StencilUB ub{};
-		if (dstBuffer->fb_format == GE_FORMAT_4444) {
-			draw_->SetStencilParams(0xFF, (i << 4) | i, 0xFF);
-			ub.stencilValue = i * (16.0f / 255.0f);
-		} else if (dstBuffer->fb_format == GE_FORMAT_5551) {
-			draw_->SetStencilParams(0xFF, 0xFF, 0xFF);
-			ub.stencilValue = i * (128.0f / 255.0f);
-		} else {
-			draw_->SetStencilParams(0xFF, i, 0xFF);
-			ub.stencilValue = i * (1.0f / 255.0f);
-		}
+		draw_->SetStencilParams(0xFF, 0xFF, 0xFF);
 		draw_->UpdateDynamicUniformBuffer(&ub, sizeof(ub));
 		draw_->DrawUP(positions, 3);
+	} else {
+		for (int i = 1; i < values; i += i) {
+			if (!(usedBits & i)) {
+				// It's already zero, let's skip it.
+				continue;
+			}
+			StencilUB ub{};
+			if (dstBuffer->fb_format == GE_FORMAT_4444) {
+				draw_->SetStencilParams(0xFF, (i << 4) | i, 0xFF);
+				ub.stencilValue = i * (16.0f / 255.0f);
+			} else if (dstBuffer->fb_format == GE_FORMAT_5551) {
+				draw_->SetStencilParams(0xFF, 0xFF, 0xFF);
+				ub.stencilValue = i * (128.0f / 255.0f);
+			} else {
+				draw_->SetStencilParams(0xFF, i, 0xFF);
+				ub.stencilValue = i * (1.0f / 255.0f);
+			}
+			draw_->UpdateDynamicUniformBuffer(&ub, sizeof(ub));
+			draw_->DrawUP(positions, 3);
+		}
 	}
 
 	if (useBlit) {

--- a/GPU/Common/StencilCommon.h
+++ b/GPU/Common/StencilCommon.h
@@ -5,5 +5,5 @@
 #include "Common/GPU/thin3d.h"
 
 // Exposed for automated tests
-void GenerateStencilFs(char *buffer, const ShaderLanguageDesc &lang, const Draw::Bugs &bugs);
+void GenerateStencilFs(char *buffer, const ShaderLanguageDesc &lang, const Draw::Bugs &bugs, bool useExport);
 void GenerateStencilVs(char *buffer, const ShaderLanguageDesc &lang);


### PR DESCRIPTION
Also on desktop OpenGL.  In both cases, an extension exists to allow directly writing to stencil.

This has been showing up as supported on some newer Adreno devices (7xx, etc.) and should be more efficient than the previous 8 pass method.  Not supported on NVIDIA, but I tested on an Intel GPU.

A small optimization, but it was easy.

-[Unknown]