### PR TITLE
Implement basic RISC-V crash handler, tweaks

### DIFF
--- a/Common/GPU/OpenGL/GLFeatures.cpp
+++ b/Common/GPU/OpenGL/GLFeatures.cpp
@@ -273,8 +273,8 @@ void CheckGLExtensions() {
 			// Try to load GLES 3.0 only if "3.0" found in version
 			// This simple heuristic avoids issues on older devices where you can only call eglGetProcAddress a limited
 			// number of times. Make sure to check for 3.0 in the shader version too to avoid false positives, see #5584.
-			bool gl_3_0_in_string = strstr(versionStr, "3.0") && (glslVersionStr && strstr(glslVersionStr, "3.0"));
-			bool gl_3_1_in_string = strstr(versionStr, "3.1") && (glslVersionStr && strstr(glslVersionStr, "3.1"));  // intentionally left out .1
+			bool gl_3_0_in_string = versionStr && strstr(versionStr, "3.0") && glslVersionStr && strstr(glslVersionStr, "3.0");
+			bool gl_3_1_in_string = versionStr && strstr(versionStr, "3.1") && glslVersionStr && strstr(glslVersionStr, "3.1");  // intentionally left out .1
 			if ((gl_3_0_in_string || gl_3_1_in_string) && gl3stubInit()) {
 				gl_extensions.ver[0] = 3;
 				if (gl_3_1_in_string) {

--- a/Common/MachineContext.h
+++ b/Common/MachineContext.h
@@ -168,6 +168,17 @@ typedef sigcontext SContext;
 #define CTX_PC arm_pc
 #define CTX_REG(x) regs[x]
 
+#elif PPSSPP_ARCH(RISCV64)
+
+#include <ucontext.h>
+typedef mcontext_t SContext;
+
+#define MACHINE_CONTEXT_SUPPORTED
+
+#define CTX_REG(x) __gregs[x]
+#define CTX_PC CTX_REG(0)
+#define CTX_SP CTX_REG(2)
+
 #else
 
 // No context definition for architecture

--- a/Core/MIPS/fake/FakeJit.cpp
+++ b/Core/MIPS/fake/FakeJit.cpp
@@ -126,14 +126,13 @@ void FakeJit::CompileDelaySlot(int flags)
 void FakeJit::Compile(u32 em_address) {
 }
 
-void FakeJit::RunLoopUntil(u64 globalticks)
-{
-	((void (*)())enterCode)();
+void FakeJit::RunLoopUntil(u64 globalticks) {
+	MIPSInterpret_RunUntil(globalticks);
 }
 
-const u8 *FakeJit::DoJit(u32 em_address, JitBlock *b)
-{
-	return b->normalEntry;
+const u8 *FakeJit::DoJit(u32 em_address, JitBlock *b) {
+	_assert_(false);
+	return nullptr;
 }
 
 void FakeJit::AddContinuedBlock(u32 dest)

--- a/Core/MIPS/fake/FakeJit.h
+++ b/Core/MIPS/fake/FakeJit.h
@@ -179,19 +179,6 @@ private:
 
 	int dontLogBlocks;
 	int logBlocks;
-
-public:
-	// Code pointers
-	const u8 *enterCode;
-
-	const u8 *outerLoop;
-	const u8 *outerLoopPCInR0;
-	const u8 *dispatcherCheckCoreState;
-	const u8 *dispatcherPCInR0;
-	const u8 *dispatcher;
-	const u8 *dispatcherNoCheck;
-
-	const u8 *breakpointBailout;
 };
 
 }	// namespace MIPSComp

--- a/git-version.cmake
+++ b/git-version.cmake
@@ -23,6 +23,14 @@ if(EXISTS ${GIT_VERSION_FILE})
 	if(NOT ${match} EQUAL "")
 		set(GIT_VERSION_UPDATE "0")
 	endif()
+
+	# Let's also skip if it's the same.
+	string(REPLACE "." "\\." GIT_VERSION_ESCAPED ${GIT_VERSION})
+	file(STRINGS ${GIT_VERSION_FILE} match
+		REGEX "PPSSPP_GIT_VERSION = \"${GIT_VERSION_ESCAPED}\";")
+	if(NOT ${match} EQUAL "")
+		set(GIT_VERSION_UPDATE "0")
+	endif()
 endif()
 
 set(code_string "// This is a generated file.\n\n"

--- a/headless/SDLHeadlessHost.cpp
+++ b/headless/SDLHeadlessHost.cpp
@@ -120,7 +120,17 @@ bool GLDummyGraphicsContext::InitFromRenderThread(std::string *errorMessage) {
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
 	screen_ = CreateHiddenWindow();
+	if (!screen_) {
+		const char *err = SDL_GetError();
+		printf("Failed to create offscreen window: %s\n", err ? err : "(unknown error)");
+		return false;
+	}
 	glContext_ = SDL_GL_CreateContext(screen_);
+	if (!glContext_) {
+		const char *err = SDL_GetError();
+		printf("Failed to create GL context: %s\n", err ? err : "(unknown error)");
+		return false;
+	}
 
 	// Ensure that the swap interval is set after context creation (needed for kmsdrm)
 	SDL_GL_SetSwapInterval(0);


### PR DESCRIPTION
This has some semi-related changes:
 * Makes the CMake git-version.cpp generation skip a write if it's unchanged, which can avoid linking steps when there are no changes to their dependencies.
 * Turns out sometimes FakeJit is used, and it always crashed if so.  Now it doesn't crash, and just runs interp.
 * Fix some crashes in GL init from Headless when GL is dead.
 * Implement a basic crash handler for RISC-V.

In theory, we could handle IR crashes if we kept a flag or did some sort of dangerous check that we were in IRInterpret in place of `bool inJitSpace = MIPSComp::jit && MIPSComp::jit->CodeInRange(codePtr);`.  I forced that to true (obviously bad in case a crash happens in a syscall/etc.) and it handled IR crashes.

-[Unknown]