### PR TITLE
Supply some extra info in asserts (currently game ID and name).

### DIFF
--- a/Common/Log.cpp
+++ b/Common/Log.cpp
@@ -16,6 +16,7 @@
 // http://code.google.com/p/dolphin-emu/
 
 #include <string>
+#include <mutex>
 
 #include "ppsspp_config.h"
 
@@ -34,6 +35,14 @@
 
 static bool hitAnyAsserts = false;
 
+std::mutex g_extraAssertInfoMutex;
+std::string g_extraAssertInfo = "no extra info set";
+
+void SetExtraAssertInfo(const char *info) {
+	std::lock_guard<std::mutex> guard(g_extraAssertInfoMutex);
+	g_extraAssertInfo = info;
+}
+
 bool HandleAssert(const char *function, const char *file, int line, const char *expression, const char* format, ...) {
 	// Read message and write it to the log
 	char text[LOG_BUF_SIZE];
@@ -45,7 +54,10 @@ bool HandleAssert(const char *function, const char *file, int line, const char *
 
 	// Secondary formatting. Wonder if this can be combined into the vsnprintf somehow.
 	char formatted[LOG_BUF_SIZE + 128];
-	snprintf(formatted, sizeof(formatted), "(%s:%s:%d) %s: [%s] %s", file, function, line, caption, expression, text);
+	{
+		std::lock_guard<std::mutex> guard(g_extraAssertInfoMutex);
+		snprintf(formatted, sizeof(formatted), "(%s:%s:%d) %s: [%s] %s (%s)", file, function, line, caption, expression, text, g_extraAssertInfo.c_str());
+	}
 
 	// Normal logging (will also log to Android log)
 	ERROR_LOG(SYSTEM, "%s", formatted);

--- a/Common/Log.cpp
+++ b/Common/Log.cpp
@@ -36,11 +36,11 @@
 static bool hitAnyAsserts = false;
 
 std::mutex g_extraAssertInfoMutex;
-std::string g_extraAssertInfo = "no extra info set";
+std::string g_extraAssertInfo = "menu";
 
 void SetExtraAssertInfo(const char *info) {
 	std::lock_guard<std::mutex> guard(g_extraAssertInfoMutex);
-	g_extraAssertInfo = info;
+	g_extraAssertInfo = info ? info : "menu";
 }
 
 bool HandleAssert(const char *function, const char *file, int line, const char *expression, const char* format, ...) {

--- a/Common/Log.h
+++ b/Common/Log.h
@@ -118,6 +118,7 @@ __attribute__((format(printf, 5, 6)))
 
 bool HitAnyAsserts();
 void ResetHitAnyAsserts();
+void SetExtraAssertInfo(const char *info);
 
 #if defined(__ANDROID__)
 // Tricky macro to get the basename, that also works if *built* on Win32.

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -263,6 +263,8 @@ void EmuScreen::bootGame(const Path &filename) {
 	if (!info || info->pending)
 		return;
 
+	SetExtraAssertInfo((info->id + " " + info->GetTitle()).c_str());
+
 	if (!info->id.empty()) {
 		g_Config.loadGameConfig(info->id, info->GetTitle());
 		// Reset views in case controls are in a different place.

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -402,6 +402,9 @@ EmuScreen::~EmuScreen() {
 		// If we were invalid, it would already be shutdown.
 		PSP_Shutdown();
 	}
+
+	SetExtraAssertInfo(nullptr);
+
 #ifndef MOBILE_DEVICE
 	if (g_Config.bDumpFrames && startDumping)
 	{


### PR DESCRIPTION
Google Play Console can now show this along with the assert stacktrace (see #16601 ), and it's obviously useful to see what games we asserted in trying to emulate it.