### PR TITLE
OpenXR - Broken rendering fixed

### DIFF
--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -86,15 +86,6 @@ void CenterDisplayOutputRect(FRect *rc, float origW, float origH, const FRect &f
 	float scale = g_Config.fDisplayScale;
 	float aspectRatioAdjust = g_Config.fDisplayAspectRatio;
 
-	if (IsVREnabled()) {
-		stretch = 0;
-		rotated = false;
-		offsetX = 0.0f;
-		offsetY = 0.0f;
-		scale = 1.0f;
-		aspectRatioAdjust = 1.0f;
-	}
-
 	// Ye olde 1080p hack, new version: If everything is setup to exactly cover the screen (defaults), and the screen display aspect ratio is 16:9,
 	// stretch the PSP's aspect ratio veeery slightly to fill it completely.
 	if (scale == 1.0f && offsetX == 0.5f && offsetY == 0.5f && aspectRatioAdjust == 1.0f) {
@@ -132,10 +123,19 @@ void CenterDisplayOutputRect(FRect *rc, float origW, float origH, const FRect &f
 		outH = scaledHeight;
 	}
 
-	rc->x = floorf(frame.x + frame.w * offsetX - outW * 0.5f);
-	rc->y = floorf(frame.y + frame.h * offsetY - outH * 0.5f);
-	rc->w = floorf(outW);
-	rc->h = floorf(outH);
+	if (IsVREnabled()) {
+		rc->x = 0;
+		rc->y = 0;
+		rc->w = floorf(frame.w);
+		rc->h = floorf(frame.h);
+		outW = frame.w;
+		outH = frame.h;
+	} else {
+		rc->x = floorf(frame.x + frame.w * offsetX - outW * 0.5f);
+		rc->y = floorf(frame.y + frame.h * offsetY - outH * 0.5f);
+		rc->w = floorf(outW);
+		rc->h = floorf(outH);
+	}
 }
 
 PresentationCommon::PresentationCommon(Draw::DrawContext *draw) : draw_(draw) {

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1354,10 +1354,8 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 		}
 
 		// HUD scaling
-		WRITE(p, "  if ((u_scaleX < 0.99) || (u_scaleY < 0.99)) {\n");
-		WRITE(p, "    %sgl_Position.x *= u_scaleX;\n", compat.vsOutPrefix);
-		WRITE(p, "    %sgl_Position.y *= u_scaleY;\n", compat.vsOutPrefix);
-		WRITE(p, "  }\n");
+		WRITE(p, "  %sgl_Position.x *= u_scaleX;\n", compat.vsOutPrefix);
+		WRITE(p, "  %sgl_Position.y *= u_scaleY;\n", compat.vsOutPrefix);
 	}
 
 	if (useSimpleStereo && useHWTransform) {

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -26,6 +26,7 @@
 #include "Common/Math/math_util.h"
 #include "Common/System/Display.h"
 #include "Common/System/NativeApp.h"
+#include "Common/VR/PPSSPPVR.h"
 #include "Common/StringUtils.h"
 
 #include "Common/Data/Color/RGBAUtil.h"
@@ -202,39 +203,42 @@ void DisplayLayoutScreen::CreateViews() {
 	rightScrollView->Add(rightColumn);
 	root_->Add(rightScrollView);
 
-	auto stretch = new CheckBox(&g_Config.bDisplayStretch, gr->T("Stretch"));
-	leftColumn->Add(stretch);
 
-	PopupSliderChoiceFloat *aspectRatio = new PopupSliderChoiceFloat(&g_Config.fDisplayAspectRatio, 0.5f, 2.0f, di->T("Aspect Ratio"), screenManager());
-	leftColumn->Add(aspectRatio);
-	aspectRatio->SetDisabledPtr(&g_Config.bDisplayStretch);
-	aspectRatio->SetHasDropShadow(false);
-	aspectRatio->SetLiveUpdate(true);
+	if (!IsVREnabled()) {
+		auto stretch = new CheckBox(&g_Config.bDisplayStretch, gr->T("Stretch"));
+		leftColumn->Add(stretch);
 
-	mode_ = new ChoiceStrip(ORIENT_VERTICAL);
-	mode_->AddChoice(di->T("Move"));
-	mode_->AddChoice(di->T("Resize"));
-	mode_->SetSelection(0, false);
-	leftColumn->Add(mode_);
+		PopupSliderChoiceFloat *aspectRatio = new PopupSliderChoiceFloat(&g_Config.fDisplayAspectRatio, 0.5f, 2.0f, di->T("Aspect Ratio"), screenManager());
+		leftColumn->Add(aspectRatio);
+		aspectRatio->SetDisabledPtr(&g_Config.bDisplayStretch);
+		aspectRatio->SetHasDropShadow(false);
+		aspectRatio->SetLiveUpdate(true);
 
-	static const char *displayRotation[] = { "Landscape", "Portrait", "Landscape Reversed", "Portrait Reversed" };
-	auto rotation = new PopupMultiChoice(&g_Config.iInternalScreenRotation, gr->T("Rotation"), displayRotation, 1, ARRAY_SIZE(displayRotation), co->GetName(), screenManager());
-	rotation->SetEnabledFunc([] {
-		return !g_Config.bSkipBufferEffects || g_Config.bSoftwareRendering;
-	});
-	leftColumn->Add(rotation);
+		mode_ = new ChoiceStrip(ORIENT_VERTICAL);
+		mode_->AddChoice(di->T("Move"));
+		mode_->AddChoice(di->T("Resize"));
+		mode_->SetSelection(0, false);
+		leftColumn->Add(mode_);
 
-	leftColumn->Add(new Spacer(12.0f));
+		static const char *displayRotation[] = { "Landscape", "Portrait", "Landscape Reversed", "Portrait Reversed" };
+		auto rotation = new PopupMultiChoice(&g_Config.iInternalScreenRotation, gr->T("Rotation"), displayRotation, 1, ARRAY_SIZE(displayRotation), co->GetName(), screenManager());
+		rotation->SetEnabledFunc([] {
+			return !g_Config.bSkipBufferEffects || g_Config.bSoftwareRendering;
+		});
+		leftColumn->Add(rotation);
 
-	Choice *center = new Choice(di->T("Reset"));
-	center->OnClick.Add([&](UI::EventParams &) {
-		g_Config.fDisplayAspectRatio = 1.0f;
-		g_Config.fDisplayScale = 1.0f;
-		g_Config.fDisplayOffsetX = 0.5f;
-		g_Config.fDisplayOffsetY = 0.5f;
-		return UI::EVENT_DONE;
-	});
-	leftColumn->Add(center);
+		leftColumn->Add(new Spacer(12.0f));
+
+		Choice *center = new Choice(di->T("Reset"));
+		center->OnClick.Add([&](UI::EventParams &) {
+			g_Config.fDisplayAspectRatio = 1.0f;
+			g_Config.fDisplayScale = 1.0f;
+			g_Config.fDisplayOffsetX = 0.5f;
+			g_Config.fDisplayOffsetY = 0.5f;
+			return UI::EVENT_DONE;
+		});
+		leftColumn->Add(center);
+	}
 
 	static const char *bufFilters[] = { "Linear", "Nearest", };
 	rightColumn->Add(new PopupMultiChoice(&g_Config.iBufFilter, gr->T("Screen Scaling Filter"), bufFilters, 1, ARRAY_SIZE(bufFilters), gr->GetName(), screenManager()));


### PR DESCRIPTION
The new stretching broke the VR rendering. This fixes it and hides unsupported settings.