### PR TITLE
Postshader - New version of bloom

### DIFF
--- a/UWP/UWP.vcxproj
+++ b/UWP/UWP.vcxproj
@@ -820,6 +820,9 @@
     <None Include="Content\shaders\bloom.fsh">
       <DeploymentContent>true</DeploymentContent>
     </None>
+    <None Include="Content\shaders\bloomnoblur.fsh">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
     <None Include="Content\shaders\cartoon.fsh">
       <DeploymentContent>true</DeploymentContent>
     </None>

--- a/UWP/UWP.vcxproj.filters
+++ b/UWP/UWP.vcxproj.filters
@@ -292,6 +292,9 @@
     <None Include="Content\shaders\bloom.fsh">
       <Filter>Content\shaders</Filter>
     </None>
+    <None Include="Content\shaders\bloomnoblur.fsh">
+      <Filter>Content\shaders</Filter>
+    </None>
     <None Include="Content\shaders\cartoon.fsh">
       <Filter>Content\shaders</Filter>
     </None>

--- a/assets/shaders/bloomnoblur.fsh
+++ b/assets/shaders/bloomnoblur.fsh
@@ -1,0 +1,43 @@
+// Simple Bloom shader; created to use in PPSSPP.
+// Without excessive samples and complex nested loops
+// (to make it compatible with low-end GPUs and to ensure ps_2_0 compatibility).
+
+#ifdef GL_ES
+precision mediump float;
+precision mediump int;
+#endif
+
+uniform sampler2D sampler0;
+varying vec2 v_texcoord0;	
+
+uniform vec4 u_setting;
+
+void main()
+{
+  //get the pixel color
+  vec3 color = texture2D(sampler0, v_texcoord0.xy).xyz;
+  gl_FragColor.rgb = color;
+  float gray = (color.r + color.g + color.b) / 3.0;
+  float saturation = (abs(color.r - gray) + abs(color.g - gray) + abs(color.b - gray)) / 3.0;
+  
+  //show the effect mainly on bright parts of the screen
+  float step = 0.001 * gray / max(saturation, 0.25) * u_setting.x;
+
+  //sum the neightbor pixels
+  vec3 sum = vec3(0);
+  for (int x = -3; x <= 3; x += 2)
+  {
+    for (int y = -3; y <= 3; y += 2)
+    {
+      color = texture2D(sampler0, v_texcoord0 + vec2(x, y)*step).xyz;
+      gray = (color.r + color.g + color.b) / 3.0;
+      saturation = (abs(color.r - gray) + abs(color.g - gray) + abs(color.b - gray)) / 3.0;
+      sum += color * gray * gray / max(saturation, 0.25);
+    }
+  }
+  sum /= 16.0;
+
+  //mix the color
+  gl_FragColor.rgb += sum * u_setting.y;
+  gl_FragColor.a = 1.0;
+}

--- a/assets/shaders/defaultshaders.ini
+++ b/assets/shaders/defaultshaders.ini
@@ -50,6 +50,18 @@ SettingName2=Power
 SettingDefaultValue2=0.5
 SettingMaxValue2=1.0
 SettingMinValue2=0.0
+[BloomNoBlur]
+Name=Bloom (no blur)r
+Fragment=bloomnoblur.fsh
+Vertex=fxaa.vsh
+SettingName1=Amount
+SettingDefaultValue1=0.6
+SettingMaxValue1=1.0
+SettingMinValue1=0.0
+SettingName2=Power
+SettingDefaultValue2=0.5
+SettingMaxValue2=1.0
+SettingMinValue2=0.0
 [Sharpen]
 Name=Sharpen
 Fragment=sharpen.fsh

--- a/assets/shaders/defaultshaders.ini
+++ b/assets/shaders/defaultshaders.ini
@@ -51,7 +51,7 @@ SettingDefaultValue2=0.5
 SettingMaxValue2=1.0
 SettingMinValue2=0.0
 [BloomNoBlur]
-Name=Bloom (no blur)r
+Name=Bloom (no blur)
 Fragment=bloomnoblur.fsh
 Vertex=fxaa.vsh
 SettingName1=Amount


### PR DESCRIPTION
The old bloom basically blurres everything (bright colors more, dark color less). This updated version reduces(~removes) the blur on dark colors so it is usable in VR (but also other platforms).

Demo video:
https://twitter.com/LubosVon/status/1676326319133540352?s=20

Complexity is +/- the same (before 19 texture reads, now it is 17).