### PR TITLE
Add compilation-enabled vertexjit compare tool

### DIFF
--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -472,6 +472,9 @@ public:
 	u8 biggest;  // in practice, alignment.
 
 	friend class VertexDecoderJitCache;
+
+private:
+	void CompareToJit(const u8 *startPtr, u8 *decodedptr, int count, const UVScale *uvScaleOffset) const;
 };
 
 


### PR DESCRIPTION
Had some wrong vertices in LBP on RISC-V, and this helped find them (#17768, #17771) more easily.  Likely to help for any future vertexjit improvements, prescale changes, skinning optimizations, etc.  Off by default.

-[Unknown]