### PR TITLE
Add a trivial profiling tool to the OpenGL backend

### DIFF
--- a/Common/GPU/OpenGL/GLFrameData.h
+++ b/Common/GPU/OpenGL/GLFrameData.h
@@ -35,6 +35,13 @@ public:
 	std::vector<GLPushBuffer *> pushBuffers;
 };
 
+struct GLQueueProfileContext {
+	bool enabled;
+	double cpuStartTime;
+	double cpuEndTime;
+};
+
+
 // Per-frame data, round-robin so we can overlap submission with execution of the previous frame.
 struct GLFrameData {
 	bool skipSwap = false;
@@ -49,4 +56,6 @@ struct GLFrameData {
 	GLDeleter deleter;
 	GLDeleter deleter_prev;
 	std::set<GLPushBuffer *> activePushBuffers;
+
+	GLQueueProfileContext profile;
 };

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -409,8 +409,10 @@ public:
 		caps_ = caps;
 	}
 
+	std::string GetGpuProfileString() const;
+
 	// Makes sure that the GPU has caught up enough that we can start writing buffers of this frame again.
-	void BeginFrame();
+	void BeginFrame(bool enableProfiling);
 	// Can run on a different thread!
 	void Finish(); 
 

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -328,6 +328,9 @@ public:
 		DrawContext::SetTargetSize(w, h);
 		renderManager_.Resize(w, h);
 	}
+	void SetDebugFlags(DebugFlags flags) override {
+		debugFlags_ = flags;
+	}
 
 	const DeviceCaps &GetDeviceCaps() const override {
 		return caps_;
@@ -514,6 +517,8 @@ private:
 		GLPushBuffer *push;
 	};
 	FrameData frameData_[GLRenderManager::MAX_INFLIGHT_FRAMES]{};
+
+	DebugFlags debugFlags_ = DebugFlags::NONE;
 };
 
 static constexpr int MakeIntelSimpleVer(int v1, int v2, int v3) {
@@ -778,7 +783,7 @@ OpenGLContext::~OpenGLContext() {
 }
 
 void OpenGLContext::BeginFrame() {
-	renderManager_.BeginFrame();
+	renderManager_.BeginFrame(debugFlags_ & DebugFlags::PROFILE_TIMESTAMPS);
 	FrameData &frameData = frameData_[renderManager_.GetCurFrame()];
 	renderManager_.BeginPushBuffer(frameData.push);
 }

--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -257,6 +257,9 @@ public:
 	// cached framebuffers / textures / vertices?
 	// get content of specific framebuffer / texture?
 	// vertex / texture decoding?
+
+	// Note: Wanted to name it GetProfileString but clashes with a Windows API.
+	virtual std::string GetGpuProfileString() { return ""; }
 };
 
 bool GPUDebugInitExpression(GPUDebugInterface *g, const char *str, PostfixExpression &exp);

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -305,3 +305,8 @@ void GPU_GLES::GetStats(char *buffer, size_t bufsize) {
 		shaderManagerGL_->GetNumPrograms()
 	);
 }
+
+std::string GPU_GLES::GetGpuProfileString() {
+	GLRenderManager *rm = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
+	return rm->GetGpuProfileString();
+}

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -51,6 +51,8 @@ public:
 	void BeginHostFrame() override;
 	void EndHostFrame() override;
 
+	std::string GetGpuProfileString() override;
+
 protected:
 	void FinishDeferred() override;
 

--- a/GPU/Vulkan/DebugVisVulkan.cpp
+++ b/GPU/Vulkan/DebugVisVulkan.cpp
@@ -37,6 +37,8 @@
 #include "GPU/Vulkan/VulkanUtil.h"
 #include "GPU/Vulkan/TextureCacheVulkan.h"
 
+#include "Core/Config.h"
+
 #undef DrawText
 
 bool comparePushBufferNames(const VulkanMemoryManager *a, const VulkanMemoryManager *b) {
@@ -107,9 +109,14 @@ void DrawGPUProfilerVis(UIContext *ui, GPUInterface *gpu) {
 
 	ui->Begin();
 
-	GPU_Vulkan *gpuVulkan = static_cast<GPU_Vulkan *>(gpu);
+	float scale = 0.4f;
+	if (g_Config.iGPUBackend == (int)GPUBackend::OPENGL) {
+		// Don't have as much info, let's go bigger.
+		scale = 0.7f;
+	}
 
-	std::string text = gpuVulkan->GetGpuProfileString();
+	GPUCommon *gpuCommon = static_cast<GPUCommon *>(gpu);
+	std::string text = gpuCommon->GetGpuProfileString();
 
 	ui->SetFontScale(0.4f, 0.4f);
 	ui->DrawTextShadow(text.c_str(), x, y, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -59,7 +59,7 @@ public:
 		return textureCacheVulkan_;
 	}
 
-	std::string GetGpuProfileString();
+	std::string GetGpuProfileString() override;
 
 protected:
 	void FinishDeferred() override;

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -102,6 +102,8 @@ void DevMenuScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	items->Add(new Choice(dev->T("Shader Viewer")))->OnClick.Handle(this, &DevMenuScreen::OnShaderView);
 	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN) {
 		items->Add(new CheckBox(&g_Config.bShowAllocatorDebug, dev->T("Allocator Viewer")));
+	}
+	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN || g_Config.iGPUBackend == (int)GPUBackend::OPENGL) {
 		items->Add(new CheckBox(&g_Config.bShowGpuProfile, dev->T("GPU Profile")));
 	}
 	items->Add(new Choice(dev->T("Toggle Freeze")))->OnClick.Handle(this, &DevMenuScreen::OnFreezeFrame);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1616,7 +1616,7 @@ void EmuScreen::renderUI() {
 		DrawAllocatorVis(ctx, gpu);
 	}
 
-	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN && g_Config.bShowGpuProfile) {
+	if ((g_Config.iGPUBackend == (int)GPUBackend::VULKAN || g_Config.iGPUBackend == (int)GPUBackend::OPENGL) && g_Config.bShowGpuProfile) {
 		DrawGPUProfilerVis(ctx, gpu);
 	}
 


### PR DESCRIPTION
Measures the time it takes to run a frame of commands (call all the glEnable/Disable/Draw/etc functions, to submit the frame to OpenGL).

Accessed from the in-game dev menu just like the Vulkan frame profiler.

With this we can easily (and cheaply) see that actually submitting the GL commands is often the biggest bottleneck on old devices like a Galaxy S3.