### PR TITLE
Found a bug where we tried to look up queue family -1 when initializing the frame profiler.

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -117,6 +117,7 @@ public:
 	void QueueDeleteFramebuffer(VkFramebuffer &framebuffer) { _dbg_assert_(framebuffer != VK_NULL_HANDLE); framebuffers_.push_back(framebuffer); framebuffer = VK_NULL_HANDLE; }
 	void QueueDeletePipelineLayout(VkPipelineLayout &pipelineLayout) { _dbg_assert_(pipelineLayout != VK_NULL_HANDLE); pipelineLayouts_.push_back(pipelineLayout); pipelineLayout = VK_NULL_HANDLE; }
 	void QueueDeleteDescriptorSetLayout(VkDescriptorSetLayout &descSetLayout) { _dbg_assert_(descSetLayout != VK_NULL_HANDLE); descSetLayouts_.push_back(descSetLayout); descSetLayout = VK_NULL_HANDLE; }
+	void QueueDeleteQueryPool(VkQueryPool &queryPool) { _dbg_assert_(queryPool != VK_NULL_HANDLE); queryPools_.push_back(queryPool); queryPool = VK_NULL_HANDLE; }
 	void QueueCallback(void(*func)(void *userdata), void *userdata) { callbacks_.push_back(Callback(func, userdata)); }
 
 	void QueueDeleteBufferAllocation(VkBuffer &buffer, VmaAllocation &alloc) { 
@@ -152,6 +153,7 @@ private:
 	std::vector<VkFramebuffer> framebuffers_;
 	std::vector<VkPipelineLayout> pipelineLayouts_;
 	std::vector<VkDescriptorSetLayout> descSetLayouts_;
+	std::vector<VkQueryPool> queryPools_;
 	std::vector<Callback> callbacks_;
 };
 
@@ -386,10 +388,11 @@ private:
 	bool CheckLayers(const std::vector<LayerProperties> &layer_props, const std::vector<const char *> &layer_names) const;
 
 	WindowSystem winsys_;
+
 	// Don't use the real types here to avoid having to include platform-specific stuff
 	// that we really don't want in everything that uses VulkanContext.
-	void *winsysData1_;
-	void *winsysData2_;
+	void *winsysData1_ = nullptr;
+	void *winsysData2_ = nullptr;
 	std::function<VkExtent2D()> cbGetDrawSize_;
 
 	VkInstance instance_ = VK_NULL_HANDLE;

--- a/Common/GPU/Vulkan/VulkanProfiler.cpp
+++ b/Common/GPU/Vulkan/VulkanProfiler.cpp
@@ -8,7 +8,14 @@ using namespace PPSSPP_VK;
 void VulkanProfiler::Init(VulkanContext *vulkan) {
 	vulkan_ = vulkan;
 
-	validBits_ = vulkan_->GetQueueFamilyProperties(vulkan_->GetGraphicsQueueFamilyIndex()).timestampValidBits;
+	int graphicsQueueFamilyIndex = vulkan_->GetGraphicsQueueFamilyIndex();
+	_assert_(graphicsQueueFamilyIndex >= 0);
+
+	if (queryPool_) {
+		vulkan->Delete().QueueDeleteQueryPool(queryPool_);
+	}
+
+	validBits_ = vulkan_->GetQueueFamilyProperties(graphicsQueueFamilyIndex).timestampValidBits;
 
 	if (validBits_) {
 		VkQueryPoolCreateInfo ci{ VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO };
@@ -20,7 +27,7 @@ void VulkanProfiler::Init(VulkanContext *vulkan) {
 
 void VulkanProfiler::Shutdown() {
 	if (queryPool_) {
-		vkDestroyQueryPool(vulkan_->GetDevice(), queryPool_, nullptr);
+		vulkan_->Delete().QueueDeleteQueryPool(queryPool_);
 	}
 }
 


### PR DESCRIPTION
Causing an out of range access. Regression from #16639