### PR TITLE
Cleanup some GE debugger logspam, small texture proj optimization

### DIFF
--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -173,8 +173,9 @@ void ComputeVertexShaderID(VShaderID *id_out, u32 vertType, bool useHWTransform,
 
 static const char *alphaTestFuncs[] = { "NEVER", "ALWAYS", "==", "!=", "<", "<=", ">", ">=" };
 
-static bool MatrixNeedsProjection(const float m[12]) {
-	return m[2] != 0.0f || m[5] != 0.0f || m[8] != 0.0f || m[11] != 1.0f;
+static bool MatrixNeedsProjection(const float m[12], GETexProjMapMode mode) {
+	// For GE_PROJMAP_UV, we can ignore m[8] since it multiplies to zero.
+	return m[2] != 0.0f || m[5] != 0.0f || (m[8] != 0.0f && mode != GE_PROJMAP_UV) || m[11] != 1.0f;
 }
 
 std::string FragmentShaderDesc(const FShaderID &id) {
@@ -283,7 +284,7 @@ void ComputeFragmentShaderID(FShaderID *id_out, const ComputedPipelineState &pip
 		bool enableAlphaTest = gstate.isAlphaTestEnabled() && !IsAlphaTestTriviallyTrue();
 		bool enableColorTest = gstate.isColorTestEnabled() && !IsColorTestTriviallyTrue();
 		bool enableColorDoubling = gstate.isColorDoublingEnabled() && gstate.isTextureMapEnabled();
-		bool doTextureProjection = (gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX && MatrixNeedsProjection(gstate.tgenMatrix));
+		bool doTextureProjection = (gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX && MatrixNeedsProjection(gstate.tgenMatrix, gstate.getUVProjMode()));
 		bool doTextureAlpha = gstate.isTextureAlphaUsed();
 		bool doFlatShading = gstate.getShadeMode() == GE_SHADE_FLAT;
 

--- a/GPU/Debugger/Debugger.cpp
+++ b/GPU/Debugger/Debugger.cpp
@@ -134,6 +134,11 @@ bool NotifyCommand(u32 pc) {
 	if (IsBreakpoint(pc, op)) {
 		GPUBreakpoints::ClearTempBreakpoints();
 
+		if (coreState == CORE_POWERDOWN || !gpuDebug) {
+			breakNext = BreakNext::NONE;
+			return process;
+		}
+
 		auto info = gpuDebug->DissassembleOp(pc);
 		if (lastStepTime >= 0.0) {
 			NOTICE_LOG(G3D, "Waiting at %08x, %s (%fms)", pc, info.desc.c_str(), (time_now_d() - lastStepTime) * 1000.0);

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -132,7 +132,12 @@ void ComputeRasterizerState(RasterizerState *state, std::function<void()> flushF
 		state->textureProj = gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX;
 		if (state->textureProj) {
 			// We may be able to optimize this off.  This is actually kinda common.
-			if (gstate.tgenMatrix[2] == 0.0f && gstate.tgenMatrix[5] == 0.0f && gstate.tgenMatrix[8] == 0.0f && gstate.tgenMatrix[11] == 1.0f) {
+			const bool qZeroST = gstate.tgenMatrix[2] == 0.0f && gstate.tgenMatrix[5] == 0.0f;
+			const bool qZeroQ = gstate.tgenMatrix[8] == 0.0f;
+
+			// Two common cases: the source q factor is zero, OR source is UV.
+			const bool qFactorZero = gstate.getUVProjMode() == GE_PROJMAP_UV;
+			if (qZeroST && (qZeroQ || qFactorZero) && gstate.tgenMatrix[11] == 1.0f) {
 				state->textureProj = false;
 			}
 		}


### PR DESCRIPTION
This helps NFS Most Wanted 5-1-0 (at least the frame dump from #16131) by around ~4% in the software renderer.  In Vulkan, it's like 0.05%, but might as well.  Maybe it'll help mobile more, and it doesn't need any new dirtying since it's the same register.

The game does a bunch of its drawing with a matrix that's used to do exactly what the UV scale/offset registers are for, but sets the Q/Q factor to 1.0 (which doesn't matter because input Q is always 0.)

-[Unknown]