### PR TITLE
Replacement: Do all I/O on threaded tasks

### DIFF
--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -101,21 +101,21 @@ bool ReplacedTexture::IsReady(double budget) {
 	return false;
 }
 
-void ReplacedTexture::FinishPopulate(const ReplacementDesc &desc) {
-	logId_ = desc.logId;
-	levelData_ = desc.cache;
+void ReplacedTexture::FinishPopulate(ReplacementDesc *desc) {
+	logId_ = desc->logId;
+	levelData_ = desc->cache;
 
 	// TODO: The rest can be done on the thread.
 
-	for (int i = 0; i < std::min(MAX_REPLACEMENT_MIP_LEVELS, (int)desc.filenames.size()); ++i) {
-		if (desc.filenames[i].empty()) {
+	for (int i = 0; i < std::min(MAX_REPLACEMENT_MIP_LEVELS, (int)desc->filenames.size()); ++i) {
+		if (desc->filenames[i].empty()) {
 			// Out of valid mip levels.  Bail out.
 			break;
 		}
 
-		const Path filename = desc.basePath / desc.filenames[i];
+		const Path filename = desc->basePath / desc->filenames[i];
 
-		VFSFileReference *fileRef = vfs_->GetFile(desc.filenames[i].c_str());
+		VFSFileReference *fileRef = vfs_->GetFile(desc->filenames[i].c_str());
 		if (!fileRef) {
 			// If the file doesn't exist, let's just bail immediately here.
 			break;
@@ -136,8 +136,8 @@ void ReplacedTexture::FinishPopulate(const ReplacementDesc &desc) {
 		good = PopulateLevel(level, false);
 
 		// We pad files that have been hashrange'd so they are the same texture size.
-		level.w = (level.w * desc.w) / desc.newW;
-		level.h = (level.h * desc.h) / desc.newH;
+		level.w = (level.w * desc->w) / desc->newW;
+		level.h = (level.h * desc->h) / desc->newH;
 
 		if (good && i != 0) {
 			// Check that the mipmap size is correct.  Can't load mips of the wrong size.
@@ -153,6 +153,8 @@ void ReplacedTexture::FinishPopulate(const ReplacementDesc &desc) {
 		else
 			break;
 	}
+
+	delete desc;
 
 	if (levels_.empty()) {
 		// Bad.

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -134,7 +134,7 @@ struct ReplacedTexture {
 
 private:
 	void Prepare(VFSBackend *vfs);
-	void PrepareData(int level);
+	bool PrepareData(const ReplacedTextureLevel &info, int level);
 	void PurgeIfOlder(double t);
 
 	bool PopulateLevel(ReplacedTextureLevel & level, bool ignoreError);

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -129,7 +129,7 @@ struct ReplacedTexture {
 	bool IsReady(double budget);
 	bool CopyLevelTo(int level, void *out, int rowPitch);
 
-	void FinishPopulate(const ReplacementDesc &desc);
+	void FinishPopulate(ReplacementDesc *desc);
 	std::string logId_;
 
 private:
@@ -148,7 +148,7 @@ private:
 	std::mutex mutex_;
 	Draw::DataFormat fmt = Draw::DataFormat::UNDEFINED;  // NOTE: Right now, the only supported format is Draw::DataFormat::R8G8B8A8_UNORM.
 
-	ReplacementState state_ = ReplacementState::UNINITIALIZED;
+	std::atomic<ReplacementState> state_ = ReplacementState::UNINITIALIZED;
 
 	VFSBackend *vfs_ = nullptr;
 

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -134,10 +134,8 @@ struct ReplacedTexture {
 
 private:
 	void Prepare(VFSBackend *vfs);
-	bool PrepareData(const ReplacedTextureLevel &info, int level);
+	bool LoadLevelData(ReplacedTextureLevel &info, int level);
 	void PurgeIfOlder(double t);
-
-	bool PopulateLevel(ReplacedTextureLevel &level, int mipLevel, bool ignoreError);
 
 	std::vector<ReplacedTextureLevel> levels_;
 	ReplacedLevelsCache *levelData_ = nullptr;

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -151,6 +151,7 @@ private:
 	std::atomic<ReplacementState> state_ = ReplacementState::UNINITIALIZED;
 
 	VFSBackend *vfs_ = nullptr;
+	ReplacementDesc *desc_ = nullptr;
 
 	friend class TextureReplacer;
 	friend class ReplacedTextureTask;

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -137,7 +137,7 @@ private:
 	bool PrepareData(const ReplacedTextureLevel &info, int level);
 	void PurgeIfOlder(double t);
 
-	bool PopulateLevel(ReplacedTextureLevel & level, bool ignoreError);
+	bool PopulateLevel(ReplacedTextureLevel &level, int mipLevel, bool ignoreError);
 
 	std::vector<ReplacedTextureLevel> levels_;
 	ReplacedLevelsCache *levelData_ = nullptr;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2829,8 +2829,9 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 	if (plan.replaceValid) {
 		// We're replacing, so we won't scale.
 		plan.scaleFactor = 1;
+		// We're ignoring how many levels were specified - instead we just load all available from the replacer.
 		plan.levelsToLoad = plan.replaced->NumLevels();
-		plan.levelsToCreate = std::min(plan.levelsToLoad, plan.levelsToCreate);
+		plan.levelsToCreate = plan.levelsToLoad;  // Or more, if we wanted to generate.
 		plan.badMipSizes = false;
 		// But, we still need to create the texture at a larger size.
 		plan.replaced->GetSize(0, &plan.createW, &plan.createH);

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -498,23 +498,24 @@ ReplacedTexture *TextureReplacer::FindReplacement(u64 cachekey, u32 hash, int w,
 }
 
 void TextureReplacer::PopulateReplacement(ReplacedTexture *texture, u64 cachekey, u32 hash, int w, int h) {
-	ReplacementDesc desc;
-	desc.newW = w;
-	desc.newH = h;
-	desc.w = w;
-	desc.h = h;
-	desc.cachekey = cachekey;
-	desc.hash = hash;
-	desc.basePath = basePath_;
-	LookupHashRange(cachekey >> 32, desc.newW, desc.newH);
+	// We pass this to a thread, so can't keep it on the stack.
+	ReplacementDesc *desc = new ReplacementDesc();
+	desc->newW = w;
+	desc->newH = h;
+	desc->w = w;
+	desc->h = h;
+	desc->cachekey = cachekey;
+	desc->hash = hash;
+	desc->basePath = basePath_;
+	LookupHashRange(cachekey >> 32, desc->newW, desc->newH);
 
 	if (ignoreAddress_) {
 		cachekey = cachekey & 0xFFFFFFFFULL;
 	}
 
-	desc.foundAlias = false;
+	desc->foundAlias = false;
 	bool ignored = false;
-	desc.hashfiles = LookupHashFile(cachekey, hash, &desc.foundAlias, &ignored);
+	desc->hashfiles = LookupHashFile(cachekey, hash, &desc->foundAlias, &ignored);
 
 	// Early-out for ignored textures, let's not bother even starting a thread task.
 	if (ignored) {
@@ -524,22 +525,22 @@ void TextureReplacer::PopulateReplacement(ReplacedTexture *texture, u64 cachekey
 		return;
 	}
 
-	if (!desc.foundAlias) {
+	if (!desc->foundAlias) {
 		// We'll just need to generate the names for each level.
 		// By default, we look for png since that's also what's dumped.
 		// For other file formats, use the ini to create aliases.
-		desc.filenames.resize(MAX_REPLACEMENT_MIP_LEVELS);
-		for (int level = 0; level < desc.filenames.size(); level++) {
-			desc.filenames[level] = TextureReplacer::HashName(desc.cachekey, desc.hash, level) + ".png";
+		desc->filenames.resize(MAX_REPLACEMENT_MIP_LEVELS);
+		for (int level = 0; level < desc->filenames.size(); level++) {
+			desc->filenames[level] = TextureReplacer::HashName(desc->cachekey, desc->hash, level) + ".png";
 		}
-		desc.logId = desc.filenames[0];
-		desc.hashfiles = desc.filenames[0];  // This is used as the key in the data cache.
+		desc->logId = desc->filenames[0];
+		desc->hashfiles = desc->filenames[0];  // This is used as the key in the data cache.
 	} else {
-		desc.logId = desc.hashfiles;
-		SplitString(desc.hashfiles, '|', desc.filenames);
+		desc->logId = desc->hashfiles;
+		SplitString(desc->hashfiles, '|', desc->filenames);
 	}
 
-	desc.cache = &levelCache_[desc.hashfiles];
+	desc->cache = &levelCache_[desc->hashfiles];
 
 	texture->FinishPopulate(desc);
 }

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -191,6 +191,13 @@ bool TextureReplacer::LoadIni() {
 	}
 
 	vfs_ = dir;
+
+	// If we have stuff loaded from before, need to update the vfs pointers to avoid
+	// crash on exit. The actual problem is that we tend to call LoadIni a little too much...
+	for (auto &repl : cache_) {
+		repl.second->vfs_ = vfs_;
+	}
+
 	INFO_LOG(G3D, "Texture pack activated from '%s'", basePath_.c_str());
 
 	// The ini doesn't have to exist for the texture directory or zip to be valid.


### PR DESCRIPTION
This should reduce I/O stutter during texture replacement considerably (especially on slow I/O like on Android 11+), no more I/O is done on the main thread by the replacer anymore except at startup.

~~We still open each file twice, I'll try to merge the Populate/Prepare steps later to avoid it.~~ Never mind, went ahead and merged them, now we only open each file once. We still first detect size, then pad the size if needed, rewind and read again.

I believe decimation of the "level cache" can still race against texture loading in some interesting ways. Need to look into that later.