### PR TITLE
Reduce time spent in IR compile

### DIFF
--- a/Core/MIPS/IR/IRAnalysis.cpp
+++ b/Core/MIPS/IR/IRAnalysis.cpp
@@ -21,28 +21,35 @@
 #include <algorithm>
 
 
-static bool IRReadsFrom(const IRInst &inst, int reg, char type, bool directly = false) {
+static bool IRReadsFrom(const IRInst &inst, int reg, char type, bool *directly) {
 	const IRMeta *m = GetIRMeta(inst.op);
 
 	if (m->types[1] == type && inst.src1 == reg) {
+		if (directly)
+			*directly = true;
 		return true;
 	}
 	if (m->types[2] == type && inst.src2 == reg) {
+		if (directly)
+			*directly = true;
 		return true;
 	}
 	if ((m->flags & (IRFLAG_SRC3 | IRFLAG_SRC3DST)) != 0 && m->types[0] == type && inst.src3 == reg) {
+		if (directly)
+			*directly = true;
 		return true;
 	}
-	if (!directly) {
-		if (inst.op == IROp::Interpret || inst.op == IROp::CallReplacement || inst.op == IROp::Syscall || inst.op == IROp::Break)
-			return true;
-		if (inst.op == IROp::Breakpoint || inst.op == IROp::MemoryCheck)
-			return true;
-	}
+
+	if (directly)
+		*directly = false;
+	if (inst.op == IROp::Interpret || inst.op == IROp::CallReplacement || inst.op == IROp::Syscall || inst.op == IROp::Break)
+		return true;
+	if (inst.op == IROp::Breakpoint || inst.op == IROp::MemoryCheck)
+		return true;
 	return false;
 }
 
-bool IRReadsFromFPR(const IRInst &inst, int reg, bool directly) {
+bool IRReadsFromFPR(const IRInst &inst, int reg, bool *directly) {
 	if (IRReadsFrom(inst, reg, 'F', directly))
 		return true;
 
@@ -85,7 +92,7 @@ static int IRReadsFromList(const IRInst &inst, IRReg regs[4], char type) {
 	return c;
 }
 
-bool IRReadsFromGPR(const IRInst &inst, int reg, bool directly) {
+bool IRReadsFromGPR(const IRInst &inst, int reg, bool *directly) {
 	return IRReadsFrom(inst, reg, 'G', directly);
 }
 

--- a/Core/MIPS/IR/IRAnalysis.h
+++ b/Core/MIPS/IR/IRAnalysis.h
@@ -19,8 +19,8 @@
 
 #include "Core/MIPS/IR/IRInst.h"
 
-bool IRReadsFromFPR(const IRInst &inst, int reg, bool directly = false);
-bool IRReadsFromGPR(const IRInst &inst, int reg, bool directly = false);
+bool IRReadsFromFPR(const IRInst &inst, int reg, bool *directly = nullptr);
+bool IRReadsFromGPR(const IRInst &inst, int reg, bool *directly = nullptr);
 bool IRWritesToGPR(const IRInst &inst, int reg);
 bool IRWritesToFPR(const IRInst &inst, int reg);
 int IRDestGPR(const IRInst &inst);

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -375,6 +375,9 @@ public:
 	int AddConstant(u32 value);
 	int AddConstantFloat(float value);
 
+	void Reserve(size_t s) {
+		insts_.reserve(s);
+	}
 	void Clear() {
 		insts_.clear();
 	}

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -168,6 +168,7 @@ void IRJit::CompileFunction(u32 start_address, u32 length) {
 	// We may go up and down from branches, so track all block starts done here.
 	std::set<u32> doneAddresses;
 	std::vector<u32> pendingAddresses;
+	pendingAddresses.reserve(16);
 	pendingAddresses.push_back(start_address);
 	while (!pendingAddresses.empty()) {
 		u32 em_address = pendingAddresses.back();

--- a/Core/MIPS/IR/IRRegCache.h
+++ b/Core/MIPS/IR/IRRegCache.h
@@ -48,12 +48,12 @@ public:
 	IRImmRegCache(IRWriter *ir);
 
 	void SetImm(IRReg r, u32 immVal) {
-		reg_[r].isImm = true;
-		reg_[r].immVal = immVal;
+		isImm_[r] = true;
+		immVal_[r] = immVal;
 	}
 
-	bool IsImm(IRReg r) const { return reg_[r].isImm; }
-	u32 GetImm(IRReg r) const { return reg_[r].immVal; }
+	bool IsImm(IRReg r) const { return isImm_[r]; }
+	u32 GetImm(IRReg r) const { return immVal_[r]; }
 
 	void FlushAll();
 
@@ -68,12 +68,8 @@ private:
 	void Flush(IRReg rd);
 	void Discard(IRReg rd);
 
-	struct RegIR {
-		bool isImm;
-		u32 immVal;
-	};
-
-	RegIR reg_[TOTAL_MAPPABLE_IRREGS];
+	bool isImm_[TOTAL_MAPPABLE_IRREGS];
+	uint32_t immVal_[TOTAL_MAPPABLE_IRREGS];
 	IRWriter *ir_;
 };
 


### PR DESCRIPTION
This reduces the time compiling IR instructions by around 35%, although I'm sure it'll vary with different conditions or games.

-[Unknown]