### PR TITLE
Add back our older VFPU approximations, as fallbacks if the table files are missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2067,6 +2067,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/MIPS/MIPSTables.h
 	Core/MIPS/MIPSVFPUUtils.cpp
 	Core/MIPS/MIPSVFPUUtils.h
+	Core/MIPS/MIPSVFPUFallbacks.cpp
+	Core/MIPS/MIPSVFPUFallbacks.h
 	Core/MIPS/MIPSAsm.cpp
 	Core/MIPS/MIPSAsm.h
 	Core/MemFault.cpp

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -590,6 +590,7 @@
     <ClCompile Include="MIPS\IR\IRJit.cpp" />
     <ClCompile Include="MIPS\IR\IRPassSimplify.cpp" />
     <ClCompile Include="MIPS\IR\IRRegCache.cpp" />
+    <ClCompile Include="MIPS\MIPSVFPUFallbacks.cpp" />
     <ClCompile Include="Replay.cpp" />
     <ClCompile Include="Compatibility.cpp" />
     <ClCompile Include="Config.cpp" />
@@ -1154,6 +1155,7 @@
     <ClInclude Include="MIPS\IR\IRJit.h" />
     <ClInclude Include="MIPS\IR\IRPassSimplify.h" />
     <ClInclude Include="MIPS\IR\IRRegCache.h" />
+    <ClInclude Include="MIPS\MIPSVFPUFallbacks.h" />
     <ClInclude Include="Replay.h" />
     <ClInclude Include="Compatibility.h" />
     <ClInclude Include="Config.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -1192,6 +1192,9 @@
     <ClCompile Include="TiltEventProcessor.cpp">
       <Filter>Core</Filter>
     </ClCompile>
+    <ClCompile Include="MIPS\MIPSVFPUFallbacks.cpp">
+      <Filter>MIPS</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -1925,6 +1928,9 @@
     </ClInclude>
     <ClInclude Include="TiltEventProcessor.h">
       <Filter>Core</Filter>
