### PR TITLE
Restore defaults in a better way

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -137,12 +137,6 @@ struct ConfigSetting {
 		CustomButtonDefaultCallback customButton;
 	};
 
-	ConfigSetting(bool v)
-		: iniKey_(""), type_(TYPE_TERMINATOR), report_(false), save_(false), perGame_(false) {
-		ptr_.b = nullptr;
-		cb_.b = nullptr;
-	}
-
 	ConfigSetting(const char *ini, bool *v, bool def, bool save = true, bool perGame = false)
 		: iniKey_(ini), type_(TYPE_BOOL), report_(false), save_(save), perGame_(perGame) {
 		ptr_.b = v;
@@ -253,10 +247,6 @@ struct ConfigSetting {
 		: iniKey_(iniX), ini2_(iniY), ini3_(iniScale), ini4_(iniShow), type_(TYPE_TOUCH_POS), report_(false), save_(save), perGame_(perGame) {
 		ptr_.touchPos = v;
 		cb_.touchPos = def;
-	}
-
-	bool HasMore() const {
-		return type_ != TYPE_TERMINATOR;
 	}
 
 	// Should actually be called ReadFromIni or something.
@@ -420,10 +410,11 @@ struct ConfigSetting {
 	const char *ini4_ = nullptr;
 	const char *ini5_ = nullptr;
 
-	Type type_;
+	const Type type_;
+
 	bool report_;
-	bool save_;
-	bool perGame_;
+	const bool save_;
+	const bool perGame_;
 	SettingPtr ptr_;
 	DefaultValue default_{};
 	DefaultCallback cb_;
@@ -619,8 +610,6 @@ static const ConfigSetting generalSettings[] = {
 	ConfigSetting("EnablePlugins", &g_Config.bLoadPlugins, true, true, true),
 
 	ReportedConfigSetting("IgnoreCompatSettings", &g_Config.sIgnoreCompatSettings, "", true, true),
-
-	ConfigSetting(false),
 };
 
 static bool DefaultSasThread() {
@@ -638,8 +627,6 @@ static const ConfigSetting cpuSettings[] = {
 	ConfigSetting("PreloadFunctions", &g_Config.bPreloadFunctions, false, true, true),
 	ConfigSetting("JitDisableFlags", &g_Config.uJitDisableFlags, (uint32_t)0, true, true),
 	ReportedConfigSetting("CPUSpeed", &g_Config.iLockedCPUSpeed, 0, true, true),
-
-	ConfigSetting(false),
 };
 
 static int DefaultInternalResolution() {
@@ -923,8 +910,6 @@ static const ConfigSetting graphicsSettings[] = {
 
 	ConfigSetting("ShaderCache", &g_Config.bShaderCache, true, false, false),  // Doesn't save. Ini-only.
 	ConfigSetting("GpuLogProfiler", &g_Config.bGpuLogProfiler, false, true, false),
-
-	ConfigSetting(false),
 };
 
 static const ConfigSetting soundSettings[] = {
@@ -936,8 +921,6 @@ static const ConfigSetting soundSettings[] = {
 	ConfigSetting("AltSpeedVolume", &g_Config.iAltSpeedVolume, -1, true, true),
 	ConfigSetting("AudioDevice", &g_Config.sAudioDevice, "", true, false),
 	ConfigSetting("AutoAudioDevice", &g_Config.bAutoAudioDevice, true, true, false),
-
-	ConfigSetting(false),
 };
 
 static bool DefaultShowTouchControls() {
@@ -1066,8 +1049,6 @@ static const ConfigSetting controlSettings[] = {
 	ConfigSetting("MouseSmoothing", &g_Config.fMouseSmoothing, 0.9f, true, true),
 
 	ConfigSetting("SystemControls", &g_Config.bSystemControls, true, true, false),
-
-	ConfigSetting(false),
 };
 
 static const ConfigSetting networkSettings[] = {
@@ -1089,8 +1070,6 @@ static const ConfigSetting networkSettings[] = {
 	ConfigSetting("QuickChat3", &g_Config.sQuickChat2, "Quick Chat 3", true, true),
 	ConfigSetting("QuickChat4", &g_Config.sQuickChat3, "Quick Chat 4", true, true),
 	ConfigSetting("QuickChat5", &g_Config.sQuickChat4, "Quick Chat 5", true, true),
-
-	ConfigSetting(false),
 };
 
 static int DefaultSystemParamLanguage() {
@@ -1126,8 +1105,6 @@ static const ConfigSetting systemParamSettings[] = {
 	ReportedConfigSetting("EncryptSave", &g_Config.bEncryptSave, true, true, true),
 	ConfigSetting("SavedataUpgradeVersion", &g_Config.bSavedataUpgrade, true, true, false),
 	ConfigSetting("MemStickSize", &g_Config.iMemStickSizeGB, 16, true, false),
-
-	ConfigSetting(false),
 };
 
 static const ConfigSetting debuggerSettings[] = {
@@ -1155,28 +1132,20 @@ static const ConfigSetting debuggerSettings[] = {
 	ConfigSetting("FuncHashMap", &g_Config.bFuncHashMap, false),
 	ConfigSetting("MemInfoDetailed", &g_Config.bDebugMemInfoDetailed, false),
 	ConfigSetting("DrawFrameGraph", &g_Config.bDrawFrameGraph, false),
-
-	ConfigSetting(false),
 };
 
 static const ConfigSetting jitSettings[] = {
 	ReportedConfigSetting("DiscardRegsOnJRRA", &g_Config.bDiscardRegsOnJRRA, false, false),
-
-	ConfigSetting(false),
 };
 
 static const ConfigSetting upgradeSettings[] = {
 	ConfigSetting("UpgradeMessage", &g_Config.upgradeMessage, ""),
 	ConfigSetting("UpgradeVersion", &g_Config.upgradeVersion, ""),
 	ConfigSetting("DismissedVersion", &g_Config.dismissedVersion, ""),
-
-	ConfigSetting(false),
 };
 
 static const ConfigSetting themeSettings[] = {
 	ConfigSetting("ThemeName", &g_Config.sThemeName, "Default", true, false),
-
-	ConfigSetting(false),
 };
 
 
@@ -1196,35 +1165,34 @@ static const ConfigSetting vrSettings[] = {
 	ConfigSetting("VRHeadRotationScale", &g_Config.fHeadRotationScale, 5.0f),
 	ConfigSetting("VRHeadRotationSmoothing", &g_Config.bHeadRotationSmoothing, false),
 	ConfigSetting("VRHeadRotation", &g_Config.iHeadRotation, 0),
-
-	ConfigSetting(false),
 };
 
 struct ConfigSectionSettings {
 	const char *section;
 	const ConfigSetting *settings;
+	size_t settingsCount;
 };
 
 static const ConfigSectionSettings sections[] = {
-	{"General", generalSettings},
-	{"CPU", cpuSettings},
-	{"Graphics", graphicsSettings},
-	{"Sound", soundSettings},
-	{"Control", controlSettings},
-	{"Network", networkSettings},
-	{"SystemParam", systemParamSettings},
-	{"Debugger", debuggerSettings},
-	{"JIT", jitSettings},
-	{"Upgrade", upgradeSettings},
-	{"Theme", themeSettings},
-	{"VR", vrSettings},
+	{"General", generalSettings, ARRAY_SIZE(generalSettings)},
+	{"CPU", cpuSettings, ARRAY_SIZE(cpuSettings)},
+	{"Graphics", graphicsSettings, ARRAY_SIZE(graphicsSettings)},
+	{"Sound", soundSettings, ARRAY_SIZE(soundSettings)},
+	{"Control", controlSettings, ARRAY_SIZE(controlSettings)},
+	{"Network", networkSettings, ARRAY_SIZE(networkSettings)},
+	{"SystemParam", systemParamSettings, ARRAY_SIZE(systemParamSettings)},
+	{"Debugger", debuggerSettings, ARRAY_SIZE(debuggerSettings)},
+	{"JIT", jitSettings, ARRAY_SIZE(jitSettings)},
+	{"Upgrade", upgradeSettings, ARRAY_SIZE(upgradeSettings)},
+	{"Theme", themeSettings, ARRAY_SIZE(themeSettings)},
+	{"VR", vrSettings, ARRAY_SIZE(vrSettings)},
 };
 
 static void IterateSettings(IniFile &iniFile, std::function<void(Section *section, const ConfigSetting &setting)> func) {
 	for (size_t i = 0; i < ARRAY_SIZE(sections); ++i) {
 		Section *section = iniFile.GetOrCreateSection(sections[i].section);
-		for (auto setting = sections[i].settings; setting->HasMore(); ++setting) {
-			func(section, *setting);
+		for (size_t j = 0; j < sections[i].settingsCount; j++) {
+			func(section, sections[i].settings[j]);
 		}
 	}
 }
@@ -2051,8 +2019,8 @@ void Config::ResetControlLayout() {
 void Config::GetReportingInfo(UrlEncoder &data) {
 	for (size_t i = 0; i < ARRAY_SIZE(sections); ++i) {
 		const std::string prefix = std::string("config.") + sections[i].section;
-		for (auto setting = sections[i].settings; setting->HasMore(); ++setting) {
-			setting->Report(data, prefix);
+		for (size_t j = 0; j < sections[i].settingsCount; j++) {
+			sections[i].settings[j].Report(data, prefix);
 		}
 	}
 }

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -319,7 +319,8 @@ struct ConfigSetting {
 		}
 	}
 
-	void Set(Section *section) {
+	// Yes, this can be const because what's modified is not the ConfigSetting struct, but the value which is stored elsewhere.
+	void Set(Section *section) const {
 		if (!save_)
 			return;
 
@@ -363,7 +364,7 @@ struct ConfigSetting {
 		}
 	}
 
-	void Report(UrlEncoder &data, const std::string &prefix) {
+	void Report(UrlEncoder &data, const std::string &prefix) const {
 		if (!report_)
 			return;
 
@@ -503,12 +504,7 @@ static float DefaultUISaturation() {
 	return IsVREnabled() ? 1.5f : 1.0f;
 }
 
-struct ConfigSectionSettings {
-	const char *section;
-	ConfigSetting *settings;
-};
-
-static ConfigSetting generalSettings[] = {
+static const ConfigSetting generalSettings[] = {
 	ConfigSetting("FirstRun", &g_Config.bFirstRun, true),
 	ConfigSetting("RunCount", &g_Config.iRunCount, 0),
 	ConfigSetting("Enable Logging", &g_Config.bEnableLogging, true),
@@ -612,7 +608,7 @@ static bool DefaultSasThread() {
 	return cpu_info.num_cores > 1;
 }
 
-static ConfigSetting cpuSettings[] = {
+static const ConfigSetting cpuSettings[] = {
 	ReportedConfigSetting("CPUCore", &g_Config.iCpuCore, &DefaultCpuCore, true, true),
 	ReportedConfigSetting("SeparateSASThread", &g_Config.bSeparateSASThread, &DefaultSasThread, true, true),
 	ReportedConfigSetting("IOTimingMethod", &g_Config.iIOTimingMethod, IOTIMING_FAST, true, true),
@@ -818,7 +814,7 @@ std::string FastForwardModeToString(int v) {
 	return "CONTINUOUS";
 }
 
-static ConfigSetting graphicsSettings[] = {
+static const ConfigSetting graphicsSettings[] = {
 	ConfigSetting("EnableCardboardVR", &g_Config.bEnableCardboardVR, false, true, true),
 	ConfigSetting("CardboardScreenSize", &g_Config.iCardboardScreenSize, 50, true, true),
 	ConfigSetting("CardboardXShift", &g_Config.iCardboardXShift, 0, true, true),
@@ -912,7 +908,7 @@ static ConfigSetting graphicsSettings[] = {
 	ConfigSetting(false),
 };
 
-static ConfigSetting soundSettings[] = {
+static const ConfigSetting soundSettings[] = {
 	ConfigSetting("Enable", &g_Config.bEnableSound, true, true, true),
 	ConfigSetting("AudioBackend", &g_Config.iAudioBackend, 0, true, true),
 	ConfigSetting("ExtraAudioBuffering", &g_Config.bExtraAudioBuffering, false, true, false),
@@ -949,7 +945,7 @@ static const float defaultControlScale = 1.15f;
 static const ConfigTouchPos defaultTouchPosShow = { -1.0f, -1.0f, defaultControlScale, true };
 static const ConfigTouchPos defaultTouchPosHide = { -1.0f, -1.0f, defaultControlScale, false };
 
-static ConfigSetting controlSettings[] = {
+static const ConfigSetting controlSettings[] = {
 	ConfigSetting("HapticFeedback", &g_Config.bHapticFeedback, false, true, true),
 	ConfigSetting("ShowTouchCross", &g_Config.bShowTouchCross, true, true, true),
 	ConfigSetting("ShowTouchCircle", &g_Config.bShowTouchCircle, true, true, true),
@@ -1055,7 +1051,7 @@ static ConfigSetting controlSettings[] = {
 	ConfigSetting(false),
 };
 
-static ConfigSetting networkSettings[] = {
+static const ConfigSetting networkSettings[] = {
 	ConfigSetting("EnableWlan", &g_Config.bEnableWlan, false, true, true),
 	ConfigSetting("EnableAdhocServer", &g_Config.bEnableAdhocServer, false, true, true),
 	ConfigSetting("proAdhocServer", &g_Config.proAdhocServer, "socom.cc", true, true),
@@ -1091,7 +1087,7 @@ static int DefaultSystemParamLanguage() {
 	return defaultLang;
 }
 
-static ConfigSetting systemParamSettings[] = {
+static const ConfigSetting systemParamSettings[] = {
 	ReportedConfigSetting("PSPModel", &g_Config.iPSPModel, PSP_MODEL_SLIM, true, true),
 	ReportedConfigSetting("PSPFirmwareVersion", &g_Config.iFirmwareVersion, PSP_DEFAULT_FIRMWARE, true, true),
 	ConfigSetting("NickName", &g_Config.sNickName, "PPSSPP", true, true),
@@ -1115,7 +1111,7 @@ static ConfigSetting systemParamSettings[] = {
 	ConfigSetting(false),
 };
 
-static ConfigSetting debuggerSettings[] = {
+static const ConfigSetting debuggerSettings[] = {
 	ConfigSetting("DisasmWindowX", &g_Config.iDisasmWindowX, -1),
 	ConfigSetting("DisasmWindowY", &g_Config.iDisasmWindowY, -1),
 	ConfigSetting("DisasmWindowW", &g_Config.iDisasmWindowW, -1),
@@ -1144,13 +1140,13 @@ static ConfigSetting debuggerSettings[] = {
 	ConfigSetting(false),
 };
 
-static ConfigSetting jitSettings[] = {
+static const ConfigSetting jitSettings[] = {
 	ReportedConfigSetting("DiscardRegsOnJRRA", &g_Config.bDiscardRegsOnJRRA, false, false),
 
 	ConfigSetting(false),
 };
 
-static ConfigSetting upgradeSettings[] = {
+static const ConfigSetting upgradeSettings[] = {
 	ConfigSetting("UpgradeMessage", &g_Config.upgradeMessage, ""),
 	ConfigSetting("UpgradeVersion", &g_Config.upgradeVersion, ""),
 	ConfigSetting("DismissedVersion", &g_Config.dismissedVersion, ""),
@@ -1158,14 +1154,14 @@ static ConfigSetting upgradeSettings[] = {
 	ConfigSetting(false),
 };
 
-static ConfigSetting themeSettings[] = {
+static const ConfigSetting themeSettings[] = {
 	ConfigSetting("ThemeName", &g_Config.sThemeName, "Default", true, false),
 
 	ConfigSetting(false),
 };
 
 
-static ConfigSetting vrSettings[] = {
+static const ConfigSetting vrSettings[] = {
 	ConfigSetting("VREnable", &g_Config.bEnableVR, true),
 	ConfigSetting("VREnable6DoF", &g_Config.bEnable6DoF, true),
 	ConfigSetting("VREnableStereo", &g_Config.bEnableStereo, false),
@@ -1185,7 +1181,12 @@ static ConfigSetting vrSettings[] = {
 	ConfigSetting(false),
 };
 
-static ConfigSectionSettings sections[] = {
+struct ConfigSectionSettings {
+	const char *section;
+	const ConfigSetting *settings;
+};
+
+static const ConfigSectionSettings sections[] = {
 	{"General", generalSettings},
 	{"CPU", cpuSettings},
 	{"Graphics", graphicsSettings},
@@ -1200,7 +1201,7 @@ static ConfigSectionSettings sections[] = {
 	{"VR", vrSettings},
 };
 
-static void IterateSettings(IniFile &iniFile, std::function<void(Section *section, ConfigSetting *setting)> func) {
+static void IterateSettings(IniFile &iniFile, std::function<void(Section *section, const ConfigSetting &setting)> func) {
 	for (size_t i = 0; i < ARRAY_SIZE(sections); ++i) {
 		Section *section = iniFile.GetOrCreateSection(sections[i].section);
 		for (auto setting = sections[i].settings; setting->HasMore(); ++setting) {
@@ -1301,9 +1302,9 @@ bool Config::LoadAppendedConfig() {
 		return false;
 	}
 
-	IterateSettings(iniFile, [&iniFile](Section *section, ConfigSetting *setting) {
-		if (iniFile.Exists(section->name().c_str(), setting->iniKey_))
-			setting->Get(section);
+	IterateSettings(iniFile, [&iniFile](Section *section, const ConfigSetting &setting) {
+		if (iniFile.Exists(section->name().c_str(), setting.iniKey_))
+			setting.Get(section);
 	});
 
 	INFO_LOG(LOADER, "Loaded appended config '%s'.", appendedConfigFileName_.c_str());
@@ -1336,8 +1337,8 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 		// Continue anyway to initialize the config.
 	}
 
-	IterateSettings(iniFile, [](Section *section, ConfigSetting *setting) {
-		setting->Get(section);
+	IterateSettings(iniFile, [](Section *section, const ConfigSetting &setting) {
+		setting.Get(section);
 	});
 
 	iRunCount++;
@@ -1492,9 +1493,9 @@ bool Config::Save(const char *saveReason) {
 		// Need to do this somewhere...
 		bFirstRun = false;
 
-		IterateSettings(iniFile, [&](Section *section, ConfigSetting *setting) {
-			if (!bGameSpecific || !setting->perGame_) {
-				setting->Set(section);
+		IterateSettings(iniFile, [&](Section *section, const ConfigSetting &setting) {
+			if (!bGameSpecific || !setting.perGame_) {
+				setting.Set(section);
 			}
 		});
 
@@ -1878,9 +1879,9 @@ bool Config::saveGameConfig(const std::string &pGameId, const std::string &title
 
 	PreSaveCleanup(true);
 
-	IterateSettings(iniFile, [](Section *section, ConfigSetting *setting) {
-		if (setting->perGame_) {
-			setting->Set(section);
+	IterateSettings(iniFile, [](Section *section, const ConfigSetting &setting) {
+		if (setting.perGame_) {
+			setting.Set(section);
 		}
 	});
 
@@ -1935,9 +1936,9 @@ bool Config::loadGameConfig(const std::string &pGameId, const std::string &title
 			vPostShaderNames.push_back(it.second);
 	}
 
-	IterateSettings(iniFile, [](Section *section, ConfigSetting *setting) {
-		if (setting->perGame_) {
-			setting->Get(section);
+	IterateSettings(iniFile, [](Section *section, const ConfigSetting &setting) {
+		if (setting.perGame_) {
+			setting.Get(section);
 		}
 	});
 
@@ -1962,9 +1963,9 @@ void Config::unloadGameConfig() {
 		iniFile.Load(iniFilename_);
 
 		// Reload game specific settings back to standard.
-		IterateSettings(iniFile, [](Section *section, ConfigSetting *setting) {
-			if (setting->perGame_) {
-				setting->Get(section);
+		IterateSettings(iniFile, [](Section *section, const ConfigSetting &setting) {
+			if (setting.perGame_) {
+				setting.Get(section);
 			}
 		});
 


### PR DESCRIPTION
First, does some refactoring (ConfigSetting struct can be const since they only contain metadata), then implements restoring defaults without deleting the ini, by iterating through the settings.

And now restoring default without touching recents should actually work @iota97 :)

Do you see any problems with this?