### PR TITLE
Fix Burnout Dominator lens flare on OpenGL ES

### DIFF
--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -1516,6 +1516,13 @@ uint32_t OpenGLContext::GetDataFormatSupport(DataFormat fmt) const {
 
 	case DataFormat::R8_UNORM:
 		return FMT_TEXTURE;
+	case DataFormat::R16_UNORM:
+		if (!gl_extensions.IsGLES) {
+			return FMT_TEXTURE;
+		} else {
+			return 0;
+		}
+		break;
 
 	case DataFormat::BC1_RGBA_UNORM_BLOCK:
 	case DataFormat::BC2_UNORM_BLOCK:


### PR DESCRIPTION
Not the prettiest solution, but works: Use `R8_UNORM` as a fallback if `R16_UNORM` is not available.

Fixes #16081 .