### PR TITLE
Android string message cleanup

### DIFF
--- a/Common/System/NativeApp.h
+++ b/Common/System/NativeApp.h
@@ -20,9 +20,6 @@ class GraphicsContext;
 // This might get called multiple times in some implementations, you must be able to handle that.
 void NativeGetAppInfo(std::string *app_dir_name, std::string *app_nice_name, bool *landscape, std::string *version);
 
-// Generic host->C++ messaging, used for functionality like system-native popup input boxes.
-void NativeMessageReceived(const char *message, const char *value);
-
 // Easy way for the Java side to ask the C++ side for configuration options, such as
 // the rotation lock which must be controlled from Java on Android.
 // It is currently not called on non-Android platforms.

--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -211,7 +211,7 @@ std::vector<std::string> System_GetCameraDeviceList();
 bool System_AudioRecordingIsAvailable();
 bool System_AudioRecordingState();
 
-// This will be changed to take an enum. Currently simply implemented by forwarding to NativeMessageReceived.
+// This will be changed to take an enum. Replacement for the old NativeMessageReceived.
 void System_PostUIMessage(const std::string &message, const std::string &param);
 
 // For these functions, most platforms will use the implementation provided in UI/AudioCommon.cpp,

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -780,6 +780,7 @@ bool HasBuiltinController(const std::string &name) {
 }
 
 void NotifyPadConnected(InputDeviceID deviceId, const std::string &name) {
+	std::lock_guard<std::recursive_mutex> guard(g_controllerMapLock);
 	g_seenPads.insert(name);
 	g_padNames[deviceId] = name;
 }
