### PR TITLE
Mac menu fixes

### DIFF
--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -612,6 +612,11 @@ public:
 	}
 
 	void BindTexture(int slot, GLRTexture *tex) {
+		if (!curRenderStep_ && !tex) {
+			// Likely a pre-emptive bindtexture for D3D11 to avoid hazards. Not necessary.
+			// This can happen in BlitUsingRaster.
+			return;
+		}
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		_dbg_assert_(slot < MAX_GL_TEXTURE_SLOTS);
 		GLRRenderData data{ GLRRenderCommand::BINDTEXTURE };


### PR DESCRIPTION
Break On Load was missing the inversion (it controls a bAutoRun flag which means the opposite).

Now, most items on the Debug menu are disabled when not in-game.

Also fixes an obscure crash in the OpenGL backend that I was able to trigger by having Break on Load enabled (!bAutoRun) and unthrottling at the start of Tekken 6.
