### PR TITLE
Fix vulkan mac libretro crash due to not creating the surface

### DIFF
--- a/libretro/LibretroVulkanContext.cpp
+++ b/libretro/LibretroVulkanContext.cpp
@@ -61,6 +61,8 @@ static bool create_device(retro_vulkan_context *context, VkInstance instance, Vk
 	vk->InitSurface(WINDOWSYSTEM_WIN32, nullptr, nullptr);
 #elif defined(__ANDROID__)
 	vk->InitSurface(WINDOWSYSTEM_ANDROID, nullptr, nullptr);
+#elif defined(VK_USE_PLATFORM_METAL_EXT)
+    vk->InitSurface(WINDOWSYSTEM_METAL_EXT, nullptr, nullptr);
 #elif defined(VK_USE_PLATFORM_XLIB_KHR)
 	vk->InitSurface(WINDOWSYSTEM_XLIB, nullptr, nullptr);
 #elif defined(VK_USE_PLATFORM_XCB_KHR)

--- a/libretro/libretro_vulkan.cpp
+++ b/libretro/libretro_vulkan.cpp
@@ -355,6 +355,9 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr_libretro(VkInstan
 #ifdef __ANDROID__
 		 || !strcmp(pName, "vkCreateAndroidSurfaceKHR")
 #endif
+#ifdef VK_USE_PLATFORM_METAL_EXT
+		 || !strcmp(pName, "vkCreateMetalSurfaceEXT")
+#endif
 #ifdef VK_USE_PLATFORM_XLIB_KHR
 		 || !strcmp(pName, "vkCreateXlibSurfaceKHR")
 #endif


### PR DESCRIPTION
This does not fix all of the libretro Vulkan Mac problems but is necessary.