### PR TITLE
Debug overlay everywhere

### DIFF
--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -492,6 +492,10 @@ public:
 		renderManager_.SetInvalidationCallback(callback);
 	}
 
+	std::string GetGpuProfileString() const override {
+		return renderManager_.GetGpuProfileString();
+	}
+
 private:
 	void ApplySamplers();
 

--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -291,6 +291,13 @@ public:
 		return device_extensions_enabled_;
 	}
 
+	const std::vector<VkExtensionProperties> &GetInstanceExtensionsAvailable() const {
+		return instance_extension_properties_;
+	}
+	const std::vector<const char *> &GetInstanceExtensionsEnabled() const {
+		return instance_extensions_enabled_;
+	}
+
 	const VkPhysicalDeviceMemoryProperties &GetMemoryProperties() const {
 		return memory_properties_;
 	}
@@ -314,7 +321,6 @@ public:
 		for (const auto &iter : instance_layer_properties_) {
 			for (const auto &ext : iter.extensions) {
 				if (!strcmp(extensionName, ext.extensionName)) {
-					INFO_LOG(G3D, "%s found in layer extensions: %s", extensionName, iter.properties.layerName);
 					return true;
 				}
 			}

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -531,6 +531,10 @@ public:
 		renderManager_.SetInvalidationCallback(callback);
 	}
 
+	std::string GetGpuProfileString() const override {
+		return renderManager_.GetGpuProfileString();
+	}
+
 private:
 	VulkanTexture *GetNullTexture();
 	VulkanContext *vulkan_ = nullptr;

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -517,7 +517,7 @@ public:
 	VkDescriptorSet GetOrCreateDescriptorSet(VkBuffer buffer);
 
 	std::vector<std::string> GetFeatureList() const override;
-	std::vector<std::string> GetExtensionList(bool enabledOnly) const override;
+	std::vector<std::string> GetExtensionList(bool device, bool enabledOnly) const override;
 
 	uint64_t GetNativeObject(NativeObject obj, void *srcObject) override;
 
@@ -1630,14 +1630,14 @@ std::vector<std::string> VKContext::GetFeatureList() const {
 	return features;
 }
 
