### PR TITLE
Minor debug text optimizations

### DIFF
--- a/Common/Data/Encoding/Utf8.cpp
+++ b/Common/Data/Encoding/Utf8.cpp
@@ -219,13 +219,15 @@ int u8_strlen(const char *s)
 }
 
 /* reads the next utf-8 sequence out of a string, updating an index */
-uint32_t u8_nextchar(const char *s, int *i) {
+uint32_t u8_nextchar(const char *s, int *index) {
 	uint32_t ch = 0;
 	int sz = 0;
+	int i = *index;
 	do {
-		ch = (ch << 6) + (unsigned char)s[(*i)++];
+		ch = (ch << 6) + (unsigned char)s[i++];
 		sz++;
-	} while (s[*i] && ((s[*i]) & 0xC0) == 0x80);
+	} while (s[i] && ((s[i]) & 0xC0) == 0x80);
+	*index = i;
 	return ch - offsetsFromUTF8[sz - 1];
 }
 

--- a/Common/Data/Text/WrapText.cpp
+++ b/Common/Data/Text/WrapText.cpp
@@ -177,19 +177,17 @@ void WordWrapper::AppendWord(int endIndex, int lastChar, bool addNewline) {
 }
 
 void WordWrapper::Wrap() {
-	out_.clear();
-
 	// First, let's check if it fits as-is.
 	size_t len = strlen(str_);
-
-	// We know it'll be approximately this size. It's fine if the guess is a little off.
-	out_.reserve(len + len / 16);
-
 	if (MeasureWidth(str_, len) <= maxW_) {
 		// If it fits, we don't need to go through each character.
 		out_ = str_;
 		return;
 	}
+
+	out_.clear();
+	// We know it'll be approximately this size. It's fine if the guess is a little off.
+	out_.reserve(len + len / 16);
 
 	if (flags_ & FLAG_ELLIPSIZE_TEXT) {
 		ellipsisWidth_ = MeasureWidth("...", 3);

--- a/UI/DebugOverlay.cpp
+++ b/UI/DebugOverlay.cpp
@@ -15,7 +15,6 @@
 // For std::max
 #include <algorithm>
 
-
 static void DrawDebugStats(UIContext *ctx, const Bounds &bounds) {
 	FontID ubuntu24("UBUNTU24");
 
@@ -29,12 +28,8 @@ static void DrawDebugStats(UIContext *ctx, const Bounds &bounds) {
 	ctx->Draw()->SetFontScale(.7f, .7f);
 
 	__DisplayGetDebugStats(statbuf, sizeof(statbuf));
-	ctx->Draw()->DrawTextRect(ubuntu24, statbuf, bounds.x + 11, bounds.y + 31, left, bounds.h - 30, 0xc0000000, FLAG_DYNAMIC_ASCII | FLAG_WRAP_TEXT);
-	ctx->Draw()->DrawTextRect(ubuntu24, statbuf, bounds.x + 10, bounds.y + 30, left, bounds.h - 30, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII | FLAG_WRAP_TEXT);
-
-	__SasGetDebugStats(statbuf, sizeof(statbuf));
-	ctx->Draw()->DrawTextRect(ubuntu24, statbuf, bounds.x + left + 21, bounds.y + 31, right, bounds.h - 30, 0xc0000000, FLAG_DYNAMIC_ASCII | FLAG_WRAP_TEXT);
-	ctx->Draw()->DrawTextRect(ubuntu24, statbuf, bounds.x + left + 20, bounds.y + 30, right, bounds.h - 30, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII | FLAG_WRAP_TEXT);
+	ctx->Draw()->DrawTextRect(ubuntu24, statbuf, bounds.x + 11, bounds.y + 31, left, bounds.h - 30, 0xc0000000, FLAG_DYNAMIC_ASCII);
+	ctx->Draw()->DrawTextRect(ubuntu24, statbuf, bounds.x + 10, bounds.y + 30, left, bounds.h - 30, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
 
 	ctx->Draw()->SetFontScale(1.0f, 1.0f);
 	ctx->Flush();
@@ -50,9 +45,17 @@ static void DrawAudioDebugStats(UIContext *ctx, const Bounds &bounds) {
 	ctx->Flush();
 	ctx->BindFontTexture();
 	ctx->Draw()->SetFontScale(0.7f, 0.7f);
-	ctx->Draw()->DrawTextRect(ubuntu24, statbuf, bounds.x + 11, bounds.y + 31, bounds.w - 20, bounds.h - 30, 0xc0000000, FLAG_DYNAMIC_ASCII | FLAG_WRAP_TEXT);
-	ctx->Draw()->DrawTextRect(ubuntu24, statbuf, bounds.x + 10, bounds.y + 30, bounds.w - 20, bounds.h - 30, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII | FLAG_WRAP_TEXT);
+	ctx->Draw()->DrawTextRect(ubuntu24, statbuf, bounds.x + 11, bounds.y + 31, bounds.w - 20, bounds.h - 30, 0xc0000000, FLAG_DYNAMIC_ASCII);
+	ctx->Draw()->DrawTextRect(ubuntu24, statbuf, bounds.x + 10, bounds.y + 30, bounds.w - 20, bounds.h - 30, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
+
+	float left = std::max(bounds.w / 2 - 20.0f, 550.0f);
+
+	__SasGetDebugStats(statbuf, sizeof(statbuf));
+	ctx->Draw()->DrawTextRect(ubuntu24, statbuf, bounds.x + left + 21, bounds.y + 31, bounds.w - left, bounds.h - 30, 0xc0000000, FLAG_DYNAMIC_ASCII);
+	ctx->Draw()->DrawTextRect(ubuntu24, statbuf, bounds.x + left + 20, bounds.y + 30, bounds.w - left, bounds.h - 30, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
+
 	ctx->Draw()->SetFontScale(1.0f, 1.0f);
+
 	ctx->Flush();
 	ctx->RebindTexture();
 }


### PR DESCRIPTION
Not very interesting. The debug overlay actually slows things down in debug builds, so fix that by disabling text wrapping, after investigating some other things. Moves Sas information to the separate audio debug overlay.