### PR TITLE
libretro: Add cpu_features flags to Android.mk

### DIFF
--- a/libretro/jni/Android.mk
+++ b/libretro/jni/Android.mk
@@ -5,7 +5,7 @@ ifneq ($(GIT_VERSION)," unknown")
 	COREFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 endif
 
-COREFLAGS  :=
+COREFLAGS  := -DSTACK_LINE_READER_BUFFER_SIZE=1024 -DHAVE_DLFCN_H
 CORE_DIR   := ../..
 FFMPEGDIR  := $(CORE_DIR)/ffmpeg
 FFMPEGLIBS += libavformat libavcodec libavutil libswresample libswscale


### PR DESCRIPTION
These should be needed.  Didn't try it / libretro stuff to confirm the full build, but it'll need these defines.

-[Unknown]