### PR TITLE
Force "Lower resolution for effects" off in Ratchet & Clank and a few other games

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -116,6 +116,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "DeswizzleDepth", &flags_.DeswizzleDepth);
 	CheckSetting(iniFile, gameID, "SplitFramebufferMargin", &flags_.SplitFramebufferMargin);
 	CheckSetting(iniFile, gameID, "ForceLowerResolutionForEffectsOn", &flags_.ForceLowerResolutionForEffectsOn);
+	CheckSetting(iniFile, gameID, "ForceLowerResolutionForEffectsOff", &flags_.ForceLowerResolutionForEffectsOff);
 	CheckSetting(iniFile, gameID, "AllowDownloadCLUT", &flags_.AllowDownloadCLUT);
 	CheckSetting(iniFile, gameID, "NearestFilteringOnFramebufferCreate", &flags_.NearestFilteringOnFramebufferCreate);
 	CheckSetting(iniFile, gameID, "SecondaryTextureCache", &flags_.SecondaryTextureCache);

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -87,6 +87,7 @@ struct CompatFlags {
 	bool DeswizzleDepth;
 	bool SplitFramebufferMargin;
 	bool ForceLowerResolutionForEffectsOn;
+	bool ForceLowerResolutionForEffectsOff;
 	bool AllowDownloadCLUT;
 	bool NearestFilteringOnFramebufferCreate;
 	bool SecondaryTextureCache;

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -91,7 +91,12 @@ void FramebufferManagerCommon::Init() {
 bool FramebufferManagerCommon::UpdateRenderSize() {
 	const bool newRender = renderWidth_ != (float)PSP_CoreParameter().renderWidth || renderHeight_ != (float)PSP_CoreParameter().renderHeight || msaaLevel_ != g_Config.iMultiSampleLevel;
 
-	const int effectiveBloomHack = PSP_CoreParameter().compat.flags().ForceLowerResolutionForEffectsOn ? 3 : g_Config.iBloomHack;
+	int effectiveBloomHack = g_Config.iBloomHack;
+	if (PSP_CoreParameter().compat.flags().ForceLowerResolutionForEffectsOn) {
+		effectiveBloomHack = 3;
+	} else if (PSP_CoreParameter().compat.flags().ForceLowerResolutionForEffectsOff) {
+		effectiveBloomHack = 0;
+	}
 
 	bool newBuffered = !g_Config.bSkipBufferEffects;
 	const bool newSettings = bloomHack_ != effectiveBloomHack || useBufferedRendering_ != newBuffered;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1259,7 +1259,18 @@ ULUS10429 = true
 ULES00280 = true
 ULUS10092 = true
 
-# Also, it's a really bad idea in Kurohyou
+# Also, it's a really bad idea in Kurohyou.
+
+# Kurohyou: Ryu ga Gotoku Shinshou
+ULJM05713 = true
+NPJH50333 = true
+ULAS42244 = true
+UCKS45159 = true
+ULJM08047 = true
+
+# Kurohyou 2: Ryu ga Gotoku Ashura Hen (Japan)
+NPJH50562 = true
+NPJH50333 = true
 
 [NearestFilteringOnFramebufferCreate]
 # Ridge Racer speedometer dynamic CLUT problem - they rely on some palette entries

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -622,6 +622,8 @@ ULJM05570 = true
 
 # Cars Race-o-rama
 ULUS10428 = true
+ULES01333 = true
+
 # MX vs ATV Reflex
 ULES01375 = true
 ULUS10429 = true
@@ -1230,6 +1232,34 @@ UCES01250 = true
 UCKS45124 = true
 UCJS10104 = true
 NPJG00047 = true
+
+[ForceLowerResolutionForEffectsOff]
+# Some games really don't work with this. Ratchet & Clank looks terrible.
+UCUS98633 = true
+UCAS40145 = true
+UCES00420 = true
+UCJS10052 = true
+UCKS45048 = true
+UCES00420 = true
+UCJS18030 = true
+UCJS18047 = true
+NPJG00015 = true
+
+# The various Tantalus games will not work with this.
+
+# Cars Race-o-rama
+ULUS10428 = true
+ULES01333 = true
+
+# MX vs ATV Reflex
+ULES01375 = true
+ULUS10429 = true
+
+# Spongebob: The Yellow Avenger
+ULES00280 = true
+ULUS10092 = true
+
+# Also, it's a really bad idea in Kurohyou
 
 [NearestFilteringOnFramebufferCreate]
 # Ridge Racer speedometer dynamic CLUT problem - they rely on some palette entries


### PR DESCRIPTION
It breaks or just makes things look terrible in these games, so no reason to allow it.

An alternative for this would be to remove the option entirely, and only use it though the ForceLowerResolutionForEffectsOn flag instead... Might be reasonable.