### PR TITLE
Frustum-cull small draws 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -737,6 +737,7 @@ add_library(Common STATIC
 	Common/Input/InputState.cpp
 	Common/Input/InputState.h
 	Common/Math/fast/fast_matrix.c
+	Common/Math/CrossSIMD.h
 	Common/Math/curves.cpp
 	Common/Math/curves.h
 	Common/Math/expression_parser.cpp

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -484,6 +484,7 @@
     <ClInclude Include="Input\GestureDetector.h" />
     <ClInclude Include="Input\InputState.h" />
     <ClInclude Include="Input\KeyCodes.h" />
+    <ClInclude Include="Math\CrossSIMD.h" />
     <ClInclude Include="Math\curves.h" />
     <ClInclude Include="Math\expression_parser.h" />
     <ClInclude Include="Math\fast\fast_matrix.h" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -518,6 +518,9 @@
     <ClInclude Include="GPU\Vulkan\VulkanDescSet.h">
       <Filter>GPU\Vulkan</Filter>
     </ClInclude>
+    <ClInclude Include="Math\CrossSIMD.h">
+      <Filter>Math</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />

--- a/Common/Math/CrossSIMD.h
+++ b/Common/Math/CrossSIMD.h
@@ -1,0 +1,54 @@
+// CrossSIMD
+//
+// Compatibility wrappers for SIMD dialects.
+//
+// In the long run, might do a more general single-source-SIMD wrapper here consisting
+// of defines that translate to either NEON or SSE. It would be possible to write quite a lot of
+// our various color conversion functions and so on in a pretty generic manner.
+
+#include "ppsspp_config.h"
+
+#include <cstdint>
+
+#ifdef _M_SSE
+#include <emmintrin.h>
+#endif
+
+#if PPSSPP_ARCH(ARM_NEON)
+#if defined(_MSC_VER) && PPSSPP_ARCH(ARM64)
+#include <arm64_neon.h>
+#else
+#include <arm_neon.h>
+#endif
+#endif
+
+// Basic types
+
+#if PPSSPP_ARCH(ARM64_NEON)
+
+// No special ones here.
+
+#elif PPSSPP_ARCH(ARM_NEON)
+
+// Compatibility wrappers making ARM64 NEON code run on ARM32
+// With optimization on, these should compile down to the optimal code.
+
+inline float32x4_t vmulq_laneq_f32(float32x4_t a, float32x4_t b, int lane) {
+	switch (lane & 3) {
+	case 0: return vmulq_lane_f32(a, vget_low_f32(b), 0);
+	case 1: return vmulq_lane_f32(a, vget_low_f32(b), 1);
+	case 2: return vmulq_lane_f32(a, vget_high_f32(b), 0);
+	case 3: return vmulq_lane_f32(a, vget_high_f32(b), 1);
+	}
+}
+
+inline float32x4_t vmlaq_laneq_f32(float32x4_t a, float32x4_t b, float32x4_t c, int lane) {
+	switch (lane & 3) {
+	case 0: return vmlaq_lane_f32(a, b, vget_low_f32(c), 0);
+	case 1: return vmlaq_lane_f32(a, b, vget_low_f32(c), 1);
+	case 2: return vmlaq_lane_f32(a, b, vget_high_f32(c), 0);
+	case 3: return vmlaq_lane_f32(a, b, vget_high_f32(c), 1);
+	}
+}
+
+#endif

--- a/Common/Math/CrossSIMD.h
+++ b/Common/Math/CrossSIMD.h
@@ -38,7 +38,7 @@ inline float32x4_t vmulq_laneq_f32(float32x4_t a, float32x4_t b, int lane) {
 	case 0: return vmulq_lane_f32(a, vget_low_f32(b), 0);
 	case 1: return vmulq_lane_f32(a, vget_low_f32(b), 1);
 	case 2: return vmulq_lane_f32(a, vget_high_f32(b), 0);
-	case 3: return vmulq_lane_f32(a, vget_high_f32(b), 1);
+	default: return vmulq_lane_f32(a, vget_high_f32(b), 1);
 	}
 }
 
@@ -47,8 +47,12 @@ inline float32x4_t vmlaq_laneq_f32(float32x4_t a, float32x4_t b, float32x4_t c, 
 	case 0: return vmlaq_lane_f32(a, b, vget_low_f32(c), 0);
 	case 1: return vmlaq_lane_f32(a, b, vget_low_f32(c), 1);
 	case 2: return vmlaq_lane_f32(a, b, vget_high_f32(c), 0);
-	case 3: return vmlaq_lane_f32(a, b, vget_high_f32(c), 1);
+	default: return vmlaq_lane_f32(a, b, vget_high_f32(c), 1);
 	}
