### PR TITLE
RetroAchievements: Show active challenge achievements on pause screen.

### DIFF
--- a/Common/System/OSD.h
+++ b/Common/System/OSD.h
@@ -53,6 +53,10 @@ public:
 	void SetProgressBar(std::string id, std::string &&message, int minValue, int maxValue, int progress);
 	void RemoveProgressBar(std::string id);
 
+	// Show stuff on the side or now, like the challenge indicators etc.
+	void SetShowSidebar(bool show) { showSidebar_ = show; }
+	bool ShowSidebar() const { return showSidebar_; }
+
 	struct Entry {
 		OSDType type;
 		std::string text;
@@ -84,6 +88,8 @@ private:
 	std::vector<Entry> sideEntries_;
 	std::vector<ProgressBar> bars_;
 	std::mutex mutex_;
+
+	bool showSidebar_ = true;
 };
 
 extern OnScreenDisplay g_OSD;

--- a/Core/RetroAchievements.h
+++ b/Core/RetroAchievements.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <set>
 #include <mutex>
 
 #include "Common/StringUtils.h"
@@ -104,5 +105,7 @@ void UnloadGame();  // Call when leaving a game.
 Statistics GetStatistics();
 
 std::string GetGameAchievementSummary();
+
+std::set<uint32_t> GetActiveChallengeIDs();
 
 } // namespace Achievements

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -197,6 +197,7 @@ EmuScreen::EmuScreen(const Path &filename)
 	// Usually, we don't want focus movement enabled on this screen, so disable on start.
 	// Only if you open chat or dev tools do we want it to start working.
 	UI::EnableFocusMovement(false);
+	g_OSD.SetShowSidebar(true);
 }
 
 bool EmuScreen::bootAllowStorage(const Path &filename) {

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -261,8 +261,14 @@ void GamePauseScreen::update() {
 	SetVRAppMode(VRAppMode::VR_MENU_MODE);
 }
 
+GamePauseScreen::GamePauseScreen(const Path &filename)
+	: UIDialogScreenWithGameBackground(filename) {
+	g_OSD.SetShowSidebar(false);
+}
+
 GamePauseScreen::~GamePauseScreen() {
 	__DisplaySetWasPaused();
+	g_OSD.SetShowSidebar(true);
 }
 
 void GamePauseScreen::CreateSavestateControls(UI::LinearLayout *leftColumnItems, bool vertical) {
@@ -326,6 +332,18 @@ void GamePauseScreen::CreateViews() {
 
 	if (!Achievements::ChallengeModeActive()) {
 		CreateSavestateControls(leftColumnItems, vertical);
+	} else {
+		// Let's show the active challenges.
+		std::set<uint32_t> ids = Achievements::GetActiveChallengeIDs();
+		if (!ids.empty()) {
+			leftColumnItems->Add(new ItemHeader(ac->T("Active Challenges")));
+			for (auto id : ids) {
+				const rc_client_achievement_t *achievement = rc_client_get_achievement_info(Achievements::GetClient(), id);
+				if (!achievement)
+					continue;
+				leftColumnItems->Add(new AchievementView(achievement));
+			}
+		}
 	}
 
 	ViewGroup *rightColumn = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(vertical ? 200 : 300, FILL_PARENT, actionMenuMargins));

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -32,7 +32,7 @@ enum class PauseScreenMode {
 
 class GamePauseScreen : public UIDialogScreenWithGameBackground {
 public:
-	GamePauseScreen(const Path &filename) : UIDialogScreenWithGameBackground(filename), gamePath_(filename) {}
+	GamePauseScreen(const Path &filename);
 	~GamePauseScreen();
 
 	void dialogFinished(const Screen *dialog, DialogResult dr) override;
@@ -65,6 +65,5 @@ private:
 
 	// hack
 	bool finishNextFrame_ = false;
-	Path gamePath_;
 	PauseScreenMode mode_ = PauseScreenMode::MAIN;
 };

--- a/UI/RetroAchievementScreens.cpp
+++ b/UI/RetroAchievementScreens.cpp
@@ -595,4 +595,3 @@ void LeaderboardEntryView::Draw(UIContext &dc) {
 void LeaderboardEntryView::GetContentDimensions(const UIContext &dc, float &w, float &h) const {
 	MeasureLeaderboardEntry(dc, entry_, &w, &h);
 }
-


### PR DESCRIPTION
Keeps track of active challenges by watching `RC_CLIENT_EVENT_ACHIEVEMENT_CHALLENGE_INDICATOR_SHOW` and `RC_CLIENT_EVENT_ACHIEVEMENT_CHALLENGE_INDICATOR_HIDE` events.

Since we have the screen space anyway in challenge mode, why not.

Also fixes an issue where sidebar items like challenge icons were drawn on top of the pause screen.