### PR TITLE
Cleanup some more string formats, mostly in debugger

### DIFF
--- a/Common/ArmCPUDetect.cpp
+++ b/Common/ArmCPUDetect.cpp
@@ -32,10 +32,10 @@
 #if defined(CPU_FEATURES_OS_LINUX) || defined(CPU_FEATURES_OS_ANDROID)
 #define USE_CPU_FEATURES 1
 #endif
-#elif PPSSPP_ARCH(ARM64) && defined(__aarch64__)
+#elif PPSSPP_ARCH(ARM64)
 #include "ext/cpu_features/include/cpuinfo_aarch64.h"
 
-#if defined(CPU_FEATURES_OS_LINUX) || defined(CPU_FEATURES_OS_ANDROID)
+#if defined(CPU_FEATURES_OS_LINUX) || defined(CPU_FEATURES_OS_ANDROID) || defined(CPU_FEATURES_OS_WINDOWS)
 #define USE_CPU_FEATURES 1
 #endif
 #endif
@@ -54,7 +54,7 @@
 std::string GetCPUBrandString();
 #else
 // No CPUID on ARM, so we'll have to read the registry
-#include <windows.h>
+#include "Common/CommonWindows.h"
 std::string GetCPUBrandString() {
 	std::string cpu_string;
 	

--- a/Common/Math/expression_parser.h
+++ b/Common/Math/expression_parser.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <cstddef>
+#include <string>
 #include <vector>
 
 typedef std::pair<uint32_t, uint32_t> ExpressionPair;
@@ -21,7 +22,7 @@ public:
 	virtual bool parseSymbol(char* str, uint32_t& symbolValue) = 0;
 	virtual uint32_t getReferenceValue(uint32_t referenceIndex) = 0;
 	virtual ExpressionType getReferenceType(uint32_t referenceIndex) = 0;
-	virtual bool getMemoryValue(uint32_t address, int size, uint32_t& dest, char *error, size_t errorBufSize) = 0;
+	virtual bool getMemoryValue(uint32_t address, int size, uint32_t& dest, std::string *error) = 0;
 };
 
 bool initPostfixExpression(const char* infix, IExpressionFunctions* funcs, PostfixExpression& dest);

--- a/Common/RiscVCPUDetect.cpp
+++ b/Common/RiscVCPUDetect.cpp
@@ -209,8 +209,8 @@ void CPUInfo::Detect()
 	RiscV_C = ExtensionSupported(hwcap, 'C');
 	RiscV_V = ExtensionSupported(hwcap, 'V');
 	RiscV_B = ExtensionSupported(hwcap, 'B');
-	// Let's assume for now...
-	RiscV_Zicsr = RiscV_M && RiscV_A && RiscV_F && RiscV_D;
+	// We assume as in RVA20U64 that F means Zicsr is available.
+	RiscV_Zicsr = RiscV_F;
 
 #ifdef USE_CPU_FEATURES
 	cpu_features::RiscvInfo info = cpu_features::GetRiscvInfo();
@@ -220,6 +220,7 @@ void CPUInfo::Detect()
 	RiscV_F = info.features.F;
 	RiscV_D = info.features.D;
 	RiscV_C = info.features.C;
+	RiscV_V = info.features.V;
 	RiscV_Zicsr = info.features.Zicsr;
 
 	truncate_cpy(brand_string, info.uarch);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -781,6 +781,7 @@ static const ConfigSetting debuggerSettings[] = {
 	ConfigSetting("ShowGpuProfile", &g_Config.bShowGpuProfile, false, CfgFlag::DONT_SAVE),
 	ConfigSetting("SkipDeadbeefFilling", &g_Config.bSkipDeadbeefFilling, false, CfgFlag::DEFAULT),
 	ConfigSetting("FuncHashMap", &g_Config.bFuncHashMap, false, CfgFlag::DEFAULT),
+	ConfigSetting("SkipFuncHashMap", &g_Config.sSkipFuncHashMap, "", CfgFlag::DEFAULT),
 	ConfigSetting("MemInfoDetailed", &g_Config.bDebugMemInfoDetailed, false, CfgFlag::DEFAULT),
 	ConfigSetting("DrawFrameGraph", &g_Config.bDrawFrameGraph, false, CfgFlag::DEFAULT),
 };

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -484,6 +484,7 @@ public:
 	// Double edged sword: much easier debugging, but not accurate.
 	bool bSkipDeadbeefFilling;
 	bool bFuncHashMap;
+	std::string sSkipFuncHashMap;
 	bool bDebugMemInfoDetailed;
 	bool bDrawFrameGraph;
 

--- a/Core/Debugger/DebugInterface.h
+++ b/Core/Debugger/DebugInterface.h
@@ -61,7 +61,7 @@ public:
 	virtual int GetNumCategories() {return 0;}
 	virtual int GetNumRegsInCategory(int cat) {return 0;}
 	virtual const char *GetCategoryName(int cat) {return 0;}
-	virtual const char *GetRegName(int cat, int index) {return 0;}
+	virtual std::string GetRegName(int cat, int index) { return ""; }
 	virtual void PrintRegValue(int cat, int index, char *out, size_t outSize) {
 		snprintf(out, outSize, "%08X", GetGPR32Value(index));
 	}

