### PR TITLE
Extend the Test Drive color ramp smoother to detect up to 3 ramps in a texture

### DIFF
--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -717,6 +717,7 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 				// lookup with the filtered value once.
 				p.F("  vec4 t = ").SampleTexture2D("tex", "uv").C(";\n");
 				p.C("  uint depalShift = (u_depal_mask_shift_off_fmt >> 0x8u) & 0xFFu;\n");
+				p.C("  uint depalOffset = ((u_depal_mask_shift_off_fmt >> 0x10u) & 0xFFu) << 0x4u;\n");
 				p.C("  uint depalFmt = (u_depal_mask_shift_off_fmt >> 0x18u) & 0x3u;\n");
 				p.C("  float index0 = t.r;\n");
 				p.C("  float factor = 31.0 / 256.0;\n");
@@ -727,7 +728,8 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 				p.C("    if (depalShift == 0x5u) { index0 = t.g; }\n");
 				p.C("    else if (depalShift == 0xAu) { index0 = t.b; }\n");
 				p.C("  }\n");
-				p.F("  t = ").SampleTexture2D("pal", "vec2(index0 * factor * 0.5, 0.0)").C(";\n");  // 0.5 for 512-entry CLUT.
+				p.C("  float offset = float(depalOffset) / 256.0;\n");
+				p.F("  t = ").SampleTexture2D("pal", "vec2((index0 * factor + offset) * 0.5 + 0.5 / 512.0, 0.0)").C(";\n");  // 0.5 for 512-entry CLUT.
 				break;
 			case ShaderDepalMode::NORMAL:
 				if (doTextureProjection) {

--- a/GPU/Common/TextureShaderCommon.h
+++ b/GPU/Common/TextureShaderCommon.h
@@ -29,11 +29,14 @@
 #include "GPU/Common/ShaderCommon.h"
 #include "GPU/Common/DepalettizeShaderCommon.h"
 
+
 class ClutTexture {
 public:
+	enum { MAX_RAMPS = 3 };
 	Draw::Texture *texture;
 	int lastFrame;
-	int rampLength;
+	int rampLengths[MAX_RAMPS];
+	int rampStarts[MAX_RAMPS];
 };
 
 // For CLUT depal shaders, and other pre-bind texture shaders.


### PR DESCRIPTION
Needed for Manhunt 2.

Note that we also offset the lookup slightly to miss the wrap-around points. The existing 31 scale factor instead of 32, together with that half-texel, are enough to avoid that problem.

Fixes #18300