### PR TITLE
Avoid shader error for uint with GLSL 1.2

### DIFF
--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -740,7 +740,9 @@ OpenGLContext::OpenGLContext() {
 			// This too...
 			shaderLanguageDesc_.shaderLanguage = ShaderLanguage::GLSL_1xx;
 			if (gl_extensions.EXT_gpu_shader4) {
-				shaderLanguageDesc_.bitwiseOps = true;
+				// Older macOS devices seem to have problems defining uint uniforms.
+				// Let's just assume OpenGL 3.0+ is required.
+				shaderLanguageDesc_.bitwiseOps = gl_extensions.VersionGEThan(3, 0, 0);
 				shaderLanguageDesc_.texelFetch = "texelFetch2D";
 			}
 		}


### PR DESCRIPTION
See #17324, although I'm not sure if we should be using such an old GL there.  I think we should just avoid bitwise ops on OpenGL 2.x (technically EXT_gpu_shader4 is written against 2.0, though.)

-[Unknown]