### PR TITLE
softgpu: Point depthbuf at the first VRAM mirror

### DIFF
--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -1040,7 +1040,9 @@ void SoftGPU::Execute_ZbufPtr(u32 op, u32 diff) {
 	// We assume depthbuf.data won't change while we're drawing.
 	if (diff) {
 		drawEngine_->transformUnit.Flush("depthbuf");
-		depthbuf.data = Memory::GetPointerWrite(gstate.getDepthBufAddress());
+		// For the pointer, ignore memory mirrors.  This also gives some buffer for draws that go outside.
+		// TODO: Confirm how wrapping is handled in drawing.  Adjust if we ever handle VRAM mirrors more accurately.
+		depthbuf.data = Memory::GetPointerWrite(gstate.getDepthBufAddress() & 0x041FFFF0);
 	}
 }
 


### PR DESCRIPTION
I forgot this wasn't pointed at the first mirror.  Should prevent crash issues in Crazy Taxi, most likely.

That said, if we ever do any tricky page faulting logic on the VRAM mirrors to swizzle the bytes, we might want to adjust this... not sure if we ever will, though.

-[Unknown]