### PR TITLE
riscv: Initial vertexjit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1485,6 +1485,10 @@ list(APPEND CoreExtra
 	Core/MIPS/MIPS/MipsJit.h
 )
 
+list(APPEND CoreExtra
+	GPU/Common/VertexDecoderRiscV.cpp
+)
+
 if(NOT MOBILE_DEVICE)
 	set(CoreExtra ${CoreExtra}
 		Core/AVIDump.cpp

--- a/Common/CommonFuncs.h
+++ b/Common/CommonFuncs.h
@@ -36,6 +36,8 @@
 #define Crash() {asm ("bkpt #0");}
 #elif PPSSPP_ARCH(ARM64)
 #define Crash() {asm ("brk #0");}
+#elif PPSSPP_ARCH(RISCV64)
+#define Crash() {asm ("ebreak");}
 #else
 #include <signal.h>
 #define Crash() {kill(getpid(), SIGINT);}

--- a/Common/RiscVEmitter.cpp
+++ b/Common/RiscVEmitter.cpp
@@ -4278,4 +4278,16 @@ void RiscVEmitter::C_SDSP(RiscVReg rs2, u32 uimm9) {
 	Write16(EncodeCSS(Opcode16::C2, rs2, imm5_4_3_8_7_6, Funct3::C_SDSP));
 }
 
+void RiscVCodeBlock::PoisonMemory(int offset) {
+	// So we can adjust region to writable space.  Might be zero.
+	ptrdiff_t writable = writable_ - code_;
+
+	u32 *ptr = (u32 *)(region + offset + writable);
+	u32 *maxptr = (u32 *)(region + region_size - offset + writable);
+	// This will only write an even multiple of u32, but not much else to do.
+	// RiscV: 0x00100073 = EBREAK
+	while (ptr < maxptr)
+		*ptr++ = 0x00100073;
+}
+
 };

--- a/Common/RiscVEmitter.h
+++ b/Common/RiscVEmitter.h
@@ -304,7 +304,7 @@ public:
 	void ECALL();
 	void EBREAK();
 
-	// 64-bit instructions - oens ending in W sign extend result to 32 bits.
+	// 64-bit instructions - ones ending in W sign extend result to 32 bits.
 	void LWU(RiscVReg rd, RiscVReg addr, s32 simm12);
 	void LD(RiscVReg rd, RiscVReg addr, s32 simm12);
 	void SD(RiscVReg rs2, RiscVReg addr, s32 simm12);

--- a/Common/RiscVEmitter.h
+++ b/Common/RiscVEmitter.h
@@ -47,6 +47,8 @@ enum RiscVReg {
 	V8, V9, V10, V11, V12, V13, V14, V15,
 	V16, V17, V18, V19, V20, V21, V22, V23,
 	V24, V25, V26, V27, V28, V29, V30, V31,
+
+	INVALID_REG = 0xFFFFFFFF,
 };
 
 enum class FixupBranchType {
@@ -1024,13 +1026,14 @@ private:
 		writable_ += 2;
 	}
 
+protected:
 	const u8 *code_ = nullptr;
 	u8 *writable_ = nullptr;
 	const u8 *lastCacheFlushEnd_ = nullptr;
 	bool autoCompress_ = false;
 };
 
