### PR TITLE
OpenGL: Pool small textures, reuse handles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,6 +626,8 @@ add_library(Common STATIC
 	Common/GPU/OpenGL/GLFeatures.cpp
 	Common/GPU/OpenGL/GLFeatures.h
 	Common/GPU/OpenGL/thin3d_gl.cpp
+	Common/GPU/OpenGL/GLTexture.cpp
+	Common/GPU/OpenGL/GLTexture.h
 	Common/GPU/OpenGL/GLRenderManager.cpp
 	Common/GPU/OpenGL/GLRenderManager.h
 	Common/GPU/OpenGL/GLQueueRunner.cpp

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -441,6 +441,7 @@
     <ClInclude Include="GPU\OpenGL\GLSLProgram.h" />
     <ClInclude Include="GPU\OpenGL\GLCommon.h" />
     <ClInclude Include="GPU\OpenGL\GLDebugLog.h" />
+    <ClInclude Include="GPU\OpenGL\GLTexture.h" />
     <ClInclude Include="GPU\Shader.h" />
     <ClInclude Include="GPU\ShaderTranslation.h" />
     <ClInclude Include="GPU\ShaderWriter.h" />
@@ -873,6 +874,7 @@
     <ClCompile Include="GPU\OpenGL\GLRenderManager.cpp" />
     <ClCompile Include="GPU\OpenGL\GLSLProgram.cpp" />
     <ClCompile Include="GPU\OpenGL\GLDebugLog.cpp" />
+    <ClCompile Include="GPU\OpenGL\GLTexture.cpp" />
     <ClCompile Include="GPU\OpenGL\thin3d_gl.cpp" />
     <ClCompile Include="GPU\Shader.cpp" />
     <ClCompile Include="GPU\ShaderTranslation.cpp" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -458,6 +458,9 @@
     <ClInclude Include="GPU\Vulkan\VulkanFramebuffer.h">
       <Filter>GPU\Vulkan</Filter>
     </ClInclude>
+    <ClInclude Include="GPU\OpenGL\GLTexture.h">
+      <Filter>GPU\OpenGL</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />
@@ -865,6 +868,9 @@
     </ClCompile>
     <ClCompile Include="GPU\Vulkan\VulkanFramebuffer.cpp">
       <Filter>GPU\Vulkan</Filter>
+    </ClCompile>
+    <ClCompile Include="GPU\OpenGL\GLTexture.cpp">
+      <Filter>GPU\OpenGL</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Common/GPU/MiscTypes.h
+++ b/Common/GPU/MiscTypes.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "Common/Common.h"
 
 enum class InvalidationFlags {

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -78,7 +78,6 @@ void GLQueueRunner::CreateDeviceObjects() {
 
 void GLQueueRunner::DestroyDeviceObjects() {
 	CHECK_GL_ERROR_IF_DEBUG();
-	texPool_.Clear();
 	if (gl_extensions.ARB_vertex_array_object) {
 		glDeleteVertexArrays(1, &globalVAO_);
 	}
@@ -88,6 +87,7 @@ void GLQueueRunner::DestroyDeviceObjects() {
 	delete[] tempBuffer_;
 	tempBuffer_ = nullptr;
 	tempBufferSize_ = 0;
+	texPool_.Clear();
 	CHECK_GL_ERROR_IF_DEBUG();
 }
 
@@ -492,6 +492,8 @@ void GLQueueRunner::InitCreateFramebuffer(const GLRInitStep &step) {
 		// To improve the pool lookup.
 		tex.w = fbo->width;
 		tex.h = fbo->height;
+		tex.numMips = 1;
+		tex.isRenderTarget = true;
 
 		texPool_.Allocate(&tex);
 		tex.target = GL_TEXTURE_2D;
@@ -1639,6 +1641,8 @@ void GLQueueRunner::fbo_ext_create(const GLRInitStep &step) {
 	glGenFramebuffersEXT(1, &fbo->handle);
 	fbo->color_texture.w = fbo->width;
 	fbo->color_texture.h = fbo->height;
+	fbo->color_texture.numMips = 1;
+	fbo->color_texture.isRenderTarget = true;
 	texPool_.Allocate(&fbo->color_texture);
 
 	// Create the surfaces.

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -78,10 +78,7 @@ void GLQueueRunner::CreateDeviceObjects() {
 
 void GLQueueRunner::DestroyDeviceObjects() {
 	CHECK_GL_ERROR_IF_DEBUG();
-	if (!nameCache_.empty()) {
-		glDeleteTextures((GLsizei)nameCache_.size(), &nameCache_[0]);
-		nameCache_.clear();
-	}
+	texPool_.Clear();
 	if (gl_extensions.ARB_vertex_array_object) {
 		glDeleteVertexArrays(1, &globalVAO_);
 	}
@@ -179,7 +176,7 @@ void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps, bool ski
 		case GLRInitStepType::CREATE_TEXTURE:
 		{
 			GLRTexture *tex = step.create_texture.texture;
-			glGenTextures(1, &tex->texture);
+			texPool_.Create(tex);
 			glBindTexture(tex->target, tex->texture);
 			boundTexture = tex->texture;
 			CHECK_GL_ERROR_IF_DEBUG();
@@ -1623,17 +1620,6 @@ void GLQueueRunner::CopyReadbackBuffer(int width, int height, Draw::DataFormat s
 	for (int y = 0; y < height; y++) {
 		memcpy(pixels + y * pixelStride * bpp, readbackBuffer_ + y * width * bpp, width * bpp);
 	}
-}
-
-GLuint GLQueueRunner::AllocTextureName() {
-	if (nameCache_.empty()) {
-		nameCache_.resize(TEXCACHE_NAME_CACHE_SIZE);
-		glGenTextures(TEXCACHE_NAME_CACHE_SIZE, &nameCache_[0]);
-	}
-	u32 name = nameCache_.back();
-	nameCache_.pop_back();
-	CHECK_GL_ERROR_IF_DEBUG();
-	return name;
 }
 
 // On PC, we always use GL_DEPTH24_STENCIL8. 

--- a/Common/GPU/OpenGL/GLQueueRunner.h
+++ b/Common/GPU/OpenGL/GLQueueRunner.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 
 #include "Common/GPU/OpenGL/GLCommon.h"
+#include "Common/GPU/OpenGL/GLTexture.h"
 #include "Common/GPU/DataFormat.h"
 #include "Common/GPU/Shader.h"
 #include "Common/GPU/thin3d.h"
@@ -429,10 +430,6 @@ private:
 	GLuint currentDrawHandle_ = 0;
 	GLuint currentReadHandle_ = 0;
 
-	GLuint AllocTextureName();
-
-	// Texture name cache. Ripped straight from TextureCacheGLES.
-	std::vector<GLuint> nameCache_;
 	std::unordered_map<int, std::string> glStrings_;
 
 	bool sawOutOfMemory_ = false;
@@ -440,4 +437,6 @@ private:
 
 	ErrorCallbackFn errorCallback_ = nullptr;
 	void *errorCallbackUserData_ = nullptr;
+
+	GLRTexturePool texPool_;
 };

--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -93,6 +93,8 @@ void GLDeleter::Perform(GLRenderManager *renderManager, bool skipGLCalls) {
 }
 
 GLRenderManager::~GLRenderManager() {
+	queueRunner_.DestroyDeviceObjects();
+
 	for (int i = 0; i < MAX_INFLIGHT_FRAMES; i++) {
 		_assert_(frameData_[i].deleter.IsEmpty());
 		_assert_(frameData_[i].deleter_prev.IsEmpty());
@@ -152,7 +154,6 @@ void GLRenderManager::ThreadEnd() {
 
 	// Wait for any shutdown to complete in StopThread().
 	std::unique_lock<std::mutex> lock(mutex_);
-	queueRunner_.DestroyDeviceObjects();
 	VLOG("PULL: Quitting");
 
 	// Good point to run all the deleters to get rid of leftover objects.

--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -7,7 +7,6 @@
 
 #include "Common/Log.h"
 #include "Common/MemoryUtil.h"
-#include "Common/Math/math_util.h"
 
 #if 0 // def _DEBUG
 #define VLOG(...) INFO_LOG(G3D, __VA_ARGS__)
@@ -21,24 +20,6 @@ static bool OnRenderThread() {
 	return std::this_thread::get_id() == renderThreadId;
 }
 #endif
-
-GLRTexture::GLRTexture(const Draw::DeviceCaps &caps, int width, int height, int depth, int numMips) {
-	if (caps.textureNPOTFullySupported) {
-		canWrap = true;
-	} else {
-		canWrap = isPowerOf2(width) && isPowerOf2(height);
-	}
-	w = width;
-	h = height;
-	d = depth;
-	this->numMips = numMips;
-}
-
-GLRTexture::~GLRTexture() {
-	if (texture) {
-		glDeleteTextures(1, &texture);
-	}
-}
 
 void GLDeleter::Take(GLDeleter &other) {
 	_assert_msg_(IsEmpty(), "Deleter already has stuff");

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -337,8 +337,6 @@ public:
 	int semanticsMask_ = 0;
 };
 
-class GLRTexturePool;
-
 // Note: The GLRenderManager is created and destroyed on the render thread, and the latter
 // happens after the emu thread has been destroyed. Therefore, it's safe to run wild deleting stuff
 // directly in the destructor.
@@ -1049,8 +1047,6 @@ private:
 	GLRProgram *curProgram_ = nullptr;
 #endif
 	Draw::DeviceCaps caps_{};
-
-	GLRTexturePool *texPool_;
 
 	InvalidationCallback invalidationCallback_;
 };

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -14,6 +14,7 @@
 #include "Common/Data/Convert/SmallDataConvert.h"
 #include "Common/Log.h"
 #include "GLQueueRunner.h"
+#include "Common/GPU/OpenGL/GLTexture.h"
 
 class GLRInputLayout;
 class GLPushBuffer;
@@ -23,30 +24,6 @@ class DrawContext;
 }
 
 constexpr int MAX_GL_TEXTURE_SLOTS = 8;
-
-class GLRTexture {
-public:
-	GLRTexture(const Draw::DeviceCaps &caps, int width, int height, int depth, int numMips);
-	~GLRTexture();
-
-	GLuint texture = 0;
-	uint16_t w;
-	uint16_t h;
-	uint16_t d;
-
-	// We don't trust OpenGL defaults - setting wildly off values ensures that we'll end up overwriting these parameters.
-	GLenum target = 0xFFFF;
-	GLenum wrapS = 0xFFFF;
-	GLenum wrapT = 0xFFFF;
-	GLenum magFilter = 0xFFFF;
-	GLenum minFilter = 0xFFFF;
-	uint8_t numMips = 0;
-	bool canWrap = true;
-	float anisotropy = -100000.0f;
-	float minLod = -1000.0f;
-	float maxLod = 1000.0f;
-	float lodBias = 0.0f;
-};
 
 class GLRFramebuffer {
 public:
@@ -74,7 +51,6 @@ public:
 
 // We need to create some custom heap-allocated types so we can forward things that need to be created on the GL thread, before
 // they've actually been created.
-
 class GLRShader {
 public:
 	~GLRShader() {
@@ -360,6 +336,8 @@ public:
 	std::vector<Entry> entries;
 	int semanticsMask_ = 0;
 };
+
+class GLRTexturePool;
 
 // Note: The GLRenderManager is created and destroyed on the render thread, and the latter
 // happens after the emu thread has been destroyed. Therefore, it's safe to run wild deleting stuff
@@ -1071,6 +1049,8 @@ private:
 	GLRProgram *curProgram_ = nullptr;
 #endif
 	Draw::DeviceCaps caps_{};
+
+	GLRTexturePool *texPool_;
 
 	InvalidationCallback invalidationCallback_;
 };

--- a/Common/GPU/OpenGL/GLTexture.cpp
+++ b/Common/GPU/OpenGL/GLTexture.cpp
@@ -1,21 +1,76 @@
 #include "Common/GPU/OpenGL/GLTexture.h"
 #include "Common/GPU/thin3d.h"
 #include "Common/Math/math_util.h"
+#include "Common/Log.h"
 
-GLRTexture::GLRTexture(const Draw::DeviceCaps &caps, int width, int height, int depth, int numMips) {
+GLRTexture::GLRTexture(const Draw::DeviceCaps &caps, int width, int height, int depth, int _numMips)
+	: w(width), h(height), d(depth), numMips(_numMips) {
 	if (caps.textureNPOTFullySupported) {
 		canWrap = true;
 	} else {
 		canWrap = isPowerOf2(width) && isPowerOf2(height);
 	}
-	w = width;
-	h = height;
-	d = depth;
-	this->numMips = numMips;
 }
 
 GLRTexture::~GLRTexture() {
-	if (texture) {
+	if (texPool_) {
+		texPool_->MoveToPoolFromDestructor(this);
+	} else {
 		glDeleteTextures(1, &texture);
 	}
+}
+
+#define SMALL_TEX_SIDE 32
+
+GLRTexturePool::~GLRTexturePool() {
+	_dbg_assert_(pool_.empty());
+}
+
+void GLRTexturePool::Create(GLRTexture *newTexture) {
+	_dbg_assert_(!newTexture->texture);
+	if (newTexture->w * newTexture->h <= SMALL_TEX_SIDE * SMALL_TEX_SIDE) {
+		// Mark for recycling later.
+		newTexture->texPool_ = this;
+
+		// We'll grab a same-sized handle from the pool if available.
+		// Loop backwards to make the erase cheaper.
+		for (auto p = pool_.rbegin(), end = pool_.rend(); p != end; p++) {
+			if (p->w == newTexture->w && p->h == newTexture->h) {
+				// Match, perfect. Remove from pool.
+				newTexture->texture = p->texture;
+				// Strange idiom, but that's what you have to do to erase a reverse iterator.
+				pool_.erase(std::next(p).base());
+				return;
+			}
+		}
+
+		// Didn't find a perfect match. Try for imperfect.
+		if (!newTexture->texture && !pool_.empty()) {
+			// Just grab the last entry in the pool.
+			auto p = pool_.back();
+			newTexture->texture = p.texture;
+			pool_.pop_back();
+			return;
+		}
+
+		// Didn't find anything to reuse, fall through.
+	}
+
+	// We simply need a new handle.
+	glGenTextures(1, &newTexture->texture);
+}
+
+void GLRTexturePool::MoveToPoolFromDestructor(GLRTexture *texture) {
+	pool_.push_back(PooledTexture{
+		texture->texture,
+		texture->w,
+		texture->h,
+	});
+}
+
+void GLRTexturePool::Clear() {
+	for (auto &p : pool_) {
+		glDeleteTextures(1, &p.texture);
+	}
+	pool_.clear();
 }

--- a/Common/GPU/OpenGL/GLTexture.cpp
+++ b/Common/GPU/OpenGL/GLTexture.cpp
@@ -1,0 +1,21 @@
+#include "Common/GPU/OpenGL/GLTexture.h"
+#include "Common/GPU/thin3d.h"
+#include "Common/Math/math_util.h"
+
+GLRTexture::GLRTexture(const Draw::DeviceCaps &caps, int width, int height, int depth, int numMips) {
+	if (caps.textureNPOTFullySupported) {
+		canWrap = true;
+	} else {
+		canWrap = isPowerOf2(width) && isPowerOf2(height);
+	}
+	w = width;
+	h = height;
+	d = depth;
+	this->numMips = numMips;
+}
+
+GLRTexture::~GLRTexture() {
+	if (texture) {
+		glDeleteTextures(1, &texture);
+	}
+}

--- a/Common/GPU/OpenGL/GLTexture.cpp
+++ b/Common/GPU/OpenGL/GLTexture.cpp
@@ -1,4 +1,5 @@
 #include "Common/GPU/OpenGL/GLTexture.h"
+#include "Common/GPU/OpenGL/GLFeatures.h"
 #include "Common/GPU/thin3d.h"
 #include "Common/Math/math_util.h"
 #include "Common/Log.h"
@@ -13,47 +14,52 @@ GLRTexture::GLRTexture(const Draw::DeviceCaps &caps, int width, int height, int 
 }
 
 GLRTexture::~GLRTexture() {
-	if (texPool_) {
-		texPool_->MoveToPoolFromDestructor(this);
-	} else {
-		glDeleteTextures(1, &texture);
+	// GLRFramebuffer can contain unused, uninitialized GLRTexture-s so need
+	// to check texture here.
+	if (texture) {
+		if (texPool_) {
+			texPool_->MoveToPoolFromDestructor(this);
+		} else {
+			glDeleteTextures(1, &texture);
+		}
 	}
 }
 
-#define SMALL_TEX_SIDE 32
+#define SMALL_TEX_SIDE 64
+
+inline bool IsSmall(int w, int h) {
+	return w * h <= SMALL_TEX_SIDE * SMALL_TEX_SIDE;
+}
+
 
 GLRTexturePool::~GLRTexturePool() {
 	_dbg_assert_(pool_.empty());
 }
 
-void GLRTexturePool::Create(GLRTexture *newTexture) {
+void GLRTexturePool::Allocate(GLRTexture *newTexture) {
 	_dbg_assert_(!newTexture->texture);
-	if (newTexture->w * newTexture->h <= SMALL_TEX_SIDE * SMALL_TEX_SIDE) {
-		// Mark for recycling later.
-		newTexture->texPool_ = this;
 
-		// We'll grab a same-sized handle from the pool if available.
-		// Loop backwards to make the erase cheaper.
-		for (auto p = pool_.rbegin(), end = pool_.rend(); p != end; p++) {
-			if (p->w == newTexture->w && p->h == newTexture->h) {
-				// Match, perfect. Remove from pool.
-				newTexture->texture = p->texture;
-				// Strange idiom, but that's what you have to do to erase a reverse iterator.
-				pool_.erase(std::next(p).base());
-				return;
-			}
-		}
+	newTexture->texPool_ = this;
 
-		// Didn't find a perfect match. Try for imperfect.
-		if (!newTexture->texture && !pool_.empty()) {
-			// Just grab the last entry in the pool.
-			auto p = pool_.back();
-			newTexture->texture = p.texture;
-			pool_.pop_back();
+	// We'll grab a same-sized handle from the pool if available.
+	// Loop backwards to make the erase cheaper.
+	for (auto p = pool_.rbegin(), end = pool_.rend(); p != end; p++) {
+		if (p->w == newTexture->w && p->h == newTexture->h) {
+			// Match, perfect. Remove from pool.
+			newTexture->texture = p->texture;
+			// Strange idiom, but that's what you have to do to erase a reverse iterator.
+			pool_.erase(std::next(p).base());
 			return;
 		}
+	}
 
-		// Didn't find anything to reuse, fall through.
+	// Didn't find a perfect match. Try for imperfect.
+	if (!newTexture->texture && !pool_.empty()) {
+		// Just grab the last entry in the pool.
+		auto p = pool_.back();
+		newTexture->texture = p.texture;
+		pool_.pop_back();
+		return;
 	}
 
 	// We simply need a new handle.
@@ -61,6 +67,13 @@ void GLRTexturePool::Create(GLRTexture *newTexture) {
 }
 
 void GLRTexturePool::MoveToPoolFromDestructor(GLRTexture *texture) {
+	if (!IsSmall(texture->w, texture->h)) {
+		// Shrink the texture right down to nothing, to save memory without destroying.
+		glBindTexture(GL_TEXTURE_2D, texture->texture);
+		uint32_t pixel = 0xFFFF00FF;
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, &pixel);
+	}
+
 	pool_.push_back(PooledTexture{
 		texture->texture,
 		texture->w,

--- a/Common/GPU/OpenGL/GLTexture.h
+++ b/Common/GPU/OpenGL/GLTexture.h
@@ -1,0 +1,31 @@
+#pragma once
+
+// Textures
+
+#include "Common/GPU/OpenGL/GLCommon.h"
+#include "Common/GPU/MiscTypes.h"
+#include "Common/GPU/thin3d.h"
+
+class GLRTexture {
+public:
+	GLRTexture(const Draw::DeviceCaps &caps, int width, int height, int depth, int numMips);
+	~GLRTexture();
+
+	GLuint texture = 0;
+	uint16_t w;
+	uint16_t h;
+	uint16_t d;
+
+	// We don't trust OpenGL defaults - setting wildly off values ensures that we'll end up overwriting these parameters.
+	GLenum target = 0xFFFF;
+	GLenum wrapS = 0xFFFF;
+	GLenum wrapT = 0xFFFF;
+	GLenum magFilter = 0xFFFF;
+	GLenum minFilter = 0xFFFF;
+	uint8_t numMips = 0;
+	bool canWrap = true;
+	float anisotropy = -100000.0f;
+	float minLod = -1000.0f;
+	float maxLod = 1000.0f;
+	float lodBias = 0.0f;
+};

--- a/Common/GPU/OpenGL/GLTexture.h
+++ b/Common/GPU/OpenGL/GLTexture.h
@@ -1,10 +1,11 @@
 #pragma once
 
 // Textures
-
 #include "Common/GPU/OpenGL/GLCommon.h"
 #include "Common/GPU/MiscTypes.h"
 #include "Common/GPU/thin3d.h"
+
+class GLRTexturePool;
 
 class GLRTexture {
 public:
@@ -28,4 +29,31 @@ public:
 	float minLod = -1000.0f;
 	float maxLod = 1000.0f;
 	float lodBias = 0.0f;
+
+private:
+	GLRTexturePool *texPool_ = nullptr;
+
+	// Ugh, but the best option here.
+	friend class GLRTexturePool;
+};
+
+struct PooledTexture {
+	GLuint texture;
+	uint16_t w;
+	uint16_t h;
+};
+
+// Managed by queuerunner, everything is done from GL submit thread.
+class GLRTexturePool {
+public:
+	~GLRTexturePool();
+
+	// Called from GL submit thread
+	void Create(GLRTexture *texture);
+	void MoveToPoolFromDestructor(GLRTexture *texture);
+
+	void Clear();
+
+private:
+	std::vector<PooledTexture> pool_;
 };

--- a/Common/GPU/OpenGL/GLTexture.h
+++ b/Common/GPU/OpenGL/GLTexture.h
@@ -24,6 +24,7 @@ public:
 	GLenum magFilter = 0xFFFF;
 	GLenum minFilter = 0xFFFF;
 	uint8_t numMips = 0;
+	bool isRenderTarget = false;
 	bool canWrap = true;
 	float anisotropy = -100000.0f;
 	float minLod = -1000.0f;
@@ -41,6 +42,8 @@ struct PooledTexture {
 	GLuint texture;
 	uint16_t w;
 	uint16_t h;
+	uint8_t numMips;
+	bool isRenderTarget;
 };
 
 // Managed by queuerunner, everything is done from GL submit thread.

--- a/Common/GPU/OpenGL/GLTexture.h
+++ b/Common/GPU/OpenGL/GLTexture.h
@@ -49,7 +49,7 @@ public:
 	~GLRTexturePool();
 
 	// Called from GL submit thread
-	void Create(GLRTexture *texture);
+	void Allocate(GLRTexture *texture);
 	void MoveToPoolFromDestructor(GLRTexture *texture);
 
 	void Clear();

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -292,9 +292,9 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 	}
 
 	if (plan.depth == 1) {
-		entry->textureName = render_->CreateTexture(GL_TEXTURE_2D, tw, tw, 1, plan.levelsToCreate);
+		entry->textureName = render_->CreateTexture(GL_TEXTURE_2D, tw, th, 1, plan.levelsToCreate);
 	} else {
-		entry->textureName = render_->CreateTexture(GL_TEXTURE_3D, tw, tw, plan.depth, 1);
+		entry->textureName = render_->CreateTexture(GL_TEXTURE_3D, tw, th, plan.depth, 1);
 	}
 
 	if (plan.depth == 1) {

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -270,12 +270,6 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 		dstFmt = Draw::DataFormat::R8_UNORM;
 	}
 
-	if (plan.depth == 1) {
-		entry->textureName = render_->CreateTexture(GL_TEXTURE_2D, tw, tw, 1, plan.levelsToCreate);
-	} else {
-		entry->textureName = render_->CreateTexture(GL_TEXTURE_3D, tw, tw, plan.depth, 1);
-	}
-
 	// Apply some additional compatibility checks.
 	if (plan.levelsToLoad > 1) {
 		// Avoid PowerVR driver bug
@@ -295,6 +289,12 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 			plan.levelsToLoad = 1;
 			entry->status |= TexCacheEntry::STATUS_NO_MIPS;
 		}
+	}
+
+	if (plan.depth == 1) {
+		entry->textureName = render_->CreateTexture(GL_TEXTURE_2D, tw, tw, 1, plan.levelsToCreate);
+	} else {
+		entry->textureName = render_->CreateTexture(GL_TEXTURE_3D, tw, tw, plan.depth, 1);
 	}
 
 	if (plan.depth == 1) {

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -40,6 +40,7 @@ NATIVE_FILES :=\
   $(SRC)/Common/GPU/OpenGL/GLFeatures.cpp \
   $(SRC)/Common/GPU/OpenGL/GLRenderManager.cpp \
   $(SRC)/Common/GPU/OpenGL/GLQueueRunner.cpp \
+  $(SRC)/Common/GPU/OpenGL/GLTexture.cpp \
   $(SRC)/Common/GPU/OpenGL/DataFormatGL.cpp
 
 EGL_FILES := \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -253,6 +253,7 @@ SOURCES_CXX += \
 	$(COMMONDIR)/GPU/OpenGL/GLFeatures.cpp \
 	$(COMMONDIR)/GPU/OpenGL/GLRenderManager.cpp \
 	$(COMMONDIR)/GPU/OpenGL/GLQueueRunner.cpp \
+	$(COMMONDIR)/GPU/OpenGL/GLTexture.cpp \
 	$(COMMONDIR)/GPU/OpenGL/DataFormatGL.cpp \
 	$(COMMONDIR)/GPU/Vulkan/thin3d_vulkan.cpp \
 	$(COMMONDIR)/GPU/Vulkan/VulkanQueueRunner.cpp \


### PR DESCRIPTION
Will hopefully work as a cleaner replacement for #16399  (Gran Turismo crashfix for Quest 2).

I guess we could periodically shrink the pool too, but since all textures in it are small, not sure it's worth the trouble.

This also deletes the unused nameCache_.