### PR TITLE
GPU: Allow depth above 65535

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -914,9 +914,8 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 			screenManager()->RecreateAllViews();
 			if (host)
 				host->UpdateUI();
-				return UI::EVENT_DONE;
-			}
-		);
+			return UI::EVENT_DONE;
+		});
 		if (e.v)
 			langScreen->SetPopupOrigin(e.v);
 		screenManager()->push(langScreen);


### PR DESCRIPTION
Hopefully it rounds down for any == or <= tests.

This helps #16866 at least.  Note that it's obviously unsafe when `DepthSliceFactor()` is 1.0 (i.e. when 65535.0 is mapped to 1.0 in the depth buffer), since that would just mean a draw with Z=1234 and maxz=0xFF00 and then another draw with Z=1234 and maxz=0xFFFF would not match, i.e. `>=` might fail.  That can happen when shadows are being drawn, etc.

-[Unknown]