-class MIPSCodeBlock : public CodeBlock<RiscVEmitter> {
+class RiscVCodeBlock : public CodeBlock<RiscVEmitter> {
 private:
 	void PoisonMemory(int offset) override;
 };

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -350,6 +350,7 @@ int PSPOskDialog::Init(u32 oskPtr) {
 
 	// Eat any keys pressed before the dialog inited.
 	UpdateButtons();
+	InitCommon();
 
 	std::lock_guard<std::mutex> guard(nativeMutex_);
 	nativeStatus_ = PSPOskNativeStatus::IDLE;
@@ -954,6 +955,7 @@ int PSPOskDialog::Update(int animSpeed) {
 	const int framesHeldRepeatRate = 5;
 
 	UpdateButtons();
+	UpdateCommon();
 	int selectedRow = selectedChar / numKeyCols[currentKeyboard];
 	int selectedExtra = selectedChar % numKeyCols[currentKeyboard];
 

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -698,7 +698,7 @@ JitBlockDebugInfo JitBlockCache::GetBlockDebugInfo(int blockNum) const {
 	debugInfo.targetDisasm = DisassembleArm64(block->normalEntry, block->codeSize);
 #elif PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 	debugInfo.targetDisasm = DisassembleX86(block->normalEntry, block->codeSize);
-#elif PPSSPP_ARCH(ARM64)
+#elif PPSSPP_ARCH(RISCV64)
 	debugInfo.targetDisasm = DisassembleRV64(block->normalEntry, block->codeSize);
 #endif
 

--- a/Core/MIPS/JitCommon/JitState.cpp
+++ b/Core/MIPS/JitCommon/JitState.cpp
@@ -60,7 +60,7 @@ namespace MIPSComp {
 
 		useStaticAlloc = false;
 		enablePointerify = false;
-#if PPSSPP_ARCH(ARM64)
+#if PPSSPP_ARCH(ARM64) || PPSSPP_ARCH(RISCV64)
 		useStaticAlloc = !Disabled(JitDisable::STATIC_ALLOC);
 		// iOS/etc. may disable at runtime if Memory::base is not nicely aligned.
 		enablePointerify = !Disabled(JitDisable::POINTERIFY);

--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -722,7 +722,7 @@ void VertexDecoderJitCache::Jit_NormalS16() {
 
 void VertexDecoderJitCache::Jit_NormalFloat() {
 	// Only need to copy 12 bytes, but copying 16 should be okay (and is faster.)
-	if ((dec_->posoff & 7) == 0 && (dec_->decFmt.posoff & 7) == 0) {
+	if ((dec_->nrmoff & 7) == 0 && (dec_->decFmt.nrmoff & 7) == 0) {
 		LDP(INDEX_SIGNED, EncodeRegTo64(tempReg1), EncodeRegTo64(tempReg2), srcReg, dec_->nrmoff);
 		STP(INDEX_SIGNED, EncodeRegTo64(tempReg1), EncodeRegTo64(tempReg2), dstReg, dec_->decFmt.nrmoff);
 	} else {

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -37,6 +37,8 @@
 #include "Common/Arm64Emitter.h"
 #elif PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 #include "Common/x64Emitter.h"
+#elif PPSSPP_ARCH(RISCV64)
+#include "Common/RiscVEmitter.h"
 #else
 #include "Common/FakeEmitter.h"
 #endif
@@ -489,6 +491,8 @@ public:
 #define VERTEXDECODER_JIT_BACKEND Arm64Gen::ARM64CodeBlock
 #elif PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 #define VERTEXDECODER_JIT_BACKEND Gen::XCodeBlock
+#elif PPSSPP_ARCH(RISCV64)
+#define VERTEXDECODER_JIT_BACKEND RiscVGen::RiscVCodeBlock
 #endif
 
 

--- a/GPU/Common/VertexDecoderRiscV.cpp
+++ b/GPU/Common/VertexDecoderRiscV.cpp
@@ -1,0 +1,152 @@
+// Copyright (c) 2023- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "ppsspp_config.h"
+#if PPSSPP_ARCH(RISCV64)
+
+#include "Common/CPUDetect.h"
+#include "Common/Log.h"
+#include "Common/RiscVEmitter.h"
+#include "Core/MIPS/JitCommon/JitCommon.h"
+#include "GPU/GPUState.h"
+#include "GPU/Common/VertexDecoderCommon.h"
+
+using namespace RiscVGen;
+
+static const RiscVReg srcReg = X10;
+static const RiscVReg dstReg = X11;
+static const RiscVReg counterReg = X12;
+
+static const RiscVReg tempReg1 = X13;
+static const RiscVReg tempReg2 = X14;
+static const RiscVReg tempReg3 = X15;
+static const RiscVReg scratchReg = X16;
+
+static const RiscVReg fullAlphaReg = X17;
+static const RiscVReg boundsMinUReg = X28;
+static const RiscVReg boundsMinVReg = X29;
+static const RiscVReg boundsMaxUReg = X30;
+static const RiscVReg boundsMaxVReg = X31;
+
+static const RiscVReg fpScratchReg1 = F10;
+static const RiscVReg fpScratchReg2 = F11;
+static const RiscVReg fpScratchReg3 = F12;
+static const RiscVReg fpScratchReg4 = F13;
+
+static const JitLookup jitLookup[] = {
+	{&VertexDecoder::Step_TcFloat, &VertexDecoderJitCache::Jit_TcFloat},
+};
+
+JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int32_t *jittedSize) {
+	dec_ = &dec;
+
+	BeginWrite(4096);
+	const u8 *start = AlignCode16();
+	SetAutoCompress(true);
+
+	bool log = false;
+
+	if (dec.col) {
+		// Or LDB and skip the conditional?  This is probably cheaper.
+		LI(fullAlphaReg, 0xFF);
+	}
+
+	if (dec.tc && dec.throughmode) {
+		// TODO: Smarter, only when doing bounds.
+		LI(tempReg1, &gstate_c.vertBounds.minU);
+		LH(boundsMinUReg, tempReg1, offsetof(KnownVertexBounds, minU));
+		LH(boundsMaxUReg, tempReg1, offsetof(KnownVertexBounds, maxU));
+		LH(boundsMinVReg, tempReg1, offsetof(KnownVertexBounds, minV));
+		LH(boundsMaxVReg, tempReg1, offsetof(KnownVertexBounds, maxV));
+	}
+
+	// TODO: Skipping, prescale.
+
+	const u8 *loopStart = GetCodePtr();
+	for (int i = 0; i < dec.numSteps_; i++) {
+		if (!CompileStep(dec, i)) {
+			EndWrite();
+			// Reset the code ptr (effectively undoing what we generated) and return zero to indicate that we failed.
+			ResetCodePtr(GetOffset(start));
+			char temp[1024]{};
+			dec.ToString(temp);
+			ERROR_LOG(G3D, "Could not compile vertex decoder, failed at step %d: %s", i, temp);
+			return nullptr;
+		}
+	}
+
+	ADDI(srcReg, srcReg, dec.VertexSize());
+	ADDI(dstReg, dstReg, dec.decFmt.stride);
+	ADDI(counterReg, counterReg, -1);
+	BLT(R_ZERO, counterReg, loopStart);
+
+	if (dec.col) {
+		LI(tempReg1, &gstate_c.vertexFullAlpha);
+		FixupBranch skip = BNE(R_ZERO, fullAlphaReg);
+		SB(fullAlphaReg, tempReg1, 0);
+		SetJumpTarget(skip);
+	}
+
+	if (dec.tc && dec.throughmode) {
+		// TODO: Smarter, only when doing bounds.
+		LI(tempReg1, &gstate_c.vertBounds.minU);
+		SH(boundsMinUReg, tempReg1, offsetof(KnownVertexBounds, minU));
+		SH(boundsMaxUReg, tempReg1, offsetof(KnownVertexBounds, maxU));
+		SH(boundsMinVReg, tempReg1, offsetof(KnownVertexBounds, minV));
+		SH(boundsMaxVReg, tempReg1, offsetof(KnownVertexBounds, maxV));
+	}
+
+	RET();
+
+	FlushIcache();
+
+	if (log) {
+		char temp[1024]{};
+		dec.ToString(temp);
+		INFO_LOG(JIT, "=== %s (%d bytes) ===", temp, (int)(GetCodePtr() - start));
+		std::vector<std::string> lines = DisassembleRV64(start, (int)(GetCodePtr() - start));
+		for (auto line : lines) {
+			INFO_LOG(JIT, "%s", line.c_str());
+		}
+		INFO_LOG(JIT, "==========");
+	}
+
+	*jittedSize = (int)(GetCodePtr() - start);
+	EndWrite();
+	return (JittedVertexDecoder)start;
+}
+
+bool VertexDecoderJitCache::CompileStep(const VertexDecoder &dec, int step) {
+	// See if we find a matching JIT function.
+	for (size_t i = 0; i < ARRAY_SIZE(jitLookup); i++) {
+		if (dec.steps_[step] == jitLookup[i].func) {
+			((*this).*jitLookup[i].jitFunc)();
+			return true;
+		}
+	}
+	return false;
+}
+
+void VertexDecoderJitCache::Jit_TcFloat() {
+	// Just copy 64 bits.  Might be nice if we could detect misaligned load perf.
+	LW(tempReg1, srcReg, dec_->tcoff);
+	LW(tempReg2, srcReg, dec_->tcoff + 4);
+	SW(tempReg1, dstReg, dec_->decFmt.uvoff);
+	SW(tempReg2, dstReg, dec_->decFmt.uvoff + 4);
+}
+
+#endif // PPSSPP_ARCH(RISCV64)

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -498,6 +498,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="Common\VertexDecoderCommon.cpp" />
+    <ClCompile Include="Common\VertexDecoderRiscV.cpp" />
     <ClCompile Include="Common\VertexDecoderX86.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -521,6 +521,9 @@
     <ClCompile Include="GLES\StencilBufferGLES.cpp">
       <Filter>GLES</Filter>
     </ClCompile>
+    <ClCompile Include="Common\VertexDecoderRiscV.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <FxCompile Include="..\assets\shaders\tex_4xbrz.csh">

--- a/GPU/Software/RasterizerRegCache.cpp
+++ b/GPU/Software/RasterizerRegCache.cpp
@@ -145,6 +145,8 @@ void RegCache::SetupABI(const std::vector<Purpose> &args, bool forceRetain) {
 	for (Reg r : vecTemps)
 		Add(r, VEC_INVALID);
 #endif
+#elif PPSSPP_ARCH(RISCV64)
+	_assert_msg_(false, "Not yet implemented (no vector calling standard yet)");
 #elif PPSSPP_ARCH(MIPS)
 	_assert_msg_(false, "Not yet implemented");
 #else

--- a/GPU/Software/RasterizerRegCache.h
+++ b/GPU/Software/RasterizerRegCache.h
@@ -44,6 +44,8 @@
 #include "Common/x64Emitter.h"
 #elif PPSSPP_ARCH(MIPS)
 #include "Common/MipsEmitter.h"
+#elif PPSSPP_ARCH(RISCV64)
+#include "Common/RiscVEmitter.h"
 #else
 #include "Common/FakeEmitter.h"
 #endif
@@ -60,6 +62,8 @@ typedef Arm64Gen::ARM64CodeBlock BaseCodeBlock;
 typedef Gen::XCodeBlock BaseCodeBlock;
 #elif PPSSPP_ARCH(MIPS)
 typedef MIPSGen::MIPSCodeBlock BaseCodeBlock;
+#elif PPSSPP_ARCH(RISCV64)
+typedef RiscVGen::RiscVCodeBlock BaseCodeBlock;
 #else
 typedef FakeGen::FakeXCodeBlock BaseCodeBlock;
 #endif
@@ -169,6 +173,9 @@ struct RegCache {
 #elif PPSSPP_ARCH(MIPS)
 	typedef MIPSGen::MIPSReg Reg;
 	static constexpr Reg REG_INVALID_VALUE = MIPSGen::INVALID_REG;
+#elif PPSSPP_ARCH(RISCV64)
+	typedef RiscVGen::RiscVReg Reg;
+	static constexpr Reg REG_INVALID_VALUE = RiscVGen::INVALID_REG;
 #else
 	typedef int Reg;
 	static constexpr Reg REG_INVALID_VALUE = -1;


### PR DESCRIPTION
This lacks skinning (probably most important) and morph, but at least has all the standard stuff.  I didn't try to do any of it with vector instructions since I don't have a device with them.

Gave a modest improvement of Crisis Core from around ~75% speed to ~77% speed, while using IR and forced on vertexjit.  For now, not actually enabled for anyone due to the jit setting.

-[Unknown]