### PR TITLE
GLES: Delete LinkedShaders after the program

### DIFF
--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -110,6 +110,9 @@ public:
 class GLRProgram {
 public:
 	~GLRProgram() {
+		if (deleteCallback_) {
+			deleteCallback_(deleteParam_);
+		}
 		if (program) {
 			glDeleteProgram(program);
 		}
@@ -161,6 +164,15 @@ public:
 		}
 		return loc;
 	}
+
+	void SetDeleteCallback(void(*cb)(void *), void *p) {
+		deleteCallback_ = cb;
+		deleteParam_ = p;
+	}
+
+private:
+	void(*deleteCallback_)(void *) = nullptr;
+	void *deleteParam_ = nullptr;
 
 	std::unordered_map<std::string, UniformInfo> uniformCache_;
 };

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -210,8 +210,17 @@ LinkedShader::LinkedShader(GLRenderManager *render, VShaderID VSID, Shader *vs, 
 	dirtyUniforms = DIRTY_ALL_UNIFORMS;
 }
 
-LinkedShader::~LinkedShader() {
+void LinkedShader::Delete() {
+	program->SetDeleteCallback([](void *thiz) {
+		LinkedShader *ls = (LinkedShader *)thiz;
+		delete ls;
+	}, this);
 	render_->DeleteProgram(program);
+	program = nullptr;
+}
+
+LinkedShader::~LinkedShader() {
+	_assert_(program == nullptr);
 }
 
 // Utility
@@ -685,7 +694,7 @@ ShaderManagerGLES::~ShaderManagerGLES() {
 void ShaderManagerGLES::Clear() {
 	DirtyLastShader();
 	for (auto iter = linkedShaderCache_.begin(); iter != linkedShaderCache_.end(); ++iter) {
-		delete iter->ls;
+		iter->ls->Delete();
 	}
 	fsCache_.Iterate([&](const FShaderID &key, Shader *shader) {
 		delete shader;

--- a/GPU/GLES/ShaderManagerGLES.h
+++ b/GPU/GLES/ShaderManagerGLES.h
@@ -42,6 +42,7 @@ public:
 
 	void use(const ShaderID &VSID);
 	void UpdateUniforms(const ShaderID &VSID, bool useBufferedRendering, const ShaderLanguageDesc &shaderLanguage);
+	void Delete();
 
 	GLRenderManager *render_;
 	Shader *vs_;


### PR DESCRIPTION
The program references the shader, so we have to delete in this order. Caused problems on useFlag change as well as probably DeviceLost as well.  Wasn't actually related to the deleter.

Fixes #16764.

-[Unknown]