### PR TITLE
HTTP user agent fix for DownloadManager

### DIFF
--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -180,7 +180,7 @@ void Connection::Disconnect() {
 namespace http {
 
 // TODO: do something sane here
-constexpr const char *DEFAULT_USERAGENT = "NATIVEAPP 1.0";
+constexpr const char *DEFAULT_USERAGENT = "PPSSPP";
 
 Client::Client() {
 	httpVersion_ = "1.1";
@@ -491,6 +491,10 @@ int Download::Perform(const std::string &url) {
 	}
 
 	http::Client client;
+	if (!userAgent_.empty()) {
+		client.SetUserAgent(userAgent_);
+	}
+
 	if (!client.Resolve(fileUrl.Host().c_str(), fileUrl.Port())) {
 		ERROR_LOG(IO, "Failed resolving %s", url.c_str());
 		return -1;
@@ -580,6 +584,8 @@ void Download::Do() {
 
 std::shared_ptr<Download> Downloader::StartDownload(const std::string &url, const Path &outfile, const char *acceptMime) {
 	std::shared_ptr<Download> dl(new Download(RequestMethod::GET, url, "", "", outfile));
+	if (!userAgent_.empty())
+		dl->SetUserAgent(userAgent_);
 	if (acceptMime)
 		dl->SetAccept(acceptMime);
 	newDownloads_.push_back(dl);
@@ -593,6 +599,8 @@ std::shared_ptr<Download> Downloader::StartDownloadWithCallback(
 	std::function<void(Download &)> callback,
 	const char *acceptMime) {
 	std::shared_ptr<Download> dl(new Download(RequestMethod::GET, url, "", "", outfile));
+	if (!userAgent_.empty())
+		dl->SetUserAgent(userAgent_);
 	if (acceptMime)
 		dl->SetAccept(acceptMime);
 	dl->SetCallback(callback);
@@ -607,6 +615,8 @@ std::shared_ptr<Download> Downloader::AsyncPostWithCallback(
 	const std::string &postMime,
 	std::function<void(Download &)> callback) {
 	std::shared_ptr<Download> dl(new Download(RequestMethod::POST, url, postData, postMime, Path()));
+	if (!userAgent_.empty())
+		dl->SetUserAgent(userAgent_);
 	dl->SetCallback(callback);
 	newDownloads_.push_back(dl);
 	dl->Start();

--- a/Common/Net/HTTPClient.h
+++ b/Common/Net/HTTPClient.h
@@ -156,6 +156,9 @@ public:
 	// Downloader::GetCurrentProgress won't return it in the results.
 	bool IsHidden() const { return hidden_; }
 	void SetHidden(bool hidden) { hidden_ = hidden; }
+	void SetUserAgent(const std::string &userAgent) {
+		userAgent_ = userAgent;
+	}
 
 private:
 	void Do();  // Actually does the download. Runs on thread.
@@ -166,6 +169,7 @@ private:
 	RequestProgress progress_;
 	RequestMethod method_;
 	std::string postData_;
+	std::string userAgent_;
 	Buffer buffer_;
 	std::vector<std::string> responseHeaders_;
 	std::string url_;
@@ -209,6 +213,9 @@ public:
 	void CancelAll();
 
 	void WaitForAll();
+	void SetUserAgent(const std::string &userAgent) {
+		userAgent_ = userAgent;
+	}
 
 	std::vector<float> GetCurrentProgress();
 
@@ -221,6 +228,8 @@ private:
 	// These get copied to downloads_ in Update(). It's so that callbacks can add new downloads
 	// while running.
 	std::vector<std::shared_ptr<Download>> newDownloads_;
+
+	std::string userAgent_;
 };
 
 }	// http

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1050,6 +1050,8 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 		bUpdatedInstanceCounter = true;
 	}
 
+	g_DownloadManager.SetUserAgent(StringFromFormat("PPSSPP/%s", PPSSPP_GIT_VERSION));
+
 	UpdateIniLocation(iniFileName, controllerIniFilename);
 
 	INFO_LOG(LOADER, "Loading config: %s", iniFilename_.c_str());

--- a/Core/RetroAchievements.cpp
+++ b/Core/RetroAchievements.cpp
@@ -579,16 +579,25 @@ std::string GetGameAchievementSummary() {
 	rc_client_user_game_summary_t summary;
 	rc_client_get_user_game_summary(g_rcClient, &summary);
 
-	std::string summaryString = StringFromFormat(ac->T("Earned", "You have unlocked %d of %d achievements, earning %d of %d points"),
-		summary.num_unlocked_achievements, summary.num_core_achievements + summary.num_unofficial_achievements,
-		summary.points_unlocked, summary.points_core);
-	if (ChallengeModeActive()) {
-		summaryString.append("\n");
-		summaryString.append(ac->T("Challenge Mode"));
-	}
-	if (EncoreModeActive()) {
-		summaryString.append("\n");
-		summaryString.append(ac->T("Encore Mode"));
+	std::string summaryString;
+	if (summary.num_core_achievements + summary.num_unofficial_achievements == 0) {
+		summaryString = ac->T("This game has no achievements");
+	} else {
+		summaryString = StringFromFormat(ac->T("Earned", "You have unlocked %d of %d achievements, earning %d of %d points"),
+			summary.num_unlocked_achievements, summary.num_core_achievements + summary.num_unofficial_achievements,
+			summary.points_unlocked, summary.points_core);
+		if (ChallengeModeActive()) {
+			summaryString.append("\n");
+			summaryString.append(ac->T("Challenge Mode"));
+		}
+		if (EncoreModeActive()) {
+			summaryString.append("\n");
+			summaryString.append(ac->T("Encore Mode"));
+		}
+		if (UnofficialEnabled()) {
+			summaryString.append("\n");
+			summaryString.append(ac->T("Unofficial achievements"));
+		}
 	}
 	return summaryString;
 }

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -52,6 +52,7 @@ Sound Effects = Sound Effects
 Statistics = Statistics
 Syncing achievements data... = Syncing achievements data...
 Test Mode = Test Mode
+This game has no achievements = This game has no achievements
 Unlocked achievements = Unlocked achievements
 Unofficial achievements = Unofficial achievements
 

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -25,6 +25,7 @@ Sound Effects = Ljudeffekter
 Statistics = Statistik
 Syncing achievements data... = Synkar achievementdata...
 Test Mode = Test-läge
+This game has no achievements = Detta spel har inga achievements
 Unlocked achievements = Upplåsta achievements
 Unofficial achievements = Inofficiella achievements
 


### PR DESCRIPTION
Our HTTP user agent was `NATIVEAPP 1.0` for these which isn't very good, RetroAchievements want clear user agents.

Now uses PPSSPP/{git-version}.

Also a quick fix for recognized games with no achievements.