### PR TITLE
expose analog-is-circle functionality to libretro

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -262,6 +262,16 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "Cross"
    },
    {
+      "ppsspp_analog_is_circular",
+      "Analog Circle vs Square Gate Compensation",
+      NULL,
+      NULL,
+      NULL,
+      "system",
+      BOOL_OPTIONS,
+      "disabled"
+   },
+   {
       "ppsspp_internal_resolution",
       "Internal Resolution (Restart)",
       NULL,


### PR DESCRIPTION
A RetroArch user reported having difficulty reaching full extension with analog diagonal directions on some games with some controllers, so I duplicated the same circle/square compensation you guys use in ControlMapper.cpp and exposed it as a core option.