### PR TITLE
Don't try to present from little temp framebuffers used by Godfather to draw text

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1267,7 +1267,7 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 				// Copy the name to ensure it's null terminated.
 				char name[32]{};
 				strncpy(name, head->modname, ARRAY_SIZE(head->modname));
-				SaveDecryptedEbootToStorageMedia(ptr, elfSize, name);
+				SaveDecryptedEbootToStorageMedia(ptr, (u32)elfSize, name);
 			}
 		}
 	}

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1525,6 +1525,11 @@ void FramebufferManagerCommon::CopyDisplayToOutput(bool reallyDirty) {
 		}
 	}
 
+	// Reject too-tiny framebuffers to display (Godfather, see issue #16915).
+	if (vfb && vfb->height < 64) {
+		vfb = nullptr;
+	}
+
 	if (!vfb) {
 		if (Memory::IsValidAddress(fbaddr)) {
 			// The game is displaying something directly from RAM. In GTA, it's decoded video.


### PR DESCRIPTION
Helps #16915, but the text is kinda hard to read, which is probably a separate issue.

The framebuffer does contain the top of the video frame at the present time though, so things have partially gone well. However the rest of the video frame lies after it in VRAM, while also overlapping it. What we probably technically should do when we see this is to assemble an image from both the framebuffer we find and VRAM contents exceeding the range of that image, but seems kinda impractical.

This works, but as mentioned there seems to be some other issue with how the text is rendered or copied. Could be a color precision issue confusing the game I suppose.

Savestate for repro (ppdmp useless in this case): 
[GodfatherSubtitles.zip](https://github.com/hrydgard/ppsspp/files/11249066/GodfatherSubtitles.zip)