### PR TITLE
Add -mfpmath=sse to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,6 +368,10 @@ if(NOT MSVC)
 	if(X86 OR X86_64)
 		# enable sse2 code generation
 		add_definitions(-msse2)
+		if(NOT X86_64 AND NOT CLANG)
+			add_definitions(-mfpmath=sse)
+			# add_definitions(-mstackrealign)
+		 endif()
 	endif()
 
 	if(IOS)


### PR DESCRIPTION
Only affects x86+32bit+gcc combo.

Taken this stuff from #16984 into its own pull request.
Fixes (on my system) some pspautotests failures mentioned in #17161.
Left `-mstackrealign` there (but commented out) mostly to match #16984, but also as a remainder that it is a thing.