### PR TITLE
Refactor the replacement cache

### DIFF
--- a/Common/GPU/Vulkan/VulkanMemory.cpp
+++ b/Common/GPU/Vulkan/VulkanMemory.cpp
@@ -158,7 +158,7 @@ void VulkanPushBuffer::GetDebugString(char *buffer, size_t bufSize) const {
 		sum += size_ * (buffers_.size() - 1);
 	sum += offset_;
 	size_t capacity = size_ * buffers_.size();
-	snprintf(buffer, bufSize, "Push %s: %s/%s", name_, NiceSizeFormat(capacity).c_str(), NiceSizeFormat(sum).c_str());
+	snprintf(buffer, bufSize, "Push %s: %s / %s", name_, NiceSizeFormat(sum).c_str(), NiceSizeFormat(capacity).c_str());
 }
 
 void VulkanPushBuffer::Map() {

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -129,14 +129,12 @@ void ReplacedTexture::PurgeIfNotUsedSinceTime(double t) {
 		}
 	}
 
-	// "atomic-enough" to not lock?
+	// This is the only place except shutdown where a texture can transition
+	// from ACTIVE to anything else, so we don't actually need to lock here.
 	if (lastUsed_ >= t) {
 		return;
 	}
 
-	std::lock_guard<std::mutex> guard(lock_);
-
-	// We have to lock since multiple textures might reference this same data.
 	data_.clear();
 	levels_.clear();
 	fmt = Draw::DataFormat::UNDEFINED;

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -170,19 +170,19 @@ private:
 
 	void Prepare(VFSBackend *vfs);
 	LoadLevelResult LoadLevelData(VFSFileReference *fileRef, const std::string &filename, int level, Draw::DataFormat *pixelFormat);
-	void PurgeIfOlder(double t);
+	void PurgeIfNotUsedSinceTime(double t);
 
 	std::vector<std::vector<uint8_t>> data_;
 	std::vector<ReplacedTextureLevel> levels_;
 
-	ReplacedTextureAlpha alphaStatus_ = ReplacedTextureAlpha::UNKNOWN;
 	double lastUsed_ = 0.0;
 	LimitedWaitable *threadWaitable_ = nullptr;
 	std::mutex lock_;
 	Draw::DataFormat fmt = Draw::DataFormat::UNDEFINED;  // NOTE: Right now, the only supported format is Draw::DataFormat::R8G8B8A8_UNORM.
+	ReplacedTextureAlpha alphaStatus_ = ReplacedTextureAlpha::UNKNOWN;
 	double lastUsed = 0.0;
 
-	std::atomic<ReplacementState> state_ = ReplacementState::UNINITIALIZED;
+	std::atomic<ReplacementState> state_ = ReplacementState::POPULATED;
 
 	VFSBackend *vfs_ = nullptr;
 	ReplacementDesc desc_;

--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -24,7 +24,6 @@
 #include "Common/GPU/thin3d.h"
 #include "Common/Log.h"
 
-struct ReplacedLevelsCache;
 class TextureReplacer;
 class LimitedWaitable;
 
@@ -51,16 +50,6 @@ enum class ReplacedImageType {
 };
 
 static const int MAX_REPLACEMENT_MIP_LEVELS = 12;  // 12 should be plenty, 8 is the max mip levels supported by the PSP.