+    </ClInclude>
+    <ClInclude Include="MIPS\MIPSVFPUFallbacks.h">
+      <Filter>MIPS</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Core/MIPS/MIPSVFPUFallbacks.cpp
+++ b/Core/MIPS/MIPSVFPUFallbacks.cpp
@@ -1,0 +1,312 @@
+#include <cmath>
+
+#include "Common/BitScan.h"
+
+#include "Core/MIPS/MIPSVFPUFallbacks.h"
+#include "Core/MIPS/MIPSVFPUUtils.h"
+
+// MIPSVFPUUtils now has the high precision instructions implemented by fp64
+// in https://github.com/hrydgard/ppsspp/pull/16984 .
+//
+// These are our older approximations that are quite good but has flaws,
+// but we need them to fall back to if the table files are missing.
+//
+// Note that currently, some of the new functions are not integrated in the JIT
+// and are thus not normally used anyway.
+
+// First the "trivial" fallbacks where we haven't done any accuracy work previously.
+
+float vfpu_asin_fallback(float angle) {
+	return (float)(asinf(angle) / M_PI_2);
+}
+
+float vfpu_rcp_fallback(float x) {
+	return 1.0f / x;
+}
+
+float vfpu_log2_fallback(float x) {
+	return log2f(x);
+}
+
+float vfpu_exp2_fallback(float x) {
+	return exp2f(x);
+}
+
+// Flushes the angle to 0 if exponent smaller than this in vfpu_sin/vfpu_cos/vfpu_sincos.
+// Was measured to be around 0x68, but GTA on Mac is somehow super sensitive
+// to the shape of the sine curve which seem to be very slightly different.
+//
+// So setting a lower value.
+#define PRECISION_EXP_THRESHOLD 0x65
+
+union float2int {
+	uint32_t i;
+	float f;
+};
+
+float vfpu_sqrt_fallback(float a) {
+	float2int val;
+	val.f = a;
+
+	if ((val.i & 0xff800000) == 0x7f800000) {
+		if ((val.i & 0x007fffff) != 0) {
+			val.i = 0x7f800001;
+		}
+		return val.f;
+	}
+	if ((val.i & 0x7f800000) == 0) {
+		// Kill any sign.
+		val.i = 0;
+		return val.f;
+	}
+	if (val.i & 0x80000000) {
+		val.i = 0x7f800001;
+		return val.f;
+	}
+
+	int k = get_exp(val.i);
+	uint32_t sp = get_mant(val.i);
+	int less_bits = k & 1;
+	k >>= 1;
+
+	uint32_t z = 0x00C00000 >> less_bits;
+	int64_t halfsp = sp >> 1;
+	halfsp <<= 23 - less_bits;
+	for (int i = 0; i < 6; ++i) {
+		z = (z >> 1) + (uint32_t)(halfsp / z);
+	}
+
+	val.i = ((k + 127) << 23) | ((z << less_bits) & 0x007FFFFF);
+	// The lower two bits never end up set on the PSP, it seems like.
+	val.i &= 0xFFFFFFFC;
+
+	return val.f;
+}
+
+static inline uint32_t mant_mul(uint32_t a, uint32_t b) {
+	uint64_t m = (uint64_t)a * (uint64_t)b;
+	if (m & 0x007FFFFF) {
+		m += 0x01437000;
+	}
+	return (uint32_t)(m >> 23);
+}
+
+float vfpu_rsqrt_fallback(float a) {
+	float2int val;
+	val.f = a;
+
+	if (val.i == 0x7f800000) {
+		return 0.0f;
+	}
+	if ((val.i & 0x7fffffff) > 0x7f800000) {
+		val.i = (val.i & 0x80000000) | 0x7f800001;
+		return val.f;
+	}
+	if ((val.i & 0x7f800000) == 0) {
+		val.i = (val.i & 0x80000000) | 0x7f800000;
+		return val.f;
+	}
+	if (val.i & 0x80000000) {
+		val.i = 0xff800001;
+		return val.f;
+	}
+
+	int k = get_exp(val.i);
+	uint32_t sp = get_mant(val.i);
+	int less_bits = k & 1;
+	k = -(k >> 1);
+
+	uint32_t z = 0x00800000 >> less_bits;
+	uint32_t halfsp = sp >> (1 + less_bits);
+	for (int i = 0; i < 6; ++i) {
+		uint32_t zsq = mant_mul(z, z);
+		uint32_t correction = 0x00C00000 - mant_mul(halfsp, zsq);
+		z = mant_mul(z, correction);
+	}
+
+	int8_t shift = (int8_t)clz32_nonzero(z) - 8 + less_bits;
+	if (shift < 1) {
+		z >>= -shift;
+		k += -shift;
+	} else if (shift > 0) {
+		z <<= shift;
+		k -= shift;
+	}
+
+	z >>= less_bits;
+
+	val.i = ((k + 127) << 23) | (z & 0x007FFFFF);
+	val.i &= 0xFFFFFFFC;
+
+	return val.f;
+}
+
+float vfpu_sin_fallback(float a) {
+	float2int val;
+	val.f = a;
+
+	int32_t k = get_uexp(val.i);
+	if (k == 255) {
+		val.i = (val.i & 0xFF800001) | 1;
+		return val.f;
+	}
+
+	if (k < PRECISION_EXP_THRESHOLD) {
+		val.i &= 0x80000000;
+		return val.f;
+	}
+
+	// Okay, now modulus by 4 to begin with (identical wave every 4.)
+	int32_t mantissa = get_mant(val.i);
+	if (k > 0x80) {
+		const uint8_t over = k & 0x1F;
+		mantissa = (mantissa << over) & 0x00FFFFFF;
+		k = 0x80;
+	}
+	// This subtracts off the 2.  If we do, flip sign to inverse the wave.
+	if (k == 0x80 && mantissa >= (1 << 23)) {
+		val.i ^= 0x80000000;
+		mantissa -= 1 << 23;
+	}
+
+	int8_t norm_shift = mantissa == 0 ? 32 : (int8_t)clz32_nonzero(mantissa) - 8;
+	mantissa <<= norm_shift;
+	k -= norm_shift;
+
+	if (k <= 0 || mantissa == 0) {
+		val.i &= 0x80000000;
+		return val.f;
+	}
+
+	// This is the value with modulus applied.
+	val.i = (val.i & 0x80000000) | (k << 23) | (mantissa & ~(1 << 23));
+	val.f = (float)sin((double)val.f * M_PI_2);
+	val.i &= 0xFFFFFFFC;
+	return val.f;
+}
+
+float vfpu_cos_fallback(float a) {
+	float2int val;
+	val.f = a;
+	bool negate = false;
+
+	int32_t k = get_uexp(val.i);
+	if (k == 255) {
+		// Note: unlike sin, cos always returns +NAN.
+		val.i = (val.i & 0x7F800001) | 1;
+		return val.f;
+	}
+
+	if (k < PRECISION_EXP_THRESHOLD)
+		return 1.0f;
+
+	// Okay, now modulus by 4 to begin with (identical wave every 4.)
+	int32_t mantissa = get_mant(val.i);
+	if (k > 0x80) {
+		const uint8_t over = k & 0x1F;
+		mantissa = (mantissa << over) & 0x00FFFFFF;
+		k = 0x80;
+	}
+	// This subtracts off the 2.  If we do, negate the result value.
+	if (k == 0x80 && mantissa >= (1 << 23)) {
+		mantissa -= 1 << 23;
+		negate = true;
+	}
+
+	int8_t norm_shift = mantissa == 0 ? 32 : (int8_t)clz32_nonzero(mantissa) - 8;
+	mantissa <<= norm_shift;
+	k -= norm_shift;
+
+	if (k <= 0 || mantissa == 0)
+		return negate ? -1.0f : 1.0f;
+
+	// This is the value with modulus applied.
+	val.i = (val.i & 0x80000000) | (k << 23) | (mantissa & ~(1 << 23));
+	if (val.f == 1.0f || val.f == -1.0f) {
+		return negate ? 0.0f : -0.0f;
+	}
+	val.f = (float)cos((double)val.f * M_PI_2);
+	val.i &= 0xFFFFFFFC;
+	return negate ? -val.f : val.f;
+}
+
+void vfpu_sincos_fallback(float a, float &s, float &c) {
+	float2int val;
+	val.f = a;
+	// For sin, negate the input, for cos negate the output.
+	bool negate = false;
+
+	int32_t k = get_uexp(val.i);
+	if (k == 255) {
+		val.i = (val.i & 0xFF800001) | 1;
+		s = val.f;
+		val.i &= 0x7F800001;
+		c = val.f;
+		return;
+	}
+
+	if (k < PRECISION_EXP_THRESHOLD) {
+		val.i &= 0x80000000;
+		s = val.f;
+		c = 1.0f;
+		return;
+	}
+
+	// Okay, now modulus by 4 to begin with (identical wave every 4.)
+	int32_t mantissa = get_mant(val.i);
+	if (k > 0x80) {
+		const uint8_t over = k & 0x1F;
+		mantissa = (mantissa << over) & 0x00FFFFFF;
+		k = 0x80;
+	}
+	// This subtracts off the 2.  If we do, flip signs.
+	if (k == 0x80 && mantissa >= (1 << 23)) {
+		mantissa -= 1 << 23;
+		negate = true;
+	}
+
+	int8_t norm_shift = mantissa == 0 ? 32 : (int8_t)clz32_nonzero(mantissa) - 8;
+	mantissa <<= norm_shift;
+	k -= norm_shift;
+
+	if (k <= 0 || mantissa == 0) {
+		val.i &= 0x80000000;
+		if (negate)
+			val.i ^= 0x80000000;
+		s = val.f;
+		c = negate ? -1.0f : 1.0f;
+		return;
+	}
+
+	// This is the value with modulus applied.
+	val.i = (val.i & 0x80000000) | (k << 23) | (mantissa & ~(1 << 23));
+	float2int i_sine, i_cosine;
+	if (val.f == 1.0f) {
+		i_sine.f = negate ? -1.0f : 1.0f;
+		i_cosine.f = negate ? 0.0f : -0.0f;
+	} else if (val.f == -1.0f) {
+		i_sine.f = negate ? 1.0f : -1.0f;
+		i_cosine.f = negate ? 0.0f : -0.0f;
+	} else if (negate) {
+		i_sine.f = (float)sin((double)-val.f * M_PI_2);
+		i_cosine.f = -(float)cos((double)val.f * M_PI_2);
+	} else {
+		double angle = (double)val.f * M_PI_2;
+#if defined(__linux__)
+		double d_sine;
+		double d_cosine;
+		sincos(angle, &d_sine, &d_cosine);
+		i_sine.f = (float)d_sine;
+		i_cosine.f = (float)d_cosine;
+#else
+		i_sine.f = (float)sin(angle);
+		i_cosine.f = (float)cos(angle);
+#endif
+	}
+
+	i_sine.i &= 0xFFFFFFFC;
+	i_cosine.i &= 0xFFFFFFFC;
+	s = i_sine.f;
+	c = i_cosine.f;
+	return;
+}

