### PR TITLE
UI: Avoid reloading PIC1 BG on game start & add plugin shutdown param

### DIFF
--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -76,14 +76,18 @@ private:
 
 		typedef bool (*InitFunc)(HandlerLogFunc logger, void *loggerArg);
 		typedef void (*ShutdownFunc)();
+		typedef void (*ShutdownV2Func)(void *loggerArg);
 		typedef HandlerHandle (*OpenFunc)(const char *basePath, const char *filename);
 		typedef HandlerOffset (*SeekFunc)(HandlerHandle handle, HandlerOffset offset, FileMove origin);
 		typedef HandlerOffset (*ReadFunc)(HandlerHandle handle, void *data, HandlerOffset size);
 		typedef void (*CloseFunc)(HandlerHandle handle);
+		typedef int (*VersionFunc)();
 
 		HandlerLibrary library;
+		VirtualDiscFileSystem *const sys_;
 		InitFunc Init;
 		ShutdownFunc Shutdown;
+		ShutdownV2Func ShutdownV2;
 		OpenFunc Open;
 		SeekFunc Seek;
 		ReadFunc Read;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -937,6 +937,8 @@ void EmuScreen::CreateViews() {
 		}
 		return EVENT_DONE;
 	});
+	// Will become visible along with the loadingView.
+	loadingBG->SetVisibility(V_INVISIBLE);
 }
 
 UI::EventReturn EmuScreen::OnDevTools(UI::EventParams &params) {


### PR DESCRIPTION
Also let plugins know which instance is shutting down if there are multiple threads.  Not noticeable when your plugin doesn't do any logging, but better to handle.

Not ideal, but not wanting to change the other function signatures.

-[Unknown]