### PR TITLE
Switch the naett submodule back to the upstream repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -49,4 +49,4 @@
 	url = https://github.com/RetroAchievements/rcheevos.git
 [submodule "ext/naett"]
 	path = ext/naett
-	url = https://github.com/hrydgard/naett.git
+	url = https://github.com/erkkah/naett.git


### PR DESCRIPTION
All my recent PRs are in now:

- https://github.com/erkkah/naett/pull/19

- https://github.com/erkkah/naett/pull/23 (replaced /18)

- https://github.com/erkkah/naett/pull/17