### PR TITLE
Cleanup IR cond move flag, fmov to self

### DIFF
--- a/Core/MIPS/IR/IRCompFPU.cpp
+++ b/Core/MIPS/IR/IRCompFPU.cpp
@@ -152,7 +152,8 @@ void IRFrontend::Comp_FPU2op(MIPSOpcode op) {
 		ir.Write(IROp::FAbs, fd, fs);
 		break;
 	case 6:	//F(fd)	   = F(fs);                   break; //mov
-		ir.Write(IROp::FMov, fd, fs);
+		if (fd != fs)
+			ir.Write(IROp::FMov, fd, fs);
 		break;
 	case 7:	//F(fd)	   = -F(fs);                  break; //neg
 		ir.Write(IROp::FNeg, fd, fs);

--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -238,7 +238,7 @@ namespace MIPSComp {
 				} else {
 					if (negate)
 						ir.Write(IROp::FNeg, vregs[i], origV[regnum]);
-					else
+					else if (vregs[i] != origV[regnum])
 						ir.Write(IROp::FMov, vregs[i], origV[regnum]);
 				}
 			} else {
@@ -855,7 +855,8 @@ namespace MIPSComp {
 			switch (optype) {
 			case 0: // d[i] = s[i]; break; //vmov
 				// Probably for swizzle.
-				ir.Write(IROp::FMov, tempregs[i], sregs[i]);
+				if (tempregs[i] != sregs[i])
+					ir.Write(IROp::FMov, tempregs[i], sregs[i]);
 				break;
 			case 1: // d[i] = fabsf(s[i]); break; //vabs
 				ir.Write(IROp::FAbs, tempregs[i], sregs[i]);
@@ -1171,7 +1172,8 @@ namespace MIPSComp {
 		}
 		for (int a = 0; a < n; a++) {
 			for (int b = 0; b < n; b++) {
-				ir.Write(IROp::FMov, dregs[a * 4 + b], sregs[a * 4 + b]);
+				if (dregs[a * 4 + b] != sregs[a * 4 + b])
+					ir.Write(IROp::FMov, dregs[a * 4 + b], sregs[a * 4 + b]);
 			}
 		}
 	}

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -269,21 +269,21 @@ void DisassembleParam(char *buf, int bufSize, u8 param, char type, u32 constant)
 		break;
 	case 'F':
 		if (param >= 32) {
-			snprintf(buf, bufSize, "v%d", param - 32);
+			snprintf(buf, bufSize, "vf%d", param - 32);
 		} else {
 			snprintf(buf, bufSize, "f%d", param);
 		}
 		break;
 	case 'V':
 		if (param >= 32) {
-			snprintf(buf, bufSize, "v%d..v%d", param - 32, param - 32 + 3);
+			snprintf(buf, bufSize, "vf%d..vf%d", param - 32, param - 32 + 3);
 		} else {
 			snprintf(buf, bufSize, "f%d..f%d", param, param + 3);
 		}
 		break;
 	case '2':
 		if (param >= 32) {
-			snprintf(buf, bufSize, "v%d,v%d", param - 32, param - 32 + 1);
+			snprintf(buf, bufSize, "vf%d,vf%d", param - 32, param - 32 + 1);
 		} else {
 			snprintf(buf, bufSize, "f%d,f%d", param, param + 1);
 		}

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -122,7 +122,7 @@ static const IRMeta irMeta[] = {
 	{ IROp::SetCtrlVFPU, "SetCtrlVFPU", "TC" },
 	{ IROp::SetCtrlVFPUReg, "SetCtrlVFPUReg", "TG" },
 	{ IROp::SetCtrlVFPUFReg, "SetCtrlVFPUFReg", "TF" },
-	{ IROp::FCmovVfpuCC, "FCmovVfpuCC", "FFI" },
+	{ IROp::FCmovVfpuCC, "FCmovVfpuCC", "FFI", IRFLAG_SRC3DST },
 	{ IROp::FCmpVfpuBit, "FCmpVfpuBit", "IFF" },
 	{ IROp::FCmpVfpuAggregate, "FCmpVfpuAggregate", "I" },
 	{ IROp::Vec4Init, "Vec4Init", "Vv" },

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -128,7 +128,9 @@ bool OptimizeFPMoves(const IRWriter &in, IRWriter &out, const IROptions &opts) {
 			if (prev.op == IROp::FMovToGPR && prev.dest == inst.src1) {
 				inst.op = IROp::FMov;
 				inst.src1 = prev.src1;
-				out.Write(inst);
+				// Skip it entirely if it's just a copy to and back.
+				if (inst.dest != inst.src1)
+					out.Write(inst);
 			} else {
 				out.Write(inst);
 			}

--- a/Core/MIPS/RiscV/RiscVCompFPU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompFPU.cpp
@@ -179,8 +179,10 @@ void RiscVJit::CompIR_FAssign(IRInst inst) {
 
 	switch (inst.op) {
 	case IROp::FMov:
-		fpr.MapDirtyIn(inst.dest, inst.src1);
-		FMV(32, fpr.R(inst.dest), fpr.R(inst.src1));
+		if (inst.dest != inst.src1) {
+			fpr.MapDirtyIn(inst.dest, inst.src1);
+			FMV(32, fpr.R(inst.dest), fpr.R(inst.src1));
+		}
 		break;
 
 	case IROp::FAbs:


### PR DESCRIPTION
Just cleans up a few weird things seen in IR.  The self-fmovs sometimes happen in popular blocks, but don't seem to be that common.

-[Unknown]