### PR TITLE
UI: Icon image cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -759,6 +759,8 @@ add_library(Common STATIC
 	Common/UI/UI.h
 	Common/UI/Context.cpp
 	Common/UI/Context.h
+	Common/UI/IconCache.cpp
+	Common/UI/IconCache.h
 	Common/UI/UIScreen.cpp
 	Common/UI/UIScreen.h
 	Common/UI/Tween.cpp

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -576,6 +576,7 @@
     <ClInclude Include="TimeUtil.h" />
     <ClInclude Include="UI\AsyncImageFileView.h" />
     <ClInclude Include="UI\Context.h" />
+    <ClInclude Include="UI\IconCache.h" />
     <ClInclude Include="UI\PopupScreens.h" />
     <ClInclude Include="UI\Root.h" />
     <ClInclude Include="UI\Screen.h" />
@@ -1029,6 +1030,7 @@
     <ClCompile Include="TimeUtil.cpp" />
     <ClCompile Include="UI\AsyncImageFileView.cpp" />
     <ClCompile Include="UI\Context.cpp" />
+    <ClCompile Include="UI\IconCache.cpp" />
     <ClCompile Include="UI\PopupScreens.cpp" />
     <ClCompile Include="UI\Root.cpp" />
     <ClCompile Include="UI\Screen.cpp" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -506,6 +506,9 @@
     <ClInclude Include="GPU\MiscTypes.h">
       <Filter>GPU</Filter>
     </ClInclude>
+    <ClInclude Include="UI\IconCache.h">
+      <Filter>UI</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />
@@ -946,6 +949,9 @@
     </ClCompile>
     <ClCompile Include="GPU\GPUBackendCommon.cpp">
       <Filter>GPU</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\IconCache.cpp">
+      <Filter>UI</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -259,6 +259,7 @@ public:
 	// We pass in width/height here even though it's not strictly needed until we support glTextureStorage
 	// and then we'll also need formats and stuff.
 	GLRTexture *CreateTexture(GLenum target, int width, int height, int depth, int numMips) {
+		_dbg_assert_(target != 0);
 		GLRInitStep &step = initSteps_.push_uninitialized();
 		step.stepType = GLRInitStepType::CREATE_TEXTURE;
 		step.create_texture.texture = new GLRTexture(caps_, width, height, depth, numMips);

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -822,7 +822,7 @@ InputLayout *OpenGLContext::CreateInputLayout(const InputLayoutDesc &desc) {
 	return fmt;
 }
 
-GLuint TypeToTarget(TextureType type) {
+static GLuint TypeToTarget(TextureType type) {
 	switch (type) {
 #ifndef USING_GLES2
 	case TextureType::LINEAR1D: return GL_TEXTURE_1D;
@@ -875,6 +875,10 @@ private:
 };
 
 OpenGLTexture::OpenGLTexture(GLRenderManager *render, const TextureDesc &desc) : render_(render) {
+	_dbg_assert_(desc.format != Draw::DataFormat::UNDEFINED);
+	_dbg_assert_(desc.width > 0 && desc.height > 0 && desc.depth > 0);
+	_dbg_assert_(type_ != Draw::TextureType::UNKNOWN);
+
 	generatedMips_ = false;
 	generateMips_ = desc.generateMips;
 	width_ = desc.width;

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -463,10 +463,10 @@ public:
 class Texture : public RefCountedObject {
 public:
 	Texture() : RefCountedObject("Texture") {}
-	int Width() { return width_; }
-	int Height() { return height_; }
-	int Depth() { return depth_; }
-	DataFormat Format() { return format_; }
+	int Width() const { return width_; }
+	int Height() const { return height_; }
+	int Depth() const { return depth_; }
+	DataFormat Format() const { return format_; }
 
 protected:
 	int width_ = -1, height_ = -1, depth_ = -1;

--- a/Common/UI/IconCache.cpp
+++ b/Common/UI/IconCache.cpp
@@ -102,7 +102,10 @@ bool IconCache::LoadFromFile(FILE *file) {
 void IconCache::ClearTextures() {
 	std::unique_lock<std::mutex> lock(lock_);
 	for (auto &iter : cache_) {
-		iter.second.texture->Release();
+		if (iter.second.texture) {
+			iter.second.texture->Release();
+			iter.second.texture = nullptr;
+		}
 	}
 }
 

--- a/Common/UI/IconCache.cpp
+++ b/Common/UI/IconCache.cpp
@@ -225,3 +225,18 @@ Draw::Texture *IconCache::BindIconTexture(UIContext *context, const std::string 
 
 	return texture;
 }
+
+IconCacheStats IconCache::GetStats() {
+	IconCacheStats stats{};
+
+	std::unique_lock<std::mutex> lock(lock_);
+
+	for (auto &iter : cache_) {
+		stats.cachedCount++;
+		if (iter.second.texture)
+			stats.textureCount++;
+		stats.dataSize += iter.second.data.size();
+	}
+
+	return stats;
+}

--- a/Common/UI/IconCache.cpp
+++ b/Common/UI/IconCache.cpp
@@ -1,0 +1,202 @@
+#include "Common/UI/IconCache.h"
+#include "Common/UI/Context.h"
+#include "Common/TimeUtil.h"
+#include "Common/Data/Format/PNGLoad.h"
+#include "Common/Log.h"
+
+#define ICON_CACHE_VERSION 1
+
+#define MK_FOURCC(str) (str[0] | ((uint8_t)str[1] << 8) | ((uint8_t)str[2] << 16) | ((uint8_t)str[3] << 24))
+
+const uint32_t ICON_CACHE_MAGIC = MK_FOURCC("pICN");
+
+IconCache g_iconCache;
+
+struct DiskCacheHeader {
+	uint32_t magic;
+	uint32_t version;
+	uint32_t entryCount;
+};
+
+struct DiskCacheEntry {
+	uint32_t keyLen;
+	uint32_t dataLen;
+	IconFormat format;
+	double insertedTimestamp;
+};
+
+void IconCache::SaveToFile(FILE *file) {
+	Decimate();
+
+	std::unique_lock<std::mutex> lock(lock_);
+
+	DiskCacheHeader header;
+	header.magic = ICON_CACHE_MAGIC;
+	header.version = ICON_CACHE_VERSION;
+	header.entryCount = 0;  // (uint32_t)cache_.size();
+
+	fwrite(&header, 1, sizeof(header), file);
+
+	return;
+
+	for (auto &iter : cache_) {
+		DiskCacheEntry entryHeader;
+		entryHeader.keyLen = (uint32_t)iter.first.size();
+		entryHeader.dataLen = (uint32_t)iter.second.data.size();
+		entryHeader.format = iter.second.format;
+		entryHeader.insertedTimestamp = iter.second.insertedTimeStamp;
+		fwrite(&entryHeader, 1, sizeof(entryHeader), file);
+		fwrite(iter.first.c_str(), 1, iter.first.size(), file);
+		fwrite(iter.second.data.data(), 1, iter.second.data.size(), file);
+	}
+}
+
+bool IconCache::LoadFromFile(FILE *file) {
+	std::unique_lock<std::mutex> lock(lock_);
+
+	DiskCacheHeader header;
+	if (fread(&header, 1, sizeof(header), file) != sizeof(DiskCacheHeader)) {
+		return false;
+	}
+	if (header.magic != ICON_CACHE_MAGIC || header.version != ICON_CACHE_VERSION) {
+		return false;
+	}
+
+	double now = time_now_d();
+
+	for (uint32_t i = 0; i < header.entryCount; i++) {
+		DiskCacheEntry entryHeader;
+		if (fread(&entryHeader, 1, sizeof(entryHeader), file) != sizeof(entryHeader)) {
+			break;
+		}
+
+		std::string key;
+		key.resize(entryHeader.keyLen, 0);
+		if (entryHeader.keyLen > 0x1000) {
+			// Let's say this is invalid, probably a corrupted file.
+			break;
+		}
+
+		fread(&key[0], 1, entryHeader.keyLen, file);
+
+		// Check if we already have the entry somehow.
+		if (cache_.find(key) != cache_.end()) {
+			// Seek past the data and go to the next entry.
+			fseek(file, entryHeader.dataLen, SEEK_CUR);
+			continue;
+		}
+
+		std::string data;
+		data.resize(entryHeader.dataLen);
+		fread(&data[0], 1, entryHeader.dataLen, file);
+
+		Entry entry{};
+		entry.data = data;
+		entry.format = entryHeader.format;
+		entry.insertedTimeStamp = entryHeader.insertedTimestamp;
+		entry.usedTimeStamp = now;
+		cache_.insert(std::pair<std::string, Entry>(key, entry));
+	}
+
+	return true;
+}
+
+void IconCache::ClearTextures() {
+	std::unique_lock<std::mutex> lock(lock_);
+	for (auto &iter : cache_) {
+		iter.second.texture->Release();
+	}
+}
+
+void IconCache::ClearData() {
+	ClearTextures();
+	std::unique_lock<std::mutex> lock(lock_);
+	cache_.clear();
+}
+
+void IconCache::Decimate() {
+	std::unique_lock<std::mutex> lock(lock_);
+
+}
+
+bool IconCache::InsertIcon(const std::string &key, IconFormat format, std::string &&data) {
+	std::unique_lock<std::mutex> lock(lock_);
+
+	if (key.empty()) {
+		return false;
+	}
+
+	if (data.empty()) {
+		ERROR_LOG(G3D, "Can't insert empty data into icon cache");
+		return false;
+	}
+
+	if (cache_.find(key) != cache_.end()) {
+		// Already have this entry.
+		return false;
+	}
+
+	double now = time_now_d();
+	cache_.emplace(key, Entry{ std::move(data), format, nullptr, now, now, false });
+	return true;
+}
+
+bool IconCache::BindIconTexture(UIContext *context, const std::string &key) {
+	std::unique_lock<std::mutex> lock(lock_);
+	auto iter = cache_.find(key);
+	if (iter == cache_.end()) {
+		// Don't have this entry.
+		return false;
+	}
+
+	if (iter->second.texture) {
+		context->GetDrawContext()->BindTexture(0, iter->second.texture);
+		iter->second.usedTimeStamp = time_now_d();
+		return true;
+	}
+
+	if (iter->second.badData) {
+		return false;
+	}
+
+	// OK, don't have a texture. Upload it!
+	int width = 0;
+	int height = 0;
+	Draw::DataFormat dataFormat;
+	unsigned char *buffer = nullptr;
+
+	switch (iter->second.format) {
+	case IconFormat::PNG:
+	{
+		int result = pngLoadPtr((const unsigned char *)iter->second.data.data(), iter->second.data.size(), &width,
+			&height, &buffer);
+
+		if (result != 1) {
+			ERROR_LOG(G3D, "IconCache: Failed to load png (%d bytes) for key %s", (int)iter->second.data.size(), key.c_str());
+			iter->second.badData = true;
+			return false;
+		}
+		dataFormat = Draw::DataFormat::R8G8B8A8_UNORM;
+		break;
+	}
+	default:
+		return false;
+	}
+
+	Draw::TextureDesc iconDesc{};
+	iconDesc.width = width;
+	iconDesc.height = height;
+	iconDesc.depth = 1;
+	iconDesc.initData.push_back((const uint8_t *)buffer);
+	iconDesc.mipLevels = 1;
+	iconDesc.swizzle = Draw::TextureSwizzle::DEFAULT;
+	iconDesc.generateMips = false;
+	iconDesc.tag = key.c_str();
+
+	Draw::Texture *texture = context->GetDrawContext()->CreateTexture(iconDesc);
+	iter->second.texture = texture;
+
+	free(buffer);
+
+	return true;
+}

--- a/Common/UI/IconCache.h
+++ b/Common/UI/IconCache.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <set>
 #include <string>
 #include <cstdio>
 #include <mutex>
@@ -23,6 +24,7 @@ class Texture;
 struct IconCacheStats {
 	size_t cachedCount;
 	size_t textureCount;  // number of cached images that are "live" textures
+	size_t pending;
 	size_t dataSize;
 };
 
@@ -30,7 +32,9 @@ class IconCache {
 public:
 	Draw::Texture *BindIconTexture(UIContext *context, const std::string &key);
 
-	// It's okay to call this from any thread.
+	// It's okay to call these from any thread.
+	bool MarkPending(const std::string &key);  // returns false if already pending or loaded
+	void Cancel(const std::string &key);
 	bool InsertIcon(const std::string &key, IconFormat format, std::string &&pngData);
 	bool GetDimensions(const std::string &key, int *width, int *height);
 	bool Contains(const std::string &key);
@@ -56,6 +60,7 @@ private:
 	void Decimate();
 
 	std::map<std::string, Entry> cache_;
+	std::set<std::string> pending_;
 
 	std::mutex lock_;
 };

--- a/Common/UI/IconCache.h
+++ b/Common/UI/IconCache.h
@@ -30,6 +30,8 @@ struct IconCacheStats {
 
 class IconCache {
 public:
+	// NOTE: Don't store the returned texture. Only use it to look up dimensions or other properties,
+	// instead call BindIconTexture every time you want to use it.
 	Draw::Texture *BindIconTexture(UIContext *context, const std::string &key);
 
 	// It's okay to call these from any thread.
@@ -41,6 +43,8 @@ public:
 
 	void SaveToFile(FILE *file);
 	bool LoadFromFile(FILE *file);
+
+	void FrameUpdate();
 
 	void ClearTextures();
 	void ClearData();
@@ -57,12 +61,12 @@ private:
 		bool badData;
 	};
 
-	void Decimate();
-
 	std::map<std::string, Entry> cache_;
 	std::set<std::string> pending_;
 
 	std::mutex lock_;
+
+	double lastUpdate_ = 0.0;
 };
 
 extern IconCache g_iconCache;

--- a/Common/UI/IconCache.h
+++ b/Common/UI/IconCache.h
@@ -20,6 +20,12 @@ class Texture;
 
 // TODO: Possibly make this smarter and use instead of ManagedTexture?
 
+struct IconCacheStats {
+	size_t cachedCount;
+	size_t textureCount;  // number of cached images that are "live" textures
+	size_t dataSize;
+};
+
 class IconCache {
 public:
 	Draw::Texture *BindIconTexture(UIContext *context, const std::string &key);
@@ -34,6 +40,8 @@ public:
 
 	void ClearTextures();
 	void ClearData();
+
+	IconCacheStats GetStats();
 
 private:
 	struct Entry {

--- a/Common/UI/IconCache.h
+++ b/Common/UI/IconCache.h
@@ -14,14 +14,20 @@ enum class IconFormat : uint32_t {
 	PNG,
 };
 
+namespace Draw {
+class Texture;
+}
+
 // TODO: Possibly make this smarter and use instead of ManagedTexture?
 
 class IconCache {
 public:
-	bool BindIconTexture(UIContext *context, const std::string &key);
+	Draw::Texture *BindIconTexture(UIContext *context, const std::string &key);
 
 	// It's okay to call this from any thread.
 	bool InsertIcon(const std::string &key, IconFormat format, std::string &&pngData);
+	bool GetDimensions(const std::string &key, int *width, int *height);
+	bool Contains(const std::string &key);
 
 	void SaveToFile(FILE *file);
 	bool LoadFromFile(FILE *file);

--- a/Common/UI/IconCache.h
+++ b/Common/UI/IconCache.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <cstdio>
+#include <mutex>
+#include <cstdint>
+
+#include "Common/GPU/thin3d.h"
+
+class UIContext;
+
+enum class IconFormat : uint32_t {
+	PNG,
+};
+
+// TODO: Possibly make this smarter and use instead of ManagedTexture?
+
+class IconCache {
+public:
+	bool BindIconTexture(UIContext *context, const std::string &key);
+
+	// It's okay to call this from any thread.
+	bool InsertIcon(const std::string &key, IconFormat format, std::string &&pngData);
+
+	void SaveToFile(FILE *file);
+	bool LoadFromFile(FILE *file);
+
+	void ClearTextures();
+	void ClearData();
+
+private:
+	struct Entry {
+		std::string data;
+		IconFormat format;
+		Draw::Texture *texture;
+		double insertedTimeStamp;
+		double usedTimeStamp;
+		bool badData;
+	};
+
+	void Decimate();
+
+	std::map<std::string, Entry> cache_;
+
+	std::mutex lock_;
+};
+
+extern IconCache g_iconCache;

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -52,6 +52,8 @@ void ScreenManager::update() {
 	if (stack_.size()) {
 		stack_.back().screen->update();
 	}
+
+	g_iconCache.FrameUpdate();
 }
 
 void ScreenManager::switchToNext() {

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -6,6 +6,7 @@
 #include "Common/UI/UI.h"
 #include "Common/UI/View.h"
 #include "Common/UI/ViewGroup.h"
+#include "Common/UI/IconCache.h"
 
 #include "Common/Log.h"
 #include "Common/TimeUtil.h"
@@ -130,6 +131,7 @@ void ScreenManager::axis(const AxisInput &axis) {
 void ScreenManager::deviceLost() {
 	for (auto &iter : stack_)
 		iter.screen->deviceLost();
+	g_iconCache.ClearTextures();
 }
 
 void ScreenManager::deviceRestored() {

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -43,6 +43,8 @@
 #include "Common/UI/View.h"
 #include "Common/UI/ViewGroup.h"
 #include "Common/UI/UI.h"
+#include "Common/UI/IconCache.h"
+#include "Common/Data/Text/Parsers.h"
 #include "Common/Profiler/Profiler.h"
 
 #include "Common/LogManager.h"
@@ -782,6 +784,19 @@ void SystemInfoScreen::CreateTabs() {
 			gpuExtensions->Add(new TextView(extension, new LayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetFocusable(true);
 		}
 	}
+
+	LinearLayout *internals = AddTab("DevSystemInfoInternals", si->T("Internals"));
+
+	internals->Add(new ItemHeader(si->T("Icon cache")));
+	IconCacheStats iconStats = g_iconCache.GetStats();
+	internals->Add(new InfoItem(si->T("Image data count"), StringFromFormat("%d", iconStats.cachedCount)));
+	internals->Add(new InfoItem(si->T("Texture count"), StringFromFormat("%d", iconStats.textureCount)));
+	internals->Add(new InfoItem(si->T("Data size"), NiceSizeFormat(iconStats.dataSize)));
+	internals->Add(new Choice(di->T("Clear")))->OnClick.Add([&](UI::EventParams &) {
+		g_iconCache.ClearData();
+		RecreateViews();
+		return UI::EVENT_DONE;
+	});
 }
 
 void AddressPromptScreen::CreatePopupContents(UI::ViewGroup *parent) {

--- a/UWP/CommonUWP/CommonUWP.vcxproj
+++ b/UWP/CommonUWP/CommonUWP.vcxproj
@@ -401,6 +401,7 @@
     <ClInclude Include="..\..\Common\TimeUtil.h" />
     <ClInclude Include="..\..\Common\UI\AsyncImageFileView.h" />
     <ClInclude Include="..\..\Common\UI\Context.h" />
+    <ClInclude Include="..\..\Common\UI\IconCache.h" />
     <ClInclude Include="..\..\Common\UI\PopupScreens.h" />
     <ClInclude Include="..\..\Common\UI\Root.h" />
     <ClInclude Include="..\..\Common\UI\Screen.h" />
@@ -535,6 +536,7 @@
     <ClCompile Include="..\..\Common\TimeUtil.cpp" />
     <ClCompile Include="..\..\Common\UI\AsyncImageFileView.cpp" />
     <ClCompile Include="..\..\Common\UI\Context.cpp" />
+    <ClCompile Include="..\..\Common\UI\IconCache.cpp" />
     <ClCompile Include="..\..\Common\UI\PopupScreens.cpp" />
     <ClCompile Include="..\..\Common\UI\Root.cpp" />
     <ClCompile Include="..\..\Common\UI\Screen.cpp" />

--- a/UWP/CommonUWP/CommonUWP.vcxproj.filters
+++ b/UWP/CommonUWP/CommonUWP.vcxproj.filters
@@ -438,6 +438,9 @@
     <ClCompile Include="..\..\Common\GPU\GPUBackendCommon.cpp">
       <Filter>GPU</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Common\UI\IconCache.cpp">
+      <Filter>UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="targetver.h" />
@@ -828,6 +831,9 @@
     </ClInclude>
     <ClInclude Include="..\..\Common\GPU\GPUBackendCommon.h">
       <Filter>GPU</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Common\UI\IconCache.h">
+      <Filter>UI</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -228,6 +228,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Common/UI/Context.cpp \
   $(SRC)/Common/UI/UIScreen.cpp \
   $(SRC)/Common/UI/Tween.cpp \
+  $(SRC)/Common/UI/IconCache.cpp \
   $(SRC)/Common/UI/View.cpp \
   $(SRC)/Common/UI/ViewGroup.cpp \
   $(SRC)/Common/UI/ScrollView.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -340,6 +340,7 @@ SOURCES_CXX += \
 	$(COMMONDIR)/UI/Context.cpp \
 	$(COMMONDIR)/UI/UIScreen.cpp \
 	$(COMMONDIR)/UI/Tween.cpp \
+	$(COMMONDIR)/UI/IconCache.cpp \
 	$(COMMONDIR)/UI/View.cpp \
 	$(COMMONDIR)/UI/ViewGroup.cpp \
 	$(COMMONDIR)/UI/ScrollView.cpp \


### PR DESCRIPTION
Adds a simple small-image cache.

It can be stored to disk (single file, for performance on Android) and restored. Though this is not yet hooked up, and I'm not sure we want it.

Will be needed to manage all the little achievement icons for #17589 . No need to cache them on disk, but something has to own them.

This also uses the icon cache for the icons in the homebrew store, for testing the concept.