### PR TITLE
SasAudio: Always reinitialize the VAG decoder on sceSasSetVoice, even if already playing

### DIFF
--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -296,7 +296,7 @@ static u32 _sceSasCore(u32 core, u32 outAddr) {
 
 	__SasEnqueueMix(outAddr);
 
-	return hleLogSuccessI(SCESAS, delaySasResult(0));
+	return hleLogSuccessVerboseI(SCESAS, delaySasResult(0));
 }
 
 // Another way of running the mixer, the inoutAddr should be both input and output
@@ -315,7 +315,7 @@ static u32 _sceSasCoreWithMix(u32 core, u32 inoutAddr, int leftVolume, int right
 
 	__SasEnqueueMix(inoutAddr, inoutAddr, leftVolume, rightVolume);
 
-	return hleLogSuccessI(SCESAS, delaySasResult(0));
+	return hleLogSuccessVerboseI(SCESAS, delaySasResult(0));
 }
 
 static u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loop) {

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -363,8 +363,9 @@ static u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loo
 	v.type = VOICETYPE_VAG;
 	v.vagAddr = vagAddr;  // Real VAG header is 0x30 bytes behind the vagAddr
 	v.vagSize = size;
-	v.loop = loop ? true : false;
-	v.ChangedParams(vagAddr == prevVagAddr);
+	v.loop = loop != 0;
+	v.playing = true;
+	v.vag.Start(vagAddr, size, loop != 0);
 	return 0;
 }
 
@@ -401,7 +402,6 @@ static u32 sceSasSetVoicePCM(u32 core, int voiceNum, u32 pcmAddr, int size, int 
 	v.pcmLoopPos = loopPos >= 0 ? loopPos : 0;
 	v.loop = loopPos >= 0 ? true : false;
 	v.playing = true;
-	v.ChangedParams(pcmAddr == prevPcmAddr);
 	return 0;
 }
 
@@ -424,7 +424,7 @@ static u32 sceSasSetPause(u32 core, u32 voicebit, int pause) {
 	for (int i = 0; voicebit != 0; i++, voicebit >>= 1) {
 		if (i < PSP_SAS_VOICES_MAX && i >= 0) {
 			if ((voicebit & 1) != 0)
-				sas->voices[i].paused = pause ? true : false;
+				sas->voices[i].paused = pause != 0;
 		}
 	}
 
@@ -466,7 +466,6 @@ static u32 sceSasSetPitch(u32 core, int voiceNum, int pitch) {
 	__SasDrain();
 	SasVoice &v = sas->voices[voiceNum];
 	v.pitch = pitch;
-	v.ChangedParams(false);
 	return 0;
 }
 
@@ -523,7 +522,6 @@ static u32 sceSasSetNoise(u32 core, int voiceNum, int freq) {
 	SasVoice &v = sas->voices[voiceNum];
 	v.type = VOICETYPE_NOISE;
 	v.noiseFreq = freq;
-	v.ChangedParams(true);
 	return 0;
 }
 

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -364,7 +364,9 @@ static u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loo
 	v.vagAddr = vagAddr;  // Real VAG header is 0x30 bytes behind the vagAddr
 	v.vagSize = size;
 	v.loop = loop != 0;
-	v.playing = true;
+	if (v.on) {
+		v.playing = true;
+	}
 	v.vag.Start(vagAddr, size, loop != 0);
 	return 0;
 }

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -71,6 +71,8 @@ void VagDecoder::DecodeBlock(const u8 *&read_pointer) {
 		return;
 	}
 
+	_dbg_assert_(curBlock_ < numBlocks_);
+
 	const u8 *readp = read_pointer;
 	int predict_nr = *readp++;
 	int shift_factor = predict_nr & 0xf;

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -815,12 +815,10 @@ void SasVoice::KeyOff() {
 }
 
 void SasVoice::ChangedParams(bool changedVag) {
-	if (!playing && on) {
+	if (type == VOICETYPE_VAG) {
 		playing = true;
-		if (changedVag)
-			vag.Start(vagAddr, vagSize, loop);
+		vag.Start(vagAddr, vagSize, loop);
 	}
-	// TODO: restart VAG somehow
 }
 
 void SasVoice::DoState(PointerWrap &p) {

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -814,13 +814,6 @@ void SasVoice::KeyOff() {
 	envelope.KeyOff();
 }
 
-void SasVoice::ChangedParams(bool changedVag) {
-	if (type == VOICETYPE_VAG) {
-		playing = true;
-		vag.Start(vagAddr, vagSize, loop);
-	}
-}
-
 void SasVoice::DoState(PointerWrap &p) {
 	auto s = p.Section("SasVoice", 1, 3);
 	if (!s)

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -243,7 +243,6 @@ struct SasVoice {
 	void Reset();
 	void KeyOn();
 	void KeyOff();
-	void ChangedParams(bool changedVag);
 
 	void DoState(PointerWrap &p);
 


### PR DESCRIPTION
Fixes terrible noises in After Burner.

~~EDIT: Also breaks the engine noise in Ridge Racer, so this needs more work.~~

Not sure why the logic was like it was, blame history wasn't much clue either.

Will of course test a large number of other games before merging.