### PR TITLE
Vulkan: Simplify pipeline and descriptor set layout, pool creation

### DIFF
--- a/Common/GPU/Vulkan/VulkanDescSet.cpp
+++ b/Common/GPU/Vulkan/VulkanDescSet.cpp
@@ -26,14 +26,14 @@ void VulkanDescSetPool::Create(VulkanContext *vulkan, const BindingType *binding
 		case BindingType::STORAGE_IMAGE_COMPUTE: storageImageCount++; break;
 		}
 	}
-	if (storageImageCount) {
-		sizes_.push_back(VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, storageImageCount * descriptorCount });
+	if (combinedImageSamplerCount) {
+		sizes_.push_back(VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, combinedImageSamplerCount * descriptorCount });
 	}
 	if (uniformBufferDynamicCount) {
 		sizes_.push_back(VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, uniformBufferDynamicCount * descriptorCount });
 	}
-	if (combinedImageSamplerCount) {
-		sizes_.push_back(VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, combinedImageSamplerCount * descriptorCount });
+	if (storageBufferCount) {
+		sizes_.push_back(VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, storageBufferCount * descriptorCount });
 	}
 	if (storageImageCount) {
 		sizes_.push_back(VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, storageImageCount * descriptorCount });

--- a/Common/GPU/Vulkan/VulkanDescSet.cpp
+++ b/Common/GPU/Vulkan/VulkanDescSet.cpp
@@ -4,13 +4,40 @@ VulkanDescSetPool::~VulkanDescSetPool() {
 	_assert_msg_(descPool_ == VK_NULL_HANDLE, "VulkanDescSetPool %s never destroyed", tag_);
 }
 
-void VulkanDescSetPool::Create(VulkanContext *vulkan, const VkDescriptorPoolCreateInfo &info, const std::vector<VkDescriptorPoolSize> &sizes) {
+void VulkanDescSetPool::Create(VulkanContext *vulkan, const BindingType *bindingTypes, uint32_t bindingTypesCount, uint32_t descriptorCount) {
 	_assert_msg_(descPool_ == VK_NULL_HANDLE, "VulkanDescSetPool::Create when already exists");
 
 	vulkan_ = vulkan;
-	info_ = info;
-	sizes_ = sizes;
+	info_ = { VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
+	info_.maxSets = descriptorCount;
+	_dbg_assert_(sizes_.empty());
 
+	uint32_t storageImageCount = 0;
+	uint32_t storageBufferCount = 0;
+	uint32_t combinedImageSamplerCount = 0;
+	uint32_t uniformBufferDynamicCount = 0;
+	for (uint32_t i = 0; i < bindingTypesCount; i++) {
+		switch (bindingTypes[i]) {
+		case BindingType::COMBINED_IMAGE_SAMPLER: combinedImageSamplerCount++; break;
+		case BindingType::UNIFORM_BUFFER_DYNAMIC_VERTEX:
+		case BindingType::UNIFORM_BUFFER_DYNAMIC_ALL: uniformBufferDynamicCount++; break;
+		case BindingType::STORAGE_BUFFER_VERTEX:
+		case BindingType::STORAGE_BUFFER_COMPUTE: storageBufferCount++; break;
+		case BindingType::STORAGE_IMAGE_COMPUTE: storageImageCount++; break;
+		}
+	}
+	if (storageImageCount) {
+		sizes_.push_back(VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, storageImageCount * descriptorCount });
+	}
+	if (uniformBufferDynamicCount) {
+		sizes_.push_back(VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, uniformBufferDynamicCount * descriptorCount });
+	}
+	if (combinedImageSamplerCount) {
+		sizes_.push_back(VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, combinedImageSamplerCount * descriptorCount });
+	}
+	if (storageImageCount) {
+		sizes_.push_back(VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, storageImageCount * descriptorCount });
+	}
 	VkResult res = Recreate(false);
 	_assert_msg_(res == VK_SUCCESS, "Could not create VulkanDescSetPool %s", tag_);
 }
