### PR TITLE
Reduce zero initialization and copying overhead of render commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -566,6 +566,7 @@ add_library(Common STATIC
 	Common/Data/Collections/FixedSizeQueue.h
 	Common/Data/Collections/Hashmaps.h
 	Common/Data/Collections/TinySet.h
+	Common/Data/Collections/FastVec.h
 	Common/Data/Collections/ThreadSafeList.h
 	Common/Data/Color/RGBAUtil.cpp
 	Common/Data/Color/RGBAUtil.h

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -859,6 +859,7 @@
     </ClCompile>
     <ClCompile Include="ArmEmitter.cpp" />
     <ClCompile Include="Buffer.cpp" />
+    <ClCompile Include="Data\Collections\FastVec.h" />
     <ClCompile Include="Data\Color\RGBAUtil.cpp" />
     <ClCompile Include="Data\Convert\SmallDataConvert.cpp" />
     <ClCompile Include="Data\Encoding\Base64.cpp" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -938,6 +938,9 @@
     <ClCompile Include="GPU\OpenGL\GLMemory.cpp">
       <Filter>GPU\OpenGL</Filter>
     </ClCompile>
+    <ClCompile Include="Data\Collections\FastVec.h">
+      <Filter>Data\Collections</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Crypto">

--- a/Common/Data/Collections/FastVec.h
+++ b/Common/Data/Collections/FastVec.h
@@ -101,6 +101,14 @@ public:
 		size_ += newItems;
 	}
 
+	void resize(size_t size) {
+		if (size < size_) {
+			size_ = size;
+		} else {
+			// TODO
+		}
+	}
+
 private:
 	void IncreaseCapacityTo(size_t newCapacity) {
 		if (newCapacity <= capacity_)
@@ -123,7 +131,7 @@ private:
 		capacity_ = newCapacity;
 	}
 
-	T *data_ = nullptr;
 	size_t size_ = 0;
 	size_t capacity_ = 0;
+	T *data_ = nullptr;
 };

--- a/Common/Data/Collections/FastVec.h
+++ b/Common/Data/Collections/FastVec.h
@@ -18,10 +18,10 @@ public:
 	}
 	~FastVec() { if (data_) free(data_); }
 
-	T *push_back() {
+	T &push_uninitialized() {
 		if (size_ < capacity_) {
 			size_++;
-			return data_ + size_ - 1;
+			return data_[size_ - 1];
 		} else {
 			T *oldData = data_;
 			size_t newCapacity = capacity_ * 2;
@@ -35,13 +35,13 @@ public:
 			}
 			size_++;
 			capacity_ = newCapacity;
-			return data_ + size_ - 1;
+			return data_[size_ - 1];
 		}
 	}
 
 	void push_back(const T &t) {
-		T *dest = push_back();
-		*dest = t;
+		T &dest = push_uninitialized();
+		dest = t;
 	}
 
 	// Move constructor

--- a/Common/Data/Collections/FastVec.h
+++ b/Common/Data/Collections/FastVec.h
@@ -23,18 +23,7 @@ public:
 			size_++;
 			return data_[size_ - 1];
 		} else {
-			T *oldData = data_;
-			size_t newCapacity = capacity_ * 2;
-			if (newCapacity < 16) {
-				newCapacity = 16;
-			}
-			data_ = (T *)malloc(sizeof(T) * newCapacity);
-			if (capacity_ != 0) {
-				memcpy(data_, oldData, sizeof(T) * size_);
-				free(oldData);
-			}
-			size_++;
-			capacity_ = newCapacity;
+			ExtendByOne();
 			return data_[size_ - 1];
 		}
 	}
@@ -74,6 +63,7 @@ public:
 	size_t size() const { return size_; }
 	size_t capacity() const { return capacity_; }
 	void clear() { size_ = 0; }
+	bool empty() const { return size_ == 0; }
 
 	T *begin() { return data_; }
 	T *end() { return data_ + size_; }
@@ -88,7 +78,32 @@ public:
 	const T &back() const { return (*this)[size() - 1]; }
 	const T &front() const { return (*this)[0]; }
 
+	// Limited functionality for inserts and similar, add as needed.
+	T &insert(T *iter) {
+		int pos = iter - data_;
+		ExtendByOne();
+		if (pos + 1 < size_) {
+			memmove(data_ + pos + 1, data_ + pos, (size_ - pos) * sizeof(T));
+		}
+		return data_[pos];
+	}
+
 private:
+	void ExtendByOne() {
+		T *oldData = data_;
+		size_t newCapacity = capacity_ * 2;
+		if (newCapacity < 16) {
+			newCapacity = 16;
+		}
+		data_ = (T *)malloc(sizeof(T) * newCapacity);
+		if (capacity_ != 0) {
+			memcpy(data_, oldData, sizeof(T) * size_);
+			free(oldData);
+		}
+		size_++;
+		capacity_ = newCapacity;
+	}
+
 	T *data_ = nullptr;
 	size_t size_ = 0;
 	size_t capacity_ = 0;

--- a/Common/Data/Collections/FastVec.h
+++ b/Common/Data/Collections/FastVec.h
@@ -73,6 +73,8 @@ public:
 	// Out of bounds (past size() - 1) is undefined behavior.
 	T &operator[] (const size_t index) { return data_[index]; }
 	const T &operator[] (const size_t index) const { return data_[index]; }
+	T &at(const size_t index) { return data_[index]; }
+	const T &at(const size_t index) const { return data_[index]; }
 
 	// These two are invalid if empty().
 	const T &back() const { return (*this)[size() - 1]; }
@@ -88,18 +90,35 @@ public:
 		return data_[pos];
 	}
 
+	void insert(T *destIter, const T *beginIter, const T *endIter) {
+		int pos = destIter - data_;
+		if (beginIter == endIter)
+			return;
+		size_t newItems = endIter - beginIter;
+		IncreaseCapacityTo(size_ + newItems);
+		memmove(data_ + pos + newItems, data_ + pos, (size_ - pos) * sizeof(T));
+		memcpy(data_ + pos, beginIter, newItems * sizeof(T));
+		size_ += newItems;
+	}
+
 private:
