### PR TITLE
Text display fixes

### DIFF
--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -290,6 +290,28 @@ void UIContext::DrawTextRect(const char *str, const Bounds &bounds, uint32_t col
 	RebindTexture();
 }
 
+static constexpr float MIN_TEXT_SCALE = 0.7f;
+
+float UIContext::CalculateTextScale(const char *text, float availWidth, float availHeight) const {
+	float actualWidth, actualHeight;
+	Bounds availBounds(0, 0, availWidth, availHeight);
+	MeasureTextRect(theme->uiFont, 1.0f, 1.0f, text, (int)strlen(text), availBounds, &actualWidth, &actualHeight, ALIGN_VCENTER);
+	if (actualWidth > availWidth) {
+		return std::max(MIN_TEXT_SCALE, availWidth / actualWidth);
+	}
+	return 1.0f;
+}
+
+void UIContext::DrawTextRectSqueeze(const char *str, const Bounds &bounds, uint32_t color, int align) {
+	float origScaleX = fontScaleX_;
+	float origScaleY = fontScaleY_;
+	float scale = CalculateTextScale(str, bounds.w / origScaleX, bounds.h / origScaleY);
+	SetFontScale(scale * origScaleX, scale * origScaleY);
+	Bounds textBounds(bounds.x, bounds.y, bounds.w, bounds.h);
+	DrawTextRect(str, textBounds, color, align);
+	SetFontScale(origScaleX, origScaleY);
+}
+
 void UIContext::DrawTextShadowRect(const char *str, const Bounds &bounds, uint32_t color, int align) {
 	uint32_t alpha = (color >> 1) & 0xFF000000;
 	Bounds shadowBounds(bounds.x+2, bounds.y+2, bounds.w, bounds.h);

--- a/Common/UI/Context.h
+++ b/Common/UI/Context.h
@@ -89,6 +89,11 @@ public:
 	void DrawTextShadow(const char *str, float x, float y, uint32_t color, int align = 0);
 	void DrawTextRect(const char *str, const Bounds &bounds, uint32_t color, int align = 0);
 	void DrawTextShadowRect(const char *str, const Bounds &bounds, uint32_t color, int align = 0);
+	// Will squeeze the text into the bounds if needed.
+	void DrawTextRectSqueeze(const char *str, const Bounds &bounds, uint32_t color, int align = 0);
+
+	float CalculateTextScale(const char *text, float availWidth, float availHeight) const;
+
 	void FillRect(const UI::Drawable &drawable, const Bounds &bounds);
 	void DrawRectDropShadow(const Bounds &bounds, float radius, float alpha, uint32_t color = 0);
 	void DrawImageVGradient(ImageID image, uint32_t color1, uint32_t color2, const Bounds &bounds);

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -460,7 +460,7 @@ void Choice::GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, 
 		}
 		if (horiz.type != EXACTLY && layoutParams_->width > 0.0f && availWidth > layoutParams_->width)
 			availWidth = layoutParams_->width;
-		float scale = CalculateTextScale(dc, availWidth);
+		float scale = dc.CalculateTextScale(text_.c_str(), availWidth, bounds_.h);
 		Bounds availBounds(0, 0, availWidth, vert.size);
 		float textW = 0.0f, textH = 0.0f;
 		dc.MeasureTextRect(dc.theme->uiFont, scale, scale, text_.c_str(), (int)text_.size(), availBounds, &textW, &textH, FLAG_WRAP_TEXT);
@@ -471,16 +471,6 @@ void Choice::GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, 
 	w = totalW + 24;
 	h = totalH + 16;
 	h = std::max(h, ITEM_HEIGHT);
