### PR TITLE
Exposed more emulator things to devctl api

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -70,6 +70,8 @@ extern "C" {
 
 // For headless screenshots.
 #include "Core/HLE/sceDisplay.h"
+// For EMULATOR_DEVCTL__GET_SCALE
+#include <System/Display.h>
 
 static const int ERROR_ERRNO_IO_ERROR                     = 0x80010005;
 static const int ERROR_MEMSTICK_DEVCTL_BAD_PARAMS         = 0x80220081;
@@ -1980,12 +1982,29 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 	if (!strcmp(name, "kemulator:") || !strcmp(name, "emulator:"))
 	{
 		// Emulator special tricks!
+		
+		enum
+		{
+			EMULATOR_DEVCTL__GET_HAS_DISPLAY = 1,
+			EMULATOR_DEVCTL__SEND_OUTPUT,
+			EMULATOR_DEVCTL__IS_EMULATOR,
+			EMULATOR_DEVCTL__VERIFY_STATE,
+
+			EMULATOR_DEVCTL__EMIT_SCREENSHOT = 0x20,
+			
+			EMULATOR_DEVCTL__TOGGLE_FASTFORWARD = 0x30,
+			EMULATOR_DEVCTL__GET_ASPECT_RATIO,
+			EMULATOR_DEVCTL__GET_SCALE,
+			EMULATOR_DEVCTL__GET_LTRIGGER,
+			EMULATOR_DEVCTL__GET_RTRIGGER
+		};
+
 		switch (cmd) {
-		case 1:	// EMULATOR_DEVCTL__GET_HAS_DISPLAY
+		case EMULATOR_DEVCTL__GET_HAS_DISPLAY:
 			if (Memory::IsValidAddress(outPtr))
 				Memory::Write_U32(PSP_CoreParameter().headLess ? 0 : 1, outPtr);
 			return 0;
-		case 2:	// EMULATOR_DEVCTL__SEND_OUTPUT
+		case EMULATOR_DEVCTL__SEND_OUTPUT:
 			{
 				std::string data(Memory::GetCharPointer(argAddr), argLen);
 				if (PSP_CoreParameter().printfEmuLog) {
@@ -1999,17 +2018,17 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 				}
 				return 0;
 			}
-		case 3:	// EMULATOR_DEVCTL__IS_EMULATOR
+		case EMULATOR_DEVCTL__IS_EMULATOR:
 			if (Memory::IsValidAddress(outPtr))
 				Memory::Write_U32(1, outPtr);
 			return 0;
-		case 4: // EMULATOR_DEVCTL__VERIFY_STATE
+		case EMULATOR_DEVCTL__VERIFY_STATE:
 			// Note that this is async, and makes sure the save state matches up.
 			SaveState::Verify();
 			// TODO: Maybe save/load to a file just to be sure?
 			return 0;
 
-		case 0x20: // EMULATOR_DEVCTL__EMIT_SCREENSHOT
+		case EMULATOR_DEVCTL__EMIT_SCREENSHOT:
 		{
 			PSPPointer<u8> topaddr;
 			u32 linesize;
@@ -2019,6 +2038,29 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 			host->SendDebugScreenshot(topaddr, linesize, 272);
 			return 0;
 		}
+		case EMULATOR_DEVCTL__TOGGLE_FASTFORWARD:
+			if (argAddr)
+				PSP_CoreParameter().fastForward = true;
+			else
+				PSP_CoreParameter().fastForward = false;
+			return 0;
+		case EMULATOR_DEVCTL__GET_ASPECT_RATIO:
+			if (Memory::IsValidAddress(outPtr))
+			{
+				float ar = static_cast<float>(PSP_CoreParameter().pixelWidth) / static_cast<float>(PSP_CoreParameter().pixelHeight);
+				Memory::Write_U32(*(reinterpret_cast<u32*>(&ar)), outPtr);
+			}
+			return 0;
+		case EMULATOR_DEVCTL__GET_SCALE:
+			if (Memory::IsValidAddress(outPtr))
+				Memory::Write_U32(static_cast<float>(dp_xres) / 480.0f, outPtr);
+			return 0;
+		case EMULATOR_DEVCTL__GET_LTRIGGER:
+			//To-do
+			return 0;
+		case EMULATOR_DEVCTL__GET_RTRIGGER:
+			//To-do
+			return 0;
 		}
 
 		ERROR_LOG(SCEIO, "sceIoDevCtl: UNKNOWN PARAMETERS");


### PR DESCRIPTION
Related to https://github.com/hrydgard/ppsspp/issues/15626

Decided to kickstart some things, to have more flexibility in plugins.

E.g., GTA VCS, now possible to fastforward automatically during loadscreens and mission/cutscene/interior loading.
Also possible to automatically detect actual screen aspect ratio and use that in game, without manually editing ini settings.

https://user-images.githubusercontent.com/4904157/204109727-15686fe2-d7ce-4ad5-be8b-1541b89f810f.mp4

Download test version of compatible with new options plugin here:

[GTAVCS.PPSSPP.WidescreenFix.zip](https://github.com/hrydgard/ppsspp/files/10097073/GTAVCS.PPSSPP.WidescreenFix.zip)

Some code examples:

```c
// not implemented yet
short CPad::GetAccelerate(short* pad) {
    if (pad[77] == 0)
    {
        unsigned char rt = 0;
        sceIoDevctl("kemulator:", EMULATOR_DEVCTL__GET_RTRIGGER, NULL, 0, &rt, sizeof(rt));
        if (rt > 30) //deadzone
            return rt;
    }
    return 0;
}
```

```c
void UnthrottleEmuEnable()
{
    sceIoDevctl("kemulator:", EMULATOR_DEVCTL__TOGGLE_FASTFORWARD, (void*)1, 0, NULL, 0);
}

void UnthrottleEmuDisable()
{
    sceIoDevctl("kemulator:", EMULATOR_DEVCTL__TOGGLE_FASTFORWARD, (void*)0, 0, NULL, 0);
}

...
int UnthrottleEmuDuringLoading = 0;
void GameLoopStuff()
{
    if (UnthrottleEmuDuringLoading)
    {
        uint32_t gMenuActivated = sub_2A9B4(sub_471400()); //inlined on psp
        float gBlackScreenTime = *(float*)(injector.GetGP() + ptr_1334C4);
        if (gBlackScreenTime && !gMenuActivated)
            UnthrottleEmuEnable();
        else
            UnthrottleEmuDisable();
    }
}
```

```c
        float ar = 0.0f;
        sceIoDevctl("kemulator:", EMULATOR_DEVCTL__GET_ASPECT_RATIO, NULL, 0, &ar, sizeof(ar));
        if (ar)
            fAspectRatio = ar;
```