### PR TITLE
Vulkan: Don't use non-indexed draws for pure tristrips and fans (only PowerVR for now)

### DIFF
--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -861,6 +861,11 @@ VKContext::VKContext(VulkanContext *vulkan)
 		break;
 	}
 
+	if (caps_.vendor == GPUVendor::VENDOR_IMGTEC) {
+		// Enable some things that cut down pipeline counts but may have other costs.
+		caps_.verySlowShaderCompiler = true;
+	}
+
 	// Hide D3D9 when we know it likely won't work well.
 #if PPSSPP_PLATFORM(WINDOWS)
 	caps_.supportsD3D9 = true;

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -577,6 +577,8 @@ struct DeviceCaps {
 	bool isTilingGPU;  // This means that it benefits from correct store-ops, msaa without backing memory, etc.
 	bool sampleRateShadingSupported;
 
+	bool verySlowShaderCompiler;
+
 	// From the other backends, we can detect if D3D9 support is known bad (like on Xe) and disable it.
 	bool supportsD3D9;
 

--- a/GPU/Common/IndexGenerator.h
+++ b/GPU/Common/IndexGenerator.h
@@ -47,6 +47,15 @@ public:
 	}
 
 	GEPrimitiveType Prim() const { return prim_; }
+	GEPrimitiveType GeneralPrim() const {
+		switch (prim_) {
+		case GE_PRIM_LINE_STRIP: return GE_PRIM_LINES; break;
+		case GE_PRIM_TRIANGLE_STRIP:
+		case GE_PRIM_TRIANGLE_FAN: return GE_PRIM_TRIANGLES; break;
+		default:
+			return prim_;
+		}
+	}
 
 	void AddPrim(int prim, int vertexCount, bool clockwise);
 	void TranslatePrim(int prim, int numInds, const u8 *inds, int indexOffset, bool clockwise);

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -956,7 +956,7 @@ enum class CacheDetectFlags {
 };
 
 #define CACHE_HEADER_MAGIC 0x83277592
-#define CACHE_VERSION 25
+#define CACHE_VERSION 26
 
 struct CacheHeader {
 	uint32_t magic;

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -584,7 +584,7 @@ void DrawEngineVulkan::DoFlush() {
 	
 	// The optimization to avoid indexing isn't really worth it on Vulkan since it means creating more pipelines.
 	// This could be avoided with the new dynamic state extensions, but not available enough on mobile.
-	const bool forceIndexed = true;
+	const bool forceIndexed = draw_->GetDeviceCaps().verySlowShaderCompiler;
 
 	if (useHWTransform) {
 		int vertexCount = 0;

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -511,7 +511,7 @@ enum class VulkanCacheDetectFlags {
 };
 
 #define CACHE_HEADER_MAGIC 0xff51f420 
-#define CACHE_VERSION 39
+#define CACHE_VERSION 40
 
 struct VulkanCacheHeader {
 	uint32_t magic;


### PR DESCRIPTION
Part of #16567

NOTE: For now, I decided to only enable this for PowerVR which has the slowest pipeline/shader compilation that I know of. Might experiment with other GPUs later.

If we detect at a flush that all we have to draw is a pure triangle strip or a fan, we currently try to draw it as such, instead of the default, an indexed triangle list.

In Vulkan, without VK_EXT_extended_dynamic_state, additional topologies creates extra pipelines, since the topology (tris, strip, fan, line, etc) is part of the pipeline state. Some drivers are very bad at coalescing work between near-identical pipelines, unfortunately, so reducing the pipelines improves shader creation stutter.

This opimization generally affected very small draws anyway - larger draws usually became indexed draws anyway due to merging multiple strips, etc.
