### PR TITLE
Common/VR: blind fix NULL type

### DIFF
--- a/Common/VR/VRBase.cpp
+++ b/Common/VR/VRBase.cpp
@@ -217,7 +217,7 @@ void VR_LeaveVR( engine_t* engine ) {
 		OXR(xrDestroySpace(engine->appState.FakeStageSpace));
 		engine->appState.CurrentSpace = XR_NULL_HANDLE;
 		OXR(xrDestroySession(engine->appState.Session));
-		engine->appState.Session = NULL;
+		engine->appState.Session = XR_NULL_HANDLE;
 	}
 }
 


### PR DESCRIPTION
Probably regressed by 9893e5c4abc4. [FreeBSD](https://github.com/freebsd/freebsd/commit/c8ed04c26b6758354853a6bed4629f71d0d01a7d) and [OpenBSD](https://github.com/openbsd/src/commit/6ecde746dea9a5d17abf3bafa06c232b9189b33b) define `NULL` via `nullptr` for C++ >= 11. Affects i386 but not amd64, didn't test armv7 and aarch64.

From [error log](https://github.com/hrydgard/ppsspp/files/10238397/ppsspp-1.14.log):
```c++
Common/VR/VRBase.cpp:220:30: error: assigning to 'XrSession' (aka 'unsigned long long') from incompatible type 'nullptr_t'
                engine->appState.Session = NULL;
                                           ^~~~
/usr/include/sys/_null.h:37:14: note: expanded from macro 'NULL'
#define NULL    nullptr
                ^~~~~~~
1 error generated.
```
