### PR TITLE
[Libretro] Prevent the removal of "huf_decompress_amd64.S" when doing "make clean" on Linux

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -500,7 +500,7 @@ else
 endif
 
 clean:
-	rm -f $(OBJECTS) $(TARGET)
+	rm -f $(filter-out $(CORE_DIR)/ext/zstd/lib/decompress/huf_decompress_amd64.S,$(OBJECTS)) $(TARGET)
 
 .PHONY: clean
 


### PR DESCRIPTION
Currently when doing `make clean` on Linux it deletes `ext/zstd/lib/decompress/huf_decompress_amd64.S`, I don't know if there's a better/cleaner fix for this but it works fine on my Linux Mint VM, also confirmed to work from another person running on a real Linux machine.