### PR TITLE
New UI view: Notice

### DIFF
--- a/Common/UI/Root.cpp
+++ b/Common/UI/Root.cpp
@@ -418,7 +418,6 @@ void UpdateViewHierarchy(ViewGroup *root) {
 			}
 			root->SubviewFocused(GetFocusedView());
 		} else {
-			INFO_LOG(SCECTRL, "Processing focus moves.");
 			for (size_t i = 0; i < focusMoves.size(); i++) {
 				switch (focusMoves[i]) {
 				case NKCODE_DPAD_LEFT: MoveFocus(root, FOCUS_LEFT); break;
@@ -432,7 +431,6 @@ void UpdateViewHierarchy(ViewGroup *root) {
 				}
 			}
 		}
-		INFO_LOG(SCECTRL, "Clearing focus moves.");
 		focusMoves.clear();
 	}
 

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -1050,6 +1050,7 @@ private:
 };
 
 void MeasureBySpec(Size sz, float contentWidth, MeasureSpec spec, float *measured);
+void ApplyBoundsBySpec(Bounds &bounds, MeasureSpec horiz, MeasureSpec vert);
 
 bool IsDPadKey(const KeyInput &key);
 bool IsAcceptKey(const KeyInput &key);

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -132,7 +132,9 @@ void DrawEngineD3D11::NotifyConfigChanged() {
 }
 
 void DrawEngineD3D11::DestroyDeviceObjects() {
-	draw_->SetInvalidationCallback(InvalidationCallback());
+	if (draw_) {
+		draw_->SetInvalidationCallback(InvalidationCallback());
+	}
 
 	ClearTrackedVertexArrays();
 	ClearInputLayoutMap();

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -46,6 +46,7 @@
 #include "UI/ControlMappingScreen.h"
 #include "UI/GameSettingsScreen.h"
 #include "UI/JoystickHistoryView.h"
+#include "UI/OnScreenDisplay.h"
 
 #if PPSSPP_PLATFORM(ANDROID)
 #include "android/jni/app-android.h"
@@ -334,7 +335,7 @@ void KeyMappingNewKeyDialog::CreatePopupContents(UI::ViewGroup *parent) {
 	parent->Add(new TextView(std::string(km->T("Map a new key for")) + " " + mc->T(pspButtonName), new LinearLayoutParams(Margins(10, 0))));
 	parent->Add(new TextView(std::string(mapping_.ToVisualString()), new LinearLayoutParams(Margins(10, 0))));
 
-	comboMappingsNotEnabled_ = parent->Add(new TextView(km->T("Combo mappings are not enabled"), new LinearLayoutParams(Margins(10, 0))));
+	comboMappingsNotEnabled_ = parent->Add(new NoticeView(NoticeLevel::WARN, km->T("Combo mappings are not enabled"), "", new LinearLayoutParams(Margins(10, 0))));
 	comboMappingsNotEnabled_->SetVisibility(UI::V_GONE);
 
 	SetVRAppMode(VRAppMode::VR_CONTROLLER_MAPPING_MODE);

--- a/UI/OnScreenDisplay.h
+++ b/UI/OnScreenDisplay.h
@@ -9,6 +9,10 @@
 #include "Common/UI/UIScreen.h"
 #include "Common/System/System.h"
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 class DrawBuffer;
 
 // Infrastructure for rendering overlays.
@@ -24,4 +28,31 @@ class OSDOverlayScreen : public UIScreen {
 public:
 	const char *tag() const override { return "OSDOverlayScreen"; }
 	void CreateViews() override;
+};
+
+enum class NoticeLevel {
+	SUCCESS,
+	INFO,
+	WARN,
+	ERROR,
+};
+
+class NoticeView : public UI::InertView {
+public:
+	NoticeView(NoticeLevel level, const std::string &text, const std::string &detailsText, UI::LayoutParams *layoutParams = 0)
+		: InertView(layoutParams), level_(level), text_(text), detailsText_(detailsText), iconName_("") {}
+
+	void SetIconName(const std::string &name) {
+		iconName_ = name;
+	}
+
+	void GetContentDimensionsBySpec(const UIContext &dc, UI::MeasureSpec horiz, UI::MeasureSpec vert, float &w, float &h) const override;
+	void Draw(UIContext &dc) override;
+
+private:
+	std::string text_;
+	std::string detailsText_;
+	std::string iconName_;
+	NoticeLevel level_;
+	mutable float height1_ = 0.0f;
 };


### PR DESCRIPTION
Break out rendering of "notices" from OnScreenDisplay. They can now also be used as views.

Use it for the new message in ControlMappingScreen, when you try to map a combo when that's disabled. It'll have more uses.