### PR TITLE
Revert "Path: If a Path is empty, the slash operator will not add an additional slash."

### DIFF
--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -84,9 +84,7 @@ Path Path::operator /(const std::string &subdir) const {
 	}
 
 	// Direct string manipulation.
-	if (path_.empty()) {
-		return Path(subdir);
-	}
+
 	if (subdir.empty()) {
 		return Path(path_);
 	}


### PR DESCRIPTION
This somehow seems to have caused problems for retroarch. Not that I understand how, must be some misuse of Path.

I don't actually need this anymore I think, so let's just revert.

This reverts commit 864b2bbb3170574fb9144201fb1786559b13c016.