### PR TITLE
OpenGL texture filtering: enforce key.mipEnable when we're forcing mip filtering on.

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -256,6 +256,7 @@ SamplerCacheKey TextureCacheCommon::GetSamplingParams(int maxLevel, const TexCac
 	if (entry && replacer_.Enabled() && entry->replacedTexture && entry->replacedTexture->State() == ReplacementState::ACTIVE) {
 		// If replacement textures have multiple mip levels, enforce mip filtering.
 		if (entry->replacedTexture->NumLevels() > 1) {
+			key.mipEnable = true;
 			key.mipFilt = 1;
 			key.maxLevel = 9 * 256;
 		}


### PR DESCRIPTION
Fixes #17268, but I feel we could possibly get rid of the bool entirely since we have maxlevel. Only GL and D3D even looks at this flag.

Oh well, that's for later.