### PR TITLE
Thread: Reduce thread stop freeing on shutdown

### DIFF
--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -740,8 +740,12 @@ void __PsmfPlayerDoState(PointerWrap &p) {
 void __PsmfShutdown() {
 	for (auto it = psmfMap.begin(), end = psmfMap.end(); it != end; ++it)
 		delete it->second;
-	for (auto it = psmfPlayerMap.begin(), end = psmfPlayerMap.end(); it != end; ++it)
+	for (auto it = psmfPlayerMap.begin(), end = psmfPlayerMap.end(); it != end; ++it) {
+		// Don't bother freeing, may already be freed.
+		if (it->second->finishThread)
+			it->second->finishThread->Forget();
 		delete it->second;
+	}
 	psmfMap.clear();
 	psmfPlayerMap.clear();
 }

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -304,6 +304,8 @@ void __UtilityShutdown() {
 	npSigninDialog->Shutdown(true);
 
 	if (accessThread) {
+		// Don't need to free it during shutdown, may have already been freed.
+		accessThread->Forget();
 		delete accessThread;
 		accessThread = nullptr;
 		accessThreadState = "shutdown";


### PR DESCRIPTION
Seeing errors for helper threads not existing, so let's try skipping delete on shutdown.  They already get freed anyway.

Old branch I forgot about.

-[Unknown]