### PR TITLE
x86jit: Fix vsat0 saturate

### DIFF
--- a/Core/MIPS/x86/X64IRCompFPU.cpp
+++ b/Core/MIPS/x86/X64IRCompFPU.cpp
@@ -622,14 +622,11 @@ void X64JitBackend::CompIR_FSat(IRInst inst) {
 
 		// Now for NAN, we want known first again.
 		// Unfortunately, this will retain -0.0, which we'll fix next.
-		XORPS(tempReg, R(tempReg));
+		XORPS(regs_.FX(inst.dest), regs_.F(inst.dest));
 		MAXSS(tempReg, regs_.F(inst.dest));
 
 		// Important: this should clamp -0.0 to +0.0.
-		XORPS(regs_.FX(inst.dest), regs_.F(inst.dest));
-		CMPEQSS(regs_.FX(inst.dest), R(tempReg));
-		// This will zero all bits if it was -0.0, and keep them otherwise.
-		ANDNPS(regs_.FX(inst.dest), R(tempReg));
+		ADDSS(regs_.FX(inst.dest), R(tempReg));
 		break;
 
 	case IROp::FSatMinus1_1:


### PR DESCRIPTION
This was only working when dest == src1, which was the case for prefixes but not for `vsat0`.  Silly mistake.

Also, optimize to just add to convert -0.0 to +0.0.  Thanks @fp64.

-[Unknown]