--- a/Core/MIPS/MIPSVFPUFallbacks.h
+++ b/Core/MIPS/MIPSVFPUFallbacks.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// These are our old implementation of VFPU math functions, that don't make use of the
+// accuracy-improving tables from #16984.
+
+float vfpu_asin_fallback(float angle);
+float vfpu_sqrt_fallback(float a);
+float vfpu_rsqrt_fallback(float a);
+float vfpu_sin_fallback(float a);
+float vfpu_cos_fallback(float a);
+void vfpu_sincos_fallback(float a, float &s, float &c);
+float vfpu_rcp_fallback(float x);
+float vfpu_log2_fallback(float x);
+float vfpu_exp2_fallback(float x);

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -67,6 +67,23 @@ extern float vfpu_rexp2(float);
 extern float vfpu_log2(float);
 extern float vfpu_rcp(float);
 
+inline uint32_t get_uexp(uint32_t x) {
+	return (x >> 23) & 0xFF;
+}
+
+inline int32_t get_exp(uint32_t x) {
+	return get_uexp(x) - 127;
+}
+
+inline int32_t get_mant(uint32_t x) {
+	// Note: this returns the hidden 1.
+	return (x & 0x007FFFFF) | 0x00800000;
+}
+
+inline int32_t get_sign(uint32_t x) {
+	return x & 0x80000000;
+}
+
 #define VFPU_FLOAT16_EXP_MAX    0x1f
 #define VFPU_SH_FLOAT16_SIGN    15
 #define VFPU_MASK_FLOAT16_SIGN  0x1

