### PR TITLE
ARM64: Optimize saved registers in vertex decoder.

### DIFF
--- a/Common/Arm64Emitter.h
+++ b/Common/Arm64Emitter.h
@@ -94,7 +94,7 @@ enum ARM64Reg
 
 // R19-R28. R29 (FP), R30 (LR) are always saved and FP updated appropriately.
 const u32 ALL_CALLEE_SAVED = 0x1FF80000;
-const u32 ALL_CALLEE_SAVED_FP = 0x0000FF00;  // d8-d15
+const u32 ALL_CALLEE_SAVED_FP = 0x0000FF00;  // q8-q15
 
 inline bool Is64Bit(ARM64Reg reg) { return (reg & 0x20) != 0; }
 inline bool IsSingle(ARM64Reg reg) { return (reg & 0xC0) == 0x40; }


### PR DESCRIPTION
Reduces the per-decode-call overhead a bit, might help games that do zillions of tiny draws that we then have to combine, there are a bunch of those.

Also simplify away some arrays with unused elements (purely cleanup).