### PR TITLE
Store: Fix race condition causing crashes if looking at another game before an icon finishes downloading

### DIFF
--- a/Common/UI/IconCache.cpp
+++ b/Common/UI/IconCache.cpp
@@ -228,7 +228,7 @@ bool IconCache::MarkPending(const std::string &key) {
 	return true;
 }
 
-void IconCache::Cancel(const std::string &key) {
+void IconCache::CancelPending(const std::string &key) {
 	std::unique_lock<std::mutex> lock(lock_);
 	pending_.erase(key);
 }
@@ -266,6 +266,7 @@ Draw::Texture *IconCache::BindIconTexture(UIContext *context, const std::string 
 		return nullptr;
 	}
 
+	// TODO: Cut down on how long we're holding this lock here.
 	std::unique_lock<std::mutex> lock(lock_);
 	auto iter = cache_.find(key);
 	if (iter == cache_.end()) {

--- a/Common/UI/IconCache.h
+++ b/Common/UI/IconCache.h
@@ -36,7 +36,7 @@ public:
 
 	// It's okay to call these from any thread.
 	bool MarkPending(const std::string &key);  // returns false if already pending or loaded
-	void Cancel(const std::string &key);
+	void CancelPending(const std::string &key);
 	bool InsertIcon(const std::string &key, IconFormat format, std::string &&pngData);
 	bool GetDimensions(const std::string &key, int *width, int *height);
 	bool Contains(const std::string &key);

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -396,6 +396,8 @@ void SasInstance::GetDebugText(char *text, size_t bufsize) {
 					indicator = " (BAD!)";
 				}
 				break;
+			default:
+				break;
 			}
 			p += snprintf(p, sizeof(voiceBuf) - (p - voiceBuf), " %d: Pitch %04x L/R,FX: %d,%d|%d,%d VAG: %08x:%d:%08x%s Height:%d%%\n", i,
 				voices[i].pitch, voices[i].volumeLeft, voices[i].volumeRight, voices[i].effectLeft, voices[i].effectRight,


### PR DESCRIPTION
Introduced this bug when hooking the homebrew store icons up to the icon cache. Oops.