### PR TITLE
Better fix for shutdown crash

### DIFF
--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -1181,6 +1181,7 @@ uint8_t *ReadLocalFile(const Path &filename, size_t *size) {
 		return nullptr;
 	}
 	fseek(file, 0, SEEK_SET);
+	// NOTE: If you find ~10 memory leaks from here, with very varying sizes, it might be the VFPU LUTs.
 	uint8_t *contents = new uint8_t[f_size + 1];
 	if (fread(contents, 1, f_size, file) != f_size) {
 		delete[] contents;

--- a/Common/GPU/Vulkan/VulkanDescSet.cpp
+++ b/Common/GPU/Vulkan/VulkanDescSet.cpp
@@ -85,10 +85,16 @@ void VulkanDescSetPool::Reset() {
 }
 
 void VulkanDescSetPool::Destroy() {
-	_assert_msg_(vulkan_ != nullptr, "VulkanDescSetPool::Destroy without VulkanContext");
-
 	if (descPool_ != VK_NULL_HANDLE) {
 		vulkan_->Delete().QueueDeleteDescriptorPool(descPool_);
+		usage_ = 0;
+	}
+	sizes_.clear();
+}
+
+void VulkanDescSetPool::DestroyImmediately() {
+	if (descPool_ != VK_NULL_HANDLE) {
+		vkDestroyDescriptorPool(vulkan_->GetDevice(), descPool_, nullptr);
 		usage_ = 0;
 	}
 	sizes_.clear();

--- a/Common/GPU/Vulkan/VulkanDescSet.cpp
+++ b/Common/GPU/Vulkan/VulkanDescSet.cpp
@@ -95,6 +95,7 @@ void VulkanDescSetPool::Destroy() {
 void VulkanDescSetPool::DestroyImmediately() {
 	if (descPool_ != VK_NULL_HANDLE) {
 		vkDestroyDescriptorPool(vulkan_->GetDevice(), descPool_, nullptr);
+		descPool_ = VK_NULL_HANDLE;
 		usage_ = 0;
 	}
 	sizes_.clear();

--- a/Common/GPU/Vulkan/VulkanDescSet.h
+++ b/Common/GPU/Vulkan/VulkanDescSet.h
@@ -25,7 +25,11 @@ public:
 	// Use only for the current frame.
 	bool Allocate(VkDescriptorSet *descriptorSets, int count, const VkDescriptorSetLayout *layouts);
 	void Reset();
+
+	// This queues up destruction.
 	void Destroy();
+	// This actually destroys immediately.
+	void DestroyImmediately();
 
 	bool IsDestroyed() const {
 		return !descPool_;


### PR DESCRIPTION
Turns out that restarting the backbuffer render pass (which happened due to the previous sync) is a no-no on MoltenVK, so refine our strategy for safely deleting our new fancy descriptor-managing `VKRPipelineLayout` objects.

(This problem doesn't exist in the branched 1.16.6 because the new descriptor management isn't in there).