### PR TITLE
Enable anisotropic filtering for replacement textures with mipmaps

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -257,6 +257,9 @@ SamplerCacheKey TextureCacheCommon::GetSamplingParams(int maxLevel, const TexCac
 			key.mipEnable = true;
 			key.mipFilt = 1;
 			key.maxLevel = 9 * 256;
+			if (gstate_c.Use(GPU_USE_ANISOTROPY) && g_Config.iAnisotropyLevel > 0) {
+				key.aniso = true;
+			}
 		}
 		useReplacerFiltering = entry->replacedTexture->ForceFiltering(&forceFiltering);
 	}


### PR DESCRIPTION
This should fix the issue seen in #17891 where if the game itself doesn't use mipmaps, but the replacement texture does, anisotropic filtering wasn't enabled.

Although I think we could be more generous about enabling anisotropic filtering - possibly we should just always turn it on, if enabled, instead of only using it together with mipmapping. It does help with the look of filtering textures at steep angles even if they don't have mipmaps by reducing shimmer. That change though I'll do after the release.