### PR TITLE
VFS cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -588,8 +588,10 @@ add_library(Common STATIC
 	Common/Data/Random/Rng.h
 	Common/File/VFS/VFS.h
 	Common/File/VFS/VFS.cpp
-	Common/File/VFS/AssetReader.cpp
-	Common/File/VFS/AssetReader.h
+	Common/File/VFS/ZipFileReader.cpp
+	Common/File/VFS/ZipFileReader.h
+	Common/File/VFS/DirectoryReader.cpp
+	Common/File/VFS/DirectoryReader.h
 	Common/File/AndroidStorage.h
 	Common/File/AndroidStorage.cpp
 	Common/File/DiskFree.h
@@ -1150,7 +1152,7 @@ elseif(IOS AND NOT LIBRETRO)
 		UI/DarwinFileSystemServices.h
 		Common/Battery/AppleBatteryClient.m
 	)
-    
+
 	set(nativeExtraLibs ${nativeExtraLibs} "-framework Foundation -framework MediaPlayer -framework AudioToolbox -framework CoreGraphics -framework QuartzCore -framework UIKit -framework GLKit -framework OpenAL -framework AVFoundation -framework CoreLocation -framework CoreVideo -framework CoreMedia -framework CoreServices" )
 	if(EXISTS "${CMAKE_IOS_SDK_ROOT}/System/Library/Frameworks/GameController.framework")
 		set(nativeExtraLibs ${nativeExtraLibs} "-weak_framework GameController")

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -425,8 +425,9 @@
     <ClInclude Include="File\FileUtil.h" />
     <ClInclude Include="File\Path.h" />
     <ClInclude Include="File\PathBrowser.h" />
+    <ClInclude Include="File\VFS\DirectoryReader.h" />
     <ClInclude Include="File\VFS\VFS.h" />
-    <ClInclude Include="File\VFS\AssetReader.h" />
+    <ClInclude Include="File\VFS\ZipFileReader.h" />
     <ClInclude Include="GPU\D3D11\D3D11Loader.h" />
     <ClInclude Include="GPU\D3D9\D3DCompilerLoader.h" />
     <ClInclude Include="GPU\D3D9\D3D9ShaderCompiler.h" />
@@ -861,8 +862,9 @@
     <ClCompile Include="File\FileUtil.cpp" />
     <ClCompile Include="File\Path.cpp" />
     <ClCompile Include="File\PathBrowser.cpp" />
+    <ClCompile Include="File\VFS\DirectoryReader.cpp" />
     <ClCompile Include="File\VFS\VFS.cpp" />
-    <ClCompile Include="File\VFS\AssetReader.cpp" />
+    <ClCompile Include="File\VFS\ZipFileReader.cpp" />
     <ClCompile Include="GPU\D3D11\D3D11Loader.cpp" />
     <ClCompile Include="GPU\D3D11\thin3d_d3d11.cpp" />
     <ClCompile Include="GPU\D3D9\D3DCompilerLoader.cpp" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -176,9 +176,6 @@
     <ClInclude Include="File\VFS\VFS.h">
       <Filter>File\VFS</Filter>
     </ClInclude>
-    <ClInclude Include="File\VFS\AssetReader.h">
-      <Filter>File\VFS</Filter>
-    </ClInclude>
     <ClInclude Include="Data\Format\IniFile.h">
       <Filter>Data\Format</Filter>
     </ClInclude>
@@ -467,6 +464,12 @@
     <ClInclude Include="GPU\OpenGL\GLFrameData.h">
       <Filter>GPU\OpenGL</Filter>
     </ClInclude>
+    <ClInclude Include="File\VFS\DirectoryReader.h">
+      <Filter>File\VFS</Filter>
+    </ClInclude>
+    <ClInclude Include="File\VFS\ZipFileReader.h">
+      <Filter>File\VFS</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />
@@ -626,9 +629,6 @@
       <Filter>File</Filter>
     </ClCompile>
     <ClCompile Include="File\VFS\VFS.cpp">
-      <Filter>File\VFS</Filter>
-    </ClCompile>
-    <ClCompile Include="File\VFS\AssetReader.cpp">
       <Filter>File\VFS</Filter>
     </ClCompile>
     <ClCompile Include="Data\Format\IniFile.cpp">
@@ -883,6 +883,12 @@
     </ClCompile>
     <ClCompile Include="GPU\OpenGL\GLFrameData.cpp">
       <Filter>GPU\OpenGL</Filter>