@@ -66,6 +93,7 @@ void VulkanDescSetPool::Destroy() {
 		clear_();
 		usage_ = 0;
 	}
+	sizes_.clear();
 }
 
 VkResult VulkanDescSetPool::Recreate(bool grow) {

--- a/Common/GPU/Vulkan/VulkanDescSet.h
+++ b/Common/GPU/Vulkan/VulkanDescSet.h
@@ -6,6 +6,15 @@
 #include <functional>
 #include <vector>
 
+enum class BindingType {
+	COMBINED_IMAGE_SAMPLER,
+	UNIFORM_BUFFER_DYNAMIC_VERTEX,
+	UNIFORM_BUFFER_DYNAMIC_ALL,
+	STORAGE_BUFFER_VERTEX,
+	STORAGE_BUFFER_COMPUTE,
+	STORAGE_IMAGE_COMPUTE,
+};
+
 // Only appropriate for use in a per-frame pool.
 class VulkanDescSetPool {
 public:
@@ -16,7 +25,7 @@ public:
 	void Setup(const std::function<void()> &clear) {
 		clear_ = clear;
 	}
-	void Create(VulkanContext *vulkan, const VkDescriptorPoolCreateInfo &info, const std::vector<VkDescriptorPoolSize> &sizes);
+	void Create(VulkanContext *vulkan, const BindingType *bindingTypes, uint32_t bindingTypesCount, uint32_t descriptorCount);
 	// Allocate a new set, which may resize and empty the current sets.
 	// Use only for the current frame, unless in a cache cleared by clear_.
 	VkDescriptorSet Allocate(int n, const VkDescriptorSetLayout *layouts, const char *tag);

--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -1241,7 +1241,7 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 
 				if (pipeline != VK_NULL_HANDLE) {
 					vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
-					pipelineLayout = c.pipeline.pipelineLayout;
+					pipelineLayout = c.pipeline.pipelineLayout->pipelineLayout;
 					lastGraphicsPipeline = graphicsPipeline;
 					pipelineOK = true;
 				} else {
@@ -1263,7 +1263,7 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 				VkPipeline pipeline = computePipeline->pipeline->BlockUntilReady();
 				if (pipeline != VK_NULL_HANDLE) {
 					vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
-					pipelineLayout = c.pipeline.pipelineLayout;
+					pipelineLayout = c.pipeline.pipelineLayout->pipelineLayout;
 					lastComputePipeline = computePipeline;
 				}
 			}

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -19,6 +19,7 @@ class VKRFramebuffer;
 struct VKRGraphicsPipeline;
 struct VKRComputePipeline;
 struct VKRImage;
+struct VKRPipelineLayout;
 struct FrameData;
 
 enum {
@@ -58,15 +59,15 @@ struct VkRenderData {
 	union {
 		struct {
 			VkPipeline pipeline;
-			VkPipelineLayout pipelineLayout;
+			VKRPipelineLayout *pipelineLayout;
 		} pipeline;
 		struct {
 			VKRGraphicsPipeline *pipeline;
-			VkPipelineLayout pipelineLayout;
+			VKRPipelineLayout *pipelineLayout;
 		} graphics_pipeline;
 		struct {
 			VKRComputePipeline *pipeline;
-			VkPipelineLayout pipelineLayout;
+			VKRPipelineLayout *pipelineLayout;
 		} compute_pipeline;
 		struct {
 			VkDescriptorSet ds;

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -116,7 +116,7 @@ bool VKRGraphicsPipeline::Create(VulkanContext *vulkan, VkRenderPass compatibleR
 	pipe.pDynamicState = &desc->ds;
 	pipe.pInputAssemblyState = &inputAssembly;
 	pipe.pMultisampleState = &ms;
-	pipe.layout = desc->pipelineLayout;
+	pipe.layout = desc->pipelineLayout->pipelineLayout;
 	pipe.basePipelineHandle = VK_NULL_HANDLE;
 	pipe.basePipelineIndex = 0;
 	pipe.subpass = 0;
@@ -192,7 +192,7 @@ void VKRGraphicsPipeline::DestroyVariantsInstant(VkDevice device) {
 
 VKRGraphicsPipeline::~VKRGraphicsPipeline() {
 	// This is called from the callbacked queued in QueueForDeletion.
-	// Here we are free to directly delete stuff, don't need to queue.
+	// When we reach here, we should already be empty, so let's assert on that.
 	for (size_t i = 0; i < (size_t)RenderPassType::TYPE_COUNT; i++) {
 		_assert_(!pipeline[i]);
 	}

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -257,7 +257,7 @@ public:
 	// WARNING: desc must stick around during the lifetime of the pipeline! It's not enough to build it on the stack and drop it.
 	VKRGraphicsPipeline *CreateGraphicsPipeline(VKRGraphicsPipelineDesc *desc, PipelineFlags pipelineFlags, uint32_t variantBitmask, VkSampleCountFlagBits sampleCount, bool cacheLoad, const char *tag);
 	VKRComputePipeline *CreateComputePipeline(VKRComputePipelineDesc *desc);
-	
+
 	VKRPipelineLayout *CreatePipelineLayout(VkPipelineLayout pipelineLayout, VkDescriptorSetLayout descSetLayout) {
 		VKRPipelineLayout *layout = new VKRPipelineLayout();
 		layout->pipelineLayout = pipelineLayout;

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -23,6 +23,7 @@
 #include "Common/GPU/MiscTypes.h"
 #include "Common/GPU/Vulkan/VulkanQueueRunner.h"
 #include "Common/GPU/Vulkan/VulkanFramebuffer.h"
+#include "Common/GPU/Vulkan/VulkanDescSet.h"
 #include "Common/GPU/thin3d.h"
 
 // Forward declaration
@@ -182,15 +183,6 @@ struct CompileQueueEntry {
 	VKRGraphicsPipeline *graphics = nullptr;
 	VKRComputePipeline *compute = nullptr;
 	VkSampleCountFlagBits sampleCount;
-};
-
-enum class BindingType {
-	COMBINED_IMAGE_SAMPLER,
-	UNIFORM_BUFFER_DYNAMIC_VERTEX,
-	UNIFORM_BUFFER_DYNAMIC_ALL,
-	STORAGE_BUFFER_VERTEX,
-	STORAGE_BUFFER_COMPUTE,
-	STORAGE_IMAGE_COMPUTE,
 };
 
 // Note that we only support a single descriptor set due to compatibility with some ancient devices.

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -189,7 +189,7 @@ public:
 		DoFlush();
 	}
 
-	VkPipelineLayout GetPipelineLayout() const {
+	VKRPipelineLayout *GetPipelineLayout() const {
 		return pipelineLayout_;
 	}
 
@@ -244,10 +244,7 @@ private:
 	Draw::DrawContext *draw_;
 
 	// We use a shared descriptor set layouts for all PSP draws.
-	// Descriptors created from descriptorSetLayout_ is rebound all the time at set 1.
-	VkDescriptorSetLayout descriptorSetLayout_;
-
-	VkPipelineLayout pipelineLayout_;
+	VKRPipelineLayout *pipelineLayout_;
 	VulkanPipeline *lastPipeline_;
 	VkDescriptorSet lastDs_ = VK_NULL_HANDLE;
 

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -676,6 +676,7 @@ void PipelineManagerVulkan::SavePipelineCache(FILE *file, bool saveRawPipelineCa
 			failed = true;
 			return;
 		}
+		_dbg_assert_(pkey.raster.topology != VK_PRIMITIVE_TOPOLOGY_POINT_LIST && pkey.raster.topology != VK_PRIMITIVE_TOPOLOGY_LINE_LIST);
 		StoredVulkanPipelineKey key{};
 		key.raster = pkey.raster;
 		key.useHWTransform = pkey.useHWTransform;
@@ -788,6 +789,12 @@ bool PipelineManagerVulkan::LoadPipelineCache(FILE *file, bool loadRawPipelineCa
 			ERROR_LOG(G3D, "Truncated Vulkan pipeline cache file, stopping.");
 			break;
 		}
+
+		if (key.raster.topology == VK_PRIMITIVE_TOPOLOGY_POINT_LIST || key.raster.topology == VK_PRIMITIVE_TOPOLOGY_LINE_LIST) {
+			WARN_LOG(G3D, "Bad raster key in cache, ignoring");
+			continue;
+		}
+
 		VulkanVertexShader *vs = shaderManager->GetVertexShaderFromID(key.vShaderID);
 		VulkanFragmentShader *fs = shaderManager->GetFragmentShaderFromID(key.fShaderID);
 		VulkanGeometryShader *gs = shaderManager->GetGeometryShaderFromID(key.gShaderID);

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -187,7 +187,7 @@ static std::string CutFromMain(std::string str) {
 }
 
 static VulkanPipeline *CreateVulkanPipeline(VulkanRenderManager *renderManager, VkPipelineCache pipelineCache,
-	VkPipelineLayout layout, PipelineFlags pipelineFlags, VkSampleCountFlagBits sampleCount, const VulkanPipelineRasterStateKey &key,
+	VKRPipelineLayout *layout, PipelineFlags pipelineFlags, VkSampleCountFlagBits sampleCount, const VulkanPipelineRasterStateKey &key,
 	const DecVtxFormat *decFmt, VulkanVertexShader *vs, VulkanFragmentShader *fs, VulkanGeometryShader *gs, bool useHwTransform, u32 variantBitmask, bool cacheLoad) {
 	_assert_(fs && vs);
 
@@ -351,7 +351,7 @@ static VulkanPipeline *CreateVulkanPipeline(VulkanRenderManager *renderManager, 
 	return vulkanPipeline;
 }
 
-VulkanPipeline *PipelineManagerVulkan::GetOrCreatePipeline(VulkanRenderManager *renderManager, VkPipelineLayout layout, const VulkanPipelineRasterStateKey &rasterKey, const DecVtxFormat *decFmt, VulkanVertexShader *vs, VulkanFragmentShader *fs, VulkanGeometryShader *gs, bool useHwTransform, u32 variantBitmask, int multiSampleLevel, bool cacheLoad) {
+VulkanPipeline *PipelineManagerVulkan::GetOrCreatePipeline(VulkanRenderManager *renderManager, VKRPipelineLayout *layout, const VulkanPipelineRasterStateKey &rasterKey, const DecVtxFormat *decFmt, VulkanVertexShader *vs, VulkanFragmentShader *fs, VulkanGeometryShader *gs, bool useHwTransform, u32 variantBitmask, int multiSampleLevel, bool cacheLoad) {
 	if (!pipelineCache_) {
 		VkPipelineCacheCreateInfo pc{ VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO };
 		VkResult res = vkCreatePipelineCache(vulkan_->GetDevice(), &pc, nullptr, &pipelineCache_);
@@ -717,7 +717,7 @@ void PipelineManagerVulkan::SavePipelineCache(FILE *file, bool saveRawPipelineCa
 	}
 }
 
-bool PipelineManagerVulkan::LoadPipelineCache(FILE *file, bool loadRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext, VkPipelineLayout layout, int multiSampleLevel) {
+bool PipelineManagerVulkan::LoadPipelineCache(FILE *file, bool loadRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext, VKRPipelineLayout *layout, int multiSampleLevel) {
 	VulkanRenderManager *rm = (VulkanRenderManager *)drawContext->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 	VulkanQueueRunner *queueRunner = rm->GetQueueRunner();
 

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -85,7 +85,7 @@ public:
 	~PipelineManagerVulkan();
 
 	// variantMask is only used when loading pipelines from cache.
-	VulkanPipeline *GetOrCreatePipeline(VulkanRenderManager *renderManager, VkPipelineLayout layout, const VulkanPipelineRasterStateKey &rasterKey, const DecVtxFormat *decFmt, VulkanVertexShader *vs, VulkanFragmentShader *fs, VulkanGeometryShader *gs, bool useHwTransform, u32 variantMask, int multiSampleLevel, bool cacheLoad);
+	VulkanPipeline *GetOrCreatePipeline(VulkanRenderManager *renderManager, VKRPipelineLayout *layout, const VulkanPipelineRasterStateKey &rasterKey, const DecVtxFormat *decFmt, VulkanVertexShader *vs, VulkanFragmentShader *fs, VulkanGeometryShader *gs, bool useHwTransform, u32 variantMask, int multiSampleLevel, bool cacheLoad);
 	int GetNumPipelines() const { return (int)pipelines_.size(); }
 
 	void Clear();
@@ -100,7 +100,7 @@ public:
 
 	// Saves data for faster creation next time.
 	void SavePipelineCache(FILE *file, bool saveRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext);
-	bool LoadPipelineCache(FILE *file, bool loadRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext, VkPipelineLayout layout, int multiSampleLevel);
+	bool LoadPipelineCache(FILE *file, bool loadRawPipelineCache, ShaderManagerVulkan *shaderManager, Draw::DrawContext *drawContext, VKRPipelineLayout *layout, int multiSampleLevel);
 
 private:
 	DenseHashMap<VulkanPipelineKey, VulkanPipeline *> pipelines_;

--- a/GPU/Vulkan/VulkanUtil.cpp
+++ b/GPU/Vulkan/VulkanUtil.cpp
@@ -60,6 +60,12 @@ void VulkanComputeShaderManager::InitDeviceObjects(Draw::DrawContext *draw) {
 	VkResult res = vkCreatePipelineCache(vulkan_->GetDevice(), &pc, nullptr, &pipelineCache_);
 	_assert_(VK_SUCCESS == res);
 
+	static const BindingType bindingTypes[3] = {
+		BindingType::STORAGE_IMAGE_COMPUTE,
+		BindingType::STORAGE_BUFFER_COMPUTE,
+		BindingType::STORAGE_BUFFER_COMPUTE,
+	};
+
 	VkDescriptorSetLayoutBinding bindings[3] = {};
 	bindings[0].descriptorCount = 1;
 	bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
@@ -82,19 +88,8 @@ void VulkanComputeShaderManager::InitDeviceObjects(Draw::DrawContext *draw) {
 	res = vkCreateDescriptorSetLayout(device, &dsl, nullptr, &descriptorSetLayout_);
 	_assert_(VK_SUCCESS == res);
 
-	std::vector<VkDescriptorPoolSize> dpTypes;
-	dpTypes.resize(2);
-	dpTypes[0].descriptorCount = 8192;
-	dpTypes[0].type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-	dpTypes[1].descriptorCount = 4096;
-	dpTypes[1].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-
-	VkDescriptorPoolCreateInfo dp = { VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
-	dp.flags = 0;   // Don't want to mess around with individually freeing these, let's go fixed each frame and zap the whole array. Might try the dynamic approach later.
-	dp.maxSets = 4096;  // GTA can end up creating more than 1000 textures in the first frame!
-
 	for (int i = 0; i < ARRAY_SIZE(frameData_); i++) {
-		frameData_[i].descPool.Create(vulkan_, dp, dpTypes);
+		frameData_[i].descPool.Create(vulkan_, bindingTypes, ARRAY_SIZE(bindingTypes), 4096);
 		frameData_[i].descPoolUsed = false;
 	}
 


### PR DESCRIPTION
Wrap pipeline/descriptor-layout in a new object VKRPipelineLayout, and simplify the creation of those, and also of matching descriptor set pools.

This is early preparatory work for moving Vulkan descriptor set management off to the render thread, to speed up the main thread. This PR on its own shouldn't have any visible effect.