### PR TITLE
PPGe: Use texture windows for atlas text

### DIFF
--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2801,7 +2801,7 @@ bool TextureCacheCommon::PrepareBuildTexture(BuildTexturePlan &plan, TexCacheEnt
 	plan.w = gstate.getTextureWidth(0);
 	plan.h = gstate.getTextureHeight(0);
 
-	bool isPPGETexture = entry->addr > 0x05000000 && entry->addr < PSP_GetKernelMemoryEnd();
+	bool isPPGETexture = entry->addr >= PSP_GetKernelMemoryBase() && entry->addr < PSP_GetKernelMemoryEnd();
 
 	// Don't scale the PPGe texture.
 	if (isPPGETexture) {


### PR DESCRIPTION
This makes it software rendering, which correctly applies clamp/wrap limits at 512x512, still has readable text.  Other textures may still be wrong.

Just a quick fix for #17885, not really optimal but should be fine.  Also didn't really check any other texture drawing that might use the atlas.

-[Unknown]