### PR TITLE
x86-64 vertex decoder: Keep the vertex-full-alpha variable in a register

### DIFF
--- a/GPU/Common/ReplacedTexture.h
+++ b/GPU/Common/ReplacedTexture.h
@@ -128,7 +128,7 @@ public:
 
 	void GetSize(int level, int *w, int *h) const {
 		_dbg_assert_(State() == ReplacementState::ACTIVE);
-		_dbg_assert_(level < levels_.size());
+		_dbg_assert_((size_t)level < levels_.size());
 		*w = levels_[level].fullW;
 		*h = levels_[level].fullH;
 	}

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -285,7 +285,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 #if PPSSPP_ARCH(AMD64)
 	if (dec.col) {
 		CMP(32, R(alphaReg), Imm32(1));
-		FixupBranch alphaJump = J_CC(CC_NE, false);
+		FixupBranch alphaJump = J_CC(CC_E, false);
 		if (RipAccessible(&gstate_c.vertexFullAlpha)) {
 			MOV(8, M(&gstate_c.vertexFullAlpha), Imm8(0));  // rip accessible
 		} else {
@@ -1076,7 +1076,7 @@ void VertexDecoderJitCache::Jit_Color5551() {
 
 	MOV(32, MDisp(dstReg, dec_->decFmt.c0off), R(tempReg2));
 
-	// Let's AND to avoid a branch, tempReg1 has alpha only in the top 8 bits.
+	// Let's AND to avoid a branch, tempReg1 has alpha only in the top 8 bits, and they're all equal.
 	SHR(32, R(tempReg1), Imm8(24));
 #if PPSSPP_ARCH(AMD64)
 	AND(8, R(alphaReg), R(tempReg1));

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -204,9 +204,11 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 #endif
 
 	// Initialize alpha reg.
+#if PPSSPP_ARCH(AMD64)
 	if (dec.col) {
 		MOV(32, R(alphaReg), Imm32(1));
 	}
+#endif
 
 	bool prescaleStep = false;
 	// Look for prescaled texcoord steps


### PR DESCRIPTION
~1% speed boost in God of War (did two repeated measurements of each configuration).

We already do this on ARM/ARM64 so no possible improvement there.