### PR TITLE
Control map multiple keys to one output

### DIFF
--- a/Common/Data/Collections/TinySet.h
+++ b/Common/Data/Collections/TinySet.h
@@ -134,3 +134,68 @@ private:
 	T fastLookup_[MaxFastSize];
 	std::vector<T> *slowLookup_ = nullptr;
 };
+
+template <class T, int MaxSize>
+struct FixedTinyVec {
+	~FixedTinyVec() {}
+	// WARNING: Can fail if you exceed MaxSize!
+	inline bool push_back(const T &t) {
+		if (count_ < MaxSize) {
+			data_[count_++] = t;
+			return true;
+		} else {
+			return false;
+		}
+	}
+	// WARNING: Can fail if you exceed MaxSize!
+	inline T *add_back() {
+		if (count_ < MaxSize) {
+			return &data_[count_++];
+		}
+		return nullptr;
+	}
+	// Invalid if empty().
+	void pop_back() { count_--;	}
+
+	// Unlike TinySet, we can trivially support begin/end as pointers.
+	T *begin() { return data_; }
+	T *end() { return data_ + count_; }
+	const T *begin() const { return data_; }
+	const T *end() const { return data_ + count_; }
+
+	size_t capacity() const { return MaxSize; }
+	void clear() { count_ = 0; }
+	bool empty() const { return count_ == 0; }
+	size_t size() const { return count_; }
+
+	bool contains(T t) const {
+		for (int i = 0; i < count_; i++) {
+			if (data_[i] == t)
+				return true;
+		}
+		return false;
+	}
+
+	// Out of bounds (past size() - 1) is undefined behavior.
+	T &operator[] (const size_t index) { return data_[index]; }
+	const T &operator[] (const size_t index) const { return data_[index]; }
+
+	// These two are invalid if empty().
+	const T &back() const { return (*this)[size() - 1]; }
+	const T &front() const { return (*this)[0]; }
+
+	bool operator == (const FixedTinyVec<T, MaxSize> &other) const {
+		if (count_ != other.count_)
+			return false;
+		for (size_t i = 0; i < count_; i++) {
+			if (!(data_[i] == other.data_[i])) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+private:
+	int count_ = 0;  // first in the struct just so it's more visible in the VS debugger.
+	T data_[MaxSize];
+};

--- a/Common/Input/GestureDetector.cpp
+++ b/Common/Input/GestureDetector.cpp
@@ -2,6 +2,8 @@
 // TODO:
 // Zoom gesture a la http://www.zdnet.com/blog/burnette/how-to-use-multi-touch-in-android-2-part-6-implementing-the-pinch-zoom-gesture/1847
 
+#include <cstring>
+
 #include "Common/TimeUtil.h"
 #include "Common/Input/GestureDetector.h"
 

--- a/Common/Input/InputState.cpp
+++ b/Common/Input/InputState.cpp
@@ -3,6 +3,7 @@
 
 #include "Common/Input/InputState.h"
 #include "Common/Input/KeyCodes.h"
+#include "Common/StringUtils.h"
 
 const char *GetDeviceName(int deviceId) {
 	switch (deviceId) {
@@ -77,6 +78,23 @@ int GetAnalogYDirection(int deviceId) {
 	if (configured != uiFlipAnalogY.end())
 		return configured->second;
 	return 0;
+}
+
+// NOTE: Changing the format of FromConfigString/ToConfigString breaks controls.ini backwards compatibility.
+InputMapping InputMapping::FromConfigString(const std::string &str) {
+	std::vector<std::string> parts;
+	SplitString(str, '-', parts);
+	int deviceId = atoi(parts[0].c_str());
+	int keyCode = atoi(parts[1].c_str());
+
+	InputMapping mapping;
+	mapping.deviceId = deviceId;
+	mapping.keyCode = keyCode;
+	return mapping;
+}
+
+std::string InputMapping::ToConfigString() const {
+	return StringFromFormat("%d-%d", deviceId, keyCode);
 }
 
 void InputMapping::FormatDebug(char *buffer, size_t bufSize) const {

--- a/Common/Input/InputState.h
+++ b/Common/Input/InputState.h
@@ -131,6 +131,15 @@ public:
 		if (keyCode < other.keyCode) return true;
 		return false;
 	}
+	// Needed for composition.
+	bool operator > (const InputMapping &other) const {
+		if (deviceId > other.deviceId) return true;
+		if (deviceId < other.deviceId) return false;
+		if (keyCode > other.keyCode) return true;
+		return false;
+	}
+
+	// This one is iffy with the != ANY checks. Should probably be a named method.
 	bool operator == (const InputMapping &other) const {
 		if (deviceId != other.deviceId && deviceId != DEVICE_ID_ANY && other.deviceId != DEVICE_ID_ANY) return false;
 		if (keyCode != other.keyCode) return false;

--- a/Common/Input/InputState.h
+++ b/Common/Input/InputState.h
@@ -5,8 +5,8 @@
 
 #include <unordered_map>
 #include <vector>
+#include <string>
 
-#include "Common/Math/lin/vec3.h"
 #include "Common/Input/KeyCodes.h"
 #include "Common/Log.h"
 
@@ -104,6 +104,9 @@ public:
 	InputMapping(int _deviceId, int axis, int direction) : deviceId(_deviceId), keyCode(TranslateKeyCodeFromAxis(axis, direction)) {
 		_dbg_assert_(direction != 0);
 	}
+
+	static InputMapping FromConfigString(const std::string &str);
+	std::string ToConfigString() const;
 
 	int deviceId;
 	int keyCode;  // Can also represent an axis with direction, if encoded properly.

--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -227,8 +227,6 @@ bool ControlMapper::UpdatePSPState(const InputMapping &changedMapping) {
 
 		// If a mapping could consist of a combo, we could trivially check it here.
 		for (auto &multiMapping : inputMappings) {
-			if (multiMapping.empty())
-				continue;
 			// Check if the changed mapping was involved in this PSP key.
 			if (multiMapping.mappings.contains(changedMapping)) {
 				changedButtonMask |= mask;

--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -298,11 +298,7 @@ bool ControlMapper::UpdatePSPState(const InputMapping &changedMapping) {
 		// Note: This is an old problem, it didn't appear with the refactoring.
 		if (!changedMapping.IsAxis()) {
 			for (auto &multiMapping : inputMappings) {
-				bool anyAxis = false;
 				for (auto &mapping : multiMapping.mappings) {
-					if (mapping.IsAxis()) {
-						anyAxis = true;
-					}
 					curInput_[mapping] = ReduceMagnitude(curInput_[mapping]);
 				}
 			}

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -110,6 +110,12 @@ void UpdateNativeMenuKeys() {
 			cancelKeys.push_back(hardcodedCancelKeys[i]);
 	}
 
+	// For DInput controllers on Windows. Doesn't clash with XInput because that uses BUTTON_X etc.
+#if PPSSPP_PLATFORM(WINDOWS) && !PPSSPP_PLATFORM(UWP)
+	confirmKeys.push_back(InputMapping(DEVICE_ID_PAD_0, NKCODE_BUTTON_2));
+	cancelKeys.push_back(InputMapping(DEVICE_ID_PAD_0, NKCODE_BUTTON_3));
+#endif
+
 	SetDPadKeys(upKeys, downKeys, leftKeys, rightKeys);
 	SetConfirmCancelKeys(confirmKeys, cancelKeys);
 	SetTabLeftRightKeys(tabLeft, tabRight);

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -870,4 +870,18 @@ std::string MultiInputMapping::ToConfigString() const {
 	return out;
 }
 
+std::string MultiInputMapping::ToVisualString() const {
+	std::string out;
+	for (auto iter : mappings) {
+		out += std::string(GetDeviceName(iter.deviceId)) + "." + GetKeyOrAxisName(iter) + " + ";
+	}
+	if (!out.empty()) {
+		// remove the last ' + '
+		out.pop_back();
+		out.pop_back();
+		out.pop_back();
+	}
+	return out;
+}
+
 }  // KeyMap

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -45,6 +45,17 @@ std::set<int> g_seenDeviceIds;
 
 bool g_swapDpadWithLStick = false;
 
+// Utility...
+void SingleInputMappingFromPspButton(int btn, std::vector<InputMapping> *mappings, bool ignoreMouse) {
+	std::vector<MultiInputMapping> multiMappings;
+	InputMappingsFromPspButton(btn, &multiMappings, ignoreMouse);
+	mappings->clear();
+	for (auto &mapping : multiMappings) {
+		_dbg_assert_(!mapping.empty());
+		mappings->push_back(mapping.mappings[0]);
+	}
+}
+
 // TODO: This is such a mess...
 void UpdateNativeMenuKeys() {
 	std::vector<InputMapping> confirmKeys, cancelKeys;
@@ -55,14 +66,14 @@ void UpdateNativeMenuKeys() {
 	int cancelKey = g_Config.iButtonPreference == PSP_SYSTEMPARAM_BUTTON_CROSS ? CTRL_CIRCLE : CTRL_CROSS;
 
 	// Mouse mapping might be problematic in UI, so let's ignore mouse for UI
-	InputMappingsFromPspButton(confirmKey, &confirmKeys, true);
-	InputMappingsFromPspButton(cancelKey, &cancelKeys, true);
-	InputMappingsFromPspButton(CTRL_LTRIGGER, &tabLeft, true);
-	InputMappingsFromPspButton(CTRL_RTRIGGER, &tabRight, true);
-	InputMappingsFromPspButton(CTRL_UP, &upKeys, true);
-	InputMappingsFromPspButton(CTRL_DOWN, &downKeys, true);
-	InputMappingsFromPspButton(CTRL_LEFT, &leftKeys, true);
-	InputMappingsFromPspButton(CTRL_RIGHT, &rightKeys, true);
+	SingleInputMappingFromPspButton(confirmKey, &confirmKeys, true);
+	SingleInputMappingFromPspButton(cancelKey, &cancelKeys, true);
+	SingleInputMappingFromPspButton(CTRL_LTRIGGER, &tabLeft, true);
+	SingleInputMappingFromPspButton(CTRL_RTRIGGER, &tabRight, true);
+	SingleInputMappingFromPspButton(CTRL_UP, &upKeys, true);
+	SingleInputMappingFromPspButton(CTRL_DOWN, &downKeys, true);
+	SingleInputMappingFromPspButton(CTRL_LEFT, &leftKeys, true);
+	SingleInputMappingFromPspButton(CTRL_RIGHT, &rightKeys, true);
 
 #ifdef __ANDROID__
 	// Hardcode DPAD on Android
@@ -493,7 +504,7 @@ bool InputMappingToPspButton(const InputMapping &mapping, std::vector<int> *pspB
 	bool found = false;
 	for (auto iter = g_controllerMap.begin(); iter != g_controllerMap.end(); ++iter) {
 		for (auto iter2 = iter->second.begin(); iter2 != iter->second.end(); ++iter2) {
-			if (*iter2 == mapping) {
+			if (iter2->EqualsSingleMapping(mapping)) {
 				if (pspButtons)
 					pspButtons->push_back(CheckAxisSwap(iter->first));
 				found = true;
@@ -503,12 +514,12 @@ bool InputMappingToPspButton(const InputMapping &mapping, std::vector<int> *pspB
 	return found;
 }
 
-bool InputMappingsFromPspButton(int btn, std::vector<InputMapping> *mappings, bool ignoreMouse) {
+bool InputMappingsFromPspButton(int btn, std::vector<MultiInputMapping> *mappings, bool ignoreMouse) {
 	bool mapped = false;
 	for (auto iter = g_controllerMap.begin(); iter != g_controllerMap.end(); ++iter) {
 		if (iter->first == btn) {
 			for (auto iter2 = iter->second.begin(); iter2 != iter->second.end(); ++iter2) {
-				if (mappings && (!ignoreMouse || iter2->deviceId != DEVICE_ID_MOUSE)) {
+				if (mappings && (!ignoreMouse || iter2->HasMouse())) {
 					mapped = true;
 					mappings->push_back(*iter2);
 				}
@@ -525,8 +536,11 @@ MappedAnalogAxes MappedAxesForDevice(int deviceId) {
 	auto findAxisId = [&](int btn) -> MappedAnalogAxis {
 		MappedAnalogAxis info{ -1 };
 		for (const auto &key : g_controllerMap[btn]) {
-			if (key.deviceId == deviceId) {
-				info.axisId = TranslateKeyCodeToAxis(key.keyCode, &info.direction);
+			// Only consider single mappings, combos don't make much sense for these.
+			if (key.mappings.empty()) continue;
+			auto &mapping = key.mappings[0];
+			if (mapping.deviceId == deviceId) {
+				info.axisId = TranslateKeyCodeToAxis(mapping.keyCode, &info.direction);
 				return info;
 			}
 		}
@@ -562,7 +576,7 @@ void RemoveButtonMapping(int btn) {
 bool IsKeyMapped(int device, int key) {
 	for (auto &iter : g_controllerMap) {
 		for (auto &mappedKey : iter.second) {
-			if (mappedKey == InputMapping(device, key)) {
+			if (mappedKey.mappings.contains(InputMapping(device, key))) {
 				return true;
 			}
 		}
@@ -570,7 +584,7 @@ bool IsKeyMapped(int device, int key) {
 	return false;
 }
 
-bool ReplaceSingleKeyMapping(int btn, int index, InputMapping key) {
+bool ReplaceSingleKeyMapping(int btn, int index, MultiInputMapping key) {
 	// Check for duplicate
 	for (int i = 0; i < (int)g_controllerMap[btn].size(); ++i) {
 		if (i != index && g_controllerMap[btn][i] == key) {
@@ -584,14 +598,18 @@ bool ReplaceSingleKeyMapping(int btn, int index, InputMapping key) {
 	KeyMap::g_controllerMap[btn][index] = key;
 	g_controllerMapGeneration++;
 
-	g_seenDeviceIds.insert(key.deviceId);
+	for (auto &mapping : key.mappings) {
+		g_seenDeviceIds.insert(mapping.deviceId);
+	}
 	UpdateNativeMenuKeys();
 	return true;
 }
 
-void SetInputMapping(int btn, const InputMapping &key, bool replace) {
-	if (key.keyCode < 0)
+void SetInputMapping(int btn, const MultiInputMapping &key, bool replace) {
+	if (key.empty()) {
+		g_controllerMap.erase(btn);
 		return;
+	}
 	if (replace) {
 		RemoveButtonMapping(btn);
 		g_controllerMap[btn].clear();
@@ -605,7 +623,9 @@ void SetInputMapping(int btn, const InputMapping &key, bool replace) {
 	}
 	g_controllerMapGeneration++;
 
-	g_seenDeviceIds.insert(key.deviceId);
+	for (auto &mapping : key.mappings) {
+		g_seenDeviceIds.insert(mapping.deviceId);
+	}
 	UpdateNativeMenuKeys();
 }
 
@@ -667,12 +687,14 @@ void LoadFromIni(IniFile &file) {
 		SplitString(value, ',', mappings);
 
 		for (size_t j = 0; j < mappings.size(); j++) {
+			// TODO: Properly parse multiple mappings.
+
 			std::vector<std::string> parts;
 			SplitString(mappings[j], '-', parts);
 			int deviceId = atoi(parts[0].c_str());
 			int keyCode = atoi(parts[1].c_str());
 
-			SetInputMapping(psp_button_names[i].key, InputMapping(deviceId, keyCode), false);
+			SetInputMapping(psp_button_names[i].key, MultiInputMapping(InputMapping(deviceId, keyCode)), false);
 			g_seenDeviceIds.insert(deviceId);
 		}
 	}
@@ -684,13 +706,15 @@ void SaveToIni(IniFile &file) {
 	Section *controls = file.GetOrCreateSection("ControlMapping");
 
 	for (size_t i = 0; i < ARRAY_SIZE(psp_button_names); i++) {
-		std::vector<InputMapping> keys;
+		std::vector<MultiInputMapping> keys;
 		InputMappingsFromPspButton(psp_button_names[i].key, &keys, false);
 
 		std::string value;
 		for (size_t j = 0; j < keys.size(); j++) {
+			auto mapping = keys[j].mappings[0];
+
 			char temp[128];
-			sprintf(temp, "%i-%i", keys[j].deviceId, keys[j].keyCode);
+			sprintf(temp, "%i-%i", mapping.deviceId, mapping.keyCode);
 			value += temp;
 			if (j != keys.size() - 1)
 				value += ",";
@@ -756,8 +780,8 @@ void AutoConfForPad(const std::string &name) {
 #endif
 
 	// Add a couple of convenient keyboard mappings by default, too.
-	g_controllerMap[VIRTKEY_PAUSE].push_back(InputMapping(DEVICE_ID_KEYBOARD, NKCODE_ESCAPE));
-	g_controllerMap[VIRTKEY_FASTFORWARD].push_back(InputMapping(DEVICE_ID_KEYBOARD, NKCODE_TAB));
+	g_controllerMap[VIRTKEY_PAUSE].push_back(MultiInputMapping(InputMapping(DEVICE_ID_KEYBOARD, NKCODE_ESCAPE)));
+	g_controllerMap[VIRTKEY_FASTFORWARD].push_back(MultiInputMapping(InputMapping(DEVICE_ID_KEYBOARD, NKCODE_TAB)));
 	g_controllerMapGeneration++;
 }
 

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -113,6 +113,8 @@ namespace KeyMap {
 		static MultiInputMapping FromConfigString(const std::string &str);
 		std::string ToConfigString() const;
 
+		std::string ToVisualString() const;
+
 		bool operator <(const MultiInputMapping &other) {
 			for (size_t i = 0; i < mappings.capacity(); i++) {
 				// If one ran out of entries, the other wins.

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -149,11 +149,11 @@ namespace KeyMap {
 		FixedTinyVec<InputMapping, 3> mappings;
 	};
 
-	// Once the multimappings are inserted here, they must not be empty.
-	// If one would be, delete the whole entry from the map instead.
 	typedef std::map<int, std::vector<MultiInputMapping>> KeyMapping;
 
-	extern KeyMapping g_controllerMap;
+	// Once the multimappings are inserted here, they must not be empty.
+	// If one would be, delete the whole entry from the map instead.
+	// This is automatically handled by SetInputMapping.
 	extern std::set<int> g_seenDeviceIds;
 	extern int g_controllerMapGeneration;
 	// Key & Button names
@@ -179,6 +179,9 @@ namespace KeyMap {
 	bool InputMappingToPspButton(const InputMapping &mapping, std::vector<int> *pspButtons);
 	bool InputMappingsFromPspButton(int btn, std::vector<MultiInputMapping> *keys, bool ignoreMouse);
 
+	// Simplified check.
+	bool PspButtonHasMappings(int btn);
+
 	// Configure the key or axis mapping.
 	// Any configuration will be saved to the Core config.
 	void SetInputMapping(int psp_key, const MultiInputMapping &key, bool replace);
@@ -189,6 +192,8 @@ namespace KeyMap {
 
 	void LoadFromIni(IniFile &iniFile);
 	void SaveToIni(IniFile &iniFile);
+	void ClearAllMappings();
+	void DeleteNthMapping(int key, int number);
 
 	void SetDefaultKeyMap(DefaultMaps dmap, bool replace);
 

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -109,6 +109,10 @@ namespace KeyMap {
 		explicit MultiInputMapping(const InputMapping &mapping) {
 			mappings.push_back(mapping);
 		}
+		
+		static MultiInputMapping FromConfigString(const std::string &str);
+		std::string ToConfigString() const;
+
 		bool operator <(const MultiInputMapping &other) {
 			for (size_t i = 0; i < mappings.capacity(); i++) {
 				// If one ran out of entries, the other wins.

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -76,6 +76,7 @@ enum {
 };
 
 const float AXIS_BIND_THRESHOLD = 0.75f;
+const float AXIS_BIND_RELEASE_THRESHOLD = 0.35f;  // Used during mapping only to detect a "key-up" reliably.
 const float AXIS_BIND_THRESHOLD_MOUSE = 0.01f;
 
 struct MappedAnalogAxis {

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -149,6 +149,8 @@ namespace KeyMap {
 		FixedTinyVec<InputMapping, 3> mappings;
 	};
 
+	// Once the multimappings are inserted here, they must not be empty.
+	// If one would be, delete the whole entry from the map instead.
 	typedef std::map<int, std::vector<MultiInputMapping>> KeyMapping;
 
 	extern KeyMapping g_controllerMap;

--- a/Core/KeyMapDefaults.cpp
+++ b/Core/KeyMapDefaults.cpp
@@ -341,9 +341,9 @@ static const DefMappingStruct defaultVRRightController[] = {
 static void SetDefaultKeyMap(int deviceId, const DefMappingStruct *array, size_t count, bool replace) {
 	for (size_t i = 0; i < count; i++) {
 		if (array[i].direction == 0)
-			SetInputMapping(array[i].pspKey, InputMapping(deviceId, array[i].keyOrAxis), replace);
+			SetInputMapping(array[i].pspKey, MultiInputMapping(InputMapping(deviceId, array[i].keyOrAxis)), replace);
 		else
-			SetInputMapping(array[i].pspKey, InputMapping(deviceId, array[i].keyOrAxis, array[i].direction), replace);
+			SetInputMapping(array[i].pspKey, MultiInputMapping(InputMapping(deviceId, array[i].keyOrAxis, array[i].direction)), replace);
 	}
 	g_seenDeviceIds.insert(deviceId);
 }

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -222,8 +222,7 @@ UI::EventReturn SingleControlMapper::OnAddMouse(UI::EventParams &params) {
 
 UI::EventReturn SingleControlMapper::OnDelete(UI::EventParams &params) {
 	int index = atoi(params.v->Tag().c_str());
-	KeyMap::g_controllerMap[pspKey_].erase(KeyMap::g_controllerMap[pspKey_].begin() + index);
-	KeyMap::g_controllerMapGeneration++;
+	KeyMap::DeleteNthMapping(pspKey_, index);
 
 	if (index + 1 < (int)rows_.size())
 		rows_[index]->SetFocus();
@@ -285,8 +284,7 @@ void ControlMappingScreen::update() {
 }
 
 UI::EventReturn ControlMappingScreen::OnClearMapping(UI::EventParams &params) {
-	KeyMap::g_controllerMap.clear();
-	KeyMap::g_controllerMapGeneration++;
+	KeyMap::ClearAllMappings();
 	return UI::EVENT_DONE;
 }
 

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -141,18 +141,12 @@ void SingleControlMapper::Refresh() {
 
 	rows_.clear();
 	for (size_t i = 0; i < mappings.size(); i++) {
-		// TODO: Correctly handle multis.
-
-		auto &mapping = mappings[i].mappings[0];
-
-		std::string deviceName = GetDeviceName(mapping.deviceId);
-		std::string keyName = KeyMap::GetKeyOrAxisName(mapping);
-
+		std::string multiMappingString = mappings[i].ToVisualString();
 		LinearLayout *row = rightColumn->Add(new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 		row->SetSpacing(2.0f);
 		rows_.push_back(row);
 
-		Choice *c = row->Add(new Choice(deviceName + "." + keyName, new LinearLayoutParams(FILL_PARENT, itemH, 1.0f)));
+		Choice *c = row->Add(new Choice(multiMappingString, new LinearLayoutParams(FILL_PARENT, itemH, 1.0f)));
 		c->SetTag(StringFromFormat("%d_Change%d", (int)i, pspKey_));
 		c->OnClick.Handle(this, &SingleControlMapper::OnReplace);
 

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -56,7 +56,7 @@ private:
 
 class KeyMappingNewKeyDialog : public PopupScreen {
 public:
-	explicit KeyMappingNewKeyDialog(int btn, bool replace, std::function<void(InputMapping)> callback, std::shared_ptr<I18NCategory> i18n)
+	explicit KeyMappingNewKeyDialog(int btn, bool replace, std::function<void(KeyMap::MultiInputMapping)> callback, std::shared_ptr<I18NCategory> i18n)
 		: PopupScreen(i18n->T("Map Key"), "Cancel", ""), pspBtn_(btn), callback_(callback) {}
 
 	const char *tag() const override { return "KeyMappingNewKey"; }
@@ -75,14 +75,14 @@ protected:
 
 private:
 	int pspBtn_;
-	std::function<void(InputMapping)> callback_;
+	std::function<void(KeyMap::MultiInputMapping)> callback_;
 	bool mapped_ = false;  // Prevent double registrations
 	double delayUntil_ = 0.0f;
 };
 
 class KeyMappingNewMouseKeyDialog : public PopupScreen {
 public:
-	KeyMappingNewMouseKeyDialog(int btn, bool replace, std::function<void(InputMapping)> callback, std::shared_ptr<I18NCategory> i18n)
+	KeyMappingNewMouseKeyDialog(int btn, bool replace, std::function<void(KeyMap::MultiInputMapping)> callback, std::shared_ptr<I18NCategory> i18n)
 		: PopupScreen(i18n->T("Map Mouse"), "", ""), pspBtn_(btn), callback_(callback), mapped_(false) {}
 
 	const char *tag() const override { return "KeyMappingNewMouseKey"; }
@@ -99,7 +99,7 @@ protected:
 
 private:
 	int pspBtn_;
-	std::function<void(InputMapping)> callback_;
+	std::function<void(KeyMap::MultiInputMapping)> callback_;
 	bool mapped_;  // Prevent double registrations
 };
 
@@ -189,7 +189,7 @@ protected:
 private:
 	UI::EventReturn OnMapButton(UI::EventParams &e);
 	UI::EventReturn OnBindAll(UI::EventParams &e);
-	void HandleKeyMapping(InputMapping key);
+	void HandleKeyMapping(KeyMap::MultiInputMapping key);
 	void MapNext(bool successive);
 
 	MockPSP *psp_ = nullptr;

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -19,6 +19,7 @@
 
 #include <functional>
 #include <memory>
+#include <set>
 #include <mutex>
 #include <vector>
 
@@ -76,7 +77,12 @@ protected:
 private:
 	int pspBtn_;
 	std::function<void(KeyMap::MultiInputMapping)> callback_;
-	bool mapped_ = false;  // Prevent double registrations
+
+	KeyMap::MultiInputMapping mapping_;
+
+	// We need to do our own detection for axis "keyup" here.
+	std::set<InputMapping> triggeredAxes_;
+
 	double delayUntil_ = 0.0f;
 };
 

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -244,8 +244,6 @@ int DinputDevice::UpdateState() {
 		AxisInput axis;
 		axis.deviceId = DEVICE_ID_PAD_0 + pDevNum;
 
-		auto axesToSquare = KeyMap::MappedAxesForDevice(axis.deviceId);
-
 		SendNativeAxis(DEVICE_ID_PAD_0 + pDevNum, js.lX, last_lX_, JOYSTICK_AXIS_X);
 		SendNativeAxis(DEVICE_ID_PAD_0 + pDevNum, js.lY, last_lY_, JOYSTICK_AXIS_Y);
 		SendNativeAxis(DEVICE_ID_PAD_0 + pDevNum, js.lZ, last_lZ_, JOYSTICK_AXIS_Z);

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -170,8 +170,8 @@ namespace MainWindow {
 	}
 
 	void DoTranslateMenus(HWND hWnd, HMENU menu) {
-		auto useDefHotkey = [](int virtkey) {
-			return KeyMap::g_controllerMap[virtkey].empty();
+		auto useDefHotkey = [](int virtKey) {
+			return !KeyMap::PspButtonHasMappings(virtKey);
 		};
 
 		TranslateMenuItem(menu, ID_FILE_MENU);
@@ -536,8 +536,7 @@ namespace MainWindow {
 
 		case ID_FILE_SAVESTATE_NEXT_SLOT_HC:
 		{
-			if (KeyMap::g_controllerMap[VIRTKEY_NEXT_SLOT].empty())
-			{
+			if (!KeyMap::PspButtonHasMappings(VIRTKEY_NEXT_SLOT)) {
 				SaveState::NextSlot();
 				NativeMessageReceived("savestate_displayslot", "");
 			}
@@ -559,7 +558,7 @@ namespace MainWindow {
 
 		case ID_FILE_QUICKLOADSTATE_HC:
 		{
-			if (KeyMap::g_controllerMap[VIRTKEY_LOAD_STATE].empty())
+			if (!KeyMap::PspButtonHasMappings(VIRTKEY_LOAD_STATE))
 			{
 				SetCursor(LoadCursor(0, IDC_WAIT));
 				SaveState::LoadSlot(PSP_CoreParameter().fileToStart, g_Config.iCurrentStateSlot, SaveStateActionFinished);
@@ -575,7 +574,7 @@ namespace MainWindow {
 
 		case ID_FILE_QUICKSAVESTATE_HC:
 		{
-			if (KeyMap::g_controllerMap[VIRTKEY_SAVE_STATE].empty())
+			if (!KeyMap::PspButtonHasMappings(VIRTKEY_SAVE_STATE))
 			{
 				SetCursor(LoadCursor(0, IDC_WAIT));
 				SaveState::SaveSlot(PSP_CoreParameter().fileToStart, g_Config.iCurrentStateSlot, SaveStateActionFinished);


### PR DESCRIPTION
Reimplementation of #17168, using the new control mapping system, but supports up to 3-key combos.

One thing I've been thinking about is that with this, if say you map RTrigger + Y to take a screenshot, it'll still send the individual RTrigger and Y while you're pressing it. I'm thinking that when you do a combo like that, maybe the individual press of the second key could be suppressed (can hardly suppress the first one..)...