### PR TITLE
Backport rcheevos build setup to libretro/Makefile.common from the rc_client branch

### DIFF
--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -193,6 +193,35 @@ SOURCES_C += \
 	$(EXTDIR)/libpng17/pngwtran.c \
 	$(EXTDIR)/libpng17/pngwutil.c
 
+INCFLAGS += -I$(EXTDIR)/rcheevos/include
+
+COREFLAGS += -DRC_DISABLE_LUA
+
+SOURCES_C += \
+	$(EXTDIR)/rcheevos/src/rapi/rc_api_common.c \
+	$(EXTDIR)/rcheevos/src/rapi/rc_api_editor.c \
+	$(EXTDIR)/rcheevos/src/rapi/rc_api_info.c \
+	$(EXTDIR)/rcheevos/src/rapi/rc_api_runtime.c \
+	$(EXTDIR)/rcheevos/src/rapi/rc_api_user.c \
+	$(EXTDIR)/rcheevos/src/rcheevos/alloc.c \
+	$(EXTDIR)/rcheevos/src/rcheevos/compat.c \
+	$(EXTDIR)/rcheevos/src/rcheevos/condition.c \
+	$(EXTDIR)/rcheevos/src/rcheevos/condset.c \
+	$(EXTDIR)/rcheevos/src/rcheevos/consoleinfo.c \
+	$(EXTDIR)/rcheevos/src/rcheevos/format.c \
+	$(EXTDIR)/rcheevos/src/rcheevos/lboard.c \
+	$(EXTDIR)/rcheevos/src/rcheevos/memref.c \
+	$(EXTDIR)/rcheevos/src/rcheevos/operand.c \
+	$(EXTDIR)/rcheevos/src/rcheevos/rc_validate.c \
+	$(EXTDIR)/rcheevos/src/rcheevos/richpresence.c \
+	$(EXTDIR)/rcheevos/src/rcheevos/runtime.c \
+	$(EXTDIR)/rcheevos/src/rcheevos/runtime_progress.c \
+	$(EXTDIR)/rcheevos/src/rcheevos/trigger.c \
+	$(EXTDIR)/rcheevos/src/rcheevos/value.c \
+	$(EXTDIR)/rcheevos/src/rhash/cdreader.c \
+	$(EXTDIR)/rcheevos/src/rhash/hash.c \
+	$(EXTDIR)/rcheevos/src/rhash/md5.c
+
 COREFLAGS += -DSTACK_LINE_READER_BUFFER_SIZE=1024
 ifeq ($(PLATFORM_EXT), android)
 COREFLAGS += -DHAVE_DLFCN_H

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1744,3 +1744,9 @@ bool System_AudioRecordingState() { return false; }
 
 void System_InputBoxGetString(const std::string &title, const std::string &defaultValue, std::function<void(bool, const std::string &)> cb) { cb(false, ""); }
 #endif
+
+// TODO: To avoid having to define these here, these should probably be turned into system "requests".
+void NativeSaveSecret(const char *nameOfSecret, const std::string &data) {}
+std::string NativeLoadSecret(const char *nameOfSecret) {
+   return "";
+}


### PR DESCRIPTION
For some reason this was only needed on Windows?

Either way, I just backported the fix I had already made for the rc-client branch, #17646 .