### PR TITLE
softgpu: Allow inversions when w >= -1.0

### DIFF
--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -50,13 +50,16 @@ inline float clip_dotprod(const ClipVertexData &vert, float A, float B, float C,
 }
 
 inline void clip_interpolate(ClipVertexData &dest, float t, const ClipVertexData &a, const ClipVertexData &b) {
-	dest.Lerp(t, a, b);
 	if (different_signs(a.clippos.w, b.clippos.w)) {
-		dest.v.screenpos.x = 0x7FFFFFFF;
-	} else {
-		dest.v.screenpos = TransformUnit::ClipToScreen(dest.clippos);
-		dest.v.clipw = dest.clippos.w;
+		if (a.clippos.w < -1.0f || b.clippos.w < -1.0f) {
+			dest.v.screenpos.x = 0x7FFFFFFF;
+			return;
+		}
 	}
+
+	dest.Lerp(t, a, b);
+	dest.v.screenpos = TransformUnit::ClipToScreen(dest.clippos);
+	dest.v.clipw = dest.clippos.w;
 }
 
 #define CLIP_POLY( PLANE_BIT, A, B, C, D )							\


### PR DESCRIPTION
This fixes several cases broken by #16402 as identified by @benderscruffy in #16131.  That testing has been very helpful.

This is still likely not accurate, but it has some sense to it (kinda) and keeps the bad inversions away without banishing the good inversions.  See https://github.com/hrydgard/ppsspp/issues/16207#issuecomment-1279812129 for notes on the actual behavior.

-[Unknown]