### PR TITLE
More tex replacement work

### DIFF
--- a/Common/GPU/OpenGL/DataFormatGL.cpp
+++ b/Common/GPU/OpenGL/DataFormatGL.cpp
@@ -93,7 +93,18 @@ bool Thin3DFormatToGLFormatAndType(DataFormat fmt, GLuint &internalFormat, GLuin
 		type = GL_FLOAT;
 		alignment = 8;
 		break;
-
+	case DataFormat::BC2_UNORM_BLOCK:
+		internalFormat = GL_COMPRESSED_RGBA_S3TC_DXT3_EXT;
+		format = GL_RGBA;
+		type = GL_FLOAT;
+		alignment = 16;
+		break;
+	case DataFormat::BC3_UNORM_BLOCK:
+		internalFormat = GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
+		format = GL_RGBA;
+		type = GL_FLOAT;
+		alignment = 16;
+		break;
 	case DataFormat::BC7_UNORM_BLOCK:
 		internalFormat = GL_COMPRESSED_RGBA_BPTC_UNORM;
 		format = GL_RGBA;

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -88,18 +88,24 @@ private:
 bool ReplacedTexture::IsReady(double budget) {
 	_assert_(vfs_ != nullptr);
 
+	double now = time_now_d();
+
 	switch (State()) {
 	case ReplacementState::ACTIVE:
 	case ReplacementState::NOT_FOUND:
 		if (threadWaitable_) {
 			if (!threadWaitable_->WaitFor(budget)) {
+				lastUsed_ = now;
 				return false;
 			}
 			// Successfully waited! Can get rid of it.
 			threadWaitable_->WaitAndRelease();
 			threadWaitable_ = nullptr;
+			if (levelData_) {
+				levelData_->lastUsed = now;
+			}
 		}
-		lastUsed_ = time_now_d();
+		lastUsed_ = now;
 		return true;
 	case ReplacementState::UNINITIALIZED:
 		// _dbg_assert_(false);
@@ -112,7 +118,7 @@ bool ReplacedTexture::IsReady(double budget) {
 		break;
 	}
 
-	lastUsed_ = time_now_d();
+	lastUsed_ = now;
 
 	// Let's not even start a new texture if we're already behind.
 	if (budget < 0.0)

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1514,7 +1514,7 @@ ReplacedTexture *TextureCacheCommon::FindReplacement(TexCacheEntry *entry, int &
 		return nullptr;
 	}
 
-	if ((entry->status & TexCacheEntry::STATUS_VIDEO) && replacer_.AllowVideo()) {
+	if ((entry->status & TexCacheEntry::STATUS_VIDEO) && !replacer_.AllowVideo()) {
 		return nullptr;
 	}
 

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -216,8 +216,6 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, bool isOverride) {
 
 	bool filenameWarning = false;
 	if (ini.HasSection("hashes")) {
-		aliases_.clear();
-
 		auto hashes = ini.GetOrCreateSection("hashes")->ToMap();
 		// Format: hashname = filename.png
 		bool checkFilenames = g_Config.bSaveNewTextures && !g_Config.bIgnoreTextureFilenames && !vfsIsZip_;
@@ -693,6 +691,9 @@ void TextureReplacer::NotifyTextureDecoded(const ReplacedTextureDecodeInfo &repl
 #endif
 	if (slash != hashfile.npos) {
 		// Does this ever happen?
+		// Answer: An alias could be used to save a texture in a subfolder of newTextureDir_
+		// (i.e. if you had the hash and purged out your pngs to redump them), although I guess this usage is probably uncommon.  - unknown
+
 		// Create any directory structure as needed.
 		task->saveDirectory = newTextureDir_ / hashfile.substr(0, slash);
 		task->createSaveDirectory = true;

--- a/GPU/D3D11/TextureCacheD3D11.h
+++ b/GPU/D3D11/TextureCacheD3D11.h
@@ -83,8 +83,6 @@ private:
 
 	ID3D11ShaderResourceView *lastBoundTexture;
 	ID3D11Buffer *depalConstants_;
-
-	FramebufferManagerD3D11 *framebufferManagerD3D11_;
 };
 
 DXGI_FORMAT GetClutDestFormatD3D11(GEPaletteFormat format);


### PR DESCRIPTION
Address feedback from previous PR #17089 (thanks Unknown).

Additionally, implement BC compressed texture support in D3D11. Though, need to do some trickery to turn off R/B swap in the shader for those..

Also implement it for OpenGL, though without any of the required feature checks. Works on PC though.

In D3D9 later, we can get BC1/2/3 support, and in ES 2.0 we'll be able to get at least ETC2. Those are enough to support basis but not UASTC. I suppose we could go full software decode to RGBA as a fallback.

Fixes part of #17092 .