### PR TITLE
Make GameSubscriber backward compatible again

### DIFF
--- a/Core/Debugger/WebSocket/GameSubscriber.cpp
+++ b/Core/Debugger/WebSocket/GameSubscriber.cpp
@@ -98,15 +98,13 @@ void WebSocketVersion(DebuggerRequest &req) {
 	JsonWriter &json = req.Respond();
 
 	std::string version;
-	if (!req.ParamString("version", &version)) {
-		return;
+	if (req.ParamString("version", &version)) {
+		req.client->version = version;
 	}
 	std::string name;
-	if (!req.ParamString("name", &name)) {
-		return;
+	if (req.ParamString("name", &name)) {
+		req.client->name = name;
 	}
-	req.client->name = name;
-	req.client->version = version;
 
 	json.writeString("name", "PPSSPP");
 	json.writeString("version", PPSSPP_GIT_VERSION);

--- a/Core/Debugger/WebSocket/GameSubscriber.cpp
+++ b/Core/Debugger/WebSocket/GameSubscriber.cpp
@@ -97,14 +97,15 @@ void WebSocketGameStatus(DebuggerRequest &req) {
 void WebSocketVersion(DebuggerRequest &req) {
 	JsonWriter &json = req.Respond();
 
-	std::string version;
-	if (req.ParamString("version", &version)) {
-		req.client->version = version;
-	}
-	std::string name;
-	if (req.ParamString("name", &name)) {
-		req.client->name = name;
-	}
+	std::string version = req.client->version;
+	if (!req.ParamString("version", &version, DebuggerParamType::OPTIONAL_LOOSE))
+		return;
+	std::string name = req.client->name;
+	if (!req.ParamString("name", &name, DebuggerParamType::OPTIONAL_LOOSE))
+		return;
+
+	req.client->version = version;
+	req.client->name = name;
 
 	json.writeString("name", "PPSSPP");
 	json.writeString("version", PPSSPP_GIT_VERSION);


### PR DESCRIPTION
Now it won't break any potential old client that doesn't pass the fields.

Should have insisted on this.

followup to #17520 