### PR TITLE
Check for valid memory range when doing fast bone matrix loads

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1475,11 +1475,11 @@ void GPUCommon::DoExecuteCall(u32 target) {
 
 	// Bone matrix optimization - many games will CALL a bone matrix (!).
 	// We don't optimize during recording - so the matrix data gets recorded.
-	if (!debugRecording_ && (Memory::ReadUnchecked_U32(target) >> 24) == GE_CMD_BONEMATRIXDATA) {
+	if (!debugRecording_ && Memory::IsValidRange(target, 13 * 4) && (Memory::ReadUnchecked_U32(target) >> 24) == GE_CMD_BONEMATRIXDATA) {
 		// Check for the end
 		if ((Memory::ReadUnchecked_U32(target + 11 * 4) >> 24) == GE_CMD_BONEMATRIXDATA &&
-				(Memory::ReadUnchecked_U32(target + 12 * 4) >> 24) == GE_CMD_RET &&
-				(gstate.boneMatrixNumber & 0x00FFFFFF) <= 96 - 12) {
+			(Memory::ReadUnchecked_U32(target + 12 * 4) >> 24) == GE_CMD_RET &&
+			(gstate.boneMatrixNumber & 0x00FFFFFF) <= 96 - 12) {
 			// Yep, pretty sure this is a bone matrix call.  Double check stall first.
 			if (target > currentList->stall || target + 12 * 4 < currentList->stall) {
 				FastLoadBoneMatrix(target);


### PR DESCRIPTION
In reality, this is probably very rarely a real concern but we do get a measurable amount of crash reports here. Though if that first access crashes, which it seems to, we'd probably likely crash soon after this anyway...

I think the performance hit here will be very small because the branches will be highly predictable.

See [16601](https://github.com/hrydgard/ppsspp/issues/16601#issuecomment-1368481651)