### PR TITLE
Control: Remove the axis event dupe filtering, batch events deeper

### DIFF
--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -119,18 +119,8 @@ bool ScreenManager::key(const KeyInput &key) {
 
 void ScreenManager::axis(const AxisInput &axis) {
 	std::lock_guard<std::recursive_mutex> guard(inputLock_);
-
-	// Ignore duplicate values to prevent axis values overwriting each other.
-	uint64_t key = ((uint64_t)axis.axisId << 32) | axis.deviceId;
-	// Center value far from zero just to ensure we send the first zero.
-	// PSP games can't see higher resolution than this.
-	int value = 128 + ceilf(axis.value * 127.5f + 127.5f);
-	if (lastAxis_[key] == value) {
-		return;
-	}
-	lastAxis_[key] = value;
-
 	// Send center axis to every screen layer.
+	// TODO: Do we still need this?
 	if (axis.value == 0) {
 		for (auto &layer : stack_) {
 			layer.screen->UnsyncAxis(axis);

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -119,10 +119,7 @@ bool ScreenManager::key(const KeyInput &key) {
 
 void ScreenManager::axis(const AxisInput *axes, size_t count) {
 	std::lock_guard<std::recursive_mutex> guard(inputLock_);
-	for (size_t i = 0; i < count; i++) {
-		const AxisInput &axis = axes[i];
-		stack_.back().screen->UnsyncAxis(axis);
-	}
+	stack_.back().screen->UnsyncAxis(axes, count);
 }
 
 void ScreenManager::deviceLost() {

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -117,7 +117,7 @@ bool ScreenManager::key(const KeyInput &key) {
 	return result;
 }
 
-void ScreenManager::axis(const AxisInput &axis) {
+void ScreenManager::axis(const AxisInput *axis, size_t count) {
 	std::lock_guard<std::recursive_mutex> guard(inputLock_);
 	stack_.back().screen->UnsyncAxis(axis);
 }

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -117,9 +117,12 @@ bool ScreenManager::key(const KeyInput &key) {
 	return result;
 }
 
-void ScreenManager::axis(const AxisInput *axis, size_t count) {
+void ScreenManager::axis(const AxisInput *axes, size_t count) {
 	std::lock_guard<std::recursive_mutex> guard(inputLock_);
-	stack_.back().screen->UnsyncAxis(axis);
+	for (size_t i = 0; i < count; i++) {
+		const AxisInput &axis = axes[i];
+		stack_.back().screen->UnsyncAxis(axis);
+	}
 }
 
 void ScreenManager::deviceLost() {

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -119,15 +119,7 @@ bool ScreenManager::key(const KeyInput &key) {
 
 void ScreenManager::axis(const AxisInput &axis) {
 	std::lock_guard<std::recursive_mutex> guard(inputLock_);
-	// Send center axis to every screen layer.
-	// TODO: Do we still need this?
-	if (axis.value == 0) {
-		for (auto &layer : stack_) {
-			layer.screen->UnsyncAxis(axis);
-		}
-	} else if (!stack_.empty()) {
-		stack_.back().screen->UnsyncAxis(axis);
-	}
+	stack_.back().screen->UnsyncAxis(axis);
 }
 
 void ScreenManager::deviceLost() {

--- a/Common/UI/Screen.h
+++ b/Common/UI/Screen.h
@@ -63,7 +63,7 @@ public:
 	virtual bool UnsyncTouch(const TouchInput &touch) = 0;
 	// Return value of UnsyncKey is used to not block certain system keys like volume when unhandled, on Android.
 	virtual bool UnsyncKey(const KeyInput &touch) = 0;
-	virtual void UnsyncAxis(const AxisInput &touch) = 0;
+	virtual void UnsyncAxis(const AxisInput *axes, size_t count) = 0;
 
 	virtual void RecreateViews() {}
 

--- a/Common/UI/Screen.h
+++ b/Common/UI/Screen.h
@@ -135,7 +135,7 @@ public:
 	// Instant touch, separate from the update() mechanism.
 	void touch(const TouchInput &touch);
 	bool key(const KeyInput &key);
-	void axis(const AxisInput &touch);
+	void axis(const AxisInput *axes, size_t count);
 
 	// Generic facility for gross hacks :P
 	void sendMessage(const char *msg, const char *value);

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -99,12 +99,14 @@ bool UIScreen::UnsyncTouch(const TouchInput &touch) {
 	return false;
 }
 
-void UIScreen::UnsyncAxis(const AxisInput &axis) {
+void UIScreen::UnsyncAxis(const AxisInput *axes, size_t count) {
 	QueuedEvent ev{};
 	ev.type = QueuedEventType::AXIS;
-	ev.axis = axis;
 	std::lock_guard<std::mutex> guard(eventQueueLock_);
-	eventQueue_.push_back(ev);
+	for (size_t i = 0; i < count; i++) {
+		ev.axis = axes[i];
+		eventQueue_.push_back(ev);
+	}
 }
 
 bool UIScreen::UnsyncKey(const KeyInput &key) {

--- a/Common/UI/UIScreen.h
+++ b/Common/UI/UIScreen.h
@@ -48,7 +48,7 @@ public:
 
 	bool UnsyncTouch(const TouchInput &touch) override;
 	bool UnsyncKey(const KeyInput &key) override;
-	void UnsyncAxis(const AxisInput &axis) override;
+	void UnsyncAxis(const AxisInput *axes, size_t count) override;
 
 	TouchInput transformTouch(const TouchInput &touch) override;
 

--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -473,11 +473,14 @@ void UpdateVRInput(bool haptics, float dp_xscale, float dp_yscale) {
 	}
 }
 
-bool UpdateVRAxis(const AxisInput &axis) {
-	if (pspAxis.find(axis.deviceId) == pspAxis.end()) {
-		pspAxis[axis.deviceId] = std::map<int, float>();
+bool UpdateVRAxis(const AxisInput *axes, size_t count) {
+	for (size_t i = 0; i < count; i++) {
+		const AxisInput &axis = axes[i];
+		if (pspAxis.find(axis.deviceId) == pspAxis.end()) {
+			pspAxis[axis.deviceId] = std::map<int, float>();
+		}
+		pspAxis[axis.deviceId][axis.axisId] = axis.value;
 	}
-	pspAxis[axis.deviceId][axis.axisId] = axis.value;
 	return !pspKeys[VIRTKEY_VR_CAMERA_ADJUST];
 }
 

--- a/Common/VR/PPSSPPVR.h
+++ b/Common/VR/PPSSPPVR.h
@@ -37,7 +37,7 @@ void SetVRCallbacks(void(*axis)(const AxisInput *axis, size_t count), bool(*key)
 // VR input integration
 void SetVRAppMode(VRAppMode mode);
 void UpdateVRInput(bool haptics, float dp_xscale, float dp_yscale);
-bool UpdateVRAxis(const AxisInput &axis);
+bool UpdateVRAxis(const AxisInput *axes, size_t count);
 bool UpdateVRKeys(const KeyInput &key);
 
 // VR games compatibility

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -16,7 +16,7 @@ public:
 	// Inputs to the table-based mapping
 	// These functions are free-threaded.
 	bool Key(const KeyInput &key, bool *pauseTrigger);
-	void Axis(const AxisInput &axis);
+	void Axis(const AxisInput *axes, size_t count);
 
 	// Required callbacks.
 	// TODO: These are so many now that a virtual interface might be more appropriate..
@@ -76,6 +76,8 @@ private:
 	bool swapAxes_ = false;
 
 	// Protects basically all the state.
+	// TODO: Maybe we should piggyback on the screenmanager mutex - it's always locked
+	// when events come in here.
 	std::mutex mutex_;
 
 	std::map<InputMapping, InputSample> curInput_;

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -535,7 +535,7 @@ void AnalogSetupScreen::axis(const AxisInput &axis) {
 	// UIScreen::axis(axis);
 
 	// Instead we just send the input directly to the mapper, that we'll visualize.
-	mapper_.Axis(axis);
+	mapper_.Axis(&axis, 1);
 }
 
 void AnalogSetupScreen::CreateViews() {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -865,9 +865,9 @@ bool EmuScreen::key(const KeyInput &key) {
 	return retval;
 }
 
-void EmuScreen::UnsyncAxis(const AxisInput &axis) {
+void EmuScreen::UnsyncAxis(const AxisInput *axes, size_t count) {
 	System_Notify(SystemNotification::ACTIVITY);
-	return controlMapper_.Axis(axis);
+	return controlMapper_.Axis(axes, count);
 }
 
 class GameInfoBGView : public UI::InertView {

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -53,7 +53,7 @@ public:
 	// to get minimal latency and full control. We forward to UIScreen when needed.
 	bool UnsyncTouch(const TouchInput &touch) override;
 	bool UnsyncKey(const KeyInput &key) override;
-	void UnsyncAxis(const AxisInput &axis) override;
+	void UnsyncAxis(const AxisInput *axes, size_t count) override;
 
 	// We also need to do some special handling of queued UI events to handle closing the chat window.
 	bool key(const KeyInput &key) override;

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1330,9 +1330,10 @@ void NativeAxis(const AxisInput *axes, size_t count) {
 		return;
 	}
 
+	g_screenManager->axis(axes, count);
+
 	for (size_t i = 0; i < count; i++) {
 		const AxisInput &axis = axes[i];
-		g_screenManager->axis(axis);
 		HLEPlugins::PluginDataAxis[axis.axisId] = axis.value;
 	}
 }

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1319,9 +1319,9 @@ bool NativeKey(const KeyInput &key) {
 	return retval;
 }
 
-static void ProcessOneAxisEvent(const AxisInput &axis) {
+void NativeAxis(const AxisInput *axes, size_t count) {
 	// VR actions
-	if (IsVREnabled() && !UpdateVRAxis(axis)) {
+	if (IsVREnabled() && !UpdateVRAxis(axes, count)) {
 		return;
 	}
 
@@ -1330,14 +1330,10 @@ static void ProcessOneAxisEvent(const AxisInput &axis) {
 		return;
 	}
 
-	// only do special handling of tilt events if tilt is enabled.
-	HLEPlugins::PluginDataAxis[axis.axisId] = axis.value;
-	g_screenManager->axis(axis);
-}
-
-void NativeAxis(const AxisInput *axes, size_t count) {
 	for (size_t i = 0; i < count; i++) {
-		ProcessOneAxisEvent(axes[i]);
+		const AxisInput &axis = axes[i];
+		g_screenManager->axis(axis);
+		HLEPlugins::PluginDataAxis[axis.axisId] = axis.value;
 	}
 }
 


### PR DESCRIPTION
It's better to have the event sources pre-filter, and most of them now do that.

Also, as previously mentioned, axis events often come in clumps, so let's process them in clumps for reduced locking.