### PR TITLE
Add range checks in replaced memcpy/memset functions.

### DIFF
--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -138,8 +138,8 @@ static int Replace_memcpy() {
 		}
 	}
 	if (!skip && bytes != 0) {
-		u8 *dst = Memory::GetPointerWrite(destPtr);
-		const u8 *src = Memory::GetPointer(srcPtr);
+		u8 *dst = Memory::GetPointerWriteRange(destPtr, bytes);
+		const u8 *src = Memory::GetPointerRange(srcPtr, bytes);
 
 		if (!dst || !src) {
 			// Already logged.
@@ -190,8 +190,8 @@ static int Replace_memcpy_jak() {
 		}
 	}
 	if (!skip && bytes != 0) {
-		u8 *dst = Memory::GetPointerWrite(destPtr);
-		const u8 *src = Memory::GetPointer(srcPtr);
+		u8 *dst = Memory::GetPointerWriteRange(destPtr, bytes);
+		const u8 *src = Memory::GetPointerRange(srcPtr, bytes);
 
 		if (!dst || !src) {
 		} else {
@@ -241,8 +241,8 @@ static int Replace_memcpy16() {
 		}
 	}
 	if (!skip && bytes != 0) {
-		u8 *dst = Memory::GetPointerWrite(destPtr);
-		const u8 *src = Memory::GetPointer(srcPtr);
+		u8 *dst = Memory::GetPointerWriteRange(destPtr, bytes);
+		const u8 *src = Memory::GetPointerRange(srcPtr, bytes);
 		if (dst && src) {
 			memmove(dst, src, bytes);
 		}
@@ -313,8 +313,8 @@ static int Replace_memmove() {
 		}
 	}
 	if (!skip && bytes != 0) {
-		u8 *dst = Memory::GetPointerWrite(destPtr);
-		const u8 *src = Memory::GetPointer(srcPtr);
+		u8 *dst = Memory::GetPointerWriteRange(destPtr, bytes);
+		const u8 *src = Memory::GetPointerRange(srcPtr, bytes);
 		if (dst && src) {
 			memmove(dst, src, bytes);
 		}
@@ -339,7 +339,7 @@ static int Replace_memset() {
 		skip = gpu->PerformMemorySet(destPtr, value, bytes);
 	}
 	if (!skip && bytes != 0) {
-		u8 *dst = Memory::GetPointerWrite(destPtr);
+		u8 *dst = Memory::GetPointerWriteRange(destPtr, bytes);
 		if (dst) {
 			memset(dst, value, bytes);
 		}
@@ -366,7 +366,7 @@ static int Replace_memset_jak() {
 		skip = gpu->PerformMemorySet(destPtr, value, bytes);
 	}
 	if (!skip && bytes != 0) {
-		u8 *dst = Memory::GetPointerWrite(destPtr);
+		u8 *dst = Memory::GetPointerWriteRange(destPtr, bytes);
 		if (dst) {
 			memset(dst, value, bytes);
 		}

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -137,13 +137,19 @@ static int Replace_memcpy() {
 			skip = gpu->PerformMemoryCopy(destPtr, srcPtr, bytes);
 		}
 	}
-	if (!skip && bytes != 0) {
-		u8 *dst = Memory::GetPointerWrite(destPtr);
-		const u8 *src = Memory::GetPointer(srcPtr);
 
-		if (!dst || !src) {
-			// Already logged.
-		} else if (std::min(destPtr, srcPtr) + bytes > std::max(destPtr, srcPtr)) {
+	// Check valid ranges before trying to copy bytes.
+	if (!Memory::IsValidRange(destPtr, bytes) || !Memory::IsValidRange(srcPtr, bytes)) {
+		// Not sure what best to do here. We just don't copy the bytes.
+		RETURN(destPtr);
+		return 10 + bytes / 4;  // approximation
+	}
+
+	if (!skip && bytes != 0) {
+		u8 *dst = Memory::GetPointerWriteUnchecked(destPtr);
+		const u8 *src = Memory::GetPointerUnchecked(srcPtr);
+
+		if (std::min(destPtr, srcPtr) + bytes > std::max(destPtr, srcPtr)) {
 			// Overlap.  Star Ocean breaks if it's not handled in 16 bytes blocks.
 			const u32 blocks = bytes & ~0x0f;
 			for (u32 offset = 0; offset < blocks; offset += 0x10) {
@@ -268,6 +274,7 @@ static int Replace_memcpy_swizzled() {
 			gpu->PerformReadbackToMemory(srcPtr, pitch * h);
 		}
 	}
+
 	u8 *dstp = Memory::GetPointerWrite(destPtr);
 	const u8 *srcp = Memory::GetPointer(srcPtr);
 
@@ -312,12 +319,18 @@ static int Replace_memmove() {
 			skip = gpu->PerformMemoryCopy(destPtr, srcPtr, bytes);
 		}
 	}
+
+	// Check valid ranges before trying to copy bytes.
+	if (!Memory::IsValidRange(destPtr, bytes) || !Memory::IsValidRange(srcPtr, bytes)) {
+		// Not sure what best to do here. We just don't copy the bytes.
+		RETURN(destPtr);
+		return 10 + bytes / 4;  // approximation
+	}
+
 	if (!skip && bytes != 0) {
-		u8 *dst = Memory::GetPointerWrite(destPtr);
-		const u8 *src = Memory::GetPointer(srcPtr);
-		if (dst && src) {
-			memmove(dst, src, bytes);
-		}
+		u8 *dst = Memory::GetPointerWriteUnchecked(destPtr);
+		const u8 *src = Memory::GetPointerUnchecked(srcPtr);
+		memmove(dst, src, bytes);
 	}
 	RETURN(destPtr);
 
@@ -334,15 +347,20 @@ static int Replace_memset() {
 	u32 destPtr = PARAM(0);
 	u8 value = PARAM(1);
 	u32 bytes = PARAM(2);
+
 	bool skip = false;
 	if (Memory::IsVRAMAddress(destPtr) && (skipGPUReplacements & (int)GPUReplacementSkip::MEMSET) == 0) {
 		skip = gpu->PerformMemorySet(destPtr, value, bytes);
 	}
+
+	if (!Memory::IsValidRange(destPtr, bytes)) {
+		RETURN(destPtr);
+		return 10 + bytes / 4;  // approximation
+	}
+
 	if (!skip && bytes != 0) {
-		u8 *dst = Memory::GetPointerWrite(destPtr);
-		if (dst) {
-			memset(dst, value, bytes);
-		}
+		u8 *dst = Memory::GetPointerWriteUnchecked(destPtr);
+		memset(dst, value, bytes);
 	}
 	RETURN(destPtr);
 

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -246,6 +246,10 @@ inline void Write_Float(float f, u32 address)
 
 u8* GetPointerWrite(const u32 address);
 const u8* GetPointer(const u32 address);
+
+u8 *GetPointerWriteRange(const u32 address, const u32 size);
+const u8 *GetPointerRange(const u32 address, const u32 size);
+
 bool IsRAMAddress(const u32 address);
 inline bool IsVRAMAddress(const u32 address) {
 	return ((address & 0x3F800000) == 0x04000000);

--- a/Core/MemMapFunctions.cpp
+++ b/Core/MemMapFunctions.cpp
@@ -62,6 +62,38 @@ const u8 *GetPointer(const u32 address) {
 	}
 }
 
+u8 *GetPointerWriteRange(const u32 address, const u32 size) {
+	u8 *ptr = GetPointerWrite(address);
+	if (ptr) {
+		if (ValidSize(address, size) != size) {
+			// That's a memory exception! TODO: Adjust reported address to the end of the range?
+			Core_MemoryException(address, currentMIPS->pc, MemoryExceptionType::WRITE_BLOCK);
+			return nullptr;
+		} else {
+			return ptr;
+		}
+	} else {
+		// Error was reported in GetPointerWrite already, if we're not ignoring errors.
+		return nullptr;
+	}
+}
+
+const u8 *GetPointerRange(const u32 address, const u32 size) {
+	const u8 *ptr = GetPointer(address);
+	if (ptr) {
+		if (ValidSize(address, size) != size) {
+			// That's a memory exception! TODO: Adjust reported address to the end of the range?
+			Core_MemoryException(address, currentMIPS->pc, MemoryExceptionType::READ_BLOCK);
+			return nullptr;
+		} else {
+			return ptr;
+		}
+	} else {
+		// Error was reported in GetPointer already, if we're not ignoring errors.
+		return nullptr;
+	}
+}
+
 template <typename T>
 inline void ReadFromHardware(T &var, const u32 address) {
 	// TODO: Figure out the fastest order of tests for both read and write (they are probably different).


### PR DESCRIPTION
Keep seeing especially Replace_memcpy as a semi-rare crash in the reports. Hopefully this will take care of it, though if games hit this, they're probably on their way to failing somehow anyway.

Question - should we instead use Memory::ValidSize to clamp the ranges?