### PR TITLE
Implement more x86 vec4 ops, float compares, etc.

### DIFF
--- a/Core/MIPS/x86/X64IRCompALU.cpp
+++ b/Core/MIPS/x86/X64IRCompALU.cpp
@@ -135,17 +135,11 @@ void X64JitBackend::CompIR_Assign(IRInst inst) {
 		break;
 
 	case IROp::Ext8to32:
-#if PPSSPP_ARCH(X86)
-		DISABLE;  // 8-bit registers need special handling
-#endif
-		regs_.Map(inst);
+		regs_.MapWithFlags(inst, X64Map::NONE, X64Map::LOW_SUBREG);
 		MOVSX(32, 8, regs_.RX(inst.dest), regs_.R(inst.src1));
 		break;
 
 	case IROp::Ext16to32:
-#if PPSSPP_ARCH(X86)
-		DISABLE;  // 8-bit registers need special handling
-#endif
 		regs_.Map(inst);
 		MOVSX(32, 16, regs_.RX(inst.dest), regs_.R(inst.src1));
 		break;

--- a/Core/MIPS/x86/X64IRCompALU.cpp
+++ b/Core/MIPS/x86/X64IRCompALU.cpp
@@ -179,10 +179,43 @@ void X64JitBackend::CompIR_Compare(IRInst inst) {
 
 	switch (inst.op) {
 	case IROp::Slt:
+		regs_.Map(inst);
+		CMP(32, regs_.R(inst.src1), regs_.R(inst.src2));
+		SETcc(CC_L, R(SCRATCH1));
+		MOVZX(32, 8, regs_.RX(inst.dest), R(SCRATCH1));
+		break;
+
 	case IROp::SltConst:
+		if (inst.constant == 0) {
+			// Basically, getting the sign bit.  Let's shift instead.
+			regs_.Map(inst);
+			if (inst.dest != inst.src1)
+				MOV(32, regs_.R(inst.dest), regs_.R(inst.src1));
+			SHR(32, regs_.R(inst.dest), Imm8(31));
+		} else {
+			regs_.Map(inst);
+			CMP(32, regs_.R(inst.src1), Imm32(inst.constant));
+			SETcc(CC_L, R(SCRATCH1));
+			MOVZX(32, 8, regs_.RX(inst.dest), R(SCRATCH1));
+		}
+		break;
+
 	case IROp::SltU:
+		regs_.Map(inst);
+		CMP(32, regs_.R(inst.src1), regs_.R(inst.src2));
+		SETcc(CC_B, R(SCRATCH1));
+		MOVZX(32, 8, regs_.RX(inst.dest), R(SCRATCH1));
+		break;
+
 	case IROp::SltUConst:
-		CompIR_Generic(inst);
+		if (inst.constant == 0) {
+			regs_.SetGPRImm(inst.dest, 0);
+		} else {
+			regs_.Map(inst);
+			CMP(32, regs_.R(inst.src1), Imm32(inst.constant));
+			SETcc(CC_B, R(SCRATCH1));
+			MOVZX(32, 8, regs_.RX(inst.dest), R(SCRATCH1));
+		}
 		break;
 
 	default:

--- a/Core/MIPS/x86/X64IRCompFPU.cpp
+++ b/Core/MIPS/x86/X64IRCompFPU.cpp
@@ -18,6 +18,10 @@
 #include "ppsspp_config.h"
 #if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 
+#ifndef offsetof
+#include <cstddef>
+#endif
+
 #include "Core/MIPS/x86/X64IRJit.h"
 #include "Core/MIPS/x86/X64IRRegCache.h"
 
@@ -36,7 +40,11 @@ namespace MIPSComp {
 using namespace Gen;
 using namespace X64IRJitConstants;
 
+struct SimdConstants {
 alignas(16) const u32 reverseQNAN[4] = { 0x803FFFFF, 0x803FFFFF, 0x803FFFFF, 0x803FFFFF };
+alignas(16) const u32 noSignMask[4] = { 0x7FFFFFFF, 0x7FFFFFFF, 0x7FFFFFFF, 0x7FFFFFFF };
+alignas(16) const u32 positiveInfinity[4] = { 0x7F800000, 0x7F800000, 0x7F800000, 0x7F800000 };
+} simdConstants;
 
 void X64JitBackend::CompIR_FArith(IRInst inst) {
 	CONDITIONAL_DISABLE;
@@ -100,10 +108,10 @@ void X64JitBackend::CompIR_FArith(IRInst inst) {
 		ANDPS(regs_.FX(inst.dest), R(tempReg));
 		// At this point fd = FFFFFFFF if non-NAN inputs produced a NAN output.
 		// We'll AND it with the inverse QNAN bits to clear (00000000 means no change.)
-		if (RipAccessible(&reverseQNAN)) {
-			ANDPS(regs_.FX(inst.dest), M(&reverseQNAN));  // rip accessible
+		if (RipAccessible(&simdConstants.reverseQNAN)) {
+			ANDPS(regs_.FX(inst.dest), M(&simdConstants.reverseQNAN));  // rip accessible
 		} else {
-			MOV(PTRBITS, R(SCRATCH1), ImmPtr(&reverseQNAN));
+			MOV(PTRBITS, R(SCRATCH1), ImmPtr(&simdConstants.reverseQNAN));
 			ANDPS(regs_.FX(inst.dest), MatR(SCRATCH1));
 		}
 		// ANDN is backwards, which is why we saved XMM0 to start.  Now put it back.
@@ -229,9 +237,152 @@ void X64JitBackend::CompIR_FCompare(IRInst inst) {
 		break;
 
 	case IROp::FCmovVfpuCC:
-	case IROp::FCmpVfpuBit:
-	case IROp::FCmpVfpuAggregate:
 		CompIR_Generic(inst);
+		break;
+
+	case IROp::FCmpVfpuBit:
+	{
+		regs_.MapGPR(IRREG_VFPU_CC, MIPSMap::DIRTY);
+		X64Reg tempReg = regs_.MapWithFPRTemp(inst);
+		uint8_t affectedBit = 1 << (inst.dest >> 4);
+		bool condNegated = (inst.dest & 4) != 0;
+
+		bool takeBitFromTempReg = true;
+		switch (VCondition(inst.dest & 0xF)) {
+		case VC_EQ:
+			if (cpu_info.bAVX) {
+				VCMPSS(tempReg, regs_.FX(inst.src1), regs_.F(inst.src2), CMP_EQ);
+			} else {
+				MOVAPS(tempReg, regs_.F(inst.src1));
+				CMPSS(tempReg, regs_.F(inst.src2), CMP_EQ);
+			}
+			break;
+		case VC_NE:
+			if (cpu_info.bAVX) {
+				VCMPSS(tempReg, regs_.FX(inst.src1), regs_.F(inst.src2), CMP_NEQ);
+			} else {
+				MOVAPS(tempReg, regs_.F(inst.src1));
+				CMPSS(tempReg, regs_.F(inst.src2), CMP_NEQ);
+			}
+			break;
+		case VC_LT:
+			if (cpu_info.bAVX) {
+				VCMPSS(tempReg, regs_.FX(inst.src1), regs_.F(inst.src2), CMP_LT);
+			} else {
+				MOVAPS(tempReg, regs_.F(inst.src1));
+				CMPSS(tempReg, regs_.F(inst.src2), CMP_LT);
+			}
+			break;
+		case VC_LE:
+			if (cpu_info.bAVX) {
+				VCMPSS(tempReg, regs_.FX(inst.src1), regs_.F(inst.src2), CMP_LE);
+			} else {
+				MOVAPS(tempReg, regs_.F(inst.src1));
+				CMPSS(tempReg, regs_.F(inst.src2), CMP_LE);
+			}
+			break;
+		case VC_GT:
+			// This is just LT with src1/src2 swapped.
+			if (cpu_info.bAVX) {
+				VCMPSS(tempReg, regs_.FX(inst.src2), regs_.F(inst.src1), CMP_LT);
+			} else {
+				MOVAPS(tempReg, regs_.F(inst.src2));
+				CMPSS(tempReg, regs_.F(inst.src1), CMP_LT);
+			}
+			break;
+		case VC_GE:
+			// This is just LE with src1/src2 swapped.
+			if (cpu_info.bAVX) {
+				VCMPSS(tempReg, regs_.FX(inst.src2), regs_.F(inst.src1), CMP_LE);
+			} else {
+				MOVAPS(tempReg, regs_.F(inst.src2));
+				CMPSS(tempReg, regs_.F(inst.src1), CMP_LE);
+			}
+			break;
+		case VC_EZ:
+		case VC_NZ:
+			XORPS(tempReg, R(tempReg));
+			CMPSS(tempReg, regs_.F(inst.src1), !condNegated ? CMP_EQ : CMP_NEQ);
+			break;
+		case VC_EN:
+		case VC_NN:
+			CMPSS(tempReg, regs_.F(inst.src1), !condNegated ? CMP_UNORD : CMP_ORD);
+			break;
+		case VC_EI:
+		case VC_NI:
+			regs_.MapFPR(inst.src1);
+			if (!RipAccessible(&simdConstants.noSignMask) || !RipAccessible(&simdConstants.positiveInfinity)) {
+				MOV(PTRBITS, R(SCRATCH1), ImmPtr(&simdConstants));
+			}
+			if (cpu_info.bAVX) {
+				if (RipAccessible(&simdConstants.noSignMask)) {
+					VANDPS(128, tempReg, regs_.FX(inst.src1), M(&simdConstants.noSignMask));  // rip accessible
+				} else {
+					VANDPS(128, tempReg, regs_.FX(inst.src1), MDisp(SCRATCH1, offsetof(SimdConstants, noSignMask)));
+				}
+			} else {
+				MOVAPS(tempReg, regs_.F(inst.src1));
+				if (RipAccessible(&simdConstants.noSignMask)) {
+					ANDPS(tempReg, M(&simdConstants.noSignMask));  // rip accessible
+				} else {
+					ANDPS(tempReg, MDisp(SCRATCH1, offsetof(SimdConstants, noSignMask)));
+				}
+			}
+			if (RipAccessible(&simdConstants.positiveInfinity)) {
+				CMPSS(tempReg, M(&simdConstants.positiveInfinity), !condNegated ? CMP_EQ : CMP_LT);  // rip accessible
+			} else {
+				CMPSS(tempReg, MDisp(SCRATCH1, offsetof(SimdConstants, positiveInfinity)), !condNegated ? CMP_EQ : CMP_LT);
+			}
+			break;
+		case VC_ES:
+		case VC_NS:
+			// NAN - NAN is NAN, and Infinity - Infinity is also NAN.
+			if (cpu_info.bAVX) {
+				VSUBSS(tempReg, regs_.FX(inst.src1), regs_.F(inst.src1));
+			} else {
+				MOVAPS(tempReg, regs_.F(inst.src1));
+				SUBSS(tempReg, regs_.F(inst.src1));
+			}
+			CMPSS(tempReg, regs_.F(inst.src1), !condNegated ? CMP_UNORD : CMP_ORD);
+			break;
+		case VC_TR:
+			OR(32, regs_.R(IRREG_VFPU_CC), Imm8(affectedBit));
+			takeBitFromTempReg = true;
+			break;
+		case VC_FL:
+			AND(32, regs_.R(IRREG_VFPU_CC), Imm8(~affectedBit));
+			takeBitFromTempReg = false;
+			break;
+		}
+
+		if (takeBitFromTempReg) {
+			MOVD_xmm(R(SCRATCH1), tempReg);
+			AND(32, R(SCRATCH1), Imm8(affectedBit));
+			AND(32, regs_.R(IRREG_VFPU_CC), Imm8(~affectedBit));
+			OR(32, regs_.R(IRREG_VFPU_CC), R(SCRATCH1));
+		}
+		break;
+	}
+
+	case IROp::FCmpVfpuAggregate:
+		regs_.MapGPR(IRREG_VFPU_CC, MIPSMap::DIRTY);
+		// First, clear out the bits we're aggregating.
+		// The register refuses writes to bits outside 0x3F, and we're setting 0x30.
+		AND(32, regs_.R(IRREG_VFPU_CC), Imm8(0xF));
+
+		// Set the any bit.
+		TEST(32, regs_.R(IRREG_VFPU_CC), Imm32(inst.dest));
+		SETcc(CC_NZ, R(SCRATCH1));
+		SHL(32, R(SCRATCH1), Imm8(4));
+		OR(32, regs_.R(IRREG_VFPU_CC), R(SCRATCH1));
+
+		// Next up, the "all" bit.  A bit annoying...
+		MOV(32, R(SCRATCH1), regs_.R(IRREG_VFPU_CC));
+		AND(32, R(SCRATCH1), Imm8(inst.dest));
+		CMP(32, R(SCRATCH1), Imm8(inst.dest));
+		SETcc(CC_E, R(SCRATCH1));
+		SHL(32, R(SCRATCH1), Imm8(5));
+		OR(32, regs_.R(IRREG_VFPU_CC), R(SCRATCH1));
 		break;
 
 	default:

--- a/Core/MIPS/x86/X64IRCompSystem.cpp
+++ b/Core/MIPS/x86/X64IRCompSystem.cpp
@@ -113,8 +113,19 @@ void X64JitBackend::CompIR_Transfer(IRInst inst) {
 	case IROp::SetCtrlVFPU:
 	case IROp::SetCtrlVFPUReg:
 	case IROp::SetCtrlVFPUFReg:
+		CompIR_Generic(inst);
+		break;
+
 	case IROp::FpCondFromReg:
+		regs_.MapWithExtra(inst, { { 'G', IRREG_FPCOND, 1, MIPSMap::NOINIT } });
+		MOV(32, regs_.R(IRREG_FPCOND), regs_.R(inst.src1));
+		break;
+
 	case IROp::FpCondToReg:
+		regs_.MapWithExtra(inst, { { 'G', IRREG_FPCOND, 1, MIPSMap::INIT } });
+		MOV(32, regs_.R(inst.dest), regs_.R(IRREG_FPCOND));
+		break;
+
 	case IROp::FpCtrlFromReg:
 	case IROp::FpCtrlToReg:
 	case IROp::VfpuCtrlToReg:

--- a/Core/MIPS/x86/X64IRCompSystem.cpp
+++ b/Core/MIPS/x86/X64IRCompSystem.cpp
@@ -55,6 +55,15 @@ void X64JitBackend::CompIR_Basic(IRInst inst) {
 		break;
 
 	case IROp::SetConstF:
+		regs_.Map(inst);
+		if (inst.constant == 0) {
+			XORPS(regs_.FX(inst.dest), regs_.F(inst.dest));
+		} else {
+			MOV(32, R(SCRATCH1), Imm32(inst.constant));
+			MOVD_xmm(regs_.FX(inst.dest), R(SCRATCH1));
+		}
+		break;
+
 	case IROp::SetPC:
 	case IROp::SetPCConst:
 		CompIR_Generic(inst);
@@ -109,9 +118,22 @@ void X64JitBackend::CompIR_Transfer(IRInst inst) {
 	case IROp::FpCtrlFromReg:
 	case IROp::FpCtrlToReg:
 	case IROp::VfpuCtrlToReg:
-	case IROp::FMovFromGPR:
-	case IROp::FMovToGPR:
 		CompIR_Generic(inst);
+		break;
+
+	case IROp::FMovFromGPR:
+		if (regs_.IsGPRImm(inst.src1) && regs_.GetGPRImm(inst.src1) == 0) {
+			regs_.MapFPR(inst.dest, MIPSMap::NOINIT);
+			XORPS(regs_.FX(inst.dest), regs_.F(inst.dest));
+		} else {
+			regs_.Map(inst);
+			MOVD_xmm(regs_.FX(inst.dest), regs_.R(inst.src1));
+		}
+		break;
+
+	case IROp::FMovToGPR:
+		regs_.Map(inst);
+		MOVD_xmm(regs_.R(inst.dest), regs_.FX(inst.src1));
 		break;
 
 	default:

--- a/Core/MIPS/x86/X64IRCompVec.cpp
+++ b/Core/MIPS/x86/X64IRCompVec.cpp
@@ -19,6 +19,7 @@
 #if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 
 #include <algorithm>
+#include "Common/CPUDetect.h"
 #include "Core/MemMap.h"
 #include "Core/MIPS/x86/X64IRJit.h"
 #include "Core/MIPS/x86/X64IRRegCache.h"
@@ -38,15 +39,109 @@ namespace MIPSComp {
 using namespace Gen;
 using namespace X64IRJitConstants;
 
+alignas(16) static const float vec4InitValues[8][4] = {
+	{ 0.0f, 0.0f, 0.0f, 0.0f },
+	{ 1.0f, 1.0f, 1.0f, 1.0f },
+	{ -1.0f, -1.0f, -1.0f, -1.0f },
+	{ 1.0f, 0.0f, 0.0f, 0.0f },
+	{ 0.0f, 1.0f, 0.0f, 0.0f },
+	{ 0.0f, 0.0f, 1.0f, 0.0f },
+	{ 0.0f, 0.0f, 0.0f, 1.0f },
+};
+
+static bool Overlap(IRReg r1, int l1, IRReg r2, int l2) {
+	return r1 < r2 + l2 && r1 + l1 > r2;
+}
+
 void X64JitBackend::CompIR_VecArith(IRInst inst) {
 	CONDITIONAL_DISABLE;
 
 	switch (inst.op) {
 	case IROp::Vec4Add:
+		regs_.Map(inst);
+		if (inst.dest == inst.src1) {
+			ADDPS(regs_.FX(inst.dest), regs_.F(inst.src2));
+		} else if (inst.dest == inst.src2) {
+			ADDPS(regs_.FX(inst.dest), regs_.F(inst.src1));
+		} else if (cpu_info.bAVX) {
+			VADDPS(128, regs_.FX(inst.dest), regs_.FX(inst.src1), regs_.F(inst.src2));
+		} else {
+			MOVAPS(regs_.FX(inst.dest), regs_.F(inst.src1));
+			ADDPS(regs_.FX(inst.dest), regs_.F(inst.src2));
+		}
+		break;
+
 	case IROp::Vec4Sub:
+		if (inst.dest == inst.src1) {
+			regs_.Map(inst);
+			SUBPS(regs_.FX(inst.dest), regs_.F(inst.src2));
+		} else if (cpu_info.bAVX) {
+			regs_.Map(inst);
+			VSUBPS(128, regs_.FX(inst.dest), regs_.FX(inst.src1), regs_.F(inst.src2));
+		} else if (inst.dest == inst.src2) {
+			X64Reg tempReg = regs_.MapWithFPRTemp(inst);
+			MOVAPS(tempReg, regs_.F(inst.src2));
+			MOVAPS(regs_.FX(inst.dest), regs_.F(inst.src1));
+			SUBPS(regs_.FX(inst.dest), R(tempReg));
+		} else {
+			regs_.Map(inst);
+			MOVAPS(regs_.FX(inst.dest), regs_.F(inst.src1));
+			SUBPS(regs_.FX(inst.dest), regs_.F(inst.src2));
+		}
+		break;
+
 	case IROp::Vec4Mul:
+		regs_.Map(inst);
+		if (inst.dest == inst.src1) {
+			MULPS(regs_.FX(inst.dest), regs_.F(inst.src2));
+		} else if (inst.dest == inst.src2) {
+			MULPS(regs_.FX(inst.dest), regs_.F(inst.src1));
+		} else if (cpu_info.bAVX) {
+			VMULPS(128, regs_.FX(inst.dest), regs_.FX(inst.src1), regs_.F(inst.src2));
+		} else {
+			MOVAPS(regs_.FX(inst.dest), regs_.F(inst.src1));
+			MULPS(regs_.FX(inst.dest), regs_.F(inst.src2));
+		}
+		break;
+
 	case IROp::Vec4Div:
+		if (inst.dest == inst.src1) {
+			regs_.Map(inst);
+			DIVPS(regs_.FX(inst.dest), regs_.F(inst.src2));
+		} else if (cpu_info.bAVX) {
+			regs_.Map(inst);
+			VDIVPS(128, regs_.FX(inst.dest), regs_.FX(inst.src1), regs_.F(inst.src2));
+		} else if (inst.dest == inst.src2) {
+			X64Reg tempReg = regs_.MapWithFPRTemp(inst);
+			MOVAPS(tempReg, regs_.F(inst.src2));
+			MOVAPS(regs_.FX(inst.dest), regs_.F(inst.src1));
+			DIVPS(regs_.FX(inst.dest), R(tempReg));
+		} else {
+			regs_.Map(inst);
+			MOVAPS(regs_.FX(inst.dest), regs_.F(inst.src1));
+			DIVPS(regs_.FX(inst.dest), regs_.F(inst.src2));
+		}
+		break;
+
 	case IROp::Vec4Scale:
+		// TODO: Handle "aliasing" of sizes.
+		if (Overlap(inst.dest, 4, inst.src2, 1) || Overlap(inst.src1, 4, inst.src2, 1))
+			DISABLE;
+
+		regs_.Map(inst);
+		SHUFPS(regs_.FX(inst.src2), regs_.F(inst.src2), 0);
+		if (inst.dest == inst.src1) {
+			MULPS(regs_.FX(inst.dest), regs_.F(inst.src2));
+		} else if (inst.dest == inst.src2) {
+			MULPS(regs_.FX(inst.dest), regs_.F(inst.src1));
+		} else if (cpu_info.bAVX) {
+			VMULPS(128, regs_.FX(inst.dest), regs_.FX(inst.src1), regs_.F(inst.src2));
+		} else {
+			MOVAPS(regs_.FX(inst.dest), regs_.F(inst.src1));
+			MULPS(regs_.FX(inst.dest), regs_.F(inst.src2));
+		}
+		break;
+
 	case IROp::Vec4Neg:
 	case IROp::Vec4Abs:
 		CompIR_Generic(inst);
@@ -63,9 +158,39 @@ void X64JitBackend::CompIR_VecAssign(IRInst inst) {
 
 	switch (inst.op) {
 	case IROp::Vec4Init:
+		regs_.Map(inst);
+		if (inst.src1 == (int)Vec4Init::AllZERO) {
+			XORPS(regs_.FX(inst.dest), regs_.F(inst.dest));
+		} else if (RipAccessible(&vec4InitValues[inst.src1])) {
+			MOVAPS(regs_.FX(inst.dest), M(&vec4InitValues[inst.src1]));  // rip accessible
+		} else {
+			MOV(PTRBITS, R(SCRATCH1), ImmPtr(&vec4InitValues[inst.src1]));
+			MOVAPS(regs_.FX(inst.dest), MatR(SCRATCH1));
+		}
+		break;
+
 	case IROp::Vec4Shuffle:
-	case IROp::Vec4Blend:
 		CompIR_Generic(inst);
+		break;
+
+	case IROp::Vec4Blend:
+		if (cpu_info.bAVX) {
+			regs_.Map(inst);
+			VBLENDPS(128, regs_.FX(inst.dest), regs_.FX(inst.src1), regs_.F(inst.src2), (uint8_t)inst.constant);
+		} else if (cpu_info.bSSE4_1) {
+			regs_.Map(inst);
+			if (inst.dest == inst.src1) {
+				BLENDPS(regs_.FX(inst.dest), regs_.F(inst.src2), (uint8_t)inst.constant);
+			} else if (inst.dest == inst.src2) {
+				BLENDPS(regs_.FX(inst.dest), regs_.F(inst.src1), (uint8_t)~inst.constant);
+			} else {
+				MOVAPS(regs_.FX(inst.dest), regs_.F(inst.src1));
+				BLENDPS(regs_.FX(inst.dest), regs_.F(inst.src2), (uint8_t)inst.constant);
+			}
+		} else {
+			// Could use some shuffles...
+			DISABLE;
+		}
 		break;
 
 	case IROp::Vec4Mov:

--- a/Core/MIPS/x86/X64IRJit.h
+++ b/Core/MIPS/x86/X64IRJit.h
@@ -29,6 +29,19 @@
 #include "Core/MIPS/JitCommon/JitCommon.h"
 #include "Core/MIPS/x86/X64IRRegCache.h"
 
+#if PPSSPP_PLATFORM(WINDOWS) && (defined(_MSC_VER) || defined(__clang__) || defined(__INTEL_COMPILER))
+#define X64JIT_XMM_CALL __vectorcall
+#define X64JIT_USE_XMM_CALL 1
+#elif PPSSPP_ARCH(AMD64) && !PPSSPP_PLATFORM(WINDOWS)
+// SystemV ABI supports XMM registers.
+#define X64JIT_XMM_CALL
+#define X64JIT_USE_XMM_CALL 1
+#else
+// GCC on x86 doesn't support vectorcall.
+#define X64JIT_XMM_CALL
+#define X64JIT_USE_XMM_CALL 0
+#endif
+
 namespace MIPSComp {
 
 class X64JitBackend : public Gen::XCodeBlock, public IRNativeBackend {

--- a/Core/MIPS/x86/X64IRRegCache.cpp
+++ b/Core/MIPS/x86/X64IRRegCache.cpp
@@ -168,6 +168,18 @@ X64Reg X64IRRegCache::MapWithFPRTemp(IRInst &inst) {
 	return FromNativeReg(MapWithTemp(inst, MIPSLoc::FREG));
 }
 
+void X64IRRegCache::MapWithFlags(IRInst inst, X64Map destFlags, X64Map src1Flags, X64Map src2Flags) {
+	Mapping mapping[3];
+	MappingFromInst(inst, mapping);
+
+	mapping[0].flags = mapping[0].flags | destFlags;
+	mapping[1].flags = mapping[1].flags | src1Flags;
+	mapping[2].flags = mapping[2].flags | src2Flags;
+
+	ApplyMapping(mapping, 3);
+	CleanupMapping(mapping, 3);
+}
+
 X64Reg X64IRRegCache::MapGPR(IRReg mipsReg, MIPSMap mapFlags) {
 	_dbg_assert_(IsValidGPR(mipsReg));
 

--- a/Core/MIPS/x86/X64IRRegCache.cpp
+++ b/Core/MIPS/x86/X64IRRegCache.cpp
@@ -50,12 +50,11 @@ const int *X64IRRegCache::GetAllocationOrder(MIPSLoc type, MIPSMap flags, int &c
 		base = RAX;
 
 		static const int allocationOrder[] = {
-			// On x64, RCX and RDX are the first args.  CallProtectedFunction() assumes they're not regcached.
 #if PPSSPP_ARCH(AMD64)
 #ifdef _WIN32
-			RSI, RDI, R8, R9, R10, R11, R12, R13,
+			RSI, RDI, R8, R9, R10, R11, R12, R13, RDX, RCX,
 #else
-			RBP, R8, R9, R10, R11, R12, R13,
+			RBP, R8, R9, R10, R11, R12, R13, RDX, RCX,
 #endif
 			// Intentionally last.
 			R15,

--- a/Core/MIPS/x86/X64IRRegCache.h
+++ b/Core/MIPS/x86/X64IRRegCache.h
@@ -77,6 +77,8 @@ public:
 
 	Gen::X64Reg MapWithFPRTemp(IRInst &inst);
 
+	void MapWithFlags(IRInst inst, X64IRJitConstants::X64Map destFlags, X64IRJitConstants::X64Map src1Flags = X64IRJitConstants::X64Map::NONE, X64IRJitConstants::X64Map src2Flags = X64IRJitConstants::X64Map::NONE);
+
 	void FlushBeforeCall();
 
 	Gen::X64Reg GetAndLockTempR();


### PR DESCRIPTION
LittleBigPlanet runs more or less the same speed now as regular jit up until in game, which is about 17% slower (still a bunch of unimplemented things.)

Also move to use RCX and RDX in the regcache.  We don't use thunks in the other regcaches (preferring flushbeforecall, etc.), and I plan to do the same here.

Regular x86jit:
> Average Bloat: 714.55%
> Min Bloat: 124.49%  (08a248c8)
> Max Bloat: 3275.00%  (089fc4a4)

Incomplete IR x86jit:
> Average Bloat: 616.37%
> Min Bloat: 129.00%  (08a248c8)
> Max Bloat: 1966.67%  (089fa97c)

Of course, that may go up, maybe the interpret call is shorter than some actual ops.

-[Unknown]