### PR TITLE
Don't use the cpu_features library on Android arm32.

### DIFF
--- a/Common/ArmCPUDetect.cpp
+++ b/Common/ArmCPUDetect.cpp
@@ -29,7 +29,7 @@
 #if PPSSPP_ARCH(ARM)
 #include "ext/cpu_features/include/cpuinfo_arm.h"
 
-#if defined(CPU_FEATURES_OS_LINUX) || defined(CPU_FEATURES_OS_ANDROID)
+#if defined(CPU_FEATURES_OS_LINUX)
 #define USE_CPU_FEATURES 1
 #endif
 #elif PPSSPP_ARCH(ARM64) && defined(__aarch64__)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,8 +44,10 @@ android {
 			}
 		}
 	}
-	compileSdkVersion 32
+
+	compileSdkVersion 33
 	ndkVersion "21.4.7075529"
+
 
 	defaultConfig {
 		applicationId 'org.ppsspp.ppsspp'


### PR DESCRIPTION
Unbreaks Xperia Play, yay.

Also bumps the compile tools version in the gradle, unrelated but doesn't hurt.