+}
+
+inline uint32x4_t vcgezq_f32(float32x4_t v) {
+	return vcgeq_f32(v, vdupq_n_f32(0.0f));
 }
 
 #endif

--- a/Common/Math/CrossSIMD.h
+++ b/Common/Math/CrossSIMD.h
@@ -10,7 +10,7 @@
 
 #include <cstdint>
 
-#ifdef _M_SSE
+#if PPSSPP_ARCH(SSE2)
 #include <emmintrin.h>
 #endif
 

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -620,7 +620,6 @@ CollapsibleHeader::CollapsibleHeader(bool *toggle, const std::string &text, Layo
 
 void CollapsibleHeader::Draw(UIContext &dc) {
 	Style style = dc.theme->itemStyle;
-	style.background.color = 0;
 	if (HasFocus()) style = dc.theme->itemFocusedStyle;
 	if (down_) style = dc.theme->itemDownStyle;
 	if (!IsEnabled()) style = dc.theme->itemDisabledStyle;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1893,7 +1893,7 @@ void PlayTimeTracker::Load(const Section *section) {
 
 		// Parse the string.
 		PlayTime gameTime{};
-		if (2 == sscanf(value.c_str(), "%d,%llu", &gameTime.totalTimePlayed, &gameTime.lastTimePlayed)) {
+		if (2 == sscanf(value.c_str(), "%d,%llu", &gameTime.totalTimePlayed, (long long *)&gameTime.lastTimePlayed)) {
 			tracker_[key] = gameTime;
 		}
 	}

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -444,11 +444,10 @@ bool DrawEngineCommon::TestBoundingBoxFast(const void *vdata, int vertexCount, u
 			_mm_storeu_ps(verts + i * 3, pos);  // TODO: use stride 4 to avoid clashing writes?
 		}
 #elif PPSSPP_ARCH(ARM_NEON)
-		float32x4_t scaleFactor = vdupq_n_f32(1.0f / 32768.0f);
 		for (int i = 0; i < vertexCount; i++) {
 			const s16 *dataPtr = ((const s16 *)((const s8 *)vdata + i * stride + offset));
 			int32x4_t data = vmovl_s16(vld1_s16(dataPtr));
-			float32x4_t pos = vmulq_f32(vcvtq_f32_s32(data), scaleFactor);
+			float32x4_t pos = vcvtq_n_f32_s32(data, 15);  // >> 15 = division by 32768.0f
 			vst1q_f32(verts + i * 3, pos);
 		}
 #else

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -670,6 +670,31 @@ int DrawEngineCommon::ExtendNonIndexedPrim(const uint32_t *cmd, const uint32_t *
 	return cmd - start;
 }
 
+void DrawEngineCommon::SkipPrim(GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int *bytesRead) {
+	if (!indexGen.PrimCompatible(prevPrim_, prim)) {
+		DispatchFlush();
+	}
+
+	// This isn't exactly right, if we flushed, since prims can straddle previous calls.
+	// But it generally works for common usage.
+	if (prim == GE_PRIM_KEEP_PREVIOUS) {
+		// Has to be set to something, let's assume POINTS (0) if no previous.
+		if (prevPrim_ == GE_PRIM_INVALID)
+			prevPrim_ = GE_PRIM_POINTS;
+		prim = prevPrim_;
+	} else {
+		prevPrim_ = prim;
+	}
+
+	// If vtype has changed, setup the vertex decoder.
+	if (vertTypeID != lastVType_ || !dec_) {
+		dec_ = GetVertexDecoder(vertTypeID);
+		lastVType_ = vertTypeID;
+	}
+
+	*bytesRead = vertexCount * dec_->VertexSize();
+}
+
 // vertTypeID is the vertex type but with the UVGen mode smashed into the top bits.
 bool DrawEngineCommon::SubmitPrim(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, bool clockwise, int *bytesRead) {
 	if (!indexGen.PrimCompatible(prevPrim_, prim) || numDrawVerts_ >= MAX_DEFERRED_DRAW_VERTS || numDrawInds_ >= MAX_DEFERRED_DRAW_INDS || vertexCountInDrawCalls_ + vertexCount > VERTEX_BUFFER_MAX) {

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -113,6 +113,8 @@ public:
 
 	int ExtendNonIndexedPrim(const uint32_t *cmd, const uint32_t *stall, u32 vertTypeID, bool clockwise, int *bytesRead, bool isTriangle);
 	bool SubmitPrim(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, bool clockwise, int *bytesRead);
+	void SkipPrim(GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int *bytesRead);
+
 	template<class Surface>
 	void SubmitCurve(const void *control_points, const void *indices, Surface &surface, u32 vertType, int *bytesRead, const char *scope);
 	void ClearSplineBezierWeights();

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -104,6 +104,10 @@ public:
 
 	bool TestBoundingBox(const void *control_points, const void *inds, int vertexCount, u32 vertType);
 
+	// This is a less accurate version of TestBoundingBox, but faster. Can have more false positives.
+	// Doesn't support indexing.
+	bool TestBoundingBoxFast(const void *control_points, int vertexCount, u32 vertType);
+
 	void FlushSkin() {
 		bool applySkin = (lastVType_ & GE_VTYPE_WEIGHT_MASK) && decOptions_.applySkinInDecode;
 		if (applySkin) {
@@ -292,4 +296,5 @@ protected:
 	Plane planes_[6];
 	Vec2f minOffset_;
 	Vec2f maxOffset_;
+	bool offsetOutsideEdge_;
 };

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -69,11 +69,11 @@ public:
 	virtual void SendDataToShader(const SimpleVertex *const *points, int size_u, int size_v, u32 vertType, const Spline::Weight2D &weights) = 0;
 };
 
-// Culling plane.
-struct Plane {
-	float x, y, z, w;
-	void Set(float _x, float _y, float _z, float _w) { x = _x; y = _y; z = _z; w = _w; }
-	float Test(const float f[3]) const { return x * f[0] + y * f[1] + z * f[2] + w; }
+// Culling plane, group of 8.
+struct alignas(16) Plane8 {
+	float x[8], y[8], z[8], w[8];
+	void Set(int i, float _x, float _y, float _z, float _w) { x[i] = _x; y[i] = _y; z[i] = _z; w[i] = _w; }
+	float Test(int i, const float f[3]) const { return x[i] * f[0] + y[i] * f[1] + z[i] * f[2] + w[i]; }
 };
 
 class DrawEngineCommon {
@@ -293,7 +293,7 @@ protected:
 	TessellationDataTransfer *tessDataTransfer;
 
 	// Culling
-	Plane planes_[6];
+	Plane8 planes_;
 	Vec2f minOffset_;
 	Vec2f maxOffset_;
 	bool offsetOutsideEdge_;

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -76,6 +76,7 @@ struct GPUStatistics {
 	void ResetFrame() {
 		numDrawCalls = 0;
 		numVertexDecodes = 0;
+		numCulledDraws = 0;
 		numDrawSyncs = 0;
 		numListSyncs = 0;
 		numVertsSubmitted = 0;
@@ -111,6 +112,7 @@ struct GPUStatistics {
 	// Per frame statistics
 	int numDrawCalls;
 	int numVertexDecodes;
+	int numCulledDraws;
 	int numDrawSyncs;
 	int numListSyncs;
 	int numFlushes;

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1457,7 +1457,7 @@ void GPUCommonHW::Execute_WorldMtxNum(u32 op, u32 diff) {
 			if (dst[i] != newVal) {
 				Flush();
 				dst[i] = newVal;
-				gstate_c.Dirty(DIRTY_WORLDMATRIX | DIRTY_CULL_PLANES);
+				gstate_c.Dirty(DIRTY_WORLDMATRIX);
 			}
 			if (++i >= end) {
 				break;
@@ -1480,7 +1480,7 @@ void GPUCommonHW::Execute_WorldMtxData(u32 op, u32 diff) {
 	if (num < 12 && newVal != ((const u32 *)gstate.worldMatrix)[num]) {
 		Flush();
 		((u32 *)gstate.worldMatrix)[num] = newVal;
-		gstate_c.Dirty(DIRTY_WORLDMATRIX | DIRTY_CULL_PLANES);
+		gstate_c.Dirty(DIRTY_WORLDMATRIX);
 	}
 	num++;
 	gstate.worldmtxnum = (GE_CMD_WORLDMATRIXNUMBER << 24) | (num & 0x00FFFFFF);

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -998,7 +998,7 @@ void GPUCommonHW::Execute_Prim(u32 op, u32 diff) {
 	bool passCulling = PASSES_CULLING;
 	if (!passCulling) {
 		// Do software culling.
-		if (drawEngineCommon_->TestBoundingBox(verts, inds, count, vertexType)) {
+		if (drawEngineCommon_->TestBoundingBoxFast(verts, count, vertexType)) {
 			passCulling = true;
 		} else {
 			gpuStats.numCulledDraws++;

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -992,7 +992,16 @@ void GPUCommonHW::Execute_Prim(u32 op, u32 diff) {
 
 #define MAX_CULL_CHECK_COUNT 6
 
+// For now, turn off culling on platforms where we don't have SIMD bounding box tests, like RISC-V.
+#if PPSSPP_ARCH(ARM_NEON) || PPSSPP_ARCH(SSE2)
+
 #define PASSES_CULLING ((vertexType & (GE_VTYPE_THROUGH_MASK | GE_VTYPE_MORPHCOUNT_MASK | GE_VTYPE_WEIGHT_MASK | GE_VTYPE_IDX_MASK)) || count > MAX_CULL_CHECK_COUNT)
+
+#else
+
+#define PASSES_CULLING true
+
+#endif
 
 	// If certain conditions are true, do frustum culling.
 	bool passCulling = PASSES_CULLING;

--- a/UWP/CommonUWP/CommonUWP.vcxproj
+++ b/UWP/CommonUWP/CommonUWP.vcxproj
@@ -105,6 +105,7 @@
     <ClInclude Include="..\..\Common\File\AndroidStorage.h" />
     <ClInclude Include="..\..\Common\GPU\GPUBackendCommon.h" />
     <ClInclude Include="..\..\Common\GPU\Vulkan\VulkanLoader.h" />
+    <ClInclude Include="..\..\Common\Math\CrossSIMD.h" />
     <ClInclude Include="..\..\Common\Math\Statistics.h" />
     <ClInclude Include="..\..\Common\Net\HTTPNaettRequest.h" />
     <ClInclude Include="..\..\Common\Net\HTTPRequest.h" />

--- a/UWP/CommonUWP/CommonUWP.vcxproj.filters
+++ b/UWP/CommonUWP/CommonUWP.vcxproj.filters
@@ -862,6 +862,9 @@
     <ClInclude Include="..\..\ext\naett\naett.h">
       <Filter>ext\naett</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\Common\Math\CrossSIMD.h">
+      <Filter>Math</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\Common\Math\fast\fast_matrix_neon.S">

--- a/ppsspp_config.h
+++ b/ppsspp_config.h
@@ -11,6 +11,7 @@
 #if defined(_M_IX86) || defined(__i386__) || defined (__EMSCRIPTEN__)
     #define PPSSPP_ARCH_X86 1
     #define PPSSPP_ARCH_32BIT 1
+    #define PPSSPP_ARCH_SSE2 1
     //TODO: Remove this compat define
     #ifndef _M_IX86
         #define _M_IX86 600
@@ -19,6 +20,7 @@
 
 #if (defined(_M_X64) || defined(__amd64__) || defined(__x86_64__)) && !defined(__EMSCRIPTEN__)
     #define PPSSPP_ARCH_AMD64 1
+    #define PPSSPP_ARCH_SSE2 1
     #if defined(__ILP32__)
         #define PPSSPP_ARCH_32BIT 1
     #else


### PR DESCRIPTION
This is an experiment, some games do a poor job of culling stuff, and some transparent sprites can be very expensive if they cause a framebuffer copy. Skipping them if outside the viewport makes sense in that case. We simply re-use the bbox code for now, though this could be optimized.

~~We are simply re-using the BBOX culling code, which is not very efficient.~~

One example is the flame sprites in #17797 .

~~!!!! Not for merging! It seems our culling isn't completely accurate and needs work. In GTA:LCS for example, some triangles intersecting the screen edges get culled by mistake. However it also manages to cull 600 draw calls per frame in that game (that inefficient water).~~ Actually, my logic was just busted. It works!

Additionally, we should be able to cull through-mode draws easily, this one doesn't even try.

Anyway, there are a few ways we can go with this:

* Check draws for culling only if weird blend/logic modes are enabled
* Check small draws only for culling, but always do it

In many games, the number of draws culled is very small since games do a good job themselves. In other games, the draws culled can be pretty high. Avoiding draws entirely can save a lot of work doing things like texture binding etc, but this will not be beneficial for all games due to the extra work (plus, the culling code needs a lot of optimization if we're gonna apply it widely).

~~Also just realized that if applied widely, this is going to seriously mess with the vertex cache when we try to cache merged sequences of draw calls - if parts of one of those gets culled, there'll be a lot of combinations...~~ The vertex cache is now gone, so not a concern.

Ended up doing culling in view space so we don't need to update the planes for every new world matrix, and additionally, SIMD-optimized the thing carefully. Now it's very fast and generally a win.