### PR TITLE
Detect the simplest Tactics Ogre case (US/EU) early

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -199,10 +199,6 @@ SamplerCacheKey TextureCacheCommon::GetSamplingParams(int maxLevel, const TexCac
 
 	// If mip level is forced to zero, disable mipmapping.
 	bool noMip = maxLevel == 0 || (!autoMip && lodBias <= 0.0f);
-	if (IsFakeMipmapChange()) {
-		noMip = noMip || !autoMip;
-	}
-
 	if (noMip) {
 		// Enforce no mip filtering, for safety.
 		key.mipEnable = false;
@@ -2786,8 +2782,8 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 
 		// Check early for the degenerate case from Tactics Ogre.
 		if (pure3D && plan.levelsToLoad == 2 && gstate.getTextureAddress(0) == gstate.getTextureAddress(1)) {
-			// Simply treat it as a regular 2D texture, no fake mipmaps or anything
-			plan.levelsToLoad = 1;
+			// Simply treat it as a regular 2D texture, no fake mipmaps or anything.
+			// levelsToLoad/Create gets set to 1 on the way out from the surrounding if.
 			isFakeMipmapChange = false;
 			pure3D = false;
 		} else if (isFakeMipmapChange) {

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2777,15 +2777,22 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 		int tw = gstate.getTextureWidth(0);
 		int th = gstate.getTextureHeight(0);
 		bool pure3D = true;
-		if (!isFakeMipmapChange) {
-			for (int i = 0; i < plan.levelsToLoad; i++) {
-				if (gstate.getTextureWidth(i) != gstate.getTextureWidth(0) || gstate.getTextureHeight(i) != gstate.getTextureHeight(0)) {
-					pure3D = false;
-					break;
-				}
+		for (int i = 0; i < plan.levelsToLoad; i++) {
+			if (gstate.getTextureWidth(i) != gstate.getTextureWidth(0) || gstate.getTextureHeight(i) != gstate.getTextureHeight(0)) {
+				pure3D = false;
+				break;
 			}
-		} else {
+		}
+
+		// Check early for the degenerate case from Tactics Ogre.
+		if (pure3D && plan.levelsToLoad == 2 && gstate.getTextureAddress(0) == gstate.getTextureAddress(1)) {
+			// Simply treat it as a regular 2D texture, no fake mipmaps or anything
+			plan.levelsToLoad = 1;
+			isFakeMipmapChange = false;
+			pure3D = false;
+		} else if (isFakeMipmapChange) {
 			// We don't want to create a volume texture, if this is a "fake mipmap change".
+			// In practice due to the compat flag, the only time we end up here is in JP Tactics Ogre.
 			pure3D = false;
 		}
 

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -269,11 +269,7 @@ ULJM06365 = true
 ULJM05753 = true
 NPJH50348 = true
 ULJM06009 = true
-
-# Tactics Ogre (US, EU). See #17491 / #17980
-# Required for texture replacement to work correctly, though unlike JP, only one layer is actually used (two duplicates, really)
-ULUS10565 = true
-ULES01500 = true
+# We handle the US/EU versions by detecting its weird use of two identical mipmaps and treating it as a normal 2D texture (#17491 / #17980)
 
 [RequireBufferedRendering]
 # Warn the user that the game will not work and have issue, if buffered rendering is not enabled.


### PR DESCRIPTION
Removes the need for the compat.ini flag for these versions, since we can just treat the texture exactly as a regular 2D texture from there on.

Followup to #18001 , better alternative.
