### PR TITLE
Dialog: Fix confirm/cancel button reversal

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -312,12 +312,12 @@ int PSPDialog::GetConfirmButton() {
 	if (PSP_CoreParameter().compat.flags().ForceCircleButtonConfirm) {
 		return CTRL_CIRCLE;
 	}
-	return g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CIRCLE : CTRL_CROSS;
+	return g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CROSS : CTRL_CIRCLE;
 }
 
 int PSPDialog::GetCancelButton() {
 	if (PSP_CoreParameter().compat.flags().ForceCircleButtonConfirm) {
 		return CTRL_CROSS;
 	}
-	return g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CROSS : CTRL_CIRCLE;
+	return g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CIRCLE : CTRL_CROSS;
 }

--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -260,10 +260,10 @@ int PSPNetconfDialog::Update(int animSpeed) {
 
 		if (!hideNotice) {
 			const float WRAP_WIDTH = 254.0f;
-			const ImageID confirmBtnImage = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? ImageID("I_CROSS") : ImageID("I_CIRCLE");
 			const int confirmBtn = GetConfirmButton();
-			const ImageID cancelBtnImage = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? ImageID("I_CIRCLE") : ImageID("I_CROSS");
 			const int cancelBtn = GetCancelButton();
+			const ImageID confirmBtnImage = confirmBtn == CTRL_CROSS ? ImageID("I_CROSS") : ImageID("I_CIRCLE");
+			const ImageID cancelBtnImage = cancelBtn == CTRL_CIRCLE ? ImageID("I_CIRCLE") : ImageID("I_CROSS");
 
 			PPGeStyle textStyle = FadedStyle(PPGeAlign::BOX_CENTER, 0.5f);
 			PPGeStyle buttonStyle = FadedStyle(PPGeAlign::BOX_LEFT, 0.5f);


### PR DESCRIPTION
#16449 accidentally set "confirm = cross" as circle, which reversed things in the OSK.  This corrects that so the setting does what it says - sets the confirmation button.  Also fixes icons in the netconf dialog when circle is forced.

-[Unknown]