### PR TITLE
IR: Add mini native jit MIPS block profiler

### DIFF
--- a/Core/MIPS/ARM64/Arm64IRCompFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64IRCompFPU.cpp
@@ -508,6 +508,8 @@ void Arm64JitBackend::CompIR_FSpecial(IRInst inst) {
 
 	auto callFuncF_F = [&](float (*func)(float)) {
 		regs_.FlushBeforeCall();
+		WriteDebugProfilerStatus(IRProfilerStatus::MATH_HELPER);
+
 		// It might be in a non-volatile register.
 		// TODO: May have to handle a transfer if SIMD here.
 		if (regs_.IsFPRMapped(inst.src1)) {
@@ -527,6 +529,8 @@ void Arm64JitBackend::CompIR_FSpecial(IRInst inst) {
 		if (regs_.F(inst.dest) != S0) {
 			fp_.FMOV(regs_.F(inst.dest), S0);
 		}
+
+		WriteDebugProfilerStatus(IRProfilerStatus::IN_JIT);
 	};
 
 	switch (inst.op) {

--- a/Core/MIPS/ARM64/Arm64IRCompSystem.cpp
+++ b/Core/MIPS/ARM64/Arm64IRCompSystem.cpp
@@ -210,6 +210,7 @@ void Arm64JitBackend::CompIR_System(IRInst inst) {
 		FlushAll();
 		SaveStaticRegisters();
 
+		WriteDebugProfilerStatus(IRProfilerStatus::SYSCALL);
 #ifdef USE_PROFILER
 		// When profiling, we can't skip CallSyscall, since it times syscalls.
 		MOVI2R(W0, inst.constant);
@@ -229,6 +230,7 @@ void Arm64JitBackend::CompIR_System(IRInst inst) {
 		}
 #endif
 
+		WriteDebugProfilerStatus(IRProfilerStatus::IN_JIT);
 		LoadStaticRegisters();
 		// This is always followed by an ExitToPC, where we check coreState.
 		break;
@@ -236,7 +238,9 @@ void Arm64JitBackend::CompIR_System(IRInst inst) {
 	case IROp::CallReplacement:
 		FlushAll();
 		SaveStaticRegisters();
+		WriteDebugProfilerStatus(IRProfilerStatus::REPLACEMENT);
 		QuickCallFunction(SCRATCH2_64, GetReplacementFunc(inst.constant)->replaceFunc);
+		WriteDebugProfilerStatus(IRProfilerStatus::IN_JIT);
 		LoadStaticRegisters();
 		SUB(DOWNCOUNTREG, DOWNCOUNTREG, W0);
 		break;

--- a/Core/MIPS/ARM64/Arm64IRJit.cpp
+++ b/Core/MIPS/ARM64/Arm64IRJit.cpp
@@ -76,6 +76,8 @@ bool Arm64JitBackend::CompileBlock(IRBlock *block, int block_num, bool preload) 
 		SetBlockCheckedOffset(block_num, (int)GetOffset(GetCodePointer()));
 		wroteCheckedOffset = true;
 
+		WriteDebugPC(startPC);
+
 		// Check the sign bit to check if negative.
 		FixupBranch normalEntry = TBZ(DOWNCOUNTREG, 31);
 		MOVI2R(SCRATCH1, startPC);
@@ -129,6 +131,8 @@ bool Arm64JitBackend::CompileBlock(IRBlock *block, int block_num, bool preload) 
 	}
 
 	if (jo.enableBlocklink && jo.useBackJump) {
+		WriteDebugPC(startPC);
+
 		// Small blocks are common, check if it's < 32KB long.
 		ptrdiff_t distance = blockStart - GetCodePointer();
 		if (distance >= -0x8000 && distance < 0x8000) {
@@ -229,8 +233,10 @@ void Arm64JitBackend::CompIR_Generic(IRInst inst) {
 
 	FlushAll();
 	SaveStaticRegisters();
+	WriteDebugProfilerStatus(IRProfilerStatus::IR_INTERPRET);
 	MOVI2R(X0, value);
 	QuickCallFunction(SCRATCH2_64, &DoIRInst);
+	WriteDebugProfilerStatus(IRProfilerStatus::IN_JIT);
 	LoadStaticRegisters();
 
 	// We only need to check the return value if it's a potential exit.
@@ -256,12 +262,14 @@ void Arm64JitBackend::CompIR_Interpret(IRInst inst) {
 	// IR protects us against this being a branching instruction (well, hopefully.)
 	FlushAll();
 	SaveStaticRegisters();
+	WriteDebugProfilerStatus(IRProfilerStatus::INTERPRET);
 	if (DebugStatsEnabled()) {
 		MOVP2R(X0, MIPSGetName(op));
 		QuickCallFunction(SCRATCH2_64, &NotifyMIPSInterpret);
 	}
 	MOVI2R(X0, inst.constant);
 	QuickCallFunction(SCRATCH2_64, MIPSGetInterpretFunc(op));
+	WriteDebugProfilerStatus(IRProfilerStatus::IN_JIT);
 	LoadStaticRegisters();
 }
 
@@ -352,6 +360,32 @@ void Arm64JitBackend::MovFromPC(ARM64Reg r) {
 
 void Arm64JitBackend::MovToPC(ARM64Reg r) {
 	STR(INDEX_UNSIGNED, r, CTXREG, offsetof(MIPSState, pc));
+}
+
+void Arm64JitBackend::WriteDebugPC(uint32_t pc) {
+	if (hooks_.profilerPC) {
+		int offset = (int)((const u8 *)hooks_.profilerPC - GetBasePtr());
+		MOVI2R(SCRATCH2, MIPS_EMUHACK_OPCODE + offset);
+		MOVI2R(SCRATCH1, pc);
+		STR(SCRATCH1, JITBASEREG, SCRATCH2);
+	}
+}
+
+void Arm64JitBackend::WriteDebugPC(ARM64Reg r) {
+	if (hooks_.profilerPC) {
+		int offset = (int)((const u8 *)hooks_.profilerPC - GetBasePtr());
+		MOVI2R(SCRATCH2, MIPS_EMUHACK_OPCODE + offset);
+		STR(r, JITBASEREG, SCRATCH2);
+	}
+}
+
+void Arm64JitBackend::WriteDebugProfilerStatus(IRProfilerStatus status) {
+	if (hooks_.profilerPC) {
+		int offset = (int)((const u8 *)hooks_.profilerStatus - GetBasePtr());
+		MOVI2R(SCRATCH2, MIPS_EMUHACK_OPCODE + offset);
+		MOVI2R(SCRATCH1, (int)status);
+		STR(SCRATCH1, JITBASEREG, SCRATCH2);
+	}
 }
 
 void Arm64JitBackend::SaveStaticRegisters() {

--- a/Core/MIPS/ARM64/Arm64IRJit.h
+++ b/Core/MIPS/ARM64/Arm64IRJit.h
@@ -57,6 +57,11 @@ private:
 	void UpdateRoundingMode(bool force = false);
 	void MovFromPC(Arm64Gen::ARM64Reg r);
 	void MovToPC(Arm64Gen::ARM64Reg r);
+	// Destroys SCRATCH2.
+	void WriteDebugPC(uint32_t pc);
+	void WriteDebugPC(Arm64Gen::ARM64Reg r);
+	// Destroys SCRATCH2.
+	void WriteDebugProfilerStatus(IRProfilerStatus status);
 
 	void SaveStaticRegisters();
 	void LoadStaticRegisters();

--- a/Core/MIPS/IR/IRNativeCommon.cpp
+++ b/Core/MIPS/IR/IRNativeCommon.cpp
@@ -15,7 +15,9 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <atomic>
 #include <climits>
+#include <thread>
 #include "Common/Profiler/Profiler.h"
 #include "Common/StringUtils.h"
 #include "Common/TimeUtil.h"
@@ -31,18 +33,57 @@ namespace MIPSComp {
 
 // Compile time flag to enable debug stats for not compiled ops.
 static constexpr bool enableDebugStats = false;
+// Compile time flag for enabling the simple IR jit profiler.
+static constexpr bool enableDebugProfiler = false;
 
 // Used only for debugging when enableDebug is true above.
 static std::map<uint8_t, int> debugSeenNotCompiledIR;
 static std::map<const char *, int> debugSeenNotCompiled;
+static std::map<std::pair<uint32_t, IRProfilerStatus>, int> debugSeenPCUsage;
 static double lastDebugStatsLog = 0.0;
+static constexpr double debugStatsFrequency = 5.0;
+
+static std::thread debugProfilerThread;
+std::atomic<bool> debugProfilerThreadStatus = false;
+
+template <int N>
+class IRProfilerTopValues {
+public:
+	void Add(const std::pair<uint32_t, IRProfilerStatus> &v, int c) {
+		for (int i = 0; i < N; ++i) {
+			if (c > counts[i]) {
+				counts[i] = c;
+				values[i] = v;
+				return;
+			}
+		}
+	}
+
+	int counts[N]{};
+	std::pair<uint32_t, IRProfilerStatus> values[N]{};
+};
+
+const char *IRProfilerStatusToString(IRProfilerStatus s) {
+	switch (s) {
+	case IRProfilerStatus::NOT_RUNNING: return "NOT_RUNNING";
+	case IRProfilerStatus::IN_JIT: return "IN_JIT";
+	case IRProfilerStatus::TIMER_ADVANCE: return "TIMER_ADVANCE";
+	case IRProfilerStatus::COMPILING: return "COMPILING";
+	case IRProfilerStatus::MATH_HELPER: return "MATH_HELPER";
+	case IRProfilerStatus::REPLACEMENT: return "REPLACEMENT";
+	case IRProfilerStatus::SYSCALL: return "SYSCALL";
+	case IRProfilerStatus::INTERPRET: return "INTERPRET";
+	case IRProfilerStatus::IR_INTERPRET: return "IR_INTERPRET";
+	}
+	return "INVALID";
+}
 
 static void LogDebugStats() {
-	if (!enableDebugStats)
+	if (!enableDebugStats && !enableDebugProfiler)
 		return;
 
 	double now = time_now_d();
-	if (now < lastDebugStatsLog + 1.0)
+	if (now < lastDebugStatsLog + debugStatsFrequency)
 		return;
 	lastDebugStatsLog = now;
 
@@ -66,14 +107,34 @@ static void LogDebugStats() {
 	}
 	debugSeenNotCompiled.clear();
 
+	IRProfilerTopValues<4> slowestPCs;
+	int64_t totalCount = 0;
+	for (auto it : debugSeenPCUsage) {
+		slowestPCs.Add(it.first, it.second);
+		totalCount += it.second;
+	}
+	debugSeenPCUsage.clear();
+
 	if (worstIROp != -1)
 		WARN_LOG(JIT, "Most not compiled IR op: %s (%d)", GetIRMeta((IROp)worstIROp)->name, worstIRVal);
 	if (worstName != nullptr)
 		WARN_LOG(JIT, "Most not compiled op: %s (%d)", worstName, worstVal);
+	if (slowestPCs.counts[0] != 0) {
+		for (int i = 0; i < 4; ++i) {
+			uint32_t pc = slowestPCs.values[i].first;
+			const char *status = IRProfilerStatusToString(slowestPCs.values[i].second);
+			const std::string label = g_symbolMap ? g_symbolMap->GetDescription(pc) : "";
+			WARN_LOG(JIT, "Slowest sampled PC #%d: %08x (%s)/%s (%f%%)", i, pc, label.c_str(), status, 100.0 * (double)slowestPCs.counts[i] / (double)totalCount);
+		}
+	}
 }
 
 bool IRNativeBackend::DebugStatsEnabled() const {
 	return enableDebugStats;
+}
+
+bool IRNativeBackend::DebugProfilerEnabled() const {
+	return enableDebugProfiler;
 }
 
 void IRNativeBackend::NotifyMIPSInterpret(const char *name) {
@@ -119,6 +180,13 @@ int IRNativeBackend::ReportBadAddress(uint32_t addr, uint32_t alignment, uint32_
 }
 
 IRNativeBackend::IRNativeBackend(IRBlockCache &blocks) : blocks_(blocks) {}
+
+IRNativeBackend::~IRNativeBackend() {
+	if (debugProfilerThreadStatus) {
+		debugProfilerThreadStatus = false;
+		debugProfilerThread.join();
+	}
+}
 
 void IRNativeBackend::CompileIRInst(IRInst inst) {
 	switch (inst.op) {
@@ -421,6 +489,20 @@ void IRNativeJit::Init(IRNativeBackend &backend) {
 
 	// Wanted this to be a reference, but vtbls get in the way.  Shouldn't change.
 	hooks_ = backend.GetNativeHooks();
+
+	if (enableDebugProfiler && hooks_.profilerPC) {
+		debugProfilerThreadStatus = true;
+		debugProfilerThread = std::thread([&] {
+			// Spin, spin spin... maybe could at least hook into sleeps.
+			while (debugProfilerThreadStatus) {
+				IRProfilerStatus stat = *hooks_.profilerStatus;
+				uint32_t pc = *hooks_.profilerPC;
+				if (stat != IRProfilerStatus::NOT_RUNNING && stat != IRProfilerStatus::SYSCALL) {
+					debugSeenPCUsage[std::make_pair(pc, stat)]++;
+				}
+			}
+		});
+	}
 }
 
 bool IRNativeJit::CompileTargetBlock(IRBlock *block, int block_num, bool preload) {
@@ -432,7 +514,7 @@ void IRNativeJit::FinalizeTargetBlock(IRBlock *block, int block_num) {
 }
 
 void IRNativeJit::RunLoopUntil(u64 globalticks) {
-	if constexpr (enableDebugStats) {
+	if constexpr (enableDebugStats || enableDebugProfiler) {
 		LogDebugStats();
 	}
 

--- a/Core/MIPS/IR/IRNativeCommon.h
+++ b/Core/MIPS/IR/IRNativeCommon.h
@@ -25,12 +25,27 @@ namespace MIPSComp {
 
 typedef void (*IRNativeFuncNoArg)();
 
+enum class IRProfilerStatus : int32_t {
+	NOT_RUNNING,
+	IN_JIT,
+	TIMER_ADVANCE,
+	COMPILING,
+	MATH_HELPER,
+	REPLACEMENT,
+	SYSCALL,
+	INTERPRET,
+	IR_INTERPRET,
+};
+
 struct IRNativeHooks {
 	IRNativeFuncNoArg enterDispatcher = nullptr;
 
 	const uint8_t *dispatcher = nullptr;
 	const uint8_t *dispatchFetch = nullptr;
 	const uint8_t *crashHandler = nullptr;
+
+	uint32_t *profilerPC = nullptr;
+	IRProfilerStatus *profilerStatus = nullptr;
 };
 
 struct IRNativeBlockExit {
@@ -47,7 +62,7 @@ struct IRNativeBlock {
 class IRNativeBackend {
 public:
 	IRNativeBackend(IRBlockCache &blocks);
-	virtual ~IRNativeBackend() {}
+	virtual ~IRNativeBackend();
 
 	void CompileIRInst(IRInst inst);
 
@@ -120,6 +135,7 @@ protected:
 
 	// Returns true when debugging statistics should be compiled in.
 	bool DebugStatsEnabled() const;
+	bool DebugProfilerEnabled() const;
 
 	// Callback (compile when DebugStatsEnabled()) to log a base interpreter hit.
 	// Call the func returned by MIPSGetInterpretFunc(op) directly for interpret.

--- a/Core/MIPS/RiscV/RiscVCompFPU.cpp
+++ b/Core/MIPS/RiscV/RiscVCompFPU.cpp
@@ -585,6 +585,8 @@ void RiscVJitBackend::CompIR_FSpecial(IRInst inst) {
 
 	auto callFuncF_F = [&](float (*func)(float)) {
 		regs_.FlushBeforeCall();
+		WriteDebugProfilerStatus(IRProfilerStatus::MATH_HELPER);
+
 		// It might be in a non-volatile register.
 		// TODO: May have to handle a transfer if SIMD here.
 		if (regs_.IsFPRMapped(inst.src1)) {
@@ -600,6 +602,8 @@ void RiscVJitBackend::CompIR_FSpecial(IRInst inst) {
 		if (regs_.F(inst.dest) != F10) {
 			FMV(32, regs_.F(inst.dest), F10);
 		}
+
+		WriteDebugProfilerStatus(IRProfilerStatus::IN_JIT);
 	};
 
 	RiscVReg tempReg = INVALID_REG;

--- a/Core/MIPS/RiscV/RiscVCompSystem.cpp
+++ b/Core/MIPS/RiscV/RiscVCompSystem.cpp
@@ -188,6 +188,7 @@ void RiscVJitBackend::CompIR_System(IRInst inst) {
 		FlushAll();
 		SaveStaticRegisters();
 
+		WriteDebugProfilerStatus(IRProfilerStatus::SYSCALL);
 #ifdef USE_PROFILER
 		// When profiling, we can't skip CallSyscall, since it times syscalls.
 		LI(X10, (int32_t)inst.constant);
@@ -207,6 +208,7 @@ void RiscVJitBackend::CompIR_System(IRInst inst) {
 		}
 #endif
 
+		WriteDebugProfilerStatus(IRProfilerStatus::IN_JIT);
 		LoadStaticRegisters();
 		// This is always followed by an ExitToPC, where we check coreState.
 		break;
@@ -214,7 +216,9 @@ void RiscVJitBackend::CompIR_System(IRInst inst) {
 	case IROp::CallReplacement:
 		FlushAll();
 		SaveStaticRegisters();
+		WriteDebugProfilerStatus(IRProfilerStatus::REPLACEMENT);
 		QuickCallFunction(GetReplacementFunc(inst.constant)->replaceFunc, SCRATCH2);
+		WriteDebugProfilerStatus(IRProfilerStatus::IN_JIT);
 		LoadStaticRegisters();
 		SUB(DOWNCOUNTREG, DOWNCOUNTREG, X10);
 		break;

--- a/Core/MIPS/RiscV/RiscVJit.h
+++ b/Core/MIPS/RiscV/RiscVJit.h
@@ -50,6 +50,9 @@ private:
 	void ApplyRoundingMode(bool force = false);
 	void MovFromPC(RiscVGen::RiscVReg r);
 	void MovToPC(RiscVGen::RiscVReg r);
+	void WriteDebugPC(uint32_t pc);
+	void WriteDebugPC(RiscVGen::RiscVReg r);
+	void WriteDebugProfilerStatus(IRProfilerStatus status);
 
 	void SaveStaticRegisters();
 	void LoadStaticRegisters();

--- a/Core/MIPS/x86/X64IRCompFPU.cpp
+++ b/Core/MIPS/x86/X64IRCompFPU.cpp
@@ -972,6 +972,7 @@ void X64JitBackend::CompIR_FSpecial(IRInst inst) {
 
 	auto callFuncF_F = [&](const void *func) {
 		regs_.FlushBeforeCall();
+		WriteDebugProfilerStatus(IRProfilerStatus::MATH_HELPER);
 
 #if X64JIT_USE_XMM_CALL
 		if (regs_.IsFPRMapped(inst.src1)) {
@@ -1004,6 +1005,8 @@ void X64JitBackend::CompIR_FSpecial(IRInst inst) {
 		regs_.MapFPR(inst.dest, MIPSMap::NOINIT);
 		MOVD_xmm(regs_.FX(inst.dest), R(SCRATCH1));
 #endif
+
+		WriteDebugProfilerStatus(IRProfilerStatus::IN_JIT);
 	};
 
 	switch (inst.op) {

--- a/Core/MIPS/x86/X64IRCompSystem.cpp
+++ b/Core/MIPS/x86/X64IRCompSystem.cpp
@@ -203,6 +203,7 @@ void X64JitBackend::CompIR_System(IRInst inst) {
 		FlushAll();
 		SaveStaticRegisters();
 
+		WriteDebugProfilerStatus(IRProfilerStatus::SYSCALL);
 #ifdef USE_PROFILER
 		// When profiling, we can't skip CallSyscall, since it times syscalls.
 		ABI_CallFunctionC((const u8 *)&CallSyscall, inst.constant);
@@ -219,6 +220,7 @@ void X64JitBackend::CompIR_System(IRInst inst) {
 		}
 #endif
 
+		WriteDebugProfilerStatus(IRProfilerStatus::IN_JIT);
 		LoadStaticRegisters();
 		// This is always followed by an ExitToPC, where we check coreState.
 		break;
@@ -226,7 +228,9 @@ void X64JitBackend::CompIR_System(IRInst inst) {
 	case IROp::CallReplacement:
 		FlushAll();
 		SaveStaticRegisters();
+		WriteDebugProfilerStatus(IRProfilerStatus::REPLACEMENT);
 		ABI_CallFunction(GetReplacementFunc(inst.constant)->replaceFunc);
+		WriteDebugProfilerStatus(IRProfilerStatus::IN_JIT);
 		LoadStaticRegisters();
 		//SUB(32, R(DOWNCOUNTREG), R(DOWNCOUNTREG), R(EAX));
 		SUB(32, MDisp(CTXREG, downcountOffset), R(EAX));

--- a/Core/MIPS/x86/X64IRJit.h
+++ b/Core/MIPS/x86/X64IRJit.h
@@ -66,6 +66,9 @@ private:
 	void ApplyRoundingMode(bool force = false);
 	void MovFromPC(Gen::X64Reg r);
 	void MovToPC(Gen::X64Reg r);
+	void WriteDebugPC(uint32_t pc);
+	void WriteDebugPC(Gen::X64Reg r);
+	void WriteDebugProfilerStatus(IRProfilerStatus status);
 
 	void SaveStaticRegisters();
 	void LoadStaticRegisters();


### PR DESCRIPTION
This adds a very simplistic profiler for the IR jits.  They function the same way on all backends.  This is helpful when profiling to expose actual jit blocks isn't available or isn't great.

I kept it simple so it could work on any backend, in theory.  That means:
 * If enabled (compile time only), it starts a thread that literally just spins sampling the block PC.
 * A page of the codeblock is reserved as writable and is kept up to date with the current PC and status (only if enabled.)
 * It logs the top 4 blocks and % samples spent in them on an interval before entering jit.

The results on a God of War demo:

```
arm64:
Slowest sampled PC #0: 0899b5d0 (z_un_0899b558)/IN_JIT (4.751447%)
Slowest sampled PC #1: 089a9d6c (z_un_089a98b4)/IN_JIT (1.526191%)
Slowest sampled PC #2: 08a0eb98 (z_un_08a0eb98)/MATH_HELPER (0.924867%)
Slowest sampled PC #3: 08990848 (z_un_08990848)/IN_JIT (0.519172%)

x64:
Slowest sampled PC #0: 0899b5d0 (z_un_0899b558)/IN_JIT (7.168335%)
Slowest sampled PC #1: 089a9d6c (z_un_089a98b4)/IN_JIT (5.345056%)
Slowest sampled PC #2: 08990848 (z_un_08990848)/IN_JIT (0.939905%)
Slowest sampled PC #3: 089908f4 (z_un_08990848)/IN_JIT (0.567960%)

riscv64:
Slowest sampled PC #0: 0897a184 (z_un_0897a15c)/IN_JIT (3.743720%)
Slowest sampled PC #1: 0899b5d0 (z_un_0899b558)/IN_JIT (2.998380%)
Slowest sampled PC #2: 089a9d6c (z_un_089a98b4)/IN_JIT (2.870566%)
Slowest sampled PC #3: 089a9e14 (z_un_089a98b4)/IN_JIT (0.972369%)
```

Of interest here is that 0897a184 is so slow on riscv64.  It's a bunch of lv.s's (which look like they could be trivially converted to lv.q... though that wouldn't help risc-v anyway) and vdot.q's, and finally some mfv/srl/or/sw (probably this is where it writes the bone matrix data.)  But 089a9e14 tells me that float must just be pretty slow, because it's a simple add.s/c.le loop.  Maybe FCLASS is performing worse than I thought...

For arm64, the notable thing is 08a0eb98 of course.  The MATH_HELPER there indicates this was exclusively time spent in vfpu_sin and vfpu_cos.

Anyway, I think this is useful for finding expensive blocks to examine further, obviously less so than a full/real profiler integrated into the block data, though.  When disabled, it doesn't have any negative impact.

-[Unknown]