### PR TITLE
skip xinput trigger threshold check

### DIFF
--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -236,14 +236,8 @@ void XinputDevice::UpdatePad(int pad, const XINPUT_STATE &state, XINPUT_VIBRATIO
 	sendAxis(JOYSTICK_AXIS_Y, (float)state.Gamepad.sThumbLY / 32767.0f, 1);
 	sendAxis(JOYSTICK_AXIS_Z, (float)state.Gamepad.sThumbRX / 32767.0f, 2);
 	sendAxis(JOYSTICK_AXIS_RZ, (float)state.Gamepad.sThumbRY / 32767.0f, 3);
-
-	if (NormalizedDeadzoneDiffers(prevState[pad].Gamepad.bLeftTrigger, state.Gamepad.bLeftTrigger, XINPUT_GAMEPAD_TRIGGER_THRESHOLD)) {
-		sendAxis(JOYSTICK_AXIS_LTRIGGER, (float)state.Gamepad.bLeftTrigger / 255.0f, 4);
-	}
-
-	if (NormalizedDeadzoneDiffers(prevState[pad].Gamepad.bRightTrigger, state.Gamepad.bRightTrigger, XINPUT_GAMEPAD_TRIGGER_THRESHOLD)) {
-		sendAxis(JOYSTICK_AXIS_RTRIGGER, (float)state.Gamepad.bRightTrigger / 255.0f, 5);
-	}
+	sendAxis(JOYSTICK_AXIS_LTRIGGER, (float)state.Gamepad.bLeftTrigger / 255.0f, 4);
+	sendAxis(JOYSTICK_AXIS_RTRIGGER, (float)state.Gamepad.bRightTrigger / 255.0f, 5);
 
 	if (axisCount) {
 		NativeAxis(axis, axisCount);


### PR DESCRIPTION
Address #18404 , remove the hard coded 30.0f/255.0f deadzone on triggers

It should be fine since analog deadzone was moved to control mapper around https://github.com/hrydgard/ppsspp/commit/633a6f612b44b36e12ba34c7ded3147897d7e3af

To further address #16643 with analog mapped to digital, I'm guessing KeyMap thresholds should be evaluated (if that still happens), but this should already make it harder for analog triggers mapped to digital buttons to get stuck

https://github.com/hrydgard/ppsspp/blob/2036f1c36a4023c2e4525002a3817f0d93a4ab83/Core/KeyMap.h#L81-L83