### PR TITLE
Add checkboxes in developer tools to allow disabling ubershaders

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -633,6 +633,9 @@ static const ConfigSetting graphicsSettings[] = {
 
 	ConfigSetting("ShaderCache", &g_Config.bShaderCache, true, CfgFlag::DONT_SAVE),  // Doesn't save. Ini-only.
 	ConfigSetting("GpuLogProfiler", &g_Config.bGpuLogProfiler, false, CfgFlag::DEFAULT),
+
+	ConfigSetting("UberShaderVertex", &g_Config.bUberShaderVertex, true, CfgFlag::DEFAULT),
+	ConfigSetting("UberShaderFragment", &g_Config.bUberShaderFragment, true, CfgFlag::DEFAULT),
 };
 
 static const ConfigSetting soundSettings[] = {

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -213,6 +213,8 @@ public:
 	int iSplineBezierQuality; // 0 = low , 1 = Intermediate , 2 = High
 	bool bHardwareTessellation;
 	bool bShaderCache;  // Hidden ini-only setting, useful for debugging shader compile times.
+	bool bUberShaderVertex;
+	bool bUberShaderFragment;
 
 	std::vector<std::string> vPostShaderNames; // Off for chain end (only Off for no shader)
 	std::map<std::string, float> mPostShaderSetting;

--- a/GPU/Common/ShaderUniforms.cpp
+++ b/GPU/Common/ShaderUniforms.cpp
@@ -275,7 +275,8 @@ void BaseUpdateUniforms(UB_VS_FS_Base *ub, uint64_t dirtyUniforms, bool flipView
 		int format = gstate_c.depalFramebufferFormat;
 		uint32_t val = BytesToUint32(indexMask, indexShift, indexOffset, format);
 		// Poke in a bilinear filter flag in the top bit.
-		val |= gstate.isMagnifyFilteringEnabled() << 31;
+		if (gstate.isMagnifyFilteringEnabled())
+			val |= 0x80000000;
 		ub->depal_mask_shift_off_fmt = val;
 	}
 }

--- a/GPU/D3D11/GPU_D3D11.cpp
+++ b/GPU/D3D11/GPU_D3D11.cpp
@@ -108,8 +108,6 @@ u32 GPU_D3D11::CheckGPUFeatures() const {
 		features |= GPU_USE_16BIT_FORMATS;
 	}
 
-	features |= GPU_USE_FRAGMENT_UBERSHADER;
-
 	return CheckGPUFeaturesLate(features);
 }
 

--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -102,9 +102,6 @@ u32 GPU_DX9::CheckGPUFeatures() const {
 	// So we cannot incorrectly use the viewport transform as the depth range on Direct3D.
 	features |= GPU_USE_ACCURATE_DEPTH;
 
-	// DX9 GPUs probably benefit more than they lose from this. Though, might be a vendor check.
-	features |= GPU_USE_FRAGMENT_UBERSHADER;
-
 	return CheckGPUFeaturesLate(features);
 }
 

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -177,6 +177,11 @@ u32 GPU_GLES::CheckGPUFeatures() const {
 		features |= GPU_USE_SINGLE_PASS_STEREO;
 	}
 
+	if (!gl_extensions.GLES3) {
+		// Heuristic.
+		features &= ~GPU_USE_FRAGMENT_UBERSHADER;
+	}
+
 	features = CheckGPUFeaturesLate(features);
 
 	if (draw_->GetBugs().Has(Draw::Bugs::ADRENO_RESOURCE_DEADLOCK) && g_Config.bVendorBugChecksEnabled) {
@@ -193,11 +198,6 @@ u32 GPU_GLES::CheckGPUFeatures() const {
 			features |= GPU_ROUND_DEPTH_TO_16BIT;
 		}
 	}
-
-	if (gl_extensions.GLES3) {
-		features |= GPU_USE_FRAGMENT_UBERSHADER;
-	}
-
 	return features;
 }
 

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -611,7 +611,7 @@ u32 GPUCommonHW::CheckGPUFeatures() const {
 		features |= GPU_USE_FRAMEBUFFER_FETCH;
 	}
 
-	if (draw_->GetShaderLanguageDesc().bitwiseOps) {
+	if (draw_->GetShaderLanguageDesc().bitwiseOps && g_Config.bUberShaderVertex) {
 		features |= GPU_USE_LIGHT_UBERSHADER;
 	}
 
@@ -622,6 +622,11 @@ u32 GPUCommonHW::CheckGPUFeatures() const {
 	// Even without depth clamp, force accurate depth on for some games that break without it.
 	if (PSP_CoreParameter().compat.flags().DepthRangeHack) {
 		features |= GPU_USE_ACCURATE_DEPTH;
+	}
+
+	// Some backends will turn this off again in the calling function.
+	if (g_Config.bUberShaderFragment) {
+		features |= GPU_USE_FRAGMENT_UBERSHADER;
 	}
 
 	return features;

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -285,10 +285,6 @@ u32 GPU_Vulkan::CheckGPUFeatures() const {
 		}
 	}
 
-	// Only a few low-power GPUs should probably avoid this.
-	// Let's figure that out later.
-	features |= GPU_USE_FRAGMENT_UBERSHADER;
-
 	// Attempt to workaround #17386
 	if (draw_->GetBugs().Has(Draw::Bugs::UNIFORM_INDEXING_BROKEN)) {
 		features &= ~GPU_USE_LIGHT_UBERSHADER;

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -296,9 +296,11 @@ xBRZ = &xBRZ
 [Developer]
 Allocator Viewer = Allocator viewer (Vulkan)
 Allow remote debugger = Allow remote debugger
+Audio Debug = Audio Debug
 Backspace = Backspace
 Block address = Block address
 By Address = By address
+Control Debug = Control Debug
 Copy savestates to memstick root = Copy save states to Memory Stick root
 Create/Open textures.ini file for current game = Create/Open textures.ini file for current game
 Current = Current
@@ -311,6 +313,7 @@ Dump next frame to log = Dump next frame to log
 Enable driver bug workarounds = Enable driver bug workarounds
 Enable Logging = Enable debug logging
 Enter address = Enter address
+Fragment = Fragment
 FPU = FPU
 Framedump tests = Framedump tests
 Frame Profiler = Frame profiler
@@ -344,10 +347,10 @@ Stats = Stats
 System Information = System information
 Texture ini file created = Texture ini file created
 Texture Replacement = Texture replacement
-Audio Debug = Audio Debug
-Control Debug = Control Debug
 Toggle Freeze = Toggle freeze
 Touchscreen Test = Touchscreen test
+Ubershaders = Ubershaders
+Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]


### PR DESCRIPTION
Separately for Vertex/Fragment. Might be helpful to diagnose performance problems on user devices.

Additionally, moves the texture replacement controls to the top. They should probably be moved somewhere else entirely...

See #17918