### PR TITLE
Emulating HW vrnd

### DIFF
--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -269,7 +269,7 @@ void MIPSState::UpdateCore(CPUCore desired) {
 }
 
 void MIPSState::DoState(PointerWrap &p) {
-	auto s = p.Section("MIPSState", 1, 3);
+	auto s = p.Section("MIPSState", 1, 4);
 	if (!s)
 		return;
 

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -306,6 +306,12 @@ void MIPSState::DoState(PointerWrap &p) {
 		Do(p, fcr0_unused);
 	}
 	Do(p, fcr31);
+	if (s <= 3) {
+		uint32_t dummy;
+		Do(p, dummy); // rng.m_w
+		Do(p, dummy); // rng.m_z
+	}
+
 	Do(p, inDelaySlot);
 	Do(p, llBit);
 	Do(p, debugCount);

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -209,8 +209,6 @@ void MIPSState::Init() {
 	llBit = 0;
 	nextPC = 0;
 	downcount = 0;
-	// Initialize the VFPU random number generator with .. something?
-	rng.Init(0x1337);
 
 	std::lock_guard<std::recursive_mutex> guard(MIPSComp::jitLock);
 	if (PSP_CoreParameter().cpuCore == CPUCore::JIT) {
@@ -308,8 +306,6 @@ void MIPSState::DoState(PointerWrap &p) {
 		Do(p, fcr0_unused);
 	}
 	Do(p, fcr31);
-	Do(p, rng.m_w);
-	Do(p, rng.m_z);
 	Do(p, inDelaySlot);
 	Do(p, llBit);
 	Do(p, debugCount);

--- a/Core/MIPS/MIPS.h
+++ b/Core/MIPS/MIPS.h
@@ -229,8 +229,6 @@ public:
 	// Temporary used around delay slots and similar.
 	u64 saved_flags;
 
-	GMRng rng;	// VFPU hardware random number generator. Probably not the right type.
-
 	// Debug stuff
 	u32 debugCount;	// can be used to count basic blocks before crashes, etc.
 

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -1543,7 +1543,7 @@ namespace MIPSInt
 		int seed = VI(vd);
 		// Swizzles apply a constant value, constants/abs/neg work to vary the seed.
 		ApplySwizzleS(reinterpret_cast<float *>(&seed), V_Single);
-		currentMIPS->rng.Init(seed);
+                vrnd_init(uint32_t(seed), currentMIPS->vfpuCtrl + VFPU_CTRL_RCX0);
 		PC += 4;
 		EatPrefixes();
 	}
@@ -1553,12 +1553,12 @@ namespace MIPSInt
 		int vd = _VD;
 		VectorSize sz = GetVecSize(op);
 		int n = GetNumVectorElements(sz);
-		for (int i = 0; i < n; i++) {
-			// TODO: Make more accurate, use and update RCX regs?
+		// Values are written in backwards order.
+		for (int i = n - 1; i >= 0; i--) {
 			switch ((op >> 16) & 0x1f) {
-			case 1: d.u[i] = currentMIPS->rng.R32(); break;  // vrndi
-			case 2: d.u[i] = 0x3F800000 | (currentMIPS->rng.R32() & 0x007FFFFF); break; // vrndf1 (>= 1, < 2)
-			case 3: d.u[i] = 0x40000000 | (currentMIPS->rng.R32() & 0x007FFFFF); break; // vrndf2 (>= 2, < 4)
+			case 1: d.u[i] = vrnd_generate(currentMIPS->vfpuCtrl + VFPU_CTRL_RCX0); break;  // vrndi
+			case 2: d.u[i] = 0x3F800000 | (vrnd_generate(currentMIPS->vfpuCtrl + VFPU_CTRL_RCX0) & 0x007FFFFF); break; // vrndf1 (>= 1, < 2)
+			case 3: d.u[i] = 0x40000000 | (vrnd_generate(currentMIPS->vfpuCtrl + VFPU_CTRL_RCX0) & 0x007FFFFF); break; // vrndf2 (>= 2, < 4)
 			default: _dbg_assert_msg_(false,"Trying to interpret instruction that can't be interpreted");
 			}
 		}

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -777,8 +777,7 @@ float vfpu_dot(const float a[4], const float b[4]) {
 
 // Redundant currently, since void MIPSState::Init() already
 // does this on its own, but left as-is to be self-contained.
-void vrnd_init_default(uint32_t *rcx)
-{
+void vrnd_init_default(uint32_t *rcx) {
 	rcx[0] = 0x00000001;
 	rcx[1] = 0x00000002;
 	rcx[2] = 0x00000004;
@@ -789,8 +788,7 @@ void vrnd_init_default(uint32_t *rcx)
 	rcx[7] = 0x00000000;
 }
 
-void vrnd_init(uint32_t seed, uint32_t *rcx)
-{
+void vrnd_init(uint32_t seed, uint32_t *rcx) {
 	for(int i = 0; i < 8; ++i) rcx[i] =
 		0x3F800000u |                          // 1.0f mask.
 		((seed >> ((i / 4) * 16)) & 0xFFFFu) | // lower or upper half of the seed.
@@ -798,22 +796,21 @@ void vrnd_init(uint32_t seed, uint32_t *rcx)
 
 }
 
-uint32_t vrnd_generate(uint32_t *rcx)
-{
+uint32_t vrnd_generate(uint32_t *rcx) {
 	// The actual RNG state appears to be 5 parts
 	// (32-bit each) stored into the registers as follows:
-	uint32_t A=(rcx[0] & 0xFFFFu) | (rcx[4] << 16);
-	uint32_t B=(rcx[1] & 0xFFFFu) | (rcx[5] << 16);
-	uint32_t C=(rcx[2] & 0xFFFFu) | (rcx[6] << 16);
-	uint32_t D=(rcx[3] & 0xFFFFu) | (rcx[7] << 16);
-	uint32_t E=(((rcx[0] >> 16) & 0xF) <<  0)|
-	           (((rcx[1] >> 16) & 0xF) <<  4)|
-	           (((rcx[2] >> 16) & 0xF) <<  8)|
-	           (((rcx[3] >> 16) & 0xF) << 12)|
-	           (((rcx[4] >> 16) & 0xF) << 16)|
-	           (((rcx[5] >> 16) & 0xF) << 20)|
-	           (((rcx[6] >> 16) & 0xF) << 24)|
-	           (((rcx[7] >> 16) & 0xF) << 28);
+	uint32_t A = (rcx[0] & 0xFFFFu) | (rcx[4] << 16);
+	uint32_t B = (rcx[1] & 0xFFFFu) | (rcx[5] << 16);
+	uint32_t C = (rcx[2] & 0xFFFFu) | (rcx[6] << 16);
+	uint32_t D = (rcx[3] & 0xFFFFu) | (rcx[7] << 16);
+	uint32_t E = (((rcx[0] >> 16) & 0xF) <<  0) |
+	             (((rcx[1] >> 16) & 0xF) <<  4) |
+	             (((rcx[2] >> 16) & 0xF) <<  8) |
+	             (((rcx[3] >> 16) & 0xF) << 12) |
+	             (((rcx[4] >> 16) & 0xF) << 16) |
+	             (((rcx[5] >> 16) & 0xF) << 20) |
+	             (((rcx[6] >> 16) & 0xF) << 24) |
+	             (((rcx[7] >> 16) & 0xF) << 28);
 	// Update.
 	// LCG with classic parameters.
 	A = 69069u * A + 1u; // NOTE: decimal constants.

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -823,8 +823,6 @@ uint32_t vrnd_generate(uint32_t *rcx)
 	B ^= B <<  5;
 	// Pell sequence, with additional increment.
 	uint32_t t= 2u * D + C + E;
-	C = D;
-	D = t;
 	// NOTE: the details of how E-part is set are
 	// largerly guesswork at the moment. This does
 	// match variety of test data.
@@ -835,6 +833,8 @@ uint32_t vrnd_generate(uint32_t *rcx)
 	    addition_overflows(C + E, D) &&
 	    addition_overflows(C + E, C + D + E) &&
 	    addition_overflows(C + E, C + D);
+	C = D;
+	D = t;
 	// Store.
 	rcx[0] = 0x3F800000u | (((E >>  0) & 0xF) << 16) | (A & 0xFFFFu);
 	rcx[1] = 0x3F800000u | (((E >>  4) & 0xF) << 16) | (B & 0xFFFFu);

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -770,6 +770,85 @@ float vfpu_dot(const float a[4], const float b[4]) {
 }
 
 //==============================================================================
+// The code below attempts to exactly match behaviour of
+// PSP's vrnd instructions. See investigation starting around
+// https://github.com/hrydgard/ppsspp/issues/16946#issuecomment-1467261209
+// for details.
+
+// Redundant currently, since void MIPSState::Init() already
+// does this on its own, but left as-is to be self-contained.
+void vrnd_init_default(uint32_t *rcx)
+{
+	rcx[0] = 0x00000001;
+	rcx[1] = 0x00000002;
+	rcx[2] = 0x00000004;
+	rcx[3] = 0x00000008;
+	rcx[4] = 0x00000000;
+	rcx[5] = 0x00000000;
+	rcx[6] = 0x00000000;
+	rcx[7] = 0x00000000;
+}
+
+void vrnd_init(uint32_t seed, uint32_t *rcx)
+{
+	for(int i = 0; i < 8; ++i) rcx[i] =
+		0x3F800000u |                          // 1.0f mask.
+		((seed >> ((i / 4) * 16)) & 0xFFFFu) | // lower or upper half of the seed.
+		(((seed >> (4 * i)) & 0xF) << 16);     // remaining nibble.
+
+}
+
+uint32_t vrnd_generate(uint32_t *rcx)
+{
+	// The actual RNG state appears to be 5 parts
+	// (32-bit each) stored into the registers as follows:
+	uint32_t A=(rcx[0] & 0xFFFFu) | (rcx[4] << 16);
+	uint32_t B=(rcx[1] & 0xFFFFu) | (rcx[5] << 16);
+	uint32_t C=(rcx[2] & 0xFFFFu) | (rcx[6] << 16);
+	uint32_t D=(rcx[3] & 0xFFFFu) | (rcx[7] << 16);
+	uint32_t E=(((rcx[0] >> 16) & 0xF) <<  0)|
+	           (((rcx[1] >> 16) & 0xF) <<  4)|
+	           (((rcx[2] >> 16) & 0xF) <<  8)|
+	           (((rcx[3] >> 16) & 0xF) << 12)|
+	           (((rcx[4] >> 16) & 0xF) << 16)|
+	           (((rcx[5] >> 16) & 0xF) << 20)|
+	           (((rcx[6] >> 16) & 0xF) << 24)|
+	           (((rcx[7] >> 16) & 0xF) << 28);
+	// Update.
+	// LCG with classic parameters.
+	A = 69069u * A + 1u; // NOTE: decimal constants.
+	// Xorshift, with classic parameters. Algorithm "xor" from p. 4 of Marsaglia, "Xorshift RNGs".
+	B ^= B << 13;
+	B ^= B >> 17;
+	B ^= B <<  5;
+	// Pell sequence, with additional increment.
+	uint32_t t= 2u * D + C + E;
+	C = D;
+	D = t;
+	// NOTE: the details of how E-part is set are
+	// largerly guesswork at the moment. This does
+	// match variety of test data.
+	auto addition_overflows=[](uint32_t x, uint32_t y) -> bool {
+		return x + y < x;
+	};
+	E = addition_overflows(C + E, C) &&
+	    addition_overflows(C + E, D) &&
+	    addition_overflows(C + E, C + D + E) &&
+	    addition_overflows(C + E, C + D);
+	// Store.
+	rcx[0] = 0x3F800000u | (((E >>  0) & 0xF) << 16) | (A & 0xFFFFu);
+	rcx[1] = 0x3F800000u | (((E >>  4) & 0xF) << 16) | (B & 0xFFFFu);
+	rcx[2] = 0x3F800000u | (((E >>  8) & 0xF) << 16) | (C & 0xFFFFu);
+	rcx[3] = 0x3F800000u | (((E >> 12) & 0xF) << 16) | (D & 0xFFFFu);
+	rcx[4] = 0x3F800000u | (((E >> 16) & 0xF) << 16) | (A >> 16);
+	rcx[5] = 0x3F800000u | (((E >> 20) & 0xF) << 16) | (B >> 16);
+	rcx[6] = 0x3F800000u | (((E >> 24) & 0xF) << 16) | (C >> 16);
+	rcx[7] = 0x3F800000u | (((E >> 28) & 0xF) << 16) | (D >> 16);
+	// Return value.
+	return A + B + D;
+}
+
+//==============================================================================
 // The code below attempts to exactly match the output of
 // several PSP's VFPU functions. For the sake of
 // making lookup tables smaller the code is

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -68,6 +68,10 @@ extern float vfpu_rexp2(float);
 extern float vfpu_log2(float);
 extern float vfpu_rcp(float);
 
+extern void vrnd_init_default(uint32_t *rcx);
+extern void vrnd_init(uint32_t seed, uint32_t *rcx);
+extern uint32_t vrnd_generate(uint32_t *rcx);
+
 inline uint32_t get_uexp(uint32_t x) {
 	return (x >> 23) & 0xFF;
 }


### PR DESCRIPTION
The vrnd stuff from https://github.com/hrydgard/ppsspp/issues/16946 (see https://github.com/hrydgard/ppsspp/issues/16946#issuecomment-1467261209 onwards).

Still needs more testing, just putting it there to get overall comments.
Only tested in couple of games (including Ridge Racer, which is known to use vrnd). Seems to work fine, with no visual differences.
Bumps save state version for `MIPSState`, so save states are probably incompatible.