### PR TITLE
Fix some issues in the RISC-V emitter

### DIFF
--- a/Common/CPUDetect.h
+++ b/Common/CPUDetect.h
@@ -109,7 +109,6 @@ struct CPUInfo {
 	bool RiscV_D;
 	bool RiscV_C;
 	bool RiscV_V;
-	bool RiscV_B;
 	bool RiscV_Zicsr;
 	bool RiscV_Zba;
 	bool RiscV_Zbb;

--- a/Common/RiscVCPUDetect.cpp
+++ b/Common/RiscVCPUDetect.cpp
@@ -221,7 +221,8 @@ void CPUInfo::Detect()
 	RiscV_D = info.features.D;
 	RiscV_C = info.features.C;
 	RiscV_V = info.features.V;
-	RiscV_Zicsr = info.features.Zicsr;
+	// Seems to be wrong sometimes, assume we have it if we have F.
+	RiscV_Zicsr = info.features.Zicsr || info.features.F;
 
 	truncate_cpy(brand_string, info.uarch);
 #endif

--- a/Common/RiscVCPUDetect.cpp
+++ b/Common/RiscVCPUDetect.cpp
@@ -194,7 +194,7 @@ void CPUInfo::Detect()
 
 	truncate_cpy(cpu_string, parser.ISAString().c_str());
 
-	// A number of CPUs support a limited set of B.  It's not all U74, so we use SOC for now...
+	// A number of CPUs support a limited set of bitmanip.  It's not all U74, so we use SOC for now...
 	if (parser.FirmwareMatchesCompatible("starfive,jh7110")) {
 		RiscV_Zba = true;
 		RiscV_Zbb = true;
@@ -208,7 +208,6 @@ void CPUInfo::Detect()
 	RiscV_D = ExtensionSupported(hwcap, 'D');
 	RiscV_C = ExtensionSupported(hwcap, 'C');
 	RiscV_V = ExtensionSupported(hwcap, 'V');
-	RiscV_B = ExtensionSupported(hwcap, 'B');
 	// We assume as in RVA20U64 that F means Zicsr is available.
 	RiscV_Zicsr = RiscV_F;
 
@@ -242,11 +241,10 @@ std::vector<std::string> CPUInfo::Features() {
 		{ RiscV_D, "Double" },
 		{ RiscV_C, "Compressed" },
 		{ RiscV_V, "Vector" },
-		{ RiscV_B, "Bitmanip" },
-		{ RiscV_Zba, "Zba" },
-		{ RiscV_Zbb, "Zbb" },
-		{ RiscV_Zbc, "Zbc" },
-		{ RiscV_Zbs, "Zbs" },
+		{ RiscV_Zba, "Bitmanip Zba" },
+		{ RiscV_Zbb, "Bitmanip Zbb" },
+		{ RiscV_Zbc, "Bitmanip Zbc" },
+		{ RiscV_Zbs, "Bitmanip Zbs" },
 		{ RiscV_Zicsr, "Zicsr" },
 		{ CPU64bit, "64-bit" },
 	};

--- a/Common/RiscVEmitter.cpp
+++ b/Common/RiscVEmitter.cpp
@@ -62,10 +62,10 @@ static inline bool SupportsVector() {
 
 static inline bool SupportsBitmanip(char zbx) {
 	switch (zbx) {
-	case 'a': return cpu_info.RiscV_B || cpu_info.RiscV_Zba;
-	case 'b': return cpu_info.RiscV_B || cpu_info.RiscV_Zbb;
-	case 'c': return cpu_info.RiscV_B || cpu_info.RiscV_Zbc;
-	case 's': return cpu_info.RiscV_B || cpu_info.RiscV_Zbs;
+	case 'a': return cpu_info.RiscV_Zba;
+	case 'b': return cpu_info.RiscV_Zbb;
+	case 'c': return cpu_info.RiscV_Zbc;
+	case 's': return cpu_info.RiscV_Zbs;
 	default: return false;
 	}
 }


### PR DESCRIPTION
Some immediates weren't being set properly, mainly.  Also, Zicsr is false from cpu_features in a VisionFive 2, but it definitely has it and my understanding is it's required if you have F.  So override there like we do for non-cpu_features.

-[Unknown]