### PR TITLE
Update PPSSPP-Info.plist

### DIFF
--- a/ios/PPSSPP-Info.plist
+++ b/ios/PPSSPP-Info.plist
@@ -10,8 +10,6 @@
 	<string>Your camera may be used to emulate Go!Cam, a camera accessory</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Your microphone may be used to emulate Go!Cam/Talkman, a microphone accessory</string>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
 	<key>CFBundleDisplayName</key>
 	<string>PPSSPP</string>
 	<key>CFBundleExecutable</key>
@@ -36,7 +34,7 @@
 	<false/>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv7</string>
+		<string>arm64</string>
 	</array>
 	<key>UIStatusBarHidden</key>
 	<true/>


### PR DESCRIPTION
First, we are no longer support armv7
then specific CFBundleDevelopmentRegion key will make https://github.com/hrydgard/ppsspp/blob/a11ca4cb9010b6c6ca33d5ec46b369045a43f6f3/ios/main.mm#L109 always return en_XX