### PR TITLE
Add `#include <cstdint>`

### DIFF
--- a/Core/MIPS/MIPSTables.h
+++ b/Core/MIPS/MIPSTables.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <stdint.h>
 #include "Common/CommonTypes.h"


### PR DESCRIPTION
Required to compile with GCC 13.

Related to https://github.com/hrydgard/ppsspp/issues/18120, fixes https://github.com/flathub/org.ppsspp.PPSSPP/pull/56.