### PR TITLE
x86jit: Implement float to integer

### DIFF
--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -1196,20 +1196,20 @@ namespace MIPSComp {
 				ir.Write(IROp::FCvtScaledWS, dregs[i], sregs[i], imm | (rmode << 6));
 		} else {
 			for (int i = 0; i < n; i++) {
-				switch (rmode) {
-				case 0: // vf2in
+				switch (IRRoundMode(rmode)) {
+				case IRRoundMode::RINT_0: // vf2in
 					ir.Write(IROp::FRound, dregs[i], sregs[i]);
 					break;
 
-				case 1: // vf2iz
+				case IRRoundMode::CAST_1: // vf2iz
 					ir.Write(IROp::FTrunc, dregs[i], sregs[i]);
 					break;
 
-				case 2: // vf2iu
+				case IRRoundMode::CEIL_2: // vf2iu
 					ir.Write(IROp::FCeil, dregs[i], sregs[i]);
 					break;
 
-				case 3: // vf2id
+				case IRRoundMode::FLOOR_3: // vf2id
 					ir.Write(IROp::FFloor, dregs[i], sregs[i]);
 					break;
 

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -252,6 +252,13 @@ enum class Vec4Init {
 	Set_0001,
 };
 
+enum class IRRoundMode : uint8_t {
+	RINT_0 = 0,
+	CAST_1 = 1,
+	CEIL_2 = 2,
+	FLOOR_3 = 3,
+};
+
 // Hm, unused
 inline IRComparison Invert(IRComparison comp) {
 	switch (comp) {

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -966,11 +966,11 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 				mips->fs[inst->dest] = my_isinf(src) && src < 0.0f ? -2147483648LL : 2147483647LL;
 				break;
 			}
-			switch (mips->fcr31 & 3) {
-			case 0: mips->fs[inst->dest] = (int)round_ieee_754(src); break;  // RINT_0
-			case 1: mips->fs[inst->dest] = (int)src; break;  // CAST_1
-			case 2: mips->fs[inst->dest] = (int)ceilf(src); break;  // CEIL_2
-			case 3: mips->fs[inst->dest] = (int)floorf(src); break;  // FLOOR_3
+			switch (IRRoundMode(mips->fcr31 & 3)) {
+			case IRRoundMode::RINT_0: mips->fs[inst->dest] = (int)round_ieee_754(src); break;
+			case IRRoundMode::CAST_1: mips->fs[inst->dest] = (int)src; break;
+			case IRRoundMode::CEIL_2: mips->fs[inst->dest] = (int)ceilf(src); break;
+			case IRRoundMode::FLOOR_3: mips->fs[inst->dest] = (int)floorf(src); break;
 			}
 			break; //cvt.w.s
 		}
@@ -994,11 +994,11 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 			} else if (sv <= (double)(int)0x80000000) {
 				mips->fs[inst->dest] = 0x80000000;
 			} else {
-				switch (inst->src2 >> 6) {
-				case 0: mips->fs[inst->dest] = (int)round_ieee_754(sv); break;
-				case 1: mips->fs[inst->dest] = src >= 0 ? (int)floor(sv) : (int)ceil(sv); break;
-				case 2: mips->fs[inst->dest] = (int)ceil(sv); break;
-				case 3: mips->fs[inst->dest] = (int)floor(sv); break;
+				switch (IRRoundMode(inst->src2 >> 6)) {
+				case IRRoundMode::RINT_0: mips->fs[inst->dest] = (int)round_ieee_754(sv); break;
+				case IRRoundMode::CAST_1: mips->fs[inst->dest] = src >= 0 ? (int)floor(sv) : (int)ceil(sv); break;
+				case IRRoundMode::CEIL_2: mips->fs[inst->dest] = (int)ceil(sv); break;
+				case IRRoundMode::FLOOR_3: mips->fs[inst->dest] = (int)floor(sv); break;
 				}
 			}
 			break;

--- a/Core/MIPS/x86/X64IRJit.h
+++ b/Core/MIPS/x86/X64IRJit.h
@@ -148,6 +148,9 @@ private:
 		const void *negativeOnes;
 		const void *qNAN;
 		const float *mulTableVi2f;
+		const double *mulTableVf2i;
+		const double *minIntAsDouble;
+		const double *maxIntAsDouble;
 		const Float4Constant *vec4InitValues;
 	};
 	Constants constants;

--- a/Core/MIPS/x86/X64IRRegCache.h
+++ b/Core/MIPS/x86/X64IRRegCache.h
@@ -42,6 +42,7 @@ static constexpr auto downcountOffset = offsetof(MIPSState, downcount) - 128;
 static constexpr auto tempOffset = offsetof(MIPSState, temp) - 128;
 static constexpr auto fcr31Offset = offsetof(MIPSState, fcr31) - 128;
 static constexpr auto pcOffset = offsetof(MIPSState, pc) - 128;
+static constexpr auto mxcsrTempOffset = offsetof(MIPSState, mxcsrTemp) - 128;
 
 enum class X64Map : uint8_t {
 	NONE = 0,


### PR DESCRIPTION
This implements rounding float -> integer.  Uses SSE4 when available, which I confirmed is faster (avoids messing with MXCSR.)

Used in Patapon for example.  This change makes Patapon faster in the newer jit.

-[Unknown]