### PR TITLE
Move the resampler usage to a common file, AudioCommon.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1293,6 +1293,13 @@ if(WIN32)
 	target_link_libraries(Common winmm d3d9 dsound)
 endif()
 
+if(NOT LIBRETRO)
+	list(APPEND NativeAppSource
+		UI/AudioCommon.h
+		UI/AudioCommon.cpp
+	)
+endif()
+
 list(APPEND NativeAppSource
 	android/jni/TestRunner.cpp
 	UI/DiscordIntegration.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1304,8 +1304,6 @@ list(APPEND NativeAppSource
 	android/jni/TestRunner.cpp
 	UI/DiscordIntegration.cpp
 	UI/NativeApp.cpp
-	UI/AudioCommon.h
-	UI/AudioCommon.cpp
 	UI/BackgroundAudio.h
 	UI/BackgroundAudio.cpp
 	UI/ChatScreen.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1297,6 +1297,8 @@ list(APPEND NativeAppSource
 	android/jni/TestRunner.cpp
 	UI/DiscordIntegration.cpp
 	UI/NativeApp.cpp
+	UI/AudioCommon.h
+	UI/AudioCommon.cpp
 	UI/BackgroundAudio.h
 	UI/BackgroundAudio.cpp
 	UI/ChatScreen.h

--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -191,5 +191,17 @@ bool System_GetPropertyBool(SystemProperty prop);
 void System_Notify(SystemNotification notification);
 
 std::vector<std::string> System_GetCameraDeviceList();
+
 bool System_AudioRecordingIsAvailable();
 bool System_AudioRecordingState();
+
+// For these functions, most platforms will use the implementation provided in UI/AudioCommon.cpp,
+// no need to implement separately.
+void System_AudioGetDebugStats(char *buf, size_t bufSize);
+void System_AudioClear();
+// These samples really have 16 bits of value, but can be a little out of range.
+void System_AudioPushSamples(const int32_t *audio, int numSamples);
+
+inline void System_AudioResetStatCounters() {
+	return System_AudioGetDebugStats(nullptr, 0);
+}

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -101,7 +101,6 @@ static void __AudioCPUMHzChange() {
 	audioHostIntervalCycles = (int)(usToCycles(1000000ULL) * 512 / hwSampleRate);
 }
 
-
 void __AudioInit() {
 	System_AudioResetStatCounters();
 	mixFrequency = 44100;

--- a/Core/HLE/__sceAudio.h
+++ b/Core/HLE/__sceAudio.h
@@ -46,21 +46,11 @@ u32 __AudioEnqueue(AudioChannel &chan, int chanNum, bool blocking);
 void __AudioWakeThreads(AudioChannel &chan, int result, int step);
 void __AudioWakeThreads(AudioChannel &chan, int result);
 
-// Resampler API, to be extracted
-int __AudioMix(short *outstereo, int numSamples, int sampleRate);
-void __AudioGetDebugStats(char *buf, size_t bufSize);
-void __AudioClear();
-void __AudioPushSamples(const s32 *audio, int numSamples);  // Should not be used in-game, only at the menu!
-void __AudioResetStatCounters();
-
-int __AudioGetHostAttemptBlockSize();
-
 // Audio Dumping stuff
 void __StartLogAudio(const Path &filename);
 void __StopLogAudio();
 
-class WAVDump
-{
+class WAVDump {
 public:
 	static void Reset();
 };

--- a/Core/HW/StereoResampler.cpp
+++ b/Core/HW/StereoResampler.cpp
@@ -343,7 +343,3 @@ void StereoResampler::ResetStatCounters() {
 	outputSampleCount_ = 0;
 	startTime_ = time_now_d();
 }
-
-void StereoResampler::DoState(PointerWrap &p) {
-	auto s = p.Section("resampler", 1);
-}

--- a/Core/HW/StereoResampler.h
+++ b/Core/HW/StereoResampler.h
@@ -22,7 +22,6 @@
 #include <cstdint>
 #include <atomic>
 
-#include "Common/Serialize/Serializer.h"
 #include "Common/CommonTypes.h"
 
 struct AudioDebugStats;
@@ -40,9 +39,6 @@ public:
 	void PushSamples(const s32* samples, unsigned int num_samples);
 
 	void Clear();
-
-	// TODO: Get rid of this.
-	static void DoState(PointerWrap &p);
 
 	void GetAudioDebugStats(char *buf, size_t bufSize);
 	void ResetStatCounters();

--- a/UI/AudioCommon.cpp
+++ b/UI/AudioCommon.cpp
@@ -1,0 +1,31 @@
+#include "Common/System/System.h"
+#include "Core/HW/StereoResampler.h"  // TODO: doesn't belong in Core/HW...
+#include "UI/AudioCommon.h"
+
+StereoResampler g_resampler;
+
+// numFrames is number of stereo frames.
+// This is called from *outside* the emulator thread.
+int __AudioMix(int16_t *outstereo, int numFrames, int sampleRate) {
+	return g_resampler.Mix(outstereo, numFrames, false, sampleRate);
+}
+
+void System_AudioGetDebugStats(char *buf, size_t bufSize) {
+	if (buf) {
+		g_resampler.GetAudioDebugStats(buf, bufSize);
+	} else {
+		g_resampler.ResetStatCounters();
+	}
+}
+
+void System_AudioClear() {
+	g_resampler.Clear();
+}
+
+void System_AudioPushSamples(const s32 *audio, int numSamples) {
+	if (audio) {
+		g_resampler.PushSamples(audio, numSamples);
+	} else {
+		g_resampler.Clear();
+	}
+}

--- a/UI/AudioCommon.h
+++ b/UI/AudioCommon.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <cstdint>
+
+int __AudioMix(int16_t *outstereo, int numFrames, int sampleRate);

--- a/UI/BackgroundAudio.cpp
+++ b/UI/BackgroundAudio.cpp
@@ -7,6 +7,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Data/Format/RIFF.h"
 #include "Common/Log.h"
+#include "Common/System/System.h"
 #include "Common/Serialize/SerializeFuncs.h"
 #include "Common/TimeUtil.h"
 #include "Common/Data/Collections/FixedSizeQueue.h"
@@ -344,7 +345,7 @@ bool BackgroundAudio::Play() {
 	// Immediately stop the sound if it is turned off while playing.
 	if (!g_Config.bEnableSound) {
 		Clear(true);
-		__AudioClear();
+		System_AudioClear();
 		return true;
 	}
 
@@ -393,7 +394,7 @@ bool BackgroundAudio::Play() {
 		}
 	}
 
-	__AudioPushSamples(buffer, sz);
+	System_AudioPushSamples(buffer, sz);
 
 	if (at3Reader_ && fadingOut_ && volume_ <= 0.0f) {
 		Clear(true);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1266,7 +1266,7 @@ Invalid / Unknown (%d)
 static void DrawAudioDebugStats(UIContext *ctx, const Bounds &bounds) {
 	FontID ubuntu24("UBUNTU24");
 	char statbuf[4096] = { 0 };
-	__AudioGetDebugStats(statbuf, sizeof(statbuf));
+	System_AudioGetDebugStats(statbuf, sizeof(statbuf));
 
 	ctx->Flush();
 	ctx->BindFontTexture();

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -106,6 +106,7 @@
 #include "Core/ThreadPools.h"
 
 #include "GPU/GPUInterface.h"
+#include "UI/AudioCommon.h"
 #include "UI/BackgroundAudio.h"
 #include "UI/ControlMappingScreen.h"
 #include "UI/DiscordIntegration.h"

--- a/UI/UI.vcxproj
+++ b/UI/UI.vcxproj
@@ -61,6 +61,7 @@
     <ClCompile Include="ReportScreen.cpp" />
     <ClCompile Include="SavedataScreen.cpp" />
     <ClCompile Include="Store.cpp" />
+    <ClCompile Include="AudioCommon.cpp" />
     <ClCompile Include="TiltAnalogSettingsScreen.cpp" />
     <ClCompile Include="TouchControlLayoutScreen.cpp" />
     <ClCompile Include="TouchControlVisibilityScreen.cpp" />
@@ -68,6 +69,7 @@
     <ClCompile Include="Theme.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="AudioCommon.h" />
     <ClInclude Include="BackgroundAudio.h" />
     <ClInclude Include="ChatScreen.h" />
     <ClInclude Include="ComboKeyMappingScreen.h" />

--- a/UI/UI.vcxproj.filters
+++ b/UI/UI.vcxproj.filters
@@ -82,6 +82,7 @@
     <ClCompile Include="JoystickHistoryView.cpp">
       <Filter>Views</Filter>
     </ClCompile>
+    <ClCompile Include="AudioCommon.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameInfoCache.h" />
@@ -165,6 +166,7 @@
     <ClInclude Include="JoystickHistoryView.h">
       <Filter>Views</Filter>
     </ClInclude>
+    <ClInclude Include="AudioCommon.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Screens">

--- a/UWP/UI_UWP/UI_UWP.vcxproj
+++ b/UWP/UI_UWP/UI_UWP.vcxproj
@@ -265,6 +265,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\UI\AudioCommon.h" />
     <ClInclude Include="..\..\UI\BackgroundAudio.h" />
     <ClInclude Include="..\..\UI\ChatScreen.h" />
     <ClInclude Include="..\..\UI\ComboKeyMappingScreen.h" />
@@ -300,6 +301,7 @@
     <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\UI\AudioCommon.cpp" />
     <ClCompile Include="..\..\UI\BackgroundAudio.cpp" />
     <ClCompile Include="..\..\UI\ChatScreen.cpp" />
     <ClCompile Include="..\..\UI\ComboKeyMappingScreen.cpp" />

--- a/UWP/UI_UWP/UI_UWP.vcxproj.filters
+++ b/UWP/UI_UWP/UI_UWP.vcxproj.filters
@@ -33,6 +33,7 @@
     <ClCompile Include="..\..\UI\ChatScreen.cpp" />
     <ClCompile Include="..\..\UI\Theme.cpp" />
     <ClCompile Include="..\..\UI\JoystickHistoryView.cpp" />
+    <ClCompile Include="..\..\UI\AudioCommon.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -68,5 +69,6 @@
     <ClInclude Include="..\..\UI\ChatScreen.h" />
     <ClInclude Include="..\..\UI\Theme.h" />
     <ClInclude Include="..\..\UI\JoystickHistoryView.h" />
+    <ClInclude Include="..\..\UI\AudioCommon.h" />
   </ItemGroup>
 </Project>

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -219,6 +219,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Common/Thread/ThreadManager.cpp \
   $(SRC)/Common/Thread/ParallelLoop.cpp \
   $(SRC)/Common/UI/AsyncImageFileView.cpp \
+  $(SRC)/Common/UI/AudioCommon.cpp \
   $(SRC)/Common/UI/Root.cpp \
   $(SRC)/Common/UI/Screen.cpp \
   $(SRC)/Common/UI/UI.cpp \

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -219,7 +219,6 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Common/Thread/ThreadManager.cpp \
   $(SRC)/Common/Thread/ParallelLoop.cpp \
   $(SRC)/Common/UI/AsyncImageFileView.cpp \
-  $(SRC)/Common/UI/AudioCommon.cpp \
   $(SRC)/Common/UI/Root.cpp \
   $(SRC)/Common/UI/Screen.cpp \
   $(SRC)/Common/UI/UI.cpp \
@@ -716,6 +715,7 @@ LOCAL_SRC_FILES := \
   $(SRC)/android/jni/AndroidVulkanContext.cpp \
   $(SRC)/android/jni/AndroidAudio.cpp \
   $(SRC)/android/jni/OpenSLContext.cpp \
+  $(SRC)/UI/AudioCommon.cpp \
   $(SRC)/UI/BackgroundAudio.cpp \
   $(SRC)/UI/DiscordIntegration.cpp \
   $(SRC)/UI/ChatScreen.cpp \

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -119,6 +119,9 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb) { cb(false, ""); }
 void System_AskForPermission(SystemPermission permission) {}
 PermissionStatus System_GetPermissionStatus(SystemPermission permission) { return PERMISSION_STATUS_GRANTED; }
+void System_AudioGetDebugStats(char *buf, size_t bufSize) { if (buf) buf[0] = '\0'; }
+void System_AudioClear() {}
+void System_AudioPushSamples(const s32 *audio, int numSamples) {}
 
 int printUsage(const char *progname, const char *reason)
 {

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -666,7 +666,6 @@ SOURCES_CXX += \
 	       $(COREDIR)/Util/PPGeDraw.cpp \
 	       $(COREDIR)/Util/AudioFormat.cpp \
 	       $(COREDIR)/Util/PortManager.cpp \
-           $(CORE_DIR)/UI/AudioCommon.cpp \
            $(CORE_DIR)/UI/GameInfoCache.cpp
 
 SOURCES_CXX += $(COREDIR)/HLE/__sceAudio.cpp

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -330,7 +330,6 @@ SOURCES_CXX += \
 	$(COMMONDIR)/Thread/ParallelLoop.cpp \
 	$(COMMONDIR)/Thread/ThreadManager.cpp \
 	$(COMMONDIR)/UI/AsyncImageFileView.cpp \
-	$(COMMONDIR)/UI/AudioCommon.cpp \
 	$(COMMONDIR)/UI/Root.cpp \
 	$(COMMONDIR)/UI/Screen.cpp \
 	$(COMMONDIR)/UI/UI.cpp \
@@ -667,6 +666,7 @@ SOURCES_CXX += \
 	       $(COREDIR)/Util/PPGeDraw.cpp \
 	       $(COREDIR)/Util/AudioFormat.cpp \
 	       $(COREDIR)/Util/PortManager.cpp \
+           $(CORE_DIR)/UI/AudioCommon.cpp \
            $(CORE_DIR)/UI/GameInfoCache.cpp
 
 SOURCES_CXX += $(COREDIR)/HLE/__sceAudio.cpp

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -330,6 +330,7 @@ SOURCES_CXX += \
 	$(COMMONDIR)/Thread/ParallelLoop.cpp \
 	$(COMMONDIR)/Thread/ThreadManager.cpp \
 	$(COMMONDIR)/UI/AsyncImageFileView.cpp \
+	$(COMMONDIR)/UI/AudioCommon.cpp \
 	$(COMMONDIR)/UI/Root.cpp \
 	$(COMMONDIR)/UI/Screen.cpp \
 	$(COMMONDIR)/UI/UI.cpp \

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -390,11 +390,8 @@ class LibretroHost : public Host
       LibretroHost() {}
       void UpdateSound() override
       {
-         int hostAttemptBlockSize = __AudioGetHostAttemptBlockSize();
-         const int blockSizeMax = 512;
-         static int16_t audio[blockSizeMax * 2];
-         assert(hostAttemptBlockSize <= blockSizeMax);
-
+         const int hostAttemptBlockSize = 512;
+         static int16_t audio[hostAttemptBlockSize * 2];
          int samples = __AudioMix(audio, hostAttemptBlockSize, SAMPLERATE);
          AudioBufferWrite(audio, samples);
       }

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -46,6 +46,8 @@
 #include "GPU/Common/TextureScalerCommon.h"
 #include "GPU/Common/PresentationCommon.h"
 
+#include "UI/AudioCommon.h"
+
 #include "libretro/libretro.h"
 #include "libretro/LibretroGraphicsContext.h"
 #include "libretro/libretro_core_options.h"

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -32,6 +32,7 @@
 #include "Core/HLE/sceUtility.h"
 #include "Core/HLE/__sceAudio.h"
 #include "Core/HW/MemoryStick.h"
+#include "Core/HW/StereoResampler.h"
 #include "Core/Host.h"
 #include "Core/MemMap.h"
 #include "Core/System.h"
@@ -1879,6 +1880,38 @@ void NativeRender(GraphicsContext *graphicsContext) {}
 void NativeResized() {}
 
 void System_Toast(const char *str) {}
+
+
+// Temporary, to keep the old behavior before changing it.
+
+StereoResampler g_resampler;
+
+// numFrames is number of stereo frames.
+// This is called from *outside* the emulator thread.
+int __AudioMix(int16_t *outstereo, int numFrames, int sampleRate) {
+   return g_resampler.Mix(outstereo, numFrames, false, sampleRate);
+}
+
+void System_AudioGetDebugStats(char *buf, size_t bufSize) {
+   if (buf) {
+      g_resampler.GetAudioDebugStats(buf, bufSize);
+   } else {
+      g_resampler.ResetStatCounters();
+   }
+}
+
+void System_AudioClear() {
+   g_resampler.Clear();
+}
+
+void System_AudioPushSamples(const int32_t *audio, int numSamples) {
+   if (audio) {
+      g_resampler.PushSamples(audio, numSamples);
+   } else {
+      g_resampler.Clear();
+   }
+}
+
 
 #if PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(IOS)
 std::vector<std::string> System_GetCameraDeviceList() { return std::vector<std::string>(); }

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -88,6 +88,9 @@ bool System_GetPropertyBool(SystemProperty prop) {
 	}
 }
 void System_Notify(SystemNotification notification) {}
+void System_AudioGetDebugStats(char *buf, size_t bufSize) { if (buf) buf[0] = '\0'; }
+void System_AudioClear() {}
+void System_AudioPushSamples(const s32 *audio, int numSamples) {}
 
 #if PPSSPP_PLATFORM(ANDROID)
 JNIEnv *getEnv() {


### PR DESCRIPTION
Ports that don't want to use the resampler can now simply exclude that file and provide their own implementation. 

Next up, libretro will be converted to do it that way. Note that this PR should not change anything noticeably - it just sets the stage.

