### PR TITLE
riscv: Avoid unaligned mem combine in IR

### DIFF
--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -1053,7 +1053,6 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 		inst++;
 	}
 
-	// If we got here, the block was badly constructed.
-	Crash();
+	// We hit count.  If this is a full block, it was badly constructed.
 	return 0;
 }

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -229,6 +229,7 @@ void IRJit::RunLoopUntil(u64 globalticks) {
 				IRBlock *block = blocks_.GetBlock(data);
 				u32 startPC = mips_->pc;
 				mips_->pc = IRInterpret(mips_, block->GetInstructions(), block->GetNumInstructions());
+				// Note: this will "jump to zero" on a badly constructed block missing exits.
 				if (!Memory::IsValidAddress(mips_->pc) || (mips_->pc & 3) != 0) {
 					Core_ExecException(mips_->pc, startPC, ExecExceptionType::JUMP);
 					break;

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
 #include <set>
 
 #include "ext/xxhash.h"
@@ -49,7 +50,10 @@ IRJit::IRJit(MIPSState *mipsState) : frontend_(mipsState->HasDefaultPrefix()), m
 
 	IROptions opts{};
 	opts.disableFlags = g_Config.uJitDisableFlags;
+	// Assume that RISC-V always has very slow unaligned memory accesses.
+#if !PPSSPP_ARCH(RISCV64)
 	opts.unalignedLoadStore = (opts.disableFlags & (uint32_t)JitDisable::LSU_UNALIGNED) == 0;
+#endif
 	frontend_.SetOptions(opts);
 }
 


### PR DESCRIPTION
Small prep for when I or someone gets to creating a RISC-V backend for IR.  Also may already improve IR speeds a little by not combining for interpret.

-[Unknown]