### PR TITLE
PresentationCommon: Simplify Y flip handling.

### DIFF
--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -67,9 +67,9 @@ enum class OutputFlags {
 	LINEAR = 0x0000,
 	NEAREST = 0x0001,
 	RB_SWIZZLE = 0x0002,
-	BACKBUFFER_FLIPPED = 0x0004,
-	POSITION_FLIPPED = 0x0008,
-	PILLARBOX = 0x0010,
+	BACKBUFFER_FLIPPED = 0x0004,  // Viewport/scissor coordinates are y-flipped.
+	POSITION_FLIPPED = 0x0008,    // Vertex position in the shader is y-flipped relative to the screen.
+	PILLARBOX = 0x0010,           // Squeeze the image horizontally. Used for the DarkStalkers hack.
 };
 ENUM_CLASS_BITOPS(OutputFlags);
 


### PR DESCRIPTION
Don't manipulate the UVs, manipulate the vertex coordinates instead.

This will simplify the next change that will fix the pixel accuracy problems in post-processing.