### PR TITLE
x86jit: Bake emuhack mask into jitbase

### DIFF
--- a/Core/MIPS/IR/IRRegCache.cpp
+++ b/Core/MIPS/IR/IRRegCache.cpp
@@ -784,10 +784,11 @@ void IRNativeRegCacheBase::ApplyMapping(const Mapping *mapping, int count) {
 			return;
 		}
 
+		bool mapSIMD = config_.mapFPUSIMD || mapping[i].type == 'G';
 		MIPSMap flags = mapping[i].flags;
 		for (int j = 0; j < count; ++j) {
 			if (mapping[j].type == mapping[i].type && mapping[j].reg == mapping[i].reg && i != j) {
-				_assert_msg_(mapping[j].lanes == mapping[i].lanes, "Lane aliasing not supported yet");
+				_assert_msg_(!mapSIMD || mapping[j].lanes == mapping[i].lanes, "Lane aliasing not supported yet");
 
 				if (!isNoinit(mapping[j].flags) && isNoinit(flags)) {
 					flags = (flags & MIPSMap::BACKEND_MASK) | MIPSMap::DIRTY;
@@ -795,7 +796,7 @@ void IRNativeRegCacheBase::ApplyMapping(const Mapping *mapping, int count) {
 			}
 		}
 
-		if (config_.mapFPUSIMD || mapping[i].type == 'G') {
+		if (mapSIMD) {
 			MapNativeReg(type, mapping[i].reg, mapping[i].lanes, flags);
 			return;
 		}

--- a/Core/MIPS/RiscV/RiscVAsm.cpp
+++ b/Core/MIPS/RiscV/RiscVAsm.cpp
@@ -121,7 +121,7 @@ void RiscVJitBackend::GenerateFixedCode(MIPSState *mipsState) {
 	// Fixed registers, these are always kept when in Jit context.
 	LI(MEMBASEREG, Memory::base, SCRATCH1);
 	LI(CTXREG, mipsState, SCRATCH1);
-	LI(JITBASEREG, GetBasePtr(), SCRATCH1);
+	LI(JITBASEREG, GetBasePtr() - MIPS_EMUHACK_OPCODE, SCRATCH1);
 
 	LoadStaticRegisters();
 	MovFromPC(SCRATCH1);
@@ -173,9 +173,7 @@ void RiscVJitBackend::GenerateFixedCode(MIPSState *mipsState) {
 	// We're in other words comparing to the top 8 bits of MIPS_EMUHACK_OPCODE by subtracting.
 	ADDI(SCRATCH2, SCRATCH2, -(MIPS_EMUHACK_OPCODE >> 24));
 	FixupBranch needsCompile = BNE(SCRATCH2, R_ZERO);
-	// Use a wall to mask by 0x00FFFFFF and extract the block jit offset.
-	SLLI(SCRATCH1, SCRATCH1, XLEN - 24);
-	SRLI(SCRATCH1, SCRATCH1, XLEN - 24);
+	// No need to mask, JITBASEREG has already accounted for the upper bits.
 	ADD(SCRATCH1, JITBASEREG, SCRATCH1);
 	JR(SCRATCH1);
 	SetJumpTarget(needsCompile);

--- a/Core/MIPS/RiscV/RiscVRegCache.cpp
+++ b/Core/MIPS/RiscV/RiscVRegCache.cpp
@@ -206,6 +206,10 @@ RiscVGen::RiscVReg RiscVRegCache::Normalize32(IRReg mipsReg, RiscVGen::RiscVReg 
 			emit_->SEXT_W(destReg, (RiscVReg)mr[mipsReg].nReg);
 		}
 		break;
+
+	default:
+		_assert_msg_(false, "Should not normalize32 floats");
+		break;
 	}
 
 	return destReg == INVALID_REG ? reg : destReg;

--- a/Core/MIPS/x86/X64IRAsm.cpp
+++ b/Core/MIPS/x86/X64IRAsm.cpp
@@ -56,15 +56,16 @@ void X64JitBackend::GenerateFixedCode(MIPSState *mipsState) {
 #if PPSSPP_ARCH(AMD64)
 	bool jitbaseInR15 = false;
 	int jitbaseCtxDisp = 0;
-	uintptr_t jitbase = (uintptr_t)GetBasePtr();
-	if (jitbase > 0x7FFFFFFFULL && !Accessible((const u8 *)&mipsState->f[0], GetBasePtr())) {
+	// We pre-bake the MIPS_EMUHACK_OPCODE subtraction into our jitbase value.
+	intptr_t jitbase = (intptr_t)GetBasePtr() - MIPS_EMUHACK_OPCODE;
+	if ((jitbase < -0x80000000ULL || jitbase > 0x7FFFFFFFULL) && !Accessible((const u8 *)&mipsState->f[0], GetBasePtr())) {
 		jo.reserveR15ForAsm = true;
 		jitbaseInR15 = true;
 	} else {
 		jo.downcountInRegister = true;
 		jo.reserveR15ForAsm = true;
-		if (jitbase > 0x7FFFFFFFULL) {
-			jitbaseCtxDisp = (int)(GetBasePtr() - (const u8 *)&mipsState->f[0]);
+		if (jitbase < -0x80000000ULL || jitbase > 0x7FFFFFFFULL) {
+			jitbaseCtxDisp = (int)(jitbase - (intptr_t)&mipsState->f[0]);
 		}
 	}
 #endif
@@ -139,7 +140,7 @@ void X64JitBackend::GenerateFixedCode(MIPSState *mipsState) {
 	// Two x64-specific statically allocated registers.
 	MOV(64, R(MEMBASEREG), ImmPtr(Memory::base));
 	if (jitbaseInR15)
-		MOV(64, R(JITBASEREG), ImmPtr(GetBasePtr()));
+		MOV(64, R(JITBASEREG), ImmPtr((const void *)jitbase));
 #endif
 	// From the start of the FP reg, a single byte offset can reach all GPR + all FPR (but not VFPR.)
 	MOV(PTRBITS, R(CTXREG), ImmPtr(&mipsState->f[0]));
@@ -228,10 +229,9 @@ void X64JitBackend::GenerateFixedCode(MIPSState *mipsState) {
 				CMP(32, R(EDX), Imm8(MIPS_EMUHACK_OPCODE >> 24));
 			}
 			FixupBranch needsCompile = J_CC(CC_NE);
-				// Mask by 0x00FFFFFF and extract the block jit offset.
-				AND(32, R(SCRATCH1), Imm32(MIPS_EMUHACK_VALUE_MASK));
+				// We don't mask here - that's baked into jitbase.
 #if PPSSPP_ARCH(X86)
-				LEA(32, SCRATCH1, MDisp(SCRATCH1, (u32)GetBasePtr()));
+				LEA(32, SCRATCH1, MDisp(SCRATCH1, (u32)GetBasePtr() - MIPS_EMUHACK_VALUE_MASK));
 #elif PPSSPP_ARCH(AMD64)
 				if (jitbaseInR15) {
 					ADD(64, R(SCRATCH1), R(JITBASEREG));
@@ -239,7 +239,7 @@ void X64JitBackend::GenerateFixedCode(MIPSState *mipsState) {
 					LEA(64, SCRATCH1, MComplex(CTXREG, SCRATCH1, SCALE_1, jitbaseCtxDisp));
 				} else {
 					// See above, reserveR15ForAsm is used when above 0x7FFFFFFF.
-					LEA(64, SCRATCH1, MDisp(SCRATCH1, (u32)jitbase));
+					LEA(64, SCRATCH1, MDisp(SCRATCH1, (s32)jitbase));
 				}
 #endif
 				JMPptr(R(SCRATCH1));

--- a/Core/MIPS/x86/X64IRRegCache.h
+++ b/Core/MIPS/x86/X64IRRegCache.h
@@ -30,6 +30,7 @@ namespace X64IRJitConstants {
 #if PPSSPP_ARCH(AMD64)
 const Gen::X64Reg MEMBASEREG = Gen::RBX;
 const Gen::X64Reg CTXREG = Gen::R14;
+// Note: this is actually offset from the base.
 const Gen::X64Reg JITBASEREG = Gen::R15;
 const Gen::X64Reg DOWNCOUNTREG = Gen::R15;
 #else


### PR DESCRIPTION
And do the same on RISC-V.  Plus an assert fix.

This is a change I made in #18059 that should be equally beneficial in other backends.

At this point, LittleBigPlanet is about 9% faster (FPS, though it varies 8-10%) in game using the new IR based x86 jit versus the old x86 jit.

-[Unknown]