### PR TITLE
Vulkan: Allocate descriptors in blocks of 8 instead of individually

### DIFF
--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -1339,6 +1339,7 @@ void VulkanQueueRunner::PerformRenderPass(const VKRStep &step, VkCommandBuffer c
 		case VKRRenderCommand::DRAW_INDEXED:
 			if (pipelineOK) {
 				VkDescriptorSet set = (*descSets)[c.drawIndexed.descSetIndex].set;
+				_dbg_assert_(set != VK_NULL_HANDLE);
 				vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, 1, &set, c.drawIndexed.numUboOffsets, c.drawIndexed.uboOffsets);
 				vkCmdBindIndexBuffer(cmd, c.drawIndexed.ibuffer, c.drawIndexed.ioffset, VK_INDEX_TYPE_UINT16);
 				VkDeviceSize voffset = c.drawIndexed.voffset;


### PR DESCRIPTION
Followup to #18328

Attempt to reduce function call overhead a bit, although doesn't seem to make a lot of difference, even on my worst test case which is GTA VCS on Redmi 9A, where descriptor writing takes as much as 4.5 milliseconds (compared to 6ms for actually submitting the render commands...)

Also adds a missing assert.