### PR TITLE
irjit: Implement vf2ix

### DIFF
--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -929,37 +929,17 @@ namespace MIPSComp {
 		VectorSize sz = GetVecSize(op);
 		int n = GetNumVectorElements(sz);
 
-		int imm = (op >> 16) & 0x1f;
-		const float mult = 1.0f / (float)(1UL << imm);
+		uint8_t imm = (op >> 16) & 0x1f;
 
 		u8 sregs[4], dregs[4];
 		GetVectorRegsPrefixS(sregs, sz, _VS);
 		GetVectorRegsPrefixD(dregs, sz, _VD);
 
-		u8 tempregs[4];
-		for (int i = 0; i < n; ++i) {
-			if (!IsOverlapSafe(dregs[i], n, sregs)) {
-				tempregs[i] = IRVTEMP_PFX_T + i;  // Need IRVTEMP_0 for the scaling factor
-			} else {
-				tempregs[i] = dregs[i];
-			}
-		}
-		if (mult != 1.0f)
-			ir.Write(IROp::SetConstF, IRVTEMP_0, ir.AddConstantFloat(mult));
-		// TODO: Use the SCVTF with builtin scaling where possible.
 		for (int i = 0; i < n; i++) {
-			ir.Write(IROp::FCvtSW, tempregs[i], sregs[i]);
-		}
-		if (mult != 1.0f) {
-			for (int i = 0; i < n; i++) {
-				ir.Write(IROp::FMul, tempregs[i], tempregs[i], IRVTEMP_0);
-			}
-		}
-
-		for (int i = 0; i < n; ++i) {
-			if (dregs[i] != tempregs[i]) {
-				ir.Write(IROp::FMov, dregs[i], tempregs[i]);
-			}
+			if (imm == 0)
+				ir.Write(IROp::FCvtSW, dregs[i], sregs[i]);
+			else
+				ir.Write(IROp::FCvtScaledSW, dregs[i], sregs[i], imm);
 		}
 		ApplyPrefixD(dregs, sz);
 	}
