### PR TITLE
Allow using a file browser to choose UMDs during disc change.

### DIFF
--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1616,7 +1616,19 @@ void UmdReplaceScreen::CreateViews() {
 
 	tabAllGames->OnHoldChoice.Handle(this, &UmdReplaceScreen::OnGameSelected);
 
+	if (System_GetPropertyBool(SYSPROP_HAS_FILE_BROWSER)) {
+		rightColumnItems->Add(new Choice(mm->T("Load", "Load...")))->OnClick.Add([&](UI::EventParams &e) {
+			auto mm = GetI18NCategory(I18NCat::MAINMENU);
+			System_BrowseForFile(mm->T("Load"), BrowseFileType::BOOTABLE, [&](const std::string &value, int) {
+				__UmdReplace(Path(value));
+				TriggerFinish(DR_OK);
+			});
+			return EVENT_DONE;
+		});
+	}
+
 	rightColumnItems->Add(new Choice(di->T("Cancel")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnCancel);
+	rightColumnItems->Add(new Spacer());
 	rightColumnItems->Add(new Choice(mm->T("Game Settings")))->OnClick.Handle(this, &UmdReplaceScreen::OnGameSettings);
 
 	if (g_Config.HasRecentIsos()) {

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -175,7 +175,6 @@ public:
 protected:
 	void CreateViews() override;
 	void update() override;
-	//virtual void sendMessage(const char *message, const char *value);
 
 private:
 	UI::EventReturn OnGameSelected(UI::EventParams &e);

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -352,7 +352,10 @@ void GamePauseScreen::CreateViews() {
 
 	rightColumnItems->SetSpacing(0.0f);
 	if (getUMDReplacePermit()) {
-		rightColumnItems->Add(new Choice(pa->T("Switch UMD")))->OnClick.Handle(this, &GamePauseScreen::OnSwitchUMD);
+		rightColumnItems->Add(new Choice(pa->T("Switch UMD")))->OnClick.Add([=](UI::EventParams &) {
+			screenManager()->push(new UmdReplaceScreen());
+			return UI::EVENT_DONE;
+		});
 	}
 	Choice *continueChoice = rightColumnItems->Add(new Choice(pa->T("Continue")));
 	root_->SetDefaultFocusView(continueChoice);
@@ -466,11 +469,6 @@ UI::EventReturn GamePauseScreen::OnLastSaveUndo(UI::EventParams &e) {
 	SaveState::UndoLastSave(gamePath_);
 
 	RecreateViews();
-	return UI::EVENT_DONE;
-}
-
-UI::EventReturn GamePauseScreen::OnSwitchUMD(UI::EventParams &e) {
-	screenManager()->push(new UmdReplaceScreen());
 	return UI::EVENT_DONE;
 }
 

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -60,7 +60,6 @@ private:
 	UI::EventReturn OnCreateConfig(UI::EventParams &e);
 	UI::EventReturn OnDeleteConfig(UI::EventParams &e);
 
-	UI::EventReturn OnSwitchUMD(UI::EventParams &e);
 	UI::EventReturn OnState(UI::EventParams &e);
 
 	// hack


### PR DESCRIPTION
In the dialog that you can get to when a game asks you to change disc, add a "Load" button just like on the main screen so you can use a system-native file browser. Can be useful if your game is on a Windows network share or something.