### PR TITLE
Quick fix for the lens flare in Burnout

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1659,7 +1659,7 @@ void FramebufferManagerCommon::ResizeFramebufFBO(VirtualFramebuffer *vfb, int w,
 		break;
 	}
 
-	if (vfb->usageFlags & FB_USAGE_COLOR_MIXED_DEPTH) {
+	if ((vfb->usageFlags & FB_USAGE_COLOR_MIXED_DEPTH) && !PSP_CoreParameter().compat.flags().ForceLowerResolutionForEffectsOn) {
 		force1x = false;
 	}
 	if (PSP_CoreParameter().compat.flags().Force04154000Download && vfb->fb_address == 0x04154000) {


### PR DESCRIPTION
We have to assume that ForceLowerResolutionForEffects has been set for good reason - in this case, the effect probably can't safely function without it.

Fixes #11100 once again, after it broke in https://github.com/hrydgard/ppsspp/commit/e5d67119a88877b1e442b2b7be170f92186a367c .