### PR TITLE
UI: Fix search within savedata screen

### DIFF
--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -675,9 +675,7 @@ UI::EventReturn SavedataScreen::OnSearch(UI::EventParams &e) {
 	auto di = GetI18NCategory(I18NCat::DIALOG);
 	if (System_GetPropertyBool(SYSPROP_HAS_TEXT_INPUT_DIALOG)) {
 		System_InputBoxGetString(di->T("Filter"), searchFilter_, [](const std::string &value, int ivalue) {
-			if (ivalue) {
-				System_PostUIMessage("savedatascreen_search", value.c_str());
-			}
+			System_PostUIMessage("savedatascreen_search", value.c_str());
 		});
 	}
 	return UI::EVENT_DONE;


### PR DESCRIPTION
Fixes breakage from converting things to requests and etc.  This was always zero, so it was never searching.

-[Unknown]