### PR TITLE
D3D11: Fix Draw state issues on pause screen

### DIFF
--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -163,15 +163,9 @@ void GPU_D3D11::CopyDisplayToOutput(bool reallyDirty) {
 	// Flush anything left over.
 	drawEngine_.Flush();
 
-	float blendColor[4]{};
-	context_->OMSetBlendState(stockD3D11.blendStateDisabledWithColorMask[0xF], blendColor, 0xFFFFFFFF);
-	// Since we're forcing the blend state, clear Draw.
-	if (draw_)
-		draw_->Invalidate(InvalidationFlags::CACHED_RENDER_STATE);
+	shaderManager_->DirtyLastShader();
 
 	framebufferManagerD3D11_->CopyDisplayToOutput(reallyDirty);
-
-	shaderManagerD3D11_->DirtyLastShader();
 
 	gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
 }

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -165,6 +165,9 @@ void GPU_D3D11::CopyDisplayToOutput(bool reallyDirty) {
 
 	float blendColor[4]{};
 	context_->OMSetBlendState(stockD3D11.blendStateDisabledWithColorMask[0xF], blendColor, 0xFFFFFFFF);
+	// Since we're forcing the blend state, clear Draw.
+	if (draw_)
+		draw_->Invalidate(InvalidationFlags::CACHED_RENDER_STATE);
 
 	framebufferManagerD3D11_->CopyDisplayToOutput(reallyDirty);
 

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -158,14 +158,11 @@ void GPU_DX9::BeginFrame() {
 }
 
 void GPU_DX9::CopyDisplayToOutput(bool reallyDirty) {
-	dxstate.depthWrite.set(true);
-	dxstate.colorMask.set(0xF);
-
 	drawEngine_.Flush();
 
-	framebufferManagerDX9_->CopyDisplayToOutput(reallyDirty);
+	shaderManager_->DirtyLastShader();
 
-	shaderManagerDX9_->DirtyLastShader();
+	framebufferManagerDX9_->CopyDisplayToOutput(reallyDirty);
 
 	gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
 }

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -304,6 +304,8 @@ void GPU_GLES::CopyDisplayToOutput(bool reallyDirty) {
 	shaderManagerGL_->DirtyLastShader();
 
 	framebufferManagerGL_->CopyDisplayToOutput(reallyDirty);
+
+	gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
 }
 
 void GPU_GLES::FinishDeferred() {


### PR DESCRIPTION
Fixes #16674.  I almost just unified this method, but GLES is rebinding the framebuffer and I'm not sure if that's necessary or or, or if doing that on Vulkan could have any small perf impact.

-[Unknown]