### PR TITLE
Log level/type: Use enum class instead of the awkward namespace trick.

### DIFF
--- a/Common/ConsoleListener.cpp
+++ b/Common/ConsoleListener.cpp
@@ -358,7 +358,7 @@ void ConsoleListener::LogWriterThread()
 
 		for (char *Text = logLocal, *End = logLocal + logLocalSize; Text < End; )
 		{
-			LogTypes::LOG_LEVELS Level = LogTypes::LINFO;
+			LogLevel Level = LogLevel::LINFO;
 
 			char *next = (char *) memchr(Text + 1, '\033', End - Text);
 			size_t Len = next - Text;
@@ -367,7 +367,7 @@ void ConsoleListener::LogWriterThread()
 
 			if (Text[0] == '\033' && Text + 1 < End)
 			{
-				Level = (LogTypes::LOG_LEVELS) (Text[1] - '0');
+				Level = (LogLevel)(Text[1] - '0');
 				Len -= 2;
 				Text += 2;
 			}
@@ -384,7 +384,7 @@ void ConsoleListener::LogWriterThread()
 	delete [] logLocal;
 }
 
-void ConsoleListener::SendToThread(LogTypes::LOG_LEVELS Level, const char *Text)
+void ConsoleListener::SendToThread(LogLevel Level, const char *Text)
 {
 	// Oops, we're already quitting.  Just do nothing.
 	if (logPendingWritePos == (u32) -1)
@@ -462,7 +462,7 @@ void ConsoleListener::SendToThread(LogTypes::LOG_LEVELS Level, const char *Text)
 	SetEvent(hTriggerEvent);
 }
 
