### PR TITLE
irjit: Cleanup/purge FPU/VFPU temps

### DIFF
--- a/Core/MIPS/IR/IRAnalysis.h
+++ b/Core/MIPS/IR/IRAnalysis.h
@@ -24,6 +24,9 @@ bool IRReadsFromGPR(const IRInst &inst, int reg, bool directly = false);
 bool IRWritesToGPR(const IRInst &inst, int reg);
 bool IRWritesToFPR(const IRInst &inst, int reg);
 int IRDestGPR(const IRInst &inst);
+int IRDestFPRs(const IRInst &inst, IRReg regs[4]);
+int IRReadsFromGPRs(const IRInst &inst, IRReg regs[4]);
+int IRReadsFromFPRs(const IRInst &inst, IRReg regs[16]);
 
 struct IRSituation {
 	int lookaheadCount;

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -941,11 +941,28 @@ bool PurgeTemps(const IRWriter &in, IRWriter &out, const IROptions &opts) {
 		int index;
 		// Whether the dest reg is read by any Exit.
 		bool readByExit;
+		int8_t fplen = 0;
 	};
 	std::vector<Check> checks;
 	// This tracks the last index at which each reg was modified.
 	int lastWrittenTo[256];
+	int lastReadFrom[256];
 	memset(lastWrittenTo, -1, sizeof(lastWrittenTo));
+	memset(lastReadFrom, -1, sizeof(lastReadFrom));
+
+	auto readsFromFPRCheck = [](IRInst &inst, Check &check, bool directly) {
+		if (check.reg < 32)
+			return false;
+		if (check.fplen >= 1 && IRReadsFromFPR(inst, check.reg - 32, directly))
+			return true;
+		if (check.fplen >= 2 && IRReadsFromFPR(inst, check.reg - 32 + 1, directly))
+			return true;
+		if (check.fplen >= 3 && IRReadsFromFPR(inst, check.reg - 32 + 2, directly))
+			return true;
+		if (check.fplen >= 4 && IRReadsFromFPR(inst, check.reg - 32 + 3, directly))
+			return true;
+		return false;
+	};
 
 	bool logBlocks = false;
 	for (int i = 0, n = (int)in.GetInstructions().size(); i < n; i++) {
@@ -998,6 +1015,82 @@ bool PurgeTemps(const IRWriter &in, IRWriter &out, const IROptions &opts) {
 					// Legitimately read from, so we can't optimize out.
 					check.reg = 0;
 				}
+			} else if (readsFromFPRCheck(inst, check, false) && check.fplen >= 1) {
+				// If one or the other is a Vec, they must match.
+				bool lenMismatch = false;
+
+				const IRMeta *m = GetIRMeta(inst.op);
+				auto checkMismatch = [&check, &lenMismatch](IRReg src, char type) {
+					int srclen = 1;
+					if (type == 'V')
+						srclen = 4;
+					else if (type == '2')
+						srclen = 2;
+					else if (type != 'F')
+						return;
+
+					if (src + 32 + srclen > check.reg && src + 32 < check.reg + check.fplen) {
+						if (src + 32 != check.reg || srclen != check.fplen)
+							lenMismatch = true;
+					}
+				};
+
+				checkMismatch(inst.src1, m->types[1]);
+				checkMismatch(inst.src2, m->types[2]);
+				if ((m->flags & (IRFLAG_SRC3 | IRFLAG_SRC3DST)) != 0)
+					checkMismatch(inst.src3, m->types[3]);
+
+				bool cannotReplace = !readsFromFPRCheck(inst, check, true) || lenMismatch;
+				if (!cannotReplace && check.srcReg >= 32 && lastWrittenTo[check.srcReg] < check.index) {
+					// This is probably not worth doing unless we can get rid of a temp.
+					if (!check.readByExit) {
+						if (insts[check.index].dest == inst.src1)
+							inst.src1 = check.srcReg - 32;
+						else if (insts[check.index].dest == inst.src2)
+							inst.src2 = check.srcReg - 32;
+						else
+							_assert_msg_(false, "Unexpected src3 read of FPR");
+
+						// Check if we've clobbered it entirely.
+						if (inst.dest == check.reg) {
+							check.reg = 0;
+							insts[check.index].op = IROp::Mov;
+							insts[check.index].dest = 0;
+							insts[check.index].src1 = 0;
+						}
+					} else {
+						// Let's not bother.
+						check.reg = 0;
+					}
+				} else if ((inst.op == IROp::FMov || inst.op == IROp::Vec4Mov) && !lenMismatch) {
+					// A swap could be profitable if this is a temp, and maybe in other cases.
+					// These can happen a lot from mask regs, etc.
+					// But make sure no other changes happened between.
+					bool destNotChanged = true;
+					for (int j = 0; j < check.fplen; ++j)
+						destNotChanged = destNotChanged && lastWrittenTo[inst.dest + 32 + j] < check.index;
+
+					bool destNotRead = true;
+					for (int j = 0; j < check.fplen; ++j)
+						destNotRead = destNotRead && lastReadFrom[inst.dest + 32 + j] <= check.index;
+
+					if (!check.readByExit && destNotChanged && destNotRead) {
+						_dbg_assert_(insts[check.index].dest == inst.src1);
+						insts[check.index].dest = inst.dest;
+						for (int j = 0; j < check.fplen; ++j)
+							lastWrittenTo[inst.dest + 32 + j] = check.index;
+						// If it's being read from (by inst now), we can't optimize out.
+						check.reg = 0;
+						// Swap the dest and src1 so we can optimize this out later, maybe.
+						std::swap(inst.dest, inst.src1);
+					} else {
+						// Doesn't look like a good candidate.
+						check.reg = 0;
+					}
+				} else {
+					// Legitimately read from, so we can't optimize out.
+					check.reg = 0;
+				}
 			} else if (check.readByExit && (m->flags & IRFLAG_EXIT) != 0) {
 				// This is an exit, and the reg is read by any exit.  Clear it.
 				check.reg = 0;
@@ -1008,6 +1101,21 @@ bool PurgeTemps(const IRWriter &in, IRWriter &out, const IROptions &opts) {
 				insts[check.index].dest = 0;
 				insts[check.index].src1 = 0;
 				check.reg = 0;
+			} else if (IRWritesToFPR(inst, check.reg - 32) && check.fplen >= 1) {
+				IRReg destFPRs[4];
+				int numFPRs = IRDestFPRs(inst, destFPRs);
+
+				if (numFPRs == check.fplen && inst.dest + 32 == check.reg) {
+					// This means we've clobbered it, and with full overlap.
+					// Sometimes this happens for non-temps, i.e. vmmov + vinit last row.
+					insts[check.index].op = IROp::Mov;
+					insts[check.index].dest = 0;
+					insts[check.index].src1 = 0;
+					check.reg = 0;
+				} else {
+					// Since there's an overlap, we simply cannot optimize.
+					check.reg = 0;
+				}
 			}
 		}
 
@@ -1051,7 +1159,46 @@ bool PurgeTemps(const IRWriter &in, IRWriter &out, const IROptions &opts) {
 			break;
 		}
 
-		// TODO: VFPU temps?  Especially for masked dregs.
+		IRReg regs[16];
+		int readGPRs = IRReadsFromGPRs(inst, regs);
+		if (readGPRs == -1) {
+			for (int j = 0; j < 256; ++j)
+				lastReadFrom[j] = i;
+		} else {
+			for (int j = 0; j < readGPRs; ++j)
+				lastReadFrom[regs[j]] = i;
+		}
+
+		int readFPRs = IRReadsFromFPRs(inst, regs);
+		if (readFPRs == -1) {
+			for (int j = 0; j < 256; ++j)
+				lastReadFrom[j] = i;
+		} else {
+			for (int j = 0; j < readFPRs; ++j)
+				lastReadFrom[regs[j] + 32] = i;
+		}
+
+		int destFPRs = IRDestFPRs(inst, regs);
+		for (int j = 0; j < destFPRs; ++j)
+			lastWrittenTo[regs[j] + 32] = i;
+
+		dest = destFPRs > 0 ? regs[0] + 32 : -1;
+		if (dest >= 32 && dest < IRTEMP_0) {
+			// Standard FPU or VFPU reg.
+			Check check(dest, i, true);
+			check.fplen = (int8_t)destFPRs;
+			checks.push_back(check);
+		} else if (dest >= IRVTEMP_PFX_S + 32 && dest < IRVTEMP_PFX_S + 32 + 16) {
+			// These are temporary regs and not read by exits.
+			Check check(dest, i, false);
+			check.fplen = (int8_t)destFPRs;
+			if (inst.op == IROp::FMov || inst.op == IROp::Vec4Mov) {
+				check.srcReg = inst.src1 + 32;
+			}
+			checks.push_back(check);
+		} else if (dest != -1) {
+			_assert_msg_(false, "Unexpected FPR output %d", dest);
+		}
 
 		insts.push_back(inst);
 	}


### PR DESCRIPTION
A lot of cases are followed by an FMov that just moved the temp to a regular register, from VFPU instructions playing safe about overlaps.

This makes 80-85% a more common occurrence on RISC-V in Fat Princess, based on profiling to find the hottest blocks.  Doesn't seem to help LittleBigPlanet or other games as much... but helps a little.

There's also some other cases I can see:
 * SetConstF with identical values, could convert to FMov for the others (probably better on all backends.)
 * Vec4Load -> FAdd x3 -> Vec4Store, could be converted to Vec4Add & Vec4Blend very beneficially on SIMD backends.
 * Vec4Store -> Vec4Load, seems to be an inlining/optimization gap, could skip the load.  In some cases, could skip the store (clobbered by another Vec4Store later), although a bit hard to detect safely.

-[Unknown]