### PR TITLE
Texture replacer: Replace three flags with a state field in ReplacedTexture

### DIFF
--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -93,7 +93,7 @@ bool ReplacedTexture::IsReady(double budget) {
 	g_threadManager.EnqueueTask(new ReplacedTextureTask(vfs_, *this, threadWaitable_));
 	if (threadWaitable_->WaitFor(budget)) {
 		// If we successfully wait here, we're done. The thread will set state accordingly.
-		_assert_(State() == ReplacementState::ACTIVE || State() == ReplacementState::NOT_FOUND);
+		_assert_(State() == ReplacementState::ACTIVE || State() == ReplacementState::NOT_FOUND || State() == ReplacementState::CANCEL_INIT);
 		return true;
 	}
 	SetState(ReplacementState::PENDING);
@@ -135,8 +135,10 @@ void ReplacedTexture::PrepareData(int level) {
 	std::vector<uint8_t> &out = levelData_->data[level];
 
 	// Already populated from cache.
-	if (!out.empty())
+	if (!out.empty()) {
+		SetState(ReplacementState::ACTIVE);
 		return;
+	}
 
 	ReplacedImageType imageType;
 

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -56,33 +56,46 @@ private:
 
 bool ReplacedTexture::IsReady(double budget) {
 	_assert_(vfs_ != nullptr);
-	lastUsed_ = time_now_d();
-	if (threadWaitable_ && !threadWaitable_->WaitFor(budget)) {
+
+	switch (State()) {
+	case ReplacementState::ACTIVE:
+	case ReplacementState::NOT_FOUND:
+		if (threadWaitable_) {
+			if (!threadWaitable_->WaitFor(budget)) {
+				return false;
+			}
+			// Successfully waited! Can get rid of it.
+			threadWaitable_->WaitAndRelease();
+			threadWaitable_ = nullptr;
+		}
+		lastUsed_ = time_now_d();
+		return true;
+	case ReplacementState::UNINITIALIZED:
+		// _dbg_assert_(false);
 		return false;
+	case ReplacementState::CANCEL_INIT:
+	case ReplacementState::PENDING:
+		return false;
+	case ReplacementState::PREPARED:
+		// We're gonna need to spawn a task.
+		break;
 	}
 
-	// Loaded already, or not yet on a thread?
-	if (initDone_ && levelData_ && !levelData_->data.empty()) {
-		// TODO: lock?
-		levelData_->lastUsed = lastUsed_;
-		return true;
-	}
+	lastUsed_ = time_now_d();
 
 	// Let's not even start a new texture if we're already behind.
 	if (budget < 0.0)
 		return false;
-	if (!prepareDone_)
-		return false;
 
-	if (threadWaitable_)
-		delete threadWaitable_;
+	_assert_(!threadWaitable_);
 	threadWaitable_ = new LimitedWaitable();
 	g_threadManager.EnqueueTask(new ReplacedTextureTask(vfs_, *this, threadWaitable_));
 	if (threadWaitable_->WaitFor(budget)) {
-		// If we finished all the levels, we're done.
-		return initDone_ && levelData_ != nullptr && !levelData_->data.empty();
+		// If we successfully wait here, we're done. The thread will set state accordingly.
+		_assert_(State() == ReplacementState::ACTIVE || State() == ReplacementState::NOT_FOUND);
+		return true;
 	}
-
+	SetState(ReplacementState::PENDING);
 	// Still pending on thread.
 	return false;
 }
@@ -90,19 +103,18 @@ bool ReplacedTexture::IsReady(double budget) {
 void ReplacedTexture::Prepare(VFSBackend *vfs) {
 	std::unique_lock<std::mutex> lock(mutex_);
 	this->vfs_ = vfs;
-	if (cancelPrepare_) {
-		initDone_ = true;
+
+	if (State() == ReplacementState::CANCEL_INIT) {
 		return;
 	}
 
 	for (int i = 0; i < (int)levels_.size(); ++i) {
-		if (cancelPrepare_)
+		if (State() == ReplacementState::CANCEL_INIT)
 			break;
 		PrepareData(i);
 	}
 
-	initDone_ = true;
-	if (!cancelPrepare_ && threadWaitable_)
+	if (threadWaitable_)
 		threadWaitable_->Notify();
 }
 
@@ -141,12 +153,14 @@ void ReplacedTexture::PrepareData(int level) {
 		std::unique_ptr<uint8_t[]> zim(new uint8_t[fileSize]);
 		if (!zim) {
 			ERROR_LOG(G3D, "Failed to allocate memory for texture replacement");
+			SetState(ReplacementState::NOT_FOUND);
 			cleanup();
 			return;
 		}
 
 		if (vfs_->Read(openFile, &zim[0], fileSize) != fileSize) {
 			ERROR_LOG(G3D, "Could not load texture replacement: %s - failed to read ZIM", info.file.c_str());
+			SetState(ReplacementState::NOT_FOUND);
 			cleanup();
 			return;
 		}
@@ -156,6 +170,7 @@ void ReplacedTexture::PrepareData(int level) {
 		if (LoadZIMPtr(&zim[0], fileSize, &w, &h, &f, &image)) {
 			if (w > info.w || h > info.h) {
 				ERROR_LOG(G3D, "Texture replacement changed since header read: %s", info.file.c_str());
+				SetState(ReplacementState::NOT_FOUND);
 				cleanup();
 				return;
 			}
@@ -184,11 +199,13 @@ void ReplacedTexture::PrepareData(int level) {
 		pngdata.resize(vfs_->Read(openFile, &pngdata[0], fileSize));
 		if (!png_image_begin_read_from_memory(&png, &pngdata[0], pngdata.size())) {
 			ERROR_LOG(G3D, "Could not load texture replacement info: %s - %s (zip)", info.file.c_str(), png.message);
+			SetState(ReplacementState::NOT_FOUND);
 			cleanup();
 			return;
 		}
 		if (png.width > (uint32_t)info.w || png.height > (uint32_t)info.h) {
 			ERROR_LOG(G3D, "Texture replacement changed since header read: %s", info.file.c_str());
+			SetState(ReplacementState::NOT_FOUND);
 			cleanup();
 			return;
 		}
@@ -206,6 +223,7 @@ void ReplacedTexture::PrepareData(int level) {
 		out.resize(info.w * info.h * 4);
 		if (!png_image_finish_read(&png, nullptr, &out[0], info.w * 4, nullptr)) {
 			ERROR_LOG(G3D, "Could not load texture replacement: %s - %s", info.file.c_str(), png.message);
+			SetState(ReplacementState::NOT_FOUND);
 			cleanup();
 			out.resize(0);
 			return;
@@ -221,6 +239,7 @@ void ReplacedTexture::PrepareData(int level) {
 		}
 	}
 
+	SetState(ReplacementState::ACTIVE);
 	cleanup();
 }
 
@@ -235,13 +254,13 @@ void ReplacedTexture::PurgeIfOlder(double t) {
 		std::lock_guard<std::mutex> guard(levelData_->lock);
 		levelData_->data.clear();
 		// This means we have to reload.  If we never purge any, there's no need.
-		initDone_ = false;
+		SetState(ReplacementState::PREPARED);
 	}
 }
 
 ReplacedTexture::~ReplacedTexture() {
 	if (threadWaitable_) {
-		cancelPrepare_ = true;
+		SetState(ReplacementState::CANCEL_INIT);
 
 		std::unique_lock<std::mutex> lock(mutex_);
 		threadWaitable_->WaitAndRelease();
@@ -258,7 +277,7 @@ bool ReplacedTexture::CopyLevelTo(int level, void *out, int rowPitch) {
 	_assert_msg_((size_t)level < levels_.size(), "Invalid miplevel");
 	_assert_msg_(out != nullptr && rowPitch > 0, "Invalid out/pitch");
 
-	if (!initDone_) {
+	if (State() != ReplacementState::ACTIVE) {
 		WARN_LOG(G3D, "Init not done yet");
 		return false;
 	}
@@ -292,4 +311,16 @@ bool ReplacedTexture::CopyLevelTo(int level, void *out, int rowPitch) {
 	}
 
 	return true;
+}
+
+const char *StateString(ReplacementState state) {
+	switch (state) {
+	case ReplacementState::UNINITIALIZED: return "UNINITIALIZED";
+	case ReplacementState::PREPARED: return "PREPARED";
+	case ReplacementState::PENDING: return "PENDING";
+	case ReplacementState::NOT_FOUND: return "NOT_FOUND";
+	case ReplacementState::ACTIVE: return "ACTIVE";
+	case ReplacementState::CANCEL_INIT: return "CANCEL_INIT";
+	default: return "N/A";
+	}
 }

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -54,6 +54,7 @@ private:
 	LimitedWaitable *waitable_;
 };
 
+// This can only return true if ACTIVE or NOT_FOUND.
 bool ReplacedTexture::IsReady(double budget) {
 	_assert_(vfs_ != nullptr);
 

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -22,6 +22,7 @@
 
 #include "Common/File/VFS/VFS.h"
 #include "Common/GPU/thin3d.h"
+#include "Common/Log.h"
 
 struct ReplacedLevelsCache;
 class TextureReplacer;
@@ -59,26 +60,36 @@ struct ReplacedTextureLevel {
 
 ReplacedImageType Identify(VFSBackend *vfs, VFSOpenFile *openFile, std::string *outMagic);
 
+enum class ReplacementState : uint32_t {
+	UNINITIALIZED,
+	PREPARED,  // We located the texture files but have not started the thread.
+	PENDING,
+	NOT_FOUND,  // Also used on error loading the images.
+	ACTIVE,
+	CANCEL_INIT,
+};
+
+const char *StateString(ReplacementState state);
+
 // These aren't actually all replaced, they can also represent a placeholder for a not-found
-// replacement.
+// replacement (state_ == NOT_FOUND).
 struct ReplacedTexture {
 	~ReplacedTexture();
 
-	inline bool Valid() const {
-		if (!initDone_)
-			return false;
-		return !levels_.empty();
+	inline ReplacementState State() const {
+		return state_;
 	}
 
-	inline bool IsInvalid() const {
-		if (!initDone_)
-			return false;
-		return levels_.empty();
+	void SetState(ReplacementState state) {
+		_dbg_assert_(state != state_);
+#ifdef _DEBUG
+		WARN_LOG(G3D, "Texture %s changed from %s to %s", logId_.c_str(), StateString(state_), StateString(state));
+#endif
+		state_ = state;
 	}
 
 	bool GetSize(int level, int &w, int &h) const {
-		if (!initDone_)
-			return false;
+		_dbg_assert_(State() == ReplacementState::ACTIVE);
 		if ((size_t)level < levels_.size()) {
 			w = levels_[level].w;
 			h = levels_[level].h;
@@ -88,18 +99,13 @@ struct ReplacedTexture {
 	}
 
 	int NumLevels() const {
-		if (!initDone_)
-			return 0;
+		_dbg_assert_(State() == ReplacementState::ACTIVE);
 		return (int)levels_.size();
 	}
 
 	Draw::DataFormat Format() const {
-		if (initDone_) {
-			return fmt;
-		} else {
-			// Shouldn't get here.
-			return Draw::DataFormat::UNDEFINED;
-		}
+		_dbg_assert_(State() == ReplacementState::ACTIVE);
+		return fmt;
 	}
 
 	u8 AlphaStatus() const {
@@ -114,8 +120,10 @@ protected:
 	void PrepareData(int level);
 	void PurgeIfOlder(double t);
 
+	std::string logId_;
+
 	std::vector<ReplacedTextureLevel> levels_;
-	ReplacedLevelsCache *levelData_;
+	ReplacedLevelsCache *levelData_ = nullptr;
 
 	ReplacedTextureAlpha alphaStatus_ = ReplacedTextureAlpha::UNKNOWN;
 	double lastUsed_ = 0.0;
@@ -123,9 +131,7 @@ protected:
 	std::mutex mutex_;
 	Draw::DataFormat fmt = Draw::DataFormat::UNDEFINED;  // NOTE: Right now, the only supported format is Draw::DataFormat::R8G8B8A8_UNORM.
 
-	bool cancelPrepare_ = false;
-	bool initDone_ = false;
-	bool prepareDone_ = false;
+	ReplacementState state_ = ReplacementState::UNINITIALIZED;
 
 	VFSBackend *vfs_ = nullptr;
 

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -83,19 +83,16 @@ struct ReplacedTexture {
 	void SetState(ReplacementState state) {
 		_dbg_assert_(state != state_);
 #ifdef _DEBUG
-		WARN_LOG(G3D, "Texture %s changed from %s to %s", logId_.c_str(), StateString(state_), StateString(state));
+		// WARN_LOG(G3D, "Texture %s changed state from %s to %s", logId_.c_str(), StateString(state_), StateString(state));
 #endif
 		state_ = state;
 	}
 
-	bool GetSize(int level, int &w, int &h) const {
+	void GetSize(int level, int *w, int *h) const {
 		_dbg_assert_(State() == ReplacementState::ACTIVE);
-		if ((size_t)level < levels_.size()) {
-			w = levels_[level].w;
-			h = levels_[level].h;
-			return true;
-		}
-		return false;
+		_dbg_assert_(level < levels_.size());
+		*w = levels_[level].w;
+		*h = levels_[level].h;
 	}
 
 	int NumLevels() const {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2843,6 +2843,7 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 			replacedInfo.addr = entry->addr;
 			replacedInfo.isFinal = (entry->status & TexCacheEntry::STATUS_TO_SCALE) == 0;
 			replacedInfo.scaleFactor = plan.scaleFactor;
+			replacedInfo.isVideo = plan.isVideo;
 			replacedInfo.fmt = Draw::DataFormat::R8G8B8A8_UNORM;
 			plan.saveTexture = replacer_.WillSave(replacedInfo);
 		}

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1514,7 +1514,7 @@ ReplacedTexture *TextureCacheCommon::FindReplacement(TexCacheEntry *entry, int &
 		return nullptr;
 	}
 
-	if (entry->status & TexCacheEntry::STATUS_VIDEO) {
+	if ((entry->status & TexCacheEntry::STATUS_VIDEO) && replacer_.AllowVideo()) {
 		return nullptr;
 	}
 

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -292,7 +292,8 @@ struct BuildTexturePlan {
 	bool decodeToClut8;
 
 	void GetMipSize(int level, int *w, int *h) const {
-		if (replaceValid && replaced->GetSize(level, *w, *h)) {
+		if (replaceValid) {
+			replaced->GetSize(level, w, h);
 			return;
 		}
 		if (depth == 1) {

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -491,6 +491,8 @@ ReplacedTexture *TextureReplacer::FindReplacement(u64 cachekey, u32 hash, int w,
 	if (budget > 0.0) {
 		_dbg_assert_(result->State() == ReplacementState::UNINITIALIZED);
 		PopulateReplacement(result, cachekey, hash, w, h);
+	} else {
+		// WARN_LOG(G3D, "Postponing preparing texture (%dx%d)", w, h);
 	}
 	cache_[replacementKey] = result;
 	return result;
@@ -510,7 +512,7 @@ void TextureReplacer::PopulateReplacement(ReplacedTexture *texture, u64 cachekey
 	const std::string hashfiles = LookupHashFile(cachekey, hash, &foundReplacement, &ignored);
 
 	if (!foundReplacement || ignored) {
-		WARN_LOG(G3D, "Not found/ignored: %s (%d, %d)", hashfiles.c_str(), (int)foundReplacement, (int)ignored);
+		// WARN_LOG(G3D, "Not found/ignored: %s (%d, %d)", hashfiles.c_str(), (int)foundReplacement, (int)ignored);
 		// nothing to do?
 		texture->SetState(ReplacementState::NOT_FOUND);
 		return;

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -137,7 +137,7 @@ protected:
 	void ParseReduceHashRange(const std::string& key, const std::string& value);
 	bool LookupHashRange(u32 addr, int &w, int &h);
 	float LookupReduceHashRange(int& w, int& h);
-	std::string LookupHashFile(u64 cachekey, u32 hash, bool *foundReplacement, bool *ignored);
+	std::string LookupHashFile(u64 cachekey, u32 hash, bool *foundAlias, bool *ignored);
 	std::string HashName(u64 cachekey, u32 hash, int level);
 	void PopulateReplacement(ReplacedTexture *result, u64 cachekey, u32 hash, int w, int h);
 	bool PopulateLevel(ReplacedTextureLevel &level, bool ignoreError);

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -106,9 +106,8 @@ public:
 	void Init();
 	void NotifyConfigChanged();
 
-	inline bool Enabled() {
-		return enabled_;
-	}
+	bool Enabled() const { return enabled_; }
+	bool AllowVideo() const { return allowVideo_; }
 
 	u32 ComputeHash(u32 addr, int bufw, int w, int h, GETextureFormat fmt, u16 maxSeenV);
 

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -153,6 +153,7 @@ protected:
 	bool ignoreMipmap_ = false;
 	std::string gameID_;
 	Path basePath_;
+	Path newTextureDir_;
 	ReplacedTextureHash hash_ = ReplacedTextureHash::QUICK;
 
 	VFSBackend *vfs_ = nullptr;

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -246,7 +246,8 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 	int th = plan.createH;
 
 	Draw::DataFormat dstFmt = GetDestFormat(GETextureFormat(entry->format), gstate.getClutPaletteFormat());
-	if (plan.replaced && plan.replaced->GetSize(plan.baseLevelSrc, tw, th)) {
+	if (plan.replaceValid) {
+		plan.replaced->GetSize(plan.baseLevelSrc, &tw, &th);
 		dstFmt = plan.replaced->Format();
 	} else if (plan.scaleFactor > 1 || plan.saveTexture) {
 		dstFmt = Draw::DataFormat::R8G8B8A8_UNORM;


### PR DESCRIPTION
To make it easier to see the actual state a replaced texture is in, and to track it with logging.