### PR TITLE
Analog stick gesture

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -804,6 +804,9 @@ static const ConfigSetting controlSettings[] = {
 
 	ConfigSetting("SystemControls", &g_Config.bSystemControls, true, CfgFlag::DEFAULT),
 	ConfigSetting("RapidFileInterval", &g_Config.iRapidFireInterval, 5, CfgFlag::DEFAULT),
+
+	ConfigSetting("AnalogGesture", &g_Config.bAnalogGesture, false, CfgFlag::PER_GAME),
+	ConfigSetting("AnalogGestureSensibility", &g_Config.fAnalogGestureSensibility, 1.0f, CfgFlag::PER_GAME),
 };
 
 static const ConfigSetting networkSettings[] = {

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -298,6 +298,8 @@ public:
 	float fSwipeSensitivity;
 	float fSwipeSmoothing;
 	int iDoubleTapGesture;
+	bool bAnalogGesture;
+	float fAnalogGestureSensibility;
 
 	// Disable diagonals
 	bool bDisableDpadDiagonals;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -2151,6 +2151,10 @@ void GestureMappingScreen::CreateViews() {
 
 	vert->Add(new ItemHeader(co->T("Double tap")));
 	vert->Add(new PopupMultiChoice(&g_Config.iDoubleTapGesture, mc->T("Double tap button"), gestureButton, 0, ARRAY_SIZE(gestureButton), I18NCat::MAPPABLECONTROLS, screenManager()))->SetEnabledPtr(&g_Config.bGestureControlEnabled);
+
+	vert->Add(new ItemHeader(co->T("Analog Stick")));
+	vert->Add(new CheckBox(&g_Config.bAnalogGesture, co->T("Enable analog stick gesture")));
+	vert->Add(new PopupSliderChoiceFloat(&g_Config.fAnalogGestureSensibility, 0.01f, 5.0f, 1.0f, co->T("Sensitivity"), 0.01f, screenManager(), "x"))->SetEnabledPtr(&g_Config.bAnalogGesture);
 }
 
 RestoreSettingsScreen::RestoreSettingsScreen(const char *title)

--- a/UI/GamepadEmu.h
+++ b/UI/GamepadEmu.h
@@ -199,6 +199,7 @@ public:
 
 	bool Touch(const TouchInput &input) override;
 	void Update() override;
+	void Draw(UIContext &dc) override;
 
 protected:
 
@@ -206,6 +207,8 @@ protected:
 	float lastY_ = 0.0f;
 	float deltaX_ = 0.0f;
 	float deltaY_ = 0.0f;
+	float downX_;
+	float downY_;
 	float lastTapRelease_ = 0.0f;
 	float lastTouchDown_ = 0.0f;
 	int dragPointerId_ = -1;


### PR DESCRIPTION
Fixes #16820. The area will be all screen with this, not the best but will get better if we get implement different gesture for the right and the left half of the screen as requested in #18032.

Could eventually support different button rather than only the analog stick, but that would require to "digitalize" the input, for now let's KISS.

Not sure if you had other ideas but this will at least kinda sidestep the UI issues a bit :)

The strings "Analog Stick" and "Sensitivity" are already in the language file, so only 1 string translation will be needed.