### PR TITLE
Improve handling of RetroAchievements login errors

### DIFF
--- a/Core/RetroAchievements.h
+++ b/Core/RetroAchievements.h
@@ -82,6 +82,10 @@ rc_client_t *GetClient();
 void Initialize();
 void UpdateSettings();
 
+bool LoginProblems(std::string *errorString);
+bool HasToken();
+void TryLoginByToken();
+
 /// Called when the system is being shut down. If Shutdown() returns false, the shutdown should be aborted if possible.
 bool Shutdown();
 

--- a/UI/RetroAchievementScreens.cpp
+++ b/UI/RetroAchievementScreens.cpp
@@ -290,7 +290,20 @@ void RetroAchievementsSettingsScreen::CreateAccountTab(UI::ViewGroup *viewGroup)
 			return UI::EVENT_DONE;
 		});
 	} else {
-		if (System_GetPropertyBool(SYSPROP_HAS_LOGIN_DIALOG)) {
+		std::string errorMessage;
+		if (Achievements::LoginProblems(&errorMessage)) {
+			viewGroup->Add(new NoticeView(NoticeLevel::WARN, ac->T("Failed logging in to RetroAchievements"), errorMessage));
+			if (Achievements::HasToken()) {
+				viewGroup->Add(new Choice(di->T("Retry")))->OnClick.Add([=](UI::EventParams &) -> UI::EventReturn {
+					Achievements::TryLoginByToken();
+					return UI::EVENT_DONE;
+				});
+			}
+			viewGroup->Add(new Choice(di->T("Log out")))->OnClick.Add([=](UI::EventParams &) -> UI::EventReturn {
+				Achievements::Logout();
+				return UI::EVENT_DONE;
+			});
+		} else if (System_GetPropertyBool(SYSPROP_HAS_LOGIN_DIALOG)) {
 			viewGroup->Add(new Choice(ac->T("Log in")))->OnClick.Add([=](UI::EventParams &) -> UI::EventReturn {
 				System_AskUsernamePassword(ac->T("Log in"), [](const std::string &value, int) {
 					std::vector<std::string> parts;

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -30,6 +30,7 @@ Account = Account
 Achievement Unlocked = Achievement Unlocked
 Achievements = Achievements
 Achievements are disabled = Achievements are disabled
+Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now
 Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...


### PR DESCRIPTION
Server errors shouldn't cause us to look like we're logged out. Instead offer a log out button so the user can try to login again, while automatically recovering eventually if the server problem was temporary.

Part of #17631 
