### PR TITLE
Safer and simpler alternative to commit cbfa4bf.

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -599,7 +599,6 @@ void PSP_RunLoopUntil(u64 globalticks) {
 	}
 
 	mipsr4k.RunLoopUntil(globalticks);
-	gpu->CleanupBeforeUI();
 }
 
 void PSP_RunLoopFor(int cycles) {

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -223,10 +223,6 @@ void GPU_D3D11::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_D3D11::ClearCacheNextFrame() {
-	textureCacheD3D11_->ClearNextFrame();
-}
-
 void GPU_D3D11::ClearShaderCache() {
 	shaderManagerD3D11_->ClearShaders();
 	drawEngine_.ClearInputLayoutMap();

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -223,11 +223,6 @@ void GPU_D3D11::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_D3D11::ClearShaderCache() {
-	shaderManagerD3D11_->ClearShaders();
-	drawEngine_.ClearInputLayoutMap();
-}
-
 void GPU_D3D11::DoState(PointerWrap &p) {
 	GPUCommon::DoState(p);
 

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -41,7 +41,6 @@ public:
 	void ExecuteOp(u32 op, u32 diff) override;
 
 	void GetStats(char *buffer, size_t bufsize) override;
-	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -46,8 +46,6 @@ public:
 
 	void DoState(PointerWrap &p) override;
 
-	void ClearShaderCache() override;
-
 	// Using string because it's generic - makes no assumptions on the size of the shader IDs of this backend.
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType shader) override;
 	std::string DebugGetShaderString(std::string id, DebugShaderType shader, DebugShaderStringType stringType) override;

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -220,10 +220,6 @@ void GPU_DX9::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_DX9::ClearShaderCache() {
-	shaderManagerDX9_->ClearCache(true);
-}
-
 void GPU_DX9::DoState(PointerWrap &p) {
 	GPUCommon::DoState(p);
 

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -220,10 +220,6 @@ void GPU_DX9::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_DX9::ClearCacheNextFrame() {
-	textureCacheDX9_->ClearNextFrame();
-}
-
 void GPU_DX9::ClearShaderCache() {
 	shaderManagerDX9_->ClearCache(true);
 }

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -41,7 +41,6 @@ public:
 
 	void ReapplyGfxState() override;
 	void GetStats(char *buffer, size_t bufsize) override;
-	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -46,8 +46,6 @@ public:
 
 	void DoState(PointerWrap &p) override;
 
-	void ClearShaderCache() override;
-
 	// Using string because it's generic - makes no assumptions on the size of the shader IDs of this backend.
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType shader) override;
 	std::string DebugGetShaderString(std::string id, DebugShaderType shader, DebugShaderStringType stringType) override;

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -362,10 +362,6 @@ void GPU_GLES::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_GLES::ClearCacheNextFrame() {
-	textureCacheGL_->ClearNextFrame();
-}
-
 void GPU_GLES::ClearShaderCache() {
 	shaderManagerGL_->ClearCache(true);
 }

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -362,15 +362,6 @@ void GPU_GLES::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_GLES::ClearShaderCache() {
-	shaderManagerGL_->ClearCache(true);
-}
-
-void GPU_GLES::CleanupBeforeUI() {
-	// Clear any enabled vertex arrays.
-	shaderManagerGL_->DirtyLastShader();
-}
-
 void GPU_GLES::DoState(PointerWrap &p) {
 	GPUCommon::DoState(p);
 

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -54,9 +54,6 @@ public:
 
 	void DoState(PointerWrap &p) override;
 
-	void ClearShaderCache() override;
-	void CleanupBeforeUI() override;
-
 	// Using string because it's generic - makes no assumptions on the size of the shader IDs of this backend.
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType shader) override;
 	std::string DebugGetShaderString(std::string id, DebugShaderType shader, DebugShaderStringType stringType) override;

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -49,7 +49,6 @@ public:
 	void ReapplyGfxState() override;
 	void GetStats(char *buffer, size_t bufsize) override;
 
-	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -627,6 +627,10 @@ void GPUCommon::NotifyDisplayResized() {
 	displayResized_ = true;
 }
 
+void GPUCommon::ClearCacheNextFrame() {
+	textureCache_->ClearNextFrame();
+}
+
 // Called once per frame. Might also get called during the pause screen
 // if "transparent".
 void GPUCommon::CheckConfigChanged() {

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -267,6 +267,8 @@ protected:
 	void DeviceLost() override;
 	void DeviceRestore() override;
 
+	void ClearCacheNextFrame();
+
 	virtual void CheckRenderResized();
 
 	// Add additional common features dependent on other features, which may be backend-determined.

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -243,8 +243,6 @@ public:
 		return dlQueue;
 	}
 	std::vector<FramebufferInfo> GetFramebufferList() const override;
-	void ClearShaderCache() override {}
-	void CleanupBeforeUI() override {}
 
 	s64 GetListTicks(int listid) const override {
 		if (listid >= 0 && listid < DisplayListMaxCount) {

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -261,8 +261,6 @@ public:
 	virtual void NotifyRenderResized() = 0;
 	virtual void NotifyConfigChanged() = 0;
 
-	virtual void ClearShaderCache() = 0;
-	virtual void CleanupBeforeUI() = 0;
 	virtual bool FramebufferDirty() = 0;
 	virtual bool FramebufferReallyDirty() = 0;
 	virtual bool BusyDrawing() = 0;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -528,10 +528,6 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_Vulkan::ClearCacheNextFrame() {
-	textureCacheVulkan_->ClearNextFrame();
-}
-
 void GPU_Vulkan::ClearShaderCache() {
 	// TODO
 }

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -528,10 +528,6 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_Vulkan::ClearShaderCache() {
-	// TODO
-}
-
 void GPU_Vulkan::DoState(PointerWrap &p) {
 	GPUCommon::DoState(p);
 

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -51,7 +51,6 @@ public:
 	void ExecuteOp(u32 op, u32 diff) override;
 
 	void GetStats(char *buffer, size_t bufsize) override;
-	void ClearCacheNextFrame() override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -56,8 +56,6 @@ public:
 
 	void DoState(PointerWrap &p) override;
 
-	void ClearShaderCache() override;
-
 	// Using string because it's generic - makes no assumptions on the size of the shader IDs of this backend.
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType shader) override;
 	std::string DebugGetShaderString(std::string id, DebugShaderType shader, DebugShaderStringType stringType) override;


### PR DESCRIPTION
Not sure how cbfa4bfc8eef3a5f0e09e0ea2c3113bb2a88a7d5 broke things, but it did change call order a little. This doesn't.

Also removes some other old unused code.

See #16483