### PR TITLE
Vulkan: Remove an assert that didn't give much actionable information

### DIFF
--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -414,7 +414,7 @@ void VulkanQueueRunner::RunSteps(std::vector<VKRStep *> &steps, FrameData &frame
 
 		if (profile && profile->timestampsEnabled && profile->timestampDescriptions.size() + 1 < MAX_TIMESTAMP_QUERIES) {
 			vkCmdWriteTimestamp(cmd, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, profile->queryPool, (uint32_t)profile->timestampDescriptions.size());
-			profile->timestampDescriptions.push_back(StepToString(step));
+			profile->timestampDescriptions.push_back(StepToString(vulkan_, step));
 		}
 
 		if (emitLabels) {
@@ -694,13 +694,13 @@ static const char *rpTypeDebugNames[] = {
 	"BACKBUF",
 };
 
-std::string VulkanQueueRunner::StepToString(const VKRStep &step) const {
+std::string VulkanQueueRunner::StepToString(VulkanContext *vulkan, const VKRStep &step) {
 	char buffer[256];
 	switch (step.stepType) {
 	case VKRStepType::RENDER:
 	{
-		int w = step.render.framebuffer ? step.render.framebuffer->width : vulkan_->GetBackbufferWidth();
-		int h = step.render.framebuffer ? step.render.framebuffer->height : vulkan_->GetBackbufferHeight();
+		int w = step.render.framebuffer ? step.render.framebuffer->width : vulkan->GetBackbufferWidth();
+		int h = step.render.framebuffer ? step.render.framebuffer->height : vulkan->GetBackbufferHeight();
 		int actual_w = step.render.renderArea.extent.width;
 		int actual_h = step.render.renderArea.extent.height;
 		const char *renderCmd = rpTypeDebugNames[(size_t)step.render.renderPassType];
@@ -938,19 +938,19 @@ void VulkanQueueRunner::LogRenderPass(const VKRStep &pass, bool verbose) {
 }
 
 void VulkanQueueRunner::LogCopy(const VKRStep &step) {
-	INFO_LOG(G3D, "%s", StepToString(step).c_str());
+	INFO_LOG(G3D, "%s", StepToString(vulkan_, step).c_str());
 }
 
 void VulkanQueueRunner::LogBlit(const VKRStep &step) {
-	INFO_LOG(G3D, "%s", StepToString(step).c_str());
+	INFO_LOG(G3D, "%s", StepToString(vulkan_, step).c_str());
 }
 
 void VulkanQueueRunner::LogReadback(const VKRStep &step) {
-	INFO_LOG(G3D, "%s", StepToString(step).c_str());
+	INFO_LOG(G3D, "%s", StepToString(vulkan_, step).c_str());
 }
 
 void VulkanQueueRunner::LogReadbackImage(const VKRStep &step) {
-	INFO_LOG(G3D, "%s", StepToString(step).c_str());
+	INFO_LOG(G3D, "%s", StepToString(vulkan_, step).c_str());
 }
 
 void TransitionToOptimal(VkCommandBuffer cmd, VkImage colorImage, VkImageLayout colorLayout, VkImage depthStencilImage, VkImageLayout depthStencilLayout, int numLayers, VulkanBarrier *recordBarrier) {

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -233,7 +233,7 @@ public:
 	void RunSteps(std::vector<VKRStep *> &steps, FrameData &frameData, FrameDataShared &frameDataShared, bool keepSteps = false);
 	void LogSteps(const std::vector<VKRStep *> &steps, bool verbose);
 
-	std::string StepToString(const VKRStep &step) const;
+	static std::string StepToString(VulkanContext *vulkan, const VKRStep &step);
 
 	void CreateDeviceObjects();
 	void DestroyDeviceObjects();

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -254,7 +254,7 @@ protected:
 	void FlushImm();
 	void DoBlockTransfer(u32 skipDrawReason);
 
-	// TODO: Unify this. The only backend that differs is Vulkan.
+	// TODO: Unify this. Vulkan and OpenGL are different due to how they buffer data.
 	virtual void FinishDeferred() {}
 
 	void AdvanceVerts(u32 vertType, int count, int bytesRead) {

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -791,20 +791,20 @@ void DrawEngineVulkan::DoFlush() {
 			VulkanGeometryShader *gshader = nullptr;
 
 			shaderManager_->GetShaders(prim, dec_, &vshader, &fshader, &gshader, pipelineState_, true, useHWTessellation_, decOptions_.expandAllWeightsToFloat, decOptions_.applySkinInDecode);
-			if (!vshader) {
-				// We're screwed, can't do anything.
-				return;
-			}
 			_dbg_assert_msg_(vshader->UseHWTransform(), "Bad vshader");
-
 			VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(renderManager, pipelineLayout_, pipelineKey_, &dec_->decFmt, vshader, fshader, gshader, true, 0, framebufferManager_->GetMSAALevel(), false);
 			if (!pipeline || !pipeline->pipeline) {
 				// Already logged, let's bail out.
+				ResetAfterDraw();
 				return;
 			}
 			BindShaderBlendTex();  // This might cause copies so important to do before BindPipeline.
 
-			renderManager->BindPipeline(pipeline->pipeline, pipeline->pipelineFlags, pipelineLayout_);
+			if (!renderManager->BindPipeline(pipeline->pipeline, pipeline->pipelineFlags, pipelineLayout_)) {
+				renderManager->ReportBadStateForDraw();
+				ResetAfterDraw();
+				return;
+			}
 			if (pipeline != lastPipeline_) {
 				if (lastPipeline_ && !(lastPipeline_->UsesBlendConstant() && pipeline->UsesBlendConstant())) {
 					gstate_c.Dirty(DIRTY_BLEND_STATE);
@@ -932,15 +932,16 @@ void DrawEngineVulkan::DoFlush() {
 				VulkanPipeline *pipeline = pipelineManager_->GetOrCreatePipeline(renderManager, pipelineLayout_, pipelineKey_, &dec_->decFmt, vshader, fshader, gshader, false, 0, framebufferManager_->GetMSAALevel(), false);
 				if (!pipeline || !pipeline->pipeline) {
 					// Already logged, let's bail out.
-					decodedVerts_ = 0;
-					numDrawCalls_ = 0;
-					decodeCounter_ = 0;
-					decOptions_.applySkinInDecode = g_Config.bSoftwareSkinning;
+					ResetAfterDraw();
 					return;
 				}
 				BindShaderBlendTex();  // This might cause copies so super important to do before BindPipeline.
 
-				renderManager->BindPipeline(pipeline->pipeline, pipeline->pipelineFlags, pipelineLayout_);
+				if (!renderManager->BindPipeline(pipeline->pipeline, pipeline->pipelineFlags, pipelineLayout_)) {
+					renderManager->ReportBadStateForDraw();
+					ResetAfterDraw();
+					return;
+				}
 				if (pipeline != lastPipeline_) {
 					if (lastPipeline_ && !lastPipeline_->UsesBlendConstant() && pipeline->UsesBlendConstant()) {
 						gstate_c.Dirty(DIRTY_BLEND_STATE);
@@ -1025,6 +1026,15 @@ void DrawEngineVulkan::DoFlush() {
 	gstate_c.vertBounds.maxV = 0;
 
 	GPUDebug::NotifyDraw();
+}
+
+void DrawEngineVulkan::ResetAfterDraw() {
+	indexGen.Reset();
+	decodedVerts_ = 0;
+	numDrawCalls_ = 0;
+	decodeCounter_ = 0;
+	decOptions_.applySkinInDecode = g_Config.bSoftwareSkinning;
+	gstate_c.vertexFullAlpha = true;
 }
 
 void DrawEngineVulkan::UpdateUBOs(FrameData *frame) {

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -45,6 +45,14 @@
 #include "GPU/Vulkan/StateMappingVulkan.h"
 #include "GPU/Vulkan/VulkanRenderManager.h"
 
+
+// TODO: Move to some appropriate header.
+#ifdef _MSC_VER
+#define NO_INLINE __declspec(noinline)
+#else
+#define NO_INLINE __attribute__((noinline))
+#endif
+
 struct DecVtxFormat;
 struct UVScale;
 
@@ -229,6 +237,8 @@ private:
 	void DoFlush();
 	void UpdateUBOs(FrameData *frame);
 	FrameData &GetCurFrame();
+
+	NO_INLINE void ResetAfterDraw();
 
 	VkDescriptorSet GetOrCreateDescriptorSet(VkImageView imageView, VkSampler sampler, VkBuffer base, VkBuffer light, VkBuffer bone, bool tess);
 

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -191,11 +191,11 @@ static VulkanPipeline *CreateVulkanPipeline(VulkanRenderManager *renderManager, 
 	const DecVtxFormat *decFmt, VulkanVertexShader *vs, VulkanFragmentShader *fs, VulkanGeometryShader *gs, bool useHwTransform, u32 variantBitmask, bool cacheLoad) {
 	_assert_(fs && vs);
 
-	if (!fs->GetModule()) {
+	if (!fs || !fs->GetModule()) {
 		ERROR_LOG(G3D, "Fragment shader missing in CreateVulkanPipeline");
 		return nullptr;
 	}
-	if (!vs->GetModule()) {
+	if (!vs || !vs->GetModule()) {
 		ERROR_LOG(G3D, "Vertex shader missing in CreateVulkanPipeline");
 		return nullptr;
 	}


### PR DESCRIPTION
Seeing some of these in the log, but the only useful information is the game name that's automatically reported.

Replace with slightly more informative reporting (which can be improved further).