### PR TITLE
Use VFS for file access in the texture replacer

### DIFF
--- a/Common/File/VFS/DirectoryReader.cpp
+++ b/Common/File/VFS/DirectoryReader.cpp
@@ -1,3 +1,5 @@
+#include <cstdio>
+
 #include "Common/Common.h"
 #include "Common/Log.h"
 #include "Common/File/VFS/DirectoryReader.h"
@@ -64,13 +66,15 @@ void DirectoryReader::ReleaseFile(VFSFileReference *vfsReference) {
 	delete reference;
 }
 
-VFSOpenFile *DirectoryReader::OpenFileForRead(VFSFileReference *vfsReference) {
+VFSOpenFile *DirectoryReader::OpenFileForRead(VFSFileReference *vfsReference, size_t *size) {
 	DirectoryReaderFileReference *reference = (DirectoryReaderFileReference *)vfsReference;
 	FILE *file = File::OpenCFile(reference->path, "rb");
 	if (!file) {
 		return nullptr;
 	}
-
+	fseek(file, 0, SEEK_END);
+	*size = ftell(file);
+	fseek(file, 0, SEEK_SET);
 	DirectoryReaderOpenFile *openFile = new DirectoryReaderOpenFile();
 	openFile->file = file;
 	return openFile;

--- a/Common/File/VFS/DirectoryReader.cpp
+++ b/Common/File/VFS/DirectoryReader.cpp
@@ -44,8 +44,13 @@ public:
 };
 
 VFSFileReference *DirectoryReader::GetFile(const char *path) {
+	Path filePath = path_ / path;
+	if (!File::Exists(filePath)) {
+		return nullptr;
+	}
+
 	DirectoryReaderFileReference *reference = new DirectoryReaderFileReference();
-	reference->path = path_ / path;
+	reference->path = filePath;
 	return reference;
 }
 

--- a/Common/File/VFS/DirectoryReader.h
+++ b/Common/File/VFS/DirectoryReader.h
@@ -14,7 +14,7 @@ public:
 	bool GetFileInfo(VFSFileReference *vfsReference, File::FileInfo *fileInfo) override;
 	void ReleaseFile(VFSFileReference *vfsReference) override;
 
-	VFSOpenFile *OpenFileForRead(VFSFileReference *vfsReference) override;
+	VFSOpenFile *OpenFileForRead(VFSFileReference *vfsReference, size_t *size) override;
 	void Rewind(VFSOpenFile *vfsOpenFile) override;
 	size_t Read(VFSOpenFile *vfsOpenFile, void *buffer, size_t length) override;
 	void CloseFile(VFSOpenFile *vfsOpenFile) override;

--- a/Common/File/VFS/VFS.h
+++ b/Common/File/VFS/VFS.h
@@ -46,7 +46,9 @@ public:
 	virtual bool GetFileInfo(VFSFileReference *vfsReference, File::FileInfo *fileInfo) = 0;
 	virtual void ReleaseFile(VFSFileReference *vfsReference) = 0;
 
-	virtual VFSOpenFile *OpenFileForRead(VFSFileReference *vfsReference) = 0;
+	// Must write the size of the file to *size. Both backends can do this efficiently here,
+	// avoiding a call to GetFileInfo.
+	virtual VFSOpenFile *OpenFileForRead(VFSFileReference *vfsReference, size_t *size) = 0;
 	virtual void Rewind(VFSOpenFile *vfsOpenFile) = 0;
 	virtual size_t Read(VFSOpenFile *vfsOpenFile, void *buffer, size_t length) = 0;
 	virtual void CloseFile(VFSOpenFile *vfsOpenFile) = 0;

--- a/Common/File/VFS/ZipFileReader.cpp
+++ b/Common/File/VFS/ZipFileReader.cpp
@@ -249,7 +249,7 @@ VFSOpenFile *ZipFileReader::OpenFileForRead(VFSFileReference *vfsReference, size
 	zip_stat_t zstat;
 	if (zip_stat_index(zip_file_, reference->zi, 0, &zstat) != 0) {
 		lock_.unlock();
-		return false;
+		return nullptr;
 	}
 
 	openFile->zf = zip_fopen_index(zip_file_, reference->zi, 0);

--- a/Common/File/VFS/ZipFileReader.cpp
+++ b/Common/File/VFS/ZipFileReader.cpp
@@ -15,25 +15,6 @@
 #include "Common/File/VFS/ZipFileReader.h"
 #include "Common/StringUtils.h"
 
-static uint8_t *ReadFromZip(zip *archive, const char* filename, size_t *size) {
-	// Figure out the file size first.
-	struct zip_stat zstat;
-	zip_file *file = zip_fopen(archive, filename, ZIP_FL_NOCASE|ZIP_FL_UNCHANGED);
-	if (!file) {
-		ERROR_LOG(IO, "Error opening %s from ZIP", filename);
-		return 0;
-	}
-	zip_stat(archive, filename, ZIP_FL_NOCASE|ZIP_FL_UNCHANGED, &zstat);
-
-	uint8_t *contents = new uint8_t[zstat.size + 1];
-	zip_fread(file, contents, zstat.size);
-	zip_fclose(file);
-	contents[zstat.size] = 0;
-
-	*size = zstat.size;
-	return contents;
-}
-
 ZipFileReader *ZipFileReader::Create(const Path &zipFile, const char *inZipPath) {
 	int error = 0;
 	zip *zip_file;
@@ -69,7 +50,21 @@ uint8_t *ZipFileReader::ReadFile(const char *path, size_t *size) {
 	snprintf(temp_path, sizeof(temp_path), "%s%s", inZipPath_, path);
 
 	std::lock_guard<std::mutex> guard(lock_);
-	return ReadFromZip(zip_file_, temp_path, size);
+	// Figure out the file size first.
+	struct zip_stat zstat;
+	zip_stat(zip_file_, temp_path, ZIP_FL_NOCASE | ZIP_FL_UNCHANGED, &zstat);
+	zip_file *file = zip_fopen(zip_file_, temp_path, ZIP_FL_NOCASE | ZIP_FL_UNCHANGED);
+	if (!file) {
+		ERROR_LOG(IO, "Error opening %s from ZIP", temp_path);
+		return 0;
+	}
+	uint8_t *contents = new uint8_t[zstat.size + 1];
+	zip_fread(file, contents, zstat.size);
+	zip_fclose(file);
+	contents[zstat.size] = 0;
+
+	*size = zstat.size;
+	return contents;
 }
 
 bool ZipFileReader::GetFileListing(const char *orig_path, std::vector<File::FileInfo> *listing, const char *filter = 0) {

--- a/Common/File/VFS/ZipFileReader.h
+++ b/Common/File/VFS/ZipFileReader.h
@@ -28,7 +28,7 @@ public:
 	bool GetFileInfo(VFSFileReference *vfsReference, File::FileInfo *fileInfo) override;
 	void ReleaseFile(VFSFileReference *vfsReference) override;
 
-	VFSOpenFile *OpenFileForRead(VFSFileReference *vfsReference) override;
+	VFSOpenFile *OpenFileForRead(VFSFileReference *vfsReference, size_t *size) override;
 	void Rewind(VFSOpenFile *vfsOpenFile) override;
 	size_t Read(VFSOpenFile *vfsOpenFile, void *buffer, size_t length) override;
 	void CloseFile(VFSOpenFile *vfsOpenFile) override;

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -116,7 +116,10 @@ bool TextureReplacer::LoadIni() {
 	// First, check for textures.zip, which is used to reduce IO.
 	VFSBackend *dir = ZipFileReader::Create(basePath_ / ZIP_FILENAME, "");
 	if (!dir) {
+		vfsIsZip_ = false;
 		dir = new DirectoryReader(basePath_);
+	} else {
+		vfsIsZip_ = true;
 	}
 
 	IniFile ini;
@@ -149,9 +152,19 @@ bool TextureReplacer::LoadIni() {
 				}
 			}
 		}
+	} else {
+		if (vfsIsZip_) {
+			// We don't accept zip files without inis.
+			ERROR_LOG(G3D, "Texture pack lacking ini file: %s", basePath_.c_str());
+			delete dir;
+			return false;
+		} else {
+			WARN_LOG(G3D, "Texture pack lacking ini file: %s", basePath_.c_str());
+		}
 	}
 
 	vfs_ = dir;
+	INFO_LOG(G3D, "Texture pack activated from '%s'", basePath_.c_str());
 
 	// The ini doesn't have to exist for the texture directory or zip to be valid.
 	return true;

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -530,13 +530,8 @@ bool TextureReplacer::PopulateLevel(ReplacedTextureLevel &level, bool ignoreErro
 		return false;
 	}
 
-	File::FileInfo info;
-	if (!vfs_->GetFileInfo(level.fileRef, &info)) {
-		return false;
-	}
-	size_t zsize = info.size;
-
-	VFSOpenFile *file = vfs_->OpenFileForRead(level.fileRef);
+	size_t fileSize;
+	VFSOpenFile *file = vfs_->OpenFileForRead(level.fileRef, &fileSize);
 	if (!file) {
 		return false;
 	}
@@ -992,14 +987,9 @@ void ReplacedTexture::PrepareData(int level) {
 
 	ReplacedImageType imageType;
 
-	File::FileInfo fileInfo;
-	if (!vfs_->GetFileInfo(info.fileRef, &fileInfo)) {
-		ERROR_LOG(G3D, "Failed to get file info for level");
-		return;
-	}
-	size_t fileSize = fileInfo.size;
+	size_t fileSize;
+	VFSOpenFile *openFile = vfs_->OpenFileForRead(info.fileRef, &fileSize);
 
-	VFSOpenFile *openFile = vfs_->OpenFileForRead(info.fileRef);
 	std::string magic;
 	imageType = Identify(vfs_, openFile, &magic);
 
@@ -1051,7 +1041,7 @@ void ReplacedTexture::PrepareData(int level) {
 
 		std::string pngdata;
 		pngdata.resize(fileSize);
-		vfs_->Read(openFile, &pngdata[0], fileSize);
+		pngdata.resize(vfs_->Read(openFile, &pngdata[0], fileSize));
 		if (!png_image_begin_read_from_memory(&png, &pngdata[0], pngdata.size())) {
 			ERROR_LOG(G3D, "Could not load texture replacement info: %s - %s (zip)", info.file.c_str(), png.message);
 			cleanup();

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -453,6 +453,10 @@ void TextureReplacer::PopulateReplacement(ReplacedTexture *result, u64 cachekey,
 		bool logError = hashfile != HashName(cachekey, hash, i) + ".png";
 
 		VFSFileReference *fileRef = vfs_->GetFile(hashfile.c_str());
+		if (!fileRef) {
+			// If the file doesn't exist, let's just bail immediately here.
+			break;
+		}
 
 		level.fileRef = fileRef;
 		good = PopulateLevel(level, !logError);
@@ -525,8 +529,11 @@ bool TextureReplacer::PopulateLevel(ReplacedTextureLevel &level, bool ignoreErro
 			ERROR_LOG(G3D, "Error opening replacement texture file '%s' in textures.zip", level.file.c_str());
 		return false;
 	}
+
 	File::FileInfo info;
-	vfs_->GetFileInfo(level.fileRef, &info);
+	if (!vfs_->GetFileInfo(level.fileRef, &info)) {
+		return false;
+	}
 	size_t zsize = info.size;
 
 	VFSOpenFile *file = vfs_->OpenFileForRead(level.fileRef);

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -293,6 +293,7 @@ protected:
 	ReplacedTextureHash hash_ = ReplacedTextureHash::QUICK;
 
 	VFSBackend *vfs_ = nullptr;
+	bool vfsIsZip_ = false;
 
 	typedef std::pair<int, int> WidthHeightPair;
 	std::unordered_map<u64, WidthHeightPair> hashranges_;


### PR DESCRIPTION
In order to be able to add more texture formats, really have to get rid of this duplication, otherwise it's just too hard to write and debug.

There's a possible performance impact in the way we get width/height from pngs, but #17074 implements an even faster method anyway.