### PR TITLE
Replacement: Verify out stride

### DIFF
--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -35,6 +35,7 @@
 #include "Common/Data/Text/I18n.h"
 #include "Common/Data/Text/Parsers.h"
 #include "Common/File/FileUtil.h"
+#include "Common/LogReporting.h"
 #include "Common/StringUtils.h"
 #include "Common/Thread/ParallelLoop.h"
 #include "Common/Thread/Waitable.h"
@@ -1262,6 +1263,10 @@ bool ReplacedTexture::Load(int level, void *out, int rowPitch) {
 
 	if (data.empty())
 		return false;
+	if (rowPitch < info.w * 4) {
+		ERROR_LOG_REPORT(G3D, "Replacement rowPitch=%d, but w=%d (level=%d)", rowPitch, info.w * 4, level);
+		return false;
+	}
 	_assert_msg_(data.size() == info.w * info.h * 4, "Data has wrong size");
 
 	if (rowPitch == info.w * 4) {


### PR DESCRIPTION
Not sure what else would cause that line to crash, as the src size is validated beforehand already.  See #16601.

-[Unknown]