### PR TITLE
Common & CodeBlock changes for Nintendo Switch

### DIFF
--- a/Common/ArmCPUDetect.cpp
+++ b/Common/ArmCPUDetect.cpp
@@ -40,6 +40,7 @@
 #endif
 #endif
 
+#include <cstring>
 #include <ctype.h>
 
 #include "Common/CommonTypes.h"

--- a/Common/CodeBlock.h
+++ b/Common/CodeBlock.h
@@ -10,6 +10,11 @@
 #include "Common/Log.h"
 #include "Common/MemoryUtil.h"
 
+#if PPSSPP_PLATFORM(SWITCH)
+#include <cstdio>
+#include <switch.h>
+#endif // PPSSPP_PLATFORM(SWITCH)
+
 // Everything that needs to generate code should inherit from this.
 // You get memory management for free, plus, you can use all emitter functions without
 // having to prefix them with gen-> or something similar.
@@ -65,9 +70,20 @@ public:
 	// Call this before you generate any code.
 	void AllocCodeSpace(int size) {
 		region_size = size;
+#if PPSSPP_PLATFORM(SWITCH)
+		Result rc = jitCreate(&jitController, size);
+		if(R_FAILED(rc)) {
+			printf("Failed to create Jitbuffer of size 0x%x err: 0x%x\n", size, rc);
+		}
+		printf("[NXJIT]: Initialized RX: %p RW: %p\n", jitController.rx_addr, jitController.rw_addr);
+
+		region = (u8 *)jitController.rx_addr;
+		writableRegion = (u8 *)jitController.rw_addr;
+#else // PPSSPP_PLATFORM(SWITCH)
 		// The protection will be set to RW if PlatformIsWXExclusive.
 		region = (u8 *)AllocateExecutableMemory(region_size);
 		writableRegion = region;
+#endif // !PPSSPP_PLATFORM(SWITCH)
 		T::SetCodePointer(region, writableRegion);
 	}
 
@@ -135,8 +151,13 @@ public:
 
 	// Call this when shutting down. Don't rely on the destructor, even though it'll do the job.
 	void FreeCodeSpace() {
+#if !PPSSPP_PLATFORM(SWITCH)
 		ProtectMemoryPages(region, region_size, MEM_PROT_READ | MEM_PROT_WRITE);
 		FreeExecutableMemory(region, region_size);
+#else // !PPSSPP_PLATFORM(SWITCH)
+		jitClose(&jitController);
+		printf("[NXJIT]: Jit closed\n");
+#endif // PPSSPP_PLATFORM(SWITCH)
 		region = nullptr;
 		writableRegion = nullptr;
 		region_size = 0;
@@ -176,5 +197,7 @@ private:
 	const uint8_t *writeStart_ = nullptr;
 	uint8_t *writableRegion = nullptr;
 	size_t writeEstimated_ = 0;
+#if PPSSPP_PLATFORM(SWITCH)
+	Jit jitController;
+#endif // PPSSPP_PLATFORM(SWITCH)
 };
-

--- a/Common/CommonFuncs.h
+++ b/Common/CommonFuncs.h
@@ -32,6 +32,9 @@
 
 #if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 #define Crash() {asm ("int $3");}
+#elif PPSSPP_PLATFORM(SWITCH)
+// TODO: Implement Crash() for Switch, lets not use breakpoint for the time being
+#define Crash() {*((volatile u32 *)0x0) = 0xDEADC0DE;}
 #elif PPSSPP_ARCH(ARM)
 #define Crash() {asm ("bkpt #0");}
 #elif PPSSPP_ARCH(ARM64)

--- a/Common/CommonTypes.h
+++ b/Common/CommonTypes.h
@@ -36,6 +36,39 @@ typedef signed __int64 s64;
 
 #else
 
+#ifdef __SWITCH__
+// Some HID conflicts
+#define KEY_UP PKEY_UP
+#define KEY_DOWN PKEY_DOWN
+// Other conflicts
+#define Event _Event
+#define Framebuffer _Framebuffer
+#define Waitable _Waitable
+#define ThreadContext _ThreadContext
+#include <switch.h>
+// Cleanup
+#undef KEY_UP
+#undef KEY_DOWN
+#undef Event
+#undef Framebuffer
+#undef Waitable
+#undef ThreadContext
+
+// Conflicting types with libnx
+#ifndef _u64
+#define u64 _u64
+#endif // _u64
+
+#ifndef s64
+#define s64 _s64
+#endif // _s64
+
+typedef unsigned char   u_char;
+typedef unsigned short  u_short;
+typedef unsigned int    u_int;
+typedef unsigned long   u_long;
+#endif // __SWITCH__
+
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned int u32;


### PR DESCRIPTION
- The first commit adds a implementation of W^X dualbase for the Nintendo Switch platform in `CodeBlock`.

- The second commit fixes CommonType for the Nintendo Switch platform, avoiding name conflicts and declaring certain types.

- The third commit adds the `cstring` include to the `ArmCPUDetect`, fixing a compilation error on some platforms.

- The fourth commit adds a placeholder implementation of the `Crash()` method for the Nintendo Switch platform.


