### PR TITLE
OpenGL: Show passes in GPU profiler, add GPU memory stats, plus a bugfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -631,6 +631,8 @@ add_library(Common STATIC
 	Common/File/FileDescriptor.h
 	Common/GPU/DataFormat.h
 	Common/GPU/MiscTypes.h
+	Common/GPU/GPUBackendCommon.cpp
+	Common/GPU/GPUBackendCommon.h
 	Common/GPU/thin3d.cpp
 	Common/GPU/thin3d.h
 	Common/GPU/thin3d_create.h

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -450,6 +450,7 @@
     <ClInclude Include="GPU\D3D9\D3D9ShaderCompiler.h" />
     <ClInclude Include="GPU\D3D9\D3D9StateCache.h" />
     <ClInclude Include="GPU\DataFormat.h" />
+    <ClInclude Include="GPU\GPUBackendCommon.h" />
     <ClInclude Include="GPU\MiscTypes.h" />
     <ClInclude Include="GPU\OpenGL\DataFormatGL.h" />
     <ClInclude Include="GPU\OpenGL\gl3stub.h" />
@@ -894,6 +895,7 @@
     <ClCompile Include="GPU\D3D9\D3D9ShaderCompiler.cpp" />
     <ClCompile Include="GPU\D3D9\D3D9StateCache.cpp" />
     <ClCompile Include="GPU\D3D9\thin3d_d3d9.cpp" />
+    <ClCompile Include="GPU\GPUBackendCommon.cpp" />
     <ClCompile Include="GPU\OpenGL\DataFormatGL.cpp" />
     <ClCompile Include="GPU\OpenGL\gl3stub.c" />
     <ClCompile Include="GPU\OpenGL\GLFeatures.cpp" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -449,9 +449,6 @@
     <ClInclude Include="Render\ManagedTexture.h">
       <Filter>Render</Filter>
     </ClInclude>
-    <ClInclude Include="GPU\MiscTypes.h">
-      <Filter>GPU</Filter>
-    </ClInclude>
     <ClInclude Include="GPU\Vulkan\VulkanFramebuffer.h">
       <Filter>GPU\Vulkan</Filter>
     </ClInclude>
@@ -502,6 +499,12 @@
     </ClInclude>
     <ClInclude Include="GPU\OpenGL\GLMemory.h">
       <Filter>GPU\OpenGL</Filter>
+    </ClInclude>
+    <ClInclude Include="GPU\GPUBackendCommon.h">
+      <Filter>GPU</Filter>
+    </ClInclude>
+    <ClInclude Include="GPU\MiscTypes.h">
+      <Filter>GPU</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -940,6 +943,9 @@
     </ClCompile>
     <ClCompile Include="Data\Collections\FastVec.h">
       <Filter>Data\Collections</Filter>
+    </ClCompile>
+    <ClCompile Include="GPU\GPUBackendCommon.cpp">
+      <Filter>GPU</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Common/GPU/GPUBackendCommon.cpp
+++ b/Common/GPU/GPUBackendCommon.cpp
@@ -1,0 +1,28 @@
+#include <mutex>
+#include <set>
+
+#include "Common/GPU/GPUBackendCommon.h"
+
+// Global push buffer tracker for GPU memory profiling.
+// Don't want to manually dig up all the active push buffers.
+static std::mutex g_pushBufferListMutex;
+static std::set<GPUMemoryManager *> g_pushBuffers;
+
+std::vector<GPUMemoryManager *> GetActiveGPUMemoryManagers() {
+	std::vector<GPUMemoryManager *> buffers;
+	std::lock_guard<std::mutex> guard(g_pushBufferListMutex);
+	for (auto iter : g_pushBuffers) {
+		buffers.push_back(iter);
+	}
+	return buffers;
+}
+
+void RegisterGPUMemoryManager(GPUMemoryManager *manager) {
+	std::lock_guard<std::mutex> guard(g_pushBufferListMutex);
+	g_pushBuffers.insert(manager);
+}
+
+void UnregisterGPUMemoryManager(GPUMemoryManager *manager) {
+	std::lock_guard<std::mutex> guard(g_pushBufferListMutex);
+	g_pushBuffers.erase(manager);
+}

--- a/Common/GPU/GPUBackendCommon.h
+++ b/Common/GPU/GPUBackendCommon.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <vector>
+
+// Just an abstract thing to get debug information.
+class GPUMemoryManager {
+public:
+	virtual ~GPUMemoryManager() {}
+
+	virtual void GetDebugString(char *buffer, size_t bufSize) const = 0;
+	virtual const char *Name() const = 0;  // for sorting
+};
+
+std::vector<GPUMemoryManager *> GetActiveGPUMemoryManagers();
+
+void RegisterGPUMemoryManager(GPUMemoryManager *manager);
+void UnregisterGPUMemoryManager(GPUMemoryManager *manager);

--- a/Common/GPU/OpenGL/GLFrameData.h
+++ b/Common/GPU/OpenGL/GLFrameData.h
@@ -3,6 +3,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <vector>
+#include <string>
 #include <set>
 
 #include "Common/GPU/OpenGL/GLCommon.h"
@@ -39,6 +40,7 @@ struct GLQueueProfileContext {
 	bool enabled;
 	double cpuStartTime;
 	double cpuEndTime;
+	std::string passesString;
 };
 
 

--- a/Common/GPU/OpenGL/GLMemory.cpp
+++ b/Common/GPU/OpenGL/GLMemory.cpp
@@ -2,6 +2,7 @@
 #include "Common/GPU/OpenGL/GLMemory.h"
 #include "Common/GPU/OpenGL/GLRenderManager.h"
 #include "Common/GPU/OpenGL/GLFeatures.h"
+#include "Common/Data/Text/Parsers.h"
 
 extern std::thread::id renderThreadId;
 #if MAX_LOGLEVEL >= DEBUG_LEVEL
@@ -64,9 +65,11 @@ bool GLRBuffer::Unmap() {
 GLPushBuffer::GLPushBuffer(GLRenderManager *render, GLuint target, size_t size, const char *tag) : render_(render), size_(size), target_(target), tag_(tag) {
 	bool res = AddBuffer();
 	_assert_(res);
+	RegisterGPUMemoryManager(this);
 }
 
 GLPushBuffer::~GLPushBuffer() {
+	UnregisterGPUMemoryManager(this);
 	Destroy(true);
 }
 
@@ -278,4 +281,8 @@ void GLPushBuffer::UnmapDevice() {
 			info.deviceMemory = nullptr;
 		}
 	}
+}
+
+void GLPushBuffer::GetDebugString(char *buffer, size_t bufSize) const {
+	snprintf(buffer, bufSize, "%s: %d/%d", tag_, NiceSizeFormat(this->offset_).c_str(), NiceSizeFormat(this->size_).c_str());
 }

