### PR TITLE
Basis/UASTC texture compression support via ktx2

### DIFF
--- a/Common/Data/Format/DDSLoad.h
+++ b/Common/Data/Format/DDSLoad.h
@@ -67,3 +67,17 @@ struct DDSLoadInfo {
 };
 
 bool DetectDDSParams(const DDSHeader *header, DDSLoadInfo *info);
+
+// We use the Basis library for the actual reading, but before we do, we pre-scan using this, similarly to the png trick.
+struct KTXHeader {
+	uint8_t identifier[12];
+	uint32_t vkFormat;
+	uint32_t typeSize;
+	uint32_t pixelWidth;
+	uint32_t pixelHeight;
+	uint32_t pixelDepth;
+	uint32_t layerCount;
+	uint32_t faceCount;
+	uint32_t levelCount;
+	uint32_t supercompressionScheme;
+};

--- a/Common/GPU/Vulkan/VulkanImage.cpp
+++ b/Common/GPU/Vulkan/VulkanImage.cpp
@@ -156,6 +156,8 @@ void VulkanTexture::CopyBufferToMipLevel(VkCommandBuffer cmd, TextureCopyBatch *
 	copy_region.imageSubresource.baseArrayLayer = 0;
 	copy_region.imageSubresource.layerCount = 1;
 
+	_dbg_assert_(mip < numMips_);
+
 	if (!copyBatch->buffer) {
 		copyBatch->buffer = buffer;
 	} else if (copyBatch->buffer != buffer) {

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -286,36 +286,9 @@ bool ReplacedTexture::LoadLevelData(VFSFileReference *fileRef, const std::string
 		// Additional quick checks
 		good = good && header.layerCount <= 1;
 	} else if (imageType == ReplacedImageType::BASIS) {
-		// Peek into the file using the header struct.
-		basist::basis_file_header header;
-		good = vfs_->Read(openFile, &header, sizeof(header)) == sizeof(header);
+		WARN_LOG(G3D, "The basis texture format is not supported. Use KTX2 (basisu texture.png -uastc -ktx2 -mipmap)");
 
-		if (header.m_tex_format == 0) {
-			// ETC1S texture data (transcodable to ETC2 or DXT1)
-			// Check what we should transcode to.
-			if (desc_->formatSupport.bc123) {
-				*pixelFormat = Draw::DataFormat::BC1_RGBA_UNORM_BLOCK;
-			} else if (desc_->formatSupport.etc2) {
-				*pixelFormat = Draw::DataFormat::ETC2_R8G8B8A1_UNORM_BLOCK;
-			} else {
-				// We're in trouble.
-				good = false;
-			}
-		} else {
-			// UASTC texture data (transcodable to ASTC or BC7).
-			if (desc_->formatSupport.bc7) {
-				*pixelFormat = Draw::DataFormat::BC7_UNORM_BLOCK;
-			} else if (desc_->formatSupport.astc) {
-				*pixelFormat = Draw::DataFormat::ASTC_4x4_UNORM_BLOCK;
-			} else {
-				good = false;
-			}
-		}
-
-		// TODO: Seek to the slice header array.
-		// vfs_->Seek(header.m_slice_desc_file_ofs);
-
-		// We don't support basis files currently.
+		// We simply don't support basis files currently.
 		good = false;
 	} else if (imageType == ReplacedImageType::DDS) {
 		DDSHeader header;

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -462,7 +462,7 @@ bool ReplacedTexture::LoadLevelData(VFSFileReference *fileRef, const std::string
 				transcoderFormat = basist::transcoder_texture_format::cTFETC1_RGB;
 				*pixelFormat = Draw::DataFormat::ETC2_R8G8B8_UNORM_BLOCK;
 			} else {
-				// Bad.
+				// TODO: Transcode to RGBA8 instead as a fallback.
 				cleanup();
 				return false;
 			}
@@ -475,6 +475,7 @@ bool ReplacedTexture::LoadLevelData(VFSFileReference *fileRef, const std::string
 				transcoderFormat = basist::transcoder_texture_format::cTFASTC_4x4_RGBA;
 				*pixelFormat = Draw::DataFormat::ASTC_4x4_UNORM_BLOCK;
 			} else {
+				// TODO: Transcode to RGBA8 instead as a fallback.
 				cleanup();
 				return false;
 			}

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -45,6 +45,7 @@ enum class ReplacedImageType {
 	PNG,
 	ZIM,
 	DDS,
+	BASIS,
 	INVALID,
 };
 

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -45,7 +45,8 @@ enum class ReplacedImageType {
 	PNG,
 	ZIM,
 	DDS,
-	BASIS,
+	BASIS,  // TODO: Might not even do this, KTX2 is a better container.
+	KTX2,
 	INVALID,
 };
 

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2013- PPSSPP Project.
+ // Copyright (c) 2013- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <png.h>
 
+#include "ext/basis_universal/basisu_transcoder.h"
 #include "ext/xxhash.h"
 
 #include "Common/Data/Convert/ColorConv.h"
@@ -53,8 +54,13 @@ static const std::string ZIP_FILENAME = "textures.zip";
 static const std::string NEW_TEXTURE_DIR = "new/";
 static const int VERSION = 1;
 static const double MAX_CACHE_SIZE = 4.0;
+static bool basisu_initialized = false;
 
 TextureReplacer::TextureReplacer(Draw::DrawContext *draw) {
+	if (!basisu_initialized) {
+		basist::basisu_transcoder_init();
+		basisu_initialized = true;
+	}
 	// We don't want to keep the draw object around, so extract the info we need.
 	if (draw->GetDataFormatSupport(Draw::DataFormat::BC3_UNORM_BLOCK)) formatSupport_.bc123 = true;
 	if (draw->GetDataFormatSupport(Draw::DataFormat::ASTC_4x4_UNORM_BLOCK)) formatSupport_.astc = true;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -411,6 +411,11 @@ static VkFormat ToVulkanFormat(Draw::DataFormat fmt) {
 	case Draw::DataFormat::BC4_UNORM_BLOCK: return VK_FORMAT_BC4_UNORM_BLOCK;
 	case Draw::DataFormat::BC5_UNORM_BLOCK: return VK_FORMAT_BC5_UNORM_BLOCK;
 	case Draw::DataFormat::BC7_UNORM_BLOCK: return VK_FORMAT_BC7_UNORM_BLOCK;
+	case Draw::DataFormat::ASTC_4x4_UNORM_BLOCK: return VK_FORMAT_ASTC_4x4_UNORM_BLOCK;
+	case Draw::DataFormat::ETC2_R8G8B8_UNORM_BLOCK: return VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK;
+	case Draw::DataFormat::ETC2_R8G8B8A1_UNORM_BLOCK: return VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK;
+	case Draw::DataFormat::ETC2_R8G8B8A8_UNORM_BLOCK: return VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK;
+
 	case Draw::DataFormat::R8G8B8A8_UNORM: return VULKAN_8888_FORMAT;
 	default: _assert_msg_(false, "Bad texture pixel format"); return VULKAN_8888_FORMAT;
 	}

--- a/UWP/CommonUWP/CommonUWP.vcxproj
+++ b/UWP/CommonUWP/CommonUWP.vcxproj
@@ -404,6 +404,13 @@
     <ClInclude Include="..\..\Common\VR\VRRenderer.h" />
     <ClInclude Include="..\..\Common\x64Analyzer.h" />
     <ClInclude Include="..\..\Common\x64Emitter.h" />
+    <ClInclude Include="..\..\ext\basis_universal\basisu.h" />
+    <ClInclude Include="..\..\ext\basis_universal\basisu_containers.h" />
+    <ClInclude Include="..\..\ext\basis_universal\basisu_containers_impl.h" />
+    <ClInclude Include="..\..\ext\basis_universal\basisu_file_headers.h" />
+    <ClInclude Include="..\..\ext\basis_universal\basisu_transcoder.h" />
+    <ClInclude Include="..\..\ext\basis_universal\basisu_transcoder_internal.h" />
+    <ClInclude Include="..\..\ext\basis_universal\basisu_transcoder_uastc.h" />
     <ClInclude Include="..\..\ext\libpng17\png.h" />
     <ClInclude Include="..\..\ext\libpng17\pngconf.h" />
     <ClInclude Include="..\..\ext\libpng17\pngdebug.h" />
@@ -528,6 +535,7 @@
     <ClCompile Include="..\..\Common\VR\VRRenderer.cpp" />
     <ClCompile Include="..\..\Common\x64Analyzer.cpp" />
     <ClCompile Include="..\..\Common\x64Emitter.cpp" />
+    <ClCompile Include="..\..\ext\basis_universal\basisu_transcoder.cpp" />
     <ClCompile Include="..\..\ext\libpng17\png.c" />
     <ClCompile Include="..\..\ext\libpng17\pngerror.c" />
     <ClCompile Include="..\..\ext\libpng17\pngget.c" />
@@ -546,6 +554,16 @@
     <ClCompile Include="..\..\ext\libpng17\pngwutil.c" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_astc.inc" />
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_astc_0_255.inc" />
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_atc_55.inc" />
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_atc_56.inc" />
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_bc7_m5_alpha.inc" />
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_bc7_m5_color.inc" />
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_dxt1_5.inc" />
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_dxt1_6.inc" />
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_pvrtc2_45.inc" />
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_pvrtc2_alpha_33.inc" />
     <None Include="..\..\ext\libpng17\CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/UWP/CommonUWP/CommonUWP.vcxproj.filters
+++ b/UWP/CommonUWP/CommonUWP.vcxproj.filters
@@ -91,6 +91,9 @@
     <Filter Include="GPU\Vulkan">
       <UniqueIdentifier>{096c3d00-fcfa-4877-8cf0-3b10d56b5d72}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ext\basis_universal">
+      <UniqueIdentifier>{8b92cc15-8e3e-45b1-ba80-ad39b1a9cdc8}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Common\ABI.cpp" />
@@ -422,6 +425,9 @@
     </ClCompile>
     <ClCompile Include="..\..\Common\Data\Format\DDSLoad.cpp">
       <Filter>Data\Format</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\ext\basis_universal\basisu_transcoder.cpp">
+      <Filter>ext\basis_universal</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -784,6 +790,27 @@
     <ClInclude Include="..\..\Common\Data\Format\DDSLoad.h">
       <Filter>Data\Format</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\ext\basis_universal\basisu.h">
+      <Filter>ext\basis_universal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\basis_universal\basisu_containers.h">
+      <Filter>ext\basis_universal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\basis_universal\basisu_containers_impl.h">
+      <Filter>ext\basis_universal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\basis_universal\basisu_file_headers.h">
+      <Filter>ext\basis_universal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\basis_universal\basisu_transcoder.h">
+      <Filter>ext\basis_universal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\basis_universal\basisu_transcoder_internal.h">
+      <Filter>ext\basis_universal</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\ext\basis_universal\basisu_transcoder_uastc.h">
+      <Filter>ext\basis_universal</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\Common\Math\fast\fast_matrix_neon.S">
@@ -793,5 +820,35 @@
       <Filter>Math\lin</Filter>
     </None>
     <None Include="..\..\ext\libpng17\CMakeLists.txt" />
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_astc.inc">
+      <Filter>ext\basis_universal</Filter>
+    </None>
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_astc_0_255.inc">
+      <Filter>ext\basis_universal</Filter>
+    </None>
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_atc_55.inc">
+      <Filter>ext\basis_universal</Filter>
+    </None>
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_atc_56.inc">
+      <Filter>ext\basis_universal</Filter>
+    </None>
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_bc7_m5_alpha.inc">
+      <Filter>ext\basis_universal</Filter>
+    </None>
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_bc7_m5_color.inc">
+      <Filter>ext\basis_universal</Filter>
+    </None>
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_dxt1_5.inc">
+      <Filter>ext\basis_universal</Filter>
+    </None>
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_dxt1_6.inc">
+      <Filter>ext\basis_universal</Filter>
+    </None>
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_pvrtc2_45.inc">
+      <Filter>ext\basis_universal</Filter>
+    </None>
+    <None Include="..\..\ext\basis_universal\basisu_transcoder_tables_pvrtc2_alpha_33.inc">
+      <Filter>ext\basis_universal</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/ext/basis_universal/basisu_containers.h
+++ b/ext/basis_universal/basisu_containers.h
@@ -315,6 +315,7 @@ namespace basisu
          {
             scalar_type<T>::destruct_array(m_p, m_size);
             free(m_p);
+			m_p = nullptr;
          }
       }
 


### PR DESCRIPTION
Allows loading basis/UASTC textures in .ktx2 format, transcoding to whatever compressed texture formats are available.

To convert your textures to this format, use:

> basisu texture.png -ktx2 -mipmap

or

> basisu texture.png -ktx2 -uastc -mipmap

resulting in `texture.ktx2`. basisu.exe can be downloaded from [here](https://github.com/BinomialLLC/basis_universal/releases). The tradeoff here is that the first ones are smaller but worse quality and don't support alpha, while the second has full alpha support but is not quite as compatible with older hardware (I will add a fallback to decode to RGBA later though).

This allows for efficient and still cross-platform compatible compressed replacement textures - while not as fast as DDS to load, should be faster than png while still taking up a lot less memory when loaded. Will try to do some benchmarks later.

~~Currently causes some VK validation errors on the last mipmaps with rectangular textures, will fix before merge.~~
