### PR TITLE
More post-shader UI improvements

### DIFF
--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -849,20 +849,30 @@ void AbstractChoiceWithValueDisplay::Draw(UIContext &dc) {
 	dc.SetFontStyle(dc.theme->uiFont);
 
 	const std::string valueText = ValueText();
-	// Assume we want at least 20% of the size for the label, at a minimum.
-	float availWidth = (bounds_.w - paddingX * 2) * 0.8f;
-	float scale = CalculateValueScale(dc, valueText, availWidth);
 
-	float w, h;
-	Bounds availBounds(0, 0, availWidth, bounds_.h);
-	dc.MeasureTextRect(dc.theme->uiFont, scale, scale, valueText.c_str(), (int)valueText.size(), availBounds, &w, &h, ALIGN_RIGHT | ALIGN_VCENTER | FLAG_WRAP_TEXT);
-	textPadding_.right = w + paddingX;
+	// If there is a label, assume we want at least 20% of the size for it, at a minimum.
 
-	Choice::Draw(dc);
-	dc.SetFontScale(scale, scale);
-	Bounds valueBounds(bounds_.x2() - textPadding_.right, bounds_.y, w, bounds_.h);
-	dc.DrawTextRect(valueText.c_str(), valueBounds, style.fgColor, ALIGN_RIGHT | ALIGN_VCENTER | FLAG_WRAP_TEXT);
-	dc.SetFontScale(1.0f, 1.0f);
+	if (!text_.empty()) {
+		float availWidth = (bounds_.w - paddingX * 2) * 0.8f;
+		float scale = CalculateValueScale(dc, valueText, availWidth);
+
+		float w, h;
+		Bounds availBounds(0, 0, availWidth, bounds_.h);
+		dc.MeasureTextRect(dc.theme->uiFont, scale, scale, valueText.c_str(), (int)valueText.size(), availBounds, &w, &h, ALIGN_RIGHT | ALIGN_VCENTER | FLAG_WRAP_TEXT);
+		textPadding_.right = w + paddingX;
+
+		Choice::Draw(dc);
+		dc.SetFontScale(scale, scale);
+		Bounds valueBounds(bounds_.x2() - textPadding_.right, bounds_.y, w, bounds_.h);
+		dc.DrawTextRect(valueText.c_str(), valueBounds, style.fgColor, ALIGN_RIGHT | ALIGN_VCENTER | FLAG_WRAP_TEXT);
+		dc.SetFontScale(1.0f, 1.0f);
+	} else {
+		Choice::Draw(dc);
+		float scale = CalculateValueScale(dc, valueText, bounds_.w);
+		dc.SetFontScale(scale, scale);
+		dc.DrawTextRect(valueText.c_str(), bounds_.Expand(-paddingX, 0.0f), style.fgColor, ALIGN_LEFT | ALIGN_VCENTER | FLAG_WRAP_TEXT);
+		dc.SetFontScale(1.0f, 1.0f);
+	}
 }
 
 float AbstractChoiceWithValueDisplay::CalculateValueScale(const UIContext &dc, const std::string &valueText, float availWidth) const {

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -483,7 +483,7 @@ void Choice::Draw(UIContext &dc) {
 
 	if (image_.isValid() && text_.empty()) {
 		dc.Draw()->DrawImageRotated(image_, bounds_.centerX(), bounds_.centerY(), imgScale_, imgRot_, style.fgColor, imgFlipH_);
-	} else {
+	} else if (!text_.empty()) {
 		dc.SetFontStyle(dc.theme->uiFont);
 
 		int paddingX = 12;

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -321,6 +321,8 @@ void DisplayLayoutScreen::CreateViews() {
 						settingValue->SetEnabled(false);
 					} else {
 						PopupSliderChoiceFloat *settingValue = rightColumn->Add(new PopupSliderChoiceFloat(&value, setting.minValue, setting.maxValue, ps->T(setting.name), setting.step, screenManager()));
+						settingValue->SetLiveUpdate(true);
+						settingValue->SetHasDropShadow(false);
 						settingValue->SetEnabledFunc([=] {
 							return !g_Config.bSkipBufferEffects && !enableStereo();
 						});

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -287,7 +287,8 @@ void DisplayLayoutScreen::CreateViews() {
 	for (int i = 0; i < (int)g_Config.vPostShaderNames.size() + 1 && i < ARRAY_SIZE(shaderNames_); ++i) {
 		// Vector element pointer get invalidated on resize, cache name to have always a valid reference in the rendering thread
 		shaderNames_[i] = i == g_Config.vPostShaderNames.size() ? "Off" : g_Config.vPostShaderNames[i];
-		postProcChoice_ = rightColumn->Add(new ChoiceWithValueDisplay(&shaderNames_[i], StringFromFormat("%s #%d", gr->T("Postprocessing Shader"), i + 1), &PostShaderTranslateName));
+		rightColumn->Add(new ItemHeader(StringFromFormat("%s #%d", gr->T("Postprocessing Shader"), i + 1)));
+		postProcChoice_ = rightColumn->Add(new ChoiceWithValueDisplay(&shaderNames_[i], "", &PostShaderTranslateName));
 		postProcChoice_->OnClick.Add([=](EventParams &e) {
 			auto gr = GetI18NCategory("Graphics");
 			auto procScreen = new PostProcScreen(gr->T("Postprocessing Shader"), i, false);


### PR DESCRIPTION
On the Display Layout & Effects screen, post effect choice buttons now don't look as cramped (moved the title out from the buttons).

Additionally, shader parameters (like bloom strength) now update live when you drag the value.