### PR TITLE
Tilt control: Split the deadzone parameter since it needs to be different for different types

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -977,7 +977,8 @@ static const ConfigSetting controlSettings[] = {
 	ConfigSetting("TiltInvertY", &g_Config.bInvertTiltY, false, true, true),
 	ConfigSetting("TiltSensitivityX", &g_Config.iTiltSensitivityX, 70, true, true),
 	ConfigSetting("TiltSensitivityY", &g_Config.iTiltSensitivityY, 70, true, true),
-	ConfigSetting("DeadzoneRadius", &g_Config.fDeadzoneRadius, 0.0f, true, true),
+	ConfigSetting("TiltAnalogDeadzoneRadius", &g_Config.fTiltAnalogDeadzoneRadius, 0.0f, true, true),
+	ConfigSetting("TiltDigitalDeadzoneRadius", &g_Config.fTiltDigitalDeadzoneRadius, 0.15f, true, true),
 	ConfigSetting("TiltInputType", &g_Config.iTiltInputType, 0, true, true),
 #endif
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -287,14 +287,15 @@ public:
 	// This is the held base angle, that we compute the tilt relative from.
 	float fTiltBaseAngleY;
 	// whether the x axes and y axes should invert directions (left becomes right, top becomes bottom.)
-	// TODO: Do we really need these?
-	bool bInvertTiltX, bInvertTiltY;
-	//the sensitivity of the tilt in the x direction
+	bool bInvertTiltX;
+	bool bInvertTiltY;
+	// The sensitivity of the tilt in the X and Y directions, separately.
 	int iTiltSensitivityX;
-	//the sensitivity of the tilt in the Y direction
 	int iTiltSensitivityY;
-	//the deadzone radius of the tilt
-	float fDeadzoneRadius;
+	// The deadzone radius of the tilt.
+	// Separate settings for analog vs digital since the usable ranges differ.
+	float fTiltAnalogDeadzoneRadius;
+	float fTiltDigitalDeadzoneRadius;
 	//type of tilt input currently selected: Defined in TiltEventProcessor.h
 	//0 - no tilt, 1 - analog stick, 2 - D-Pad, 3 - Action Buttons (Tri, Cross, Square, Circle)
 	int iTiltInputType;

--- a/Core/TiltEventProcessor.h
+++ b/Core/TiltEventProcessor.h
@@ -11,7 +11,7 @@ struct Tilt {
 
 // generates a tilt in the correct coordinate system based on
 // calibration. x, y, z is the current accelerometer reading (with no conversion).
-Tilt GenTilt(bool landscape, const float calibrationAngle, float x, float y, float z, bool invertX, bool invertY, float deadzone, float xSensitivity, float ySensitivity);
+Tilt GenTilt(bool landscape, const float calibrationAngle, float x, float y, float z, bool invertX, bool invertY, float xSensitivity, float ySensitivity);
 
 void TranslateTiltToInput(const Tilt &tilt);
 void ResetTiltEvents();

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -542,27 +542,6 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 	}
 }
 
-//tiltInputCurve implements a smooth deadzone as described here:
-//http://www.gamasutra.com/blogs/JoshSutphin/20130416/190541/Doing_Thumbstick_Dead_Zones_Right.php
-inline float tiltInputCurve(float x) {
-	const float deadzone = g_Config.fDeadzoneRadius;
-	const float factor = 1.0f / (1.0f - deadzone);
-
-	if (x > deadzone) {
-		return (x - deadzone) * (x - deadzone) * factor;
-	} else if (x < -deadzone) {
-		return -(x + deadzone) * (x + deadzone) * factor;
-	} else {
-		return 0.0f;
-	}
-}
-
-inline float clamp1(float x) {
-	if (x > 1.0f) return 1.0f;
-	if (x < -1.0f) return -1.0f;
-	return x;
-}
-
 void EmuScreen::touch(const TouchInput &touch) {
 	Core_NotifyActivity();
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1405,7 +1405,7 @@ void NativeAxis(const AxisInput &axis) {
 	bool landscape = dp_yres < dp_xres;
 	// now transform out current tilt to the calibrated coordinate system
 	Tilt trueTilt = GenTilt(landscape, tiltBaseAngleY, tiltX, tiltY, tiltZ,
-		g_Config.bInvertTiltX, g_Config.bInvertTiltY, g_Config.fDeadzoneRadius,
+		g_Config.bInvertTiltX, g_Config.bInvertTiltY,
 		xSensitivity, ySensitivity);
 
 	TranslateTiltToInput(trueTilt);

--- a/UI/TiltAnalogSettingsScreen.cpp
+++ b/UI/TiltAnalogSettingsScreen.cpp
@@ -120,14 +120,18 @@ void TiltAnalogSettingsScreen::CreateViews() {
 	calibrate->SetEnabledFunc(enabledFunc);
 	settings->Add(calibrate);
 
+	settings->Add(new ItemHeader(co->T("Sensitivity")));
+	if (g_Config.iTiltInputType > 1) {
+		settings->Add(new PopupSliderChoiceFloat(&g_Config.fTiltDigitalDeadzoneRadius, 0.05f, 0.5f, co->T("Deadzone radius"), 0.01f, screenManager(), "/ 1.0"))->SetEnabledFunc(enabledFunc);
+	} else {
+		settings->Add(new PopupSliderChoiceFloat(&g_Config.fTiltAnalogDeadzoneRadius, 0.0f, 0.8f, co->T("Deadzone radius"), 0.01f, screenManager(), "/ 1.0"))->SetEnabledFunc(enabledFunc);
+	}
+	settings->Add(new PopupSliderChoice(&g_Config.iTiltSensitivityX, 0, 100, co->T("Tilt Sensitivity along X axis"), screenManager(), "%"))->SetEnabledFunc(enabledFunc);
+	settings->Add(new PopupSliderChoice(&g_Config.iTiltSensitivityY, 0, 100, co->T("Tilt Sensitivity along Y axis"), screenManager(), "%"))->SetEnabledFunc(enabledFunc);
+
 	settings->Add(new ItemHeader(co->T("Invert Axes")));
 	settings->Add(new CheckBox(&g_Config.bInvertTiltX, co->T("Invert Tilt along X axis")))->SetEnabledFunc(enabledFunc);
 	settings->Add(new CheckBox(&g_Config.bInvertTiltY, co->T("Invert Tilt along Y axis")))->SetEnabledFunc(enabledFunc);
-
-	settings->Add(new ItemHeader(co->T("Sensitivity")));
-	settings->Add(new PopupSliderChoice(&g_Config.iTiltSensitivityX, 0, 100, co->T("Tilt Sensitivity along X axis"), screenManager(), "%"))->SetEnabledFunc(enabledFunc);
-	settings->Add(new PopupSliderChoice(&g_Config.iTiltSensitivityY, 0, 100, co->T("Tilt Sensitivity along Y axis"), screenManager(), "%"))->SetEnabledFunc(enabledFunc);
-	settings->Add(new PopupSliderChoiceFloat(&g_Config.fDeadzoneRadius, 0.0, 1.0, co->T("Deadzone radius"), 0.01f, screenManager(), "/ 1.0"))->SetEnabledFunc(enabledFunc);
 
 	settings->Add(new BorderView(BORDER_BOTTOM, BorderStyle::HEADER_FG, 2.0f, new LayoutParams(FILL_PARENT, 40.0f)));
 	settings->Add(new Choice(di->T("Back")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);


### PR DESCRIPTION
Can at least share the string without problems.

Also rearrange the settings a little bit.

Last part of the tilt improvements for 1.15.