### PR TITLE
Buildfix for VS2017

### DIFF
--- a/Core/MIPS/IR/IRAnalysis.cpp
+++ b/Core/MIPS/IR/IRAnalysis.cpp
@@ -17,6 +17,10 @@
 
 #include "Core/MIPS/IR/IRAnalysis.h"
 
+// For std::min
+#include <algorithm>
+
+
 static bool IRReadsFrom(const IRInst &inst, int reg, char type, bool directly = false) {
 	const IRMeta *m = GetIRMeta(inst.op);
 

--- a/UI/DebugOverlay.cpp
+++ b/UI/DebugOverlay.cpp
@@ -10,6 +10,10 @@
 // TODO: This should be moved here or to Common, doesn't belong in /GPU
 #include "GPU/Vulkan/DebugVisVulkan.h"
 
+// For std::max
+#include <algorithm>
+
+
 static void DrawDebugStats(UIContext *ctx, const Bounds &bounds) {
 	FontID ubuntu24("UBUNTU24");
 


### PR DESCRIPTION
Neither vector nor utility include the algorithm header, so I'm confused why this successfully builds on newer versions. Nonetheless, here's a buildfix.