### PR TITLE
Add winhttp for cmake Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2332,6 +2332,9 @@ target_link_libraries(${CoreLibName} Common native chdr kirk cityhash sfmt19937 
 
 if(NOT HTTPS_NOT_AVAILABLE)
 	target_link_libraries(${CoreLibName} naett)
+	if(WIN32)
+		target_link_libraries(${CoreLibName} winhttp)
+	endif()
 endif()
 
 target_compile_features(${CoreLibName} PUBLIC cxx_std_17)


### PR DESCRIPTION
I'm really not sure if this is the correct way to do it but I needed this change to build on Windows using CLion+MSVC since `naett` requires `winhttp`.