### PR TITLE
Depth scale cleanup

### DIFF
--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -55,9 +55,9 @@ void GenerateDepalShader300(ShaderWriter &writer, const DepalConfig &config) {
 	// NOTE: This swizzle can be made to work with any power-of-2 resolution scaleFactor by shifting
 	// the bits around, but not sure how to handle 3x scaling. For now this is 1x-only (rough edges at higher resolutions).
 	if (config.bufferFormat == GE_FORMAT_DEPTH16) {
-		DepthScaleFactors factors = GetDepthScaleFactors();
-		writer.ConstFloat("z_scale", factors.scale);
-		writer.ConstFloat("z_offset", factors.offset);
+		DepthScaleFactors factors = GetDepthScaleFactors(gstate_c.UseFlags());
+		writer.ConstFloat("z_scale", factors.ScaleU16());
+		writer.ConstFloat("z_offset", factors.Offset());
 		if (config.depthUpperBits == 0x2) {
 			writer.C(R"(
   int x = int((texcoord.x / scaleFactor) * texSize.x);
@@ -116,7 +116,7 @@ void GenerateDepalShader300(ShaderWriter &writer, const DepalConfig &config) {
 		writer.C("  int index = (a << 15) | (b << 10) | (g << 5) | (r);\n");
 		break;
 	case GE_FORMAT_DEPTH16:
-		// Remap depth buffer.
+		// Decode depth buffer.
 		writer.C("  float depth = (color.x - z_offset) * z_scale;\n");
 
 		if (config.bufferFormat == GE_FORMAT_DEPTH16 && config.textureFormat == GE_TFMT_5650) {
@@ -161,9 +161,9 @@ void GenerateDepalShaderFloat(ShaderWriter &writer, const DepalConfig &config) {
 	const int mask = config.mask;
 
 	if (config.bufferFormat == GE_FORMAT_DEPTH16) {
-		DepthScaleFactors factors = GetDepthScaleFactors();
-		writer.ConstFloat("z_scale", factors.scale);
-		writer.ConstFloat("z_offset", factors.offset);
+		DepthScaleFactors factors = GetDepthScaleFactors(gstate_c.UseFlags());
+		writer.ConstFloat("z_scale", factors.ScaleU16());
+		writer.ConstFloat("z_offset", factors.Offset());
 	}
 
 	writer.C("  vec4 index = ").SampleTexture2D("tex", "v_texcoord").C(";\n");

--- a/GPU/Common/DepthBufferCommon.cpp
+++ b/GPU/Common/DepthBufferCommon.cpp
@@ -227,7 +227,7 @@ bool FramebufferManagerCommon::ReadbackDepthbuffer(Draw::Framebuffer *fbo, int x
 			ub.u_depthFactor[0] = 0.0f;
 			ub.u_depthFactor[1] = fudgeFactor;
 		} else {
-			const float factor = DepthSliceFactor();
+			const float factor = DepthSliceFactor(gstate_c.UseFlags());
 			ub.u_depthFactor[0] = -0.5f * (factor - 1.0f) * (1.0f / factor);
 			ub.u_depthFactor[1] = factor * fudgeFactor;
 		}
@@ -276,10 +276,10 @@ bool FramebufferManagerCommon::ReadbackDepthbuffer(Draw::Framebuffer *fbo, int x
 		// We downloaded float values directly in this case.
 		uint16_t *dest = pixels;
 		const float *packedf = (float *)convBuf_;
-		DepthScaleFactors depthScale = GetDepthScaleFactors();
+		DepthScaleFactors depthScale = GetDepthScaleFactors(gstate_c.UseFlags());
 		for (int yp = 0; yp < destH; ++yp) {
 			for (int xp = 0; xp < destW; ++xp) {
-				float scaled = depthScale.Apply(packedf[xp]);
+				float scaled = depthScale.DecodeToU16(packedf[xp]);
 				if (scaled <= 0.0f) {
 					dest[xp] = 0;
 				} else if (scaled >= 65535.0f) {

--- a/GPU/Common/DepthBufferCommon.h
+++ b/GPU/Common/DepthBufferCommon.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/GPU/Common/DepthBufferCommon.h
+++ b/GPU/Common/DepthBufferCommon.h
@@ -1,1 +1,0 @@
-#pragma once

--- a/GPU/Common/Draw2D.cpp
+++ b/GPU/Common/Draw2D.cpp
@@ -108,10 +108,10 @@ Draw2DPipelineInfo GenerateDraw2D565ToDepthFs(ShaderWriter &writer) {
 	writer.C("  vec4 outColor = vec4(0.0, 0.0, 0.0, 0.0);\n");
 	// Unlike when just copying a depth buffer, here we're generating new depth values so we'll
 	// have to apply the scaling.
-	DepthScaleFactors factors = GetDepthScaleFactors();
+	DepthScaleFactors factors = GetDepthScaleFactors(gstate_c.UseFlags());
 	writer.C("  vec3 rgb = ").SampleTexture2D("tex", "v_texcoord.xy").C(".xyz;\n");
 	writer.F("  highp float depthValue = (floor(rgb.x * 31.99) + floor(rgb.y * 63.99) * 32.0 + floor(rgb.z * 31.99) * 2048.0); \n");
-	writer.F("  gl_FragDepth = (depthValue / %f) + %f;\n", factors.scale, factors.offset);
+	writer.F("  gl_FragDepth = (depthValue / %f) + %f;\n", factors.ScaleU16(), factors.Offset());
 	writer.EndFSMain("outColor");
 
 	return Draw2DPipelineInfo{
@@ -128,7 +128,7 @@ Draw2DPipelineInfo GenerateDraw2D565ToDepthDeswizzleFs(ShaderWriter &writer) {
 	writer.C("  vec4 outColor = vec4(0.0, 0.0, 0.0, 0.0);\n");
 	// Unlike when just copying a depth buffer, here we're generating new depth values so we'll
 	// have to apply the scaling.
-	DepthScaleFactors factors = GetDepthScaleFactors();
+	DepthScaleFactors factors = GetDepthScaleFactors(gstate_c.UseFlags());
 	writer.C("  vec2 tsize = texSize;\n");
 	writer.C("  vec2 coord = v_texcoord * tsize;\n");
 	writer.F("  float strip = 4.0 * scaleFactor;\n");
@@ -137,7 +137,7 @@ Draw2DPipelineInfo GenerateDraw2D565ToDepthDeswizzleFs(ShaderWriter &writer) {
 	writer.C("  coord /= tsize;\n");
 	writer.C("  vec3 rgb = ").SampleTexture2D("tex", "coord").C(".xyz;\n");
 	writer.F("  highp float depthValue = (floor(rgb.x * 31.99) + floor(rgb.y * 63.99) * 32.0 + floor(rgb.z * 31.99) * 2048.0); \n");
-	writer.F("  gl_FragDepth = (depthValue / %f) + %f;\n", factors.scale, factors.offset);
+	writer.F("  gl_FragDepth = (depthValue / %f) + %f;\n", factors.ScaleU16(), factors.Offset());
 	writer.EndFSMain("outColor");
 	
 	return Draw2DPipelineInfo{

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -1185,13 +1185,13 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 	}
 
 	if (gstate_c.Use(GPU_ROUND_FRAGMENT_DEPTH_TO_16BIT)) {
-		const double scale = DepthSliceFactor() * 65535.0;
+		const double scale = DepthSliceFactor(gstate_c.UseFlags()) * 65535.0;
 
 		WRITE(p, "  highp float z = gl_FragCoord.z;\n");
 		if (gstate_c.Use(GPU_USE_ACCURATE_DEPTH)) {
 			// We center the depth with an offset, but only its fraction matters.
 			// When (DepthSliceFactor() - 1) is odd, it will be 0.5, otherwise 0.
-			if (((int)(DepthSliceFactor() - 1.0f) & 1) == 1) {
+			if (((int)(DepthSliceFactor(gstate_c.UseFlags()) - 1.0f) & 1) == 1) {
 				WRITE(p, "  z = (floor((z * %f) - (1.0 / 2.0)) + (1.0 / 2.0)) * (1.0 / %f);\n", scale, scale);
 			} else {
 				WRITE(p, "  z = floor(z * %f) * (1.0 / %f);\n", scale, scale);

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1063,7 +1063,7 @@ void FramebufferManagerCommon::NotifyRenderFramebufferSwitched(VirtualFramebuffe
 			float clearDepth = 0.0f;
 			if (vfb->usageFlags & FB_USAGE_INVALIDATE_DEPTH) {
 				depthAction = Draw::RPAction::CLEAR;
-				clearDepth = GetDepthScaleFactors().offset;
+				clearDepth = GetDepthScaleFactors(gstate_c.UseFlags()).Offset();
 				vfb->usageFlags &= ~FB_USAGE_INVALIDATE_DEPTH;
 			}
 			draw_->BindFramebufferAsRenderTarget(vfb->fbo, {Draw::RPAction::KEEP, depthAction, Draw::RPAction::KEEP, 0, clearDepth}, "FBSwitch");

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -522,13 +522,13 @@ float ToScaledDepthFromIntegerScale(u32 useFlags, float z) {
 	}
 
 	const float depthSliceFactor = DepthSliceFactor(useFlags);
-	const double doffset = 0.5 * (depthSliceFactor - 1.0) * (1.0 / depthSliceFactor);
 	if (useFlags & GPU_SCALE_DEPTH_FROM_24BIT_TO_16BIT) {
+		const double doffset = 0.5 * (depthSliceFactor - 1.0) / depthSliceFactor;
 		// Use one bit for each value, rather than 1.0 / (65535.0 * 256.0).
 		return (float)((double)z * (1.0 / 16777215.0) + doffset);
 	} else {
-		const float offset = 0.5f * (depthSliceFactor - 1.0f) * (1.0f / depthSliceFactor);
-		return z * (1.0f / depthSliceFactor) * (1.0f / 65535.0f) + offset;
+		const float offset = 0.5f * (depthSliceFactor - 1.0f) / depthSliceFactor;
+		return z / depthSliceFactor * (1.0f / 65535.0f) + offset;
 	}
 }
 

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -502,7 +502,7 @@ ReplaceBlendType ReplaceBlendWithShader(GEBufferFormat bufferFormat) {
 static const float DEPTH_SLICE_FACTOR_HIGH = 4.0f;
 static const float DEPTH_SLICE_FACTOR_16BIT = 256.0f;
 
-// The supported flag combinations
+// The supported flag combinations. TODO: Maybe they should be distilled down into an enum.
 //
 // 0 - "Old"-style GL depth.
 //     Or "Non-accurate depth" : effectively ignore minz / maxz. Map Z values based on viewport, which clamps.
@@ -525,7 +525,8 @@ static const float DEPTH_SLICE_FACTOR_16BIT = 256.0f;
 //     from the GPU to represent the 16-bit values the PSP had, to try to make everything round and
 //     z-fight (close to) the same way as on hardware, cheaply (cheaper than rounding depth in fragment shader).
 //     We automatically switch to this if Z tests for equality are used.
-//     Depth clamp has no noticeable effect here if set.
+//     Depth clamp has no effect on the depth scaling here if set, though will still be enabled
+//     and clamp wildly out of line values.
 //
 // Any other combinations of these particular flags are bogus (like for example a lonely GPU_USE_DEPTH_CLAMP).
 

--- a/GPU/Common/GPUStateUtils.h
+++ b/GPU/Common/GPUStateUtils.h
@@ -90,6 +90,7 @@ struct ViewportAndScissor {
 void ConvertViewportAndScissor(bool useBufferedRendering, float renderWidth, float renderHeight, int bufferWidth, int bufferHeight, ViewportAndScissor &out);
 void UpdateCachedViewportState(const ViewportAndScissor &vpAndScissor);
 
+// NOTE: See the .cpp file for detailed comment about how the use flags are interpreted.
 class DepthScaleFactors {
 public:
 	// This should only be used from GetDepthScaleFactors.
@@ -97,13 +98,13 @@ public:
 
 	// Decodes a value from a depth buffer to a value of range 0..65536
 	float DecodeToU16(float z) const {
-		return (z - offset_) * scale_;
+		return (float)((z - offset_) * scale_);
 	}
 
 	// Encodes a value from the range 0..65536 to a normalized depth value (0-1), in the
 	// range that we write to the depth buffer.
 	float EncodeFromU16(float z_u16) const {
-		return (z_u16 / scale_) + offset_;
+		return (float)(((double)z_u16 / scale_) + offset_);
 	}
 
 	float Offset() const { return (float)offset_; }
@@ -111,11 +112,14 @@ public:
 	// float Scale() const { return scale_ / 65535.0f; }
 
 private:
+	// Doubles hardly cost anything these days, and precision matters here.
 	double offset_;
 	double scale_;
 };
 
 DepthScaleFactors GetDepthScaleFactors(u32 useFlags);
+
+// These two will be replaced with just DepthScaleFactors.
 float ToScaledDepthFromIntegerScale(u32 useFlags, float z);
 float DepthSliceFactor(u32 useFlags);
 

--- a/GPU/Common/GPUStateUtils.h
+++ b/GPU/Common/GPUStateUtils.h
@@ -93,7 +93,7 @@ void UpdateCachedViewportState(const ViewportAndScissor &vpAndScissor);
 class DepthScaleFactors {
 public:
 	// This should only be used from GetDepthScaleFactors.
-	DepthScaleFactors(float offset, float scale) : offset_(offset), scale_(scale) {}
+	DepthScaleFactors(double offset, double scale) : offset_(offset), scale_(scale) {}
 
 	// Decodes a value from a depth buffer to a value of range 0..65536
 	float DecodeToU16(float z) const {
@@ -106,13 +106,13 @@ public:
 		return (z_u16 / scale_) + offset_;
 	}
 
-	float Offset() const { return offset_; }
-	float ScaleU16() const { return scale_; }
+	float Offset() const { return (float)offset_; }
+	float ScaleU16() const { return (float)scale_; }
 	// float Scale() const { return scale_ / 65535.0f; }
 
 private:
-	float offset_;
-	float scale_;
+	double offset_;
+	double scale_;
 };
 
 DepthScaleFactors GetDepthScaleFactors(u32 useFlags);

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -255,7 +255,7 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 		float minz = -((gstate_c.vpZOffset * halfActualZRange) - vpZCenter) - halfActualZRange;
 		float viewZScale = halfActualZRange * 2.0f;
 		// Account for the half pixel offset.
-		float viewZCenter = minz + (DepthSliceFactor() / 256.0f) * 0.5f;
+		float viewZCenter = minz + (DepthSliceFactor(gstate_c.UseFlags()) / 256.0f) * 0.5f;
 
 		ub->depthRange[0] = viewZScale;
 		ub->depthRange[1] = viewZCenter;

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -454,7 +454,7 @@ void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVt
 		if (matchingComponents && stencilNotMasked) {
 			result->color = transformed[1].color0_32;
 			// Need to rescale from a [0, 1] float.  This is the final transformed value.
-			result->depth = ToScaledDepthFromIntegerScale((int)(transformed[1].z * 65535.0f));
+			result->depth = ToScaledDepthFromIntegerScale(gstate_c.UseFlags(), (int)(transformed[1].z * 65535.0f));
 			result->action = SW_CLEAR;
 			gpuStats.numClears++;
 			return;

--- a/GPU/Directx9/FramebufferManagerDX9.cpp
+++ b/GPU/Directx9/FramebufferManagerDX9.cpp
@@ -74,13 +74,13 @@ bool FramebufferManagerDX9::ReadbackDepthbuffer(Draw::Framebuffer *fbo, int x, i
 	const u32 *packed = (const u32 *)locked.pBits;
 	u16 *depth = (u16 *)pixels;
 
-	DepthScaleFactors depthScale = GetDepthScaleFactors();
+	DepthScaleFactors depthScale = GetDepthScaleFactors(gstate_c.UseFlags());
 	// TODO: Optimize.
 	for (int yp = 0; yp < h; ++yp) {
 		for (int xp = 0; xp < w; ++xp) {
 			const int offset = (yp + y) * pixelsStride + x + xp;
 
-			float scaled = depthScale.Apply((packed[offset] & 0x00FFFFFF) * (1.0f / 16777215.0f));
+			float scaled = depthScale.DecodeToU16((packed[offset] & 0x00FFFFFF) * (1.0f / 16777215.0f));
 			if (scaled <= 0.0f) {
 				depth[offset] = 0;
 			} else if (scaled >= 65535.0f) {

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -466,7 +466,7 @@ void ShaderManagerDX9::VSUpdateUniforms(u64 dirtyUniforms) {
 		float minz = -((gstate_c.vpZOffset * halfActualZRange) - vpZCenter) - halfActualZRange;
 		float viewZScale = halfActualZRange * 2.0f;
 		// Account for the half pixel offset.
-		float viewZCenter = minz + (DepthSliceFactor() / 256.0f) * 0.5f;
+		float viewZCenter = minz + (DepthSliceFactor(gstate_c.UseFlags()) / 256.0f) * 0.5f;
 		float reverseScale = 2.0f * (1.0f / gstate_c.vpDepthScale);
 		float reverseTranslate = gstate_c.vpZOffset * 0.5f + 0.5f;
 

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -524,8 +524,10 @@ enum class SubmitType {
 };
 
 struct GPUStateCache {
-	bool Use(u32 flags) { return (useFlags_ & flags) != 0; } // Return true if ANY of flags are true.
-	bool UseAll(u32 flags) { return (useFlags_ & flags) == flags; } // Return true if ALL flags are true.
+	bool Use(u32 flags) const { return (useFlags_ & flags) != 0; } // Return true if ANY of flags are true.
+	bool UseAll(u32 flags) const { return (useFlags_ & flags) == flags; } // Return true if ALL flags are true.
+
+	u32 UseFlags() const { return useFlags_; }
 
 	uint64_t GetDirtyUniforms() { return dirty & DIRTY_ALL_UNIFORMS; }
 	void Dirty(u64 what) {

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -839,9 +839,9 @@ void CGEDebugger::DescribePixel(u32 pix, GPUDebugBufferFormat fmt, int x, int y,
 
 	case GPU_DBG_FORMAT_24BIT_8X:
 	{
-		DepthScaleFactors depthScale = GetDepthScaleFactors();
+		DepthScaleFactors depthScale = GetDepthScaleFactors(gstate_c.UseFlags());
 		// These are only ever going to be depth values, so let's also show scaled to 16 bit.
-		snprintf(desc, 256, "%d,%d: %d / %f / %f", x, y, pix & 0x00FFFFFF, (pix & 0x00FFFFFF) * (1.0f / 16777215.0f), depthScale.Apply((pix & 0x00FFFFFF) * (1.0f / 16777215.0f)));
+		snprintf(desc, 256, "%d,%d: %d / %f / %f", x, y, pix & 0x00FFFFFF, (pix & 0x00FFFFFF) * (1.0f / 16777215.0f), depthScale.DecodeToU16((pix & 0x00FFFFFF) * (1.0f / 16777215.0f)));
 		break;
 	}
 
@@ -860,8 +860,8 @@ void CGEDebugger::DescribePixel(u32 pix, GPUDebugBufferFormat fmt, int x, int y,
 
 	case GPU_DBG_FORMAT_FLOAT: {
 		float pixf = *(float *)&pix;
-		DepthScaleFactors depthScale = GetDepthScaleFactors();
-		snprintf(desc, 256, "%d,%d: %f / %f", x, y, pixf, depthScale.Apply(pixf));
+		DepthScaleFactors depthScale = GetDepthScaleFactors(gstate_c.UseFlags());
+		snprintf(desc, 256, "%d,%d: %f / %f", x, y, pixf, depthScale.DecodeToU16(pixf));
 		break;
 	}
 
@@ -870,11 +870,11 @@ void CGEDebugger::DescribePixel(u32 pix, GPUDebugBufferFormat fmt, int x, int y,
 			double z = *(float *)&pix;
 			int z24 = (int)(z * 16777215.0);
 
-			DepthScaleFactors factors = GetDepthScaleFactors();
+			DepthScaleFactors factors = GetDepthScaleFactors(gstate_c.UseFlags());
 			// TODO: Use GetDepthScaleFactors here too, verify it's the same.
 			int z16 = z24 - 0x800000 + 0x8000;
 
-			int z16_2 = factors.Apply(z);
+			int z16_2 = factors.DecodeToU16(z);
 
 			snprintf(desc, 256, "%d,%d: %d / %f", x, y, z16, (z - 0.5 + (1.0 / 512.0)) * 256.0);
 		}

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -29,6 +29,7 @@
 
 #include "ppsspp_config.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <cmath>
@@ -801,18 +802,23 @@ static bool TestDepthMath() {
 	// 0
 	// GPU_USE_ACCURATE_DEPTH
 	// GPU_USE_ACCURATE_DEPTH | GPU_SCALE_DEPTH_FROM_24BIT_TO_16BIT
-	// What about GPU_USE_DEPTH_CLAMP? It basically overrides GPU_USE_ACCURATE_DEPTH?
+	// 
+	// TODO: What about GPU_USE_DEPTH_CLAMP? It basically overrides GPU_USE_ACCURATE_DEPTH?
 
 	// These are in normalized space.
-	static const float testValues[] = { 0.0f * 65535.0f, 0.1f * 65535.0f, 0.9f * 65535.0f, 1.0f * 65535.0f };
+	static const volatile float testValues[] = { 0.0f, 0.1f, 0.5f, 0.9f, 1.0f };
 
 	static const u32 useFlagsArray[] = {
 		0,
 		GPU_USE_ACCURATE_DEPTH,
 		GPU_USE_ACCURATE_DEPTH | GPU_SCALE_DEPTH_FROM_24BIT_TO_16BIT,
+		// GPU_USE_DEPTH_CLAMP | GPU_USE_ACCURATE_DEPTH,  fails
+		// GPU_USE_DEPTH_CLAMP | GPU_USE_ACCURATE_DEPTH | GPU_SCALE_DEPTH_FROM_24BIT_TO_16BIT,  fails
 	};
-	static const float expectedScale[] = { 65535.0f, 262140.0f, -1.0f };
-	static const float expectedOffset[] = { 0.0f, 0.375f, -2.0f };
+	static const float expectedScale[] = { 65535.0f, 262140.0f, 16776960.0f };
+	static const float expectedOffset[] = { 0.0f, 0.375f, 0.498047f };
+
+	EXPECT_REL_EQ_FLOAT(100000.0f, 100001.0f, 0.00001f);
 
 	for (int j = 0; j < ARRAY_SIZE(useFlagsArray); j++) {
 		u32 useFlags = useFlagsArray[j];
@@ -820,14 +826,16 @@ static bool TestDepthMath() {
 		DepthScaleFactors factors = GetDepthScaleFactors(useFlags);
 
 		EXPECT_EQ_FLOAT(factors.ScaleU16(), expectedScale[j]);
-		EXPECT_EQ_FLOAT(factors.Offset(), expectedOffset[j]);
+		EXPECT_REL_EQ_FLOAT(factors.Offset(), expectedOffset[j], 0.00001f);
 		EXPECT_EQ_FLOAT(factors.ScaleU16(), DepthSliceFactor(useFlags) * 65535.0f);
 
 		for (int i = 0; i < ARRAY_SIZE(testValues); i++) {
-			float encoded = factors.EncodeFromU16(testValues[i]);
+			float testValue = testValues[i] * 65535.0f;
+
+			float encoded = factors.EncodeFromU16(testValue);
 			float decodedU16 = factors.DecodeToU16(encoded);
-			EXPECT_EQ_FLOAT(decodedU16, testValues[i]);
-			EXPECT_EQ_FLOAT(encoded, ToScaledDepthFromIntegerScale(useFlags, testValues[i]));
+			EXPECT_REL_EQ_FLOAT(decodedU16, testValue, 0.0001f);
+			EXPECT_REL_EQ_FLOAT(encoded, ToScaledDepthFromIntegerScale(useFlags, testValue), 0.00001f);
 		}
 	}
 

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -798,16 +798,11 @@ static bool TestSmallDataConvert() {
 }
 
 static bool TestDepthMath() {
-	// Flag combinations that can happen:
-	// 0
-	// GPU_USE_ACCURATE_DEPTH
-	// GPU_USE_ACCURATE_DEPTH | GPU_SCALE_DEPTH_FROM_24BIT_TO_16BIT
-	// 
-	// TODO: What about GPU_USE_DEPTH_CLAMP? It basically overrides GPU_USE_ACCURATE_DEPTH?
-
 	// These are in normalized space.
 	static const volatile float testValues[] = { 0.0f, 0.1f, 0.5f, M_PI / 4.0f, 0.9f, 1.0f };
 
+	// Flag combinations that can happen (any combination not included here is invalid, see comment
+	// over in GPUStateUtils.cpp):
 	static const u32 useFlagsArray[] = {
 		0,
 		GPU_USE_ACCURATE_DEPTH,

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -806,17 +806,17 @@ static bool TestDepthMath() {
 	// TODO: What about GPU_USE_DEPTH_CLAMP? It basically overrides GPU_USE_ACCURATE_DEPTH?
 
 	// These are in normalized space.
-	static const volatile float testValues[] = { 0.0f, 0.1f, 0.5f, 0.9f, 1.0f };
+	static const volatile float testValues[] = { 0.0f, 0.1f, 0.5f, M_PI / 4.0f, 0.9f, 1.0f };
 
 	static const u32 useFlagsArray[] = {
 		0,
 		GPU_USE_ACCURATE_DEPTH,
 		GPU_USE_ACCURATE_DEPTH | GPU_SCALE_DEPTH_FROM_24BIT_TO_16BIT,
-		// GPU_USE_DEPTH_CLAMP | GPU_USE_ACCURATE_DEPTH,  fails
-		// GPU_USE_DEPTH_CLAMP | GPU_USE_ACCURATE_DEPTH | GPU_SCALE_DEPTH_FROM_24BIT_TO_16BIT,  fails
+		GPU_USE_DEPTH_CLAMP | GPU_USE_ACCURATE_DEPTH,
+		GPU_USE_DEPTH_CLAMP | GPU_USE_ACCURATE_DEPTH | GPU_SCALE_DEPTH_FROM_24BIT_TO_16BIT,  // Here, GPU_SCALE_DEPTH_FROM_24BIT_TO_16BIT should take precedence over USE_DEPTH_CLAMP.
 	};
-	static const float expectedScale[] = { 65535.0f, 262140.0f, 16776960.0f };
-	static const float expectedOffset[] = { 0.0f, 0.375f, 0.498047f };
+	static const float expectedScale[] = { 65535.0f, 262140.0f, 16776960.0f, 65535.0f, 16776960.0f, };
+	static const float expectedOffset[] = { 0.0f, 0.375f, 0.498047f, 0.0f, 0.498047f, };
 
 	EXPECT_REL_EQ_FLOAT(100000.0f, 100001.0f, 0.00001f);
 
@@ -835,7 +835,7 @@ static bool TestDepthMath() {
 			float encoded = factors.EncodeFromU16(testValue);
 			float decodedU16 = factors.DecodeToU16(encoded);
 			EXPECT_REL_EQ_FLOAT(decodedU16, testValue, 0.0001f);
-			EXPECT_REL_EQ_FLOAT(encoded, ToScaledDepthFromIntegerScale(useFlags, testValue), 0.00001f);
+			EXPECT_REL_EQ_FLOAT(encoded, ToScaledDepthFromIntegerScale(useFlags, testValue), 0.000001f);
 		}
 	}
 

--- a/unittest/UnitTest.h
+++ b/unittest/UnitTest.h
@@ -20,7 +20,7 @@ inline bool rel_equal(float a, float b, float precision) {
 #define EXPECT_EQ_HEX(a, b) if ((a) != (b)) { printf("%s:%i: Test Fail\n%x\nvs\n%x\n", __FUNCTION__, __LINE__, a, b); return false; }
 #define EXPECT_EQ_FLOAT(a, b) if ((a) != (b)) { printf("%s:%i: Test Fail\n%0.7f\nvs\n%0.7f\n", __FUNCTION__, __LINE__, a, b); return false; }
 #define EXPECT_APPROX_EQ_FLOAT(a, b) if (fabsf((a)-(b))>0.00001f) { printf("%s:%i: Test Fail\n%f\nvs\n%f\n", __FUNCTION__, __LINE__, a, b); /*return false;*/ }
-#define EXPECT_REL_EQ_FLOAT(a, b, precision) if (!rel_equal(a, b, precision)) { printf("%s:%i: Test Fail\n%0.7f\nvs\n%0.7f\n", __FUNCTION__, __LINE__, a, b); /*return false;*/ }
+#define EXPECT_REL_EQ_FLOAT(a, b, precision) if (!rel_equal(a, b, precision)) { printf("%s:%i: Test Fail\n%0.9f\nvs\n%0.9f\n", __FUNCTION__, __LINE__, a, b); /*return false;*/ }
 #define EXPECT_EQ_STR(a, b) if (a != b) { printf("%s: Test Fail\n%s\nvs\n%s\n", __FUNCTION__, a.c_str(), b.c_str()); return false; }
 
 #define RET(a) if (!(a)) { return false; }

--- a/unittest/UnitTest.h
+++ b/unittest/UnitTest.h
@@ -1,11 +1,26 @@
 #pragma once
 
+#include <cmath>
+#include <algorithm>
+
+inline bool rel_equal(float a, float b, float precision) {
+	float diff = fabsf(a - b);
+	if (diff == 0.0f) {
+		return true;
+	}
+	float range = std::max(fabsf(a), fabsf(b));
+	float quot = diff / range;
+	return quot < precision;
+}
+
+
 #define EXPECT_TRUE(a) if (!(a)) { printf("%s:%i: Test Fail\n", __FUNCTION__, __LINE__); return false; }
 #define EXPECT_FALSE(a) if ((a)) { printf("%s:%i: Test Fail\n", __FUNCTION__, __LINE__); return false; }
 #define EXPECT_EQ_INT(a, b) if ((a) != (b)) { printf("%s:%i: Test Fail\n%d\nvs\n%d\n", __FUNCTION__, __LINE__, (int)(a), (int)(b)); return false; }
 #define EXPECT_EQ_HEX(a, b) if ((a) != (b)) { printf("%s:%i: Test Fail\n%x\nvs\n%x\n", __FUNCTION__, __LINE__, a, b); return false; }
-#define EXPECT_EQ_FLOAT(a, b) if ((a) != (b)) { printf("%s:%i: Test Fail\n%f\nvs\n%f\n", __FUNCTION__, __LINE__, a, b); return false; }
+#define EXPECT_EQ_FLOAT(a, b) if ((a) != (b)) { printf("%s:%i: Test Fail\n%0.7f\nvs\n%0.7f\n", __FUNCTION__, __LINE__, a, b); return false; }
 #define EXPECT_APPROX_EQ_FLOAT(a, b) if (fabsf((a)-(b))>0.00001f) { printf("%s:%i: Test Fail\n%f\nvs\n%f\n", __FUNCTION__, __LINE__, a, b); /*return false;*/ }
+#define EXPECT_REL_EQ_FLOAT(a, b, precision) if (!rel_equal(a, b, precision)) { printf("%s:%i: Test Fail\n%0.7f\nvs\n%0.7f\n", __FUNCTION__, __LINE__, a, b); /*return false;*/ }
 #define EXPECT_EQ_STR(a, b) if (a != b) { printf("%s: Test Fail\n%s\nvs\n%s\n", __FUNCTION__, a.c_str(), b.c_str()); return false; }
 
 #define RET(a) if (!(a)) { return false; }


### PR DESCRIPTION
This tests that some depth related functions match each other better, and makes them purer (useflags are passed in as a parameter now, for ease of testing). 

Later, I intend to make GetDepthScaleFactors the only way to get these, with the returned DepthScaleFactors object giving you all the needed functionality.

There's nothing here that changes behavior, only some renaming, except that calling DepthScaleFactor on its own now respects GPU_ACCURATE_DEPTH.

~~However, the new unit test fails when DEPTH_CLAMP is set, so I think we have some problems... Also, we always set DEPTH_CLAMP and ACCURATE_DEPTH together in GPUCommon, which seems like a contradiction - DEPTH_CLAMP seems to mean that we always use the full range 0-1 in depth buffers, while ACCURATE_DEPTH seems to mean that we don't... I'm a little confused.~~

EDIT: Removed misunderstanding, added better comments.
