### PR TITLE
Enable [DisallowFramebufferAtOffset] for WWE SvR 2006.

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1507,6 +1507,11 @@ UCJS10107 = true
 NPJG00073 = true
 UCAS40262 = true
 
+# WWE Smackdown vs RAW 2006 : See #13797
+ULES00227 = true
+ULKS46057 = true
+ULUS10050 = true
+
 [RockmanDash2SoundFix]
 # Rockman Dash 2, see #11442
 ULJM05037 = true


### PR DESCRIPTION
The game renders some audience members into sprites to individual render targets out in the "stride border" of one of the main framebuffers, and then textures from that to actually then place them in the scene.

We would accidentally expand one of the main framebuffers to accomodate for drawing one of the sprites, but not the others. This cause a lot of badness like repeated texturing from the framebuffer being rendered to every other frame, and some other confusion.

Simply enabling this compat flag that I created recently for a somewhat similar situation in LBP (see #16520 ) fixes it. Though, I'm not 100% happy that our other framebuffer management is unable to handle the wacky situation that merging one of the sprites with the main framebuffer caused.

Fixes #13797

Fixes #13822