### PR TITLE
arm64jit: Implement some float compares and conversions

### DIFF
--- a/Common/Arm64Emitter.cpp
+++ b/Common/Arm64Emitter.cpp
@@ -3011,6 +3011,12 @@ void ARM64FloatEmitter::BSL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {
 	EmitThreeSame(1, 1, 3, Rd, Rn, Rm);
 }
+void ARM64FloatEmitter::BIT(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm) {
+	EmitThreeSame(1, 2, 3, Rd, Rn, Rm);
+}
+void ARM64FloatEmitter::BIF(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm) {
+	EmitThreeSame(1, 3, 3, Rd, Rn, Rm);
+}
 void ARM64FloatEmitter::DUP(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index)
 {
 	u32 imm5 = 0;
@@ -3182,6 +3188,61 @@ void ARM64FloatEmitter::XTN(u8 dest_size, ARM64Reg Rd, ARM64Reg Rn)
 void ARM64FloatEmitter::XTN2(u8 dest_size, ARM64Reg Rd, ARM64Reg Rn)
 {
 	Emit2RegMisc(true, 0, dest_size >> 4, 0x12, Rd, Rn);
+}
+
+void ARM64FloatEmitter::CMEQ(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm) {
+	_assert_msg_(!IsQuad(Rd) || size != 64, "%s cannot be used for scalar double", __FUNCTION__);
+	EmitThreeSame(true, size >> 4, 0b10001, Rd, Rn, Rm);
+}
+
+void ARM64FloatEmitter::CMGE(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm) {
+	_assert_msg_(!IsQuad(Rd) || size != 64, "%s cannot be used for scalar double", __FUNCTION__);
+	EmitThreeSame(false, size >> 4, 0b00111, Rd, Rn, Rm);
+}
+
+void ARM64FloatEmitter::CMGT(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm) {
+	_assert_msg_(!IsQuad(Rd) || size != 64, "%s cannot be used for scalar double", __FUNCTION__);
+	EmitThreeSame(false, size >> 4, 0b00110, Rd, Rn, Rm);
+}
+
+void ARM64FloatEmitter::CMHI(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm) {
+	_assert_msg_(!IsQuad(Rd) || size != 64, "%s cannot be used for scalar double", __FUNCTION__);
+	EmitThreeSame(true, size >> 4, 0b00110, Rd, Rn, Rm);
+}
+
+void ARM64FloatEmitter::CMHS(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm) {
+	_assert_msg_(!IsQuad(Rd) || size != 64, "%s cannot be used for scalar double", __FUNCTION__);
+	EmitThreeSame(true, size >> 4, 0b00111, Rd, Rn, Rm);
+}
+
+void ARM64FloatEmitter::CMTST(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm) {
+	_assert_msg_(!IsQuad(Rd) || size != 64, "%s cannot be used for scalar double", __FUNCTION__);
+	EmitThreeSame(false, size >> 4, 0b10001, Rd, Rn, Rm);
+}
+
+void ARM64FloatEmitter::CMEQ(u8 size, ARM64Reg Rd, ARM64Reg Rn) {
+	_assert_msg_(!IsQuad(Rd) || size != 64, "%s cannot be used for scalar double", __FUNCTION__);
+	Emit2RegMisc(IsQuad(Rd), false, size >> 4, 0b01001, Rd, Rn);
+}
+
+void ARM64FloatEmitter::CMGE(u8 size, ARM64Reg Rd, ARM64Reg Rn) {
+	_assert_msg_(!IsQuad(Rd) || size != 64, "%s cannot be used for scalar double", __FUNCTION__);
+	Emit2RegMisc(IsQuad(Rd), true, size >> 4, 0b01000, Rd, Rn);
+}
+
+void ARM64FloatEmitter::CMGT(u8 size, ARM64Reg Rd, ARM64Reg Rn) {
+	_assert_msg_(!IsQuad(Rd) || size != 64, "%s cannot be used for scalar double", __FUNCTION__);
+	Emit2RegMisc(IsQuad(Rd), false, size >> 4, 0b01000, Rd, Rn);
+}
+
+void ARM64FloatEmitter::CMLE(u8 size, ARM64Reg Rd, ARM64Reg Rn) {
+	_assert_msg_(!IsQuad(Rd) || size != 64, "%s cannot be used for scalar double", __FUNCTION__);
+	Emit2RegMisc(IsQuad(Rd), true, size >> 4, 0b01001, Rd, Rn);
+}
+
+void ARM64FloatEmitter::CMLT(u8 size, ARM64Reg Rd, ARM64Reg Rn) {
+	_assert_msg_(!IsQuad(Rd) || size != 64, "%s cannot be used for scalar double", __FUNCTION__);
+	Emit2RegMisc(IsQuad(Rd), false, size >> 4, 0b01010, Rd, Rn);
 }
 
 // Move

--- a/Common/Arm64Emitter.h
+++ b/Common/Arm64Emitter.h
@@ -851,6 +851,8 @@ public:
 	void AND(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void EOR(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void BSL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
+	void BIT(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
+	void BIF(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void DUP(u8 size, ARM64Reg Rd, ARM64Reg Rn, u8 index);
 	void FABS(u8 size, ARM64Reg Rd, ARM64Reg Rn);
 	void FADD(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
@@ -893,6 +895,18 @@ public:
 	void UQXTN2(u8 dest_size, ARM64Reg Rd, ARM64Reg Rn);
 	void XTN(u8 dest_size, ARM64Reg Rd, ARM64Reg Rn);
 	void XTN2(u8 dest_size, ARM64Reg Rd, ARM64Reg Rn);
+
+	void CMEQ(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
+	void CMGE(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
+	void CMGT(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
+	void CMHI(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
+	void CMHS(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
+	void CMTST(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
+	void CMEQ(u8 size, ARM64Reg Rd, ARM64Reg Rn);
+	void CMGE(u8 size, ARM64Reg Rd, ARM64Reg Rn);
+	void CMGT(u8 size, ARM64Reg Rd, ARM64Reg Rn);
+	void CMLE(u8 size, ARM64Reg Rd, ARM64Reg Rn);
+	void CMLT(u8 size, ARM64Reg Rd, ARM64Reg Rn);
 
 	// Move
 	void DUP(u8 size, ARM64Reg Rd, ARM64Reg Rn);

--- a/Core/MIPS/ARM64/Arm64IRAsm.cpp
+++ b/Core/MIPS/ARM64/Arm64IRAsm.cpp
@@ -240,12 +240,11 @@ void Arm64JitBackend::GenerateFixedCode(MIPSState *mipsState) {
 	for (size_t i = 0; i < ARRAY_SIZE(roundModes); ++i) {
 		convertS0ToSCRATCH1_[i] = AlignCode16();
 
+		// Invert 0x80000000 -> 0x7FFFFFFF for the NAN result.
+		fp_.MVNI(32, EncodeRegToDouble(SCRATCHF2), 0x80, 24);
 		fp_.FCMP(S0, S0);  // Detect NaN
 		fp_.FCVTS(S0, S0, roundModes[i]);
-		FixupBranch skip = B(CC_VC);
-		MOVI2R(SCRATCH2, 0x7FFFFFFF);
-		fp_.FMOV(S0, SCRATCH2);
-		SetJumpTarget(skip);
+		fp_.FCSEL(S0, S0, SCRATCHF2, CC_VC);
 
 		RET();
 	}

--- a/Core/MIPS/ARM64/Arm64IRCompFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64IRCompFPU.cpp
@@ -237,7 +237,14 @@ void Arm64JitBackend::CompIR_FCvt(IRInst inst) {
 
 	switch (inst.op) {
 	case IROp::FCvtWS:
+		CompIR_Generic(inst);
+		break;
+
 	case IROp::FCvtSW:
+		regs_.Map(inst);
+		fp_.SCVTF(regs_.F(inst.dest), regs_.F(inst.src1));
+		break;
+
 	case IROp::FCvtScaledWS:
 	case IROp::FCvtScaledSW:
 		CompIR_Generic(inst);

--- a/Core/MIPS/RiscV/RiscVCompFPU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompFPU.cpp
@@ -405,6 +405,9 @@ void RiscVJitBackend::CompIR_FCompare(IRInst inst) {
 			SEQZ(regs_.R(IRREG_FPCOND), regs_.R(IRREG_FPCOND));
 			regs_.MarkGPRDirty(IRREG_FPCOND, true);
 			break;
+
+		default:
+			_assert_msg_(false, "Unexpected IRFpCompareMode %d", inst.dest);
 		}
 		break;
 

--- a/Core/MIPS/x86/X64IRCompFPU.cpp
+++ b/Core/MIPS/x86/X64IRCompFPU.cpp
@@ -322,6 +322,9 @@ void X64JitBackend::CompIR_FCompare(IRInst inst) {
 			// B/CF = LESS THAN or UNORDERED.
 			ccToFpcond(inst.src1, inst.src2, CC_B);
 			break;
+
+		default:
+			_assert_msg_(false, "Unexpected IRFpCompareMode %d", inst.dest);
 		}
 		break;
 


### PR DESCRIPTION
This handles the min/max and fcmp, but not the vfpu compares yet.  Also the basic int/float conversions.

By the way, there are so many ARM64 SIMD ops.  The emitter is missing a bunch of them still.

At this point, LittleBigPlanet in game is about ~88% speed compared to the regular arm64jit.  It mostly really needs VFPU compares which are frequent, and then also Vec2Pack32To16 (mostly during loading.)

There are also a few more ops that LittleBigPlanet doesn't use, just been using it as my first-case "is it fast yet?" example, since it does enough vec4 and it's easy to tell when I've erred when the sackboy has funny physics.

-[Unknown]