### PR TITLE
[Nintendo Switch] Lower distance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -801,8 +801,10 @@ add_library(Common STATIC
 	Common/MemArenaDarwin.cpp
 	Common/MemArenaPosix.cpp
 	Common/MemArenaWin32.cpp
+	Common/MemArenaHorizon.cpp
 	Common/MemArena.h
 	Common/MemoryUtil.cpp
+	Common/MemoryUtilHorizon.cpp
 	Common/MemoryUtil.h
 	Common/OSVersion.cpp
 	Common/OSVersion.h

--- a/Common/MemArenaPosix.cpp
+++ b/Common/MemArenaPosix.cpp
@@ -17,7 +17,7 @@
 
 #include "ppsspp_config.h"
 
-#if !defined(_WIN32) && !defined(ANDROID) && !defined(__APPLE__)
+#if !defined(_WIN32) && !defined(ANDROID) && !defined(__APPLE__) && !PPSSPP_PLATFORM(SWITCH)
 
 #include <sys/mman.h>
 #include <sys/stat.h>

--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -17,6 +17,7 @@
 
 #include "ppsspp_config.h"
 
+#if !PPSSPP_PLATFORM(SWITCH)
 #include <cstring>
 #include <cstdlib>
 
@@ -257,7 +258,7 @@ void *AllocateAlignedMemory(size_t size, size_t alignment) {
 #endif
 #endif
 
-	_assert_msg_(ptr != nullptr, "Failed to allocate aligned memory of size %llu", size);
+	_assert_msg_(ptr != nullptr, "Failed to allocate aligned memory of size %lu", size);
 	return ptr;
 }
 
@@ -355,3 +356,4 @@ int GetMemoryProtectPageSize() {
 #endif
 	return MEM_PAGE_SIZE;
 }
+#endif // !PPSSPP_PLATFORM(SWITCH)

--- a/Common/MemoryUtil.h
+++ b/Common/MemoryUtil.h
@@ -18,7 +18,11 @@
 #pragma once
 
 #ifndef _WIN32
+#ifndef __SWITCH__
 #include <sys/mman.h>
+#else
+#include <switch.h>
+#endif // !__SWITCH__
 #endif
 #include <stdint.h>
 

--- a/Common/MemoryUtilHorizon.cpp
+++ b/Common/MemoryUtilHorizon.cpp
@@ -1,0 +1,89 @@
+// Copyright (C) 2003 Dolphin Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official SVN repository and contact information can be found at
+// http://code.google.com/p/dolphin-emu/
+
+#include "ppsspp_config.h"
+
+#if PPSSPP_PLATFORM(SWITCH)
+#include <cstring>
+#include <cstdlib>
+
+#include "Common/CommonTypes.h"
+#include "Common/Log.h"
+#include "Common/MemoryUtil.h"
+#include "Common/StringUtils.h"
+#include "Common/SysError.h"
+
+#include <errno.h>
+#include <stdio.h>
+
+#include <malloc.h> // memalign
+
+#define MEM_PAGE_SIZE (0x1000)
+#define MEM_PAGE_MASK ((MEM_PAGE_SIZE)-1)
+#define ppsspp_round_page(x) ((((uintptr_t)(x)) + MEM_PAGE_MASK) & ~(MEM_PAGE_MASK))
+
+// On Switch we dont support allocating executable memory here
+// See CodeBlock.h
+void *AllocateExecutableMemory(size_t size) {
+	return nullptr;
+}
+
+void *AllocateMemoryPages(size_t size, uint32_t memProtFlags) {
+	void* ptr = nullptr;
+	size = ppsspp_round_page(size);
+	ptr = memalign(MEM_PAGE_SIZE, size);
+	return ptr;
+}
+
+void *AllocateAlignedMemory(size_t size, size_t alignment) {
+	void* ptr = memalign(alignment, size);
+
+	_assert_msg_(ptr != nullptr, "Failed to allocate aligned memory of size %lu", size);
+	return ptr;
+}
+
+void FreeMemoryPages(void *ptr, size_t size) {
+	if (!ptr)
+		return;
+
+	free(ptr);
+	return;
+}
+
+void FreeExecutableMemory(void *ptr, size_t size) {
+	return; // Not supported on Switch
+}
+
+void FreeAlignedMemory(void* ptr) {
+	if (!ptr)
+		return;
+		
+	free(ptr);
+}
+
+bool PlatformIsWXExclusive() {
+	return false; // Switch technically is W^X but we use dual mappings instead of reprotecting the pages to allow a W and X mapping
+}
+
+bool ProtectMemoryPages(const void* ptr, size_t size, uint32_t memProtFlags) {
+	return true;
+}
+
+int GetMemoryProtectPageSize() {
+	return MEM_PAGE_SIZE;
+}
+#endif // PPSSPP_PLATFORM(SWITCH)


### PR DESCRIPTION
First commit just does a fix-up for my last PR
Second commit brings in the required MemoryUtil changes for the Nintendo Switch platform
Could probably argue to move the Switch platform into its own MemoryUtil because of its simplicity.

Tried to fix all whitespaces, _assert_msg_ was changed due to compiler warn which doesnt seem to be Switch specific?