### PR TITLE
Android: Fix changing display resolution scale in-game

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2622,6 +2622,8 @@ void FramebufferManagerCommon::NotifyDisplayResized() {
 	pixelHeight_ = PSP_CoreParameter().pixelHeight;
 	presentation_->UpdateDisplaySize(pixelWidth_, pixelHeight_);
 
+	INFO_LOG(G3D, "FramebufferManagerCommon::NotifyDisplayResized: %dx%d", pixelWidth_, pixelHeight_);
+
 	// No drawing is allowed here. This includes anything that might potentially touch a command buffer, like creating images!
 	// So we need to defer the post processing initialization.
 	updatePostShaders_ = true;

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -447,6 +447,8 @@ void GPUCommonHW::DeviceLost() {
 // Call at the start of the GPU implementation's DeviceRestore
 void GPUCommonHW::DeviceRestore(Draw::DrawContext *draw) {
 	draw_ = draw;
+	displayResized_ = true;  // re-check display bounds.
+	renderResized_ = true;
 	framebufferManager_->DeviceRestore(draw_);
 	textureCache_->DeviceRestore(draw_);
 	shaderManager_->DeviceRestore(draw_);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -319,7 +319,10 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 			max_res_temp = 4;  // At least allow 2x
 		int max_res = std::min(max_res_temp, (int)ARRAY_SIZE(deviceResolutions));
 		UI::PopupMultiChoice *hwscale = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iAndroidHwScale, gr->T("Display Resolution (HW scaler)"), deviceResolutions, 0, max_res, I18NCat::GRAPHICS, screenManager()));
-		hwscale->OnChoice.Handle(this, &GameSettingsScreen::OnHwScaleChange);  // To refresh the display mode
+		hwscale->OnChoice.Add([](UI::EventParams &) {
+			System_RecreateActivity();
+			return UI::EVENT_DONE;
+		});
 	}
 #endif
 
@@ -1330,11 +1333,6 @@ UI::EventReturn GameSettingsScreen::OnResolutionChange(UI::EventParams &e) {
 	}
 	Reporting::UpdateConfig();
 	System_PostUIMessage("gpu_renderResized", "");
-	return UI::EVENT_DONE;
-}
-
-UI::EventReturn GameSettingsScreen::OnHwScaleChange(UI::EventParams &e) {
-	System_RecreateActivity();
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -96,7 +96,6 @@ private:
 	UI::EventReturn OnFullscreenChange(UI::EventParams &e);
 	UI::EventReturn OnFullscreenMultiChange(UI::EventParams &e);
 	UI::EventReturn OnResolutionChange(UI::EventParams &e);
-	UI::EventReturn OnHwScaleChange(UI::EventParams &e);
 	UI::EventReturn OnRestoreDefaultSettings(UI::EventParams &e);
 	UI::EventReturn OnRenderingBackend(UI::EventParams &e);
 	UI::EventReturn OnRenderingDevice(UI::EventParams &e);

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -153,7 +153,7 @@
 
 #include <Core/HLE/Plugins.h>
 
-void HandleGlobalMessage(const std::string &msg, const std::string &value);
+bool HandleGlobalMessage(const std::string &msg, const std::string &value);
 
 ScreenManager *g_screenManager;
 std::string config_filename;
@@ -1076,7 +1076,9 @@ void NativeFrame(GraphicsContext *graphicsContext) {
 	}
 
 	for (const auto &item : toProcess) {
-		HandleGlobalMessage(item.msg, item.value);
+		if (HandleGlobalMessage(item.msg, item.value)) {
+			INFO_LOG(SYSTEM, "Handled global message: %s / %s", item.msg.c_str(), item.value.c_str());
+		}
 		g_screenManager->sendMessage(item.msg.c_str(), item.value.c_str());
 	}
 
@@ -1181,28 +1183,32 @@ void NativeFrame(GraphicsContext *graphicsContext) {
 	}
 }
 
-void HandleGlobalMessage(const std::string &msg, const std::string &value) {
+bool HandleGlobalMessage(const std::string &msg, const std::string &value) {
 	if (msg == "savestate_displayslot") {
 		auto sy = GetI18NCategory(I18NCat::SYSTEM);
 		std::string msg = StringFromFormat("%s: %d", sy->T("Savestate Slot"), SaveState::GetCurrentSlot() + 1);
 		// Show for the same duration as the preview.
 		g_OSD.Show(OSDType::MESSAGE_INFO, msg, 2.0f, "savestate_slot");
+		return true;
 	}
 	else if (msg == "gpu_displayResized") {
 		if (gpu) {
 			gpu->NotifyDisplayResized();
 		}
+		return true;
 	}
 	else if (msg == "gpu_renderResized") {
 		if (gpu) {
 			gpu->NotifyRenderResized();
 		}
+		return true;
 	}
 	else if (msg == "gpu_configChanged") {
 		if (gpu) {
 			gpu->NotifyConfigChanged();
 		}
 		Reporting::UpdateConfig();
+		return true;
 	}
 	else if (msg == "core_powerSaving") {
 		if (value != "false") {
@@ -1214,6 +1220,7 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 #endif
 		}
 		Core_SetPowerSaving(value != "false");
+		return true;
 	}
 	else if (msg == "permission_granted" && value == "storage") {
 		CreateSysDirectories();
@@ -1227,9 +1234,13 @@ void HandleGlobalMessage(const std::string &msg, const std::string &value) {
 		g_Config.Reload();
 		PostLoadConfig();
 		g_Config.iGPUBackend = gpuBackend;
+		return true;
 	} else if (msg == "app_resumed" || msg == "got_focus") {
 		// Assume that the user may have modified things.
 		MemoryStick_NotifyWrite();
+		return true;
+	} else {
+		return false;
 	}
 }
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -885,6 +885,8 @@ bool NativeInitGraphics(GraphicsContext *graphicsContext) {
 	g_gameInfoCache = new GameInfoCache();
 
 	if (gpu) {
+		PSP_CoreParameter().pixelWidth = g_display.pixel_xres;
+		PSP_CoreParameter().pixelHeight = g_display.pixel_yres;
 		gpu->DeviceRestore(g_draw);
 	}
 


### PR DESCRIPTION
Since NativeInitGraphics eats the resize flag, when recreating the activity we never updated the pixel width/height properly.

So do a quick and dirty workaround and simply set them.

Fixes #17586  (changing the Android display scaler in-game).

The architecture of display sizes and how they are propagated is deeply messy and needs a cleanup, however, this is a safe interim fix.

This also adds some logging of global messages (I tried to rely on these first, but they also end up getting cleared out).