### PR TITLE
Common: Cleanup zip file stat flag checks

### DIFF
--- a/Common/File/VFS/DirectoryReader.cpp
+++ b/Common/File/VFS/DirectoryReader.cpp
@@ -37,7 +37,10 @@ public:
 
 class DirectoryReaderOpenFile : public VFSOpenFile {
 public:
-	FILE *file;
+	~DirectoryReaderOpenFile() {
+		_dbg_assert_(file == nullptr);
+	}
+	FILE *file = nullptr;
 };
 
 VFSFileReference *DirectoryReader::GetFile(const char *path) {
@@ -80,6 +83,8 @@ size_t DirectoryReader::Read(VFSOpenFile *vfsOpenFile, void *buffer, size_t leng
 
 void DirectoryReader::CloseFile(VFSOpenFile *vfsOpenFile) {
 	DirectoryReaderOpenFile *openFile = (DirectoryReaderOpenFile *)vfsOpenFile;
+	_dbg_assert_(openFile->file != nullptr);
 	fclose(openFile->file);
+	openFile->file = nullptr;
 	delete openFile;
 }

--- a/Common/File/VFS/VFS.h
+++ b/Common/File/VFS/VFS.h
@@ -42,8 +42,6 @@ public:
 
 class VFSBackend : public VFSInterface {
 public:
-	// use delete[] to release the returned memory.
-
 	virtual VFSFileReference *GetFile(const char *path) = 0;
 	virtual bool GetFileInfo(VFSFileReference *vfsReference, File::FileInfo *fileInfo) = 0;
 	virtual void ReleaseFile(VFSFileReference *vfsReference) = 0;

--- a/Common/File/VFS/ZipFileReader.cpp
+++ b/Common/File/VFS/ZipFileReader.cpp
@@ -205,8 +205,6 @@ public:
 	zip_file_t *zf = nullptr;
 };
 
-static constexpr zip_uint64_t INVALID_ZIP_SIZE = 0xFFFFFFFFFFFFFFFFULL;
-
 VFSFileReference *ZipFileReader::GetFile(const char *path) {
 	std::lock_guard<std::mutex> guard(lock_);
 	int zi = zip_name_locate(zip_file_, path, ZIP_FL_NOCASE);

--- a/Common/File/VFS/ZipFileReader.cpp
+++ b/Common/File/VFS/ZipFileReader.cpp
@@ -197,8 +197,12 @@ public:
 
 class ZipFileReaderOpenFile : public VFSOpenFile {
 public:
+	~ZipFileReaderOpenFile() {
+		// Needs to be closed properly and unlocked.
+		_dbg_assert_(zf == nullptr);
+	}
 	ZipFileReaderFileReference *reference;
-	zip_file_t *zf;
+	zip_file_t *zf = nullptr;
 };
 
 static constexpr zip_uint64_t INVALID_ZIP_SIZE = 0xFFFFFFFFFFFFFFFFULL;
@@ -270,6 +274,7 @@ void ZipFileReader::CloseFile(VFSOpenFile *vfsOpenFile) {
 	ZipFileReaderOpenFile *file = (ZipFileReaderOpenFile *)vfsOpenFile;
 	_dbg_assert_(file->zf != nullptr);
 	zip_fclose(file->zf);
+	file->zf = nullptr;
 	lock_.unlock();
 	delete file;
 }


### PR DESCRIPTION
Just a quick reaction to #17072, cleanup a comment and some flag checks.  I also think it's a good idea to prevent against someone accidentally forgetting and `delete`ing a reference directly.

-[Unknown]