### PR TITLE
Controller mapping fixes

### DIFF
--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -254,6 +254,7 @@ void UpdateVRInput(bool haptics, float dp_xscale, float dp_yscale) {
 			keyInput.deviceId = controllerIds[j];
 
 			//process the key action
+
 			if (m.pressed != pressed) {
 				if (pressed && haptics) {
 					INVR_Vibrate(100, j, 1000);
@@ -446,7 +447,8 @@ void UpdateVRInput(bool haptics, float dp_xscale, float dp_yscale) {
 			mousePressed = pressed;
 		}
 
-		//mouse wheel emulation
+		// mouse wheel emulation
+		// TODO: Spams key-up events if nothing changed!
 		for (int j = 0; j < 2; j++) {
 			keyInput.deviceId = controllerIds[j];
 			float scroll = -IN_VRGetJoystickState(j).y;

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -360,6 +360,13 @@ bool KeyMappingNewKeyDialog::key(const KeyInput &key) {
 		}
 	}
 	if (key.flags & KEY_UP) {
+		// If the key released wasn't part of the mapping, ignore it here. Some device can cause
+		// stray key-up events.
+		InputMapping upMapping(key.deviceId, key.keyCode);
+		if (!mapping_.mappings.contains(upMapping)) {
+			return true;
+		}
+
 		if (callback_)
 			callback_(mapping_);
 		TriggerFinish(DR_YES);
@@ -391,7 +398,9 @@ bool KeyMappingNewMouseKeyDialog::key(const KeyInput &key) {
 		}
 
 		mapped_ = true;
+
 		MultiInputMapping kdf(InputMapping(key.deviceId, key.keyCode));
+
 		TriggerFinish(DR_YES);
 		g_Config.bMapMouse = false;
 		if (callback_)

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -163,6 +163,11 @@ void SingleControlMapper::Refresh() {
 }
 
 void SingleControlMapper::MappedCallback(MultiInputMapping kdf) {
+	if (kdf.empty()) {
+		// Don't want to try to add this.
+		return;
+	}
+
 	switch (action_) {
 	case ADD:
 		KeyMap::SetInputMapping(pspKey_, kdf, false);


### PR DESCRIPTION
Fix an issue where stray KEY_UP events could confuse the control mapper into setting empty events.

This had some not-so-good consequences, like inability to map anything in VR (due to code spamming mouse-wheel key_up events), and sometimes empty MultiMappings would result that we could end up asserting on before the previous commit. Replaced the assert with log, and add paranoia-level checks, too.


Fixes #17411