### PR TITLE
x86jit: Fix spill on sc in longer block

### DIFF
--- a/Core/MIPS/x86/CompLoadStore.cpp
+++ b/Core/MIPS/x86/CompLoadStore.cpp
@@ -428,6 +428,12 @@ namespace MIPSComp {
 			break;
 
 		case 56: // sc
+			// Map before the jump in case any regs spill.  Unlock happens inside CompITypeMemWrite().
+			// This is not a very common op, but it's in jit so memory breakpoints can trip.
+			gpr.Lock(rt, rs);
+			gpr.MapReg(rt, true, true);
+			gpr.MapReg(rs, true, false);
+
 			CMP(8, MDisp(X64JitConstants::CTXREG, -128 + offsetof(MIPSState, llBit)), Imm8(1));
 			skipStore = J_CC(CC_NE);
 


### PR DESCRIPTION
I only added sc this year for the debugger - it was a mistake to not make sure any spill happens outside the conditional.  That said, this should most of the time be in a tight loop, so usually won't be an issue.  Still, there may be some game, especially on 32-bit, that triggers a spill inside the conditional and that'd be bad.

Just to make sure it's clear, this is the scenario (simplified, since actually `li` would not map a reg):

```
li a0, 0
li a1, 1
li a2, 2
li a3, 3
li t0, 4

sc t1, 42(t2)
```

In this case, i386 only has 5 mappable regs, so mapping `t1` will necessarily spill one of those first 5.  However, if the spill happens inside the if (`skipStore = J_CC(CC_NE);` - i.e. `if (llBit == 1) {`) then that other register will silently not be updated if llBit was 0.  In that case, i.e. `a0` would stay `0xDEADBEEF` and not be set to 0.

I don't have Beats to make sure this works there.

-[Unknown]