### PR TITLE
Pass uvScale in as a fourth argument to the vertex decoder

### DIFF
--- a/Common/Arm64Emitter.cpp
+++ b/Common/Arm64Emitter.cpp
@@ -315,6 +315,14 @@ const u8* ARM64XEmitter::AlignCodePage()
 	return m_code;
 }
 
+const u8 *ARM64XEmitter::NopAlignCode16() {
+	int bytes = ((-(intptr_t)m_code) & 15);
+	for (int i = 0; i < bytes / 4; i++) {
+		Write32(0xD503201F); // official nop instruction
+	}
+	return m_code;
+}
+
 void ARM64XEmitter::FlushIcache()
 {
 	FlushIcacheSection(m_lastCacheFlushEnd, m_code);

--- a/Common/Arm64Emitter.h
+++ b/Common/Arm64Emitter.h
@@ -401,6 +401,7 @@ public:
 	void ReserveCodeSpace(u32 bytes);
 	const u8* AlignCode16();
 	const u8* AlignCodePage();
+	const u8 *NopAlignCode16();
 	void FlushIcache();
 	void FlushIcacheSection(const u8* start, const u8* end);
 	u8* GetWritableCodePtr();

--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -613,6 +613,14 @@ const u8 *ARMXEmitter::AlignCode16()
 	return code;
 }
 
+const u8 *ARMXEmitter::NopAlignCode16() {
+	int bytes = ((-(intptr_t)code) & 15);
+	for (int i = 0; i < bytes / 4; i++) {
+		Write32(0xE320F000); // one of many possible nops
+	}
+	return code;
+}
+
 const u8 *ARMXEmitter::AlignCodePage()
 {
 	ReserveCodeSpace((-(intptr_t)code) & 4095);

--- a/Common/ArmEmitter.h
+++ b/Common/ArmEmitter.h
@@ -446,6 +446,8 @@ public:
 	void ReserveCodeSpace(u32 bytes);
 	const u8 *AlignCode16();
 	const u8 *AlignCodePage();
+	const u8 *NopAlignCode16();
+
 	void FlushIcache();
 	void FlushIcacheSection(u8 *start, u8 *end);
 	u8 *GetWritableCodePtr();

--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -140,6 +140,37 @@ const u8 *XEmitter::AlignCodePage()
 	return code;
 }
 
+const u8 *XEmitter::NopAlignCode16() {
+	int nops = 16 - ((u64)code & 15);
+	if (nops == 16)
+		return code;
+
+	// note: the string lengths are obviously not computable with strlen, but are equal to the index.
+	// Nop strings from https://stackoverflow.com/questions/25545470/long-multi-byte-nops-commonly-understood-macros-or-other-notation
+	static const char * const nopStrings[16] = {
+		"",
+		"\x90",
+		"\x66\x90",
+		"\x0f\x1f\00",
+		"\x0f\x1f\x40\x00",
+		"\x0f\x1f\x44\x00\x00",
+		"\x66\x0f\x1f\x44\x00\x00",
+		"\x0f\x1f\x80\x00\x00\x00\x00",
+		"\x0f\x1f\x84\x00\x00\x00\x00\x00",
+		"\x66\x0f\x1f\x84\x00\x00\x00\x00\x00",
+		"\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00",
+		"\x66\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00",
+		"\x66\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00\x90",
+		"\x66\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00\x66\x90",
+		"\x66\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00\x0f\x1f\00",
+		"\x66\x66\x66\x0f\x1f\x84\x00\x00\x00\x00\x00\x0f\x1f\x40\x00",
+	};
+
+	memcpy(code, nopStrings[nops], nops);
+	code += nops;
+	return code;
+}
+
 // This operation modifies flags; check to see the flags are locked.
 // If the flags are locked, we should immediately and loudly fail before
 // causing a subtle JIT bug.

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -406,6 +406,10 @@ public:
 	const u8 *AlignCode4();
 	const u8 *AlignCode16();
 	const u8 *AlignCodePage();
+
+	// Nops until the code pointer is 16-byte aligned. Good for loops.
+	const u8 *NopAlignCode16();
+
 	u8 *GetWritableCodePtr();
 
 	void LockFlags() { flags_locked = true; }

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -143,7 +143,7 @@ protected:
 	uint64_t ComputeHash();
 
 	// Vertex decoding
-	void DecodeVertsStep(u8 *dest, int &i, int &decodedVerts);
+	void DecodeVertsStep(u8 *dest, int &i, int &decodedVerts, const UVScale *uvScale);
 
 	void ApplyFramebufferRead(FBOTexState *fboTexState);
 

--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -248,7 +248,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 		MOV(fullAlphaReg, 0xFF);
 	}
 
