### PR TITLE
More x86 IR JIT

### DIFF
--- a/Core/MIPS/IR/IRRegCache.cpp
+++ b/Core/MIPS/IR/IRRegCache.cpp
@@ -367,7 +367,7 @@ IRNativeReg IRNativeRegCacheBase::FindFreeReg(MIPSLoc type, MIPSMap flags) const
 	for (int i = 0; i < allocCount; i++) {
 		IRNativeReg nreg = IRNativeReg(allocOrder[i] - base);
 
-		if (nr[nreg].mipsReg == IRREG_INVALID) {
+		if (nr[nreg].mipsReg == IRREG_INVALID && nr[nreg].tempLockIRIndex < irIndex_) {
 			return nreg;
 		}
 	}

--- a/Core/MIPS/IR/IRRegCache.cpp
+++ b/Core/MIPS/IR/IRRegCache.cpp
@@ -698,6 +698,10 @@ void IRNativeRegCacheBase::ApplyMapping(const Mapping *mapping, int count) {
 		}
 	}
 
+	auto isNoinit = [](MIPSMap f) {
+		return (f & MIPSMap::NOINIT) == MIPSMap::NOINIT;
+	};
+
 	auto mapRegs = [&](int i) {
 		MIPSLoc type = MIPSLoc::MEM;
 		switch (mapping[i].type) {
@@ -714,24 +718,39 @@ void IRNativeRegCacheBase::ApplyMapping(const Mapping *mapping, int count) {
 			return;
 		}
 
+		MIPSMap flags = mapping[i].flags;
+		for (int j = 0; j < count; ++j) {
+			if (mapping[j].type == mapping[i].type && mapping[j].reg == mapping[i].reg && i != j) {
+				_assert_msg_(mapping[j].lanes == mapping[i].lanes, "Lane aliasing not supported yet");
+
+				if (!isNoinit(mapping[j].flags) && isNoinit(flags)) {
+					flags = (flags & MIPSMap::BACKEND_MASK) | MIPSMap::DIRTY;
+				}
+			}
+		}
+
 		if (config_.mapFPUSIMD || mapping[i].type == 'G') {
-			MapNativeReg(type, mapping[i].reg, mapping[i].lanes, mapping[i].flags);
+			MapNativeReg(type, mapping[i].reg, mapping[i].lanes, flags);
 			return;
 		}
 
 		for (int j = 0; j < mapping[i].lanes; ++j)
-			MapNativeReg(type, mapping[i].reg + j, 1, mapping[i].flags);
+			MapNativeReg(type, mapping[i].reg + j, 1, flags);
+	};
+	auto mapFilteredRegs = [&](auto pred) {
+		for (int i = 0; i < count; ++i) {
+			if (pred(mapping[i].flags))
+				mapRegs(i);
+		}
 	};
 
-	// Do two passes: first any without NOINIT, then NOINIT.
-	for (int i = 0; i < count; ++i) {
-		if ((mapping[i].flags & MIPSMap::NOINIT) != MIPSMap::NOINIT)
-			mapRegs(i);
-	}
-	for (int i = 0; i < count; ++i) {
-		if ((mapping[i].flags & MIPSMap::NOINIT) == MIPSMap::NOINIT)
-			mapRegs(i);
-	}
+	// Do two passes: with backend special flags, and without.
+	mapFilteredRegs([](MIPSMap flags) {
+		return (flags & MIPSMap::BACKEND_MASK) != MIPSMap::INIT;
+	});
+	mapFilteredRegs([](MIPSMap flags) {
+		return (flags & MIPSMap::BACKEND_MASK) == MIPSMap::INIT;
+	});
 }
 
 void IRNativeRegCacheBase::CleanupMapping(const Mapping *mapping, int count) {

--- a/Core/MIPS/IR/IRRegCache.h
+++ b/Core/MIPS/IR/IRRegCache.h
@@ -79,6 +79,8 @@ enum class MIPSMap : uint8_t {
 	INIT = 0,
 	DIRTY = 1,
 	NOINIT = 2 | DIRTY,
+
+	BACKEND_MASK = 0xF0,
 };
 static inline MIPSMap operator |(const MIPSMap &lhs, const MIPSMap &rhs) {
 	return MIPSMap((uint8_t)lhs | (uint8_t)rhs);

--- a/Core/MIPS/x86/X64IRCompALU.cpp
+++ b/Core/MIPS/x86/X64IRCompALU.cpp
@@ -233,10 +233,53 @@ void X64JitBackend::CompIR_CondAssign(IRInst inst) {
 
 	switch (inst.op) {
 	case IROp::MovZ:
+		if (inst.dest != inst.src2) {
+			regs_.Map(inst);
+			CMP(32, regs_.R(inst.src1), Imm32(0));
+			CMOVcc(32, regs_.RX(inst.dest), regs_.R(inst.src2), CC_Z);
+		}
+		break;
+
 	case IROp::MovNZ:
+		if (inst.dest != inst.src2) {
+			regs_.Map(inst);
+			CMP(32, regs_.R(inst.src1), Imm32(0));
+			CMOVcc(32, regs_.RX(inst.dest), regs_.R(inst.src2), CC_NZ);
+		}
+		break;
+
 	case IROp::Max:
+		regs_.Map(inst);
+		if (inst.src1 == inst.src2) {
+			MOV(32, regs_.R(inst.dest), regs_.R(inst.src1));
+		} else if (inst.dest == inst.src1) {
+			CMP(32, regs_.R(inst.src1), regs_.R(inst.src2));
+			CMOVcc(32, regs_.RX(inst.dest), regs_.R(inst.src2), CC_L);
+		} else if (inst.dest == inst.src2) {
+			CMP(32, regs_.R(inst.src1), regs_.R(inst.src2));
+			CMOVcc(32, regs_.RX(inst.dest), regs_.R(inst.src1), CC_G);
+		} else {
+			MOV(32, regs_.R(inst.dest), regs_.R(inst.src1));
+			CMP(32, regs_.R(inst.dest), regs_.R(inst.src2));
+			CMOVcc(32, regs_.RX(inst.dest), regs_.R(inst.src2), CC_L);
+		}
+		break;
+
 	case IROp::Min:
-		CompIR_Generic(inst);
+		regs_.Map(inst);
+		if (inst.src1 == inst.src2) {
+			MOV(32, regs_.R(inst.dest), regs_.R(inst.src1));
+		} else if (inst.dest == inst.src1) {
+			CMP(32, regs_.R(inst.src1), regs_.R(inst.src2));
+			CMOVcc(32, regs_.RX(inst.dest), regs_.R(inst.src2), CC_G);
+		} else if (inst.dest == inst.src2) {
+			CMP(32, regs_.R(inst.src1), regs_.R(inst.src2));
+			CMOVcc(32, regs_.RX(inst.dest), regs_.R(inst.src1), CC_L);
+		} else {
+			MOV(32, regs_.R(inst.dest), regs_.R(inst.src1));
+			CMP(32, regs_.R(inst.dest), regs_.R(inst.src2));
+			CMOVcc(32, regs_.RX(inst.dest), regs_.R(inst.src2), CC_G);
+		}
 		break;
 
 	default:

--- a/Core/MIPS/x86/X64IRCompBranch.cpp
+++ b/Core/MIPS/x86/X64IRCompBranch.cpp
@@ -54,7 +54,8 @@ void X64JitBackend::CompIR_Exit(IRInst inst) {
 		break;
 
 	case IROp::ExitToPC:
-		CompIR_Generic(inst);
+		FlushAll();
+		JMP(dispatcherCheckCoreState_, true);
 		break;
 
 	default:

--- a/Core/MIPS/x86/X64IRRegCache.h
+++ b/Core/MIPS/x86/X64IRRegCache.h
@@ -43,8 +43,12 @@ static constexpr auto pcOffset = offsetof(MIPSState, pc) - 128;
 
 enum class X64Map : uint8_t {
 	NONE = 0,
+	// On 32-bit: EAX, EBX, ECX, EDX
 	LOW_SUBREG = 0x10,
-	SHIFT = 0x20,
+	// EDX/RDX
+	HIGH_DATA = 0x20,
+	// ECX/RCX
+	SHIFT = 0x30,
 	MASK = 0xF0,
 };
 static inline MIPSMap operator |(const MIPSMap &lhs, const X64Map &rhs) {
@@ -84,6 +88,7 @@ public:
 	void FlushBeforeCall();
 
 	Gen::X64Reg GetAndLockTempR();
+	void ReserveAndLockXGPR(Gen::X64Reg r);
 
 	Gen::OpArg R(IRReg preg);
 	Gen::OpArg RPtr(IRReg preg);

--- a/Core/MIPS/x86/X64IRRegCache.h
+++ b/Core/MIPS/x86/X64IRRegCache.h
@@ -44,6 +44,8 @@ static constexpr auto pcOffset = offsetof(MIPSState, pc) - 128;
 enum class X64Map : uint8_t {
 	NONE = 0,
 	LOW_SUBREG = 0x10,
+	SHIFT = 0x20,
+	MASK = 0xF0,
 };
 static inline MIPSMap operator |(const MIPSMap &lhs, const X64Map &rhs) {
 	return MIPSMap((uint8_t)lhs | (uint8_t)rhs);


### PR DESCRIPTION
Didn't do divide yet, but otherwise this mostly covers the ALU stuff.  Still some float and vec stuff that gets hit.

This also does multiplies the same way as "modern" 64-bit backends, with a single register.  This does make madd/etc. simpler.  This decreases the average bloat further.

-[Unknown]