### PR TITLE
Tales of Phantasia - Narikiri Dungeon X: Avoid some GPU readbacks.

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -667,6 +667,9 @@ ULES00040 = true
 ULES00041 = true
 ULJM05160 = true
 
+# Narikiri Dungeon X. See issue #16714.
+ULJS00293 = true
+
 [IntraVRAMBlockTransferAllowCreateFB]
 # Final Fantasy - Type 0
 ULJM05900 = true


### PR DESCRIPTION
Copies to a framebuffer instead of RAM.

Confirmed through e-mail that is fixes the performance drop from #16714, but unknown whether there are any regressions in the rest of the game.

I guess we'll find out.

Fixes #16714. 