### PR TITLE
Fix GLES and Vulkan cache with equal depth check detect

### DIFF
--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -110,6 +110,9 @@ public:
 	bool EverUsedExactEqualDepth() const {
 		return everUsedExactEqualDepth_;
 	}
+	void SetEverUsedExactEqualDepth(bool v) {
+		everUsedExactEqualDepth_ = v;
+	}
 
 	bool IsCodePtrVertexDecoder(const u8 *ptr) const {
 		return decJitCache_->IsInSpace(ptr);

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -157,6 +157,14 @@ void GPU_D3D11::BeginFrame() {
 
 	framebufferManagerD3D11_->BeginFrame();
 	gstate_c.Dirty(DIRTY_PROJTHROUGHMATRIX);
+
+	if (gstate_c.useFlagsChanged) {
+		// TODO: It'd be better to recompile them in the background, probably?
+		// This most likely means that saw equal depth changed.
+		WARN_LOG(G3D, "Shader use flags changed, clearing all shaders");
+		shaderManagerD3D11_->ClearShaders();
+		gstate_c.useFlagsChanged = false;
+	}
 }
 
 void GPU_D3D11::CopyDisplayToOutput(bool reallyDirty) {

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -155,6 +155,14 @@ void GPU_DX9::BeginFrame() {
 	shaderManagerDX9_->DirtyShader();
 
 	framebufferManager_->BeginFrame();
+
+	if (gstate_c.useFlagsChanged) {
+		// TODO: It'd be better to recompile them in the background, probably?
+		// This most likely means that saw equal depth changed.
+		WARN_LOG(G3D, "Shader use flags changed, clearing all shaders");
+		shaderManagerDX9_->ClearCache(true);
+		gstate_c.useFlagsChanged = false;
+	}
 }
 
 void GPU_DX9::CopyDisplayToOutput(bool reallyDirty) {

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -271,6 +271,14 @@ void GPU_GLES::InitClear() {
 void GPU_GLES::BeginHostFrame() {
 	GPUCommon::BeginHostFrame();
 	drawEngine_.BeginFrame();
+
+	if (gstate_c.useFlagsChanged) {
+		// TODO: It'd be better to recompile them in the background, probably?
+		// This most likely means that saw equal depth changed.
+		WARN_LOG(G3D, "Shader use flags changed, clearing all shaders");
+		shaderManagerGL_->ClearCache(true);
+		gstate_c.useFlagsChanged = false;
+	}
 }
 
 void GPU_GLES::EndHostFrame() {

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -98,7 +98,20 @@ GPU_GLES::GPU_GLES(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 			File::CreateFullPath(GetSysDirectory(DIRECTORY_APP_CACHE));
 			shaderCachePath_ = GetSysDirectory(DIRECTORY_APP_CACHE) / (discID + ".glshadercache");
 			// Actually precompiled by IsReady() since we're single-threaded.
-			shaderManagerGL_->Load(shaderCachePath_);
+			File::IOFile f(shaderCachePath_, "rb");
+			if (f.IsOpen()) {
+				if (shaderManagerGL_->LoadCacheFlags(f, &drawEngine_)) {
+					if (drawEngineCommon_->EverUsedExactEqualDepth()) {
+						sawExactEqualDepth_ = true;
+					}
+					gstate_c.SetUseFlags(CheckGPUFeatures());
+					// We're compiling now, clear if they changed.
+					gstate_c.useFlagsChanged = false;
+
+					if (shaderManagerGL_->LoadCache(f))
+						NOTICE_LOG(G3D, "Precompiling the shader cache from '%s'", shaderCachePath_.c_str());
+				}
+			}
 		} else {
 			INFO_LOG(G3D, "Shader cache disabled. Not loading.");
 		}
@@ -125,7 +138,7 @@ GPU_GLES::~GPU_GLES() {
 
 	if (shaderCachePath_.Valid() && draw_) {
 		if (g_Config.bShaderCache) {
-			shaderManagerGL_->Save(shaderCachePath_);
+			shaderManagerGL_->SaveCache(shaderCachePath_, &drawEngine_);
 		} else {
 			INFO_LOG(G3D, "Shader cache disabled. Not saving.");
 		}
@@ -297,7 +310,7 @@ void GPU_GLES::BeginFrame() {
 
 	// Save the cache from time to time. TODO: How often? We save on exit, so shouldn't need to do this all that often.
 	if (shaderCachePath_.Valid() && (gpuStats.numFlips & 4095) == 0) {
-		shaderManagerGL_->Save(shaderCachePath_);
+		shaderManagerGL_->SaveCache(shaderCachePath_, &drawEngine_);
 	}
 
 	shaderManagerGL_->DirtyShader();

--- a/GPU/GLES/ShaderManagerGLES.h
+++ b/GPU/GLES/ShaderManagerGLES.h
@@ -27,8 +27,13 @@
 #include "GPU/Common/VertexShaderGenerator.h"
 #include "GPU/Common/FragmentShaderGenerator.h"
 
+class DrawEngineGLES;
 class Shader;
 struct ShaderLanguageDesc;
+
+namespace File {
+class IOFile;
+}
 
 class LinkedShader {
 public:
@@ -177,10 +182,11 @@ public:
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType type);
 	std::string DebugGetShaderString(std::string id, DebugShaderType type, DebugShaderStringType stringType);
 
-	void Load(const Path &filename);
+	bool LoadCacheFlags(File::IOFile &f, DrawEngineGLES *drawEngine);
+	bool LoadCache(File::IOFile &f);
 	bool ContinuePrecompile(float sliceTime = 1.0f / 60.0f);
 	void CancelPrecompile();
-	void Save(const Path &filename);
+	void SaveCache(const Path &filename, DrawEngineGLES *drawEngine);
 
 private:
 	void Clear();

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2776,7 +2776,6 @@ void GPUCommon::FastLoadBoneMatrix(u32 target) {
 
 	if (coreCollectDebugStats) {
 		gpuStats.otherGPUCycles += 2 * 14;
-		gpuStats.gpuCommandsAtCallLevel[std::min(currentList->stackptr, 3)] += 14;
 	}
 }
 

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -580,8 +580,9 @@ struct GPUStateCache {
 	}
 	void SetUseFlags(u32 newFlags) {
 		if (newFlags != useFlags_) {
+			if (useFlags_ != 0)
+				useFlagsChanged = true;
 			useFlags_ = newFlags;
-			useFlagsChanged = true;
 		}
 	}
 

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -581,7 +581,7 @@ struct GPUStateCache {
 	void SetUseFlags(u32 newFlags) {
 		if (newFlags != useFlags_) {
 			useFlags_ = newFlags;
-			// Recompile shaders and stuff?
+			useFlagsChanged = true;
 		}
 	}
 
@@ -612,6 +612,7 @@ public:
 	bool bgraTexture;
 	bool needShaderTexClamp;
 	bool arrayTexture;
+	bool useFlagsChanged;
 
 	float morphWeights[8];
 	u32 deferredVertTypeDirty;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -129,9 +129,17 @@ void GPU_Vulkan::LoadCache(const Path &filename) {
 	// First compile shaders to SPIR-V, then load the pipeline cache and recreate the pipelines.
 	// It's when recreating the pipelines that the pipeline cache is useful - in the ideal case,
 	// it can just memcpy the finished shader binaries out of the pipeline cache file.
-	bool result = shaderManagerVulkan_->LoadCache(f);
+	bool result = shaderManagerVulkan_->LoadCacheFlags(f, &drawEngine_);
 	if (!result) {
-		WARN_LOG(G3D, "ShaderManagerVulkan failed to load cache.");
+		WARN_LOG(G3D, "ShaderManagerVulkan failed to load cache header.");
+	}
+	if (result) {
+		// Reload use flags in case LoadCacheFlags() changed them.
+		gstate_c.SetUseFlags(CheckGPUFeatures());
+		result = shaderManagerVulkan_->LoadCache(f);
+		if (!result) {
+			WARN_LOG(G3D, "ShaderManagerVulkan failed to load cache.");
+		}
 	}
 	if (result) {
 		// WARNING: See comment in LoadPipelineCache if you are tempted to flip the second parameter to true.
@@ -163,7 +171,7 @@ void GPU_Vulkan::SaveCache(const Path &filename) {
 	FILE *f = File::OpenCFile(filename, "wb");
 	if (!f)
 		return;
-	shaderManagerVulkan_->SaveCache(f);
+	shaderManagerVulkan_->SaveCache(f, &drawEngine_);
 	// WARNING: See comment in LoadCache if you are tempted to flip the second parameter to true.
 	pipelineManager_->SavePipelineCache(f, false, shaderManagerVulkan_, draw_);
 	INFO_LOG(G3D, "Saved Vulkan pipeline cache");

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -565,6 +565,9 @@ bool ShaderManagerVulkan::LoadCache(FILE *f) {
 		// This can simply be a result of sawExactEqualDepth_ having been flipped to true in the previous run.
 		// Let's just keep going.
 		WARN_LOG(G3D, "Shader cache useFlags mismatch, %08x, expected %08x", header.useFlags, gstate_c.GetUseFlags());
+	} else {
+		// We're compiling shaders now, so they haven't changed anymore.
+		gstate_c.useFlagsChanged = false;
 	}
 
 	int failCount = 0;

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -348,8 +348,13 @@ void ShaderManagerVulkan::GetShaders(int prim, VertexDecoder *decoder, VulkanVer
 		bool success = GenerateVertexShader(VSID, codeBuffer_, compat_, draw_->GetBugs(), &attributeMask, &uniformMask, &flags, &genErrorString);
 		_assert_msg_(success, "VS gen error: %s", genErrorString.c_str());
 		_assert_msg_(strlen(codeBuffer_) < CODE_BUFFER_SIZE, "VS length error: %d", (int)strlen(codeBuffer_));
-		vs = new VulkanVertexShader(vulkan, VSID, flags, codeBuffer_, useHWTransform);
-		vsCache_.Insert(VSID, vs);
+
+		std::lock_guard<std::mutex> guard(cacheLock_);
+		vs = vsCache_.Get(VSID);
+		if (!vs) {
+			vs = new VulkanVertexShader(vulkan, VSID, flags, codeBuffer_, useHWTransform);
+			vsCache_.Insert(VSID, vs);
+		}
 	}
 
 	VulkanFragmentShader *fs = fsCache_.Get(FSID);
@@ -361,8 +366,13 @@ void ShaderManagerVulkan::GetShaders(int prim, VertexDecoder *decoder, VulkanVer
 		bool success = GenerateFragmentShader(FSID, codeBuffer_, compat_, draw_->GetBugs(), &uniformMask, &flags, &genErrorString);
 		_assert_msg_(success, "FS gen error: %s", genErrorString.c_str());
 		_assert_msg_(strlen(codeBuffer_) < CODE_BUFFER_SIZE, "FS length error: %d", (int)strlen(codeBuffer_));
-		fs = new VulkanFragmentShader(vulkan, FSID, flags, codeBuffer_);
-		fsCache_.Insert(FSID, fs);
+
+		std::lock_guard<std::mutex> guard(cacheLock_);
+		fs = fsCache_.Get(FSID);
+		if (!fs) {
+			fs = new VulkanFragmentShader(vulkan, FSID, flags, codeBuffer_);
+			fsCache_.Insert(FSID, fs);
+		}
 	}
 
 	VulkanGeometryShader *gs;
@@ -374,8 +384,13 @@ void ShaderManagerVulkan::GetShaders(int prim, VertexDecoder *decoder, VulkanVer
 			bool success = GenerateGeometryShader(GSID, codeBuffer_, compat_, draw_->GetBugs(), &genErrorString);
 			_assert_msg_(success, "GS gen error: %s", genErrorString.c_str());
 			_assert_msg_(strlen(codeBuffer_) < CODE_BUFFER_SIZE, "GS length error: %d", (int)strlen(codeBuffer_));
-			gs = new VulkanGeometryShader(vulkan, GSID, codeBuffer_);
-			gsCache_.Insert(GSID, gs);
+
+			std::lock_guard<std::mutex> guard(cacheLock_);
+			gs = gsCache_.Get(GSID);
+			if (!gs) {
+				gs = new VulkanGeometryShader(vulkan, GSID, codeBuffer_);
+				gsCache_.Insert(GSID, gs);
+			}
 		}
 	} else {
 		gs = nullptr;
@@ -574,6 +589,13 @@ bool ShaderManagerVulkan::LoadCache(FILE *f) {
 		}
 		_assert_msg_(strlen(codeBuffer_) < CODE_BUFFER_SIZE, "VS length error: %d", (int)strlen(codeBuffer_));
 		VulkanVertexShader *vs = new VulkanVertexShader(vulkan, id, flags, codeBuffer_, useHWTransform);
+		// Remove first, just to be safe (we are loading on a background thread.)
+		std::lock_guard<std::mutex> guard(cacheLock_);
+		VulkanVertexShader *old = vsCache_.Get(id);
+		if (old) {
+			vsCache_.Remove(id);
+			delete old;
+		}
 		vsCache_.Insert(id, vs);
 	}
 	uint32_t vendorID = vulkan->GetPhysicalDeviceProperties().properties.vendorID;
@@ -595,6 +617,12 @@ bool ShaderManagerVulkan::LoadCache(FILE *f) {
 		}
 		_assert_msg_(strlen(codeBuffer_) < CODE_BUFFER_SIZE, "FS length error: %d", (int)strlen(codeBuffer_));
 		VulkanFragmentShader *fs = new VulkanFragmentShader(vulkan, id, flags, codeBuffer_);
+		std::lock_guard<std::mutex> guard(cacheLock_);
+		VulkanFragmentShader *old = fsCache_.Get(id);
+		if (old) {
+			fsCache_.Remove(id);
+			delete old;
+		}
 		fsCache_.Insert(id, fs);
 	}
 
@@ -613,6 +641,12 @@ bool ShaderManagerVulkan::LoadCache(FILE *f) {
 		}
 		_assert_msg_(strlen(codeBuffer_) < CODE_BUFFER_SIZE, "GS length error: %d", (int)strlen(codeBuffer_));
 		VulkanGeometryShader *gs = new VulkanGeometryShader(vulkan, id, codeBuffer_);
+		std::lock_guard<std::mutex> guard(cacheLock_);
+		VulkanGeometryShader *old = gsCache_.Get(id);
+		if (old) {
+			gsCache_.Remove(id);
+			delete old;
+		}
 		gsCache_.Insert(id, gs);
 	}
 

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -552,14 +552,7 @@ bool ShaderManagerVulkan::LoadCacheFlags(FILE *f, DrawEngineVulkan *drawEngine) 
 bool ShaderManagerVulkan::LoadCache(FILE *f) {
 	VulkanCacheHeader header{};
 	bool success = fread(&header, sizeof(header), 1, f) == 1;
-	if (!success || header.magic != CACHE_HEADER_MAGIC) {
-		WARN_LOG(G3D, "Shader cache magic mismatch");
-		return false;
-	}
-	if (header.version != CACHE_VERSION) {
-		WARN_LOG(G3D, "Shader cache version mismatch, %d, expected %d", header.version, CACHE_VERSION);
-		return false;
-	}
+	// We don't need to validate magic/version again, done in LoadCacheFlags().
 
 	if (header.useFlags != gstate_c.GetUseFlags()) {
 		// This can simply be a result of sawExactEqualDepth_ having been flipped to true in the previous run.

--- a/GPU/Vulkan/ShaderManagerVulkan.h
+++ b/GPU/Vulkan/ShaderManagerVulkan.h
@@ -19,6 +19,7 @@
 
 #include <cstdio>
 #include <cstdint>
+#include <mutex>
 
 #include "Common/Thread/Promise.h"
 #include "Common/Data/Collections/Hashmaps.h"
@@ -174,6 +175,7 @@ private:
 	GSCache gsCache_;
 
 	char *codeBuffer_;
+	std::mutex cacheLock_;
 
 	uint64_t uboAlignment_;
 	// Uniform block scratchpad. These (the relevant ones) are copied to the current pushbuffer at draw time.

--- a/GPU/Vulkan/ShaderManagerVulkan.h
+++ b/GPU/Vulkan/ShaderManagerVulkan.h
@@ -32,6 +32,7 @@
 #include "GPU/Common/ShaderUniforms.h"
 
 class VulkanContext;
+class DrawEngineVulkan;
 class VulkanPushBuffer;
 
 class VulkanFragmentShader {
@@ -154,8 +155,9 @@ public:
 		return dest->PushAligned(&ub_bones, sizeof(ub_bones), uboAlignment_, buf);
 	}
 
+	bool LoadCacheFlags(FILE *f, DrawEngineVulkan *drawEngine);
 	bool LoadCache(FILE *f);
-	void SaveCache(FILE *f);
+	void SaveCache(FILE *f, DrawEngineVulkan *drawEngine);
 
 private:
 	void Clear();


### PR DESCRIPTION
This clears out shaders when the flag changes, and saves it to the cache header so we only need to detect it once.

This also fixes GLES having a similar issue compared to Vulkan where the cache would be invalid on each start if equal depth was seen.

-[Unknown]