### PR TITLE
Multisampling level: Don't read directly from g_Config

### DIFF
--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -48,6 +48,12 @@ bool VKRGraphicsPipeline::Create(VulkanContext *vulkan, VkRenderPass compatibleR
 		return false;
 	}
 
+	if (!compatibleRenderPass) {
+		ERROR_LOG(G3D, "Failed creating graphics pipeline - compatible render pass was null");
+		// We're kinda screwed here?
+		return false;
+	}
+
 	uint32_t stageCount = 2;
 	VkPipelineShaderStageCreateInfo ss[3]{};
 	ss[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -853,13 +853,16 @@ VKContext::VKContext(VulkanContext *vulkan)
 		break;
 	}
 
-	bool hasLazyMemory = false;
-	for (u32 i = 0; i < vulkan->GetMemoryProperties().memoryTypeCount; i++) {
-		if (vulkan->GetMemoryProperties().memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) {
-			hasLazyMemory = true;
-		}
+	switch (caps_.vendor) {
+	case GPUVendor::VENDOR_ARM:
+	case GPUVendor::VENDOR_IMGTEC:
+	case GPUVendor::VENDOR_QUALCOMM:
+		caps_.isTilingGPU = true;
+		break;
+	default:
+		caps_.isTilingGPU = false;
+		break;
 	}
-	caps_.isTilingGPU = hasLazyMemory && caps_.vendor != GPUVendor::VENDOR_APPLE;
 
 	// Hide D3D9 when we know it likely won't work well.
 #if PPSSPP_PLATFORM(WINDOWS)

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -272,7 +272,7 @@ public:
 		drawEngine_ = td;
 	}
 
-	virtual void Init();
+	void Init(int msaaLevel);
 	virtual void BeginFrame();
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format);
 	void DestroyFramebuf(VirtualFramebuffer *v);
@@ -398,7 +398,7 @@ public:
 	}
 	void SetSafeSize(u16 w, u16 h);
 
-	void NotifyRenderResized();
+	void NotifyRenderResized(int msaaLevel);
 	virtual void NotifyDisplayResized();
 	void NotifyConfigChanged();
 
@@ -445,6 +445,10 @@ public:
 
 	void ReleasePipelines();
 
+	int GetMSAALevel() const {
+		return msaaLevel_;
+	}
+
 protected:
 	virtual void ReadbackFramebufferSync(VirtualFramebuffer *vfb, int x, int y, int w, int h, RasterChannel channel);
 	// Used for when a shader is required, such as GLES.
@@ -457,7 +461,7 @@ protected:
 	void CopyToColorFromOverlappingFramebuffers(VirtualFramebuffer *dest);
 	void CopyToDepthFromOverlappingFramebuffers(VirtualFramebuffer *dest);
 
