### PR TITLE
Windows: Fix initial window show for all displays

### DIFF
--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -375,6 +375,7 @@ namespace MainWindow
 				int totalHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN);
 				MoveWindow(hwndMain, totalX, totalY, totalWidth, totalHeight, TRUE);
 				HandleSizeChange(oldWindowState);
+				ShowWindow(hwndMain, SW_SHOW);
 			} else {
 				ShowWindow(hwndMain, SW_MAXIMIZE);
 			}


### PR DESCRIPTION
Fixes #17421.  I've only ever turned this off before quitting, actually, since I don't like things starting full screen.

-[Unknown]