### PR TITLE
Fix texture alpha when texturing from full-alpha textures.

### DIFF
--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -199,7 +199,11 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 	}
 
 	if (dirtyUniforms & DIRTY_TEX_ALPHA_MUL) {
-		ub->texNoAlpha = gstate.isTextureAlphaUsed() ? 0.0f : 1.0f;
+		bool doTextureAlpha = gstate.isTextureAlphaUsed();
+		if (gstate_c.textureFullAlpha && gstate.getTextureFunction() != GE_TEXFUNC_REPLACE) {
+			doTextureAlpha = false;
+		}
+		ub->texNoAlpha = doTextureAlpha ? 0.0f : 1.0f;
 		ub->texMul = gstate.isColorDoublingEnabled() ? 2.0f : 1.0f;
 	}
 

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -549,7 +549,7 @@ struct GPUStateCache {
 	void SetTextureFullAlpha(bool fullAlpha) {
 		if (fullAlpha != textureFullAlpha) {
 			textureFullAlpha = fullAlpha;
-			Dirty(DIRTY_FRAGMENTSHADER_STATE);
+			Dirty(DIRTY_FRAGMENTSHADER_STATE | DIRTY_TEX_ALPHA_MUL);
 		}
 	}
 	void SetNeedShaderTexclamp(bool need) {


### PR DESCRIPTION
Fixes #16875

Tested some random games in addition to the GE dump from that issue, can't find any issues.