### PR TITLE
OpenXR - Vertical HMD rotation to keys removed

### DIFF
--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -315,7 +315,7 @@ void UpdateVRInput(bool haptics, float dp_xscale, float dp_yscale) {
 	}
 
 	// Head control
-	if (g_Config.iHeadRotation) {
+	if (g_Config.bHeadRotationEnabled) {
 		float pitch = -VR_GetHMDAngles().x;
 		float yaw = -VR_GetHMDAngles().y;
 		bool disable = vrFlatForced || appMode == VR_MENU_MODE;
@@ -341,25 +341,6 @@ void UpdateVRInput(bool haptics, float dp_xscale, float dp_yscale) {
 		bool activate;
 		float limit = isVR ? g_Config.fHeadRotationScale : 20;
 		keyInput.deviceId = DEVICE_ID_XR_HMD;
-
-		// vertical rotations
-		if (g_Config.iHeadRotation == 2) {
-			//up
-			activate = !disable && pitch > limit;
-			keyInput.flags = activate ? KEY_DOWN : KEY_UP;
-			keyInput.keyCode = NKCODE_EXT_ROTATION_UP;
-			if (hmdMotion[0] != activate) NativeKey(keyInput);
-			if (isVR && activate) hmdMotionDiff[0] -= limit;
-			hmdMotion[0] = activate;
-
-			//down
-			activate = !disable && pitch < -limit;
-			keyInput.flags = activate ? KEY_DOWN : KEY_UP;
-			keyInput.keyCode = NKCODE_EXT_ROTATION_DOWN;
-			if (hmdMotion[1] != activate) NativeKey(keyInput);
-			if (isVR && activate) hmdMotionDiff[0] += limit;
-			hmdMotion[1] = activate;
-		}
 
 		//left
 		activate = !disable && yaw < -limit;
@@ -690,8 +671,7 @@ bool StartVRRender() {
 				float mRoll = mz * ToRadians(rotation.z);
 
 				// use in-game camera interpolated rotation
-				if (g_Config.iHeadRotation >= 2) mPitch = -mx * ToRadians(hmdMotionDiffLast[0]); // vertical
-				if (g_Config.iHeadRotation >= 1) mYaw = -my * ToRadians(hmdMotionDiffLast[1]); // horizontal
+				if (g_Config.bHeadRotationEnabled) mYaw = -my * ToRadians(hmdMotionDiffLast[1]); // horizontal
 
 				// create updated quaternion
 				XrQuaternionf pitch = XrQuaternionf_CreateFromVectorAngle({1, 0, 0}, mPitch);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1154,7 +1154,7 @@ static const ConfigSetting vrSettings[] = {
 	ConfigSetting("VRMotionLength", &g_Config.fMotionLength, 0.5f),
 	ConfigSetting("VRHeadRotationScale", &g_Config.fHeadRotationScale, 5.0f),
 	ConfigSetting("VRHeadRotationSmoothing", &g_Config.bHeadRotationSmoothing, false),
-	ConfigSetting("VRHeadRotation", &g_Config.iHeadRotation, 0),
+	ConfigSetting("VRHeadRotation", &g_Config.iHeadRotation, false),
 };
 
 struct ConfigSectionSettings {

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1153,8 +1153,8 @@ static const ConfigSetting vrSettings[] = {
 	ConfigSetting("VRHeadUpDisplayScale", &g_Config.fHeadUpDisplayScale, 0.3f),
 	ConfigSetting("VRMotionLength", &g_Config.fMotionLength, 0.5f),
 	ConfigSetting("VRHeadRotationScale", &g_Config.fHeadRotationScale, 5.0f),
+	ConfigSetting("VRHeadRotationEnabled", &g_Config.bHeadRotationEnabled, false),
 	ConfigSetting("VRHeadRotationSmoothing", &g_Config.bHeadRotationSmoothing, false),
-	ConfigSetting("VRHeadRotation", &g_Config.iHeadRotation, false),
 };
 
 struct ConfigSectionSettings {

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -471,8 +471,8 @@ public:
 	float fHeadUpDisplayScale;
 	float fMotionLength;
 	float fHeadRotationScale;
+	bool bHeadRotationEnabled;
 	bool bHeadRotationSmoothing;
-	bool iHeadRotation;
 
 	// Debugger
 	int iDisasmWindowX;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -472,7 +472,7 @@ public:
 	float fMotionLength;
 	float fHeadRotationScale;
 	bool bHeadRotationSmoothing;
-	int iHeadRotation;
+	bool iHeadRotation;
 
 	// Debugger
 	int iDisasmWindowX;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1143,11 +1143,11 @@ void GameSettingsScreen::CreateVRSettings(UI::ViewGroup *vrSettings) {
 
 	vrSettings->Add(new ItemHeader(vr->T("Experts only")));
 	vrSettings->Add(new CheckBox(&g_Config.bManualForceVR, vr->T("Manual switching between flat screen and VR using SCREEN key")));
-	vrSettings->Add(new CheckBox(&g_Config.iHeadRotation, vr->T("Map HMD rotations on keys instead of VR camera")));
+	vrSettings->Add(new CheckBox(&g_Config.bHeadRotationEnabled, vr->T("Map HMD rotations on keys instead of VR camera")));
 	PopupSliderChoiceFloat *vrHeadRotationScale = vrSettings->Add(new PopupSliderChoiceFloat(&g_Config.fHeadRotationScale, 0.1f, 10.0f, vr->T("Game camera rotation step per frame"), 0.1f, screenManager(), "°"));
-	vrHeadRotationScale->SetEnabledFunc([&] { return g_Config.iHeadRotation > 0; });
+	vrHeadRotationScale->SetEnabledPtr(&g_Config.bHeadRotationEnabled);
 	CheckBox *vrHeadRotationSmoothing = vrSettings->Add(new CheckBox(&g_Config.bHeadRotationSmoothing, vr->T("Game camera uses rotation smoothing")));
-	vrHeadRotationSmoothing->SetEnabledFunc([&] { return g_Config.iHeadRotation > 0; });
+	vrHeadRotationSmoothing->SetEnabledPtr(&g_Config.bHeadRotationEnabled);
 	vrSettings->Add(new CheckBox(&g_Config.bEnableMotions, vr->T("Map controller movements to keys")));
 	PopupSliderChoiceFloat *vrMotions = vrSettings->Add(new PopupSliderChoiceFloat(&g_Config.fMotionLength, 0.3f, 1.0f, vr->T("Motion needed to generate action"), 0.1f, screenManager(), vr->T("m")));
 	vrMotions->SetEnabledPtr(&g_Config.bEnableMotions);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1143,8 +1143,7 @@ void GameSettingsScreen::CreateVRSettings(UI::ViewGroup *vrSettings) {
 
 	vrSettings->Add(new ItemHeader(vr->T("Experts only")));
 	vrSettings->Add(new CheckBox(&g_Config.bManualForceVR, vr->T("Manual switching between flat screen and VR using SCREEN key")));
-	static const char *vrHeadRotations[] = { vr->T("Disabled"), vr->T("Horizontal only"), vr->T("Horizontal and vertical") };
-	vrSettings->Add(new PopupMultiChoice(&g_Config.iHeadRotation, vr->T("Map HMD rotations on keys instead of VR camera"), vrHeadRotations, 0, ARRAY_SIZE(vrHeadRotations), vr->GetName(), screenManager()));
+	vrSettings->Add(new CheckBox(&g_Config.iHeadRotation, vr->T("Map HMD rotations on keys instead of VR camera")));
 	PopupSliderChoiceFloat *vrHeadRotationScale = vrSettings->Add(new PopupSliderChoiceFloat(&g_Config.fHeadRotationScale, 0.1f, 10.0f, vr->T("Game camera rotation step per frame"), 0.1f, screenManager(), "°"));
 	vrHeadRotationScale->SetEnabledFunc([&] { return g_Config.iHeadRotation > 0; });
 	CheckBox *vrHeadRotationSmoothing = vrSettings->Add(new CheckBox(&g_Config.bHeadRotationSmoothing, vr->T("Game camera uses rotation smoothing")));

--- a/android/VRManifest.xml
+++ b/android/VRManifest.xml
@@ -6,7 +6,7 @@
 
     <application
         android:allowBackup="true"
-        android:icon="@drawable/ic_launcher"
+        android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name" 
         android:logo="@drawable/ic_banner"
         android:isGame="true"


### PR DESCRIPTION
Vertical HMD rotation to keys doesn't work well in any single game. It only leads to user's neck issues. Horizontal version of this works fine.

I updated the app icon as gradle was failing on merging Manifests.