### PR TITLE
UI: Prevent crash installing second game quickly

### DIFF
--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -278,7 +278,7 @@ ZipFileContents DetectZipFileContents(struct zip *z, ZipFileInfo *info) {
 
 // Parameters need to be by value, since this is a thread func.
 bool GameManager::InstallGame(Path url, Path fileName, bool deleteAfter) {
-	if (installInProgress_) {
+	if (installInProgress_ || installDonePending_) {
 		ERROR_LOG(HLE, "Cannot have two installs in progress at the same time");
 		return false;
 	}
@@ -708,7 +708,7 @@ bool GameManager::InstallZippedISO(struct zip *z, int isoFileIndex, const Path &
 }
 
 bool GameManager::InstallGameOnThread(const Path &url, const Path &fileName, bool deleteAfter) {
-	if (installInProgress_) {
+	if (installInProgress_ || installDonePending_) {
 		return false;
 	}
 	installThread_.reset(new std::thread(std::bind(&GameManager::InstallGame, this, url, fileName, deleteAfter)));

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -58,7 +58,7 @@ public:
 	void Update();
 
 	GameManagerState GetState() {
-		if (installInProgress_)
+		if (installInProgress_ || installDonePending_)
 			return GameManagerState::INSTALLING;
 		if (curDownload_)
 			return GameManagerState::DOWNLOADING;


### PR DESCRIPTION
See #16601.  We need to wait until done to reset the thread.

-[Unknown]