### PR TITLE
Move RetroAchievements to the tools tab, fix leaderboard submitted notification positioning

### DIFF
--- a/Common/System/OSD.cpp
+++ b/Common/System/OSD.cpp
@@ -221,7 +221,7 @@ void OnScreenDisplay::ShowLeaderboardStartEnd(const std::string &title, const st
 }
 
 void OnScreenDisplay::ShowLeaderboardSubmitted(const std::string &title, const std::string &value) {
-	g_OSD.Show(OSDType::MESSAGE_SUCCESS, title, value, 3.0f);
+	g_OSD.Show(OSDType::LEADERBOARD_SUBMITTED, title, value, 3.0f);
 }
 
 void OnScreenDisplay::SetProgressBar(std::string id, std::string &&message, float minValue, float maxValue, float progress, float delay) {

--- a/Common/UI/PopupScreens.cpp
+++ b/Common/UI/PopupScreens.cpp
@@ -128,6 +128,8 @@ void PopupMultiChoice::UpdateText() {
 
 void PopupMultiChoice::ChoiceCallback(int num) {
 	if (num != -1) {
+		_assert_(value_ != nullptr);
+
 		*value_ = num + minVal_;
 		UpdateText();
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -894,11 +894,30 @@ void GameSettingsScreen::CreateToolsSettings(UI::ViewGroup *tools) {
 	auto ri = GetI18NCategory(I18NCat::REMOTEISO);
 
 	tools->Add(new ItemHeader(ms->T("Tools")));
+
+	auto retro = tools->Add(new Choice(sy->T("RetroAchievements")));
+	retro->OnClick.Add([=](UI::EventParams &) -> UI::EventReturn {
+		screenManager()->push(new RetroAchievementsSettingsScreen(gamePath_));
+		return UI::EVENT_DONE;
+	});
+	retro->SetIcon(ImageID("I_RETROACHIEVEMENTS_LOGO"));
 	// These were moved here so use the wrong translation objects, to avoid having to change all inis... This isn't a sustainable situation :P
-	tools->Add(new Choice(sa->T("Savedata Manager")))->OnClick.Handle(this, &GameSettingsScreen::OnSavedataManager);
-	tools->Add(new Choice(dev->T("System Information")))->OnClick.Handle(this, &GameSettingsScreen::OnSysInfo);
-	tools->Add(new Choice(sy->T("Developer Tools")))->OnClick.Handle(this, &GameSettingsScreen::OnDeveloperTools);
-	tools->Add(new Choice(ri->T("Remote disc streaming")))->OnClick.Handle(this, &GameSettingsScreen::OnRemoteISO);
+	tools->Add(new Choice(sa->T("Savedata Manager")))->OnClick.Add([=](UI::EventParams &) {
+		screenManager()->push(new SavedataScreen(gamePath_));
+		return UI::EVENT_DONE;
+	});
+	tools->Add(new Choice(dev->T("System Information")))->OnClick.Add([=](UI::EventParams &) {
+		screenManager()->push(new SystemInfoScreen(gamePath_));
+		return UI::EVENT_DONE;
+	});
+	tools->Add(new Choice(sy->T("Developer Tools")))->OnClick.Add([=](UI::EventParams &) {
+		screenManager()->push(new DeveloperToolsScreen(gamePath_));
+		return UI::EVENT_DONE;
+	});
+	tools->Add(new Choice(ri->T("Remote disc streaming")))->OnClick.Add([=](UI::EventParams &) {
+		screenManager()->push(new RemoteISOScreen(gamePath_));
+		return UI::EVENT_DONE;
+	});
 }
 
 void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
@@ -909,15 +928,6 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 	auto vr = GetI18NCategory(I18NCat::VR);
 	auto th = GetI18NCategory(I18NCat::THEMES);
 	auto psps = GetI18NCategory(I18NCat::PSPSETTINGS);  // TODO: Should move more into this section.
-
-	systemSettings->Add(new ItemHeader(sy->T("RetroAchievements")));
-	auto retro = systemSettings->Add(new Choice(sy->T("RetroAchievements")));
-
-	retro->OnClick.Add([&](UI::EventParams &) -> UI::EventReturn {
-		screenManager()->push(new RetroAchievementsSettingsScreen(gamePath_));
-		return UI::EVENT_DONE;
-	});
-	retro->SetIcon(ImageID("I_RETROACHIEVEMENTS_LOGO"));
 
 	systemSettings->Add(new ItemHeader(sy->T("UI")));
 
@@ -1582,16 +1592,6 @@ UI::EventReturn GameSettingsScreen::OnTextureShaderChange(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
-UI::EventReturn GameSettingsScreen::OnDeveloperTools(UI::EventParams &e) {
-	screenManager()->push(new DeveloperToolsScreen(gamePath_));
-	return UI::EVENT_DONE;
-}
-
-UI::EventReturn GameSettingsScreen::OnRemoteISO(UI::EventParams &e) {
-	screenManager()->push(new RemoteISOScreen(gamePath_));
-	return UI::EVENT_DONE;
-}
-
 UI::EventReturn GameSettingsScreen::OnControlMapping(UI::EventParams &e) {
 	screenManager()->push(new ControlMappingScreen(gamePath_));
 	return UI::EVENT_DONE;
@@ -1611,17 +1611,6 @@ UI::EventReturn GameSettingsScreen::OnTiltCustomize(UI::EventParams &e) {
 	screenManager()->push(new TiltAnalogSettingsScreen(gamePath_));
 	return UI::EVENT_DONE;
 };
-
-UI::EventReturn GameSettingsScreen::OnSavedataManager(UI::EventParams &e) {
-	auto saveData = new SavedataScreen(gamePath_);
-	screenManager()->push(saveData);
-	return UI::EVENT_DONE;
-}
-
-UI::EventReturn GameSettingsScreen::OnSysInfo(UI::EventParams &e) {
-	screenManager()->push(new SystemInfoScreen(gamePath_));
-	return UI::EVENT_DONE;
-}
 
 void DeveloperToolsScreen::CreateViews() {
 	using namespace UI;

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -83,8 +83,6 @@ private:
 	UI::EventReturn OnAutoFrameskip(UI::EventParams &e);
 	UI::EventReturn OnTextureShader(UI::EventParams &e);
 	UI::EventReturn OnTextureShaderChange(UI::EventParams &e);
-	UI::EventReturn OnDeveloperTools(UI::EventParams &e);
-	UI::EventReturn OnRemoteISO(UI::EventParams &e);
 	UI::EventReturn OnChangeQuickChat0(UI::EventParams &e);
 	UI::EventReturn OnChangeQuickChat1(UI::EventParams &e);
 	UI::EventReturn OnChangeQuickChat2(UI::EventParams &e);
@@ -114,9 +112,6 @@ private:
 	UI::EventReturn OnSustainedPerformanceModeChange(UI::EventParams &e);
 
 	UI::EventReturn OnAdhocGuides(UI::EventParams &e);
-
-	UI::EventReturn OnSavedataManager(UI::EventParams &e);
-	UI::EventReturn OnSysInfo(UI::EventParams &e);
 
 	// Temporaries to convert setting types, cache enabled, etc.
 	int iAlternateSpeedPercent1_ = 0;


### PR DESCRIPTION
Makes more sense in Tools (which is kind of a grab bag of stuff) than System (which itself needs reorganizing, but RetroAchievements doesn't belong there).

Just forgot to use the correct notification type.