### PR TITLE
SDL: text renderer fixes, and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,7 +225,7 @@ jobs:
       run: |
         sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe restricted multiverse"
         sudo apt-get update -y -qq
-        sudo apt-get install libsdl2-dev libgl1-mesa-dev libglu1-mesa-dev
+        sudo apt-get install libsdl2-dev libgl1-mesa-dev libglu1-mesa-dev libsdl2-ttf-dev libfontconfig1-dev
 
     - name: Create macOS git-version.cpp for tagged release
       if: startsWith(github.ref, 'refs/tags/') && runner.os == 'macOS' && matrix.extra == 'test'


### PR DESCRIPTION
1. Since `ALIGN_LEFT == 0`, the `if (align & ALIGN_LEFT)` case is never hit. This leads to unintended text alignment sometimes... (See the homebrew description in screenshot) 

2. SDL_ttf pads the rendered text to the right a lot, which is the reason why in some buttons, you can see their labels getting pushed to the left. Fortunately though, the `text->w` field stores the exact width of the text we rendered, hence instead using an entire row of pixels, we use only the pixels right up to `text->w` (rounded up a little).

3. Added dependencies sdl2_ttf and fontconfig to Linux CI. 

Master:
![image](https://github.com/hrydgard/ppsspp/assets/7030150/db630826-45ff-45e0-bdd3-2c3f2d5543d1)

PR:
![image](https://github.com/hrydgard/ppsspp/assets/7030150/83811465-87dc-4c03-bc61-e861ac8ac5dd)
