### PR TITLE
More efficient dirtying of the UV scale uniform

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -179,6 +179,8 @@ void DrawEngineCommon::NotifyConfigChanged() {
 	if (decJitCache_)
 		decJitCache_->Clear();
 	dec_ = nullptr;
+	// Just make sure there's no pending draw, since we wipe the decoders. There shouldn't be one.
+	numDrawCalls = 0;
 	decoderMap_.Iterate([&](const uint32_t vtype, VertexDecoder *decoder) {
 		delete decoder;
 	});

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -189,7 +189,7 @@ protected:
 	u16 *decIndex = nullptr;
 
 	// Cached vertex decoders
-	u32 lastVType_ = -1;  // corresponds to dec_.  Could really just pick it out of dec_...
+	u32 lastVType_ = -1;  // corresponds to dec_, but also has a few extra bits.
 	DenseHashMap<u32, VertexDecoder *, nullptr> decoderMap_;
 	VertexDecoder *dec_ = nullptr;
 	VertexDecoderJitCache *decJitCache_ = nullptr;
@@ -202,13 +202,17 @@ protected:
 	struct DeferredDrawCall {
 		const void *verts;
 		const void *inds;
+		VertexDecoder *dec;  // These will soon be able to be different with each draw.
 		u32 vertexCount;
-		u8 indexType;
 		s8 prim;
 		u8 cullMode;
 		u16 indexLowerBound;
 		u16 indexUpperBound;
 		UVScale uvScale;
+
+		int IndexType() const {
+			return (dec->VertexType() & GE_VTYPE_IDX_MASK) >> GE_VTYPE_IDX_SHIFT;
+		}
 	};
 
 	enum { MAX_DEFERRED_DRAW_CALLS = 128 };

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -406,6 +406,7 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 		Unbind();
 		gstate_c.SetTextureIs3D(false);
 		gstate_c.SetTextureIsArray(false);
+		gstate_c.SetTextureIsFramebuffer(false);
 		return nullptr;
 	}
 
@@ -573,6 +574,7 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 			gstate_c.SetTextureIs3D((entry->status & TexCacheEntry::STATUS_3D) != 0);
 			gstate_c.SetTextureIsArray(false);
 			gstate_c.SetTextureIsBGRA((entry->status & TexCacheEntry::STATUS_BGRA) != 0);
+			gstate_c.SetTextureIsFramebuffer(false);
 
 			if (rehash) {
 				// Update in case any of these changed.
@@ -681,6 +683,7 @@ TexCacheEntry *TextureCacheCommon::SetTexture() {
 	gstate_c.curTextureHeight = h;
 	gstate_c.SetTextureIs3D((entry->status & TexCacheEntry::STATUS_3D) != 0);
 	gstate_c.SetTextureIsArray(false);  // Ordinary 2D textures still aren't used by array view in VK. We probably might as well, though, at this point..
+	gstate_c.SetTextureIsFramebuffer(false);
 
 	failedTexture_ = false;
 	nextTexture_ = entry;
@@ -1154,6 +1157,8 @@ void TextureCacheCommon::SetTextureFramebuffer(const AttachCandidate &candidate)
 			gstate_c.Dirty(DIRTY_FRAGMENTSHADER_STATE);
 		}
 		gstate_c.SetTextureIsBGRA(false);
+		gstate_c.SetTextureIsFramebuffer(true);
+
 		gstate_c.curTextureXOffset = fbInfo.xOffset;
 		gstate_c.curTextureYOffset = fbInfo.yOffset;
 		u32 texW = (u32)gstate.getTextureWidth(0);

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -1176,7 +1176,7 @@ void VertexDecoder::SetVertexType(u32 fmt, const VertexDecoderOptions &options, 
 
 		steps_[numSteps_++] = morphcount == 1 ? colstep[col] : colstep_morph[col];
 
-		// All color formats decode to DEC_U8_4 currently.
+		// All color formats decode to DEC_U8_4.
 		// They can become floats later during transform though.
 		decFmt.c0fmt = DEC_U8_4;
 		decFmt.c0off = decOff;

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -336,7 +336,7 @@ public:
 
 	u32 VertexType() const { return fmt_; }
 
-	const DecVtxFormat &GetDecVtxFmt() { return decFmt; }
+	const DecVtxFormat &GetDecVtxFmt() const { return decFmt; }
 
 	void DecodeVerts(u8 *decoded, const void *verts, int indexLowerBound, int indexUpperBound) const;
 

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -820,13 +820,13 @@ void GPUCommonHW::FastRunLoop(DisplayList &list) {
 }
 
 void GPUCommonHW::Execute_VertexType(u32 op, u32 diff) {
-	if (diff)
+	// When this function is active (instead of Execute_VertexTypeSkinning), auto-flush-on-change is enabled, so we always flush here
+	if (diff) {
 		gstate_c.Dirty(DIRTY_VERTEXSHADER_STATE);
-	if (diff & (GE_VTYPE_THROUGH_MASK)) {
-		gstate_c.Dirty(DIRTY_UVSCALEOFFSET);
-		// Switching between through and non-through, we need to invalidate a bunch of stuff.
-		if (diff & GE_VTYPE_THROUGH_MASK)
+		if (diff & GE_VTYPE_THROUGH_MASK) {
+			// Switching between through and non-through, we need to invalidate a bunch of stuff.
 			gstate_c.Dirty(DIRTY_RASTER_STATE | DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_FRAGMENTSHADER_STATE | DIRTY_GEOMETRYSHADER_STATE | DIRTY_CULLRANGE);
+		}
 	}
 }
 
@@ -860,7 +860,7 @@ void GPUCommonHW::Execute_VertexTypeSkinning(u32 op, u32 diff) {
 		}
 	}
 	if (diff & GE_VTYPE_THROUGH_MASK)
-		gstate_c.Dirty(DIRTY_RASTER_STATE | DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_FRAGMENTSHADER_STATE | DIRTY_GEOMETRYSHADER_STATE | DIRTY_CULLRANGE | DIRTY_UVSCALEOFFSET);
+		gstate_c.Dirty(DIRTY_RASTER_STATE | DIRTY_VIEWPORTSCISSOR_STATE | DIRTY_FRAGMENTSHADER_STATE | DIRTY_GEOMETRYSHADER_STATE | DIRTY_CULLRANGE);
 }
 
 void GPUCommonHW::Execute_Prim(u32 op, u32 diff) {

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -574,6 +574,12 @@ struct GPUStateCache {
 			Dirty(DIRTY_FRAGMENTSHADER_STATE);
 		}
 	}
+	void SetTextureIsFramebuffer(bool framebuf) {
+		if (framebufTexture != framebuf) {
+			framebufTexture = framebuf;
+			Dirty(DIRTY_UVSCALEOFFSET);
+		}
+	}
 	void SetTextureIsBGRA(bool isBGRA) {
 		if (bgraTexture != isBGRA) {
 			bgraTexture = isBGRA;
@@ -616,6 +622,7 @@ public:
 	bool needShaderTexClamp;
 	bool arrayTexture;
 	bool useFlagsChanged;
+	bool framebufTexture;
 
 	float morphWeights[8];
 	u32 deferredVertTypeDirty;


### PR DESCRIPTION
This allows more draw calls to be merged in some games like GTA that wildly mix different but output-compatible vertex formats for related geometry. The result is about a 10% reduction in drawcalls in GTA games, and some reduction in uniform value updates. Many other games are barely affected at all by this.

This one is backend-neutral.