### PR TITLE
Headless: Use more consistent logic to find assets

### DIFF
--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include "ppsspp_config.h"
 
 #include <png.h>

--- a/headless/SDLHeadlessHost.cpp
+++ b/headless/SDLHeadlessHost.cpp
@@ -99,12 +99,6 @@ private:
 	SDL_GLContext glContext_;
 };
 
-void SDLHeadlessHost::LoadNativeAssets() {
-	g_VFS.Register("", new DirectoryReader(Path("assets")));
-	g_VFS.Register("", new DirectoryReader(Path("")));
-	g_VFS.Register("", new DirectoryReader(Path("..")));
-}
-
 bool GLDummyGraphicsContext::InitFromRenderThread(std::string *errorMessage) {
 	SDL_Init(SDL_INIT_VIDEO);
 
@@ -202,8 +196,6 @@ bool SDLHeadlessHost::InitGraphics(std::string *error_message, GraphicsContext *
 		threadState_ = RenderThreadState::STOPPED;
 	});
 	th.detach();
-
-	LoadNativeAssets();
 
 	threadState_ = RenderThreadState::START_REQUESTED;
 	while (threadState_ == RenderThreadState::START_REQUESTED || threadState_ == RenderThreadState::STARTING)

--- a/headless/SDLHeadlessHost.h
+++ b/headless/SDLHeadlessHost.h
@@ -36,8 +36,6 @@ public:
 	void SwapBuffers() override;
 
 protected:
-	void LoadNativeAssets();
-
 	enum class RenderThreadState {
 		IDLE,
 		START_REQUESTED,

--- a/headless/WindowsHeadlessHost.cpp
+++ b/headless/WindowsHeadlessHost.cpp
@@ -66,16 +66,6 @@ HWND CreateHiddenWindow() {
 	return CreateWindowEx(0, L"PPSSPPHeadless", L"PPSSPPHeadless", style, CW_USEDEFAULT, CW_USEDEFAULT, WINDOW_WIDTH, WINDOW_HEIGHT, NULL, NULL, NULL, NULL);
 }
 
-void WindowsHeadlessHost::LoadNativeAssets()
-{
-	g_VFS.Register("", new DirectoryReader(Path("assets")));
-	g_VFS.Register("", new DirectoryReader(Path("")));
-	g_VFS.Register("", new DirectoryReader(Path("..")));
-	g_VFS.Register("", new DirectoryReader(Path("../assets")));
-	g_VFS.Register("", new DirectoryReader(Path("../Windows/assets")));
-	g_VFS.Register("", new DirectoryReader(Path("../Windows")));
-}
-
 void WindowsHeadlessHost::SendDebugOutput(const std::string &output)
 {
 	fwrite(output.data(), sizeof(char), output.length(), stdout);
@@ -151,8 +141,6 @@ bool WindowsHeadlessHost::InitGraphics(std::string *error_message, GraphicsConte
 		});
 		th.detach();
 	}
-
-	LoadNativeAssets();
 
 	if (needRenderThread) {
 		threadState_ = RenderThreadState::START_REQUESTED;

--- a/headless/WindowsHeadlessHost.h
+++ b/headless/WindowsHeadlessHost.h
@@ -37,8 +37,6 @@ public:
 	void SendDebugOutput(const std::string &output) override;
 
 protected:
-	void LoadNativeAssets();
-
 	enum class RenderThreadState {
 		IDLE,
 		START_REQUESTED,


### PR DESCRIPTION
Depending on graphics backend and legacy logic from when flash0 wasn't inside assets, the assets path was still wrong and wouldn't get registered.  Now it's working on GitHub Actions too.

-[Unknown]