### PR TITLE
ThreadManager priority bugfix

### DIFF
--- a/Common/Log.cpp
+++ b/Common/Log.cpp
@@ -24,6 +24,7 @@
 #include "Common/Log.h"
 #include "StringUtils.h"
 #include "Common/Data/Encoding/Utf8.h"
+#include "Common/Thread/ThreadUtil.h"
 
 #if PPSSPP_PLATFORM(ANDROID)
 #include <android/log.h>
@@ -71,7 +72,7 @@ bool HandleAssert(const char *function, const char *file, int line, const char *
 	if (!getenv("CI")) {
 		int msgBoxStyle = MB_ICONINFORMATION | MB_YESNO;
 		std::wstring wtext = ConvertUTF8ToWString(formatted) + L"\n\nTry to continue?";
-		std::wstring wcaption = ConvertUTF8ToWString(caption);
+		std::wstring wcaption = ConvertUTF8ToWString(std::string(caption) + " " + GetCurrentThreadName());
 		OutputDebugString(wtext.c_str());
 		if (IDYES != MessageBox(0, wtext.c_str(), wcaption.c_str(), msgBoxStyle)) {
 			return false;

--- a/Common/Thread/Channel.h
+++ b/Common/Thread/Channel.h
@@ -24,9 +24,7 @@ struct Mailbox {
 
 	T Wait() {
 		std::unique_lock<std::mutex> lock(mutex_);
-		while (!dataReceived_) {
-			condvar_.wait(lock);
-		}
+		condvar_.wait(lock, [&] {return dataReceived_;});
 		return data_;
 	}
 

--- a/Common/Thread/ThreadManager.cpp
+++ b/Common/Thread/ThreadManager.cpp
@@ -164,12 +164,14 @@ static void WorkerThreadFunc(GlobalThreadContext *global, TaskThreadContext *thr
 
 					// We are processing one now, so mark that.
 					thread->queue_size++;
+					break;
 				} else if (thread->queue_size != 0) {
 					// Check the thread, as we prefer a HIGH thread task to a global NORMAL task.
 					std::unique_lock<std::mutex> lock(thread->mutex);
 					if (!thread->private_queue[p].empty()) {
 						task = thread->private_queue[p].front();
 						thread->private_queue[p].pop_front();
+						break;
 					}
 				}
 			}
@@ -198,9 +200,9 @@ static void WorkerThreadFunc(GlobalThreadContext *global, TaskThreadContext *thr
 		if (task) {
 			task->Run();
 			task->Release();
-
 			// Reduce the queue size once complete.
 			thread->queue_size--;
+			// _dbg_assert_(thread->queue_size == thread->private_queue[0].size() + thread->private_queue[1].size() + thread->private_queue[2].size());
 		}
 	}
 


### PR DESCRIPTION
After picking a task from the global queue, we have to break from the loop over priorities.

Fixes #17124 

Otherwise we might end up first picking a high priority task, but before we even get a chance to process it, we overwrite the task pointer with a lower priority task. So a task could get lost, and we got a deadlock if something was waiting on the task.