### PR TITLE
arm64jit: Implement VFPU compare, trig, couple others

### DIFF
--- a/Common/Arm64Emitter.cpp
+++ b/Common/Arm64Emitter.cpp
@@ -4115,8 +4115,6 @@ void ARM64FloatEmitter::MOVI2F(ARM64Reg Rd, float value, ARM64Reg scratch, bool 
 // TODO: Quite a few values could be generated easily using the MOVI instruction and friends.
 void ARM64FloatEmitter::MOVI2FDUP(ARM64Reg Rd, float value, ARM64Reg scratch, bool negate) {
 	_assert_msg_(!IsSingle(Rd), "%s doesn't support singles", __FUNCTION__);
-	// TODO: Make it work with more element sizes
-	ARM64Reg s = (ARM64Reg)(S0 + DecodeReg(Rd));
 	int ival;
 	memcpy(&ival, &value, 4);
 	uint8_t imm8;

--- a/Common/Arm64Emitter.cpp
+++ b/Common/Arm64Emitter.cpp
@@ -2268,6 +2268,17 @@ void ARM64FloatEmitter::EmitCondSelect(bool M, bool S, CCFlags cond, ARM64Reg Rd
 	        (cond << 12) | (3 << 10) | (Rn << 5) | Rd);
 }
 
+void ARM64FloatEmitter::EmitCondCompare(bool M, bool S, CCFlags cond, int op, u8 nzcv, ARM64Reg Rn, ARM64Reg Rm) {
+	_assert_msg_(!IsQuad(Rn), "%s doesn't support vector!", __FUNCTION__);
+	bool is_double = IsDouble(Rn);
+
+	Rn = DecodeReg(Rn);
+	Rm = DecodeReg(Rm);
+
+	Write32((M << 31) | (S << 29) | (0xF1 << 21) | (is_double << 22) | (Rm << 16) | \
+		(cond << 12) | (1 << 10) | (Rn << 5) | (op << 4) | nzcv);
+}
+
 void ARM64FloatEmitter::EmitPermute(u32 size, u32 op, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 {
 	_assert_msg_(!IsSingle(Rd), "%s doesn't support singles!", __FUNCTION__);
@@ -3598,6 +3609,14 @@ void ARM64FloatEmitter::FCMLT(u8 size, ARM64Reg Rd, ARM64Reg Rn)
 void ARM64FloatEmitter::FCSEL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, CCFlags cond)
 {
 	EmitCondSelect(0, 0, cond, Rd, Rn, Rm);
+}
+
+void ARM64FloatEmitter::FCCMP(ARM64Reg Rn, ARM64Reg Rm, u8 nzcv, CCFlags cond) {
+	EmitCondCompare(0, 0, cond, 0, nzcv, Rn, Rm);
+}
+
+void ARM64FloatEmitter::FCCMPE(ARM64Reg Rn, ARM64Reg Rm, u8 nzcv, CCFlags cond) {
+	EmitCondCompare(0, 0, cond, 1, nzcv, Rn, Rm);
 }
 
 // Permute

--- a/Common/Arm64Emitter.h
+++ b/Common/Arm64Emitter.h
@@ -957,6 +957,10 @@ public:
 	// Conditional select
 	void FCSEL(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, CCFlags cond);
 
+	// Conditional compare
+	void FCCMP(ARM64Reg Rn, ARM64Reg Rm, u8 nzcv, CCFlags cond);
+	void FCCMPE(ARM64Reg Rn, ARM64Reg Rm, u8 nzcv, CCFlags cond);
+
 	// Permute
 	void UZP1(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void TRN1(u8 size, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
@@ -1012,6 +1016,7 @@ private:
 	void EmitConversion2(bool sf, bool S, bool direction, u32 type, u32 rmode, u32 opcode, int scale, ARM64Reg Rd, ARM64Reg Rn);
 	void EmitCompare(bool M, bool S, u32 op, u32 opcode2, ARM64Reg Rn, ARM64Reg Rm);
 	void EmitCondSelect(bool M, bool S, CCFlags cond, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
+	void EmitCondCompare(bool M, bool S, CCFlags cond, int op, u8 nzcv, ARM64Reg Rn, ARM64Reg Rm);
 	void EmitPermute(u32 size, u32 op, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void EmitScalarImm(bool M, bool S, u32 type, u32 imm5, ARM64Reg Rd, u32 imm8);
 	void EmitShiftImm(bool Q, bool U, u32 immh, u32 immb, u32 opcode, ARM64Reg Rd, ARM64Reg Rn);

--- a/Core/MIPS/ARM64/Arm64IRCompFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64IRCompFPU.cpp
@@ -285,7 +285,6 @@ void Arm64JitBackend::CompIR_FCompare(IRInst inst) {
 			// Less than Infinity, but not NAN.
 			CSET(SCRATCH1, CC_LO);
 			break;
-			break;
 		case VC_TR:
 			MOVI2R(SCRATCH1, 1);
 			break;

--- a/Core/MIPS/ARM64/Arm64IRRegCache.cpp
+++ b/Core/MIPS/ARM64/Arm64IRRegCache.cpp
@@ -296,6 +296,17 @@ ARM64Reg Arm64IRRegCache::MapFPR(IRReg mipsReg, MIPSMap mapFlags) {
 	return INVALID_REG;
 }
 
+ARM64Reg Arm64IRRegCache::MapVec2(IRReg first, MIPSMap mapFlags) {
+	_dbg_assert_(IsValidFPR(first));
+	_dbg_assert_((first & 1) == 0);
+	_dbg_assert_(mr[first + 32].loc == MIPSLoc::MEM || mr[first + 32].loc == MIPSLoc::FREG);
+
+	IRNativeReg nreg = MapNativeReg(MIPSLoc::FREG, first + 32, 2, mapFlags);
+	if (nreg != -1)
+		return EncodeRegToDouble(FromNativeReg(nreg));
+	return INVALID_REG;
+}
+
 ARM64Reg Arm64IRRegCache::MapVec4(IRReg first, MIPSMap mapFlags) {
 	_dbg_assert_(IsValidFPR(first));
 	_dbg_assert_((first & 3) == 0);

--- a/Core/MIPS/ARM64/Arm64IRRegCache.h
+++ b/Core/MIPS/ARM64/Arm64IRRegCache.h
@@ -59,6 +59,7 @@ public:
 	Arm64Gen::ARM64Reg MapGPR2(IRReg reg, MIPSMap mapFlags = MIPSMap::INIT);
 	Arm64Gen::ARM64Reg MapGPRAsPointer(IRReg reg);
 	Arm64Gen::ARM64Reg MapFPR(IRReg reg, MIPSMap mapFlags = MIPSMap::INIT);
+	Arm64Gen::ARM64Reg MapVec2(IRReg first, MIPSMap mapFlags = MIPSMap::INIT);
 	Arm64Gen::ARM64Reg MapVec4(IRReg first, MIPSMap mapFlags = MIPSMap::INIT);
 
 	Arm64Gen::ARM64Reg MapWithFPRTemp(const IRInst &inst);

--- a/Core/MIPS/RiscV/RiscVCompFPU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompFPU.cpp
@@ -442,17 +442,8 @@ void RiscVJitBackend::CompIR_FCompare(IRInst inst) {
 			break;
 		case VC_NE:
 			regs_.Map(inst);
-			// We could almost negate FEQ, except NAN != NAN.
-			// Anything != NAN is false and NAN != NAN is within that, so we only check one side.
-			FCLASS(32, SCRATCH2, regs_.F(inst.src2));
-			// NAN is 0x100 or 0x200.
-			ANDI(SCRATCH2, SCRATCH2, 0x300);
-			SNEZ(SCRATCH2, SCRATCH2);
-
 			FEQ(32, SCRATCH1, regs_.F(inst.src1), regs_.F(inst.src2));
 			SEQZ(SCRATCH1, SCRATCH1);
-			// Just OR in whether that side was a NAN so it's always not equal.
-			OR(SCRATCH1, SCRATCH1, SCRATCH2);
 			break;
 		case VC_LT:
 			regs_.Map(inst);


### PR DESCRIPTION
Also FSign just because.

This implements all the remaining ops used in LittleBigPlanet ingame (and, many other games, again just using this as a test case.)

Bloat is reduced a good bit -> about 530% down to 420%.  However, performance on my device doesn't seem significantly different - maybe even slightly slower, but it's hard to tell due to thermal throttling.  A bit disappointing.  I haven't tried other games yet (and there may still be bugs because of this.)

Would be curious how it runs on an M1 or similar, which might have more predictable thermal behavior.

Interestingly, I think bloat is on par with RISC-V, and that's comparing ARM64 NEON to RISC-V without vector.  Likely a good story for code density there, but obviously my phone is running circles and complicated loops around my RISC-V test board.

-[Unknown]