@@ -812,10 +813,12 @@ void AutoConfForPad(const std::string &name) {
 }
 
 const std::set<std::string> &GetSeenPads() {
+	std::lock_guard<std::recursive_mutex> guard(g_controllerMapLock);
 	return g_seenPads;
 }
 
 std::string PadName(InputDeviceID deviceId) {
+	std::lock_guard<std::recursive_mutex> guard(g_controllerMapLock);
 	auto it = g_padNames.find(deviceId);
 	if (it != g_padNames.end())
 		return it->second;

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -537,7 +537,7 @@ QString MainUI::InputBoxGetQString(QString title, QString defaultValue) {
 
 void MainUI::resizeGL(int w, int h) {
 	if (UpdateScreenScale(w, h)) {
-		NativeMessageReceived("gpu_displayResized", "");
+		System_PostUIMessage("gpu_displayResized", "");
 	}
 	xscale = w / this->width();
 	yscale = h / this->height();

--- a/Qt/mainwindow.cpp
+++ b/Qt/mainwindow.cpp
@@ -130,7 +130,7 @@ void MainWindow::loadAct()
 	{
 		QFileInfo info(filename);
 		g_Config.currentDirectory = Path(info.absolutePath().toStdString());
-		NativeMessageReceived("boot", filename.toStdString().c_str());
+		System_PostUIMessage("boot", filename.toStdString().c_str());
 	}
 }
 
@@ -138,7 +138,7 @@ void MainWindow::closeAct()
 {
 	updateMenus();
 
-	NativeMessageReceived("stop", "");
+	System_PostUIMessage("stop", "");
 	SetGameTitle("");
 }
 
@@ -232,25 +232,25 @@ void MainWindow::exitAct()
 
 void MainWindow::runAct()
 {
-	NativeMessageReceived("run", "");
+	System_PostUIMessage("run", "");
 }
 
 void MainWindow::pauseAct()
 {
-	NativeMessageReceived("pause", "");
+	System_PostUIMessage("pause", "");
 }
 
 void MainWindow::stopAct()
 {
 	Core_Stop();
-	NativeMessageReceived("stop", "");
+	System_PostUIMessage("stop", "");
 }
 
 void MainWindow::resetAct()
 {
 	updateMenus();
 
-	NativeMessageReceived("reset", "");
+	System_PostUIMessage("reset", "");
 }
 
 void MainWindow::switchUMDAct()

--- a/Qt/mainwindow.h
+++ b/Qt/mainwindow.h
@@ -113,20 +113,20 @@ private slots:
 	void consoleAct();
 
 	// Game settings
-	void languageAct() { NativeMessageReceived("language screen", ""); }
-	void controlMappingAct() { NativeMessageReceived("control mapping", ""); }
-	void displayLayoutEditorAct() { NativeMessageReceived("display layout editor", ""); }
-	void moreSettingsAct() { NativeMessageReceived("settings", ""); }
+	void languageAct() { System_PostUIMessage("language screen", ""); }
+	void controlMappingAct() { System_PostUIMessage("control mapping", ""); }
+	void displayLayoutEditorAct() { System_PostUIMessage("display layout editor", ""); }
+	void moreSettingsAct() { System_PostUIMessage("settings", ""); }
 
 	void bufferRenderAct() {
-		NativeMessageReceived("gpu_renderResized", "");
-		NativeMessageReceived("gpu_configChanged", "");
+		System_PostUIMessage("gpu_renderResized", "");
+		System_PostUIMessage("gpu_configChanged", "");
 	}
 	void linearAct() { g_Config.iTexFiltering = (g_Config.iTexFiltering != 0) ? 0 : 3; }
 
 	void renderingResolutionGroup_triggered(QAction *action) {
 		g_Config.iInternalResolution = action->data().toInt();
-		NativeMessageReceived("gpu_renderResized", "");
+		NativeMessagSystem_PostUIMessageeReceived("gpu_renderResized", "");
 	}
 	void windowGroup_triggered(QAction *action) { SetWindowScale(action->data().toInt()); }
 
@@ -134,7 +134,7 @@ private slots:
 		g_Config.bAutoFrameSkip = !g_Config.bAutoFrameSkip;
 		if (g_Config.bSkipBufferEffects) {
 			g_Config.bSkipBufferEffects = false;
-			NativeMessageReceived("gpu_configChanged", "");
+			System_PostUIMessage("gpu_configChanged", "");
 		}
 	}
 	void frameSkippingGroup_triggered(QAction *action) { g_Config.iFrameSkip = action->data().toInt(); }
@@ -143,19 +143,19 @@ private slots:
 	void screenScalingFilterGroup_triggered(QAction *action) { g_Config.iDisplayFilter = action->data().toInt(); }
 	void textureScalingLevelGroup_triggered(QAction *action) {
 		g_Config.iTexScalingLevel = action->data().toInt();
-		NativeMessageReceived("gpu_configChanged", "");
+		System_PostUIMessage("gpu_configChanged", "");
 	}
 	void textureScalingTypeGroup_triggered(QAction *action) {
 		g_Config.iTexScalingType = action->data().toInt();
-		NativeMessageReceived("gpu_configChanged", "");
+		System_PostUIMessage("gpu_configChanged", "");
 	}
 	void deposterizeAct() {
 		g_Config.bTexDeposterize = !g_Config.bTexDeposterize;
-		NativeMessageReceived("gpu_configChanged", "");
+		System_PostUIMessage("gpu_configChanged", "");
 	}
 	void transformAct() {
 		g_Config.bHardwareTransform = !g_Config.bHardwareTransform;
-		NativeMessageReceived("gpu_configChanged", "");
+		System_PostUIMessage("gpu_configChanged", "");
 	}
 	void vertexCacheAct() { g_Config.bVertexCache = !g_Config.bVertexCache; }
 	void frameskipAct() { g_Config.iFrameSkip = !g_Config.iFrameSkip; }
@@ -172,7 +172,7 @@ private slots:
 	// Chat
 	void chatAct() {
 		if (GetUIState() == UISTATE_INGAME) {
-			NativeMessageReceived("chat screen", "");
+			System_PostUIMessage("chat screen", "");
 		}
 	}
 
@@ -180,7 +180,7 @@ private slots:
 	void raiseTopMost();
 	void statsAct() {
 		g_Config.bShowDebugStats = !g_Config.bShowDebugStats;
-		NativeMessageReceived("clear jit", "");
+		System_PostUIMessage("clear jit", "");
 	}
 
 	// Help

--- a/Qt/mainwindow.h
+++ b/Qt/mainwindow.h
@@ -126,7 +126,7 @@ private slots:
 
 	void renderingResolutionGroup_triggered(QAction *action) {
 		g_Config.iInternalResolution = action->data().toInt();
-		NativeMessagSystem_PostUIMessageeReceived("gpu_renderResized", "");
+		System_PostUIMessage("gpu_renderResized", "");
 	}
 	void windowGroup_triggered(QAction *action) { SetWindowScale(action->data().toInt()); }
 

--- a/SDL/CocoaBarItems.mm
+++ b/SDL/CocoaBarItems.mm
@@ -442,17 +442,17 @@ void OSXOpenURL(const char *url) {
 }
 
 -(void)pauseAction: (NSMenuItem *)item {
-	NativeMessageReceived("pause", "");
+	System_PostUIMessage("pause", "");
 }
 
 -(void)resetAction: (NSMenuItem *)item {
-    NativeMessageReceived("reset", "");
+    System_PostUIMessage("reset", "");
 	Core_EnableStepping(false);
 }
 
 -(void)chatAction: (NSMenuItem *)item {
     if (GetUIState() == UISTATE_INGAME) {
-        NativeMessageReceived("chat screen", "");
+        System_PostUIMessage("chat screen", "");
     }
 }
 
@@ -541,7 +541,7 @@ TOGGLE_METHOD(AutoFrameSkip, g_Config.bAutoFrameSkip, g_Config.UpdateAfterSettin
 TOGGLE_METHOD(SoftwareRendering, g_Config.bSoftwareRendering)
 TOGGLE_METHOD(FullScreen, g_Config.bFullScreen, System_MakeRequest(SystemRequestType::TOGGLE_FULLSCREEN_STATE, 0, g_Config.UseFullScreen() ? "1" : "0", "", 3))
 // TOGGLE_METHOD(VSync, g_Config.bVSync)
-TOGGLE_METHOD(ShowDebugStats, g_Config.bShowDebugStats, NativeMessageReceived("clear jit", ""))
+TOGGLE_METHOD(ShowDebugStats, g_Config.bShowDebugStats, System_PostUIMessage("clear jit", ""))
 #undef TOGGLE_METHOD
 
 -(void)setToggleShowCounterItem: (NSMenuItem *)item {
@@ -622,14 +622,14 @@ TOGGLE_METHOD(ShowDebugStats, g_Config.bShowDebugStats, NativeMessageReceived("c
 }
 
 -(void)openRecentItem: (NSMenuItem *)item {
-    NativeMessageReceived("boot", g_Config.RecentIsos()[item.tag].c_str());
+    System_PostUIMessage("boot", g_Config.RecentIsos()[item.tag].c_str());
 }
 
 -(void)openSystemFileBrowser {
     int g = 0;
     DarwinDirectoryPanelCallback callback = [g] (bool succ, Path thePathChosen) {
         if (succ)
-            NativeMessageReceived("boot", thePathChosen.c_str());
+            System_PostUIMessage("boot", thePathChosen.c_str());
     };
     
     DarwinFileSystemServices services;

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -155,9 +155,9 @@ UI::EventReturn DisplayLayoutScreen::OnPostProcShaderChange(UI::EventParams &e) 
 	g_Config.vPostShaderNames.erase(std::remove(g_Config.vPostShaderNames.begin(), g_Config.vPostShaderNames.end(), "Off"), g_Config.vPostShaderNames.end());
 	FixPostShaderOrder(&g_Config.vPostShaderNames);
 
-	NativeMessageReceived("gpu_configChanged", "");
-	NativeMessageReceived("gpu_renderResized", "");  // To deal with shaders that can change render resolution like upscaling.
-	NativeMessageReceived("postshader_updated", "");
+	System_PostUIMessage("gpu_configChanged", "");
+	System_PostUIMessage("gpu_renderResized", "");  // To deal with shaders that can change render resolution like upscaling.
+	System_PostUIMessage("postshader_updated", "");
 
 	if (gpu) {
 		gpu->NotifyConfigChanged();
@@ -381,7 +381,7 @@ void DisplayLayoutScreen::CreateViews() {
 			auto removeButton = shaderRow->Add(new Choice(ImageID("I_TRASHCAN"), new LinearLayoutParams(0.0f)));
 			removeButton->OnClick.Add([=](EventParams &e) -> UI::EventReturn {
 				g_Config.vPostShaderNames.erase(g_Config.vPostShaderNames.begin() + i);
-				NativeMessageReceived("gpu_configChanged", "");
+				System_PostUIMessage("gpu_configChanged", "");
 				RecreateViews();
 				return UI::EVENT_DONE;
 			});
@@ -409,7 +409,7 @@ void DisplayLayoutScreen::CreateViews() {
 						return UI::EVENT_DONE;
 					}
 					FixPostShaderOrder(&g_Config.vPostShaderNames);
-					NativeMessageReceived("gpu_configChanged", "");
+					System_PostUIMessage("gpu_configChanged", "");
 					RecreateViews();
 					return UI::EVENT_DONE;
 				});
@@ -493,18 +493,18 @@ void PostProcScreen::OnCompleted(DialogResult result) {
 	if (showStereoShaders_) {
 		if (g_Config.sStereoToMonoShader != value) {
 			g_Config.sStereoToMonoShader = value;
-			NativeMessageReceived("gpu_configChanged", "");
+			System_PostUIMessage("gpu_configChanged", "");
 		}
 	} else {
 		if (id_ < (int)g_Config.vPostShaderNames.size()) {
 			if (g_Config.vPostShaderNames[id_] != value) {
 				g_Config.vPostShaderNames[id_] = value;
-				NativeMessageReceived("gpu_configChanged", "");
+				System_PostUIMessage("gpu_configChanged", "");
 			}
 		}
 		else {
 			g_Config.vPostShaderNames.push_back(value);
-			NativeMessageReceived("gpu_configChanged", "");
+			System_PostUIMessage("gpu_configChanged", "");
 		}
 	}
 }

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -428,7 +428,7 @@ EmuScreen::~EmuScreen() {
 void EmuScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 	// TODO: improve the way with which we got commands from PauseMenu.
 	// DR_CANCEL/DR_BACK means clicked on "continue", DR_OK means clicked on "back to menu",
-	// DR_YES means a message sent to PauseMenu by NativeMessageReceived.
+	// DR_YES means a message sent to PauseMenu by System_PostUIMessage.
 	if (result == DR_OK || quit_) {
 		screenManager()->switchScreen(new MainScreen());
 		quit_ = false;
@@ -709,13 +709,13 @@ void EmuScreen::onVKey(int virtualKeyCode, bool down) {
 	case VIRTKEY_PREVIOUS_SLOT:
 		if (down) {
 			SaveState::PrevSlot();
-			NativeMessageReceived("savestate_displayslot", "");
+			System_PostUIMessage("savestate_displayslot", "");
 		}
 		break;
 	case VIRTKEY_NEXT_SLOT:
 		if (down) {
 			SaveState::NextSlot();
-			NativeMessageReceived("savestate_displayslot", "");
+			System_PostUIMessage("savestate_displayslot", "");
 		}
 		break;
 	case VIRTKEY_TOGGLE_FULLSCREEN:
@@ -733,7 +733,7 @@ void EmuScreen::onVKey(int virtualKeyCode, bool down) {
 			g_Config.bSaveNewTextures = !g_Config.bSaveNewTextures;
 			if (g_Config.bSaveNewTextures) {
 				g_OSD.Show(OSDType::MESSAGE_INFO, sc->T("saveNewTextures_true", "Textures will now be saved to your storage"), 2.0);
-				NativeMessageReceived("gpu_configChanged", "");
+				System_PostUIMessage("gpu_configChanged", "");
 			} else {
 				g_OSD.Show(OSDType::MESSAGE_INFO, sc->T("saveNewTextures_false", "Texture saving was disabled"), 2.0);
 			}
@@ -746,7 +746,7 @@ void EmuScreen::onVKey(int virtualKeyCode, bool down) {
 				g_OSD.Show(OSDType::MESSAGE_INFO, sc->T("replaceTextures_true", "Texture replacement enabled"), 2.0);
 			else
 				g_OSD.Show(OSDType::MESSAGE_INFO, sc->T("replaceTextures_false", "Textures no longer are being replaced"), 2.0);
-			NativeMessageReceived("gpu_configChanged", "");
+			System_PostUIMessage("gpu_configChanged", "");
 		}
 		break;
 	case VIRTKEY_RAPID_FIRE:
@@ -1037,7 +1037,7 @@ UI::EventReturn EmuScreen::OnResume(UI::EventParams &params) {
 
 UI::EventReturn EmuScreen::OnReset(UI::EventParams &params) {
 	if (coreState == CoreState::CORE_RUNTIME_ERROR) {
-		NativeMessageReceived("reset", "");
+		System_PostUIMessage("reset", "");
 	}
 	return UI::EVENT_DONE;
 }

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -297,7 +297,7 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 		static const char *msaaModes[] = { "Off", "2x", "4x", "8x", "16x" };
 		auto msaaChoice = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iMultiSampleLevel, gr->T("Antialiasing (MSAA)"), msaaModes, 0, ARRAY_SIZE(msaaModes), I18NCat::GRAPHICS, screenManager()));
 		msaaChoice->OnChoice.Add([&](UI::EventParams &) -> UI::EventReturn {
-			NativeMessageReceived("gpu_renderResized", "");
+			System_PostUIMessage("gpu_renderResized", "");
 			return UI::EVENT_DONE;
 		});
 		msaaChoice->SetDisabledPtr(&g_Config.bSoftwareRendering);
@@ -388,7 +388,7 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 			settingInfo_->Show(gr->T("RenderingMode NonBuffered Tip", "Faster, but graphics may be missing in some games"), e.v);
 			g_Config.bAutoFrameSkip = false;
 		}
-		NativeMessageReceived("gpu_renderResized", "");
+		System_PostUIMessage("gpu_renderResized", "");
 		return UI::EVENT_DONE;
 	});
 	skipBufferEffects->SetDisabledPtr(&g_Config.bSoftwareRendering);
@@ -1147,7 +1147,7 @@ UI::EventReturn GameSettingsScreen::OnSustainedPerformanceModeChange(UI::EventPa
 }
 
 UI::EventReturn GameSettingsScreen::OnJitAffectingSetting(UI::EventParams &e) {
-	NativeMessageReceived("clear jit", "");
+	System_PostUIMessage("clear jit", "");
 	return UI::EVENT_DONE;
 }
 
@@ -1263,7 +1263,7 @@ UI::EventReturn GameSettingsScreen::OnResolutionChange(UI::EventParams &e) {
 		System_RecreateActivity();
 	}
 	Reporting::UpdateConfig();
-	NativeMessageReceived("gpu_renderResized", "");
+	System_PostUIMessage("gpu_renderResized", "");
 	return UI::EVENT_DONE;
 }
 
@@ -1292,7 +1292,7 @@ void GameSettingsScreen::onFinish(DialogResult result) {
 
 	// Wipe some caches after potentially changing settings.
 	// Let's not send resize messages here, handled elsewhere.
-	NativeMessageReceived("gpu_configChanged", "");
+	System_PostUIMessage("gpu_configChanged", "");
 }
 
 void GameSettingsScreen::dialogFinished(const Screen *dialog, DialogResult result) {
@@ -1538,7 +1538,7 @@ UI::EventReturn GameSettingsScreen::OnTextureShader(UI::EventParams &e) {
 }
 
 UI::EventReturn GameSettingsScreen::OnTextureShaderChange(UI::EventParams &e) {
-	NativeMessageReceived("gpu_configChanged", "");
+	System_PostUIMessage("gpu_configChanged", "");
 	RecreateViews(); // Update setting name
 	g_Config.bTexHardwareScaling = g_Config.sTextureShaderName != "Off";
 	return UI::EVENT_DONE;
@@ -1727,7 +1727,7 @@ void DeveloperToolsScreen::CreateViews() {
 
 void DeveloperToolsScreen::onFinish(DialogResult result) {
 	g_Config.Save("DeveloperToolsScreen::onFinish");
-	NativeMessageReceived("gpu_configChanged", "");
+	System_PostUIMessage("gpu_configChanged", "");
 }
 
 void GameSettingsScreen::CallbackRestoreDefaults(bool yes) {
@@ -1808,7 +1808,7 @@ UI::EventReturn DeveloperToolsScreen::OnTouchscreenTest(UI::EventParams &e) {
 }
 
 UI::EventReturn DeveloperToolsScreen::OnJitAffectingSetting(UI::EventParams &e) {
-	NativeMessageReceived("clear jit", "");
+	System_PostUIMessage("clear jit", "");
 	return UI::EVENT_DONE;
 }
 

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1375,7 +1375,7 @@ UI::EventReturn MainScreen::OnLoadFile(UI::EventParams &e) {
 	if (System_GetPropertyBool(SYSPROP_HAS_FILE_BROWSER)) {
 		auto mm = GetI18NCategory(I18NCat::MAINMENU);
 		System_BrowseForFile(mm->T("Load"), BrowseFileType::BOOTABLE, [](const std::string &value, int) {
-			NativeMessageReceived("boot", value.c_str());
+			System_PostUIMessage("boot", value.c_str());
 		});
 	}
 	return UI::EVENT_DONE;

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -435,7 +435,7 @@ void HandleCommonMessages(const char *message, const char *value, ScreenManager 
 		auto sy = GetI18NCategory(I18NCat::SYSTEM);
 		auto langScreen = new NewLanguageScreen(sy->T("Language"));
 		langScreen->OnChoice.Add([](UI::EventParams &) {
-			NativeMessageReceived("recreateviews", "");
+			System_PostUIMessage("recreateviews", "");
 			System_Notify(SystemNotification::UI);
 			return UI::EVENT_DONE;
 		});

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1118,7 +1118,7 @@ void NativeRender(GraphicsContext *graphicsContext) {
 #if !PPSSPP_PLATFORM(WINDOWS) && !defined(ANDROID)
 		PSP_CoreParameter().pixelWidth = g_display.pixel_xres;
 		PSP_CoreParameter().pixelHeight = g_display.pixel_yres;
-		NativeMessageReceived("gpu_displayResized", "");
+		System_PostUIMessage("gpu_displayResized", "");
 #endif
 	} else {
 		// INFO_LOG(G3D, "Polling graphics context");
@@ -1341,16 +1341,12 @@ void NativeAxis(const AxisInput &axis) {
 		xSensitivity, ySensitivity);
 }
 
-void NativeMessageReceived(const char *message, const char *value) {
+void System_PostUIMessage(const std::string &message, const std::string &value) {
 	std::lock_guard<std::mutex> lock(pendingMutex);
 	PendingMessage pendingMessage;
 	pendingMessage.msg = message;
 	pendingMessage.value = value;
 	pendingMessages.push_back(pendingMessage);
-}
-
-void System_PostUIMessage(const std::string &message, const std::string &value) {
-	NativeMessageReceived(message.c_str(), value.c_str());
 }
 
 void NativeResized() {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1135,15 +1135,7 @@ void NativeRender(GraphicsContext *graphicsContext) {
 }
 
 void HandleGlobalMessage(const std::string &msg, const std::string &value) {
-	// A bit ugly, see InputDeviceState.java.
-	static InputDeviceID nextInputDeviceID = DEVICE_ID_ANY;
-	if (msg == "inputDeviceConnectedID") {
-		nextInputDeviceID = (InputDeviceID)parseLong(value);
-	}
-	else if (msg == "inputDeviceConnected") {
-		KeyMap::NotifyPadConnected(nextInputDeviceID, value);
-	}
-	else if (msg == "savestate_displayslot") {
+	if (msg == "savestate_displayslot") {
 		auto sy = GetI18NCategory(I18NCat::SYSTEM);
 		std::string msg = StringFromFormat("%s: %d", sy->T("Savestate Slot"), SaveState::GetCurrentSlot() + 1);
 		// Show for the same duration as the preview.

--- a/UI/PSPNSApplicationDelegate.mm
+++ b/UI/PSPNSApplicationDelegate.mm
@@ -6,9 +6,11 @@
 //
 
 #import <Cocoa/Cocoa.h>
+
 #import "PSPNSApplicationDelegate.h"
+
+#include "Common/System/System.h"
 #include "Core/SaveState.h"
-#include "Common/System/NativeApp.h"
 #include "Core/Config.h"
 
 @implementation PSPNSApplicationDelegate

--- a/UI/PSPNSApplicationDelegate.mm
+++ b/UI/PSPNSApplicationDelegate.mm
@@ -26,7 +26,7 @@
 	NSURL *firstURL = urls.firstObject;
 	if (!firstURL) return; // No URLs, don't do anything
 	
-	NativeMessageReceived("boot", firstURL.fileSystemRepresentation);
+	System_PostUIMessage("boot", firstURL.fileSystemRepresentation);
 }
 
 - (NSMenu *)applicationDockMenu:(NSApplication *)sender {

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -676,7 +676,7 @@ UI::EventReturn SavedataScreen::OnSearch(UI::EventParams &e) {
 	if (System_GetPropertyBool(SYSPROP_HAS_TEXT_INPUT_DIALOG)) {
 		System_InputBoxGetString(di->T("Filter"), searchFilter_, [](const std::string &value, int ivalue) {
 			if (ivalue) {
-				NativeMessageReceived("savedatascreen_search", value.c_str());
+				System_PostUIMessage("savedatascreen_search", value.c_str());
 			}
 		});
 	}

--- a/UI/TabbedDialogScreen.cpp
+++ b/UI/TabbedDialogScreen.cpp
@@ -88,13 +88,13 @@ void TabbedUIDialogScreenWithGameBackground::CreateViews() {
 
 			searchSettings->Add(new ItemHeader(se->T("Find settings")));
 			searchSettings->Add(new PopupTextInputChoice(&searchFilter_, se->T("Filter"), "", 64, screenManager()))->OnChange.Add([=](UI::EventParams &e) {
-				NativeMessageReceived("gameSettings_search", StripSpaces(searchFilter_).c_str());
+				System_PostUIMessage("gameSettings_search", StripSpaces(searchFilter_).c_str());
 				return UI::EVENT_DONE;
 			});
 
 			clearSearchChoice_ = searchSettings->Add(new Choice(se->T("Clear filter")));
 			clearSearchChoice_->OnClick.Add([=](UI::EventParams &e) {
-				NativeMessageReceived("gameSettings_search", "");
+				System_PostUIMessage("gameSettings_search", "");
 				return UI::EVENT_DONE;
 			});
 

--- a/UWP/App.cpp
+++ b/UWP/App.cpp
@@ -267,7 +267,7 @@ void App::OnWindowSizeChanged(CoreWindow^ sender, WindowSizeChangedEventArgs^ ar
 	PSP_CoreParameter().pixelWidth = (int)(width * scale);
 	PSP_CoreParameter().pixelHeight = (int)(height * scale);
 	if (UpdateScreenScale((int)width, (int)height)) {
-		NativeMessageReceived("gpu_displayResized", "");
+		System_PostUIMessage("gpu_displayResized", "");
 	}
 }
 

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -241,7 +241,7 @@ namespace MainWindow
 				g_Config.iInternalResolution = 0;
 		}
 
-		NativeMessageReceived("gpu_renderResized", "");
+		System_PostUIMessage("gpu_renderResized", "");
 	}
 
 	void CorrectCursor() {
@@ -282,7 +282,7 @@ namespace MainWindow
 		SavePosition();
 		Core_NotifyWindowHidden(false);
 		if (!g_Config.bPauseWhenMinimized) {
-			NativeMessageReceived("window minimized", "false");
+			System_PostUIMessage("window minimized", "false");
 		}
 
 		int width = 0, height = 0;
@@ -305,8 +305,8 @@ namespace MainWindow
 		DEBUG_LOG(SYSTEM, "Pixel width/height: %dx%d", PSP_CoreParameter().pixelWidth, PSP_CoreParameter().pixelHeight);
 
 		if (UpdateScreenScale(width, height)) {
-			NativeMessageReceived("gpu_displayResized", "");
-			NativeMessageReceived("gpu_renderResized", "");
+			System_PostUIMessage("gpu_displayResized", "");
+			System_PostUIMessage("gpu_renderResized", "");
 		}
 
 		// Don't save the window state if fullscreen.
@@ -856,12 +856,12 @@ namespace MainWindow
 				}
 
 				if (wParam == WA_ACTIVE || wParam == WA_CLICKACTIVE) {
-					NativeMessageReceived("got_focus", "");
+					System_PostUIMessage("got_focus", "");
 					hasFocus = true;
 					trapMouse = true;
 				}
 				if (wParam == WA_INACTIVE) {
-					NativeMessageReceived("lost_focus", "");
+					System_PostUIMessage("lost_focus", "");
 					WindowsRawInput::LoseFocus();
 					InputDevice::LoseFocus();
 					hasFocus = false;
@@ -908,7 +908,7 @@ namespace MainWindow
 			case SIZE_MINIMIZED:
 				Core_NotifyWindowHidden(true);
 				if (!g_Config.bPauseWhenMinimized) {
-					NativeMessageReceived("window minimized", "true");
+					System_PostUIMessage("window minimized", "true");
 				}
 				InputDevice::LoseFocus();
 				break;
@@ -1032,7 +1032,7 @@ namespace MainWindow
 					TCHAR filename[512];
 					if (DragQueryFile(hdrop, 0, filename, 512) != 0) {
 						const std::string utf8_filename = ReplaceAll(ConvertWStringToUTF8(filename), "\\", "/");
-						NativeMessageReceived("boot", utf8_filename.c_str());
+						System_PostUIMessage("boot", utf8_filename.c_str());
 						Core_EnableStepping(false);
 					}
 				}

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -339,7 +339,7 @@ namespace MainWindow {
 			Core_EnableStepping(false);
 		}
 		filename = ReplaceAll(filename, "\\", "/");
-		NativeMessageReceived("boot", filename.c_str());
+		System_PostUIMessage("boot", filename.c_str());
 		W32Util::MakeTopMost(GetHWND(), g_Config.bTopMost);
 	}
 
@@ -367,17 +367,17 @@ namespace MainWindow {
 	// not static
 	void setTexScalingMultiplier(int level) {
 		g_Config.iTexScalingLevel = level;
-		NativeMessageReceived("gpu_configChanged", "");
+		System_PostUIMessage("gpu_configChanged", "");
 	}
 
 	static void setTexScalingType(int type) {
 		g_Config.iTexScalingType = type;
-		NativeMessageReceived("gpu_configChanged", "");
+		System_PostUIMessage("gpu_configChanged", "");
 	}
 
 	static void setSkipBufferEffects(bool skip) {
 		g_Config.bSkipBufferEffects = skip;
-		NativeMessageReceived("gpu_configChanged", "");
+		System_PostUIMessage("gpu_configChanged", "");
 	}
 
 	static void setFrameSkipping(int framesToSkip = -1) {
@@ -461,7 +461,7 @@ namespace MainWindow {
 		case ID_TOGGLE_BREAK:
 			if (GetUIState() == UISTATE_PAUSEMENU) {
 				// Causes hang
-				//NativeMessageReceived("run", "");
+				//System_PostUIMessage("run", "");
 
 				if (disasmWindow)
 					SendMessage(disasmWindow->GetDlgHandle(), WM_COMMAND, IDC_STOPGO, 0);
@@ -480,7 +480,7 @@ namespace MainWindow {
 			break;
 
 		case ID_EMULATION_PAUSE:
-			NativeMessageReceived("pause", "");
+			System_PostUIMessage("pause", "");
 			break;
 
 		case ID_EMULATION_STOP:
@@ -488,12 +488,12 @@ namespace MainWindow {
 				Core_EnableStepping(false);
 
 			Core_Stop();
-			NativeMessageReceived("stop", "");
+			System_PostUIMessage("stop", "");
 			Core_WaitInactive();
 			break;
 
 		case ID_EMULATION_RESET:
-			NativeMessageReceived("reset", "");
+			System_PostUIMessage("reset", "");
 			Core_EnableStepping(false);
 			break;
 
@@ -513,7 +513,7 @@ namespace MainWindow {
 
 		case ID_EMULATION_CHAT:
 			if (GetUIState() == UISTATE_INGAME) {
-				NativeMessageReceived("chat screen", "");
+				System_PostUIMessage("chat screen", "");
 			}
 			break;
 		case ID_FILE_LOADSTATEFILE:
@@ -532,7 +532,7 @@ namespace MainWindow {
 		case ID_FILE_SAVESTATE_NEXT_SLOT:
 		{
 			SaveState::NextSlot();
-			NativeMessageReceived("savestate_displayslot", "");
+			System_PostUIMessage("savestate_displayslot", "");
 			break;
 		}
 
@@ -540,7 +540,7 @@ namespace MainWindow {
 		{
 			if (!KeyMap::PspButtonHasMappings(VIRTKEY_NEXT_SLOT)) {
 				SaveState::NextSlot();
-				NativeMessageReceived("savestate_displayslot", "");
+				System_PostUIMessage("savestate_displayslot", "");
 			}
 			break;
 		}
@@ -586,7 +586,7 @@ namespace MainWindow {
 		}
 
 		case ID_OPTIONS_LANGUAGE:
-			NativeMessageReceived("language screen", "");
+			System_PostUIMessage("language screen", "");
 			break;
 
 		case ID_OPTIONS_IGNOREWINKEY:
@@ -631,7 +631,7 @@ namespace MainWindow {
 			g_Config.bAutoFrameSkip = !g_Config.bAutoFrameSkip;
 			if (g_Config.bAutoFrameSkip && g_Config.bSkipBufferEffects) {
 				g_Config.bSkipBufferEffects = false;
-				NativeMessageReceived("gpu_configChanged", "");
+				System_PostUIMessage("gpu_configChanged", "");
 			}
 			break;
 
@@ -648,7 +648,7 @@ namespace MainWindow {
 
 		case ID_TEXTURESCALING_DEPOSTERIZE:
 			g_Config.bTexDeposterize = !g_Config.bTexDeposterize;
-			NativeMessageReceived("gpu_configChanged", "");
+			System_PostUIMessage("gpu_configChanged", "");
 			break;
 
 		case ID_OPTIONS_DIRECT3D9:
@@ -677,23 +677,23 @@ namespace MainWindow {
 
 		case ID_OPTIONS_SKIP_BUFFER_EFFECTS:
 			g_Config.bSkipBufferEffects = !g_Config.bSkipBufferEffects;
-			NativeMessageReceived("gpu_renderResized", "");
+			System_PostUIMessage("gpu_renderResized", "");
 			g_OSD.ShowOnOff(gr->T("Skip Buffer Effects"), g_Config.bSkipBufferEffects);
 			break;
 
 		case ID_DEBUG_SHOWDEBUGSTATISTICS:
 			g_Config.bShowDebugStats = !g_Config.bShowDebugStats;
-			NativeMessageReceived("clear jit", "");
+			System_PostUIMessage("clear jit", "");
 			break;
 
 		case ID_OPTIONS_HARDWARETRANSFORM:
 			g_Config.bHardwareTransform = !g_Config.bHardwareTransform;
-			NativeMessageReceived("gpu_configChanged", "");
+			System_PostUIMessage("gpu_configChanged", "");
 			g_OSD.ShowOnOff(gr->T("Hardware Transform"), g_Config.bHardwareTransform);
 			break;
 
 		case ID_OPTIONS_DISPLAY_LAYOUT:
-			NativeMessageReceived("display layout editor", "");
+			System_PostUIMessage("display layout editor", "");
 			break;
 
 
@@ -724,7 +724,7 @@ namespace MainWindow {
 			break;
 
 		case ID_DEBUG_DUMPNEXTFRAME:
-			NativeMessageReceived("gpu dump next frame", "");
+			System_PostUIMessage("gpu dump next frame", "");
 			break;
 
 		case ID_DEBUG_LOADMAPFILE:
@@ -860,11 +860,11 @@ namespace MainWindow {
 			break;
 
 		case ID_OPTIONS_CONTROLS:
-			NativeMessageReceived("control mapping", "");
+			System_PostUIMessage("control mapping", "");
 			break;
 
 		case ID_OPTIONS_MORE_SETTINGS:
-			NativeMessageReceived("settings", "");
+			System_PostUIMessage("settings", "");
 			break;
 
 		case ID_EMULATION_SOUND:

--- a/Windows/PPSSPP.vcxproj
+++ b/Windows/PPSSPP.vcxproj
@@ -1272,6 +1272,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClInclude>
+    <ClInclude Include="..\SDL\CocoaBarItems.h" />
     <ClInclude Include="..\SDL\NKCodeFromSDL.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
@@ -1332,6 +1333,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClInclude>
+    <ClInclude Include="..\UI\PSPNSApplicationDelegate.h" />
     <ClInclude Include="..\UWP\App.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
@@ -1647,6 +1649,16 @@
     <None Include="..\ppsspp.iss" />
     <None Include="..\Qt\macbundle.sh" />
     <None Include="..\README.md" />
+    <None Include="..\SDL\CocoaBarItems.mm">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </None>
     <None Include="..\SDL\macbundle.sh" />
     <None Include="..\SDL\SDLCocoaMetalLayer.mm">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
@@ -1669,6 +1681,16 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </None>
     <None Include="..\settings.gradle" />
+    <None Include="..\UI\PSPNSApplicationDelegate.mm">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </None>
     <None Include="build-x64.cmd" />
     <None Include="build-x86.cmd" />
     <None Include="git-version-gen.cmd" />

--- a/Windows/PPSSPP.vcxproj.filters
+++ b/Windows/PPSSPP.vcxproj.filters
@@ -62,6 +62,9 @@
     <Filter Include="Windows\Darkmode">
       <UniqueIdentifier>{e6f1a7f6-807b-484e-9595-bdb58ecaa2ae}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Other Platforms\Mac">
+      <UniqueIdentifier>{e2dd8951-ccb6-4575-996a-69c6832fafbf}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Debugger\CtrlDisAsmView.cpp">
@@ -565,6 +568,12 @@
     <ClInclude Include="Debugger\WatchItemWindow.h">
       <Filter>Windows\Debugger</Filter>
     </ClInclude>
+    <ClInclude Include="..\SDL\CocoaBarItems.h">
+      <Filter>Other Platforms\Mac</Filter>
+    </ClInclude>
+    <ClInclude Include="..\UI\PSPNSApplicationDelegate.h">
+      <Filter>Other Platforms\Mac</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="icon1.ico">
@@ -793,6 +802,12 @@
     </None>
     <None Include="..\cmake\Toolchains\nvidiajetsonsdl.armv8.cmake">
       <Filter>Build\CMake</Filter>
+    </None>
+    <None Include="..\SDL\CocoaBarItems.mm">
+      <Filter>Other Platforms\Mac</Filter>
+    </None>
+    <None Include="..\UI\PSPNSApplicationDelegate.mm">
+      <Filter>Other Platforms\Mac</Filter>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -860,7 +860,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_resume(JNIEnv *, jclass) {
 	INFO_LOG(SYSTEM, "NativeApp.resume() - resuming audio");
 	AndroidAudio_Resume(g_audioState);
 
-	NativeMessageReceived("app_resumed", "");
+	System_PostUIMessage("app_resumed", "");
 }
 
 extern "C" void Java_org_ppsspp_ppsspp_NativeApp_pause(JNIEnv *, jclass) {
@@ -973,7 +973,7 @@ extern "C" bool Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * env, 
 		renderer_inited = true;
 	}
 
-	NativeMessageReceived("recreateviews", "");
+	System_PostUIMessage("recreateviews", "");
 
 	if (IsVREnabled()) {
 		EnterVR(firstStart, graphicsContext->GetAPIContext());
@@ -1266,7 +1266,7 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_sendMessageFromJava(JNI
 	} else if (msg == "permission_granted") {
 		INFO_LOG(SYSTEM, "STORAGE PERMISSION: GRANTED");
 		// Send along.
-		NativeMessageReceived(msg.c_str(), prm.c_str());
+		System_PostUIMessage(msg.c_str(), prm.c_str());
 	} else if (msg == "sustained_perf_supported") {
 		sustainedPerfSupported = true;
 	} else if (msg == "safe_insets") {
@@ -1285,7 +1285,7 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_sendMessageFromJava(JNI
 		KeyMap::NotifyPadConnected(nextInputDeviceID, prm);
 	} else if (msg == "core_powerSaving") {
 		// Forward.
-		NativeMessageReceived(msg.c_str(), prm.c_str());
+		System_PostUIMessage(msg.c_str(), prm.c_str());
 	} else {
 		ERROR_LOG(SYSTEM, "Got unexpected message from Java, ignoring: %s / %s", msg.c_str(), prm.c_str());
 	}

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -90,6 +90,7 @@ struct JNIEnv {};
 #include "Core/ConfigValues.h"
 #include "Core/Loaders.h"
 #include "Core/FileLoaders/LocalFileLoader.h"
+#include "Core/KeyMap.h"
 #include "Core/System.h"
 #include "Core/HLE/sceUsbCam.h"
 #include "Core/HLE/sceUsbGps.h"
@@ -369,7 +370,7 @@ static void EmuThreadJoin() {
 
 static void ProcessFrameCommands(JNIEnv *env);
 
-void PushCommand(std::string cmd, std::string param) {
+static void PushCommand(std::string cmd, std::string param) {
 	std::lock_guard<std::mutex> guard(frameCommandLock);
 	frameCommands.push(FrameCommand(cmd, param));
 }
@@ -1243,9 +1244,12 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_accelerometer(JNIEnv *,
 	NativeAxis(axis);
 }
 
-extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_sendMessage(JNIEnv *env, jclass, jstring message, jstring param) {
+extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_sendMessageFromJava(JNIEnv *env, jclass, jstring message, jstring param) {
 	std::string msg = GetJavaString(env, message);
 	std::string prm = GetJavaString(env, param);
+
+	// A bit ugly, see InputDeviceState.java.
+	static InputDeviceID nextInputDeviceID = DEVICE_ID_ANY;
 
 	// Some messages are caught by app-android. TODO: Should be all.
 	if (msg == "moga") {
@@ -1254,12 +1258,15 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_sendMessage(JNIEnv *env
 		INFO_LOG(SYSTEM, "STORAGE PERMISSION: PENDING");
 		// TODO: Add support for other permissions
 		permissions[SYSTEM_PERMISSION_STORAGE] = PERMISSION_STATUS_PENDING;
+		// Don't need to send along, nothing else is listening.
 	} else if (msg == "permission_denied") {
 		INFO_LOG(SYSTEM, "STORAGE PERMISSION: DENIED");
 		permissions[SYSTEM_PERMISSION_STORAGE] = PERMISSION_STATUS_DENIED;
+		// Don't need to send along, nothing else is listening.
 	} else if (msg == "permission_granted") {
 		INFO_LOG(SYSTEM, "STORAGE PERMISSION: GRANTED");
-		permissions[SYSTEM_PERMISSION_STORAGE] = PERMISSION_STATUS_GRANTED;
+		// Send along.
+		NativeMessageReceived(msg.c_str(), prm.c_str());
 	} else if (msg == "sustained_perf_supported") {
 		sustainedPerfSupported = true;
 	} else if (msg == "safe_insets") {
@@ -1272,10 +1279,16 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_sendMessage(JNIEnv *env
 			g_safeInsetTop = (float)top * g_display.dpi_scale_y;
 			g_safeInsetBottom = (float)bottom * g_display.dpi_scale_y;
 		}
+	} else if (msg == "inputDeviceConnectedID") {
+		nextInputDeviceID = (InputDeviceID)parseLong(prm);
+	} else if (msg == "inputDeviceConnected") {
+		KeyMap::NotifyPadConnected(nextInputDeviceID, prm);
+	} else if (msg == "core_powerSaving") {
+		// Forward.
+		NativeMessageReceived(msg.c_str(), prm.c_str());
+	} else {
+		ERROR_LOG(SYSTEM, "Got unexpected message from Java, ignoring: %s / %s", msg.c_str(), prm.c_str());
 	}
-
-	// Ensures that the receiver can handle it on a sensible thread.
-	NativeMessageReceived(msg.c_str(), prm.c_str());
 }
 
 extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeActivity_requestExitVulkanRenderLoop(JNIEnv *env, jobject obj) {

--- a/android/src/org/ppsspp/ppsspp/InputDeviceState.java
+++ b/android/src/org/ppsspp/ppsspp/InputDeviceState.java
@@ -128,8 +128,8 @@ public class InputDeviceState {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
 			logAdvanced(device);
 		}
-		NativeApp.sendMessage("inputDeviceConnectedID", String.valueOf(this.deviceId));
-		NativeApp.sendMessage("inputDeviceConnected", device.getName());
+		NativeApp.sendMessageFromJava("inputDeviceConnectedID", String.valueOf(this.deviceId));
+		NativeApp.sendMessageFromJava("inputDeviceConnected", device.getName());
 	}
 
 	public boolean onKeyDown(KeyEvent event) {

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -200,9 +200,9 @@ public abstract class NativeActivity extends Activity {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 			// Let's start out granted if it was granted already.
 			if (this.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
-				NativeApp.sendMessage("permission_granted", "storage");
+				NativeApp.sendMessageFromJava("permission_granted", "storage");
 			} else {
-				NativeApp.sendMessage("permission_denied", "storage");
+				NativeApp.sendMessageFromJava("permission_denied", "storage");
 			}
 		}
 	}
@@ -220,9 +220,9 @@ public abstract class NativeActivity extends Activity {
 		switch (requestCode) {
 		case REQUEST_CODE_STORAGE_PERMISSION:
 			if (permissionsGranted(permissions, grantResults)) {
-				NativeApp.sendMessage("permission_granted", "storage");
+				NativeApp.sendMessageFromJava("permission_granted", "storage");
 			} else {
-				NativeApp.sendMessage("permission_denied", "storage");
+				NativeApp.sendMessageFromJava("permission_denied", "storage");
 			}
 			break;
 		case REQUEST_CODE_LOCATION_PERMISSION:
@@ -364,7 +364,7 @@ public abstract class NativeActivity extends Activity {
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
 			if (powerManager != null && powerManager.isSustainedPerformanceModeSupported()) {
 				sustainedPerfSupported = true;
-				NativeApp.sendMessage("sustained_perf_supported", "1");
+				NativeApp.sendMessageFromJava("sustained_perf_supported", "1");
 			}
 		}
 
@@ -1515,9 +1515,9 @@ public abstract class NativeActivity extends Activity {
 			recreate();
 		} else if (command.equals("ask_permission") && params.equals("storage")) {
 			if (askForPermissions(permissionsForStorage, REQUEST_CODE_STORAGE_PERMISSION)) {
-				NativeApp.sendMessage("permission_pending", "storage");
+				NativeApp.sendMessageFromJava("permission_pending", "storage");
 			} else {
-				NativeApp.sendMessage("permission_granted", "storage");
+				NativeApp.sendMessageFromJava("permission_granted", "storage");
 			}
 		} else if (command.equals("gps_command")) {
 			if (params.equals("open")) {

--- a/android/src/org/ppsspp/ppsspp/NativeApp.java
+++ b/android/src/org/ppsspp/ppsspp/NativeApp.java
@@ -50,7 +50,7 @@ public class NativeApp {
 
 	public static native void accelerometer(float x, float y, float z);
 
-	public static native void sendMessage(String msg, String arg);
+	public static native void sendMessageFromJava(String msg, String arg);
 	public static native void sendRequestResult(int seqID, boolean result, String value, int iValue);
 	public static native String queryConfig(String queryName);
 

--- a/android/src/org/ppsspp/ppsspp/NativeGLView.java
+++ b/android/src/org/ppsspp/ppsspp/NativeGLView.java
@@ -189,11 +189,11 @@ public class NativeGLView extends GLSurfaceView implements SensorEventListener, 
 			case StateEvent.ACTION_CONNECTED:
 				Log.i(TAG, "Moga Connected");
 				if (mController.getState(Controller.STATE_CURRENT_PRODUCT_VERSION) == Controller.ACTION_VERSION_MOGA) {
-					NativeApp.sendMessage("moga", "Moga");
+					NativeApp.sendMessageFromJava("moga", "Moga");
 				} else {
 					Log.i(TAG, "MOGA Pro detected");
 					isMogaPro = true;
-					NativeApp.sendMessage("moga", "MogaPro");
+					NativeApp.sendMessageFromJava("moga", "MogaPro");
 				}
 				break;
 			case StateEvent.ACTION_CONNECTING:
@@ -201,7 +201,7 @@ public class NativeGLView extends GLSurfaceView implements SensorEventListener, 
 				break;
 			case StateEvent.ACTION_DISCONNECTED:
 				Log.i(TAG, "Moga Disconnected (or simply Not connected)");
-				NativeApp.sendMessage("moga", "");
+				NativeApp.sendMessageFromJava("moga", "");
 				break;
 			}
 			break;

--- a/android/src/org/ppsspp/ppsspp/NativeSurfaceView.java
+++ b/android/src/org/ppsspp/ppsspp/NativeSurfaceView.java
@@ -186,11 +186,11 @@ public class NativeSurfaceView extends SurfaceView implements SensorEventListene
 			case StateEvent.ACTION_CONNECTED:
 				Log.i(TAG, "Moga Connected");
 				if (mController.getState(Controller.STATE_CURRENT_PRODUCT_VERSION) == Controller.ACTION_VERSION_MOGA) {
-					NativeApp.sendMessage("moga", "Moga");
+					NativeApp.sendMessageFromJava("moga", "Moga");
 				} else {
 					Log.i(TAG, "MOGA Pro detected");
 					isMogaPro = true;
-					NativeApp.sendMessage("moga", "MogaPro");
+					NativeApp.sendMessageFromJava("moga", "MogaPro");
 				}
 				break;
 			case StateEvent.ACTION_CONNECTING:
@@ -198,7 +198,7 @@ public class NativeSurfaceView extends SurfaceView implements SensorEventListene
 				break;
 			case StateEvent.ACTION_DISCONNECTED:
 				Log.i(TAG, "Moga Disconnected (or simply Not connected)");
-				NativeApp.sendMessage("moga", "");
+				NativeApp.sendMessageFromJava("moga", "");
 				break;
 			}
 			break;

--- a/android/src/org/ppsspp/ppsspp/PowerSaveModeReceiver.java
+++ b/android/src/org/ppsspp/ppsspp/PowerSaveModeReceiver.java
@@ -108,9 +108,9 @@ public class PowerSaveModeReceiver extends BroadcastReceiver {
 
 		try {
 			if (isBatteryLow || isPowerSaving) {
-				NativeApp.sendMessage("core_powerSaving", "true");
+				NativeApp.sendMessageFromJava("core_powerSaving", "true");
 			} else {
-				NativeApp.sendMessage("core_powerSaving", "false");
+				NativeApp.sendMessageFromJava("core_powerSaving", "false");
 			}
 		} catch (Exception e) {
 			Log.e(TAG, "Exception in sendPowerSaving: " + e.toString());

--- a/android/src/org/ppsspp/ppsspp/SizeManager.java
+++ b/android/src/org/ppsspp/ppsspp/SizeManager.java
@@ -203,7 +203,7 @@ public class SizeManager implements SurfaceHolder.Callback {
 				safeInsetTop = 0;
 				safeInsetBottom = 0;
 			}
-			NativeApp.sendMessage("safe_insets", safeInsetLeft + ":" + safeInsetRight + ":" + safeInsetTop + ":" + safeInsetBottom);
+			NativeApp.sendMessageFromJava("safe_insets", safeInsetLeft + ":" + safeInsetRight + ":" + safeInsetTop + ":" + safeInsetBottom);
 		}
 	}
 }

--- a/ios/AppDelegate.mm
+++ b/ios/AppDelegate.mm
@@ -112,7 +112,7 @@
 		iOSCoreAudioShutdown();
 	}
 
-	NativeMessageReceived("lost_focus", "");
+	System_PostUIMessage("lost_focus", "");
 }
 
 -(void) applicationDidBecomeActive:(UIApplication *)application {
@@ -120,7 +120,7 @@
 		iOSCoreAudioInit();
 	}
 
-	NativeMessageReceived("got_focus", "");
+	System_PostUIMessage("got_focus", "");
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application {


### PR DESCRIPTION
Just want to make sure that string messages used in the java interface don't leak out uncontrolled to the UI message mechanism in the rest of the app.

This also replaced NativeMessageReceived with System_PostUIMessage.

Next step (at some point) will be to change the first part of each message to an enum instead. This is why we can't have it connected to our ugly java string message mechanism.