### PR TITLE
Touch controls: Add an option for "Sticky D-Pad".

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -314,6 +314,9 @@ public:
 	// Floating analog stick (recenters on thumb on press).
 	bool bAutoCenterTouchAnalog;
 
+	// Sticky D-pad (can't glide off it)
+	bool bStickyTouchDPad;
+
 	//space between PSP buttons
 	//the PSP button's center (triangle, circle, square, cross)
 	ConfigTouchPos touchActionButtonCenter;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -688,6 +688,10 @@ void GameSettingsScreen::CreateControlsSettings(UI::ViewGroup *controlsSettings)
 		CheckBox *hideStickBackground = controlsSettings->Add(new CheckBox(&g_Config.bHideStickBackground, co->T("Hide touch analog stick background circle")));
 		hideStickBackground->SetEnabledPtr(&g_Config.bShowTouchControls);
 
+		// Sticky D-pad.
+		CheckBox *stickyDpad = controlsSettings->Add(new CheckBox(&g_Config.bStickyTouchDPad, co->T("Sticky D-Pad (easier sweeping movements)")));
+		stickyDpad->SetEnabledPtr(&g_Config.bShowTouchControls);
+
 		// Re-centers itself to the touch location on touch-down.
 		CheckBox *floatingAnalog = controlsSettings->Add(new CheckBox(&g_Config.bAutoCenterTouchAnalog, co->T("Auto-centering analog stick")));
 		floatingAnalog->SetEnabledPtr(&g_Config.bShowTouchControls);

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -319,7 +319,7 @@ void PSPDpad::ProcessTouch(float x, float y, bool down) {
 	float dx = (x - bounds_.centerX()) * inv_stick_size;
 	float dy = (y - bounds_.centerY()) * inv_stick_size;
 	float rad = sqrtf(dx * dx + dy * dy);
-	if (rad < deadzone || fabs(dx) > 0.5f || fabs(dy) > 0.5)
+	if (!g_Config.bStickyTouchDPad && (rad < deadzone || fabs(dx) > 0.5f || fabs(dy) > 0.5))
 		down = false;
 
 	int ctrlMask = 0;


### PR DESCRIPTION
Will make it a lot easier to pull off certain moves in fighting games - much easier to do sweeps without falling off the d-pad. Basically, once you press the D-Pad, some direction is active until you release, even if you slide off. I also think this behavior is more similar to what we had back in 1.11.

Should help #17950