### PR TITLE
Eat some CPU cycles in sceUtilityOskUpdate. Works around timing bug in Ghost Recon Predator.

### DIFF
--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -641,6 +641,9 @@ static int sceUtilityOskUpdate(int animSpeed) {
 		return hleLogWarning(SCEUTILITY, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 	
+	// This is the vblank period, plus a little slack. Needed to fix timing bug in Ghost Recon: Predator.
+	// See issue #12044.
+	hleEatCycles(msToCycles(0.7315 + 0.1));
 	return hleLogSuccessX(SCEUTILITY, oskDialog->Update(animSpeed));
 }
 


### PR DESCRIPTION
The bug is in the game, it uses the wrong vblank wait function (that won't wait if you're still inside the vblank), but it only works because the dialog processing takes so much time that it misses the vblank period.

Fixes #12044, and hopefully won't break anything else.