### PR TITLE
Add compat setting to force using maximum depth resolution

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -672,11 +672,6 @@ VkResult VulkanContext::CreateDevice() {
 		extensionsLookup_.KHR_get_memory_requirements2 = true;
 		extensionsLookup_.KHR_dedicated_allocation = EnableDeviceExtension(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
 	}
-	if (EnableDeviceExtension(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME)) {
-		if (EnableDeviceExtension(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME)) {
-			extensionsLookup_.EXT_external_memory_host = EnableDeviceExtension(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME);
-		}
-	}
 	if (EnableDeviceExtension(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME)) {
 		extensionsLookup_.KHR_create_renderpass2 = true;
 		extensionsLookup_.KHR_depth_stencil_resolve = EnableDeviceExtension(VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME);

--- a/Common/GPU/Vulkan/VulkanDebug.cpp
+++ b/Common/GPU/Vulkan/VulkanDebug.cpp
@@ -47,26 +47,37 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDebugUtilsCallback(
 	const char *pMessage = pCallbackData->pMessage;
 
 	int messageCode = pCallbackData->messageIdNumber;
-	if (messageCode == 101294395) {
+	switch (messageCode) {
+	case 101294395:
 		// UNASSIGNED-CoreValidation-Shader-OutputNotConsumed - benign perf warning
 		return false;
-	}
-	if (messageCode == 1303270965) {
+	case 1303270965:
 		// Benign perf warning, image blit using GENERAL layout.
 		// UNASSIGNED
 		return false;
-	}
-	if (messageCode == 606910136 || messageCode == -392708513 || messageCode == -384083808) {
+	case 606910136:
+	case -392708513:
+	case -384083808:
 		// VUID-vkCmdDraw-None-02686
 		// Kinda false positive, or at least very unnecessary, now that I solved the real issue.
 		// See https://github.com/hrydgard/ppsspp/pull/16354
 		return false;
-	}
-	if (messageCode == -375211665) {
+	case -375211665:
 		// VUID-vkAllocateMemory-pAllocateInfo-01713
 		// Can happen when VMA aggressively tries to allocate aperture memory for upload. It gracefully
 		// falls back to regular video memory, so we just ignore this. I'd argue this is a VMA bug, actually.
 		return false;
+	case 181611958:
+		// Extended validation.
+		// UNASSIGNED-BestPractices-vkCreateDevice-deprecated-extension
+		// Doing what this one says doesn't seem very reliable - if I rely strictly on the Vulkan version, I don't get some function pointers? Like createrenderpass2.
+		return false;
+	case 657182421:
+		// Extended validation (ARM best practices)
+		// Non-fifo validation not recommended
+		return false;
+	default:
+		break;
 	}
 
 	int count;

--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -223,7 +223,6 @@ PFN_vkCmdInsertDebugUtilsLabelEXT	 vkCmdInsertDebugUtilsLabelEXT;
 PFN_vkSetDebugUtilsObjectNameEXT     vkSetDebugUtilsObjectNameEXT;
 PFN_vkSetDebugUtilsObjectTagEXT      vkSetDebugUtilsObjectTagEXT;
 
-PFN_vkGetMemoryHostPointerPropertiesEXT vkGetMemoryHostPointerPropertiesEXT;
 PFN_vkGetBufferMemoryRequirements2KHR vkGetBufferMemoryRequirements2KHR;
 PFN_vkGetImageMemoryRequirements2KHR vkGetImageMemoryRequirements2KHR;
 PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR;
@@ -727,9 +726,6 @@ void VulkanLoadDeviceFunctions(VkDevice device, const VulkanExtensions &enabledE
 	LOAD_DEVICE_FUNC(device, vkCmdEndRenderPass);
 	LOAD_DEVICE_FUNC(device, vkCmdExecuteCommands);
 
-	if (enabledExtensions.EXT_external_memory_host) {
-		LOAD_DEVICE_FUNC(device, vkGetMemoryHostPointerPropertiesEXT);
-	}
 	if (enabledExtensions.KHR_dedicated_allocation) {
 		LOAD_DEVICE_FUNC(device, vkGetBufferMemoryRequirements2KHR);
 		LOAD_DEVICE_FUNC(device, vkGetImageMemoryRequirements2KHR);

--- a/Common/GPU/Vulkan/VulkanLoader.h
+++ b/Common/GPU/Vulkan/VulkanLoader.h
@@ -247,7 +247,6 @@ struct VulkanExtensions {
 	bool KHR_get_memory_requirements2;
 	bool KHR_dedicated_allocation;
 	bool KHR_create_renderpass2;
-	bool EXT_external_memory_host;
 	bool KHR_get_physical_device_properties2;
 	bool KHR_depth_stencil_resolve;
 	bool EXT_shader_stencil_export;

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -129,6 +129,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ReadbackDepth", &flags_.ReadbackDepth);
 	CheckSetting(iniFile, gameID, "BlockTransferDepth", &flags_.BlockTransferDepth);
 	CheckSetting(iniFile, gameID, "DaxterRotatedAnalogStick", &flags_.DaxterRotatedAnalogStick);
+	CheckSetting(iniFile, gameID, "ForceMaxDepthResolution", &flags_.ForceMaxDepthResolution);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -99,6 +99,7 @@ struct CompatFlags {
 	bool ReadbackDepth;
 	bool BlockTransferDepth;
 	bool DaxterRotatedAnalogStick;
+	bool ForceMaxDepthResolution;
 };
 
 struct VRCompat {

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -609,7 +609,7 @@ u32 GPUCommonHW::CheckGPUFeaturesLate(u32 features) const {
 	bool prefer24 = draw_->GetDeviceCaps().preferredDepthBufferFormat == Draw::DataFormat::D24_S8;
 	bool prefer16 = draw_->GetDeviceCaps().preferredDepthBufferFormat == Draw::DataFormat::D16;
 	if (!prefer16) {
-		if (sawExactEqualDepth_ && (features & GPU_USE_ACCURATE_DEPTH) != 0) {
+		if (sawExactEqualDepth_ && (features & GPU_USE_ACCURATE_DEPTH) != 0 && !PSP_CoreParameter().compat.flags().ForceMaxDepthResolution) {
 			// Exact equal tests tend to have issues unless we use the PSP's depth range.
 			// We use 24-bit depth virtually everwhere, the fallback is just for safety.
 			if (prefer24)

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -144,7 +144,7 @@ VkSampler SamplerCache::GetOrCreateSampler(const SamplerCacheKey &key) {
 		samp.anisotropyEnable = false;
 	}
 	if (key.maxLevel == 9 * 256) {
-		// No max level needed.
+		// No max level needed. Better for performance on some archs like ARM Mali.
 		samp.maxLod = VK_LOD_CLAMP_NONE;
 	} else {
 		samp.maxLod = (float)(int32_t)key.maxLevel * (1.0f / 256.0f);

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1075,6 +1075,24 @@ ULES00262 = true
 ULUS10064 = true
 ULKS46087 = true
 
+[ForceMaxDepthResolution]
+# See #17014 - some games don't need our heuristics that drop down to 16-bit depth.
+
+# Outrun 2006: Coast to Coast - issue #11358 (car reflections)
+ULES00262 = true
+ULUS10064 = true
+ULKS46087 = true
+
+# Split/Second
+ULES01402 = true
+ULUS10513 = true
+ULJM05812 = true
+NPJH50371 = true
+
+# Cars Race-o-rama
+ULUS10428 = true
+ULES01333 = true
+
 [DateLimited]
 # Car Jack Streets - issue #12698
 NPUZ00043 = true


### PR DESCRIPTION
Fixes #17014

Even if our depth-testing-equal heuristic believes that the game needs lower depth resolution.

This removes some depth-fighting artifacts (that are present on the real PSP, but nice to avoid) in Outrun, Split/Second and Cars: Race-o-Rama - essentially reverting these to the behavior we had before the heuristic.

(The heuristic is good though - it means less compat.ini hacks going in the other direction).

In the case of Outrun, this relies on two passes that pass exactly the same vertex coordinates twice resulting in the exact same final geometry. This is actually guaranteed by the spec if the vertex math on the position is exactly the same and "invariant" is set on the position output, though I guess you never know.. Haven't seen any issues at least.

Also sneak in disabling some validation messages from using extra Vulkan validation layers other than the default, and removed detection for a VK extension we're never gonna use.