### PR TITLE
Don't load the shader cache on a separate thread - all it does is already async

### DIFF
--- a/Common/Data/Collections/Hashmaps.h
+++ b/Common/Data/Collections/Hashmaps.h
@@ -72,7 +72,7 @@ public:
 	}
 
 	bool ContainsKey(const Key &key) const {
-		// Slightly wasteful.
+		// Slightly wasteful, though compiler might optimize it.
 		Value value;
 		return Get(key, &value);
 	}

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -93,25 +93,12 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	if (discID.size()) {
 		File::CreateFullPath(GetSysDirectory(DIRECTORY_APP_CACHE));
 		shaderCachePath_ = GetSysDirectory(DIRECTORY_APP_CACHE) / (discID + ".vkshadercache");
-		shaderCacheLoaded_ = false;
-
-		shaderCacheLoadThread_ = std::thread([&] {
-			SetCurrentThreadName("VulkanLoadCache");
-			AndroidJNIThreadContext ctx;
-			LoadCache(shaderCachePath_);
-			shaderCacheLoaded_ = true;
-		});
-	} else {
-		shaderCacheLoaded_ = true;
+		LoadCache(shaderCachePath_);
 	}
 }
 
 bool GPU_Vulkan::IsReady() {
-	return shaderCacheLoaded_;
-}
-
-void GPU_Vulkan::CancelReady() {
-	pipelineManager_->CancelCache();
+	return true;
 }
 
 void GPU_Vulkan::LoadCache(const Path &filename) {
@@ -182,10 +169,6 @@ void GPU_Vulkan::SaveCache(const Path &filename) {
 }
 
 GPU_Vulkan::~GPU_Vulkan() {
-	if (shaderCacheLoadThread_.joinable()) {
-		shaderCacheLoadThread_.join();
-	}
-
 	if (draw_) {
 		VulkanRenderManager *rm = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 		rm->DrainAndBlockCompileQueue();

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -42,7 +42,6 @@ public:
 	u32 CheckGPUFeatures() const override;
 
 	bool IsReady() override;
-	void CancelReady() override;
 
 	// These are where we can reset command buffers etc.
 	void BeginHostFrame() override;
@@ -84,7 +83,4 @@ private:
 	PipelineManagerVulkan *pipelineManager_;
 
 	Path shaderCachePath_;
-	std::atomic<bool> shaderCacheLoaded_{};
-
-	std::thread shaderCacheLoadThread_;
 };

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -719,8 +719,6 @@ bool PipelineManagerVulkan::LoadPipelineCache(FILE *file, bool loadRawPipelineCa
 	VulkanRenderManager *rm = (VulkanRenderManager *)drawContext->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 	VulkanQueueRunner *queueRunner = rm->GetQueueRunner();
 
-	cancelCache_ = false;
-
 	uint32_t size = 0;
 	if (loadRawPipelineCache) {
 		NOTICE_LOG(G3D, "WARNING: Using the badly tested raw pipeline cache path!!!!");
@@ -779,7 +777,7 @@ bool PipelineManagerVulkan::LoadPipelineCache(FILE *file, bool loadRawPipelineCa
 	int pipelineCreateFailCount = 0;
 	int shaderFailCount = 0;
 	for (uint32_t i = 0; i < size; i++) {
-		if (failed || cancelCache_) {
+		if (failed) {
 			break;
 		}
 		StoredVulkanPipelineKey key;
@@ -823,8 +821,4 @@ bool PipelineManagerVulkan::LoadPipelineCache(FILE *file, bool loadRawPipelineCa
 	NOTICE_LOG(G3D, "Recreated Vulkan pipeline cache (%d pipelines, %d failed).", (int)size, pipelineCreateFailCount);
 	// We just ignore any failures.
 	return true;
-}
-
-void PipelineManagerVulkan::CancelCache() {
-	cancelCache_ = true;
 }

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -101,11 +101,9 @@ public:
 	// Saves data for faster creation next time.
 	void SavePipelineCache(FILE *file, bool saveRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext);
 	bool LoadPipelineCache(FILE *file, bool loadRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext, VkPipelineLayout layout, int multiSampleLevel);
-	void CancelCache();
 
 private:
 	DenseHashMap<VulkanPipelineKey, VulkanPipeline *> pipelines_;
 	VkPipelineCache pipelineCache_ = VK_NULL_HANDLE;
 	VulkanContext *vulkan_;
-	bool cancelCache_ = false;
 };

--- a/GPU/Vulkan/ShaderManagerVulkan.h
+++ b/GPU/Vulkan/ShaderManagerVulkan.h
@@ -121,9 +121,9 @@ public:
 	int GetNumGeometryShaders() const { return (int)gsCache_.size(); }
 
 	// Used for saving/loading the cache. Don't need to be particularly fast.
-	VulkanVertexShader *GetVertexShaderFromID(VShaderID id) { std::lock_guard<std::mutex> guard(cacheLock_); return vsCache_.GetOrNull(id); }
-	VulkanFragmentShader *GetFragmentShaderFromID(FShaderID id) { std::lock_guard<std::mutex> guard(cacheLock_); return fsCache_.GetOrNull(id); }
-	VulkanGeometryShader *GetGeometryShaderFromID(GShaderID id) { std::lock_guard<std::mutex> guard(cacheLock_); return gsCache_.GetOrNull(id); }
+	VulkanVertexShader *GetVertexShaderFromID(VShaderID id) { return vsCache_.GetOrNull(id); }
+	VulkanFragmentShader *GetFragmentShaderFromID(FShaderID id) { return fsCache_.GetOrNull(id); }
+	VulkanGeometryShader *GetGeometryShaderFromID(GShaderID id) { return gsCache_.GetOrNull(id); }
 
 	VulkanVertexShader *GetVertexShaderFromModule(VkShaderModule module);
 	VulkanFragmentShader *GetFragmentShaderFromModule(VkShaderModule module);
@@ -170,7 +170,6 @@ private:
 	GSCache gsCache_;
 
 	char *codeBuffer_;
-	std::mutex cacheLock_;
 
 	uint64_t uboAlignment_;
 	// Uniform block scratchpad. These (the relevant ones) are copied to the current pushbuffer at draw time.


### PR DESCRIPTION
Since some time, all the shader cache load has really done in practice is to spawn asynchronous tasks, so it itself runs really quickly.

Gets rid of a mutex and should remove some additional potential for sync bugs, although I think I fixed most of them in the last PR.

We already have to properly handle shutdown of all the async tasks, no need to add another layer of async-ness and locks.