### PR TITLE
Move more stuff to GPUCommonHW

### DIFF
--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -74,6 +74,8 @@ public:
 	virtual ~DrawEngineCommon();
 
 	void Init();
+	virtual void DeviceLost() = 0;
+	virtual void DeviceRestore(Draw::DrawContext *draw) = 0;
 
 	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices);
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -139,7 +139,22 @@ TextureCacheCommon::~TextureCacheCommon() {
 }
 
 void TextureCacheCommon::StartFrame() {
+	ForgetLastTexture();
 	textureShaderCache_->Decimate();
+	timesInvalidatedAllThisFrame_ = 0;
+	replacementTimeThisFrame_ = 0.0;
+
+	if (texelsScaledThisFrame_) {
+		VERBOSE_LOG(G3D, "Scaled %d texels", texelsScaledThisFrame_);
+	}
+	texelsScaledThisFrame_ = 0;
+
+	if (clearCacheNextFrame_) {
+		Clear(true);
+		clearCacheNextFrame_ = false;
+	} else {
+		Decimate(false);
+	}
 }
 
 // Produces a signed 1.23.8 value.

--- a/GPU/D3D11/DrawEngineD3D11.h
+++ b/GPU/D3D11/DrawEngineD3D11.h
@@ -119,6 +119,9 @@ public:
 	DrawEngineD3D11(Draw::DrawContext *draw, ID3D11Device *device, ID3D11DeviceContext *context);
 	~DrawEngineD3D11();
 
+	void DeviceLost() override { draw_ = nullptr;  }
+	void DeviceRestore(Draw::DrawContext *draw) override { draw_ = draw; }
+
 	void SetShaderManager(ShaderManagerD3D11 *shaderManager) {
 		shaderManager_ = shaderManager;
 	}

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -122,8 +122,8 @@ void GPU_D3D11::DeviceLost() {
 	GPUCommonHW::DeviceLost();
 }
 
