### PR TITLE
irjit: Implement some missing, handle partial Vec4s more

### DIFF
--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -385,6 +385,7 @@ private:
 struct IROptions {
 	uint32_t disableFlags;
 	bool unalignedLoadStore;
+	bool unalignedLoadStoreVec4;
 	bool preferVec4;
 };
 

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -385,6 +385,7 @@ private:
 struct IROptions {
 	uint32_t disableFlags;
 	bool unalignedLoadStore;
+	bool preferVec4;
 };
 
 const IRMeta *GetIRMeta(IROp op);

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -50,9 +50,16 @@ IRJit::IRJit(MIPSState *mipsState) : frontend_(mipsState->HasDefaultPrefix()), m
 
 	IROptions opts{};
 	opts.disableFlags = g_Config.uJitDisableFlags;
-	// Assume that RISC-V always has very slow unaligned memory accesses.
-#if !PPSSPP_ARCH(RISCV64)
+#if PPSSPP_ARCH(RISCV64)
+	// Assume RISC-V always has very slow unaligned memory accesses.
+	opts.unalignedLoadStore = false;
+	opts.preferVec4 = cpu_info.RiscV_V;
+#elif PPSSPP_ARCH(ARM)
 	opts.unalignedLoadStore = (opts.disableFlags & (uint32_t)JitDisable::LSU_UNALIGNED) == 0;
+	opts.preferVec4 = cpu_info.bASIMD || cpu_info.bNEON;
+#else
+	opts.unalignedLoadStore = (opts.disableFlags & (uint32_t)JitDisable::LSU_UNALIGNED) == 0;
+	opts.preferVec4 = true;
 #endif
 	frontend_.SetOptions(opts);
 }

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -53,12 +53,16 @@ IRJit::IRJit(MIPSState *mipsState) : frontend_(mipsState->HasDefaultPrefix()), m
 #if PPSSPP_ARCH(RISCV64)
 	// Assume RISC-V always has very slow unaligned memory accesses.
 	opts.unalignedLoadStore = false;
+	opts.unalignedLoadStoreVec4 = true;
 	opts.preferVec4 = cpu_info.RiscV_V;
 #elif PPSSPP_ARCH(ARM)
 	opts.unalignedLoadStore = (opts.disableFlags & (uint32_t)JitDisable::LSU_UNALIGNED) == 0;
+	opts.unalignedLoadStoreVec4 = true;
 	opts.preferVec4 = cpu_info.bASIMD || cpu_info.bNEON;
 #else
 	opts.unalignedLoadStore = (opts.disableFlags & (uint32_t)JitDisable::LSU_UNALIGNED) == 0;
+	// TODO: Could allow on x86 pretty easily...
+	opts.unalignedLoadStoreVec4 = false;
 	opts.preferVec4 = true;
 #endif
 	frontend_.SetOptions(opts);

--- a/Core/MIPS/JitCommon/JitState.h
+++ b/Core/MIPS/JitCommon/JitState.h
@@ -233,6 +233,7 @@ namespace MIPSComp {
 		bool downcountInRegister;
 		// ARM64 only
 		bool useASIMDVFPU;
+		// ARM64 and RV64
 		bool useStaticAlloc;
 		bool enablePointerify;
 


### PR DESCRIPTION
It's very common, especially in some hot blocks, to see code that does lv.q, then something like vdot.t, vsub.t, vmov.t, vcst.t, etc.  Swapping between vec4 and not will be costly when we have those jitted, so this handles some simple but common cases using Vec4Blend.

Also implements vcrs.t and allows some vdiv/vasin prefixes that are safe to be compiled.  Also combines lvr.q/lvl.q or svr.q/svl.q when used for an unaligned vector store (not 128-bit aligned, they still must be 32-bit aligned.) These are minor optimizations for a few games seen using them.

-[Unknown]