### PR TITLE
Execute_Prim: Minor fixes and cleanups

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1944,7 +1944,7 @@ bool GPUCommon::DescribeCodePtr(const u8 *ptr, std::string &name) {
 
 void GPUCommon::UpdateUVScaleOffset() {
 #ifdef _M_SSE
-	__m128i values = _mm_slli_epi32(_mm_load_si128((const __m128i *) & gstate.texscaleu), 8);
+	__m128i values = _mm_slli_epi32(_mm_load_si128((const __m128i *)&gstate.texscaleu), 8);
 	_mm_storeu_si128((__m128i *)&gstate_c.uv, values);
 #elif PPSSPP_ARCH(ARM_NEON)
 	const uint32x4_t values = vshlq_n_u32(vld1q_u32((const u32 *)&gstate.texscaleu), 8);

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -225,9 +225,13 @@ protected:
 
 	inline bool IsTrianglePrim(GEPrimitiveType prim) const {
 		// TODO: KEEP_PREVIOUS is mistakenly treated as TRIANGLE here... This isn't new.
+		//
+		// Interesting optimization, but not confident in performance:
 		// static const bool p[8] = { false, false, false, true, true, true, false, true };
 		// 10111000 = 0xB8;
-		return (0xB8U >> (u8)prim) & 1;
+		// return (0xB8U >> (u8)prim) & 1;
+
+		return prim > GE_PRIM_LINE_STRIP && prim != GE_PRIM_RECTANGLES;
 	}
 
 	void SetDrawType(DrawType type, GEPrimitiveType prim) {

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -224,7 +224,10 @@ protected:
 	virtual void CheckRenderResized() {}
 
 	inline bool IsTrianglePrim(GEPrimitiveType prim) const {
-		return prim != GE_PRIM_RECTANGLES && prim > GE_PRIM_LINE_STRIP;
+		// TODO: KEEP_PREVIOUS is mistakenly treated as TRIANGLE here... This isn't new.
+		// static const bool p[8] = { false, false, false, true, true, true, false, true };
+		// 10111000 = 0xB8;
+		return (0xB8 >> (int)prim) & 1;
 	}
 
 	void SetDrawType(DrawType type, GEPrimitiveType prim) {

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -227,7 +227,7 @@ protected:
 		// TODO: KEEP_PREVIOUS is mistakenly treated as TRIANGLE here... This isn't new.
 		// static const bool p[8] = { false, false, false, true, true, true, false, true };
 		// 10111000 = 0xB8;
-		return (0xB8 >> (int)prim) & 1;
+		return (0xB8U >> (u8)prim) & 1;
 	}
 
 	void SetDrawType(DrawType type, GEPrimitiveType prim) {

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1003,10 +1003,11 @@ void GPUCommonHW::Execute_Prim(u32 op, u32 diff) {
 
 	uint32_t vtypeCheckMask = g_Config.bSoftwareSkinning ? (~GE_VTYPE_WEIGHTCOUNT_MASK) : 0xFFFFFFFF;
 
+	bool isTriangle = IsTrianglePrim(prim);
+
 	if (debugRecording_)
 		goto bail;
 
-	bool isTriangle = IsTrianglePrim(prim);
 	while (src != stall) {
 		uint32_t data = *src;
 		switch (data >> 24) {

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -949,8 +949,6 @@ void GPUCommonHW::Execute_Prim(u32 op, u32 diff) {
 	}
 
 	u32 count = op & 0xFFFF;
-	if (count == 0)
-		return;
 
 	// Must check this after SetRenderFrameBuffer so we know SKIPDRAW_NON_DISPLAYED_FB.
 	if (gstate_c.skipDrawReason & (SKIPDRAW_SKIPFRAME | SKIPDRAW_NON_DISPLAYED_FB)) {
@@ -1017,11 +1015,6 @@ void GPUCommonHW::Execute_Prim(u32 op, u32 diff) {
 		case GE_CMD_PRIM:
 		{
 			u32 count = data & 0xFFFF;
-			if (count == 0) {
-				// Ignore.
-				break;
-			}
-
 			GEPrimitiveType newPrim = static_cast<GEPrimitiveType>((data >> 16) & 7);
 			SetDrawType(DRAW_PRIM, newPrim);
 			// TODO: more efficient updating of verts/inds
@@ -1151,8 +1144,9 @@ bail:
 		}
 	}
 
-	gpuStats.vertexGPUCycles += vertexCost_ * totalVertCount;
-	cyclesExecuted += vertexCost_ * totalVertCount;
+	int cycles = vertexCost_ * totalVertCount;
+	gpuStats.vertexGPUCycles += cycles;
+	cyclesExecuted += cycles;
 }
 
 void GPUCommonHW::Execute_Bezier(u32 op, u32 diff) {


### PR DESCRIPTION
SetDrawType can cause a Flush which would not be appropriate from within the optimized prim loop (though in practice, the loop might itself reject GPU instructions that would lead down that path).

~~Also, optimize away branches from IsTrianglePrim.~~ (holding off)

Checking prim for count == 0 shouldn't be necessary - we already have a check for it inside of SubmitPrim.