### PR TITLE
Vulkan: Use VK_KHR_present_wait to get numbers on how much latency we have to the screen

### DIFF
--- a/Common/GPU/MiscTypes.h
+++ b/Common/GPU/MiscTypes.h
@@ -24,4 +24,5 @@ struct FrameTimeData {
 	double afterFenceWait;
 	double firstSubmit;
 	double queuePresent;
+	double actualPresent;
 };

--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -598,6 +598,7 @@ void VulkanContext::ChooseDevice(int physical_device) {
 		features2.pNext = &multiViewFeatures;
 		multiViewFeatures.pNext = &presentWaitFeatures;
 		presentWaitFeatures.pNext = &presentIdFeatures;
+		presentIdFeatures.pNext = nullptr;
 
 		vkGetPhysicalDeviceFeatures2KHR(physical_devices_[physical_device_], &features2);
 		deviceFeatures_.available.standard = features2.features;
@@ -709,6 +710,9 @@ VkResult VulkanContext::CreateDevice() {
 		device_info.pNext = &features2;
 		features2.features = deviceFeatures_.enabled.standard;
 		features2.pNext = &deviceFeatures_.enabled.multiview;
+		deviceFeatures_.enabled.multiview.pNext = &deviceFeatures_.enabled.presentWait;
+		deviceFeatures_.enabled.presentWait.pNext = &deviceFeatures_.enabled.presentId;
+		deviceFeatures_.enabled.presentId.pNext = nullptr;
 	} else {
 		device_info.pEnabledFeatures = &deviceFeatures_.enabled.standard;
 	}

--- a/Common/GPU/Vulkan/VulkanDebug.cpp
+++ b/Common/GPU/Vulkan/VulkanDebug.cpp
@@ -82,6 +82,10 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDebugUtilsCallback(
 		// Extended validation (ARM best practices)
 		// Non-fifo validation not recommended
 		return false;
+	case 337425955:
+		// False positive
+		// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3615
+		return false;
 	default:
 		break;
 	}

--- a/Common/GPU/Vulkan/VulkanFrameData.cpp
+++ b/Common/GPU/Vulkan/VulkanFrameData.cpp
@@ -110,6 +110,13 @@ VkResult FrameData::QueuePresent(VulkanContext *vulkan, FrameDataShared &shared)
 	present.pWaitSemaphores = &shared.renderingCompleteSemaphore;
 	present.waitSemaphoreCount = 1;
 
+	VkPresentIdKHR presentID{ VK_STRUCTURE_TYPE_PRESENT_ID_KHR };
+	if (vulkan->Extensions().KHR_present_id && vulkan->GetDeviceFeatures().enabled.presentId.presentId) {
+		presentID.pPresentIds = &frameID;
+		presentID.swapchainCount = 1;
+		present.pNext = &presentID;
+	}
+
 	return vkQueuePresentKHR(vulkan->GetGraphicsQueue(), &present);
 }
 

--- a/Common/GPU/Vulkan/VulkanFrameData.h
+++ b/Common/GPU/Vulkan/VulkanFrameData.h
@@ -72,6 +72,7 @@ struct FrameData {
 	std::mutex fenceMutex;
 	std::condition_variable fenceCondVar;
 	bool readyForFence = true;
+	uint64_t frameID;  // always incrementing, set at the start of each frame.
 
 	VkFence fence = VK_NULL_HANDLE;
 

--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -223,11 +223,14 @@ PFN_vkCmdInsertDebugUtilsLabelEXT	 vkCmdInsertDebugUtilsLabelEXT;
 PFN_vkSetDebugUtilsObjectNameEXT     vkSetDebugUtilsObjectNameEXT;
 PFN_vkSetDebugUtilsObjectTagEXT      vkSetDebugUtilsObjectTagEXT;
 
+// Assorted other extensions.
 PFN_vkGetBufferMemoryRequirements2KHR vkGetBufferMemoryRequirements2KHR;
 PFN_vkGetImageMemoryRequirements2KHR vkGetImageMemoryRequirements2KHR;
 PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR;
 PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR;
 PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR;
+PFN_vkWaitForPresentKHR vkWaitForPresentKHR;
+
 } // namespace PPSSPP_VK
 
 using namespace PPSSPP_VK;
