### PR TITLE
Vulkan: Enable the present-id/present-wait/display-timing extensions

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -592,10 +592,18 @@ void VulkanContext::ChooseDevice(int physical_device) {
 		VkPhysicalDeviceFeatures2 features2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR};
 		// Add to chain even if not supported, GetPhysicalDeviceFeatures is supposed to ignore unknown structs.
 		VkPhysicalDeviceMultiviewFeatures multiViewFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES };
+		VkPhysicalDevicePresentWaitFeaturesKHR presentWaitFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR };
+		VkPhysicalDevicePresentIdFeaturesKHR presentIdFeatures{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR };
+
 		features2.pNext = &multiViewFeatures;
+		multiViewFeatures.pNext = &presentWaitFeatures;
+		presentWaitFeatures.pNext = &presentIdFeatures;
+
 		vkGetPhysicalDeviceFeatures2KHR(physical_devices_[physical_device_], &features2);
 		deviceFeatures_.available.standard = features2.features;
 		deviceFeatures_.available.multiview = multiViewFeatures;
+		deviceFeatures_.available.presentWait = presentWaitFeatures;
+		deviceFeatures_.available.presentId = presentIdFeatures;
 	} else {
 		vkGetPhysicalDeviceFeatures(physical_devices_[physical_device_], &deviceFeatures_.available.standard);
 		deviceFeatures_.available.multiview = {};
@@ -615,6 +623,8 @@ void VulkanContext::ChooseDevice(int physical_device) {
 
 	deviceFeatures_.enabled.multiview = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES };
 	deviceFeatures_.enabled.multiview.multiview = deviceFeatures_.available.multiview.multiview;
+	deviceFeatures_.enabled.presentId = deviceFeatures_.available.presentId;
+	deviceFeatures_.enabled.presentWait = deviceFeatures_.available.presentWait;
 	// deviceFeatures_.enabled.multiview.multiviewGeometryShader = deviceFeatures_.available.multiview.multiviewGeometryShader;
 
 	GetDeviceLayerExtensionList(nullptr, device_extension_properties_);
@@ -680,6 +690,10 @@ VkResult VulkanContext::CreateDevice() {
 	extensionsLookup_.EXT_shader_stencil_export = EnableDeviceExtension(VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME);
 	extensionsLookup_.EXT_fragment_shader_interlock = EnableDeviceExtension(VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME);
 	extensionsLookup_.ARM_rasterization_order_attachment_access = EnableDeviceExtension(VK_ARM_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_EXTENSION_NAME);
+
+	extensionsLookup_.KHR_present_id = EnableDeviceExtension(VK_KHR_PRESENT_ID_EXTENSION_NAME);
+	extensionsLookup_.KHR_present_wait = EnableDeviceExtension(VK_KHR_PRESENT_WAIT_EXTENSION_NAME);
+	extensionsLookup_.GOOGLE_display_timing = EnableDeviceExtension(VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME);
 
 	VkPhysicalDeviceFeatures2 features2{ VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 };
 

--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -264,6 +264,8 @@ public:
 	struct AllPhysicalDeviceFeatures {
 		VkPhysicalDeviceFeatures standard;
 		VkPhysicalDeviceMultiviewFeatures multiview;
+		VkPhysicalDevicePresentWaitFeaturesKHR presentWait;
+		VkPhysicalDevicePresentIdFeaturesKHR presentId;
 	};
 
 	const PhysicalDeviceProps &GetPhysicalDeviceProperties(int i = -1) const {

--- a/Common/GPU/Vulkan/VulkanLoader.h
+++ b/Common/GPU/Vulkan/VulkanLoader.h
@@ -253,6 +253,9 @@ struct VulkanExtensions {
 	bool EXT_swapchain_colorspace;
 	bool ARM_rasterization_order_attachment_access;
 	bool EXT_fragment_shader_interlock;
+	bool KHR_present_id;  // Should probably check the feature flags instead.
+	bool KHR_present_wait;  // Same
+	bool GOOGLE_display_timing;
 	// bool EXT_depth_range_unrestricted;  // Allows depth outside [0.0, 1.0] in 32-bit float depth buffers.
 };
 

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1614,6 +1614,8 @@ std::vector<std::string> VKContext::GetFeatureList() const {
 
 	AddFeature(features, "multiview", vulkan_->GetDeviceFeatures().available.multiview.multiview, vulkan_->GetDeviceFeatures().enabled.multiview.multiview);
 	AddFeature(features, "multiviewGeometryShader", vulkan_->GetDeviceFeatures().available.multiview.multiviewGeometryShader, vulkan_->GetDeviceFeatures().enabled.multiview.multiviewGeometryShader);
+	AddFeature(features, "presentId", vulkan_->GetDeviceFeatures().available.presentId.presentId, vulkan_->GetDeviceFeatures().enabled.presentId.presentId);
+	AddFeature(features, "presentWait", vulkan_->GetDeviceFeatures().available.presentWait.presentWait, vulkan_->GetDeviceFeatures().enabled.presentWait.presentWait);
 
 	features.emplace_back(std::string("Preferred depth buffer format: ") + VulkanFormatToString(vulkan_->GetDeviceInfo().preferredDepthStencilFormat));
 

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -781,6 +781,7 @@ void SystemInfoScreen::CreateTabs() {
 
 		gpuExtensions->Add(new ItemHeader(si->T("Vulkan Extensions")));
 		std::vector<std::string> extensions = draw->GetExtensionList();
+		std::sort(extensions.begin(), extensions.end());
 		for (auto &extension : extensions) {
 			gpuExtensions->Add(new TextView(extension, new LayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetFocusable(true);
 		}


### PR DESCRIPTION
Doesn't actually use any of them yet, just making sure enabling them doesn't cause any weird issues. 

They will be used for the future display timing rewrite.