### PR TITLE
Loader: Support HI16/16 pairs, not just LO16

### DIFF
--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -549,7 +549,7 @@ int ElfReader::LoadInto(u32 loadAddress, bool fromTop)
 
 		if (s->sh_flags & SHF_ALLOC)
 		{
-			std::string tag = name && name[0] ? StringFromFormat("ELF/%s", name) : StringFromFormat("ELF/%08x", writeAddr);
+			std::string tag = name && name[0] ? StringFromFormat("%s/%s", modName.c_str(), name) : StringFromFormat("%s/%08x", modName.c_str(), writeAddr);
 			NotifyMemInfo(MemBlockFlags::SUB_ALLOC, writeAddr, s->sh_size, tag.c_str(), tag.size());
 			DEBUG_LOG(LOADER,"Data Section found: %s     Sitting at %08x, size %08x", name, writeAddr, (u32)s->sh_size);
 		}


### PR DESCRIPTION
#17561 tripped in Motorstorm: Arctic Edge, but initially making sure pairs matched didn't make any obvious impact.

https://report.ppsspp.org/logs/kind/1185

After some testing and comparing with PSP relocation behavior (mostly via RAM dumps), it seems that R_MIPS_16 (and maybe any other type) is paired with the R_MIPS_HI16 relocation for the purposes of the carry.

After matching that behavior, the shadows in the game appear to be fixed.  Fixes #7552.

-[Unknown]