### PR TITLE
x86jit: Fix some issues in 32-bit

### DIFF
--- a/Core/MIPS/IR/IRRegCache.h
+++ b/Core/MIPS/IR/IRRegCache.h
@@ -74,6 +74,7 @@ private:
 };
 
 // Initing is the default so the flag is reversed.
+// 8 bits - upper 4 are reserved for backend purposes.
 enum class MIPSMap : uint8_t {
 	INIT = 0,
 	DIRTY = 1,
@@ -191,15 +192,15 @@ public:
 
 protected:
 	virtual void SetupInitialRegs();
-	virtual const int *GetAllocationOrder(MIPSLoc type, int &count, int &base) const = 0;
+	virtual const int *GetAllocationOrder(MIPSLoc type, MIPSMap flags, int &count, int &base) const = 0;
 	virtual const StaticAllocation *GetStaticAllocations(int &count) const {
 		count = 0;
 		return nullptr;
 	}
 
-	IRNativeReg AllocateReg(MIPSLoc type);
-	IRNativeReg FindFreeReg(MIPSLoc type) const;
-	IRNativeReg FindBestToSpill(MIPSLoc type, bool unusedOnly, bool *clobbered) const;
+	IRNativeReg AllocateReg(MIPSLoc type, MIPSMap flags);
+	IRNativeReg FindFreeReg(MIPSLoc type, MIPSMap flags) const;
+	IRNativeReg FindBestToSpill(MIPSLoc type, MIPSMap flags, bool unusedOnly, bool *clobbered) const;
 	virtual void DiscardNativeReg(IRNativeReg nreg);
 	virtual void FlushNativeReg(IRNativeReg nreg);
 	virtual void DiscardReg(IRReg mreg);

--- a/Core/MIPS/IR/IRRegCache.h
+++ b/Core/MIPS/IR/IRRegCache.h
@@ -201,6 +201,7 @@ protected:
 	IRNativeReg AllocateReg(MIPSLoc type, MIPSMap flags);
 	IRNativeReg FindFreeReg(MIPSLoc type, MIPSMap flags) const;
 	IRNativeReg FindBestToSpill(MIPSLoc type, MIPSMap flags, bool unusedOnly, bool *clobbered) const;
+	virtual bool IsNativeRegCompatible(IRNativeReg nreg, MIPSLoc type, MIPSMap flags);
 	virtual void DiscardNativeReg(IRNativeReg nreg);
 	virtual void FlushNativeReg(IRNativeReg nreg);
 	virtual void DiscardReg(IRReg mreg);

--- a/Core/MIPS/RiscV/RiscVRegCache.cpp
+++ b/Core/MIPS/RiscV/RiscVRegCache.cpp
@@ -55,7 +55,7 @@ void RiscVRegCache::SetupInitialRegs() {
 	mrInitial_[MIPS_REG_ZERO].isStatic = true;
 }
 
-const int *RiscVRegCache::GetAllocationOrder(MIPSLoc type, int &count, int &base) const {
+const int *RiscVRegCache::GetAllocationOrder(MIPSLoc type, MIPSMap flags, int &count, int &base) const {
 	base = X0;
 
 	if (type == MIPSLoc::REG) {
@@ -236,7 +236,7 @@ RiscVReg RiscVRegCache::TryMapTempImm(IRReg r) {
 }
 
 RiscVReg RiscVRegCache::GetAndLockTempR() {
-	RiscVReg reg = (RiscVReg)AllocateReg(MIPSLoc::REG);
+	RiscVReg reg = (RiscVReg)AllocateReg(MIPSLoc::REG, MIPSMap::INIT);
 	if (reg != INVALID_REG) {
 		nr[reg].tempLockIRIndex = irIndex_;
 	}

--- a/Core/MIPS/RiscV/RiscVRegCache.cpp
+++ b/Core/MIPS/RiscV/RiscVRegCache.cpp
@@ -300,6 +300,13 @@ void RiscVRegCache::AdjustNativeRegAsPtr(IRNativeReg nreg, bool state) {
 	}
 }
 
+bool RiscVRegCache::IsNativeRegCompatible(IRNativeReg nreg, MIPSLoc type, MIPSMap flags) {
+	// No special flags except VREG, skip the check for a little speed.
+	if (type != MIPSLoc::VREG)
+		return true;
+	return IRNativeRegCacheBase::IsNativeRegCompatible(nreg, type, flags);
+}
+
 void RiscVRegCache::LoadNativeReg(IRNativeReg nreg, IRReg first, int lanes) {
 	RiscVReg r = (RiscVReg)(X0 + nreg);
 	_dbg_assert_(r > X0);

--- a/Core/MIPS/RiscV/RiscVRegCache.h
+++ b/Core/MIPS/RiscV/RiscVRegCache.h
@@ -76,6 +76,7 @@ protected:
 	const int *GetAllocationOrder(MIPSLoc type, MIPSMap flags, int &count, int &base) const override;
 	void AdjustNativeRegAsPtr(IRNativeReg nreg, bool state) override;
 
+	bool IsNativeRegCompatible(IRNativeReg nreg, MIPSLoc type, MIPSMap flags) override;
 	void LoadNativeReg(IRNativeReg nreg, IRReg first, int lanes) override;
 	void StoreNativeReg(IRNativeReg nreg, IRReg first, int lanes) override;
 	void SetNativeRegValue(IRNativeReg nreg, uint32_t imm) override;

--- a/Core/MIPS/RiscV/RiscVRegCache.h
+++ b/Core/MIPS/RiscV/RiscVRegCache.h
@@ -73,7 +73,7 @@ public:
 protected:
 	void SetupInitialRegs() override;
 	const StaticAllocation *GetStaticAllocations(int &count) const override;
-	const int *GetAllocationOrder(MIPSLoc type, int &count, int &base) const override;
+	const int *GetAllocationOrder(MIPSLoc type, MIPSMap flags, int &count, int &base) const override;
 	void AdjustNativeRegAsPtr(IRNativeReg nreg, bool state) override;
 
 	void LoadNativeReg(IRNativeReg nreg, IRReg first, int lanes) override;

--- a/Core/MIPS/x86/X64IRAsm.cpp
+++ b/Core/MIPS/x86/X64IRAsm.cpp
@@ -176,7 +176,7 @@ void X64JitBackend::GenerateFixedCode(MIPSState *mipsState) {
 				else
 					ABI_CallFunctionAC(reinterpret_cast<void *>(&ShowPC), R(MEMBASEREG), (u32)jitbase);
 #else
-				ABI_CallFunctionCC(reinterpret_cast<void *>(&ShowPC), Menory::base, (u32)jitbase);
+				ABI_CallFunctionCC(reinterpret_cast<void *>(&ShowPC), (u32)Memory::base, (u32)GetBasePtr());
 #endif
 			}
 

--- a/Core/MIPS/x86/X64IRAsm.cpp
+++ b/Core/MIPS/x86/X64IRAsm.cpp
@@ -54,13 +54,13 @@ void X64JitBackend::GenerateFixedCode(MIPSState *mipsState) {
 
 	if (jo.useStaticAlloc && false) {
 		saveStaticRegisters_ = AlignCode16();
-		//MOV(32, MDisp(CTXREG, -128 + offsetof(MIPSState, downcount)), R(DOWNCOUNTREG));
+		//MOV(32, MDisp(CTXREG, downcountOffset), R(DOWNCOUNTREG));
 		//regs_.EmitSaveStaticRegisters();
 		RET();
 
 		loadStaticRegisters_ = AlignCode16();
 		//regs_.EmitLoadStaticRegisters();
-		//MOV(32, R(DOWNCOUNTREG), MDisp(CTXREG, -128 + offsetof(MIPSState, downcount)));
+		//MOV(32, R(DOWNCOUNTREG), MDisp(CTXREG, downcountOffset));
 		RET();
 
 		start = saveStaticRegisters_;
@@ -71,22 +71,22 @@ void X64JitBackend::GenerateFixedCode(MIPSState *mipsState) {
 
 	restoreRoundingMode_ = AlignCode16();
 	{
-		STMXCSR(MDisp(CTXREG, -128 + offsetof(MIPSState, temp)));
+		STMXCSR(MDisp(CTXREG, tempOffset));
 		// Clear the rounding mode and flush-to-zero bits back to 0.
-		AND(32, MDisp(CTXREG, -128 + offsetof(MIPSState, temp)), Imm32(~(7 << 13)));
-		LDMXCSR(MDisp(CTXREG, -128 + offsetof(MIPSState, temp)));
+		AND(32, MDisp(CTXREG, tempOffset), Imm32(~(7 << 13)));
+		LDMXCSR(MDisp(CTXREG, tempOffset));
 		RET();
 	}
 
 	applyRoundingMode_ = AlignCode16();
 	{
-		MOV(32, R(SCRATCH1), MDisp(CTXREG, -128 + offsetof(MIPSState, fcr31)));
+		MOV(32, R(SCRATCH1), MDisp(CTXREG, fcr31Offset));
 		AND(32, R(SCRATCH1), Imm32(0x01000003));
 
 		// If it's 0 (nearest + no flush0), we don't actually bother setting - we cleared the rounding
 		// mode out in restoreRoundingMode anyway. This is the most common.
 		FixupBranch skip = J_CC(CC_Z);
-		STMXCSR(MDisp(CTXREG, -128 + offsetof(MIPSState, temp)));
+		STMXCSR(MDisp(CTXREG, tempOffset));
 
 		// The MIPS bits don't correspond exactly, so we have to adjust.
 		// 0 -> 0 (skip2), 1 -> 3, 2 -> 2 (skip2), 3 -> 1
@@ -99,15 +99,15 @@ void X64JitBackend::GenerateFixedCode(MIPSState *mipsState) {
 		SHL(32, R(SCRATCH1), Imm8(13));
 		// Before setting new bits, we must clear the old ones.
 		// Clearing bits 13-14 (rounding mode) and 15 (flush to zero.)
-		AND(32, MDisp(CTXREG, -128 + offsetof(MIPSState, temp)), Imm32(~(7 << 13)));
-		OR(32, MDisp(CTXREG, -128 + offsetof(MIPSState, temp)), R(SCRATCH1));
+		AND(32, MDisp(CTXREG, tempOffset), Imm32(~(7 << 13)));
+		OR(32, MDisp(CTXREG, tempOffset), R(SCRATCH1));
 
-		TEST(32, MDisp(CTXREG, -128 + offsetof(MIPSState, fcr31)), Imm32(1 << 24));
+		TEST(32, MDisp(CTXREG, fcr31Offset), Imm32(1 << 24));
 		FixupBranch skip3 = J_CC(CC_Z);
-		OR(32, MDisp(CTXREG, -128 + offsetof(MIPSState, temp)), Imm32(1 << 15));
+		OR(32, MDisp(CTXREG, tempOffset), Imm32(1 << 15));
 		SetJumpTarget(skip3);
 
-		LDMXCSR(MDisp(CTXREG, -128 + offsetof(MIPSState, temp)));
+		LDMXCSR(MDisp(CTXREG, tempOffset));
 		SetJumpTarget(skip);
 		RET();
 	}
@@ -151,7 +151,7 @@ void X64JitBackend::GenerateFixedCode(MIPSState *mipsState) {
 		FixupBranch badCoreState = J_CC(CC_NZ, true);
 
 		//CMP(32, R(DOWNCOUNTREG), Imm32(0));
-		CMP(32, MDisp(CTXREG, -128 + offsetof(MIPSState, downcount)), Imm32(0));
+		CMP(32, MDisp(CTXREG, downcountOffset), Imm32(0));
 		J_CC(CC_S, outerLoop_);
 		FixupBranch skipToRealDispatch = J();
 
@@ -162,7 +162,7 @@ void X64JitBackend::GenerateFixedCode(MIPSState *mipsState) {
 
 			// TODO: See if we can get the slice decrement to line up with IR.
 			//CMP(32, R(DOWNCOUNTREG), Imm32(0));
-			CMP(32, MDisp(CTXREG, -128 + offsetof(MIPSState, downcount)), Imm32(0));
+			CMP(32, MDisp(CTXREG, downcountOffset), Imm32(0));
 			FixupBranch bail = J_CC(CC_S, true);
 			SetJumpTarget(skipToRealDispatch);
 

--- a/Core/MIPS/x86/X64IRCompALU.cpp
+++ b/Core/MIPS/x86/X64IRCompALU.cpp
@@ -64,6 +64,7 @@ void X64JitBackend::CompIR_Arith(IRInst inst) {
 		if (regs_.IsGPRImm(inst.src1) && regs_.GetGPRImm(inst.src1) == 0) {
 			// TODO: Might be nice to have a pass to turn this into Neg.
 			// Special cased to avoid wasting a reg on zero.
+			regs_.SpillLockGPR(inst.dest, inst.src2);
 			regs_.MapGPR(inst.src2);
 			regs_.MapGPR(inst.dest, MIPSMap::NOINIT);
 			if (inst.dest != inst.src2)

--- a/Core/MIPS/x86/X64IRCompALU.cpp
+++ b/Core/MIPS/x86/X64IRCompALU.cpp
@@ -285,11 +285,75 @@ void X64JitBackend::CompIR_Shift(IRInst inst) {
 	case IROp::Shr:
 	case IROp::Sar:
 	case IROp::Ror:
-	case IROp::ShlImm:
-	case IROp::ShrImm:
-	case IROp::SarImm:
-	case IROp::RorImm:
 		CompIR_Generic(inst);
+		break;
+
+	case IROp::ShlImm:
+		// Shouldn't happen, but let's be safe of any passes that modify the ops.
+		if (inst.src2 >= 32) {
+			regs_.SetGPRImm(inst.dest, 0);
+		} else if (inst.src2 == 0) {
+			if (inst.dest != inst.src1) {
+				regs_.Map(inst);
+				MOV(32, regs_.R(inst.dest), regs_.R(inst.src1));
+			}
+		} else {
+			regs_.Map(inst);
+			if (inst.dest != inst.src1)
+				MOV(32, regs_.R(inst.dest), regs_.R(inst.src1));
+			SHL(32, regs_.R(inst.dest), Imm8(inst.src2));
+		}
+		break;
+
+	case IROp::ShrImm:
+		// Shouldn't happen, but let's be safe of any passes that modify the ops.
+		if (inst.src2 >= 32) {
+			regs_.SetGPRImm(inst.dest, 0);
+		} else if (inst.src2 == 0) {
+			if (inst.dest != inst.src1) {
+				regs_.Map(inst);
+				MOV(32, regs_.R(inst.dest), regs_.R(inst.src1));
+			}
+		} else {
+			regs_.Map(inst);
+			if (inst.dest != inst.src1)
+				MOV(32, regs_.R(inst.dest), regs_.R(inst.src1));
+			SHR(32, regs_.R(inst.dest), Imm8(inst.src2));
+		}
+		break;
+
+	case IROp::SarImm:
+		// Shouldn't happen, but let's be safe of any passes that modify the ops.
+		if (inst.src2 >= 32) {
+			regs_.Map(inst);
+			if (inst.dest != inst.src1)
+				MOV(32, regs_.R(inst.dest), regs_.R(inst.src1));
+			SAR(32, regs_.R(inst.dest), Imm8(31));
+		} else if (inst.src2 == 0) {
+			if (inst.dest != inst.src1) {
+				regs_.Map(inst);
+				MOV(32, regs_.R(inst.dest), regs_.R(inst.src1));
+			}
+		} else {
+			regs_.Map(inst);
+			if (inst.dest != inst.src1)
+				MOV(32, regs_.R(inst.dest), regs_.R(inst.src1));
+			SAR(32, regs_.R(inst.dest), Imm8(inst.src2));
+		}
+		break;
+
+	case IROp::RorImm:
+		if (inst.src2 == 0) {
+			if (inst.dest != inst.src1) {
+				regs_.Map(inst);
+				MOV(32, regs_.R(inst.dest), regs_.R(inst.src1));
+			}
+		} else {
+			regs_.Map(inst);
+			if (inst.dest != inst.src1)
+				MOV(32, regs_.R(inst.dest), regs_.R(inst.src1));
+			ROR(32, regs_.R(inst.dest), Imm8(inst.src2 & 31));
+		}
 		break;
 
 	default:

--- a/Core/MIPS/x86/X64IRCompLoadStore.cpp
+++ b/Core/MIPS/x86/X64IRCompLoadStore.cpp
@@ -180,8 +180,11 @@ void X64JitBackend::CompIR_Store(IRInst inst) {
 	regs_.SpillLockGPR(inst.src3, inst.src1);
 	OpArg addrArg = PrepareSrc1Address(inst);
 
+	// i386 can only use certain regs for 8-bit operations.
+	X64Map valueFlags = inst.op == IROp::Store8 ? X64Map::LOW_SUBREG : X64Map::NONE;
+
 	OpArg valueArg;
-	X64Reg valueReg = regs_.TryMapTempImm(inst.src3);
+	X64Reg valueReg = regs_.TryMapTempImm(inst.src3, valueFlags);
 	if (valueReg != INVALID_REG) {
 		valueArg = R(valueReg);
 	} else if (regs_.IsGPRImm(inst.src3)) {
@@ -195,7 +198,7 @@ void X64JitBackend::CompIR_Store(IRInst inst) {
 			break;
 		}
 	} else {
-		valueArg = R(regs_.MapGPR(inst.src3));
+		valueArg = R(regs_.MapGPR(inst.src3, MIPSMap::INIT | valueFlags));
 	}
 
 	// TODO: Safe memory?  Or enough to have crash handler + validate?

--- a/Core/MIPS/x86/X64IRCompLoadStore.cpp
+++ b/Core/MIPS/x86/X64IRCompLoadStore.cpp
@@ -37,6 +37,42 @@ namespace MIPSComp {
 using namespace Gen;
 using namespace X64IRJitConstants;
 
+Gen::OpArg X64JitBackend::PrepareSrc1Address(IRInst inst) {
+	const IRMeta *m = GetIRMeta(inst.op);
+	bool readsFromSrc1 = inst.src1 == inst.src3 && (m->flags & (IRFLAG_SRC3 | IRFLAG_SRC3DST)) != 0;
+
+	OpArg addrArg;
+	if (inst.src1 == MIPS_REG_ZERO) {
+#ifdef MASKED_PSP_MEMORY
+		inst.constant &= Memory::MEMVIEW32_MASK;
+#endif
+#if PPSSPP_ARCH(AMD64)
+		addrArg = MDisp(MEMBASEREG, inst.constant & 0x7FFFFFFF);
+#else
+		addrArg = M(Memory::base + inst.constant);
+#endif
+	} else if ((jo.cachePointers || regs_.IsGPRMappedAsPointer(inst.src1)) && !readsFromSrc1) {
+		X64Reg src1 = regs_.MapGPRAsPointer(inst.src1);
+		addrArg = MDisp(src1, (int)inst.constant);
+	} else {
+		regs_.MapGPR(inst.src1);
+#ifdef MASKED_PSP_MEMORY
+		LEA(PTRBITS, SCRATCH1, MDisp(regs_.RX(inst.src1), (int)inst.constant));
+		AND(PTRBITS, R(SCRATCH1), Imm32(Memory::MEMVIEW32_MASK));
+		ADD(PTRBITS, R(SCRATCH1), ImmPtr(Memory::base));
+		addrArg = MatR(SCRATCH1);
+#else
+#if PPSSPP_ARCH(AMD64)
+		addrArg = MComplex(MEMBASEREG, regs_.RX(inst.src1), SCALE_1, (int)inst.constant);
+#else
+		addrArg = MDisp(regs_.RX(inst.src1), Memory::base + inst.constant);
+#endif
+#endif
+	}
+
+	return addrArg;
+}
+
 void X64JitBackend::CompIR_CondStore(IRInst inst) {
 	CONDITIONAL_DISABLE;
 
@@ -83,23 +119,7 @@ void X64JitBackend::CompIR_Load(IRInst inst) {
 	CONDITIONAL_DISABLE;
 
 	regs_.SpillLockGPR(inst.dest, inst.src1);
-	OpArg addrArg;
-	if (inst.src1 == MIPS_REG_ZERO) {
-#ifdef MASKED_PSP_MEMORY
-		inst.constant &= Memory::MEMVIEW32_MASK;
-#endif
-#if PPSSPP_ARCH(AMD64)
-		addrArg = MDisp(MEMBASEREG, inst.constant & 0x7FFFFFFF);
-#else
-		addrArg = M(Memory::base + inst.constant);
-#endif
-	} else if (jo.cachePointers || regs_.IsGPRMappedAsPointer(inst.src1)) {
-		X64Reg src1 = regs_.MapGPRAsPointer(inst.src1);
-		addrArg = MDisp(src1, inst.constant & 0x7FFFFFFF);
-	} else {
-		regs_.MapGPR(inst.src1);
-		addrArg = MComplex(MEMBASEREG, regs_.RX(inst.src1), SCALE_1, inst.constant & 0x7FFFFFFF);
-	}
+	OpArg addrArg = PrepareSrc1Address(inst);
 	// With NOINIT, MapReg won't subtract MEMBASEREG even if dest == src1.
 	regs_.MapGPR(inst.dest, MIPSMap::NOINIT);
 
@@ -158,23 +178,7 @@ void X64JitBackend::CompIR_Store(IRInst inst) {
 	CONDITIONAL_DISABLE;
 
 	regs_.SpillLockGPR(inst.src3, inst.src1);
-	OpArg addrArg;
-	if (inst.src1 == MIPS_REG_ZERO) {
-#ifdef MASKED_PSP_MEMORY
-		inst.constant &= Memory::MEMVIEW32_MASK;
-#endif
-#if PPSSPP_ARCH(AMD64)
-		addrArg = MDisp(MEMBASEREG, inst.constant & 0x7FFFFFFF);
-#else
-		addrArg = M(Memory::base + inst.constant);
-#endif
-	} else if ((jo.cachePointers || regs_.IsGPRMappedAsPointer(inst.src1)) && inst.src3 != inst.src1) {
-		X64Reg src1 = regs_.MapGPRAsPointer(inst.src1);
-		addrArg = MDisp(src1, inst.constant & 0x7FFFFFFF);
-	} else {
-		regs_.MapGPR(inst.src1);
-		addrArg = MComplex(MEMBASEREG, regs_.RX(inst.src1), SCALE_1, inst.constant & 0x7FFFFFFF);
-	}
+	OpArg addrArg = PrepareSrc1Address(inst);
 
 	OpArg valueArg;
 	X64Reg valueReg = regs_.TryMapTempImm(inst.src3);

--- a/Core/MIPS/x86/X64IRCompSystem.cpp
+++ b/Core/MIPS/x86/X64IRCompSystem.cpp
@@ -47,7 +47,7 @@ void X64JitBackend::CompIR_Basic(IRInst inst) {
 	switch (inst.op) {
 	case IROp::Downcount:
 		//ADD(32, R(DOWNCOUNTREG), R(DOWNCOUNTREG), Imm32(-(s32)inst.constant));
-		SUB(32, MDisp(CTXREG, -128 + offsetof(MIPSState, downcount)), Imm32((s32)inst.constant));
+		SUB(32, MDisp(CTXREG, downcountOffset), Imm32((s32)inst.constant));
 		break;
 
 	case IROp::SetConst:

--- a/Core/MIPS/x86/X64IRJit.cpp
+++ b/Core/MIPS/x86/X64IRJit.cpp
@@ -64,7 +64,7 @@ bool X64JitBackend::CompileBlock(IRBlock *block, int block_num, bool preload) {
 
 		// TODO: See if we can get flags to always have the downcount compare.
 		//CMP(32, R(DOWNCOUNTREG), Imm32(0));
-		CMP(32, MDisp(CTXREG, -128 + offsetof(MIPSState, downcount)), Imm32(0));
+		CMP(32, MDisp(CTXREG, downcountOffset), Imm32(0));
 		FixupBranch normalEntry = J_CC(CC_NS);
 		MOV(32, R(SCRATCH1), Imm32(startPC));
 		JMP(outerLoopPCInSCRATCH1_, true);
@@ -117,7 +117,7 @@ bool X64JitBackend::CompileBlock(IRBlock *block, int block_num, bool preload) {
 
 	if (jo.enableBlocklink && jo.useBackJump) {
 		//CMP(32, R(DOWNCOUNTREG), Imm32(0));
-		CMP(32, MDisp(CTXREG, -128 + offsetof(MIPSState, downcount)), Imm32(0));
+		CMP(32, MDisp(CTXREG, downcountOffset), Imm32(0));
 		J_CC(CC_NS, blockStart, true);
 
 		MOV(32, R(SCRATCH1), Imm32(startPC));
@@ -302,11 +302,11 @@ void X64JitBackend::ApplyRoundingMode(bool force) {
 }
 
 void X64JitBackend::MovFromPC(X64Reg r) {
-	MOV(32, R(r), MDisp(CTXREG, -128 + offsetof(MIPSState, pc)));
+	MOV(32, R(r), MDisp(CTXREG, pcOffset));
 }
 
 void X64JitBackend::MovToPC(X64Reg r) {
-	MOV(32, MDisp(CTXREG, -128 + offsetof(MIPSState, pc)), R(r));
+	MOV(32, MDisp(CTXREG, pcOffset), R(r));
 }
 
 void X64JitBackend::SaveStaticRegisters() {
@@ -314,7 +314,7 @@ void X64JitBackend::SaveStaticRegisters() {
 		//CALL(saveStaticRegisters_);
 	} else {
 		// Inline the single operation
-		//MOV(32, MDisp(CTXREG, -128 + offsetof(MIPSState, downcount)), R(DOWNCOUNTREG));
+		//MOV(32, MDisp(CTXREG, downcountOffset), R(DOWNCOUNTREG));
 	}
 }
 
@@ -322,7 +322,7 @@ void X64JitBackend::LoadStaticRegisters() {
 	if (jo.useStaticAlloc) {
 		//CALL(loadStaticRegisters_);
 	} else {
-		//MOV(32, R(DOWNCOUNTREG), MDisp(CTXREG, -128 + offsetof(MIPSState, downcount)));
+		//MOV(32, R(DOWNCOUNTREG), MDisp(CTXREG, downcountOffset));
 	}
 }
 

--- a/Core/MIPS/x86/X64IRJit.h
+++ b/Core/MIPS/x86/X64IRJit.h
@@ -106,6 +106,8 @@ private:
 	void CompIR_VecStore(IRInst inst) override;
 	void CompIR_ValidateAddress(IRInst inst) override;
 
+	Gen::OpArg PrepareSrc1Address(IRInst inst);
+
 	JitOptions &jo;
 	X64IRRegCache regs_;
 

--- a/Core/MIPS/x86/X64IRRegCache.cpp
+++ b/Core/MIPS/x86/X64IRRegCache.cpp
@@ -172,11 +172,6 @@ X64Reg X64IRRegCache::MapWithFPRTemp(IRInst &inst) {
 X64Reg X64IRRegCache::MapGPR(IRReg mipsReg, MIPSMap mapFlags) {
 	_dbg_assert_(IsValidGPR(mipsReg));
 
-	if ((mapFlags & X64Map::LOW_SUBREG) == X64Map::LOW_SUBREG && IsGPRMapped(mipsReg) && !HasLowSubregister(RX(mipsReg))) {
-		// Unfortunate.  For now, let's flush it.  We'll realloc a better one.
-		FlushNativeReg(mr[mipsReg].nReg);
-	}
-
 	// Okay, not mapped, so we need to allocate an RV register.
 	IRNativeReg nreg = MapNativeReg(MIPSLoc::REG, mipsReg, 1, mapFlags);
 	return FromNativeReg(nreg);

--- a/Core/MIPS/x86/X64IRRegCache.cpp
+++ b/Core/MIPS/x86/X64IRRegCache.cpp
@@ -46,7 +46,7 @@ void X64IRRegCache::Init(XEmitter *emitter) {
 	emit_ = emitter;
 }
 
-const int *X64IRRegCache::GetAllocationOrder(MIPSLoc type, int &count, int &base) const {
+const int *X64IRRegCache::GetAllocationOrder(MIPSLoc type, MIPSMap flags, int &count, int &base) const {
 	if (type == MIPSLoc::REG) {
 		base = RAX;
 
@@ -143,7 +143,7 @@ X64Reg X64IRRegCache::TryMapTempImm(IRReg r) {
 }
 
 X64Reg X64IRRegCache::GetAndLockTempR() {
-	X64Reg reg = FromNativeReg(AllocateReg(MIPSLoc::REG));
+	X64Reg reg = FromNativeReg(AllocateReg(MIPSLoc::REG, MIPSMap::INIT));
 	if (reg != INVALID_REG) {
 		nr[reg].tempLockIRIndex = irIndex_;
 	}

--- a/Core/MIPS/x86/X64IRRegCache.cpp
+++ b/Core/MIPS/x86/X64IRRegCache.cpp
@@ -61,7 +61,7 @@ const int *X64IRRegCache::GetAllocationOrder(MIPSLoc type, int &count, int &base
 			// Intentionally last.
 			R15,
 #elif PPSSPP_ARCH(X86)
-			ESI, EDI, EDX, ECX, EBX,
+			ESI, EDI, EDX, EBX, ECX,
 #endif
 		};
 
@@ -79,9 +79,9 @@ const int *X64IRRegCache::GetAllocationOrder(MIPSLoc type, int &count, int &base
 		// TODO: Might have to change this if we can't live without dedicated temps.
 		static const int allocationOrder[] = {
 #if PPSSPP_ARCH(AMD64)
-		XMM6, XMM7, XMM8, XMM9, XMM10, XMM11, XMM12, XMM13, XMM14, XMM15, XMM0, XMM1, XMM2, XMM3, XMM4, XMM5
+		XMM6, XMM7, XMM8, XMM9, XMM10, XMM11, XMM12, XMM13, XMM14, XMM15, XMM1, XMM2, XMM3, XMM4, XMM5, XMM0,
 #elif PPSSPP_ARCH(X86)
-		XMM0, XMM1, XMM2, XMM3, XMM4, XMM5, XMM6, XMM7,
+		XMM1, XMM2, XMM3, XMM4, XMM5, XMM6, XMM7, XMM0,
 #endif
 		};
 

--- a/Core/MIPS/x86/X64IRRegCache.h
+++ b/Core/MIPS/x86/X64IRRegCache.h
@@ -41,6 +41,23 @@ static constexpr auto tempOffset = offsetof(MIPSState, temp) - 128;
 static constexpr auto fcr31Offset = offsetof(MIPSState, fcr31) - 128;
 static constexpr auto pcOffset = offsetof(MIPSState, pc) - 128;
 
+enum class X64Map : uint8_t {
+	NONE = 0,
+	LOW_SUBREG = 0x10,
+};
+static inline MIPSMap operator |(const MIPSMap &lhs, const X64Map &rhs) {
+	return MIPSMap((uint8_t)lhs | (uint8_t)rhs);
+}
+static inline X64Map operator |(const X64Map &lhs, const X64Map &rhs) {
+	return X64Map((uint8_t)lhs | (uint8_t)rhs);
+}
+static inline X64Map operator &(const MIPSMap &lhs, const X64Map &rhs) {
+	return X64Map((uint8_t)lhs & (uint8_t)rhs);
+}
+static inline X64Map operator &(const X64Map &lhs, const X64Map &rhs) {
+	return X64Map((uint8_t)lhs & (uint8_t)rhs);
+}
+
 } // namespace X64IRJitConstants
 
 class X64IRRegCache : public IRNativeRegCacheBase {
@@ -50,7 +67,7 @@ public:
 	void Init(Gen::XEmitter *emitter);
 
 	// May fail and return INVALID_REG if it needs flushing.
-	Gen::X64Reg TryMapTempImm(IRReg);
+	Gen::X64Reg TryMapTempImm(IRReg, X64IRJitConstants::X64Map flags = X64IRJitConstants::X64Map::NONE);
 
 	// Returns an RV register containing the requested MIPS register.
 	Gen::X64Reg MapGPR(IRReg reg, MIPSMap mapFlags = MIPSMap::INIT);
@@ -69,6 +86,8 @@ public:
 	Gen::X64Reg RX(IRReg preg); // Returns a cached register, while checking that it's NOT mapped as a pointer
 	Gen::X64Reg RXPtr(IRReg preg); // Returns a cached register, if it has been mapped as a pointer
 	Gen::X64Reg FX(IRReg preg);
+
+	static bool HasLowSubregister(Gen::X64Reg reg);
 
 protected:
 	const int *GetAllocationOrder(MIPSLoc type, MIPSMap flags, int &count, int &base) const override;

--- a/Core/MIPS/x86/X64IRRegCache.h
+++ b/Core/MIPS/x86/X64IRRegCache.h
@@ -71,7 +71,7 @@ public:
 	Gen::X64Reg FX(IRReg preg);
 
 protected:
-	const int *GetAllocationOrder(MIPSLoc type, int &count, int &base) const override;
+	const int *GetAllocationOrder(MIPSLoc type, MIPSMap flags, int &count, int &base) const override;
 	void AdjustNativeRegAsPtr(IRNativeReg nreg, bool state) override;
 
 	void LoadNativeReg(IRNativeReg nreg, IRReg first, int lanes) override;

--- a/Core/MIPS/x86/X64IRRegCache.h
+++ b/Core/MIPS/x86/X64IRRegCache.h
@@ -36,6 +36,11 @@ const Gen::X64Reg CTXREG = Gen::EBP;
 #endif
 const Gen::X64Reg SCRATCH1 = Gen::EAX;
 
+static constexpr auto downcountOffset = offsetof(MIPSState, downcount) - 128;
+static constexpr auto tempOffset = offsetof(MIPSState, temp) - 128;
+static constexpr auto fcr31Offset = offsetof(MIPSState, fcr31) - 128;
+static constexpr auto pcOffset = offsetof(MIPSState, pc) - 128;
+
 } // namespace X64IRJitConstants
 
 class X64IRRegCache : public IRNativeRegCacheBase {


### PR DESCRIPTION
There were several mistakes making 32-bit not work correctly.

This also adds a mechanism for backend specific flags to make it to register allocation.  This could be optimized to transfer directly to an allocated register that matches the constraint (I'm thinking of a function to handle that and lane-size transfers, currently mapping 4-lane to 1-lane flushes and reloads similarly.)

Also adds some shifts while I was there.

-[Unknown]