### PR TITLE
GPU: Support framebuf depal from rendered CLUT

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1274,6 +1274,8 @@ void TextureCacheCommon::LoadClut(u32 clutAddr, u32 loadBytes) {
 					if (matchRange && !inMargin && offset < (int)clutRenderOffset_) {
 						WARN_LOG_N_TIMES(clutfb, 5, G3D, "Detected LoadCLUT(%d bytes) from framebuffer %08x (%s), byte offset %d", loadBytes, fb_address, GeBufferFormatToString(framebuffer->fb_format), offset);
 						framebuffer->last_frame_clut = gpuStats.numFlips;
+						// Also mark used so it's not decimated.
+						framebuffer->last_frame_used = gpuStats.numFlips;
 						framebuffer->usageFlags |= FB_USAGE_CLUT;
 						bestClutAddress = framebuffer->fb_address;
 						clutRenderOffset_ = (u32)offset;


### PR DESCRIPTION
This fixes the transitions into battle in Kurhyo 2 (see #15956.)  They're no longer incorrectly red.

For reproduction / posterity:

Here's a frame dump entering battle (incorrectly red before these changes):
[#15956_NPJH90274_kurohyo_red_bg.zip](https://github.com/hrydgard/ppsspp/files/10100500/15956_NPJH90274_kurohyo_red_bg.zip)

Correct rendering (PSP, software looks the same):
![#15956_NPJH90274_kurohyo_red_bg](https://user-images.githubusercontent.com/191233/204194816-2f2015fa-22bd-417b-8de2-7f613b4fc401.png)

CLUT is rendered at 64/767, to 0x04116200 (256x1, 565.)  It's textured from a RAM texture.  It's read back as 8888, with `& 0x1f` (pass 1), then `(>> 5) & 0x1f` (pass 2), etc.  Basically red/green/blue ramps next to each other.  The CLUT address is adjusted each time, which is the first issue:
 * 69/767 uses red (CLUT at 04116200, 0-31 - so pixels 0-63 of 565 render)
 * 73/767 uses green (CLUT at 04116280, 0-31 - so pixels 64-127 of 565 render)
 * 77/767 uses blue (CLUT at 04116300, 0-31 - so pixels 128-191 of 565 render)

Next, it uses this to depal a framebuffer, so that's the second issue.  Finally, it uses this same rendered CLUT for many frames without re-rendering it, and previously we decimated framebuffers if they weren't updated.

-[Unknown]