-}
-
-float Choice::CalculateTextScale(const UIContext &dc, float availWidth) const {
-	float actualWidth, actualHeight;
-	Bounds availBounds(0, 0, availWidth, bounds_.h);
-	dc.MeasureTextRect(dc.theme->uiFont, 1.0f, 1.0f, text_.c_str(), (int)text_.size(), availBounds, &actualWidth, &actualHeight, drawTextFlags_);
-	if (actualWidth > availWidth) {
-		return std::max(MIN_TEXT_SCALE, availWidth / actualWidth);
-	}
-	return 1.0f;
 }
 
 void Choice::Draw(UIContext &dc) {
@@ -508,18 +498,15 @@ void Choice::Draw(UIContext &dc) {
 			dc.Draw()->DrawImage(image_, bounds_.x + 6, bounds_.centerY(), 1.0f, style.fgColor, ALIGN_LEFT | ALIGN_VCENTER);
 		}
 
-		float scale = CalculateTextScale(dc, availWidth);
-
-		dc.SetFontScale(scale, scale);
 		if (centered_) {
-			dc.DrawTextRect(text_.c_str(), bounds_, style.fgColor, ALIGN_CENTER | FLAG_WRAP_TEXT | drawTextFlags_);
+			dc.DrawTextRectSqueeze(text_.c_str(), bounds_, style.fgColor, ALIGN_CENTER | FLAG_WRAP_TEXT | drawTextFlags_);
 		} else {
 			if (rightIconImage_.isValid()) {
 				uint32_t col = rightIconKeepColor_ ? 0xffffffff : style.fgColor; // Don't apply theme to gold icon
 				dc.Draw()->DrawImageRotated(rightIconImage_, bounds_.x2() - 32 - paddingX, bounds_.centerY(), rightIconScale_, rightIconRot_, col, rightIconFlipH_);
 			}
 			Bounds textBounds(bounds_.x + paddingX + textPadding_.left, bounds_.y, availWidth, bounds_.h);
-			dc.DrawTextRect(text_.c_str(), textBounds, style.fgColor, ALIGN_VCENTER | FLAG_WRAP_TEXT | drawTextFlags_);
+			dc.DrawTextRectSqueeze(text_.c_str(), textBounds, style.fgColor, ALIGN_VCENTER | FLAG_WRAP_TEXT | drawTextFlags_);
 		}
 		dc.SetFontScale(1.0f, 1.0f);
 	}
