### PR TITLE
Add basic CI support for build-testing the Android-based VR build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,18 @@ jobs:
           extra: android
           cc: clang
           cxx: clang++
+          args: cd android && ./ab.sh -j2 APP_ABI=arm64-v8a OPENXR=1 OPENXR_PLATFORM_QUEST=1
+          id: android-vr-quest
+        - os: ubuntu-latest
+          extra: android
+          cc: clang
+          cxx: clang++
+          args: cd android && ./ab.sh -j2 APP_ABI=arm64-v8a OPENXR=1 OPENXR_PLATFORM_PICO=1
+          id: android-vr-pico
+        - os: ubuntu-latest
+          extra: android
+          cc: clang
+          cxx: clang++
           args: ./b.sh --libretro_android ppsspp_libretro
           id: android-libretro
 

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -739,6 +739,18 @@ ifeq ($(HEADLESS),1)
   include $(BUILD_EXECUTABLE)
 endif
 
+ifeq ($(OPENXR),1)
+  LOCAL_CFLAGS += -DOPENXR
+endif
+
+ifeq ($(OPENXR_PLATFORM_QUEST),1)
+  LOCAL_CFLAGS += -DOPENXR_PLATFORM_QUEST
+endif
+
+ifeq ($(OPENXR_PLATFORM_PICO),1)
+  LOCAL_CFLAGS += -DOPENXR_PLATFORM_PICO
+endif
+
 ifeq ($(UNITTEST),1)
   include $(CLEAR_VARS)
   include $(LOCAL_PATH)/Locals.mk


### PR DESCRIPTION
Note: Doesn't do APK generation, to keep things simple, instead using the old NDK build.

Later should run gradle on github CI too, I guess.

Fixes #15981