--- a/UWP/CoreUWP/CoreUWP.vcxproj
+++ b/UWP/CoreUWP/CoreUWP.vcxproj
@@ -461,6 +461,7 @@
     <ClInclude Include="..\..\Core\MIPS\MIPSIntVFPU.h" />
     <ClInclude Include="..\..\Core\MIPS\MIPSStackWalk.h" />
     <ClInclude Include="..\..\Core\MIPS\MIPSTables.h" />
+    <ClInclude Include="..\..\Core\MIPS\MIPSVFPUFallbacks.h" />
     <ClInclude Include="..\..\Core\MIPS\MIPSVFPUUtils.h" />
     <ClInclude Include="..\..\Core\MIPS\x86\IRToX86.h" />
     <ClInclude Include="..\..\Core\MIPS\x86\Jit.h" />
@@ -716,6 +717,7 @@
     <ClCompile Include="..\..\Core\MIPS\MIPSIntVFPU.cpp" />
     <ClCompile Include="..\..\Core\MIPS\MIPSStackWalk.cpp" />
     <ClCompile Include="..\..\Core\MIPS\MIPSTables.cpp" />
+    <ClCompile Include="..\..\Core\MIPS\MIPSVFPUFallbacks.cpp" />
     <ClCompile Include="..\..\Core\MIPS\MIPSVFPUUtils.cpp" />
     <ClCompile Include="..\..\Core\MIPS\x86\Asm.cpp" />
     <ClCompile Include="..\..\Core\MIPS\x86\CompALU.cpp" />