-void ConsoleListener::WriteToConsole(LogTypes::LOG_LEVELS Level, const char *Text, size_t Len)
+void ConsoleListener::WriteToConsole(LogLevel Level, const char *Text, size_t Len)
 {
 	_dbg_assert_msg_(IsOpen(), "Don't call this before opening the console.");
 
@@ -479,21 +479,20 @@ void ConsoleListener::WriteToConsole(LogTypes::LOG_LEVELS Level, const char *Tex
 	WORD Color;
 	static wchar_t tempBuf[2048];
 
-	switch (Level)
-	{
-	case NOTICE_LEVEL: // light green
+	switch (Level) {
+	case LogLevel::LNOTICE: // light green
 		Color = FOREGROUND_GREEN | FOREGROUND_INTENSITY;
 		break;
-	case ERROR_LEVEL: // light red
+	case LogLevel::LERROR: // light red
 		Color = FOREGROUND_RED | FOREGROUND_INTENSITY;
 		break;
-	case WARNING_LEVEL: // light yellow
+	case LogLevel::LWARNING: // light yellow
 		Color = FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_INTENSITY;
 		break;
-	case INFO_LEVEL: // cyan
+	case LogLevel::LINFO: // cyan
 		Color = FOREGROUND_GREEN | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
 		break;
-	case DEBUG_LEVEL: // gray
+	case LogLevel::LDEBUG: // gray
 		Color = FOREGROUND_INTENSITY;
 		break;
 	default: // off-white
@@ -593,7 +592,7 @@ void ConsoleListener::PixelSpace(int Left, int Top, int Width, int Height, bool 
 	COORD Coo = GetCoordinates(OldCursor, LBufWidth);
 	SetConsoleCursorPosition(hConsole, Coo);
 
-	// if (SLog.length() > 0) Log(LogTypes::LNOTICE, SLog.c_str());
+	// if (SLog.length() > 0) Log(LogLevel::LNOTICE, SLog.c_str());
 
 	// Resize the window too
 	if (Resize) MoveWindow(GetConsoleWindow(), Left,Top, (Width + 100),Height, true);
@@ -615,18 +614,16 @@ void ConsoleListener::Log(const LogMessage &msg) {
 	char ColorAttr[16] = "";
 	char ResetAttr[16] = "";
 
-	if (bUseColor)
-	{
+	if (bUseColor) {
 		strcpy(ResetAttr, "\033[0m");
-		switch (msg.level)
-		{
-		case NOTICE_LEVEL: // light green
+		switch (msg.level) {
+		case LogLevel::LNOTICE: // light green
 			strcpy(ColorAttr, "\033[92m");
 			break;
-		case ERROR_LEVEL: // light red
+		case LogLevel::LERROR: // light red
 			strcpy(ColorAttr, "\033[91m");
 			break;
-		case WARNING_LEVEL: // light yellow
+		case LogLevel::LWARNING: // light yellow
 			strcpy(ColorAttr, "\033[93m");
 			break;
 		default:
@@ -656,5 +653,3 @@ void ConsoleListener::ClearScreen(bool Cursor)
 	if (Cursor) SetConsoleCursorPosition(hConsole, coordScreen); 
 #endif
 }
-
-

--- a/Common/ConsoleListener.h
+++ b/Common/ConsoleListener.h
@@ -54,8 +54,8 @@ private:
 
 	static unsigned int WINAPI RunThread(void *lpParam);
 	void LogWriterThread();
-	void SendToThread(LogTypes::LOG_LEVELS Level, const char *Text);
-	void WriteToConsole(LogTypes::LOG_LEVELS Level, const char *Text, size_t Len);
+	void SendToThread(LogLevel Level, const char *Text);
+	void WriteToConsole(LogLevel Level, const char *Text, size_t Len);
 
 	static int refCount;
 	static HANDLE hThread;

--- a/Common/Log.h
+++ b/Common/Log.h
@@ -26,9 +26,7 @@
 #define	DEBUG_LEVEL   5  // Detailed debugging - might make things slow.
 #define	VERBOSE_LEVEL 6  // Noisy debugging - sometimes needed but usually unimportant.
 
-namespace LogTypes {
-
-enum LOG_TYPE {
+enum class LogType {
 	SYSTEM = 0,  // Catch-all for uncategorized things
 	BOOT,
 	COMMON,
@@ -67,7 +65,7 @@ enum LOG_TYPE {
 	ACHIEVEMENTS = HLE,  // TODO: Make a real category
 };
 
-enum LOG_LEVELS : int {
+enum class LogLevel : int {
 	LNOTICE = NOTICE_LEVEL,
 	LERROR = ERROR_LEVEL,
 	LWARNING = WARNING_LEVEL,
@@ -76,19 +74,18 @@ enum LOG_LEVELS : int {
 	LVERBOSE = VERBOSE_LEVEL,
 };
 
-}  // namespace
-
-void GenericLog(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type,
+void GenericLog(LogLevel level, LogType type,
 		const char *file, int line, const char *fmt, ...)
 #ifdef __GNUC__
 		__attribute__((format(printf, 5, 6)))
 #endif
 		;
-bool GenericLogEnabled(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type);
+bool GenericLogEnabled(LogLevel level, LogType type);
 
 // Exception for Windows - enable more log levels in release mode than on other platforms.
 #if defined(_DEBUG) || defined(_WIN32)
 
+// Needs to be an int (and not use the enum) because it's used by the preprocessor!
 #define MAX_LOGLEVEL DEBUG_LEVEL
 
 #else
@@ -102,16 +99,16 @@ bool GenericLogEnabled(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type);
 // Let the compiler optimize this out.
 // TODO: Compute a dynamic max level as well that can be checked here.
 #define GENERIC_LOG(t, v, ...) { \
-	if (v <= MAX_LOGLEVEL) \
+	if ((int)v <= MAX_LOGLEVEL) \
 		GenericLog(v, t, __FILE__, __LINE__, __VA_ARGS__); \
 	}
 
-#define ERROR_LOG(t,...)   do { GENERIC_LOG(LogTypes::t, LogTypes::LERROR,   __VA_ARGS__) } while (false)
-#define WARN_LOG(t,...)    do { GENERIC_LOG(LogTypes::t, LogTypes::LWARNING, __VA_ARGS__) } while (false)
-#define NOTICE_LOG(t,...)  do { GENERIC_LOG(LogTypes::t, LogTypes::LNOTICE,  __VA_ARGS__) } while (false)
-#define INFO_LOG(t,...)    do { GENERIC_LOG(LogTypes::t, LogTypes::LINFO,    __VA_ARGS__) } while (false)
-#define DEBUG_LOG(t,...)   do { GENERIC_LOG(LogTypes::t, LogTypes::LDEBUG,   __VA_ARGS__) } while (false)
-#define VERBOSE_LOG(t,...) do { GENERIC_LOG(LogTypes::t, LogTypes::LVERBOSE, __VA_ARGS__) } while (false)
+#define ERROR_LOG(t,...)   do { GENERIC_LOG(LogType::t, LogLevel::LERROR,   __VA_ARGS__) } while (false)
+#define WARN_LOG(t,...)    do { GENERIC_LOG(LogType::t, LogLevel::LWARNING, __VA_ARGS__) } while (false)
+#define NOTICE_LOG(t,...)  do { GENERIC_LOG(LogType::t, LogLevel::LNOTICE,  __VA_ARGS__) } while (false)
+#define INFO_LOG(t,...)    do { GENERIC_LOG(LogType::t, LogLevel::LINFO,    __VA_ARGS__) } while (false)
+#define DEBUG_LOG(t,...)   do { GENERIC_LOG(LogType::t, LogLevel::LDEBUG,   __VA_ARGS__) } while (false)
+#define VERBOSE_LOG(t,...) do { GENERIC_LOG(LogType::t, LogLevel::LVERBOSE, __VA_ARGS__) } while (false)
 
 // Currently only actually shows a dialog box on Windows.
 bool HandleAssert(const char *function, const char *file, int line, const char *expression, const char* format, ...)

--- a/Common/Log.h
+++ b/Common/Log.h
@@ -26,6 +26,7 @@
 #define	DEBUG_LEVEL   5  // Detailed debugging - might make things slow.
 #define	VERBOSE_LEVEL 6  // Noisy debugging - sometimes needed but usually unimportant.
 
+// NOTE: Needs to be kept in sync with the g_logTypeNames array.
 enum class LogType {
 	SYSTEM = 0,  // Catch-all for uncategorized things
 	BOOT,

--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -77,56 +77,53 @@ bool GenericLogEnabled(LogLevel level, LogType type) {
 
 LogManager *LogManager::logManager_ = NULL;
 
-struct LogNameTableEntry {
-	LogType logType;
-	const char *name;
-};
+// NOTE: Needs to be kept in sync with the LogType enum.
+static const char *g_logTypeNames[] = {
+	"SYSTEM",
+	"BOOT",
+	"COMMON",
+	"CPU",
+	"FILESYS",
+	"G3D",
+	"HLE",
+	"JIT",
+	"LOADER",
+	"ME",  // Media Engine
+	"MEMMAP",
+	"SASMIX",
+	"SAVESTATE",
+	"FRAMEBUF",
+	"AUDIO",
+	"IO",
 
-static const LogNameTableEntry logTable[] = {
-	{LogType::SYSTEM,     "SYSTEM"},
-	{LogType::BOOT,       "BOOT"},
-	{LogType::COMMON,     "COMMON"},
-	{LogType::CPU,        "CPU"},
-	{LogType::FILESYS,    "FILESYS"},
-	{LogType::G3D,        "G3D"},
-	{LogType::HLE,        "HLE"},
-	{LogType::JIT,        "JIT"},
-	{LogType::LOADER,     "LOADER"},
-	{LogType::ME,         "ME"},  // Media Engine
-	{LogType::MEMMAP,     "MEMMAP"},
-	{LogType::SASMIX,     "SASMIX"},
-	{LogType::SAVESTATE,  "SAVESTATE"},
-	{LogType::FRAMEBUF,   "FRAMEBUF"},
-	{LogType::AUDIO,      "AUDIO"},
-	{LogType::IO,         "IO"},
-
-	{LogType::SCEAUDIO,   "SCEAUDIO"},
-	{LogType::SCECTRL,    "SCECTRL"},
-	{LogType::SCEDISPLAY, "SCEDISP"},
-	{LogType::SCEFONT,    "SCEFONT"},
-	{LogType::SCEGE,      "SCEGE"},
-	{LogType::SCEINTC,    "SCEINTC"},
-	{LogType::SCEIO,      "SCEIO"},
-	{LogType::SCEKERNEL,  "SCEKERNEL"},
-	{LogType::SCEMODULE,  "SCEMODULE"},
-	{LogType::SCENET,     "SCENET"},
-	{LogType::SCERTC,     "SCERTC"},
-	{LogType::SCESAS,     "SCESAS"},
-	{LogType::SCEUTILITY, "SCEUTIL"},
-	{LogType::SCEMISC,    "SCEMISC"},
+	"SCEAUDIO",
+	"SCECTRL",
+	"SCEDISP",
+	"SCEFONT",
+	"SCEGE",
+	"SCEINTC",
+	"SCEIO",
+	"SCEKERNEL",
+	"SCEMODULE",
+	"SCENET",
+	"SCERTC",
+	"SCESAS",
+	"SCEUTIL",
+	"SCEMISC",
 };
 
 LogManager::LogManager(bool *enabledSetting) {
 	g_bLogEnabledSetting = enabledSetting;
 
-	for (size_t i = 0; i < ARRAY_SIZE(logTable); i++) {
-		_assert_msg_((LogType)i == logTable[i].logType, "Bad logtable at %i", (int)i);
-		truncate_cpy(log_[(size_t)logTable[i].logType].m_shortName, logTable[i].name);
-		log_[(size_t)logTable[i].logType].enabled = true;
+	_dbg_assert_(ARRAY_SIZE(g_logTypeNames) == (size_t)LogType::NUMBER_OF_LOGS);
+
+	for (size_t i = 0; i < ARRAY_SIZE(g_logTypeNames); i++) {
+		truncate_cpy(log_[i].m_shortName, g_logTypeNames[i]);
+		log_[i].enabled = true;
 #if defined(_DEBUG)
-		log_[(size_t)logTable[i].logType].level = LogLevel::LDEBUG;
+		log_[i].level = LogLevel::LDEBUG;
 #else
-		log_[(size_t)logTable[i].logType].level = LogLevel::LINFO;
+		log_[i].level = LogLevel::LINFO;
 #endif
 	}
 

--- a/Common/LogManager.h
+++ b/Common/LogManager.h
@@ -37,7 +37,7 @@ extern const char *hleCurrentThreadName;
 struct LogMessage {
 	char timestamp[16];
 	char header[64];  // Filename/thread/etc. in front.
-	LogTypes::LOG_LEVELS level;
+	LogLevel level;
 	const char *log;
 	std::string msg;  // The actual log message.
 };
@@ -83,7 +83,7 @@ public:
 
 	int GetCount() const { return count_ < MAX_LOGS ? count_ : MAX_LOGS; }
 	const char *TextAt(int i) const { return messages_[(curMessage_ - i - 1) & (MAX_LOGS - 1)].msg.c_str(); }
-	LogTypes::LOG_LEVELS LevelAt(int i) const { return messages_[(curMessage_ - i - 1) & (MAX_LOGS - 1)].level; }
+	LogLevel LevelAt(int i) const { return messages_[(curMessage_ - i - 1) & (MAX_LOGS - 1)].level; }
 
 private:
 	enum { MAX_LOGS = 128 };
@@ -99,7 +99,7 @@ private:
 
 struct LogChannel {
 	char m_shortName[32]{};
-	LogTypes::LOG_LEVELS level;
+	LogLevel level;
 	bool enabled;
 };
 
@@ -114,7 +114,7 @@ private:
 	LogManager(const LogManager &) = delete;
 	void operator=(const LogManager &) = delete;
 
-	LogChannel log_[LogTypes::NUMBER_OF_LOGS];
+	LogChannel log_[(size_t)LogType::NUMBER_OF_LOGS];
 	FileLogListener *fileLog_ = nullptr;
 	ConsoleListener *consoleLog_ = nullptr;
 	OutputDebugStringLogListener *debuggerLog_ = nullptr;
@@ -128,33 +128,33 @@ public:
 	void AddListener(LogListener *listener);
 	void RemoveListener(LogListener *listener);
 
-	static u32 GetMaxLevel() { return MAX_LOGLEVEL;	}
-	static int GetNumChannels() { return LogTypes::NUMBER_OF_LOGS; }
+	static u32 GetMaxLevel() { return (u32)MAX_LOGLEVEL;	}
+	static int GetNumChannels() { return (int)LogType::NUMBER_OF_LOGS; }
 
-	void Log(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type, 
+	void Log(LogLevel level, LogType type,
 			 const char *file, int line, const char *fmt, va_list args);
-	bool IsEnabled(LogTypes::LOG_LEVELS level, LogTypes::LOG_TYPE type);
+	bool IsEnabled(LogLevel level, LogType type);
 
-	LogChannel *GetLogChannel(LogTypes::LOG_TYPE type) {
-		return &log_[type];
+	LogChannel *GetLogChannel(LogType type) {
+		return &log_[(size_t)type];
 	}
 
-	void SetLogLevel(LogTypes::LOG_TYPE type, LogTypes::LOG_LEVELS level) {
-		log_[type].level = level;
+	void SetLogLevel(LogType type, LogLevel level) {
+		log_[(size_t)type].level = level;
 	}
 
-	void SetAllLogLevels(LogTypes::LOG_LEVELS level) {
-		for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; ++i) {
+	void SetAllLogLevels(LogLevel level) {
+		for (int i = 0; i < (int)LogType::NUMBER_OF_LOGS; ++i) {
 			log_[i].level = level;
 		}
 	}
 
-	void SetEnabled(LogTypes::LOG_TYPE type, bool enable) {
-		log_[type].enabled = enable;
+	void SetEnabled(LogType type, bool enable) {
+		log_[(size_t)type].enabled = enable;
 	}
 
-	LogTypes::LOG_LEVELS GetLogLevel(LogTypes::LOG_TYPE type) {
-		return log_[type].level;
+	LogLevel GetLogLevel(LogType type) {
+		return log_[(size_t)type].level;
 	}
 
 	ConsoleListener *GetConsoleListener() const {

--- a/Core/Debugger/WebSocket.cpp
+++ b/Core/Debugger/WebSocket.cpp
@@ -160,14 +160,14 @@ void HandleDebuggerRequest(const http::ServerRequest &request) {
 	ws->SetTextHandler([&](const std::string &t) {
 		JsonReader reader(t.c_str(), t.size());
 		if (!reader.ok()) {
-			ws->Send(DebuggerErrorEvent("Bad message: invalid JSON", LogTypes::LERROR));
+			ws->Send(DebuggerErrorEvent("Bad message: invalid JSON", LogLevel::LERROR));
 			return;
 		}
 
 		const JsonGet root = reader.root();
 		const char *event = root ? root.getString("event", nullptr) : nullptr;
 		if (!event) {
-			ws->Send(DebuggerErrorEvent("Bad message: no event property", LogTypes::LERROR, root));
+			ws->Send(DebuggerErrorEvent("Bad message: no event property", LogLevel::LERROR, root));
 			return;
 		}
 
@@ -185,7 +185,7 @@ void HandleDebuggerRequest(const http::ServerRequest &request) {
 		}
 	});
 	ws->SetBinaryHandler([&](const std::vector<uint8_t> &d) {
-		ws->Send(DebuggerErrorEvent("Bad message", LogTypes::LERROR));
+		ws->Send(DebuggerErrorEvent("Bad message", LogLevel::LERROR));
 	});
 
 	while (ws->Process(highActivity ? 1.0f / 1000.0f : 1.0f / 60.0f)) {

--- a/Core/Debugger/WebSocket/LogBroadcaster.cpp
+++ b/Core/Debugger/WebSocket/LogBroadcaster.cpp
@@ -95,7 +95,7 @@ struct DebuggerLogEvent {
 		j.writeString("timestamp", l.timestamp);
 		j.writeString("header", l.header);
 		j.writeString("message", l.msg);
-		j.writeInt("level", l.level);
+		j.writeInt("level", (int)l.level);
 		j.writeString("channel", l.log);
 		j.end();
 		return j.str();

--- a/Core/Debugger/WebSocket/WebSocketUtils.h
+++ b/Core/Debugger/WebSocket/WebSocketUtils.h
@@ -42,7 +42,7 @@ struct WebSocketClientInfo {
 };
 
 struct DebuggerErrorEvent {
-	DebuggerErrorEvent(const std::string m, LogTypes::LOG_LEVELS l, const JsonGet data = JsonValue(JSON_NULL))
+	DebuggerErrorEvent(const std::string m, LogLevel l, const JsonGet data = JsonValue(JSON_NULL))
 		: message(m), level(l) {
 		// Need to format right away, before it's out of scope.
 		if (data) {
@@ -53,7 +53,7 @@ struct DebuggerErrorEvent {
 	}
 
 	std::string message;
-	LogTypes::LOG_LEVELS level;
+	LogLevel level;
 	std::string ticketRaw;
 
 	operator std::string() const {
@@ -61,7 +61,7 @@ struct DebuggerErrorEvent {
 		j.begin();
 		j.writeString("event", "error");
 		j.writeString("message", message);
-		j.writeInt("level", level);
+		j.writeInt("level", (int)level);
 		if (!ticketRaw.empty()) {
 			j.writeRaw("ticket", ticketRaw);
 		}
@@ -88,7 +88,7 @@ struct DebuggerRequest {
 	WebSocketClientInfo *client;
 
 	void Fail(const std::string &message) {
-		ws->Send(DebuggerErrorEvent(message, LogTypes::LERROR, data));
+		ws->Send(DebuggerErrorEvent(message, LogLevel::LERROR, data));
 		responseSent_ = true;
 	}
 

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -813,7 +813,7 @@ bool VirtualDiscFileSystem::RemoveFile(const std::string &filename)
 	return false;
 }
 
-void VirtualDiscFileSystem::HandlerLogger(void *arg, HandlerHandle handle, LogTypes::LOG_LEVELS level, const char *msg) {
+void VirtualDiscFileSystem::HandlerLogger(void *arg, HandlerHandle handle, LogLevel level, const char *msg) {
 	VirtualDiscFileSystem *sys = static_cast<VirtualDiscFileSystem *>(arg);
 
 	// TODO: Probably could do this smarter / use a lookup.
@@ -826,9 +826,9 @@ void VirtualDiscFileSystem::HandlerLogger(void *arg, HandlerHandle handle, LogTy
 	}
 
 	if (filename != NULL) {
-		GENERIC_LOG(LogTypes::FILESYS, level, "%s: %s", filename, msg);
+		GENERIC_LOG(LogType::FILESYS, level, "%s: %s", filename, msg);
 	} else {
-		GENERIC_LOG(LogTypes::FILESYS, level, "%s", msg);
+		GENERIC_LOG(LogType::FILESYS, level, "%s", msg);
 	}
 }
 

--- a/Core/FileSystems/VirtualDiscFileSystem.h
+++ b/Core/FileSystems/VirtualDiscFileSystem.h
@@ -64,9 +64,9 @@ private:
 	typedef void *HandlerLibrary;
 	typedef int HandlerHandle;
 	typedef s64 HandlerOffset;
-	typedef void (*HandlerLogFunc)(void *arg, HandlerHandle handle, LogTypes::LOG_LEVELS level, const char *msg);
+	typedef void (*HandlerLogFunc)(void *arg, HandlerHandle handle, LogLevel level, const char *msg);
 
-	static void HandlerLogger(void *arg, HandlerHandle handle, LogTypes::LOG_LEVELS level, const char *msg);
+	static void HandlerLogger(void *arg, HandlerHandle handle, LogLevel level, const char *msg);
 
 	// The primary purpose of handlers is to make it easier to work with large archives.
 	// However, they have other uses as well, such as patching individual files.

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -853,7 +853,7 @@ size_t hleFormatLogArgs(char *message, size_t sz, const char *argmask) {
 	return used;
 }
 
-void hleDoLogInternal(LogTypes::LOG_TYPE t, LogTypes::LOG_LEVELS level, u64 res, const char *file, int line, const char *reportTag, char retmask, const char *reason, const char *formatted_reason) {
+void hleDoLogInternal(LogType t, LogLevel level, u64 res, const char *file, int line, const char *reportTag, char retmask, const char *reason, const char *formatted_reason) {
 	char formatted_args[4096];
 	const char *funcName = "?";
 	u32 funcFlags = 0;

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -155,11 +155,11 @@ const HLEFunction *GetSyscallFuncPointer(MIPSOpcode op);
 // For jit, takes arg: const HLEFunction *
 void *GetQuickSyscallFunc(MIPSOpcode op);
 
-void hleDoLogInternal(LogTypes::LOG_TYPE t, LogTypes::LOG_LEVELS level, u64 res, const char *file, int line, const char *reportTag, char retmask, const char *reason, const char *formatted_reason);
+void hleDoLogInternal(LogType t, LogLevel level, u64 res, const char *file, int line, const char *reportTag, char retmask, const char *reason, const char *formatted_reason);
 
 template <typename T>
-T hleDoLog(LogTypes::LOG_TYPE t, LogTypes::LOG_LEVELS level, T res, const char *file, int line, const char *reportTag, char retmask, const char *reason, ...) {
-	if (level > MAX_LOGLEVEL || !GenericLogEnabled(level, t)) {
+T hleDoLog(LogType t, LogLevel level, T res, const char *file, int line, const char *reportTag, char retmask, const char *reason, ...) {
+	if ((int)level > MAX_LOGLEVEL || !GenericLogEnabled(level, t)) {
 		return res;
 	}
 
@@ -186,8 +186,8 @@ T hleDoLog(LogTypes::LOG_TYPE t, LogTypes::LOG_LEVELS level, T res, const char *
 }
 
 template <typename T>
-T hleDoLog(LogTypes::LOG_TYPE t, LogTypes::LOG_LEVELS level, T res, const char *file, int line, const char *reportTag, char retmask) {
-	if ((level > MAX_LOGLEVEL || !GenericLogEnabled(level, t)) && !reportTag) {
+T hleDoLog(LogType t, LogLevel level, T res, const char *file, int line, const char *reportTag, char retmask) {
+	if (((int)level > MAX_LOGLEVEL || !GenericLogEnabled(level, t)) && !reportTag) {
 		return res;
 	}
 
@@ -216,7 +216,7 @@ T hleDoLog(LogTypes::LOG_TYPE t, LogTypes::LOG_LEVELS level, T res, const char *
 #define HLE_LOG_LVERBOSE LVERBOSE
 #endif
 
-#define hleLogHelper(t, level, res, retmask, ...) hleDoLog(LogTypes::t, LogTypes::level, res, __FILE__, __LINE__, nullptr, retmask, ##__VA_ARGS__)
+#define hleLogHelper(t, level, res, retmask, ...) hleDoLog(LogType::t, LogLevel::level, res, __FILE__, __LINE__, nullptr, retmask, ##__VA_ARGS__)
 #define hleLogError(t, res, ...) hleLogHelper(t, LERROR, res, 'x', ##__VA_ARGS__)
 #define hleLogWarning(t, res, ...) hleLogHelper(t, LWARNING, res, 'x', ##__VA_ARGS__)
 #define hleLogDebug(t, res, ...) hleLogHelper(t, HLE_LOG_LDEBUG, res, 'x', ##__VA_ARGS__)
@@ -228,7 +228,7 @@ T hleDoLog(LogTypes::LOG_TYPE t, LogTypes::LOG_LEVELS level, T res, const char *
 #define hleLogSuccessVerboseX(t, res, ...) hleLogHelper(t, HLE_LOG_LVERBOSE, res, 'x', ##__VA_ARGS__)
 #define hleLogSuccessVerboseI(t, res, ...) hleLogHelper(t, HLE_LOG_LVERBOSE, res, 'i', ##__VA_ARGS__)
 
-#define hleReportError(t, res, ...) hleDoLog(LogTypes::t, LogTypes::LERROR, res, __FILE__, __LINE__, "", 'x', ##__VA_ARGS__)
-#define hleReportWarning(t, res, ...) hleDoLog(LogTypes::t, LogTypes::LWARNING, res, __FILE__, __LINE__, "", 'x', ##__VA_ARGS__)
-#define hleReportDebug(t, res, ...) hleDoLog(LogTypes::t, LogTypes::HLE_LOG_LDEBUG, res, __FILE__, __LINE__, "", 'x', ##__VA_ARGS__)
-#define hleReportVerbose(t, res, ...) hleDoLog(LogTypes::t, LogTypes::HLE_LOG_LVERBOSE, res, __FILE__, __LINE__, "", 'x', ##__VA_ARGS__)
+#define hleReportError(t, res, ...) hleDoLog(LogType::t, LogLevel::LERROR, res, __FILE__, __LINE__, "", 'x', ##__VA_ARGS__)
+#define hleReportWarning(t, res, ...) hleDoLog(LogType::t, LogLevel::LWARNING, res, __FILE__, __LINE__, "", 'x', ##__VA_ARGS__)
+#define hleReportDebug(t, res, ...) hleDoLog(LogType::t, LogLevel::HLE_LOG_LDEBUG, res, __FILE__, __LINE__, "", 'x', ##__VA_ARGS__)
+#define hleReportVerbose(t, res, ...) hleDoLog(LogType::t, LogLevel::HLE_LOG_LVERBOSE, res, __FILE__, __LINE__, "", 'x', ##__VA_ARGS__)

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "ppsspp_config.h"
+
 #if PPSSPP_ARCH(ARM64)
 
 #include "Common/Profiler/Profiler.h"

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -224,12 +224,12 @@ void LogScreen::UpdateLog() {
 		TextView *v = vert_->Add(new TextView(ring->TextAt(i), FLAG_DYNAMIC_ASCII, false));
 		uint32_t color = 0xFFFFFF;
 		switch (ring->LevelAt(i)) {
-		case LogTypes::LDEBUG: color = 0xE0E0E0; break;
-		case LogTypes::LWARNING: color = 0x50FFFF; break;
-		case LogTypes::LERROR: color = 0x5050FF; break;
-		case LogTypes::LNOTICE: color = 0x30FF30; break;
-		case LogTypes::LINFO: color = 0xFFFFFF; break;
-		case LogTypes::LVERBOSE: color = 0xC0C0C0; break;
+		case LogLevel::LDEBUG: color = 0xE0E0E0; break;
+		case LogLevel::LWARNING: color = 0x50FFFF; break;
+		case LogLevel::LERROR: color = 0x5050FF; break;
+		case LogLevel::LNOTICE: color = 0x30FF30; break;
+		case LogLevel::LINFO: color = 0xFFFFFF; break;
+		case LogLevel::LVERBOSE: color = 0xC0C0C0; break;
 		}
 		v->SetTextColor(0xFF000000 | color);
 	}
@@ -308,7 +308,7 @@ void LogConfigScreen::CreateViews() {
 	GridLayout *grid = vert->Add(new GridLayoutList(gridsettings, new LayoutParams(FILL_PARENT, WRAP_CONTENT)));
 
 	for (int i = 0; i < LogManager::GetNumChannels(); i++) {
-		LogTypes::LOG_TYPE type = (LogTypes::LOG_TYPE)i;
+		LogType type = (LogType)i;
 		LogChannel *chan = logMan->GetLogChannel(type);
 		LinearLayout *row = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(cellSize - 50, WRAP_CONTENT));
 		row->SetSpacing(0);
@@ -321,7 +321,7 @@ void LogConfigScreen::CreateViews() {
 UI::EventReturn LogConfigScreen::OnToggleAll(UI::EventParams &e) {
 	LogManager *logMan = LogManager::GetInstance();
 	for (int i = 0; i < LogManager::GetNumChannels(); i++) {
-		LogChannel *chan = logMan->GetLogChannel((LogTypes::LOG_TYPE)i);
+		LogChannel *chan = logMan->GetLogChannel((LogType)i);
 		chan->enabled = !chan->enabled;
 	}
 	return UI::EVENT_DONE;
@@ -330,7 +330,7 @@ UI::EventReturn LogConfigScreen::OnToggleAll(UI::EventParams &e) {
 UI::EventReturn LogConfigScreen::OnEnableAll(UI::EventParams &e) {
 	LogManager *logMan = LogManager::GetInstance();
 	for (int i = 0; i < LogManager::GetNumChannels(); i++) {
-		LogChannel *chan = logMan->GetLogChannel((LogTypes::LOG_TYPE)i);
+		LogChannel *chan = logMan->GetLogChannel((LogType)i);
 		chan->enabled = true;
 	}
 	return UI::EVENT_DONE;
@@ -339,7 +339,7 @@ UI::EventReturn LogConfigScreen::OnEnableAll(UI::EventParams &e) {
 UI::EventReturn LogConfigScreen::OnDisableAll(UI::EventParams &e) {
 	LogManager *logMan = LogManager::GetInstance();
 	for (int i = 0; i < LogManager::GetNumChannels(); i++) {
-		LogChannel *chan = logMan->GetLogChannel((LogTypes::LOG_TYPE)i);
+		LogChannel *chan = logMan->GetLogChannel((LogType)i);
 		chan->enabled = false;
 	}
 	return UI::EVENT_DONE;
@@ -377,10 +377,10 @@ void LogLevelScreen::OnCompleted(DialogResult result) {
 	LogManager *logMan = LogManager::GetInstance();
 	
 	for (int i = 0; i < LogManager::GetNumChannels(); ++i) {
-		LogTypes::LOG_TYPE type = (LogTypes::LOG_TYPE)i;
+		LogType type = (LogType)i;
 		LogChannel *chan = logMan->GetLogChannel(type);
 		if (chan->enabled)
-			chan->level = (LogTypes::LOG_LEVELS)(selected + 1);
+			chan->level = (LogLevel)(selected + 1);
 	}
 }
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -188,18 +188,18 @@ public:
 	void Log(const LogMessage &message) override {
 		// Log with simplified headers as Android already provides timestamp etc.
 		switch (message.level) {
-		case LogTypes::LVERBOSE:
-		case LogTypes::LDEBUG:
-		case LogTypes::LINFO:
+		case LogLevel::LVERBOSE:
+		case LogLevel::LDEBUG:
+		case LogLevel::LINFO:
 			printf("INFO [%s] %s", message.log, message.msg.c_str());
 			break;
-		case LogTypes::LERROR:
+		case LogLevel::LERROR:
 			printf("ERR  [%s] %s", message.log, message.msg.c_str());
 			break;
-		case LogTypes::LWARNING:
+		case LogLevel::LWARNING:
 			printf("WARN [%s] %s", message.log, message.msg.c_str());
 			break;
-		case LogTypes::LNOTICE:
+		case LogLevel::LNOTICE:
 		default:
 			printf("NOTE [%s] !!! %s", message.log, message.msg.c_str());
 			break;
@@ -567,9 +567,9 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	boot_filename.clear();
 
 	// Parse command line
-	LogTypes::LOG_LEVELS logLevel = LogTypes::LINFO;
+	LogLevel logLevel = LogLevel::LINFO;
 	bool forceLogLevel = false;
-	const auto setLogLevel = [&logLevel, &forceLogLevel](LogTypes::LOG_LEVELS level) {
+	const auto setLogLevel = [&logLevel, &forceLogLevel](LogLevel level) {
 		logLevel = level;
 		forceLogLevel = true;
 	};
@@ -587,12 +587,12 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 			case 'd':
 				// Enable debug logging
 				// Note that you must also change the max log level in Log.h.
-				setLogLevel(LogTypes::LDEBUG);
+				setLogLevel(LogLevel::LDEBUG);
 				break;
 			case 'v':
 				// Enable verbose logging
 				// Note that you must also change the max log level in Log.h.
-				setLogLevel(LogTypes::LVERBOSE);
+				setLogLevel(LogLevel::LVERBOSE);
 				break;
 			case 'j':
 				g_Config.iCpuCore = (int)CPUCore::JIT;
@@ -612,7 +612,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 				break;
 			case '-':
 				if (!strncmp(argv[i], "--loglevel=", strlen("--loglevel=")) && strlen(argv[i]) > strlen("--loglevel="))
-					setLogLevel(static_cast<LogTypes::LOG_LEVELS>(std::atoi(argv[i] + strlen("--loglevel="))));
+					setLogLevel(static_cast<LogLevel>(std::atoi(argv[i] + strlen("--loglevel="))));
 				if (!strncmp(argv[i], "--log=", strlen("--log=")) && strlen(argv[i]) > strlen("--log="))
 					fileToLog = argv[i] + strlen("--log=");
 				if (!strncmp(argv[i], "--state=", strlen("--state=")) && strlen(argv[i]) > strlen("--state="))

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -127,7 +127,7 @@ PPSSPP_UWPMain::PPSSPP_UWPMain(App ^app, const std::shared_ptr<DX::DeviceResourc
 	g_Config.iGPUBackend = (int)GPUBackend::DIRECT3D11;
 
 	if (debugLogLevel) {
-		LogManager::GetInstance()->SetAllLogLevels(LogTypes::LDEBUG);
+		LogManager::GetInstance()->SetAllLogLevels(LogLevel::LDEBUG);
 	}
 
 	// Set log file location

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -972,7 +972,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	LogManager::GetInstance()->GetConsoleListener()->Init(showLog, 150, 120, "PPSSPP Debug Console");
 
 	if (debugLogLevel) {
-		LogManager::GetInstance()->SetAllLogLevels(LogTypes::LDEBUG);
+		LogManager::GetInstance()->SetAllLogLevels(LogLevel::LDEBUG);
 	}
 
 	// This still seems to improve performance noticeably.

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -202,10 +202,10 @@ int utimensat(int fd, const char *path, const struct timespec times[2]) {
 void AndroidLogger::Log(const LogMessage &message) {
 	int mode;
 	switch (message.level) {
-	case LogTypes::LWARNING:
+	case LogLevel::LWARNING:
 		mode = ANDROID_LOG_WARN;
 		break;
-	case LogTypes::LERROR:
+	case LogLevel::LERROR:
 		mode = ANDROID_LOG_ERROR;
 		break;
 	default:

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -70,22 +70,22 @@ class PrintfLogger : public LogListener {
 public:
 	void Log(const LogMessage &message) override {
 		switch (message.level) {
-		case LogTypes::LVERBOSE:
+		case LogLevel::LVERBOSE:
 			fprintf(stderr, "V %s", message.msg.c_str());
 			break;
-		case LogTypes::LDEBUG:
+		case LogLevel::LDEBUG:
 			fprintf(stderr, "D %s", message.msg.c_str());
 			break;
-		case LogTypes::LINFO:
+		case LogLevel::LINFO:
 			fprintf(stderr, "I %s", message.msg.c_str());
 			break;
-		case LogTypes::LERROR:
+		case LogLevel::LERROR:
 			fprintf(stderr, "E %s", message.msg.c_str());
 			break;
-		case LogTypes::LWARNING:
+		case LogLevel::LWARNING:
 			fprintf(stderr, "W %s", message.msg.c_str());
 			break;
-		case LogTypes::LNOTICE:
+		case LogLevel::LNOTICE:
 		default:
 			fprintf(stderr, "N %s", message.msg.c_str());
 			break;
@@ -428,10 +428,10 @@ int main(int argc, const char* argv[])
 
 	PrintfLogger *printfLogger = new PrintfLogger();
 
-	for (int i = 0; i < LogTypes::NUMBER_OF_LOGS; i++) {
-		LogTypes::LOG_TYPE type = (LogTypes::LOG_TYPE)i;
+	for (int i = 0; i < (int)LogType::NUMBER_OF_LOGS; i++) {
+		LogType type = (LogType)i;
 		logman->SetEnabled(type, fullLog);
-		logman->SetLogLevel(type, LogTypes::LDEBUG);
+		logman->SetLogLevel(type, LogLevel::LDEBUG);
 	}
 	logman->AddListener(printfLogger);
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -239,22 +239,22 @@ class PrintfLogger : public LogListener
       {
          switch (message.level)
          {
-            case LogTypes::LVERBOSE:
-            case LogTypes::LDEBUG:
+            case LogLevel::LVERBOSE:
+            case LogLevel::LDEBUG:
                log_(RETRO_LOG_DEBUG, "[%s] %s",
                      message.log, message.msg.c_str());
                break;
 
-            case LogTypes::LERROR:
+            case LogLevel::LERROR:
                log_(RETRO_LOG_ERROR, "[%s] %s",
                      message.log, message.msg.c_str());
                break;
-            case LogTypes::LNOTICE:
-            case LogTypes::LWARNING:
+            case LogLevel::LNOTICE:
+            case LogLevel::LWARNING:
                log_(RETRO_LOG_WARN, "[%s] %s",
                      message.log, message.msg.c_str());
                break;
-            case LogTypes::LINFO:
+            case LogLevel::LINFO:
             default:
                log_(RETRO_LOG_INFO, "[%s] %s",
                      message.log, message.msg.c_str());
@@ -1081,7 +1081,7 @@ void retro_init(void)
       logman->RemoveListener(logman->GetDebuggerListener());
       logman->ChangeFileLog(nullptr);
       logman->AddListener(printfLogger);
-      logman->SetAllLogLevels(LogTypes::LINFO);
+      logman->SetAllLogLevels(LogLevel::LINFO);
    }
 
    g_Config.Load("", "");


### PR DESCRIPTION
Just a small cleanup I've wanted to do for a long time. Good to do before making changes.