### PR TITLE
Reduce delays in sceKernelReferThreadProfiler/ReferGlobalProfiler.

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -683,19 +683,16 @@ static u32 sceKernelReferThreadProfiler() {
 	// This seems to simply has no parameter:
 	// https://pspdev.github.io/pspsdk/group__ThreadMan.html#ga8fd30da51b9dc0507ac4dae04a7e4a17 , 
 	// And in testing it just returns null in 55 usec (which is surprisingly long).
-
-	// So, we log only if debug logging is enabled, and sleep for a bit.
+	// However, this breaks MLB 2k11. See issue #17623. So I've removed the sleeps for now.
 	DEBUG_LOG(SCEKERNEL, "0=sceKernelReferThreadProfiler()");
-
-	// The delay has been measured, 53-56 us.
-	hleEatMicro(55);
+	// hleEatMicro(55);
 	return 0;
 }
 
 static int sceKernelReferGlobalProfiler() {
 	DEBUG_LOG(SCEKERNEL, "0=sceKernelReferGlobalProfiler()");
-	// The delay has been measured, 53-56 us.
-	hleEatMicro(55);
+	// See sceKernelReferThreadProfiler(), similar.
+	// hleEatMicro(55);
 	return 0;
 }
 

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -681,18 +681,17 @@ struct DebugProfilerRegs {
 
 static u32 sceKernelReferThreadProfiler() {
 	// This seems to simply has no parameter:
-	// https://pspdev.github.io/pspsdk/group__ThreadMan.html#ga8fd30da51b9dc0507ac4dae04a7e4a17 , 
-	// And in testing it just returns null in 55 usec (which is surprisingly long).
-	// However, this breaks MLB 2k11. See issue #17623. So I've removed the sleeps for now.
+	// https://pspdev.github.io/pspsdk/group__ThreadMan.html#ga8fd30da51b9dc0507ac4dae04a7e4a17
+	// In testing it just returns null in around 140-150 cycles.  See issue #17623.
 	DEBUG_LOG(SCEKERNEL, "0=sceKernelReferThreadProfiler()");
-	// hleEatMicro(55);
+	hleEatCycles(140);
 	return 0;
 }
 
 static int sceKernelReferGlobalProfiler() {
 	DEBUG_LOG(SCEKERNEL, "0=sceKernelReferGlobalProfiler()");
 	// See sceKernelReferThreadProfiler(), similar.
-	// hleEatMicro(55);
+	hleEatCycles(140);
 	return 0;
 }
 


### PR DESCRIPTION
This fixes timing in the MLB games. ~~, but is inconsistent with testing :(~~ I measured wrong before. Thanks @unknownbrackets for setting it straight.

See issue #17623.