### PR TITLE
SDL: Add a way to reset OpenGL rendering by pressing F7.

### DIFF
--- a/Common/GPU/OpenGL/GLFeatures.cpp
+++ b/Common/GPU/OpenGL/GLFeatures.cpp
@@ -626,11 +626,11 @@ bool CheckGLExtensions() {
 }
 
 void SetGLCoreContext(bool flag) {
-	_assert_msg_(!extensionsDone, "SetGLCoreContext() after CheckGLExtensions()");
-
-	useCoreContext = flag;
-	// For convenience, it'll get reset later.
-	gl_extensions.IsCoreContext = useCoreContext;
+	if (!extensionsDone) {
+		useCoreContext = flag;
+		// For convenience, it'll get reset later.
+		gl_extensions.IsCoreContext = useCoreContext;
+	}
 }
 
 void ResetGLExtensions() {

--- a/SDL/SDLGLGraphicsContext.cpp
+++ b/SDL/SDLGLGraphicsContext.cpp
@@ -449,9 +449,12 @@ void SDLGLGraphicsContext::Shutdown() {
 void SDLGLGraphicsContext::ShutdownFromRenderThread() {
 	delete draw_;
 	draw_ = nullptr;
+	renderManager_ = nullptr;
 
 #ifdef USING_EGL
 	EGL_Close();
 #endif
 	SDL_GL_DeleteContext(glContext);
+	glContext = nullptr;
+	window_ = nullptr;
 }


### PR DESCRIPTION
This branch has been sitting around on one of my machines for a long time, and is very occasionally useful, so let's get it in.

Only enabling it in debug builds, though.

Will do something similar for Vulkan as part of lost device recovery soon.