### PR TITLE
Remove confusing setting fAnalogLimiterDeadzone

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -680,8 +680,6 @@ static const ConfigSetting controlSettings[] = {
 	ConfigSetting("AnalogIsCircular", &g_Config.bAnalogIsCircular, false, CfgFlag::PER_GAME),
 	ConfigSetting("AnalogAutoRotSpeed", &g_Config.fAnalogAutoRotSpeed, 8.0f, CfgFlag::PER_GAME),
 
-	ConfigSetting("AnalogLimiterDeadzone", &g_Config.fAnalogLimiterDeadzone, 0.25f, CfgFlag::DEFAULT),
-
 	ConfigSetting("LeftStickHeadScale", &g_Config.fLeftStickHeadScale, 1.0f, CfgFlag::PER_GAME),
 	ConfigSetting("RightStickHeadScale", &g_Config.fRightStickHeadScale, 1.0f, CfgFlag::PER_GAME),
 	ConfigSetting("HideStickBackground", &g_Config.bHideStickBackground, false, CfgFlag::PER_GAME),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -387,8 +387,6 @@ public:
 	// Auto rotation speed
 	float fAnalogAutoRotSpeed;
 
-	float fAnalogLimiterDeadzone;
-
 	bool bMouseControl;
 	bool bMapMouse; // Workaround for mapping screen:|
 	bool bMouseConfine; // Trap inside the window.

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -769,8 +769,8 @@ void EmuScreen::onVKeyAnalog(int virtualKeyCode, float value) {
 
 	// Xbox controllers need a pretty big deadzone here to not leave behind small values
 	// on occasion when releasing the trigger. Still feels right.
-	float DEADZONE_THRESHOLD = g_Config.fAnalogLimiterDeadzone;
-	float DEADZONE_SCALE = 1.0f / (1.0f - DEADZONE_THRESHOLD);
+	constexpr float DEADZONE_THRESHOLD = 0.2f;
+	constexpr float DEADZONE_SCALE = 1.0f / (1.0f - DEADZONE_THRESHOLD);
 
 	FPSLimit &limitMode = PSP_CoreParameter().fpsLimit;
 	// If we're using an alternate speed already, let that win.

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -760,12 +760,6 @@ void GameSettingsScreen::CreateControlsSettings(UI::ViewGroup *controlsSettings)
 #if defined(USING_WIN_UI)
 		controlsSettings->Add(new CheckBox(&g_Config.bIgnoreWindowsKey, co->T("Ignore Windows Key")));
 #endif // #if defined(USING_WIN_UI)
-		auto analogLimiter = new PopupSliderChoiceFloat(&g_Config.fAnalogLimiterDeadzone, 0.0f, 1.0f, 0.6f, co->T("Analog Limiter"), 0.10f, screenManager(), "/ 1.0");
-		controlsSettings->Add(analogLimiter);
-		analogLimiter->OnChange.Add([=](EventParams &e) {
-			settingInfo_->Show(co->T("AnalogLimiter Tip", "When the analog limiter button is pressed"), e.v);
-			return UI::EVENT_CONTINUE;
-		});
 #if defined(USING_WIN_UI) || defined(SDL)
 		controlsSettings->Add(new ItemHeader(co->T("Mouse", "Mouse settings")));
 		CheckBox *mouseControl = controlsSettings->Add(new CheckBox(&g_Config.bMouseControl, co->T("Use Mouse Control")));


### PR DESCRIPTION
As mentioned in comments for #17286 , there was some confusion about this setting.

Let's just get rid of it instead.