### PR TITLE
Qt: Buildfix with SDL disabled

### DIFF
--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -278,8 +278,10 @@ void System_Notify(SystemNotification notification) {
 			g_symbolMap->SortSymbols();
 		break;
 	case SystemNotification::AUDIO_RESET_DEVICE:
+#ifdef SDL
 		StopSDLAudioDevice();
 		InitSDLAudioDevice();
+#endif
 		break;
 	default:
 		break;


### PR DESCRIPTION
Quick not well tested fix for #17405.

-[Unknown]