### PR TITLE
Custom button analog fix

### DIFF
--- a/Common/Data/Format/IniFile.cpp
+++ b/Common/Data/Format/IniFile.cpp
@@ -5,6 +5,8 @@
 #include <cstdlib>
 #include <cstdio>
 
+#include <inttypes.h>
+
 #ifndef _MSC_VER
 #include <strings.h>
 #endif
@@ -192,7 +194,7 @@ void Section::Set(const char* key, uint32_t newValue) {
 }
 
 void Section::Set(const char* key, uint64_t newValue) {
-	Set(key, StringFromFormat("0x%016lx", newValue).c_str());
+	Set(key, StringFromFormat("0x%016" PRIx64, newValue).c_str());
 }
 
 void Section::Set(const char* key, float newValue) {

--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -504,10 +504,12 @@ void ControlMapper::PSPKey(int deviceId, int pspKeyCode, int flags) {
 		if (flags & KEY_DOWN) {
 			virtKeys_[vk] = 1.0f;
 			onVKey(pspKeyCode, true);
+			onVKeyAnalog(deviceId, pspKeyCode, 1.0f);
 		}
 		if (flags & KEY_UP) {
 			virtKeys_[vk] = 0.0f;
 			onVKey(pspKeyCode, false);
+			onVKeyAnalog(deviceId, pspKeyCode, 0.0f);
 		}
 	} else {
 		// INFO_LOG(SYSTEM, "pspKey %d %d", pspKeyCode, flags);

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -29,7 +29,7 @@ public:
 
 	// Inject raw PSP key input directly, such as from touch screen controls.
 	// Combined with the mapped input. Unlike __Ctrl APIs, this supports
-	// virtual key codes, though not analog mappings.
+	// virtual key codes, including analog mappings.
 	void PSPKey(int deviceId, int pspKeyCode, int flags);
 
 	// Toggle swapping DPAD and Analog. Useful on some input devices with few buttons.

--- a/UI/CustomButtonMappingScreen.h
+++ b/UI/CustomButtonMappingScreen.h
@@ -28,7 +28,7 @@ class CustomButtonMappingScreen : public UIDialogScreenWithGameBackground {
 public:
 	CustomButtonMappingScreen(const Path &gamePath, int id) : UIDialogScreenWithGameBackground(gamePath), id_(id) {}
 
-	const char *tag() const override { return "CustomKey"; }
+	const char *tag() const override { return "CustomButton"; }
 
 	void CreateViews() override;
 	void onFinish(DialogResult result) override;

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -189,11 +189,11 @@ bool PSPButton::Touch(const TouchInput &input) {
 	return retval;
 }
 
-bool CustomKey::IsDown() {
+bool CustomButton::IsDown() {
 	return (toggle_ && on_) || (!toggle_ && pointerDownMask_ != 0);
 }
 
-void CustomKey::GetContentDimensions(const UIContext &dc, float &w, float &h) const {
+void CustomButton::GetContentDimensions(const UIContext &dc, float &w, float &h) const {
 	MultiTouchButton::GetContentDimensions(dc, w, h);
 	if (invertedContextDimension_) {
 		float tmp = w;
@@ -202,7 +202,7 @@ void CustomKey::GetContentDimensions(const UIContext &dc, float &w, float &h) co
 	}
 }
 
-bool CustomKey::Touch(const TouchInput &input) {
+bool CustomButton::Touch(const TouchInput &input) {
 	using namespace CustomKeyData;
 	bool lastDown = pointerDownMask_ != 0;
 	bool retval = MultiTouchButton::Touch(input);
@@ -233,7 +233,7 @@ bool CustomKey::Touch(const TouchInput &input) {
 	return retval;
 }
 
-void CustomKey::Update() {
+void CustomButton::Update() {
 	MultiTouchButton::Update();
 	using namespace CustomKeyData;
 
@@ -825,10 +825,10 @@ UI::ViewGroup *CreatePadLayout(float xres, float yres, bool *pause, bool showPau
 		}
 		return nullptr;
 	};
-	auto addCustomButton = [=](const ConfigCustomButton& cfg, const char *key, const ConfigTouchPos &touch) -> CustomKey * {
+	auto addCustomButton = [=](const ConfigCustomButton& cfg, const char *key, const ConfigTouchPos &touch) -> CustomButton * {
 		using namespace CustomKeyData;
 		if (touch.show) {
-			auto aux = root->Add(new CustomKey(cfg.key, key, cfg.toggle, cfg.repeat, controllMapper,
+			auto aux = root->Add(new CustomButton(cfg.key, key, cfg.toggle, cfg.repeat, controllMapper,
 					g_Config.iTouchButtonStyle == 0 ? customKeyShapes[cfg.shape].i : customKeyShapes[cfg.shape].l, customKeyShapes[cfg.shape].i,
 					customKeyImages[cfg.image].i, touch.scale, customKeyShapes[cfg.shape].d, buttonLayoutParams(touch)));
 			aux->SetAngle(customKeyImages[cfg.image].r, customKeyShapes[cfg.shape].r);

--- a/UI/GamepadEmu.h
+++ b/UI/GamepadEmu.h
@@ -173,9 +173,9 @@ UI::ViewGroup *CreatePadLayout(float xres, float yres, bool *pause, bool showPau
 const int D_pad_Radius = 50;
 const int baseActionButtonSpacing = 60;
 
-class CustomKey : public MultiTouchButton {
+class CustomButton : public MultiTouchButton {
 public:
-	CustomKey(uint64_t pspButtonBit, const char *key, bool toggle, bool repeat, ControlMapper* controllMapper, ImageID bgImg, ImageID bgDownImg, ImageID img, float scale, bool invertedContextDimension, UI::LayoutParams *layoutParams)
+	CustomButton(uint64_t pspButtonBit, const char *key, bool toggle, bool repeat, ControlMapper* controllMapper, ImageID bgImg, ImageID bgDownImg, ImageID img, float scale, bool invertedContextDimension, UI::LayoutParams *layoutParams)
 		: MultiTouchButton(key, bgImg, bgDownImg, img, scale, layoutParams), pspButtonBit_(pspButtonBit), toggle_(toggle), repeat_(repeat), controlMapper_(controllMapper), on_(false), invertedContextDimension_(invertedContextDimension) {
 	}
 	bool Touch(const TouchInput &input) override;


### PR DESCRIPTION
In the big input refactoring, seems I broke the ability for custom buttons to be mapped to analog inputs.

Additionally, if you tried to set this up on Windows, it didn't save properly. 

Fixes #17428 .