### PR TITLE
headless: Remove printfEmuLog, simplify output

### DIFF
--- a/Common/System/Request.h
+++ b/Common/System/Request.h
@@ -142,8 +142,8 @@ inline void System_SetWindowTitle(const std::string &param) {
 	g_requestManager.MakeSystemRequest(SystemRequestType::SET_WINDOW_TITLE, nullptr, nullptr, param, "", 0);
 }
 
-inline void System_SendDebugOutput(const std::string &string) {
-	g_requestManager.MakeSystemRequest(SystemRequestType::SEND_DEBUG_OUTPUT, nullptr, nullptr, string, "", 0);
+inline bool System_SendDebugOutput(const std::string &string) {
+	return g_requestManager.MakeSystemRequest(SystemRequestType::SEND_DEBUG_OUTPUT, nullptr, nullptr, string, "", 0);
 }
 
 inline void System_SendDebugScreenshot(const std::string &data, int height) {

--- a/Core/CoreParameter.h
+++ b/Core/CoreParameter.h
@@ -61,7 +61,6 @@ struct CoreParameter {
 	std::string errorString;
 
 	bool startBreak;
-	bool printfEmuLog;  // writes "emulator:" logging to stdout
 	std::string *collectEmuLog = nullptr;
 	bool headLess;   // Try to avoid messageboxes etc
 

--- a/Core/CoreParameter.h
+++ b/Core/CoreParameter.h
@@ -61,7 +61,7 @@ struct CoreParameter {
 	std::string errorString;
 
 	bool startBreak;
-	std::string *collectEmuLog = nullptr;
+	std::string *collectDebugOutput = nullptr;
 	bool headLess;   // Try to avoid messageboxes etc
 
 	// Internal PSP rendering resolution and scale factor.

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2012,15 +2012,10 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 		case EMULATOR_DEVCTL__SEND_OUTPUT:
 			{
 				std::string data(Memory::GetCharPointer(argAddr), argLen);
-				if (PSP_CoreParameter().printfEmuLog) {
-					System_SendDebugOutput(data);
-				} else {
-					if (PSP_CoreParameter().collectEmuLog) {
-						*PSP_CoreParameter().collectEmuLog += data;
-					} else {
-						DEBUG_LOG(SCEIO, "%s", data.c_str());
-					}
-				}
+				if (!System_SendDebugOutput(data))
+					DEBUG_LOG(SCEIO, "%s", data.c_str());
+				if (PSP_CoreParameter().collectEmuLog)
+					*PSP_CoreParameter().collectEmuLog += data;
 				return 0;
 			}
 		case EMULATOR_DEVCTL__IS_EMULATOR:

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2014,8 +2014,8 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 				std::string data(Memory::GetCharPointer(argAddr), argLen);
 				if (!System_SendDebugOutput(data))
 					DEBUG_LOG(SCEIO, "%s", data.c_str());
-				if (PSP_CoreParameter().collectEmuLog)
-					*PSP_CoreParameter().collectEmuLog += data;
+				if (PSP_CoreParameter().collectDebugOutput)
+					*PSP_CoreParameter().collectDebugOutput += data;
 				return 0;
 			}
 		case EMULATOR_DEVCTL__IS_EMULATOR:

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1208,6 +1208,10 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 		ptr = newptr;
 		magicPtr = (u32_le *)ptr;
 		int ret = pspDecryptPRX(in, (u8*)ptr, head->psp_size);
+		if (ret <= 0 && *(u32_le *)&ptr[0x150] == 0x464c457f) {
+			ret = head->psp_size - 0x150;
+			memcpy(newptr, in + 0x150, ret);
+		}
 		if (reportedModule) {
 			// This should happen for all "kernel" modules.
 			*error_string = "Missing key";

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -305,7 +305,6 @@ void EmuScreen::bootGame(const Path &filename) {
 	coreParam.mountIso.clear();
 	coreParam.mountRoot.clear();
 	coreParam.startBreak = !g_Config.bAutoRun;
-	coreParam.printfEmuLog = false;
 	coreParam.headLess = false;
 
 	if (g_Config.iInternalResolution == 0) {

--- a/android/jni/TestRunner.cpp
+++ b/android/jni/TestRunner.cpp
@@ -100,7 +100,7 @@ bool RunTests() {
 	coreParam.renderHeight = 272;
 	coreParam.pixelWidth = 480;
 	coreParam.pixelHeight = 272;
-	coreParam.collectEmuLog = &output;
+	coreParam.collectDebugOutput = &output;
 	coreParam.fastForward = true;
 	coreParam.updateRecent = false;
 

--- a/android/jni/TestRunner.cpp
+++ b/android/jni/TestRunner.cpp
@@ -95,7 +95,6 @@ bool RunTests() {
 	coreParam.mountIso.clear();
 	coreParam.mountRoot = baseDirectory / "pspautotests";
 	coreParam.startBreak = false;
-	coreParam.printfEmuLog = false;
 	coreParam.headLess = true;
 	coreParam.renderWidth = 480;
 	coreParam.renderHeight = 272;

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -201,7 +201,7 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, const
 
 	std::string output;
 	if (opt.compare || opt.bench)
-		coreParameter.collectEmuLog = &output;
+		coreParameter.collectDebugOutput = &output;
 
 	std::string error_string;
 	if (!PSP_InitStart(coreParameter, &error_string)) {

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -446,7 +446,6 @@ int main(int argc, const char* argv[])
 	coreParameter.mountIso = mountIso ? Path(std::string(mountIso)) : Path();
 	coreParameter.mountRoot = mountRoot ? Path(std::string(mountRoot)) : Path();
 	coreParameter.startBreak = false;
-	coreParameter.printfEmuLog = !testOptions.compare;
 	coreParameter.headLess = true;
 	coreParameter.renderScaleFactor = 1;
 	coreParameter.renderWidth = 480;
@@ -523,6 +522,7 @@ int main(int argc, const char* argv[])
 	if (screenshotFilename)
 		headlessHost->SetComparisonScreenshot(Path(std::string(screenshotFilename)), testOptions.maxScreenshotError);
 	headlessHost->SetWriteFailureScreenshot(!teamCityMode && !getenv("GITHUB_ACTIONS") && !testOptions.bench);
+	headlessHost->SetWriteDebugOutput(!testOptions.compare && !testOptions.bench);
 
 #if PPSSPP_PLATFORM(ANDROID)
 	// For some reason the debugger installs it with this name?

--- a/headless/HeadlessHost.cpp
+++ b/headless/HeadlessHost.cpp
@@ -24,16 +24,6 @@
 #include "headless/Compare.h"
 #include "headless/HeadlessHost.h"
 
-void HeadlessHost::SendOrCollectDebugOutput(const std::string &data)
-{
-	if (PSP_CoreParameter().printfEmuLog)
-		SendDebugOutput(data);
-	else if (PSP_CoreParameter().collectEmuLog)
-		*PSP_CoreParameter().collectEmuLog += data;
-	else
-		DEBUG_LOG(COMMON, "%s", data.c_str());
-}
-
 void HeadlessHost::SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h) {
 	// Only if we're actually comparing.
 	if (comparisonScreenshot_.empty()) {
@@ -52,14 +42,14 @@ void HeadlessHost::SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h) {
 	ScreenshotComparer comparer(pixels, FRAME_STRIDE, FRAME_WIDTH, FRAME_HEIGHT);
 	double errors = comparer.Compare(comparisonScreenshot_);
 	if (errors < 0)
-		SendOrCollectDebugOutput(comparer.GetError() + "\n");
+		SendDebugOutput(comparer.GetError() + "\n");
 
 	if (errors > maxScreenshotError_)
-		SendOrCollectDebugOutput(StringFromFormat("Screenshot MSE: %f\n", errors));
+		SendDebugOutput(StringFromFormat("Screenshot MSE: %f\n", errors));
 
 	if (errors > maxScreenshotError_ && writeFailureScreenshot_) {
 		if (comparer.SaveActualBitmap(Path("__testfailure.bmp")))
-			SendOrCollectDebugOutput("Actual output written to: __testfailure.bmp\n");
+			SendDebugOutput("Actual output written to: __testfailure.bmp\n");
 		comparer.SaveVisualComparisonPNG(Path("__testcompare.png"));
 	}
 }

--- a/headless/HeadlessHost.h
+++ b/headless/HeadlessHost.h
@@ -29,21 +29,24 @@ public:
 	virtual void ShutdownGraphics() {}
 
 	virtual void SendDebugOutput(const std::string &output) {
+		if (!writeDebugOutput_)
+			return;
 		if (output.find('\n') != output.npos) {
-			DoFlushDebugOutput();
+			FlushDebugOutput();
 			fwrite(output.data(), sizeof(char), output.length(), stdout);
 		} else {
 			debugOutputBuffer_ += output;
 		}
 	}
-	virtual void FlushDebugOutput() {
-		DoFlushDebugOutput();
-	}
-	inline void DoFlushDebugOutput() {
+	void FlushDebugOutput() {
 		if (!debugOutputBuffer_.empty()) {
 			fwrite(debugOutputBuffer_.data(), sizeof(char), debugOutputBuffer_.length(), stdout);
 			debugOutputBuffer_.clear();
 		}
+	}
+
+	void SetWriteDebugOutput(bool flag) {
+		writeDebugOutput_ = flag;
 	}
 
 	void SetComparisonScreenshot(const Path &filename, double maxError) {
@@ -54,18 +57,16 @@ public:
 		writeFailureScreenshot_ = flag;
 	}
 
-	virtual void SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h);
+	void SendDebugScreenshot(const u8 *pixbuf, u32 w, u32 h);
 
-	// Unique for HeadlessHost
 	virtual void SwapBuffers() {}
 
 protected:
-	void SendOrCollectDebugOutput(const std::string &output);
-
 	Path comparisonScreenshot_;
 	double maxScreenshotError_ = 0.0;
 	std::string debugOutputBuffer_;
 	GPUCore gpuCore_;
 	GraphicsContext *gfx_ = nullptr;
 	bool writeFailureScreenshot_ = true;
+	bool writeDebugOutput_ = true;
 };

--- a/headless/WindowsHeadlessHost.cpp
+++ b/headless/WindowsHeadlessHost.cpp
@@ -66,9 +66,9 @@ HWND CreateHiddenWindow() {
 	return CreateWindowEx(0, L"PPSSPPHeadless", L"PPSSPPHeadless", style, CW_USEDEFAULT, CW_USEDEFAULT, WINDOW_WIDTH, WINDOW_HEIGHT, NULL, NULL, NULL, NULL);
 }
 
-void WindowsHeadlessHost::SendDebugOutput(const std::string &output)
-{
-	fwrite(output.data(), sizeof(char), output.length(), stdout);
+void WindowsHeadlessHost::SendDebugOutput(const std::string &output) {
+	if (writeDebugOutput_)
+		fwrite(output.data(), sizeof(char), output.length(), stdout);
 	OutputDebugStringUTF8(output.c_str());
 }
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1434,7 +1434,6 @@ bool retro_load_game(const struct retro_game_info *game)
    coreParam.fileToStart     = Path(std::string(game->path));
    coreParam.mountIso.clear();
    coreParam.startBreak      = false;
-   coreParam.printfEmuLog    = true;
    coreParam.headLess        = true;
    coreParam.graphicsContext = ctx;
    coreParam.gpuCore         = ctx->GetGPUCore();


### PR DESCRIPTION
Just a bit more quick cleanup, this doesn't really belong in CoreParameter and it's not actually about "emu logging" anyway.

-[Unknown]