### PR TITLE
RetroAchievements: Call rc_client_do_frame from hleEnterVblank

### DIFF
--- a/Common/UI/IconCache.cpp
+++ b/Common/UI/IconCache.cpp
@@ -91,7 +91,11 @@ bool IconCache::LoadFromFile(FILE *file) {
 
 		std::string data;
 		data.resize(entryHeader.dataLen);
-		fread(&data[0], 1, entryHeader.dataLen, file);
+		size_t len = fread(&data[0], 1, entryHeader.dataLen, file);
+		if (len != (size_t)entryHeader.dataLen) {
+			// Stop reading and don't use this entry. Seems the file is truncated, but we'll recover.
+			break;
+		}
 
 		Entry entry{};
 		entry.data = data;

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -506,6 +506,9 @@ static void DoFrameIdleTiming() {
 void hleEnterVblank(u64 userdata, int cyclesLate) {
 	int vbCount = userdata;
 
+	// This should be a good place to do it. Should happen once per vblank. Here or in leave? Not sure it matters much.
+	Achievements::FrameUpdate();
+
 	VERBOSE_LOG(SCEDISPLAY, "Enter VBlank %i", vbCount);
 
 	DisplayFireVblankStart();

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1146,8 +1146,6 @@ void EmuScreen::update() {
 			}
 		}
 	}
-
-	Achievements::FrameUpdate();
 }
 
 void EmuScreen::checkPowerDown() {


### PR DESCRIPTION
This is a more appropriate place, which should lead to more consistent timing.

Also add a check for truncated files when loading the icon cache.

Part of #17631 