### PR TITLE
OpenGL: Apply stencil writemask when clearing properly again

### DIFF
--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -378,8 +378,8 @@ void DrawEngineGLES::DoFlush() {
 			ConvertViewportAndScissor(framebufferManager_->UseBufferedRendering(),
 				framebufferManager_->GetRenderWidth(), framebufferManager_->GetRenderHeight(),
 				framebufferManager_->GetTargetBufferWidth(), framebufferManager_->GetTargetBufferHeight(),
-				vpAndScissor);
-			UpdateCachedViewportState(vpAndScissor);
+				vpAndScissor_);
+			UpdateCachedViewportState(vpAndScissor_);
 		}
 
 		int maxIndex = indexGen.MaxIndex();
@@ -455,7 +455,7 @@ void DrawEngineGLES::DoFlush() {
 			if (alphaMask) target |= GL_STENCIL_BUFFER_BIT;
 			if (depthMask) target |= GL_DEPTH_BUFFER_BIT;
 
-			render_->Clear(clearColor, clearDepth, clearColor >> 24, target, rgbaMask, vpAndScissor.scissorX, vpAndScissor.scissorY, vpAndScissor.scissorW, vpAndScissor.scissorH);
+			render_->Clear(clearColor, clearDepth, clearColor >> 24, target, rgbaMask, vpAndScissor_.scissorX, vpAndScissor_.scissorY, vpAndScissor_.scissorW, vpAndScissor_.scissorH);
 			framebufferManager_->SetColorUpdated(gstate_c.skipDrawReason);
 
 			if (gstate_c.Use(GPU_USE_CLEAR_RAM_HACK) && colorMask && (alphaMask || gstate_c.framebufFormat == GE_FORMAT_565)) {

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -141,7 +141,9 @@ private:
 	Draw::DrawContext *draw_;
 
 	// Need to preserve the scissor for use when clearing.
-	ViewportAndScissor vpAndScissor;
+	ViewportAndScissor vpAndScissor_{};
+	// Need to preserve writemask, easiest way.
+	GenericStencilFuncState stencilState_{};
 
 	int bufferDecimationCounter_ = 0;
 	int lastRenderStepId_ = -1;


### PR DESCRIPTION
See #17478

Also renames vpAndScissor to vpAndScissor_ for consistency.