### PR TITLE
Add time-elapsed to assert messages

### DIFF
--- a/Common/Log.cpp
+++ b/Common/Log.cpp
@@ -25,6 +25,7 @@
 #include "StringUtils.h"
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/Thread/ThreadUtil.h"
+#include "Common/TimeUtil.h"
 
 #if PPSSPP_PLATFORM(ANDROID)
 #include <android/log.h>
@@ -38,10 +39,12 @@ static bool hitAnyAsserts = false;
 
 std::mutex g_extraAssertInfoMutex;
 std::string g_extraAssertInfo = "menu";
+double g_assertInfoTime = 0.0;
 
 void SetExtraAssertInfo(const char *info) {
 	std::lock_guard<std::mutex> guard(g_extraAssertInfoMutex);
 	g_extraAssertInfo = info ? info : "menu";
+	g_assertInfoTime = time_now_d();
 }
 
 bool HandleAssert(const char *function, const char *file, int line, const char *expression, const char* format, ...) {
@@ -57,7 +60,8 @@ bool HandleAssert(const char *function, const char *file, int line, const char *
 	char formatted[LOG_BUF_SIZE + 128];
 	{
 		std::lock_guard<std::mutex> guard(g_extraAssertInfoMutex);
-		snprintf(formatted, sizeof(formatted), "(%s:%s:%d): [%s] (%s) %s", file, function, line, expression, g_extraAssertInfo.c_str(), text);
+		double delta = time_now_d() - g_assertInfoTime;
+		snprintf(formatted, sizeof(formatted), "(%s:%s:%d): [%s] (%s, %0.1fs) %s", file, function, line, expression, g_extraAssertInfo.c_str(), delta, text);
 	}
 
 	// Normal logging (will also log to Android log)


### PR DESCRIPTION
Just a crude thing to easily see if a crash is from just starting a game or later.