### PR TITLE
Fix mac bundle version string.

### DIFF
--- a/SDL/macbundle.sh
+++ b/SDL/macbundle.sh
@@ -35,11 +35,7 @@ install_name_tool -rpath "${RPATH}" "@executable_path/../Frameworks" "${PPSSPPSD
 
 echo "Done."
 
-GIT_VERSION_LINE=$(grep "PPSSPP_GIT_VERSION = " "$(dirname "${0}")/../git-version.cpp")
-# Hack, need to do something better here.
-if [ -z "$GIT_VERSION_LINE" ]; then
-  GIT_VERSION_LINE=$(grep "PPSSPP_GIT_VERSION = " "$(dirname "${0}")/../build/git-version.cpp")
-fi
+GIT_VERSION_LINE=$(grep "PPSSPP_GIT_VERSION = " "$(dirname "${0}")/../build/git-version.cpp")
 
 echo "Setting version to '${GIT_VERSION_LINE}'..."
 SHORT_VERSION_MATCH='.*"v([0-9\.]+(-[0-9]+)?).*";'


### PR DESCRIPTION
Make sure we don't read it from some left-behind git-version.cpp in the wrong directory.