### PR TITLE
RISC-V: Centralize IR regcaches

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -523,9 +523,9 @@ void KernelObjectPool::List() {
 			char buffer[256];
 			if (pool[i]) {
 				pool[i]->GetQuickInfo(buffer, sizeof(buffer));
-				INFO_LOG(SCEKERNEL, "KO %i: %s \"%s\": %s", i + handleOffset, pool[i]->GetTypeName(), pool[i]->GetName(), buffer);
+				DEBUG_LOG(SCEKERNEL, "KO %i: %s \"%s\": %s", i + handleOffset, pool[i]->GetTypeName(), pool[i]->GetName(), buffer);
 			} else {
-				strcpy(buffer, "WTF? Zero Pointer");
+				ERROR_LOG(SCEKERNEL, "KO %i: bad object", i + handleOffset);
 			}
 		}
 	}

--- a/Core/MIPS/IR/IRRegCache.cpp
+++ b/Core/MIPS/IR/IRRegCache.cpp
@@ -1,7 +1,30 @@
+// Copyright (c) 2023- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#ifndef offsetof
+#include <cstddef>
+#endif
+
 #include <cstring>
 #include "Common/Log.h"
 #include "Core/MIPS/IR/IRRegCache.h"
 #include "Core/MIPS/IR/IRInst.h"
