### PR TITLE
Unify memstick PSP/subdirectory creation

### DIFF
--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -182,6 +182,8 @@ enum SystemProperty {
 	SYSPROP_KEYBOARD_LAYOUT,
 
 	SYSPROP_SKIP_UI,
+
+	SYSPROP_USER_DOCUMENTS_DIR,
 };
 
 enum class SystemNotification {

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -149,6 +149,7 @@ static bool DefaultCodeGen() {
 
 static bool DefaultVSync() {
 #if PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(UWP)
+	ERROR_LOG(SYSTEM, "Default vsync true");
 	// Previously we didn't allow turning off vsync/FIFO on Android. Let's set the default accordingly.
 	return true;
 #else
@@ -1225,7 +1226,7 @@ bool Config::Save(const char *saveReason) {
 		CleanRecent();
 		IniFile iniFile;
 		if (!iniFile.Load(iniFilename_)) {
-			ERROR_LOG(LOADER, "Error saving config - can't read ini '%s'", iniFilename_.c_str());
+			WARN_LOG(LOADER, "Likely saving config for first time - couldn't read ini '%s'", iniFilename_.c_str());
 		}
 
 		// Need to do this somewhere...

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -149,7 +149,6 @@ static bool DefaultCodeGen() {
 
 static bool DefaultVSync() {
 #if PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(UWP)
-	ERROR_LOG(SYSTEM, "Default vsync true");
 	// Previously we didn't allow turning off vsync/FIFO on Android. Let's set the default accordingly.
 	return true;
 #else
@@ -1197,11 +1196,6 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 	}
 
 	CleanRecent();
-
-#if PPSSPP_PLATFORM(ANDROID)
-	// The on path here is untested, since we don't expose it.
-	g_Config.bVSync = false;
-#endif
 
 	PostLoadCleanup(false);
 

--- a/Core/System.h
+++ b/Core/System.h
@@ -106,7 +106,7 @@ void UpdateLoadedFile(FileLoader *fileLoader);
 // they are not stored anywhere.
 Path GetSysDirectory(PSPDirectories directoryType);
 
-void CreateSysDirectories();
+bool CreateSysDirectories();
 
 // RUNNING must be at 0, NEXTFRAME must be at 1.
 enum CoreState {

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -465,6 +465,11 @@ std::string System_GetProperty(SystemProperty prop) {
 		}
 	case SYSPROP_BUILD_VERSION:
 		return PPSSPP_GIT_VERSION;
+	case SYSPROP_USER_DOCUMENTS_DIR:
+	{
+		const char *home = getenv("HOME");
+		return home ? std::string(home) : "/";
+	}
 	default:
 		return "";
 	}

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -291,15 +291,9 @@ static bool CheckFontIsUsable(const wchar_t *fontFace) {
 #endif
 
 void PostLoadConfig() {
-#if !PPSSPP_PLATFORM(WINDOWS)
 	if (g_Config.currentDirectory.empty()) {
 		g_Config.currentDirectory = g_Config.defaultCurrentDirectory;
 	}
-#else
-	if (g_Config.currentDirectory.empty()) {
-		g_Config.currentDirectory = GetSysDirectory(DIRECTORY_GAME);
-	}
-#endif
 
 	// Allow the lang directory to be overridden for testing purposes (e.g. Android, where it's hard to
 	// test new languages without recompiling the entire app, which is a hassle).
@@ -437,7 +431,12 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 #endif
 	g_VFS.Register("", new DirectoryReader(Path(savegame_dir)));
 
+#if !PPSSPP_PLATFORM(WINDOWS)
 	g_Config.defaultCurrentDirectory = Path("/");
+#else
+	g_Config.defaultCurrentDirectory = GetSysDirectory(DIRECTORY_GAME);
+#endif
+
 #if !PPSSPP_PLATFORM(UWP)
 	g_Config.internalDataDirectory = Path(savegame_dir);
 #endif
@@ -537,11 +536,9 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	}
 #endif
 
-#if (PPSSPP_PLATFORM(WINDOWS) && !PPSSPP_PLATFORM(UWP)) || PPSSPP_PLATFORM(MAC)
 	if (g_Config.currentDirectory.empty()) {
-		g_Config.currentDirectory = Path("/");
+		g_Config.currentDirectory = g_Config.defaultCurrentDirectory;
 	}
-#endif
 
 	if (cache_dir && strlen(cache_dir)) {
 		g_Config.appCacheDirectory = Path(cache_dir);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -290,13 +290,14 @@ static bool CheckFontIsUsable(const wchar_t *fontFace) {
 }
 #endif
 
-bool CreateDirectoriesAndroid();
-
 void PostLoadConfig() {
-	// On Windows, we deal with currentDirectory in InitSysDirectories().
 #if !PPSSPP_PLATFORM(WINDOWS)
 	if (g_Config.currentDirectory.empty()) {
 		g_Config.currentDirectory = g_Config.defaultCurrentDirectory;
+	}
+#else
+	if (g_Config.currentDirectory.empty()) {
+		g_Config.currentDirectory = GetSysDirectory(DIRECTORY_GAME);
 	}
 #endif
 
@@ -310,49 +311,9 @@ void PostLoadConfig() {
 	else
 		g_i18nrepo.LoadIni(g_Config.sLanguageIni, langOverridePath);
 
-#if PPSSPP_PLATFORM(ANDROID)
-	CreateDirectoriesAndroid();
+#if !PPSSPP_PLATFORM(WINDOWS) && !PPSSPP_PLATFORM(UWP)
+	CreateSysDirectories();
 #endif
-}
-
-bool CreateDirectoriesAndroid() {
-	// TODO: We should probably simply use this as the shared function to create memstick directories.
-#if PPSSPP_PLATFORM(ANDROID)
-	const bool createNoMedia = true;
-#else
-	const bool createNoMedia = false;
-#endif
-
-	Path pspDir = GetSysDirectory(DIRECTORY_PSP);
-
-	INFO_LOG(IO, "Creating '%s' and subdirs:", pspDir.c_str());
-	File::CreateFullPath(pspDir);
-	if (!File::Exists(pspDir)) {
-		INFO_LOG(IO, "Not a workable memstick directory. Giving up");
-		return false;
-	}
-
-	static const PSPDirectories sysDirs[] = {
-		DIRECTORY_CHEATS,
-		DIRECTORY_SAVEDATA,
-		DIRECTORY_SAVESTATE,
-		DIRECTORY_GAME,
-		DIRECTORY_SYSTEM,
-		DIRECTORY_TEXTURES,
-		DIRECTORY_PLUGINS,
-		DIRECTORY_CACHE,
-	};
-
-	for (auto dir : sysDirs) {
-		Path path = GetSysDirectory(dir);
-		File::CreateFullPath(path);
-		if (createNoMedia) {
-			// Create a nomedia file in each specified subdirectory.
-			File::CreateEmptyFile(path / ".nomedia");
-		}
-	}
-
-	return true;
 }
 
 static void CheckFailedGPUBackends() {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -804,12 +804,10 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	std::string sysName = System_GetProperty(SYSPROP_NAME);
 	isOuya = KeyMap::IsOuya(sysName);
 
-	ERROR_LOG(G3D, "Backend: %d", g_Config.iGPUBackend);
-
 	// We do this here, instead of in NativeInitGraphics, because the display may be reset.
 	// When it's reset we don't want to forget all our managed things.
 	CheckFailedGPUBackends();
-	SetGPUBackend((GPUBackend) g_Config.iGPUBackend);
+	SetGPUBackend((GPUBackend)g_Config.iGPUBackend);
 	renderCounter = 0;
 
 	// Initialize retro achievements runtime.

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -243,6 +243,8 @@ std::string System_GetProperty(SystemProperty prop) {
 		return gpuDriverVersion;
 	case SYSPROP_BUILD_VERSION:
 		return PPSSPP_GIT_VERSION;
+	case SYSPROP_USER_DOCUMENTS_DIR:
+		return Path(W32Util::UserDocumentsPath()).ToString();  // this'll reverse the slashes.
 	default:
 		return "";
 	}


### PR DESCRIPTION
Previously, we had separate functions to create subdirectories for the PSP directory on Android and Windows, and we didn't even do it on other platforms.

This fixes that.

Additionally:

* Remove hack that forced bVsync to false on Android, that's just wrong now.
* More sensible defaults for current directory on Windows/Mac.