### PR TITLE
Crash: Ensure we never handle faults in faults

### DIFF
--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -427,12 +427,20 @@ bool Arm64Jit::DescribeCodePtr(const u8 *ptr, std::string &name) {
 		name = "loadStaticRegisters";
 	else {
 		u32 addr = blocks.GetAddressFromBlockPtr(ptr);
-		std::vector<int> numbers;
-		blocks.GetBlockNumbersFromAddress(addr, &numbers);
-		if (!numbers.empty()) {
-			const JitBlock *block = blocks.GetBlock(numbers[0]);
+		// Returns 0 when it's valid, but unknown.
+		if (addr == 0) {
+			name = "(unknown or deleted block)";
+			return true;
+		} else if (addr != (u32)-1) {
+			name = "(outside space)";
+			return true;
+		}
+
+		int number = blocks.GetBlockNumberFromAddress(addr);
+		if (number != -1) {
+			const JitBlock *block = blocks.GetBlock(number);
 			if (block) {
-				name = StringFromFormat("(block %d at %08x)", numbers[0], block->originalAddress);
+				name = StringFromFormat("(block %d at %08x)", number, block->originalAddress);
 				return true;
 			}
 		}

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -375,6 +375,15 @@ void JitBlockCache::GetBlockNumbersFromAddress(u32 em_address, std::vector<int> 
 			block_numbers->push_back(i);
 }
 
+int JitBlockCache::GetBlockNumberFromAddress(u32 em_address) {
+	for (int i = 0; i < num_blocks_; i++) {
+		if (blocks_[i].ContainsAddress(em_address))
+			return i;
+	}
+
+	return -1;
+}
+
 u32 JitBlockCache::GetAddressFromBlockPtr(const u8 *ptr) const {
 	if (!codeBlock_->IsInSpace(ptr))
 		return (u32)-1;

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -143,6 +143,8 @@ public:
 	// Returns a list of block numbers - only one block can start at a particular address, but they CAN overlap.
 	// This one is slow so should only be used for one-shots from the debugger UI, not for anything during runtime.
 	void GetBlockNumbersFromAddress(u32 em_address, std::vector<int> *block_numbers);
+	// Similar to above, but only the first matching address.
+	int GetBlockNumberFromAddress(u32 em_address);
 	int GetBlockNumberFromEmuHackOp(MIPSOpcode inst, bool ignoreBad = false) const;
 
 	u32 GetAddressFromBlockPtr(const u8 *ptr) const;

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -1145,13 +1145,7 @@ UI::EventReturn JitCompareScreen::OnCurrentBlock(UI::EventParams &e) {
 	JitBlockCache *blockCache = MIPSComp::jit->GetBlockCache();
 	if (!blockCache)
 		return UI::EVENT_DONE;
-	std::vector<int> blockNum;
-	blockCache->GetBlockNumbersFromAddress(currentMIPS->pc, &blockNum);
-	if (blockNum.size() > 0) {
-		currentBlock_ = blockNum[0];
-	} else {
-		currentBlock_ = -1;
-	}
+	currentBlock_ = blockCache->GetBlockNumberFromAddress(currentMIPS->pc);
 	UpdateDisasm();
 	return UI::EVENT_DONE;
 }


### PR DESCRIPTION
Just a bit of paranoia.  Makes me wish for the simple syntax D had, `scope(exit) { inCrashHandler = false; }`.

Also tweaked the DescribeCodePtr lookup in case something was going wrong in it.  Maybe it returned 0 and a bunch of invalid blocks matched it, or something.

-[Unknown]