### PR TITLE
Build: Fix link issue for rv64 disasm

### DIFF
--- a/Core/MIPS/RiscV/RiscVAsm.cpp
+++ b/Core/MIPS/RiscV/RiscVAsm.cpp
@@ -232,10 +232,12 @@ void RiscVJit::GenerateFixedCode(const JitOptions &jo) {
 
 	// Leave this at the end, add more stuff above.
 	if (enableDisasm) {
+#if PPSSPP_ARCH(RISCV64)
 		std::vector<std::string> lines = DisassembleRV64(start, GetCodePtr() - start);
 		for (auto s : lines) {
 			INFO_LOG(JIT, "%s", s.c_str());
 		}
+#endif
 	}
 
 	// Let's spare the pre-generated code from unprotect-reprotect.

--- a/Core/MIPS/RiscV/RiscVJit.cpp
+++ b/Core/MIPS/RiscV/RiscVJit.cpp
@@ -652,9 +652,11 @@ void RiscVBlockCacheDebugInterface::GetBlockCodeRange(int blockNum, int *startOf
 JitBlockDebugInfo RiscVBlockCacheDebugInterface::GetBlockDebugInfo(int blockNum) const {
 	JitBlockDebugInfo debugInfo = irBlocks_.GetBlockDebugInfo(blockNum);
 
+#if PPSSPP_ARCH(RISCV64)
 	int blockOffset, codeSize;
 	GetBlockCodeRange(blockNum, &blockOffset, &codeSize);
 	debugInfo.targetDisasm = DisassembleRV64(jit_.GetBasePtr() + blockOffset, codeSize);
+#endif
 	return debugInfo;
 }
 


### PR DESCRIPTION
Gradle failing on the buildbot, somehow pulling this in.  DisassembleRV64 ends up not defined on arm64.

-[Unknown]