-void GPU_D3D11::DeviceRestore() {
-	GPUCommonHW::DeviceRestore();
+void GPU_D3D11::DeviceRestore(Draw::DrawContext *draw) {
+	GPUCommonHW::DeviceRestore(draw);
 	// Nothing needed.
 }
 

--- a/GPU/D3D11/GPU_D3D11.h
+++ b/GPU/D3D11/GPU_D3D11.h
@@ -38,7 +38,7 @@ public:
 
 	void GetStats(char *buffer, size_t bufsize) override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
-	void DeviceRestore() override;
+	void DeviceRestore(Draw::DrawContext *draw) override;
 
 protected:
 	void FinishDeferred() override;

--- a/GPU/D3D11/ShaderManagerD3D11.h
+++ b/GPU/D3D11/ShaderManagerD3D11.h
@@ -89,7 +89,7 @@ public:
 	void ClearShaders() override;
 	void DirtyLastShader() override;
 
-	void DeviceLost() override {}
+	void DeviceLost() override { draw_ = nullptr; }
 	void DeviceRestore(Draw::DrawContext *draw) override { draw_ = draw; }
 	int GetNumVertexShaders() const { return (int)vsCache_.size(); }
 	int GetNumFragmentShaders() const { return (int)fsCache_.size(); }

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -185,25 +185,6 @@ void TextureCacheD3D11::ForgetLastTexture() {
 	context_->PSSetShaderResources(0, 4, nullTex);
 }
 
-void TextureCacheD3D11::StartFrame() {
-	TextureCacheCommon::StartFrame();
-
-	lastBoundTexture = INVALID_TEX;
-	timesInvalidatedAllThisFrame_ = 0;
-	replacementTimeThisFrame_ = 0.0;
-
-	if (texelsScaledThisFrame_) {
-		// INFO_LOG(G3D, "Scaled %i texels", texelsScaledThisFrame_);
-	}
-	texelsScaledThisFrame_ = 0;
-	if (clearCacheNextFrame_) {
-		Clear(true);
-		clearCacheNextFrame_ = false;
-	} else {
-		Decimate();
-	}
-}
-
 void TextureCacheD3D11::UpdateCurrentClut(GEPaletteFormat clutFormat, u32 clutBase, bool clutIndexIsSimple) {
 	const u32 clutBaseBytes = clutBase * (clutFormat == GE_CMODE_32BIT_ABGR8888 ? sizeof(u32) : sizeof(u16));
 	// Technically, these extra bytes weren't loaded, but hopefully it was loaded earlier.

--- a/GPU/D3D11/TextureCacheD3D11.h
+++ b/GPU/D3D11/TextureCacheD3D11.h
@@ -52,7 +52,7 @@ public:
 
 	bool GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level, bool *isFramebuffer) override;
 
-	void DeviceLost() override {}
+	void DeviceLost() override { draw_ = nullptr; }
 	void DeviceRestore(Draw::DrawContext *draw) override { draw_ = draw; }
 
 protected:

--- a/GPU/D3D11/TextureCacheD3D11.h
+++ b/GPU/D3D11/TextureCacheD3D11.h
@@ -46,8 +46,6 @@ public:
 	TextureCacheD3D11(Draw::DrawContext *draw, Draw2D *draw2D);
 	~TextureCacheD3D11();
 
-	void StartFrame() override;
-
 	void SetFramebufferManager(FramebufferManagerD3D11 *fbManager);
 
 	void ForgetLastTexture() override;

--- a/GPU/Directx9/DrawEngineDX9.h
+++ b/GPU/Directx9/DrawEngineDX9.h
@@ -107,6 +107,9 @@ public:
 	DrawEngineDX9(Draw::DrawContext *draw);
 	~DrawEngineDX9();
 
+	void DeviceLost() override { draw_ = nullptr; }
+	void DeviceRestore(Draw::DrawContext *draw) override { draw_ = draw; }
+
 	void SetShaderManager(ShaderManagerDX9 *shaderManager) {
 		shaderManager_ = shaderManager;
 	}

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -105,6 +105,14 @@ u32 GPU_DX9::CheckGPUFeatures() const {
 	return CheckGPUFeaturesLate(features);
 }
 
+void GPU_DX9::DeviceLost() {
+	GPUCommonHW::DeviceLost();
+}
+
+void GPU_DX9::DeviceRestore(Draw::DrawContext *draw) {
+	GPUCommonHW::DeviceRestore(draw);
+}
+
 void GPU_DX9::ReapplyGfxState() {
 	dxstate.Restore();
 	GPUCommonHW::ReapplyGfxState();

--- a/GPU/Directx9/GPU_DX9.h
+++ b/GPU/Directx9/GPU_DX9.h
@@ -36,6 +36,9 @@ public:
 
 	u32 CheckGPUFeatures() const override;
 
+	void DeviceLost() override;
+	void DeviceRestore(Draw::DrawContext *draw) override;
+
 	void ReapplyGfxState() override;
 	void GetStats(char *buffer, size_t bufsize) override;
 

--- a/GPU/Directx9/ShaderManagerDX9.h
+++ b/GPU/Directx9/ShaderManagerDX9.h
@@ -85,7 +85,7 @@ public:
 	int GetNumVertexShaders() const { return (int)vsCache_.size(); }
 	int GetNumFragmentShaders() const { return (int)fsCache_.size(); }
 
-	void DeviceLost() override {}
+	void DeviceLost() override { draw_ = nullptr; }
 	void DeviceRestore(Draw::DrawContext *draw) override { draw_ = draw; }
 
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType type);

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -154,22 +154,8 @@ void TextureCacheDX9::ApplySamplingParams(const SamplerCacheKey &key) {
 void TextureCacheDX9::StartFrame() {
 	TextureCacheCommon::StartFrame();
 
-	lastBoundTexture = nullptr;
-	timesInvalidatedAllThisFrame_ = 0;
-	replacementTimeThisFrame_ = 0.0;
-
-	if (texelsScaledThisFrame_) {
-		VERBOSE_LOG(G3D, "Scaled %i texels", texelsScaledThisFrame_);
-	}
-	texelsScaledThisFrame_ = 0;
-	if (clearCacheNextFrame_) {
-		Clear(true);
-		clearCacheNextFrame_ = false;
-	} else {
-		Decimate();
-	}
-
 	if (gstate_c.Use(GPU_USE_ANISOTROPY)) {
+		// Just take the opportunity to set the global aniso level here, once per frame.
 		DWORD aniso = 1 << g_Config.iAnisotropyLevel;
 		DWORD anisotropyLevel = aniso > maxAnisotropyLevel ? maxAnisotropyLevel : aniso;
 		device_->SetSamplerState(0, D3DSAMP_MAXANISOTROPY, anisotropyLevel);

--- a/GPU/Directx9/TextureCacheDX9.h
+++ b/GPU/Directx9/TextureCacheDX9.h
@@ -42,7 +42,7 @@ public:
 
 	bool GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level, bool *isFramebuffer) override;
 
-	void DeviceLost() override {}
+	void DeviceLost() override { draw_ = nullptr; }
 	void DeviceRestore(Draw::DrawContext *draw) override { draw_ = draw; }
 
 protected:

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -76,8 +76,8 @@ public:
 		fragmentTestCache_ = testCache;
 	}
 
-	void DeviceLost();
-	void DeviceRestore(Draw::DrawContext *draw);
+	void DeviceLost() override;
+	void DeviceRestore(Draw::DrawContext *draw) override;
 
 	void ClearTrackedVertexArrays() override {}
 

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -239,7 +239,6 @@ void GPU_GLES::DeviceLost() {
 	// TransformDraw has registered as a GfxResourceHolder.
 	CancelReady();
 	fragmentTestCache_.DeviceLost();
-	drawEngine_.DeviceLost();
 
 	GPUCommonHW::DeviceLost();
 }
@@ -247,13 +246,8 @@ void GPU_GLES::DeviceLost() {
 void GPU_GLES::DeviceRestore(Draw::DrawContext *draw) {
 	GPUCommonHW::DeviceRestore(draw);
 
-	UpdateCmdInfo();
-	UpdateVsyncInterval(true);
-
-	shaderManager_->DeviceRestore(draw_);
-	textureCache_->DeviceRestore(draw_);
-	drawEngine_.DeviceRestore(draw_);
 	fragmentTestCache_.DeviceRestore(draw_);
+	UpdateVsyncInterval(true);
 }
 
 void GPU_GLES::BeginHostFrame() {

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -244,8 +244,8 @@ void GPU_GLES::DeviceLost() {
 	GPUCommonHW::DeviceLost();
 }
 
-void GPU_GLES::DeviceRestore() {
-	GPUCommonHW::DeviceRestore();
+void GPU_GLES::DeviceRestore(Draw::DrawContext *draw) {
+	GPUCommonHW::DeviceRestore(draw);
 
 	UpdateCmdInfo();
 	UpdateVsyncInterval(true);

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -46,7 +46,7 @@ public:
 	void GetStats(char *buffer, size_t bufsize) override;
 
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
-	void DeviceRestore() override;
+	void DeviceRestore(Draw::DrawContext *draw) override;
 
 	void BeginHostFrame() override;
 	void EndHostFrame() override;

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -143,10 +143,6 @@ static void ConvertColors(void *dstBuf, const void *srcBuf, Draw::DataFormat dst
 void TextureCacheGLES::StartFrame() {
 	TextureCacheCommon::StartFrame();
 
-	ForgetLastTexture();
-	timesInvalidatedAllThisFrame_ = 0;
-	replacementTimeThisFrame_ = 0.0;
-
 	GLRenderManager *renderManager = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 	if (!lowMemoryMode_ && renderManager->SawOutOfMemory()) {
 		lowMemoryMode_ = true;
@@ -158,17 +154,6 @@ void TextureCacheGLES::StartFrame() {
 		} else {
 			host->NotifyUserMessage(err->T("Warning: Video memory FULL, switching to slow caching mode"), 2.0f);
 		}
-	}
-
-	if (texelsScaledThisFrame_) {
-		VERBOSE_LOG(G3D, "Scaled %i texels", texelsScaledThisFrame_);
-	}
-	texelsScaledThisFrame_ = 0;
-	if (clearCacheNextFrame_) {
-		Clear(true);
-		clearCacheNextFrame_ = false;
-	} else {
-		Decimate();
 	}
 }
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -133,8 +133,8 @@ void GPUCommon::DeviceLost() {
 }
 
 // Call at the start of the GPU implementation's DeviceRestore
-void GPUCommon::DeviceRestore() {
-	draw_ = (Draw::DrawContext *)PSP_CoreParameter().graphicsContext->GetDrawContext();
+void GPUCommon::DeviceRestore(Draw::DrawContext *draw) {
+	draw_ = draw;
 	framebufferManager_->DeviceRestore(draw_);
 	PPGeSetDrawContext(draw_);
 }
@@ -2024,10 +2024,6 @@ bool GPUCommon::PerformWriteStencilFromMemory(u32 dest, int size, WriteStencil f
 		return true;
 	}
 	return false;
-}
-
-std::vector<FramebufferInfo> GPUCommon::GetFramebufferList() const {
-	return framebufferManager_->GetFramebufferList();
 }
 
 bool GPUCommon::GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices) {

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -211,7 +211,6 @@ public:
 	const std::list<int>& GetDisplayLists() override {
 		return dlQueue;
 	}
-	std::vector<FramebufferInfo> GetFramebufferList() const override;
 
 	s64 GetListTicks(int listid) const override {
 		if (listid >= 0 && listid < DisplayListMaxCount) {
@@ -227,7 +226,7 @@ public:
 
 protected:
 	void DeviceLost() override;
-	void DeviceRestore() override;
+	void DeviceRestore(Draw::DrawContext *draw) override;
 
 	void ClearCacheNextFrame() override {}
 

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -70,7 +70,6 @@ struct TransformedVertex {
 class GPUCommon : public GPUInterface, public GPUDebugInterface {
 public:
 	GPUCommon(GraphicsContext *gfxCtx, Draw::DrawContext *draw);
-	~GPUCommon();
 
 	Draw::DrawContext *GetDrawContext() override {
 		return draw_;
@@ -225,9 +224,6 @@ public:
 	}
 
 protected:
-	void DeviceLost() override;
-	void DeviceRestore(Draw::DrawContext *draw) override;
-
 	void ClearCacheNextFrame() override {}
 
 	virtual void CheckRenderResized() {}
@@ -274,8 +270,6 @@ protected:
 			gstate_c.vertexAddr += bytesRead;
 		}
 	}
-
-	size_t FormatGPUStatsCommon(char *buf, size_t size);
 
 	virtual void BuildReportingInfo() = 0;
 

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -6,6 +6,7 @@
 
 #include "Core/System.h"
 #include "Core/Config.h"
+#include "Core/Util/PPGeDraw.h"
 
 #include "GPU/GPUCommonHW.h"
 #include "GPU/Common/SplineCommon.h"
@@ -386,6 +387,8 @@ GPUCommonHW::GPUCommonHW(GraphicsContext *gfxCtx, Draw::DrawContext *draw) : GPU
 
 	UpdateCmdInfo();
 	UpdateMSAALevel(draw);
+
+	PPGeSetDrawContext(draw);
 }
 
 GPUCommonHW::~GPUCommonHW() {
@@ -407,11 +410,20 @@ void GPUCommonHW::CheckRenderResized() {
 	}
 }
 
+// Call at the END of the GPU implementation's DeviceLost
 void GPUCommonHW::DeviceLost() {
-	textureCache_->Clear(false);
 	framebufferManager_->DeviceLost();
+	draw_ = nullptr;
+	textureCache_->Clear(false);
 	textureCache_->DeviceLost();
 	shaderManager_->DeviceLost();
+}
+
+// Call at the start of the GPU implementation's DeviceRestore
+void GPUCommonHW::DeviceRestore(Draw::DrawContext *draw) {
+	draw_ = draw;
+	framebufferManager_->DeviceRestore(draw_);
+	PPGeSetDrawContext(draw_);
 }
 
 void GPUCommonHW::UpdateCmdInfo() {
@@ -1598,4 +1610,47 @@ void GPUCommonHW::Execute_BoneMtxData(u32 op, u32 diff) {
 	num++;
 	gstate.boneMatrixNumber = (GE_CMD_BONEMATRIXNUMBER << 24) | (num & 0x00FFFFFF);
 	gstate.boneMatrixData = GE_CMD_BONEMATRIXDATA << 24;
+}
+
+size_t GPUCommonHW::FormatGPUStatsCommon(char *buffer, size_t size) {
+	float vertexAverageCycles = gpuStats.numVertsSubmitted > 0 ? (float)gpuStats.vertexGPUCycles / (float)gpuStats.numVertsSubmitted : 0.0f;
+	return snprintf(buffer, size,
+		"DL processing time: %0.2f ms, %d drawsync, %d listsync\n"
+		"Draw calls: %d, flushes %d, clears %d (cached: %d)\n"
+		"Num Tracked Vertex Arrays: %d\n"
+		"Vertices: %d cached: %d uncached: %d\n"
+		"FBOs active: %d (evaluations: %d)\n"
+		"Textures: %d, dec: %d, invalidated: %d, hashed: %d kB\n"
+		"readbacks %d (%d non-block), uploads %d, depal %d\n"
+		"Copies: depth %d, color %d, reint %d, blend %d, selftex %d\n"
+		"GPU cycles executed: %d (%f per vertex)\n",
+		gpuStats.msProcessingDisplayLists * 1000.0f,
+		gpuStats.numDrawSyncs,
+		gpuStats.numListSyncs,
+		gpuStats.numDrawCalls,
+		gpuStats.numFlushes,
+		gpuStats.numClears,
+		gpuStats.numCachedDrawCalls,
+		gpuStats.numTrackedVertexArrays,
+		gpuStats.numVertsSubmitted,
+		gpuStats.numCachedVertsDrawn,
+		gpuStats.numUncachedVertsDrawn,
+		(int)framebufferManager_->NumVFBs(),
+		gpuStats.numFramebufferEvaluations,
+		(int)textureCache_->NumLoadedTextures(),
+		gpuStats.numTexturesDecoded,
+		gpuStats.numTextureInvalidations,
+		gpuStats.numTextureDataBytesHashed / 1024,
+		gpuStats.numBlockingReadbacks,
+		gpuStats.numReadbacks,
+		gpuStats.numUploads,
+		gpuStats.numDepal,
+		gpuStats.numDepthCopies,
+		gpuStats.numColorCopies,
+		gpuStats.numReinterpretCopies,
+		gpuStats.numCopiesForShaderBlend,
+		gpuStats.numCopiesForSelfTex,
+		gpuStats.vertexGPUCycles + gpuStats.otherGPUCycles,
+		vertexAverageCycles
+	);
 }

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -678,6 +678,10 @@ bool GPUCommonHW::GetOutputFramebuffer(GPUDebugBuffer &buffer) {
 	return framebufferManager_ ? framebufferManager_->GetOutputFramebuffer(buffer) : false;
 }
 
+std::vector<FramebufferInfo> GPUCommonHW::GetFramebufferList() const {
+	return framebufferManager_->GetFramebufferList();
+}
+
 bool GPUCommonHW::GetCurrentClut(GPUDebugBuffer &buffer) {
 	return textureCache_->GetCurrentClutBuffer(buffer);
 }

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -417,13 +417,22 @@ void GPUCommonHW::DeviceLost() {
 	textureCache_->Clear(false);
 	textureCache_->DeviceLost();
 	shaderManager_->DeviceLost();
+	drawEngineCommon_->DeviceLost();
 }
 
 // Call at the start of the GPU implementation's DeviceRestore
 void GPUCommonHW::DeviceRestore(Draw::DrawContext *draw) {
 	draw_ = draw;
 	framebufferManager_->DeviceRestore(draw_);
+	textureCache_->DeviceRestore(draw_);
+	shaderManager_->DeviceRestore(draw_);
+	drawEngineCommon_->DeviceRestore(draw_);
+
 	PPGeSetDrawContext(draw_);
+
+	gstate_c.SetUseFlags(CheckGPUFeatures());
+	BuildReportingInfo();
+	UpdateCmdInfo();
 }
 
 void GPUCommonHW::UpdateCmdInfo() {

--- a/GPU/GPUCommonHW.h
+++ b/GPU/GPUCommonHW.h
@@ -12,6 +12,7 @@ public:
 	void CopyDisplayToOutput(bool reallyDirty) override;
 	void DoState(PointerWrap &p) override;
 	void DeviceLost() override;
+	void DeviceRestore(Draw::DrawContext *draw) override;
 
 	void BeginFrame() override;
 
@@ -69,6 +70,7 @@ private:
 	void CheckFlushOp(int cmd, u32 diff);
 
 protected:
+	size_t FormatGPUStatsCommon(char *buf, size_t size);
 	void UpdateCmdInfo() override;
 
 	void PreExecuteOp(u32 op, u32 diff) override;

--- a/GPU/GPUCommonHW.h
+++ b/GPU/GPUCommonHW.h
@@ -22,6 +22,7 @@ public:
 	bool GetCurrentDepthbuffer(GPUDebugBuffer &buffer) override;
 	bool GetCurrentStencilbuffer(GPUDebugBuffer &buffer) override;
 	bool GetOutputFramebuffer(GPUDebugBuffer &buffer) override;
+	std::vector<FramebufferInfo> GetFramebufferList() const override;
 	bool GetCurrentTexture(GPUDebugBuffer &buffer, int level, bool *isFramebuffer) override;
 	bool GetCurrentClut(GPUDebugBuffer &buffer) override;
 

--- a/GPU/GPUInterface.h
+++ b/GPU/GPUInterface.h
@@ -251,7 +251,7 @@ public:
 	virtual void EnableInterrupts(bool enable) = 0;
 
 	virtual void DeviceLost() = 0;
-	virtual void DeviceRestore() = 0;
+	virtual void DeviceRestore(Draw::DrawContext *draw) = 0;
 	virtual void ReapplyGfxState() = 0;
 	virtual void DoState(PointerWrap &p) = 0;
 

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -466,9 +466,8 @@ void SoftGPU::DeviceLost() {
 	}
 }
 
-void SoftGPU::DeviceRestore() {
-	if (PSP_CoreParameter().graphicsContext)
-		draw_ = (Draw::DrawContext *)PSP_CoreParameter().graphicsContext->GetDrawContext();
+void SoftGPU::DeviceRestore(Draw::DrawContext *draw) {
+	draw_ = draw;
 	if (presentation_)
 		presentation_->DeviceRestore(draw_);
 	PPGeSetDrawContext(draw_);

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -454,6 +454,8 @@ SoftGPU::SoftGPU(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	NotifyConfigChanged();
 	NotifyRenderResized();
 	NotifyDisplayResized();
+
+	PPGeSetDrawContext(draw);
 }
 
 void SoftGPU::DeviceLost() {

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -138,6 +138,7 @@ public:
 	void SetDisplayFramebuffer(u32 framebuf, u32 stride, GEBufferFormat format) override;
 	void CopyDisplayToOutput(bool reallyDirty) override;
 	void GetStats(char *buffer, size_t bufsize) override;
+	std::vector<FramebufferInfo> GetFramebufferList() const override { return std::vector<FramebufferInfo>(); }
 	void InvalidateCache(u32 addr, int size, GPUInvalidationType type) override;
 	void PerformWriteFormattedFromMemory(u32 addr, int size, int width, GEBufferFormat format) override;
 	bool PerformMemoryCopy(u32 dest, u32 src, int size, GPUCopyFlag flags = GPUCopyFlag::NONE) override;
@@ -147,7 +148,7 @@ public:
 	bool PerformWriteStencilFromMemory(u32 dest, int size, WriteStencil flags) override;
 
 	void DeviceLost() override;
-	void DeviceRestore() override;
+	void DeviceRestore(Draw::DrawContext *draw) override;
 
 	void NotifyRenderResized() override;
 	void NotifyDisplayResized() override;

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -173,6 +173,9 @@ public:
 	SoftwareDrawEngine();
 	~SoftwareDrawEngine();
 
+	void DeviceLost() override {}
+	void DeviceRestore(Draw::DrawContext *draw) override {}
+
 	void NotifyConfigChanged() override;
 	void DispatchFlush() override;
 	void DispatchSubmitPrim(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, u32 vertType, int cullMode, int *bytesRead) override;

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -287,7 +287,6 @@ void DrawEngineVulkan::DeviceLost() {
 
 void DrawEngineVulkan::DeviceRestore(Draw::DrawContext *draw) {
 	draw_ = draw;
-
 	InitDeviceObjects();
 }
 

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -158,8 +158,8 @@ public:
 		framebufferManager_ = fbManager;
 	}
 
-	void DeviceLost();
-	void DeviceRestore(Draw::DrawContext *draw);
+	void DeviceLost() override;
+	void DeviceRestore(Draw::DrawContext *draw) override;
 
 	// So that this can be inlined
 	void Flush() {

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -460,8 +460,8 @@ void GPU_Vulkan::DeviceLost() {
 	GPUCommonHW::DeviceLost();
 }
 
-void GPU_Vulkan::DeviceRestore() {
-	GPUCommonHW::DeviceRestore();
+void GPU_Vulkan::DeviceRestore(Draw::DrawContext *draw) {
+	GPUCommonHW::DeviceRestore(draw);
 	InitDeviceObjects();
 
 	gstate_c.SetUseFlags(CheckGPUFeatures());

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -454,7 +454,6 @@ void GPU_Vulkan::DeviceLost() {
 		SaveCache(shaderCachePath_);
 	}
 	DestroyDeviceObjects();
-	drawEngine_.DeviceLost();
 	pipelineManager_->DeviceLost();
 
 	GPUCommonHW::DeviceLost();
@@ -462,17 +461,11 @@ void GPU_Vulkan::DeviceLost() {
 
 void GPU_Vulkan::DeviceRestore(Draw::DrawContext *draw) {
 	GPUCommonHW::DeviceRestore(draw);
-	InitDeviceObjects();
-
-	gstate_c.SetUseFlags(CheckGPUFeatures());
-	BuildReportingInfo();
-	UpdateCmdInfo();
 
 	VulkanContext *vulkan = (VulkanContext *)draw_->GetNativeObject(Draw::NativeObject::CONTEXT);
-	drawEngine_.DeviceRestore(draw_);
 	pipelineManager_->DeviceRestore(vulkan);
-	textureCacheVulkan_->DeviceRestore(draw_);
-	shaderManagerVulkan_->DeviceRestore(draw_);
+
+	InitDeviceObjects();
 }
 
 void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -49,7 +49,7 @@ public:
 
 	void GetStats(char *buffer, size_t bufsize) override;
 	void DeviceLost() override;  // Only happens on Android. Drop all textures and shaders.
-	void DeviceRestore() override;
+	void DeviceRestore(Draw::DrawContext *draw) override;
 
 	// Using string because it's generic - makes no assumptions on the size of the shader IDs of this backend.
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType shader) override;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -327,27 +327,8 @@ static const VkFilter MagFiltVK[2] = {
 
 void TextureCacheVulkan::StartFrame() {
 	TextureCacheCommon::StartFrame();
-
-	textureShaderCache_->Decimate();
-
-	timesInvalidatedAllThisFrame_ = 0;
-	texelsScaledThisFrame_ = 0;
-	replacementTimeThisFrame_ = 0.0;
-
-	if (clearCacheNextFrame_) {
-		Clear(true);
-		clearCacheNextFrame_ = false;
-	} else {
-		int slabPressureLimit = TEXCACHE_SLAB_PRESSURE;
-		if (g_Config.iTexScalingLevel > 1) {
-			// Since textures are 2D maybe we should square this, but might get too non-aggressive.
-			slabPressureLimit *= g_Config.iTexScalingLevel;
-		}
-		// TODO: Use some indication from VMA.
-		// Maybe see https://gpuopen-librariesandsdks.github.io/VulkanMemoryAllocator/html/staying_within_budget.html#staying_within_budget_querying_for_budget .
-		Decimate(false);
-	}
-
+	// TODO: For low memory detection, maybe use some indication from VMA.
+	// Maybe see https://gpuopen-librariesandsdks.github.io/VulkanMemoryAllocator/html/staying_within_budget.html#staying_within_budget_querying_for_budget .
 	computeShaderManager_.BeginFrame();
 }
 

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -59,8 +59,8 @@ public:
 
 	void StartFrame() override;
 
-	void DeviceLost();
-	void DeviceRestore(Draw::DrawContext *draw);
+	void DeviceLost() override;
+	void DeviceRestore(Draw::DrawContext *draw) override;
 
 	void SetFramebufferManager(FramebufferManagerVulkan *fbManager);
 	void SetDrawEngine(DrawEngineVulkan *td) {

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -52,8 +52,7 @@ VkShaderModule CompileShaderModule(VulkanContext *vulkan, VkShaderStageFlagBits 
 	}
 }
 
-VulkanComputeShaderManager::VulkanComputeShaderManager(VulkanContext *vulkan) : vulkan_(vulkan), pipelines_(8) {
-}
+VulkanComputeShaderManager::VulkanComputeShaderManager(VulkanContext *vulkan) : vulkan_(vulkan), pipelines_(8) {}
 VulkanComputeShaderManager::~VulkanComputeShaderManager() {}
 
 void VulkanComputeShaderManager::InitDeviceObjects(Draw::DrawContext *draw) {
@@ -96,6 +95,7 @@ void VulkanComputeShaderManager::InitDeviceObjects(Draw::DrawContext *draw) {
 
 	for (int i = 0; i < ARRAY_SIZE(frameData_); i++) {
 		frameData_[i].descPool.Create(vulkan_, dp, dpTypes);
+		frameData_[i].descPoolUsed = false;
 	}
 
 	VkPushConstantRange push = {};
@@ -137,6 +137,7 @@ void VulkanComputeShaderManager::DestroyDeviceObjects() {
 VkDescriptorSet VulkanComputeShaderManager::GetDescriptorSet(VkImageView image, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize range, VkBuffer buffer2, VkDeviceSize offset2, VkDeviceSize range2) {
 	int curFrame = vulkan_->GetCurFrame();
 	FrameData &frameData = frameData_[curFrame];
+	frameData.descPoolUsed = true;
 	VkDescriptorSet desc = frameData.descPool.Allocate(1, &descriptorSetLayout_, "compute_descset");
 	_assert_(desc != VK_NULL_HANDLE);
 
@@ -206,5 +207,8 @@ VkPipeline VulkanComputeShaderManager::GetPipeline(VkShaderModule cs) {
 void VulkanComputeShaderManager::BeginFrame() {
 	int curFrame = vulkan_->GetCurFrame();
 	FrameData &frame = frameData_[curFrame];
-	frame.descPool.Reset();
+	if (frame.descPoolUsed) {
+		frame.descPool.Reset();
+		frame.descPoolUsed = false;
+	}
 }

--- a/GPU/Vulkan/VulkanUtil.h
+++ b/GPU/Vulkan/VulkanUtil.h
@@ -77,6 +77,7 @@ private:
 		}
 
 		VulkanDescSetPool descPool;
+		bool descPoolUsed = false;
 	};
 	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES];
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -914,7 +914,7 @@ bool NativeInitGraphics(GraphicsContext *graphicsContext) {
 	g_gameInfoCache = new GameInfoCache();
 
 	if (gpu) {
-		gpu->DeviceRestore();
+		gpu->DeviceRestore(g_draw);
 	}
 
 	INFO_LOG(SYSTEM, "NativeInitGraphics completed");

--- a/libretro/LibretroGraphicsContext.cpp
+++ b/libretro/LibretroGraphicsContext.cpp
@@ -58,7 +58,7 @@ void LibretroHWRenderContext::ContextReset() {
 	GotBackbuffer();
 
 	if (gpu) {
-		gpu->DeviceRestore();
+		gpu->DeviceRestore(draw_);
 	}
 }
 


### PR DESCRIPTION
And some cleanup/consistency improvements with DeviceLost/DeviceRestore.

Yeah, the D3D backends probably don't need it, but let's make it really uniform.