### PR TITLE
Fix crash from fontconfig

### DIFF
--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -508,6 +508,7 @@
     <ClInclude Include="Render\Text\draw_text.h" />
     <ClInclude Include="Render\Text\draw_text_android.h" />
     <ClInclude Include="Render\Text\draw_text_qt.h" />
+    <ClInclude Include="Render\Text\draw_text_sdl.h" />
     <ClInclude Include="Render\Text\draw_text_uwp.h" />
     <ClInclude Include="Render\Text\draw_text_win.h" />
     <ClInclude Include="LogReporting.h" />
@@ -934,6 +935,7 @@
     <ClCompile Include="Render\Text\draw_text.cpp" />
     <ClCompile Include="Render\Text\draw_text_android.cpp" />
     <ClCompile Include="Render\Text\draw_text_qt.cpp" />
+    <ClCompile Include="Render\Text\draw_text_sdl.cpp" />
     <ClCompile Include="Render\Text\draw_text_uwp.cpp" />
     <ClCompile Include="Render\Text\draw_text_win.cpp" />
     <ClCompile Include="LogReporting.cpp" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -512,6 +512,9 @@
     <ClInclude Include="Net\HTTPNaettRequest.h">
       <Filter>Net</Filter>
     </ClInclude>
+    <ClInclude Include="Render\Text\draw_text_sdl.h">
+      <Filter>Render\Text</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />
@@ -958,6 +961,9 @@
     </ClCompile>
     <ClCompile Include="Net\HTTPNaettRequest.cpp">
       <Filter>Net</Filter>
+    </ClCompile>
+    <ClCompile Include="Render\Text\draw_text_sdl.cpp">
+      <Filter>Render\Text</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Common/Render/Text/draw_text_sdl.cpp
+++ b/Common/Render/Text/draw_text_sdl.cpp
@@ -38,7 +38,8 @@ TextDrawerSDL::~TextDrawerSDL() {
 
 #if defined(USE_SDL2_TTF_FONTCONFIG)
 	FcConfigDestroy(config);
-	FcFini();
+	// Don't call this - it crashes, see https://github.com/openframeworks/openFrameworks/issues/5061.
+	//FcFini();
 #endif
 }
 


### PR DESCRIPTION
Apparently FcFini is known to crash - Chromium has intentionally not called it for the last 10 years, and various other projects avoid it similarly.  Was getting crashes randomly when exiting a game.

Per docs, init already doesn't do double work if it's already inited, so this pretty safe for us to do as well.

-[Unknown]