### PR TITLE
Libretro: skip leading zeros in IP address.

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1096,13 +1096,21 @@ static void check_variables(CoreParameter &coreParam)
    if (changeProAdhocServer == "IP address")
    {
       g_Config.proAdhocServer = "";
+      bool leadingZero = true;
       for (int i = 0; i < 12; i++)
       {
          if (i && i % 3 == 0)
+	 {
             g_Config.proAdhocServer += '.';
+	    leadingZero = true;
+	 }
 
          int addressPt = ppsspp_pro_ad_hoc_ipv4[i];
-         g_Config.proAdhocServer += static_cast<char>('0' + addressPt);
+	 if (addressPt || i % 3 == 2)
+	    leadingZero = false; // We are either non-zero or the last digit of a byte
+
+         if (! leadingZero)
+            g_Config.proAdhocServer += static_cast<char>('0' + addressPt);
       }
    }
    else

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1100,14 +1100,14 @@ static void check_variables(CoreParameter &coreParam)
       for (int i = 0; i < 12; i++)
       {
          if (i && i % 3 == 0)
-	 {
+         {
             g_Config.proAdhocServer += '.';
-	    leadingZero = true;
-	 }
+            leadingZero = true;
+         }
 
          int addressPt = ppsspp_pro_ad_hoc_ipv4[i];
-	 if (addressPt || i % 3 == 2)
-	    leadingZero = false; // We are either non-zero or the last digit of a byte
+         if (addressPt || i % 3 == 2)
+            leadingZero = false; // We are either non-zero or the last digit of a byte
 
          if (! leadingZero)
             g_Config.proAdhocServer += static_cast<char>('0' + addressPt);


### PR DESCRIPTION
In the LibRetro settings GUI, we enter the IP address digit by digit (in order to avoid a drop down menu with 256 values). When we combine these digits into a string, we should skip leading zeros for every byte. Failing to do so seems to change the interpretation of the remainder of the byte to an octal number. This only yields the desired result for bytes in the range [000, 007]. Anything else would either be invalid (in case it contains an 8 or a 9) or misinterpreted (since the byte would be composed with a base of 8 instead of 10).

This PR intends to fix that.