### PR TITLE
Debugger: Trigger mem breakpoints for mirrors

### DIFF
--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -616,7 +616,7 @@ u32 CBreakPoints::CheckSkipFirst()
 
 const std::vector<MemCheck> CBreakPoints::GetMemCheckRanges(bool write) {
 	std::lock_guard<std::mutex> guard(memCheckMutex_);
-	std::vector<MemCheck> ranges = memChecks_;
+	std::vector<MemCheck> ranges;
 	for (const auto &check : memChecks_) {
 		if (!(check.cond & MEMCHECK_READ) && !write)
 			continue;
@@ -628,6 +628,7 @@ const std::vector<MemCheck> CBreakPoints::GetMemCheckRanges(bool write) {
 		copy.start ^= 0x40000000;
 		if (copy.end != 0)
 			copy.end ^= 0x40000000;
+		ranges.push_back(check);
 		ranges.push_back(copy);
 	}
 

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -180,6 +180,7 @@ private:
 	// Finds exactly, not using a range check.
 	static size_t FindMemCheck(u32 start, u32 end);
 	static MemCheck *GetMemCheckLocked(u32 address, int size);
+	static void UpdateCachedMemCheckRanges();
 
 	static std::vector<BreakPoint> breakPoints_;
 	static u32 breakSkipFirstAt_;
@@ -187,6 +188,8 @@ private:
 
 	static std::vector<MemCheck> memChecks_;
 	static std::vector<MemCheck *> cleanupMemChecks_;
+	static std::vector<MemCheck> memCheckRangesRead_;
+	static std::vector<MemCheck> memCheckRangesWrite_;
 };
 
 

--- a/Core/MIPS/ARM/ArmCompFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompFPU.cpp
@@ -95,7 +95,7 @@ void ArmJit::Comp_FPULS(MIPSOpcode op)
 	CONDITIONAL_DISABLE(LSU_FPU);
 	CheckMemoryBreakpoint();
 
-	s32 offset = (s16)(op & 0xFFFF);
+	s32 offset = SignExtend16ToS32(op & 0xFFFF);
 	int ft = _FT;
 	MIPSGPReg rs = _RS;
 	// u32 addr = R(rs) + offset;

--- a/Core/MIPS/ARM/ArmCompLoadStore.cpp
+++ b/Core/MIPS/ARM/ArmCompLoadStore.cpp
@@ -113,7 +113,7 @@ namespace MIPSComp
 	void ArmJit::Comp_ITypeMemLR(MIPSOpcode op, bool load) {
 		CONDITIONAL_DISABLE(LSU);
 		CheckMemoryBreakpoint();
-		int offset = (signed short)(op & 0xFFFF);
+		int offset = SignExtend16ToS32(op & 0xFFFF);
 		MIPSGPReg rt = _RT;
 		MIPSGPReg rs = _RS;
 		int o = op >> 26;

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -91,7 +91,7 @@ static u32 JitMemCheck(u32 pc) {
 
 	// Note: pc may be the delay slot.
 	const auto op = Memory::Read_Instruction(pc, true);
-	s32 offset = (s16)(op & 0xFFFF);
+	s32 offset = SignExtend16ToS32(op & 0xFFFF);
 	if (MIPSGetInfo(op) & IS_VFPU)
 		offset &= 0xFFFC;
 	u32 addr = currentMIPS->r[MIPS_GET_RS(op)] + offset;

--- a/Core/MIPS/ARM64/Arm64CompFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompFPU.cpp
@@ -83,9 +83,7 @@ void Arm64Jit::Comp_FPULS(MIPSOpcode op)
 	CONDITIONAL_DISABLE(LSU_FPU);
 	CheckMemoryBreakpoint();
 
-	// Surprisingly, these work fine alraedy.
-
-	s32 offset = (s16)(op & 0xFFFF);
+	s32 offset = SignExtend16ToS32(op & 0xFFFF);
 	int ft = _FT;
 	MIPSGPReg rs = _RS;
 	// u32 addr = R(rs) + offset;

--- a/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
+++ b/Core/MIPS/ARM64/Arm64CompLoadStore.cpp
@@ -115,7 +115,7 @@ namespace MIPSComp {
 	void Arm64Jit::Comp_ITypeMemLR(MIPSOpcode op, bool load) {
 		CONDITIONAL_DISABLE(LSU);
 		CheckMemoryBreakpoint();
-		int offset = (signed short)(op & 0xFFFF);
+		int offset = SignExtend16ToS32(op & 0xFFFF);
 		MIPSGPReg rt = _RT;
 		MIPSGPReg rs = _RS;
 		int o = op >> 26;
@@ -267,7 +267,7 @@ namespace MIPSComp {
 		CONDITIONAL_DISABLE(LSU);
 		CheckMemoryBreakpoint();
 
-		int offset = (signed short)(op & 0xFFFF);
+		int offset = SignExtend16ToS32(op & 0xFFFF);
 		bool load = false;
 		MIPSGPReg rt = _RT;
 		MIPSGPReg rs = _RS;

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -81,7 +81,7 @@ static u32 JitMemCheck(u32 pc) {
 
 	// Note: pc may be the delay slot.
 	const auto op = Memory::Read_Instruction(pc, true);
-	s32 offset = (s16)(op & 0xFFFF);
+	s32 offset = SignExtend16ToS32(op & 0xFFFF);
 	if (MIPSGetInfo(op) & IS_VFPU)
 		offset &= 0xFFFC;
 	u32 addr = currentMIPS->r[MIPS_GET_RS(op)] + offset;

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -1449,7 +1449,7 @@ skip:
 		case 0x08:	// addi
 		case 0x09:	// addiu
 			info.hasRelevantAddress = true;
-			info.relevantAddress = cpu->GetRegValue(0,MIPS_GET_RS(op))+((s16)(op & 0xFFFF));
+			info.relevantAddress = cpu->GetRegValue(0, MIPS_GET_RS(op)) + SignExtend16ToS32(op & 0xFFFF);
 			break;
 		}
 

--- a/Core/MIPS/MIPSDis.cpp
+++ b/Core/MIPS/MIPSDis.cpp
@@ -64,7 +64,7 @@ namespace MIPSDis
 
 	void Dis_Cache(MIPSOpcode op, char *out)
 	{
-		int imm = (s16)(op & 0xFFFF);
+		int imm = SignExtend16ToS32(op & 0xFFFF);
 		int rs = _RS;
 		int func = (op >> 16) & 0x1F;
 		sprintf(out, "%s\tfunc=%i, %s(%s)", MIPSGetName(op), func, RN(rs), SignedHex(imm));

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -94,7 +94,7 @@ namespace MIPSInt
 {
 	void Int_Cache(MIPSOpcode op)
 	{
-		int imm = (s16)(op & 0xFFFF);
+		int imm = SignExtend16ToS32(op & 0xFFFF);
 		int rs = _RS;
 		uint32_t addr = R(rs) + imm;
 		int func = (op >> 16) & 0x1F;


### PR DESCRIPTION
For some reason I forgot we didn't, so I was trying to find a depth read without pointing at the mirrors.  I think it's better to just handle the VRAM mirrors automatically.

This also optimizes x86jit handling of memory breakpoints a bit.

-[Unknown]