### PR TITLE
Disable debug asserts and debug-level logging in Windows release builds

### DIFF
--- a/Common/Log.h
+++ b/Common/Log.h
@@ -83,7 +83,8 @@ void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type,
 		;
 bool GenericLogEnabled(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type);
 
-#if defined(_DEBUG)
+// Exception for Windows - enable more log levels in release mode than on other platforms.
+#if defined(_DEBUG) || defined(_WIN32)
 
 #define MAX_LOGLEVEL DEBUG_LEVEL
 
@@ -128,8 +129,8 @@ void SetExtraAssertInfo(const char *info);
 #define __FILENAME__ __FILE__
 #endif
 
-// If we're in "debug" assert mode
-#if MAX_LOGLEVEL >= DEBUG_LEVEL
+// If we're a debug build, _dbg_assert_ is active. Not otherwise, even on Windows.
+#if defined(_DEBUG)
 
 #define _dbg_assert_(_a_) \
 	if (!(_a_)) {\

--- a/Common/Log.h
+++ b/Common/Log.h
@@ -83,7 +83,7 @@ void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type,
 		;
 bool GenericLogEnabled(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type);
 
-#if defined(_DEBUG) || defined(_WIN32)
+#if defined(_DEBUG)
 
 #define MAX_LOGLEVEL DEBUG_LEVEL
 


### PR DESCRIPTION
We allowed debug asserts and logging to be always enabled in Windows on the assumption of CPU power just always being strong enough. But there are slow x86/x64 devices out there, and we shouldn't slow them down unnecessarily.

It also makes for more fair profiling, and makes `_dbg_assert_` safer to sprinkle more liberally. There might very well be some  `_dbg_assert_` we should now convert to `_assert_`, though.

Debug builds are fast enough to use for most debugging on Windows now, I generally use them, so I'll still mostly run with all asserts enabled.