### PR TITLE
WM_USER_GET_EMULATION_STATE message

### DIFF
--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -91,6 +91,7 @@ int verysleepy__useSendMessage = 1;
 
 const UINT WM_VERYSLEEPY_MSG = WM_APP + 0x3117;
 const UINT WM_USER_GET_BASE_POINTER = WM_APP + 0x3118;  // 0xB118
+const UINT WM_USER_GET_EMULATION_STATE = WM_APP + 0x3119;  // 0xB119
 
 // Respond TRUE to a message with this param value to indicate support.
 const WPARAM VERYSLEEPY_WPARAM_SUPPORTED = 0;
@@ -788,6 +789,9 @@ namespace MainWindow
 				return 0;
 			}
 			break;
+
+		case WM_USER_GET_EMULATION_STATE:
+			return (u32)(Core_IsActive() && GetUIState() == UISTATE_INGAME);
 
 		// Hack to kill the white line underneath the menubar.
 		// From https://stackoverflow.com/questions/57177310/how-to-paint-over-white-line-between-menu-bar-and-client-area-of-window


### PR DESCRIPTION
Since there's `WM_USER_GET_BASE_POINTER` message, it makes sense to have a way to check whether or not the game is actually running.

Code sample:

```cpp
        if (hWndPPSSPP != std::end(vhWnds))
        {
            const UINT WM_USER_GET_BASE_POINTER = WM_APP + 0x3118;  // 0xB118
            const UINT WM_USER_GET_EMULATION_STATE = WM_APP + 0x3119;  // 0xB119

            if (SendMessage(*hWndPPSSPP, WM_USER_GET_EMULATION_STATE, 0, 0))
            {
                enum
                {
                    lo,   // Lower 32 bits of pointer to the base of emulated memory
                    hi,   // Upper 32 bits of pointer to the base of emulated memory
                    p_lo, // Lower 32 bits of pointer to the pointer to the base of emulated memory
                    p_hi, // Upper 32 bits of pointer to the pointer to the base of emulated memory
                };

                uint32_t high = SendMessage(*hWndPPSSPP, WM_USER_GET_BASE_POINTER, 0, hi);
                uint32_t low = SendMessage(*hWndPPSSPP, WM_USER_GET_BASE_POINTER, 0, lo);
                uint64_t ptr = (uint64_t(high) << 32 | low);

                if (ptr)
                {
                    auto gMenuActivated = *(uint8_t*)(ptr + 0x08BC9100 + 0x20);
                    auto pRwMatrix = *(uint32_t*)(ptr + 0x08BB4020);
                    if (!gMenuActivated && pRwMatrix)
                    {
                        ...
                    }
                }
            }
        }
```

Maybe also worth updating this page: https://www.ppsspp.org/docs/reference/process-hacks