### PR TITLE
Replacement: Save textures even if already replaced, if the texture file is missing.

### DIFF
--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -220,6 +220,12 @@ void ReplacedTexture::Prepare(VFSBackend *vfs) {
 
 		VFSFileReference *fileRef = vfs_->GetFile(desc_.filenames[i].c_str());
 		if (!fileRef) {
+			if (i == 0) {
+				WARN_LOG(G3D, "Texture replacement file '%s' not found", desc_.filenames[i].c_str());
+				// No file at all. Mark as NOT_FOUND.
+				SetState(ReplacementState::NOT_FOUND);
+				return;
+			}
 			// If the file doesn't exist, let's just bail immediately here.
 			// Mark as DONE, not error.
 			result = LoadLevelResult::DONE;
@@ -276,8 +282,7 @@ void ReplacedTexture::Prepare(VFSBackend *vfs) {
 
 	SetState(ReplacementState::ACTIVE);
 
-	if (threadWaitable_)
-		threadWaitable_->Notify();
+	// the caller calls threadWaitable->notify().
 }
 
 // Returns true if Prepare should keep calling this to load more levels.

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -186,6 +186,8 @@ bool ReplacedTexture::Poll(double budget) {
 	if (threadWaitable_->WaitFor(budget)) {
 		// If we successfully wait here, we're done. The thread will set state accordingly.
 		_assert_(State() == ReplacementState::ACTIVE || State() == ReplacementState::NOT_FOUND || State() == ReplacementState::CANCEL_INIT);
+		delete threadWaitable_;
+		threadWaitable_ = nullptr;
 		return true;
 	}
 	// Still pending on thread.

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2967,7 +2967,7 @@ void TextureCacheCommon::LoadTextureLevel(TexCacheEntry &entry, uint8_t *data, s
 			replacedInfo.fmt = dstFmt;
 
 			// NOTE: Reading the decoded texture here may be very slow, if we just wrote it to write-combined memory.
-			replacer_.NotifyTextureDecoded(replacedInfo, pixelData, decPitch, srcLevel, w, h, scaledW, scaledH);
+			replacer_.NotifyTextureDecoded(plan.replaced, replacedInfo, pixelData, decPitch, srcLevel, w, h, scaledW, scaledH);
 		}
 	}
 }

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -611,7 +611,7 @@ public:
 			return;
 		}
 
-		Path saveDirectory = filename.NavigateUp();
+		Path saveDirectory = saveFilename.NavigateUp();
 		if (!File::Exists(saveDirectory)) {
 			// Previously, we created a .nomedia file here. This is unnecessary as they have recursive behavior.
 			// When initializing (see NotifyConfigChange above) we create one in the "root" of the "new" folder.

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -111,7 +111,8 @@ public:
 	bool WillSave(const ReplacedTextureDecodeInfo &replacedInfo);
 
 	// Notify that a new texture was decoded. May already be upscaled, saves the data passed.
-	void NotifyTextureDecoded(const ReplacedTextureDecodeInfo &replacedInfo, const void *data, int pitch, int level, int origW, int origH, int scaledW, int scaledH);
+	// If the replacer knows about this one already, texture will be passed in, otherwise nullptr.
+	void NotifyTextureDecoded(ReplacedTexture *texture, const ReplacedTextureDecodeInfo &replacedInfo, const void *data, int pitch, int level, int origW, int origH, int scaledW, int scaledH);
 
 	void Decimate(ReplacerDecimateMode mode);
 

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1636,7 +1636,7 @@ size_t GPUCommonHW::FormatGPUStatsCommon(char *buffer, size_t size) {
 		"FBOs active: %d (evaluations: %d)\n"
 		"Textures: %d, dec: %d, invalidated: %d, hashed: %d kB\n"
 		"readbacks %d (%d non-block), uploads %d, depal %d\n"
-		"replacer: tracks %d textures, %d unique loaded\n"
+		"replacer: tracks %d references, %d unique textures\n"
 		"Copies: depth %d, color %d, reint %d, blend %d, selftex %d\n"
 		"GPU cycles executed: %d (%f per vertex)\n",
 		gpuStats.msProcessingDisplayLists * 1000.0f,

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -648,7 +648,7 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 				replacedInfo.isVideo = IsVideo(entry->addr);
 				replacedInfo.isFinal = (entry->status & TexCacheEntry::STATUS_TO_SCALE) == 0;
 				replacedInfo.fmt = FromVulkanFormat(actualFmt);
-				replacer_.NotifyTextureDecoded(replacedInfo, data, byteStride, plan.baseLevelSrc + i, mipUnscaledWidth, mipUnscaledHeight, w, h);
+				replacer_.NotifyTextureDecoded(plan.replaced, replacedInfo, data, byteStride, plan.baseLevelSrc + i, mipUnscaledWidth, mipUnscaledHeight, w, h);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #17182

Not exactly sure what behavior we really want, but I think this one is OK, and at least more similar to the old one. Now we save already-replaced textures if the ini-named replacement texture is missing, and there isn't already a hash-named one in new or the "root". 