### PR TITLE
OpenGL: Avoid rebind between glDrawArrays calls when possible

### DIFF
--- a/Common/GPU/OpenGL/GLFrameData.h
+++ b/Common/GPU/OpenGL/GLFrameData.h
@@ -39,6 +39,7 @@ struct GLQueueProfileContext {
 	bool enabled;
 	double cpuStartTime;
 	double cpuEndTime;
+	int drawArraysRebindsAvoided;
 };
 
 

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -651,7 +651,7 @@ retry_depth:
 	currentReadHandle_ = fbo->handle;
 }
 
-void GLQueueRunner::RunSteps(const std::vector<GLRStep *> &steps, bool skipGLCalls, bool keepSteps, bool useVR) {
+void GLQueueRunner::RunSteps(const std::vector<GLRStep *> &steps, bool skipGLCalls, bool keepSteps, bool useVR, GLQueueProfileContext &profile) {
 	if (skipGLCalls) {
 		if (keepSteps) {
 			return;
@@ -713,9 +713,9 @@ void GLQueueRunner::RunSteps(const std::vector<GLRStep *> &steps, bool skipGLCal
 			if (IsVREnabled()) {
 				GLRStep vrStep = step;
 				PreprocessStepVR(&vrStep);
-				PerformRenderPass(vrStep, renderCount == 1, renderCount == totalRenderCount);
+				PerformRenderPass(vrStep, renderCount == 1, renderCount == totalRenderCount, profile);
 			} else {
-				PerformRenderPass(step, renderCount == 1, renderCount == totalRenderCount);
+				PerformRenderPass(step, renderCount == 1, renderCount == totalRenderCount, profile);
 			}
 			break;
 		case GLRStepType::COPY:
@@ -791,7 +791,7 @@ static void EnableDisableVertexArrays(uint32_t prevAttr, uint32_t newAttr) {
 	}
 }
 
-void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last) {
+void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last, GLQueueProfileContext &profile) {
 	CHECK_GL_ERROR_IF_DEBUG();
 
 	PerformBindFramebufferAsRenderTarget(step);
@@ -1216,6 +1216,7 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last
 						// Compatible draws.
 						offset = diff / layout->stride;
 						rebind = false;
+						profile.drawArraysRebindsAvoided++;
 					}
 				}
 				if (rebind) {

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -778,6 +778,19 @@ void GLQueueRunner::PerformBlit(const GLRStep &step) {
 	}
 }
 
+static void EnableDisableVertexArrays(uint32_t prevAttr, uint32_t newAttr) {
+	int enable = (~prevAttr) & newAttr;
+	int disable = prevAttr & (~newAttr);
+	for (int i = 0; i < 7; i++) {  // SEM_MAX
+		if (enable & (1 << i)) {
+			glEnableVertexAttribArray(i);
+		}
+		if (disable & (1 << i)) {
+			glDisableVertexAttribArray(i);
+		}
+	}
+}
+
 void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last) {
 	CHECK_GL_ERROR_IF_DEBUG();
 
@@ -1165,16 +1178,7 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last
 				curArrayBuffer = buf;
 			}
 			if (attrMask != layout->semanticsMask_) {
-				int enable = layout->semanticsMask_ & ~attrMask;
-				int disable = (~layout->semanticsMask_) & attrMask;
-				for (int i = 0; i < 7; i++) {  // SEM_MAX
-					if (enable & (1 << i)) {
-						glEnableVertexAttribArray(i);
-					}
-					if (disable & (1 << i)) {
-						glDisableVertexAttribArray(i);
-					}
-				}
+				EnableDisableVertexArrays(attrMask, layout->semanticsMask_);
 				attrMask = layout->semanticsMask_;
 			}
 			for (size_t i = 0; i < layout->entries.size(); i++) {

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -1179,7 +1179,7 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last
 			}
 			for (size_t i = 0; i < layout->entries.size(); i++) {
 				auto &entry = layout->entries[i];
-				glVertexAttribPointer(entry.location, entry.count, entry.type, entry.normalized, entry.stride, (const void *)(c.draw.offset + entry.offset));
+				glVertexAttribPointer(entry.location, entry.count, entry.type, entry.normalized, layout->stride, (const void *)(c.draw.offset + entry.offset));
 			}
 			if (c.draw.indexBuffer) {
 				GLuint buf = c.draw.indexBuffer->buffer_;

--- a/Common/GPU/OpenGL/GLQueueRunner.h
+++ b/Common/GPU/OpenGL/GLQueueRunner.h
@@ -357,7 +357,7 @@ public:
 
 	void RunInitSteps(const std::vector<GLRInitStep> &steps, bool skipGLCalls);
 
-	void RunSteps(const std::vector<GLRStep *> &steps, bool skipGLCalls, bool keepSteps, bool useVR);
+	void RunSteps(const std::vector<GLRStep *> &steps, bool skipGLCalls, bool keepSteps, bool useVR, GLQueueProfileContext &profile);
 
 	void CreateDeviceObjects();
 	void DestroyDeviceObjects();
@@ -382,7 +382,7 @@ private:
 	void InitCreateFramebuffer(const GLRInitStep &step);
 
 	void PerformBindFramebufferAsRenderTarget(const GLRStep &pass);
-	void PerformRenderPass(const GLRStep &pass, bool first, bool last);
+	void PerformRenderPass(const GLRStep &pass, bool first, bool last, GLQueueProfileContext &profile);
 	void PerformCopy(const GLRStep &pass);
 	void PerformBlit(const GLRStep &pass);
 	void PerformReadback(const GLRStep &pass);

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -362,7 +362,7 @@ public:
 		intptr_t offset;
 	};
 	std::vector<Entry> entries;
-	int stride;
+	unsigned int stride;
 	int semanticsMask_ = 0;
 };
 

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -359,10 +359,10 @@ public:
 		int count;
 		GLenum type;
 		GLboolean normalized;
