### PR TITLE
Remove graphics init/shutdown stuff from "Host"

### DIFF
--- a/Core/Host.h
+++ b/Core/Host.h
@@ -27,9 +27,6 @@ class Host {
 public:
 	virtual ~Host() {}
 
-	virtual bool InitGraphics(std::string *error_string, GraphicsContext **ctx) = 0;
-	virtual void ShutdownGraphics() = 0;
-
 	virtual void UpdateSound() {}  // still needed for libretro, will need a proper effort.
 	virtual void PollControllers() {}
 	virtual void ToggleDebugConsoleVisibility() {}

--- a/Core/Host.h
+++ b/Core/Host.h
@@ -30,7 +30,7 @@ public:
 	virtual bool InitGraphics(std::string *error_string, GraphicsContext **ctx) = 0;
 	virtual void ShutdownGraphics() = 0;
 
-	virtual void UpdateSound() {}
+	virtual void UpdateSound() {}  // still needed for libretro, will need a proper effort.
 	virtual void PollControllers() {}
 	virtual void ToggleDebugConsoleVisibility() {}
 

--- a/Qt/QtHost.h
+++ b/Qt/QtHost.h
@@ -31,9 +31,6 @@ public:
 		mainWindow = mainWindow_;
 	}
 
-	bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override { return true; }
-	void ShutdownGraphics() override {}
-
 	void UpdateSound() override {}
 
 	bool AttemptLoadSymbolMap() override {

--- a/UI/HostTypes.h
+++ b/UI/HostTypes.h
@@ -24,9 +24,6 @@ class NativeHost : public Host {
 public:
 	NativeHost() {}
 
-	bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override { return true; }
-	void ShutdownGraphics() override {}
-
 	void UpdateSound() override {}
 
 	bool AttemptLoadSymbolMap() override {return false;}

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1426,12 +1426,6 @@ void NativeShutdown() {
 		screenManager = nullptr;
 	}
 
-	if (host) {
-		host->ShutdownGraphics();
-		delete host;
-		host = nullptr;
-	}
-
 #if !PPSSPP_PLATFORM(UWP)
 #endif
 	g_Config.Save("NativeShutdown");

--- a/UWP/UWPHost.cpp
+++ b/UWP/UWPHost.cpp
@@ -54,15 +54,6 @@ void UWPHost::SetConsolePosition() {
 void UWPHost::UpdateConsolePosition() {
 }
 
-bool UWPHost::InitGraphics(std::string *error_message, GraphicsContext **ctx) {
-	// Done elsewhere
-	return true;
-}
-
-void UWPHost::ShutdownGraphics() {
-	// Done elsewhere
-}
-
 void UWPHost::SetWindowTitle(const char *message) {
 }
 

--- a/UWP/UWPHost.h
+++ b/UWP/UWPHost.h
@@ -12,10 +12,7 @@ public:
 	UWPHost();
 	~UWPHost();
 
-	// If returns false, will return a null context
-	bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override;
 	void PollControllers() override;
-	void ShutdownGraphics() override;
 
 	void UpdateSound() override;
 

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -26,6 +26,13 @@
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
 
+#if PPSSPP_API(ANY_GL)
+#include "Windows/GPU/WindowsGLContext.h"
+#endif
+#include "Windows/GPU/WindowsVulkanContext.h"
+#include "Windows/GPU/D3D9Context.h"
+#include "Windows/GPU/D3D11Context.h"
+
 enum class EmuThreadState {
 	DISABLED,
 	START_REQUESTED,
@@ -112,6 +119,37 @@ static void EmuThreadJoin() {
 	INFO_LOG(SYSTEM, "EmuThreadJoin - joined");
 }
 
+bool CreateGraphicsBackend(std::string *error_message, GraphicsContext **ctx) {
+	WindowsGraphicsContext *graphicsContext = nullptr;
+	switch (g_Config.iGPUBackend) {
+#if PPSSPP_API(ANY_GL)
+	case (int)GPUBackend::OPENGL:
+		graphicsContext = new WindowsGLContext();
+		break;
+#endif
+	case (int)GPUBackend::DIRECT3D9:
+		graphicsContext = new D3D9Context();
+		break;
+	case (int)GPUBackend::DIRECT3D11:
+		graphicsContext = new D3D11Context();
+		break;
+	case (int)GPUBackend::VULKAN:
+		graphicsContext = new WindowsVulkanContext();
+		break;
+	default:
+		return false;
+	}
+
+	if (graphicsContext->Init(MainWindow::GetHInstance(), MainWindow::GetDisplayHWND(), error_message)) {
+		*ctx = graphicsContext;
+		return true;
+	} else {
+		delete graphicsContext;
+		*ctx = nullptr;
+		return false;
+	}
+}
+
 void MainThreadFunc() {
 	if (useEmuThread) {
 		// We'll start up a separate thread we'll call Emu
@@ -164,7 +202,7 @@ void MainThreadFunc() {
 	System_Notify(SystemNotification::UI);
 
 	std::string error_string;
-	bool success = host->InitGraphics(&error_string, &g_graphicsContext);
+	bool success = CreateGraphicsBackend(&error_string, &g_graphicsContext);
 
 	if (success) {
 		// Main thread is the render thread.
@@ -299,7 +337,8 @@ shutdown:
 	g_graphicsContext->ThreadEnd();
 	g_graphicsContext->ShutdownFromRenderThread();
 
-	// NativeShutdown deletes the graphics context through host->ShutdownGraphics().
+	g_graphicsContext->Shutdown();
+
 	NativeShutdown();
 
 	PostMessage(MainWindow::GetHWND(), MainWindow::WM_USER_UPDATE_UI, 0, 0);

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -109,13 +109,6 @@ void WindowsHost::UpdateConsolePosition() {
 	}
 }
 
-bool WindowsHost::InitGraphics(std::string *error_message, GraphicsContext **ctx) {
-	return true;
-}
-
-void WindowsHost::ShutdownGraphics() {
-}
-
 void WindowsHost::SetWindowTitle(const char *message) {
 #ifdef GOLD
 	const char *name = "PPSSPP Gold ";

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -53,13 +53,6 @@
 #include "Windows/WindowsHost.h"
 #include "Windows/MainWindow.h"
 
-#if PPSSPP_API(ANY_GL)
-#include "Windows/GPU/WindowsGLContext.h"
-#endif
-#include "Windows/GPU/WindowsVulkanContext.h"
-#include "Windows/GPU/D3D9Context.h"
-#include "Windows/GPU/D3D11Context.h"
-
 #include "Windows/Debugger/DebuggerShared.h"
 #include "Windows/Debugger/Debugger_Disasm.h"
 #include "Windows/Debugger/Debugger_MemoryDlg.h"
@@ -117,42 +110,10 @@ void WindowsHost::UpdateConsolePosition() {
 }
 
 bool WindowsHost::InitGraphics(std::string *error_message, GraphicsContext **ctx) {
-	WindowsGraphicsContext *graphicsContext = nullptr;
-	switch (g_Config.iGPUBackend) {
-#if PPSSPP_API(ANY_GL)
-	case (int)GPUBackend::OPENGL:
-		graphicsContext = new WindowsGLContext();
-		break;
-#endif
-	case (int)GPUBackend::DIRECT3D9:
-		graphicsContext = new D3D9Context();
-		break;
-	case (int)GPUBackend::DIRECT3D11:
-		graphicsContext = new D3D11Context();
-		break;
-	case (int)GPUBackend::VULKAN:
-		graphicsContext = new WindowsVulkanContext();
-		break;
-	default:
-		return false;
-	}
-
-	if (graphicsContext->Init(hInstance_, displayWindow_, error_message)) {
-		*ctx = graphicsContext;
-		gfx_ = graphicsContext;
-		return true;
-	} else {
-		delete graphicsContext;
-		*ctx = nullptr;
-		gfx_ = nullptr;
-		return false;
-	}
+	return true;
 }
 
 void WindowsHost::ShutdownGraphics() {
-	gfx_->Shutdown();
-	delete gfx_;
-	gfx_ = nullptr;
 }
 
 void WindowsHost::SetWindowTitle(const char *message) {

--- a/Windows/WindowsHost.h
+++ b/Windows/WindowsHost.h
@@ -24,8 +24,6 @@
 extern float g_mouseDeltaX;
 extern float g_mouseDeltaY;
 
-class GraphicsContext;
-
 class WindowsHost : public Host {
 public:
 	WindowsHost(HINSTANCE hInstance, HWND mainWindow, HWND displayWindow);
@@ -61,7 +59,6 @@ private:
 	HINSTANCE hInstance_;
 	HWND displayWindow_;
 	HWND mainWindow_;
-	GraphicsContext *gfx_ = nullptr;
 	size_t numDinputDevices_ = 0;
 	std::wstring lastTitle_;
 

--- a/Windows/WindowsHost.h
+++ b/Windows/WindowsHost.h
@@ -32,10 +32,7 @@ public:
 		UpdateConsolePosition();
 	}
 
-	// If returns false, will return a null context
-	bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override;
 	void PollControllers() override;
-	void ShutdownGraphics() override;
 
 	void UpdateSound() override;
 
@@ -49,8 +46,6 @@ public:
 
 	void NotifyUserMessage(const std::string &message, float duration = 1.0f, u32 color = 0x00FFFFFF, const char *id = nullptr) override;
 	void SendUIMessage(const std::string &message, const std::string &value) override;
-
-	GraphicsContext *GetGraphicsContext() { return gfx_; }
 
 private:
 	void SetConsolePosition();

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -409,12 +409,11 @@ int main(int argc, const char* argv[])
 	g_threadManager.Init(cpu_info.num_cores, cpu_info.logical_cpu_count);
 
 	HeadlessHost *headlessHost = getHost(gpuCore);
-	headlessHost->SetGraphicsCore(gpuCore);
 	host = headlessHost;
 
 	std::string error_string;
 	GraphicsContext *graphicsContext = nullptr;
-	bool glWorking = host->InitGraphics(&error_string, &graphicsContext);
+	bool glWorking = ((HeadlessHost *)host)->InitGraphics(&error_string, &graphicsContext, gpuCore);
 
 	CoreParameter coreParameter;
 	coreParameter.cpuCore = cpuCore;
@@ -578,7 +577,7 @@ int main(int argc, const char* argv[])
 		ShutdownWebServer();
 	}
 
-	host->ShutdownGraphics();
+	 ((HeadlessHost *)host)->ShutdownGraphics();
 	delete host;
 	host = nullptr;
 	headlessHost = nullptr;

--- a/headless/SDLHeadlessHost.cpp
+++ b/headless/SDLHeadlessHost.cpp
@@ -165,7 +165,7 @@ bool GLDummyGraphicsContext::InitFromRenderThread(std::string *errorMessage) {
 	return success;
 }
 
-bool SDLHeadlessHost::InitGraphics(std::string *error_message, GraphicsContext **ctx) {
+bool SDLHeadlessHost::InitGraphics(std::string *error_message, GraphicsContext **ctx, GPUCore core) {
 	GraphicsContext *graphicsContext = new GLDummyGraphicsContext();
 	*ctx = graphicsContext;
 	gfx_ = graphicsContext;

--- a/headless/SDLHeadlessHost.h
+++ b/headless/SDLHeadlessHost.h
@@ -30,7 +30,7 @@ typedef void *SDL_GLContext;
 class SDLHeadlessHost : public HeadlessHost
 {
 public:
-	bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override;
+	bool InitGraphics(std::string *error_message, GraphicsContext **ctx, GPUCore core) override;
 	void ShutdownGraphics() override;
 
 	void SwapBuffers() override;

--- a/headless/StubHost.h
+++ b/headless/StubHost.h
@@ -23,12 +23,10 @@
 #include "Core/Host.h"
 #include "Core/Debugger/SymbolMap.h"
 
-// TODO: Get rid of this junk
 class HeadlessHost : public Host {
 public:
-	void SetGraphicsCore(GPUCore core) { gpuCore_ = core; }
-	bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override {return false;}
-	void ShutdownGraphics() override {}
+	virtual bool InitGraphics(std::string *error_message, GraphicsContext **ctx, GPUCore core) {return false;}
+	virtual void ShutdownGraphics() {}
 
 	void UpdateSound() override {}
 

--- a/headless/WindowsHeadlessHost.cpp
+++ b/headless/WindowsHeadlessHost.cpp
@@ -72,8 +72,9 @@ void WindowsHeadlessHost::SendDebugOutput(const std::string &output)
 	OutputDebugStringUTF8(output.c_str());
 }
 
-bool WindowsHeadlessHost::InitGraphics(std::string *error_message, GraphicsContext **ctx) {
+bool WindowsHeadlessHost::InitGraphics(std::string *error_message, GraphicsContext **ctx, GPUCore core) {
 	hWnd = CreateHiddenWindow();
+	gpuCore_ = core;
 
 	if (WINDOW_VISIBLE) {
 		ShowWindow(hWnd, TRUE);

--- a/headless/WindowsHeadlessHost.h
+++ b/headless/WindowsHeadlessHost.h
@@ -29,7 +29,7 @@
 class WindowsHeadlessHost : public HeadlessHost
 {
 public:
-	bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override;
+	bool InitGraphics(std::string *error_message, GraphicsContext **ctx, GPUCore core) override;
 	void ShutdownGraphics() override;
 
 	void SwapBuffers() override;

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -386,8 +386,6 @@ class LibretroHost : public Host
 {
    public:
       LibretroHost() {}
-      bool InitGraphics(std::string *error_message, GraphicsContext **ctx) override { return true; }
-      void ShutdownGraphics() override {}
       void UpdateSound() override
       {
          int hostAttemptBlockSize = __AudioGetHostAttemptBlockSize();


### PR DESCRIPTION
On most platforms it did nothing, and in Windows, it was trivial to just move the logic.

~Headless got slightly uglier (couple of ifdefs), though might clean that up later in a different way.~ Cleaned it up for now, the headless only gained a couple of ugly casts.

Followup to #17155 