### PR TITLE
Fix performance issue in MLB 2k games with profiler funcs

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -679,22 +679,24 @@ struct DebugProfilerRegs {
 	u32 local_bus;
 };
 
-static u32 sceKernelReferThreadProfiler(u32 unused) {
+static u32 sceKernelReferThreadProfiler() {
 	// This seems to simply has no parameter:
 	// https://pspdev.github.io/pspsdk/group__ThreadMan.html#ga8fd30da51b9dc0507ac4dae04a7e4a17 , 
 	// And in testing it just returns null in 55 usec (which is surprisingly long).
 
 	// So, we log only if debug logging is enabled, and sleep for a bit.
-	DEBUG_LOG(SCEKERNEL, "sceKernelReferThreadProfiler(%08x)", unused);
+	DEBUG_LOG(SCEKERNEL, "0=sceKernelReferThreadProfiler()");
 
-	// The delay has been measured, 53-56.
-	return hleDelayResult(0, "refer_thread_profiler", 55);
+	// The delay has been measured, 53-56 us.
+	hleEatMicro(55);
+	return 0;
 }
 
-static int sceKernelReferGlobalProfiler(u32 unused) {
-	DEBUG_LOG(SCEKERNEL, "sceKernelReferGlobalProfiler(%08x)", unused);
-	// The delay has been measured, 53-56.
-	return hleDelayResult(0, "refer_thread_profiler", 55);
+static int sceKernelReferGlobalProfiler() {
+	DEBUG_LOG(SCEKERNEL, "0=sceKernelReferGlobalProfiler()");
+	// The delay has been measured, 53-56 us.
+	hleEatMicro(55);
+	return 0;
 }
 
 const HLEFunction ThreadManForUser[] =
@@ -779,9 +781,9 @@ const HLEFunction ThreadManForUser[] =
 	{0XDB738F35, &WrapI_U<sceKernelGetSystemTime>,                   "sceKernelGetSystemTime",                    'i', "x"       },
 	{0X369ED59D, &WrapU_V<sceKernelGetSystemTimeLow>,                "sceKernelGetSystemTimeLow",                 'x', ""        },
 
-	{0X8218B4DD, &WrapI_U<sceKernelReferGlobalProfiler>,             "sceKernelReferGlobalProfiler",              'i', "x"       },
+	{0X8218B4DD, &WrapI_V<sceKernelReferGlobalProfiler>,             "sceKernelReferGlobalProfiler",              'i', ""       },
 	{0X627E6F3A, &WrapI_U<sceKernelReferSystemStatus>,               "sceKernelReferSystemStatus",                'i', "x"       },
-	{0X64D4540E, &WrapU_U<sceKernelReferThreadProfiler>,             "sceKernelReferThreadProfiler",              'x', "x"       },
+	{0X64D4540E, &WrapU_V<sceKernelReferThreadProfiler>,             "sceKernelReferThreadProfiler",              'x', ""       },
 
 	//Fifa Street 2 uses alarms
 	{0X6652B8CA, &WrapI_UUU<sceKernelSetAlarm>,                      "sceKernelSetAlarm",                         'i', "xxx"     },

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -655,6 +655,7 @@ static int sceKernelReferSystemStatus(u32 statusPtr) {
 	return 0;
 }
 
+// Unused - believed to be the returned struct from sceKernelReferThreadProfiler.
 struct DebugProfilerRegs {
 	u32 enable;
 	u32 systemck;
@@ -678,24 +679,22 @@ struct DebugProfilerRegs {
 	u32 local_bus;
 };
 
-static u32 sceKernelReferThreadProfiler(u32 statusPtr) {
-	ERROR_LOG(SCEKERNEL, "FAKE sceKernelReferThreadProfiler()");
+static u32 sceKernelReferThreadProfiler(u32 unused) {
+	// This seems to simply has no parameter:
+	// https://pspdev.github.io/pspsdk/group__ThreadMan.html#ga8fd30da51b9dc0507ac4dae04a7e4a17 , 
+	// And in testing it just returns null in 55 usec (which is surprisingly long).
 
-	// Can we confirm that the struct above is the right struct?
-	// If so, re-enable this code.
-	//auto regs = PSPPointer<DebugProfilerRegs>::Create(statusPtr);
-	// TODO: fill the struct.
-	//if (regs.IsValid()) {
-	//	memset((DebugProfilerRegs *)regs, 0, sizeof(DebugProfilerRegs));
-	//	regs.NotifyWrite("ThreadProfiler");
-	//}
-	return 0;
+	// So, we log only if debug logging is enabled, and sleep for a bit.
+	DEBUG_LOG(SCEKERNEL, "sceKernelReferThreadProfiler(%08x)", unused);
+
+	// The delay has been measured, 53-56.
+	return hleDelayResult(0, "refer_thread_profiler", 55);
 }
 
-static int sceKernelReferGlobalProfiler(u32 statusPtr) {
-	ERROR_LOG(SCEKERNEL, "UNIMPL sceKernelReferGlobalProfiler(%08x)", statusPtr);
-	// Ignore for now
-	return 0;
+static int sceKernelReferGlobalProfiler(u32 unused) {
+	DEBUG_LOG(SCEKERNEL, "sceKernelReferGlobalProfiler(%08x)", unused);
+	// The delay has been measured, 53-56.
+	return hleDelayResult(0, "refer_thread_profiler", 55);
 }
 
 const HLEFunction ThreadManForUser[] =


### PR DESCRIPTION
The function `sceKernelReferGlobalProfiler` are spammed by this game between matches. So let's reduce logging to DEBUG and delay the response by a tested number of ms. And do the same for its sibling function, sceKernelReferThreadProfiler.

Fixes #17623

Here's the pspautotest I wrote, though not a good idea to check in the timing checks:

```cpp
#include "shared.h"
#include "string.h"

int main(int argc, char *argv[]) {
	checkpointNext("sceKernelReferThreadProfiler");
	u64 before = sceKernelGetSystemTimeWide();
	PspDebugProfilerRegs *regs = sceKernelReferThreadProfiler();
	checkpoint("regs: %08x", regs);
	u64 timeTaken = sceKernelGetSystemTimeWide() - before;
	checkpoint("timeTaken: %llu", (unsigned long long)timeTaken);
	if (regs) {
		// TODO: Inspect the data here, but we don't seem to get any.
	}

	checkpointNext("sceKernelReferGlobalProfiler");
	before = sceKernelGetSystemTimeWide();
	regs = sceKernelReferGlobalProfiler();
	checkpoint("regs: %08x", regs);
	timeTaken = sceKernelGetSystemTimeWide() - before;
	checkpoint("timeTaken: %llu", (unsigned long long)timeTaken);
	if (regs) {
		// TODO: Inspect the data here, but we don't seem to get any.
	}
	return 0;
}
```
and the output:
```
[x] sceKernelReferThreadProfiler
[x] regs: 00000000
[x] timeTaken: 55

[x] sceKernelReferGlobalProfiler
[x] regs: 00000000
[x] timeTaken: 54
```

It should be noted though that this doesn't really confirm that the functions don't take a parameter, only that they return 0. But I've chosen to just follow https://pspdev.github.io/pspsdk/group__ThreadMan.html#ga8fd30da51b9dc0507ac4dae04a7e4a17 . It does seem assymetrical with `sceKernelReferSystemStatus` though...