### PR TITLE
Add support for using %1 and %2 in some more translation strings.

### DIFF
--- a/Common/StringUtils.cpp
+++ b/Common/StringUtils.cpp
@@ -385,7 +385,7 @@ std::string UnescapeMenuString(const char *input, char *shortcutChar) {
 	return output;
 }
 
-std::string ApplySafeSubstitutions(const char *format, const std::string &string1, const std::string &string2, const std::string &string3) {
+std::string ApplySafeSubstitutions(const char *format, std::string_view string1, std::string_view string2, std::string_view string3, std::string_view string4) {
 	size_t formatLen = strlen(format);
 	std::string output;
 	output.reserve(formatLen + 20);
@@ -407,6 +407,40 @@ std::string ApplySafeSubstitutions(const char *format, const std::string &string
 			break;
 		case '3':
 			output += string3; i++;
+			break;
+		case '4':
+			output += string4; i++;
+			break;
+		}
+	}
+	return output;
+}
+
+std::string ApplySafeSubstitutions(const char *format, int i1, int i2, int i3, int i4) {
+	size_t formatLen = strlen(format);
+	std::string output;
+	output.reserve(formatLen + 20);
+	for (size_t i = 0; i < formatLen; i++) {
+		char c = format[i];
+		if (c != '%') {
+			output.push_back(c);
+			continue;
+		}
+		if (i >= formatLen - 1) {
+			break;
+		}
+		switch (format[i + 1]) {
+		case '1':
+			output += StringFromInt(i1); i++;
+			break;
+		case '2':
+			output += StringFromInt(i2); i++;
+			break;
+		case '3':
+			output += StringFromInt(i3); i++;
+			break;
+		case '4':
+			output += StringFromInt(i4); i++;
 			break;
 		}
 	}

--- a/Common/StringUtils.h
+++ b/Common/StringUtils.h
@@ -127,4 +127,6 @@ bool SplitPath(const std::string& full_path, std::string* _pPath, std::string* _
 
 // Replaces %1, %2, %3 in format with arg1, arg2, arg3.
 // Much safer than snprintf and friends.
-std::string ApplySafeSubstitutions(const char *format, const std::string &string1, const std::string &string2 = "", const std::string &string3 = "");
+// For mixes of strings and ints, manually convert the ints to strings.
+std::string ApplySafeSubstitutions(const char *format, std::string_view string1, std::string_view string2 = "", std::string_view string3 = "", std::string_view string4 = "");
+std::string ApplySafeSubstitutions(const char *format, int i1, int i2 = 0, int i3 = 0, int i4 = 0);

--- a/Core/RetroAchievements.cpp
+++ b/Core/RetroAchievements.cpp
@@ -246,7 +246,7 @@ static void event_handler_callback(const rc_client_event_t *event, rc_client_t *
 		rc_client_user_game_summary_t summary;
 		rc_client_get_user_game_summary(g_rcClient, &summary);
 
-		std::string message = StringFromFormat(ac->T("%d achievements"), summary.num_unlocked_achievements);
+		std::string message = ApplySafeSubstitutions(ac->T("%d achievements, %d points"), summary.num_unlocked_achievements, summary.points_unlocked);
 
 		g_OSD.Show(OSDType::MESSAGE_INFO, title, message, DeNull(gameInfo->badge_name), 10.0f);
 
@@ -725,7 +725,7 @@ std::string GetGameAchievementSummary() {
 	if (summary.num_core_achievements + summary.num_unofficial_achievements == 0) {
 		summaryString = ac->T("This game has no achievements");
 	} else {
-		summaryString = StringFromFormat(ac->T("Earned", "You have unlocked %d of %d achievements, earning %d of %d points"),
+		summaryString = ApplySafeSubstitutions(ac->T("Earned", "You have unlocked %1 of %2 achievements, earning %3 of %4 points"),
 			summary.num_unlocked_achievements, summary.num_core_achievements + summary.num_unofficial_achievements,
 			summary.points_unlocked, summary.points_core);
 		if (ChallengeModeActive()) {

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -9,7 +9,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -25,7 +25,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -23,7 +23,7 @@
 # Happy translating.
 
 [Achievements]
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 %1: Attempt started = %1: Attempt started
 %1: Attempt failed = %1: Attempt failed
 Account = Account
@@ -40,7 +40,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have unlocked %d of %d achievements, and earned %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and earned %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -1,5 +1,5 @@
 [Achievements]
-%d achievements, %d points = %d logros, %d puntos
+%1 achievements, %2 points = %1 logros, %2 puntos
 %1: Attempt started = %1: intento para el leaderboard iniciado
 %1: Attempt failed = %1: intento para el leaderboard fallido
 Account = Cuenta
@@ -17,7 +17,7 @@ Challenge Mode = Modo Desafío
 Challenge Mode (no savestates) = Modo Desafío (Sin estados)
 Contacting RetroAchievements server... = Contactando al servidor de RetroAchievements...
 Customize = Customizar
-Earned = Has obtenido %d de %d logros y %d de %d puntos
+Earned = Has obtenido %1 de %2 logros y %3 de %4 puntos
 Encore Mode = Modo Encore
 Failed logging in to RetroAchievements = No se pudo iniciar sesión a RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -1,5 +1,5 @@
 [Achievements]
-%d achievements, %d points = %d logros, %d puntos
+%1 achievements, %2 points = %1 logros, %2 puntos
 %1: Attempt started = %1: intento para el leaderboard iniciado
 %1: Attempt failed = %1: intento para el leaderboard fallido
 Account = Cuenta
@@ -17,7 +17,7 @@ Challenge Mode = Modo Desafío
 Challenge Mode (no savestates) = Modo Desafío (Sin estados)
 Contacting RetroAchievements server... = Contactando al servidor de RetroAchievements...
 Customize = Customizar
-Earned = Has obtenido %d de %d logros y %d de %d puntos
+Earned = Has obtenido %1 de %2 logros y %3 de %4 puntos
 Encore Mode = Modo Encore
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d saavutusta, %d pistettä
+%1 achievements, %2 points = %1 saavutusta, %2 pistettä
 Account = Tili
 Achievement progress = Achievement progress
 Achievement unlocked = Saavutus avattu

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -1,5 +1,5 @@
-[Achievements]
-%d achievements, %d points = %d obiettivi, %d punti
+﻿[Achievements]
+%1 achievements, %2 points = %1 obiettivi, %2 punti
 %1: Attempt failed = %1: Tentativo fallito
 %1: Attempt started = %1: Tentativo iniziato
 Account = Account
@@ -16,7 +16,7 @@ Challenge Mode = Modalità Sfida
 Challenge Mode (no savestates) = Modalità Sfida (senza stati salvati)
 Contacting RetroAchievements server... = Contatto con il server di RetroAchievements in corso...
 Customize = Personalizza
-Earned = Hai sbloccato %d su %d obiettivi, e guadagnato %d su %d punti
+Earned = Hai sbloccato %1 su %2 obiettivi, e guadagnato %3 su %4 punti
 Encore Mode = Modalità Encore
 Failed logging in to RetroAchievements = Accesso a RetroAchievements non riuscito
 Failed to connect to RetroAchievements. Achievements will not unlock. = Connessione a RetroAchievements non riuscita. Gli obiettivi non verranno sbloccati.

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -1,5 +1,5 @@
 [Achievements]
-%d achievements, %d points = %d 성과, %d 포인트
+%1 achievements, %2 points = %1 성과, %2 포인트
 %1: Attempt started = %1: 순위표 시도 시작
 %1: Attempt failed = %1: 순위표 시도 실패
 Account = 계정
@@ -16,7 +16,7 @@ Challenge Mode = 도전 모드
 Challenge Mode (no savestates) = 도전 모드 (저장 상태 없음)
 Contacting RetroAchievements server... = RetroAchievements 서버에 연결 중...
 Customize = 맞춤 설정
-Earned = %d 의 %d 성과 및 %d 의 %d 포인트 획득
+Earned = %1 의 %2 성과 및 %3 의 %4 포인트 획득
 Encore Mode = 앙코르 모드
 Failed logging in to RetroAchievements = RetroAchievements에 로그인 실패
 Failed to connect to RetroAchievements. Achievements will not unlock. = RetroAchievements에 연결하지 못했습니다. 성과가 잠금 해제되지 않습니다.

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Próba nieudana
 %1: Attempt started = %1: Próba wystartowała
-%d achievements, %d points = %d Osiągnięć, %d punktów
+%1 achievements, %2 points = %1 Osiągnięć, %2 punktów
 Account = Konto
 Achievement progress = Postęp osiągnięcia
 Achievement unlocked = Osiągnięcie odblokowane
@@ -17,7 +17,7 @@ Challenge Mode = Tryb Wyzwania
 Challenge Mode (no savestates) = Tryb Wyzwania (bez zapisów stanu)
 Contacting RetroAchievements server... = Łączenie z serwerem RetroAchievements...
 Customize = Dostosuj
-Earned = Zdobyłeś %d z %d osiągnięć i %d z %d punktów
+Earned = Zdobyłeś %1 z %2 osiągnięć i %3 z %4 punktów
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Logowanie do RetroAchievements nieudane
 Failed to connect to RetroAchievements. Achievements will not unlock. = Łączenie z serwerem RetroAchievements nieudane. Osiągnięcia nie będą odblokowywane.
@@ -139,7 +139,7 @@ OnScreen = Przyciski ekranowe
 Portrait = Pionowo
 Portrait Reversed = Odwrócone pionowo
 PSP Action Buttons = Klawisze akcji PSP
-Rapid fire interval = 
+Rapid fire interval =
 Raw input = Zwykłe wejście
 Repeat mode = Tryb powtarzania
 Reset to defaults = Domyślne

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -23,7 +23,7 @@
 # Happy translating.
 
 [Achievements]
-%d achievements, %d points = %d conquistas, %d pontos
+%1 achievements, %2 points = %1 conquistas, %2 pontos
 %1: Attempt started = %1: A tentativa começou
 %1: Attempt failed = %1: A tentativa falhou
 Account = Conta
@@ -40,7 +40,7 @@ Challenge Mode = Modo Desafio
 Challenge Mode (no savestates) = Modo Desafio (sem save states)
 Contacting RetroAchievements server... = Contactando o servidor do RetroAchievements...
 Customize = Personalizar
-Earned = Você ganhou %d de %d conquistas e %d de %d pontos
+Earned = Você ganhou %1 de %2 conquistas e %3 de %4 pontos
 Encore Mode = Modo de Repetição
 Failed logging in to RetroAchievements = Falhou em logar no RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Falhou em conectar com o RetroAchievements. As conquistas não destrancarão.
@@ -616,7 +616,7 @@ Frame Skipping = Pulo dos frames
 Frame Skipping Type = Tipo de pulo dos frames
 FullScreen = Tela cheia
 Geometry shader culling = Abate do shader da geometria
-Hack Settings = Configurações dos hacks (pode causar erros gráficos)									  
+Hack Settings = Configurações dos hacks (pode causar erros gráficos)
 Hardware Tessellation = Tesselação por hardware
 Hardware Transform = Transformação por hardware
 hardware transform error - falling back to software = Erro de transformação pelo hardware, retrocedendo pro software.
@@ -981,10 +981,10 @@ tools = Ferramentas grátis usadas:
 # Leave extra lines blank. 4 contributors per line seems to look best.
 translators1 = Papel, gabrielmop, Efraim Lopes, AkiraJkr
 translators2 = Felipe
-translators3 = 
-translators4 = 
-translators5 = 
-translators6 = 
+translators3 =
+translators4 =
+translators5 =
+translators6 =
 Twitter @PPSSPP_emu = Twitter @PPSSPP_emu
 website = Verifique o site da web:
 written = Escrito em C++ pela velocidade e portabilidade

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -25,7 +25,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -41,7 +41,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Попытка не удалась
 %1: Attempt started = %1: Попытка началась
-%d achievements, %d points = %d достижений, %d очков
+%1 achievements, %2 points = %1 достижений, %2 очков
 Account = Аккаунт
 Achievement progress = Прогресс достижения
 Achievement unlocked = Достижение разблокировано
@@ -17,7 +17,7 @@ Challenge Mode = Режим испытания
 Challenge Mode (no savestates) = Режим испытания (без сохранений состояния)
 Contacting RetroAchievements server... = Подключение к серверу RetroAchievements...
 Customize = Настроить
-Earned = Вы разблокировали %d из %d достижений и получили %d из %d очков
+Earned = Вы разблокировали %1 из %2 достижений и получили %3 из %4 очков
 Encore Mode = Режим повтора
 Failed logging in to RetroAchievements = Не удалось войти в RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Не удалось подключиться к RetroAchievements. Достижения не будут разблокированы.

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -1,5 +1,5 @@
 [Achievements]
-%d achievements, %d points = %d achievements, %d poäng
+%1 achievements, %2 points = %1 achievements, %2 poäng
 %1: Attempt started = %1: Topplisteförsök startat
 %1: Attempt failed = %1: Topplisteförsök misslyckades
 Account = Inloggning
@@ -17,7 +17,7 @@ Challenge Mode = Utmanings-läge
 Challenge Mode (no savestates) = Utmanings-läge (inga sparade state)
 Contacting RetroAchievements server... = Kontaktar RetroAchievements' server...
 Customize = Anpassa
-Earned = Du har tjänat %d av %d achievements, och %d of %d poäng
+Earned = Du har tjänat %1 av %2 achievements, och %3 of %4 poäng
 Encore Mode = Encore-läge (kan ta achievements igen)
 Failed logging in to RetroAchievements = Misslyckades logga in till RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Misslyckades logga in RetroAchievements. Achievements kommer ej kunna avklaras.

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: ส่งข้อมูลไปยังกระดานแต้มผู้นำล้มเหลว
 %1: Attempt started = %1: เริ่มการส่งข้อมูลไปยังกระดานแต้มผู้นำแล้ว
-%d achievements, %d points = %d เป้าหมายความสำเร็จ, %d แต้ม
+%1 achievements, %2 points = %1 เป้าหมายความสำเร็จ, %2 แต้ม
 Account = บัญชีผู้ใช้งาน
 Achievement progress = ความคืบหน้าเป้าหมายความสำเร็จ
 Achievement unlocked =  ตอนเป้าหมายความสำเร็จถูกปลดล็อค
@@ -17,7 +17,7 @@ Challenge Mode = โหมดท้าทาย
 Challenge Mode (no savestates) = โหมดท้าทาย (ไม่มีเซฟสเตท)
 Contacting RetroAchievements server... = กำลังเชื่อมต่อกับเซิร์ฟเวอร์ RetroAchievements...
 Customize = ปรับแต่ง
-Earned = คุณได้รับ %d of %d เป้าหมายความสำเร็จ, และ %d ของ %d แต้ม
+Earned = คุณได้รับ %1 of %2 เป้าหมายความสำเร็จ, และ %3 ของ %4 แต้ม
 Encore Mode = โหมดคำราม
 Failed logging in to RetroAchievements = ล้มเหลวในการเข้าใช้งานไปยัง RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = ล้มเหลวในการเข้าใช้งานไปยัง RetroAchievements เป้าหมายความสำเร็จอาจจะไม่ถูกปลดล็อค

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: Attempt failed
 %1: Attempt started = %1: Attempt started
-%d achievements, %d points = %d achievements, %d points
+%1 achievements, %2 points = %1 achievements, %2 points
 Account = Account
 Achievement progress = Achievement progress
 Achievement unlocked = Achievement unlocked
@@ -17,7 +17,7 @@ Challenge Mode = Challenge Mode
 Challenge Mode (no savestates) = Challenge Mode (no savestates)
 Contacting RetroAchievements server... = Contacting RetroAchievements server...
 Customize = Customize
-Earned = You have earned %d of %d achievements, and %d of %d points
+Earned = You have unlocked %1 of %2 achievements, and %3 of %4 points
 Encore Mode = Encore Mode
 Failed logging in to RetroAchievements = Failed logging in to RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1: 排行榜失败，再接再厉吧！
 %1: Attempt started = %1: 排行榜尝试开始！
-%d achievements, %d points = %d成就，%d点数
+%1 achievements, %2 points = %1成就，%2点数
 Account = 账号
 Achievement progress = 成就进度
 Achievement unlocked = 成就达成！
@@ -17,7 +17,7 @@ Challenge Mode = 挑战模式
 Challenge Mode (no savestates) = 挑战模式（无即时存档）
 Contacting RetroAchievements server... = 连接RetroAchievements服务器…
 Customize = 自定义
-Earned = 您已经达成%d个成就，总共有%d个可解锁，已获得%d点数，总共%d点数。
+Earned = 您已经达成%1个成就，总共有%2个可解锁，已获得%3点数，总共%4点数。
 Encore Mode = 回味模式
 Failed logging in to RetroAchievements = 未能登录到RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = 未连接到服务器，成就不会解锁。

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -1,7 +1,7 @@
 [Achievements]
 %1: Attempt failed = %1：嘗試失敗
 %1: Attempt started = %1：嘗試開始
-%d achievements, %d points = %d 個成就，%d 個點數
+%1 achievements, %2 points = %1 個成就，%2 個點數
 Account = 帳戶
 Achievement progress = 成就進度
 Achievement unlocked = 成就已解鎖
@@ -17,7 +17,7 @@ Challenge Mode = 挑戰模式
 Challenge Mode (no savestates) = 挑戰模式 (無存檔)
 Contacting RetroAchievements server... = 正在聯絡 RetroAchievements 伺服器…
 Customize = 自訂
-Earned = 您已經取得 %d/%d 個成就，以及 %d/%d 個點數
+Earned = 您已經取得 %1/%2 個成就，以及 %3/%4 個點數
 Encore Mode = Encore 模式
 Failed logging in to RetroAchievements = 無法登入至 RetroAchievements
 Failed to connect to RetroAchievements. Achievements will not unlock. = Failed to connect to RetroAchievements. Achievements will not unlock.


### PR DESCRIPTION
Actually all the way up to %3 and %4. This is for languages where the word order is different - you can flip around %1 and %2 and expect the strings to follow.

Requested in #18306