### PR TITLE
GLES: Correct unit tests for framebuffer fetch

### DIFF
--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -172,7 +172,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 	bool fetchFramebuffer = needFramebufferRead && id.Bit(FS_BIT_USE_FRAMEBUFFER_FETCH);
 	bool readFramebufferTex = needFramebufferRead && !id.Bit(FS_BIT_USE_FRAMEBUFFER_FETCH);
 
-	if (fetchFramebuffer && (compat.shaderLanguage != GLSL_VULKAN && compat.shaderLanguage != GLSL_3xx)) {
+	if (fetchFramebuffer && compat.shaderLanguage != GLSL_VULKAN && (compat.shaderLanguage != GLSL_3xx || !compat.lastFragData)) {
 		*errorString = "framebuffer fetch requires GLSL: vulkan or 3xx";
 		return false;
 	}
@@ -568,7 +568,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 		if (compat.shaderLanguage == GLSL_3xx) {
 			WRITE(p, "  lowp vec4 destColor = %s;\n", compat.lastFragData);
 		} else if (compat.shaderLanguage == GLSL_VULKAN) {
-			WRITE(p, "  lowp vec4 destColor = subpassLoad(inputColor);\n", compat.lastFragData);
+			WRITE(p, "  lowp vec4 destColor = subpassLoad(inputColor);\n");
 		} else {
 			_assert_msg_(false, "Need fetch destColor, but not a compatible language");
 		}


### PR DESCRIPTION
Sorry, I fixed the assert in Vulkan, but didn't notice the unit test error for GL/GLES, this fixes it properly.  Follow up from #16471.

-[Unknown]