### PR TITLE
Vulkan: Keep track of a short history of some timestamps in each frame

### DIFF
--- a/Common/Data/Collections/FastVec.h
+++ b/Common/Data/Collections/FastVec.h
@@ -155,3 +155,16 @@ private:
 	bool capacityLocked_ = false;
 #endif
 };
+
+// Simple cyclical vector.
+// Initially, doesn't do any sanity checking.
+template <class T, size_t size>
+class HistoryBuffer {
+public:
+	// Out of bounds (past size() - 1) is undefined behavior.
+	T &operator[] (const size_t index) { return data_[index % size]; }
+	const T &operator[] (const size_t index) const { return data_[index % size]; }
+
+private:
+	T data_[size]{};
+};

--- a/Common/Data/Collections/FixedSizeQueue.h
+++ b/Common/Data/Collections/FixedSizeQueue.h
@@ -222,4 +222,3 @@ private:
 	volatile int curReadBlock;
 	volatile int curWriteBlock;
 };
-

--- a/Common/GPU/MiscTypes.h
+++ b/Common/GPU/MiscTypes.h
@@ -2,6 +2,8 @@
 
 #include "Common/Common.h"
 
+// Flags and structs shared between backends that haven't found a good home.
+
 enum class InvalidationFlags {
 	CACHED_RENDER_STATE = 1,
 };
@@ -14,3 +16,12 @@ enum class InvalidationCallbackFlags {
 ENUM_CLASS_BITOPS(InvalidationCallbackFlags);
 
 typedef std::function<void(InvalidationCallbackFlags)> InvalidationCallback;
+
+// These are separate from FrameData because we store some history of these.
+// Also, this might be joined with more non-GPU timing information later.
+struct FrameTimeData {
+	double frameBegin;
+	double afterFenceWait;
+	double firstSubmit;
+	double queuePresent;
+};

--- a/Common/GPU/Vulkan/VulkanFrameData.h
+++ b/Common/GPU/Vulkan/VulkanFrameData.h
@@ -95,6 +95,10 @@ struct FrameData {
 	// Swapchain.
 	uint32_t curSwapchainImage = -1;
 
+	// Frames need unique IDs to wait for present on, let's keep them here.
+	// Also used for indexing into the frame timing history buffer.
+	uint64_t frameId;
+
 	// Profiling.
 	QueueProfileContext profile{};
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -17,6 +17,7 @@
 #include "Common/System/Display.h"
 #include "Common/GPU/Vulkan/VulkanContext.h"
 #include "Common/Data/Convert/SmallDataConvert.h"
+#include "Common/Data/Collections/FastVec.h"
 #include "Common/Math/math_util.h"
 #include "Common/GPU/DataFormat.h"
 #include "Common/GPU/MiscTypes.h"
@@ -456,6 +457,17 @@ public:
 	void ResetStats();
 	void DrainCompileQueue();
 
+	// framesBack is the number of frames into the past to look.
+	FrameTimeData GetFrameTimeData(int framesBack) const {
+		FrameTimeData data;
+		if (framesBack >= frameIdGen_) {
+			data = {};
+			return data;
+		}
+		data = frameTimeData_[frameIdGen_ - framesBack];
+		return data;
+	}
+
 private:
 	void EndCurRenderStep();
 
@@ -532,4 +544,7 @@ private:
 	SimpleStat renderCPUTimeMs_;
 
 	std::function<void(InvalidationCallbackFlags)> invalidationCallback_;
+
+	uint64_t frameIdGen_ = 31;
+	HistoryBuffer<FrameTimeData, 32> frameTimeData_;
 };

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -487,6 +487,10 @@ public:
 		return frameCount_;
 	}
 
+	FrameTimeData GetFrameTimeData(int framesBack) const override {
+		return renderManager_.GetFrameTimeData(framesBack);
+	}
+
 	void FlushState() override {}
 
 	void ResetStats() override {

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -844,6 +844,10 @@ public:
 	// Total amount of frames rendered. Unaffected by game pause, so more robust than gpuStats.numFlips
 	virtual int GetFrameCount() = 0;
 
+	virtual FrameTimeData GetFrameTimeData(int framesBack) const {
+		return FrameTimeData{};
+	}
+
 protected:
 	ShaderModule *vsPresets_[VS_MAX_PRESET];
 	ShaderModule *fsPresets_[FS_MAX_PRESET];

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -461,8 +461,10 @@ public:
 	bool bDisplayStatusBar;
 	bool bShowBottomTabTitles;
 	bool bShowDeveloperMenu;
+
 	// Double edged sword: much easier debugging, but not accurate.
 	bool bSkipDeadbeefFilling;
+
 	bool bFuncHashMap;
 	std::string sSkipFuncHashMap;
 	bool bDebugMemInfoDetailed;
@@ -470,6 +472,7 @@ public:
 	// Volatile development settings
 	// Overlays
 	DebugOverlay iDebugOverlay;
+
 	bool bGpuLogProfiler; // Controls the Vulkan logging profiler (profiles textures uploads etc).
 
 	// Retro Achievement settings

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -180,6 +180,7 @@ enum class DebugOverlay : int {
 	OFF,
 	DEBUG_STATS,
 	FRAME_GRAPH,
+	FRAME_TIMING,
 #ifdef USE_PROFILER
 	FRAME_PROFILE,
 #endif

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -92,6 +92,7 @@ static const char *g_debugOverlayList[] = {
 	"Off",
 	"Debug stats",
 	"Draw Frametimes Graph",
+	"Frame timing",
 #ifdef USE_PROFILER
 	"Frame profile",
 #endif

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -310,6 +310,7 @@ Enter address = Enter address
 FPU = FPU
 Framedump tests = Framedump tests
 Frame Profiler = Frame profiler
+Frame timing = Frame timing
 GPU Driver Test = GPU driver test
 GPU Profile = GPU profile
 GPU log profiler = GPU log profiler


### PR DESCRIPTION
Sets up the framework to store some timestamps from a short history of recent frames. There's also a simple overlay to show some of it.

To this, I'll soon add the results from VK_KHR_present_wait in a different PR (I'll have a thread that just sits and waits for every present, and writes the timing into this buffer).

Later, that will be used as an input of the solution to #17685 .