### PR TITLE
irjit: Fix mfvc eating prefixes

### DIFF
--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -1013,6 +1013,10 @@ namespace MIPSComp {
 	void IRFrontend::Comp_Mftv(MIPSOpcode op) {
 		CONDITIONAL_DISABLE(VFPU_XFER);
 
+		// Vector move from VFPU / from VFPU ctrl (no prefixes)
+		// gpr = S
+		// gpr = VFPU_CTRL[i]
+
 		int imm = op & 0xFF;
 		MIPSGPReg rt = _RT;
 		switch ((op >> 21) & 0x1f) {
@@ -1067,8 +1071,6 @@ namespace MIPSComp {
 		default:
 			INVALIDOP;
 		}
-		// This op is marked not to auto-eat prefix so we must do it manually.
-		EatPrefix();
 	}
 
 	void IRFrontend::Comp_Vmfvc(MIPSOpcode op) {

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -716,6 +716,20 @@ bool PropagateConstants(const IRWriter &in, IRWriter &out, const IROptions &opts
 			break;
 
 		case IROp::SetCtrlVFPU:
+			gpr.MapDirty(IRREG_VFPU_CTRL_BASE + inst.dest);
+			goto doDefault;
+
+		case IROp::SetCtrlVFPUReg:
+			if (gpr.IsImm(inst.src1)) {
+				out.Write(IROp::SetCtrlVFPU, inst.dest, out.AddConstant(gpr.GetImm(inst.src1)));
+			} else {
+				gpr.MapDirtyIn(IRREG_VFPU_CTRL_BASE + inst.dest, inst.src1);
+				out.Write(inst);
+			}
+			break;
+
+		case IROp::SetCtrlVFPUFReg:
+			gpr.MapDirty(IRREG_VFPU_CTRL_BASE + inst.dest);
 			goto doDefault;
 
 		case IROp::FCvtWS:
@@ -775,6 +789,18 @@ bool PropagateConstants(const IRWriter &in, IRWriter &out, const IROptions &opts
 
 		case IROp::VfpuCtrlToReg:
 			gpr.MapDirtyIn(inst.dest, IRREG_VFPU_CTRL_BASE + inst.src1);
+			goto doDefault;
+
+		case IROp::FCmpVfpuBit:
+			gpr.MapDirty(IRREG_VFPU_CC);
+			goto doDefault;
+
+		case IROp::FCmovVfpuCC:
+			gpr.MapIn(IRREG_VFPU_CC);
+			goto doDefault;
+
+		case IROp::FCmpVfpuAggregate:
+			gpr.MapDirtyIn(IRREG_VFPU_CC, IRREG_VFPU_CC);
 			goto doDefault;
 
 		case IROp::CallReplacement:

--- a/Core/MIPS/IR/IRRegCache.cpp
+++ b/Core/MIPS/IR/IRRegCache.cpp
@@ -1,4 +1,5 @@
 #include <cstring>
+#include "Common/Log.h"
 #include "Core/MIPS/IR/IRRegCache.h"
 #include "Core/MIPS/IR/IRInst.h"
 
@@ -7,6 +8,7 @@ void IRRegCache::Flush(IRReg rd) {
 		return;
 	}
 	if (reg_[rd].isImm) {
+		_assert_((rd > 0 && rd < 32) || (rd >= IRTEMP_0 && rd < IRREG_VFPU_CTRL_BASE));
 		ir_->WriteSetConstant(rd, reg_[rd].immVal);
 		reg_[rd].isImm = false;
 	}


### PR DESCRIPTION
Also cleanup the pass that propagates imms to consistently handle VFPU ctrl regs, as it does fpcond.

-[Unknown]