### PR TITLE
Vulkan: Split EndFrame and Present

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -139,6 +139,7 @@ public:
 
 	void BeginFrame() override;
 	void EndFrame() override;
+	void Present() override;
 
 	int GetFrameCount() override { return frameCount_; }
 
@@ -433,6 +434,9 @@ void D3D11DrawContext::HandleEvent(Event ev, int width, int height, void *param1
 
 void D3D11DrawContext::EndFrame() {
 	curPipeline_ = nullptr;
+}
+
+void D3D11DrawContext::Present() {
 	frameCount_++;
 }
 

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -580,6 +580,8 @@ public:
 	}
 
 	void EndFrame() override;
+	void Present() override;
+
 	int GetFrameCount() override { return frameCount_; }
 
 	void UpdateDynamicUniformBuffer(const void *ub, size_t size) override;
@@ -966,6 +968,9 @@ void D3D9Context::BindNativeTexture(int index, void *nativeTexture) {
 
 void D3D9Context::EndFrame() {
 	curPipeline_ = nullptr;
+}
+
+void D3D9Context::Present() {
 	frameCount_++;
 }
 

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -369,6 +369,7 @@ public:
 
 	void BeginFrame() override;
 	void EndFrame() override;
+	void Present() override;
 
 	int GetFrameCount() override {
 		return frameCount_;
@@ -803,8 +804,10 @@ void OpenGLContext::EndFrame() {
 	FrameData &frameData = frameData_[renderManager_.GetCurFrame()];
 	renderManager_.EndPushBuffer(frameData.push);  // upload the data!
 	renderManager_.Finish();
-
 	Invalidate(InvalidationFlags::CACHED_RENDER_STATE);
+}
+
+void OpenGLContext::Present() {
 	frameCount_++;
 }
 

--- a/Common/GPU/Vulkan/VulkanFrameData.h
+++ b/Common/GPU/Vulkan/VulkanFrameData.h
@@ -13,6 +13,7 @@ enum {
 };
 
 enum class VKRRunType {
+	SUBMIT,
 	PRESENT,
 	SYNC,
 	EXIT,

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -187,8 +187,9 @@ public:
 
 	// Makes sure that the GPU has caught up enough that we can start writing buffers of this frame again.
 	void BeginFrame(bool enableProfiling, bool enableLogProfiler);
-	// Can run on a different thread!
+	// These can run on a different thread!
 	void Finish();
+	void Present();
 	// Zaps queued up commands. Use if you know there's a risk you've queued up stuff that has already been deleted. Can happen during in-game shutdown.
 	void Wipe();
 

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1116,6 +1116,7 @@ void VKContext::BeginFrame() {
 
 void VKContext::EndFrame() {
 	renderManager_.Finish();
+	renderManager_.Present();
 
 	// Unbind stuff, to avoid accidentally relying on it across frames (and provide some protection against forgotten unbinds of deleted things).
 	Invalidate(InvalidationFlags::CACHED_RENDER_STATE);

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -481,6 +481,8 @@ public:
 
 	void BeginFrame() override;
 	void EndFrame() override;
+	void Present() override;
+
 	void WipeQueue() override;
 
 	int GetFrameCount() override {
@@ -1115,12 +1117,14 @@ void VKContext::BeginFrame() {
 }
 
 void VKContext::EndFrame() {
+	// Do all the work to submit the command buffers etc.
 	renderManager_.Finish();
-	renderManager_.Present();
-
 	// Unbind stuff, to avoid accidentally relying on it across frames (and provide some protection against forgotten unbinds of deleted things).
 	Invalidate(InvalidationFlags::CACHED_RENDER_STATE);
+}
 
+void VKContext::Present() {
+	renderManager_.Present();
 	frameCount_++;
 }
 

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -816,6 +816,8 @@ public:
 	// Frame management (for the purposes of sync and resource management, necessary with modern APIs). Default implementations here.
 	virtual void BeginFrame() {}
 	virtual void EndFrame() = 0;
+	virtual void Present() = 0;
+
 	virtual void WipeQueue() {}
 
 	// This should be avoided as much as possible, in favor of clearing when binding a render target, which is native

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1143,11 +1143,6 @@ void NativeFrame(GraphicsContext *graphicsContext) {
 	}
 	g_draw->EndFrame();
 
-	// This, between EndFrame and Present, is where we should actually wait to do present time management.
-	// There might not be a meaningful distinction here for all backends..
-
-	g_draw->Present();
-
 	if (resized) {
 		INFO_LOG(G3D, "Resized flag set - recalculating bounds");
 		resized = false;
@@ -1187,6 +1182,11 @@ void NativeFrame(GraphicsContext *graphicsContext) {
 		// We're rendering fine, clear out failure info.
 		ClearFailedGPUBackends();
 	}
+
+	// This, between EndFrame and Present, is where we should actually wait to do present time management.
+	// There might not be a meaningful distinction here for all backends..
+
+	g_draw->Present();
 }
 
 void HandleGlobalMessage(const std::string &msg, const std::string &value) {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1136,15 +1136,17 @@ void NativeFrame(GraphicsContext *graphicsContext) {
 	g_screenManager->getDrawContext()->SetDebugFlags(debugFlags);
 
 	g_draw->BeginFrame();
-
 	// All actual rendering happen in here.
 	g_screenManager->render();
 	if (g_screenManager->getUIContext()->Text()) {
 		g_screenManager->getUIContext()->Text()->OncePerFrame();
 	}
-
-	// This triggers present.
 	g_draw->EndFrame();
+
+	// This, between EndFrame and Present, is where we should actually wait to do present time management.
+	// There might not be a meaningful distinction here for all backends..
+
+	g_draw->Present();
 
 	if (resized) {
 		INFO_LOG(G3D, "Resized flag set - recalculating bounds");

--- a/Windows/GPU/D3D11Context.cpp
+++ b/Windows/GPU/D3D11Context.cpp
@@ -33,12 +33,6 @@
 #error This file should not be compiled for UWP.
 #endif
 
-D3D11Context::D3D11Context() : draw_(nullptr), adapterId(-1), hDC(nullptr), hWnd_(nullptr), hD3D11(nullptr) {
-}
-
-D3D11Context::~D3D11Context() {
-}
-
 void D3D11Context::SwapBuffers() {
 	swapChain_->Present(swapInterval_, 0);
 	draw_->HandleEvent(Draw::Event::PRESENTED, 0, 0, nullptr, nullptr);
@@ -79,13 +73,6 @@ HRESULT D3D11Context::CreateTheDevice(IDXGIAdapter *adapter) {
 			D3D11_SDK_VERSION, &device_, &featureLevel_, &context_);
 	}
 	return hr;
-}
-
-static void GetRes(HWND hWnd, int &xres, int &yres) {
-	RECT rc;
-	GetClientRect(hWnd, &rc);
-	xres = rc.right - rc.left;
-	yres = rc.bottom - rc.top;
 }
 
 bool D3D11Context::Init(HINSTANCE hInst, HWND wnd, std::string *error_message) {
@@ -178,7 +165,7 @@ bool D3D11Context::Init(HINSTANCE hInst, HWND wnd, std::string *error_message) {
 
 	int width;
 	int height;
-	GetRes(hWnd_, width, height);
+	W32Util::GetWindowRes(hWnd_, &width, &height);
 
 	// Obtain DXGI factory from device (since we used nullptr for pAdapter above)
 	IDXGIFactory1 *dxgiFactory = nullptr;
@@ -249,7 +236,7 @@ void D3D11Context::Resize() {
 	LostBackbuffer();
 	int width;
 	int height;
-	GetRes(hWnd_, width, height);
+	W32Util::GetWindowRes(hWnd_, &width, &height);
 	swapChain_->ResizeBuffers(0, width, height, DXGI_FORMAT_UNKNOWN, 0);
 	GotBackbuffer();
 }

--- a/Windows/GPU/D3D11Context.h
+++ b/Windows/GPU/D3D11Context.h
@@ -28,8 +28,6 @@ class DrawContext;
 
 class D3D11Context : public WindowsGraphicsContext {
 public:
-	D3D11Context();
-	~D3D11Context();
 	bool Init(HINSTANCE hInst, HWND window, std::string *error_message) override;
 	void Shutdown() override;
 	void SwapInterval(int interval) override;
@@ -59,13 +57,12 @@ private:
 	ID3D11Debug *d3dDebug_ = nullptr;
 	ID3D11InfoQueue *d3dInfoQueue_ = nullptr;
 #endif
-
 	D3D_FEATURE_LEVEL featureLevel_ = D3D_FEATURE_LEVEL_11_0;
-	int adapterId;
-	HDC hDC;     // Private GDI Device Context
-	HWND hWnd_;   // Holds Our Window Handle
-	HMODULE hD3D11;
-	int width;
-	int height;
+	int adapterId = -1;
+	HDC hDC = nullptr;     // Private GDI Device Context
+	HWND hWnd_ = nullptr;   // Holds Our Window Handle
+	HMODULE hD3D11 = nullptr;
+	int width = 0;
+	int height = 0;
 	int swapInterval_ = 0;
 };

--- a/Windows/GPU/D3D9Context.cpp
+++ b/Windows/GPU/D3D9Context.cpp
@@ -35,13 +35,6 @@ void D3D9Context::SwapBuffers() {
 
 typedef HRESULT (__stdcall *DIRECT3DCREATE9EX)(UINT, IDirect3D9Ex**);
 
-static void GetRes(HWND hWnd, int &xres, int &yres) {
-	RECT rc;
-	GetClientRect(hWnd, &rc);
-	xres = rc.right - rc.left;
-	yres = rc.bottom - rc.top;
-}
-
 void D3D9Context::SwapInterval(int interval) {
 	swapInterval_ = interval;
 }
@@ -126,7 +119,7 @@ bool D3D9Context::Init(HINSTANCE hInst, HWND wnd, std::string *error_message) {
 		dwBehaviorFlags |= D3DCREATE_SOFTWARE_VERTEXPROCESSING;
 
 	int xres, yres;
-	GetRes(hWnd_, xres, yres);
+	W32Util::GetWindowRes(hWnd_, &xres, &yres);
 
 	presentParams_ = {};
 	presentParams_.BackBufferWidth = xres;
@@ -183,8 +176,8 @@ bool D3D9Context::Init(HINSTANCE hInst, HWND wnd, std::string *error_message) {
 void D3D9Context::Resize() {
 	// This should only be called from the emu thread.
 	int xres, yres;
-	GetRes(hWnd_, xres, yres);
-	uint32_t newInterval = swapInterval_ == 1 ? D3DPRESENT_INTERVAL_ONE : D3DPRESENT_INTERVAL_IMMEDIATE;;
+	W32Util::GetWindowRes(hWnd_, &xres, &yres);
+	uint32_t newInterval = swapInterval_ == 1 ? D3DPRESENT_INTERVAL_ONE : D3DPRESENT_INTERVAL_IMMEDIATE;
 	bool w_changed = presentParams_.BackBufferWidth != xres;
 	bool h_changed = presentParams_.BackBufferHeight != yres;
 	bool i_changed = presentParams_.PresentationInterval != newInterval;

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -285,11 +285,8 @@ namespace MainWindow
 			System_PostUIMessage("window minimized", "false");
 		}
 
-		int width = 0, height = 0;
-		RECT rc;
-		GetClientRect(hwndMain, &rc);
-		width = rc.right - rc.left;
-		height = rc.bottom - rc.top;
+		int width, height;
+		W32Util::GetWindowRes(hwndMain, &width, &height);
 
 		// Moves the internal display window to match the inner size of the main window.
 		MoveWindow(hwndDisplay, 0, 0, width, height, TRUE);

--- a/Windows/W32Util/Misc.cpp
+++ b/Windows/W32Util/Misc.cpp
@@ -87,6 +87,13 @@ namespace W32Util
 		SetWindowPos(hwnd, style, 0,0,0,0, SWP_NOMOVE | SWP_NOSIZE);
 	}
 
+	void GetWindowRes(HWND hWnd, int *xres, int *yres) {
+		RECT rc;
+		GetClientRect(hWnd, &rc);
+		*xres = rc.right - rc.left;
+		*yres = rc.bottom - rc.top;
+	}
+
 	static const wchar_t *RemoveExecutableFromCommandLine(const wchar_t *cmdline) {
 		if (!cmdline) {
 			return L"";

--- a/Windows/W32Util/Misc.h
+++ b/Windows/W32Util/Misc.h
@@ -15,6 +15,8 @@ namespace W32Util
 	void SpawnNewInstance(bool overrideArgs = false, const std::string &args = "");
 	void GetSelfExecuteParams(std::wstring &workingDirectory, std::wstring &moduleFilename);
 
+	void GetWindowRes(HWND hWnd, int *xres, int *yres);
+
 	struct ClipboardData {
 		ClipboardData(const char *format, size_t sz);
 		ClipboardData(UINT format, size_t sz);

--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -161,9 +161,6 @@ void AndroidVulkanContext::Shutdown() {
 	INFO_LOG(G3D, "AndroidVulkanContext::Shutdown completed");
 }
 
-void AndroidVulkanContext::SwapBuffers() {
-}
-
 void AndroidVulkanContext::Resize() {
 	INFO_LOG(G3D, "AndroidVulkanContext::Resize begin (oldsize: %dx%d)", g_Vulkan->GetBackbufferWidth(), g_Vulkan->GetBackbufferHeight());
 

--- a/android/jni/AndroidVulkanContext.h
+++ b/android/jni/AndroidVulkanContext.h
@@ -16,7 +16,7 @@ public:
 
 	void Shutdown() override;
 	void SwapInterval(int interval) override;
-	void SwapBuffers() override;
+	void SwapBuffers() override {}
 	void Resize() override;
 
 	void *GetAPIContext() override { return g_Vulkan; }


### PR DESCRIPTION
When we later move the wait from sceDisplay until after the frame / before the next frame, we want to be able to place it between triggering the end-of-frame work (that submits command buffers etc) and the actual present. This will mimic the existing behavior but will achieve more accurate present timing, before we try to optimize where to place the waits more. So, we split things up here.

This is already separated in the other backends where we call SwapBuffers separately (although on some platforms like Android, SwapBuffers is not something we call explicitly, IIRC).

Next step needs to be to make things even more similar between the backends, I haven't quite decided the next refactoring though.