### PR TITLE
SDL: Use an "EmuThread" in Vulkan mode

### DIFF
--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -96,7 +96,6 @@ static float g_ForcedDPI = 0.0f; // if this is 0.0f, use g_DesktopDPI
 static float g_RefreshRate = 60.f;
 static int g_sampleRate = 44100;
 
-static int g_frameCount = 0;
 static bool g_rebootEmuThread = false;
 
 static SDL_AudioSpec g_retFmt;
@@ -1102,7 +1101,7 @@ static void ProcessSDLEvent(SDL_Window *window, const SDL_Event &event, InputSta
 				break;
 			}
 			// Don't start auto switching for a second, because some devices init on start.
-			bool doAutoSwitch = g_Config.bAutoAudioDevice && g_frameCount > 60;
+			bool doAutoSwitch = g_Config.bAutoAudioDevice && time_now_d() > 1.0f;
 			if (doAutoSwitch || g_Config.sAudioDevice == name) {
 				StopSDLAudioDevice();
 				InitSDLAudioDevice(name ? name : "");
@@ -1455,13 +1454,14 @@ int main(int argc, char *argv[]) {
 
 		inputTracker.TranslateMouseWheel();
 
-		SDL_Event event;
-		while (SDL_PollEvent(&event)) {
-			ProcessSDLEvent(window, event, &inputTracker);
+		{
+			SDL_Event event;
+			while (SDL_PollEvent(&event)) {
+				ProcessSDLEvent(window, event, &inputTracker);
+			}
 		}
 		if (g_QuitRequested || g_RestartRequested)
 			break;
-		const uint8_t *keys = SDL_GetKeyboardState(NULL);
 		if (emuThreadState == (int)EmuThreadState::DISABLED) {
 			UpdateRunLoop(graphicsContext);
 		}
@@ -1531,8 +1531,6 @@ int main(int argc, char *argv[]) {
 			if (sleepTime > 0)
 				sleep_ms(sleepTime);
 		}
-
-		g_frameCount++;
 	}
 
 	if (useEmuThread) {

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -1122,7 +1122,18 @@ static void ProcessSDLEvent(SDL_Window *window, const SDL_Event &event, InputSta
 		}
 		break;
 	}
+}
 
+void UpdateSDLCursor() {
+#if !defined(MOBILE_DEVICE)
+	if (lastUIState != GetUIState()) {
+		lastUIState = GetUIState();
+		if (lastUIState == UISTATE_INGAME && g_Config.UseFullScreen() && !g_Config.bShowTouchControls)
+			SDL_ShowCursor(SDL_DISABLE);
+		if (lastUIState != UISTATE_INGAME || !g_Config.UseFullScreen())
+			SDL_ShowCursor(SDL_ENABLE);
+	}
+#endif
 }
 
 #ifdef _WIN32
@@ -1468,15 +1479,7 @@ int main(int argc, char *argv[]) {
 		if (g_QuitRequested || g_RestartRequested)
 			break;
 
-#if !defined(MOBILE_DEVICE)
-		if (lastUIState != GetUIState()) {
-			lastUIState = GetUIState();
-			if (lastUIState == UISTATE_INGAME && g_Config.UseFullScreen() && !g_Config.bShowTouchControls)
-				SDL_ShowCursor(SDL_DISABLE);
-			if (lastUIState != UISTATE_INGAME || !g_Config.UseFullScreen())
-				SDL_ShowCursor(SDL_ENABLE);
-		}
-#endif
+		UpdateSDLCursor();
 
 		inputTracker.MouseControl();
 		inputTracker.MouseCaptureControl();


### PR DESCRIPTION
This avoids the problem of sampling input once per rendered frame, instead allowing inputs to arrive at any time, as seen from the emulation. Should help with the jittery feeling of input events reported on Linux by JMC for example.

Takes care of the Vulkan part of #17876 . Doing the same for OpenGL is iffier due to threading issues.

- [x] Add some missing functionality from the old loop
- [x] Test on Linux