+    </ClCompile>
+    <ClCompile Include="File\VFS\DirectoryReader.cpp">
+      <Filter>File\VFS</Filter>
+    </ClCompile>
+    <ClCompile Include="File\VFS\ZipFileReader.cpp">
+      <Filter>File\VFS</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Common/Data/Format/IniFile.cpp
+++ b/Common/Data/Format/IniFile.cpp
@@ -569,7 +569,7 @@ bool IniFile::Load(const Path &path)
 
 bool IniFile::LoadFromVFS(const std::string &filename) {
 	size_t size;
-	uint8_t *data = VFSReadFile(filename.c_str(), &size);
+	uint8_t *data = g_VFS.ReadFile(filename.c_str(), &size);
 	if (!data)
 		return false;
 	std::string str((const char*)data, size);

--- a/Common/Data/Format/JSONReader.cpp
+++ b/Common/Data/Format/JSONReader.cpp
@@ -8,7 +8,7 @@ namespace json {
 
 JsonReader::JsonReader(const std::string &filename) {
 	size_t buf_size;
-	buffer_ = (char *)VFSReadFile(filename.c_str(), &buf_size);
+	buffer_ = (char *)g_VFS.ReadFile(filename.c_str(), &buf_size);
 	if (buffer_) {
 		parse();
 	} else {

--- a/Common/Data/Format/ZIMLoad.cpp
+++ b/Common/Data/Format/ZIMLoad.cpp
@@ -126,7 +126,7 @@ int LoadZIMPtr(const uint8_t *zim, size_t datasize, int *width, int *height, int
 
 int LoadZIM(const char *filename, int *width, int *height, int *format, uint8_t **image) {
 	size_t size;
-	uint8_t *buffer = VFSReadFile(filename, &size);
+	uint8_t *buffer = g_VFS.ReadFile(filename, &size);
 	if (!buffer) {
 		ERROR_LOG(IO, "Couldn't read data for '%s'", filename);
 		return 0;

--- a/Common/Data/Text/I18n.cpp
+++ b/Common/Data/Text/I18n.cpp
@@ -73,7 +73,7 @@ Path I18NRepo::GetIniPath(const std::string &languageID) const {
 
 bool I18NRepo::IniExists(const std::string &languageID) const {
 	File::FileInfo info;
-	if (!VFSGetFileInfo(GetIniPath(languageID).ToString().c_str(), &info))
+	if (!g_VFS.GetFileInfo(GetIniPath(languageID).ToString().c_str(), &info))
 		return false;
 	if (!info.exists)
 		return false;

--- a/Common/File/AndroidStorage.cpp
+++ b/Common/File/AndroidStorage.cpp
@@ -1,3 +1,5 @@
+#include <inttypes.h>
+
 #include "Common/File/AndroidStorage.h"
 #include "Common/StringUtils.h"
 #include "Common/Log.h"

--- a/Common/File/DirListing.h
+++ b/Common/File/DirListing.h
@@ -2,10 +2,8 @@
 
 #include <string>
 #include <vector>
-
 #include <cstdio>
-
-#include <inttypes.h>
+#include <cstdint>
 
 #include "Common/File/Path.h"
 

--- a/Common/File/VFS/AssetReader.h
+++ b/Common/File/VFS/AssetReader.h
@@ -1,8 +1,9 @@
-// TODO: Move much of this code to vfs.cpp
 #pragma once
 
-#ifdef __ANDROID__
+#ifdef SHARED_LIBZIP
 #include <zip.h>
+#else
+#include "ext/libzip/zip.h"
 #endif
 
 #include <mutex>
@@ -14,24 +15,11 @@
 #include "Common/File/FileUtil.h"
 #include "Common/File/Path.h"
 
-class AssetReader {
-public:
-	virtual ~AssetReader() {}
-	// use delete[]
-	virtual uint8_t *ReadAsset(const char *path, size_t *size) = 0;
-	// Filter support is optional but nice to have
-	virtual bool GetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter = 0) = 0;
-	virtual bool GetFileInfo(const char *path, File::FileInfo *info) = 0;
-	virtual std::string toString() const = 0;
-};
-
-#ifdef __ANDROID__
-uint8_t *ReadFromZip(zip *archive, const char* filename, size_t *size);
 class ZipAssetReader : public AssetReader {
 public:
 	ZipAssetReader(const char *zip_file, const char *in_zip_path);
 	~ZipAssetReader();
-	// use delete[]
+	// use delete[] on the returned value.
 	uint8_t *ReadAsset(const char *path, size_t *size) override;
 	bool GetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter) override;
 	bool GetFileInfo(const char *path, File::FileInfo *info) override;
@@ -46,7 +34,6 @@ private:
 	std::mutex lock_;
 	char in_zip_path_[256];
 };
-#endif
 
 class DirectoryAssetReader : public AssetReader {
 public:

--- a/Common/File/VFS/DirectoryReader.cpp
+++ b/Common/File/VFS/DirectoryReader.cpp
@@ -1,0 +1,31 @@
+#include "Common/Common.h"
+#include "Common/Log.h"
+#include "Common/File/VFS/DirectoryReader.h"
+
+DirectoryReader::DirectoryReader(const Path &path) {
+	path_ = path;
+}
+
+uint8_t *DirectoryReader::ReadFile(const char *path, size_t *size) {
+	Path new_path = Path(path).StartsWith(path_) ? Path(path) : path_ / path;
+	return File::ReadLocalFile(new_path, size);
+}
+
+bool DirectoryReader::GetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter = nullptr) {
+	Path new_path = Path(path).StartsWith(path_) ? Path(path) : path_ / path;
+
+	File::FileInfo info;
+	if (!File::GetFileInfo(new_path, &info))
+		return false;
+
+	if (info.isDirectory) {
+		File::GetFilesInDir(new_path, listing, filter);
+		return true;
+	}
+	return false;
+}
+
+bool DirectoryReader::GetFileInfo(const char *path, File::FileInfo *info) {
+	Path new_path = Path(path).StartsWith(path_) ? Path(path) : path_ / path;
+	return File::GetFileInfo(new_path, info);
+}

--- a/Common/File/VFS/DirectoryReader.h
+++ b/Common/File/VFS/DirectoryReader.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Common/File/VFS/VFS.h"
+#include "Common/File/FileUtil.h"
+#include "Common/File/Path.h"
+
+class DirectoryReader : public VFSBackend {
+public:
+	explicit DirectoryReader(const Path &path);
+	// use delete[] on the returned value.
+	uint8_t *ReadFile(const char *path, size_t *size) override;
+	bool GetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter) override;
+	bool GetFileInfo(const char *path, File::FileInfo *info) override;
+	std::string toString() const override {
+		return path_.ToString();
+	}
+
+private:
+	Path path_;
+};
+

--- a/Common/File/VFS/VFS.cpp
+++ b/Common/File/VFS/VFS.cpp
@@ -3,26 +3,20 @@
 #include "Common/File/VFS/AssetReader.h"
 #include "Common/File/AndroidStorage.h"
 
-struct VFSEntry {
-	const char *prefix;
-	AssetReader *reader;
-};
+VFS g_VFS;
 
-static VFSEntry entries[16];
-static int num_entries = 0;
-
-void VFSRegister(const char *prefix, AssetReader *reader) {
-	entries[num_entries].prefix = prefix;
-	entries[num_entries].reader = reader;
+void VFS::Register(const char *prefix, AssetReader *reader) {
+	entries_[numEntries_].prefix = prefix;
+	entries_[numEntries_].reader = reader;
 	DEBUG_LOG(IO, "Registered VFS for prefix %s: %s", prefix, reader->toString().c_str());
-	num_entries++;
+	numEntries_++;
 }
 
-void VFSShutdown() {
-	for (int i = 0; i < num_entries; i++) {
-		delete entries[i].reader;
+void VFS::Clear() {
+	for (int i = 0; i < numEntries_; i++) {
+		delete entries_[i].reader;
 	}
-	num_entries = 0;
+	numEntries_ = 0;
 }
 
 // TODO: Use Path more.
@@ -38,7 +32,7 @@ static bool IsLocalAbsolutePath(const char *path) {
 }
 
 // The returned data should be free'd with delete[].
-uint8_t *VFSReadFile(const char *filename, size_t *size) {
+uint8_t *VFS::ReadFile(const char *filename, size_t *size) {
 	if (IsLocalAbsolutePath(filename)) {
 		// Local path, not VFS.
 		// INFO_LOG(IO, "Not a VFS path: %s . Reading local file.", filename);
@@ -47,13 +41,13 @@ uint8_t *VFSReadFile(const char *filename, size_t *size) {
 
 	int fn_len = (int)strlen(filename);
 	bool fileSystemFound = false;
-	for (int i = 0; i < num_entries; i++) {
-		int prefix_len = (int)strlen(entries[i].prefix);
+	for (int i = 0; i < numEntries_; i++) {
+		int prefix_len = (int)strlen(entries_[i].prefix);
 		if (prefix_len >= fn_len) continue;
-		if (0 == memcmp(filename, entries[i].prefix, prefix_len)) {
+		if (0 == memcmp(filename, entries_[i].prefix, prefix_len)) {
 			fileSystemFound = true;
 			// INFO_LOG(IO, "Prefix match: %s (%s) -> %s", entries[i].prefix, filename, filename + prefix_len);
-			uint8_t *data = entries[i].reader->ReadAsset(filename + prefix_len, size);
+			uint8_t *data = entries_[i].reader->ReadAsset(filename + prefix_len, size);
 			if (data)
 				return data;
 			else
@@ -67,7 +61,7 @@ uint8_t *VFSReadFile(const char *filename, size_t *size) {
 	return 0;
 }
 
-bool VFSGetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter) {
+bool VFS::GetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter) {
 	if (IsLocalAbsolutePath(path)) {
 		// Local path, not VFS.
 		// INFO_LOG(IO, "Not a VFS path: %s . Reading local directory.", path);
@@ -77,12 +71,12 @@ bool VFSGetFileListing(const char *path, std::vector<File::FileInfo> *listing, c
 
 	int fn_len = (int)strlen(path);
 	bool fileSystemFound = false;
-	for (int i = 0; i < num_entries; i++) {
-		int prefix_len = (int)strlen(entries[i].prefix);
+	for (int i = 0; i < numEntries_; i++) {
+		int prefix_len = (int)strlen(entries_[i].prefix);
 		if (prefix_len >= fn_len) continue;
-		if (0 == memcmp(path, entries[i].prefix, prefix_len)) {
+		if (0 == memcmp(path, entries_[i].prefix, prefix_len)) {
 			fileSystemFound = true;
-			if (entries[i].reader->GetFileListing(path + prefix_len, listing, filter)) {
+			if (entries_[i].reader->GetFileListing(path + prefix_len, listing, filter)) {
 				return true;
 			}
 		}
@@ -94,7 +88,7 @@ bool VFSGetFileListing(const char *path, std::vector<File::FileInfo> *listing, c
 	return false;
 }
 
-bool VFSGetFileInfo(const char *path, File::FileInfo *info) {
+bool VFS::GetFileInfo(const char *path, File::FileInfo *info) {
 	if (IsLocalAbsolutePath(path)) {
 		// Local path, not VFS.
 		// INFO_LOG(IO, "Not a VFS path: %s . Getting local file info.", path);
@@ -103,19 +97,19 @@ bool VFSGetFileInfo(const char *path, File::FileInfo *info) {
 
 	bool fileSystemFound = false;
 	int fn_len = (int)strlen(path);
-	for (int i = 0; i < num_entries; i++) {
-		int prefix_len = (int)strlen(entries[i].prefix);
+	for (int i = 0; i < numEntries_; i++) {
+		int prefix_len = (int)strlen(entries_[i].prefix);
 		if (prefix_len >= fn_len) continue;
-		if (0 == memcmp(path, entries[i].prefix, prefix_len)) {
+		if (0 == memcmp(path, entries_[i].prefix, prefix_len)) {
 			fileSystemFound = true;
-			if (entries[i].reader->GetFileInfo(path + prefix_len, info))
+			if (entries_[i].reader->GetFileInfo(path + prefix_len, info))
 				return true;
 			else
 				continue;
 		}
 	}
 	if (!fileSystemFound) {
-		ERROR_LOG(IO, "Missing filesystem for %s", path);
+		ERROR_LOG(IO, "Missing filesystem for '%s'", path);
 	}  // Otherwise, the file was just missing. No need to log.
 	return false;
 }

--- a/Common/File/VFS/VFS.cpp
+++ b/Common/File/VFS/VFS.cpp
@@ -1,11 +1,13 @@
+#include <cstring>
+
 #include "Common/Log.h"
 #include "Common/File/VFS/VFS.h"
-#include "Common/File/VFS/AssetReader.h"
+#include "Common/File/FileUtil.h"
 #include "Common/File/AndroidStorage.h"
 
 VFS g_VFS;
 
-void VFS::Register(const char *prefix, AssetReader *reader) {
+void VFS::Register(const char *prefix, VFSBackend *reader) {
 	entries_.push_back(VFSEntry{ prefix, reader });
 	DEBUG_LOG(IO, "Registered VFS for prefix %s: %s", prefix, reader->toString().c_str());
 }
@@ -45,7 +47,7 @@ uint8_t *VFS::ReadFile(const char *filename, size_t *size) {
 		if (0 == memcmp(filename, entry.prefix, prefix_len)) {
 			fileSystemFound = true;
 			// INFO_LOG(IO, "Prefix match: %s (%s) -> %s", entries[i].prefix, filename, filename + prefix_len);
-			uint8_t *data = entry.reader->ReadAsset(filename + prefix_len, size);
+			uint8_t *data = entry.reader->ReadFile(filename + prefix_len, size);
 			if (data)
 				return data;
 			else

--- a/Common/File/VFS/VFS.h
+++ b/Common/File/VFS/VFS.h
@@ -10,12 +10,26 @@
 
 class AssetReader;
 
-void VFSRegister(const char *prefix, AssetReader *reader);
-void VFSShutdown();
+class VFS {
+public:
+	void Register(const char *prefix, AssetReader *reader);
+	void Clear();
 
-// Use delete [] to release the returned memory.
-// Always allocates an extra zero byte at the end, so that it
-// can be used for text like shader sources.
-uint8_t *VFSReadFile(const char *filename, size_t *size);
-bool VFSGetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter = 0);
-bool VFSGetFileInfo(const char *filename, File::FileInfo *fileInfo);
+	// Use delete [] to release the returned memory.
+	// Always allocates an extra zero byte at the end, so that it
+	// can be used for text like shader sources.
+	uint8_t *ReadFile(const char *filename, size_t *size);
+	bool GetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter = 0);
+	bool GetFileInfo(const char *filename, File::FileInfo *fileInfo);
+
+private:
+	struct VFSEntry {
+		const char *prefix;
+		AssetReader *reader;
+	};
+
+	VFSEntry entries_[16];
+	int numEntries_ = 0;
+};
+
+extern VFS g_VFS;

--- a/Common/File/VFS/VFS.h
+++ b/Common/File/VFS/VFS.h
@@ -14,11 +14,11 @@
 // on the system level, like loading assets, and maybe texture packs. Also, as mentioned,
 // this one is read-only, so a bit smaller and simpler.
 
-class AssetReader {
+class VFSBackend {
 public:
-	virtual ~AssetReader() {}
+	virtual ~VFSBackend() {}
 	// use delete[] to release the returned memory.
-	virtual uint8_t *ReadAsset(const char *path, size_t *size) = 0;
+	virtual uint8_t *ReadFile(const char *path, size_t *size) = 0;
 
 	// Filter support is optional but nice to have
 	virtual bool GetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter = 0) = 0;
@@ -29,7 +29,7 @@ public:
 class VFS {
 public:
 	~VFS() { Clear(); }
-	void Register(const char *prefix, AssetReader *reader);
+	void Register(const char *prefix, VFSBackend *reader);
 	void Clear();
 
 	// Use delete [] to release the returned memory.
@@ -42,7 +42,7 @@ public:
 private:
 	struct VFSEntry {
 		const char *prefix;
-		AssetReader *reader;
+		VFSBackend *reader;
 	};
 	std::vector<VFSEntry> entries_;
 };

--- a/Common/File/VFS/VFS.h
+++ b/Common/File/VFS/VFS.h
@@ -1,18 +1,25 @@
 #pragma once
 
 #include <vector>
+#include <cstdint>
 
 #include "Common/File/DirListing.h"
 
-// Basic virtual file system. Used to manage assets on Android, where we have to
+// Basic read-only virtual file system. Used to manage assets on Android, where we have to
 // read them manually out of the APK zipfile, while being able to run on other
 // platforms as well with the appropriate directory set-up.
+
+// Note that this is kinda similar in concept to Core/MetaFileSystem.h, but that one
+// is specifically for operations done by the emulated PSP, while this is for operations
+// on the system level, like loading assets, and maybe texture packs. Also, as mentioned,
+// this one is read-only, so a bit smaller and simpler.
 
 class AssetReader {
 public:
 	virtual ~AssetReader() {}
-	// use delete[]
+	// use delete[] to release the returned memory.
 	virtual uint8_t *ReadAsset(const char *path, size_t *size) = 0;
+
 	// Filter support is optional but nice to have
 	virtual bool GetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter = 0) = 0;
 	virtual bool GetFileInfo(const char *path, File::FileInfo *info) = 0;
@@ -21,6 +28,7 @@ public:
 
 class VFS {
 public:
+	~VFS() { Clear(); }
 	void Register(const char *prefix, AssetReader *reader);
 	void Clear();
 
@@ -36,9 +44,7 @@ private:
 		const char *prefix;
 		AssetReader *reader;
 	};
-
-	VFSEntry entries_[16];
-	int numEntries_ = 0;
+	std::vector<VFSEntry> entries_;
 };
 
 extern VFS g_VFS;

--- a/Common/File/VFS/VFS.h
+++ b/Common/File/VFS/VFS.h
@@ -8,7 +8,16 @@
 // read them manually out of the APK zipfile, while being able to run on other
 // platforms as well with the appropriate directory set-up.
 
-class AssetReader;
+class AssetReader {
+public:
+	virtual ~AssetReader() {}
+	// use delete[]
+	virtual uint8_t *ReadAsset(const char *path, size_t *size) = 0;
+	// Filter support is optional but nice to have
+	virtual bool GetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter = 0) = 0;
+	virtual bool GetFileInfo(const char *path, File::FileInfo *info) = 0;
+	virtual std::string toString() const = 0;
+};
 
 class VFS {
 public:

--- a/Common/File/VFS/ZipFileReader.h
+++ b/Common/File/VFS/ZipFileReader.h
@@ -8,19 +8,18 @@
 
 #include <mutex>
 #include <set>
-#include <string.h>
 #include <string>
 
 #include "Common/File/VFS/VFS.h"
 #include "Common/File/FileUtil.h"
 #include "Common/File/Path.h"
 
-class ZipAssetReader : public AssetReader {
+class ZipFileReader : public VFSBackend {
 public:
-	ZipAssetReader(const char *zip_file, const char *in_zip_path);
-	~ZipAssetReader();
+	ZipFileReader(const char *zip_file, const char *in_zip_path);
+	~ZipFileReader();
 	// use delete[] on the returned value.
-	uint8_t *ReadAsset(const char *path, size_t *size) override;
+	uint8_t *ReadFile(const char *path, size_t *size) override;
 	bool GetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter) override;
 	bool GetFileInfo(const char *path, File::FileInfo *info) override;
 	std::string toString() const override {
@@ -34,19 +33,3 @@ private:
 	std::mutex lock_;
 	char in_zip_path_[256];
 };
-
-class DirectoryAssetReader : public AssetReader {
-public:
-	explicit DirectoryAssetReader(const Path &path);
-	// use delete[]
-	uint8_t *ReadAsset(const char *path, size_t *size) override;
-	bool GetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter) override;
-	bool GetFileInfo(const char *path, File::FileInfo *info) override;
-	std::string toString() const override {
-		return path_.ToString();
-	}
-
-private:
-	Path path_;
-};
-

--- a/Common/File/VFS/ZipFileReader.h
+++ b/Common/File/VFS/ZipFileReader.h
@@ -16,14 +16,14 @@
 
 class ZipFileReader : public VFSBackend {
 public:
-	ZipFileReader(const char *zip_file, const char *in_zip_path);
+	ZipFileReader(const Path &zipFile, const char *inZipPath);
 	~ZipFileReader();
 	// use delete[] on the returned value.
 	uint8_t *ReadFile(const char *path, size_t *size) override;
 	bool GetFileListing(const char *path, std::vector<File::FileInfo> *listing, const char *filter) override;
 	bool GetFileInfo(const char *path, File::FileInfo *info) override;
 	std::string toString() const override {
-		return in_zip_path_;
+		return inZipPath_;
 	}
 
 private:
@@ -31,5 +31,5 @@ private:
 
 	zip *zip_file_;
 	std::mutex lock_;
-	char in_zip_path_[256];
+	char inZipPath_[256];
 };

--- a/Common/GPU/OpenGL/GLSLProgram.cpp
+++ b/Common/GPU/OpenGL/GLSLProgram.cpp
@@ -102,7 +102,7 @@ bool glsl_recompile(GLSLProgram *program, std::string *error_message) {
 
 	if (!program->vshader_source && !vsh_src) {
 		size_t sz;
-		vsh_src.reset((char *)VFSReadFile(program->vshader_filename, &sz));
+		vsh_src.reset((char *)g_VFS.ReadFile(program->vshader_filename, &sz));
 	}
 	if (!program->vshader_source && !vsh_src) {
 		ERROR_LOG(G3D, "File missing: %s", program->vshader_filename);
@@ -113,7 +113,7 @@ bool glsl_recompile(GLSLProgram *program, std::string *error_message) {
 	}
 	if (!program->fshader_source && !fsh_src) {
 		size_t sz;
-		fsh_src.reset((char *)VFSReadFile(program->fshader_filename, &sz));
+		fsh_src.reset((char *)g_VFS.ReadFile(program->fshader_filename, &sz));
 	}
 	if (!program->fshader_source && !fsh_src) {
 		ERROR_LOG(G3D, "File missing: %s", program->fshader_filename);

--- a/Common/Render/ManagedTexture.cpp
+++ b/Common/Render/ManagedTexture.cpp
@@ -148,7 +148,7 @@ bool ManagedTexture::LoadFromFileData(const uint8_t *data, size_t dataSize, Imag
 bool ManagedTexture::LoadFromFile(const std::string &filename, ImageFileType type, bool generateMips) {
 	generateMips_ = generateMips;
 	size_t fileSize;
-	uint8_t *buffer = VFSReadFile(filename.c_str(), &fileSize);
+	uint8_t *buffer = g_VFS.ReadFile(filename.c_str(), &fileSize);
 	if (!buffer) {
 		filename_.clear();
 		ERROR_LOG(IO, "Failed to read file '%s'", filename.c_str());

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -980,7 +980,7 @@ int VFSFileSystem::OpenFile(std::string filename, FileAccess access, const char 
 	VERBOSE_LOG(FILESYS, "VFSFileSystem actually opening %s (%s)", fullNameC, filename.c_str());
 
 	size_t size;
-	u8 *data = VFSReadFile(fullNameC, &size);
+	u8 *data = g_VFS.ReadFile(fullNameC, &size);
 	if (!data) {
 		ERROR_LOG(FILESYS, "VFSFileSystem failed to open %s", filename.c_str());
 		return SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND;
@@ -1001,7 +1001,7 @@ PSPFileInfo VFSFileSystem::GetFileInfo(std::string filename) {
 
 	std::string fullName = GetLocalPath(filename);
 	File::FileInfo fo;
-	if (VFSGetFileInfo(fullName.c_str(), &fo)) {
+	if (g_VFS.GetFileInfo(fullName.c_str(), &fo)) {
 		x.exists = fo.exists;
 		if (x.exists) {
 			x.size = fo.size;

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -569,7 +569,7 @@ namespace Reporting
 			return false;
 #else
 		File::FileInfo fo;
-		if (!VFSGetFileInfo("flash0/font/jpn0.pgf", &fo))
+		if (!g_VFS.GetFileInfo("flash0/font/jpn0.pgf", &fo))
 			return false;
 #endif
 

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -252,7 +252,7 @@ void __PPGeInit() {
 	if (loadedZIM) {
 		size_t atlas_data_size;
 		if (!g_ppge_atlas.IsMetadataLoaded()) {
-			uint8_t *atlas_data = VFSReadFile("ppge_atlas.meta", &atlas_data_size);
+			uint8_t *atlas_data = g_VFS.ReadFile("ppge_atlas.meta", &atlas_data_size);
 			if (atlas_data)
 				g_ppge_atlas.Load(atlas_data, atlas_data_size);
 			delete[] atlas_data;

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -237,7 +237,7 @@ static bool ServeDebuggerFile(const http::Request &request) {
 		return false;
 
 	size_t size;
-	uint8_t *data = VFSReadFile(filename, &size);
+	uint8_t *data = g_VFS.ReadFile(filename, &size);
 	if (!data)
 		return false;
 

--- a/GPU/Common/PostShader.cpp
+++ b/GPU/Common/PostShader.cpp
@@ -70,7 +70,7 @@ void LoadPostShaderInfo(Draw::DrawContext *draw, const std::vector<Path> &direct
 
 	for (size_t d = 0; d < directories.size(); d++) {
 		std::vector<File::FileInfo> fileInfo;
-		VFSGetFileListing(directories[d].c_str(), &fileInfo, "ini:");
+		g_VFS.GetFileListing(directories[d].c_str(), &fileInfo, "ini:");
 
 		if (fileInfo.empty()) {
 			File::GetFilesInDir(directories[d], &fileInfo, "ini:");

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -212,7 +212,7 @@ void PresentationCommon::CalculatePostShaderUniforms(int bufferWidth, int buffer
 
 static std::string ReadShaderSrc(const Path &filename) {
 	size_t sz = 0;
-	char *data = (char *)VFSReadFile(filename.c_str(), &sz);
+	char *data = (char *)g_VFS.ReadFile(filename.c_str(), &sz);
 	if (!data) {
 		return "";
 	}

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -260,7 +260,7 @@ void TextureCacheVulkan::NotifyConfigChanged() {
 
 static std::string ReadShaderSrc(const Path &filename) {
 	size_t sz = 0;
-	char *data = (char *)VFSReadFile(filename.c_str(), &sz);
+	char *data = (char *)g_VFS.ReadFile(filename.c_str(), &sz);
 	if (!data)
 		return std::string();
 

--- a/Qt/QtMain.h
+++ b/Qt/QtMain.h
@@ -25,7 +25,7 @@ QTM_USE_NAMESPACE
 #include "Common/System/Display.h"
 #include "Common/TimeUtil.h"
 #include "Common/File/VFS/VFS.h"
-#include "Common/File/VFS/AssetReader.h"
+#include "Common/File/VFS/DirectoryReader.h"
 #include "Common/GPU/OpenGL/GLCommon.h"
 #include "Common/GPU/OpenGL/GLFeatures.h"
 #include "Common/Input/InputState.h"
@@ -191,4 +191,3 @@ private:
 #endif //SDL
 
 #endif
-

--- a/SDL/SDLJoystick.cpp
+++ b/SDL/SDLJoystick.cpp
@@ -29,7 +29,7 @@ SDLJoystick::SDLJoystick(bool init_SDL ) : registeredAsEventHandler(false) {
 	cout << "loading control pad mappings from " << dbPath << ": ";
 
 	size_t size;
-	u8 *mappingData = VFSReadFile(dbPath, &size);
+	u8 *mappingData = g_VFS.ReadFile(dbPath, &size);
 	if (mappingData) {
 		SDL_RWops *rw = SDL_RWFromConstMem(mappingData, size);
 		// 1 to free the rw after use
@@ -191,7 +191,7 @@ void SDLJoystick::ProcessInput(SDL_Event &event){
 		NativeAxis(axis);
 		break;
 	case SDL_CONTROLLERDEVICEREMOVED:
-		// for removal events, "which" is the instance ID for SDL_CONTROLLERDEVICEREMOVED		
+		// for removal events, "which" is the instance ID for SDL_CONTROLLERDEVICEREMOVED
 		for (auto it = controllers.begin(); it != controllers.end(); ++it) {
 			if (SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(*it)) == event.cdevice.which) {
 				SDL_GameControllerClose(*it);

--- a/UI/BackgroundAudio.cpp
+++ b/UI/BackgroundAudio.cpp
@@ -257,7 +257,7 @@ BackgroundAudio::~BackgroundAudio() {
 
 BackgroundAudio::Sample *BackgroundAudio::LoadSample(const std::string &path) {
 	size_t bytes;
-	uint8_t *data = VFSReadFile(path.c_str(), &bytes);
+	uint8_t *data = g_VFS.ReadFile(path.c_str(), &bytes);
 	if (!data) {
 		return nullptr;
 	}

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -314,7 +314,7 @@ static bool ReadFileToString(IFileSystem *fs, const char *filename, std::string 
 
 static bool ReadVFSToString(const char *filename, std::string *contents, std::mutex *mtx) {
 	size_t sz;
-	uint8_t *data = VFSReadFile(filename, &sz);
+	uint8_t *data = g_VFS.ReadFile(filename, &sz);
 	if (data) {
 		if (mtx) {
 			std::lock_guard<std::mutex> lock(*mtx);

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -590,7 +590,7 @@ NewLanguageScreen::NewLanguageScreen(const std::string &title) : ListPopupScreen
 	auto &langValuesMapping = g_Config.GetLangValuesMapping();
 
 	std::vector<File::FileInfo> tempLangs;
-	VFSGetFileListing("lang", &tempLangs, "ini");
+	g_VFS.GetFileListing("lang", &tempLangs, "ini");
 	std::vector<std::string> listing;
 	int selected = -1;
 	int counter = 0;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -467,27 +467,27 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	// We want this to be FIRST.
 #if PPSSPP_PLATFORM(IOS) || PPSSPP_PLATFORM(MAC)
 	// Packed assets are included in app
-	VFSRegister("", new DirectoryAssetReader(Path(external_dir)));
+	g_VFS.Register("", new DirectoryAssetReader(Path(external_dir)));
 #endif
 #if defined(ASSETS_DIR)
-	VFSRegister("", new DirectoryAssetReader(Path(ASSETS_DIR)));
+	g_VFS.Register("", new DirectoryAssetReader(Path(ASSETS_DIR)));
 #endif
 #if !defined(MOBILE_DEVICE) && !defined(_WIN32) && !PPSSPP_PLATFORM(SWITCH)
-	VFSRegister("", new DirectoryAssetReader(File::GetExeDirectory() / "assets"));
-	VFSRegister("", new DirectoryAssetReader(File::GetExeDirectory()));
-	VFSRegister("", new DirectoryAssetReader(Path("/usr/local/share/ppsspp/assets")));
-	VFSRegister("", new DirectoryAssetReader(Path("/usr/local/share/games/ppsspp/assets")));
-	VFSRegister("", new DirectoryAssetReader(Path("/usr/share/ppsspp/assets")));
-	VFSRegister("", new DirectoryAssetReader(Path("/usr/share/games/ppsspp/assets")));
+	g_VFS.Register("", new DirectoryAssetReader(File::GetExeDirectory() / "assets"));
+	g_VFS.Register("", new DirectoryAssetReader(File::GetExeDirectory()));
+	g_VFS.Register("", new DirectoryAssetReader(Path("/usr/local/share/ppsspp/assets")));
+	g_VFS.Register("", new DirectoryAssetReader(Path("/usr/local/share/games/ppsspp/assets")));
+	g_VFS.Register("", new DirectoryAssetReader(Path("/usr/share/ppsspp/assets")));
+	g_VFS.Register("", new DirectoryAssetReader(Path("/usr/share/games/ppsspp/assets")));
 #endif
 
 #if PPSSPP_PLATFORM(SWITCH)
 	Path assetPath = Path(user_data_path) / "assets";
-	VFSRegister("", new DirectoryAssetReader(assetPath));
+	g_VFS.Register("", new DirectoryAssetReader(assetPath));
 #else
-	VFSRegister("", new DirectoryAssetReader(Path("assets")));
+	g_VFS.Register("", new DirectoryAssetReader(Path("assets")));
 #endif
-	VFSRegister("", new DirectoryAssetReader(Path(savegame_dir)));
+	g_VFS.Register("", new DirectoryAssetReader(Path(savegame_dir)));
 
 #if (defined(MOBILE_DEVICE) || !defined(USING_QT_UI)) && !PPSSPP_PLATFORM(UWP)
 	if (host == nullptr) {
@@ -777,7 +777,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	}
 #elif defined(USING_QT_UI)
 	size_t fontSize = 0;
-	uint8_t *fontData = VFSReadFile("Roboto-Condensed.ttf", &fontSize);
+	uint8_t *fontData = g_VFS.ReadFile("Roboto-Condensed.ttf", &fontSize);
 	if (fontData) {
 		int fontID = QFontDatabase::addApplicationFontFromData(QByteArray((const char *)fontData, fontSize));
 		delete [] fontData;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -67,7 +67,8 @@
 #include "Common/Profiler/Profiler.h"
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/File/VFS/VFS.h"
-#include "Common/File/VFS/AssetReader.h"
+#include "Common/File/VFS/ZipFileReader.h"
+#include "Common/File/VFS/DirectoryReader.h"
 #include "Common/CPUDetect.h"
 #include "Common/File/FileUtil.h"
 #include "Common/TimeUtil.h"
@@ -467,27 +468,27 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	// We want this to be FIRST.
 #if PPSSPP_PLATFORM(IOS) || PPSSPP_PLATFORM(MAC)
 	// Packed assets are included in app
-	g_VFS.Register("", new DirectoryAssetReader(Path(external_dir)));
+	g_VFS.Register("", new DirectoryReader(Path(external_dir)));
 #endif
 #if defined(ASSETS_DIR)
-	g_VFS.Register("", new DirectoryAssetReader(Path(ASSETS_DIR)));
+	g_VFS.Register("", new DirectoryReader(Path(ASSETS_DIR)));
 #endif
 #if !defined(MOBILE_DEVICE) && !defined(_WIN32) && !PPSSPP_PLATFORM(SWITCH)
-	g_VFS.Register("", new DirectoryAssetReader(File::GetExeDirectory() / "assets"));
-	g_VFS.Register("", new DirectoryAssetReader(File::GetExeDirectory()));
-	g_VFS.Register("", new DirectoryAssetReader(Path("/usr/local/share/ppsspp/assets")));
-	g_VFS.Register("", new DirectoryAssetReader(Path("/usr/local/share/games/ppsspp/assets")));
-	g_VFS.Register("", new DirectoryAssetReader(Path("/usr/share/ppsspp/assets")));
-	g_VFS.Register("", new DirectoryAssetReader(Path("/usr/share/games/ppsspp/assets")));
+	g_VFS.Register("", new DirectoryReader(File::GetExeDirectory() / "assets"));
+	g_VFS.Register("", new DirectoryReader(File::GetExeDirectory()));
+	g_VFS.Register("", new DirectoryReader(Path("/usr/local/share/ppsspp/assets")));
+	g_VFS.Register("", new DirectoryReader(Path("/usr/local/share/games/ppsspp/assets")));
+	g_VFS.Register("", new DirectoryReader(Path("/usr/share/ppsspp/assets")));
+	g_VFS.Register("", new DirectoryReader(Path("/usr/share/games/ppsspp/assets")));
 #endif
 
 #if PPSSPP_PLATFORM(SWITCH)
 	Path assetPath = Path(user_data_path) / "assets";
-	g_VFS.Register("", new DirectoryAssetReader(assetPath));
+	g_VFS.Register("", new DirectoryReader(assetPath));
 #else
-	g_VFS.Register("", new DirectoryAssetReader(Path("assets")));
+	g_VFS.Register("", new DirectoryReader(Path("assets")));
 #endif
-	g_VFS.Register("", new DirectoryAssetReader(Path(savegame_dir)));
+	g_VFS.Register("", new DirectoryReader(Path(savegame_dir)));
 
 #if (defined(MOBILE_DEVICE) || !defined(USING_QT_UI)) && !PPSSPP_PLATFORM(UWP)
 	if (host == nullptr) {

--- a/UI/Theme.cpp
+++ b/UI/Theme.cpp
@@ -84,7 +84,7 @@ static void LoadThemeInfo(const std::vector<Path> &directories) {
 
 	for (size_t d = 0; d < directories.size(); d++) {
 		std::vector<File::FileInfo> fileInfo;
-		VFSGetFileListing(directories[d].c_str(), &fileInfo, "ini:");
+		g_VFS.GetFileListing(directories[d].c_str(), &fileInfo, "ini:");
 
 		if (fileInfo.empty()) {
 			File::GetFilesInDir(directories[d], &fileInfo, "ini:");
@@ -138,7 +138,7 @@ static void LoadThemeInfo(const std::vector<Path> &directories) {
 					tmpPath = (path / tmpPath).ToString();
 
 					File::FileInfo tmpInfo;
-					if (VFSGetFileInfo((tmpPath+".meta").c_str(), &tmpInfo) && VFSGetFileInfo((tmpPath+".zim").c_str(), &tmpInfo)) {
+					if (g_VFS.GetFileInfo((tmpPath + ".meta").c_str(), &tmpInfo) && g_VFS.GetFileInfo((tmpPath + ".zim").c_str(), &tmpInfo)) {
 						info.sUIAtlas = tmpPath;
 					}
 				}
@@ -158,7 +158,7 @@ static UI::Style MakeStyle(uint32_t fg, uint32_t bg) {
 
 static void LoadAtlasMetadata(Atlas &metadata, const char *filename, bool required) {
 	size_t atlas_data_size = 0;
-	const uint8_t *atlas_data = VFSReadFile(filename, &atlas_data_size);
+	const uint8_t *atlas_data = g_VFS.ReadFile(filename, &atlas_data_size);
 	bool load_success = atlas_data != nullptr && metadata.Load(atlas_data, atlas_data_size);
 	if (!load_success) {
 		if (required)

--- a/UWP/CommonUWP/CommonUWP.vcxproj
+++ b/UWP/CommonUWP/CommonUWP.vcxproj
@@ -306,7 +306,8 @@
     <ClInclude Include="..\..\Common\File\FileUtil.h" />
     <ClInclude Include="..\..\Common\File\Path.h" />
     <ClInclude Include="..\..\Common\File\PathBrowser.h" />
-    <ClInclude Include="..\..\Common\File\VFS\AssetReader.h" />
+    <ClInclude Include="..\..\Common\File\VFS\DirectoryReader.h" />
+    <ClInclude Include="..\..\Common\File\VFS\ZipFileReader.h" />
     <ClInclude Include="..\..\Common\File\VFS\VFS.h" />
     <ClInclude Include="..\..\Common\GPU\DataFormat.h" />
     <ClInclude Include="..\..\Common\GPU\OpenGL\GLFeatures.h" />
@@ -443,7 +444,8 @@
     <ClCompile Include="..\..\Common\File\FileUtil.cpp" />
     <ClCompile Include="..\..\Common\File\Path.cpp" />
     <ClCompile Include="..\..\Common\File\PathBrowser.cpp" />
-    <ClCompile Include="..\..\Common\File\VFS\AssetReader.cpp" />
+    <ClCompile Include="..\..\Common\File\VFS\DirectoryReader.cpp" />
+    <ClCompile Include="..\..\Common\File\VFS\ZipFileReader.cpp" />
     <ClCompile Include="..\..\Common\File\VFS\VFS.cpp" />
     <ClCompile Include="..\..\Common\GPU\D3D11\thin3d_d3d11.cpp" />
     <ClCompile Include="..\..\Common\GPU\OpenGL\GLFeatures.cpp" />

--- a/UWP/CommonUWP/CommonUWP.vcxproj.filters
+++ b/UWP/CommonUWP/CommonUWP.vcxproj.filters
@@ -252,7 +252,10 @@
     <ClCompile Include="..\..\Common\Data\Format\RIFF.cpp">
       <Filter>Data\Format</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\Common\File\VFS\AssetReader.cpp">
+    <ClCompile Include="..\..\Common\File\VFS\DirectoryReader.cpp">
+      <Filter>File\VFS</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Common\File\VFS\ZipFileReader.cpp">
       <Filter>File\VFS</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Common\File\VFS\VFS.cpp">
@@ -589,7 +592,10 @@
     <ClInclude Include="..\..\Common\Data\Format\RIFF.h">
       <Filter>Data\Format</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\Common\File\VFS\AssetReader.h">
+    <ClInclude Include="..\..\Common\File\VFS\DirectoryReader.h">
+      <Filter>File\VFS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\File\VFS\ZipFileReader.h">
       <Filter>File\VFS</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Common\File\VFS\VFS.h">

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -76,8 +76,8 @@ PPSSPP_UWPMain::PPSSPP_UWPMain(App ^app, const std::shared_ptr<DX::DeviceResourc
 	ctx_.reset(new UWPGraphicsContext(deviceResources));
 
 	const Path &exePath = File::GetExeDirectory();
-	VFSRegister("", new DirectoryAssetReader(exePath / "Content"));
-	VFSRegister("", new DirectoryAssetReader(exePath));
+	g_VFS.Register("", new DirectoryAssetReader(exePath / "Content"));
+	g_VFS.Register("", new DirectoryAssetReader(exePath));
 
 	wchar_t lcCountry[256];
 
@@ -135,6 +135,7 @@ PPSSPP_UWPMain::~PPSSPP_UWPMain() {
 	ctx_->GetDrawContext()->HandleEvent(Draw::Event::LOST_BACKBUFFER, 0, 0, nullptr);
 	NativeShutdownGraphics();
 	NativeShutdown();
+	g_VFS.Clear();
 
 	// Deregister device notification
 	m_deviceResources->RegisterDeviceNotify(nullptr);

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -11,7 +11,7 @@
 #include "Common/Common.h"
 #include "Common/Input/InputState.h"
 #include "Common/File/VFS/VFS.h"
-#include "Common/File/VFS/AssetReader.h"
+#include "Common/File/VFS/DirectoryReader.h"
 #include "Common/Thread/ThreadUtil.h"
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/DirectXHelper.h"
@@ -76,8 +76,8 @@ PPSSPP_UWPMain::PPSSPP_UWPMain(App ^app, const std::shared_ptr<DX::DeviceResourc
 	ctx_.reset(new UWPGraphicsContext(deviceResources));
 
 	const Path &exePath = File::GetExeDirectory();
-	g_VFS.Register("", new DirectoryAssetReader(exePath / "Content"));
-	g_VFS.Register("", new DirectoryAssetReader(exePath));
+	g_VFS.Register("", new DirectoryReader(exePath / "Content"));
+	g_VFS.Register("", new DirectoryReader(exePath));
 
 	wchar_t lcCountry[256];
 

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -36,7 +36,7 @@
 #include "Common/System/System.h"
 #include "Common/File/FileUtil.h"
 #include "Common/File/VFS/VFS.h"
-#include "Common/File/VFS/AssetReader.h"
+#include "Common/File/VFS/DirectoryReader.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Profiler/Profiler.h"
 #include "Common/Thread/ThreadUtil.h"
@@ -583,8 +583,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 #endif
 
 	const Path &exePath = File::GetExeDirectory();
-	g_VFS.Register("", new DirectoryAssetReader(exePath / "assets"));
-	g_VFS.Register("", new DirectoryAssetReader(exePath));
+	g_VFS.Register("", new DirectoryReader(exePath / "assets"));
+	g_VFS.Register("", new DirectoryReader(exePath));
 
 	langRegion = GetDefaultLangRegion();
 	osName = GetWindowsVersion() + " " + GetWindowsSystemArchitecture();

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -583,8 +583,8 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 #endif
 
 	const Path &exePath = File::GetExeDirectory();
-	VFSRegister("", new DirectoryAssetReader(exePath / "assets"));
-	VFSRegister("", new DirectoryAssetReader(exePath));
+	g_VFS.Register("", new DirectoryAssetReader(exePath / "assets"));
+	g_VFS.Register("", new DirectoryAssetReader(exePath));
 
 	langRegion = GetDefaultLangRegion();
 	osName = GetWindowsVersion() + " " + GetWindowsSystemArchitecture();
@@ -796,7 +796,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 		}
 	}
 
-	VFSShutdown();
+	g_VFS.Clear();
 
 	MainWindow::DestroyDebugWindows();
 	DialogManager::DestroyAll();

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -175,7 +175,8 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Common/Data/Text/WrapText.cpp \
   $(SRC)/Common/File/AndroidStorage.cpp \
   $(SRC)/Common/File/VFS/VFS.cpp \
-  $(SRC)/Common/File/VFS/AssetReader.cpp \
+  $(SRC)/Common/File/VFS/ZipFileReader.cpp \
+  $(SRC)/Common/File/VFS/DirectoryReader.cpp \
   $(SRC)/Common/File/DiskFree.cpp \
   $(SRC)/Common/File/Path.cpp \
   $(SRC)/Common/File/PathBrowser.cpp \

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -695,8 +695,8 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_init
 	androidVersion = jAndroidVersion;
 	deviceType = jdeviceType;
 
-	std::string apkPath = GetJavaString(env, japkpath);
-	g_VFS.Register("", new ZipFileReader(apkPath.c_str(), "assets/"));
+	Path apkPath(GetJavaString(env, japkpath));
+	g_VFS.Register("", new ZipFileReader(apkPath, "assets/"));
 
 	systemName = GetJavaString(env, jmodel);
 	langRegion = GetJavaString(env, jlangRegion);

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -65,7 +65,8 @@ struct JNIEnv {};
 #include "Common/File/Path.h"
 #include "Common/File/DirListing.h"
 #include "Common/File/VFS/VFS.h"
-#include "Common/File/VFS/AssetReader.h"
+#include "Common/File/VFS/DirectoryReader.h"
+#include "Common/File/VFS/ZipFileReader.h"
 #include "Common/File/AndroidStorage.h"
 #include "Common/Input/InputState.h"
 #include "Common/Input/KeyCodes.h"
@@ -695,7 +696,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_init
 	deviceType = jdeviceType;
 
 	std::string apkPath = GetJavaString(env, japkpath);
-	g_VFS.Register("", new ZipAssetReader(apkPath.c_str(), "assets/"));
+	g_VFS.Register("", new ZipFileReader(apkPath.c_str(), "assets/"));
 
 	systemName = GetJavaString(env, jmodel);
 	langRegion = GetJavaString(env, jlangRegion);

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -695,7 +695,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_init
 	deviceType = jdeviceType;
 
 	std::string apkPath = GetJavaString(env, japkpath);
-	VFSRegister("", new ZipAssetReader(apkPath.c_str(), "assets/"));
+	g_VFS.Register("", new ZipAssetReader(apkPath.c_str(), "assets/"));
 
 	systemName = GetJavaString(env, jmodel);
 	langRegion = GetJavaString(env, jlangRegion);
@@ -907,7 +907,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_shutdown(JNIEnv *, jclass) {
 		std::lock_guard<std::mutex> guard(renderLock);
 		inputBoxCallbacks.clear();
 		NativeShutdown();
-		VFSShutdown();
+		g_VFS.Clear();
 	}
 
 	{

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -483,10 +483,10 @@ int main(int argc, const char* argv[])
 #if PPSSPP_PLATFORM(ANDROID)
 	// For some reason the debugger installs it with this name?
 	if (File::Exists(Path("/data/app/org.ppsspp.ppsspp-2.apk"))) {
-		g_VFS.Register("", new ZipFileReader("/data/app/org.ppsspp.ppsspp-2.apk", "assets/"));
+		g_VFS.Register("", new ZipFileReader(Path("/data/app/org.ppsspp.ppsspp-2.apk"), "assets/"));
 	}
 	if (File::Exists(Path("/data/app/org.ppsspp.ppsspp.apk"))) {
-		g_VFS.Register("", new ZipFileReader("/data/app/org.ppsspp.ppsspp.apk", "assets/"));
+		g_VFS.Register("", new ZipFileReader(Path("/data/app/org.ppsspp.ppsspp.apk"), "assets/"));
 	}
 #elif !PPSSPP_PLATFORM(WINDOWS)
 	g_VFS.Register("", new DirectoryReader(g_Config.flash0Directory / ".."));

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -482,13 +482,13 @@ int main(int argc, const char* argv[])
 #if PPSSPP_PLATFORM(ANDROID)
 	// For some reason the debugger installs it with this name?
 	if (File::Exists(Path("/data/app/org.ppsspp.ppsspp-2.apk"))) {
-		VFSRegister("", new ZipAssetReader("/data/app/org.ppsspp.ppsspp-2.apk", "assets/"));
+		g_VFS.Register("", new ZipAssetReader("/data/app/org.ppsspp.ppsspp-2.apk", "assets/"));
 	}
 	if (File::Exists(Path("/data/app/org.ppsspp.ppsspp.apk"))) {
-		VFSRegister("", new ZipAssetReader("/data/app/org.ppsspp.ppsspp.apk", "assets/"));
+		g_VFS.Register("", new ZipAssetReader("/data/app/org.ppsspp.ppsspp.apk", "assets/"));
 	}
 #elif !PPSSPP_PLATFORM(WINDOWS)
-	VFSRegister("", new DirectoryAssetReader(g_Config.flash0Directory / ".."));
+	g_VFS.Register("", new DirectoryAssetReader(g_Config.flash0Directory / ".."));
 #endif
 
 	UpdateUIState(UISTATE_INGAME);
@@ -557,7 +557,7 @@ int main(int argc, const char* argv[])
 	host = nullptr;
 	headlessHost = nullptr;
 
-	VFSShutdown();
+	g_VFS.Clear();
 	LogManager::Shutdown();
 	delete printfLogger;
 

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -24,7 +24,8 @@
 #endif
 #include "Common/CPUDetect.h"
 #include "Common/File/VFS/VFS.h"
-#include "Common/File/VFS/AssetReader.h"
+#include "Common/File/VFS/ZipFileReader.h"
+#include "Common/File/VFS/DirectoryReader.h"
 #include "Common/File/FileUtil.h"
 #include "Common/GraphicsContext.h"
 #include "Common/TimeUtil.h"
@@ -103,7 +104,7 @@ int System_GetPropertyInt(SystemProperty prop) {
 	return -1;
 }
 float System_GetPropertyFloat(SystemProperty prop) { return -1.0f; }
-bool System_GetPropertyBool(SystemProperty prop) { 
+bool System_GetPropertyBool(SystemProperty prop) {
 	switch (prop) {
 		case SYSPROP_CAN_JIT:
 			return true;
@@ -482,13 +483,13 @@ int main(int argc, const char* argv[])
 #if PPSSPP_PLATFORM(ANDROID)
 	// For some reason the debugger installs it with this name?
 	if (File::Exists(Path("/data/app/org.ppsspp.ppsspp-2.apk"))) {
-		g_VFS.Register("", new ZipAssetReader("/data/app/org.ppsspp.ppsspp-2.apk", "assets/"));
+		g_VFS.Register("", new ZipFileReader("/data/app/org.ppsspp.ppsspp-2.apk", "assets/"));
 	}
 	if (File::Exists(Path("/data/app/org.ppsspp.ppsspp.apk"))) {
-		g_VFS.Register("", new ZipAssetReader("/data/app/org.ppsspp.ppsspp.apk", "assets/"));
+		g_VFS.Register("", new ZipFileReader("/data/app/org.ppsspp.ppsspp.apk", "assets/"));
 	}
 #elif !PPSSPP_PLATFORM(WINDOWS)
-	g_VFS.Register("", new DirectoryAssetReader(g_Config.flash0Directory / ".."));
+	g_VFS.Register("", new DirectoryReader(g_Config.flash0Directory / ".."));
 #endif
 
 	UpdateUIState(UISTATE_INGAME);

--- a/headless/SDLHeadlessHost.cpp
+++ b/headless/SDLHeadlessHost.cpp
@@ -26,7 +26,7 @@
 #include "Common/GPU/thin3d_create.h"
 #include "Common/GPU/OpenGL/GLRenderManager.h"
 #include "Common/File/VFS/VFS.h"
-#include "Common/File/VFS/AssetReader.h"
+#include "Common/File/VFS/DirectoryReader.h"
 #include "Common/GraphicsContext.h"
 #include "Common/TimeUtil.h"
 #include "Core/Config.h"
@@ -100,9 +100,9 @@ private:
 };
 
 void SDLHeadlessHost::LoadNativeAssets() {
-	g_VFS.Register("", new DirectoryAssetReader(Path("assets")));
-	g_VFS.Register("", new DirectoryAssetReader(Path("")));
-	g_VFS.Register("", new DirectoryAssetReader(Path("..")));
+	g_VFS.Register("", new DirectoryReader(Path("assets")));
+	g_VFS.Register("", new DirectoryReader(Path("")));
+	g_VFS.Register("", new DirectoryReader(Path("..")));
 }
 
 bool GLDummyGraphicsContext::InitFromRenderThread(std::string *errorMessage) {

--- a/headless/SDLHeadlessHost.cpp
+++ b/headless/SDLHeadlessHost.cpp
@@ -100,9 +100,9 @@ private:
 };
 
 void SDLHeadlessHost::LoadNativeAssets() {
-	VFSRegister("", new DirectoryAssetReader(Path("assets")));
-	VFSRegister("", new DirectoryAssetReader(Path("")));
-	VFSRegister("", new DirectoryAssetReader(Path("..")));
+	g_VFS.Register("", new DirectoryAssetReader(Path("assets")));
+	g_VFS.Register("", new DirectoryAssetReader(Path("")));
+	g_VFS.Register("", new DirectoryAssetReader(Path("..")));
 }
 
 bool GLDummyGraphicsContext::InitFromRenderThread(std::string *errorMessage) {

--- a/headless/WindowsHeadlessHost.cpp
+++ b/headless/WindowsHeadlessHost.cpp
@@ -23,7 +23,7 @@
 #include "Common/GPU/OpenGL/GLCommon.h"
 #include "Common/GPU/OpenGL/GLFeatures.h"
 #include "Common/File/VFS/VFS.h"
-#include "Common/File/VFS/AssetReader.h"
+#include "Common/File/VFS/DirectoryReader.h"
 
 #include "Common/CommonWindows.h"
 #include "Common/Log.h"
@@ -68,11 +68,11 @@ HWND CreateHiddenWindow() {
 
 void WindowsHeadlessHost::LoadNativeAssets()
 {
-	g_VFS.Register("", new DirectoryAssetReader(Path("assets")));
-	g_VFS.Register("", new DirectoryAssetReader(Path("")));
-	g_VFS.Register("", new DirectoryAssetReader(Path("..")));
-	g_VFS.Register("", new DirectoryAssetReader(Path("../Windows/assets")));
-	g_VFS.Register("", new DirectoryAssetReader(Path("../Windows")));
+	g_VFS.Register("", new DirectoryReader(Path("assets")));
+	g_VFS.Register("", new DirectoryReader(Path("")));
+	g_VFS.Register("", new DirectoryReader(Path("..")));
+	g_VFS.Register("", new DirectoryReader(Path("../Windows/assets")));
+	g_VFS.Register("", new DirectoryReader(Path("../Windows")));
 }
 
 void WindowsHeadlessHost::SendDebugOutput(const std::string &output)

--- a/headless/WindowsHeadlessHost.cpp
+++ b/headless/WindowsHeadlessHost.cpp
@@ -68,11 +68,11 @@ HWND CreateHiddenWindow() {
 
 void WindowsHeadlessHost::LoadNativeAssets()
 {
-	VFSRegister("", new DirectoryAssetReader(Path("assets")));
-	VFSRegister("", new DirectoryAssetReader(Path("")));
-	VFSRegister("", new DirectoryAssetReader(Path("..")));
-	VFSRegister("", new DirectoryAssetReader(Path("../Windows/assets")));
-	VFSRegister("", new DirectoryAssetReader(Path("../Windows")));
+	g_VFS.Register("", new DirectoryAssetReader(Path("assets")));
+	g_VFS.Register("", new DirectoryAssetReader(Path("")));
+	g_VFS.Register("", new DirectoryAssetReader(Path("..")));
+	g_VFS.Register("", new DirectoryAssetReader(Path("../Windows/assets")));
+	g_VFS.Register("", new DirectoryAssetReader(Path("../Windows")));
 }
 
 void WindowsHeadlessHost::SendDebugOutput(const std::string &output)

--- a/ios/PPSSPPUIApplication.mm
+++ b/ios/PPSSPPUIApplication.mm
@@ -17,7 +17,7 @@
 #include "Common/System/NativeApp.h"
 #include "Common/TimeUtil.h"
 #include "Common/File/VFS/VFS.h"
-#include "Common/File/VFS/AssetReader.h"
+#include "Common/File/VFS/DirectoryReader.h"
 #include "Common/Input/InputState.h"
 #include "Common/Net/Resolve.h"
 #include "Common/UI/Screen.h"
@@ -66,9 +66,9 @@
 - (void)decodeKeyEvent:(NSInteger *)eventMem {
     NSInteger eventType = eventMem[GSEVENT_TYPE];
     NSInteger eventScanCode = eventMem[GSEVENTKEY_KEYCODE];
-    
+
     //NSLog(@"Got key: %d", (int)eventScanCode);
-    
+
     if (eventType == GSEVENT_TYPE_KEYUP) {
         struct KeyInput key;
         key.flags = KEY_UP;
@@ -82,13 +82,13 @@
         key.deviceId = DEVICE_ID_KEYBOARD;
         NativeKey(key);
     }
-    
+
 }
 
 - (void)handleKeyUIEvent:(UIEvent *) event {
     if ([event respondsToSelector:@selector(_gsEvent)]) {
         NSInteger *eventMem;
-        
+
         eventMem = (NSInteger *) (__bridge void*)[event performSelector:@selector(_gsEvent)];
         if (eventMem) {
             [self decodeKeyEvent:eventMem];
@@ -100,7 +100,7 @@
     [super sendEvent:event];
     if ([event respondsToSelector:@selector(_gsEvent)]) {
         NSInteger *eventMem;
-        
+
         eventMem = (NSInteger *) (__bridge void*)[event performSelector:@selector(_gsEvent)];
         if (eventMem) {
             [self decodeKeyEvent:eventMem];

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -269,7 +269,8 @@ SOURCES_CXX += \
 	$(COMMONDIR)/Data/Text/Parsers.cpp \
 	$(COMMONDIR)/Data/Text/WrapText.cpp \
 	$(COMMONDIR)/File/VFS/VFS.cpp \
-	$(COMMONDIR)/File/VFS/AssetReader.cpp \
+	$(COMMONDIR)/File/VFS/DirectoryReader.cpp \
+	$(COMMONDIR)/File/VFS/ZipFileReader.cpp \
 	$(COMMONDIR)/File/AndroidStorage.cpp \
 	$(COMMONDIR)/File/DiskFree.cpp \
 	$(COMMONDIR)/File/Path.cpp \
@@ -818,7 +819,7 @@ SOURCES_CXX += \
 	$(COMMONDIR)/GPU/D3D9/thin3d_d3d9.cpp \
 	$(COMMONDIR)/GPU/D3D11/D3D11Loader.cpp \
 	$(COMMONDIR)/GPU/D3D11/thin3d_d3d11.cpp
-	
+
 INCFLAGS += -I$(CORE_DIR)/dx9sdk/Include -I$(CORE_DIR)/dx9sdk/Include/DX11
 
 endif

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -21,7 +21,7 @@
 #include "Common/Thread/ThreadUtil.h"
 #include "Common/Thread/ThreadManager.h"
 #include "Common/File/VFS/VFS.h"
-#include "Common/File/VFS/AssetReader.h"
+#include "Common/File/VFS/DirectoryReader.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/StringUtils.h"
 
@@ -1284,7 +1284,7 @@ void retro_init(void)
    g_Config.bEnableNetworkChat = false;
    g_Config.bDiscordPresence = false;
 
-   g_VFS.Register("", new DirectoryAssetReader(retro_base_dir));
+   g_VFS.Register("", new DirectoryReader(retro_base_dir));
 
    host = new LibretroHost();
 }
@@ -1561,14 +1561,14 @@ static void retro_input(void)
    float y_left = input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y) / -32767.0f;
    float x_right = input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X) / 32767.0f;
    float y_right = input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y) / -32767.0f;
-   
+
    __CtrlSetAnalogXY(CTRL_STICK_LEFT, x_left, y_left);
    __CtrlSetAnalogXY(CTRL_STICK_RIGHT, x_right, y_right);
-   
+
    // Analog circle vs square gate compensation
    // copied from ControlMapper.cpp's ConvertAnalogStick function
    const bool isCircular = g_Config.bAnalogIsCircular;
-   
+
    float norm = std::max(fabsf(x_left), fabsf(y_left));
 
    if (norm == 0.0f)
@@ -1585,7 +1585,7 @@ static void retro_input(void)
    float mappedNorm = norm;
    x_left = std::clamp(x_left / norm * mappedNorm, -1.0f, 1.0f);
    y_left = std::clamp(y_left / norm * mappedNorm, -1.0f, 1.0f);
-   
+
    __CtrlSetAnalogXY(CTRL_STICK_LEFT, x_left, y_left);
    __CtrlSetAnalogXY(CTRL_STICK_RIGHT, x_right, y_right);
 }

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1284,7 +1284,7 @@ void retro_init(void)
    g_Config.bEnableNetworkChat = false;
    g_Config.bDiscordPresence = false;
 
-   VFSRegister("", new DirectoryAssetReader(retro_base_dir));
+   g_VFS.Register("", new DirectoryAssetReader(retro_base_dir));
 
    host = new LibretroHost();
 }
@@ -1486,7 +1486,7 @@ void retro_unload_game(void)
 		Libretro::EmuThreadStop();
 
 	PSP_Shutdown();
-	VFSShutdown();
+	g_VFS.Clear();
 
 	delete ctx;
 	ctx = nullptr;


### PR DESCRIPTION
First steps towards being able to use the internal read-only VFS for file access during texture replacement. Right now the replacer has a lot of duplicated code between zip and direct access, and we just need a simple abstraction on top. We already have this one, so why not use it.

This doesn't give it all the needed features yet, but cleans things up a bit and gives things better names.