### PR TITLE
Debugger: Make sure we don't restore twice

### DIFF
--- a/Core/Debugger/WebSocket/MemorySubscriber.cpp
+++ b/Core/Debugger/WebSocket/MemorySubscriber.cpp
@@ -86,7 +86,9 @@ AutoDisabledReplacements::AutoDisabledReplacements(AutoDisabledReplacements &&ot
 	replacements = std::move(other.replacements);
 	emuhacks = std::move(emuhacks);
 	saved = other.saved;
+	other.saved = false;
 	wasStepping = other.wasStepping;
+	other.wasStepping = true;
 }
 
 AutoDisabledReplacements::~AutoDisabledReplacements() {


### PR DESCRIPTION
Aside from the lock, we also don't want to restore emuhacks/replacements or resume from stepping early.

Sorry, looked at the merge of #16729 and realized I should do this as well to be safe.  Should've included it there.

-[Unknown]