### PR TITLE
Add "Create frame dump" to the in-game developer menu

### DIFF
--- a/Core/Debugger/WebSocket/GPURecordSubscriber.cpp
+++ b/Core/Debugger/WebSocket/GPURecordSubscriber.cpp
@@ -44,7 +44,7 @@ DebuggerSubscriber *WebSocketGPURecordInit(DebuggerEventHandlerMap &map) {
 WebSocketGPURecordState::~WebSocketGPURecordState() {
 	// Clear the callback to hopefully avoid a crash.
 	if (pending_)
-		GPURecord::SetCallback(nullptr);
+		GPURecord::ClearCallback();
 }
 
 // Begin recording (gpu.record.dump)
@@ -56,17 +56,20 @@ WebSocketGPURecordState::~WebSocketGPURecordState() {
 //
 // Note: recording may take a moment.
 void WebSocketGPURecordState::Dump(DebuggerRequest &req) {
-	if (!PSP_IsInited())
+	if (!PSP_IsInited()) {
 		return req.Fail("CPU not started");
+	}
 
-	if (!GPURecord::Activate())
-		return req.Fail("Recording already in progress");
-
-	pending_ = true;
-	GPURecord::SetCallback([=](const Path &filename) {
+	bool result = GPURecord::RecordNextFrame([=](const Path &filename) {
 		lastFilename_ = filename;
 		pending_ = false;
 	});
+
+	if (!result) {
+		return req.Fail("Recording already in progress");
+	}
+
+	pending_ = true;
 
 	const JsonNode *value = req.data.get("ticket");
 	lastTicket_ = value ? json_stringify(value) : "";

--- a/GPU/Debugger/Record.cpp
+++ b/GPU/Debugger/Record.cpp
@@ -49,7 +49,7 @@
 namespace GPURecord {
 
 static bool active = false;
-static bool nextFrame = false;
+static std::atomic<bool> nextFrame = false;
 static int flipLastAction = -1;
 static int flipFinishAt = -1;
 static uint32_t lastEdramTrans = 0x400;
@@ -601,18 +601,20 @@ bool IsActivePending() {
 	return nextFrame || active;
 }
 
-bool Activate() {
+bool RecordNextFrame(const std::function<void(const Path &)> callback) {
 	if (!nextFrame) {
-		nextFrame = true;
 		flipLastAction = gpuStats.numFlips;
 		flipFinishAt = -1;
+		writeCallback = callback;
+		nextFrame = true;
 		return true;
 	}
 	return false;
 }
 
-void SetCallback(const std::function<void(const Path &)> callback) {
-	writeCallback = callback;
+void ClearCallback() {
+	// Not super thread safe..
+	writeCallback = nullptr;
 }
 
 static void FinishRecording() {

--- a/GPU/Debugger/Record.h
+++ b/GPU/Debugger/Record.h
@@ -27,9 +27,8 @@ namespace GPURecord {
 
 bool IsActive();
 bool IsActivePending();
-bool Activate();
-// Call only if Activate() returns true.
-void SetCallback(const std::function<void(const Path &)> callback);
+bool RecordNextFrame(const std::function<void(const Path &)> callback);
+void ClearCallback();
 
 void NotifyCommand(u32 pc);
 void NotifyMemcpy(u32 dest, u32 src, u32 sz);

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -1212,11 +1212,10 @@ BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 			break;
 
 		case IDC_GEDBG_RECORD:
-			GPURecord::SetCallback([](const Path &path) {
-				// Opens a Windows Explorer window with the file.
+			GPURecord::RecordNextFrame([](const Path &path) {
+				// Opens a Windows Explorer window with the file, when done.
 				System_ShowFileInFolder(path);
 			});
-			GPURecord::Activate();
 			break;
 
 		case IDC_GEDBG_FLUSH:

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -302,6 +302,7 @@ Block address = Block address
 By Address = By address
 Control Debug = Control Debug
 Copy savestates to memstick root = Copy save states to Memory Stick root
+Create frame dump = Create frame dump
 Create/Open textures.ini file for current game = Create/Open textures.ini file for current game
 Current = Current
 Dev Tools = Development tools


### PR DESCRIPTION
(The in-game dev menu can be enabled in dev settings)

Makes it possible to create GE frame dumps without connecting the websocket debugger, even on non-Windows platforms.

Later I want to improve this by adding the ability to "share" the file to e-mail or google drive or even discord directly, but it'll take a little research into android intents it seems. Maybe also even automatically zip up the file.