### PR TITLE
OpenGL: Efficiency improvements for stencil commands

### DIFF
--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -862,22 +862,20 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last
 				depthEnabled = false;
 			}
 			break;
-		case GLRRenderCommand::STENCILFUNC:
-			if (c.stencilFunc.enabled) {
+		case GLRRenderCommand::STENCIL:
+			if (c.stencil.enabled) {
 				if (!stencilEnabled) {
 					glEnable(GL_STENCIL_TEST);
 					stencilEnabled = true;
 				}
-				glStencilFunc(c.stencilFunc.func, c.stencilFunc.ref, c.stencilFunc.compareMask);
+				glStencilFunc(c.stencil.func, c.stencil.ref, c.stencil.compareMask);
+				glStencilOp(c.stencil.sFail, c.stencil.zFail, c.stencil.pass);
+				glStencilMask(c.stencil.writeMask);
 			} else if (/* !c.stencilFunc.enabled && */stencilEnabled) {
 				glDisable(GL_STENCIL_TEST);
 				stencilEnabled = false;
 			}
 			CHECK_GL_ERROR_IF_DEBUG();
-			break;
-		case GLRRenderCommand::STENCILOP:
-			glStencilOp(c.stencilOp.sFail, c.stencilOp.zFail, c.stencilOp.pass);
-			glStencilMask(c.stencilOp.writeMask);
 			break;
 		case GLRRenderCommand::BLEND:
 			if (c.blend.enabled) {

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -836,6 +836,13 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last
 	bool clipDistanceEnabled[8]{};
 	GLuint blendEqColor = (GLuint)-1;
 	GLuint blendEqAlpha = (GLuint)-1;
+	GLuint stencilWriteMask = (GLuint)-1;
+	GLenum stencilFunc = (GLenum)-1;
+	GLuint stencilRef = (GLuint)-1;
+	GLuint stencilCompareMask = (GLuint)-1;
+	GLenum stencilSFail = (GLenum)-1;
+	GLenum stencilZFail = (GLenum)-1;
+	GLenum stencilPass = (GLenum)-1;
 
 	GLRTexture *curTex[MAX_GL_TEXTURE_SLOTS]{};
 
@@ -868,9 +875,22 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last
 					glEnable(GL_STENCIL_TEST);
 					stencilEnabled = true;
 				}
-				glStencilFunc(c.stencil.func, c.stencil.ref, c.stencil.compareMask);
-				glStencilOp(c.stencil.sFail, c.stencil.zFail, c.stencil.pass);
-				glStencilMask(c.stencil.writeMask);
+				if (c.stencil.func != stencilFunc || c.stencil.ref != stencilRef || c.stencil.compareMask != stencilCompareMask) {
+					glStencilFunc(c.stencil.func, c.stencil.ref, c.stencil.compareMask);
+					stencilFunc = c.stencil.func;
+					stencilRef = c.stencil.ref;
+					stencilCompareMask = c.stencil.compareMask;
+				}
+				if (c.stencil.sFail != stencilSFail || c.stencil.zFail != stencilZFail || c.stencil.pass != stencilPass) {
+					glStencilOp(c.stencil.sFail, c.stencil.zFail, c.stencil.pass);
+					stencilSFail = c.stencil.sFail;
+					stencilZFail = c.stencil.zFail;
+					stencilPass = c.stencil.pass;
+				}
+				if (c.stencil.writeMask != stencilWriteMask) {
+					glStencilMask(c.stencil.writeMask);
+					stencilWriteMask = c.stencil.writeMask;
+				}
 			} else if (/* !c.stencilFunc.enabled && */stencilEnabled) {
 				glDisable(GL_STENCIL_TEST);
 				stencilEnabled = false;

--- a/Common/GPU/OpenGL/GLQueueRunner.h
+++ b/Common/GPU/OpenGL/GLQueueRunner.h
@@ -40,8 +40,7 @@ class GLRInputLayout;
 
 enum class GLRRenderCommand : uint8_t {
 	DEPTH,
-	STENCILFUNC,
-	STENCILOP,
+	STENCIL,
 	BLEND,
 	BLENDCOLOR,
 	LOGICOP,
@@ -100,13 +99,11 @@ struct GLRRenderData {
 			GLenum func;
 			uint8_t ref;
 			uint8_t compareMask;
-		} stencilFunc;
-		struct {
 			GLenum sFail;
 			GLenum zFail;
 			GLenum pass;
 			uint8_t writeMask;
-		} stencilOp;  // also write mask
+		} stencil;
 		struct {
 			GLRInputLayout *inputLayout;
 			GLRBuffer *buffer;

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -664,32 +664,25 @@ public:
 	}
 #endif
 
-	void SetStencilFunc(bool enabled, GLenum func, uint8_t refValue, uint8_t compareMask) {
+	void SetStencil(bool enabled, GLenum func, uint8_t refValue, uint8_t compareMask, uint8_t writeMask, GLenum sFail, GLenum zFail, GLenum pass) {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
-		data.cmd = GLRRenderCommand::STENCILFUNC;
-		data.stencilFunc.enabled = enabled;
-		data.stencilFunc.func = func;
-		data.stencilFunc.ref = refValue;
-		data.stencilFunc.compareMask = compareMask;
-	}
-
-	void SetStencilOp(uint8_t writeMask, GLenum sFail, GLenum zFail, GLenum pass) {
-		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
-		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
-		data.cmd = GLRRenderCommand::STENCILOP;
-		data.stencilOp.writeMask = writeMask;
-		data.stencilOp.sFail = sFail;
-		data.stencilOp.zFail = zFail;
-		data.stencilOp.pass = pass;
+		data.cmd = GLRRenderCommand::STENCIL;
+		data.stencil.enabled = enabled;
+		data.stencil.func = func;
+		data.stencil.ref = refValue;
+		data.stencil.compareMask = compareMask;
+		data.stencil.writeMask = writeMask;
+		data.stencil.sFail = sFail;
+		data.stencil.zFail = zFail;
+		data.stencil.pass = pass;
 	}
 
 	void SetStencilDisabled() {
 		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
-		data.cmd = GLRRenderCommand::STENCILFUNC;
-		data.stencilFunc.enabled = false;
-		// When enabled = false, the others aren't read so we don't zero-initialize them.
+		data.cmd = GLRRenderCommand::STENCIL;
+		data.stencil.enabled = false;
 	}
 
 	void SetBlendFactor(const float color[4]) {

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -180,8 +180,9 @@ public:
 
 	void Apply(GLRenderManager *render, uint8_t stencilRef, uint8_t stencilWriteMask, uint8_t stencilCompareMask) {
 		render->SetDepth(depthTestEnabled, depthWriteEnabled, depthComp);
-		render->SetStencilFunc(stencilEnabled, stencilCompareOp, stencilRef, stencilCompareMask);
-		render->SetStencilOp(stencilWriteMask, stencilFail, stencilZFail, stencilPass);
+		render->SetStencil(
+			stencilEnabled, stencilCompareOp, stencilRef, stencilCompareMask,
+			stencilWriteMask, stencilFail, stencilZFail, stencilPass);
 	}
 };
 
@@ -407,12 +408,11 @@ public:
 		stencilWriteMask_ = writeMask;
 		stencilCompareMask_ = compareMask;
 		// Do we need to update on the fly here?
-		renderManager_.SetStencilFunc(
+		renderManager_.SetStencil(
 			curPipeline_->depthStencil->stencilEnabled,
 			curPipeline_->depthStencil->stencilCompareOp,
 			refValue,
-			compareMask);
-		renderManager_.SetStencilOp(
+			compareMask,
 			writeMask,
 			curPipeline_->depthStencil->stencilFail,
 			curPipeline_->depthStencil->stencilZFail,

--- a/GPU/GLES/StateMappingGLES.cpp
+++ b/GPU/GLES/StateMappingGLES.cpp
@@ -302,6 +302,7 @@ void DrawEngineGLES::ApplyDrawState(int prim) {
 void DrawEngineGLES::ApplyDrawStateLate(bool setStencilValue, int stencilValue) {
 	if (setStencilValue) {
 		render_->SetStencilFunc(GL_TRUE, GL_ALWAYS, stencilValue, 255);
+		render_->SetStencilOp(0xFF, GL_REPLACE, GL_REPLACE, GL_REPLACE);
 	}
 
 	// At this point, we know if the vertices are full alpha or not.


### PR DESCRIPTION
Merges the two stencil-state-setting commands, and dirty-tracks the individual parts.

While not big, compounds with the other recent OpenGL optimizations.

For merge after 1.15.x is done.