### PR TITLE
Log fixes

### DIFF
--- a/Common/File/VFS/ZipFileReader.cpp
+++ b/Common/File/VFS/ZipFileReader.cpp
@@ -15,13 +15,15 @@
 #include "Common/File/VFS/ZipFileReader.h"
 #include "Common/StringUtils.h"
 
-ZipFileReader *ZipFileReader::Create(const Path &zipFile, const char *inZipPath) {
+ZipFileReader *ZipFileReader::Create(const Path &zipFile, const char *inZipPath, bool logErrors) {
 	int error = 0;
 	zip *zip_file;
 	if (zipFile.Type() == PathType::CONTENT_URI) {
 		int fd = File::OpenFD(zipFile, File::OPEN_READ);
 		if (!fd) {
-			ERROR_LOG(IO, "Failed to open FD for %s as zip file", zipFile.c_str());
+			if (logErrors) {
+				ERROR_LOG(IO, "Failed to open FD for '%s' as zip file", zipFile.c_str());
+			}
 			return nullptr;
 		}
 		zip_file = zip_fdopen(fd, 0, &error);
@@ -30,7 +32,9 @@ ZipFileReader *ZipFileReader::Create(const Path &zipFile, const char *inZipPath)
 	}
 
 	if (!zip_file) {
-		ERROR_LOG(IO, "Failed to open %s as a zip file", zipFile.c_str());
+		if (logErrors) {
+			ERROR_LOG(IO, "Failed to open %s as a zip file", zipFile.c_str());
+		}
 		return nullptr;
 	}
 

--- a/Common/File/VFS/ZipFileReader.h
+++ b/Common/File/VFS/ZipFileReader.h
@@ -16,7 +16,7 @@
 
 class ZipFileReader : public VFSBackend {
 public:
-	static ZipFileReader *Create(const Path &zipFile, const char *inZipPath);
+	static ZipFileReader *Create(const Path &zipFile, const char *inZipPath, bool logErrors = true);
 	~ZipFileReader();
 
 	bool IsValid() const { return zip_file_ != nullptr; }

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -561,7 +561,7 @@ int DirectoryFileSystem::OpenFile(std::string filename, FileAccess access, const
 	OpenFileEntry entry;
 	entry.hFile.fileSystemFlags_ = flags;
 	u32 err = 0;
-	bool success = entry.hFile.Open(basePath, filename, access, err);
+	bool success = entry.hFile.Open(basePath, filename, (FileAccess)(access & FILEACCESS_PSP_FLAGS), err);
 	if (err == 0 && !success) {
 		err = SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND;
 	}
@@ -577,7 +577,9 @@ int DirectoryFileSystem::OpenFile(std::string filename, FileAccess access, const
 #else
 		logError = (int)errno;
 #endif
-		ERROR_LOG(FILESYS, "DirectoryFileSystem::OpenFile('%s'): FAILED, %d - access = %d '%s'", filename.c_str(), logError, (int)access, errorString.c_str());
+		if (!(access & FILEACCESS_PPSSPP_QUIET)) {
+			ERROR_LOG(FILESYS, "DirectoryFileSystem::OpenFile('%s'): FAILED, %d - access = %d '%s'", filename.c_str(), logError, (int)(access & FILEACCESS_PSP_FLAGS), errorString.c_str());
+		}
 		return err;
 	} else {
 #ifdef _WIN32
@@ -589,7 +591,7 @@ int DirectoryFileSystem::OpenFile(std::string filename, FileAccess access, const
 		u32 newHandle = hAlloc->GetNewHandle();
 
 		entry.guestFilename = filename;
-		entry.access = access;
+		entry.access = (FileAccess)(access & FILEACCESS_PSP_FLAGS);
 
 		entries[newHandle] = entry;
 

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -34,6 +34,11 @@ enum FileAccess {
 	FILEACCESS_CREATE   = 8,
 	FILEACCESS_TRUNCATE = 16,
 	FILEACCESS_EXCL     = 32,
+
+	FILEACCESS_PSP_FLAGS = 63,  // Sum of all the above.
+
+	// Non-PSP flags
+	FILEACCESS_PPSSPP_QUIET = 128,
 };
 
 enum FileMove {

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -581,8 +581,12 @@ size_t MetaFileSystem::SeekFile(u32 handle, s32 position, FileMove type)
 		return 0;
 }
 
-int MetaFileSystem::ReadEntireFile(const std::string &filename, std::vector<u8> &data) {
-	int handle = OpenFile(filename, FILEACCESS_READ);
+int MetaFileSystem::ReadEntireFile(const std::string &filename, std::vector<u8> &data, bool quiet) {
+	FileAccess access = FILEACCESS_READ;
+	if (quiet) {
+		access = (FileAccess)(access | FILEACCESS_PPSSPP_QUIET);
+	}
+	int handle = OpenFile(filename, access);
 	if (handle < 0)
 		return handle;
 

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -129,7 +129,7 @@ public:
 	u64  FreeSpace(const std::string &path) override;
 
 	// Convenience helper - returns < 0 on failure.
-	int ReadEntireFile(const std::string &filename, std::vector<u8> &data);
+	int ReadEntireFile(const std::string &filename, std::vector<u8> &data, bool quiet = false);
 
 	void SetStartingDirectory(const std::string &dir) {
 		std::lock_guard<std::recursive_mutex> guard(lock);

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -340,7 +340,7 @@ int VirtualDiscFileSystem::OpenFile(std::string filename, FileAccess access, con
 		return newHandle;
 	}
 
-	if (filename.compare(0,8,"/sce_lbn") == 0)
+	if (filename.compare(0, 8, "/sce_lbn") == 0)
 	{
 		u32 sectorStart = 0xFFFFFFFF, readSize = 0xFFFFFFFF;
 		parseLBN(filename, &sectorStart, &readSize);
@@ -365,11 +365,13 @@ int VirtualDiscFileSystem::OpenFile(std::string filename, FileAccess access, con
 		bool success = entry.Open(basePath, fileList[entry.fileIndex].fileName, FILEACCESS_READ);
 
 		if (!success) {
+			if (!(access & FILEACCESS_PPSSPP_QUIET)) {
 #ifdef _WIN32
-			ERROR_LOG(FILESYS, "VirtualDiscFileSystem::OpenFile: FAILED, %i", (int)GetLastError());
+				ERROR_LOG(FILESYS, "VirtualDiscFileSystem::OpenFile: FAILED, %i", (int)GetLastError());
 #else
-			ERROR_LOG(FILESYS, "VirtualDiscFileSystem::OpenFile: FAILED");
+				ERROR_LOG(FILESYS, "VirtualDiscFileSystem::OpenFile: FAILED");
 #endif
+			}
 			return 0;
 		}
 
@@ -388,15 +390,16 @@ int VirtualDiscFileSystem::OpenFile(std::string filename, FileAccess access, con
 	if (entry.fileIndex != (u32)-1 && fileList[entry.fileIndex].handler != NULL) {
 		entry.handler = fileList[entry.fileIndex].handler;
 	}
-	bool success = entry.Open(basePath, filename, access);
+	bool success = entry.Open(basePath, filename, (FileAccess)(access & FILEACCESS_PSP_FLAGS));
 
 	if (!success) {
+		if (!(access & FILEACCESS_PPSSPP_QUIET)) {
 #ifdef _WIN32
-		ERROR_LOG(FILESYS, "VirtualDiscFileSystem::OpenFile: FAILED, %i - access = %i", (int)GetLastError(), (int)access);
+			ERROR_LOG(FILESYS, "VirtualDiscFileSystem::OpenFile: FAILED, %i - access = %i", (int)GetLastError(), (int)access);
 #else
-		ERROR_LOG(FILESYS, "VirtualDiscFileSystem::OpenFile: FAILED, access = %i", (int)access);
+			ERROR_LOG(FILESYS, "VirtualDiscFileSystem::OpenFile: FAILED, access = %i", (int)access);
 #endif
-		//wwwwaaaaahh!!
+		}
 		return SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND;
 	} else {
 		u32 newHandle = hAlloc->GetNewHandle();

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -891,12 +891,12 @@ static void __LoadInternalFonts() {
 		bool bufferRead = false;
 
 		std::string fontFilename = gameFontPath + entry.fileName;
-		bufferRead = pspFileSystem.ReadEntireFile(fontFilename, buffer) >= 0;
+		bufferRead = pspFileSystem.ReadEntireFile(fontFilename, buffer, true) >= 0;
 
 		if (!bufferRead) {
 			// No game font, let's try override path.
 			fontFilename = fontOverridePath + entry.fileName;
-			bufferRead = pspFileSystem.ReadEntireFile(fontFilename, buffer) >= 0;
+			bufferRead = pspFileSystem.ReadEntireFile(fontFilename, buffer, true) >= 0;
 		}
 
 		if (!bufferRead) {

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -124,9 +124,12 @@ bool TextureReplacer::LoadIni() {
 	delete vfs_;
 	vfs_ = nullptr;
 
+	Path zipPath = basePath_ / ZIP_FILENAME;
+
 	// First, check for textures.zip, which is used to reduce IO.
-	VFSBackend *dir = ZipFileReader::Create(basePath_ / ZIP_FILENAME, "");
+	VFSBackend *dir = ZipFileReader::Create(zipPath, "", false);
 	if (!dir) {
+		INFO_LOG(G3D, "%s wasn't a zip file - opening the directory %s instead.", zipPath.c_str(), basePath_.c_str());
 		vfsIsZip_ = false;
 		dir = new DirectoryReader(basePath_);
 	} else {


### PR DESCRIPTION
IncognitoMan on Discord reports seeing this, still (and not just when loading old saves):

![image](https://user-images.githubusercontent.com/130929/225763799-0215e292-1180-44d4-a70b-292659930f5b.png)

Let's just get rid of that logging... Some slightly ugly flag gymnastics required.