### PR TITLE
More rendering cleanup

### DIFF
--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -123,9 +123,10 @@ public:
 
 	VertexDecoder *GetVertexDecoder(u32 vtype);
 
+	virtual void ClearTrackedVertexArrays() {}
+
 protected:
 	virtual bool UpdateUseHWTessellation(bool enabled) { return enabled; }
-	virtual void ClearTrackedVertexArrays() {}
 
 	int ComputeNumVertsToDecode() const;
 	void DecodeVerts(u8 *dest);

--- a/GPU/D3D11/FramebufferManagerD3D11.cpp
+++ b/GPU/D3D11/FramebufferManagerD3D11.cpp
@@ -15,10 +15,6 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include <algorithm>
-#include <d3d11.h>
-#include <D3Dcompiler.h>
-
 #include "Common/Common.h"
 #include "Common/GPU/thin3d.h"
 

--- a/GPU/D3D11/FramebufferManagerD3D11.h
+++ b/GPU/D3D11/FramebufferManagerD3D11.h
@@ -17,19 +17,12 @@
 
 #pragma once
 
-#include <d3d11.h>
-
 // Keeps track of allocated FBOs.
 // Also provides facilities for drawing and later converting raw
 // pixel data.
 
-#include "GPU/GPUCommon.h"
 #include "GPU/Common/FramebufferManagerCommon.h"
 #include "Common/GPU/thin3d.h"
