### PR TITLE
Achievement list: Support the more detailed categorization.

### DIFF
--- a/UI/DebugOverlay.cpp
+++ b/UI/DebugOverlay.cpp
@@ -111,7 +111,7 @@ static void DrawFrameTiming(UIContext *ctx, const Bounds &bounds) {
 	for (int i = 0; i < 8; i++) {
 		FrameTimeData data = ctx->GetDrawContext()->GetFrameTimeData(6 + i);
 		if (data.frameBegin == 0.0) {
-			snprintf(statBuf, sizeof(statBuf), "(Frame timing collection not supported on this backend)");
+			snprintf(statBuf, sizeof(statBuf), "(No frame time data)");
 		} else {
 			double fenceLatency_s = data.afterFenceWait - data.frameBegin;
 			double submitLatency_s = data.firstSubmit - data.frameBegin;

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -32,6 +32,8 @@ Achievement progress = Achievement progress
 Achievements = Achievements
 Achievements enabled = Achievements enabled
 Achievements are disabled = Achievements are disabled
+Achievements with active challenges = Achievements with active challenges
+Almost completed achievements = Almost completed achievements
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now
 Challenge indicator = Challenge indicator
 Challenge Mode = Challenge Mode
@@ -55,6 +57,7 @@ Log bad memory accesses = Log bad memory accesses
 Mastered %1 = Mastered %1
 Around me = Around me
 Notifications = Notifications
+Recently unlocked achievements = Recently unlocked achievements
 Register on www.retroachievements.org = Register on www.retroachievements.org
 RetroAchievements are not available for this game = RetroAchievements are not available for this game
 RetroAchievements website = RetroAchievements website
@@ -70,6 +73,7 @@ This feature is not available in Challenge Mode = This feature is not available 
 This game has no achievements = This game has no achievements
 Top players = Top players
 Unlocked achievements = Unlocked achievements
+Unsupported achievements = Unsupported achievements
 Unofficial achievements = Unofficial achievements
 
 [Audio]


### PR DESCRIPTION
rc_client provides RC_CLIENT_ACHIEVEMENT_LIST_GROUPING_PROGRESS,  which has some additional categories.

Should resolve the feature request by RANDOMPLAYER1 at the bottom of the OP at #17631 .