### PR TITLE
GamedataInstall: Add simple progress bar

### DIFF
--- a/Core/Dialog/PSPGamedataInstallDialog.cpp
+++ b/Core/Dialog/PSPGamedataInstallDialog.cpp
@@ -25,6 +25,8 @@
 #include "Core/System.h"
 #include "Core/FileSystems/MetaFileSystem.h"
 #include "Core/Dialog/PSPGamedataInstallDialog.h"
+#include "Common/Data/Text/I18n.h"
+#include "UI/OnScreenDisplay.h"
 
 std::string saveBasePath = "ms0:/PSP/SAVEDATA/";
 
@@ -270,7 +272,9 @@ void PSPGamedataInstallDialog::UpdateProgress() {
 		progressValue = (int)((allReadSize * 100) / allFilesSize);
 	else 
 		progressValue = 100;
-
+	auto di = GetI18NCategory("Dialog");
+	std::string temp = di->T("Save");
+	osm.Show(temp + " "  + std::to_string(progressValue) + " / 100", 0.5f);
 	param->progress = progressValue;
 	param.NotifyWrite("DialogResult");
 }

--- a/Core/Dialog/PSPGamedataInstallDialog.h
+++ b/Core/Dialog/PSPGamedataInstallDialog.h
@@ -54,6 +54,7 @@ protected:
 
 private:
 	void UpdateProgress();
+	void RenderProgress(int percentage);
 	void OpenNextFile();
 	void CopyCurrentFileData();
 	void CloseCurrentFile();

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -395,6 +395,7 @@ Finish = Finish
 GE Frame Dumps = GE Frame Dumps
 Grid = Grid
 Inactive = Inactive
+Installing... = Installing...
 InternalError = An internal error has occurred.
 Load = Load
 Load completed = Load completed.


### PR DESCRIPTION
Based on, and replaces, PR #16036 by @sum2012 .

Instead of posting little notifications, this actually draws a progress bar.

It does not add cancellation, confirmation and all that jazz yet, but this is an improvement.