-		int stride;
 		intptr_t offset;
 	};
 	std::vector<Entry> entries;
+	int stride;
 	int semanticsMask_ = 0;
 };
 
@@ -487,10 +487,11 @@ public:
 		return step.create_program.program;
 	}
 
-	GLRInputLayout *CreateInputLayout(const std::vector<GLRInputLayout::Entry> &entries) {
+	GLRInputLayout *CreateInputLayout(const std::vector<GLRInputLayout::Entry> &entries, int stride) {
 		GLRInitStep step{ GLRInitStepType::CREATE_INPUT_LAYOUT };
 		step.create_input_layout.inputLayout = new GLRInputLayout();
 		step.create_input_layout.inputLayout->entries = entries;
+		step.create_input_layout.inputLayout->stride = stride;
 		for (auto &iter : step.create_input_layout.inputLayout->entries) {
 			step.create_input_layout.inputLayout->semanticsMask_ |= 1 << iter.location;
 		}

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -1393,13 +1393,13 @@ OpenGLInputLayout::~OpenGLInputLayout() {
 void OpenGLInputLayout::Compile(const InputLayoutDesc &desc) {
 	// TODO: This is only accurate if there's only one stream. But whatever, for now we
 	// never use multiple streams anyway.
-	stride = desc.bindings.empty() ? 0 : (GLsizei)desc.bindings[0].stride;
+	_dbg_assert_(desc.bindings.size() == 1);
+	stride = (GLsizei)desc.bindings[0].stride;
 
 	std::vector<GLRInputLayout::Entry> entries;
 	for (auto &attr : desc.attributes) {
 		GLRInputLayout::Entry entry;
 		entry.location = attr.location;
-		entry.stride = (GLsizei)desc.bindings[attr.binding].stride;
 		entry.offset = attr.offset;
 		switch (attr.format) {
 		case DataFormat::R32G32_FLOAT:
@@ -1431,7 +1431,7 @@ void OpenGLInputLayout::Compile(const InputLayoutDesc &desc) {
 		entries.push_back(entry);
 	}
 	if (!entries.empty()) {
-		inputLayout_ = render_->CreateInputLayout(entries);
+		inputLayout_ = render_->CreateInputLayout(entries, stride);
 	} else {
 		inputLayout_ = nullptr;
 	}

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -103,12 +103,12 @@ void DrawEngineGLES::InitDeviceObjects() {
 
 	int vertexSize = sizeof(TransformedVertex);
 	std::vector<GLRInputLayout::Entry> entries;
-	entries.push_back({ ATTR_POSITION, 4, GL_FLOAT, GL_FALSE, vertexSize, offsetof(TransformedVertex, x) });
-	entries.push_back({ ATTR_TEXCOORD, 3, GL_FLOAT, GL_FALSE, vertexSize, offsetof(TransformedVertex, u) });
-	entries.push_back({ ATTR_COLOR0, 4, GL_UNSIGNED_BYTE, GL_TRUE, vertexSize, offsetof(TransformedVertex, color0) });
-	entries.push_back({ ATTR_COLOR1, 3, GL_UNSIGNED_BYTE, GL_TRUE, vertexSize, offsetof(TransformedVertex, color1) });
-	entries.push_back({ ATTR_NORMAL, 1, GL_FLOAT, GL_FALSE, vertexSize, offsetof(TransformedVertex, fog) });
-	softwareInputLayout_ = render_->CreateInputLayout(entries);
+	entries.push_back({ ATTR_POSITION, 4, GL_FLOAT, GL_FALSE, offsetof(TransformedVertex, x) });
+	entries.push_back({ ATTR_TEXCOORD, 3, GL_FLOAT, GL_FALSE, offsetof(TransformedVertex, u) });
+	entries.push_back({ ATTR_COLOR0, 4, GL_UNSIGNED_BYTE, GL_TRUE, offsetof(TransformedVertex, color0) });
+	entries.push_back({ ATTR_COLOR1, 3, GL_UNSIGNED_BYTE, GL_TRUE, offsetof(TransformedVertex, color1) });
+	entries.push_back({ ATTR_NORMAL, 1, GL_FLOAT, GL_FALSE, offsetof(TransformedVertex, fog) });
+	softwareInputLayout_ = render_->CreateInputLayout(entries, vertexSize);
 
 	draw_->SetInvalidationCallback(std::bind(&DrawEngineGLES::Invalidate, this, std::placeholders::_1));
 }
@@ -189,7 +189,7 @@ static const GlTypeInfo GLComp[] = {
 	{GL_UNSIGNED_SHORT, 4, GL_TRUE},// 	DEC_U16_4,
 };
 
-static inline void VertexAttribSetup(int attrib, int fmt, int stride, int offset, std::vector<GLRInputLayout::Entry> &entries) {
+static inline void VertexAttribSetup(int attrib, int fmt, int offset, std::vector<GLRInputLayout::Entry> &entries) {
 	if (fmt) {
 		const GlTypeInfo &type = GLComp[fmt];
 		GLRInputLayout::Entry entry;
@@ -197,7 +197,6 @@ static inline void VertexAttribSetup(int attrib, int fmt, int stride, int offset
 		entry.location = attrib;
 		entry.normalized = type.normalized;
 		entry.type = type.type;
-		entry.stride = stride;
 		entry.count = type.count;
 		entries.push_back(entry);
 	}
@@ -212,15 +211,15 @@ GLRInputLayout *DrawEngineGLES::SetupDecFmtForDraw(LinkedShader *program, const 
 	}
 
 	std::vector<GLRInputLayout::Entry> entries;
-	VertexAttribSetup(ATTR_W1, decFmt.w0fmt, decFmt.stride, decFmt.w0off, entries);
-	VertexAttribSetup(ATTR_W2, decFmt.w1fmt, decFmt.stride, decFmt.w1off, entries);
-	VertexAttribSetup(ATTR_TEXCOORD, decFmt.uvfmt, decFmt.stride, decFmt.uvoff, entries);
-	VertexAttribSetup(ATTR_COLOR0, decFmt.c0fmt, decFmt.stride, decFmt.c0off, entries);
-	VertexAttribSetup(ATTR_COLOR1, decFmt.c1fmt, decFmt.stride, decFmt.c1off, entries);
-	VertexAttribSetup(ATTR_NORMAL, decFmt.nrmfmt, decFmt.stride, decFmt.nrmoff, entries);
-	VertexAttribSetup(ATTR_POSITION, decFmt.posfmt, decFmt.stride, decFmt.posoff, entries);
+	VertexAttribSetup(ATTR_W1, decFmt.w0fmt, decFmt.w0off, entries);
+	VertexAttribSetup(ATTR_W2, decFmt.w1fmt, decFmt.w1off, entries);
+	VertexAttribSetup(ATTR_TEXCOORD, decFmt.uvfmt, decFmt.uvoff, entries);
+	VertexAttribSetup(ATTR_COLOR0, decFmt.c0fmt, decFmt.c0off, entries);
+	VertexAttribSetup(ATTR_COLOR1, decFmt.c1fmt, decFmt.c1off, entries);
+	VertexAttribSetup(ATTR_NORMAL, decFmt.nrmfmt, decFmt.nrmoff, entries);
+	VertexAttribSetup(ATTR_POSITION, decFmt.posfmt, decFmt.posoff, entries);
 
-	inputLayout = render_->CreateInputLayout(entries);
+	inputLayout = render_->CreateInputLayout(entries, decFmt.stride);
 	inputLayoutMap_.Insert(key, inputLayout);
 	return inputLayout;
 }


### PR DESCRIPTION
Relatively profitable optimization for DrawArrays-heavy games like GTA on slow devices.

Can't do the same with glDrawElements (indexed draws) due to the lack of base vertex index. Well, some devices do support it as an extension (`glDrawElementsBaseVertex`). But there might be a better way by simply counting up the indices written to the index buffer.
 
Will do the same later in Vulkan but expecting a smaller benefit since rebinding the vertex buffer is less expensive there. I actually tried this on Vulkan before but had weird driver issues when applying a base vertex index.

Gonna get some numbers.

EDIT: Some very unscientific testing on an old Adreno (Nexus 5X), drawing in GTA gets about 20-30% faster (!) (though the framerate improves with ~15%). Though, the device has severe thermal throttling issues.

Now also tried it on Vulkan on Adreno and the difference is not really measurable so far, so maybe not worth it.