### PR TITLE
Blind workaround for Shining Ark circle button problem

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -121,6 +121,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "SecondaryTextureCache", &flags_.SecondaryTextureCache);
 	CheckSetting(iniFile, gameID, "EnglishOrJapaneseOnly", &flags_.EnglishOrJapaneseOnly);
 	CheckSetting(iniFile, gameID, "OldAdrenoPixelDepthRoundingGL", &flags_.OldAdrenoPixelDepthRoundingGL);
+	CheckSetting(iniFile, gameID, "ForceCircleButtonConfirm", &flags_.ForceCircleButtonConfirm);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -92,6 +92,7 @@ struct CompatFlags {
 	bool SecondaryTextureCache;
 	bool EnglishOrJapaneseOnly;
 	bool OldAdrenoPixelDepthRoundingGL;
+	bool ForceCircleButtonConfirm;
 };
 
 struct VRCompat {

--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -317,7 +317,7 @@ int PSPDialog::GetConfirmButton() {
 
 int PSPDialog::GetCancelButton() {
 	if (PSP_CoreParameter().compat.flags().ForceCircleButtonConfirm) {
-		return CTRL_CIRCLE;
+		return CTRL_CROSS;
 	}
 	return g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CROSS : CTRL_CIRCLE;
 }

--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -20,6 +20,8 @@
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"
 #include "Common/StringUtils.h"
+#include "Core/Config.h"
+#include "Core/System.h"
 #include "Core/CoreTiming.h"
 #include "Core/Dialog/PSPDialog.h"
 #include "Core/HLE/sceCtrl.h"
@@ -304,4 +306,18 @@ void PSPDialog::DisplayButtons(int flags, const char *caption)
 		PPGeDrawImage(cancelButtonImg, x1, 256, 11.5f, 11.5f, textStyle);
 		PPGeDrawText(text, x1 + 14.5f, 252, textStyle);
 	}
+}
+
+int PSPDialog::GetConfirmButton() {
+	if (PSP_CoreParameter().compat.flags().ForceCircleButtonConfirm) {
+		return CTRL_CIRCLE;
+	}
+	return g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CIRCLE : CTRL_CROSS;
+}
+
+int PSPDialog::GetCancelButton() {
+	if (PSP_CoreParameter().compat.flags().ForceCircleButtonConfirm) {
+		return CTRL_CIRCLE;
+	}
+	return g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CROSS : CTRL_CIRCLE;
 }

--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -106,6 +106,9 @@ protected:
 	// TODO: Remove this once all dialogs are updated.
 	virtual bool UseAutoStatus() = 0;
 
+	static int GetConfirmButton();
+	static int GetCancelButton();
+
 	void StartFade(bool fadeIn_);
 	void UpdateFade(int animSpeed);
 	virtual void FinishFadeOut();

--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -261,9 +261,9 @@ int PSPNetconfDialog::Update(int animSpeed) {
 		if (!hideNotice) {
 			const float WRAP_WIDTH = 254.0f;
 			const ImageID confirmBtnImage = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? ImageID("I_CROSS") : ImageID("I_CIRCLE");
-			const int confirmBtn = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CROSS : CTRL_CIRCLE;
+			const int confirmBtn = GetConfirmButton();
 			const ImageID cancelBtnImage = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? ImageID("I_CIRCLE") : ImageID("I_CROSS");
-			const int cancelBtn = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CIRCLE : CTRL_CROSS;
+			const int cancelBtn = GetCancelButton();
 
 			PPGeStyle textStyle = FadedStyle(PPGeAlign::BOX_CENTER, 0.5f);
 			PPGeStyle buttonStyle = FadedStyle(PPGeAlign::BOX_LEFT, 0.5f);

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -941,8 +941,9 @@ int PSPOskDialog::Update(int animSpeed) {
 		return SCE_ERROR_UTILITY_INVALID_STATUS;
 	}
 
-	int cancelButton = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CIRCLE : CTRL_CROSS;
-	int confirmButton = cancelButton == CTRL_CROSS ? CTRL_CIRCLE : CTRL_CROSS;
+	int cancelButton = GetCancelButton();
+	int confirmButton = GetConfirmButton();
+
 	static int cancelBtnFramesHeld = 0;
 	static int confirmBtnFramesHeld = 0;
 	static int leftBtnFramesHeld = 0;
@@ -979,7 +980,7 @@ int PSPOskDialog::Update(int animSpeed) {
 	PPGeDrawImage(ImageID("I_SQUARE"), 365, 222, 16, 16, guideStyle);
 	PPGeDrawText(di->T("Space"), 390, 222, actionStyle);
 
-	if (g_Config.iButtonPreference != PSP_SYSTEMPARAM_BUTTON_CIRCLE) {
+	if (GetConfirmButton() != PSP_SYSTEMPARAM_BUTTON_CIRCLE) {
 		PPGeDrawImage(ImageID("I_CROSS"), 45, 222, 16, 16, guideStyle);
 		PPGeDrawImage(ImageID("I_CIRCLE"), 45, 247, 16, 16, guideStyle);
 	} else {

--- a/Core/HLE/sceImpose.cpp
+++ b/Core/HLE/sceImpose.cpp
@@ -46,7 +46,7 @@ void __ImposeInit()
 			language = PSP_SYSTEMPARAM_LANGUAGE_ENGLISH;
 		}
 	}
-	buttonValue = g_Config.iButtonPreference;
+	buttonValue = PSP_CoreParameter().compat.flags().ForceCircleButtonConfirm ? PSP_SYSTEMPARAM_BUTTON_CIRCLE : g_Config.iButtonPreference;
 	umdPopup = PSP_UMD_POPUP_DISABLE;
 	backlightOffTime = 0;
 }

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -893,7 +893,7 @@ static u32 sceUtilityGetSystemParamInt(u32 id, u32 destaddr)
 		}
 		break;
 	case PSP_SYSTEMPARAM_ID_INT_BUTTON_PREFERENCE:
-		param = g_Config.iButtonPreference;
+		param = PSP_CoreParameter().compat.flags().ForceCircleButtonConfirm ? PSP_SYSTEMPARAM_BUTTON_CIRCLE : g_Config.iButtonPreference;
 		break;
 	case PSP_SYSTEMPARAM_ID_INT_LOCK_PARENTAL_LEVEL:
 		param = g_Config.iLockParentalLevel;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1348,3 +1348,8 @@ UCAS40306 = true
 UCJS10112 = true
 NPJG00116 = true
 NPUG70097 = true  # Demo
+
+[ForceCircleButtonConfirm]
+# Shining Ark, issue #15663
+NPJH50717 = true
+ULJM06223 = true


### PR DESCRIPTION
Seems the game might not handle the case of confirm button being set to cross properly, so force it to circle if this game is running.

Fixes #15663 (hopefully..)