### PR TITLE
Tilt: Fix sensitivity for digital mappings, simplify things

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -1663,6 +1663,7 @@ void VulkanDeleteList::PerformDeletes(VulkanContext *vulkan, VmaAllocator alloca
 	}
 	imagesWithAllocs_.clear();
 	for (auto &imageView : imageViews_) {
+		INFO_LOG(G3D, "deleting imageview %p", imageView);
 		vkDestroyImageView(device, imageView, nullptr);
 	}
 	imageViews_.clear();

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -975,10 +975,9 @@ static const ConfigSetting controlSettings[] = {
 	ConfigSetting("TiltBaseAngleY", &g_Config.fTiltBaseAngleY, 0.9f, true, true),
 	ConfigSetting("TiltInvertX", &g_Config.bInvertTiltX, false, true, true),
 	ConfigSetting("TiltInvertY", &g_Config.bInvertTiltY, false, true, true),
-	ConfigSetting("TiltSensitivityX", &g_Config.iTiltSensitivityX, 70, true, true),
-	ConfigSetting("TiltSensitivityY", &g_Config.iTiltSensitivityY, 70, true, true),
+	ConfigSetting("TiltSensitivityX", &g_Config.iTiltSensitivityX, 60, true, true),
+	ConfigSetting("TiltSensitivityY", &g_Config.iTiltSensitivityY, 60, true, true),
 	ConfigSetting("TiltAnalogDeadzoneRadius", &g_Config.fTiltAnalogDeadzoneRadius, 0.0f, true, true),
-	ConfigSetting("TiltDigitalDeadzoneRadius", &g_Config.fTiltDigitalDeadzoneRadius, 0.15f, true, true),
 	ConfigSetting("TiltInputType", &g_Config.iTiltInputType, 0, true, true),
 #endif
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -284,20 +284,18 @@ public:
 	bool bShowGpuProfile;
 
 	// Analog stick tilting
-	// This is the held base angle, that we compute the tilt relative from.
+	// This is the held base angle (from the horizon), that we compute the tilt relative from.
 	float fTiltBaseAngleY;
-	// whether the x axes and y axes should invert directions (left becomes right, top becomes bottom.)
+	// Inverts the direction of the x axes and y axes for the purposes of tilt input.
 	bool bInvertTiltX;
 	bool bInvertTiltY;
 	// The sensitivity of the tilt in the X and Y directions, separately.
 	int iTiltSensitivityX;
 	int iTiltSensitivityY;
-	// The deadzone radius of the tilt.
-	// Separate settings for analog vs digital since the usable ranges differ.
+	// The deadzone radius of the tilt. Only used in the analog mapping.
 	float fTiltAnalogDeadzoneRadius;
-	float fTiltDigitalDeadzoneRadius;
-	//type of tilt input currently selected: Defined in TiltEventProcessor.h
-	//0 - no tilt, 1 - analog stick, 2 - D-Pad, 3 - Action Buttons (Tri, Cross, Square, Circle)
+	// Type of tilt input currently selected: Defined in TiltEventProcessor.h
+	// 0 - no tilt, 1 - analog stick, 2 - D-Pad, 3 - Action Buttons (Tri, Cross, Square, Circle)
 	int iTiltInputType;
 
 	// The three tabs.

--- a/Core/TiltEventProcessor.cpp
+++ b/Core/TiltEventProcessor.cpp
@@ -35,8 +35,8 @@ void GenerateTriggerButtonEvent(const Tilt &tilt);
 
 // deadzone is normalized - 0 to 1
 // sensitivity controls how fast the deadzone reaches max value
-inline float TiltInputCurve(float x, float deadzone, float sensitivity) {
-	const float factor = sensitivity * 1.0f / (1.0f - deadzone);
+inline float ApplyDeadzone(float x, float deadzone) {
+	const float factor = 1.0f / (1.0f - deadzone);
 
 	if (x > deadzone) {
 		return (x - deadzone) * factor + deadzone;
@@ -53,8 +53,8 @@ inline Tilt DampenTilt(const Tilt &tilt, float deadzone, float xSensitivity, flo
 	//sensitivity >1 for kingdom hearts and < 1 for Gods Eater. so yes, overshoot is nice
 	//to have. 
 	return Tilt(
-		TiltInputCurve(tilt.x_, deadzone, 2.0f * xSensitivity),
-		TiltInputCurve(tilt.y_, deadzone, 2.0f * ySensitivity)
+		ApplyDeadzone(tilt.x_ * xSensitivity, deadzone),
+		ApplyDeadzone(tilt.y_ * ySensitivity, deadzone)
 	);
 }
 
@@ -85,7 +85,7 @@ void ProcessTilt(bool landscape, float calibrationAngle, float x, float y, float
 	}
 
 	// finally, dampen the tilt according to our curve.
-	Tilt tilt = DampenTilt(transformedTilt, deadzone, xSensitivity, ySensitivity);
+	Tilt tilt = DampenTilt(transformedTilt, deadzone, xSensitivity * 2.0f, ySensitivity * 2.0f);
 
 	switch (g_Config.iTiltInputType) {
 	case TILT_NULL:

--- a/Core/TiltEventProcessor.cpp
+++ b/Core/TiltEventProcessor.cpp
@@ -19,6 +19,13 @@ static u32 tiltButtonsDown = 0;
 float rawTiltAnalogX;
 float rawTiltAnalogY;
 
+// Represents a generic Tilt event
+struct Tilt {
+	Tilt() : x_(0), y_(0) {}
+	Tilt(const float x, const float y) : x_(x), y_(y) {}
+	float x_, y_;
+};
+
 // These functions generate tilt events given the current Tilt amount,
 // and the deadzone radius.
 void GenerateAnalogStickEvent(const Tilt &tilt);
@@ -51,7 +58,7 @@ inline Tilt DampenTilt(const Tilt &tilt, float deadzone, float xSensitivity, flo
 	);
 }
 
-Tilt GenTilt(bool landscape, float calibrationAngle, float x, float y, float z, bool invertX, bool invertY, float xSensitivity, float ySensitivity) {
+void ProcessTilt(bool landscape, float calibrationAngle, float x, float y, float z, bool invertX, bool invertY, float xSensitivity, float ySensitivity) {
 	if (landscape) {
 		std::swap(x, y);
 	} else {
@@ -78,18 +85,15 @@ Tilt GenTilt(bool landscape, float calibrationAngle, float x, float y, float z, 
 	}
 
 	// finally, dampen the tilt according to our curve.
-	return DampenTilt(transformedTilt, deadzone, xSensitivity, ySensitivity);
-}
-
-void TranslateTiltToInput(const Tilt &tilt) {
-	rawTiltAnalogX = tilt.x_;
-	rawTiltAnalogY = tilt.y_;
+	Tilt tilt = DampenTilt(transformedTilt, deadzone, xSensitivity, ySensitivity);
 
 	switch (g_Config.iTiltInputType) {
 	case TILT_NULL:
 		break;
 
 	case TILT_ANALOG:
+		rawTiltAnalogX = tilt.x_;
+		rawTiltAnalogY = tilt.y_;
 		GenerateAnalogStickEvent(tilt);
 		break;
 

--- a/Core/TiltEventProcessor.h
+++ b/Core/TiltEventProcessor.h
@@ -2,18 +2,9 @@
 
 namespace TiltEventProcessor {
 
-// Represents a generic Tilt event
-struct Tilt {
-	Tilt() : x_(0), y_(0) {}
-	Tilt(const float x, const float y) : x_(x), y_(y) {}
-	float x_, y_;
-};
-
 // generates a tilt in the correct coordinate system based on
 // calibration. x, y, z is the current accelerometer reading (with no conversion).
-Tilt GenTilt(bool landscape, const float calibrationAngle, float x, float y, float z, bool invertX, bool invertY, float xSensitivity, float ySensitivity);
-
-void TranslateTiltToInput(const Tilt &tilt);
+void ProcessTilt(bool landscape, const float calibrationAngle, float x, float y, float z, bool invertX, bool invertY, float xSensitivity, float ySensitivity);
 void ResetTiltEvents();
 
 // Lets you preview the amount of tilt in TiltAnalogSettingsScreen.

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1404,11 +1404,9 @@ void NativeAxis(const AxisInput &axis) {
 	// see [http://developer.android.com/guide/topics/sensors/sensors_overview.html] for details
 	bool landscape = dp_yres < dp_xres;
 	// now transform out current tilt to the calibrated coordinate system
-	Tilt trueTilt = GenTilt(landscape, tiltBaseAngleY, tiltX, tiltY, tiltZ,
+	ProcessTilt(landscape, tiltBaseAngleY, tiltX, tiltY, tiltZ,
 		g_Config.bInvertTiltX, g_Config.bInvertTiltY,
 		xSensitivity, ySensitivity);
-
-	TranslateTiltToInput(trueTilt);
 }
 
 void NativeMessageReceived(const char *message, const char *value) {

--- a/UI/TiltAnalogSettingsScreen.cpp
+++ b/UI/TiltAnalogSettingsScreen.cpp
@@ -121,9 +121,7 @@ void TiltAnalogSettingsScreen::CreateViews() {
 	settings->Add(calibrate);
 
 	settings->Add(new ItemHeader(co->T("Sensitivity")));
-	if (g_Config.iTiltInputType > 1) {
-		settings->Add(new PopupSliderChoiceFloat(&g_Config.fTiltDigitalDeadzoneRadius, 0.05f, 0.5f, co->T("Deadzone radius"), 0.01f, screenManager(), "/ 1.0"))->SetEnabledFunc(enabledFunc);
-	} else {
+	if (g_Config.iTiltInputType == 1) {
 		settings->Add(new PopupSliderChoiceFloat(&g_Config.fTiltAnalogDeadzoneRadius, 0.0f, 0.8f, co->T("Deadzone radius"), 0.01f, screenManager(), "/ 1.0"))->SetEnabledFunc(enabledFunc);
 	}
 	settings->Add(new PopupSliderChoice(&g_Config.iTiltSensitivityX, 0, 100, co->T("Tilt Sensitivity along X axis"), screenManager(), "%"))->SetEnabledFunc(enabledFunc);


### PR DESCRIPTION
Changes:

* Deadzone now only applies to analog - the combination of sensitivity and deadzone as independent parameters didn't make sense for digital. Digital deadzone is gone.
* Sensitivity is now processed before deadzone processing, which feels more intuitive and fixes #16909 
* Code is simplified and easier to follow and change.