### PR TITLE
New logging channel "PRINTF" for SceKernelPrintf

### DIFF
--- a/Common/Log.h
+++ b/Common/Log.h
@@ -46,6 +46,7 @@ enum class LogType {
 	IO,
 	ACHIEVEMENTS,
 	HTTP,
+	KERNELPRINTF,
 
 	SCEAUDIO,
 	SCECTRL,

--- a/Common/Log.h
+++ b/Common/Log.h
@@ -46,7 +46,7 @@ enum class LogType {
 	IO,
 	ACHIEVEMENTS,
 	HTTP,
-	KERNELPRINTF,
+	PRINTF,
 
 	SCEAUDIO,
 	SCECTRL,

--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -97,6 +97,7 @@ static const char *g_logTypeNames[] = {
 	"IO",
 	"ACHIEVEMENTS",
 	"HTTP",
+	"KERNELPRINTF",
 
 	"SCEAUDIO",
 	"SCECTRL",

--- a/Common/LogManager.cpp
+++ b/Common/LogManager.cpp
@@ -97,7 +97,7 @@ static const char *g_logTypeNames[] = {
 	"IO",
 	"ACHIEVEMENTS",
 	"HTTP",
-	"KERNELPRINTF",
+	"PRINTF",
 
 	"SCEAUDIO",
 	"SCECTRL",

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1179,7 +1179,7 @@ static bool __IoWrite(int &result, int id, u32 data_addr, int size, int &us) {
 	if (id == PSP_STDOUT || id == PSP_STDERR) {
 		const char *str = (const char *) data_ptr;
 		const int str_size = size <= 0 ? 0 : (str[validSize - 1] == '\n' ? validSize - 1 : validSize);
-		INFO_LOG(SCEIO, "%s: %.*s", id == 1 ? "stdout" : "stderr", str_size, str);
+		INFO_LOG(PRINTF, "%s: %.*s", id == 1 ? "stdout" : "stderr", str_size, str);
 		result = validSize;
 		return true;
 	}
@@ -1205,7 +1205,7 @@ static bool __IoWrite(int &result, int id, u32 data_addr, int size, int &us) {
 		if (f->isTTY) {
 			const char *str = (const char *)data_ptr;
 			const int str_size = size <= 0 ? 0 : (str[validSize - 1] == '\n' ? validSize - 1 : validSize);
-			INFO_LOG(SCEIO, "%s: %.*s", "tty", str_size, str);
+			INFO_LOG(PRINTF, "%s: %.*s", "tty", str_size, str);
 			result = validSize;
 			return true;
 		}

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -1211,9 +1211,9 @@ static int sceKernelPrintf(const char *formatString)
 		result.resize(result.size() - 1);
 
 	if (supported)
-		INFO_LOG(SCEKERNEL, "sceKernelPrintf: %s", result.c_str());
+		NOTICE_LOG(KERNELPRINTF, "sceKernelPrintf: %s", result.c_str());
 	else
-		ERROR_LOG(SCEKERNEL, "UNIMPL sceKernelPrintf(%s, %08x, %08x, %08x)", format.c_str(), PARAM(1), PARAM(2), PARAM(3));
+		ERROR_LOG(KERNELPRINTF, "UNIMPL sceKernelPrintf(%s, %08x, %08x, %08x)", format.c_str(), PARAM(1), PARAM(2), PARAM(3));
 	return 0;
 }
 

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -1211,9 +1211,9 @@ static int sceKernelPrintf(const char *formatString)
 		result.resize(result.size() - 1);
 
 	if (supported)
-		NOTICE_LOG(KERNELPRINTF, "sceKernelPrintf: %s", result.c_str());
+		INFO_LOG(PRINTF, "sceKernelPrintf: %s", result.c_str());
 	else
-		ERROR_LOG(KERNELPRINTF, "UNIMPL sceKernelPrintf(%s, %08x, %08x, %08x)", format.c_str(), PARAM(1), PARAM(2), PARAM(3));
+		ERROR_LOG(PRINTF, "UNIMPL sceKernelPrintf(%s, %08x, %08x, %08x)", format.c_str(), PARAM(1), PARAM(2), PARAM(3));
 	return 0;
 }
 


### PR DESCRIPTION
This is simply Nemoumbra's #18098 but with KERNELPRINTF changed to PRINTF and NOTICE changed to INFO.