### PR TITLE
Disable geometry shader culling by default

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -881,7 +881,7 @@ static ConfigSetting graphicsSettings[] = {
 #endif
 	ConfigSetting("CameraDevice", &g_Config.sCameraDevice, "", true, false),
 	ConfigSetting("VendorBugChecksEnabled", &g_Config.bVendorBugChecksEnabled, true, false, false),
-	ConfigSetting("UseGeometryShader", &g_Config.bUseGeometryShader, true, true, true),
+	ConfigSetting("UseGeometryShader", &g_Config.bUseGeometryShader, false, true, true),
 	ReportedConfigSetting("SkipBufferEffects", &g_Config.bSkipBufferEffects, false, true, true),
 	ConfigSetting("SoftwareRenderer", &g_Config.bSoftwareRendering, false, true, true),
 	ConfigSetting("SoftwareRendererJit", &g_Config.bSoftwareRenderingJit, true, true, true),


### PR DESCRIPTION
Considering getting this one in for the release but have not decided yet.

Geometry shaders allow us to fix some clipping and culling issues in a neat way on Mali and other platforms that don't support cull/clip planes, plus allow us to take care of some esoteric edge cases (triangle inversion), but unfortunately, at least on my Galaxy S20 with 32.1 drivers, they're just incredibly slow to compile. Around 100ms per shader, which leads to multi-second stutters on first run in Wipeout for example.

Until we can either reduce the number of shaders drastically, or we find a driver version that's faster at compiling that we can cut this off at, let's not default to them on. They are still available for use, and I'll put something on the website to explain the issue...