### PR TITLE
Fix issue where achievements wouldn't always activate when starting from frontends

### DIFF
--- a/Core/RetroAchievements.cpp
+++ b/Core/RetroAchievements.cpp
@@ -647,12 +647,14 @@ struct FileContext {
 
 static BlockDevice *g_blockDevice;
 
+bool IsReadyToStart() {
+	return !g_isLoggingIn;
+}
+
 void SetGame(const Path &path, FileLoader *fileLoader) {
-	// If we are currently logging in, give it a couple of seconds. This is not ideal, but works.
 	if (g_isLoggingIn) {
-		for (int i = 0; i < 3000 / 50; i++) {
-			sleep_ms(50);
-		}
+		// IsReadyToStart should have been checked, so we shouldn't be here.
+		ERROR_LOG(ACHIEVEMENTS, "Still logging in during SetGame - shouldn't happen");
 	}
 
 	if (!g_rcClient || !IsLoggedIn()) {

--- a/Core/RetroAchievements.h
+++ b/Core/RetroAchievements.h
@@ -106,6 +106,7 @@ bool HasAchievementsOrLeaderboards();
 bool LoginAsync(const char *username, const char *password);
 void Logout();
 
+bool IsReadyToStart();
 void SetGame(const Path &path, FileLoader *fileLoader);
 void ChangeUMD(const Path &path);  // for in-game UMD change
 void UnloadGame();  // Call when leaving a game.

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -418,6 +418,10 @@ bool PSP_InitStart(const CoreParameter &coreParam, std::string *error_string) {
 		return false;
 	}
 
+	if (!Achievements::IsReadyToStart()) {
+		return false;
+	}
+
 #if defined(_WIN32) && PPSSPP_ARCH(AMD64)
 	NOTICE_LOG(BOOT, "PPSSPP %s Windows 64 bit", PPSSPP_GIT_VERSION);
 #elif defined(_WIN32) && !PPSSPP_ARCH(AMD64)


### PR DESCRIPTION
My previous workaround was flawed - it didn't work at all since we run http callbacks on the main thread, so no progress was made in the background. This problem was not very easy to reproduce on my machine so I interpreted my repro failures as success.

Now we really delay starting the game until the achievement system is ready, if it's in the process of logging in.

Part of #17631 