### PR TITLE
filter the sdl joystick number via command line

### DIFF
--- a/SDL/SDLJoystick.h
+++ b/SDL/SDLJoystick.h
@@ -16,7 +16,7 @@
 
 class SDLJoystick{
 public:
-	SDLJoystick(bool init_SDL = false);
+	SDLJoystick(bool init_SDL = false, int njoy = 0);
 	~SDLJoystick();
 
 	void registerEventHandler();
@@ -30,4 +30,5 @@ private:
 	bool registeredAsEventHandler;
 	std::vector<SDL_GameController *> controllers;
 	std::map<int, int> controllerDeviceMap;
+	int njoy_;
 };

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -646,6 +646,7 @@ int main(int argc, char *argv[]) {
 	bool set_ipad = false;
 	float set_dpi = 1.0f;
 	float set_scale = 1.0f;
+	int set_njoy = 0;
 
 	// Produce a new set of arguments with the ones we skip.
 	int remain_argc = 1;
@@ -664,6 +665,8 @@ int main(int argc, char *argv[]) {
 			set_dpi = parseFloat(argv[i]);
 		else if (set_scale == -2)
 			set_scale = parseFloat(argv[i]);
+		else if (set_njoy == -2)
+			set_njoy = parseInt(argv[i]);
 		else if (!strcmp(argv[i],"--xres"))
 			set_xres = -2;
 		else if (!strcmp(argv[i],"--yres"))
@@ -676,6 +679,8 @@ int main(int argc, char *argv[]) {
 			set_ipad = true;
 		else if (!strcmp(argv[i],"--portrait"))
 			portrait = true;
+		else if (!strcmp(argv[i],"--njoy"))
+			set_njoy = -2;
 		else {
 			remain_argv[remain_argc++] = argv[i];
 		}
@@ -908,7 +913,7 @@ int main(int argc, char *argv[]) {
 	InitSDLAudioDevice();
 
 	if (joystick_enabled) {
-		joystick = new SDLJoystick();
+		joystick = new SDLJoystick(false, set_njoy);
 	} else {
 		joystick = nullptr;
 	}


### PR DESCRIPTION
the aim is to be able to play with the pad i want (by sdl id). not always the first found. In case i've many pads plugged on my computer, i've to unplug the others.

it is not perfect.
maybe the SDL_CONTROLLERDEVICEADDED should clean controllers.

however, the current way it not good too. it initialise all pads, but apply events only on pad 0 (the code make think it is possible to have multiple players in psp, but i don't think it is possible) (key.deviceId = DEVICE_ID_PAD_0 + getDeviceIndex(event.cbutton.which);)
