### PR TITLE
Linux/Mac/iOS: time_now_d(): Switch from gettimeofday() to clock_gettime(CLOCK_MONOTONIC)

### DIFF
--- a/Common/TimeUtil.h
+++ b/Common/TimeUtil.h
@@ -1,7 +1,13 @@
 #pragma once
 
+#include <cstdint>
+
 // Seconds.
 double time_now_d();
+
+// Raw time in nanoseconds.
+// The only intended use is to match the timings from VK_GOOGLE_display_timing.
+uint64_t time_now_raw();
 
 // Sleep. Does not necessarily have millisecond granularity, especially on Windows.
 void sleep_ms(int ms);


### PR DESCRIPTION
Linux here includes Android.

More appropriate, and adds a raw function that can be used to match up exactly with VK_GOOGLE_display_timing.