### PR TITLE
Resurrect the Vulkan memory visualizer, but now it's global stats and pushbuffer stats.

### DIFF
--- a/Common/GPU/Vulkan/VulkanLoader.h
+++ b/Common/GPU/Vulkan/VulkanLoader.h
@@ -33,6 +33,11 @@
 
 #include "ext/vulkan/vulkan.h"
 
+// Hacky X11 header workaround
+#ifdef Opposite
+#undef Opposite
+#endif
+
 namespace PPSSPP_VK {
 // Putting our own Vulkan function pointers in a namespace ensures that ppsspp_libretro.so doesn't collide with libvulkan.so.
 extern PFN_vkCreateInstance vkCreateInstance;

--- a/Common/GPU/Vulkan/VulkanMemory.h
+++ b/Common/GPU/Vulkan/VulkanMemory.h
@@ -131,7 +131,10 @@ public:
 		info->range = sizeof(T);
 	}
 
-	size_t GetTotalSize() const;
+	size_t GetTotalSize() const;  // Used size
+	size_t GetTotalCapacity() const;
+
+	static std::vector<VulkanPushBuffer *> GetAllActive();
 
 private:
 	bool AddBuffer();
@@ -173,7 +176,7 @@ private:
 	const char *tag_;
 	VulkanContext *vulkan_ = nullptr;
 	VkDescriptorPool descPool_ = VK_NULL_HANDLE;
-	VkDescriptorPoolCreateInfo info_;
+	VkDescriptorPoolCreateInfo info_{};
 	std::vector<VkDescriptorPoolSize> sizes_;
 	std::function<void()> clear_;
 	uint32_t usage_ = 0;

--- a/GPU/Vulkan/DebugVisVulkan.cpp
+++ b/GPU/Vulkan/DebugVisVulkan.cpp
@@ -15,24 +15,84 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
+#include <sstream>
+#include <cstring>
+
 #include "Common/Render/DrawBuffer.h"
 #include "Common/GPU/thin3d.h"
+#include "Common/GPU/Vulkan/VulkanContext.h"
 #include "Common/UI/Context.h"
 #include "Common/UI/View.h"
 #include "Common/System/Display.h"
 #include "Common/System/System.h"
 
+#include "ext/vma/vk_mem_alloc.h"
+
 #include "DebugVisVulkan.h"
 #include "Common/GPU/Vulkan/VulkanMemory.h"
 #include "Common/GPU/Vulkan/VulkanImage.h"
+#include "Common/Data/Text/Parsers.h"
 #include "GPU/Vulkan/GPU_Vulkan.h"
 #include "GPU/Vulkan/VulkanUtil.h"
 #include "GPU/Vulkan/TextureCacheVulkan.h"
 
 #undef DrawText
 
+bool comparePushBufferNames(const VulkanPushBuffer *a, const VulkanPushBuffer *b) {
+	return strcmp(a->Name(), b->Name()) < 0;
+}
+
 void DrawAllocatorVis(UIContext *ui, GPUInterface *gpu) {
-	// TODO: Make a new allocator visualizer for VMA.
+	// This one will simply display stats.
+	Draw::DrawContext *draw = ui->GetDrawContext();
+
+	VulkanContext *vulkan = (VulkanContext *)draw->GetNativeObject(Draw::NativeObject::CONTEXT);
+	if (!vulkan) {
+		return;
+	}
+
+	VmaTotalStatistics vmaStats;
+	vmaCalculateStatistics(vulkan->Allocator(), &vmaStats);
+
+	std::vector<VmaBudget> budgets;
+	budgets.resize(vulkan->GetMemoryProperties().memoryHeapCount);
+	vmaGetHeapBudgets(vulkan->Allocator(), &budgets[0]);
+
+	size_t totalBudget = 0;
+	size_t totalUsedBytes = 0;
+	for (auto &budget : budgets) {
+		totalBudget += budget.budget;
+		totalUsedBytes += budget.usage;
+	}
+
+	std::stringstream str;
+	str << vulkan->GetPhysicalDeviceProperties().properties.deviceName << std::endl;
+	str << "Allocated " << NiceSizeFormat(vmaStats.total.statistics.allocationBytes) << " in " << vmaStats.total.statistics.allocationCount << " allocs" << std::endl;
+	// Note: The overall number includes stuff like descriptor sets pools and other things that are not directly visible as allocations.
+	str << "Overall " << NiceSizeFormat(totalUsedBytes) << " used out of " << NiceSizeFormat(totalBudget) << " available" << std::endl;
+
+	str << "Push buffers:" << std::endl;
+
+	// Now list the various push buffers.
+	auto pushBuffers = VulkanPushBuffer::GetAllActive();
+	std::sort(pushBuffers.begin(), pushBuffers.end(), comparePushBufferNames);
+
+	for (auto push : pushBuffers) {
+		str << "  " << push->Name() << " "
+			<< NiceSizeFormat(push->GetTotalCapacity()) << ", used: "
+			<< NiceSizeFormat(push->GetTotalSize()) << std::endl;
+	}
+
+	const int padding = 10 + System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_LEFT);
+	const int starty = 50 + System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_TOP);
+	int x = padding;
+	int y = starty;
+
+	ui->SetFontScale(0.7f, 0.7f);
+	ui->DrawTextShadow(str.str().c_str(), x, y, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
+	ui->SetFontScale(1.0f, 1.0f);
+	ui->Flush();
 }
 
 void DrawGPUProfilerVis(UIContext *ui, GPUInterface *gpu) {

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -101,8 +101,7 @@ void DevMenuScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	items->Add(new Choice(dev->T("Jit Compare")))->OnClick.Handle(this, &DevMenuScreen::OnJitCompare);
 	items->Add(new Choice(dev->T("Shader Viewer")))->OnClick.Handle(this, &DevMenuScreen::OnShaderView);
 	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN) {
-		// TODO: Make a new allocator visualizer for VMA.
-		// items->Add(new CheckBox(&g_Config.bShowAllocatorDebug, dev->T("Allocator Viewer")));
+		items->Add(new CheckBox(&g_Config.bShowAllocatorDebug, dev->T("Allocator Viewer")));
 		items->Add(new CheckBox(&g_Config.bShowGpuProfile, dev->T("GPU Profile")));
 	}
 	items->Add(new Choice(dev->T("Toggle Freeze")))->OnClick.Handle(this, &DevMenuScreen::OnFreezeFrame);


### PR DESCRIPTION
Not as visually interesting as the old pre-VMA one, but useful:

Overhead should be minimal.

![image](https://user-images.githubusercontent.com/130929/221445241-8374fb87-4a61-445b-899b-2a7161f2509b.png)

The point is to check and improve the push buffer sizing algorithms (or replacements for them such as ring buffers) and see the impact on memory usage. Currently the pushbuffers can go to rather extreme sizes when loading high-res texture replacement packs, and we need to get smarter, it seems.