### PR TITLE
GLES: Remove some unused depth related code

### DIFF
--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -61,15 +61,6 @@ void FramebufferManagerGLES::UpdateDownloadTempBuffer(VirtualFramebuffer *nvfb) 
 	}
 }
 
-void FramebufferManagerGLES::DeviceLost() {
-	FramebufferManagerCommon::DeviceLost();
-	if (depthDownloadProgram_) {
-		GLRenderManager *render = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
-		render->DeleteProgram(depthDownloadProgram_);
-		depthDownloadProgram_ = nullptr;
-	}
-}
-
 void FramebufferManagerGLES::NotifyDisplayResized() {
 	FramebufferManagerCommon::NotifyDisplayResized();
 

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -32,7 +32,6 @@ public:
 	~FramebufferManagerGLES();
 
 	void NotifyDisplayResized() override;
-	void DeviceLost() override;
 
 	bool GetOutputFramebuffer(GPUDebugBuffer &buffer) override;
 
@@ -44,10 +43,4 @@ protected:
 private:
 	u8 *convBuf_ = nullptr;
 	u32 convBufSize_ = 0;
-
-	GLRProgram *depthDownloadProgram_ = nullptr;
-	int u_depthDownloadTex = -1;
-	int u_depthDownloadFactor = -1;
-	int u_depthDownloadShift = -1;
-	int u_depthDownloadTo8 = -1;
 };


### PR DESCRIPTION
Just some quick cleanup.  `depthReadbackPipeline_` is in Common now.

-[Unknown]