+#include "Core/MIPS/IR/IRJit.h"
+#include "Core/MIPS/JitCommon/JitState.h"
 
 void IRImmRegCache::Flush(IRReg rd) {
 	if (rd == 0) {
@@ -28,7 +51,7 @@ IRImmRegCache::IRImmRegCache(IRWriter *ir) : ir_(ir) {
 }
 
 void IRImmRegCache::FlushAll() {
-	for (int i = 0; i < TOTAL_MAPPABLE_MIPSREGS; i++) {
+	for (int i = 0; i < TOTAL_MAPPABLE_IRREGS; i++) {
 		Flush(i);
 	}
 }
@@ -67,3 +90,40 @@ void IRImmRegCache::MapDirtyInIn(IRReg rd, IRReg rs, IRReg rt) {
 	Flush(rt);
 }
 
+IRNativeRegCache::IRNativeRegCache(MIPSComp::JitOptions *jo)
+	: jo_(jo) {}
+
+void IRNativeRegCache::Start(MIPSComp::IRBlock *irBlock) {
+	if (!initialReady_) {
+		SetupInitialRegs();
+		initialReady_ = true;
+	}
+
+	memcpy(nr, nrInitial_, sizeof(nr[0]) * totalNativeRegs_);
+	memcpy(mr, mrInitial_, sizeof(mr));
+	pendingFlush_ = false;
+
+	int numStatics;
+	const StaticAllocation *statics = GetStaticAllocations(numStatics);
+	for (int i = 0; i < numStatics; i++) {
+		nr[statics[i].nr].mipsReg = statics[i].mr;
+		nr[statics[i].nr].pointerified = statics[i].pointerified && jo_->enablePointerify;
+		nr[statics[i].nr].normalized32 = statics[i].normalized32;
+		mr[statics[i].mr].loc = MIPSLoc::REG;
+		mr[statics[i].mr].nReg = statics[i].nr;
+		mr[statics[i].mr].isStatic = true;
+		// Lock it until the very end.
+		mr[statics[i].mr].spillLockIRIndex = irBlock->GetNumInstructions();
+	}
+
+	irBlock_ = irBlock;
+	irIndex_ = 0;
+}
+
+void IRNativeRegCache::SetupInitialRegs() {
+	_assert_msg_(totalNativeRegs_ > 0, "totalNativeRegs_ was never set by backend");
+
+	// Everything else is initialized in the struct.
+	mrInitial_[MIPS_REG_ZERO].loc = MIPSLoc::IMM;
+	mrInitial_[MIPS_REG_ZERO].imm = 0;
+}

--- a/Core/MIPS/IR/IRRegCache.cpp
+++ b/Core/MIPS/IR/IRRegCache.cpp
@@ -21,6 +21,8 @@
 
 #include <cstring>
 #include "Common/Log.h"
+#include "Common/LogReporting.h"
+#include "Core/MIPS/IR/IRAnalysis.h"
 #include "Core/MIPS/IR/IRRegCache.h"
 #include "Core/MIPS/IR/IRInst.h"
 #include "Core/MIPS/IR/IRJit.h"
@@ -90,10 +92,10 @@ void IRImmRegCache::MapDirtyInIn(IRReg rd, IRReg rs, IRReg rt) {
 	Flush(rt);
 }
 
-IRNativeRegCache::IRNativeRegCache(MIPSComp::JitOptions *jo)
+IRNativeRegCacheBase::IRNativeRegCacheBase(MIPSComp::JitOptions *jo)
 	: jo_(jo) {}
 
-void IRNativeRegCache::Start(MIPSComp::IRBlock *irBlock) {
+void IRNativeRegCacheBase::Start(MIPSComp::IRBlock *irBlock) {
 	if (!initialReady_) {
 		SetupInitialRegs();
 		initialReady_ = true;
@@ -109,7 +111,7 @@ void IRNativeRegCache::Start(MIPSComp::IRBlock *irBlock) {
 		nr[statics[i].nr].mipsReg = statics[i].mr;
 		nr[statics[i].nr].pointerified = statics[i].pointerified && jo_->enablePointerify;
 		nr[statics[i].nr].normalized32 = statics[i].normalized32;
-		mr[statics[i].mr].loc = MIPSLoc::REG;
+		mr[statics[i].mr].loc = statics[i].loc;
 		mr[statics[i].mr].nReg = statics[i].nr;
 		mr[statics[i].mr].isStatic = true;
 		// Lock it until the very end.
@@ -120,10 +122,242 @@ void IRNativeRegCache::Start(MIPSComp::IRBlock *irBlock) {
 	irIndex_ = 0;
 }
 
-void IRNativeRegCache::SetupInitialRegs() {
+void IRNativeRegCacheBase::SetupInitialRegs() {
 	_assert_msg_(totalNativeRegs_ > 0, "totalNativeRegs_ was never set by backend");
 
 	// Everything else is initialized in the struct.
 	mrInitial_[MIPS_REG_ZERO].loc = MIPSLoc::IMM;
 	mrInitial_[MIPS_REG_ZERO].imm = 0;
+}
+
+IRNativeReg IRNativeRegCacheBase::AllocateReg(MIPSLoc type) {
+	_dbg_assert_(type == MIPSLoc::REG || type == MIPSLoc::FREG || type == MIPSLoc::VREG);
+
+	IRNativeReg nreg = FindFreeReg(type);
+	if (nreg != -1)
+		return nreg;
+
+	// Still nothing. Let's spill a reg and goto 10.
+	bool clobbered;
+	IRNativeReg bestToSpill = FindBestToSpill(type, true, &clobbered);
+	if (bestToSpill == -1) {
+		bestToSpill = FindBestToSpill(type, false, &clobbered);
+	}
+
+	if (bestToSpill != -1) {
+		if (clobbered) {
+			DiscardNativeReg(bestToSpill);
+		} else {
+			FlushNativeReg(bestToSpill);
+		}
+		// Now one must be free.
+		return FindFreeReg(type);
+	}
+
+	// Uh oh, we have all of them spilllocked....
+	ERROR_LOG_REPORT(JIT, "Out of spillable registers in block PC %08x, index %d", irBlock_->GetOriginalStart(), irIndex_);
+	_assert_(bestToSpill != -1);
+	return -1;
+}
+
+IRNativeReg IRNativeRegCacheBase::FindFreeReg(MIPSLoc type) const {
+	int allocCount = 0, base = 0;
+	const int *allocOrder = GetAllocationOrder(type, allocCount, base);
+
+	for (int i = 0; i < allocCount; i++) {
+		IRNativeReg nreg = IRNativeReg(allocOrder[i] - base);
+
+		if (nr[nreg].mipsReg == IRREG_INVALID) {
+			return nreg;
+		}
+	}
+
+	return -1;
+}
+
+IRNativeReg IRNativeRegCacheBase::FindBestToSpill(MIPSLoc type, bool unusedOnly, bool *clobbered) const {
+	int allocCount = 0, base = 0;
+	const int *allocOrder = GetAllocationOrder(type, allocCount, base);
+
+	static const int UNUSED_LOOKAHEAD_OPS = 30;
+
+	IRSituation info;
+	info.lookaheadCount = UNUSED_LOOKAHEAD_OPS;
+	info.currentIndex = irIndex_;
+	info.instructions = irBlock_->GetInstructions();
+	info.numInstructions = irBlock_->GetNumInstructions();
+
+	auto getUsage = [type, &info](IRReg mipsReg) {
+		if (type == MIPSLoc::REG)
+			return IRNextGPRUsage(mipsReg, info);
+		else if (type == MIPSLoc::FREG || type == MIPSLoc::VREG)
+			return IRNextFPRUsage(mipsReg - 32, info);
+		_assert_msg_(false, "Unknown spill allocation type");
+		return IRUsage::UNKNOWN;
+	};
+
+	*clobbered = false;
+	for (int i = 0; i < allocCount; i++) {
+		IRNativeReg nreg = IRNativeReg(allocOrder[i] - base);
+		if (nr[nreg].mipsReg != IRREG_INVALID && mr[nr[nreg].mipsReg].spillLockIRIndex >= irIndex_)
+			continue;
+		if (nr[nreg].tempLockIRIndex >= irIndex_)
+			continue;
+
+		// As it's in alloc-order, we know it's not static so we don't need to check for that.
+		IRReg mipsReg = nr[nreg].mipsReg;
+		IRUsage usage = getUsage(mipsReg);
+
+		// Awesome, a clobbered reg.  Let's use it?
+		if (usage == IRUsage::CLOBBERED) {
+			// If multiple mips regs use this native reg (i.e. vector, HI/LO), check each.
+			// Note: mipsReg points to the lowest numbered IRReg.
+			bool canClobber = true;
+			for (IRReg m = mipsReg + 1; mr[m].nReg == nreg && m < IRREG_INVALID && canClobber; ++m)
+				canClobber = getUsage(mipsReg) == IRUsage::CLOBBERED;
+
+			// Okay, if all can be clobbered, we're good to go.
+			if (canClobber) {
+				*clobbered = true;
+				return nreg;
+			}
+		}
+
+		// Not awesome.  A used reg.  Let's try to avoid spilling.
+		if (!unusedOnly || usage == IRUsage::UNUSED) {
+			// TODO: Use age or something to choose which register to spill?
+			// TODO: Spill dirty regs first? or opposite?
+			return nreg;
+		}
+	}
+
+	return -1;
+}
+
+void IRNativeRegCacheBase::DiscardNativeReg(IRNativeReg nreg) {
+	_assert_msg_(nreg >= 0 && nreg < totalNativeRegs_, "DiscardNativeReg on invalid register %d", nreg);
+	if (nr[nreg].mipsReg != IRREG_INVALID) {
+		_assert_(nr[nreg].mipsReg != MIPS_REG_ZERO);
+		int8_t lanes = 0;
+		for (IRReg m = nr[nreg].mipsReg; mr[m].nReg == nreg && m < IRREG_INVALID; ++m)
+			lanes++;
+
+		if (mr[nr[nreg].mipsReg].isStatic) {
+			int numStatics;
+			const StaticAllocation *statics = GetStaticAllocations(numStatics);
+
+			// If it's not currently marked as in a reg, throw it away.
+			for (IRReg m = nr[nreg].mipsReg; m < nr[nreg].mipsReg + lanes; ++m) {
+				_assert_msg_(!mr[m].isStatic, "Reg in lane %d mismatched static status", m - nr[nreg].mipsReg);
+				for (int i = 0; i < numStatics; i++) {
+					if (m == statics[i].mr)
+						mr[m].loc = statics[i].loc;
+				}
+			}
+		} else {
+			for (IRReg m = nr[nreg].mipsReg; m < nr[nreg].mipsReg + lanes; ++m) {
+				mr[m].loc = MIPSLoc::MEM;
+				mr[m].nReg = -1;
+				mr[m].imm = 0;
+				_assert_msg_(!mr[m].isStatic, "Reg in lane %d mismatched static status", m - nr[nreg].mipsReg);
+			}
+
+			nr[nreg].mipsReg = IRREG_INVALID;
+		}
+	}
+
+	// Even for a static reg, we assume this means it's not pointerified anymore.
+	nr[nreg].pointerified = false;
+	nr[nreg].isDirty = false;
+	nr[nreg].normalized32 = false;
+}
+
+void IRNativeRegCacheBase::FlushNativeReg(IRNativeReg nreg) {
+	_assert_msg_(nreg >= 0 && nreg < totalNativeRegs_, "FlushNativeReg on invalid register %d", nreg);
+	if (nr[nreg].mipsReg == IRREG_INVALID || nr[nreg].mipsReg == MIPS_REG_ZERO) {
+		// Nothing to do, reg not mapped or mapped to fixed zero.
+		_dbg_assert_(!nr[nreg].isDirty);
+		return;
+	}
+	_dbg_assert_(!mr[nr[nreg].mipsReg].isStatic);
+	if (mr[nr[nreg].mipsReg].isStatic) {
+		ERROR_LOG(JIT, "Cannot FlushNativeReg a statically mapped register");
+		return;
+	}
+
+	// Multiple mipsRegs may match this if a vector or HI/LO, etc.
+	bool isDirty = nr[nreg].isDirty;
+	int8_t lanes = 0;
+	for (IRReg m = nr[nreg].mipsReg; mr[m].nReg == nreg && m < IRREG_INVALID; ++m) {
+		_dbg_assert_(!mr[m].isStatic);
+		lanes++;
+	}
+
+	if (isDirty) {
+		IRReg first = nr[nreg].mipsReg;
+		if (mr[first].loc == MIPSLoc::REG_AS_PTR) {
+			// We assume this can't be multiple lanes.  Maybe some gather craziness?
+			_assert_(lanes == 1);
+			AdjustNativeRegAsPtr(nreg, false);
+			mr[first].loc = MIPSLoc::REG;
+		}
+		StoreNativeReg(nreg, first, lanes);
+	}
+
+	for (int8_t i = 0; i < lanes; ++i) {
+		auto &mreg = mr[nr[nreg].mipsReg + i];
+		mreg.nReg = -1;
+		// Note that it loses its imm status, because imms are always dirty.
+		mreg.loc = MIPSLoc::MEM;
+		mreg.imm = 0;
+	}
+
+	nr[nreg].mipsReg = IRREG_INVALID;
+	nr[nreg].isDirty = false;
+	nr[nreg].pointerified = false;
+	nr[nreg].normalized32 = false;
+}
+
+void IRNativeRegCacheBase::AdjustNativeRegAsPtr(IRNativeReg nreg, bool state) {
+	// This isn't necessary to implement if REG_AS_PTR is unsupported entirely.
+	_assert_msg_(false, "AdjustNativeRegAsPtr unimplemented");
+}
+
+bool IRNativeRegCacheBase::IsValidGPR(IRReg r) const {
+	// See MIPSState for these offsets.
+
+	// Don't allow FPU regs, VFPU regs, or VFPU temps here.
+	if (r >= 32 && IsValidFPR(r - 32))
+		return false;
+	// Don't allow nextPC, etc. since it's probably a mistake.
+	if (r > IRREG_FPCOND && r != IRREG_LLBIT)
+		return false;
+	// Don't allow PC either.
+	if (r == 241)
+		return false;
+
+	return true;
+}
+
+bool IRNativeRegCacheBase::IsValidGPRNoZero(IRReg r) const {
+	return IsValidGPR(r) && r != MIPS_REG_ZERO;
+}
+
+bool IRNativeRegCacheBase::IsValidFPR(IRReg r) const {
+	// FPR parameters are off by 32 within the MIPSState object.
+	if (r >= TOTAL_MAPPABLE_IRREGS - 32)
+		return false;
+
+	// See MIPSState for these offsets.
+	int index = r + 32;
+
+	// Allow FPU or VFPU regs here.
+	if (index >= 32 && index < 32 + 32 + 128)
+		return true;
+	// Also allow VFPU temps.
+	if (index >= 224 && index < 224 + 16)
+		return true;
+
+	// Nothing else is allowed for the FPU side.
+	return false;
 }

--- a/Core/MIPS/IR/IRRegCache.h
+++ b/Core/MIPS/IR/IRRegCache.h
@@ -1,3 +1,20 @@
+// Copyright (c) 2023- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
 #pragma once
 
 // IRImmRegCache is only to perform pre-constant folding. This is worth it to get cleaner
@@ -7,16 +24,21 @@
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/IR/IRInst.h"
 
-enum {
-	TOTAL_MAPPABLE_MIPSREGS = 256,
-};
 
-struct RegIR {
-	bool isImm;
-	u32 immVal;
-};
+// Have to account for all of them due to temps, etc.
+constexpr int TOTAL_MAPPABLE_IRREGS = 256;
+// Arbitrary - increase if your backend has more.
+constexpr int TOTAL_POSSIBLE_NATIVEREGS = 128;
+
+constexpr IRReg IRREG_INVALID = 255;
 
 class IRWriter;
+class MIPSState;
+
+namespace MIPSComp {
+class IRBlock;
+struct JitOptions;
+}
 
 // Transient
 class IRImmRegCache {
@@ -43,6 +65,99 @@ public:
 private:
 	void Flush(IRReg rd);
 	void Discard(IRReg rd);
-	RegIR reg_[TOTAL_MAPPABLE_MIPSREGS];
+
+	struct RegIR {
+		bool isImm;
+		u32 immVal;
+	};
+
+	RegIR reg_[TOTAL_MAPPABLE_IRREGS];
 	IRWriter *ir_;
+};
+
+class IRNativeRegCache {
+protected:
+	enum class MIPSLoc {
+		// Known immediate value (only in regcache.)
+		IMM,
+		// In a general reg.
+		REG,
+		// In a general reg, but an adjusted pointer (not pointerified - unaligned.)
+		REG_AS_PTR,
+		// In a general reg, but also has a known immediate value.
+		REG_IMM,
+		// In a native floating-point reg.
+		FREG,
+		// In a native vector reg.
+		VREG,
+		// Away in memory (in the mips context struct.)
+		MEM,
+	};
+
+	struct RegStatusMIPS {
+		// Where is this IR/MIPS register?
+		MIPSLoc loc = MIPSLoc::MEM;
+		// If in a register, what index (into nr array)?
+		int8_t nReg = -1;
+		// If a known immediate value, what value?
+		uint64_t imm = 0;
+		// Locked from spilling (i.e. used by current instruction) as of what IR instruction?
+		int spillLockIRIndex = -1;
+		// If in a multipart reg (vector or HI/LO), which lane?
+		int lane = -1;
+		// Whether this reg is statically allocated.
+		bool isStatic = false;
+	};
+	struct RegStatusNative {
+		// Which IR/MIPS reg is this currently holding?
+		IRReg mipsReg = IRREG_INVALID;
+		// Locked either as temp or direct reg as of what IR instruction?
+		int tempLockIRIndex = -1;
+		// Should the register be written back?
+		bool isDirty = false;
+		// Upper part of the register is used for "pointerification".
+		// Depending on backend, this may not be used or some/all operations may work on the lower 32 bits.
+		bool pointerified = false;
+		// Upper part of the register has a normalized form (i.e. zero or sign extend.)
+		// Which this means or if it matters depends on the backend.
+		bool normalized32 = false;
+	};
+
+	struct StaticAllocation {
+		IRReg mr;
+		int8_t nr;
+		// Whether the reg should be marked pointerified by default.
+		bool pointerified = false;
+		// Whether the reg should be considered always normalized at the start of a block.
+		bool normalized32 = false;
+	};
+
+public:
+	IRNativeRegCache(MIPSComp::JitOptions *jo);
+	virtual ~IRNativeRegCache() {}
+
+	virtual void Start(MIPSComp::IRBlock *irBlock);
+	void SetIRIndex(int index) {
+		irIndex_ = index;
+	}
+
+protected:
+	virtual void SetupInitialRegs();
+	virtual const StaticAllocation *GetStaticAllocations(int &count) {
+		count = 0;
+		return nullptr;
+	}
+
+	MIPSComp::JitOptions *jo_;
+	MIPSComp::IRBlock *irBlock_ = nullptr;
+	int irIndex_ = 0;
+	int totalNativeRegs_ = 0;
+
+	RegStatusNative nr[TOTAL_POSSIBLE_NATIVEREGS];
+	RegStatusMIPS mr[TOTAL_MAPPABLE_IRREGS];
+	RegStatusNative nrInitial_[TOTAL_POSSIBLE_NATIVEREGS];
+	RegStatusMIPS mrInitial_[TOTAL_MAPPABLE_IRREGS];
+
+	bool initialReady_ = false;
+	bool pendingFlush_ = false;
 };

--- a/Core/MIPS/IR/IRRegCache.h
+++ b/Core/MIPS/IR/IRRegCache.h
@@ -183,6 +183,8 @@ public:
 	void MarkGPRDirty(IRReg gpr, bool andNormalized32 = false);
 	void MarkGPRAsPointerDirty(IRReg gpr);
 
+	virtual void FlushAll();
+
 protected:
 	virtual void SetupInitialRegs();
 	virtual const int *GetAllocationOrder(MIPSLoc type, int &count, int &base) const = 0;
@@ -196,6 +198,8 @@ protected:
 	IRNativeReg FindBestToSpill(MIPSLoc type, bool unusedOnly, bool *clobbered) const;
 	virtual void DiscardNativeReg(IRNativeReg nreg);
 	virtual void FlushNativeReg(IRNativeReg nreg);
+	virtual void DiscardReg(IRReg mreg);
+	virtual void FlushReg(IRReg mreg);
 	virtual void AdjustNativeRegAsPtr(IRNativeReg nreg, bool state);
 	virtual void MapNativeReg(MIPSLoc type, IRNativeReg nreg, IRReg first, int lanes, MIPSMap flags);
 	virtual IRNativeReg MapNativeReg(MIPSLoc type, IRReg first, int lanes, MIPSMap flags);
@@ -211,6 +215,7 @@ protected:
 	virtual void StoreRegValue(IRReg mreg, uint32_t imm) = 0;
 
 	void SetSpillLockIRIndex(IRReg reg, IRReg reg2, IRReg reg3, IRReg reg4, int offset, int index);
+	int GetMipsRegOffset(IRReg r);
 
 	bool IsValidGPR(IRReg r) const;
 	bool IsValidGPRNoZero(IRReg r) const;
@@ -227,5 +232,4 @@ protected:
 	RegStatusMIPS mrInitial_[TOTAL_MAPPABLE_IRREGS];
 
 	bool initialReady_ = false;
-	bool pendingFlush_ = false;
 };

--- a/Core/MIPS/IR/IRRegCache.h
+++ b/Core/MIPS/IR/IRRegCache.h
@@ -102,7 +102,7 @@ protected:
 		// If in a register, what index (into nr array)?
 		IRNativeReg nReg = -1;
 		// If a known immediate value, what value?
-		uint64_t imm = 0;
+		uint32_t imm = 0;
 		// Locked from spilling (i.e. used by current instruction) as of what IR instruction?
 		int spillLockIRIndex = -1;
 		// If in a multipart reg (vector or HI/LO), which lane?
@@ -145,6 +145,27 @@ public:
 		irIndex_ = index;
 	}
 
+	bool IsGPRInRAM(IRReg gpr);
+	bool IsFPRInRAM(IRReg fpr);
+	bool IsGPRMapped(IRReg gpr);
+	bool IsFPRMapped(IRReg fpr);
+	bool IsGPRMappedAsPointer(IRReg gpr);
+	bool IsGPRMappedAsStaticPointer(IRReg gpr);
+
+	bool IsGPRImm(IRReg gpr);
+	bool IsGPR2Imm(IRReg base);
+	uint32_t GetGPRImm(IRReg gpr);
+	uint64_t GetGPR2Imm(IRReg first);
+	void SetGPRImm(IRReg gpr, uint32_t immval);
+	void SetGPR2Imm(IRReg first, uint64_t immval);
+
+	// Protect the native registers containing register froms spilling, to ensure that
+	// it's being kept allocated.
+	void SpillLockGPR(IRReg reg, IRReg reg2 = IRREG_INVALID, IRReg reg3 = IRREG_INVALID, IRReg reg4 = IRREG_INVALID);
+	void SpillLockFPR(IRReg reg, IRReg reg2 = IRREG_INVALID, IRReg reg3 = IRREG_INVALID, IRReg reg4 = IRREG_INVALID);
+	void ReleaseSpillLockGPR(IRReg reg, IRReg reg2 = IRREG_INVALID, IRReg reg3 = IRREG_INVALID, IRReg reg4 = IRREG_INVALID);
+	void ReleaseSpillLockFPR(IRReg reg, IRReg reg2 = IRREG_INVALID, IRReg reg3 = IRREG_INVALID, IRReg reg4 = IRREG_INVALID);
+
 protected:
 	virtual void SetupInitialRegs();
 	virtual const int *GetAllocationOrder(MIPSLoc type, int &count, int &base) const = 0;
@@ -160,6 +181,8 @@ protected:
 	virtual void FlushNativeReg(IRNativeReg nreg);
 	virtual void AdjustNativeRegAsPtr(IRNativeReg nreg, bool state);
 	virtual void StoreNativeReg(IRNativeReg nreg, IRReg first, int lanes) = 0;
+
+	void SetSpillLockIRIndex(IRReg reg, IRReg reg2, IRReg reg3, IRReg reg4, int offset, int index);
 
 	bool IsValidGPR(IRReg r) const;
 	bool IsValidGPRNoZero(IRReg r) const;

--- a/Core/MIPS/IR/IRRegCache.h
+++ b/Core/MIPS/IR/IRRegCache.h
@@ -199,6 +199,7 @@ protected:
 	virtual void AdjustNativeRegAsPtr(IRNativeReg nreg, bool state);
 	virtual void MapNativeReg(MIPSLoc type, IRNativeReg nreg, IRReg first, int lanes, MIPSMap flags);
 	virtual IRNativeReg MapNativeReg(MIPSLoc type, IRReg first, int lanes, MIPSMap flags);
+	IRNativeReg MapNativeRegAsPointer(IRReg gpr);
 
 	// Load data from memory (possibly multiple lanes) into a native reg.
 	virtual void LoadNativeReg(IRNativeReg nreg, IRReg first, int lanes) = 0;

--- a/Core/MIPS/IR/IRRegCache.h
+++ b/Core/MIPS/IR/IRRegCache.h
@@ -166,6 +166,9 @@ public:
 	void ReleaseSpillLockGPR(IRReg reg, IRReg reg2 = IRREG_INVALID, IRReg reg3 = IRREG_INVALID, IRReg reg4 = IRREG_INVALID);
 	void ReleaseSpillLockFPR(IRReg reg, IRReg reg2 = IRREG_INVALID, IRReg reg3 = IRREG_INVALID, IRReg reg4 = IRREG_INVALID);
 
+	void MarkGPRDirty(IRReg gpr, bool andNormalized32 = false);
+	void MarkGPRAsPointerDirty(IRReg gpr);
+
 protected:
 	virtual void SetupInitialRegs();
 	virtual const int *GetAllocationOrder(MIPSLoc type, int &count, int &base) const = 0;

--- a/Core/MIPS/RiscV/RiscVCompALU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompALU.cpp
@@ -65,8 +65,8 @@ void RiscVJitBackend::CompIR_Arith(IRInst inst) {
 	case IROp::AddConst:
 		if ((int32_t)inst.constant >= -2048 && (int32_t)inst.constant <= 2047) {
 			// Typical of stack pointer updates.
-			if (gpr.IsGPRMappedAsPointer(inst.src1) && inst.dest == inst.src1 && allowPtrMath) {
-				gpr.MarkPtrDirty(gpr.RPtr(inst.dest));
+			if (gpr.IsGPRMappedAsPointer(inst.dest) && inst.dest == inst.src1 && allowPtrMath) {
+				gpr.MarkGPRAsPointerDirty(inst.dest);
 				ADDI(gpr.RPtr(inst.dest), gpr.RPtr(inst.dest), inst.constant);
 			} else {
 				gpr.MapDirtyIn(inst.dest, inst.src1, MapType::AVOID_LOAD_MARK_NORM32);
@@ -107,7 +107,7 @@ void RiscVJitBackend::CompIR_Logic(IRInst inst) {
 		} else if (inst.src1 != inst.dest) {
 			gpr.MapDirtyIn(inst.dest, inst.src1);
 			MV(gpr.R(inst.dest), gpr.R(inst.src1));
-			gpr.MarkDirty(gpr.R(inst.dest), gpr.IsNormalized32(inst.src1));
+			gpr.MarkGPRDirty(inst.dest, gpr.IsNormalized32(inst.src1));
 		}
 		break;
 
@@ -117,11 +117,11 @@ void RiscVJitBackend::CompIR_Logic(IRInst inst) {
 			OR(gpr.R(inst.dest), gpr.R(inst.src1), gpr.R(inst.src2));
 			// If both were normalized before, the result is normalized.
 			if (gpr.IsNormalized32(inst.src1) && gpr.IsNormalized32(inst.src2))
-				gpr.MarkDirty(gpr.R(inst.dest), true);
+				gpr.MarkGPRDirty(inst.dest, true);
 		} else if (inst.src1 != inst.dest) {
 			gpr.MapDirtyIn(inst.dest, inst.src1);
 			MV(gpr.R(inst.dest), gpr.R(inst.src1));
-			gpr.MarkDirty(gpr.R(inst.dest), gpr.IsNormalized32(inst.src1));
+			gpr.MarkGPRDirty(inst.dest, gpr.IsNormalized32(inst.src1));
 		}
 		break;
 
@@ -145,10 +145,10 @@ void RiscVJitBackend::CompIR_Logic(IRInst inst) {
 		}
 		// If the sign bits aren't cleared, and it was normalized before - it still is.
 		if ((inst.constant & 0x80000000) != 0 && gpr.IsNormalized32(inst.src1))
-			gpr.MarkDirty(gpr.R(inst.dest), true);
+			gpr.MarkGPRDirty(inst.dest, true);
 		// Otherwise, if we cleared the sign bits, it's naturally normalized.
 		else if ((inst.constant & 0x80000000) == 0)
-			gpr.MarkDirty(gpr.R(inst.dest), true);
+			gpr.MarkGPRDirty(inst.dest, true);
 		break;
 
 	case IROp::OrConst:
@@ -162,7 +162,7 @@ void RiscVJitBackend::CompIR_Logic(IRInst inst) {
 		}
 		// Since our constant is normalized, oring its bits in won't hurt normalization.
 		if (gpr.IsNormalized32(inst.src1))
-			gpr.MarkDirty(gpr.R(inst.dest), true);
+			gpr.MarkGPRDirty(inst.dest, true);
 		break;
 
 	case IROp::XorConst:
@@ -195,7 +195,7 @@ void RiscVJitBackend::CompIR_Assign(IRInst inst) {
 		if (inst.dest != inst.src1) {
 			gpr.MapDirtyIn(inst.dest, inst.src1);
 			MV(gpr.R(inst.dest), gpr.R(inst.src1));
-			gpr.MarkDirty(gpr.R(inst.dest), gpr.IsNormalized32(inst.src1));
+			gpr.MarkGPRDirty(inst.dest, gpr.IsNormalized32(inst.src1));
 		}
 		break;
 
@@ -280,7 +280,7 @@ void RiscVJitBackend::CompIR_Bits(IRInst inst) {
 			if (XLEN >= 64) {
 				// REV8 swaps the entire register, so get the 32 highest bits.
 				SRAI(gpr.R(inst.dest), gpr.R(inst.dest), XLEN - 32);
-				gpr.MarkDirty(gpr.R(inst.dest), true);
+				gpr.MarkGPRDirty(inst.dest, true);
 			}
 		} else {
 			CompIR_Generic(inst);
@@ -339,7 +339,7 @@ void RiscVJitBackend::CompIR_Shift(IRInst inst) {
 			if (inst.dest != inst.src1) {
 				gpr.MapDirtyIn(inst.dest, inst.src1);
 				MV(gpr.R(inst.dest), gpr.R(inst.src1));
-				gpr.MarkDirty(gpr.R(inst.dest), gpr.IsNormalized32(inst.src1));
+				gpr.MarkGPRDirty(inst.dest, gpr.IsNormalized32(inst.src1));
 			}
 		} else {
 			gpr.MapDirtyIn(inst.dest, inst.src1, MapType::AVOID_LOAD_MARK_NORM32);
@@ -355,7 +355,7 @@ void RiscVJitBackend::CompIR_Shift(IRInst inst) {
 			if (inst.dest != inst.src1) {
 				gpr.MapDirtyIn(inst.dest, inst.src1);
 				MV(gpr.R(inst.dest), gpr.R(inst.src1));
-				gpr.MarkDirty(gpr.R(inst.dest), gpr.IsNormalized32(inst.src1));
+				gpr.MarkGPRDirty(inst.dest, gpr.IsNormalized32(inst.src1));
 			}
 		} else {
 			gpr.MapDirtyIn(inst.dest, inst.src1, MapType::AVOID_LOAD_MARK_NORM32);
@@ -372,7 +372,7 @@ void RiscVJitBackend::CompIR_Shift(IRInst inst) {
 			if (inst.dest != inst.src1) {
 				gpr.MapDirtyIn(inst.dest, inst.src1);
 				MV(gpr.R(inst.dest), gpr.R(inst.src1));
-				gpr.MarkDirty(gpr.R(inst.dest), gpr.IsNormalized32(inst.src1));
+				gpr.MarkGPRDirty(inst.dest, gpr.IsNormalized32(inst.src1));
 			}
 		} else {
 			gpr.MapDirtyIn(inst.dest, inst.src1, MapType::AVOID_LOAD_MARK_NORM32);
@@ -385,7 +385,7 @@ void RiscVJitBackend::CompIR_Shift(IRInst inst) {
 			if (inst.dest != inst.src1) {
 				gpr.MapDirtyIn(inst.dest, inst.src1);
 				MV(gpr.R(inst.dest), gpr.R(inst.src1));
-				gpr.MarkDirty(gpr.R(inst.dest), gpr.IsNormalized32(inst.src1));
+				gpr.MarkGPRDirty(inst.dest, gpr.IsNormalized32(inst.src1));
 			}
 		} else if (cpu_info.RiscV_Zbb) {
 			gpr.MapDirtyIn(inst.dest, inst.src1, MapType::AVOID_LOAD_MARK_NORM32);
@@ -434,7 +434,7 @@ void RiscVJitBackend::CompIR_Compare(IRInst inst) {
 				LI(SCRATCH2, (int32_t)inst.constant);
 				SLT(gpr.R(inst.dest), lhs, SCRATCH2);
 			}
-			gpr.MarkDirty(gpr.R(inst.dest), true);
+			gpr.MarkGPRDirty(inst.dest, true);
 		}
 		break;
 
@@ -514,14 +514,14 @@ void RiscVJitBackend::CompIR_CondAssign(IRInst inst) {
 				NormalizeSrc12(inst, &lhs, &rhs, SCRATCH1, SCRATCH2, true);
 				MAX(gpr.R(inst.dest), lhs, rhs);
 				// Because we had to normalize the inputs, the output is normalized.
-				gpr.MarkDirty(gpr.R(inst.dest), true);
+				gpr.MarkGPRDirty(inst.dest, true);
 			} else {
 				CompIR_Generic(inst);
 			}
 		} else if (inst.dest != inst.src1) {
 			gpr.MapDirtyIn(inst.dest, inst.src1);
 			MV(gpr.R(inst.dest), gpr.R(inst.src1));
-			gpr.MarkDirty(gpr.R(inst.dest), gpr.IsNormalized32(inst.src1));
+			gpr.MarkGPRDirty(inst.dest, gpr.IsNormalized32(inst.src1));
 		}
 		break;
 
@@ -532,14 +532,14 @@ void RiscVJitBackend::CompIR_CondAssign(IRInst inst) {
 				NormalizeSrc12(inst, &lhs, &rhs, SCRATCH1, SCRATCH2, true);
 				MIN(gpr.R(inst.dest), lhs, rhs);
 				// Because we had to normalize the inputs, the output is normalized.
-				gpr.MarkDirty(gpr.R(inst.dest), true);
+				gpr.MarkGPRDirty(inst.dest, true);
 			} else {
 				CompIR_Generic(inst);
 			}
 		} else if (inst.dest != inst.src1) {
 			gpr.MapDirtyIn(inst.dest, inst.src1);
 			MV(gpr.R(inst.dest), gpr.R(inst.src1));
-			gpr.MarkDirty(gpr.R(inst.dest), gpr.IsNormalized32(inst.src1));
+			gpr.MarkGPRDirty(inst.dest, gpr.IsNormalized32(inst.src1));
 		}
 		break;
 
@@ -556,25 +556,25 @@ void RiscVJitBackend::CompIR_HiLo(IRInst inst) {
 	case IROp::MtLo:
 		gpr.MapDirtyIn(IRREG_LO, inst.src1);
 		MV(gpr.R(IRREG_LO), gpr.R(inst.src1));
-		gpr.MarkDirty(gpr.R(IRREG_LO), gpr.IsNormalized32(inst.src1));
+		gpr.MarkGPRDirty(IRREG_LO, gpr.IsNormalized32(inst.src1));
 		break;
 
 	case IROp::MtHi:
 		gpr.MapDirtyIn(IRREG_HI, inst.src1);
 		MV(gpr.R(IRREG_HI), gpr.R(inst.src1));
-		gpr.MarkDirty(gpr.R(IRREG_HI), gpr.IsNormalized32(inst.src1));
+		gpr.MarkGPRDirty(IRREG_HI, gpr.IsNormalized32(inst.src1));
 		break;
 
 	case IROp::MfLo:
 		gpr.MapDirtyIn(inst.dest, IRREG_LO);
 		MV(gpr.R(inst.dest), gpr.R(IRREG_LO));
-		gpr.MarkDirty(gpr.R(inst.dest), gpr.IsNormalized32(IRREG_LO));
+		gpr.MarkGPRDirty(inst.dest, gpr.IsNormalized32(IRREG_LO));
 		break;
 
 	case IROp::MfHi:
 		gpr.MapDirtyIn(inst.dest, IRREG_HI);
 		MV(gpr.R(inst.dest), gpr.R(IRREG_HI));
-		gpr.MarkDirty(gpr.R(inst.dest), gpr.IsNormalized32(IRREG_HI));
+		gpr.MarkGPRDirty(inst.dest, gpr.IsNormalized32(IRREG_HI));
 		break;
 
 	default:
@@ -612,7 +612,7 @@ void RiscVJitBackend::CompIR_Mult(IRInst inst) {
 	};
 	auto splitMulResult = [&] {
 		SRAI(gpr.R(IRREG_HI), gpr.R(IRREG_LO), 32);
-		gpr.MarkDirty(gpr.R(IRREG_HI), true);
+		gpr.MarkGPRDirty(IRREG_HI, true);
 	};
 
 	RiscVReg lhs = INVALID_REG;

--- a/Core/MIPS/RiscV/RiscVCompFPU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompFPU.cpp
@@ -117,8 +117,6 @@ void RiscVJitBackend::CompIR_FCondAssign(IRInst inst) {
 		SetJumpTarget(skipSwapCompare);
 	} else {
 		RiscVReg isSrc1LowerReg = gpr.GetAndLockTempR();
-		gpr.ReleaseSpillLocksAndDiscardTemps();
-
 		SLT(isSrc1LowerReg, SCRATCH1, SCRATCH2);
 		// Flip the flag (to reverse the min/max) based on if both were negative.
 		XOR(isSrc1LowerReg, isSrc1LowerReg, R_RA);
@@ -342,7 +340,7 @@ void RiscVJitBackend::CompIR_FSat(IRInst inst) {
 void RiscVJitBackend::CompIR_FCompare(IRInst inst) {
 	CONDITIONAL_DISABLE;
 
-	constexpr IRRegIndex IRREG_VFPUL_CC = IRREG_VFPU_CTRL_BASE + VFPU_CTRL_CC;
+	constexpr IRReg IRREG_VFPUL_CC = IRREG_VFPU_CTRL_BASE + VFPU_CTRL_CC;
 
 	switch (inst.op) {
 	case IROp::FCmp:

--- a/Core/MIPS/RiscV/RiscVCompFPU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompFPU.cpp
@@ -346,7 +346,7 @@ void RiscVJitBackend::CompIR_FCompare(IRInst inst) {
 	case IROp::FCmp:
 		switch (inst.dest) {
 		case IRFpCompareMode::False:
-			gpr.SetImm(IRREG_FPCOND, 0);
+			gpr.SetGPRImm(IRREG_FPCOND, 0);
 			break;
 
 		case IRFpCompareMode::EitherUnordered:
@@ -584,7 +584,7 @@ void RiscVJitBackend::CompIR_FSpecial(IRInst inst) {
 		gpr.FlushBeforeCall();
 		fpr.FlushBeforeCall();
 		// It might be in a non-volatile register.
-		if (fpr.IsMapped(inst.src1)) {
+		if (fpr.IsFPRMapped(inst.src1)) {
 			FMV(32, F10, fpr.R(inst.src1));
 		} else {
 			int offset = offsetof(MIPSState, f) + inst.src1 * 4;

--- a/Core/MIPS/RiscV/RiscVCompSystem.cpp
+++ b/Core/MIPS/RiscV/RiscVCompSystem.cpp
@@ -96,7 +96,7 @@ void RiscVJitBackend::CompIR_Transfer(IRInst inst) {
 	case IROp::SetCtrlVFPUReg:
 		gpr.MapDirtyIn(IRREG_VFPU_CTRL_BASE + inst.dest, inst.src1);
 		MV(gpr.R(IRREG_VFPU_CTRL_BASE + inst.dest), gpr.R(inst.src1));
-		gpr.MarkDirty(gpr.R(IRREG_VFPU_CTRL_BASE + inst.dest), gpr.IsNormalized32(inst.src1));
+		gpr.MarkGPRDirty(IRREG_VFPU_CTRL_BASE + inst.dest, gpr.IsNormalized32(inst.src1));
 		break;
 
 	case IROp::SetCtrlVFPUFReg:
@@ -113,7 +113,7 @@ void RiscVJitBackend::CompIR_Transfer(IRInst inst) {
 	case IROp::FpCondToReg:
 		gpr.MapDirtyIn(inst.dest, IRREG_FPCOND);
 		MV(gpr.R(inst.dest), gpr.R(IRREG_FPCOND));
-		gpr.MarkDirty(gpr.R(inst.dest), gpr.IsNormalized32(IRREG_FPCOND));
+		gpr.MarkGPRDirty(inst.dest, gpr.IsNormalized32(IRREG_FPCOND));
 		break;
 
 	case IROp::FpCtrlFromReg:
@@ -153,7 +153,7 @@ void RiscVJitBackend::CompIR_Transfer(IRInst inst) {
 	case IROp::VfpuCtrlToReg:
 		gpr.MapDirtyIn(inst.dest, IRREG_VFPU_CTRL_BASE + inst.src1);
 		MV(gpr.R(inst.dest), gpr.R(IRREG_VFPU_CTRL_BASE + inst.src1));
-		gpr.MarkDirty(gpr.R(inst.dest), gpr.IsNormalized32(IRREG_VFPU_CTRL_BASE + inst.src1));
+		gpr.MarkGPRDirty(inst.dest, gpr.IsNormalized32(IRREG_VFPU_CTRL_BASE + inst.src1));
 		break;
 
 	case IROp::FMovFromGPR:

--- a/Core/MIPS/RiscV/RiscVCompSystem.cpp
+++ b/Core/MIPS/RiscV/RiscVCompSystem.cpp
@@ -45,7 +45,7 @@ void RiscVJitBackend::CompIR_Basic(IRInst inst) {
 	case IROp::SetConst:
 		// Sign extend all constants.  We get 0xFFFFFFFF sometimes, and it's more work to truncate.
 		// The register only holds 32 bits in the end anyway.
-		gpr.SetImm(inst.dest, (int32_t)inst.constant);
+		gpr.SetGPRImm(inst.dest, (int32_t)inst.constant);
 		break;
 
 	case IROp::SetConstF:
@@ -90,7 +90,7 @@ void RiscVJitBackend::CompIR_Transfer(IRInst inst) {
 
 	switch (inst.op) {
 	case IROp::SetCtrlVFPU:
-		gpr.SetImm(IRREG_VFPU_CTRL_BASE + inst.dest, (int32_t)inst.constant);
+		gpr.SetGPRImm(IRREG_VFPU_CTRL_BASE + inst.dest, (int32_t)inst.constant);
 		break;
 
 	case IROp::SetCtrlVFPUReg:
@@ -158,7 +158,7 @@ void RiscVJitBackend::CompIR_Transfer(IRInst inst) {
 
 	case IROp::FMovFromGPR:
 		fpr.MapReg(inst.dest, MIPSMap::NOINIT);
-		if (gpr.IsImm(inst.src1) && gpr.GetImm(inst.src1) == 0) {
+		if (gpr.IsGPRImm(inst.src1) && gpr.GetGPRImm(inst.src1) == 0) {
 			FCVT(FConv::S, FConv::W, fpr.R(inst.dest), R_ZERO);
 		} else {
 			gpr.MapReg(inst.src1);

--- a/Core/MIPS/RiscV/RiscVCompVec.cpp
+++ b/Core/MIPS/RiscV/RiscVCompVec.cpp
@@ -309,7 +309,6 @@ void RiscVJitBackend::CompIR_VecPack(IRInst inst) {
 		fpr.MapReg(inst.src1);
 		for (int i = 0; i < 4; ++i)
 			fpr.MapReg(inst.dest + i, MIPSMap::NOINIT);
-		fpr.ReleaseSpillLocksAndDiscardTemps();
 
 		FMV(FMv::X, FMv::W, SCRATCH2, fpr.R(inst.src1));
 		for (int i = 0; i < 4; ++i) {
@@ -331,7 +330,6 @@ void RiscVJitBackend::CompIR_VecPack(IRInst inst) {
 		fpr.MapReg(inst.src1);
 		for (int i = 0; i < 2; ++i)
 			fpr.MapReg(inst.dest + i, MIPSMap::NOINIT);
-		fpr.ReleaseSpillLocksAndDiscardTemps();
 
 		FMV(FMv::X, FMv::W, SCRATCH2, fpr.R(inst.src1));
 		SLLI(SCRATCH1, SCRATCH2, 16);
@@ -361,7 +359,6 @@ void RiscVJitBackend::CompIR_VecPack(IRInst inst) {
 			fpr.MapReg(inst.src1 + i);
 		}
 		fpr.MapReg(inst.dest, MIPSMap::NOINIT);
-		fpr.ReleaseSpillLocksAndDiscardTemps();
 
 		for (int i = 0; i < 4; ++i) {
 			FMV(FMv::X, FMv::W, SCRATCH1, fpr.R(inst.src1 + i));

--- a/Core/MIPS/RiscV/RiscVCompVec.cpp
+++ b/Core/MIPS/RiscV/RiscVCompVec.cpp
@@ -41,11 +41,9 @@ void RiscVJitBackend::CompIR_VecAssign(IRInst inst) {
 	switch (inst.op) {
 	case IROp::Vec4Init:
 		for (int i = 0; i < 4; ++i)
-			fpr.SpillLock(inst.dest + i);
+			fpr.SpillLockFPR(inst.dest + i);
 		for (int i = 0; i < 4; ++i)
 			fpr.MapReg(inst.dest + i, MIPSMap::NOINIT);
-		for (int i = 0; i < 4; ++i)
-			fpr.ReleaseSpillLock(inst.dest + i);
 
 		// TODO: Check if FCVT/FMV/FL is better.
 		switch ((Vec4Init)inst.src1) {
@@ -220,10 +218,9 @@ void RiscVJitBackend::CompIR_VecArith(IRInst inst) {
 		break;
 
 	case IROp::Vec4Scale:
-		fpr.SpillLock(inst.src2);
+		fpr.SpillLockFPR(inst.src2);
 		fpr.MapReg(inst.src2);
 		fpr.Map4DirtyIn(inst.dest, inst.src1);
-		fpr.ReleaseSpillLock(inst.src2);
 		for (int i = 0; i < 4; ++i)
 			FMUL(32, fpr.R(inst.dest + i), fpr.R(inst.src1 + i), fpr.R(inst.src2));
 		break;
@@ -252,21 +249,16 @@ void RiscVJitBackend::CompIR_VecHoriz(IRInst inst) {
 	switch (inst.op) {
 	case IROp::Vec4Dot:
 		// TODO: Maybe some option to call the slow accurate mode?
-		fpr.SpillLock(inst.dest);
+		fpr.SpillLockFPR(inst.dest);
 		for (int i = 0; i < 4; ++i) {
-			fpr.SpillLock(inst.src1 + i);
-			fpr.SpillLock(inst.src2 + i);
+			fpr.SpillLockFPR(inst.src1 + i);
+			fpr.SpillLockFPR(inst.src2 + i);
 		}
 		for (int i = 0; i < 4; ++i) {
 			fpr.MapReg(inst.src1 + i);
 			fpr.MapReg(inst.src2 + i);
 		}
 		fpr.MapReg(inst.dest, MIPSMap::NOINIT);
-		for (int i = 0; i < 4; ++i) {
-			fpr.ReleaseSpillLock(inst.src1 + i);
-			fpr.ReleaseSpillLock(inst.src2 + i);
-		}
-		fpr.ReleaseSpillLock(inst.dest);
 
 		if ((inst.dest < inst.src1 + 4 && inst.dest >= inst.src1) || (inst.dest < inst.src2 + 4 && inst.dest >= inst.src2)) {
 			// This means inst.dest overlaps one of src1 or src2.  We have to do that one first.
@@ -303,9 +295,9 @@ void RiscVJitBackend::CompIR_VecPack(IRInst inst) {
 		break;
 
 	case IROp::Vec4Unpack8To32:
-		fpr.SpillLock(inst.src1);
+		fpr.SpillLockFPR(inst.src1);
 		for (int i = 0; i < 4; ++i)
-			fpr.SpillLock(inst.dest + i);
+			fpr.SpillLockFPR(inst.dest + i);
 		fpr.MapReg(inst.src1);
 		for (int i = 0; i < 4; ++i)
 			fpr.MapReg(inst.dest + i, MIPSMap::NOINIT);
@@ -324,9 +316,9 @@ void RiscVJitBackend::CompIR_VecPack(IRInst inst) {
 		break;
 
 	case IROp::Vec2Unpack16To32:
-		fpr.SpillLock(inst.src1);
+		fpr.SpillLockFPR(inst.src1);
 		for (int i = 0; i < 2; ++i)
-			fpr.SpillLock(inst.dest + i);
+			fpr.SpillLockFPR(inst.dest + i);
 		fpr.MapReg(inst.src1);
 		for (int i = 0; i < 2; ++i)
 			fpr.MapReg(inst.dest + i, MIPSMap::NOINIT);
@@ -353,9 +345,9 @@ void RiscVJitBackend::CompIR_VecPack(IRInst inst) {
 		break;
 
 	case IROp::Vec4Pack31To8:
-		fpr.SpillLock(inst.dest);
+		fpr.SpillLockFPR(inst.dest);
 		for (int i = 0; i < 4; ++i) {
-			fpr.SpillLock(inst.src1 + i);
+			fpr.SpillLockFPR(inst.src1 + i);
 			fpr.MapReg(inst.src1 + i);
 		}
 		fpr.MapReg(inst.dest, MIPSMap::NOINIT);

--- a/Core/MIPS/RiscV/RiscVJit.cpp
+++ b/Core/MIPS/RiscV/RiscVJit.cpp
@@ -31,8 +31,8 @@ using namespace RiscVJitConstants;
 static constexpr int MIN_BLOCK_NORMAL_LEN = 16;
 static constexpr int MIN_BLOCK_EXIT_LEN = 8;
 
-RiscVJitBackend::RiscVJitBackend(MIPSState *mipsState, JitOptions &jitopt, IRBlockCache &blocks)
-	: IRNativeBackend(blocks), jo(jitopt), gpr(mipsState, &jo), fpr(mipsState, &jo) {
+RiscVJitBackend::RiscVJitBackend(JitOptions &jitopt, IRBlockCache &blocks)
+	: IRNativeBackend(blocks), jo(jitopt), gpr(&jo), fpr(&jo) {
 	// Automatically disable incompatible options.
 	if (((intptr_t)Memory::base & 0x00000000FFFFFFFFUL) != 0) {
 		jo.enablePointerify = false;
@@ -352,7 +352,7 @@ void RiscVJitBackend::NormalizeSrc12(IRInst inst, RiscVReg *lhs, RiscVReg *rhs, 
 	*rhs = NormalizeR(inst.src2, allowOverlap ? 0 : inst.dest, rhsTempReg);
 }
 
-RiscVReg RiscVJitBackend::NormalizeR(IRRegIndex rs, IRRegIndex rd, RiscVReg tempReg) {
+RiscVReg RiscVJitBackend::NormalizeR(IRReg rs, IRReg rd, RiscVReg tempReg) {
 	// For proper compare, we must sign extend so they both match or don't match.
 	// But don't change pointers, in case one is SP (happens in LittleBigPlanet.)
 	if (gpr.IsImm(rs) && gpr.GetImm(rs) == 0) {

--- a/Core/MIPS/RiscV/RiscVJit.cpp
+++ b/Core/MIPS/RiscV/RiscVJit.cpp
@@ -355,9 +355,9 @@ void RiscVJitBackend::NormalizeSrc12(IRInst inst, RiscVReg *lhs, RiscVReg *rhs, 
 RiscVReg RiscVJitBackend::NormalizeR(IRReg rs, IRReg rd, RiscVReg tempReg) {
 	// For proper compare, we must sign extend so they both match or don't match.
 	// But don't change pointers, in case one is SP (happens in LittleBigPlanet.)
-	if (gpr.IsImm(rs) && gpr.GetImm(rs) == 0) {
+	if (gpr.IsGPRImm(rs) && gpr.GetGPRImm(rs) == 0) {
 		return R_ZERO;
-	} else if (gpr.IsMappedAsPointer(rs) || rs == rd) {
+	} else if (gpr.IsGPRMappedAsPointer(rs) || rs == rd) {
 		return gpr.Normalize32(rs, tempReg);
 	} else {
 		return gpr.Normalize32(rs);

--- a/Core/MIPS/RiscV/RiscVJit.h
+++ b/Core/MIPS/RiscV/RiscVJit.h
@@ -31,7 +31,7 @@ namespace MIPSComp {
 
 class RiscVJitBackend : public RiscVGen::RiscVCodeBlock, public IRNativeBackend {
 public:
-	RiscVJitBackend(MIPSState *mipsState, JitOptions &jo, IRBlockCache &blocks);
+	RiscVJitBackend(JitOptions &jo, IRBlockCache &blocks);
 	~RiscVJitBackend();
 
 	bool DescribeCodePtr(const u8 *ptr, std::string &name) const override;
@@ -109,7 +109,7 @@ private:
 	int32_t AdjustForAddressOffset(RiscVGen::RiscVReg *reg, int32_t constant, int32_t range = 0);
 	void NormalizeSrc1(IRInst inst, RiscVGen::RiscVReg *reg, RiscVGen::RiscVReg tempReg, bool allowOverlap);
 	void NormalizeSrc12(IRInst inst, RiscVGen::RiscVReg *lhs, RiscVGen::RiscVReg *rhs, RiscVGen::RiscVReg lhsTempReg, RiscVGen::RiscVReg rhsTempReg, bool allowOverlap);
-	RiscVGen::RiscVReg NormalizeR(IRRegIndex rs, IRRegIndex rd, RiscVGen::RiscVReg tempReg);
+	RiscVGen::RiscVReg NormalizeR(IRReg rs, IRReg rd, RiscVGen::RiscVReg tempReg);
 
 	JitOptions &jo;
 	RiscVRegCache gpr;
@@ -133,7 +133,7 @@ private:
 class RiscVJit : public IRNativeJit {
 public:
 	RiscVJit(MIPSState *mipsState)
-		: IRNativeJit(mipsState), rvBackend_(mipsState, jo, blocks_) {
+		: IRNativeJit(mipsState), rvBackend_(jo, blocks_) {
 		Init(rvBackend_);
 	}
 

--- a/Core/MIPS/RiscV/RiscVRegCache.cpp
+++ b/Core/MIPS/RiscV/RiscVRegCache.cpp
@@ -137,35 +137,6 @@ bool RiscVRegCache::IsNormalized32(IRReg mipsReg) {
 	return false;
 }
 
-void RiscVRegCache::MarkDirty(RiscVReg reg, bool andNormalized32) {
-	// Can't mark X0 dirty.
-	_dbg_assert_(reg > X0 && reg <= X31);
-	nr[reg].isDirty = true;
-	nr[reg].normalized32 = andNormalized32;
-	// If reg is written to, pointerification is lost.
-	nr[reg].pointerified = false;
-	if (nr[reg].mipsReg != IRREG_INVALID) {
-		RegStatusMIPS &m = mr[nr[reg].mipsReg];
-		if (m.loc == MIPSLoc::REG_AS_PTR || m.loc == MIPSLoc::REG_IMM) {
-			m.loc = MIPSLoc::REG;
-			m.imm = -1;
-		}
-		_dbg_assert_(m.loc == MIPSLoc::REG);
-	}
-}
-
-void RiscVRegCache::MarkPtrDirty(RiscVReg reg) {
-	// Can't mark X0 dirty.
-	_dbg_assert_(reg > X0 && reg <= X31);
-	_dbg_assert_(!nr[reg].normalized32);
-	nr[reg].isDirty = true;
-	if (nr[reg].mipsReg != IRREG_INVALID) {
-		_dbg_assert_(mr[nr[reg].mipsReg].loc == MIPSLoc::REG_AS_PTR);
-	} else {
-		_dbg_assert_(nr[reg].pointerified);
-	}
-}
-
 RiscVGen::RiscVReg RiscVRegCache::Normalize32(IRReg mipsReg, RiscVGen::RiscVReg destReg) {
 	_dbg_assert_(IsValidGPR(mipsReg));
 	_dbg_assert_(destReg == INVALID_REG || (destReg > X0 && destReg <= X31));

--- a/Core/MIPS/RiscV/RiscVRegCache.h
+++ b/Core/MIPS/RiscV/RiscVRegCache.h
@@ -20,6 +20,7 @@
 #include "Common/RiscVEmitter.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/IR/IRJit.h"
+#include "Core/MIPS/IR/IRRegCache.h"
 
 namespace RiscVJitConstants {
 
@@ -33,19 +34,6 @@ const RiscVGen::RiscVReg MEMBASEREG = RiscVGen::X27;
 // TODO: Experiment.  X7-X13 are compressed regs.  X8/X9 are saved so nice for static alloc, though.
 const RiscVGen::RiscVReg SCRATCH1 = RiscVGen::X10;
 const RiscVGen::RiscVReg SCRATCH2 = RiscVGen::X11;
-
-// Have to account for all of them due to temps, etc.
-constexpr int TOTAL_MAPPABLE_MIPSREGS = 256;
-
-enum class MIPSLoc {
-	IMM,
-	RVREG,
-	// In a native reg, but an adjusted pointer (not pointerified - unaligned.)
-	RVREG_AS_PTR,
-	// In a native reg, but also has a known immediate value.
-	RVREG_IMM,
-	MEM,
-};
 
 // Initing is the default so the flag is reversed.
 enum class MIPSMap {
@@ -69,129 +57,79 @@ enum class MapType {
 
 } // namespace RiscVJitConstants
 
-namespace MIPSComp {
-struct JitOptions;
-}
-
-// Not using IRReg since this can be -1.
-typedef int IRRegIndex;
-constexpr IRRegIndex IRREG_INVALID = -1;
-
-struct RegStatusRiscV {
-	IRRegIndex mipsReg;  // if -1, no mipsreg attached.
-	bool isDirty;  // Should the register be written back?
-	bool pointerified;  // Has added the memory base into the top part of the reg. Note - still usable as 32-bit reg (in only some cases.)
-	bool tempLocked; // Reserved for a temp register.
-	bool normalized32;  // 32 bits sign extended to XLEN.  RISC-V can't always address just the low 32-bits, so this matters.
-};
-
-struct RegStatusMIPS {
-	// Where is this MIPS register?
-	RiscVJitConstants::MIPSLoc loc;
-	// Data (both or only one may be used, depending on loc.)
-	u64 imm;
-	RiscVGen::RiscVReg reg;  // reg index
-	bool spillLock;  // if true, this register cannot be spilled.
-	bool isStatic;  // if true, this register will not be written back to ram by the regcache
-	// If loc == ML_MEM, it's back in its location in the CPU context struct.
-};
-
-class RiscVRegCache {
+class RiscVRegCache : public IRNativeRegCache {
 public:
-	RiscVRegCache(MIPSState *mipsState, MIPSComp::JitOptions *jo);
-	~RiscVRegCache() {}
+	RiscVRegCache(MIPSComp::JitOptions *jo);
 
 	void Init(RiscVGen::RiscVEmitter *emitter);
-	void Start(MIPSComp::IRBlock *irBlock);
-	void SetIRIndex(int index) {
-		irIndex_ = index;
-	}
 
 	// Protect the arm register containing a MIPS register from spilling, to ensure that
 	// it's being kept allocated.
-	void SpillLock(IRRegIndex reg, IRRegIndex reg2 = IRREG_INVALID, IRRegIndex reg3 = IRREG_INVALID, IRRegIndex reg4 = IRREG_INVALID);
-	void ReleaseSpillLock(IRRegIndex reg, IRRegIndex reg2 = IRREG_INVALID, IRRegIndex reg3 = IRREG_INVALID, IRRegIndex reg4 = IRREG_INVALID);
-	void ReleaseSpillLocksAndDiscardTemps();
+	void SpillLock(IRReg reg, IRReg reg2 = IRREG_INVALID, IRReg reg3 = IRREG_INVALID, IRReg reg4 = IRREG_INVALID);
+	void ReleaseSpillLock(IRReg reg, IRReg reg2 = IRREG_INVALID, IRReg reg3 = IRREG_INVALID, IRReg reg4 = IRREG_INVALID);
 
-	void SetImm(IRRegIndex reg, u64 immVal);
-	bool IsImm(IRRegIndex reg) const;
-	u64 GetImm(IRRegIndex reg) const;
+	void SetImm(IRReg reg, u64 immVal);
+	bool IsImm(IRReg reg) const;
+	u64 GetImm(IRReg reg) const;
 
 	// May fail and return INVALID_REG if it needs flushing.
-	RiscVGen::RiscVReg TryMapTempImm(IRRegIndex);
+	RiscVGen::RiscVReg TryMapTempImm(IRReg);
 
 	// Returns an ARM register containing the requested MIPS register.
-	RiscVGen::RiscVReg MapReg(IRRegIndex reg, RiscVJitConstants::MIPSMap mapFlags = RiscVJitConstants::MIPSMap::INIT);
-	RiscVGen::RiscVReg MapRegAsPointer(IRRegIndex reg);
+	RiscVGen::RiscVReg MapReg(IRReg reg, RiscVJitConstants::MIPSMap mapFlags = RiscVJitConstants::MIPSMap::INIT);
+	RiscVGen::RiscVReg MapRegAsPointer(IRReg reg);
 
-	bool IsMapped(IRRegIndex reg);
-	bool IsMappedAsPointer(IRRegIndex reg);
-	bool IsMappedAsStaticPointer(IRRegIndex reg);
-	bool IsInRAM(IRRegIndex reg);
-	bool IsNormalized32(IRRegIndex reg);
+	bool IsMapped(IRReg reg);
+	bool IsMappedAsPointer(IRReg reg);
+	bool IsMappedAsStaticPointer(IRReg reg);
+	bool IsInRAM(IRReg reg);
+	bool IsNormalized32(IRReg reg);
 
 	void MarkDirty(RiscVGen::RiscVReg reg, bool andNormalized32 = false);
 	void MarkPtrDirty(RiscVGen::RiscVReg reg);
 	// Copies to another reg if specified, otherwise same reg.
-	RiscVGen::RiscVReg Normalize32(IRRegIndex reg, RiscVGen::RiscVReg destReg = RiscVGen::INVALID_REG);
-	void MapIn(IRRegIndex rs);
-	void MapInIn(IRRegIndex rd, IRRegIndex rs);
-	void MapDirtyIn(IRRegIndex rd, IRRegIndex rs, RiscVJitConstants::MapType type = RiscVJitConstants::MapType::AVOID_LOAD);
-	void MapDirtyInIn(IRRegIndex rd, IRRegIndex rs, IRRegIndex rt, RiscVJitConstants::MapType type = RiscVJitConstants::MapType::AVOID_LOAD);
-	void MapDirtyDirtyIn(IRRegIndex rd1, IRRegIndex rd2, IRRegIndex rs, RiscVJitConstants::MapType type = RiscVJitConstants::MapType::AVOID_LOAD);
-	void MapDirtyDirtyInIn(IRRegIndex rd1, IRRegIndex rd2, IRRegIndex rs, IRRegIndex rt, RiscVJitConstants::MapType type = RiscVJitConstants::MapType::AVOID_LOAD);
+	RiscVGen::RiscVReg Normalize32(IRReg reg, RiscVGen::RiscVReg destReg = RiscVGen::INVALID_REG);
+	void MapIn(IRReg rs);
+	void MapInIn(IRReg rd, IRReg rs);
+	void MapDirtyIn(IRReg rd, IRReg rs, RiscVJitConstants::MapType type = RiscVJitConstants::MapType::AVOID_LOAD);
+	void MapDirtyInIn(IRReg rd, IRReg rs, IRReg rt, RiscVJitConstants::MapType type = RiscVJitConstants::MapType::AVOID_LOAD);
+	void MapDirtyDirtyIn(IRReg rd1, IRReg rd2, IRReg rs, RiscVJitConstants::MapType type = RiscVJitConstants::MapType::AVOID_LOAD);
+	void MapDirtyDirtyInIn(IRReg rd1, IRReg rd2, IRReg rs, IRReg rt, RiscVJitConstants::MapType type = RiscVJitConstants::MapType::AVOID_LOAD);
 	void FlushBeforeCall();
 	void FlushAll();
-	void FlushR(IRRegIndex r);
+	void FlushR(IRReg r);
 	void FlushRiscVReg(RiscVGen::RiscVReg r);
-	void DiscardR(IRRegIndex r);
+	void DiscardR(IRReg r);
 
 	RiscVGen::RiscVReg GetAndLockTempR();
 
-	RiscVGen::RiscVReg R(IRRegIndex preg); // Returns a cached register, while checking that it's NOT mapped as a pointer
-	RiscVGen::RiscVReg RPtr(IRRegIndex preg); // Returns a cached register, if it has been mapped as a pointer
+	RiscVGen::RiscVReg R(IRReg preg); // Returns a cached register, while checking that it's NOT mapped as a pointer
+	RiscVGen::RiscVReg RPtr(IRReg preg); // Returns a cached register, if it has been mapped as a pointer
 
 	// These are called once on startup to generate functions, that you should then call.
 	void EmitLoadStaticRegisters();
 	void EmitSaveStaticRegisters();
 
+protected:
+	void SetupInitialRegs() override;
+	const StaticAllocation *GetStaticAllocations(int &count) override;
+
 private:
-	struct StaticAllocation {
-		IRRegIndex mr;
-		RiscVGen::RiscVReg ar;
-		bool pointerified;
-	};
-	const StaticAllocation *GetStaticAllocations(int &count);
 	const RiscVGen::RiscVReg *GetMIPSAllocationOrder(int &count);
-	void MapRegTo(RiscVGen::RiscVReg reg, IRRegIndex mipsReg, RiscVJitConstants::MIPSMap mapFlags);
+	void MapRegTo(RiscVGen::RiscVReg reg, IRReg mipsReg, RiscVJitConstants::MIPSMap mapFlags);
 	RiscVGen::RiscVReg AllocateReg();
 	RiscVGen::RiscVReg FindBestToSpill(bool unusedOnly, bool *clobbered);
-	RiscVGen::RiscVReg RiscVRegForFlush(IRRegIndex r);
+	RiscVGen::RiscVReg RiscVRegForFlush(IRReg r);
 	void SetRegImm(RiscVGen::RiscVReg reg, u64 imm);
 	void AddMemBase(RiscVGen::RiscVReg reg);
-	int GetMipsRegOffset(IRRegIndex r);
+	int GetMipsRegOffset(IRReg r);
 
-	bool IsValidReg(IRRegIndex r) const;
-	bool IsValidRegNoZero(IRRegIndex r) const;
+	bool IsValidReg(IRReg r) const;
+	bool IsValidRegNoZero(IRReg r) const;
 
-	void SetupInitialRegs();
-
-	MIPSState *mips_;
 	RiscVGen::RiscVEmitter *emit_ = nullptr;
-	MIPSComp::JitOptions *jo_;
-	MIPSComp::IRBlock *irBlock_ = nullptr;
-	int irIndex_ = 0;
 
 	enum {
-		NUM_RVREG = 32,  // 31 actual registers, plus the zero/sp register which is not mappable.
-		NUM_MIPSREG = RiscVJitConstants::TOTAL_MAPPABLE_MIPSREGS,
+		NUM_RVREG = 32,
 	};
-
-	RegStatusRiscV ar[NUM_RVREG]{};
-	RegStatusMIPS mr[NUM_MIPSREG]{};
-
-	bool initialReady_ = false;
-	bool pendingUnlock_ = false;
-	RegStatusRiscV arInitial_[NUM_RVREG];
-	RegStatusMIPS mrInitial_[NUM_MIPSREG];
 };

--- a/Core/MIPS/RiscV/RiscVRegCache.h
+++ b/Core/MIPS/RiscV/RiscVRegCache.h
@@ -57,7 +57,7 @@ enum class MapType {
 
 } // namespace RiscVJitConstants
 
-class RiscVRegCache : public IRNativeRegCache {
+class RiscVRegCache : public IRNativeRegCacheBase {
 public:
 	RiscVRegCache(MIPSComp::JitOptions *jo);
 
@@ -98,7 +98,6 @@ public:
 	void FlushBeforeCall();
 	void FlushAll();
 	void FlushR(IRReg r);
-	void FlushRiscVReg(RiscVGen::RiscVReg r);
 	void DiscardR(IRReg r);
 
 	RiscVGen::RiscVReg GetAndLockTempR();
@@ -112,20 +111,17 @@ public:
 
 protected:
 	void SetupInitialRegs() override;
-	const StaticAllocation *GetStaticAllocations(int &count) override;
+	const StaticAllocation *GetStaticAllocations(int &count) const override;
+	const int *GetAllocationOrder(MIPSLoc type, int &count, int &base) const override;
+	void AdjustNativeRegAsPtr(IRNativeReg nreg, bool state) override;
+	void StoreNativeReg(IRNativeReg nreg, IRReg first, int lanes) override;
 
 private:
-	const RiscVGen::RiscVReg *GetMIPSAllocationOrder(int &count);
 	void MapRegTo(RiscVGen::RiscVReg reg, IRReg mipsReg, RiscVJitConstants::MIPSMap mapFlags);
-	RiscVGen::RiscVReg AllocateReg();
-	RiscVGen::RiscVReg FindBestToSpill(bool unusedOnly, bool *clobbered);
 	RiscVGen::RiscVReg RiscVRegForFlush(IRReg r);
 	void SetRegImm(RiscVGen::RiscVReg reg, u64 imm);
 	void AddMemBase(RiscVGen::RiscVReg reg);
 	int GetMipsRegOffset(IRReg r);
-
-	bool IsValidReg(IRReg r) const;
-	bool IsValidRegNoZero(IRReg r) const;
 
 	RiscVGen::RiscVEmitter *emit_ = nullptr;
 

--- a/Core/MIPS/RiscV/RiscVRegCache.h
+++ b/Core/MIPS/RiscV/RiscVRegCache.h
@@ -67,7 +67,6 @@ public:
 	void MapDirtyDirtyIn(IRReg rd1, IRReg rd2, IRReg rs, RiscVJitConstants::MapType type = RiscVJitConstants::MapType::AVOID_LOAD);
 	void MapDirtyDirtyInIn(IRReg rd1, IRReg rd2, IRReg rs, IRReg rt, RiscVJitConstants::MapType type = RiscVJitConstants::MapType::AVOID_LOAD);
 	void FlushBeforeCall();
-	void FlushAll();
 	void FlushR(IRReg r);
 	void DiscardR(IRReg r);
 
@@ -92,8 +91,6 @@ protected:
 	void StoreRegValue(IRReg mreg, uint32_t imm) override;
 
 private:
-	int GetMipsRegOffset(IRReg r);
-
 	RiscVGen::RiscVEmitter *emit_ = nullptr;
 
 	enum {

--- a/Core/MIPS/RiscV/RiscVRegCache.h
+++ b/Core/MIPS/RiscV/RiscVRegCache.h
@@ -35,20 +35,6 @@ const RiscVGen::RiscVReg MEMBASEREG = RiscVGen::X27;
 const RiscVGen::RiscVReg SCRATCH1 = RiscVGen::X10;
 const RiscVGen::RiscVReg SCRATCH2 = RiscVGen::X11;
 
-// Initing is the default so the flag is reversed.
-enum class MIPSMap {
-	INIT = 0,
-	DIRTY = 1,
-	NOINIT = 2 | DIRTY,
-	MARK_NORM32 = 4,
-};
-static inline MIPSMap operator |(const MIPSMap &lhs, const MIPSMap &rhs) {
-	return MIPSMap((int)lhs | (int)rhs);
-}
-static inline MIPSMap operator &(const MIPSMap &lhs, const MIPSMap &rhs) {
-	return MIPSMap((int)lhs & (int)rhs);
-}
-
 enum class MapType {
 	AVOID_LOAD,
 	AVOID_LOAD_MARK_NORM32,
@@ -67,7 +53,7 @@ public:
 	RiscVGen::RiscVReg TryMapTempImm(IRReg);
 
 	// Returns an ARM register containing the requested MIPS register.
-	RiscVGen::RiscVReg MapReg(IRReg reg, RiscVJitConstants::MIPSMap mapFlags = RiscVJitConstants::MIPSMap::INIT);
+	RiscVGen::RiscVReg MapReg(IRReg reg, MIPSMap mapFlags = MIPSMap::INIT);
 	RiscVGen::RiscVReg MapRegAsPointer(IRReg reg);
 
 	bool IsNormalized32(IRReg reg);
@@ -99,13 +85,13 @@ protected:
 	const StaticAllocation *GetStaticAllocations(int &count) const override;
 	const int *GetAllocationOrder(MIPSLoc type, int &count, int &base) const override;
 	void AdjustNativeRegAsPtr(IRNativeReg nreg, bool state) override;
+
+	void LoadNativeReg(IRNativeReg nreg, IRReg first, int lanes) override;
 	void StoreNativeReg(IRNativeReg nreg, IRReg first, int lanes) override;
+	void SetNativeRegValue(IRNativeReg nreg, uint32_t imm) override;
+	void StoreRegValue(IRReg mreg, uint32_t imm) override;
 
 private:
-	void MapRegTo(RiscVGen::RiscVReg reg, IRReg mipsReg, RiscVJitConstants::MIPSMap mapFlags);
-	RiscVGen::RiscVReg RiscVRegForFlush(IRReg r);
-	void SetRegImm(RiscVGen::RiscVReg reg, u64 imm);
-	void AddMemBase(RiscVGen::RiscVReg reg);
 	int GetMipsRegOffset(IRReg r);
 
 	RiscVGen::RiscVEmitter *emit_ = nullptr;

--- a/Core/MIPS/RiscV/RiscVRegCache.h
+++ b/Core/MIPS/RiscV/RiscVRegCache.h
@@ -72,8 +72,6 @@ public:
 
 	bool IsNormalized32(IRReg reg);
 
-	void MarkDirty(RiscVGen::RiscVReg reg, bool andNormalized32 = false);
-	void MarkPtrDirty(RiscVGen::RiscVReg reg);
 	// Copies to another reg if specified, otherwise same reg.
 	RiscVGen::RiscVReg Normalize32(IRReg reg, RiscVGen::RiscVReg destReg = RiscVGen::INVALID_REG);
 	void MapIn(IRReg rs);

--- a/Core/MIPS/RiscV/RiscVRegCache.h
+++ b/Core/MIPS/RiscV/RiscVRegCache.h
@@ -63,15 +63,6 @@ public:
 
 	void Init(RiscVGen::RiscVEmitter *emitter);
 
-	// Protect the arm register containing a MIPS register from spilling, to ensure that
-	// it's being kept allocated.
-	void SpillLock(IRReg reg, IRReg reg2 = IRREG_INVALID, IRReg reg3 = IRREG_INVALID, IRReg reg4 = IRREG_INVALID);
-	void ReleaseSpillLock(IRReg reg, IRReg reg2 = IRREG_INVALID, IRReg reg3 = IRREG_INVALID, IRReg reg4 = IRREG_INVALID);
-
-	void SetImm(IRReg reg, u64 immVal);
-	bool IsImm(IRReg reg) const;
-	u64 GetImm(IRReg reg) const;
-
 	// May fail and return INVALID_REG if it needs flushing.
 	RiscVGen::RiscVReg TryMapTempImm(IRReg);
 
@@ -79,10 +70,6 @@ public:
 	RiscVGen::RiscVReg MapReg(IRReg reg, RiscVJitConstants::MIPSMap mapFlags = RiscVJitConstants::MIPSMap::INIT);
 	RiscVGen::RiscVReg MapRegAsPointer(IRReg reg);
 
-	bool IsMapped(IRReg reg);
-	bool IsMappedAsPointer(IRReg reg);
-	bool IsMappedAsStaticPointer(IRReg reg);
-	bool IsInRAM(IRReg reg);
 	bool IsNormalized32(IRReg reg);
 
 	void MarkDirty(RiscVGen::RiscVReg reg, bool andNormalized32 = false);

--- a/Core/MIPS/RiscV/RiscVRegCacheFPU.h
+++ b/Core/MIPS/RiscV/RiscVRegCacheFPU.h
@@ -21,92 +21,59 @@
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/RiscV/RiscVRegCache.h"
 
-struct FPURegStatusRiscV {
-	int mipsReg;  // if -1, no mipsreg attached.
-	bool isDirty;  // Should the register be written back?
-};
-
-struct FPURegStatusMIPS {
-	// Where is this MIPS register?
-	RiscVJitConstants::MIPSLoc loc;
-	// Index from F0.
-	int reg;
-
-	bool spillLock;  // if true, this register cannot be spilled.
-	// If loc == ML_MEM, it's back in its location in the CPU context struct.
-};
-
 namespace MIPSComp {
 struct JitOptions;
 }
 
-class RiscVRegCacheFPU {
+class RiscVRegCacheFPU : public IRNativeRegCache {
 public:
-	RiscVRegCacheFPU(MIPSState *mipsState, MIPSComp::JitOptions *jo);
-	~RiscVRegCacheFPU() {}
+	RiscVRegCacheFPU(MIPSComp::JitOptions *jo);
 
 	void Init(RiscVGen::RiscVEmitter *emitter);
-	void Start(MIPSComp::IRBlock *irBlock);
-	void SetIRIndex(int index) {
-		irIndex_ = index;
-	}
 
 	// Protect the RISC-V register containing a MIPS register from spilling, to ensure that
 	// it's being kept allocated.
-	void SpillLock(IRRegIndex reg, IRRegIndex reg2 = IRREG_INVALID, IRRegIndex reg3 = IRREG_INVALID, IRRegIndex reg4 = IRREG_INVALID);
-	void ReleaseSpillLock(IRRegIndex reg, IRRegIndex reg2 = IRREG_INVALID, IRRegIndex reg3 = IRREG_INVALID, IRRegIndex reg4 = IRREG_INVALID);
-	void ReleaseSpillLocksAndDiscardTemps();
+	void SpillLock(IRReg reg, IRReg reg2 = IRREG_INVALID, IRReg reg3 = IRREG_INVALID, IRReg reg4 = IRREG_INVALID);
+	void ReleaseSpillLock(IRReg reg, IRReg reg2 = IRREG_INVALID, IRReg reg3 = IRREG_INVALID, IRReg reg4 = IRREG_INVALID);
 
 	// Returns a RISC-V register containing the requested MIPS register.
-	RiscVGen::RiscVReg MapReg(IRRegIndex reg, RiscVJitConstants::MIPSMap mapFlags = RiscVJitConstants::MIPSMap::INIT);
+	RiscVGen::RiscVReg MapReg(IRReg reg, RiscVJitConstants::MIPSMap mapFlags = RiscVJitConstants::MIPSMap::INIT);
 
-	bool IsMapped(IRRegIndex r);
-	bool IsInRAM(IRRegIndex r);
+	bool IsMapped(IRReg r);
+	bool IsInRAM(IRReg r);
 
-	void MapInIn(IRRegIndex rd, IRRegIndex rs);
-	void MapDirtyIn(IRRegIndex rd, IRRegIndex rs, bool avoidLoad = true);
-	void MapDirtyInIn(IRRegIndex rd, IRRegIndex rs, IRRegIndex rt, bool avoidLoad = true);
-	RiscVGen::RiscVReg MapDirtyInTemp(IRRegIndex rd, IRRegIndex rs, bool avoidLoad = true);
-	void Map4DirtyIn(IRRegIndex rdbase, IRRegIndex rsbase, bool avoidLoad = true);
-	void Map4DirtyInIn(IRRegIndex rdbase, IRRegIndex rsbase, IRRegIndex rtbase, bool avoidLoad = true);
-	RiscVGen::RiscVReg Map4DirtyInTemp(IRRegIndex rdbase, IRRegIndex rsbase, bool avoidLoad = true);
+	void MapInIn(IRReg rd, IRReg rs);
+	void MapDirtyIn(IRReg rd, IRReg rs, bool avoidLoad = true);
+	void MapDirtyInIn(IRReg rd, IRReg rs, IRReg rt, bool avoidLoad = true);
+	RiscVGen::RiscVReg MapDirtyInTemp(IRReg rd, IRReg rs, bool avoidLoad = true);
+	void Map4DirtyIn(IRReg rdbase, IRReg rsbase, bool avoidLoad = true);
+	void Map4DirtyInIn(IRReg rdbase, IRReg rsbase, IRReg rtbase, bool avoidLoad = true);
+	RiscVGen::RiscVReg Map4DirtyInTemp(IRReg rdbase, IRReg rsbase, bool avoidLoad = true);
 	void FlushBeforeCall();
 	void FlushAll();
-	void FlushR(IRRegIndex r);
+	void FlushR(IRReg r);
 	void FlushRiscVReg(RiscVGen::RiscVReg r);
-	void DiscardR(IRRegIndex r);
+	void DiscardR(IRReg r);
 
-	RiscVGen::RiscVReg R(int preg); // Returns a cached register
+	RiscVGen::RiscVReg R(IRReg preg); // Returns a cached register
+
+protected:
+	void SetupInitialRegs() override;
 
 private:
 	const RiscVGen::RiscVReg *GetMIPSAllocationOrder(int &count);
 	RiscVGen::RiscVReg AllocateReg();
 	RiscVGen::RiscVReg FindBestToSpill(bool unusedOnly, bool *clobbered);
-	RiscVGen::RiscVReg RiscVRegForFlush(IRRegIndex r);
-	int GetMipsRegOffset(IRRegIndex r);
+	RiscVGen::RiscVReg RiscVRegForFlush(IRReg r);
+	int GetMipsRegOffset(IRReg r);
 
-	bool IsValidReg(IRRegIndex r) const;
+	bool IsValidReg(IRReg r) const;
 
-	void SetupInitialRegs();
-
-	MIPSState *mips_;
 	RiscVGen::RiscVEmitter *emit_ = nullptr;
-	MIPSComp::JitOptions *jo_;
-	MIPSComp::IRBlock *irBlock_ = nullptr;
-	int irIndex_ = 0;
 
 	enum {
 		// On RiscV, each of the 32 registers are full 128-bit. No sharing of components!
 		NUM_RVFPUREG = 32,
-		NUM_MIPSFPUREG = RiscVJitConstants::TOTAL_MAPPABLE_MIPSREGS - 32,
+		NUM_MIPSFPUREG = TOTAL_MAPPABLE_IRREGS - 32,
 	};
-
-	FPURegStatusRiscV ar[NUM_RVFPUREG];
-	FPURegStatusMIPS mr[NUM_MIPSFPUREG];
-
-	bool pendingFlush_ = false;
-	bool pendingUnlock_ = false;
-	bool initialReady_ = false;
-	FPURegStatusRiscV arInitial_[NUM_RVFPUREG];
-	FPURegStatusMIPS mrInitial_[NUM_MIPSFPUREG];
 };

--- a/Core/MIPS/RiscV/RiscVRegCacheFPU.h
+++ b/Core/MIPS/RiscV/RiscVRegCacheFPU.h
@@ -31,16 +31,8 @@ public:
 
 	void Init(RiscVGen::RiscVEmitter *emitter);
 
-	// Protect the RISC-V register containing a MIPS register from spilling, to ensure that
-	// it's being kept allocated.
-	void SpillLock(IRReg reg, IRReg reg2 = IRREG_INVALID, IRReg reg3 = IRREG_INVALID, IRReg reg4 = IRREG_INVALID);
-	void ReleaseSpillLock(IRReg reg, IRReg reg2 = IRREG_INVALID, IRReg reg3 = IRREG_INVALID, IRReg reg4 = IRREG_INVALID);
-
 	// Returns a RISC-V register containing the requested MIPS register.
 	RiscVGen::RiscVReg MapReg(IRReg reg, RiscVJitConstants::MIPSMap mapFlags = RiscVJitConstants::MIPSMap::INIT);
-
-	bool IsMapped(IRReg r);
-	bool IsInRAM(IRReg r);
 
 	void MapInIn(IRReg rd, IRReg rs);
 	void MapDirtyIn(IRReg rd, IRReg rs, bool avoidLoad = true);
@@ -62,7 +54,6 @@ protected:
 	void StoreNativeReg(IRNativeReg nreg, IRReg first, int lanes) override;
 
 private:
-	RiscVGen::RiscVReg RiscVRegForFlush(IRReg r);
 	int GetMipsRegOffset(IRReg r);
 
 	RiscVGen::RiscVEmitter *emit_ = nullptr;

--- a/Core/MIPS/RiscV/RiscVRegCacheFPU.h
+++ b/Core/MIPS/RiscV/RiscVRegCacheFPU.h
@@ -25,7 +25,7 @@ namespace MIPSComp {
 struct JitOptions;
 }
 
-class RiscVRegCacheFPU : public IRNativeRegCache {
+class RiscVRegCacheFPU : public IRNativeRegCacheBase {
 public:
 	RiscVRegCacheFPU(MIPSComp::JitOptions *jo);
 
@@ -52,22 +52,18 @@ public:
 	void FlushBeforeCall();
 	void FlushAll();
 	void FlushR(IRReg r);
-	void FlushRiscVReg(RiscVGen::RiscVReg r);
 	void DiscardR(IRReg r);
 
 	RiscVGen::RiscVReg R(IRReg preg); // Returns a cached register
 
 protected:
 	void SetupInitialRegs() override;
+	const int *GetAllocationOrder(MIPSLoc type, int &count, int &base) const override;
+	void StoreNativeReg(IRNativeReg nreg, IRReg first, int lanes) override;
 
 private:
-	const RiscVGen::RiscVReg *GetMIPSAllocationOrder(int &count);
-	RiscVGen::RiscVReg AllocateReg();
-	RiscVGen::RiscVReg FindBestToSpill(bool unusedOnly, bool *clobbered);
 	RiscVGen::RiscVReg RiscVRegForFlush(IRReg r);
 	int GetMipsRegOffset(IRReg r);
-
-	bool IsValidReg(IRReg r) const;
 
 	RiscVGen::RiscVEmitter *emit_ = nullptr;
 

--- a/Core/MIPS/RiscV/RiscVRegCacheFPU.h
+++ b/Core/MIPS/RiscV/RiscVRegCacheFPU.h
@@ -42,7 +42,6 @@ public:
 	void Map4DirtyInIn(IRReg rdbase, IRReg rsbase, IRReg rtbase, bool avoidLoad = true);
 	RiscVGen::RiscVReg Map4DirtyInTemp(IRReg rdbase, IRReg rsbase, bool avoidLoad = true);
 	void FlushBeforeCall();
-	void FlushAll();
 	void FlushR(IRReg r);
 	void DiscardR(IRReg r);
 
@@ -58,13 +57,9 @@ protected:
 	void StoreRegValue(IRReg mreg, uint32_t imm) override;
 
 private:
-	int GetMipsRegOffset(IRReg r);
-
 	RiscVGen::RiscVEmitter *emit_ = nullptr;
 
 	enum {
-		// On RiscV, each of the 32 registers are full 128-bit. No sharing of components!
 		NUM_RVFPUREG = 32,
-		NUM_MIPSFPUREG = TOTAL_MAPPABLE_IRREGS - 32,
 	};
 };

--- a/Core/MIPS/RiscV/RiscVRegCacheFPU.h
+++ b/Core/MIPS/RiscV/RiscVRegCacheFPU.h
@@ -32,7 +32,7 @@ public:
 	void Init(RiscVGen::RiscVEmitter *emitter);
 
 	// Returns a RISC-V register containing the requested MIPS register.
-	RiscVGen::RiscVReg MapReg(IRReg reg, RiscVJitConstants::MIPSMap mapFlags = RiscVJitConstants::MIPSMap::INIT);
+	RiscVGen::RiscVReg MapReg(IRReg reg, MIPSMap mapFlags = MIPSMap::INIT);
 
 	void MapInIn(IRReg rd, IRReg rs);
 	void MapDirtyIn(IRReg rd, IRReg rs, bool avoidLoad = true);
@@ -51,7 +51,11 @@ public:
 protected:
 	void SetupInitialRegs() override;
 	const int *GetAllocationOrder(MIPSLoc type, int &count, int &base) const override;
+
+	void LoadNativeReg(IRNativeReg nreg, IRReg first, int lanes) override;
 	void StoreNativeReg(IRNativeReg nreg, IRReg first, int lanes) override;
+	void SetNativeRegValue(IRNativeReg nreg, uint32_t imm) override;
+	void StoreRegValue(IRReg mreg, uint32_t imm) override;
 
 private:
 	int GetMipsRegOffset(IRReg r);


### PR DESCRIPTION
This takes the existing GPR and FPR caches from the RISC-V IR backend, merges the common parts together, and further makes it generic as an IR regcache backend.  Meanwhile, I added (theoretical, probably has bugs) multi-lane support.

I'm still thinking to have "one" regcache for each IR backend (i.e. gpr/fpr -> regs) and add auto-mapping functionality from the instruction.  I wanted to start with this step, which is to have a common foundation for that (and RISC-V still works fine.)

The idea will be that x86/arm/arm64 we would use REG and FREG.  However, on RISC-V we would use REG, FREG, and VREG (since they are separate.)  At some point will need to think about transfers (right now it stores if you remap with different lane count or type.)  May also need to think about mapped "views" (i.e. Vec4Scale v0...v3, v0...v3, v3.)

The purpose of this, of course, is to make writing a new IR backend (i.e. x86 or arm64) easier.  However, it can also be used to try the LO+HI single register optimization on RISC-V (that would be treated as a Vec2 basically.)

I've also imagined other optimizations this could simplify: for example, if two contiguous registers (i.e. a2 and a3) are imms and need to be flushed, we could add a method that attempts that and returns false if the backend doesn't support it.  In general I think many optimizations can apply to multiple backends with less code this way.

-[Unknown]