### PR TITLE
Post-processing: Fix using limited UV ranges when there's a single upscaling filter in the chain.

### DIFF
--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -287,6 +287,8 @@ public:
 	}
 
 	GLRFramebuffer *CreateFramebuffer(int width, int height, bool z_stencil, const char *tag) {
+		_dbg_assert_(width > 0 && height > 0 && tag != nullptr);
+
 		GLRInitStep &step = initSteps_.push_uninitialized();
 		step.stepType = GLRInitStepType::CREATE_FRAMEBUFFER;
 		step.create_framebuffer.framebuffer = new GLRFramebuffer(caps_, width, height, z_stencil, tag);

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -668,7 +668,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 
 	float finalU0 = u0, finalU1 = u1, finalV0 = v0, finalV1 = v1;
 
-	if (usePostShader) {
+	if (usePostShader && !(isFinalAtOutputResolution && postShaderPipelines_.size() == 1)) {
 		// The final blit will thus use the full texture.
 		finalU0 = 0.0f;
 		finalV0 = 0.0f;

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -293,6 +293,8 @@ bool PresentationCommon::UpdatePostShader() {
 		int w = usePreviousAtOutputResolution ? pixelWidth_ : renderWidth_;
 		int h = usePreviousAtOutputResolution ? pixelHeight_ : renderHeight_;
 
+		_dbg_assert_(w > 0 && h > 0);
+
 		static constexpr int FRAMES = 2;
 		previousFramebuffers_.resize(FRAMES);
 		previousIndex_ = 0;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -212,32 +212,6 @@ void GPUCommon::NotifyDisplayResized() {
 	displayResized_ = true;
 }
 
-// Called once per frame. Might also get called during the pause screen
-// if "transparent".
-void GPUCommon::CheckConfigChanged() {
-	if (configChanged_) {
-		ClearCacheNextFrame();
-		gstate_c.SetUseFlags(CheckGPUFeatures());
-		drawEngineCommon_->NotifyConfigChanged();
-		textureCache_->NotifyConfigChanged();
-		framebufferManager_->NotifyConfigChanged();
-		BuildReportingInfo();
-		configChanged_ = false;
-	}
-
-	// Check needed when running tests.
-	if (framebufferManager_) {
-		framebufferManager_->CheckPostShaders();
-	}
-}
-
-void GPUCommon::CheckDisplayResized() {
-	if (displayResized_) {
-		framebufferManager_->NotifyDisplayResized();
-		displayResized_ = false;
-	}
-}
-
 void GPUCommon::DumpNextFrame() {
 	dumpNextFrame_ = true;
 }

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -76,9 +76,6 @@ public:
 	}
 	virtual u32 CheckGPUFeatures() const = 0;
 
-	void CheckDisplayResized() override;
-	void CheckConfigChanged() override;
-
 	virtual void UpdateCmdInfo() = 0;
 
 	bool IsReady() override {

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -401,6 +401,32 @@ GPUCommonHW::~GPUCommonHW() {
 	delete shaderManager_;
 }
 
+// Called once per frame. Might also get called during the pause screen
+// if "transparent".
+void GPUCommonHW::CheckConfigChanged() {
+	if (configChanged_) {
+		ClearCacheNextFrame();
+		gstate_c.SetUseFlags(CheckGPUFeatures());
+		drawEngineCommon_->NotifyConfigChanged();
+		textureCache_->NotifyConfigChanged();
+		framebufferManager_->NotifyConfigChanged();
+		BuildReportingInfo();
+		configChanged_ = false;
+	}
+
+	// Check needed when running tests.
+	if (framebufferManager_) {
+		framebufferManager_->CheckPostShaders();
+	}
+}
+
+void GPUCommonHW::CheckDisplayResized() {
+	if (displayResized_) {
+		framebufferManager_->NotifyDisplayResized();
+		displayResized_ = false;
+	}
+}
+
 void GPUCommonHW::CheckRenderResized() {
 	if (renderResized_) {
 		framebufferManager_->NotifyRenderResized(msaaLevel_);

--- a/GPU/GPUCommonHW.h
+++ b/GPU/GPUCommonHW.h
@@ -83,7 +83,10 @@ protected:
 	void BuildReportingInfo() override;
 	void UpdateMSAALevel(Draw::DrawContext *draw) override;
 
+	void CheckDisplayResized() override;
 	void CheckRenderResized() override;
+	void CheckConfigChanged() override;
+
 	u32 CheckGPUFeaturesLate(u32 features) const;
 
 	int msaaLevel_ = 0;

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -730,7 +730,18 @@ void SoftGPU::NotifyDisplayResized() {
 	}
 }
 
-void SoftGPU::NotifyConfigChanged() {}
+void SoftGPU::NotifyConfigChanged() {
+	configChanged_ = true;
+}
+
+void SoftGPU::CheckConfigChanged() {
+	if (configChanged_) {
+		drawEngineCommon_->NotifyConfigChanged();
+		BuildReportingInfo();
+		presentation_->UpdatePostShader();
+		configChanged_ = false;
+	}
+}
 
 void SoftGPU::FastRunLoop(DisplayList &list) {
 	PROFILE_THIS_SCOPE("soft_runloop");

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -449,11 +449,13 @@ SoftGPU::SoftGPU(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	if (gfxCtx && draw) {
 		presentation_ = new PresentationCommon(draw_);
 		presentation_->SetLanguage(draw_->GetShaderLanguageDesc().shaderLanguage);
+		presentation_->UpdateDisplaySize(PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
+		presentation_->UpdateRenderSize(PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
 	}
 
 	NotifyConfigChanged();
-	NotifyRenderResized();
 	NotifyDisplayResized();
+	NotifyRenderResized();
 }
 
 void SoftGPU::DeviceLost() {
@@ -723,22 +725,25 @@ void SoftGPU::NotifyRenderResized() {
 }
 
 void SoftGPU::NotifyDisplayResized() {
-	if (presentation_) {
+	displayResized_ = true;
+}
+
+void SoftGPU::CheckDisplayResized() {
+	if (displayResized_ && presentation_) {
 		presentation_->UpdateDisplaySize(PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
 		presentation_->UpdateRenderSize(PSP_CoreParameter().renderWidth, PSP_CoreParameter().renderHeight);
 		presentation_->UpdatePostShader();
+		displayResized_ = false;
 	}
-}
-
-void SoftGPU::NotifyConfigChanged() {
-	configChanged_ = true;
 }
 
 void SoftGPU::CheckConfigChanged() {
 	if (configChanged_) {
 		drawEngineCommon_->NotifyConfigChanged();
 		BuildReportingInfo();
-		presentation_->UpdatePostShader();
+		if (presentation_) {
+			presentation_->UpdatePostShader();
+		}
 		configChanged_ = false;
 	}
 }

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -152,8 +152,8 @@ public:
 
 	void NotifyRenderResized() override;
 	void NotifyDisplayResized() override;
-	void NotifyConfigChanged() override;
 
+	void CheckDisplayResized() override;
 	void CheckConfigChanged() override;
 
 	void GetReportingInfo(std::string &primaryInfo, std::string &fullInfo) override {

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -154,6 +154,8 @@ public:
 	void NotifyDisplayResized() override;
 	void NotifyConfigChanged() override;
 
+	void CheckConfigChanged() override;
+
 	void GetReportingInfo(std::string &primaryInfo, std::string &fullInfo) override {
 		primaryInfo = "Software";
 		fullInfo = "Software";


### PR DESCRIPTION
Can't force the final blit to use the full range if it's the only blit, and that blit needs to use the subrange.

Fixes #17499

Additionally, added checking for post shader changes to softgpu, fixing #17511.