### PR TITLE
Vulkan: Fix disabling VSync on SDL platforms that support IMMEDIATE but not MAILBOX

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -1290,9 +1290,9 @@ bool VulkanContext::InitSwapchain() {
 	for (size_t i = 0; i < presentModeCount; i++) {
 		bool match = false;
 		match = match || ((flags_ & VULKAN_FLAG_PRESENT_MAILBOX) && presentModes[i] == VK_PRESENT_MODE_MAILBOX_KHR);
+		match = match || ((flags_ & VULKAN_FLAG_PRESENT_IMMEDIATE) && presentModes[i] == VK_PRESENT_MODE_IMMEDIATE_KHR);
 		match = match || ((flags_ & VULKAN_FLAG_PRESENT_FIFO_RELAXED) && presentModes[i] == VK_PRESENT_MODE_FIFO_RELAXED_KHR);
 		match = match || ((flags_ & VULKAN_FLAG_PRESENT_FIFO) && presentModes[i] == VK_PRESENT_MODE_FIFO_KHR);
-		match = match || ((flags_ & VULKAN_FLAG_PRESENT_IMMEDIATE) && presentModes[i] == VK_PRESENT_MODE_IMMEDIATE_KHR);
 
 		// Default to the first present mode from the list.
 		if (match || swapchainPresentMode == VK_PRESENT_MODE_MAX_ENUM_KHR) {

--- a/SDL/SDLVulkanGraphicsContext.cpp
+++ b/SDL/SDLVulkanGraphicsContext.cpp
@@ -27,9 +27,14 @@ static const bool g_Validate = true;
 static const bool g_Validate = false;
 #endif
 
+// TODO: Share this between backends.
 static uint32_t FlagsFromConfig() {
-	uint32_t flags = 0;
-	flags = g_Config.bVSync ? VULKAN_FLAG_PRESENT_FIFO : VULKAN_FLAG_PRESENT_MAILBOX;
+	uint32_t flags;
+	if (g_Config.bVSync) {
+		flags = VULKAN_FLAG_PRESENT_FIFO;
+	} else {
+		flags = VULKAN_FLAG_PRESENT_MAILBOX | VULKAN_FLAG_PRESENT_IMMEDIATE;
+	}
 	if (g_Validate) {
 		flags |= VULKAN_FLAG_VALIDATE;
 	}

--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -13,25 +13,32 @@
 #include "Core/ConfigValues.h"
 #include "Core/System.h"
 
+
+#ifdef _DEBUG
+static const bool g_Validate = true;
+#else
+static const bool g_Validate = false;
+#endif
+
+// TODO: Share this between backends.
+static uint32_t FlagsFromConfig() {
+	uint32_t flags;
+	if (g_Config.bVSync) {
+		flags = VULKAN_FLAG_PRESENT_FIFO;
+	} else {
+		flags = VULKAN_FLAG_PRESENT_MAILBOX | VULKAN_FLAG_PRESENT_IMMEDIATE;
+	}
+	if (g_Validate) {
+		flags |= VULKAN_FLAG_VALIDATE;
+	}
+	return flags;
+}
+
 AndroidVulkanContext::AndroidVulkanContext() {}
 
 AndroidVulkanContext::~AndroidVulkanContext() {
 	delete g_Vulkan;
 	g_Vulkan = nullptr;
-}
-
-static uint32_t FlagsFromConfig() {
-	uint32_t flags;
-
-	if (g_Config.bVSync) {
-		flags = VULKAN_FLAG_PRESENT_FIFO;
-	} else {
-		flags = VULKAN_FLAG_PRESENT_MAILBOX | VULKAN_FLAG_PRESENT_FIFO_RELAXED;
-	}
-#ifdef _DEBUG
-	flags |= VULKAN_FLAG_VALIDATE;
-#endif
-	return flags;
 }
 
 bool AndroidVulkanContext::InitAPI() {


### PR DESCRIPTION
This includes Mac M1.

Also allow IMMEDIATE and ignore FIFO_RELAXED on Android - the latter is simply not ever supported. Well, IMMEDIATE isn't supported much either on Android but its semantics are clearer than FIFO_RELAXED.

Fixes #18084