### PR TITLE
Lighting code cleanup and optimization

### DIFF
--- a/Common/Data/Convert/SmallDataConvert.h
+++ b/Common/Data/Convert/SmallDataConvert.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <cmath>
 
 #include "Common/Common.h"
 #include "ppsspp_config.h"
@@ -225,6 +226,23 @@ inline void ExpandFloat24x3ToFloat4(float dest[4], const uint32_t src[3]) {
 	uint32_t temp[4] = { src[0] << 8, src[1] << 8, src[2] << 8, 0 };
 	memcpy(dest, temp, sizeof(float) * 4);
 #endif
+}
+
+// Note: If length is 0.0, it's gonna be left as 0.0 instead of trying to normalize. This is important.
+inline void ExpandFloat24x3ToFloat4AndNormalize(float dest[4], const uint32_t src[3]) {
+	float temp[4];
+	ExpandFloat24x3ToFloat4(temp, src);
+	// TODO: Reuse code from NormalizedOr001 and optimize
+	float x = temp[0];
+	float y = temp[1];
+	float z = temp[2];
+	float len = sqrtf(x * x + y * y + z * z);
+	if (len != 0.0f)
+		len = 1.0f / len;
+	dest[0] = x * len;
+	dest[1] = y * len;
+	dest[2] = z * len;
+	dest[3] = 0.0f;
 }
 
 inline uint32_t BytesToUint32(uint8_t a, uint8_t b, uint8_t c, uint8_t d) {

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -306,25 +306,6 @@ uint32_t PackLightControlBits() {
 	return lightControl;
 }
 
-// Note: If length is 0.0, it's gonna be left as 0.0 instead of normalized.
-void ExpandFloat24x3ToFloat4AndNormalize(float dest[4], const uint32_t src[3]) {
-	float temp[4];
-	ExpandFloat24x3ToFloat4(temp, src);
-	// TODO: Reuse code from NormalizedOr001 and optimize
-	float x = temp[0];
-	float y = temp[1];
-	float z = temp[2];
-	float len = sqrtf(x * x + y * y + z * z);
-	if (len == 0.0f)
-		return;
-
-	len = 1.0f / len;
-	dest[0] = x * len;
-	dest[1] = y * len;
-	dest[2] = z * len;
-	dest[3] = 0.0f;
-}
-
 void LightUpdateUniforms(UB_VS_Lights *ub, uint64_t dirtyUniforms) {
 	// Lighting
 	if (dirtyUniforms & DIRTY_AMBIENT) {

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -294,6 +294,7 @@ uint32_t PackLightControlBits() {
 
 		u32 computation = (u32)gstate.getLightComputation(i);  // 2 bits
 		u32 type = (u32)gstate.getLightType(i);  // 2 bits
+		if (type == 3) { type = 0; }  // Don't want to handle this degenerate case in the shader.
 		lightControl |= computation << (4 + i * 4);
 		lightControl |= type << (4 + i * 4 + 2);
 	}

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1059,25 +1059,19 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 				p.C("    }\n");
 				p.C("    ldot = dot(toLight, worldnormal);\n");
 				p.C("    if (comp == 0x2u) {\n");  // GE_LIGHTCOMP_ONLYPOWDIFFUSE
-				p.C("      if (u_matspecular.a > 0.0) {\n");
-				p.C("        ldot = pow(max(ldot, 0.0), u_matspecular.a);\n");
-				p.C("      } else {\n");
-				p.C("        ldot = 1.0;\n");
-				p.C("      }\n");
-				p.C("    }\n");
-				p.F("    diffuse = (u_lightdiffuse%s * diffuseColor) * max(ldot, 0.0);\n", iStr);
-				p.C("    if (comp == 0x1u) {\n");  // do specular
+				p.C("      ldot = u_matspecular.a > 0.0 ? pow(max(ldot, 0.0), u_matspecular.a) : 1.0;\n");
+				p.C("    } else if (comp == 0x1u) {\n");  // do specular
 				p.C("      if (ldot >= 0.0) {\n");
-				p.C("        ldot = dot(normalize(toLight + vec3(0.0, 0.0, 1.0)), worldnormal);\n");
 				p.C("        if (u_matspecular.a > 0.0) {\n");
+				p.C("          ldot = dot(normalize(toLight + vec3(0.0, 0.0, 1.0)), worldnormal);\n");
 				p.C("          ldot = pow(max(ldot, 0.0), u_matspecular.a);\n");
 				p.C("        } else {\n");
 				p.C("          ldot = 1.0;\n");
 				p.C("        }\n");
-				p.C("        if (ldot > 0.0)\n");
-				p.F("          lightSum1 += u_lightspecular%s * specularColor * ldot * lightScale;\n", iStr);
+				p.F("        lightSum1 += u_lightspecular%s * specularColor * ldot * lightScale;\n", iStr);
 				p.C("      }\n");
 				p.C("    }\n");
+				p.F("    diffuse = (u_lightdiffuse%s * diffuseColor) * max(ldot, 0.0);\n", iStr);
 				p.F("    lightSum0.rgb += (u_lightambient%s * ambientColor.rgb + diffuse) * lightScale;\n", iStr);
 				p.C("  }\n");
 			}

--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1057,7 +1057,7 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 				p.F("      lightScale = clamp(1.0 / dot(u_lightatt%s, vec3(1.0, distance, distance*distance)), 0.0, 1.0);\n", iStr);
 				p.C("      break;\n");
 				p.C("    case 2:\n");  // GE_LIGHTTYPE_SPOT
-				p.F("      angle = length(u_lightdir%s) == 0.0 ? 0.0 : dot(normalize(u_lightdir%s), toLight);\n", iStr, iStr);
+				p.F("      angle = dot(u_lightdir%s, toLight);\n", iStr, iStr);
 				p.F("      if (angle >= u_lightangle_spotCoef%s.x) {\n", iStr);
 				p.F("        lightScale = clamp(1.0 / dot(u_lightatt%s, vec3(1.0, distance, distance*distance)), 0.0, 1.0) * (u_lightangle_spotCoef%s.y <= 0.0 ? 1.0 : pow(angle, u_lightangle_spotCoef%s.y));\n", iStr, iStr, iStr);
 				p.C("      } else {\n");
@@ -1133,7 +1133,7 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 					break;
 				case GE_LIGHTTYPE_SPOT:
 				case GE_LIGHTTYPE_UNKNOWN:
-					p.F("  angle = length(u_lightdir%s) == 0.0 ? 0.0 : dot(normalize(u_lightdir%s), toLight);\n", iStr, iStr);
+					p.F("  angle = dot(u_lightdir%s, toLight);\n", iStr, iStr);
 					p.F("  if (angle >= u_lightangle_spotCoef%s.x) {\n", iStr);
 					p.F("    lightScale = clamp(1.0 / dot(u_lightatt%s, vec3(1.0, distance, distance*distance)), 0.0, 1.0) * (u_lightangle_spotCoef%s.y <= 0.0 ? 1.0 : pow(angle, u_lightangle_spotCoef%s.y));\n", iStr, iStr, iStr);
 					p.C("  } else {\n");

--- a/GPU/Directx9/ShaderManagerDX9.h
+++ b/GPU/Directx9/ShaderManagerDX9.h
@@ -104,6 +104,7 @@ private:
 	void VSSetFloat(int creg, float value);
 	void VSSetFloatArray(int creg, const float *value, int count);
 	void VSSetFloat24Uniform3(int creg, const u32 data[3]);
+	void VSSetFloat24Uniform3Normalized(int creg, const u32 data[3]);
 	void VSSetFloatUniform4(int creg, const float data[4]);
 
 	void Clear();


### PR DESCRIPTION
Tighten up the vertex shader lighting code a bit, and prenormalize the spotlight direction to save a few instructions.

Anything to help the driver shader compilers compile faster and generate better code...

Followup to #16787 