### PR TITLE
Temporarily disable the UWP github CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
         path: ppsspp/
 
   build-uwp:
+    if: ${{false}}  # Temporarily disable
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
There's a lot of weird errors right now, seems like a platform issue.