### PR TITLE
Format memory tags using less allocations

### DIFF
--- a/Core/Debugger/MemBlockInfo.cpp
+++ b/Core/Debugger/MemBlockInfo.cpp
@@ -548,17 +548,6 @@ static const char *FindWriteTagByFlag(MemBlockFlags flags, uint32_t start, uint3
 	return nullptr;
 }
 
-std::string GetMemWriteTagAt(const char *prefix, uint32_t start, uint32_t size) {
-	const char *tag = FindWriteTagByFlag(MemBlockFlags::WRITE, start, size);
-	if (tag && strcmp(tag, "MemInit") != 0)
-		return std::string(prefix) + tag;
-	// Fall back to alloc and texture, especially for VRAM.  We prefer write above.
-	tag = FindWriteTagByFlag(MemBlockFlags::ALLOC | MemBlockFlags::TEXTURE, start, size);
-	if (tag)
-		return std::string(prefix) + tag;
-	return StringFromFormat("%s%08x_size_%08x", prefix, start, size);
-}
-
 size_t FormatMemWriteTagAt(char *buf, size_t sz, const char *prefix, uint32_t start, uint32_t size) {
 	const char *tag = FindWriteTagByFlag(MemBlockFlags::WRITE, start, size);
 	if (tag && strcmp(tag, "MemInit") != 0) {

--- a/Core/Debugger/MemBlockInfo.h
+++ b/Core/Debugger/MemBlockInfo.h
@@ -68,8 +68,6 @@ inline void NotifyMemInfo(MemBlockFlags flags, uint32_t start, uint32_t size, co
 std::vector<MemBlockInfo> FindMemInfo(uint32_t start, uint32_t size);
 std::vector<MemBlockInfo> FindMemInfoByFlag(MemBlockFlags flags, uint32_t start, uint32_t size);
 
-std::string GetMemWriteTagAt(const char *prefix, uint32_t start, uint32_t size);
-// Same as above but allocation-free.
 size_t FormatMemWriteTagAt(char *buf, size_t sz, const char *prefix, uint32_t start, uint32_t size);
 
 void MemBlockInfoInit();

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -159,12 +159,13 @@ static int Replace_memcpy() {
 	RETURN(destPtr);
 
 	if (MemBlockInfoDetailed(bytes)) {
-		const std::string tag = GetMemWriteTagAt("ReplaceMemcpy/", srcPtr, bytes);
-		NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, tag.c_str(), tag.size());
-		NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, tag.c_str(), tag.size());
+		char tagData[128];
+		size_t tagSize = FormatMemWriteTagAt(tagData, sizeof(tagData), "ReplaceMemcpy/", srcPtr, bytes);
+		NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, tagData, tagSize);
+		NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, tagData, tagSize);
 
 		// It's pretty common that games will copy video data.
-		if (tag == "ReplaceMemcpy/VideoDecode" || tag == "ReplaceMemcpy/VideoDecodeRange") {
+		if (!strcmp(tagData, "ReplaceMemcpy/VideoDecode") || !strcmp(tagData, "ReplaceMemcpy/VideoDecodeRange")) {
 			if (bytes == 512 * 272 * 4) {
 				gpu->PerformWriteFormattedFromMemory(destPtr, bytes, 512, GE_FORMAT_8888);
 			}
@@ -211,12 +212,13 @@ static int Replace_memcpy_jak() {
 	RETURN(destPtr);
 
 	if (MemBlockInfoDetailed(bytes)) {
-		const std::string tag = GetMemWriteTagAt("ReplaceMemcpy/", srcPtr, bytes);
-		NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, tag.c_str(), tag.size());
-		NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, tag.c_str(), tag.size());
+		char tagData[128];
+		size_t tagSize = FormatMemWriteTagAt(tagData, sizeof(tagData), "ReplaceMemcpy/", srcPtr, bytes);
+		NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, tagData, tagSize);
+		NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, tagData, tagSize);
 
 		// It's pretty common that games will copy video data.
-		if (tag == "ReplaceMemcpy/VideoDecode" || tag == "ReplaceMemcpy/VideoDecodeRange") {
+		if (!strcmp(tagData, "ReplaceMemcpy/VideoDecode") || !strcmp(tagData, "ReplaceMemcpy/VideoDecodeRange")) {
 			if (bytes == 512 * 272 * 4) {
 				gpu->PerformWriteFormattedFromMemory(destPtr, bytes, 512, GE_FORMAT_8888);
 			}
@@ -250,9 +252,10 @@ static int Replace_memcpy16() {
 	RETURN(destPtr);
 
 	if (MemBlockInfoDetailed(bytes)) {
-		const std::string tag = GetMemWriteTagAt("ReplaceMemcpy16/", srcPtr, bytes);
-		NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, tag.c_str(), tag.size());
-		NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, tag.c_str(), tag.size());
+		char tagData[128];
+		size_t tagSize = FormatMemWriteTagAt(tagData, sizeof(tagData), "ReplaceMemcpy16/", srcPtr, bytes);
+		NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, tagData, tagSize);
+		NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, tagData, tagSize);
 	}
 
 	return 10 + bytes / 4;  // approximation
