### PR TITLE
Replace a too-simple heuristic with a compat flag, fixing Castlevania flicker.

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -426,14 +426,6 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(Framebuffer
 			u32 v_fb_end_ptr = v->fb_address + v->fb_stride * v->height * bpp;
 
 			if (params.fb_address > v->fb_address && params.fb_address < v_fb_first_line_end_ptr) {
-				// If the framebuffer we can join to is currently bound as a texture, we likely have
-				// a situation like in #9324 and don't want to do this.
-				u32 curTextureAddress = gstate.getTextureAddress(0);
-				if (v->fb_address == curTextureAddress) {
-					// Don't try these joining shenanigans.
-					continue;
-				}
-
 				const int x_offset = (params.fb_address - v->fb_address) / bpp;
 				if (x_offset < params.fb_stride && v->height >= drawing_height) {
 					// Pretty certainly a pure render-to-X-offset.

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1512,6 +1512,11 @@ ULES00227 = true
 ULKS46057 = true
 ULUS10050 = true
 
+# Rainbow Six: Vegas: See #9324
+# Replaces a heuristic we added in #16971, which broke Castlevania - Symphony of the Night.
+ULES00584 = true
+ULUS10206 = true
+
 [RockmanDash2SoundFix]
 # Rockman Dash 2, see #11442
 ULJM05037 = true


### PR DESCRIPTION
Should fix the flicker in Castlevania: Symphony of the Night.

Fixes #17517

The heuristic from #16971 worked for Rainbow Six but broke Castlevania, so I'd rather use a compat flag instead of breaking a different game until we can find a more reliable heuristic for Rainbow Six.