### PR TITLE
Some cleanups and fixes to obscure crashes

### DIFF
--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -219,9 +219,9 @@ namespace http {
 
 // TODO: do something sane here
 constexpr const char *DEFAULT_USERAGENT = "PPSSPP";
+constexpr const char *HTTP_VERSION = "1.1";
 
 Client::Client() {
-	httpVersion_ = "1.1";
 	userAgent_ = DEFAULT_USERAGENT;
 }
 
@@ -353,7 +353,7 @@ int Client::SendRequestWithData(const char *method, const RequestParams &req, co
 		"\r\n";
 
 	buffer.Printf(tpl,
-		method, req.resource.c_str(), httpVersion_,
+		method, req.resource.c_str(), HTTP_VERSION,
 		host_.c_str(),
 		userAgent_.c_str(),
 		req.acceptMime,

--- a/Common/Net/HTTPClient.h
+++ b/Common/Net/HTTPClient.h
@@ -86,7 +86,6 @@ public:
 
 protected:
 	std::string userAgent_;
-	const char *httpVersion_;
 	double dataTimeout_ = 900.0;
 };
 

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -227,9 +227,11 @@ void ScreenManager::getFocusPosition(float &x, float &y, float &z) {
 }
 
 void ScreenManager::sendMessage(const char *msg, const char *value) {
-	if (!strcmp(msg, "recreateviews"))
+	if (!msg) {
+		_dbg_assert_msg_(false, "Empty msg in ScreenManager::sendMessage");
+	} else if (!strcmp(msg, "recreateviews")) {
 		RecreateAllViews();
-	if (!strcmp(msg, "lost_focus")) {
+	} else if (!strcmp(msg, "lost_focus")) {
 		TouchInput input{};
 		input.x = -50000.0f;
 		input.y = -50000.0f;
@@ -238,6 +240,7 @@ void ScreenManager::sendMessage(const char *msg, const char *value) {
 		input.id = 0;
 		touch(input);
 	}
+
 	if (!stack_.empty())
 		stack_.back().screen->sendMessage(msg, value);
 }

--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -393,7 +393,7 @@ NPDRMDemoBlockDevice::NPDRMDemoBlockDevice(FileLoader *fileLoader)
 
 	fileLoader_->ReadAt(0x24, 1, 4, &psarOffset);
 	size_t readSize = fileLoader_->ReadAt(psarOffset, 1, 256, &np_header);
-	if(readSize!=256){
+	if (readSize != 256){
 		ERROR_LOG(LOADER, "Invalid NPUMDIMG header!");
 	}
 
@@ -445,7 +445,6 @@ NPDRMDemoBlockDevice::NPDRMDemoBlockDevice(FileLoader *fileLoader)
 	}
 
 	currentBlock = -1;
-
 }
 
 NPDRMDemoBlockDevice::~NPDRMDemoBlockDevice()

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1486,6 +1486,12 @@ static u32 sceIoLseek32Async(int id, int offset, int whence) {
 }
 
 static FileNode *__IoOpen(int &error, const char *filename, int flags, int mode) {
+	if (!filename) {
+		// To prevent crashes. Not sure about the correct value.
+		error = SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND;
+		return nullptr;
+	}
+
 	int access = FILEACCESS_NONE;
 	if (flags & PSP_O_RDONLY)
 		access |= FILEACCESS_READ;


### PR DESCRIPTION
The httpVersion thing I don't think does anything, the crashlog I saw around Buffer::Printf is probably something else. Just eliminating an unnecessary variable.