### PR TITLE
Texture replacement: Load DDS mipmaps

### DIFF
--- a/Common/Thread/ParallelLoop.cpp
+++ b/Common/Thread/ParallelLoop.cpp
@@ -111,8 +111,8 @@ void ParallelRangeLoop(ThreadManager *threadMan, const std::function<void(int, i
 
 // NOTE: Supports a max of 2GB.
 void ParallelMemcpy(ThreadManager *threadMan, void *dst, const void *src, size_t bytes, TaskPriority priority) {
-	// This threshold can probably be a lot bigger.
-	if (bytes < 512) {
+	// This threshold should be the same as the minimum split below, 128kb.
+	if (bytes < 128 * 1024) {
 		memcpy(dst, src, bytes);
 		return;
 	}
@@ -129,7 +129,7 @@ void ParallelMemcpy(ThreadManager *threadMan, void *dst, const void *src, size_t
 // NOTE: Supports a max of 2GB.
 void ParallelMemset(ThreadManager *threadMan, void *dst, uint8_t value, size_t bytes, TaskPriority priority) {
 	// This threshold can probably be a lot bigger.
-	if (bytes < 512) {
+	if (bytes < 128 * 1024) {
 		memset(dst, 0, bytes);
 		return;
 	}

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -561,8 +561,7 @@ bool ReplacedTexture::CopyLevelTo(int level, void *out, int rowPitch) {
 		}
 	} else {
 		// TODO: Add sanity checks here for other formats?
-		// Just gonna do a memcpy, slightly scared of the parallel ones.
-		memcpy(out, data.data(), data.size());
+		ParallelMemcpy(&g_threadManager, out, data.data(), data.size());
 	}
 
 	return true;

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -364,6 +364,7 @@ bool ReplacedTexture::LoadLevelData(VFSFileReference *fileRef, const std::string
 
 	// Already populated from cache. TODO: Move this above the first read, and take level.w/h from the cache.
 	if (!out.empty()) {
+		vfs_->CloseFile(openFile);
 		*pixelFormat = levelData_->fmt;
 		return true;
 	}
@@ -382,6 +383,7 @@ bool ReplacedTexture::LoadLevelData(VFSFileReference *fileRef, const std::string
 	}
 
 	if (!good) {
+		vfs_->CloseFile(openFile);
 		return false;
 	}
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1551,8 +1551,8 @@ ReplacedTexture *TextureCacheCommon::FindReplacement(TexCacheEntry *entry, int &
 		// Make sure we keep polling.
 		entry->status |= TexCacheEntry::STATUS_TO_REPLACE;
 		break;
-    default:
-        break;
+	default:
+		break;
 	}
 	replacementTimeThisFrame_ += time_now_d() - replaceStart;
 	return replaced;

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -301,7 +301,7 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 		if (plan.replaceValid) {
 			int blockSize = 0;
 			if (Draw::DataFormatIsBlockCompressed(plan.replaced->Format(), &blockSize)) {
-				stride = mipWidth * 4;  // This stride value doesn't quite make sense to me, but it works.
+				stride = ((mipWidth + 3) & ~3) * 4;  // This stride value doesn't quite make sense to me, but it works.
 				dataSize = plan.replaced->GetLevelDataSize(i);
 			} else {
 				int bpp = (int)Draw::DataFormatSizeInBytes(plan.replaced->Format());

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -584,11 +584,11 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 
 		bool dataScaled = true;
 		if (plan.replaceValid) {
-			int bufferRowLength = byteStride;
+			int rowLength = pixelStride;
 			if (bcFormat) {
 				// For block compressed formats, we just set the upload size to the data size..
 				uploadSize = plan.replaced->GetLevelDataSize(plan.baseLevelSrc + i);
-				bufferRowLength = mipWidth;
+				rowLength = (mipWidth + 3) & ~3;
 			}
 			// Directly load the replaced image.
 			data = pushBuffer->PushAligned(uploadSize, &bufferOffset, &texBuf, pushAlignment);
@@ -600,7 +600,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 			replacementTimeThisFrame_ += time_now_d() - replaceStart;
 			VK_PROFILE_BEGIN(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT,
 				"Copy Upload (replaced): %dx%d", mipWidth, mipHeight);
-			entry->vkTex->UploadMip(cmdInit, i, mipWidth, mipHeight, 0, texBuf, bufferOffset, pixelStride);
+			entry->vkTex->UploadMip(cmdInit, i, mipWidth, mipHeight, 0, texBuf, bufferOffset, rowLength);
 			VK_PROFILE_END(vulkan, cmdInit, VK_PIPELINE_STAGE_TRANSFER_BIT);
 		} else {
 			if (plan.depth != 1) {

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -455,9 +455,6 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		Draw::DataFormat fmt = plan.replaced->Format();
 		bcFormat = Draw::DataFormatIsBlockCompressed(fmt, &bcAlign);
 		actualFmt = ToVulkanFormat(fmt);
-		if (actualFmt != VULKAN_8888_FORMAT) {
-			actualFmt = actualFmt;
-		}
 	}
 
 	bool computeUpload = false;


### PR DESCRIPTION
Implement mipmap loading in the DDS reader (loading a whole mipmap pyramid from a single file, quite convenient).

Also address feedback from #17083.