### PR TITLE
libretro: fix fast forwarding

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -425,6 +425,10 @@ static std::string map_psp_language_to_i18n_locale(int val)
 
 static void check_variables(CoreParameter &coreParam)
 {
+   bool isFastForwarding;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_FASTFORWARDING, &isFastForwarding))
+       coreParam.fastForward = isFastForwarding;
+
    bool updated = false;
 
    if (     coreState != CoreState::CORE_POWERUP
@@ -1024,10 +1028,6 @@ static void check_variables(CoreParameter &coreParam)
       retro_get_system_av_info(&avInfo);
       environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &avInfo);
    }
-
-   bool isFastForwarding;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_FASTFORWARDING, &isFastForwarding))
-       coreParam.fastForward = isFastForwarding;
 
    set_variable_visibility();
 }


### PR DESCRIPTION
This is a quick and dirty fix that makes it work the way it was supposed to when originally written, which is good enough most of the time, except that the FPS isn't reported correctly. There is a better libretro api that should be used (`RETRO_ENVIRONMENT_GET_THROTTLE_STATE`) that supersedes `RETRO_ENVIRONMENT_GET_FASTFORWARDING`.