### PR TITLE
SDL ttf rendering: Try two 4444 tex formats to find one that works.

### DIFF
--- a/Common/Render/Text/draw_text_sdl.cpp
+++ b/Common/Render/Text/draw_text_sdl.cpp
@@ -316,6 +316,10 @@ void TextDrawerSDL::DrawString(DrawBuffer &target, const char *str, float x, flo
 		entry->lastUsedFrame = frameCount_;
 	} else {
 		DataFormat texFormat = Draw::DataFormat::R4G4B4A4_UNORM_PACK16;
+		if ((draw_->GetDataFormatSupport(texFormat) & Draw::FMT_TEXTURE) == 0) {
+			// This is always supported in Vulkan. The other format is the common OpenGL one.
+			texFormat = Draw::DataFormat::B4G4R4A4_UNORM_PACK16;
+		}
 
 		entry = new TextStringEntry();
 


### PR DESCRIPTION
We actually handle both already in TextDrawerSDL::DrawStringBitmap.

This is the quickfix mentioned in #18167 

Fixes #18163 , I believe.

I'm struggling with getting PPSSPP to use SDL2_ttf in the cmake... See #18167 .