### PR TITLE
Some minor code cleanups (merge two functions, remove a parameter)

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -112,7 +112,7 @@ public:
 
 	// Raster state
 	void SetScissorRect(int left, int top, int width, int height) override;
-	void SetViewports(int count, Viewport *viewports) override;
+	void SetViewport(const Viewport &viewport) override;
 	void SetBlendFactor(float color[4]) override {
 		if (memcmp(blendFactor_, color, sizeof(float) * 4)) {
 			memcpy(blendFactor_, color, sizeof(float) * 4);
@@ -420,20 +420,18 @@ void D3D11DrawContext::EndFrame() {
 	curPipeline_ = nullptr;
 }
 
-void D3D11DrawContext::SetViewports(int count, Viewport *viewports) {
-	D3D11_VIEWPORT vp[4];
-	for (int i = 0; i < count; i++) {
-		DisplayRect<float> rc{ viewports[i].TopLeftX , viewports[i].TopLeftY, viewports[i].Width, viewports[i].Height };
-		if (curRenderTargetView_ == bbRenderTargetView_)  // Only the backbuffer is actually rotated wrong!
-			RotateRectToDisplay(rc, curRTWidth_, curRTHeight_);
-		vp[i].TopLeftX = rc.x;
-		vp[i].TopLeftY = rc.y;
-		vp[i].Width = rc.w;
-		vp[i].Height = rc.h;
-		vp[i].MinDepth = viewports[i].MinDepth;
-		vp[i].MaxDepth = viewports[i].MaxDepth;
-	}
-	context_->RSSetViewports(count, vp);
+void D3D11DrawContext::SetViewport(const Viewport &viewport) {
+	DisplayRect<float> rc{ viewport.TopLeftX , viewport.TopLeftY, viewport.Width, viewport.Height };
+	if (curRenderTargetView_ == bbRenderTargetView_)  // Only the backbuffer is actually rotated wrong!
+		RotateRectToDisplay(rc, curRTWidth_, curRTHeight_);
+	D3D11_VIEWPORT vp;
+	vp.TopLeftX = rc.x;
+	vp.TopLeftY = rc.y;
+	vp.Width = rc.w;
+	vp.Height = rc.h;
+	vp.MinDepth = viewport.MinDepth;
+	vp.MaxDepth = viewport.MaxDepth;
+	context_->RSSetViewports(1, &vp);
 }
 
 void D3D11DrawContext::SetScissorRect(int left, int top, int width, int height) {

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -573,7 +573,7 @@ public:
 
 	// Raster state
 	void SetScissorRect(int left, int top, int width, int height) override;
-	void SetViewports(int count, Viewport *viewports) override;
+	void SetViewport(const Viewport &viewport) override;
 	void SetBlendFactor(float color[4]) override;
 	void SetStencilParams(uint8_t refValue, uint8_t writeMask, uint8_t compareMask) override;
 
@@ -1173,12 +1173,12 @@ void D3D9Context::SetScissorRect(int left, int top, int width, int height) {
 	dxstate.scissorTest.set(true);
 }
 
-void D3D9Context::SetViewports(int count, Viewport *viewports) {
-	int x = (int)viewports[0].TopLeftX;
-	int y = (int)viewports[0].TopLeftY;
-	int w = (int)viewports[0].Width;
-	int h = (int)viewports[0].Height;
-	dxstate.viewport.set(x, y, w, h, viewports[0].MinDepth, viewports[0].MaxDepth);
+void D3D9Context::SetViewport(const Viewport &viewport) {
+	int x = (int)viewport.TopLeftX;
+	int y = (int)viewport.TopLeftY;
+	int w = (int)viewport.Width;
+	int h = (int)viewport.Height;
+	dxstate.viewport.set(x, y, w, h, viewport.MinDepth, viewport.MaxDepth);
 }
 
 void D3D9Context::SetBlendFactor(float color[4]) {

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -385,9 +385,9 @@ public:
 		renderManager_.SetScissor({ left, top, width, height });
 	}
 
-	void SetViewports(int count, Viewport *viewports) override {
+	void SetViewport(const Viewport &viewport) override {
 		// Same structure, different name.
-		renderManager_.SetViewport((GLRViewport &)*viewports);
+		renderManager_.SetViewport((GLRViewport &)viewport);
 	}
 
 	void SetBlendFactor(float color[4]) override {

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -425,7 +425,7 @@ public:
 	void GetFramebufferDimensions(Framebuffer *fbo, int *w, int *h) override;
 
 	void SetScissorRect(int left, int top, int width, int height) override;
-	void SetViewports(int count, Viewport *viewports) override;
+	void SetViewport(const Viewport &viewport) override;
 	void SetBlendFactor(float color[4]) override;
 	void SetStencilParams(uint8_t refValue, uint8_t writeMask, uint8_t compareMask) override;
 
@@ -1237,18 +1237,16 @@ void VKContext::SetScissorRect(int left, int top, int width, int height) {
 	renderManager_.SetScissor(left, top, width, height);
 }
 
-void VKContext::SetViewports(int count, Viewport *viewports) {
-	if (count > 0) {
-		// Ignore viewports more than the first.
-		VkViewport viewport;
-		viewport.x = viewports[0].TopLeftX;
-		viewport.y = viewports[0].TopLeftY;
-		viewport.width = viewports[0].Width;
-		viewport.height = viewports[0].Height;
-		viewport.minDepth = viewports[0].MinDepth;
-		viewport.maxDepth = viewports[0].MaxDepth;
-		renderManager_.SetViewport(viewport);
-	}
+void VKContext::SetViewport(const Viewport &viewport) {
+	// Ignore viewports more than the first.
+	VkViewport vkViewport;
+	vkViewport.x = viewport.TopLeftX;
+	vkViewport.y = viewport.TopLeftY;
+	vkViewport.width = viewport.Width;
+	vkViewport.height = viewport.Height;
+	vkViewport.minDepth = viewport.MinDepth;
+	vkViewport.maxDepth = viewport.MaxDepth;
+	renderManager_.SetViewport(vkViewport);
 }
 
 void VKContext::SetBlendFactor(float color[4]) {

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -733,7 +733,7 @@ public:
 
 	// Dynamic state
 	virtual void SetScissorRect(int left, int top, int width, int height) = 0;
-	virtual void SetViewports(int count, Viewport *viewports) = 0;
+	virtual void SetViewport(const Viewport &viewport) = 0;
 	virtual void SetBlendFactor(float color[4]) = 0;
 	virtual void SetStencilParams(uint8_t refValue, uint8_t writeMask, uint8_t compareMask) = 0;
 

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -102,7 +102,7 @@ void UIScreen::preRender() {
 	viewport.Height = pixel_yres;
 	viewport.MaxDepth = 1.0;
 	viewport.MinDepth = 0.0;
-	draw->SetViewports(1, &viewport);
+	draw->SetViewport(viewport);
 	draw->SetTargetSize(pixel_xres, pixel_yres);
 }
 

--- a/GPU/Common/DepthBufferCommon.cpp
+++ b/GPU/Common/DepthBufferCommon.cpp
@@ -207,7 +207,7 @@ bool FramebufferManagerCommon::ReadbackDepthbuffer(Draw::Framebuffer *fbo, int x
 		auto *blitFBO = GetTempFBO(TempFBO::COPY, fbo->Width() * scaleX, fbo->Height() * scaleY);
 		draw_->BindFramebufferAsRenderTarget(blitFBO, { RPAction::DONT_CARE, RPAction::DONT_CARE, RPAction::DONT_CARE }, "ReadbackDepthbufferSync");
 		Draw::Viewport viewport = { 0.0f, 0.0f, (float)destW, (float)destH, 0.0f, 1.0f };
-		draw_->SetViewports(1, &viewport);
+		draw_->SetViewport(viewport);
 		draw_->SetScissorRect(0, 0, fbo->Width() * scaleX, fbo->Height() * scaleY);
 
 		draw_->BindFramebufferAsTexture(fbo, TEX_SLOT_PSP_TEXTURE, FB_DEPTH_BIT, 0);

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1429,8 +1429,8 @@ void FramebufferManagerCommon::DrawFramebufferToOutput(const u8 *srcPixels, int 
 }
 
 void FramebufferManagerCommon::SetViewport2D(int x, int y, int w, int h) {
-	Draw::Viewport vp{ (float)x, (float)y, (float)w, (float)h, 0.0f, 1.0f };
-	draw_->SetViewports(1, &vp);
+	Draw::Viewport viewport{ (float)x, (float)y, (float)w, (float)h, 0.0f, 1.0f };
+	draw_->SetViewport(viewport);
 }
 
 void FramebufferManagerCommon::CopyDisplayToOutput(bool reallyDirty) {
@@ -3235,8 +3235,8 @@ void FramebufferManagerCommon::BlitUsingRaster(
 		draw_->InvalidateFramebuffer(Draw::FB_INVALIDATION_LOAD, pipeline->info.writeChannel == RASTER_COLOR ? Draw::FB_COLOR_BIT : Draw::FB_DEPTH_BIT);
 	}
 
-	Draw::Viewport vp{ 0.0f, 0.0f, (float)dest->Width(), (float)dest->Height(), 0.0f, 1.0f };
-	draw_->SetViewports(1, &vp);
+	Draw::Viewport viewport{ 0.0f, 0.0f, (float)dest->Width(), (float)dest->Height(), 0.0f, 1.0f };
+	draw_->SetViewport(viewport);
 	draw_->SetScissorRect(0, 0, (int)dest->Width(), (int)dest->Height());
 
 	draw2D_.Blit(pipeline, srcX1, srcY1, srcX2, srcY2, destX1, destY1, destX2, destY2, (float)srcW, (float)srcH, (float)destW, (float)destH, linearFilter, scaleFactor);

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -734,7 +734,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 		int nextWidth, nextHeight;
 		draw_->GetFramebufferDimensions(postShaderFramebuffer, &nextWidth, &nextHeight);
 		Draw::Viewport viewport{ 0, 0, (float)nextWidth, (float)nextHeight, 0.0f, 1.0f };
-		draw_->SetViewports(1, &viewport);
+		draw_->SetViewport(viewport);
 		draw_->SetScissorRect(0, 0, nextWidth, nextHeight);
 
 		CalculatePostShaderUniforms(lastWidth, lastHeight, nextWidth, nextHeight, shaderInfo, &uniforms);
@@ -853,7 +853,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 
 	auto setViewport = [&](float x, float y, float w, float h) {
 		Draw::Viewport viewport{ x, y, w, h, 0.0f, 1.0f };
-		draw_->SetViewports(1, &viewport);
+		draw_->SetViewport(viewport);
 	};
 
 	CardboardSettings cardboardSettings;

--- a/GPU/Common/StencilCommon.cpp
+++ b/GPU/Common/StencilCommon.cpp
@@ -304,7 +304,7 @@ bool FramebufferManagerCommon::PerformWriteStencilFromMemory(u32 addr, int size,
 	}
 
 	Draw::Viewport viewport = { 0.0f, 0.0f, (float)w, (float)h, 0.0f, 1.0f };
-	draw_->SetViewports(1, &viewport);
+	draw_->SetViewport(viewport);
 
 	// TODO: Switch the format to a single channel format?
 	Draw::Texture *tex = MakePixelTexture(src, dstBuffer->fb_format, dstBuffer->fb_stride, dstBuffer->width, dstBuffer->height);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2247,8 +2247,8 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 		draw_->BindFramebufferAsRenderTarget(depalFBO, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Depal");
 		draw_->InvalidateFramebuffer(Draw::FB_INVALIDATION_STORE, Draw::FB_DEPTH_BIT | Draw::FB_STENCIL_BIT);
 		draw_->SetScissorRect(u1, v1, u2 - u1, v2 - v1);
-		Draw::Viewport vp{ 0.0f, 0.0f, (float)depalWidth, (float)framebuffer->renderHeight, 0.0f, 1.0f };
-		draw_->SetViewports(1, &vp);
+		Draw::Viewport viewport{ 0.0f, 0.0f, (float)depalWidth, (float)framebuffer->renderHeight, 0.0f, 1.0f };
+		draw_->SetViewport(viewport);
 
 		draw_->BindFramebufferAsTexture(framebuffer->fbo, 0, depth ? Draw::FB_DEPTH_BIT : Draw::FB_COLOR_BIT, Draw::ALL_LAYERS);
 		if (clutRenderAddress_ == 0xFFFFFFFF) {
@@ -2352,8 +2352,8 @@ void TextureCacheCommon::ApplyTextureDepal(TexCacheEntry *entry) {
 	draw_->BindFramebufferAsRenderTarget(depalFBO, { Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE, Draw::RPAction::DONT_CARE }, "Depal");
 	draw_->InvalidateFramebuffer(Draw::FB_INVALIDATION_STORE, Draw::FB_DEPTH_BIT | Draw::FB_STENCIL_BIT);
 	draw_->SetScissorRect(u1, v1, u2 - u1, v2 - v1);
-	Draw::Viewport vp{ 0.0f, 0.0f, (float)texWidth, (float)texHeight, 0.0f, 1.0f };
-	draw_->SetViewports(1, &vp);
+	Draw::Viewport viewport{ 0.0f, 0.0f, (float)texWidth, (float)texHeight, 0.0f, 1.0f };
+	draw_->SetViewport(viewport);
 
 	draw_->BindNativeTexture(0, GetNativeTextureView(entry));
 	draw_->BindFramebufferAsTexture(dynamicClutFbo_, 1, Draw::FB_COLOR_BIT, 0);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -817,7 +817,7 @@ void TextureCacheCommon::HandleTextureChange(TexCacheEntry *const entry, const c
 	gpuStats.numTextureInvalidations++;
 	DEBUG_LOG(G3D, "Texture different or overwritten, reloading at %08x: %s", entry->addr, reason);
 	if (doDelete) {
-		InvalidateLastTexture();
+		ForgetLastTexture();
 		ReleaseTexture(entry, true);
 		entry->status &= ~TexCacheEntry::STATUS_IS_SCALED;
 	}
@@ -1990,7 +1990,7 @@ void TextureCacheCommon::ApplyTexture() {
 	TexCacheEntry *entry = nextTexture_;
 	if (!entry) {
 		// Maybe we bound a framebuffer?
-		InvalidateLastTexture();
+		ForgetLastTexture();
 		if (failedTexture_) {
 			// Backends should handle this by binding a black texture with 0 alpha.
 			BindTexture(nullptr);
@@ -2050,7 +2050,7 @@ void TextureCacheCommon::ApplyTexture() {
 	if (nextNeedsRebuild_) {
 		_assert_(!entry->texturePtr);
 		BuildTexture(entry);
-		InvalidateLastTexture();
+		ForgetLastTexture();
 	}
 
 	if (entry->status & TexCacheEntry::STATUS_CLUT_GPU) {
@@ -2205,7 +2205,7 @@ void TextureCacheCommon::ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer
 			gstate_c.SetTextureFullAlpha(alphaStatus == CHECKALPHA_FULL);
 
 			draw_->Invalidate(InvalidationFlags::CACHED_RENDER_STATE);
-			InvalidateLastTexture();
+			ForgetLastTexture();
 			return;
 		}
 

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -329,7 +329,6 @@ public:
 	TextureShaderCache *GetTextureShaderCache() { return textureShaderCache_; }
 
 	virtual void ForgetLastTexture() = 0;
-	virtual void InvalidateLastTexture() = 0;
 	virtual void Clear(bool delete_them);
 	virtual void NotifyConfigChanged();
 	virtual void ApplySamplingParams(const SamplerCacheKey &key) = 0;

--- a/GPU/D3D11/StateMappingD3D11.cpp
+++ b/GPU/D3D11/StateMappingD3D11.cpp
@@ -442,7 +442,7 @@ void DrawEngineD3D11::ApplyDrawState(int prim) {
 void DrawEngineD3D11::ApplyDrawStateLate(bool applyStencilRef, uint8_t stencilRef) {
 	// we go through Draw here because it automatically handles screen rotation, as needed in UWP on mobiles.
 	if (gstate_c.IsDirty(DIRTY_VIEWPORTSCISSOR_STATE)) {
-		draw_->SetViewports(1, &dynState_.viewport);
+		draw_->SetViewport(dynState_.viewport);
 		draw_->SetScissorRect(dynState_.scissor.left, dynState_.scissor.top, dynState_.scissor.right - dynState_.scissor.left, dynState_.scissor.bottom - dynState_.scissor.top);
 	}
 	if (gstate_c.IsDirty(DIRTY_RASTER_STATE)) {

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -179,20 +179,16 @@ void TextureCacheD3D11::ReleaseTexture(TexCacheEntry *entry, bool delete_them) {
 }
 
 void TextureCacheD3D11::ForgetLastTexture() {
-	InvalidateLastTexture();
+	lastBoundTexture = INVALID_TEX;
 
 	ID3D11ShaderResourceView *nullTex[4]{};
 	context_->PSSetShaderResources(0, 4, nullTex);
 }
 
-void TextureCacheD3D11::InvalidateLastTexture() {
-	lastBoundTexture = INVALID_TEX;
-}
-
 void TextureCacheD3D11::StartFrame() {
 	TextureCacheCommon::StartFrame();
 
-	InvalidateLastTexture();
+	lastBoundTexture = INVALID_TEX;
 	timesInvalidatedAllThisFrame_ = 0;
 	replacementTimeThisFrame_ = 0.0;
 
@@ -268,9 +264,7 @@ void TextureCacheD3D11::ApplySamplingParams(const SamplerCacheKey &key) {
 }
 
 void TextureCacheD3D11::Unbind() {
-	ID3D11ShaderResourceView *nullView = nullptr;
-	context_->PSSetShaderResources(0, 1, &nullView);
-	InvalidateLastTexture();
+	ForgetLastTexture();
 }
 
 void TextureCacheD3D11::BindAsClutTexture(Draw::Texture *tex, bool smooth) {

--- a/GPU/D3D11/TextureCacheD3D11.h
+++ b/GPU/D3D11/TextureCacheD3D11.h
@@ -51,7 +51,6 @@ public:
 	void SetFramebufferManager(FramebufferManagerD3D11 *fbManager);
 
 	void ForgetLastTexture() override;
-	void InvalidateLastTexture() override;
 
 	bool GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level, bool *isFramebuffer) override;
 

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -111,7 +111,7 @@ void TextureCacheDX9::ReleaseTexture(TexCacheEntry *entry, bool delete_them) {
 	}
 }
 
-void TextureCacheDX9::InvalidateLastTexture() {
+void TextureCacheDX9::ForgetLastTexture() {
 	lastBoundTexture = INVALID_TEX;
 }
 
@@ -154,7 +154,7 @@ void TextureCacheDX9::ApplySamplingParams(const SamplerCacheKey &key) {
 void TextureCacheDX9::StartFrame() {
 	TextureCacheCommon::StartFrame();
 
-	InvalidateLastTexture();
+	lastBoundTexture = nullptr;
 	timesInvalidatedAllThisFrame_ = 0;
 	replacementTimeThisFrame_ = 0.0;
 
@@ -229,7 +229,7 @@ void TextureCacheDX9::BindTexture(TexCacheEntry *entry) {
 
 void TextureCacheDX9::Unbind() {
 	device_->SetTexture(0, nullptr);
-	InvalidateLastTexture();
+	ForgetLastTexture();
 }
 
 void TextureCacheDX9::BindAsClutTexture(Draw::Texture *tex, bool smooth) {

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -38,10 +38,7 @@ public:
 
 	void SetFramebufferManager(FramebufferManagerDX9 *fbManager);
 
-	void ForgetLastTexture() override {
-		InvalidateLastTexture();
-	}
-	void InvalidateLastTexture() override;
+	void ForgetLastTexture() override;
 
 	bool GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level, bool *isFramebuffer) override;
 

--- a/GPU/GLES/StencilBufferGLES.cpp
+++ b/GPU/GLES/StencilBufferGLES.cpp
@@ -133,7 +133,7 @@ bool FramebufferManagerGLES::ReadbackStencilbuffer(Draw::Framebuffer *fbo, int x
 	auto *blitFBO = GetTempFBO(TempFBO::COPY, fbo->Width(), fbo->Height());
 	draw_->BindFramebufferAsRenderTarget(blitFBO, { RPAction::DONT_CARE, RPAction::DONT_CARE, RPAction::DONT_CARE }, "ReadbackStencilbufferSync");
 	Draw::Viewport viewport = { 0.0f, 0.0f, (float)fbo->Width(), (float)fbo->Height(), 0.0f, 1.0f };
-	draw_->SetViewports(1, &viewport);
+	draw_->SetViewport(viewport);
 
 	draw_->BindFramebufferAsTexture(fbo, TEX_SLOT_PSP_TEXTURE, FB_STENCIL_BIT, 0);
 	draw_->BindSamplerStates(TEX_SLOT_PSP_TEXTURE, 1, &stencilReadbackSampler_);

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -143,7 +143,7 @@ static void ConvertColors(void *dstBuf, const void *srcBuf, Draw::DataFormat dst
 void TextureCacheGLES::StartFrame() {
 	TextureCacheCommon::StartFrame();
 
-	InvalidateLastTexture();
+	ForgetLastTexture();
 	timesInvalidatedAllThisFrame_ = 0;
 	replacementTimeThisFrame_ = 0.0;
 
@@ -234,7 +234,7 @@ void TextureCacheGLES::BindTexture(TexCacheEntry *entry) {
 
 void TextureCacheGLES::Unbind() {
 	render_->BindTexture(TEX_SLOT_PSP_TEXTURE, nullptr);
-	InvalidateLastTexture();
+	ForgetLastTexture();
 }
 
 void TextureCacheGLES::BindAsClutTexture(Draw::Texture *tex, bool smooth) {
@@ -385,7 +385,7 @@ Draw::DataFormat TextureCacheGLES::GetDestFormat(GETextureFormat format, GEPalet
 }
 
 bool TextureCacheGLES::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level, bool *isFramebuffer) {
-	InvalidateLastTexture();
+	ForgetLastTexture();
 	SetTexture();
 	if (!nextTexture_) {
 		return GetCurrentFramebufferTextureDebug(buffer, isFramebuffer);

--- a/GPU/GLES/TextureCacheGLES.h
+++ b/GPU/GLES/TextureCacheGLES.h
@@ -51,9 +51,6 @@ public:
 	void ForgetLastTexture() override {
 		lastBoundTexture = nullptr;
 	}
-	void InvalidateLastTexture() override {
-		lastBoundTexture = nullptr;
-	}
 
 	bool GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level, bool *isFramebuffer) override;
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -329,7 +329,6 @@ static const VkFilter MagFiltVK[2] = {
 void TextureCacheVulkan::StartFrame() {
 	TextureCacheCommon::StartFrame();
 
-	InvalidateLastTexture();
 	textureShaderCache_->Decimate();
 
 	timesInvalidatedAllThisFrame_ = 0;
@@ -419,7 +418,6 @@ void TextureCacheVulkan::ApplySamplingParams(const SamplerCacheKey &key) {
 void TextureCacheVulkan::Unbind() {
 	imageView_ = VK_NULL_HANDLE;
 	curSampler_ = VK_NULL_HANDLE;
-	InvalidateLastTexture();
 }
 
 void TextureCacheVulkan::BindAsClutTexture(Draw::Texture *tex, bool smooth) {

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -72,8 +72,6 @@ public:
 	}
 
 	void ForgetLastTexture() override {}
-	void InvalidateLastTexture() override {}
-
 	void NotifyConfigChanged() override;
 
 	void GetVulkanHandles(VkImageView &imageView, VkSampler &sampler) {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1375,7 +1375,7 @@ void EmuScreen::preRender() {
 		viewport.Height = pixel_yres;
 		viewport.MaxDepth = 1.0;
 		viewport.MinDepth = 0.0;
-		draw->SetViewports(1, &viewport);
+		draw->SetViewport(viewport);
 	}
 	draw->SetTargetSize(pixel_xres, pixel_yres);
 }
@@ -1523,7 +1523,7 @@ void EmuScreen::renderUI() {
 	viewport.Height = pixel_yres;
 	viewport.MaxDepth = 1.0;
 	viewport.MinDepth = 0.0;
-	thin3d->SetViewports(1, &viewport);
+	thin3d->SetViewport(viewport);
 
 	if (root_) {
 		UI::LayoutViewHierarchy(*ctx, root_, false);

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -375,7 +375,7 @@ void DrawGameBackground(UIContext &dc, const Path &gamePath, float x, float y, f
 		viewport.Height = pixel_yres;
 		viewport.MaxDepth = 1.0;
 		viewport.MinDepth = 0.0;
-		draw->SetViewports(1, &viewport);
+		draw->SetViewport(viewport);
 		dc.BeginFrame();
 		dc.RebindTexture();
 		dc.Begin();

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -201,7 +201,7 @@ bool PPSSPP_UWPMain::Render() {
 	dp_xres = pixel_xres * g_dpi_scale_x;
 	dp_yres = pixel_yres * g_dpi_scale_y;
 
-	context->RSSetViewport(viewport);
+	context->RSSetViewports(1, &viewport);
 
 	NativeRender(ctx_.get());
 	return true;

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -201,7 +201,7 @@ bool PPSSPP_UWPMain::Render() {
 	dp_xres = pixel_xres * g_dpi_scale_x;
 	dp_yres = pixel_yres * g_dpi_scale_y;
 
-	context->RSSetViewports(1, &viewport);
+	context->RSSetViewport(viewport);
 
 	NativeRender(ctx_.get());
 	return true;


### PR DESCRIPTION
~~`DIRTY_TEXTURE_PARAMS` and `DIRTY_TEXTURE_IMAGE` had so many interdependencies that we never actually checked for them separately. So let's just merge them into a new flag, `DIRTY_TEXTURE`.~~

Took out the above since I missed that we are actually smart with "rehash" and that might matter indeed in some cases.

Additionally, ForgetTexture and InvalidateTexture only had a meaningful distinction on D3D, and that was easily cleaned up, so get rid of one of them.

Plus, threw in a removal of the "count" parameter of SetViewport in thin3d, not used and won't be.