### PR TITLE
Add checkbox controlling if new mappings can be combo mappings.

### DIFF
--- a/Common/Input/InputState.cpp
+++ b/Common/Input/InputState.cpp
@@ -20,7 +20,7 @@ const char *GetDeviceName(int deviceId) {
 	case DEVICE_ID_PAD_7: return "pad8";
 	case DEVICE_ID_PAD_8: return "pad9";
 	case DEVICE_ID_PAD_9: return "pad10";
-	case DEVICE_ID_XINPUT_0: return "x360";  // keeping these strings for backward compat
+	case DEVICE_ID_XINPUT_0: return "x360";  // keeping these strings for backward compat. Hm, what would break if we changed them to xbox?
 	case DEVICE_ID_XINPUT_1: return "x360_2";
 	case DEVICE_ID_XINPUT_2: return "x360_3";
 	case DEVICE_ID_XINPUT_3: return "x360_4";

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -758,6 +758,8 @@ static const ConfigSetting controlSettings[] = {
 
 	ConfigSetting("AnalogLimiterDeadzone", &g_Config.fAnalogLimiterDeadzone, 0.6f, CfgFlag::DEFAULT),
 
+	ConfigSetting("AllowMappingCombos", &g_Config.bAllowMappingCombos, false, CfgFlag::DEFAULT),
+
 	ConfigSetting("LeftStickHeadScale", &g_Config.fLeftStickHeadScale, 1.0f, CfgFlag::PER_GAME),
 	ConfigSetting("RightStickHeadScale", &g_Config.fRightStickHeadScale, 1.0f, CfgFlag::PER_GAME),
 	ConfigSetting("HideStickBackground", &g_Config.bHideStickBackground, false, CfgFlag::PER_GAME),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -376,6 +376,9 @@ public:
 	// Sets up how much the analog limiter button restricts digital->analog input.
 	float fAnalogLimiterDeadzone;
 
+	// Sets whether combo mapping is enabled.
+	bool bAllowMappingCombos;
+
 	bool bMouseControl;
 	bool bMapMouse; // Workaround for mapping screen:|
 	bool bMouseConfine; // Trap inside the window.

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -873,12 +873,12 @@ namespace SaveState
 			// Sometimes this exposes game bugs that were rarely seen on real devices,
 			// because few people played on a real PSP for 10 hours straight.
 			callbackMessage = sc->T("Loaded. Save in game, restart, and load for less bugs.");
-			return Status::WARNING;
+			return Status::SUCCESS;
 		}
 		if (IsOldVersion()) {
 			// Save states also preserve bugs from old PPSSPP versions, so warn.
 			callbackMessage = sc->T("Loaded. Save in game, restart, and load for less bugs.");
-			return Status::WARNING;
+			return Status::SUCCESS;
 		}
 		// If the loaded state (saveDataGeneration) is older, the game may prevent saving again.
 		// This can happen with newer too, but ignore to/from 0 as a common likely safe case.

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -252,6 +252,7 @@ void ControlMappingScreen::CreateViews() {
 	}
 
 	leftColumn->Add(new Choice(km->T("Show PSP")))->OnClick.Handle(this, &ControlMappingScreen::OnVisualizeMapping);
+	leftColumn->Add(new CheckBox(&g_Config.bAllowMappingCombos, km->T("Allow combo mappings")));
 
 	leftColumn->Add(new Spacer(new LinearLayoutParams(1.0f)));
 	AddStandardBack(leftColumn);
@@ -333,6 +334,9 @@ void KeyMappingNewKeyDialog::CreatePopupContents(UI::ViewGroup *parent) {
 	parent->Add(new TextView(std::string(km->T("Map a new key for")) + " " + mc->T(pspButtonName), new LinearLayoutParams(Margins(10, 0))));
 	parent->Add(new TextView(std::string(mapping_.ToVisualString()), new LinearLayoutParams(Margins(10, 0))));
 
+	comboMappingsNotEnabled_ = parent->Add(new TextView(km->T("Combo mappings are not enabled"), new LinearLayoutParams(Margins(10, 0))));
+	comboMappingsNotEnabled_->SetVisibility(UI::V_GONE);
+
 	SetVRAppMode(VRAppMode::VR_CONTROLLER_MAPPING_MODE);
 }
 
@@ -341,6 +345,7 @@ bool KeyMappingNewKeyDialog::key(const KeyInput &key) {
 		return true;
 	if (time_now_d() < delayUntil_)
 		return true;
+
 	if (key.flags & KEY_DOWN) {
 		if (key.keyCode == NKCODE_EXT_MOUSEBUTTON_1) {
 			// Don't map
@@ -355,7 +360,9 @@ bool KeyMappingNewKeyDialog::key(const KeyInput &key) {
 		InputMapping newMapping(key.deviceId, key.keyCode);
 
 		if (!(key.flags & KEY_IS_REPEAT)) {
-			if (!mapping_.mappings.contains(newMapping)) {
+			if (!g_Config.bAllowMappingCombos && !mapping_.mappings.empty()) {
+				comboMappingsNotEnabled_->SetVisibility(UI::V_VISIBLE);
+			} else if (!mapping_.mappings.contains(newMapping)) {
 				mapping_.mappings.push_back(newMapping);
 				RecreateViews();
 			}

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -81,6 +81,8 @@ private:
 
 	KeyMap::MultiInputMapping mapping_;
 
+	UI::View *comboMappingsNotEnabled_ = nullptr;
+
 	// We need to do our own detection for axis "keyup" here.
 	std::set<InputMapping> triggeredAxes_;
 

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -1027,7 +1027,7 @@ public abstract class NativeActivity extends Activity {
 	@TargetApi(Build.VERSION_CODES.HONEYCOMB_MR1)
 	public boolean onGenericMotionEvent(MotionEvent event) {
 		// Log.d(TAG, "onGenericMotionEvent: " + event);
-		if ((event.getSource() & InputDevice.SOURCE_JOYSTICK) != 0) {
+		if (InputDeviceState.inputSourceIsJoystick(event.getSource())) {
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1) {
 				InputDeviceState state = getInputDeviceState(event);
 				if (state == null) {
@@ -1080,7 +1080,7 @@ public abstract class NativeActivity extends Activity {
 		case KeyEvent.KEYCODE_DPAD_LEFT:
 		case KeyEvent.KEYCODE_DPAD_RIGHT:
 			// Joysticks are supported in Honeycomb MR1 and later via the onGenericMotionEvent method.
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1 && (event.getSource() & InputDevice.SOURCE_JOYSTICK) != 0) {
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1 && InputDeviceState.inputSourceIsJoystick(event.getSource())) {
 				// Pass through / ignore
 				return super.onKeyDown(keyCode, event);
 			}
@@ -1118,7 +1118,7 @@ public abstract class NativeActivity extends Activity {
 		case KeyEvent.KEYCODE_DPAD_LEFT:
 		case KeyEvent.KEYCODE_DPAD_RIGHT:
 			// Joysticks are supported in Honeycomb MR1 and later via the onGenericMotionEvent method.
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1 && event.getSource() == InputDevice.SOURCE_JOYSTICK) {
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1 && InputDeviceState.inputSourceIsJoystick(event.getSource())) {
 				return super.onKeyUp(keyCode, event);
 			}
 			// Fall through

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -644,10 +644,12 @@ Zip archive corrupt = ZIP archive corrupt
 Zip file does not contain PSP software = ZIP file does not contain PSP software
 
 [KeyMapping]
+Allow combo mappings = Allow combo mappings
 Autoconfigure = Auto configure
 Autoconfigure for device = Autoconfigure for device
 Bind All = Bind All
 Clear All = Clear all
+Combo mappings are not enabled = Combo mappings are not enabled
 Default All = Restore defaults
 Map a new key for = Map a new key for
 Map Key = Map key


### PR DESCRIPTION
These turned out to be surprisingly problematic, especially with certain controllers that send double signals. Like for example PS4 controllers on Android, the analog triggers send dual axis events, and additionally digital events.

So by default, let's not allow combo mappings, but let's have a prominent checkbox to enable them for those who want them.