### PR TITLE
Backend change from Win32 menu: Add quick workaround for instance counter misbehavior

### DIFF
--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -822,6 +822,13 @@ static void WinMainCleanup() {
 	CoUninitialize();
 
 	if (g_Config.bRestartRequired) {
+		// TODO: ExitAndRestart prevents the Config::~Config destructor from running,
+		// which normally would have done this instance counter update.
+		// ExitAndRestart calls ExitProcess which really bad, we should do something better that
+		// allows us to fall out of main() properly.
+		if (g_Config.bUpdatedInstanceCounter) {
+			ShutdownInstanceCounter();
+		}
 		W32Util::ExitAndRestart(!restartArgs.empty(), restartArgs);
 	}
 }


### PR DESCRIPTION
Should really do this some better way.. but this is quick and safe for now.

See #18148