### PR TITLE
Vertex shaders: On platforms with uniform buffers, use indexing and loop over the lights.

### DIFF
--- a/GPU/Common/ShaderUniforms.h
+++ b/GPU/Common/ShaderUniforms.h
@@ -91,35 +91,14 @@ R"(  vec4 u_ambient;
   vec3 u_matdiffuse;
   vec4 u_matspecular;
   vec3 u_matemissive;
-  uint u_lightControl;  // light ubershader
-  vec3 u_lightpos0;
-  vec3 u_lightpos1;
-  vec3 u_lightpos2;
-  vec3 u_lightpos3;
-  vec3 u_lightdir0;
-  vec3 u_lightdir1;
-  vec3 u_lightdir2;
-  vec3 u_lightdir3;
-  vec3 u_lightatt0;
-  vec3 u_lightatt1;
-  vec3 u_lightatt2;
-  vec3 u_lightatt3;
-  vec4 u_lightangle_spotCoef0;
-  vec4 u_lightangle_spotCoef1;
-  vec4 u_lightangle_spotCoef2;
-  vec4 u_lightangle_spotCoef3;
-  vec3 u_lightambient0;
-  vec3 u_lightambient1;
-  vec3 u_lightambient2;
-  vec3 u_lightambient3;
-  vec3 u_lightdiffuse0;
-  vec3 u_lightdiffuse1;
-  vec3 u_lightdiffuse2;
-  vec3 u_lightdiffuse3;
-  vec3 u_lightspecular0;
-  vec3 u_lightspecular1;
-  vec3 u_lightspecular2;
-  vec3 u_lightspecular3;
+  uint u_lightControl;  // light ubershader control bits
+  vec3 u_lightpos[4];
+  vec3 u_lightdir[4];
+  vec3 u_lightatt[4];
+  vec4 u_lightangle_spotCoef[4];
+  vec3 u_lightambient[4];
+  vec3 u_lightdiffuse[4];
+  vec3 u_lightspecular[4];
 )";
 
 // With some cleverness, we could get away with uploading just half this when only the four or five first

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1017,13 +1017,15 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 		char iStr[4];
 
 		if (lightUberShader) {
-			// TODO: Actually loop in the shader. For now, we write it all out.
-			// Will need to change how the data is stored to loop efficiently.
-			// u_lightControl is computed in PackLightControlBits().
+			// We generate generic code that can calculate any combination of lights specified
+			// in u_lightControl. u_lightControl is computed in PackLightControlBits().
 			p.C("  uint comp; uint type;\n");
 			if (useIndexing) {
 				p.C("  for (uint i = 0; i < 4; i++) {\n");
 			}
+			// If we can use indexing, we actually loop in the shader now, using the loop emitted
+			// above. In that case, we only need to emit the code once, so the for loop here will
+			// only run for a single pass.
 			int count = useIndexing ? 1 : 4;
 			for (int i = 0; i < count; i++) {
 				snprintf(iStr, sizeof(iStr), useIndexing ? "[i]" : "%d", i);
@@ -1086,8 +1088,7 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 				p.F("  }");
 			}
 		} else {
-			// Calculate lights if needed. If shade mapping is enabled, lights may need to be
-			// at least partially calculated.
+			// Generate specific code for calculating the enabled lights only.
 			for (int i = 0; i < 4; i++) {
 				if (doLight[i] != LIGHT_FULL)
 					continue;


### PR DESCRIPTION
Instead of duplicating the code for each light.

Strangely, maybe because there's less code to parse, this speeds up ubershader pipeline creation on PowerVR by over 30%. There shouldn't be any performance difference at runtime as the loop is trivial and easy for the driver to unroll if it feels like it.

For now, we only do this in Vulkan and D3D11, but it would be possible to also support in OpenGL, though the uniform management gets tricker (or we need to start using uniform buffers in OpenGL).