### PR TITLE
OpenXR - Force flat mode for Madden NFL games

### DIFF
--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -671,8 +671,9 @@ bool StartVRRender() {
 
 		// Decide if the scene is 3D or not
 		bool stereo = hasUnitScale && g_Config.bEnableStereo;
+		bool forceFlat = PSP_CoreParameter().compat.vrCompat().ForceFlatScreen;
 		VR_SetConfigFloat(VR_CONFIG_CANVAS_ASPECT, 480.0f / 272.0f);
-		if (g_Config.bEnableVR && !pspKeys[CTRL_SCREEN] && (appMode == VR_GAME_MODE) && (vr3DGeometryCount > 15)) {
+		if (g_Config.bEnableVR && !pspKeys[CTRL_SCREEN] && !forceFlat && (appMode == VR_GAME_MODE) && (vr3DGeometryCount > 15)) {
 			VR_SetConfig(VR_CONFIG_MODE, stereo ? VR_MODE_STEREO_6DOF : VR_MODE_MONO_6DOF);
 			vrFlatGame = false;
 		} else {

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -127,6 +127,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {
+	CheckSetting(iniFile, gameID, "ForceFlatScreen", &vrCompat_.ForceFlatScreen);
 	CheckSetting(iniFile, gameID, "IdentityViewHack", &vrCompat_.IdentityViewHack);
 	CheckSetting(iniFile, gameID, "Skyplane", &vrCompat_.Skyplane);
 	CheckSetting(iniFile, gameID, "UnitsPerMeter", &vrCompat_.UnitsPerMeter);

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -98,6 +98,7 @@ struct CompatFlags {
 };
 
 struct VRCompat {
+	bool ForceFlatScreen;
 	bool IdentityViewHack;
 	bool Skyplane;
 	float UnitsPerMeter;

--- a/assets/compatvr.ini
+++ b/assets/compatvr.ini
@@ -30,6 +30,36 @@
 # ========================================================================================
 
 
+[ForceFlatScreen]
+# Forces flat screen rendering in games which don't work in VR.
+
+# Madden NFL 06
+ULES00147 = true
+ULUS10024 = true
+
+# Madden NFL 07
+ULUS10117 = true
+
+# Madden NFL 08
+ULES00867 = true
+ULUS10275 = true
+
+# Madden NFL 09
+ULES01093 = true
+ULUS10352 = true
+
+# Madden NFL 10
+NPEH00010 = true
+ULUS10441 = true
+
+# Madden NFL 11
+ULJM05757 = true
+ULUS10541 = true
+
+# Madden NFL 12
+ULUS10581 = true
+
+
 [IdentityViewHack]
 # Disables head tracking for render passes where view matrix is Identity
 


### PR DESCRIPTION
Madden NFL games use a weird combination of 3D and 2D rendering. It will probably never work in VR. It is better to force flat screen rendering than a broken VR rendering.