### PR TITLE
http: Fix hang on early close

### DIFF
--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -371,7 +371,7 @@ int Client::ReadResponseHeaders(net::Buffer *readbuf, std::vector<std::string> &
 
 	while (true) {
 		int sz = readbuf->TakeLineCRLF(&line);
-		if (!sz)
+		if (!sz || sz < 0)
 			break;
 		responseHeaders.push_back(line);
 	}


### PR DESCRIPTION
I was using an HTTP proxy and PPSSPP hung, this was the cause.  I think it closed the response before a \r\n.

Could've done `<= 0`, but the `< 0` case is an error and this should compile the same as long as the most basic of optimizations are enabled.

-[Unknown]