### PR TITLE
GPU: Remove JumpFast/CallFast

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1000,6 +1000,7 @@ void GPUCommon::DoExecuteCall(u32 target) {
 
 	if (currentList->stackptr == ARRAY_SIZE(currentList->stack)) {
 		ERROR_LOG(G3D, "CALL: Stack full!");
+		// TODO: UpdateState(GPUSTATE_ERROR) ?
 	} else {
 		auto &stackEntry = currentList->stack[currentList->stackptr++];
 		stackEntry.pc = retval;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -953,12 +953,6 @@ void GPUCommon::Execute_Jump(u32 op, u32 diff) {
 	currentList->pc = target - 4; // pc will be increased after we return, counteract that
 }
 
-void GPUCommon::Execute_JumpFast(u32 op, u32 diff) {
-	const u32 target = gstate_c.getRelativeAddress(op & 0x00FFFFFC);
-	UpdatePC(currentList->pc, target - 4);
-	currentList->pc = target - 4; // pc will be increased after we return, counteract that
-}
-
 void GPUCommon::Execute_BJump(u32 op, u32 diff) {
 	if (!currentList->bboxResult) {
 		// bounding box jump.
@@ -982,13 +976,6 @@ void GPUCommon::Execute_Call(u32 op, u32 diff) {
 		UpdateState(GPUSTATE_ERROR);
 		return;
 	}
-	DoExecuteCall(target);
-}
-
-void GPUCommon::Execute_CallFast(u32 op, u32 diff) {
-	PROFILE_THIS_SCOPE("gpu_call");
-
-	const u32 target = gstate_c.getRelativeAddress(op & 0x00FFFFFC);
 	DoExecuteCall(target);
 }
 

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -140,10 +140,8 @@ public:
 	void Execute_Iaddr(u32 op, u32 diff);
 	void Execute_Origin(u32 op, u32 diff);
 	void Execute_Jump(u32 op, u32 diff);
-	void Execute_JumpFast(u32 op, u32 diff);
 	void Execute_BJump(u32 op, u32 diff);
 	void Execute_Call(u32 op, u32 diff);
-	void Execute_CallFast(u32 op, u32 diff);
 	void Execute_Ret(u32 op, u32 diff);
 	void Execute_End(u32 op, u32 diff);
 

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -442,14 +442,6 @@ void GPUCommonHW::UpdateCmdInfo() {
 		cmdInfo_[GE_CMD_VERTEXTYPE].func = &GPUCommonHW::Execute_VertexType;
 	}
 
-	if (g_Config.bFastMemory) {
-		cmdInfo_[GE_CMD_JUMP].func = &GPUCommon::Execute_JumpFast;
-		cmdInfo_[GE_CMD_CALL].func = &GPUCommon::Execute_CallFast;
-	} else {
-		cmdInfo_[GE_CMD_JUMP].func = &GPUCommon::Execute_Jump;
-		cmdInfo_[GE_CMD_CALL].func = &GPUCommon::Execute_Call;
-	}
-
 	// Reconfigure for light ubershader or not.
 	for (int i = 0; i < 4; i++) {
 		if (gstate_c.Use(GPU_USE_LIGHT_UBERSHADER)) {

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -803,9 +803,7 @@ void GPUCommonHW::FastRunLoop(DisplayList &list) {
 		} else {
 			uint64_t flags = info.flags;
 			if (flags & FLAG_FLUSHBEFOREONCHANGE) {
-				if (drawEngineCommon_->GetNumDrawCalls()) {
-					drawEngineCommon_->DispatchFlush();
-				}
+				drawEngineCommon_->DispatchFlush();
 			}
 			gstate.cmdmem[cmd] = op;
 			if (flags & (FLAG_EXECUTE | FLAG_EXECUTEONCHANGE)) {


### PR DESCRIPTION
Not worth the absolutely miniscule performance difference, I think, since they turn a GPU emulation error into an emulator crash.

I think this should be OK for 1.15.3 ... Hm.