### PR TITLE
Buildfix on CI ?

### DIFF
--- a/ext/libchdr-build/CMakeLists.txt
+++ b/ext/libchdr-build/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SRC_DIR ../libchdr/src)
 
 include_directories(../libchdr/deps/lzma-22.01/include)
 include_directories(../libchdr/include)
+include_directories(../zlib)
 
 add_definitions(-D_7ZIP_ST)
 


### PR DESCRIPTION
Seems to be getting spurious failures, sometimes failing to find zlib.h here. Let's add the include path.