### PR TITLE
GE Debugger: Fix src/dst stride formatting

### DIFF
--- a/Common/Thread/ThreadManager.cpp
+++ b/Common/Thread/ThreadManager.cpp
@@ -125,7 +125,12 @@ bool ThreadManager::TeardownTask(Task *task, bool enqueue) {
 
 static void WorkerThreadFunc(GlobalThreadContext *global, ThreadContext *thread) {
 	char threadName[16];
-	snprintf(threadName, sizeof(threadName), "PoolWorker %d", thread->index);
+	if (thread->type == TaskType::CPU_COMPUTE) {
+		snprintf(threadName, sizeof(threadName), "PoolWorker %d", thread->index);
+	} else {
+		_assert_(thread->type == TaskType::IO_BLOCKING);
+		snprintf(threadName, sizeof(threadName), "PoolWorkerIO %d", thread->index);
+	}
 	SetCurrentThreadName(threadName);
 
 	const bool isCompute = thread->type == TaskType::CPU_COMPUTE;
@@ -199,8 +204,8 @@ void ThreadManager::Init(int numRealCores, int numLogicalCoresPerCpu) {
 		thread->cancelled.store(false);
 		thread->private_single.store(nullptr);
 		thread->type = i < numComputeThreads_ ? TaskType::CPU_COMPUTE : TaskType::IO_BLOCKING;
-		thread->thread = std::thread(&WorkerThreadFunc, global_, thread);
 		thread->index = i;
+		thread->thread = std::thread(&WorkerThreadFunc, global_, thread);
 		global_->threads_.push_back(thread);
 	}
 }

--- a/Common/Thread/ThreadManager.h
+++ b/Common/Thread/ThreadManager.h
@@ -4,7 +4,7 @@
 
 // The new threadpool.
 
-// To help future smart scheduling.
+// To help smart scheduling.
 enum class TaskType {
 	CPU_COMPUTE,
 	IO_BLOCKING,

--- a/GPU/GeDisasm.cpp
+++ b/GPU/GeDisasm.cpp
@@ -525,9 +525,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer, int bufsize) {
 	case GE_CMD_TRANSFERSRCW:
 		{
 			u32 xferSrc = (gstate.transfersrc & 0x00FFFFFF) | ((data & 0xFF0000) << 8);
-			u32 xferSrcW = data & 0x3FF;
-			if (data & ~0xFF03FF)
-				snprintf(buffer, bufsize, "Block transfer src: high=%02x, w=%d (addr %08x, extra %x)", data >> 16, xferSrcW, xferSrc, data & ~0xFF03FF);
+			u32 xferSrcW = (data & 0x400) != 0 ? 0x400 : (data & 0x3FF);
+			u32 validMask = (data & 0x400) != 0 ? 0xFF0400 : 0xFF03FF;
+			if (data & ~validMask)
+				snprintf(buffer, bufsize, "Block transfer src: high=%02x, w=%d (addr %08x, extra %x)", data >> 16, xferSrcW, xferSrc, data & ~validMask);
 			else
 				snprintf(buffer, bufsize, "Block transfer src: high=%02x, w=%d (addr %08x)", data >> 16, xferSrcW, xferSrc);
 			break;
@@ -546,9 +547,10 @@ void GeDisassembleOp(u32 pc, u32 op, u32 prev, char *buffer, int bufsize) {
 	case GE_CMD_TRANSFERDSTW:
 		{
 			u32 xferDst = (gstate.transferdst & 0x00FFFFFF) | ((data & 0xFF0000) << 8);
-			u32 xferDstW = data & 0x3FF;
-			if (data & ~0xFF03FF)
-				snprintf(buffer, bufsize, "Block transfer dst: high=%02x, w=%d (addr %08x, extra %x)", data >> 16, xferDstW, xferDst, data & ~0xFF03FF);
+			u32 xferDstW = (data & 0x400) != 0 ? 0x400 : (data & 0x3FF);
+			u32 validMask = (data & 0x400) != 0 ? 0xFF0400 : 0xFF03FF;
+			if (data & ~validMask)
+				snprintf(buffer, bufsize, "Block transfer dst: high=%02x, w=%d (addr %08x, extra %x)", data >> 16, xferDstW, xferDst, data & ~validMask);
 			else
 				snprintf(buffer, bufsize, "Block transfer dst: high=%02x, w=%d (addr %08x)", data >> 16, xferDstW, xferDst);
 			break;


### PR DESCRIPTION
Just a disasm glitch.  Also fix thread pool worker names, which were all "PoolWorker 0" before.

-[Unknown]