### PR TITLE
IndexGenerator::AddStrip: Reduce unnecessary writes for small strips

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -104,9 +104,11 @@ int DrawEngineCommon::ComputeNumVertsToDecode() const {
 }
 
 void DrawEngineCommon::DecodeVerts(u8 *dest) {
-	for (; decodeCounter_ < numDrawCalls_; decodeCounter_++) {
-		DecodeVertsStep(dest, decodeCounter_, decodedVerts_, &drawCalls_[decodeCounter_].uvScale);  // NOTE! DecodeVertsStep can modify decodeCounter_!
+	int decodeCounter = decodeCounter_;
+	for (; decodeCounter < numDrawCalls_; decodeCounter++) {
+		DecodeVertsStep(dest, decodeCounter, decodedVerts_, &drawCalls_[decodeCounter].uvScale);  // NOTE! DecodeVertsStep can modify decodeCounter_!
 	}
+	decodeCounter_ = decodeCounter;
 
 	// Sanity check
 	if (indexGen.Prim() < 0) {

--- a/GPU/Common/IndexGenerator.cpp
+++ b/GPU/Common/IndexGenerator.cpp
@@ -159,18 +159,23 @@ void IndexGenerator::AddStrip(int numVerts, bool clockwise) {
 #elif PPSSPP_ARCH(ARM_NEON)
 	int numChunks = (numTris + 7) / 8;
 	uint16x8_t ibase8 = vdupq_n_u16(index_);
-	uint16x8_t increment = vdupq_n_u16(8);
 	const u16 *offsets = clockwise ? offsets_clockwise : offsets_counter_clockwise;
-	uint16x8_t offsets0 = vld1q_u16(offsets);
-	uint16x8_t offsets1 = vld1q_u16(offsets + 8);
-	uint16x8_t offsets2 = vld1q_u16(offsets + 16);
 	u16 *dst = inds_;
-	for (int i = 0; i < numChunks; i++) {
-		vst1q_u16(dst, vaddq_u16(ibase8, offsets0));
-		vst1q_u16(dst + 8, vaddq_u16(ibase8, offsets1));
-		vst1q_u16(dst + 16, vaddq_u16(ibase8, offsets2));
-		ibase8 = vaddq_u16(ibase8, increment);
+	uint16x8_t offsets0 = vaddq_u16(ibase8, vld1q_u16(offsets));
+	vst1q_u16(dst, offsets0);
+	uint16x8_t offsets1 = vaddq_u16(ibase8, vld1q_u16(offsets + 8));
+	vst1q_u16(dst + 8, offsets1);
+	uint16x8_t offsets2 = vaddq_u16(ibase8, vld1q_u16(offsets + 16));
+	vst1q_u16(dst + 16, offsets2);
+	uint16x8_t increment = vdupq_n_u16(8);
+	for (int i = 1; i < numChunks; i++) {
 		dst += 3 * 8;
+		offsets0 = vaddq_u16(offsets0, increment);
+		offsets1 = vaddq_u16(offsets1, increment);
+		offsets2 = vaddq_u16(offsets2, increment);
+		vst1q_u16(dst, offsets0);
+		vst1q_u16(dst + 8, offsets1);
+		vst1q_u16(dst + 16, offsets2);
 	}
 	inds_ += numTris * 3;
 #else

--- a/GPU/Common/IndexGenerator.cpp
+++ b/GPU/Common/IndexGenerator.cpp
@@ -163,19 +163,23 @@ void IndexGenerator::AddStrip(int numVerts, bool clockwise) {
 	u16 *dst = inds_;
 	uint16x8_t offsets0 = vaddq_u16(ibase8, vld1q_u16(offsets));
 	vst1q_u16(dst, offsets0);
-	uint16x8_t offsets1 = vaddq_u16(ibase8, vld1q_u16(offsets + 8));
-	vst1q_u16(dst + 8, offsets1);
-	uint16x8_t offsets2 = vaddq_u16(ibase8, vld1q_u16(offsets + 16));
-	vst1q_u16(dst + 16, offsets2);
-	uint16x8_t increment = vdupq_n_u16(8);
-	for (int i = 1; i < numChunks; i++) {
-		dst += 3 * 8;
-		offsets0 = vaddq_u16(offsets0, increment);
-		offsets1 = vaddq_u16(offsets1, increment);
-		offsets2 = vaddq_u16(offsets2, increment);
-		vst1q_u16(dst, offsets0);
+	if (numTris > 2) {
+		uint16x8_t offsets1 = vaddq_u16(ibase8, vld1q_u16(offsets + 8));
 		vst1q_u16(dst + 8, offsets1);
-		vst1q_u16(dst + 16, offsets2);
+		if (numTris > 5) {
+			uint16x8_t offsets2 = vaddq_u16(ibase8, vld1q_u16(offsets + 16));
+			vst1q_u16(dst + 16, offsets2);
+			uint16x8_t increment = vdupq_n_u16(8);
+			for (int i = 1; i < numChunks; i++) {
+				dst += 3 * 8;
+				offsets0 = vaddq_u16(offsets0, increment);
+				offsets1 = vaddq_u16(offsets1, increment);
+				offsets2 = vaddq_u16(offsets2, increment);
+				vst1q_u16(dst, offsets0);
+				vst1q_u16(dst + 8, offsets1);
+				vst1q_u16(dst + 16, offsets2);
+			}
+		}
 	}
 	inds_ += numTris * 3;
 #else

--- a/GPU/Common/IndexGenerator.cpp
+++ b/GPU/Common/IndexGenerator.cpp
@@ -129,7 +129,7 @@ void IndexGenerator::AddStrip(int numVerts, bool clockwise) {
 
 	// We allow ourselves to write some extra indices to avoid the fallback loop.
 	// That's alright as we're appending to a buffer - they will get overwritten anyway.
-	int numChunks = (numTris + 7) / 8;
+	int numChunks = (numTris + 7) >> 3;
 	__m128i ibase8 = _mm_set1_epi16(index_);
 	const __m128i *offsets = (const __m128i *)(clockwise ? offsets_clockwise : offsets_counter_clockwise);
 	__m128i *dst = (__m128i *)inds_;
@@ -157,7 +157,7 @@ void IndexGenerator::AddStrip(int numVerts, bool clockwise) {
 	inds_ += numTris * 3;
 	// wind doesn't need to be updated, an even number of triangles have been drawn.
 #elif PPSSPP_ARCH(ARM_NEON)
-	int numChunks = (numTris + 7) / 8;
+	int numChunks = (numTris + 7) >> 3;
 	uint16x8_t ibase8 = vdupq_n_u16(index_);
 	const u16 *offsets = clockwise ? offsets_clockwise : offsets_counter_clockwise;
 	u16 *dst = inds_;


### PR DESCRIPTION
I plan to eventually have the index generator write directly into the index buffer instead of going to a temporary one and then copy, and for that, it'll be more important to minimize the amount of stores. Plus, this is slightly faster as-is.

Small strips are more common than I realized, especially in PS2 ports or games based on engines coming from the PS2.

I'm not sure the > 5 check is worth it, though, it'll probably depend on the game.

Inspected the generated assembly, it's super tight even with the early-outs. Can't be faster than this.