### PR TITLE
Argument code cleanup (avoid input/output args)

### DIFF
--- a/Common/GPU/Vulkan/VulkanMemory.cpp
+++ b/Common/GPU/Vulkan/VulkanMemory.cpp
@@ -158,7 +158,7 @@ void VulkanPushBuffer::GetDebugString(char *buffer, size_t bufSize) const {
 		sum += size_ * (buffers_.size() - 1);
 	sum += offset_;
 	size_t capacity = size_ * buffers_.size();
-	snprintf(buffer, bufSize, "Push %s: %s/%s", name_, NiceSizeFormat(capacity).c_str(), NiceSizeFormat(sum).c_str());
+	snprintf(buffer, bufSize, "Push %s: %s / %s", name_, NiceSizeFormat(sum).c_str(), NiceSizeFormat(capacity).c_str());
 }
 
 void VulkanPushBuffer::Map() {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2924,7 +2924,7 @@ void TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, i
 
 		if (plan.scaleFactor > 1) {
 			// Note that this updates w and h!
-			scaler_.ScaleAlways((u32 *)data, pixelData, w, h, plan.scaleFactor);
+			scaler_.ScaleAlways((u32 *)data, pixelData, w, h, &w, &h, plan.scaleFactor);
 			pixelData = (u32 *)data;
 
 			decPitch = w * 4;

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -131,7 +131,7 @@ protected:
 	void ParseHashRange(const std::string &key, const std::string &value);
 	void ParseFiltering(const std::string &key, const std::string &value);
 	void ParseReduceHashRange(const std::string& key, const std::string& value);
-	bool LookupHashRange(u32 addr, int &w, int &h);
+	bool LookupHashRange(u32 addr, int w, int h, int *newW, int *newH);
 	float LookupReduceHashRange(int& w, int& h);
 	std::string LookupHashFile(u64 cachekey, u32 hash, bool *foundAlias, bool *ignored);
 	void PopulateReplacement(ReplacedTexture *result, u64 cachekey, u32 hash, int w, int h);
@@ -157,12 +157,14 @@ protected:
 	typedef std::pair<int, int> WidthHeightPair;
 	std::unordered_map<u64, WidthHeightPair> hashranges_;
 	std::unordered_map<u64, float> reducehashranges_;
+
 	std::unordered_map<ReplacementCacheKey, std::string> aliases_;
 	std::unordered_map<ReplacementCacheKey, TextureFiltering> filtering_;
 
 	std::unordered_map<ReplacementCacheKey, ReplacedTexture *> cache_;
 	std::unordered_map<ReplacementCacheKey, SavedTextureCacheData> savedCache_;
 
-	// the key is from aliases_. It's a |-separated sequence of texture filenames of the levels of a texture.
+	// the key is either from aliases_, in which case it's a |-separated sequence of texture filenames of the levels of a texture.
+	// alternatively the key is from the generated texture filename.
 	std::unordered_map<std::string, ReplacedLevelsCache> levelCache_;
 };

--- a/GPU/Common/TextureScalerCommon.h
+++ b/GPU/Common/TextureScalerCommon.h
@@ -30,9 +30,9 @@ public:
 	TextureScalerCommon();
 	~TextureScalerCommon();
 
-	void ScaleAlways(u32 *out, u32 *src, int &width, int &height, int factor);
-	bool Scale(u32 *&data, int &width, int &height, int factor);
-	bool ScaleInto(u32 *out, u32 *src, int &width, int &height, int factor);
+	void ScaleAlways(u32 *out, u32 *src, int width, int height, int *scaledWidth, int *scaledHeight, int factor);
+	bool Scale(u32 *&data, int width, int height, int *scaledWidth, int *scaledHeight, int factor);
+	bool ScaleInto(u32 *out, u32 *src, int width, int height, int *scaledWidth, int *scaledHeight, int factor);
 
 	enum { XBRZ = 0, HYBRID = 1, BICUBIC = 2, HYBRID_BICUBIC = 3 };
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -754,7 +754,7 @@ void TextureCacheVulkan::LoadVulkanTextureLevel(TexCacheEntry &entry, uint8_t *w
 		u32 fmt = dstFmt;
 		// CPU scaling reads from the destination buffer so we want cached RAM.
 		uint8_t *rearrange = (uint8_t *)AllocateAlignedMemory(w * scaleFactor * h * scaleFactor * 4, 16);
-		scaler_.ScaleAlways((u32 *)rearrange, pixelData, w, h, scaleFactor);
+		scaler_.ScaleAlways((u32 *)rearrange, pixelData, w, h, &w, &h, scaleFactor);
 		pixelData = (u32 *)writePtr;
 
 		// We always end up at 8888.  Other parts assume this.


### PR DESCRIPTION
Function arguments that are used both as input and output are confusing, especially when they're references so you can't see it.

Change some for input/output pairs, where the output is a pointer, making it more visible what's going on.