--- a/Common/GPU/OpenGL/GLMemory.h
+++ b/Common/GPU/OpenGL/GLMemory.h
@@ -124,6 +124,8 @@ public:
 		NextBuffer(numBytes);
 		*bindOffset = 0;
 		*buf = buffers_[buf_].buffer;
+		// Need to mark the allocated range used in the new buffer. How did things work before this?
+		offset_ = numBytes;
 		return writePtr_;
 	}
 

--- a/Common/GPU/OpenGL/GLMemory.h
+++ b/Common/GPU/OpenGL/GLMemory.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include "Common/GPU/GPUBackendCommon.h"
 #include "Common/GPU/OpenGL/GLCommon.h"
 #include "Common/Log.h"
 
@@ -61,7 +62,7 @@ class GLRenderManager;
 // trouble.
 // We need to manage the lifetime of this together with the other resources so its destructor
 // runs on the render thread.
-class GLPushBuffer {
+class GLPushBuffer : public GPUMemoryManager {
 public:
 	friend class GLRenderManager;
 
@@ -77,6 +78,10 @@ public:
 	~GLPushBuffer();
 
 	void Reset() { offset_ = 0; }
+
+	void GetDebugString(char *buffer, size_t bufSize) const override;
+
+	const char *Name() const override { return tag_; };  // for sorting
 
 	// Utility for users of this class, not used internally.
 	const uint32_t INVALID_OFFSET = 0xFFFFFFFF;

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -1843,3 +1843,44 @@ GLRFramebuffer::~GLRFramebuffer() {
 		glDeleteRenderbuffers(1, &stencil_buffer);
 	CHECK_GL_ERROR_IF_DEBUG();
 }
+
+std::string GLQueueRunner::StepToString(const GLRStep &step) const {
+	char buffer[256];
+	switch (step.stepType) {
+	case GLRStepType::RENDER:
+	{
+		int w = step.render.framebuffer ? step.render.framebuffer->width : targetWidth_;
+		int h = step.render.framebuffer ? step.render.framebuffer->height : targetHeight_;
+		snprintf(buffer, sizeof(buffer), "RENDER %s %s (draws: %d, %dx%d)", step.tag, step.render.framebuffer ? step.render.framebuffer->Tag() : "", -1, w, h);
+		break;
+	}
+	case GLRStepType::COPY:
+		snprintf(buffer, sizeof(buffer), "COPY '%s' %s -> %s (%dx%d, %s)", step.tag, step.copy.src->Tag(), step.copy.dst->Tag(), step.copy.srcRect.w, step.copy.srcRect.h, GLRAspectToString((GLRAspect)step.copy.aspectMask));
+		break;
+	case GLRStepType::BLIT:
+		snprintf(buffer, sizeof(buffer), "BLIT '%s' %s -> %s (%dx%d->%dx%d, %s)", step.tag, step.copy.src->Tag(), step.copy.dst->Tag(), step.blit.srcRect.w, step.blit.srcRect.h, step.blit.dstRect.w, step.blit.dstRect.h, GLRAspectToString((GLRAspect)step.blit.aspectMask));
+		break;
+	case GLRStepType::READBACK:
+		snprintf(buffer, sizeof(buffer), "READBACK '%s' %s (%dx%d, %s)", step.tag, step.readback.src ? step.readback.src->Tag() : "(backbuffer)", step.readback.srcRect.w, step.readback.srcRect.h, GLRAspectToString((GLRAspect)step.readback.aspectMask));
+		break;
+	case GLRStepType::READBACK_IMAGE:
+		snprintf(buffer, sizeof(buffer), "READBACK_IMAGE '%s' (%dx%d)", step.tag, step.readback_image.srcRect.w, step.readback_image.srcRect.h);
+		break;
+	case GLRStepType::RENDER_SKIP:
+		snprintf(buffer, sizeof(buffer), "(RENDER_SKIP) %s", step.tag);
+		break;
+	default:
+		buffer[0] = 0;
+		break;
+	}
+	return std::string(buffer);
+}
+
+const char *GLRAspectToString(GLRAspect aspect) {
+	switch (aspect) {
+	case GLR_ASPECT_COLOR: return "COLOR";
+	case GLR_ASPECT_DEPTH: return "DEPTH";
+	case GLR_ASPECT_STENCIL: return "STENCIL";
+	default: return "N/A";
+	}
+}

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -651,7 +651,7 @@ retry_depth:
 	currentReadHandle_ = fbo->handle;
 }
 
-void GLQueueRunner::RunSteps(const std::vector<GLRStep *> &steps, bool skipGLCalls, bool keepSteps, bool useVR) {
+void GLQueueRunner::RunSteps(const std::vector<GLRStep *> &steps, GLFrameData &frameData, bool skipGLCalls, bool keepSteps, bool useVR) {
 	if (skipGLCalls) {
 		if (keepSteps) {
 			return;
@@ -741,11 +741,14 @@ void GLQueueRunner::RunSteps(const std::vector<GLRStep *> &steps, bool skipGLCal
 		if (useDebugGroups_)
 			glPopDebugGroup();
 #endif
-
+		if (frameData.profile.enabled) {
+			frameData.profile.passesString += StepToString(step);
+		}
 		if (!keepSteps) {
 			delete steps[i];
 		}
 	}
+
 	CHECK_GL_ERROR_IF_DEBUG();
 }
 
@@ -1851,23 +1854,23 @@ std::string GLQueueRunner::StepToString(const GLRStep &step) const {
 	{
 		int w = step.render.framebuffer ? step.render.framebuffer->width : targetWidth_;
 		int h = step.render.framebuffer ? step.render.framebuffer->height : targetHeight_;
-		snprintf(buffer, sizeof(buffer), "RENDER %s %s (draws: %d, %dx%d)", step.tag, step.render.framebuffer ? step.render.framebuffer->Tag() : "", -1, w, h);
+		snprintf(buffer, sizeof(buffer), "RENDER %s %s (commands: %d, %dx%d)\n", step.tag, step.render.framebuffer ? step.render.framebuffer->Tag() : "", (int)step.commands.size(), w, h);
 		break;
 	}
 	case GLRStepType::COPY:
-		snprintf(buffer, sizeof(buffer), "COPY '%s' %s -> %s (%dx%d, %s)", step.tag, step.copy.src->Tag(), step.copy.dst->Tag(), step.copy.srcRect.w, step.copy.srcRect.h, GLRAspectToString((GLRAspect)step.copy.aspectMask));
+		snprintf(buffer, sizeof(buffer), "COPY '%s' %s -> %s (%dx%d, %s)\n", step.tag, step.copy.src->Tag(), step.copy.dst->Tag(), step.copy.srcRect.w, step.copy.srcRect.h, GLRAspectToString((GLRAspect)step.copy.aspectMask));
 		break;
 	case GLRStepType::BLIT:
-		snprintf(buffer, sizeof(buffer), "BLIT '%s' %s -> %s (%dx%d->%dx%d, %s)", step.tag, step.copy.src->Tag(), step.copy.dst->Tag(), step.blit.srcRect.w, step.blit.srcRect.h, step.blit.dstRect.w, step.blit.dstRect.h, GLRAspectToString((GLRAspect)step.blit.aspectMask));
+		snprintf(buffer, sizeof(buffer), "BLIT '%s' %s -> %s (%dx%d->%dx%d, %s)\n", step.tag, step.copy.src->Tag(), step.copy.dst->Tag(), step.blit.srcRect.w, step.blit.srcRect.h, step.blit.dstRect.w, step.blit.dstRect.h, GLRAspectToString((GLRAspect)step.blit.aspectMask));
 		break;
 	case GLRStepType::READBACK:
-		snprintf(buffer, sizeof(buffer), "READBACK '%s' %s (%dx%d, %s)", step.tag, step.readback.src ? step.readback.src->Tag() : "(backbuffer)", step.readback.srcRect.w, step.readback.srcRect.h, GLRAspectToString((GLRAspect)step.readback.aspectMask));
+		snprintf(buffer, sizeof(buffer), "READBACK '%s' %s (%dx%d, %s)\n", step.tag, step.readback.src ? step.readback.src->Tag() : "(backbuffer)", step.readback.srcRect.w, step.readback.srcRect.h, GLRAspectToString((GLRAspect)step.readback.aspectMask));
 		break;
 	case GLRStepType::READBACK_IMAGE:
-		snprintf(buffer, sizeof(buffer), "READBACK_IMAGE '%s' (%dx%d)", step.tag, step.readback_image.srcRect.w, step.readback_image.srcRect.h);
+		snprintf(buffer, sizeof(buffer), "READBACK_IMAGE '%s' (%dx%d)\n", step.tag, step.readback_image.srcRect.w, step.readback_image.srcRect.h);
 		break;
 	case GLRStepType::RENDER_SKIP:
-		snprintf(buffer, sizeof(buffer), "(RENDER_SKIP) %s", step.tag);
+		snprintf(buffer, sizeof(buffer), "(RENDER_SKIP) %s\n", step.tag);
 		break;
 	default:
 		buffer[0] = 0;

--- a/Common/GPU/OpenGL/GLQueueRunner.h
+++ b/Common/GPU/OpenGL/GLQueueRunner.h
@@ -290,11 +290,12 @@ enum class GLRRenderPassAction {
 
 class GLRFramebuffer;
 
-enum {
+enum GLRAspect {
 	GLR_ASPECT_COLOR = 1,
 	GLR_ASPECT_DEPTH = 2,
 	GLR_ASPECT_STENCIL = 3,
 };
+const char *GLRAspectToString(GLRAspect aspect);
 
 struct GLRStep {
 	GLRStep(GLRStepType _type) : stepType(_type) {}
@@ -388,6 +389,8 @@ private:
 	void fbo_bind_fb_target(bool read, GLuint name);
 	GLenum fbo_get_fb_target(bool read, GLuint **cached);
 	void fbo_unbind();
+
+	std::string StepToString(const GLRStep &step) const;
 
 	GLRFramebuffer *curFB_ = nullptr;
 

--- a/Common/GPU/OpenGL/GLQueueRunner.h
+++ b/Common/GPU/OpenGL/GLQueueRunner.h
@@ -354,7 +354,7 @@ public:
 
 	void RunInitSteps(const FastVec<GLRInitStep> &steps, bool skipGLCalls);
 
-	void RunSteps(const std::vector<GLRStep *> &steps, bool skipGLCalls, bool keepSteps, bool useVR);
+	void RunSteps(const std::vector<GLRStep *> &steps, GLFrameData &frameData, bool skipGLCalls, bool keepSteps, bool useVR);
 
 	void CreateDeviceObjects();
 	void DestroyDeviceObjects();

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -905,5 +905,6 @@ private:
 #endif
 	Draw::DeviceCaps caps_{};
 
+	std::string profilePassesString_;
 	InvalidationCallback invalidationCallback_;
 };

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -53,12 +53,13 @@ public:
 
 class GLRFramebuffer {
 public:
-	GLRFramebuffer(const Draw::DeviceCaps &caps, int _width, int _height, bool z_stencil)
+	GLRFramebuffer(const Draw::DeviceCaps &caps, int _width, int _height, bool z_stencil, const char *tag)
 		: color_texture(caps, _width, _height, 1, 1), z_stencil_texture(caps, _width, _height, 1, 1),
 		width(_width), height(_height), z_stencil_(z_stencil) {
 	}
-
 	~GLRFramebuffer();
+
+	const char *Tag() const { return tag_.c_str(); }
 
 	GLuint handle = 0;
 	GLRTexture color_texture;
@@ -71,8 +72,10 @@ public:
 	int width;
 	int height;
 	GLuint colorDepth = 0;
-
 	bool z_stencil_;
+
+private:
+	std::string tag_;
 };
 
 // We need to create some custom heap-allocated types so we can forward things that need to be created on the GL thread, before
@@ -283,10 +286,10 @@ public:
 		return step.create_shader.shader;
 	}
 
-	GLRFramebuffer *CreateFramebuffer(int width, int height, bool z_stencil) {
+	GLRFramebuffer *CreateFramebuffer(int width, int height, bool z_stencil, const char *tag) {
 		GLRInitStep &step = initSteps_.push_uninitialized();
 		step.stepType = GLRInitStepType::CREATE_FRAMEBUFFER;
-		step.create_framebuffer.framebuffer = new GLRFramebuffer(caps_, width, height, z_stencil);
+		step.create_framebuffer.framebuffer = new GLRFramebuffer(caps_, width, height, z_stencil, tag);
 		return step.create_framebuffer.framebuffer;
 	}
 

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -1447,7 +1447,7 @@ Framebuffer *OpenGLContext::CreateFramebuffer(const FramebufferDesc &desc) {
 	// TODO: Support multiview later. (It's our only use case for multi layers).
 	_dbg_assert_(desc.numLayers == 1);
 
-	GLRFramebuffer *framebuffer = renderManager_.CreateFramebuffer(desc.width, desc.height, desc.z_stencil);
+	GLRFramebuffer *framebuffer = renderManager_.CreateFramebuffer(desc.width, desc.height, desc.z_stencil, desc.tag);
 	OpenGLFramebuffer *fbo = new OpenGLFramebuffer(&renderManager_, framebuffer);
 	return fbo;
 }

--- a/Common/GPU/Vulkan/VulkanMemory.cpp
+++ b/Common/GPU/Vulkan/VulkanMemory.cpp
@@ -35,37 +35,15 @@ using namespace PPSSPP_VK;
 // Always keep around push buffers at least this long (seconds).
 static const double PUSH_GARBAGE_COLLECTION_DELAY = 10.0;
 
-// Global push buffer tracker for vulkan memory profiling.
-// Don't want to manually dig up all the active push buffers.
-static std::mutex g_pushBufferListMutex;
-static std::set<VulkanMemoryManager *> g_pushBuffers;
-
-std::vector<VulkanMemoryManager *> GetActiveVulkanMemoryManagers() {
-	std::vector<VulkanMemoryManager *> buffers;
-	std::lock_guard<std::mutex> guard(g_pushBufferListMutex);
-	for (auto iter : g_pushBuffers) {
-		buffers.push_back(iter);
-	}
-	return buffers;
-}
-
 VulkanPushBuffer::VulkanPushBuffer(VulkanContext *vulkan, const char *name, size_t size, VkBufferUsageFlags usage)
 		: vulkan_(vulkan), name_(name), size_(size), usage_(usage) {
-	{
-		std::lock_guard<std::mutex> guard(g_pushBufferListMutex);
-		g_pushBuffers.insert(this);
-	}
-
+	RegisterGPUMemoryManager(this);
 	bool res = AddBuffer();
 	_assert_(res);
 }
 
 VulkanPushBuffer::~VulkanPushBuffer() {
-	{
-		std::lock_guard<std::mutex> guard(g_pushBufferListMutex);
-		g_pushBuffers.erase(this);
-	}
-
+	UnregisterGPUMemoryManager(this);
 	_dbg_assert_(!writePtr_);
 	_assert_(buffers_.empty());
 }
@@ -276,11 +254,7 @@ VkResult VulkanDescSetPool::Recreate(bool grow) {
 
 VulkanPushPool::VulkanPushPool(VulkanContext *vulkan, const char *name, size_t originalBlockSize, VkBufferUsageFlags usage)
 	: vulkan_(vulkan), name_(name), originalBlockSize_(originalBlockSize), usage_(usage) {
-	{
-		std::lock_guard<std::mutex> guard(g_pushBufferListMutex);
-		g_pushBuffers.insert(this);
-	}
-
+	RegisterGPUMemoryManager(this);
 	for (int i = 0; i < VulkanContext::MAX_INFLIGHT_FRAMES; i++) {
 		blocks_.push_back(CreateBlock(originalBlockSize));
 		blocks_.back().original = true;
@@ -289,11 +263,7 @@ VulkanPushPool::VulkanPushPool(VulkanContext *vulkan, const char *name, size_t o
 }
 
 VulkanPushPool::~VulkanPushPool() {
-	{
-		std::lock_guard<std::mutex> guard(g_pushBufferListMutex);
-		g_pushBuffers.erase(this);
-	}
-
+	UnregisterGPUMemoryManager(this);
 	_dbg_assert_(blocks_.empty());
 }
 

--- a/Common/GPU/Vulkan/VulkanMemory.h
+++ b/Common/GPU/Vulkan/VulkanMemory.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Common/GPU/Vulkan/VulkanContext.h"
+#include "Common/GPU/GPUBackendCommon.h"
 
 // Forward declaration
 VK_DEFINE_HANDLE(VmaAllocation);
@@ -14,22 +15,13 @@ VK_DEFINE_HANDLE(VmaAllocation);
 //
 // Vulkan memory management utils.
 
-// Just an abstract thing to get debug information.
-class VulkanMemoryManager {
-public:
-	virtual ~VulkanMemoryManager() {}
-
-	virtual void GetDebugString(char *buffer, size_t bufSize) const = 0;
-	virtual const char *Name() const = 0;  // for sorting
-};
-
 // VulkanPushBuffer
 // Simple incrementing allocator.
 // Use these to push vertex, index and uniform data. Generally you'll have two or three of these
 // and alternate on each frame. Make sure not to reset until the fence from the last time you used it
 // has completed.
 // NOTE: This has now been replaced with VulkanPushPool for all uses except the vertex cache.
-class VulkanPushBuffer : public VulkanMemoryManager {
+class VulkanPushBuffer : public GPUMemoryManager {
 	struct BufInfo {
 		VkBuffer buffer;
 		VmaAllocation allocation;
@@ -108,7 +100,7 @@ private:
 // Simple memory pushbuffer pool that can share blocks between the "frames", to reduce the impact of push memory spikes -
 // a later frame can gobble up redundant buffers from an earlier frame even if they don't share frame index.
 // NOT thread safe! Can only be used from one thread (our main thread).
-class VulkanPushPool : public VulkanMemoryManager {
+class VulkanPushPool : public GPUMemoryManager {
 public:
 	VulkanPushPool(VulkanContext *vulkan, const char *name, size_t originalBlockSize, VkBufferUsageFlags usage);
 	~VulkanPushPool();
@@ -211,6 +203,4 @@ private:
 	uint32_t usage_ = 0;
 	bool grow_;
 };
-
-std::vector<VulkanMemoryManager *> GetActiveVulkanMemoryManagers();
 

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -100,8 +100,8 @@ void DevMenuScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	items->Add(new Choice(sy->T("Developer Tools")))->OnClick.Handle(this, &DevMenuScreen::OnDeveloperTools);
 	items->Add(new Choice(dev->T("Jit Compare")))->OnClick.Handle(this, &DevMenuScreen::OnJitCompare);
 	items->Add(new Choice(dev->T("Shader Viewer")))->OnClick.Handle(this, &DevMenuScreen::OnShaderView);
-	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN) {
-		items->Add(new CheckBox(&g_Config.bShowAllocatorDebug, dev->T("Allocator Viewer")));
+	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN || g_Config.iGPUBackend == (int)GPUBackend::OPENGL) {
+		items->Add(new CheckBox(&g_Config.bShowAllocatorDebug, dev->T("GPU Allocator Viewer")));
 	}
 	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN || g_Config.iGPUBackend == (int)GPUBackend::OPENGL) {
 		items->Add(new CheckBox(&g_Config.bShowGpuProfile, dev->T("GPU Profile")));

--- a/UWP/CommonUWP/CommonUWP.vcxproj
+++ b/UWP/CommonUWP/CommonUWP.vcxproj
@@ -287,6 +287,7 @@
     <ClInclude Include="..\..\Common\Data\Format\DDSLoad.h" />
     <ClInclude Include="..\..\Common\File\AndroidContentURI.h" />
     <ClInclude Include="..\..\Common\File\AndroidStorage.h" />
+    <ClInclude Include="..\..\Common\GPU\GPUBackendCommon.h" />
     <ClInclude Include="..\..\Common\GPU\Vulkan\VulkanLoader.h" />
     <ClInclude Include="..\..\Common\Math\Statistics.h" />
     <ClInclude Include="..\..\Common\Net\NetBuffer.h" />
@@ -443,6 +444,7 @@
     <ClCompile Include="..\..\Common\Data\Format\DDSLoad.cpp" />
     <ClCompile Include="..\..\Common\File\AndroidContentURI.cpp" />
     <ClCompile Include="..\..\Common\File\AndroidStorage.cpp" />
+    <ClCompile Include="..\..\Common\GPU\GPUBackendCommon.cpp" />
     <ClCompile Include="..\..\Common\GPU\Vulkan\VulkanLoader.cpp" />
     <ClCompile Include="..\..\Common\Math\Statistics.cpp" />
     <ClCompile Include="..\..\Common\Net\NetBuffer.cpp" />

--- a/UWP/CommonUWP/CommonUWP.vcxproj.filters
+++ b/UWP/CommonUWP/CommonUWP.vcxproj.filters
@@ -435,6 +435,9 @@
     <ClCompile Include="..\..\Common\File\AndroidContentURI.cpp">
       <Filter>File</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\GPU\GPUBackendCommon.cpp">
+      <Filter>GPU</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="targetver.h" />
@@ -822,6 +825,9 @@
     </ClInclude>
     <ClInclude Include="..\..\Common\File\AndroidContentURI.h">
       <Filter>File</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\GPU\GPUBackendCommon.h">
+      <Filter>GPU</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -189,6 +189,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Common/File/DirListing.cpp \
   $(SRC)/Common/File/FileDescriptor.cpp \
   $(SRC)/Common/GPU/thin3d.cpp \
+  $(SRC)/Common/GPU/GPUBackendCommon.cpp \
   $(SRC)/Common/GPU/Shader.cpp \
   $(SRC)/Common/GPU/ShaderWriter.cpp \
   $(SRC)/Common/GPU/ShaderTranslation.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -286,6 +286,7 @@ SOURCES_CXX += \
 	$(COMMONDIR)/File/DirListing.cpp \
 	$(COMMONDIR)/GPU/thin3d.cpp \
 	$(COMMONDIR)/GPU/Shader.cpp \
+	$(COMMONDIR)/GPU/GPUBackendCommon.cpp \
 	$(COMMONDIR)/GPU/ShaderWriter.cpp \
 	$(COMMONDIR)/GPU/ShaderTranslation.cpp \
 	$(COMMONDIR)/GPU/OpenGL/thin3d_gl.cpp \


### PR DESCRIPTION
An important pushbuffer bugfix that could cause data corruption is included here, in f4035a0. 

The OpenGL backend now has some more debug information at runtime - simple memory profiling and renderpass list.