### PR TITLE
Simpsons crash on GLES fixed

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1197,7 +1197,6 @@ bool TextureCacheCommon::GetCurrentFramebufferTextureDebug(GPUDebugBuffer &buffe
 }
 
 void TextureCacheCommon::NotifyConfigChanged() {
-	clearCacheNextFrame_ = true;
 	int scaleFactor = g_Config.iTexScalingLevel;
 
 	if (!gstate_c.Use(GPU_USE_TEXTURE_NPOT)) {
@@ -2577,6 +2576,10 @@ void TextureCacheCommon::InvalidateAll(GPUInvalidationType /*unused*/) {
 		}
 		iter->second->invalidHint++;
 	}
+}
+
+void TextureCacheCommon::ClearNextFrame() {
+	clearCacheNextFrame_ = true;
 }
 
 std::string AttachCandidate::ToString() const {

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -323,6 +323,7 @@ public:
 	bool SetOffsetTexture(u32 yOffset);
 	void Invalidate(u32 addr, int size, GPUInvalidationType type);
 	void InvalidateAll(GPUInvalidationType type);
+	void ClearNextFrame();
 
 	TextureShaderCache *GetTextureShaderCache() { return textureShaderCache_; }
 

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -223,6 +223,10 @@ void GPU_D3D11::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
+void GPU_D3D11::ClearCacheNextFrame() {
+	textureCacheD3D11_->ClearNextFrame();
+}
+
 void GPU_D3D11::ClearShaderCache() {
 	shaderManagerD3D11_->ClearShaders();
 	drawEngine_.ClearInputLayoutMap();

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -41,6 +41,7 @@ public:
 	void ExecuteOp(u32 op, u32 diff) override;
 
 	void GetStats(char *buffer, size_t bufsize) override;
+	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -220,6 +220,10 @@ void GPU_DX9::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
+void GPU_DX9::ClearCacheNextFrame() {
+	textureCacheDX9_->ClearNextFrame();
+}
+
 void GPU_DX9::ClearShaderCache() {
 	shaderManagerDX9_->ClearCache(true);
 }

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -41,6 +41,7 @@ public:
 
 	void ReapplyGfxState() override;
 	void GetStats(char *buffer, size_t bufsize) override;
+	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -362,6 +362,10 @@ void GPU_GLES::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
+void GPU_GLES::ClearCacheNextFrame() {
+	textureCacheGL_->ClearNextFrame();
+}
+
 void GPU_GLES::ClearShaderCache() {
 	shaderManagerGL_->ClearCache(true);
 }

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -49,6 +49,7 @@ public:
 	void ReapplyGfxState() override;
 	void GetStats(char *buffer, size_t bufsize) override;
 
+	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -631,6 +631,7 @@ void GPUCommon::NotifyDisplayResized() {
 // if "transparent".
 void GPUCommon::CheckConfigChanged() {
 	if (configChanged_) {
+		ClearCacheNextFrame();
 		gstate_c.useFlags = CheckGPUFeatures();
 		drawEngineCommon_->NotifyConfigChanged();
 		textureCache_->NotifyConfigChanged();

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -245,6 +245,9 @@ public:
 	virtual bool PerformWriteColorFromMemory(u32 dest, int size) = 0;
 	virtual bool PerformWriteStencilFromMemory(u32 dest, int size, WriteStencil flags = WriteStencil::NEEDS_CLEAR) = 0;
 
+	// Will cause the texture cache to be cleared at the start of the next frame.
+	virtual void ClearCacheNextFrame() = 0;
+
 	// Internal hack to avoid interrupts from "PPGe" drawing (utility UI, etc)
 	virtual void EnableInterrupts(bool enable) = 0;
 

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -144,6 +144,7 @@ public:
 	bool PerformReadbackToMemory(u32 dest, int size) override;
 	bool PerformWriteColorFromMemory(u32 dest, int size) override;
 	bool PerformWriteStencilFromMemory(u32 dest, int size, WriteStencil flags) override;
+	void ClearCacheNextFrame() override {}
 
 	void DeviceLost() override;
 	void DeviceRestore() override;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -514,6 +514,10 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
+void GPU_Vulkan::ClearCacheNextFrame() {
+	textureCacheVulkan_->ClearNextFrame();
+}
+
 void GPU_Vulkan::ClearShaderCache() {
 	// TODO
 }

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -51,6 +51,7 @@ public:
 	void ExecuteOp(u32 op, u32 diff) override;
 
 	void GetStats(char *buffer, size_t bufsize) override;
+	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 


### PR DESCRIPTION
Tested on Pico Neo 3 and Pico 4 VR headsets. Loading saved game renders one frame and then it crashes on texture destroying with a broken pointer (0x1FFF...FFF). No idea why is it happening, I only found the commit from which it started happening and reverted it.

This reverts commit cbfa4bfc8eef3a5f0e09e0ea2c3113bb2a88a7d5.