### PR TITLE
Call draw->Begin/EndFrame from outside the screen manager.

### DIFF
--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -191,10 +191,7 @@ void UIScreen::deviceRestored() {
 void UIScreen::preRender() {
 	using namespace Draw;
 	Draw::DrawContext *draw = screenManager()->getDrawContext();
-	if (!draw) {
-		return;
-	}
-	draw->BeginFrame();
+	_dbg_assert_(draw != nullptr);
 	// Bind and clear the back buffer
 	draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, 0xFF000000 }, "UI");
 	screenManager()->getUIContext()->BeginFrame();
@@ -211,12 +208,7 @@ void UIScreen::preRender() {
 }
 
 void UIScreen::postRender() {
-	Draw::DrawContext *draw = screenManager()->getDrawContext();
-	if (!draw) {
-		return;
-	}
 	screenManager()->getUIContext()->Flush();
-	draw->EndFrame();
 }
 
 void UIScreen::render() {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1355,7 +1355,6 @@ static void DrawFPS(UIContext *ctx, const Bounds &bounds) {
 void EmuScreen::preRender() {
 	using namespace Draw;
 	DrawContext *draw = screenManager()->getDrawContext();
-	draw->BeginFrame();
 	// Here we do NOT bind the backbuffer or clear the screen, unless non-buffered.
 	// The emuscreen is different than the others - we really want to allow the game to render to framebuffers
 	// before we ever bind the backbuffer for rendering. On mobile GPUs, switching back and forth between render
@@ -1389,7 +1388,6 @@ void EmuScreen::postRender() {
 		return;
 	if (stopRender_)
 		draw->WipeQueue();
-	draw->EndFrame();
 }
 
 void EmuScreen::render() {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1135,11 +1135,16 @@ void NativeFrame(GraphicsContext *graphicsContext) {
 		debugFlags |= Draw::DebugFlags::PROFILE_SCOPES;
 	g_screenManager->getDrawContext()->SetDebugFlags(debugFlags);
 
+	g_draw->BeginFrame();
+
 	// All actual rendering happen in here.
 	g_screenManager->render();
 	if (g_screenManager->getUIContext()->Text()) {
 		g_screenManager->getUIContext()->Text()->OncePerFrame();
 	}
+
+	// This triggers present.
+	g_draw->EndFrame();
 
 	if (resized) {
 		INFO_LOG(G3D, "Resized flag set - recalculating bounds");


### PR DESCRIPTION
Just a very small refactoring that I want in a separate commit.

Part of #17685 