### PR TITLE
Cleanup value corrections in config load/save

### DIFF
--- a/Common/Data/Text/I18n.cpp
+++ b/Common/Data/Text/I18n.cpp
@@ -67,13 +67,13 @@ std::shared_ptr<I18NCategory> I18NRepo::GetCategory(const char *category) {
 	}
 }
 
-std::string I18NRepo::GetIniPath(const std::string &languageID) const {
-	return "lang/" + languageID + ".ini";
+Path I18NRepo::GetIniPath(const std::string &languageID) const {
+	return Path("lang") / (languageID + ".ini");
 }
 
 bool I18NRepo::IniExists(const std::string &languageID) const {
 	File::FileInfo info;
-	if (!VFSGetFileInfo(GetIniPath(languageID).c_str(), &info))
+	if (!VFSGetFileInfo(GetIniPath(languageID).ToString().c_str(), &info))
 		return false;
 	if (!info.exists)
 		return false;
@@ -88,7 +88,7 @@ bool I18NRepo::LoadIni(const std::string &languageID, const Path &overridePath) 
 	if (!overridePath.empty()) {
 		iniPath = overridePath / (languageID + ".ini");
 	} else {
-		iniPath = Path(GetIniPath(languageID));
+		iniPath = GetIniPath(languageID);
 	}
 
 	if (!ini.LoadFromVFS(iniPath.ToString()))

--- a/Common/Data/Text/I18n.h
+++ b/Common/Data/Text/I18n.h
@@ -92,7 +92,7 @@ public:
 	std::map<std::string, std::vector<std::string>> GetMissingKeys() const;
 
 private:
-	std::string GetIniPath(const std::string &languageID) const;
+	Path GetIniPath(const std::string &languageID) const;
 	void Clear();
 	I18NCategory *LoadSection(const Section *section, const char *name);
 	void SaveSection(IniFile &ini, Section *section, std::shared_ptr<I18NCategory> cat);

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -47,7 +47,7 @@ void Compatibility::Load(const std::string &gameID) {
 		IniFile compat2;
 		// This one is user-editable. Need to load it after the system one.
 		Path path = GetSysDirectory(DIRECTORY_SYSTEM) / "compat.ini";
-		if (compat2.Load(path.ToString())) {
+		if (compat2.Load(path)) {
 			CheckSettings(compat2, gameID);
 		}
 	}
@@ -64,7 +64,7 @@ void Compatibility::Load(const std::string &gameID) {
 		IniFile compat2;
 		// This one is user-editable. Need to load it after the system one.
 		Path path = GetSysDirectory(DIRECTORY_SYSTEM) / "compatvr.ini";
-		if (compat2.Load(path.ToString())) {
+		if (compat2.Load(path)) {
 			CheckVRSettings(compat2, gameID);
 		}
 	}

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1433,11 +1433,6 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 			vPostShaderNames.push_back(it.second);
 	}
 
-	// This caps the exponent 4 (so 16x.)
-	if (iAnisotropyLevel > 4) {
-		iAnisotropyLevel = 4;
-	}
-
 	// Check for an old dpad setting
 	Section *control = iniFile.GetOrCreateSection("Control");
 	float f;
@@ -1482,24 +1477,6 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	}
 
 	CleanRecent();
-
-	// Set a default MAC, and correct if it's an old format.
-	if (sMACAddress.length() != 17)
-		sMACAddress = CreateRandMAC();
-
-	if (g_Config.bAutoFrameSkip && g_Config.bSkipBufferEffects) {
-		g_Config.bSkipBufferEffects = false;
-	}
-
-	// Automatically silence secondary instances. Could be an option I guess, but meh.
-	if (PPSSPP_ID > 1) {
-		g_Config.iGlobalVolume = 0;
-	}
-
-	// Automatically switch away from deprecated setting value.
-	if (iTexScalingLevel <= 0) {
-		iTexScalingLevel = 1;
-	}
 
 #if PPSSPP_PLATFORM(ANDROID)
 	// The on path here is untested, since we don't expose it.
@@ -1619,6 +1596,29 @@ void Config::PostLoadCleanup(bool gameSpecific) {
 	if (DefaultCpuCore() != (int)CPUCore::JIT && g_Config.iCpuCore == (int)CPUCore::JIT) {
 		jitForcedOff = true;
 		g_Config.iCpuCore = (int)CPUCore::IR_JIT;
+	}
+
+	// This caps the exponent 4 (so 16x.)
+	if (iAnisotropyLevel > 4) {
+		iAnisotropyLevel = 4;
+	}
+
+	// Set a default MAC, and correct if it's an old format.
+	if (sMACAddress.length() != 17)
+		sMACAddress = CreateRandMAC();
+
+	if (g_Config.bAutoFrameSkip && g_Config.bSkipBufferEffects) {
+		g_Config.bSkipBufferEffects = false;
+	}
+
+	// Automatically silence secondary instances. Could be an option I guess, but meh.
+	if (PPSSPP_ID > 1) {
+		g_Config.iGlobalVolume = 0;
+	}
+
+	// Automatically switch away from deprecated setting value.
+	if (iTexScalingLevel <= 0) {
+		iTexScalingLevel = 1;
 	}
 }
 

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1351,7 +1351,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	bShowFrameProfiler = true;
 
 	IniFile iniFile;
-	if (!iniFile.Load(iniFilename_.ToString())) {
+	if (!iniFile.Load(iniFilename_)) {
 		ERROR_LOG(LOADER, "Failed to read '%s'. Setting config to default.", iniFilename_.c_str());
 		// Continue anyway to initialize the config.
 	}
@@ -1879,7 +1879,7 @@ bool Config::saveGameConfig(const std::string &pGameId, const std::string &title
 	}
 
 	KeyMap::SaveToIni(iniFile);
-	iniFile.Save(fullIniFilePath.ToString());
+	iniFile.Save(fullIniFilePath);
 
 	return true;
 }
@@ -1894,7 +1894,7 @@ bool Config::loadGameConfig(const std::string &pGameId, const std::string &title
 
 	changeGameSpecific(pGameId, title);
 	IniFile iniFile;
-	iniFile.Load(iniFileNameFull.ToString());
+	iniFile.Load(iniFileNameFull);
 
 	auto postShaderSetting = iniFile.GetOrCreateSection("PostShaderSetting")->ToMap();
 	mPostShaderSetting.clear();
@@ -1929,7 +1929,7 @@ void Config::unloadGameConfig() {
 		changeGameSpecific();
 
 		IniFile iniFile;
-		iniFile.Load(iniFilename_.ToString());
+		iniFile.Load(iniFilename_);
 
 		// Reload game specific settings back to standard.
 		IterateSettings(iniFile, [](Section *section, ConfigSetting *setting) {
@@ -1957,7 +1957,7 @@ void Config::unloadGameConfig() {
 
 void Config::LoadStandardControllerIni() {
 	IniFile controllerIniFile;
-	if (!controllerIniFile.Load(controllerIniFilename_.ToString())) {
+	if (!controllerIniFile.Load(controllerIniFilename_)) {
 		ERROR_LOG(LOADER, "Failed to read %s. Setting controller config to default.", controllerIniFilename_.c_str());
 		KeyMap::RestoreDefault();
 	} else {

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -575,6 +575,10 @@ protected:
 	void LoadStandardControllerIni();
 	void LoadLangValuesMapping();
 
+	void PostLoadCleanup(bool gameSpecific);
+	void PreSaveCleanup(bool gameSpecific);
+	void PostSaveCleanup(bool gameSpecific);
+
 private:
 	bool reload_ = false;
 	std::string gameId_;


### PR DESCRIPTION
This may help #16607 and might fix some other bugs.

Whether Load() or loadGameConfig() is used seems to be a bit dynamic in the code currently, so I figured it was safest to add a dedicated place to cleanup loaded config data or to modify configs before saving them.  I think separating it makes it cleaner anyway, though (even if Load vs loadGameConfig were more consistent.)

I suspect on iOS, jit was just getting re-enabled for people and it was crashing from that.

-[Unknown]