### PR TITLE
Vulkan texture uploads: Take optimalBufferCopyRowPitchAlignment into account

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -222,7 +222,8 @@ public:
 	// Simple workaround for the casting warning.
 	template <class T>
 	void SetDebugName(T handle, VkObjectType type, const char *name) {
-		if (extensionsLookup_.EXT_debug_utils) {
+		if (extensionsLookup_.EXT_debug_utils && handle != VK_NULL_HANDLE) {
+			_dbg_assert_(handle != VK_NULL_HANDLE);
 			SetDebugNameImpl((uint64_t)handle, type, name);
 		}
 	}

--- a/Common/Math/math_util.h
+++ b/Common/Math/math_util.h
@@ -40,6 +40,10 @@ inline uint32_t RoundUpToPowerOf2(uint32_t v) {
 	return v;
 }
 
+inline uint32_t RoundUpToPowerOf2(uint32_t v, uint32_t power) {
+	return (v + power - 1) & ~(power - 1);
+}
+
 inline uint32_t log2i(uint32_t val) {
 	unsigned int ret = -1;
 	while (val != 0) {


### PR DESCRIPTION
Just something I noticed we didn't do, while poking around the texture code.

Might marginally increase texture upload performance on some GPUs, but mainly just the right thing to do.

For example, on Intel, this is 64.