### PR TITLE
Better pipeline descriptions

### DIFF
--- a/Common/Thread/Promise.h
+++ b/Common/Thread/Promise.h
@@ -78,6 +78,7 @@ public:
 	}
 
 	// Returns T if the data is ready, nullptr if it's not.
+	// Obviously, can only be used if T is nullable, otherwise it won't compile.
 	T Poll() {
 		std::lock_guard<std::mutex> guard(readyMutex_);
 		if (ready_) {

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -475,7 +475,7 @@ void Choice::GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, 
 float Choice::CalculateTextScale(const UIContext &dc, float availWidth) const {
 	float actualWidth, actualHeight;
 	Bounds availBounds(0, 0, availWidth, bounds_.h);
-	dc.MeasureTextRect(dc.theme->uiFont, 1.0f, 1.0f, text_.c_str(), (int)text_.size(), availBounds, &actualWidth, &actualHeight);
+	dc.MeasureTextRect(dc.theme->uiFont, 1.0f, 1.0f, text_.c_str(), (int)text_.size(), availBounds, &actualWidth, &actualHeight, drawTextFlags_);
 	if (actualWidth > availWidth) {
 		return std::max(MIN_TEXT_SCALE, availWidth / actualWidth);
 	}
@@ -511,14 +511,14 @@ void Choice::Draw(UIContext &dc) {
 
 		dc.SetFontScale(scale, scale);
 		if (centered_) {
-			dc.DrawTextRect(text_.c_str(), bounds_, style.fgColor, ALIGN_CENTER | FLAG_WRAP_TEXT);
+			dc.DrawTextRect(text_.c_str(), bounds_, style.fgColor, ALIGN_CENTER | FLAG_WRAP_TEXT | drawTextFlags_);
 		} else {
 			if (rightIconImage_.isValid()) {
 				uint32_t col = rightIconKeepColor_ ? 0xffffffff : style.fgColor; // Don't apply theme to gold icon
 				dc.Draw()->DrawImageRotated(rightIconImage_, bounds_.x2() - 32 - paddingX, bounds_.centerY(), rightIconScale_, rightIconRot_, col, rightIconFlipH_);
 			}
 			Bounds textBounds(bounds_.x + paddingX + textPadding_.left, bounds_.y, availWidth, bounds_.h);
-			dc.DrawTextRect(text_.c_str(), textBounds, style.fgColor, ALIGN_VCENTER | FLAG_WRAP_TEXT);
+			dc.DrawTextRect(text_.c_str(), textBounds, style.fgColor, ALIGN_VCENTER | FLAG_WRAP_TEXT | drawTextFlags_);
 		}
 		dc.SetFontScale(1.0f, 1.0f);
 	}

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -719,10 +719,13 @@ public:
 	void GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const override;
 	void Draw(UIContext &dc) override;
 	std::string DescribeText() const override;
-	virtual void SetCentered(bool c) {
+	void SetCentered(bool c) {
 		centered_ = c;
 	}
-	virtual void SetIcon(ImageID iconImage, float scale = 1.0f, float rot = 0.0f, bool flipH = false, bool keepColor = true) {
+	void SetDrawTextFlags(u32 flags) {
+		drawTextFlags_ = flags;
+	}
+	void SetIcon(ImageID iconImage, float scale = 1.0f, float rot = 0.0f, bool flipH = false, bool keepColor = true) {
 		rightIconKeepColor_ = keepColor;
 		rightIconScale_ = scale;
 		rightIconRot_ = rot;
@@ -748,6 +751,7 @@ protected:
 	float imgScale_ = 1.0f;
 	float imgRot_ = 0.0f;
 	bool imgFlipH_ = false;
+	u32 drawTextFlags_ = 0;
 
 private:
 	bool selected_ = false;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -581,7 +581,7 @@ std::string GPU_Vulkan::DebugGetShaderString(std::string id, DebugShaderType typ
 	if (type == SHADER_TYPE_VERTEXLOADER) {
 		return drawEngine_.DebugGetVertexLoaderString(id, stringType);
 	} else if (type == SHADER_TYPE_PIPELINE) {
-		return pipelineManager_->DebugGetObjectString(id, type, stringType);
+		return pipelineManager_->DebugGetObjectString(id, type, stringType, shaderManagerVulkan_);
 	} else if (type == SHADER_TYPE_TEXTURE) {
 		return textureCache_->GetTextureShaderCache()->DebugGetShaderString(id, type, stringType);
 	} else if (type == SHADER_TYPE_SAMPLER) {

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -32,6 +32,12 @@
 
 struct VKRGraphicsPipeline;
 class VulkanRenderManager;
+class VulkanContext;
+class VulkanVertexShader;
+class VulkanFragmentShader;
+class VulkanGeometryShader;
+class ShaderManagerVulkan;
+class DrawEngineCommon;
 
 struct VulkanPipelineKey {
 	VulkanPipelineRasterStateKey raster;  // prim is included here
@@ -49,7 +55,10 @@ struct VulkanPipelineKey {
 	void FromString(const std::string &str) {
 		memcpy(this, &str[0], sizeof(*this));
 	}
-	std::string GetDescription(DebugShaderStringType stringType) const;
+	std::string GetDescription(DebugShaderStringType stringType, ShaderManagerVulkan *shaderManager) const;
+
+private:
+	std::string GetRasterStateDesc(bool lineBreaks) const;
 };
 
 // Simply wraps a Vulkan pipeline, providing some metadata.
@@ -71,13 +80,6 @@ struct VulkanPipeline {
 	u32 GetVariantsBitmask() const;
 };
 
-class VulkanContext;
-class VulkanVertexShader;
-class VulkanFragmentShader;
-class VulkanGeometryShader;
-class ShaderManagerVulkan;
-class DrawEngineCommon;
-
 class PipelineManagerVulkan {
 public:
 	PipelineManagerVulkan(VulkanContext *ctx);
@@ -94,7 +96,7 @@ public:
 
 	void InvalidateMSAAPipelines();
 
-	std::string DebugGetObjectString(std::string id, DebugShaderType type, DebugShaderStringType stringType);
+	std::string DebugGetObjectString(std::string id, DebugShaderType type, DebugShaderStringType stringType, ShaderManagerVulkan *shaderManager);
 	std::vector<std::string> DebugGetObjectIDs(DebugShaderType type) const;
 
 	// Saves data for faster creation next time.

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -1157,6 +1157,7 @@ int ShaderListScreen::ListShaders(DebugShaderType shaderType, UI::LinearLayout *
 	for (const auto &id : shaderIds_) {
 		Choice *choice = view->Add(new Choice(gpu->DebugGetShaderString(id, shaderType, SHADER_STRING_SHORT_DESC)));
 		choice->SetTag(id);
+		choice->SetDrawTextFlags(FLAG_DYNAMIC_ASCII);
 		choice->OnClick.Handle(this, &ShaderListScreen::OnShaderClick);
 		count++;
 	}


### PR DESCRIPTION
In Shader Viewer, accessible from the in-game Dev Menu. For debugging and pipeline comparison purposes, to help suss out what pipelines we might be able to merge.

Also makes a change to clear the pipeline cache, not just the shader module cache, if useflag changes.