### PR TITLE
softgpu: Cull verts outside post-viewport Z

### DIFF
--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -181,7 +181,7 @@ static ScreenCoords ClipToScreenInternal(Vec3f scaled, const ClipCoords &coords,
 			scaled.z = 0.f;
 		else if (scaled.z > 65535.0f)
 			scaled.z = 65535.0f;
-	} else if (scaled.x > SCREEN_BOUND || scaled.y >= SCREEN_BOUND || scaled.x < 0 || scaled.y < 0) {
+	} else if (scaled.x > SCREEN_BOUND || scaled.y >= SCREEN_BOUND || scaled.x < 0 || scaled.y < 0 || scaled.z < 0.0f || scaled.z >= 65536.0f) {
 		*outside_range_flag = true;
 	}
 


### PR DESCRIPTION
Shouldn't have removed this before, points are still culled when depth clamp is off and throughmode is off.

Fixes Crazy Taxi 2 graphics glitches, see #16131.  Had removed this in #14820 (0b73c1c) overzealously.  Also checked accuracy better, it's definitely at >= 65536.0.

Ran through a bunch of previously fixed frame dumps to make sure I didn't miss anything... hopefully.

Also, not dealt with here... some of my tests related to this are suggesting that through-mode depth is *not* clamped at the vertex level to 0/FFFF, but rather that it interpolates and clamps at the fragment level.  So maybe clamping it within the vertex reader is wrong, after all...

-[Unknown]