### PR TITLE
x86jit: Fix Ext8to32/Ext16to32, some reg issues

### DIFF
--- a/Core/MIPS/IR/IRRegCache.cpp
+++ b/Core/MIPS/IR/IRRegCache.cpp
@@ -427,6 +427,7 @@ IRNativeReg IRNativeRegCacheBase::FindBestToSpill(MIPSLoc type, MIPSMap flags, b
 		if (!unusedOnly || usage == IRUsage::UNUSED) {
 			// TODO: Use age or something to choose which register to spill?
 			// TODO: Spill dirty regs first? or opposite?
+			*clobbered = mipsReg == MIPS_REG_ZERO;
 			return nreg;
 		}
 	}

--- a/Core/MIPS/x86/X64IRCompALU.cpp
+++ b/Core/MIPS/x86/X64IRCompALU.cpp
@@ -139,7 +139,7 @@ void X64JitBackend::CompIR_Assign(IRInst inst) {
 		DISABLE;  // 8-bit registers need special handling
 #endif
 		regs_.Map(inst);
-		MOVZX(32, 8, regs_.RX(inst.dest), regs_.R(inst.src1));
+		MOVSX(32, 8, regs_.RX(inst.dest), regs_.R(inst.src1));
 		break;
 
 	case IROp::Ext16to32:
@@ -147,7 +147,7 @@ void X64JitBackend::CompIR_Assign(IRInst inst) {
 		DISABLE;  // 8-bit registers need special handling
 #endif
 		regs_.Map(inst);
-		MOVZX(32, 16, regs_.RX(inst.dest), regs_.R(inst.src1));
+		MOVSX(32, 16, regs_.RX(inst.dest), regs_.R(inst.src1));
 		break;
 
 	default:


### PR DESCRIPTION
These register issues would be relevant to armv7 as well.  Easier to find on i386 with so few regs.

-[Unknown]