-
-// Metadata about a given texture level.
-struct ReplacedTextureLevel {
-	int w = 0;
-	int h = 0;
-
-	// To be able to reload, we need to be able to reopen, unfortunate we can't use zip_file_t.
-	// TODO: This really belongs on the level in the cache, not in the individual ReplacedTextureLevel objects.
-	VFSFileReference *fileRef = nullptr;
-};
 
 enum class ReplacementState : uint32_t {
 	UNINITIALIZED,
@@ -89,23 +78,33 @@ struct ReplacementDesc {
 	int h;
 	std::string hashfiles;
 	Path basePath;
-	bool foundAlias;
 	std::vector<std::string> filenames;
 	std::string logId;
-	ReplacedLevelsCache *cache;
 	GPUFormatSupport formatSupport;
 };
 
-struct ReplacedLevelsCache {
-	Draw::DataFormat fmt = Draw::DataFormat::UNDEFINED;
-	std::mutex lock;
-	std::vector<std::vector<uint8_t>> data;
-	double lastUsed = 0.0;
-};
+class ReplacedTexture;
 
 // These aren't actually all replaced, they can also represent a placeholder for a not-found
-// replacement (state_ == NOT_FOUND).
-struct ReplacedTexture {
+// replacement (texture == nullptr).
+struct ReplacedTextureRef {
+	ReplacedTexture *texture;  // shortcut
+	std::string hashfiles;  // key into the cache
+};
+
+// Metadata about a given texture level.
+struct ReplacedTextureLevel {
+	int w = 0;
+	int h = 0;
+
+	// To be able to reload, we need to be able to reopen, unfortunate we can't use zip_file_t.
+	// TODO: This really belongs on the level in the cache, not in the individual ReplacedTextureLevel objects.
+	VFSFileReference *fileRef = nullptr;
+};
+
+class ReplacedTexture {
+public:
+	ReplacedTexture(VFSBackend *vfs, const ReplacementDesc &desc);
 	~ReplacedTexture();
 
 	inline ReplacementState State() const {
@@ -129,7 +128,18 @@ struct ReplacedTexture {
 
 	int GetLevelDataSize(int level) const {
 		_dbg_assert_(State() == ReplacementState::ACTIVE);
-		return (int)levelData_->data[level].size();
+		return (int)data_[level].size();
+	}
+
+	size_t GetTotalDataSize() const {
+		if (State() != ReplacementState::ACTIVE) {
+			return 0;
+		}
+		size_t sz = 0;
+		for (auto &data : data_) {
+			sz += data.size();
+		}
+		return sz;
 	}
 
 	int NumLevels() const {
@@ -149,7 +159,6 @@ struct ReplacedTexture {
 	bool IsReady(double budget);
 	bool CopyLevelTo(int level, void *out, int rowPitch);
 
-	void FinishPopulate(ReplacementDesc *desc);
 	std::string logId_;
 
 private:
@@ -163,19 +172,20 @@ private:
 	LoadLevelResult LoadLevelData(VFSFileReference *fileRef, const std::string &filename, int level, Draw::DataFormat *pixelFormat);
 	void PurgeIfOlder(double t);
 
+	std::vector<std::vector<uint8_t>> data_;
 	std::vector<ReplacedTextureLevel> levels_;
-	ReplacedLevelsCache *levelData_ = nullptr;
 
 	ReplacedTextureAlpha alphaStatus_ = ReplacedTextureAlpha::UNKNOWN;
 	double lastUsed_ = 0.0;
 	LimitedWaitable *threadWaitable_ = nullptr;
-	std::mutex mutex_;
+	std::mutex lock_;
 	Draw::DataFormat fmt = Draw::DataFormat::UNDEFINED;  // NOTE: Right now, the only supported format is Draw::DataFormat::R8G8B8A8_UNORM.
+	double lastUsed = 0.0;
 
 	std::atomic<ReplacementState> state_ = ReplacementState::UNINITIALIZED;
 
 	VFSBackend *vfs_ = nullptr;
-	ReplacementDesc *desc_ = nullptr;
+	ReplacementDesc desc_;
 
 	friend class TextureReplacer;
 	friend class ReplacedTextureTask;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1523,9 +1523,8 @@ ReplacedTexture *TextureCacheCommon::FindReplacement(TexCacheEntry *entry, int &
 	constexpr double MAX_BUDGET_PER_TEX = 0.25 / 60.0;
 
 	double replaceStart = time_now_d();
-	double budget = std::min(MAX_BUDGET_PER_TEX, replacementFrameBudget_ - replacementTimeThisFrame_);
 	u64 cachekey = replacer_.Enabled() ? entry->CacheKey() : 0;
-	ReplacedTexture *replaced = replacer_.FindReplacement(cachekey, entry->fullhash, w, h, budget);
+	ReplacedTexture *replaced = replacer_.FindReplacement(cachekey, entry->fullhash, w, h);
 	if (!replaced) {
 		// TODO: Remove the flag here?
 		// entry->status &= ~TexCacheEntry::STATUS_TO_REPLACE;
@@ -1533,6 +1532,7 @@ ReplacedTexture *TextureCacheCommon::FindReplacement(TexCacheEntry *entry, int &
 		return nullptr;
 	}
 
+	double budget = std::min(MAX_BUDGET_PER_TEX, replacementFrameBudget_ - replacementTimeThisFrame_);
 	if (replaced->IsReady(budget)) {
 		if (replaced->State() == ReplacementState::ACTIVE) {
 			replaced->GetSize(0, &w, &h);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2847,7 +2847,6 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 			replacedInfo.hash = entry->fullhash;
 			replacedInfo.addr = entry->addr;
 			replacedInfo.isFinal = (entry->status & TexCacheEntry::STATUS_TO_SCALE) == 0;
-			replacedInfo.scaleFactor = plan.scaleFactor;
 			replacedInfo.isVideo = plan.isVideo;
 			replacedInfo.fmt = Draw::DataFormat::R8G8B8A8_UNORM;
 			plan.saveTexture = replacer_.WillSave(replacedInfo);
@@ -2899,7 +2898,7 @@ void TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, i
 		GETextureFormat tfmt = (GETextureFormat)entry.format;
 		GEPaletteFormat clutformat = gstate.getClutPaletteFormat();
 		u32 texaddr = gstate.getTextureAddress(srcLevel);
-		int bufw = GetTextureBufw(srcLevel, texaddr, tfmt);
+		const int bufw = GetTextureBufw(srcLevel, texaddr, tfmt);
 		u32 *pixelData;
 		int decPitch;
 		if (plan.scaleFactor > 1) {
@@ -2922,19 +2921,20 @@ void TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, i
 		CheckAlphaResult alphaResult = DecodeTextureLevel((u8 *)pixelData, decPitch, tfmt, clutformat, texaddr, srcLevel, bufw, texDecFlags);
 		entry.SetAlphaStatus(alphaResult, srcLevel);
 
+		int scaledW = w, scaledH = h;
 		if (plan.scaleFactor > 1) {
 			// Note that this updates w and h!
-			scaler_.ScaleAlways((u32 *)data, pixelData, w, h, &w, &h, plan.scaleFactor);
+			scaler_.ScaleAlways((u32 *)data, pixelData, w, h, &scaledW, &scaledH, plan.scaleFactor);
 			pixelData = (u32 *)data;
 
-			decPitch = w * 4;
+			decPitch = scaledW * sizeof(u32);
 
 			if (decPitch != stride) {
 				// Rearrange in place to match the requested pitch.
 				// (it can only be larger than w * bpp, and a match is likely.)
 				// Note! This is bad because it reads the mapped memory! TODO: Look into if DX9 does this right.
-				for (int y = h - 1; y >= 0; --y) {
-					memcpy((u8 *)data + stride * y, (u8 *)data + decPitch * y, w * 4);
+				for (int y = scaledH - 1; y >= 0; --y) {
+					memcpy((u8 *)data + stride * y, (u8 *)data + decPitch * y, scaledW *4);
 				}
 				decPitch = stride;
 			}
@@ -2947,11 +2947,10 @@ void TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, i
 			replacedInfo.addr = entry.addr;
 			replacedInfo.isVideo = IsVideo(entry.addr);
 			replacedInfo.isFinal = (entry.status & TexCacheEntry::STATUS_TO_SCALE) == 0;
-			replacedInfo.scaleFactor = plan.scaleFactor;
 			replacedInfo.fmt = dstFmt;
 
 			// NOTE: Reading the decoded texture here may be very slow, if we just wrote it to write-combined memory.
-			replacer_.NotifyTextureDecoded(replacedInfo, pixelData, decPitch, srcLevel, w, h);
+			replacer_.NotifyTextureDecoded(replacedInfo, pixelData, decPitch, srcLevel, w, h, scaledW, scaledH);
 		}
 	}
 }

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2924,7 +2924,7 @@ void TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, i
 
 		if (plan.scaleFactor > 1) {
 			// Note that this updates w and h!
-			scaler_.ScaleAlways((u32 *)data, pixelData, w, h, plan.scaleFactor);
+			scaler_.ScaleAlways((u32 *)data, pixelData, w, h, &w, &h, plan.scaleFactor);
 			pixelData = (u32 *)data;
 
 			decPitch = w * 4;

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -69,10 +69,9 @@ TextureReplacer::TextureReplacer(Draw::DrawContext *draw) {
 }
 
 TextureReplacer::~TextureReplacer() {
-	for (auto &iter : cache_) {
+	for (auto iter : levelCache_) {
 		delete iter.second;
 	}
-
 	delete vfs_;
 }
 
@@ -179,7 +178,7 @@ bool TextureReplacer::LoadIni() {
 
 	// If we have stuff loaded from before, need to update the vfs pointers to avoid
 	// crash on exit. The actual problem is that we tend to call LoadIni a little too much...
-	for (auto &repl : cache_) {
+	for (auto &repl : levelCache_) {
 		repl.second->vfs_ = vfs_;
 	}
 
@@ -461,7 +460,7 @@ u32 TextureReplacer::ComputeHash(u32 addr, int bufw, int w, int h, GETextureForm
 	}
 }
 
-ReplacedTexture *TextureReplacer::FindReplacement(u64 cachekey, u32 hash, int w, int h, double budget) {
+ReplacedTexture *TextureReplacer::FindReplacement(u64 cachekey, u32 hash, int w, int h) {
 	// Only actually replace if we're replacing.  We might just be saving.
 	if (!Enabled() || !g_Config.bReplaceTextures) {
 		return nullptr;
@@ -470,74 +469,76 @@ ReplacedTexture *TextureReplacer::FindReplacement(u64 cachekey, u32 hash, int w,
 	ReplacementCacheKey replacementKey(cachekey, hash);
 	auto it = cache_.find(replacementKey);
 	if (it != cache_.end()) {
-		if (it->second->State() == ReplacementState::UNINITIALIZED && budget > 0.0) {
-			// We don't do this on a thread, but we only do it while within budget.
-			PopulateReplacement(it->second, cachekey, hash, w, h);
-		}
-		return it->second;
+		return it->second.texture;
 	}
 
-	// Okay, let's construct the result.
-
-	ReplacedTexture *result = new ReplacedTexture();
-	result->vfs_ = this->vfs_;
-	if (budget > 0.0) {
-		_dbg_assert_(result->State() == ReplacementState::UNINITIALIZED);
-		PopulateReplacement(result, cachekey, hash, w, h);
-	} else {
-		// WARN_LOG(G3D, "Postponing preparing texture (%dx%d)", w, h);
-	}
-	cache_[replacementKey] = result;
-	return result;
-}
-
-void TextureReplacer::PopulateReplacement(ReplacedTexture *texture, u64 cachekey, u32 hash, int w, int h) {
-	// We pass this to a thread, so can't keep it on the stack.
-	ReplacementDesc *desc = new ReplacementDesc();
-	desc->newW = w;
-	desc->newH = h;
-	desc->w = w;
-	desc->h = h;
-	desc->cachekey = cachekey;
-	desc->hash = hash;
-	desc->basePath = basePath_;
-	desc->formatSupport = formatSupport_;
-	LookupHashRange(cachekey >> 32, w, h, &desc->newW, &desc->newH);
+	ReplacementDesc desc;
+	desc.newW = w;
+	desc.newH = h;
+	desc.w = w;
+	desc.h = h;
+	desc.cachekey = cachekey;
+	desc.hash = hash;
+	LookupHashRange(cachekey >> 32, w, h, &desc.newW, &desc.newH);
 
 	if (ignoreAddress_) {
 		cachekey = cachekey & 0xFFFFFFFFULL;
 	}
 
-	desc->foundAlias = false;
+	bool foundAlias = false;
 	bool ignored = false;
-	desc->hashfiles = LookupHashFile(cachekey, hash, &desc->foundAlias, &ignored);
+	std::string hashfiles = LookupHashFile(cachekey, hash, &foundAlias, &ignored);
 
 	// Early-out for ignored textures, let's not bother even starting a thread task.
 	if (ignored) {
 		// WARN_LOG(G3D, "Not found/ignored: %s (%d, %d)", hashfiles.c_str(), (int)foundReplacement, (int)ignored);
-		// nothing to do?
-		texture->SetState(ReplacementState::NOT_FOUND);
-		return;
+		// Insert an entry into the cache for faster lookup next time.
+		ReplacedTextureRef ref{};
+		cache_.emplace(std::make_pair(replacementKey, ref));
+		return nullptr;
 	}
 
-	if (!desc->foundAlias) {
+	if (!foundAlias) {
 		// We'll just need to generate the names for each level.
 		// By default, we look for png since that's also what's dumped.
 		// For other file formats, use the ini to create aliases.
-		desc->filenames.resize(MAX_REPLACEMENT_MIP_LEVELS);
-		for (int level = 0; level < desc->filenames.size(); level++) {
-			desc->filenames[level] = TextureReplacer::HashName(desc->cachekey, desc->hash, level) + ".png";
+		desc.filenames.resize(MAX_REPLACEMENT_MIP_LEVELS);
+		for (int level = 0; level < desc.filenames.size(); level++) {
+			desc.filenames[level] = TextureReplacer::HashName(cachekey, hash, level) + ".png";
 		}
-		desc->logId = desc->filenames[0];
-		desc->hashfiles = desc->filenames[0];  // This is used as the key in the data cache.
+		desc.logId = desc.filenames[0];
+		desc.hashfiles = desc.filenames[0];  // The generated filename of the top level is used as the key in the data cache.
 	} else {
-		desc->logId = desc->hashfiles;
-		SplitString(desc->hashfiles, '|', desc->filenames);
+		desc.logId = hashfiles;
+		SplitString(hashfiles, '|', desc.filenames);
+		desc.hashfiles = hashfiles;
 	}
 
-	desc->cache = &levelCache_[desc->hashfiles];
+	// OK, we might already have a matching texture, we use hashfiles as a key. Look it up in the level cache.
+	auto iter = levelCache_.find(hashfiles);
+	if (iter != levelCache_.end()) {
+		// Insert an entry into the cache for faster lookup next time.
+		ReplacedTextureRef ref;
+		ref.hashfiles = hashfiles;
+		ref.texture = iter->second;
+		cache_.emplace(std::make_pair(replacementKey, ref));
+		return iter->second;
+	}
 
-	texture->FinishPopulate(desc);
+	// Final path - we actually need a new replacement texture, because we haven't seen "hashfiles" before.
+	desc.basePath = basePath_;
+	desc.formatSupport = formatSupport_;
+
+	ReplacedTexture *texture = new ReplacedTexture(vfs_, desc);
+
+	ReplacedTextureRef ref;
+	ref.hashfiles = hashfiles;
+	ref.texture = texture;
+	cache_.emplace(std::make_pair(replacementKey, ref));
+
+	// Also, insert the level in the level cache so we can look up by desc_->hashfiles again.
+	levelCache_.emplace(std::make_pair(hashfiles, texture));
+	return texture;
 }
 
 static bool WriteTextureToPNG(png_imagep image, const Path &filename, int convert_to_8bit, const void *buffer, png_int_32 row_stride, const void *colormap) {
@@ -742,15 +743,12 @@ void TextureReplacer::Decimate(ReplacerDecimateMode mode) {
 	}
 
 	const double threshold = time_now_d() - age;
-	for (auto &item : cache_) {
-		item.second->PurgeIfOlder(threshold);
-		// don't actually delete the items here, just clean out the data.
-	}
-
 	size_t totalSize = 0;
 	for (auto &item : levelCache_) {
-		std::lock_guard<std::mutex> guard(item.second.lock);
-		totalSize += item.second.data.size();
+		std::lock_guard<std::mutex> guard(item.second->lock_);
+		item.second->PurgeIfOlder(threshold);
+		totalSize += item.second->GetTotalDataSize();  // TODO: Make something better.
+		// don't actually delete the items here, just clean out the data.
 	}
 
 	double totalSizeGB = totalSize / (1024.0 * 1024.0 * 1024.0);

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -746,7 +746,7 @@ void TextureReplacer::Decimate(ReplacerDecimateMode mode) {
 	size_t totalSize = 0;
 	for (auto &item : levelCache_) {
 		std::lock_guard<std::mutex> guard(item.second->lock_);
-		item.second->PurgeIfOlder(threshold);
+		item.second->PurgeIfNotUsedSinceTime(threshold);
 		totalSize += item.second->GetTotalDataSize();  // TODO: Make something better.
 		// don't actually delete the items here, just clean out the data.
 	}

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -81,7 +81,6 @@ struct ReplacedTextureDecodeInfo {
 	u32 addr;
 	bool isVideo;
 	bool isFinal;
-	int scaleFactor;
 	Draw::DataFormat fmt;
 };
 
@@ -112,8 +111,8 @@ public:
 	// Check if a NotifyTextureDecoded for this texture is desired (used to avoid reads from write-combined memory.)
 	bool WillSave(const ReplacedTextureDecodeInfo &replacedInfo);
 
-	// Notify that a new texture was decoded.  May already be upscaled, saves the data passed.
-	void NotifyTextureDecoded(const ReplacedTextureDecodeInfo &replacedInfo, const void *data, int pitch, int level, int w, int h);
+	// Notify that a new texture was decoded. May already be upscaled, saves the data passed.
+	void NotifyTextureDecoded(const ReplacedTextureDecodeInfo &replacedInfo, const void *data, int pitch, int level, int origW, int origH, int scaledW, int scaledH);
 
 	void Decimate(ReplacerDecimateMode mode);
 

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -131,7 +131,7 @@ protected:
 	void ParseHashRange(const std::string &key, const std::string &value);
 	void ParseFiltering(const std::string &key, const std::string &value);
 	void ParseReduceHashRange(const std::string& key, const std::string& value);
-	bool LookupHashRange(u32 addr, int &w, int &h);
+	bool LookupHashRange(u32 addr, int w, int h, int *newW, int *newH);
 	float LookupReduceHashRange(int& w, int& h);
 	std::string LookupHashFile(u64 cachekey, u32 hash, bool *foundAlias, bool *ignored);
 	void PopulateReplacement(ReplacedTexture *result, u64 cachekey, u32 hash, int w, int h);
@@ -157,12 +157,14 @@ protected:
 	typedef std::pair<int, int> WidthHeightPair;
 	std::unordered_map<u64, WidthHeightPair> hashranges_;
 	std::unordered_map<u64, float> reducehashranges_;
+
 	std::unordered_map<ReplacementCacheKey, std::string> aliases_;
 	std::unordered_map<ReplacementCacheKey, TextureFiltering> filtering_;
 
 	std::unordered_map<ReplacementCacheKey, ReplacedTexture *> cache_;
 	std::unordered_map<ReplacementCacheKey, SavedTextureCacheData> savedCache_;
 
-	// the key is from aliases_. It's a |-separated sequence of texture filenames of the levels of a texture.
+	// the key is either from aliases_, in which case it's a |-separated sequence of texture filenames of the levels of a texture.
+	// alternatively the key is from the generated texture filename.
 	std::unordered_map<std::string, ReplacedLevelsCache> levelCache_;
 };

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -105,7 +105,7 @@ public:
 	u32 ComputeHash(u32 addr, int bufw, int w, int h, GETextureFormat fmt, u16 maxSeenV);
 
 	// Returns nullptr if not found.
-	ReplacedTexture *FindReplacement(u64 cachekey, u32 hash, int w, int h, double budget);
+	ReplacedTexture *FindReplacement(u64 cachekey, u32 hash, int w, int h);
 	bool FindFiltering(u64 cachekey, u32 hash, TextureFiltering *forceFiltering);
 
 	// Check if a NotifyTextureDecoded for this texture is desired (used to avoid reads from write-combined memory.)
@@ -133,7 +133,6 @@ protected:
 	bool LookupHashRange(u32 addr, int w, int h, int *newW, int *newH);
 	float LookupReduceHashRange(int& w, int& h);
 	std::string LookupHashFile(u64 cachekey, u32 hash, bool *foundAlias, bool *ignored);
-	void PopulateReplacement(ReplacedTexture *result, u64 cachekey, u32 hash, int w, int h);
 
 	bool enabled_ = false;
 	bool allowVideo_ = false;
@@ -160,10 +159,10 @@ protected:
 	std::unordered_map<ReplacementCacheKey, std::string> aliases_;
 	std::unordered_map<ReplacementCacheKey, TextureFiltering> filtering_;
 
-	std::unordered_map<ReplacementCacheKey, ReplacedTexture *> cache_;
+	std::unordered_map<ReplacementCacheKey, ReplacedTextureRef> cache_;
 	std::unordered_map<ReplacementCacheKey, SavedTextureCacheData> savedCache_;
 
 	// the key is either from aliases_, in which case it's a |-separated sequence of texture filenames of the levels of a texture.
 	// alternatively the key is from the generated texture filename.
-	std::unordered_map<std::string, ReplacedLevelsCache> levelCache_;
+	std::unordered_map<std::string, ReplacedTexture *> levelCache_;
 };

--- a/GPU/Common/TextureScalerCommon.h
+++ b/GPU/Common/TextureScalerCommon.h
@@ -30,9 +30,9 @@ public:
 	TextureScalerCommon();
 	~TextureScalerCommon();
 
-	void ScaleAlways(u32 *out, u32 *src, int &width, int &height, int factor);
-	bool Scale(u32 *&data, int &width, int &height, int factor);
-	bool ScaleInto(u32 *out, u32 *src, int &width, int &height, int factor);
+	void ScaleAlways(u32 *out, u32 *src, int width, int height, int *scaledWidth, int *scaledHeight, int factor);
+	bool Scale(u32 *&data, int width, int height, int *scaledWidth, int *scaledHeight, int factor);
+	bool ScaleInto(u32 *out, u32 *src, int width, int height, int *scaledWidth, int *scaledHeight, int factor);
 
 	enum { XBRZ = 0, HYBRID = 1, BICUBIC = 2, HYBRID_BICUBIC = 3 };
 

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -754,7 +754,7 @@ void TextureCacheVulkan::LoadVulkanTextureLevel(TexCacheEntry &entry, uint8_t *w
 		u32 fmt = dstFmt;
 		// CPU scaling reads from the destination buffer so we want cached RAM.
 		uint8_t *rearrange = (uint8_t *)AllocateAlignedMemory(w * scaleFactor * h * scaleFactor * 4, 16);
-		scaler_.ScaleAlways((u32 *)rearrange, pixelData, w, h, scaleFactor);
+		scaler_.ScaleAlways((u32 *)rearrange, pixelData, w, h, &w, &h, scaleFactor);
 		pixelData = (u32 *)writePtr;
 
 		// We always end up at 8888.  Other parts assume this.

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -647,10 +647,8 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 				replacedInfo.addr = entry->addr;
 				replacedInfo.isVideo = IsVideo(entry->addr);
 				replacedInfo.isFinal = (entry->status & TexCacheEntry::STATUS_TO_SCALE) == 0;
-				replacedInfo.scaleFactor = plan.scaleFactor;
 				replacedInfo.fmt = FromVulkanFormat(actualFmt);
-
-				replacer_.NotifyTextureDecoded(replacedInfo, data, byteStride, plan.baseLevelSrc + i, w, h);
+				replacer_.NotifyTextureDecoded(replacedInfo, data, byteStride, plan.baseLevelSrc + i, mipUnscaledWidth, mipUnscaledHeight, w, h);
 			}
 		}
 	}


### PR DESCRIPTION
The `cache_` now only contains minimal references, while ReplacedTexture now takes over the previous roles of the `levelCache_` entries. Basically, we no longer create duplicate `ReplacedTexture`, only duplicated `ReplacedTextureRef` that point to the same ReplacedTexture.

This makes things a lot more understandable and maintainable, mainly, there might also be some minor reduction in memory usage.

Additionally, this opens for the TextureCacheCommon to find out if multiple PSP texture get replaced with the same replaced texture and avoiding creating multiple host textures, but that's for later.

Additionally, this fixes enabling/disable texture replacement at runtime as a side effect.