### PR TITLE
Better (but not great) workaround for key bindings that pop up dialogs.

### DIFF
--- a/Common/Input/InputState.h
+++ b/Common/Input/InputState.h
@@ -87,7 +87,8 @@ inline int TranslateKeyCodeToAxis(int keyCode, int *direction) {
 		return 0;
 	int k = keyCode - AXIS_BIND_NKCODE_START;
 	// Even/odd for direction.
-	*direction = k & 1 ? -1 : 1;
+	if (direction)
+		*direction = k & 1 ? -1 : 1;
 	return k / 2;
 }
 

--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -158,12 +158,8 @@ void ControlMapper::ForceReleaseVKey(int vkey) {
 	if (KeyMap::InputMappingsFromPspButton(vkey, &multiMappings, true)) {
 		for (const auto &entry : multiMappings) {
 			for (const auto &mapping : entry.mappings) {
-				int direction = 0;
-				if (mapping.IsAxis() && IsSignedAxis(mapping.Axis(&direction))) {
-					curInput_[mapping] = direction == -1 ? -1 : 1;
-				} else {
-					curInput_[mapping] = 0.0f;
-				}
+				curInput_[mapping] = 0.0f;
+				// Different logic for signed axes?
 				UpdatePSPState(mapping);
 			}
 		}

--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -153,6 +153,23 @@ void ControlMapper::UpdateAnalogOutput(int stick) {
 	setPSPAnalog_(stick, x, y);
 }
 
+void ControlMapper::ForceReleaseVKey(int vkey) {
+	std::vector<KeyMap::MultiInputMapping> multiMappings;
+	if (KeyMap::InputMappingsFromPspButton(vkey, &multiMappings, true)) {
+		for (const auto &entry : multiMappings) {
+			for (const auto &mapping : entry.mappings) {
+				int direction = 0;
+				if (mapping.IsAxis() && IsSignedAxis(mapping.Axis(&direction))) {
+					curInput_[mapping] = direction == -1 ? -1 : 1;
+				} else {
+					curInput_[mapping] = 0.0f;
+				}
+				UpdatePSPState(mapping);
+			}
+		}
+	}
+}
+
 static int RotatePSPKeyCode(int x) {
 	switch (x) {
 	case CTRL_UP: return CTRL_RIGHT;

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -35,6 +35,11 @@ public:
 	// Toggle swapping DPAD and Analog. Useful on some input devices with few buttons.
 	void ToggleSwapAxes();
 
+	// Call this when a Vkey press triggers leaving the screen you're using the controlmapper on. This can cause
+	// the loss of key-up events, which will confuse things later when you're back.
+	// Might replace this later by allowing through "key-up" and similar events to lower screens.
+	void ForceReleaseVKey(int vkey);
+
 	void GetDebugString(char *buffer, size_t bufSize) const;
 
 private:

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -620,7 +620,11 @@ void EmuScreen::onVKey(int virtualKeyCode, bool down) {
 
 	case VIRTKEY_PAUSE:
 		if (down) {
+			// Trigger on key-up to partially avoid repetition problems.
+			// This is needed whenever we pop up a menu since the mapper
+			// might miss  the key-up. Same as VIRTKEY_OPENCHAT.
 			pauseTrigger_ = true;
+			controlMapper_.ForceReleaseVKey(virtualKeyCode);
 		}
 		break;
 
@@ -637,12 +641,10 @@ void EmuScreen::onVKey(int virtualKeyCode, bool down) {
 		break;
 
 	case VIRTKEY_OPENCHAT:
-		// If we react at "down", the control mapper will never receive the "up" since
-		// we pop up a dialog which takes over input.
-		// Could hack around it, but this seems more sensible, even if it might feel less snappy.
-		if (!down && g_Config.bEnableNetworkChat) {
+		if (down && g_Config.bEnableNetworkChat) {
 			UI::EventParams e{};
 			OnChatMenu.Trigger(e);
+			controlMapper_.ForceReleaseVKey(virtualKeyCode);
 		}
 		break;
 

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -160,6 +160,8 @@ public:
 class FloatingSymbolsAnimation : public Animation {
 public:
 	void Draw(UIContext &dc, double t, float alpha, float x, float y, float z) override {
+		dc.Flush();
+		dc.Begin();
 		float xres = dc.GetBounds().w;
 		float yres = dc.GetBounds().h;
 		if (last_xres != xres || last_yres != yres) {


### PR DESCRIPTION
This forcibly releases the key from the controlmapper, since by popping up a dialog on key-down the control mapper loses the key-up.

There might be a slight race condition here, but works well enough.

However, it doesn't quite fix it for signed axes like the analog triggers on PS4 controllers.

Still it's an improvement, and lets us use the snappier-feeling key-down as a trigger instead of key-up.

Will do something better for 1.16.

