### PR TITLE
Fix issue with hidden flag in homebrew store (removing it)

### DIFF
--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -198,7 +198,7 @@ public:
 	StoreEntry GetEntry() const { return entry_; }
 
 private:
-	const StoreEntry &entry_;
+	const StoreEntry entry_;
 };
 
 // This is a "details" view of a game. Lets you install it.
@@ -441,7 +441,7 @@ void StoreScreen::ParseListing(std::string json) {
 			e.size = game.getInt("size");
 			e.downloadURL = game.getString("download-url", "");
 			e.iconURL = game.getString("icon-url", "");
-			e.hidden = game.getBool("hidden", false);
+			e.hidden = false;  // NOTE: Handling of the "hidden" flag is broken in old versions of PPSSPP. Do not use.
 			const char *file = game.getString("file", nullptr);
 			if (!file)
 				continue;
@@ -484,8 +484,7 @@ void StoreScreen::CreateViews() {
 		scrollItemView_ = new LinearLayoutList(ORIENT_VERTICAL, new LayoutParams(FILL_PARENT, WRAP_CONTENT));
 		leftScroll->Add(scrollItemView_);
 
-		std::vector<StoreEntry> entries = FilterEntries();
-		for (size_t i = 0; i < entries.size(); i++) {
+		for (size_t i = 0; i < entries_.size(); i++) {
 			scrollItemView_->Add(new ProductItemView(entries_[i]))->OnClick.Handle(this, &StoreScreen::OnGameSelected);
 		}
 
@@ -511,9 +510,7 @@ void StoreScreen::CreateViews() {
 std::vector<StoreEntry> StoreScreen::FilterEntries() {
 	std::vector<StoreEntry> filtered;
 	for (size_t i = 0; i < entries_.size(); i++) {
-		// TODO: Actually filter by category etc.
-		if (!entries_[i].hidden)
-			filtered.push_back(entries_[i]);
+		filtered.push_back(entries_[i]);
 	}
 	return filtered;
 }


### PR DESCRIPTION
Lots of problems in a few lines of code. We retained references to the filtered vector that lived temporarily in the load function... EDIT: Actually wasn't as bad as I thought as we referred to entries_, not entries. Still, the logic is wrong.

Plus, the "hidden" flag is utterly broken and could only ever work on the last entry, due to the above issue, and even then only if lucky.

So I'm banning it from use, pointless anyway.