### PR TITLE
Add compat flag to not load CLUTs from old framebuffers

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -132,6 +132,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ForceMaxDepthResolution", &flags_.ForceMaxDepthResolution);
 	CheckSetting(iniFile, gameID, "SOCOMClut8Replacement", &flags_.SOCOMClut8Replacement);
 	CheckSetting(iniFile, gameID, "Fontltn12Hack", &flags_.Fontltn12Hack);
+	CheckSetting(iniFile, gameID, "LoadCLUTFromCurrentFrameOnly", &flags_.LoadCLUTFromCurrentFrameOnly);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -102,6 +102,7 @@ struct CompatFlags {
 	bool ForceMaxDepthResolution;
 	bool SOCOMClut8Replacement;
 	bool Fontltn12Hack;
+	bool LoadCLUTFromCurrentFrameOnly;
 };
 
 struct VRCompat {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -1355,7 +1355,8 @@ void TextureCacheCommon::LoadClut(u32 clutAddr, u32 loadBytes) {
 				// the framebuffer with the smallest offset. This is yet another framebuffer matching
 				// loop with its own rules, eventually we'll probably want to do something
 				// more systematic.
-				if (matchRange && !inMargin && offset < (int)clutRenderOffset_) {
+				bool okAge = !PSP_CoreParameter().compat.flags().LoadCLUTFromCurrentFrameOnly || framebuffer->last_frame_used == gpuStats.numFlips;
+				if (matchRange && !inMargin && offset < (int)clutRenderOffset_ && okAge) {
 					WARN_LOG_N_TIMES(clutfb, 5, G3D, "Detected LoadCLUT(%d bytes) from framebuffer %08x (%s), byte offset %d, pixel offset %d",
 						loadBytes, fb_address, GeBufferFormatToString(framebuffer->fb_format), offset, offset / fb_bpp);
 					framebuffer->last_frame_clut = gpuStats.numFlips;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1593,3 +1593,14 @@ NPJG90068 = true  # demo
 [Fontltn12Hack]
 #optimumFont do not return ltn12.pgf see #11055
 NPJH00052  = true
+
+[LoadCLUTFromCurrentFrameOnly]
+# Helps Syphon Filter: Logan's Shadow color issue, # where we accidentally load a CLUT from an outdated framebuffer.
+# Perhaps this should be the default.
+UCUS98606 = true
+UCES00710 = true
+NPUG80173 = true
+NPUA80013 = true  # Demo
+UCUS98704 = true  # Demo
+NPEG90002 = true  # Demo
+SYPH04036 = true  # Prototype?


### PR DESCRIPTION
Fixes #17373 by adding a compat flag to avoid loading CLUTs (palettes) from framebuffers not rendered to during the current frame.

#17373 is a LoadCLUT issue (where we load a palette from a framebuffer). Doesn't persist after a save/reload state, so it seems we end up reading a palette from a framebuffer that contains outdated data, maybe due to sticking around from a previous frame while in reality the game has replaced that memory with the correct data. Checking for changes in the memory area covered by framebuffers might be necessary to fix this without flags, which gets too risky to include in the upcoming release.

I don't think it's that common though that we need LoadCLUT from framebuffers from old frames, so perhaps we should eventually invert this flag, and make it the default - risk seems fairly high to erroneously load CLUTs from outdated framebuffers lingering around. I'll do that after the release though.