### PR TITLE
RetroAchievements: Warn the user if has token and not logged in on start of game

### DIFF
--- a/Core/RetroAchievements.cpp
+++ b/Core/RetroAchievements.cpp
@@ -695,6 +695,10 @@ void SetGame(const Path &path, FileLoader *fileLoader) {
 	}
 
 	if (!g_rcClient || !IsLoggedIn()) {
+		if (HasToken()) {
+			auto ac = GetI18NCategory(I18NCat::ACHIEVEMENTS);
+			g_OSD.Show(OSDType::MESSAGE_WARNING, ac->T("RetroAchievements: Not logged in! Achievements will not unlock."));
+		}
 		// Nothing to do.
 		return;
 	}


### PR DESCRIPTION
This can happen if the internet connection was down when PPSSPP was being started.

Next, separately from this, I'll add retries when not in-game.