### PR TITLE
arm64jit: Enable in UI

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1668,7 +1668,7 @@ void DeveloperToolsScreen::CreateViews() {
 		core->HideChoice(3);
 	}
 	// TODO: Enable on more architectures.
-#if !PPSSPP_ARCH(X86) && !PPSSPP_ARCH(AMD64)
+#if !PPSSPP_ARCH(X86) && !PPSSPP_ARCH(AMD64) && !PPSSPP_ARCH(ARM64)
 	core->HideChoice(3);
 #endif
 


### PR DESCRIPTION
For later, but once it's working on M1 I'd like to merge this to enable.  It's all it takes.

For now I know it works fine on Qualcomm and Google Tensor processors.  I suspect whatever's happening on M1 is actually macOS specific (or some non-pointerify mistake) but not sure.

-[Unknown]