### PR TITLE
GLES: Apply vertex limit only to GLES2

### DIFF
--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -383,13 +383,13 @@ void DrawEngineGLES::DoFlush() {
 		int vertexCount = indexGen.VertexCount();
 
 		// TODO: Split up into multiple draw calls for GLES 2.0 where you can't guarantee support for more than 0x10000 verts.
-#if defined(MOBILE_DEVICE)
-		constexpr int vertexCountLimit = 0x10000 / 3;
-		if (vertexCount > vertexCountLimit) {
-			WARN_LOG_REPORT_ONCE(manyVerts, G3D, "Truncating vertex count from %d to %d", vertexCount, vertexCountLimit);
-			vertexCount = vertexCountLimit;
+		if (gl_extensions.IsGLES && !gl_extensions.GLES3) {
+			constexpr int vertexCountLimit = 0x10000 / 3;
+			if (vertexCount > vertexCountLimit) {
+				WARN_LOG_REPORT_ONCE(manyVerts, G3D, "Truncating vertex count from %d to %d", vertexCount, vertexCountLimit);
+				vertexCount = vertexCountLimit;
+			}
 		}
-#endif
 
 		SoftwareTransform swTransform(params);
 


### PR DESCRIPTION
This limit [has been around a long time](https://github.com/hrydgard/ppsspp/blame/ddf5b695ac870a0f906649c1385dad953c9468dc/GPU/GLES/TransformPipeline.cpp#L500).  I added reporting and we're seeing it trigger in quite a few games.  It doesn't really look broken either - sometimes it's just a bit over the limit.

This change makes the limit apply only to GLES2 - I think GLES3 should hopefully be able to handle the verts.

-[Unknown]