### PR TITLE
Empirical attempt at fixing #15661

### DIFF
--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -600,9 +600,9 @@ void SoftwareTransform::BuildDrawingParams(int prim, int vertexCount, u32 vertTy
 			// First, check inside/outside directions for each index.
 			for (int i = 0; i < vertexCount; ++i) {
 				float z = transformed[indsIn[i]].z / transformed[indsIn[i]].pos_w;
-				if (z >= maxZValue)
+				if (z > maxZValue)
 					outsideZ[i] = 1;
-				else if (z <= minZValue)
+				else if (z < minZValue)
 					outsideZ[i] = -1;
 				else
 					outsideZ[i] = 0;


### PR DESCRIPTION
Basically, software culling fails in some configurations, like the one we end up with on Mali (but only with Hardware Transform set to off).

As noted by unknownbrackets in #15661, the viewport Z scale, offset is -0.0, 0.0.

We end up with CalcCullParams computing minZValue == maxZValue == 1.0f, and with the vertices ending up with z,w == 1.0, 1.0. and as a result, the inside/outside calculations will always decide that it's outside.

Changing the comparisons from >= / <= to > / < fixes the problem, but I don't know if this might break something else.

Anyhow, here's the simple way to repro on PC: Change the ending of GPU_Vulkan::CheckFeatures to:

```c
	return GPU_USE_LIGHT_UBERSHADER | GPU_USE_BLEND_MINMAX | GPU_USE_TEXTURE_NPOT | GPU_USE_INSTANCE_RENDERING |
		GPU_USE_VERTEX_TEXTURE_FETCH | GPU_USE_TEXTURE_FLOAT | GPU_USE_16BIT_FORMATS | GPU_USE_TEXTURE_LOD_CONTROL |
		GPU_USE_DEPTH_TEXTURE | GPU_USE_ACCURATE_DEPTH;
```