### PR TITLE
Don't crash if VK_KHR_present_id / VK_KHR_present_wait are not exposed

### DIFF
--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -543,6 +543,8 @@ void VulkanRenderManager::ThreadFunc() {
 void VulkanRenderManager::PresentWaitThreadFunc() {
 	SetCurrentThreadName("PresentWait");
 
+	_dbg_assert_(vkWaitForPresentKHR != nullptr);
+
 	uint64_t waitedId = frameIdGen_;
 	while (run_) {
 		const uint64_t timeout = 1000000000ULL;  // 1 sec


### PR DESCRIPTION
...but feature still reported available. Weirdness in Intel driver.

Fixes the new crash in #17858