### PR TITLE
Remove polling requirement from DSound audio backend

### DIFF
--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -239,15 +239,8 @@ int NativeMix(short *audio, int num_samples) {
 	if (GetUIState() != UISTATE_INGAME) {
 		g_BackgroundAudio.Play();
 	}
-
 	int sample_rate = System_GetPropertyInt(SYSPROP_AUDIO_SAMPLE_RATE);
-	num_samples = __AudioMix(audio, num_samples, sample_rate > 0 ? sample_rate : 44100);
-
-#ifdef _WIN32
-	winAudioBackend->Update();
-#endif
-
-	return num_samples;
+	return __AudioMix(audio, num_samples, sample_rate > 0 ? sample_rate : 44100);
 }
 
 // This is called before NativeInit so we do a little bit of initialization here.

--- a/UWP/XAudioSoundStream.cpp
+++ b/UWP/XAudioSoundStream.cpp
@@ -19,8 +19,7 @@ public:
 	~XAudioBackend() override;
 
 	bool Init(HWND window, StreamCallback callback, int sampleRate) override;  // If fails, can safely delete the object
-	void Update() override;
-	int GetSampleRate() override { return sampleRate_; }
+	int GetSampleRate() const override { return sampleRate_; }
 
 private:
 	bool RunSound();
@@ -131,9 +130,6 @@ bool XAudioBackend::Init(HWND window, StreamCallback _callback, int sampleRate) 
 	callback_ = _callback;
 	sampleRate_ = sampleRate;
 	return RunSound();
