### PR TITLE
Add support for integer scale factor for display

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -870,6 +870,7 @@ static const ConfigSetting graphicsSettings[] = {
 	ConfigSetting("DisplayOffsetX", &g_Config.fDisplayOffsetX, 0.5f, true, true),
 	ConfigSetting("DisplayOffsetY", &g_Config.fDisplayOffsetY, 0.5f, true, true),
 	ConfigSetting("DisplayScale", &g_Config.fDisplayScale, 1.0f, true, true),
+	ConfigSetting("DisplayIntegerScale", &g_Config.bDisplayIntegerScale, false, true, true),
 	ConfigSetting("DisplayAspectRatio", &g_Config.fDisplayAspectRatio, 1.0f, true, true),
 	ConfigSetting("DisplayStretch", &g_Config.bDisplayStretch, false, true, true),
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -174,6 +174,7 @@ public:
 	float fDisplayOffsetX;
 	float fDisplayOffsetY;
 	float fDisplayScale;   // Relative to the most constraining axis (x or y).
+	bool bDisplayIntegerScale;  // Snaps scaling to integer scale factors in raw pixels.
 	float fDisplayAspectRatio;  // Stored relative to the PSP's native ratio, so 1.0 is the normal pixel aspect ratio.
 
 	bool bImmersiveMode;  // Mode on Android Kitkat 4.4 and later that hides the back button etc.

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2046,7 +2046,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 			return 0;
 		case EMULATOR_DEVCTL__GET_ASPECT_RATIO:
 			if (Memory::IsValidAddress(outPtr)) {
-				// TODO: Share code with CenterDisplayOutputRect to take a few more things into account.
+				// TODO: Share code with CalculateDisplayOutputRect to take a few more things into account.
 				// I have a planned further refactoring.
 				float ar;
 				if (g_Config.bDisplayStretch) {

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1192,7 +1192,7 @@ void FramebufferManagerCommon::DrawPixels(VirtualFramebuffer *vfb, int dstX, int
 		flags = flags | DRAWTEX_TO_BACKBUFFER;
 		FRect frame = GetScreenFrame(pixelWidth_, pixelHeight_);
 		FRect rc;
-		CenterDisplayOutputRect(&rc, 480.0f, 272.0f, frame, ROTATION_LOCKED_HORIZONTAL);
+		CalculateDisplayOutputRect(&rc, 480.0f, 272.0f, frame, ROTATION_LOCKED_HORIZONTAL);
 		SetViewport2D(rc.x, rc.y, rc.w, rc.h);
 		draw_->SetScissorRect(0, 0, pixelWidth_, pixelHeight_);
 	}

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -583,7 +583,7 @@ void ConvertViewportAndScissor(bool useBufferedRendering, float renderWidth, flo
 		float pixelH = PSP_CoreParameter().pixelHeight;
 		FRect frame = GetScreenFrame(pixelW, pixelH);
 		FRect rc;
-		CenterDisplayOutputRect(&rc, 480, 272, frame, ROTATION_LOCKED_HORIZONTAL);
+		CalculateDisplayOutputRect(&rc, 480, 272, frame, ROTATION_LOCKED_HORIZONTAL);
 		displayOffsetX = rc.x;
 		displayOffsetY = rc.y;
 		renderWidth = rc.w;

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -68,7 +68,7 @@ FRect GetScreenFrame(float pixelWidth, float pixelHeight) {
 	return rc;
 }
 
-void CenterDisplayOutputRect(FRect *rc, float origW, float origH, const FRect &frame, int rotation) {
+void CalculateDisplayOutputRect(FRect *rc, float origW, float origH, const FRect &frame, int rotation) {
 	float outW;
 	float outH;
 
@@ -368,7 +368,7 @@ bool PresentationCommon::BuildPostShader(const ShaderInfo * shaderInfo, const Sh
 			// If the current shader uses output res (not next), we will use output res for it.
 			FRect rc;
 			FRect frame = GetScreenFrame((float)pixelWidth_, (float)pixelHeight_);
-			CenterDisplayOutputRect(&rc, 480.0f, 272.0f, frame, g_Config.iInternalScreenRotation);
+			CalculateDisplayOutputRect(&rc, 480.0f, 272.0f, frame, g_Config.iInternalScreenRotation);
 			nextWidth = (int)rc.w;
 			nextHeight = (int)rc.h;
 		}
@@ -644,7 +644,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 		pixelWidth /= 2;
 	}
 	FRect rc;
-	CenterDisplayOutputRect(&rc, 480.0f, 272.0f, frame, uvRotation);
+	CalculateDisplayOutputRect(&rc, 480.0f, 272.0f, frame, uvRotation);
 
 	if (GetGPUBackend() == GPUBackend::DIRECT3D9) {
 		rc.x -= 0.5f;

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -123,7 +123,11 @@ void CalculateDisplayOutputRect(FRect *rc, float origW, float origH, const FRect
 	}
 
 	if (g_Config.bDisplayIntegerScale) {
-		outW = std::max(1.0f, floorf(outW / 480.0f)) * 480.0f;
+		float wDim = 480.0f;
+		if (rotated) {
+			wDim = 272.0f;
+		}
+		outW = std::max(1.0f, floorf(outW / wDim)) * wDim;
 		outH = outW / origRatio;
 	}
 

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -74,7 +74,7 @@ void CenterDisplayOutputRect(FRect *rc, float origW, float origH, const FRect &f
 
 	bool rotated = rotation == ROTATION_LOCKED_VERTICAL || rotation == ROTATION_LOCKED_VERTICAL180;
 
-	bool stretch = g_Config.bDisplayStretch;
+	bool stretch = g_Config.bDisplayStretch && !g_Config.bDisplayIntegerScale;
 
 	float offsetX = g_Config.fDisplayOffsetX;
 	float offsetY = g_Config.fDisplayOffsetY;
@@ -87,7 +87,7 @@ void CenterDisplayOutputRect(FRect *rc, float origW, float origH, const FRect &f
 
 	// Ye olde 1080p hack, new version: If everything is setup to exactly cover the screen (defaults), and the screen display aspect ratio is 16:9,
 	// stretch the PSP's aspect ratio veeery slightly to fill it completely.
-	if (scale == 1.0f && offsetX == 0.5f && offsetY == 0.5f && aspectRatioAdjust == 1.0f) {
+	if (scale == 1.0f && offsetX == 0.5f && offsetY == 0.5f && aspectRatioAdjust == 1.0f && !g_Config.bDisplayIntegerScale) {
 		if (fabsf(frame.w / frame.h - 16.0f / 9.0f) < 0.0001f) {
 			aspectRatioAdjust = (frame.w / frame.h) / (480.0f / 272.0f);
 		}
@@ -120,6 +120,11 @@ void CenterDisplayOutputRect(FRect *rc, float origW, float origH, const FRect &f
 		// Image is taller than frame. Center horizontally.
 		outW = scaledHeight * origRatio;
 		outH = scaledHeight;
+	}
+
+	if (g_Config.bDisplayIntegerScale) {
+		outW = std::max(1.0f, floorf(outW / 480.0f)) * 480.0f;
+		outH = outW / origRatio;
 	}
 
 	if (IsVREnabled()) {

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -48,7 +48,7 @@ struct FRect {
 };
 
 FRect GetScreenFrame(float pixelWidth, float pixelHeight);
-void CenterDisplayOutputRect(FRect *rc, float origW, float origH, const FRect &frame, int rotation);
+void CalculateDisplayOutputRect(FRect *rc, float origW, float origH, const FRect &frame, int rotation);
 
 namespace Draw {
 class Buffer;

--- a/Tools/langtool/Cargo.lock
+++ b/Tools/langtool/Cargo.lock
@@ -106,18 +106,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0dd4be24fcdcfeaa12a432d588dc59bbad6cad3510c67e74a2b6b2fc950564"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -241,13 +241,18 @@ void DisplayLayoutScreen::CreateViews() {
 
 	if (!IsVREnabled()) {
 		auto stretch = new CheckBox(&g_Config.bDisplayStretch, gr->T("Stretch"));
+		stretch->SetDisabledPtr(&g_Config.bDisplayIntegerScale);
 		rightColumn->Add(stretch);
 
 		PopupSliderChoiceFloat *aspectRatio = new PopupSliderChoiceFloat(&g_Config.fDisplayAspectRatio, 0.5f, 2.0f, gr->T("Aspect Ratio"), screenManager());
 		rightColumn->Add(aspectRatio);
-		aspectRatio->SetDisabledPtr(&g_Config.bDisplayStretch);
+		aspectRatio->SetEnabledFunc([]() {
+			return !g_Config.bDisplayStretch && !g_Config.bDisplayIntegerScale;
+		});
 		aspectRatio->SetHasDropShadow(false);
 		aspectRatio->SetLiveUpdate(true);
+
+		rightColumn->Add(new CheckBox(&g_Config.bDisplayIntegerScale, gr->T("Integer scale factor")));
 
 #if PPSSPP_PLATFORM(ANDROID)
 		// Hide insets option if no insets, or OS too old.
@@ -295,8 +300,10 @@ void DisplayLayoutScreen::CreateViews() {
 		leftColumn->Add(new Spacer(24.0f));
 	}
 
-	static const char *bufFilters[] = { "Linear", "Nearest", };
-	leftColumn->Add(new PopupMultiChoice(&g_Config.iBufFilter, gr->T("Screen Scaling Filter"), bufFilters, 1, ARRAY_SIZE(bufFilters), gr->GetName(), screenManager()));
+	if (!IsVREnabled()) {
+		static const char *bufFilters[] = { "Linear", "Nearest", };
+		leftColumn->Add(new PopupMultiChoice(&g_Config.iBufFilter, gr->T("Screen Scaling Filter"), bufFilters, 1, ARRAY_SIZE(bufFilters), gr->GetName(), screenManager()));
+	}
 
 	Draw::DrawContext *draw = screenManager()->getDrawContext();
 

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -134,7 +134,7 @@ void DisplayLayoutScreen::DrawBackground(UIContext &dc) {
 		// TODO: Clean this up a bit, this GetScreenFrame/CenterDisplay combo is too common.
 		FRect screenFrame = GetScreenFrame(g_display.pixel_xres, g_display.pixel_yres);
 		FRect rc;
-		CenterDisplayOutputRect(&rc, 480.0f, 272.0f, screenFrame, g_Config.iInternalScreenRotation);
+		CalculateDisplayOutputRect(&rc, 480.0f, 272.0f, screenFrame, g_Config.iInternalScreenRotation);
 
 		dc.Flush();
 		ImageID bg = ImageID("I_PSP_DISPLAY");

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -509,6 +509,7 @@ High = ‎عالي
 Hybrid = ‎هجين
 Hybrid + Bicubic = ‎هجين + تكعيب
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Internal resolution
 Lazy texture caching = Lazy texture caching (speedup)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -501,6 +501,7 @@ High = High
 Hybrid = Hybrid
 Hybrid + Bicubic = Hybrid + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Internal resolution
 Lazy texture caching = Lazy texture caching (speedup)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -501,6 +501,7 @@ High = High
 Hybrid = Hybrid
 Hybrid + Bicubic = Hybrid + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Вътрешна резолюция
 Lazy texture caching = Мързеливо текстурно кеширане (ускорява)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -501,6 +501,7 @@ High = Alta
 Hybrid = Híbrid
 Hybrid + Bicubic = Híbrid i bicúbic
 Ignore camera notch when centering = Ignora la notch de la càmera usant el centre d'imatge.
+Integer scale factor = Integer scale factor
 Internal Resolution = Resolució interna
 Lazy texture caching = Memòria cau de textures diferit (ràpid)
 Lazy texture caching Tip = Ràpid, però puc provocar problemes als textos d'alguns jocs

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -501,6 +501,7 @@ High = Vysoká
 Hybrid = Hybridní
 Hybrid + Bicubic = Hybridní + Bikubická
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Vnitřní rozlišení
 Lazy texture caching = Líné ukládání textur do mezipaměti (zrychlení)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -500,6 +500,7 @@ High = Høj
 Hybrid = Hybrid
 Hybrid + Bicubic = Hybrid + Bicubisk
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Intern opløsning
 Lazy texture caching = Træg textur caching (hurtigere)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -500,6 +500,7 @@ High = Hoch
 Hybrid = Hybrid
 Hybrid + Bicubic = Hybrid + Bikubisch
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Interne Auflösung
 Lazy texture caching = Träges Textur-Caching (schneller)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -501,6 +501,7 @@ High = High
 Hybrid = Hybrid
 Hybrid + Bicubic = Hybrid + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Internal resolution
 Lazy texture caching = Lazy texture caching (speedup)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -525,6 +525,7 @@ High = High
 Hybrid = Hybrid
 Hybrid + Bicubic = Hybrid + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Internal resolution
 Lazy texture caching = Lazy texture caching (speedup)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -500,6 +500,7 @@ High = Alta
 Hybrid = Híbrido
 Hybrid + Bicubic = Híbrido y bicúbico
 Ignore camera notch when centering = Ignorar notch de la cámara usando centrado de imagen.
+Integer scale factor = Integer scale factor
 Internal Resolution = Resolución interna
 Lazy texture caching = Caché de texturas diferido (rápido)
 Lazy texture caching Tip = Rápido, pero puedo provocar problemas en los textos de algunos juegos

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -500,6 +500,7 @@ High = Alta
 Hybrid = Híbrido
 Hybrid + Bicubic = Híbrido + bicúbico
 Ignore camera notch when centering = Ignorar muesca de la cámara al centrar
+Integer scale factor = Integer scale factor
 Internal Resolution = Resolución interna
 Lazy texture caching = Caché de texturas diferido (rápido)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -500,6 +500,7 @@ High = ‎زیاد
 Hybrid = ‎Hybrid (ترکیبی)
 Hybrid + Bicubic = Hybrid + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = ‎رزولوشن داخلی
 Lazy texture caching = ‎کش کردن تکسچر های ماندگار (افزایش سرعت)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -501,6 +501,7 @@ High = High
 Hybrid = Hybridi
 Hybrid + Bicubic = Hybrid + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Internal resolution
 Lazy texture caching = Lazy texture caching (speedup)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -501,6 +501,7 @@ High = Haute
 Hybrid = Hybride
 Hybrid + Bicubic = Hybride + Bicubique
 Ignore camera notch when centering = Ignorer l'encoche de la caméra lors du centrage
+Integer scale factor = Integer scale factor
 Internal Resolution = Définition interne
 Lazy texture caching = Mise en cache paresseuse des textures (gain de vitesse)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -501,6 +501,7 @@ High = Alta
 Hybrid = Híbrido
 Hybrid + Bicubic = Híbrido + Bicúbico
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Resolución interna
 Lazy texture caching = Caché de texturas diferido (rápido)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -501,6 +501,7 @@ High = Υψηλή
 Hybrid = Υβριδική
 Hybrid + Bicubic = Υβριδική + Διακυβική
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Εσωτερική Ανάλυση
 Lazy texture caching = Τεμπέλικη προσωρινή μνήμη υφών (ταχύτερο)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -501,6 +501,7 @@ High = High
 Hybrid = היברידי
 Hybrid + Bicubic = היברידי + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Internal resolution
 Lazy texture caching = Lazy texture caching (speedup)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -501,6 +501,7 @@ High = High
 Hybrid = ידירביה
 Hybrid + Bicubic = ידירביה + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Internal resolution
 Lazy texture caching = Lazy texture caching (speedup)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -501,6 +501,7 @@ High = Visoko
 Hybrid = Hibrid
 Hybrid + Bicubic = Hibrid + Bikubični
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Unutarnja rezolucija
 Lazy texture caching = Lijeno teksturno predmemoriranje (ubrzanje)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -501,6 +501,7 @@ High = Magas
 Hybrid = Hibrid
 Hybrid + Bicubic = Hibrid + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Belső felbontás
 Lazy texture caching = Lusta textúra gyorsítótárazás (gyorsítás)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -501,6 +501,7 @@ High = Tinggi
 Hybrid = Hibrida
 Hybrid + Bicubic = Hibrida + Bikubik
 Ignore camera notch when centering = Abaikan pandangan kamera saat sedang fokus
+Integer scale factor = Integer scale factor
 Internal Resolution = Resolusi internal
 Lazy texture caching = Perlambatan penembolokan tekstur (mempercepat)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -502,6 +502,7 @@ High = Alta
 Hybrid = Ibrido
 Hybrid + Bicubic = Ibrido + Bicubico
 Ignore camera notch when centering = Ignora il notch della foto camera durante il centramento
+Integer scale factor = Integer scale factor
 Internal Resolution = Risoluzione Interna
 Lazy texture caching = Caching lenta delle texture (velocizza)
 Lazy texture caching Tip = Veloce, ma può causare problemi di testo in alcuni giochi

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -501,6 +501,7 @@ High = 高
 Hybrid = Hybrid
 Hybrid + Bicubic = Hybrid + Bicubic
 Ignore camera notch when centering = インカメラ液晶部分を画面センタリング領域に含めない
+Integer scale factor = Integer scale factor
 Internal Resolution = 内部解像度
 Lazy texture caching = テクスチャキャッシュを遅延させる (高速化)
 Lazy texture caching Tip = 高速化するが いくつかのゲームでテキスト表示が崩れる場合があります

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -500,6 +500,7 @@ High = Dhuwur
 Hybrid = Hybrid
 Hybrid + Bicubic = Hybrid + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Resolusi internal
 Lazy texture caching = Caching tektur puguh (Luwih cepet)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -498,6 +498,7 @@ High = 높음
 Hybrid = 혼합
 Hybrid + Bicubic = 혼합 + 고등차수보간
 Ignore camera notch when centering = 센터링 시 카메라 노치 무시
+Integer scale factor = Integer scale factor
 Internal Resolution = 내부 해상도
 Lazy texture caching = 레이지 텍스처 캐싱 (속도 상승)
 Lazy texture caching Tip = 더 빠르지만 몇몇 게임에서 텍스트 문제를 일으킬 수 있음

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -500,6 +500,7 @@ High = ສູງ
 Hybrid = Hybrid
 Hybrid + Bicubic = Hybrid + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = ຄວາມລະອຽດພາຍໃນ
 Lazy texture caching = ແຄດພື້ນຜິວແບບຫຍາບ (ໄວຂຶ້ນ)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -501,6 +501,7 @@ High = Aukšta
 Hybrid = Hybridas
 Hybrid + Bicubic = Hybridas + "Bicubic"
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Vidinė rezoliucija
 Lazy texture caching = "Tingus" tekstūrų spartinimas (greičio didintojas)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -501,6 +501,7 @@ High = High
 Hybrid = Hibrid
 Hybrid + Bicubic = Hibrid + Bikubik
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Resolusi dalaman
 Lazy texture caching = Pengkuki tekstur ringkas (tingkatkan kelajuan)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -501,6 +501,7 @@ High = Hoog
 Hybrid = Hybride
 Hybrid + Bicubic = Hybride + bicubisch
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Interne resolutie
 Lazy texture caching = Texturecaching reduceren (sneller)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -501,6 +501,7 @@ High = High
 Hybrid = Hybrid
 Hybrid + Bicubic = Hybrid + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Internal resolution
 Lazy texture caching = Lazy texture caching (speedup)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -501,6 +501,7 @@ High = Wysokie
 Hybrid = Hybrydowe
 Hybrid + Bicubic = Hybrydowe + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Rozdzielczość wewnętrzna
 Lazy texture caching = Leniwa pamięć tekstur (przyśpieszenie)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -525,6 +525,7 @@ High = Alta
 Hybrid = Híbrido
 Hybrid + Bicubic = Híbrido + Bi-cúbico
 Ignore camera notch when centering = Ignora o nível da câmera quando centralizar
+Integer scale factor = Integer scale factor
 Internal Resolution = Resolução interna
 Lazy texture caching = Cache preguiçoso da textura (mais rápido)
 Lazy texture caching Tip = Mais rápido mas pode causar problemas no texto em alguns jogos

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -525,6 +525,7 @@ High = Alta
 Hybrid = Híbrido
 Hybrid + Bicubic = Híbrido + Bi-cúbico
 Ignore camera notch when centering = Ignora o nível da câmera quando centralizar
+Integer scale factor = Integer scale factor
 Internal Resolution = Resolução interna
 Lazy texture caching = Cache preguiçoso da textura (mais rápido)
 Lazy texture caching Tip = Mais rápido mas pode causar problemas no texto em alguns jogos

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -501,6 +501,7 @@ High = Înalt
 Hybrid = Hibrid
 Hybrid + Bicubic = Hibrid + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Rezoluție internă
 Lazy texture caching = Stocare de texturi leneșă (mărire viteză)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -501,6 +501,7 @@ High = Высокое
 Hybrid = Гибридный
 Hybrid + Bicubic = Гибридный + бикубический
 Ignore camera notch when centering = Игнорировать челку камеры при центрировании
+Integer scale factor = Integer scale factor
 Internal Resolution = Внутренние разрешение
 Lazy texture caching = Ленивое кэширование текстур (быстрее)
 Lazy texture caching Tip = Быстрее, но может вызвать проблемы с текстом в некоторых играх

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -501,6 +501,7 @@ High = High
 Hybrid = Hybrid
 Hybrid + Bicubic = Hybrid + Bicubic
 Ignore camera notch when centering = Ignorera kamerahål vid centrering
+Integer scale factor = Integer scale factor
 Internal Resolution = Intern upplösning
 Lazy texture caching = Lazy texture caching (speedup)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -500,6 +500,7 @@ High = Mataas
 Hybrid = Hybrid
 Hybrid + Bicubic = Hybrid + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Resolusyong Internal
 Lazy texture caching = Lazy texture caching (pampa-bilis)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -500,6 +500,7 @@ High = สูง
 Hybrid = ไฮบริด
 Hybrid + Bicubic = ไฮบริด + ไบคิวบิค
 Ignore camera notch when centering = ละเว้นตำแหน่งจอแหว่งเพื่อปรับภาพให้อยู่ตรงกลาง
+Integer scale factor = Integer scale factor
 Internal Resolution = ความละเอียดภายใน
 Lazy texture caching = แคชพื้นผิวแบบหยาบ (เร็วขึ้น)
 Lazy texture caching Tip = เร็วขึ้น แต่อาจจะทำให้ฟ้อนต์ตัวหนังสือไม่แสดงผลในบางเกม

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -503,6 +503,7 @@ High = Yüksek
 Hybrid = Hibrit
 Hybrid + Bicubic = Hibrit + Bikübik
 Ignore camera notch when centering = Merkezleme sırasında kamera çentiğini yoksay
+Integer scale factor = Integer scale factor
 Internal Resolution = İç çözünürlük
 Lazy texture caching = Yavaş doku önbellekleme (hızlandırır)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -501,6 +501,7 @@ High = Висока
 Hybrid = Гібридний
 Hybrid + Bicubic = Гібридний + Бікубічний
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Внутрішнє розширення
 Lazy texture caching = Кешування текстур
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -501,6 +501,7 @@ High = Cao
 Hybrid = Hybrid (hỗn hợp)
 Hybrid + Bicubic = Hybrid + Bicubic
 Ignore camera notch when centering = Ignore camera notch when centering
+Integer scale factor = Integer scale factor
 Internal Resolution = Độ phân giải bên trong
 Lazy texture caching = Bộ nhớ đệm lazy texture (tăng tốc)
 Lazy texture caching Tip = Faster, but can cause text problems in a few games

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -501,6 +501,7 @@ High = 高质量
 Hybrid = 混合
 Hybrid + Bicubic = 混合+双三次
 Ignore camera notch when centering = 忽略摄像头挖孔
+Integer scale factor = Integer scale factor
 Internal Resolution = 内部分辨率
 Lazy texture caching = 减少缓存存取(提速)
 Lazy texture caching Tip = 更快, 在一些游戏里引起文字渲染错误

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -501,6 +501,7 @@ High = 高
 Hybrid = 混合
 Hybrid + Bicubic = 混合 + 雙立方
 Ignore camera notch when centering = 置中時忽略相機凹口
+Integer scale factor = Integer scale factor
 Internal Resolution = 內部解析度
 Lazy texture caching = 消極式紋理快取 (加速)
 Lazy texture caching Tip = 更快，但在某些遊戲中可能會造成文字問題


### PR DESCRIPTION
This is mainly useful if you want an authentic pixellated look with 1x rendering (or software) and nearest display filter. Cave Story is a good game for testing. 

The new option is a boolean, that'll simply round down the auto-scaled sized to the nearest integer scale factor, configuring exactly which one isn't that interesting since they all are gonna look good.

Fixes #17093

I'm not a huge fan of the name "Integer scale factor" but I don't really know what would be better, suggestions wanted.

~~(Oops, just realized that vertical screen rotation isn't gonna look good right now, will fix).~~