### PR TITLE
Android: Explicitly allow content URI intents

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -70,6 +70,7 @@
 				<category android:name="android.intent.category.BROWSABLE" />
 
 				<data android:scheme="file" />
+				<data android:scheme="content" />
 				<data android:mimeType="*/*" />
 				<data android:host="*" />
 				<data android:pathPattern=".*\\.iso" />
@@ -90,6 +91,7 @@
 				<data android:pathPattern=".*\\.ELF" />
 				<data android:pathPattern=".*\\..*\\.ELF" />
 				<data android:pathPattern=".*\\..*\\..*\\.ELF" />
+				<data android:pathPattern=".*\\.ppdmp" />
 			</intent-filter>
         </activity>
         <meta-data android:name="isGame" android:value="true" />


### PR DESCRIPTION
Considered also adding `http`, but I think that could lead to PPSSPP showing up confusingly in scenarios where you don't want it to.

See #17416.

-[Unknown]