### PR TITLE
Libretro: Cheat Support

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -23,6 +23,7 @@
 #include "Common/File/VFS/VFS.h"
 #include "Common/File/VFS/AssetReader.h"
 #include "Common/Data/Text/I18n.h"
+#include "Common/StringUtils.h"
 
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
@@ -36,6 +37,8 @@
 #include "Core/System.h"
 #include "Core/CoreTiming.h"
 #include "Core/HW/Display.h"
+#include "Core/CwCheat.h"
+#include "Core/ELF/ParamSFO.h"
 
 #include "GPU/GPUState.h"
 #include "GPU/GPUInterface.h"
@@ -1663,9 +1666,86 @@ size_t retro_get_memory_size(unsigned id)
 	return 0;
 }
 
-void retro_cheat_reset(void) {}
+void retro_cheat_reset(void) {
+   // Init Cheat Engine
+   CWCheatEngine *cheatEngine = new CWCheatEngine(g_paramSFO.GetDiscID());
+   Path file=cheatEngine->CheatFilename();
 
-void retro_cheat_set(unsigned index, bool enabled, const char *code) { }
+   // Output cheats to cheat file
+   std::ofstream outFile;
+   outFile.open(file.c_str());
+   outFile << "_S " << g_paramSFO.GetDiscID() << std::endl;
+   outFile.close();
+
+   g_Config.bReloadCheats = true;
+
+   // Parse and Run the Cheats
+   cheatEngine->ParseCheats();
+   if (cheatEngine->HasCheats()) {
+      cheatEngine->Run();
+   }
+
+}
+
+void retro_cheat_set(unsigned index, bool enabled, const char *code) {
+   // Initialize Cheat Engine
+   CWCheatEngine *cheatEngine = new CWCheatEngine(g_paramSFO.GetDiscID());
+   cheatEngine->CreateCheatFile();
+   Path file=cheatEngine->CheatFilename();
+
+   // Read cheats file
+   std::vector<std::string> cheats;
+   std::ifstream cheat_content(file.c_str());
+   std::stringstream buffer;
+   buffer << cheat_content.rdbuf();
+   std::string existing_cheats=ReplaceAll(buffer.str(), std::string("\n_C"), std::string("|"));
+   SplitString(existing_cheats, '|', cheats);
+
+   // Generate Cheat String
+   std::stringstream cheat("");
+   cheat << (enabled ? "1 " : "0 ") << index << std::endl;
+   std::string code_str(code);
+   std::vector<std::string> codes;
+   code_str=ReplaceAll(code_str, std::string(" "), std::string("+"));
+   SplitString(code_str, '+', codes);
+   int part=0;
+   for (int i=0; i < codes.size(); i++) {
+      if (codes[i].size() <= 2) {
+         // _L _M ..etc
+         // Assume _L
+      } else if (part == 0) {
+         cheat << "_L " << codes[i] << " ";
+         part++;
+      } else {
+         cheat << codes[i] << std::endl;
+         part=0;
+      }
+   }
+
+   // Add or Replace the Cheat
+   if (index + 1 < cheats.size()) {
+      cheats[index + 1]=cheat.str();
+   } else {
+      cheats.push_back(cheat.str());
+   }
+
+   // Output cheats to cheat file
+   std::ofstream outFile;
+   outFile.open(file.c_str());
+   outFile << "_S " << g_paramSFO.GetDiscID() << std::endl;
+   for (int i=1; i < cheats.size(); i++) {
+      outFile << "_C" << cheats[i] << std::endl;
+   }
+   outFile.close();
+
+   g_Config.bReloadCheats = true;
+
+   // Parse and Run the Cheats
+   cheatEngine->ParseCheats();
+   if (cheatEngine->HasCheats()) {
+      cheatEngine->Run();
+   }
+}
 
 int System_GetPropertyInt(SystemProperty prop)
 {


### PR DESCRIPTION
# Description

Adds Emulator Cheat support on top of RetroArch native cheat engine. Supports CwCheat syntax 

# Usage
Using Final Fantasy IV Complete Edition as an example:

To enter:
_C0 CECIL HP 9999
_L 0x103F742C 0x0000270F

Under Cheats Setting in RetroArch user could input "0x103F742C 0x0000270F" or "_L 0x103F742C 0x0000270F" in the code section, enable the cheat. 

To enter longer cheats:

_C0 Move Speed (Normal)
_L 0x200e3c6c 0x8C900030
_L 0xD0000001 0x10004000
_L 0x200e3c6c 0x24100002

User could input "0x200e3c6c 0x8C900030 0xD0000001 0x10004000 0x200e3c6c 0x24100002" in the code section.