### PR TITLE
Cache framebuffer copies (for self-texturing) until the next TexFlush GPU instruction

### DIFF
--- a/GPU/Common/DepthBufferCommon.cpp
+++ b/GPU/Common/DepthBufferCommon.cpp
@@ -204,7 +204,7 @@ bool FramebufferManagerCommon::ReadbackDepthbuffer(Draw::Framebuffer *fbo, int x
 		}
 
 		shaderManager_->DirtyLastShader();
-		auto *blitFBO = GetTempFBO(TempFBO::COPY, fbo->Width() * scaleX, fbo->Height() * scaleY);
+		auto *blitFBO = GetTempFBO(TempFBO::Z_COPY, fbo->Width() * scaleX, fbo->Height() * scaleY);
 		draw_->BindFramebufferAsRenderTarget(blitFBO, { RPAction::DONT_CARE, RPAction::DONT_CARE, RPAction::DONT_CARE }, "ReadbackDepthbufferSync");
 		Draw::Viewport viewport = { 0.0f, 0.0f, (float)destW, (float)destH, 0.0f, 1.0f };
 		draw_->SetViewport(viewport);

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -932,6 +932,7 @@ void FramebufferManagerCommon::DestroyFramebuf(VirtualFramebuffer *v) {
 	}
 
 	// Wipe some pointers
+	DiscardFramebufferCopy();
 	if (currentRenderVfb_ == v)
 		currentRenderVfb_ = nullptr;
 	if (displayFramebuf_ == v)
@@ -1450,6 +1451,7 @@ void FramebufferManagerCommon::DrawFramebufferToOutput(const u8 *srcPixels, int 
 	// PresentationCommon sets all kinds of state, we can't rely on anything.
 	gstate_c.Dirty(DIRTY_ALL);
 
+	DiscardFramebufferCopy();
 	currentRenderVfb_ = nullptr;
 }
 
