### PR TITLE
Android: Fix crashes on screen rotation

### DIFF
--- a/Common/GPU/Vulkan/VulkanFrameData.cpp
+++ b/Common/GPU/Vulkan/VulkanFrameData.cpp
@@ -84,6 +84,7 @@ void FrameData::AcquireNextImage(VulkanContext *vulkan, FrameDataShared &shared)
 		WARN_LOG(G3D, "VK_SUBOPTIMAL_KHR returned - ignoring");
 		break;
 	case VK_ERROR_OUT_OF_DATE_KHR:
+	case VK_ERROR_SURFACE_LOST_KHR:
 	case VK_TIMEOUT:
 	case VK_NOT_READY:
 		// We do not set hasAcquired here!

--- a/Common/Render/ManagedTexture.cpp
+++ b/Common/Render/ManagedTexture.cpp
@@ -186,8 +186,15 @@ void ManagedTexture::DeviceLost() {
 
 void ManagedTexture::DeviceRestored(Draw::DrawContext *draw) {
     INFO_LOG(G3D, "ManagedTexture::DeviceRestored(%s)", filename_.c_str());
-	_assert_(!texture_);
+
 	draw_ = draw;
+
+	_dbg_assert_(!texture_);
+	if (texture_) {
+		ERROR_LOG(G3D, "ManagedTexture: Unexpected - texture already present: %s", filename_.c_str());
+		return;
+	}
+
 	// Vulkan: Can't load textures before the first frame has started.
 	// Should probably try to lift that restriction again someday..
 	loadPending_ = true;

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1450,6 +1450,7 @@ extern "C" bool JNICALL Java_org_ppsspp_ppsspp_NativeActivity_runVulkanRenderLoo
 
 	if (g_vulkanRenderLoopThread.joinable()) {
 		ERROR_LOG(G3D, "runVulkanRenderLoop: Already running");
+		return false;
 	}
 
 	ANativeWindow *wnd = _surf ? ANativeWindow_fromSurface(env, _surf) : nullptr;


### PR DESCRIPTION
Fixes #18330

(ideally, the function shouldn't be called in that state, the check shouldn't be needed - will look into that later)