### PR TITLE
irjit: Use Vec4 a bit more

### DIFF
--- a/Core/MIPS/IR/IRCompFPU.cpp
+++ b/Core/MIPS/IR/IRCompFPU.cpp
@@ -226,7 +226,8 @@ void IRFrontend::Comp_mxc1(MIPSOpcode op) {
 			UpdateRoundingMode();
 			ApplyRoundingMode();
 		} else {
-			Comp_Generic(op);
+			// Maybe not strictly invalid?  But likely invalid.
+			INVALIDOP;
 		}
 		return;
 	default:

--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -782,6 +782,10 @@ namespace MIPSComp {
 		if (optype == 0) {
 			if (js.HasUnknownPrefix() || !IsPrefixWithinSize(js.prefixS, op))
 				DISABLE;
+		} else if (optype == 1 || optype == 2) {
+			// D prefix is fine for these, and used sometimes.
+			if (js.HasUnknownPrefix() || js.HasSPrefix())
+				DISABLE;
 		} else {
 			// Many of these apply the D prefix strangely or override parts of the S prefix.
 			if (!js.HasNoPrefix())

--- a/Core/MIPS/IR/IRFrontend.h
+++ b/Core/MIPS/IR/IRFrontend.h
@@ -126,7 +126,8 @@ private:
 	void CompShiftVar(MIPSOpcode op, IROp shiftType);
 
 	void ApplyPrefixST(u8 *vregs, u32 prefix, VectorSize sz, int tempReg);
-	void ApplyPrefixD(const u8 *vregs, VectorSize sz);
+	void ApplyPrefixD(u8 *vregs, VectorSize sz, int vectorReg);
+	void ApplyPrefixDMask(u8 *vregs, VectorSize sz, int vectorReg);
 	void GetVectorRegsPrefixS(u8 *regs, VectorSize sz, int vectorReg);
 	void GetVectorRegsPrefixT(u8 *regs, VectorSize sz, int vectorReg);
 	void GetVectorRegsPrefixD(u8 *regs, VectorSize sz, int vectorReg);

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -126,6 +126,7 @@ static const IRMeta irMeta[] = {
 	{ IROp::FCmpVfpuAggregate, "FCmpVfpuAggregate", "I" },
 	{ IROp::Vec4Init, "Vec4Init", "Vv" },
 	{ IROp::Vec4Shuffle, "Vec4Shuffle", "VVs" },
+	{ IROp::Vec4Blend, "Vec4Blend", "VVVC" },
 	{ IROp::Vec4Mov, "Vec4Mov", "VV" },
 	{ IROp::Vec4Add, "Vec4Add", "VVV" },
 	{ IROp::Vec4Sub, "Vec4Sub", "VVV" },
@@ -328,14 +329,20 @@ void DisassembleIR(char *buf, size_t bufsize, IRInst inst) {
 	char bufDst[16];
 	char bufSrc1[16];
 	char bufSrc2[16];
+	// Only really used for constant.
+	char bufSrc3[16];
 	DisassembleParam(bufDst, sizeof(bufDst) - 2, inst.dest, meta->types[0], inst.constant);
 	DisassembleParam(bufSrc1, sizeof(bufSrc1) - 2, inst.src1, meta->types[1], inst.constant);
 	DisassembleParam(bufSrc2, sizeof(bufSrc2), inst.src2, meta->types[2], inst.constant);
+	DisassembleParam(bufSrc3, sizeof(bufSrc3), inst.src3, meta->types[3], inst.constant);
 	if (meta->types[1] && meta->types[0] != '_') {
 		strcat(bufDst, ", ");
 	}
 	if (meta->types[2] && meta->types[1] != '_') {
 		strcat(bufSrc1, ", ");
 	}
-	snprintf(buf, bufsize, "%s %s%s%s", meta->name, bufDst, bufSrc1, bufSrc2);
+	if (meta->types[3] && meta->types[2] != '_') {
+		strcat(bufSrc2, ", ");
+	}
+	snprintf(buf, bufsize, "%s %s%s%s%s", meta->name, bufDst, bufSrc1, bufSrc2, bufSrc3);
 }

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -164,6 +164,7 @@ enum class IROp : u8 {
 	// support SIMD.
 	Vec4Init,
 	Vec4Shuffle,
+	Vec4Blend,
 	Vec4Mov,
 	Vec4Add,
 	Vec4Sub,
@@ -330,7 +331,7 @@ enum IRFlags {
 struct IRMeta {
 	IROp op;
 	const char *name;
-	const char types[4];  // GGG
+	const char types[5];  // GGG
 	u32 flags;
 };
 

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -304,13 +304,17 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 		}
 
 		case IROp::Vec4Shuffle:
-		{
 			// Can't use the SSE shuffle here because it takes an immediate. pshufb with a table would work though,
 			// or a big switch - there are only 256 shuffles possible (4^4)
 			for (int i = 0; i < 4; i++)
 				mips->f[inst->dest + i] = mips->f[inst->src1 + ((inst->src2 >> (i * 2)) & 3)];
 			break;
-		}
+
+		case IROp::Vec4Blend:
+			// Could use _mm_blendv_ps (SSE4+BMI), vbslq_f32 (ARM), __riscv_vmerge_vvm (RISC-V)
+			for (int i = 0; i < 4; i++)
+				mips->f[inst->dest + i] = ((inst->constant >> i) & 1) ? mips->f[inst->src2 + i] : mips->f[inst->src1 + i];
+			break;
 
 		case IROp::Vec4Mov:
 		{

--- a/Core/MIPS/IR/IRNativeCommon.cpp
+++ b/Core/MIPS/IR/IRNativeCommon.cpp
@@ -299,6 +299,7 @@ void IRNativeBackend::CompileIRInst(IRInst inst) {
 
 	case IROp::Vec4Init:
 	case IROp::Vec4Shuffle:
+	case IROp::Vec4Blend:
 	case IROp::Vec4Mov:
 		CompIR_VecAssign(inst);
 		break;

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -750,6 +750,7 @@ bool PropagateConstants(const IRWriter &in, IRWriter &out, const IROptions &opts
 		case IROp::Vec4Dot:
 		case IROp::Vec4Scale:
 		case IROp::Vec4Shuffle:
+		case IROp::Vec4Blend:
 		case IROp::Vec4Neg:
 		case IROp::Vec4Abs:
 		case IROp::Vec4Pack31To8:

--- a/Core/MIPS/RiscV/RiscVCompVec.cpp
+++ b/Core/MIPS/RiscV/RiscVCompVec.cpp
@@ -117,6 +117,14 @@ void RiscVJitBackend::CompIR_VecAssign(IRInst inst) {
 		}
 		break;
 
+	case IROp::Vec4Blend:
+		fpr.Map4DirtyInIn(inst.dest, inst.src1, inst.src2);
+		for (int i = 0; i < 4; ++i) {
+			int which = (inst.constant >> i) & 1;
+			FMV(32, fpr.R(inst.dest + i), fpr.R((which ? inst.src2 : inst.src1) + i));
+		}
+		break;
+
 	case IROp::Vec4Mov:
 		fpr.Map4DirtyIn(inst.dest, inst.src1);
 		for (int i = 0; i < 4; ++i)


### PR DESCRIPTION
This introduces a Vec4Blend op, which on clang seems to optimally use fcsel even without simd, so may already be a perf improvement.

This is used to keep Vec4 when masking, when using a prefix to zero out certain source reg lanes, etc.  Also implemented vqmul using it.  Was considering a Vec4BlendVfpuCC to do the same but not from a constant, although it'll be slightly a pain to expand that (most will want 0xFFFFFFFF for lanes we want B and 0 for lanes we want A.)

-[Unknown]