### PR TITLE
Input event and device enums

### DIFF
--- a/Common/Input/InputState.cpp
+++ b/Common/Input/InputState.cpp
@@ -39,7 +39,7 @@ std::vector<InputMapping> confirmKeys;
 std::vector<InputMapping> cancelKeys;
 std::vector<InputMapping> tabLeftKeys;
 std::vector<InputMapping> tabRightKeys;
-static std::unordered_map<int, int> uiFlipAnalogY;
+static std::unordered_map<InputDeviceID, int> uiFlipAnalogY;
 
 static void AppendKeys(std::vector<InputMapping> &keys, const std::vector<InputMapping> &newKeys) {
 	for (auto iter = newKeys.begin(); iter != newKeys.end(); ++iter) {
@@ -69,11 +69,11 @@ void SetTabLeftRightKeys(const std::vector<InputMapping> &tabLeft, const std::ve
 	tabRightKeys = tabRight;
 }
 
-void SetAnalogFlipY(std::unordered_map<int, int> flipYByDeviceId) {
+void SetAnalogFlipY(std::unordered_map<InputDeviceID, int> flipYByDeviceId) {
 	uiFlipAnalogY = flipYByDeviceId;
 }
 
-int GetAnalogYDirection(int deviceId) {
+int GetAnalogYDirection(InputDeviceID deviceId) {
 	auto configured = uiFlipAnalogY.find(deviceId);
 	if (configured != uiFlipAnalogY.end())
 		return configured->second;
@@ -84,7 +84,7 @@ int GetAnalogYDirection(int deviceId) {
 InputMapping InputMapping::FromConfigString(const std::string &str) {
 	std::vector<std::string> parts;
 	SplitString(str, '-', parts);
-	int deviceId = atoi(parts[0].c_str());
+	InputDeviceID deviceId = (InputDeviceID)(atoi(parts[0].c_str()));
 	int keyCode = atoi(parts[1].c_str());
 
 	InputMapping mapping;
@@ -94,15 +94,15 @@ InputMapping InputMapping::FromConfigString(const std::string &str) {
 }
 
 std::string InputMapping::ToConfigString() const {
-	return StringFromFormat("%d-%d", deviceId, keyCode);
+	return StringFromFormat("%d-%d", (int)deviceId, keyCode);
 }
 
 void InputMapping::FormatDebug(char *buffer, size_t bufSize) const {
 	if (IsAxis()) {
 		int direction;
 		int axis = Axis(&direction);
-		snprintf(buffer, bufSize, "Device: %d Axis: %d (%d)", deviceId, axis, direction);
+		snprintf(buffer, bufSize, "Device: %d Axis: %d (%d)", (int)deviceId, axis, direction);
 	} else {
-		snprintf(buffer, bufSize, "Device: %d Key: %d", deviceId, keyCode);
+		snprintf(buffer, bufSize, "Device: %d Key: %d", (int)deviceId, keyCode);
 	}
 }

--- a/Common/Input/InputState.cpp
+++ b/Common/Input/InputState.cpp
@@ -85,7 +85,7 @@ InputMapping InputMapping::FromConfigString(const std::string &str) {
 	std::vector<std::string> parts;
 	SplitString(str, '-', parts);
 	InputDeviceID deviceId = (InputDeviceID)(atoi(parts[0].c_str()));
-	int keyCode = atoi(parts[1].c_str());
+	InputKeyCode keyCode = (InputKeyCode)atoi(parts[1].c_str());
 
 	InputMapping mapping;
 	mapping.deviceId = deviceId;

--- a/Common/Input/InputState.h
+++ b/Common/Input/InputState.h
@@ -168,6 +168,7 @@ enum {
 struct KeyInput {
 	KeyInput() {}
 	KeyInput(InputDeviceID devId, InputKeyCode code, int fl) : deviceId(devId), keyCode(code), flags(fl) {}
+	KeyInput(InputDeviceID devId, int unicode) : deviceId(devId), unicodeChar(unicode), flags(KEY_CHAR) {}
 	InputDeviceID deviceId;
 	union {
 		InputKeyCode keyCode;  // Android keycodes are the canonical keycodes, everyone else map to them.

--- a/Common/Input/InputState.h
+++ b/Common/Input/InputState.h
@@ -12,7 +12,7 @@
 
 // Default device IDs
 
-enum {
+enum InputDeviceID {
 	DEVICE_ID_ANY = -1,  // Represents any device ID
 	DEVICE_ID_DEFAULT = 0,  // Old Android
 	DEVICE_ID_KEYBOARD = 1,  // PC keyboard, android keyboards
@@ -38,42 +38,14 @@ enum {
 	DEVICE_ID_TOUCH = 42,
 };
 
+inline InputDeviceID operator +(InputDeviceID deviceID, int addend) {
+	return (InputDeviceID)((int)deviceID + addend);
+}
+
 //number of contiguous generic joypad IDs
 const int MAX_NUM_PADS = 10;
 
 const char *GetDeviceName(int deviceId);
-
-enum {
-	PAD_BUTTON_A = 1,
-	PAD_BUTTON_B = 2,
-	PAD_BUTTON_X = 4,
-	PAD_BUTTON_Y = 8,
-	PAD_BUTTON_LBUMPER = 16,
-	PAD_BUTTON_RBUMPER = 32,
-	PAD_BUTTON_START = 64,
-	PAD_BUTTON_SELECT = 128,
-	PAD_BUTTON_UP = 256,
-	PAD_BUTTON_DOWN = 512,
-	PAD_BUTTON_LEFT = 1024,
-	PAD_BUTTON_RIGHT = 2048,
-
-	PAD_BUTTON_MENU = 4096,
-	PAD_BUTTON_BACK = 8192,
-
-	// For Qt
-	PAD_BUTTON_JOY_UP = 1<<14,
-	PAD_BUTTON_JOY_DOWN = 1<<15,
-	PAD_BUTTON_JOY_LEFT = 1<<16,
-	PAD_BUTTON_JOY_RIGHT = 1<<17,
-
-	PAD_BUTTON_LEFT_THUMB = 1 << 18,   // Click left thumb stick on X360
-	PAD_BUTTON_RIGHT_THUMB = 1 << 19,   // Click right thumb stick on X360
-
-	PAD_BUTTON_LEFT_TRIGGER = 1 << 21,   // Click left thumb stick on X360
-	PAD_BUTTON_RIGHT_TRIGGER = 1 << 22,   // Click left thumb stick on X360
-
-	PAD_BUTTON_FASTFORWARD = 1 << 20, // Click Tab to unthrottle
-};
 
 #ifndef MAX_KEYQUEUESIZE
 #define MAX_KEYQUEUESIZE 20
@@ -98,18 +70,18 @@ private:
 		return AXIS_BIND_NKCODE_START + axisId * 2 + (direction < 0 ? 1 : 0);
 	}
 public:
-	InputMapping() : deviceId(0), keyCode(0) {}
+	InputMapping() : deviceId(DEVICE_ID_DEFAULT), keyCode(0) {}
 	// From a key mapping
-	InputMapping(int _deviceId, int key) : deviceId(_deviceId), keyCode(key) {}
+	InputMapping(InputDeviceID _deviceId, int key) : deviceId(_deviceId), keyCode(key) {}
 	// From an axis
-	InputMapping(int _deviceId, int axis, int direction) : deviceId(_deviceId), keyCode(TranslateKeyCodeFromAxis(axis, direction)) {
+	InputMapping(InputDeviceID _deviceId, int axis, int direction) : deviceId(_deviceId), keyCode(TranslateKeyCodeFromAxis(axis, direction)) {
 		_dbg_assert_(direction != 0);
 	}
 
 	static InputMapping FromConfigString(const std::string &str);
 	std::string ToConfigString() const;
 
-	int deviceId;
+	InputDeviceID deviceId;
 	int keyCode;  // Can also represent an axis with direction, if encoded properly.
 
 	bool IsAxis() const {
@@ -195,14 +167,14 @@ enum {
 
 struct KeyInput {
 	KeyInput() {}
-	KeyInput(int devId, int code, int fl) : deviceId(devId), keyCode(code), flags(fl) {}
-	int deviceId;
+	KeyInput(InputDeviceID devId, int code, int fl) : deviceId(devId), keyCode(code), flags(fl) {}
+	InputDeviceID deviceId;
 	int keyCode;  // Android keycodes are the canonical keycodes, everyone else map to them.
 	int flags;
 };
 
 struct AxisInput {
-	int deviceId;
+	InputDeviceID deviceId;
 	int axisId;  // Android axis Ids are the canonical ones.
 	float value;
 };
@@ -219,5 +191,5 @@ void SetConfirmCancelKeys(const std::vector<InputMapping> &confirm, const std::v
 void SetTabLeftRightKeys(const std::vector<InputMapping> &tabLeft, const std::vector<InputMapping> &tabRight);
 
 // 0 means unknown (attempt autodetect), -1 means flip, 1 means original direction.
-void SetAnalogFlipY(std::unordered_map<int, int> flipYByDeviceId);
-int GetAnalogYDirection(int deviceId);
+void SetAnalogFlipY(std::unordered_map<InputDeviceID, int> flipYByDeviceId);
+int GetAnalogYDirection(InputDeviceID deviceId);

--- a/Common/Input/InputState.h
+++ b/Common/Input/InputState.h
@@ -167,15 +167,18 @@ enum {
 
 struct KeyInput {
 	KeyInput() {}
-	KeyInput(InputDeviceID devId, int code, int fl) : deviceId(devId), keyCode(code), flags(fl) {}
+	KeyInput(InputDeviceID devId, InputKeyCode code, int fl) : deviceId(devId), keyCode(code), flags(fl) {}
 	InputDeviceID deviceId;
-	int keyCode;  // Android keycodes are the canonical keycodes, everyone else map to them.
+	union {
+		InputKeyCode keyCode;  // Android keycodes are the canonical keycodes, everyone else map to them.
+		int unicodeChar;  // for KEY_CHAR
+	};
 	int flags;
 };
 
 struct AxisInput {
 	InputDeviceID deviceId;
-	InputAxis axisId;  // Android axis Ids are the canonical ones.
+	InputAxis axisId;
 	float value;
 };
 

--- a/Common/Input/InputState.h
+++ b/Common/Input/InputState.h
@@ -175,7 +175,7 @@ struct KeyInput {
 
 struct AxisInput {
 	InputDeviceID deviceId;
-	int axisId;  // Android axis Ids are the canonical ones.
+	InputAxis axisId;  // Android axis Ids are the canonical ones.
 	float value;
 };
 

--- a/Common/Input/KeyCodes.h
+++ b/Common/Input/KeyCodes.h
@@ -1,6 +1,6 @@
 #pragma once
 
-typedef enum _keycode_t {
+enum InputKeyCode {
 	NKCODE_BUTTON_CROSS = 23, // trackpad or X button(Xperia Play) is pressed
 	NKCODE_BUTTON_CROSS_PS3 = 96, // PS3 X button is pressed
 	NKCODE_BUTTON_CIRCLE = 1004, // Special custom keycode generated from 'O' button by our java code. Or 'O' button if Alt is pressed (TODO)
@@ -259,9 +259,9 @@ typedef enum _keycode_t {
 	NKCODE_EXT_ROTATION_RIGHT = 1114,
 
 	NKCODE_MAX
-} keycode_t;
+};
 
-enum AndroidJoystickAxis {
+enum InputAxis {
 	// Field descriptor #15 I
 	JOYSTICK_AXIS_X = 0,
 	JOYSTICK_AXIS_Y = 1,

--- a/Common/Input/KeyCodes.h
+++ b/Common/Input/KeyCodes.h
@@ -1,5 +1,6 @@
 #pragma once
 
+// These mostly match Android keycodes.
 enum InputKeyCode {
 	NKCODE_BUTTON_CROSS = 23, // trackpad or X button(Xperia Play) is pressed
 	NKCODE_BUTTON_CROSS_PS3 = 96, // PS3 X button is pressed
@@ -261,6 +262,7 @@ enum InputKeyCode {
 	NKCODE_MAX
 };
 
+// These mostly match Android axis IDs.
 enum InputAxis {
 	// Field descriptor #15 I
 	JOYSTICK_AXIS_X = 0,

--- a/Common/UI/Root.cpp
+++ b/Common/UI/Root.cpp
@@ -318,7 +318,7 @@ bool AxisEvent(const AxisInput &axis, ViewGroup *root) {
 
 	// Cannot use the remapper since this is for the menu, so we provide our own
 	// axis->button emulation here.
-	auto GenerateKeyFromAxis = [&](DirState old, DirState cur, keycode_t neg_key, keycode_t pos_key) {
+	auto GenerateKeyFromAxis = [&](DirState old, DirState cur, InputKeyCode neg_key, InputKeyCode pos_key) {
 		if (old == cur)
 			return;
 		if (old == DirState::POS) {

--- a/Common/UI/Root.cpp
+++ b/Common/UI/Root.cpp
@@ -175,7 +175,7 @@ static int frameCount;
 // completely broken input where the original keypresses have deviceId = 10 and the repeats
 // have deviceId = 0.
 struct HeldKey {
-	int key;
+	InputKeyCode key;
 	InputDeviceID deviceId;
 	double triggerTime;
 

--- a/Common/UI/Root.cpp
+++ b/Common/UI/Root.cpp
@@ -250,6 +250,8 @@ bool KeyEvent(const KeyInput &key, ViewGroup *root) {
 	case NKCODE_VOLUME_MUTE:
 		retval = false;
 		break;
+	default:
+		break;
 	}
 
 	return retval;

--- a/Common/UI/Root.cpp
+++ b/Common/UI/Root.cpp
@@ -176,7 +176,7 @@ static int frameCount;
 // have deviceId = 0.
 struct HeldKey {
 	int key;
-	int deviceId;
+	InputDeviceID deviceId;
 	double triggerTime;
 
 	// Ignores startTime

--- a/Common/UI/ScrollView.cpp
+++ b/Common/UI/ScrollView.cpp
@@ -112,6 +112,8 @@ bool ScrollView::Key(const KeyInput &input) {
 	case DEVICE_ID_XR_CONTROLLER_RIGHT:
 		scrollSpeed = 50;
 		break;
+	default:
+		break;
 	}
 
 	if (input.flags & KEY_DOWN) {
@@ -126,6 +128,8 @@ bool ScrollView::Key(const KeyInput &input) {
 			break;
 		case NKCODE_EXT_MOUSEWHEEL_DOWN:
 			ScrollRelative(scrollSpeed);
+			break;
+		default:
 			break;
 		}
 	}

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -349,7 +349,7 @@ bool Clickable::Key(const KeyInput &key) {
 				down_ = false;
 				ret = true;
 			}
-		} else if (IsEscapeKey(key)) {
+		} else if (down_ && IsEscapeKey(key)) {
 			down_ = false;
 		}
 	}

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -1190,6 +1190,8 @@ bool TextEdit::Key(const KeyInput &input) {
 		case NKCODE_BACK:
 		case NKCODE_ESCAPE:
 			return false;
+		default:
+			break;
 		}
 
 		if (ctrlDown_) {
@@ -1227,6 +1229,8 @@ bool TextEdit::Key(const KeyInput &input) {
 			case NKCODE_Z:
 				text_ = undo_;
 				break;
+			default:
+				break;
 			}
 		}
 
@@ -1243,6 +1247,8 @@ bool TextEdit::Key(const KeyInput &input) {
 		case NKCODE_CTRL_LEFT:
 		case NKCODE_CTRL_RIGHT:
 			ctrlDown_ = false;
+			break;
+		default:
 			break;
 		}
 	}

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -1369,7 +1369,7 @@ bool Slider::Key(const KeyInput &input) {
 	}
 }
 
-bool Slider::ApplyKey(int keyCode) {
+bool Slider::ApplyKey(InputKeyCode keyCode) {
 	switch (keyCode) {
 	case NKCODE_DPAD_LEFT:
 	case NKCODE_MINUS:
@@ -1497,7 +1497,7 @@ bool SliderFloat::Key(const KeyInput &input) {
 	}
 }
 
-bool SliderFloat::ApplyKey(int keyCode) {
+bool SliderFloat::ApplyKey(InputKeyCode keyCode) {
 	switch (keyCode) {
 	case NKCODE_DPAD_LEFT:
 	case NKCODE_MINUS:

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -19,6 +19,7 @@
 #include "Common/Math/lin/matrix4x4.h"
 #include "Common/Math/math_util.h"
 #include "Common/Math/geom2d.h"
+#include "Common/Input/KeyCodes.h"
 
 #include "Common/Common.h"
 
@@ -619,7 +620,7 @@ public:
 	Event OnChange;
 
 private:
-	bool ApplyKey(int keyCode);
+	bool ApplyKey(InputKeyCode keyCode);
 
 	int *value_;
 	bool showPercent_;
@@ -629,7 +630,7 @@ private:
 	float paddingRight_;
 	int step_;
 	int repeat_ = 0;
-	int repeatCode_ = 0;
+	InputKeyCode repeatCode_ = NKCODE_UNKNOWN;
 };
 
 class SliderFloat : public Clickable {
@@ -649,7 +650,7 @@ public:
 	Event OnChange;
 
 private:
-	bool ApplyKey(int keyCode);
+	bool ApplyKey(InputKeyCode keyCode);
 
 	float *value_;
 	float minValue_;
@@ -657,7 +658,7 @@ private:
 	float paddingLeft_;
 	float paddingRight_;
 	int repeat_;
-	int repeatCode_ = 0;
+	InputKeyCode repeatCode_ = NKCODE_UNKNOWN;
 };
 
 // Basic button that modifies a bitfield based on the pressed status. Supports multitouch.

--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -46,7 +46,7 @@ enum VRMirroring {
 
 static VRAppMode appMode = VR_MENU_MODE;
 static std::map<int, std::map<int, float> > pspAxis;
-static std::map<int, bool> pspKeys;
+static std::map<int, bool> pspKeys;  // key can be virtual, so not using the enum.
 
 static int vr3DGeometryCount = 0;
 static long vrCompat[VR_COMPAT_MAX];
@@ -69,11 +69,11 @@ VR button mapping
 
 struct ButtonMapping {
 	ovrButton ovr;
-	int keycode;
+	InputKeyCode keycode;
 	bool pressed;
 	int repeat;
 
-	ButtonMapping(int keycode, ovrButton ovr) {
+	ButtonMapping(InputKeyCode keycode, ovrButton ovr) {
 		this->keycode = keycode;
 		this->ovr = ovr;
 		pressed = false;
@@ -106,7 +106,7 @@ static std::vector<ButtonMapping> rightControllerMapping = {
 		ButtonMapping(NKCODE_ENTER, ovrButton_Trigger),
 };
 
-static const int controllerIds[] = {DEVICE_ID_XR_CONTROLLER_LEFT, DEVICE_ID_XR_CONTROLLER_RIGHT};
+static const InputDeviceID controllerIds[] = {DEVICE_ID_XR_CONTROLLER_LEFT, DEVICE_ID_XR_CONTROLLER_RIGHT};
 static std::vector<ButtonMapping> controllerMapping[2] = {
 		leftControllerMapping,
 		rightControllerMapping
@@ -223,7 +223,7 @@ void SetVRAppMode(VRAppMode mode) {
 
 void UpdateVRInput(bool haptics, float dp_xscale, float dp_yscale) {
 	//axis
-	if (pspKeys[VIRTKEY_VR_CAMERA_ADJUST]) {
+	if (pspKeys[(int)VIRTKEY_VR_CAMERA_ADJUST]) {
 		AxisInput axis = {};
 		for (int j = 0; j < 2; j++) {
 			XrVector2f joystick = IN_VRGetJoystickState(j);
@@ -515,7 +515,7 @@ bool UpdateVRKeys(const KeyInput &key) {
 		pspKeys[VIRTKEY_VR_CAMERA_ADJUST] = false;
 		for (auto& pspKey : pspKeys) {
 			if (pspKey.second) {
-				keyUp.keyCode = pspKey.first;
+				keyUp.keyCode = (InputKeyCode)pspKey.first;
 				NativeKey(keyUp);
 			}
 		}

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -441,6 +441,7 @@ const KeyMap_IntStrPair psp_button_names[] = {
 	{CTRL_NOTE, "Note"},
 };
 
+// key here can be other things than InputKeyCode.
 static std::string FindName(int key, const KeyMap_IntStrPair list[], size_t size) {
 	for (size_t i = 0; i < size; i++) {
 		if (list[i].key == key)
@@ -449,7 +450,7 @@ static std::string FindName(int key, const KeyMap_IntStrPair list[], size_t size
 	return StringFromFormat("%02x?", key);
 }
 
-std::string GetKeyName(int keyCode) {
+std::string GetKeyName(InputKeyCode keyCode) {
 	return FindName(keyCode, key_names, ARRAY_SIZE(key_names));
 }
 

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -45,8 +45,8 @@ KeyMapping g_controllerMap;
 // Incremented on modification, so we know when to update menus.
 int g_controllerMapGeneration = 0;
 std::set<std::string> g_seenPads;
-std::map<int, std::string> g_padNames;
-std::set<int> g_seenDeviceIds;
+std::map<InputDeviceID, std::string> g_padNames;
+std::set<InputDeviceID> g_seenDeviceIds;
 
 // Utility for UI navigation
 void SingleInputMappingFromPspButton(int btn, std::vector<InputMapping> *mappings, bool ignoreMouse) {
@@ -120,8 +120,8 @@ void UpdateNativeMenuKeys() {
 	SetConfirmCancelKeys(confirmKeys, cancelKeys);
 	SetTabLeftRightKeys(tabLeft, tabRight);
 
-	std::unordered_map<int, int> flipYByDeviceId;
-	for (int deviceId : g_seenDeviceIds) {
+	std::unordered_map<InputDeviceID, int> flipYByDeviceId;
+	for (InputDeviceID deviceId : g_seenDeviceIds) {
 		auto analogs = MappedAxesForDevice(deviceId);
 		flipYByDeviceId[deviceId] = analogs.leftY.direction;
 	}
@@ -532,7 +532,7 @@ bool PspButtonHasMappings(int btn) {
 	return !iter->second.empty();
 }
 
-MappedAnalogAxes MappedAxesForDevice(int deviceId) {
+MappedAnalogAxes MappedAxesForDevice(InputDeviceID deviceId) {
 	MappedAnalogAxes result{};
 
 	// Find the axisId mapped for a specific virtual button.
@@ -578,7 +578,7 @@ void RemoveButtonMapping(int btn) {
 	}
 }
 
-bool IsKeyMapped(int device, int key) {
+bool IsKeyMapped(InputDeviceID device, int key) {
 	std::lock_guard<std::recursive_mutex> guard(g_controllerMapLock);
 	for (auto &iter : g_controllerMap) {
 		for (auto &mappedKey : iter.second) {
@@ -778,7 +778,7 @@ bool HasBuiltinController(const std::string &name) {
 	return IsOuya(name) || IsXperiaPlay(name) || IsNvidiaShield(name) || IsMOQII7S(name) || IsRetroid(name);
 }
 
-void NotifyPadConnected(int deviceId, const std::string &name) {
+void NotifyPadConnected(InputDeviceID deviceId, const std::string &name) {
 	g_seenPads.insert(name);
 	g_padNames[deviceId] = name;
 }
@@ -814,7 +814,7 @@ const std::set<std::string> &GetSeenPads() {
 	return g_seenPads;
 }
 
-std::string PadName(int deviceId) {
+std::string PadName(InputDeviceID deviceId) {
 	auto it = g_padNames.find(deviceId);
 	if (it != g_padNames.end())
 		return it->second;

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -164,7 +164,7 @@ namespace KeyMap {
 	};
 
 	// Use if you need to display the textual name
-	std::string GetKeyName(int keyCode);
+	std::string GetKeyName(InputKeyCode keyCode);
 	std::string GetKeyOrAxisName(const InputMapping &mapping);
 	std::string GetAxisName(int axisId);
 	std::string GetPspButtonName(int btn);

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -155,7 +155,7 @@ namespace KeyMap {
 	// Once the multimappings are inserted here, they must not be empty.
 	// If one would be, delete the whole entry from the map instead.
 	// This is automatically handled by SetInputMapping.
-	extern std::set<int> g_seenDeviceIds;
+	extern std::set<InputDeviceID> g_seenDeviceIds;
 	extern int g_controllerMapGeneration;
 	// Key & Button names
 	struct KeyMap_IntStrPair {
@@ -189,7 +189,7 @@ namespace KeyMap {
 	// Return false if bind was a duplicate and got removed
 	bool ReplaceSingleKeyMapping(int btn, int index, MultiInputMapping key);
 
-	MappedAnalogAxes MappedAxesForDevice(int deviceId);
+	MappedAnalogAxes MappedAxesForDevice(InputDeviceID deviceId);
 
 	void LoadFromIni(IniFile &iniFile);
 	void SaveToIni(IniFile &iniFile);
@@ -202,7 +202,7 @@ namespace KeyMap {
 
 	void UpdateNativeMenuKeys();
 
-	void NotifyPadConnected(int deviceId, const std::string &name);
+	void NotifyPadConnected(InputDeviceID deviceId, const std::string &name);
 	bool IsNvidiaShield(const std::string &name);
 	bool IsNvidiaShieldTV(const std::string &name);
 	bool IsXperiaPlay(const std::string &name);
@@ -212,10 +212,10 @@ namespace KeyMap {
 	bool HasBuiltinController(const std::string &name);
 
 	const std::set<std::string> &GetSeenPads();
-	std::string PadName(int deviceId);
+	std::string PadName(InputDeviceID deviceId);
 	void AutoConfForPad(const std::string &name);
 
-	bool IsKeyMapped(int device, int key);
+	bool IsKeyMapped(InputDeviceID device, int key);
 
 	bool HasChanged(int &prevGeneration);
 }

--- a/Core/KeyMapDefaults.cpp
+++ b/Core/KeyMapDefaults.cpp
@@ -338,7 +338,7 @@ static const DefMappingStruct defaultVRRightController[] = {
 	{VIRTKEY_AXIS_X_MAX, NKCODE_DPAD_RIGHT},
 };
 
-static void SetDefaultKeyMap(int deviceId, const DefMappingStruct *array, size_t count, bool replace) {
+static void SetDefaultKeyMap(InputDeviceID deviceId, const DefMappingStruct *array, size_t count, bool replace) {
 	for (size_t i = 0; i < count; i++) {
 		if (array[i].direction == 0)
 			SetInputMapping(array[i].pspKey, MultiInputMapping(InputMapping(deviceId, array[i].keyOrAxis)), replace);

--- a/Qt/NKCodeFromQt.h
+++ b/Qt/NKCodeFromQt.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "Common/Data/Collections/ConstMap.h"
+#include "Common/Input/KeyCodes.h"
 #include <map>
 
 // TODO: Add any missing keys
-static const std::map<int, int> KeyMapRawQttoNative = InitConstMap<int, int>
+static const std::map<int, InputKeyCode> KeyMapRawQttoNative = InitConstMap<int, InputKeyCode>
 	(Qt::Key_P, NKCODE_P)
 	(Qt::Key_O, NKCODE_O)
 	(Qt::Key_I, NKCODE_I)

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -633,7 +633,7 @@ bool MainUI::event(QEvent *e) {
 		{
 			auto qtKeycode = ((QKeyEvent*)e)->key();
 			auto iter = KeyMapRawQttoNative.find(qtKeycode);
-			int nativeKeycode = 0;
+			InputKeyCode nativeKeycode = NKCODE_UNKNOWN;
 			if (iter != KeyMapRawQttoNative.end()) {
 				nativeKeycode = iter->second;
 				NativeKey(KeyInput(DEVICE_ID_KEYBOARD, nativeKeycode, KEY_DOWN));
@@ -652,8 +652,8 @@ bool MainUI::event(QEvent *e) {
 			default:
 				if (str.size()) {
 					int pos = 0;
-					int code = u8_nextchar(str.c_str(), &pos);
-					NativeKey(KeyInput(DEVICE_ID_KEYBOARD, code, KEY_CHAR));
+					int unicode = u8_nextchar(str.c_str(), &pos);
+					NativeKey(KeyInput(DEVICE_ID_KEYBOARD, unicode));
 				}
 				break;
 			}

--- a/SDL/NKCodeFromSDL.h
+++ b/SDL/NKCodeFromSDL.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "Common/Data/Collections/ConstMap.h"
+#include "Common/Input/KeyCodes.h"
 #include <map>
 
 // TODO: Add any missing keys
-static const std::map<int, int> KeyMapRawSDLtoNative = InitConstMap<int, int>
+static const std::map<int, InputKeyCode> KeyMapRawSDLtoNative = InitConstMap<int, InputKeyCode>
 	(SDLK_UNKNOWN, NKCODE_UNKNOWN)
 	(SDLK_p, NKCODE_P)
 	(SDLK_o, NKCODE_O)

--- a/SDL/SDLJoystick.cpp
+++ b/SDL/SDLJoystick.cpp
@@ -88,7 +88,8 @@ void SDLJoystick::setUpController(int deviceIndex) {
 			controllers.push_back(controller);
 			controllerDeviceMap[SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(controller))] = deviceIndex;
 			cout << "found control pad: " << SDL_GameControllerName(controller) << ", loading mapping: ";
-			KeyMap::NotifyPadConnected(deviceIndex, std::string(pszGUID) + ": " + SDL_GameControllerName(controller));
+			// NOTE: The case to InputDeviceID here is wrong, we should do some kind of lookup.
+			KeyMap::NotifyPadConnected((InputDeviceID)deviceIndex, std::string(pszGUID) + ": " + SDL_GameControllerName(controller));
 			auto mapping = SDL_GameControllerMapping(controller);
 			if (mapping == NULL) {
 				//cout << "FAILED" << endl;
@@ -182,7 +183,8 @@ void SDLJoystick::ProcessInput(SDL_Event &event){
 		break;
 	case SDL_CONTROLLERAXISMOTION:
 		AxisInput axis;
-		axis.axisId = event.caxis.axis;
+		// TODO: Can we really cast axis events like that? Do they match?
+		axis.axisId = (InputAxis)event.caxis.axis;
 		axis.value = event.caxis.value / 32767.0f;
 		if (axis.value > 1.0f) axis.value = 1.0f;
 		if (axis.value < -1.0f) axis.value = -1.0f;

--- a/SDL/SDLJoystick.cpp
+++ b/SDL/SDLJoystick.cpp
@@ -116,7 +116,7 @@ void SDLJoystick::registerEventHandler() {
 	registeredAsEventHandler = true;
 }
 
-keycode_t SDLJoystick::getKeycodeForButton(SDL_GameControllerButton button) {
+InputKeyCode SDLJoystick::getKeycodeForButton(SDL_GameControllerButton button) {
 	switch (button) {
 	case SDL_CONTROLLER_BUTTON_DPAD_UP:
 		return NKCODE_DPAD_UP;

--- a/SDL/SDLJoystick.h
+++ b/SDL/SDLJoystick.h
@@ -25,7 +25,7 @@ public:
 private:
 	void setUpController(int deviceIndex);
 	void setUpControllers();
-	keycode_t getKeycodeForButton(SDL_GameControllerButton button);
+	InputKeyCode getKeycodeForButton(SDL_GameControllerButton button);
 	int getDeviceIndex(int instanceId);
 	bool registeredAsEventHandler;
 	std::vector<SDL_GameController *> controllers;

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -1069,7 +1069,7 @@ int main(int argc, char *argv[]) {
 					int c = u8_nextchar(event.text.text, &pos);
 					KeyInput key;
 					key.flags = KEY_CHAR;
-					key.keyCode = c;
+					key.unicodeChar = c;
 					key.deviceId = DEVICE_ID_KEYBOARD;
 					NativeKey(key);
 					break;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -2063,7 +2063,7 @@ void HostnameSelectScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	progressView_->SetVisibility(UI::V_GONE);
 }
 
-void HostnameSelectScreen::SendEditKey(int keyCode, int flags) {
+void HostnameSelectScreen::SendEditKey(InputKeyCode keyCode, int flags) {
 	auto oldView = UI::GetFocusedView();
 	UI::SetFocusedView(addrView_);
 	KeyInput fakeKey{ DEVICE_ID_KEYBOARD, keyCode, KEY_DOWN | flags };
@@ -2074,13 +2074,13 @@ void HostnameSelectScreen::SendEditKey(int keyCode, int flags) {
 UI::EventReturn HostnameSelectScreen::OnNumberClick(UI::EventParams &e) {
 	std::string text = e.v ? e.v->Tag() : "";
 	if (text.length() == 1 && text[0] >= '0' && text[0] <= '9') {
-		SendEditKey(text[0], KEY_CHAR);
+		SendEditKey((InputKeyCode)text[0], KEY_CHAR);  // ASCII for digits match keycodes.
 	}
 	return UI::EVENT_DONE;
 }
 
 UI::EventReturn HostnameSelectScreen::OnPointClick(UI::EventParams &e) {
-	SendEditKey('.', KEY_CHAR);
+	SendEditKey(NKCODE_PERIOD, KEY_CHAR);
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -214,7 +214,7 @@ protected:
 
 private:
 	void ResolverThread();
-	void SendEditKey(int keyCode, int flags = 0);
+	void SendEditKey(InputKeyCode keyCode, int flags = 0);
 
 	UI::EventReturn OnNumberClick(UI::EventParams &e);
 	UI::EventReturn OnPointClick(UI::EventParams &e);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1147,9 +1147,9 @@ void NativeRender(GraphicsContext *graphicsContext) {
 }
 
 void HandleGlobalMessage(const std::string &msg, const std::string &value) {
-	int nextInputDeviceID = -1;
+	InputDeviceID nextInputDeviceID = DEVICE_ID_ANY;
 	if (msg == "inputDeviceConnectedID") {
-		nextInputDeviceID = parseLong(value);
+		nextInputDeviceID = (InputDeviceID)parseLong(value);
 	}
 	else if (msg == "inputDeviceConnected") {
 		KeyMap::NotifyPadConnected(nextInputDeviceID, value);

--- a/UI/TiltAnalogSettingsScreen.cpp
+++ b/UI/TiltAnalogSettingsScreen.cpp
@@ -145,6 +145,7 @@ void TiltAnalogSettingsScreen::axis(const AxisInput &axis) {
 		case JOYSTICK_AXIS_ACCELEROMETER_X: down_.x = axis.value; break;
 		case JOYSTICK_AXIS_ACCELEROMETER_Y: down_.y = axis.value; break;
 		case JOYSTICK_AXIS_ACCELEROMETER_Z: down_.z = axis.value; break;
+		default: break;
 		}
 	}
 }

--- a/UWP/NKCodeFromWindowsSystem.cpp
+++ b/UWP/NKCodeFromWindowsSystem.cpp
@@ -3,7 +3,7 @@
 
 using namespace Windows::System;
 
-std::map<Windows::System::VirtualKey, int> virtualKeyCodeToNKCode{
+std::map<Windows::System::VirtualKey, InputKeyCode> virtualKeyCodeToNKCode{
 	{ VirtualKey::A, NKCODE_A },
 	{ VirtualKey::B, NKCODE_B },
 	{ VirtualKey::C, NKCODE_C },

--- a/UWP/NKCodeFromWindowsSystem.h
+++ b/UWP/NKCodeFromWindowsSystem.h
@@ -4,4 +4,4 @@
 
 #include "Common/Input/KeyCodes.h"
 
-extern std::map<Windows::System::VirtualKey, int> virtualKeyCodeToNKCode;
+extern std::map<Windows::System::VirtualKey, InputKeyCode> virtualKeyCodeToNKCode;

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -251,7 +251,7 @@ void PPSSPP_UWPMain::OnKeyUp(int scanCode, Windows::System::VirtualKey virtualKe
 }
 
 void PPSSPP_UWPMain::OnMouseWheel(float delta) {
-	int key = NKCODE_EXT_MOUSEWHEEL_UP;
+	InputKeyCode key = NKCODE_EXT_MOUSEWHEEL_UP;
 	if (delta < 0) {
 		key = NKCODE_EXT_MOUSEWHEEL_DOWN;
 	} else if (delta == 0) {

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -39,7 +39,7 @@ std::vector<DIDEVICEINSTANCE> DinputDevice::devices;
 bool DinputDevice::needsCheck_ = true;
 
 // In order from 0.  There can be 128, but most controllers do not have that many.
-static const int dinput_buttons[] = {
+static const InputKeyCode dinput_buttons[] = {
 	NKCODE_BUTTON_1,
 	NKCODE_BUTTON_2,
 	NKCODE_BUTTON_3,

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -203,7 +203,7 @@ DinputDevice::~DinputDevice() {
 	}
 }
 
-void SendNativeAxis(InputDeviceID deviceId, int value, int &lastValue, int axisId) {
+void SendNativeAxis(InputDeviceID deviceId, int value, int &lastValue, InputAxis axisId) {
 	AxisInput axis;
 	axis.deviceId = deviceId;
 	axis.axisId = axisId;

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -207,7 +207,7 @@ void SendNativeAxis(InputDeviceID deviceId, int value, int &lastValue, InputAxis
 	AxisInput axis;
 	axis.deviceId = deviceId;
 	axis.axisId = axisId;
-	axis.value = (float)value * (1.0 / 10000.0f); // Convert axis to normalised float
+	axis.value = (float)value * (1.0f / 10000.0f); // Convert axis to normalised float
 	NativeAxis(axis);
 
 	lastValue = value;

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -203,11 +203,11 @@ DinputDevice::~DinputDevice() {
 	}
 }
 
-void SendNativeAxis(int deviceId, int value, int &lastValue, int axisId) {
+void SendNativeAxis(InputDeviceID deviceId, int value, int &lastValue, int axisId) {
 	AxisInput axis;
 	axis.deviceId = deviceId;
 	axis.axisId = axisId;
-	axis.value = (float)value / 10000.0f; // Convert axis to normalised float
+	axis.value = (float)value * (1.0 / 10000.0f); // Convert axis to normalised float
 	NativeAxis(axis);
 
 	lastValue = value;

--- a/Windows/RawInput.cpp
+++ b/Windows/RawInput.cpp
@@ -57,7 +57,7 @@
 #endif
 
 namespace WindowsRawInput {
-	static std::set<int> keyboardKeysDown;
+	static std::set<InputKeyCode> keyboardKeysDown;
 	static void *rawInputBuffer;
 	static size_t rawInputBufferSize;
 	static bool menuActive;
@@ -68,7 +68,7 @@ namespace WindowsRawInput {
 
 	// TODO: More keys need to be added, but this is more than
 	// a fair start.
-	static std::map<int, int> windowsTransTable = {
+	static std::map<int, InputKeyCode> windowsTransTable = {
 		{ 'A', NKCODE_A },
 		{ 'B', NKCODE_B },
 		{ 'C', NKCODE_C },
@@ -213,7 +213,7 @@ namespace WindowsRawInput {
 		return menuActive;
 	}
 
-	static int GetTrueVKey(const RAWKEYBOARD &kb) {
+	static InputKeyCode GetTrueVKey(const RAWKEYBOARD &kb) {
 		int vKey = kb.VKey;
 		switch (kb.VKey) {
 		case VK_SHIFT:
@@ -285,7 +285,7 @@ namespace WindowsRawInput {
 
 	LRESULT ProcessChar(HWND hWnd, WPARAM wParam, LPARAM lParam) {
 		KeyInput key;
-		key.keyCode = (int)wParam;  // Note that this is NOT a NKCODE but a Unicode character!
+		key.unicodeChar = (int)wParam;  // Note that this is NOT a NKCODE but a Unicode character!
 		key.flags = KEY_CHAR;
 		key.deviceId = DEVICE_ID_KEYBOARD;
 		NativeKey(key);

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -126,7 +126,7 @@ static void UnloadXInputDLL() {}
 
 
 // Permanent map. Actual mapping happens elsewhere.
-static const struct {int from, to;} xinput_ctrl_map[] = {
+static const struct { int from; InputKeyCode to; } xinput_ctrl_map[] = {
 	{XINPUT_GAMEPAD_A,              NKCODE_BUTTON_A},
 	{XINPUT_GAMEPAD_B,              NKCODE_BUTTON_B},
 	{XINPUT_GAMEPAD_X,              NKCODE_BUTTON_X},

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -221,7 +221,7 @@ void XinputDevice::UpdatePad(int pad, const XINPUT_STATE &state, XINPUT_VIBRATIO
 
 	AxisInput axis;
 	axis.deviceId = (InputDeviceID)(DEVICE_ID_XINPUT_0 + pad);
-	auto sendAxis = [&](AndroidJoystickAxis axisId, float value) {
+	auto sendAxis = [&](InputAxis axisId, float value) {
 		axis.axisId = axisId;
 		axis.value = value;
 		NativeAxis(axis);

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -220,7 +220,7 @@ void XinputDevice::UpdatePad(int pad, const XINPUT_STATE &state, XINPUT_VIBRATIO
 	ApplyVibration(pad, vibration);
 
 	AxisInput axis;
-	axis.deviceId = DEVICE_ID_XINPUT_0 + pad;
+	axis.deviceId = (InputDeviceID)(DEVICE_ID_XINPUT_0 + pad);
 	auto sendAxis = [&](AndroidJoystickAxis axisId, float value) {
 		axis.axisId = axisId;
 		axis.value = value;

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1181,8 +1181,8 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_touch
 
 extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_keyDown(JNIEnv *, jclass, jint deviceId, jint key, jboolean isRepeat) {
 	KeyInput keyInput;
-	keyInput.deviceId = deviceId;
-	keyInput.keyCode = key;
+	keyInput.deviceId = (InputDeviceID)deviceId;
+	keyInput.keyCode = (InputKeyCode)key;
 	keyInput.flags = KEY_DOWN;
 	if (isRepeat) {
 		keyInput.flags |= KEY_IS_REPEAT;
@@ -1192,8 +1192,8 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_keyDown(JNIEnv *, jclass, j
 
 extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_keyUp(JNIEnv *, jclass, jint deviceId, jint key) {
 	KeyInput keyInput;
-	keyInput.deviceId = deviceId;
-	keyInput.keyCode = key;
+	keyInput.deviceId = (InputDeviceID)deviceId;
+	keyInput.keyCode = (InputKeyCode)key;
 	keyInput.flags = KEY_UP;
 	return NativeKey(keyInput);
 }
@@ -1204,8 +1204,8 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_joystickAxis(
 		return;
 
 	AxisInput axis;
-	axis.axisId = axisId;
-	axis.deviceId = deviceId;
+	axis.axisId = (InputAxis)axisId;
+	axis.deviceId = (InputDeviceID)deviceId;
 	axis.value = value;
 
 	NativeAxis(axis);

--- a/ios/SmartKeyboardMap.cpp
+++ b/ios/SmartKeyboardMap.cpp
@@ -9,7 +9,7 @@
 #include "SmartKeyboardMap.hpp"
 #include "Common/Input/KeyCodes.h"
 
-int getSmartKeyboardMap(int keycode) {
+InputKeyCode getSmartKeyboardMap(int keycode) {
     switch(keycode) {
         case 4: return NKCODE_A;
         case 5: return NKCODE_B;
@@ -73,6 +73,6 @@ int getSmartKeyboardMap(int keycode) {
         case 229: return NKCODE_SHIFT_RIGHT;
         case 230: return NKCODE_META_RIGHT;
         case 231: return NKCODE_ALT_RIGHT;
-        default: return 0;
+        default: return NKCODE_UNKNOWN;
     }
 }

--- a/ios/SmartKeyboardMap.hpp
+++ b/ios/SmartKeyboardMap.hpp
@@ -8,4 +8,6 @@
 
 #pragma once
 
+#include "Common/Input/KeyCodes.h"
+
 InputKeyCode getSmartKeyboardMap(int keycode);

--- a/ios/SmartKeyboardMap.hpp
+++ b/ios/SmartKeyboardMap.hpp
@@ -6,9 +6,6 @@
 //
 //
 
-#ifndef SmartKeyboardMap_hpp
-#define SmartKeyboardMap_hpp
+#pragma once
 
-int getSmartKeyboardMap(int keycode);
-
-#endif /* SmartKeyboardMap_hpp */
+InputKeyCode getSmartKeyboardMap(int keycode);

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -567,7 +567,7 @@ int ToTouchID(UITouch *uiTouch, bool allowAllocate) {
 	}
 }
 
-- (void)controllerButtonPressed:(BOOL)pressed keyCode:(keycode_t)keyCode
+- (void)controllerButtonPressed:(BOOL)pressed keyCode:(InputKeyCode)keyCode
 {
 	KeyInput key;
 	key.deviceId = DEVICE_ID_PAD_0;

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -105,7 +105,7 @@ static CameraHelper *cameraHelper;
 static LocationHelper *locationHelper;
 
 @interface ViewController () {
-	std::map<uint16_t, uint16_t> iCadeToKeyMap;
+	std::map<uint16_t, InputKeyCode> iCadeToKeyMap;
 }
 
 @property (nonatomic, strong) EAGLContext* context;

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -910,10 +910,10 @@ static bool TestDepthMath() {
 
 bool TestInputMapping() {
 	InputMapping mapping;
-	mapping.deviceId = 10;
+	mapping.deviceId = DEVICE_ID_PAD_0;
 	mapping.keyCode = 20;
 	InputMapping mapping2;
-	mapping2.deviceId = 18;
+	mapping2.deviceId = DEVICE_ID_PAD_8;
 	mapping2.keyCode = 38;
 	std::string cfg = mapping.ToConfigString();
 


### PR DESCRIPTION
Got tired of not being able to see these in the debugger when looking at input events, for the input threading refactor.

Many are still int, where we store both keycodes and virtual keys. Might do something about those at a later time.