### PR TITLE
net: Fix request cancelling

### DIFF
--- a/Common/System/OSD.cpp
+++ b/Common/System/OSD.cpp
@@ -235,10 +235,6 @@ void OnScreenDisplay::SetProgressBar(std::string id, std::string &&message, floa
 		}
 	}
 
-	if (message == "dorequest.php") {
-		found = found;
-	}
-
 	ProgressBar bar;
 	bar.id = id;
 	bar.message = std::move(message);

--- a/GPU/Software/Clipper.cpp
+++ b/GPU/Software/Clipper.cpp
@@ -405,7 +405,7 @@ void ProcessTriangle(const ClipVertexData &v0, const ClipVertexData &v1, const C
 			ClipVertexData &subv1 = *Vertices[indices[i + 1]];
 			ClipVertexData &subv2 = *Vertices[indices[i + 2]];
 
-			if (subv0.OutsideRange() || subv1.OutsideRange() | subv2.OutsideRange())
+			if (subv0.OutsideRange() || subv1.OutsideRange() || subv2.OutsideRange())
 				continue;
 
 			if (gstate.getShadeMode() == GE_SHADE_FLAT) {


### PR DESCRIPTION
Was broken in #17737.

The previous code was simply:

```c++
while (!ready && has_cancelled_ptr) {
    if (*cancelled)
        return false;
    ready = wait_for_socket_ready(max = 0.25);
}
```

This just restores that logic.  It's needed for blocking mode sockets.

-[Unknown]