### PR TITLE
Android: On some newer devices with 32-bit userland, default to Vulkan.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -396,6 +396,12 @@ static int DefaultGPUBackend() {
 	if (System_GetPropertyInt(SYSPROP_SYSTEMVERSION) >= 27) {
 		return (int)GPUBackend::VULKAN;
 	}
+#else
+	// There are some newer devices that benefit from Vulkan as default, but are 32-bit. Example: Redmi 9A.
+	// Let's only allow the very newest generation though.
+	if (System_GetPropertyInt(SYSPROP_SYSTEMVERSION) >= 30) {
+		return (int)GPUBackend::VULKAN;
+	}
 #endif
 #elif PPSSPP_PLATFORM(MAC)
 #if PPSSPP_ARCH(ARM64)


### PR DESCRIPTION
We already default to Vulkan on all recent 64-bit devices, but there are some 32-bit devices that benefit, so let's set a high lower bound for OS version for this.