### PR TITLE
x86jit: Implement trig instructions, couple other FPU

### DIFF
--- a/Common/x64Emitter.cpp
+++ b/Common/x64Emitter.cpp
@@ -1689,6 +1689,9 @@ void XEmitter::CVTTPD2DQ(X64Reg regOp, OpArg arg) {WriteSSEOp(0x66, 0xE6, regOp,
 
 void XEmitter::MASKMOVDQU(X64Reg dest, X64Reg src)  {WriteSSEOp(0x66, sseMASKMOVDQU, dest, R(src));}
 
+void XEmitter::MOVSHDUP(X64Reg regOp, OpArg arg) { WriteSSEOp(0xF3, sseMOVHPfromRM, regOp, arg); }
+void XEmitter::MOVSLDUP(X64Reg regOp, OpArg arg) { WriteSSEOp(0xF3, sseMOVLPfromRM, regOp, arg); }
+
 void XEmitter::MOVMSKPS(X64Reg dest, OpArg arg) {WriteSSEOp(0x00, 0x50, dest, arg);}
 void XEmitter::MOVMSKPD(X64Reg dest, OpArg arg) {WriteSSEOp(0x66, 0x50, dest, arg);}
 

--- a/Common/x64Emitter.h
+++ b/Common/x64Emitter.h
@@ -746,6 +746,10 @@ public:
 	void MOVD_xmm(const OpArg &arg, X64Reg src);
 	void MOVQ_xmm(OpArg arg, X64Reg src);
 
+	// SSE3: Some additional moves.
+	void MOVSHDUP(X64Reg regOp1, OpArg arg);
+	void MOVSLDUP(X64Reg regOp1, OpArg arg);
+
 	// SSE/SSE2: Generates a mask from the high bits of the components of the packed register in question.
 	void MOVMSKPS(X64Reg dest, OpArg arg);
 	void MOVMSKPD(X64Reg dest, OpArg arg);

--- a/Core/MIPS/IR/IRRegCache.cpp
+++ b/Core/MIPS/IR/IRRegCache.cpp
@@ -159,6 +159,15 @@ bool IRNativeRegCacheBase::IsFPRMapped(IRReg fpr) {
 	return mr[fpr + 32].loc == MIPSLoc::FREG || mr[fpr + 32].loc == MIPSLoc::VREG;
 }
 
+int IRNativeRegCacheBase::GetFPRLane(IRReg fpr) {
+	_dbg_assert_(IsValidFPR(fpr));
+	if (mr[fpr + 32].loc == MIPSLoc::FREG || mr[fpr + 32].loc == MIPSLoc::VREG) {
+		int l = mr[fpr + 32].lane;
+		return l == -1 ? 0 : l;
+	}
+	return -1;
+}
+
 bool IRNativeRegCacheBase::IsGPRMappedAsPointer(IRReg gpr) {
 	_dbg_assert_(IsValidGPR(gpr));
 	if (mr[gpr].loc == MIPSLoc::REG) {

--- a/Core/MIPS/IR/IRRegCache.cpp
+++ b/Core/MIPS/IR/IRRegCache.cpp
@@ -159,6 +159,25 @@ bool IRNativeRegCacheBase::IsFPRMapped(IRReg fpr) {
 	return mr[fpr + 32].loc == MIPSLoc::FREG || mr[fpr + 32].loc == MIPSLoc::VREG;
 }
 
+int IRNativeRegCacheBase::GetFPRLaneCount(IRReg fpr) {
+	if (!IsFPRMapped(fpr) || mr[fpr].lane > 0)
+		return 0;
+	if (mr[fpr].lane == -1)
+		return 1;
+
+	int c = 1;
+	for (int i = 1; i < 4; ++i) {
+		if (mr[fpr + i].nReg != mr[fpr].nReg || mr[fpr + i].loc != mr[fpr].loc)
+			return c;
+		if (mr[fpr + i].lane != i)
+			return c;
+
+		c++;
+	}
+
+	return c;
+}
+
 int IRNativeRegCacheBase::GetFPRLane(IRReg fpr) {
 	_dbg_assert_(IsValidFPR(fpr));
 	if (mr[fpr + 32].loc == MIPSLoc::FREG || mr[fpr + 32].loc == MIPSLoc::VREG) {

--- a/Core/MIPS/IR/IRRegCache.h
+++ b/Core/MIPS/IR/IRRegCache.h
@@ -164,6 +164,7 @@ public:
 	bool IsGPRMappedAsPointer(IRReg gpr);
 	bool IsGPRMappedAsStaticPointer(IRReg gpr);
 	int GetFPRLane(IRReg fpr);
+	int GetFPRLaneCount(IRReg fpr);
 
 	bool IsGPRImm(IRReg gpr);
 	bool IsGPR2Imm(IRReg base);

--- a/Core/MIPS/IR/IRRegCache.h
+++ b/Core/MIPS/IR/IRRegCache.h
@@ -163,6 +163,7 @@ public:
 	bool IsFPRMapped(IRReg fpr);
 	bool IsGPRMappedAsPointer(IRReg gpr);
 	bool IsGPRMappedAsStaticPointer(IRReg gpr);
+	int GetFPRLane(IRReg fpr);
 
 	bool IsGPRImm(IRReg gpr);
 	bool IsGPR2Imm(IRReg base);

--- a/Core/MIPS/RiscV/RiscVCompFPU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompFPU.cpp
@@ -578,9 +578,10 @@ void RiscVJitBackend::CompIR_FSpecial(IRInst inst) {
 #error Currently hard float is required.
 #endif
 
-	auto callFuncF_F = [&](float (*func)(float)){
+	auto callFuncF_F = [&](float (*func)(float)) {
 		regs_.FlushBeforeCall();
 		// It might be in a non-volatile register.
+		// TODO: May have to handle a transfer if SIMD here.
 		if (regs_.IsFPRMapped(inst.src1)) {
 			FMV(32, F10, regs_.F(inst.src1));
 		} else {

--- a/Core/MIPS/RiscV/RiscVCompFPU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompFPU.cpp
@@ -115,7 +115,7 @@ void RiscVJitBackend::CompIR_FCondAssign(IRInst inst) {
 			MAX(SCRATCH1, SCRATCH1, SCRATCH2);
 		SetJumpTarget(skipSwapCompare);
 	} else {
-		RiscVReg isSrc1LowerReg = regs_.GetAndLockTempR();
+		RiscVReg isSrc1LowerReg = regs_.GetAndLockTempGPR();
 		SLT(isSrc1LowerReg, SCRATCH1, SCRATCH2);
 		// Flip the flag (to reverse the min/max) based on if both were negative.
 		XOR(isSrc1LowerReg, isSrc1LowerReg, R_RA);

--- a/Core/MIPS/RiscV/RiscVRegCache.cpp
+++ b/Core/MIPS/RiscV/RiscVRegCache.cpp
@@ -235,7 +235,7 @@ RiscVReg RiscVRegCache::TryMapTempImm(IRReg r) {
 	return INVALID_REG;
 }
 
-RiscVReg RiscVRegCache::GetAndLockTempR() {
+RiscVReg RiscVRegCache::GetAndLockTempGPR() {
 	RiscVReg reg = (RiscVReg)AllocateReg(MIPSLoc::REG, MIPSMap::INIT);
 	if (reg != INVALID_REG) {
 		nr[reg].tempLockIRIndex = irIndex_;
@@ -243,7 +243,7 @@ RiscVReg RiscVRegCache::GetAndLockTempR() {
 	return reg;
 }
 
-RiscVReg RiscVRegCache::MapWithFPRTemp(IRInst &inst) {
+RiscVReg RiscVRegCache::MapWithFPRTemp(const IRInst &inst) {
 	return (RiscVReg)MapWithTemp(inst, MIPSLoc::FREG);
 }
 

--- a/Core/MIPS/RiscV/RiscVRegCache.h
+++ b/Core/MIPS/RiscV/RiscVRegCache.h
@@ -51,7 +51,7 @@ public:
 	RiscVGen::RiscVReg MapGPRAsPointer(IRReg reg);
 	RiscVGen::RiscVReg MapFPR(IRReg reg, MIPSMap mapFlags = MIPSMap::INIT);
 
-	RiscVGen::RiscVReg MapWithFPRTemp(IRInst &inst);
+	RiscVGen::RiscVReg MapWithFPRTemp(const IRInst &inst);
 
 	bool IsNormalized32(IRReg reg);
 
@@ -60,7 +60,7 @@ public:
 
 	void FlushBeforeCall();
 
-	RiscVGen::RiscVReg GetAndLockTempR();
+	RiscVGen::RiscVReg GetAndLockTempGPR();
 
 	RiscVGen::RiscVReg R(IRReg preg); // Returns a cached register, while checking that it's NOT mapped as a pointer
 	RiscVGen::RiscVReg RPtr(IRReg preg); // Returns a cached register, if it has been mapped as a pointer

--- a/Core/MIPS/x86/X64IRCompVec.cpp
+++ b/Core/MIPS/x86/X64IRCompVec.cpp
@@ -212,7 +212,14 @@ void X64JitBackend::CompIR_VecAssign(IRInst inst) {
 		break;
 
 	case IROp::Vec4Shuffle:
-		CompIR_Generic(inst);
+		regs_.Map(inst);
+		if (cpu_info.bAVX) {
+			VPERMILPS(128, regs_.FX(inst.dest), regs_.F(inst.src1), inst.src2);
+		} else {
+			if (inst.dest != inst.src1)
+				MOVAPS(regs_.FX(inst.dest), regs_.F(inst.src1));
+			SHUFPS(regs_.FX(inst.dest), regs_.F(inst.dest), inst.src2);
+		}
 		break;
 
 	case IROp::Vec4Blend:

--- a/Core/MIPS/x86/X64IRCompVec.cpp
+++ b/Core/MIPS/x86/X64IRCompVec.cpp
@@ -212,7 +212,13 @@ void X64JitBackend::CompIR_VecAssign(IRInst inst) {
 		break;
 
 	case IROp::Vec4Shuffle:
-		regs_.Map(inst);
+		if (regs_.GetFPRLaneCount(inst.src1) == 1 && (inst.src1 & 3) == 0 && inst.src2 == 0) {
+			// This is a broadcast.  If dest == src1, this won't clear it.
+			regs_.SpillLockFPR(inst.src1);
+			regs_.MapVec4(inst.dest, MIPSMap::NOINIT);
+		} else {
+			regs_.Map(inst);
+		}
 		if (cpu_info.bAVX) {
 			VPERMILPS(128, regs_.FX(inst.dest), regs_.F(inst.src1), inst.src2);
 		} else {

--- a/Core/MIPS/x86/X64IRJit.h
+++ b/Core/MIPS/x86/X64IRJit.h
@@ -32,7 +32,7 @@
 #if PPSSPP_PLATFORM(WINDOWS) && (defined(_MSC_VER) || defined(__clang__) || defined(__INTEL_COMPILER))
 #define X64JIT_XMM_CALL __vectorcall
 #define X64JIT_USE_XMM_CALL 1
-#elif PPSSPP_ARCH(AMD64) && !PPSSPP_PLATFORM(WINDOWS)
+#elif PPSSPP_ARCH(AMD64)
 // SystemV ABI supports XMM registers.
 #define X64JIT_XMM_CALL
 #define X64JIT_USE_XMM_CALL 1

--- a/Core/MIPS/x86/X64IRRegCache.cpp
+++ b/Core/MIPS/x86/X64IRRegCache.cpp
@@ -103,6 +103,13 @@ const int *X64IRRegCache::GetAllocationOrder(MIPSLoc type, MIPSMap flags, int &c
 #endif
 		};
 
+		if ((flags & X64Map::MASK) == X64Map::XMM0) {
+			// Certain cases require this reg.
+			static const int blendReg[] = { XMM0 };
+			count = 1;
+			return blendReg;
+		}
+
 		count = ARRAY_SIZE(allocationOrder);
 		return allocationOrder;
 	} else {
@@ -236,6 +243,11 @@ void X64IRRegCache::MapWithFlags(IRInst inst, X64Map destFlags, X64Map src1Flags
 		case X64Map::HIGH_DATA:
 			if (nr[RDX].mipsReg != mapping[i].reg)
 				flushReg(RDX);
+			break;
+
+		case X64Map::XMM0:
+			if (nr[XMMToNativeReg(XMM0)].mipsReg != mapping[i].reg)
+				flushReg(XMMToNativeReg(XMM0));
 			break;
 
 		default:

--- a/Core/MIPS/x86/X64IRRegCache.cpp
+++ b/Core/MIPS/x86/X64IRRegCache.cpp
@@ -179,12 +179,20 @@ X64Reg X64IRRegCache::TryMapTempImm(IRReg r, X64Map flags) {
 	return INVALID_REG;
 }
 
-X64Reg X64IRRegCache::GetAndLockTempR() {
-	X64Reg reg = FromNativeReg(AllocateReg(MIPSLoc::REG, MIPSMap::INIT));
-	if (reg != INVALID_REG) {
+X64Reg X64IRRegCache::GetAndLockTempGPR() {
+	IRNativeReg reg = AllocateReg(MIPSLoc::REG, MIPSMap::INIT);
+	if (reg != -1) {
 		nr[reg].tempLockIRIndex = irIndex_;
 	}
-	return reg;
+	return FromNativeReg(reg);
+}
+
+X64Reg X64IRRegCache::GetAndLockTempFPR() {
+	IRNativeReg reg = AllocateReg(MIPSLoc::FREG, MIPSMap::INIT);
+	if (reg != -1) {
+		nr[reg].tempLockIRIndex = irIndex_;
+	}
+	return FromNativeReg(reg);
 }
 
 void X64IRRegCache::ReserveAndLockXGPR(Gen::X64Reg r) {
@@ -194,7 +202,7 @@ void X64IRRegCache::ReserveAndLockXGPR(Gen::X64Reg r) {
 	nr[r].tempLockIRIndex = irIndex_;
 }
 
-X64Reg X64IRRegCache::MapWithFPRTemp(IRInst &inst) {
+X64Reg X64IRRegCache::MapWithFPRTemp(const IRInst &inst) {
 	return FromNativeReg(MapWithTemp(inst, MIPSLoc::FREG));
 }
 
@@ -282,7 +290,6 @@ void X64IRRegCache::AdjustNativeRegAsPtr(IRNativeReg nreg, bool state) {
 		emit_->AND(PTRBITS, ::R(r), Imm32(Memory::MEMVIEW32_MASK));
 		emit_->ADD(PTRBITS, ::R(r), ImmPtr(Memory::base));
 #else
-		// Clear the top bits to be safe.
 		emit_->ADD(PTRBITS, ::R(r), ::R(MEMBASEREG));
 #endif
 	} else {

--- a/Core/MIPS/x86/X64IRRegCache.h
+++ b/Core/MIPS/x86/X64IRRegCache.h
@@ -45,10 +45,12 @@ enum class X64Map : uint8_t {
 	NONE = 0,
 	// On 32-bit: EAX, EBX, ECX, EDX
 	LOW_SUBREG = 0x10,
-	// EDX/RDX
+	// EDX/RDX for DIV/MUL/similar.
 	HIGH_DATA = 0x20,
-	// ECX/RCX
+	// ECX/RCX only, for shifts.
 	SHIFT = 0x30,
+	// XMM0 for BLENDVPS, funcs.
+	XMM0 = 0x40,
 	MASK = 0xF0,
 };
 static inline MIPSMap operator |(const MIPSMap &lhs, const X64Map &rhs) {

--- a/Core/MIPS/x86/X64IRRegCache.h
+++ b/Core/MIPS/x86/X64IRRegCache.h
@@ -81,13 +81,14 @@ public:
 	Gen::X64Reg MapFPR(IRReg reg, MIPSMap mapFlags = MIPSMap::INIT);
 	Gen::X64Reg MapVec4(IRReg first, MIPSMap mapFlags = MIPSMap::INIT);
 
-	Gen::X64Reg MapWithFPRTemp(IRInst &inst);
+	Gen::X64Reg MapWithFPRTemp(const IRInst &inst);
 
 	void MapWithFlags(IRInst inst, X64IRJitConstants::X64Map destFlags, X64IRJitConstants::X64Map src1Flags = X64IRJitConstants::X64Map::NONE, X64IRJitConstants::X64Map src2Flags = X64IRJitConstants::X64Map::NONE);
 
 	void FlushBeforeCall();
 
-	Gen::X64Reg GetAndLockTempR();
+	Gen::X64Reg GetAndLockTempGPR();
+	Gen::X64Reg GetAndLockTempFPR();
 	void ReserveAndLockXGPR(Gen::X64Reg r);
 
 	Gen::OpArg R(IRReg preg);


### PR DESCRIPTION
~With this and other recent pulls, LittleBigPlanet now runs faster in x86 IR than in original x86 jit.  I didn't carefully check which took it over the line.  The dot one is definitely necessary but wasn't enough on its own (it's only about 3% faster, though... might be a bit less because I have another change I need to test the pros/cons of a bit better.)~

Actually, another change is needed to make it consistently faster, this makes it sometimes faster and in many places (including in game) about the same.

-[Unknown]