### PR TITLE
libretro: Update flags for Android ndk-build

### DIFF
--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -192,7 +192,12 @@ SOURCES_C += \
 	$(EXTDIR)/libpng17/pngwtran.c \
 	$(EXTDIR)/libpng17/pngwutil.c
 
-COREFLAGS += -DHAVE_STRONG_GETAUXVAL -DSTACK_LINE_READER_BUFFER_SIZE=1024
+COREFLAGS += -DSTACK_LINE_READER_BUFFER_SIZE=1024
+ifeq ($(PLATFORM_EXT), android)
+COREFLAGS += -DHAVE_DLFCN_H
+else ifneq ($(PLATFORM_EXT), win32)
+COREFLAGS += -DHAVE_STRONG_GETAUXVAL
+endif
 ifneq (,$(findstring osx,$(platform)))
 ifneq (,$(findstring x86,$(TARGET_ARCH)))
 	COREFLAGS += -DHAVE_SYSCTLBYNAME


### PR DESCRIPTION
Although I think libretro uses cmake normally.  See #16913.

-[Unknown]