### PR TITLE
Android: Remove support for 32-bit x86 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,12 +143,6 @@ jobs:
           extra: android
           cc: clang
           cxx: clang++
-          args: cd android && ./ab.sh -j2 APP_ABI=x86 UNITTEST=1 HEADLESS=1
-          id: android-x86_32
-        - os: ubuntu-latest
-          extra: android
-          cc: clang
-          cxx: clang++
           args: cd android && ./ab.sh -j2 APP_ABI=x86_64 UNITTEST=1 HEADLESS=1
           id: android-x86_64
         - os: ubuntu-latest

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -133,7 +133,7 @@ android {
 				}
 			}
 			ndk {
-				abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+				abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86_64'
 			}
 		}
 		gold {
@@ -152,7 +152,7 @@ android {
 				}
 			}
 			ndk {
-				abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+				abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86_64'
 			}
 		}
 		vr {

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -290,23 +290,7 @@ include $(CLEAR_VARS)
 include $(LOCAL_PATH)/Locals.mk
 LOCAL_WHOLE_STATIC_LIBRARIES += ppsspp_common
 
-ifeq ($(TARGET_ARCH_ABI),x86)
-ARCH_FILES := \
-  $(SRC)/Core/MIPS/x86/CompALU.cpp \
-  $(SRC)/Core/MIPS/x86/CompBranch.cpp \
-  $(SRC)/Core/MIPS/x86/CompFPU.cpp \
-  $(SRC)/Core/MIPS/x86/CompLoadStore.cpp \
-  $(SRC)/Core/MIPS/x86/CompVFPU.cpp \
-  $(SRC)/Core/MIPS/x86/CompReplace.cpp \
-  $(SRC)/Core/MIPS/x86/Asm.cpp \
-  $(SRC)/Core/MIPS/x86/Jit.cpp \
-  $(SRC)/Core/MIPS/x86/JitSafeMem.cpp \
-  $(SRC)/Core/MIPS/x86/RegCache.cpp \
-  $(SRC)/Core/MIPS/x86/RegCacheFPU.cpp \
-  $(SRC)/GPU/Common/VertexDecoderX86.cpp \
-  $(SRC)/GPU/Software/DrawPixelX86.cpp \
-  $(SRC)/GPU/Software/SamplerX86.cpp
-else ifeq ($(TARGET_ARCH_ABI),x86_64)
+ifeq ($(TARGET_ARCH_ABI),x86_64)
 ARCH_FILES := \
   $(SRC)/Core/MIPS/x86/CompALU.cpp \
   $(SRC)/Core/MIPS/x86/CompBranch.cpp \

--- a/android/jni/Application.mk
+++ b/android/jni/Application.mk
@@ -1,5 +1,5 @@
 APP_STL := c++_static
 APP_PLATFORM := android-9
-APP_ABI := arm64-v8a armeabi-v7a x86 x86_64
+APP_ABI := arm64-v8a armeabi-v7a x86_64
 APP_GNUSTL_CPP_FEATURES := exceptions
 NDK_TOOLCHAIN_VERSION := clang

--- a/android/jni/Locals.mk
+++ b/android/jni/Locals.mk
@@ -53,16 +53,6 @@ ifeq ($(TARGET_ARCH_ABI),armeabi)
 
   LOCAL_CFLAGS := $(LOCAL_CFLAGS) -D_ARCH_32 -march=armv6
 endif
-ifeq ($(TARGET_ARCH_ABI),x86)
-  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/x86/lib/libavformat.a
-  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/x86/lib/libavcodec.a
-  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/x86/lib/libswresample.a
-  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/x86/lib/libswscale.a
-  LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/x86/lib/libavutil.a
-  LOCAL_C_INCLUDES += $(LOCAL_PATH)/../../ffmpeg/android/x86/include
-
-  LOCAL_CFLAGS := $(LOCAL_CFLAGS) -D_ARCH_32 -D_M_IX86 -fomit-frame-pointer -mtune=atom -mfpmath=sse -mssse3 -mstackrealign
-endif
 
 ifeq ($(TARGET_ARCH_ABI),x86_64)
   LOCAL_LDLIBS += $(LOCAL_PATH)/../../ffmpeg/android/x86_64/lib/libavformat.a


### PR DESCRIPTION
I'm having issues building for this very outdated platform with the modern tools, and instead of spending time trying to fix it, let's just disable it. There's no point - unlike some other things that are also old, approximately nobody still uses Android for x86 in practice. And these users can still use the ARM32 build, although even slower, since the few phones that released with this architecture all have ARM emulators included.

Android x86-64 still works and will continue to be supported.