### PR TITLE
Re-enable framebuffer fetch for blend where available.

### DIFF
--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -607,6 +607,10 @@ u32 GPUCommonHW::CheckGPUFeatures() const {
 		features |= GPU_USE_VS_RANGE_CULLING;
 	}
 
+	if (draw_->GetDeviceCaps().framebufferFetchSupported) {
+		features |= GPU_USE_FRAMEBUFFER_FETCH;
+	}
+
 	if (draw_->GetShaderLanguageDesc().bitwiseOps) {
 		features |= GPU_USE_LIGHT_UBERSHADER;
 	}


### PR DESCRIPTION
Accidentally disabled this in #17575

Helps #17797 but only on OpenGL on mobile. There's more to improve there.

`caps_.framebufferFetchSupported` is now always set to false in Vulkan so won't auto-re-enable there.