### PR TITLE
Debugger: Fix memory viewer, inverted check

### DIFF
--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -901,7 +901,7 @@ void CtrlMemView::search(bool continueSearch) {
 		segmentEnd = memoryAreas[i].second;
 
 		// better safe than sorry, I guess
-		if (Memory::IsValidAddress(segmentStart))
+		if (!Memory::IsValidAddress(segmentStart))
 			continue;
 		const u8 *dataPointer = Memory::GetPointerUnchecked(segmentStart);
 


### PR DESCRIPTION
Looks like I broke this in #16701.  I hardly ever use the search these days in the memory viewer, preferring to dump to a file if I need that (and usually I'm just looking at a range.)  Oops.

-[Unknown]