### PR TITLE
Round addr to nearest cacheline when invalidating

### DIFF
--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -112,7 +112,7 @@ namespace MIPSInt
 			// Invalidate the instruction cache at this address.
 			// We assume the CPU won't be reset during this, so no locking.
 			if (MIPSComp::jit) {
-				MIPSComp::jit->InvalidateCacheAt(addr, 0x40);
+				MIPSComp::jit->InvalidateCacheAt(addr & ~0x3F, 0x40);
 			}
 			break;
 


### PR DESCRIPTION
This branch has been sitting around locally for a couple of years now, always forgetting to get it in. But it should be right.