### PR TITLE
Control: Change internal interfaces to batch-process input axis updates

### DIFF
--- a/Common/System/NativeApp.h
+++ b/Common/System/NativeApp.h
@@ -54,7 +54,7 @@ bool NativeIsRestarting();
 // input latency - assuming your main loop is architected properly (NativeFrame called from a different thread than input event handling).
 void NativeTouch(const TouchInput &touch);
 bool NativeKey(const KeyInput &key);
-void NativeAxis(const AxisInput &axis);
+void NativeAxis(const AxisInput *axis, size_t count);
 
 // Called when it's process a frame, including rendering. If the device can keep up, this
 // will be called sixty times per second. Main thread.

--- a/Common/VR/PPSSPPVR.h
+++ b/Common/VR/PPSSPPVR.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 struct AxisInput;
 struct TouchInput;
 struct KeyInput;
@@ -30,7 +32,7 @@ bool IsVREnabled();
 void InitVROnAndroid(void* vm, void* activity, const char* system, int version, const char* name);
 void EnterVR(bool firstStart, void* vulkanContext);
 void GetVRResolutionPerEye(int* width, int* height);
-void SetVRCallbacks(void(*axis)(const AxisInput &axis), bool(*key)(const KeyInput &key), void(*touch)(const TouchInput &touch));
+void SetVRCallbacks(void(*axis)(const AxisInput *axis, size_t count), bool(*key)(const KeyInput &key), void(*touch)(const TouchInput &touch));
 
 // VR input integration
 void SetVRAppMode(VRAppMode mode);

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -731,20 +731,18 @@ void MainUI::updateAccelerometer() {
 	// TODO: Toggle it depending on whether it is enabled
 	QAccelerometerReading *reading = acc->reading();
 	if (reading) {
-		AxisInput axis;
-		axis.deviceId = DEVICE_ID_ACCELEROMETER;
+		AxisInput axis[3];
+		for (int i = 0; i < 3; i++) {
+			axis[i].deviceId = DEVICE_ID_ACCELEROMETER;
+		}
 
-		axis.axisId = JOYSTICK_AXIS_ACCELEROMETER_X;
-		axis.value = reading->x();
-		NativeAxis(axis);
-
-		axis.axisId = JOYSTICK_AXIS_ACCELEROMETER_Y;
-		axis.value = reading->y();
-		NativeAxis(axis);
-
-		axis.axisId = JOYSTICK_AXIS_ACCELEROMETER_Z;
-		axis.value = reading->z();
-		NativeAxis(axis);
+		axis[0].axisId = JOYSTICK_AXIS_ACCELEROMETER_X;
+		axis[0].value = reading->x();
+		axis[1].axisId = JOYSTICK_AXIS_ACCELEROMETER_Y;
+		axis[1].value = reading->y();
+		axis[2].axisId = JOYSTICK_AXIS_ACCELEROMETER_Z;
+		axis[2].value = reading->z();
+		NativeAxis(axis, 3);
 	}
 #endif
 }

