### PR TITLE
Fix memory leak in basisu_transcoder.cpp

### DIFF
--- a/ext/basis_universal/basisu_transcoder.cpp
+++ b/ext/basis_universal/basisu_transcoder.cpp
@@ -7884,6 +7884,8 @@ namespace basist
 		if (!endpoints.size() || !selectors.size())
 		{
 			BASISU_DEVEL_ERROR("basisu_lowlevel_etc1s_transcoder::transcode_slice: global codebooks must be unpacked first\n");
+			if (pPVRTC_work_mem)
+				free(pPVRTC_work_mem);
 			return false;
 		}
 


### PR DESCRIPTION
This commit addresses a memory leak issue by releasing the pPVRTC_work_mem resource when global codebooks are not unpacked yet.