### PR TITLE
arm64jit: Implement several other Vec4 IR ops

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,6 +229,8 @@ jobs:
 
     - name: Setup ccache
       uses: hendrikmuhs/ccache-action@v1.2
+      # Disable ccache on macos for now, it's become buggy for some reason.
+      if: matrix.id != 'macos'
       with:
         key: ${{ matrix.id }}
 

--- a/Common/Arm64Emitter.cpp
+++ b/Common/Arm64Emitter.cpp
@@ -2128,6 +2128,13 @@ void ARM64FloatEmitter::EmitCopy(bool Q, u32 op, u32 imm5, u32 imm4, ARM64Reg Rd
 	        (1 << 10) | (Rn << 5) | Rd);
 }
 
+void ARM64FloatEmitter::EmitScalarPairwise(bool U, u32 size, u32 opcode, ARM64Reg Rd, ARM64Reg Rn) {
+	Rd = DecodeReg(Rd);
+	Rn = DecodeReg(Rn);
+
+	Write32((1 << 30) | (U << 29) | (0b111100011 << 20) | (size << 22) | (opcode << 12) | (1 << 11) | (Rn << 5) | Rd);
+}
+
 void ARM64FloatEmitter::Emit2RegMisc(bool Q, bool U, u32 size, u32 opcode, ARM64Reg Rd, ARM64Reg Rn)
 {
 	_assert_msg_(!IsSingle(Rd), "%s doesn't support singles!", __FUNCTION__);
@@ -2906,6 +2913,22 @@ void ARM64FloatEmitter::FSQRT(ARM64Reg Rd, ARM64Reg Rn)
 	EmitScalar1Source(0, 0, IsDouble(Rd), 3, Rd, Rn);
 }
 
