### PR TITLE
ControlMapper: Fix a range check and array size. In reality, probably not a danger.

### DIFF
--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -480,8 +480,9 @@ void ControlMapper::Axis(const AxisInput &axis) {
 	double now = time_now_d();
 
 	std::lock_guard<std::mutex> guard(mutex_);
-	if (axis.deviceId < DEVICE_ID_COUNT) {
-		deviceTimestamps_[(int)axis.deviceId] = now;
+	size_t deviceIndex = (size_t)axis.deviceId;  // this'll wrap around ANY (-1) to max, which will eliminate it on the next line, if such an event appears by mistake.
+	if (deviceIndex < (size_t)DEVICE_ID_COUNT) {
+		deviceTimestamps_[deviceIndex] = now;
 	}
 	if (axis.value >= 0.0f) {
 		InputMapping mapping(axis.deviceId, axis.axisId, 1);

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -62,7 +62,7 @@ private:
 	float virtKeys_[VIRTKEY_COUNT]{};
 	bool virtKeyOn_[VIRTKEY_COUNT]{};  // Track boolean output separaately since thresholds may differ.
 
-	double deviceTimestamps_[42]{};
+	double deviceTimestamps_[(size_t)DEVICE_ID_COUNT]{};
 
 	int lastNonDeadzoneDeviceID_[2]{};
 


### PR DESCRIPTION
Probably a theoretical risk, MSVC's static analyzer nags about it so fixing it.