@@ -754,459 +756,573 @@
     <ClCompile Include="..\..\ext\jpge\jpge.cpp" />
     <ClCompile Include="..\..\ext\libzip\zip_add.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_add_dir.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_add_entry.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_algorithm_deflate.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_buffer.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_close.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_delete.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_dirent.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_dir_add.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_discard.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_entry.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_error.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_error_clear.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_error_get.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_error_get_sys_type.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_error_strerror.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_error_to_str.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_err_str.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_extra_field.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_extra_field_api.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_fclose.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_fdopen.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_file_add.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_file_error_clear.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_file_error_get.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_file_get_comment.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_file_get_external_attributes.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_file_get_offset.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_file_rename.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_file_replace.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_file_set_comment.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_file_set_encryption.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_file_set_external_attributes.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_file_set_mtime.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_file_strerror.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_fopen.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_fopen_encrypted.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_fopen_index.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_fopen_index_encrypted.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_fread.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_fseek.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_ftell.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_get_archive_comment.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_get_archive_flag.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_get_encryption_implementation.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_get_file_comment.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_get_name.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_get_num_entries.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_get_num_files.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_hash.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_io_util.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_libzip_version.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_memdup.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_name_locate.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_new.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_open.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_pkware.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_progress.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_random_uwp.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_rename.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_replace.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_set_archive_comment.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_set_archive_flag.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_set_default_password.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_set_file_comment.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_set_file_compression.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_set_name.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_accept_empty.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_begin_write.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_begin_write_cloning.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_buffer.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_call.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_close.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_commit_write.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_compress.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_crc.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_error.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_file_common.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_file_stdio.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_file_win32.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_file_win32_named.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_file_win32_utf16.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_file_win32_utf8.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_free.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_function.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_get_file_attributes.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_is_deleted.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_layered.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_open.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_pkware_decode.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_pkware_encode.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_read.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_remove.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_rollback_write.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_seek.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_seek_write.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_stat.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_supports.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_tell.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_tell_write.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_window.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_write.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_zip.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_source_zip_new.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_stat.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_stat_index.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_stat_init.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_strerror.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_string.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_unchange.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_unchange_all.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_unchange_archive.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_unchange_data.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\libzip\zip_utf-8.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <ForcedIncludeFiles></ForcedIncludeFiles>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="..\..\ext\sfmt19937\SFMT.c">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>

--- a/UWP/CoreUWP/CoreUWP.vcxproj.filters
+++ b/UWP/CoreUWP/CoreUWP.vcxproj.filters
@@ -1123,6 +1123,9 @@
       <Filter>HLE</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Core\TiltEventProcessor.cpp" />
+    <ClCompile Include="..\..\Core\MIPS\MIPSVFPUFallbacks.cpp">
+      <Filter>MIPS</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -1774,6 +1777,9 @@
       <Filter>HLE</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Core\TiltEventProcessor.h" />
+    <ClInclude Include="..\..\Core\MIPS\MIPSVFPUFallbacks.h">
+      <Filter>MIPS</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\ext\gason\LICENSE">

--- a/UWP/UWP.vcxproj
+++ b/UWP/UWP.vcxproj
@@ -494,6 +494,51 @@
       <DeploymentContent>true</DeploymentContent>
       <FileType>Document</FileType>
     </Image>
