### PR TITLE
Minor initialization cleanup, setup for Vulkan validation layers on Android

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -298,11 +298,22 @@ public:
 	const VulkanPhysicalDeviceInfo &GetDeviceInfo() const { return deviceInfo_; }
 	const VkSurfaceCapabilitiesKHR &GetSurfaceCapabilities() const { return surfCapabilities_; }
 
-	bool IsInstanceExtensionAvailable(const char *name) const {
-		for (auto &iter : instance_extension_properties_) {
-			if (!strcmp(name, iter.extensionName))
+	bool IsInstanceExtensionAvailable(const char *extensionName) const {
+		for (const auto &iter : instance_extension_properties_) {
+			if (!strcmp(extensionName, iter.extensionName))
 				return true;
 		}
+
+		// Also search through the layers, one of them might carry the extension (especially DEBUG_utils)
+		for (const auto &iter : instance_layer_properties_) {
+			for (const auto &ext : iter.extensions) {
+				if (!strcmp(extensionName, ext.extensionName)) {
+					INFO_LOG(G3D, "%s found in layer extensions: %s", extensionName, iter.properties.layerName);
+					return true;
+				}
+			}
+		}
+
 		return false;
 	}
 

--- a/Common/GPU/Vulkan/VulkanFrameData.cpp
+++ b/Common/GPU/Vulkan/VulkanFrameData.cpp
@@ -112,8 +112,10 @@ VkCommandBuffer FrameData::GetInitCmd(VulkanContext *vulkan) {
 		}
 
 		// Good spot to reset the query pool.
-		vkCmdResetQueryPool(initCmd, profile.queryPool, 0, MAX_TIMESTAMP_QUERIES);
-		vkCmdWriteTimestamp(initCmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, profile.queryPool, 0);
+		if (profilingEnabled_) {
+			vkCmdResetQueryPool(initCmd, profile.queryPool, 0, MAX_TIMESTAMP_QUERIES);
+			vkCmdWriteTimestamp(initCmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, profile.queryPool, 0);
+		}
 
 		hasInitCommands = true;
 	}

--- a/Common/GPU/Vulkan/VulkanProfiler.cpp
+++ b/Common/GPU/Vulkan/VulkanProfiler.cpp
@@ -8,17 +8,27 @@ using namespace PPSSPP_VK;
 void VulkanProfiler::Init(VulkanContext *vulkan) {
 	vulkan_ = vulkan;
 
-	VkQueryPoolCreateInfo ci{ VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO };
-	ci.queryCount = MAX_QUERY_COUNT;
-	ci.queryType = VK_QUERY_TYPE_TIMESTAMP;
-	vkCreateQueryPool(vulkan->GetDevice(), &ci, nullptr, &queryPool_);
+	validBits_ = vulkan_->GetQueueFamilyProperties(vulkan_->GetGraphicsQueueFamilyIndex()).timestampValidBits;
+
+	if (validBits_) {
+		VkQueryPoolCreateInfo ci{ VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO };
+		ci.queryCount = MAX_QUERY_COUNT;
+		ci.queryType = VK_QUERY_TYPE_TIMESTAMP;
+		vkCreateQueryPool(vulkan->GetDevice(), &ci, nullptr, &queryPool_);
+	}
 }
 
 void VulkanProfiler::Shutdown() {
-	vkDestroyQueryPool(vulkan_->GetDevice(), queryPool_, nullptr);
+	if (queryPool_) {
+		vkDestroyQueryPool(vulkan_->GetDevice(), queryPool_, nullptr);
+	}
 }
 
 void VulkanProfiler::BeginFrame(VulkanContext *vulkan, VkCommandBuffer firstCommandBuf) {
+	if (!validBits_) {
+		return;
+	}
+
 	vulkan_ = vulkan;
 
 	// Check for old queries belonging to this frame context that we can log out - these are now
@@ -28,8 +38,7 @@ void VulkanProfiler::BeginFrame(VulkanContext *vulkan, VkCommandBuffer firstComm
 		vkGetQueryPoolResults(vulkan->GetDevice(), queryPool_, 0, numQueries_, sizeof(uint64_t) * numQueries_, results.data(), sizeof(uint64_t), VK_QUERY_RESULT_64_BIT);
 
 		double timestampConversionFactor = (double)vulkan_->GetPhysicalDeviceProperties().properties.limits.timestampPeriod * (1.0 / 1000000.0);
-		int validBits = vulkan_->GetQueueFamilyProperties(vulkan_->GetGraphicsQueueFamilyIndex()).timestampValidBits;
-		uint64_t timestampDiffMask = validBits == 64 ? 0xFFFFFFFFFFFFFFFFULL : ((1ULL << validBits) - 1);
+		uint64_t timestampDiffMask = validBits_ == 64 ? 0xFFFFFFFFFFFFFFFFULL : ((1ULL << validBits_) - 1);
 
 		static const char * const indent[4] = { "", "  ", "    ", "      " };
 
@@ -69,7 +78,7 @@ void VulkanProfiler::BeginFrame(VulkanContext *vulkan, VkCommandBuffer firstComm
 }
 
 void VulkanProfiler::Begin(VkCommandBuffer cmdBuf, VkPipelineStageFlagBits stageFlags, const char *fmt, ...) {
-	if ((enabledPtr_ && !*enabledPtr_) || numQueries_ >= MAX_QUERY_COUNT - 1) {
+	if (!validBits_ || (enabledPtr_ && !*enabledPtr_) || numQueries_ >= MAX_QUERY_COUNT - 1) {
 		return;
 	}
 
@@ -90,7 +99,7 @@ void VulkanProfiler::Begin(VkCommandBuffer cmdBuf, VkPipelineStageFlagBits stage
 }
 
 void VulkanProfiler::End(VkCommandBuffer cmdBuf, VkPipelineStageFlagBits stageFlags) {
-	if ((enabledPtr_ && !*enabledPtr_) || numQueries_ >= MAX_QUERY_COUNT - 1) {
+	if (!validBits_ || (enabledPtr_ && !*enabledPtr_) || numQueries_ >= MAX_QUERY_COUNT - 1) {
 		return;
 	}
 

--- a/Common/GPU/Vulkan/VulkanProfiler.h
+++ b/Common/GPU/Vulkan/VulkanProfiler.h
@@ -47,6 +47,7 @@ private:
 	int numQueries_ = 0;
 	bool firstFrame_ = true;
 	bool *enabledPtr_ = nullptr;
+	int validBits_ = 0;
 
 	std::vector<size_t> scopeStack_;
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -451,8 +451,10 @@ void VulkanRenderManager::BeginFrame(bool enableProfiling, bool enableLogProfile
 	}
 	vkResetFences(device, 1, &frameData.fence);
 
+	int validBits = vulkan_->GetQueueFamilyProperties(vulkan_->GetGraphicsQueueFamilyIndex()).timestampValidBits;
+
 	// Can't set this until after the fence.
-	frameData.profilingEnabled_ = enableProfiling;
+	frameData.profilingEnabled_ = enableProfiling && validBits > 0;
 
 	uint64_t queryResults[MAX_TIMESTAMP_QUERIES];
 
@@ -466,7 +468,6 @@ void VulkanRenderManager::BeginFrame(bool enableProfiling, bool enableLogProfile
 				VK_QUERY_RESULT_64_BIT);
 			if (res == VK_SUCCESS) {
 				double timestampConversionFactor = (double)vulkan_->GetPhysicalDeviceProperties().properties.limits.timestampPeriod * (1.0 / 1000000.0);
-				int validBits = vulkan_->GetQueueFamilyProperties(vulkan_->GetGraphicsQueueFamilyIndex()).timestampValidBits;
 				uint64_t timestampDiffMask = validBits == 64 ? 0xFFFFFFFFFFFFFFFFULL : ((1ULL << validBits) - 1);
 				std::stringstream str;
 

--- a/Common/Math/geom2d.h
+++ b/Common/Math/geom2d.h
@@ -28,7 +28,7 @@ struct Point {
 
 // Resolved bounds on screen after layout.
 struct Bounds {
-	Bounds() : x(0), y(0), w(0), h(0) {}
+	Bounds() : x(0.0f), y(0.0f), w(0.0f), h(0.0f) {}
 	Bounds(float x_, float y_, float w_, float h_) : x(x_), y(y_), w(w_), h(h_) {}
 
 	bool Contains(float px, float py) const {

--- a/Common/Render/DrawBuffer.cpp
+++ b/Common/Render/DrawBuffer.cpp
@@ -14,6 +14,8 @@
 #include "Common/Log.h"
 #include "Common/StringUtils.h"
 
+#include "Common/Math/math_util.h"
+
 DrawBuffer::DrawBuffer() {
 	verts_ = new Vertex[MAX_VERTS];
 	fontscalex = 1.0f;
@@ -85,7 +87,13 @@ void DrawBuffer::Flush(bool set_blend_state) {
 }
 
 void DrawBuffer::V(float x, float y, float z, uint32_t color, float u, float v) {
-	_assert_msg_(count_ < MAX_VERTS, "Overflowed the DrawBuffer");
+	_dbg_assert_msg_(count_ < MAX_VERTS, "Overflowed the DrawBuffer");
+
+#ifdef _DEBUG
+	if (my_isnanorinf(x) || my_isnanorinf(y) || my_isnanorinf(z)) {
+		_assert_(false);
+	}
+#endif
 
 	Vertex *vert = &verts_[count_++];
 	vert->x = x;

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -372,7 +372,7 @@ class CallbackColorTween;
 
 class View {
 public:
-	View(LayoutParams *layoutParams = 0) : layoutParams_(layoutParams), visibility_(V_VISIBLE), measuredWidth_(0), measuredHeight_(0), enabledPtr_(0), enabled_(true), enabledMeansDisabled_(false) {
+	View(LayoutParams *layoutParams = 0) : layoutParams_(layoutParams) {
 		if (!layoutParams)
 			layoutParams_.reset(new LayoutParams());
 	}
@@ -481,22 +481,22 @@ protected:
 	std::unique_ptr<LayoutParams> layoutParams_;
 
 	std::string tag_;
-	Visibility visibility_;
+	Visibility visibility_ = V_VISIBLE;
 
 	// Results of measure pass. Set these in Measure.
-	float measuredWidth_;
-	float measuredHeight_;
+	float measuredWidth_ = 0.0f;
+	float measuredHeight_ = 0.0f;
 
 	// Outputs of layout. X/Y are absolute screen coordinates, hierarchy is "gone" here.
-	Bounds bounds_;
+	Bounds bounds_{};
 
 	std::vector<Tween *> tweens_;
 
 private:
 	std::function<bool()> enabledFunc_;
-	bool *enabledPtr_;
-	bool enabled_;
-	bool enabledMeansDisabled_;
+	bool *enabledPtr_ = nullptr;
+	bool enabled_ = true;
+	bool enabledMeansDisabled_ = false;
 
 	DISALLOW_COPY_AND_ASSIGN(View);
 };

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -46,7 +46,7 @@ private:
 
 	int lastNonDeadzoneDeviceID_[2]{};
 
-	float history[2][2] = {};
+	float history[2][2]{};
 
 	// Mappable auto-rotation. Useful for keyboard/dpad->analog in a few games.
 	bool autoRotatingAnalogCW_ = false;

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -34,7 +34,7 @@ class SingleControlMapper;
 
 class ControlMappingScreen : public UIDialogScreenWithGameBackground {
 public:
-	ControlMappingScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {}
+	explicit ControlMappingScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {}
 	const char *tag() const override { return "ControlMapping"; }
 
 protected:
@@ -49,7 +49,7 @@ private:
 
 	void dialogFinished(const Screen *dialog, DialogResult result) override;
 
-	UI::ScrollView *rightScroll_;
+	UI::ScrollView *rightScroll_ = nullptr;
 	std::vector<SingleControlMapper *> mappers_;
 	int keyMapGeneration_ = -1;
 };
@@ -57,9 +57,7 @@ private:
 class KeyMappingNewKeyDialog : public PopupScreen {
 public:
 	explicit KeyMappingNewKeyDialog(int btn, bool replace, std::function<void(KeyDef)> callback, std::shared_ptr<I18NCategory> i18n)
-		: PopupScreen(i18n->T("Map Key"), "Cancel", ""), callback_(callback) {
-		pspBtn_ = btn;
-	}
+		: PopupScreen(i18n->T("Map Key"), "Cancel", ""), pspBtn_(btn), callback_(callback) {}
 
 	const char *tag() const override { return "KeyMappingNewKey"; }
 
@@ -85,9 +83,7 @@ private:
 class KeyMappingNewMouseKeyDialog : public PopupScreen {
 public:
 	KeyMappingNewMouseKeyDialog(int btn, bool replace, std::function<void(KeyDef)> callback, std::shared_ptr<I18NCategory> i18n)
-		: PopupScreen(i18n->T("Map Mouse"), "", ""), callback_(callback), mapped_(false) {
-		pspBtn_ = btn;
-	}
+		: PopupScreen(i18n->T("Map Mouse"), "", ""), pspBtn_(btn), callback_(callback), mapped_(false) {}
 
 	const char *tag() const override { return "KeyMappingNewMouseKey"; }
 

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -308,13 +308,8 @@ private:
 
 class SnapGrid : public UI::View {
 public:
-	SnapGrid(int leftMargin, int rightMargin, int topMargin, int bottomMargin, u32 color) {
-		x1 = leftMargin;
-		x2 = rightMargin;
-		y1 = topMargin;
-		y2 = bottomMargin;
-		col = color;
-	}
+	SnapGrid(int leftMargin, int rightMargin, int topMargin, int bottomMargin, u32 color)
+		: UI::View(), x1(leftMargin), x2(rightMargin), y1(topMargin), y2(bottomMargin), col(color) {}
 
 	void Draw(UIContext &dc) override {
 		if (g_Config.bTouchSnapToGrid) {
@@ -602,7 +597,7 @@ UI::EventReturn TouchControlLayoutScreen::OnMode(UI::EventParams &e) {
 }
 
 void TouchControlLayoutScreen::update() {
-	UIDialogScreenWithBackground::update();
+	UIDialogScreenWithGameBackground::update();
 
 	// TODO: We really, really need a cleaner solution for creating sub-views
 	// of custom compound controls.

--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -21,10 +21,17 @@ AndroidVulkanContext::~AndroidVulkanContext() {
 }
 
 static uint32_t FlagsFromConfig() {
+	uint32_t flags;
+
 	if (g_Config.bVSync) {
-		return VULKAN_FLAG_PRESENT_FIFO;
+		flags = VULKAN_FLAG_PRESENT_FIFO;
+	} else {
+		flags = VULKAN_FLAG_PRESENT_MAILBOX | VULKAN_FLAG_PRESENT_FIFO_RELAXED;
 	}
-	return VULKAN_FLAG_PRESENT_MAILBOX | VULKAN_FLAG_PRESENT_FIFO_RELAXED;
+#ifdef _DEBUG
+	flags |= VULKAN_FLAG_VALIDATE;
+#endif
+	return flags;
 }
 
 bool AndroidVulkanContext::InitAPI() {

--- a/android/src/main/jniLibs/.gitignore
+++ b/android/src/main/jniLibs/.gitignore
@@ -1,0 +1,4 @@
+arm64-v8a
+armeabi-v7a
+x86
+x86_64

--- a/android/src/main/jniLibs/README.txt
+++ b/android/src/main/jniLibs/README.txt
@@ -1,0 +1,1 @@
+Put the arm64-v8a and the other folders here, downloaded from https://github.com/KhronosGroup/Vulkan-ValidationLayers/releases


### PR DESCRIPTION
This adds the necessary parts to enable the Vulkan validation layers in debug mode on Android (after copying them to `android/src/main/jniLibs/`).

Additionally, fixes one validation error this finds on some PowerVR GPUs (they have no working timestamp support).

Not really an important 1.14.2 fix, but shouldn't exactly be risky.