### PR TITLE
fix `Memory init failed` on Linux x32 ABI

### DIFF
--- a/ppsspp_config.h
+++ b/ppsspp_config.h
@@ -19,7 +19,11 @@
 
 #if defined(_M_X64) || defined(__amd64__) || defined(__x86_64__)
     #define PPSSPP_ARCH_AMD64 1
-    #define PPSSPP_ARCH_64BIT 1
+    #if defined(__ILP32__)
+        #define PPSSPP_ARCH_32BIT 1
+    #else
+        #define PPSSPP_ARCH_64BIT 1
+    #endif
     //TODO: Remove this compat define
     #ifndef _M_X64
         #define _M_X64 1


### PR DESCRIPTION
Error logs

```
OpenGL 2.0 or higher.
loading control pad mappings from gamecontrollerdb.txt: SUCCESS!
found control pad: Speedlink TORID Wireless Gamepad, loading mapping: SUCCESS, mapping is:
030003f05e0400008e02000010010000,Speedlink TORID Wireless Gamepad,platform:Linux,x:b2,a:b0,b:b1,y:b3,back:b6,guide:b8,start:b7,dpleft:h0.8,dpdown:h0.4,dp
right:h0.2,dpup:h0.1,leftshoulder:b4,lefttrigger:a2,rightshoulder:b5,righttrigger:a5,leftstick:b9,rightstick:b10,leftx:a0,lefty:a1,rightx:a3,righty:a4,
pad 1 has been assigned to control pad: Speedlink TORID Wireless Gamepad
found control pad: Speedlink TORID Wireless Gamepad, loading mapping: SUCCESS, mapping is:
030003f05e0400008e02000010010000,Speedlink TORID Wireless Gamepad,platform:Linux,x:b2,a:b0,b:b1,y:b3,back:b6,guide:b8,start:b7,dpleft:h0.8,dpdown:h0.4,dp
right:h0.2,dpup:h0.1,leftshoulder:b4,lefttrigger:a2,rightshoulder:b5,righttrigger:a5,leftstick:b9,rightstick:b10,leftx:a0,lefty:a1,rightx:a3,righty:a4,
03:08:976 Core/System.cpp:430 N[BOOT]: PPSSPP 1.15.4
03:08:976 UI/EmuScreen.cpp:331 E[BOOT]: Memory init failed
```