### PR TITLE
GPU: Skip depth resize when forcing 1x

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -485,7 +485,7 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(Framebuffer
 
 		if (!resized && renderScaleFactor_ != 1 && vfb->renderScaleFactor == 1) {
 			// Might be time to change this framebuffer - have we used depth?
-			if (vfb->usageFlags & FB_USAGE_COLOR_MIXED_DEPTH) {
+			if ((vfb->usageFlags & FB_USAGE_COLOR_MIXED_DEPTH) && !PSP_CoreParameter().compat.flags().ForceLowerResolutionForEffectsOn) {
 				ResizeFramebufFBO(vfb, vfb->width, vfb->height, true);
 				_assert_(vfb->renderScaleFactor != 1);
 			}


### PR DESCRIPTION
Regression from #16908, which only forced the size when resizing to 1x, but didn't stop it from trying to resize all the time.  This also prevents the resize.  Should help #16941, but I don't think I have Outrun.

-[Unknown]