### PR TITLE
Common: Rename Download to Request, and the old Request to ServerRequest.

### DIFF
--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -444,21 +444,21 @@ int Client::ReadResponseEntity(net::Buffer *readbuf, const std::vector<std::stri
 	return 0;
 }
 
-HTTPDownload::HTTPDownload(RequestMethod method, const std::string &url, const std::string &postData, const std::string &postMime, const Path &outfile, ProgressBarMode progressBarMode, const std::string &name)
-	: Download(method, url, name, &cancelled_, progressBarMode), postData_(postData), postMime_(postMime), outfile_(outfile) {
+HTTPRequest::HTTPRequest(RequestMethod method, const std::string &url, const std::string &postData, const std::string &postMime, const Path &outfile, ProgressBarMode progressBarMode, const std::string &name)
+	: Request(method, url, name, &cancelled_, progressBarMode), postData_(postData), postMime_(postMime), outfile_(outfile) {
 }
 
-HTTPDownload::~HTTPDownload() {
+HTTPRequest::~HTTPRequest() {
 	g_OSD.RemoveProgressBar(url_, Failed() ? false : true, 0.5f);
 
 	_assert_msg_(joined_, "Download destructed without join");
 }
 
-void HTTPDownload::Start() {
-	thread_ = std::thread(std::bind(&HTTPDownload::Do, this));
+void HTTPRequest::Start() {
+	thread_ = std::thread(std::bind(&HTTPRequest::Do, this));
 }
 
-void HTTPDownload::Join() {
+void HTTPRequest::Join() {
 	if (joined_) {
 		ERROR_LOG(IO, "Already joined thread!");
 	}
@@ -466,13 +466,13 @@ void HTTPDownload::Join() {
 	joined_ = true;
 }
 
-void HTTPDownload::SetFailed(int code) {
+void HTTPRequest::SetFailed(int code) {
 	failed_ = true;
 	progress_.Update(0, 0, true);
 	completed_ = true;
 }
 
-int HTTPDownload::Perform(const std::string &url) {
+int HTTPRequest::Perform(const std::string &url) {
 	Url fileUrl(url);
 	if (!fileUrl.Valid()) {
 		return -1;
@@ -509,7 +509,7 @@ int HTTPDownload::Perform(const std::string &url) {
 	}
 }
 
-std::string HTTPDownload::RedirectLocation(const std::string &baseUrl) {
+std::string HTTPRequest::RedirectLocation(const std::string &baseUrl) {
 	std::string redirectUrl;
 	if (GetHeaderValue(responseHeaders_, "Location", &redirectUrl)) {
 		Url url(baseUrl);
@@ -520,7 +520,7 @@ std::string HTTPDownload::RedirectLocation(const std::string &baseUrl) {
 	return redirectUrl;
 }
 
-void HTTPDownload::Do() {
+void HTTPRequest::Do() {
 	SetCurrentThreadName("HTTPDownload::Do");
 
 	AndroidJNIThreadContext jniContext;

--- a/Common/Net/HTTPClient.h
+++ b/Common/Net/HTTPClient.h
@@ -91,10 +91,10 @@ protected:
 };
 
 // Really an asynchronous request.
-class HTTPDownload : public Download {
+class HTTPRequest : public Request {
 public:
-	HTTPDownload(RequestMethod method, const std::string &url, const std::string &postData, const std::string &postMime, const Path &outfile, ProgressBarMode progressBarMode = ProgressBarMode::DELAYED, const std::string &name = "");
-	~HTTPDownload();
+	HTTPRequest(RequestMethod method, const std::string &url, const std::string &postData, const std::string &postMime, const Path &outfile, ProgressBarMode progressBarMode = ProgressBarMode::DELAYED, const std::string &name = "");
+	~HTTPRequest();
 
 	void Start() override;
 	void Join() override;

--- a/Common/Net/HTTPNaettRequest.cpp
+++ b/Common/Net/HTTPNaettRequest.cpp
@@ -12,15 +12,15 @@
 
 namespace http {
 
-HTTPSDownload::HTTPSDownload(RequestMethod method, const std::string &url, const std::string &postData, const std::string &postMime, const Path &outfile, ProgressBarMode progressBarMode, const std::string &name)
-	: Download(method, url, name, &cancelled_, progressBarMode), method_(method), postData_(postData), postMime_(postMime), outfile_(outfile) {
+HTTPSRequest::HTTPSRequest(RequestMethod method, const std::string &url, const std::string &postData, const std::string &postMime, const Path &outfile, ProgressBarMode progressBarMode, const std::string &name)
+	: Request(method, url, name, &cancelled_, progressBarMode), method_(method), postData_(postData), postMime_(postMime), outfile_(outfile) {
 }
 
-HTTPSDownload::~HTTPSDownload() {
+HTTPSRequest::~HTTPSRequest() {
 	Join();
 }
 
-void HTTPSDownload::Start() {
+void HTTPSRequest::Start() {
 	_dbg_assert_(!req_);
 	_dbg_assert_(!res_);
 
@@ -49,7 +49,7 @@ void HTTPSDownload::Start() {
 	progress_.Update(0, 0, false);
 }
 
-void HTTPSDownload::Join() {
+void HTTPSRequest::Join() {
 	if (!res_ || !req_)
 		return;  // No pending operation.
 	// Tear down.
@@ -64,7 +64,7 @@ void HTTPSDownload::Join() {
 	}
 }
 
-bool HTTPSDownload::Done() {
+bool HTTPSRequest::Done() {
 	if (completed_)
 		return true;
 

--- a/Common/Net/HTTPNaettRequest.h
+++ b/Common/Net/HTTPNaettRequest.h
@@ -11,10 +11,10 @@
 namespace http {
 
 // Really an asynchronous request.
-class HTTPSDownload : public Download {
+class HTTPSRequest : public Request {
 public:
-	HTTPSDownload(RequestMethod method, const std::string &url, const std::string &postData, const std::string &postMime, const Path &outfile, ProgressBarMode progressBarMode = ProgressBarMode::DELAYED, const std::string &name = "");
-	~HTTPSDownload();
+	HTTPSRequest(RequestMethod method, const std::string &url, const std::string &postData, const std::string &postMime, const Path &outfile, ProgressBarMode progressBarMode = ProgressBarMode::DELAYED, const std::string &name = "");
+	~HTTPSRequest();
 
 	void Start() override;
 	void Join() override;

--- a/Common/Net/HTTPRequest.cpp
+++ b/Common/Net/HTTPRequest.cpp
@@ -8,7 +8,7 @@
 
 namespace http {
 
-Download::Download(RequestMethod method, const std::string &url, const std::string &name, bool *cancelled, ProgressBarMode mode) : method_(method), url_(url), name_(name), progress_(cancelled), progressBarMode_(mode) {
+Request::Request(RequestMethod method, const std::string &url, const std::string &name, bool *cancelled, ProgressBarMode mode) : method_(method), url_(url), name_(name), progress_(cancelled), progressBarMode_(mode) {
 	progress_.callback = [=](int64_t bytes, int64_t contentLength, bool done) {
 		std::string message;
 		if (!name_.empty()) {
@@ -35,16 +35,16 @@ bool RequestManager::IsHttpsUrl(const std::string &url) {
 	return startsWith(url, "https:");
 }
 
-std::shared_ptr<Download> RequestManager::StartDownload(const std::string &url, const Path &outfile, ProgressBarMode mode, const char *acceptMime) {
-	std::shared_ptr<Download> dl;
+std::shared_ptr<Request> RequestManager::StartDownload(const std::string &url, const Path &outfile, ProgressBarMode mode, const char *acceptMime) {
+	std::shared_ptr<Request> dl;
 	if (IsHttpsUrl(url)) {
 #ifndef HTTPS_NOT_AVAILABLE
-		dl.reset(new HTTPSDownload(RequestMethod::GET, url, "", "", outfile, mode));
+		dl.reset(new HTTPSRequest(RequestMethod::GET, url, "", "", outfile, mode));
 #else
-		return std::shared_ptr<Download>();
+		return std::shared_ptr<Request>();
 #endif
 	} else {
-		dl.reset(new HTTPDownload(RequestMethod::GET, url, "", "", outfile, mode));
+		dl.reset(new HTTPRequest(RequestMethod::GET, url, "", "", outfile, mode));
 	}
 
 	if (!userAgent_.empty())
@@ -56,22 +56,22 @@ std::shared_ptr<Download> RequestManager::StartDownload(const std::string &url, 
 	return dl;
 }
 
-std::shared_ptr<Download> RequestManager::StartDownloadWithCallback(
+std::shared_ptr<Request> RequestManager::StartDownloadWithCallback(
 	const std::string &url,
 	const Path &outfile,
 	ProgressBarMode mode,
-	std::function<void(Download &)> callback,
+	std::function<void(Request &)> callback,
 	const std::string &name,
 	const char *acceptMime) {
-	std::shared_ptr<Download> dl;
+	std::shared_ptr<Request> dl;
 	if (IsHttpsUrl(url)) {
 #ifndef HTTPS_NOT_AVAILABLE
-		dl.reset(new HTTPSDownload(RequestMethod::GET, url, "", "", outfile, mode, name));
+		dl.reset(new HTTPSRequest(RequestMethod::GET, url, "", "", outfile, mode, name));
 #else
-		return std::shared_ptr<Download>();
+		return std::shared_ptr<Request>();
 #endif
 	} else {
-		dl.reset(new HTTPDownload(RequestMethod::GET, url, "", "", outfile, mode, name));
+		dl.reset(new HTTPRequest(RequestMethod::GET, url, "", "", outfile, mode, name));
 	}
 	if (!userAgent_.empty())
 		dl->SetUserAgent(userAgent_);
@@ -83,22 +83,22 @@ std::shared_ptr<Download> RequestManager::StartDownloadWithCallback(
 	return dl;
 }
 
-std::shared_ptr<Download> RequestManager::AsyncPostWithCallback(
+std::shared_ptr<Request> RequestManager::AsyncPostWithCallback(
 	const std::string &url,
 	const std::string &postData,
 	const std::string &postMime,
 	ProgressBarMode mode,
-	std::function<void(Download &)> callback,
+	std::function<void(Request &)> callback,
 	const std::string &name) {
-	std::shared_ptr<Download> dl;
+	std::shared_ptr<Request> dl;
 	if (IsHttpsUrl(url)) {
 #ifndef HTTPS_NOT_AVAILABLE
-		dl.reset(new HTTPSDownload(RequestMethod::POST, url, postData, postMime, Path(), mode, name));
+		dl.reset(new HTTPSRequest(RequestMethod::POST, url, postData, postMime, Path(), mode, name));
 #else
-		return std::shared_ptr<Download>();
+		return std::shared_ptr<Request>();
 #endif
 	} else {
-		dl.reset(new HTTPDownload(RequestMethod::POST, url, postData, postMime, Path(), mode, name));
+		dl.reset(new HTTPRequest(RequestMethod::POST, url, postData, postMime, Path(), mode, name));
 	}
 	if (!userAgent_.empty())
 		dl->SetUserAgent(userAgent_);

--- a/Common/Net/HTTPRequest.h
+++ b/Common/Net/HTTPRequest.h
@@ -21,10 +21,10 @@ enum class ProgressBarMode {
 };
 
 // Abstract request.
-class Download {
+class Request {
 public:
-	Download(RequestMethod method, const std::string &url, const std::string &name, bool *cancelled, ProgressBarMode mode);
-	virtual ~Download() {}
+	Request(RequestMethod method, const std::string &url, const std::string &name, bool *cancelled, ProgressBarMode mode);
+	virtual ~Request() {}
 
 	void SetAccept(const char *mime) {
 		acceptMime_ = mime;
@@ -36,7 +36,7 @@ public:
 
 	// NOTE: Completion callbacks (which these are) are deferred until RunCallback is called. This is so that
 	// the call will end up on the thread that calls g_DownloadManager.Update().
-	void SetCallback(std::function<void(Download &)> callback) {
+	void SetCallback(std::function<void(Request &)> callback) {
 		callback_ = callback;
 	}
 	void RunCallback() {
@@ -67,7 +67,7 @@ public:
 	virtual const Buffer &buffer() const = 0;
 
 protected:
-	std::function<void(Download &)> callback_;
+	std::function<void(Request &)> callback_;
 	RequestMethod method_;
 	std::string url_;
 	std::string name_;
@@ -76,8 +76,6 @@ protected:
 
 	net::RequestProgress progress_;
 	ProgressBarMode progressBarMode_;
-
-private:
 };
 
 using std::shared_ptr;
@@ -88,22 +86,22 @@ public:
 		CancelAll();
 	}
 
-	std::shared_ptr<Download> StartDownload(const std::string &url, const Path &outfile, ProgressBarMode mode, const char *acceptMime = nullptr);
+	std::shared_ptr<Request> StartDownload(const std::string &url, const Path &outfile, ProgressBarMode mode, const char *acceptMime = nullptr);
 
-	std::shared_ptr<Download> StartDownloadWithCallback(
+	std::shared_ptr<Request> StartDownloadWithCallback(
 		const std::string &url,
 		const Path &outfile,
 		ProgressBarMode mode,
-		std::function<void(Download &)> callback,
+		std::function<void(Request &)> callback,
 		const std::string &name = "",
 		const char *acceptMime = nullptr);
 
-	std::shared_ptr<Download> AsyncPostWithCallback(
+	std::shared_ptr<Request> AsyncPostWithCallback(
 		const std::string &url,
 		const std::string &postData,
 		const std::string &postMime, // Use postMime = "application/x-www-form-urlencoded" for standard form-style posts, such as used by retroachievements. For encoding form data manually we have MultipartFormDataEncoder.
 		ProgressBarMode mode,
-		std::function<void(Download &)> callback,
+		std::function<void(Request &)> callback,
 		const std::string &name = "");
 
 	// Drops finished downloads from the list.
@@ -118,10 +116,10 @@ public:
 private:
 	bool IsHttpsUrl(const std::string &url);
 
-	std::vector<std::shared_ptr<Download>> downloads_;
+	std::vector<std::shared_ptr<Request>> downloads_;
 	// These get copied to downloads_ in Update(). It's so that callbacks can add new downloads
 	// while running.
-	std::vector<std::shared_ptr<Download>> newDownloads_;
+	std::vector<std::shared_ptr<Request>> newDownloads_;
 
 	std::string userAgent_;
 };

--- a/Common/Net/HTTPServer.h
+++ b/Common/Net/HTTPServer.h
@@ -25,10 +25,10 @@ class OutputSink;
 
 namespace http {
 
-class Request {
+class ServerRequest {
 public:
-	Request(int fd);
-	~Request();
+	ServerRequest(int fd);
+	~ServerRequest();
 
 	const char *resource() const {
 		return header_.resource;
@@ -75,7 +75,7 @@ public:
 	Server(NewThreadExecutor *executor);
 	virtual ~Server();
 
-	typedef std::function<void(const Request &)> UrlHandlerFunc;
+	typedef std::function<void(const ServerRequest &)> UrlHandlerFunc;
 	typedef std::map<std::string, UrlHandlerFunc> UrlHandlerMap;
 
 	// Runs forever, serving request. If you want to do something else than serve pages,
@@ -94,7 +94,7 @@ public:
 	// If you want to customize things at a lower level than just a simple path handler,
 	// then inherit and override this. Implementations should forward to HandleRequestDefault
 	// if they don't recognize the url.
-	virtual void HandleRequest(const Request &request);
+	virtual void HandleRequest(const ServerRequest &request);
 
 	int Port() {
 		return port_;
@@ -107,11 +107,11 @@ private:
 	void HandleConnection(int conn_fd);
 
 	// Things like default 404, etc.
-	void HandleRequestDefault(const Request &request);
+	void HandleRequestDefault(const ServerRequest &request);
 
 	// Neat built-in handlers that are tied to the server.
-	void HandleListing(const Request &request);
-	void Handle404(const Request &request);
+	void HandleListing(const ServerRequest &request);
+	void Handle404(const ServerRequest &request);
 
 	int listener_;
 	int port_ = 0;

--- a/Common/Net/WebsocketServer.cpp
+++ b/Common/Net/WebsocketServer.cpp
@@ -69,7 +69,7 @@ static bool ListContainsNoCase(const std::string &list, const std::string value)
 	return false;
 }
 
-WebSocketServer *WebSocketServer::CreateAsUpgrade(const http::Request &request, const std::string &protocol) {
+WebSocketServer *WebSocketServer::CreateAsUpgrade(const http::ServerRequest &request, const std::string &protocol) {
 	auto requireHeader = [&](const char *name, const char *expected) {
 		std::string val;
 		if (!request.GetHeader(name, &val)) {

--- a/Common/Net/WebsocketServer.h
+++ b/Common/Net/WebsocketServer.h
@@ -29,7 +29,7 @@ enum class WebSocketClose : uint16_t {
 // RFC 6455
 class WebSocketServer {
 public:
-	static WebSocketServer *CreateAsUpgrade(const http::Request &request, const std::string &protocol = "");
+	static WebSocketServer *CreateAsUpgrade(const http::ServerRequest &request, const std::string &protocol = "");
 
 	void Send(const std::string &str);
 	void Send(const std::vector<uint8_t> &payload);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1363,7 +1363,7 @@ void Config::NotifyUpdatedCpuCore() {
 #define PPSSPP_GIT_VERSION "v0.0.1-gaaaaaaaaa"
 #endif
 
-void Config::DownloadCompletedCallback(http::Download &download) {
+void Config::DownloadCompletedCallback(http::Request &download) {
 	if (download.ResultCode() != 200) {
 		ERROR_LOG(LOADER, "Failed to download %s: %d", download.url().c_str(), download.ResultCode());
 		return;

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -41,7 +41,7 @@ enum ChatPositions {
 };
 
 namespace http {
-	class Download;
+	class Request;
 	class RequestManager;
 }
 
@@ -543,7 +543,7 @@ public:
 	void RemoveRecent(const std::string &file);
 	void CleanRecent();
 
-	static void DownloadCompletedCallback(http::Download &download);
+	static void DownloadCompletedCallback(http::Request &download);
 	void DismissUpgrade();
 
 	void ResetControlLayout();

--- a/Core/Debugger/WebSocket.cpp
+++ b/Core/Debugger/WebSocket.cpp
@@ -131,7 +131,7 @@ static void SetupDebuggerLock() {
 	}
 }
 
-void HandleDebuggerRequest(const http::Request &request) {
+void HandleDebuggerRequest(const http::ServerRequest &request) {
 	net::WebSocketServer *ws = net::WebSocketServer::CreateAsUpgrade(request, "debugger.ppsspp.org");
 	if (!ws)
 		return;

--- a/Core/Debugger/WebSocket.h
+++ b/Core/Debugger/WebSocket.h
@@ -18,9 +18,9 @@
 #pragma once
 
 namespace http {
-class Request;
+class ServerRequest;
 }
 
-void HandleDebuggerRequest(const http::Request &request);
+void HandleDebuggerRequest(const http::ServerRequest &request);
 // Note: blocks.
 void StopAllDebuggers();

--- a/Core/RetroAchievements.cpp
+++ b/Core/RetroAchievements.cpp
@@ -177,7 +177,7 @@ static void server_call_callback(const rc_api_request_t *request,
 	// If post data is provided, we need to make a POST request, otherwise, a GET request will suffice.
 	auto ac = GetI18NCategory(I18NCat::ACHIEVEMENTS);
 	if (request->post_data) {
-		std::shared_ptr<http::Download> download = g_DownloadManager.AsyncPostWithCallback(std::string(request->url), std::string(request->post_data), "application/x-www-form-urlencoded", http::ProgressBarMode::DELAYED, [=](http::Download &download) {
+		std::shared_ptr<http::Request> download = g_DownloadManager.AsyncPostWithCallback(std::string(request->url), std::string(request->post_data), "application/x-www-form-urlencoded", http::ProgressBarMode::DELAYED, [=](http::Request &download) {
 			std::string buffer;
 			download.buffer().TakeAll(&buffer);
 			rc_api_server_response_t response{};
@@ -187,7 +187,7 @@ static void server_call_callback(const rc_api_request_t *request,
 			callback(&response, callback_data);
 		}, ac->T("Contacting RetroAchievements server..."));
 	} else {
-		std::shared_ptr<http::Download> download = g_DownloadManager.StartDownloadWithCallback(std::string(request->url), Path(), http::ProgressBarMode::DELAYED, [=](http::Download &download) {
+		std::shared_ptr<http::Request> download = g_DownloadManager.StartDownloadWithCallback(std::string(request->url), Path(), http::ProgressBarMode::DELAYED, [=](http::Request &download) {
 			std::string buffer;
 			download.buffer().TakeAll(&buffer);
 			rc_api_server_response_t response{};
@@ -543,7 +543,7 @@ bool HasAchievementsOrLeaderboards() {
 void DownloadImageIfMissing(const std::string &cache_key, std::string &&url) {
 	if (g_iconCache.MarkPending(cache_key)) {
 		INFO_LOG(ACHIEVEMENTS, "Downloading image: %s (%s)", url.c_str(), cache_key.c_str());
-		g_DownloadManager.StartDownloadWithCallback(url, Path(), http::ProgressBarMode::NONE, [cache_key](http::Download &download) {
+		g_DownloadManager.StartDownloadWithCallback(url, Path(), http::ProgressBarMode::NONE, [cache_key](http::Request &download) {
 			if (download.ResultCode() != 200)
 				return;
 			std::string data;

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -91,7 +91,7 @@ private:
 	std::string GetGameID(const Path &path) const;
 	std::string GetPBPGameID(FileLoader *loader) const;
 	std::string GetISOGameID(FileLoader *loader) const;
-	std::shared_ptr<http::Download> curDownload_;
+	std::shared_ptr<http::Request> curDownload_;
 	std::shared_ptr<std::thread> installThread_;
 	bool installInProgress_ = false;
 	bool installDonePending_ = false;

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -159,7 +159,7 @@ static Path LocalFromRemotePath(const std::string &path) {
 	return Path();
 }
 
-static void DiscHandler(const http::Request &request, const Path &filename) {
+static void DiscHandler(const http::ServerRequest &request, const Path &filename) {
 	s64 sz = File::GetFileSize(filename);
 
 	std::string range;
@@ -211,7 +211,7 @@ static void DiscHandler(const http::Request &request, const Path &filename) {
 	}
 }
 
-static void HandleListing(const http::Request &request) {
+static void HandleListing(const http::ServerRequest &request) {
 	AndroidJNIThreadContext jniContext;
 
 	request.WriteHttpResponseHeader("1.0", 200, -1, "text/plain");
@@ -230,7 +230,7 @@ static void HandleListing(const http::Request &request) {
 	}
 }
 
-static bool ServeDebuggerFile(const http::Request &request) {
+static bool ServeDebuggerFile(const http::ServerRequest &request) {
 	// Skip the slash at the start of the resource path.
 	const char *filename = request.resource() + 1;
 	if (strstr(filename, "..") != nullptr)
@@ -264,13 +264,13 @@ static bool ServeDebuggerFile(const http::Request &request) {
 	return true;
 }
 
-static void RedirectToDebugger(const http::Request &request) {
+static void RedirectToDebugger(const http::ServerRequest &request) {
 	static const std::string payload = "Redirecting to debugger UI...\r\n";
 	request.WriteHttpResponseHeader("1.0", 301, (int)payload.size(), "text/plain", "Location: /debugger/index.html\r\n");
 	request.Out()->Push(payload);
 }
 
-static void HandleFallback(const http::Request &request) {
+static void HandleFallback(const http::ServerRequest &request) {
 	AndroidJNIThreadContext jniContext;
 
 	if (serverFlags & (int)WebServerFlags::DISCS) {
@@ -296,7 +296,7 @@ static void HandleFallback(const http::Request &request) {
 	request.Out()->Push(payload);
 }
 
-static void ForwardDebuggerRequest(const http::Request &request) {
+static void ForwardDebuggerRequest(const http::ServerRequest &request) {
 	AndroidJNIThreadContext jniContext;
 
 	if (serverFlags & (int)WebServerFlags::DEBUGGER) {

--- a/UI/DevScreens.h
+++ b/UI/DevScreens.h
@@ -218,8 +218,8 @@ private:
 	UI::EventReturn OnLoadDump(UI::EventParams &e);
 
 	std::vector<std::string> files_;
-	std::shared_ptr<http::Download> listing_;
-	std::shared_ptr<http::Download> dumpDownload_;
+	std::shared_ptr<http::Request> listing_;
+	std::shared_ptr<http::Request> dumpDownload_;
 };
 
 void DrawProfile(UIContext &ui);

--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -63,7 +63,7 @@ public:
 
 		if (useIconCache && g_iconCache.MarkPending(path_)) {
 			const char *acceptMime = "image/png, image/jpeg, image/*; q=0.9, */*; q=0.8";
-			requestManager_->StartDownloadWithCallback(path_, Path(), http::ProgressBarMode::DELAYED, [&](http::Download &download) {
+			requestManager_->StartDownloadWithCallback(path_, Path(), http::ProgressBarMode::DELAYED, [&](http::Request &download) {
 				if (download.ResultCode() == 200) {
 					std::string data;
 					download.buffer().TakeAll(&data);
@@ -98,7 +98,7 @@ public:
 	const std::string &GetFilename() const { return path_; }
 
 private:
-	void DownloadCompletedCallback(http::Download &download);
+	void DownloadCompletedCallback(http::Request &download);
 
 	bool canFocus_ = false;
 	bool useIconCache_ = false;
@@ -106,7 +106,7 @@ private:
 	uint32_t color_ = 0xFFFFFFFF;
 	UI::ImageSizeMode sizeMode_;
 	http::RequestManager *requestManager_;
-	std::shared_ptr<http::Download> download_;
+	std::shared_ptr<http::Request> download_;
 
 	std::string textureData_;
 	std::unique_ptr<ManagedTexture> texture_;
@@ -155,7 +155,7 @@ void HttpImageFileView::SetFilename(std::string filename) {
 	}
 }
 
-void HttpImageFileView::DownloadCompletedCallback(http::Download &download) {
+void HttpImageFileView::DownloadCompletedCallback(http::Request &download) {
 	if (download.IsCancelled()) {
 		// We were probably destroyed. Can't touch "this" (heh).
 		return;

--- a/UI/Store.h
+++ b/UI/Store.h
@@ -78,8 +78,8 @@ private:
 
 	std::string GetTranslatedString(const json::JsonGet json, std::string key, const char *fallback = nullptr) const;
 
-	std::shared_ptr<http::Download> listing_;
-	std::shared_ptr<http::Download> image_;
+	std::shared_ptr<http::Request> listing_;
+	std::shared_ptr<http::Request> image_;
 
 	// TODO: Replace with a PathBrowser or similar. Though that one only supports
 	// local filesystems at the moment.


### PR DESCRIPTION
Could alternatively have been more specific with namespaces I guess, but meh, I think it's better that things are named differently.