### PR TITLE
Add some texture loading safety checks

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2918,6 +2918,7 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 	}
 
 	if (plan.isVideo || plan.depth != 1 || plan.decodeToClut8) {
+		plan.levelsToLoad = 1;
 		plan.maxPossibleLevels = 1;
 	} else {
 		plan.maxPossibleLevels = log2i(std::min(plan.createW, plan.createH)) + 1;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -442,6 +442,8 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 		dstFmt = VULKAN_CLUT8_FORMAT;
 	}
 
+	_dbg_assert_(plan.levelsToLoad <= plan.maxPossibleLevels);
+
 	// We don't generate mipmaps for 512x512 textures because they're almost exclusively used for menu backgrounds
 	// and similar, which don't really need it.
 	// Also, if using replacements, check that we really can generate mips for this format - that's not possible for compressed ones.


### PR DESCRIPTION
I hit a spurious, non-consistently-reproducible debug assert in Archer McLean's Mercury. Just want to rule out some potentially bad code paths.