### PR TITLE
Make the achievement lists collapsible on the main achievements screen

### DIFF
--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -612,6 +612,45 @@ std::string ItemHeader::DescribeText() const {
 	return ApplySafeSubstitutions(u->T("%1 heading"), text_);
 }
 
+CollapsibleHeader::CollapsibleHeader(bool *toggle, const std::string &text, LayoutParams *layoutParams)
+	: CheckBox(toggle, text, "", layoutParams) {
+	layoutParams_->width = FILL_PARENT;
+	layoutParams_->height = 40;
+}
+
+void CollapsibleHeader::Draw(UIContext &dc) {
+	Style style = dc.theme->itemStyle;
+	if (HasFocus()) style = dc.theme->itemFocusedStyle;
+	if (down_) style = dc.theme->itemDownStyle;
+	if (!IsEnabled()) style = dc.theme->itemDisabledStyle;
+
+	DrawBG(dc, style);
+
+	float xoff = 37.0f;
+
+	dc.SetFontStyle(dc.theme->uiFontSmall);
+	dc.DrawText(text_.c_str(), bounds_.x + 4 + xoff, bounds_.centerY(), dc.theme->headerStyle.fgColor, ALIGN_LEFT | ALIGN_VCENTER);
+	dc.Draw()->DrawImageCenterTexel(dc.theme->whiteImage, bounds_.x, bounds_.y2() - 2, bounds_.x2(), bounds_.y2(), dc.theme->headerStyle.fgColor);
+	dc.Draw()->DrawImageRotated(ImageID("I_ARROW"), bounds_.x + 20.0f, bounds_.y + 20.0f, 1.0f, *toggle_ ? -M_PI / 2 : M_PI);
+}
+
+void CollapsibleHeader::GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const {
+	Bounds bounds(0, 0, layoutParams_->width, layoutParams_->height);
+	if (bounds.w < 0) {
+		// If there's no size, let's grow as big as we want.
+		bounds.w = horiz.size == 0 ? MAX_ITEM_SIZE : horiz.size;
+	}
+	if (bounds.h < 0) {
+		bounds.h = vert.size == 0 ? MAX_ITEM_SIZE : vert.size;
+	}
+	ApplyBoundsBySpec(bounds, horiz, vert);
+	dc.MeasureTextRect(dc.theme->uiFontSmall, 1.0f, 1.0f, text_.c_str(), (int)text_.length(), bounds, &w, &h, ALIGN_LEFT | ALIGN_VCENTER);
+}
+
+void CollapsibleHeader::GetContentDimensions(const UIContext &dc, float &w, float &h) const {
+	View::GetContentDimensions(dc, w, h);
+}
+
 void BorderView::Draw(UIContext &dc) {
 	Color color = 0xFFFFFFFF;
 	if (style_ == BorderStyle::HEADER_FG)

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -857,13 +857,22 @@ public:
 	//allow external agents to toggle the checkbox
 	virtual void Toggle();
 	virtual bool Toggled() const;
-private:
+
+protected:
 	float CalculateTextScale(const UIContext &dc, float availWidth) const;
 
 	bool *toggle_;
 	std::string text_;
 	std::string smallText_;
 	ImageID imageID_;
+};
+
+class CollapsibleHeader : public CheckBox {
+public:
+	CollapsibleHeader(bool *toggle, const std::string &text, LayoutParams *layoutParams = nullptr);
+	void Draw(UIContext &dc) override;
+	void GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const override;
+	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
 };
 
 class BitCheckBox : public CheckBox {

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -1181,6 +1181,8 @@ StickyChoice *ChoiceStrip::Choice(int index) {
 }
 
 CollapsibleSection::CollapsibleSection(const std::string &title, LayoutParams *layoutParams) : LinearLayout(ORIENT_VERTICAL, layoutParams) {
+	SetSpacing(0.0f);
+
 	CollapsibleHeader *heading = new CollapsibleHeader(&open_, title);
 	views_.push_back(heading);
 	heading->OnClick.Add([=](UI::EventParams &) {

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -1180,4 +1180,17 @@ StickyChoice *ChoiceStrip::Choice(int index) {
 	return nullptr;
 }
 
+CollapsibleSection::CollapsibleSection(const std::string &title, LayoutParams *layoutParams) : LinearLayout(ORIENT_VERTICAL, layoutParams) {
+	CollapsibleHeader *heading = new CollapsibleHeader(&open_, title);
+	views_.push_back(heading);
+	heading->OnClick.Add([=](UI::EventParams &) {
+		// Change the visibility of all children except the first one.
+		// Later maybe try something more ambitious.
+		for (size_t i = 1; i < views_.size(); i++) {
+			views_[i]->SetVisibility(open_ ? V_VISIBLE : V_GONE);
+		}
+		return UI::EVENT_DONE;
+	});
+}
+
 }  // namespace UI

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -290,7 +290,6 @@ private:
 	bool topTabs_ = false;
 };
 
-
 class TabHolder : public LinearLayout {
 public:
 	TabHolder(Orientation orientation, float stripSize, LayoutParams *layoutParams = 0);
@@ -323,6 +322,14 @@ private:
 	int currentTab_ = 0;
 	std::vector<View *> tabs_;
 	std::vector<AnchorTranslateTween *> tabTweens_;
+};
+
+class CollapsibleSection : public LinearLayout {
+public:
+	CollapsibleSection(const std::string &title, LayoutParams *layoutParams = nullptr);
+
+private:
+	bool open_ = true;
 };
 
 }  // namespace UI

--- a/Core/RetroAchievements.h
+++ b/Core/RetroAchievements.h
@@ -56,6 +56,9 @@ bool IsActive();
 // Returns true if unofficial achievements are enabled.
 bool UnofficialEnabled();
 
+// Returns true if encore-mode is active.
+bool EncoreModeActive();
+
 // Returns true if the emulator should hold off on executing game code, such as during game identification.
 bool IsBlockingExecution();
 

--- a/UI/RetroAchievementScreens.cpp
+++ b/UI/RetroAchievementScreens.cpp
@@ -11,6 +11,7 @@
 
 #include "UI/RetroAchievementScreens.h"
 #include "UI/BackgroundAudio.h"
+#include "UI/OnScreenDisplay.h"
 
 static inline const char *DeNull(const char *ptr) {
 	return ptr ? ptr : "";
@@ -115,18 +116,23 @@ void RetroAchievementsListScreen::CreateAchievementsTab(UI::ViewGroup *achieveme
 
 	achievements->Add(new GameAchievementSummaryView());
 
-	achievements->Add(new ItemHeader(ac->T("Unlocked achievements")));
+	CollapsibleSection *unlocked = new CollapsibleSection(ac->T("Unlocked achievements"));
 	for (auto &achievement : unlockedAchievements) {
-		achievements->Add(new AchievementView(achievement));
+		unlocked->Add(new AchievementView(achievement));
 	}
-	achievements->Add(new ItemHeader(ac->T("Locked achievements")));
+	achievements->Add(unlocked);
+
+	CollapsibleSection *locked = new CollapsibleSection(ac->T("Locked achievements"));
 	for (auto &achievement : lockedAchievements) {
-		achievements->Add(new AchievementView(achievement));
+		locked->Add(new AchievementView(achievement));
 	}
-	achievements->Add(new ItemHeader(ac->T("Other achievements")));
+	achievements->Add(locked);
+
+	CollapsibleSection *other = new CollapsibleSection(ac->T("Other achievements"));
 	for (auto &achievement : otherAchievements) {
-		achievements->Add(new AchievementView(achievement));
+		other->Add(new AchievementView(achievement));
 	}
+	achievements->Add(other);
 }
 
 void RetroAchievementsListScreen::CreateLeaderboardsTab(UI::ViewGroup *viewGroup) {

--- a/UI/RetroAchievementScreens.cpp
+++ b/UI/RetroAchievementScreens.cpp
@@ -116,19 +116,22 @@ void RetroAchievementsListScreen::CreateAchievementsTab(UI::ViewGroup *achieveme
 
 	achievements->Add(new GameAchievementSummaryView());
 
-	CollapsibleSection *unlocked = new CollapsibleSection(ac->T("Unlocked achievements"));
+	CollapsibleSection *unlocked = new CollapsibleSection(StringFromFormat("%s (%d)", ac->T("Unlocked achievements"), (int)unlockedAchievements.size()));
+	unlocked->SetSpacing(2.0f);
 	for (auto &achievement : unlockedAchievements) {
 		unlocked->Add(new AchievementView(achievement));
 	}
 	achievements->Add(unlocked);
 
-	CollapsibleSection *locked = new CollapsibleSection(ac->T("Locked achievements"));
+	CollapsibleSection *locked = new CollapsibleSection(StringFromFormat("%s (%d)", ac->T("Locked achievements"), (int)lockedAchievements.size()));
+	unlocked->SetSpacing(2.0f);
 	for (auto &achievement : lockedAchievements) {
 		locked->Add(new AchievementView(achievement));
 	}
 	achievements->Add(locked);
 
-	CollapsibleSection *other = new CollapsibleSection(ac->T("Other achievements"));
+	CollapsibleSection *other = new CollapsibleSection(StringFromFormat("%s (%d)", ac->T("Other achievements"), (int)otherAchievements.size()));
+	unlocked->SetSpacing(2.0f);
 	for (auto &achievement : otherAchievements) {
 		other->Add(new AchievementView(achievement));
 	}


### PR DESCRIPTION
New UI component "CollapsibleSection". 

Use it to make the achievement lists collapsible so you don't have to scroll way down to see the locked achievements.

I'm sure we'll end up with other uses for it elsewhere.

Part of #17631 