### PR TITLE
Debugger: Don't hang memory dump if stepping in GE

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -131,14 +131,14 @@ static inline void Core_StateProcessed() {
 }
 
 void Core_WaitInactive() {
-	while (Core_IsActive()) {
+	while (Core_IsActive() && !GPUStepping::IsStepping()) {
 		std::unique_lock<std::mutex> guard(m_hInactiveMutex);
 		m_InactiveCond.wait(guard);
 	}
 }
 
 void Core_WaitInactive(int milliseconds) {
-	if (Core_IsActive()) {
+	if (Core_IsActive() && !GPUStepping::IsStepping()) {
 		std::unique_lock<std::mutex> guard(m_hInactiveMutex);
 		m_InactiveCond.wait_for(guard, std::chrono::milliseconds(milliseconds));
 	}


### PR DESCRIPTION
Previously, if you clicked "Step Frame" or "Step Prim" and then went to the memory view to dump memory to a file, all of PPSSPP would lock up.

-[Unknown]