### PR TITLE
softgpu: Handle infnan fog coefficients better

### DIFF
--- a/GPU/Common/GPUDebugInterface.cpp
+++ b/GPU/Common/GPUDebugInterface.cpp
@@ -19,6 +19,7 @@
 #include "Common/Math/expression_parser.h"
 #include "Core/Debugger/SymbolMap.h"
 #include "GPU/Common/GPUDebugInterface.h"
+#include "GPU/Debugger/Debugger.h"
 #include "GPU/Debugger/GECommandTable.h"
 #include "GPU/GPUState.h"
 
@@ -34,6 +35,8 @@ enum class GEReferenceIndex : uint32_t {
 	CLUTADDR,
 	TRANSFERSRC,
 	TRANSFERDST,
+	PRIMCOUNT,
+	LASTPRIMCOUNT,
 
 	TEXADDR0,
 	TEXADDR1,
@@ -74,6 +77,8 @@ static constexpr ReferenceName referenceNames[] = {
 	{ GEReferenceIndex::CLUTADDR, "clutaddr" },
 	{ GEReferenceIndex::TRANSFERSRC, "transfersrc" },
 	{ GEReferenceIndex::TRANSFERDST, "transferdst" },
+	{ GEReferenceIndex::PRIMCOUNT, "primcount" },
+	{ GEReferenceIndex::LASTPRIMCOUNT, "lastprimcount" },
 	{ GEReferenceIndex::TEXADDR0, "texaddr0" },
 	{ GEReferenceIndex::TEXADDR1, "texaddr1" },
 	{ GEReferenceIndex::TEXADDR2, "texaddr2" },
@@ -694,6 +699,12 @@ uint32_t GEExpressionFunctions::getReferenceValue(uint32_t referenceIndex) {
 
 	case GEReferenceIndex::TRANSFERDST:
 		return state.getTransferDstAddress();
+
+	case GEReferenceIndex::PRIMCOUNT:
+		return GPUDebug::PrimsThisFrame();
+
+	case GEReferenceIndex::LASTPRIMCOUNT:
+		return GPUDebug::PrimsLastFrame();
 
 	case GEReferenceIndex::TEXADDR0:
 	case GEReferenceIndex::TEXADDR1:

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -304,9 +304,13 @@ void ComputeTransformState(TransformState *state, const VertexReader &vreader) {
 			// The PSP treats these exponents as if they were valid.
 			if (my_isnanorinf(fogEnd)) {
 				bool sign = std::signbit(fogEnd);
-				// The multiply would reverse it.
-				if (my_isnanorinf(fogSlope) && std::signbit(fogSlope))
+				// The multiply would reverse it if it wasn't infinity (doesn't matter if it's infnan.)
+				if (std::signbit(fogSlope))
 					sign = !sign;
+				// Also allow a multiply by zero (slope) to result in zero, regardless of sign.
+				// Act like it was negative and clamped to zero.
+				if (fogSlope == 0.0f)
+					sign = true;
 
 				// Since this is constant for the entire draw, we don't even use infinity.
 				float forced = sign ? 0.0f : 1.0f;


### PR DESCRIPTION
This fixes the sky in Outrun, which was broken by my optimization to use a dot for the fog constant.  See #11380 for the correct behavior, and #16131 for the frame dump.

Also slip in some debugger improvements I added while checking that.

-[Unknown]
