### PR TITLE
Avoid double texture cache load.

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -125,8 +125,6 @@ TextureCacheCommon::TextureCacheCommon(Draw::DrawContext *draw, Draw2D *draw2D)
 	tmpTexBuf32_.resize(512 * 512);  // 1MB
 	tmpTexBufRearrange_.resize(512 * 512);   // 1MB
 
-	replacer_.Init();
-
 	textureShaderCache_ = new TextureShaderCache(draw, draw2D_);
 }
 

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -75,10 +75,6 @@ TextureReplacer::~TextureReplacer() {
 	delete vfs_;
 }
 
-void TextureReplacer::Init() {
-	NotifyConfigChanged();
-}
-
 void TextureReplacer::NotifyConfigChanged() {
 	gameID_ = g_paramSFO.GetDiscID();
 

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -96,7 +96,6 @@ public:
 	TextureReplacer(Draw::DrawContext *draw);
 	~TextureReplacer();
 
-	void Init();
 	void NotifyConfigChanged();
 
 	bool Enabled() const { return enabled_; }


### PR DESCRIPTION
Texture packs are loaded from NotifyConfigChanged which is called anyway.

Fixes #17381