### PR TITLE
Reorganize the display layout screen

### DIFF
--- a/Common/File/Path.h
+++ b/Common/File/Path.h
@@ -118,6 +118,9 @@ public:
 	bool operator <(const Path &other) const {
 		return path_ < other.path_;
 	}
+	bool operator >(const Path &other) const {
+		return path_ > other.path_;
+	}
 
 private:
 	// The internal representation is currently always the plain string.

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -1272,6 +1272,9 @@ void AnchorLayout::Layout() {
 			if (center) {
 				vBounds.x += vBounds.w * 0.5f;
 			}
+		} else {
+			// Both left and right are NONE. Center.
+			vBounds.x = (bounds_.w - vBounds.w) / 2.0f + bounds_.x;
 		}
 
 		if (top > NONE) {
@@ -1282,6 +1285,9 @@ void AnchorLayout::Layout() {
 			vBounds.y = bounds_.y2() - bottom - vBounds.h;
 			if (center)
 				vBounds.y += vBounds.h * 0.5f;
+		} else {
+			// Both top and bottom are NONE. Center.
+			vBounds.y = (bounds_.h - vBounds.h) / 2.0f + bounds_.y;
 		}
 
 		views_[i]->SetBounds(vBounds);

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -123,6 +123,7 @@ public:
 
 	// These are not bounds, but distances from the container edges.
 	// Set to NONE to not attach this edge to the container.
+	// If two opposite edges are NONE, centering will happen.
 	float left, top, right, bottom;
 	bool center;  // If set, only two "sides" can be set, and they refer to the center, not the edge, of the view being layouted.
 

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -51,12 +51,6 @@ void LoadPostShaderInfo(Draw::DrawContext *draw, const std::vector<Path> &direct
 
 	shaderInfo.clear();
 
-	textureShaderInfo.clear();
-	TextureShaderInfo textureOff{};
-	textureOff.name = "Off";
-	textureOff.section = "Off";
-	textureShaderInfo.push_back(textureOff);
-
 	auto appendShader = [&](const ShaderInfo &info) {
 		auto beginErase = std::remove(shaderInfo.begin(), shaderInfo.end(), info.name);
 		if (beginErase != shaderInfo.end()) {
@@ -221,6 +215,7 @@ void LoadPostShaderInfo(Draw::DrawContext *draw, const std::vector<Path> &direct
 
 	// Sort shaders alphabetically.
 	std::sort(shaderInfo.begin(), shaderInfo.end());
+	std::sort(textureShaderInfo.begin(), textureShaderInfo.end());
 
 	ShaderInfo off{};
 	off.visible = true;
@@ -234,6 +229,12 @@ void LoadPostShaderInfo(Draw::DrawContext *draw, const std::vector<Path> &direct
 		off.settings[i].step = 0.01f;
 	}
 	shaderInfo.insert(shaderInfo.begin(), off);
+
+	textureShaderInfo.clear();
+	TextureShaderInfo textureOff{};
+	textureOff.name = "Off";
+	textureOff.section = "Off";
+	textureShaderInfo.push_back(textureOff);
 
 	// We always want the not visible ones at the end.  Makes menus easier.
 	for (const auto &info : notVisible) {

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -50,6 +50,7 @@ void LoadPostShaderInfo(Draw::DrawContext *draw, const std::vector<Path> &direct
 	}
 
 	shaderInfo.clear();
+	textureShaderInfo.clear();
 
 	auto appendShader = [&](const ShaderInfo &info) {
 		auto beginErase = std::remove(shaderInfo.begin(), shaderInfo.end(), info.name);
@@ -230,11 +231,10 @@ void LoadPostShaderInfo(Draw::DrawContext *draw, const std::vector<Path> &direct
 	}
 	shaderInfo.insert(shaderInfo.begin(), off);
 
-	textureShaderInfo.clear();
 	TextureShaderInfo textureOff{};
 	textureOff.name = "Off";
 	textureOff.section = "Off";
-	textureShaderInfo.push_back(textureOff);
+	textureShaderInfo.insert(textureShaderInfo.begin(), textureOff);
 
 	// We always want the not visible ones at the end.  Makes menus easier.
 	for (const auto &info : notVisible) {

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -50,18 +50,6 @@ void LoadPostShaderInfo(Draw::DrawContext *draw, const std::vector<Path> &direct
 	}
 
 	shaderInfo.clear();
-	ShaderInfo off{};
-	off.visible = true;
-	off.name = "Off";
-	off.section = "Off";
-	for (size_t i = 0; i < ARRAY_SIZE(off.settings); ++i) {
-		off.settings[i].name.clear();
-		off.settings[i].value = 0.0f;
-		off.settings[i].minValue = -1.0f;
-		off.settings[i].maxValue = 1.0f;
-		off.settings[i].step = 0.01f;
-	}
-	shaderInfo.push_back(off);
 
 	textureShaderInfo.clear();
 	TextureShaderInfo textureOff{};
@@ -230,6 +218,22 @@ void LoadPostShaderInfo(Draw::DrawContext *draw, const std::vector<Path> &direct
 			}
 		}
 	}
+
+	// Sort shaders alphabetically.
+	std::sort(shaderInfo.begin(), shaderInfo.end());
+
+	ShaderInfo off{};
+	off.visible = true;
+	off.name = "Off";
+	off.section = "Off";
+	for (size_t i = 0; i < ARRAY_SIZE(off.settings); ++i) {
+		off.settings[i].name.clear();
+		off.settings[i].value = 0.0f;
+		off.settings[i].minValue = -1.0f;
+		off.settings[i].maxValue = 1.0f;
+		off.settings[i].step = 0.01f;
+	}
+	shaderInfo.insert(shaderInfo.begin(), off);
 
 	// We always want the not visible ones at the end.  Makes menus easier.
 	for (const auto &info : notVisible) {

--- a/GPU/Common/PostShader.h
+++ b/GPU/Common/PostShader.h
@@ -60,16 +60,19 @@ struct ShaderInfo {
 	// TODO: Add support for all kinds of fun options like mapping the depth buffer,
 	// SRGB texture reads, etc.  prev shader?
 
-	bool operator == (const std::string &other) {
+	bool operator == (const std::string &other) const {
 		return name == other;
 	}
-	bool operator == (const ShaderInfo &other) {
+	bool operator == (const ShaderInfo &other) const {
 		return name == other.name;
 	}
 
-	bool operator < (const ShaderInfo &other) {
+	bool operator < (const ShaderInfo &other) const {
 		if (name < other.name) return true;
 		if (name > other.name) return false;
+		// Tie breaker
+		if (iniFile < other.iniFile) return true;
+		if (iniFile > other.iniFile) return false;
 		return false;
 	}
 };
@@ -84,11 +87,20 @@ struct TextureShaderInfo {
 	// Upscaling shaders have a fixed scale factor.
 	int scaleFactor;
 
-	bool operator == (const std::string &other) {
+	bool operator == (const std::string &other) const {
 		return name == other;
 	}
-	bool operator == (const TextureShaderInfo &other) {
+	bool operator == (const TextureShaderInfo &other) const {
 		return name == other.name;
+	}
+
+	bool operator < (const TextureShaderInfo &other) const {
+		if (name < other.name) return true;
+		if (name > other.name) return false;
+		// Tie breaker
+		if (iniFile < other.iniFile) return true;
+		if (iniFile > other.iniFile) return false;
+		return false;
 	}
 };
 

--- a/GPU/Common/PostShader.h
+++ b/GPU/Common/PostShader.h
@@ -66,6 +66,12 @@ struct ShaderInfo {
 	bool operator == (const ShaderInfo &other) {
 		return name == other.name;
 	}
+
+	bool operator < (const ShaderInfo &other) {
+		if (name < other.name) return true;
+		if (name > other.name) return false;
+		return false;
+	}
 };
 
 struct TextureShaderInfo {

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -267,6 +267,7 @@ void DisplayLayoutScreen::CreateViews() {
 		postProcChoice_->OnClick.Add([=](EventParams &e) {
 			auto gr = GetI18NCategory("Graphics");
 			auto procScreen = new PostProcScreen(gr->T("Postprocessing Shader"), i, false);
+			procScreen->SetHasDropShadow(false);
 			procScreen->OnChoice.Handle(this, &DisplayLayoutScreen::OnPostProcShaderChange);
 			if (e.v)
 				procScreen->SetPopupOrigin(e.v);

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -208,31 +208,31 @@ void DisplayLayoutScreen::CreateViews() {
 	rightScrollView->Add(rightColumn);
 	root_->Add(rightScrollView);
 
+	LinearLayout *bottomControls = new LinearLayout(ORIENT_HORIZONTAL, new AnchorLayoutParams(NONE, NONE, NONE, 10.0f, false));
+	root_->Add(bottomControls);
 
 	if (!IsVREnabled()) {
 		auto stretch = new CheckBox(&g_Config.bDisplayStretch, gr->T("Stretch"));
-		leftColumn->Add(stretch);
+		rightColumn->Add(stretch);
 
 		PopupSliderChoiceFloat *aspectRatio = new PopupSliderChoiceFloat(&g_Config.fDisplayAspectRatio, 0.5f, 2.0f, gr->T("Aspect Ratio"), screenManager());
-		leftColumn->Add(aspectRatio);
+		rightColumn->Add(aspectRatio);
 		aspectRatio->SetDisabledPtr(&g_Config.bDisplayStretch);
 		aspectRatio->SetHasDropShadow(false);
 		aspectRatio->SetLiveUpdate(true);
 
-		mode_ = new ChoiceStrip(ORIENT_VERTICAL);
+		mode_ = new ChoiceStrip(ORIENT_HORIZONTAL, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT));
 		mode_->AddChoice(di->T("Move"));
 		mode_->AddChoice(di->T("Resize"));
 		mode_->SetSelection(0, false);
-		leftColumn->Add(mode_);
+		bottomControls->Add(mode_);
 
 		static const char *displayRotation[] = { "Landscape", "Portrait", "Landscape Reversed", "Portrait Reversed" };
 		auto rotation = new PopupMultiChoice(&g_Config.iInternalScreenRotation, gr->T("Rotation"), displayRotation, 1, ARRAY_SIZE(displayRotation), co->GetName(), screenManager());
 		rotation->SetEnabledFunc([] {
 			return !g_Config.bSkipBufferEffects || g_Config.bSoftwareRendering;
 		});
-		leftColumn->Add(rotation);
-
-		leftColumn->Add(new Spacer(12.0f));
+		rightColumn->Add(rotation);
 
 		Choice *center = new Choice(di->T("Reset"));
 		center->OnClick.Add([&](UI::EventParams &) {
@@ -242,13 +242,19 @@ void DisplayLayoutScreen::CreateViews() {
 			g_Config.fDisplayOffsetY = 0.5f;
 			return UI::EVENT_DONE;
 		});
-		leftColumn->Add(center);
+		rightColumn->Add(center);
+
+		rightColumn->Add(new Spacer(12.0f));
 	}
 
-	static const char *bufFilters[] = { "Linear", "Nearest", };
-	rightColumn->Add(new PopupMultiChoice(&g_Config.iBufFilter, gr->T("Screen Scaling Filter"), bufFilters, 1, ARRAY_SIZE(bufFilters), gr->GetName(), screenManager()));
+	Choice *back = new Choice(di->T("Back"), "", false);
+	back->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
+	rightColumn->Add(back);
 
-	rightColumn->Add(new ItemHeader(gr->T("Postprocessing effect")));
+	static const char *bufFilters[] = { "Linear", "Nearest", };
+	leftColumn->Add(new PopupMultiChoice(&g_Config.iBufFilter, gr->T("Screen Scaling Filter"), bufFilters, 1, ARRAY_SIZE(bufFilters), gr->GetName(), screenManager()));
+
+	leftColumn->Add(new ItemHeader(gr->T("Postprocessing effect")));
 
 	Draw::DrawContext *draw = screenManager()->getDrawContext();
 
@@ -262,8 +268,8 @@ void DisplayLayoutScreen::CreateViews() {
 	for (int i = 0; i < (int)g_Config.vPostShaderNames.size() + 1 && i < ARRAY_SIZE(shaderNames_); ++i) {
 		// Vector element pointer get invalidated on resize, cache name to have always a valid reference in the rendering thread
 		shaderNames_[i] = i == g_Config.vPostShaderNames.size() ? "Off" : g_Config.vPostShaderNames[i];
-		rightColumn->Add(new ItemHeader(StringFromFormat("%s #%d", gr->T("Postprocessing Shader"), i + 1)));
-		postProcChoice_ = rightColumn->Add(new ChoiceWithValueDisplay(&shaderNames_[i], "", &PostShaderTranslateName));
+		leftColumn->Add(new ItemHeader(StringFromFormat("%s #%d", gr->T("Postprocessing Shader"), i + 1)));
+		postProcChoice_ = leftColumn->Add(new ChoiceWithValueDisplay(&shaderNames_[i], "", &PostShaderTranslateName));
 		postProcChoice_->OnClick.Add([=](EventParams &e) {
 			auto gr = GetI18NCategory("Graphics");
 			auto procScreen = new PostProcScreen(gr->T("Postprocessing Shader"), i, false);
@@ -293,10 +299,10 @@ void DisplayLayoutScreen::CreateViews() {
 					auto &value = g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderInfo->section.c_str(), i + 1)];
 					if (duplicated) {
 						auto sliderName = StringFromFormat("%s %s", ps->T(setting.name), ps->T("(duplicated setting, previous slider will be used)"));
-						PopupSliderChoiceFloat *settingValue = rightColumn->Add(new PopupSliderChoiceFloat(&value, setting.minValue, setting.maxValue, sliderName, setting.step, screenManager()));
+						PopupSliderChoiceFloat *settingValue = leftColumn->Add(new PopupSliderChoiceFloat(&value, setting.minValue, setting.maxValue, sliderName, setting.step, screenManager()));
 						settingValue->SetEnabled(false);
 					} else {
-						PopupSliderChoiceFloat *settingValue = rightColumn->Add(new PopupSliderChoiceFloat(&value, setting.minValue, setting.maxValue, ps->T(setting.name), setting.step, screenManager()));
+						PopupSliderChoiceFloat *settingValue = leftColumn->Add(new PopupSliderChoiceFloat(&value, setting.minValue, setting.maxValue, ps->T(setting.name), setting.step, screenManager()));
 						settingValue->SetLiveUpdate(true);
 						settingValue->SetHasDropShadow(false);
 						settingValue->SetEnabledFunc([=] {
@@ -307,10 +313,6 @@ void DisplayLayoutScreen::CreateViews() {
 			}
 		}
 	}
-
-	Choice *back = new Choice(di->T("Back"), "", false);
-	back->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
-	rightColumn->Add(back);
 
 	root_->Add(new DisplayLayoutBackground(mode_, new AnchorLayoutParams(FILL_PARENT, FILL_PARENT, 0.0f, 0.0f, 0.0f, 0.0f)));
 }

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -305,6 +305,11 @@ void GameSettingsScreen::CreateViews() {
 		return !g_Config.bSoftwareRendering && !g_Config.bSkipBufferEffects;
 	});
 
+	if (deviceType != DEVICE_TYPE_VR) {
+		CheckBox *softwareGPU = graphicsSettings->Add(new CheckBox(&g_Config.bSoftwareRendering, gr->T("Software Rendering", "Software Rendering (slow)")));
+		softwareGPU->SetEnabled(!PSP_IsInited());
+	}
+
 	if (draw->GetDeviceCaps().multiSampleLevelsMask != 1) {
 		static const char *msaaModes[] = { "Off", "2x", "4x", "8x", "16x" };
 		auto msaaChoice = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iMultiSampleLevel, gr->T("Antialiasing (MSAA)"), msaaModes, 0, ARRAY_SIZE(msaaModes), gr->GetName(), screenManager()));
@@ -312,6 +317,8 @@ void GameSettingsScreen::CreateViews() {
 			NativeMessageReceived("gpu_renderResized", "");
 			return UI::EVENT_DONE;
 		});
+		msaaChoice->SetDisabledPtr(&g_Config.bSoftwareRendering);
+
 		// Hide unsupported levels.
 		for (int i = 1; i < 5; i++) {
 			if ((draw->GetDeviceCaps().multiSampleLevelsMask & (1 << i)) == 0) {
@@ -331,11 +338,6 @@ void GameSettingsScreen::CreateViews() {
 		hwscale->OnChoice.Handle(this, &GameSettingsScreen::OnHwScaleChange);  // To refresh the display mode
 	}
 #endif
-
-	if (deviceType != DEVICE_TYPE_VR) {
-		CheckBox *softwareGPU = graphicsSettings->Add(new CheckBox(&g_Config.bSoftwareRendering, gr->T("Software Rendering", "Software Rendering (slow)")));
-		softwareGPU->SetEnabled(!PSP_IsInited());
-	}
 
 	if (deviceType != DEVICE_TYPE_VR) {
 #if !defined(MOBILE_DEVICE)

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1128,7 +1128,7 @@ void MainScreen::CreateViews() {
 #endif
 
 	rightColumnItems->Add(logos);
-	TextView *ver = rightColumnItems->Add(new TextView(versionString, new LinearLayoutParams(Margins(70, -6, 0, 0))));
+	TextView *ver = rightColumnItems->Add(new TextView(versionString, new LinearLayoutParams(Margins(70, -10, 0, 4))));
 	ver->SetSmall(true);
 	ver->SetClip(false);
 


### PR DESCRIPTION
Move post shaders to the left and the main settings to the right. This makes sure that the back button always is in exactly the same position (won't move by adding post shaders), and feels more logical (after getting used to it)..

Move/Resize selector is moved to the bottom.

Also, post shaders are now sorted alphabetically in the list.

Next step after this will be to redo the post shader list to be more user-friendly and compact.

![image](https://user-images.githubusercontent.com/130929/205455841-d4cd604f-8281-482a-b60b-608d8151e139.png)
