### PR TITLE
Postshader: Don't save default setting values

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1417,10 +1417,10 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	Section *postShaderSetting = iniFile.GetOrCreateSection("PostShaderSetting");
 	if (IsVREnabled() && !postShadersInitialized) {
 		postShaderChain->Set("PostShader1", "ColorCorrection");
-		postShaderSetting->Set("ColorCorrectionSettingValue1",1.0f);
-		postShaderSetting->Set("ColorCorrectionSettingValue2",1.5f);
-		postShaderSetting->Set("ColorCorrectionSettingValue3",1.1f);
-		postShaderSetting->Set("ColorCorrectionSettingValue4",1.0f);
+		postShaderSetting->Set("ColorCorrectionSettingCurrentValue1", 1.0f);
+		postShaderSetting->Set("ColorCorrectionSettingCurrentValue2", 1.5f);
+		postShaderSetting->Set("ColorCorrectionSettingCurrentValue3", 1.1f);
+		postShaderSetting->Set("ColorCorrectionSettingCurrentValue4", 1.0f);
 	}
 
 	// Load post process shader values

--- a/Core/CwCheat.cpp
+++ b/Core/CwCheat.cpp
@@ -962,7 +962,7 @@ void CWCheatEngine::ExecuteOp(const CheatOperation &op, const CheatCode &cheat, 
 			auto shaderChain = GetFullPostShadersChain(g_Config.vPostShaderNames);
 			if (op.PostShaderUniform.shader < shaderChain.size()) {
 				std::string shaderName = shaderChain[op.PostShaderUniform.shader]->section;
-				g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderName.c_str(), op.PostShaderUniform.uniform + 1)] = op.PostShaderUniform.value.f;
+				g_Config.mPostShaderSetting[StringFromFormat("%sSettingCurrentValue%d", shaderName.c_str(), op.PostShaderUniform.uniform + 1)] = op.PostShaderUniform.value.f;
 			}
 		}
 		break;
@@ -979,16 +979,16 @@ void CWCheatEngine::ExecuteOp(const CheatOperation &op, const CheatCode &cheat, 
 				std::string shaderName = shaderChain[op.PostShaderUniform.shader]->section;
 				switch (op.PostShaderUniform.format) {
 				case 0:
-					g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderName.c_str(), op.PostShaderUniform.uniform + 1)] = value.u & 0x000000FF;
+					g_Config.mPostShaderSetting[StringFromFormat("%sSettingCurrentValue%d", shaderName.c_str(), op.PostShaderUniform.uniform + 1)] = value.u & 0x000000FF;
 					break;
 				case 1:
-					g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderName.c_str(), op.PostShaderUniform.uniform + 1)] = value.u & 0x0000FFFF;
+					g_Config.mPostShaderSetting[StringFromFormat("%sSettingCurrentValue%d", shaderName.c_str(), op.PostShaderUniform.uniform + 1)] = value.u & 0x0000FFFF;
 					break;
 				case 2:
-					g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderName.c_str(), op.PostShaderUniform.uniform + 1)] = value.u;
+					g_Config.mPostShaderSetting[StringFromFormat("%sSettingCurrentValue%d", shaderName.c_str(), op.PostShaderUniform.uniform + 1)] = value.u;
 					break;
 				case 3:
