### PR TITLE
Tex replacement: Support BC1,2,3 formats also if packed in a DX10-style DDS.

### DIFF
--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -339,10 +339,34 @@ ReplacedTexture::LoadLevelResult ReplacedTexture::LoadLevelData(VFSFileReference
 				good = good && vfs_->Read(openFile, &header10, sizeof(header10)) == sizeof(header10);
 				format = header10.dxgiFormat;
 				switch (format) {
+				case 71: // DXGI_FORMAT_BC1_UNORM
+				case 72: // DXGI_FORMAT_BC1_UNORM_SRGB
+					if (!desc_.formatSupport.bc123) {
+						WARN_LOG(G3D, "BC1 format not supported, skipping texture");
+						good = false;
+					}
+					*pixelFormat = Draw::DataFormat::BC1_RGBA_UNORM_BLOCK;
+					break;
+				case 74: // DXGI_FORMAT_BC2_UNORM
+				case 75: // DXGI_FORMAT_BC2_UNORM_SRGB
+					if (!desc_.formatSupport.bc123) {
+						WARN_LOG(G3D, "BC2 format not supported, skipping texture");
+						good = false;
+					}
+					*pixelFormat = Draw::DataFormat::BC2_UNORM_BLOCK;
+					break;
+				case 77: // DXGI_FORMAT_BC3_UNORM
+				case 78: // DXGI_FORMAT_BC3_UNORM_SRGB
+					if (!desc_.formatSupport.bc123) {
+						WARN_LOG(G3D, "BC3 format not supported, skipping texture");
+						good = false;
+					}
+					*pixelFormat = Draw::DataFormat::BC3_UNORM_BLOCK;
+					break;
 				case 98: // DXGI_FORMAT_BC7_UNORM:
 				case 99: // DXGI_FORMAT_BC7_UNORM_SRGB:
 					if (!desc_.formatSupport.bc7) {
-						WARN_LOG(G3D, "BC1-3 formats not supported, skipping texture");
+						WARN_LOG(G3D, "BC7 format not supported, skipping texture");
 						good = false;
 					}
 					*pixelFormat = Draw::DataFormat::BC7_UNORM_BLOCK;


### PR DESCRIPTION
I haven't seen any DDS files like this but they're certainly valid, so let's support them.