### PR TITLE
Add facility to run tasks on dedicated threads using the ThreadManager interface

### DIFF
--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -213,7 +213,7 @@ public:
 	}
 
 private:
-	VulkanContext *vulkan_;
+	VulkanContext *vulkan_ = nullptr;
 	Promise<VkShaderModule> *module_ = nullptr;
 	VkShaderStageFlagBits vkstage_;
 	bool ok_ = false;

--- a/Common/Net/HTTPHeaders.h
+++ b/Common/Net/HTTPHeaders.h
@@ -18,11 +18,12 @@ public:
 	// Public variables since it doesn't make sense
 	// to bother with accessors for all these.
 	int status = 100;
-	// Intentional misspelling.
-	char *referer = nullptr;
+
+	char *referer = nullptr;  // Intentional misspelling.
 	char *user_agent = nullptr;
 	char *resource = nullptr;
 	char *params = nullptr;
+
 	int content_length = -1;
 	std::unordered_map<std::string, std::string> other;
 	enum RequestType {

--- a/Common/Net/HTTPServer.cpp
+++ b/Common/Net/HTTPServer.cpp
@@ -81,7 +81,7 @@ Request::~Request() {
 	}
 	delete in_;
 	if (!out_->Empty()) {
-		ERROR_LOG(IO, "Output not empty - connection abort?");
+		ERROR_LOG(IO, "Output not empty - connection abort? (%s)", this->header_.resource);
 	}
 	delete out_;
 }

--- a/Common/Thread/ThreadManager.h
+++ b/Common/Thread/ThreadManager.h
@@ -8,6 +8,7 @@
 enum class TaskType {
 	CPU_COMPUTE,
 	IO_BLOCKING,
+	DEDICATED_THREAD,  // These can never get stuck in queue behind others, but are more expensive to launch. Cannot use I/O.
 };
 
 // Implement this to make something that you can run on the thread manager.

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -98,12 +98,17 @@ static Promise<VkShaderModule> *CompileShaderModuleAsync(VulkanContext *vulkan, 
 
 #if defined(_DEBUG)
 	// Don't parallelize in debug mode, pathological behavior due to mutex locks in allocator which is HEAVILY used by glslang.
-	return Promise<VkShaderModule>::AlreadyDone(compile());
+	bool singleThreaded = true;
 #else
-	return Promise<VkShaderModule>::Spawn(&g_threadManager, compile, TaskType::CPU_COMPUTE);
+	bool singleThreaded = false;
 #endif
-}
 
+	if (singleThreaded) {
+		return Promise<VkShaderModule>::AlreadyDone(compile());
+	} else {
+		return Promise<VkShaderModule>::Spawn(&g_threadManager, compile, TaskType::CPU_COMPUTE);
+	}
+}
 
 VulkanFragmentShader::VulkanFragmentShader(VulkanContext *vulkan, FShaderID id, FragmentShaderFlags flags, const char *code)
 	: vulkan_(vulkan), id_(id), flags_(flags) {


### PR DESCRIPTION
Useful for things that should be run ASAP even if the threadpool is full, at a small extra cost. (Not recommended for very small tasks).

Considering using this to resolve the deadlocks in #16802.