### PR TITLE
OpenXR - Game compatibility fixes

### DIFF
--- a/Common/VR/PPSSPPVR.h
+++ b/Common/VR/PPSSPPVR.h
@@ -56,7 +56,7 @@ bool IsFlatVRGame();
 bool IsFlatVRScene();
 bool IsGameVRScene();
 bool Is2DVRObject(float* projMatrix, bool ortho);
-void UpdateVRParams(float* projMatrix, float* viewMatrix);
+void UpdateVRParams(float* projMatrix);
 void UpdateVRProjection(float* projMatrix, float* leftEye, float* rightEye);
 void UpdateVRView(float* leftEye, float* rightEye);
 void UpdateVRViewMatrices();

--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -137,6 +137,7 @@ void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID)
 	CheckSetting(iniFile, gameID, "ForceFlatScreen", &vrCompat_.ForceFlatScreen);
 	CheckSetting(iniFile, gameID, "ForceMono", &vrCompat_.ForceMono);
 	CheckSetting(iniFile, gameID, "IdentityViewHack", &vrCompat_.IdentityViewHack);
+	CheckSetting(iniFile, gameID, "MirroringVariant", &vrCompat_.MirroringVariant);
 	CheckSetting(iniFile, gameID, "Skyplane", &vrCompat_.Skyplane);
 	CheckSetting(iniFile, gameID, "UnitsPerMeter", &vrCompat_.UnitsPerMeter);
 
@@ -155,6 +156,12 @@ void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, co
 }
 
 void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, float *flag) {
+	std::string value;
+	iniFile.Get(option, gameID.c_str(), &value, "0");
+	*flag = stof(value);
+}
+
+void Compatibility::CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, int *flag) {
 	std::string value;
 	iniFile.Get(option, gameID.c_str(), &value, "0");
 	*flag = stof(value);

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -107,6 +107,7 @@ struct VRCompat {
 	bool ForceMono;
 	bool ForceFlatScreen;
 	bool IdentityViewHack;
+	int MirroringVariant;
 	bool Skyplane;
 	float UnitsPerMeter;
 };
@@ -132,6 +133,7 @@ private:
 	void CheckVRSettings(IniFile &iniFile, const std::string &gameID);
 	void CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, bool *flag);
 	void CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, float *value);
+	void CheckSetting(IniFile &iniFile, const std::string &gameID, const char *option, int *value);
 
 	CompatFlags flags_{};
 	VRCompat vrCompat_{};

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -356,6 +356,8 @@ static inline bool GuessVRDrawingHUD(bool is2D, bool flatScreen) {
 	else if (gstate.isClearModeDepthMask()) hud = false;
 	//HUD texture has to contain alpha channel
 	else if (!gstate.isTextureAlphaUsed()) hud = false;
+	//HUD texture cannot be in 5551 format
+	else if (gstate.getTextureFormat() == GETextureFormat::GE_TFMT_5551) hud = false;
 	//HUD texture cannot be in CLUT16 format
 	else if (gstate.getTextureFormat() == GETextureFormat::GE_TFMT_CLUT16) hud = false;
 	//HUD texture cannot be in CLUT32 format

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -429,6 +429,7 @@ void LinkedShader::UpdateUniforms(const ShaderID &vsid, bool useBufferedRenderin
 			} else {
 				UpdateVRProjection(gstate.projMatrix, leftEyeMatrix.m, rightEyeMatrix.m);
 			}
+			UpdateVRParams(gstate.projMatrix);
 
 			FlipProjMatrix(leftEyeMatrix, useBufferedRendering);
 			FlipProjMatrix(rightEyeMatrix, useBufferedRendering);
@@ -566,14 +567,13 @@ void LinkedShader::UpdateUniforms(const ShaderID &vsid, bool useBufferedRenderin
 	if (dirty & DIRTY_WORLDMATRIX) {
 		SetMatrix4x3(render_, &u_world, gstate.worldMatrix);
 	}
-	if ((dirty & DIRTY_VIEWMATRIX) || IsVREnabled()) {
+	if (dirty & DIRTY_VIEWMATRIX) {
 		if (gstate_c.Use(GPU_USE_VIRTUAL_REALITY)) {
 			float leftEyeView[16];
 			float rightEyeView[16];
 			ConvertMatrix4x3To4x4Transposed(leftEyeView, gstate.viewMatrix);
 			ConvertMatrix4x3To4x4Transposed(rightEyeView, gstate.viewMatrix);
 			if (!is2D) {
-				UpdateVRParams(gstate.projMatrix, leftEyeView);
 				UpdateVRView(leftEyeView, rightEyeView);
 			}
 			render_->SetUniformM4x4Stereo("u_view", &u_view, leftEyeView, rightEyeView);

--- a/assets/compatvr.ini
+++ b/assets/compatvr.ini
@@ -84,7 +84,7 @@ ULUS10105 = true
 
 
 [IdentityViewHack]
-# Disables head tracking for render passes where view matrix is Identity
+# Disables head tracking for render passes where view matrix is identity
 
 # Sonic Rivals 1
 ULES00622 = true
@@ -93,6 +93,16 @@ ULUS10195 = true
 # Sonic Rivals 2
 ULES00940 = true
 ULUS10323 = true
+
+
+[MirroringVariant]
+# Forces mirroring of the view matrix
+
+# Tony Hawk's Underground 2 Remix
+ULES00033 = 3
+ULES00034 = 3
+ULES00035 = 3
+ULUS10014 = 3
 
 
 [Skyplane]


### PR DESCRIPTION
This fixes are only for VR version, it doens't affect other versions.
* https://github.com/hrydgard/ppsspp/pull/17636 made the math better but broke the hack for https://github.com/hrydgard/ppsspp/pull/16374. This PR makes that hack better (still unsure what the game does, maybe rotating pitch by 180˚?)

* Digimon Adventure rendering fixed, there was incorrectly the character outline detected as HUD layer.