### PR TITLE
Remove the rather redundant DoTexture flag from vshaders.

### DIFF
--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -302,7 +302,8 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 		}
 
 		WRITE(p, "struct PS_IN {\n");
-		if (doTexture) {
+		if (doTexture || compat.shaderLanguage == HLSL_D3D11) {
+			// In D3D11, if we always have a texcoord in the VS, we always need it in the PS too for the structs to match.
 			WRITE(p, "  vec3 v_texcoord: TEXCOORD0;\n");
 		}
 		const char *colorInterpolation = doFlatShading && compat.shaderLanguage == HLSL_D3D11 ? "nointerpolation " : "";

--- a/GPU/Common/ShaderId.cpp
+++ b/GPU/Common/ShaderId.cpp
@@ -23,7 +23,6 @@ std::string VertexShaderDesc(const VShaderID &id) {
 	if (id.Bit(VS_BIT_HAS_NORMAL)) desc << "N ";
 	if (id.Bit(VS_BIT_LMODE)) desc << "LM ";
 	if (id.Bit(VS_BIT_NORM_REVERSE)) desc << "RevN ";
-	if (id.Bit(VS_BIT_DO_TEXTURE)) desc << "Tex ";
 	int uvgMode = id.Bits(VS_BIT_UVGEN_MODE, 2);
 	if (uvgMode == GE_TEXMAP_TEXTURE_MATRIX) {
 		int uvprojMode = id.Bits(VS_BIT_UVPROJ_MODE, 2);
@@ -100,8 +99,6 @@ void ComputeVertexShaderID(VShaderID *id_out, VertexDecoder *vertexDecoder, bool
 	}
 
 	if (doTexture) {
-		id.SetBit(VS_BIT_DO_TEXTURE);
-
 		// UV generation mode. doShadeMapping is implicitly stored here.
 		id.SetBits(VS_BIT_UVGEN_MODE, 2, gstate.getUVGenMode());
 	}

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -11,8 +11,9 @@
 enum VShaderBit : uint8_t {
 	VS_BIT_LMODE = 0,
 	VS_BIT_IS_THROUGH = 1,
+	// bit 2 is free.
 	VS_BIT_HAS_COLOR = 3,
-	VS_BIT_DO_TEXTURE = 4,
+	// bit 4 is free.
 	VS_BIT_VERTEX_RANGE_CULLING = 5,
 	VS_BIT_SIMPLE_STEREO = 6,
 	// 7 is free.

--- a/GPU/Common/ShaderUniforms.h
+++ b/GPU/Common/ShaderUniforms.h
@@ -87,39 +87,39 @@ struct alignas(16) UB_VS_Lights {
 };
 
 static const char * const ub_vs_lightsStr =
-R"(	vec4 u_ambient;
-	vec3 u_matdiffuse;
-	vec4 u_matspecular;
-	vec3 u_matemissive;
-	uint u_lightControl;  // light ubershader
-	vec3 u_lightpos0;
-	vec3 u_lightpos1;
-	vec3 u_lightpos2;
-	vec3 u_lightpos3;
-	vec3 u_lightdir0;
-	vec3 u_lightdir1;
-	vec3 u_lightdir2;
-	vec3 u_lightdir3;
-	vec3 u_lightatt0;
-	vec3 u_lightatt1;
-	vec3 u_lightatt2;
-	vec3 u_lightatt3;
-	vec4 u_lightangle_spotCoef0;
-	vec4 u_lightangle_spotCoef1;
-	vec4 u_lightangle_spotCoef2;
-	vec4 u_lightangle_spotCoef3;
-	vec3 u_lightambient0;
-	vec3 u_lightambient1;
-	vec3 u_lightambient2;
-	vec3 u_lightambient3;
-	vec3 u_lightdiffuse0;
-	vec3 u_lightdiffuse1;
-	vec3 u_lightdiffuse2;
-	vec3 u_lightdiffuse3;
-	vec3 u_lightspecular0;
-	vec3 u_lightspecular1;
-	vec3 u_lightspecular2;
-	vec3 u_lightspecular3;
+R"(  vec4 u_ambient;
+  vec3 u_matdiffuse;
+  vec4 u_matspecular;
+  vec3 u_matemissive;
+  uint u_lightControl;  // light ubershader
+  vec3 u_lightpos0;
+  vec3 u_lightpos1;
+  vec3 u_lightpos2;
+  vec3 u_lightpos3;
+  vec3 u_lightdir0;
+  vec3 u_lightdir1;
+  vec3 u_lightdir2;
+  vec3 u_lightdir3;
+  vec3 u_lightatt0;
+  vec3 u_lightatt1;
+  vec3 u_lightatt2;
+  vec3 u_lightatt3;
+  vec4 u_lightangle_spotCoef0;
+  vec4 u_lightangle_spotCoef1;
+  vec4 u_lightangle_spotCoef2;
+  vec4 u_lightangle_spotCoef3;
+  vec3 u_lightambient0;
+  vec3 u_lightambient1;
+  vec3 u_lightambient2;
+  vec3 u_lightambient3;
+  vec3 u_lightdiffuse0;
+  vec3 u_lightdiffuse1;
+  vec3 u_lightdiffuse2;
+  vec3 u_lightdiffuse3;
+  vec3 u_lightspecular0;
+  vec3 u_lightspecular1;
+  vec3 u_lightspecular2;
+  vec3 u_lightspecular3;
 )";
 
 // With some cleverness, we could get away with uploading just half this when only the four or five first

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -868,7 +868,6 @@ LinkedShader *ShaderManagerGLES::ApplyFragmentShader(VShaderID VSID, Shader *vs,
 	shaderSwitchDirtyUniforms_ = 0;
 
 	if (ls == nullptr) {
-		_dbg_assert_(FSID.Bit(FS_BIT_DO_TEXTURE) == VSID.Bit(VS_BIT_DO_TEXTURE));
 		_dbg_assert_(FSID.Bit(FS_BIT_FLATSHADE) == VSID.Bit(VS_BIT_FLATSHADE));
 
 		// Check if we can link these.
@@ -960,7 +959,8 @@ enum class CacheDetectFlags {
 };
 
 #define CACHE_HEADER_MAGIC 0x83277592
-#define CACHE_VERSION 24
+#define CACHE_VERSION 25
+
 struct CacheHeader {
 	uint32_t magic;
 	uint32_t version;

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -287,7 +287,7 @@ static VulkanPipeline *CreateVulkanPipeline(VulkanRenderManager *renderManager, 
 		attributeCount = SetupVertexAttribs(attrs, *decFmt);
 		vertexStride = decFmt->stride;
 	} else {
-		bool needsUV = vs->GetID().Bit(VS_BIT_DO_TEXTURE);
+		bool needsUV = true;
 		bool needsColor1 = vs->GetID().Bit(VS_BIT_LMODE);
 		attributeCount = SetupVertexAttribsPretransformed(attrs, needsUV, needsColor1, true);
 		vertexStride = (int)sizeof(TransformedVertex);

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -320,12 +320,7 @@ void ShaderManagerVulkan::GetShaders(int prim, VertexDecoder *decoder, VulkanVer
 		GSID = lastGSID_;
 	}
 
-	_dbg_assert_(FSID.Bit(FS_BIT_DO_TEXTURE) == VSID.Bit(VS_BIT_DO_TEXTURE));
 	_dbg_assert_(FSID.Bit(FS_BIT_FLATSHADE) == VSID.Bit(VS_BIT_FLATSHADE));
-
-	if (GSID.Bit(GS_BIT_ENABLED)) {
-		_dbg_assert_(GSID.Bit(GS_BIT_DO_TEXTURE) == VSID.Bit(VS_BIT_DO_TEXTURE));
-	}
 
 	// Just update uniforms if this is the same shader as last time.
 	if (lastVShader_ != nullptr && lastFShader_ != nullptr && VSID == lastVSID_ && FSID == lastFSID_ && GSID == lastGSID_) {
@@ -516,7 +511,8 @@ enum class VulkanCacheDetectFlags {
 };
 
 #define CACHE_HEADER_MAGIC 0xff51f420 
-#define CACHE_VERSION 38
+#define CACHE_VERSION 39
+
 struct VulkanCacheHeader {
 	uint32_t magic;
 	uint32_t version;


### PR DESCRIPTION
Part of https://github.com/hrydgard/ppsspp/issues/16567 and compounds with the other changes.

Slightly reduces the number of unique vertex shaders but doesn't do much for the pipeline count, as the fragment shader has a tex flag (which will stay). Still worth doing for the simplification and reduction of vertex shader generation cost.