### PR TITLE
Add an x86/x64 backend for IR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1611,6 +1611,11 @@ list(APPEND CoreExtra
 	Core/MIPS/x86/RegCache.h
 	Core/MIPS/x86/RegCacheFPU.cpp
 	Core/MIPS/x86/RegCacheFPU.h
+	Core/MIPS/x86/X64IRAsm.cpp
+	Core/MIPS/x86/X64IRJit.cpp
+	Core/MIPS/x86/X64IRJit.h
+	Core/MIPS/x86/X64IRRegCache.cpp
+	Core/MIPS/x86/X64IRRegCache.h
 	GPU/Common/VertexDecoderX86.cpp
 	GPU/Software/DrawPixelX86.cpp
 	GPU/Software/SamplerX86.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1612,6 +1612,12 @@ list(APPEND CoreExtra
 	Core/MIPS/x86/RegCacheFPU.cpp
 	Core/MIPS/x86/RegCacheFPU.h
 	Core/MIPS/x86/X64IRAsm.cpp
+	Core/MIPS/x86/X64IRCompALU.cpp
+	Core/MIPS/x86/X64IRCompBranch.cpp
+	Core/MIPS/x86/X64IRCompFPU.cpp
+	Core/MIPS/x86/X64IRCompLoadStore.cpp
+	Core/MIPS/x86/X64IRCompSystem.cpp
+	Core/MIPS/x86/X64IRCompVec.cpp
 	Core/MIPS/x86/X64IRJit.cpp
 	Core/MIPS/x86/X64IRJit.h
 	Core/MIPS/x86/X64IRRegCache.cpp

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -133,9 +133,9 @@ static int DefaultCpuCore() {
 #if PPSSPP_ARCH(ARM) || PPSSPP_ARCH(ARM64) || PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64) || PPSSPP_ARCH(RISCV64)
 	if (System_GetPropertyBool(SYSPROP_CAN_JIT))
 		return (int)CPUCore::JIT;
-	return (int)CPUCore::IR_JIT;
+	return (int)CPUCore::IR_INTERPRETER;
 #else
-	return (int)CPUCore::IR_JIT;
+	return (int)CPUCore::IR_INTERPRETER;
 #endif
 }
 
@@ -1313,9 +1313,9 @@ bool Config::Save(const char *saveReason) {
 
 void Config::PostLoadCleanup(bool gameSpecific) {
 	// Override ppsspp.ini JIT value to prevent crashing
-	jitForcedOff = DefaultCpuCore() != (int)CPUCore::JIT && g_Config.iCpuCore == (int)CPUCore::JIT;
+	jitForcedOff = DefaultCpuCore() != (int)CPUCore::JIT && (g_Config.iCpuCore == (int)CPUCore::JIT || g_Config.iCpuCore == (int)CPUCore::JIT_IR);
 	if (jitForcedOff) {
-		g_Config.iCpuCore = (int)CPUCore::IR_JIT;
+		g_Config.iCpuCore = (int)CPUCore::IR_INTERPRETER;
 	}
 
 	// This caps the exponent 4 (so 16x.)
@@ -1345,7 +1345,7 @@ void Config::PostLoadCleanup(bool gameSpecific) {
 void Config::PreSaveCleanup(bool gameSpecific) {
 	if (jitForcedOff) {
 		// If we forced jit off and it's still set to IR, change it back to jit.
-		if (g_Config.iCpuCore == (int)CPUCore::IR_JIT)
+		if (g_Config.iCpuCore == (int)CPUCore::IR_INTERPRETER)
 			g_Config.iCpuCore = (int)CPUCore::JIT;
 	}
 }
@@ -1354,12 +1354,12 @@ void Config::PostSaveCleanup(bool gameSpecific) {
 	if (jitForcedOff) {
 		// Force JIT off again just in case Config::Save() is called without exiting PPSSPP.
 		if (g_Config.iCpuCore == (int)CPUCore::JIT)
-			g_Config.iCpuCore = (int)CPUCore::IR_JIT;
+			g_Config.iCpuCore = (int)CPUCore::IR_INTERPRETER;
 	}
 }
 
 void Config::NotifyUpdatedCpuCore() {
-	if (jitForcedOff && g_Config.iCpuCore == (int)CPUCore::IR_JIT) {
+	if (jitForcedOff && g_Config.iCpuCore == (int)CPUCore::IR_INTERPRETER) {
 		// No longer forced off, the user set it to IR jit.
 		jitForcedOff = false;
 	}

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -50,7 +50,8 @@ struct ConfigCustomButton {
 enum class CPUCore {
 	INTERPRETER = 0,
 	JIT = 1,
-	IR_JIT = 2,
+	IR_INTERPRETER = 2,
+	JIT_IR = 3,
 };
 
 enum {

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -411,7 +411,7 @@ const char *ExecExceptionTypeAsString(ExecExceptionType type) {
 void Core_MemoryException(u32 address, u32 accessSize, u32 pc, MemoryExceptionType type) {
 	const char *desc = MemoryExceptionTypeAsString(type);
 	// In jit, we only flush PC when bIgnoreBadMemAccess is off.
-	if (g_Config.iCpuCore == (int)CPUCore::JIT && g_Config.bIgnoreBadMemAccess) {
+	if ((g_Config.iCpuCore == (int)CPUCore::JIT || g_Config.iCpuCore == (int)CPUCore::JIT_IR) && g_Config.bIgnoreBadMemAccess) {
 		WARN_LOG(MEMMAP, "%s: Invalid access at %08x (size %08x)", desc, address, accessSize);
 	} else {
 		WARN_LOG(MEMMAP, "%s: Invalid access at %08x (size %08x) PC %08x LR %08x", desc, address, accessSize, currentMIPS->pc, currentMIPS->r[MIPS_REG_RA]);
@@ -439,7 +439,7 @@ void Core_MemoryException(u32 address, u32 accessSize, u32 pc, MemoryExceptionTy
 void Core_MemoryExceptionInfo(u32 address, u32 accessSize, u32 pc, MemoryExceptionType type, std::string additionalInfo, bool forceReport) {
 	const char *desc = MemoryExceptionTypeAsString(type);
 	// In jit, we only flush PC when bIgnoreBadMemAccess is off.
-	if (g_Config.iCpuCore == (int)CPUCore::JIT && g_Config.bIgnoreBadMemAccess) {
+	if ((g_Config.iCpuCore == (int)CPUCore::JIT || g_Config.iCpuCore == (int)CPUCore::JIT_IR) && g_Config.bIgnoreBadMemAccess) {
 		WARN_LOG(MEMMAP, "%s: Invalid access at %08x (size %08x). %s", desc, address, accessSize, additionalInfo.c_str());
 	} else {
 		WARN_LOG(MEMMAP, "%s: Invalid access at %08x (size %08x) PC %08x LR %08x %s", desc, address, accessSize, currentMIPS->pc, currentMIPS->r[MIPS_REG_RA], additionalInfo.c_str());

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -605,6 +605,8 @@
     <ClCompile Include="MIPS\RiscV\RiscVCompVec.cpp" />
     <ClCompile Include="MIPS\RiscV\RiscVJit.cpp" />
     <ClCompile Include="MIPS\RiscV\RiscVRegCache.cpp" />
+    <ClCompile Include="MIPS\x86\X64IRAsm.cpp" />
+    <ClCompile Include="MIPS\x86\X64IRJit.cpp" />
     <ClCompile Include="Replay.cpp" />
     <ClCompile Include="Compatibility.cpp" />
     <ClCompile Include="Config.cpp" />
@@ -1091,6 +1093,7 @@
     </ClCompile>
     <ClCompile Include="WaveFile.cpp" />
     <ClCompile Include="WebServer.cpp" />
+    <ClCompile Include="MIPS\x86\X64IRRegCache.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\ext\cityhash\city.h" />
@@ -1178,6 +1181,7 @@
     <ClInclude Include="MIPS\MIPSVFPUFallbacks.h" />
     <ClInclude Include="MIPS\RiscV\RiscVJit.h" />
     <ClInclude Include="MIPS\RiscV\RiscVRegCache.h" />
+    <ClInclude Include="MIPS\x86\X64IRJit.h" />
     <ClInclude Include="Replay.h" />
     <ClInclude Include="Compatibility.h" />
     <ClInclude Include="Config.h" />
@@ -1429,6 +1433,7 @@
     <ClInclude Include="..\ext\xxhash.h" />
     <ClInclude Include="WaveFile.h" />
     <ClInclude Include="WebServer.h" />
+    <ClInclude Include="MIPS\x86\X64IRRegCache.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\ext\cityhash\COPYING" />

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -606,6 +606,12 @@
     <ClCompile Include="MIPS\RiscV\RiscVJit.cpp" />
     <ClCompile Include="MIPS\RiscV\RiscVRegCache.cpp" />
     <ClCompile Include="MIPS\x86\X64IRAsm.cpp" />
+    <ClCompile Include="MIPS\x86\X64IRCompALU.cpp" />
+    <ClCompile Include="MIPS\x86\X64IRCompBranch.cpp" />
+    <ClCompile Include="MIPS\x86\X64IRCompFPU.cpp" />
+    <ClCompile Include="MIPS\x86\X64IRCompLoadStore.cpp" />
+    <ClCompile Include="MIPS\x86\X64IRCompSystem.cpp" />
+    <ClCompile Include="MIPS\x86\X64IRCompVec.cpp" />
     <ClCompile Include="MIPS\x86\X64IRJit.cpp" />
     <ClCompile Include="Replay.cpp" />
     <ClCompile Include="Compatibility.cpp" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -1243,6 +1243,15 @@
     <ClCompile Include="FrameTiming.cpp">
       <Filter>Core</Filter>
     </ClCompile>
+    <ClCompile Include="MIPS\x86\X64IRRegCache.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="MIPS\x86\X64IRAsm.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="MIPS\x86\X64IRJit.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -2003,6 +2012,12 @@
     </ClInclude>
     <ClInclude Include="FrameTiming.h">
       <Filter>Core</Filter>
+    </ClInclude>
+    <ClInclude Include="MIPS\x86\X64IRRegCache.h">
+      <Filter>MIPS\x86</Filter>
+    </ClInclude>
+    <ClInclude Include="MIPS\x86\X64IRJit.h">
+      <Filter>MIPS\x86</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -1252,6 +1252,24 @@
     <ClCompile Include="MIPS\x86\X64IRJit.cpp">
       <Filter>MIPS\x86</Filter>
     </ClCompile>
+    <ClCompile Include="MIPS\x86\X64IRCompBranch.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="MIPS\x86\X64IRCompFPU.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="MIPS\x86\X64IRCompLoadStore.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="MIPS\x86\X64IRCompSystem.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="MIPS\x86\X64IRCompVec.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="MIPS\x86\X64IRCompALU.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">

--- a/Core/MIPS/IR/IRAnalysis.cpp
+++ b/Core/MIPS/IR/IRAnalysis.cpp
@@ -42,9 +42,9 @@ static bool IRReadsFrom(const IRInst &inst, int reg, char type, bool *directly) 
 
 	if (directly)
 		*directly = false;
-	if (inst.op == IROp::Interpret || inst.op == IROp::CallReplacement || inst.op == IROp::Syscall || inst.op == IROp::Break)
+	if (inst.op == IROp::Interpret || inst.op == IROp::CallReplacement)
 		return true;
-	if (inst.op == IROp::Breakpoint || inst.op == IROp::MemoryCheck)
+	if ((m->flags & IRFLAG_EXIT) != 0)
 		return true;
 	return false;
 }

--- a/Core/MIPS/IR/IRRegCache.cpp
+++ b/Core/MIPS/IR/IRRegCache.cpp
@@ -437,12 +437,13 @@ IRNativeReg IRNativeRegCacheBase::FindBestToSpill(MIPSLoc type, bool unusedOnly,
 void IRNativeRegCacheBase::DiscardNativeReg(IRNativeReg nreg) {
 	_assert_msg_(nreg >= 0 && nreg < config_.totalNativeRegs, "DiscardNativeReg on invalid register %d", nreg);
 	if (nr[nreg].mipsReg != IRREG_INVALID) {
-		_assert_(nr[nreg].mipsReg != MIPS_REG_ZERO);
 		int8_t lanes = 0;
 		for (IRReg m = nr[nreg].mipsReg; mr[m].nReg == nreg && m < IRREG_INVALID; ++m)
 			lanes++;
 
 		if (mr[nr[nreg].mipsReg].isStatic) {
+			_assert_(nr[nreg].mipsReg != MIPS_REG_ZERO);
+
 			int numStatics;
 			const StaticAllocation *statics = GetStaticAllocations(numStatics);
 
@@ -580,6 +581,9 @@ void IRNativeRegCacheBase::FlushReg(IRReg mreg) {
 void IRNativeRegCacheBase::FlushAll(bool gprs, bool fprs) {
 	// Note: make sure not to change the registers when flushing.
 	// Branching code may expect the native reg to retain its value.
+
+	if (!mr[MIPS_REG_ZERO].isStatic && mr[MIPS_REG_ZERO].nReg != -1)
+		DiscardNativeReg(mr[MIPS_REG_ZERO].nReg);
 
 	for (int i = 1; i < TOTAL_MAPPABLE_IRREGS; i++) {
 		IRReg mipsReg = (IRReg)i;

--- a/Core/MIPS/JitCommon/JitCommon.cpp
+++ b/Core/MIPS/JitCommon/JitCommon.cpp
@@ -43,6 +43,7 @@
 #include "../ARM64/Arm64Jit.h"
 #elif PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 #include "../x86/Jit.h"
+#include "../x86/X64IRJit.h"
 #elif PPSSPP_ARCH(MIPS)
 #include "../MIPS/MipsJit.h"
 #elif PPSSPP_ARCH(RISCV64)
@@ -101,12 +102,14 @@ namespace MIPSComp {
 		return notTakenTarget;
 }
 
-	JitInterface *CreateNativeJit(MIPSState *mipsState) {
+	JitInterface *CreateNativeJit(MIPSState *mipsState, bool useIR) {
 #if PPSSPP_ARCH(ARM)
 		return new MIPSComp::ArmJit(mipsState);
 #elif PPSSPP_ARCH(ARM64)
 		return new MIPSComp::Arm64Jit(mipsState);
 #elif PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+		if (useIR)
+			return new MIPSComp::X64IRJit(mipsState);
 		return new MIPSComp::Jit(mipsState);
 #elif PPSSPP_ARCH(MIPS)
 		return new MIPSComp::MipsJit(mipsState);

--- a/Core/MIPS/JitCommon/JitCommon.h
+++ b/Core/MIPS/JitCommon/JitCommon.h
@@ -177,5 +177,5 @@ namespace MIPSComp {
 
 	void DoDummyJitState(PointerWrap &p);
 
-	JitInterface *CreateNativeJit(MIPSState *mipsState);
+	JitInterface *CreateNativeJit(MIPSState *mipsState, bool useIR);
 }

--- a/Core/MIPS/RiscV/RiscVCompFPU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompFPU.cpp
@@ -15,7 +15,6 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include "Core/MemMap.h"
 #include "Core/MIPS/RiscV/RiscVJit.h"
 #include "Core/MIPS/RiscV/RiscVRegCache.h"
 

--- a/Core/MIPS/x86/X64IRAsm.cpp
+++ b/Core/MIPS/x86/X64IRAsm.cpp
@@ -171,7 +171,10 @@ void X64JitBackend::GenerateFixedCode(MIPSState *mipsState) {
 			// Debug
 			if (enableDebug) {
 #if PPSSPP_ARCH(AMD64)
-				ABI_CallFunctionAA(reinterpret_cast<void *>(&ShowPC), R(MEMBASEREG), R(JITBASEREG));
+				if (jo.reserveR15ForAsm)
+					ABI_CallFunctionAA(reinterpret_cast<void *>(&ShowPC), R(MEMBASEREG), R(JITBASEREG));
+				else
+					ABI_CallFunctionAC(reinterpret_cast<void *>(&ShowPC), R(MEMBASEREG), (u32)jitbase);
 #else
 				ABI_CallFunctionCC(reinterpret_cast<void *>(&ShowPC), Menory::base, (u32)jitbase);
 #endif

--- a/Core/MIPS/x86/X64IRAsm.cpp
+++ b/Core/MIPS/x86/X64IRAsm.cpp
@@ -1,0 +1,264 @@
+// Copyright (c) 2023- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "ppsspp_config.h"
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+
+#include "Common/Log.h"
+#include "Core/CoreTiming.h"
+#include "Core/MemMap.h"
+#include "Core/MIPS/x86/X64IRJit.h"
+#include "Core/MIPS/x86/X64IRRegCache.h"
+#include "Core/MIPS/JitCommon/JitCommon.h"
+#include "Core/MIPS/JitCommon/JitState.h"
+#include "Core/System.h"
+
+namespace MIPSComp {
+
+using namespace Gen;
+using namespace X64IRJitConstants;
+
+static const bool enableDebug = false;
+static const bool enableDisasm = false;
+
+static void ShowPC(void *membase, void *jitbase) {
+	static int count = 0;
+	if (currentMIPS) {
+		u32 downcount = currentMIPS->downcount;
+		ERROR_LOG(JIT, "[%08x] ShowPC  Downcount : %08x %d %p %p", currentMIPS->pc, downcount, count, membase, jitbase);
+	} else {
+		ERROR_LOG(JIT, "Universe corrupt?");
+	}
+	//if (count > 2000)
+	//	exit(0);
+	count++;
+}
+
+void X64JitBackend::GenerateFixedCode(MIPSState *mipsState) {
+	BeginWrite(GetMemoryProtectPageSize());
+	const u8 *start = AlignCodePage();
+
+	if (jo.useStaticAlloc && false) {
+		saveStaticRegisters_ = AlignCode16();
+		//MOV(32, MDisp(CTXREG, -128 + offsetof(MIPSState, downcount)), R(DOWNCOUNTREG));
+		//regs_.EmitSaveStaticRegisters();
+		RET();
+
+		loadStaticRegisters_ = AlignCode16();
+		//regs_.EmitLoadStaticRegisters();
+		//MOV(32, R(DOWNCOUNTREG), MDisp(CTXREG, -128 + offsetof(MIPSState, downcount)));
+		RET();
+
+		start = saveStaticRegisters_;
+	} else {
+		saveStaticRegisters_ = nullptr;
+		loadStaticRegisters_ = nullptr;
+	}
+
+	restoreRoundingMode_ = AlignCode16();
+	{
+		STMXCSR(MDisp(CTXREG, -128 + offsetof(MIPSState, temp)));
+		// Clear the rounding mode and flush-to-zero bits back to 0.
+		AND(32, MDisp(CTXREG, -128 + offsetof(MIPSState, temp)), Imm32(~(7 << 13)));
+		LDMXCSR(MDisp(CTXREG, -128 + offsetof(MIPSState, temp)));
+		RET();
+	}
+
+	applyRoundingMode_ = AlignCode16();
+	{
+		MOV(32, R(SCRATCH1), MDisp(CTXREG, -128 + offsetof(MIPSState, fcr31)));
+		AND(32, R(SCRATCH1), Imm32(0x01000003));
+
+		// If it's 0 (nearest + no flush0), we don't actually bother setting - we cleared the rounding
+		// mode out in restoreRoundingMode anyway. This is the most common.
+		FixupBranch skip = J_CC(CC_Z);
+		STMXCSR(MDisp(CTXREG, -128 + offsetof(MIPSState, temp)));
+
+		// The MIPS bits don't correspond exactly, so we have to adjust.
+		// 0 -> 0 (skip2), 1 -> 3, 2 -> 2 (skip2), 3 -> 1
+		TEST(8, R(AL), Imm8(1));
+		FixupBranch skip2 = J_CC(CC_Z);
+		XOR(32, R(SCRATCH1), Imm8(2));
+		SetJumpTarget(skip2);
+
+		// Adjustment complete, now reconstruct MXCSR
+		SHL(32, R(SCRATCH1), Imm8(13));
+		// Before setting new bits, we must clear the old ones.
+		// Clearing bits 13-14 (rounding mode) and 15 (flush to zero.)
+		AND(32, MDisp(CTXREG, -128 + offsetof(MIPSState, temp)), Imm32(~(7 << 13)));
+		OR(32, MDisp(CTXREG, -128 + offsetof(MIPSState, temp)), R(SCRATCH1));
+
+		TEST(32, MDisp(CTXREG, -128 + offsetof(MIPSState, fcr31)), Imm32(1 << 24));
+		FixupBranch skip3 = J_CC(CC_Z);
+		OR(32, MDisp(CTXREG, -128 + offsetof(MIPSState, temp)), Imm32(1 << 15));
+		SetJumpTarget(skip3);
+
+		LDMXCSR(MDisp(CTXREG, -128 + offsetof(MIPSState, temp)));
+		SetJumpTarget(skip);
+		RET();
+	}
+
+	hooks_.enterDispatcher = (IRNativeFuncNoArg)AlignCode16();
+
+	ABI_PushAllCalleeSavedRegsAndAdjustStack();
+#if PPSSPP_ARCH(AMD64)
+	// Two x64-specific statically allocated registers.
+	MOV(64, R(MEMBASEREG), ImmPtr(Memory::base));
+	uintptr_t jitbase = (uintptr_t)GetBasePtr();
+	if (jitbase > 0x7FFFFFFFULL) {
+		MOV(64, R(JITBASEREG), ImmPtr(GetBasePtr()));
+		jo.reserveR15ForAsm = true;
+	}
+#endif
+	// From the start of the FP reg, a single byte offset can reach all GPR + all FPR (but not VFPR.)
+	MOV(PTRBITS, R(CTXREG), ImmPtr(&mipsState->f[0]));
+
+	LoadStaticRegisters();
+	MovFromPC(SCRATCH1);
+	outerLoopPCInSCRATCH1_ = GetCodePtr();
+	MovToPC(SCRATCH1);
+	outerLoop_ = GetCodePtr();
+		// Advance can change the downcount (or thread), so must save/restore around it.
+		SaveStaticRegisters();
+		RestoreRoundingMode(true);
+		ABI_CallFunction(reinterpret_cast<void *>(&CoreTiming::Advance));
+		ApplyRoundingMode(true);
+		LoadStaticRegisters();
+
+		dispatcherCheckCoreState_ = GetCodePtr();
+		// TODO: See if we can get the slice decrement to line up with IR.
+
+		if (RipAccessible((const void *)&coreState)) {
+			CMP(32, M(&coreState), Imm32(0));  // rip accessible
+		} else {
+			MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
+			CMP(32, MatR(RAX), Imm32(0));
+		}
+		FixupBranch badCoreState = J_CC(CC_NZ, true);
+
+		//CMP(32, R(DOWNCOUNTREG), Imm32(0));
+		CMP(32, MDisp(CTXREG, -128 + offsetof(MIPSState, downcount)), Imm32(0));
+		J_CC(CC_S, outerLoop_);
+		FixupBranch skipToRealDispatch = J();
+
+		dispatcherPCInSCRATCH1_ = GetCodePtr();
+		MovToPC(SCRATCH1);
+
+		hooks_.dispatcher = GetCodePtr();
+
+			// TODO: See if we can get the slice decrement to line up with IR.
+			//CMP(32, R(DOWNCOUNTREG), Imm32(0));
+			CMP(32, MDisp(CTXREG, -128 + offsetof(MIPSState, downcount)), Imm32(0));
+			FixupBranch bail = J_CC(CC_S, true);
+			SetJumpTarget(skipToRealDispatch);
+
+			dispatcherNoCheck_ = GetCodePtr();
+
+			// Debug
+			if (enableDebug) {
+#if PPSSPP_ARCH(AMD64)
+				ABI_CallFunctionAA(reinterpret_cast<void *>(&ShowPC), R(MEMBASEREG), R(JITBASEREG));
+#else
+				ABI_CallFunctionCC(reinterpret_cast<void *>(&ShowPC), Menory::base, (u32)jitbase);
+#endif
+			}
+
+			MovFromPC(SCRATCH1);
+#ifdef MASKED_PSP_MEMORY
+			AND(32, R(SCRATCH1), Imm32(Memory::MEMVIEW32_MASK));
+#endif
+			hooks_.dispatchFetch = GetCodePtr();
+#if PPSSPP_ARCH(X86)
+			_assert_msg_( Memory::base != 0, "Memory base bogus");
+			MOV(32, R(SCRATCH1), MDisp(SCRATCH1, (u32)Memory::base));
+#elif PPSSPP_ARCH(AMD64)
+			MOV(32, R(SCRATCH1), MComplex(MEMBASEREG, SCRATCH1, SCALE_1, 0));
+#endif
+			MOV(32, R(EDX), R(SCRATCH1));
+			_assert_msg_(MIPS_JITBLOCK_MASK == 0xFF000000, "Hardcoded assumption of emuhack mask");
+			SHR(32, R(EDX), Imm8(24));
+			CMP(32, R(EDX), Imm8(MIPS_EMUHACK_OPCODE >> 24));
+			FixupBranch needsCompile = J_CC(CC_NE);
+				// Mask by 0x00FFFFFF and extract the block jit offset.
+				AND(32, R(SCRATCH1), Imm32(MIPS_EMUHACK_VALUE_MASK));
+#if PPSSPP_ARCH(X86)
+				ADD(32, R(SCRATCH1), ImmPtr(GetBasePtr()));
+#elif PPSSPP_ARCH(AMD64)
+				if (jo.reserveR15ForAsm) {
+					ADD(64, R(SCRATCH1), R(JITBASEREG));
+				} else {
+					// See above, reserveR15ForAsm is used when above 0x7FFFFFFF.
+					ADD(64, R(SCRATCH1), Imm32((u32)jitbase));
+				}
+#endif
+				JMPptr(R(SCRATCH1));
+			SetJumpTarget(needsCompile);
+
+			// No block found, let's jit.  We don't need to save static regs, they're all callee saved.
+			RestoreRoundingMode(true);
+			ABI_CallFunction(&MIPSComp::JitAt);
+			ApplyRoundingMode(true);
+			// Let's just dispatch again, we'll enter the block since we know it's there.
+			JMP(dispatcherNoCheck_, true);
+
+		SetJumpTarget(bail);
+
+		if (RipAccessible((const void *)&coreState)) {
+			CMP(32, M(&coreState), Imm32(0));  // rip accessible
+		} else {
+			MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
+			CMP(32, MatR(RAX), Imm32(0));
+		}
+		J_CC(CC_Z, outerLoop_, true);
+
+	const uint8_t *quitLoop = GetCodePtr();
+	SetJumpTarget(badCoreState);
+
+	SaveStaticRegisters();
+	RestoreRoundingMode(true);
+	ABI_PopAllCalleeSavedRegsAndAdjustStack();
+	RET();
+
+	hooks_.crashHandler = GetCodePtr();
+	if (RipAccessible((const void *)&coreState)) {
+		MOV(32, M(&coreState), Imm32(CORE_RUNTIME_ERROR));
+	} else {
+		MOV(PTRBITS, R(RAX), ImmPtr((const void *)&coreState));
+		MOV(32, MatR(RAX), Imm32(CORE_RUNTIME_ERROR));
+	}
+	JMP(quitLoop, true);
+
+
+	// Leave this at the end, add more stuff above.
+	if (enableDisasm) {
+#if PPSSPP_ARCH(AMD64)
+		std::vector<std::string> lines = DisassembleX86(start, (int)(GetCodePtr() - start));
+		for (auto s : lines) {
+			INFO_LOG(JIT, "%s", s.c_str());
+		}
+#endif
+	}
+
+	// Let's spare the pre-generated code from unprotect-reprotect.
+	AlignCodePage();
+	jitStartOffset_ = (int)(GetCodePtr() - start);
+	EndWrite();
+}
+
+} // namespace MIPSComp
+
+#endif

--- a/Core/MIPS/x86/X64IRCompALU.cpp
+++ b/Core/MIPS/x86/X64IRCompALU.cpp
@@ -1,0 +1,220 @@
+// Copyright (c) 2023- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "ppsspp_config.h"
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+
+#include "Common/CPUDetect.h"
+#include "Core/MemMap.h"
+#include "Core/MIPS/x86/X64IRJit.h"
+#include "Core/MIPS/x86/X64IRRegCache.h"
+
+// This file contains compilation for integer / arithmetic / logic related instructions.
+//
+// All functions should have CONDITIONAL_DISABLE, so we can narrow things down to a file quickly.
+// Currently known non working ones should have DISABLE.  No flags because that's in IR already.
+
+// #define CONDITIONAL_DISABLE { CompIR_Generic(inst); return; }
+#define CONDITIONAL_DISABLE {}
+#define DISABLE { CompIR_Generic(inst); return; }
+#define INVALIDOP { _assert_msg_(false, "Invalid IR inst %d", (int)inst.op); CompIR_Generic(inst); return; }
+
+namespace MIPSComp {
+
+using namespace Gen;
+using namespace X64IRJitConstants;
+
+void X64JitBackend::CompIR_Arith(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Add:
+	case IROp::Sub:
+	case IROp::AddConst:
+	case IROp::SubConst:
+	case IROp::Neg:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_Assign(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Mov:
+	case IROp::Ext8to32:
+	case IROp::Ext16to32:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_Bits(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::ReverseBits:
+	case IROp::BSwap16:
+	case IROp::BSwap32:
+	case IROp::Clz:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_Compare(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Slt:
+	case IROp::SltConst:
+	case IROp::SltU:
+	case IROp::SltUConst:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_CondAssign(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::MovZ:
+	case IROp::MovNZ:
+	case IROp::Max:
+	case IROp::Min:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_Div(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Div:
+	case IROp::DivU:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_HiLo(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::MtLo:
+	case IROp::MtHi:
+	case IROp::MfLo:
+	case IROp::MfHi:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_Logic(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::And:
+	case IROp::Or:
+	case IROp::Xor:
+	case IROp::AndConst:
+	case IROp::OrConst:
+	case IROp::XorConst:
+	case IROp::Not:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_Mult(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Mult:
+	case IROp::MultU:
+	case IROp::Madd:
+	case IROp::MaddU:
+	case IROp::Msub:
+	case IROp::MsubU:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_Shift(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Shl:
+	case IROp::Shr:
+	case IROp::Sar:
+	case IROp::Ror:
+	case IROp::ShlImm:
+	case IROp::ShrImm:
+	case IROp::SarImm:
+	case IROp::RorImm:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+} // namespace MIPSComp
+
+#endif

--- a/Core/MIPS/x86/X64IRCompBranch.cpp
+++ b/Core/MIPS/x86/X64IRCompBranch.cpp
@@ -41,6 +41,10 @@ void X64JitBackend::CompIR_Exit(IRInst inst) {
 
 	switch (inst.op) {
 	case IROp::ExitToConst:
+		FlushAll();
+		WriteConstExit(inst.constant);
+		break;
+
 	case IROp::ExitToReg:
 	case IROp::ExitToPC:
 		CompIR_Generic(inst);

--- a/Core/MIPS/x86/X64IRCompFPU.cpp
+++ b/Core/MIPS/x86/X64IRCompFPU.cpp
@@ -1,0 +1,199 @@
+// Copyright (c) 2023- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "ppsspp_config.h"
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+
+#include "Core/MIPS/x86/X64IRJit.h"
+#include "Core/MIPS/x86/X64IRRegCache.h"
+
+// This file contains compilation for floating point related instructions.
+//
+// All functions should have CONDITIONAL_DISABLE, so we can narrow things down to a file quickly.
+// Currently known non working ones should have DISABLE.  No flags because that's in IR already.
+
+// #define CONDITIONAL_DISABLE { CompIR_Generic(inst); return; }
+#define CONDITIONAL_DISABLE {}
+#define DISABLE { CompIR_Generic(inst); return; }
+#define INVALIDOP { _assert_msg_(false, "Invalid IR inst %d", (int)inst.op); CompIR_Generic(inst); return; }
+
+namespace MIPSComp {
+
+using namespace Gen;
+using namespace X64IRJitConstants;
+
+void X64JitBackend::CompIR_FArith(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::FAdd:
+	case IROp::FSub:
+	case IROp::FMul:
+	case IROp::FDiv:
+	case IROp::FSqrt:
+	case IROp::FNeg:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_FAssign(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::FMov:
+	case IROp::FAbs:
+	case IROp::FSign:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_FCompare(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	constexpr IRReg IRREG_VFPU_CC = IRREG_VFPU_CTRL_BASE + VFPU_CTRL_CC;
+
+	switch (inst.op) {
+	case IROp::FCmp:
+	case IROp::FCmovVfpuCC:
+	case IROp::FCmpVfpuBit:
+	case IROp::FCmpVfpuAggregate:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_FCondAssign(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::FMin:
+	case IROp::FMax:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_FCvt(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::FCvtWS:
+	case IROp::FCvtSW:
+	case IROp::FCvtScaledWS:
+	case IROp::FCvtScaledSW:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_FRound(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::FRound:
+	case IROp::FTrunc:
+	case IROp::FCeil:
+	case IROp::FFloor:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_FSat(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::FSat0_1:
+	case IROp::FSatMinus1_1:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_FSpecial(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::FSin:
+	case IROp::FCos:
+	case IROp::FRSqrt:
+	case IROp::FRecip:
+	case IROp::FAsin:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_RoundingMode(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::RestoreRoundingMode:
+		RestoreRoundingMode();
+		break;
+
+	case IROp::ApplyRoundingMode:
+		ApplyRoundingMode();
+		break;
+
+	case IROp::UpdateRoundingMode:
+		// TODO: We might want to do something here?
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+} // namespace MIPSComp
+
+#endif

--- a/Core/MIPS/x86/X64IRCompLoadStore.cpp
+++ b/Core/MIPS/x86/X64IRCompLoadStore.cpp
@@ -1,0 +1,179 @@
+// Copyright (c) 2023- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "ppsspp_config.h"
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+
+#include "Core/MemMap.h"
+#include "Core/MIPS/x86/X64IRJit.h"
+#include "Core/MIPS/x86/X64IRRegCache.h"
+
+// This file contains compilation for load/store instructions.
+//
+// All functions should have CONDITIONAL_DISABLE, so we can narrow things down to a file quickly.
+// Currently known non working ones should have DISABLE.  No flags because that's in IR already.
+
+// #define CONDITIONAL_DISABLE { CompIR_Generic(inst); return; }
+#define CONDITIONAL_DISABLE {}
+#define DISABLE { CompIR_Generic(inst); return; }
+#define INVALIDOP { _assert_msg_(false, "Invalid IR inst %d", (int)inst.op); CompIR_Generic(inst); return; }
+
+namespace MIPSComp {
+
+using namespace Gen;
+using namespace X64IRJitConstants;
+
+void X64JitBackend::CompIR_CondStore(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Store32Conditional:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_FLoad(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::LoadFloat:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_FStore(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::StoreFloat:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_Load(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Load8:
+	case IROp::Load8Ext:
+	case IROp::Load16:
+	case IROp::Load16Ext:
+	case IROp::Load32:
+	case IROp::Load32Linked:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_LoadShift(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Load32Left:
+	case IROp::Load32Right:
+		// Should not happen if the pass to split is active.
+		DISABLE;
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_Store(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Store8:
+	case IROp::Store16:
+	case IROp::Store32:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_StoreShift(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Store32Left:
+	case IROp::Store32Right:
+		// Should not happen if the pass to split is active.
+		DISABLE;
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_VecLoad(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::LoadVec4:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_VecStore(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::StoreVec4:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+} // namespace MIPSComp
+
+#endif

--- a/Core/MIPS/x86/X64IRCompSystem.cpp
+++ b/Core/MIPS/x86/X64IRCompSystem.cpp
@@ -1,0 +1,142 @@
+// Copyright (c) 2023- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "ppsspp_config.h"
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+
+#include "Common/Profiler/Profiler.h"
+#include "Core/Core.h"
+#include "Core/HLE/HLE.h"
+#include "Core/HLE/ReplaceTables.h"
+#include "Core/MemMap.h"
+#include "Core/MIPS/x86/X64IRJit.h"
+#include "Core/MIPS/x86/X64IRRegCache.h"
+
+// This file contains compilation for basic PC/downcount accounting, syscalls, debug funcs, etc.
+//
+// All functions should have CONDITIONAL_DISABLE, so we can narrow things down to a file quickly.
+// Currently known non working ones should have DISABLE.  No flags because that's in IR already.
+
+// #define CONDITIONAL_DISABLE { CompIR_Generic(inst); return; }
+#define CONDITIONAL_DISABLE {}
+#define DISABLE { CompIR_Generic(inst); return; }
+#define INVALIDOP { _assert_msg_(false, "Invalid IR inst %d", (int)inst.op); CompIR_Generic(inst); return; }
+
+namespace MIPSComp {
+
+using namespace Gen;
+using namespace X64IRJitConstants;
+
+void X64JitBackend::CompIR_Basic(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Downcount:
+		//ADD(32, R(DOWNCOUNTREG), R(DOWNCOUNTREG), Imm32(-(s32)inst.constant));
+		SUB(32, MDisp(CTXREG, -128 + offsetof(MIPSState, downcount)), Imm32((s32)inst.constant));
+		break;
+
+	case IROp::SetConst:
+		regs_.SetGPRImm(inst.dest, inst.constant);
+		break;
+
+	case IROp::SetConstF:
+	case IROp::SetPC:
+	case IROp::SetPCConst:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_Breakpoint(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Breakpoint:
+	case IROp::MemoryCheck:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_System(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Syscall:
+	case IROp::CallReplacement:
+	case IROp::Break:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_Transfer(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::SetCtrlVFPU:
+	case IROp::SetCtrlVFPUReg:
+	case IROp::SetCtrlVFPUFReg:
+	case IROp::FpCondFromReg:
+	case IROp::FpCondToReg:
+	case IROp::FpCtrlFromReg:
+	case IROp::FpCtrlToReg:
+	case IROp::VfpuCtrlToReg:
+	case IROp::FMovFromGPR:
+	case IROp::FMovToGPR:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_ValidateAddress(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::ValidateAddress8:
+	case IROp::ValidateAddress16:
+	case IROp::ValidateAddress32:
+	case IROp::ValidateAddress128:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+} // namespace MIPSComp
+
+#endif

--- a/Core/MIPS/x86/X64IRCompVec.cpp
+++ b/Core/MIPS/x86/X64IRCompVec.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2023- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "ppsspp_config.h"
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+
+#include <algorithm>
+#include "Core/MemMap.h"
+#include "Core/MIPS/x86/X64IRJit.h"
+#include "Core/MIPS/x86/X64IRRegCache.h"
+
+// This file contains compilation for vector instructions.
+//
+// All functions should have CONDITIONAL_DISABLE, so we can narrow things down to a file quickly.
+// Currently known non working ones should have DISABLE.  No flags because that's in IR already.
+
+// #define CONDITIONAL_DISABLE { CompIR_Generic(inst); return; }
+#define CONDITIONAL_DISABLE {}
+#define DISABLE { CompIR_Generic(inst); return; }
+#define INVALIDOP { _assert_msg_(false, "Invalid IR inst %d", (int)inst.op); CompIR_Generic(inst); return; }
+
+namespace MIPSComp {
+
+using namespace Gen;
+using namespace X64IRJitConstants;
+
+void X64JitBackend::CompIR_VecArith(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Vec4Add:
+	case IROp::Vec4Sub:
+	case IROp::Vec4Mul:
+	case IROp::Vec4Div:
+	case IROp::Vec4Scale:
+	case IROp::Vec4Neg:
+	case IROp::Vec4Abs:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_VecAssign(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Vec4Init:
+	case IROp::Vec4Shuffle:
+	case IROp::Vec4Blend:
+	case IROp::Vec4Mov:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_VecClamp(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Vec4ClampToZero:
+	case IROp::Vec2ClampToZero:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_VecHoriz(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Vec4Dot:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+void X64JitBackend::CompIR_VecPack(IRInst inst) {
+	CONDITIONAL_DISABLE;
+
+	switch (inst.op) {
+	case IROp::Vec2Unpack16To31:
+	case IROp::Vec4Pack32To8:
+	case IROp::Vec2Pack31To16:
+	case IROp::Vec4Unpack8To32:
+	case IROp::Vec2Unpack16To32:
+	case IROp::Vec4DuplicateUpperBitsAndShift1:
+	case IROp::Vec4Pack31To8:
+	case IROp::Vec2Pack32To16:
+		CompIR_Generic(inst);
+		break;
+
+	default:
+		INVALIDOP;
+		break;
+	}
+}
+
+} // namespace MIPSComp
+
+#endif

--- a/Core/MIPS/x86/X64IRJit.cpp
+++ b/Core/MIPS/x86/X64IRJit.cpp
@@ -325,48 +325,6 @@ void X64JitBackend::LoadStaticRegisters() {
 	}
 }
 
-// TODO: Move out to files.
-void X64JitBackend::CompIR_Arith(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_Assign(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_Basic(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_Bits(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_Breakpoint(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_Compare(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_CondAssign(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_CondStore(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_Div(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_Exit(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_ExitIf(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_FArith(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_FAssign(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_FCompare(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_FCondAssign(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_FCvt(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_FLoad(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_FRound(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_FSat(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_FSpecial(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_FStore(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_HiLo(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_Load(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_LoadShift(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_Logic(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_Mult(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_RoundingMode(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_Shift(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_Store(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_StoreShift(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_System(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_Transfer(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_VecArith(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_VecAssign(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_VecClamp(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_VecHoriz(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_VecLoad(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_VecPack(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_VecStore(IRInst inst) { CompIR_Generic(inst); }
-void X64JitBackend::CompIR_ValidateAddress(IRInst inst) { CompIR_Generic(inst); }
-
 } // namespace MIPSComp
 
 #endif

--- a/Core/MIPS/x86/X64IRJit.h
+++ b/Core/MIPS/x86/X64IRJit.h
@@ -106,10 +106,6 @@ private:
 	void CompIR_VecStore(IRInst inst) override;
 	void CompIR_ValidateAddress(IRInst inst) override;
 
-	void SetScratch1ToSrc1Address(IRReg src1);
-	// Modifies SCRATCH regs.
-	int32_t AdjustForAddressOffset(Gen::X64Reg *reg, int32_t constant, int32_t range = 0);
-
 	JitOptions &jo;
 	X64IRRegCache regs_;
 

--- a/Core/MIPS/x86/X64IRJit.h
+++ b/Core/MIPS/x86/X64IRJit.h
@@ -1,0 +1,145 @@
+// Copyright (c) 2023- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "ppsspp_config.h"
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+
+#include <string>
+#include <vector>
+#include "Common/x64Emitter.h"
+#include "Core/MIPS/IR/IRJit.h"
+#include "Core/MIPS/IR/IRNativeCommon.h"
+#include "Core/MIPS/JitCommon/JitState.h"
+#include "Core/MIPS/JitCommon/JitCommon.h"
+#include "Core/MIPS/x86/X64IRRegCache.h"
+
+namespace MIPSComp {
+
+class X64JitBackend : public Gen::XCodeBlock, public IRNativeBackend {
+public:
+	X64JitBackend(JitOptions &jo, IRBlockCache &blocks);
+	~X64JitBackend();
+
+	bool DescribeCodePtr(const u8 *ptr, std::string &name) const override;
+
+	void GenerateFixedCode(MIPSState *mipsState) override;
+	bool CompileBlock(IRBlock *block, int block_num, bool preload) override;
+	void ClearAllBlocks() override;
+	void InvalidateBlock(IRBlock *block, int block_num) override;
+
+protected:
+	const CodeBlockCommon &CodeBlock() const override {
+		return *this;
+	}
+
+private:
+	void RestoreRoundingMode(bool force = false);
+	void ApplyRoundingMode(bool force = false);
+	void MovFromPC(Gen::X64Reg r);
+	void MovToPC(Gen::X64Reg r);
+
+	void SaveStaticRegisters();
+	void LoadStaticRegisters();
+
+	// Note: destroys SCRATCH1.
+	void FlushAll();
+
+	void WriteConstExit(uint32_t pc);
+	void OverwriteExit(int srcOffset, int len, int block_num) override;
+
+	void CompIR_Arith(IRInst inst) override;
+	void CompIR_Assign(IRInst inst) override;
+	void CompIR_Basic(IRInst inst) override;
+	void CompIR_Bits(IRInst inst) override;
+	void CompIR_Breakpoint(IRInst inst) override;
+	void CompIR_Compare(IRInst inst) override;
+	void CompIR_CondAssign(IRInst inst) override;
+	void CompIR_CondStore(IRInst inst) override;
+	void CompIR_Div(IRInst inst) override;
+	void CompIR_Exit(IRInst inst) override;
+	void CompIR_ExitIf(IRInst inst) override;
+	void CompIR_FArith(IRInst inst) override;
+	void CompIR_FAssign(IRInst inst) override;
+	void CompIR_FCompare(IRInst inst) override;
+	void CompIR_FCondAssign(IRInst inst) override;
+	void CompIR_FCvt(IRInst inst) override;
+	void CompIR_FLoad(IRInst inst) override;
+	void CompIR_FRound(IRInst inst) override;
+	void CompIR_FSat(IRInst inst) override;
+	void CompIR_FSpecial(IRInst inst) override;
+	void CompIR_FStore(IRInst inst) override;
+	void CompIR_Generic(IRInst inst) override;
+	void CompIR_HiLo(IRInst inst) override;
+	void CompIR_Interpret(IRInst inst) override;
+	void CompIR_Load(IRInst inst) override;
+	void CompIR_LoadShift(IRInst inst) override;
+	void CompIR_Logic(IRInst inst) override;
+	void CompIR_Mult(IRInst inst) override;
+	void CompIR_RoundingMode(IRInst inst) override;
+	void CompIR_Shift(IRInst inst) override;
+	void CompIR_Store(IRInst inst) override;
+	void CompIR_StoreShift(IRInst inst) override;
+	void CompIR_System(IRInst inst) override;
+	void CompIR_Transfer(IRInst inst) override;
+	void CompIR_VecArith(IRInst inst) override;
+	void CompIR_VecAssign(IRInst inst) override;
+	void CompIR_VecClamp(IRInst inst) override;
+	void CompIR_VecHoriz(IRInst inst) override;
+	void CompIR_VecLoad(IRInst inst) override;
+	void CompIR_VecPack(IRInst inst) override;
+	void CompIR_VecStore(IRInst inst) override;
+	void CompIR_ValidateAddress(IRInst inst) override;
+
+	void SetScratch1ToSrc1Address(IRReg src1);
+	// Modifies SCRATCH regs.
+	int32_t AdjustForAddressOffset(Gen::X64Reg *reg, int32_t constant, int32_t range = 0);
+
+	JitOptions &jo;
+	X64IRRegCache regs_;
+
+	const u8 *outerLoop_ = nullptr;
+	const u8 *outerLoopPCInSCRATCH1_ = nullptr;
+	const u8 *dispatcherCheckCoreState_ = nullptr;
+	const u8 *dispatcherPCInSCRATCH1_ = nullptr;
+	const u8 *dispatcherNoCheck_ = nullptr;
+	const u8 *restoreRoundingMode_ = nullptr;
+	const u8 *applyRoundingMode_ = nullptr;
+
+	const u8 *saveStaticRegisters_ = nullptr;
+	const u8 *loadStaticRegisters_ = nullptr;
+
+	int jitStartOffset_ = 0;
+	int compilingBlockNum_ = -1;
+	int logBlocks_ = 0;
+};
+
+class X64IRJit : public IRNativeJit {
+public:
+	X64IRJit(MIPSState *mipsState)
+		: IRNativeJit(mipsState), rvBackend_(jo, blocks_) {
+		Init(rvBackend_);
+	}
+
+private:
+	X64JitBackend rvBackend_;
+};
+
+} // namespace MIPSComp
+
+#endif

--- a/Core/MIPS/x86/X64IRRegCache.cpp
+++ b/Core/MIPS/x86/X64IRRegCache.cpp
@@ -126,7 +126,7 @@ X64Reg X64IRRegCache::TryMapTempImm(IRReg r) {
 	_dbg_assert_(IsValidGPR(r));
 	// If already mapped, no need for a temporary.
 	if (IsGPRMapped(r)) {
-		return R(r);
+		return RX(r);
 	}
 
 	if (mr[r].loc == MIPSLoc::IMM) {
@@ -282,7 +282,15 @@ void X64IRRegCache::StoreRegValue(IRReg mreg, uint32_t imm) {
 		emit_->MOV(32, MDisp(CTXREG, -128 + GetMipsRegOffset(mreg)), ::R(storeReg));
 }
 
-X64Reg X64IRRegCache::R(IRReg mipsReg) {
+OpArg X64IRRegCache::R(IRReg mipsReg) {
+	return ::R(RX(mipsReg));
+}
+
+OpArg X64IRRegCache::F(IRReg mipsReg) {
+	return ::R(FX(mipsReg));
+}
+
+X64Reg X64IRRegCache::RX(IRReg mipsReg) {
 	_dbg_assert_(IsValidGPR(mipsReg));
 	_dbg_assert_(mr[mipsReg].loc == MIPSLoc::REG || mr[mipsReg].loc == MIPSLoc::REG_IMM);
 	if (mr[mipsReg].loc == MIPSLoc::REG || mr[mipsReg].loc == MIPSLoc::REG_IMM) {
@@ -293,7 +301,7 @@ X64Reg X64IRRegCache::R(IRReg mipsReg) {
 	}
 }
 
-X64Reg X64IRRegCache::RPtr(IRReg mipsReg) {
+X64Reg X64IRRegCache::RXPtr(IRReg mipsReg) {
 	_dbg_assert_(IsValidGPR(mipsReg));
 	_dbg_assert_(mr[mipsReg].loc == MIPSLoc::REG || mr[mipsReg].loc == MIPSLoc::REG_IMM || mr[mipsReg].loc == MIPSLoc::REG_AS_PTR);
 	if (mr[mipsReg].loc == MIPSLoc::REG_AS_PTR) {
@@ -313,7 +321,7 @@ X64Reg X64IRRegCache::RPtr(IRReg mipsReg) {
 	}
 }
 
-X64Reg X64IRRegCache::F(IRReg mipsReg) {
+X64Reg X64IRRegCache::FX(IRReg mipsReg) {
 	_dbg_assert_(IsValidFPR(mipsReg));
 	_dbg_assert_(mr[mipsReg + 32].loc == MIPSLoc::FREG);
 	if (mr[mipsReg + 32].loc == MIPSLoc::FREG) {

--- a/Core/MIPS/x86/X64IRRegCache.cpp
+++ b/Core/MIPS/x86/X64IRRegCache.cpp
@@ -1,0 +1,324 @@
+// Copyright (c) 2023- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "ppsspp_config.h"
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+
+#ifndef offsetof
+#include <cstddef>
+#endif
+
+#include "Common/CPUDetect.h"
+#include "Core/MemMap.h"
+#include "Core/MIPS/IR/IRInst.h"
+#include "Core/MIPS/IR/IRAnalysis.h"
+#include "Core/MIPS/x86/X64IRRegCache.h"
+#include "Core/MIPS/JitCommon/JitState.h"
+#include "Core/Reporting.h"
+
+using namespace Gen;
+using namespace X64IRJitConstants;
+
+X64IRRegCache::X64IRRegCache(MIPSComp::JitOptions *jo)
+	: IRNativeRegCacheBase(jo) {
+	// TODO: Enable SIMD.
+	config_.totalNativeRegs = NUM_X_REGS + NUM_X_FREGS;
+	config_.mapFPUSIMD = false;
+	// XMM regs are used for both FPU and Vec, so we don't need VREGs.
+	config_.mapUseVRegs = false;
+}
+
+void X64IRRegCache::Init(XEmitter *emitter) {
+	emit_ = emitter;
+}
+
+const int *X64IRRegCache::GetAllocationOrder(MIPSLoc type, int &count, int &base) const {
+	if (type == MIPSLoc::REG) {
+		base = RAX;
+
+		static const int allocationOrder[] = {
+			// On x64, RCX and RDX are the first args.  CallProtectedFunction() assumes they're not regcached.
+#if PPSSPP_ARCH(AMD64)
+#ifdef _WIN32
+			RSI, RDI, R8, R9, R10, R11, R12, R13,
+#else
+			RBP, R8, R9, R10, R11, R12, R13,
+#endif
+#elif PPSSPP_ARCH(X86)
+			ESI, EDI, EDX, ECX, EBX,
+#endif
+			// Intentionally last.
+			R15,
+		};
+
+		if (!jo_->reserveR15ForAsm)
+			count = ARRAY_SIZE(allocationOrder) - 1;
+		else
+			count = ARRAY_SIZE(allocationOrder);
+		return allocationOrder;
+	} else if (type == MIPSLoc::FREG) {
+		base = -NUM_X_REGS;
+
+		// TODO: Might have to change this if we can't live without dedicated temps.
+		static const int allocationOrder[] = {
+#if PPSSPP_ARCH(AMD64)
+		XMM6, XMM7, XMM8, XMM9, XMM10, XMM11, XMM12, XMM13, XMM14, XMM15, XMM0, XMM1, XMM2, XMM3, XMM4, XMM5
+#elif PPSSPP_ARCH(X86)
+		XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6, XMM7,
+#endif
+		};
+
+		count = ARRAY_SIZE(allocationOrder);
+		return allocationOrder;
+	} else {
+		_assert_msg_(false, "Allocation order not yet implemented");
+		count = 0;
+		return nullptr;
+	}
+}
+
+void X64IRRegCache::FlushBeforeCall() {
+	// These registers are not preserved by function calls.
+#if PPSSPP_ARCH(AMD64)
+#ifdef _WIN32
+	FlushNativeReg(GPRToNativeReg(RCX));
+	FlushNativeReg(GPRToNativeReg(RDX));
+	FlushNativeReg(GPRToNativeReg(R8));
+	FlushNativeReg(GPRToNativeReg(R9));
+	FlushNativeReg(GPRToNativeReg(R10));
+	FlushNativeReg(GPRToNativeReg(R11));
+	for (int i = 0; i < 6; ++i)
+		FlushNativeReg(NUM_X_REGS + i);
+#else
+	FlushNativeReg(GPRToNativeReg(R8));
+	FlushNativeReg(GPRToNativeReg(R9));
+	FlushNativeReg(GPRToNativeReg(R10));
+	FlushNativeReg(GPRToNativeReg(R11));
+	for (int i = 0; i < NUM_X_FREGS; ++i)
+		FlushNativeReg(NUM_X_REGS + i);
+#endif
+#elif PPSSPP_ARCH(X86)
+	FlushNativeReg(GPRToNativeReg(ECX));
+	FlushNativeReg(GPRToNativeReg(EDX));
+	for (int i = 0; i < NUM_X_FREGS; ++i)
+		FlushNativeReg(NUM_X_REGS + i);
+#endif
+}
+
+X64Reg X64IRRegCache::TryMapTempImm(IRReg r) {
+	_dbg_assert_(IsValidGPR(r));
+	// If already mapped, no need for a temporary.
+	if (IsGPRMapped(r)) {
+		return R(r);
+	}
+
+	if (mr[r].loc == MIPSLoc::IMM) {
+		// Try our luck - check for an exact match in another xreg.
+		for (int i = 0; i < TOTAL_MAPPABLE_IRREGS; ++i) {
+			if (mr[i].loc == MIPSLoc::REG_IMM && mr[i].imm == mr[r].imm) {
+				// Awesome, let's just use this reg.
+				return FromNativeReg(mr[i].nReg);
+			}
+		}
+	}
+
+	return INVALID_REG;
+}
+
+X64Reg X64IRRegCache::GetAndLockTempR() {
+	X64Reg reg = FromNativeReg(AllocateReg(MIPSLoc::REG));
+	if (reg != INVALID_REG) {
+		nr[reg].tempLockIRIndex = irIndex_;
+	}
+	return reg;
+}
+
+X64Reg X64IRRegCache::MapWithFPRTemp(IRInst &inst) {
+	return FromNativeReg(MapWithTemp(inst, MIPSLoc::FREG));
+}
+
+X64Reg X64IRRegCache::MapGPR(IRReg mipsReg, MIPSMap mapFlags) {
+	_dbg_assert_(IsValidGPR(mipsReg));
+
+	// Okay, not mapped, so we need to allocate an RV register.
+	IRNativeReg nreg = MapNativeReg(MIPSLoc::REG, mipsReg, 1, mapFlags);
+	return FromNativeReg(nreg);
+}
+
+X64Reg X64IRRegCache::MapGPRAsPointer(IRReg reg) {
+	return FromNativeReg(MapNativeRegAsPointer(reg));
+}
+
+X64Reg X64IRRegCache::MapFPR(IRReg mipsReg, MIPSMap mapFlags) {
+	_dbg_assert_(IsValidFPR(mipsReg));
+	_dbg_assert_(mr[mipsReg + 32].loc == MIPSLoc::MEM || mr[mipsReg + 32].loc == MIPSLoc::FREG);
+
+	IRNativeReg nreg = MapNativeReg(MIPSLoc::FREG, mipsReg + 32, 1, mapFlags);
+	if (nreg != -1)
+		return FromNativeReg(nreg);
+	return INVALID_REG;
+}
+
+void X64IRRegCache::AdjustNativeRegAsPtr(IRNativeReg nreg, bool state) {
+	_assert_(nreg >= 0 && nreg < NUM_X_REGS);
+	X64Reg r = FromNativeReg(nreg);
+	if (state) {
+#if defined(MASKED_PSP_MEMORY)
+		// This destroys the value...
+		_dbg_assert_(!nr[nreg].isDirty);
+		emit_->AND(PTRBITS, ::R(r), Imm32(Memory::MEMVIEW32_MASK));
+		emit_->ADD(PTRBITS, ::R(r), ImmPtr(Memory::base));
+#else
+		// Clear the top bits to be safe.
+		emit_->ADD(PTRBITS, ::R(r), ::R(MEMBASEREG));
+#endif
+	} else {
+#if defined(MASKED_PSP_MEMORY)
+		_dbg_assert_(!nr[nreg].isDirty);
+		emit_->SUB(PTRBITS, ::R(r), ImmPtr(Memory::base));
+#else
+		emit_->SUB(PTRBITS, ::R(r), ::R(MEMBASEREG));
+#endif
+	}
+}
+
+void X64IRRegCache::LoadNativeReg(IRNativeReg nreg, IRReg first, int lanes) {
+	X64Reg r = FromNativeReg(nreg);
+	_dbg_assert_(first != MIPS_REG_ZERO);
+	if (nreg < NUM_X_REGS) {
+		// Multilane not yet supported.
+		_assert_(lanes == 1 || (lanes == 2 && first == IRREG_LO));
+		if (lanes == 1)
+			emit_->MOV(32, ::R(r), MDisp(CTXREG, -128 + GetMipsRegOffset(first)));
+#if PPSSPP_ARCH(AMD64)
+		else if (lanes == 2)
+			emit_->MOV(64, ::R(r), MDisp(CTXREG, -128 + GetMipsRegOffset(first)));
+#endif
+		else
+			_assert_(false);
+	} else {
+		_dbg_assert_(nreg < NUM_X_REGS + NUM_X_FREGS);
+		_assert_msg_(mr[first].loc == MIPSLoc::FREG, "Cannot load this type: %d", (int)mr[first].loc);
+		if (lanes == 1)
+			emit_->MOVSS(r, MDisp(CTXREG, -128 + GetMipsRegOffset(first)));
+		else if (lanes == 2)
+			emit_->MOVLPS(r, MDisp(CTXREG, -128 + GetMipsRegOffset(first)));
+		else if (lanes == 4)
+			emit_->MOVUPS(r, MDisp(CTXREG, -128 + GetMipsRegOffset(first)));
+		else
+			_assert_(false);
+	}
+}
+
+void X64IRRegCache::StoreNativeReg(IRNativeReg nreg, IRReg first, int lanes) {
+	X64Reg r = FromNativeReg(nreg);
+	_dbg_assert_(first != MIPS_REG_ZERO);
+	if (nreg < NUM_X_REGS) {
+		// Multilane not yet supported.
+		_assert_(lanes == 1 || (lanes == 2 && first == IRREG_LO));
+		_assert_(mr[first].loc == MIPSLoc::REG || mr[first].loc == MIPSLoc::REG_IMM);
+		if (lanes == 1)
+			emit_->MOV(32, MDisp(CTXREG, -128 + GetMipsRegOffset(first)), ::R(r));
+#if PPSSPP_ARCH(AMD64)
+		else if (lanes == 2)
+			emit_->MOV(64, MDisp(CTXREG, -128 + GetMipsRegOffset(first)), ::R(r));
+#endif
+		else
+			_assert_(false);
+	} else {
+		_dbg_assert_(nreg < NUM_X_REGS + NUM_X_FREGS);
+		_assert_msg_(mr[first].loc == MIPSLoc::FREG, "Cannot store this type: %d", (int)mr[first].loc);
+		if (lanes == 1)
+			emit_->MOVSS(MDisp(CTXREG, -128 + GetMipsRegOffset(first)), r);
+		else if (lanes == 2)
+			emit_->MOVLPS(MDisp(CTXREG, -128 + GetMipsRegOffset(first)), r);
+		else if (lanes == 4)
+			emit_->MOVUPS(MDisp(CTXREG, -128 + GetMipsRegOffset(first)), r);
+		else
+			_assert_(false);
+	}
+}
+
+void X64IRRegCache::SetNativeRegValue(IRNativeReg nreg, uint32_t imm) {
+	X64Reg r = FromNativeReg(nreg);
+	_dbg_assert_(nreg >= 0 && nreg < NUM_X_REGS);
+	emit_->MOV(32, ::R(r), Imm32(imm));
+}
+
+void X64IRRegCache::StoreRegValue(IRReg mreg, uint32_t imm) {
+	_assert_(IsValidGPRNoZero(mreg));
+	// Try to optimize using a different reg.
+	X64Reg storeReg = INVALID_REG;
+
+	// Could we get lucky?  Check for an exact match in another xreg.
+	for (int i = 0; i < TOTAL_MAPPABLE_IRREGS; ++i) {
+		if (mr[i].loc == MIPSLoc::REG_IMM && mr[i].imm == imm) {
+			// Awesome, let's just store this reg.
+			storeReg = (X64Reg)mr[i].nReg;
+			break;
+		}
+	}
+
+	if (storeReg == INVALID_REG)
+		emit_->MOV(32, MDisp(CTXREG, -128 + GetMipsRegOffset(mreg)), Imm32(imm));
+	else
+		emit_->MOV(32, MDisp(CTXREG, -128 + GetMipsRegOffset(mreg)), ::R(storeReg));
+}
+
+X64Reg X64IRRegCache::R(IRReg mipsReg) {
+	_dbg_assert_(IsValidGPR(mipsReg));
+	_dbg_assert_(mr[mipsReg].loc == MIPSLoc::REG || mr[mipsReg].loc == MIPSLoc::REG_IMM);
+	if (mr[mipsReg].loc == MIPSLoc::REG || mr[mipsReg].loc == MIPSLoc::REG_IMM) {
+		return FromNativeReg(mr[mipsReg].nReg);
+	} else {
+		ERROR_LOG_REPORT(JIT, "Reg %i not in riscv reg", mipsReg);
+		return INVALID_REG;  // BAAAD
+	}
+}
+
+X64Reg X64IRRegCache::RPtr(IRReg mipsReg) {
+	_dbg_assert_(IsValidGPR(mipsReg));
+	_dbg_assert_(mr[mipsReg].loc == MIPSLoc::REG || mr[mipsReg].loc == MIPSLoc::REG_IMM || mr[mipsReg].loc == MIPSLoc::REG_AS_PTR);
+	if (mr[mipsReg].loc == MIPSLoc::REG_AS_PTR) {
+		return FromNativeReg(mr[mipsReg].nReg);
+	} else if (mr[mipsReg].loc == MIPSLoc::REG || mr[mipsReg].loc == MIPSLoc::REG_IMM) {
+		int rv = mr[mipsReg].nReg;
+		_dbg_assert_(nr[rv].pointerified);
+		if (nr[rv].pointerified) {
+			return FromNativeReg(mr[mipsReg].nReg);
+		} else {
+			ERROR_LOG(JIT, "Tried to use a non-pointer register as a pointer");
+			return INVALID_REG;
+		}
+	} else {
+		ERROR_LOG_REPORT(JIT, "Reg %i not in x64 reg", mipsReg);
+		return INVALID_REG;  // BAAAD
+	}
+}
+
+X64Reg X64IRRegCache::F(IRReg mipsReg) {
+	_dbg_assert_(IsValidFPR(mipsReg));
+	_dbg_assert_(mr[mipsReg + 32].loc == MIPSLoc::FREG);
+	if (mr[mipsReg + 32].loc == MIPSLoc::FREG) {
+		return FromNativeReg(mr[mipsReg + 32].nReg);
+	} else {
+		ERROR_LOG_REPORT(JIT, "Reg %i not in x64 reg", mipsReg);
+		return INVALID_REG;  // BAAAD
+	}
+}
+
+#endif

--- a/Core/MIPS/x86/X64IRRegCache.cpp
+++ b/Core/MIPS/x86/X64IRRegCache.cpp
@@ -58,17 +58,20 @@ const int *X64IRRegCache::GetAllocationOrder(MIPSLoc type, int &count, int &base
 #else
 			RBP, R8, R9, R10, R11, R12, R13,
 #endif
+			// Intentionally last.
+			R15,
 #elif PPSSPP_ARCH(X86)
 			ESI, EDI, EDX, ECX, EBX,
 #endif
-			// Intentionally last.
-			R15,
 		};
 
-		if (!jo_->reserveR15ForAsm)
+#if !PPSSPP_ARCH(X86)
+		if (jo_->reserveR15ForAsm) {
 			count = ARRAY_SIZE(allocationOrder) - 1;
-		else
-			count = ARRAY_SIZE(allocationOrder);
+			return allocationOrder;
+		}
+#endif
+		count = ARRAY_SIZE(allocationOrder);
 		return allocationOrder;
 	} else if (type == MIPSLoc::FREG) {
 		base = -NUM_X_REGS;
@@ -285,7 +288,7 @@ X64Reg X64IRRegCache::R(IRReg mipsReg) {
 	if (mr[mipsReg].loc == MIPSLoc::REG || mr[mipsReg].loc == MIPSLoc::REG_IMM) {
 		return FromNativeReg(mr[mipsReg].nReg);
 	} else {
-		ERROR_LOG_REPORT(JIT, "Reg %i not in riscv reg", mipsReg);
+		ERROR_LOG_REPORT(JIT, "Reg %i not in x64 reg", mipsReg);
 		return INVALID_REG;  // BAAAD
 	}
 }

--- a/Core/MIPS/x86/X64IRRegCache.cpp
+++ b/Core/MIPS/x86/X64IRRegCache.cpp
@@ -286,6 +286,10 @@ OpArg X64IRRegCache::R(IRReg mipsReg) {
 	return ::R(RX(mipsReg));
 }
 
+OpArg X64IRRegCache::RPtr(IRReg mipsReg) {
+	return ::R(RXPtr(mipsReg));
+}
+
 OpArg X64IRRegCache::F(IRReg mipsReg) {
 	return ::R(FX(mipsReg));
 }

--- a/Core/MIPS/x86/X64IRRegCache.h
+++ b/Core/MIPS/x86/X64IRRegCache.h
@@ -1,0 +1,100 @@
+// Copyright (c) 2023- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include "ppsspp_config.h"
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+
+#include "Common/x64Emitter.h"
+#include "Core/MIPS/MIPS.h"
+#include "Core/MIPS/IR/IRJit.h"
+#include "Core/MIPS/IR/IRRegCache.h"
+
+namespace X64IRJitConstants {
+
+#if PPSSPP_ARCH(AMD64)
+const Gen::X64Reg MEMBASEREG = Gen::RBX;
+const Gen::X64Reg CTXREG = Gen::R14;
+const Gen::X64Reg JITBASEREG = Gen::R15;
+#else
+const Gen::X64Reg CTXREG = Gen::EBP;
+#endif
+const Gen::X64Reg SCRATCH1 = Gen::EAX;
+
+} // namespace X64IRJitConstants
+
+class X64IRRegCache : public IRNativeRegCacheBase {
+public:
+	X64IRRegCache(MIPSComp::JitOptions *jo);
+
+	void Init(Gen::XEmitter *emitter);
+
+	// May fail and return INVALID_REG if it needs flushing.
+	Gen::X64Reg TryMapTempImm(IRReg);
+
+	// Returns an RV register containing the requested MIPS register.
+	Gen::X64Reg MapGPR(IRReg reg, MIPSMap mapFlags = MIPSMap::INIT);
+	Gen::X64Reg MapGPRAsPointer(IRReg reg);
+	Gen::X64Reg MapFPR(IRReg reg, MIPSMap mapFlags = MIPSMap::INIT);
+
+	Gen::X64Reg MapWithFPRTemp(IRInst &inst);
+
+	void FlushBeforeCall();
+
+	Gen::X64Reg GetAndLockTempR();
+
+	Gen::X64Reg R(IRReg preg); // Returns a cached register, while checking that it's NOT mapped as a pointer
+	Gen::X64Reg RPtr(IRReg preg); // Returns a cached register, if it has been mapped as a pointer
+	Gen::X64Reg F(IRReg preg);
+
+protected:
+	const int *GetAllocationOrder(MIPSLoc type, int &count, int &base) const override;
+	void AdjustNativeRegAsPtr(IRNativeReg nreg, bool state) override;
+
+	void LoadNativeReg(IRNativeReg nreg, IRReg first, int lanes) override;
+	void StoreNativeReg(IRNativeReg nreg, IRReg first, int lanes) override;
+	void SetNativeRegValue(IRNativeReg nreg, uint32_t imm) override;
+	void StoreRegValue(IRReg mreg, uint32_t imm) override;
+
+private:
+	IRNativeReg GPRToNativeReg(Gen::X64Reg r) {
+		return (IRNativeReg)r;
+	}
+	IRNativeReg XMMToNativeReg(Gen::X64Reg r) {
+		return (IRNativeReg)(r + NUM_X_REGS);
+	}
+	Gen::X64Reg FromNativeReg(IRNativeReg r) {
+		if (r >= NUM_X_REGS)
+			return (Gen::X64Reg)(Gen::XMM0 + (r - NUM_X_REGS));
+		return (Gen::X64Reg)(Gen::RAX + r);
+	}
+
+	Gen::XEmitter *emit_ = nullptr;
+
+	enum {
+#if PPSSPP_ARCH(AMD64)
+		NUM_X_REGS = 16,
+		NUM_X_FREGS = 16,
+#elif PPSSPP_ARCH(X86)
+		NUM_X_REGS = 8,
+		NUM_X_FREGS = 8,
+#endif
+	};
+};
+
+#endif

--- a/Core/MIPS/x86/X64IRRegCache.h
+++ b/Core/MIPS/x86/X64IRRegCache.h
@@ -58,9 +58,11 @@ public:
 
 	Gen::X64Reg GetAndLockTempR();
 
-	Gen::X64Reg R(IRReg preg); // Returns a cached register, while checking that it's NOT mapped as a pointer
-	Gen::X64Reg RPtr(IRReg preg); // Returns a cached register, if it has been mapped as a pointer
-	Gen::X64Reg F(IRReg preg);
+	Gen::OpArg R(IRReg preg);
+	Gen::OpArg F(IRReg preg);
+	Gen::X64Reg RX(IRReg preg); // Returns a cached register, while checking that it's NOT mapped as a pointer
+	Gen::X64Reg RXPtr(IRReg preg); // Returns a cached register, if it has been mapped as a pointer
+	Gen::X64Reg FX(IRReg preg);
 
 protected:
 	const int *GetAllocationOrder(MIPSLoc type, int &count, int &base) const override;

--- a/Core/MIPS/x86/X64IRRegCache.h
+++ b/Core/MIPS/x86/X64IRRegCache.h
@@ -59,6 +59,7 @@ public:
 	Gen::X64Reg GetAndLockTempR();
 
 	Gen::OpArg R(IRReg preg);
+	Gen::OpArg RPtr(IRReg preg);
 	Gen::OpArg F(IRReg preg);
 	Gen::X64Reg RX(IRReg preg); // Returns a cached register, while checking that it's NOT mapped as a pointer
 	Gen::X64Reg RXPtr(IRReg preg); // Returns a cached register, if it has been mapped as a pointer

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -36,7 +36,7 @@ enum {
 };
 
 DrawEngineCommon::DrawEngineCommon() : decoderMap_(16) {
-	if (g_Config.bVertexDecoderJit && g_Config.iCpuCore == (int)CPUCore::JIT) {
+	if (g_Config.bVertexDecoderJit && (g_Config.iCpuCore == (int)CPUCore::JIT || g_Config.iCpuCore == (int)CPUCore::JIT_IR)) {
 		decJitCache_ = new VertexDecoderJitCache();
 	}
 	transformed_ = (TransformedVertex *)AllocateMemoryPages(TRANSFORMED_VERTEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -1524,7 +1524,7 @@ VertexDecoderJitCache::VertexDecoderJitCache()
 }
 
 void VertexDecoderJitCache::Clear() {
-	if (g_Config.iCpuCore == (int)CPUCore::JIT) {
+	if (g_Config.iCpuCore == (int)CPUCore::JIT || g_Config.iCpuCore == (int)CPUCore::JIT_IR) {
 		ClearCodeSpace(0);
 	}
 }

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1177,6 +1177,7 @@ static const char *CPUCoreAsString(int core) {
 	case 0: return "Interpreter";
 	case 1: return "JIT";
 	case 2: return "IR Interpreter";
+	case 3: return "JIT Using IR";
 	default: return "N/A";
 	}
 }

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1663,7 +1663,7 @@ void DeveloperToolsScreen::CreateViews() {
 	// iOS can now use JIT on all modes, apparently.
 	// The bool may come in handy for future non-jit platforms though (UWP XB1?)
 
-	static const char *cpuCores[] = {"Interpreter", "Dynarec (JIT)", "IR Interpreter"};
+	static const char *cpuCores[] = {"Interpreter", "Dynarec (JIT)", "IR Interpreter", "JIT Using IR"};
 	PopupMultiChoice *core = list->Add(new PopupMultiChoice(&g_Config.iCpuCore, gr->T("CPU Core"), cpuCores, 0, ARRAY_SIZE(cpuCores), I18NCat::SYSTEM, screenManager()));
 	core->OnChoice.Handle(this, &DeveloperToolsScreen::OnJitAffectingSetting);
 	core->OnChoice.Add([](UI::EventParams &) {
@@ -1672,7 +1672,12 @@ void DeveloperToolsScreen::CreateViews() {
 	});
 	if (!canUseJit) {
 		core->HideChoice(1);
+		core->HideChoice(3);
 	}
+	// TODO: Enable on more architectures.
+#if !PPSSPP_ARCH(X86) && !PPSSPP_ARCH(AMD64)
+	core->HideChoice(3);
+#endif
 
 	list->Add(new Choice(dev->T("JIT debug tools")))->OnClick.Handle(this, &DeveloperToolsScreen::OnJitDebugTools);
 	list->Add(new CheckBox(&g_Config.bShowDeveloperMenu, dev->T("Show Developer Menu")));

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -603,7 +603,11 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 				g_Config.bSaveSettings = false;
 				break;
 			case 'r':
-				g_Config.iCpuCore = (int)CPUCore::IR_JIT;
+				g_Config.iCpuCore = (int)CPUCore::IR_INTERPRETER;
+				g_Config.bSaveSettings = false;
+				break;
+			case 'J':
+				g_Config.iCpuCore = (int)CPUCore::JIT_IR;
 				g_Config.bSaveSettings = false;
 				break;
 			case '-':

--- a/UWP/CoreUWP/CoreUWP.vcxproj
+++ b/UWP/CoreUWP/CoreUWP.vcxproj
@@ -304,6 +304,8 @@
     <ClInclude Include="..\..\Core\MIPS\x86\JitSafeMem.h" />
     <ClInclude Include="..\..\Core\MIPS\x86\RegCache.h" />
     <ClInclude Include="..\..\Core\MIPS\x86\RegCacheFPU.h" />
+    <ClInclude Include="..\..\Core\MIPS\x86\X64IRJit.h" />
+    <ClInclude Include="..\..\Core\MIPS\x86\X64IRRegCache.h" />
     <ClInclude Include="..\..\Core\Opcode.h" />
     <ClInclude Include="..\..\Core\PSPLoaders.h" />
     <ClInclude Include="..\..\Core\Reporting.h" />
@@ -573,6 +575,9 @@
     <ClCompile Include="..\..\Core\MIPS\x86\JitSafeMem.cpp" />
     <ClCompile Include="..\..\Core\MIPS\x86\RegCache.cpp" />
     <ClCompile Include="..\..\Core\MIPS\x86\RegCacheFPU.cpp" />
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRAsm.cpp" />
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRJit.cpp" />
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRRegCache.cpp" />
     <ClCompile Include="..\..\Core\PSPLoaders.cpp" />
     <ClCompile Include="..\..\Core\Reporting.cpp" />
     <ClCompile Include="..\..\Core\Replay.cpp" />

--- a/UWP/CoreUWP/CoreUWP.vcxproj
+++ b/UWP/CoreUWP/CoreUWP.vcxproj
@@ -576,6 +576,12 @@
     <ClCompile Include="..\..\Core\MIPS\x86\RegCache.cpp" />
     <ClCompile Include="..\..\Core\MIPS\x86\RegCacheFPU.cpp" />
     <ClCompile Include="..\..\Core\MIPS\x86\X64IRAsm.cpp" />
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRCompALU.cpp" />
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRCompBranch.cpp" />
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRCompFPU.cpp" />
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRCompLoadStore.cpp" />
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRCompSystem.cpp" />
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRCompVec.cpp" />
     <ClCompile Include="..\..\Core\MIPS\x86\X64IRJit.cpp" />
     <ClCompile Include="..\..\Core\MIPS\x86\X64IRRegCache.cpp" />
     <ClCompile Include="..\..\Core\PSPLoaders.cpp" />

--- a/UWP/CoreUWP/CoreUWP.vcxproj.filters
+++ b/UWP/CoreUWP/CoreUWP.vcxproj.filters
@@ -189,6 +189,15 @@
     <ClCompile Include="..\..\Core\MIPS\x86\RegCacheFPU.cpp">
       <Filter>MIPS\x86</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRAsm.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRJit.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRRegCache.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Core\FileSystems\BlobFileSystem.cpp">
       <Filter>FileSystems</Filter>
     </ClCompile>
@@ -1198,6 +1207,12 @@
       <Filter>MIPS\x86</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Core\MIPS\x86\RegCacheFPU.h">
+      <Filter>MIPS\x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Core\MIPS\x86\X64IRJit.h">
+      <Filter>MIPS\x86</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Core\MIPS\x86\X64IRRegCache.h">
       <Filter>MIPS\x86</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Core\FileSystems\BlobFileSystem.h">

--- a/UWP/CoreUWP/CoreUWP.vcxproj.filters
+++ b/UWP/CoreUWP/CoreUWP.vcxproj.filters
@@ -192,6 +192,24 @@
     <ClCompile Include="..\..\Core\MIPS\x86\X64IRAsm.cpp">
       <Filter>MIPS\x86</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRCompALU.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRCompBranch.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRCompFPU.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRCompLoadStore.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRCompSystem.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Core\MIPS\x86\X64IRCompVec.cpp">
+      <Filter>MIPS\x86</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Core\MIPS\x86\X64IRJit.cpp">
       <Filter>MIPS\x86</Filter>
     </ClCompile>

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -303,6 +303,9 @@ ARCH_FILES := \
   $(SRC)/Core/MIPS/x86/JitSafeMem.cpp \
   $(SRC)/Core/MIPS/x86/RegCache.cpp \
   $(SRC)/Core/MIPS/x86/RegCacheFPU.cpp \
+  $(SRC)/Core/MIPS/x86/X64IRAsm.cpp \
+  $(SRC)/Core/MIPS/x86/X64IRJit.cpp \
+  $(SRC)/Core/MIPS/x86/X64IRRegCache.cpp \
   $(SRC)/GPU/Common/VertexDecoderX86.cpp \
   $(SRC)/GPU/Software/DrawPixelX86.cpp \
   $(SRC)/GPU/Software/SamplerX86.cpp

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -304,6 +304,12 @@ ARCH_FILES := \
   $(SRC)/Core/MIPS/x86/RegCache.cpp \
   $(SRC)/Core/MIPS/x86/RegCacheFPU.cpp \
   $(SRC)/Core/MIPS/x86/X64IRAsm.cpp \
+  $(SRC)/Core/MIPS/x86/X64IRCompALU.cpp \
+  $(SRC)/Core/MIPS/x86/X64IRCompBranch.cpp \
+  $(SRC)/Core/MIPS/x86/X64IRCompFPU.cpp \
+  $(SRC)/Core/MIPS/x86/X64IRCompLoadStore.cpp \
+  $(SRC)/Core/MIPS/x86/X64IRCompSystem.cpp \
+  $(SRC)/Core/MIPS/x86/X64IRCompVec.cpp \
   $(SRC)/Core/MIPS/x86/X64IRJit.cpp \
   $(SRC)/Core/MIPS/x86/X64IRRegCache.cpp \
   $(SRC)/GPU/Common/VertexDecoderX86.cpp \

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -365,8 +365,10 @@ int main(int argc, const char* argv[])
 			cpuCore = CPUCore::INTERPRETER;
 		else if (!strcmp(argv[i], "-j"))
 			cpuCore = CPUCore::JIT;
+		else if (!strcmp(argv[i], "--jit-ir"))
+			cpuCore = CPUCore::JIT_IR;
 		else if (!strcmp(argv[i], "--ir"))
-			cpuCore = CPUCore::IR_JIT;
+			cpuCore = CPUCore::IR_INTERPRETER;
 		else if (!strcmp(argv[i], "-c") || !strcmp(argv[i], "--compare"))
 			testOptions.compare = true;
 		else if (!strcmp(argv[i], "--bench"))

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -803,6 +803,12 @@ ifeq ($(WITH_DYNAREC),1)
 						$(COREDIR)/MIPS/x86/RegCache.cpp \
 						$(COREDIR)/MIPS/x86/RegCacheFPU.cpp \
 						$(COREDIR)/MIPS/x86/X64IRAsm.cpp \
+						$(COREDIR)/MIPS/x86/X64IRCompALU.cpp \
+						$(COREDIR)/MIPS/x86/X64IRCompBranch.cpp \
+						$(COREDIR)/MIPS/x86/X64IRCompFPU.cpp \
+						$(COREDIR)/MIPS/x86/X64IRCompLoadStore.cpp \
+						$(COREDIR)/MIPS/x86/X64IRCompSystem.cpp \
+						$(COREDIR)/MIPS/x86/X64IRCompVec.cpp \
 						$(COREDIR)/MIPS/x86/X64IRJit.cpp \
 						$(COREDIR)/MIPS/x86/X64IRRegCache.cpp \
 						$(GPUDIR)/Common/VertexDecoderX86.cpp

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -802,6 +802,9 @@ ifeq ($(WITH_DYNAREC),1)
 						$(COREDIR)/MIPS/x86/JitSafeMem.cpp \
 						$(COREDIR)/MIPS/x86/RegCache.cpp \
 						$(COREDIR)/MIPS/x86/RegCacheFPU.cpp \
+						$(COREDIR)/MIPS/x86/X64IRAsm.cpp \
+						$(COREDIR)/MIPS/x86/X64IRJit.cpp \
+						$(COREDIR)/MIPS/x86/X64IRRegCache.cpp \
 						$(GPUDIR)/Common/VertexDecoderX86.cpp
    endif
 endif

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -481,7 +481,7 @@ static void check_variables(CoreParameter &coreParam)
       if (!strcmp(var.value, "JIT"))
          g_Config.iCpuCore = (int)CPUCore::JIT;
       else if (!strcmp(var.value, "IR JIT"))
-         g_Config.iCpuCore = (int)CPUCore::IR_JIT;
+         g_Config.iCpuCore = (int)CPUCore::IR_INTERPRETER;
       else if (!strcmp(var.value, "Interpreter"))
          g_Config.iCpuCore = (int)CPUCore::INTERPRETER;
    }
@@ -490,7 +490,7 @@ static void check_variables(CoreParameter &coreParam)
        // Just gonna force it to the IR interpreter on startup.
        // We don't hide the option, but we make sure it's off on bootup. In case someone wants
        // to experiment in future iOS versions or something...
-       g_Config.iCpuCore = (int)CPUCore::IR_JIT;
+       g_Config.iCpuCore = (int)CPUCore::IR_INTERPRETER;
    }
 #else
    g_Config.iCpuCore = (int)CPUCore::INTERPRETER;


### PR DESCRIPTION
This adds a new option under CPU core for "JIT Using IR" and more consistently renames the old option to IR Interpreter.

So far this is a very limited backend with only a small percentage of ops implemented (no floats or vectors yet, only some of ALU.)  Includes/based on #17942.  It is however already faster than the IR Interpreter for games/areas where float/vec ops are not being used much.

This was pretty easy to get started with the shared backend stuff, and I'm thinking arm32/arm64 will both be similarly easy.  Obviously, x86 isn't the most important target but it does make it easier to debug common issues (as evidenced by #17942.)  I'm also curious to see how it compares in speed between the two jits once it has more float ops implemented.

Part of that is: this uses some techniques more akin to the other jits, such as mapping regs as pointers.  Obviously not as necessary for x86/x64, but offers some knobs to play with.  And I want it to be more similar for debuggability anyway.

-[Unknown]