### PR TITLE
Fix running some file formats from the Downloads folder

### DIFF
--- a/Common/File/AndroidContentURI.cpp
+++ b/Common/File/AndroidContentURI.cpp
@@ -148,11 +148,11 @@ std::string AndroidContentURI::GetLastPart() const {
 
 	if (!CanNavigateUp()) {
 		size_t colon = file.rfind(':');
-		if (file.back() == ':') {
-			return file;
-		}
 		if (colon == std::string::npos) {
 			return std::string();
+		}
+		if (file.back() == ':') {
+			return file;
 		}
 		return file.substr(colon + 1);
 	}

--- a/Common/File/AndroidContentURI.h
+++ b/Common/File/AndroidContentURI.h
@@ -66,4 +66,8 @@ public:
 	const std::string &RootPath() const {
 		return root.empty() ? file : root;
 	}
+
+	bool IsTreeURI() const {
+		return !root.empty();
+	}
 };

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -722,14 +722,20 @@ static bool TestAndroidContentURI() {
 	EXPECT_EQ_STR(diff, std::string("Tekken 6.iso"));
 
 	EXPECT_EQ_STR(fileURI.GetFileExtension(), std::string(".prx"));
-	EXPECT_FALSE(fileURI.CanNavigateUp());
+	EXPECT_TRUE(fileURI.CanNavigateUp());  // Can now virtually navigate up one step from these.
 
-	// These are annoying because they hide the actual filename, and we can't get at a parent folder,
-	// which confuses our elf loading.
+	// These are annoying because they hide the actual filename, and we can't get at a parent folder.
+	// Decided to handle the ':' as a directory separator for navigation purposes, which fixes the problem (though not the extension thing).
 	AndroidContentURI downloadURI;
 	EXPECT_TRUE(downloadURI.Parse(std::string(downloadURIString)));
 	EXPECT_EQ_STR(downloadURI.GetLastPart(), std::string("10000000006"));
-	EXPECT_FALSE(downloadURI.CanNavigateUp());
+	EXPECT_TRUE(downloadURI.CanNavigateUp());
+	EXPECT_TRUE(downloadURI.NavigateUp());
+	// While this is not an openable valid content URI, we can still get something that we can concatenate a filename on top of.
+	EXPECT_EQ_STR(downloadURI.ToString(), std::string("content://com.android.providers.downloads.documents/document/msf%3A"));
+	EXPECT_EQ_STR(downloadURI.GetLastPart(), std::string("msf:"));
+	downloadURI = downloadURI.WithComponent("myfile");
+	EXPECT_EQ_STR(downloadURI.ToString(), std::string("content://com.android.providers.downloads.documents/document/msf%3Amyfile"));
 	return true;
 }
 


### PR DESCRIPTION
Due to how we mount stuff, we need to be able to navigate one step up from the executable, and then re-attach the executable filename. To allow this, in single-file (non-tree) content URIs, treat ':' as a directory separator for navigation purposes. Fixes #17462 in a way (see that issue for more information).

End result, you can now download cube.elf from the website and run it directly from Downloads without using a file manager to move it.

Seems to work just fine and fixes quite an annoying issue, so getting it in for 1.15.4.