### PR TITLE
Vulkan: Turn off the ubershader on Mali T880, T860 and T830 on old driver versions

### DIFF
--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -948,6 +948,9 @@ VKContext::VKContext(VulkanContext *vulkan)
 		// Workaround for Intel driver bug. TODO: Re-enable after some driver version
 		bugs_.Infest(Bugs::DUAL_SOURCE_BLENDING_BROKEN);
 	} else if (caps_.vendor == GPUVendor::VENDOR_ARM) {
+		// Really old Vulkan drivers for Mali didn't have proper versions. We try to detect that (can't be 100% but pretty good).
+		bool isOldVersion = IsHashMaliDriverVersion(deviceProps);
+
 		int majorVersion = VK_API_VERSION_MAJOR(deviceProps.driverVersion);
 
 		// These GPUs (up to some certain hardware version?) have a bug where draws where gl_Position.w == .z
@@ -966,8 +969,17 @@ VKContext::VKContext(VulkanContext *vulkan)
 
 		// Older ARM devices have very slow geometry shaders, not worth using.  At least before 15.
 		// Also seen to cause weird issues on 18, so let's lump it in.
-		if (majorVersion <= 18) {
+		if (majorVersion <= 18 || isOldVersion) {
 			bugs_.Infest(Bugs::GEOMETRY_SHADERS_SLOW_OR_BROKEN);
+		}
+
+		// Attempt to workaround #17386
+		if (isOldVersion) {
+			if (!strcmp(deviceProps.deviceName, "Mali-T880") ||
+				!strcmp(deviceProps.deviceName, "Mali-T860") ||
+				!strcmp(deviceProps.deviceName, "Mali-T830")) {
+				bugs_.Infest(Bugs::UNIFORM_INDEXING_BROKEN);
+			}
 		}
 	}
 

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -347,6 +347,7 @@ public:
 		SUBPASS_FEEDBACK_BROKEN = 10,
 		GEOMETRY_SHADERS_SLOW_OR_BROKEN = 11,
 		ADRENO_RESOURCE_DEADLOCK = 12,
+		UNIFORM_INDEXING_BROKEN = 13,  // not a properly diagnosed issue, a workaround attempt: #17386
 		MAX_BUG,
 	};
 

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -199,7 +199,7 @@ u32 GPU_Vulkan::CheckGPUFeatures() const {
 	uint32_t features = GPUCommonHW::CheckGPUFeatures();
 
 	VulkanContext *vulkan = (VulkanContext *)draw_->GetNativeObject(Draw::NativeObject::CONTEXT);
-	
+
 	// Could simplify this, but it's good as documentation.
 	switch (vulkan->GetPhysicalDeviceProperties().properties.vendorID) {
 	case VULKAN_VENDOR_AMD:
@@ -215,6 +215,8 @@ u32 GPU_Vulkan::CheckGPUFeatures() const {
 		// This check is probably not exactly accurate. But old drivers had problems with reverse-Z, just like AMD and Qualcomm.
 
 		// NOTE: Galaxy S8 has version 16 but still seems to have some problems with accurate depth.
+
+		// TODO: Move this check to thin3d_vulkan.
 
 		bool driverTooOld = IsHashMaliDriverVersion(vulkan->GetPhysicalDeviceProperties().properties)
 			|| VK_VERSION_MAJOR(vulkan->GetPhysicalDeviceProperties().properties.driverVersion) < 14;
@@ -292,6 +294,11 @@ u32 GPU_Vulkan::CheckGPUFeatures() const {
 	// if (msaaLevel_ != 0) {
 	features &= ~GPU_USE_FRAMEBUFFER_FETCH;
 	// }
+
+	// Attempt to workaround #17386
+	if (draw_->GetBugs().Has(Draw::Bugs::UNIFORM_INDEXING_BROKEN)) {
+		features &= ~GPU_USE_LIGHT_UBERSHADER;
+	}
 
 	return CheckGPUFeaturesLate(features);
 }


### PR DESCRIPTION
Attempt to workaround #17386

Basically a repeat of #17222 but for old Mali drivers this time.