### PR TITLE
iOS: Disable jit in DefaultCpuCore()

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -60,7 +60,7 @@ http::Downloader g_DownloadManager;
 
 Config g_Config;
 
-bool jitForcedOff;
+static bool jitForcedOff;
 
 // Not in Config.h because it's #included a lot.
 struct ConfigPrivate {
@@ -477,9 +477,11 @@ std::string CreateRandMAC() {
 
 static int DefaultCpuCore() {
 #if PPSSPP_ARCH(ARM) || PPSSPP_ARCH(ARM64) || PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
-	return (int)CPUCore::JIT;
+	if (System_GetPropertyBool(SYSPROP_CAN_JIT))
+		return (int)CPUCore::JIT;
+	return (int)CPUCore::IR_JIT;
 #else
-	return (int)CPUCore::INTERPRETER;
+	return (int)CPUCore::IR_JIT;
 #endif
 }
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -29,8 +29,6 @@
 
 extern const char *PPSSPP_GIT_VERSION;
 
-extern bool jitForcedOff;
-
 enum ChatPositions {
 	BOTTOM_LEFT = 0,
 	BOTTOM_CENTER = 1,

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -758,13 +758,6 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 		}
 	}
 
-	if (System_GetPropertyBool(SYSPROP_CAN_JIT) == false && g_Config.iCpuCore == (int)CPUCore::JIT) {
-		// Just gonna force it to the IR interpreter on startup.
-		// We don't hide the option, but we make sure it's off on bootup. In case someone wants
-		// to experiment in future iOS versions or something...
-		jitForcedOff = true;
-	}
-
 	auto des = GetI18NCategory("DesktopUI");
 	// Note to translators: do not translate this/add this to PPSSPP-lang's files.
 	// It's intended to be custom for every user.


### PR DESCRIPTION
This means loading game-specific inis should properly auto-disable.

Also, let's fall back to IR here always.  No reason to default to INTERPRETER.

May help #16607.

-[Unknown]