### PR TITLE
OpenGL: Try a different way to exclude desktop tex compression formats in build

### DIFF
--- a/Common/GPU/OpenGL/DataFormatGL.cpp
+++ b/Common/GPU/OpenGL/DataFormatGL.cpp
@@ -86,7 +86,7 @@ bool Thin3DFormatToGLFormatAndType(DataFormat fmt, GLuint &internalFormat, GLuin
 		alignment = 16;
 		break;
 
-#if PPSSPP_PLATFORM(WINDOWS)
+#ifndef USING_GLES2
 	case DataFormat::BC1_RGBA_UNORM_BLOCK:
 		internalFormat = GL_COMPRESSED_RGB_S3TC_DXT1_EXT;
 		format = GL_RGB;

--- a/Common/GPU/OpenGL/GLFeatures.cpp
+++ b/Common/GPU/OpenGL/GLFeatures.cpp
@@ -593,10 +593,8 @@ bool CheckGLExtensions() {
 			switch (compressedFormats[i]) {
 			case GL_COMPRESSED_RGB8_ETC2: gl_extensions.supportsETC2 = true; break;
 			case GL_COMPRESSED_RGBA_ASTC_4x4_KHR: gl_extensions.supportsASTC = true; break;
-#if !PPSSPP_PLATFORM(IOS) && !PPSSPP_PLATFORM(MAC)
+#ifndef USING_GLES2
 			case GL_COMPRESSED_RGBA_S3TC_DXT5_EXT: gl_extensions.supportsBC123 = true; break;
-#endif
-#if PPSSPP_PLATFORM(WINDOWS)
 			case GL_COMPRESSED_RGBA_BPTC_UNORM: gl_extensions.supportsBC7 = true; break;
 #endif
 			}


### PR DESCRIPTION
May fix #17110