### PR TITLE
Experiment with handling VK_LOST_DEVICE

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -137,7 +137,7 @@ public:
 	void DrawUP(const void *vdata, int vertexCount) override;
 	void Clear(int mask, uint32_t colorval, float depthVal, int stencilVal) override;
 
-	void BeginFrame() override;
+	bool BeginFrame() override;
 
 	std::string GetInfoString(InfoField info) const override {
 		switch (info) {
@@ -1448,7 +1448,7 @@ void D3D11DrawContext::Clear(int mask, uint32_t colorval, float depthVal, int st
 	}
 }
 
-void D3D11DrawContext::BeginFrame() {
+bool D3D11DrawContext::BeginFrame() {
 	context_->OMSetRenderTargets(1, &curRenderTargetView_, curDepthStencilView_);
 
 	if (curBlend_ != nullptr) {
@@ -1475,6 +1475,7 @@ void D3D11DrawContext::BeginFrame() {
 			context_->PSSetConstantBuffers(0, 1, &curPipeline_->dynamicUniforms);
 		}
 	}
+	return true;
 }
 
 void D3D11DrawContext::CopyFramebufferImage(Framebuffer *srcfb, int level, int x, int y, int z, Framebuffer *dstfb, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth, int channelBit, const char *tag) {

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -367,7 +367,7 @@ public:
 	Buffer *CreateBuffer(size_t size, uint32_t usageFlags) override;
 	Framebuffer *CreateFramebuffer(const FramebufferDesc &desc) override;
 
-	void BeginFrame() override;
+	bool BeginFrame() override;
 	void EndFrame() override;
 
 	void UpdateBuffer(Buffer *buffer, const uint8_t *data, size_t offset, size_t size, UpdateBufferFlags flags) override;
@@ -782,10 +782,11 @@ OpenGLContext::~OpenGLContext() {
 	}
 }
 
-void OpenGLContext::BeginFrame() {
+bool OpenGLContext::BeginFrame() {
 	renderManager_.BeginFrame(debugFlags_ & DebugFlags::PROFILE_TIMESTAMPS);
 	FrameData &frameData = frameData_[renderManager_.GetCurFrame()];
 	renderManager_.BeginPushBuffer(frameData.push);
+	return true;
 }
 
 void OpenGLContext::EndFrame() {

--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -702,7 +702,8 @@ VkResult VulkanContext::CreateDevice() {
 	VkResult res = vkCreateDevice(physical_devices_[physical_device_], &device_info, nullptr, &device_);
 	if (res != VK_SUCCESS) {
 		init_error_ = "Unable to create Vulkan device";
-		ERROR_LOG(G3D, "Unable to create Vulkan device");
+		ERROR_LOG(G3D, "Unable to create Vulkan device: '%s'", VulkanResultToString(res));
+		return res;
 	} else {
 		VulkanLoadDeviceFunctions(device_, extensionsLookup_);
 	}

--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -365,8 +365,6 @@ public:
 		return devicePerfClass_;
 	}
 
-	void GetImageMemoryRequirements(VkImage image, VkMemoryRequirements *mem_reqs, bool *dedicatedAllocation);
-
 	VmaAllocator Allocator() const {
 		return allocator_;
 	}
@@ -382,6 +380,10 @@ public:
 	std::vector<VkPresentModeKHR> GetAvailablePresentModes() const {
 		return availablePresentModes_;
 	}
+
+	// Forces a device loss, to help debug device recovery.
+	// It'll create its own command buffer for this.
+	void IntentionallyLoseDevice();
 
 private:
 	bool ChooseQueue();
@@ -476,6 +478,8 @@ private:
 	std::vector<VkCommandBuffer> cmdQueue_;
 
 	VmaAllocator allocator_ = VK_NULL_HANDLE;
+
+	bool deviceLost_ = false;
 };
 
 // Detailed control.

--- a/Common/GPU/Vulkan/VulkanDebug.cpp
+++ b/Common/GPU/Vulkan/VulkanDebug.cpp
@@ -76,6 +76,14 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDebugUtilsCallback(
 		// Extended validation (ARM best practices)
 		// Non-fifo validation not recommended
 		return false;
+
+	// These get triggered during the device lost simulation. Ignore.
+	case -556648736:
+	case 1812873262:
+	case 337425955:
+		WARN_LOG(G3D, "Validation message %d typical of device lost simulation, ignoring.", messageCode);
+		return false;
+
 	default:
 		break;
 	}

--- a/Common/GPU/Vulkan/VulkanFrameData.h
+++ b/Common/GPU/Vulkan/VulkanFrameData.h
@@ -88,6 +88,9 @@ struct FrameData {
 
 	bool syncDone = false;
 
+	// Set if the device was just lost.
+	bool deviceLost = false;
+
 	// Swapchain.
 	uint32_t curSwapchainImage = -1;
 

--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -742,6 +742,7 @@ void VulkanFree() {
 const char *VulkanResultToString(VkResult res) {
 	static char temp[128]{};
 	switch (res) {
+	case VK_SUCCESS: return "VK_SUCCESS";
 	case VK_NOT_READY: return "VK_NOT_READY";
 	case VK_TIMEOUT: return "VK_TIMEOUT";
 	case VK_EVENT_SET: return "VK_EVENT_SET";

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -395,6 +395,9 @@ void VulkanQueueRunner::RunSteps(std::vector<VKRStep *> &steps, FrameData &frame
 					vkCmdEndDebugUtilsLabelEXT(cmd);
 				}
 				frameData.SubmitPending(vulkan_, FrameSubmitType::Pending, frameDataShared);
+				if (frameData.deviceLost) {
+					goto bail;
+				}
 
 				// When stepping in the GE debugger, we can end up here multiple times in a "frame".
 				// So only acquire once.
@@ -447,6 +450,7 @@ void VulkanQueueRunner::RunSteps(std::vector<VKRStep *> &steps, FrameData &frame
 		}
 	}
 
+bail:
 	// Deleting all in one go should be easier on the instruction cache than deleting
 	// them as we go - and easier to debug because we can look backwards in the frame.
 	if (!keepSteps) {

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -507,6 +507,8 @@ void VulkanRenderManager::ThreadFunc() {
 		// push more work when it feels like it, and just start working.
 		if (task->runType == VKRRunType::EXIT) {
 			// Oh, host wanted out. Let's leave.
+			delete task;
+			// In this case, there should be no more tasks.
 			break;
 		}
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -185,7 +185,8 @@ public:
 	~VulkanRenderManager();
 
 	// Makes sure that the GPU has caught up enough that we can start writing buffers of this frame again.
-	void BeginFrame(bool enableProfiling, bool enableLogProfiler);
+	// A false return value means that the device is lost, and we should just try to end the frame ASAP without doing anything.
+	bool BeginFrame(bool enableProfiling, bool enableLogProfiler);
 	// Can run on a different thread!
 	void Finish();
 	// Zaps queued up commands. Use if you know there's a risk you've queued up stuff that has already been deleted. Can happen during in-game shutdown.
@@ -461,13 +462,16 @@ public:
 	void ResetStats();
 	void DrainCompileQueue();
 
+	bool DeviceIsLost() const { return deviceLost_; }
+
 private:
 	void EndCurRenderStep();
 
 	void ThreadFunc();
 	void CompileThreadFunc();
 
-	void Run(VKRRenderThreadTask &task);
+	// Fails if the device was lost.
+	bool Run(VKRRenderThreadTask &task);
 
 	// Bad for performance but sometimes necessary for synchronous CPU readbacks (screenshots and whatnot).
 	void FlushSync();
@@ -480,6 +484,8 @@ private:
 	int inflightFramesAtStart_ = 0;
 
 	int outOfDateFrames_ = 0;
+
+	bool deviceLost_ = false;
 
 	// Submission time state
 

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -476,7 +476,7 @@ public:
 
 	void Clear(int mask, uint32_t colorval, float depthVal, int stencilVal) override;
 
-	void BeginFrame() override;
+	bool BeginFrame() override;
 	void EndFrame() override;
 	void WipeQueue() override;
 
@@ -1072,15 +1072,18 @@ VKContext::~VKContext() {
 	vulkan_->Delete().QueueDeletePipelineCache(pipelineCache_);
 }
 
-void VKContext::BeginFrame() {
-	// TODO: Bad dependency on g_Config here!
-	renderManager_.BeginFrame(debugFlags_ & DebugFlags::PROFILE_TIMESTAMPS, debugFlags_ & DebugFlags::PROFILE_SCOPES);
+bool VKContext::BeginFrame() {
+	if (!renderManager_.BeginFrame(debugFlags_ & DebugFlags::PROFILE_TIMESTAMPS, debugFlags_ & DebugFlags::PROFILE_SCOPES)) {
+		// Something failed badly, let's bail.
+		return false;
+	}
 
 	FrameData &frame = frame_[vulkan_->GetCurFrame()];
 
 	push_->BeginFrame();
 
 	frame.descriptorPool.Reset();
+	return true;
 }
 
 void VKContext::EndFrame() {

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -408,6 +408,10 @@ public:
 		}
 	}
 
+	void IntentionallyLoseDevice() override {
+		vulkan_->IntentionallyLoseDevice();
+	}
+
 	DepthStencilState *CreateDepthStencilState(const DepthStencilStateDesc &desc) override;
 	BlendState *CreateBlendState(const BlendStateDesc &desc) override;
 	InputLayout *CreateInputLayout(const InputLayoutDesc &desc) override;

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -805,7 +805,7 @@ public:
 	virtual void DrawUP(const void *vdata, int vertexCount) = 0;
 	
 	// Frame management (for the purposes of sync and resource management, necessary with modern APIs). Default implementations here.
-	virtual void BeginFrame() {}
+	virtual bool BeginFrame() { return true; }
 	virtual void EndFrame() = 0;
 	virtual void WipeQueue() {}
 

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -834,6 +834,8 @@ public:
 	// Not very elegant, but more elegant than the old passId hack.
 	virtual void SetInvalidationCallback(InvalidationCallback callback) = 0;
 
+	virtual void IntentionallyLoseDevice() {}
+
 protected:
 	ShaderModule *vsPresets_[VS_MAX_PRESET];
 	ShaderModule *fsPresets_[FS_MAX_PRESET];

--- a/Common/GraphicsContext.h
+++ b/Common/GraphicsContext.h
@@ -38,5 +38,9 @@ public:
 	// Should strive to get rid of these.
 	virtual void Poll() {}
 
+	virtual bool DeviceIsLost() const {
+		return false;
+	}
+
 	virtual Draw::DrawContext *GetDrawContext() = 0;
 };

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -165,21 +165,23 @@ void ScreenManager::render() {
 
 				// TODO: Make really sure that this "mismatched" pre/post only happens
 				// when screens are "compatible" (both are UIScreens, for example).
-				backback.screen->preRender();
-				backback.screen->render();
-				stack_.back().screen->render();
-				if (postRenderCb_)
-					postRenderCb_(getUIContext(), postRenderUserdata_);
-				backback.screen->postRender();
-				break;
+				if (backback.screen->preRender()) {
+					backback.screen->render();
+					stack_.back().screen->render();
+					if (postRenderCb_)
+						postRenderCb_(getUIContext(), postRenderUserdata_);
+					backback.screen->postRender();
+					break;
+				}
 			}
 		default:
 			_assert_(stack_.back().screen);
-			stack_.back().screen->preRender();
-			stack_.back().screen->render();
-			if (postRenderCb_)
-				postRenderCb_(getUIContext(), postRenderUserdata_);
-			stack_.back().screen->postRender();
+			if (stack_.back().screen->preRender()) {
+				stack_.back().screen->render();
+				if (postRenderCb_)
+					postRenderCb_(getUIContext(), postRenderUserdata_);
+				stack_.back().screen->postRender();
+			}
 			break;
 		}
 	} else {

--- a/Common/UI/Screen.h
+++ b/Common/UI/Screen.h
@@ -50,7 +50,7 @@ public:
 
 	virtual void onFinish(DialogResult reason) {}
 	virtual void update() {}
-	virtual void preRender() {}
+	virtual bool preRender() { return true; }  // If this returns false, something is really bad and we should try to skip the rest of the frame, the error will be handled at the end.
 	virtual void render() {}
 	virtual void postRender() {}
 	virtual void resized() {}

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -189,13 +189,15 @@ void UIScreen::deviceRestored() {
 		root_->DeviceRestored(screenManager()->getDrawContext());
 }
 
-void UIScreen::preRender() {
+bool UIScreen::preRender() {
 	using namespace Draw;
 	Draw::DrawContext *draw = screenManager()->getDrawContext();
 	if (!draw) {
-		return;
+		return true;
 	}
-	draw->BeginFrame();
+	if (!draw->BeginFrame()) {
+		return false;
+	}
 	// Bind and clear the back buffer
 	draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, 0xFF000000 }, "UI");
 	screenManager()->getUIContext()->BeginFrame();
@@ -209,6 +211,7 @@ void UIScreen::preRender() {
 	viewport.MinDepth = 0.0;
 	draw->SetViewport(viewport);
 	draw->SetTargetSize(g_display.pixel_xres, g_display.pixel_yres);
+	return true;
 }
 
 void UIScreen::postRender() {

--- a/Common/UI/UIScreen.h
+++ b/Common/UI/UIScreen.h
@@ -36,7 +36,7 @@ public:
 	~UIScreen();
 
 	void update() override;
-	void preRender() override;
+	bool preRender() override;
 	void render() override;
 	void postRender() override;
 	void deviceLost() override;

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -230,6 +230,10 @@ void Core_RunLoop(GraphicsContext *ctx) {
 		Core_StateProcessed();
 		double startTime = time_now_d();
 		UpdateRunLoop();
+		if (graphicsContext->DeviceIsLost()) {
+			// Let the outer loop take care of this.
+			return;
+		}
 
 		// Simple throttling to not burn the GPU in the menu.
 		double diffTime = time_now_d() - startTime;
@@ -243,6 +247,10 @@ void Core_RunLoop(GraphicsContext *ctx) {
 
 	while ((coreState == CORE_RUNNING || coreState == CORE_STEPPING) && GetUIState() == UISTATE_INGAME) {
 		UpdateRunLoop();
+		if (graphicsContext->DeviceIsLost()) {
+			// Let the outer loop take care of this.
+			break;
+		}
 		if (!windowHidden && !Core_IsStepping()) {
 			ctx->SwapBuffers();
 
@@ -337,6 +345,9 @@ bool Core_Run(GraphicsContext *ctx) {
 				return false;
 			}
 			Core_RunLoop(ctx);
+			if (ctx->DeviceIsLost()) {
+				return true;
+			}
 			continue;
 		}
 
@@ -345,6 +356,9 @@ bool Core_Run(GraphicsContext *ctx) {
 		case CORE_STEPPING:
 			// enter a fast runloop
 			Core_RunLoop(ctx);
+			if (ctx->DeviceIsLost()) {
+				return true;
+			}
 			if (coreState == CORE_POWERDOWN) {
 				Core_StateProcessed();
 				return true;
@@ -357,7 +371,6 @@ bool Core_Run(GraphicsContext *ctx) {
 		case CORE_RUNTIME_ERROR:
 			// Exit loop!!
 			Core_StateProcessed();
-
 			return true;
 
 		case CORE_NEXTFRAME:

--- a/GPU/Vulkan/ShaderManagerVulkan.cpp
+++ b/GPU/Vulkan/ShaderManagerVulkan.cpp
@@ -237,6 +237,7 @@ ShaderManagerVulkan::~ShaderManagerVulkan() {
 }
 
 void ShaderManagerVulkan::DeviceLost() {
+	Clear();  // We only really need to do this if the device is actually lost, so DeviceLost might need an argument.
 	draw_ = nullptr;
 }
 

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -123,6 +123,14 @@ void DevMenuScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	items->Add(new CheckBox(&g_Config.bDrawFrameGraph, dev->T("Draw Frametimes Graph")));
 	items->Add(new Choice(dev->T("Reset limited logging")))->OnClick.Handle(this, &DevMenuScreen::OnResetLimitedLogging);
 
+	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN) {
+		items->Add(new Choice(dev->T("Crash GPU")))->OnClick.Add([&](UI::EventParams &) {
+			Draw::DrawContext *draw = screenManager()->getDrawContext();
+			draw->IntentionallyLoseDevice();
+			return UI::EVENT_DONE;
+		});
+	}
+
 	scroll->Add(items);
 	parent->Add(scroll);
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1414,10 +1414,12 @@ static void DrawFrameTimes(UIContext *ctx, const Bounds &bounds) {
 	ctx->RebindTexture();
 }
 
-void EmuScreen::preRender() {
+bool EmuScreen::preRender() {
 	using namespace Draw;
 	DrawContext *draw = screenManager()->getDrawContext();
-	draw->BeginFrame();
+	if (!draw->BeginFrame()) {
+		return false;
+	}
 	// Here we do NOT bind the backbuffer or clear the screen, unless non-buffered.
 	// The emuscreen is different than the others - we really want to allow the game to render to framebuffers
 	// before we ever bind the backbuffer for rendering. On mobile GPUs, switching back and forth between render
@@ -1443,6 +1445,7 @@ void EmuScreen::preRender() {
 		draw->SetViewport(viewport);
 	}
 	draw->SetTargetSize(g_display.pixel_xres, g_display.pixel_yres);
+	return true;
 }
 
 void EmuScreen::postRender() {

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -44,7 +44,7 @@ public:
 
 	void update() override;
 	void render() override;
-	void preRender() override;
+	bool preRender() override;
 	void postRender() override;
 	void dialogFinished(const Screen *dialog, DialogResult result) override;
 	void sendMessage(const char *msg, const char *value) override;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1045,6 +1045,7 @@ void RenderOverlays(UIContext *dc, void *userdata) {
 void NativeRender(GraphicsContext *graphicsContext) {
 	_dbg_assert_(graphicsContext != nullptr);
 	_dbg_assert_(g_screenManager != nullptr);
+	_dbg_assert_(!graphicsContext->DeviceIsLost())
 
 	g_GameManager.Update();
 

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -119,6 +119,7 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 	vulkan_->ChooseDevice(deviceNum);
 	if (vulkan_->CreateDevice() != VK_SUCCESS) {
 		*error_message = vulkan_->InitError();
+		vulkan_->DestroyInstance();
 		delete vulkan_;
 		vulkan_ = nullptr;
 		return false;
@@ -183,4 +184,8 @@ void WindowsVulkanContext::Poll() {
 
 void *WindowsVulkanContext::GetAPIContext() {
 	return vulkan_;
+}
+
+bool WindowsVulkanContext::DeviceIsLost() const {
+	return renderManager_->DeviceIsLost();
 }

--- a/Windows/GPU/WindowsVulkanContext.h
+++ b/Windows/GPU/WindowsVulkanContext.h
@@ -35,6 +35,7 @@ public:
 	void Poll() override;
 
 	void *GetAPIContext() override;
+	bool DeviceIsLost() const override;
 
 	Draw::DrawContext *GetDrawContext() override { return draw_; }
 private:


### PR DESCRIPTION
The idea is to gracefully teardown and recreate the Vulkan device if this happens due to either emulator or driver bug.

Currently, we don't fully implement LostDevice/RestoreDevice for Vulkan (as called from Android task switching), as in reality we do keep around the same device. So we don't delete/recreate everything, just most things, and finding the last things might be tricky.

However I was able to get this working to some degree on Intel GPU on Windows. On NVIDIA, I can't seem to create a new device in the same process after I've crashed one.

So overall, this is a bit questionable. Might be better to try to root out the remaining causes of lost device, although it would be nice to have this as a safety net.