### PR TITLE
Use NEON intrinsics in software renderer

### DIFF
--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -1161,6 +1161,10 @@ inline Vec3<float> Vec3<float>::FromRGB(unsigned int rgb)
 	__m128i c = _mm_cvtsi32_si128(rgb);
 	c = _mm_unpacklo_epi16(_mm_unpacklo_epi8(c, z), z);
 	return Vec3<float>(_mm_mul_ps(_mm_cvtepi32_ps(c), _mm_set_ps1(1.0f / 255.0f)));
+#elif PPSSPP_ARCH(ARM64_NEON)
+	uint8x8_t c = vreinterpret_u8_u32(vdup_n_u32(rgb));
+	uint32x4_t u = vmovl_u16(vget_low_u16(vmovl_u8(c)));
+	return Vec3<float>(vmulq_f32(vcvtq_f32_u32(u), vdupq_n_f32(1.0f / 255.0f)));
 #else
 	return Vec3((rgb & 0xFF) * (1.0f/255.0f),
 				((rgb >> 8) & 0xFF) * (1.0f/255.0f),
@@ -1176,6 +1180,10 @@ inline Vec3<int> Vec3<int>::FromRGB(unsigned int rgb)
 	__m128i c = _mm_cvtsi32_si128(rgb);
 	c = _mm_unpacklo_epi16(_mm_unpacklo_epi8(c, z), z);
 	return Vec3<int>(c);
+#elif PPSSPP_ARCH(ARM64_NEON)
+	uint8x8_t c = vreinterpret_u8_u32(vdup_n_u32(rgb));
+	uint32x4_t u = vmovl_u16(vget_low_u16(vmovl_u8(c)));
+	return Vec3<int>(vreinterpretq_s32_u32(u));
 #else
 	return Vec3(rgb & 0xFF, (rgb >> 8) & 0xFF, (rgb >> 16) & 0xFF);
 #endif
@@ -1192,6 +1200,10 @@ __forceinline unsigned int Vec3<float>::ToRGB() const
 #endif
 	__m128i c16 = _mm_packs_epi32(c, c);
 	return _mm_cvtsi128_si32(_mm_packus_epi16(c16, c16)) & 0x00FFFFFF;
+#elif PPSSPP_ARCH(ARM64_NEON)
+	uint16x4_t c16 = vqmovun_s32(vcvtq_s32_f32(vmulq_f32(vsetq_lane_f32(0.0f, vec, 3), vdupq_n_f32(255.0f))));
+	uint8x8_t c8 = vqmovn_u16(vcombine_u16(c16, c16));
+	return vget_lane_u32(vreinterpret_u32_u8(c8), 0);
 #else
 	return (clamp_u8((int)(r() * 255.f)) << 0) |
 			(clamp_u8((int)(g() * 255.f)) << 8) |
@@ -1209,6 +1221,10 @@ __forceinline unsigned int Vec3<int>::ToRGB() const
 	__m128i c16 = _mm_packs_epi32(_mm_loadu_si128(&ivec), _mm_setzero_si128());
 #endif
 	return _mm_cvtsi128_si32(_mm_packus_epi16(c16, c16)) & 0x00FFFFFF;
+#elif PPSSPP_ARCH(ARM64_NEON)
+	uint16x4_t c16 = vqmovun_s32(vsetq_lane_s32(0, ivec, 3));
+	uint8x8_t c8 = vqmovn_u16(vcombine_u16(c16, c16));
+	return vget_lane_u32(vreinterpret_u32_u8(c8), 0);
 #else
 	return clamp_u8(r()) | (clamp_u8(g()) << 8) | (clamp_u8(b()) << 16);
 #endif
@@ -1222,6 +1238,10 @@ inline Vec4<float> Vec4<float>::FromRGBA(unsigned int rgba)
 	__m128i c = _mm_cvtsi32_si128(rgba);
 	c = _mm_unpacklo_epi16(_mm_unpacklo_epi8(c, z), z);
 	return Vec4<float>(_mm_mul_ps(_mm_cvtepi32_ps(c), _mm_set_ps1(1.0f / 255.0f)));
+#elif PPSSPP_ARCH(ARM64_NEON)
+	uint8x8_t c = vreinterpret_u8_u32(vdup_n_u32(rgba));
+	uint32x4_t u = vmovl_u16(vget_low_u16(vmovl_u8(c)));
+	return Vec4<float>(vmulq_f32(vcvtq_f32_u32(u), vdupq_n_f32(1.0f / 255.0f)));
 #else
 	return Vec4((rgba & 0xFF) * (1.0f/255.0f),
 				((rgba >> 8) & 0xFF) * (1.0f/255.0f),
@@ -1244,6 +1264,10 @@ inline Vec4<int> Vec4<int>::FromRGBA(unsigned int rgba)
 	__m128i c = _mm_cvtsi32_si128(rgba);
 	c = _mm_unpacklo_epi16(_mm_unpacklo_epi8(c, z), z);
 	return Vec4<int>(c);
+#elif PPSSPP_ARCH(ARM64_NEON)
+	uint8x8_t c = vreinterpret_u8_u32(vdup_n_u32(rgba));
+	uint32x4_t u = vmovl_u16(vget_low_u16(vmovl_u8(c)));
+	return Vec4<int>(vreinterpretq_s32_u32(u));
 #else
 	return Vec4(rgba & 0xFF, (rgba >> 8) & 0xFF, (rgba >> 16) & 0xFF, (rgba >> 24) & 0xFF);
 #endif
@@ -1260,6 +1284,10 @@ __forceinline unsigned int Vec4<float>::ToRGBA() const
 #endif
 	__m128i c16 = _mm_packs_epi32(c, c);
 	return _mm_cvtsi128_si32(_mm_packus_epi16(c16, c16));
+#elif PPSSPP_ARCH(ARM64_NEON)
+	uint16x4_t c16 = vqmovun_s32(vcvtq_s32_f32(vmulq_f32(vec, vdupq_n_f32(255.0f))));
+	uint8x8_t c8 = vqmovn_u16(vcombine_u16(c16, c16));
+	return vget_lane_u32(vreinterpret_u32_u8(c8), 0);
 #else
 	return (clamp_u8((int)(r() * 255.f)) << 0) |
 			(clamp_u8((int)(g() * 255.f)) << 8) |
@@ -1278,6 +1306,10 @@ __forceinline unsigned int Vec4<int>::ToRGBA() const
 	__m128i c16 = _mm_packs_epi32(_mm_loadu_si128(&ivec), _mm_setzero_si128());
 #endif
 	return _mm_cvtsi128_si32(_mm_packus_epi16(c16, c16));
+#elif PPSSPP_ARCH(ARM64_NEON)
+	uint16x4_t c16 = vqmovun_s32(ivec);
+	uint8x8_t c8 = vqmovn_u16(vcombine_u16(c16, c16));
+	return vget_lane_u32(vreinterpret_u32_u8(c8), 0);
 #else
 	return clamp_u8(r()) | (clamp_u8(g()) << 8) | (clamp_u8(b()) << 16) | (clamp_u8(a()) << 24);
 #endif

--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include <mutex>
 #include "Common/Common.h"
 #include "Common/Data/Convert/ColorConv.h"
@@ -416,6 +417,8 @@ static inline Vec3<int> GetSourceFactor(PixelBlendFactor factor, const Vec4<int>
 	case PixelBlendFactor::SRCALPHA:
 #if defined(_M_SSE)
 		return Vec3<int>(_mm_shuffle_epi32(source.ivec, _MM_SHUFFLE(3, 3, 3, 3)));
+#elif PPSSPP_ARCH(ARM64_NEON)
+		return Vec3<int>(vdupq_laneq_s32(source.ivec, 3));
 #else
 		return Vec3<int>::AssignToAll(source.a());
 #endif
@@ -423,6 +426,8 @@ static inline Vec3<int> GetSourceFactor(PixelBlendFactor factor, const Vec4<int>
 	case PixelBlendFactor::INVSRCALPHA:
 #if defined(_M_SSE)
 		return Vec3<int>(_mm_sub_epi32(_mm_set1_epi32(255), _mm_shuffle_epi32(source.ivec, _MM_SHUFFLE(3, 3, 3, 3))));
+#elif PPSSPP_ARCH(ARM64_NEON)
+		return Vec3<int>(vsubq_s32(vdupq_n_s32(255), vdupq_laneq_s32(source.ivec, 3)));
 #else
 		return Vec3<int>::AssignToAll(255 - source.a());
 #endif
@@ -469,6 +474,8 @@ static inline Vec3<int> GetDestFactor(PixelBlendFactor factor, const Vec4<int> &
 	case PixelBlendFactor::SRCALPHA:
 #if defined(_M_SSE)
 		return Vec3<int>(_mm_shuffle_epi32(source.ivec, _MM_SHUFFLE(3, 3, 3, 3)));
+#elif PPSSPP_ARCH(ARM64_NEON)
+		return Vec3<int>(vdupq_laneq_s32(source.ivec, 3));
 #else
 		return Vec3<int>::AssignToAll(source.a());
 #endif
@@ -476,6 +483,8 @@ static inline Vec3<int> GetDestFactor(PixelBlendFactor factor, const Vec4<int> &
 	case PixelBlendFactor::INVSRCALPHA:
 #if defined(_M_SSE)
 		return Vec3<int>(_mm_sub_epi32(_mm_set1_epi32(255), _mm_shuffle_epi32(source.ivec, _MM_SHUFFLE(3, 3, 3, 3))));
+#elif PPSSPP_ARCH(ARM64_NEON)
+		return Vec3<int>(vsubq_s32(vdupq_n_s32(255), vdupq_laneq_s32(source.ivec, 3)));
 #else
 		return Vec3<int>::AssignToAll(255 - source.a());
 #endif
@@ -533,6 +542,18 @@ static Vec3<int> AlphaBlendingResult(const PixelFuncID &pixelID, const Vec4<int>
 		const __m128i d = _mm_mulhi_epi16(drgb, df);
 
 		return Vec3<int>(_mm_unpacklo_epi16(_mm_adds_epi16(s, d), _mm_setzero_si128()));
+#elif PPSSPP_ARCH(ARM64_NEON)
+		const int32x4_t half = vdupq_n_s32(1);
+
+		const int32x4_t srgb = vaddq_s32(vshlq_n_s32(source.ivec, 1), half);
+		const int32x4_t sf = vaddq_s32(vshlq_n_s32(srcfactor.ivec, 1), half);
+		const int32x4_t s = vshrq_n_s32(vmulq_s32(srgb, sf), 10);
+
+		const int32x4_t drgb = vaddq_s32(vshlq_n_s32(dst.ivec, 1), half);
+		const int32x4_t df = vaddq_s32(vshlq_n_s32(dstfactor.ivec, 1), half);
+		const int32x4_t d = vshrq_n_s32(vmulq_s32(drgb, df), 10);
+
+		return Vec3<int>(vaddq_s32(s, d));
 #else
 		static constexpr Vec3<int> half = Vec3<int>::AssignToAll(1);
 		Vec3<int> lhs = ((source.rgb() * 2 + half) * (srcfactor * 2 + half)) / 1024;
@@ -555,6 +576,18 @@ static Vec3<int> AlphaBlendingResult(const PixelFuncID &pixelID, const Vec4<int>
 		const __m128i d = _mm_mulhi_epi16(drgb, df);
 
 		return Vec3<int>(_mm_unpacklo_epi16(_mm_max_epi16(_mm_subs_epi16(s, d), _mm_setzero_si128()), _mm_setzero_si128()));
+#elif PPSSPP_ARCH(ARM64_NEON)
+		const int32x4_t half = vdupq_n_s32(1);
+
+		const int32x4_t srgb = vaddq_s32(vshlq_n_s32(source.ivec, 1), half);
+		const int32x4_t sf = vaddq_s32(vshlq_n_s32(srcfactor.ivec, 1), half);
+		const int32x4_t s = vshrq_n_s32(vmulq_s32(srgb, sf), 10);
+
+		const int32x4_t drgb = vaddq_s32(vshlq_n_s32(dst.ivec, 1), half);
+		const int32x4_t df = vaddq_s32(vshlq_n_s32(dstfactor.ivec, 1), half);
+		const int32x4_t d = vshrq_n_s32(vmulq_s32(drgb, df), 10);
+
+		return Vec3<int>(vqsubq_s32(s, d));
 #else
 		static constexpr Vec3<int> half = Vec3<int>::AssignToAll(1);
 		Vec3<int> lhs = ((source.rgb() * 2 + half) * (srcfactor * 2 + half)) / 1024;
@@ -577,6 +610,18 @@ static Vec3<int> AlphaBlendingResult(const PixelFuncID &pixelID, const Vec4<int>
 		const __m128i d = _mm_mulhi_epi16(drgb, df);
 
 		return Vec3<int>(_mm_unpacklo_epi16(_mm_max_epi16(_mm_subs_epi16(d, s), _mm_setzero_si128()), _mm_setzero_si128()));
+#elif PPSSPP_ARCH(ARM64_NEON)
+		const int32x4_t half = vdupq_n_s32(1);
+
+		const int32x4_t srgb = vaddq_s32(vshlq_n_s32(source.ivec, 1), half);
+		const int32x4_t sf = vaddq_s32(vshlq_n_s32(srcfactor.ivec, 1), half);
+		const int32x4_t s = vshrq_n_s32(vmulq_s32(srgb, sf), 10);
+
+		const int32x4_t drgb = vaddq_s32(vshlq_n_s32(dst.ivec, 1), half);
+		const int32x4_t df = vaddq_s32(vshlq_n_s32(dstfactor.ivec, 1), half);
+		const int32x4_t d = vshrq_n_s32(vmulq_s32(drgb, df), 10);
+
+		return Vec3<int>(vqsubq_s32(d, s));
 #else
 		static constexpr Vec3<int> half = Vec3<int>::AssignToAll(1);
 		Vec3<int> lhs = ((source.rgb() * 2 + half) * (srcfactor * 2 + half)) / 1024;
@@ -586,19 +631,31 @@ static Vec3<int> AlphaBlendingResult(const PixelFuncID &pixelID, const Vec4<int>
 	}
 
 	case GE_BLENDMODE_MIN:
+#if PPSSPP_ARCH(ARM64_NEON)
+		return Vec3<int>(vminq_s32(source.ivec, dst.ivec));
+#else
 		return Vec3<int>(std::min(source.r(), dst.r()),
 			std::min(source.g(), dst.g()),
 			std::min(source.b(), dst.b()));
+#endif
 
 	case GE_BLENDMODE_MAX:
+#if PPSSPP_ARCH(ARM64_NEON)
+		return Vec3<int>(vmaxq_s32(source.ivec, dst.ivec));
+#else
 		return Vec3<int>(std::max(source.r(), dst.r()),
 			std::max(source.g(), dst.g()),
 			std::max(source.b(), dst.b()));
+#endif
 
 	case GE_BLENDMODE_ABSDIFF:
+#if PPSSPP_ARCH(ARM64_NEON)
+		return Vec3<int>(vabdq_s32(source.ivec, dst.ivec));
+#else
 		return Vec3<int>(::abs(source.r() - dst.r()),
 			::abs(source.g() - dst.g()),
 			::abs(source.b() - dst.b()));
+#endif
 
 	default:
 		return source.rgb();
@@ -684,7 +741,7 @@ void SOFTRAST_CALL DrawSinglePixel(int x, int y, int z, int fog, Vec4IntArg colo
 			prim_color += Vec4<int>::AssignToAll(pixelID.cached.ditherMatrix[(y & 3) * 4 + (x & 3)]);
 		}
 
-#if defined(_M_SSE)
+#if defined(_M_SSE) || PPSSPP_ARCH(ARM64_NEON)
 		new_color = Vec3<int>(prim_color.ivec).ToRGB();
 		new_color |= stencil << 24;
 #else

--- a/GPU/Software/Lighting.cpp
+++ b/GPU/Software/Lighting.cpp
@@ -29,6 +29,10 @@ static inline Vec3f GetLightVec(const u32 lparams[12], int light) {
 	__m128i values = _mm_loadu_si128((__m128i *)&lparams[3 * light]);
 	__m128i from24 = _mm_slli_epi32(values, 8);
 	return _mm_castsi128_ps(from24);
+#elif PPSSPP_ARCH(ARM64_NEON)
+	uint32x4_t values = vld1q_u32((uint32_t *)&lparams[3 * light]);
+	uint32x4_t from24 = vshlq_n_u32(values, 8);
+	return vreinterpretq_f32_u32(from24);
 #else
 	return Vec3<float>(getFloat24(lparams[3 * light]), getFloat24(lparams[3 * light + 1]), getFloat24(lparams[3 * light + 2]));
 #endif
@@ -48,6 +52,8 @@ static inline float pspLightPow(float v, float e) {
 static inline Vec4<int> LightColorFactor(const Vec4<int> &expanded, const Vec4<int> &ones) {
 #if defined(_M_SSE) && !PPSSPP_ARCH(X86)
 	return _mm_add_epi32(_mm_slli_epi32(expanded.ivec, 1), ones.ivec);
+#elif PPSSPP_ARCH(ARM64_NEON)
+	return vaddq_s32(vshlq_n_s32(expanded.ivec, 1), ones.ivec);
 #else
 	return expanded * 2 + ones;
 #endif
@@ -62,6 +68,10 @@ static inline bool IsLargerThanHalf(const Vec4<int> &v) {
 	__m128i add23 = _mm_add_epi32(v.ivec, _mm_shuffle_epi32(v.ivec, _MM_SHUFFLE(3, 2, 3, 2)));
 	__m128i add1 = _mm_add_epi32(add23, _mm_shuffle_epi32(add23, _MM_SHUFFLE(1, 1, 1, 1)));
 	return _mm_cvtsi128_si32(add1) > 4;
+#elif PPSSPP_ARCH(ARM64_NEON)
+	int32x2_t add02 = vpmax_s32(vget_low_s32(v.ivec), vget_high_s32(v.ivec));
+	int32x2_t add1 = vpmax_s32(add02, add02);
+	return vget_lane_s32(add1, 0) > 4;
 #else
 	bool larger = false;
 	for (int i = 0; i < 3; ++i)

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -46,15 +46,26 @@ namespace Rasterizer {
 
 // Only OK on x64 where our stack is aligned
 #if defined(_M_SSE) && !PPSSPP_ARCH(X86)
-static inline __m128 Interpolate(const __m128 &c0, const __m128 &c1, const __m128 &c2, int w0, int w1, int w2, float wsum) {
+static inline __m128 InterpolateF(const __m128 &c0, const __m128 &c1, const __m128 &c2, int w0, int w1, int w2, float wsum) {
 	__m128 v = _mm_mul_ps(c0, _mm_cvtepi32_ps(_mm_set1_epi32(w0)));
 	v = _mm_add_ps(v, _mm_mul_ps(c1, _mm_cvtepi32_ps(_mm_set1_epi32(w1))));
 	v = _mm_add_ps(v, _mm_mul_ps(c2, _mm_cvtepi32_ps(_mm_set1_epi32(w2))));
 	return _mm_mul_ps(v, _mm_set_ps1(wsum));
 }
 
-static inline __m128i Interpolate(const __m128i &c0, const __m128i &c1, const __m128i &c2, int w0, int w1, int w2, float wsum) {
-	return _mm_cvtps_epi32(Interpolate(_mm_cvtepi32_ps(c0), _mm_cvtepi32_ps(c1), _mm_cvtepi32_ps(c2), w0, w1, w2, wsum));
+static inline __m128i InterpolateI(const __m128i &c0, const __m128i &c1, const __m128i &c2, int w0, int w1, int w2, float wsum) {
+	return _mm_cvtps_epi32(InterpolateF(_mm_cvtepi32_ps(c0), _mm_cvtepi32_ps(c1), _mm_cvtepi32_ps(c2), w0, w1, w2, wsum));
+}
+#elif PPSSPP_ARCH(ARM64_NEON)
+static inline float32x4_t InterpolateF(const float32x4_t &c0, const float32x4_t &c1, const float32x4_t &c2, int w0, int w1, int w2, float wsum) {
+	float32x4_t v = vmulq_f32(c0, vcvtq_f32_s32(vdupq_n_s32(w0)));
+	v = vaddq_f32(v, vmulq_f32(c1, vcvtq_f32_s32(vdupq_n_s32(w1))));
+	v = vaddq_f32(v, vmulq_f32(c2, vcvtq_f32_s32(vdupq_n_s32(w2))));
+	return vmulq_f32(v, vdupq_n_f32(wsum));
+}
+
+static inline int32x4_t InterpolateI(const int32x4_t &c0, const int32x4_t &c1, const int32x4_t &c2, int w0, int w1, int w2, float wsum) {
+	return vcvtq_s32_f32(InterpolateF(vcvtq_f32_s32(c0), vcvtq_f32_s32(c1), vcvtq_f32_s32(c2), w0, w1, w2, wsum));
 }
 #endif
 
@@ -62,16 +73,16 @@ static inline __m128i Interpolate(const __m128i &c0, const __m128i &c1, const __
 // Not sure if that should be regarded as a bug or if casting to float is a valid fix.
 
 static inline Vec4<int> Interpolate(const Vec4<int> &c0, const Vec4<int> &c1, const Vec4<int> &c2, int w0, int w1, int w2, float wsum) {
-#if defined(_M_SSE) && !PPSSPP_ARCH(X86)
-	return Vec4<int>(Interpolate(c0.ivec, c1.ivec, c2.ivec, w0, w1, w2, wsum));
+#if (defined(_M_SSE) || PPSSPP_ARCH(ARM64_NEON)) && !PPSSPP_ARCH(X86)
+	return Vec4<int>(InterpolateI(c0.ivec, c1.ivec, c2.ivec, w0, w1, w2, wsum));
 #else
 	return ((c0.Cast<float>() * w0 + c1.Cast<float>() * w1 + c2.Cast<float>() * w2) * wsum).Cast<int>();
 #endif
 }
 
 static inline Vec3<int> Interpolate(const Vec3<int> &c0, const Vec3<int> &c1, const Vec3<int> &c2, int w0, int w1, int w2, float wsum) {
-#if defined(_M_SSE) && !PPSSPP_ARCH(X86)
-	return Vec3<int>(Interpolate(c0.ivec, c1.ivec, c2.ivec, w0, w1, w2, wsum));
+#if (defined(_M_SSE) || PPSSPP_ARCH(ARM64_NEON)) && !PPSSPP_ARCH(X86)
+	return Vec3<int>(InterpolateI(c0.ivec, c1.ivec, c2.ivec, w0, w1, w2, wsum));
 #else
 	return ((c0.Cast<float>() * w0 + c1.Cast<float>() * w1 + c2.Cast<float>() * w2) * wsum).Cast<int>();
 #endif
@@ -83,6 +94,11 @@ static inline Vec4<float> Interpolate(const float &c0, const float &c1, const fl
 	v = _mm_add_ps(v, _mm_mul_ps(w1.vec, _mm_set1_ps(c1)));
 	v = _mm_add_ps(v, _mm_mul_ps(w2.vec, _mm_set1_ps(c2)));
 	return _mm_mul_ps(v, wsum_recip.vec);
+#elif PPSSPP_ARCH(ARM64_NEON)
+	float32x4_t v = vmulq_f32(w0.vec, vdupq_n_f32(c0));
+	v = vaddq_f32(v, vmulq_f32(w1.vec, vdupq_n_f32(c1)));
+	v = vaddq_f32(v, vmulq_f32(w2.vec, vdupq_n_f32(c2)));
+	return vmulq_f32(v, wsum_recip.vec);
 #else
 	return (w0 * c0 + w1 * c1 + w2 * c2) * wsum_recip;
 #endif
@@ -722,6 +738,8 @@ template <bool useSSE4>
 inline Vec4<int> TriangleEdge<useSSE4>::StepX(const Vec4<int> &w) {
 #if defined(_M_SSE) && !PPSSPP_ARCH(X86)
 	return _mm_add_epi32(w.ivec, stepX.ivec);
+#elif PPSSPP_ARCH(ARM64_NEON)
+	return vaddq_s32(w.ivec, stepX.ivec);
 #else
 	return w + stepX;
 #endif
@@ -731,6 +749,8 @@ template <bool useSSE4>
 inline Vec4<int> TriangleEdge<useSSE4>::StepY(const Vec4<int> &w) {
 #if defined(_M_SSE) && !PPSSPP_ARCH(X86)
 	return _mm_add_epi32(w.ivec, stepY.ivec);
+#elif PPSSPP_ARCH(ARM64_NEON)
+	return vaddq_s32(w.ivec, stepY.ivec);
 #else
 	return w + stepY;
 #endif
@@ -756,6 +776,9 @@ void TriangleEdge<useSSE4>::NarrowMinMaxX(const Vec4<int> &w, int64_t minX, int6
 	} else {
 		wmax = std::max(std::max(w.x, w.y), std::max(w.z, w.w));
 	}
+#elif PPSSPP_ARCH(ARM64_NEON)
+	int32x2_t wmax_temp = vpmax_s32(vget_low_s32(w.vec), vget_high_s32(w.vec));
+	wmax = vget_lane_s32(vpmax_s32(wmax_temp, wmax_temp), 0);
 #else
 	wmax = std::max(std::max(w.x, w.y), std::max(w.z, w.w));
 #endif
@@ -788,6 +811,8 @@ inline Vec4<int> TriangleEdge<useSSE4>::StepXTimes(const Vec4<int> &w, int c) {
 #if defined(_M_SSE) && !PPSSPP_ARCH(X86)
 	if (useSSE4)
 		return StepTimesSSE4(w.ivec, stepX.ivec, c);
+#elif PPSSPP_ARCH(ARM64_NEON)
+	return vaddq_s32(w.ivec, vmulq_s32(vdupq_n_s32(c), stepX.ivec));
 #endif
 	return w + stepX * c;
 }
@@ -799,6 +824,12 @@ static inline Vec4<int> MakeMask(const Vec4<int> &w0, const Vec4<int> &w1, const
 	__m128i biased2 = _mm_add_epi32(w2.ivec, bias2.ivec);
 
 	return _mm_or_si128(_mm_or_si128(biased0, _mm_or_si128(biased1, biased2)), scissor.ivec);
+#elif PPSSPP_ARCH(ARM64_NEON)
+	int32x4_t biased0 = vaddq_s32(w0.ivec, bias0.ivec);
+	int32x4_t biased1 = vaddq_s32(w1.ivec, bias1.ivec);
+	int32x4_t biased2 = vaddq_s32(w2.ivec, bias2.ivec);
+
+	return vorrq_s32(vorrq_s32(biased0, vorrq_s32(biased1, biased2)), scissor.ivec);
 #else
 	return (w0 + bias0) | (w1 + bias1) | (w2 + bias2) | scissor;
 #endif
@@ -826,6 +857,9 @@ static inline bool AnyMask(const Vec4<int> &mask) {
 	__m128i low1 = _mm_and_si128(low2, _mm_shuffle_epi32(low2, _MM_SHUFFLE(1, 1, 1, 1)));
 	// Now we only need to check one sign bit.
 	return _mm_cvtsi128_si32(low1) >= 0;
+#elif PPSSPP_ARCH(ARM64_NEON)
+	int64x2_t sig = vreinterpretq_s64_s32(vshrq_n_s32(mask.ivec, 31));
+	return vgetq_lane_s64(sig, 0) != -1 || vgetq_lane_s64(sig, 1) != -1;
 #else
 	return mask.x >= 0 || mask.y >= 0 || mask.z >= 0 || mask.w >= 0;
 #endif
@@ -836,6 +870,9 @@ static inline Vec4<float> EdgeRecip(const Vec4<int> &w0, const Vec4<int> &w1, co
 	__m128i wsum = _mm_add_epi32(w0.ivec, _mm_add_epi32(w1.ivec, w2.ivec));
 	// _mm_rcp_ps loses too much precision.
 	return _mm_div_ps(_mm_set1_ps(1.0f), _mm_cvtepi32_ps(wsum));
+#elif PPSSPP_ARCH(ARM64_NEON)
+	int32x4_t wsum = vaddq_s32(w0.ivec, vaddq_s32(w1.ivec, w2.ivec));
+	return vdivq_f32(vdupq_n_f32(1.0f), vcvtq_f32_s32(wsum));
 #else
 	return (w0 + w1 + w2).Cast<float>().Reciprocal();
 #endif
@@ -1010,6 +1047,9 @@ void DrawTriangleSlice(
 						// TODO: Tried making Vec4 do this, but things got slower.
 						const __m128i sec = _mm_and_si128(sec_color[i].ivec, _mm_set_epi32(0, -1, -1, -1));
 						prim_color[i].ivec = _mm_add_epi32(prim_color[i].ivec, sec);
+#elif PPSSPP_ARCH(ARM64_NEON)
+						int32x4_t sec = vsetq_lane_s32(0, sec_color[i].ivec, 3);
+						prim_color[i].ivec = vaddq_s32(prim_color[i].ivec, sec);
 #else
 						prim_color[i] += Vec4<int>(sec_color[i], 0);
 #endif
@@ -1216,6 +1256,9 @@ void DrawRectangle(const VertexData &v0, const VertexData &v1, const BinCoords &
 					// TODO: Tried making Vec4 do this, but things got slower.
 					const __m128i sec = _mm_and_si128(sec_color.ivec, _mm_set_epi32(0, -1, -1, -1));
 					prim_color[i].ivec = _mm_add_epi32(prim_color[i].ivec, sec);
+#elif PPSSPP_ARCH(ARM64_NEON)
+					int32x4_t sec = vsetq_lane_s32(0, sec_color.ivec, 3);
+					prim_color[i].ivec = vaddq_s32(prim_color[i].ivec, sec);
 #else
 					prim_color[i] += Vec4<int>(sec_color, 0);
 #endif

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -211,6 +211,14 @@ static inline Vec4IntResult SOFTRAST_CALL ModulateRGBA(Vec4IntArg prim_in, Vec4I
 	}
 	const __m128i b = _mm_mulhi_epi16(pboost, t);
 	out.ivec = _mm_unpacklo_epi16(b, _mm_setzero_si128());
+#elif PPSSPP_ARCH(ARM64_NEON)
+	int32x4_t pboost = vaddq_s32(prim_color.ivec, vdupq_n_s32(1));
+	int32x4_t t = texcolor.ivec;
+	if (samplerID.useColorDoubling) {
+		static const int32_t rgbDouble[4] = {1, 1, 1, 0};
+		t = vshlq_s32(t, vld1q_s32(rgbDouble));
+	}
+	out.ivec = vshrq_n_s32(vmulq_s32(pboost, t), 8);
 #else
 	if (samplerID.useColorDoubling) {
 		Vec4<int> tex = texcolor * Vec4<int>(2, 2, 2, 1);

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -1,5 +1,6 @@
 // See comment in header for the purpose of the code in this file.
 
+#include "ppsspp_config.h"
 #include <algorithm>
 #include <cmath>
 
@@ -23,6 +24,14 @@
 
 #if defined(_M_SSE)
 #include <emmintrin.h>
+#endif
+
+#if PPSSPP_ARCH(ARM_NEON)
+#if defined(_MSC_VER) && PPSSPP_ARCH(ARM64)
+#include <arm64_neon.h>
+#else
+#include <arm_neon.h>
+#endif
 #endif
 
 extern DSStretch g_DarkStalkerStretch;
@@ -57,6 +66,23 @@ static uint32_t StandardAlphaBlend(uint32_t source, uint32_t dst) {
 
 	const __m128i blended16 = _mm_adds_epi16(s, d);
 	return _mm_cvtsi128_si32(_mm_packus_epi16(blended16, blended16));
+#elif PPSSPP_ARCH(ARM64_NEON)
+	uint16x4_t sf = vdup_n_u16((source >> 24) * 2 + 1);
+	uint16x4_t df = vdup_n_u16((255 - (source >> 24)) * 2 + 1);
+
+	// Convert both to 16-bit, double, and add the half before even going to 32 bit.
+	uint16x8_t sd_c16 = vmovl_u8(vcreate_u8((uint64_t)source | ((uint64_t)dst << 32)));
+	sd_c16 = vaddq_u16(vshlq_n_u16(sd_c16, 1), vdupq_n_u16(1));
+
+	uint16x4_t srgb = vget_low_u16(sd_c16);
+	uint16x4_t drgb = vget_high_u16(sd_c16);
+
+	uint16x4_t s = vshrn_n_u32(vmull_u16(srgb, sf), 10);
+	uint16x4_t d = vshrn_n_u32(vmull_u16(drgb, df), 10);
+
+	uint16x4_t blended = vset_lane_s16(0, vadd_u16(s, d), 3);
+	uint8x8_t blended8 = vqmovn_u16(vcombine_u16(blended, blended));
+	return vget_lane_u32(vreinterpret_u32_u8(blended8), 0);
 #else
 	Vec3<int> srcfactor = Vec3<int>::AssignToAll(source >> 24);
 	Vec3<int> dstfactor = Vec3<int>::AssignToAll(255 - (source >> 24));


### PR DESCRIPTION
While clang/gcc seem to do a better job than MSVC on vectorizing, there were still a lot of cases (especially Vec3s) where it wasn't.

This basically changes all the places we used SSE for software rendering to use NEON.  Although I checked several places, I didn't carefully verify each case especially around Vec3s.  I also didn't validate carefully that other code around these were prodded to use vectors more, as happens with SSE in MSVC.

In my testing, I was only seeing at most 10% improvement from this in FPS, although power management made it a bit hard to tell.

-[Unknown]