### PR TITLE
Texture replacer: Make the internal cache model texture-centric instead of miplevel-centric

### DIFF
--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -736,7 +736,6 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 		cachekey = cachekey & 0xFFFFFFFFULL;
 	}
 
-	/*
 	bool found = false;
 	std::string hashfile = LookupHashFile(cachekey, replacedInfo.hash, &found);
 	const Path filename = basePath_ / hashfile;
@@ -753,9 +752,10 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 	double now = time_now_d();
 	if (it != savedCache_.end()) {
 		// We've already saved this texture.  Let's only save if it's bigger (e.g. scaled now.)
-		if (it->second.first.w >= w && it->second.first.h >= h) {
+		// TODO: Isn't this check backwards?
+		if (it->second.levelW[level] >= w && it->second.levelH[level] >= h) {
 			// If it's been more than 5 seconds, we'll check again.  Maybe they deleted.
-			double age = now - it->second.second;
+			double age = now - it->second.lastTimeSaved;
 			if (age < 5.0)
 				return;
 
@@ -794,13 +794,11 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 
 	// Remember that we've saved this for next time.
 	// Should be OK that the actual disk write may not be finished yet.
-	ReplacedTextureLevel saved;
-	saved.fmt = Draw::DataFormat::R8G8B8A8_UNORM;
-	saved.file = filename;
-	saved.w = w;
-	saved.h = h;
-	savedCache_[replacementKey] = std::make_pair(saved, now);
-	*/
+	SavedTextureCacheData &saveData = savedCache_[replacementKey];
+	saveData.levelW[level] = w;
+	saveData.levelH[level] = h;
+	saveData.levelSaved[level] = true;
+	saveData.lastTimeSaved = now;
 }
 
 void TextureReplacer::Decimate(ReplacerDecimateMode mode) {

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -87,7 +87,9 @@ static ReplacedImageType Identify(VFSBackend *vfs, VFSOpenFile *openFile, std::s
 	return IdentifyMagic(magic);
 }
 
-TextureReplacer::TextureReplacer() {}
+TextureReplacer::TextureReplacer(Draw::DrawContext *draw) {
+	// TODO: Check draw for supported texture formats.
+}
 
 TextureReplacer::~TextureReplacer() {
 	for (auto &iter : cache_) {
@@ -274,7 +276,7 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, bool isOverride) {
 					alias += level.second + "|";
 					mipIndex++;
 				} else {
-					WARN_LOG(G3D, "Non-sequential mip index %d, breaking", level.first);
+					WARN_LOG(G3D, "Non-sequential mip index %d, breaking. filenames=%s", level.first, level.second.c_str());
 					break;
 				}
 			}
@@ -531,8 +533,11 @@ void TextureReplacer::PopulateReplacement(ReplacedTexture *texture, u64 cachekey
 		// TODO: Here, if we find a file with multiple built-in mipmap levels,
 		// we'll have to change a bit how things work...
 		ReplacedTextureLevel level;
-		level.fmt = Draw::DataFormat::R8G8B8A8_UNORM;
 		level.file = filename;
+
+		if (i == 0) {
+			texture->fmt = Draw::DataFormat::R8G8B8A8_UNORM;
+		}
 
 		bool good;
 

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -517,7 +517,7 @@ void TextureReplacer::PopulateReplacement(ReplacedTexture *texture, u64 cachekey
 		return;
 	}
 
-	INFO_LOG(G3D, "Found: %s", hashfiles.c_str());
+	// INFO_LOG(G3D, "Found: %s", hashfiles.c_str());
 
 	std::vector<std::string> filenames;
 	SplitString(hashfiles, '|', filenames);
@@ -1208,7 +1208,6 @@ bool ReplacedTexture::CopyLevelTo(int level, void *out, int rowPitch) {
 		}, 0, info.h, MIN_LINES_PER_THREAD);
 	}
 
-	INFO_LOG(G3D, "Successfully copied texture level");
 	return true;
 }
 

--- a/Core/TextureReplacer.cpp
+++ b/Core/TextureReplacer.cpp
@@ -1169,6 +1169,11 @@ ReplacedTexture::~ReplacedTexture() {
 		threadWaitable_->WaitAndRelease();
 		threadWaitable_ = nullptr;
 	}
