### PR TITLE
Queue up input events for processing, except in-game. Avoids some potential threading issues/hangs.

### DIFF
--- a/Common/UI/Root.cpp
+++ b/Common/UI/Root.cpp
@@ -204,8 +204,8 @@ bool IsScrollKey(const KeyInput &input) {
 	}
 }
 
-bool KeyEvent(const KeyInput &key, ViewGroup *root) {
-	bool retval = false;
+KeyEventResult UnsyncKeyEvent(const KeyInput &key, ViewGroup *root) {
+	KeyEventResult retval = KeyEventResult::PASS_THROUGH;
 	// Ignore repeats for focus moves.
 	if ((key.flags & (KEY_DOWN | KEY_IS_REPEAT)) == KEY_DOWN) {
 		if (IsDPadKey(key) || IsScrollKey(key)) {
@@ -218,13 +218,13 @@ bool KeyEvent(const KeyInput &key, ViewGroup *root) {
 			// Check if the key is already held. If it is, ignore it. This is to avoid
 			// multiple key repeat mechanisms colliding.
 			if (heldKeys.find(hk) != heldKeys.end()) {
-				return false;
+				return KeyEventResult::IGNORE_KEY;
 			}
 
 			heldKeys.insert(hk);
 			std::lock_guard<std::mutex> lock(focusLock);
 			focusMoves.push_back(key.keyCode);
-			retval = true;
+			retval = KeyEventResult::ACCEPT;
 		}
 	}
 	if (key.flags & KEY_UP) {
@@ -236,25 +236,26 @@ bool KeyEvent(const KeyInput &key, ViewGroup *root) {
 			hk.triggerTime = 0.0; // irrelevant
 			if (heldKeys.find(hk) != heldKeys.end()) {
 				heldKeys.erase(hk);
-				retval = true;
+				retval = KeyEventResult::ACCEPT;
 			}
 		}
 	}
-
-	retval = root->Key(key);
 
 	// Ignore volume keys and stuff here. Not elegant but need to propagate bools through the view hierarchy as well...
 	switch (key.keyCode) {
 	case NKCODE_VOLUME_DOWN:
 	case NKCODE_VOLUME_UP:
 	case NKCODE_VOLUME_MUTE:
-		retval = false;
+		retval = KeyEventResult::PASS_THROUGH;
 		break;
 	default:
 		break;
 	}
-
 	return retval;
+}
+
+void KeyEvent(const KeyInput &key, ViewGroup *root) {
+	root->Key(key);
 }
 
 static void ProcessHeldKeys(ViewGroup *root) {
@@ -283,16 +284,15 @@ restart:
 	}
 }
 
-bool TouchEvent(const TouchInput &touch, ViewGroup *root) {
+void TouchEvent(const TouchInput &touch, ViewGroup *root) {
 	focusForced = false;
 	root->Touch(touch);
 	if ((touch.flags & TOUCH_DOWN) && !focusForced) {
 		EnableFocusMovement(false);
 	}
-	return true;
 }
 
-bool AxisEvent(const AxisInput &axis, ViewGroup *root) {
+void AxisEvent(const AxisInput &axis, ViewGroup *root) {
 	enum class DirState {
 		NONE = 0,
 		POS = 1,
@@ -376,10 +376,11 @@ bool AxisEvent(const AxisInput &axis, ViewGroup *root) {
 		}
 		break;
 	}
+	default:
+		break;
 	}
 
 	root->Axis(axis);
-	return true;
 }
 
 void UpdateViewHierarchy(ViewGroup *root) {

--- a/Common/UI/Root.h
+++ b/Common/UI/Root.h
@@ -23,10 +23,19 @@ class ViewGroup;
 
 void LayoutViewHierarchy(const UIContext &dc, ViewGroup *root, bool ignoreInsets);
 void UpdateViewHierarchy(ViewGroup *root);
+
+enum class KeyEventResult {
+	IGNORE_KEY,  // Don't let it be processed.
+	PASS_THROUGH,  // Let it be processed, but return false.
+	ACCEPT,  // Let it be processed, but return true.
+};
+
 // Hooks arrow keys for navigation
-bool KeyEvent(const KeyInput &key, ViewGroup *root);
-bool TouchEvent(const TouchInput &touch, ViewGroup *root);
-bool AxisEvent(const AxisInput &axis, ViewGroup *root);
+KeyEventResult UnsyncKeyEvent(const KeyInput &key, ViewGroup *root);
+
+void KeyEvent(const KeyInput &key, ViewGroup *root);
+void TouchEvent(const TouchInput &touch, ViewGroup *root);
+void AxisEvent(const AxisInput &axis, ViewGroup *root);
 
 enum class UISound {
 	SELECT = 0,

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -82,11 +82,11 @@ void ScreenManager::touch(const TouchInput &touch) {
 	if (touch.flags & TOUCH_RELEASE_ALL) {
 		for (auto &layer : stack_) {
 			Screen *screen = layer.screen;
-			layer.screen->touch(screen->transformTouch(touch));
+			layer.screen->UnsyncTouch(screen->transformTouch(touch));
 		}
 	} else if (!stack_.empty()) {
 		Screen *screen = stack_.back().screen;
-		stack_.back().screen->touch(screen->transformTouch(touch));
+		stack_.back().screen->UnsyncTouch(screen->transformTouch(touch));
 	}
 }
 
@@ -96,10 +96,10 @@ bool ScreenManager::key(const KeyInput &key) {
 	// Send key up to every screen layer, to avoid stuck keys.
 	if (key.flags & KEY_UP) {
 		for (auto &layer : stack_) {
-			result = layer.screen->key(key);
+			result = layer.screen->UnsyncKey(key);
 		}
 	} else if (!stack_.empty()) {
-		result = stack_.back().screen->key(key);
+		result = stack_.back().screen->UnsyncKey(key);
 	}
 	return result;
 }
@@ -120,10 +120,10 @@ void ScreenManager::axis(const AxisInput &axis) {
 	// Send center axis to every screen layer.
 	if (axis.value == 0) {
 		for (auto &layer : stack_) {
-			layer.screen->axis(axis);
+			layer.screen->UnsyncAxis(axis);
 		}
 	} else if (!stack_.empty()) {
-		stack_.back().screen->axis(axis);
+		stack_.back().screen->UnsyncAxis(axis);
 	}
 }
 

--- a/Common/UI/Screen.h
+++ b/Common/UI/Screen.h
@@ -55,12 +55,13 @@ public:
 	virtual void postRender() {}
 	virtual void resized() {}
 	virtual void dialogFinished(const Screen *dialog, DialogResult result) {}
-	virtual void touch(const TouchInput &touch) {}
-	virtual bool key(const KeyInput &key) { return false; }
-	virtual void axis(const AxisInput &touch) {}
 	virtual void sendMessage(const char *msg, const char *value) {}
 	virtual void deviceLost() {}
 	virtual void deviceRestored() {}
+
+	virtual void UnsyncTouch(const TouchInput &touch) {}
+	virtual bool UnsyncKey(const KeyInput &touch) { return false; }
+	virtual void UnsyncAxis(const AxisInput &touch) {}
 
 	virtual void RecreateViews() {}
 

--- a/Common/UI/UIScreen.h
+++ b/Common/UI/UIScreen.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <set>
+#include <mutex>
+#include <string>
+#include <deque>
 
 #include "Common/Math/lin/vec3.h"
 #include "Common/UI/Screen.h"
@@ -12,6 +14,21 @@ class I18NCategory;
 namespace Draw {
 	class DrawContext;
 }
+
+enum class QueuedEventType : u8 {
+	KEY,
+	AXIS,
+	TOUCH,
+};
+
+struct QueuedEvent {
+	QueuedEventType type;
+	union {
+		TouchInput touch;
+		KeyInput key;
+		AxisInput axis;
+	};
+};
 
 class UIScreen : public Screen {
 public:
@@ -57,6 +74,9 @@ private:
 
 	bool recreateViews_ = true;
 	bool lastVertical_;
+
+	std::mutex eventQueueLock_;
+	std::deque<QueuedEvent> eventQueue_;
 };
 
 class UIDialogScreen : public UIScreen {

--- a/Common/UI/UIScreen.h
+++ b/Common/UI/UIScreen.h
@@ -42,9 +42,13 @@ public:
 	void deviceLost() override;
 	void deviceRestored() override;
 
-	void touch(const TouchInput &touch) override;
-	bool key(const KeyInput &touch) override;
-	void axis(const AxisInput &touch) override;
+	virtual void touch(const TouchInput &touch);
+	virtual bool key(const KeyInput &touch);
+	virtual void axis(const AxisInput &touch);
+
+	void UnsyncTouch(const TouchInput &touch) override;
+	bool UnsyncKey(const KeyInput &touch) override;
+	void UnsyncAxis(const AxisInput &touch) override;
 
 	TouchInput transformTouch(const TouchInput &touch) override;
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -538,7 +538,7 @@ void EmuScreen::sendMessage(const char *message, const char *value) {
 	}
 }
 
-void EmuScreen::touch(const TouchInput &touch) {
+void EmuScreen::UnsyncTouch(const TouchInput &touch) {
 	Core_NotifyActivity();
 
 	if (chatMenu_ && chatMenu_->GetVisibility() == UI::V_VISIBLE) {
@@ -802,11 +802,11 @@ void EmuScreen::onVKeyAnalog(int virtualKeyCode, float value) {
 	limitMode = PSP_CoreParameter().analogFpsLimit == 60 ? FPSLimit::NORMAL : FPSLimit::ANALOG;
 }
 
-bool EmuScreen::key(const KeyInput &key) {
+bool EmuScreen::UnsyncKey(const KeyInput &key) {
 	Core_NotifyActivity();
 
 	if (UI::IsFocusMovementEnabled()) {
-		if (UIScreen::key(key)) {
+		if (UIScreen::UnsyncKey(key)) {
 			return true;
 		} else if ((key.flags & KEY_DOWN) != 0 && UI::IsEscapeKey(key)) {
 			if (chatMenu_)
@@ -821,7 +821,7 @@ bool EmuScreen::key(const KeyInput &key) {
 	return controlMapper_.Key(key, &pauseTrigger_);
 }
 
-void EmuScreen::axis(const AxisInput &axis) {
+void EmuScreen::UnsyncAxis(const AxisInput &axis) {
 	Core_NotifyActivity();
 
 	return controlMapper_.Axis(axis);

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -50,9 +50,11 @@ public:
 	void sendMessage(const char *msg, const char *value) override;
 	void resized() override;
 
-	void touch(const TouchInput &touch) override;
-	bool key(const KeyInput &key) override;
-	void axis(const AxisInput &axis) override;
+	// Note: Unlike your average boring UIScreen, here we override the Unsync* functions
+	// to get minimal latency and full control. We forward to UIScreen when needed.
+	void UnsyncTouch(const TouchInput &touch) override;
+	bool UnsyncKey(const KeyInput &key) override;
+	void UnsyncAxis(const AxisInput &axis) override;
 
 private:
 	void CreateViews() override;


### PR DESCRIPTION
Tries to reduce the potential for weird race conditions in the UI, by queueing up UI events before processing them, so they're all really processed on the main thread.

Currently tricky for key events because they return a value.

Actually, I'll do this a bit differently. Here's the new design:

* Screens only support UnsyncKey, UnsyncAxis, UnsyncTouch.  These are called without buffering or locking, the current way.
* UIScreen contains a buffer that buffers them up and dispatches Key, Axis and Touch from UIScreen::Update. 
* Screens derived from UIScreen that really want the events immediately (basically, EmuScreen) can simply override UnsyncKey etc directly, taking over the duty from UIScreen. They can also thus return true when needed.