-}
-
-void XAudioBackend::Update() {
 }
 
 void XAudioBackend::PollLoop() {

--- a/Windows/DSoundStream.cpp
+++ b/Windows/DSoundStream.cpp
@@ -29,8 +29,8 @@ unsigned int WINAPI DSoundAudioBackend::soundThread(void *param) {
 }
 
 bool DSoundAudioBackend::WriteDataToBuffer(DWORD offset, // Our own write cursor.
-																		char* soundData, // Start of our data.
-																		DWORD soundBytes) { // Size of block to copy.
+										   char* soundData, // Start of our data.
+										   DWORD soundBytes) { // Size of block to copy.
 	void *ptr1, *ptr2;
 	DWORD numBytes1, numBytes2;
 	// Obtain memory address of write block. This will be in two parts if the block wraps around.
@@ -41,15 +41,16 @@ bool DSoundAudioBackend::WriteDataToBuffer(DWORD offset, // Our own write cursor
 	dsBuffer->Restore();
 	hr=dsBuffer->Lock(dwOffset, dwSoundBytes, &ptr1, &numBytes1, &ptr2, &numBytes2, 0);
 	} */
-	if (SUCCEEDED(hr)) { 
-		memcpy(ptr1, soundData, numBytes1);
-		if (ptr2)
-			memcpy(ptr2, soundData+numBytes1, numBytes2);
-		// Release the data back to DirectSound.
-		dsBuffer_->Unlock(ptr1, numBytes1, ptr2, numBytes2);
-		return true;
+	if (FAILED(hr)) {
+		return false;
 	}
-	return false;
+
+	memcpy(ptr1, soundData, numBytes1);
+	if (ptr2)
+		memcpy(ptr2, soundData + numBytes1, numBytes2);
+	// Release the data back to DirectSound.
+	dsBuffer_->Unlock(ptr1, numBytes1, ptr2, numBytes2);
+	return true;
 }
 
 bool DSoundAudioBackend::CreateBuffer() {
@@ -97,7 +98,6 @@ int DSoundAudioBackend::RunThread() {
 		return 1;
 	}
 
-	soundSyncEvent_ = CreateEvent(0, false, false, 0);
 	InitializeCriticalSection(&soundCriticalSection);
 
 	DWORD num1;
@@ -114,6 +114,8 @@ int DSoundAudioBackend::RunThread() {
 	lastPos_ = 0;
 
 	dsBuffer_->Play(0, 0, DSBPLAY_LOOPING);
+
+	auto ModBufferSize = [&](int x) { return (x + bufferSize_) % bufferSize_; };
 
 	while (!threadData_) {
 		EnterCriticalSection(&soundCriticalSection);
@@ -135,7 +137,7 @@ int DSoundAudioBackend::RunThread() {
 		}
 
 		LeaveCriticalSection(&soundCriticalSection);
-		WaitForSingleObject(soundSyncEvent_, MAXWAIT);
+		Sleep(5);
 	}
 	dsBuffer_->Stop();
 
@@ -144,9 +146,6 @@ int DSoundAudioBackend::RunThread() {
 
 	threadData_ = 2;
 	return 0;
-}
-
-DSoundAudioBackend::DSoundAudioBackend() {
 }
 
 DSoundAudioBackend::~DSoundAudioBackend() {
@@ -168,10 +167,6 @@ DSoundAudioBackend::~DSoundAudioBackend() {
 		hThread_ = NULL;
 	}
 
-	if (soundSyncEvent_ != NULL) {
-		CloseHandle(soundSyncEvent_);
-	}
-	soundSyncEvent_ = NULL;
 	LeaveCriticalSection(&soundCriticalSection);
 	DeleteCriticalSection(&soundCriticalSection);
 }
@@ -186,9 +181,4 @@ bool DSoundAudioBackend::Init(HWND window, StreamCallback _callback, int sampleR
 		return false;
 	SetThreadPriority(hThread_, THREAD_PRIORITY_ABOVE_NORMAL);
 	return true;
-}
-
-void DSoundAudioBackend::Update() {
-	if (soundSyncEvent_ != NULL)
-		SetEvent(soundSyncEvent_);
 }

--- a/Windows/DSoundStream.h
+++ b/Windows/DSoundStream.h
@@ -10,15 +10,12 @@ struct IDirectSoundBuffer;
 
 class DSoundAudioBackend : public WindowsAudioBackend {
 public:
-	DSoundAudioBackend();
 	~DSoundAudioBackend();
 
 	bool Init(HWND window, StreamCallback callback, int sampleRate) override;  // If fails, can safely delete the object
-	void Update() override;
-	int GetSampleRate() override { return sampleRate_; }
+	int GetSampleRate() const override { return sampleRate_; }
 
 private:
-	inline int ModBufferSize(int x) { return (x + bufferSize_) % bufferSize_; }
 	int RunThread();
 	static unsigned int WINAPI soundThread(void *param);
 	bool CreateBuffer();
@@ -27,8 +24,7 @@ private:
 		DWORD soundBytes); // Size of block to copy.
 
 	CRITICAL_SECTION soundCriticalSection;
-	HWND window_;
-	HANDLE soundSyncEvent_ = nullptr;
+	HWND window_ = nullptr;
 	HANDLE hThread_ = nullptr;
 
 	StreamCallback callback_;
@@ -36,9 +32,9 @@ private:
 	IDirectSound8 *ds_ = nullptr;
 	IDirectSoundBuffer *dsBuffer_ = nullptr;
 
-	int bufferSize_; // bytes
-	int totalRenderedBytes_;
-	int sampleRate_;
+	int bufferSize_ = 0; // bytes
+	int totalRenderedBytes_ = 0;
+	int sampleRate_ = 0;
 
 	volatile int threadData_ = 0;
 
@@ -47,7 +43,7 @@ private:
 		MAXWAIT = 20,   //ms
 	};
 
-	int currentPos_;
-	int lastPos_;
+	int currentPos_ = 0;
+	int lastPos_ = 0;
 	short realtimeBuffer_[BUFSIZE * 2];
 };

--- a/Windows/WASAPIStream.h
+++ b/Windows/WASAPIStream.h
@@ -11,8 +11,7 @@ public:
 	~WASAPIAudioBackend();
 
 	bool Init(HWND window, StreamCallback callback, int sampleRate) override;  // If fails, can safely delete the object
-	void Update() override {}
-	int GetSampleRate() override { return sampleRate_; }
+	int GetSampleRate() const override { return sampleRate_; }
 
 private:
 	int RunThread();

--- a/Windows/WindowsAudio.h
+++ b/Windows/WindowsAudio.h
@@ -10,11 +10,9 @@ typedef int(*StreamCallback)(short *buffer, int numSamples, int bits, int rate);
 // should be returned by GetSampleRate though.
 class WindowsAudioBackend {
 public:
-	WindowsAudioBackend() {}
 	virtual ~WindowsAudioBackend() {}
 	virtual bool Init(HWND window, StreamCallback _callback, int sampleRate) = 0;
-	virtual void Update() {}  // Doesn't have to do anything
-	virtual int GetSampleRate() = 0;
+	virtual int GetSampleRate() const = 0;
 };
 
 // Factory

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -132,11 +132,6 @@ void WindowsHost::SetWindowTitle(const char *message) {
 // UGLY!
 extern WindowsAudioBackend *winAudioBackend;
 
-void WindowsHost::UpdateSound() {
-	if (winAudioBackend)
-		winAudioBackend->Update();
-}
-
 void WindowsHost::PollControllers() {
 	static int checkCounter = 0;
 	static const int CHECK_FREQUENCY = 71;

--- a/Windows/WindowsHost.h
+++ b/Windows/WindowsHost.h
@@ -34,8 +34,6 @@ public:
 
 	void PollControllers() override;
 
-	void UpdateSound() override;
-
 	bool AttemptLoadSymbolMap() override;
 	void SaveSymbolMap() override;
 	void SetWindowTitle(const char *message) override;


### PR DESCRIPTION
Might as well sleep for a short period instead, same effect really.

Preparation for some audio refactoring.