+// Scalar - pairwise
+void ARM64FloatEmitter::FADDP(ARM64Reg Rd, ARM64Reg Rn) {
+	EmitScalarPairwise(1, IsDouble(Rd), 0b01101, Rd, Rn);
+}
+void ARM64FloatEmitter::FMAXP(ARM64Reg Rd, ARM64Reg Rn) {
+	EmitScalarPairwise(1, IsDouble(Rd), 0b01111, Rd, Rn);
+}
+void ARM64FloatEmitter::FMINP(ARM64Reg Rd, ARM64Reg Rn) {
+	EmitScalarPairwise(1, IsDouble(Rd) ? 3 : 2, 0b01111, Rd, Rn);
+}
+void ARM64FloatEmitter::FMAXNMP(ARM64Reg Rd, ARM64Reg Rn) {
+	EmitScalarPairwise(1, IsDouble(Rd), 0b01100, Rd, Rn);
+}
+void ARM64FloatEmitter::FMINNMP(ARM64Reg Rd, ARM64Reg Rn) {
+	EmitScalarPairwise(1, IsDouble(Rd) ? 3 : 2, 0b01100, Rd, Rn);
+}
 
 // Scalar - 2 Source
 void ARM64FloatEmitter::FADD(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
@@ -3022,6 +3045,9 @@ void ARM64FloatEmitter::FABS(u8 size, ARM64Reg Rd, ARM64Reg Rn)
 void ARM64FloatEmitter::FADD(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {
 	EmitThreeSame(0, size >> 6, 0x1A, Rd, Rn, Rm);
+}
+void ARM64FloatEmitter::FADDP(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm) {
+	EmitThreeSame(1, size >> 6, 0x1A, Rd, Rn, Rm);
 }
 void ARM64FloatEmitter::FMAX(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {

--- a/Common/Arm64Emitter.h
+++ b/Common/Arm64Emitter.h
@@ -901,6 +901,14 @@ public:
 	void UMOV(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index);
 	void SMOV(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index);
 
+	// Vector immediates
+	void FMOV(u8 size, ARM64Reg Rd, u8 imm8);
+	// MSL means bits shifted in are 1s.  For size=64, each bit of imm8 is expanded to 8 actual bits.
+	void MOVI(u8 size, ARM64Reg Rd, u8 imm8, u8 shift = 0, bool MSL = false);
+	void MVNI(u8 size, ARM64Reg Rd, u8 imm8, u8 shift = 0, bool MSL = false);
+	void ORR(u8 size, ARM64Reg Rd, u8 imm8, u8 shift = 0);
+	void BIC(u8 size, ARM64Reg Rd, u8 imm8, u8 shift = 0);
+
 	// One source
 	void FCVT(u8 size_to, u8 size_from, ARM64Reg Rd, ARM64Reg Rn);
 
@@ -966,7 +974,7 @@ public:
 	void FMLA(u8 esize, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, u8 index);
 
 	void MOVI2F(ARM64Reg Rd, float value, ARM64Reg scratch = INVALID_REG, bool negate = false);
-	void MOVI2FDUP(ARM64Reg Rd, float value, ARM64Reg scratch = INVALID_REG);
+	void MOVI2FDUP(ARM64Reg Rd, float value, ARM64Reg scratch = INVALID_REG, bool negate = false);
 
 	// ABI related
 	void ABI_PushRegisters(uint32_t gpr_registers, uint32_t fp_registers);
@@ -1003,6 +1011,7 @@ private:
 	void EmitScalar3Source(bool isDouble, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ARM64Reg Ra, int opcode);
 	void EncodeLoadStorePair(u32 size, bool load, IndexType type, ARM64Reg Rt, ARM64Reg Rt2, ARM64Reg Rn, s32 imm);
 	void EncodeLoadStoreRegisterOffset(u32 size, bool load, ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm);
+	void EncodeModImm(bool Q, u8 op, u8 cmode, u8 o2, ARM64Reg Rd, u8 abcdefgh);
 
 	void SSHLL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, bool upper);
 	void USHLL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, bool upper);

--- a/Common/Arm64Emitter.h
+++ b/Common/Arm64Emitter.h
@@ -820,6 +820,13 @@ public:
 	void FSQRT(ARM64Reg Rd, ARM64Reg Rn);
 	void FMOV(ARM64Reg Rd, ARM64Reg Rn, bool top = false);  // Also generalized move between GPR/FP
 
+	// Scalar - pairwise
+	void FADDP(ARM64Reg Rd, ARM64Reg Rn);
+	void FMAXP(ARM64Reg Rd, ARM64Reg Rn);
+	void FMINP(ARM64Reg Rd, ARM64Reg Rn);
+	void FMAXNMP(ARM64Reg Rd, ARM64Reg Rn);
+	void FMINNMP(ARM64Reg Rd, ARM64Reg Rn);
+
 	// Scalar - 2 Source
 	void FADD(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void FMUL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
@@ -847,6 +854,7 @@ public:
 	void DUP(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index);
 	void FABS(u8 size, ARM64Reg Rd, ARM64Reg Rn);
 	void FADD(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
+	void FADDP(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void FMAX(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void FMLA(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void FMLS(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
@@ -973,6 +981,7 @@ private:
 	void EmitScalar2Source(bool M, bool S, u32 type, u32 opcode, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void EmitThreeSame(bool U, u32 size, u32 opcode, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void EmitCopy(bool Q, u32 op, u32 imm5, u32 imm4, ARM64Reg Rd, ARM64Reg Rn);
+	void EmitScalarPairwise(bool U, u32 size, u32 opcode, ARM64Reg Rd, ARM64Reg Rn);
 	void Emit2RegMisc(bool Q, bool U, u32 size, u32 opcode, ARM64Reg Rd, ARM64Reg Rn);
 	void EmitLoadStoreSingleStructure(bool L, bool R, u32 opcode, bool S, u32 size, ARM64Reg Rt, ARM64Reg Rn);
 	void EmitLoadStoreSingleStructure(bool L, bool R, u32 opcode, bool S, u32 size, ARM64Reg Rt, ARM64Reg Rn, ARM64Reg Rm);

--- a/Core/MIPS/RiscV/RiscVCompVec.cpp
+++ b/Core/MIPS/RiscV/RiscVCompVec.cpp
@@ -174,14 +174,18 @@ void RiscVJitBackend::CompIR_VecAssign(IRInst inst) {
 		regs_.Map(inst);
 		for (int i = 0; i < 4; ++i) {
 			int which = (inst.constant >> i) & 1;
-			FMV(32, regs_.F(inst.dest + i), regs_.F((which ? inst.src2 : inst.src1) + i));
+			IRReg srcReg = which ? inst.src2 : inst.src1;
+			if (inst.dest != srcReg)
+				FMV(32, regs_.F(inst.dest + i), regs_.F(srcReg + i));
 		}
 		break;
 
 	case IROp::Vec4Mov:
-		regs_.Map(inst);
-		for (int i = 0; i < 4; ++i)
-			FMV(32, regs_.F(inst.dest + i), regs_.F(inst.src1 + i));
+		if (inst.dest != inst.src1) {
+			regs_.Map(inst);
+			for (int i = 0; i < 4; ++i)
+				FMV(32, regs_.F(inst.dest + i), regs_.F(inst.src1 + i));
+		}
 		break;
 
 	default:


### PR DESCRIPTION
Now it's mostly float stuff left.  Compares, integer convert, saturate, trig.

Vec4Blend isn't straight forward, like shuffle, but at least there's only a handful of cases.

Note: the MOVI2FDUP cleanup might slightly improve/affect the arm64 vertexjit, but should be in a positive way.

-[Unknown]