### PR TITLE
UI: Highlight buttons on press in visual PSP map

### DIFF
--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -177,6 +177,9 @@ public:
 
 	const char *tag() const override { return "VisualMapping"; }
 
+	bool key(const KeyInput &key) override;
+	void axis(const AxisInput &axis) override;
+
 protected:
 	void CreateViews() override;
 


### PR DESCRIPTION
This makes two changes, because the latter made the UI a bit confusing alone:
 * When highlighting a focused button in the mock PSP, also display its label next to it.
 * When the mock PSP is displayed and a button is pressed, highlight just the interior of the button for a second.

This makes it a bit more obvious what buttons are mapped to what, although X/O will of course still do things if they are pressed.

On resize, the label might temporarily not be shown until you change focus.

-[Unknown]