### PR TITLE
riscv: Fix crash on clear icache

### DIFF
--- a/Core/MIPS/IR/IRNativeCommon.cpp
+++ b/Core/MIPS/IR/IRNativeCommon.cpp
@@ -428,14 +428,8 @@ void IRNativeJit::InvalidateCacheAt(u32 em_address, int length) {
 	std::vector<int> numbers = blocks_.FindInvalidatedBlockNumbers(em_address, length);
 	for (int block_num : numbers) {
 		auto block = blocks_.GetBlock(block_num);
-		if (em_address != 0 || length < 0x1FFFFFFF) {
-			backend_->InvalidateBlock(block, block_num);
-		}
+		backend_->InvalidateBlock(block, block_num);
 		block->Destroy(block->GetTargetOffset());
-	}
-
-	if (em_address == 0 && length >= 0x1FFFFFFF) {
-		backend_->ClearAllBlocks();
 	}
 }
 


### PR DESCRIPTION
Oops, can't avoid marking all blocks invalid.  Luckily a syscall should always take more bytes than the bail invalidated block code.

Pretty much crashed right away in Grand Knights History because of this.

-[Unknown]