### PR TITLE
Avoid symbol collisions with RetroArch on mac

### DIFF
--- a/libretro/CMakeLists.txt
+++ b/libretro/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 
 if(NOT MSVC)
    if (APPLE OR IOS)
-   	target_link_libraries(ppsspp_libretro "-Wl")
+   	target_link_libraries(ppsspp_libretro "-Wl,-exported_symbols_list,${CMAKE_CURRENT_SOURCE_DIR}/libretro.osx.def")
    else()
    	target_link_libraries(ppsspp_libretro "-Wl,-Bsymbolic")
    endif()

--- a/libretro/libretro.osx.def
+++ b/libretro/libretro.osx.def
@@ -1,0 +1,27 @@
+#LIBRARY "libretro"
+#EXPORTS
+_retro_set_environment
+_retro_set_video_refresh
+_retro_set_audio_sample
+_retro_set_audio_sample_batch
+_retro_set_input_poll
+_retro_set_input_state
+_retro_init
+_retro_deinit
+_retro_api_version
+_retro_get_system_info
+_retro_get_system_av_info
+_retro_set_controller_port_device
+_retro_reset
+_retro_run
+_retro_serialize_size
+_retro_serialize
+_retro_unserialize
+_retro_cheat_reset
+_retro_cheat_set
+_retro_load_game
+_retro_load_game_special
+_retro_unload_game
+_retro_get_region
+_retro_get_memory_data
+_retro_get_memory_size


### PR DESCRIPTION
ppsspp_libretro.dylib and RetroArch both include glslang (among others) that cause symbol collisions. On Mac those symbols get resolved seemingly randomly and there isn't a great equivalent of `-Wl,-Bsymbolic`. So instead I've copied libretro.def and reformatted it for Xcode's linker. And now Vulkan works. (Modulo a build fix in armips.)