### PR TITLE
Memory safety: Replace many sprintf with snprintf

### DIFF
--- a/Common/Buffer.cpp
+++ b/Common/Buffer.cpp
@@ -42,7 +42,7 @@ void Buffer::Append(const Buffer &other) {
 void Buffer::AppendValue(int value) {
 	char buf[16];
 	// This is slow.
-	sprintf(buf, "%i", value);
+	snprintf(buf, sizeof(buf), "%i", value);
 	Append(buf);
 }
 

--- a/Common/Data/Text/Parsers.cpp
+++ b/Common/Data/Text/Parsers.cpp
@@ -43,7 +43,7 @@ bool Version::ParseVersionString(std::string str) {
 
 std::string Version::ToString() const {
 	char temp[128];
-	sprintf(temp, "%i.%i.%i", major, minor, sub);
+	snprintf(temp, sizeof(temp), "%i.%i.%i", major, minor, sub);
 	return std::string(temp);
 }
 

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -751,10 +751,10 @@ D3D9Context::D3D9Context(IDirect3D9 *d3d, IDirect3D9Ex *d3dEx, int adapterId, ID
 	}
 
 	if (SUCCEEDED(result)) {
-		sprintf(shadeLangVersion_, "PS: %04x VS: %04x", d3dCaps_.PixelShaderVersion & 0xFFFF, d3dCaps_.VertexShaderVersion & 0xFFFF);
+		snprintf(shadeLangVersion_, sizeof(shadeLangVersion_), "PS: %04x VS: %04x", d3dCaps_.PixelShaderVersion & 0xFFFF, d3dCaps_.VertexShaderVersion & 0xFFFF);
 	} else {
 		WARN_LOG(G3D, "Direct3D9: Failed to get the device caps!");
-		strcpy(shadeLangVersion_, "N/A");
+		truncate_cpy(shadeLangVersion_, "N/A");
 	}
 
 	caps_.deviceID = identifier_.DeviceId;

--- a/Common/Math/expression_parser.cpp
+++ b/Common/Math/expression_parser.cpp
@@ -386,13 +386,13 @@ bool initPostfixExpression(const char* infix, IExpressionFunctions* funcs, Postf
 		{
 		case EXCOMM_CONST:
 		case EXCOMM_CONST_FLOAT:
-			testPos += sprintf(&test[testPos],"0x%04X ",dest[i].second);
+			testPos += snprintf(&test[testPos], sizeof(test) - testPos, "0x%04X ", dest[i].second);
 			break;
 		case EXCOMM_REF:
-			testPos += sprintf(&test[testPos],"r%d ",dest[i].second);
+			testPos += snprintf(&test[testPos], sizeof(test) - testPos, "r%d ", dest[i].second);
 			break;
 		case EXCOMM_OP:
-			testPos += sprintf(&test[testPos],"%s ",ExpressionOpcodes[dest[i].second].Name);
+			testPos += snprintf(&test[testPos], sizeof(test) - testPos, "%s ", ExpressionOpcodes[dest[i].second].Name);
 			break;
 		};
 	}
@@ -451,7 +451,7 @@ bool parsePostfixExpression(PostfixExpression& exp, IExpressionFunctions* funcs,
 				}
 
 				uint32_t val;
-				if(funcs->getMemoryValue(arg[1],arg[0],val,expressionError) == false)
+				if(funcs->getMemoryValue(arg[1],arg[0],val,expressionError, sizeof(expressionError)) == false)
 				{
 					return false;
 				}
@@ -460,7 +460,7 @@ bool parsePostfixExpression(PostfixExpression& exp, IExpressionFunctions* funcs,
 			case EXOP_MEM:
 				{
 					uint32_t val;
-					if (funcs->getMemoryValue(arg[0],4,val,expressionError) == false)
+					if (funcs->getMemoryValue(arg[0],4,val,expressionError, sizeof(expressionError)) == false)
 					{
 						return false;
 					}
@@ -479,7 +479,7 @@ bool parsePostfixExpression(PostfixExpression& exp, IExpressionFunctions* funcs,
 				valueStack.push_back(~arg[0]);
 				break;
 			case EXOP_LOGNOT:			// !b
-				valueStack.push_back(!arg[0]);
+				valueStack.push_back(!(arg[0] != 0));
 				break;
 			case EXOP_MUL:			// a*b
 				if (useFloat)

--- a/Common/Math/expression_parser.h
+++ b/Common/Math/expression_parser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstddef>
 #include <vector>
 
 typedef std::pair<uint32_t, uint32_t> ExpressionPair;

--- a/Common/Math/expression_parser.h
+++ b/Common/Math/expression_parser.h
@@ -20,7 +20,7 @@ public:
 	virtual bool parseSymbol(char* str, uint32_t& symbolValue) = 0;
 	virtual uint32_t getReferenceValue(uint32_t referenceIndex) = 0;
 	virtual ExpressionType getReferenceType(uint32_t referenceIndex) = 0;
-	virtual bool getMemoryValue(uint32_t address, int size, uint32_t& dest, char* error) = 0;
+	virtual bool getMemoryValue(uint32_t address, int size, uint32_t& dest, char *error, size_t errorBufSize) = 0;
 };
 
 bool initPostfixExpression(const char* infix, IExpressionFunctions* funcs, PostfixExpression& dest);

--- a/Common/StringUtils.cpp
+++ b/Common/StringUtils.cpp
@@ -242,7 +242,7 @@ std::string StringFromFormat(const char* format, ...)
 std::string StringFromInt(int value)
 {
 	char temp[16];
-	sprintf(temp, "%i", value);
+	snprintf(temp, sizeof(temp), "%d", value);
 	return temp;
 }
 

--- a/Common/UI/PopupScreens.cpp
+++ b/Common/UI/PopupScreens.cpp
@@ -146,13 +146,13 @@ std::string PopupMultiChoice::ValueText() const {
 
 PopupSliderChoice::PopupSliderChoice(int *value, int minValue, int maxValue, int defaultValue, const std::string &text, ScreenManager *screenManager, const std::string &units, LayoutParams *layoutParams)
 	: AbstractChoiceWithValueDisplay(text, layoutParams), value_(value), minValue_(minValue), maxValue_(maxValue), defaultValue_(defaultValue), step_(1), units_(units), screenManager_(screenManager) {
-	fmt_ = "%i";
+	fmt_ = "%d";
 	OnClick.Handle(this, &PopupSliderChoice::HandleClick);
 }
 
 PopupSliderChoice::PopupSliderChoice(int *value, int minValue, int maxValue, int defaultValue, const std::string &text, int step, ScreenManager *screenManager, const std::string &units, LayoutParams *layoutParams)
 	: AbstractChoiceWithValueDisplay(text, layoutParams), value_(value), minValue_(minValue), maxValue_(maxValue), defaultValue_(defaultValue), step_(step), units_(units), screenManager_(screenManager) {
-	fmt_ = "%i";
+	fmt_ = "%d";
 	OnClick.Handle(this, &PopupSliderChoice::HandleClick);
 }
 
@@ -191,18 +191,41 @@ EventReturn PopupSliderChoice::HandleChange(EventParams &e) {
 	return EVENT_DONE;
 }
 
+static bool IsValidNumberFormatString(const std::string &s) {
+	if (s.empty())
+		return false;
+	size_t percentCount = 0;
+	for (int i = 0; i < (int)s.size(); i++) {
+		if (s[i] == '%') {
+			percentCount++;
+			if (i < s.size() - 1) {
+				if (s[i] == 's')
+					return false;
+			}
+		}
+	}
+	return percentCount == 1;
+}
+
 std::string PopupSliderChoice::ValueText() const {
 	// Always good to have space for Unicode.
 	char temp[256];
+	temp[0] = '\0';
 	if (zeroLabel_.size() && *value_ == 0) {
-		strcpy(temp, zeroLabel_.c_str());
+		truncate_cpy(temp, zeroLabel_.c_str());
 	} else if (negativeLabel_.size() && *value_ < 0) {
-		strcpy(temp, negativeLabel_.c_str());
+		truncate_cpy(temp, negativeLabel_.c_str());
 	} else {
-		sprintf(temp, fmt_, *value_);
+		// Would normally be dangerous to have user-controlled format strings!
+		// However, let's check that there's only one % sign, and that it's not followed by an S.
+		// Also, these strings are from translations, which are kinda-fixed (though can be modified in theory).
+		if (IsValidNumberFormatString(fmt_)) {
+			snprintf(temp, sizeof(temp), fmt_.c_str(), *value_);
+		} else {
+			truncate_cpy(temp, "(translation error)");
+		}
 	}
-
-	return temp;
+	return std::string(temp);
 }
 
 EventReturn PopupSliderChoiceFloat::HandleClick(EventParams &e) {
@@ -229,12 +252,14 @@ EventReturn PopupSliderChoiceFloat::HandleChange(EventParams &e) {
 
 std::string PopupSliderChoiceFloat::ValueText() const {
 	char temp[256];
+	temp[0] = '\0';
 	if (zeroLabel_.size() && *value_ == 0.0f) {
-		strcpy(temp, zeroLabel_.c_str());
+		truncate_cpy(temp, zeroLabel_.c_str());
+	} else if (IsValidNumberFormatString(fmt_.c_str())) {
+		snprintf(temp, sizeof(temp), fmt_.c_str(), *value_);
 	} else {
-		sprintf(temp, fmt_, *value_);
+		snprintf(temp, sizeof(temp), "%0.2f", *value_);
 	}
-
 	return temp;
 }
 
@@ -282,8 +307,8 @@ EventReturn SliderPopupScreen::OnTextChange(EventParams &params) {
 }
 
 void SliderPopupScreen::UpdateTextBox() {
-	char temp[64];
-	sprintf(temp, "%d", sliderValue_);
+	char temp[128];
+	snprintf(temp, sizeof(temp), "%d", sliderValue_);
 	edit_->SetText(temp);
 }
 
@@ -295,6 +320,7 @@ void SliderPopupScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	sliderValue_ = *value_;
 	if (disabled_ && sliderValue_ < 0)
 		sliderValue_ = 0;
+
 	LinearLayout *vert = parent->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(UI::Margins(10, 10))));
 	slider_ = new Slider(&sliderValue_, minValue_, maxValue_, new LinearLayoutParams(UI::Margins(10, 10)));
 	slider_->OnChange.Handle(this, &SliderPopupScreen::OnSliderChange);
@@ -417,8 +443,8 @@ EventReturn SliderFloatPopupScreen::OnSliderChange(EventParams &params) {
 }
 
 void SliderFloatPopupScreen::UpdateTextBox() {
-	char temp[64];
-	sprintf(temp, "%0.3f", sliderValue_);
+	char temp[128];
+	snprintf(temp, sizeof(temp), "%0.3f", sliderValue_);
 	edit_->SetText(temp);
 }
 

--- a/Common/UI/PopupScreens.h
+++ b/Common/UI/PopupScreens.h
@@ -309,7 +309,7 @@ private:
 	int maxValue_;
 	int defaultValue_;
 	int step_;
-	const char *fmt_;
+	std::string fmt_;
 	std::string zeroLabel_;
 	std::string negativeLabel_;
 	std::string units_;
@@ -348,7 +348,7 @@ private:
 	float maxValue_;
 	float defaultValue_;
 	float step_;
-	const char *fmt_;
+	std::string fmt_;
 	std::string zeroLabel_;
 	std::string units_;
 	ScreenManager *screenManager_;

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -1284,7 +1284,7 @@ void ProgressBar::GetContentDimensions(const UIContext &dc, float &w, float &h) 
 
 void ProgressBar::Draw(UIContext &dc) {
 	char temp[32];
-	sprintf(temp, "%i%%", (int)(progress_ * 100.0f));
+	snprintf(temp, sizeof(temp), "%d%%", (int)(progress_ * 100.0f));
 	dc.Draw()->DrawImageCenterTexel(dc.theme->whiteImage, bounds_.x, bounds_.y, bounds_.x + bounds_.w * progress_, bounds_.y2(), 0xc0c0c0c0);
 	dc.SetFontStyle(dc.theme->uiFont);
 	dc.DrawTextRect(temp, bounds_, 0xFFFFFFFF, ALIGN_CENTER);
@@ -1443,17 +1443,17 @@ void Slider::Draw(UIContext &dc) {
 	dc.Draw()->DrawImage(dc.theme->sliderKnob, knobX, bounds_.centerY(), 1.0f, knobStyle.fgColor, ALIGN_CENTER);
 	char temp[64];
 	if (showPercent_)
-		sprintf(temp, "%i%%", *value_);
+		snprintf(temp, sizeof(temp), "%d%%", *value_);
 	else
-		sprintf(temp, "%i", *value_);
+		snprintf(temp, sizeof(temp), "%d", *value_);
 	dc.SetFontStyle(dc.theme->uiFont);
 	dc.DrawText(temp, bounds_.x2() - 22, bounds_.centerY(), dc.theme->popupStyle.fgColor, ALIGN_CENTER | FLAG_DYNAMIC_ASCII);
 }
 
 std::string Slider::DescribeText() const {
 	if (showPercent_)
-		return StringFromFormat("%i%% / %i%%", *value_, maxValue_);
-	return StringFromFormat("%i / %i", *value_, maxValue_);
+		return StringFromFormat("%d%% / %d%%", *value_, maxValue_);
+	return StringFromFormat("%d / %d", *value_, maxValue_);
 }
 
 void Slider::Update() {
@@ -1567,7 +1567,7 @@ void SliderFloat::Draw(UIContext &dc) {
 	dc.FillRect(Drawable(0xFF808080), Bounds(knobX, bounds_.centerY() - 2, (bounds_.x + bounds_.w - paddingRight_ - knobX), 4));
 	dc.Draw()->DrawImage(dc.theme->sliderKnob, knobX, bounds_.centerY(), 1.0f, knobStyle.fgColor, ALIGN_CENTER);
 	char temp[64];
-	sprintf(temp, "%0.2f", *value_);
+	snprintf(temp, sizeof(temp), "%0.2f", *value_);
 	dc.SetFontStyle(dc.theme->uiFont);
 	dc.DrawText(temp, bounds_.x2() - 22, bounds_.centerY(), dc.theme->popupStyle.fgColor, ALIGN_CENTER);
 }

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -672,7 +672,7 @@ std::string GetScheduledEventsSummary() {
 		if (!name)
 			name = "[unknown]";
 		char temp[512];
-		sprintf(temp, "%s : %i %08x%08x\n", name, (int)ptr->time, (u32)(ptr->userdata >> 32), (u32)(ptr->userdata));
+		snprintf(temp, sizeof(temp), "%s : %i %08x%08x\n", name, (int)ptr->time, (u32)(ptr->userdata >> 32), (u32)(ptr->userdata));
 		text += temp;
 		ptr = ptr->next;
 	}

--- a/Core/Debugger/DebugInterface.h
+++ b/Core/Debugger/DebugInterface.h
@@ -18,6 +18,7 @@
 #pragma once
 #include <string>
 #include <cstdio>
+
 #include "Common/CommonTypes.h"
 #include "Common/Math/expression_parser.h"
 

--- a/Core/Debugger/DebugInterface.h
+++ b/Core/Debugger/DebugInterface.h
@@ -54,14 +54,16 @@ public:
 	virtual u32 GetPC() = 0;
 	virtual void SetPC(u32 _pc) = 0;
 	virtual u32 GetLR() {return GetPC();}
-	virtual void DisAsm(u32 op, u32 pc, int align, char *out) {sprintf(out,"[%08x] UNKNOWN", op);}
-	//More stuff for debugger
+	virtual void DisAsm(u32 op, u32 pc, int align, char *out, size_t outSize) {
+		snprintf(out, outSize, "[%08x] UNKNOWN", op);
+	}
+	// More stuff for debugger
 	virtual int GetNumCategories() {return 0;}
 	virtual int GetNumRegsInCategory(int cat) {return 0;}
 	virtual const char *GetCategoryName(int cat) {return 0;}
 	virtual const char *GetRegName(int cat, int index) {return 0;}
-	virtual void PrintRegValue(int cat, int index, char *out) {
-		sprintf(out,"%08X",GetGPR32Value(index));
+	virtual void PrintRegValue(int cat, int index, char *out, size_t outSize) {
+		snprintf(out, outSize, "%08X", GetGPR32Value(index));
 	}
 	virtual u32 GetRegValue(int cat, int index) {return 0;}
 	virtual void SetRegValue(int cat, int index, u32 value) {}

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "ppsspp_config.h"
+
 #include <string>
 #include <algorithm>
 #include <map>
@@ -24,6 +25,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/Data/Encoding/Utf8.h"
+#include "Common/StringUtils.h"
 #include "Core/MemMap.h"
 #include "Core/System.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
@@ -123,14 +125,13 @@ void parseDisasm(const char* disasm, char* opcode, char* arguments, bool insertS
 		if (disasm == jumpAddress)
 		{
 			u32 branchTarget = 0;
-			sscanf(disasm+3,"%08x",&branchTarget);
-
+			sscanf(disasm+3, "%08x", &branchTarget);
 			const std::string addressSymbol = g_symbolMap->GetLabelString(branchTarget);
 			if (!addressSymbol.empty() && insertSymbols)
 			{
-				arguments += sprintf(arguments,"%s",addressSymbol.c_str());
+				arguments += sprintf(arguments, "%s", addressSymbol.c_str());
 			} else {
-				arguments += sprintf(arguments,"0x%08X",branchTarget);
+				arguments += sprintf(arguments, "0x%08X", branchTarget);
 			}
 
 			disasm += 3+8;
@@ -849,9 +850,9 @@ bool DisassemblyMacro::disassemble(u32 address, DisassemblyLineInfo &dest, bool 
 		
 		addressSymbol = g_symbolMap->GetLabelString(immediate);
 		if (!addressSymbol.empty() && insertSymbols) {
-			sprintf(buffer, "%s,%s", cpuDebug->GetRegName(0, rt), addressSymbol.c_str());
+			snprintf(buffer, sizeof(buffer), "%s,%s", cpuDebug->GetRegName(0, rt), addressSymbol.c_str());
 		} else {
-			sprintf(buffer, "%s,0x%08X", cpuDebug->GetRegName(0, rt), immediate);
+			snprintf(buffer, sizeof(buffer), "%s,0x%08X", cpuDebug->GetRegName(0, rt), immediate);
 		}
 
 		dest.params = buffer;
@@ -864,9 +865,9 @@ bool DisassemblyMacro::disassemble(u32 address, DisassemblyLineInfo &dest, bool 
 
 		addressSymbol = g_symbolMap->GetLabelString(immediate);
 		if (!addressSymbol.empty() && insertSymbols) {
-			sprintf(buffer, "%s,%s", cpuDebug->GetRegName(0, rt), addressSymbol.c_str());
+			snprintf(buffer, sizeof(buffer), "%s,%s", cpuDebug->GetRegName(0, rt), addressSymbol.c_str());
 		} else {
-			sprintf(buffer, "%s,0x%08X", cpuDebug->GetRegName(0, rt), immediate);
+			snprintf(buffer, sizeof(buffer), "%s,0x%08X", cpuDebug->GetRegName(0, rt), immediate);
 		}
 
 		dest.params = buffer;
@@ -1001,9 +1002,9 @@ void DisassemblyData::createLines()
 			} else {
 				char buffer[64];
 				if (pos == end && b == 0)
-					strcpy(buffer,"0");
+					truncate_cpy(buffer, "0");
 				else
-					sprintf(buffer,"0x%02X",b);
+					snprintf(buffer, sizeof(buffer), "0x%02X", b);
 
 				if (currentLine.size()+strlen(buffer) >= maxChars)
 				{

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -223,7 +223,7 @@ const char *GetFuncName(const char *moduleName, u32 nib)
 		return func->name;
 
 	static char temp[256];
-	sprintf(temp,"[UNK: 0x%08x]", nib);
+	snprintf(temp, sizeof(temp), "[UNK: 0x%08x]", nib);
 	return temp;
 }
 

--- a/Core/HLE/KernelThreadDebugInterface.h
+++ b/Core/HLE/KernelThreadDebugInterface.h
@@ -32,11 +32,11 @@ public:
 	u32 GetLR() override { return ctx.r[MIPS_REG_RA]; }
 	void SetPC(u32 _pc) override { ctx.pc = _pc; }
 
-	void PrintRegValue(int cat, int index, char *out) override {
+	void PrintRegValue(int cat, int index, char *out, size_t outSize) override {
 		switch (cat) {
-		case 0: sprintf(out, "%08X", ctx.r[index]); break;
-		case 1: sprintf(out, "%f", ctx.f[index]); break;
-		case 2: sprintf(out, "N/A"); break;
+		case 0: snprintf(out, outSize, "%08X", ctx.r[index]); break;
+		case 1: snprintf(out, outSize, "%f", ctx.f[index]); break;
+		case 2: snprintf(out, outSize, "N/A"); break;
 		}
 	}
 

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -224,8 +224,8 @@ public:
 	const char *GetName() override { return fullpath.c_str(); }
 	const char *GetTypeName() override { return GetStaticTypeName(); }
 	static const char *GetStaticTypeName() { return "OpenFile"; }
-	void GetQuickInfo(char *ptr, int size) override {
-		sprintf(ptr, "Seekpos: %08x", (u32)pspFileSystem.GetSeekPos(handle));
+	void GetQuickInfo(char *buf, int bufSize) override {
+		snprintf(buf, bufSize, "Seekpos: %08x", (u32)pspFileSystem.GetSeekPos(handle));
 	}
 	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_BADF; }
 	static int GetStaticIDType() { return PPSSPP_KERNEL_TMID_File; }
@@ -2767,7 +2767,7 @@ static int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, 
 			if (result == (int)SCE_KERNEL_ERROR_ERRNO_FUNCTION_NOT_SUPPORTED) {
 				char temp[256];
 				// We want the reported message to include the cmd, so it's unique.
-				sprintf(temp, "sceIoIoctl(%%s, %08x, %%08x, %%x, %%08x, %%x)", cmd);
+				snprintf(temp, sizeof(temp), "sceIoIoctl(%%s, %08x, %%08x, %%x, %%08x, %%x)", cmd);
 				Reporting::ReportMessage(temp, f->fullpath.c_str(), indataPtr, inlen, outdataPtr, outlen);
 				ERROR_LOG(SCEIO, "UNIMPL 0=sceIoIoctl id: %08x, cmd %08x, indataPtr %08x, inlen %08x, outdataPtr %08x, outLen %08x", id,cmd,indataPtr,inlen,outdataPtr,outlen);
 			}

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -523,7 +523,7 @@ void KernelObjectPool::List() {
 		if (occupied[i]) {
 			char buffer[256];
 			if (pool[i]) {
-				pool[i]->GetQuickInfo(buffer, 256);
+				pool[i]->GetQuickInfo(buffer, sizeof(buffer));
 				INFO_LOG(SCEKERNEL, "KO %i: %s \"%s\": %s", i + handleOffset, pool[i]->GetTypeName(), pool[i]->GetName(), buffer);
 			} else {
 				strcpy(buffer, "WTF? Zero Pointer");

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -62,7 +62,7 @@ void DisassembleArm(const u8 *data, int size) {
 			int reg0 = (inst & 0x0000F000) >> 12;
 			int reg1 = (next & 0x0000F000) >> 12;
 			if (reg0 == reg1) {
-				sprintf(temp, "%08x MOV32 %s, %04x%04x", (u32)inst, ArmRegName(reg0), hi, low);
+				snprintf(temp, sizeof(temp), "%08x MOV32 %s, %04x%04x", (u32)inst, ArmRegName(reg0), hi, low);
 				INFO_LOG(JIT, "A:   %s", temp);
 				i += 4;
 				continue;

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -280,13 +280,13 @@ void JitBlockCache::FinalizeBlock(int block_num, bool block_link) {
 
 #if defined USE_OPROFILE && USE_OPROFILE
 	char buf[100];
-	sprintf(buf, "EmuCode%x", b.originalAddress);
+	snprintf(buf, sizeof(buf), "EmuCode%x", b.originalAddress);
 	const u8* blockStart = blocks_[block_num].checkedEntry;
 	op_write_native_code(agent, buf, (uint64_t)blockStart, blockStart, b.normalEntry + b.codeSize - b.checkedEntry);
 #endif
 
 #ifdef USE_VTUNE
-	sprintf(b.blockName, "EmuCode_0x%08x", b.originalAddress);
+	snprintf(b.blockName, sizeof(b.blockName), "EmuCode_0x%08x", b.originalAddress);
 
 	iJIT_Method_Load jmethod = {0};
 	jmethod.method_id = iJIT_GetNewMethodID();

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -930,7 +930,7 @@ skip:
 	}
 
 	static const char *DefaultFunctionName(char buffer[256], u32 startAddr) {
-		sprintf(buffer, "z_un_%08x", startAddr);
+		snprintf(buffer, sizeof(buffer), "z_un_%08x", startAddr);
 		return buffer;
 	}
 

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -930,7 +930,7 @@ skip:
 	}
 
 	static const char *DefaultFunctionName(char buffer[256], u32 startAddr) {
-		snprintf(buffer, sizeof(buffer), "z_un_%08x", startAddr);
+		snprintf(buffer, 256, "z_un_%08x", startAddr);
 		return buffer;
 	}
 

--- a/Core/MIPS/MIPSDebugInterface.h
+++ b/Core/MIPS/MIPSDebugInterface.h
@@ -64,11 +64,11 @@ public:
 	}
 	const char *GetRegName(int cat, int index) override;
 
-	void PrintRegValue(int cat, int index, char *out) override {
+	void PrintRegValue(int cat, int index, char *out, size_t outSize) override {
 		switch (cat) {
-		case 0: sprintf(out, "%08X", cpu->r[index]); break;
-		case 1: sprintf(out, "%f", cpu->f[index]); break;
-		case 2: sprintf(out, "N/A"); break;
+		case 0: snprintf(out, outSize, "%08X", cpu->r[index]); break;
+		case 1: snprintf(out, outSize, "%f", cpu->f[index]); break;
+		case 2: snprintf(out, outSize, "N/A"); break;
 		}
 	}
 

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -540,7 +540,7 @@ MatrixOverlapType GetMatrixOverlap(int mtx1, int mtx2, MatrixSize msize) {
 
 const char *GetVectorNotation(int reg, VectorSize size)
 {
-	static char hej[4][16];
+	static char temp[4][16];
 	static int yo = 0; yo++; yo &= 3;
 
 	int mtx = (reg>>2)&7;
@@ -548,8 +548,7 @@ const char *GetVectorNotation(int reg, VectorSize size)
 	int row = 0;
 	int transpose = (reg>>5)&1;
 	char c;
-	switch (size)
-	{
+	switch (size) {
 	case V_Single:  transpose=0; c='S'; row=(reg>>5)&3; break;
 	case V_Pair:    c='C'; row=(reg>>5)&2; break;
 	case V_Triple:	c='C'; row=(reg>>6)&1; break;
@@ -558,15 +557,15 @@ const char *GetVectorNotation(int reg, VectorSize size)
 	}
 	if (transpose && c == 'C') c='R';
 	if (transpose)
-		sprintf(hej[yo],"%c%i%i%i",c,mtx,row,col);
+		snprintf(temp[yo], sizeof(temp[yo]), "%c%i%i%i",c,mtx,row,col);
 	else
-		sprintf(hej[yo],"%c%i%i%i",c,mtx,col,row);
-	return hej[yo];
+		snprintf(temp[yo], sizeof(temp[yo]), "%c%i%i%i",c,mtx,col,row);
+	return temp[yo];
 }
 
 const char *GetMatrixNotation(int reg, MatrixSize size)
 {
-  static char hej[4][16];
+  static char temp[4][16];
   static int yo=0;yo++;yo&=3;
   int mtx = (reg>>2)&7;
   int col = reg&3;
@@ -582,10 +581,10 @@ const char *GetMatrixNotation(int reg, MatrixSize size)
   }
   if (transpose && c=='M') c='E';
   if (transpose)
-    sprintf(hej[yo],"%c%i%i%i",c,mtx,row,col);
+    snprintf(temp[yo], sizeof(temp[yo]), "%c%i%i%i",c,mtx,row,col);
   else
-    sprintf(hej[yo],"%c%i%i%i",c,mtx,col,row);
-  return hej[yo];
+    snprintf(temp[yo], sizeof(temp[yo]), "%c%i%i%i",c,mtx,col,row);
+  return temp[yo];
 }
 
 bool GetVFPUCtrlMask(int reg, u32 *mask) {

--- a/Core/Util/PortManager.cpp
+++ b/Core/Util/PortManager.cpp
@@ -220,8 +220,8 @@ bool PortManager::Add(const char* protocol, unsigned short port, unsigned short 
 		Terminate();
 		return false;
 	}
-	sprintf(port_str, "%d", port);
-	sprintf(intport_str, "%d", intport);
+	snprintf(port_str, sizeof(port_str), "%d", port);
+	snprintf(intport_str, sizeof(intport_str), "%d", intport);
 	// Only add new port map if it's not previously created by PPSSPP for current IP
 	auto el_it = std::find_if(m_portList.begin(), m_portList.end(),
 		[port_str, protocol](const std::pair<std::string, std::string> &el) { return el.first == port_str && el.second == protocol; });
@@ -275,7 +275,7 @@ bool PortManager::Remove(const char* protocol, unsigned short port) {
 		Terminate();
 		return false;
 	}
-	sprintf(port_str, "%d", port);
+	snprintf(port_str, sizeof(port_str), "%d", port);
 	int r = UPNP_DeletePortMapping(urls->controlURL, datas->first.servicetype, port_str, protocol, NULL);
 	if (r != 0)
 	{

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -191,7 +191,7 @@ static void DiscHandler(const http::Request &request, const Path &filename) {
 
 		s64 len = last - begin + 1;
 		char contentRange[1024];
-		sprintf(contentRange, "Content-Range: bytes %lld-%lld/%lld\r\n", begin, last, sz);
+		snprintf(contentRange, sizeof(contentRange), "Content-Range: bytes %lld-%lld/%lld\r\n", begin, last, sz);
 		request.WriteHttpResponseHeader("1.0", 206, len, "application/octet-stream", contentRange);
 
 		const size_t CHUNK_SIZE = 16 * 1024;

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -184,9 +184,9 @@ void GenerateDepalShaderFloat(ShaderWriter &writer, const DepalConfig &config) {
 		if (shift == 0 && mask == 0xFF) {
 			// Easy peasy.
 			if (writer.Lang().shaderLanguage == HLSL_D3D9)
-				sprintf(lookupMethod, "index.a");
+				snprintf(lookupMethod, sizeof(lookupMethod), "index.a");
 			else
-				sprintf(lookupMethod, "index.r");
+				snprintf(lookupMethod, sizeof(lookupMethod), "index.r");
 			formatOK = true;
 		} else {
 			// Deal with this if we find it.
@@ -199,9 +199,9 @@ void GenerateDepalShaderFloat(ShaderWriter &writer, const DepalConfig &config) {
 			const char *rgba = "rrrrrrrrggggggggbbbbbbbbaaaaaaaa";
 			const u8 rgba_shift = shift & 7;
 			if (rgba_shift == 0 && mask == 0xFF) {
-				sprintf(lookupMethod, "index.%c", rgba[shift]);
+				snprintf(lookupMethod, sizeof(lookupMethod), "index.%c", rgba[shift]);
 			} else {
-				sprintf(lookupMethod, "mod(index.%c * %f, %d.0)", rgba[shift], 255.99f / (1 << rgba_shift), mask + 1);
+				snprintf(lookupMethod, sizeof(lookupMethod), "mod(index.%c * %f, %d.0)", rgba[shift], 255.99f / (1 << rgba_shift), mask + 1);
 				index_multiplier = 1.0f / 256.0f;
 				// Format was OK if there weren't bits from another component.
 				formatOK = mask <= 255 - (1 << rgba_shift);
@@ -215,11 +215,11 @@ void GenerateDepalShaderFloat(ShaderWriter &writer, const DepalConfig &config) {
 			const char *rgba = "rrrrggggbbbbaaaa";
 			const u8 rgba_shift = shift & 3;
 			if (rgba_shift == 0 && mask == 0xF) {
-				sprintf(lookupMethod, "index.%c", rgba[shift]);
+				snprintf(lookupMethod, sizeof(lookupMethod), "index.%c", rgba[shift]);
 				index_multiplier = 15.0f / 256.0f;
 			} else {
 				// Let's divide and mod to get the right bits.  A common case is shift=0, mask=01.
-				sprintf(lookupMethod, "mod(index.%c * %f, %d.0)", rgba[shift], 15.99f / (1 << rgba_shift), mask + 1);
+				snprintf(lookupMethod, sizeof(lookupMethod), "mod(index.%c * %f, %d.0)", rgba[shift], 15.99f / (1 << rgba_shift), mask + 1);
 				index_multiplier = 1.0f / 256.0f;
 				formatOK = mask <= 15 - (1 << rgba_shift);
 			}
@@ -234,12 +234,12 @@ void GenerateDepalShaderFloat(ShaderWriter &writer, const DepalConfig &config) {
 			const char *rgba = "rrrrrggggggbbbbb";
 			const u8 rgba_shift = shifts[shift];
 			if (rgba_shift == 0 && mask == multipliers[shift]) {
-				sprintf(lookupMethod, "index.%c", rgba[shift]);
+				snprintf(lookupMethod, sizeof(lookupMethod), "index.%c", rgba[shift]);
 				index_multiplier = multipliers[shift] / 256.0f;
 			} else {
 				// We just need to divide the right component by the right value, and then mod against the mask.
 				// A common case is shift=1, mask=0f.
-				sprintf(lookupMethod, "mod(index.%c * %f, %d.0)", rgba[shift], ((float)multipliers[shift] + 0.99f) / (1 << rgba_shift), mask + 1);
+				snprintf(lookupMethod, sizeof(lookupMethod), "mod(index.%c * %f, %d.0)", rgba[shift], ((float)multipliers[shift] + 0.99f) / (1 << rgba_shift), mask + 1);
 				index_multiplier = 1.0f / 256.0f;
 				formatOK = mask <= multipliers[shift] - (1 << rgba_shift);
 			}
@@ -250,21 +250,21 @@ void GenerateDepalShaderFloat(ShaderWriter &writer, const DepalConfig &config) {
 	case GE_FORMAT_5551:
 		if (config.textureFormat == GE_TFMT_CLUT8 && mask == 0xFF && shift == 0) {
 			// Follow the intent here, and ignore g (and let's not round unnecessarily).
-			sprintf(lookupMethod, "floor(floor(index.a) * 128.0 + index.b * 64.0)");
+			snprintf(lookupMethod, sizeof(lookupMethod), "floor(floor(index.a) * 128.0 + index.b * 64.0)");
 			index_multiplier = 1.0f / 256.0f;
 			// SOCOM case. #16210
 		} else if ((mask & (mask + 1)) == 0 && shift < 16) {
 			const char *rgba = "rrrrrgggggbbbbba";
 			const u8 rgba_shift = shift % 5;
 			if (rgba_shift == 0 && mask == 0x1F) {
-				sprintf(lookupMethod, "index.%c", rgba[shift]);
+				snprintf(lookupMethod, sizeof(lookupMethod), "index.%c", rgba[shift]);
 				index_multiplier = 31.0f / 256.0f;
 			} else if (shift == 15 && mask == 1) {
-				sprintf(lookupMethod, "index.%c", rgba[shift]);
+				snprintf(lookupMethod, sizeof(lookupMethod), "index.%c", rgba[shift]);
 				index_multiplier = 1.0f / 256.0f;
 			} else {
 				// A isn't possible here.
-				sprintf(lookupMethod, "mod(index.%c * %f, %d.0)", rgba[shift], 31.99f / (1 << rgba_shift), mask + 1);
+				snprintf(lookupMethod, sizeof(lookupMethod), "mod(index.%c * %f, %d.0)", rgba[shift], 31.99f / (1 << rgba_shift), mask + 1);
 				index_multiplier = 1.0f / 256.0f;
 				formatOK = mask <= 31 - (1 << rgba_shift);
 			}

--- a/GPU/Common/GPUDebugInterface.cpp
+++ b/GPU/Common/GPUDebugInterface.cpp
@@ -516,7 +516,7 @@ public:
 	bool parseSymbol(char *str, uint32_t &symbolValue) override;
 	uint32_t getReferenceValue(uint32_t referenceIndex) override;
 	ExpressionType getReferenceType(uint32_t referenceIndex) override;
-	bool getMemoryValue(uint32_t address, int size, uint32_t &dest, char *error) override;
+	bool getMemoryValue(uint32_t address, int size, uint32_t &dest, char *error, size_t errorBufSize) override;
 
 private:
 	bool parseFieldReference(const char *ref, const char *field, uint32_t &referenceIndex);
@@ -926,7 +926,7 @@ ExpressionType GEExpressionFunctions::getFieldType(GECmdFormat fmt, GECmdField f
 	return EXPR_TYPE_UINT;
 }
 
-bool GEExpressionFunctions::getMemoryValue(uint32_t address, int size, uint32_t &dest, char *error) {
+bool GEExpressionFunctions::getMemoryValue(uint32_t address, int size, uint32_t &dest, char *error, size_t errorBufSize) {
 	// We allow, but ignore, bad access.
 	// If we didn't, log/condition statements that reference registers couldn't be configured.
 	uint32_t valid = Memory::ValidSize(address, size);
@@ -946,7 +946,7 @@ bool GEExpressionFunctions::getMemoryValue(uint32_t address, int size, uint32_t 
 		return true;
 	}
 
-	sprintf(error, "Unexpected memory access size %d", size);
+	snprintf(error, errorBufSize, "Unexpected memory access size %d", size);
 	return false;
 }
 

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -322,9 +322,9 @@ void GameButton::Draw(UIContext &dc) {
 
 	char discNumInfo[8];
 	if (ginfo->disc_total > 1)
-		sprintf(discNumInfo, "-DISC%d", ginfo->disc_number);
+		snprintf(discNumInfo, sizeof(discNumInfo), "-DISC%d", ginfo->disc_number);
 	else
-		strcpy(discNumInfo, "");
+		discNumInfo[0] = '\0';
 
 	dc.Draw()->Flush();
 	dc.RebindTexture();
@@ -1120,7 +1120,7 @@ void MainScreen::CreateViews() {
 	rightColumn->Add(rightColumnItems);
 
 	char versionString[256];
-	sprintf(versionString, "%s", PPSSPP_GIT_VERSION);
+	snprintf(versionString, sizeof(versionString), "%s", PPSSPP_GIT_VERSION);
 	rightColumnItems->SetSpacing(0.0f);
 	AnchorLayout *logos = new AnchorLayout(new AnchorLayoutParams(FILL_PARENT, 60.0f, false));
 	if (System_GetPropertyBool(SYSPROP_APP_GOLD)) {

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -1,5 +1,3 @@
-// NOTE: Apologies for the quality of this code, this is really from pre-opensource Dolphin - that is, 2003.
-
 #include "Windows/resource.h"
 #include "Core/MemMap.h"
 #include "Core/MIPS/JitCommon/JitCommon.h"

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -1,25 +1,22 @@
-// NOTE: Apologies for the quality of this code, this is really from pre-opensource Dolphin - that is, 2003.
-
 #pragma once
 
-//////////////////////////////////////////////////////////////////////////
-//CtrlDisAsmView
-// CtrlDisAsmView.cpp
-//////////////////////////////////////////////////////////////////////////
-//This Win32 control is made to be flexible and usable with
-//every kind of CPU architechture that has fixed width instruction words.
-//Just supply it an instance of a class derived from Debugger, with all methods
-//overridden for full functionality. Look at the ppc one for an example.
-//
-//To add to a dialog box, just draw a User Control in the dialog editor,
-//and set classname to "CtrlDisAsmView". you also need to call CtrlDisAsmView::init()
-//before opening this dialog, to register the window class.
-//
-//To get a class instance to be able to access it, just use 
-//  CtrlDisAsmView::getFrom(GetDlgItem(yourdialog, IDC_yourid)).
+// CtrlDisAsmView
+//  
+// This Win32 control is made to be flexible and usable with
+// every kind of CPU architecture that has fixed width instruction words.
+// Just supply it an instance of a class derived from Debugger, with all methods
+// overridden for full functionality. Look at the ppc one for an example.
+// 
+// To add to a dialog box, just draw a User Control in the dialog editor,
+// and set classname to "CtrlDisAsmView". you also need to call CtrlDisAsmView::init()
+// before opening this dialog, to register the window class.
+// 
+// To get a class instance to be able to access it, just use 
+//   CtrlDisAsmView::getFrom(GetDlgItem(yourdialog, IDC_yourid)).
 
 #include <vector>
 #include <algorithm>
+
 #include "Common/CommonWindows.h"
 #include "Common/Log.h"
 #include "Core/Debugger/DebugInterface.h"

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -1,11 +1,11 @@
-// NOTE: Apologies for the quality of this code, this is really from pre-opensource Dolphin - that is, 2003.
-
 #include <cctype>
 #include <tchar.h>
-#include <math.h>
+#include <cmath>
 #include <iomanip>
 #include <sstream>
+
 #include "ext/xxhash.h"
+#include "Common/StringUtils.h"
 #include "Core/Config.h"
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
@@ -229,7 +229,7 @@ void CtrlMemView::onPaint(WPARAM wParam, LPARAM lParam) {
 
 		char temp[32];
 		uint32_t address = windowStart_ + i * rowSize_;
-		sprintf(temp, "%08X", address);
+		snprintf(temp, sizeof(temp), "%08X", address);
 
 		setTextColors(0x600000, standardBG);
 		TextOutA(hdc, addressStartX_, rowY, temp, (int)strlen(temp));
@@ -260,12 +260,12 @@ void CtrlMemView::onPaint(WPARAM wParam, LPARAM lParam) {
 
 			char c;
 			if (valid) {
-				sprintf(temp, "%02X ", memory.bytes[j]);
+				snprintf(temp, sizeof(temp), "%02X ", memory.bytes[j]);
 				c = (char)memory.bytes[j];
 				if (memory.bytes[j] < 32 || memory.bytes[j] >= 128)
 					c = '.';
 			} else {
-				strcpy(temp, "??");
+				truncate_cpy(temp, "??");
 				c = '.';
 			}
 
@@ -616,7 +616,7 @@ void CtrlMemView::onMouseUp(WPARAM wParam, LPARAM lParam, int button) {
 		case ID_MEMVIEW_COPYADDRESS:
 			{
 				char temp[24];
-				sprintf(temp, "0x%08X", curAddress_);
+				snprintf(temp, sizeof(temp), "0x%08X", curAddress_);
 				W32Util::CopyTextToClipboard(wnd, temp);
 			}
 			break;
@@ -959,7 +959,7 @@ void CtrlMemView::drawOffsetScale(HDC hdc) {
 	
 	char temp[64];
 	for (int i = 0; i < 16; i++) {
-		sprintf(temp, "%02X", i);
+		snprintf(temp, sizeof(temp), "%02X", i);
 		TextOutA(hdc, currentX, offsetPositionY_, temp, 2);
 		currentX += 3 * charWidth_; // hex and space
 	}

--- a/Windows/Debugger/CtrlMemView.h
+++ b/Windows/Debugger/CtrlMemView.h
@@ -1,5 +1,3 @@
-// NOTE: Apologies for the quality of this code, this is really from pre-opensource Dolphin - that is, 2003.
-
 #pragma once
 
 //////////////////////////////////////////////////////////////////////////

--- a/Windows/Debugger/CtrlRegisterList.cpp
+++ b/Windows/Debugger/CtrlRegisterList.cpp
@@ -1,6 +1,4 @@
-// NOTE: Apologies for the quality of this code, this is really from pre-opensource Dolphin - that is, 2003.
-
-#include <math.h>
+#include <cmath>
 #include <tchar.h>
 
 #include "Common/System/Display.h"
@@ -253,12 +251,12 @@ void CtrlRegisterList::onPaint(WPARAM wParam, LPARAM lParam)
 		if (i<cpu->GetNumRegsInCategory(category))
 		{
 			char temp[256];
-			int temp_len = sprintf(temp,"%s",cpu->GetRegName(category,i));
+			int temp_len = snprintf(temp, sizeof(temp), "%s", cpu->GetRegName(category, i));
 			SetTextColor(hdc,0x600000);
 			TextOutA(hdc,17,rowY1,temp,temp_len);
 			SetTextColor(hdc,0x000000);
 
-			cpu->PrintRegValue(category,i,temp);
+			cpu->PrintRegValue(category, i, temp, sizeof(temp));
 			if (category == 0 && changedCat0Regs[i])
 				SetTextColor(hdc, 0x0000FF);
 			else
@@ -274,15 +272,15 @@ void CtrlRegisterList::onPaint(WPARAM wParam, LPARAM lParam)
 			{
 			case REGISTER_PC:
 				value = cpu->GetPC();
-				len = sprintf(temp,"pc");
+				len = snprintf(temp, sizeof(temp), "pc");
 				break;
 			case REGISTER_HI:
 				value = cpu->GetHi();
-				len = sprintf(temp,"hi");
+				len = snprintf(temp, sizeof(temp), "hi");
 				break;
 			case REGISTER_LO:
 				value = cpu->GetLo();
-				len = sprintf(temp,"lo");
+				len = snprintf(temp, sizeof(temp), "lo");
 				break;
 			default:
 				temp[0] = '\0';
@@ -292,7 +290,7 @@ void CtrlRegisterList::onPaint(WPARAM wParam, LPARAM lParam)
 
 			SetTextColor(hdc,0x600000);
 			TextOutA(hdc,17,rowY1,temp,len);
-			len = sprintf(temp,"%08X",value);
+			len = snprintf(temp, sizeof(temp), "%08X",value);
 			if (changedCat0Regs[i])
 				SetTextColor(hdc, 0x0000FF);
 			else

--- a/Windows/Debugger/CtrlRegisterList.h
+++ b/Windows/Debugger/CtrlRegisterList.h
@@ -1,5 +1,3 @@
-// NOTE: Apologies for the quality of this code, this is really from pre-opensource Dolphin - that is, 2003.
-
 #pragma once
 
 //////////////////////////////////////////////////////////////////////////

--- a/Windows/Debugger/Debugger_MemoryDlg.cpp
+++ b/Windows/Debugger/Debugger_MemoryDlg.cpp
@@ -1,5 +1,3 @@
-// NOTE: Apologies for the quality of this code, this is really from pre-opensource Dolphin - that is, 2003.
-
 #include "Windows/stdafx.h"
 #include <windowsx.h>
 #include <commctrl.h>

--- a/Windows/Debugger/Debugger_MemoryDlg.h
+++ b/Windows/Debugger/Debugger_MemoryDlg.h
@@ -1,5 +1,3 @@
-// NOTE: Apologies for the quality of this code, this is really from pre-opensource Dolphin - that is, 2003.
-
 #pragma once
 #include "Windows/W32Util/DialogManager.h"
 

--- a/Windows/Debugger/Debugger_VFPUDlg.cpp
+++ b/Windows/Debugger/Debugger_VFPUDlg.cpp
@@ -1,5 +1,3 @@
-// NOTE: Apologies for the quality of this code, this is really from pre-opensource Dolphin - that is, 2003.
-
 #include "Common/CommonWindows.h"
 #include <windowsx.h>
 #include <commctrl.h>

--- a/Windows/Debugger/DumpMemoryWindow.cpp
+++ b/Windows/Debugger/DumpMemoryWindow.cpp
@@ -152,7 +152,7 @@ bool DumpMemoryWindow::fetchDialogData(HWND hwnd)
 	if (cpu->initExpression(str,exp) == false
 		|| cpu->parseExpression(exp,start) == false)
 	{
-		sprintf(errorMessage,"Invalid address expression \"%s\".",str);
+		snprintf(errorMessage, sizeof(errorMessage), "Invalid address expression \"%s\".",str);
 		MessageBoxA(hwnd,errorMessage,"Error",MB_OK);
 		return false;
 	}
@@ -162,7 +162,7 @@ bool DumpMemoryWindow::fetchDialogData(HWND hwnd)
 	if (cpu->initExpression(str,exp) == false
 		|| cpu->parseExpression(exp,size) == false)
 	{
-		sprintf(errorMessage,"Invalid size expression \"%s\".",str);
+		snprintf(errorMessage, sizeof(errorMessage), "Invalid size expression \"%s\".",str);
 		MessageBoxA(hwnd,errorMessage,"Error",MB_OK);
 		return false;
 	}
@@ -198,12 +198,12 @@ bool DumpMemoryWindow::fetchDialogData(HWND hwnd)
 
 	if (invalidAddress)
 	{
-		sprintf(errorMessage,"Invalid address 0x%08X.",start);
+		snprintf(errorMessage, sizeof(errorMessage), "Invalid address 0x%08X.",start);
 		MessageBoxA(hwnd,errorMessage,"Error",MB_OK);
 		return false;
 	} else if (invalidSize)
 	{
-		sprintf(errorMessage,"Invalid end address 0x%08X.",start+size);
+		snprintf(errorMessage, sizeof(errorMessage), "Invalid end address 0x%08X.",start+size);
 		MessageBoxA(hwnd,errorMessage,"Error",MB_OK);
 		return false;
 	}
@@ -232,8 +232,7 @@ void DumpMemoryWindow::changeMode(HWND hwnd, Mode newMode)
 		u32 start = 0, size = 0;
 		const char *defaultFileName = "";
 
-		switch (selectedMode)
-		{
+		switch (selectedMode) {
 		case MODE_RAM:
 			start = PSP_GetUserMemoryBase();
 			size = PSP_GetUserMemoryEnd()-start;
@@ -251,11 +250,11 @@ void DumpMemoryWindow::changeMode(HWND hwnd, Mode newMode)
 			break;
 		}
 		
-		sprintf(buffer,"0x%08X",start);
+		snprintf(buffer, sizeof(buffer), "0x%08X", start);
 		SetWindowTextA(GetDlgItem(hwnd,IDC_DUMP_STARTADDRESS),buffer);
 		EnableWindow(GetDlgItem(hwnd,IDC_DUMP_STARTADDRESS),FALSE);
 
-		sprintf(buffer,"0x%08X",size);
+		snprintf(buffer, sizeof(buffer), "0x%08X", size);
 		SetWindowTextA(GetDlgItem(hwnd,IDC_DUMP_SIZE),buffer);
 		EnableWindow(GetDlgItem(hwnd,IDC_DUMP_SIZE),FALSE);
 		

--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -228,7 +228,7 @@ void CtrlDisplayListView::onPaint(WPARAM wParam, LPARAM lParam)
 		GPUDebugOp op = i < (int)disasm.size() ? disasm[i] : GPUDebugOp();
 
 		char addressText[64];
-		sprintf(addressText,"%08X %08X",op.pc,op.op);
+		snprintf(addressText,sizeof(addressText),"%08X %08X",op.pc,op.op);
 		TextOutA(hdc,pixelPositions.addressStart,rowY1+2,addressText,(int)strlen(addressText));
 
 		if (address == list.pc)
@@ -344,7 +344,7 @@ void CtrlDisplayListView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 		case ID_DISASM_COPYADDRESS:
 			{
 				char temp[16];
-				sprintf(temp,"%08X",curAddress);
+				snprintf(temp,sizeof(temp),"%08X",curAddress);
 				W32Util::CopyTextToClipboard(wnd, temp);
 			}
 			break;

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -18,12 +18,12 @@
 // TODO: Get rid of the internal window.
 // Tried before but Intel drivers screw up when minimizing, or something ?
 
-// NOTE: Apologies for the quality of this code, this is really from pre-opensource Dolphin - that is, 2003.
-// It's improving slowly, though. :)
 #include "stdafx.h"
+
+#include "ppsspp_config.h"
+
 #include "Common/CommonWindows.h"
 #include "Common/OSVersion.h"
-#include "ppsspp_config.h"
 
 #include <Windowsx.h>
 #include <shellapi.h>

--- a/Windows/W32Util/ShellUtil.cpp
+++ b/Windows/W32Util/ShellUtil.cpp
@@ -1,5 +1,3 @@
-// NOTE: Apologies for the quality of this code, this is really from pre-opensource Dolphin - that is, 2003.
-
 #pragma warning(disable:4091)  // workaround bug in VS2015 headers
 
 #include "Windows/stdafx.h"
@@ -59,9 +57,6 @@ namespace W32Util
 		return result;
 	}
 
-	//---------------------------------------------------------------------------------------------------
-	// function WinBrowseForFileName
-	//---------------------------------------------------------------------------------------------------
 	bool BrowseForFileName(bool _bLoad, HWND _hParent, const wchar_t *_pTitle,
 		const wchar_t *_pInitialFolder, const wchar_t *_pFilter, const wchar_t *_pExtension,
 		std::string &_strFileName) {

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -384,7 +384,7 @@ void System_ShowKeyboard() {
 
 void System_Vibrate(int length_ms) {
 	char temp[32];
-	sprintf(temp, "%i", length_ms);
+	snprintf(temp, sizeof(temp), "%", length_ms);
 	PushCommand("vibrate", temp);
 }
 


### PR DESCRIPTION
Protects against various possible buffer overflows. Some of these could never overflow, but replacing them makes it easier to search for instances of sprintf in the future.

There are still a few places in the code where we use sprintf (like in disassemblers), will fix them up in the future.

With some luck, this may help #17341 .