### PR TITLE
[CMake] ext related CMake changes for Nintendo Switch

### DIFF
--- a/ext/cmake/cpu_features/CMakeLists.txt
+++ b/ext/cmake/cpu_features/CMakeLists.txt
@@ -142,7 +142,9 @@ endif()
 add_library(cpu_features ${CPU_FEATURES_HDRS} ${CPU_FEATURES_SRCS})
 set_target_properties(cpu_features PROPERTIES PUBLIC_HEADER "${CPU_FEATURES_HDRS}")
 setup_include_and_definitions(cpu_features)
-target_link_libraries(cpu_features PUBLIC ${CMAKE_DL_LIBS})
+if(NOT USE_LIBNX)
+  target_link_libraries(cpu_features PUBLIC ${CMAKE_DL_LIBS})
+endif()
 target_include_directories(cpu_features
   PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/cpu_features>
 )

--- a/ext/glew/CMakeLists.txt
+++ b/ext/glew/CMakeLists.txt
@@ -1,21 +1,23 @@
 find_package(GLEW)
-if((NOT APPLE OR USE_SYSTEM_FFMPEG) AND GLEW_FOUND)
-  add_library(system_glew INTERFACE)
-  add_library(Ext::GLEW ALIAS system_glew)
-  target_link_libraries(system_glew INTERFACE GLEW::GLEW)
-else()
-  find_package(OpenGL REQUIRED)
-  add_library(glew STATIC
-    GL/glew.h
-    GL/glxew.h
-    GL/wglew.h
-    glew.c
-  )
-  add_library(Ext::GLEW ALIAS glew)
-  target_link_libraries(glew PUBLIC ${OPENGL_LIBRARIES})
-  target_compile_definitions(glew PUBLIC GLEW_STATIC)
-  target_include_directories(glew PUBLIC . ${OPENGL_INCLUDE_DIR})
-  set_target_properties(glew PROPERTIES
-    EXCLUDE_FROM_ALL ON
-  )
+if(NOT USE_LIBNX)
+  if((NOT APPLE OR USE_SYSTEM_FFMPEG) AND GLEW_FOUND)
+    add_library(system_glew INTERFACE)
+    add_library(Ext::GLEW ALIAS system_glew)
+    target_link_libraries(system_glew INTERFACE GLEW::GLEW)
+  else()
+    find_package(OpenGL REQUIRED)
+    add_library(glew STATIC
+      GL/glew.h
+      GL/glxew.h
+      GL/wglew.h
+      glew.c
+    )
+    add_library(Ext::GLEW ALIAS glew)
+    target_link_libraries(glew PUBLIC ${OPENGL_LIBRARIES})
+    target_compile_definitions(glew PUBLIC GLEW_STATIC)
+    target_include_directories(glew PUBLIC . ${OPENGL_INCLUDE_DIR})
+    set_target_properties(glew PROPERTIES
+      EXCLUDE_FROM_ALL ON
+    )
+  endif()
 endif()


### PR DESCRIPTION
Opt-out from a few things, only accounting for committed files.
We dont use GLEW & cpu_features caused to link against -ldl which isnt a thing on Nintendo Switch