### PR TITLE
Mac/Linux: Restart app on backend change

### DIFF
--- a/SDL/CocoaBarItems.mm
+++ b/SDL/CocoaBarItems.mm
@@ -18,6 +18,7 @@
 #include "GPU/GPUInterface.h"
 #include "Common/File/Path.h"
 #include "Common/System/System.h"
+#include "Common/System/Request.h"
 #include "Common/System/NativeApp.h"
 #include "Core/Config.h"
 #include "Common/Data/Text/I18n.h"
@@ -551,6 +552,10 @@ TOGGLE_METHOD(ShowDebugStats, g_Config.bShowDebugStats, NativeMessageReceived("c
             break;
         }
     }
+
+    // TODO: Use same command line params as the previous startup?
+    // Note that this does a clean shutdown, so the config will be saved automatically.
+    System_RestartApp("");
 }
 
 -(NSControlStateValue) controlStateForBool: (BOOL)boolValue {

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -192,6 +192,7 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 	switch (type) {
 	case SystemRequestType::RESTART_APP:
 		g_RestartRequested = true;
+		// TODO: Also save param1 and then split it into an argv.
 		return true;
 	case SystemRequestType::EXIT_APP:
 		// Do a clean exit
@@ -1400,6 +1401,10 @@ int main(int argc, char *argv[]) {
 	if (g_RestartRequested) {
 #if PPSSPP_PLATFORM(MAC)
 		RestartMacApp();
+#elif PPSSPP_PLATFORM(LINUX)
+		// Hackery from https://unix.stackexchange.com/questions/207935/how-to-restart-or-reset-a-running-process-in-linux,
+		char *exec_argv[] = { argv[0], nullptr };
+		execv("/proc/self/exe", exec_argv);
 #endif
 	}
 	return 0;

--- a/SDL/SDLMain.mm
+++ b/SDL/SDLMain.mm
@@ -351,8 +351,6 @@ static void CustomApplicationMain (int argc, char **argv)
 
 @end
 
-
-
 #ifdef main
 #  undef main
 #endif

--- a/UI/DarwinFileSystemServices.h
+++ b/UI/DarwinFileSystemServices.h
@@ -33,3 +33,4 @@ private:
 #endif // PPSSPP_PLATFORM(IOS)
 };
 
+void RestartMacApp();

--- a/UI/DarwinFileSystemServices.mm
+++ b/UI/DarwinFileSystemServices.mm
@@ -115,3 +115,13 @@ void DarwinFileSystemServices::setUserPreferredMemoryStickDirectory(Path path) {
     g_Config.memStickDirectory = path;
 }
 
+void RestartMacApp() {
+#if PPSSPP_PLATFORM(MAC)
+    NSURL *bundleURL = NSBundle.mainBundle.bundleURL;
+    NSTask *task = [[NSTask alloc] init];
+    task.executableURL = [NSURL fileURLWithPath:@"/usr/bin/open"];
+    task.arguments = @[@"-n", bundleURL.path];
+    [task launch];
+    exit(0);
+#endif
+}


### PR DESCRIPTION
This works both when changing backends through the cocoa menu, and through the in-window settings menu, since this correctly implements System_RestartApp on Mac unlike before where it would just exit.

In Linux, we just self-execv. Not sure if that's the best way, but appears to work.