### PR TITLE
Vulkan: Fix pipeline cache clearing.

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -74,6 +74,7 @@ struct VulkanPhysicalDeviceInfo {
 };
 
 class VulkanProfiler;
+class VulkanContext;
 
 // Extremely rough split of capabilities.
 enum class PerfClass {
@@ -93,11 +94,11 @@ class VulkanDeleteList {
 	};
 
 	struct Callback {
-		explicit Callback(void(*f)(void *userdata), void *u)
+		explicit Callback(void(*f)(VulkanContext *vulkan, void *userdata), void *u)
 			: func(f), userdata(u) {
 		}
 
-		void(*func)(void *userdata);
+		void (*func)(VulkanContext *vulkan, void *userdata);
 		void *userdata;
 	};
 
@@ -118,7 +119,7 @@ public:
 	void QueueDeletePipelineLayout(VkPipelineLayout &pipelineLayout) { _dbg_assert_(pipelineLayout != VK_NULL_HANDLE); pipelineLayouts_.push_back(pipelineLayout); pipelineLayout = VK_NULL_HANDLE; }
 	void QueueDeleteDescriptorSetLayout(VkDescriptorSetLayout &descSetLayout) { _dbg_assert_(descSetLayout != VK_NULL_HANDLE); descSetLayouts_.push_back(descSetLayout); descSetLayout = VK_NULL_HANDLE; }
 	void QueueDeleteQueryPool(VkQueryPool &queryPool) { _dbg_assert_(queryPool != VK_NULL_HANDLE); queryPools_.push_back(queryPool); queryPool = VK_NULL_HANDLE; }
-	void QueueCallback(void(*func)(void *userdata), void *userdata) { callbacks_.push_back(Callback(func, userdata)); }
+	void QueueCallback(void (*func)(VulkanContext *vulkan, void *userdata), void *userdata) { callbacks_.push_back(Callback(func, userdata)); }
 
 	void QueueDeleteBufferAllocation(VkBuffer &buffer, VmaAllocation &alloc) { 
 		_dbg_assert_(buffer != VK_NULL_HANDLE); 
@@ -134,7 +135,7 @@ public:
 	}
 
 	void Take(VulkanDeleteList &del);
-	void PerformDeletes(VkDevice device, VmaAllocator allocator);
+	void PerformDeletes(VulkanContext *vulkan, VmaAllocator allocator);
 
 private:
 	std::vector<VkCommandPool> cmdPools_;

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -118,13 +118,7 @@ struct VKRComputePipelineDesc {
 // Wrapped pipeline. Doesn't own desc.
 struct VKRGraphicsPipeline {
 	VKRGraphicsPipeline(PipelineFlags flags, const char *tag) : flags_(flags), tag_(tag) {}
-	~VKRGraphicsPipeline() {
-		for (size_t i = 0; i < (size_t)RenderPassType::TYPE_COUNT; i++) {
-			delete pipeline[i];
-		}
-		if (desc)
-			desc->Release();
-	}
+	~VKRGraphicsPipeline();
 
 	bool Create(VulkanContext *vulkan, VkRenderPass compatibleRenderPass, RenderPassType rpType, VkSampleCountFlagBits sampleCount);
 
@@ -142,6 +136,8 @@ struct VKRGraphicsPipeline {
 
 	VkSampleCountFlagBits SampleCount() const { return sampleCount_; }
 private:
+	void DestroyVariantsInstant(VkDevice device);
+
 	std::string tag_;
 	PipelineFlags flags_;
 	VkSampleCountFlagBits sampleCount_ = VK_SAMPLE_COUNT_FLAG_BITS_MAX_ENUM;

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -201,7 +201,7 @@ public:
 			DEBUG_LOG(G3D, "Queueing %s (shmodule %p) for release", tag_.c_str(), module_);
 			VkShaderModule shaderModule = module_->BlockUntilReady();
 			vulkan_->Delete().QueueDeleteShaderModule(shaderModule);
-			vulkan_->Delete().QueueCallback([](void *m) {
+			vulkan_->Delete().QueueCallback([](VulkanContext *context, void *m) {
 				auto module = (Promise<VkShaderModule> *)m;
 				delete module;
 			}, module_);
@@ -1579,7 +1579,7 @@ public:
 	}
 	~VKFramebuffer() {
 		_assert_msg_(buf_, "Null buf_ in VKFramebuffer - double delete?");
-		buf_->Vulkan()->Delete().QueueCallback([](void *fb) {
+		buf_->Vulkan()->Delete().QueueCallback([](VulkanContext *vulkan, void *fb) {
 			VKRFramebuffer *vfb = static_cast<VKRFramebuffer *>(fb);
 			delete vfb;
 		}, buf_);

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -312,6 +312,7 @@ void GPU_Vulkan::BeginHostFrame() {
 		// This most likely means that saw equal depth changed.
 		WARN_LOG(G3D, "Shader use flags changed, clearing all shaders");
 		shaderManagerVulkan_->ClearShaders();
+		pipelineManager_->Clear();
 		gstate_c.useFlagsChanged = false;
 	}
 

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -122,7 +122,7 @@ VulkanFragmentShader::~VulkanFragmentShader() {
 		if (shaderModule) {
 			vulkan_->Delete().QueueDeleteShaderModule(shaderModule);
 		}
-		vulkan_->Delete().QueueCallback([](void *m) {
+		vulkan_->Delete().QueueCallback([](VulkanContext *vulkan, void *m) {
 			auto module = (Promise<VkShaderModule> *)m;
 			delete module;
 		}, module_);
@@ -157,7 +157,7 @@ VulkanVertexShader::~VulkanVertexShader() {
 		if (shaderModule) {
 			vulkan_->Delete().QueueDeleteShaderModule(shaderModule);
 		}
-		vulkan_->Delete().QueueCallback([](void *m) {
+		vulkan_->Delete().QueueCallback([](VulkanContext *vulkan, void *m) {
 			auto module = (Promise<VkShaderModule> *)m;
 			delete module;
 		}, module_);
@@ -192,7 +192,7 @@ VulkanGeometryShader::~VulkanGeometryShader() {
 		if (shaderModule) {
 			vulkan_->Delete().QueueDeleteShaderModule(shaderModule);
 		}
-		vulkan_->Delete().QueueCallback([](void *m) {
+		vulkan_->Delete().QueueCallback([](VulkanContext *vulkan, void *m) {
 			auto module = (Promise<VkShaderModule> *)m;
 			delete module;
 		}, module_);


### PR DESCRIPTION
Extracted from #16759 and bugfixed, will rebase that one once this is in. Fixes a leak of Vulkan pipelines.

I guess another way would be to queue the variants for destruction at the same time as we queue the callback, but I like this better.