### PR TITLE
Eat some cycles in sceGeListSync, count listsyncs and drawsyncs in gpu stats

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -383,6 +383,7 @@ static int sceGeListUpdateStallAddr(u32 displayListID, u32 stallAddress) {
 // 0 : wait for completion. 1:check and return
 int sceGeListSync(u32 displayListID, u32 mode) {
 	DEBUG_LOG(SCEGE, "sceGeListSync(dlid=%08x, mode=%08x)", displayListID, mode);
+	hleEatCycles(220);  // Fudged without measuring, copying sceGeContinue.
 	return gpu->ListSync(LIST_ID_MAGIC ^ displayListID, mode);
 }
 

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -74,6 +74,8 @@ struct GPUStatistics {
 
 	void ResetFrame() {
 		numDrawCalls = 0;
+		numDrawSyncs = 0;
+		numListSyncs = 0;
 		numCachedDrawCalls = 0;
 		numVertsSubmitted = 0;
 		numCachedVertsDrawn = 0;
@@ -104,6 +106,8 @@ struct GPUStatistics {
 
 	// Per frame statistics
 	int numDrawCalls;
+	int numDrawSyncs;
+	int numListSyncs;
 	int numCachedDrawCalls;
 	int numFlushes;
 	int numVertsSubmitted;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -675,6 +675,8 @@ void GPUCommon::DumpNextFrame() {
 }
 
 u32 GPUCommon::DrawSync(int mode) {
+	gpuStats.numDrawSyncs++;
+
 	if (mode < 0 || mode > 1)
 		return SCE_KERNEL_ERROR_INVALID_MODE;
 
@@ -723,6 +725,8 @@ void GPUCommon::CheckDrawSync() {
 }
 
 int GPUCommon::ListSync(int listid, int mode) {
+	gpuStats.numListSyncs++;
+
 	if (listid < 0 || listid >= DisplayListMaxCount)
 		return SCE_KERNEL_ERROR_INVALID_ID;
 
@@ -3461,7 +3465,7 @@ void GPUCommon::UpdateUVScaleOffset() {
 size_t GPUCommon::FormatGPUStatsCommon(char *buffer, size_t size) {
 	float vertexAverageCycles = gpuStats.numVertsSubmitted > 0 ? (float)gpuStats.vertexGPUCycles / (float)gpuStats.numVertsSubmitted : 0.0f;
 	return snprintf(buffer, size,
-		"DL processing time: %0.2f ms\n"
+		"DL processing time: %0.2f ms, %d drawsync, %d listsync\n"
 		"Draw calls: %d, flushes %d, clears %d (cached: %d)\n"
 		"Num Tracked Vertex Arrays: %d\n"
 		"Vertices: %d cached: %d uncached: %d\n"
@@ -3471,6 +3475,8 @@ size_t GPUCommon::FormatGPUStatsCommon(char *buffer, size_t size) {
 		"Copies: depth %d, color %d, reint %d, blend %d, selftex %d\n"
 		"GPU cycles executed: %d (%f per vertex)\n",
 		gpuStats.msProcessingDisplayLists * 1000.0f,
+		gpuStats.numDrawSyncs,
+		gpuStats.numListSyncs,
 		gpuStats.numDrawCalls,
 		gpuStats.numFlushes,
 		gpuStats.numClears,


### PR DESCRIPTION
Chose a conservative cycle count (same as sceGeContinue).

![image](https://user-images.githubusercontent.com/130929/217392143-e4835e2e-5265-4046-9db3-886e4c4ef331.png)

Syphon Filter calls it in a tight loop when you have the flashlight on, which is very costly in debug mode due to logging overhead (even though the log level is set higher). So this is a major speedup in this situation, might help a little bit in release builds too.

Also add a couple of stats, should have minimal overhead overall since a normal count per frame for these two are in the low single digits.