### PR TITLE
softgpu: Fix lighting with 0 exp

### DIFF
--- a/GPU/Software/Lighting.cpp
+++ b/GPU/Software/Lighting.cpp
@@ -35,6 +35,9 @@ static inline Vec3f GetLightVec(const u32 lparams[12], int light) {
 }
 
 static inline float pspLightPow(float v, float e) {
+	if (e <= 0.0f) {
+		return 1.0f;
+	}
 	if (v > 0.0f) {
 		return pow(v, e);
 	}


### PR DESCRIPTION
Broken in #15317.  Fixes Kratos scene demo.

-[Unknown]