### PR TITLE
DDS texture support in texture replacer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,6 +571,8 @@ add_library(Common STATIC
 	Common/Data/Format/JSONReader.cpp
 	Common/Data/Format/JSONWriter.h
 	Common/Data/Format/JSONWriter.cpp
+	Common/Data/Format/DDSLoad.cpp
+	Common/Data/Format/DDSLoad.h
 	Common/Data/Format/PNGLoad.cpp
 	Common/Data/Format/PNGLoad.h
 	Common/Data/Format/ZIMLoad.cpp

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -405,6 +405,7 @@
     <ClInclude Include="Data\Encoding\Shiftjis.h" />
     <ClInclude Include="Data\Encoding\Utf16.h" />
     <ClInclude Include="Data\Encoding\Utf8.h" />
+    <ClInclude Include="Data\Format\DDSLoad.h" />
     <ClInclude Include="Data\Format\IniFile.h" />
     <ClInclude Include="Data\Format\JSONReader.h" />
     <ClInclude Include="Data\Format\JSONWriter.h" />
@@ -844,6 +845,7 @@
     <ClCompile Include="Data\Encoding\Base64.cpp" />
     <ClCompile Include="Data\Encoding\Compression.cpp" />
     <ClCompile Include="Data\Encoding\Utf8.cpp" />
+    <ClCompile Include="Data\Format\DDSLoad.cpp" />
     <ClCompile Include="Data\Format\IniFile.cpp" />
     <ClCompile Include="Data\Format\JSONReader.cpp" />
     <ClCompile Include="Data\Format\JSONWriter.cpp" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -470,6 +470,9 @@
     <ClInclude Include="File\VFS\ZipFileReader.h">
       <Filter>File\VFS</Filter>
     </ClInclude>
+    <ClInclude Include="Data\Format\DDSLoad.h">
+      <Filter>Data\Format</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />
@@ -889,6 +892,9 @@
     </ClCompile>
     <ClCompile Include="File\VFS\ZipFileReader.cpp">
       <Filter>File\VFS</Filter>
+    </ClCompile>
+    <ClCompile Include="Data\Format\DDSLoad.cpp">
+      <Filter>Data\Format</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Common/Data/Format/DDSLoad.cpp
+++ b/Common/Data/Format/DDSLoad.cpp
@@ -1,0 +1,5 @@
+#include "Common/Data/Format/DDSLoad.h"
+
+bool DetectDDSParams(const DDSHeader *header, DDSLoadInfo *info) {
+	return false;
+}

--- a/Common/Data/Format/DDSLoad.h
+++ b/Common/Data/Format/DDSLoad.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cstdint>
+
+// DDSPixelFormat.dwFlags bits
+enum {
+	DDPF_ALPHAPIXELS = 1,   // Texture contains alpha data; dwRGBAlphaBitMask contains valid data.
+	DDPF_ALPHA       = 2,   // Used in some older DDS files for alpha channel only uncompressed data(dwRGBBitCount contains the alpha channel bitcount; dwABitMask contains valid data)
+	DDPF_FOURCC      = 4,   // Texture contains compressed RGB data; dwFourCC contains valid data.	0x4
+	DDPF_RGB         = 8,   // Texture contains uncompressed RGB data; dwRGBBitCount and the RGB masks(dwRBitMask, dwGBitMask, dwBBitMask) contain valid data.	0x40
+	DDPF_YUV         = 16,  //Used in some older DDS files for YUV uncompressed data(dwRGBBitCount contains the YUV bit count; dwRBitMask contains the Y mask, dwGBitMask contains the U mask, dwBBitMask contains the V mask)
+	DDPF_LUMINANCE   = 32,  // Used in some older DDS files for single channel color uncompressed data (dwRGBBitCount contains the luminance channel bit count; dwRBitMask contains the channel mask). Can be combined with DDPF_ALPHAPIXELS for a two channel DDS file.
+};
+
+// dwCaps members
+enum {
+	DDSCAPS_COMPLEX = 8,
+	DDSCAPS_MIPMAP = 0x400000,
+	DDSCAPS_TEXTURE = 0x1000,  // Required
+};
+
+// Not using any D3D headers here, this is cross platform and minimal.
+// Boiled down from the public documentation.
+struct DDSPixelFormat {
+	uint32_t dwSize;  // must be 32
+	uint32_t dwFlags;
+	uint32_t dwFourCC;
+	uint32_t dwRGBBitCount;
+	uint32_t dwRBitMask;
+	uint32_t dwGBitMask;
+	uint32_t dwBBitMask;
+	uint32_t dwABitMask;
+};
+
+struct DDSHeader {
+	uint32_t dwMagic;  // Magic is not technically part of the header struct but convenient to have here when reading the files.
+	uint32_t dwSize;  // must be 124
+	uint32_t dwFlags;
+	uint32_t dwHeight;
+	uint32_t dwWidth;
+	uint32_t dwPitchOrLinearSize;  // The pitch or number of bytes per scan line in an uncompressed texture; the total number of bytes in the top level texture for a compressed texture
+	uint32_t dwDepth; // we'll always use 1 here
+	uint32_t dwMipMapCount;
+	uint32_t dwReserved1[11];
+	DDSPixelFormat ddspf;
+	uint32_t dwCaps;
+	uint32_t dwCaps2; // nothing we care about
+	uint32_t dwCaps3; // unused
+	uint32_t dwCaps4; // unused
+	uint32_t dwReserved2;
+};
+
+// DDS header extension to handle resource arrays, DXGI pixel formats that don't map to the legacy Microsoft DirectDraw pixel format structures, and additional metadata.
+struct DDSHeaderDXT10 {
+	uint32_t dxgiFormat;
+	uint32_t resourceDimension;  // 1d = 2, 2d = 3, 3d = 4. very intuitive
+	uint32_t miscFlag;
+	uint32_t arraySize;  // we only support 1 here
+	uint32_t miscFlags2;  // sets alpha interpretation, let's not bother
+};
+
+// Simple DDS parser, suitable for texture replacement packs.
+// Doesn't actually load, only does some logic to fill out DDSLoadInfo so the caller can then
+// do the actual load with a simple series of memcpys or whatever is appropriate.
+struct DDSLoadInfo {
+	uint32_t bytesToCopy;
+};
+
+bool DetectDDSParams(const DDSHeader *header, DDSLoadInfo *info);

--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -491,7 +491,12 @@ static DXGI_FORMAT dataFormatToD3D11(DataFormat format) {
 	case DataFormat::D16: return DXGI_FORMAT_D16_UNORM;
 	case DataFormat::D32F: return DXGI_FORMAT_D32_FLOAT;
 	case DataFormat::D32F_S8: return DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
-	case DataFormat::ETC1:
+	case DataFormat::BC1_RGBA_UNORM_BLOCK: return DXGI_FORMAT_BC1_UNORM;
+	case DataFormat::BC2_UNORM_BLOCK: return DXGI_FORMAT_BC2_UNORM;
+	case DataFormat::BC3_UNORM_BLOCK: return DXGI_FORMAT_BC3_UNORM;
+	case DataFormat::BC4_UNORM_BLOCK: return DXGI_FORMAT_BC4_UNORM;
+	case DataFormat::BC5_UNORM_BLOCK: return DXGI_FORMAT_BC5_UNORM;
+	case DataFormat::BC7_UNORM_BLOCK: return DXGI_FORMAT_BC7_UNORM;
 	default:
 		return DXGI_FORMAT_UNKNOWN;
 	}

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -125,6 +125,9 @@ D3DFORMAT FormatToD3DFMT(DataFormat fmt) {
 	case DataFormat::A1R5G5B5_UNORM_PACK16: return D3DFMT_A1R5G5B5;
 	case DataFormat::D24_S8: return D3DFMT_D24S8;
 	case DataFormat::D16: return D3DFMT_D16;
+	case DataFormat::BC1_RGBA_UNORM_BLOCK: return D3DFMT_DXT1;
+	case DataFormat::BC2_UNORM_BLOCK: return D3DFMT_DXT3;  // DXT3 is indeed BC2.
+	case DataFormat::BC3_UNORM_BLOCK: return D3DFMT_DXT5;  // DXT5 is indeed BC3
 	default: return D3DFMT_UNKNOWN;
 	}
 }

