### PR TITLE
Add *.ctags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ Windows/*.ipch
 # For vim
 *.swp
 tags
+*.ctags
 
 # Other VCS
 .bzr/


### PR DESCRIPTION
Allows to keep ctags option file in-tree.