### PR TITLE
Add UI to allow setting fast-forward mode (in developer tools)

### DIFF
--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1716,6 +1716,11 @@ void DeveloperToolsScreen::CreateViews() {
 		list->Add(new CheckBox(&g_Config.bGpuLogProfiler, dev->T("GPU log profiler")));
 	}
 
+	static const char *ffModes[] = { "Render all frames", "", "Frame Skipping" };
+	PopupMultiChoice *ffMode = list->Add(new PopupMultiChoice(&g_Config.iFastForwardMode, dev->T("Fast-forward mode"), ffModes, 0, ARRAY_SIZE(ffModes), I18NCat::GRAPHICS, screenManager()));
+	ffMode->SetEnabledFunc([]() { return !g_Config.bVSync; });
+	ffMode->HideChoice(1);  // not used
+
 	Draw::DrawContext *draw = screenManager()->getDrawContext();
 
 	list->Add(new ItemHeader(dev->T("Ubershaders")));

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -653,6 +653,7 @@ Percent of FPS = Percent of FPS
 Performance = Performance
 Postprocessing shaders = Postprocessing shaders
 Recreate Activity = Recreate activity
+Render all frames = Render all frames
 Render duplicate frames to 60hz = Render duplicate frames to 60 Hz
 RenderDuplicateFrames Tip = Can make framerate smoother in games that run at lower framerates
 Rendering Mode = Rendering mode


### PR DESCRIPTION
Setting to "Continuous" (or now, "Render all frames") is useful for benchmarking with vsync off.

Editing the ini file is a bit painful on Android so this just exposes the setting in the developer tools.

(Though, PowerVR drivers have very strange behavior with this..)