### PR TITLE
SDL: let's not remove the candidate fallback fonts

### DIFF
--- a/Common/Render/Text/draw_text_sdl.cpp
+++ b/Common/Render/Text/draw_text_sdl.cpp
@@ -173,7 +173,6 @@ bool TextDrawerSDL::FindFallbackFonts(uint32_t missingGlyph, int ptSize) {
 
 		if (TTF_GlyphIsProvided32(font, missingGlyph)) {
 			fallbackFonts_.insert(fallbackFonts_.begin(), font);
-			fallbackFontPaths_.erase(fallbackFontPaths_.begin() + i);
 			return true;
 		} else {
 			TTF_CloseFont(font);


### PR DESCRIPTION
Something I found while investigating #17910, but I doubt this fixes it.

It's possible that we need to reload the fonts again when there's a display change (physical unplugging or DPI change)