### PR TITLE
Remove the RAIntegration stuff for now (wasn't actually enabled)

### DIFF
--- a/UI/RetroAchievements.h
+++ b/UI/RetroAchievements.h
@@ -108,9 +108,6 @@ bool ConfirmSystemReset();
 /// Called when the system is being shut down. If Shutdown() returns false, the shutdown should be aborted if possible.
 bool Shutdown();
 
-/// Called when the system is being paused and resumed.
-void OnSystemPaused(bool paused);
-
 /// Called once a frame at vsync time on the CPU thread.
 void FrameUpdate();
 


### PR DESCRIPTION
This is just the unused, untested achievement editor integration code that came along with the ride when I adapted RetroAchievement code from DuckStation.

Removing this code will make the conversion to rc_client_t easier. Might eventually add this capability back properly in one way or another.

Part of #17631