### PR TITLE
libretro yaml fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ include:
 
   # MacOS 64-bit
   - project: 'libretro-infrastructure/ci-templates'
-    file: '/osx-cmake-x64.yml'
+    file: '/osx-cmake-x86.yml'
 
   # MacOS arm64
   - project: 'libretro-infrastructure/ci-templates'


### PR DESCRIPTION
Fix the libretro yaml to pull in the right template.

https://git.libretro.com/libretro-infrastructure/ci-templates/-/blob/master/osx-cmake-x86.yml

I've double checked all the other parts of my previous change and believe it should be good. I wish I knew how to verify the yaml before requesting a PR.