### PR TITLE
Windows: Adjust window sleep interval in idle menus to refresh rate

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -223,6 +223,8 @@ void KeepScreenAwake() {
 }
 
 void Core_RunLoop(GraphicsContext *ctx) {
+	float refreshRate = System_GetPropertyFloat(SYSPROP_DISPLAY_REFRESH_RATE);
+
 	graphicsContext = ctx;
 	while ((GetUIState() != UISTATE_INGAME || !PSP_IsInited()) && GetUIState() != UISTATE_EXIT) {
 		// In case it was pending, we're not in game anymore.  We won't get to Core_Run().
@@ -232,7 +234,7 @@ void Core_RunLoop(GraphicsContext *ctx) {
 
 		// Simple throttling to not burn the GPU in the menu.
 		double diffTime = time_now_d() - startTime;
-		int sleepTime = (int)(1000.0 / 60.0) - (int)(diffTime * 1000.0);
+		int sleepTime = (int)(1000.0 / refreshRate) - (int)(diffTime * 1000.0);
 		if (sleepTime > 0)
 			sleep_ms(sleepTime);
 		if (!windowHidden) {

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -280,6 +280,19 @@ static int ScreenDPI() {
 #endif
 #endif
 
+static int ScreenRefreshRateHz() {
+	DEVMODE lpDevMode;
+	memset(&lpDevMode, 0, sizeof(DEVMODE));
+	lpDevMode.dmSize = sizeof(DEVMODE);
+	lpDevMode.dmDriverExtra = 0;
+
+	if (EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &lpDevMode) == 0) {
+		return 60;  // default value
+	} else {
+		return lpDevMode.dmDisplayFrequency > 15 ? lpDevMode.dmDisplayFrequency : 60;
+	}
+}
+
 int System_GetPropertyInt(SystemProperty prop) {
 	switch (prop) {
 	case SYSPROP_AUDIO_SAMPLE_RATE:
@@ -311,7 +324,7 @@ int System_GetPropertyInt(SystemProperty prop) {
 float System_GetPropertyFloat(SystemProperty prop) {
 	switch (prop) {
 	case SYSPROP_DISPLAY_REFRESH_RATE:
-		return 60.f;
+		return (float)ScreenRefreshRateHz();
 	case SYSPROP_DISPLAY_DPI:
 		return (float)ScreenDPI();
 	case SYSPROP_DISPLAY_SAFE_INSET_LEFT:

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -289,7 +289,11 @@ static int ScreenRefreshRateHz() {
 	if (EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &lpDevMode) == 0) {
 		return 60;  // default value
 	} else {
-		return lpDevMode.dmDisplayFrequency > 15 ? lpDevMode.dmDisplayFrequency : 60;
+		if (lpDevMode.dmFields & DM_DISPLAYFREQUENCY) {
+			return lpDevMode.dmDisplayFrequency > 15 ? lpDevMode.dmDisplayFrequency : 60;
+		} else {
+			return 60;
+		}
 	}
 }
 


### PR DESCRIPTION
For smoother scroll animations if you have a high refresh rate monitor.