### PR TITLE
Workaround for sin/cos issue in GTA on Mac (and maybe others)

### DIFF
--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -29,6 +29,13 @@
 #define V(i)   (currentMIPS->v[voffset[i]])
 #define VI(i)  (currentMIPS->vi[voffset[i]])
 
+// Flushes the angle to 0 if exponent smaller than this in vfpu_sin/vfpu_cos/vfpu_sincos.
+// Was measured to be around 0x68, but GTA on Mac is somehow super sensitive
+// to the shape of the sine curve which seem to be very slightly different.
+//
+// So setting a lower value.
+#define PRECISION_EXP_THRESHOLD 0x65
+
 union float2int {
 	uint32_t i;
 	float f;
@@ -899,7 +906,7 @@ float vfpu_sin(float a) {
 		return val.f;
 	}
 
-	if (k < 0x68) {
+	if (k < PRECISION_EXP_THRESHOLD) {
 		val.i &= 0x80000000;
 		return val.f;
 	}
@@ -945,7 +952,7 @@ float vfpu_cos(float a) {
 		return val.f;
 	}
 
-	if (k < 0x68)
+	if (k < PRECISION_EXP_THRESHOLD)
 		return 1.0f;
 
 	// Okay, now modulus by 4 to begin with (identical wave every 4.)
@@ -993,7 +1000,7 @@ void vfpu_sincos(float a, float &s, float &c) {
 		return;
 	}
 
-	if (k < 0x68) {
+	if (k < PRECISION_EXP_THRESHOLD) {
 		val.i &= 0x80000000;
 		s = val.f;
 		c = 1.0f;


### PR DESCRIPTION
Fixes #15149 

Turns out the game is hyper sensitive to the shape of the sin curve, so while we tried making its precision a bit more accurate to the hardware by reducing the precision, this resulted in something going slightly over one threshold or another due to the sin curve shape not being bit identical on all platforms. This just works around it by lowering the threshold for when we flush the angle to zero.

