### PR TITLE
Eliminate GPU readbacks in the DTM Race Driver series.

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -644,6 +644,18 @@ ULJM05564 = true
 NPJH50148 = true
 ULAS42189 = true
 
+# Toca Race Driver 3 / DTM Race Driver 3 / V8 Supercars Shootout 3
+# Avoids readback.
+ULES00613 = true
+ULES00615 = true
+ULES00614 = true
+
+# Toca Race Driver 2 / DTM Race Driver 2
+# Avoids readback.
+ULES00040 = true
+ULES00041 = true
+ULJM05160 = true
+
 [IntraVRAMBlockTransferAllowCreateFB]
 # Final Fantasy - Type 0
 ULJM05900 = true


### PR DESCRIPTION
By using the compat option `[BlockTransferAllowCreateFB]`.

Fixes #16713.

This lets us create a texture on the GPU from the copied bytes, instead of reading it all the way back to the CPU causing costly sync.

Unfortunately I'm not sure exactly why the game does this readback - it might be something debug related like that one readback in Tactics Ogre, or it might be something else that's just not very noticeable? Let's see if we get any complaints about glitches after this is merged.