### PR TITLE
Vulkan: Avoid race in compile thread exit

### DIFF
--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -294,7 +294,11 @@ void VulkanRenderManager::StopThread() {
 
 	INFO_LOG(G3D, "Vulkan submission thread joined. Frame=%d", vulkan_->GetCurFrame());
 
-	compileCond_.notify_all();
+	if (compileThread_.joinable()) {
+		// Lock to avoid race conditions.
+		std::lock_guard<std::mutex> guard(compileMutex_);
+		compileCond_.notify_all();
+	}
 	compileThread_.join();
 	INFO_LOG(G3D, "Vulkan compiler thread joined.");
 
@@ -352,7 +356,7 @@ void VulkanRenderManager::CompileThreadFunc() {
 		std::vector<CompileQueueEntry> toCompile;
 		{
 			std::unique_lock<std::mutex> lock(compileMutex_);
-			if (compileQueue_.empty()) {
+			if (compileQueue_.empty() && run_) {
 				compileCond_.wait(lock);
 			}
 			toCompile = std::move(compileQueue_);


### PR DESCRIPTION
Without the lock, we could enter the wait at just the wrong moment, potentially causing a shutdown hang (see #16601.)

I also wonder if we should just remove vkDeviceWaitIdle...

-[Unknown]