### PR TITLE
Vulkan: Only use geometry shaders with accurate depth

### DIFF
--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -232,7 +232,8 @@ u32 GPU_Vulkan::CheckGPUFeatures() const {
 	features |= GPU_USE_TEXTURE_FLOAT;
 
 	// Fall back to geometry shader culling if we can't do vertex range culling.
-	if (draw_->GetDeviceCaps().geometryShaderSupported) {
+	// Checking accurate depth here because the old depth path is uncommon and not well tested for this.
+	if (draw_->GetDeviceCaps().geometryShaderSupported && (features & GPU_USE_ACCURATE_DEPTH) != 0) {
 		const bool useGeometry = g_Config.bUseGeometryShader && !draw_->GetBugs().Has(Draw::Bugs::GEOMETRY_SHADERS_SLOW_OR_BROKEN);
 		const bool vertexSupported = draw_->GetDeviceCaps().clipDistanceSupported && draw_->GetDeviceCaps().cullDistanceSupported;
 		if (useGeometry && (!vertexSupported || (features & GPU_USE_VS_RANGE_CULLING) == 0)) {


### PR DESCRIPTION
Just to be safe, since that's what it's most well tested with.  See #15661 - some of these devices intentionally disable accurate depth for a subset of games, which is probably an old workaround to problems possibly solved with depth clamp or geometry shaders.

Anyway, let's not use geometry shaders without accurate depth, because I'm not sure they work and don't want to worry about that path.

-[Unknown]