### PR TITLE
Frame time history: Write timestamps into it from all backends

### DIFF
--- a/Common/Data/Collections/FastVec.h
+++ b/Common/Data/Collections/FastVec.h
@@ -161,7 +161,9 @@ template <class T, size_t size>
 class HistoryBuffer {
 public:
 	T &Add(size_t index) {
+#ifdef _DEBUG
 		_dbg_assert_((int64_t)index >= 0);
+#endif
 		if (index > maxIndex_)
 			maxIndex_ = index;
 		T &entry = data_[index % size];
@@ -170,17 +172,23 @@ public:
 	}
 
 	const T &Back(size_t index) const {
+#ifdef _DEBUG
 		_dbg_assert_(index < maxIndex_ && index < size);
+#endif
 		return data_[(maxIndex_ - index) % size];
 	}
 
 	// Out of bounds (past size() - 1) is undefined behavior.
 	T &operator[] (const size_t index) {
+#ifdef _DEBUG
 		_dbg_assert_(index <= maxIndex_);
+#endif
 		return data_[index % size];
 	}
 	const T &operator[] (const size_t index) const {
+#ifdef _DEBUG
 		_dbg_assert_(index <= maxIndex_);
+#endif
 		return data_[index % size];
 	}
 	size_t MaxIndex() const {

--- a/Common/Data/Collections/FastVec.h
+++ b/Common/Data/Collections/FastVec.h
@@ -157,14 +157,37 @@ private:
 };
 
 // Simple cyclical vector.
-// Initially, doesn't do any sanity checking.
 template <class T, size_t size>
 class HistoryBuffer {
 public:
+	T &Add(size_t index) {
+		_dbg_assert_((int64_t)index >= 0);
+		if (index > maxIndex_)
+			maxIndex_ = index;
+		T &entry = data_[index % size];
+		entry = T{};
+		return entry;
+	}
+
+	const T &Back(size_t index) const {
+		_dbg_assert_(index < maxIndex_ && index < size);
+		return data_[(maxIndex_ - index) % size];
+	}
+
 	// Out of bounds (past size() - 1) is undefined behavior.
-	T &operator[] (const size_t index) { return data_[index % size]; }
-	const T &operator[] (const size_t index) const { return data_[index % size]; }
+	T &operator[] (const size_t index) {
+		_dbg_assert_(index <= maxIndex_);
+		return data_[index % size];
+	}
+	const T &operator[] (const size_t index) const {
+		_dbg_assert_(index <= maxIndex_);
+		return data_[index % size];
+	}
+	size_t MaxIndex() const {
+		return maxIndex_;
+	}
 
 private:
 	T data_[size]{};
+	size_t maxIndex_ = 0;
 };

--- a/Common/GPU/MiscTypes.h
+++ b/Common/GPU/MiscTypes.h
@@ -34,3 +34,4 @@ struct FrameTimeData {
 	double earliestPresentTime;
 	double presentMargin;
 };
+constexpr size_t FRAME_TIME_HISTORY_LENGTH = 32;

--- a/Common/GPU/OpenGL/GLFrameData.h
+++ b/Common/GPU/OpenGL/GLFrameData.h
@@ -49,6 +49,10 @@ struct GLQueueProfileContext {
 struct GLFrameData {
 	bool skipSwap = false;
 
+	// Frames need unique IDs to wait for present on, let's keep them here.
+	// Also used for indexing into the frame timing history buffer.
+	uint64_t frameId;
+
 	std::mutex fenceMutex;
 	std::condition_variable fenceCondVar;
 	bool readyForFence = true;

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -227,7 +227,7 @@ struct GLRRenderThreadTask {
 // directly in the destructor.
 class GLRenderManager {
 public:
-	GLRenderManager();
+	GLRenderManager(HistoryBuffer<FrameTimeData, FRAME_TIME_HISTORY_LENGTH> &frameTimeHistory);
 	~GLRenderManager();
 
 	GLRenderManager(GLRenderManager &) = delete;
@@ -910,4 +910,7 @@ private:
 
 	std::string profilePassesString_;
 	InvalidationCallback invalidationCallback_;
+
+	uint64_t frameIdGen_ = FRAME_TIME_HISTORY_LENGTH;
+	HistoryBuffer<FrameTimeData, FRAME_TIME_HISTORY_LENGTH> &frameTimeHistory_;
 };

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -542,7 +542,7 @@ static bool HasIntelDualSrcBug(const int versions[4]) {
 	}
 }
 
-OpenGLContext::OpenGLContext(bool canChangeSwapInterval) {
+OpenGLContext::OpenGLContext(bool canChangeSwapInterval) : renderManager_(frameTimeHistory_) {
 	if (gl_extensions.IsGLES) {
 		if (gl_extensions.OES_packed_depth_stencil || gl_extensions.OES_depth24) {
 			caps_.preferredDepthBufferFormat = DataFormat::D24_S8;

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -250,12 +250,13 @@ bool VKRComputePipeline::CreateAsync(VulkanContext *vulkan) {
 	return true;
 }
 
-VulkanRenderManager::VulkanRenderManager(VulkanContext *vulkan, bool useThread)
+VulkanRenderManager::VulkanRenderManager(VulkanContext *vulkan, bool useThread, HistoryBuffer<FrameTimeData, FRAME_TIME_HISTORY_LENGTH> &frameTimeHistory)
 	: vulkan_(vulkan), queueRunner_(vulkan),
 	initTimeMs_("initTimeMs"),
 	totalGPUTimeMs_("totalGPUTimeMs"),
 	renderCPUTimeMs_("renderCPUTimeMs"),
-	useRenderThread_(useThread)
+	useRenderThread_(useThread),
+	frameTimeHistory_(frameTimeHistory)
 {
 	inflightFramesAtStart_ = vulkan_->GetInflightFrames();
 
@@ -552,13 +553,13 @@ void VulkanRenderManager::PresentWaitThreadFunc() {
 	while (run_) {
 		const uint64_t timeout = 1000000000ULL;  // 1 sec
 		if (VK_SUCCESS == vkWaitForPresentKHR(vulkan_->GetDevice(), vulkan_->GetSwapchain(), waitedId, timeout)) {
-			frameTimeData_[waitedId].actualPresent = time_now_d();
-			frameTimeData_[waitedId].waitCount++;
+			frameTimeHistory_[waitedId].actualPresent = time_now_d();
+			frameTimeHistory_[waitedId].waitCount++;
 			waitedId++;
 		} else {
 			// We caught up somehow, which is a bad sign (we should have blocked, right?). Maybe we should break out of the loop?
 			sleep_ms(1);
-			frameTimeData_[waitedId].waitCount++;
+			frameTimeHistory_[waitedId].waitCount++;
 		}
 		_dbg_assert_(waitedId <= frameIdGen_);
 	}
@@ -580,11 +581,11 @@ void VulkanRenderManager::PollPresentTiming() {
 			vkGetPastPresentationTimingGOOGLE(vulkan_->GetDevice(), vulkan_->GetSwapchain(), &count, timings);
 			for (uint32_t i = 0; i < count; i++) {
 				uint64_t presentId = timings[i].presentID;
-				frameTimeData_[presentId].actualPresent = from_time_raw(timings[i].actualPresentTime);
-				frameTimeData_[presentId].desiredPresentTime = from_time_raw(timings[i].desiredPresentTime);
-				frameTimeData_[presentId].earliestPresentTime = from_time_raw(timings[i].earliestPresentTime);
+				frameTimeHistory_[presentId].actualPresent = from_time_raw(timings[i].actualPresentTime);
+				frameTimeHistory_[presentId].desiredPresentTime = from_time_raw(timings[i].desiredPresentTime);
+				frameTimeHistory_[presentId].earliestPresentTime = from_time_raw(timings[i].earliestPresentTime);
 				double presentMargin = from_time_raw_relative(timings[i].presentMargin);
-				frameTimeData_[presentId].presentMargin = presentMargin;
+				frameTimeHistory_[presentId].presentMargin = presentMargin;
 			}
 			delete[] timings;
 		}
@@ -623,15 +624,15 @@ void VulkanRenderManager::BeginFrame(bool enableProfiling, bool enableLogProfile
 
 	int validBits = vulkan_->GetQueueFamilyProperties(vulkan_->GetGraphicsQueueFamilyIndex()).timestampValidBits;
 
+	FrameTimeData &frameTimeData = frameTimeHistory_.Add(frameId);
+	frameTimeData.frameId = frameId;
+	frameTimeData.frameBegin = frameBeginTime;
+	frameTimeData.afterFenceWait = time_now_d();
+
 	// Can't set this until after the fence.
 	frameData.profile.enabled = enableProfiling;
 	frameData.profile.timestampsEnabled = enableProfiling && validBits > 0;
 	frameData.frameId = frameId;
-
-	frameTimeData_[frameId] = {};
-	frameTimeData_[frameId].frameId = frameId;
-	frameTimeData_[frameId].frameBegin = frameBeginTime;
-	frameTimeData_[frameId].afterFenceWait = time_now_d();
 
 	uint64_t queryResults[MAX_TIMESTAMP_QUERIES];
 
@@ -1391,7 +1392,7 @@ void VulkanRenderManager::Run(VKRRenderThreadTask &task) {
 	if (task.runType == VKRRunType::PRESENT) {
 		if (!frameData.skipSwap) {
 			VkResult res = frameData.QueuePresent(vulkan_, frameDataShared_);
-			frameTimeData_[frameData.frameId].queuePresent = time_now_d();
+			frameTimeHistory_[frameData.frameId].queuePresent = time_now_d();
 			if (res == VK_ERROR_OUT_OF_DATE_KHR) {
 				// We clearly didn't get this in vkAcquireNextImageKHR because of the skipSwap check above.
 				// Do the increment.
@@ -1414,8 +1415,8 @@ void VulkanRenderManager::Run(VKRRenderThreadTask &task) {
 
 	_dbg_assert_(!frameData.hasPresentCommands);
 
-	if (!frameTimeData_[frameData.frameId].firstSubmit) {
-		frameTimeData_[frameData.frameId].firstSubmit = time_now_d();
+	if (!frameTimeHistory_[frameData.frameId].firstSubmit) {
+		frameTimeHistory_[frameData.frameId].firstSubmit = time_now_d();
 	}
 	frameData.SubmitPending(vulkan_, FrameSubmitType::Pending, frameDataShared_);
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -182,7 +182,7 @@ struct CompileQueueEntry {
 
 class VulkanRenderManager {
 public:
-	VulkanRenderManager(VulkanContext *vulkan, bool useThread);
+	VulkanRenderManager(VulkanContext *vulkan, bool useThread, HistoryBuffer<FrameTimeData, FRAME_TIME_HISTORY_LENGTH> &frameTimeHistory);
 	~VulkanRenderManager();
 
 	// Makes sure that the GPU has caught up enough that we can start writing buffers of this frame again.
@@ -458,17 +458,6 @@ public:
 	void ResetStats();
 	void DrainCompileQueue();
 
-	// framesBack is the number of frames into the past to look.
-	FrameTimeData GetFrameTimeData(int framesBack) const {
-		FrameTimeData data;
-		if (framesBack >= frameIdGen_) {
-			data = {};
-			return data;
-		}
-		data = frameTimeData_[frameIdGen_ - framesBack];
-		return data;
-	}
-
 private:
 	void EndCurRenderStep();
 
@@ -553,5 +542,5 @@ private:
 	std::function<void(InvalidationCallbackFlags)> invalidationCallback_;
 
 	uint64_t frameIdGen_ = 31;
-	HistoryBuffer<FrameTimeData, 32> frameTimeData_;
+	HistoryBuffer<FrameTimeData, 32> &frameTimeHistory_;
 };

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -541,6 +541,6 @@ private:
 
 	std::function<void(InvalidationCallbackFlags)> invalidationCallback_;
 
-	uint64_t frameIdGen_ = 31;
-	HistoryBuffer<FrameTimeData, 32> &frameTimeHistory_;
+	uint64_t frameIdGen_ = FRAME_TIME_HISTORY_LENGTH;
+	HistoryBuffer<FrameTimeData, FRAME_TIME_HISTORY_LENGTH> &frameTimeHistory_;
 };

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -488,10 +488,6 @@ public:
 		return frameCount_;
 	}
 
-	FrameTimeData GetFrameTimeData(int framesBack) const override {
-		return renderManager_.GetFrameTimeData(framesBack);
-	}
-
 	void FlushState() override {}
 
 	void ResetStats() override {
@@ -564,7 +560,7 @@ private:
 	AutoRef<VKTexture> boundTextures_[MAX_BOUND_TEXTURES];
 	AutoRef<VKSamplerState> boundSamplers_[MAX_BOUND_TEXTURES];
 	VkImageView boundImageView_[MAX_BOUND_TEXTURES]{};
-	TextureBindFlags boundTextureFlags_[MAX_BOUND_TEXTURES];
+	TextureBindFlags boundTextureFlags_[MAX_BOUND_TEXTURES]{};
 
 	VulkanPushPool *push_ = nullptr;
 
@@ -866,7 +862,7 @@ static DataFormat DataFormatFromVulkanDepth(VkFormat fmt) {
 }
 
 VKContext::VKContext(VulkanContext *vulkan, bool useRenderThread)
-	: vulkan_(vulkan), renderManager_(vulkan, useRenderThread) {
+	: vulkan_(vulkan), renderManager_(vulkan, useRenderThread, frameTimeHistory_) {
 	shaderLanguageDesc_.Init(GLSL_VULKAN);
 
 	VkFormat depthStencilFormat = vulkan->GetDeviceInfo().preferredDepthStencilFormat;

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -18,6 +18,7 @@
 #include "Common/GPU/Shader.h"
 #include "Common/GPU/MiscTypes.h"
 #include "Common/Data/Collections/Slice.h"
+#include "Common/Data/Collections/FastVec.h"
 
 namespace Lin {
 class Matrix4x4;
@@ -853,15 +854,17 @@ public:
 	// Total amount of frames rendered. Unaffected by game pause, so more robust than gpuStats.numFlips
 	virtual int GetFrameCount() = 0;
 
-	virtual FrameTimeData GetFrameTimeData(int framesBack) const {
-		return FrameTimeData{};
-	}
-
 	virtual std::string GetGpuProfileString() const {
 		return "";
 	}
 
+	const HistoryBuffer<FrameTimeData, FRAME_TIME_HISTORY_LENGTH> &FrameTimeHistory() const {
+		return frameTimeHistory_;
+	}
+
 protected:
+	HistoryBuffer<FrameTimeData, FRAME_TIME_HISTORY_LENGTH> frameTimeHistory_;
+
 	ShaderModule *vsPresets_[VS_MAX_PRESET];
 	ShaderModule *fsPresets_[FS_MAX_PRESET];
 

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -817,7 +817,7 @@ public:
 	virtual void DrawUP(const void *vdata, int vertexCount) = 0;
 	
 	// Frame management (for the purposes of sync and resource management, necessary with modern APIs). Default implementations here.
-	virtual void BeginFrame(DebugFlags debugFlags) {}
+	virtual void BeginFrame(DebugFlags debugFlags) = 0;
 	virtual void EndFrame() = 0;
 
 	// vblanks is only relevant in FIFO present mode.

--- a/UI/DebugOverlay.cpp
+++ b/UI/DebugOverlay.cpp
@@ -115,15 +115,18 @@ static void DrawFrameTiming(UIContext *ctx, const Bounds &bounds) {
 	ctx->Draw()->SetFontScale(0.5f, 0.5f);
 
 	snprintf(statBuf, sizeof(statBuf),
-		"Present mode (interval): %s (%d)",
+		"Mode (interval): %s (%d)",
 		Draw::PresentModeToString(g_frameTiming.presentMode),
 		g_frameTiming.presentInterval);
 
 	ctx->Draw()->DrawTextRect(ubuntu24, statBuf, bounds.x + 10, bounds.y + 50, bounds.w - 20, bounds.h - 30, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
 
 	for (int i = 0; i < 5; i++) {
-		FrameTimeData data = ctx->GetDrawContext()->GetFrameTimeData(6 + i);
-		FrameTimeData prevData = ctx->GetDrawContext()->GetFrameTimeData(7 + i);
+		size_t curIndex = i + 6;
+		size_t prevIndex = i + 7;
+
+		FrameTimeData data = ctx->GetDrawContext()->FrameTimeHistory().Back(curIndex);
+		FrameTimeData prevData = ctx->GetDrawContext()->FrameTimeHistory().Back(prevIndex);
 		if (data.frameBegin == 0.0) {
 			snprintf(statBuf, sizeof(statBuf), "(No frame time data)");
 		} else {


### PR DESCRIPTION
These timestamps are important for the new frame timer. Even though we can't have accurate present times, we can still measure the length of the frame pipeline and try to avoid filling it up when not needed.

Most relevant for GL and Vulkan where we manage frame queues.