### PR TITLE
Thread manager: rename ThreadContext to TaskThreadContext

### DIFF
--- a/Common/Thread/ThreadManager.cpp
+++ b/Common/Thread/ThreadManager.cpp
@@ -25,25 +25,25 @@ const int MIN_IO_BLOCKING_THREADS = 4;
 static constexpr size_t TASK_PRIORITY_COUNT = (size_t)TaskPriority::COUNT;
 
 struct GlobalThreadContext {
-	std::mutex mutex; // associated with each respective condition variable
+	std::mutex mutex;
 	std::deque<Task *> compute_queue[TASK_PRIORITY_COUNT];
 	std::atomic<int> compute_queue_size;
 	std::deque<Task *> io_queue[TASK_PRIORITY_COUNT];
 	std::atomic<int> io_queue_size;
-	std::vector<ThreadContext *> threads_;
+	std::vector<TaskThreadContext *> threads_;
 
 	std::atomic<int> roundRobin;
 };
 
-struct ThreadContext {
+struct TaskThreadContext {
+	std::atomic<int> queue_size;
+	std::deque<Task *> private_queue[TASK_PRIORITY_COUNT];
 	std::thread thread; // the worker thread
 	std::condition_variable cond; // used to signal new work
 	std::mutex mutex; // protects the local queue.
-	std::atomic<int> queue_size;
 	int index;
 	TaskType type;
 	std::atomic<bool> cancelled;
-	std::deque<Task *> private_queue[TASK_PRIORITY_COUNT];
 	char name[16];
 };
 
@@ -58,7 +58,7 @@ ThreadManager::~ThreadManager() {
 }
 
 void ThreadManager::Teardown() {
-	for (ThreadContext *&threadCtx : global_->threads_) {
+	for (TaskThreadContext *&threadCtx : global_->threads_) {
 		threadCtx->cancelled = true;
 		std::unique_lock<std::mutex> lock(threadCtx->mutex);
 		threadCtx->cond.notify_one();
@@ -86,7 +86,7 @@ void ThreadManager::Teardown() {
 			continue;
 	}
 
-	for (ThreadContext *&threadCtx : global_->threads_) {
+	for (TaskThreadContext *&threadCtx : global_->threads_) {
 		threadCtx->thread.join();
 		// TODO: Is it better to just delete these?
 		for (size_t i = 0; i < TASK_PRIORITY_COUNT; ++i) {
@@ -128,7 +128,7 @@ bool ThreadManager::TeardownTask(Task *task, bool enqueue) {
 	return false;
 }
 
-static void WorkerThreadFunc(GlobalThreadContext *global, ThreadContext *thread) {
+static void WorkerThreadFunc(GlobalThreadContext *global, TaskThreadContext *thread) {
 	if (thread->type == TaskType::CPU_COMPUTE) {
 		snprintf(thread->name, sizeof(thread->name), "PoolWorker %d", thread->index);
 	} else {
@@ -223,7 +223,7 @@ void ThreadManager::Init(int numRealCores, int numLogicalCoresPerCpu) {
 	INFO_LOG(SYSTEM, "ThreadManager::Init(compute threads: %d, all: %d)", numComputeThreads_, numThreads_);
 
 	for (int i = 0; i < numThreads; i++) {
-		ThreadContext *thread = new ThreadContext();
+		TaskThreadContext *thread = new TaskThreadContext();
 		thread->cancelled.store(false);
 		thread->type = i < numComputeThreads_ ? TaskType::CPU_COMPUTE : TaskType::IO_BLOCKING;
 		thread->index = i;
@@ -261,7 +261,7 @@ void ThreadManager::EnqueueTask(Task *task) {
 	// Find a thread with no outstanding work.
 	_assert_(maxThread <= (int)global_->threads_.size());
 	for (int threadNum = minThread; threadNum < maxThread; threadNum++) {
-		ThreadContext *thread = global_->threads_[threadNum];
+		TaskThreadContext *thread = global_->threads_[threadNum];
 		if (thread->queue_size.load() == 0) {
 			std::unique_lock<std::mutex> lock(thread->mutex);
 			thread->private_queue[queueIndex].push_back(task);
@@ -289,7 +289,7 @@ void ThreadManager::EnqueueTask(Task *task) {
 
 	int chosenIndex = global_->roundRobin++;
 	chosenIndex = minThread + (chosenIndex % (maxThread - minThread));
-	ThreadContext *&chosenThread = global_->threads_[chosenIndex];
+	TaskThreadContext *&chosenThread = global_->threads_[chosenIndex];
 
 	// Lock the thread to ensure it gets the message.
 	std::unique_lock<std::mutex> lock(chosenThread->mutex);
@@ -300,7 +300,7 @@ void ThreadManager::EnqueueTaskOnThread(int threadNum, Task *task) {
 	_assert_msg_(task->Type() != TaskType::DEDICATED_THREAD, "Dedicated thread tasks can't be put on specific threads");
 
 	_assert_msg_(threadNum >= 0 && threadNum < (int)global_->threads_.size(), "Bad threadnum or not initialized");
-	ThreadContext *thread = global_->threads_[threadNum];
+	TaskThreadContext *thread = global_->threads_[threadNum];
 	size_t queueIndex = (size_t)task->Priority();
 
 	thread->queue_size++;

--- a/Common/Thread/ThreadManager.h
+++ b/Common/Thread/ThreadManager.h
@@ -44,7 +44,7 @@ public:
 	}
 };
 
-struct ThreadContext;
+struct TaskThreadContext;
 struct GlobalThreadContext;
 
 class ThreadManager {
@@ -81,7 +81,7 @@ private:
 	int numThreads_ = 0;
 	int numComputeThreads_ = 0;
 
-	friend struct ThreadContext;
+	friend struct TaskThreadContext;
 };
 
 extern ThreadManager g_threadManager;


### PR DESCRIPTION
Kept getting bogus debug symbols for ThreadContext so renamed it (I guess it collided with some other type).

Curiously, with this, it's much harder or impossible to reproduce #17124 ... Strange!