### PR TITLE
ClientConfigSubscriber added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1835,6 +1835,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/Debugger/WebSocket/GameBroadcaster.h
 	Core/Debugger/WebSocket/GameSubscriber.cpp
 	Core/Debugger/WebSocket/GameSubscriber.h
+	Core/Debugger/WebSocket/ClientConfigSubscriber.cpp
+	Core/Debugger/WebSocket/ClientConfigSubscriber.h
 	Core/Debugger/WebSocket/GPUBufferSubscriber.cpp
 	Core/Debugger/WebSocket/GPUBufferSubscriber.h
 	Core/Debugger/WebSocket/GPURecordSubscriber.cpp

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -547,6 +547,7 @@
     <ClCompile Include="Debugger\WebSocket.cpp" />
     <ClCompile Include="Debugger\WebSocket\BreakpointSubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\CPUCoreSubscriber.cpp" />
+    <ClCompile Include="Debugger\WebSocket\ClientConfigSubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\GameBroadcaster.cpp" />
     <ClCompile Include="Debugger\WebSocket\GameSubscriber.cpp" />
     <ClCompile Include="Debugger\WebSocket\GPUBufferSubscriber.cpp" />
@@ -1118,6 +1119,7 @@
     <ClInclude Include="Debugger\MemBlockInfo.h" />
     <ClInclude Include="Debugger\WebSocket.h" />
     <ClInclude Include="Debugger\WebSocket\BreakpointSubscriber.h" />
+    <ClInclude Include="Debugger\WebSocket\ClientConfigSubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\GameSubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\DisasmSubscriber.h" />
     <ClInclude Include="Debugger\WebSocket\GPUBufferSubscriber.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -718,6 +718,9 @@
     <ClCompile Include="Debugger\WebSocket\CPUCoreSubscriber.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="Debugger\WebSocket\ClientConfigSubscriber.cpp">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClCompile>
     <ClCompile Include="Debugger\WebSocket\WebSocketUtils.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
@@ -1780,6 +1783,9 @@
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>
     <ClInclude Include="Debugger\WebSocket\GameBroadcaster.h">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClInclude>
+    <ClInclude Include="Debugger\WebSocket\ClientConfigSubscriber.h">
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>
     <ClInclude Include="Debugger\WebSocket\CPUCoreSubscriber.h">

