### PR TITLE
riscv: Add debug log of block disasm

### DIFF
--- a/Core/MIPS/RiscV/RiscVJit.h
+++ b/Core/MIPS/RiscV/RiscVJit.h
@@ -127,6 +127,7 @@ private:
 
 	int jitStartOffset_ = 0;
 	int compilingBlockNum_ = -1;
+	int logBlocks_ = 0;
 };
 
 class RiscVJit : public IRNativeJit {


### PR DESCRIPTION
Often I'm focusing on a specific block and it helps to compare the IR when asking "why is this asm generated this way?" and really want to also see why the IR looks a certain way too.

This simply logs interleaving the IR since the generated RISC-V is pretty much sequential and 1:1 with it.  Helpful for narrowing down cases to optimize or debug.

-[Unknown]