### PR TITLE
VFPU: Some micro-optimizations. Don't fall back to interpreter path for vexp/vlog/vrexp.

### DIFF
--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -83,7 +83,7 @@ JitBlockCache::~JitBlockCache() {
 	Shutdown();
 }
 
-bool JitBlock::ContainsAddress(u32 em_address) {
+bool JitBlock::ContainsAddress(u32 em_address) const {
 	// WARNING - THIS DOES NOT WORK WITH JIT INLINING ENABLED.
 	// However, that doesn't exist yet so meh.
 	return (em_address >= originalAddress && em_address < originalAddress + 4 * originalSize);

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -59,7 +59,7 @@ enum class DestroyType {
 // We should be careful not to access these block structures during runtime as they are large.
 // Fine to mess with them at block compile time though.
 struct JitBlock {
-	bool ContainsAddress(u32 em_address);
+	bool ContainsAddress(u32 em_address) const;
 
 	const u8 *checkedEntry;  // const, we have to translate to writable.
 	const u8 *normalEntry;

--- a/Core/MIPS/MIPSDisVFPU.cpp
+++ b/Core/MIPS/MIPSDisVFPU.cpp
@@ -261,14 +261,14 @@ namespace MIPSDis
 	void Dis_MatrixSet1(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		const char *name = MIPSGetName(op);
 		int vd = _VD;
-		MatrixSize sz = GetMtxSizeSafe(op);
+		MatrixSize sz = GetMtxSize(op);
 		snprintf(out, outSize, "%s%s\t%s", name, VSuff(op), MN(vd, sz));
 	}
 	void Dis_MatrixSet2(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		const char *name = MIPSGetName(op);
 		int vd = _VD;
 		int vs = _VS;
-		MatrixSize sz = GetMtxSizeSafe(op);
+		MatrixSize sz = GetMtxSize(op);
 		snprintf(out, outSize, "%s%s\t%s, %s", name, VSuff(op), MN(vd, sz), MN(vs,sz));
 	}
 	void Dis_MatrixSet3(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
@@ -276,7 +276,7 @@ namespace MIPSDis
 		int vd = _VD;
 		int vs = _VS;
 		int vt = _VT;
-		MatrixSize sz = GetMtxSizeSafe(op);
+		MatrixSize sz = GetMtxSize(op);
 		snprintf(out, outSize, "%s%s\t%s, %s, %s", name, VSuff(op), MN(vd, sz), MN(vs,sz), MN(vt,sz));
 	}
 
@@ -285,7 +285,7 @@ namespace MIPSDis
 		int vd = _VD;
 		int vs = _VS;
 		int vt = _VT;
-		MatrixSize sz = GetMtxSizeSafe(op);
+		MatrixSize sz = GetMtxSize(op);
 		// TODO: Xpose?
 		snprintf(out, outSize, "%s%s\t%s, %s, %s", name, VSuff(op), MN(vd, sz), MN(Xpose(vs),sz), MN(vt,sz));
 	}
@@ -295,7 +295,7 @@ namespace MIPSDis
 		int vd = _VD;
 		int vs = _VS;
 		int vt = _VT;
-		MatrixSize sz = GetMtxSizeSafe(op);
+		MatrixSize sz = GetMtxSize(op);
 		snprintf(out, outSize, "%s%s\t%s, %s, %s", name, VSuff(op), MN(vd, sz), MN(vs, sz), VN(vt, V_Single));
 	}
 
@@ -314,7 +314,7 @@ namespace MIPSDis
 		int vt = _VT;
 		int ins = (op>>23) & 7;
 		VectorSize sz = GetVecSize(op);
-		MatrixSize msz = GetMtxSizeSafe(op);
+		MatrixSize msz = GetMtxSize(op);
 		int n = GetNumVectorElements(sz);
 
 		if (n == ins)

--- a/Core/MIPS/MIPSDisVFPU.cpp
+++ b/Core/MIPS/MIPSDisVFPU.cpp
@@ -227,7 +227,7 @@ namespace MIPSDis
 	void Dis_Vcst(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		int conNum = (op>>16) & 0x1f;
 		int vd = _VD;
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		static const char *constants[32] = 
 		{
 			"(undef)",
@@ -304,7 +304,7 @@ namespace MIPSDis
 		int vd = _VD;
 		int vs = _VS;
 		int vt = _VT;
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		snprintf(out, outSize, "%s%s\t%s, %s, %s", name, VSuff(op), VN(vd, V_Single), VN(vs,sz), VN(vt, sz));
 	}
 
@@ -313,7 +313,7 @@ namespace MIPSDis
 		int vs = _VS;
 		int vt = _VT;
 		int ins = (op>>23) & 7;
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		MatrixSize msz = GetMtxSizeSafe(op);
 		int n = GetNumVectorElements(sz);
 
@@ -341,7 +341,7 @@ namespace MIPSDis
 		int vt = _VT;
 		int vs = _VS;
 		int vd = _VD;
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		if (sz != V_Triple)
 		{
 			truncate_cpy(out, outSize, "vcrs\tERROR");
@@ -356,14 +356,14 @@ namespace MIPSDis
 		int vt = _VT;
 		int vs = _VS;
 		int cond = op&15;
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		const char *condNames[16] = {"FL","EQ","LT","LE","TR","NE","GE","GT","EZ","EN","EI","ES","NZ","NN","NI","NS"};
 		snprintf(out, outSize, "%s%s\t%s, %s, %s", name, VSuff(op), condNames[cond], VN(vs, sz), VN(vt,sz));
 	}
 
 	void Dis_Vcmov(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		const char *name = MIPSGetName(op);
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		int vd = _VD;
 		int vs = _VS;
 		int tf = (op >> 19)&3;
@@ -383,7 +383,7 @@ namespace MIPSDis
 		const char *name = MIPSGetName(op);
 		int vd = _VD;
 		int vs = _VS;
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		snprintf(out, outSize, "%s%s\t%s, %s", name, VSuff(op), VN(vd, V_Single), VN(vs,sz));
 	}
 
@@ -392,21 +392,21 @@ namespace MIPSDis
 		int vd = _VD;
 		int vs = _VS;
 		int vt = _VT;
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		snprintf(out, outSize, "%s%s\t%s, %s, %s", name, VSuff(op), VN(vd, sz), VN(vs,sz), VN(vt, V_Single));
 	}
 
 	void Dis_VectorSet1(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		const char *name = MIPSGetName(op);
 		int vd = _VD;
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		snprintf(out, outSize, "%s%s\t%s", name, VSuff(op), VN(vd, sz));
 	}
 	void Dis_VectorSet2(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
 		const char *name = MIPSGetName(op);
 		int vd = _VD;
 		int vs = _VS;
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		snprintf(out, outSize, "%s%s\t%s, %s", name, VSuff(op), VN(vd, sz), VN(vs, sz));
 	}
 	void Dis_VectorSet3(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
@@ -414,7 +414,7 @@ namespace MIPSDis
 		int vd = _VD;
 		int vs = _VS;
 		int vt = _VT;
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		snprintf(out, outSize, "%s%s\t%s, %s, %s", name, VSuff(op), VN(vd, sz), VN(vs,sz), VN(vt, sz));
 	}
 
@@ -432,7 +432,7 @@ namespace MIPSDis
 		}
 		c[(imm>>2) & 3] = 'S';
 		c[imm&3] = 'C';
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		int numElems = GetNumVectorElements(sz);
 		int pos = 0;
 		temp[pos++] = '[';
@@ -451,7 +451,7 @@ namespace MIPSDis
 	}
 
 	void Dis_CrossQuat(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		const char *name;
 		switch (sz)
 		{
@@ -475,7 +475,7 @@ namespace MIPSDis
 	}
 
 	void Dis_Vbfy(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		int vd = _VD;
 		int vs = _VS;
 		const char *name = MIPSGetName(op);
@@ -483,7 +483,7 @@ namespace MIPSDis
 	}
 
 	void Dis_Vf2i(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		int vd = _VD;
 		int vs = _VS;
 		int imm = (op>>16)&0x1f;
@@ -492,7 +492,7 @@ namespace MIPSDis
 	}
 
 	void Dis_Vs2i(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		int vd = _VD;
 		int vs = _VS;
 		const char *name = MIPSGetName(op);
@@ -500,7 +500,7 @@ namespace MIPSDis
 	}
 
 	void Dis_Vi2x(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		VectorSize dsz = GetHalfVectorSizeSafe(sz);
 		if (((op>>16)&3)==0)
 			dsz = V_Single;
@@ -512,7 +512,7 @@ namespace MIPSDis
 	}
 
 	void Dis_Vwbn(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 
 		int vd = _VD;
 		int vs = _VS;
@@ -522,7 +522,7 @@ namespace MIPSDis
 	}
 
 	void Dis_Vf2h(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		VectorSize dsz = GetHalfVectorSizeSafe(sz);
 		if (((op>>16)&3)==0)
 			dsz = V_Single;
@@ -534,7 +534,7 @@ namespace MIPSDis
 	}
 
 	void Dis_Vh2f(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		VectorSize dsz = GetDoubleVectorSizeSafe(sz);
 
 		int vd = _VD;
@@ -544,7 +544,7 @@ namespace MIPSDis
 	}
 
 	void Dis_ColorConv(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 		VectorSize dsz = GetHalfVectorSizeSafe(sz);
 
 		int vd = _VD;
@@ -560,7 +560,7 @@ namespace MIPSDis
 	}
 
 	void Dis_VrndX(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {
-		VectorSize sz = GetVecSizeSafe(op);
+		VectorSize sz = GetVecSize(op);
 
 		int vd = _VD;
 		const char *name = MIPSGetName(op);

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -388,25 +388,6 @@ VectorSize GetDoubleVectorSize(VectorSize sz) {
 	return res;
 }
 
-VectorSize GetVecSizeSafe(MIPSOpcode op) {
-	int a = (op >> 7) & 1;
-	int b = (op >> 15) & 1;
-	a += (b << 1);
-	switch (a) {
-	case 0: return V_Single;
-	case 1: return V_Pair;
-	case 2: return V_Triple;
-	case 3: return V_Quad;
-	default: return V_Invalid;
-	}
-}
-
-VectorSize GetVecSize(MIPSOpcode op) {
-	VectorSize res = GetVecSizeSafe(op);
-	_assert_msg_(res != V_Invalid, "%s: Bad vector size", __FUNCTION__);
-	return res;
-}
-
 VectorSize GetVectorSizeSafe(MatrixSize sz) {
 	switch (sz) {
 	case M_1x1: return V_Single;

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -420,25 +420,6 @@ MatrixSize GetMatrixSize(VectorSize sz) {
 	return res;
 }
 
-MatrixSize GetMtxSizeSafe(MIPSOpcode op) {
-	int a = (op >> 7) & 1;
-	int b = (op >> 15) & 1;
-	a += (b << 1);
-	switch (a) {
-	case 0: return M_1x1;  // This happens in disassembly of junk, but has predictable behavior.
-	case 1: return M_2x2;
-	case 2: return M_3x3;
-	case 3: return M_4x4;
-	default: return M_Invalid;
-	}
-}
-
-MatrixSize GetMtxSize(MIPSOpcode op) {
-	MatrixSize res = GetMtxSizeSafe(op);
-	_assert_msg_(res != M_Invalid, "%s: Bad matrix size", __FUNCTION__);
-	return res;
-}
-
 VectorSize MatrixVectorSizeSafe(MatrixSize sz) {
 	switch (sz) {
 	case M_1x1: return V_Single;

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -203,17 +203,17 @@ enum MatrixOverlapType {
 MatrixOverlapType GetMatrixOverlap(int m1, int m2, MatrixSize msize);
 
 // Returns a number from 0-7, good for checking overlap for 4x4 matrices.
-inline int GetMtx(int matrixReg) {
+static inline int GetMtx(int matrixReg) {
 	return (matrixReg >> 2) & 7;
 }
 
-inline VectorSize GetVecSize(MIPSOpcode op) {
+static inline VectorSize GetVecSize(MIPSOpcode op) {
 	int a = (op >> 7) & 1;
 	int b = (op >> 14) & 2;
 	return (VectorSize)(a + b + 1);  // Safe, there are no other possibilities
 }
 
-inline MatrixSize GetMtxSize(MIPSOpcode op) {
+static inline MatrixSize GetMtxSize(MIPSOpcode op) {
 	int a = (op >> 7) & 1;
 	int b = (op >> 14) & 2;
 	return (MatrixSize)(a + b + 1);  // Safe, there are no other possibilities
@@ -226,7 +226,7 @@ VectorSize GetDoubleVectorSize(VectorSize sz);
 VectorSize MatrixVectorSizeSafe(MatrixSize sz);
 VectorSize MatrixVectorSize(MatrixSize sz);
 
-inline int GetNumVectorElements(VectorSize sz) {
+static inline int GetNumVectorElements(VectorSize sz) {
 	switch (sz) {
 	case V_Single: return 1;
 	case V_Pair:   return 2;
@@ -240,13 +240,13 @@ int GetMatrixSideSafe(MatrixSize sz);
 int GetMatrixSide(MatrixSize sz);
 std::string GetVectorNotation(int reg, VectorSize size);
 std::string GetMatrixNotation(int reg, MatrixSize size);
-inline bool IsMatrixTransposed(int matrixReg) {
+static inline bool IsMatrixTransposed(int matrixReg) {
 	return (matrixReg >> 5) & 1;
 }
-inline bool IsVectorColumn(int vectorReg) {
+static inline bool IsVectorColumn(int vectorReg) {
 	return !((vectorReg >> 5) & 1);
 }
-inline int TransposeMatrixReg(int matrixReg) {
+static inline int TransposeMatrixReg(int matrixReg) {
 	return matrixReg ^ 0x20;
 }
 int GetVectorOverlap(int reg1, VectorSize size1, int reg2, VectorSize size2);

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -218,7 +218,17 @@ VectorSize GetDoubleVectorSizeSafe(VectorSize sz);
 VectorSize GetDoubleVectorSize(VectorSize sz);
 VectorSize MatrixVectorSizeSafe(MatrixSize sz);
 VectorSize MatrixVectorSize(MatrixSize sz);
-int GetNumVectorElements(VectorSize sz);
+
+inline int GetNumVectorElements(VectorSize sz) {
+	switch (sz) {
+	case V_Single: return 1;
+	case V_Pair:   return 2;
+	case V_Triple: return 3;
+	case V_Quad:   return 4;
+	default:       return 0;
+	}
+}
+
 int GetMatrixSideSafe(MatrixSize sz);
 int GetMatrixSide(MatrixSize sz);
 std::string GetVectorNotation(int reg, VectorSize size);

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -213,8 +213,12 @@ inline VectorSize GetVecSize(MIPSOpcode op) {
 	return (VectorSize)(a + b + 1);  // Safe, there are no other possibilities
 }
 
-MatrixSize GetMtxSizeSafe(MIPSOpcode op);
-MatrixSize GetMtxSize(MIPSOpcode op);
+inline MatrixSize GetMtxSize(MIPSOpcode op) {
+	int a = (op >> 7) & 1;
+	int b = (op >> 14) & 2;
+	return (MatrixSize)(a + b + 1);  // Safe, there are no other possibilities
+}
+
 VectorSize GetHalfVectorSizeSafe(VectorSize sz);
 VectorSize GetHalfVectorSize(VectorSize sz);
 VectorSize GetDoubleVectorSizeSafe(VectorSize sz);

--- a/Core/MIPS/MIPSVFPUUtils.h
+++ b/Core/MIPS/MIPSVFPUUtils.h
@@ -202,14 +202,17 @@ enum MatrixOverlapType {
 
 MatrixOverlapType GetMatrixOverlap(int m1, int m2, MatrixSize msize);
 
-
 // Returns a number from 0-7, good for checking overlap for 4x4 matrices.
 inline int GetMtx(int matrixReg) {
 	return (matrixReg >> 2) & 7;
 }
 
-VectorSize GetVecSizeSafe(MIPSOpcode op);
-VectorSize GetVecSize(MIPSOpcode op);
+inline VectorSize GetVecSize(MIPSOpcode op) {
+	int a = (op >> 7) & 1;
+	int b = (op >> 14) & 2;
+	return (VectorSize)(a + b + 1);  // Safe, there are no other possibilities
+}
+
 MatrixSize GetMtxSizeSafe(MIPSOpcode op);
 MatrixSize GetMtxSize(MIPSOpcode op);
 VectorSize GetHalfVectorSizeSafe(VectorSize sz);

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -87,6 +87,7 @@
 #define MOUSEEVENTF_FROMTOUCH_NOPEN 0xFF515780 //http://msdn.microsoft.com/en-us/library/windows/desktop/ms703320(v=vs.85).aspx
 #define MOUSEEVENTF_MASK_PLUS_PENTOUCH 0xFFFFFF80
 
+// See https://github.com/unknownbrackets/verysleepy/commit/fc1b1b3bd6081fae3566cdb542d896e413238b71
 int verysleepy__useSendMessage = 1;
 
 const UINT WM_VERYSLEEPY_MSG = WM_APP + 0x3117;

--- a/ext/libkirk/SHA1.c
+++ b/ext/libkirk/SHA1.c
@@ -138,9 +138,8 @@ void SHAInit(SHA_CTX *shsInfo)
 
    Note that this corrupts the shsInfo->data area */
 
-static void SHSTransform( digest, data )
-     UINT4 *digest, *data ;
-    {
+static void SHSTransform( UINT4 *digest, UINT4 *data )
+{
     UINT4 A, B, C, D, E;     /* Local vars */
     UINT4 eData[ 16 ];       /* Expanded data */
 

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -133,8 +133,9 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 			return true;
 		}
 		return false;
+	default:
+		return false;
 	}
-	return false;
 }
 void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb) { cb(false, ""); }
 void System_AskForPermission(SystemPermission permission) {}


### PR DESCRIPTION
Overall this reduces CPU time in ReadVector/WriteVector by about 30% in GTA. They're actually somewhat hot in GTA (3-4% of execution time) due to the unknown prefix problem, forcing us to fallback a lot of first-vfpu-op-in-block to interpreter.

Just noticed this when doing a little profiling.

I think we can reduce the amount of asserts we have in the various VFPU decode functions like GetVecSize etc by the way, often we can never reach the INVALID case in practice. Added a bit of this.