-					g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderName.c_str(), op.PostShaderUniform.uniform + 1)] = value.f;
+					g_Config.mPostShaderSetting[StringFromFormat("%sSettingCurrentValue%d", shaderName.c_str(), op.PostShaderUniform.uniform + 1)] = value.f;
 					break;
 				}
 			}

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -174,12 +174,6 @@ void LoadPostShaderInfo(Draw::DrawContext *draw, const std::vector<Path> &direct
 						section.Get(StringFromFormat("SettingMinValue%d", i + 1).c_str(), &setting.minValue, -1.0f);
 						section.Get(StringFromFormat("SettingMaxValue%d", i + 1).c_str(), &setting.maxValue, 1.0f);
 						section.Get(StringFromFormat("SettingStep%d", i + 1).c_str(), &setting.step, 0.01f);
-
-						// Populate the default setting value.
-						std::string section = StringFromFormat("%sSettingValue%d", info.section.c_str(), i + 1);
-						if (!setting.name.empty() && g_Config.mPostShaderSetting.find(section) == g_Config.mPostShaderSetting.end()) {
-							g_Config.mPostShaderSetting.emplace(section, setting.value);
-						}
 					}
 
 					// Let's ignore shaders we can't support. TODO: Not a very good check

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -204,10 +204,10 @@ void PresentationCommon::CalculatePostShaderUniforms(int bufferWidth, int buffer
 	uniforms->gl_HalfPixel[0] = u_pixel_delta * 0.5f;
 	uniforms->gl_HalfPixel[1] = v_pixel_delta * 0.5f;
 
-	uniforms->setting[0] = GetShaderSettingValue(shaderInfo, 0, "SettingValue1");
-	uniforms->setting[1] = GetShaderSettingValue(shaderInfo, 1, "SettingValue2");
-	uniforms->setting[2] = GetShaderSettingValue(shaderInfo, 2, "SettingValue3");
-	uniforms->setting[3] = GetShaderSettingValue(shaderInfo, 3, "SettingValue4");
+	uniforms->setting[0] = GetShaderSettingValue(shaderInfo, 0, "SettingCurrentValue1");
+	uniforms->setting[1] = GetShaderSettingValue(shaderInfo, 1, "SettingCurrentValue2");
+	uniforms->setting[2] = GetShaderSettingValue(shaderInfo, 2, "SettingCurrentValue3");
+	uniforms->setting[3] = GetShaderSettingValue(shaderInfo, 3, "SettingCurrentValue4");
 }
 
 static std::string ReadShaderSrc(const Path &filename) {

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -172,6 +172,14 @@ void PresentationCommon::GetCardboardSettings(CardboardSettings *cardboardSettin
 	cardboardSettings->screenHeight = cardboardScreenHeight;
 }
 
+static float GetShaderSettingValue(const ShaderInfo *shaderInfo, int i, const char *nameSuffix) {
+	std::string key = shaderInfo->section + nameSuffix;
+	auto it = g_Config.mPostShaderSetting.find(key);
+	if (it != g_Config.mPostShaderSetting.end())
+		return it->second;
+	return shaderInfo->settings[i].value;
+}
+
 void PresentationCommon::CalculatePostShaderUniforms(int bufferWidth, int bufferHeight, int targetWidth, int targetHeight, const ShaderInfo *shaderInfo, PostShaderUniforms *uniforms) const {
 	float u_delta = 1.0f / bufferWidth;
 	float v_delta = 1.0f / bufferHeight;
@@ -196,10 +204,10 @@ void PresentationCommon::CalculatePostShaderUniforms(int bufferWidth, int buffer
 	uniforms->gl_HalfPixel[0] = u_pixel_delta * 0.5f;
 	uniforms->gl_HalfPixel[1] = v_pixel_delta * 0.5f;
 
-	uniforms->setting[0] = g_Config.mPostShaderSetting[shaderInfo->section + "SettingValue1"];
-	uniforms->setting[1] = g_Config.mPostShaderSetting[shaderInfo->section + "SettingValue2"];
-	uniforms->setting[2] = g_Config.mPostShaderSetting[shaderInfo->section + "SettingValue3"];
-	uniforms->setting[3] = g_Config.mPostShaderSetting[shaderInfo->section + "SettingValue4"];
+	uniforms->setting[0] = GetShaderSettingValue(shaderInfo, 0, "SettingValue1");
+	uniforms->setting[1] = GetShaderSettingValue(shaderInfo, 1, "SettingValue2");
+	uniforms->setting[2] = GetShaderSettingValue(shaderInfo, 2, "SettingValue3");
+	uniforms->setting[3] = GetShaderSettingValue(shaderInfo, 3, "SettingValue4");
 }
 
 static std::string ReadShaderSrc(const Path &filename) {

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -418,7 +418,12 @@ void DisplayLayoutScreen::CreateViews() {
 				auto &setting = shaderInfo->settings[i];
 				if (!setting.name.empty()) {
 					// This map lookup will create the setting in the mPostShaderSetting map if it doesn't exist, with a default value of 0.0.
-					auto &value = g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderInfo->section.c_str(), i + 1)];
+					std::string key = StringFromFormat("%sSettingValue%d", shaderInfo->section.c_str(), i + 1);
+					bool keyExisted = g_Config.mPostShaderSetting.find(key) != g_Config.mPostShaderSetting.end();
+					auto &value = g_Config.mPostShaderSetting[key];
+					if (!keyExisted)
+						value = setting.value;
+
 					if (duplicated) {
 						auto sliderName = StringFromFormat("%s %s", ps->T(setting.name), ps->T("(duplicated setting, previous slider will be used)"));
 						PopupSliderChoiceFloat *settingValue = settingContainer->Add(new PopupSliderChoiceFloat(&value, setting.minValue, setting.maxValue, sliderName, setting.step, screenManager()));

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -418,7 +418,7 @@ void DisplayLayoutScreen::CreateViews() {
 				auto &setting = shaderInfo->settings[i];
 				if (!setting.name.empty()) {
 					// This map lookup will create the setting in the mPostShaderSetting map if it doesn't exist, with a default value of 0.0.
-					std::string key = StringFromFormat("%sSettingValue%d", shaderInfo->section.c_str(), i + 1);
+					std::string key = StringFromFormat("%sSettingCurrentValue%d", shaderInfo->section.c_str(), i + 1);
 					bool keyExisted = g_Config.mPostShaderSetting.find(key) != g_Config.mPostShaderSetting.end();
 					auto &value = g_Config.mPostShaderSetting[key];
 					if (!keyExisted)

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1817,7 +1817,12 @@ void DeveloperToolsScreen::CreateViews() {
 			for (size_t i = 0; i < ARRAY_SIZE(shaderInfo->settings); ++i) {
 				auto &setting = shaderInfo->settings[i];
 				if (!setting.name.empty()) {
-					auto &value = g_Config.mPostShaderSetting[StringFromFormat("%sSettingValue%d", shaderInfo->section.c_str(), i + 1)];
+					std::string key = StringFromFormat("%sSettingValue%d", shaderInfo->section.c_str(), i + 1);
+					bool keyExisted = g_Config.mPostShaderSetting.find(key) != g_Config.mPostShaderSetting.end();
+					auto &value = g_Config.mPostShaderSetting[key];
+					if (!keyExisted)
+						value = setting.value;
+
 					PopupSliderChoiceFloat *settingValue = list->Add(new PopupSliderChoiceFloat(&value, setting.minValue, setting.maxValue, ps->T(setting.name), setting.step, screenManager()));
 					settingValue->SetEnabledFunc([=] {
 						return !g_Config.bSkipBufferEffects && enableStereo();

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1817,7 +1817,7 @@ void DeveloperToolsScreen::CreateViews() {
 			for (size_t i = 0; i < ARRAY_SIZE(shaderInfo->settings); ++i) {
 				auto &setting = shaderInfo->settings[i];
 				if (!setting.name.empty()) {
-					std::string key = StringFromFormat("%sSettingValue%d", shaderInfo->section.c_str(), i + 1);
+					std::string key = StringFromFormat("%sSettingCurrentValue%d", shaderInfo->section.c_str(), i + 1);
 					bool keyExisted = g_Config.mPostShaderSetting.find(key) != g_Config.mPostShaderSetting.end();
 					auto &value = g_Config.mPostShaderSetting[key];
 					if (!keyExisted)


### PR DESCRIPTION
Fixes #16562, but does mean resetting the ini key (not so weird for this release given all the UI changes.)

The problem was all shaders saved "0.0" settings by default, and then those were your current values even if the shader changed to have settings later.  This now avoids saving values unless they're actually set.  Even future values for Vignette should work.

-[Unknown]