### PR TITLE
Cheat import: Allow picking a file to import from

### DIFF
--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -255,12 +255,34 @@ std::wstring Path::ToWString() const {
 }
 #endif
 
-std::string Path::ToVisualString() const {
+std::string Path::ToVisualString(const char *relativeRoot) const {
 	if (type_ == PathType::CONTENT_URI) {
 		return AndroidContentURI(path_).ToVisualString();
 #if PPSSPP_PLATFORM(WINDOWS)
 	} else if (type_ == PathType::NATIVE) {
-		return ReplaceAll(path_, "/", "\\");
+		// It can be useful to show the path as relative to the memstick
+		if (relativeRoot) {
+			std::string root = ReplaceAll(relativeRoot, "/", "\\");
+			std::string path = ReplaceAll(path_, "/", "\\");
+			if (startsWithNoCase(path, root)) {
+				return path.substr(root.size());
+			} else {
+				return path;
+			}
+		} else {
+			return ReplaceAll(path_, "/", "\\");
+		}
+#else
+		if (relativeRoot) {
+			std::string root = relativeRoot;
+			if (startsWithNoCase(path_, root)) {
+				return path_.substr(root.size());
+			} else {
+				return path_;
+			}
+		} else {
+			return path_;
+		}
 #endif
 	} else {
 		return path_;

--- a/Common/File/Path.h
+++ b/Common/File/Path.h
@@ -92,7 +92,8 @@ public:
 	std::wstring ToWString() const;
 #endif
 
-	std::string ToVisualString() const;
+	// Pass in a relative root to turn the path into a relative path - if it is one!
+	std::string ToVisualString(const char *relativeRoot = nullptr) const;
 
 	bool CanNavigateUp() const;
 	Path NavigateUp() const;

--- a/Common/System/Request.h
+++ b/Common/System/Request.h
@@ -69,6 +69,7 @@ enum class BrowseFileType {
 	BOOTABLE,
 	IMAGE,
 	INI,
+	DB,
 	ANY,
 };
 

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -741,10 +741,10 @@ protected:
 	std::string smallText_;
 	ImageID image_;  // Centered if no text, on the left if text.
 	ImageID rightIconImage_ = ImageID::invalid();  // Shows in the right.
-	float rightIconScale_;
-	float rightIconRot_;
-	bool rightIconFlipH_;
-	bool rightIconKeepColor_;
+	float rightIconScale_ = 0.0f;
+	float rightIconRot_ = 0.0f;
+	bool rightIconFlipH_ = false;
+	bool rightIconKeepColor_ = false;
 	Padding textPadding_;
 	bool centered_ = false;
 	float imgScale_ = 1.0f;

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -300,6 +300,9 @@ bool MainUI::HandleCustomEvent(QEvent *e) {
 		case BrowseFileType::INI:
 			filter = "INI files (*.ini)";
 			break;
+		case BrowseFileType::DB:
+			filter = "DB files (*.db)";
+			break;
 		case BrowseFileType::ANY:
 			break;
 		}

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -24,6 +24,7 @@
 #include "Common/File/FileUtil.h"
 #include "Common/StringUtils.h"
 #include "Common/System/System.h"
+#include "Common/System/Request.h"
 #include "Core/Core.h"
 #include "Core/Config.h"
 #include "Core/CwCheat.h"
@@ -152,21 +153,6 @@ void CwCheatScreen::onFinish(DialogResult result) {
 	}
 }
 
-void CwCheatScreen::sendMessage(const char *message, const char *value) {
-	// Always call the base class method first to handle the most common messages.
-	UIDialogScreenWithGameBackground::sendMessage(message, value);
-	if (!strcmp(message, "browse_fileSelect")) {
-		Path path(value);
-		INFO_LOG(SYSTEM, "Attempting to load cheats from: '%s'", path.ToVisualString().c_str());
-		if (ImportCheats(path)) {
-			g_Config.bReloadCheats = true;
-		} else {
-			// Show an error message?
-		}
-		RecreateViews();
-	}
-}
-
 UI::EventReturn CwCheatScreen::OnEnableAll(UI::EventParams &params) {
 	enableAllFlag_ = !enableAllFlag_;
 
@@ -220,7 +206,17 @@ static char *GetLineNoNewline(char *temp, int sz, FILE *fp) {
 }
 
 UI::EventReturn CwCheatScreen::OnImportBrowse(UI::EventParams &params) {
-	System_SendMessage("browse_file", "");
+	System_BrowseForFile("Open cheat DB file", BrowseFileType::DB, [&](const std::string &value, int) {
+		Path path(value);
+		INFO_LOG(SYSTEM, "Attempting to load cheats from: '%s'", path.ToVisualString().c_str());
+		if (ImportCheats(path)) {
+			g_Config.bReloadCheats = true;
+		} else {
+			// Show an error message?
+		}
+		RecreateViews();
+		// Chose a cheat file.
+	});
 	return UI::EVENT_DONE;
 }
 

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -97,7 +97,9 @@ void CwCheatScreen::CreateViews() {
 
 	std::string root = GetSysDirectory(DIRECTORY_MEMSTICK_ROOT).ToString();
 
-	leftColumn->Add(new Choice(cheatPath.ToVisualString(root.c_str())))->OnClick.Handle(this, &CwCheatScreen::OnImportCheat);
+	std::string title = StringFromFormat(cw->T("Import from %s"), "PSP/Cheats/cheat.db");
+
+	leftColumn->Add(new Choice(title.c_str()))->OnClick.Handle(this, &CwCheatScreen::OnImportCheat);
 	leftColumn->Add(new Choice(mm->T("Browse"), ImageID("I_FOLDER_OPEN")))->OnClick.Handle(this, &CwCheatScreen::OnImportBrowse);
 	errorMessageView_ = leftColumn->Add(new TextView(di->T("LoadingFailed")));
 	errorMessageView_->SetVisibility(V_GONE);

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -35,8 +35,11 @@ public:
 
 	UI::EventReturn OnAddCheat(UI::EventParams &params);
 	UI::EventReturn OnImportCheat(UI::EventParams &params);
+	UI::EventReturn OnImportBrowse(UI::EventParams &params);
 	UI::EventReturn OnEditCheatFile(UI::EventParams &params);
 	UI::EventReturn OnEnableAll(UI::EventParams &params);
+
+	void sendMessage(const char *message, const char *value) override;
 
 	void update() override;
 	void onFinish(DialogResult result) override;
@@ -48,16 +51,19 @@ protected:
 
 private:
 	UI::EventReturn OnCheckBox(int index);
+	bool ImportCheats(const Path &cheatFile);
 
 	enum { INDEX_ALL = -1 };
 	bool HasCheatWithName(const std::string &name);
 	bool RebuildCheatFile(int index);
 
 	UI::ScrollView *rightScroll_ = nullptr;
+	UI::TextView *errorMessageView_ = nullptr;
+
 	CWCheatEngine *engine_ = nullptr;
 	std::vector<CheatFileInfo> fileInfo_;
 	std::string gameID_;
 	int fileCheckCounter_ = 0;
-	uint64_t fileCheckHash_;
+	uint64_t fileCheckHash_ = 0;
 	bool enableAllFlag_ = false;
 };

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -39,8 +39,6 @@ public:
 	UI::EventReturn OnEditCheatFile(UI::EventParams &params);
 	UI::EventReturn OnEnableAll(UI::EventParams &params);
 
-	void sendMessage(const char *message, const char *value) override;
-
 	void update() override;
 	void onFinish(DialogResult result) override;
 

--- a/UI/CwCheatScreen.h
+++ b/UI/CwCheatScreen.h
@@ -37,7 +37,7 @@ public:
 	UI::EventReturn OnImportCheat(UI::EventParams &params);
 	UI::EventReturn OnImportBrowse(UI::EventParams &params);
 	UI::EventReturn OnEditCheatFile(UI::EventParams &params);
-	UI::EventReturn OnEnableAll(UI::EventParams &params);
+	UI::EventReturn OnDisableAll(UI::EventParams &params);
 
 	void update() override;
 	void onFinish(DialogResult result) override;

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -468,6 +468,9 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 			case BrowseFileType::INI:
 				picker->FileTypeFilter->Append(".ini");
 				break;
+			case BrowseFileType::DB:
+				picker->FileTypeFilter->Append(".db");
+				break;
 			case BrowseFileType::ANY:
 				picker->FileTypeFilter->Append("*");
 				break;

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -509,6 +509,9 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 		case BrowseFileType::INI:
 			filter = MakeFilter(L"Ini files (*.ini)|*.ini|All files (*.*)|*.*||");
 			break;
+		case BrowseFileType::DB:
+			filter = MakeFilter(L"Cheat db files (*.db)|*.db|All files (*.*)|*.*||");
+			break;
 		case BrowseFileType::ANY:
 			filter = MakeFilter(L"All files (*.*)|*.*||");
 			break;

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -117,6 +117,7 @@ Y = Y
 Cheats = ‎الشفرات
 Edit Cheat File = ‎عدل ملف الشفرة
 Import Cheats = ‎إستورد من  cheat.db
+Import from %s = ‎إستورد من  %s
 Refresh Rate = ‎معدل التحديث
 
 [DesktopUI]

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -116,9 +116,7 @@ Y = Y
 [CwCheats]
 Cheats = ‎الشفرات
 Edit Cheat File = ‎عدل ملف الشفرة
-Enable/Disable All = ‎تمكين/تعطيل كل الشفرات
 Import Cheats = ‎إستورد من  cheat.db
-Options = ‎إعدادات
 Refresh Rate = ‎معدل التحديث
 
 [DesktopUI]

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Cheats
 Edit Cheat File = Edit cheat file
 Import Cheats = Import from cheat.db
+Import from %s = Import from %s
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Cheats
 Edit Cheat File = Edit cheat file
-Enable/Disable All = Enable/Disable all Cheats
 Import Cheats = Import from cheat.db
-Options = Options
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Чийтове
 Edit Cheat File = Edit cheat file
 Import Cheats = Внеси от cheat.db
+Import from %s = Внеси от %s
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Чийтове
 Edit Cheat File = Edit cheat file
-Enable/Disable All = Включи/Изключи всички чийтове
 Import Cheats = Внеси от cheat.db
-Options = Опции
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Trucs
 Edit Cheat File = Editar el fitxer de trucs
 Import Cheats = Importar «cheat.db»
+Import from %s = Importar %s
 Refresh Rate = Freqüència de refrescament
 
 [DesktopUI]

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Trucs
 Edit Cheat File = Editar el fitxer de trucs
-Enable/Disable All = Activar/desactivar tots els trucs
 Import Cheats = Importar «cheat.db»
-Options = Opcions
 Refresh Rate = Freqüència de refrescament
 
 [DesktopUI]

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Cheaty
 Edit Cheat File = Upravit soubor s cheaty
-Enable/Disable All = Povolit/Zakázat všechny cheaty
 Import Cheats = Importovat z cheat.db
-Options = Nastavení
 Refresh Rate = Frekvence obnoveni
 
 [DesktopUI]

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Cheaty
 Edit Cheat File = Upravit soubor s cheaty
 Import Cheats = Importovat z cheat.db
+Import from %s = Importovat z %s
 Refresh Rate = Frekvence obnoveni
 
 [DesktopUI]

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Snyd
 Edit Cheat File = Editer snydefil
-Enable/Disable All = Aktiver/Deaktiver alle snyd
 Import Cheats = Importer fra cheat.db
-Options = Optioner
 Refresh Rate = Opdateringsrate
 
 [DesktopUI]

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -108,7 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Snyd
 Edit Cheat File = Editer snydefil
-Import Cheats = Importer fra cheat.db
+Import from %s = Importer fra %s
 Refresh Rate = Opdateringsrate
 
 [DesktopUI]

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Cheats
 Edit Cheat File = Cheatdatei ändern
-Enable/Disable All = Alle de- oder aktivieren
 Import Cheats = Cheats importieren (aus cheat.db)
-Options = Optionen
 Refresh Rate = Wiederholfrequenz
 
 [DesktopUI]

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Cheat
 Edit Cheat File = Edit cheat file
 Import Cheats = Patamanni cheat.db
+Import from %s = Patamanni %s
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Cheat
 Edit Cheat File = Edit cheat file
-Enable/Disable All = Pajalan/Bosian nasan Cheat
 Import Cheats = Patamanni cheat.db
-Options = Pangpillean
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -133,6 +133,7 @@ Y = Y
 Cheats = Cheats
 Edit Cheat File = Edit cheat file
 Import Cheats = Import from cheat.db
+Import from %s = Import from %s
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -132,9 +132,7 @@ Y = Y
 [CwCheats]
 Cheats = Cheats
 Edit Cheat File = Edit cheat file
-Enable/Disable All = Enable/Disable all Cheats
 Import Cheats = Import from cheat.db
-Options = Options
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Trucos
 Edit Cheat File = Editar archivo de trucos
-Enable/Disable All = Activar/desactivar todos los trucos
 Import Cheats = Importar archivo cheat.db
-Options = Opciones
 Refresh Rate = Frecuencia de actualización
 
 [DesktopUI]

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = trucos
 Edit Cheat File = Editar archivo de trucos
-Enable/Disable All = Activar/desactivar todos los trucos
 Import Cheats = Importar archivo cheat.db
-Options = Opciones
 Refresh Rate = Frecuencia de actualización
 
 [DesktopUI]

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = ‎کد های تقلب
 Edit Cheat File = ‎ویرایش فایل کد ها
-Enable/Disable All = ‎فعال/غیرفعال کردن همه ی کدهای تقلب
 Import Cheats = ‎cheat.db وارد کردن از
-Options = ‎تنظیمات
 Refresh Rate = بازیابی نرخ
 
 [DesktopUI]

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Huijaukset
 Edit Cheat File = Muokkaa huijaus tiedostoa
 Import Cheats = Tuo huijauksia
+Import from %s = %s
 Refresh Rate = Ruudunpäivitysnopeus
 
 [DesktopUI]

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Huijaukset
 Edit Cheat File = Muokkaa huijaus tiedostoa
-Enable/Disable All = Ota/Poista käytöstä kaikki huijaukset
 Import Cheats = Tuo huijauksia
-Options = Asetukset
 Refresh Rate = Ruudunpäivitysnopeus
 
 [DesktopUI]

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -108,9 +108,7 @@ Y = Axe Y
 [CwCheats]
 Cheats = Codes de triche
 Edit Cheat File = Modifier le fichier de triche
-Enable/Disable All = Tout activer/désactiver
 Import Cheats = Importer des codes de triche
-Options = Options
 Refresh Rate = Taux de rafraîchissement
 
 [DesktopUI]

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -109,6 +109,7 @@ Y = Axe Y
 Cheats = Codes de triche
 Edit Cheat File = Modifier le fichier de triche
 Import Cheats = Importer des codes de triche
+Import from %s = Importer de %s
 Refresh Rate = Taux de rafraîchissement
 
 [DesktopUI]

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Trucos
 Edit Cheat File = Editar arquivo de trucos
 Import Cheats = Importar cheat.db
+Import from %s = Importar %s
 Refresh Rate = Frecuencia de actualización
 
 [DesktopUI]

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Trucos
 Edit Cheat File = Editar arquivo de trucos
-Enable/Disable All = Activar/desactivar tódolos trucos
 Import Cheats = Importar cheat.db
-Options = Opcións
 Refresh Rate = Frecuencia de actualización
 
 [DesktopUI]

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Κωδικοί
 Edit Cheat File = Επεξεργασία αρχείου κωδικών
 Import Cheats = Εισαγωγή από cheat.db
+Import from %s = Εισαγωγή από %s
 Refresh Rate = Ρυθμός ανανέωσης
 
 [DesktopUI]

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Κωδικοί
 Edit Cheat File = Επεξεργασία αρχείου κωδικών
-Enable/Disable All = Ενεργοπ./Απενεργοπ. Όλων
 Import Cheats = Εισαγωγή από cheat.db
-Options = Ρυθμίσεις
 Refresh Rate = Ρυθμός ανανέωσης
 
 [DesktopUI]

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Cheats
 Edit Cheat File = Edit cheat file
 Import Cheats = Import from cheat.db
+Import from %s = Import from %s
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Cheats
 Edit Cheat File = Edit cheat file
-Enable/Disable All = Enable/Disable all Cheats
 Import Cheats = Import from cheat.db
-Options = Options
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Cheats
 Edit Cheat File = Edit cheat file
 Import Cheats = Import from cheat.db
+Import from %s = Import from %s
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Cheats
 Edit Cheat File = Edit cheat file
-Enable/Disable All = Enable/Disable all Cheats
 Import Cheats = Import from cheat.db
-Options = Options
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Šifre
 Edit Cheat File = Izmijeni cheat datoteku
-Enable/Disable All = Upali/Izgasi sve Šifre
 Import Cheats = Uvezi iz cheat.db
-Options = Opcije
 Refresh Rate = Brzina osvježavanja
 
 [DesktopUI]

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Šifre
 Edit Cheat File = Izmijeni cheat datoteku
 Import Cheats = Uvezi iz cheat.db
+Import from %s = Uvezi iz %s
 Refresh Rate = Brzina osvježavanja
 
 [DesktopUI]

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Csalások
 Edit Cheat File = Csalás fájl szerkesztése
 Import Cheats = Importálás cheat.db-ből
+Import from %s = Importálás %s-ből
 Refresh Rate = Frissítési gyakoriság
 
 [DesktopUI]

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Csalások
 Edit Cheat File = Csalás fájl szerkesztése
-Enable/Disable All = Összes csalás engedélyezése/tiltása
 Import Cheats = Importálás cheat.db-ből
-Options = Beállítások
 Refresh Rate = Frissítési gyakoriság
 
 [DesktopUI]

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Pengecoh
 Edit Cheat File = Edit berkas pengecoh
-Enable/Disable All = Hidupkan/matikan semua pengecoh
 Import Cheats = Impor dari cheat.db
-Options = Pilihan
 Refresh Rate = Perbarui penyegaran
 
 [DesktopUI]

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Pengecoh
 Edit Cheat File = Edit berkas pengecoh
 Import Cheats = Impor dari cheat.db
+Import from %s = Impor dari %s
 Refresh Rate = Perbarui penyegaran
 
 [DesktopUI]

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Trucchi
 Edit Cheat File = Modifica file Trucchi
 Import Cheats = Importa da cheat.db
+Import from %s = Importa da %s
 Refresh Rate = Frequenza di Aggiornamento
 
 [DesktopUI]

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Trucchi
 Edit Cheat File = Modifica file Trucchi
-Enable/Disable All = Attiva/Disattiva Trucchi
 Import Cheats = Importa da cheat.db
-Options = Opzioni
 Refresh Rate = Frequenza di Aggiornamento
 
 [DesktopUI]

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = チート
 Edit Cheat File = チートファイルを編集する
 Import Cheats = cheat.dbからインポートする
+Import from %s = %sからインポートする
 Refresh Rate = リフレッシュレート
 
 [DesktopUI]

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = チート
 Edit Cheat File = チートファイルを編集する
-Enable/Disable All = 全て有効/無効にする
 Import Cheats = cheat.dbからインポートする
-Options = オプション
 Refresh Rate = リフレッシュレート
 
 [DesktopUI]

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Mbeling
 Edit Cheat File = Sunting berkas mbeling
-Enable/Disable All = Ngatifke/Pateni Kabeh mbeling
 Import Cheats = Njokot soko cheat.db
-Options = Pilian
 Refresh Rate = Restar rate
 
 [DesktopUI]

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -108,7 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Mbeling
 Edit Cheat File = Sunting berkas mbeling
-Import Cheats = Njokot soko cheat.db
+Import from %s = Njokot soko %s
 Refresh Rate = Restar rate
 
 [DesktopUI]

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = 치트
 Edit Cheat File = 치트 파일 수정
-Enable/Disable All = 모든 치트 활성화/비활성화
 Import Cheats = cheat.db에서 가져오기
-Options = 옵션
 Refresh Rate = 주사율
 
 [DesktopUI]

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -108,7 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = ການໃຊ້ສູດໂກງ
 Edit Cheat File = ປັບແຕ່ງໄຟລ໌ສູດໂກງ
-Import Cheats = ນຳເຂົ້າຈາກໄຟລ໌ສູດໂກງ
+Import from %s = ນຳເຂົ້າຈາກໄຟລ໌ສູດໂກງ %s
 Refresh Rate = ອັດຕາການຟື້ນຟູ
 
 [DesktopUI]

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = ການໃຊ້ສູດໂກງ
 Edit Cheat File = ປັບແຕ່ງໄຟລ໌ສູດໂກງ
-Enable/Disable All = ເປີດ/ປິດ ສູດທັງໝົດ
 Import Cheats = ນຳເຂົ້າຈາກໄຟລ໌ສູດໂກງ
-Options = ໂຕເລືອກ
 Refresh Rate = ອັດຕາການຟື້ນຟູ
 
 [DesktopUI]

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Kodai
 Edit Cheat File = Redaguoti kodų failą
 Import Cheats = Importuoti iš cheat.db
+Import from %s = Importuoti iš %s
 Refresh Rate = Atsinaujinimo dažnis
 
 [DesktopUI]

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Kodai
 Edit Cheat File = Redaguoti kodų failą
-Enable/Disable All = Įjungti/Išjungti visus Kodus
 Import Cheats = Importuoti iš cheat.db
-Options = Parametrai
 Refresh Rate = Atsinaujinimo dažnis
 
 [DesktopUI]

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Cheat
 Edit Cheat File = Ubah cheat file
-Enable/Disable All = Upayakan/Lumpuhkan semua Cheat
 Import Cheats = Import dari cheat.db
-Options = Pilihan
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Cheat
 Edit Cheat File = Ubah cheat file
 Import Cheats = Import dari cheat.db
+Import from %s = Import dari %s
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Cheats
 Edit Cheat File = Cheatbestand bewerken
 Import Cheats = Importeren van cheat.db
+Import from %s = Importeren van %s
 Refresh Rate = Vernieuwingsfrequentie
 
 [DesktopUI]

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Cheats
 Edit Cheat File = Cheatbestand bewerken
-Enable/Disable All = Alle cheats aan-/uitzetten
 Import Cheats = Importeren van cheat.db
-Options = Opties
 Refresh Rate = Vernieuwingsfrequentie
 
 [DesktopUI]

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Cheats
 Edit Cheat File = Edit cheat file
 Import Cheats = Import from cheat.db
+Import from %s = Import from %s
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Cheats
 Edit Cheat File = Edit cheat file
-Enable/Disable All = Enable/Disable all Cheats
 Import Cheats = Import from cheat.db
-Options = Options
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Kody
 Edit Cheat File = Edytuj plik kodów
 Import Cheats = Importuj z pliku cheat.db
+Import from %s = Importuj z pliku %s
 Refresh Rate = Szybkość odświeżania
 
 [DesktopUI]

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Kody
 Edit Cheat File = Edytuj plik kodów
-Enable/Disable All = Wł./wył. wszystkie kody
 Import Cheats = Importuj z pliku cheat.db
-Options = Opcje
 Refresh Rate = Szybkość odświeżania
 
 [DesktopUI]

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -133,6 +133,7 @@ Y = Y
 Cheats = Trapaças
 Edit Cheat File = Editar arquivo de trapaças
 Import Cheats = Importar do cheat.db
+Import from %s = Importar do %s
 Refresh Rate = Taxa de atualização
 
 [DesktopUI]
@@ -515,7 +516,7 @@ Frame Skipping = Pulo dos frames
 Frame Skipping Type = Tipo de pulo dos frames
 FullScreen = Tela cheia
 Geometry shader culling = Abate do shader da geometria
-Hack Settings = Configurações dos hacks (pode causar erros gráficos)									  
+Hack Settings = Configurações dos hacks (pode causar erros gráficos)
 Hardware Tessellation = Tesselação por hardware
 Hardware Transform = Transformação por hardware
 hardware transform error - falling back to software = Erro de transformação pelo hardware, retrocedendo pro software.
@@ -884,10 +885,10 @@ tools = Ferramentas grátis usadas:
 # Leave extra lines blank. 4 contributors per line seems to look best.
 translators1 = Papel, gabrielmop, Efraim Lopes, AkiraJkr
 translators2 = Felipe
-translators3 = 
-translators4 = 
-translators5 = 
-translators6 = 
+translators3 =
+translators4 =
+translators5 =
+translators6 =
 Twitter @PPSSPP_emu = Twitter @PPSSPP_emu
 website = Verifique o site da web:
 written = Escrito em C++ pela velocidade e portabilidade

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -132,9 +132,7 @@ Y = Y
 [CwCheats]
 Cheats = Trapaças
 Edit Cheat File = Editar arquivo de trapaças
-Enable/Disable All = Ativar/Desativar todas as trapaças
 Import Cheats = Importar do cheat.db
-Options = Opções
 Refresh Rate = Taxa de atualização
 
 [DesktopUI]

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -132,9 +132,7 @@ Y = Y
 [CwCheats]
 Cheats = Cheats
 Edit Cheat File = Editar ficheiro de Cheats
-Enable/Disable All = Ativar/Desativar todas os Cheats
 Import Cheats = Importar de cheat.db
-Options = Opções
 Refresh Rate = Taxa de refrescamento
 
 [DesktopUI]

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -133,6 +133,7 @@ Y = Y
 Cheats = Cheats
 Edit Cheat File = Editar ficheiro de Cheats
 Import Cheats = Importar de cheat.db
+Import from %s = Importar de %s
 Refresh Rate = Taxa de refrescamento
 
 [DesktopUI]

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Trișare
 Edit Cheat File = Editare fișier trișare
-Enable/Disable All = Activează/Dezactivează tot trișatul
 Import Cheats = Importă din cheat.db
-Options = Opțiuni
 Refresh Rate = Rată de împrospatare
 
 [DesktopUI]

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Trișare
 Edit Cheat File = Editare fișier trișare
 Import Cheats = Importă din cheat.db
+Import %s = Importă din %s
 Refresh Rate = Rată de împrospatare
 
 [DesktopUI]

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Читы
 Edit Cheat File = Изменить файл чита
 Import Cheats = Импортировать из cheat.db
+Import from %s = Импортировать из %s
 Refresh Rate = Частота обновления
 
 [DesktopUI]

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Читы
 Edit Cheat File = Изменить файл чита
-Enable/Disable All = Включить/выключить все
 Import Cheats = Импортировать из cheat.db
-Options = Настройки
 Refresh Rate = Частота обновления
 
 [DesktopUI]

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Fusk
 Edit Cheat File = Redigera fusk-fil
-Enable/Disable All = Slå av eller på alla
 Import Cheats = Importera från cheat.db
-Options = Inställningar
 Refresh Rate = Uppdateringsfrekvens
 
 [DesktopUI]

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Fusk
 Edit Cheat File = Redigera fusk-fil
 Import Cheats = Importera från cheat.db
+Import from %s = Importera från %s
 Refresh Rate = Uppdateringsfrekvens
 
 [DesktopUI]

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -108,7 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Mga Daya
 Edit Cheat File = Edit Cheat File
-Import Cheats = Import ang mga daya mula sa cheat.db
+Import from %s = Import ang mga daya mula sa %s
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Mga Daya
 Edit Cheat File = Edit Cheat File
-Enable/Disable All = Paganahin/Wag paganahin ang mga daya
 Import Cheats = Import ang mga daya mula sa cheat.db
-Options = Ayos
 Refresh Rate = Refresh rate
 
 [DesktopUI]

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -108,9 +108,7 @@ Y = แกน Y
 [CwCheats]
 Cheats = การใช้สูตรโกง
 Edit Cheat File = ปรับแต่งไฟล์สูตรโกง
-Enable/Disable All = เปิด/ปิด ใช้งานสูตรทั้งหมด
 Import Cheats = นำเข้าจากไฟล์สูตรโกง
-Options = ตัวเลือก
 Refresh Rate = อัตรารีเฟรช
 
 [DesktopUI]

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Hileler
 Edit Cheat File = Hile dosyasını düzenle
 Import Cheats = cheat.db'den hile al
+Import from %s = %s'den hile al
 Refresh Rate = Yenileme Hızı
 
 [DesktopUI]

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Hileler
 Edit Cheat File = Hile dosyasını düzenle
-Enable/Disable All = Bütün hileleri Aç/Kapat
 Import Cheats = cheat.db'den hile al
-Options = Ayarlar
 Refresh Rate = Yenileme Hızı
 
 [DesktopUI]

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Чит-коди
 Edit Cheat File = Змінити файл чит-коду
 Import Cheats = Імпортувати з cheat.db
+Import from %s = Імпортувати з %s
 Refresh Rate = Частота оновлення
 
 [DesktopUI]

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Чит-коди
 Edit Cheat File = Змінити файл чит-коду
-Enable/Disable All = Ввімкнути/Вимкнути все
 Import Cheats = Імпортувати з cheat.db
-Options = Налаштування
 Refresh Rate = Частота оновлення
 
 [DesktopUI]

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = Cheats
 Edit Cheat File = Sửa mục cheat
 Import Cheats = Nhập mã từ cheat.db
+Import from %s = Nhập mã từ %s
 Refresh Rate = Tần số làm mới
 
 [DesktopUI]

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = Cheats
 Edit Cheat File = Sửa mục cheat
-Enable/Disable All = Bật/Tắt tất cả các mã cheat
 Import Cheats = Nhập mã từ cheat.db
-Options = Thiết lập
 Refresh Rate = Tần số làm mới
 
 [DesktopUI]

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = 金手指
 Edit Cheat File = 编辑金手指文件
 Import Cheats = 从cheat.db导入
+Import from %s = 从%s导入
 Refresh Rate = 刷新率
 
 [DesktopUI]

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = 金手指
 Edit Cheat File = 编辑金手指文件
-Enable/Disable All = 启用/禁用全部
 Import Cheats = 从cheat.db导入
-Options = 选项
 Refresh Rate = 刷新率
 
 [DesktopUI]

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -108,9 +108,7 @@ Y = Y
 [CwCheats]
 Cheats = 密技
 Edit Cheat File = 編輯密技檔案
-Enable/Disable All = 啟用/停用所有密技
 Import Cheats = 從 cheat.db 匯入
-Options = 選項
 Refresh Rate = 重新整理速率
 
 [DesktopUI]

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -109,6 +109,7 @@ Y = Y
 Cheats = 密技
 Edit Cheat File = 編輯密技檔案
 Import Cheats = 從 cheat.db 匯入
+Import Cheats = 從 %s 匯入
 Refresh Rate = 重新整理速率
 
 [DesktopUI]


### PR DESCRIPTION
Allows the user to pick a cheat.db file to import from, which is more intuitive than a fixed location on the memstick. Was super easy to implement now after the big refactoring I did yesterday - previously it was gonna be rough.

![image](https://user-images.githubusercontent.com/130929/227207950-40d69a85-1c9e-4fb2-98b9-3cf35f7f6690.png)

A very minimal upgrade to the UI. How cheats work really needs a complete overhaul (just look at those category headers, heh), but that won't happen for 1.15.

Fixes #16648 