### PR TITLE
Fix build with GCC13: various standard includes

### DIFF
--- a/Common/Data/Format/IniFile.h
+++ b/Common/Data/Format/IniFile.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include "Common/File/Path.h"
 

--- a/Common/GPU/OpenGL/GLFeatures.h
+++ b/Common/GPU/OpenGL/GLFeatures.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 // TODO: Replace with thin3d's vendor enum.
 enum {

--- a/Common/Net/NetBuffer.h
+++ b/Common/Net/NetBuffer.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include <cstdint>
+
 #include "Common/Buffer.h"
 
 namespace net {

--- a/Core/Reporting.h
+++ b/Core/Reporting.h
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include "Common/CommonTypes.h"
 #include "Common/File/Path.h"

--- a/ext/vma/vk_mem_alloc.h
+++ b/ext/vma/vk_mem_alloc.h
@@ -2624,6 +2624,7 @@ VMA_CALL_PRE void VMA_CALL_POST vmaFreeStatsString(
 #include <cstring>
 #include <utility>
 #include <type_traits>
+#include <cstdio>
 
 #ifdef _MSC_VER
     #include <intrin.h> // For functions like __popcnt, _BitScanForward etc.


### PR DESCRIPTION
Fixes various undefined int types and snprintf() new in gcc 13.
As used in https://build.opensuse.org/package/show/Emulators/ppsspp