### PR TITLE
Workaround for some SOCOM games' misuse of CLUT8 to texture from framebuffer

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -130,6 +130,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "BlockTransferDepth", &flags_.BlockTransferDepth);
 	CheckSetting(iniFile, gameID, "DaxterRotatedAnalogStick", &flags_.DaxterRotatedAnalogStick);
 	CheckSetting(iniFile, gameID, "ForceMaxDepthResolution", &flags_.ForceMaxDepthResolution);
+	CheckSetting(iniFile, gameID, "SOCOMClut8Replacement", &flags_.SOCOMClut8Replacement);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -100,6 +100,7 @@ struct CompatFlags {
 	bool BlockTransferDepth;
 	bool DaxterRotatedAnalogStick;
 	bool ForceMaxDepthResolution;
+	bool SOCOMClut8Replacement;
 };
 
 struct VRCompat {

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -111,6 +111,13 @@ void GenerateDepalShader300(ShaderWriter &writer, const DepalConfig &config) {
 		if (shiftedMask & 0x7C00) writer.C("  int b = int(color.b * 31.99);\n"); else writer.C("  int b = 0;\n");
 		if (shiftedMask & 0x8000) writer.C("  int a = int(color.a);\n"); else writer.C("  int a = 0;\n");
 		writer.C("  int index = (a << 15) | (b << 10) | (g << 5) | (r);\n");
+
+		if (config.textureFormat == GE_TFMT_CLUT8) {
+			// SOCOM case. #16210
+			// To debug the issue, remove this shift to see the texture (check for clamping etc).
+			writer.C("  index >>= 8;\n");
+		}
+
 		break;
 	case GE_FORMAT_DEPTH16:
 		// Decode depth buffer.

--- a/GPU/Common/Draw2D.cpp
+++ b/GPU/Common/Draw2D.cpp
@@ -261,7 +261,7 @@ Draw2DPipeline *Draw2D::Create2DPipeline(std::function<Draw2DPipelineInfo (Shade
 
 	ShaderModule *fs = draw_->CreateShaderModule(ShaderStage::Fragment, shaderLanguageDesc.shaderLanguage, (const uint8_t *)fsCode, strlen(fsCode), info.tag);
 
-	_assert_(fs);
+	_assert_msg_(fs, "Failed to create shader module!\n%s", fsCode);
 
 	// verts have positions in 2D clip coordinates.
 	static const InputLayoutDesc desc = {

--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -48,6 +48,25 @@
 #define DO_NOT_VECTORIZE_LOOP
 #endif
 
+const u8 textureBitsPerPixel[16] = {
+	16,  //GE_TFMT_5650,
+	16,  //GE_TFMT_5551,
+	16,  //GE_TFMT_4444,
+	32,  //GE_TFMT_8888,
+	4,   //GE_TFMT_CLUT4,
+	8,   //GE_TFMT_CLUT8,
+	16,  //GE_TFMT_CLUT16,
+	32,  //GE_TFMT_CLUT32,
+	4,   //GE_TFMT_DXT1,
+	8,   //GE_TFMT_DXT3,
+	8,   //GE_TFMT_DXT5,
+	0,   // INVALID,
+	0,   // INVALID,
+	0,   // INVALID,
+	0,   // INVALID,
+	0,   // INVALID,
+};
+
 #ifdef _M_SSE
 
 static u32 QuickTexHashSSE2(const void *checkp, u32 size) {

--- a/GPU/Common/TextureDecoder.h
+++ b/GPU/Common/TextureDecoder.h
@@ -73,26 +73,15 @@ uint32_t GetDXT1Texel(const DXT1Block *src, int x, int y);
 uint32_t GetDXT3Texel(const DXT3Block *src, int x, int y);
 uint32_t GetDXT5Texel(const DXT5Block *src, int x, int y);
 
-static const u8 textureBitsPerPixel[16] = {
-	16,  //GE_TFMT_5650,
-	16,  //GE_TFMT_5551,
-	16,  //GE_TFMT_4444,
-	32,  //GE_TFMT_8888,
-	4,   //GE_TFMT_CLUT4,
-	8,   //GE_TFMT_CLUT8,
-	16,  //GE_TFMT_CLUT16,
-	32,  //GE_TFMT_CLUT32,
-	4,   //GE_TFMT_DXT1,
-	8,   //GE_TFMT_DXT3,
-	8,   //GE_TFMT_DXT5,
-	0,   // INVALID,
-	0,   // INVALID,
-	0,   // INVALID,
-	0,   // INVALID,
-	0,   // INVALID,
-};
+extern const u8 textureBitsPerPixel[16];
 
 u32 GetTextureBufw(int level, u32 texaddr, GETextureFormat format);
+
+// WARNING: Bits not bytes, this is needed due to the presence of 4 - bit formats.
+inline u32 TextureFormatBitsPerPixel(GETextureFormat format) {
+	u32 bits = textureBitsPerPixel[(int)format];
+	return bits != 0 ? bits : 1;  // Best to return 1 here to survive divisions in case of invalid data.
+}
 
 inline bool AlphaSumIsFull(u32 alphaSum, u32 fullAlphaMask) {
 	return fullAlphaMask != 0 && (alphaSum & fullAlphaMask) == fullAlphaMask;

--- a/GPU/GLES/ShaderManagerGLES.h
+++ b/GPU/GLES/ShaderManagerGLES.h
@@ -209,7 +209,7 @@ private:
 	GLRenderManager *render_;
 	LinkedShaderCache linkedShaderCache_;
 
-	bool lastVShaderSame_;
+	bool lastVShaderSame_ = false;
 
 	FShaderID lastFSID_;
 	VShaderID lastVSID_;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1555,3 +1555,16 @@ UCET00844 = true
 UCUS98705 = true
 UCED00971 = true
 UCUS98713 = true
+
+[SOCOMClut8Replacement]
+# SOCOM and other games use CLUT8 with crafty sampling as if it was CLUT16. Issue #16210
+UCES00855 = true
+UCUS98649 = true
+NPUG70003 = true  # demo
+UCUS98714 = true  # demo
+
+# SOCOM Fireteam Bravo 3
+UCES01242 = true
+NPHG00032 = true
+UCUS98716 = true
+NPEG90024 = true  # demo


### PR DESCRIPTION
Emulating this correctly would be possible too but would only work at 1x rendering resolution.

Quick summary: The game is doing a CLUT texture lookup from the main framebuffer, and adding the result on top of itself to do a super minor brightness adjustment (maybe different in different parts of the game). This isn't really legal but in practice works since it does it in vertical strips that match whatever cacheline size, etc etc.

Anyway, the bad part is that instead of using CLUT16 which is designed for what it's doing (treating a chosen 8 bits of each pixel of a 16-bit texture as a CLUT index and look it up), it instead configures the texture as a double-width CLUT8 texture, then carefully adjusts the texture coordinates and uses nearest filtering so that it that way picks up the correct half of every pixel. This doesn't work when rendering at higher resolutions, so instead, I'm here adding a compat flag to actually follow the intention of the game and treat the texture as CLUT16, which has the exact same effect, but will work at higher rendering resolution.

Previously we rejected this framebuffer texturing case, so instead it'd pickup whatever was in memory and draw that on top of the scene, which caused #16210.

I have to gate this behind the flag, so that we don't catch any other intentional use of this hacky trick.

(Pretty sure this code must have been ported from the PS2, ugh).

Fixes #16210 .