### PR TITLE
x86jit: A few more ops, float literal pool

### DIFF
--- a/Core/MIPS/x86/X64IRAsm.cpp
+++ b/Core/MIPS/x86/X64IRAsm.cpp
@@ -280,6 +280,9 @@ void X64JitBackend::GenerateFixedCode(MIPSState *mipsState) {
 #endif
 	}
 
+	EmitFPUConstants();
+	EmitVecConstants();
+
 	// Let's spare the pre-generated code from unprotect-reprotect.
 	AlignCodePage();
 	jitStartOffset_ = (int)(GetCodePtr() - start);

--- a/Core/MIPS/x86/X64IRJit.cpp
+++ b/Core/MIPS/x86/X64IRJit.cpp
@@ -337,6 +337,12 @@ void X64JitBackend::LoadStaticRegisters() {
 	}
 }
 
+void X64JitBackend::EmitConst4x32(const void **c, uint32_t v) {
+	*c = AlignCode16();
+	for (int i = 0; i < 4; ++i)
+		Write32(v);
+}
+
 } // namespace MIPSComp
 
 #endif

--- a/Core/MIPS/x86/X64IRJit.h
+++ b/Core/MIPS/x86/X64IRJit.h
@@ -144,7 +144,8 @@ private:
 		const void *noSignMask;
 		const void *signBitAll;
 		const void *positiveInfinity;
-		const void *ones;
+		const void *positiveOnes;
+		const void *negativeOnes;
 		const void *qNAN;
 		const float *mulTableVi2f;
 		const Float4Constant *vec4InitValues;

--- a/Core/MIPS/x86/X64IRJit.h
+++ b/Core/MIPS/x86/X64IRJit.h
@@ -119,6 +119,10 @@ private:
 	void CompIR_VecStore(IRInst inst) override;
 	void CompIR_ValidateAddress(IRInst inst) override;
 
+	void EmitConst4x32(const void **c, uint32_t v);
+	void EmitFPUConstants();
+	void EmitVecConstants();
+
 	Gen::OpArg PrepareSrc1Address(IRInst inst);
 
 	JitOptions &jo;
@@ -134,6 +138,18 @@ private:
 
 	const u8 *saveStaticRegisters_ = nullptr;
 	const u8 *loadStaticRegisters_ = nullptr;
+
+	typedef struct { float f[4]; } Float4Constant;
+	struct Constants {
+		const void *noSignMask;
+		const void *signBitAll;
+		const void *positiveInfinity;
+		const void *ones;
+		const void *qNAN;
+		const float *mulTableVi2f;
+		const Float4Constant *vec4InitValues;
+	};
+	Constants constants;
 
 	int jitStartOffset_ = 0;
 	int compilingBlockNum_ = -1;


### PR DESCRIPTION
The literal pool doesn't really do anything for perf usually, it just makes the code simpler on all the usages.

I've seen some slightly hot code that does q integer conversions or Vec4 saturates, so it's probably worth playing with Vec4ing some of those but not sure yet.

Anyway, these are just a few things seen while I checked a few other games to see the impacts of my Vec4 pass.

-[Unknown]