### PR TITLE
Rename KeyDef to InputMapping and give it responsibility for Axis encoding

### DIFF
--- a/Common/Input/InputState.cpp
+++ b/Common/Input/InputState.cpp
@@ -31,21 +31,21 @@ const char *GetDeviceName(int deviceId) {
 	}
 }
 
-std::vector<KeyDef> dpadKeys;
-std::vector<KeyDef> confirmKeys;
-std::vector<KeyDef> cancelKeys;
-std::vector<KeyDef> tabLeftKeys;
-std::vector<KeyDef> tabRightKeys;
+std::vector<InputMapping> dpadKeys;
+std::vector<InputMapping> confirmKeys;
+std::vector<InputMapping> cancelKeys;
+std::vector<InputMapping> tabLeftKeys;
+std::vector<InputMapping> tabRightKeys;
 static std::unordered_map<int, int> uiFlipAnalogY;
 
-static void AppendKeys(std::vector<KeyDef> &keys, const std::vector<KeyDef> &newKeys) {
+static void AppendKeys(std::vector<InputMapping> &keys, const std::vector<InputMapping> &newKeys) {
 	for (auto iter = newKeys.begin(); iter != newKeys.end(); ++iter) {
 		keys.push_back(*iter);
 	}
 }
 
-void SetDPadKeys(const std::vector<KeyDef> &leftKey, const std::vector<KeyDef> &rightKey,
-		const std::vector<KeyDef> &upKey, const std::vector<KeyDef> &downKey) {
+void SetDPadKeys(const std::vector<InputMapping> &leftKey, const std::vector<InputMapping> &rightKey,
+		const std::vector<InputMapping> &upKey, const std::vector<InputMapping> &downKey) {
 	dpadKeys.clear();
 
 	// Store all directions into one vector for now.  In the future it might be
@@ -56,12 +56,12 @@ void SetDPadKeys(const std::vector<KeyDef> &leftKey, const std::vector<KeyDef> &
 	AppendKeys(dpadKeys, downKey);
 }
 
-void SetConfirmCancelKeys(const std::vector<KeyDef> &confirm, const std::vector<KeyDef> &cancel) {
+void SetConfirmCancelKeys(const std::vector<InputMapping> &confirm, const std::vector<InputMapping> &cancel) {
 	confirmKeys = confirm;
 	cancelKeys = cancel;
 }
 
-void SetTabLeftRightKeys(const std::vector<KeyDef> &tabLeft, const std::vector<KeyDef> &tabRight) {
+void SetTabLeftRightKeys(const std::vector<InputMapping> &tabLeft, const std::vector<InputMapping> &tabRight) {
 	tabLeftKeys = tabLeft;
 	tabRightKeys = tabRight;
 }

--- a/Common/Input/InputState.h
+++ b/Common/Input/InputState.h
@@ -8,6 +8,7 @@
 
 #include "Common/Math/lin/vec3.h"
 #include "Common/Input/KeyCodes.h"
+#include "Common/Log.h"
 
 // Default device IDs
 
@@ -79,21 +80,51 @@ enum {
 #endif
 
 // Represents a single bindable key
-class KeyDef {
+static const int AXIS_BIND_NKCODE_START = 4000;
+
+inline int TranslateKeyCodeToAxis(int keyCode, int *direction) {
+	if (keyCode < AXIS_BIND_NKCODE_START)
+		return 0;
+	int k = keyCode - AXIS_BIND_NKCODE_START;
+	// Even/odd for direction.
+	*direction = k & 1 ? -1 : 1;
+	return k / 2;
+}
+
+class InputMapping {
+private:
+	inline int TranslateKeyCodeFromAxis(int axisId, int direction) {
+		return AXIS_BIND_NKCODE_START + axisId * 2 + (direction < 0 ? 1 : 0);
+	}
 public:
-	KeyDef() : deviceId(0), keyCode(0) {}
-	KeyDef(int devId, int k) : deviceId(devId), keyCode(k) {}
+	InputMapping() : deviceId(0), keyCode(0) {}
+	// From a key mapping
+	InputMapping(int _deviceId, int key) : deviceId(_deviceId), keyCode(key) {}
+	// From an axis
+	InputMapping(int _deviceId, int axis, int direction) : deviceId(_deviceId), keyCode(TranslateKeyCodeFromAxis(axis, direction)) {
+		_dbg_assert_(direction != 0);
+	}
+
 	int deviceId;
-	int keyCode;
+	int keyCode;  // Can also represent an axis with direction, if encoded properly.
+
+	bool IsAxis() const {
+		return keyCode >= AXIS_BIND_NKCODE_START;
+	}
+
+	int Axis(int *direction) const {
+		_dbg_assert_(IsAxis());
+		return TranslateKeyCodeToAxis(keyCode, direction);
+	}
 
 	// If you want to use std::find and match ANY, you need to perform an explicit search for that.
-	bool operator < (const KeyDef &other) const {
+	bool operator < (const InputMapping &other) const {
 		if (deviceId < other.deviceId) return true;
 		if (deviceId > other.deviceId) return false;
 		if (keyCode < other.keyCode) return true;
 		return false;
 	}
-	bool operator == (const KeyDef &other) const {
+	bool operator == (const InputMapping &other) const {
 		if (deviceId != other.deviceId && deviceId != DEVICE_ID_ANY && other.deviceId != DEVICE_ID_ANY) return false;
 		if (keyCode != other.keyCode) return false;
 		return true;
@@ -156,15 +187,15 @@ struct AxisInput {
 };
 
 // Is there a nicer place for this stuff? It's here to avoid dozens of linking errors in UnitTest..
-extern std::vector<KeyDef> dpadKeys;
-extern std::vector<KeyDef> confirmKeys;
-extern std::vector<KeyDef> cancelKeys;
-extern std::vector<KeyDef> tabLeftKeys;
-extern std::vector<KeyDef> tabRightKeys;
-void SetDPadKeys(const std::vector<KeyDef> &leftKey, const std::vector<KeyDef> &rightKey,
-		const std::vector<KeyDef> &upKey, const std::vector<KeyDef> &downKey);
-void SetConfirmCancelKeys(const std::vector<KeyDef> &confirm, const std::vector<KeyDef> &cancel);
-void SetTabLeftRightKeys(const std::vector<KeyDef> &tabLeft, const std::vector<KeyDef> &tabRight);
+extern std::vector<InputMapping> dpadKeys;
+extern std::vector<InputMapping> confirmKeys;
+extern std::vector<InputMapping> cancelKeys;
+extern std::vector<InputMapping> tabLeftKeys;
+extern std::vector<InputMapping> tabRightKeys;
+void SetDPadKeys(const std::vector<InputMapping> &leftKey, const std::vector<InputMapping> &rightKey,
+		const std::vector<InputMapping> &upKey, const std::vector<InputMapping> &downKey);
+void SetConfirmCancelKeys(const std::vector<InputMapping> &confirm, const std::vector<InputMapping> &cancel);
+void SetTabLeftRightKeys(const std::vector<InputMapping> &tabLeft, const std::vector<InputMapping> &tabRight);
 
 // 0 means unknown (attempt autodetect), -1 means flip, 1 means original direction.
 void SetAnalogFlipY(std::unordered_map<int, int> flipYByDeviceId);

--- a/Common/Input/KeyCodes.h
+++ b/Common/Input/KeyCodes.h
@@ -234,24 +234,6 @@ typedef enum _keycode_t {
 	NKCODE_LEFTBRACE = 221,
 	NKCODE_RIGHTBRACE = 222,
 
-	// Ouya buttons. Just here for reference, they map straight to regular android buttons
-	// and will be mapped the same way.
-	NKCODE_OUYA_BUTTON_A = 97,
-	NKCODE_OUYA_BUTTON_DPAD_DOWN = 20,
-	NKCODE_OUYA_BUTTON_DPAD_LEFT = 21,
-	NKCODE_OUYA_BUTTON_DPAD_RIGHT = 22,
-	NKCODE_OUYA_BUTTON_DPAD_UP = 19,
-	NKCODE_OUYA_BUTTON_L1 = 102,
-	NKCODE_OUYA_BUTTON_L2 = 104,
-	NKCODE_OUYA_BUTTON_L3 = 106,
-	NKCODE_OUYA_BUTTON_MENU = 82,
-	NKCODE_OUYA_BUTTON_O = 96,
-	NKCODE_OUYA_BUTTON_R1 = 103,
-	NKCODE_OUYA_BUTTON_R2 = 105,
-	NKCODE_OUYA_BUTTON_R3 = 107,
-	NKCODE_OUYA_BUTTON_U = 99,
-	NKCODE_OUYA_BUTTON_Y = 100,
-
 	// Extended keycodes, not available on Android
 	NKCODE_EXT_PIPE = 1001,  // The key next to Z on euro 102-key keyboards.
 

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -263,11 +263,11 @@ bool Clickable::Touch(const TouchInput &input) {
 	return contains;
 }
 
-static bool MatchesKeyDef(const std::vector<KeyDef> &defs, const KeyInput &key) {
+static bool MatchesKeyDef(const std::vector<InputMapping> &defs, const KeyInput &key) {
 	// In addition to the actual search, we need to do another search where we replace the device ID with "ANY".
 	return
-		std::find(defs.begin(), defs.end(), KeyDef(key.deviceId, key.keyCode)) != defs.end() ||
-		std::find(defs.begin(), defs.end(), KeyDef(DEVICE_ID_ANY, key.keyCode)) != defs.end();
+		std::find(defs.begin(), defs.end(), InputMapping(key.deviceId, key.keyCode)) != defs.end() ||
+		std::find(defs.begin(), defs.end(), InputMapping(DEVICE_ID_ANY, key.keyCode)) != defs.end();
 }
 
 // TODO: O/X confirm preference for xperia play?

--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -469,7 +469,7 @@ bool UpdateVRKeys(const KeyInput &key) {
 	std::vector<int> nativeKeys;
 	bool wasScreenKeyOn = pspKeys[CTRL_SCREEN];
 	bool wasCameraAdjustOn = pspKeys[VIRTKEY_VR_CAMERA_ADJUST];
-	if (KeyMap::KeyToPspButton(key.deviceId, key.keyCode, &nativeKeys)) {
+	if (KeyMap::InputMappingToPspButton(InputMapping(key.deviceId, key.keyCode), &nativeKeys)) {
 		for (int& nativeKey : nativeKeys) {
 			pspKeys[nativeKey] = key.flags & KEY_DOWN;
 		}

--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -13,6 +13,9 @@
 
 #include "Common/Math/lin/matrix4x4.h"
 
+#include "Common/Input/InputState.h"
+#include "Common/Input/KeyCodes.h"
+
 #include "Core/HLE/sceDisplay.h"
 #include "Core/HLE/sceCtrl.h"
 

--- a/Common/VR/PPSSPPVR.h
+++ b/Common/VR/PPSSPPVR.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "Common/Input/InputState.h"
-#include "Common/Input/KeyCodes.h"
+struct AxisInput;
+struct TouchInput;
+struct KeyInput;
 
 enum VRCompatFlag {
 	//compatibility tweaks

--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -95,7 +95,7 @@ void ControlMapper::SetPSPAxis(int device, char axis, float value, int stick) {
 
 bool ControlMapper::Key(const KeyInput &key, bool *pauseTrigger) {
 	std::vector<int> pspKeys;
-	KeyMap::KeyToPspButton(key.deviceId, key.keyCode, &pspKeys);
+	KeyMap::InputMappingToPspButton(InputMapping(key.deviceId, key.keyCode), &pspKeys);
 
 	if (pspKeys.size() && (key.flags & KEY_IS_REPEAT)) {
 		// Claim that we handled this. Prevents volume key repeats from popping up the volume control on Android.
@@ -329,7 +329,7 @@ void ControlMapper::ProcessAxis(const AxisInput &axis, int direction) {
 	const float scale = virtKeys_[VIRTKEY_ANALOG_LIGHTLY - VIRTKEY_FIRST] ? g_Config.fAnalogLimiterDeadzone : 1.0f;
 
 	std::vector<int> results;
-	KeyMap::AxisToPspButton(axis.deviceId, axis.axisId, direction, &results);
+	KeyMap::InputMappingToPspButton(InputMapping(axis.deviceId, axis.axisId, direction), &results);
 
 	for (int result : results) {
 		float value = fabs(axis.value) * scale;
@@ -367,7 +367,7 @@ void ControlMapper::ProcessAxis(const AxisInput &axis, int direction) {
 	}
 
 	std::vector<int> resultsOpposite;
-	KeyMap::AxisToPspButton(axis.deviceId, axis.axisId, -direction, &resultsOpposite);
+	KeyMap::InputMappingToPspButton(InputMapping(axis.deviceId, axis.axisId, -direction), &resultsOpposite);
 
 	for (int result : resultsOpposite) {
 		if (result == VIRTKEY_SPEED_ANALOG)

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -22,7 +22,7 @@
 #include <vector>
 #include <set>
 
-#include "Common/Input/InputState.h" // KeyDef
+#include "Common/Input/InputState.h" // InputMapping
 #include "Common/Input/KeyCodes.h"     // keyboard keys
 #include "Core/KeyMapDefaults.h"
 
@@ -76,7 +76,7 @@ enum {
 const float AXIS_BIND_THRESHOLD = 0.75f;
 const float AXIS_BIND_THRESHOLD_MOUSE = 0.01f;
 
-typedef std::map<int, std::vector<KeyDef>> KeyMapping;
+typedef std::map<int, std::vector<InputMapping>> KeyMapping;
 
 struct MappedAnalogAxis {
 	int axisId;
@@ -115,34 +115,24 @@ namespace KeyMap {
 
 	// Use if you need to display the textual name
 	std::string GetKeyName(int keyCode);
-	std::string GetKeyOrAxisName(int keyCode);
+	std::string GetKeyOrAxisName(const InputMapping &mapping);
 	std::string GetAxisName(int axisId);
 	std::string GetPspButtonName(int btn);
 	const char* GetPspButtonNameCharPointer(int btn);
 
 	std::vector<KeyMap_IntStrPair> GetMappableKeys();
 
-	// Use to translate KeyMap Keys to PSP
-	// buttons. You should have already translated
-	// your platform's keys to KeyMap keys.
-	bool KeyToPspButton(int deviceId, int key, std::vector<int> *pspKeys);
-	bool KeyFromPspButton(int btn, std::vector<KeyDef> *keys, bool ignoreMouse);
+	// Use to translate input mappings to and from PSP buttons. You should have already translated
+	// your platform's keys to InputMapping keys.
+	bool InputMappingToPspButton(const InputMapping &mapping, std::vector<int> *pspButtons);
+	bool InputMappingsFromPspButton(int btn, std::vector<InputMapping> *keys, bool ignoreMouse);
 
-	int TranslateKeyCodeToAxis(int keyCode, int &direction);
-	int TranslateKeyCodeFromAxis(int axisId, int direction);
-
-	// Configure the key mapping.
+	// Configure the key or axis mapping.
 	// Any configuration will be saved to the Core config.
-	void SetKeyMapping(int psp_key, KeyDef key, bool replace);
+	void SetInputMapping(int psp_key, const InputMapping &key, bool replace);
 	// Return false if bind was a duplicate and got removed
-	bool ReplaceSingleKeyMapping(int btn, int index, KeyDef key);
+	bool ReplaceSingleKeyMapping(int btn, int index, InputMapping key);
 
-	// Configure an axis mapping, saves the configuration.
-	// Direction is negative or positive.
-	void SetAxisMapping(int btn, int deviceId, int axisId, int direction, bool replace);
-
-	bool AxisToPspButton(int deviceId, int axisId, int direction, std::vector<int> *pspKeys);
-	bool AxisFromPspButton(int btn, int *deviceId, int *axisId, int *direction);
 	MappedAnalogAxes MappedAxesForDevice(int deviceId);
 
 	void LoadFromIni(IniFile &iniFile);

--- a/Core/KeyMapDefaults.cpp
+++ b/Core/KeyMapDefaults.cpp
@@ -13,8 +13,8 @@ namespace KeyMap {
 
 struct DefMappingStruct {
 	int pspKey;
-	int key;
-	int direction;
+	int keyOrAxis;
+	int direction;  // if 0, it's a key, otherwise an axis.
 };
 
 static const DefMappingStruct defaultQwertyKeyboardKeyMap[] = {
@@ -341,9 +341,9 @@ static const DefMappingStruct defaultVRRightController[] = {
 static void SetDefaultKeyMap(int deviceId, const DefMappingStruct *array, size_t count, bool replace) {
 	for (size_t i = 0; i < count; i++) {
 		if (array[i].direction == 0)
-			SetKeyMapping(array[i].pspKey, KeyDef(deviceId, array[i].key), replace);
+			SetInputMapping(array[i].pspKey, InputMapping(deviceId, array[i].keyOrAxis), replace);
 		else
-			SetAxisMapping(array[i].pspKey, deviceId, array[i].key, array[i].direction, replace);
+			SetInputMapping(array[i].pspKey, InputMapping(deviceId, array[i].keyOrAxis, array[i].direction), replace);
 	}
 	g_seenDeviceIds.insert(deviceId);
 }

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -56,7 +56,7 @@ private:
 
 class KeyMappingNewKeyDialog : public PopupScreen {
 public:
-	explicit KeyMappingNewKeyDialog(int btn, bool replace, std::function<void(KeyDef)> callback, std::shared_ptr<I18NCategory> i18n)
+	explicit KeyMappingNewKeyDialog(int btn, bool replace, std::function<void(InputMapping)> callback, std::shared_ptr<I18NCategory> i18n)
 		: PopupScreen(i18n->T("Map Key"), "Cancel", ""), pspBtn_(btn), callback_(callback) {}
 
 	const char *tag() const override { return "KeyMappingNewKey"; }
@@ -75,14 +75,14 @@ protected:
 
 private:
 	int pspBtn_;
-	std::function<void(KeyDef)> callback_;
+	std::function<void(InputMapping)> callback_;
 	bool mapped_ = false;  // Prevent double registrations
 	double delayUntil_ = 0.0f;
 };
 
 class KeyMappingNewMouseKeyDialog : public PopupScreen {
 public:
-	KeyMappingNewMouseKeyDialog(int btn, bool replace, std::function<void(KeyDef)> callback, std::shared_ptr<I18NCategory> i18n)
+	KeyMappingNewMouseKeyDialog(int btn, bool replace, std::function<void(InputMapping)> callback, std::shared_ptr<I18NCategory> i18n)
 		: PopupScreen(i18n->T("Map Mouse"), "", ""), pspBtn_(btn), callback_(callback), mapped_(false) {}
 
 	const char *tag() const override { return "KeyMappingNewMouseKey"; }
@@ -99,7 +99,7 @@ protected:
 
 private:
 	int pspBtn_;
-	std::function<void(KeyDef)> callback_;
+	std::function<void(InputMapping)> callback_;
 	bool mapped_;  // Prevent double registrations
 };
 
@@ -189,7 +189,7 @@ protected:
 private:
 	UI::EventReturn OnMapButton(UI::EventParams &e);
 	UI::EventReturn OnBindAll(UI::EventParams &e);
-	void HandleKeyMapping(KeyDef key);
+	void HandleKeyMapping(InputMapping key);
 	void MapNext(bool successive);
 
 	MockPSP *psp_ = nullptr;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -97,7 +97,7 @@ extern AndroidAudioState *g_audioState;
 GameSettingsScreen::GameSettingsScreen(const Path &gamePath, std::string gameID, bool editThenRestore)
 	: UIDialogScreenWithGameBackground(gamePath), gameID_(gameID), editThenRestore_(editThenRestore) {
 	prevInflightFrames_ = g_Config.iInflightFrames;
-	analogSpeedMapped_ = KeyMap::AxisFromPspButton(VIRTKEY_SPEED_ANALOG, nullptr, nullptr, nullptr);
+	analogSpeedMapped_ = KeyMap::InputMappingsFromPspButton(VIRTKEY_SPEED_ANALOG, nullptr, true);
 }
 
 // This needs before run CheckGPUFeatures()
@@ -1405,7 +1405,7 @@ void GameSettingsScreen::dialogFinished(const Screen *dialog, DialogResult resul
 		RecreateViews();
 	}
 
-	bool mapped = KeyMap::AxisFromPspButton(VIRTKEY_SPEED_ANALOG, nullptr, nullptr, nullptr);
+	bool mapped = KeyMap::InputMappingsFromPspButton(VIRTKEY_SPEED_ANALOG, nullptr, true);
 	if (mapped != analogSpeedMapped_) {
 		analogSpeedMapped_ = mapped;
 		RecreateViews();

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -158,7 +158,7 @@ public:
 		std::vector<int> pspKeys;
 		bool showInfo = false;
 
-		if (KeyMap::KeyToPspButton(key.deviceId, key.keyCode, &pspKeys)) {
+		if (KeyMap::InputMappingToPspButton(InputMapping(key.deviceId, key.keyCode), &pspKeys)) {
 			for (auto it = pspKeys.begin(), end = pspKeys.end(); it != end; ++it) {
 				// If the button mapped to triangle, then show the info.
 				if (HasFocus() && (key.flags & KEY_UP) && *it == CTRL_TRIANGLE) {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1261,7 +1261,7 @@ bool NativeKey(const KeyInput &key) {
 	if (g_Config.bPauseExitsEmulator) {
 		static std::vector<int> pspKeys;
 		pspKeys.clear();
-		if (KeyMap::KeyToPspButton(key.deviceId, key.keyCode, &pspKeys)) {
+		if (KeyMap::InputMappingToPspButton(InputMapping(key.deviceId, key.keyCode), &pspKeys)) {
 			if (std::find(pspKeys.begin(), pspKeys.end(), VIRTKEY_PAUSE) != pspKeys.end()) {
 				System_ExitApp();
 				return true;


### PR DESCRIPTION
This allows us to eliminate some differences between handling of Key and Axis mappings, simplifying some code, and especially simplifying the upcoming ControlMapper rewrite.