@@ -1607,10 +1609,12 @@ void FramebufferManagerCommon::CopyDisplayToOutput(bool reallyDirty) {
 	// This may get called mid-draw if the game uses an immediate flip.
 	// PresentationCommon sets all kinds of state, we can't rely on anything.
 	gstate_c.Dirty(DIRTY_ALL);
+	DiscardFramebufferCopy();
 	currentRenderVfb_ = nullptr;
 }
 
 void FramebufferManagerCommon::DecimateFBOs() {
+	DiscardFramebufferCopy();
 	currentRenderVfb_ = nullptr;
 
 	for (auto iter : fbosToDelete_) {
@@ -1767,6 +1771,7 @@ void FramebufferManagerCommon::ResizeFramebufFBO(VirtualFramebuffer *vfb, int w,
 	} else {
 		draw_->BindFramebufferAsRenderTarget(vfb->fbo, { Draw::RPAction::CLEAR, Draw::RPAction::CLEAR, Draw::RPAction::CLEAR }, "ResizeFramebufFBO");
 	}
+	DiscardFramebufferCopy();
 	currentRenderVfb_ = vfb;
 
 	if (!vfb->fbo) {
@@ -2568,6 +2573,7 @@ void FramebufferManagerCommon::NotifyConfigChanged() {
 }
 
 void FramebufferManagerCommon::DestroyAllFBOs() {
+	DiscardFramebufferCopy();
 	currentRenderVfb_ = nullptr;
 	displayFramebuf_ = nullptr;
 	prevDisplayFramebuf_ = nullptr;

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -490,7 +490,7 @@ protected:
 	// Used by ReadFramebufferToMemory and later framebuffer block copies
 	void BlitFramebuffer(VirtualFramebuffer *dst, int dstX, int dstY, VirtualFramebuffer *src, int srcX, int srcY, int w, int h, int bpp, RasterChannel channel, const char *tag);
 
-	void CopyFramebufferForColorTexture(VirtualFramebuffer *dst, VirtualFramebuffer *src, int flags, int layer);
+	void CopyFramebufferForColorTexture(VirtualFramebuffer *dst, VirtualFramebuffer *src, int flags, int layer, bool *partial);
 
 	void EstimateDrawingSize(u32 fb_address, int fb_stride, GEBufferFormat fb_format, int viewport_width, int viewport_height, int region_width, int region_height, int scissor_width, int scissor_height, int &drawing_width, int &drawing_height);
 

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -466,6 +466,10 @@ public:
 		return msaaLevel_;
 	}
 
+	void DiscardFramebufferCopy() {
+		currentFramebufferCopy_ = nullptr;
+	}
+
 protected:
 	virtual void ReadbackFramebuffer(VirtualFramebuffer *vfb, int x, int y, int w, int h, RasterChannel channel, Draw::ReadbackMode mode);
 	// Used for when a shader is required, such as GLES.
@@ -551,6 +555,8 @@ protected:
 	int frameLastFramebufUsed_ = 0;
 
 	VirtualFramebuffer *currentRenderVfb_ = nullptr;
+
+	Draw::Framebuffer *currentFramebufferCopy_ = nullptr;
 
 	// The range of PSP memory that may contain FBOs.  So we can skip iterating.
 	u32 framebufRangeEnd_ = 0;

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -217,6 +217,8 @@ enum class TempFBO {
 	BLIT,
 	// For copies of framebuffers (e.g. shader blending.)
 	COPY,
+	// Used for copies when setting color to depth.
+	Z_COPY,
 	// Used to copy stencil data, means we need a stencil backing.
 	STENCIL,
 };

--- a/GPU/GLES/StencilBufferGLES.cpp
+++ b/GPU/GLES/StencilBufferGLES.cpp
@@ -130,7 +130,7 @@ bool FramebufferManagerGLES::ReadbackStencilbuffer(Draw::Framebuffer *fbo, int x
 	}
 
 	shaderManager_->DirtyLastShader();
-	auto *blitFBO = GetTempFBO(TempFBO::COPY, fbo->Width(), fbo->Height());
+	auto *blitFBO = GetTempFBO(TempFBO::Z_COPY, fbo->Width(), fbo->Height());
 	draw_->BindFramebufferAsRenderTarget(blitFBO, { RPAction::DONT_CARE, RPAction::DONT_CARE, RPAction::DONT_CARE }, "ReadbackStencilbufferSync");
 	Draw::Viewport viewport = { 0.0f, 0.0f, (float)fbo->Width(), (float)fbo->Height(), 0.0f, 1.0f };
 	draw_->SetViewport(viewport);

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -287,7 +287,7 @@ const CommonCommandTableEntry commonCommandTable[] = {
 	{ GE_CMD_LSC3, FLAG_FLUSHBEFOREONCHANGE, DIRTY_LIGHT3 },
 
 	// Ignored commands
-	{ GE_CMD_TEXFLUSH, 0 },
+	{ GE_CMD_TEXFLUSH, FLAG_EXECUTE, 0, &GPUCommonHW::Execute_TexFlush },
 	{ GE_CMD_TEXSYNC, 0 },
 
 	// These are just nop or part of other later commands.
@@ -1617,6 +1617,13 @@ void GPUCommonHW::Execute_BoneMtxData(u32 op, u32 diff) {
 	num++;
 	gstate.boneMatrixNumber = (GE_CMD_BONEMATRIXNUMBER << 24) | (num & 0x00FFFFFF);
 	gstate.boneMatrixData = GE_CMD_BONEMATRIXDATA << 24;
+}
+
+void GPUCommonHW::Execute_TexFlush(u32 op, u32 diff) {
+	// Games call this when they need the effect of drawing to be visible to texturing.
+	// And for a bunch of other reasons, but either way, this is what we need to do.
+	// It's possible we could also use this as a hint for the texture cache somehow.
+	framebufferManager_->DiscardFramebufferCopy();
 }
 
 size_t GPUCommonHW::FormatGPUStatsCommon(char *buffer, size_t size) {

--- a/GPU/GPUCommonHW.h
+++ b/GPU/GPUCommonHW.h
@@ -60,6 +60,8 @@ public:
 	void Execute_BoneMtxNum(u32 op, u32 diff);
 	void Execute_BoneMtxData(u32 op, u32 diff);
 
+	void Execute_TexFlush(u32 op, u32 diff);
+
 	typedef void (GPUCommonHW::*CmdFunc)(u32 op, u32 diff);
 
 	void FastRunLoop(DisplayList &list) override;


### PR DESCRIPTION
Fixes #17030 , or at least improves on it - for optimal performance that big framebuffer used for bloom should be split like in Killzone, but it's not trivial. So there's still a bunch of copies happening, just less of them.

The performance regression in Dante's Inferno in 1.14 is fixed with this, at least.

I tried it with a few other games with no issues - it seems games are using TexFlush when needed. But let's see if it really is safe to rely on that...

There might also be other places we should call DiscardFramebufferCopy in.

For these copies, ideally we should look at texture coordinates to figure out the regions to copy, and if the previously copied region was enough. Actually we do that already, in some cases - and I just realized that this isn't necessarily valid in that case. So need a couple more checks. EDIT: Added - works because that path isn't currently active in Dante for some reason.