### PR TITLE
RISC-V: Implement a few more ops

### DIFF
--- a/Common/RiscVEmitter.cpp
+++ b/Common/RiscVEmitter.cpp
@@ -1186,7 +1186,10 @@ void RiscVEmitter::QuickJAL(RiscVReg scratchreg, RiscVReg rd, const u8 *dst) {
 		int64_t pcdelta = (int64_t)dst - (int64_t)GetCodePointer();
 		int32_t lower = (int32_t)SignReduce64(pcdelta, 12);
 		uintptr_t upper = ((pcdelta - lower) >> 12) << 12;
-		LI(scratchreg, (uintptr_t)GetCodePointer() + upper);
+		if (scratchreg != rd)
+			LI(scratchreg, (uintptr_t)GetCodePointer() + upper, rd);
+		else
+			LI(scratchreg, (uintptr_t)GetCodePointer() + upper);
 		JALR(rd, scratchreg, lower);
 	} else {
 		JAL(rd, dst);

--- a/Common/RiscVEmitter.h
+++ b/Common/RiscVEmitter.h
@@ -217,13 +217,13 @@ public:
 	void QuickJ(RiscVReg scratchreg, const u8 *dst) {
 		QuickJAL(scratchreg, R_ZERO, dst);
 	}
-	void QuickCallFunction(const u8 *func) {
-		QuickJAL(R_RA, R_RA, func);
+	void QuickCallFunction(const u8 *func, RiscVReg scratchreg = R_RA) {
+		QuickJAL(scratchreg, R_RA, func);
 	}
 	template <typename T>
-	void QuickCallFunction(T *func) {
+	void QuickCallFunction(T *func, RiscVReg scratchreg = R_RA) {
 		static_assert(std::is_function<T>::value, "QuickCallFunction without function");
-		QuickCallFunction((const u8 *)func);
+		QuickCallFunction((const u8 *)func, scratchreg);
 	}
 
 	void LUI(RiscVReg rd, s32 simm32);

--- a/Core/MIPS/IR/IRNativeCommon.cpp
+++ b/Core/MIPS/IR/IRNativeCommon.cpp
@@ -394,7 +394,7 @@ IRNativeJit::IRNativeJit(MIPSState *mipsState)
 void IRNativeJit::Init(IRNativeBackend &backend) {
 	backend_ = &backend;
 	debugInterface_.Init(&backend_->CodeBlock());
-	backend_->GenerateFixedCode();
+	backend_->GenerateFixedCode(mips_);
 
 	// Wanted this to be a reference, but vtbls get in the way.  Shouldn't change.
 	hooks_ = backend.GetNativeHooks();

--- a/Core/MIPS/IR/IRNativeCommon.h
+++ b/Core/MIPS/IR/IRNativeCommon.h
@@ -56,7 +56,7 @@ public:
 	bool CodeInRange(const u8 *ptr) const;
 	int OffsetFromCodePtr(const u8 *ptr);
 
-	virtual void GenerateFixedCode() = 0;
+	virtual void GenerateFixedCode(MIPSState *mipsState) = 0;
 	virtual bool CompileBlock(IRBlock *block, int block_num, bool preload) = 0;
 	virtual void ClearAllBlocks() = 0;
 

--- a/Core/MIPS/RiscV/RiscVAsm.cpp
+++ b/Core/MIPS/RiscV/RiscVAsm.cpp
@@ -44,7 +44,7 @@ static void ShowPC(u32 downcount, void *membase, void *jitbase) {
 	count++;
 }
 
-void RiscVJitBackend::GenerateFixedCode() {
+void RiscVJitBackend::GenerateFixedCode(MIPSState *mipsState) {
 	BeginWrite(GetMemoryProtectPageSize());
 	const u8 *start = AlignCodePage();
 
@@ -120,7 +120,7 @@ void RiscVJitBackend::GenerateFixedCode() {
 
 	// Fixed registers, these are always kept when in Jit context.
 	LI(MEMBASEREG, Memory::base, SCRATCH1);
-	LI(CTXREG, mips_, SCRATCH1);
+	LI(CTXREG, mipsState, SCRATCH1);
 	LI(JITBASEREG, GetBasePtr(), SCRATCH1);
 
 	LoadStaticRegisters();

--- a/Core/MIPS/RiscV/RiscVAsm.cpp
+++ b/Core/MIPS/RiscV/RiscVAsm.cpp
@@ -131,7 +131,7 @@ void RiscVJitBackend::GenerateFixedCode(MIPSState *mipsState) {
 	// Advance can change the downcount (or thread), so must save/restore around it.
 	SaveStaticRegisters();
 	RestoreRoundingMode(true);
-	QuickCallFunction(&CoreTiming::Advance);
+	QuickCallFunction(&CoreTiming::Advance, X7);
 	ApplyRoundingMode(true);
 	LoadStaticRegisters();
 
@@ -158,7 +158,7 @@ void RiscVJitBackend::GenerateFixedCode(MIPSState *mipsState) {
 		MV(X10, DOWNCOUNTREG);
 		MV(X11, MEMBASEREG);
 		MV(X12, JITBASEREG);
-		QuickCallFunction(&ShowPC);
+		QuickCallFunction(&ShowPC, X7);
 	}
 
 	LWU(SCRATCH1, CTXREG, offsetof(MIPSState, pc));
@@ -182,7 +182,7 @@ void RiscVJitBackend::GenerateFixedCode(MIPSState *mipsState) {
 
 	// No block found, let's jit.  We don't need to save static regs, they're all callee saved.
 	RestoreRoundingMode(true);
-	QuickCallFunction(&MIPSComp::JitAt);
+	QuickCallFunction(&MIPSComp::JitAt, X7);
 	ApplyRoundingMode(true);
 
 	// Try again, the block index should be set now.

--- a/Core/MIPS/RiscV/RiscVCompFPU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompFPU.cpp
@@ -624,7 +624,7 @@ void RiscVJitBackend::CompIR_FSpecial(IRInst inst) {
 			int offset = offsetof(MIPSState, f) + inst.src1 * 4;
 			FL(32, F10, CTXREG, offset);
 		}
-		QuickCallFunction(func);
+		QuickCallFunction(func, SCRATCH1);
 
 		fpr.MapReg(inst.dest, MIPSMap::NOINIT);
 		// If it's already F10, we're done - MapReg doesn't actually overwrite the reg in that case.

--- a/Core/MIPS/RiscV/RiscVCompFPU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompFPU.cpp
@@ -254,10 +254,9 @@ void RiscVJitBackend::CompIR_FRound(IRInst inst) {
 void RiscVJitBackend::CompIR_FCvt(IRInst inst) {
 	CONDITIONAL_DISABLE;
 
+	RiscVReg tempReg = INVALID_REG;
 	switch (inst.op) {
 	case IROp::FCvtWS:
-	case IROp::FCvtScaledWS:
-	case IROp::FCvtScaledSW:
 		CompIR_Generic(inst);
 		break;
 
@@ -266,6 +265,44 @@ void RiscVJitBackend::CompIR_FCvt(IRInst inst) {
 		fpr.MapDirtyIn(inst.dest, inst.src1);
 		FMV(FMv::X, FMv::W, SCRATCH1, fpr.R(inst.src1));
 		FCVT(FConv::S, FConv::W, fpr.R(inst.dest), SCRATCH1);
+		break;
+
+	case IROp::FCvtScaledWS:
+		if (cpu_info.RiscV_D) {
+			Round rm = Round::NEAREST_EVEN;
+			switch (inst.src2 >> 6) {
+			case 0: rm = Round::NEAREST_EVEN; break;
+			case 1: rm = Round::TOZERO; break;
+			case 2: rm = Round::UP; break;
+			case 3: rm = Round::DOWN; break;
+			}
+
+			tempReg = fpr.MapDirtyInTemp(inst.dest, inst.src1);
+			// Prepare the double src1 and the multiplier.
+			FCVT(FConv::D, FConv::S, fpr.R(inst.dest), fpr.R(inst.src1));
+			LI(SCRATCH1, 1UL << (inst.src2 & 0x1F));
+			FCVT(FConv::D, FConv::WU, tempReg, SCRATCH1, rm);
+
+			FMUL(64, fpr.R(inst.dest), fpr.R(inst.dest), tempReg, rm);
+			// NAN and clamping should all be correct.
+			FCVT(FConv::W, FConv::D, SCRATCH1, fpr.R(inst.dest), rm);
+			// TODO: Could combine with a transfer, often is one...
+			FMV(FMv::W, FMv::X, fpr.R(inst.dest), SCRATCH1);
+		} else {
+			CompIR_Generic(inst);
+		}
+		break;
+
+	case IROp::FCvtScaledSW:
+		// TODO: This is probably proceeded by a GPR transfer, might be ideal to combine.
+		tempReg = fpr.MapDirtyInTemp(inst.dest, inst.src1);
+		FMV(FMv::X, FMv::W, SCRATCH1, fpr.R(inst.src1));
+		FCVT(FConv::S, FConv::W, fpr.R(inst.dest), SCRATCH1);
+
+		// Pre-divide so we can avoid any actual divide.
+		LI(SCRATCH1, 1.0f / (1UL << (inst.src2 & 0x1F)));
+		FMV(FMv::W, FMv::X, tempReg, SCRATCH1);
+		FMUL(32, fpr.R(inst.dest), fpr.R(inst.dest), tempReg);
 		break;
 
 	default:

--- a/Core/MIPS/RiscV/RiscVCompSystem.cpp
+++ b/Core/MIPS/RiscV/RiscVCompSystem.cpp
@@ -188,7 +188,7 @@ void RiscVJitBackend::CompIR_System(IRInst inst) {
 #ifdef USE_PROFILER
 		// When profiling, we can't skip CallSyscall, since it times syscalls.
 		LI(X10, (int32_t)inst.constant);
-		QuickCallFunction(&CallSyscall);
+		QuickCallFunction(&CallSyscall, SCRATCH2);
 #else
 		// Skip the CallSyscall where possible.
 		{
@@ -196,10 +196,10 @@ void RiscVJitBackend::CompIR_System(IRInst inst) {
 			void *quickFunc = GetQuickSyscallFunc(op);
 			if (quickFunc) {
 				LI(X10, (uintptr_t)GetSyscallFuncPointer(op));
-				QuickCallFunction((const u8 *)quickFunc);
+				QuickCallFunction((const u8 *)quickFunc, SCRATCH2);
 			} else {
 				LI(X10, (int32_t)inst.constant);
-				QuickCallFunction(&CallSyscall);
+				QuickCallFunction(&CallSyscall, SCRATCH2);
 			}
 		}
 #endif
@@ -211,7 +211,7 @@ void RiscVJitBackend::CompIR_System(IRInst inst) {
 	case IROp::CallReplacement:
 		FlushAll();
 		SaveStaticRegisters();
-		QuickCallFunction(GetReplacementFunc(inst.constant)->replaceFunc);
+		QuickCallFunction(GetReplacementFunc(inst.constant)->replaceFunc, SCRATCH2);
 		LoadStaticRegisters();
 		SUB(DOWNCOUNTREG, DOWNCOUNTREG, X10);
 		break;
@@ -222,7 +222,7 @@ void RiscVJitBackend::CompIR_System(IRInst inst) {
 		RestoreRoundingMode(true);
 		SaveStaticRegisters();
 		MovFromPC(X10);
-		QuickCallFunction(&Core_Break);
+		QuickCallFunction(&Core_Break, SCRATCH2);
 		LoadStaticRegisters();
 		ApplyRoundingMode(true);
 		MovFromPC(SCRATCH1);

--- a/Core/MIPS/RiscV/RiscVJit.cpp
+++ b/Core/MIPS/RiscV/RiscVJit.cpp
@@ -26,7 +26,7 @@ using namespace RiscVGen;
 using namespace RiscVJitConstants;
 
 RiscVJitBackend::RiscVJitBackend(MIPSState *mipsState, JitOptions &jitopt)
-	: mips_(mipsState), jo(jitopt), gpr(mipsState, &jo), fpr(mipsState, &jo) {
+	: jo(jitopt), gpr(mipsState, &jo), fpr(mipsState, &jo) {
 	// Automatically disable incompatible options.
 	if (((intptr_t)Memory::base & 0x00000000FFFFFFFFUL) != 0) {
 		jo.enablePointerify = false;

--- a/Core/MIPS/RiscV/RiscVJit.cpp
+++ b/Core/MIPS/RiscV/RiscVJit.cpp
@@ -81,7 +81,7 @@ bool RiscVJitBackend::CompileBlock(IRBlock *block, int block_num, bool preload) 
 	// We should've written an exit above.  If we didn't, bad things will happen.
 	// Only check if debug stats are enabled - needlessly wastes jit space.
 	if (DebugStatsEnabled()) {
-		QuickCallFunction(&NoBlockExits);
+		QuickCallFunction(&NoBlockExits, SCRATCH2);
 		QuickJ(R_RA, hooks_.crashHandler);
 	}
 
@@ -98,7 +98,7 @@ void RiscVJitBackend::CompIR_Generic(IRInst inst) {
 	FlushAll();
 	LI(X10, value, SCRATCH2);
 	SaveStaticRegisters();
-	QuickCallFunction(&DoIRInst);
+	QuickCallFunction(&DoIRInst, SCRATCH2);
 	LoadStaticRegisters();
 
 	// We only need to check the return value if it's a potential exit.
@@ -123,10 +123,10 @@ void RiscVJitBackend::CompIR_Interpret(IRInst inst) {
 	SaveStaticRegisters();
 	if (DebugStatsEnabled()) {
 		LI(X10, MIPSGetName(op));
-		QuickCallFunction(&NotifyMIPSInterpret);
+		QuickCallFunction(&NotifyMIPSInterpret, SCRATCH2);
 	}
 	LI(X10, (int32_t)inst.constant);
-	QuickCallFunction((const u8 *)MIPSGetInterpretFunc(op));
+	QuickCallFunction((const u8 *)MIPSGetInterpretFunc(op), SCRATCH2);
 	LoadStaticRegisters();
 }
 

--- a/Core/MIPS/RiscV/RiscVJit.h
+++ b/Core/MIPS/RiscV/RiscVJit.h
@@ -36,7 +36,7 @@ public:
 
 	bool DescribeCodePtr(const u8 *ptr, std::string &name) const override;
 
-	void GenerateFixedCode() override;
+	void GenerateFixedCode(MIPSState *mipsState) override;
 	bool CompileBlock(IRBlock *block, int block_num, bool preload) override;
 	void ClearAllBlocks() override;
 
@@ -107,8 +107,6 @@ private:
 	void NormalizeSrc12(IRInst inst, RiscVGen::RiscVReg *lhs, RiscVGen::RiscVReg *rhs, RiscVGen::RiscVReg lhsTempReg, RiscVGen::RiscVReg rhsTempReg, bool allowOverlap);
 	RiscVGen::RiscVReg NormalizeR(IRRegIndex rs, IRRegIndex rd, RiscVGen::RiscVReg tempReg);
 
-	// TODO: Maybe just a param to GenerateFixedCode().
-	MIPSState *mips_;
 	JitOptions &jo;
 	RiscVRegCache gpr;
 	RiscVRegCacheFPU fpr;


### PR DESCRIPTION
This implements a few more instructions, getting Fat Princess up to like 60-65% speed (with the other pulls.)  Not sure if 100% is gonna happen, but this was better than I expected.  It's still got half/float conversion although not that many... might be worth two more ops.

Also helps Crisis Core a little bit.

-[Unknown]