-	JumpTarget loopStart = GetCodePtr();
+	JumpTarget loopStart = NopAlignCode16();
 	// Preload data cache ahead of reading. This offset seems pretty good.
 	PLD(srcReg, 64);
 	for (int i = 0; i < dec.numSteps_; i++) {

--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -190,7 +190,6 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 
 	// Keep the scale/offset in a few fp registers if we need it.
 	if (prescaleStep) {
-		MOVP2R(R3, &gstate_c.uv);
 		VLD1(F_32, neonUVScaleReg, R3, 2, ALIGN_NONE);
 		if ((dec.VertexType() & GE_VTYPE_TC_MASK) == GE_VTYPE_TC_8BIT) {
 			VMOV_neon(F_32, neonScratchReg, by128);

--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -238,7 +238,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 		LDRH(INDEX_UNSIGNED, boundsMaxVReg, scratchReg64, offsetof(KnownVertexBounds, maxV));
 	}
 
-	const u8 *loopStart = GetCodePtr();
+	const u8 *loopStart = NopAlignCode16();
 	for (int i = 0; i < dec.numSteps_; i++) {
 		if (!CompileStep(dec, i)) {
 			EndWrite();

--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -39,6 +39,9 @@ static const ARM64Reg srcReg = X0;
 static const ARM64Reg dstReg = X1;
 
 static const ARM64Reg counterReg = W2;
+
+static const ARM64Reg uvScaleReg = X3;
+
 static const ARM64Reg tempReg1 = W3;
 static const ARM64Reg tempRegPtr = X3;
 static const ARM64Reg tempReg2 = W4;
@@ -175,7 +178,6 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 
 	// Keep the scale/offset in a few fp registers if we need it.
 	if (prescaleStep) {
-		MOVP2R(X3, &gstate_c.uv);
 		fp.LDR(64, INDEX_UNSIGNED, neonUVScaleReg, X3, 0);
 		fp.LDR(64, INDEX_UNSIGNED, neonUVOffsetReg, X3, 8);
 		if ((dec.VertexType() & GE_VTYPE_TC_MASK) == GE_VTYPE_TC_8BIT) {

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -320,7 +320,7 @@ struct JitLookup {
 // Collapse to less skinning shaders to reduce shader switching, which is expensive.
 int TranslateNumBones(int bones);
 
-typedef void(*JittedVertexDecoder)(const u8 *src, u8 *dst, int count);
+typedef void (*JittedVertexDecoder)(const u8 *src, u8 *dst, int count, const UVScale *uvScaleOffset);
 
 struct VertexDecoderOptions {
 	bool expandAllWeightsToFloat;
@@ -338,7 +338,7 @@ public:
 
 	const DecVtxFormat &GetDecVtxFmt() const { return decFmt; }
 
-	void DecodeVerts(u8 *decoded, const void *verts, int indexLowerBound, int indexUpperBound) const;
+	void DecodeVerts(u8 *decoded, const void *verts, const UVScale *uvScaleOffset, int indexLowerBound, int indexUpperBound) const;
 
 	int VertexSize() const { return size; }  // PSP format size
 

--- a/GPU/Common/VertexDecoderRiscV.cpp
+++ b/GPU/Common/VertexDecoderRiscV.cpp
@@ -33,11 +33,11 @@ static const float const65535 = 65535.0f;
 
 using namespace RiscVGen;
 
-static const RiscVReg srcReg = X10;
-static const RiscVReg dstReg = X11;
-static const RiscVReg counterReg = X12;
+static const RiscVReg srcReg = X10;  // a0
+static const RiscVReg dstReg = X11;  // a1
+static const RiscVReg counterReg = X12;  // a2
 
-static const RiscVReg tempReg1 = X13;
+static const RiscVReg tempReg1 = X13;  // a3
 static const RiscVReg tempReg2 = X14;
 static const RiscVReg tempReg3 = X15;
 static const RiscVReg scratchReg = X16;
@@ -234,7 +234,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 
 	// Keep the scale/offset in a few fp registers if we need it.
 	if (prescaleStep) {
-		LI(tempReg1, &gstate_c.uv);
+		// tempReg1 happens to be the fourth argument register.
 		FL(32, prescaleRegs.scale.u, tempReg1, 0);
 		FL(32, prescaleRegs.scale.v, tempReg1, 4);
 		FL(32, prescaleRegs.offset.u, tempReg1, 8);

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -272,7 +272,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 	}
 
 	// Let's not bother with a proper stack frame. We just grab the arguments and go.
-	JumpTarget loopStart = GetCodePtr();
+	JumpTarget loopStart = NopAlignCode16();
 	for (int i = 0; i < dec.numSteps_; i++) {
 		if (!CompileStep(dec, i)) {
 			EndWrite();

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -469,7 +469,7 @@ public:
 		if (useIndices_)
 			GetIndexBounds(indices, vertex_count, vertex_type, &lowerBound_, &upperBound_);
 		if (vertex_count != 0)
-			vdecoder.DecodeVerts(base, vertices, lowerBound_, upperBound_);
+			vdecoder.DecodeVerts(base, vertices, &gstate_c.uv, lowerBound_, upperBound_);
 
 		// If we're only using a subset of verts, it's better to decode with random access (usually.)
 		// However, if we're reusing a lot of verts, we should read and cache them.

--- a/Windows/.gitignore
+++ b/Windows/.gitignore
@@ -2,3 +2,4 @@
 *.VC.db
 *.txt
 enc_temp_folder
+Win32

--- a/unittest/TestVertexJit.cpp
+++ b/unittest/TestVertexJit.cpp
@@ -78,7 +78,7 @@ public:
 	void Execute(int vtype, int indexUpperBound, bool useJit) {
 		SetupExecute(vtype, useJit);
 
-		dec_->DecodeVerts(dst_, src_, indexLowerBound_, indexUpperBound);
+		dec_->DecodeVerts(dst_, src_, &gstate_c.uv, indexLowerBound_, indexUpperBound);
 	}
 
 	double ExecuteTimed(int vtype, int indexUpperBound, bool useJit) {
@@ -88,7 +88,7 @@ public:
 		double st = time_now_d();
 		do {
 			for (int j = 0; j < ROUNDS; ++j) {
-				dec_->DecodeVerts(dst_, src_, indexLowerBound_, indexUpperBound);
+				dec_->DecodeVerts(dst_, src_, &gstate_c.uv, indexLowerBound_, indexUpperBound);
 				++total;
 			}
 		} while (time_now_d() - st < 0.5);


### PR DESCRIPTION
Cleaner than overwriting/restoring gstate_c.uvScale in the decoder loop. A small cleanup I've been wanting to do for ages.

Expecting a negligible perf boost if any.