### PR TITLE
Properly fix the analog limiter feature ("lightly").

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -680,7 +680,7 @@ static const ConfigSetting controlSettings[] = {
 	ConfigSetting("AnalogIsCircular", &g_Config.bAnalogIsCircular, false, CfgFlag::PER_GAME),
 	ConfigSetting("AnalogAutoRotSpeed", &g_Config.fAnalogAutoRotSpeed, 8.0f, CfgFlag::PER_GAME),
 
-	ConfigSetting("AnalogLimiterDeadzone", &g_Config.fAnalogLimiterDeadzone, 0.25f, CfgFlag::DEFAULT),
+	ConfigSetting("AnalogLimiterDeadzone", &g_Config.fAnalogLimiterDeadzone, 0.6f, CfgFlag::DEFAULT),
 
 	ConfigSetting("LeftStickHeadScale", &g_Config.fLeftStickHeadScale, 1.0f, CfgFlag::PER_GAME),
 	ConfigSetting("RightStickHeadScale", &g_Config.fRightStickHeadScale, 1.0f, CfgFlag::PER_GAME),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -387,6 +387,7 @@ public:
 	// Auto rotation speed
 	float fAnalogAutoRotSpeed;
 
+	// Sets up how much the analog limiter button restricts digital->analog input.
 	float fAnalogLimiterDeadzone;
 
 	bool bMouseControl;

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -39,12 +39,14 @@ private:
 	float MapAxisValue(float value, int vkId, const InputMapping &mapping, const InputMapping &changedMapping, bool *oppositeTouched);
 
 	void SetPSPAxis(int deviceId, int stick, char axis, float value);
+	void UpdateAnalogOutput(int stick);
 
 	void onVKey(int vkey, bool down);
 	void onVKeyAnalog(int deviceId, int vkey, float value);
 
 	// To track mappable virtual keys. We can have as many as we want.
 	float virtKeys_[VIRTKEY_COUNT]{};
+	bool virtKeyOn_[VIRTKEY_COUNT]{};  // Track boolean output separaately since thresholds may differ.
 
 	int lastNonDeadzoneDeviceID_[2]{};
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -769,8 +769,8 @@ void EmuScreen::onVKeyAnalog(int virtualKeyCode, float value) {
 
 	// Xbox controllers need a pretty big deadzone here to not leave behind small values
 	// on occasion when releasing the trigger. Still feels right.
-	float DEADZONE_THRESHOLD = g_Config.fAnalogLimiterDeadzone;
-	float DEADZONE_SCALE = 1.0f / (1.0f - DEADZONE_THRESHOLD);
+	static constexpr float DEADZONE_THRESHOLD = 0.2f;
+	static constexpr float DEADZONE_SCALE = 1.0f / (1.0f - DEADZONE_THRESHOLD);
 
 	FPSLimit &limitMode = PSP_CoreParameter().fpsLimit;
 	// If we're using an alternate speed already, let that win.


### PR DESCRIPTION
This got lost in the big refactoring, and then ended up with some confusion (see #17286 ). 

Need to apply the multiplier after the deadzone processing, since otherwise it'll get watered down by the deadzone etc. Also need to retrigger the computation if you press the shift key, needing another flag in the big processing loop.