-std::vector<std::string> VKContext::GetExtensionList(bool enabledOnly) const {
+std::vector<std::string> VKContext::GetExtensionList(bool device, bool enabledOnly) const {
 	std::vector<std::string> extensions;
 	if (enabledOnly) {
-		for (auto &iter : vulkan_->GetDeviceExtensionsEnabled()) {
+		for (auto &iter : (device ? vulkan_->GetDeviceExtensionsEnabled() : vulkan_->GetInstanceExtensionsEnabled())) {
 			extensions.push_back(iter);
 		}
 	} else {
-		for (auto &iter : vulkan_->GetDeviceExtensionsAvailable()) {
+		for (auto &iter : (device ? vulkan_->GetDeviceExtensionsAvailable() : vulkan_->GetInstanceExtensionsAvailable())) {
 			extensions.push_back(iter.extensionName);
 		}
 	}

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -848,6 +848,10 @@ public:
 		return FrameTimeData{};
 	}
 
+	virtual std::string GetGpuProfileString() const {
+		return "";
+	}
+
 protected:
 	ShaderModule *vsPresets_[VS_MAX_PRESET];
 	ShaderModule *fsPresets_[FS_MAX_PRESET];

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -691,7 +691,7 @@ public:
 	virtual const DeviceCaps &GetDeviceCaps() const = 0;
 	virtual uint32_t GetDataFormatSupport(DataFormat fmt) const = 0;
 	virtual std::vector<std::string> GetFeatureList() const { return std::vector<std::string>(); }
-	virtual std::vector<std::string> GetExtensionList(bool enabledOnly) const { return std::vector<std::string>(); }
+	virtual std::vector<std::string> GetExtensionList(bool device, bool enabledOnly) const { return std::vector<std::string>(); }
 	virtual std::vector<std::string> GetDeviceList() const { return std::vector<std::string>(); }
 
 	virtual PresentationMode GetPresentationMode() const = 0;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -179,6 +179,7 @@ static const ConfigSetting generalSettings[] = {
 	ConfigSetting("CwCheatRefreshRate", &g_Config.iCwCheatRefreshRate, 77, CfgFlag::PER_GAME),
 	ConfigSetting("CwCheatScrollPosition", &g_Config.fCwCheatScrollPosition, 0.0f, CfgFlag::PER_GAME),
 	ConfigSetting("GameListScrollPosition", &g_Config.fGameListScrollPosition, 0.0f, CfgFlag::DEFAULT),
+	ConfigSetting("DebugOverlay", &g_Config.iDebugOverlay, 0, CfgFlag::DONT_SAVE),
 
 	ConfigSetting("ScreenshotsAsPNG", &g_Config.bScreenshotsAsPNG, false, CfgFlag::PER_GAME),
 	ConfigSetting("UseFFV1", &g_Config.bUseFFV1, false, CfgFlag::DEFAULT),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -471,7 +471,7 @@ public:
 
 	// Volatile development settings
 	// Overlays
-	DebugOverlay iDebugOverlay;
+	int iDebugOverlay;
 
 	bool bGpuLogProfiler; // Controls the Vulkan logging profiler (profiles textures uploads etc).
 

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -496,7 +496,7 @@ static void DoFrameIdleTiming() {
 #endif
 		}
 
-		if (g_Config.iDebugOverlay == DebugOverlay::FRAME_GRAPH || coreCollectDebugStats) {
+		if ((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::FRAME_GRAPH || coreCollectDebugStats) {
 			DisplayNotifySleep(time_now_d() - before);
 		}
 	}
@@ -662,7 +662,7 @@ void __DisplayFlip(int cyclesLate) {
 		CoreTiming::ScheduleEvent(0 - cyclesLate, afterFlipEvent, 0);
 		numVBlanksSinceFlip = 0;
 
-		if (g_Config.iDebugOverlay == DebugOverlay::FRAME_GRAPH || coreCollectDebugStats) {
+		if ((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::FRAME_GRAPH || coreCollectDebugStats) {
 			// Track how long we sleep (whether vsync or sleep_ms.)
 			DisplayNotifySleep(time_now_d() - frameSleepStart, frameSleepPos);
 		}
@@ -726,7 +726,7 @@ void hleLagSync(u64 userdata, int cyclesLate) {
 	const int over = (int)((now - goal) * 1000000);
 	ScheduleLagSync(over - emuOver);
 
-	if (g_Config.iDebugOverlay == DebugOverlay::FRAME_GRAPH || coreCollectDebugStats) {
+	if ((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::FRAME_GRAPH || coreCollectDebugStats) {
 		DisplayNotifySleep(now - before);
 	}
 }

--- a/Core/HW/Display.cpp
+++ b/Core/HW/Display.cpp
@@ -92,7 +92,7 @@ static void CalculateFPS() {
 		}
 	}
 
-	if (g_Config.iDebugOverlay == DebugOverlay::FRAME_GRAPH || coreCollectDebugStats) {
+	if ((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::FRAME_GRAPH || coreCollectDebugStats) {
 		frameTimeHistory[frameTimeHistoryPos++] = now - lastFrameTimeHistory;
 		lastFrameTimeHistory = now;
 		frameTimeHistoryPos = frameTimeHistoryPos % frameTimeHistorySize;
@@ -182,6 +182,10 @@ void DisplayNotifySleep(double t, int pos) {
 
 void __DisplayGetDebugStats(char *stats, size_t bufsize) {
 	char statbuf[4096];
+	if (!gpu) {
+		snprintf(stats, bufsize, "N/A");
+		return;
+	}
 	gpu->GetStats(statbuf, sizeof(statbuf));
 
 	snprintf(stats, bufsize,

--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -252,14 +252,6 @@ public:
 	virtual bool GetOutputFramebuffer(GPUDebugBuffer &buffer) {
 		return false;
 	}
-
-	// TODO:
-	// cached framebuffers / textures / vertices?
-	// get content of specific framebuffer / texture?
-	// vertex / texture decoding?
-
-	// Note: Wanted to name it GetProfileString but clashes with a Windows API.
-	virtual std::string GetGpuProfileString() { return ""; }
 };
 
 bool GPUDebugInitExpression(GPUDebugInterface *g, const char *str, PostfixExpression &exp);

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -142,7 +142,7 @@ void TextureCacheCommon::StartFrame() {
 	timesInvalidatedAllThisFrame_ = 0;
 	replacementTimeThisFrame_ = 0.0;
 
-	if (g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS) {
+	if ((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS) {
 		gpuStats.numReplacerTrackedTex = replacer_.GetNumTrackedTextures();
 		gpuStats.numCachedReplacedTextures = replacer_.GetNumCachedReplacedTextures();
 	}

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -309,8 +309,3 @@ void GPU_GLES::GetStats(char *buffer, size_t bufsize) {
 		shaderManagerGL_->GetNumPrograms()
 	);
 }
-
-std::string GPU_GLES::GetGpuProfileString() {
-	GLRenderManager *rm = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
-	return rm->GetGpuProfileString();
-}

--- a/GPU/GLES/GPU_GLES.h
+++ b/GPU/GLES/GPU_GLES.h
@@ -51,8 +51,6 @@ public:
 	void BeginHostFrame() override;
 	void EndHostFrame() override;
 
-	std::string GetGpuProfileString() override;
-
 protected:
 	void FinishDeferred() override;
 

--- a/GPU/Vulkan/DebugVisVulkan.cpp
+++ b/GPU/Vulkan/DebugVisVulkan.cpp
@@ -98,9 +98,6 @@ void DrawGPUMemoryVis(UIContext *ui, GPUInterface *gpu) {
 }
 
 void DrawGPUProfilerVis(UIContext *ui, GPUInterface *gpu) {
-	if (!gpu) {
-		return;
-	}
 	using namespace Draw;
 	const int padding = 10 + System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_LEFT);
 	const int starty = 50 + System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_TOP);
@@ -115,8 +112,7 @@ void DrawGPUProfilerVis(UIContext *ui, GPUInterface *gpu) {
 		scale = 0.7f;
 	}
 
-	GPUCommon *gpuCommon = static_cast<GPUCommon *>(gpu);
-	std::string text = gpuCommon->GetGpuProfileString();
+	std::string text = ui->GetDrawContext()->GetGpuProfileString();
 
 	ui->SetFontScale(0.4f, 0.4f);
 	ui->DrawTextShadow(text.c_str(), x, y, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -499,8 +499,3 @@ std::string GPU_Vulkan::DebugGetShaderString(std::string id, DebugShaderType typ
 		return GPUCommonHW::DebugGetShaderString(id, type, stringType);
 	}
 }
-
-std::string GPU_Vulkan::GetGpuProfileString() {
-	VulkanRenderManager *rm = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
-	return rm->GetGpuProfileString();
-}

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -59,8 +59,6 @@ public:
 		return textureCacheVulkan_;
 	}
 
-	std::string GetGpuProfileString() override;
-
 protected:
 	void FinishDeferred() override;
 	void CheckRenderResized() override;

--- a/SDL/CocoaBarItems.mm
+++ b/SDL/CocoaBarItems.mm
@@ -545,9 +545,9 @@ TOGGLE_METHOD(FullScreen, g_Config.bFullScreen, System_MakeRequest(SystemRequest
 
 -(void)toggleShowDebugStats: (NSMenuItem *)item { \
     if ((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS) {
-        g_Config.iDebugOverlay = DebugOverlay::OFF;
+        g_Config.iDebugOverlay = (int)DebugOverlay::OFF;
     } else {
-        g_Config.iDebugOverlay = DebugOverlay::DEBUG_STATS;
+        g_Config.iDebugOverlay = (int)DebugOverlay::DEBUG_STATS;
     }
     System_PostUIMessage("clear jit", "");
     item.state = [self controlStateForBool: (DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS]; \

--- a/SDL/CocoaBarItems.mm
+++ b/SDL/CocoaBarItems.mm
@@ -217,7 +217,7 @@ void OSXOpenURL(const char *url) {
                     item.state = [self controlStateForBool:g_Config.bIgnoreBadMemAccess];
                     break;
                 case 12:
-                    item.state = [self controlStateForBool:g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS];
+                    item.state = [self controlStateForBool:(DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS];
                     break;
                 default:
                     item.enabled = state == UISTATE_INGAME ? YES : NO;
@@ -405,7 +405,7 @@ void OSXOpenURL(const char *url) {
     copyBaseAddr.target = self;
     copyBaseAddr.tag = 11;
 
-    MENU_ITEM(showDebugStatsAction, DESKTOPUI_LOCALIZED("Show Debug Statistics"), @selector(toggleShowDebugStats:), (g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS), 12)
+    MENU_ITEM(showDebugStatsAction, DESKTOPUI_LOCALIZED("Show Debug Statistics"), @selector(toggleShowDebugStats:), ((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS), 12)
 
     [parent addItem:loadSymbolMapAction];
     [parent addItem:saveMapFileAction];
@@ -544,13 +544,13 @@ TOGGLE_METHOD(FullScreen, g_Config.bFullScreen, System_MakeRequest(SystemRequest
 #undef TOGGLE_METHOD
 
 -(void)toggleShowDebugStats: (NSMenuItem *)item { \
-    if (g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS) {
+    if ((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS) {
         g_Config.iDebugOverlay = DebugOverlay::OFF;
     } else {
         g_Config.iDebugOverlay = DebugOverlay::DEBUG_STATS;
     }
     System_PostUIMessage("clear jit", "");
-    item.state = [self controlStateForBool: g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS]; \
+    item.state = [self controlStateForBool: (DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS]; \
 }
 
 -(void)setToggleShowCounterItem: (NSMenuItem *)item {

--- a/UI/DebugOverlay.cpp
+++ b/UI/DebugOverlay.cpp
@@ -150,7 +150,11 @@ static void DrawFrameTiming(UIContext *ctx, const Bounds &bounds) {
 	ctx->RebindTexture();
 }
 
-void DrawDebugOverlay(UIContext *ctx, const Bounds &bounds, const ControlMapper &controlMapper, DebugOverlay overlay) {
+void DrawControlMapperOverlay(UIContext *ctx, const Bounds &bounds, const ControlMapper &controlMapper) {
+	DrawControlDebug(ctx, controlMapper, ctx->GetLayoutBounds());
+}
+
+void DrawDebugOverlay(UIContext *ctx, const Bounds &bounds, DebugOverlay overlay) {
 	switch (overlay) {
 	case DebugOverlay::DEBUG_STATS:
 		DrawDebugStats(ctx, ctx->GetLayoutBounds());
@@ -164,11 +168,7 @@ void DrawDebugOverlay(UIContext *ctx, const Bounds &bounds, const ControlMapper 
 	case DebugOverlay::AUDIO:
 		DrawAudioDebugStats(ctx, ctx->GetLayoutBounds());
 		break;
-	case DebugOverlay::CONTROL:
-		DrawControlDebug(ctx, controlMapper, ctx->GetLayoutBounds());
-		break;
 #if !PPSSPP_PLATFORM(UWP) && !PPSSPP_PLATFORM(SWITCH)
-
 	case DebugOverlay::GPU_PROFILE:
 		if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN || g_Config.iGPUBackend == (int)GPUBackend::OPENGL) {
 			DrawGPUProfilerVis(ctx, gpu);
@@ -180,5 +180,7 @@ void DrawDebugOverlay(UIContext *ctx, const Bounds &bounds, const ControlMapper 
 		}
 		break;
 #endif
+	default:
+		break;
 	}
 }

--- a/UI/DebugOverlay.h
+++ b/UI/DebugOverlay.h
@@ -4,4 +4,5 @@
 #include "Core/ConfigValues.h"
 #include "Core/ControlMapper.h"
 
-void DrawDebugOverlay(UIContext *ctx, const Bounds &bounds, const ControlMapper &controlMapper, DebugOverlay overlay);
+void DrawControlMapperOverlay(UIContext *ctx, const Bounds &bounds, const ControlMapper &controlMapper);
+void DrawDebugOverlay(UIContext *ctx, const Bounds &bounds, DebugOverlay overlay);

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -790,14 +790,29 @@ void SystemInfoScreen::CreateTabs() {
 #endif
 
 		CollapsibleSection *enabledExtensions = gpuExtensions->Add(new CollapsibleSection(std::string(si->T("Vulkan Extensions")) + " (" + di->T("Enabled") + ")"));
-		std::vector<std::string> extensions = draw->GetExtensionList(true);
+		std::vector<std::string> extensions = draw->GetExtensionList(true, true);
+		std::sort(extensions.begin(), extensions.end());
+		for (auto &extension : extensions) {
+			enabledExtensions->Add(new TextView(extension, new LayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetFocusable(true);
+		}
+		// Also get instance extensions
+		enabledExtensions->Add(new ItemHeader("Instance"));
+		extensions = draw->GetExtensionList(false, true);
 		std::sort(extensions.begin(), extensions.end());
 		for (auto &extension : extensions) {
 			enabledExtensions->Add(new TextView(extension, new LayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetFocusable(true);
 		}
 
 		CollapsibleSection *vulkanExtensions = gpuExtensions->Add(new CollapsibleSection(si->T("Vulkan Extensions")));
-		extensions = draw->GetExtensionList(false);
+		extensions = draw->GetExtensionList(true, false);
+		std::sort(extensions.begin(), extensions.end());
+		for (auto &extension : extensions) {
+			vulkanExtensions->Add(new TextView(extension, new LayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetFocusable(true);
+		}
+
+		vulkanExtensions->Add(new ItemHeader("Instance"));
+		// Also get instance extensions
+		extensions = draw->GetExtensionList(false, false);
 		std::sort(extensions.begin(), extensions.end());
 		for (auto &extension : extensions) {
 			vulkanExtensions->Add(new TextView(extension, new LayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetFocusable(true);

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -776,7 +776,7 @@ void SystemInfoScreen::CreateTabs() {
 			if (mode == vk->GetPresentMode()) {
 				str += std::string(" (") + di->T("Current") + ")";
 			}
-			presentModes->Add(new TextView(VulkanPresentModeToString(mode), new LayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetFocusable(true);
+			presentModes->Add(new TextView(str, new LayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetFocusable(true);
 		}
 
 		CollapsibleSection *colorFormats = gpuExtensions->Add(new CollapsibleSection(si->T("Display Color Formats")));

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1427,7 +1427,7 @@ void EmuScreen::render() {
 		}
 	}
 
-	Core_UpdateDebugStats(g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS || g_Config.bLogFrameDrops);
+	Core_UpdateDebugStats((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS || g_Config.bLogFrameDrops);
 
 	bool blockedExecution = Achievements::IsBlockingExecution();
 	if (!blockedExecution) {
@@ -1503,7 +1503,7 @@ bool EmuScreen::hasVisibleUI() {
 	if (g_Config.bEnableCardboardVR || g_Config.bEnableNetworkChat)
 		return true;
 	// Debug UI.
-	if (g_Config.iDebugOverlay != DebugOverlay::OFF)
+	if ((DebugOverlay)g_Config.iDebugOverlay != DebugOverlay::OFF)
 		return true;
 
 	// Exception information.
@@ -1538,8 +1538,9 @@ void EmuScreen::renderUI() {
 	}
 
 	if (!invalid_) {
-		DrawDebugOverlay(ctx, ctx->GetLayoutBounds(), controlMapper_, g_Config.iDebugOverlay);
-
+		if ((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::CONTROL) {
+			DrawControlMapperOverlay(ctx, ctx->GetLayoutBounds(), controlMapper_);
+		}
 		if (g_Config.iShowStatusFlags) {
 			DrawFPS(ctx, ctx->GetLayoutBounds());
 		}

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1098,7 +1098,7 @@ void NativeRender(GraphicsContext *graphicsContext) {
 	g_screenManager->getUIContext()->SetTintSaturation(g_Config.fUITint, g_Config.fUISaturation);
 
 	Draw::DebugFlags debugFlags = Draw::DebugFlags::NONE;
-	if (g_Config.iDebugOverlay == DebugOverlay::GPU_PROFILE)
+	if ((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::GPU_PROFILE)
 		debugFlags |= Draw::DebugFlags::PROFILE_TIMESTAMPS;
 	if (g_Config.bGpuLogProfiler)
 		debugFlags |= Draw::DebugFlags::PROFILE_SCOPES;

--- a/UI/OnScreenDisplay.cpp
+++ b/UI/OnScreenDisplay.cpp
@@ -10,6 +10,7 @@
 #include "Common/Math/math_util.h"
 #include "Common/UI/IconCache.h"
 #include "UI/RetroAchievementScreens.h"
+#include "UI/DebugOverlay.h"
 
 #include "Common/UI/Context.h"
 #include "Common/System/OSD.h"
@@ -454,6 +455,18 @@ void OSDOverlayScreen::CreateViews() {
 	root_ = new UI::AnchorLayout();
 	root_->SetTag("OSDOverlayScreen");
 	root_->Add(new OnScreenMessagesView(new UI::AnchorLayoutParams(0.0f, 0.0f, 0.0f, 0.0f)));
+}
+
+void OSDOverlayScreen::render() {
+	UIScreen::render();
+
+	DebugOverlay debugOverlay = (DebugOverlay)g_Config.iDebugOverlay;
+
+	// Special case control for now, since it uses the control mapper that's owned by EmuScreen.
+	if (debugOverlay != DebugOverlay::OFF && debugOverlay != DebugOverlay::CONTROL) {
+		UIContext *uiContext = screenManager()->getUIContext();
+		DrawDebugOverlay(uiContext, uiContext->GetLayoutBounds(), debugOverlay);
+	}
 }
 
 void NoticeView::GetContentDimensionsBySpec(const UIContext &dc, UI::MeasureSpec horiz, UI::MeasureSpec vert, float &w, float &h) const {

--- a/UI/OnScreenDisplay.h
+++ b/UI/OnScreenDisplay.h
@@ -28,6 +28,7 @@ class OSDOverlayScreen : public UIScreen {
 public:
 	const char *tag() const override { return "OSDOverlayScreen"; }
 	void CreateViews() override;
+	void render() override;
 };
 
 enum class NoticeLevel {

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -711,10 +711,10 @@ namespace MainWindow {
 		case ID_DEBUG_SHOWDEBUGSTATISTICS:
 			// This is still useful as a shortcut to tell users to use.
 			// So let's fake the enum.
-			if (g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS) {
-				g_Config.iDebugOverlay = DebugOverlay::OFF;
+			if ((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS) {
+				g_Config.iDebugOverlay = (int)DebugOverlay::OFF;
 			} else {
-				g_Config.iDebugOverlay = DebugOverlay::DEBUG_STATS;
+				g_Config.iDebugOverlay = (int)DebugOverlay::DEBUG_STATS;
 			}
 			System_PostUIMessage("clear jit", "");
 			break;
@@ -964,7 +964,7 @@ namespace MainWindow {
 		HMENU menu = GetMenu(GetHWND());
 #define CHECKITEM(item,value) 	CheckMenuItem(menu,item,MF_BYCOMMAND | ((value) ? MF_CHECKED : MF_UNCHECKED));
 		CHECKITEM(ID_DEBUG_IGNOREILLEGALREADS, g_Config.bIgnoreBadMemAccess);
-		CHECKITEM(ID_DEBUG_SHOWDEBUGSTATISTICS, g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS);
+		CHECKITEM(ID_DEBUG_SHOWDEBUGSTATISTICS, (DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS);
 		CHECKITEM(ID_OPTIONS_HARDWARETRANSFORM, g_Config.bHardwareTransform);
 		CHECKITEM(ID_DEBUG_BREAKONLOAD, !g_Config.bAutoRun);
 		CHECKITEM(ID_OPTIONS_VERTEXCACHE, g_Config.bVertexCache);

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -234,7 +234,7 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, const
 
 	System_Notify(SystemNotification::BOOT_DONE);
 
-	Core_UpdateDebugStats(g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS || g_Config.bLogFrameDrops);
+	Core_UpdateDebugStats((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::DEBUG_STATS || g_Config.bLogFrameDrops);
 
 	PSP_BeginHostFrame();
 	Draw::DrawContext *draw = coreParameter.graphicsContext ? coreParameter.graphicsContext->GetDrawContext() : nullptr;


### PR DESCRIPTION
Moves debug overlays to the OSDOverlayScreen, so we can get frame timing info even if you're just sitting in the menu.

Also makes it possible to pre-configure a debug overlay in the ini, manually. This is not a runtime setting though.

Additionally, we now show instance extensions. This allows you to easily tell if you managed to enable validation layers by looking for VK_EXT_debug_utils.

I can see that we have up to 100ms latency on a Poco F1 when just scrolling around the menu, if buffer frames == 2. I'll start by improving that next, I think...