### PR TITLE
Fix GL hang with buffered commands = off

### DIFF
--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -422,6 +422,7 @@ void GLRenderManager::Present() {
 	{
 		std::unique_lock<std::mutex> lock(pushMutex_);
 		renderThreadQueue_.push(presentTask);
+		pushCondVar_.notify_one();
 	}
 
 	int newCurFrame = curFrame_ + 1;
@@ -524,7 +525,7 @@ bool GLRenderManager::Run(GLRRenderThreadTask &task) {
 		// glFinish is not actually necessary here, and won't be unless we start using
 		// glBufferStorage. Then we need to use fences.
 		{
-			std::unique_lock<std::mutex> lock(syncMutex_);
+			std::lock_guard<std::mutex> lock(syncMutex_);
 			syncDone_ = true;
 			syncCondVar_.notify_one();
 		}

--- a/Common/UI/IconCache.cpp
+++ b/Common/UI/IconCache.cpp
@@ -232,8 +232,6 @@ void IconCache::Cancel(const std::string &key) {
 }
 
 bool IconCache::InsertIcon(const std::string &key, IconFormat format, std::string &&data) {
-	std::unique_lock<std::mutex> lock(lock_);
-
 	if (key.empty()) {
 		return false;
 	}
@@ -244,6 +242,7 @@ bool IconCache::InsertIcon(const std::string &key, IconFormat format, std::strin
 		return false;
 	}
 
+	std::unique_lock<std::mutex> lock(lock_);
 	if (cache_.find(key) != cache_.end()) {
 		// Already have this entry.
 		return false;
@@ -261,6 +260,10 @@ bool IconCache::InsertIcon(const std::string &key, IconFormat format, std::strin
 }
 
 Draw::Texture *IconCache::BindIconTexture(UIContext *context, const std::string &key) {
+	if (key.empty()) {
+		return nullptr;
+	}
+
 	std::unique_lock<std::mutex> lock(lock_);
 	auto iter = cache_.find(key);
 	if (iter == cache_.end()) {

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -296,6 +296,7 @@ void ScreenManager::pop() {
 }
 
 void ScreenManager::RecreateAllViews() {
+	std::lock_guard<std::recursive_mutex> guard(inputLock_);
 	for (auto it = stack_.begin(); it != stack_.end(); ++it) {
 		it->screen->RecreateViews();
 	}


### PR DESCRIPTION
Need to notify_one any time we push to the queue, otherwise there are tricky race conditions.

Also adds a missing mutex lock and adds some early-outs to iconcache.