### PR TITLE
GLES: Avoid GLSL redefinition error

### DIFF
--- a/Common/GPU/OpenGL/GLFeatures.cpp
+++ b/Common/GPU/OpenGL/GLFeatures.cpp
@@ -568,6 +568,13 @@ bool CheckGLExtensions() {
 		}
 	}
 
+	// Force off clip for a cmomon buggy Samsung version.
+	if (!strcmp(versionStr, "OpenGL ES 3.2 ANGLE git hash: aa8f94c52952")) {
+		// Maybe could use bugs, but for now let's just force it back off.
+		// Seeing errors that gl_ClipDistance is undefined.
+		gl_extensions.EXT_clip_cull_distance = false;
+	}
+
 	ProcessGPUFeatures();
 
 	int error = glGetError();

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1029,10 +1029,12 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 			// TODO: Actually loop in the shader. For now, we write it all out.
 			// Will need to change how the data is stored to loop efficiently.
 			// u_lightControl is computed in PackLightControlBits().
+			p.F("  uint comp;");
+			p.F("  uint type;");
 			for (int i = 0; i < 4; i++) {
 				p.F("  if ((u_lightControl & %du) != 0x0u) { \n", 1 << i);
-				p.F("    uint comp = (u_lightControl >> 0x%02xu) & 0x3u;\n", 4 + 4 * i);
-				p.F("    uint type = (u_lightControl >> 0x%02xu) & 0x3u;\n", 4 + 4 * i + 2);
+				p.F("    comp = (u_lightControl >> 0x%02xu) & 0x3u;\n", 4 + 4 * i);
+				p.F("    type = (u_lightControl >> 0x%02xu) & 0x3u;\n", 4 + 4 * i + 2);
 				p.C("    if (type == 0x0u) {\n");  // GE_LIGHTTYPE_DIRECTIONAL
 				p.F("      toLight = u_lightpos%d;\n", i);
 				p.C("    } else {\n");


### PR DESCRIPTION
This is coming up from Adreno 305 drivers:

```
Error in shader compilation: info: Vertex shader compilation failed.
ERROR: 0:126: 'comp' : redefinition
ERROR: 0:127: 'type' : redefinition
ERROR: 0:175: 'comp' : redefinition
ERROR: 0:176: 'type' : redefinition
ERROR: 0:224: 'comp' : redefinition
ERROR: 0:225: 'type' : redefinition
ERROR: 6 compilation errors.  No code generated.
```

So let's just define outside the if.

-[Unknown]