### PR TITLE
Vulkan: Disable framebuffer fetch (through input attachments) for now.

### DIFF
--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -280,9 +280,12 @@ u32 GPU_Vulkan::CheckGPUFeatures() const {
 
 	// We need to turn off framebuffer fetch through input attachments if MSAA is on for now.
 	// This is fixable, just needs some shader generator work (subpassInputMS).
-	if (msaaLevel_ != 0) {
-		features &= ~GPU_USE_FRAMEBUFFER_FETCH;
-	}
+	// Actually, I've decided to disable framebuffer fetch entirely for now. Perf isn't worth
+	// the compatibility problems.
+
+	// if (msaaLevel_ != 0) {
+	features &= ~GPU_USE_FRAMEBUFFER_FETCH;
+	// }
 
 	return CheckGPUFeaturesLate(features);
 }


### PR DESCRIPTION
This is a conceptually cool trick that just doesn't seem to be worth it, compared to the old approach of copy + blend-in-shader. I haven't found any game that benefits more than absolutely minimally, and having two paths to test isn't great, when the win is so small.

So I'm disabling it. I'm keeping the code for now, but might clear it out later.

Fixes #17069