### PR TITLE
More texture replacement fixes

### DIFF
--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -232,19 +232,22 @@ void ReplacedTexture::Prepare(VFSBackend *vfs) {
 		}
 	}
 
-	delete desc_;
-	desc_ = nullptr;
-
 	if (levels_.empty()) {
-		// Bad.
-		WARN_LOG(G3D, "Failed to load texture");
+		// No replacement found.
+		std::string name = TextureReplacer::HashName(desc_->cachekey, desc_->hash, 0);
+		INFO_LOG(G3D, "Failed to load replacement texture. %s", name.c_str());
 		SetState(ReplacementState::NOT_FOUND);
 		levelData_ = nullptr;
+		delete desc_;
+		desc_ = nullptr;
 		return;
 	}
 
 	levelData_->fmt = fmt;
 	SetState(ReplacementState::ACTIVE);
+
+	delete desc_;
+	desc_ = nullptr;
 
 	if (threadWaitable_)
 		threadWaitable_->Notify();

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -153,8 +153,14 @@ struct ReplacedTexture {
 	std::string logId_;
 
 private:
+	enum class LoadLevelResult {
+		LOAD_ERROR = 0,
+		CONTINUE = 1,
+		DONE = 2,
+	};
+
 	void Prepare(VFSBackend *vfs);
-	bool LoadLevelData(VFSFileReference *fileRef, const std::string &filename, int level, Draw::DataFormat *pixelFormat);
+	LoadLevelResult LoadLevelData(VFSFileReference *fileRef, const std::string &filename, int level, Draw::DataFormat *pixelFormat);
 	void PurgeIfOlder(double t);
 
 	std::vector<ReplacedTextureLevel> levels_;

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -135,7 +135,7 @@ bool TextureReplacer::LoadIni() {
 	}
 
 	IniFile ini;
-	bool iniLoaded = ini.LoadFromVFS(g_VFS, (basePath_ / INI_FILENAME).ToString());
+	bool iniLoaded = ini.LoadFromVFS(*dir, INI_FILENAME);
 
 	if (iniLoaded) {
 		if (!LoadIniValues(ini)) {
@@ -183,7 +183,11 @@ bool TextureReplacer::LoadIni() {
 		repl.second->vfs_ = vfs_;
 	}
 
-	INFO_LOG(G3D, "Texture pack activated from '%s'", basePath_.c_str());
+	if (vfsIsZip_) {
+		INFO_LOG(G3D, "Texture pack activated from '%s'", (basePath_ / ZIP_FILENAME).c_str());
+	} else {
+		INFO_LOG(G3D, "Texture pack activated from '%s'", basePath_.c_str());
+	}
 
 	// The ini doesn't have to exist for the texture directory or zip to be valid.
 	return true;

--- a/GPU/D3D11/TextureCacheD3D11.cpp
+++ b/GPU/D3D11/TextureCacheD3D11.cpp
@@ -301,7 +301,7 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 		if (plan.replaceValid) {
 			int blockSize = 0;
 			if (Draw::DataFormatIsBlockCompressed(plan.replaced->Format(), &blockSize)) {
-				stride = ((mipWidth + 3) & ~3) * 4;  // This stride value doesn't quite make sense to me, but it works.
+				stride = ((mipWidth + 3) & ~3) * blockSize / 4;  // This stride value doesn't quite make sense to me, but it works?
 				dataSize = plan.replaced->GetLevelDataSize(i);
 			} else {
 				int bpp = (int)Draw::DataFormatSizeInBytes(plan.replaced->Format());
@@ -364,7 +364,6 @@ void TextureCacheD3D11::BuildTexture(TexCacheEntry *const entry) {
 		desc.Format = dstFmt;
 		desc.MipLevels = levels;
 		desc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
-
 		ASSERT_SUCCESS(device_->CreateTexture2D(&desc, subresData, &tex));
 		texture = tex;
 	} else {

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -129,7 +129,9 @@ void DrawEngineDX9::InitDeviceObjects() {
 }
 
 void DrawEngineDX9::DestroyDeviceObjects() {
-	draw_->SetInvalidationCallback(InvalidationCallback());
+	if (draw_) {
+		draw_->SetInvalidationCallback(InvalidationCallback());
+	}
 	ClearTrackedVertexArrays();
 }
 


### PR DESCRIPTION
* Fix zip texture packs (didn't read the ini from the zip, which I didn't notice due to a silly test setup)
* Correct some error reporting
* Fallback to transcoding UASTC/basis textures to RGBA8888 if there's no suitable compressed texture format supported by the hardware/driver.