### PR TITLE
Avoid double-processing of input events caused by the overlay screen.

### DIFF
--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -49,14 +49,12 @@ void ScreenManager::update() {
 	}
 
 	if (overlayScreen_) {
+		// NOTE: This is not a full UIScreen update, to avoid double global event processing.
 		overlayScreen_->update();
 	}
 	if (stack_.size()) {
 		stack_.back().screen->update();
 	}
-
-	// NOTE: We should not update the OverlayScreen. In fact, we must never update more than one
-	// UIScreen in here, because we might end up double-processing the stuff in Root.cpp.
 
 	g_iconCache.FrameUpdate();
 }

--- a/Common/UI/UIScreen.h
+++ b/Common/UI/UIScreen.h
@@ -73,12 +73,13 @@ protected:
 	bool ignoreInsets_ = false;
 	bool ignoreInput_ = false;
 
-private:
+protected:
 	void DoRecreateViews();
 
 	bool recreateViews_ = true;
 	bool lastVertical_;
 
+private:
 	std::mutex eventQueueLock_;
 	std::deque<QueuedEvent> eventQueue_;
 };

--- a/UI/OnScreenDisplay.cpp
+++ b/UI/OnScreenDisplay.cpp
@@ -11,6 +11,7 @@
 #include "Common/UI/IconCache.h"
 #include "UI/RetroAchievementScreens.h"
 #include "UI/DebugOverlay.h"
+#include "UI/Root.h"
 
 #include "Common/UI/Context.h"
 #include "Common/System/OSD.h"
@@ -524,6 +525,17 @@ void OSDOverlayScreen::render() {
 		UIContext *uiContext = screenManager()->getUIContext();
 		DrawDebugOverlay(uiContext, uiContext->GetLayoutBounds(), debugOverlay);
 	}
+}
+
+void OSDOverlayScreen::update() {
+	// Partial version of UIScreen::update() but doesn't do event processing to avoid duplicate event processing.
+	bool vertical = UseVerticalLayout();
+	if (vertical != lastVertical_) {
+		RecreateViews();
+		lastVertical_ = vertical;
+	}
+
+	DoRecreateViews();
 }
 
 void NoticeView::GetContentDimensionsBySpec(const UIContext &dc, UI::MeasureSpec horiz, UI::MeasureSpec vert, float &w, float &h) const {

--- a/UI/OnScreenDisplay.h
+++ b/UI/OnScreenDisplay.h
@@ -42,6 +42,7 @@ public:
 
 	void CreateViews() override;
 	void render() override;
+	void update() override;
 
 private:
 	OnScreenMessagesView *osmView_ = nullptr;


### PR DESCRIPTION
Fixes #18070