### PR TITLE
VulkanPushPool - more efficient replacement for 3x VulkanPushBuffer

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -330,6 +330,7 @@ public:
 	}
 
 	int GetInflightFrames() const {
+		// out of MAX_INFLIGHT_FRAMES.
 		return inflightFrames_;
 	}
 	// Don't call while a frame is in progress.

--- a/Common/GPU/Vulkan/VulkanMemory.cpp
+++ b/Common/GPU/Vulkan/VulkanMemory.cpp
@@ -397,6 +397,16 @@ void VulkanPushPool::NextBlock(VkDeviceSize allocationSize) {
 	DEBUG_LOG(G3D, "%s: Created new block of size %s in %0.2f ms", name_, NiceSizeFormat(newBlockSize).c_str(), 1000.0 * (time_now_d() - start));
 }
 
+size_t VulkanPushPool::GetUsedThisFrame() const {
+	size_t used = 0;
+	for (auto &block : blocks_) {
+		if (block.frameIndex == vulkan_->GetCurFrame()) {
+			used += block.used;
+		}
+	}
+	return used;
+}
+
 void VulkanPushPool::GetDebugString(char *buffer, size_t bufSize) const {
 	size_t used = 0;
 	size_t capacity = 0;

--- a/Common/GPU/Vulkan/VulkanMemory.cpp
+++ b/Common/GPU/Vulkan/VulkanMemory.cpp
@@ -349,9 +349,11 @@ void VulkanPushPool::NextBlock(VkDeviceSize allocationSize) {
 	curBlockIndex_++;
 	while (curBlockIndex_ < blocks_.size()) {
 		Block &block = blocks_[curBlockIndex_];
-		if (block.frameIndex == curFrameIndex) {
+		// Grab the first matching block, or unused block (frameIndex == -1).
+		if ((block.frameIndex == curFrameIndex || block.frameIndex == -1) && block.size >= allocationSize) {
 			_assert_(block.used == 0);
 			block.used = allocationSize;
+			block.frameIndex = curFrameIndex;
 			return;
 		}
 		curBlockIndex_++;

--- a/Common/GPU/Vulkan/VulkanMemory.h
+++ b/Common/GPU/Vulkan/VulkanMemory.h
@@ -148,6 +148,8 @@ public:
 		return bindOffset;
 	}
 
+	size_t GetUsedThisFrame() const;
+
 private:
 	void NextBlock(VkDeviceSize allocationSize);
 

--- a/Common/GPU/Vulkan/VulkanMemory.h
+++ b/Common/GPU/Vulkan/VulkanMemory.h
@@ -216,6 +216,7 @@ private:
 
 		int frameIndex;
 		bool original;  // these blocks aren't garbage collected.
+		double lastUsed;
 
 		uint8_t *writePtr;
 

--- a/Common/GPU/Vulkan/VulkanMemory.h
+++ b/Common/GPU/Vulkan/VulkanMemory.h
@@ -24,9 +24,8 @@ class VulkanMemoryManager {
 public:
 	virtual ~VulkanMemoryManager() {}
 
-	virtual size_t GetTotalSize() const = 0;
-	virtual size_t GetTotalCapacity() const = 0;
-	virtual const char *Name() const = 0;
+	virtual void GetDebugString(char *buffer, size_t bufSize) const = 0;
+	virtual const char *Name() const = 0;  // for sorting
 };
 
 // VulkanPushBuffer
@@ -52,6 +51,11 @@ public:
 	void Destroy(VulkanContext *vulkan);
 
 	void Reset() { offset_ = 0; }
+
+	void GetDebugString(char *buffer, size_t bufSize) const override;
+	const char *Name() const override {
+		return name_;
+	}
 
 	// Needs context in case of defragment.
 	void Begin(VulkanContext *vulkan) {
@@ -112,10 +116,6 @@ public:
 		return offset_;
 	}
 
-	const char *Name() const override {
-		return name_;
-	}
-
 	// "Zero-copy" variant - you can write the data directly as you compute it.
 	// Recommended.
 	void *Push(size_t size, uint32_t *bindOffset, VkBuffer *vkbuf) {
@@ -141,8 +141,7 @@ public:
 		info->range = sizeof(T);
 	}
 
-	size_t GetTotalSize() const override;  // Used size
-	size_t GetTotalCapacity() const override;
+	size_t GetTotalSize() const;
 
 private:
 	bool AddBuffer();
@@ -171,8 +170,10 @@ public:
 	void Destroy();
 	void BeginFrame();
 
-	size_t GetTotalSize() const override;  // Used size
-	size_t GetTotalCapacity() const override;
+	const char *Name() const override {
+		return name_;
+	}
+	void GetDebugString(char *buffer, size_t bufSize) const override;
 
 	// When using the returned memory, make sure to bind the returned vkbuf.
 	uint8_t *Allocate(VkDeviceSize numBytes, VkDeviceSize alignment, VkBuffer *vkbuf, uint32_t *bindOffset) {
@@ -200,10 +201,6 @@ public:
 		uint8_t *ptr = Allocate(numBytes, alignment, vkbuf, &bindOffset);
 		memcpy(ptr, data, numBytes);
 		return bindOffset;
-	}
-
-	const char *Name() const override {
-		return name_;
 	}
 
 private:

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -981,7 +981,7 @@ VKContext::VKContext(VulkanContext *vulkan)
 	// 200 textures per frame was not enough for the UI.
 	dp.maxSets = 4096;
 
-	VkBufferUsageFlags usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+	VkBufferUsageFlags usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
 	push_ = new VulkanPushPool(vulkan_, "pushBuffer", 1024 * 1024, usage);
 
 	for (int i = 0; i < VulkanContext::MAX_INFLIGHT_FRAMES; i++) {
@@ -1770,7 +1770,8 @@ uint64_t VKContext::GetNativeObject(NativeObject obj, void *srcObject) {
 		return (uint64_t)curFramebuffer_->GetFB()->GetRTView();
 	case NativeObject::THIN3D_PIPELINE_LAYOUT:
 		return (uint64_t)pipelineLayout_;
-
+	case NativeObject::PUSH_POOL:
+		return (uint64_t)push_;
 	default:
 		Crash();
 		return 0;

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -982,7 +982,7 @@ VKContext::VKContext(VulkanContext *vulkan)
 	dp.maxSets = 4096;
 
 	VkBufferUsageFlags usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-	push_ = new VulkanPushPool(vulkan_, "pushBuffer", 1024 * 1024, usage);
+	push_ = new VulkanPushPool(vulkan_, "pushBuffer", 4 * 1024 * 1024, usage);
 
 	for (int i = 0; i < VulkanContext::MAX_INFLIGHT_FRAMES; i++) {
 		frame_[i].descriptorPool.Create(vulkan_, dp, dpTypes);

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -252,6 +252,7 @@ enum class NativeObject {
 	NULL_IMAGEVIEW,
 	NULL_IMAGEVIEW_ARRAY,
 	THIN3D_PIPELINE_LAYOUT,
+	PUSH_POOL,
 };
 
 enum FBChannel {

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -509,7 +509,7 @@ ReplacedTexture::LoadLevelResult ReplacedTexture::LoadLevelData(VFSFileReference
 			}
 			levelData_->data[i].resize(dataSizeBytes);
 
-			transcoder.transcode_image_level(i, 0, 0, &out[0], outputSize, transcoderFormat, 0, outputPitch, level.h, -1, -1, &transcodeState);
+			transcoder.transcode_image_level(i, 0, 0, &out[0], (uint32_t)outputSize, transcoderFormat, 0, (uint32_t)outputPitch, level.h, -1, -1, &transcodeState);
 			level.w = levelInfo.m_orig_width;
 			level.h = levelInfo.m_orig_height;
 			if (i != 0)

--- a/GPU/Vulkan/DebugVisVulkan.cpp
+++ b/GPU/Vulkan/DebugVisVulkan.cpp
@@ -78,10 +78,10 @@ void DrawAllocatorVis(UIContext *ui, GPUInterface *gpu) {
 	auto managers = GetActiveVulkanMemoryManagers();
 	std::sort(managers.begin(), managers.end(), comparePushBufferNames);
 
+	char buffer[512];
 	for (auto manager : managers) {
-		str << "  " << manager->Name() << " "
-			<< NiceSizeFormat(manager->GetTotalCapacity()) << ", used: "
-			<< NiceSizeFormat(manager->GetTotalSize()) << std::endl;
+		manager->GetDebugString(buffer, sizeof(buffer));
+		str << "  " << buffer << std::endl;
 	}
 
 	const int padding = 10 + System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_LEFT);

--- a/GPU/Vulkan/DebugVisVulkan.cpp
+++ b/GPU/Vulkan/DebugVisVulkan.cpp
@@ -39,7 +39,7 @@
 
 #undef DrawText
 
-bool comparePushBufferNames(const VulkanPushBuffer *a, const VulkanPushBuffer *b) {
+bool comparePushBufferNames(const VulkanMemoryManager *a, const VulkanMemoryManager *b) {
 	return strcmp(a->Name(), b->Name()) < 0;
 }
 
@@ -75,13 +75,13 @@ void DrawAllocatorVis(UIContext *ui, GPUInterface *gpu) {
 	str << "Push buffers:" << std::endl;
 
 	// Now list the various push buffers.
-	auto pushBuffers = VulkanPushBuffer::GetAllActive();
-	std::sort(pushBuffers.begin(), pushBuffers.end(), comparePushBufferNames);
+	auto managers = GetActiveVulkanMemoryManagers();
+	std::sort(managers.begin(), managers.end(), comparePushBufferNames);
 
-	for (auto push : pushBuffers) {
-		str << "  " << push->Name() << " "
-			<< NiceSizeFormat(push->GetTotalCapacity()) << ", used: "
-			<< NiceSizeFormat(push->GetTotalSize()) << std::endl;
+	for (auto manager : managers) {
+		str << "  " << manager->Name() << " "
+			<< NiceSizeFormat(manager->GetTotalCapacity()) << ", used: "
+			<< NiceSizeFormat(manager->GetTotalSize()) << std::endl;
 	}
 
 	const int padding = 10 + System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_LEFT);

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -173,7 +173,7 @@ void DrawEngineVulkan::InitDeviceObjects() {
 		// the null texture. This should be cleaned up...
 	}
 
-	pushUBO = new VulkanPushPool(vulkan, "pushUBO", 4 * 1024 * 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+	pushUBO = (VulkanPushPool *)draw_->GetNativeObject(Draw::NativeObject::PUSH_POOL);
 	pushVertex = new VulkanPushPool(vulkan, "pushVertex", 2 * 1024 * 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 	pushIndex = new VulkanPushPool(vulkan, "pushIndex", 1 * 1024 * 1024, VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
 
@@ -252,11 +252,6 @@ void DrawEngineVulkan::DestroyDeviceObjects() {
 		delete pushIndex;
 		pushIndex = nullptr;
 	}
-	if (pushUBO) {
-		pushUBO->Destroy();
-		delete pushUBO;
-		pushUBO = nullptr;
-	}
 
 	if (samplerSecondaryNearest_ != VK_NULL_HANDLE)
 		vulkan->Delete().QueueDeleteSampler(samplerSecondaryNearest_);
@@ -297,7 +292,7 @@ void DrawEngineVulkan::BeginFrame() {
 
 	lastPipeline_ = nullptr;
 
-	pushUBO->BeginFrame();
+	// pushUBO is the thin3d push pool, don't need to BeginFrame again.
 	pushVertex->BeginFrame();
 	pushIndex->BeginFrame();
 

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -354,9 +354,8 @@ void DrawEngineVulkan::BeginFrame() {
 
 void DrawEngineVulkan::EndFrame() {
 	FrameData *frame = &GetCurFrame();
-	stats_.pushUBOSpaceUsed = 0; // (int)pushUBO->GetOffset();
-	stats_.pushVertexSpaceUsed = 0; // (int)frame->pushVertex->GetOffset();
-	stats_.pushIndexSpaceUsed = 0; // (int)frame->pushIndex->GetOffset();
+	stats_.pushVertexSpaceUsed = (int)pushVertex_->GetUsedThisFrame();
+	stats_.pushIndexSpaceUsed = (int)pushIndex_->GetUsedThisFrame();
 	vertexCache_->End();
 }
 

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -205,7 +205,7 @@ void DrawEngineVulkan::InitDeviceObjects() {
 	res = vkCreateSampler(device, &samp, nullptr, &nullSampler_);
 	_dbg_assert_(VK_SUCCESS == res);
 
-	vertexCache_ = new VulkanPushBuffer(vulkan, "pushVertexCache", VERTEX_CACHE_SIZE, VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, PushBufferType::CPU_TO_GPU);
+	vertexCache_ = new VulkanPushBuffer(vulkan, "pushVertexCache", VERTEX_CACHE_SIZE, VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 
 	tessDataTransferVulkan = new TessellationDataTransferVulkan(vulkan);
 	tessDataTransfer = tessDataTransferVulkan;
@@ -312,7 +312,7 @@ void DrawEngineVulkan::BeginFrame() {
 	if (vertexCache_->GetTotalSize() > VERTEX_CACHE_SIZE) {
 		vertexCache_->Destroy(vulkan);
 		delete vertexCache_;  // orphans the buffers, they'll get deleted once no longer used by an in-flight frame.
-		vertexCache_ = new VulkanPushBuffer(vulkan, "vertexCacheR", VERTEX_CACHE_SIZE, VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, PushBufferType::CPU_TO_GPU);
+		vertexCache_ = new VulkanPushBuffer(vulkan, "vertexCacheR", VERTEX_CACHE_SIZE, VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 		vai_.Iterate([&](uint32_t hash, VertexArrayInfoVulkan *vai) {
 			delete vai;
 		});

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -364,7 +364,7 @@ void DrawEngineVulkan::DecodeVertsToPushBuffer(VulkanPushBuffer *push, uint32_t 
 	// Figure out how much pushbuffer space we need to allocate.
 	if (push) {
 		int vertsToDecode = ComputeNumVertsToDecode();
-		dest = (u8 *)push->Push(vertsToDecode * dec_->GetDecVtxFmt().stride, bindOffset, vkbuf);
+		dest = (u8 *)push->Allocate(vertsToDecode * dec_->GetDecVtxFmt().stride, 4, vkbuf, bindOffset);
 	}
 	DecodeVerts(dest);
 }
@@ -691,7 +691,7 @@ void DrawEngineVulkan::DoFlush() {
 
 					if (useElements) {
 						u32 size = sizeof(uint16_t) * indexGen.VertexCount();
-						void *dest = vertexCache_->Push(size, &vai->ibOffset, &vai->ib);
+						void *dest = vertexCache_->Allocate(size, 4, &vai->ib, &vai->ibOffset);
 						memcpy(dest, decIndex, size);
 					} else {
 						vai->ib = VK_NULL_HANDLE;

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -174,8 +174,8 @@ void DrawEngineVulkan::InitDeviceObjects() {
 	}
 
 	pushUBO = (VulkanPushPool *)draw_->GetNativeObject(Draw::NativeObject::PUSH_POOL);
-	pushVertex = new VulkanPushPool(vulkan, "pushVertex", 2 * 1024 * 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
-	pushIndex = new VulkanPushPool(vulkan, "pushIndex", 1 * 1024 * 1024, VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
+	pushVertex = new VulkanPushPool(vulkan, "pushVertex", 4 * 1024 * 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
+	pushIndex = new VulkanPushPool(vulkan, "pushIndex", 1 * 512 * 1024, VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
 
 	VkPipelineLayoutCreateInfo pl{ VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
 	pl.pPushConstantRanges = nullptr;

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -194,7 +194,7 @@ public:
 	}
 
 	VulkanPushPool *GetPushBufferForTextureData() {
-		return pushUBO;
+		return pushUBO_;
 	}
 
 	const DrawEngineVulkanStats &GetStats() const {
@@ -279,9 +279,11 @@ private:
 	GEPrimitiveType lastPrim_ = GE_PRIM_INVALID;
 	FrameData frame_[VulkanContext::MAX_INFLIGHT_FRAMES];
 
-	VulkanPushPool *pushUBO = nullptr;
-	VulkanPushPool *pushVertex = nullptr;
-	VulkanPushPool *pushIndex = nullptr;
+	// This one's not accurately named, it's used for all kinds of stuff that's not vertices or indices.
+	VulkanPushPool *pushUBO_ = nullptr;
+
+	VulkanPushPool *pushVertex_ = nullptr;
+	VulkanPushPool *pushIndex_ = nullptr;
 
 	// Other
 	ShaderManagerVulkan *shaderManager_ = nullptr;

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -55,6 +55,7 @@ class FramebufferManagerVulkan;
 
 class VulkanContext;
 class VulkanPushBuffer;
+class VulkanPushPool;
 struct VulkanPipeline;
 
 struct DrawEngineVulkanStats {
@@ -218,6 +219,7 @@ private:
 
 	void DestroyDeviceObjects();
 
+	void DecodeVertsToPushPool(VulkanPushPool *push, uint32_t *bindOffset, VkBuffer *vkbuf);
 	void DecodeVertsToPushBuffer(VulkanPushBuffer *push, uint32_t *bindOffset, VkBuffer *vkbuf);
 
 	void DoFlush();
@@ -269,8 +271,6 @@ private:
 		VulkanDescSetPool descPool;
 
 		VulkanPushBuffer *pushUBO = nullptr;
-		VulkanPushBuffer *pushVertex = nullptr;
-		VulkanPushBuffer *pushIndex = nullptr;
 
 		// We do rolling allocation and reset instead of caching across frames. That we might do later.
 		DenseHashMap<DescriptorSetKey, VkDescriptorSet, (VkDescriptorSet)VK_NULL_HANDLE> descSets;
@@ -280,6 +280,9 @@ private:
 
 	GEPrimitiveType lastPrim_ = GE_PRIM_INVALID;
 	FrameData frame_[VulkanContext::MAX_INFLIGHT_FRAMES];
+
+	VulkanPushPool *pushVertex = nullptr;
+	VulkanPushPool *pushIndex = nullptr;
 
 	// Other
 	ShaderManagerVulkan *shaderManager_ = nullptr;

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -113,13 +113,13 @@ class TessellationDataTransferVulkan : public TessellationDataTransfer  {
 public:
 	TessellationDataTransferVulkan(VulkanContext *vulkan) : vulkan_(vulkan) {}
 
-	void SetPushBuffer(VulkanPushBuffer *push) { push_ = push; }
+	void SetPushPool(VulkanPushPool *push) { push_ = push; }
 	// Send spline/bezier's control points and weights to vertex shader through structured shader buffer.
 	void SendDataToShader(const SimpleVertex *const *points, int size_u, int size_v, u32 vertType, const Spline::Weight2D &weights) override;
 	const VkDescriptorBufferInfo *GetBufferInfo() { return bufInfo_; }
 private:
 	VulkanContext *vulkan_;
-	VulkanPushBuffer *push_;  // Updated each frame.
+	VulkanPushPool *push_;  // Updated each frame.
 	VkDescriptorBufferInfo bufInfo_[3]{};
 };
 
@@ -193,8 +193,8 @@ public:
 		lastPipeline_ = nullptr;
 	}
 
-	VulkanPushBuffer *GetPushBufferForTextureData() {
-		return GetCurFrame().pushUBO;
+	VulkanPushPool *GetPushBufferForTextureData() {
+		return pushUBO;
 	}
 
 	const DrawEngineVulkanStats &GetStats() const {
@@ -270,8 +270,6 @@ private:
 
 		VulkanDescSetPool descPool;
 
-		VulkanPushBuffer *pushUBO = nullptr;
-
 		// We do rolling allocation and reset instead of caching across frames. That we might do later.
 		DenseHashMap<DescriptorSetKey, VkDescriptorSet, (VkDescriptorSet)VK_NULL_HANDLE> descSets;
 
@@ -281,6 +279,7 @@ private:
 	GEPrimitiveType lastPrim_ = GE_PRIM_INVALID;
 	FrameData frame_[VulkanContext::MAX_INFLIGHT_FRAMES];
 
+	VulkanPushPool *pushUBO = nullptr;
 	VulkanPushPool *pushVertex = nullptr;
 	VulkanPushPool *pushIndex = nullptr;
 

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -59,7 +59,6 @@ class VulkanPushPool;
 struct VulkanPipeline;
 
 struct DrawEngineVulkanStats {
-	int pushUBOSpaceUsed;
 	int pushVertexSpaceUsed;
 	int pushIndexSpaceUsed;
 };

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -455,12 +455,11 @@ void GPU_Vulkan::GetStats(char *buffer, size_t bufsize) {
 	textureCacheVulkan_->GetStats(texStats, sizeof(texStats));
 	snprintf(buffer, bufsize,
 		"Vertex, Fragment, Pipelines loaded: %i, %i, %i\n"
-		"Pushbuffer space used: UBO %d, Vtx %d, Idx %d\n"
+		"Pushbuffer space used: Vtx %d, Idx %d\n"
 		"%s\n",
 		shaderManagerVulkan_->GetNumVertexShaders(),
 		shaderManagerVulkan_->GetNumFragmentShaders(),
 		pipelineManager_->GetNumPipelines(),
-		drawStats.pushUBOSpaceUsed,
 		drawStats.pushVertexSpaceUsed,
 		drawStats.pushIndexSpaceUsed,
 		texStats

--- a/GPU/Vulkan/ShaderManagerVulkan.h
+++ b/GPU/Vulkan/ShaderManagerVulkan.h
@@ -34,7 +34,7 @@
 
 class VulkanContext;
 class DrawEngineVulkan;
-class VulkanPushBuffer;
+class VulkanPushPool;
 
 class VulkanFragmentShader {
 public:
@@ -145,15 +145,15 @@ public:
 	bool IsLightDirty() { return true; }
 	bool IsBoneDirty() { return true; }
 
-	uint32_t PushBaseBuffer(VulkanPushBuffer *dest, VkBuffer *buf) {
-		return dest->PushAligned(&ub_base, sizeof(ub_base), uboAlignment_, buf);
+	uint32_t PushBaseBuffer(VulkanPushPool *dest, VkBuffer *buf) {
+		return dest->Push(&ub_base, sizeof(ub_base), uboAlignment_, buf);
 	}
-	uint32_t PushLightBuffer(VulkanPushBuffer *dest, VkBuffer *buf) {
-		return dest->PushAligned(&ub_lights, sizeof(ub_lights), uboAlignment_, buf);
+	uint32_t PushLightBuffer(VulkanPushPool *dest, VkBuffer *buf) {
+		return dest->Push(&ub_lights, sizeof(ub_lights), uboAlignment_, buf);
 	}
 	// TODO: Only push half the bone buffer if we only have four bones.
-	uint32_t PushBoneBuffer(VulkanPushBuffer *dest, VkBuffer *buf) {
-		return dest->PushAligned(&ub_bones, sizeof(ub_bones), uboAlignment_, buf);
+	uint32_t PushBoneBuffer(VulkanPushPool *dest, VkBuffer *buf) {
+		return dest->Push(&ub_bones, sizeof(ub_bones), uboAlignment_, buf);
 	}
 
 	bool LoadCacheFlags(FILE *f, DrawEngineVulkan *drawEngine);


### PR DESCRIPTION
This new `VulkanPushPool` is similar to 3x `VulkanPushBuffer`, except that unused buffers are shared among the (up to) 3 frame contexts - any frame can grab them if they're free and haven't been used in the last couple frames.

The result is that excessive allocations from spikes can be more efficiently re-used. When using texture packs with very large textures, VRAM consumption is cut by more than a third.

Anyway, the result will be good VRAM savings, effectively leading to less out-of-memory conditions. Though the effect is really mostly there when using large texture replacements.

The shrinking heuristics can be tweaked further, but it's doing a better job than the old code already. It's very non-aggressive to avoid excessive re-allocation, while shaving off really huge spikes over time.

Also changes the old VulkanPushBuffer to have the same allocation interface as the new one.