### PR TITLE
sceDisplay/FrameTiming: Add comments, move some stuff around, get rid of some indentation

### DIFF
--- a/Core/FrameTiming.h
+++ b/Core/FrameTiming.h
@@ -2,6 +2,8 @@
 
 #include "Common/GPU/thin3d.h"
 
+// See big comment in the CPP file.
+
 namespace Draw {
 class DrawContext;
 }

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -301,6 +301,8 @@ static int ScreenRefreshRateHz() {
 	lpDevMode.dmSize = sizeof(DEVMODE);
 	lpDevMode.dmDriverExtra = 0;
 
+	// TODO: Use QueryDisplayConfig instead (Win7+) so we can get fractional refresh rates correctly.
+
 	if (EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &lpDevMode) == 0) {
 		return 60;  // default value
 	} else {


### PR DESCRIPTION
No functionality change. The messy part of the diff is just an early out, leading to removal of a level of indentation for easier changes.

I started to try to refactor it more as well, but the frameskipping logic is confusing and FrameTiming is called even with no flip about to happen in some cases, which makes my plan not work.

The plan after this PR is now a three-phase approach instead:

1. Add new, separate frame timing system, but only use it under ideal conditions (no frameskipping). In other conditions, fall back to the old timing system
2. Then try to get more and more stuff working with the new timing system (add support for frame skipping, etc)
3. Rip out the old timing system.

For 1.16, we'll likely just be at 1, assuming I can get a big enough improvement.