### PR TITLE
D3D9: Support old-style user clip planes

### DIFF
--- a/Common/GPU/D3D9/D3D9StateCache.h
+++ b/Common/GPU/D3D9/D3D9StateCache.h
@@ -361,6 +361,7 @@ public:
 
 	DxState1<D3DRS_CULLMODE, D3DCULL_NONE> cullMode;
 	DxState1<D3DRS_SHADEMODE, D3DSHADE_GOURAUD> shadeMode;
+	DxState1<D3DRS_CLIPPLANEENABLE, 0> clipPlaneEnable;
 
 	BoolState<D3DRS_ZENABLE, false> depthTest;
 

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -177,6 +177,8 @@ public:
 	void Apply(LPDIRECT3DDEVICE9 device) {
 		dxstate.cullMode.set(cullMode);
 		dxstate.scissorTest.enable();
+		// Force user clipping off.
+		dxstate.clipPlaneEnable.set(0);
 	}
 };
 
@@ -765,6 +767,8 @@ D3D9Context::D3D9Context(IDirect3D9 *d3d, IDirect3D9Ex *d3dEx, int adapterId, ID
 	caps_.blendMinMaxSupported = true;
 	caps_.isTilingGPU = false;
 	caps_.multiSampleLevelsMask = 1;  // More could be supported with some work.
+
+	caps_.clipPlanesSupported = caps.MaxUserClipPlanes;
 
 	if ((caps.RasterCaps & D3DPRASTERCAPS_ANISOTROPY) != 0 && caps.MaxAnisotropy > 1) {
 		caps_.anisoSupported = true;

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -580,6 +580,9 @@ struct DeviceCaps {
 	// From the other backends, we can detect if D3D9 support is known bad (like on Xe) and disable it.
 	bool supportsD3D9;
 
+	// Old style, for older GL or Direct3D 9.
+	u32 clipPlanesSupported;
+
 	u32 multiSampleLevelsMask;  // Bit n is set if (1 << n) is a valid multisample level. Bit 0 is always set.
 	std::string deviceName;  // The device name to use when creating the thin3d context, to get the same one.
 };

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -452,6 +452,12 @@ void ShaderManagerDX9::VSUpdateUniforms(u64 dirtyUniforms) {
 
 		float data[4] = { viewZScale, viewZCenter, reverseTranslate, reverseScale };
 		VSSetFloatUniform4(CONST_VS_DEPTHRANGE, data);
+
+		if (draw_->GetDeviceCaps().clipPlanesSupported >= 1) {
+			float clip[4] = { 0.0f, 0.0f, reverseScale, 1.0f - reverseTranslate * reverseScale };
+			// Well, not a uniform, but we treat it as one like other backends.
+			device_->SetClipPlane(0, clip);
+		}
 	}
 	if (dirtyUniforms & DIRTY_CULLRANGE) {
 		float minValues[4], maxValues[4];

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -201,6 +201,12 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 		} else {
 			dxstate.shadeMode.set(gstate.getShadeMode() == GE_SHADE_GOURAUD ? D3DSHADE_GOURAUD : D3DSHADE_FLAT);
 		}
+
+		// We use fixed-function user clipping on D3D9, where available, for negative Z clipping.
+		if (draw_->GetDeviceCaps().clipPlanesSupported >= 1) {
+			bool wantClip = !gstate.isModeThrough();
+			dxstate.clipPlaneEnable.set(wantClip ? 1 : 0);
+		}
 	}
 
 	if (gstate_c.IsDirty(DIRTY_DEPTHSTENCIL_STATE)) {

--- a/GPU/Directx9/StateMappingDX9.cpp
+++ b/GPU/Directx9/StateMappingDX9.cpp
@@ -204,7 +204,7 @@ void DrawEngineDX9::ApplyDrawState(int prim) {
 
 		// We use fixed-function user clipping on D3D9, where available, for negative Z clipping.
 		if (draw_->GetDeviceCaps().clipPlanesSupported >= 1) {
-			bool wantClip = !gstate.isModeThrough();
+			bool wantClip = !gstate.isModeThrough() && gstate_c.submitType == SubmitType::DRAW;
 			dxstate.clipPlaneEnable.set(wantClip ? 1 : 0);
 		}
 	}

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2115,7 +2115,7 @@ void GPUCommon::Execute_Bezier(u32 op, u32 diff) {
 
 	SetDrawType(DRAW_BEZIER, PatchPrimToPrim(surface.primType));
 
-	gstate_c.Dirty(DIRTY_VERTEXSHADER_STATE | DIRTY_GEOMETRYSHADER_STATE);
+	gstate_c.Dirty(DIRTY_RASTER_STATE | DIRTY_VERTEXSHADER_STATE | DIRTY_GEOMETRYSHADER_STATE);
 	if (drawEngineCommon_->CanUseHardwareTessellation(surface.primType)) {
 		gstate_c.submitType = SubmitType::HW_BEZIER;
 		if (gstate_c.spline_num_points_u != surface.num_points_u) {
@@ -2130,7 +2130,7 @@ void GPUCommon::Execute_Bezier(u32 op, u32 diff) {
 	UpdateUVScaleOffset();
 	drawEngineCommon_->SubmitCurve(control_points, indices, surface, gstate.vertType, &bytesRead, "bezier");
 
-	gstate_c.Dirty(DIRTY_VERTEXSHADER_STATE | DIRTY_GEOMETRYSHADER_STATE);
+	gstate_c.Dirty(DIRTY_RASTER_STATE | DIRTY_VERTEXSHADER_STATE | DIRTY_GEOMETRYSHADER_STATE);
 	gstate_c.submitType = SubmitType::DRAW;
 
 	// After drawing, we advance pointers - see SubmitPrim which does the same.
@@ -2190,7 +2190,7 @@ void GPUCommon::Execute_Spline(u32 op, u32 diff) {
 
 	SetDrawType(DRAW_SPLINE, PatchPrimToPrim(surface.primType));
 
-	gstate_c.Dirty(DIRTY_VERTEXSHADER_STATE);
+	gstate_c.Dirty(DIRTY_RASTER_STATE | DIRTY_VERTEXSHADER_STATE | DIRTY_GEOMETRYSHADER_STATE);
 	if (drawEngineCommon_->CanUseHardwareTessellation(surface.primType)) {
 		gstate_c.submitType = SubmitType::HW_SPLINE;
 		if (gstate_c.spline_num_points_u != surface.num_points_u) {
@@ -2205,7 +2205,7 @@ void GPUCommon::Execute_Spline(u32 op, u32 diff) {
 	UpdateUVScaleOffset();
 	drawEngineCommon_->SubmitCurve(control_points, indices, surface, gstate.vertType, &bytesRead, "spline");
 
-	gstate_c.Dirty(DIRTY_VERTEXSHADER_STATE | DIRTY_GEOMETRYSHADER_STATE);
+	gstate_c.Dirty(DIRTY_RASTER_STATE | DIRTY_VERTEXSHADER_STATE | DIRTY_GEOMETRYSHADER_STATE);
 	gstate_c.submitType = SubmitType::DRAW;
 
 	// After drawing, we advance pointers - see SubmitPrim which does the same.


### PR DESCRIPTION
This fixes negative Z issues on D3D9 in many cases, such as #14168 and #16574, but only when clip planes are supported.  Fixes #16615.

Something similar is doable on GL2 (may help older Apple), but I'm having trouble being able to test it, so I'll create a separate PR...

-[Unknown]