+    <None Include="Content\vfpu\vfpu_asin_lut65536.dat">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="Content\vfpu\vfpu_asin_lut_deltas.dat">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="Content\vfpu\vfpu_asin_lut_indices.dat">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="Content\vfpu\vfpu_exp2_lut.dat">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="Content\vfpu\vfpu_exp2_lut65536.dat">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="Content\vfpu\vfpu_log2_lut.dat">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="Content\vfpu\vfpu_log2_lut65536.dat">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="Content\vfpu\vfpu_log2_lut65536_quadratic.dat">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="Content\vfpu\vfpu_rcp_lut.dat">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="Content\vfpu\vfpu_rsqrt_lut.dat">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="Content\vfpu\vfpu_sin_lut8192.dat">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="Content\vfpu\vfpu_sin_lut_delta.dat">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="Content\vfpu\vfpu_sin_lut_exceptions.dat">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="Content\vfpu\vfpu_sin_lut_interval_delta.dat">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="Content\vfpu\vfpu_sqrt_lut.dat">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
     <None Include="Content\asciifont_atlas.meta">
       <DeploymentContent>true</DeploymentContent>
     </None>

--- a/UWP/UWP.vcxproj.filters
+++ b/UWP/UWP.vcxproj.filters
@@ -493,28 +493,6 @@
     <None Include="Content\debugger\static\media\*.svg">
       <Filter>Content\debugger\static\media</Filter>
     </None>
-    <None Include="Content\debugger\static\css\*.css" />
-    <None Include="Content\debugger\static\css\*.css" />
-    <None Include="Content\debugger\static\css\*.map" />
-    <None Include="Content\debugger\static\css\*.map" />
-    <None Include="Content\debugger\static\js\*.js" />
-    <None Include="Content\debugger\static\js\*.js" />
-    <None Include="Content\debugger\static\js\*.js" />
-    <None Include="Content\debugger\static\js\*.map" />
-    <None Include="Content\debugger\static\js\*.map" />
-    <None Include="Content\debugger\static\js\*.map" />
-    <None Include="Content\debugger\static\media\*.svg" />
-    <None Include="Content\debugger\static\css\*.css" />
-    <None Include="Content\debugger\static\css\*.css" />
-    <None Include="Content\debugger\static\css\*.map" />
-    <None Include="Content\debugger\static\css\*.map" />
-    <None Include="Content\debugger\static\js\*.js" />
-    <None Include="Content\debugger\static\js\*.js" />
-    <None Include="Content\debugger\static\js\*.js" />
-    <None Include="Content\debugger\static\js\*.map" />
-    <None Include="Content\debugger\static\js\*.map" />
-    <None Include="Content\debugger\static\js\*.map" />
-    <None Include="Content\debugger\static\media\*.svg" />
     <None Include="Content\vfpu\vfpu_sqrt_lut.dat">
       <Filter>Content\vfpu</Filter>
     </None>

--- a/UWP/UWP.vcxproj.filters
+++ b/UWP/UWP.vcxproj.filters
@@ -68,6 +68,9 @@
     <Filter Include="Content\debugger\static\media">
       <UniqueIdentifier>{83476056-57b8-409f-b729-754d6401e3d5}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Content\vfpu">
+      <UniqueIdentifier>{eebef4bc-52b6-460d-946d-c70c8a4ee337}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="App.cpp" />
@@ -501,6 +504,62 @@
     <None Include="Content\debugger\static\js\*.map" />
     <None Include="Content\debugger\static\js\*.map" />
     <None Include="Content\debugger\static\media\*.svg" />
