### PR TITLE
Debugger: sceKernelPrintf improvement, QOL adjustments

### DIFF
--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <sstream>
 
 #include "Common/Thread/ParallelLoop.h"
 #include "Core/CoreTiming.h"
@@ -1100,6 +1101,8 @@ static int sceKernelPrintf(const char *formatString)
 	char tempStr[24];
 	char tempFormat[24] = {'%'};
 	std::string result, format = formatString;
+	std::stringstream stream;
+	float f_arg;
 
 	// Each printf is a separate line already in the log, so don't double space.
 	// This does mean we break up strings, unfortunately.
@@ -1170,6 +1173,18 @@ static int sceKernelPrintf(const char *formatString)
 			snprintf(tempStr, sizeof(tempStr), "%08x", PARAM(param++));
 			result += tempStr;
 			++i;
+			break;
+
+		case 'f':
+			static_assert(sizeof(float) == 4, "sizeof(float) != sizeof(u32)!");
+
+			// Maybe worth replacing with std::bit_cast when (if) we move to C++20
+			std::memcpy(&f_arg, &PARAM(param++), sizeof(u32));
+			stream << f_arg;
+			result += stream.str();
+			
+			++i;
+			stream.str(std::string()); // Reset the stream
 			break;
 
 		default:

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -584,7 +584,8 @@ void CtrlMemView::onMouseUp(WPARAM wParam, LPARAM lParam, int button) {
 			auto memLock = Memory::Lock();
 			std::ostringstream stream;
 			stream << (Memory::IsValidAddress(curAddress_) ? Memory::Read_Float(curAddress_) : NAN);
-			W32Util::CopyTextToClipboard(wnd, stream.str().c_str());
+			auto temp_string = stream.str();
+			W32Util::CopyTextToClipboard(wnd, temp_string.c_str());
 		}
 		break;
 

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -776,7 +776,7 @@ namespace MainWindow {
 
 		case ID_DEBUG_MEMORYBASE:
 		{
-			W32Util::CopyTextToClipboard(hWnd, ConvertUTF8ToWString(StringFromFormat("%016llx", (uintptr_t)Memory::base)));
+			W32Util::CopyTextToClipboard(hWnd, ConvertUTF8ToWString(StringFromFormat("%016llx", (uint64_t)(uintptr_t)Memory::base)));
 			break;
 		}
 

--- a/Windows/ppsspp.rc
+++ b/Windows/ppsspp.rc
@@ -555,7 +555,7 @@ BEGIN
         MENUITEM "GE Debugger...",                          ID_DEBUG_GEDEBUGGER
         MENUITEM "Extract File...",                         ID_DEBUG_EXTRACTFILE
         MENUITEM "Log Console",                             ID_DEBUG_LOG
-        MENUITEM "Copy PSP memory base pointer",             ID_DEBUG_MEMORYBASE
+        MENUITEM "Copy PSP memory base address",            ID_DEBUG_MEMORYBASE
         MENUITEM "Memory View...",                          ID_DEBUG_MEMORYVIEW
     END
 
@@ -715,10 +715,11 @@ BEGIN
         MENUITEM "Go to Extent Begin",         ID_MEMVIEW_EXTENTBEGIN
         MENUITEM "Go to Extent End",           ID_MEMVIEW_EXTENTEND
         MENUITEM SEPARATOR
+        MENUITEM "Copy Float (32 bit)",        ID_MEMVIEW_COPYFLOAT_32
+        MENUITEM SEPARATOR
         MENUITEM "Copy Value (8 bit)",         ID_MEMVIEW_COPYVALUE_8
         MENUITEM "Copy Value (16 bit)",        ID_MEMVIEW_COPYVALUE_16
         MENUITEM "Copy Value (32 bit)",        ID_MEMVIEW_COPYVALUE_32
-        MENUITEM "Copy Float (32 bit)",        ID_MEMVIEW_COPYFLOAT_32
         MENUITEM "Dump...",                    ID_MEMVIEW_DUMP
     END
     POPUP "disasm"


### PR DESCRIPTION
1. Now sceKernelPrintf can print %f floats. Note: it doesn't use the floating registers (if anyone has some evidence of a real PSP game that prepares f0 or something before the call, please do show).
Example with a1 equal to 0x3f8ccccd:
![image](https://user-images.githubusercontent.com/62447396/231172298-8f42cb51-484e-4e9b-b987-5b3181f705d9.png)


2. The "Copy Float (32 bit)" menu item has been moved to its own section because I suspect some people might have memorized the layout and thus experience slight inconveniences due to it now being the last element. Well, that's no longer a problem. We may also later add other floating types here.

![image](https://user-images.githubusercontent.com/62447396/231169107-1a33dd84-99ed-40c1-bbb9-087ffc19a522.png)


3. [This commit](https://github.com/hrydgard/ppsspp/commit/8a74d95eb2bfbd8c17c09036257c6ae6f85283b3) does not fix the recently added menu item so I decided to do that.
I have also renamed it to have consistent terms across the code: 
![image](https://user-images.githubusercontent.com/62447396/231173473-31d3a56a-908c-46df-8e99-e72c009c8ba9.png)

4. Lastly, check the notes here: https://en.cppreference.com/w/cpp/io/basic_stringstream/str