### PR TITLE
softgpu: Detect binner alloc fail and bail

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -487,6 +487,14 @@ bool PSP_InitUpdate(std::string *error_string) {
 	if (pspIsInited) {
 		Core_NotifyLifecycle(CoreLifecycle::START_COMPLETE);
 		pspIsRebooting = false;
+
+		// If GPU init failed during IsReady checks, bail.
+		if (!GPU_IsStarted()) {
+			*error_string = "Unable to initialize rendering engine.";
+			pspIsRebooting = false;
+			PSP_Shutdown();
+			return true;
+		}
 	}
 	return pspIsInited;
 }

--- a/GPU/GPU.cpp
+++ b/GPU/GPU.cpp
@@ -58,6 +58,12 @@ bool GPU_IsReady() {
 	return false;
 }
 
+bool GPU_IsStarted() {
+	if (gpu)
+		return gpu->IsReady() && gpu->IsStarted();
+	return false;
+}
+
 bool GPU_Init(GraphicsContext *ctx, Draw::DrawContext *draw) {
 	const auto &gpuCore = PSP_CoreParameter().gpuCore;
 	_assert_(draw || gpuCore == GPUCORE_SOFTWARE);
@@ -106,7 +112,10 @@ bool GPU_Init(GraphicsContext *ctx, Draw::DrawContext *draw) {
 #endif
 	}
 
-	return gpu != NULL;
+	if (gpu && gpu->IsReady() && !gpu->IsStarted())
+		SetGPU<SoftGPU>(nullptr);
+
+	return gpu != nullptr;
 #endif
 }
 #ifdef USE_CRT_DBG

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -147,4 +147,5 @@ namespace Draw {
 
 bool GPU_Init(GraphicsContext *ctx, Draw::DrawContext *draw);
 bool GPU_IsReady();
+bool GPU_IsStarted();
 void GPU_Shutdown();

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -86,6 +86,9 @@ public:
 	bool IsReady() override {
 		return true;
 	}
+	bool IsStarted() override {
+		return true;
+	}
 	void CancelReady() override {}
 	void Reinitialize() override;
 

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -191,6 +191,7 @@ public:
 	// Initialization
 	virtual bool IsReady() = 0;
 	virtual void CancelReady() = 0;
+	virtual bool IsStarted() = 0;
 	virtual void InitClear() = 0;
 	virtual void Reinitialize() = 0;
 

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -433,11 +433,15 @@ SoftGPU::SoftGPU(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	Rasterizer::Init();
 	Sampler::Init();
 	drawEngine_ = new SoftwareDrawEngine();
+	if (!drawEngine_)
+		return;
+
 	drawEngine_->Init();
 	drawEngineCommon_ = drawEngine_;
 
 	// Push the initial CLUT buffer in case it's all zero (we push only on change.)
-	drawEngine_->transformUnit.NotifyClutUpdate(clut);
+	if (drawEngine_->transformUnit.IsStarted())
+		drawEngine_->transformUnit.NotifyClutUpdate(clut);
 
 	// No need to flush for simple parameter changes.
 	flushOnParams_ = false;
@@ -760,6 +764,10 @@ void SoftGPU::FastRunLoop(DisplayList &list) {
 	}
 	downcount = 0;
 	dirtyFlags_ = dirty;
+}
+
+bool SoftGPU::IsStarted() {
+	return drawEngine_ && drawEngine_->transformUnit.IsStarted();
 }
 
 void SoftGPU::ExecuteOp(u32 op, u32 diff) {

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -128,6 +128,7 @@ public:
 	~SoftGPU();
 
 	u32 CheckGPUFeatures() const override { return 0; }
+	bool IsStarted() override;
 	void InitClear() override {}
 	void ExecuteOp(u32 op, u32 diff) override;
 	void FinishDeferred() override;

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -42,12 +42,18 @@
 
 TransformUnit::TransformUnit() {
 	decoded_ = (u8 *)AllocateMemoryPages(TRANSFORM_BUF_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
+	if (!decoded_)
+		return;
 	binner_ = new BinManager();
 }
 
 TransformUnit::~TransformUnit() {
 	FreeMemoryPages(decoded_, TRANSFORM_BUF_SIZE);
 	delete binner_;
+}
+
+bool TransformUnit::IsStarted() {
+	return binner_ && decoded_;
 }
 
 SoftwareDrawEngine::SoftwareDrawEngine() {

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -117,6 +117,8 @@ public:
 	TransformUnit();
 	~TransformUnit();
 
+	bool IsStarted();
+
 	static WorldCoords ModelToWorldNormal(const ModelCoords& coords);
 	static WorldCoords ModelToWorld(const ModelCoords& coords);
 	static ViewCoords WorldToView(const WorldCoords& coords);


### PR DESCRIPTION
It seems like there are crashes when `binner_` is null, so let's actually check for that.  Adds a consistent way for other backends to report a startup failure, although currently without any particular message.

In theory, if fundamental resources couldn't be created/allocated, other backends could return false here too.

-[Unknown]