### PR TITLE
Fix a valgrind warning

### DIFF
--- a/Common/UI/IconCache.cpp
+++ b/Common/UI/IconCache.cpp
@@ -80,7 +80,9 @@ bool IconCache::LoadFromFile(FILE *file) {
 			break;
 		}
 
-		fread(&key[0], 1, entryHeader.keyLen, file);
+		if (fread(&key[0], 1, entryHeader.keyLen, file) != entryHeader.keyLen) {
+			break;
+		}
 
 		// Check if we already have the entry somehow.
 		if (cache_.find(key) != cache_.end()) {

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -636,7 +636,7 @@ static int sceMpegQueryStreamOffset(u32 mpeg, u32 bufferAddr, u32 offsetAddr)
 
 	DEBUG_LOG(ME, "sceMpegQueryStreamOffset(%08x, %08x, %08x)", mpeg, bufferAddr, offsetAddr);
 
-	// Kinda destructive, no?
+	// Kinda destructive, no? Shouldn't this just do what sceMpegQueryStreamSize does?
 	AnalyzeMpeg(Memory::GetPointerWriteUnchecked(bufferAddr), Memory::ValidSize(bufferAddr, 32768), ctx);
 
 	if (ctx->mpegMagic != PSMF_MAGIC) {
@@ -667,7 +667,8 @@ static u32 sceMpegQueryStreamSize(u32 bufferAddr, u32 sizeAddr)
 	DEBUG_LOG(ME, "sceMpegQueryStreamSize(%08x, %08x)", bufferAddr, sizeAddr);
 
 	MpegContext ctx;
-	ctx.mediaengine = 0;
+	ctx.mediaengine = nullptr;  // makes sure we don't actually load the stream.
+	ctx.isAnalyzed = false;
 
 	AnalyzeMpeg(Memory::GetPointerWriteUnchecked(bufferAddr), Memory::ValidSize(bufferAddr, 32768), &ctx);
 


### PR DESCRIPTION
Found when trying to investigate something else. It never could lead to execution going down the wrong path though.

Also fix a simple compiler warning in iconcache.