### PR TITLE
irjit: Fix vi2us/vi2s with non-consecutive

### DIFF
--- a/Common/GPU/Vulkan/VulkanMemory.cpp
+++ b/Common/GPU/Vulkan/VulkanMemory.cpp
@@ -18,6 +18,7 @@
 // Additionally, Common/Vulkan/* , including this file, are also licensed
 // under the public domain.
 
+#include <algorithm>
 #include <set>
 #include <mutex>
 

--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -206,11 +206,12 @@ void *AllocateExecutableMemory(size_t size) {
 }
 
 void *AllocateMemoryPages(size_t size, uint32_t memProtFlags) {
-	size = ppsspp_round_page(size);
 #ifdef _WIN32
 	if (sys_info.dwPageSize == 0)
 		GetSystemInfo(&sys_info);
 	uint32_t protect = ConvertProtFlagsWin32(memProtFlags);
+	// Make sure to do this after GetSystemInfo().
+	size = ppsspp_round_page(size);
 #if PPSSPP_PLATFORM(UWP)
 	void* ptr = VirtualAllocFromApp(0, size, MEM_COMMIT, protect);
 #else
@@ -221,6 +222,7 @@ void *AllocateMemoryPages(size_t size, uint32_t memProtFlags) {
 		return nullptr;
 	}
 #else
+	size = ppsspp_round_page(size);
 	uint32_t protect = ConvertProtFlagsUnix(memProtFlags);
 	void *ptr = mmap(0, size, protect, MAP_ANON | MAP_PRIVATE, -1, 0);
 	if (ptr == MAP_FAILED) {

--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -72,6 +72,10 @@ namespace MIPSComp {
 			     regs[3] == regs[2] + 1;
 	}
 
+	static bool IsVec2(VectorSize sz, const u8 regs[2]) {
+		return sz == V_Pair && IsConsecutive2(regs) && (regs[0] & 1) == 0;
+	}
+
 	static bool IsVec4(VectorSize sz, const u8 regs[4]) {
 		return sz == V_Quad && IsConsecutive4(regs) && (regs[0] & 3) == 0;
 	}
@@ -1534,10 +1538,10 @@ namespace MIPSComp {
 
 		int nOut = GetNumVectorElements(outsize);
 
-		// If src registers aren't contiguous, make them (mainly for bits == 8.)
-		if (sz == V_Quad && !IsVec4(sz, sregs)) {
+		// If src registers aren't contiguous, make them.
+		if (!IsVec2(sz, sregs) && !IsVec4(sz, sregs)) {
 			// T prefix is unused.
-			for (int i = 0; i < 4; i++) {
+			for (int i = 0; i < GetNumVectorElements(sz); i++) {
 				srcregs[i] = IRVTEMP_PFX_T + i;
 				ir.Write(IROp::FMov, srcregs[i], sregs[i]);
 			}


### PR DESCRIPTION
This fixes the crashes noted in #17109, I think.  At least it fixes the Windows one, and based on some partial debug info I got I think vi2us/vi2s was the cause.  If it doesn't fix it, this still is a bug that should be fixed.

-[Unknown]