### PR TITLE
Account for the GPU cycle cost of loading bone matrices.

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2762,6 +2762,13 @@ void GPUCommon::FastLoadBoneMatrix(u32 target) {
 		gstate_c.deferredVertTypeDirty |= uniformsToDirty;
 	}
 	gstate.FastLoadBoneMatrix(target);
+
+	cyclesExecuted += 2 * 14;  // one to reset the counter, 12 to load the matrix, and a return.
+
+	if (coreCollectDebugStats) {
+		gpuStats.otherGPUCycles += 2 * 14;
+		gpuStats.gpuCommandsAtCallLevel[std::min(currentList->stackptr, 3)] += 14;
+	}
 }
 
 struct DisplayList_v1 {


### PR DESCRIPTION
This could change timing slightly in games that use many of these, like maybe God of War for example. We should probably get it in for 1.15 and just handle any fallout.