### PR TITLE
arm64jit: Skip unnecessary const load w/4 weights

### DIFF
--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -315,7 +315,7 @@ bool VertexDecoderJitCache::CompileStep(const VertexDecoder &dec, int step) {
 
 void VertexDecoderJitCache::Jit_ApplyWeights() {
 	// We construct a matrix in Q4-Q7
-	if (dec_->nweights >= 4) {
+	if (dec_->nweights > 4) {
 		MOVP2R(scratchReg64, bones + 16 * 4);
 	}
 	for (int i = 0; i < dec_->nweights; i++) {


### PR DESCRIPTION
Oops, sorry.  I caught this later after initially pushing #18125, but must've forgotten to push this extra commit.  Just skips a MOVP2R with 4 weights (which is I think the most common number in God of War's title screen, at least.)

-[Unknown]