### PR TITLE
Minor leak fix

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1853,6 +1853,11 @@ int __AtracSetContext(Atrac *atrac) {
 		return hleReportError(ME, ATRAC_ERROR_UNKNOWN_FORMAT, "unknown codec type in set context");
 	}
 
+	if (atrac->codecCtx_) {
+		// Shouldn't happen, but just in case.
+		atrac->ReleaseFFMPEGContext();
+	}
+
 	const AVCodec *codec = avcodec_find_decoder(ff_codec);
 	atrac->codecCtx_ = avcodec_alloc_context3(codec);
 

--- a/Windows/TouchInputHandler.cpp
+++ b/Windows/TouchInputHandler.cpp
@@ -98,24 +98,18 @@ void TouchInputHandler::handleTouchEvent(HWND hWnd, UINT message, WPARAM wParam,
 
 // from http://msdn.microsoft.com/en-us/library/ms812373.aspx
 // disable the press and hold gesture for the given window
-void TouchInputHandler::disablePressAndHold(HWND hWnd)
-{
+void TouchInputHandler::disablePressAndHold(HWND hWnd) {
 	// The atom identifier and Tablet PC atom
-	ATOM atomID = 0;
 	LPCTSTR tabletAtom = _T("MicrosoftTabletPenServiceProperty");
-	
-	// Get the Tablet PC atom ID
-	atomID = GlobalAddAtom(tabletAtom);
+	ATOM atomID = GlobalAddAtom(tabletAtom);
 	
 	// If getting the ID failed, return false
-	if (atomID == 0)
-	{
-	 return;
+	if (atomID != 0) {
+		// Try to disable press and hold gesture by setting the window property.
+		SetProp(hWnd, tabletAtom, (HANDLE)1);
 	}
-	
-	// Try to disable press and hold gesture by 
-	// setting the window property, return the result
-	SetProp(hWnd, tabletAtom, (HANDLE)1);
+
+	GlobalDeleteAtom(atomID);
 }
 
 void TouchInputHandler::touchUp(int id, float x, float y){


### PR DESCRIPTION
Based on #17077, but not sure the glslang leak is in our code, maybe even misdetected.  Atrac I believe since Valgrind also reports, but we seem to be calling avcodec_free_context() properly.

-[Unknown]