### PR TITLE
Build: Use Windows 2019 for UWP builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,8 +69,7 @@ jobs:
         path: ppsspp/
 
   build-uwp:
-    if: ${{false}}  # Temporarily disable
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
This re-enables the UWP build, for now using Windows 2019 runners, since they're still able to link.  I think it's a problem with the std::filesystem library implementation on the latest Visual Studio update on the 2022 runners, or something.

-[Unknown]