@@ -989,7 +969,7 @@ namespace MIPSComp {
 		VectorSize sz = GetVecSize(op);
 		int n = GetNumVectorElements(sz);
 
-		int imm = (op >> 16) & 0x1f;
+		uint8_t imm = (op >> 16) & 0x1f;
 
 		u8 sregs[4], dregs[4];
 		GetVectorRegsPrefixS(sregs, sz, _VS);
@@ -1000,17 +980,9 @@ namespace MIPSComp {
 		if (((op >> 21) & 0x1C) != 0x10)
 			INVALIDOP;
 
-		u8 tempregs[4];
-		for (int i = 0; i < n; ++i) {
-			if (!IsOverlapSafe(dregs[i], n, sregs)) {
-				tempregs[i] = IRVTEMP_PFX_T + i;  // Need IRVTEMP_0 for the scaling factor
-			} else {
-				tempregs[i] = dregs[i];
-			}
-		}
 		if (imm != 0) {
 			for (int i = 0; i < n; i++)
-				ir.Write(IROp::FCvtScaledWS, dregs[i], sregs[i], (uint8_t)(imm | (rmode << 6)));
+				ir.Write(IROp::FCvtScaledWS, dregs[i], sregs[i], imm | (rmode << 6));
 		} else {
 			for (int i = 0; i < n; i++) {
 				switch (rmode) {

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -105,6 +105,7 @@ static const IRMeta irMeta[] = {
 	{ IROp::FFloor, "FFloor", "FF" },
 	{ IROp::FCvtWS, "FCvtWS", "FF" },
 	{ IROp::FCvtSW, "FCvtSW", "FF" },
+	{ IROp::FCvtScaledWS, "FCvtScaledWS", "FFI" },
 	{ IROp::FCmp, "FCmp", "mFF" },
 	{ IROp::FSat0_1, "FSat(0 - 1)", "FF" },
 	{ IROp::FSatMinus1_1, "FSat(-1 - 1)", "FF" },

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -106,6 +106,7 @@ static const IRMeta irMeta[] = {
 	{ IROp::FCvtWS, "FCvtWS", "FF" },
 	{ IROp::FCvtSW, "FCvtSW", "FF" },
 	{ IROp::FCvtScaledWS, "FCvtScaledWS", "FFI" },
+	{ IROp::FCvtScaledSW, "FCvtScaledSW", "FFI" },
 	{ IROp::FCmp, "FCmp", "mFF" },
 	{ IROp::FSat0_1, "FSat(0 - 1)", "FF" },
 	{ IROp::FSatMinus1_1, "FSat(-1 - 1)", "FF" },

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -128,6 +128,7 @@ enum class IROp : u8 {
 	FCvtWS,
 	FCvtSW,
 	FCvtScaledWS,
+	FCvtScaledSW,
 
 	FMovFromGPR,
 	FMovToGPR,

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -127,6 +127,7 @@ enum class IROp : u8 {
 
 	FCvtWS,
 	FCvtSW,
+	FCvtScaledWS,
 
 	FMovFromGPR,
 	FMovToGPR,
@@ -303,9 +304,6 @@ enum : IRReg {
 	IRVTEMP_PFX_T = 228 - 32,
 	IRVTEMP_PFX_D = 232 - 32,
 	IRVTEMP_0 = 236 - 32,
-
-	// 16 float temps for vector S and T prefixes and things like that.
-	// IRVTEMP_0 = 208 - 64,  // -64 to be relative to v[0]
 
 	// Hacky way to get to other state
 	IRREG_VFPU_CTRL_BASE = 208,

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -931,6 +931,9 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 			}
 			break; //cvt.w.s
 		}
+		case IROp::FCvtScaledSW:
+			mips->f[inst->dest] = (float)mips->fs[inst->src1] * (1.0f / (1UL << (inst->src2 & 0x1F)));
+			break;
 		case IROp::FCvtScaledWS:
 		{
 			float src = mips->f[inst->src1];

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -834,7 +834,7 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 				mips->fi[inst->dest] = my_isinf(value) && value < 0.0f ? -2147483648LL : 2147483647LL;
 				break;
 			} else {
-				mips->fs[inst->dest] = (int)floorf(value + 0.5f);
+				mips->fs[inst->dest] = (int)round_ieee_754(value);
 			}
 			break;
 		}
@@ -930,6 +930,32 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 			case 3: mips->fs[inst->dest] = (int)floorf(src); break;  // FLOOR_3
 			}
 			break; //cvt.w.s
+		}
+		case IROp::FCvtScaledWS:
+		{
+			float src = mips->f[inst->src1];
+			if (my_isnan(src)) {
+				// TODO: True for negatives too?
+				mips->fs[inst->dest] = 2147483647L;
+				break;
+			}
+
+			float mult = (float)(1UL << (inst->src2 & 0x1F));
+			double sv = src * mult; // (float)0x7fffffff == (float)0x80000000
+			// Cap/floor it to 0x7fffffff / 0x80000000
+			if (sv > (double)0x7fffffff) {
+				mips->fs[inst->dest] = 0x7fffffff;
+			} else if (sv <= (double)(int)0x80000000) {
+				mips->fs[inst->dest] = 0x80000000;
+			} else {
+				switch (inst->src2 >> 6) {
+				case 0: mips->fs[inst->dest] = (int)round_ieee_754(sv); break;
+				case 1: mips->fs[inst->dest] = src >= 0 ? (int)floor(sv) : (int)ceil(sv); break;
+				case 2: mips->fs[inst->dest] = (int)ceil(sv); break;
+				case 3: mips->fs[inst->dest] = (int)floor(sv); break;
+				}
+			}
+			break;
 		}
 
 		case IROp::ZeroFpCond:

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -668,6 +668,7 @@ bool PropagateConstants(const IRWriter &in, IRWriter &out, const IROptions &opts
 		case IROp::FFloor:
 		case IROp::FCvtSW:
 		case IROp::FCvtScaledWS:
+		case IROp::FCvtScaledSW:
 		case IROp::FSin:
 		case IROp::FCos:
 		case IROp::FSqrt:

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -667,6 +667,7 @@ bool PropagateConstants(const IRWriter &in, IRWriter &out, const IROptions &opts
 		case IROp::FCeil:
 		case IROp::FFloor:
 		case IROp::FCvtSW:
+		case IROp::FCvtScaledWS:
 		case IROp::FSin:
 		case IROp::FCos:
 		case IROp::FSqrt:

--- a/Core/MIPS/RiscV/RiscVCompFPU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompFPU.cpp
@@ -190,6 +190,7 @@ void RiscVJit::CompIR_FCvt(IRInst inst) {
 
 	switch (inst.op) {
 	case IROp::FCvtWS:
+	case IROp::FCvtScaledWS:
 	case IROp::FCvtSW:
 		CompIR_Generic(inst);
 		break;

--- a/Core/MIPS/RiscV/RiscVCompFPU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompFPU.cpp
@@ -192,6 +192,7 @@ void RiscVJit::CompIR_FCvt(IRInst inst) {
 	case IROp::FCvtWS:
 	case IROp::FCvtScaledWS:
 	case IROp::FCvtSW:
+	case IROp::FCvtScaledSW:
 		CompIR_Generic(inst);
 		break;
 

--- a/Core/MIPS/RiscV/RiscVJit.cpp
+++ b/Core/MIPS/RiscV/RiscVJit.cpp
@@ -266,6 +266,7 @@ void RiscVJit::CompileIRInst(IRInst inst) {
 	case IROp::FCvtWS:
 	case IROp::FCvtSW:
 	case IROp::FCvtScaledWS:
+	case IROp::FCvtScaledSW:
 		CompIR_FCvt(inst);
 		break;
 

--- a/Core/MIPS/RiscV/RiscVJit.cpp
+++ b/Core/MIPS/RiscV/RiscVJit.cpp
@@ -265,6 +265,7 @@ void RiscVJit::CompileIRInst(IRInst inst) {
 
 	case IROp::FCvtWS:
 	case IROp::FCvtSW:
+	case IROp::FCvtScaledWS:
 		CompIR_FCvt(inst);
 		break;
 


### PR DESCRIPTION
Used in LittleBigPlanet when playing intro movies.  Didn't help a ton after all (they still play under 100% on my RISC-V device), but since I already implemented it, it may help some other game more.

This adds a new IROp for the scaled conversion since it needs a double to scale properly, or else to use a directly scaling instruction.  Similarly adds one for FCvtScaledSW, which makes clang generate ucvtf we'd want it to.

-[Unknown]