### PR TITLE
fix build error: duplicate case value: 'SDL_SYSWM_X11' and  'WINDOWSY…

### DIFF
--- a/SDL/SDLVulkanGraphicsContext.cpp
+++ b/SDL/SDLVulkanGraphicsContext.cpp
@@ -112,7 +112,7 @@ bool SDLVulkanGraphicsContext::Init(SDL_Window *&window, int x, int y, int w, in
 #endif
 #endif
 #if defined(VK_USE_PLATFORM_DISPLAY_KHR)
-	case WINDOWSYSTEM_DISPLAY:
+	case SDL_SYSWM_KMSDRM:
 		/*
 		There is no problem passing null for the next two arguments, and reinit will be called later
 		huangzihan china


### PR DESCRIPTION
…STEM_DISPLAY' both equal '2'