### PR TITLE
Revert unnecessary log changes

### DIFF
--- a/Common/Data/Format/IniFile.cpp
+++ b/Common/Data/Format/IniFile.cpp
@@ -403,18 +403,6 @@ std::map<std::string, std::string> Section::ToMap() const
 	return outMap;
 }
 
-std::vector<std::pair<std::string, std::string>> Section::ToVec() const {
-	std::vector<std::pair<std::string, std::string>> outVec;
-	for (std::vector<std::string>::const_iterator iter = lines.begin(); iter != lines.end(); ++iter)
-	{
-		std::string lineKey, lineValue;
-		if (ParseLine(*iter, &lineKey, &lineValue, NULL)) {
-			outVec.push_back(std::pair<std::string, std::string>(lineKey, lineValue));
-		}
-	}
-	return outVec;
-}
-
 bool Section::Delete(const char *key)
 {
 	std::string* line = GetLine(key, 0, 0);

--- a/Common/Data/Format/IniFile.h
+++ b/Common/Data/Format/IniFile.h
@@ -28,7 +28,6 @@ public:
 	void Clear();
 
 	std::map<std::string, std::string> ToMap() const;
-	std::vector<std::pair<std::string, std::string>> ToVec() const;  // Often more appropriate than ToMap() - doesn't artifically remove duplicates.
 
 	std::string *GetLine(const char* key, std::string* valueOut, std::string* commentOut);
 	const std::string *GetLine(const char* key, std::string* valueOut, std::string* commentOut) const;

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -232,7 +232,7 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverri
 	std::string badFilenames;
 
 	if (ini.HasSection("hashes")) {
-		auto hashes = ini.GetOrCreateSection("hashes")->ToVec();
+		auto hashes = ini.GetOrCreateSection("hashes")->ToMap();
 		// Format: hashname = filename.png
 		bool checkFilenames = g_Config.bSaveNewTextures && !g_Config.bIgnoreTextureFilenames && !vfsIsZip_;
 
@@ -242,10 +242,7 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverri
 			// sscanf doesn't write to non-matched outputs.
 			int level = 0;
 			if (sscanf(item.first.c_str(), "%16llx%8x_%d", &key.cachekey, &key.hash, &level) >= 1) {
-				if (item.second.empty()) {
-					WARN_LOG(G3D, "Texture replacement: Ignoring hash mapping to empty filename: '%s ='", item.first.c_str());
-					continue;
-				}
+				// We allow empty filenames, to mark textures that we don't want to keep saving.
 				filenameMap[key][level] = item.second;
 				if (checkFilenames) {
 					// TODO: We should check for the union of these on all platforms, really.

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -454,6 +454,8 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		plan.levelsToCreate = plan.maxPossibleLevels;
 	}
 
+	_dbg_assert_(plan.levelsToCreate >= plan.levelsToLoad);
+
 	// Any texture scaling is gonna move away from the original 16-bit format, if any.
 	VkFormat actualFmt = plan.scaleFactor > 1 ? VULKAN_8888_FORMAT : dstFmt;
 	bool bcFormat = false;


### PR DESCRIPTION
Address some of the feedback from #18001 .

Will remove the need to compat-flag the US/EU versions of the game at a later date, I have a plan for that. I might also make it work for the JP version that actually uses multiple layers.