### PR TITLE
Port file browser to the request manager

### DIFF
--- a/Common/System/Request.cpp
+++ b/Common/System/Request.cpp
@@ -12,10 +12,10 @@ const char *RequestTypeAsString(SystemRequestType type) {
 	}
 }
 
-bool RequestManager::MakeSystemRequest(SystemRequestType type, RequestCallback callback, const std::string &param1, const std::string &param2) {
+bool RequestManager::MakeSystemRequest(SystemRequestType type, RequestCallback callback, const std::string &param1, const std::string &param2, int param3) {
 	int requestId = idCounter_++;
 	INFO_LOG(SYSTEM, "Making system request %s: id %d, callback_valid %d", RequestTypeAsString(type), requestId, callback != nullptr);
-	if (!System_MakeRequest(type, requestId, param1, param2)) {
+	if (!System_MakeRequest(type, requestId, param1, param2, param3)) {
 		return false;
 	}
 

--- a/Common/System/Request.h
+++ b/Common/System/Request.h
@@ -16,7 +16,7 @@ class RequestManager {
 public:
 	// These requests are to be handled by platform implementations.
 	// The callback you pass in will be called on the main thread later.
-	bool MakeSystemRequest(SystemRequestType type, RequestCallback callback, const std::string &param1, const std::string &param2);
+	bool MakeSystemRequest(SystemRequestType type, RequestCallback callback, const std::string &param1, const std::string &param2, int param3);
 
 	// Called by the platform implementation, when it's finished with a request.
 	void PostSystemSuccess(int requestId, const char *responseString, int responseValue = 0);
@@ -56,9 +56,19 @@ extern RequestManager g_requestManager;
 // Wrappers for easy requests.
 // NOTE: Semantics have changed - this no longer calls the callback on cancellation.
 inline void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, RequestCallback callback) {
-	g_requestManager.MakeSystemRequest(SystemRequestType::INPUT_TEXT_MODAL, callback, title, defaultValue);
+	g_requestManager.MakeSystemRequest(SystemRequestType::INPUT_TEXT_MODAL, callback, title, defaultValue, 0);
 }
 
 inline void System_BrowseForImage(const std::string &title, RequestCallback callback) {
-	g_requestManager.MakeSystemRequest(SystemRequestType::BROWSE_FOR_IMAGE, callback, title, "");
+	g_requestManager.MakeSystemRequest(SystemRequestType::BROWSE_FOR_IMAGE, callback, title, "", 0);
+}
+
+enum class BrowseFileType {
+	BOOTABLE,
+	INI,
+	ANY,
+};
+
+inline void System_BrowseForFile(const std::string &title, BrowseFileType type, RequestCallback callback) {
+	g_requestManager.MakeSystemRequest(SystemRequestType::BROWSE_FOR_FILE, callback, title, "", (int)type);
 }

--- a/Common/System/Request.h
+++ b/Common/System/Request.h
@@ -59,12 +59,15 @@ inline void System_InputBoxGetString(const std::string &title, const std::string
 	g_requestManager.MakeSystemRequest(SystemRequestType::INPUT_TEXT_MODAL, callback, title, defaultValue, 0);
 }
 
+// This one will pop up a special image brwoser if available. You can also pick
+// images with the file browser below.
 inline void System_BrowseForImage(const std::string &title, RequestCallback callback) {
 	g_requestManager.MakeSystemRequest(SystemRequestType::BROWSE_FOR_IMAGE, callback, title, "", 0);
 }
 
 enum class BrowseFileType {
 	BOOTABLE,
+	IMAGE,
 	INI,
 	ANY,
 };

--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -54,13 +54,14 @@ void System_LaunchUrl(LaunchUrlType urlType, const char *url);
 enum class SystemRequestType {
 	INPUT_TEXT_MODAL,
 	BROWSE_FOR_IMAGE,
+	BROWSE_FOR_FILE,
 };
 
 // Implementations are supposed to process the request, and post the response to the g_RequestManager (see Message.h).
 // This is not to be used directly by applications, instead use the g_RequestManager to make the requests.
 // This can return false if it's known that the platform doesn't support the request, the app is supposed to handle
 // or ignore that cleanly.
-bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2);
+bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2, int param3);
 
 // TODO: To be separated into requests, see Request.h, and a way to post "UI messages".
 void System_SendMessage(const char *command, const char *parameter);

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -311,7 +311,7 @@ bool MainUI::HandleCustomEvent(QEvent *e) {
 	return true;
 }
 
-bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2) {
+bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2, int param3) {
 	switch (type) {
 	case SystemRequestType::INPUT_TEXT_MODAL:
 	{

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -166,7 +166,7 @@ void System_Vibrate(int length_ms) {
 	// Ignore on PC
 }
 
-bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2) { return false; }
+bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2, int param3) { return false; }
 
 void System_SendMessage(const char *command, const char *parameter) {
 	if (!strcmp(command, "toggle_fullscreen")) {

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -23,6 +23,8 @@
 
 #include "Common/System/Display.h"
 #include "Common/System/System.h"
+#include "Common/System/Request.h"
+#include "Common/System/NativeApp.h"
 #include "Common/Render/TextureAtlas.h"
 #include "Common/Render/DrawBuffer.h"
 #include "Common/UI/Root.h"
@@ -1278,7 +1280,10 @@ void MainScreen::update() {
 
 UI::EventReturn MainScreen::OnLoadFile(UI::EventParams &e) {
 	if (System_GetPropertyBool(SYSPROP_HAS_FILE_BROWSER)) {
-		System_SendMessage("browse_file", "");
+		auto mm = GetI18NCategory("MainMenu");
+		System_BrowseForFile(mm->T("Load"), BrowseFileType::BOOTABLE, [](const std::string &value, int) {
+			NativeMessageReceived("boot", value.c_str());
+		});
 	}
 	return UI::EVENT_DONE;
 }

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1254,10 +1254,6 @@ void MainScreen::sendMessage(const char *message, const char *value) {
 		if (!strcmp(message, "boot")) {
 			LaunchFile(screenManager(), Path(std::string(value)));
 		}
-		if (!strcmp(message, "browse_fileSelect")) {
-			INFO_LOG(SYSTEM, "Attempting to launch: '%s'", value);
-			LaunchFile(screenManager(), Path(std::string(value)));
-		}
 		if (!strcmp(message, "browse_folderSelect")) {
 			std::string filename = value;
 			INFO_LOG(SYSTEM, "Got folder: '%s'", filename.c_str());

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -443,7 +443,7 @@ void System_Notify(SystemNotification notification) {
 	}
 }
 
-bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2) { return false; }
+bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2, int param3) { return false; }
 
 void System_SendMessage(const char *command, const char *parameter) {
 	using namespace concurrency;

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -56,7 +56,6 @@ namespace MainWindow {
 	extern HINSTANCE hInst;
 	extern bool noFocusPause;
 	static W32Util::AsyncBrowseDialog *browseDialog;
-	static W32Util::AsyncBrowseDialog *browseImageDialog;
 	static bool browsePauseAfter;
 
 	static std::unordered_map<int, std::string> initialMenuKeys;
@@ -361,10 +360,6 @@ namespace MainWindow {
 		}
 	}
 
-	static void setScreenRotation(int rotation) {
-		g_Config.iInternalScreenRotation = rotation;
-	}
-
 	static void SaveStateActionFinished(SaveState::Status status, const std::string &message, void *userdata) {
 		if (!message.empty() && (!g_Config.bDumpFrames || !g_Config.bDumpVideoOutput)) {
 			osm.Show(message, status == SaveState::Status::SUCCESS ? 2.0 : 5.0);
@@ -376,14 +371,6 @@ namespace MainWindow {
 	void setTexScalingMultiplier(int level) {
 		g_Config.iTexScalingLevel = level;
 		NativeMessageReceived("gpu_configChanged", "");
-	}
-
-	static void setTexFiltering(int type) {
-		g_Config.iTexFiltering = type;
-	}
-
-	static void setBufFilter(int type) {
-		g_Config.iBufFilter = type;
 	}
 
 	static void setTexScalingType(int type) {
@@ -517,10 +504,10 @@ namespace MainWindow {
 			UmdSwitchAction();
 			break;
 
-		case ID_EMULATION_ROTATION_H:                 setScreenRotation(ROTATION_LOCKED_HORIZONTAL); break;
-		case ID_EMULATION_ROTATION_V:                 setScreenRotation(ROTATION_LOCKED_VERTICAL); break;
-		case ID_EMULATION_ROTATION_H_R:               setScreenRotation(ROTATION_LOCKED_HORIZONTAL180); break;
-		case ID_EMULATION_ROTATION_V_R:               setScreenRotation(ROTATION_LOCKED_VERTICAL180); break;
+		case ID_EMULATION_ROTATION_H:   g_Config.iInternalScreenRotation = ROTATION_LOCKED_HORIZONTAL; break;
+		case ID_EMULATION_ROTATION_V:   g_Config.iInternalScreenRotation = ROTATION_LOCKED_VERTICAL; break;
+		case ID_EMULATION_ROTATION_H_R: g_Config.iInternalScreenRotation = ROTATION_LOCKED_HORIZONTAL180; break;
+		case ID_EMULATION_ROTATION_V_R: g_Config.iInternalScreenRotation = ROTATION_LOCKED_VERTICAL180; break;
 
 		case ID_EMULATION_CHEATS:
 			g_Config.bEnableCheats = !g_Config.bEnableCheats;
@@ -858,13 +845,13 @@ namespace MainWindow {
 		case ID_OPTIONS_VERTEXCACHE:
 			g_Config.bVertexCache = !g_Config.bVertexCache;
 			break;
-		case ID_OPTIONS_TEXTUREFILTERING_AUTO:   setTexFiltering(TEX_FILTER_AUTO); break;
-		case ID_OPTIONS_NEARESTFILTERING:        setTexFiltering(TEX_FILTER_FORCE_NEAREST); break;
-		case ID_OPTIONS_LINEARFILTERING:         setTexFiltering(TEX_FILTER_FORCE_LINEAR); break;
-		case ID_OPTIONS_AUTOMAXQUALITYFILTERING: setTexFiltering(TEX_FILTER_AUTO_MAX_QUALITY); break;
+		case ID_OPTIONS_TEXTUREFILTERING_AUTO:   g_Config.iTexFiltering = TEX_FILTER_AUTO; break;
+		case ID_OPTIONS_NEARESTFILTERING:        g_Config.iTexFiltering = TEX_FILTER_FORCE_NEAREST; break;
+		case ID_OPTIONS_LINEARFILTERING:         g_Config.iTexFiltering = TEX_FILTER_FORCE_LINEAR; break;
+		case ID_OPTIONS_AUTOMAXQUALITYFILTERING: g_Config.iTexFiltering = TEX_FILTER_AUTO_MAX_QUALITY; break;
 
-		case ID_OPTIONS_BUFLINEARFILTER:       setBufFilter(SCALE_LINEAR); break;
-		case ID_OPTIONS_BUFNEARESTFILTER:      setBufFilter(SCALE_NEAREST); break;
+		case ID_OPTIONS_BUFLINEARFILTER:  g_Config.iBufFilter = SCALE_LINEAR; break;
+		case ID_OPTIONS_BUFNEARESTFILTER: g_Config.iBufFilter = SCALE_NEAREST; break;
 
 		case ID_OPTIONS_TOPMOST:
 			g_Config.bTopMost = !g_Config.bTopMost;

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1027,7 +1027,7 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_backbufferResize(JNIEnv
 	}
 }
 
-bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2) {
+bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2, int param3) {
 	switch (type) {
 	case SystemRequestType::INPUT_TEXT_MODAL:
 	{

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1038,6 +1038,9 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 	case SystemRequestType::BROWSE_FOR_IMAGE:
 		PushCommand("browse_image", StringFromFormat("%d", requestId));
 		return true;
+	case SystemRequestType::BROWSE_FOR_FILE:
+		PushCommand("browse_file", StringFromFormat("%d", requestId));
+		return true;
 	default:
 		return false;
 	}

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -105,7 +105,9 @@ public abstract class NativeActivity extends Activity {
 	private static final int RESULT_OPEN_DOCUMENT = 2;
 	private static final int RESULT_OPEN_DOCUMENT_TREE = 3;
 
+	// These can probably be merged, but conceptually nice to have them separate.
 	private int imageRequestId = -1;
+	private int fileRequestId = -1;
 
 	// Allow for multiple connected gamepads but just consider them the same for now.
 	// Actually this is not entirely true, see the code.
@@ -1173,12 +1175,15 @@ public abstract class NativeActivity extends Activity {
 					}
 				} catch (Exception e) {
 					Log.w(TAG, "Exception getting permissions for document: " + e.toString());
+					NativeApp.sendRequestResult(fileRequestId, false, "", 0);
+					return;
 				}
 				// Even if we got an exception getting permissions, try to pass along the file. Maybe this version of Android
 				// doesn't need it.
 				Log.i(TAG, "Browse file finished:" + selectedFile.toString());
-				NativeApp.sendMessage("browse_fileSelect", selectedFile.toString());
+				NativeApp.sendRequestResult(fileRequestId, true, selectedFile.toString(), 0);
 			}
+			fileRequestId = -1;
 		} else if (requestCode == RESULT_OPEN_DOCUMENT_TREE) {
 			if (resultCode != RESULT_OK || data == null) {
 				return;
@@ -1346,6 +1351,7 @@ public abstract class NativeActivity extends Activity {
 			}
 		} else if (command.equals("browse_file")) {
 			try {
+				fileRequestId = Integer.parseInt(params);
 				Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
 				intent.addCategory(Intent.CATEGORY_OPENABLE);
 				intent.setType("*/*");

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -116,7 +116,7 @@ bool System_GetPropertyBool(SystemProperty prop) {
 }
 void System_Notify(SystemNotification notification) {}
 void System_SendMessage(const char *command, const char *parameter) {}
-bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2) { return false; }
+bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2, int param3) { return false; }
 void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb) { cb(false, ""); }
 void System_AskForPermission(SystemPermission permission) {}
 PermissionStatus System_GetPermissionStatus(SystemPermission permission) { return PERMISSION_STATUS_GRANTED; }

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -219,7 +219,7 @@ void System_SendMessage(const char *command, const char *parameter) {
 	}
 }
 
-bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2) {
+bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2, int param3) {
 	return false;
 }
 

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -211,7 +211,7 @@ void System_SendMessage(const char *command, const char *parameter) {
 		}
 	} else if (!strcmp(command, "browse_folder")) {
 		DarwinDirectoryPanelCallback callback = [] (Path thePathChosen) {
-				NativeMessageReceived("browse_folder", thePathChosen.c_str());
+			NativeMessageReceived("browse_folderSelect", thePathChosen.c_str());
 		};
 
 		DarwinFileSystemServices services;

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1874,7 +1874,7 @@ void System_Notify(SystemNotification notification) {
       break;
    }
 }
-bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2) { return false; }
+bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2, int param3) { return false; }
 void System_SendMessage(const char *command, const char *parameter) {}
 void NativeUpdate() {}
 void NativeRender(GraphicsContext *graphicsContext) {}

--- a/unittest/JitHarness.cpp
+++ b/unittest/JitHarness.cpp
@@ -42,7 +42,7 @@ void NativeRender(GraphicsContext *graphicsContext) { }
 void NativeResized() { }
 
 void System_SendMessage(const char *command, const char *parameter) {}
-bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2) { return false; }
+bool System_MakeRequest(SystemRequestType type, int requestId, const std::string &param1, const std::string &param2, int param3) { return false; }
 void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb) { cb(false, ""); }
 void System_AskForPermission(SystemPermission permission) {}
 PermissionStatus System_GetPermissionStatus(SystemPermission permission) { return PERMISSION_STATUS_GRANTED; }


### PR DESCRIPTION
Like #17158 but for the file browser.

The file browser now also uses the new mechanism, making it more generic and easier to use for new things.

Additionally, two new backends now have a working image browser, UWP and Qt, so they can now set the background image.

Also drive-by fix a problem with the iOS folder browser (seemed to send the wrong message after picking one).

In Windows, there's still a legacy path left for File->Open, but I'll refactor away that later.