@@ -783,10 +770,8 @@ void CheckBox::Draw(UIContext &dc) {
 	const float availWidth = bounds_.w - paddingX * 2 - imageW - paddingX;
 
 	if (!text_.empty()) {
-		float scale = CalculateTextScale(dc, availWidth);
-		dc.SetFontScale(scale, scale);
 		Bounds textBounds(bounds_.x + paddingX, bounds_.y, availWidth, bounds_.h);
-		dc.DrawTextRect(text_.c_str(), textBounds, style.fgColor, ALIGN_VCENTER | FLAG_WRAP_TEXT);
+		dc.DrawTextRectSqueeze(text_.c_str(), textBounds, style.fgColor, ALIGN_VCENTER | FLAG_WRAP_TEXT);
 	}
 	dc.Draw()->DrawImage(image, bounds_.x2() - paddingX, bounds_.centerY(), 1.0f, style.fgColor, ALIGN_RIGHT | ALIGN_VCENTER);
 	dc.SetFontScale(1.0f, 1.0f);
@@ -799,16 +784,6 @@ std::string CheckBox::DescribeText() const {
 		text += "\n" + smallText_;
 	}
 	return text;
-}
-
-float CheckBox::CalculateTextScale(const UIContext &dc, float availWidth) const {
-	float actualWidth, actualHeight;
-	Bounds availBounds(0, 0, availWidth, bounds_.h);
-	dc.MeasureTextRect(dc.theme->uiFont, 1.0f, 1.0f, text_.c_str(), (int)text_.size(), availBounds, &actualWidth, &actualHeight, ALIGN_VCENTER);
-	if (actualWidth > availWidth) {
-		return std::max(MIN_TEXT_SCALE, availWidth / actualWidth);
-	}
-	return 1.0f;
 }
 
 void CheckBox::GetContentDimensions(const UIContext &dc, float &w, float &h) const {
@@ -838,7 +813,7 @@ void CheckBox::GetContentDimensions(const UIContext &dc, float &w, float &h) con
 	}
 
 	if (!text_.empty()) {
-		float scale = CalculateTextScale(dc, availWidth);
+		float scale = dc.CalculateTextScale(text_.c_str(), availWidth, bounds_.h);
 
 		float actualWidth, actualHeight;
 		Bounds availBounds(0, 0, availWidth, bounds_.h);

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -736,7 +736,6 @@ public:
 protected:
 	// hackery
 	virtual bool IsSticky() const { return false; }
-	virtual float CalculateTextScale(const UIContext &dc, float availWidth) const;
 
 	std::string text_;
 	std::string smallText_;
@@ -859,8 +858,6 @@ public:
 	virtual bool Toggled() const;
 
 protected:
-	float CalculateTextScale(const UIContext &dc, float availWidth) const;
-
 	bool *toggle_;
 	std::string text_;
 	std::string smallText_;

--- a/UI/RetroAchievementScreens.cpp
+++ b/UI/RetroAchievementScreens.cpp
@@ -464,7 +464,7 @@ void RenderAchievement(UIContext &dc, const rc_client_achievement_t *achievement
 		dc.DrawTextRect(achievement->title, bounds.Inset(iconSpace + 12.0f, 2.0f, padding, padding), fgColor, ALIGN_TOPLEFT);
 
 		dc.SetFontScale(0.66f, 0.66f);
-		dc.DrawTextRect(DeNull(achievement->description), bounds.Inset(iconSpace + 12.0f, 39.0f, padding, padding), fgColor, ALIGN_TOPLEFT);
+		dc.DrawTextRectSqueeze(DeNull(achievement->description), bounds.Inset(iconSpace + 12.0f, 39.0f, padding, padding), fgColor, ALIGN_TOPLEFT);
 
 		if (style == AchievementRenderStyle::LISTED && strlen(achievement->measured_progress) > 0) {
 			dc.SetFontScale(1.0f, 1.0f);
@@ -578,7 +578,7 @@ void RenderLeaderboardSummary(UIContext &dc, const rc_client_leaderboard_t *lead
 	dc.DrawTextRect(DeNull(leaderboard->title), bounds.Inset(12.0f, 2.0f, 5.0f, 5.0f), fgColor, ALIGN_TOPLEFT);
 
 	dc.SetFontScale(0.66f, 0.66f);
-	dc.DrawTextRect(DeNull(leaderboard->description), bounds.Inset(12.0f, 39.0f, 5.0f, 5.0f), fgColor, ALIGN_TOPLEFT);
+	dc.DrawTextRectSqueeze(DeNull(leaderboard->description), bounds.Inset(12.0f, 39.0f, 5.0f, 5.0f), fgColor, ALIGN_TOPLEFT);
 
 	/*
 	char temp[64];
@@ -587,9 +587,9 @@ void RenderLeaderboardSummary(UIContext &dc, const rc_client_leaderboard_t *lead
 	dc.SetFontScale(1.5f, 1.5f);
 	dc.DrawTextRect(temp, bounds.Expand(-5.0f, -5.0f), fgColor, ALIGN_RIGHT | ALIGN_VCENTER);
 
-	dc.SetFontScale(1.0f, 1.0f);
 	dc.Flush();
 	*/
+	dc.SetFontScale(1.0f, 1.0f);
 
 	dc.Flush();
 	dc.RebindTexture();

--- a/android/src/org/ppsspp/ppsspp/TextRenderer.java
+++ b/android/src/org/ppsspp/ppsspp/TextRenderer.java
@@ -61,10 +61,10 @@ public class TextRenderer {
 			total.x = 1;
 		if (total.y < 1)
 			total.y = 1;
-		if (total.x > 2048)
-			total.x = 2048;
-		if (total.y > 2048)
-			total.y = 2048;
+		if (total.x > 4096)
+			total.x = 4096;
+		if (total.y > 4096)
+			total.y = 4096;
 		return total;
 	}
 


### PR DESCRIPTION
Squeezes text, making RetroAchievement descriptions fit most of the time.

Doesn't yet properly consider line breaks. 

Kinda regretting not building these out of tiny views and layouts now.. 