### PR TITLE
Controls: Make the analog/digital mapping clash resolution more gentle.

### DIFF
--- a/Common/Input/InputState.h
+++ b/Common/Input/InputState.h
@@ -36,6 +36,7 @@ enum InputDeviceID {
 	DEVICE_ID_XR_CONTROLLER_LEFT = 40,
 	DEVICE_ID_XR_CONTROLLER_RIGHT = 41,
 	DEVICE_ID_TOUCH = 42,
+	DEVICE_ID_COUNT,
 };
 
 inline InputDeviceID operator +(InputDeviceID deviceID, int addend) {
@@ -120,6 +121,9 @@ public:
 		if (deviceId != other.deviceId && deviceId != DEVICE_ID_ANY && other.deviceId != DEVICE_ID_ANY) return false;
 		if (keyCode != other.keyCode) return false;
 		return true;
+	}
+	bool operator != (const InputMapping &other) const {
+		return !(*this == other);
 	}
 
 	void FormatDebug(char *buffer, size_t bufSize) const;

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -11,7 +11,7 @@
 // Main use is of course from EmuScreen.cpp, but also useful from control settings etc.
 class ControlMapper {
 public:
-	void Update();
+	void Update(double now);
 
 	// Inputs to the table-based mapping
 	// These functions are free-threaded.
@@ -48,7 +48,7 @@ public:
 	};
 
 private:
-	bool UpdatePSPState(const InputMapping &changedMapping);
+	bool UpdatePSPState(const InputMapping &changedMapping, double now);
 	float MapAxisValue(float value, int vkId, const InputMapping &mapping, const InputMapping &changedMapping, bool *oppositeTouched);
 	void SwapMappingIfEnabled(uint32_t *vkey);
 
@@ -61,6 +61,8 @@ private:
 	// To track mappable virtual keys. We can have as many as we want.
 	float virtKeys_[VIRTKEY_COUNT]{};
 	bool virtKeyOn_[VIRTKEY_COUNT]{};  // Track boolean output separaately since thresholds may differ.
+
+	double deviceTimestamps_[42]{};
 
 	int lastNonDeadzoneDeviceID_[2]{};
 

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -42,6 +42,11 @@ public:
 
 	void GetDebugString(char *buffer, size_t bufSize) const;
 
+	struct InputSample {
+		float value;
+		double timestamp;
+	};
+
 private:
 	bool UpdatePSPState(const InputMapping &changedMapping);
 	float MapAxisValue(float value, int vkId, const InputMapping &mapping, const InputMapping &changedMapping, bool *oppositeTouched);
@@ -71,7 +76,7 @@ private:
 	// Protects basically all the state.
 	std::mutex mutex_;
 
-	std::map<InputMapping, float> curInput_;
+	std::map<InputMapping, InputSample> curInput_;
 
 	// Callbacks
 	std::function<void(int, bool)> onVKey_;

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -512,7 +512,7 @@ AnalogSetupScreen::AnalogSetupScreen(const Path &gamePath) : UIDialogScreenWithG
 }
 
 void AnalogSetupScreen::update() {
-	mapper_.Update();
+	mapper_.Update(time_now_d());
 	// We ignore the secondary stick for now and just use the two views
 	// for raw and psp input.
 	if (stickView_[0]) {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1117,7 +1117,9 @@ void EmuScreen::update() {
 	if (invalid_)
 		return;
 
-	controlMapper_.Update();
+	double now = time_now_d();
+
+	controlMapper_.Update(now);
 
 	if (pauseTrigger_) {
 		pauseTrigger_ = false;
@@ -1137,7 +1139,7 @@ void EmuScreen::update() {
 			saveStatePreview_->SetFilename(fn);
 			if (!fn.empty()) {
 				saveStatePreview_->SetVisibility(UI::V_VISIBLE);
-				saveStatePreviewShownTime_ = time_now_d();
+				saveStatePreviewShownTime_ = now;
 			} else {
 				saveStatePreview_->SetVisibility(UI::V_GONE);
 			}
@@ -1145,10 +1147,10 @@ void EmuScreen::update() {
 
 		if (saveStatePreview_->GetVisibility() == UI::V_VISIBLE) {
 			double endTime = saveStatePreviewShownTime_ + 2.0;
-			float alpha = clamp_value((endTime - time_now_d()) * 4.0, 0.0, 1.0);
+			float alpha = clamp_value((endTime - now) * 4.0, 0.0, 1.0);
 			saveStatePreview_->SetColor(colorAlpha(0x00FFFFFF, alpha));
 
-			if (time_now_d() - saveStatePreviewShownTime_ > 2) {
+			if (now - saveStatePreviewShownTime_ > 2) {
 				saveStatePreview_->SetVisibility(UI::V_GONE);
 			}
 		}


### PR DESCRIPTION
Now takes the time into account, so clashing digital input will only shrink analog inputs once it's a few seconds old.

Also fixes a bug where if there are both inputs, it was hard to reach the limits because the digital input itself ended up getting shrunk.

This might help #17860
