### PR TITLE
HTTP: Ignore failed connects when trying to select

### DIFF
--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -121,6 +121,7 @@ bool Connection::Connect(int maxTries, double timeout, bool *cancelConnect) {
 			if (connect(sock, possible->ai_addr, (int)possible->ai_addrlen) < 0) {
 				if (errno != EINPROGRESS) {
 					ERROR_LOG(HTTP, "connect(%d) call failed (%d: %s)", sock, errno, strerror(errno));
+					closesocket(sock);
 					continue;
 				}
 			}

--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -150,11 +150,6 @@ bool Connection::Connect(int maxTries, double timeout, bool *cancelConnect) {
 			}
 		}
 
-		if (sockets.empty()) {
-			ERROR_LOG(HTTP, "No resolved address would connect!");
-			// TODO: What do we do here?
-		}
-
 		int selectResult = 0;
 		long timeoutHalfSeconds = floor(2 * timeout);
 		while (timeoutHalfSeconds >= 0 && selectResult == 0) {


### PR DESCRIPTION
Fixes #18161 

There's weird stuff going on, we get six results in resolve and three seem to be bad. Currently getting a bunch of these for every time we connect:

15:51:038 Net/HTTPClient.cpp:123 E[HTTP]: connect(66) call failed (101: Network is unreachable)
15:51:038 Net/HTTPClient.cpp:123 E[HTTP]: connect(67) call failed (101: Network is unreachable)
15:51:038 Net/HTTPClient.cpp:123 E[HTTP]: connect(68) call failed (101: Network is unreachable)

Where it seems the first three results succeed in connecting (and then select picks one) and the rest fail with network unreachable. Really not sure what's going on or if it's supposed to be like this, but ignoring the failed connects makes things work, at least.
I'll add more detailed logging to look at those later, first need to get this critical fix in.