### PR TITLE
Fix glitch when mapping analog inputs, caused by multiple TriggerFinish

### DIFF
--- a/Common/UI/UIScreen.h
+++ b/Common/UI/UIScreen.h
@@ -50,6 +50,7 @@ protected:
 	Vec3 scale_ = Vec3(1.0f);
 	float alpha_ = 1.0f;
 	bool ignoreInsets_ = false;
+	bool ignoreInput_ = false;
 
 private:
 	void DoRecreateViews();

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -337,6 +337,8 @@ void KeyMappingNewKeyDialog::CreatePopupContents(UI::ViewGroup *parent) {
 }
 
 bool KeyMappingNewKeyDialog::key(const KeyInput &key) {
+	if (ignoreInput_)
+		return true;
 	if (time_now_d() < delayUntil_)
 		return true;
 	if (key.flags & KEY_DOWN) {
@@ -390,6 +392,8 @@ void KeyMappingNewMouseKeyDialog::CreatePopupContents(UI::ViewGroup *parent) {
 bool KeyMappingNewMouseKeyDialog::key(const KeyInput &key) {
 	if (mapped_)
 		return false;
+	if (ignoreInput_)
+		return true;
 	if (key.flags & KEY_DOWN) {
 		if (key.keyCode == NKCODE_ESCAPE) {
 			TriggerFinish(DR_OK);
@@ -427,6 +431,8 @@ void KeyMappingNewKeyDialog::axis(const AxisInput &axis) {
 	if (time_now_d() < delayUntil_)
 		return;
 	if (IgnoreAxisForMapping(axis.axisId))
+		return;
+	if (ignoreInput_)
 		return;
 
 	if (axis.value > AXIS_BIND_THRESHOLD) {


### PR DESCRIPTION
Which in turn are caused by stray analog axis events, which we now eat up.

Add some guards all over the place against the same thing.