### PR TITLE
Core/MIPS/MIPSTables.h: add stdint.h include

### DIFF
--- a/Core/MIPS/MIPSTables.h
+++ b/Core/MIPS/MIPSTables.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <string>
+#include <stdint.h>
 #include "Common/CommonTypes.h"
 #include "Core/MIPS/MIPS.h"
 


### PR DESCRIPTION
without `stdint.h` compilation fails on Gentoo with GCC 13.2.1