### PR TITLE
ClientConfigSubscriber added to the Remote API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1812,8 +1812,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/Debugger/WebSocket/GameBroadcaster.h
 	Core/Debugger/WebSocket/GameSubscriber.cpp
 	Core/Debugger/WebSocket/GameSubscriber.h
-	Core/Debugger/WebSocket/ClientInfoSubscriber.cpp
-	Core/Debugger/WebSocket/ClientInfoSubscriber.h
+	Core/Debugger/WebSocket/ClientConfigSubscriber.cpp.cpp
+	Core/Debugger/WebSocket/ClientConfigSubscriber.cpp.h
 	Core/Debugger/WebSocket/GPUBufferSubscriber.cpp
 	Core/Debugger/WebSocket/GPUBufferSubscriber.h
 	Core/Debugger/WebSocket/GPURecordSubscriber.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1812,8 +1812,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/Debugger/WebSocket/GameBroadcaster.h
 	Core/Debugger/WebSocket/GameSubscriber.cpp
 	Core/Debugger/WebSocket/GameSubscriber.h
-    Core/Debugger/WebSocket/ClientInfoSubscriber.cpp
-    Core/Debugger/WebSocket/ClientInfoSubscriber.h
+	Core/Debugger/WebSocket/ClientInfoSubscriber.cpp
+	Core/Debugger/WebSocket/ClientInfoSubscriber.h
 	Core/Debugger/WebSocket/GPUBufferSubscriber.cpp
 	Core/Debugger/WebSocket/GPUBufferSubscriber.h
 	Core/Debugger/WebSocket/GPURecordSubscriber.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1812,8 +1812,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/Debugger/WebSocket/GameBroadcaster.h
 	Core/Debugger/WebSocket/GameSubscriber.cpp
 	Core/Debugger/WebSocket/GameSubscriber.h
-	Core/Debugger/WebSocket/ClientConfigSubscriber.cpp.cpp
-	Core/Debugger/WebSocket/ClientConfigSubscriber.cpp.h
+	Core/Debugger/WebSocket/ClientConfigSubscriber.cpp
+	Core/Debugger/WebSocket/ClientConfigSubscriber.h
 	Core/Debugger/WebSocket/GPUBufferSubscriber.cpp
 	Core/Debugger/WebSocket/GPUBufferSubscriber.h
 	Core/Debugger/WebSocket/GPURecordSubscriber.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1812,6 +1812,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/Debugger/WebSocket/GameBroadcaster.h
 	Core/Debugger/WebSocket/GameSubscriber.cpp
 	Core/Debugger/WebSocket/GameSubscriber.h
+    Core/Debugger/WebSocket/ClientInfoSubscriber.cpp
+    Core/Debugger/WebSocket/ClientInfoSubscriber.h
 	Core/Debugger/WebSocket/GPUBufferSubscriber.cpp
 	Core/Debugger/WebSocket/GPUBufferSubscriber.h
 	Core/Debugger/WebSocket/GPURecordSubscriber.cpp

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -547,6 +547,7 @@
     <ClCompile Include="Debugger\WebSocket.cpp" />
     <ClCompile Include="Debugger\WebSocket\BreakpointSubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\CPUCoreSubscriber.cpp" />
+    <ClCompile Include="Debugger\WebSocket\ClientConfigSubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\GameBroadcaster.cpp" />
     <ClCompile Include="Debugger\WebSocket\GameSubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\GPUBufferSubscriber.cpp" />
@@ -1118,6 +1119,7 @@
     <ClInclude Include="Debugger\MemBlockInfo.h" />
     <ClInclude Include="Debugger\WebSocket.h" />
     <ClInclude Include="Debugger\WebSocket\BreakpointSubscriber.h" />
+    <ClInclude Include="Debugger\WebSocket\ClientConfigSubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\GameSubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\DisasmSubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\GPUBufferSubscriber.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -718,6 +718,9 @@
     <ClCompile Include="Debugger\WebSocket\CPUCoreSubscriber.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="Debugger\WebSocket\ClientConfigSubscriber.cpp">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClCompile>
     <ClCompile Include="Debugger\WebSocket\WebSocketUtils.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
@@ -1780,6 +1783,9 @@
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>
     <ClInclude Include="Debugger\WebSocket\GameBroadcaster.h">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClInclude>
+    <ClInclude Include="Debugger\WebSocket\ClientConfigSubscriber.h">
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>
     <ClInclude Include="Debugger\WebSocket\CPUCoreSubscriber.h">

--- a/Core/Debugger/WebSocket.cpp
+++ b/Core/Debugger/WebSocket.cpp
@@ -79,7 +79,7 @@ static const std::vector<SubscriberInit> subscribers({
 	&WebSocketMemoryInit,
 	&WebSocketReplayInit,
 	&WebSocketSteppingInit,
-	&WebSocketClientConfigInit
+	&WebSocketClientConfigInit,
 });
 
 // To handle webserver restart, keep track of how many running.

