### PR TITLE
GL: Cleanup a check to use ARB instead

### DIFF
--- a/Common/Data/Convert/SmallDataConvert.h
+++ b/Common/Data/Convert/SmallDataConvert.h
@@ -174,7 +174,7 @@ inline void CopyFloat3(float dest[3], const float src[3]) {
 	dest[2] = src[2];
 }
 
-inline void CopyFloat4(float dest[3], const float src[3]) {
+inline void CopyFloat4(float dest[4], const float src[4]) {
 #ifdef _M_SSE
 	_mm_storeu_ps(dest, _mm_loadu_ps(src));
 #else

--- a/GPU/GLES/DepthBufferGLES.cpp
+++ b/GPU/GLES/DepthBufferGLES.cpp
@@ -128,7 +128,7 @@ static bool SupportsDepthTexturing() {
 	if (gl_extensions.IsGLES) {
 		return gl_extensions.OES_packed_depth_stencil && (gl_extensions.OES_depth_texture || gl_extensions.GLES3);
 	}
-	return gl_extensions.VersionGEThan(3, 0);
+	return gl_extensions.ARB_texture_float;
 }
 
 static Draw::Pipeline *CreateReadbackPipeline(Draw::DrawContext *draw, const char *tag, const UniformBufferDesc *ubDesc, const char *fs, const char *fsTag, const char *vs, const char *vsTag) {


### PR DESCRIPTION
Small cleanup I'd seen when messing with GL for #16615 before.

-[Unknown]