### PR TITLE
irjit: Fix regalloc clobber on exit

### DIFF
--- a/Core/MIPS/IR/IRAnalysis.cpp
+++ b/Core/MIPS/IR/IRAnalysis.cpp
@@ -42,9 +42,9 @@ static bool IRReadsFrom(const IRInst &inst, int reg, char type, bool *directly) 
 
 	if (directly)
 		*directly = false;
-	if (inst.op == IROp::Interpret || inst.op == IROp::CallReplacement || inst.op == IROp::Syscall || inst.op == IROp::Break)
+	if (inst.op == IROp::Interpret || inst.op == IROp::CallReplacement)
 		return true;
-	if (inst.op == IROp::Breakpoint || inst.op == IROp::MemoryCheck)
+	if ((m->flags & IRFLAG_EXIT) != 0)
 		return true;
 	return false;
 }


### PR DESCRIPTION
Not sure how I haven't run into this before, but exits weren't considered as "reading" from regs, and so a write after an exit (i.e. due to likely branch) could make it think it was clobbered.

Actually messing with an x86 ir jit, which was pretty easy to get going, and ran into this right away.  Must be RISC-V just had enough registers I didn't run into the case yet... anyway, this fixes it for all backends.

-[Unknown]