### PR TITLE
SDL: Add a way to reset OpenGL graphics by pressing F7.

### DIFF
--- a/Common/GPU/OpenGL/GLFeatures.cpp
+++ b/Common/GPU/OpenGL/GLFeatures.cpp
@@ -573,11 +573,11 @@ void CheckGLExtensions() {
 }
 
 void SetGLCoreContext(bool flag) {
-	_assert_msg_(!extensionsDone, "SetGLCoreContext() after CheckGLExtensions()");
-
-	useCoreContext = flag;
-	// For convenience, it'll get reset later.
-	gl_extensions.IsCoreContext = useCoreContext;
+	if (!extensionsDone) {		
+		useCoreContext = flag;
+		// For convenience, it'll get reset later.
+		gl_extensions.IsCoreContext = useCoreContext;
+	}
 }
 
 void ResetGLExtensions() {

--- a/SDL/SDLGLGraphicsContext.cpp
+++ b/SDL/SDLGLGraphicsContext.cpp
@@ -449,9 +449,12 @@ void SDLGLGraphicsContext::Shutdown() {
 void SDLGLGraphicsContext::ShutdownFromRenderThread() {
 	delete draw_;
 	draw_ = nullptr;
+	renderManager_ = nullptr;
 
 #ifdef USING_EGL
 	EGL_Close();
 #endif
 	SDL_GL_DeleteContext(glContext);
+	glContext = nullptr;
+	window_ = nullptr;
 }


### PR DESCRIPTION
Tried to use this to debug the wacky issue I'm seeing on Android but doesn't reproduce the memory error, for whatever reason.

Also needs some work to be more generic.

We really should refactor these graphic contexts and EmuThread and stuff to share more code between platforms..