### PR TITLE
unittest: Add jit compare for jit IR

### DIFF
--- a/Core/MIPS/x86/X64IRAsm.cpp
+++ b/Core/MIPS/x86/X64IRAsm.cpp
@@ -58,7 +58,7 @@ void X64JitBackend::GenerateFixedCode(MIPSState *mipsState) {
 	int jitbaseCtxDisp = 0;
 	// We pre-bake the MIPS_EMUHACK_OPCODE subtraction into our jitbase value.
 	intptr_t jitbase = (intptr_t)GetBasePtr() - MIPS_EMUHACK_OPCODE;
-	if ((jitbase < -0x80000000LL || jitbase > 0x7FFFFFFFLL) && !Accessible((const u8 *)&mipsState->f[0], GetBasePtr())) {
+	if ((jitbase < -0x80000000LL || jitbase > 0x7FFFFFFFLL) && !Accessible((const u8 *)&mipsState->f[0], (const u8 *)jitbase)) {
 		jo.reserveR15ForAsm = true;
 		jitbaseInR15 = true;
 	} else {

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -58,6 +58,7 @@
 #include "Common/Render/DrawBuffer.h"
 #include "Common/System/NativeApp.h"
 #include "Common/System/System.h"
+#include "Common/Thread/ThreadUtil.h"
 
 #include "Common/ArmEmitter.h"
 #include "Common/BitScan.h"
@@ -1038,6 +1039,8 @@ TestItem availableTests[] = {
 };
 
 int main(int argc, const char *argv[]) {
+	SetCurrentThreadName("UnitTest");
+
 	cpu_info.bNEON = true;
 	cpu_info.bVFP = true;
 	cpu_info.bVFPv3 = true;


### PR DESCRIPTION
This makes it so you can easily compare a code block's codegen between:
 * Interpreter
 * IR Interpreter
 * Linear JIT
 * JIT IR

Also adds a thread name for UnitTest so asserts don't break.

-[Unknown]