### PR TITLE
We somehow lost the usage_ counter increment in VulkanDescSetPool, fix that

### DIFF
--- a/Common/GPU/Vulkan/VulkanDescSet.cpp
+++ b/Common/GPU/Vulkan/VulkanDescSet.cpp
@@ -73,6 +73,8 @@ VkDescriptorSet VulkanDescSetPool::Allocate(int n, const VkDescriptorSetLayout *
 		return VK_NULL_HANDLE;
 	}
 
+	usage_++;
+
 	vulkan_->SetDebugName(desc, VK_OBJECT_TYPE_DESCRIPTOR_SET, tag);
 	return desc;
 }

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -59,7 +59,6 @@ enum {
 };
 
 #define VERTEXCACHE_DECIMATION_INTERVAL 17
-#define DESCRIPTORSET_DECIMATION_INTERVAL 1  // Temporarily cut to 1. Handle reuse breaks this when textures get deleted.
 
 enum { VAI_KILL_AGE = 120, VAI_UNRELIABLE_KILL_AGE = 240, VAI_UNRELIABLE_KILL_MAX = 4 };
 
@@ -242,10 +241,7 @@ void DrawEngineVulkan::BeginFrame() {
 
 	vertexCache_->BeginNoReset();
 
-	if (--descDecimationCounter_ <= 0) {
-		frame->descPool.Reset();
-		descDecimationCounter_ = DESCRIPTORSET_DECIMATION_INTERVAL;
-	}
+	frame->descPool.Reset();
 
 	if (--decimationCounter_ <= 0) {
 		decimationCounter_ = VERTEXCACHE_DECIMATION_INTERVAL;

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -259,7 +259,6 @@ private:
 
 	PrehashMap<VertexArrayInfoVulkan *> vai_;
 	VulkanPushBuffer *vertexCache_;
-	int descDecimationCounter_ = 0;
 
 	struct DescriptorSetKey {
 		VkImageView imageView_;


### PR DESCRIPTION
This caused assorted problems depending on the driver, but always including spamming of resets once there's more than 512 descriptors.

Also remove a unused decimation counter.