--- a/Core/Debugger/WebSocket/ClientConfigSubscriber.cpp
+++ b/Core/Debugger/WebSocket/ClientConfigSubscriber.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "Core/Debugger/WebSocket/ClientConfigSubscriber.h"
+#include "Core/Debugger/WebSocket/WebSocketUtils.h"
 #include "Common/StringUtils.h"
 
 DebuggerSubscriber *WebSocketClientConfigInit(DebuggerEventHandlerMap & map) {

--- a/Core/Debugger/WebSocket/ClientConfigSubscriber.cpp
+++ b/Core/Debugger/WebSocket/ClientConfigSubscriber.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2018- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "Core/Debugger/WebSocket/ClientConfigSubscriber.h"
+#include "Common/StringUtils.h"
+
+DebuggerSubscriber *WebSocketClientConfigInit(DebuggerEventHandlerMap & map) {
+	map["broadcast.config.get"] = &WebSocketBroadcastConfigGet;
+	map["broadcast.config.set"] = &WebSocketBroadcastConfigSet;
+
+	return nullptr;
+}
+
+
+// Request the current client broadcast configuration (broadcast.config.get)
+//
+// No parameters.
+//
+// Response (same event name):
+//  - allowed: object with boolean fields:
+//     - logger: whether logger events are allowed
+//     - game: whether game events are allowed
+//     - stepping: whether stepping events are allowed
+//     - input: whether input events are allowed
+void WebSocketBroadcastConfigGet(DebuggerRequest & req) {
+	JsonWriter &json = req.Respond();
+	const auto& allowed_config = req.client->allowed;
+
+	json.pushDict("allowed");
+
+	json.writeBool("logger", allowed_config.at("logger"));
+	json.writeBool("game", allowed_config.at("game"));
+	json.writeBool("stepping", allowed_config.at("stepping"));
+	json.writeBool("input", allowed_config.at("input"));
+
+	json.end();
+}
+
+// Update the current client broadcast configuration (broadcast.config.set)
+//
+// Parameters:
+//  - allowed: object with boolean fields (all of them are optional):
+//     - logger: new logger config state
+//     - game: new game config state
+//     - stepping: new stepping config state
+//     - input: new input config state
+//
+// Response (same event name):
+//  - allowed: object with boolean fields:
+//     - logger: whether logger events are now allowed
+//     - game: whether game events are now allowed
+//     - stepping: whether stepping events are bow allowed
+//     - input: whether input events are now allowed
+void WebSocketBroadcastConfigSet(DebuggerRequest & req) {
+	JsonWriter &json = req.Respond();
+	// WebSocketClientInfo& client = req.client;
+	auto& allowed_config = req.client->allowed;
+
+	const JsonNode *jsonAllowed = req.data.get("allowed");
+	if (!jsonAllowed) {
+		return req.Fail("Missing 'allowed' parameter");
+	}
+	if (jsonAllowed->value.getTag() != JSON_OBJECT) {
+		return req.Fail("Invalid 'allowed' parameter type");
+	}
+
+	for (const JsonNode *broadcaster : jsonAllowed->value) {
+		auto it = allowed_config.find(broadcaster->key);
+		if (it == allowed_config.end()) {
+			return req.Fail(StringFromFormat("Unsupported 'allowed' object key '%s'", broadcaster->key));
+		}
+
+		if (broadcaster->value.getTag() == JSON_TRUE) {
+			it->second = true;
+		}
+		else if (broadcaster->value.getTag() == JSON_FALSE) {
+			it->second = false;
+		}
+		else if (broadcaster->value.getTag() != JSON_NULL) {
+			return req.Fail(StringFromFormat("Unsupported 'allowed' object type for key '%s'", broadcaster->key));
+		}
+	}
+
+	json.pushDict("allowed");
+
+	json.writeBool("logger", allowed_config.at("logger"));
+	json.writeBool("game", allowed_config.at("game"));
+	json.writeBool("stepping", allowed_config.at("stepping"));
+	json.writeBool("input", allowed_config.at("input"));
+
+	json.end();
+}

--- a/Core/Debugger/WebSocket/ClientConfigSubscriber.h
+++ b/Core/Debugger/WebSocket/ClientConfigSubscriber.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2018- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "Core/Debugger/WebSocket/WebSocketUtils.h"
+
+DebuggerSubscriber *WebSocketClientConfigInit(DebuggerEventHandlerMap &map);
+
+void WebSocketBroadcastConfigSet(DebuggerRequest &req);
+void WebSocketBroadcastConfigGet(DebuggerRequest &req);

--- a/Core/Debugger/WebSocket/GameSubscriber.cpp
+++ b/Core/Debugger/WebSocket/GameSubscriber.cpp
@@ -96,6 +96,18 @@ void WebSocketGameStatus(DebuggerRequest &req) {
 //  - version: string, typically starts with "v" and may have git build info.
 void WebSocketVersion(DebuggerRequest &req) {
 	JsonWriter &json = req.Respond();
+
+	std::string version;
+	if (!req.ParamString("version", &version)) {
+		return;
+	}
+	std::string name;
+	if (!req.ParamString("name", &name)) {
+		return;
+	}
+	req.client->name = name;
+	req.client->version = version;
+
 	json.writeString("name", "PPSSPP");
 	json.writeString("version", PPSSPP_GIT_VERSION);
 }

--- a/Core/Debugger/WebSocket/WebSocketUtils.h
+++ b/Core/Debugger/WebSocket/WebSocketUtils.h
@@ -33,6 +33,18 @@
 
 using namespace json;
 
+struct WebSocketClientInfo {
+	WebSocketClientInfo(): name(), version(), allowed() {
+		allowed.emplace("logger", true);
+		allowed.emplace("game", true);
+		allowed.emplace("stepping", true);
+		allowed.emplace("input", true);
+	}
+	std::string name;
+	std::string version;
+	std::map <std::string, bool> allowed;
+};
+
 struct DebuggerErrorEvent {
 	DebuggerErrorEvent(const std::string m, LogTypes::LOG_LEVELS l, const JsonGet data = JsonValue(JSON_NULL))
 		: message(m), level(l) {
@@ -70,13 +82,14 @@ enum class DebuggerParamType {
 };
 
 struct DebuggerRequest {
-	DebuggerRequest(const char *n, net::WebSocketServer *w, const JsonGet &d)
-		: name(n), ws(w), data(d) {
+	DebuggerRequest(const char *n, net::WebSocketServer *w, const JsonGet &d, WebSocketClientInfo *client_info)
+		: name(n), ws(w), data(d), client(client_info) {
 	}
 
 	const char *name;
 	net::WebSocketServer *ws;
 	const JsonGet data;
+	WebSocketClientInfo *client;
 
 	void Fail(const std::string &message) {
 		ws->Send(DebuggerErrorEvent(message, LogTypes::LERROR, data));

--- a/UWP/CoreUWP/CoreUWP.vcxproj
+++ b/UWP/CoreUWP/CoreUWP.vcxproj
@@ -295,6 +295,7 @@
     <ClInclude Include="..\..\Core\Debugger\WebSocket.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\BreakpointSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\CPUCoreSubscriber.h" />
+    <ClInclude Include="..\..\Core\Debugger\WebSocket\ClientConfigSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\DisasmSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\GameBroadcaster.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\GameSubscriber.h" />
@@ -534,6 +535,7 @@
     <ClCompile Include="..\..\Core\Debugger\WebSocket.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\BreakpointSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\CPUCoreSubscriber.cpp" />
+    <ClInclude Include="..\..\Core\Debugger\WebSocket\ClientConfigSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\DisasmSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GameBroadcaster.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GameSubscriber.cpp" />

--- a/UWP/CoreUWP/CoreUWP.vcxproj
+++ b/UWP/CoreUWP/CoreUWP.vcxproj
@@ -535,7 +535,7 @@
     <ClCompile Include="..\..\Core\Debugger\WebSocket.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\BreakpointSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\CPUCoreSubscriber.cpp" />
-    <ClInclude Include="..\..\Core\Debugger\WebSocket\ClientConfigSubscriber.cpp" />
+    <ClCompile Include="..\..\Core\Debugger\WebSocket\ClientConfigSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\DisasmSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GameBroadcaster.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GameSubscriber.cpp" />

--- a/UWP/CoreUWP/CoreUWP.vcxproj.filters
+++ b/UWP/CoreUWP/CoreUWP.vcxproj.filters
@@ -671,6 +671,9 @@
     <ClCompile Include="..\..\Core\Debugger\WebSocket\CPUCoreSubscriber.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Core\Debugger\WebSocket\ClientConfigSubscriber.cpp">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Core\Debugger\WebSocket\DisasmSubscriber.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>

--- a/UWP/CoreUWP/CoreUWP.vcxproj.filters
+++ b/UWP/CoreUWP/CoreUWP.vcxproj.filters
@@ -1692,6 +1692,9 @@
     <ClInclude Include="..\..\Core\Debugger\WebSocket\CPUCoreSubscriber.h">
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>
+    <ClCompile Include="..\..\Core\Debugger\WebSocket\ClientConfigSubscriber.h">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\Core\Debugger\WebSocket\DisasmSubscriber.h">
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -473,6 +473,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/Debugger/WebSocket.cpp \
   $(SRC)/Core/Debugger/WebSocket/BreakpointSubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp \
+  $(SRC)/Core/Debugger/WebSocket/ClientConfigSubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/DisasmSubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/GameBroadcaster.cpp \
   $(SRC)/Core/Debugger/WebSocket/GameSubscriber.cpp \


### PR DESCRIPTION
This commit brings 
1) the ability to configure what broadcast events you want to receive
2) the means to work with the client info in general. For instance, the "version" event handling code now saves the name and the version the client submits for later use. Before this change, the version event had de-facto 2 optional arguments, which are now mandatory as the description claims.