### PR TITLE
Add savestate checkpoints to verify that MEASURE and WRITE match

### DIFF
--- a/Common/Serialize/SerializeFuncs.h
+++ b/Common/Serialize/SerializeFuncs.h
@@ -85,7 +85,8 @@ template<class T>
 void DoVector(PointerWrap &p, std::vector<T> &x, T &default_val) {
 	u32 vec_size = (u32)x.size();
 	Do(p, vec_size);
-	x.resize(vec_size, default_val);
+	if (vec_size != x.size())
+		x.resize(vec_size, default_val);
 	if (vec_size > 0)
 		DoArray(p, &x[0], vec_size);
 }

--- a/Common/Serialize/SerializeMap.h
+++ b/Common/Serialize/SerializeMap.h
@@ -38,8 +38,8 @@ void DoMap(PointerWrap &p, M &x, typename M::mapped_type &default_val) {
 			x[first] = second;
 			--number;
 		}
+		break;
 	}
-	break;
 	case PointerWrap::MODE_WRITE:
 	case PointerWrap::MODE_MEASURE:
 	case PointerWrap::MODE_VERIFY:
@@ -52,8 +52,10 @@ void DoMap(PointerWrap &p, M &x, typename M::mapped_type &default_val) {
 			--number;
 			++itr;
 		}
+		break;
 	}
-	break;
+	case PointerWrap::MODE_NOOP:
+		break;
 	}
 }
 
@@ -109,8 +111,8 @@ void DoMultimap(PointerWrap &p, M &x, typename M::mapped_type &default_val) {
 			x.insert(std::make_pair(first, second));
 			--number;
 		}
+		break;
 	}
-	break;
 	case PointerWrap::MODE_WRITE:
 	case PointerWrap::MODE_MEASURE:
 	case PointerWrap::MODE_VERIFY:
@@ -122,8 +124,10 @@ void DoMultimap(PointerWrap &p, M &x, typename M::mapped_type &default_val) {
 			--number;
 			++itr;
 		}
+		break;
 	}
-	break;
+	case PointerWrap::MODE_NOOP:
+		break;
 	}
 }
 

--- a/Common/Serialize/Serializer.cpp
+++ b/Common/Serialize/Serializer.cpp
@@ -35,7 +35,7 @@ static constexpr SerializeCompressType SAVE_TYPE = SerializeCompressType::ZSTD;
 
 void PointerWrap::RewindForWrite(u8 *writePtr) {
 	_assert_(mode == MODE_MEASURE);
-	// Switch to writing mode and
+	// Switch to writing mode, save the size for later checking and start again.
 	measuredSize_ = Offset();
 	mode = MODE_WRITE;
 	*ptr = writePtr;

--- a/Common/Serialize/Serializer.cpp
+++ b/Common/Serialize/Serializer.cpp
@@ -105,8 +105,10 @@ PointerWrapSection PointerWrap::Section(const char *title, int minVer, int ver) 
 		if (!firstBadSectionTitle_) {
 			firstBadSectionTitle_ = title;
 		}
-		WARN_LOG(SAVESTATE, "Savestate failure: wrong version %d found for section '%s'", foundVersion, title);
-		SetError(ERROR_FAILURE);
+		if (mode != MODE_NOOP) {
+			WARN_LOG(SAVESTATE, "Savestate failure: wrong version %d found for section '%s'", foundVersion, title);
+			SetError(ERROR_FAILURE);
+		}
 		return PointerWrapSection(*this, -1, title);
 	}
 	return PointerWrapSection(*this, foundVersion, title);
@@ -117,8 +119,9 @@ void PointerWrap::SetError(Error error_) {
 		error = error_;
 	}
 	if (error > ERROR_WARNING) {
-		// For the rest of this run, just measure.
-		mode = PointerWrap::MODE_MEASURE;
+		// For the rest of this run, do nothing, to avoid running off the end of memory or something,
+		// and also not logspam like MEASURE will do in an error case.
+		mode = PointerWrap::MODE_NOOP;
 	}
 }
 

--- a/Common/Serialize/Serializer.h
+++ b/Common/Serialize/Serializer.h
@@ -95,9 +95,10 @@ class PointerWrap
 public:
 	enum Mode {
 		MODE_READ = 1, // load
-		MODE_WRITE, // save
-		MODE_MEASURE, // calculate size
-		MODE_VERIFY, // compare
+		MODE_WRITE,    // save
+		MODE_MEASURE,  // calculate size
+		MODE_VERIFY,   // compare
+		MODE_NOOP,     // don't do anything. Useful to cleanly doing stuff once we've hit an error.
 	};
 
 	enum Error {

--- a/Common/Serialize/Serializer.h
+++ b/Common/Serialize/Serializer.h
@@ -111,8 +111,11 @@ public:
 	Mode mode;
 	Error error = ERROR_NONE;
 
-	PointerWrap(u8 **ptr_, Mode mode_) : ptr(ptr_), ptrStart_(*ptr), mode(mode_) {}
-	PointerWrap(unsigned char **ptr_, int mode_) : ptr((u8**)ptr_), ptrStart_(*ptr), mode((Mode)mode_) {}
+	PointerWrap(u8 **ptr_, Mode mode_) : ptr(ptr_), ptrStart_(*ptr), mode(mode_) {
+		if (mode == MODE_MEASURE) {
+			checkpoints_.reserve(750);
+		}
+	}
 
 	void RewindForWrite(u8 *writePtr);
 	bool CheckAfterWrite();
@@ -143,7 +146,6 @@ public:
 	size_t Offset() const { return *ptr - ptrStart_; }
 
 private:
-
 	const char *firstBadSectionTitle_ = nullptr;
 	u8 *ptrStart_;
 	std::vector<SerializeCheckpoint> checkpoints_;

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -1255,7 +1255,7 @@ void PSPSaveDialog::DoState(PointerWrap &p) {
 	// Just reset it.
 	bool hasParam = param.GetPspParam() != NULL;
 	Do(p, hasParam);
-	if (hasParam) {
+	if (hasParam && p.mode == p.MODE_READ) {
 		param.SetPspParam(&request);
 	}
 	Do(p, requestAddr);

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1890,13 +1890,13 @@ void SavedataParam::DoState(PointerWrap &p) {
 	Do(p, saveDataListCount);
 	Do(p, saveNameListDataCount);
 	if (p.mode == p.MODE_READ) {
-		if (saveDataList != NULL)
+		if (saveDataList)
 			delete [] saveDataList;
 		if (saveDataListCount != 0) {
 			saveDataList = new SaveFileInfo[saveDataListCount];
 			DoArray(p, saveDataList, saveDataListCount);
 		} else {
-			saveDataList = NULL;
+			saveDataList = nullptr;
 		}
 	}
 	else


### PR DESCRIPTION
Verifies that MEASURE and WRITE match in every detail. Did this because I got save state crashes in Ratchet & Clank, writing beyond the end of the buffer.

And indeed, I have a situation now where saveDataListCount in SaveDataParam::DoState differs (0 during measure, 5 during write), leading to different data lengths! 

I can get into this situation by loading a state just after booting up Ratchet, and then loading it again, resulting in a backup save. During that backup save, this happens, sometimes leading to a crash if there was no spare space at the end of the last memory page of the buffer.

Will debug and fix that before merging this, but at least this should result in future cases like this gracefully failing to save instead of crashing.

This seems to have something to do PSPSaveDialog::DoState which calls param.SetPspParam which seems to modify it!