### PR TITLE
Android: Update target version to SDK 33

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools"
-    android:installLocation="auto"
-    android:versionCode="114040000"
-    android:versionName="1.14.4.0">
-    <!-- Note that versionCode should be in the format xyyzzrrrr. Example: 110030000 -->
-    <!-- In this same case, versionName should be 1.10.3.0 -->
-    <!-- Also note that we are overriding these values anyway from gradle. -->
+    android:installLocation="auto">
+    <!-- We use version codes in the format xyyzzrrrr. Example: 110030000
+    In this same case, versionName should be 1.10.3.0
+    Also note that we are overriding these values automatically from a gradle plugin,
+	so we don't need to set them manually. -->
 
     <uses-feature android:glEsVersion="0x00020000" />
     <uses-feature android:name="android.hardware.screen.landscape" android:required="false" />
@@ -19,7 +18,7 @@
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 
     <!-- I tried using android:maxSdkVersion="29" on WRITE/READ_EXTERNAL_STORAGE, but that made
-    <it so that in legacy mode, you can't ask for permission anymore. So removed that. -->
+    it so that in legacy mode, you can't ask for permission anymore. So removed that. -->
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,7 +62,7 @@ android {
 		new File("versioncode.txt").write(androidGitVersion.code().toString())
 
 		minSdkVersion 9
-		targetSdkVersion 32
+		targetSdkVersion 33
 		if (project.hasProperty("ANDROID_VERSION_CODE") && project.hasProperty("ANDROID_VERSION_NAME")) {
 			versionCode ANDROID_VERSION_CODE
 			versionName ANDROID_VERSION_NAME

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1033,6 +1033,8 @@ void System_Notify(SystemNotification notification) {
 	case SystemNotification::SUSTAINED_PERF_CHANGE:
 		PushCommand("sustainedPerfMode", "");
 		break;
+	default:
+		break;
 	}
 }
 


### PR DESCRIPTION
Which corresponds to Android 13.

Additionally removes redundant version lines from the manifest, and includes a small warning fix.