@@ -725,6 +728,7 @@ void VulkanLoadDeviceFunctions(VkDevice device, const VulkanExtensions &enabledE
 	LOAD_DEVICE_FUNC(device, vkCmdNextSubpass);
 	LOAD_DEVICE_FUNC(device, vkCmdEndRenderPass);
 	LOAD_DEVICE_FUNC(device, vkCmdExecuteCommands);
+	LOAD_DEVICE_FUNC(device, vkWaitForPresentKHR);
 
 	if (enabledExtensions.KHR_dedicated_allocation) {
 		LOAD_DEVICE_FUNC(device, vkGetBufferMemoryRequirements2KHR);

--- a/Common/GPU/Vulkan/VulkanLoader.h
+++ b/Common/GPU/Vulkan/VulkanLoader.h
@@ -235,6 +235,7 @@ extern PFN_vkGetMemoryHostPointerPropertiesEXT vkGetMemoryHostPointerPropertiesE
 extern PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR;
 extern PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR;
 extern PFN_vkCreateRenderPass2KHR vkCreateRenderPass2KHR;
+extern PFN_vkWaitForPresentKHR vkWaitForPresentKHR;
 } // namespace PPSSPP_VK
 
 // For fast extension-enabled checks.

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -480,6 +480,8 @@ private:
 	void FlushSync();
 	void StopThread();
 
+	void PresentWaitThreadFunc();
+
 	FrameDataShared frameDataShared_;
 
 	FrameData frameData_[VulkanContext::MAX_INFLIGHT_FRAMES];
@@ -534,6 +536,9 @@ private:
 	std::condition_variable compileCond_;
 	std::mutex compileMutex_;
 	std::vector<CompileQueueEntry> compileQueue_;
+
+	// Thread for measuring presentation delay.
+	std::thread presentWaitThread_;
 
 	// pipelines to check and possibly create at the end of the current render pass.
 	std::vector<VKRGraphicsPipeline *> pipelinesToCheck_;

--- a/UI/DebugOverlay.cpp
+++ b/UI/DebugOverlay.cpp
@@ -112,15 +112,24 @@ static void DrawFrameTiming(UIContext *ctx, const Bounds &bounds) {
 		double fenceLatency_s = data.afterFenceWait - data.frameBegin;
 		double submitLatency_s = data.firstSubmit - data.frameBegin;
 		double queuePresentLatency_s = data.queuePresent - data.frameBegin;
+		double actualPresentLatency_s = data.actualPresent - data.frameBegin;
 
+		char presentStats[256] = "";
+		if (data.actualPresent != 0.0) {
+			snprintf(presentStats, sizeof(presentStats),
+				"* Actual present: %0.1f ms\n",
+				actualPresentLatency_s * 1000.0);
+		}
 		snprintf(statBuf, sizeof(statBuf),
 			"Time from start of frame to event:\n"
 			"* Past the fence: %0.1f ms\n"
 			"* First submit: %0.1f ms\n"
-			"* Queue-present: %0.1f ms\n",
+			"* Queue-present: %0.1f ms\n"
+			"%s",
 			fenceLatency_s * 1000.0,
 			submitLatency_s * 1000.0,
-			queuePresentLatency_s * 1000.0
+			queuePresentLatency_s * 1000.0,
+			presentStats
 		);
 	}
 


### PR DESCRIPTION
This extension is not available on Android, there they have VK_GOOGLE_display_timing, which they also have an abstraction library for, so will look at that later.

From a 30hz game on Windows:

![image](https://github.com/hrydgard/ppsspp/assets/130929/54b6c768-48a1-4ba9-ae22-10881d2c0b6d)

This is pretty bad, and this is on a 90hz monitor where we won't end up queueing very many frames...

EDIT: It's not quite as bad as it looks, presentation delay is showing an extra frame here due to a frame ID bug.

When fast forwarding, the latency drops to like 7ms. This means that by dynamically measuring and inserting appropriate waits early in our frames (ideally before the fence), instead of wherever the sceDisplay timing stuff happens, we can get latency a lot lower. However, this will also mean that sensitivity to minor hitches will increase, so we'll need to make it configurable.

Early part of work on #17685