### PR TITLE
DrawEngineGLES: reduce buffer rebinds

### DIFF
--- a/Common/GPU/OpenGL/GLMemory.h
+++ b/Common/GPU/OpenGL/GLMemory.h
@@ -84,7 +84,7 @@ public:
 	const char *Name() const override { return tag_; };  // for sorting
 
 	// Utility for users of this class, not used internally.
-	const uint32_t INVALID_OFFSET = 0xFFFFFFFF;
+	static const uint32_t INVALID_OFFSET = 0xFFFFFFFF;
 
 private:
 	// Needs context in case of defragment.

--- a/Common/GPU/OpenGL/GLMemory.h
+++ b/Common/GPU/OpenGL/GLMemory.h
@@ -142,6 +142,10 @@ public:
 		return bindOffset;
 	}
 
+	uint8_t *GetPtr(uint32_t offset) {
+		return writePtr_ + offset;
+	}
+
 	// If you didn't use all of the previous allocation you just made (obviously can't be another one),
 	// you can return memory to the buffer by specifying the offset up until which you wrote data.
 	void Rewind(uint32_t offset) {

--- a/Common/GPU/OpenGL/GLMemory.h
+++ b/Common/GPU/OpenGL/GLMemory.h
@@ -148,8 +148,12 @@ public:
 
 	// If you didn't use all of the previous allocation you just made (obviously can't be another one),
 	// you can return memory to the buffer by specifying the offset up until which you wrote data.
-	void Rewind(uint32_t offset) {
-		offset_ = offset;
+	void Rewind(GLRBuffer *buffer, uint32_t offset) {
+		if (buffer == buffers_[buf_].buffer) {
+			_dbg_assert_(offset != INVALID_OFFSET);
+			_dbg_assert_(offset <= offset_);
+			offset_ = offset;
+		}
 	}
 
 	size_t GetOffset() const { return offset_; }

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -1236,8 +1236,8 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last
 			// TODO: Add fast path for glBindVertexBuffer
 			GLRInputLayout *layout = c.draw.inputLayout;
 			// TODO: We really shouldn't need null checks here, right?
-			GLuint buf = c.draw.vertexBuffer ? c.draw.vertexBuffer->buffer_ : 0;
-			_dbg_assert_(!c.draw.vertexBuffer || !c.draw.vertexBuffer->Mapped());
+			GLuint buf = c.draw.vertexBuffer->buffer_;
+			_dbg_assert_(!c.draw.vertexBuffer->Mapped());
 			if (buf != curArrayBuffer) {
 				glBindBuffer(GL_ARRAY_BUFFER, buf);
 				curArrayBuffer = buf;

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -750,22 +750,24 @@ public:
 	}
 
 	void Draw(GLRInputLayout *inputLayout, GLRBuffer *vertexBuffer, uint32_t vertexOffset, GLenum mode, int first, int count) {
-		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(vertexBuffer && curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
 		data.cmd = GLRRenderCommand::DRAW;
 		data.draw.inputLayout = inputLayout;
 		data.draw.vertexOffset = vertexOffset;
 		data.draw.vertexBuffer = vertexBuffer;
 		data.draw.indexBuffer = nullptr;
+		data.draw.indexOffset = 0;
 		data.draw.mode = mode;
 		data.draw.first = first;
 		data.draw.count = count;
 		data.draw.indexType = 0;
+		data.draw.instances = 1;
 	}
 
 	// Would really love to have a basevertex parameter, but impossible in unextended GLES, without glDrawElementsBaseVertex, unfortunately.
 	void DrawIndexed(GLRInputLayout *inputLayout, GLRBuffer *vertexBuffer, uint32_t vertexOffset, GLRBuffer *indexBuffer, uint32_t indexOffset, GLenum mode, int count, GLenum indexType, int instances = 1) {
-		_dbg_assert_(curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
+		_dbg_assert_(vertexBuffer && curRenderStep_ && curRenderStep_->stepType == GLRStepType::RENDER);
 		GLRRenderData &data = curRenderStep_->commands.push_uninitialized();
 		data.cmd = GLRRenderCommand::DRAW;
 		data.draw.inputLayout = inputLayout;

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -409,7 +409,7 @@ public:
 		GLRInitStep &step = initSteps_.push_uninitialized();
 		step.stepType = GLRInitStepType::BUFFER_SUBDATA;
 		_dbg_assert_(offset >= 0);
-		_dbg_assert_(offset <= buffer->size_ - size);
+		_dbg_assert_(offset + size <= buffer->size_);
 		step.buffer_subdata.buffer = buffer;
 		step.buffer_subdata.offset = (int)offset;
 		step.buffer_subdata.size = (int)size;

--- a/Common/Log.h
+++ b/Common/Log.h
@@ -83,7 +83,7 @@ void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type,
 		;
 bool GenericLogEnabled(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type);
 
-#if defined(_DEBUG) || defined(_WIN32)
+#if defined(_DEBUG)
 
 #define MAX_LOGLEVEL DEBUG_LEVEL
 

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -173,6 +173,7 @@ void DrawEngineGLES::BeginFrame() {
 
 void DrawEngineGLES::EndFrame() {
 	FrameData &frameData = frameData_[render_->GetCurFrame()];
+	ReleaseReservedPushMemory(frameData);
 	render_->EndPushBuffer(frameData.pushIndex);
 	render_->EndPushBuffer(frameData.pushVertex);
 	tessDataTransferGLES->EndFrame();

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -204,7 +204,7 @@ static inline void VertexAttribSetup(int attrib, int fmt, int stride, int offset
 }
 
 // TODO: Use VBO and get rid of the vertexData pointers - with that, we will supply only offsets
-GLRInputLayout *DrawEngineGLES::SetupDecFmtForDraw(LinkedShader *program, const DecVtxFormat &decFmt) {
+GLRInputLayout *DrawEngineGLES::SetupDecFmtForDraw(const DecVtxFormat &decFmt) {
 	uint32_t key = decFmt.id;
 	GLRInputLayout *inputLayout = inputLayoutMap_.Get(key);
 	if (inputLayout) {
@@ -274,6 +274,7 @@ void DrawEngineGLES::DoFlush() {
 	if (vshader->UseHWTransform()) {
 		int vertexCount = 0;
 		bool useElements = true;
+		GLRInputLayout *inputLayout = SetupDecFmtForDraw(dec_->GetDecVtxFmt());
 
 		if (decOptions_.applySkinInDecode && (lastVType_ & GE_VTYPE_WEIGHT_MASK)) {
 			// If software skinning, we've already predecoded into "decoded_", and indices
@@ -325,7 +326,6 @@ void DrawEngineGLES::DoFlush() {
 		ApplyDrawStateLate(false, 0);
 		
 		LinkedShader *program = shaderManager_->ApplyFragmentShader(vsid, vshader, pipelineState_, framebufferManager_->UseBufferedRendering());
-		GLRInputLayout *inputLayout = SetupDecFmtForDraw(program, dec_->GetDecVtxFmt());
 		if (useElements) {
 			render_->DrawIndexed(inputLayout,
 				vertexBuffer, vertexBufferOffset,

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -126,12 +126,24 @@ private:
 		GLPushBuffer *pushVertex;
 		GLPushBuffer *pushIndex;
 	};
-	FrameData frameData_[GLRenderManager::MAX_INFLIGHT_FRAMES];
+
+	// Manage suballocating pushbuffer reservations
+	void ReleaseReservedPushMemory(FrameData &frameData);
+	u8 *AllocateVertices(FrameData &frameData, int stride, int count, GLRBuffer **vertexBuffer, uint32_t *bindOffset, uint32_t *vertexOffset);
+
+	FrameData frameData_[GLRenderManager::MAX_INFLIGHT_FRAMES]{};
 
 	DenseHashMap<uint32_t, GLRInputLayout *, nullptr> inputLayoutMap_;
 
 	GLRInputLayout *softwareInputLayout_ = nullptr;
+	GLRInputLayout *lastInputLayout_ = nullptr;
 	GLRenderManager *render_;
+
+	// These are ONLY touched within AllocateVertices and ReleaseReservedPushMemory, to isolate the logic properly.
+	GLRBuffer *curVBuffer_ = nullptr;
+	uint32_t curVBufferBindOffset_ = 0;
+	uint32_t curVBufferOffset_ = 0;
+	uint32_t curVBufferEnd_ = 0;
 
 	// Other
 	ShaderManagerGLES *shaderManager_ = nullptr;

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -144,6 +144,7 @@ private:
 	uint32_t curVBufferBindOffset_ = 0;
 	uint32_t curVBufferOffset_ = 0;
 	uint32_t curVBufferEnd_ = 0;
+	uint32_t curVertexIndex_ = 0;
 
 	// Other
 	ShaderManagerGLES *shaderManager_ = nullptr;

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -120,7 +120,7 @@ private:
 	void ApplyDrawState(int prim);
 	void ApplyDrawStateLate(bool setStencil, int stencilValue);
 
-	GLRInputLayout *SetupDecFmtForDraw(LinkedShader *program, const DecVtxFormat &decFmt);
+	GLRInputLayout *SetupDecFmtForDraw(const DecVtxFormat &decFmt);
 
 	struct FrameData {
 		GLPushBuffer *pushVertex;


### PR DESCRIPTION
For some reason, not quite seeing the performance uplift I hoped to see given previous experiments like #17477. Will experiment more with this.

Works by "reserving" memory and then suballocating from it, computing vertex offsets as we go, instead of "allocating" every time. Works around the OpenGL deficit (lack of basevertex parameter) by nudging indices instead.