### PR TITLE
Camera on Android: Choose the preview framerate closest to 30fps.

### DIFF
--- a/android/src/org/ppsspp/ppsspp/CameraHelper.java
+++ b/android/src/org/ppsspp/ppsspp/CameraHelper.java
@@ -224,19 +224,35 @@ class CameraHelper {
 				throw new Exception("Couldn't find a viable preview size");
 			}
 
-			Log.d(TAG, "setPreviewSize(" + mPreviewSize.width + ", " + mPreviewSize.height + ")");
+			Log.i(TAG, "setPreviewSize(" + mPreviewSize.width + ", " + mPreviewSize.height + ")");
 			param.setPreviewSize(mPreviewSize.width, mPreviewSize.height);
 
 			// Set preview FPS
-			int[] fps;
 			List<int[]> previewFps = param.getSupportedPreviewFpsRange();
-			fps = previewFps.get(0);
+
+			int idealRate = 30000;
+
+			int bestIndex = -1;
+			int bestDistance = 0;  // bestIndex is -1 so irrelevant what the initial value is here.
+
 			for (int i = 0; i < previewFps.size(); i++) {
-				Log.d(TAG, "getSupportedPreviewFpsRange[" + i + "]: " + previewFps.get(i)[0] + " " + previewFps.get(i)[1]);
-				if (previewFps.get(i)[0] <= fps[0] && previewFps.get(i)[1] <= fps[1]) {
-					fps = previewFps.get(i);
+				int rangeStart = previewFps.get(i)[0];
+				int rangeEnd = previewFps.get(i)[1];
+				int distance = Integer.max(Math.abs(rangeStart - idealRate), Math.abs(rangeEnd - idealRate));
+
+				if (bestIndex == -1 || distance < bestDistance) {
+					bestDistance = distance;
+					bestIndex = i;
 				}
+				Log.d(TAG, "getSupportedPreviewFpsRange[" + i + "]: " + previewFps.get(i)[0] + " " + previewFps.get(i)[1]);
 			}
+
+			if (bestIndex == -1) {
+				// This is pretty much impossible.
+				throw new Exception("Couldn't find a viable preview FPS");
+			}
+
+			int[] fps = previewFps.get(bestIndex);
 			Log.d(TAG, "setPreviewFpsRange(" + fps[0] + ", " + fps[1] + ")");
 			param.setPreviewFpsRange(fps[0], fps[1]);
 

--- a/android/src/org/ppsspp/ppsspp/CameraHelper.java
+++ b/android/src/org/ppsspp/ppsspp/CameraHelper.java
@@ -126,9 +126,9 @@ class CameraHelper {
 	private Camera.PreviewCallback mPreviewCallback = new Camera.PreviewCallback() {
 		@Override
 		public void onPreviewFrame(byte[] previewData, Camera camera) {
-			// throttle at 66 ms
+			// throttle at 16 ms
 			long currentTime = SystemClock.elapsedRealtime();
-			if (currentTime - mLastFrameTime < 66) {
+			if (currentTime - mLastFrameTime < 16) {
 				return;
 			}
 			mLastFrameTime = currentTime;


### PR DESCRIPTION
For some reason, we were previously choosing the slowest available rate. Might be very slow on some devices.

Also found that we are throttling the preview images a bit excessively. Fixing this make camera games run a lot smoother on my Poco F1.

Might help #17283