### PR TITLE
Added StartupWMClass

### DIFF
--- a/Qt/PPSSPP.desktop
+++ b/Qt/PPSSPP.desktop
@@ -9,3 +9,4 @@ Icon=/usr/share/icons/hicolor/114x114/apps/icon-114.png
 X-Window-Icon=
 X-HildonDesk-ShowInToolbar=true
 X-Osso-Type=application/x-executable
+StartupWMClass=PPSSPPQt


### PR DESCRIPTION
This is a minor one but what it basically does is that in a setup like KDE, instead of adding a second icon to the taskbar, it groups it with the PPSSPP icon, which looks better.

Adding images to show what it would look like.

# Without the StartupWMClass
![without](https://user-images.githubusercontent.com/74340622/211210010-2eccad08-1e2f-4724-bcf8-9ac64da2207f.png)

# With the StartupWMClass
![with](https://user-images.githubusercontent.com/74340622/211209917-a6361d6f-096d-451b-81ee-6b4ea01628e0.png)
