### PR TITLE
Remove return values from Axis and Touch input functions

### DIFF
--- a/Common/System/NativeApp.h
+++ b/Common/System/NativeApp.h
@@ -65,7 +65,7 @@ void NativeUpdate();
 // time is not yet implemented. finger can be from 0 to 7, inclusive.
 void NativeTouch(const TouchInput &touch);
 bool NativeKey(const KeyInput &key);
-bool NativeAxis(const AxisInput &axis);
+void NativeAxis(const AxisInput &axis);
 
 // Called when it's time to render. If the device can keep up, this
 // will also be called sixty times per second. Main thread.

--- a/Common/System/NativeApp.h
+++ b/Common/System/NativeApp.h
@@ -63,7 +63,7 @@ void NativeUpdate();
 // Useful for triggering audio events, saving a few ms.
 // If you don't care about touch latency, just do a no-op implementation of this.
 // time is not yet implemented. finger can be from 0 to 7, inclusive.
-bool NativeTouch(const TouchInput &touch);
+void NativeTouch(const TouchInput &touch);
 bool NativeKey(const KeyInput &key);
 bool NativeAxis(const AxisInput &axis);
 

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -75,20 +75,18 @@ void ScreenManager::switchToNext() {
 	nextStack_.clear();
 }
 
-bool ScreenManager::touch(const TouchInput &touch) {
+void ScreenManager::touch(const TouchInput &touch) {
 	std::lock_guard<std::recursive_mutex> guard(inputLock_);
-	bool result = false;
 	// Send release all events to every screen layer.
 	if (touch.flags & TOUCH_RELEASE_ALL) {
 		for (auto &layer : stack_) {
 			Screen *screen = layer.screen;
-			result = layer.screen->touch(screen->transformTouch(touch));
+			layer.screen->touch(screen->transformTouch(touch));
 		}
 	} else if (!stack_.empty()) {
 		Screen *screen = stack_.back().screen;
-		result = stack_.back().screen->touch(screen->transformTouch(touch));
+		stack_.back().screen->touch(screen->transformTouch(touch));
 	}
-	return result;
 }
 
 bool ScreenManager::key(const KeyInput &key) {

--- a/Common/UI/Screen.h
+++ b/Common/UI/Screen.h
@@ -55,7 +55,7 @@ public:
 	virtual void postRender() {}
 	virtual void resized() {}
 	virtual void dialogFinished(const Screen *dialog, DialogResult result) {}
-	virtual bool touch(const TouchInput &touch) { return false;  }
+	virtual void touch(const TouchInput &touch) {}
 	virtual bool key(const KeyInput &key) { return false; }
 	virtual bool axis(const AxisInput &touch) { return false; }
 	virtual void sendMessage(const char *msg, const char *value) {}
@@ -132,7 +132,7 @@ public:
 	Screen *dialogParent(const Screen *dialog) const;
 
 	// Instant touch, separate from the update() mechanism.
-	bool touch(const TouchInput &touch);
+	void touch(const TouchInput &touch);
 	bool key(const KeyInput &key);
 	bool axis(const AxisInput &touch);
 

--- a/Common/UI/Screen.h
+++ b/Common/UI/Screen.h
@@ -57,7 +57,7 @@ public:
 	virtual void dialogFinished(const Screen *dialog, DialogResult result) {}
 	virtual void touch(const TouchInput &touch) {}
 	virtual bool key(const KeyInput &key) { return false; }
-	virtual bool axis(const AxisInput &touch) { return false; }
+	virtual void axis(const AxisInput &touch) {}
 	virtual void sendMessage(const char *msg, const char *value) {}
 	virtual void deviceLost() {}
 	virtual void deviceRestored() {}
@@ -134,7 +134,7 @@ public:
 	// Instant touch, separate from the update() mechanism.
 	void touch(const TouchInput &touch);
 	bool key(const KeyInput &key);
-	bool axis(const AxisInput &touch);
+	void axis(const AxisInput &touch);
 
 	// Generic facility for gross hacks :P
 	void sendMessage(const char *msg, const char *value);

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -151,7 +151,7 @@ TouchInput UIScreen::transformTouch(const TouchInput &touch) {
 	return updated;
 }
 
-bool UIScreen::touch(const TouchInput &touch) {
+void UIScreen::touch(const TouchInput &touch) {
 	if (root_) {
 		if (ClickDebug && (touch.flags & TOUCH_DOWN)) {
 			INFO_LOG(SYSTEM, "Touch down!");
@@ -163,9 +163,7 @@ bool UIScreen::touch(const TouchInput &touch) {
 		}
 
 		UI::TouchEvent(touch, root_);
-		return true;
 	}
-	return false;
 }
 
 bool UIScreen::key(const KeyInput &key) {
@@ -235,16 +233,16 @@ PopupScreen::PopupScreen(std::string title, std::string button1, std::string but
 	alpha_ = 0.0f;
 }
 
-bool PopupScreen::touch(const TouchInput &touch) {
+void PopupScreen::touch(const TouchInput &touch) {
 	if (!box_ || (touch.flags & TOUCH_DOWN) == 0) {
-		return UIDialogScreen::touch(touch);
+		UIDialogScreen::touch(touch);
 	}
 
 	if (!box_->GetBounds().Contains(touch.x, touch.y)) {
 		TriggerFinish(DR_BACK);
 	}
 
-	return UIDialogScreen::touch(touch);
+	UIDialogScreen::touch(touch);
 }
 
 bool PopupScreen::key(const KeyInput &key) {

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -199,12 +199,10 @@ void UIDialogScreen::sendMessage(const char *msg, const char *value) {
 	}
 }
 
-bool UIScreen::axis(const AxisInput &axis) {
+void UIScreen::axis(const AxisInput &axis) {
 	if (root_) {
 		UI::AxisEvent(axis, root_);
-		return true;
 	}
-	return false;
 }
 
 UI::EventReturn UIScreen::OnBack(UI::EventParams &e) {

--- a/Common/UI/UIScreen.h
+++ b/Common/UI/UIScreen.h
@@ -27,7 +27,7 @@ public:
 
 	void touch(const TouchInput &touch) override;
 	bool key(const KeyInput &touch) override;
-	bool axis(const AxisInput &touch) override;
+	void axis(const AxisInput &touch) override;
 
 	TouchInput transformTouch(const TouchInput &touch) override;
 

--- a/Common/UI/UIScreen.h
+++ b/Common/UI/UIScreen.h
@@ -25,7 +25,7 @@ public:
 	void deviceLost() override;
 	void deviceRestored() override;
 
-	bool touch(const TouchInput &touch) override;
+	void touch(const TouchInput &touch) override;
 	bool key(const KeyInput &touch) override;
 	bool axis(const AxisInput &touch) override;
 
@@ -76,7 +76,7 @@ public:
 	virtual void CreatePopupContents(UI::ViewGroup *parent) = 0;
 	void CreateViews() override;
 	bool isTransparent() const override { return true; }
-	bool touch(const TouchInput &touch) override;
+	void touch(const TouchInput &touch) override;
 	bool key(const KeyInput &key) override;
 
 	void TriggerFinish(DialogResult result) override;

--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -46,9 +46,9 @@ static bool vrFlatGame = false;
 static float vrMatrix[VR_MATRIX_COUNT][16];
 static bool vrMirroring[VR_MIRRORING_COUNT];
 
-static bool(*NativeAxis)(const AxisInput &axis);
-static bool(*NativeKey)(const KeyInput &key);
-static bool(*NativeTouch)(const TouchInput &touch);
+static bool (*NativeAxis)(const AxisInput &axis);
+static bool (*NativeKey)(const KeyInput &key);
+static void (*NativeTouch)(const TouchInput &touch);
 
 /*
 ================================================================================
@@ -189,7 +189,7 @@ void GetVRResolutionPerEye(int* width, int* height) {
 	}
 }
 
-void SetVRCallbacks(bool(*axis)(const AxisInput &axis), bool(*key)(const KeyInput &key), bool(*touch)(const TouchInput &touch)) {
+void SetVRCallbacks(bool(*axis)(const AxisInput &axis), bool(*key)(const KeyInput &key), void (*touch)(const TouchInput &touch)) {
 	NativeAxis = axis;
 	NativeKey = key;
 	NativeTouch = touch;

--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -46,7 +46,7 @@ static bool vrFlatGame = false;
 static float vrMatrix[VR_MATRIX_COUNT][16];
 static bool vrMirroring[VR_MIRRORING_COUNT];
 
-static bool (*NativeAxis)(const AxisInput &axis);
+static void (*NativeAxis)(const AxisInput &axis);
 static bool (*NativeKey)(const KeyInput &key);
 static void (*NativeTouch)(const TouchInput &touch);
 
@@ -189,7 +189,7 @@ void GetVRResolutionPerEye(int* width, int* height) {
 	}
 }
 
-void SetVRCallbacks(bool(*axis)(const AxisInput &axis), bool(*key)(const KeyInput &key), void (*touch)(const TouchInput &touch)) {
+void SetVRCallbacks(void (*axis)(const AxisInput &axis), bool(*key)(const KeyInput &key), void (*touch)(const TouchInput &touch)) {
 	NativeAxis = axis;
 	NativeKey = key;
 	NativeTouch = touch;

--- a/Common/VR/PPSSPPVR.h
+++ b/Common/VR/PPSSPPVR.h
@@ -29,7 +29,7 @@ bool IsVREnabled();
 void InitVROnAndroid(void* vm, void* activity, const char* system, int version, const char* name);
 void EnterVR(bool firstStart, void* vulkanContext);
 void GetVRResolutionPerEye(int* width, int* height);
-void SetVRCallbacks(bool(*axis)(const AxisInput &axis), bool(*key)(const KeyInput &key), void(*touch)(const TouchInput &touch));
+void SetVRCallbacks(void(*axis)(const AxisInput &axis), bool(*key)(const KeyInput &key), void(*touch)(const TouchInput &touch));
 
 // VR input integration
 void SetVRAppMode(VRAppMode mode);

--- a/Common/VR/PPSSPPVR.h
+++ b/Common/VR/PPSSPPVR.h
@@ -29,7 +29,7 @@ bool IsVREnabled();
 void InitVROnAndroid(void* vm, void* activity, const char* system, int version, const char* name);
 void EnterVR(bool firstStart, void* vulkanContext);
 void GetVRResolutionPerEye(int* width, int* height);
-void SetVRCallbacks(bool(*axis)(const AxisInput &axis), bool(*key)(const KeyInput &key), bool(*touch)(const TouchInput &touch));
+void SetVRCallbacks(bool(*axis)(const AxisInput &axis), bool(*key)(const KeyInput &key), void(*touch)(const TouchInput &touch));
 
 // VR input integration
 void SetVRAppMode(VRAppMode mode);

--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -117,20 +117,16 @@ bool ControlMapper::Key(const KeyInput &key, bool *pauseTrigger) {
 	return pspKeys.size() > 0;
 }
 
-bool ControlMapper::Axis(const AxisInput &axis) {
+void ControlMapper::Axis(const AxisInput &axis) {
 	if (axis.value > 0) {
 		processAxis(axis, 1);
-		return true;
 	} else if (axis.value < 0) {
 		processAxis(axis, -1);
-		return true;
 	} else if (axis.value == 0) {
 		// Both directions! Prevents sticking for digital input devices that are axises (like HAT)
 		processAxis(axis, 1);
 		processAxis(axis, -1);
-		return true;
 	}
-	return false;
 }
 
 void ControlMapper::Update() {

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -17,7 +17,7 @@ public:
 
 	bool Key(const KeyInput &key, bool *pauseTrigger);
 	void pspKey(int deviceId, int pspKeyCode, int flags);
-	bool Axis(const AxisInput &axis);
+	void Axis(const AxisInput &axis);
 
 	// Required callbacks
 	void SetCallbacks(

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -672,7 +672,7 @@ UI::EventReturn AnalogSetupScreen::OnResetToDefaults(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
-bool TouchTestScreen::touch(const TouchInput &touch) {
+void TouchTestScreen::touch(const TouchInput &touch) {
 	UIDialogScreenWithGameBackground::touch(touch);
 	if (touch.flags & TOUCH_DOWN) {
 		bool found = false;
@@ -721,7 +721,6 @@ bool TouchTestScreen::touch(const TouchInput &touch) {
 			WARN_LOG(SYSTEM, "Touch release without touch down");
 		}
 	}
-	return true;
 }
 
 void TouchTestScreen::CreateViews() {

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -407,11 +407,11 @@ static bool IgnoreAxisForMapping(int axis) {
 }
 
 
-bool KeyMappingNewKeyDialog::axis(const AxisInput &axis) {
+void KeyMappingNewKeyDialog::axis(const AxisInput &axis) {
 	if (mapped_ || time_now_d() < delayUntil_)
-		return false;
+		return;
 	if (IgnoreAxisForMapping(axis.axisId))
-		return false;
+		return;
 
 	if (axis.value > AXIS_BIND_THRESHOLD) {
 		mapped_ = true;
@@ -428,14 +428,13 @@ bool KeyMappingNewKeyDialog::axis(const AxisInput &axis) {
 		if (callback_)
 			callback_(kdf);
 	}
-	return true;
 }
 
-bool KeyMappingNewMouseKeyDialog::axis(const AxisInput &axis) {
+void KeyMappingNewMouseKeyDialog::axis(const AxisInput &axis) {
 	if (mapped_)
-		return false;
+		return;
 	if (IgnoreAxisForMapping(axis.axisId))
-		return false;
+		return;
 
 	if (axis.value > AXIS_BIND_THRESHOLD) {
 		mapped_ = true;
@@ -452,7 +451,6 @@ bool KeyMappingNewMouseKeyDialog::axis(const AxisInput &axis) {
 		if (callback_)
 			callback_(kdf);
 	}
-	return true;
 }
 
 enum class StickHistoryViewType {
@@ -619,12 +617,12 @@ bool AnalogSetupScreen::key(const KeyInput &key) {
 	return retval;
 }
 
-bool AnalogSetupScreen::axis(const AxisInput &axis) {
+void AnalogSetupScreen::axis(const AxisInput &axis) {
 	// We DON'T call UIScreen::Axis here! Otherwise it'll try to move the UI focus around.
 	// UIScreen::axis(axis);
 
 	// Instead we just send the input directly to the mapper, that we'll visualize.
-	return mapper_.Axis(axis);
+	mapper_.Axis(axis);
 }
 
 void AnalogSetupScreen::CreateViews() {
@@ -778,13 +776,12 @@ bool TouchTestScreen::key(const KeyInput &key) {
 	return true;
 }
 
-bool TouchTestScreen::axis(const AxisInput &axis) {
-
+void TouchTestScreen::axis(const AxisInput &axis) {
 	// This is mainly to catch axis events that would otherwise get translated
 	// into arrow keys, since seeing keyboard arrow key events appear when using
 	// a controller would be confusing for the user.
 	if (IgnoreAxisForMapping(axis.axisId))
-		return false;
+		return;
 
 	const float AXIS_LOG_THRESHOLD = AXIS_BIND_THRESHOLD * 0.5f;
 	if (axis.value > AXIS_LOG_THRESHOLD || axis.value < -AXIS_LOG_THRESHOLD) {
@@ -797,7 +794,6 @@ bool TouchTestScreen::axis(const AxisInput &axis) {
 			lastKeyEvent_->SetText(buf);
 		}
 	}
-	return true;
 }
 
 void TouchTestScreen::render() {

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -62,7 +62,7 @@ public:
 	const char *tag() const override { return "KeyMappingNewKey"; }
 
 	bool key(const KeyInput &key) override;
-	bool axis(const AxisInput &axis) override;
+	void axis(const AxisInput &axis) override;
 
 	void SetDelay(float t);
 
@@ -88,7 +88,7 @@ public:
 	const char *tag() const override { return "KeyMappingNewMouseKey"; }
 
 	bool key(const KeyInput &key) override;
-	bool axis(const AxisInput &axis) override;
+	void axis(const AxisInput &axis) override;
 
 protected:
 	void CreatePopupContents(UI::ViewGroup *parent) override;
@@ -110,7 +110,7 @@ public:
 	AnalogSetupScreen(const Path &gamePath);
 
 	bool key(const KeyInput &key) override;
-	bool axis(const AxisInput &axis) override;
+	void axis(const AxisInput &axis) override;
 
 	void update() override;
 
@@ -144,7 +144,7 @@ public:
 	void render() override;
 
 	bool key(const KeyInput &key) override;
-	bool axis(const AxisInput &axis) override;
+	void axis(const AxisInput &axis) override;
 
 	const char *tag() const override { return "TouchTest"; }
 

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -140,7 +140,7 @@ public:
 		}
 	}
 
-	bool touch(const TouchInput &touch) override;
+	void touch(const TouchInput &touch) override;
 	void render() override;
 
 	bool key(const KeyInput &key) override;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -560,14 +560,14 @@ inline float clamp1(float x) {
 	return x;
 }
 
-bool EmuScreen::touch(const TouchInput &touch) {
+void EmuScreen::touch(const TouchInput &touch) {
 	Core_NotifyActivity();
 
 	if (chatMenu_ && chatMenu_->GetVisibility() == UI::V_VISIBLE) {
 		// Avoid pressing touch button behind the chat
 		if (chatMenu_->Contains(touch.x, touch.y)) {
 			chatMenu_->Touch(touch);
-			return true;
+			return;
 		} else if ((touch.flags & TOUCH_DOWN) != 0) {
 			chatMenu_->Close();
 			if (chatButton_)
@@ -578,9 +578,6 @@ bool EmuScreen::touch(const TouchInput &touch) {
 
 	if (root_) {
 		root_->Touch(touch);
-		return true;
-	} else {
-		return false;
 	}
 }
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -788,7 +788,7 @@ bool EmuScreen::key(const KeyInput &key) {
 	return controlMapper_.Key(key, &pauseTrigger_);
 }
 
-bool EmuScreen::axis(const AxisInput &axis) {
+void EmuScreen::axis(const AxisInput &axis) {
 	Core_NotifyActivity();
 
 	return controlMapper_.Axis(axis);

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -50,7 +50,7 @@ public:
 	void sendMessage(const char *msg, const char *value) override;
 	void resized() override;
 
-	bool touch(const TouchInput &touch) override;
+	void touch(const TouchInput &touch) override;
 	bool key(const KeyInput &key) override;
 	bool axis(const AxisInput &axis) override;
 

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -52,7 +52,7 @@ public:
 
 	void touch(const TouchInput &touch) override;
 	bool key(const KeyInput &key) override;
-	bool axis(const AxisInput &axis) override;
+	void axis(const AxisInput &axis) override;
 
 private:
 	void CreateViews() override;

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -744,12 +744,10 @@ bool LogoScreen::key(const KeyInput &key) {
 	return false;
 }
 
-bool LogoScreen::touch(const TouchInput &touch) {
+void LogoScreen::touch(const TouchInput &touch) {
 	if (touch.flags & TOUCH_DOWN) {
 		Next();
-		return true;
 	}
-	return false;
 }
 
 void LogoScreen::render() {

--- a/UI/MiscScreens.h
+++ b/UI/MiscScreens.h
@@ -137,7 +137,7 @@ public:
 	LogoScreen(AfterLogoScreen afterLogoScreen = AfterLogoScreen::DEFAULT);
 
 	bool key(const KeyInput &key) override;
-	bool touch(const TouchInput &touch) override;
+	void touch(const TouchInput &touch) override;
 	void update() override;
 	void render() override;
 	void sendMessage(const char *message, const char *value) override;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1353,15 +1353,15 @@ bool NativeKey(const KeyInput &key) {
 	return retval;
 }
 
-bool NativeAxis(const AxisInput &axis) {
+void NativeAxis(const AxisInput &axis) {
 	// VR actions
 	if (IsVREnabled() && !UpdateVRAxis(axis)) {
-		return false;
+		return;
 	}
 
 	if (!screenManager) {
 		// Too early.
-		return false;
+		return;
 	}
 
 	using namespace TiltEventProcessor;
@@ -1369,11 +1369,8 @@ bool NativeAxis(const AxisInput &axis) {
 	// only handle tilt events if tilt is enabled.
 	if (g_Config.iTiltInputType == TILT_NULL) {
 		// if tilt events are disabled, then run it through the usual way.
-		if (screenManager) {
-			return screenManager->axis(axis);
-		} else {
-			return false;
-		}
+		screenManager->axis(axis);
+		return;
 	}
 
 	// create the base coordinate tilt system from the calibration data.
@@ -1404,7 +1401,7 @@ bool NativeAxis(const AxisInput &axis) {
 				if (fabs(axis.value) < 0.8f && g_Config.iTiltOrientation == 2) // Auto tilt switch
 					verticalTilt = false;
 				else
-					return false; // Tilt on Z instead
+					return; // Tilt on Z instead
 			}
 			if (portrait) {
 				currentTilt.x_ = axis.value;
@@ -1426,7 +1423,7 @@ bool NativeAxis(const AxisInput &axis) {
 				if (fabs(axis.value) < 0.8f && g_Config.iTiltOrientation == 2) // Auto tilt switch
 					verticalTilt = true;
 				else
-					return false; // Tilt on X instead
+					return; // Tilt on X instead
 			}
 			if (portrait) {
 				currentTilt.x_ = -axis.value;
@@ -1442,13 +1439,12 @@ bool NativeAxis(const AxisInput &axis) {
 			//Don't know how to handle these. Someone should figure it out.
 			//Does the Ouya even have an accelerometer / gyro? I can't find any reference to these
 			//in the Ouya docs...
-			return false;
+			return;
 
 		default:
 			// Don't take over completely!
-			if (!screenManager)
-				return false;
-			return screenManager->axis(axis);
+			screenManager->axis(axis);
+			return;
 	}
 
 	//figure out the sensitivity of the tilt. (sensitivity is originally 0 - 100)
@@ -1463,7 +1459,6 @@ bool NativeAxis(const AxisInput &axis) {
 	Tilt trueTilt = GenTilt(baseTilt, currentTilt, g_Config.bInvertTiltX, g_Config.bInvertTiltY, g_Config.fDeadzoneRadius, xSensitivity, ySensitivity);
 
 	TranslateTiltToInput(trueTilt);
-	return true;
 }
 
 void NativeMessageReceived(const char *message, const char *value) {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1315,17 +1315,17 @@ bool NativeIsAtTopLevel() {
 	}
 }
 
-bool NativeTouch(const TouchInput &touch) {
-	if (screenManager) {
-		// Brute force prevent NaNs from getting into the UI system
-		if (my_isnan(touch.x) || my_isnan(touch.y)) {
-			return false;
-		}
-		screenManager->touch(touch);
-		return true;
-	} else {
-		return false;
+void NativeTouch(const TouchInput &touch) {
+	if (!screenManager) {
+		return;
 	}
+
+	// Brute force prevent NaNs from getting into the UI system.
+	// Don't think this is actually necessary in practice.
+	if (my_isnan(touch.x) || my_isnan(touch.y)) {
+		return;
+	}
+	screenManager->touch(touch);
 }
 
 bool NativeKey(const KeyInput &key) {

--- a/UI/TiltAnalogSettingsScreen.cpp
+++ b/UI/TiltAnalogSettingsScreen.cpp
@@ -58,7 +58,7 @@ void TiltAnalogSettingsScreen::CreateViews() {
 	settings->Add(new Choice(di->T("Back")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
 }
 
-bool TiltAnalogSettingsScreen::axis(const AxisInput &axis) {
+void TiltAnalogSettingsScreen::axis(const AxisInput &axis) {
 	if (axis.deviceId == DEVICE_ID_ACCELEROMETER) {
 		// Historically, we've had X and Y swapped, likely due to portrait vs landscape.
 		// TODO: We may want to configure this based on screen orientation.
@@ -69,7 +69,6 @@ bool TiltAnalogSettingsScreen::axis(const AxisInput &axis) {
 			currentTiltX_ = axis.value;
 		}
 	}
-	return false;
 }
 
 UI::EventReturn TiltAnalogSettingsScreen::OnCalibrate(UI::EventParams &e) {

--- a/UI/TiltAnalogSettingsScreen.h
+++ b/UI/TiltAnalogSettingsScreen.h
@@ -25,7 +25,7 @@ public:
 	TiltAnalogSettingsScreen() {}
 
 	void CreateViews() override;
-	bool axis(const AxisInput &axis) override;
+	void axis(const AxisInput &axis) override;
 
 	const char *tag() const override { return "TiltAnalogSettings"; }
 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1147,17 +1147,17 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_keyUp(JNIEnv *, jclass, jin
 	return NativeKey(keyInput);
 }
 
-extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_joystickAxis(
+extern "C" void Java_org_ppsspp_ppsspp_NativeApp_joystickAxis(
 		JNIEnv *env, jclass, jint deviceId, jint axisId, jfloat value) {
 	if (!renderer_inited)
-		return false;
+		return;
 
 	AxisInput axis;
 	axis.axisId = axisId;
 	axis.deviceId = deviceId;
 	axis.value = value;
 
-	return NativeAxis(axis);
+	NativeAxis(axis);
 }
 
 extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_mouseWheelEvent(
@@ -1169,9 +1169,9 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_mouseWheelEvent(
 	return true;
 }
 
-extern "C" jboolean JNICALL Java_org_ppsspp_ppsspp_NativeApp_accelerometer(JNIEnv *, jclass, float x, float y, float z) {
+extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_accelerometer(JNIEnv *, jclass, float x, float y, float z) {
 	if (!renderer_inited)
-		return false;
+		return;
 
 	AxisInput axis;
 	axis.deviceId = DEVICE_ID_ACCELEROMETER;
@@ -1179,17 +1179,15 @@ extern "C" jboolean JNICALL Java_org_ppsspp_ppsspp_NativeApp_accelerometer(JNIEn
 
 	axis.axisId = JOYSTICK_AXIS_ACCELEROMETER_X;
 	axis.value = x;
-	bool retvalX = NativeAxis(axis);
+	NativeAxis(axis);
 
 	axis.axisId = JOYSTICK_AXIS_ACCELEROMETER_Y;
 	axis.value = y;
-	bool retvalY = NativeAxis(axis);
+	NativeAxis(axis);
 
 	axis.axisId = JOYSTICK_AXIS_ACCELEROMETER_Z;
 	axis.value = z;
-	bool retvalZ = NativeAxis(axis);
-
-	return retvalX || retvalY || retvalZ;
+	NativeAxis(axis);
 }
 
 extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_sendMessage(JNIEnv *env, jclass, jstring message, jstring param) {

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1113,7 +1113,7 @@ PermissionStatus System_GetPermissionStatus(SystemPermission permission) {
 	}
 }
 
-extern "C" jboolean JNICALL Java_org_ppsspp_ppsspp_NativeApp_touch
+extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_touch
 	(JNIEnv *, jclass, float x, float y, int code, int pointerId) {
 
 	float scaledX = x * g_dpi_scale_x;
@@ -1125,8 +1125,7 @@ extern "C" jboolean JNICALL Java_org_ppsspp_ppsspp_NativeApp_touch
 	touch.y = scaledY;
 	touch.flags = code;
 
-	bool retval = NativeTouch(touch);
-	return retval;
+	NativeTouch(touch);
 }
 
 extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_keyDown(JNIEnv *, jclass, jint deviceId, jint key, jboolean isRepeat) {

--- a/android/src/org/ppsspp/ppsspp/NativeApp.java
+++ b/android/src/org/ppsspp/ppsspp/NativeApp.java
@@ -48,7 +48,7 @@ public class NativeApp {
 	// Sensor/input data. These are asynchronous, beware!
 	public static native void touch(float x, float y, int data, int pointerId);
 
-	public static native boolean accelerometer(float x, float y, float z);
+	public static native void accelerometer(float x, float y, float z);
 
 	public static native void sendMessage(String msg, String arg);
 	public static native void sendInputBox(String seqID, boolean result, String value);

--- a/android/src/org/ppsspp/ppsspp/NativeApp.java
+++ b/android/src/org/ppsspp/ppsspp/NativeApp.java
@@ -46,7 +46,7 @@ public class NativeApp {
 	public static native boolean mouseWheelEvent(float x, float y);
 
 	// Sensor/input data. These are asynchronous, beware!
-	public static native boolean touch(float x, float y, int data, int pointerId);
+	public static native void touch(float x, float y, int data, int pointerId);
 
 	public static native boolean accelerometer(float x, float y, float z);
 

--- a/android/src/org/ppsspp/ppsspp/NativeGLView.java
+++ b/android/src/org/ppsspp/ppsspp/NativeGLView.java
@@ -62,7 +62,6 @@ public class NativeGLView extends GLSurfaceView implements SensorEventListener, 
 	public boolean onTouchEvent(final MotionEvent ev) {
 		boolean canReadToolType = Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH;
 
-		int numTouchesHandled = 0;
 		for (int i = 0; i < ev.getPointerCount(); i++) {
 			int pid = ev.getPointerId(i);
 			int code = 0;
@@ -94,10 +93,10 @@ public class NativeGLView extends GLSurfaceView implements SensorEventListener, 
 					code |= tool << 10; // We use the Android tool type codes
 				}
 				// Can't use || due to short circuit evaluation
-				numTouchesHandled += NativeApp.touch(ev.getX(i), ev.getY(i), code, pid) ? 1 : 0;
+				NativeApp.touch(ev.getX(i), ev.getY(i), code, pid);
 			}
 		}
-		return numTouchesHandled > 0;
+		return true;
 	}
 
 	// Sensor management

--- a/android/src/org/ppsspp/ppsspp/NativeSurfaceView.java
+++ b/android/src/org/ppsspp/ppsspp/NativeSurfaceView.java
@@ -63,7 +63,6 @@ public class NativeSurfaceView extends SurfaceView implements SensorEventListene
 	public boolean onTouchEvent(final MotionEvent ev) {
 		boolean canReadToolType = Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH;
 
-		int numTouchesHandled = 0;
 		for (int i = 0; i < ev.getPointerCount(); i++) {
 			int pid = ev.getPointerId(i);
 			int code = 0;
@@ -95,10 +94,10 @@ public class NativeSurfaceView extends SurfaceView implements SensorEventListene
 					code |= tool << 10; // We use the Android tool type codes
 				}
 				// Can't use || due to short circuit evaluation
-				numTouchesHandled += NativeApp.touch(ev.getX(i), ev.getY(i), code, pid) ? 1 : 0;
+				NativeApp.touch(ev.getX(i), ev.getY(i), code, pid);
 			}
 		}
-		return numTouchesHandled > 0;
+		return true;
 	}
 
 	// Sensor management


### PR DESCRIPTION
It's never been clear what to return from these, and we never used the return values for anything anyway. So let's get rid of them.

Key is a bit more complicated and there the return value actually get used in a couple of circumstances. I think some simplification is possible there too, though.