### PR TITLE
Add a cache for MakePixelsTexture

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -92,7 +92,7 @@ public:
 	Framebuffer *CreateFramebuffer(const FramebufferDesc &desc) override;
 
 	void UpdateBuffer(Buffer *buffer, const uint8_t *data, size_t offset, size_t size, UpdateBufferFlags flags) override;
-	void UpdateTextureLevels(Texture *texture, const uint8_t **data, int numLevels) override;
+	void UpdateTextureLevels(Texture *texture, const uint8_t **data, TextureCallback initDataCallback, int numLevels) override;
 
 	void CopyFramebufferImage(Framebuffer *src, int level, int x, int y, int z, Framebuffer *dst, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth, int channelBits, const char *tag) override;
 	bool BlitFramebuffer(Framebuffer *src, int srcX1, int srcY1, int srcX2, int srcY2, Framebuffer *dst, int dstX1, int dstY1, int dstX2, int dstY2, int channelBits, FBBlitFilter filter, const char *tag) override;
@@ -796,6 +796,7 @@ public:
 		width_ = desc.width;
 		height_ = desc.height;
 		depth_ = desc.depth;
+		format_ = desc.format;
 	}
 	~D3D11Texture() {
 		if (tex)
@@ -944,7 +945,7 @@ Texture *D3D11DrawContext::CreateTexture(const TextureDesc &desc) {
 	return tex;
 }
 
-void D3D11DrawContext::UpdateTextureLevels(Texture *texture, const uint8_t **data, int numLevels) {
+void D3D11DrawContext::UpdateTextureLevels(Texture *texture, const uint8_t **data, TextureCallback initDataCallback, int numLevels) {
 	D3D11Texture *tex = (D3D11Texture *)texture;
 	// TODO
 }

--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -92,6 +92,7 @@ public:
 	Framebuffer *CreateFramebuffer(const FramebufferDesc &desc) override;
 
 	void UpdateBuffer(Buffer *buffer, const uint8_t *data, size_t offset, size_t size, UpdateBufferFlags flags) override;
+	void UpdateTextureLevels(Texture *texture, const uint8_t **data, int numLevels) override;
 
 	void CopyFramebufferImage(Framebuffer *src, int level, int x, int y, int z, Framebuffer *dst, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth, int channelBits, const char *tag) override;
 	bool BlitFramebuffer(Framebuffer *src, int srcX1, int srcY1, int srcX2, int srcY2, Framebuffer *dst, int dstX1, int dstY1, int dstX2, int dstY2, int channelBits, FBBlitFilter filter, const char *tag) override;
@@ -941,6 +942,11 @@ Texture *D3D11DrawContext::CreateTexture(const TextureDesc &desc) {
 		tex->stagingTex = nullptr;
 	}
 	return tex;
+}
+
+void D3D11DrawContext::UpdateTextureLevels(Texture *texture, const uint8_t **data, int numLevels) {
+	D3D11Texture *tex = (D3D11Texture *)texture;
+	// TODO
 }
 
 ShaderModule *D3D11DrawContext::CreateShaderModule(ShaderStage stage, ShaderLanguage language, const uint8_t *data, size_t dataSize, const char *tag) {

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -316,7 +316,6 @@ private:
 	LPDIRECT3DDEVICE9 device_;
 	LPDIRECT3DDEVICE9EX deviceEx_;
 	TextureType type_;
-	DataFormat format_;
 	D3DFORMAT d3dfmt_;
 	LPDIRECT3DTEXTURE9 tex_ = nullptr;
 	LPDIRECT3DVOLUMETEXTURE9 volTex_ = nullptr;
@@ -537,7 +536,7 @@ public:
 	Framebuffer *CreateFramebuffer(const FramebufferDesc &desc) override;
 
 	void UpdateBuffer(Buffer *buffer, const uint8_t *data, size_t offset, size_t size, UpdateBufferFlags flags) override;
-	void UpdateTextureLevels(Texture *texture, const uint8_t **data, int numLevels) override;
+	void UpdateTextureLevels(Texture *texture, const uint8_t **data, TextureCallback initDataCallback, int numLevels) override;
 
 	void CopyFramebufferImage(Framebuffer *src, int level, int x, int y, int z, Framebuffer *dst, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth, int channelBits, const char *tag) override {
 		// Not implemented
@@ -940,9 +939,9 @@ Texture *D3D9Context::CreateTexture(const TextureDesc &desc) {
 	return tex;
 }
 
-void D3D9Context::UpdateTextureLevels(Texture *texture, const uint8_t **data, int numLevels) {
+void D3D9Context::UpdateTextureLevels(Texture *texture, const uint8_t **data, TextureCallback initDataCallback, int numLevels) {
 	D3D9Texture *tex = (D3D9Texture *)texture;
-	tex->UpdateTextureLevels(data, numLevels, TextureCallback());
+	tex->UpdateTextureLevels(data, numLevels, initDataCallback);
 }
 
 

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -371,7 +371,7 @@ public:
 	void EndFrame() override;
 
 	void UpdateBuffer(Buffer *buffer, const uint8_t *data, size_t offset, size_t size, UpdateBufferFlags flags) override;
-	void UpdateTextureLevels(Texture *texture, const uint8_t **data, int numLevels) override;
+	void UpdateTextureLevels(Texture *texture, const uint8_t **data, TextureCallback initDataCallback, int numLevels) override;
 
 	void CopyFramebufferImage(Framebuffer *src, int level, int x, int y, int z, Framebuffer *dst, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth, int channelBits, const char *tag) override;
 	bool BlitFramebuffer(Framebuffer *src, int srcX1, int srcY1, int srcX2, int srcY2, Framebuffer *dst, int dstX1, int dstY1, int dstX2, int dstY2, int channelBits, FBBlitFilter filter, const char *tag) override;
@@ -862,7 +862,6 @@ private:
 	GLRenderManager *render_;
 	GLRTexture *tex_;
 
-	DataFormat format_;
 	TextureType type_;
 	int mipLevels_;
 	bool generateMips_;  // Generate mips requested
@@ -1031,9 +1030,9 @@ Texture *OpenGLContext::CreateTexture(const TextureDesc &desc) {
 	return new OpenGLTexture(&renderManager_, desc);
 }
 
-void OpenGLContext::UpdateTextureLevels(Texture *texture, const uint8_t **data, int numLevels) {
+void OpenGLContext::UpdateTextureLevels(Texture *texture, const uint8_t **data, TextureCallback initDataCallback, int numLevels) {
 	OpenGLTexture *tex = (OpenGLTexture *)texture;
-	tex->UpdateTextureLevels(&renderManager_, data, numLevels, TextureCallback());
+	tex->UpdateTextureLevels(&renderManager_, data, numLevels, initDataCallback);
 }
 
 DepthStencilState *OpenGLContext::CreateDepthStencilState(const DepthStencilStateDesc &desc) {

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -337,6 +337,7 @@ public:
 	VKTexture(VulkanContext *vulkan, VkCommandBuffer cmd, VulkanPushPool *pushBuffer, const TextureDesc &desc)
 		: vulkan_(vulkan), mipLevels_(desc.mipLevels), format_(desc.format) {}
 	bool Create(VkCommandBuffer cmd, VulkanPushPool *pushBuffer, const TextureDesc &desc);
+	void Update(VkCommandBuffer cmd, VulkanPushPool *pushBuffer, const uint8_t *const *data, TextureCallback callback, int numLevels);
 
 	~VKTexture() {
 		Destroy();
@@ -356,7 +357,13 @@ public:
 		return VK_NULL_HANDLE;  // This would be bad.
 	}
 
+	int NumLevels() const {
+		return mipLevels_;
+	}
+
 private:
+	void UpdateInternal(VkCommandBuffer cmd, VulkanPushPool *pushBuffer, const uint8_t *const *data, TextureCallback callback, int numLevels);
+
 	void Destroy() {
 		if (vkTex_) {
 			vkTex_->Destroy();
@@ -421,6 +428,7 @@ public:
 	Framebuffer *CreateFramebuffer(const FramebufferDesc &desc) override;
 
 	void UpdateBuffer(Buffer *buffer, const uint8_t *data, size_t offset, size_t size, UpdateBufferFlags flags) override;
+	void UpdateTextureLevels(Texture *texture, const uint8_t **data, int numLevels) override;
 
 	void CopyFramebufferImage(Framebuffer *src, int level, int x, int y, int z, Framebuffer *dst, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth, int channelBits, const char *tag) override;
 	bool BlitFramebuffer(Framebuffer *src, int srcX1, int srcY1, int srcX2, int srcY2, Framebuffer *dst, int dstX1, int dstY1, int dstX2, int dstY2, int channelBits, FBBlitFilter filter, const char *tag) override;
@@ -748,14 +756,14 @@ enum class TextureState {
 	PENDING_DESTRUCTION,
 };
 
-bool VKTexture::Create(VkCommandBuffer cmd, VulkanPushPool *push, const TextureDesc &desc) {
+bool VKTexture::Create(VkCommandBuffer cmd, VulkanPushPool *pushBuffer, const TextureDesc &desc) {
 	// Zero-sized textures not allowed.
 	_assert_(desc.width * desc.height * desc.depth > 0);  // remember to set depth to 1!
 	if (desc.width * desc.height * desc.depth <= 0) {
 		ERROR_LOG(G3D,  "Bad texture dimensions %dx%dx%d", desc.width, desc.height, desc.depth);
 		return false;
 	}
-	_assert_(push);
+	_dbg_assert_(pushBuffer);
 	format_ = desc.format;
 	mipLevels_ = desc.mipLevels;
 	width_ = desc.width;
@@ -763,8 +771,6 @@ bool VKTexture::Create(VkCommandBuffer cmd, VulkanPushPool *push, const TextureD
 	depth_ = desc.depth;
 	vkTex_ = new VulkanTexture(vulkan_, desc.tag);
 	VkFormat vulkanFormat = DataFormatToVulkan(format_);
-	int bpp = GetBpp(vulkanFormat);
-	int bytesPerPixel = bpp / 8;
 	int usageBits = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
 	if (mipLevels_ > (int)desc.initData.size()) {
 		// Gonna have to generate some, which requires TRANSFER_SRC
@@ -779,38 +785,52 @@ bool VKTexture::Create(VkCommandBuffer cmd, VulkanPushPool *push, const TextureD
 	}
 	VkImageLayout layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
 	if (desc.initData.size()) {
-		int w = width_;
-		int h = height_;
-		int d = depth_;
-		int i;
-		for (i = 0; i < (int)desc.initData.size(); i++) {
-			uint32_t offset;
-			VkBuffer buf;
-			size_t size = w * h * d * bytesPerPixel;
-			uint8_t *dest = (uint8_t *)push->Allocate(size, 16, &buf, &offset);
-			if (desc.initDataCallback) {
-				_assert_(dest != nullptr);
-				if (!desc.initDataCallback(dest, desc.initData[i], w, h, d, w * bytesPerPixel, h * w * bytesPerPixel)) {
-					memcpy(dest, desc.initData[i], size);
-				}
-			} else {
-				memcpy(dest, desc.initData[i], size);
-			}
-			TextureCopyBatch batch;
-			vkTex_->CopyBufferToMipLevel(cmd, &batch, i, w, h, 0, buf, offset, w);
-			vkTex_->FinishCopyBatch(cmd, &batch);
-			w = (w + 1) / 2;
-			h = (h + 1) / 2;
-			d = (d + 1) / 2;
-		}
+		UpdateInternal(cmd, pushBuffer, desc.initData.data(), desc.initDataCallback, (int)desc.initData.size());
 		// Generate the rest of the mips automatically.
-		if (i < mipLevels_) {
-			vkTex_->GenerateMips(cmd, i, false);
+		if (desc.initData.size() < mipLevels_) {
+			vkTex_->GenerateMips(cmd, desc.initData.size(), false);
 			layout = VK_IMAGE_LAYOUT_GENERAL;
 		}
 	}
 	vkTex_->EndCreate(cmd, false, VK_PIPELINE_STAGE_TRANSFER_BIT, layout);
 	return true;
+}
+
+void VKTexture::Update(VkCommandBuffer cmd, VulkanPushPool *pushBuffer, const uint8_t * const *data, TextureCallback initDataCallback, int numLevels) {
+	// Before we can use UpdateInternal, we need to transition the image to the same state as after CreateDirect,
+	// making it ready for writing.
+
+	UpdateInternal(cmd, pushBuffer, data, initDataCallback, numLevels);
+}
+
+void VKTexture::UpdateInternal(VkCommandBuffer cmd, VulkanPushPool *pushBuffer, const uint8_t * const *data, TextureCallback initDataCallback, int numLevels) {
+	int w = width_;
+	int h = height_;
+	int d = depth_;
+	int i;
+	VkFormat vulkanFormat = DataFormatToVulkan(format_);
+	int bpp = GetBpp(vulkanFormat);
+	int bytesPerPixel = bpp / 8;
+	TextureCopyBatch batch;
+	for (i = 0; i < numLevels; i++) {
+		uint32_t offset;
+		VkBuffer buf;
+		size_t size = w * h * d * bytesPerPixel;
+		uint8_t *dest = (uint8_t *)pushBuffer->Allocate(size, 16, &buf, &offset);
+		if (initDataCallback) {
+			_assert_(dest != nullptr);
+			if (!initDataCallback(dest, data[i], w, h, d, w * bytesPerPixel, h * w * bytesPerPixel)) {
+				memcpy(dest, data[i], size);
+			}
+		} else {
+			memcpy(dest, data[i], size);
+		}
+		vkTex_->CopyBufferToMipLevel(cmd, &batch, i, w, h, 0, buf, offset, w);
+		w = (w + 1) / 2;
+		h = (h + 1) / 2;
+		d = (d + 1) / 2;
+	}
+	vkTex_->FinishCopyBatch(cmd, &batch);
 }
 
 static DataFormat DataFormatFromVulkanDepth(VkFormat fmt) {
@@ -1340,6 +1360,20 @@ Texture *VKContext::CreateTexture(const TextureDesc &desc) {
 		delete tex;
 		return nullptr;
 	}
+}
+
+void VKContext::UpdateTextureLevels(Texture *texture, const uint8_t **data, int numLevels) {
+	VkCommandBuffer initCmd = renderManager_.GetInitCmd();
+	if (!push_ || !initCmd) {
+		// Too early! Fail.
+		ERROR_LOG(G3D, "Can't create textures before the first frame has started.");
+		return;
+	}
+
+	VKTexture *tex = (VKTexture *)texture;
+
+	_dbg_assert_(numLevels <= tex->NumLevels());
+	tex->Update(initCmd, push_, data, Draw::TextureCallback(), numLevels);
 }
 
 static inline void CopySide(VkStencilOpState &dest, const StencilSetup &src) {

--- a/Common/GPU/thin3d.cpp
+++ b/Common/GPU/thin3d.cpp
@@ -132,6 +132,7 @@ bool RefCountedObject::Release() {
 			return true;
 		}
 	} else {
+		// No point in printing the name here if the object has already been free-d, it'll be corrupt and dangerous to print.
 		_dbg_assert_msg_(false, "Refcount (%d) invalid for object %p - corrupt?", refcount_.load(), this);
 	}
 	return false;
@@ -139,10 +140,9 @@ bool RefCountedObject::Release() {
 
 bool RefCountedObject::ReleaseAssertLast() {
 	bool released = Release();
-	_dbg_assert_msg_(released, "RefCountedObject: Expected to be the last reference, but isn't!");
+	_dbg_assert_msg_(released, "RefCountedObject: Expected to be the last reference, but isn't! (%s)", name_);
 	return released;
 }
-
 
 // ================================== PIXEL/FRAGMENT SHADERS
 

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -731,6 +731,11 @@ public:
 	// Copies data from the CPU over into the buffer, at a specific offset. This does not change the size of the buffer and cannot write outside it.
 	virtual void UpdateBuffer(Buffer *buffer, const uint8_t *data, size_t offset, size_t size, UpdateBufferFlags flags) = 0;
 
+	// Used to optimize DrawPixels by re-using previously allocated temp textures.
+	// Do not try to update a texture that might be used by an in-flight command buffer! In OpenGL and D3D, this will cause stalls
+	// while in Vulkan this might cause various strangeness like image corruption.
+	virtual void UpdateTextureLevels(Texture *texture, const uint8_t **data, int numLevels) = 0;
+
 	virtual void CopyFramebufferImage(Framebuffer *src, int level, int x, int y, int z, Framebuffer *dst, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth, int channelBits, const char *tag) = 0;
 	virtual bool BlitFramebuffer(Framebuffer *src, int srcX1, int srcY1, int srcX2, int srcY2, Framebuffer *dst, int dstX1, int dstY1, int dstX2, int dstY2, int channelBits, FBBlitFilter filter, const char *tag) = 0;
 

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -466,9 +466,11 @@ public:
 	int Width() { return width_; }
 	int Height() { return height_; }
 	int Depth() { return depth_; }
+	DataFormat Format() { return format_; }
 
 protected:
 	int width_ = -1, height_ = -1, depth_ = -1;
+	DataFormat format_ = DataFormat::UNDEFINED;
 };
 
 struct BindingDesc {
@@ -734,7 +736,7 @@ public:
 	// Used to optimize DrawPixels by re-using previously allocated temp textures.
 	// Do not try to update a texture that might be used by an in-flight command buffer! In OpenGL and D3D, this will cause stalls
 	// while in Vulkan this might cause various strangeness like image corruption.
-	virtual void UpdateTextureLevels(Texture *texture, const uint8_t **data, int numLevels) = 0;
+	virtual void UpdateTextureLevels(Texture *texture, const uint8_t **data, TextureCallback initDataCallback, int numLevels) = 0;
 
 	virtual void CopyFramebufferImage(Framebuffer *src, int level, int x, int y, int z, Framebuffer *dst, int dstLevel, int dstX, int dstY, int dstZ, int width, int height, int depth, int channelBits, const char *tag) = 0;
 	virtual bool BlitFramebuffer(Framebuffer *src, int srcX1, int srcY1, int srcX2, int srcY2, Framebuffer *dst, int dstX1, int dstY1, int dstX2, int dstY2, int channelBits, FBBlitFilter filter, const char *tag) = 0;

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -267,6 +267,11 @@ namespace Draw {
 class DrawContext;
 }
 
+struct DrawPixelsEntry {
+	Draw::Texture *tex;
+	int frameNumber;
+};
+
 struct GPUDebugBuffer;
 class DrawEngineCommon;
 class PresentationCommon;
@@ -570,6 +575,8 @@ protected:
 
 	std::vector<VirtualFramebuffer *> vfbs_;
 	std::vector<VirtualFramebuffer *> bvfbs_; // blitting framebuffers (for download)
+
+	std::vector<DrawPixelsEntry> drawPixelsCache_;
 
 	bool gameUsesSequentialCopies_ = false;
 

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -581,20 +581,23 @@ Draw::ShaderModule *PresentationCommon::CompileShaderModule(ShaderStage stage, S
 }
 
 void PresentationCommon::SourceTexture(Draw::Texture *texture, int bufferWidth, int bufferHeight) {
+	// AddRef before release and assign in case it's the same.
+	texture->AddRef();
+
 	DoRelease(srcTexture_);
 	DoRelease(srcFramebuffer_);
 
-	texture->AddRef();
 	srcTexture_ = texture;
 	srcWidth_ = bufferWidth;
 	srcHeight_ = bufferHeight;
 }
 
 void PresentationCommon::SourceFramebuffer(Draw::Framebuffer *fb, int bufferWidth, int bufferHeight) {
+	fb->AddRef();
+
 	DoRelease(srcTexture_);
 	DoRelease(srcFramebuffer_);
 
-	fb->AddRef();
 	srcFramebuffer_ = fb;
 	srcWidth_ = bufferWidth;
 	srcHeight_ = bufferHeight;

--- a/GPU/Common/StencilCommon.cpp
+++ b/GPU/Common/StencilCommon.cpp
@@ -354,7 +354,6 @@ bool FramebufferManagerCommon::PerformWriteStencilFromMemory(u32 addr, int size,
 		draw_->BlitFramebuffer(blitFBO, 0, 0, w, h, dstBuffer->fbo, 0, 0, dstBuffer->renderWidth, dstBuffer->renderHeight, Draw::FB_STENCIL_BIT, Draw::FB_BLIT_NEAREST, "WriteStencilFromMemory_Blit");
 		RebindFramebuffer("RebindFramebuffer - Stencil");
 	}
-	tex->Release();
 
 	draw_->Invalidate(InvalidationFlags::CACHED_RENDER_STATE);
 	gstate_c.Dirty(DIRTY_ALL_RENDER_STATE);


### PR DESCRIPTION
This allows us to not recreate the textures every frame for the purposes of DrawPixels, instead reuse them from previous frames. We don't use textures from the last 3 frames to be sure (should actually check the buffered frame count, perhaps).

We're still quite aggressive at garbage collecting these for now, currently after 10 frames but can easily tweak.

Previously we couldn't update the content of thin3d textures, but I've now added a path to do that.

Basically, it turns out that creating/destroying textures in Vulkan was more expensive than I thought, and in God of War which does a lot of DrawPixels for whatever reason, this is a really good speed boost, at least on PC, I'm seeing 20%. Working smoothly on mobile, too.

~~D3D11 implementation still missing, so draft.~~