-
-class TextureCacheD3D11;
-class DrawEngineD3D11;
-class ShaderManagerD3D11;
 
 class FramebufferManagerD3D11 : public FramebufferManagerCommon {
 public:

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -185,16 +185,6 @@ void GPU_D3D11::FinishDeferred() {
 	drawEngine_.FinishDeferred();
 }
 
-inline void GPU_D3D11::CheckFlushOp(int cmd, u32 diff) {
-	const u8 cmdFlags = cmdInfo_[cmd].flags;
-	if (diff && (cmdFlags & FLAG_FLUSHBEFOREONCHANGE)) {
-		if (dumpThisFrame_) {
-			NOTICE_LOG(G3D, "================ FLUSH ================");
-		}
-		drawEngine_.Flush();
-	}
-}
-
 void GPU_D3D11::PreExecuteOp(u32 op, u32 diff) {
 	CheckFlushOp(op >> 24, diff);
 }

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -185,10 +185,6 @@ void GPU_D3D11::FinishDeferred() {
 	drawEngine_.FinishDeferred();
 }
 
-void GPU_D3D11::PreExecuteOp(u32 op, u32 diff) {
-	CheckFlushOp(op >> 24, diff);
-}
-
 void GPU_D3D11::ExecuteOp(u32 op, u32 diff) {
 	const u8 cmd = op >> 24;
 	const CommandInfo info = cmdInfo_[cmd];

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -198,20 +198,6 @@ void GPU_D3D11::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_D3D11::DoState(PointerWrap &p) {
-	GPUCommon::DoState(p);
-
-	// TODO: Some of these things may not be necessary.
-	// None of these are necessary when saving.
-	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen) {
-		textureCache_->Clear(true);
-		drawEngine_.ClearTrackedVertexArrays();
-
-		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-		framebufferManager_->DestroyAllFBOs();
-	}
-}
-
 std::vector<std::string> GPU_D3D11::DebugGetShaderIDs(DebugShaderType type) {
 	switch (type) {
 	case SHADER_TYPE_VERTEXLOADER:

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -15,7 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include <set>
+#include <string>
 
 #include "Common/Log.h"
 #include "Common/Serialize/Serializer.h"

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -185,19 +185,6 @@ void GPU_D3D11::FinishDeferred() {
 	drawEngine_.FinishDeferred();
 }
 
-void GPU_D3D11::ExecuteOp(u32 op, u32 diff) {
-	const u8 cmd = op >> 24;
-	const CommandInfo info = cmdInfo_[cmd];
-	const u8 cmdFlags = info.flags;
-	if ((cmdFlags & FLAG_EXECUTE) || (diff && (cmdFlags & FLAG_EXECUTEONCHANGE))) {
-		(this->*info.func)(op, diff);
-	} else if (diff) {
-		uint64_t dirty = info.flags >> 8;
-		if (dirty)
-			gstate_c.Dirty(dirty);
-	}
-}
-
 void GPU_D3D11::GetStats(char *buffer, size_t bufsize) {
 	size_t offset = FormatGPUStatsCommon(buffer, bufsize);
 	buffer += offset;

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -37,7 +37,6 @@ public:
 	~GPU_D3D11();
 
 	u32 CheckGPUFeatures() const override;
-	void ExecuteOp(u32 op, u32 diff) override;
 
 	void GetStats(char *buffer, size_t bufsize) override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -54,8 +54,6 @@ protected:
 	void FinishDeferred() override;
 
 private:
-	// void ApplyDrawState(int prim);
-	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo() override;
 
 	void InitClear() override;

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -42,8 +42,6 @@ public:
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 
-	void DoState(PointerWrap &p) override;
-
 	// Using string because it's generic - makes no assumptions on the size of the shader IDs of this backend.
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType shader) override;
 	std::string DebugGetShaderString(std::string id, DebugShaderType shader, DebugShaderStringType stringType) override;

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -37,7 +37,6 @@ public:
 	~GPU_D3D11();
 
 	u32 CheckGPUFeatures() const override;
-	void PreExecuteOp(u32 op, u32 diff) override;
 	void ExecuteOp(u32 op, u32 diff) override;
 
 	void GetStats(char *buffer, size_t bufsize) override;

--- a/GPU/Directx9/FramebufferManagerDX9.cpp
+++ b/GPU/Directx9/FramebufferManagerDX9.cpp
@@ -15,34 +15,16 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include "Common/Common.h"
-#include "Common/Data/Convert/ColorConv.h"
-#include "Common/GPU/thin3d.h"
-#include "Common/Math/lin/matrix4x4.h"
-#include "Core/MemMap.h"
-#include "Core/Config.h"
-#include "Core/ConfigValues.h"
-#include "Core/System.h"
-#include "GPU/ge_constants.h"
-#include "GPU/GPUState.h"
-#include "GPU/Debugger/Stepping.h"
+#include <d3d9.h>
 
-#include "Common/GPU/D3D9/D3D9StateCache.h"
+#include "Common/Common.h"
+#include "Common/GPU/thin3d.h"
+
 #include "GPU/Common/FramebufferManagerCommon.h"
+#include "GPU/Common/GPUStateUtils.h"
 #include "GPU/Common/PresentationCommon.h"
 #include "GPU/Common/TextureDecoder.h"
 #include "GPU/Directx9/FramebufferManagerDX9.h"
-#include "GPU/Directx9/ShaderManagerDX9.h"
-#include "GPU/Directx9/TextureCacheDX9.h"
-#include "GPU/Directx9/DrawEngineDX9.h"
-
-#include "Common/GPU/thin3d.h"
-
-#include <algorithm>
-
-#ifdef _M_SSE
-#include <emmintrin.h>
-#endif
 
 FramebufferManagerDX9::FramebufferManagerDX9(Draw::DrawContext *draw)
 	: FramebufferManagerCommon(draw) {

--- a/GPU/Directx9/FramebufferManagerDX9.h
+++ b/GPU/Directx9/FramebufferManagerDX9.h
@@ -17,16 +17,8 @@
 
 #pragma once
 
-#include <unordered_map>
-
-#include <d3d9.h>
-
 #include "GPU/GPUCommon.h"
 #include "GPU/Common/FramebufferManagerCommon.h"
-
-class TextureCacheDX9;
-class DrawEngineDX9;
-class ShaderManagerDX9;
 
 class FramebufferManagerDX9 : public FramebufferManagerCommon {
 public:

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -15,7 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include <set>
+#include <string>
 
 #include "Common/Serialize/Serializer.h"
 #include "Common/GraphicsContext.h"

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -194,20 +194,6 @@ void GPU_DX9::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_DX9::DoState(PointerWrap &p) {
-	GPUCommon::DoState(p);
-
-	// TODO: Some of these things may not be necessary.
-	// None of these are necessary when saving.
-	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen) {
-		textureCache_->Clear(true);
-		drawEngine_.ClearTrackedVertexArrays();
-
-		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-		framebufferManager_->DestroyAllFBOs();
-	}
-}
-
 std::vector<std::string> GPU_DX9::DebugGetShaderIDs(DebugShaderType type) {
 	switch (type) {
 	case SHADER_TYPE_VERTEXLOADER:

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -181,19 +181,6 @@ void GPU_DX9::FinishDeferred() {
 	drawEngine_.FinishDeferred();
 }
 
-void GPU_DX9::ExecuteOp(u32 op, u32 diff) {
-	const u8 cmd = op >> 24;
-	const CommandInfo info = cmdInfo_[cmd];
-	const u8 cmdFlags = info.flags;
-	if ((cmdFlags & FLAG_EXECUTE) || (diff && (cmdFlags & FLAG_EXECUTEONCHANGE))) {
-		(this->*info.func)(op, diff);
-	} else if (diff) {
-		uint64_t dirty = info.flags >> 8;
-		if (dirty)
-			gstate_c.Dirty(dirty);
-	}
-}
-
 void GPU_DX9::GetStats(char *buffer, size_t bufsize) {
 	size_t offset = FormatGPUStatsCommon(buffer, bufsize);
 	buffer += offset;

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -181,16 +181,6 @@ void GPU_DX9::FinishDeferred() {
 	drawEngine_.FinishDeferred();
 }
 
-inline void GPU_DX9::CheckFlushOp(int cmd, u32 diff) {
-	const u8 cmdFlags = cmdInfo_[cmd].flags;
-	if (diff && (cmdFlags & FLAG_FLUSHBEFOREONCHANGE)) {
-		if (dumpThisFrame_) {
-			NOTICE_LOG(G3D, "================ FLUSH ================");
-		}
-		drawEngine_.Flush();
-	}
-}
-
 void GPU_DX9::PreExecuteOp(u32 op, u32 diff) {
 	CheckFlushOp(op >> 24, diff);
 }

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -181,10 +181,6 @@ void GPU_DX9::FinishDeferred() {
 	drawEngine_.FinishDeferred();
 }
 
-void GPU_DX9::PreExecuteOp(u32 op, u32 diff) {
-	CheckFlushOp(op >> 24, diff);
-}
-
 void GPU_DX9::ExecuteOp(u32 op, u32 diff) {
 	const u8 cmd = op >> 24;
 	const CommandInfo info = cmdInfo_[cmd];

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -54,7 +54,6 @@ protected:
 	void FinishDeferred() override;
 
 private:
-	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo() override;
 
 	void InitClear() override;

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -36,7 +36,6 @@ public:
 	~GPU_DX9();
 
 	u32 CheckGPUFeatures() const override;
-	void PreExecuteOp(u32 op, u32 diff) override;
 	void ExecuteOp(u32 op, u32 diff) override;
 
 	void ReapplyGfxState() override;

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -42,8 +42,6 @@ public:
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 
-	void DoState(PointerWrap &p) override;
-
 	// Using string because it's generic - makes no assumptions on the size of the shader IDs of this backend.
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType shader) override;
 	std::string DebugGetShaderString(std::string id, DebugShaderType shader, DebugShaderStringType stringType) override;

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -36,7 +36,6 @@ public:
 	~GPU_DX9();
 
 	u32 CheckGPUFeatures() const override;
-	void ExecuteOp(u32 op, u32 diff) override;
 
 	void ReapplyGfxState() override;
 	void GetStats(char *buffer, size_t bufsize) override;

--- a/GPU/GLES/FramebufferManagerGLES.cpp
+++ b/GPU/GLES/FramebufferManagerGLES.cpp
@@ -15,28 +15,14 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include <algorithm>
-
-#include "Common/Data/Convert/ColorConv.h"
-#include "Common/Profiler/Profiler.h"
-#include "Common/GPU/OpenGL/GLCommon.h"
-#include "Common/GPU/OpenGL/GLDebugLog.h"
-#include "Common/GPU/OpenGL/GLSLProgram.h"
+#include "Common/GPU/OpenGL/GLFeatures.h"
+#include "Common/GPU/OpenGL/GLRenderManager.h"
 #include "Common/GPU/thin3d.h"
-#include "Core/MemMap.h"
-#include "Core/Config.h"
-#include "Core/ConfigValues.h"
 #include "Core/System.h"
-#include "Core/Reporting.h"
-#include "GPU/ge_constants.h"
-#include "GPU/GPUState.h"
 #include "GPU/Common/FramebufferManagerCommon.h"
 #include "GPU/Common/PresentationCommon.h"
 #include "GPU/Common/TextureDecoder.h"
-#include "GPU/Debugger/Stepping.h"
 #include "GPU/GLES/FramebufferManagerGLES.h"
-#include "GPU/GLES/TextureCacheGLES.h"
-#include "GPU/GLES/ShaderManagerGLES.h"
 
 FramebufferManagerGLES::FramebufferManagerGLES(Draw::DrawContext *draw) :
 	FramebufferManagerCommon(draw)

--- a/GPU/GLES/FramebufferManagerGLES.h
+++ b/GPU/GLES/FramebufferManagerGLES.h
@@ -18,13 +18,8 @@
 #pragma once
 
 #include "Common/GPU/thin3d.h"
-#include "GPU/GPUCommon.h"
 #include "GPU/Common/FramebufferManagerCommon.h"
-
-class TextureCacheGLES;
-class DrawEngineGLES;
-class ShaderManagerGLES;
-class GLRProgram;
+#include "GPU/Common/GPUDebugInterface.h"
 
 class FramebufferManagerGLES : public FramebufferManagerCommon {
 public:

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -334,19 +334,6 @@ void GPU_GLES::FinishDeferred() {
 	drawEngine_.FinishDeferred();
 }
 
-void GPU_GLES::ExecuteOp(u32 op, u32 diff) {
-	const u8 cmd = op >> 24;
-	const CommandInfo info = cmdInfo_[cmd];
-	const u8 cmdFlags = info.flags;
-	if ((cmdFlags & FLAG_EXECUTE) || (diff && (cmdFlags & FLAG_EXECUTEONCHANGE))) {
-		(this->*info.func)(op, diff);
-	} else if (diff) {
-		uint64_t dirty = info.flags >> 8;
-		if (dirty)
-			gstate_c.Dirty(dirty);
-	}
-}
-
 void GPU_GLES::GetStats(char *buffer, size_t bufsize) {
 	size_t offset = FormatGPUStatsCommon(buffer, bufsize);
 	buffer += offset;

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -348,21 +348,6 @@ void GPU_GLES::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_GLES::DoState(PointerWrap &p) {
-	GPUCommon::DoState(p);
-
-	// TODO: Some of these things may not be necessary.
-	// None of these are necessary when saving.
-	// In Freeze-Frame mode, we don't want to do any of this.
-	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen) {
-		textureCache_->Clear(true);
-		drawEngine_.ClearTrackedVertexArrays();
-
-		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-		framebufferManager_->DestroyAllFBOs();
-	}
-}
-
 std::vector<std::string> GPU_GLES::DebugGetShaderIDs(DebugShaderType type) {
 	switch (type) {
 	case SHADER_TYPE_VERTEXLOADER:

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -334,16 +334,6 @@ void GPU_GLES::FinishDeferred() {
 	drawEngine_.FinishDeferred();
 }
 
-inline void GPU_GLES::CheckFlushOp(int cmd, u32 diff) {
-	const u8 cmdFlags = cmdInfo_[cmd].flags;
-	if (diff && (cmdFlags & FLAG_FLUSHBEFOREONCHANGE)) {
-		if (dumpThisFrame_) {
-			NOTICE_LOG(G3D, "================ FLUSH ================");
-		}
-		drawEngine_.Flush();
-	}
-}
-
 void GPU_GLES::PreExecuteOp(u32 op, u32 diff) {
 	CheckFlushOp(op >> 24, diff);
 }

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -334,10 +334,6 @@ void GPU_GLES::FinishDeferred() {
 	drawEngine_.FinishDeferred();
 }
 
-void GPU_GLES::PreExecuteOp(u32 op, u32 diff) {
-	CheckFlushOp(op >> 24, diff);
-}
-
 void GPU_GLES::ExecuteOp(u32 op, u32 diff) {
 	const u8 cmd = op >> 24;
 	const CommandInfo info = cmdInfo_[cmd];

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -43,8 +43,6 @@ public:
 	bool IsReady() override;
 	void CancelReady() override;
 
-	void ExecuteOp(u32 op, u32 diff) override;
-
 	void ReapplyGfxState() override;
 	void GetStats(char *buffer, size_t bufsize) override;
 

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -43,7 +43,6 @@ public:
 	bool IsReady() override;
 	void CancelReady() override;
 
-	void PreExecuteOp(u32 op, u32 diff) override;
 	void ExecuteOp(u32 op, u32 diff) override;
 
 	void ReapplyGfxState() override;

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -65,7 +65,6 @@ protected:
 	void FinishDeferred() override;
 
 private:
-	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo() override;
 
 	void InitClear() override;

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -49,8 +49,6 @@ public:
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 
-	void DoState(PointerWrap &p) override;
-
 	// Using string because it's generic - makes no assumptions on the size of the shader IDs of this backend.
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType shader) override;
 	std::string DebugGetShaderString(std::string id, DebugShaderType shader, DebugShaderStringType stringType) override;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2706,6 +2706,19 @@ void GPUCommon::FlushImm() {
 	}
 }
 
+void GPUCommon::ExecuteOp(u32 op, u32 diff) {
+	const u8 cmd = op >> 24;
+	const CommandInfo info = cmdInfo_[cmd];
+	const u8 cmdFlags = info.flags;
+	if ((cmdFlags & FLAG_EXECUTE) || (diff && (cmdFlags & FLAG_EXECUTEONCHANGE))) {
+		(this->*info.func)(op, diff);
+	} else if (diff) {
+		uint64_t dirty = info.flags >> 8;
+		if (dirty)
+			gstate_c.Dirty(dirty);
+	}
+}
+
 void GPUCommon::Execute_Unknown(u32 op, u32 diff) {
 	if ((op & 0xFFFFFF) != 0)
 		WARN_LOG_REPORT_ONCE(unknowncmd, G3D, "Unknown GE command : %08x ", op);

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2706,53 +2706,6 @@ void GPUCommon::FlushImm() {
 	}
 }
 
-void GPUCommon::ExecuteOp(u32 op, u32 diff) {
-	const u32 cmd = op >> 24;
-
-	// Handle control and drawing commands here directly. The others we delegate.
-	switch (cmd) {
-	case GE_CMD_NOP:
-		break;
-
-	case GE_CMD_OFFSETADDR:
-		Execute_OffsetAddr(op, diff);
-		break;
-
-	case GE_CMD_ORIGIN:
-		Execute_Origin(op, diff);
-		break;
-
-	case GE_CMD_JUMP:
-		Execute_Jump(op, diff);
-		break;
-
-	case GE_CMD_BJUMP:
-		Execute_BJump(op, diff);
-		break;
-
-	case GE_CMD_CALL:
-		Execute_Call(op, diff);
-		break;
-
-	case GE_CMD_RET:
-		Execute_Ret(op, diff);
-		break;
-
-	case GE_CMD_SIGNAL:
-	case GE_CMD_FINISH:
-		// Processed in GE_END.
-		break;
-
-	case GE_CMD_END:
-		Execute_End(op, diff);
-		break;
-
-	default:
-		DEBUG_LOG(G3D, "DL Unknown: %08x @ %08x", op, currentList == NULL ? 0 : currentList->pc);
-		break;
-	}
-}
-
 void GPUCommon::Execute_Unknown(u32 op, u32 diff) {
 	if ((op & 0xFFFFFF) != 0)
 		WARN_LOG_REPORT_ONCE(unknowncmd, G3D, "Unknown GE command : %08x ", op);

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1411,7 +1411,7 @@ void GPUCommon::ProcessDLQueue() {
 }
 
 void GPUCommon::PreExecuteOp(u32 op, u32 diff) {
-	// Nothing to do
+	CheckFlushOp(op >> 24, diff);
 }
 
 void GPUCommon::Execute_OffsetAddr(u32 op, u32 diff) {

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -3609,3 +3609,13 @@ void GPUCommon::UpdateMSAALevel(Draw::DrawContext *draw) {
 		msaaLevel_ = 0;
 	}
 }
+
+void GPUCommon::CheckFlushOp(int cmd, u32 diff) {
+	const u8 cmdFlags = cmdInfo_[cmd].flags;
+	if (diff && (cmdFlags & FLAG_FLUSHBEFOREONCHANGE)) {
+		if (dumpThisFrame_) {
+			NOTICE_LOG(G3D, "================ FLUSH ================");
+		}
+		drawEngineCommon_->DispatchFlush();
+	}
+}

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2871,6 +2871,17 @@ void GPUCommon::DoState(PointerWrap &p) {
 	if (s >= 6) {
 		Do(p, edramTranslation_);
 	}
+
+	// TODO: Some of these things may not be necessary.
+	// None of these are necessary when saving.
+	// The textureCache_ check avoids this getting called in SoftGPU.
+	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen && textureCache_) {
+		textureCache_->Clear(true);
+		drawEngineCommon_->ClearTrackedVertexArrays();
+
+		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
+		framebufferManager_->DestroyAllFBOs();
+	}
 }
 
 void GPUCommon::InterruptStart(int listid) {

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -108,6 +108,7 @@ public:
 
 	void DumpNextFrame() override;
 
+	void ExecuteOp(u32 op, u32 diff) override;
 	virtual void PreExecuteOp(u32 op, u32 diff);
 
 	bool InterpretList(DisplayList &list);

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -108,7 +108,6 @@ public:
 
 	void DumpNextFrame() override;
 
-	void ExecuteOp(u32 op, u32 diff) override;
 	virtual void PreExecuteOp(u32 op, u32 diff);
 
 	bool InterpretList(DisplayList &list);

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -109,7 +109,7 @@ public:
 	void DumpNextFrame() override;
 
 	void ExecuteOp(u32 op, u32 diff) override;
-	void PreExecuteOp(u32 op, u32 diff) override;
+	virtual void PreExecuteOp(u32 op, u32 diff);
 
 	bool InterpretList(DisplayList &list);
 	void ProcessDLQueue();

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -313,6 +313,8 @@ protected:
 	// TODO: Unify this. The only backend that differs is Vulkan.
 	virtual void FinishDeferred() {}
 
+	void CheckFlushOp(int cmd, u32 diff);
+
 	void AdvanceVerts(u32 vertType, int count, int bytesRead) {
 		if ((vertType & GE_VTYPE_IDX_MASK) != GE_VTYPE_IDX_NONE) {
 			int indexShift = ((vertType & GE_VTYPE_IDX_MASK) >> GE_VTYPE_IDX_SHIFT) - 1;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -310,7 +310,7 @@ protected:
 	void FlushImm();
 	void DoBlockTransfer(u32 skipDrawReason);
 
-	// TODO: Unify this.
+	// TODO: Unify this. The only backend that differs is Vulkan.
 	virtual void FinishDeferred() {}
 
 	void AdvanceVerts(u32 vertType, int count, int bytesRead) {

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -221,7 +221,6 @@ public:
 	virtual void InterruptEnd(int listid) = 0;
 	virtual void SyncEnd(GPUSyncType waitType, int listid, bool wokeThreads) = 0;
 
-	virtual void PreExecuteOp(u32 op, u32 diff) = 0;
 	virtual void ExecuteOp(u32 op, u32 diff) = 0;
 
 	// Framebuffer management

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -210,6 +210,7 @@ protected:
 	void ConvertTextureDescFrom16(Draw::TextureDesc &desc, int srcwidth, int srcheight, const uint16_t *overrideData = nullptr);
 
 	void BuildReportingInfo() override {}
+	void PreExecuteOp(u32 op, u32 diff) override {}
 
 private:
 	void MarkDirty(uint32_t addr, uint32_t stride, uint32_t height, GEBufferFormat fmt, SoftGPUVRAMDirty value);

--- a/GPU/Vulkan/FramebufferManagerVulkan.cpp
+++ b/GPU/Vulkan/FramebufferManagerVulkan.cpp
@@ -15,35 +15,9 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include <algorithm>
-
-#include "Common/Profiler/Profiler.h"
-
-#include "Common/System/Display.h"
-#include "Common/Math/lin/matrix4x4.h"
-#include "Common/Data/Convert/ColorConv.h"
-#include "Common/Data/Convert/SmallDataConvert.h"
-#include "Common/GPU/thin3d.h"
-
-#include "Common/GPU/Vulkan/VulkanContext.h"
-#include "Common/GPU/Vulkan/VulkanMemory.h"
-#include "Common/GPU/Vulkan/VulkanImage.h"
-#include "Common/GPU/Vulkan/VulkanRenderManager.h"
-#include "Core/MemMap.h"
-#include "Core/Config.h"
-#include "Core/ConfigValues.h"
-#include "Core/System.h"
-#include "GPU/ge_constants.h"
-#include "GPU/GPUInterface.h"
 #include "GPU/GPUState.h"
 
-#include "GPU/Common/TextureDecoder.h"
-#include "GPU/Common/FramebufferManagerCommon.h"
-#include "GPU/Debugger/Stepping.h"
 #include "GPU/Vulkan/FramebufferManagerVulkan.h"
-#include "GPU/Vulkan/DrawEngineVulkan.h"
-#include "GPU/Vulkan/TextureCacheVulkan.h"
-#include "GPU/Vulkan/ShaderManagerVulkan.h"
 #include "GPU/Vulkan/VulkanUtil.h"
 
 using namespace PPSSPP_VK;
@@ -51,10 +25,6 @@ using namespace PPSSPP_VK;
 FramebufferManagerVulkan::FramebufferManagerVulkan(Draw::DrawContext *draw) :
 	FramebufferManagerCommon(draw) {
 	presentation_->SetLanguage(GLSL_VULKAN);
-}
-
-FramebufferManagerVulkan::~FramebufferManagerVulkan() {
-	DeviceLost();
 }
 
 void FramebufferManagerVulkan::NotifyClear(bool clearColor, bool clearAlpha, bool clearDepth, uint32_t color, float depth) {

--- a/GPU/Vulkan/FramebufferManagerVulkan.h
+++ b/GPU/Vulkan/FramebufferManagerVulkan.h
@@ -17,24 +17,14 @@
 
 #pragma once
 
-#include "Common/GPU/Vulkan/VulkanLoader.h"
-#include "GPU/GPUInterface.h"
-#include "GPU/Common/FramebufferManagerCommon.h"
-#include "GPU/Common/GPUDebugInterface.h"
-#include "GPU/Common/PresentationCommon.h"
-#include "GPU/Vulkan/VulkanUtil.h"
+#include "Common/GPU/thin3d.h"
 
-class TextureCacheVulkan;
-class DrawEngineVulkan;
-class VulkanContext;
-class ShaderManagerVulkan;
-class VulkanTexture;
-class VulkanPushBuffer;
+#include "GPU/Common/FramebufferManagerCommon.h"
+#include "GPU/Common/PresentationCommon.h"
 
 class FramebufferManagerVulkan : public FramebufferManagerCommon {
 public:
 	explicit FramebufferManagerVulkan(Draw::DrawContext *draw);
-	~FramebufferManagerVulkan();
 
 	// If within a render pass, this will just issue a regular clear. If beginning a new render pass,
 	// do that.

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -523,20 +523,6 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 	);
 }
 
-void GPU_Vulkan::DoState(PointerWrap &p) {
-	GPUCommon::DoState(p);
-
-	// TODO: Some of these things may not be necessary.
-	// None of these are necessary when saving.
-	// In Freeze-Frame mode, we don't want to do any of this.
-	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen) {
-		textureCache_->Clear(true);
-
-		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-		framebufferManager_->DestroyAllFBOs();
-	}
-}
-
 std::vector<std::string> GPU_Vulkan::DebugGetShaderIDs(DebugShaderType type) {
 	if (type == SHADER_TYPE_VERTEXLOADER) {
 		return drawEngine_.DebugGetVertexLoaderIDs();

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -416,16 +416,6 @@ void GPU_Vulkan::FinishDeferred() {
 	drawEngine_.FinishDeferred();
 }
 
-inline void GPU_Vulkan::CheckFlushOp(int cmd, u32 diff) {
-	const u8 cmdFlags = cmdInfo_[cmd].flags;
-	if (diff && (cmdFlags & FLAG_FLUSHBEFOREONCHANGE)) {
-		if (dumpThisFrame_) {
-			NOTICE_LOG(G3D, "================ FLUSH ================");
-		}
-		drawEngine_.Flush();
-	}
-}
-
 void GPU_Vulkan::PreExecuteOp(u32 op, u32 diff) {
 	CheckFlushOp(op >> 24, diff);
 }

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -416,19 +416,6 @@ void GPU_Vulkan::FinishDeferred() {
 	drawEngine_.FinishDeferred();
 }
 
-void GPU_Vulkan::ExecuteOp(u32 op, u32 diff) {
-	const u8 cmd = op >> 24;
-	const CommandInfo info = cmdInfo_[cmd];
-	const u8 cmdFlags = info.flags;
-	if ((cmdFlags & FLAG_EXECUTE) || (diff && (cmdFlags & FLAG_EXECUTEONCHANGE))) {
-		(this->*info.func)(op, diff);
-	} else if (diff) {
-		uint64_t dirty = info.flags >> 8;
-		if (dirty)
-			gstate_c.Dirty(dirty);
-	}
-}
-
 void GPU_Vulkan::InitDeviceObjects() {
 	INFO_LOG(G3D, "GPU_Vulkan::InitDeviceObjects");
 	VulkanContext *vulkan = (VulkanContext *)draw_->GetNativeObject(Draw::NativeObject::CONTEXT);

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -416,10 +416,6 @@ void GPU_Vulkan::FinishDeferred() {
 	drawEngine_.FinishDeferred();
 }
 
-void GPU_Vulkan::PreExecuteOp(u32 op, u32 diff) {
-	CheckFlushOp(op >> 24, diff);
-}
-
 void GPU_Vulkan::ExecuteOp(u32 op, u32 diff) {
 	const u8 cmd = op >> 24;
 	const CommandInfo info = cmdInfo_[cmd];

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -71,7 +71,6 @@ protected:
 	void CheckRenderResized() override;
 
 private:
-	void CheckFlushOp(int cmd, u32 diff);
 	void BuildReportingInfo() override;
 	void InitClear() override;
 	void CopyDisplayToOutput(bool reallyDirty) override;

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -47,8 +47,6 @@ public:
 	void BeginHostFrame() override;
 	void EndHostFrame() override;
 
-	void ExecuteOp(u32 op, u32 diff) override;
-
 	void GetStats(char *buffer, size_t bufsize) override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -47,7 +47,6 @@ public:
 	void BeginHostFrame() override;
 	void EndHostFrame() override;
 
-	void PreExecuteOp(u32 op, u32 diff) override;
 	void ExecuteOp(u32 op, u32 diff) override;
 
 	void GetStats(char *buffer, size_t bufsize) override;

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -51,8 +51,6 @@ public:
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
 	void DeviceRestore() override;
 
-	void DoState(PointerWrap &p) override;
-
 	// Using string because it's generic - makes no assumptions on the size of the shader IDs of this backend.
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType shader) override;
 	std::string DebugGetShaderString(std::string id, DebugShaderType shader, DebugShaderStringType stringType) override;


### PR DESCRIPTION
Unify a bunch of functions. Code duplication makes maintenance and refactoring hard so let's keep removing it.

There's more to unify that's common to the accelerated backends, so in a next step after this I'll introduce a GPUCommonHardware or something like that, as an intermediate step in the hiearchy. SoftGPU will continue to inherit from GPUCommon, while the the others will inherit from GPUCommonHardware where they can share logic that's not relevant to the software renderer.