### PR TITLE
Vulkan on Android: In non-debug mode, avoid devices that were rejected by VulkanMayBeAvailable

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -712,6 +712,8 @@ VkResult VulkanContext::CreateDevice() {
 		VulkanLoadDeviceFunctions(device_, extensionsLookup_);
 	}
 	INFO_LOG(G3D, "Vulkan Device created: %s", physicalDeviceProperties_[physical_device_].properties.deviceName);
+
+	// Since we successfully created a device (however we got here, might be interesting in debug), we force the choice to be visible in the menu.
 	VulkanSetAvailable(true);
 
 	VmaAllocatorCreateInfo allocatorInfo = {};

--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -310,6 +310,7 @@ static void VulkanFreeLibrary(VulkanLibraryHandle &h) {
 }
 
 void VulkanSetAvailable(bool available) {
+	INFO_LOG(G3D, "Forcing Vulkan availability to true");
 	g_vulkanAvailabilityChecked = true;
 	g_vulkanMayBeAvailable = available;
 }
@@ -495,8 +496,9 @@ bail:
 	}
 	if (lib) {
 		VulkanFreeLibrary(lib);
-	} else {
-		ERROR_LOG(G3D, "Vulkan with working device not detected.");
+	}
+	if (!g_vulkanMayBeAvailable) {
+		WARN_LOG(G3D, "Vulkan with working device not detected.");
 	}
 	return g_vulkanMayBeAvailable;
 }


### PR DESCRIPTION
Fixes #16931 (Poco C40 devices were defaulting to software Vulkan device)

Can still use these devices in debug builds by modifying the ini.