### PR TITLE
Libretro audio simplification

### DIFF
--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -907,7 +907,7 @@ SOURCES_C += $(LIBRETROCOMMONDIR)/compat/compat_posix_string.c \
 endif
 
 GIT_VERSION_SRC = $(CORE_DIR)/git-version.cpp
-GIT_VERSION := $(shell git describe --always || echo v1.7.0-git)
+GIT_VERSION := $(shell git describe --always || echo v-1.unknown)
 GIT_VERSION_NO_UPDATE = $(findstring 1,$(shell grep -s PPSSPP_GIT_VERSION_NO_UPDATE $(GIT_VERSION_SRC)))
 ifneq (,$(findstring $(GIT_VERSION),$(shell grep -s char $(GIT_VERSION_SRC))))
    GIT_VERSION_NO_UPDATE = 1

--- a/libretro/README_WINDOWS.txt
+++ b/libretro/README_WINDOWS.txt
@@ -19,6 +19,8 @@ make platform=windows_msvc2019_desktop_x64 -j32 && cp ppsspp_libretro.* /d/retro
 Note that the latter part copies the DLL/PDB into wherever retroarch reads it from. Might need to adjust the path,
 and adjust -j32 depending on your number of logical CPUs - might not need that many threads (or you might need more...).
 
+Also, the "2019" part has no significance, it seems - it's fine even if you're on MSVC 2022.
+
 (plain make without a platform parameter doesn't work - g++ isn't able to build the D3D11 stuff, or at least it fails to link).
 
 To debug from within MSVC, open retroarch.exe (or retroarch_debug.exe) as a Project/Solution, then open a few of the cpp files,


### PR DESCRIPTION
There's just no reason to have a separate speed control mechanism when Libretro has one built-in. So just delete it.

(So in effect, libretro used to run with THREE audio speed control mechanisms bolted on top of each other, including PPSSPP's own..)

May help #15561.