### PR TITLE
VRBase: fix build error with musl libc

### DIFF
--- a/Common/VR/VRBase.cpp
+++ b/Common/VR/VRBase.cpp
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <vector>
 


### PR DESCRIPTION
```
ppsspp-1.14.1/Common/VR/VRBase.cpp:94:9: error: 'exit' was not declared in this scope
   exit(1);                                                                   
```
exit() is declared in stdlib.h, but due to namespace pollution in glibc it happens to work there.