### PR TITLE
UI: Forget jit override on user selection

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1603,6 +1603,13 @@ void Config::PostSaveCleanup(bool gameSpecific) {
 	}
 }
 
+void Config::NotifyUpdatedCpuCore() {
+	if (jitForcedOff && g_Config.iCpuCore == (int)CPUCore::IR_JIT) {
+		// No longer forced off, the user set it to IR jit.
+		jitForcedOff = false;
+	}
+}
+
 // Use for debugging the version check without messing with the server
 #if 0
 #define PPSSPP_GIT_VERSION "v0.0.1-gaaaaaaaaa"

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1589,15 +1589,16 @@ void Config::PostLoadCleanup(bool gameSpecific) {
 
 void Config::PreSaveCleanup(bool gameSpecific) {
 	if (jitForcedOff) {
-		// if JIT has been forced off, we don't want to screw up the user's ppsspp.ini
-		g_Config.iCpuCore = (int)CPUCore::JIT;
+		// If we forced jit off and it's still set to IR, change it back to jit.
+		if (g_Config.iCpuCore == (int)CPUCore::IR_JIT)
+			g_Config.iCpuCore = (int)CPUCore::JIT;
 	}
 }
 
 void Config::PostSaveCleanup(bool gameSpecific) {
 	if (jitForcedOff) {
-		// force JIT off again just in case Config::Save() is called without exiting PPSSPP
-		if (g_Config.iCpuCore != (int)CPUCore::INTERPRETER)
+		// Force JIT off again just in case Config::Save() is called without exiting PPSSPP.
+		if (g_Config.iCpuCore == (int)CPUCore::JIT)
 			g_Config.iCpuCore = (int)CPUCore::IR_JIT;
 	}
 }

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -568,6 +568,8 @@ public:
 	bool LoadAppendedConfig();
 	void SetAppendedConfigIni(const Path &path);
 
+	void NotifyUpdatedCpuCore();
+
 protected:
 	void LoadStandardControllerIni();
 	void LoadLangValuesMapping();

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -36,7 +36,9 @@ enum {
 };
 
 DrawEngineCommon::DrawEngineCommon() : decoderMap_(16) {
-	decJitCache_ = new VertexDecoderJitCache();
+	if (g_Config.bVertexDecoderJit && g_Config.iCpuCore == (int)CPUCore::JIT) {
+		decJitCache_ = new VertexDecoderJitCache();
+	}
 	transformed = (TransformedVertex *)AllocateMemoryPages(TRANSFORMED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
 	transformedExpanded = (TransformedVertex *)AllocateMemoryPages(3 * TRANSFORMED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
 }
@@ -169,7 +171,8 @@ static Vec3f ScreenToDrawing(const Vec3f& coords) {
 }
 
 void DrawEngineCommon::NotifyConfigChanged() {
-	decJitCache_->Clear();
+	if (decJitCache_)
+		decJitCache_->Clear();
 	lastVType_ = -1;
 	dec_ = nullptr;
 	decoderMap_.Iterate([&](const uint32_t vtype, VertexDecoder *decoder) {

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -117,7 +117,9 @@ public:
 	}
 
 	bool IsCodePtrVertexDecoder(const u8 *ptr) const {
-		return decJitCache_->IsInSpace(ptr);
+		if (decJitCache_)
+			return decJitCache_->IsInSpace(ptr);
+		return false;
 	}
 	int GetNumDrawCalls() const {
 		return numDrawCalls;

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -1274,7 +1274,7 @@ void VertexDecoder::SetVertexType(u32 fmt, const VertexDecoderOptions &options, 
 
 	// Attempt to JIT as well. But only do that if the main CPU JIT is enabled, in order to aid
 	// debugging attempts - if the main JIT doesn't work, this one won't do any better, probably.
-	if (jitCache && g_Config.bVertexDecoderJit && g_Config.iCpuCore == (int)CPUCore::JIT) {
+	if (jitCache) {
 		jitted_ = jitCache->Compile(*this, &jittedSize_);
 		if (!jitted_) {
 			WARN_LOG(G3D, "Vertex decoder JIT failed! fmt = %08x (%s)", fmt_, GetString(SHADER_STRING_SHORT_DESC).c_str());

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1774,6 +1774,10 @@ void DeveloperToolsScreen::CreateViews() {
 	static const char *cpuCores[] = {"Interpreter", "Dynarec (JIT)", "IR Interpreter"};
 	PopupMultiChoice *core = list->Add(new PopupMultiChoice(&g_Config.iCpuCore, gr->T("CPU Core"), cpuCores, 0, ARRAY_SIZE(cpuCores), sy->GetName(), screenManager()));
 	core->OnChoice.Handle(this, &DeveloperToolsScreen::OnJitAffectingSetting);
+	core->OnChoice.Add([](UI::EventParams &) {
+		g_Config.NotifyUpdatedCpuCore();
+		return UI::EVENT_DONE;
+	});
 	if (!canUseJit) {
 		core->HideChoice(1);
 	}

--- a/unittest/TestVertexJit.cpp
+++ b/unittest/TestVertexJit.cpp
@@ -38,9 +38,6 @@ public:
 		dst_ = new u8[BUFFER_SIZE];
 		cache_ = new VertexDecoderJitCache();
 
-		g_Config.bVertexDecoderJit = true;
-		// Required for jit to be enabled.
-		g_Config.iCpuCore = (int)CPUCore::JIT;
 		gstate_c.uv.uScale = 1.0f;
 		gstate_c.uv.vScale = 1.0f;
 	}


### PR DESCRIPTION
This cleans up the issues noted in #17025, I think (don't have an iPhone to test with.)  Also, cleans up wasted memory alloc when vertexjit off.

-[Unknown]