### PR TITLE
#16869 Fix libretro Mac x64 build, add Mac arm64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,11 @@ include:
 
   # MacOS 64-bit
   - project: 'libretro-infrastructure/ci-templates'
-    file: '/osx-x64.yml'
+    file: '/osx-cmake-x64.yml'
+
+  # MacOS arm64
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/osx-cmake-arm64.yml'
     
   ################################## CELLULAR ################################
   # Android  
@@ -92,7 +96,16 @@ libretro-build-osx-x64:
   tags:
     - macosx-packaging
   extends:
-    - .libretro-osx-x64-make-default
+    - .libretro-osx-cmake-x86_64
+    - .core-defs
+    - .make-defs
+
+# MacOS 64-bit
+libretro-build-osx-arm64:
+  tags:
+    - macosx-packaging
+  extends:
+    - .libretro-osx-cmake-arm64
     - .core-defs
     - .make-defs
 

--- a/libretro/CMakeLists.txt
+++ b/libretro/CMakeLists.txt
@@ -22,7 +22,7 @@ if(ANDROID)
 endif()
 
 if(NOT MSVC)
-   if (IOS)
+   if (APPLE OR IOS)
    	target_link_libraries(ppsspp_libretro "-Wl")
    else()
    	target_link_libraries(ppsspp_libretro "-Wl,-Bsymbolic")


### PR DESCRIPTION
libretro does use cmake for Linux and Android so this moves Mac builds to be in line with that.

The Mac Metal build of RetroArch now has four graphics drivers:
- The gl graphics driver mostly works, though crashes for some content
- The glcore graphics driver displays a black screen, though the proper audio can be heard underneath
- The metal graphics driver displays a black screen, though the proper audio can be heard underneath
- The vulkan graphics driver crashes, I think due to a RetroArch bug.