### PR TITLE
Allow disabling HTTPS through the config file

### DIFF
--- a/Common/Net/HTTPRequest.cpp
+++ b/Common/Net/HTTPRequest.cpp
@@ -5,6 +5,7 @@
 #include "Common/StringUtils.h"
 #include "Common/Log.h"
 #include "Common/System/OSD.h"
+#include "Common/System/System.h"
 
 namespace http {
 
@@ -37,7 +38,7 @@ bool RequestManager::IsHttpsUrl(const std::string &url) {
 
 std::shared_ptr<Request> RequestManager::StartDownload(const std::string &url, const Path &outfile, ProgressBarMode mode, const char *acceptMime) {
 	std::shared_ptr<Request> dl;
-	if (IsHttpsUrl(url)) {
+	if (IsHttpsUrl(url) && System_GetPropertyBool(SYSPROP_SUPPORTS_HTTPS)) {
 #ifndef HTTPS_NOT_AVAILABLE
 		dl.reset(new HTTPSRequest(RequestMethod::GET, url, "", "", outfile, mode));
 #else
@@ -64,7 +65,7 @@ std::shared_ptr<Request> RequestManager::StartDownloadWithCallback(
 	const std::string &name,
 	const char *acceptMime) {
 	std::shared_ptr<Request> dl;
-	if (IsHttpsUrl(url)) {
+	if (IsHttpsUrl(url) && System_GetPropertyBool(SYSPROP_SUPPORTS_HTTPS)) {
 #ifndef HTTPS_NOT_AVAILABLE
 		dl.reset(new HTTPSRequest(RequestMethod::GET, url, "", "", outfile, mode, name));
 #else
@@ -91,7 +92,7 @@ std::shared_ptr<Request> RequestManager::AsyncPostWithCallback(
 	std::function<void(Request &)> callback,
 	const std::string &name) {
 	std::shared_ptr<Request> dl;
-	if (IsHttpsUrl(url)) {
+	if (IsHttpsUrl(url) && System_GetPropertyBool(SYSPROP_SUPPORTS_HTTPS)) {
 #ifndef HTTPS_NOT_AVAILABLE
 		dl.reset(new HTTPSRequest(RequestMethod::POST, url, postData, postMime, Path(), mode, name));
 #else

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -183,6 +183,7 @@ static const ConfigSetting generalSettings[] = {
 	ConfigSetting("DiscordPresence", &g_Config.bDiscordPresence, true, CfgFlag::DEFAULT),  // Or maybe it makes sense to have it per-game? Race conditions abound...
 	ConfigSetting("UISound", &g_Config.bUISound, false, CfgFlag::DEFAULT),
 
+	ConfigSetting("DisableHTTPS", &g_Config.bDisableHTTPS, false, CfgFlag::DONT_SAVE),
 	ConfigSetting("AutoLoadSaveState", &g_Config.iAutoLoadSaveState, 0, CfgFlag::PER_GAME),
 	ConfigSetting("EnableCheats", &g_Config.bEnableCheats, false, CfgFlag::PER_GAME | CfgFlag::REPORT),
 	ConfigSetting("CwCheatRefreshRate", &g_Config.iCwCheatRefreshRate, 77, CfgFlag::PER_GAME),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -92,6 +92,8 @@ public:
 	bool bPreloadFunctions;
 	uint32_t uJitDisableFlags;
 
+	bool bDisableHTTPS;
+
 	bool bSeparateSASThread;
 	int iIOTimingMethod;
 	int iLockedCPUSpeed;

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -573,7 +573,7 @@ bool System_GetPropertyBool(SystemProperty prop) {
 		return true;  // FileUtil.cpp: OpenFileInEditor
 #ifndef HTTPS_NOT_AVAILABLE
 	case SYSPROP_SUPPORTS_HTTPS:
-		return true;
+		return !g_Config.bDisableHTTPS;
 #endif
 #if PPSSPP_PLATFORM(MAC)
 	case SYSPROP_HAS_FOLDER_BROWSER:

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -374,7 +374,7 @@ bool System_GetPropertyBool(SystemProperty prop) {
 	case SYSPROP_SUPPORTS_OPEN_FILE_IN_EDITOR:
 		return true;  // FileUtil.cpp: OpenFileInEditor
 	case SYSPROP_SUPPORTS_HTTPS:
-		return true;
+		return !g_Config.bDisableHTTPS;
 	default:
 		return false;
 	}
@@ -597,7 +597,7 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 
 	case SystemRequestType::SHOW_FILE_IN_FOLDER:
 		W32Util::ShowFileInFolder(param1);
-		break;
+		return true;
 
 	case SystemRequestType::TOGGLE_FULLSCREEN_STATE:
 	{
@@ -620,7 +620,6 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 		return true;
 	}
 	case SystemRequestType::CREATE_GAME_SHORTCUT:
-		// This is not actually working, but ported it to the request framework anyway.
 		return W32Util::CreateDesktopShortcut(param1, param2);
 	default:
 		return false;

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -533,7 +533,7 @@ bool System_GetPropertyBool(SystemProperty prop) {
 		return deviceType != DEVICE_TYPE_VR;
 #ifndef HTTPS_NOT_AVAILABLE
 	case SYSPROP_SUPPORTS_HTTPS:
-		return true;
+		return !g_Config.bDisableHTTPS;
 #endif
 	default:
 		return false;


### PR DESCRIPTION
Simply set:

```ini
[General]
DisableHTTPS = True
```

in PSP/SYSTEM/ppsspp.ini in the memstick folder. Make the change when PPSSPP is not running.

Added to help debug issue #17969 . Although I really have no idea how this could affect it, so it's a bit of a shot in the dark.

You can only set this option by editing the INI for now, not much reason to expose it.