-	void ExtendByOne() {
+	void IncreaseCapacityTo(size_t newCapacity) {
+		if (newCapacity <= capacity_)
+			return;
 		T *oldData = data_;
-		size_t newCapacity = capacity_ * 2;
-		if (newCapacity < 16) {
-			newCapacity = 16;
-		}
 		data_ = (T *)malloc(sizeof(T) * newCapacity);
 		if (capacity_ != 0) {
 			memcpy(data_, oldData, sizeof(T) * size_);
 			free(oldData);
 		}
+	}
+
+	void ExtendByOne() {
+		size_t newCapacity = capacity_ * 2;
+		if (newCapacity < 16) {
+			newCapacity = 16;
+		}
+		IncreaseCapacityTo(newCapacity);
 		size_++;
 		capacity_ = newCapacity;
 	}

--- a/Common/Data/Collections/FastVec.h
+++ b/Common/Data/Collections/FastVec.h
@@ -1,0 +1,95 @@
+#pragma once
+
+// Yet another replacement for std::vector, this time for use in graphics queues.
+// Its major difference is that you can append uninitialized structures and initialize them after.
+// This is not allows by std::vector but is very useful for our sometimes oversized unions.
+// Also, copies during resize are done by memcpy, not by any move constructor or similar.
+
+#include <cstdlib>
+#include <cstring>
+
+template<class T>
+class FastVec {
+public:
+	FastVec() {}
+	FastVec(size_t initialCapacity) {
+		capacity_ = initialCapacity;
+		data_ = (T *)malloc(initialCapacity * sizeof(T));
+	}
+	~FastVec() { if (data_) free(data_); }
+
+	T *push_back() {
+		if (size_ < capacity_) {
+			size_++;
+			return data_ + size_ - 1;
+		} else {
+			T *oldData = data_;
+			size_t newCapacity = capacity_ * 2;
+			if (newCapacity < 16) {
+				newCapacity = 16;
+			}
+			data_ = (T *)malloc(sizeof(T) * newCapacity);
+			if (capacity_ != 0) {
+				memcpy(data_, oldData, sizeof(T) * size_);
+				free(oldData);
+			}
+			size_++;
+			capacity_ = newCapacity;
+			return data_ + size_ - 1;
+		}
+	}
+
+	void push_back(const T &t) {
+		T *dest = push_back();
+		*dest = t;
+	}
+
+	// Move constructor
+	FastVec(FastVec &&other) {
+		data_ = other.data_;
+		size_ = other.size_;
+		capacity_ = other.capacity_;
+		other.data_ = nullptr;
+		other.size_ = 0;
+		other.capacity_ = 0;
+	}
+
+	FastVec &operator=(FastVec &&other)	{
+		if (this != &other) {
+			delete[] data_;
+			data_ = other.data_;
+			size_ = other.size_;
+			capacity_ = other.capacity_;
+			other.data_ = nullptr;
+			other.size_ = 0;
+			other.capacity_ = 0;
+		}
+		return *this;
+	}
+
+	// No copy constructor.
+	FastVec(const FastVec &other) = delete;
+	FastVec &operator=(const FastVec &other) = delete;
+
+	size_t size() const { return size_; }
+	size_t capacity() const { return capacity_; }
+	void clear() { size_ = 0; }
+
+	T *begin() { return data_; }
+	T *end() { return data_ + size_; }
+	const T *begin() const { return data_; }
+	const T *end() const { return data_ + size_; }
+
+	// Out of bounds (past size() - 1) is undefined behavior.
+	T &operator[] (const size_t index) { return data_[index]; }
+	const T &operator[] (const size_t index) const { return data_[index]; }
+
+	// These two are invalid if empty().
+	const T &back() const { return (*this)[size() - 1]; }
+	const T &front() const { return (*this)[0]; }
+
+private:
+	T *data_ = nullptr;
+	size_t size_ = 0;
+	size_t capacity_ = 0;
+};

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -118,7 +118,7 @@ static std::string GetStereoBufferLayout(const char *uniformName) {
 	else return "undefined";
 }
 
-void GLQueueRunner::RunInitSteps(const std::vector<GLRInitStep> &steps, bool skipGLCalls) {
+void GLQueueRunner::RunInitSteps(const FastVec<GLRInitStep> &steps, bool skipGLCalls) {
 	if (skipGLCalls) {
 		// Some bookkeeping still needs to be done.
 		for (size_t i = 0; i < steps.size(); i++) {

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -700,7 +700,7 @@ void GLQueueRunner::RunSteps(const std::vector<GLRStep *> &steps, bool skipGLCal
 	CHECK_GL_ERROR_IF_DEBUG();
 	size_t renderCount = 0;
 	for (size_t i = 0; i < steps.size(); i++) {
-		const GLRStep &step = *steps[i];
+		GLRStep &step = *steps[i];
 
 #if !defined(USING_GLES2)
 		if (useDebugGroups_)
@@ -711,7 +711,7 @@ void GLQueueRunner::RunSteps(const std::vector<GLRStep *> &steps, bool skipGLCal
 		case GLRStepType::RENDER:
 			renderCount++;
 			if (IsVREnabled()) {
-				GLRStep vrStep = step;
+				GLRStep &vrStep = step;
 				PreprocessStepVR(&vrStep);
 				PerformRenderPass(vrStep, renderCount == 1, renderCount == totalRenderCount);
 			} else {

--- a/Common/GPU/OpenGL/GLQueueRunner.h
+++ b/Common/GPU/OpenGL/GLQueueRunner.h
@@ -311,8 +311,6 @@ struct GLRStep {
 			GLRRenderPassAction color;
 			GLRRenderPassAction depth;
 			GLRRenderPassAction stencil;
-			// Note: not accurate.
-			int numDraws;
 		} render;
 		struct {
 			GLRFramebuffer *src;

--- a/Common/GPU/OpenGL/GLQueueRunner.h
+++ b/Common/GPU/OpenGL/GLQueueRunner.h
@@ -302,7 +302,7 @@ enum {
 struct GLRStep {
 	GLRStep(GLRStepType _type) : stepType(_type) {}
 	GLRStepType stepType;
-	std::vector<GLRRenderData> commands;
+	FastVec<GLRRenderData> commands;
 	TinySet<const GLRFramebuffer *, 8> dependencies;
 	const char *tag;
 	union {

--- a/Common/GPU/OpenGL/GLQueueRunner.h
+++ b/Common/GPU/OpenGL/GLQueueRunner.h
@@ -70,6 +70,7 @@ enum class GLRRenderCommand : uint8_t {
 // type field, smashed right after each other?)
 // Also, all GLenums are really only 16 bits.
 struct GLRRenderData {
+	GLRRenderData(GLRRenderCommand _cmd) : cmd(_cmd) {}
 	GLRRenderCommand cmd;
 	union {
 		struct {

--- a/Common/GPU/OpenGL/GLQueueRunner.h
+++ b/Common/GPU/OpenGL/GLQueueRunner.h
@@ -11,7 +11,7 @@
 #include "Common/GPU/Shader.h"
 #include "Common/GPU/thin3d.h"
 #include "Common/Data/Collections/TinySet.h"
-
+#include "Common/Data/Collections/FastVec.h"
 
 struct GLRViewport {
 	float x, y, w, h, minZ, maxZ;
@@ -354,7 +354,7 @@ public:
 		caps_ = caps;
 	}
 
-	void RunInitSteps(const std::vector<GLRInitStep> &steps, bool skipGLCalls);
+	void RunInitSteps(const FastVec<GLRInitStep> &steps, bool skipGLCalls);
 
 	void RunSteps(const std::vector<GLRStep *> &steps, bool skipGLCalls, bool keepSteps, bool useVR);
 

--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -215,7 +215,6 @@ void GLRenderManager::BindFramebufferAsRenderTarget(GLRFramebuffer *fb, GLRRende
 	step->render.color = color;
 	step->render.depth = depth;
 	step->render.stencil = stencil;
-	step->render.numDraws = 0;
 	step->tag = tag;
 	steps_.push_back(step);
 

--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -220,8 +220,7 @@ void GLRenderManager::BindFramebufferAsRenderTarget(GLRFramebuffer *fb, GLRRende
 	steps_.push_back(step);
 
 	GLuint clearMask = 0;
-	GLRRenderData data;
-	data.cmd = GLRRenderCommand::CLEAR;
+	GLRRenderData data(GLRRenderCommand::CLEAR);
 	if (color == GLRRenderPassAction::CLEAR) {
 		clearMask |= GL_COLOR_BUFFER_BIT;
 		data.clear.clearColor = clearColor;

--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -135,13 +135,12 @@ bool GLRenderManager::ThreadFrame() {
 	while (true) {
 		// Pop a task of the queue and execute it.
 		// NOTE: We need to actually wait for a task, we can't just bail!
-
 		{
 			std::unique_lock<std::mutex> lock(pushMutex_);
 			while (renderThreadQueue_.empty()) {
 				pushCondVar_.wait(lock);
 			}
-			task = renderThreadQueue_.front();
+			task = std::move(renderThreadQueue_.front());
 			renderThreadQueue_.pop();
 		}
 

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -757,7 +757,6 @@ public:
 		data.draw.count = count;
 		data.draw.indexType = 0;
 		curRenderStep_->commands.push_back(data);
-		curRenderStep_->render.numDraws++;
 	}
 
 	void DrawIndexed(GLRInputLayout *inputLayout, GLRBuffer *buffer, size_t offset, GLRBuffer *indexBuffer, GLenum mode, int count, GLenum indexType, void *indices, int instances = 1) {
@@ -773,7 +772,6 @@ public:
 		data.draw.indices = indices;
 		data.draw.instances = instances;
 		curRenderStep_->commands.push_back(data);
-		curRenderStep_->render.numDraws++;
 	}
 
 	enum { MAX_INFLIGHT_FRAMES = 3 };

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -203,14 +203,19 @@ enum class GLRRunType {
 class GLRenderManager;
 class GLPushBuffer;
 
-// These are enqueued from the main thread,
-// and the render thread pops them off
+// These are enqueued from the main thread, and the render thread pops them off
 struct GLRRenderThreadTask {
+	GLRRenderThreadTask(GLRRunType _runType) : runType(_runType) {}
+
 	std::vector<GLRStep *> steps;
 	std::vector<GLRInitStep> initSteps;
 
-	int frame;
+	int frame = -1;
 	GLRRunType runType;
+
+	// Avoid copying these by accident.
+	GLRRenderThreadTask(GLRRenderThreadTask &) = delete;
+	GLRRenderThreadTask& operator =(GLRRenderThreadTask &) = delete;
 };
 
 // Note: The GLRenderManager is created and destroyed on the render thread, and the latter
@@ -866,7 +871,7 @@ private:
 	std::mutex pushMutex_;
 	std::condition_variable pushCondVar_;
 
-	std::queue<GLRRenderThreadTask> renderThreadQueue_;
+	std::queue<GLRRenderThreadTask *> renderThreadQueue_;
 
 	// For readbacks and other reasons we need to sync with the render thread.
 	std::mutex syncMutex_;

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -446,11 +446,11 @@ public:
 	}
 
 	void FinalizeTexture(GLRTexture *texture, int loadedLevels, bool genMips) {
-		GLRInitStep step(GLRInitStepType::TEXTURE_FINALIZE);
+		GLRInitStep &step = initSteps_.push_uninitialized();
+		step.stepType = GLRInitStepType::TEXTURE_FINALIZE;
 		step.texture_finalize.texture = texture;
 		step.texture_finalize.loadedLevels = loadedLevels;
 		step.texture_finalize.genMips = genMips;
-		initSteps_.push_back(step);
 	}
 
 	void BindTexture(int slot, GLRTexture *tex) {
@@ -461,18 +461,18 @@ public:
 		}
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		_dbg_assert_(slot < MAX_GL_TEXTURE_SLOTS);
-		GLRRenderData data(GLRRenderCommand::BINDTEXTURE);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::BINDTEXTURE;
 		data.texture.slot = slot;
 		data.texture.texture = tex;
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void BindProgram(GLRProgram *program) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data(GLRRenderCommand::BINDPROGRAM);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::BINDPROGRAM;
 		_dbg_assert_(program != nullptr);
 		data.program.program = program;
-		curRenderStep_->commands.push_back(data);
 #ifdef _DEBUG
 		curProgram_ = program;
 #endif
@@ -480,25 +480,25 @@ public:
 
 	void SetDepth(bool enabled, bool write, GLenum func) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data(GLRRenderCommand::DEPTH);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::DEPTH;
 		data.depth.enabled = enabled;
 		data.depth.write = write;
 		data.depth.func = func;
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetViewport(const GLRViewport &vp) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data(GLRRenderCommand::VIEWPORT);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::VIEWPORT;
 		data.viewport.vp = vp;
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetScissor(const GLRect2D &rc) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data(GLRRenderCommand::SCISSOR);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::SCISSOR;
 		data.scissor.rc = rc;
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetUniformI(const GLint *loc, int count, const int *udata) {
@@ -506,12 +506,12 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data(GLRRenderCommand::UNIFORM4I);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::UNIFORM4I;
 		data.uniform4.name = nullptr;
 		data.uniform4.loc = loc;
 		data.uniform4.count = count;
 		memcpy(data.uniform4.v, udata, sizeof(int) * count);
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetUniformI1(const GLint *loc, int udata) {
@@ -519,12 +519,12 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data(GLRRenderCommand::UNIFORM4I);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::UNIFORM4I;
 		data.uniform4.name = nullptr;
 		data.uniform4.loc = loc;
 		data.uniform4.count = 1;
 		memcpy(data.uniform4.v, &udata, sizeof(udata));
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetUniformUI(const GLint *loc, int count, const uint32_t *udata) {
@@ -532,12 +532,12 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data(GLRRenderCommand::UNIFORM4UI);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::UNIFORM4UI;
 		data.uniform4.name = nullptr;
 		data.uniform4.loc = loc;
 		data.uniform4.count = count;
 		memcpy(data.uniform4.v, udata, sizeof(uint32_t) * count);
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetUniformUI1(const GLint *loc, uint32_t udata) {
@@ -545,12 +545,12 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data(GLRRenderCommand::UNIFORM4UI);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::UNIFORM4UI;
 		data.uniform4.name = nullptr;
 		data.uniform4.loc = loc;
 		data.uniform4.count = 1;
 		memcpy(data.uniform4.v, &udata, sizeof(udata));
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetUniformF(const GLint *loc, int count, const float *udata) {
@@ -558,12 +558,12 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data(GLRRenderCommand::UNIFORM4F);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::UNIFORM4F;
 		data.uniform4.name = nullptr;
 		data.uniform4.loc = loc;
 		data.uniform4.count = count;
 		memcpy(data.uniform4.v, udata, sizeof(float) * count);
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetUniformF1(const GLint *loc, const float udata) {
@@ -571,12 +571,12 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data(GLRRenderCommand::UNIFORM4F);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::UNIFORM4F;
 		data.uniform4.name = nullptr;
 		data.uniform4.loc = loc;
 		data.uniform4.count = 1;
 		memcpy(data.uniform4.v, &udata, sizeof(float));
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetUniformF(const char *name, int count, const float *udata) {
@@ -584,12 +584,12 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data(GLRRenderCommand::UNIFORM4F);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::UNIFORM4F;
 		data.uniform4.name = name;
 		data.uniform4.loc = nullptr;
 		data.uniform4.count = count;
 		memcpy(data.uniform4.v, udata, sizeof(float) * count);
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetUniformM4x4(const GLint *loc, const float *udata) {
@@ -597,11 +597,11 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data(GLRRenderCommand::UNIFORMMATRIX);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::UNIFORMMATRIX;
 		data.uniformMatrix4.name = nullptr;
 		data.uniformMatrix4.loc = loc;
 		memcpy(data.uniformMatrix4.m, udata, sizeof(float) * 16);
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetUniformM4x4Stereo(const char *name, const GLint *loc, const float *left, const float *right) {
@@ -609,13 +609,13 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data(GLRRenderCommand::UNIFORMSTEREOMATRIX);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::UNIFORMSTEREOMATRIX;
 		data.uniformStereoMatrix4.name = name;
 		data.uniformStereoMatrix4.loc = loc;
 		data.uniformStereoMatrix4.mData = new float[32];
 		memcpy(&data.uniformStereoMatrix4.mData[0], left, sizeof(float) * 16);
 		memcpy(&data.uniformStereoMatrix4.mData[16], right, sizeof(float) * 16);
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetUniformM4x4(const char *name, const float *udata) {
@@ -623,18 +623,19 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data(GLRRenderCommand::UNIFORMMATRIX);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::UNIFORMMATRIX;
 		data.uniformMatrix4.name = name;
 		data.uniformMatrix4.loc = nullptr;
 		memcpy(data.uniformMatrix4.m, udata, sizeof(float) * 16);
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetBlendAndMask(int colorMask, bool blendEnabled, GLenum srcColor, GLenum dstColor, GLenum srcAlpha, GLenum dstAlpha, GLenum funcColor, GLenum funcAlpha) {
 		// Make this one only a non-debug _assert_, since it often comes first.
 		// Lets us collect info about this potential crash through assert extra data.
 		_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data(GLRRenderCommand::BLEND);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::BLEND;
 		data.blend.mask = colorMask;
 		data.blend.enabled = blendEnabled;
 		data.blend.srcColor = srcColor;
@@ -643,96 +644,95 @@ public:
 		data.blend.dstAlpha = dstAlpha;
 		data.blend.funcColor = funcColor;
 		data.blend.funcAlpha = funcAlpha;
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetNoBlendAndMask(int colorMask) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data(GLRRenderCommand::BLEND);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::BLEND;
 		data.blend.mask = colorMask;
 		data.blend.enabled = false;
-		curRenderStep_->commands.push_back(data);
 	}
 
 #ifndef USING_GLES2
 	void SetLogicOp(bool enabled, GLenum logicOp) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data(GLRRenderCommand::LOGICOP);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::LOGICOP;
 		data.logic.enabled = enabled;
 		data.logic.logicOp = logicOp;
-		curRenderStep_->commands.push_back(data);
 	}
 #endif
 
 	void SetStencilFunc(bool enabled, GLenum func, uint8_t refValue, uint8_t compareMask) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data(GLRRenderCommand::STENCILFUNC);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::STENCILFUNC;
 		data.stencilFunc.enabled = enabled;
 		data.stencilFunc.func = func;
 		data.stencilFunc.ref = refValue;
 		data.stencilFunc.compareMask = compareMask;
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetStencilOp(uint8_t writeMask, GLenum sFail, GLenum zFail, GLenum pass) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data(GLRRenderCommand::STENCILOP);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::STENCILOP;
 		data.stencilOp.writeMask = writeMask;
 		data.stencilOp.sFail = sFail;
 		data.stencilOp.zFail = zFail;
 		data.stencilOp.pass = pass;
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetStencilDisabled() {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data(GLRRenderCommand::STENCILFUNC);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::STENCILFUNC;
 		data.stencilFunc.enabled = false;
 		// When enabled = false, the others aren't read so we don't zero-initialize them.
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetBlendFactor(const float color[4]) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data(GLRRenderCommand::BLENDCOLOR);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::BLENDCOLOR;
 		CopyFloat4(data.blendColor.color, color);
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetRaster(GLboolean cullEnable, GLenum frontFace, GLenum cullFace, GLboolean ditherEnable, GLboolean depthClamp) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data(GLRRenderCommand::RASTER);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::RASTER;
 		data.raster.cullEnable = cullEnable;
 		data.raster.frontFace = frontFace;
 		data.raster.cullFace = cullFace;
 		data.raster.ditherEnable = ditherEnable;
 		data.raster.depthClampEnable = depthClamp;
-		curRenderStep_->commands.push_back(data);
 	}
 	
 	// Modifies the current texture as per GL specs, not global state.
 	void SetTextureSampler(int slot, GLenum wrapS, GLenum wrapT, GLenum magFilter, GLenum minFilter, float anisotropy) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		_dbg_assert_(slot < MAX_GL_TEXTURE_SLOTS);
-		GLRRenderData data(GLRRenderCommand::TEXTURESAMPLER);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::TEXTURESAMPLER;
 		data.textureSampler.slot = slot;
 		data.textureSampler.wrapS = wrapS;
 		data.textureSampler.wrapT = wrapT;
 		data.textureSampler.magFilter = magFilter;
 		data.textureSampler.minFilter = minFilter;
 		data.textureSampler.anisotropy = anisotropy;
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetTextureLod(int slot, float minLod, float maxLod, float lodBias) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		_dbg_assert_(slot < MAX_GL_TEXTURE_SLOTS);
-		GLRRenderData data(GLRRenderCommand::TEXTURELOD);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::TEXTURELOD;
 		data.textureLod.slot = slot;
 		data.textureLod.minLod = minLod;
 		data.textureLod.maxLod = maxLod;
 		data.textureLod.lodBias = lodBias;
-		curRenderStep_->commands.push_back(data);
 	}
 
 	// If scissorW == 0, no scissor is applied (the whole render target is cleared).
@@ -740,7 +740,8 @@ public:
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		if (!clearMask)
 			return;
-		GLRRenderData data(GLRRenderCommand::CLEAR);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::CLEAR;
 		data.clear.clearMask = clearMask;
 		data.clear.clearColor = clearColor;
 		data.clear.clearZ = clearZ;
@@ -750,12 +751,12 @@ public:
 		data.clear.scissorY = scissorY;
 		data.clear.scissorW = scissorW;
 		data.clear.scissorH = scissorH;
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void Draw(GLRInputLayout *inputLayout, GLRBuffer *buffer, size_t offset, GLenum mode, int first, int count) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data(GLRRenderCommand::DRAW);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::DRAW;
 		data.draw.inputLayout = inputLayout;
 		data.draw.offset = offset;
 		data.draw.buffer = buffer;
@@ -764,12 +765,12 @@ public:
 		data.draw.first = first;
 		data.draw.count = count;
 		data.draw.indexType = 0;
-		curRenderStep_->commands.push_back(data);
 	}
 
 	void DrawIndexed(GLRInputLayout *inputLayout, GLRBuffer *buffer, size_t offset, GLRBuffer *indexBuffer, GLenum mode, int count, GLenum indexType, void *indices, int instances = 1) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data(GLRRenderCommand::DRAW);
+		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
+		data.cmd = GLRRenderCommand::DRAW;
 		data.draw.inputLayout = inputLayout;
 		data.draw.offset = offset;
 		data.draw.buffer = buffer;
@@ -779,7 +780,6 @@ public:
 		data.draw.indexType = indexType;
 		data.draw.indices = indices;
 		data.draw.instances = instances;
-		curRenderStep_->commands.push_back(data);
 	}
 
 	enum { MAX_INFLIGHT_FRAMES = 3 };

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -395,7 +395,7 @@ public:
 	void BufferSubdata(GLRBuffer *buffer, size_t offset, size_t size, uint8_t *data, bool deleteData = true) {
 		// TODO: Maybe should be a render command instead of an init command? When possible it's better as
 		// an init command, that's for sure.
-		GLRInitStep step{ GLRInitStepType::BUFFER_SUBDATA };
+		GLRInitStep step(GLRInitStepType::BUFFER_SUBDATA);
 		_dbg_assert_(offset >= 0);
 		_dbg_assert_(offset <= buffer->size_ - size);
 		step.buffer_subdata.buffer = buffer;
@@ -408,7 +408,7 @@ public:
 
 	// Takes ownership over the data pointer and delete[]-s it.
 	void TextureImage(GLRTexture *texture, int level, int width, int height, int depth, Draw::DataFormat format, uint8_t *data, GLRAllocType allocType = GLRAllocType::NEW, bool linearFilter = false) {
-		GLRInitStep step{ GLRInitStepType::TEXTURE_IMAGE };
+		GLRInitStep step(GLRInitStepType::TEXTURE_IMAGE);
 		step.texture_image.texture = texture;
 		step.texture_image.data = data;
 		step.texture_image.format = format;
@@ -423,7 +423,7 @@ public:
 
 	void TextureSubImage(int slot, GLRTexture *texture, int level, int x, int y, int width, int height, Draw::DataFormat format, uint8_t *data, GLRAllocType allocType = GLRAllocType::NEW) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData _data{ GLRRenderCommand::TEXTURE_SUBIMAGE };
+		GLRRenderData _data(GLRRenderCommand::TEXTURE_SUBIMAGE);
 		_data.texture_subimage.texture = texture;
 		_data.texture_subimage.data = data;
 		_data.texture_subimage.format = format;
@@ -438,7 +438,7 @@ public:
 	}
 
 	void FinalizeTexture(GLRTexture *texture, int loadedLevels, bool genMips) {
-		GLRInitStep step{ GLRInitStepType::TEXTURE_FINALIZE };
+		GLRInitStep step(GLRInitStepType::TEXTURE_FINALIZE);
 		step.texture_finalize.texture = texture;
 		step.texture_finalize.loadedLevels = loadedLevels;
 		step.texture_finalize.genMips = genMips;
@@ -453,7 +453,7 @@ public:
 		}
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		_dbg_assert_(slot < MAX_GL_TEXTURE_SLOTS);
-		GLRRenderData data{ GLRRenderCommand::BINDTEXTURE };
+		GLRRenderData data(GLRRenderCommand::BINDTEXTURE);
 		data.texture.slot = slot;
 		data.texture.texture = tex;
 		curRenderStep_->commands.push_back(data);
@@ -461,7 +461,7 @@ public:
 
 	void BindProgram(GLRProgram *program) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data{ GLRRenderCommand::BINDPROGRAM };
+		GLRRenderData data(GLRRenderCommand::BINDPROGRAM);
 		_dbg_assert_(program != nullptr);
 		data.program.program = program;
 		curRenderStep_->commands.push_back(data);
@@ -472,7 +472,7 @@ public:
 
 	void SetDepth(bool enabled, bool write, GLenum func) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data{ GLRRenderCommand::DEPTH };
+		GLRRenderData data(GLRRenderCommand::DEPTH);
 		data.depth.enabled = enabled;
 		data.depth.write = write;
 		data.depth.func = func;
@@ -481,14 +481,14 @@ public:
 
 	void SetViewport(const GLRViewport &vp) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data{ GLRRenderCommand::VIEWPORT };
+		GLRRenderData data(GLRRenderCommand::VIEWPORT);
 		data.viewport.vp = vp;
 		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetScissor(const GLRect2D &rc) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data{ GLRRenderCommand::SCISSOR };
+		GLRRenderData data(GLRRenderCommand::SCISSOR);
 		data.scissor.rc = rc;
 		curRenderStep_->commands.push_back(data);
 	}
@@ -498,7 +498,8 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data{ GLRRenderCommand::UNIFORM4I };
+		GLRRenderData data(GLRRenderCommand::UNIFORM4I);
+		data.uniform4.name = nullptr;
 		data.uniform4.loc = loc;
 		data.uniform4.count = count;
 		memcpy(data.uniform4.v, udata, sizeof(int) * count);
@@ -510,7 +511,8 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data{ GLRRenderCommand::UNIFORM4I };
+		GLRRenderData data(GLRRenderCommand::UNIFORM4I);
+		data.uniform4.name = nullptr;
 		data.uniform4.loc = loc;
 		data.uniform4.count = 1;
 		memcpy(data.uniform4.v, &udata, sizeof(udata));
@@ -522,7 +524,8 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data{ GLRRenderCommand::UNIFORM4UI };
+		GLRRenderData data(GLRRenderCommand::UNIFORM4UI);
+		data.uniform4.name = nullptr;
 		data.uniform4.loc = loc;
 		data.uniform4.count = count;
 		memcpy(data.uniform4.v, udata, sizeof(uint32_t) * count);
@@ -534,7 +537,8 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data{ GLRRenderCommand::UNIFORM4UI };
+		GLRRenderData data(GLRRenderCommand::UNIFORM4UI);
+		data.uniform4.name = nullptr;
 		data.uniform4.loc = loc;
 		data.uniform4.count = 1;
 		memcpy(data.uniform4.v, &udata, sizeof(udata));
@@ -546,7 +550,8 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data{ GLRRenderCommand::UNIFORM4F };
+		GLRRenderData data(GLRRenderCommand::UNIFORM4F);
+		data.uniform4.name = nullptr;
 		data.uniform4.loc = loc;
 		data.uniform4.count = count;
 		memcpy(data.uniform4.v, udata, sizeof(float) * count);
@@ -558,7 +563,8 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data{ GLRRenderCommand::UNIFORM4F };
+		GLRRenderData data(GLRRenderCommand::UNIFORM4F);
+		data.uniform4.name = nullptr;
 		data.uniform4.loc = loc;
 		data.uniform4.count = 1;
 		memcpy(data.uniform4.v, &udata, sizeof(float));
@@ -570,8 +576,9 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data{ GLRRenderCommand::UNIFORM4F };
+		GLRRenderData data(GLRRenderCommand::UNIFORM4F);
 		data.uniform4.name = name;
+		data.uniform4.loc = nullptr;
 		data.uniform4.count = count;
 		memcpy(data.uniform4.v, udata, sizeof(float) * count);
 		curRenderStep_->commands.push_back(data);
@@ -582,7 +589,8 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data{ GLRRenderCommand::UNIFORMMATRIX };
+		GLRRenderData data(GLRRenderCommand::UNIFORMMATRIX);
+		data.uniformMatrix4.name = nullptr;
 		data.uniformMatrix4.loc = loc;
 		memcpy(data.uniformMatrix4.m, udata, sizeof(float) * 16);
 		curRenderStep_->commands.push_back(data);
@@ -593,7 +601,7 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data{ GLRRenderCommand::UNIFORMSTEREOMATRIX };
+		GLRRenderData data(GLRRenderCommand::UNIFORMSTEREOMATRIX);
 		data.uniformStereoMatrix4.name = name;
 		data.uniformStereoMatrix4.loc = loc;
 		data.uniformStereoMatrix4.mData = new float[32];
@@ -607,8 +615,9 @@ public:
 #ifdef _DEBUG
 		_dbg_assert_(curProgram_);
 #endif
-		GLRRenderData data{ GLRRenderCommand::UNIFORMMATRIX };
+		GLRRenderData data(GLRRenderCommand::UNIFORMMATRIX);
 		data.uniformMatrix4.name = name;
+		data.uniformMatrix4.loc = nullptr;
 		memcpy(data.uniformMatrix4.m, udata, sizeof(float) * 16);
 		curRenderStep_->commands.push_back(data);
 	}
@@ -617,7 +626,7 @@ public:
 		// Make this one only a non-debug _assert_, since it often comes first.
 		// Lets us collect info about this potential crash through assert extra data.
 		_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data{ GLRRenderCommand::BLEND };
+		GLRRenderData data(GLRRenderCommand::BLEND);
 		data.blend.mask = colorMask;
 		data.blend.enabled = blendEnabled;
 		data.blend.srcColor = srcColor;
@@ -631,7 +640,7 @@ public:
 
 	void SetNoBlendAndMask(int colorMask) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data{ GLRRenderCommand::BLEND };
+		GLRRenderData data(GLRRenderCommand::BLEND);
 		data.blend.mask = colorMask;
 		data.blend.enabled = false;
 		curRenderStep_->commands.push_back(data);
@@ -640,7 +649,7 @@ public:
 #ifndef USING_GLES2
 	void SetLogicOp(bool enabled, GLenum logicOp) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data{ GLRRenderCommand::LOGICOP };
+		GLRRenderData data(GLRRenderCommand::LOGICOP);
 		data.logic.enabled = enabled;
 		data.logic.logicOp = logicOp;
 		curRenderStep_->commands.push_back(data);
@@ -649,7 +658,7 @@ public:
 
 	void SetStencilFunc(bool enabled, GLenum func, uint8_t refValue, uint8_t compareMask) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data{ GLRRenderCommand::STENCILFUNC };
+		GLRRenderData data(GLRRenderCommand::STENCILFUNC);
 		data.stencilFunc.enabled = enabled;
 		data.stencilFunc.func = func;
 		data.stencilFunc.ref = refValue;
@@ -659,7 +668,7 @@ public:
 
 	void SetStencilOp(uint8_t writeMask, GLenum sFail, GLenum zFail, GLenum pass) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data{ GLRRenderCommand::STENCILOP };
+		GLRRenderData data(GLRRenderCommand::STENCILOP);
 		data.stencilOp.writeMask = writeMask;
 		data.stencilOp.sFail = sFail;
 		data.stencilOp.zFail = zFail;
@@ -669,22 +678,22 @@ public:
 
 	void SetStencilDisabled() {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data;
-		data.cmd = GLRRenderCommand::STENCILFUNC;
+		GLRRenderData data(GLRRenderCommand::STENCILFUNC);
 		data.stencilFunc.enabled = false;
+		// When enabled = false, the others aren't read so we don't zero-initialize them.
 		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetBlendFactor(const float color[4]) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data{ GLRRenderCommand::BLENDCOLOR };
+		GLRRenderData data(GLRRenderCommand::BLENDCOLOR);
 		CopyFloat4(data.blendColor.color, color);
 		curRenderStep_->commands.push_back(data);
 	}
 
 	void SetRaster(GLboolean cullEnable, GLenum frontFace, GLenum cullFace, GLboolean ditherEnable, GLboolean depthClamp) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data{ GLRRenderCommand::RASTER };
+		GLRRenderData data(GLRRenderCommand::RASTER);
 		data.raster.cullEnable = cullEnable;
 		data.raster.frontFace = frontFace;
 		data.raster.cullFace = cullFace;
@@ -697,7 +706,7 @@ public:
 	void SetTextureSampler(int slot, GLenum wrapS, GLenum wrapT, GLenum magFilter, GLenum minFilter, float anisotropy) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		_dbg_assert_(slot < MAX_GL_TEXTURE_SLOTS);
-		GLRRenderData data{ GLRRenderCommand::TEXTURESAMPLER };
+		GLRRenderData data(GLRRenderCommand::TEXTURESAMPLER);
 		data.textureSampler.slot = slot;
 		data.textureSampler.wrapS = wrapS;
 		data.textureSampler.wrapT = wrapT;
@@ -710,7 +719,7 @@ public:
 	void SetTextureLod(int slot, float minLod, float maxLod, float lodBias) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		_dbg_assert_(slot < MAX_GL_TEXTURE_SLOTS);
-		GLRRenderData data{ GLRRenderCommand::TEXTURELOD};
+		GLRRenderData data(GLRRenderCommand::TEXTURELOD);
 		data.textureLod.slot = slot;
 		data.textureLod.minLod = minLod;
 		data.textureLod.maxLod = maxLod;
@@ -723,7 +732,7 @@ public:
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		if (!clearMask)
 			return;
-		GLRRenderData data{ GLRRenderCommand::CLEAR };
+		GLRRenderData data(GLRRenderCommand::CLEAR);
 		data.clear.clearMask = clearMask;
 		data.clear.clearColor = clearColor;
 		data.clear.clearZ = clearZ;
@@ -738,7 +747,7 @@ public:
 
 	void Draw(GLRInputLayout *inputLayout, GLRBuffer *buffer, size_t offset, GLenum mode, int first, int count) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data{ GLRRenderCommand::DRAW };
+		GLRRenderData data(GLRRenderCommand::DRAW);
 		data.draw.inputLayout = inputLayout;
 		data.draw.offset = offset;
 		data.draw.buffer = buffer;
@@ -753,7 +762,7 @@ public:
 
 	void DrawIndexed(GLRInputLayout *inputLayout, GLRBuffer *buffer, size_t offset, GLRBuffer *indexBuffer, GLenum mode, int count, GLenum indexType, void *indices, int instances = 1) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData data{ GLRRenderCommand::DRAW };
+		GLRRenderData data(GLRRenderCommand::DRAW);
 		data.draw.inputLayout = inputLayout;
 		data.draw.offset = offset;
 		data.draw.buffer = buffer;

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -208,7 +208,7 @@ struct GLRRenderThreadTask {
 	GLRRenderThreadTask(GLRRunType _runType) : runType(_runType) {}
 
 	std::vector<GLRStep *> steps;
-	std::vector<GLRInitStep> initSteps;
+	FastVec<GLRInitStep> initSteps;
 
 	int frame = -1;
 	GLRRunType runType;
@@ -225,6 +225,9 @@ class GLRenderManager {
 public:
 	GLRenderManager();
 	~GLRenderManager();
+
+	GLRenderManager(GLRenderManager &) = delete;
+	GLRenderManager &operator=(GLRenderManager &) = delete;
 
 	void SetInvalidationCallback(InvalidationCallback callback) {
 		invalidationCallback_ = callback;
@@ -859,7 +862,7 @@ private:
 
 	GLRStep *curRenderStep_ = nullptr;
 	std::vector<GLRStep *> steps_;
-	std::vector<GLRInitStep> initSteps_;
+	FastVec<GLRInitStep> initSteps_;
 
 	// Execution time state
 	bool run_ = true;

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -1241,7 +1241,7 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 	VKRGraphicsPipeline *lastGraphicsPipeline = nullptr;
 	VKRComputePipeline *lastComputePipeline = nullptr;
 
-	auto &commands = step.commands;
+	const auto &commands = step.commands;
 
 	// We can do a little bit of state tracking here to eliminate some calls into the driver.
 	// The stencil ones are very commonly mostly redundant so let's eliminate them where possible.

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -481,7 +481,7 @@ void VulkanQueueRunner::ApplyMGSHack(std::vector<VKRStep *> &steps) {
 					last = j - 1;
 				// should really also check descriptor sets...
 				if (steps[j]->commands.size()) {
-					VkRenderData &cmd = steps[j]->commands.back();
+					const VkRenderData &cmd = steps[j]->commands.back();
 					if (cmd.cmd == VKRRenderCommand::DRAW_INDEXED && cmd.draw.count != 6)
 						last = j - 1;
 				}

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -6,6 +6,7 @@
 
 #include "Common/Thread/Promise.h"
 #include "Common/Data/Collections/Hashmaps.h"
+#include "Common/Data/Collections/FastVec.h"
 #include "Common/GPU/Vulkan/VulkanContext.h"
 #include "Common/GPU/Vulkan/VulkanBarrier.h"
 #include "Common/GPU/Vulkan/VulkanFrameData.h"
@@ -153,7 +154,7 @@ struct VKRStep {
 	~VKRStep() {}
 
 	VKRStepType stepType;
-	std::vector<VkRenderData> commands;
+	FastVec<VkRenderData> commands;
 	TinySet<TransitionRequest, 4> preTransitions;
 	TinySet<VKRFramebuffer *, 8> dependencies;
 	const char *tag;

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -212,9 +212,14 @@ struct VKRStep {
 // These are enqueued from the main thread,
 // and the render thread pops them off
 struct VKRRenderThreadTask {
+	VKRRenderThreadTask(VKRRunType _runType) : runType(_runType) {}
 	std::vector<VKRStep *> steps;
-	int frame;
+	int frame = -1;
 	VKRRunType runType;
+
+	// Avoid copying these by accident.
+	VKRRenderThreadTask(VKRRenderThreadTask &) = delete;
+	VKRRenderThreadTask &operator =(VKRRenderThreadTask &) = delete;
 };
 
 class VulkanQueueRunner {

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -999,7 +999,7 @@ void VulkanRenderManager::CopyImageToMemorySync(VkImage image, int mipLevel, int
 	queueRunner_.CopyReadbackBuffer(frameData_[vulkan_->GetCurFrame()], nullptr, w, h, destFormat, destFormat, pixelStride, pixels);
 }
 
-static void RemoveDrawCommands(std::vector<VkRenderData> *cmds) {
+static void RemoveDrawCommands(FastVec<VkRenderData> *cmds) {
 	// Here we remove any DRAW type commands when we hit a CLEAR.
 	for (auto &c : *cmds) {
 		if (c.cmd == VKRRenderCommand::DRAW || c.cmd == VKRRenderCommand::DRAW_INDEXED) {
@@ -1008,7 +1008,7 @@ static void RemoveDrawCommands(std::vector<VkRenderData> *cmds) {
 	}
 }
 
-static void CleanupRenderCommands(std::vector<VkRenderData> *cmds) {
+static void CleanupRenderCommands(FastVec<VkRenderData> *cmds) {
 	size_t lastCommand[(int)VKRRenderCommand::NUM_RENDER_COMMANDS];
 	memset(lastCommand, -1, sizeof(lastCommand));
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -509,7 +509,7 @@ private:
 	std::mutex pushMutex_;
 	std::condition_variable pushCondVar_;
 
-	std::queue<VKRRenderThreadTask> renderThreadQueue_;
+	std::queue<VKRRenderThreadTask *> renderThreadQueue_;
 
 	// For readbacks and other reasons we need to sync with the render thread.
 	std::mutex syncMutex_;

--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -560,11 +560,11 @@ void PreprocessSkyplane(GLRStep* step) {
 
 	// Clear sky with the fog color.
 	if (!vrCompat[VR_COMPAT_FBO_CLEAR]) {
-		GLRRenderData skyClear{ GLRRenderCommand::CLEAR };  // intentional zero-initialize
+		GLRRenderData &skyClear = step->commands.insert(step->commands.begin());
+		skyClear.cmd = GLRRenderCommand::CLEAR;  // intentional zero-initialize
 		skyClear.clear.colorMask = 0xF;
 		skyClear.clear.clearMask = GL_COLOR_BUFFER_BIT;
 		skyClear.clear.clearColor = vrCompat[VR_COMPAT_FOG_COLOR];
-		step->commands.insert(step->commands.begin(), skyClear);
 		vrCompat[VR_COMPAT_FBO_CLEAR] = true;
 	}
 

--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -560,8 +560,7 @@ void PreprocessSkyplane(GLRStep* step) {
 
 	// Clear sky with the fog color.
 	if (!vrCompat[VR_COMPAT_FBO_CLEAR]) {
-		GLRRenderData skyClear {};
-		skyClear.cmd = GLRRenderCommand::CLEAR;
+		GLRRenderData skyClear{ GLRRenderCommand::CLEAR };  // intentional zero-initialize
 		skyClear.clear.colorMask = 0xF;
 		skyClear.clear.clearMask = GL_COLOR_BUFFER_BIT;
 		skyClear.clear.clearColor = vrCompat[VR_COMPAT_FOG_COLOR];

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -47,9 +47,11 @@
 #endif
 
 #include "Common/Data/Collections/TinySet.h"
+#include "Common/Data/Collections/FastVec.h"
 #include "Common/Data/Convert/SmallDataConvert.h"
 #include "Common/Data/Text/Parsers.h"
 #include "Common/Data/Text/WrapText.h"
+#include "Common/Data/Collections/FastVec.h"
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/File/Path.h"
 #include "Common/Input/InputState.h"
@@ -362,6 +364,25 @@ bool TestTinySet() {
 	EXPECT_EQ_INT((int)b.size(), 8);
 	b.push_back(13);
 	EXPECT_EQ_INT(b.size(), 9);
+	return true;
+}
+
+bool TestFastVec() {
+	FastVec<int> a;
+	EXPECT_EQ_INT((int)a.size(), 0);
+	a.push_back(1);
+	EXPECT_EQ_INT((int)a.size(), 1);
+	a.push_back(2);
+	EXPECT_EQ_INT((int)a.size(), 2);
+	FastVec<int> b;
+	b.push_back(8);
+	b.push_back(9);
+	b.push_back(10);
+	EXPECT_EQ_INT((int)b.size(), 3);
+	for (int i = 0; i < 100; i++) {
+		b.push_back(33);
+	}
+	EXPECT_EQ_INT((int)b.size(), 103);
 	return true;
 }
 
@@ -977,6 +998,7 @@ TestItem availableTests[] = {
 	TEST_ITEM(ThreadManager),
 	TEST_ITEM(WrapText),
 	TEST_ITEM(TinySet),
+	TEST_ITEM(FastVec),
 	TEST_ITEM(SmallDataConvert),
 	TEST_ITEM(DepthMath),
 	TEST_ITEM(InputMapping),

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -392,6 +392,16 @@ bool TestFastVec() {
 	EXPECT_EQ_INT(b[4], 80);
 	EXPECT_EQ_INT(b[5], 9);
 
+	b.resize(2);
+	b.insert(b.end(), items, items + 4);
+	EXPECT_EQ_INT(b[0], 8);
+	EXPECT_EQ_INT(b[1], 50);
+	EXPECT_EQ_INT(b[2], 50);
+	EXPECT_EQ_INT(b[3], 60);
+	EXPECT_EQ_INT(b[4], 70);
+	EXPECT_EQ_INT(b[5], 80);
+
+
 	return true;
 }
 

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -51,7 +51,6 @@
 #include "Common/Data/Convert/SmallDataConvert.h"
 #include "Common/Data/Text/Parsers.h"
 #include "Common/Data/Text/WrapText.h"
-#include "Common/Data/Collections/FastVec.h"
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/File/Path.h"
 #include "Common/Input/InputState.h"
@@ -383,6 +382,16 @@ bool TestFastVec() {
 		b.push_back(33);
 	}
 	EXPECT_EQ_INT((int)b.size(), 103);
+
+	int items[4] = { 50, 60, 70, 80 };
+	b.insert(b.begin() + 1, items, items + 4);
+	EXPECT_EQ_INT(b[0], 8);
+	EXPECT_EQ_INT(b[1], 50);
+	EXPECT_EQ_INT(b[2], 60);
+	EXPECT_EQ_INT(b[3], 70);
+	EXPECT_EQ_INT(b[4], 80);
+	EXPECT_EQ_INT(b[5], 9);
+
 	return true;
 }
 


### PR DESCRIPTION
This introduces yet another custom vector, this time one specialized for cheaply adding items that don't need to be fully initialized, like our graphics command unions. It simply has a push_uninitialized() method that returns a pointer to the new item. std::vector simply can't do that.

This saves both zero-initialization of the structs and copying of the structs during push_back to the vectors.

So, this new vector is now used for command lists in both OpenGL and Vulkan backends. OpenGL gets the biggest wins here, sometimes up to a 8% detectable performance increase when profiling on PC (!). Vulkan only gets maybe 1-2% since those command structs are generally smaller I guess, and there are less of them since more state is passed in other ways like in pipeline keys.

Not intending to merge this until after the 1.15 process.