### PR TITLE
TextureReplacer code cleanup: Move Populate to ReplacedTexture

### DIFF
--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -77,7 +77,7 @@ bool ReplacedTexture::IsReady(double budget) {
 	case ReplacementState::CANCEL_INIT:
 	case ReplacementState::PENDING:
 		return false;
-	case ReplacementState::PREPARED:
+	case ReplacementState::POPULATED:
 		// We're gonna need to spawn a task.
 		break;
 	}
@@ -257,7 +257,7 @@ void ReplacedTexture::PurgeIfOlder(double t) {
 		std::lock_guard<std::mutex> guard(levelData_->lock);
 		levelData_->data.clear();
 		// This means we have to reload.  If we never purge any, there's no need.
-		SetState(ReplacementState::PREPARED);
+		SetState(ReplacementState::POPULATED);
 	}
 }
 
@@ -319,7 +319,7 @@ bool ReplacedTexture::CopyLevelTo(int level, void *out, int rowPitch) {
 const char *StateString(ReplacementState state) {
 	switch (state) {
 	case ReplacementState::UNINITIALIZED: return "UNINITIALIZED";
-	case ReplacementState::PREPARED: return "PREPARED";
+	case ReplacementState::POPULATED: return "PREPARED";
 	case ReplacementState::PENDING: return "PENDING";
 	case ReplacementState::NOT_FOUND: return "NOT_FOUND";
 	case ReplacementState::ACTIVE: return "ACTIVE";

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -101,6 +101,55 @@ bool ReplacedTexture::IsReady(double budget) {
 	return false;
 }
 
+bool ReplacedTexture::PopulateLevel(ReplacedTextureLevel &level, bool ignoreError) {
+	bool good = false;
+
+	if (!level.fileRef) {
+		if (!ignoreError)
+			ERROR_LOG(G3D, "Error opening replacement texture file '%s' in textures.zip", level.file.c_str());
+		return false;
+	}
+
+	size_t fileSize;
+	VFSOpenFile *file = vfs_->OpenFileForRead(level.fileRef, &fileSize);
+	if (!file) {
+		return false;
+	}
+
+	std::string magic;
+	auto imageType = Identify(vfs_, file, &magic);
+
+	if (imageType == ReplacedImageType::ZIM) {
+		uint32_t ignore = 0;
+		struct ZimHeader {
+			uint32_t magic;
+			uint32_t w;
+			uint32_t h;
+			uint32_t flags;
+		} header;
+		good = vfs_->Read(file, &header, sizeof(header)) == sizeof(header);
+		level.w = header.w;
+		level.h = header.h;
+		good = (header.flags & ZIM_FORMAT_MASK) == ZIM_RGBA8888;
+	} else if (imageType == ReplacedImageType::PNG) {
+		PNGHeaderPeek headerPeek;
+		good = vfs_->Read(file, &headerPeek, sizeof(headerPeek)) == sizeof(headerPeek);
+		if (good && headerPeek.IsValidPNGHeader()) {
+			level.w = headerPeek.Width();
+			level.h = headerPeek.Height();
+			good = true;
+		} else {
+			ERROR_LOG(G3D, "Could not get PNG dimensions: %s (zip)", level.file.ToVisualString().c_str());
+			good = false;
+		}
+	} else {
+		ERROR_LOG(G3D, "Could not load texture replacement info: %s - unsupported format %s", level.file.ToVisualString().c_str(), magic.c_str());
+	}
+	vfs_->CloseFile(file);
+
+	return good;
+}
+
 void ReplacedTexture::Prepare(VFSBackend *vfs) {
 	std::unique_lock<std::mutex> lock(mutex_);
 	this->vfs_ = vfs;

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -71,6 +71,8 @@ enum class ReplacementState : uint32_t {
 
 const char *StateString(ReplacementState state);
 
+struct ReplacementDesc;
+
 // These aren't actually all replaced, they can also represent a placeholder for a not-found
 // replacement (state_ == NOT_FOUND).
 struct ReplacedTexture {
@@ -112,14 +114,15 @@ struct ReplacedTexture {
 	bool IsReady(double budget);
 	bool CopyLevelTo(int level, void *out, int rowPitch);
 
-	bool PopulateLevel(ReplacedTextureLevel &level, bool ignoreError);
+	void FinishPopulate(const ReplacementDesc &desc);
+	std::string logId_;
 
-protected:
+private:
 	void Prepare(VFSBackend *vfs);
 	void PrepareData(int level);
 	void PurgeIfOlder(double t);
 
-	std::string logId_;
+	bool PopulateLevel(ReplacedTextureLevel & level, bool ignoreError);
 
 	std::vector<ReplacedTextureLevel> levels_;
 	ReplacedLevelsCache *levelData_ = nullptr;

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -112,6 +112,8 @@ struct ReplacedTexture {
 	bool IsReady(double budget);
 	bool CopyLevelTo(int level, void *out, int rowPitch);
 
+	bool PopulateLevel(ReplacedTextureLevel &level, bool ignoreError);
+
 protected:
 	void Prepare(VFSBackend *vfs);
 	void PrepareData(int level);

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -62,7 +62,7 @@ ReplacedImageType Identify(VFSBackend *vfs, VFSOpenFile *openFile, std::string *
 
 enum class ReplacementState : uint32_t {
 	UNINITIALIZED,
-	PREPARED,  // We located the texture files but have not started the thread.
+	POPULATED,  // We located the texture files but have not started the thread.
 	PENDING,
 	NOT_FOUND,  // Also used on error loading the images.
 	ACTIVE,

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -47,6 +47,8 @@ enum class ReplacedImageType {
 	INVALID,
 };
 
+static const int MAX_REPLACEMENT_MIP_LEVELS = 12;  // 12 should be plenty, 8 is the max mip levels supported by the PSP.
+
 // Metadata about a given texture level.
 struct ReplacedTextureLevel {
 	int w = 0;
@@ -71,7 +73,20 @@ enum class ReplacementState : uint32_t {
 
 const char *StateString(ReplacementState state);
 
-struct ReplacementDesc;
+struct ReplacementDesc {
+	int newW;
+	int newH;
+	uint64_t cachekey;
+	uint32_t hash;
+	int w;
+	int h;
+	std::string hashfiles;
+	Path basePath;
+	bool foundAlias;
+	std::vector<std::string> filenames;
+	std::string logId;
+	ReplacedLevelsCache *cache;
+};
 
 // These aren't actually all replaced, they can also represent a placeholder for a not-found
 // replacement (state_ == NOT_FOUND).

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1544,7 +1544,7 @@ ReplacedTexture *TextureCacheCommon::FindReplacement(TexCacheEntry *entry, int &
 	}
 
 	switch (replaced->State()) {
-	case ReplacementState::PREPARED:
+	case ReplacementState::POPULATED:
 	case ReplacementState::PENDING:
 	case ReplacementState::UNINITIALIZED:
 		// Make sure we keep polling.

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -561,7 +561,7 @@ void TextureReplacer::PopulateReplacement(ReplacedTexture *texture, u64 cachekey
 		bool good;
 
 		level.fileRef = fileRef;
-		good = PopulateLevel(level, false);
+		good = texture->PopulateLevel(level, false);
 
 		// We pad files that have been hashrange'd so they are the same texture size.
 		level.w = (level.w * w) / newW;
@@ -592,55 +592,6 @@ void TextureReplacer::PopulateReplacement(ReplacedTexture *texture, u64 cachekey
 	// Populate the data pointer.
 	texture->levelData_ = &levelCache_[hashfiles];
 	texture->SetState(ReplacementState::POPULATED);
-}
-
-bool TextureReplacer::PopulateLevel(ReplacedTextureLevel &level, bool ignoreError) {
-	bool good = false;
-
-	if (!level.fileRef) {
-		if (!ignoreError)
-			ERROR_LOG(G3D, "Error opening replacement texture file '%s' in textures.zip", level.file.c_str());
-		return false;
-	}
-
-	size_t fileSize;
-	VFSOpenFile *file = vfs_->OpenFileForRead(level.fileRef, &fileSize);
-	if (!file) {
-		return false;
-	}
-
-	std::string magic;
-	auto imageType = Identify(vfs_, file, &magic);
-
-	if (imageType == ReplacedImageType::ZIM) {
-		uint32_t ignore = 0;
-		struct ZimHeader {
-			uint32_t magic;
-			uint32_t w;
-			uint32_t h;
-			uint32_t flags;
-		} header;
-		good = vfs_->Read(file, &header, sizeof(header)) == sizeof(header);
-		level.w = header.w;
-		level.h = header.h;
-		good = (header.flags & ZIM_FORMAT_MASK) == ZIM_RGBA8888;
-	} else if (imageType == ReplacedImageType::PNG) {
-		PNGHeaderPeek headerPeek;
-		good = vfs_->Read(file, &headerPeek, sizeof(headerPeek)) == sizeof(headerPeek);
-		if (good && headerPeek.IsValidPNGHeader()) {
-			level.w = headerPeek.Width();
-			level.h = headerPeek.Height();
-			good = true;
-		} else {
-			ERROR_LOG(G3D, "Could not get PNG dimensions: %s (zip)", level.file.ToVisualString().c_str());
-			good = false;
-		}
-	} else {
-		ERROR_LOG(G3D, "Could not load texture replacement info: %s - unsupported format %s", level.file.ToVisualString().c_str(), magic.c_str());
-	}
-	vfs_->CloseFile(file);
-
-	return good;
 }
 
 static bool WriteTextureToPNG(png_imagep image, const Path &filename, int convert_to_8bit, const void *buffer, png_int_32 row_stride, const void *colormap) {

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -498,19 +498,41 @@ ReplacedTexture *TextureReplacer::FindReplacement(u64 cachekey, u32 hash, int w,
 	return result;
 }
 
+struct ReplacementDesc {
+	int newW;
+	int newH;
+	u64 cachekey;
+	u32 hash;
+	int w;
+	int h;
+	std::string hashfiles;
+	Path basePath;
+	bool foundAlias;
+	std::vector<std::string> filenames;
+	std::string logId;
+	ReplacedLevelsCache *cache;
+};
+
 void TextureReplacer::PopulateReplacement(ReplacedTexture *texture, u64 cachekey, u32 hash, int w, int h) {
-	int newW = w;
-	int newH = h;
-	LookupHashRange(cachekey >> 32, newW, newH);
+	ReplacementDesc desc;
+	desc.newW = w;
+	desc.newH = h;
+	desc.w = w;
+	desc.h = h;
+	desc.cachekey = cachekey;
+	desc.hash = hash;
+	desc.basePath = basePath_;
+	LookupHashRange(cachekey >> 32, desc.newW, desc.newH);
 
 	if (ignoreAddress_) {
 		cachekey = cachekey & 0xFFFFFFFFULL;
 	}
 
-	bool foundAlias = false;
+	desc.foundAlias = false;
 	bool ignored = false;
-	std::string hashfiles = LookupHashFile(cachekey, hash, &foundAlias, &ignored);
+	desc.hashfiles = LookupHashFile(cachekey, hash, &desc.foundAlias, &ignored);
 
+	// Early-out for ignored textures, let's not bother even starting a thread task.
 	if (ignored) {
 		// WARN_LOG(G3D, "Not found/ignored: %s (%d, %d)", hashfiles.c_str(), (int)foundReplacement, (int)ignored);
 		// nothing to do?
@@ -518,32 +540,41 @@ void TextureReplacer::PopulateReplacement(ReplacedTexture *texture, u64 cachekey
 		return;
 	}
 
-	std::vector<std::string> filenames;
-
-	if (!foundAlias) {
+	if (!desc.foundAlias) {
 		// We'll just need to generate the names for each level.
 		// By default, we look for png since that's also what's dumped.
 		// For other file formats, use the ini to create aliases.
-		filenames.resize(MAX_MIP_LEVELS);
-		for (int level = 0; level < filenames.size(); level++) {
-			filenames[level] = HashName(cachekey, hash, level) + ".png";
+		desc.filenames.resize(MAX_MIP_LEVELS);
+		for (int level = 0; level < desc.filenames.size(); level++) {
+			desc.filenames[level] = TextureReplacer::HashName(desc.cachekey, desc.hash, level) + ".png";
 		}
-		texture->logId_ = filenames[0];
-		hashfiles = filenames[0];  // This is used as the key in the data cache.
+		desc.logId = desc.filenames[0];
+		desc.hashfiles = desc.filenames[0];  // This is used as the key in the data cache.
 	} else {
-		texture->logId_ = hashfiles;
-		SplitString(hashfiles, '|', filenames);
+		desc.logId = desc.hashfiles;
+		SplitString(desc.hashfiles, '|', desc.filenames);
 	}
 
-	for (int i = 0; i < std::min(MAX_MIP_LEVELS, (int)filenames.size()); ++i) {
-		if (filenames[i].empty()) {
+	desc.cache = &levelCache_[desc.hashfiles];
+
+	texture->FinishPopulate(desc);
+}
+
+void ReplacedTexture::FinishPopulate(const ReplacementDesc &desc) {
+	logId_ = desc.logId;
+	levelData_ = desc.cache;
+
+	// The rest can be done on the thread.
+
+	for (int i = 0; i < std::min(MAX_MIP_LEVELS, (int)desc.filenames.size()); ++i) {
+		if (desc.filenames[i].empty()) {
 			// Out of valid mip levels.  Bail out.
 			break;
 		}
 
-		const Path filename = basePath_ / filenames[i];
+		const Path filename = desc.basePath / desc.filenames[i];
 
-		VFSFileReference *fileRef = vfs_->GetFile(filenames[i].c_str());
+		VFSFileReference *fileRef = vfs_->GetFile(desc.filenames[i].c_str());
 		if (!fileRef) {
 			// If the file doesn't exist, let's just bail immediately here.
 			break;
@@ -555,43 +586,42 @@ void TextureReplacer::PopulateReplacement(ReplacedTexture *texture, u64 cachekey
 		level.file = filename;
 
 		if (i == 0) {
-			texture->fmt = Draw::DataFormat::R8G8B8A8_UNORM;
+			fmt = Draw::DataFormat::R8G8B8A8_UNORM;
 		}
 
 		bool good;
 
 		level.fileRef = fileRef;
-		good = texture->PopulateLevel(level, false);
+		good = PopulateLevel(level, false);
 
 		// We pad files that have been hashrange'd so they are the same texture size.
-		level.w = (level.w * w) / newW;
-		level.h = (level.h * h) / newH;
+		level.w = (level.w * desc.w) / desc.newW;
+		level.h = (level.h * desc.h) / desc.newH;
 
 		if (good && i != 0) {
 			// Check that the mipmap size is correct.  Can't load mips of the wrong size.
-			if (level.w != (texture->levels_[0].w >> i) || level.h != (texture->levels_[0].h >> i)) {
-				 WARN_LOG(G3D, "Replacement mipmap invalid: size=%dx%d, expected=%dx%d (level %d, '%s')", level.w, level.h, texture->levels_[0].w >> i, texture->levels_[0].h >> i, i, filename.c_str());
+			if (level.w != (levels_[0].w >> i) || level.h != (levels_[0].h >> i)) {
+				 WARN_LOG(G3D, "Replacement mipmap invalid: size=%dx%d, expected=%dx%d (level %d, '%s')", level.w, level.h, levels_[0].w >> i, levels_[0].h >> i, i, filename.c_str());
 				 good = false;
 			}
 		}
 
 		if (good)
-			texture->levels_.push_back(level);
+			levels_.push_back(level);
 		// Otherwise, we're done loading mips (bad PNG or bad size, either way.)
 		else
 			break;
 	}
 
-	if (texture->levels_.empty()) {
+	if (levels_.empty()) {
 		// Bad.
-		texture->SetState(ReplacementState::NOT_FOUND);
-		texture->levelData_ = nullptr;
+		SetState(ReplacementState::NOT_FOUND);
+		levelData_ = nullptr;
 		return;
 	}
 
 	// Populate the data pointer.
-	texture->levelData_ = &levelCache_[hashfiles];
-	texture->SetState(ReplacementState::POPULATED);
+	SetState(ReplacementState::POPULATED);
 }
 
 static bool WriteTextureToPNG(png_imagep image, const Path &filename, int convert_to_8bit, const void *buffer, png_int_32 row_stride, const void *colormap) {

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -591,7 +591,7 @@ void TextureReplacer::PopulateReplacement(ReplacedTexture *texture, u64 cachekey
 
 	// Populate the data pointer.
 	texture->levelData_ = &levelCache_[hashfiles];
-	texture->SetState(ReplacementState::PREPARED);
+	texture->SetState(ReplacementState::POPULATED);
 }
 
 bool TextureReplacer::PopulateLevel(ReplacedTextureLevel &level, bool ignoreError) {

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -129,6 +129,8 @@ public:
 	int GetNumTrackedTextures() const { return (int)cache_.size(); }
 	int GetNumCachedReplacedTextures() const { return (int)levelCache_.size(); }
 
+	static std::string HashName(u64 cachekey, u32 hash, int level);
+
 protected:
 	bool LoadIni();
 	bool LoadIniValues(IniFile &ini, bool isOverride = false);
@@ -138,7 +140,6 @@ protected:
 	bool LookupHashRange(u32 addr, int &w, int &h);
 	float LookupReduceHashRange(int& w, int& h);
 	std::string LookupHashFile(u64 cachekey, u32 hash, bool *foundAlias, bool *ignored);
-	std::string HashName(u64 cachekey, u32 hash, int level);
 	void PopulateReplacement(ReplacedTexture *result, u64 cachekey, u32 hash, int w, int h);
 
 	bool enabled_ = false;

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -140,7 +140,6 @@ protected:
 	std::string LookupHashFile(u64 cachekey, u32 hash, bool *foundAlias, bool *ignored);
 	std::string HashName(u64 cachekey, u32 hash, int level);
 	void PopulateReplacement(ReplacedTexture *result, u64 cachekey, u32 hash, int w, int h);
-	bool PopulateLevel(ReplacedTextureLevel &level, bool ignoreError);
 
 	bool enabled_ = false;
 	bool allowVideo_ = false;


### PR DESCRIPTION
Just preparation, last step before moving it to the thread and combining it with Prepare.

Doing that will simplify texture loading and finally get _all_ the runtime replacement I/O off the main thread, for less stuttering.