### PR TITLE
Fix the Qt/SDL window icon path

### DIFF
--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -5,6 +5,7 @@
 #include <QApplication>
 #include <QDesktopServices>
 #include <QDesktopWidget>
+#include <QFile>
 #include <QFileDialog>
 #include <QMessageBox>
 
@@ -26,7 +27,14 @@ MainWindow::MainWindow(QWidget *parent, bool fullscreen) :
 	nextState(CORE_POWERDOWN),
 	lastUIState(UISTATE_MENU)
 {
+#if defined(ASSETS_DIR)
+	if (QFile::exists(ASSETS_DIR "icon_regular_72.png"))
+		setWindowIcon(QIcon(ASSETS_DIR "icon_regular_72.png"));
+	else
+		setWindowIcon(QIcon(qApp->applicationDirPath() + "/assets/icon_regular_72.png"));
+#else
 	setWindowIcon(QIcon(qApp->applicationDirPath() + "/assets/icon_regular_72.png"));
+#endif
 
 	SetGameTitle("");
 	emugl = new MainUI(this);

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -770,7 +770,13 @@ int main(int argc, char *argv[]) {
 	SDL_SetWindowTitle(window, (app_name_nice + " " + PPSSPP_GIT_VERSION).c_str());
 
 	char iconPath[PATH_MAX];
+#if defined(ASSETS_DIR)
+	snprintf(iconPath, PATH_MAX, "%sicon_regular_72.png", ASSETS_DIR);
+	if (access(iconPath, F_OK) != 0)
+		snprintf(iconPath, PATH_MAX, "%sassets/icon_regular_72.png", SDL_GetBasePath() ? SDL_GetBasePath() : "");
+#else
 	snprintf(iconPath, PATH_MAX, "%sassets/icon_regular_72.png", SDL_GetBasePath() ? SDL_GetBasePath() : "");
+#endif
 	int width = 0, height = 0;
 	unsigned char *imageData;
 	if (pngLoad(iconPath, &width, &height, &imageData) == 1) {


### PR DESCRIPTION
The assets directory will be installed into `${CMAKE_INSTALL_DATADIR}/ppsspp` https://github.com/hrydgard/ppsspp/blob/4fd336f5ef458708ce89631f4582af3427e0de01/CMakeLists.txt#L2520-L2522

But the Qt/SDL window will try to load window icon from the PPSSPP binary's directory https://github.com/hrydgard/ppsspp/blob/4fd336f5ef458708ce89631f4582af3427e0de01/Qt/mainwindow.cpp#L29 https://github.com/hrydgard/ppsspp/blob/4fd336f5ef458708ce89631f4582af3427e0de01/SDL/SDLMain.cpp#L773

My patch is to use the ASSETS_DIR defined in CMakeLists.txt to get the correct path https://github.com/hrydgard/ppsspp/blob/4fd336f5ef458708ce89631f4582af3427e0de01/CMakeLists.txt#L117