### PR TITLE
ffmpeg: Don't ask for multi-threaded decoding

### DIFF
--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -521,11 +521,7 @@ bool MediaEngine::setVideoStream(int streamNum, bool force) {
 
 		m_pCodecCtx->flags |= AV_CODEC_FLAG_OUTPUT_CORRUPT | AV_CODEC_FLAG_LOW_DELAY;
 
-		AVDictionary *opt = nullptr;
-		// Allow ffmpeg to use any number of threads it wants.  Without this, it doesn't use threads.
-		av_dict_set(&opt, "threads", "0", 0);
-		int openResult = avcodec_open2(m_pCodecCtx, pCodec, &opt);
-		av_dict_free(&opt);
+		int openResult = avcodec_open2(m_pCodecCtx, pCodec, nullptr);
 		if (openResult < 0) {
 			return false;
 		}

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -107,12 +107,10 @@ bool SimpleAudio::OpenCodec(int block_align) {
 		codecCtx_->block_align = block_align;
 	}
 
-	AVDictionary *opts = 0;
-	int retval = avcodec_open2(codecCtx_, codec_, &opts);
+	int retval = avcodec_open2(codecCtx_, codec_, nullptr);
 	if (retval < 0) {
 		ERROR_LOG(ME, "Failed to open codec: retval = %i", retval);
 	}
-	av_dict_free(&opts);
 	codecOpen_ = true;
 	return retval >= 0;
 #else

--- a/Core/MemFault.cpp
+++ b/Core/MemFault.cpp
@@ -268,6 +268,7 @@ bool HandleFault(uintptr_t hostAddress, void *ctx) {
 		}
 	} else {
 		type = MemoryExceptionType::UNKNOWN;
+
 	}
 
 	g_lastMemoryExceptionType = type;


### PR DESCRIPTION
For whatever reason, our version of ffmpeg has problems with it, and I don't care enough to dig deep.

See PR #13806, which this replaces.