### PR TITLE
[NetResolver] Implement sceNetResolver library

### DIFF
--- a/Core/HLE/FunctionWrappers.h
+++ b/Core/HLE/FunctionWrappers.h
@@ -443,6 +443,11 @@ template<int func(int, u32, u32, int, int)> void WrapI_IUUII() {
 	RETURN(retval);
 }
 
+template<int func(int, u32, u32, int, int, int)> void WrapI_IUUIII() {
+	int retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4), PARAM(5));
+	RETURN(retval);
+}
+
 template<int func(int, const char *, int, u32, u32)> void WrapI_ICIUU() {
 	int retval = func(PARAM(0), Memory::GetCharPointer(PARAM(1)), PARAM(2), PARAM(3), PARAM(4));
 	RETURN(retval);

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -334,6 +334,8 @@ void __NetDoState(PointerWrap &p) {
 
 		// Discard leftover events
 		apctlEvents.clear();
+		// Discard created resolvers for now (since i'm not sure whether the information in the struct is sufficient or not, and we don't support multi-threading yet anyway)
+		netResolvers.clear();
 	}
 }
 

--- a/Core/HLE/sceNet.h
+++ b/Core/HLE/sceNet.h
@@ -290,6 +290,13 @@ struct ApctlArgs {
 	u32_le data[5]; // OldState, NewState, Event, Error, ArgsAddr
 };
 
+struct NetResolver {
+	int  id;
+	bool isRunning;
+	u32  bufferAddr; // May be used for the Async version?
+	int  bufferLen;
+};
+
 class PointerWrap;
 
 class AfterApctlMipsCall : public PSPAction {


### PR DESCRIPTION
Yet another rough and experimental implementation taken from my stashed codes.

It works on most of the games i tested, also used for the test builds at https://github.com/hrydgard/ppsspp/issues/14256
However, since it use dummy id (1), it can only support one resolver created at a time.
It also enforce synchronous resolving (i think), including for the Async syscalls, this will lower the chance for the game to create more than one resolver, as the game will delete it once the result are out.

Leaving this as a draft until i can work on it later, at least to get the id properly generated to support multiple resolvers (ie. for games/app with multi-threading).

PS: Should also move it to a separate file (ie. sceNetResolver.cpp) as the general sceNet.cpp will grow bigger with infrastructure being implemented later.