### PR TITLE
softgpu: Correctly fix inversions, matching tests

### DIFF
--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -50,16 +50,15 @@ inline float clip_dotprod(const ClipVertexData &vert, float A, float B, float C,
 }
 
 inline void clip_interpolate(ClipVertexData &dest, float t, const ClipVertexData &a, const ClipVertexData &b) {
-	if (different_signs(a.clippos.w, b.clippos.w)) {
-		if (a.clippos.w < -1.0f || b.clippos.w < -1.0f) {
-			dest.v.screenpos.x = 0x7FFFFFFF;
-			return;
-		}
-	}
-
+	bool outsideRange = false;
 	dest.Lerp(t, a, b);
-	dest.v.screenpos = TransformUnit::ClipToScreen(dest.clippos);
+	dest.v.screenpos = TransformUnit::ClipToScreen(dest.clippos, &outsideRange);
 	dest.v.clipw = dest.clippos.w;
+
+	// If the clipped coordinate is outside range, then we throw it away.
+	// This prevents a lot of inversions that shouldn't be drawn.
+	if (outsideRange)
+		dest.v.screenpos.x = 0x7FFFFFFF;
 }
 
 #define CLIP_POLY( PLANE_BIT, A, B, C, D )							\

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -121,7 +121,7 @@ public:
 	static WorldCoords ModelToWorld(const ModelCoords& coords);
 	static ViewCoords WorldToView(const WorldCoords& coords);
 	static ClipCoords ViewToClip(const ViewCoords& coords);
-	static ScreenCoords ClipToScreen(const ClipCoords& coords);
+	static ScreenCoords ClipToScreen(const ClipCoords &coords, bool *outsideRangeFlag);
 	static inline DrawingCoords ScreenToDrawing(int x, int y) {
 		DrawingCoords ret;
 		// When offset > coord, this is negative and force-scissors.


### PR DESCRIPTION
Inversions are allowed just fine, but if clipping results in coordinates outside range, the triangle should be culled.  Fixes more wanted inversions.

It feels stupidly obvious now why the particular Z value I found was such an arbitrary threshold, it was causing the screen coordinates to go out of bounds.  I should've been checking them.

This seems to cull in all the correct places, at least in the frame dumps I've gathered.  I haven't tested some of the latest from #16131 yet but this makes a lot of sense and matches the previous ones.

Fixes the case in #16207 (better than hardware, there's an innocent inversion Vulkan/etc. draw which the PSP doesn't), fixes #15875.  Takes care of #11376 in software only, as well as #10914 (both of those are still issues in hardware renderers.)

-[Unknown]