### PR TITLE
align should be 3 when format is GL_RGB and type is GL_UNSIGNED_BYTE

### DIFF
--- a/Common/GPU/OpenGL/DataFormatGL.cpp
+++ b/Common/GPU/OpenGL/DataFormatGL.cpp
@@ -55,7 +55,7 @@ bool Thin3DFormatToGLFormatAndType(DataFormat fmt, GLuint &internalFormat, GLuin
 		internalFormat = GL_RGB;
 		format = GL_RGB;
 		type = GL_UNSIGNED_BYTE;
-		alignment = 1;
+		alignment = 3;
 		break;
 
 	case DataFormat::R4G4B4A4_UNORM_PACK16:


### PR DESCRIPTION
![04b6d12435d7653fe994ca2315cd114](https://github.com/hrydgard/ppsspp/assets/56127613/fe78ddeb-b12a-406f-bf63-a00e3be2dc2e)

>according to `es_spec_3.2.pdf` - Table 8.2: Valid combinations of format, type, and sized internal format.