### PR TITLE
Less broken behavior with integer scale factor + auto render resolution

### DIFF
--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -125,9 +125,20 @@ void CalculateDisplayOutputRect(FRect *rc, float origW, float origH, const FRect
 		if (rotated) {
 			wDim = 272.0f;
 		}
+
+		int zoom = g_Config.iInternalResolution;
+		if (zoom == 0) {
+			// Auto (1:1) mode, not super meaningful with integer scaling, but let's do something that makes
+			// some sense. use the longest dimension, just to have something. round down.
+			if (!g_Config.IsPortrait()) {
+				zoom = (PSP_CoreParameter().pixelWidth) / 480;
+			} else {
+				zoom = (PSP_CoreParameter().pixelHeight) / 480;
+			}
+		}
 		// If integer scaling, limit ourselves to even multiples of the rendered resolution,
 		// to make sure all the pixels are square.
-		wDim *= g_Config.iInternalResolution;
+		wDim *= zoom;
 		outW = std::max(1.0f, floorf(outW / wDim)) * wDim;
 		outH = outW / origRatio;
 	}


### PR DESCRIPTION
Unfortunately these don't make the same decision (integer scale factor tries to make sure the whole image can fit in the window, while auto render resolution is glad to step up a level), but at least the user is not faced with a black screen.

Not sure what's actually the best thing here, possibly this case should be disallowed somehow.

Fixes #17355