### PR TITLE
Revert "Control: Remove the axis event dupe filtering from ScreenManager"

### DIFF
--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -119,9 +119,28 @@ bool ScreenManager::key(const KeyInput &key) {
 
 void ScreenManager::axis(const AxisInput *axes, size_t count) {
 	std::lock_guard<std::recursive_mutex> guard(inputLock_);
-	if (stack_.empty())
-		return;
-	stack_.back().screen->UnsyncAxis(axes, count);
+
+	for (size_t i = 0; i < count; i++) {
+		const AxisInput &axis = axes[i];
+		// Ignore duplicate values to prevent axis values overwriting each other.
+		uint64_t key = ((uint64_t)axis.axisId << 32) | axis.deviceId;
+		// Center value far from zero just to ensure we send the first zero.
+		// PSP games can't see higher resolution than this.
+		int value = 128 + ceilf(axis.value * 127.5f + 127.5f);
+		if (lastAxis_[key] == value) {
+			return;
+		}
+		lastAxis_[key] = value;
+
+		// Send center axis to every screen layer.
+		if (axis.value == 0) {
+			for (auto &layer : stack_) {
+				layer.screen->UnsyncAxis(&axis, 1);
+			}
+		} else if (!stack_.empty()) {
+			stack_.back().screen->UnsyncAxis(&axis, 1);
+		}
+	}
 }
 
 void ScreenManager::deviceLost() {


### PR DESCRIPTION
This reverts commit 265a9021fd87b530970e4be093b5c29ae0b6f17e, having to do it a bit differently due to conflicts.

The change seems to have caused issues on SDL, I'll test that before doing it again.

This undoes the event batching here, but no big deal.