### PR TITLE
Fix an oversight when saving replacement textures on scoped storage

### DIFF
--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -131,6 +131,11 @@ Path Path::WithReplacedExtension(const std::string &oldExtension, const std::str
 }
 
 Path Path::WithReplacedExtension(const std::string &newExtension) const {
+	if (type_ == PathType::CONTENT_URI) {
+		AndroidContentURI uri(path_);
+		return Path(uri.WithReplacedExtension(newExtension).ToString());
+	}
+
 	_dbg_assert_(!newExtension.empty() && newExtension[0] == '.');
 	if (path_.empty()) {
 		return Path(*this);

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -561,7 +561,7 @@ ReplacedTexture *TextureReplacer::FindReplacement(u64 cachekey, u32 hash, int w,
 static bool WriteTextureToPNG(png_imagep image, const Path &filename, int convert_to_8bit, const void *buffer, png_int_32 row_stride, const void *colormap) {
 	FILE *fp = File::OpenCFile(filename, "wb");
 	if (!fp) {
-		ERROR_LOG(IO, "Unable to open texture file for writing.");
+		ERROR_LOG(IO, "Unable to open texture file '%s' for writing.", filename.c_str());
 		return false;
 	}
 


### PR DESCRIPTION
We ended up not properly mangling the filename when changing extensions if the file URI is an Android content URI.

Fixes #17320