### PR TITLE
Debugger: Ignore func imports in ppmap files

### DIFF
--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -181,6 +181,14 @@ bool SymbolMap::LoadSymbolMap(const Path &filename) {
 		if (type == ST_DATA && size == 0)
 			size = 4;
 
+		// Ignore syscalls, will be recognized from stubs.
+		// Note: it's still useful to save these for grepping and importing into other tools.
+		if (strncmp(name, "zz_sce", 6) == 0)
+			continue;
+		// Also ignore unresolved imports, which will similarly be replaced.
+		if (strncmp(name, "zz_[UNK", 7) == 0)
+			continue;
+
 		if (!strcmp(name, ".text") || !strcmp(name, ".init") || strlen(name) <= 1) {
 
 		} else {


### PR DESCRIPTION
My real motivation is that, somehow, I had gotten a knownfuncs reference named zz_sceKernelStdin that basically matched anything that was a basic `addiu sp; sw ra; jal realfunc; lw ra; addiu sp`.  I didn't notice before it had poisoned a bunch of my maps.  Easier to exclude on load than fix all the wrong maps...

That said, I think this makes sense because we should redefine any zz_ imports on load anyway, and they might've been wrong or corrected.  Especially for the "[UNK: ...]" ones.

-[Unknown]