### PR TITLE
DNS resolver warning logs fix

### DIFF
--- a/Common/Net/Resolve.cpp
+++ b/Common/Net/Resolve.cpp
@@ -29,6 +29,7 @@
 
 #include "Common/Log.h"
 #include "Common/TimeUtil.h"
+#include "Common/Data/Encoding/Utf8.h"
 
 #ifndef HTTPS_NOT_AVAILABLE
 #include "ext/naett/naett.h"
@@ -109,7 +110,7 @@ bool DNSResolve(const std::string &host, const std::string &service, addrinfo **
 
 	if (result != 0) {
 #ifdef _WIN32
-		error = gai_strerrorA(result);
+		error = ConvertWStringToUTF8(gai_strerror(result));
 #else
 		error = gai_strerror(result);
 #endif


### PR DESCRIPTION
The function `gai_strerrorA` returns a string localized in accordance with the system's culture. In my case this is the extended ASCII encoding called "866 (OEM - Russian)". The code that prints logs to the console expects a UTF8 encoding and fails here.

Old VS New:
![image](https://github.com/hrydgard/ppsspp/assets/62447396/7526659e-ec5e-4e07-97a7-f25730ab774c)

I guess it wasn't found before because UTF8 encodes the English chars like in ASCII.