### PR TITLE
ElfLoader: Don't scan for functions in zero-length sections

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1412,6 +1412,10 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 			// Note: scan end is inclusive.
 			u32 end = start + reader.GetSectionSize(id) - 4;
 			u32 len = end + 4 - start;
+			if (len == 0) {
+				// Seen in WWE: Smackdown vs Raw 2009. See #17435.
+				continue;
+			}
 			if (!Memory::IsValidRange(start, len)) {
 				ERROR_LOG(LOADER, "Bad section %08x (len %08x) of section %d", start, len, id);
 				continue;


### PR DESCRIPTION
This section has both GetSectionAddr and GetSectionSize returning 0.

```cpp
			u32 start = reader.GetSectionAddr(id);
			// Note: scan end is inclusive.
			u32 end = start + reader.GetSectionSize(id) - 4;
			u32 len = end + 4 - start;
```
We end up with start = 0, end = 0xFFFFFFFC, len = 0 and Memory::IsValidRange returning true because len = 0 due to wraparound. 

So we try to scan 0 to 0xFFFFFFFFC for functions, which causes problems.

Happens in WWE: Smackdown Vs Raw 2009 during initial load.

Fixes #12414 again (somewhat different problem this time).