### PR TITLE
DrawContext destructor: Need to call DestroyPresets earlier.

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -341,6 +341,8 @@ D3D11DrawContext::D3D11DrawContext(ID3D11Device *device, ID3D11DeviceContext *de
 }
 
 D3D11DrawContext::~D3D11DrawContext() {
+	DestroyPresets();
+
 	upBuffer_->Release();
 	packTexture_->Release();
 

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -815,6 +815,7 @@ D3D9Context::D3D9Context(IDirect3D9 *d3d, IDirect3D9Ex *d3dEx, int adapterId, ID
 }
 
 D3D9Context::~D3D9Context() {
+	DestroyPresets();
 }
 
 ShaderModule *D3D9Context::CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t size, const char *tag) {

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -764,6 +764,8 @@ OpenGLContext::OpenGLContext() {
 }
 
 OpenGLContext::~OpenGLContext() {
+	DestroyPresets();
+
 	for (int i = 0; i < GLRenderManager::MAX_INFLIGHT_FRAMES; i++) {
 		renderManager_.DeletePushBuffer(frameData_[i].push);
 	}

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1004,6 +1004,8 @@ VKContext::VKContext(VulkanContext *vulkan)
 }
 
 VKContext::~VKContext() {
+	DestroyPresets();
+
 	delete nullTexture_;
 	// This also destroys all descriptor sets.
 	for (int i = 0; i < VulkanContext::MAX_INFLIGHT_FRAMES; i++) {

--- a/Common/GPU/thin3d.cpp
+++ b/Common/GPU/thin3d.cpp
@@ -523,7 +523,7 @@ void DrawContext::DestroyPresets() {
 }
 
 DrawContext::~DrawContext() {
-	DestroyPresets();
+	// TODO: Can't call DestroyPresets here, too late.
 }
 
 void ConvertFromRGBA8888(uint8_t *dst, const uint8_t *src, uint32_t dstStride, uint32_t srcStride, uint32_t width, uint32_t height, DataFormat format) {


### PR DESCRIPTION
Very minor memory/resource leak, but why not fix it.