### PR TITLE
Jit: Assert on bad exit numbers, allow two more exits per block

### DIFF
--- a/Core/MIPS/ARM/ArmJit.cpp
+++ b/Core/MIPS/ARM/ArmJit.cpp
@@ -746,6 +746,8 @@ void ArmJit::UpdateRoundingMode(u32 fcr31) {
 void ArmJit::WriteExit(u32 destination, int exit_num)
 {
 	// TODO: Check destination is valid and trigger exception.
+	_assert_msg_(exit_num < MAX_JIT_BLOCK_EXITS, "Expected a valid exit_num. dest=%08x", destination);
+
 	WriteDownCount(); 
 	//If nobody has taken care of this yet (this can be removed when all branches are done)
 	JitBlock *b = js.curBlock;

--- a/Core/MIPS/ARM64/Arm64Jit.cpp
+++ b/Core/MIPS/ARM64/Arm64Jit.cpp
@@ -726,6 +726,9 @@ void Arm64Jit::UpdateRoundingMode(u32 fcr31) {
 // I don't think this gives us that much benefit.
 void Arm64Jit::WriteExit(u32 destination, int exit_num) {
 	// TODO: Check destination is valid and trigger exception.
+	_assert_msg_(exit_num < MAX_JIT_BLOCK_EXITS, "Expected a valid exit_num. dest=%08x", destination);
+
+	// TODO: Check destination is valid and trigger exception.
 	WriteDownCount(); 
 	//If nobody has taken care of this yet (this can be removed when all branches are done)
 	JitBlock *b = js.curBlock;

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -29,7 +29,7 @@
 #include "Core/MIPS/MIPS.h"
 
 #if PPSSPP_ARCH(ARM) || PPSSPP_ARCH(ARM64)
-const int MAX_JIT_BLOCK_EXITS = 2;
+const int MAX_JIT_BLOCK_EXITS = 4;
 #else
 const int MAX_JIT_BLOCK_EXITS = 8;
 #endif

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -708,7 +708,7 @@ static void HitInvalidBranch(uint32_t dest) {
 }
 
 void Jit::WriteExit(u32 destination, int exit_num) {
-	_dbg_assert_msg_(exit_num < MAX_JIT_BLOCK_EXITS, "Expected a valid exit_num");
+	_assert_msg_(exit_num < MAX_JIT_BLOCK_EXITS, "Expected a valid exit_num. dest=%08x", destination);
 
 	if (!Memory::IsValidAddress(destination) || (destination & 3) != 0) {
 		ERROR_LOG_REPORT(JIT, "Trying to write block exit to illegal destination %08x: pc = %08x", destination, currentMIPS->pc);


### PR DESCRIPTION
 Trying to fix an issue from #18116.

We should really do this exit tracking in a better way, but defer that to later.

I'm not even sure how more than 2 branches happen, but it really does look like they do in the logs. So bump it to 4. Trying to keep this change minimal.