+
+	for (auto &level : levels_) {
+		vfs_->ReleaseFile(level.fileRef);
+		level.fileRef = nullptr;
+	}
 }
 
 bool ReplacedTexture::CopyLevelTo(int level, void *out, int rowPitch) {

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -68,7 +68,7 @@ struct SavedTextureCacheData {
 	int levelW[8]{};
 	int levelH[8]{};
 	bool levelSaved[8]{};
-	double lastTimeSaved;
+	double lastTimeSaved = 0.0;
 };
 
 struct ReplacedLevelsCache {
@@ -230,7 +230,7 @@ protected:
 	void ParseReduceHashRange(const std::string& key, const std::string& value);
 	bool LookupHashRange(u32 addr, int &w, int &h);
 	float LookupReduceHashRange(int& w, int& h);
-	std::string LookupHashFile(u64 cachekey, u32 hash, bool *foundReplacement);
+	std::string LookupHashFile(u64 cachekey, u32 hash, bool *foundReplacement, bool *ignored);
 	std::string HashName(u64 cachekey, u32 hash, int level);
 	void PopulateReplacement(ReplacedTexture *result, u64 cachekey, u32 hash, int w, int h);
 	bool PopulateLevel(ReplacedTextureLevel &level, bool ignoreError);

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -150,7 +150,6 @@ struct ReplacedTexture {
 	}
 
 	bool IsReady(double budget);
-
 	bool CopyLevelTo(int level, void *out, int rowPitch);
 
 protected:

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -46,13 +46,14 @@ enum class ReplacedTextureAlpha {
 	FULL = 0x00,
 };
 
-// For forward comatibility, we specify the hash.
+// For forward compatibility, we specify the hash.
 enum class ReplacedTextureHash {
 	QUICK,
 	XXH32,
 	XXH64,
 };
 
+// Metadata about a given texture level.
 struct ReplacedTextureLevel {
 	ReplacedTextureLevel() {}
 	int w = 0;
@@ -69,25 +70,9 @@ struct ReplacedTextureLevel {
 	}
 };
 
-namespace std {
-	template <>
-	struct hash<ReplacedTextureLevel> {
-		std::size_t operator()(const ReplacedTextureLevel &k) const {
-#if PPSSPP_ARCH(64BIT)
-			uint64_t v = (uint64_t)k.w | ((uint64_t)k.h << 32);
-			v = __rotl64(v ^ (uint64_t)k.fmt, 13);
-#else
-			uint32_t v = k.w ^ (uint32_t)k.fmt;
-			v = __rotl(__rotl(v, 13) ^ k.h, 13);
-#endif
-			return v ^ hash<string>()(k.file.ToString());
-		}
-	};
-}
-
-struct ReplacedLevelCache {
+struct ReplacedLevelsCache {
 	std::mutex lock;
-	std::vector<uint8_t> data;
+	std::vector<std::vector<uint8_t>> data;
 	double lastUsed = 0.0;
 };
 
@@ -109,42 +94,11 @@ struct ReplacementCacheKey {
 	}
 };
 
-struct ReplacementAliasKey {
-	u64 cachekey;
-	union {
-		u64 hashAndLevel;
-		struct {
-			u32 level;
-			u32 hash;
-		};
-	};
-
-	ReplacementAliasKey(u64 c, u32 h, u32 l) : cachekey(c), level(l), hash(h) { }
-
-	bool operator ==(const ReplacementAliasKey &k) const {
-		return k.cachekey == cachekey && k.hashAndLevel == hashAndLevel;
-	}
-
-	bool operator <(const ReplacementAliasKey &k) const {
-		if (k.cachekey == cachekey) {
-			return k.hashAndLevel < hashAndLevel;
-		}
-		return k.cachekey < cachekey;
-	}
-};
-
 namespace std {
 	template <>
 	struct hash<ReplacementCacheKey> {
 		size_t operator()(const ReplacementCacheKey &k) const {
 			return std::hash<u64>()(k.cachekey ^ ((u64)k.hash << 32));
-		}
-	};
-
-	template <>
-	struct hash<ReplacementAliasKey> {
-		size_t operator()(const ReplacementAliasKey &k) const {
-			return std::hash<u64>()(k.cachekey ^ k.hashAndLevel);
 		}
 	};
 }
@@ -196,7 +150,7 @@ struct ReplacedTexture {
 
 	bool IsReady(double budget);
 
-	bool Load(int level, void *out, int rowPitch);
+	bool CopyLevelTo(int level, void *out, int rowPitch);
 
 protected:
 	void Prepare(VFSBackend *vfs);
@@ -204,7 +158,8 @@ protected:
 	void PurgeIfOlder(double t);
 
 	std::vector<ReplacedTextureLevel> levels_;
-	std::vector<ReplacedLevelCache *> levelData_;
+	ReplacedLevelsCache *levelData_;
+
 	ReplacedTextureAlpha alphaStatus_ = ReplacedTextureAlpha::UNKNOWN;
 	double lastUsed_ = 0.0;
 	LimitedWaitable *threadWaitable_ = nullptr;
@@ -273,7 +228,7 @@ protected:
 	void ParseReduceHashRange(const std::string& key, const std::string& value);
 	bool LookupHashRange(u32 addr, int &w, int &h);
 	float LookupReduceHashRange(int& w, int& h);
-	std::string LookupHashFile(u64 cachekey, u32 hash, int level);
+	std::string LookupHashFile(u64 cachekey, u32 hash, bool *foundReplacement);
 	std::string HashName(u64 cachekey, u32 hash, int level);
 	void PopulateReplacement(ReplacedTexture *result, u64 cachekey, u32 hash, int w, int h);
 	bool PopulateLevel(ReplacedTextureLevel &level, bool ignoreError);
@@ -297,10 +252,12 @@ protected:
 	typedef std::pair<int, int> WidthHeightPair;
 	std::unordered_map<u64, WidthHeightPair> hashranges_;
 	std::unordered_map<u64, float> reducehashranges_;
-	std::unordered_map<ReplacementAliasKey, std::string> aliases_;
+	std::unordered_map<ReplacementCacheKey, std::string> aliases_;
 	std::unordered_map<ReplacementCacheKey, TextureFiltering> filtering_;
 
 	std::unordered_map<ReplacementCacheKey, ReplacedTexture *> cache_;
 	std::unordered_map<ReplacementCacheKey, std::pair<ReplacedTextureLevel, double>> savedCache_;
-	std::unordered_map<ReplacedTextureLevel, ReplacedLevelCache> levelCache_;
+
+	// the key is from aliases_. It's a |-separated sequence of texture filenames of the levels of a texture.
+	std::unordered_map<std::string, ReplacedLevelsCache> levelCache_;
 };

--- a/Core/TextureReplacer.h
+++ b/Core/TextureReplacer.h
@@ -64,6 +64,13 @@ struct ReplacedTextureLevel {
 	VFSFileReference *fileRef = nullptr;
 };
 
+struct SavedTextureCacheData {
+	int levelW[8]{};
+	int levelH[8]{};
+	bool levelSaved[8]{};
+	double lastTimeSaved;
+};
+
 struct ReplacedLevelsCache {
 	std::mutex lock;
 	std::vector<std::vector<uint8_t>> data;
@@ -252,7 +259,7 @@ protected:
 	std::unordered_map<ReplacementCacheKey, TextureFiltering> filtering_;
 
 	std::unordered_map<ReplacementCacheKey, ReplacedTexture *> cache_;
-	std::unordered_map<ReplacementCacheKey, std::pair<ReplacedTextureLevel, double>> savedCache_;
+	std::unordered_map<ReplacementCacheKey, SavedTextureCacheData> savedCache_;
 
 	// the key is from aliases_. It's a |-separated sequence of texture filenames of the levels of a texture.
 	std::unordered_map<std::string, ReplacedLevelsCache> levelCache_;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2901,7 +2901,7 @@ void TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, i
 			}
 		}
 
-		if (replacer_.Enabled() && plan.replaced->IsInvalid()) {
+		if (plan.saveTexture && !lowMemoryMode_) {
 			ReplacedTextureDecodeInfo replacedInfo;
 			replacedInfo.cachekey = entry.CacheKey();
 			replacedInfo.hash = entry.fullhash;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -107,7 +107,7 @@ inline int dimHeight(u16 dim) {
 }
 
 TextureCacheCommon::TextureCacheCommon(Draw::DrawContext *draw, Draw2D *draw2D)
-	: draw_(draw), draw2D_(draw2D) {
+	: draw_(draw), draw2D_(draw2D), replacer_(draw) {
 	decimationCounter_ = TEXCACHE_DECIMATION_INTERVAL;
 
 	// It's only possible to have 1KB of palette entries, although we allow 2KB in a hack.

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2854,7 +2854,7 @@ void TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, i
 
 	if (plan.replaceValid && plan.replaced->GetSize(srcLevel, w, h)) {
 		double replaceStart = time_now_d();
-		plan.replaced->Load(srcLevel, data, stride);
+		plan.replaced->CopyLevelTo(srcLevel, data, stride);
 		replacementTimeThisFrame_ += time_now_d() - replaceStart;
 	} else {
 		GETextureFormat tfmt = (GETextureFormat)entry.format;

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -263,7 +263,7 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 
 	DXGI_FORMAT dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
 	if (plan.replaceValid) {
-		dstFmt = ToDXGIFormat(plan.replaced->Format(plan.baseLevelSrc));
+		dstFmt = ToDXGIFormat(plan.replaced->Format());
 	} else if (plan.scaleFactor > 1 || plan.saveTexture) {
 		dstFmt = DXGI_FORMAT_B8G8R8A8_UNORM;
 	} else if (plan.decodeToClut8) {
@@ -339,7 +339,7 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 		// For UpdateSubresource, we can't decode directly into the texture so we allocate a buffer :(
 		// NOTE: Could reuse it between levels or textures!
 		if (plan.replaceValid) {
-			bpp = (int)Draw::DataFormatSizeInBytes(plan.replaced->Format(srcLevel));
+			bpp = (int)Draw::DataFormatSizeInBytes(plan.replaced->Format());
 		} else {
 			if (plan.scaleFactor > 1) {
 				bpp = 4;

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -235,7 +235,7 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 
 	D3DFORMAT dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
 	if (plan.replaceValid) {
-		dstFmt = ToD3D9Format(plan.replaced->Format(plan.baseLevelSrc));
+		dstFmt = ToD3D9Format(plan.replaced->Format());
 	} else if (plan.scaleFactor > 1 || plan.saveTexture) {
 		dstFmt = D3DFMT_A8R8G8B8;
 	} else if (plan.decodeToClut8) {

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -247,7 +247,7 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 
 	Draw::DataFormat dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
 	if (plan.replaced->GetSize(plan.baseLevelSrc, tw, th)) {
-		dstFmt = plan.replaced->Format(plan.baseLevelSrc);
+		dstFmt = plan.replaced->Format();
 	} else if (plan.scaleFactor > 1 || plan.saveTexture) {
 		dstFmt = Draw::DataFormat::R8G8B8A8_UNORM;
 	} else if (plan.decodeToClut8) {
@@ -294,7 +294,7 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 			int bpp;
 
 			if (plan.replaceValid) {
-				bpp = (int)Draw::DataFormatSizeInBytes(plan.replaced->Format(srcLevel));
+				bpp = (int)Draw::DataFormatSizeInBytes(plan.replaced->Format());
 			} else {
 				if (plan.scaleFactor > 1) {
 					bpp = 4;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -443,7 +443,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 	// Any texture scaling is gonna move away from the original 16-bit format, if any.
 	VkFormat actualFmt = plan.scaleFactor > 1 ? VULKAN_8888_FORMAT : dstFmt;
 	if (plan.replaceValid) {
-		actualFmt = ToVulkanFormat(plan.replaced->Format(plan.baseLevelSrc));
+		actualFmt = ToVulkanFormat(plan.replaced->Format());
 	}
 
 	bool computeUpload = false;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -614,7 +614,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 				VK_PROFILE_END(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT);
 			}
 			// Format might be wrong in lowMemoryMode_, so don't save.
-			if (replacer_.Enabled() && plan.replaced->IsInvalid() && !lowMemoryMode_) {
+			if (plan.saveTexture && !lowMemoryMode_) {
 				// When hardware texture scaling is enabled, this saves the original.
 				int w = dataScaled ? mipWidth : mipUnscaledWidth;
 				int h = dataScaled ? mipHeight : mipUnscaledHeight;


### PR DESCRIPTION
As it says on the tin - will make it easier to support texture formats where multiple mips come from one file.

Also, remove the "support" for different texture color formats per mip level, that's nonsensical (except when doing the Tactics Ogre mipmap hack, but even there it's of dubious use). Since we only supported one color format in the cache, this was not relevant anyway.