### PR TITLE
Debugger: copy PSP memory base to clipboard

### DIFF
--- a/Windows/.gitignore
+++ b/Windows/.gitignore
@@ -1,3 +1,4 @@
 *.VC.VC.opendb
 *.VC.db
+*.txt
 enc_temp_folder

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -91,6 +91,7 @@ namespace MainWindow {
 		EnableMenuItem(menu, ID_DEBUG_TAKESCREENSHOT, menuEnable);
 		EnableMenuItem(menu, ID_DEBUG_SHOWDEBUGSTATISTICS, menuInGameEnable);
 		EnableMenuItem(menu, ID_DEBUG_EXTRACTFILE, menuEnable);
+		EnableMenuItem(menu, ID_DEBUG_MEMORYBASE, menuInGameEnable);
 
 		// While playing, this pop up doesn't work - and probably doesn't make sense.
 		EnableMenuItem(menu, ID_OPTIONS_LANGUAGE, state == UISTATE_INGAME ? MF_GRAYED : MF_ENABLED);
@@ -221,6 +222,7 @@ namespace MainWindow {
 		TranslateMenuItem(menu, ID_DEBUG_GEDEBUGGER, g_Config.bSystemControls ? L"\tCtrl+G" : L"");
 		TranslateMenuItem(menu, ID_DEBUG_EXTRACTFILE);
 		TranslateMenuItem(menu, ID_DEBUG_LOG, g_Config.bSystemControls ? L"\tCtrl+L" : L"");
+		TranslateMenuItem(menu, ID_DEBUG_MEMORYBASE);
 		TranslateMenuItem(menu, ID_DEBUG_MEMORYVIEW, g_Config.bSystemControls ? L"\tCtrl+M" : L"");
 
 		// Options menu
@@ -821,6 +823,12 @@ namespace MainWindow {
 			if (memoryWindow)
 				memoryWindow->Show(true);
 			break;
+
+		case ID_DEBUG_MEMORYBASE:
+		{
+			W32Util::CopyTextToClipboard(hWnd, ConvertUTF8ToWString(StringFromFormat("%016llx", (uintptr_t)Memory::base)));
+			break;
+		}
 
 		case ID_DEBUG_EXTRACTFILE:
 		{

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -537,6 +537,7 @@ BEGIN
         MENUITEM "GE Debugger...",                          ID_DEBUG_GEDEBUGGER
         MENUITEM "Extract File...",                         ID_DEBUG_EXTRACTFILE
         MENUITEM "Log Console",                             ID_DEBUG_LOG
+        MENUITEM "Copy PSP memory base pointer",             ID_DEBUG_MEMORYBASE
         MENUITEM "Memory View...",                          ID_DEBUG_MEMORYVIEW
     END
 

--- a/Windows/resource.h
+++ b/Windows/resource.h
@@ -18,6 +18,7 @@
 #define ID_DEBUG_DISASSEMBLY            119
 #define WHEEL_DELTA                     120
 #define ID_DEBUG_LOG                    121
+#define ID_DEBUG_MEMORYBASE             122
 #define ID_FILE_OPEN_NEW_INSTANCE       123
 #define ID_FILE_LOADSTATEFILE           126
 #define ID_FILE_SAVESTATEFILE           127


### PR DESCRIPTION
Requesting the current PSP memory base address was only possible through memory.base remote API command.