--- a/Common/GPU/DataFormat.h
+++ b/Common/GPU/DataFormat.h
@@ -46,22 +46,20 @@ enum class DataFormat : uint8_t {
 	// Block compression formats.
 	// These are modern names for DXT and friends, now patent free.
 	// https://msdn.microsoft.com/en-us/library/bb694531.aspx
-	BC1_RGBA_UNORM_BLOCK,
-	BC1_RGBA_SRGB_BLOCK,
-	BC2_UNORM_BLOCK,  // 4-bit straight alpha + DXT1 color. Usually not worth using
-	BC2_SRGB_BLOCK,
-	BC3_UNORM_BLOCK,  // 3-bit alpha with 2 ref values (+ magic) + DXT1 color
-	BC3_SRGB_BLOCK,
-	BC4_UNORM_BLOCK,  // 1-channel, same storage as BC3 alpha
-	BC4_SNORM_BLOCK,
-	BC5_UNORM_BLOCK,  // 2-channel RG, each has same storage as BC3 alpha
-	BC5_SNORM_BLOCK,
-	BC6H_UFLOAT_BLOCK,  // TODO
-	BC6H_SFLOAT_BLOCK,
-	BC7_UNORM_BLOCK,    // Highly advanced, very expensive to compress, very good quality.
-	BC7_SRGB_BLOCK,
+	BC1_RGBA_UNORM_BLOCK,  // 64 bits per 4x4 block. Used by Basis, along with ETC2_R8G8B8_UNORM_BLOCK.
+	BC2_UNORM_BLOCK,  // 4-bit straight alpha + DXT1 color. 128 bits per block. Usually not worth using
+	BC3_UNORM_BLOCK,  // 3-bit alpha with 2 ref values (+ magic) + DXT1 color. 128 bits per block.
+	BC4_UNORM_BLOCK,  // 1-channel, same storage as BC3 alpha. 64 bits per block.
+	BC5_UNORM_BLOCK,  // 2-channel RG, each has same storage as BC3 alpha. 128 bits per block.
+	BC7_UNORM_BLOCK,  // Highly advanced RGBA, very expensive to compress, very good quality. 128 bits per block.
 
-	ETC1,
+	// Ericsson texture compression.
+	ETC2_R8G8B8_UNORM_BLOCK,  // Color-only, 64 bits per 4x4 block.
+	ETC2_R8G8B8A1_UNORM_BLOCK,  // Color + alpha, 128 bits per 4x4 block.
+	ETC2_R8G8B8A8_UNORM_BLOCK,  // Color + alpha, 128 bits per 4x4 block.
+
+	// This is the one ASTC format used by UASTC / basis Universal.
+	ASTC_4x4_UNORM_BLOCK,
 
 	S8,
 	D16,
@@ -76,6 +74,7 @@ bool DataFormatIsDepthStencil(DataFormat fmt);
 inline bool DataFormatIsColor(DataFormat fmt) {
 	return !DataFormatIsDepthStencil(fmt);
 }
+bool DataFormatIsBlockCompressed(DataFormat fmt, int *blockSize);
 
 // Limited format support for now.
 const char *DataFormatToString(DataFormat fmt);

--- a/Common/GPU/OpenGL/DataFormatGL.cpp
+++ b/Common/GPU/OpenGL/DataFormatGL.cpp
@@ -86,6 +86,7 @@ bool Thin3DFormatToGLFormatAndType(DataFormat fmt, GLuint &internalFormat, GLuin
 		alignment = 16;
 		break;
 
+#if PPSSPP_PLATFORM(WINDOWS)
 	case DataFormat::BC1_RGBA_UNORM_BLOCK:
 		internalFormat = GL_COMPRESSED_RGB_S3TC_DXT1_EXT;
 		format = GL_RGB;
@@ -93,7 +94,6 @@ bool Thin3DFormatToGLFormatAndType(DataFormat fmt, GLuint &internalFormat, GLuin
 		alignment = 8;
 		break;
 
-#if PPSSPP_PLATFORM(WINDOWS)
 	case DataFormat::BC7_UNORM_BLOCK:
 		internalFormat = GL_COMPRESSED_RGBA_BPTC_UNORM;
 		format = GL_RGBA;

--- a/Common/GPU/OpenGL/DataFormatGL.cpp
+++ b/Common/GPU/OpenGL/DataFormatGL.cpp
@@ -86,6 +86,50 @@ bool Thin3DFormatToGLFormatAndType(DataFormat fmt, GLuint &internalFormat, GLuin
 		alignment = 16;
 		break;
 
+	case DataFormat::BC1_RGBA_UNORM_BLOCK:
+		internalFormat = GL_COMPRESSED_RGB_S3TC_DXT1_EXT;
+		format = GL_RGB;
+		type = GL_FLOAT;
+		alignment = 8;
+		break;
+
+#if PPSSPP_PLATFORM(WINDOWS)
+	case DataFormat::BC7_UNORM_BLOCK:
+		internalFormat = GL_COMPRESSED_RGBA_BPTC_UNORM;
+		format = GL_RGBA;
+		type = GL_FLOAT;
+		alignment = 16;
+		break;
+#endif
+
+	case DataFormat::ETC2_R8G8B8_UNORM_BLOCK:
+		internalFormat = GL_COMPRESSED_RGB8_ETC2;
+		format = GL_RGB;
+		type = GL_FLOAT;
+		alignment = 8;
+		break;
+
+	case DataFormat::ETC2_R8G8B8A1_UNORM_BLOCK:
+		internalFormat = GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2;
+		format = GL_RGBA;
+		type = GL_FLOAT;
+		alignment = 16;
+		break;
+
+	case DataFormat::ETC2_R8G8B8A8_UNORM_BLOCK:
+		internalFormat = GL_COMPRESSED_RGBA8_ETC2_EAC;
+		format = GL_RGBA;
+		type = GL_FLOAT;
+		alignment = 16;
+		break;
+
+	case DataFormat::ASTC_4x4_UNORM_BLOCK:
+		internalFormat = GL_COMPRESSED_RGBA_ASTC_4x4_KHR;
+		format = GL_RGBA;
+		type = GL_FLOAT;
+		alignment = 16;
+		break;
+
 	default:
 		return false;
 	}

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -560,6 +560,7 @@ private:
 	uint8_t stencilCompareMask_ = 0xFF;
 };
 
+// Bits per pixel, not bytes.
 static int GetBpp(VkFormat format) {
 	switch (format) {
 	case VK_FORMAT_R8G8B8A8_UNORM:
@@ -582,6 +583,21 @@ static int GetBpp(VkFormat format) {
 		return 32;
 	case VK_FORMAT_D16_UNORM:
 		return 16;
+	case VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK:
+		return 4;
+	case VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK:
+	case VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK:
+		return 8;
+	case VK_FORMAT_ASTC_4x4_UNORM_BLOCK:
+		return 8;
+	case VK_FORMAT_BC1_RGBA_UNORM_BLOCK:
+		return 4;
+	case VK_FORMAT_BC2_UNORM_BLOCK:
+	case VK_FORMAT_BC3_UNORM_BLOCK:
+	case VK_FORMAT_BC4_UNORM_BLOCK:
+	case VK_FORMAT_BC5_UNORM_BLOCK:
+	case VK_FORMAT_BC7_UNORM_BLOCK:
+		return 8;
 	default:
 		return 0;
 	}
@@ -625,13 +641,15 @@ static VkFormat DataFormatToVulkan(DataFormat format) {
 	case DataFormat::BC2_UNORM_BLOCK: return VK_FORMAT_BC2_UNORM_BLOCK;
 	case DataFormat::BC3_UNORM_BLOCK: return VK_FORMAT_BC3_UNORM_BLOCK;
 	case DataFormat::BC4_UNORM_BLOCK: return VK_FORMAT_BC4_UNORM_BLOCK;
-	case DataFormat::BC4_SNORM_BLOCK: return VK_FORMAT_BC4_SNORM_BLOCK;
 	case DataFormat::BC5_UNORM_BLOCK: return VK_FORMAT_BC5_UNORM_BLOCK;
-	case DataFormat::BC5_SNORM_BLOCK: return VK_FORMAT_BC5_SNORM_BLOCK;
-	case DataFormat::BC6H_SFLOAT_BLOCK: return VK_FORMAT_BC6H_SFLOAT_BLOCK;
-	case DataFormat::BC6H_UFLOAT_BLOCK: return VK_FORMAT_BC6H_UFLOAT_BLOCK;
 	case DataFormat::BC7_UNORM_BLOCK: return VK_FORMAT_BC7_UNORM_BLOCK;
-	case DataFormat::BC7_SRGB_BLOCK:  return VK_FORMAT_BC7_SRGB_BLOCK;
+
+	case DataFormat::ETC2_R8G8B8A1_UNORM_BLOCK: return VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK;
+	case DataFormat::ETC2_R8G8B8A8_UNORM_BLOCK: return VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK;
+	case DataFormat::ETC2_R8G8B8_UNORM_BLOCK: return VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK;
+
+	case DataFormat::ASTC_4x4_UNORM_BLOCK: return VK_FORMAT_ASTC_4x4_UNORM_BLOCK;
+
 	default:
 		return VK_FORMAT_UNDEFINED;
 	}

--- a/Common/GPU/thin3d.cpp
+++ b/Common/GPU/thin3d.cpp
@@ -93,6 +93,31 @@ bool DataFormatIsDepthStencil(DataFormat fmt) {
 	}
 }
 
+// We don't bother listing the formats that are irrelevant for PPSSPP, like BC6 (HDR format)
+// or weird-shaped ASTC formats. We only support 4x4 block size formats for now.
+// If you pass in a blockSize parameter, it receives byte count that a 4x4 block takes in this format.
+bool DataFormatIsBlockCompressed(DataFormat fmt, int *blockSize) {
+	switch (fmt) {
+	case DataFormat::BC1_RGBA_UNORM_BLOCK:
+	case DataFormat::BC4_UNORM_BLOCK:
+	case DataFormat::ETC2_R8G8B8_UNORM_BLOCK:
+		if (blockSize) *blockSize = 8;  // 64 bits
+		return true;
+	case DataFormat::BC2_UNORM_BLOCK:
+	case DataFormat::BC3_UNORM_BLOCK:
+	case DataFormat::BC5_UNORM_BLOCK:
+	case DataFormat::BC7_UNORM_BLOCK:
+	case DataFormat::ETC2_R8G8B8A1_UNORM_BLOCK:
+	case DataFormat::ETC2_R8G8B8A8_UNORM_BLOCK:
+	case DataFormat::ASTC_4x4_UNORM_BLOCK:
+		if (blockSize) *blockSize = 16;  // 128 bits
+		return true;
+	default:
+		if (blockSize) *blockSize = 0;
+		return false;
+	}
+}
+
 RefCountedObject::~RefCountedObject() {
 	_dbg_assert_(refcount_ == 0xDEDEDE);
 }

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -88,6 +88,7 @@ struct ReplacementDesc {
 };
 
 struct ReplacedLevelsCache {
+	Draw::DataFormat fmt = Draw::DataFormat::UNDEFINED;
 	std::mutex lock;
 	std::vector<std::vector<uint8_t>> data;
 	double lastUsed = 0.0;

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -87,6 +87,12 @@ struct ReplacementDesc {
 	ReplacedLevelsCache *cache;
 };
 
+struct ReplacedLevelsCache {
+	std::mutex lock;
+	std::vector<std::vector<uint8_t>> data;
+	double lastUsed = 0.0;
+};
+
 // These aren't actually all replaced, they can also represent a placeholder for a not-found
 // replacement (state_ == NOT_FOUND).
 struct ReplacedTexture {
@@ -111,6 +117,11 @@ struct ReplacedTexture {
 		*h = levels_[level].h;
 	}
 
+	int GetLevelDataSize(int level) const {
+		_dbg_assert_(State() == ReplacementState::ACTIVE);
+		return (int)levelData_->data[level].size();
+	}
+
 	int NumLevels() const {
 		_dbg_assert_(State() == ReplacementState::ACTIVE);
 		return (int)levels_.size();
@@ -133,7 +144,7 @@ struct ReplacedTexture {
 
 private:
 	void Prepare(VFSBackend *vfs);
-	bool LoadLevelData(ReplacedTextureLevel &info, int level);
+	bool LoadLevelData(ReplacedTextureLevel &info, int level, Draw::DataFormat *pixelFormat);
 	void PurgeIfOlder(double t);
 
 	std::vector<ReplacedTextureLevel> levels_;

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -44,6 +44,7 @@ enum class ReplacedTextureHash {
 enum class ReplacedImageType {
 	PNG,
 	ZIM,
+	DDS,
 	INVALID,
 };
 
@@ -59,8 +60,6 @@ struct ReplacedTextureLevel {
 	// TODO: This really belongs on the level in the cache, not in the individual ReplacedTextureLevel objects.
 	VFSFileReference *fileRef = nullptr;
 };
-
-ReplacedImageType Identify(VFSBackend *vfs, VFSOpenFile *openFile, std::string *outMagic);
 
 enum class ReplacementState : uint32_t {
 	UNINITIALIZED,

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1550,6 +1550,8 @@ ReplacedTexture *TextureCacheCommon::FindReplacement(TexCacheEntry *entry, int &
 		// Make sure we keep polling.
 		entry->status |= TexCacheEntry::STATUS_TO_REPLACE;
 		break;
+    default:
+        break;
 	}
 	replacementTimeThisFrame_ += time_now_d() - replaceStart;
 	return replaced;

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -54,31 +54,6 @@ static const std::string NEW_TEXTURE_DIR = "new/";
 static const int VERSION = 1;
 static const double MAX_CACHE_SIZE = 4.0;
 
-static inline ReplacedImageType IdentifyMagic(const uint8_t magic[4]) {
-	if (strncmp((const char *)magic, "ZIMG", 4) == 0)
-		return ReplacedImageType::ZIM;
-	if (magic[0] == 0x89 && strncmp((const char *)&magic[1], "PNG", 3) == 0)
-		return ReplacedImageType::PNG;
-	return ReplacedImageType::INVALID;
-}
-
-ReplacedImageType Identify(VFSBackend *vfs, VFSOpenFile *openFile, std::string *outMagic) {
-	uint8_t magic[4];
-	if (vfs->Read(openFile, magic, 4) != 4) {
-		*outMagic = "FAIL";
-		return ReplacedImageType::INVALID;
-	}
-	// Turn the signature into a readable string that we can display in an error message.
-	*outMagic = std::string((const char *)magic, 4);
-	for (int i = 0; i < outMagic->size(); i++) {
-		if ((s8)(*outMagic)[i] < 32) {
-			(*outMagic)[i] = '_';
-		}
-	}
-	vfs->Rewind(openFile);
-	return IdentifyMagic(magic);
-}
-
 TextureReplacer::TextureReplacer(Draw::DrawContext *draw) {
 	// TODO: Check draw for supported texture formats.
 }

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -48,12 +48,6 @@ struct SavedTextureCacheData {
 	double lastTimeSaved = 0.0;
 };
 
-struct ReplacedLevelsCache {
-	std::mutex lock;
-	std::vector<std::vector<uint8_t>> data;
-	double lastUsed = 0.0;
-};
-
 struct ReplacementCacheKey {
 	u64 cachekey;
 	u32 hash;

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -56,7 +56,7 @@ static const D3D11_INPUT_ELEMENT_DESC g_QuadVertexElements[] = {
 
 // NOTE: In the D3D backends, we flip R and B in the shaders, so while these look wrong, they're OK.
 
-Draw::DataFormat FromD3D11Format(u32 fmt) {
+static Draw::DataFormat FromD3D11Format(u32 fmt) {
 	switch (fmt) {
 	case DXGI_FORMAT_B4G4R4A4_UNORM:
 		return Draw::DataFormat::A4R4G4B4_UNORM_PACK16;
@@ -72,9 +72,16 @@ Draw::DataFormat FromD3D11Format(u32 fmt) {
 	}
 }
 
-DXGI_FORMAT ToDXGIFormat(Draw::DataFormat fmt) {
+static DXGI_FORMAT ToDXGIFormat(Draw::DataFormat fmt) {
 	switch (fmt) {
-	case Draw::DataFormat::R8G8B8A8_UNORM: default: return DXGI_FORMAT_B8G8R8A8_UNORM;
+	case Draw::DataFormat::BC1_RGBA_UNORM_BLOCK: return DXGI_FORMAT_BC1_UNORM;
+	case Draw::DataFormat::BC2_UNORM_BLOCK: return DXGI_FORMAT_BC2_UNORM;
+	case Draw::DataFormat::BC3_UNORM_BLOCK: return DXGI_FORMAT_BC3_UNORM;
+	case Draw::DataFormat::BC4_UNORM_BLOCK: return DXGI_FORMAT_BC4_UNORM;
+	case Draw::DataFormat::BC5_UNORM_BLOCK: return DXGI_FORMAT_BC5_UNORM;
+	case Draw::DataFormat::BC7_UNORM_BLOCK: return DXGI_FORMAT_BC7_UNORM;
+	case Draw::DataFormat::R8G8B8A8_UNORM: return DXGI_FORMAT_B8G8R8A8_UNORM;
+	default: _dbg_assert_(false); return DXGI_FORMAT_UNKNOWN;
 	}
 }
 

--- a/UWP/CommonUWP/CommonUWP.vcxproj
+++ b/UWP/CommonUWP/CommonUWP.vcxproj
@@ -272,6 +272,7 @@
     <ClInclude Include="..\..\Common\BitScan.h" />
     <ClInclude Include="..\..\Common\BitSet.h" />
     <ClInclude Include="..\..\Common\Buffer.h" />
+    <ClInclude Include="..\..\Common\Data\Format\DDSLoad.h" />
     <ClInclude Include="..\..\Common\File\AndroidStorage.h" />
     <ClInclude Include="..\..\Common\GPU\Vulkan\VulkanLoader.h" />
     <ClInclude Include="..\..\Common\Math\Statistics.h" />
@@ -418,6 +419,7 @@
     <ClCompile Include="..\..\Common\ArmCPUDetect.cpp" />
     <ClCompile Include="..\..\Common\ArmEmitter.cpp" />
     <ClCompile Include="..\..\Common\Buffer.cpp" />
+    <ClCompile Include="..\..\Common\Data\Format\DDSLoad.cpp" />
     <ClCompile Include="..\..\Common\File\AndroidStorage.cpp" />
     <ClCompile Include="..\..\Common\GPU\Vulkan\VulkanLoader.cpp" />
     <ClCompile Include="..\..\Common\Math\Statistics.cpp" />

--- a/UWP/CommonUWP/CommonUWP.vcxproj.filters
+++ b/UWP/CommonUWP/CommonUWP.vcxproj.filters
@@ -420,6 +420,9 @@
     <ClCompile Include="..\..\Common\UI\ScrollView.cpp">
       <Filter>UI</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\Data\Format\DDSLoad.cpp">
+      <Filter>Data\Format</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="targetver.h" />
@@ -777,6 +780,9 @@
     </ClInclude>
     <ClInclude Include="..\..\Common\UI\ScrollView.h">
       <Filter>UI</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\Data\Format\DDSLoad.h">
+      <Filter>Data\Format</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -163,6 +163,8 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Common/Data/Format/IniFile.cpp \
   $(SRC)/Common/Data/Format/JSONReader.cpp \
   $(SRC)/Common/Data/Format/JSONWriter.cpp \
+  $(SRC)/Common/Data/Format/DDSLoad.cpp \
+  $(SRC)/Common/Data/Format/DDSLoad.h \
   $(SRC)/Common/Data/Format/PNGLoad.cpp \
   $(SRC)/Common/Data/Format/PNGLoad.h \
   $(SRC)/Common/Data/Format/ZIMLoad.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -261,6 +261,7 @@ SOURCES_CXX += \
 	$(COMMONDIR)/Data/Format/IniFile.cpp \
 	$(COMMONDIR)/Data/Format/JSONReader.cpp \
 	$(COMMONDIR)/Data/Format/JSONWriter.cpp \
+	$(COMMONDIR)/Data/Format/DDSLoad.cpp \
 	$(COMMONDIR)/Data/Format/PNGLoad.cpp \
 	$(COMMONDIR)/Data/Format/ZIMLoad.cpp \
 	$(COMMONDIR)/Data/Format/ZIMSave.cpp \


### PR DESCRIPTION
Supports the various BC formats that can be stored in a DDS file, single mipmap only for now (will be extended later).

Work-in-progress, currently only works with Vulkan.