### PR TITLE
Fix waves background

### DIFF
--- a/Common/Render/DrawBuffer.cpp
+++ b/Common/Render/DrawBuffer.cpp
@@ -106,7 +106,7 @@ void DrawBuffer::V(float x, float y, float z, uint32_t color, float u, float v) 
 
 void DrawBuffer::Rect(float x, float y, float w, float h, uint32_t color, int align) {
 	DoAlign(align, &x, &y, &w, &h);
-	RectVGradient(x, y, w, h, color, color);
+	RectVGradient(x, y, x + w, y + h, color, color);
 }
 
 void DrawBuffer::hLine(float x1, float y, float x2, uint32_t color) {
@@ -121,13 +121,13 @@ void DrawBuffer::vLine(float x, float y1, float y2, uint32_t color) {
 	Rect(x, y1, g_display.pixel_in_dps_x, y2 - y1, color);
 }
 
-void DrawBuffer::RectVGradient(float x, float y, float w, float h, uint32_t colorTop, uint32_t colorBottom) {
-	V(x,		 y,     0, colorTop,    0, 0);
-	V(x + w, y,		 0, colorTop,    1, 0);
-	V(x + w, y + h, 0, colorBottom, 1, 1);
-	V(x,		 y,     0, colorTop,    0, 0);
-	V(x + w, y + h, 0, colorBottom, 1, 1);
-	V(x,		 y + h, 0, colorBottom, 0, 1);
+void DrawBuffer::RectVGradient(float x1, float y1, float x2, float y2, uint32_t colorTop, uint32_t colorBottom) {
+	V(x1, y1, 0, colorTop,    0, 0);
+	V(x2, y1, 0, colorTop,    1, 0);
+	V(x2, y2, 0, colorBottom, 1, 1);
+	V(x1, y1, 0, colorTop,    0, 0);
+	V(x2, y2, 0, colorBottom, 1, 1);
+	V(x1, y2, 0, colorBottom, 0, 1);
 }
 
 void DrawBuffer::RectOutline(float x, float y, float w, float h, uint32_t color, int align) {
@@ -142,7 +142,7 @@ void DrawBuffer::MultiVGradient(float x, float y, float w, float h, const Gradie
 	for (int i = 0; i < numStops - 1; i++) {
 		float t0 = stops[i].t, t1 = stops[i+1].t;
 		uint32_t c0 = stops[i].color, c1 = stops[i+1].color;
-		RectVGradient(x, y + h * t0, w, h * (t1 - t0), c0, c1);
+		RectVGradient(x, y + h * t0, x + w, y + h * (t1 - t0), c0, c1);
 	}
 }
 

--- a/Common/Render/DrawBuffer.h
+++ b/Common/Render/DrawBuffer.h
@@ -83,9 +83,10 @@ public:
 
 	void RectOutline(float x, float y, float w, float h, uint32_t color, int align = ALIGN_TOPLEFT);
 
-	void RectVGradient(float x, float y, float w, float h, uint32_t colorTop, uint32_t colorBottom);
+	// NOTE: This one takes x2/y2 instead of w/h, better for gap-free graphics.
+	void RectVGradient(float x1, float y1, float x2, float y2, uint32_t colorTop, uint32_t colorBottom);
 	void RectVDarkFaded(float x, float y, float w, float h, uint32_t colorTop) {
-		RectVGradient(x, y, w, h, colorTop, darkenColor(colorTop));
+		RectVGradient(x, y, x + w, y + h, colorTop, darkenColor(colorTop));
 	}
 
 	void MultiVGradient(float x, float y, float w, float h, const GradientStop *stops, int numStops);

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -136,28 +136,21 @@ public:
 
 		// 500 is enough for any resolution really. 24 * 500 = 12000 which fits handily in our UI vertex buffer (max 65536 per flush).
 		const int steps = std::max(20, std::min((int)g_display.dp_xres, 500));
-		float stepSize = (float)g_display.dp_xres / (float)steps;
+		float step = (float)g_display.dp_xres / (float)steps;
 		t *= speed;
 
-		float stepx = x;
 		for (int n = 0; n < steps; n++) {
-			float nextx = stepx + stepSize;
-			// Round actual x and width to prevent gaps between waves.
-			float roundedx = floorf(stepx);
-			float w = floorf(nextx) - roundedx;
+			float x = (float)n * step;
+			float i = x * 1280 / bounds.w;
 
-			float i = stepx * 1280 / bounds.w;
 			float wave0 = sin(i*0.005+t*0.8)*0.05 + sin(i*0.002+t*0.25)*0.02 + sin(i*0.001+t*0.3)*0.03 + 0.625;
 			float wave1 = sin(i*0.0044+t*0.4)*0.07 + sin(i*0.003+t*0.1)*0.02 + sin(i*0.001+t*0.3)*0.01 + 0.625;
-
-			dc.Draw()->RectVGradient(roundedx, wave0*bounds.h, w, (1.0-wave0)*bounds.h, color, 0x00000000);
-			dc.Draw()->RectVGradient(roundedx, wave1*bounds.h, w, (1.0-wave1)*bounds.h, color, 0x00000000);
+			dc.Draw()->RectVGradient(x, wave0*bounds.h, step, (1.0-wave0)*bounds.h, color, 0x00000000);
+			dc.Draw()->RectVGradient(x, wave1*bounds.h, step, (1.0-wave1)*bounds.h, color, 0x00000000);
 
 			// Add some "antialiasing"
-			dc.Draw()->RectVGradient(roundedx, wave0*bounds.h-3.0f * g_display.pixel_in_dps_y, w, 3.0f * g_display.pixel_in_dps_y, 0x00000000, color);
-			dc.Draw()->RectVGradient(roundedx, wave1*bounds.h-3.0f * g_display.pixel_in_dps_y, w, 3.0f * g_display.pixel_in_dps_y, 0x00000000, color);
-
-			stepx = nextx;
+			dc.Draw()->RectVGradient(x, wave0*bounds.h-3.0f * g_display.pixel_in_dps_y, step, 3.0f * g_display.pixel_in_dps_y, 0x00000000, color);
+			dc.Draw()->RectVGradient(x, wave1*bounds.h-3.0f * g_display.pixel_in_dps_y, step, 3.0f * g_display.pixel_in_dps_y, 0x00000000, color);
 		}
 
 		dc.Flush();

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -141,16 +141,17 @@ public:
 
 		for (int n = 0; n < steps; n++) {
 			float x = (float)n * step;
+			float nextX = (float)(n + 1) * step;
 			float i = x * 1280 / bounds.w;
 
 			float wave0 = sin(i*0.005+t*0.8)*0.05 + sin(i*0.002+t*0.25)*0.02 + sin(i*0.001+t*0.3)*0.03 + 0.625;
 			float wave1 = sin(i*0.0044+t*0.4)*0.07 + sin(i*0.003+t*0.1)*0.02 + sin(i*0.001+t*0.3)*0.01 + 0.625;
-			dc.Draw()->RectVGradient(x, wave0*bounds.h, step, (1.0-wave0)*bounds.h, color, 0x00000000);
-			dc.Draw()->RectVGradient(x, wave1*bounds.h, step, (1.0-wave1)*bounds.h, color, 0x00000000);
+			dc.Draw()->RectVGradient(x, wave0*bounds.h, nextX, bounds.h, color, 0x00000000);
+			dc.Draw()->RectVGradient(x, wave1*bounds.h, nextX, bounds.h, color, 0x00000000);
 
 			// Add some "antialiasing"
-			dc.Draw()->RectVGradient(x, wave0*bounds.h-3.0f * g_display.pixel_in_dps_y, step, 3.0f * g_display.pixel_in_dps_y, 0x00000000, color);
-			dc.Draw()->RectVGradient(x, wave1*bounds.h-3.0f * g_display.pixel_in_dps_y, step, 3.0f * g_display.pixel_in_dps_y, 0x00000000, color);
+			dc.Draw()->RectVGradient(x, wave0*bounds.h-3.0f * g_display.pixel_in_dps_y, nextX, wave0 * bounds.h, 0x00000000, color);
+			dc.Draw()->RectVGradient(x, wave1*bounds.h-3.0f * g_display.pixel_in_dps_y, nextX, wave1 * bounds.h, 0x00000000, color);
 		}
 
 		dc.Flush();


### PR DESCRIPTION
Fixes #18270 

Reverts #18210 and applies a different fix for #18178 .

Don't really understand what in #18210 broke it though, but it does break when navigating with gamepad/keyboard as reported...

EDIT: Actually there was a confusing variable name collision - it started the background at the focus position....