### PR TITLE
Startup and tex-replacement performance fixes

### DIFF
--- a/Windows/W32Util/Misc.h
+++ b/Windows/W32Util/Misc.h
@@ -14,6 +14,7 @@ namespace W32Util
 	void MakeTopMost(HWND hwnd, bool topMost);
 	void ExitAndRestart(bool overrideArgs = false, const std::string &args = "");
 	void SpawnNewInstance(bool overrideArgs = false, const std::string &args = "");
+	bool ExecuteAndGetReturnCode(const wchar_t *executable, const wchar_t *cmdline, const wchar_t *currentDirectory, DWORD *exitCode);
 	void GetSelfExecuteParams(std::wstring &workingDirectory, std::wstring &moduleFilename);
 
 	void GetWindowRes(HWND hWnd, int *xres, int *yres);

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -694,28 +694,13 @@ static bool DetectVulkanInExternalProcess() {
 
 	const wchar_t *cmdline = L"--vulkan-available-check";
 
-	SHELLEXECUTEINFO info{ sizeof(SHELLEXECUTEINFO) };
-	info.fMask = SEE_MASK_NOCLOSEPROCESS;
-	info.lpFile = moduleFilename.c_str();
-	info.lpParameters = cmdline;
-	info.lpDirectory = workingDirectory.c_str();
-	info.nShow = SW_HIDE;
-	if (ShellExecuteEx(&info) != TRUE) {
-		return false;
-	}
-	if (info.hProcess == nullptr) {
-		return false;
-	}
-
-	DWORD result = WaitForSingleObject(info.hProcess, 10000);
 	DWORD exitCode = 0;
-	if (result == WAIT_FAILED || GetExitCodeProcess(info.hProcess, &exitCode) == 0) {
-		CloseHandle(info.hProcess);
+	if (W32Util::ExecuteAndGetReturnCode(moduleFilename.c_str(), cmdline, workingDirectory.c_str(), &exitCode)) {
+		return exitCode == EXIT_CODE_VULKAN_WORKS;
+	} else {
+		ERROR_LOG(G3D, "Failed to detect Vulkan in external process somehow");
 		return false;
 	}
-	CloseHandle(info.hProcess);
-
-	return exitCode == EXIT_CODE_VULKAN_WORKS;
 }
 #endif
 


### PR DESCRIPTION
The Vulkan-in-other-process check was slower than necessary by using shell APIs early in startup, which cost a couple hundred ms to load. Let's avoid that.

I found this while profiling for another problem, which was that texture replacement decimation tries to lock textures, and we ended up blocking the main thread unnecessarily while large textures were loaded, leading to less performance glitches when using texture packs.