--- a/SDL/SDLJoystick.cpp
+++ b/SDL/SDLJoystick.cpp
@@ -189,7 +189,7 @@ void SDLJoystick::ProcessInput(const SDL_Event &event){
 		if (axis.value > 1.0f) axis.value = 1.0f;
 		if (axis.value < -1.0f) axis.value = -1.0f;
 		axis.deviceId = DEVICE_ID_PAD_0 + getDeviceIndex(event.caxis.which);
-		NativeAxis(axis);
+		NativeAxis(&axis, 1);
 		break;
 	case SDL_CONTROLLERDEVICEREMOVED:
 		// for removal events, "which" is the instance ID for SDL_CONTROLLERDEVICEREMOVED

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -724,17 +724,16 @@ struct InputStateTracker {
 			float scaleFactor_x = g_display.dpi_scale_x * 0.1 * g_Config.fMouseSensitivity;
 			float scaleFactor_y = g_display.dpi_scale_y * 0.1 * g_Config.fMouseSensitivity;
 
-			AxisInput axisX, axisY;
-			axisX.axisId = JOYSTICK_AXIS_MOUSE_REL_X;
-			axisX.deviceId = DEVICE_ID_MOUSE;
-			axisX.value = std::max(-1.0f, std::min(1.0f, mouseDeltaX * scaleFactor_x));
-			axisY.axisId = JOYSTICK_AXIS_MOUSE_REL_Y;
-			axisY.deviceId = DEVICE_ID_MOUSE;
-			axisY.value = std::max(-1.0f, std::min(1.0f, mouseDeltaY * scaleFactor_y));
+			AxisInput axis[2];
+			axis[0].axisId = JOYSTICK_AXIS_MOUSE_REL_X;
+			axis[0].deviceId = DEVICE_ID_MOUSE;
+			axis[0].value = std::max(-1.0f, std::min(1.0f, mouseDeltaX * scaleFactor_x));
+			axis[1].axisId = JOYSTICK_AXIS_MOUSE_REL_Y;
+			axis[1].deviceId = DEVICE_ID_MOUSE;
+			axis[1].value = std::max(-1.0f, std::min(1.0f, mouseDeltaY * scaleFactor_y));
 
 			if (GetUIState() == UISTATE_INGAME || g_Config.bMapMouse) {
-				NativeAxis(axisX);
-				NativeAxis(axisY);
+				NativeAxis(axis, 2);
 			}
 			mouseDeltaX *= g_Config.fMouseSmoothing;
 			mouseDeltaY *= g_Config.fMouseSmoothing;

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -208,7 +208,7 @@ void SendNativeAxis(InputDeviceID deviceId, int value, int &lastValue, InputAxis
 	axis.deviceId = deviceId;
 	axis.axisId = axisId;
 	axis.value = (float)value * (1.0f / 10000.0f); // Convert axis to normalised float
-	NativeAxis(axis);
+	NativeAxis(&axis, 1);
 
 	lastValue = value;
 }
@@ -241,6 +241,7 @@ int DinputDevice::UpdateState() {
 	ApplyButtons(js);
 
 	if (analog)	{
+		// TODO: Use the batched interface.
 		AxisInput axis;
 		axis.deviceId = DEVICE_ID_PAD_0 + pDevNum;
 

--- a/Windows/WindowsHost.cpp
+++ b/Windows/WindowsHost.cpp
@@ -107,17 +107,16 @@ void WindowsInputManager::PollControllers() {
 
 		float mx = std::max(-1.0f, std::min(1.0f, mouseDeltaX_ * scaleFactor_x));
 		float my = std::max(-1.0f, std::min(1.0f, mouseDeltaY_ * scaleFactor_y));
-		AxisInput axisX{}, axisY{};
-		axisX.axisId = JOYSTICK_AXIS_MOUSE_REL_X;
-		axisX.deviceId = DEVICE_ID_MOUSE;
-		axisX.value = mx;
-		axisY.axisId = JOYSTICK_AXIS_MOUSE_REL_Y;
-		axisY.deviceId = DEVICE_ID_MOUSE;
-		axisY.value = my;
+		AxisInput axis[2];
+		axis[0].axisId = JOYSTICK_AXIS_MOUSE_REL_X;
+		axis[0].deviceId = DEVICE_ID_MOUSE;
+		axis[0].value = mx;
+		axis[1].axisId = JOYSTICK_AXIS_MOUSE_REL_Y;
+		axis[1].deviceId = DEVICE_ID_MOUSE;
+		axis[1].value = my;
 
 		if (GetUIState() == UISTATE_INGAME || g_Config.bMapMouse) {
-			NativeAxis(axisX);
-			NativeAxis(axisY);
+			NativeAxis(axis, 2);
 		}
 	}
 

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -218,14 +218,17 @@ void XinputDevice::UpdatePad(int pad, const XINPUT_STATE &state, XINPUT_VIBRATIO
 	ApplyButtons(pad, state);
 	ApplyVibration(pad, vibration);
 
-	AxisInput axis;
-	axis.deviceId = (InputDeviceID)(DEVICE_ID_XINPUT_0 + pad);
+	AxisInput axis[6];
+	int axisCount = 0;
+	for (int i = 0; i < ARRAY_SIZE(axis); i++) {
+		axis[i].deviceId = (InputDeviceID)(DEVICE_ID_XINPUT_0 + pad);
+	}
 	auto sendAxis = [&](InputAxis axisId, float value, int axisIndex) {
 		if (value != prevAxisValue_[pad][axisIndex]) {
 			prevAxisValue_[pad][axisIndex] = value;
-			axis.axisId = axisId;
-			axis.value = value;
-			NativeAxis(axis);
+			axis[axisCount].axisId = axisId;
+			axis[axisCount].value = value;
+			axisCount++;
 		}
 	};
 
@@ -240,6 +243,10 @@ void XinputDevice::UpdatePad(int pad, const XINPUT_STATE &state, XINPUT_VIBRATIO
 
 	if (NormalizedDeadzoneDiffers(prevState[pad].Gamepad.bRightTrigger, state.Gamepad.bRightTrigger, XINPUT_GAMEPAD_TRIGGER_THRESHOLD)) {
 		sendAxis(JOYSTICK_AXIS_RTRIGGER, (float)state.Gamepad.bRightTrigger / 255.0f, 5);
+	}
+
+	if (axisCount) {
+		NativeAxis(axis, axisCount);
 	}
 
 	prevState[pad] = state;

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1210,6 +1210,7 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_keyUp(JNIEnv *, jclass, jin
 	return NativeKey(keyInput);
 }
 
+// TODO: Make a batched interface, since we get these in batches on the Android side.
 extern "C" void Java_org_ppsspp_ppsspp_NativeApp_joystickAxis(
 		JNIEnv *env, jclass, jint deviceId, jint axisId, jfloat value) {
 	if (!renderer_inited)
@@ -1219,7 +1220,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_joystickAxis(
 	axis.deviceId = (InputDeviceID)deviceId;
 	axis.axisId = (InputAxis)axisId;
 	axis.value = value;
-	NativeAxis(axis);
+	NativeAxis(&axis, 1);
 }
 
 extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_mouseWheelEvent(
@@ -1234,20 +1235,17 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_accelerometer(JNIEnv *,
 	if (!renderer_inited)
 		return;
 
-	AxisInput axis;
-	axis.deviceId = DEVICE_ID_ACCELEROMETER;
-
-	axis.axisId = JOYSTICK_AXIS_ACCELEROMETER_X;
-	axis.value = x;
-	NativeAxis(axis);
-
-	axis.axisId = JOYSTICK_AXIS_ACCELEROMETER_Y;
-	axis.value = y;
-	NativeAxis(axis);
-
-	axis.axisId = JOYSTICK_AXIS_ACCELEROMETER_Z;
-	axis.value = z;
-	NativeAxis(axis);
+	AxisInput axis[3];
+	for (int i = 0; i < 3; i++) {
+		axis[i].deviceId = DEVICE_ID_ACCELEROMETER;
+	}
+	axis[0].axisId = JOYSTICK_AXIS_ACCELEROMETER_X;
+	axis[0].value = x;
+	axis[1].axisId = JOYSTICK_AXIS_ACCELEROMETER_Y;
+	axis[1].value = y;
+	axis[2].axisId = JOYSTICK_AXIS_ACCELEROMETER_Z;
+	axis[2].value = z;
+	NativeAxis(axis, 3);
 }
 
 extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_sendMessageFromJava(JNIEnv *env, jclass, jstring message, jstring param) {

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -462,7 +462,7 @@ int ToTouchID(UITouch *uiTouch, bool allowAllocate) {
 					break;
 			}
 			axis.deviceId = DEVICE_ID_PAD_0;
-			NativeAxis(axis);
+			NativeAxis(&axis, 1);
 		} else {
 			KeyInput key;
 			key.flags = KEY_DOWN;
@@ -531,7 +531,7 @@ int ToTouchID(UITouch *uiTouch, bool allowAllocate) {
 				break;
 		}
 		axis.deviceId = DEVICE_ID_PAD_0;
-		NativeAxis(axis);
+		NativeAxis(&axis, 1);
 	} else {
 		KeyInput key;
 		key.flags = KEY_UP;
@@ -689,7 +689,7 @@ int ToTouchID(UITouch *uiTouch, bool allowAllocate) {
 		axisInput.deviceId = DEVICE_ID_PAD_0;
 		axisInput.axisId = JOYSTICK_AXIS_X;
 		axisInput.value = value;
-		NativeAxis(axisInput);
+		NativeAxis(&axisInput, 1);
 	};
 
 	extendedProfile.leftThumbstick.yAxis.valueChangedHandler = ^(GCControllerAxisInput *axis, float value) {
@@ -697,7 +697,7 @@ int ToTouchID(UITouch *uiTouch, bool allowAllocate) {
 		axisInput.deviceId = DEVICE_ID_PAD_0;
 		axisInput.axisId = JOYSTICK_AXIS_Y;
 		axisInput.value = -value;
-		NativeAxis(axisInput);
+		NativeAxis(&axisInput, 1);
 	};
 
 	// Map right thumbstick as another analog stick, particularly useful for controllers like the DualShock 3/4 when connected to an iOS device
@@ -706,7 +706,7 @@ int ToTouchID(UITouch *uiTouch, bool allowAllocate) {
 		axisInput.deviceId = DEVICE_ID_PAD_0;
 		axisInput.axisId = JOYSTICK_AXIS_Z;
 		axisInput.value = value;
-		NativeAxis(axisInput);
+		NativeAxis(&axisInput, 1);
 	};
 
 	extendedProfile.rightThumbstick.yAxis.valueChangedHandler = ^(GCControllerAxisInput *axis, float value) {
@@ -714,7 +714,7 @@ int ToTouchID(UITouch *uiTouch, bool allowAllocate) {
 		axisInput.deviceId = DEVICE_ID_PAD_0;
 		axisInput.axisId = JOYSTICK_AXIS_RZ;
 		axisInput.value = -value;
-		NativeAxis(axisInput);
+		NativeAxis(&axisInput, 1);
 	};
 }
 #endif


### PR DESCRIPTION
These naturally come in bunches on many platforms like Android, so lay some groundwork to also handle them in bunches to minimize locking and JNI calls in the future (needs to actually add a batched JNI function too). I don't know if this will ever have a noticeable impact, but figure that less locking will be better.