### PR TITLE
Fix iOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2623,7 +2623,7 @@ if(IOS AND NOT LIBRETRO)
 	)
 endif()
 
-if(MACOSX)
+if(MACOSX AND NOT IOS)
 	if(GOLD)
 		set_target_properties(${TargetBin} PROPERTIES
 			MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/macOS/InfoGold.plist"


### PR DESCRIPTION
https://github.com/hrydgard/ppsspp/blob/5fef404946411573545908cfd08bbcb64718dcf7/CMakeLists.txt#L91-L94
Due to the defind, "MACOSX" text will effect iOS build. This will limit the change only effect "really" MACOSX build.