+    <None Include="Content\debugger\static\css\*.css" />
+    <None Include="Content\debugger\static\css\*.css" />
+    <None Include="Content\debugger\static\css\*.map" />
+    <None Include="Content\debugger\static\css\*.map" />
+    <None Include="Content\debugger\static\js\*.js" />
+    <None Include="Content\debugger\static\js\*.js" />
+    <None Include="Content\debugger\static\js\*.js" />
+    <None Include="Content\debugger\static\js\*.map" />
+    <None Include="Content\debugger\static\js\*.map" />
+    <None Include="Content\debugger\static\js\*.map" />
+    <None Include="Content\debugger\static\media\*.svg" />
+    <None Include="Content\vfpu\vfpu_sqrt_lut.dat">
+      <Filter>Content\vfpu</Filter>
+    </None>
+    <None Include="Content\vfpu\vfpu_asin_lut_deltas.dat">
+      <Filter>Content\vfpu</Filter>
+    </None>
+    <None Include="Content\vfpu\vfpu_asin_lut_indices.dat">
+      <Filter>Content\vfpu</Filter>
+    </None>
+    <None Include="Content\vfpu\vfpu_asin_lut65536.dat">
+      <Filter>Content\vfpu</Filter>
+    </None>
+    <None Include="Content\vfpu\vfpu_exp2_lut.dat">
+      <Filter>Content\vfpu</Filter>
+    </None>
+    <None Include="Content\vfpu\vfpu_exp2_lut65536.dat">
+      <Filter>Content\vfpu</Filter>
+    </None>
+    <None Include="Content\vfpu\vfpu_log2_lut.dat">
+      <Filter>Content\vfpu</Filter>
+    </None>
+    <None Include="Content\vfpu\vfpu_log2_lut65536.dat">
+      <Filter>Content\vfpu</Filter>
+    </None>
+    <None Include="Content\vfpu\vfpu_log2_lut65536_quadratic.dat">
+      <Filter>Content\vfpu</Filter>
+    </None>
+    <None Include="Content\vfpu\vfpu_rcp_lut.dat">
+      <Filter>Content\vfpu</Filter>
+    </None>
+    <None Include="Content\vfpu\vfpu_rsqrt_lut.dat">
+      <Filter>Content\vfpu</Filter>
+    </None>
+    <None Include="Content\vfpu\vfpu_sin_lut_delta.dat">
+      <Filter>Content\vfpu</Filter>
+    </None>
+    <None Include="Content\vfpu\vfpu_sin_lut_exceptions.dat">
+      <Filter>Content\vfpu</Filter>
+    </None>
+    <None Include="Content\vfpu\vfpu_sin_lut_interval_delta.dat">
+      <Filter>Content\vfpu</Filter>
+    </None>
+    <None Include="Content\vfpu\vfpu_sin_lut8192.dat">
+      <Filter>Content\vfpu</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Text Include="Content\gamecontrollerdb.txt">
@@ -509,6 +568,7 @@
     <Text Include="Content\debugger\static\js\*.txt">
       <Filter>Content\debugger\static\js</Filter>
     </Text>
+    <Text Include="Content\debugger\static\js\*.txt" />
     <Text Include="Content\debugger\static\js\*.txt" />
   </ItemGroup>
   <ItemGroup>

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -347,6 +347,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/MIPS/MIPSStackWalk.cpp \
   $(SRC)/Core/MIPS/MIPSTables.cpp \
   $(SRC)/Core/MIPS/MIPSVFPUUtils.cpp.arm \
+  $(SRC)/Core/MIPS/MIPSVFPUFallbacks.cpp.arm \
   $(SRC)/Core/MIPS/MIPSCodeUtils.cpp.arm \
   $(SRC)/Core/MIPS/MIPSDebugInterface.cpp \
   $(SRC)/Core/MIPS/IR/IRFrontend.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -652,6 +652,7 @@ SOURCES_CXX += \
 	       $(COREDIR)/MIPS/MIPSTables.cpp \
 	       $(COREDIR)/MIPS/MIPSStackWalk.cpp \
 	       $(COREDIR)/MIPS/MIPSVFPUUtils.cpp \
+	       $(COREDIR)/MIPS/MIPSVFPUFallbacks.cpp \
 	       $(COREDIR)/MemFault.cpp \
 	       $(COREDIR)/MemMap.cpp \
 	       $(COREDIR)/MemMapFunctions.cpp \


### PR DESCRIPTION
PR #16984 added more accurate versions of these functions, but they require large lookup tables stored in assets/.

If these files are missing, PPSSPP would simply crash, which isn't good. It's very common for assets files to be missing when running as a libretro core, because those users just don't seem to be in the habit of copying these when they install a core.

We should probably try to warn the user somehow that these files are missing, though...

This also fixes deployment of the table files on UWP builds (some additional files snuck in too, without me explicitly adding them.. might as well let them, they're just gonna get auto-added again later and don't do any harm)