### PR TITLE
Add Nayuta Endless Trails to BlockTransferAllowCreateFB compat option

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -671,6 +671,12 @@ ULJM05160 = true
 # Narikiri Dungeon X. See issue #16714.
 ULJS00293 = true
 
+# Nayuta Endless Trails. See issue #17431.
+ULJM06113 = true
+NPJH50625 = true
+ULJM08069 = true
+NPJH50625 = true
+
 [IntraVRAMBlockTransferAllowCreateFB]
 # Final Fantasy - Type 0
 ULJM05900 = true


### PR DESCRIPTION
Should get rid of the slow GPU readbacks, fixing #17431 (see that issue for video and details)

However, I have not tested this myself, so would be good if someone could give it a try.

Otherwise, the start of the 1.16 process is a good time to merge this to see if we get any complaints about anything else in the game getting broken, like savegame thumbnails or something..

It would also be ideal if we could try IntraVRAMBlockTransferAllowCreateFB instead (which has a tighter check).