--- a/Core/Debugger/DebugInterface.h
+++ b/Core/Debugger/DebugInterface.h
@@ -26,7 +26,6 @@ struct MemMap;
 
 class DebugInterface {
 public:
-	virtual const char *disasm(unsigned int address, unsigned int align) {return "NODEBUGGER";}
 	virtual int getInstructionSize(int instruction) {return 1;}
 
 	virtual bool isAlive() {return true;}
@@ -55,8 +54,8 @@ public:
 	virtual u32 GetPC() = 0;
 	virtual void SetPC(u32 _pc) = 0;
 	virtual u32 GetLR() {return GetPC();}
-	virtual void DisAsm(u32 op, u32 pc, int align, char *out, size_t outSize) {
-		snprintf(out, outSize, "[%08x] UNKNOWN", op);
+	virtual void DisAsm(u32 pc, char *out, size_t outSize) {
+		snprintf(out, outSize, "[%08x] UNKNOWN", pc);
 	}
 	// More stuff for debugger
 	virtual int GetNumCategories() {return 0;}

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -102,36 +102,33 @@ static HashType computeHash(u32 address, u32 size)
 }
 
 
-void parseDisasm(const char* disasm, char* opcode, char* arguments, bool insertSymbols)
-{
+static void parseDisasm(const char *disasm, char *opcode, size_t opcodeSize, char *arguments, size_t argumentsSize, bool insertSymbols) {
 	// copy opcode
-	while (*disasm != 0 && *disasm != '\t')
-	{
-		*opcode++ = *disasm++;
+	size_t opcodePos = 0;
+	while (*disasm != 0 && *disasm != '\t' && opcodePos + 1 < opcodeSize) {
+		opcode[opcodePos++] = *disasm++;
 	}
-	*opcode = 0;
+	opcode[opcodePos] = 0;
 
-	if (*disasm++ == 0)
-	{
+	// Otherwise it's a tab, and we skip intentionally.
+	if (*disasm++ == 0) {
 		*arguments = 0;
 		return;
 	}
 
 	const char* jumpAddress = strstr(disasm,"->$");
 	const char* jumpRegister = strstr(disasm,"->");
-	while (*disasm != 0)
-	{
+	size_t argumentsPos = 0;
+	while (*disasm != 0 && argumentsPos + 1 < argumentsSize) {
 		// parse symbol
-		if (disasm == jumpAddress)
-		{
+		if (disasm == jumpAddress) {
 			u32 branchTarget = 0;
 			sscanf(disasm+3, "%08x", &branchTarget);
 			const std::string addressSymbol = g_symbolMap->GetLabelString(branchTarget);
-			if (!addressSymbol.empty() && insertSymbols)
-			{
-				arguments += sprintf(arguments, "%s", addressSymbol.c_str());
+			if (!addressSymbol.empty() && insertSymbols) {
+				argumentsPos += snprintf(&arguments[argumentsPos], argumentsSize - argumentsPos, "%s", addressSymbol.c_str());
 			} else {
-				arguments += sprintf(arguments, "0x%08X", branchTarget);
+				argumentsPos += snprintf(&arguments[argumentsPos], argumentsSize - argumentsPos, "0x%08X", branchTarget);
 			}
 
 			disasm += 3+8;
@@ -141,15 +138,14 @@ void parseDisasm(const char* disasm, char* opcode, char* arguments, bool insertS
 		if (disasm == jumpRegister)
 			disasm += 2;
 
-		if (*disasm == ' ')
-		{
+		if (*disasm == ' ') {
 			disasm++;
 			continue;
 		}
-		*arguments++ = *disasm++;
+		arguments[argumentsPos++] = *disasm++;
 	}
 
-	*arguments = 0;
+	arguments[argumentsPos] = 0;
 }
 
 std::map<u32,DisassemblyEntry*>::iterator findDisassemblyEntry(std::map<u32,DisassemblyEntry*>& entries, u32 address, bool exact)
@@ -768,7 +764,7 @@ bool DisassemblyOpcode::disassemble(u32 address, DisassemblyLineInfo &dest, bool
 	char opcode[64],arguments[256];
 	char dizz[512];
 	cpuDebug->DisAsm(address, dizz, sizeof(dizz));
-	parseDisasm(dizz,opcode,arguments,insertSymbols);
+	parseDisasm(dizz, opcode, sizeof(opcode), arguments, sizeof(arguments), insertSymbols);
 	dest.type = DISTYPE_OPCODE;
 	dest.name = opcode;
 	dest.params = arguments;

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -847,9 +847,9 @@ bool DisassemblyMacro::disassemble(u32 address, DisassemblyLineInfo &dest, bool 
 		
 		addressSymbol = g_symbolMap->GetLabelString(immediate);
 		if (!addressSymbol.empty() && insertSymbols) {
-			snprintf(buffer, sizeof(buffer), "%s,%s", cpuDebug->GetRegName(0, rt), addressSymbol.c_str());
+			snprintf(buffer, sizeof(buffer), "%s,%s", cpuDebug->GetRegName(0, rt).c_str(), addressSymbol.c_str());
 		} else {
-			snprintf(buffer, sizeof(buffer), "%s,0x%08X", cpuDebug->GetRegName(0, rt), immediate);
+			snprintf(buffer, sizeof(buffer), "%s,0x%08X", cpuDebug->GetRegName(0, rt).c_str(), immediate);
 		}
 
 		dest.params = buffer;
@@ -862,9 +862,9 @@ bool DisassemblyMacro::disassemble(u32 address, DisassemblyLineInfo &dest, bool 
 
 		addressSymbol = g_symbolMap->GetLabelString(immediate);
 		if (!addressSymbol.empty() && insertSymbols) {
-			snprintf(buffer, sizeof(buffer), "%s,%s", cpuDebug->GetRegName(0, rt), addressSymbol.c_str());
+			snprintf(buffer, sizeof(buffer), "%s,%s", cpuDebug->GetRegName(0, rt).c_str(), addressSymbol.c_str());
 		} else {
-			snprintf(buffer, sizeof(buffer), "%s,0x%08X", cpuDebug->GetRegName(0, rt), immediate);
+			snprintf(buffer, sizeof(buffer), "%s,0x%08X", cpuDebug->GetRegName(0, rt).c_str(), immediate);
 		}
 
 		dest.params = buffer;

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -766,7 +766,8 @@ bool DisassemblyOpcode::disassemble(u32 address, DisassemblyLineInfo &dest, bool
 		cpuDebug = DisassemblyManager::getCpu();
 
 	char opcode[64],arguments[256];
-	const char *dizz = cpuDebug->disasm(address, 4);
+	char dizz[512];
+	cpuDebug->DisAsm(address, dizz, sizeof(dizz));
 	parseDisasm(dizz,opcode,arguments,insertSymbols);
 	dest.type = DISTYPE_OPCODE;
 	dest.name = opcode;

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -204,7 +204,7 @@ bool ElfReader::LoadRelocations(const Elf32_Rel *rels, int numRelocs) {
 			default:
 			{
 				char temp[256];
-				MIPSDisAsm(MIPSOpcode(op), 0, temp);
+				MIPSDisAsm(MIPSOpcode(op), 0, temp, sizeof(temp));
 				ERROR_LOG_REPORT(LOADER, "ARGH IT'S AN UNKNOWN RELOCATION!!!!!!!! %08x, type=%d : %s", addr, type, temp);
 			}
 			break;

--- a/Core/MIPS/ARM/ArmCompVFPU.cpp
+++ b/Core/MIPS/ARM/ArmCompVFPU.cpp
@@ -142,7 +142,7 @@ namespace MIPSComp
 				// Prefix may say "z, z, z, z" but if this is a pair, we force to x.
 				// TODO: But some ops seem to use const 0 instead?
 				if (regnum >= n) {
-					WARN_LOG(CPU, "JIT: Invalid VFPU swizzle: %08x : %d / %d at PC = %08x (%s)", prefix, regnum, n, GetCompilerPC(), MIPSDisasmAt(GetCompilerPC()));
+					WARN_LOG(CPU, "JIT: Invalid VFPU swizzle: %08x : %d / %d at PC = %08x (%s)", prefix, regnum, n, GetCompilerPC(), MIPSDisasmAt(GetCompilerPC()).c_str());
 					regnum = 0;
 				}
 				

--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -383,7 +383,7 @@ const u8 *ArmJit::DoJit(u32 em_address, JitBlock *b)
 	if (logBlocks > 0 && dontLogBlocks == 0) {
 		INFO_LOG(JIT, "=============== mips ===============");
 		for (u32 cpc = em_address; cpc != GetCompilerPC() + 4; cpc += 4) {
-			MIPSDisAsm(Memory::Read_Opcode_JIT(cpc), cpc, temp, true);
+			MIPSDisAsm(Memory::Read_Opcode_JIT(cpc), cpc, temp, sizeof(temp), true);
 			INFO_LOG(JIT, "M: %08x   %s", cpc, temp);
 		}
 	}

--- a/Core/MIPS/ARM/ArmRegCacheFPU.cpp
+++ b/Core/MIPS/ARM/ArmRegCacheFPU.cpp
@@ -584,11 +584,11 @@ ARMReg ArmRegCacheFPU::R(int mipsReg) {
 		return (ARMReg)(mr[mipsReg].reg + S0);
 	} else {
 		if (mipsReg < 32) {
-			ERROR_LOG(JIT, "FReg %i not in ARM reg. compilerPC = %08x : %s", mipsReg, js_->compilerPC, MIPSDisasmAt(js_->compilerPC));
+			ERROR_LOG(JIT, "FReg %i not in ARM reg. compilerPC = %08x : %s", mipsReg, js_->compilerPC, MIPSDisasmAt(js_->compilerPC).c_str());
 		} else if (mipsReg < 32 + 128) {
-			ERROR_LOG(JIT, "VReg %i not in ARM reg. compilerPC = %08x : %s", mipsReg - 32, js_->compilerPC, MIPSDisasmAt(js_->compilerPC));
+			ERROR_LOG(JIT, "VReg %i not in ARM reg. compilerPC = %08x : %s", mipsReg - 32, js_->compilerPC, MIPSDisasmAt(js_->compilerPC).c_str());
 		} else {
-			ERROR_LOG(JIT, "Tempreg %i not in ARM reg. compilerPC = %08x : %s", mipsReg - 128 - 32, js_->compilerPC, MIPSDisasmAt(js_->compilerPC));
+			ERROR_LOG(JIT, "Tempreg %i not in ARM reg. compilerPC = %08x : %s", mipsReg - 128 - 32, js_->compilerPC, MIPSDisasmAt(js_->compilerPC).c_str());
 		}
 		return INVALID_REG;  // BAAAD
 	}

--- a/Core/MIPS/ARM/ArmRegCacheFPU.cpp
+++ b/Core/MIPS/ARM/ArmRegCacheFPU.cpp
@@ -618,7 +618,7 @@ void ArmRegCacheFPU::QFlush(int quad) {
 	}
 
 	if (qr[quad].isDirty && !qr[quad].isTemp) {
-		INFO_LOG(JIT, "Flushing Q%i (%s)", quad, GetVectorNotation(qr[quad].mipsVec, qr[quad].sz));
+		INFO_LOG(JIT, "Flushing Q%i (%s)", quad, GetVectorNotation(qr[quad].mipsVec, qr[quad].sz).c_str());
 
 		ARMReg q = QuadAsQ(quad);
 		// Unlike reads, when writing to the register file we need to be careful to write the correct
@@ -881,7 +881,7 @@ ARMReg ArmRegCacheFPU::QMapReg(int vreg, VectorSize sz, int flags) {
 	// We didn't find the extra register, but we got a list of regs to flush. Flush 'em.
 	// Here we can check for opportunities to do a "transpose-flush" of row vectors, etc.
 	if (!quadsToFlush.empty()) {
-		INFO_LOG(JIT, "New mapping %s collided with %d quads, flushing them.", GetVectorNotation(vreg, sz), (int)quadsToFlush.size());
+		INFO_LOG(JIT, "New mapping %s collided with %d quads, flushing them.", GetVectorNotation(vreg, sz).c_str(), (int)quadsToFlush.size());
 	}
 	for (size_t i = 0; i < quadsToFlush.size(); i++) {
 		QFlush(quadsToFlush[i]);
@@ -973,7 +973,7 @@ ARMReg ArmRegCacheFPU::QMapReg(int vreg, VectorSize sz, int flags) {
 	qr[quad].isDirty = (flags & MAP_DIRTY) != 0;
 	qr[quad].spillLock = true;
 
-	INFO_LOG(JIT, "Mapped Q%i to vfpu %i (%s), sz=%i, dirty=%i", quad, vreg, GetVectorNotation(vreg, sz), (int)sz, qr[quad].isDirty);
+	INFO_LOG(JIT, "Mapped Q%i to vfpu %i (%s), sz=%i, dirty=%i", quad, vreg, GetVectorNotation(vreg, sz).c_str(), (int)sz, qr[quad].isDirty);
 	if (sz == V_Single || sz == V_Pair) {
 		return D_0(QuadAsQ(quad));
 	} else {

--- a/Core/MIPS/ARM64/Arm64CompVFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompVFPU.cpp
@@ -134,7 +134,7 @@ namespace MIPSComp {
 				// Prefix may say "z, z, z, z" but if this is a pair, we force to x.
 				// TODO: But some ops seem to use const 0 instead?
 				if (regnum >= n) {
-					WARN_LOG(CPU, "JIT: Invalid VFPU swizzle: %08x : %d / %d at PC = %08x (%s)", prefix, regnum, n, GetCompilerPC(), MIPSDisasmAt(GetCompilerPC()));
+					WARN_LOG(CPU, "JIT: Invalid VFPU swizzle: %08x : %d / %d at PC = %08x (%s)", prefix, regnum, n, GetCompilerPC(), MIPSDisasmAt(GetCompilerPC()).c_str());
 					regnum = 0;
 				}
 

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -372,7 +372,7 @@ const u8 *Arm64Jit::DoJit(u32 em_address, JitBlock *b) {
 	if (logBlocks > 0 && dontLogBlocks == 0) {
 		INFO_LOG(JIT, "=============== mips %d ===============", blocks.GetNumBlocks());
 		for (u32 cpc = em_address; cpc != GetCompilerPC() + 4; cpc += 4) {
-			MIPSDisAsm(Memory::Read_Opcode_JIT(cpc), cpc, temp, true);
+			MIPSDisAsm(Memory::Read_Opcode_JIT(cpc), cpc, temp, sizeof(temp), true);
 			INFO_LOG(JIT, "M: %08x   %s", cpc, temp);
 		}
 	}

--- a/Core/MIPS/ARM64/Arm64RegCacheFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCacheFPU.cpp
@@ -520,11 +520,11 @@ ARM64Reg Arm64RegCacheFPU::R(int mipsReg) {
 		return (ARM64Reg)(mr[mipsReg].reg + S0);
 	} else {
 		if (mipsReg < 32) {
-			ERROR_LOG(JIT, "FReg %i not in ARM reg. compilerPC = %08x : %s", mipsReg, js_->compilerPC, MIPSDisasmAt(js_->compilerPC));
+			ERROR_LOG(JIT, "FReg %i not in ARM reg. compilerPC = %08x : %s", mipsReg, js_->compilerPC, MIPSDisasmAt(js_->compilerPC).c_str());
 		} else if (mipsReg < 32 + 128) {
-			ERROR_LOG(JIT, "VReg %i not in ARM reg. compilerPC = %08x : %s", mipsReg - 32, js_->compilerPC, MIPSDisasmAt(js_->compilerPC));
+			ERROR_LOG(JIT, "VReg %i not in ARM reg. compilerPC = %08x : %s", mipsReg - 32, js_->compilerPC, MIPSDisasmAt(js_->compilerPC).c_str());
 		} else {
-			ERROR_LOG(JIT, "Tempreg %i not in ARM reg. compilerPC = %08x : %s", mipsReg - 128 - 32, js_->compilerPC, MIPSDisasmAt(js_->compilerPC));
+			ERROR_LOG(JIT, "Tempreg %i not in ARM reg. compilerPC = %08x : %s", mipsReg - 128 - 32, js_->compilerPC, MIPSDisasmAt(js_->compilerPC).c_str());
 		}
 		return INVALID_REG;  // BAAAD
 	}

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -283,7 +283,7 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, u32 &m
 		NOTICE_LOG(JIT, "=============== mips %08x ===============", em_address);
 		for (u32 cpc = em_address; cpc != GetCompilerPC(); cpc += 4) {
 			temp2[0] = 0;
-			MIPSDisAsm(Memory::Read_Opcode_JIT(cpc), cpc, temp2, true);
+			MIPSDisAsm(Memory::Read_Opcode_JIT(cpc), cpc, temp2, sizeof(temp2), true);
 			NOTICE_LOG(JIT, "M: %08x   %s", cpc, temp2);
 		}
 	}

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -208,7 +208,7 @@ int IRWriter::AddConstantFloat(float value) {
 	return AddConstant(val);
 }
 
-const char *GetGPRName(int r) {
+static std::string GetGPRName(int r) {
 	if (r < 32) {
 		return currentDebugMIPS->GetRegName(0, r);
 	}
@@ -259,7 +259,7 @@ void DisassembleParam(char *buf, int bufSize, u8 param, char type, u32 constant)
 
 	switch (type) {
 	case 'G':
-		snprintf(buf, bufSize, "%s", GetGPRName(param));
+		snprintf(buf, bufSize, "%s", GetGPRName(param).c_str());
 		break;
 	case 'F':
 		if (param >= 32) {

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -371,7 +371,7 @@ JitBlockDebugInfo IRBlockCache::GetBlockDebugInfo(int blockNum) const {
 
 	for (u32 addr = start; addr < start + size; addr += 4) {
 		char temp[256];
-		MIPSDisAsm(Memory::Read_Instruction(addr), addr, temp, true);
+		MIPSDisAsm(Memory::Read_Instruction(addr), addr, temp, sizeof(temp), true);
 		std::string mipsDis = temp;
 		debugInfo.origDisasm.push_back(mipsDis);
 	}

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -687,7 +687,7 @@ JitBlockDebugInfo JitBlockCache::GetBlockDebugInfo(int blockNum) const {
 	debugInfo.originalAddress = block->originalAddress;
 	for (u32 addr = block->originalAddress; addr <= block->originalAddress + block->originalSize * 4; addr += 4) {
 		char temp[256];
-		MIPSDisAsm(Memory::Read_Instruction(addr), addr, temp, true);
+		MIPSDisAsm(Memory::Read_Instruction(addr), addr, temp, sizeof(temp), true);
 		std::string mipsDis = temp;
 		debugInfo.origDisasm.push_back(mipsDis);
 	}

--- a/Core/MIPS/MIPSDebugInterface.cpp
+++ b/Core/MIPS/MIPSDebugInterface.cpp
@@ -22,11 +22,11 @@
 #include <strings.h>
 #endif
 
+#include "Common/StringUtils.h"
 #include "Core/Debugger/Breakpoints.h"
 #include "Core/Debugger/SymbolMap.h"
 #include "Core/Debugger/DebugInterface.h"
 #include "Core/MIPS/MIPSDebugInterface.h"
-
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/MemMap.h"
 #include "Core/MIPS/MIPSTables.h"
@@ -189,14 +189,11 @@ private:
 
 
 
-const char *MIPSDebugInterface::disasm(unsigned int address, unsigned int align)
-{
-	static char mojs[256];
-	if (Memory::IsValidAddress(address))
-		MIPSDisAsm(Memory::Read_Opcode_JIT(address), address, mojs);
+void MIPSDebugInterface::DisAsm(u32 pc, char *out, size_t outSize) {
+	if (Memory::IsValidAddress(pc))
+		MIPSDisAsm(Memory::Read_Opcode_JIT(pc), pc, out, outSize);
 	else
-		strcpy(mojs, "-");
-	return mojs;
+		truncate_cpy(out, outSize, "-");
 }
 
 unsigned int MIPSDebugInterface::readMemory(unsigned int address) {

--- a/Core/MIPS/MIPSDebugInterface.cpp
+++ b/Core/MIPS/MIPSDebugInterface.cpp
@@ -159,7 +159,7 @@ public:
 		return EXPR_TYPE_UINT;
 	}
 	
-	bool getMemoryValue(uint32_t address, int size, uint32_t& dest, char* error, size_t errorBufSize) override {
+	bool getMemoryValue(uint32_t address, int size, uint32_t& dest, std::string *error) override {
 		// We allow, but ignore, bad access.
 		// If we didn't, log/condition statements that reference registers couldn't be configured.
 		uint32_t valid = Memory::ValidSize(address, size);
@@ -179,7 +179,7 @@ public:
 			return true;
 		}
 
-		snprintf(error, errorBufSize, "Unexpected memory access size %d", size);
+		*error = StringFromFormat("Unexpected memory access size %d", size);
 		return false;
 	}
 

--- a/Core/MIPS/MIPSDebugInterface.h
+++ b/Core/MIPS/MIPSDebugInterface.h
@@ -62,7 +62,7 @@ public:
 		static int r[3] = { 32, 32, 128 };
 		return r[cat];
 	}
-	const char *GetRegName(int cat, int index) override;
+	std::string GetRegName(int cat, int index) override;
 
 	void PrintRegValue(int cat, int index, char *out, size_t outSize) override {
 		switch (cat) {

--- a/Core/MIPS/MIPSDebugInterface.h
+++ b/Core/MIPS/MIPSDebugInterface.h
@@ -28,7 +28,6 @@ class MIPSDebugInterface : public DebugInterface
 	MIPSState *cpu;
 public:
 	MIPSDebugInterface(MIPSState *_cpu) { cpu = _cpu; }
-	const char *disasm(unsigned int address, unsigned int align) override;
 	int getInstructionSize(int instruction) override { return 4; }
 	bool isAlive() override;
 	bool isBreakpoint(unsigned int address) override;
@@ -51,6 +50,7 @@ public:
 	u32 GetGPR32Value(int reg) override { return cpu->r[reg]; }
 	u32 GetPC() override { return cpu->pc; }
 	u32 GetLR() override { return cpu->r[MIPS_REG_RA]; }
+	void DisAsm(u32 pc, char *out, size_t outSize) override;
 	void SetPC(u32 _pc) override { cpu->pc = _pc; }
 
 	const char *GetCategoryName(int cat) override {

--- a/Core/MIPS/MIPSDis.cpp
+++ b/Core/MIPS/MIPSDis.cpp
@@ -40,10 +40,8 @@
 
 namespace MIPSDis
 {
-	// One shot, not re-entrant.
-	const char *SignedHex(int i)
-	{
-		static char temp[32];
+	std::string SignedHex(int i) {
+		char temp[32];
 		int offset = 0;
 		if (i < 0)
 		{
@@ -64,7 +62,7 @@ namespace MIPSDis
 		int imm = SignExtend16ToS32(op & 0xFFFF);
 		int rs = _RS;
 		int func = (op >> 16) & 0x1F;
-		snprintf(out, outSize, "%s\tfunc=%i, %s(%s)", MIPSGetName(op), func, RN(rs), SignedHex(imm));
+		snprintf(out, outSize, "%s\tfunc=%i, %s(%s)", MIPSGetName(op), func, RN(rs), SignedHex(imm).c_str());
 	}
 
 	void Dis_mxc1(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
@@ -94,7 +92,7 @@ namespace MIPSDis
 		int ft = _FT;
 		int rs = _RS;
 		const char *name = MIPSGetName(op);
-		snprintf(out, outSize, "%s\t%s, %s(%s)", name, FN(ft), SignedHex(offset), RN(rs));
+		snprintf(out, outSize, "%s\t%s, %s(%s)", name, FN(ft), SignedHex(offset).c_str(), RN(rs));
 	}
 
 	void Dis_FPUComp(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
@@ -170,7 +168,7 @@ namespace MIPSDis
 		case 8: //addi
 		case 9: //addiu
 		case 10: //slti
-			snprintf(out, outSize, "%s\t%s, %s, %s", name, RN(rt), RN(rs), SignedHex(simm));
+			snprintf(out, outSize, "%s\t%s, %s, %s", name, RN(rt), RN(rs), SignedHex(simm).c_str());
 			break;
 		case 11: //sltiu
 			snprintf(out, outSize, "%s\t%s, %s, 0x%X", name, RN(rt), RN(rs), suimm);
@@ -203,7 +201,7 @@ namespace MIPSDis
 		int rt = _RT;
 		int rs = _RS;
 		if (rs == 0)
-			snprintf(out, outSize, "li\t%s, %s", RN(rt), SignedHex(imm));
+			snprintf(out, outSize, "li\t%s, %s", RN(rt), SignedHex(imm).c_str());
 		else
 			Dis_IType(op, pc, out, outSize);
 	}
@@ -213,7 +211,7 @@ namespace MIPSDis
 		int rt = _RT;
 		int rs = _RS;
 		const char *name = MIPSGetName(op);
-		snprintf(out, outSize, "%s\t%s, %s(%s)", name, RN(rt), SignedHex(imm), RN(rs));
+		snprintf(out, outSize, "%s\t%s, %s(%s)", name, RN(rt), SignedHex(imm).c_str(), RN(rs));
 	}
 
 	void Dis_RType2(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {

--- a/Core/MIPS/MIPSDis.cpp
+++ b/Core/MIPS/MIPSDis.cpp
@@ -34,9 +34,9 @@
 #define _POS  ((op>>6 ) & 0x1F)
 #define _SIZE ((op>>11) & 0x1F)
 
-#define RN(i) currentDebugMIPS->GetRegName(0,i)
-#define FN(i) currentDebugMIPS->GetRegName(1,i)
-//#define VN(i) currentMIPS->GetRegName(2,i)
+#define RN(i) (currentDebugMIPS->GetRegName(0, i).c_str())
+#define FN(i) (currentDebugMIPS->GetRegName(1, i).c_str())
+//#define VN(i) (currentDebugMIPS->GetRegName(2, i).c_str())
 
 namespace MIPSDis
 {

--- a/Core/MIPS/MIPSDis.cpp
+++ b/Core/MIPS/MIPSDis.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include <cstring>
+#include "Common/StringUtils.h"
 #include "Core/HLE/HLE.h"
 #include "Core/MemMap.h"
 #include "Core/MIPS/MIPS.h"
@@ -37,8 +38,6 @@
 #define FN(i) currentDebugMIPS->GetRegName(1,i)
 //#define VN(i) currentMIPS->GetRegName(2,i)
 
-u32 disPC;
-
 namespace MIPSDis
 {
 	// One shot, not re-entrant.
@@ -53,108 +52,96 @@ namespace MIPSDis
 			i = -i;
 		}
 
-		sprintf(&temp[offset], "0x%X", i);
+		snprintf(&temp[offset], sizeof(temp) - offset, "0x%X", i);
 		return temp;
 	}
 
-	void Dis_Generic(MIPSOpcode op, char *out)
-	{
-		sprintf(out, "%s\t --- unknown ---", MIPSGetName(op));
+	void Dis_Generic(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
+		snprintf(out, outSize, "%s\t --- unknown ---", MIPSGetName(op));
 	}
 
-	void Dis_Cache(MIPSOpcode op, char *out)
-	{
+	void Dis_Cache(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int imm = SignExtend16ToS32(op & 0xFFFF);
 		int rs = _RS;
 		int func = (op >> 16) & 0x1F;
-		sprintf(out, "%s\tfunc=%i, %s(%s)", MIPSGetName(op), func, RN(rs), SignedHex(imm));
+		snprintf(out, outSize, "%s\tfunc=%i, %s(%s)", MIPSGetName(op), func, RN(rs), SignedHex(imm));
 	}
 
-	void Dis_mxc1(MIPSOpcode op, char *out)
-	{
+	void Dis_mxc1(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int fs = _FS;
 		int rt = _RT;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t%s, %s",name,RN(rt),FN(fs));
+		snprintf(out, outSize, "%s\t%s, %s", name, RN(rt), FN(fs));
 	}
 
-	void Dis_FPU3op(MIPSOpcode op, char *out)
-	{
+	void Dis_FPU3op(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int ft = _FT;
 		int fs = _FS;
 		int fd = _FD;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t%s, %s, %s",name,FN(fd),FN(fs),FN(ft));
+		snprintf(out, outSize, "%s\t%s, %s, %s", name, FN(fd), FN(fs), FN(ft));
 	}
 
-	void Dis_FPU2op(MIPSOpcode op, char *out)
-	{
+	void Dis_FPU2op(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int fs = _FS;
 		int fd = _FD;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t%s, %s",name,FN(fd),FN(fs));
+		snprintf(out, outSize, "%s\t%s, %s", name, FN(fd), FN(fs));
 	}
 
-	void Dis_FPULS(MIPSOpcode op, char *out)
-	{
+	void Dis_FPULS(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int offset = SignExtend16ToS32(op & 0xFFFF);
 		int ft = _FT;
 		int rs = _RS;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t%s, %s(%s)",name,FN(ft),SignedHex(offset),RN(rs));
+		snprintf(out, outSize, "%s\t%s, %s(%s)", name, FN(ft), SignedHex(offset), RN(rs));
 	}
-	void Dis_FPUComp(MIPSOpcode op, char *out)
-	{
+
+	void Dis_FPUComp(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int fs = _FS;
 		int ft = _FT;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t%s, %s",name,FN(fs),FN(ft));
+		snprintf(out, outSize, "%s\t%s, %s", name, FN(fs), FN(ft));
 	}
 
-	void Dis_FPUBranch(MIPSOpcode op, char *out)
-	{
-		u32 off = disPC;
+	void Dis_FPUBranch(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
+		u32 off = pc;
 		int imm = SignExtend16ToS32(op & 0xFFFF) << 2;
 		off += imm + 4;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t->$%08x",name,off);
+		snprintf(out, outSize, "%s\t->$%08x", name, off);
 	}
 
-	void Dis_RelBranch(MIPSOpcode op, char *out)
-	{
-		u32 off = disPC;
+	void Dis_RelBranch(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
+		u32 off = pc;
 		int imm = SignExtend16ToS32(op & 0xFFFF) << 2;
 		int rs = _RS;
 		off += imm + 4;
 
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t%s, ->$%08x", name, RN(rs), off);
+		snprintf(out, outSize, "%s\t%s, ->$%08x", name, RN(rs), off);
 	}
 
-	void Dis_Syscall(MIPSOpcode op, char *out)
-	{
+	void Dis_Syscall(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		u32 callno = (op>>6) & 0xFFFFF; //20 bits
 		int funcnum = callno & 0xFFF;
 		int modulenum = (callno & 0xFF000) >> 12;
-		sprintf(out, "syscall\t	%s",/*PSPHLE::GetModuleName(modulenum),*/GetFuncName(modulenum, funcnum));
+		snprintf(out, outSize, "syscall\t	%s", GetFuncName(modulenum, funcnum));
 	}
 
-	void Dis_ToHiloTransfer(MIPSOpcode op, char *out)
-	{
+	void Dis_ToHiloTransfer(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int rs = _RS;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t%s",name,RN(rs));
+		snprintf(out, outSize, "%s\t%s", name, RN(rs));
 	}
-	void Dis_FromHiloTransfer(MIPSOpcode op, char *out)
-	{
+	void Dis_FromHiloTransfer(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int rd = _RD;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t%s",name,RN(rd));
+		snprintf(out, outSize, "%s\t%s", name, RN(rd));
 	}
 
-	void Dis_RelBranch2(MIPSOpcode op, char *out)
-	{
-		u32 off = disPC;
+	void Dis_RelBranch2(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
+		u32 off = pc;
 		int imm = SignExtend16ToS32(op & 0xFFFF) << 2;
 		int rt = _RT;
 		int rs = _RS;
@@ -163,15 +150,14 @@ namespace MIPSDis
 		const char *name = MIPSGetName(op);
 		int o = op>>26;
 		if (o==4 && rs == rt)//beq
-			sprintf(out, "b\t->$%08x", off);
+			snprintf(out, outSize, "b\t->$%08x", off);
 		else if (o==20 && rs == rt)//beql
-			sprintf(out, "bl\t->$%08x", off);
+			snprintf(out, outSize, "bl\t->$%08x", off);
 		else
-			sprintf(out, "%s\t%s, %s, ->$%08x", name, RN(rs), RN(rt), off);
+			snprintf(out, outSize, "%s\t%s, %s, ->$%08x", name, RN(rs), RN(rt), off);
 	}
 
-	void Dis_IType(MIPSOpcode op, char *out)
-	{
+	void Dis_IType(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		u32 uimm = op & 0xFFFF;
 		u32 suimm = SignExtend16ToU32(op);
 		s32 simm = SignExtend16ToS32(op);
@@ -184,127 +170,114 @@ namespace MIPSDis
 		case 8: //addi
 		case 9: //addiu
 		case 10: //slti
-			sprintf(out, "%s\t%s, %s, %s",name,RN(rt),RN(rs),SignedHex(simm));
+			snprintf(out, outSize, "%s\t%s, %s, %s", name, RN(rt), RN(rs), SignedHex(simm));
 			break;
 		case 11: //sltiu
-			sprintf(out, "%s\t%s, %s, 0x%X",name,RN(rt),RN(rs),suimm);
+			snprintf(out, outSize, "%s\t%s, %s, 0x%X", name, RN(rt), RN(rs), suimm);
 			break;
 		default:
-			sprintf(out, "%s\t%s, %s, 0x%X",name,RN(rt),RN(rs),uimm);
+			snprintf(out, outSize, "%s\t%s, %s, 0x%X", name, RN(rt), RN(rs), uimm);
 			break;
 		}
 	}
-	void Dis_ori(MIPSOpcode op, char *out)
-	{
+	void Dis_ori(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		u32 uimm = op & 0xFFFF;
 		int rt = _RT;
 		int rs = _RS;
 		const char *name = MIPSGetName(op);
 		if (rs == 0)
-			sprintf(out, "li\t%s, 0x%X",RN(rt),uimm);
+			snprintf(out, outSize, "li\t%s, 0x%X", RN(rt), uimm);
 		else
-			sprintf(out, "%s\t%s, %s, 0x%X",name,RN(rt),RN(rs),uimm);
+			snprintf(out, outSize, "%s\t%s, %s, 0x%X", name, RN(rt), RN(rs), uimm);
 	}
 
-	void Dis_IType1(MIPSOpcode op, char *out)
-	{
+	void Dis_IType1(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		u32 uimm = op & 0xFFFF;
 		int rt = _RT;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t%s, 0x%X",name,RN(rt),uimm);
+		snprintf(out, outSize, "%s\t%s, 0x%X", name, RN(rt), uimm);
 	}
 
-	void Dis_addi(MIPSOpcode op, char *out)
-	{
+	void Dis_addi(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int imm = SignExtend16ToS32(op & 0xFFFF);
 		int rt = _RT;
 		int rs = _RS;
 		if (rs == 0)
-			sprintf(out, "li\t%s, %s",RN(rt),SignedHex(imm));
+			snprintf(out, outSize, "li\t%s, %s", RN(rt), SignedHex(imm));
 		else
-			Dis_IType(op,out);
+			Dis_IType(op, pc, out, outSize);
 	}
 
-	void Dis_ITypeMem(MIPSOpcode op, char *out)
-	{
+	void Dis_ITypeMem(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int imm = SignExtend16ToS32(op & 0xFFFF);
 		int rt = _RT;
 		int rs = _RS;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t%s, %s(%s)",name,RN(rt),SignedHex(imm),RN(rs));
+		snprintf(out, outSize, "%s\t%s, %s(%s)", name, RN(rt), SignedHex(imm), RN(rs));
 	}
 
-	void Dis_RType2(MIPSOpcode op, char *out)
-	{
+	void Dis_RType2(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int rs = _RS;
 		int rd = _RD;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t%s, %s",name,RN(rd),RN(rs));
+		snprintf(out, outSize, "%s\t%s, %s", name, RN(rd), RN(rs));
 	}
 
-	void Dis_RType3(MIPSOpcode op, char *out)
-	{
+	void Dis_RType3(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int rt = _RT;
 		int rs = _RS;
 		int rd = _RD;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t%s, %s, %s",name,RN(rd),RN(rs),RN(rt));
+		snprintf(out, outSize, "%s\t%s, %s, %s", name, RN(rd), RN(rs), RN(rt));
 	}
 
-	void Dis_addu(MIPSOpcode op, char *out)
-	{
+	void Dis_addu(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int rt = _RT;
 		int rs = _RS;
 		int rd = _RD;
 		const char *name = MIPSGetName(op);
 		if (rs==0 && rt==0)
-			sprintf(out,"li\t%s, 0",RN(rd));
+			snprintf(out, outSize, "li\t%s, 0", RN(rd));
 		else if (rs == 0)
-			sprintf(out,"move\t%s, %s",RN(rd),RN(rt));
+			snprintf(out, outSize, "move\t%s, %s", RN(rd), RN(rt));
 		else if (rt == 0)
-			sprintf(out,"move\t%s, %s",RN(rd),RN(rs));
+			snprintf(out, outSize, "move\t%s, %s", RN(rd), RN(rs));
 		else
-			sprintf(out, "%s\t%s, %s, %s",name,RN(rd),RN(rs),RN(rt));
+			snprintf(out, outSize, "%s\t%s, %s, %s", name, RN(rd), RN(rs), RN(rt));
 	}
 
-	void Dis_ShiftType(MIPSOpcode op, char *out)
-	{
+	void Dis_ShiftType(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int rt = _RT;
 		int rs = _RS;
 		int rd = _RD;
-		int sa = (op>>6)	& 0x1F;
+		int sa = (op>>6) & 0x1F;
 		const char *name = MIPSGetName(op);
 		if (((op & 0x3f) == 2) && rs == 1)
 			name = "rotr";
 		if (((op & 0x3f) == 6) && sa == 1)
 			name = "rotrv";
-		sprintf(out, "%s\t%s, %s, 0x%X",name,RN(rd),RN(rt),sa);
+		snprintf(out, outSize, "%s\t%s, %s, 0x%X", name, RN(rd), RN(rt), sa);
 	}
 
-	void Dis_VarShiftType(MIPSOpcode op, char *out)
-	{
+	void Dis_VarShiftType(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int rt = _RT;
 		int rs = _RS;
 		int rd = _RD;
-		int sa = (op>>6)	& 0x1F;
+		int sa = (op>>6) & 0x1F;
 		const char *name = MIPSGetName(op);
 		if (((op & 0x3f) == 6) && sa == 1)
 			name = "rotrv";
-		sprintf(out, "%s\t%s, %s, %s",name,RN(rd),RN(rt),RN(rs));
+		snprintf(out, outSize, "%s\t%s, %s, %s", name, RN(rd), RN(rt), RN(rs));
 	}
 
-
-	void Dis_MulDivType(MIPSOpcode op, char *out)
-	{
+	void Dis_MulDivType(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int rt = _RT;
 		int rs = _RS;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t%s, %s",name,RN(rs),RN(rt));
+		snprintf(out, outSize, "%s\t%s, %s", name, RN(rs), RN(rt));
 	}
 
-
-	void Dis_Special3(MIPSOpcode op, char *out)
-	{
+	void Dis_Special3(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int rs = _RS;
 		int Rt = _RT;
 		int pos = _POS;
@@ -315,77 +288,67 @@ namespace MIPSDis
 		case 0x0: //ext
 			{
 				int size = _SIZE + 1;
-				sprintf(out,"%s\t%s, %s, 0x%X, 0x%X",name,RN(Rt),RN(rs),pos,size);
+				snprintf(out, outSize, "%s\t%s, %s, 0x%X, 0x%X", name, RN(Rt), RN(rs), pos, size);
 			}
 			break;
 		case 0x4: // ins
 			{
 				int size = (_SIZE + 1) - pos;
-				sprintf(out,"%s\t%s, %s, 0x%X, 0x%X",name,RN(Rt),RN(rs),pos,size);
+				snprintf(out, outSize, "%s\t%s, %s, 0x%X, 0x%X", name, RN(Rt), RN(rs), pos, size);
 			}
 			break;
 		}
 	}
 
-	void Dis_JumpType(MIPSOpcode op, char *out)
-	{
+	void Dis_JumpType(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		u32 off = ((op & 0x03FFFFFF) << 2);
-		u32 addr = (disPC & 0xF0000000) | off;
+		u32 addr = (pc & 0xF0000000) | off;
 		const char *name = MIPSGetName(op);
-		sprintf(out, "%s\t->$%08x",name,addr);
+		snprintf(out, outSize, "%s\t->$%08x", name, addr);
 	}
 
-	void Dis_JumpRegType(MIPSOpcode op, char *out)
-	{
+	void Dis_JumpRegType(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int rs = _RS;
 		int rd = _RD;
 		const char *name = MIPSGetName(op);
 		if ((op & 0x3f) == 9 && rd != MIPS_REG_RA)
-			sprintf(out, "%s\t%s,->%s", name, RN(rd), RN(rs));
+			snprintf(out, outSize, "%s\t%s,->%s", name, RN(rd), RN(rs));
 		else
-			sprintf(out, "%s\t->%s", name, RN(rs));
+			snprintf(out, outSize, "%s\t->%s", name, RN(rs));
 	}
 
-	void Dis_Allegrex(MIPSOpcode op, char *out)
-	{
+	void Dis_Allegrex(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int rt = _RT;
 		int rd = _RD;
 		const char *name = MIPSGetName(op);
-		sprintf(out,"%s\t%s,%s",name,RN(rd),RN(rt));
+		snprintf(out, outSize, "%s\t%s,%s", name, RN(rd), RN(rt));
 	}
 
-	void Dis_Allegrex2(MIPSOpcode op, char *out)
-	{
+	void Dis_Allegrex2(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int rt = _RT;
 		int rd = _RD;
 		const char *name = MIPSGetName(op);
-		sprintf(out,"%s\t%s,%s",name,RN(rd),RN(rt));
+		snprintf(out, outSize,"%s\t%s,%s", name, RN(rd), RN(rt));
 	}
 
-	void Dis_Emuhack(MIPSOpcode op, char *out)
-	{
-		auto resolved = Memory::Read_Instruction(disPC, true);
-		union {
-			char disasm[256];
-			char truncated[241];
-		};
+	void Dis_Emuhack(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
+		auto resolved = Memory::Read_Instruction(pc, true);
+		char disasm[256];
 		if (MIPS_IS_EMUHACK(resolved)) {
-			strcpy(disasm, "(invalid emuhack)");
+			truncate_cpy(disasm, sizeof(disasm), "(invalid emuhack)");
 		} else {
-			MIPSDisAsm(resolved, disPC, disasm, true);
+			MIPSDisAsm(resolved, pc, disasm, sizeof(disasm), true);
 		}
 
-		// Truncate in case it was too long, just to avoid warnings.
-		truncated[240] = '\0';
 		switch (op.encoding >> 24) {
 		case 0x68:
-			snprintf(out, 256, "* jitblock: %s", truncated);
+			snprintf(out, outSize, "* jitblock: %s", disasm);
 			break;
 		case 0x6a:
-			snprintf(out, 256, "* replacement: %s", truncated);
+			snprintf(out, outSize, "* replacement: %s", disasm);
 			break;
 		default:
-			snprintf(out, 256, "* (invalid): %s", truncated);
+			snprintf(out, outSize, "* (invalid): %s", disasm);
 			break;
 		}
 	}

--- a/Core/MIPS/MIPSDis.h
+++ b/Core/MIPS/MIPSDis.h
@@ -20,44 +20,42 @@
 #include "Common/CommonTypes.h"
 #include "Core/MIPS/MIPS.h"
 
-extern u32 disPC;
-
 namespace MIPSDis
 {
-	void Dis_Unknown(MIPSOpcode op, char *out);
-	void Dis_Unimpl(MIPSOpcode op, char *out);
-	void Dis_Syscall(MIPSOpcode op, char *out);
+	void Dis_Unknown(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Unimpl(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Syscall(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
 
-	void Dis_mxc1(MIPSOpcode op, char *out);
-	void Dis_addi(MIPSOpcode op, char *out);
-	void Dis_addu(MIPSOpcode op, char *out);
-	void Dis_RelBranch2(MIPSOpcode op, char *out);
-	void Dis_RelBranch(MIPSOpcode op, char *out);
-	void Dis_Generic(MIPSOpcode op, char *out);
-	void Dis_Cache(MIPSOpcode op, char *out);
-	void Dis_IType(MIPSOpcode op, char *out);
-	void Dis_IType1(MIPSOpcode op, char *out);
-	void Dis_ITypeMem(MIPSOpcode op, char *out);
-	void Dis_RType2(MIPSOpcode op, char *out);
-	void Dis_RType3(MIPSOpcode op, char *out);
-	void Dis_MulDivType(MIPSOpcode op, char *out);
-	void Dis_ShiftType(MIPSOpcode op, char *out);
-	void Dis_VarShiftType(MIPSOpcode op, char *out);
-	void Dis_FPU3op(MIPSOpcode op, char *out);
-	void Dis_FPU2op(MIPSOpcode op, char *out);
-	void Dis_FPULS(MIPSOpcode op, char *out);
-	void Dis_FPUComp(MIPSOpcode op, char *out);
-	void Dis_FPUBranch(MIPSOpcode op, char *out);
-	void Dis_ori(MIPSOpcode op, char *out);
-	void Dis_Special3(MIPSOpcode op, char *out);
+	void Dis_mxc1(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_addi(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_addu(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_RelBranch2(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_RelBranch(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Generic(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Cache(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_IType(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_IType1(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_ITypeMem(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_RType2(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_RType3(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_MulDivType(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_ShiftType(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_VarShiftType(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_FPU3op(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_FPU2op(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_FPULS(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_FPUComp(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_FPUBranch(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_ori(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Special3(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
 
-	void Dis_ToHiloTransfer(MIPSOpcode op, char *out);
-	void Dis_FromHiloTransfer(MIPSOpcode op, char *out);
-	void Dis_JumpType(MIPSOpcode op, char *out);
-	void Dis_JumpRegType(MIPSOpcode op, char *out);
+	void Dis_ToHiloTransfer(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_FromHiloTransfer(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_JumpType(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_JumpRegType(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
 
-	void Dis_Allegrex(MIPSOpcode op, char *out);
-	void Dis_Allegrex2(MIPSOpcode op, char *out);
+	void Dis_Allegrex(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Allegrex2(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
 
-	void Dis_Emuhack(MIPSOpcode op, char *out);
+	void Dis_Emuhack(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
 }

--- a/Core/MIPS/MIPSDisVFPU.cpp
+++ b/Core/MIPS/MIPSDisVFPU.cpp
@@ -100,14 +100,14 @@ inline const char *VSuff(MIPSOpcode op)
 
 namespace MIPSDis
 {
-	const char *SignedHex(int i);
+	std::string SignedHex(int i);
 
 	void Dis_SV(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int offset = SignExtend16ToS32(op & 0xFFFC);
 		int vt = ((op>>16)&0x1f)|((op&3)<<5);
 		int rs = (op>>21) & 0x1f;
 		const char *name = MIPSGetName(op);
-		snprintf(out, outSize, "%s\t%s, %s(%s)", name, VN(vt, V_Single), SignedHex(offset), RN(rs));
+		snprintf(out, outSize, "%s\t%s, %s(%s)", name, VN(vt, V_Single), SignedHex(offset).c_str(), RN(rs));
 	}
 
 	void Dis_SVQ(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
@@ -116,7 +116,7 @@ namespace MIPSDis
 		int rs = (op>>21) & 0x1f;
 		const char *name = MIPSGetName(op);
 		size_t outpos = 0;
-		outpos += snprintf(out, outSize, "%s\t%s, %s(%s)", name, VN(vt, V_Quad), SignedHex(offset), RN(rs));
+		outpos += snprintf(out, outSize, "%s\t%s, %s(%s)", name, VN(vt, V_Quad), SignedHex(offset).c_str(), RN(rs));
 		if ((op & 2) && outpos < outSize)
 			truncate_cpy(out + outpos, outSize - outpos, ", wb");
 	}
@@ -127,7 +127,7 @@ namespace MIPSDis
 		int rs = (op>>21) & 0x1f;
 		int lr = (op>>1)&1;
 		const char *name = MIPSGetName(op);
-		snprintf(out, outSize, "%s%s.q\t%s, %s(%s)", name, lr ? "r" : "l", VN(vt, V_Quad), SignedHex(offset), RN(rs));
+		snprintf(out, outSize, "%s%s.q\t%s, %s(%s)", name, lr ? "r" : "l", VN(vt, V_Quad), SignedHex(offset).c_str(), RN(rs));
 	}
 
 	void Dis_Mftv(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {

--- a/Core/MIPS/MIPSDisVFPU.cpp
+++ b/Core/MIPS/MIPSDisVFPU.cpp
@@ -34,9 +34,9 @@
 #define _SIZE ((op>>11) & 0x1F)
 
 
-#define RN(i) currentDebugMIPS->GetRegName(0,i)
-#define FN(i) currentDebugMIPS->GetRegName(1,i)
-//#define VN(i) currentDebugMIPS->GetRegName(2,i)
+#define RN(i) (currentDebugMIPS->GetRegName(0, i).c_str())
+#define FN(i) (currentDebugMIPS->GetRegName(1, i).c_str())
+//#define VN(i) (currentDebugMIPS->GetRegName(2, i).c_str())
 
 
 #define S_not(a,b,c) (a<<2)|(b)|(c<<5)
@@ -48,8 +48,7 @@
 #define VertOff 1
 #define MtxOff 4
 
-inline const char *VN(int v, VectorSize size)
-{
+inline std::string VNStr(int v, VectorSize size) {
 	static const char *vfpuCtrlNames[VFPU_CTRL_MAX] = {
 		"SPFX",
 		"TPFX",
@@ -77,10 +76,12 @@ inline const char *VN(int v, VectorSize size)
 	return GetVectorNotation(v, size);
 }
 
-inline const char *MN(int v, MatrixSize size)
-{
+inline std::string MNStr(int v, MatrixSize size) {
 	return GetMatrixNotation(v, size);
 }
+
+#define VN(v, s) (VNStr(v, s).c_str())
+#define MN(v, s) (MNStr(v, s).c_str())
 
 inline const char *VSuff(MIPSOpcode op)
 {

--- a/Core/MIPS/MIPSDisVFPU.h
+++ b/Core/MIPS/MIPSDisVFPU.h
@@ -19,52 +19,50 @@
 
 #include "Common/CommonTypes.h"
 
-extern u32 disPC;
-
 namespace MIPSDis
 {
-	void Dis_Mftv(MIPSOpcode op, char *out);
-	void Dis_Vmfvc(MIPSOpcode op, char *out);
-	void Dis_Vmtvc(MIPSOpcode op, char *out);
+	void Dis_Mftv(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vmfvc(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vmtvc(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
 
-	void Dis_SV(MIPSOpcode op, char *out);
-	void Dis_SVQ(MIPSOpcode op, char *out);
-	void Dis_SVLRQ(MIPSOpcode op, char *out);
+	void Dis_SV(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_SVQ(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_SVLRQ(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
 
-	void Dis_MatrixSet1(MIPSOpcode op, char *out);
-	void Dis_MatrixSet2(MIPSOpcode op, char *out);
-	void Dis_MatrixSet3(MIPSOpcode op, char *out);
-	void Dis_MatrixMult(MIPSOpcode op, char *out);
-	void Dis_Vmscl(MIPSOpcode op, char *out);
+	void Dis_MatrixSet1(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_MatrixSet2(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_MatrixSet3(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_MatrixMult(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vmscl(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
 
-	void Dis_VectorDot(MIPSOpcode op, char *out);
-	void Dis_Vfad(MIPSOpcode op, char *out);
-	void Dis_VectorSet1(MIPSOpcode op, char *out);
-	void Dis_VectorSet2(MIPSOpcode op, char *out);
-	void Dis_VectorSet3(MIPSOpcode op, char *out);
-	void Dis_VRot(MIPSOpcode op, char *out);
-	void Dis_VScl(MIPSOpcode op, char *out);
+	void Dis_VectorDot(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vfad(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_VectorSet1(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_VectorSet2(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_VectorSet3(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_VRot(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_VScl(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
 
-	void Dis_VPFXST(MIPSOpcode op, char *out);
-	void Dis_VPFXD(MIPSOpcode op, char *out);
-	void Dis_Vcrs(MIPSOpcode op, char *out);
-	void Dis_Viim(MIPSOpcode op, char *out);
-	void Dis_Vcst(MIPSOpcode op, char *out);
-	void Dis_CrossQuat(MIPSOpcode op, char *out);
-	void Dis_Vtfm(MIPSOpcode op, char *out);
-	void Dis_Vcmp(MIPSOpcode op, char *out);
-	void Dis_Vcmov(MIPSOpcode op, char *out);
-	void Dis_Vflush(MIPSOpcode op, char *out);
-	void Dis_Vbfy(MIPSOpcode op, char *out);
-	void Dis_Vf2i(MIPSOpcode op, char *out);
-	void Dis_Vi2x(MIPSOpcode op, char *out);
-	void Dis_Vs2i(MIPSOpcode op, char *out);
-	void Dis_Vwbn(MIPSOpcode op, char *out);
-	void Dis_Vf2h(MIPSOpcode op, char *out);
-	void Dis_Vh2f(MIPSOpcode op, char *out);
-	void Dis_Vrnds(MIPSOpcode op, char *out);
-	void Dis_VrndX(MIPSOpcode op, char *out);
-	void Dis_ColorConv(MIPSOpcode op, char *out);
+	void Dis_VPFXST(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_VPFXD(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vcrs(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Viim(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vcst(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_CrossQuat(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vtfm(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vcmp(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vcmov(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vflush(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vbfy(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vf2i(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vi2x(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vs2i(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vwbn(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vf2h(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vh2f(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_Vrnds(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_VrndX(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
+	void Dis_ColorConv(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
 
-	void Dis_VBranch(MIPSOpcode op, char *out);
+	void Dis_VBranch(MIPSOpcode op, uint32_t pc, char *out, size_t outSize);
 }

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -124,7 +124,7 @@ void ApplyPrefixST(float *r, u32 data, VectorSize size, float invalid = 0.0f) {
 		if (!constants) {
 			if (regnum >= n) {
 				// We mostly handle this now, but still worth reporting.
-				ERROR_LOG_REPORT(CPU, "Invalid VFPU swizzle: %08x: %i / %d at PC = %08x (%s)", data, regnum, n, currentMIPS->pc, MIPSDisasmAt(currentMIPS->pc));
+				ERROR_LOG_REPORT(CPU, "Invalid VFPU swizzle: %08x: %i / %d at PC = %08x (%s)", data, regnum, n, currentMIPS->pc, MIPSDisasmAt(currentMIPS->pc).c_str());
 			}
 			r[i] = origV[regnum];
 			if (abs)

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -1119,8 +1119,8 @@ int MIPSGetMemoryAccessSize(MIPSOpcode op) {
 	return 0;
 }
 
-const char *MIPSDisasmAt(u32 compilerPC) {
-	static char temp[256];
+std::string MIPSDisasmAt(u32 compilerPC) {
+	char temp[512];
 	MIPSDisAsm(Memory::Read_Instruction(compilerPC), 0, temp, sizeof(temp));
 	return temp;
 }

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -918,14 +918,13 @@ void MIPSCompileOp(MIPSOpcode op, MIPSComp::MIPSFrontendInterface *jit) {
 	}
 }
 
-void MIPSDisAsm(MIPSOpcode op, u32 pc, char *out, bool tabsToSpaces) {
+void MIPSDisAsm(MIPSOpcode op, u32 pc, char *out, size_t outSize, bool tabsToSpaces) {
 	if (op == 0) {
-		strcpy(out, "nop");
+		truncate_cpy(out, outSize, "nop");
 	} else {
-		disPC = pc;
 		const MIPSInstruction *instr = MIPSGetInstruction(op);
 		if (instr && instr->disasm) {
-			instr->disasm(op, out);
+			instr->disasm(op, pc, out, outSize);
 			if (tabsToSpaces) {
 				while (*out) {
 					if (*out == '\t')
@@ -934,7 +933,7 @@ void MIPSDisAsm(MIPSOpcode op, u32 pc, char *out, bool tabsToSpaces) {
 				}
 			}
 		} else {
-			strcpy(out, "no instruction :(");
+			truncate_cpy(out, outSize, "no instruction :(");
 		}
 	}
 }
@@ -946,7 +945,7 @@ static inline void Interpret(const MIPSInstruction *instr, MIPSOpcode op) {
 		ERROR_LOG_REPORT(CPU, "Unknown instruction %08x at %08x", op.encoding, currentMIPS->pc);
 		// Try to disassemble it
 		char disasm[256];
-		MIPSDisAsm(op, currentMIPS->pc, disasm);
+		MIPSDisAsm(op, currentMIPS->pc, disasm, sizeof(disasm));
 		_dbg_assert_msg_(0, "%s", disasm);
 		currentMIPS->pc += 4;
 	}
@@ -1122,6 +1121,6 @@ int MIPSGetMemoryAccessSize(MIPSOpcode op) {
 
 const char *MIPSDisasmAt(u32 compilerPC) {
 	static char temp[256];
-	MIPSDisAsm(Memory::Read_Instruction(compilerPC), 0, temp);
+	MIPSDisAsm(Memory::Read_Instruction(compilerPC), 0, temp, sizeof(temp));
 	return temp;
 }

--- a/Core/MIPS/MIPSTables.h
+++ b/Core/MIPS/MIPSTables.h
@@ -115,7 +115,7 @@ struct MIPSInfo {
 	u64 cycles : 16;
 };
 
-typedef void (CDECL *MIPSDisFunc)(MIPSOpcode opcode, char *out);
+typedef void (CDECL *MIPSDisFunc)(MIPSOpcode opcode, uint32_t pc, char *out, size_t outSize);
 typedef void (CDECL *MIPSInterpretFunc)(MIPSOpcode opcode);
 
 namespace MIPSComp {
@@ -123,7 +123,7 @@ namespace MIPSComp {
 }
 
 void MIPSCompileOp(MIPSOpcode op, MIPSComp::MIPSFrontendInterface *jit);
-void MIPSDisAsm(MIPSOpcode op, u32 pc, char *out, bool tabsToSpaces = false);
+void MIPSDisAsm(MIPSOpcode op, u32 pc, char *out, size_t outSize, bool tabsToSpaces = false);
 MIPSInfo MIPSGetInfo(MIPSOpcode op);
 void MIPSInterpret(MIPSOpcode op); //only for those rare ones
 int MIPSInterpret_RunUntil(u64 globalTicks);

--- a/Core/MIPS/MIPSTables.h
+++ b/Core/MIPS/MIPSTables.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <string>
 #include "Common/CommonTypes.h"
 #include "Core/MIPS/MIPS.h"
 
@@ -132,4 +133,4 @@ MIPSInterpretFunc MIPSGetInterpretFunc(MIPSOpcode op);
 int MIPSGetInstructionCycleEstimate(MIPSOpcode op);
 int MIPSGetMemoryAccessSize(MIPSOpcode op);
 const char *MIPSGetName(MIPSOpcode op);
-const char *MIPSDisasmAt(u32 compilerPC);
+std::string MIPSDisasmAt(u32 compilerPC);

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -23,6 +23,7 @@
 #include "Common/BitScan.h"
 #include "Common/CommonFuncs.h"
 #include "Common/File/VFS/VFS.h"
+#include "Common/StringUtils.h"
 #include "Core/Reporting.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSVFPUUtils.h"
@@ -538,11 +539,7 @@ MatrixOverlapType GetMatrixOverlap(int mtx1, int mtx2, MatrixSize msize) {
 	return OVERLAP_NONE;
 }
 
-const char *GetVectorNotation(int reg, VectorSize size)
-{
-	static char temp[4][16];
-	static int yo = 0; yo++; yo &= 3;
-
+std::string GetVectorNotation(int reg, VectorSize size) {
 	int mtx = (reg>>2)&7;
 	int col = reg&3;
 	int row = 0;
@@ -557,34 +554,27 @@ const char *GetVectorNotation(int reg, VectorSize size)
 	}
 	if (transpose && c == 'C') c='R';
 	if (transpose)
-		snprintf(temp[yo], sizeof(temp[yo]), "%c%i%i%i",c,mtx,row,col);
-	else
-		snprintf(temp[yo], sizeof(temp[yo]), "%c%i%i%i",c,mtx,col,row);
-	return temp[yo];
+		return StringFromFormat("%c%i%i%i", c, mtx, row, col);
+	return StringFromFormat("%c%i%i%i", c, mtx, col, row);
 }
 
-const char *GetMatrixNotation(int reg, MatrixSize size)
-{
-  static char temp[4][16];
-  static int yo=0;yo++;yo&=3;
-  int mtx = (reg>>2)&7;
-  int col = reg&3;
-  int row = 0;
-  int transpose = (reg>>5)&1;
-  char c;
-  switch (size)
-  {
-  case M_2x2:     c='M'; row=(reg>>5)&2; break;
-  case M_3x3:     c='M'; row=(reg>>6)&1; break;
-  case M_4x4:     c='M'; row=(reg>>5)&2; break;
-  default:        c='?'; break;
-  }
-  if (transpose && c=='M') c='E';
-  if (transpose)
-    snprintf(temp[yo], sizeof(temp[yo]), "%c%i%i%i",c,mtx,row,col);
-  else
-    snprintf(temp[yo], sizeof(temp[yo]), "%c%i%i%i",c,mtx,col,row);
-  return temp[yo];
+std::string GetMatrixNotation(int reg, MatrixSize size) {
+	int mtx = (reg>>2)&7;
+	int col = reg&3;
+	int row = 0;
+	int transpose = (reg>>5)&1;
+	char c;
+	switch (size)
+	{
+	case M_2x2:     c='M'; row=(reg>>5)&2; break;
+	case M_3x3:     c='M'; row=(reg>>6)&1; break;
+	case M_4x4:     c='M'; row=(reg>>5)&2; break;
+	default:        c='?'; break;
+	}
+	if (transpose && c=='M') c='E';
+	if (transpose)
+		return StringFromFormat("%c%i%i%i", c, mtx, row, col);
+	return StringFromFormat("%c%i%i%i", c, mtx, col, row);
 }
 
 bool GetVFPUCtrlMask(int reg, u32 *mask) {

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -16,8 +16,9 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #pragma once
-#include <cmath>
 
+#include <cmath>
+#include <string>
 #include "Common/CommonTypes.h"
 #include "Core/MIPS/MIPS.h"
 
@@ -216,8 +217,8 @@ VectorSize MatrixVectorSize(MatrixSize sz);
 int GetNumVectorElements(VectorSize sz);
 int GetMatrixSideSafe(MatrixSize sz);
 int GetMatrixSide(MatrixSize sz);
-const char *GetVectorNotation(int reg, VectorSize size);
-const char *GetMatrixNotation(int reg, MatrixSize size);
+std::string GetVectorNotation(int reg, VectorSize size);
+std::string GetMatrixNotation(int reg, MatrixSize size);
 inline bool IsMatrixTransposed(int matrixReg) {
 	return (matrixReg >> 5) & 1;
 }

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -107,7 +107,7 @@ static void JitBranchLog(MIPSOpcode op, u32 pc) {
 static void JitBranchLogMismatch(MIPSOpcode op, u32 pc)
 {
 	char temp[256];
-	MIPSDisAsm(op, pc, temp, true);
+	MIPSDisAsm(op, pc, temp, sizeof(temp), true);
 	ERROR_LOG(JIT, "Bad jump: %s - int:%08x jit:%08x", temp, currentMIPS->intBranchExit, currentMIPS->jitBranchExit);
 	Core_EnableStepping(true, "jit.branchdebug", pc);
 }

--- a/GPU/Common/GPUDebugInterface.cpp
+++ b/GPU/Common/GPUDebugInterface.cpp
@@ -17,6 +17,7 @@
 
 #include "Common/Log.h"
 #include "Common/Math/expression_parser.h"
+#include "Common/StringUtils.h"
 #include "Core/Debugger/SymbolMap.h"
 #include "GPU/Common/GPUDebugInterface.h"
 #include "GPU/Debugger/Debugger.h"
@@ -516,7 +517,7 @@ public:
 	bool parseSymbol(char *str, uint32_t &symbolValue) override;
 	uint32_t getReferenceValue(uint32_t referenceIndex) override;
 	ExpressionType getReferenceType(uint32_t referenceIndex) override;
-	bool getMemoryValue(uint32_t address, int size, uint32_t &dest, char *error, size_t errorBufSize) override;
+	bool getMemoryValue(uint32_t address, int size, uint32_t &dest, std::string *error) override;
 
 private:
 	bool parseFieldReference(const char *ref, const char *field, uint32_t &referenceIndex);
@@ -926,7 +927,7 @@ ExpressionType GEExpressionFunctions::getFieldType(GECmdFormat fmt, GECmdField f
 	return EXPR_TYPE_UINT;
 }
 
-bool GEExpressionFunctions::getMemoryValue(uint32_t address, int size, uint32_t &dest, char *error, size_t errorBufSize) {
+bool GEExpressionFunctions::getMemoryValue(uint32_t address, int size, uint32_t &dest, std::string *error) {
 	// We allow, but ignore, bad access.
 	// If we didn't, log/condition statements that reference registers couldn't be configured.
 	uint32_t valid = Memory::ValidSize(address, size);
@@ -946,7 +947,7 @@ bool GEExpressionFunctions::getMemoryValue(uint32_t address, int size, uint32_t 
 		return true;
 	}
 
-	snprintf(error, errorBufSize, "Unexpected memory access size %d", size);
+	*error = StringFromFormat("Unexpected memory access size %d", size);
 	return false;
 }
 

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -1186,7 +1186,6 @@ int main(int argc, char *argv[]) {
 						break;
 					}
 #endif
-					// TODO: Should we even keep the "non-precise" events?
 					if (event.wheel.y > 0) {
 						key.keyCode = NKCODE_EXT_MOUSEWHEEL_UP;
 						mouseWheelMovedUpFrames = 5;

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -1141,7 +1141,7 @@ void JitCompareScreen::OnRandomBlock(int flag) {
 				MIPSOpcode opcode = Memory::Read_Instruction(addr);
 				if (MIPSGetInfo(opcode) & flag) {
 					char temp[256];
-					MIPSDisAsm(opcode, addr, temp);
+					MIPSDisAsm(opcode, addr, temp, sizeof(temp));
 					// INFO_LOG(HLE, "Stopping at random instruction: %08x %s", addr, temp);
 					anyWanted = true;
 					break;

--- a/UWP/cpu_features_UWP/cpu_features_UWP.vcxproj
+++ b/UWP/cpu_features_UWP/cpu_features_UWP.vcxproj
@@ -296,6 +296,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\ext\cpu_features\src\filesystem.c" />
     <ClCompile Include="..\..\ext\cpu_features\src\impl_aarch64_linux_or_android.c" />
+    <ClCompile Include="..\..\ext\cpu_features\src\impl_aarch64_windows.c" />
     <ClCompile Include="..\..\ext\cpu_features\src\impl_arm_linux_or_android.c" />
     <ClCompile Include="..\..\ext\cpu_features\src\impl_mips_linux_or_android.c" />
     <ClCompile Include="..\..\ext\cpu_features\src\impl_ppc_linux.c" />

--- a/UWP/cpu_features_UWP/cpu_features_UWP.vcxproj.filters
+++ b/UWP/cpu_features_UWP/cpu_features_UWP.vcxproj.filters
@@ -110,6 +110,9 @@
     <ClCompile Include="..\..\ext\cpu_features\src\impl_aarch64_linux_or_android.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\ext\cpu_features\src\impl_aarch64_windows.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\ext\cpu_features\src\impl_arm_linux_or_android.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -302,7 +302,7 @@ void CtrlDisAsmView::assembleOpcode(u32 address, std::string defaultText)
 			{
 				for (int reg = 0; reg < debugger->GetNumRegsInCategory(cat); reg++)
 				{
-					if (strcasecmp(debugger->GetRegName(cat,reg),registerName.c_str()) == 0)
+					if (strcasecmp(debugger->GetRegName(cat,reg).c_str(), registerName.c_str()) == 0)
 					{
 						debugger->SetRegValue(cat,reg,value);
 						Reporting::NotifyDebugger();

--- a/Windows/Debugger/CtrlRegisterList.cpp
+++ b/Windows/Debugger/CtrlRegisterList.cpp
@@ -251,7 +251,7 @@ void CtrlRegisterList::onPaint(WPARAM wParam, LPARAM lParam)
 		if (i<cpu->GetNumRegsInCategory(category))
 		{
 			char temp[256];
-			int temp_len = snprintf(temp, sizeof(temp), "%s", cpu->GetRegName(category, i));
+			int temp_len = snprintf(temp, sizeof(temp), "%s", cpu->GetRegName(category, i).c_str());
 			SetTextColor(hdc,0x600000);
 			TextOutA(hdc,17,rowY1,temp,temp_len);
 			SetTextColor(hdc,0x000000);

--- a/ext/cpu_features.vcxproj
+++ b/ext/cpu_features.vcxproj
@@ -359,6 +359,7 @@
   <ItemGroup>
     <ClCompile Include="cpu_features\src\filesystem.c" />
     <ClCompile Include="cpu_features\src\impl_aarch64_linux_or_android.c" />
+    <ClCompile Include="cpu_features\src\impl_aarch64_windows.c" />
     <ClCompile Include="cpu_features\src\impl_arm_linux_or_android.c" />
     <ClCompile Include="cpu_features\src\impl_mips_linux_or_android.c" />
     <ClCompile Include="cpu_features\src\impl_ppc_linux.c" />

--- a/ext/cpu_features.vcxproj.filters
+++ b/ext/cpu_features.vcxproj.filters
@@ -111,6 +111,9 @@
     <ClCompile Include="cpu_features\src\impl_aarch64_linux_or_android.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="cpu_features\src\impl_aarch64_windows.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="cpu_features\src\impl_arm_linux_or_android.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -207,6 +207,7 @@ endif
 SOURCES_C += \
 	$(EXTDIR)/cpu_features/src/filesystem.c \
 	$(EXTDIR)/cpu_features/src/impl_aarch64_linux_or_android.c \
+	$(EXTDIR)/cpu_features/src/impl_aarch64_windows.c \
 	$(EXTDIR)/cpu_features/src/impl_arm_linux_or_android.c \
 	$(EXTDIR)/cpu_features/src/impl_mips_linux_or_android.c \
 	$(EXTDIR)/cpu_features/src/impl_ppc_linux.c \

--- a/unittest/JitHarness.cpp
+++ b/unittest/JitHarness.cpp
@@ -164,7 +164,7 @@ bool TestJit() {
 	addr = currentMIPS->pc;
 	for (size_t j = 0; j < ARRAY_SIZE(lines); ++j) {
 		char line[512];
-		MIPSDisAsm(Memory::Read_Instruction(addr), addr, line, true);
+		MIPSDisAsm(Memory::Read_Instruction(addr), addr, line, sizeof(line), true);
 		addr += 4;
 		printf("%s\n", line);
 	}

--- a/unittest/TestArmEmitter.cpp
+++ b/unittest/TestArmEmitter.cpp
@@ -243,8 +243,8 @@ bool TestArmEmitter() {
 	int R001 = GetRowName(0, M_4x4, 1, 0);
 	int R002 = GetRowName(0, M_4x4, 2, 0);
 	int R003 = GetRowName(0, M_4x4, 3, 0);
-	printf("Col 010: %s\n", GetVectorNotation(C010, V_Quad));
-	printf("Row 003: %s\n", GetVectorNotation(R003, V_Quad));
+	printf("Col 010: %s\n", GetVectorNotation(C010, V_Quad).c_str());
+	printf("Row 003: %s\n", GetVectorNotation(R003, V_Quad).c_str());
 	
 	MIPSAnalyst::AnalysisResults results;
 	memset(&results, 0, sizeof(results));

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -431,7 +431,7 @@ bool TestMatrixTranspose() {
 }
 
 void TestGetMatrix(int matrix, MatrixSize sz) {
-	INFO_LOG(SYSTEM, "Testing matrix %s", GetMatrixNotation(matrix, sz));
+	INFO_LOG(SYSTEM, "Testing matrix %s", GetMatrixNotation(matrix, sz).c_str());
 	u8 fullMatrix[16];
 
 	u8 cols[4];
@@ -449,8 +449,8 @@ void TestGetMatrix(int matrix, MatrixSize sz) {
 		// int rowName = GetRowName(matrix, sz, i, 0);
 		int colName = cols[i];
 		int rowName = rows[i];
-		INFO_LOG(SYSTEM, "Column %i: %s", i, GetVectorNotation(colName, vsz));
-		INFO_LOG(SYSTEM, "Row %i: %s", i, GetVectorNotation(rowName, vsz));
+		INFO_LOG(SYSTEM, "Column %i: %s", i, GetVectorNotation(colName, vsz).c_str());
+		INFO_LOG(SYSTEM, "Row %i: %s", i, GetVectorNotation(rowName, vsz).c_str());
 
 		u8 colRegs[4];
 		u8 rowRegs[4];


### PR DESCRIPTION
This cleans up some of those YOLO `static char` usages and such.  In many cases, I just switched to std::string as it's likely not a major concern for most of this usage.

A few other changes:
 * Switches reg names for VFPU from "v000" etc. to "S000" using the expected numbers.  This affects breakpoint conditions.
 * Enables some new features of cpu_features on RISC-V and Windows ARM64.  These detect things like SVE, etc. but they're not used yet anyway.
 * Adds a very quick setting to exclude func names from the shared hashmap.

-[Unknown]