### PR TITLE
More RISC-V jit ops

### DIFF
--- a/Core/MIPS/RiscV/RiscVCompALU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompALU.cpp
@@ -254,7 +254,13 @@ void RiscVJit::CompIR_Bits(IRInst inst) {
 		break;
 
 	case IROp::Clz:
-		CompIR_Generic(inst);
+		if (cpu_info.RiscV_Zbb) {
+			gpr.MapDirtyIn(inst.dest, inst.src1, MapType::AVOID_LOAD_MARK_NORM32);
+			// This even sets to 32 when zero, perfect.
+			CLZW(gpr.R(inst.dest), gpr.R(inst.src1));
+		} else {
+			CompIR_Generic(inst);
+		}
 		break;
 
 	default:

--- a/Core/MIPS/RiscV/RiscVCompALU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompALU.cpp
@@ -640,10 +640,53 @@ void RiscVJit::CompIR_Mult(IRInst inst) {
 void RiscVJit::CompIR_Div(IRInst inst) {
 	CONDITIONAL_DISABLE;
 
+	RiscVReg numReg, denomReg;
 	switch (inst.op) {
 	case IROp::Div:
+		gpr.MapDirtyDirtyInIn(IRREG_LO, IRREG_HI, inst.src1, inst.src2, MapType::AVOID_LOAD_MARK_NORM32);
+		// We have to do this because of the divide by zero and overflow checks below.
+		NormalizeSrc12(inst, &numReg, &denomReg, SCRATCH1, SCRATCH2, true);
+		DIVW(gpr.R(IRREG_LO), numReg, denomReg);
+		REMW(gpr.R(IRREG_HI), numReg, denomReg);
+
+		// Now some tweaks for divide by zero and overflow.
+		{
+			// Start with divide by zero, remainder is fine.
+			FixupBranch skipNonZero = BNE(denomReg, R_ZERO);
+			FixupBranch keepNegOne = BGE(numReg, R_ZERO);
+			LI(gpr.R(IRREG_LO), 1);
+			SetJumpTarget(keepNegOne);
+			SetJumpTarget(skipNonZero);
+
+			// For overflow, RISC-V sets LO right, but remainder to zero.
+			// Cheating a bit by using R_RA as a temp...
+			LI(R_RA, (int32_t)0x80000000);
+			FixupBranch notMostNegative = BNE(numReg, R_RA);
+			LI(R_RA, -1);
+			FixupBranch notNegativeOne = BNE(denomReg, R_RA);
+			LI(gpr.R(IRREG_HI), -1);
+			SetJumpTarget(notNegativeOne);
+			SetJumpTarget(notMostNegative);
+		}
+		break;
+
 	case IROp::DivU:
-		CompIR_Generic(inst);
+		gpr.MapDirtyDirtyInIn(IRREG_LO, IRREG_HI, inst.src1, inst.src2, MapType::AVOID_LOAD_MARK_NORM32);
+		// We have to do this because of the divide by zero check below.
+		NormalizeSrc12(inst, &numReg, &denomReg, SCRATCH1, SCRATCH2, true);
+		DIVUW(gpr.R(IRREG_LO), numReg, denomReg);
+		REMUW(gpr.R(IRREG_HI), numReg, denomReg);
+
+		// On divide by zero, everything is correct already except the 0xFFFF case.
+		{
+			FixupBranch skipNonZero = BNE(denomReg, R_ZERO);
+			// Luckily, we don't need SCRATCH2/denomReg anymore.
+			LI(SCRATCH2, 0xFFFF);
+			FixupBranch keepNegOne = BLTU(SCRATCH2, numReg);
+			MV(gpr.R(IRREG_LO), SCRATCH2);
+			SetJumpTarget(keepNegOne);
+			SetJumpTarget(skipNonZero);
+		}
 		break;
 
 	default:

--- a/Core/MIPS/RiscV/RiscVCompSystem.cpp
+++ b/Core/MIPS/RiscV/RiscVCompSystem.cpp
@@ -101,7 +101,7 @@ void RiscVJit::CompIR_Transfer(IRInst inst) {
 		break;
 
 	case IROp::SetCtrlVFPUFReg:
-		gpr.MapReg(IRREG_VFPU_CTRL_BASE + inst.dest, MIPSMap::NOINIT);
+		gpr.MapReg(IRREG_VFPU_CTRL_BASE + inst.dest, MIPSMap::NOINIT | MIPSMap::MARK_NORM32);
 		fpr.MapReg(inst.src1);
 		FMV(FMv::X, FMv::W, gpr.R(IRREG_VFPU_CTRL_BASE + inst.dest), fpr.R(inst.src1));
 		break;
@@ -167,7 +167,7 @@ void RiscVJit::CompIR_Transfer(IRInst inst) {
 		break;
 
 	case IROp::FMovToGPR:
-		gpr.MapReg(inst.dest, MIPSMap::NOINIT);
+		gpr.MapReg(inst.dest, MIPSMap::NOINIT | MIPSMap::MARK_NORM32);
 		fpr.MapReg(inst.src1);
 		FMV(FMv::X, FMv::W, gpr.R(inst.dest), fpr.R(inst.src1));
 		break;

--- a/Core/MIPS/RiscV/RiscVCompSystem.cpp
+++ b/Core/MIPS/RiscV/RiscVCompSystem.cpp
@@ -20,7 +20,6 @@
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/ReplaceTables.h"
 #include "Core/MemMap.h"
-#include "Core/MIPS/MIPSTables.h"
 #include "Core/MIPS/RiscV/RiscVJit.h"
 #include "Core/MIPS/RiscV/RiscVRegCache.h"
 
@@ -182,15 +181,6 @@ void RiscVJit::CompIR_System(IRInst inst) {
 	CONDITIONAL_DISABLE;
 
 	switch (inst.op) {
-	case IROp::Interpret:
-		// IR protects us against this being a branching instruction (well, hopefully.)
-		FlushAll();
-		SaveStaticRegisters();
-		LI(X10, (int32_t)inst.constant);
-		QuickCallFunction((const u8 *)MIPSGetInterpretFunc(MIPSOpcode(inst.constant)));
-		LoadStaticRegisters();
-		break;
-
 	case IROp::Syscall:
 		FlushAll();
 		SaveStaticRegisters();

--- a/Core/MIPS/RiscV/RiscVJit.h
+++ b/Core/MIPS/RiscV/RiscVJit.h
@@ -46,7 +46,7 @@ public:
 	// TODO: GetBlockCacheDebugInterface, block linking?
 
 protected:
-	bool CompileBlock(u32 em_address, std::vector<IRInst> &instructions, u32 &mipsBytes, bool preload) override;
+	bool CompileTargetBlock(IRBlock *block, int block_num, bool preload) override;
 
 	void CompileIRInst(IRInst inst);
 
@@ -115,8 +115,6 @@ private:
 	RiscVRegCache gpr;
 	RiscVRegCacheFPU fpr;
 
-	static constexpr int MAX_ALLOWED_JIT_BLOCKS = 262144;
-
 	const u8 *enterDispatcher_ = nullptr;
 
 	const u8 *outerLoop_ = nullptr;
@@ -134,7 +132,6 @@ private:
 	const u8 *crashHandler_ = nullptr;
 
 	int jitStartOffset_ = 0;
-	const u8 **blockStartAddrs_ = nullptr;
 };
 
 } // namespace MIPSComp

--- a/Core/MIPS/RiscV/RiscVJit.h
+++ b/Core/MIPS/RiscV/RiscVJit.h
@@ -86,6 +86,7 @@ private:
 	void CompIR_FStore(IRInst inst);
 	void CompIR_Generic(IRInst inst);
 	void CompIR_HiLo(IRInst inst);
+	void CompIR_Interpret(IRInst inst);
 	void CompIR_Load(IRInst inst);
 	void CompIR_LoadShift(IRInst inst);
 	void CompIR_Logic(IRInst inst);

--- a/Core/MIPS/RiscV/RiscVRegCache.h
+++ b/Core/MIPS/RiscV/RiscVRegCache.h
@@ -140,6 +140,7 @@ public:
 	void FlushBeforeCall();
 	void FlushAll();
 	void FlushR(IRRegIndex r);
+	void FlushRiscVReg(RiscVGen::RiscVReg r);
 	void DiscardR(IRRegIndex r);
 
 	RiscVGen::RiscVReg GetAndLockTempR();
@@ -163,7 +164,6 @@ private:
 	RiscVGen::RiscVReg AllocateReg();
 	RiscVGen::RiscVReg FindBestToSpill(bool unusedOnly, bool *clobbered);
 	RiscVGen::RiscVReg RiscVRegForFlush(IRRegIndex r);
-	void FlushRiscVReg(RiscVGen::RiscVReg r);
 	void SetRegImm(RiscVGen::RiscVReg reg, u64 imm);
 	void AddMemBase(RiscVGen::RiscVReg reg);
 	int GetMipsRegOffset(IRRegIndex r);

--- a/Core/MIPS/RiscV/RiscVRegCacheFPU.cpp
+++ b/Core/MIPS/RiscV/RiscVRegCacheFPU.cpp
@@ -27,9 +27,6 @@
 using namespace RiscVGen;
 using namespace RiscVJitConstants;
 
-using namespace RiscVGen;
-using namespace RiscVJitConstants;
-
 RiscVRegCacheFPU::RiscVRegCacheFPU(MIPSState *mipsState, MIPSComp::JitOptions *jo)
 	: mips_(mipsState), jo_(jo) {}
 
@@ -276,6 +273,24 @@ RiscVReg RiscVRegCacheFPU::RiscVRegForFlush(IRRegIndex r) {
 	default:
 		_assert_(false);
 		return INVALID_REG;
+	}
+}
+
+void RiscVRegCacheFPU::FlushBeforeCall() {
+	// Note: don't set this false at the end, since we don't flush everything.
+	if (!pendingFlush_) {
+		return;
+	}
+
+	// These registers are not preserved by function calls.
+	for (int i = 0; i <= 7; ++i) {
+		FlushRiscVReg(RiscVReg(F0 + i));
+	}
+	for (int i = 10; i <= 17; ++i) {
+		FlushRiscVReg(RiscVReg(F0 + i));
+	}
+	for (int i = 28; i <= 31; ++i) {
+		FlushRiscVReg(RiscVReg(F0 + i));
 	}
 }
 

--- a/Core/MIPS/RiscV/RiscVRegCacheFPU.h
+++ b/Core/MIPS/RiscV/RiscVRegCacheFPU.h
@@ -64,11 +64,12 @@ public:
 	void MapInIn(IRRegIndex rd, IRRegIndex rs);
 	void MapDirtyIn(IRRegIndex rd, IRRegIndex rs, bool avoidLoad = true);
 	void MapDirtyInIn(IRRegIndex rd, IRRegIndex rs, IRRegIndex rt, bool avoidLoad = true);
-	void Map4Dirty(IRRegIndex rdbase, bool avoidLoad = true);
 	void Map4DirtyIn(IRRegIndex rdbase, IRRegIndex rsbase, bool avoidLoad = true);
 	void Map4DirtyInIn(IRRegIndex rdbase, IRRegIndex rsbase, IRRegIndex rtbase, bool avoidLoad = true);
+	void FlushBeforeCall();
 	void FlushAll();
 	void FlushR(IRRegIndex r);
+	void FlushRiscVReg(RiscVGen::RiscVReg r);
 	void DiscardR(IRRegIndex r);
 
 	RiscVGen::RiscVReg R(int preg); // Returns a cached register
@@ -78,7 +79,6 @@ private:
 	RiscVGen::RiscVReg AllocateReg();
 	RiscVGen::RiscVReg FindBestToSpill(bool unusedOnly, bool *clobbered);
 	RiscVGen::RiscVReg RiscVRegForFlush(IRRegIndex r);
-	void FlushRiscVReg(RiscVGen::RiscVReg r);
 	int GetMipsRegOffset(IRRegIndex r);
 
 	bool IsValidReg(IRRegIndex r) const;


### PR DESCRIPTION
This improves LittleBigPlanet in game perf on RISC-V by about 14% from ~145% speed.  That's the first level, so it may help complex areas become more playable, and should help other games of course.

With this, it no longer uses IR block indexes and a lookup table for block start addresses, but works the same as other jits.  However, it still doesn't have block linking which would probably give a good boost to tight loops and etc.

-[Unknown]