@@ -322,9 +325,10 @@ static int Replace_memmove() {
 	RETURN(destPtr);
 
 	if (MemBlockInfoDetailed(bytes)) {
-		const std::string tag = GetMemWriteTagAt("ReplaceMemmove/", srcPtr, bytes);
-		NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, tag.c_str(), tag.size());
-		NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, tag.c_str(), tag.size());
+		char tagData[128];
+		size_t tagSize = FormatMemWriteTagAt(tagData, sizeof(tagData), "ReplaceMemmove/", srcPtr, bytes);
+		NotifyMemInfo(MemBlockFlags::READ, srcPtr, bytes, tagData, tagSize);
+		NotifyMemInfo(MemBlockFlags::WRITE, destPtr, bytes, tagData, tagSize);
 	}
 
 	return 10 + bytes / 4;  // approximation

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -294,9 +294,10 @@ static int Replace_memcpy_swizzled() {
 	RETURN(0);
 
 	if (MemBlockInfoDetailed(pitch * h)) {
-		const std::string tag = GetMemWriteTagAt("ReplaceMemcpySwizzle/", srcPtr, pitch * h);
-		NotifyMemInfo(MemBlockFlags::READ, srcPtr, pitch * h, tag.c_str(), tag.size());
-		NotifyMemInfo(MemBlockFlags::WRITE, destPtr, pitch * h, tag.c_str(), tag.size());
+		char tagData[128];
+		size_t tagSize = FormatMemWriteTagAt(tagData, sizeof(tagData), "ReplaceMemcpySwizzle/", srcPtr, pitch * h);
+		NotifyMemInfo(MemBlockFlags::READ, srcPtr, pitch * h, tagData, tagSize);
+		NotifyMemInfo(MemBlockFlags::WRITE, destPtr, pitch * h, tagData, tagSize);
 	}
 
 	return 10 + (pitch * h) / 4;  // approximation

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1271,9 +1271,10 @@ u32 _AtracDecodeData(int atracID, u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u3
 							if (outbufPtr != 0) {
 								u32 outBytes = numSamples * atrac->outputChannels_ * sizeof(s16);
 								if (packetAddr != 0 && MemBlockInfoDetailed()) {
-									const std::string tag = GetMemWriteTagAt("AtracDecode/", packetAddr, packetSize);
-									NotifyMemInfo(MemBlockFlags::READ, packetAddr, packetSize, tag.c_str(), tag.size());
-									NotifyMemInfo(MemBlockFlags::WRITE, outbufPtr, outBytes, tag.c_str(), tag.size());
+									char tagData[128];
+									size_t tagSize = FormatMemWriteTagAt(tagData, sizeof(tagData), "AtracDecode/", packetAddr, packetSize);
+									NotifyMemInfo(MemBlockFlags::READ, packetAddr, packetSize, tagData, tagSize);
+									NotifyMemInfo(MemBlockFlags::WRITE, outbufPtr, outBytes, tagData, tagSize);
 								} else {
 									NotifyMemInfo(MemBlockFlags::WRITE, outbufPtr, outBytes, "AtracDecode");
 								}

--- a/Core/HLE/sceDeflt.cpp
+++ b/Core/HLE/sceDeflt.cpp
@@ -59,9 +59,10 @@ static int CommonDecompress(int windowBits, u32 OutBuffer, int OutBufferLength, 
 	}
 
 	if (MemBlockInfoDetailed(stream.total_in, stream.total_out)) {
-		const std::string tag = GetMemWriteTagAt("sceDeflt/", InBuffer, stream.total_in);
-		NotifyMemInfo(MemBlockFlags::READ, InBuffer, stream.total_in, tag.c_str(), tag.size());
-		NotifyMemInfo(MemBlockFlags::WRITE, OutBuffer, stream.total_out, tag.c_str(), tag.size());
+		char tagData[128];
+		size_t tagSize = FormatMemWriteTagAt(tagData, sizeof(tagData), "sceDeflt/", InBuffer, stream.total_in);
+		NotifyMemInfo(MemBlockFlags::READ, InBuffer, stream.total_in, tagData, tagSize);
+		NotifyMemInfo(MemBlockFlags::WRITE, OutBuffer, stream.total_out, tagData, tagSize);
 	}
 
 	return hleLogSuccessI(HLE, stream.total_out);

--- a/Core/HLE/sceDmac.cpp
+++ b/Core/HLE/sceDmac.cpp
@@ -52,8 +52,9 @@ static int __DmacMemcpy(u32 dst, u32 src, u32 size) {
 	if (!skip && size != 0) {
 		currentMIPS->InvalidateICache(src, size);
 		if (MemBlockInfoDetailed(size)) {
-			const std::string tag = GetMemWriteTagAt("DmacMemcpy/", src, size);
-			Memory::Memcpy(dst, src, size, tag.c_str(), tag.size());
+			char tagData[128];
+			size_t tagSize = FormatMemWriteTagAt(tagData, sizeof(tagData), "DmacMemcpy/", src, size);
+			Memory::Memcpy(dst, src, size, tagData, tagSize);
 		} else {
 			Memory::Memcpy(dst, src, size, "DmacMemcpy");
 		}

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -657,9 +657,10 @@ static u32 sceKernelMemcpy(u32 dst, u32 src, u32 size)
 	}
 
 	if (MemBlockInfoDetailed(size)) {
-		const std::string tag = GetMemWriteTagAt("KernelMemcpy/", src, size);
-		NotifyMemInfo(MemBlockFlags::READ, src, size, tag.c_str(), tag.size());
-		NotifyMemInfo(MemBlockFlags::WRITE, dst, size, tag.c_str(), tag.size());
+		char tagData[128];
+		size_t tagSize = FormatMemWriteTagAt(tagData, sizeof(tagData), "KernelMemcpy/", src, size);
+		NotifyMemInfo(MemBlockFlags::READ, src, size, tagData, tagSize);
+		NotifyMemInfo(MemBlockFlags::WRITE, dst, size, tagData, tagSize);
 	}
 
 	return dst;

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -693,9 +693,10 @@ static u32 sysclib_memcpy(u32 dst, u32 src, u32 size) {
 		memcpy(Memory::GetPointerWriteUnchecked(dst), Memory::GetPointerUnchecked(src), size);
 	}
 	if (MemBlockInfoDetailed(size)) {
-		const std::string tag = GetMemWriteTagAt("KernelMemcpy/", src, size);
-		NotifyMemInfo(MemBlockFlags::READ, src, size, tag.c_str(), tag.size());
-		NotifyMemInfo(MemBlockFlags::WRITE, dst, size, tag.c_str(), tag.size());
+		char tagData[128];
+		size_t tagSize = FormatMemWriteTagAt(tagData, sizeof(tagData), "KernelMemcpy/", src, size);
+		NotifyMemInfo(MemBlockFlags::READ, src, size, tagData, tagSize);
+		NotifyMemInfo(MemBlockFlags::WRITE, dst, size, tagData, tagSize);
 	}
 	return dst;
 }
@@ -796,9 +797,10 @@ static u32 sysclib_memmove(u32 dst, u32 src, u32 size) {
 		memmove(Memory::GetPointerWriteUnchecked(dst), Memory::GetPointerUnchecked(src), size);
 	}
 	if (MemBlockInfoDetailed(size)) {
-		const std::string tag = GetMemWriteTagAt("KernelMemmove/", src, size);
-		NotifyMemInfo(MemBlockFlags::READ, src, size, tag.c_str(), tag.size());
-		NotifyMemInfo(MemBlockFlags::WRITE, dst, size, tag.c_str(), tag.size());
+		char tagData[128];
+		size_t tagSize = FormatMemWriteTagAt(tagData, sizeof(tagData), "KernelMemmove/", src, size);
+		NotifyMemInfo(MemBlockFlags::READ, src, size, tagData, tagSize);
+		NotifyMemInfo(MemBlockFlags::WRITE, dst, size, tagData, tagSize);
 	}
 	return 0;
 }


### PR DESCRIPTION
Already replaced the hottest ones, this just takes care of the rest.

While this makes the code very slightly uglier, it's not that bad and some of these can be called in hot loops, and the existing path just makes too many allocations with those strings.