### PR TITLE
Core, UI, Windows: Removed excess converting C-string in params

### DIFF
--- a/Common/Data/Format/IniFile.cpp
+++ b/Common/Data/Format/IniFile.cpp
@@ -322,7 +322,7 @@ bool Section::Get(const char* key, int* value, int defaultValue) const
 {
 	std::string temp;
 	bool retval = Get(key, &temp, 0);
-	if (retval && TryParse(temp.c_str(), value))
+	if (retval && TryParse(temp, value))
 		return true;
 	*value = defaultValue;
 	return false;
@@ -352,7 +352,7 @@ bool Section::Get(const char* key, bool* value, bool defaultValue) const
 {
 	std::string temp;
 	bool retval = Get(key, &temp, 0);
-	if (retval && TryParse(temp.c_str(), value))
+	if (retval && TryParse(temp, value))
 		return true;
 	*value = defaultValue;
 	return false;
@@ -362,7 +362,7 @@ bool Section::Get(const char* key, float* value, float defaultValue) const
 {
 	std::string temp;
 	bool retval = Get(key, &temp, 0);
-	if (retval && TryParse(temp.c_str(), value))
+	if (retval && TryParse(temp, value))
 		return true;
 	*value = defaultValue;
 	return false;
@@ -372,7 +372,7 @@ bool Section::Get(const char* key, double* value, double defaultValue) const
 {
 	std::string temp;
 	bool retval = Get(key, &temp, 0);
-	if (retval && TryParse(temp.c_str(), value))
+	if (retval && TryParse(temp, value))
 		return true;
 	*value = defaultValue;
 	return false;

--- a/Common/UI/PopupScreens.cpp
+++ b/Common/UI/PopupScreens.cpp
@@ -265,7 +265,7 @@ std::string PopupSliderChoiceFloat::ValueText() const {
 	temp[0] = '\0';
 	if (zeroLabel_.size() && *value_ == 0.0f) {
 		truncate_cpy(temp, zeroLabel_.c_str());
-	} else if (IsValidNumberFormatString(fmt_.c_str())) {
+	} else if (IsValidNumberFormatString(fmt_)) {
 		snprintf(temp, sizeof(temp), fmt_.c_str(), *value_);
 	} else {
 		snprintf(temp, sizeof(temp), "%0.2f", *value_);

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -1225,7 +1225,7 @@ bool TextEdit::Key(const KeyInput &input) {
 			switch (input.keyCode) {
 			case NKCODE_C:
 				// Just copy the entire text contents, until we get selection support.
-				System_CopyStringToClipboard(text_.c_str());
+				System_CopyStringToClipboard(text_);
 				break;
 			case NKCODE_V:
 				{

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -285,7 +285,7 @@ bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string) {
 
 				std::string dir = fileLoader->GetPath().GetDirectory();
 				if (fileLoader->GetPath().Type() == PathType::CONTENT_URI) {
-					dir = AndroidContentURI(dir.c_str()).FilePath();
+					dir = AndroidContentURI(dir).FilePath();
 				}
 				size_t pos = dir.find("PSP/GAME/");
 				if (pos != std::string::npos) {

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -382,7 +382,7 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 	std::string file = full_path.GetFilename();
 
 	if (full_path.Type() == PathType::CONTENT_URI) {
-		path = AndroidContentURI(full_path.GetDirectory().c_str()).FilePath();
+		path = AndroidContentURI(full_path.GetDirectory()).FilePath();
 	}
 
 	size_t pos = path.find("PSP/GAME/");

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -763,7 +763,7 @@ void GameBrowser::Refresh() {
 		LinearLayout *topBar = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
 		if (browseFlags_ & BrowseFlags::NAVIGATE) {
 			topBar->Add(new Spacer(2.0f));
-			topBar->Add(new TextView(path_.GetFriendlyPath().c_str(), ALIGN_VCENTER | FLAG_WRAP_TEXT, true, new LinearLayoutParams(FILL_PARENT, 64.0f, 1.0f)));
+			topBar->Add(new TextView(path_.GetFriendlyPath(), ALIGN_VCENTER | FLAG_WRAP_TEXT, true, new LinearLayoutParams(FILL_PARENT, 64.0f, 1.0f)));
 			topBar->Add(new Choice(ImageID("I_HOME"), new LayoutParams(WRAP_CONTENT, 64.0f)))->OnClick.Handle(this, &GameBrowser::OnHomeClick);
 			if (System_GetPropertyBool(SYSPROP_HAS_ADDITIONAL_STORAGE)) {
 				topBar->Add(new Choice(ImageID("I_SDCARD"), new LayoutParams(WRAP_CONTENT, 64.0f)))->OnClick.Handle(this, &GameBrowser::StorageClick);
@@ -1383,7 +1383,7 @@ UI::EventReturn MainScreen::OnLoadFile(UI::EventParams &e) {
 	if (System_GetPropertyBool(SYSPROP_HAS_FILE_BROWSER)) {
 		auto mm = GetI18NCategory(I18NCat::MAINMENU);
 		System_BrowseForFile(mm->T("Load"), BrowseFileType::BOOTABLE, [](const std::string &value, int) {
-			System_PostUIMessage("boot", value.c_str());
+			System_PostUIMessage("boot", value);
 		});
 	}
 	return UI::EVENT_DONE;

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -675,7 +675,7 @@ UI::EventReturn SavedataScreen::OnSearch(UI::EventParams &e) {
 	auto di = GetI18NCategory(I18NCat::DIALOG);
 	if (System_GetPropertyBool(SYSPROP_HAS_TEXT_INPUT_DIALOG)) {
 		System_InputBoxGetString(di->T("Filter"), searchFilter_, [](const std::string &value, int ivalue) {
-			System_PostUIMessage("savedatascreen_search", value.c_str());
+			System_PostUIMessage("savedatascreen_search", value);
 		});
 	}
 	return UI::EVENT_DONE;

--- a/UI/TabbedDialogScreen.cpp
+++ b/UI/TabbedDialogScreen.cpp
@@ -87,7 +87,7 @@ void TabbedUIDialogScreenWithGameBackground::CreateViews() {
 
 			searchSettings->Add(new ItemHeader(se->T("Find settings")));
 			searchSettings->Add(new PopupTextInputChoice(&searchFilter_, se->T("Filter"), "", 64, screenManager()))->OnChange.Add([=](UI::EventParams &e) {
-				System_PostUIMessage("gameSettings_search", StripSpaces(searchFilter_).c_str());
+				System_PostUIMessage("gameSettings_search", StripSpaces(searchFilter_));
 				return UI::EVENT_DONE;
 			});
 

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -1029,7 +1029,7 @@ namespace MainWindow
 					TCHAR filename[512];
 					if (DragQueryFile(hdrop, 0, filename, 512) != 0) {
 						const std::string utf8_filename = ReplaceAll(ConvertWStringToUTF8(filename), "\\", "/");
-						System_PostUIMessage("boot", utf8_filename.c_str());
+						System_PostUIMessage("boot", utf8_filename);
 						Core_EnableStepping(false);
 					}
 				}

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -343,7 +343,7 @@ namespace MainWindow {
 			Core_EnableStepping(false);
 		}
 		filename = ReplaceAll(filename, "\\", "/");
-		System_PostUIMessage("boot", filename.c_str());
+		System_PostUIMessage("boot", filename);
 		W32Util::MakeTopMost(GetHWND(), g_Config.bTopMost);
 	}
 


### PR DESCRIPTION
Minor code cleaning from unnecessary calls `c_str()`