### PR TITLE
Inject default vertex components to avoid needing separate vshaders for various formats.

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -39,6 +39,7 @@ DrawEngineCommon::DrawEngineCommon() : decoderMap_(16) {
 	decJitCache_ = new VertexDecoderJitCache();
 	transformed = (TransformedVertex *)AllocateMemoryPages(TRANSFORMED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
 	transformedExpanded = (TransformedVertex *)AllocateMemoryPages(3 * TRANSFORMED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
+	decOptions_.injectDummyUVIfMissing = true;
 }
 
 DrawEngineCommon::~DrawEngineCommon() {

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -41,6 +41,7 @@ DrawEngineCommon::DrawEngineCommon() : decoderMap_(16) {
 	transformedExpanded = (TransformedVertex *)AllocateMemoryPages(3 * TRANSFORMED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
 	decOptions_.injectDummyUVIfMissing = true;
 	decOptions_.injectDummyNormalIfMissing = true;
+	decOptions_.injectDummyColorIfMissing = true;
 }
 
 DrawEngineCommon::~DrawEngineCommon() {

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -40,6 +40,7 @@ DrawEngineCommon::DrawEngineCommon() : decoderMap_(16) {
 	transformed = (TransformedVertex *)AllocateMemoryPages(TRANSFORMED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
 	transformedExpanded = (TransformedVertex *)AllocateMemoryPages(3 * TRANSFORMED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
 	decOptions_.injectDummyUVIfMissing = true;
+	decOptions_.injectDummyNormalIfMissing = true;
 }
 
 DrawEngineCommon::~DrawEngineCommon() {

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -18,7 +18,6 @@ std::string VertexShaderDesc(const VShaderID &id) {
 	desc << StringFromFormat("%08x:%08x ", id.d[1], id.d[0]);
 	if (id.Bit(VS_BIT_IS_THROUGH)) desc << "THR ";
 	if (id.Bit(VS_BIT_USE_HW_TRANSFORM)) desc << "HWX ";
-	if (id.Bit(VS_BIT_HAS_COLOR)) desc << "C ";
 	if (id.Bit(VS_BIT_LMODE)) desc << "LM ";
 	if (id.Bit(VS_BIT_NORM_REVERSE)) desc << "RevN ";
 	int uvgMode = id.Bits(VS_BIT_UVGEN_MODE, 2);
@@ -72,8 +71,6 @@ void ComputeVertexShaderID(VShaderID *id_out, VertexDecoder *vertexDecoder, bool
 	bool doShadeMapping = doTexture && (gstate.getUVGenMode() == GE_TEXMAP_ENVIRONMENT_MAP);
 	bool doFlatShading = gstate.getShadeMode() == GE_SHADE_FLAT && !gstate.isModeClear();
 
-	bool vtypeHasColor = (vertType & GE_VTYPE_COL_MASK) != 0;
-
 	bool doBezier = gstate_c.submitType == SubmitType::HW_BEZIER;
 	bool doSpline = gstate_c.submitType == SubmitType::HW_SPLINE;
 
@@ -83,7 +80,6 @@ void ComputeVertexShaderID(VShaderID *id_out, VertexDecoder *vertexDecoder, bool
 
 	VShaderID id;
 	id.SetBit(VS_BIT_IS_THROUGH, isModeThrough);
-	id.SetBit(VS_BIT_HAS_COLOR, vtypeHasColor);
 	id.SetBit(VS_BIT_VERTEX_RANGE_CULLING, vertexRangeCulling);
 
 	if (!isModeThrough && gstate_c.Use(GPU_USE_SINGLE_PASS_STEREO)) {

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -19,7 +19,6 @@ std::string VertexShaderDesc(const VShaderID &id) {
 	if (id.Bit(VS_BIT_IS_THROUGH)) desc << "THR ";
 	if (id.Bit(VS_BIT_USE_HW_TRANSFORM)) desc << "HWX ";
 	if (id.Bit(VS_BIT_HAS_COLOR)) desc << "C ";
-	if (id.Bit(VS_BIT_HAS_TEXCOORD)) desc << "T ";
 	if (id.Bit(VS_BIT_HAS_NORMAL)) desc << "N ";
 	if (id.Bit(VS_BIT_LMODE)) desc << "LM ";
 	if (id.Bit(VS_BIT_NORM_REVERSE)) desc << "RevN ";
@@ -76,7 +75,6 @@ void ComputeVertexShaderID(VShaderID *id_out, VertexDecoder *vertexDecoder, bool
 
 	bool vtypeHasColor = (vertType & GE_VTYPE_COL_MASK) != 0;
 	bool vtypeHasNormal = (vertType & GE_VTYPE_NRM_MASK) != 0;
-	bool vtypeHasTexcoord = (vertType & GE_VTYPE_TC_MASK) != 0;
 
 	bool doBezier = gstate_c.submitType == SubmitType::HW_BEZIER;
 	bool doSpline = gstate_c.submitType == SubmitType::HW_SPLINE;
@@ -147,7 +145,6 @@ void ComputeVertexShaderID(VShaderID *id_out, VertexDecoder *vertexDecoder, bool
 		}
 
 		id.SetBit(VS_BIT_NORM_REVERSE, gstate.areNormalsReversed());
-		id.SetBit(VS_BIT_HAS_TEXCOORD, vtypeHasTexcoord);
 
 		if (useHWTessellation) {
 			id.SetBit(VS_BIT_BEZIER, doBezier);

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -19,7 +19,6 @@ std::string VertexShaderDesc(const VShaderID &id) {
 	if (id.Bit(VS_BIT_IS_THROUGH)) desc << "THR ";
 	if (id.Bit(VS_BIT_USE_HW_TRANSFORM)) desc << "HWX ";
 	if (id.Bit(VS_BIT_HAS_COLOR)) desc << "C ";
-	if (id.Bit(VS_BIT_HAS_NORMAL)) desc << "N ";
 	if (id.Bit(VS_BIT_LMODE)) desc << "LM ";
 	if (id.Bit(VS_BIT_NORM_REVERSE)) desc << "RevN ";
 	int uvgMode = id.Bits(VS_BIT_UVGEN_MODE, 2);
@@ -74,14 +73,9 @@ void ComputeVertexShaderID(VShaderID *id_out, VertexDecoder *vertexDecoder, bool
 	bool doFlatShading = gstate.getShadeMode() == GE_SHADE_FLAT && !gstate.isModeClear();
 
 	bool vtypeHasColor = (vertType & GE_VTYPE_COL_MASK) != 0;
-	bool vtypeHasNormal = (vertType & GE_VTYPE_NRM_MASK) != 0;
 
 	bool doBezier = gstate_c.submitType == SubmitType::HW_BEZIER;
 	bool doSpline = gstate_c.submitType == SubmitType::HW_SPLINE;
-
-	if (doBezier || doSpline) {
-		_assert_(vtypeHasNormal);
-	}
 
 	bool lmode = gstate.isUsingSecondaryColor() && gstate.isLightingEnabled() && !isModeThrough && !gstate.isModeClear();
 	bool vertexRangeCulling = gstate_c.Use(GPU_USE_VS_RANGE_CULLING) &&
@@ -103,7 +97,6 @@ void ComputeVertexShaderID(VShaderID *id_out, VertexDecoder *vertexDecoder, bool
 
 	if (useHWTransform) {
 		id.SetBit(VS_BIT_USE_HW_TRANSFORM);
-		id.SetBit(VS_BIT_HAS_NORMAL, vtypeHasNormal);
 
 		// The next bits are used differently depending on UVgen mode
 		if (gstate.getUVGenMode() == GE_TEXMAP_TEXTURE_MATRIX) {

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -11,9 +11,7 @@
 enum VShaderBit : uint8_t {
 	VS_BIT_LMODE = 0,
 	VS_BIT_IS_THROUGH = 1,
-	// bit 2 is free.
-	VS_BIT_HAS_COLOR = 3,
-	// bit 4 is free.
+	// bits 2-4 are free.
 	VS_BIT_VERTEX_RANGE_CULLING = 5,
 	VS_BIT_SIMPLE_STEREO = 6,
 	// 7 is free.

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -18,7 +18,7 @@ enum VShaderBit : uint8_t {
 	VS_BIT_SIMPLE_STEREO = 6,
 	// 7 is free.
 	VS_BIT_USE_HW_TRANSFORM = 8,
-	VS_BIT_HAS_NORMAL = 9,  // conditioned on hw transform
+	// 9 is free
 	VS_BIT_NORM_REVERSE = 10,
 	VS_BIT_HAS_COLOR_TESS = 12,  // 1 bit
 	VS_BIT_HAS_TEXCOORD_TESS = 13,  // 1 bit

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -20,7 +20,6 @@ enum VShaderBit : uint8_t {
 	VS_BIT_USE_HW_TRANSFORM = 8,
 	VS_BIT_HAS_NORMAL = 9,  // conditioned on hw transform
 	VS_BIT_NORM_REVERSE = 10,
-	VS_BIT_HAS_TEXCOORD = 11,
 	VS_BIT_HAS_COLOR_TESS = 12,  // 1 bit
 	VS_BIT_HAS_TEXCOORD_TESS = 13,  // 1 bit
 	VS_BIT_NORM_REVERSE_TESS = 14, // 1 bit

--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -109,6 +109,8 @@ static const JitLookup jitLookup[] = {
 	{&VertexDecoder::Step_WeightsU16Skin, &VertexDecoderJitCache::Jit_WeightsU16Skin},
 	{&VertexDecoder::Step_WeightsFloatSkin, &VertexDecoderJitCache::Jit_WeightsFloatSkin},
 
+	{&VertexDecoder::Step_TcDefault, &VertexDecoderJitCache::Jit_TcDefault},
+
 	{&VertexDecoder::Step_TcFloat, &VertexDecoderJitCache::Jit_TcFloat},
 	{&VertexDecoder::Step_TcU8ToFloat, &VertexDecoderJitCache::Jit_TcU8ToFloat},
 	{&VertexDecoder::Step_TcU16ToFloat, &VertexDecoderJitCache::Jit_TcU16ToFloat},
@@ -485,6 +487,12 @@ void VertexDecoderJitCache::Jit_WeightsFloatSkin() {
 		VLD1(F_32, neonWeightRegsD[0], srcReg, (dec_->nweights + 1) / 2);
 	}
 	Jit_ApplyWeights();
+}
+
+void VertexDecoderJitCache::Jit_TcDefault() {
+	MOVI(tempReg1, 0);
+	STR(tempReg1, dstReg, dec_->decFmt.uvoff);
+	STR(tempReg1, dstReg, dec_->decFmt.uvoff + 4);
 }
 
 void VertexDecoderJitCache::Jit_TcFloat() {

--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -490,7 +490,7 @@ void VertexDecoderJitCache::Jit_WeightsFloatSkin() {
 }
 
 void VertexDecoderJitCache::Jit_TcDefault() {
-	MOVI(tempReg1, 0);
+	MOVI2R(tempReg1, 0);
 	STR(tempReg1, dstReg, dec_->decFmt.uvoff);
 	STR(tempReg1, dstReg, dec_->decFmt.uvoff + 4);
 }
@@ -846,6 +846,22 @@ void VertexDecoderJitCache::Jit_WriteMorphColor(int outOff, bool checkAlpha) {
 		MOV(fullAlphaReg, 0);
 		SetCC(CC_AL);
 	}
+}
+
+void VertexDecoderJitCache::Jit_NormalDefaultS8() {
+	// Directly write the immediate to where it goes.
+	MOVI2R(tempReg1, 0x007F0000);
+	STR(tempReg1, dstReg, dec_->decFmt.nrmoff);
+}
+
+void VertexDecoderJitCache::Jit_NormalDefaultFloat() {
+	// Directly write the immediate to where it goes.
+	MOVI2R(tempReg1, 0x00000000);
+	MOVI2R(tempReg2, 0x3F800000);
+
+	STR(tempReg1, dstReg, dec_->decFmt.nrmoff);
+	STR(tempReg1, dstReg, dec_->decFmt.nrmoff + 4);
+	STR(tempReg2, dstReg, dec_->decFmt.nrmoff + 8);
 }
 
 void VertexDecoderJitCache::Jit_NormalS8() {

--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -40,6 +40,7 @@ static const ARM64Reg dstReg = X1;
 
 static const ARM64Reg counterReg = W2;
 static const ARM64Reg tempReg1 = W3;
+static const ARM64Reg tempReg1_64 = X3;
 static const ARM64Reg tempRegPtr = X3;
 static const ARM64Reg tempReg2 = W4;
 static const ARM64Reg tempReg3 = W5;
@@ -85,6 +86,8 @@ static const JitLookup jitLookup[] = {
 	{&VertexDecoder::Step_WeightsU8Skin, &VertexDecoderJitCache::Jit_WeightsU8Skin},
 	{&VertexDecoder::Step_WeightsU16Skin, &VertexDecoderJitCache::Jit_WeightsU16Skin},
 	{&VertexDecoder::Step_WeightsFloatSkin, &VertexDecoderJitCache::Jit_WeightsFloatSkin},
+
+	{&VertexDecoder::Step_TcDefault, &VertexDecoderJitCache::Jit_TcDefault},
 
 	{&VertexDecoder::Step_TcFloat, &VertexDecoderJitCache::Jit_TcFloat},
 	{&VertexDecoder::Step_TcU8ToFloat, &VertexDecoderJitCache::Jit_TcU8ToFloat},
@@ -590,6 +593,11 @@ void VertexDecoderJitCache::Jit_TcU16ThroughToFloat() {
 	fp.UXTL(16, neonScratchRegQ, neonScratchRegD); // Widen to 32-bit
 	fp.UCVTF(32, neonScratchRegD, neonScratchRegD);
 	fp.STUR(64, neonScratchRegD, dstReg, dec_->decFmt.uvoff);
+}
+
+void VertexDecoderJitCache::Jit_TcDefault() {
+	MOVI2R(tempReg1_64, 0);
+	STR(INDEX_UNSIGNED, tempReg1, dstReg, dec_->decFmt.uvoff);
 }
 
 void VertexDecoderJitCache::Jit_TcFloatThrough() {

--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -713,6 +713,19 @@ void VertexDecoderJitCache::Jit_PosFloatThrough() {
 	fp.STUR(32, neonScratchRegD, dstReg, dec_->decFmt.posoff + 8);
 }
 
+void VertexDecoderJitCache::Jit_NormalDefaultS8() {
+	MOVI2R(tempReg1, 0x007F0000);
+	STR(INDEX_UNSIGNED, tempReg1, dstReg, dec_->decFmt.nrmoff);
+}
+
+void VertexDecoderJitCache::Jit_NormalDefaultFloat() {
+	MOVI2R(tempReg1, 0x00000000);
+	MOVI2R(tempReg2, 0x3F800000);
+	STR(INDEX_UNSIGNED, tempReg1, dstReg, dec_->decFmt.nrmoff);
+	STR(INDEX_UNSIGNED, tempReg1, dstReg, dec_->decFmt.nrmoff + 4);
+	STR(INDEX_UNSIGNED, tempReg2, dstReg, dec_->decFmt.nrmoff + 8);
+}
+
 void VertexDecoderJitCache::Jit_NormalS8() {
 	LDURH(tempReg1, srcReg, dec_->nrmoff);
 	LDRB(INDEX_UNSIGNED, tempReg3, srcReg, dec_->nrmoff + 2);

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -270,9 +270,15 @@ void VertexDecoder::Step_WeightsFloatSkin() const {
 	ComputeSkinMatrix(wdata);
 }
 
+void VertexDecoder::Step_TcDefault() const
+{
+	uint64_t *uv = (uint64_t *)(decoded_ + decFmt.uvoff);
+	// Write two zero floats in one instruction.
+	*uv = 0;
+}
+
 void VertexDecoder::Step_TcU8ToFloat() const
 {
-	// u32 to write two bytes of zeroes for free.
 	float *uv = (float *)(decoded_ + decFmt.uvoff);
 	const u8 *uvdata = (const u8*)(ptr_ + tcoff);
 	uv[0] = uvdata[0] * (1.0f / 128.0f);
@@ -1163,6 +1169,11 @@ void VertexDecoder::SetVertexType(u32 fmt, const VertexDecoderOptions &options, 
 			decFmt.uvfmt = DEC_FLOAT_2;
 		}
 
+		decFmt.uvoff = decOff;
+		decOff += DecFmtSize(decFmt.uvfmt);
+	} else if (options.injectDummyUVIfMissing) {
+		steps_[numSteps_++] = &VertexDecoder::Step_TcDefault;
+		decFmt.uvfmt = DEC_FLOAT_2;
 		decFmt.uvoff = decOff;
 		decOff += DecFmtSize(decFmt.uvfmt);
 	}

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -603,6 +603,24 @@ void VertexDecoder::Step_Color8888Morph() const
 	gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && (int)col[3] >= 255;
 }
 
+// Writes in packed s8 format.
+void VertexDecoder::Step_NormalDefaultS8() const
+{
+	s8 *normal = (s8 *)(decoded_ + decFmt.nrmoff);
+	normal[0] = 0;
+	normal[1] = 0;
+	normal[2] = 127;
+	normal[3] = 0;
+}
+
+void VertexDecoder::Step_NormalDefaultFloat() const
+{
+	float *normal = (float *)(decoded_ + decFmt.nrmoff);
+	normal[0] = 0.0f;
+	normal[1] = 0.0f;
+	normal[2] = 1.0f;
+}
+
 void VertexDecoder::Step_NormalS8() const
 {
 	s8 *normal = (s8 *)(decoded_ + decFmt.nrmoff);
@@ -1234,6 +1252,11 @@ void VertexDecoder::SetVertexType(u32 fmt, const VertexDecoderOptions &options, 
 				steps_[numSteps_++] = nrmstep_morph[nrm];
 			}
 		}
+		decFmt.nrmoff = decOff;
+		decOff += DecFmtSize(decFmt.nrmfmt);
+	} else if (options.injectDummyNormalIfMissing) {
+		steps_[numSteps_++] = options.expand8BitNormalsToFloat ? &VertexDecoder::Step_NormalDefaultFloat : &VertexDecoder::Step_NormalDefaultS8;
+		decFmt.nrmfmt = options.expand8BitNormalsToFloat ? DEC_FLOAT_3 : DEC_S8_3;
 		decFmt.nrmoff = decOff;
 		decOff += DecFmtSize(decFmt.nrmfmt);
 	}

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -496,6 +496,13 @@ void VertexDecoder::Step_ColorInvalid() const
 	// Do nothing.  This is only here to prevent crashes.
 }
 
+void VertexDecoder::Step_ColorDefault() const
+{
+	u32 color = gstate.getMaterialAmbientRGBA();
+	u32 *c = (u32 *)(decoded_ + decFmt.c0off);
+	*c = color;
+}
+
 void VertexDecoder::Step_Color565() const
 {
 	u8 *c = decoded_ + decFmt.c0off;
@@ -1207,6 +1214,11 @@ void VertexDecoder::SetVertexType(u32 fmt, const VertexDecoderOptions &options, 
 
 		// All color formats decode to DEC_U8_4 currently.
 		// They can become floats later during transform though.
+		decFmt.c0fmt = DEC_U8_4;
+		decFmt.c0off = decOff;
+		decOff += DecFmtSize(decFmt.c0fmt);
+	} else if (options.injectDummyColorIfMissing) {
+		steps_[numSteps_++] = &VertexDecoder::Step_ColorDefault;
 		decFmt.c0fmt = DEC_U8_4;
 		decFmt.c0off = decOff;
 		decOff += DecFmtSize(decFmt.c0fmt);

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -324,6 +324,7 @@ struct VertexDecoderOptions {
 	bool expandAllWeightsToFloat;
 	bool expand8BitNormalsToFloat;
 	bool applySkinInDecode;
+	bool injectDummyUVIfMissing;
 };
 
 class VertexDecoder {
@@ -352,6 +353,8 @@ public:
 	void Step_WeightsU8Skin() const;
 	void Step_WeightsU16Skin() const;
 	void Step_WeightsFloatSkin() const;
+
+	void Step_TcDefault() const;
 
 	void Step_TcU8ToFloat() const;
 	void Step_TcU16ToFloat() const;
@@ -509,6 +512,8 @@ public:
 	void Jit_WeightsU8Skin();
 	void Jit_WeightsU16Skin();
 	void Jit_WeightsFloatSkin();
+
+	void Jit_TcDefault();
 
 	void Jit_TcU8ToFloat();
 	void Jit_TcU16ToFloat();

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -326,6 +326,7 @@ struct VertexDecoderOptions {
 	bool applySkinInDecode;
 	bool injectDummyUVIfMissing;
 	bool injectDummyNormalIfMissing;
+	bool injectDummyColorIfMissing;
 };
 
 class VertexDecoder {
@@ -381,6 +382,7 @@ public:
 	void Step_TcFloatPrescaleMorph() const;
 
 	void Step_ColorInvalid() const;
+	void Step_ColorDefault() const;
 	void Step_Color4444() const;
 	void Step_Color565() const;
 	void Step_Color5551() const;
@@ -537,6 +539,8 @@ public:
 
 	void Jit_TcU16ThroughToFloat();
 	void Jit_TcFloatThrough();
+
+	void Jit_ColorDefault();
 
 	void Jit_Color8888();
 	void Jit_Color4444();

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -325,6 +325,7 @@ struct VertexDecoderOptions {
 	bool expand8BitNormalsToFloat;
 	bool applySkinInDecode;
 	bool injectDummyUVIfMissing;
+	bool injectDummyNormalIfMissing;
 };
 
 class VertexDecoder {
@@ -389,6 +390,9 @@ public:
 	void Step_Color565Morph() const;
 	void Step_Color5551Morph() const;
 	void Step_Color8888Morph() const;
+
+	void Step_NormalDefaultS8() const;
+	void Step_NormalDefaultFloat() const;
 
 	void Step_NormalS8() const;
 	void Step_NormalS8ToFloat() const;
@@ -538,6 +542,9 @@ public:
 	void Jit_Color4444();
 	void Jit_Color565();
 	void Jit_Color5551();
+
+	void Jit_NormalDefaultS8();
+	void Jit_NormalDefaultFloat();
 
 	void Jit_NormalS8();
 	void Jit_NormalS8ToFloat();

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -123,6 +123,9 @@ static const JitLookup jitLookup[] = {
 	{&VertexDecoder::Step_TcU16PrescaleMorph, &VertexDecoderJitCache::Jit_TcU16PrescaleMorph},
 	{&VertexDecoder::Step_TcFloatPrescaleMorph, &VertexDecoderJitCache::Jit_TcFloatPrescaleMorph},
 
+	{&VertexDecoder::Step_NormalDefaultFloat, &VertexDecoderJitCache::Jit_NormalDefaultFloat},
+	{&VertexDecoder::Step_NormalDefaultS8, &VertexDecoderJitCache::Jit_NormalDefaultS8},
+
 	{&VertexDecoder::Step_NormalS8, &VertexDecoderJitCache::Jit_NormalS8},
 	{&VertexDecoder::Step_NormalS8ToFloat, &VertexDecoderJitCache::Jit_NormalS8ToFloat},
 	{&VertexDecoder::Step_NormalS16, &VertexDecoderJitCache::Jit_NormalS16},
@@ -1278,6 +1281,18 @@ void VertexDecoderJitCache::Jit_WriteMorphColor(int outOff, bool checkAlpha) {
 	}
 
 	MOV(32, MDisp(dstReg, outOff), R(tempReg1));
+}
+
+void VertexDecoderJitCache::Jit_NormalDefaultS8() {
+	// Directly write the immediate to where it goes.
+	MOV(32, MDisp(dstReg, dec_->decFmt.nrmoff), Imm32(0x007F0000));
+}
+
+void VertexDecoderJitCache::Jit_NormalDefaultFloat() {
+	// Directly write the immediate to where it goes.
+	MOV(32, MDisp(dstReg, dec_->decFmt.nrmoff), Imm32(0));
+	MOV(32, MDisp(dstReg, dec_->decFmt.nrmoff + 4), Imm32(0));
+	MOV(32, MDisp(dstReg, dec_->decFmt.nrmoff + 8), Imm32(0x3F800000));  // 1.0
 }
 
 // Copy 3 bytes and then a zero. Might as well copy four.

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -103,6 +103,8 @@ static const JitLookup jitLookup[] = {
 	{&VertexDecoder::Step_WeightsU8ToFloat, &VertexDecoderJitCache::Jit_WeightsU8ToFloat},
 	{&VertexDecoder::Step_WeightsU16ToFloat, &VertexDecoderJitCache::Jit_WeightsU16ToFloat},
 
+	{&VertexDecoder::Step_TcDefault, &VertexDecoderJitCache::Jit_TcDefault},
+
 	{&VertexDecoder::Step_TcFloat, &VertexDecoderJitCache::Jit_TcFloat},
 	{&VertexDecoder::Step_TcU8ToFloat, &VertexDecoderJitCache::Jit_TcU8ToFloat},
 	{&VertexDecoder::Step_TcU16ToFloat, &VertexDecoderJitCache::Jit_TcU16ToFloat},
@@ -719,6 +721,11 @@ void VertexDecoderJitCache::Jit_WeightsFloatSkin() {
 		}
 		ADD(PTRBITS, R(tempReg2), Imm8(4 * 16));
 	}
+}
+
+void VertexDecoderJitCache::Jit_TcDefault() {
+	PXOR(XMM3, R(XMM3));
+	MOVQ_xmm(MDisp(dstReg, dec_->decFmt.uvoff), XMM3);
 }
 
 void VertexDecoderJitCache::Jit_TcU8ToFloat() {

--- a/GPU/Vulkan/StateMappingVulkan.h
+++ b/GPU/Vulkan/StateMappingVulkan.h
@@ -53,7 +53,8 @@ struct VulkanPipelineRasterStateKey {
 	unsigned int stencilDepthFailOp : 4;  // VkStencilOp 
 
 	// We'll use dynamic state for writemask, reference and comparemask to start with,
-	// and viewport/scissor.
+	// and viewport/scissor. There are further extensions for dynamic state which we should
+	// use if available, but not widespread on mobile yet.
 
 	// Rasterizer
 	unsigned int cullMode : 2;  // VkCullModeFlagBits 

--- a/unittest/TestVertexJit.cpp
+++ b/unittest/TestVertexJit.cpp
@@ -32,8 +32,7 @@ class VertexDecoderTestHarness {
 	static const int ROUNDS = 200;
 
 public:
-	VertexDecoderTestHarness()
-		: dec_(nullptr), needsReset_(true), dstPos_(0), assertFailed_(false) {
+	VertexDecoderTestHarness() {
 		src_ = new u8[BUFFER_SIZE];
 		dst_ = new u8[BUFFER_SIZE];
 		cache_ = new VertexDecoderJitCache();
@@ -285,13 +284,13 @@ private:
 	u8 *dst_;
 	VertexDecoderJitCache *cache_;
 	VertexDecoderOptions options_;
-	VertexDecoder *dec_;
+	VertexDecoder *dec_ = nullptr;
 	int indexLowerBound_;
 	int indexUpperBound_;
-	bool needsReset_;
-	size_t srcPos_;
-	size_t dstPos_;
-	bool assertFailed_;
+	bool needsReset_ = true;
+	size_t srcPos_ = 0;
+	size_t dstPos_ = 0;
+	bool assertFailed_ = false;
 };
 
 static bool TestVertex8() {


### PR DESCRIPTION
Part of #16567 and compounds with the other changes.

This one removes 3 vertex shaders from Outrun, for example, resulting in a slightly larger decrease in the overall pipeline count.

A majority of the vertices in most games do have UVs so this doesn't add a lot of extra vertex decoding work.