### PR TITLE
x86jit: Correct wrong PC after bad mem access, other minor

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -462,7 +462,7 @@ void Core_MemoryException(u32 address, u32 accessSize, u32 pc, MemoryExceptionTy
 	}
 }
 
-void Core_MemoryExceptionInfo(u32 address, u32 pc, u32 accessSize, MemoryExceptionType type, std::string additionalInfo, bool forceReport) {
+void Core_MemoryExceptionInfo(u32 address, u32 accessSize, u32 pc, MemoryExceptionType type, std::string additionalInfo, bool forceReport) {
 	const char *desc = MemoryExceptionTypeAsString(type);
 	// In jit, we only flush PC when bIgnoreBadMemAccess is off.
 	if (g_Config.iCpuCore == (int)CPUCore::JIT && g_Config.bIgnoreBadMemAccess) {
@@ -483,6 +483,7 @@ void Core_MemoryExceptionInfo(u32 address, u32 pc, u32 accessSize, MemoryExcepti
 		e.info = additionalInfo;
 		e.memory_type = type;
 		e.address = address;
+		e.accessSize = accessSize;
 		e.stackTrace = stackTrace;
 		e.pc = pc;
 		Core_EnableStepping(true, "memory.exception", address);

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -794,10 +794,11 @@ size_t hleFormatLogArgs(char *message, size_t sz, const char *argmask) {
 		case 's':
 			if (Memory::IsValidAddress(regval)) {
 				const char *s = Memory::GetCharPointer(regval);
-				if (strnlen(s, 64) >= 64) {
-					APPEND_FMT("%.64s...", Memory::GetCharPointer(regval));
+				const int safeLen = Memory::ValidSize(regval, 128);
+				if (strnlen(s, safeLen) >= safeLen) {
+					APPEND_FMT("%.*s...", safeLen, Memory::GetCharPointer(regval));
 				} else {
-					APPEND_FMT("%s", Memory::GetCharPointer(regval));
+					APPEND_FMT("%.*s", safeLen, Memory::GetCharPointer(regval));
 				}
 			} else {
 				APPEND_FMT("(invalid)");

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -884,7 +884,7 @@ void PSPModule::Cleanup() {
 	}
 }
 
-static void __SaveDecryptedEbootToStorageMedia(const u8 *decryptedEbootDataPtr, const u32 length) {
+static void SaveDecryptedEbootToStorageMedia(const u8 *decryptedEbootDataPtr, const u32 length, const char *name) {
 	if (!decryptedEbootDataPtr) {
 		ERROR_LOG(SCEMODULE, "Error saving decrypted EBOOT.BIN: invalid pointer");
 		return;
@@ -895,7 +895,7 @@ static void __SaveDecryptedEbootToStorageMedia(const u8 *decryptedEbootDataPtr, 
 		return;
 	}
 
-	const std::string filenameToDumpTo = g_paramSFO.GetDiscID() + ".BIN";
+	const std::string filenameToDumpTo = StringFromFormat("%s_%s.BIN", g_paramSFO.GetDiscID().c_str(), name);
 	const Path dumpDirectory = GetSysDirectory(DIRECTORY_DUMP);
 	const Path fullPath = dumpDirectory / filenameToDumpTo;
 
@@ -1264,9 +1264,10 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 
 			// If we've made it this far, it should be safe to dump.
 			if (g_Config.bDumpDecryptedEboot) {
-				INFO_LOG(SCEMODULE, "Dumping decrypted EBOOT.BIN to file.");
-				const u32 dumpLength = ret;
-				__SaveDecryptedEbootToStorageMedia(ptr, dumpLength);
+				// Copy the name to ensure it's null terminated.
+				char name[32]{};
+				strncpy(name, head->modname, ARRAY_SIZE(head->modname));
+				SaveDecryptedEbootToStorageMedia(ptr, elfSize, name);
 			}
 		}
 	}

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -390,7 +390,7 @@ const u8 *Jit::DoJit(u32 em_address, JitBlock *b) {
 				CMP(32, MatR(RAX), Imm32(CORE_NEXTFRAME));
 			}
 			FixupBranch skipCheck = J_CC(CC_LE, true);
-			MOV(32, MIPSSTATE_VAR(pc), Imm32(GetCompilerPC() + 4));
+			// All cases of AFTER_CORE_STATE should update PC.  We don't update here.
 			RegCacheState state;
 			GetStateAndFlushAll(state);
 			WriteSyscallExit();
@@ -697,7 +697,7 @@ void Jit::WriteExit(u32 destination, int exit_num) {
 			CMP(32, MatR(RAX), Imm32(CORE_NEXTFRAME));
 		}
 		FixupBranch skipCheck = J_CC(CC_LE);
-		MOV(32, MIPSSTATE_VAR(pc), Imm32(GetCompilerPC()));
+		// All cases of AFTER_CORE_STATE should update PC.  We don't update here.
 		WriteSyscallExit();
 		SetJumpTarget(skipCheck);
 	}
@@ -753,7 +753,7 @@ void Jit::WriteExitDestInReg(X64Reg reg) {
 			CMP(32, MatR(temp), Imm32(CORE_NEXTFRAME));
 		}
 		FixupBranch skipCheck = J_CC(CC_LE);
-		MOV(32, MIPSSTATE_VAR(pc), Imm32(GetCompilerPC()));
+		// All cases of AFTER_CORE_STATE should update PC.  We don't update here.
 		WriteSyscallExit();
 		SetJumpTarget(skipCheck);
 	}


### PR DESCRIPTION
In 0f585951, I broke the PC after resume for a bad memory access when fast memory is off.

Also some minor cleanup related to debugger features.

-[Unknown]