### PR TITLE
Another (hopefully final) build fix for libretro mac x86_64

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,7 +98,7 @@ libretro-build-osx-x64:
   extends:
     - .libretro-osx-cmake-x86_64
     - .core-defs
-    - .make-defs
+    - .cmake-defs
 
 # MacOS 64-bit
 libretro-build-osx-arm64:
@@ -107,7 +107,7 @@ libretro-build-osx-arm64:
   extends:
     - .libretro-osx-cmake-arm64
     - .core-defs
-    - .make-defs
+    - .cmake-defs
 
 ################################### CELLULAR #################################
 # Android ARMv7a


### PR DESCRIPTION
The x86_64 mac build succeeded, but because some variables weren't properly set, it did not copy the built library correctly.

There will be another PR coming to fix the other arm64 build issues.