### PR TITLE
Android JNI: Try a bit harder to properly detach threads from the JVM when they exit

### DIFF
--- a/Common/File/PathBrowser.cpp
+++ b/Common/File/PathBrowser.cpp
@@ -141,6 +141,8 @@ void PathBrowser::HandlePath() {
 	pendingThread_ = std::thread([&] {
 		SetCurrentThreadName("PathBrowser");
 
+		AndroidJNIThreadContext jniContext;  // destructor detaches
+
 		std::unique_lock<std::mutex> guard(pendingLock_);
 		std::vector<File::FileInfo> results;
 		Path lastPath("NONSENSE THAT WONT EQUAL A PATH");
@@ -177,8 +179,6 @@ void PathBrowser::HandlePath() {
 				ready_ = true;
 			}
 		}
-
-		DetachThreadFromJNI();
 	});
 }
 

--- a/Common/File/PathBrowser.cpp
+++ b/Common/File/PathBrowser.cpp
@@ -177,6 +177,8 @@ void PathBrowser::HandlePath() {
 				ready_ = true;
 			}
 		}
+
+		DetachThreadFromJNI();
 	});
 }
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -115,15 +115,17 @@ bool VKRGraphicsPipeline::Create(VulkanContext *vulkan, VkRenderPass compatibleR
 	pipe.basePipelineIndex = 0;
 	pipe.subpass = 0;
 
+	INFO_LOG(G3D, "Creating pipeline... rpType: %08x sampleBits: %d (%s)", (u32)rpType, (u32)sampleCount, tag_.c_str());
+
 	double start = time_now_d();
 	VkPipeline vkpipeline;
 	VkResult result = vkCreateGraphicsPipelines(vulkan->GetDevice(), desc->pipelineCache, 1, &pipe, nullptr, &vkpipeline);
 	double taken_ms = (time_now_d() - start) * 1000.0;
 
 	if (taken_ms < 0.1) {
-		DEBUG_LOG(G3D, "Pipeline creation time: %0.2f ms (fast) rpType: %08x sampleBits: %d\n(%s)", taken_ms, (u32)rpType, (u32)sampleCount, tag_.c_str());
+		DEBUG_LOG(G3D, "Pipeline creation time: %0.2f ms (fast) rpType: %08x sampleBits: %d (%s)", taken_ms, (u32)rpType, (u32)sampleCount, tag_.c_str());
 	} else {
-		INFO_LOG(G3D, "Pipeline creation time: %0.2f ms  rpType: %08x sampleBits: %d\n(%s)", taken_ms, (u32)rpType, (u32)sampleCount, tag_.c_str());
+		INFO_LOG(G3D, "Pipeline creation time: %0.2f ms  rpType: %08x sampleBits: %d (%s)", taken_ms, (u32)rpType, (u32)sampleCount, tag_.c_str());
 	}
 
 	bool success = true;

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -115,8 +115,6 @@ bool VKRGraphicsPipeline::Create(VulkanContext *vulkan, VkRenderPass compatibleR
 	pipe.basePipelineIndex = 0;
 	pipe.subpass = 0;
 
-	INFO_LOG(G3D, "Creating pipeline... rpType: %08x sampleBits: %d (%s)", (u32)rpType, (u32)sampleCount, tag_.c_str());
-
 	double start = time_now_d();
 	VkPipeline vkpipeline;
 	VkResult result = vkCreateGraphicsPipelines(vulkan->GetDevice(), desc->pipelineCache, 1, &pipe, nullptr, &vkpipeline);

--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -526,6 +526,9 @@ std::string Download::RedirectLocation(const std::string &baseUrl) {
 
 void Download::Do() {
 	SetCurrentThreadName("Downloader::Do");
+
+	AndroidJNIThreadContext jniContext;
+
 	resultCode_ = 0;
 
 	std::string downloadURL = url_;

--- a/Common/Thread/ThreadUtil.cpp
+++ b/Common/Thread/ThreadUtil.cpp
@@ -28,6 +28,27 @@
 #include "Common/Thread/ThreadUtil.h"
 #include "Common/Data/Encoding/Utf8.h"
 
+AttachDetachFunc g_attach;
+AttachDetachFunc g_detach;
+
+void AttachThreadToJNI() {
+	if (g_attach) {
+		g_attach();
+	}
+}
+
+
+void DetachThreadFromJNI() {
+	if (g_detach) {
+		g_detach();
+	}
+}
+
+void RegisterAttachDetach(AttachDetachFunc attach, AttachDetachFunc detach) {
+	g_attach = attach;
+	g_detach = detach;
+}
+
 #if (PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(LINUX)) && !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
 #endif
@@ -66,23 +87,6 @@ static EXCEPTION_DISPOSITION NTAPI ignore_handler(EXCEPTION_RECORD *rec,
 	return ExceptionContinueExecution;
 }
 #endif
-
-void AttachThreadToJNI() {
-#if PPSSPP_PLATFORM(ANDROID)
-	Android_AttachThreadToJNI();
-#else
-	// Do nothing
-#endif
-}
-
-
-void DetachThreadFromJNI() {
-#if PPSSPP_PLATFORM(ANDROID)
-	Android_DetachThreadFromJNI();
-#else
-	// Do nothing
-#endif
-}
 
 #if PPSSPP_PLATFORM(WINDOWS) && !PPSSPP_PLATFORM(UWP)
 typedef HRESULT (WINAPI *TSetThreadDescription)(HANDLE, PCWSTR);

--- a/Common/Thread/ThreadUtil.cpp
+++ b/Common/Thread/ThreadUtil.cpp
@@ -67,6 +67,15 @@ static EXCEPTION_DISPOSITION NTAPI ignore_handler(EXCEPTION_RECORD *rec,
 }
 #endif
 
+void AttachThreadToJNI() {
+#if PPSSPP_PLATFORM(ANDROID)
+	Android_AttachThreadToJNI();
+#else
+	// Do nothing
+#endif
+}
+
+
 void DetachThreadFromJNI() {
 #if PPSSPP_PLATFORM(ANDROID)
 	Android_DetachThreadFromJNI();

--- a/Common/Thread/ThreadUtil.cpp
+++ b/Common/Thread/ThreadUtil.cpp
@@ -12,9 +12,14 @@
 
 #elif defined(__ANDROID__)
 
+#include "android/jni/app-android.h"
+
 #define TLS_SUPPORTED
 
 #endif
+
+// TODO: Many other platforms also support TLS, in fact probably nearly all that we support
+// these days.
 
 #include <cstring>
 #include <cstdint>
@@ -62,6 +67,13 @@ static EXCEPTION_DISPOSITION NTAPI ignore_handler(EXCEPTION_RECORD *rec,
 }
 #endif
 
+void DetachThreadFromJNI() {
+#if PPSSPP_PLATFORM(ANDROID)
+	Android_DetachThreadFromJNI();
+#else
+	// Do nothing
+#endif
+}
 
 #if PPSSPP_PLATFORM(WINDOWS) && !PPSSPP_PLATFORM(UWP)
 typedef HRESULT (WINAPI *TSetThreadDescription)(HANDLE, PCWSTR);
@@ -90,7 +102,15 @@ static void InitializeSetThreadDescription() {
 void SetCurrentThreadNameThroughException(const char *threadName);
 #endif
 
-void SetCurrentThreadName(const char* threadName) {
+const char *GetCurrentThreadName() {
+#ifdef TLS_SUPPORTED
+	return curThreadName;
+#else
+	return "";
+#endif
+}
+
+void SetCurrentThreadName(const char *threadName) {
 #if PPSSPP_PLATFORM(WINDOWS) && !PPSSPP_PLATFORM(UWP)
 	InitializeSetThreadDescription();
 	if (g_pSetThreadDescription) {

--- a/Common/Thread/ThreadUtil.h
+++ b/Common/Thread/ThreadUtil.h
@@ -2,7 +2,7 @@
 
 #include <mutex>
 
-// Note that the string pointed to must be have a lifetime until the end of the thread,
+// Note that the string pointed to must have a lifetime until the end of the thread,
 // for AssertCurrentThreadName to work.
 void SetCurrentThreadName(const char *threadName);
 void AssertCurrentThreadName(const char *threadName);

--- a/Common/Thread/ThreadUtil.h
+++ b/Common/Thread/ThreadUtil.h
@@ -2,11 +2,26 @@
 
 #include <mutex>
 
-// Note that name must be a global string that lives until the end of the process,
+// Note that the string pointed to must be have a lifetime until the end of the thread,
 // for AssertCurrentThreadName to work.
 void SetCurrentThreadName(const char *threadName);
 void AssertCurrentThreadName(const char *threadName);
 
+// If TLS is not supported, this will return an empty string.
+const char *GetCurrentThreadName();
+
 // Just gets a cheap thread identifier so that you can see different threads in debug output,
 // exactly what it is is badly specified and not useful for anything.
 int GetCurrentThreadIdForDebug();
+
+// Call when leaving threads. On Android, calls DetachCurrentThread.
+// Threads that use scoped storage I/O end up attached as JNI threads, and will thus
+// need this in order to follow the rules correctly. Some devices seem to enforce this.
+void DetachThreadFromJNI();
+
+class AndroidJNIThreadContext {
+public:
+	~AndroidJNIThreadContext() {
+		DetachThreadFromJNI();
+	}
+};

--- a/Common/Thread/ThreadUtil.h
+++ b/Common/Thread/ThreadUtil.h
@@ -14,13 +14,20 @@ const char *GetCurrentThreadName();
 // exactly what it is is badly specified and not useful for anything.
 int GetCurrentThreadIdForDebug();
 
+// When you know that a thread potentially will make JNI calls, call this after setting its name.
+void AttachThreadToJNI();
+
 // Call when leaving threads. On Android, calls DetachCurrentThread.
 // Threads that use scoped storage I/O end up attached as JNI threads, and will thus
 // need this in order to follow the rules correctly. Some devices seem to enforce this.
 void DetachThreadFromJNI();
 
+// Utility to call the above two functions.
 class AndroidJNIThreadContext {
 public:
+	AndroidJNIThreadContext() {
+		AttachThreadToJNI();
+	}
 	~AndroidJNIThreadContext() {
 		DetachThreadFromJNI();
 	}

--- a/Common/Thread/ThreadUtil.h
+++ b/Common/Thread/ThreadUtil.h
@@ -14,6 +14,10 @@ const char *GetCurrentThreadName();
 // exactly what it is is badly specified and not useful for anything.
 int GetCurrentThreadIdForDebug();
 
+typedef void (*AttachDetachFunc)();
+
+void RegisterAttachDetach(AttachDetachFunc attach, AttachDetachFunc detach);
+
 // When you know that a thread potentially will make JNI calls, call this after setting its name.
 void AttachThreadToJNI();
 

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1736,6 +1736,9 @@ void Config::RemoveRecent(const std::string &file) {
 void Config::CleanRecent() {
 	private_->SetRecentIsosThread([this] {
 		SetCurrentThreadName("RecentISOs");
+
+		AndroidJNIThreadContext jniContext;  // destructor detaches
+
 		double startTime = time_now_d();
 
 		std::lock_guard<std::mutex> guard(private_->recentIsosLock);
@@ -1766,8 +1769,6 @@ void Config::CleanRecent() {
 
 		INFO_LOG(SYSTEM, "CleanRecent took %0.2f", time_now_d() - startTime);
 		recentIsos = cleanedRecent;
-
-		DetachThreadFromJNI();
 	});
 }
 

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -32,6 +32,7 @@
 
 #include "Common/Log.h"
 #include "Common/TimeUtil.h"
+#include "Common/Thread/ThreadUtil.h"
 #include "Common/Data/Format/IniFile.h"
 #include "Common/Data/Format/JSONReader.h"
 #include "Common/Data/Text/I18n.h"
@@ -43,6 +44,7 @@
 #include "Common/System/Display.h"
 #include "Common/System/System.h"
 #include "Common/StringUtils.h"
+#include "Common/Thread/ThreadUtil.h"
 #include "Common/GPU/Vulkan/VulkanLoader.h"
 #include "Common/VR/PPSSPPVR.h"
 #include "Core/Config.h"
@@ -1733,6 +1735,7 @@ void Config::RemoveRecent(const std::string &file) {
 
 void Config::CleanRecent() {
 	private_->SetRecentIsosThread([this] {
+		SetCurrentThreadName("RecentISOs");
 		double startTime = time_now_d();
 
 		std::lock_guard<std::mutex> guard(private_->recentIsosLock);
@@ -1763,6 +1766,8 @@ void Config::CleanRecent() {
 
 		INFO_LOG(SYSTEM, "CleanRecent took %0.2f", time_now_d() - startTime);
 		recentIsos = cleanedRecent;
+
+		DetachThreadFromJNI();
 	});
 }
 

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -1210,6 +1210,8 @@ void PSPSaveDialog::JoinIOThread() {
 
 static void DoExecuteIOAction(PSPSaveDialog *dialog) {
 	SetCurrentThreadName("SaveIO");
+
+	AndroidJNIThreadContext jniContext;
 	dialog->ExecuteIOAction();
 }
 

--- a/Core/FileLoaders/CachingFileLoader.cpp
+++ b/Core/FileLoaders/CachingFileLoader.cpp
@@ -269,6 +269,8 @@ void CachingFileLoader::StartReadAhead(s64 pos) {
 	aheadThread_ = std::thread([this, pos] {
 		SetCurrentThreadName("FileLoaderReadAhead");
 
+		AndroidJNIThreadContext jniContext;
+
 		std::unique_lock<std::recursive_mutex> guard(blocksMutex_);
 		s64 cacheStartPos = pos >> BLOCK_SHIFT;
 		s64 cacheEndPos = cacheStartPos + BLOCK_READAHEAD - 1;

--- a/Core/FileLoaders/RamCachingFileLoader.cpp
+++ b/Core/FileLoaders/RamCachingFileLoader.cpp
@@ -227,6 +227,8 @@ void RamCachingFileLoader::StartReadAhead(s64 pos) {
 	aheadThread_ = std::thread([this] {
 		SetCurrentThreadName("FileLoaderReadAhead");
 
+		AndroidJNIThreadContext jniContext;
+
 		while (aheadRemaining_ != 0 && !aheadCancel_) {
 			// Where should we look?
 			const u32 cacheStartPos = NextAheadBlock();

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -579,6 +579,7 @@ static void __IoAsyncEndCallback(SceUID threadID, SceUID prevCallbackId) {
 
 static void __IoManagerThread() {
 	SetCurrentThreadName("IO");
+	AndroidJNIThreadContext jniContext;
 	while (ioManagerThreadEnabled && coreState != CORE_BOOT_ERROR && coreState != CORE_RUNTIME_ERROR && coreState != CORE_POWERDOWN) {
 		ioManager.RunEventsUntil(CoreTiming::GetTicks() + msToCycles(1000));
 	}

--- a/Core/HW/MemoryStick.cpp
+++ b/Core/HW/MemoryStick.cpp
@@ -19,8 +19,10 @@
 #include <condition_variable>
 #include <mutex>
 #include <thread>
+
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"
+#include "Common/Thread/ThreadUtil.h"
 #include "Core/Config.h"
 #include "Core/CoreTiming.h"
 #include "Core/Compatibility.h"
@@ -97,6 +99,10 @@ static void MemoryStick_CalcInitialFree() {
 	std::unique_lock<std::mutex> guard(freeCalcMutex);
 	freeCalcStatus = FreeCalcStatus::RUNNING;
 	freeCalcThread = std::thread([] {
+		SetCurrentThreadName("CalcInitialFree");
+
+		AndroidJNIThreadContext jniContext;
+
 		memstickInitialFree = pspFileSystem.FreeSpace("ms0:/") + pspFileSystem.ComputeRecursiveDirectorySize("ms0:/PSP/SAVEDATA/");
 
 		std::unique_lock<std::mutex> guard(freeCalcMutex);

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -307,7 +307,7 @@ bool Load_PSP_ISO(FileLoader *fileLoader, std::string *error_string) {
 	//in case we didn't go through EmuScreen::boot
 	g_Config.loadGameConfig(id, g_paramSFO.GetValueString("TITLE"));
 	host->SendUIMessage("config_loaded", "");
-	INFO_LOG(LOADER,"Loading %s...", bootpath.c_str());
+	INFO_LOG(LOADER, "Loading %s...", bootpath.c_str());
 
 	PSPLoaders_Shutdown();
 	// Note: this thread reads the game binary, loads caches, and links HLE while UI spins.
@@ -318,6 +318,8 @@ bool Load_PSP_ISO(FileLoader *fileLoader, std::string *error_string) {
 		PSP_LoadingLock guard;
 		if (coreState != CORE_POWERUP)
 			return;
+
+		AndroidJNIThreadContext jniContext;
 
 		PSP_SetLoading("Loading executable...");
 		// TODO: We can't use the initial error_string pointer.
@@ -455,6 +457,8 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 		if (coreState != CORE_POWERUP)
 			return;
 
+		AndroidJNIThreadContext jniContext;
+
 		bool success = __KernelLoadExec(finalName.c_str(), 0, &PSP_CoreParameter().errorString);
 		if (success && coreState == CORE_POWERUP) {
 			coreState = PSP_CoreParameter().startBreak ? CORE_STEPPING : CORE_RUNNING;
@@ -478,6 +482,8 @@ bool Load_PSP_GE_Dump(FileLoader *fileLoader, std::string *error_string) {
 		PSP_LoadingLock guard;
 		if (coreState != CORE_POWERUP)
 			return;
+
+		AndroidJNIThreadContext jniContext;
 
 		bool success = __KernelLoadGEDump("disc0:/data.ppdmp", &PSP_CoreParameter().errorString);
 		if (success && coreState == CORE_POWERUP) {

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -111,6 +111,8 @@ namespace Reporting
 	static int CalculateCRCThread() {
 		SetCurrentThreadName("ReportCRC");
 
+		AndroidJNIThreadContext jniContext;
+
 		FileLoader *fileLoader = ResolveFileLoaderTarget(ConstructFileLoader(crcFilename));
 		BlockDevice *blockDevice = constructBlockDevice(fileLoader);
 

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -164,6 +164,9 @@ namespace SaveState
 				compressThread_.join();
 			compressThread_ = std::thread([=]{
 				SetCurrentThreadName("SaveStateCompress");
+
+				AndroidJNIThreadContext jniContext;
+
 				Compress(*result, *state, *base);
 			});
 		}

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -165,8 +165,7 @@ namespace SaveState
 			compressThread_ = std::thread([=]{
 				SetCurrentThreadName("SaveStateCompress");
 
-				AndroidJNIThreadContext jniContext;
-
+				// Should do no I/O, so no JNI thread context needed.
 				Compress(*result, *state, *base);
 			});
 		}

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -314,6 +314,8 @@ static void ForwardDebuggerRequest(const http::Request &request) {
 static void ExecuteWebServer() {
 	SetCurrentThreadName("HTTPServer");
 
+	AndroidJNIThreadContext context;  // Destructor detaches.
+
 	auto http = new http::Server(new NewThreadExecutor());
 	http->RegisterHandler("/", &HandleListing);
 	// This lists all the (current) recent ISOs.

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -212,6 +212,8 @@ static void DiscHandler(const http::Request &request, const Path &filename) {
 }
 
 static void HandleListing(const http::Request &request) {
+	AndroidJNIThreadContext jniContext;
+
 	request.WriteHttpResponseHeader("1.0", 200, -1, "text/plain");
 	request.Out()->Printf("/\n");
 	if (serverFlags & (int)WebServerFlags::DISCS) {
@@ -269,6 +271,8 @@ static void RedirectToDebugger(const http::Request &request) {
 }
 
 static void HandleFallback(const http::Request &request) {
+	AndroidJNIThreadContext jniContext;
+
 	if (serverFlags & (int)WebServerFlags::DISCS) {
 		Path filename = LocalFromRemotePath(request.resource());
 		if (!filename.empty()) {
@@ -293,6 +297,8 @@ static void HandleFallback(const http::Request &request) {
 }
 
 static void ForwardDebuggerRequest(const http::Request &request) {
+	AndroidJNIThreadContext jniContext;
+
 	if (serverFlags & (int)WebServerFlags::DEBUGGER) {
 		// Check if this is a websocket request...
 		std::string upgrade;

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -30,6 +30,7 @@
 #include "Common/Net/HTTPClient.h"
 #include "Common/Net/Resolve.h"
 #include "Common/Net/URL.h"
+#include "Common/Thread/ThreadUtil.h"
 
 #include "Common/File/PathBrowser.h"
 #include "Common/Data/Format/JSONReader.h"
@@ -366,6 +367,7 @@ RemoteISOConnectScreen::RemoteISOConnectScreen() {
 	scanAborted = false;
 
 	scanThread_ = new std::thread([](RemoteISOConnectScreen *thiz) {
+		SetCurrentThreadName("RemoteISOScan");
 		thiz->ExecuteScan();
 	}, this);
 }

--- a/android/README.TXT
+++ b/android/README.TXT
@@ -1,6 +1,20 @@
+================================================================
+
+NOTE: These are legacy instructions for building using ndk-build.
+
+We mostly only use this on CI because it's faster than gradle.
+There might also be some holdouts around still using eclipse.
+
+================================================================
+
 First, build the C++ static library:
+
 > cd android
 > ./ab.sh
+Or
+> ./ab.cmd
+
+as appropriate.
 
 Start Eclipse, import the android directory as an existing project
 You need to also load the "native" project into your eclipse workspace

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -32,6 +32,13 @@ ARCH_FILES := \
   $(SRC)/ext/libpng17/arm/filter_neon_intrinsics.c
 endif
 
+ANDROID_FILES :=\
+  $(SRC)/android/jni/app-android.cpp \
+  $(SRC)/android/jni/AndroidJavaGLContext.cpp \
+  $(SRC)/android/jni/AndroidVulkanContext.cpp \
+  $(SRC)/android/jni/AndroidAudio.cpp \
+  $(SRC)/android/jni/OpenSLContext.cpp \
+
 NATIVE_FILES :=\
   $(SRC)/Common/GPU/OpenGL/gl3stub.c \
   $(SRC)/Common/GPU/OpenGL/thin3d_gl.cpp \
@@ -130,6 +137,7 @@ EXEC_AND_LIB_FILES := \
   $(SPIRV_CROSS_FILES) \
   $(EXT_FILES) \
   $(NATIVE_FILES) \
+  $(ANDROID_FILES) \
   $(SRC)/Common/Buffer.cpp \
   $(SRC)/Common/Crypto/md5.cpp \
   $(SRC)/Common/Crypto/sha1.cpp \
@@ -680,11 +688,6 @@ LOCAL_STATIC_LIBRARIES += ppsspp_common ppsspp_core libarmips libzstd
 # These are the files just for ppsspp_jni
 LOCAL_MODULE := ppsspp_jni
 LOCAL_SRC_FILES := \
-  $(SRC)/android/jni/app-android.cpp \
-  $(SRC)/android/jni/AndroidJavaGLContext.cpp \
-  $(SRC)/android/jni/AndroidVulkanContext.cpp \
-  $(SRC)/android/jni/AndroidAudio.cpp \
-  $(SRC)/android/jni/OpenSLContext.cpp \
   $(SRC)/UI/BackgroundAudio.cpp \
   $(SRC)/UI/DiscordIntegration.cpp \
   $(SRC)/UI/ChatScreen.cpp \

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -32,13 +32,6 @@ ARCH_FILES := \
   $(SRC)/ext/libpng17/arm/filter_neon_intrinsics.c
 endif
 
-ANDROID_FILES :=\
-  $(SRC)/android/jni/app-android.cpp \
-  $(SRC)/android/jni/AndroidJavaGLContext.cpp \
-  $(SRC)/android/jni/AndroidVulkanContext.cpp \
-  $(SRC)/android/jni/AndroidAudio.cpp \
-  $(SRC)/android/jni/OpenSLContext.cpp \
-
 NATIVE_FILES :=\
   $(SRC)/Common/GPU/OpenGL/gl3stub.c \
   $(SRC)/Common/GPU/OpenGL/thin3d_gl.cpp \
@@ -137,7 +130,6 @@ EXEC_AND_LIB_FILES := \
   $(SPIRV_CROSS_FILES) \
   $(EXT_FILES) \
   $(NATIVE_FILES) \
-  $(ANDROID_FILES) \
   $(SRC)/Common/Buffer.cpp \
   $(SRC)/Common/Crypto/md5.cpp \
   $(SRC)/Common/Crypto/sha1.cpp \
@@ -688,6 +680,11 @@ LOCAL_STATIC_LIBRARIES += ppsspp_common ppsspp_core libarmips libzstd
 # These are the files just for ppsspp_jni
 LOCAL_MODULE := ppsspp_jni
 LOCAL_SRC_FILES := \
+  $(SRC)/android/jni/app-android.cpp \
+  $(SRC)/android/jni/AndroidJavaGLContext.cpp \
+  $(SRC)/android/jni/AndroidVulkanContext.cpp \
+  $(SRC)/android/jni/AndroidAudio.cpp \
+  $(SRC)/android/jni/OpenSLContext.cpp \
   $(SRC)/UI/BackgroundAudio.cpp \
   $(SRC)/UI/DiscordIntegration.cpp \
   $(SRC)/UI/ChatScreen.cpp \

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -50,6 +50,9 @@ struct JNIEnv {};
 #define JNI_VERSION_1_6 16
 #endif
 
+#include "Common/Log.h"
+#include "Common/LogReporting.h"
+
 #include "Common/Net/Resolve.h"
 #include "android/jni/AndroidAudio.h"
 #include "Common/GPU/OpenGL/GLCommon.h"
@@ -71,7 +74,6 @@ struct JNIEnv {};
 #include "Common/Data/Text/Parsers.h"
 #include "Common/VR/PPSSPPVR.h"
 
-#include "Common/Log.h"
 #include "Common/GraphicsContext.h"
 #include "Common/StringUtils.h"
 #include "Common/TimeUtil.h"
@@ -264,7 +266,6 @@ void Android_AttachThreadToJNI() {
 	JNIEnv *env;
 	int status = gJvm->GetEnv((void **)&env, JNI_VERSION_1_6);
 	if (status < 0) {
-		// TODO: We should have a version of getEnv that doesn't allow auto-attach.
 		INFO_LOG(SYSTEM, "Attaching thread '%s' (not already attached) to JNI.", GetCurrentThreadName());
 		JavaVMAttachArgs args{};
 		args.version = JNI_VERSION_1_6;
@@ -272,7 +273,8 @@ void Android_AttachThreadToJNI() {
 		status = gJvm->AttachCurrentThread(&env, &args);
 
 		if (status < 0) {
-			// bad, but wh
+			// bad, but what can we do other than report..
+			ERROR_LOG_REPORT_ONCE(threadAttachFail, SYSTEM, "Failed to attach thread %s to JNI.", GetCurrentThreadName());
 		}
 	} else {
 		WARN_LOG(SYSTEM, "Thread %s was already attached to JNI.", GetCurrentThreadName());

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -246,22 +246,6 @@ jclass findClass(const char* name) {
 	return static_cast<jclass>(getEnv()->CallObjectMethod(gClassLoader, gFindClassMethod, getEnv()->NewStringUTF(name)));
 }
 
-JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *pjvm, void *reserved) {
-	INFO_LOG(SYSTEM, "JNI_OnLoad");
-	gJvm = pjvm;  // cache the JavaVM pointer
-	auto env = getEnv();
-	//replace with one of your classes in the line below
-	auto randomClass = env->FindClass("org/ppsspp/ppsspp/NativeActivity");
-	jclass classClass = env->GetObjectClass(randomClass);
-	auto classLoaderClass = env->FindClass("java/lang/ClassLoader");
-	auto getClassLoaderMethod = env->GetMethodID(classClass, "getClassLoader",
-												 "()Ljava/lang/ClassLoader;");
-	gClassLoader = env->NewGlobalRef(env->CallObjectMethod(randomClass, getClassLoaderMethod));
-	gFindClassMethod = env->GetMethodID(classLoaderClass, "findClass",
-										"(Ljava/lang/String;)Ljava/lang/Class;");
-	return JNI_VERSION_1_6;
-}
-
 void Android_AttachThreadToJNI() {
 	JNIEnv *env;
 	int status = gJvm->GetEnv((void **)&env, JNI_VERSION_1_6);
@@ -287,6 +271,24 @@ void Android_DetachThreadFromJNI() {
 	} else {
 		WARN_LOG(SYSTEM, "Failed to detach thread '%s' from JNI - never attached?", GetCurrentThreadName());
 	}
+}
+
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *pjvm, void *reserved) {
+	INFO_LOG(SYSTEM, "JNI_OnLoad");
+	gJvm = pjvm;  // cache the JavaVM pointer
+	auto env = getEnv();
+	//replace with one of your classes in the line below
+	auto randomClass = env->FindClass("org/ppsspp/ppsspp/NativeActivity");
+	jclass classClass = env->GetObjectClass(randomClass);
+	auto classLoaderClass = env->FindClass("java/lang/ClassLoader");
+	auto getClassLoaderMethod = env->GetMethodID(classClass, "getClassLoader",
+												 "()Ljava/lang/ClassLoader;");
+	gClassLoader = env->NewGlobalRef(env->CallObjectMethod(randomClass, getClassLoaderMethod));
+	gFindClassMethod = env->GetMethodID(classLoaderClass, "findClass",
+										"(Ljava/lang/String;)Ljava/lang/Class;");
+
+	RegisterAttachDetach(&Android_AttachThreadToJNI, &Android_DetachThreadFromJNI);
+	return JNI_VERSION_1_6;
 }
 
 // Only used in OpenGL mode.

--- a/android/jni/app-android.h
+++ b/android/jni/app-android.h
@@ -27,4 +27,7 @@ public:
 };
 #endif
 
+void Android_DetachThreadFromJNI();
+
 #endif
+

--- a/android/jni/app-android.h
+++ b/android/jni/app-android.h
@@ -27,8 +27,5 @@ public:
 };
 #endif
 
-void Android_AttachThreadToJNI();
-void Android_DetachThreadFromJNI();
-
 #endif
 

--- a/android/jni/app-android.h
+++ b/android/jni/app-android.h
@@ -27,6 +27,7 @@ public:
 };
 #endif
 
+void Android_AttachThreadToJNI();
 void Android_DetachThreadFromJNI();
 
 #endif


### PR DESCRIPTION
I'm considering revamping getEnv so you can't use it without having once explicitly attached the thread. That should shake things out...