### PR TITLE
After Burner: Black Falcon:  Fix flickering video by enabling vertex depth rounding

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -79,6 +79,11 @@ NPJH50579 = true
 ULJS19069 = true
 NPJH50579 = true
 
+# After Burner: Black Falcon (#8514, only affects video)
+ULUS10244 = true
+ULES00753 = true
+ULES00785 = true
+
 [PixelDepthRounding]
 # Heroes Phantasia requires pixel depth rounding.  #6485 (flickering overlaid sprites)
 NPJH50558 = true


### PR DESCRIPTION
Working workaround, don't see any obvious negative effects so let's just go with it, this has been sitting around long enough.

Fixes #8514 