### PR TITLE
Presentation: Switch from indexed trilist to plain tristrip

### DIFF
--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -132,7 +132,6 @@ protected:
 	Draw::SamplerState *samplerNearest_ = nullptr;
 	Draw::SamplerState *samplerLinear_ = nullptr;
 	Draw::Buffer *vdata_ = nullptr;
-	Draw::Buffer *idata_ = nullptr;
 
 	std::vector<Draw::Pipeline *> postShaderPipelines_;
 	std::vector<Draw::Framebuffer *> postShaderFramebuffers_;


### PR DESCRIPTION
Insignificant performance difference, but nice to get rid of the index buffer. Basically just a driveby cleanup while changing some code around here.

Choosing strip instead of fan due to lack of fans in some APIs.