### PR TITLE
Dialog: Warn when ignoring the dialog language

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -39,6 +39,23 @@ PSPDialog::PSPDialog(UtilityDialogType type) : dialogType_(type) {
 PSPDialog::~PSPDialog() {
 }
 
+void PSPDialog::InitCommon() {
+	UpdateCommon();
+}
+
+void PSPDialog::UpdateCommon() {
+	okButtonImg = ImageID("I_CIRCLE");
+	cancelButtonImg = ImageID("I_CROSS");
+	okButtonFlag = CTRL_CIRCLE;
+	cancelButtonFlag = CTRL_CROSS;
+	if (GetCommonParam() && GetCommonParam()->buttonSwap == 1) {
+		okButtonImg = ImageID("I_CROSS");
+		cancelButtonImg = ImageID("I_CIRCLE");
+		okButtonFlag = CTRL_CROSS;
+		cancelButtonFlag = CTRL_CIRCLE;
+	}
+}
+
 PSPDialog::DialogStatus PSPDialog::GetStatus() {
 	if (pendingStatusTicks != 0 && CoreTiming::GetTicks() >= pendingStatusTicks) {
 		bool changeAllowed = true;

--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -41,6 +41,10 @@ PSPDialog::~PSPDialog() {
 
 void PSPDialog::InitCommon() {
 	UpdateCommon();
+
+	if (GetCommonParam() && GetCommonParam()->language != g_Config.iLanguage) {
+		WARN_LOG(SCEUTILITY, "Game requested language %d, ignoring and using user language", GetCommonParam()->language);
+	}
 }
 
 void PSPDialog::UpdateCommon() {

--- a/Core/Dialog/PSPDialog.h
+++ b/Core/Dialog/PSPDialog.h
@@ -89,6 +89,8 @@ public:
 	int FinishShutdown();
 
 protected:
+	void InitCommon();
+	void UpdateCommon();
 	PPGeStyle FadedStyle(PPGeAlign align, float scale);
 	PPGeImageStyle FadedImageStyle();
 	void UpdateButtons();

--- a/Core/Dialog/PSPGamedataInstallDialog.cpp
+++ b/Core/Dialog/PSPGamedataInstallDialog.cpp
@@ -97,6 +97,7 @@ int PSPGamedataInstallDialog::Init(u32 paramAddr) {
 	memset(&request, 0, sizeof(request));
 	// Only copy the right size to support different request format
 	Memory::Memcpy(&request, paramAddr, size, "sceGamedataInstallInitStart");
+	InitCommon();
 
 	ChangeStatusInit(GAMEDATA_INIT_DELAY_US);
 	return 0;
@@ -113,6 +114,8 @@ int PSPGamedataInstallDialog::Update(int animSpeed) {
 		WARN_LOG_REPORT(SCEUTILITY, "sceUtilityGamedataInstallUpdate: invalid mode %d", param->mode);
 		return 0;
 	}
+
+	UpdateCommon();
 
 	// TODO: param->mode == 1 should show a prompt to confirm, then a progress bar.
 	// Any other mode (i.e. 0 or negative) should proceed and show no UI.

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -140,6 +140,7 @@ int PSPMsgDialog::Init(unsigned int paramAddr) {
 	ChangeStatusInit(MSG_INIT_DELAY_US);
 
 	UpdateButtons();
+	InitCommon();
 	StartFade(true);
 	return 0;
 }
@@ -282,19 +283,8 @@ int PSPMsgDialog::Update(int animSpeed) {
 		ChangeStatus(SCE_UTILITY_STATUS_FINISHED, 0);
 	} else {
 		UpdateButtons();
+		UpdateCommon();
 		UpdateFade(animSpeed);
-
-		okButtonImg = ImageID("I_CIRCLE");
-		cancelButtonImg = ImageID("I_CROSS");
-		okButtonFlag = CTRL_CIRCLE;
-		cancelButtonFlag = CTRL_CROSS;
-		if (messageDialog.common.buttonSwap == 1)
-		{
-			okButtonImg = ImageID("I_CROSS");
-			cancelButtonImg = ImageID("I_CIRCLE");
-			okButtonFlag = CTRL_CROSS;
-			cancelButtonFlag = CTRL_CIRCLE;
-		}
 
 		StartDraw();
 		// white -> RGB(168,173,189), black -> RGB(129,134,150)

--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -73,18 +73,8 @@ int PSPNetconfDialog::Init(u32 paramAddr) {
 	ChangeStatusInit(NET_INIT_DELAY_US);
 
 	// Eat any keys pressed before the dialog inited.
+	InitCommon();
 	UpdateButtons();
-	okButtonImg = ImageID("I_CIRCLE");
-	cancelButtonImg = ImageID("I_CROSS");
-	okButtonFlag = CTRL_CIRCLE;
-	cancelButtonFlag = CTRL_CROSS;
-	if (request.common.buttonSwap == 1)
-	{
-		okButtonImg = ImageID("I_CROSS");
-		cancelButtonImg = ImageID("I_CIRCLE");
-		okButtonFlag = CTRL_CROSS;
-		cancelButtonFlag = CTRL_CIRCLE;
-	}
 
 	connResult = -1;
 	scanInfosAddr = 0;
@@ -247,6 +237,7 @@ int PSPNetconfDialog::Update(int animSpeed) {
 	}
 
 	UpdateButtons();
+	UpdateCommon();
 	auto di = GetI18NCategory("Dialog");
 	auto err = GetI18NCategory("Error");
 	u64 now = (u64)(time_now_d() * 1000000.0);

--- a/Core/Dialog/PSPNpSigninDialog.cpp
+++ b/Core/Dialog/PSPNpSigninDialog.cpp
@@ -67,17 +67,7 @@ int PSPNpSigninDialog::Init(u32 paramAddr) {
 
 	// Eat any keys pressed before the dialog inited.
 	UpdateButtons();
-	okButtonImg = ImageID("I_CIRCLE");
-	cancelButtonImg = ImageID("I_CROSS");
-	okButtonFlag = CTRL_CIRCLE;
-	cancelButtonFlag = CTRL_CROSS;
-	if (request.common.buttonSwap == 1)
-	{
-		okButtonImg = ImageID("I_CROSS");
-		cancelButtonImg = ImageID("I_CIRCLE");
-		okButtonFlag = CTRL_CROSS;
-		cancelButtonFlag = CTRL_CIRCLE;
-	}
+	InitCommon();
 
 	//npSigninResult = -1;
 	startTime = (u64)(time_now_d() * 1000000.0);
@@ -244,6 +234,7 @@ int PSPNpSigninDialog::Update(int animSpeed) {
 	}
 
 	UpdateButtons();
+	UpdateCommon();
 	auto di = GetI18NCategory("Dialog");
 	auto err = GetI18NCategory("Error");
 	u64 now = (u64)(time_now_d() * 1000000.0);

--- a/Core/Dialog/PSPPlaceholderDialog.cpp
+++ b/Core/Dialog/PSPPlaceholderDialog.cpp
@@ -27,6 +27,7 @@ PSPPlaceholderDialog::~PSPPlaceholderDialog() {
 
 int PSPPlaceholderDialog::Init() {
 	ChangeStatus(SCE_UTILITY_STATUS_INITIALIZE, 0);
+	InitCommon();
 	return 0;
 }
 
@@ -38,6 +39,7 @@ int PSPPlaceholderDialog::Update(int animSpeed) {
 	} else if (ReadStatus() == SCE_UTILITY_STATUS_FINISHED) {
 		ChangeStatus(SCE_UTILITY_STATUS_SHUTDOWN, 0);
 	}
+	UpdateCommon();
 
 	return 0;
 }

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -270,6 +270,7 @@ int PSPSaveDialog::Init(int paramAddr)
 	}
 
 	param.ClearCaches();
+	InitCommon();
 	UpdateButtons();
 	StartFade(true);
 
@@ -654,16 +655,7 @@ int PSPSaveDialog::Update(int animSpeed)
 	UpdateButtons();
 	UpdateFade(animSpeed);
 
-	okButtonImg = ImageID("I_CIRCLE");
-	cancelButtonImg = ImageID("I_CROSS");
-	okButtonFlag = CTRL_CIRCLE;
-	cancelButtonFlag = CTRL_CROSS;
-	if (param.GetPspParam()->common.buttonSwap == 1) {
-		okButtonImg = ImageID("I_CROSS");
-		cancelButtonImg = ImageID("I_CIRCLE");
-		okButtonFlag = CTRL_CROSS;
-		cancelButtonFlag = CTRL_CIRCLE;
-	}
+	UpdateCommon();
 
 	auto di = GetI18NCategory("Dialog");
 

--- a/Core/Dialog/PSPScreenshotDialog.cpp
+++ b/Core/Dialog/PSPScreenshotDialog.cpp
@@ -84,11 +84,13 @@ int PSPScreenshotDialog::Init(u32 paramAddr) {
 
 	mode = params_->mode;
 	ChangeStatus(SCE_UTILITY_STATUS_INITIALIZE, 0);
+	InitCommon();
 
 	return 0;
 }
 
 int PSPScreenshotDialog::Update(int animSpeed) {
+	UpdateCommon();
 	if (UseAutoStatus()) {
 		if (ReadStatus() == SCE_UTILITY_STATUS_INITIALIZE) {
 			ChangeStatus(SCE_UTILITY_STATUS_RUNNING, 0);

--- a/Core/HLE/sceImpose.cpp
+++ b/Core/HLE/sceImpose.cpp
@@ -73,12 +73,13 @@ static u32 sceImposeGetBatteryIconStatus(u32 chargingPtr, u32 iconStatusPtr)
 	return 0;
 }
 
-static u32 sceImposeSetLanguageMode(u32 languageVal, u32 buttonVal)
-{
-	DEBUG_LOG(SCEUTILITY, "sceImposeSetLanguageMode(%08x, %08x)", languageVal, buttonVal);
+static u32 sceImposeSetLanguageMode(u32 languageVal, u32 buttonVal) {
 	language = languageVal;
 	buttonValue = buttonVal;
-	return 0;
+	if (language != g_Config.iLanguage) {
+		return hleLogWarning(SCEUTILITY, 0, "ignoring requested language");
+	}
+	return hleLogSuccessI(SCEUTILITY, 0);
 }
 
 static u32 sceImposeGetLanguageMode(u32 languagePtr, u32 btnPtr)
@@ -116,7 +117,7 @@ static u32 sceImposeGetBacklightOffTime() {
 //OSD stuff? home button?
 const HLEFunction sceImpose[] =
 {
-	{0X36AA6E91, &WrapU_UU<sceImposeSetLanguageMode>,      "sceImposeSetLanguageMode",      'x', "xx"},  // Seen
+	{0X36AA6E91, &WrapU_UU<sceImposeSetLanguageMode>,      "sceImposeSetLanguageMode",      'i', "ii"},
 	{0X381BD9E7, nullptr,                                  "sceImposeHomeButton",           '?', ""  },
 	{0X0F341BE4, nullptr,                                  "sceImposeGetHomePopup",         '?', ""  },
 	{0X5595A71A, nullptr,                                  "sceImposeSetHomePopup",         '?', ""  },


### PR DESCRIPTION
For the purposes of #16934, I think logging is enough - I don't really want to bother a typical user.  Also refactor away some duplicated logic.

-[Unknown]