### PR TITLE
Add yield() function to tell the CPU that we're busy-waiting (rare)

### DIFF
--- a/Common/TimeUtil.cpp
+++ b/Common/TimeUtil.cpp
@@ -19,8 +19,8 @@
 #endif
 
 // for _mm_pause
-#ifdef _M_SSE
-#include <emmintrin.h>
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+#include <immintrin.h>
 #endif
 
 #include <ctime>
@@ -96,7 +96,7 @@ double from_time_raw_relative(uint64_t raw_time) {
 }
 
 void yield() {
-#if PPSSPP_ARCH(AMD64)
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 	_mm_pause();
 #elif PPSSPP_ARCH(ARM64)
 	__builtin_arm_isb(15);

--- a/Common/TimeUtil.cpp
+++ b/Common/TimeUtil.cpp
@@ -17,6 +17,12 @@
 #include <sys/time.h>
 #include <unistd.h>
 #endif
+
+// for _mm_pause
+#ifdef _M_SSE
+#include <emmintrin.h>
+#endif
+
 #include <ctime>
 
 // TODO: https://github.com/floooh/sokol/blob/9a6237fcdf213e6da48e4f9201f144bcb2dcb46f/sokol_time.h#L229-L248
@@ -24,7 +30,7 @@
 static const double micros = 1000000.0;
 static const double nanos = 1000000000.0;
 
-#ifdef _WIN32
+#if PPSSPP_PLATFORM(WINDOWS)
 
 static LARGE_INTEGER frequency;
 static double frequencyMult;
@@ -58,6 +64,10 @@ double from_time_raw_relative(uint64_t raw_time) {
 	return from_time_raw(raw_time);
 }
 
+void yield() {
+	YieldProcessor();
+}
+
 #elif PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(LINUX) || PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS)
 
 // The only intended use is to match the timings in VK_GOOGLE_display_timing
@@ -85,6 +95,14 @@ double from_time_raw_relative(uint64_t raw_time) {
 	return (double)raw_time * (1.0 / nanos);
 }
 
+void yield() {
+#if PPSSPP_ARCH(AMD64)
+	_mm_pause();
+#elif PPSSPP_ARCH(ARM64)
+	__builtin_arm_isb(15);
+#endif
+}
+
 #else
 
 double time_now_d() {
@@ -109,6 +127,8 @@ double from_time_raw(uint64_t raw_time) {
 double from_time_raw_relative(uint64_t raw_time) {
 	return from_time_raw(raw_time);
 }
+
+void yield() {}
 
 #endif
 

--- a/Common/TimeUtil.h
+++ b/Common/TimeUtil.h
@@ -16,6 +16,9 @@ double from_time_raw_relative(uint64_t raw_time);
 // Sleep. Does not necessarily have millisecond granularity, especially on Windows.
 void sleep_ms(int ms);
 
+// Yield. Signals that this thread is busy-waiting but wants to allow other hyperthreads to run.
+void yield();
+
 void GetTimeFormatted(char formattedTime[13]);
 
 // Rust-style Instant for clear and easy timing.

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -718,6 +718,8 @@ void hleLagSync(u64 userdata, int cyclesLate) {
 #ifndef _WIN32
 		const double left = goal - now;
 		usleep((long)(left * 1000000.0));
+#else
+		yield();
 #endif
 		now = time_now_d();
 	}

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -898,7 +898,7 @@ static UI::AnchorLayoutParams *AnchorInCorner(const Bounds &bounds, int corner, 
 	switch ((ScreenEdgePosition)g_Config.iChatButtonPosition) {
 	case ScreenEdgePosition::BOTTOM_LEFT:   return new AnchorLayoutParams(WRAP_CONTENT, WRAP_CONTENT, xOffset, NONE, NONE, yOffset, true);
 	case ScreenEdgePosition::BOTTOM_CENTER: return new AnchorLayoutParams(WRAP_CONTENT, WRAP_CONTENT, bounds.centerX(), NONE, NONE, yOffset, true);
-	case ScreenEdgePosition::BOTTOM_RIGHT:   return new AnchorLayoutParams(WRAP_CONTENT, WRAP_CONTENT, NONE, NONE, xOffset, yOffset, true);
+	case ScreenEdgePosition::BOTTOM_RIGHT:  return new AnchorLayoutParams(WRAP_CONTENT, WRAP_CONTENT, NONE, NONE, xOffset, yOffset, true);
 	case ScreenEdgePosition::TOP_LEFT:      return new AnchorLayoutParams(WRAP_CONTENT, WRAP_CONTENT, xOffset, yOffset, NONE, NONE, true);
 	case ScreenEdgePosition::TOP_CENTER:    return new AnchorLayoutParams(WRAP_CONTENT, WRAP_CONTENT, bounds.centerX(), yOffset, NONE, NONE, true);
 	case ScreenEdgePosition::TOP_RIGHT:     return new AnchorLayoutParams(WRAP_CONTENT, WRAP_CONTENT, NONE, yOffset, xOffset, NONE, true);


### PR DESCRIPTION
Use it only for the busy-wait in lag sync, which only happens in Windows. But just for good measure, add dummy or proper implementations of yield() for the other platforms as well.

Broke this out of a cancelled refactoring which I will do a different way than I first intended.