-	bool UpdateRenderSize();
+	bool UpdateRenderSize(int msaaLevel);
 
 	void FlushBeforeCopy();
 	virtual void DecimateFBOs();  // keeping it virtual to let D3D do a little extra

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -70,7 +70,7 @@ GPU_D3D11::GPU_D3D11(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	framebufferManagerD3D11_->SetTextureCache(textureCacheD3D11_);
 	framebufferManagerD3D11_->SetShaderManager(shaderManagerD3D11_);
 	framebufferManagerD3D11_->SetDrawEngine(&drawEngine_);
-	framebufferManagerD3D11_->Init();
+	framebufferManagerD3D11_->Init(msaaLevel_);
 	textureCacheD3D11_->SetFramebufferManager(framebufferManagerD3D11_);
 	textureCacheD3D11_->SetShaderManager(shaderManagerD3D11_);
 

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -69,7 +69,7 @@ GPU_DX9::GPU_DX9(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	framebufferManagerDX9_->SetTextureCache(textureCacheDX9_);
 	framebufferManagerDX9_->SetShaderManager(shaderManagerDX9_);
 	framebufferManagerDX9_->SetDrawEngine(&drawEngine_);
-	framebufferManagerDX9_->Init();
+	framebufferManagerDX9_->Init(msaaLevel_);
 	textureCacheDX9_->SetFramebufferManager(framebufferManagerDX9_);
 	textureCacheDX9_->SetShaderManager(shaderManagerDX9_);
 

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -74,7 +74,7 @@ GPU_GLES::GPU_GLES(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	framebufferManagerGL_->SetTextureCache(textureCacheGL_);
 	framebufferManagerGL_->SetShaderManager(shaderManagerGL_);
 	framebufferManagerGL_->SetDrawEngine(&drawEngine_);
-	framebufferManagerGL_->Init();
+	framebufferManagerGL_->Init(msaaLevel_);
 	textureCacheGL_->SetFramebufferManager(framebufferManagerGL_);
 	textureCacheGL_->SetShaderManager(shaderManagerGL_);
 	textureCacheGL_->SetDrawEngine(&drawEngine_);

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -3582,7 +3582,7 @@ u32 GPUCommon::CheckGPUFeaturesLate(u32 features) const {
 
 void GPUCommon::UpdateMSAALevel(Draw::DrawContext *draw) {
 	int level = g_Config.iMultiSampleLevel;
-	if (draw->GetDeviceCaps().multiSampleLevelsMask & (1 << level)) {
+	if (draw && draw->GetDeviceCaps().multiSampleLevelsMask & (1 << level)) {
 		msaaLevel_ = level;
 	} else {
 		// Didn't support the configured level, so revert to 0.

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -428,6 +428,8 @@ GPUCommon::GPUCommon(GraphicsContext *gfxCtx, Draw::DrawContext *draw) :
 	ResetMatrices();
 
 	PPGeSetDrawContext(draw);
+
+	UpdateMSAALevel(draw);
 }
 
 GPUCommon::~GPUCommon() {
@@ -484,6 +486,8 @@ void GPUCommon::BeginHostFrame() {
 	gstate_c.Dirty(DIRTY_ALL);
 
 	UpdateCmdInfo();
+
+	UpdateMSAALevel(draw_);
 	CheckConfigChanged();
 	CheckDisplayResized();
 	CheckRenderResized();
@@ -659,7 +663,7 @@ void GPUCommon::CheckDisplayResized() {
 
 void GPUCommon::CheckRenderResized() {
 	if (renderResized_) {
-		framebufferManager_->NotifyRenderResized();
+		framebufferManager_->NotifyRenderResized(msaaLevel_);
 		renderResized_ = false;
 	}
 }
@@ -3574,4 +3578,14 @@ u32 GPUCommon::CheckGPUFeaturesLate(u32 features) const {
 	}
 
 	return features;
+}
+
+void GPUCommon::UpdateMSAALevel(Draw::DrawContext *draw) {
+	int level = g_Config.iMultiSampleLevel;
+	if (draw->GetDeviceCaps().multiSampleLevelsMask & (1 << level)) {
+		msaaLevel_ = level;
+	} else {
+		// Didn't support the configured level, so revert to 0.
+		msaaLevel_ = 0;
+	}
 }

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -261,6 +261,10 @@ public:
 		fullInfo = reportingFullInfo_;
 	}
 
+	int MSAALevel() const {
+		return msaaLevel_;
+	}
+
 protected:
 	void DeviceLost() override;
 	void DeviceRestore() override;
@@ -318,6 +322,8 @@ protected:
 	size_t FormatGPUStatsCommon(char *buf, size_t size);
 
 	virtual void BuildReportingInfo() = 0;
+
+	void UpdateMSAALevel(Draw::DrawContext *draw);
 
 	FramebufferManagerCommon *framebufferManager_ = nullptr;
 	TextureCacheCommon *textureCache_ = nullptr;
@@ -405,6 +411,8 @@ protected:
 	std::string reportingPrimaryInfo_;
 	std::string reportingFullInfo_;
 
+	int msaaLevel_ = 0;
+
 private:
 	void CheckDepthUsage(VirtualFramebuffer *vfb);
 	void DoExecuteCall(u32 target);
@@ -415,6 +423,7 @@ private:
 	// Debug stats.
 	double timeSteppingStarted_;
 	double timeSpentStepping_;
+
 	int lastVsync_ = -1;
 };
 

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -788,7 +788,7 @@ void DrawEngineVulkan::DoFlush() {
 			}
 			_dbg_assert_msg_(vshader->UseHWTransform(), "Bad vshader");
 
-			VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(renderManager, pipelineLayout_, pipelineKey_, &dec_->decFmt, vshader, fshader, gshader, true, 0);
+			VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(renderManager, pipelineLayout_, pipelineKey_, &dec_->decFmt, vshader, fshader, gshader, true, 0, g_Config.iMultiSampleLevel);
 			if (!pipeline || !pipeline->pipeline) {
 				// Already logged, let's bail out.
 				return;
@@ -917,7 +917,7 @@ void DrawEngineVulkan::DoFlush() {
 
 				shaderManager_->GetShaders(prim, lastVType_, &vshader, &fshader, &gshader, pipelineState_, false, false, decOptions_.expandAllWeightsToFloat, true);
 				_dbg_assert_msg_(!vshader->UseHWTransform(), "Bad vshader");
-				VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(renderManager, pipelineLayout_, pipelineKey_, &dec_->decFmt, vshader, fshader, gshader, false, 0);
+				VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(renderManager, pipelineLayout_, pipelineKey_, &dec_->decFmt, vshader, fshader, gshader, false, 0, g_Config.iMultiSampleLevel);
 				if (!pipeline || !pipeline->pipeline) {
 					// Already logged, let's bail out.
 					decodedVerts_ = 0;

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -788,7 +788,7 @@ void DrawEngineVulkan::DoFlush() {
 			}
 			_dbg_assert_msg_(vshader->UseHWTransform(), "Bad vshader");
 
-			VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(renderManager, pipelineLayout_, pipelineKey_, &dec_->decFmt, vshader, fshader, gshader, true, 0, g_Config.iMultiSampleLevel);
+			VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(renderManager, pipelineLayout_, pipelineKey_, &dec_->decFmt, vshader, fshader, gshader, true, 0, framebufferManager_->GetMSAALevel());
 			if (!pipeline || !pipeline->pipeline) {
 				// Already logged, let's bail out.
 				return;
@@ -917,7 +917,7 @@ void DrawEngineVulkan::DoFlush() {
 
 				shaderManager_->GetShaders(prim, lastVType_, &vshader, &fshader, &gshader, pipelineState_, false, false, decOptions_.expandAllWeightsToFloat, true);
 				_dbg_assert_msg_(!vshader->UseHWTransform(), "Bad vshader");
-				VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(renderManager, pipelineLayout_, pipelineKey_, &dec_->decFmt, vshader, fshader, gshader, false, 0, g_Config.iMultiSampleLevel);
+				VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(renderManager, pipelineLayout_, pipelineKey_, &dec_->decFmt, vshader, fshader, gshader, false, 0, framebufferManager_->GetMSAALevel());
 				if (!pipeline || !pipeline->pipeline) {
 					// Already logged, let's bail out.
 					decodedVerts_ = 0;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -140,7 +140,7 @@ void GPU_Vulkan::LoadCache(const Path &filename) {
 	}
 	if (result) {
 		// WARNING: See comment in LoadPipelineCache if you are tempted to flip the second parameter to true.
-		result = pipelineManager_->LoadPipelineCache(f, false, shaderManagerVulkan_, draw_, drawEngine_.GetPipelineLayout());
+		result = pipelineManager_->LoadPipelineCache(f, false, shaderManagerVulkan_, draw_, drawEngine_.GetPipelineLayout(), g_Config.iMultiSampleLevel);
 	}
 	fclose(f);
 	if (!result) {

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -76,7 +76,7 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	framebufferManagerVulkan_->SetTextureCache(textureCacheVulkan_);
 	framebufferManagerVulkan_->SetDrawEngine(&drawEngine_);
 	framebufferManagerVulkan_->SetShaderManager(shaderManagerVulkan_);
-	framebufferManagerVulkan_->Init();
+	framebufferManagerVulkan_->Init(msaaLevel_);
 	textureCacheVulkan_->SetFramebufferManager(framebufferManagerVulkan_);
 	textureCacheVulkan_->SetShaderManager(shaderManagerVulkan_);
 	textureCacheVulkan_->SetDrawEngine(&drawEngine_);
@@ -140,9 +140,10 @@ void GPU_Vulkan::LoadCache(const Path &filename) {
 	}
 	if (result) {
 		// WARNING: See comment in LoadPipelineCache if you are tempted to flip the second parameter to true.
-		result = pipelineManager_->LoadPipelineCache(f, false, shaderManagerVulkan_, draw_, drawEngine_.GetPipelineLayout(), g_Config.iMultiSampleLevel);
+		result = pipelineManager_->LoadPipelineCache(f, false, shaderManagerVulkan_, draw_, drawEngine_.GetPipelineLayout(), msaaLevel_);
 	}
 	fclose(f);
+
 	if (!result) {
 		WARN_LOG(G3D, "Incompatible Vulkan pipeline cache - rebuilding.");
 		// Bad cache file for this GPU/Driver/etc. Delete it.
@@ -274,7 +275,7 @@ u32 GPU_Vulkan::CheckGPUFeatures() const {
 
 	// We need to turn off framebuffer fetch through input attachments if MSAA is on for now.
 	// This is fixable, just needs some shader generator work (subpassInputMS).
-	if (g_Config.iMultiSampleLevel != 0) {
+	if (msaaLevel_ != 0) {
 		features &= ~GPU_USE_FRAMEBUFFER_FETCH;
 	}
 

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -727,7 +727,7 @@ bool PipelineManagerVulkan::LoadPipelineCache(FILE *file, bool loadRawPipelineCa
 	// Read the number of pipelines.
 	bool failed = fread(&size, sizeof(size), 1, file) != 1;
 
-	NOTICE_LOG(G3D, "Creating %d pipelines from cache...", size);
+	NOTICE_LOG(G3D, "Creating %d pipelines from cache (%dx MSAA)...", size, (1 << multiSampleLevel));
 	int pipelineCreateFailCount = 0;
 	int shaderFailCount = 0;
 	for (uint32_t i = 0; i < size; i++) {

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -324,7 +324,7 @@ static VulkanPipeline *CreateVulkanPipeline(VulkanRenderManager *renderManager, 
 	return vulkanPipeline;
 }
 
-VulkanPipeline *PipelineManagerVulkan::GetOrCreatePipeline(VulkanRenderManager *renderManager, VkPipelineLayout layout, const VulkanPipelineRasterStateKey &rasterKey, const DecVtxFormat *decFmt, VulkanVertexShader *vs, VulkanFragmentShader *fs, VulkanGeometryShader *gs, bool useHwTransform, u32 variantBitmask) {
+VulkanPipeline *PipelineManagerVulkan::GetOrCreatePipeline(VulkanRenderManager *renderManager, VkPipelineLayout layout, const VulkanPipelineRasterStateKey &rasterKey, const DecVtxFormat *decFmt, VulkanVertexShader *vs, VulkanFragmentShader *fs, VulkanGeometryShader *gs, bool useHwTransform, u32 variantBitmask, int multiSampleLevel) {
 	if (!pipelineCache_) {
 		VkPipelineCacheCreateInfo pc{ VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO };
 		VkResult res = vkCreatePipelineCache(vulkan_->GetDevice(), &pc, nullptr, &pipelineCache_);
@@ -355,7 +355,7 @@ VulkanPipeline *PipelineManagerVulkan::GetOrCreatePipeline(VulkanRenderManager *
 		pipelineFlags |= PipelineFlags::USES_MULTIVIEW;
 	}
 
-	VkSampleCountFlagBits sampleCount = MultiSampleLevelToFlagBits(g_Config.iMultiSampleLevel);
+	VkSampleCountFlagBits sampleCount = MultiSampleLevelToFlagBits(multiSampleLevel);
 
 	VulkanPipeline *pipeline = CreateVulkanPipeline(
 		renderManager, pipelineCache_, layout, pipelineFlags, sampleCount,
@@ -370,7 +370,7 @@ VulkanPipeline *PipelineManagerVulkan::GetOrCreatePipeline(VulkanRenderManager *
 	}
 }
 
-std::vector<std::string> PipelineManagerVulkan::DebugGetObjectIDs(DebugShaderType type) {
+std::vector<std::string> PipelineManagerVulkan::DebugGetObjectIDs(DebugShaderType type) const {
 	std::vector<std::string> ids;
 	switch (type) {
 	case SHADER_TYPE_PIPELINE:
@@ -667,7 +667,7 @@ void PipelineManagerVulkan::SavePipelineCache(FILE *file, bool saveRawPipelineCa
 	}
 }
 
-bool PipelineManagerVulkan::LoadPipelineCache(FILE *file, bool loadRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext, VkPipelineLayout layout) {
+bool PipelineManagerVulkan::LoadPipelineCache(FILE *file, bool loadRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext, VkPipelineLayout layout, int multiSampleLevel) {
 	VulkanRenderManager *rm = (VulkanRenderManager *)drawContext->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 	VulkanQueueRunner *queueRunner = rm->GetQueueRunner();
 
@@ -752,7 +752,7 @@ bool PipelineManagerVulkan::LoadPipelineCache(FILE *file, bool loadRawPipelineCa
 
 		// Avoid creating multisampled shaders if it's not enabled, as that results in an invalid combination.
 		u32 variantsToBuild = key.variants;
-		if (g_Config.iMultiSampleLevel == 0) {
+		if (multiSampleLevel == 0) {
 			for (u32 i = 0; i < (int)RenderPassType::TYPE_COUNT; i++) {
 				if (RenderPassTypeHasMultisample((RenderPassType)i)) {
 					variantsToBuild &= ~(1 << i);
@@ -763,7 +763,7 @@ bool PipelineManagerVulkan::LoadPipelineCache(FILE *file, bool loadRawPipelineCa
 		DecVtxFormat fmt;
 		fmt.InitializeFromID(key.vtxFmtId);
 		VulkanPipeline *pipeline = GetOrCreatePipeline(
-			rm, layout, key.raster, key.useHWTransform ? &fmt : 0, vs, fs, gs, key.useHWTransform, variantsToBuild);
+			rm, layout, key.raster, key.useHWTransform ? &fmt : 0, vs, fs, gs, key.useHWTransform, variantsToBuild, multiSampleLevel);
 		if (!pipeline) {
 			pipelineCreateFailCount += 1;
 		}

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -84,7 +84,7 @@ public:
 	~PipelineManagerVulkan();
 
 	// variantMask is only used when loading pipelines from cache.
-	VulkanPipeline *GetOrCreatePipeline(VulkanRenderManager *renderManager, VkPipelineLayout layout, const VulkanPipelineRasterStateKey &rasterKey, const DecVtxFormat *decFmt, VulkanVertexShader *vs, VulkanFragmentShader *fs, VulkanGeometryShader *gs, bool useHwTransform, u32 variantMask);
+	VulkanPipeline *GetOrCreatePipeline(VulkanRenderManager *renderManager, VkPipelineLayout layout, const VulkanPipelineRasterStateKey &rasterKey, const DecVtxFormat *decFmt, VulkanVertexShader *vs, VulkanFragmentShader *fs, VulkanGeometryShader *gs, bool useHwTransform, u32 variantMask, int multiSampleLevel);
 	int GetNumPipelines() const { return (int)pipelines_.size(); }
 
 	void Clear();
@@ -95,11 +95,11 @@ public:
 	void InvalidateMSAAPipelines();
 
 	std::string DebugGetObjectString(std::string id, DebugShaderType type, DebugShaderStringType stringType);
-	std::vector<std::string> DebugGetObjectIDs(DebugShaderType type);
+	std::vector<std::string> DebugGetObjectIDs(DebugShaderType type) const;
 
 	// Saves data for faster creation next time.
 	void SavePipelineCache(FILE *file, bool saveRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext);
-	bool LoadPipelineCache(FILE *file, bool loadRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext, VkPipelineLayout layout);
+	bool LoadPipelineCache(FILE *file, bool loadRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext, VkPipelineLayout layout, int multiSampleLevel);
 	void CancelCache();
 
 private:


### PR DESCRIPTION
Fixes some crashes if MSAA level is set to something that is not supported by the current GPU.