### PR TITLE
DrawEngine refactor, quickly merge non-indexed consecutive draws

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -718,6 +718,7 @@ void DrawEngineCommon::SubmitPrim(const void *verts, const void *inds, GEPrimiti
 	di.cullMode = cullMode;
 	di.vertexCount = vertexCount;
 	di.vertDecodeIndex = numDrawVerts_;
+	di.offset = 0;
 
 	_dbg_assert_(numDrawVerts_ <= MAX_DEFERRED_DRAW_VERTS);
 	_dbg_assert_(numDrawInds_ <= MAX_DEFERRED_DRAW_INDS);
@@ -782,7 +783,7 @@ void DrawEngineCommon::DecodeInds() {
 	for (; i < numDrawInds_; i++) {
 		const DeferredInds &di = drawInds_[i];
 
-		int indexOffset = drawVertexOffsets_[di.vertDecodeIndex];
+		int indexOffset = drawVertexOffsets_[di.vertDecodeIndex] + di.offset;
 		bool clockwise = true;
 		if (gstate.isCullEnabled() && gstate.getCullMode() != di.cullMode) {
 			clockwise = false;

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -683,12 +683,6 @@ bool DrawEngineCommon::ExtendNonIndexedPrim(GEPrimitiveType prim, int vertexCoun
 		return false;
 	}
 
-	bool applySkin = (vertTypeID & GE_VTYPE_WEIGHT_MASK) && decOptions_.applySkinInDecode;
-	if (applySkin) {
-		// TODO: Support this somehow.
-		return false;
-	}
-
 	_dbg_assert_(numDrawInds_ < MAX_DEFERRED_DRAW_INDS);
 	_dbg_assert_(numDrawVerts_ > 0);
 	*bytesRead = vertexCount * dec_->VertexSize();
@@ -707,6 +701,7 @@ bool DrawEngineCommon::ExtendNonIndexedPrim(GEPrimitiveType prim, int vertexCoun
 	dv.vertexCount += vertexCount;
 	dv.indexUpperBound = dv.vertexCount - 1;
 	vertexCountInDrawCalls_ += vertexCount;
+
 	return true;
 }
 
@@ -786,10 +781,6 @@ void DrawEngineCommon::SubmitPrim(const void *verts, const void *inds, GEPrimiti
 		// This prevents issues with consecutive self-renders in Ridge Racer.
 		gstate_c.Dirty(DIRTY_TEXTURE_PARAMS);
 		DispatchFlush();
-	}
-
-	if (applySkin) {
-		DecodeVerts(decoded_);
 	}
 }
 

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -228,6 +228,7 @@ protected:
 		u8 indexType;
 		s8 prim;
 		u8 cullMode;
+		u16 offset;
 	};
 
 	enum { MAX_DEFERRED_DRAW_VERTS = 128 };  // If you change this to more than 256, change type of DeferredInds::vertDecodeIndex.

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -144,16 +144,16 @@ protected:
 	void DecodeVerts(u8 *dest);
 	void DecodeInds();
 
+	int MaxIndex() const {
+		return decodedVerts_;
+	}
+
 	// Preprocessing for spline/bezier
 	u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, u32 vertType, int *vertexSize = nullptr);
 
 	// Utility for vertex caching
 	u32 ComputeMiniHash();
 	uint64_t ComputeHash();
-
-	// Vertex decoding
-	void DecodeVertsStep(u8 *dest, int i, int &decodedVerts, const UVScale *uvScale);
-	void DecodeIndsStep(int i);
 
 	int ComputeNumVertsToDecode() const;
 
@@ -224,15 +224,17 @@ protected:
 	struct DeferredInds {
 		const void *inds;
 		u32 vertexCount;
+		u8 vertDecodeIndex;  // index into the drawVerts_ array to look up the vertexOffset.
 		u8 indexType;
 		s8 prim;
 		u8 cullMode;
-		u16 indexOffset;
 	};
 
-	enum { MAX_DEFERRED_DRAW_CALLS = 128 };
-	DeferredVerts drawVerts_[MAX_DEFERRED_DRAW_CALLS];
-	DeferredInds drawInds_[MAX_DEFERRED_DRAW_CALLS];
+	enum { MAX_DEFERRED_DRAW_VERTS = 128 };  // If you change this to more than 256, change type of DeferredInds::vertDecodeIndex.
+	enum { MAX_DEFERRED_DRAW_INDS = 512 };  // Monster Hunter spams indexed calls that we end up merging.
+	DeferredVerts drawVerts_[MAX_DEFERRED_DRAW_VERTS];
+	uint32_t drawVertexOffsets_[MAX_DEFERRED_DRAW_VERTS];
+	DeferredInds drawInds_[MAX_DEFERRED_DRAW_INDS];
 
 	int numDrawVerts_ = 0;
 	int numDrawInds_ = 0;
@@ -241,8 +243,6 @@ protected:
 	int decimationCounter_ = 0;
 	int decodeVertsCounter_ = 0;
 	int decodeIndsCounter_ = 0;
-
-	int indexOffset_ = 0;
 
 	// Vertex collector state
 	IndexGenerator indexGen;

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -104,6 +104,7 @@ public:
 
 	bool TestBoundingBox(const void *control_points, const void *inds, int vertexCount, u32 vertType);
 
+	bool ExtendNonIndexedPrim(GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead);
 	void SubmitPrim(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead);
 	template<class Surface>
 	void SubmitCurve(const void *control_points, const void *indices, Surface &surface, u32 vertType, int *bytesRead, const char *scope);

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -104,6 +104,13 @@ public:
 
 	bool TestBoundingBox(const void *control_points, const void *inds, int vertexCount, u32 vertType);
 
+	void FlushSkin() {
+		bool applySkin = (lastVType_ & GE_VTYPE_WEIGHT_MASK) && decOptions_.applySkinInDecode;
+		if (applySkin) {
+			DecodeVerts(decoded_);
+		}
+	}
+
 	bool ExtendNonIndexedPrim(GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead);
 	void SubmitPrim(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int cullMode, int *bytesRead);
 	template<class Surface>

--- a/GPU/Common/IndexGenerator.cpp
+++ b/GPU/Common/IndexGenerator.cpp
@@ -50,44 +50,40 @@ void IndexGenerator::Setup(u16 *inds) {
 	Reset();
 }
 
-void IndexGenerator::AddPrim(int prim, int vertexCount, bool clockwise) {
+void IndexGenerator::AddPrim(int prim, int vertexCount, int indexOffset, bool clockwise) {
 	switch (prim) {
-	case GE_PRIM_POINTS: AddPoints(vertexCount); break;
-	case GE_PRIM_LINES: AddLineList(vertexCount); break;
-	case GE_PRIM_LINE_STRIP: AddLineStrip(vertexCount); break;
-	case GE_PRIM_TRIANGLES: AddList(vertexCount, clockwise); break;
-	case GE_PRIM_TRIANGLE_STRIP: AddStrip(vertexCount, clockwise); break;
-	case GE_PRIM_TRIANGLE_FAN: AddFan(vertexCount, clockwise); break;
-	case GE_PRIM_RECTANGLES: AddRectangles(vertexCount); break;  // Same
+	case GE_PRIM_POINTS: AddPoints(vertexCount, indexOffset); break;
+	case GE_PRIM_LINES: AddLineList(vertexCount, indexOffset); break;
+	case GE_PRIM_LINE_STRIP: AddLineStrip(vertexCount, indexOffset); break;
+	case GE_PRIM_TRIANGLES: AddList(vertexCount, indexOffset, clockwise); break;
+	case GE_PRIM_TRIANGLE_STRIP: AddStrip(vertexCount, indexOffset, clockwise); break;
+	case GE_PRIM_TRIANGLE_FAN: AddFan(vertexCount, indexOffset, clockwise); break;
+	case GE_PRIM_RECTANGLES: AddRectangles(vertexCount, indexOffset); break;  // Same
 	}
 }
 
-void IndexGenerator::AddPoints(int numVerts) {
+void IndexGenerator::AddPoints(int numVerts, int indexOffset) {
 	u16 *outInds = inds_;
-	const int startIndex = index_;
 	for (int i = 0; i < numVerts; i++)
-		*outInds++ = startIndex + i;
+		*outInds++ = indexOffset + i;
 	inds_ = outInds;
 	// ignore overflow verts
-	index_ += numVerts;
 	count_ += numVerts;
 	prim_ = GE_PRIM_POINTS;
 	seenPrims_ |= 1 << GE_PRIM_POINTS;
 }
 
-void IndexGenerator::AddList(int numVerts, bool clockwise) {
+void IndexGenerator::AddList(int numVerts, int indexOffset, bool clockwise) {
 	u16 *outInds = inds_;
-	const int startIndex = index_;
 	const int v1 = clockwise ? 1 : 2;
 	const int v2 = clockwise ? 2 : 1;
 	for (int i = 0; i < numVerts; i += 3) {
-		*outInds++ = startIndex + i;
-		*outInds++ = startIndex + i + v1;
-		*outInds++ = startIndex + i + v2;
+		*outInds++ = indexOffset + i;
+		*outInds++ = indexOffset + i + v1;
+		*outInds++ = indexOffset + i + v2;
 	}
 	inds_ = outInds;
 	// ignore overflow verts
-	index_ += numVerts;
 	count_ += numVerts;
 	prim_ = GE_PRIM_TRIANGLES;
 	seenPrims_ |= 1 << GE_PRIM_TRIANGLES;
@@ -119,7 +115,7 @@ alignas(16) static const uint16_t offsets_counter_clockwise[24] = {
 	7, (u16)(7 + 1), (u16)(7 + 2),
 };
 
-void IndexGenerator::AddStrip(int numVerts, bool clockwise) {
+void IndexGenerator::AddStrip(int numVerts, int indexOffset, bool clockwise) {
 	int numTris = numVerts - 2;
 #ifdef _M_SSE
 	// In an SSE2 register we can fit 8 16-bit integers.
@@ -130,7 +126,7 @@ void IndexGenerator::AddStrip(int numVerts, bool clockwise) {
 	// We allow ourselves to write some extra indices to avoid the fallback loop.
 	// That's alright as we're appending to a buffer - they will get overwritten anyway.
 	int numChunks = (numTris + 7) >> 3;
-	__m128i ibase8 = _mm_set1_epi16(index_);
+	__m128i ibase8 = _mm_set1_epi16(indexOffset);
 	const __m128i *offsets = (const __m128i *)(clockwise ? offsets_clockwise : offsets_counter_clockwise);
 	__m128i *dst = (__m128i *)inds_;
 	__m128i offsets0 = _mm_add_epi16(ibase8, _mm_load_si128(offsets));
@@ -158,7 +154,7 @@ void IndexGenerator::AddStrip(int numVerts, bool clockwise) {
 	// wind doesn't need to be updated, an even number of triangles have been drawn.
 #elif PPSSPP_ARCH(ARM_NEON)
 	int numChunks = (numTris + 7) >> 3;
-	uint16x8_t ibase8 = vdupq_n_u16(index_);
+	uint16x8_t ibase8 = vdupq_n_u16(indexOffset);
 	const u16 *offsets = clockwise ? offsets_clockwise : offsets_counter_clockwise;
 	u16 *dst = inds_;
 	uint16x8_t offsets0 = vaddq_u16(ibase8, vld1q_u16(offsets));
@@ -185,7 +181,7 @@ void IndexGenerator::AddStrip(int numVerts, bool clockwise) {
 #else
 	// Slow fallback loop.
 	int wind = clockwise ? 1 : 2;
-	int ibase = index_;
+	int ibase = indexOffset;
 	size_t numPairs = numTris / 2;
 	u16 *outInds = inds_;
 	while (numPairs > 0) {
@@ -207,7 +203,6 @@ void IndexGenerator::AddStrip(int numVerts, bool clockwise) {
 	inds_ = outInds;
 #endif
 
-	index_ += numVerts;
 	if (numTris > 0)
 		count_ += numTris * 3;
 	// This is so we can detect one single strip by just looking at seenPrims_.
@@ -222,19 +217,17 @@ void IndexGenerator::AddStrip(int numVerts, bool clockwise) {
 	}
 }
 
-void IndexGenerator::AddFan(int numVerts, bool clockwise) {
+void IndexGenerator::AddFan(int numVerts, int indexOffset, bool clockwise) {
 	const int numTris = numVerts - 2;
 	u16 *outInds = inds_;
-	const int startIndex = index_;
 	const int v1 = clockwise ? 1 : 2;
 	const int v2 = clockwise ? 2 : 1;
 	for (int i = 0; i < numTris; i++) {
-		*outInds++ = startIndex;
-		*outInds++ = startIndex + i + v1;
-		*outInds++ = startIndex + i + v2;
+		*outInds++ = indexOffset;
+		*outInds++ = indexOffset + i + v1;
+		*outInds++ = indexOffset + i + v2;
 	}
 	inds_ = outInds;
-	index_ += numVerts;
 	count_ += numTris * 3;
 	prim_ = GE_PRIM_TRIANGLES;
 	seenPrims_ |= 1 << GE_PRIM_TRIANGLE_FAN;
@@ -245,46 +238,40 @@ void IndexGenerator::AddFan(int numVerts, bool clockwise) {
 }
 
 //Lines
-void IndexGenerator::AddLineList(int numVerts) {
+void IndexGenerator::AddLineList(int numVerts, int indexOffset) {
 	u16 *outInds = inds_;
-	const int startIndex = index_;
 	for (int i = 0; i < numVerts; i += 2) {
-		*outInds++ = startIndex + i;
-		*outInds++ = startIndex + i + 1;
+		*outInds++ = indexOffset + i;
+		*outInds++ = indexOffset + i + 1;
 	}
 	inds_ = outInds;
-	index_ += numVerts;
 	count_ += numVerts;
 	prim_ = GE_PRIM_LINES;
 	seenPrims_ |= 1 << prim_;
 }
 
-void IndexGenerator::AddLineStrip(int numVerts) {
+void IndexGenerator::AddLineStrip(int numVerts, int indexOffset) {
 	const int numLines = numVerts - 1;
 	u16 *outInds = inds_;
-	const int startIndex = index_;
 	for (int i = 0; i < numLines; i++) {
-		*outInds++ = startIndex + i;
-		*outInds++ = startIndex + i + 1;
+		*outInds++ = indexOffset + i;
+		*outInds++ = indexOffset + i + 1;
 	}
 	inds_ = outInds;
-	index_ += numVerts;
 	count_ += numLines * 2;
 	prim_ = GE_PRIM_LINES;
 	seenPrims_ |= 1 << GE_PRIM_LINE_STRIP;
 }
 
-void IndexGenerator::AddRectangles(int numVerts) {
+void IndexGenerator::AddRectangles(int numVerts, int indexOffset) {
 	u16 *outInds = inds_;
-	const int startIndex = index_;
 	//rectangles always need 2 vertices, disregard the last one if there's an odd number
 	numVerts = numVerts & ~1;
 	for (int i = 0; i < numVerts; i += 2) {
-		*outInds++ = startIndex + i;
-		*outInds++ = startIndex + i + 1;
+		*outInds++ = indexOffset + i;
+		*outInds++ = indexOffset + i + 1;
 	}
 	inds_ = outInds;
-	index_ += numVerts;
 	count_ += numVerts;
 	prim_ = GE_PRIM_RECTANGLES;
 	seenPrims_ |= 1 << GE_PRIM_RECTANGLES;
@@ -292,7 +279,6 @@ void IndexGenerator::AddRectangles(int numVerts) {
 
 template <class ITypeLE, int flag>
 void IndexGenerator::TranslatePoints(int numInds, const ITypeLE *inds, int indexOffset) {
-	indexOffset = index_ - indexOffset;
 	u16 *outInds = inds_;
 	for (int i = 0; i < numInds; i++)
 		*outInds++ = indexOffset + inds[i];
@@ -304,7 +290,6 @@ void IndexGenerator::TranslatePoints(int numInds, const ITypeLE *inds, int index
 
 template <class ITypeLE, int flag>
 void IndexGenerator::TranslateLineList(int numInds, const ITypeLE *inds, int indexOffset) {
-	indexOffset = index_ - indexOffset;
 	u16 *outInds = inds_;
 	numInds = numInds & ~1;
 	for (int i = 0; i < numInds; i += 2) {
@@ -319,7 +304,6 @@ void IndexGenerator::TranslateLineList(int numInds, const ITypeLE *inds, int ind
 
 template <class ITypeLE, int flag>
 void IndexGenerator::TranslateLineStrip(int numInds, const ITypeLE *inds, int indexOffset) {
-	indexOffset = index_ - indexOffset;
 	int numLines = numInds - 1;
 	u16 *outInds = inds_;
 	for (int i = 0; i < numLines; i++) {
@@ -334,7 +318,6 @@ void IndexGenerator::TranslateLineStrip(int numInds, const ITypeLE *inds, int in
 
 template <class ITypeLE, int flag>
 void IndexGenerator::TranslateList(int numInds, const ITypeLE *inds, int indexOffset, bool clockwise) {
-	indexOffset = index_ - indexOffset;
 	// We only bother doing this minor optimization in triangle list, since it's by far the most
 	// common operation that can benefit.
 	if (sizeof(ITypeLE) == sizeof(inds_[0]) && indexOffset == 0 && clockwise) {
@@ -347,6 +330,7 @@ void IndexGenerator::TranslateList(int numInds, const ITypeLE *inds, int indexOf
 		numInds = numTris * 3;
 		const int v1 = clockwise ? 1 : 2;
 		const int v2 = clockwise ? 2 : 1;
+		// TODO: This can actually be SIMD-d, although will need complex shuffles if clockwise.
 		for (int i = 0; i < numInds; i += 3) {
 			*outInds++ = indexOffset + inds[i];
 			*outInds++ = indexOffset + inds[i + v1];
@@ -362,7 +346,6 @@ void IndexGenerator::TranslateList(int numInds, const ITypeLE *inds, int indexOf
 template <class ITypeLE, int flag>
 void IndexGenerator::TranslateStrip(int numInds, const ITypeLE *inds, int indexOffset, bool clockwise) {
 	int wind = clockwise ? 1 : 2;
-	indexOffset = index_ - indexOffset;
 	int numTris = numInds - 2;
 	u16 *outInds = inds_;
 	for (int i = 0; i < numTris; i++) {
@@ -380,7 +363,6 @@ void IndexGenerator::TranslateStrip(int numInds, const ITypeLE *inds, int indexO
 template <class ITypeLE, int flag>
 void IndexGenerator::TranslateFan(int numInds, const ITypeLE *inds, int indexOffset, bool clockwise) {
 	if (numInds <= 0) return;
-	indexOffset = index_ - indexOffset;
 	int numTris = numInds - 2;
 	u16 *outInds = inds_;
 	const int v1 = clockwise ? 1 : 2;
@@ -398,7 +380,6 @@ void IndexGenerator::TranslateFan(int numInds, const ITypeLE *inds, int indexOff
 
 template <class ITypeLE, int flag>
 inline void IndexGenerator::TranslateRectangles(int numInds, const ITypeLE *inds, int indexOffset) {
-	indexOffset = index_ - indexOffset;
 	u16 *outInds = inds_;
 	//rectangles always need 2 vertices, disregard the last one if there's an odd number
 	numInds = numInds & ~1;

--- a/GPU/Common/IndexGenerator.h
+++ b/GPU/Common/IndexGenerator.h
@@ -28,7 +28,6 @@ public:
 	void Reset() {
 		prim_ = GE_PRIM_INVALID;
 		count_ = 0;
-		index_ = 0;
 		seenPrims_ = 0;
 		pureCount_ = 0;
 		this->inds_ = indsBase_;
@@ -57,19 +56,12 @@ public:
 		}
 	}
 
-	void AddPrim(int prim, int vertexCount, bool clockwise);
+	void AddPrim(int prim, int vertexCount, int indexOffset, bool clockwise);
 	void TranslatePrim(int prim, int numInds, const u8 *inds, int indexOffset, bool clockwise);
 	void TranslatePrim(int prim, int numInds, const u16_le *inds, int indexOffset, bool clockwise);
 	void TranslatePrim(int prim, int numInds, const u32_le *inds, int indexOffset, bool clockwise);
 
-	void Advance(int numVerts) {
-		index_ += numVerts;
-	}
-
-	void SetIndex(int ind) { index_ = ind; }
-	int MaxIndex() const { return index_; }  // Really NextIndex rather than MaxIndex, it's one more than the highest index generated
 	int VertexCount() const { return count_; }
-	bool Empty() const { return index_ == 0; }
 	int SeenPrims() const { return seenPrims_; }
 	int PureCount() const { return pureCount_; }
 	bool SeenOnlyPurePrims() const {
@@ -81,16 +73,16 @@ public:
 
 private:
 	// Points (why index these? code simplicity)
-	void AddPoints(int numVerts);
+	void AddPoints(int numVerts, int indexOffset);
 	// Triangles
-	void AddList(int numVerts, bool clockwise);
-	void AddStrip(int numVerts, bool clockwise);
-	void AddFan(int numVerts, bool clockwise);
+	void AddList(int numVerts, int indexOffset, bool clockwise);
+	void AddStrip(int numVerts, int indexOffset, bool clockwise);
+	void AddFan(int numVerts, int indexOffset, bool clockwise);
 	// Lines
-	void AddLineList(int numVerts);
-	void AddLineStrip(int numVerts);
+	void AddLineList(int numVerts, int indexOffset);
+	void AddLineStrip(int numVerts, int indexOffset);
 	// Rectangles
-	void AddRectangles(int numVerts);
+	void AddRectangles(int numVerts, int indexOffset);
 
 	// These translate already indexed lists
 	template <class ITypeLE, int flag>
@@ -118,7 +110,6 @@ private:
 
 	u16 *indsBase_;
 	u16 *inds_;
-	int index_;
 	int count_;
 	int pureCount_;
 	GEPrimitiveType prim_;

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -1293,6 +1293,9 @@ void VertexDecoder::SetVertexType(u32 fmt, const VertexDecoderOptions &options, 
 }
 
 void VertexDecoder::DecodeVerts(u8 *decodedptr, const void *verts, const UVScale *uvScaleOffset, int indexLowerBound, int indexUpperBound) const {
+	// A single 0 is acceptable for point lists.
+	_dbg_assert_(indexLowerBound <= indexUpperBound);
+
 	// Decode the vertices within the found bounds, once each
 	// decoded_ and ptr_ are used in the steps, so can't be turned into locals for speed.
 	const u8 *startPtr = (const u8*)verts + indexLowerBound * size;

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -727,6 +727,7 @@ rotateVBO:
 
 	gpuStats.numFlushes++;
 	gpuStats.numDrawCalls += numDrawInds_;
+	gpuStats.numVertexDecodes += numDrawVerts_;
 	gpuStats.numVertsSubmitted += vertexCountInDrawCalls_;
 
 	indexGen.Reset();

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -366,7 +366,7 @@ void DrawEngineD3D11::DoFlush() {
 
 		if (useCache) {
 			// getUVGenMode can have an effect on which UV decoder we need to use! And hence what the decoded data will look like. See #9263
-			u32 dcid = (u32)XXH3_64bits(&drawCalls_, sizeof(DeferredDrawCall) * numDrawCalls_) ^ gstate.getUVGenMode();
+			u32 dcid = ComputeDrawcallsHash() ^ gstate.getUVGenMode();
 
 			VertexArrayInfoD3D11 *vai;
 			if (!vai_.Get(dcid, &vai)) {
@@ -719,14 +719,16 @@ rotateVBO:
 	}
 
 	gpuStats.numFlushes++;
-	gpuStats.numDrawCalls += numDrawCalls_;
+	gpuStats.numDrawCalls += numDrawInds_;
 	gpuStats.numVertsSubmitted += vertexCountInDrawCalls_;
 
 	indexGen.Reset();
 	decodedVerts_ = 0;
-	numDrawCalls_ = 0;
+	numDrawVerts_ = 0;
+	numDrawInds_ = 0;
 	vertexCountInDrawCalls_ = 0;
-	decodeCounter_ = 0;
+	decodeVertsCounter_ = 0;
+	decodeIndsCounter_ = 0;
 	gstate_c.vertexFullAlpha = true;
 	framebufferManager_->SetColorUpdated(gstate_c.skipDrawReason);
 

--- a/GPU/D3D11/DrawEngineD3D11.h
+++ b/GPU/D3D11/DrawEngineD3D11.h
@@ -138,19 +138,19 @@ public:
 
 	// So that this can be inlined
 	void Flush() {
-		if (!numDrawCalls_)
+		if (!numDrawVerts_)
 			return;
 		DoFlush();
 	}
 
 	void FinishDeferred() {
-		if (!numDrawCalls_)
+		if (!numDrawVerts_)
 			return;
 		DecodeVerts(decoded_);
 	}
 
 	void DispatchFlush() override {
-		if (!numDrawCalls_)
+		if (!numDrawVerts_)
 			return;
 		Flush();
 	}

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -668,6 +668,7 @@ rotateVBO:
 
 	gpuStats.numFlushes++;
 	gpuStats.numDrawCalls += numDrawInds_;
+	gpuStats.numVertexDecodes += numDrawVerts_;
 	gpuStats.numVertsSubmitted += vertexCountInDrawCalls_;
 
 	// TODO: The below should be shared.

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -345,7 +345,7 @@ void DrawEngineDX9::DoFlush() {
 
 		if (useCache) {
 			// getUVGenMode can have an effect on which UV decoder we need to use! And hence what the decoded data will look like. See #9263
-			u32 dcid = (u32)XXH3_64bits(&drawCalls_, sizeof(DeferredDrawCall) * numDrawCalls_) ^ gstate.getUVGenMode();
+			u32 dcid = ComputeDrawcallsHash() ^ gstate.getUVGenMode();
 			VertexArrayInfoDX9 *vai;
 			if (!vai_.Get(dcid, &vai)) {
 				vai = new VertexArrayInfoDX9();
@@ -658,14 +658,18 @@ rotateVBO:
 	}
 
 	gpuStats.numFlushes++;
-	gpuStats.numDrawCalls += numDrawCalls_;
+	gpuStats.numDrawCalls += numDrawInds_;
 	gpuStats.numVertsSubmitted += vertexCountInDrawCalls_;
+
+	// TODO: The below should be shared.
 
 	indexGen.Reset();
 	decodedVerts_ = 0;
-	numDrawCalls_ = 0;
+	numDrawVerts_ = 0;
+	numDrawInds_ = 0;
 	vertexCountInDrawCalls_ = 0;
-	decodeCounter_ = 0;
+	decodeVertsCounter_ = 0;
+	decodeIndsCounter_ = 0;
 	gstate_c.vertexFullAlpha = true;
 	framebufferManager_->SetColorUpdated(gstate_c.skipDrawReason);
 

--- a/GPU/Directx9/DrawEngineDX9.h
+++ b/GPU/Directx9/DrawEngineDX9.h
@@ -128,19 +128,19 @@ public:
 
 	// So that this can be inlined
 	void Flush() {
-		if (!numDrawCalls_)
+		if (!numDrawVerts_)
 			return;
 		DoFlush();
 	}
 
 	void FinishDeferred() {
-		if (!numDrawCalls_)
+		if (!numDrawVerts_)
 			return;
 		DecodeVerts(decoded_);
 	}
 
 	void DispatchFlush() override {
-		if (!numDrawCalls_)
+		if (!numDrawVerts_)
 			return;
 		Flush();
 	}

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -286,9 +286,9 @@ void DrawEngineGLES::DoFlush() {
 			// Figure out how much pushbuffer space we need to allocate.
 			int vertsToDecode = ComputeNumVertsToDecode();
 			u8 *dest = (u8 *)frameData.pushVertex->Allocate(vertsToDecode * dec_->GetDecVtxFmt().stride, 4, &vertexBuffer, &vertexBufferOffset);
-			// Indices are decoded in here.
 			DecodeVerts(dest);
 		}
+		DecodeInds();
 
 		gpuStats.numUncachedVertsDrawn += indexGen.VertexCount();
 
@@ -345,6 +345,7 @@ void DrawEngineGLES::DoFlush() {
 			dec_ = GetVertexDecoder(lastVType_);
 		}
 		DecodeVerts(decoded_);
+		DecodeInds();
 
 		bool hasColor = (lastVType_ & GE_VTYPE_COL_MASK) != GE_VTYPE_COL_NONE;
 		if (gstate.isModeThrough()) {
@@ -383,7 +384,7 @@ void DrawEngineGLES::DoFlush() {
 			UpdateCachedViewportState(vpAndScissor_);
 		}
 
-		int maxIndex = indexGen.MaxIndex();
+		int maxIndex = MaxIndex();
 		int vertexCount = indexGen.VertexCount();
 
 		// TODO: Split up into multiple draw calls for GLES 2.0 where you can't guarantee support for more than 0x10000 verts.

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -475,6 +475,7 @@ void DrawEngineGLES::DoFlush() {
 bail:
 	gpuStats.numFlushes++;
 	gpuStats.numDrawCalls += numDrawInds_;
+	gpuStats.numVertexDecodes += numDrawVerts_;
 	gpuStats.numVertsSubmitted += vertexCountInDrawCalls_;
 
 	// TODO: When the next flush has the same vertex format, we can continue with the same offset in the vertex buffer,

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -245,9 +245,11 @@ void DrawEngineGLES::DoFlush() {
 		// can't goto bail here, skips too many variable initializations. So let's wipe the most important stuff.
 		indexGen.Reset();
 		decodedVerts_ = 0;
-		numDrawCalls_ = 0;
+		numDrawVerts_ = 0;
+		numDrawInds_ = 0;
 		vertexCountInDrawCalls_ = 0;
-		decodeCounter_ = 0;
+		decodeVertsCounter_ = 0;
+		decodeIndsCounter_ = 0;
 		return;
 	}
 
@@ -471,7 +473,7 @@ void DrawEngineGLES::DoFlush() {
 
 bail:
 	gpuStats.numFlushes++;
-	gpuStats.numDrawCalls += numDrawCalls_;
+	gpuStats.numDrawCalls += numDrawInds_;
 	gpuStats.numVertsSubmitted += vertexCountInDrawCalls_;
 
 	// TODO: When the next flush has the same vertex format, we can continue with the same offset in the vertex buffer,
@@ -479,9 +481,11 @@ bail:
 	// wanted to avoid rebinding the vertex input every time).
 	indexGen.Reset();
 	decodedVerts_ = 0;
-	numDrawCalls_ = 0;
+	numDrawVerts_ = 0;
+	numDrawInds_ = 0;
 	vertexCountInDrawCalls_ = 0;
-	decodeCounter_ = 0;
+	decodeVertsCounter_ = 0;
+	decodeIndsCounter_ = 0;
 	gstate_c.vertexFullAlpha = true;
 	framebufferManager_->SetColorUpdated(gstate_c.skipDrawReason);
 

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -86,19 +86,19 @@ public:
 
 	// So that this can be inlined
 	void Flush() {
-		if (!numDrawCalls_)
+		if (!numDrawVerts_)
 			return;
 		DoFlush();
 	}
 
 	void FinishDeferred() {
-		if (!numDrawCalls_)
+		if (!numDrawVerts_)
 			return;
 		DoFlush();
 	}
 
 	void DispatchFlush() override {
-		if (!numDrawCalls_)
+		if (!numDrawVerts_)
 			return;
 		Flush();
 	}

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -75,6 +75,7 @@ struct GPUStatistics {
 
 	void ResetFrame() {
 		numDrawCalls = 0;
+		numVertexDecodes = 0;
 		numDrawSyncs = 0;
 		numListSyncs = 0;
 		numCachedDrawCalls = 0;
@@ -111,6 +112,7 @@ struct GPUStatistics {
 
 	// Per frame statistics
 	int numDrawCalls;
+	int numVertexDecodes;
 	int numDrawSyncs;
 	int numListSyncs;
 	int numCachedDrawCalls;

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1049,19 +1049,19 @@ void GPUCommonHW::Execute_Prim(u32 op, u32 diff) {
 		}
 		case GE_CMD_VERTEXTYPE:
 		{
-			canExtend = false;  // TODO: Might support extending between some vertex types in the future.
 			uint32_t diff = data ^ vertexType;
 			// don't mask upper bits, vertexType is unmasked
 			if (diff & vtypeCheckMask) {
 				goto bail;
-			} else {
+			} else if (data != vertexType) {
+				canExtend = false;  // TODO: Might support extending between some vertex types in the future.
 				vertexType = data;
 				vertTypeID = GetVertTypeID(vertexType, gstate.getUVGenMode(), g_Config.bSoftwareSkinning);
 			}
 			break;
 		}
 		case GE_CMD_VADDR:
-			canExtend = false;
+			canExtend = false;  // TODO: See if we can do a more lenient check.
 			gstate.cmdmem[GE_CMD_VADDR] = data;
 			gstate_c.vertexAddr = gstate_c.getRelativeAddress(data & 0x00FFFFFF);
 			break;
@@ -1070,7 +1070,6 @@ void GPUCommonHW::Execute_Prim(u32 op, u32 diff) {
 			gstate_c.indexAddr = gstate_c.getRelativeAddress(data & 0x00FFFFFF);
 			break;
 		case GE_CMD_OFFSETADDR:
-			canExtend = false;
 			gstate.cmdmem[GE_CMD_OFFSETADDR] = data;
 			gstate_c.offsetAddr = data << 8;
 			break;

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1647,7 +1647,7 @@ size_t GPUCommonHW::FormatGPUStatsCommon(char *buffer, size_t size) {
 	float vertexAverageCycles = gpuStats.numVertsSubmitted > 0 ? (float)gpuStats.vertexGPUCycles / (float)gpuStats.numVertsSubmitted : 0.0f;
 	return snprintf(buffer, size,
 		"DL processing time: %0.2f ms, %d drawsync, %d listsync\n"
-		"Draw calls: %d, flushes %d, clears %d, bbox jumps %d (%d updates)\n"
+		"Draw: %d (%d dec), flushes %d, clears %d, bbox jumps %d (%d updates)\n"
 		"Cached draws: %d (tracked: %d)\n"
 		"Vertices: %d cached: %d uncached: %d\n"
 		"FBOs active: %d (evaluations: %d)\n"
@@ -1660,6 +1660,7 @@ size_t GPUCommonHW::FormatGPUStatsCommon(char *buffer, size_t size) {
 		gpuStats.numDrawSyncs,
 		gpuStats.numListSyncs,
 		gpuStats.numDrawCalls,
+		gpuStats.numVertexDecodes,
 		gpuStats.numFlushes,
 		gpuStats.numClears,
 		gpuStats.numBBOXJumps,

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1052,6 +1052,7 @@ void GPUCommonHW::Execute_Prim(u32 op, u32 diff) {
 			uint32_t diff = data ^ vertexType;
 			// don't mask upper bits, vertexType is unmasked
 			if (diff) {
+				drawEngineCommon_->FlushSkin();
 				if (diff & vtypeCheckMask)
 					goto bail;
 				canExtend = false;  // TODO: Might support extending between some vertex types in the future.

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -566,10 +566,11 @@ bool DrawEngineVulkan::VertexCacheLookup(int &vertexCount, GEPrimitiveType &prim
 		vai->minihash = ComputeMiniHash();
 		vai->status = VertexArrayInfoVulkan::VAI_HASHING;
 		vai->drawsUntilNextFullHash = 0;
-		DecodeVertsToPushPool(pushVertex_, &vbOffset, &vbuf);  // writes to indexGen
+		DecodeVertsToPushPool(pushVertex_, &vbOffset, &vbuf);
+		DecodeInds();
 		vai->numVerts = indexGen.VertexCount();
 		vai->prim = indexGen.Prim();
-		vai->maxIndex = indexGen.MaxIndex();
+		vai->maxIndex = MaxIndex();
 		vai->flags = gstate_c.vertexFullAlpha ? VAIVULKAN_FLAG_VERTEXFULLALPHA : 0;
 		return true;
 	}
@@ -593,6 +594,7 @@ bool DrawEngineVulkan::VertexCacheLookup(int &vertexCount, GEPrimitiveType &prim
 			if (newMiniHash != vai->minihash || newHash != vai->hash) {
 				MarkUnreliable(vai);
 				DecodeVertsToPushPool(pushVertex_, &vbOffset, &vbuf);
+				DecodeInds();
 				return true;
 			}
 			if (vai->numVerts > 64) {
@@ -612,6 +614,7 @@ bool DrawEngineVulkan::VertexCacheLookup(int &vertexCount, GEPrimitiveType &prim
 			if (newMiniHash != vai->minihash) {
 				MarkUnreliable(vai);
 				DecodeVertsToPushPool(pushVertex_, &vbOffset, &vbuf);
+				DecodeInds();
 				return true;
 			}
 		}
@@ -619,9 +622,10 @@ bool DrawEngineVulkan::VertexCacheLookup(int &vertexCount, GEPrimitiveType &prim
 		if (!vai->vb) {
 			// Directly push to the vertex cache.
 			DecodeVertsToPushBuffer(vertexCache_, &vai->vbOffset, &vai->vb);
+			DecodeInds();
 			_dbg_assert_msg_(gstate_c.vertBounds.minV >= gstate_c.vertBounds.maxV, "Should not have checked UVs when caching.");
 			vai->numVerts = indexGen.VertexCount();
-			vai->maxIndex = indexGen.MaxIndex();
+			vai->maxIndex = MaxIndex();
 			vai->flags = gstate_c.vertexFullAlpha ? VAIVULKAN_FLAG_VERTEXFULLALPHA : 0;
 			if (forceIndexed) {
 				vai->prim = indexGen.GeneralPrim();
@@ -684,6 +688,7 @@ bool DrawEngineVulkan::VertexCacheLookup(int &vertexCount, GEPrimitiveType &prim
 			vai->numFrames++;
 		}
 		DecodeVertsToPushPool(pushVertex_, &vbOffset, &vbuf);
+		DecodeInds();
 		return true;
 	}
 	default:
@@ -889,7 +894,7 @@ void DrawEngineVulkan::DoFlush() {
 			UpdateCachedViewportState(vpAndScissor);
 		}
 
-		int maxIndex = indexGen.MaxIndex();
+		int maxIndex = MaxIndex();
 		SoftwareTransform swTransform(params);
 
 		const Lin::Vec3 trans(gstate_c.vpXOffset, gstate_c.vpYOffset, gstate_c.vpZOffset * 0.5f + 0.5f);
@@ -1037,6 +1042,7 @@ void DrawEngineVulkan::ResetAfterDraw() {
 	decodedVerts_ = 0;
 	numDrawVerts_ = 0;
 	numDrawInds_ = 0;
+	vertexCountInDrawCalls_ = 0;
 	decodeIndsCounter_ = 0;
 	decodeVertsCounter_ = 0;
 	decOptions_.applySkinInDecode = g_Config.bSoftwareSkinning;

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -1016,6 +1016,7 @@ void DrawEngineVulkan::DoFlush() {
 
 	gpuStats.numFlushes++;
 	gpuStats.numDrawCalls += numDrawInds_;
+	gpuStats.numVertexDecodes += numDrawVerts_;
 	gpuStats.numVertsSubmitted += vertexCountInDrawCalls_;
 
 	indexGen.Reset();

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -170,13 +170,13 @@ public:
 
 	// So that this can be inlined
 	void Flush() {
-		if (!numDrawVerts_)
+		if (!numDrawInds_)
 			return;
 		DoFlush();
 	}
 
 	void FinishDeferred() {
-		if (!numDrawVerts_)
+		if (!numDrawInds_)
 			return;
 		// Decode any pending vertices. And also flush while we're at it, for simplicity.
 		// It might be possible to only decode like in the other backends, but meh, it can't matter.
@@ -185,9 +185,9 @@ public:
 	}
 
 	void DispatchFlush() override {
-		if (!numDrawVerts_)
+		if (!numDrawInds_)
 			return;
-		Flush();
+		DoFlush();
 	}
 
 	VkPipelineLayout GetPipelineLayout() const {

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -170,13 +170,13 @@ public:
 
 	// So that this can be inlined
 	void Flush() {
-		if (!numDrawCalls_)
+		if (!numDrawVerts_)
 			return;
 		DoFlush();
 	}
 
 	void FinishDeferred() {
-		if (!numDrawCalls_)
+		if (!numDrawVerts_)
 			return;
 		// Decode any pending vertices. And also flush while we're at it, for simplicity.
 		// It might be possible to only decode like in the other backends, but meh, it can't matter.
@@ -185,7 +185,7 @@ public:
 	}
 
 	void DispatchFlush() override {
-		if (!numDrawCalls_)
+		if (!numDrawVerts_)
 			return;
 		Flush();
 	}

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -291,6 +291,8 @@ static VulkanPipeline *CreateVulkanPipeline(VulkanRenderManager *renderManager, 
 		desc->geometryShaderSource = gs->GetShaderString(SHADER_STRING_SOURCE_CODE);
 	}
 
+	_dbg_assert_(key.topology != VK_PRIMITIVE_TOPOLOGY_POINT_LIST);
+	_dbg_assert_(key.topology != VK_PRIMITIVE_TOPOLOGY_LINE_LIST);
 	desc->topology = (VkPrimitiveTopology)key.topology;
 
 	int vertexStride = 0;


### PR DESCRIPTION
Redo the representation of deferred draws in the DrawEngine.

With this, we "merge" indexed draws into bigger indexed draws as we go, instead of as a post-process on the list of draws. This is just as cheap if not cheaper since we need to write less stuff to memory. Additionally, we now also merge non-indexed draws into bigger decode steps, so we don't have to stress the entry/exit of the vertex decoder so much.

Basically, before this PR, we were able to efficiently merge many back-to-back indexed draws pointing to the same vertex buffer, like Monster Hunter does, but we are not as efficiently merging back-to-back unindexed draws,. like those that God of War does. It likes to do tons of tiny draws in sequence, and we end up doing an individual Decode call for every one of them, which has overhead (of course, we are still merging them to one big vertex/index buffer, but the decode process is inefficient). With this new internal representation, we'll able to get rid of that overhead - but it'll require some extra logic that's not in here yet.

Typical sequence that this helps:

![image](https://github.com/hrydgard/ppsspp/assets/130929/62c870bc-19ea-4010-b2bd-518d771b15b8)

This also gets rid of an internal vertex counter from the IndexGenerator which was confusing.

Some games don't benefit at all though while being drawcall-heavy, and maybe should be looked into:

* ~~Syphon Filter~~ (actually, false positive - forgot that when the disassembly window is up, debugRecording_ gets enabled and this optimization disabled)