### PR TITLE
Vulkan: Simplify GetShaders and DirtyLastShader, making them internally consistent.

### DIFF
--- a/GPU/Directx9/GPU_DX9.cpp
+++ b/GPU/Directx9/GPU_DX9.cpp
@@ -123,7 +123,7 @@ void GPU_DX9::BeginFrame() {
 	drawEngine_.BeginFrame();
 
 	GPUCommonHW::BeginFrame();
-	shaderManagerDX9_->DirtyShader();
+	shaderManagerDX9_->DirtyLastShader();
 
 	framebufferManager_->BeginFrame();
 

--- a/GPU/Directx9/ShaderManagerDX9.cpp
+++ b/GPU/Directx9/ShaderManagerDX9.cpp
@@ -535,25 +535,21 @@ void ShaderManagerDX9::Clear() {
 	}
 	fsCache_.clear();
 	vsCache_.clear();
-	DirtyShader();
+	DirtyLastShader();
 }
 
 void ShaderManagerDX9::ClearShaders() {
 	Clear();
 }
 
-void ShaderManagerDX9::DirtyShader() {
+void ShaderManagerDX9::DirtyLastShader() {
 	// Forget the last shader ID
 	lastFSID_.set_invalid();
 	lastVSID_.set_invalid();
 	lastVShader_ = nullptr;
 	lastPShader_ = nullptr;
+	// TODO: Probably not necessary to dirty uniforms here on DX9.
 	gstate_c.Dirty(DIRTY_ALL_UNIFORMS | DIRTY_VERTEXSHADER_STATE | DIRTY_FRAGMENTSHADER_STATE);
-}
-
-void ShaderManagerDX9::DirtyLastShader() {
-	lastVShader_ = nullptr;
-	lastPShader_ = nullptr;
 }
 
 VSShader *ShaderManagerDX9::ApplyShader(bool useHWTransform, bool useHWTessellation, VertexDecoder *decoder, bool weightsAsFloat, bool useSkinInDecode, const ComputedPipelineState &pipelineState) {

--- a/GPU/Directx9/ShaderManagerDX9.h
+++ b/GPU/Directx9/ShaderManagerDX9.h
@@ -79,7 +79,6 @@ public:
 
 	void ClearShaders() override;
 	VSShader *ApplyShader(bool useHWTransform, bool useHWTessellation, VertexDecoder *decoder, bool weightsAsFloat, bool useSkinInDecode, const ComputedPipelineState &pipelineState);
-	void DirtyShader();
 	void DirtyLastShader() override;
 
 	int GetNumVertexShaders() const { return (int)vsCache_.size(); }

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -277,7 +277,7 @@ void GPU_GLES::BeginFrame() {
 	if (shaderCachePath_.Valid() && (gpuStats.numFlips & 4095) == 0) {
 		shaderManagerGL_->SaveCache(shaderCachePath_, &drawEngine_);
 	}
-	shaderManagerGL_->DirtyShader();
+	shaderManagerGL_->DirtyLastShader();
 
 	// Not sure if this is really needed.
 	gstate_c.Dirty(DIRTY_ALL_UNIFORMS);

--- a/GPU/GLES/ShaderManagerGLES.cpp
+++ b/GPU/GLES/ShaderManagerGLES.cpp
@@ -716,7 +716,7 @@ void ShaderManagerGLES::Clear() {
 	linkedShaderCache_.clear();
 	fsCache_.Clear();
 	vsCache_.Clear();
-	DirtyShader();
+	DirtyLastShader();
 }
 
 void ShaderManagerGLES::ClearShaders() {
@@ -735,16 +735,12 @@ void ShaderManagerGLES::DeviceRestore(Draw::DrawContext *draw) {
 	draw_ = draw;
 }
 
-void ShaderManagerGLES::DirtyShader() {
+void ShaderManagerGLES::DirtyLastShader() {
 	// Forget the last shader ID
 	lastFSID_.set_invalid();
 	lastVSID_.set_invalid();
-	DirtyLastShader();
 	gstate_c.Dirty(DIRTY_ALL_UNIFORMS | DIRTY_VERTEXSHADER_STATE | DIRTY_FRAGMENTSHADER_STATE);
 	shaderSwitchDirtyUniforms_ = 0;
-}
-
-void ShaderManagerGLES::DirtyLastShader() {
 	lastShader_ = nullptr;
 	lastVShaderSame_ = false;
 }

--- a/GPU/GLES/ShaderManagerGLES.h
+++ b/GPU/GLES/ShaderManagerGLES.h
@@ -172,7 +172,6 @@ public:
 	void DeviceLost() override;
 	void DeviceRestore(Draw::DrawContext *draw) override;
 
-	void DirtyShader();
 	void DirtyLastShader() override;
 
 	int GetNumVertexShaders() const { return (int)vsCache_.size(); }

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -97,10 +97,6 @@ GPU_Vulkan::GPU_Vulkan(GraphicsContext *gfxCtx, Draw::DrawContext *draw)
 	}
 }
 
-bool GPU_Vulkan::IsReady() {
-	return true;
-}
-
 void GPU_Vulkan::LoadCache(const Path &filename) {
 	if (!g_Config.bShaderCache) {
 		WARN_LOG(G3D, "Shader cache disabled. Not loading.");
@@ -303,7 +299,7 @@ void GPU_Vulkan::BeginHostFrame() {
 
 	framebufferManager_->BeginFrame();
 
-	shaderManagerVulkan_->DirtyShader();
+	shaderManagerVulkan_->DirtyLastShader();
 	gstate_c.Dirty(DIRTY_ALL);
 
 	if (gstate_c.useFlagsChanged) {

--- a/GPU/Vulkan/GPU_Vulkan.h
+++ b/GPU/Vulkan/GPU_Vulkan.h
@@ -41,8 +41,6 @@ public:
 	// This gets called on startup and when we get back from settings.
 	u32 CheckGPUFeatures() const override;
 
-	bool IsReady() override;
-
 	// These are where we can reset command buffers etc.
 	void BeginHostFrame() override;
 	void EndHostFrame() override;

--- a/GPU/Vulkan/ShaderManagerVulkan.h
+++ b/GPU/Vulkan/ShaderManagerVulkan.h
@@ -113,7 +113,6 @@ public:
 
 	void GetShaders(int prim, VertexDecoder *decoder, VulkanVertexShader **vshader, VulkanFragmentShader **fshader, VulkanGeometryShader **gshader, const ComputedPipelineState &pipelineState, bool useHWTransform, bool useHWTessellation, bool weightsAsFloat, bool useSkinInDecode);
 	void ClearShaders() override;
-	void DirtyShader();
 	void DirtyLastShader() override;
 
 	int GetNumVertexShaders() const { return (int)vsCache_.size(); }


### PR DESCRIPTION
There was some weirdness before where the cached pointers and IDs could potentially get out of sync...

This was caused by the difference of DirtyShader and DirtyLastShader which didn't make all that much sense to have as two different functions.

This also reduces the number of shader hash lookups in some circumstances.