### PR TITLE
arm64jit: When rouding unset, use nearest

### DIFF
--- a/Core/MIPS/ARM64/Arm64Asm.cpp
+++ b/Core/MIPS/ARM64/Arm64Asm.cpp
@@ -312,7 +312,7 @@ void Arm64Jit::GenerateFixedCode(const JitOptions &jo) {
 
 	// Leave this at the end, add more stuff above.
 	if (enableDisasm) {
-		std::vector<std::string> lines = DisassembleArm64(start, GetCodePtr() - start);
+		std::vector<std::string> lines = DisassembleArm64(start, (int)(GetCodePtr() - start));
 		for (auto s : lines) {
 			INFO_LOG(JIT, "%s", s.c_str());
 		}

--- a/Core/MIPS/ARM64/Arm64CompFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64CompFPU.cpp
@@ -292,7 +292,7 @@ void Arm64Jit::Comp_FPU2op(MIPSOpcode op) {
 			fp.FMOV(fpr.R(fd), S0);
 		} else {
 			fp.FCMP(fpr.R(fs), fpr.R(fs));
-			fp.FCVTS(fpr.R(fd), fpr.R(fs), ROUND_Z);
+			fp.FCVTS(fpr.R(fd), fpr.R(fs), ROUND_N);
 			FixupBranch skip_nan = B(CC_VC);
 			MOVI2R(SCRATCH1, 0x7FFFFFFF);
 			fp.FMOV(fpr.R(fd), SCRATCH1);


### PR DESCRIPTION
The 0/default rounding mode is nearest, not toward zero. We set hasSetRounding only when fcr31 has a non-zero rounding mode or flush to zero set.

Noticed while implementing the RISC-V jit.  Not sure if it fixes anything... would be interesting to check any bugs that are arm64-only, and if the game doesn't ever set a rounding mode.

-[Unknown]