### PR TITLE
Windows: Fix cleanup order on shutdown

### DIFF
--- a/Core/Debugger/DebugInterface.h
+++ b/Core/Debugger/DebugInterface.h
@@ -23,16 +23,8 @@
 
 struct MemMap;
 
-enum {
-	GPR_SIZE_32,
-	GPR_SIZE_64,
-};
-
-class DebugInterface
-{
+class DebugInterface {
 public:
-	virtual ~DebugInterface() {}
-
 	virtual const char *disasm(unsigned int address, unsigned int align) {return "NODEBUGGER";}
 	virtual int getInstructionSize(int instruction) {return 1;}
 
@@ -52,16 +44,13 @@ public:
 	virtual bool initExpression(const char* exp, PostfixExpression& dest) { return false; };
 	virtual bool parseExpression(PostfixExpression& exp, u32& dest) { return false; };
 
-	
 	virtual u32 GetHi() { return 0; };
 	virtual u32 GetLo() { return 0; };
 	virtual void SetHi(u32 val) { };
 	virtual void SetLo(u32 val) { };
 	virtual const char *GetName() = 0;
-	virtual int GetGPRSize() = 0; //32 or 64
 	virtual u32 GetGPR32Value(int reg) {return 0;}
 	virtual void SetGPR32Value(int reg) {}
-	virtual void SetGPR64Value(int reg) {}
 	virtual u32 GetPC() = 0;
 	virtual void SetPC(u32 _pc) = 0;
 	virtual u32 GetLR() {return GetPC();}
@@ -71,11 +60,9 @@ public:
 	virtual int GetNumRegsInCategory(int cat) {return 0;}
 	virtual const char *GetCategoryName(int cat) {return 0;}
 	virtual const char *GetRegName(int cat, int index) {return 0;}
-	virtual void PrintRegValue(int cat, int index, char *out)
-	{
+	virtual void PrintRegValue(int cat, int index, char *out) {
 		sprintf(out,"%08X",GetGPR32Value(index));
 	}
 	virtual u32 GetRegValue(int cat, int index) {return 0;}
 	virtual void SetRegValue(int cat, int index, u32 value) {}
-
 };

--- a/Core/MIPS/MIPSDebugInterface.h
+++ b/Core/MIPS/MIPSDebugInterface.h
@@ -48,7 +48,6 @@ public:
 
 	//overridden functions
 	const char *GetName() override;
-	int GetGPRSize() override { return GPR_SIZE_32; }
 	u32 GetGPR32Value(int reg) override { return cpu->r[reg]; }
 	u32 GetPC() override { return cpu->pc; }
 	u32 GetLR() override { return cpu->r[MIPS_REG_RA]; }

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -968,6 +968,7 @@ namespace MainWindow
 			break;
 
 		case WM_CLOSE:
+			MainThread_Stop();
 			InputDevice::StopPolling();
 			WindowsRawInput::Shutdown();
 			return DefWindowProc(hWnd,message,wParam,lParam);
@@ -976,8 +977,9 @@ namespace MainWindow
 			KillTimer(hWnd, TIMER_CURSORUPDATE);
 			KillTimer(hWnd, TIMER_CURSORMOVEUPDATE);
 			KillTimer(hWnd, TIMER_WHEELRELEASE);
+			// Main window is gone, this tells the message loop to exit.
 			PostQuitMessage(0);
-			break;
+			return 0;
 
 		case WM_USER + 1:
 			NotifyDebuggerMapLoaded();

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -776,8 +776,6 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 		}
 	}
 
-	MainThread_Stop();
-
 	VFSShutdown();
 
 	MainWindow::DestroyDebugWindows();


### PR DESCRIPTION
This seems to prevent the occasional shutdown crash for me.

It seems graphics drivers are not entirely happy about windows getting destroyed before the swapchain etc has been shut down properly.