### PR TITLE
Change BGRA to be a texture-specific flag. Fixes R/B swap in DDS textures in D3D11.

### DIFF
--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -254,7 +254,7 @@ bool ReplacedTexture::LoadLevelData(ReplacedTextureLevel &level, int mipLevel, D
 		u32 format;
 		if (good && (header.ddspf.dwFlags & DDPF_FOURCC)) {
 			char *fcc = (char *)&header.ddspf.dwFourCC;
-			INFO_LOG(G3D, "DDS fourcc: %c%c%c%c", fcc[0], fcc[1], fcc[2], fcc[3]);
+			// INFO_LOG(G3D, "DDS fourcc: %c%c%c%c", fcc[0], fcc[1], fcc[2], fcc[3]);
 			if (header.ddspf.dwFourCC == MK_FOURCC("DX10")) {
 				ddsDX10 = true;
 				good = good && vfs_->Read(openFile, &header10, sizeof(header10)) == sizeof(header10);

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -151,6 +151,7 @@ struct TexCacheEntry {
 		STATUS_CLUT_GPU = 0x8000,
 
 		STATUS_VIDEO = 0x10000,
+		STATUS_BGRA = 0x20000,
 	};
 
 	// TexStatus enum flag combination.
@@ -510,8 +511,6 @@ protected:
 	bool nextNeedsRehash_;
 	bool nextNeedsChange_;
 	bool nextNeedsRebuild_;
-
-	bool isBgraBackend_ = false;
 
 	u32 *expandClut_;
 };

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -148,7 +148,6 @@ TextureCacheD3D11::TextureCacheD3D11(Draw::DrawContext *draw, Draw2D *draw2D)
 	device_ = (ID3D11Device *)draw->GetNativeObject(Draw::NativeObject::DEVICE);
 	context_ = (ID3D11DeviceContext *)draw->GetNativeObject(Draw::NativeObject::CONTEXT);
 
-	isBgraBackend_ = true;
 	lastBoundTexture = INVALID_TEX;
 
 	D3D11_BUFFER_DESC desc{ sizeof(DepthPushConstants), D3D11_USAGE_DYNAMIC, D3D11_BIND_CONSTANT_BUFFER, D3D11_CPU_ACCESS_WRITE };
@@ -414,6 +413,12 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 
 	if (plan.replaceValid) {
 		entry->SetAlphaStatus(TexCacheEntry::TexStatus(plan.replaced->AlphaStatus()));
+
+		if (!Draw::DataFormatIsBlockCompressed(plan.replaced->Format(), nullptr)) {
+			entry->status |= TexCacheEntry::STATUS_BGRA;
+		}
+	} else {
+		entry->status |= TexCacheEntry::STATUS_BGRA;
 	}
 }
 

--- a/GPU/Directx9/TextureCacheDX9.cpp
+++ b/GPU/Directx9/TextureCacheDX9.cpp
@@ -71,8 +71,6 @@ static const D3DVERTEXELEMENT9 g_FramebufferVertexElements[] = {
 TextureCacheDX9::TextureCacheDX9(Draw::DrawContext *draw, Draw2D *draw2D)
 	: TextureCacheCommon(draw, draw2D) {
 	lastBoundTexture = INVALID_TEX;
-	isBgraBackend_ = true;
-
 	device_ = (LPDIRECT3DDEVICE9)draw->GetNativeObject(Draw::NativeObject::DEVICE);
 	deviceEx_ = (LPDIRECT3DDEVICE9EX)draw->GetNativeObject(Draw::NativeObject::DEVICE_EX);
 	D3DCAPS9 pCaps;
@@ -322,6 +320,12 @@ void TextureCacheDX9::BuildTexture(TexCacheEntry *const entry) {
 
 	if (plan.replaceValid) {
 		entry->SetAlphaStatus(TexCacheEntry::TexStatus(plan.replaced->AlphaStatus()));
+
+		if (!Draw::DataFormatIsBlockCompressed(plan.replaced->Format(), nullptr)) {
+			entry->status |= TexCacheEntry::STATUS_BGRA;
+		}
+	} else {
+		entry->status |= TexCacheEntry::STATUS_BGRA;
 	}
 }
 


### PR DESCRIPTION
Fixes the R/B problem mentioned in #17095.

Also some log cleanup.