### PR TITLE
Debugger: Lock memory during stack walk

### DIFF
--- a/GPU/Software/DrawPixel.cpp
+++ b/GPU/Software/DrawPixel.cpp
@@ -802,10 +802,12 @@ SingleFunc PixelJitCache::GenericSingle(const PixelFuncID &id) {
 }
 
 thread_local PixelJitCache::LastCache PixelJitCache::lastSingle_;
+int PixelJitCache::clearGen_ = 0;
 
 // 256k should be plenty of space for plenty of variations.
 PixelJitCache::PixelJitCache() : CodeBlock(1024 * 64 * 4), cache_(64) {
 	lastSingle_.gen = -1;
+	clearGen_++;
 }
 
 void PixelJitCache::Clear() {

--- a/GPU/Software/DrawPixel.h
+++ b/GPU/Software/DrawPixel.h
@@ -128,7 +128,7 @@ private:
 	DenseHashMap<size_t, SingleFunc, nullptr> cache_;
 	std::unordered_map<PixelFuncID, const u8 *> addresses_;
 	std::unordered_set<PixelFuncID> compileQueue_;
-	int clearGen_ = 0;
+	static int clearGen_;
 	static thread_local LastCache lastSingle_;
 
 	const u8 *constBlendHalf_11_4s_ = nullptr;

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -109,12 +109,14 @@ FetchFunc GetFetchFunc(SamplerID id, BinManager *binner) {
 thread_local SamplerJitCache::LastCache SamplerJitCache::lastFetch_;
 thread_local SamplerJitCache::LastCache SamplerJitCache::lastNearest_;
 thread_local SamplerJitCache::LastCache SamplerJitCache::lastLinear_;
+int SamplerJitCache::clearGen_ = 0;
 
 // 256k should be enough.
 SamplerJitCache::SamplerJitCache() : Rasterizer::CodeBlock(1024 * 64 * 4), cache_(64) {
 	lastFetch_.gen = -1;
 	lastNearest_.gen = -1;
 	lastLinear_.gen = -1;
+	clearGen_++;
 }
 
 void SamplerJitCache::Clear() {

--- a/GPU/Software/Sampler.h
+++ b/GPU/Software/Sampler.h
@@ -147,7 +147,7 @@ private:
 	DenseHashMap<size_t, NearestFunc, nullptr> cache_;
 	std::unordered_map<SamplerID, const u8 *> addresses_;
 	std::unordered_set<SamplerID> compileQueue_;
-	int clearGen_ = 0;
+	static int clearGen_;
 	static thread_local LastCache lastFetch_;
 	static thread_local LastCache lastNearest_;
 	static thread_local LastCache lastLinear_;

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -291,11 +291,10 @@ void CDisasm::stepOver()
 	UpdateDialog();
 }
 
-void CDisasm::stepOut()
-{
-	if (!PSP_IsInited()) {
+void CDisasm::stepOut() {
+	auto memLock = Memory::Lock();
+	if (!PSP_IsInited())
 		return;
-	}
 
 	auto threads = GetThreadsInfo();
 

--- a/Windows/Debugger/Debugger_Lists.cpp
+++ b/Windows/Debugger/Debugger_Lists.cpp
@@ -700,8 +700,11 @@ void CtrlStackTraceView::OnDoubleClick(int itemIndex, int column)
 	SendMessage(GetParent(GetHandle()),WM_DEB_GOTOWPARAM,frames[itemIndex].pc,0);
 }
 
-void CtrlStackTraceView::loadStackTrace()
-{
+void CtrlStackTraceView::loadStackTrace() {
+	auto memLock = Memory::Lock();
+	if (!PSP_IsInited())
+		return;
+
 	auto threads = GetThreadsInfo();
 
 	u32 entry = 0, stackTop = 0;


### PR DESCRIPTION
This just fixes a couple of crashes during/after reset.

The US region version of Patapon 3 doesn't seem to reproduce #16836 with the same addresses, but I think this is likely the cause of that.

-[Unknown]