### PR TITLE
Fix crash in Beats on x86-64, minor other fixes

### DIFF
--- a/Common/GPU/Vulkan/VulkanMemory.cpp
+++ b/Common/GPU/Vulkan/VulkanMemory.cpp
@@ -291,7 +291,7 @@ VulkanPushPool::Block VulkanPushPool::CreateBlock(size_t size) {
 	_assert_(result == VK_SUCCESS);
 
 	result = vmaMapMemory(vulkan_->Allocator(), block.allocation, (void **)(&block.writePtr));
-	_assert_(result == VK_SUCCESS);
+	_assert_msg_(result == VK_SUCCESS, "VulkanPushPool: Failed to map memory (result = %08x)", result);
 
 	_assert_msg_(block.writePtr != nullptr, "VulkanPushPool: Failed to map memory on block of size %d", (int)block.size);
 	return block;

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -247,6 +247,8 @@ static void ExpandRange(std::pair<u32, u32> &range, u32 newStart, u32 newEnd) {
 void JitBlockCache::FinalizeBlock(int block_num, bool block_link) {
 	JitBlock &b = blocks_[block_num];
 
+	_assert_msg_(Memory::IsValidAddress(b.originalAddress), "FinalizeBlock: Bad originalAddress %08x in block %d", b.originalAddress, block_num);
+
 	b.originalFirstOpcode = Memory::Read_Opcode_JIT(b.originalAddress);
 	MIPSOpcode opcode = GetEmuHackOpForBlock(block_num);
 	Memory::Write_Opcode_JIT(b.originalAddress, opcode);

--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -429,6 +429,7 @@ namespace MIPSComp {
 			skipStore = J_CC(CC_NE);
 
 			CompITypeMemWrite(op, 32, safeMemFuncs.writeU32);
+			gpr.MapReg(rt, true, true);
 			MOV(32, gpr.R(rt), Imm32(1));
 			finish = J();
 

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -827,7 +827,7 @@ static void PPGeResetCurrentText() {
 // Draws some text using the one font we have in the atlas.
 void PPGeDrawCurrentText(u32 color) {
 	// If the atlas is larger than 512x512, need to use windows into it.
-	bool useTextureWindow = atlasWidth > 512 || atlasHeight > 512;
+	bool useTextureWindow = g_Config.bSoftwareRendering && atlasWidth > 512 || atlasHeight > 512;
 	uint32_t texturePosX = 0;
 	uint32_t texturePosY = 0;
 


### PR DESCRIPTION
Fixes #18130 , the sc instruction failed to map the destination register.

Only use #18126 in soft-gpu mode (for now)

Add a couple of asserts.