--- a/Core/Debugger/WebSocket.cpp
+++ b/Core/Debugger/WebSocket.cpp
@@ -141,18 +141,12 @@ void HandleDebuggerRequest(const http::Request &request) {
 	SetupDebuggerLock();
 
 	WebSocketClientInfo client_info;
-	auto& allowed_config = client_info.allowed;
+	auto& disallowed_config = client_info.disallowed;
 
 	GameBroadcaster game;
 	LogBroadcaster logger;
 	InputBroadcaster input;
 	SteppingBroadcaster stepping;
-
-	// By default everything is on
-	allowed_config.emplace("logger", true);
-	allowed_config.emplace("game", true);
-	allowed_config.emplace("stepping", true);
-	allowed_config.emplace("input", true);
 
 	std::unordered_map<std::string, DebuggerEventHandler> eventHandlers;
 	std::vector<DebuggerSubscriber *> subscriberData;
@@ -200,13 +194,13 @@ void HandleDebuggerRequest(const http::Request &request) {
 
 		// The client can explicitly ask not to be notified about some events
 		// so we check the client settings first
-		if (allowed_config.at("logger"))
+		if (!disallowed_config["logger"])
 			logger.Broadcast(ws);
-		if (allowed_config.at("game"))
+		if (!disallowed_config["game"])
 			game.Broadcast(ws);
-		if (allowed_config.at("stepping"))
+		if (!disallowed_config["stepping"])
 			stepping.Broadcast(ws);
-		if (allowed_config.at("input"))
+		if (!disallowed_config["input"])
 			input.Broadcast(ws);
 
 		for (size_t i = 0; i < subscribers.size(); ++i) {

--- a/Core/Debugger/WebSocket.cpp
+++ b/Core/Debugger/WebSocket.cpp
@@ -148,6 +148,12 @@ void HandleDebuggerRequest(const http::Request &request) {
 	InputBroadcaster input;
 	SteppingBroadcaster stepping;
 
+	// By default everything is on
+	allowed_config.emplace("logger", true);
+	allowed_config.emplace("game", true);
+	allowed_config.emplace("stepping", true);
+	allowed_config.emplace("input", true);
+
 	std::unordered_map<std::string, DebuggerEventHandler> eventHandlers;
 	std::vector<DebuggerSubscriber *> subscriberData;
 	for (auto init : subscribers) {
@@ -193,6 +199,7 @@ void HandleDebuggerRequest(const http::Request &request) {
 		// These send events that aren't just responses to requests
 
 		// The client can explicitly ask not to be notified about some events
+		// so we check the client settings first
 		if (allowed_config.at("logger"))
 			logger.Broadcast(ws);
 		if (allowed_config.at("game"))

--- a/Core/Debugger/WebSocket.cpp
+++ b/Core/Debugger/WebSocket.cpp
@@ -62,6 +62,7 @@
 #include "Core/Debugger/WebSocket/MemorySubscriber.h"
 #include "Core/Debugger/WebSocket/ReplaySubscriber.h"
 #include "Core/Debugger/WebSocket/SteppingSubscriber.h"
+#include "Core/Debugger/WebSocket/ClientConfigSubscriber.h"
 
 typedef DebuggerSubscriber *(*SubscriberInit)(DebuggerEventHandlerMap &map);
 static const std::vector<SubscriberInit> subscribers({
@@ -78,6 +79,7 @@ static const std::vector<SubscriberInit> subscribers({
 	&WebSocketMemoryInit,
 	&WebSocketReplayInit,
 	&WebSocketSteppingInit,
+	&WebSocketClientConfigInit,
 });
 
 // To handle webserver restart, keep track of how many running.
@@ -139,6 +141,7 @@ void HandleDebuggerRequest(const http::Request &request) {
 	SetupDebuggerLock();
 
 	WebSocketClientInfo client_info;
+	auto& allowed_config = client_info.allowed;
 
 	GameBroadcaster game;
 	LogBroadcaster logger;
@@ -187,11 +190,17 @@ void HandleDebuggerRequest(const http::Request &request) {
 
 	while (ws->Process(highActivity ? 1.0f / 1000.0f : 1.0f / 60.0f)) {
 		std::lock_guard<std::mutex> guard(lifecycleLock);
-		// These send events that aren't just responses to requests.
-		logger.Broadcast(ws);
-		game.Broadcast(ws);
-		stepping.Broadcast(ws);
-		input.Broadcast(ws);
+		// These send events that aren't just responses to requests
+
+		// The client can explicitly ask not to be notified about some events
+		if (allowed_config.at("logger"))
+			logger.Broadcast(ws);
+		if (allowed_config.at("game"))
+			game.Broadcast(ws);
+		if (allowed_config.at("stepping"))
+			stepping.Broadcast(ws);
+		if (allowed_config.at("input"))
+			input.Broadcast(ws);
 
 		for (size_t i = 0; i < subscribers.size(); ++i) {
 			if (subscriberData[i]) {

--- a/Core/Debugger/WebSocket/ClientConfigSubscriber.cpp
+++ b/Core/Debugger/WebSocket/ClientConfigSubscriber.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018- PPSSPP Project.
+// Copyright (c) 2023- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Core/Debugger/WebSocket/ClientConfigSubscriber.cpp
+++ b/Core/Debugger/WebSocket/ClientConfigSubscriber.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2018- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "Core/Debugger/WebSocket/ClientConfigSubscriber.h"
+#include "Core/Debugger/WebSocket/WebSocketUtils.h"
+#include "Common/StringUtils.h"
+
+DebuggerSubscriber *WebSocketClientConfigInit(DebuggerEventHandlerMap & map) {
+	map["broadcast.config.get"] = &WebSocketBroadcastConfigGet;
+	map["broadcast.config.set"] = &WebSocketBroadcastConfigSet;
+
+	return nullptr;
+}
+
+
+// Request the current client broadcast configuration (broadcast.config.get)
+//
+// No parameters.
+//
+// Response (same event name):
+//  - allowed: object with boolean fields:
+//     - logger: whether logger events are allowed
+//     - game: whether game events are allowed
+//     - stepping: whether stepping events are allowed
+//     - input: whether input events are allowed
+void WebSocketBroadcastConfigGet(DebuggerRequest & req) {
+	JsonWriter &json = req.Respond();
+	const auto& allowed_config = req.client->allowed;
+
+	json.pushDict("allowed");
+
+	json.writeBool("logger", allowed_config.at("logger"));
+	json.writeBool("game", allowed_config.at("game"));
+	json.writeBool("stepping", allowed_config.at("stepping"));
+	json.writeBool("input", allowed_config.at("input"));
+
+	json.end();
+}
+
+// Update the current client broadcast configuration (broadcast.config.set)
+//
+// Parameters:
+//  - allowed: object with boolean fields (all of them are optional):
+//     - logger: new logger config state
+//     - game: new game config state
+//     - stepping: new stepping config state
+//     - input: new input config state
+//
+// Response (same event name):
+//  - allowed: object with boolean fields:
+//     - logger: whether logger events are now allowed
+//     - game: whether game events are now allowed
+//     - stepping: whether stepping events are bow allowed
+//     - input: whether input events are now allowed
+void WebSocketBroadcastConfigSet(DebuggerRequest & req) {
+	JsonWriter &json = req.Respond();
+	// WebSocketClientInfo& client = req.client;
+	auto& allowed_config = req.client->allowed;
+
+	const JsonNode *jsonAllowed = req.data.get("allowed");
+	if (!jsonAllowed) {
+		return req.Fail("Missing 'allowed' parameter");
+	}
+	if (jsonAllowed->value.getTag() != JSON_OBJECT) {
+		return req.Fail("Invalid 'allowed' parameter type");
+	}
+
+	for (const JsonNode *broadcaster : jsonAllowed->value) {
+		auto it = allowed_config.find(broadcaster->key);
+		if (it == allowed_config.end()) {
+			return req.Fail(StringFromFormat("Unsupported 'allowed' object key '%s'", broadcaster->key));
+		}
+
+		if (broadcaster->value.getTag() == JSON_TRUE) {
+			it->second = true;
+		}
+		else if (broadcaster->value.getTag() == JSON_FALSE) {
+			it->second = false;
+		}
+		else if (broadcaster->value.getTag() != JSON_NULL) {
+			return req.Fail(StringFromFormat("Unsupported 'allowed' object type for key '%s'", broadcaster->key));
+		}
+	}
+
+	json.pushDict("allowed");
+
+	json.writeBool("logger", allowed_config.at("logger"));
+	json.writeBool("game", allowed_config.at("game"));
+	json.writeBool("stepping", allowed_config.at("stepping"));
+	json.writeBool("input", allowed_config.at("input"));
+
+	json.end();
+}

--- a/Core/Debugger/WebSocket/ClientConfigSubscriber.h
+++ b/Core/Debugger/WebSocket/ClientConfigSubscriber.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018- PPSSPP Project.
+// Copyright (c) 2023- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Core/Debugger/WebSocket/ClientConfigSubscriber.h
+++ b/Core/Debugger/WebSocket/ClientConfigSubscriber.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2018- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "Core/Debugger/WebSocket/WebSocketUtils.h"
+
+DebuggerSubscriber *WebSocketClientConfigInit(DebuggerEventHandlerMap &map);
+
+void WebSocketBroadcastConfigSet(DebuggerRequest &req);
+void WebSocketBroadcastConfigGet(DebuggerRequest &req);

--- a/Core/Debugger/WebSocket/WebSocketUtils.h
+++ b/Core/Debugger/WebSocket/WebSocketUtils.h
@@ -34,9 +34,7 @@
 using namespace json;
 
 struct WebSocketClientInfo {
-	WebSocketClientInfo() : name(), version(), disallowed() {
-
-	}
+	WebSocketClientInfo() = default;
 
 	std::string name;
 	std::string version;

--- a/Core/Debugger/WebSocket/WebSocketUtils.h
+++ b/Core/Debugger/WebSocket/WebSocketUtils.h
@@ -35,11 +35,7 @@ using namespace json;
 
 struct WebSocketClientInfo {
 	WebSocketClientInfo() : name(), version(), allowed() {
-		// By default everything is on
-		allowed.emplace("logger", true);
-		allowed.emplace("game", true);
-		allowed.emplace("stepping", true);
-		allowed.emplace("input", true);
+
 	}
 
 	std::string name;

--- a/Core/Debugger/WebSocket/WebSocketUtils.h
+++ b/Core/Debugger/WebSocket/WebSocketUtils.h
@@ -34,13 +34,13 @@
 using namespace json;
 
 struct WebSocketClientInfo {
-	WebSocketClientInfo() : name(), version(), allowed() {
+	WebSocketClientInfo() : name(), version(), disallowed() {
 
 	}
 
 	std::string name;
 	std::string version;
-	std::map <std::string, bool> allowed;
+	std::map <std::string, bool> disallowed;
 };
 
 struct DebuggerErrorEvent {

--- a/Core/Debugger/WebSocket/WebSocketUtils.h
+++ b/Core/Debugger/WebSocket/WebSocketUtils.h
@@ -34,11 +34,17 @@
 using namespace json;
 
 struct WebSocketClientInfo {
-	WebSocketClientInfo() : name(), version() {
-
+	WebSocketClientInfo() : name(), version(), allowed() {
+		// By default everything is on
+		allowed.emplace("logger", true);
+		allowed.emplace("game", true);
+		allowed.emplace("stepping", true);
+		allowed.emplace("input", true);
 	}
+
 	std::string name;
 	std::string version;
+	std::map <std::string, bool> allowed;
 };
 
 struct DebuggerErrorEvent {

--- a/UWP/CoreUWP/CoreUWP.vcxproj
+++ b/UWP/CoreUWP/CoreUWP.vcxproj
@@ -295,6 +295,7 @@
     <ClInclude Include="..\..\Core\Debugger\WebSocket.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\BreakpointSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\CPUCoreSubscriber.h" />
+    <ClInclude Include="..\..\Core\Debugger\WebSocket\ClientConfigSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\DisasmSubscriber.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\GameBroadcaster.h" />
     <ClInclude Include="..\..\Core\Debugger\WebSocket\GameSubscriber.h" />
@@ -534,6 +535,7 @@
     <ClCompile Include="..\..\Core\Debugger\WebSocket.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\BreakpointSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\CPUCoreSubscriber.cpp" />
+    <ClCompile Include="..\..\Core\Debugger\WebSocket\ClientConfigSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\DisasmSubscriber.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GameBroadcaster.cpp" />
     <ClCompile Include="..\..\Core\Debugger\WebSocket\GameSubscriber.cpp" />

--- a/UWP/CoreUWP/CoreUWP.vcxproj.filters
+++ b/UWP/CoreUWP/CoreUWP.vcxproj.filters
@@ -671,6 +671,9 @@
     <ClCompile Include="..\..\Core\Debugger\WebSocket\CPUCoreSubscriber.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Core\Debugger\WebSocket\ClientConfigSubscriber.cpp">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Core\Debugger\WebSocket\DisasmSubscriber.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
@@ -1689,6 +1692,9 @@
     <ClInclude Include="..\..\Core\Debugger\WebSocket\CPUCoreSubscriber.h">
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>
+    <ClCompile Include="..\..\Core\Debugger\WebSocket\ClientConfigSubscriber.h">
+      <Filter>Debugger\WebSocket</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\Core\Debugger\WebSocket\DisasmSubscriber.h">
       <Filter>Debugger\WebSocket</Filter>
     </ClInclude>

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -476,6 +476,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/Debugger/WebSocket.cpp \
   $(SRC)/Core/Debugger/WebSocket/BreakpointSubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp \
+  $(SRC)/Core/Debugger/WebSocket/ClientConfigSubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/DisasmSubscriber.cpp \
   $(SRC)/Core/Debugger/WebSocket/GameBroadcaster.cpp \
   $(SRC)/Core/Debugger/WebSocket/GameSubscriber.cpp \


### PR DESCRIPTION
Ok, now that the WebsocketClientInfo has been dealt with, here comes the second part.
This is a direct continuation of this (now closed) PR: https://github.com/hrydgard/ppsspp/pull/17388
The differences between my older code and this one are merely aesthetical (more comments + a slight style change in one place).

Unknownbrackets has recently expressed their concerns about whether the change makes it harder for contributors to add new broadcasters.
Well, let's think about it... Currently a programmer needs to add two new files (hpp and cpp with the broadcaster implementation) and register them in all the build scripts and project structure files, then create an instance of said broadcaster in the function `HandleDebuggerRequest` (WebSocket.cpp) and call `instance_name.Broadcast(ws)`.
After the proposed change it will also be necessary to add the name to the WebSocketClientInfo constructor (and that's easy to find because the map needs to be initialized somewhere and the new name is obviously not there by default) and surround the call with the check.

> One example would simply be fixing the bool values. If the default was false and it was zero-initialized, that'd be one less place to remember to change to have a correct implementation. The goal with things like this should be easy for "Nemoumbra from 6 months in the future" or "unknownbrackets from 6 months in the future" to write correct code. We silly humans tend to miss things when they are spread out in multiple places.

Exactly. Yet... the bool values are not default-initialized in my code! If you have some other notes, please tell me.

Note: I've just noticed how the GPU stat feed is implemented... Of course, I'm not considering configuring all the potential broadcasting subscribers. I don't even know if that's an architectural misstep, but it came as a surprise to me that the subscribers can broadcast.

