### PR TITLE
Remove "disable first frame readback" compat flag from SOCOM games.

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1140,15 +1140,6 @@ UCES00001 = true
 UCKS45008 = true
 NPJG00059 = true
 
-#Socom FireTeam Bravo 3 / Navy Seals Portable. See issue #11814
-UCES01242 = true
-UCUS98716 = true
-NPHG00032 = true
-NPJG00035 = true
-UCJS10102 = true
-NPEG90024 = true  # demo
-NPJG90068 = true  # demo
-
 [MpegAvcWarmUp]
 # God Eater issue #13527 ,It is custom mpeg library that required sceMpegGetAvcAu return ERROR_MPEG_NO_DATA but break FIFA 14 issue #14086
 # God Eater 1
@@ -1568,3 +1559,8 @@ UCES01242 = true
 NPHG00032 = true
 UCUS98716 = true
 NPEG90024 = true  # demo
+
+# SOCOM Navy Seals Portable (Japanese version)
+UCJS10102 = true
+NPJG00035 = true
+NPJG90068 = true  # demo


### PR DESCRIPTION
The CLUT8 fix for #16210 takes care of this.

Also enable it for the Japanese version.