### PR TITLE
Debugger: Add memory breakpoint conditions

### DIFF
--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -87,6 +87,9 @@ struct MemCheck {
 	BreakAction result = BREAK_ACTION_IGNORE;
 	std::string logFormat;
 
+	bool hasCondition = false;
+	BreakPointCond condition;
+
 	u32 numHits = 0;
 
 	u32 lastPC = 0;
@@ -142,6 +145,10 @@ public:
 	static void RemoveMemCheck(u32 start, u32 end);
 	static void ChangeMemCheck(u32 start, u32 end, MemCheckCondition cond, BreakAction result);
 	static void ClearAllMemChecks();
+
+	static void ChangeMemCheckAddCond(u32 start, u32 end, const BreakPointCond &cond);
+	static void ChangeMemCheckRemoveCond(u32 start, u32 end);
+	static BreakPointCond *GetMemCheckCondition(u32 start, u32 end);
 
 	static void ChangeMemCheckLogFormat(u32 start, u32 end, const std::string &fmt);
 

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -97,10 +97,6 @@ struct MemCheck {
 	BreakAction Apply(u32 addr, bool write, int size, u32 pc);
 	// Called on a copy.
 	BreakAction Action(u32 addr, bool write, int size, u32 pc, const char *reason);
-	void JitBeforeApply(u32 addr, bool write, int size, u32 pc);
-	void JitBeforeAction(u32 addr, bool write, int size, u32 pc);
-	bool JitApplyChanged();
-	void JitCleanup(bool changed);
 
 	void Log(u32 addr, bool write, int size, u32 pc, const char *reason);
 
@@ -154,10 +150,6 @@ public:
 	static BreakAction ExecMemCheck(u32 address, bool write, int size, u32 pc, const char *reason);
 	static BreakAction ExecOpMemCheck(u32 address, u32 pc);
 
-	// Executes memchecks but used by the jit.  Cleanup finalizes after jit is done.
-	static void ExecMemCheckJitBefore(u32 address, bool write, int size, u32 pc);
-	static void ExecMemCheckJitCleanup();
-
 	static void SetSkipFirst(u32 pc);
 	static u32 CheckSkipFirst();
 
@@ -187,7 +179,6 @@ private:
 	static u64 breakSkipFirstTicks_;
 
 	static std::vector<MemCheck> memChecks_;
-	static std::vector<MemCheck *> cleanupMemChecks_;
 	static std::vector<MemCheck> memCheckRangesRead_;
 	static std::vector<MemCheck> memCheckRangesWrite_;
 };

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -787,7 +787,7 @@ bool ArmJit::CheckMemoryBreakpoint(int instructionOffset) {
 		MOVI2R(R0, GetCompilerPC());
 		MovToPC(R0);
 		if (off != 0)
-			ADDI2R(R0, R0, off, SCRATCHREG2);
+			ADDI2R(R0, R0, off * 4, SCRATCHREG2);
 		QuickCallFunction(SCRATCHREG2, &JitMemCheck);
 
 		// If 0, the breakpoint wasn't tripped.

--- a/Core/MIPS/JitCommon/JitState.h
+++ b/Core/MIPS/JitCommon/JitState.h
@@ -53,8 +53,6 @@ namespace MIPSComp {
 		{
 			AFTER_NONE = 0x00,
 			AFTER_CORE_STATE = 0x01,
-			AFTER_REWIND_PC_BAD_STATE = 0x02,
-			AFTER_MEMCHECK_CLEANUP = 0x04,
 		};
 
 		u32 compilerPC;

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -676,7 +676,6 @@ namespace MIPSAnalyst {
 			return memcmp(rd, Memory::GetPointerRange(addr, 16), sizeof(float) * 4) != 0;
 		}
 
-		// TODO: Technically, the break might be for 1 byte in the middle of a sw.
 		return writeVal != prevVal;
 	}
 

--- a/Core/MIPS/x86/CompFPU.cpp
+++ b/Core/MIPS/x86/CompFPU.cpp
@@ -127,6 +127,8 @@ void Jit::Comp_FPULS(MIPSOpcode op) {
 	int ft = _FT;
 	MIPSGPReg rs = _RS;
 
+	CheckMemoryBreakpoint(0, rs, offset);
+
 	switch (op >> 26) {
 	case 49: //FI(ft) = Memory::Read_U32(addr); break; //lwc1
 		{

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -286,12 +286,15 @@ namespace MIPSComp {
 	{
 		CONDITIONAL_DISABLE(LSU);
 		int offset = _IMM16;
+		MIPSGPReg rs = _RS;
 		MIPSGPReg rt = _RT;
 		int o = op>>26;
 		if (((op >> 29) & 1) == 0 && rt == MIPS_REG_ZERO) {
 			// Don't load anything into $zr
 			return;
 		}
+
+		CheckMemoryBreakpoint(0, rs, offset);
 
 		switch (o)
 		{
@@ -334,6 +337,7 @@ namespace MIPSComp {
 				u32 desiredOp = ((op & 0xFFFF0000) + (4 << 26)) + (offset - 3);
 				if (!js.inDelaySlot && nextOp == desiredOp && !jo.Disabled(JitDisable::LSU_UNALIGNED))
 				{
+					CheckMemoryBreakpoint(1, rs, offset - 3);
 					EatInstruction(nextOp);
 					// nextOp has the correct address.
 					CompITypeMemRead(nextOp, 32, &XEmitter::MOVZX, safeMemFuncs.readU32);
@@ -350,6 +354,7 @@ namespace MIPSComp {
 				u32 desiredOp = ((op & 0xFFFF0000) - (4 << 26)) + (offset + 3);
 				if (!js.inDelaySlot && nextOp == desiredOp && !jo.Disabled(JitDisable::LSU_UNALIGNED))
 				{
+					CheckMemoryBreakpoint(1, rs, offset + 3);
 					EatInstruction(nextOp);
 					// op has the correct address.
 					CompITypeMemRead(op, 32, &XEmitter::MOVZX, safeMemFuncs.readU32);
@@ -366,6 +371,7 @@ namespace MIPSComp {
 				u32 desiredOp = ((op & 0xFFFF0000) + (4 << 26)) + (offset - 3);
 				if (!js.inDelaySlot && nextOp == desiredOp && !jo.Disabled(JitDisable::LSU_UNALIGNED))
 				{
+					CheckMemoryBreakpoint(1, rs, offset - 3);
 					EatInstruction(nextOp);
 					// nextOp has the correct address.
 					CompITypeMemWrite(nextOp, 32, safeMemFuncs.writeU32);
@@ -382,6 +388,7 @@ namespace MIPSComp {
 				u32 desiredOp = ((op & 0xFFFF0000) - (4 << 26)) + (offset + 3);
 				if (!js.inDelaySlot && nextOp == desiredOp && !jo.Disabled(JitDisable::LSU_UNALIGNED))
 				{
+					CheckMemoryBreakpoint(1, rs, offset + 3);
 					EatInstruction(nextOp);
 					// op has the correct address.
 					CompITypeMemWrite(op, 32, safeMemFuncs.writeU32);

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -245,6 +245,8 @@ void Jit::Comp_SV(MIPSOpcode op) {
 	int vt = ((op >> 16) & 0x1f) | ((op & 3) << 5);
 	MIPSGPReg rs = _RS;
 
+	CheckMemoryBreakpoint(0, rs, imm);
+
 	switch (op >> 26) {
 	case 50: //lv.s  // VI(vt) = Memory::Read_U32(addr);
 		{
@@ -299,6 +301,8 @@ void Jit::Comp_SVQ(MIPSOpcode op) {
 	int imm = (signed short)(op&0xFFFC);
 	int vt = (((op >> 16) & 0x1f)) | ((op&1) << 5);
 	MIPSGPReg rs = _RS;
+
+	CheckMemoryBreakpoint(0, rs, imm);
 
 	switch (op >> 26) {
 	case 53: //lvl.q/lvr.q

--- a/Core/MIPS/x86/Jit.h
+++ b/Core/MIPS/x86/Jit.h
@@ -204,6 +204,7 @@ private:
 //	void WriteRfiExitDestInEAX();
 	void WriteSyscallExit();
 	bool CheckJitBreakpoint(u32 addr, int downcountOffset);
+	void CheckMemoryBreakpoint(int instructionOffset, MIPSGPReg rs, int offset);
 
 	// Utility compilation functions
 	void BranchFPFlag(MIPSOpcode op, Gen::CCFlags cc, bool likely);
@@ -242,8 +243,8 @@ private:
 
 	void CallProtectedFunction(const void *func, const Gen::OpArg &arg1);
 	void CallProtectedFunction(const void *func, const Gen::OpArg &arg1, const Gen::OpArg &arg2);
-	void CallProtectedFunction(const void *func, const u32 arg1, const u32 arg2, const u32 arg3);
-	void CallProtectedFunction(const void *func, const Gen::OpArg &arg1, const u32 arg2, const u32 arg3);
+	void CallProtectedFunction(const void *func, const Gen::OpArg &arg1, const u32 arg2);
+	void CallProtectedFunction(const void *func, const u32 arg1, const u32 arg2);
 
 	template <typename Tr, typename T1>
 	void CallProtectedFunction(Tr (*func)(T1), const Gen::OpArg &arg1) {
@@ -255,14 +256,14 @@ private:
 		CallProtectedFunction((const void *)func, arg1, arg2);
 	}
 
-	template <typename Tr, typename T1, typename T2, typename T3>
-	void CallProtectedFunction(Tr (*func)(T1, T2, T3), const u32 arg1, const u32 arg2, const u32 arg3) {
-		CallProtectedFunction((const void *)func, arg1, arg2, arg3);
+	template <typename Tr, typename T1, typename T2>
+	void CallProtectedFunction(Tr(*func)(T1, T2), const Gen::OpArg &arg1, const u32 arg2) {
+		CallProtectedFunction((const void *)func, arg1, arg2);
 	}
 
-	template <typename Tr, typename T1, typename T2, typename T3>
-	void CallProtectedFunction(Tr (*func)(T1, T2, T3), const Gen::OpArg &arg1, const u32 arg2, const u32 arg3) {
-		CallProtectedFunction((const void *)func, arg1, arg2, arg3);
+	template <typename Tr, typename T1, typename T2>
+	void CallProtectedFunction(Tr(*func)(T1, T2), const u32 arg1, const u32 arg2) {
+		CallProtectedFunction((const void *)func, arg1, arg2);
 	}
 
 	bool PredictTakeBranch(u32 targetAddr, bool likely);

--- a/Core/MIPS/x86/JitSafeMem.cpp
+++ b/Core/MIPS/x86/JitSafeMem.cpp
@@ -33,24 +33,6 @@ namespace MIPSComp
 using namespace Gen;
 using namespace X64JitConstants;
 
-void JitMemCheck(u32 addr, int size, int isWrite)
-{
-	// Should we skip this breakpoint?
-	if (CBreakPoints::CheckSkipFirst() == currentMIPS->pc)
-		return;
-
-	// Did we already hit one?
-	if (coreState != CORE_RUNNING && coreState != CORE_NEXTFRAME)
-		return;
-
-	CBreakPoints::ExecMemCheckJitBefore(addr, isWrite == 1, size, currentMIPS->pc);
-}
-
-void JitMemCheckCleanup()
-{
-	CBreakPoints::ExecMemCheckJitCleanup();
-}
-
 JitSafeMem::JitSafeMem(Jit *jit, MIPSGPReg raddr, s32 offset, u32 alignMask)
 	: jit_(jit), raddr_(raddr), offset_(offset), needsCheck_(false), needsSkip_(false), alignMask_(alignMask)
 {
@@ -77,7 +59,6 @@ bool JitSafeMem::PrepareWrite(OpArg &dest, int size)
 	{
 		if (ImmValid())
 		{
-			MemCheckImm(MEM_WRITE);
 			u32 addr = (iaddr_ & alignMask_);
 #ifdef MASKED_PSP_MEMORY
 			addr &= Memory::MEMVIEW32_MASK;
@@ -106,7 +87,6 @@ bool JitSafeMem::PrepareRead(OpArg &src, int size)
 	{
 		if (ImmValid())
 		{
-			MemCheckImm(MEM_READ);
 			u32 addr = (iaddr_ & alignMask_);
 #ifdef MASKED_PSP_MEMORY
 			addr &= Memory::MEMVIEW32_MASK;
@@ -173,8 +153,6 @@ OpArg JitSafeMem::PrepareMemoryOpArg(MemoryOpType type)
 		jit_->MOV(32, R(EAX), jit_->gpr.R(raddr_));
 		xaddr_ = EAX;
 	}
-
-	MemCheckAsm(type);
 
 	if (!fast_)
 	{
@@ -375,85 +353,6 @@ void JitSafeMem::Finish()
 		jit_->SetJumpTarget(skip_);
 	for (auto it = skipChecks_.begin(), end = skipChecks_.end(); it != end; ++it)
 		jit_->SetJumpTarget(*it);
-}
-
-void JitSafeMem::MemCheckImm(MemoryOpType type) {
-	MemCheck check;
-	if (CBreakPoints::GetMemCheckInRange(iaddr_, size_, &check)) {
-		if (!(check.cond & MEMCHECK_READ) && type == MEM_READ)
-			return;
-		if (!(check.cond & MEMCHECK_WRITE) && type == MEM_WRITE)
-			return;
-
-		jit_->MOV(32, MIPSSTATE_VAR(pc), Imm32(jit_->GetCompilerPC()));
-		jit_->CallProtectedFunction(&JitMemCheck, iaddr_, size_, type == MEM_WRITE ? 1 : 0);
-
-		// CORE_RUNNING is <= CORE_NEXTFRAME.
-		if (jit_->RipAccessible((const void *)&coreState)) {
-			jit_->CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));  // rip accessible
-		} else {
-			// We can't safely overwrite any register, so push.  This is only while debugging.
-			jit_->PUSH(RAX);
-			jit_->MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
-			jit_->CMP(32, MatR(RAX), Imm32(CORE_NEXTFRAME));
-			jit_->POP(RAX);
-		}
-		skipChecks_.push_back(jit_->J_CC(CC_G, true));
-		jit_->js.afterOp |= JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE | JitState::AFTER_MEMCHECK_CLEANUP;
-	}
-}
-
-void JitSafeMem::MemCheckAsm(MemoryOpType type) {
-	const auto memchecks = CBreakPoints::GetMemCheckRanges(type == MEM_WRITE);
-	bool possible = !memchecks.empty();
-	std::vector<FixupBranch> hitChecks;
-	for (auto it = memchecks.begin(), end = memchecks.end(); it != end; ++it) {
-		if (it->end != 0) {
-			jit_->CMP(32, R(xaddr_), Imm32(it->start - offset_ - size_));
-			FixupBranch skipNext = jit_->J_CC(CC_BE);
-
-			jit_->CMP(32, R(xaddr_), Imm32(it->end - offset_));
-			hitChecks.push_back(jit_->J_CC(CC_B, true));
-
-			jit_->SetJumpTarget(skipNext);
-		} else {
-			jit_->CMP(32, R(xaddr_), Imm32(it->start - offset_));
-			hitChecks.push_back(jit_->J_CC(CC_E, true));
-		}
-	}
-
-	if (possible) {
-		FixupBranch noHits = jit_->J(true);
-
-		// Okay, now land any hit here.
-		for (auto &fixup : hitChecks)
-			jit_->SetJumpTarget(fixup);
-		hitChecks.clear();
-
-		jit_->PUSH(xaddr_);
-		// Keep the stack 16-byte aligned.
-		jit_->SUB(PTRBITS, R(SP), Imm32(16 - PTRBITS / 8));
-		jit_->MOV(32, MIPSSTATE_VAR(pc), Imm32(jit_->GetCompilerPC()));
-		jit_->ADD(32, R(xaddr_), Imm32(offset_));
-		jit_->CallProtectedFunction(&JitMemCheck, R(xaddr_), size_, type == MEM_WRITE ? 1 : 0);
-		jit_->ADD(PTRBITS, R(SP), Imm32(16 - PTRBITS / 8));
-		jit_->POP(xaddr_);
-
-		// CORE_RUNNING is <= CORE_NEXTFRAME.
-		if (jit_->RipAccessible((const void *)&coreState)) {
-			jit_->CMP(32, M(&coreState), Imm32(CORE_NEXTFRAME));  // rip accessible
-		} else {
-			// We can't safely overwrite any register, so push.  This is only while debugging.
-			jit_->PUSH(RAX);
-			jit_->MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
-			jit_->CMP(32, MatR(RAX), Imm32(CORE_NEXTFRAME));
-			jit_->POP(RAX);
-		}
-		skipChecks_.push_back(jit_->J_CC(CC_G, true));
-		jit_->js.afterOp |= JitState::AFTER_CORE_STATE | JitState::AFTER_REWIND_PC_BAD_STATE | JitState::AFTER_MEMCHECK_CLEANUP;
-
-		jit_->SetJumpTarget(noHits);
-	}
 }
 
 static const int FUNCS_ARENA_SIZE = 512 * 1024;

--- a/Core/MIPS/x86/JitSafeMem.h
+++ b/Core/MIPS/x86/JitSafeMem.h
@@ -69,8 +69,6 @@ private:
 
 	Gen::OpArg PrepareMemoryOpArg(MemoryOpType type);
 	void PrepareSlowAccess();
-	void MemCheckImm(MemoryOpType type);
-	void MemCheckAsm(MemoryOpType type);
 	bool ImmValid();
 	void IndirectCALL(const void *safeFunc);
 

--- a/Windows/Debugger/BreakpointWindow.h
+++ b/Windows/Debugger/BreakpointWindow.h
@@ -44,7 +44,7 @@ public:
 	bool isMemoryBreakpoint() { return memory; };
 
 	void addBreakpoint();
-	void loadFromMemcheck(MemCheck& memcheck);
-	void loadFromBreakpoint(BreakPoint& memcheck);
+	void loadFromMemcheck(const MemCheck &memcheck);
+	void loadFromBreakpoint(const BreakPoint &bp);
 	void initBreakpoint(u32 address);
 };

--- a/Windows/Debugger/BreakpointWindow.h
+++ b/Windows/Debugger/BreakpointWindow.h
@@ -22,9 +22,11 @@ class BreakpointWindow
 	std::string logFormat;
 	PostfixExpression compiledCondition;
 
-	static BreakpointWindow* bp;
 	bool fetchDialogData(HWND hwnd);
 	bool GetCheckState(HWND hwnd, int dlgItem);
+
+	static INT_PTR CALLBACK StaticDlgFunc(HWND hWnd, UINT iMsg, WPARAM wParam, LPARAM lParam);
+	INT_PTR DlgFunc(HWND hWnd, UINT iMsg, WPARAM wParam, LPARAM lParam);
 
 public:
 	BreakpointWindow(HWND parent, DebugInterface* cpu): cpu(cpu)
@@ -38,8 +40,6 @@ public:
 		size = 1;
 	};
 
-
-	static INT_PTR CALLBACK dlgFunc(HWND hWnd, UINT iMsg, WPARAM wParam, LPARAM lParam);
 	bool exec();
 	bool isMemoryBreakpoint() { return memory; };
 


### PR DESCRIPTION
This makes it possible to set an expression condition on any memory breakpoint.  It also fixes log using outdated values of registers in jit when a memory breakpoint is hit (for non-change breakpoints.)

-[Unknown]