### PR TITLE
 Fragment shader generator: Move the framebuffer fetch bit to the shader ID.

### DIFF
--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -169,8 +169,13 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 
 	bool needFramebufferRead = replaceBlend == REPLACE_BLEND_READ_FRAMEBUFFER || colorWriteMask || replaceLogicOp;
 
-	bool fetchFramebuffer = needFramebufferRead && gstate_c.Use(GPU_USE_FRAMEBUFFER_FETCH);
-	bool readFramebufferTex = needFramebufferRead && !gstate_c.Use(GPU_USE_FRAMEBUFFER_FETCH);
+	bool fetchFramebuffer = needFramebufferRead && id.Bit(FS_BIT_USE_FRAMEBUFFER_FETCH);
+	bool readFramebufferTex = needFramebufferRead && !id.Bit(FS_BIT_USE_FRAMEBUFFER_FETCH);
+
+	if (fetchFramebuffer && (compat.shaderLanguage != GLSL_VULKAN || compat.shaderLanguage != GLSL_3xx)) {
+		*errorString = "framebuffer fetch requires GLSL: vulkan or 3xx";
+		return false;
+	}
 
 	bool needFragCoord = readFramebufferTex || gstate_c.Use(GPU_ROUND_FRAGMENT_DEPTH_TO_16BIT);
 	bool writeDepth = gstate_c.Use(GPU_ROUND_FRAGMENT_DEPTH_TO_16BIT);

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -100,6 +100,7 @@ enum FShaderBit : uint8_t {
 	FS_BIT_SHADER_DEPAL_MODE = 55,  // 2 bits (ShaderDepalMode)
 	FS_BIT_SAMPLE_ARRAY_TEXTURE = 57,  // For multiview, framebuffers are array textures and we need to sample the two layers correctly.
 	FS_BIT_STEREO = 58,
+	FS_BIT_USE_FRAMEBUFFER_FETCH = 59,
 };
 
 static inline FShaderBit operator +(FShaderBit bit, int i) {

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -484,7 +484,7 @@ VulkanGeometryShader *ShaderManagerVulkan::GetGeometryShaderFromModule(VkShaderM
 // instantaneous.
 
 #define CACHE_HEADER_MAGIC 0xff51f420 
-#define CACHE_VERSION 30
+#define CACHE_VERSION 31
 struct VulkanCacheHeader {
 	uint32_t magic;
 	uint32_t version;


### PR DESCRIPTION
Will resolve a future issue in the multisampling PR (#16458), where the GPU_USE_FRAMEBUFFER_FETCH flag changes at runtime if you switch between no AA and MSAA.

Just figured I'd get it in separately for safety.