### PR TITLE
Optimize lighting for softgpu a bit

### DIFF
--- a/GPU/Software/BinManager.cpp
+++ b/GPU/Software/BinManager.cpp
@@ -368,8 +368,9 @@ void BinManager::UpdateClut(const void *src) {
 	PROFILE_THIS_SCOPE("bin_clut");
 	if (cluts_.Full())
 		Flush("cluts");
-	clutIndex_ = (uint16_t)cluts_.Push(BinClut());
-	memcpy(cluts_[clutIndex_].readable, src, sizeof(BinClut));
+	BinClut &clut = cluts_.PeekPush();
+	memcpy(clut.readable, src, sizeof(BinClut));
+	clutIndex_ = (uint16_t)cluts_.PushPeeked();
 }
 
 void BinManager::AddTriangle(const VertexData &v0, const VertexData &v1, const VertexData &v2) {

--- a/GPU/Software/BinManager.h
+++ b/GPU/Software/BinManager.h
@@ -117,11 +117,12 @@ struct BinQueue {
 		return items_[tail_];
 	}
 
-	void PushPeeked() {
+	size_t PushPeeked() {
 		size_t i = tail_++;
 		if (i + 1 == N)
 			tail_ -= N;
 		size_++;
+		return i;
 	}
 
 	size_t Size() const {

--- a/GPU/Software/Lighting.cpp
+++ b/GPU/Software/Lighting.cpp
@@ -86,6 +86,7 @@ void ComputeState(State *state, bool hasColor0) {
 	bool anyAmbient = false;
 	bool anyDiffuse = false;
 	bool anySpecular = false;
+	bool anyDirectional = false;
 	for (int light = 0; light < 4; ++light) {
 		auto &lstate = state->lights[light];
 		lstate.enabled = gstate.isLightChanEnabled(light);
@@ -112,10 +113,12 @@ void ComputeState(State *state, bool hasColor0) {
 		}
 
 		lstate.pos = GetLightVec(gstate.lpos, light);
-		if (lstate.directional)
+		if (lstate.directional) {
 			lstate.pos.NormalizeOr001();
-		else
+			anyDirectional = true;
+		} else {
 			lstate.att = GetLightVec(gstate.latt, light);
+		}
 
 		if (lstate.spot) {
 			lstate.spotDir = GetLightVec(gstate.ldir, light);
@@ -174,6 +177,8 @@ void ComputeState(State *state, bool hasColor0) {
 	state->baseAmbientColorFactor = LightColorFactor(gstate.getAmbientRGBA(), ones);
 	state->setColor1 = gstate.isUsingSecondaryColor() && anySpecular;
 	state->addColor1 = !gstate.isUsingSecondaryColor() && anySpecular;
+	state->usesWorldPos = anyDirectional;
+	state->usesWorldNormal = gstate.getUVGenMode() == GE_TEXMAP_ENVIRONMENT_MAP || anyDiffuse || anySpecular;
 }
 
 static inline float GenerateLightCoord(VertexData &vertex, const WorldCoords &worldnormal, int light) {

--- a/GPU/Software/Lighting.h
+++ b/GPU/Software/Lighting.h
@@ -60,6 +60,8 @@ struct State {
 		bool colorForSpecular : 1;
 		bool setColor1 : 1;
 		bool addColor1 : 1;
+		bool usesWorldPos : 1;
+		bool usesWorldNormal : 1;
 	};
 };
 

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -273,12 +273,9 @@ void ComputeTransformState(TransformState *state, const VertexReader &vreader) {
 		bool canSkipWorldPos = true;
 		if (state->enableLighting) {
 			Lighting::ComputeState(&state->lightingState, vreader.hasColor0());
-			for (int i = 0; i < 4; ++i) {
-				if (!state->lightingState.lights[i].enabled)
-					continue;
-				if (!state->lightingState.lights[i].directional)
-					canSkipWorldPos = false;
-			}
+			canSkipWorldPos = !state->lightingState.usesWorldPos;
+		} else {
+			state->lightingState.usesWorldNormal = state->uvGenMode == GE_TEXMAP_ENVIRONMENT_MAP;
 		}
 
 		float world[16];
@@ -412,7 +409,7 @@ ClipVertexData TransformUnit::ReadVertex(const VertexReader &vreader, const Tran
 		vertex.v.clipw = vertex.clippos.w;
 
 		Vec3<float> worldnormal;
-		if (state.enableLighting || state.uvGenMode == GE_TEXMAP_ENVIRONMENT_MAP) {
+		if (state.lightingState.usesWorldNormal) {
 			worldnormal = TransformUnit::ModelToWorldNormal(normal);
 			worldnormal.NormalizeOr001();
 		}


### PR DESCRIPTION
This ends up only improving FPS by maybe 1-2% for games that push more verts, and it can vary.  Although it's faster, some of the time is just traded by waiting for the drawing threads to complete their background work.

Still, it's good to reduce this as it's a bottleneck in some scenes.  May help the tradeoffs of some vector (4 pixels at a time) stuff I tried a while back.

-[Unknown]