### PR TITLE
Resurrect and refactor the AxisSwap feature

### DIFF
--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -426,11 +426,6 @@ bool ControlMapper::Key(const KeyInput &key, bool *pauseTrigger) {
 void ControlMapper::ToggleSwapAxes() {
 	swapAxes_ = !swapAxes_;
 
-	// To avoid stuck keys, just reset it all.
-	for (auto &mapping : curInput_) {
-		mapping.second = 0.0f;
-	}
-
 	updatePSPButtons_(0, CTRL_LEFT | CTRL_RIGHT | CTRL_UP | CTRL_DOWN);
 
 	for (uint32_t vkey = VIRTKEY_FIRST; vkey < VIRTKEY_LAST; vkey++) {

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -32,11 +32,15 @@ public:
 	// virtual key codes, though not analog mappings.
 	void PSPKey(int deviceId, int pspKeyCode, int flags);
 
+	// Toggle swapping DPAD and Analog. Useful on some input devices with few buttons.
+	void ToggleSwapAxes();
+
 	void GetDebugString(char *buffer, size_t bufSize) const;
 
 private:
 	bool UpdatePSPState(const InputMapping &changedMapping);
 	float MapAxisValue(float value, int vkId, const InputMapping &mapping, const InputMapping &changedMapping, bool *oppositeTouched);
+	void SwapMappingIfEnabled(uint32_t *vkey);
 
 	void SetPSPAxis(int deviceId, int stick, char axis, float value);
 	void UpdateAnalogOutput(int stick);
@@ -56,6 +60,8 @@ private:
 	// Mappable auto-rotation. Useful for keyboard/dpad->analog in a few games.
 	bool autoRotatingAnalogCW_ = false;
 	bool autoRotatingAnalogCCW_ = false;
+
+	bool swapAxes_ = false;
 
 	// Protects basically all the state.
 	std::mutex mutex_;

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -43,8 +43,6 @@ std::set<std::string> g_seenPads;
 std::map<int, std::string> g_padNames;
 std::set<int> g_seenDeviceIds;
 
-bool g_swapDpadWithLStick = false;
-
 // Utility...
 void SingleInputMappingFromPspButton(int btn, std::vector<InputMapping> *mappings, bool ignoreMouse) {
 	std::vector<MultiInputMapping> multiMappings;
@@ -484,29 +482,13 @@ std::vector<KeyMap_IntStrPair> GetMappableKeys() {
 	return temp;
 }
 
-inline int CheckAxisSwap(int btn) {
-	if (g_swapDpadWithLStick) {
-		switch (btn) {
-			case CTRL_UP: btn = VIRTKEY_AXIS_Y_MAX; break;
-			case VIRTKEY_AXIS_Y_MAX: btn = CTRL_UP; break;
-			case CTRL_DOWN: btn = VIRTKEY_AXIS_Y_MIN; break;
-			case VIRTKEY_AXIS_Y_MIN: btn = CTRL_DOWN; break;
-			case CTRL_LEFT: btn = VIRTKEY_AXIS_X_MIN; break;
-			case VIRTKEY_AXIS_X_MIN: btn = CTRL_LEFT; break;
-			case CTRL_RIGHT: btn = VIRTKEY_AXIS_X_MAX; break;
-			case VIRTKEY_AXIS_X_MAX: btn = CTRL_RIGHT; break;
-		}
-	}
-	return btn;
-}
-
 bool InputMappingToPspButton(const InputMapping &mapping, std::vector<int> *pspButtons) {
 	bool found = false;
 	for (auto iter = g_controllerMap.begin(); iter != g_controllerMap.end(); ++iter) {
 		for (auto iter2 = iter->second.begin(); iter2 != iter->second.end(); ++iter2) {
 			if (iter2->EqualsSingleMapping(mapping)) {
 				if (pspButtons)
-					pspButtons->push_back(CheckAxisSwap(iter->first));
+					pspButtons->push_back(iter->first);
 				found = true;
 			}
 		}
@@ -810,11 +792,6 @@ std::string PadName(int deviceId) {
 	if (it != g_padNames.end())
 		return it->second;
 	return "";
-}
-
-// Swap direction buttons and left analog axis
-void SwapAxis() {
-	g_swapDpadWithLStick = !g_swapDpadWithLStick;
 }
 
 bool HasChanged(int &prevGeneration) {

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -199,7 +199,6 @@ namespace KeyMap {
 
 	void RestoreDefault();
 
-	void SwapAxis();
 	void UpdateNativeMenuKeys();
 
 	void NotifyPadConnected(int deviceId, const std::string &name);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -561,6 +561,7 @@ void EmuScreen::touch(const TouchInput &touch) {
 
 void EmuScreen::onVKey(int virtualKeyCode, bool down) {
 	auto sc = GetI18NCategory(I18NCat::SCREEN);
+	auto mc = GetI18NCategory(I18NCat::MAPPABLECONTROLS);
 
 	switch (virtualKeyCode) {
 	case VIRTKEY_FASTFORWARD:
@@ -647,7 +648,8 @@ void EmuScreen::onVKey(int virtualKeyCode, bool down) {
 
 	case VIRTKEY_AXIS_SWAP:
 		if (down) {
-			KeyMap::SwapAxis();
+			controlMapper_.ToggleSwapAxes();
+			osm.Show(mc->T("AxisSwap"));  // best string we have.
 		}
 		break;
 


### PR DESCRIPTION
It indeed got broken in the big input refactor.

Fixes #17292 , and makes it a little more robust than before (now zero chance of stuck keys on swap).