### PR TITLE
Overlay: Support progress bars and "extra text" in messages

### DIFF
--- a/Common/Math/geom2d.h
+++ b/Common/Math/geom2d.h
@@ -72,6 +72,9 @@ struct Bounds {
 	Bounds Offset(float xAmount, float yAmount) const {
 		return Bounds(x + xAmount, y + yAmount, w, h);
 	}
+	Bounds Inset(float left, float top, float right, float bottom) {
+		return Bounds(x + left, y + top, w - left - right, h - bottom - top);
+	}
 
 	float x;
 	float y;

--- a/Common/System/Request.cpp
+++ b/Common/System/Request.cpp
@@ -95,8 +95,8 @@ void OnScreenDisplay::SetProgressBar(std::string id, std::string &&message, int 
 	bool found = false;
 	for (auto &bar : bars_) {
 		if (bar.id == id) {
-			_dbg_assert_(minValue == bar.minValue);
-			_dbg_assert_(maxValue == bar.maxValue);
+			bar.minValue = minValue;
+			bar.maxValue = maxValue;
 			bar.progress = progress;
 			bar.message = message;
 			bar.endTime = now + 60.0;  // Nudge the progress bar to keep it shown.

--- a/Common/System/Request.cpp
+++ b/Common/System/Request.cpp
@@ -40,7 +40,7 @@ std::vector<OnScreenDisplay::ProgressBar> OnScreenDisplay::ProgressBars() {
 	return bars_;  // makes a copy.
 }
 
-void OnScreenDisplay::Show(OSDType type, const std::string &text, float duration_s, const char *id) {
+void OnScreenDisplay::Show(OSDType type, const std::string &text, const std::string &text2, float duration_s, const char *id) {
 	// Automatic duration based on type.
 	if (duration_s <= 0.0f) {
 		switch (type) {
@@ -68,7 +68,9 @@ void OnScreenDisplay::Show(OSDType type, const std::string &text, float duration
 				Entry msg = *iter;
 				msg.endTime = now + duration_s;
 				msg.text = text;
+				msg.text2 = text2;
 				msg.type = type;
+				// Move to top (should we? maybe not?)
 				entries_.erase(iter);
 				entries_.insert(entries_.begin(), msg);
 				return;
@@ -78,6 +80,7 @@ void OnScreenDisplay::Show(OSDType type, const std::string &text, float duration
 
 	Entry msg;
 	msg.text = text;
+	msg.text2 = text2;
 	msg.endTime = now + duration_s;
 	msg.type = type;
 	msg.id = id;

--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -228,7 +228,10 @@ enum class OSDType {
 class OnScreenDisplay {
 public:
 	// If you specify 0.0f as duration, a duration will be chosen automatically depending on type.
-	void Show(OSDType type, const std::string &message, float duration_s = 0.0f, const char *id = nullptr);
+	void Show(OSDType type, const std::string &text, float duration_s = 0.0f, const char *id = nullptr) {
+		Show(type, text, "", duration_s, id);
+	}
+	void Show(OSDType type, const std::string &text, const std::string &text2, float duration_s = 0.0f, const char *id = nullptr);
 	void ShowOnOff(const std::string &message, bool on, float duration_s = 0.0f);
 
 	bool IsEmpty() const { return entries_.empty(); }  // Shortcut to skip rendering.
@@ -244,6 +247,7 @@ public:
 	struct Entry {
 		OSDType type;
 		std::string text;
+		std::string text2;
 		const char *id;
 		double endTime;
 		double duration;

--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -236,18 +236,34 @@ public:
 	// Call this every frame, cleans up old entries.
 	void Update();
 
+	// Progress bar controls
+	// Set is both create and update.
+	void SetProgressBar(std::string id, std::string &&message, int minValue, int maxValue, int progress);
+	void RemoveProgressBar(std::string id, float fadeout_s);
+
 	struct Entry {
 		OSDType type;
 		std::string text;
 		const char *id;
 		double endTime;
 		double duration;
-		float progress;
 	};
+
+	struct ProgressBar {
+		std::string id;
+		std::string message;
+		int minValue;
+		int maxValue;
+		int progress;
+		double endTime;
+	};
+
 	std::vector<Entry> Entries();
+	std::vector<ProgressBar> ProgressBars();
 
 private:
 	std::vector<Entry> entries_;
+	std::vector<ProgressBar> bars_;
 	std::mutex mutex_;
 };
 

--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -73,13 +73,13 @@ u32 BlockDevice::CalculateCRC(volatile bool *cancel) {
 void BlockDevice::NotifyReadError() {
 	auto err = GetI18NCategory(I18NCat::ERRORS);
 	if (!reportedError_) {
-		g_OSD.Show(OSDType::MESSAGE_ERROR, err->T("Game disc read error - ISO corrupt"), 6.0f);
+		g_OSD.Show(OSDType::MESSAGE_WARNING, err->T("Game disc read error - ISO corrupt"), fileLoader_->GetPath().ToVisualString(), 6.0f);
 		reportedError_ = true;
 	}
 }
 
 FileBlockDevice::FileBlockDevice(FileLoader *fileLoader)
-	: fileLoader_(fileLoader) {
+	: BlockDevice(fileLoader) {
 	filesize_ = fileLoader->FileSize();
 }
 
@@ -137,7 +137,7 @@ typedef struct ciso_header
 static const u32 CSO_READ_BUFFER_SIZE = 256 * 1024;
 
 CISOFileBlockDevice::CISOFileBlockDevice(FileLoader *fileLoader)
-	: fileLoader_(fileLoader)
+	: BlockDevice(fileLoader)
 {
 	// CISO format is fairly simple, but most tools do not write the header_size.
 
@@ -382,7 +382,7 @@ bool CISOFileBlockDevice::ReadBlocks(u32 minBlock, int count, u8 *outPtr) {
 }
 
 NPDRMDemoBlockDevice::NPDRMDemoBlockDevice(FileLoader *fileLoader)
-	: fileLoader_(fileLoader)
+	: BlockDevice(fileLoader)
 {
 	std::lock_guard<std::mutex> guard(mutex_);
 	MAC_KEY mkey;

--- a/Core/FileSystems/BlockDevices.h
+++ b/Core/FileSystems/BlockDevices.h
@@ -32,6 +32,7 @@ class FileLoader;
 
 class BlockDevice {
 public:
+	BlockDevice(FileLoader *fileLoader) : fileLoader_(fileLoader) {}
 	virtual ~BlockDevice() {}
 	virtual bool ReadBlock(int blockNumber, u8 *outPtr, bool uncached = false) = 0;
 	virtual bool ReadBlocks(u32 minBlock, int count, u8 *outPtr) {
@@ -51,6 +52,7 @@ public:
 	void NotifyReadError();
 
 protected:
+	FileLoader *fileLoader_;
 	bool reportedError_ = false;
 };
 
@@ -64,7 +66,6 @@ public:
 	bool IsDisc() override { return true; }
 
 private:
-	FileLoader *fileLoader_;
 	u32 *index;
 	u8 *readBuffer;
 	u8 *zlibBuffer;
@@ -88,7 +89,6 @@ public:
 	bool IsDisc() override { return true; }
 
 private:
-	FileLoader *fileLoader_;
 	u64 filesize_;
 };
 
@@ -113,7 +113,6 @@ public:
 	bool IsDisc() override { return false; }
 
 private:
-	FileLoader *fileLoader_;
 	static std::mutex mutex_;
 	u32 lbaSize;
 

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -804,7 +804,7 @@ void SystemInfoScreen::CreateTabs() {
 		return UI::EVENT_DONE;
 	});
 	internals->Add(new Choice(si->T("Warning")))->OnClick.Add([&](UI::EventParams &) {
-		g_OSD.Show(OSDType::MESSAGE_WARNING, si->T("Warning"));
+		g_OSD.Show(OSDType::MESSAGE_WARNING, si->T("Warning"), "Some\nAdditional\nDetail");
 		return UI::EVENT_DONE;
 	});
 	internals->Add(new Choice(si->T("Info")))->OnClick.Add([&](UI::EventParams &) {

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -824,6 +824,10 @@ void SystemInfoScreen::CreateTabs() {
 		g_OSD.SetProgressBar("testprogress", "Test Progress", 1, 100, 100);
 		return UI::EVENT_DONE;
 	});
+	internals->Add(new Choice(si->T("N/A%")))->OnClick.Add([&](UI::EventParams &) {
+		g_OSD.SetProgressBar("testprogress", "Test Progress", 0, 0, 0);
+		return UI::EVENT_DONE;
+	});
 	internals->Add(new Choice(si->T("Clear")))->OnClick.Add([&](UI::EventParams &) {
 		g_OSD.RemoveProgressBar("testprogress", 0.25f);
 		return UI::EVENT_DONE;

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -815,6 +815,20 @@ void SystemInfoScreen::CreateTabs() {
 		g_OSD.Show(OSDType::MESSAGE_SUCCESS, si->T("Success"));
 		return UI::EVENT_DONE;
 	});
+	internals->Add(new ItemHeader(si->T("Progress tests")));
+	internals->Add(new Choice(si->T("30%")))->OnClick.Add([&](UI::EventParams &) {
+		g_OSD.SetProgressBar("testprogress", "Test Progress", 1, 100, 30);
+		return UI::EVENT_DONE;
+	});
+	internals->Add(new Choice(si->T("100%")))->OnClick.Add([&](UI::EventParams &) {
+		g_OSD.SetProgressBar("testprogress", "Test Progress", 1, 100, 100);
+		return UI::EVENT_DONE;
+	});
+	internals->Add(new Choice(si->T("Clear")))->OnClick.Add([&](UI::EventParams &) {
+		g_OSD.RemoveProgressBar("testprogress", 0.25f);
+		return UI::EVENT_DONE;
+	});
+
 }
 
 void AddressPromptScreen::CreatePopupContents(UI::ViewGroup *parent) {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -229,6 +229,8 @@ bool EmuScreen::bootAllowStorage(const Path &filename) {
 }
 
 void EmuScreen::bootGame(const Path &filename) {
+	auto sc = GetI18NCategory(I18NCat::SCREEN);
+
 	if (PSP_IsRebooting())
 		return;
 	if (PSP_IsInited()) {
@@ -258,8 +260,6 @@ void EmuScreen::bootGame(const Path &filename) {
 	// Check permission status first, in case we came from a shortcut.
 	if (!bootAllowStorage(filename))
 		return;
-
-	auto sc = GetI18NCategory(I18NCat::SCREEN);
 
 	invalid_ = true;
 


### PR DESCRIPTION
Will later switch over downloads to use these fancy new progress bar indicators, plus they'll be used while downloading achievement data.

The extra text in messages is useful for error data and stuff like that. Now used for "Game disc read error - ISO corrupt" messages, showing the file path. Useful when you get this message when scrolling through a directory of games, where it previously would have been invisible, and now it'll tell you which file is corrupt.