### PR TITLE
Show version on prompt screens that aren't questions

### DIFF
--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -117,6 +117,7 @@ enum SystemProperty {
 	SYSPROP_BOARDNAME,
 	SYSPROP_CLIPBOARD_TEXT,
 	SYSPROP_GPUDRIVER_VERSION,
+	SYSPROP_BUILD_VERSION,
 
 	// Separate SD cards or similar.
 	// Need hacky solutions to get at this.

--- a/Common/UI/PopupScreens.h
+++ b/Common/UI/PopupScreens.h
@@ -55,6 +55,9 @@ class MessagePopupScreen : public PopupScreen {
 public:
 	MessagePopupScreen(std::string title, std::string message, std::string button1, std::string button2, std::function<void(bool)> callback)
 		: PopupScreen(title, button1, button2), message_(message), callback_(callback) {}
+
+	const char *tag() const override { return "MessagePopupScreen"; }
+
 	UI::Event OnChoice;
 
 protected:

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include "Common/System/Display.h"
+#include "Common/System/System.h"
 #include "Common/Input/InputState.h"
 #include "Common/Input/KeyCodes.h"
 #include "Common/Math/curves.h"
@@ -9,7 +10,6 @@
 #include "Common/UI/Root.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Render/DrawBuffer.h"
-
 #include "Common/Log.h"
 
 static const bool ClickDebug = false;
@@ -426,7 +426,6 @@ void PopupScreen::CreateViews() {
 
 	CreatePopupContents(box_);
 	root_->SetDefaultFocusView(box_);
-
 	if (ShowButtons() && !button1_.empty()) {
 		// And the two buttons at the bottom.
 		LinearLayout *buttonRow = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(200, WRAP_CONTENT));

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -161,6 +161,8 @@ std::string System_GetProperty(SystemProperty prop) {
 			return result;
 		}
 #endif
+	case SYSPROP_BUILD_VERSION:
+		return PPSSPP_GIT_VERSION;
 	default:
 		return "";
 	}

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -431,6 +431,8 @@ std::string System_GetProperty(SystemProperty prop) {
 			}
 			return result;
 		}
+	case SYSPROP_BUILD_VERSION:
+		return PPSSPP_GIT_VERSION;
 	default:
 		return "";
 	}

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -542,8 +542,14 @@ void PromptScreen::CreateViews() {
 	Choice *yesButton = rightColumnItems->Add(new Choice(yesButtonText_));
 	yesButton->OnClick.Handle(this, &PromptScreen::OnYes);
 	root_->SetDefaultFocusView(yesButton);
-	if (!noButtonText_.empty())
+	if (!noButtonText_.empty()) {
 		rightColumnItems->Add(new Choice(noButtonText_))->OnClick.Handle(this, &PromptScreen::OnNo);
+	} else {
+		// This is an information screen, not a question.
+		// Sneak in the version of PPSSPP in the corner, for debug-reporting user screenshots.
+		std::string version = System_GetProperty(SYSPROP_BUILD_VERSION);
+		root_->Add(new TextView(version, 0, true, new AnchorLayoutParams(10.0f, NONE, NONE, 10.0f)));
+	}
 }
 
 UI::EventReturn PromptScreen::OnYes(UI::EventParams &e) {

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -347,6 +347,8 @@ std::string System_GetProperty(SystemProperty prop) {
 		return "";
 	case SYSPROP_GPUDRIVER_VERSION:
 		return "";
+	case SYSPROP_BUILD_VERSION:
+		return PPSSPP_GIT_VERSION;
 	default:
 		return "";
 	}

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -234,6 +234,8 @@ std::string System_GetProperty(SystemProperty prop) {
 			gpuDriverVersion = GetVideoCardDriverVersion();
 		}
 		return gpuDriverVersion;
+	case SYSPROP_BUILD_VERSION:
+		return PPSSPP_GIT_VERSION;
 	default:
 		return "";
 	}

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -412,6 +412,8 @@ std::string System_GetProperty(SystemProperty prop) {
 		return mogaVersion;
 	case SYSPROP_BOARDNAME:
 		return boardName;
+	case SYSPROP_BUILD_VERSION:
+		return PPSSPP_GIT_VERSION;
 	default:
 		return "";
 	}

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -108,6 +108,8 @@ std::string System_GetProperty(SystemProperty prop) {
 			return StringFromFormat("iOS %s", version.c_str());
 		case SYSPROP_LANGREGION:
 			return [[[NSLocale currentLocale] objectForKey:NSLocaleIdentifier] UTF8String];
+		case SYSPROP_BUILD_VERSION:
+			return PPSSPP_GIT_VERSION;
 		default:
 			return "";
 	}

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -21,6 +21,7 @@
 #include "Common/System/Request.h"
 #include "Common/StringUtils.h"
 #include "Common/Profiler/Profiler.h"
+#include "Core/Config.h"
 #include "UI/DarwinFileSystemServices.h"
 
 static int (*csops)(pid_t pid, unsigned int ops, void * useraddr, size_t usersize);


### PR DESCRIPTION
Users often send screenshots of the "Can't load game" screen, let's put the version on it in the corner for convenience.