### PR TITLE
Introduce GPUCommonHW (code cleanup)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1659,6 +1659,8 @@ set(GPU_SOURCES
 	GPU/GPU.h
 	GPU/GPUCommon.cpp
 	GPU/GPUCommon.h
+	GPU/GPUCommonHW.cpp
+	GPU/GPUCommonHW.h
 	GPU/GPUState.cpp
 	GPU/GPUState.h
 	GPU/Math3D.cpp

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -169,17 +169,6 @@ void GPU_D3D11::BeginFrame() {
 	}
 }
 
-void GPU_D3D11::CopyDisplayToOutput(bool reallyDirty) {
-	// Flush anything left over.
-	drawEngine_.Flush();
-
-	shaderManager_->DirtyLastShader();
-
-	framebufferManagerD3D11_->CopyDisplayToOutput(reallyDirty);
-
-	gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-}
-
 void GPU_D3D11::FinishDeferred() {
 	// This finishes reading any vertex data that is pending.
 	drawEngine_.FinishDeferred();

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -42,7 +42,7 @@
 #include "GPU/D3D11/D3D11Util.h"
 
 GPU_D3D11::GPU_D3D11(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
-	: GPUCommon(gfxCtx, draw), drawEngine_(draw,
+	: GPUCommonHW(gfxCtx, draw), drawEngine_(draw,
 	(ID3D11Device *)draw->GetNativeObject(Draw::NativeObject::DEVICE),
 	(ID3D11DeviceContext *)draw->GetNativeObject(Draw::NativeObject::CONTEXT)) {
 	device_ = (ID3D11Device *)draw->GetNativeObject(Draw::NativeObject::DEVICE);

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -52,7 +52,6 @@ private:
 
 	void InitClear() override;
 	void BeginFrame() override;
-	void CopyDisplayToOutput(bool reallyDirty) override;
 
 	ID3D11Device *device_;
 	ID3D11DeviceContext *context_;

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -21,17 +21,15 @@
 #include <vector>
 #include <d3d11.h>
 
-#include "GPU/GPUCommon.h"
+#include "GPU/GPUCommonHW.h"
 #include "GPU/D3D11/DrawEngineD3D11.h"
-#include "GPU/Common/TextureShaderCommon.h"
 #include "GPU/Common/VertexDecoderCommon.h"
 
 class FramebufferManagerD3D11;
 class ShaderManagerD3D11;
-class LinkedShaderD3D11;
 class TextureCacheD3D11;
 
-class GPU_D3D11 : public GPUCommon {
+class GPU_D3D11 : public GPUCommonHW {
 public:
 	GPU_D3D11(GraphicsContext *gfxCtx, Draw::DrawContext *draw);
 	~GPU_D3D11();

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -166,16 +166,6 @@ void GPU_DX9::BeginFrame() {
 	}
 }
 
-void GPU_DX9::CopyDisplayToOutput(bool reallyDirty) {
-	drawEngine_.Flush();
-
-	shaderManager_->DirtyLastShader();
-
-	framebufferManagerDX9_->CopyDisplayToOutput(reallyDirty);
-
-	gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-}
-
 void GPU_DX9::FinishDeferred() {
 	// This finishes reading any vertex data that is pending.
 	drawEngine_.FinishDeferred();

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -44,7 +44,7 @@
 #include "GPU/Directx9/TextureCacheDX9.h"
 
 GPU_DX9::GPU_DX9(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
-	: GPUCommon(gfxCtx, draw),
+	: GPUCommonHW(gfxCtx, draw),
 	  drawEngine_(draw) {
 	device_ = (LPDIRECT3DDEVICE9)draw->GetNativeObject(Draw::NativeObject::DEVICE);
 	deviceEx_ = (LPDIRECT3DDEVICE9EX)draw->GetNativeObject(Draw::NativeObject::DEVICE_EX);

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -54,7 +54,6 @@ private:
 
 	void InitClear() override;
 	void BeginFrame() override;
-	void CopyDisplayToOutput(bool reallyDirty) override;
 
 	LPDIRECT3DDEVICE9 device_;
 	LPDIRECT3DDEVICE9EX deviceEx_;

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -20,7 +20,7 @@
 #include <string>
 #include <vector>
 
-#include "GPU/GPUCommon.h"
+#include "GPU/GPUCommonHW.h"
 #include "GPU/Directx9/FramebufferManagerDX9.h"
 #include "GPU/Directx9/DrawEngineDX9.h"
 #include "GPU/Common/TextureShaderCommon.h"
@@ -30,7 +30,7 @@ class ShaderManagerDX9;
 class LinkedShaderDX9;
 class TextureCacheDX9;
 
-class GPU_DX9 : public GPUCommon {
+class GPU_DX9 : public GPUCommonHW {
 public:
 	GPU_DX9(GraphicsContext *gfxCtx, Draw::DrawContext *draw);
 	~GPU_DX9();

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -48,7 +48,7 @@
 #endif
 
 GPU_GLES::GPU_GLES(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
-	: GPUCommon(gfxCtx, draw), drawEngine_(draw), fragmentTestCache_(draw) {
+	: GPUCommonHW(gfxCtx, draw), drawEngine_(draw), fragmentTestCache_(draw) {
 	UpdateVsyncInterval(true);
 	gstate_c.SetUseFlags(CheckGPUFeatures());
 

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -317,18 +317,6 @@ void GPU_GLES::BeginFrame() {
 	framebufferManagerGL_->BeginFrame();
 }
 
-void GPU_GLES::CopyDisplayToOutput(bool reallyDirty) {
-	// Flush anything left over.
-	framebufferManagerGL_->RebindFramebuffer("RebindFramebuffer - CopyDisplayToOutput");
-	drawEngine_.Flush();
-
-	shaderManagerGL_->DirtyLastShader();
-
-	framebufferManagerGL_->CopyDisplayToOutput(reallyDirty);
-
-	gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-}
-
 void GPU_GLES::FinishDeferred() {
 	// This finishes reading any vertex data that is pending.
 	drawEngine_.FinishDeferred();

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -22,7 +22,7 @@
 
 #include "Common/File/Path.h"
 
-#include "GPU/GPUCommon.h"
+#include "GPU/GPUCommonHW.h"
 #include "GPU/Common/TextureShaderCommon.h"
 #include "GPU/GLES/FramebufferManagerGLES.h"
 #include "GPU/GLES/DrawEngineGLES.h"
@@ -32,7 +32,7 @@ class ShaderManagerGLES;
 class TextureCacheGLES;
 class LinkedShader;
 
-class GPU_GLES : public GPUCommon {
+class GPU_GLES : public GPUCommonHW {
 public:
 	GPU_GLES(GraphicsContext *gfxCtx, Draw::DrawContext *draw);
 	~GPU_GLES();

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -64,7 +64,6 @@ private:
 
 	void InitClear() override;
 	void BeginFrame() override;
-	void CopyDisplayToOutput(bool reallyDirty) override;
 	void Reinitialize() override;
 
 	FramebufferManagerGLES *framebufferManagerGL_;

--- a/GPU/GPU.vcxproj
+++ b/GPU/GPU.vcxproj
@@ -427,6 +427,7 @@
     </ClInclude>
     <ClInclude Include="GPU.h" />
     <ClInclude Include="GPUCommon.h" />
+    <ClInclude Include="GPUCommonHW.h" />
     <ClInclude Include="GPUInterface.h" />
     <ClInclude Include="GPUState.h" />
     <ClInclude Include="Math3D.h" />
@@ -572,6 +573,7 @@
     </ClCompile>
     <ClCompile Include="GPU.cpp" />
     <ClCompile Include="GPUCommon.cpp" />
+    <ClCompile Include="GPUCommonHW.cpp" />
     <ClCompile Include="GPUState.cpp" />
     <ClCompile Include="Math3D.cpp" />
     <ClCompile Include="Software\BinManager.cpp" />

--- a/GPU/GPU.vcxproj.filters
+++ b/GPU/GPU.vcxproj.filters
@@ -264,6 +264,9 @@
     <ClInclude Include="Common\GeometryShaderGenerator.h">
       <Filter>Common</Filter>
     </ClInclude>
+    <ClInclude Include="GPUCommonHW.h">
+      <Filter>Common</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Math3D.cpp">
@@ -522,6 +525,9 @@
       <Filter>GLES</Filter>
     </ClCompile>
     <ClCompile Include="Common\VertexDecoderRiscV.cpp">
+      <Filter>Common</Filter>
+    </ClCompile>
+    <ClCompile Include="GPUCommonHW.cpp">
       <Filter>Common</Filter>
     </ClCompile>
   </ItemGroup>

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -2867,17 +2867,6 @@ void GPUCommon::DoState(PointerWrap &p) {
 	if (s >= 6) {
 		Do(p, edramTranslation_);
 	}
-
-	// TODO: Some of these things may not be necessary.
-	// None of these are necessary when saving.
-	// The textureCache_ check avoids this getting called in SoftGPU.
-	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen && textureCache_) {
-		textureCache_->Clear(true);
-		drawEngineCommon_->ClearTrackedVertexArrays();
-
-		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-		framebufferManager_->DestroyAllFBOs();
-	}
 }
 
 void GPUCommon::InterruptStart(int listid) {

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1410,10 +1410,6 @@ void GPUCommon::ProcessDLQueue() {
 	// Since the event is in CoreTiming, we're in sync.  Just set 0 now.
 }
 
-void GPUCommon::PreExecuteOp(u32 op, u32 diff) {
-	CheckFlushOp(op >> 24, diff);
-}
-
 void GPUCommon::Execute_OffsetAddr(u32 op, u32 diff) {
 	gstate_c.offsetAddr = op << 8;
 }

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -109,7 +109,7 @@ public:
 	void DumpNextFrame() override;
 
 	void ExecuteOp(u32 op, u32 diff) override;
-	virtual void PreExecuteOp(u32 op, u32 diff);
+	virtual void PreExecuteOp(u32 op, u32 diff) {}
 
 	bool InterpretList(DisplayList &list);
 	void ProcessDLQueue();

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -330,9 +330,10 @@ protected:
 
 	void UpdateMSAALevel(Draw::DrawContext *draw);
 
+	DrawEngineCommon *drawEngineCommon_ = nullptr;
+
 	FramebufferManagerCommon *framebufferManager_ = nullptr;
 	TextureCacheCommon *textureCache_ = nullptr;
-	DrawEngineCommon *drawEngineCommon_ = nullptr;
 	ShaderManagerCommon *shaderManager_ = nullptr;
 	bool flushOnParams_ = true;
 

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1,5 +1,7 @@
 #include "Common/GPU/thin3d.h"
 #include "GPU/GPUCommonHW.h"
+#include "GPU/Common/DrawEngineCommon.h"
+#include "GPU/Common/FramebufferManagerCommon.h"
 
 
 GPUCommonHW::GPUCommonHW(GraphicsContext *gfxCtx, Draw::DrawContext *draw) : GPUCommon(gfxCtx, draw) {
@@ -10,4 +12,15 @@ GPUCommonHW::~GPUCommonHW() {}
 
 void GPUCommonHW::PreExecuteOp(u32 op, u32 diff) {
 	CheckFlushOp(op >> 24, diff);
+}
+
+void GPUCommonHW::CopyDisplayToOutput(bool reallyDirty) {
+	// Flush anything left over.
+	drawEngineCommon_->DispatchFlush();
+
+	shaderManager_->DirtyLastShader();
+
+	framebufferManager_->CopyDisplayToOutput(reallyDirty);
+
+	gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
 }

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1,13 +1,14 @@
 #include "Common/GPU/thin3d.h"
+#include "Common/Serialize/Serializer.h"
+
+#include "Core/System.h"
+
 #include "GPU/GPUCommonHW.h"
 #include "GPU/Common/DrawEngineCommon.h"
+#include "GPU/Common/TextureCacheCommon.h"
 #include "GPU/Common/FramebufferManagerCommon.h"
 
-
-GPUCommonHW::GPUCommonHW(GraphicsContext *gfxCtx, Draw::DrawContext *draw) : GPUCommon(gfxCtx, draw) {
-
-}
-
+GPUCommonHW::GPUCommonHW(GraphicsContext *gfxCtx, Draw::DrawContext *draw) : GPUCommon(gfxCtx, draw) {}
 GPUCommonHW::~GPUCommonHW() {}
 
 void GPUCommonHW::PreExecuteOp(u32 op, u32 diff) {
@@ -23,4 +24,18 @@ void GPUCommonHW::CopyDisplayToOutput(bool reallyDirty) {
 	framebufferManager_->CopyDisplayToOutput(reallyDirty);
 
 	gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
+}
+
+void GPUCommonHW::DoState(PointerWrap &p) {
+	GPUCommon::DoState(p);
+
+	// TODO: Some of these things may not be necessary.
+	// None of these are necessary when saving.
+	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen) {
+		textureCache_->Clear(true);
+		drawEngineCommon_->ClearTrackedVertexArrays();
+
+		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
+		framebufferManager_->DestroyAllFBOs();
+	}
 }

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1,0 +1,13 @@
+#include "Common/GPU/thin3d.h"
+#include "GPU/GPUCommonHW.h"
+
+
+GPUCommonHW::GPUCommonHW(GraphicsContext *gfxCtx, Draw::DrawContext *draw) : GPUCommon(gfxCtx, draw) {
+
+}
+
+GPUCommonHW::~GPUCommonHW() {}
+
+void GPUCommonHW::PreExecuteOp(u32 op, u32 diff) {
+	CheckFlushOp(op >> 24, diff);
+}

--- a/GPU/GPUCommonHW.h
+++ b/GPU/GPUCommonHW.h
@@ -9,8 +9,9 @@ public:
 	GPUCommonHW(GraphicsContext *gfxCtx, Draw::DrawContext *draw);
 	~GPUCommonHW();
 
+	void CopyDisplayToOutput(bool reallyDirty) override;
+
 protected:
 	void PreExecuteOp(u32 op, u32 diff);
-
 };
 

--- a/GPU/GPUCommonHW.h
+++ b/GPU/GPUCommonHW.h
@@ -10,8 +10,10 @@ public:
 	~GPUCommonHW();
 
 	void CopyDisplayToOutput(bool reallyDirty) override;
+	void DoState(PointerWrap &p) override;
 
 protected:
 	void PreExecuteOp(u32 op, u32 diff);
+
 };
 

--- a/GPU/GPUCommonHW.h
+++ b/GPU/GPUCommonHW.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "GPUCommon.h"
+
+// Shared GPUCommon implementation for the HW backends.
+// Things that are irrelevant for SoftGPU should live here.
+class GPUCommonHW : public GPUCommon {
+public:
+	GPUCommonHW(GraphicsContext *gfxCtx, Draw::DrawContext *draw);
+	~GPUCommonHW();
+
+protected:
+	void PreExecuteOp(u32 op, u32 diff);
+
+};
+

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -210,7 +210,6 @@ protected:
 	void ConvertTextureDescFrom16(Draw::TextureDesc &desc, int srcwidth, int srcheight, const uint16_t *overrideData = nullptr);
 
 	void BuildReportingInfo() override {}
-	void PreExecuteOp(u32 op, u32 diff) override {}
 
 private:
 	void MarkDirty(uint32_t addr, uint32_t stride, uint32_t height, GEBufferFormat fmt, SoftGPUVRAMDirty value);

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -401,17 +401,6 @@ void GPU_Vulkan::InitClear() {
 	}
 }
 
-void GPU_Vulkan::CopyDisplayToOutput(bool reallyDirty) {
-	// Flush anything left over.
-	drawEngine_.Flush();
-
-	shaderManagerVulkan_->DirtyLastShader();
-
-	framebufferManagerVulkan_->CopyDisplayToOutput(reallyDirty);
-
-	gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
-}
-
 void GPU_Vulkan::FinishDeferred() {
 	drawEngine_.FinishDeferred();
 }

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -46,7 +46,7 @@
 #include "Common/GPU/Vulkan/VulkanQueueRunner.h"
 
 GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
-	: GPUCommon(gfxCtx, draw), drawEngine_(draw) {
+	: GPUCommonHW(gfxCtx, draw), drawEngine_(draw) {
 	gstate_c.SetUseFlags(CheckGPUFeatures());
 	drawEngine_.InitDeviceObjects();
 

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -22,7 +22,7 @@
 
 #include "Common/File/Path.h"
 
-#include "GPU/GPUCommon.h"
+#include "GPU/GPUCommonHW.h"
 #include "GPU/Vulkan/DrawEngineVulkan.h"
 #include "GPU/Vulkan/PipelineManagerVulkan.h"
 #include "GPU/Common/TextureShaderCommon.h"
@@ -32,7 +32,7 @@ class ShaderManagerVulkan;
 class LinkedShader;
 class TextureCacheVulkan;
 
-class GPU_Vulkan : public GPUCommon {
+class GPU_Vulkan : public GPUCommonHW {
 public:
 	GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw);
 	~GPU_Vulkan();

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -68,7 +68,6 @@ protected:
 private:
 	void BuildReportingInfo() override;
 	void InitClear() override;
-	void CopyDisplayToOutput(bool reallyDirty) override;
 	void Reinitialize() override;
 
 	void InitDeviceObjects();

--- a/UWP/GPU_UWP/GPU_UWP.vcxproj
+++ b/UWP/GPU_UWP/GPU_UWP.vcxproj
@@ -423,6 +423,7 @@
     <ClInclude Include="..\..\GPU\ge_constants.h" />
     <ClInclude Include="..\..\GPU\GPU.h" />
     <ClInclude Include="..\..\GPU\GPUCommon.h" />
+    <ClInclude Include="..\..\GPU\GPUCommonHW.h" />
     <ClInclude Include="..\..\GPU\GPUInterface.h" />
     <ClInclude Include="..\..\GPU\GPUState.h" />
     <ClInclude Include="..\..\GPU\Math3D.h" />
@@ -487,6 +488,7 @@
     <ClCompile Include="..\..\GPU\GeDisasm.cpp" />
     <ClCompile Include="..\..\GPU\GPU.cpp" />
     <ClCompile Include="..\..\GPU\GPUCommon.cpp" />
+    <ClCompile Include="..\..\GPU\GPUCommonHW.cpp" />
     <ClCompile Include="..\..\GPU\GPUState.cpp" />
     <ClCompile Include="..\..\GPU\Math3D.cpp" />
     <ClCompile Include="..\..\GPU\Software\BinManager.cpp" />

--- a/UWP/GPU_UWP/GPU_UWP.vcxproj.filters
+++ b/UWP/GPU_UWP/GPU_UWP.vcxproj.filters
@@ -61,6 +61,7 @@
     <ClCompile Include="..\..\GPU\Common\Draw2D.cpp" />
     <ClCompile Include="..\..\GPU\Common\TextureShaderCommon.cpp" />
     <ClCompile Include="..\..\GPU\Common\DepthBufferCommon.cpp" />
+    <ClCompile Include="..\..\GPU\GPUCommonHW.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\GPU\Common\DepalettizeShaderCommon.h" />
@@ -123,5 +124,6 @@
     <ClInclude Include="..\..\GPU\Common\ReinterpretFramebuffer.h" />
     <ClInclude Include="..\..\GPU\Common\Draw2D.h" />
     <ClInclude Include="..\..\GPU\Common\TextureShaderCommon.h" />
+    <ClInclude Include="..\..\GPU\GPUCommonHW.h" />
   </ItemGroup>
 </Project>

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -358,6 +358,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/GPU/Math3D.cpp \
   $(SRC)/GPU/GPU.cpp \
   $(SRC)/GPU/GPUCommon.cpp \
+  $(SRC)/GPU/GPUCommonHW.cpp \
   $(SRC)/GPU/GPUState.cpp \
   $(SRC)/GPU/GeConstants.cpp \
   $(SRC)/GPU/GeDisasm.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -406,6 +406,7 @@ SOURCES_CXX += \
 	$(GPUDIR)/GeConstants.cpp \
 	$(GPUDIR)/GeDisasm.cpp \
 	$(GPUDIR)/GPUCommon.cpp \
+	$(GPUDIR)/GPUCommonHW.cpp \
 	$(GPUDIR)/GPU.cpp \
 	$(GPUDIR)/GPUState.cpp \
 	$(GPUDIR)/Math3D.cpp \


### PR DESCRIPTION
Followup to #17000 . Just creates a home for GPU functions that are shared between the HW renderers, but not the software renderer, and moves a couple of things there. More to come.