### PR TITLE
Move the menu frame-rate throttling to NativeFrame

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -212,24 +212,7 @@ void Core_RunLoop(GraphicsContext *ctx) {
 		return;
 	}
 
-	bool menuThrottle = (GetUIState() != UISTATE_INGAME || !PSP_IsInited()) && GetUIState() != UISTATE_EXIT;
-
-	double startTime;
-	if (menuThrottle) {
-		startTime = time_now_d();
-	}
-
 	NativeFrame(ctx);
-
-	if (menuThrottle) {
-		float refreshRate = System_GetPropertyFloat(SYSPROP_DISPLAY_REFRESH_RATE);
-		// Simple throttling to not burn the GPU in the menu.
-		// TODO: This should move into NativeFrame. Also, it's only necessary in MAILBOX or IMMEDIATE presentation modes.
-		double diffTime = time_now_d() - startTime;
-		int sleepTime = (int)(1000.0 / refreshRate) - (int)(diffTime * 1000.0);
-		if (sleepTime > 0)
-			sleep_ms(sleepTime);
-	}
 }
 
 void Core_DoSingleStep() {


### PR DESCRIPTION
Now needed on Android since we added the ability to turn off vsync, which caused the menu to burn battery by rendering too fast.