### PR TITLE
Add SSE2 version of vfpu_dot

### DIFF
--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -879,8 +879,9 @@ static float vfpu_dot_sse2(const float a[4], const float b[4])
 float vfpu_dot(const float a[4], const float b[4]) {
 #if defined(__SSE2__)
 	return vfpu_dot_sse2(a, b);
-#endif
+#else
 	return vfpu_dot_cpp(a, b);
+#endif
 }
 
 //==============================================================================


### PR DESCRIPTION
See #18249. Speedup for this function ranges 10%..100%, depending on system. Updated verification and speed measurements: https://godbolt.org/z/W1z3sj6hz

Please feel free to double-check that it matches the current version (previous code - and verification - were wrong around NaNs, this is *hopefully* correct).