### PR TITLE
UI: Round wave coords to prevent gaps

### DIFF
--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -136,21 +136,28 @@ public:
 
 		// 500 is enough for any resolution really. 24 * 500 = 12000 which fits handily in our UI vertex buffer (max 65536 per flush).
 		const int steps = std::max(20, std::min((int)g_display.dp_xres, 500));
-		float step = (float)g_display.dp_xres / (float)steps;
+		float stepSize = (float)g_display.dp_xres / (float)steps;
 		t *= speed;
 
+		float stepx = x;
 		for (int n = 0; n < steps; n++) {
-			float x = (float)n * step;
-			float i = x * 1280 / bounds.w;
+			float nextx = stepx + stepSize;
+			// Round actual x and width to prevent gaps between waves.
+			float roundedx = floorf(stepx);
+			float w = floorf(nextx) - roundedx;
 
+			float i = stepx * 1280 / bounds.w;
 			float wave0 = sin(i*0.005+t*0.8)*0.05 + sin(i*0.002+t*0.25)*0.02 + sin(i*0.001+t*0.3)*0.03 + 0.625;
 			float wave1 = sin(i*0.0044+t*0.4)*0.07 + sin(i*0.003+t*0.1)*0.02 + sin(i*0.001+t*0.3)*0.01 + 0.625;
-			dc.Draw()->RectVGradient(x, wave0*bounds.h, step, (1.0-wave0)*bounds.h, color, 0x00000000);
-			dc.Draw()->RectVGradient(x, wave1*bounds.h, step, (1.0-wave1)*bounds.h, color, 0x00000000);
+
+			dc.Draw()->RectVGradient(roundedx, wave0*bounds.h, w, (1.0-wave0)*bounds.h, color, 0x00000000);
+			dc.Draw()->RectVGradient(roundedx, wave1*bounds.h, w, (1.0-wave1)*bounds.h, color, 0x00000000);
 
 			// Add some "antialiasing"
-			dc.Draw()->RectVGradient(x, wave0*bounds.h-3.0f * g_display.pixel_in_dps_y, step, 3.0f * g_display.pixel_in_dps_y, 0x00000000, color);
-			dc.Draw()->RectVGradient(x, wave1*bounds.h-3.0f * g_display.pixel_in_dps_y, step, 3.0f * g_display.pixel_in_dps_y, 0x00000000, color);
+			dc.Draw()->RectVGradient(roundedx, wave0*bounds.h-3.0f * g_display.pixel_in_dps_y, w, 3.0f * g_display.pixel_in_dps_y, 0x00000000, color);
+			dc.Draw()->RectVGradient(roundedx, wave1*bounds.h-3.0f * g_display.pixel_in_dps_y, w, 3.0f * g_display.pixel_in_dps_y, 0x00000000, color);
+
+			stepx = nextx;
 		}
 
 		dc.Flush();


### PR DESCRIPTION
Fixes #18178.  Should work fine until we hit 16000K resolutions.  But by then hopefully no one will be able to notice the nanometer wide gaps.

-[Unknown]