### PR TITLE
The first step to  allow .sprx to load

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1266,7 +1266,8 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 	}
 
 	// DO NOT change to else if, see above.
-	if (*magicPtr != 0x464c457f) {
+	// 0x50535000 is for Fushigi no Dungeon - Fuurai no Shiren 4 Plus - Kami no Hitomi to Akuma no Heso (Japan) (v3.10)
+	if (*magicPtr != 0x464c457f && *magicPtr != 0x50535000) {
 		ERROR_LOG(SCEMODULE, "Wrong magic number %08x", *magicPtr);
 		*error_string = "File corrupt";
 		if (newptr)


### PR DESCRIPTION
It is for Fushigi no Dungeon - Fuurai no Shiren 4 Plus - Kami no Hitomi to Akuma no Heso (Japan) (v3.10)

Orignal log:
04:21:901 LoadModuleTh E[SCEMODULE]: HLE\sceKernelModule.cpp:1270 Wrong magic number 50535000
04:21:901 LoadModuleTh E[LOADER]: HLE\sceKernelModule.cpp:2070 80020148=sceKernelLoadModuleNpDrm(ms0:/PSP/GAME/NPJH50698/f5psp.sprx, 00000000, 00000000): failed to load

Modify log:
57:24:317 user_main    I[HLE]: HLE\scePspNpDrm_user.cpp:9 call sceNpDrmSetLicenseeKey(0880a420)
57:24:350 user_main    I[SCEKERNEL]: HLE\sceKernelThread.cpp:2004 280=sceKernelCreateThread(LoadModuleThread, 08804384, 00000020, 2048, 00000000, 00000000)
57:24:350 user_main    I[SCEKERNEL]: HLE\sceKernelThread.cpp:2101 0=sceKernelStartThread(280, 35, 0880a3d4)
57:24:353 LoadModuleTh E[SCEMODULE]: HLE\sceKernelModule.cpp:1285 LoadInto failed with error 80020148
57:24:353 LoadModuleTh E[LOADER]: HLE\sceKernelModule.cpp:2070 80020148=sceKernelLoadModuleNpDrm(ms0:/PSP/GAME/NPJH50698/f5psp.sprx, 00000000, 00000000): failed to load
