### PR TITLE
arm64jit: Correct vertexjit bug on invalid case

### DIFF
--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -673,10 +673,9 @@ void VertexDecoderJitCache::Jit_PosFloat() {
 
 void VertexDecoderJitCache::Jit_PosS8Through() {
 	// 8-bit positions in throughmode always decode to 0, depth included.
-	fp.EOR(fpScratchReg, fpScratchReg, fpScratchReg);
-	STR(INDEX_UNSIGNED, fpScratchReg, dstReg, dec_->decFmt.posoff);
-	STR(INDEX_UNSIGNED, fpScratchReg, dstReg, dec_->decFmt.posoff + 4);
-	STR(INDEX_UNSIGNED, fpScratchReg, dstReg, dec_->decFmt.posoff + 8);
+	STR(INDEX_UNSIGNED, WZR, dstReg, dec_->decFmt.posoff);
+	STR(INDEX_UNSIGNED, WZR, dstReg, dec_->decFmt.posoff + 4);
+	STR(INDEX_UNSIGNED, WZR, dstReg, dec_->decFmt.posoff + 8);
 }
 
 void VertexDecoderJitCache::Jit_PosS16Through() {

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -252,7 +252,7 @@ void Android_AttachThreadToJNI() {
 	JNIEnv *env;
 	int status = gJvm->GetEnv((void **)&env, JNI_VERSION_1_6);
 	if (status < 0) {
-		INFO_LOG(SYSTEM, "Attaching thread '%s' (not already attached) to JNI.", GetCurrentThreadName());
+		DEBUG_LOG(SYSTEM, "Attaching thread '%s' (not already attached) to JNI.", GetCurrentThreadName());
 		JavaVMAttachArgs args{};
 		args.version = JNI_VERSION_1_6;
 		args.name = GetCurrentThreadName();
@@ -269,7 +269,7 @@ void Android_AttachThreadToJNI() {
 
 void Android_DetachThreadFromJNI() {
 	if (gJvm->DetachCurrentThread() == JNI_OK) {
-		INFO_LOG(SYSTEM, "Detached thread from JNI: '%s'", GetCurrentThreadName());
+		DEBUG_LOG(SYSTEM, "Detached thread from JNI: '%s'", GetCurrentThreadName());
 	} else {
 		WARN_LOG(SYSTEM, "Failed to detach thread '%s' from JNI - never attached?", GetCurrentThreadName());
 	}


### PR DESCRIPTION
Was tripping in our vertexjit test when run via adb shell.  Also reduce the noise a bit, sometimes we spawn a bunch of threads and it's in the way.

-[Unknown]