### PR TITLE
Switch back to rcheevos upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,4 +46,4 @@
 	url = https://github.com/google/cpu_features.git
 [submodule "ext/rcheevos"]
 	path = ext/rcheevos
-	url = https://github.com/hrydgard/rcheevos.git
+	url = https://github.com/RetroAchievements/rcheevos.git

--- a/Core/RetroAchievements.cpp
+++ b/Core/RetroAchievements.cpp
@@ -161,12 +161,8 @@ static uint32_t read_memory_callback(uint32_t address, uint8_t *buffer, uint32_t
 			WARN_LOG(G3D, "RetroAchievements PeekMemory: Bad address %08x (%d bytes) (%08x was passed in)", address, num_bytes, orig_address);
 		}
 
-		// TEMPORARY HACK: rcheevos' handling of bad memory accesses causes a LOT of extra work, since
-		// for some reason these invalid accesses keeps happening. So we'll temporarily to back to the previous
-		// behavior of simply returning 0. This is fixed in a PR upstream, not yet merged.
-		uint32_t temp = 0;
-		memcpy(buffer, &temp, num_bytes);
-		return num_bytes;
+		// This tells rcheevos that the access was bad, which should now be handled properly.
+		return 0;
 	}
 
 	Memory::MemcpyUnchecked(buffer, address, num_bytes);

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2604,13 +2604,6 @@ void FramebufferManagerCommon::NotifyRenderResized(int msaaLevel) {
 	// No drawing is allowed here. This includes anything that might potentially touch a command buffer, like creating images!
 	// So we need to defer the post processing initialization.
 	updatePostShaders_ = true;
-
-#ifdef _WIN32
-	// Seems related - if you're ok with numbers all the time, show some more :)
-	if (g_Config.iShowStatusFlags != 0) {
-		ShowScreenResolution();
-	}
-#endif
 }
 
 void FramebufferManagerCommon::NotifyConfigChanged() {
@@ -2698,24 +2691,6 @@ void FramebufferManagerCommon::UpdateFramebufUsage(VirtualFramebuffer *vfb) {
 	checkFlag(FB_USAGE_TEXTURE, vfb->last_frame_used);
 	checkFlag(FB_USAGE_RENDER_COLOR, vfb->last_frame_render);
 	checkFlag(FB_USAGE_CLUT, vfb->last_frame_clut);
-}
-
-void FramebufferManagerCommon::ShowScreenResolution() {
-	auto gr = GetI18NCategory(I18NCat::GRAPHICS);
-
-	std::ostringstream messageStream;
-	messageStream << gr->T("Internal Resolution") << ": ";
-	messageStream << PSP_CoreParameter().renderWidth << "x" << PSP_CoreParameter().renderHeight << " ";
-	if (postShaderIsUpscalingFilter_) {
-		messageStream << gr->T("(upscaling)") << " ";
-	} else if (postShaderIsSupersampling_) {
-		messageStream << gr->T("(supersampling)") << " ";
-	}
-	messageStream << gr->T("Window Size") << ": ";
-	messageStream << PSP_CoreParameter().pixelWidth << "x" << PSP_CoreParameter().pixelHeight;
-
-	g_OSD.Show(OSDType::MESSAGE_INFO, messageStream.str(), 0.0f, "resize");
-	INFO_LOG(SYSTEM, "%s", messageStream.str().c_str());
 }
 
 void FramebufferManagerCommon::ClearAllDepthBuffers() {

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -509,7 +509,6 @@ protected:
 	void BlitFramebufferDepth(VirtualFramebuffer *src, VirtualFramebuffer *dst);
 
 	void ResizeFramebufFBO(VirtualFramebuffer *vfb, int w, int h, bool force = false, bool skipCopy = false);
-	void ShowScreenResolution();
 
 	bool ShouldDownloadFramebufferColor(const VirtualFramebuffer *vfb) const;
 	bool ShouldDownloadFramebufferDepth(const VirtualFramebuffer *vfb) const;


### PR DESCRIPTION
Now that Jamiras has merged the latest update, we can switch back to the upstream version of rcheevos.

Hopefully we can stay on it from now on!

Also, delete the old annoying resolution information popup that only showed up on Windows.

Part of https://github.com/hrydgard/ppsspp/issues/17631