### PR TITLE
UI: Fix crash on input with no screens

### DIFF
--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -119,6 +119,8 @@ bool ScreenManager::key(const KeyInput &key) {
 
 void ScreenManager::axis(const AxisInput *axes, size_t count) {
 	std::lock_guard<std::recursive_mutex> guard(inputLock_);
+	if (stack_.empty())
+		return;
 	stack_.back().screen->UnsyncAxis(axes, count);
 }
 


### PR DESCRIPTION
I was pretty consistently getting an axis event before any screens were ready, causing an insta-crash on startup.

-[Unknown]