### PR TITLE
Add stub symbol for 'utimensat', making it work on Android 2.3 again

### DIFF
--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -199,6 +199,15 @@ AndroidGraphicsContext *graphicsContext;
 
 #define MessageBox(a, b, c, d) __android_log_print(ANDROID_LOG_INFO, APP_NAME, "%s %s", (b), (c));
 
+#if PPSSPP_ARCH(ARMV7)
+// Old Android workaround
+extern "C" {
+int utimensat(int fd, const char *path, const struct timespec times[2]) {
+	return -1;
+}
+}
+#endif
+
 void AndroidLogger::Log(const LogMessage &message) {
 	int mode;
 	switch (message.level) {


### PR DESCRIPTION
Fixes #16578