### PR TITLE
Vulkan: Don't use multithreaded rendering if buffer commands (frames in flight) is set to 1

### DIFF
--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -843,7 +843,6 @@ public:
 
 	// Total amount of frames rendered. Unaffected by game pause, so more robust than gpuStats.numFlips
 	virtual int GetFrameCount() = 0;
-	virtual int GetFramesInFlight() { return 3; }
 
 protected:
 	ShaderModule *vsPresets_[VS_MAX_PRESET];

--- a/SDL/SDLVulkanGraphicsContext.cpp
+++ b/SDL/SDLVulkanGraphicsContext.cpp
@@ -136,7 +136,11 @@ bool SDLVulkanGraphicsContext::Init(SDL_Window *&window, int x, int y, int w, in
 		return false;
 	}
 
-	draw_ = Draw::T3DCreateVulkanContext(vulkan_, g_Config.bRenderMultiThreading);
+	bool useMultiThreading = g_Config.bRenderMultiThreading;
+	if (g_Config.iInflightFrames == 1) {
+		useMultiThreading = false;
+	}
+	draw_ = Draw::T3DCreateVulkanContext(vulkan_, useMultiThreading);
 	SetGPUBackend(GPUBackend::VULKAN);
 	bool success = draw_->CreatePresets();
 	_assert_(success);

--- a/Windows/GPU/WindowsVulkanContext.cpp
+++ b/Windows/GPU/WindowsVulkanContext.cpp
@@ -131,7 +131,12 @@ bool WindowsVulkanContext::Init(HINSTANCE hInst, HWND hWnd, std::string *error_m
 		return false;
 	}
 
-	draw_ = Draw::T3DCreateVulkanContext(vulkan_, g_Config.bRenderMultiThreading);
+	bool useMultiThreading = g_Config.bRenderMultiThreading;
+	if (g_Config.iInflightFrames == 1) {
+		useMultiThreading = false;
+	}
+
+	draw_ = Draw::T3DCreateVulkanContext(vulkan_, useMultiThreading);
 	SetGPUBackend(GPUBackend::VULKAN, vulkan_->GetPhysicalDeviceProperties(deviceNum).properties.deviceName);
 	bool success = draw_->CreatePresets();
 	_assert_msg_(success, "Failed to compile preset shaders");

--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -113,7 +113,11 @@ bool AndroidVulkanContext::InitFromRenderThread(ANativeWindow *wnd, int desiredB
 
 	bool success = true;
 	if (g_Vulkan->InitSwapchain()) {
-		draw_ = Draw::T3DCreateVulkanContext(g_Vulkan, g_Config.bRenderMultiThreading);
+		bool useMultiThreading = g_Config.bRenderMultiThreading;
+		if (g_Config.iInflightFrames == 1) {
+			useMultiThreading = false;
+		}
+		draw_ = Draw::T3DCreateVulkanContext(g_Vulkan, useMultiThreading);
 		SetGPUBackend(GPUBackend::VULKAN);
 		success = draw_->CreatePresets();  // Doesn't fail, we ship the compiler.
 		_assert_msg_(success, "Failed to compile preset shaders");

--- a/libretro/LibretroVulkanContext.cpp
+++ b/libretro/LibretroVulkanContext.cpp
@@ -139,7 +139,11 @@ void LibretroVulkanContext::CreateDrawContext() {
       return;
    }
 
-   draw_ = Draw::T3DCreateVulkanContext(vk, true);
+   bool useMultiThreading = g_Config.bRenderMultiThreading;
+   if (g_Config.iInflightFrames == 1) {
+      useMultiThreading = false;
+   }
+   draw_ = Draw::T3DCreateVulkanContext(vk, useMultiThreading);
    ((VulkanRenderManager*)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER))->SetInflightFrames(g_Config.iInflightFrames);
    SetGPUBackend(GPUBackend::VULKAN);
 }


### PR DESCRIPTION
Let's turn it off in this particular case, as it then has no benefit (no overlapping processing), and loses by a few percent in simple benchmarking.

We'll still keep the dev option to turn off multithreading for other cases if desired, but there's not much point in exposing it more, I think - this is the one case where it's a positive.

A little bit hard to centralize the logic since it's kinda spread out between the context and render manager.

Will make it cleaner at a later point, there's some refactoring I want to do in this area.