### PR TITLE
Fix issue uploading narrow textures in OpenGL.

### DIFF
--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -304,7 +304,7 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 					bc = true;
 				} else {
 					int bpp = (int)Draw::DataFormatSizeInBytes(plan.replaced->Format());
-					stride = std::max(mipWidth * bpp, 16);
+					stride = mipWidth * bpp;
 					dataSize = stride * mipHeight;
 				}
 			} else {
@@ -314,7 +314,7 @@ void TextureCacheGLES::BuildTexture(TexCacheEntry *const entry) {
 				} else {
 					bpp = (int)Draw::DataFormatSizeInBytes(dstFmt);
 				}
-				stride = std::max(mipWidth * bpp, 16);
+				stride = mipWidth * bpp;
 				dataSize = stride * mipHeight;
 			}
 


### PR DESCRIPTION
We had some stride adjustment that is not needed - and we're not passing the stride along, so it can't do the "right thing".

Fixes #18254