### PR TITLE
Avoid union reinterpret

### DIFF
--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -731,31 +731,29 @@ bool CBreakPoints::EvaluateLogFormat(DebugInterface *cpu, const std::string &fmt
 				return false;
 			}
 
-			union {
-				int i;
-				u32 u;
-				float f;
-			} expResult;
+			uint32_t expResult;
 			char resultString[256];
-			if (!cpu->parseExpression(exp, expResult.u)) {
+			if (!cpu->parseExpression(exp, expResult)) {
 				return false;
 			}
 
+			float expResultf;
 			switch (type) {
 			case 'd':
-				snprintf(resultString, sizeof(resultString), "%d", expResult.i);
+				snprintf(resultString, sizeof(resultString), "%d", (int)expResult);
 				break;
 			case 'f':
-				snprintf(resultString, sizeof(resultString), "%f", expResult.f);
+				memcpy(&expResultf, &expResult, sizeof(float));
+				snprintf(resultString, sizeof(resultString), "%f", expResultf);
 				break;
 			case 'p':
-				snprintf(resultString, sizeof(resultString), "%08x[%08x]", expResult.u, Memory::IsValidAddress(expResult.u) ? Memory::Read_U32(expResult.u) : 0);
+				snprintf(resultString, sizeof(resultString), "%08x[%08x]", expResult, Memory::IsValidRange(expResult, 4) ? Memory::ReadUnchecked_U32(expResult) : 0);
 				break;
 			case 's':
-				snprintf(resultString, sizeof(resultString) - 1, "%s", Memory::IsValidAddress(expResult.u) ? Memory::GetCharPointer(expResult.u) : "(invalid)");
+				snprintf(resultString, sizeof(resultString) - 1, "%s", Memory::IsValidAddress(expResult) ? Memory::GetCharPointer(expResult) : "(invalid)");
 				break;
 			case 'x':
-				snprintf(resultString, sizeof(resultString), "%08x", expResult.u);
+				snprintf(resultString, sizeof(resultString), "%08x", expResult);
 				break;
 			}
 			result += resultString;

--- a/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp
+++ b/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp
@@ -40,11 +40,9 @@ DebuggerSubscriber *WebSocketCPUCoreInit(DebuggerEventHandlerMap &map) {
 }
 
 static std::string RegValueAsFloat(uint32_t u) {
-	union {
-		uint32_t u;
-		float f;
-	} bits = { u };
-	return StringFromFormat("%f", bits.f);
+	float f;
+	memcpy(&f, &u, sizeof(float));
+	return StringFromFormat("%f", f);
 }
 
 static DebugInterface *CPUFromRequest(DebuggerRequest &req) {

--- a/Core/Debugger/WebSocket/WebSocketUtils.cpp
+++ b/Core/Debugger/WebSocket/WebSocketUtils.cpp
@@ -70,12 +70,9 @@ static bool U32FromString(const char *str, uint32_t *out, bool allowFloat) {
 
 	// We have to try float last because we use float bits, so 1.0 != 1.
 	if (allowFloat) {
-		union {
-			uint32_t u;
-			float f;
-		} bits;
-		if (TryParse(str, &bits.f)) {
-			*out = bits.u;
+		float parsedFloat;
+		if (TryParse(str, &parsedFloat)) {
+			memcpy(out, &parsedFloat, sizeof(uint32_t));
 			return true;
 		}
 
@@ -129,11 +126,8 @@ bool DebuggerRequest::ParamU32(const char *name, uint32_t *out, bool allowFloatB
 				Fail(StringFromFormat("Could not parse '%s' parameter: integer required", name));
 			return false;
 		} else if (!isInteger && allowFloatBits) {
-			union {
-				float f;
-				uint32_t u;
-			} bits = { (float)val };
-			*out = bits.u;
+			float valf = (float)val;
+			memcpy(out, &valf, sizeof(float));
 			return true;
 		}
 

--- a/Core/HLE/KernelThreadDebugInterface.h
+++ b/Core/HLE/KernelThreadDebugInterface.h
@@ -33,9 +33,13 @@ public:
 	void SetPC(u32 _pc) override { ctx.pc = _pc; }
 
 	void PrintRegValue(int cat, int index, char *out) override {
+		float tempf;
 		switch (cat) {
 		case 0: sprintf(out, "%08X", ctx.r[index]); break;
-		case 1: sprintf(out, "%f", ctx.f[index]); break;
+		case 1:
+			memcpy(&tempf, &ctx.fi[index], sizeof(float));
+			sprintf(out, "%f", tempf);
+			break;
 		case 2: sprintf(out, "N/A"); break;
 		}
 	}

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -543,10 +543,10 @@ public:
 		{
 			// We must have been loading an old state if we're here.
 			// Reorder VFPU data to new order.
-			float temp[128];
-			memcpy(temp, context.v, 128 * sizeof(float));
+			u32 temp[128];
+			memcpy(temp, context.vi, 128 * sizeof(u32));
 			for (int i = 0; i < 128; i++) {
-				context.v[voffset[i]] = temp[i];
+				context.vi[voffset[i]] = temp[i];
 			}
 		}
 
@@ -1455,10 +1455,10 @@ u32 sceKernelGetThreadmanIdList(u32 type, u32 readBufPtr, u32 readBufSize, u32 i
 // Saves the current CPU context
 void __KernelSaveContext(PSPThreadContext *ctx, bool vfpuEnabled) {
 	// r and f are immediately next to each other and must be.
-	memcpy((void *)ctx->r, (void *)currentMIPS->r, sizeof(ctx->r) + sizeof(ctx->f));
+	memcpy((void *)ctx->r, (void *)currentMIPS->r, sizeof(ctx->r) + sizeof(ctx->fi));
 
 	if (vfpuEnabled) {
-		memcpy(ctx->v, currentMIPS->v, sizeof(ctx->v));
+		memcpy(ctx->vi, currentMIPS->v, sizeof(ctx->vi));
 		memcpy(ctx->vfpuCtrl, currentMIPS->vfpuCtrl, sizeof(ctx->vfpuCtrl));
 	}
 
@@ -1468,10 +1468,10 @@ void __KernelSaveContext(PSPThreadContext *ctx, bool vfpuEnabled) {
 // Loads a CPU context
 void __KernelLoadContext(const PSPThreadContext *ctx, bool vfpuEnabled) {
 	// r and f are immediately next to each other and must be.
-	memcpy((void *)currentMIPS->r, (void *)ctx->r, sizeof(ctx->r) + sizeof(ctx->f));
+	memcpy((void *)currentMIPS->r, (void *)ctx->r, sizeof(ctx->r) + sizeof(ctx->fi));
 
 	if (vfpuEnabled) {
-		memcpy(currentMIPS->v, ctx->v, sizeof(ctx->v));
+		memcpy(currentMIPS->v, ctx->vi, sizeof(ctx->vi));
 		memcpy(currentMIPS->vfpuCtrl, ctx->vfpuCtrl, sizeof(ctx->vfpuCtrl));
 	}
 

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -129,15 +129,8 @@ struct PSPThreadContext {
 
 	// r must be followed by f.
 	u32 r[32];
-	union {
-		float f[32];
-		u32 fi[32];
-		int fs[32];
-	};
-	union {
-		float v[128];
-		u32 vi[128];
-	};
+	u32 fi[32];
+	u32 vi[128];
 	u32 vfpuCtrl[16];
 
 	union {

--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -2135,16 +2135,20 @@ namespace MIPSComp
 	}
 
 	static double SinCos(float angle) {
-		union { struct { float sin; float cos; }; double out; } sincos;
+		double out;
+		struct { float sin; float cos; } sincos;
 		vfpu_sincos(angle, sincos.sin, sincos.cos);
-		return sincos.out;
+		memcpy(&out, &sincos, sizeof(double));
+		return out;
 	}
 
 	static double SinCosNegSin(float angle) {
-		union { struct { float sin; float cos; }; double out; } sincos;
+		double out;
+		struct { float sin; float cos; } sincos;
 		vfpu_sincos(angle, sincos.sin, sincos.cos);
 		sincos.sin = -sincos.sin;
-		return sincos.out;
+		memcpy(&out, &sincos, sizeof(double));
+		return out;
 	}
 
 	void ArmJit::CompVrotShuffle(u8 *dregs, int imm, VectorSize sz, bool negSin) {
@@ -2230,7 +2234,7 @@ namespace MIPSComp
 		// FlushBeforeCall saves R1.
 		QuickCallFunction(R1, negSin1 ? (void *)&SinCosNegSin : (void *)&SinCos);
 #if !defined(__ARM_PCS_VFP)
-		// Returns D0 on hardfp and R0,R1 on softfp due to union joining the two floats
+		// Returns D0 on hardfp and R0,R1 on softfp due to memcpy joining the two floats
 		VMOV(D0, R0, R1);
 #endif
 		CompVrotShuffle(dregs, imm, sz, false);

--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -2100,9 +2100,9 @@ namespace MIPSComp
 
 		FP16 half;
 		half.u = op & 0xFFFF;
-		FP32 fval = half_to_float_fast5(half);
+		float fval = half_to_float_fast5(half);
 		fpr.MapRegV(dreg, MAP_DIRTY | MAP_NOINIT);
-		MOVI2F(fpr.V(dreg), fval.f, SCRATCHREG1);
+		MOVI2F(fpr.V(dreg), fval, SCRATCHREG1);
 
 		ApplyPrefixD(&dreg, V_Single);
 		fpr.ReleaseSpillLocksAndDiscardTemps();

--- a/Core/MIPS/ARM/ArmCompVFPUNEON.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPUNEON.cpp
@@ -1367,9 +1367,9 @@ void ArmJit::CompNEON_Vfim(MIPSOpcode op) {
 
 	FP16 half;
 	half.u = op & 0xFFFF;
-	FP32 fval = half_to_float_fast5(half);
+	float fval = half_to_float_fast5(half);
 	// TODO: Optimize for low registers.
-	MOVI2F(S0, (float)fval.f, R0);
+	MOVI2F(S0, fval, R0);
 	VMOV_neon(vt.rd, D0);
 
 	NEONApplyPrefixD(vt);

--- a/Core/MIPS/ARM64/Arm64CompVFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompVFPU.cpp
@@ -1831,9 +1831,9 @@ namespace MIPSComp {
 
 		FP16 half;
 		half.u = op & 0xFFFF;
-		FP32 fval = half_to_float_fast5(half);
+		float fval = half_to_float_fast5(half);
 		fpr.MapRegV(dreg, MAP_DIRTY | MAP_NOINIT);
-		fp.MOVI2F(fpr.V(dreg), fval.f, SCRATCH1);
+		fp.MOVI2F(fpr.V(dreg), fval, SCRATCH1);
 
 		ApplyPrefixD(&dreg, V_Single);
 		fpr.ReleaseSpillLocksAndDiscardTemps();

--- a/Core/MIPS/ARM64/Arm64CompVFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompVFPU.cpp
@@ -1865,16 +1865,20 @@ namespace MIPSComp {
 	}
 
 	static double SinCos(float angle) {
-		union { struct { float sin; float cos; }; double out; } sincos;
+		double out;
+		struct { float sin; float cos; } sincos;
 		vfpu_sincos(angle, sincos.sin, sincos.cos);
-		return sincos.out;
+		memcpy(&out, &sincos, sizeof(double));
+		return out;
 	}
 
 	static double SinCosNegSin(float angle) {
-		union { struct { float sin; float cos; }; double out; } sincos;
+		double out;
+		struct { float sin; float cos; } sincos;
 		vfpu_sincos(angle, sincos.sin, sincos.cos);
 		sincos.sin = -sincos.sin;
-		return sincos.out;
+		memcpy(&out, &sincos, sizeof(double));
+		return out;
 	}
 
 	void Arm64Jit::CompVrotShuffle(u8 *dregs, int imm, VectorSize sz, bool negSin) {

--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -1824,11 +1824,11 @@ namespace MIPSComp {
 
 		FP16 half;
 		half.u = op & 0xFFFF;
-		FP32 fval = half_to_float_fast5(half);
+		float fval = half_to_float_fast5(half);
 
 		u8 dreg;
 		GetVectorRegsPrefixD(&dreg, V_Single, _VT);
-		ir.Write(IROp::SetConstF, dreg, ir.AddConstantFloat(fval.f));
+		ir.Write(IROp::SetConstF, dreg, ir.AddConstantFloat(fval));
 		ApplyPrefixD(&dreg, V_Single);
 	}
 

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -183,15 +183,8 @@ public:
 
 	// MUST start with r and be followed by f, v, and t!
 	u32 r[32];
-	union {
-		float f[32];
-		u32 fi[32];
-		int fs[32];
-	};
-	union {
-		float v[128];
-		u32 vi[128];
-	};
+	float f[32];
+	float v[128];
 
 	// Register-allocated JIT Temps don't get flushed so we don't reserve space for them.
 	// However, the IR interpreter needs some temps that can stick around between ops.

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -659,13 +659,13 @@ namespace MIPSAnalyst {
 
 		if (IsSWC1Instr(op)) {
 			int ft = MIPS_GET_FT(op);
-			writeVal = currentMIPS->fi[ft];
+			memcpy(&writeVal, &currentMIPS->f[ft], sizeof(writeVal));
 			prevVal = Memory::Read_U32(addr);
 		}
 
 		if (IsSVSInstr(op)) {
 			int vt = ((op >> 16) & 0x1f) | ((op & 3) << 5);
-			writeVal = currentMIPS->vi[voffset[vt]];
+			memcpy(&writeVal, &currentMIPS->v[voffset[vt]], sizeof(writeVal));
 			prevVal = Memory::Read_U32(addr);
 		}
 

--- a/Core/MIPS/MIPSDebugInterface.h
+++ b/Core/MIPS/MIPSDebugInterface.h
@@ -89,15 +89,18 @@ public:
 	}
 
 	u32 GetRegValue(int cat, int index) override {
+		uint32_t temp;
 		switch (cat) {
 		case 0:
 			return cpu->r[index];
 
 		case 1:
-			return cpu->fi[index];
+			memcpy(&temp, &cpu->f[index], sizeof(uint32_t));
+			return temp;
 
 		case 2:
-			return cpu->vi[voffset[index]];
+			memcpy(&temp, &cpu->v[voffset[index]], sizeof(uint32_t));
+			return temp;
 
 		default:
 			return 0;
@@ -105,6 +108,7 @@ public:
 	}
 
 	void SetRegValue(int cat, int index, u32 value) override {
+		float valuef;
 		switch (cat) {
 		case 0:
 			if (index != 0)
@@ -112,11 +116,13 @@ public:
 			break;
 
 		case 1:
-			cpu->fi[index] = value;
+			memcpy(&valuef, &value, sizeof(float));
+			cpu->f[index] = valuef;
 			break;
 
 		case 2:
-			cpu->vi[voffset[index]] = value;
+			memcpy(&valuef, &value, sizeof(float));
+			cpu->v[voffset[index]] = valuef;
 			break;
 
 		default:

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -3466,9 +3466,10 @@ void Jit::Comp_Viim(MIPSOpcode op) {
 	fpr.SimpleRegsV(&dreg, V_Single, MAP_NOINIT | MAP_DIRTY);
 
 	s32 imm = SignExtend16ToS32(op);
-	FP32 fp;
-	fp.f = (float)imm;
-	MOV(32, R(TEMPREG), Imm32(fp.u));
+	float fp = (float)imm;
+	uint32_t fpu;
+	memcpy(&fpu, &fp, sizeof(uint32_t));
+	MOV(32, R(TEMPREG), Imm32(fpu));
 	fpr.MapRegV(dreg, MAP_DIRTY | MAP_NOINIT);
 	MOVD_xmm(fpr.VX(dreg), R(TEMPREG));
 
@@ -3490,8 +3491,10 @@ void Jit::Comp_Vfim(MIPSOpcode op) {
 
 	FP16 half;
 	half.u = op & 0xFFFF;
-	FP32 fval = half_to_float_fast5(half);
-	MOV(32, R(TEMPREG), Imm32(fval.u));
+	float fval = half_to_float_fast5(half);
+	uint32_t fvalu;
+	memcpy(&fvalu, &fval, sizeof(uint32_t));
+	MOV(32, R(TEMPREG), Imm32(fvalu));
 	fpr.MapRegV(dreg, MAP_DIRTY | MAP_NOINIT);
 	MOVD_xmm(fpr.VX(dreg), R(TEMPREG));
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -139,15 +139,11 @@ TextureCacheCommon::~TextureCacheCommon() {
 
 // Produces a signed 1.23.8 value.
 static int TexLog2(float delta) {
-	union FloatBits {
-		float f;
-		u32 u;
-	};
-	FloatBits f;
-	f.f = delta;
+	uint32_t floatBits;
+	memcpy(&floatBits, &delta, sizeof(uint32_t));
 	// Use the exponent as the tex level, and the top mantissa bits for a frac.
 	// We can't support more than 8 bits of frac, so truncate.
-	int useful = (f.u >> 15) & 0xFFFF;
+	int useful = (floatBits >> 15) & 0xFFFF;
 	// Now offset so the exponent aligns with log2f (exp=127 is 0.)
 	return useful - 127 * 256;
 }

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -507,20 +507,16 @@ RasterizerState OptimizeFlatRasterizerState(const RasterizerState &origState, co
 }
 
 static inline u8 ClampFogDepth(float fogdepth) {
-	union FloatBits {
-		float f;
-		u32 u;
-	};
-	FloatBits f;
-	f.f = fogdepth;
+	uint32_t floatBits;
+	memcpy(&floatBits, &fogdepth, sizeof(uint32_t));
 
-	u32 exp = f.u >> 23;
-	if ((f.u & 0x80000000) != 0 || exp <= 126 - 8)
+	u32 exp = floatBits >> 23;
+	if ((floatBits & 0x80000000) != 0 || exp <= 126 - 8)
 		return 0;
 	if (exp > 126)
 		return 255;
 
-	u32 mantissa = (f.u & 0x007FFFFF) | 0x00800000;
+	u32 mantissa = (floatBits & 0x007FFFFF) | 0x00800000;
 	return mantissa >> (16 + 126 - exp);
 }
 
@@ -613,15 +609,11 @@ static inline Vec4IntResult SOFTRAST_CALL ApplyTexturingSingle(float s, float t,
 
 // Produces a signed 1.27.4 value.
 static int TexLog2(float delta) {
-	union FloatBits {
-		float f;
-		u32 u;
-	};
-	FloatBits f;
-	f.f = delta;
+	uint32_t floatBits;
+	memcpy(&floatBits, &delta, sizeof(uint32_t));
 	// Use the exponent as the tex level, and the top mantissa bits for a frac.
 	// We can't support more than 4 bits of frac, so truncate.
-	int useful = (f.u >> 19) & 0x0FFF;
+	int useful = (floatBits >> 19) & 0x0FFF;
 	// Now offset so the exponent aligns with log2f (exp=127 is 0.)
 	return useful - 127 * 16;
 }

--- a/Windows/Debugger/Debugger_VFPUDlg.cpp
+++ b/Windows/Debugger/Debugger_VFPUDlg.cpp
@@ -167,7 +167,8 @@ BOOL CVFPUDlg::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					for (int row = 0; row<4; row++)
 					{
 						float val = mipsr4k.v[voffset[column*32+row+matrix*4]];
-						u32 hex = mipsr4k.vi[voffset[column*32+row+matrix*4]];
+						u32 hex;
+						memcpy(&hex, &val, sizeof(uint32_t));
 						switch (mode)
 						{
 						case 0: temp_len = sprintf_s(temp,"%f",val); break;


### PR DESCRIPTION
It seems like the consensus is that this is undefined behavior in C++, though not newer C.  Let's just avoid it, whether or not it fixes the M1 thing.  It does seem like it would explain it, though.  It's unfortunate, this may make debug mode a bit slower for IR/interp...

Might've missed some but I think I got most of them.

-[Unknown]