### PR TITLE
UI: Avoid crash on axis input during shutdown

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1431,6 +1431,8 @@ bool NativeAxis(const AxisInput &axis) {
 
 		default:
 			// Don't take over completely!
+			if (!screenManager)
+				return false;
 			return screenManager->axis(axis);
 	}
 


### PR DESCRIPTION
Hit this while doing something else.  The lock is right inside the function, so not a perfect fix, but should make it much more unlikely.

-[Unknown]