### PR TITLE
Rotate Daxter analog stick input

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -127,6 +127,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "RockmanDash2SoundFix", &flags_.RockmanDash2SoundFix);
 	CheckSetting(iniFile, gameID, "ReadbackDepth", &flags_.ReadbackDepth);
 	CheckSetting(iniFile, gameID, "BlockTransferDepth", &flags_.BlockTransferDepth);
+	CheckSetting(iniFile, gameID, "DaxterRotatedAnalogStick", &flags_.DaxterRotatedAnalogStick);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -98,6 +98,7 @@ struct CompatFlags {
 	bool RockmanDash2SoundFix;
 	bool ReadbackDepth;
 	bool BlockTransferDepth;
+	bool DaxterRotatedAnalogStick;
 };
 
 struct VRCompat {

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1479,3 +1479,10 @@ NPEG00004 = true
 ULES01070 = true
 ULES01071 = true
 ULUS10347 = true
+
+[DaxterRotatedAnalogStick]
+# Daxter (see issue #17015)
+UCUS98618 = true
+UCES00044 = true
+NPUG80329 = true
+NPEG00025 = true

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1490,3 +1490,36 @@ UCES00044 = true
 NPUG80329 = true
 NPEG00025 = true
 UCKS45025 = true
+
+# GOW : Ghost of Sparta
+UCUS98737 = true
+UCAS40323 = true
+NPHG00092 = true
+NPEG00044 = true
+NPEG00045 = true
+NPJG00120 = true
+NPUG80508 = true
+UCJS10114 = true
+UCES01401 = true
+UCES01473 = true
+# GOW : Ghost of Sparta Demo
+NPJG90095 = true
+NPEG90035 = true
+NPUG70125 = true
+# GOW : Chains Of Olympus
+UCAS40198 = true
+UCUS98653 = true
+UCES00842 = true
+ULJM05438 = true
+ULJM05348 = true
+UCKS45084 = true
+NPUG80325 = true
+NPEG00023 = true
+NPHG00027 = true
+NPHG00028 = true
+NPJH50170 = true
+UCET00844 = true
+# GOW: Chains of Olympus Demo
+UCUS98705 = true
+UCED00971 = true
+UCUS98713 = true

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -328,9 +328,11 @@ UCED00971 = true
 UCUS98713 = true
 # Daxter
 UCUS98618 = true
+UCUS98654 = true
 UCES00044 = true
 NPUG80329 = true
 NPEG00025 = true
+UCKS45025 = true
 # Ys Seven
 ULUS10551 = true
 ULJM05475 = true
@@ -1483,6 +1485,8 @@ ULUS10347 = true
 [DaxterRotatedAnalogStick]
 # Daxter (see issue #17015)
 UCUS98618 = true
+UCUS98654 = true
 UCES00044 = true
 NPUG80329 = true
 NPEG00025 = true
+UCKS45025 = true


### PR DESCRIPTION
For some reason, the developers of this game decided to rotate analog input by 15 degrees, maybe they thought it felt better on the real hardware.

Unfortunately when emulating the analog stick using a keyboard or other digital device, this gets very noticeable, as reported in #17015. 

So, this adds a compatibility setting that pre-rotates the analog input just before feeding the game with it. Works great, 15 degrees seems to be exactly right.