### PR TITLE
softgpu: Fix w culling of triangles combined as rectangles

### DIFF
--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -413,6 +413,9 @@ static bool AreCoordsRectangleCompatible(const RasterizerState &state, const Cli
 			if (data1.clippos.w - halftexel > data0.clippos.w || data1.clippos.w + halftexel < data0.clippos.w)
 				return false;
 		}
+		// We might need to cull this if all verts have negative w, which doesn't seem to happen for rectangles.
+		if (data0.clippos.w < 0.0f && data1.clippos.w < 0.0f)
+			return false;
 		// If we're projecting textures, only allow an exact match for simplicity.
 		if (state.enableTextures && data1.v.texturecoords.q() != data0.v.texturecoords.q())
 			return false;


### PR DESCRIPTION
This bug has actually existed for a while, but wasn't fixed by the recent learnings for w culling because of the triangles being optimized to a rectangle.  Fixes some effects in Kingdom Hearts (see #16131.)

The clipping one is less likely, mainly for non-textured rectangles, but I'd rather not fight with a weird bug for that either.

-[Unknown]