### PR TITLE
Minor RISC-V cleanups, frame profiler fix

### DIFF
--- a/Core/MIPS/RiscV/RiscVCompLoadStore.cpp
+++ b/Core/MIPS/RiscV/RiscVCompLoadStore.cpp
@@ -80,11 +80,8 @@ void RiscVJitBackend::CompIR_Load(IRInst inst) {
 		SetScratch1ToSrc1Address(inst.src1);
 		addrReg = SCRATCH1;
 	}
-	// If they're the same, MapReg may subtract MEMBASEREG, so just mark dirty.
-	if (inst.dest == inst.src1)
-		gpr.MarkDirty(gpr.R(inst.dest), true);
-	else
-		gpr.MapReg(inst.dest, MIPSMap::NOINIT | MIPSMap::MARK_NORM32);
+	// With NOINIT, MapReg won't subtract MEMBASEREG even if dest == src1.
+	gpr.MapReg(inst.dest, MIPSMap::NOINIT | MIPSMap::MARK_NORM32);
 	gpr.ReleaseSpillLock(inst.dest, inst.src1);
 
 	s32 imm = AdjustForAddressOffset(&addrReg, inst.constant);

--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -243,8 +243,13 @@ static u32 QuickTexHashNonSSE(const void *checkp, u32 size) {
 	if (((intptr_t)checkp & 0xf) == 0 && (size & 0x3f) == 0) {
 		static const u16 cursor2_initial[8] = {0xc00bU, 0x9bd9U, 0x4b73U, 0xb651U, 0x4d9bU, 0x4309U, 0x0083U, 0x0001U};
 		union u32x4_u16x8 {
+#if defined(__GNUC__)
+			uint32_t x32 __attribute__((vector_size(16)));
+			uint16_t x16 __attribute__((vector_size(16)));
+#else
 			u32 x32[4];
 			u16 x16[8];
+#endif
 		};
 		u32x4_u16x8 cursor{};
 		u32x4_u16x8 cursor2;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1547,7 +1547,7 @@ void EmuScreen::renderUI() {
 	}
 
 #ifdef USE_PROFILER
-	if (g_Config.bShowFrameProfiler && !invalid_) {
+	if ((DebugOverlay)g_Config.iDebugOverlay == DebugOverlay::FRAME_PROFILE && !invalid_) {
 		DrawProfile(*ctx);
 	}
 #endif


### PR DESCRIPTION
Decided to just switch the FMul over, we'll find out if it's wrong and git will have the workaround if needed.

`vector_size` was able to convince clang and I think gcc to vectorize texhash, which is a top perf hit on RISC-V.  I didn't test on a chip with vector, so not sure how performant it is - but it's quite decently less instructions.  Although it does some suboptimal looking vslidedown seemingly because it's unwilling to use vadd.vx?

Also fix the frame profiler, which was broken.

-[Unknown]