### PR TITLE
x86jit: Improve vdot performance

### DIFF
--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -394,6 +394,7 @@ struct IROptions {
 	bool unalignedLoadStore;
 	bool unalignedLoadStoreVec4;
 	bool preferVec4;
+	bool preferVec4Dot;
 };
 
 const IRMeta *GetIRMeta(IROp op);


### PR DESCRIPTION
I'd assumed that `lv.q; vdot.t; sv.q` would be a case we'd want to optimize to keep things in a Vec4, but dot products are so slow on x86 that it's just better to use three FMuls and FAdds.  LittleBigPlanet gets around 8% faster with these changes.

I kept the path so we can try it on NEON or RISC-V vector.

-[Unknown]