### PR TITLE
SDL: Enable precise (smooth touchpad) scrolling.

### DIFF
--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -1170,6 +1170,19 @@ int main(int argc, char *argv[]) {
 					KeyInput key;
 					key.deviceId = DEVICE_ID_MOUSE;
 					key.flags = KEY_DOWN;
+					if (event.wheel.preciseY != 0.0f) {
+						// Should the scale be DPI-driven?
+						const float scale = 30.0f;
+						key.keyCode = event.wheel.preciseY > 0 ? NKCODE_EXT_MOUSEWHEEL_UP : NKCODE_EXT_MOUSEWHEEL_DOWN;
+						key.flags |= KEY_HASWHEELDELTA;
+						int wheelDelta = event.wheel.preciseY * scale;
+						if (event.wheel.preciseY < 0) {
+							 wheelDelta = -wheelDelta;
+						}
+						key.flags |= wheelDelta << 16;
+						NativeKey(key);
+						break;
+					}
 					if (event.wheel.y > 0) {
 						key.keyCode = NKCODE_EXT_MOUSEWHEEL_UP;
 						mouseWheelMovedUpFrames = 5;


### PR DESCRIPTION
Silky smooth menu scrolling with mac touchpads now.

Made possible by #17329