### PR TITLE
Vulkan: Don't use the present time extensions (but keep the code around for future experiments)

### DIFF
--- a/Common/GPU/Vulkan/VulkanFrameData.h
+++ b/Common/GPU/Vulkan/VulkanFrameData.h
@@ -55,8 +55,9 @@ struct FrameDataShared {
 	// For synchronous readbacks.
 	VkFence readbackFence = VK_NULL_HANDLE;
 	bool useMultiThreading;
+	bool measurePresentTime;
 
-	void Init(VulkanContext *vulkan, bool useMultiThreading);
+	void Init(VulkanContext *vulkan, bool useMultiThreading, bool measurePresentTime);
 	void Destroy(VulkanContext *vulkan);
 };
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -25,9 +25,6 @@
 #define UINT64_MAX 0xFFFFFFFFFFFFFFFFULL
 #endif
 
-
-#define USE_PRESENT_WAIT 0
-
 using namespace PPSSPP_VK;
 
 // renderPass is an example of the "compatibility class" or RenderPassType type.
@@ -260,7 +257,10 @@ VulkanRenderManager::VulkanRenderManager(VulkanContext *vulkan, bool useThread, 
 {
 	inflightFramesAtStart_ = vulkan_->GetInflightFrames();
 
-	frameDataShared_.Init(vulkan, useThread);
+	// For present timing experiments. Disabled for now.
+	measurePresentTime_ = false;
+
+	frameDataShared_.Init(vulkan, useThread, measurePresentTime_);
 
 	for (int i = 0; i < inflightFramesAtStart_; i++) {
 		frameData_[i].Init(vulkan, i);
@@ -308,7 +308,7 @@ bool VulkanRenderManager::CreateBackbuffers() {
 		INFO_LOG(G3D, "Starting Vulkan compiler thread");
 		compileThread_ = std::thread(&VulkanRenderManager::CompileThreadFunc, this);
 
-		if (USE_PRESENT_WAIT && vulkan_->Extensions().KHR_present_wait && vulkan_->GetPresentMode() == VK_PRESENT_MODE_FIFO_KHR) {
+		if (measurePresentTime_ && vulkan_->Extensions().KHR_present_wait && vulkan_->GetPresentMode() == VK_PRESENT_MODE_FIFO_KHR) {
 			INFO_LOG(G3D, "Starting Vulkan present wait thread");
 			presentWaitThread_ = std::thread(&VulkanRenderManager::PresentWaitThreadFunc, this);
 		}

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -495,6 +495,7 @@ private:
 	bool run_ = false;
 
 	bool useRenderThread_ = true;
+	bool measurePresentTime_ = false;
 
 	// This is the offset within this frame, in case of a mid-frame sync.
 	VKRStep *curRenderStep_ = nullptr;


### PR DESCRIPTION
The code will be needed for the advanced parts of #17917 , but we don't use the measurements for anything yet, so let's disable it for the release.

Seen some suspicious crashes on Poco F1.