### PR TITLE
Fix the chat window closing on pressing the X key.

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -844,19 +844,25 @@ bool EmuScreen::UnsyncKey(const KeyInput &key) {
 	System_Notify(SystemNotification::ACTIVITY);
 
 	if (UI::IsFocusMovementEnabled()) {
-		bool retval = UIScreen::UnsyncKey(key);
-		if ((key.flags & KEY_DOWN) != 0 && UI::IsEscapeKey(key)) {
-			if (chatMenu_)
-				chatMenu_->Close();
-			if (chatButton_)
-				chatButton_->SetVisibility(UI::V_VISIBLE);
-			UI::EnableFocusMovement(false);
-			retval = true;
-		}
-		return retval;
+		return UIScreen::UnsyncKey(key);
 	}
 
 	return controlMapper_.Key(key, &pauseTrigger_);
+}
+
+bool EmuScreen::key(const KeyInput &key) {
+	bool retval = UIScreen::key(key);
+
+	if (!retval && (key.flags & KEY_DOWN) != 0 && UI::IsEscapeKey(key)) {
+		if (chatMenu_)
+			chatMenu_->Close();
+		if (chatButton_)
+			chatButton_->SetVisibility(UI::V_VISIBLE);
+		UI::EnableFocusMovement(false);
+		return true;
+	}
+
+	return retval;
 }
 
 void EmuScreen::UnsyncAxis(const AxisInput &axis) {

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -55,6 +55,9 @@ public:
 	bool UnsyncKey(const KeyInput &key) override;
 	void UnsyncAxis(const AxisInput &axis) override;
 
+	// We also need to do some special handling of queued UI events to handle closing the chat window.
+	bool key(const KeyInput &key) override;
+
 private:
 	void CreateViews() override;
 	UI::EventReturn OnDevTools(UI::EventParams &params);


### PR DESCRIPTION
It's better to handle the chat window on the queued event path.