### PR TITLE
New logging channel "KERNELPRINTF" for SceKernelPrintf

### DIFF
--- a/Common/Log.h
+++ b/Common/Log.h
@@ -46,6 +46,7 @@ enum class LogType {
 	IO,
 	ACHIEVEMENTS,
 	HTTP,
+	KERNELPRINTF,
 
 	SCEAUDIO,
 	SCECTRL,

--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -97,6 +97,7 @@ static const char *g_logTypeNames[] = {
 	"IO",
 	"ACHIEVEMENTS",
 	"HTTP",
+	"KERNELPRINTF",
 
 	"SCEAUDIO",
 	"SCECTRL",

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -1211,9 +1211,9 @@ static int sceKernelPrintf(const char *formatString)
 		result.resize(result.size() - 1);
 
 	if (supported)
-		INFO_LOG(SCEKERNEL, "sceKernelPrintf: %s", result.c_str());
+		NOTICE_LOG(KERNELPRINTF, "sceKernelPrintf: %s", result.c_str());
 	else
-		ERROR_LOG(SCEKERNEL, "UNIMPL sceKernelPrintf(%s, %08x, %08x, %08x)", format.c_str(), PARAM(1), PARAM(2), PARAM(3));
+		ERROR_LOG(KERNELPRINTF, "UNIMPL sceKernelPrintf(%s, %08x, %08x, %08x)", format.c_str(), PARAM(1), PARAM(2), PARAM(3));
 	return 0;
 }
 


### PR DESCRIPTION
This enables the users to set up their logs so that the internal game logs wouldn't force them to change the logging channel for SCEKERNEL to Info (which produces quite a few logs, for instance, the ones related to thread management).

![image](https://github.com/hrydgard/ppsspp/assets/62447396/0f8ca2ca-3782-4857-b2a4-1de9442adfe4)

As you can see, I've also changed the log level from Info to Notice just to make the logs easier to distinguish from random PPSSPP logs and to make them similar to breakpoint logs.