### PR TITLE
UI: Remove unnecessary mutexes, assorted cleanup

### DIFF
--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -129,7 +129,6 @@ bool VulkanQueueRunner::CreateSwapchain(VkCommandBuffer cmdInit) {
 	return true;
 }
 
-
 bool VulkanQueueRunner::InitBackbufferFramebuffers(int width, int height) {
 	VkResult res;
 	// We share the same depth buffer but have multiple color buffers, see the loop below.

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -57,17 +57,9 @@ struct VkRenderData {
 	VKRRenderCommand cmd;
 	union {
 		struct {
-			VkPipeline pipeline;
-			VKRPipelineLayout *pipelineLayout;
-		} pipeline;
-		struct {
 			VKRGraphicsPipeline *pipeline;
 			VKRPipelineLayout *pipelineLayout;
 		} graphics_pipeline;
-		struct {
-			VKRComputePipeline *pipeline;
-			VKRPipelineLayout *pipelineLayout;
-		} compute_pipeline;
 		struct {
 			uint32_t descSetIndex;
 			int numUboOffsets;

--- a/Common/UI/Root.cpp
+++ b/Common/UI/Root.cpp
@@ -1,5 +1,3 @@
-#include <atomic>
-#include <mutex>
 #include <deque>
 
 #include "ppsspp_config.h"
@@ -12,14 +10,12 @@
 
 namespace UI {
 
-static std::mutex focusLock;
 static std::vector<int> focusMoves;
 extern bool focusForced;
 
 static View *focusedView;
 static bool focusMovementEnabled;
 bool focusForced;
-static std::mutex eventMutex_;
 
 static std::function<void(UISound, float)> soundCallback;
 static bool soundEnabled = true;
@@ -29,29 +25,20 @@ struct DispatchQueueItem {
 	EventParams params;
 };
 
-std::atomic<bool> hasDispatchQueue;
 std::deque<DispatchQueueItem> g_dispatchQueue;
 
 void EventTriggered(Event *e, EventParams params) {
 	DispatchQueueItem item{ e, params };
-
-	std::unique_lock<std::mutex> guard(eventMutex_);
-	// Set before adding so we lock and check the added value.
-	hasDispatchQueue = true;
 	g_dispatchQueue.push_front(item);
 }
 
 void DispatchEvents() {
-	while (hasDispatchQueue) {
+	while (!g_dispatchQueue.empty()) {
 		DispatchQueueItem item;
-		{
-			std::unique_lock<std::mutex> guard(eventMutex_);
-			if (g_dispatchQueue.empty())
-				break;
-			item = g_dispatchQueue.back();
-			g_dispatchQueue.pop_back();
-			hasDispatchQueue = !g_dispatchQueue.empty();
-		}
+		if (g_dispatchQueue.empty())
+			break;
+		item = g_dispatchQueue.back();
+		g_dispatchQueue.pop_back();
 		if (item.e) {
 			item.e->Dispatch(item.params);
 		}
@@ -59,9 +46,6 @@ void DispatchEvents() {
 }
 
 void RemoveQueuedEventsByView(View *view) {
-	if (!hasDispatchQueue)
-		return;
-	std::unique_lock<std::mutex> guard(eventMutex_);
 	for (auto it = g_dispatchQueue.begin(); it != g_dispatchQueue.end(); ) {
 		if (it->params.v == view) {
 			it = g_dispatchQueue.erase(it);
@@ -72,9 +56,6 @@ void RemoveQueuedEventsByView(View *view) {
 }
 
 void RemoveQueuedEventsByEvent(Event *event) {
-	if (!hasDispatchQueue)
-		return;
-	std::unique_lock<std::mutex> guard(eventMutex_);
 	for (auto it = g_dispatchQueue.begin(); it != g_dispatchQueue.end(); ) {
 		if (it->e == event) {
 			it = g_dispatchQueue.erase(it);
@@ -214,7 +195,6 @@ static KeyEventResult KeyEventToFocusMoves(const KeyInput &key) {
 			hk.deviceId = key.deviceId;
 			hk.triggerTime = time_now_d() + repeatDelay;
 
-			std::lock_guard<std::mutex> lock(focusLock);
 			// Check if the key is already held. If it is, ignore it. This is to avoid
 			// multiple key repeat mechanisms colliding.
 			if (heldKeys.find(hk) != heldKeys.end()) {
@@ -381,7 +361,6 @@ restart:
 			key.flags = KEY_DOWN;
 			KeyEvent(key, root);
 
-			std::lock_guard<std::mutex> lock(focusLock);
 			focusMoves.push_back(key.keyCode);
 
 			// Cannot modify the current item when looping over a set, so let's do this instead.
@@ -404,7 +383,6 @@ void UpdateViewHierarchy(ViewGroup *root) {
 	}
 
 	if (focusMoves.size()) {
-		std::lock_guard<std::mutex> lock(focusLock);
 		EnableFocusMovement(true);
 		if (!GetFocusedView()) {
 			// Find a view to focus.

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -48,7 +48,6 @@ ViewGroup::~ViewGroup() {
 }
 
 void ViewGroup::RemoveSubview(View *subView) {
-	std::lock_guard<std::mutex> guard(modifyLock_);
 	// loop counter needed, so can't convert loop.
 	for (size_t i = 0; i < views_.size(); i++) {
 		if (views_[i] == subView) {
@@ -68,7 +67,6 @@ bool ViewGroup::ContainsSubview(const View *view) const {
 }
 
 void ViewGroup::Clear() {
-	std::lock_guard<std::mutex> guard(modifyLock_);
 	for (View *view : views_) {
 		delete view;
 	}
@@ -76,8 +74,6 @@ void ViewGroup::Clear() {
 }
 
 void ViewGroup::PersistData(PersistStatus status, std::string anonId, PersistMap &storage) {
-	std::lock_guard<std::mutex> guard(modifyLock_);
-
 	std::string tag = Tag();
 	if (tag.empty()) {
 		tag = anonId;
@@ -89,7 +85,6 @@ void ViewGroup::PersistData(PersistStatus status, std::string anonId, PersistMap
 }
 
 bool ViewGroup::Touch(const TouchInput &input) {
-	std::lock_guard<std::mutex> guard(modifyLock_);
 	bool any = false;
 	for (View *view : views_) {
 		// TODO: If there is a transformation active, transform input coordinates accordingly.
@@ -118,7 +113,6 @@ void ViewGroup::Query(float x, float y, std::vector<View *> &list) {
 }
 
 bool ViewGroup::Key(const KeyInput &input) {
-	std::lock_guard<std::mutex> guard(modifyLock_);
 	bool ret = false;
 	for (View *view : views_) {
 		// TODO: If there is a transformation active, transform input coordinates accordingly.
@@ -129,7 +123,6 @@ bool ViewGroup::Key(const KeyInput &input) {
 }
 
 void ViewGroup::Axis(const AxisInput &input) {
-	std::lock_guard<std::mutex> guard(modifyLock_);
 	for (View *view : views_) {
 		// TODO: If there is a transformation active, transform input coordinates accordingly.
 		if (view->GetVisibility() == V_VISIBLE)
@@ -138,14 +131,12 @@ void ViewGroup::Axis(const AxisInput &input) {
 }
 
 void ViewGroup::DeviceLost() {
-	std::lock_guard<std::mutex> guard(modifyLock_);
 	for (View *view : views_) {
 		view->DeviceLost();
 	}
 }
 
 void ViewGroup::DeviceRestored(Draw::DrawContext *draw) {
-	std::lock_guard<std::mutex> guard(modifyLock_);
 	for (View *view : views_) {
 		view->DeviceRestored(draw);
 	}
@@ -245,7 +236,6 @@ void ViewGroup::Update() {
 }
 
 bool ViewGroup::SetFocus() {
-	std::lock_guard<std::mutex> guard(modifyLock_);
 	if (!CanBeFocused() && !views_.empty()) {
 		for (View *view : views_) {
 			if (view->SetFocus())

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -45,7 +45,6 @@ public:
 	// Takes ownership! DO NOT add a view to multiple parents!
 	template <class T>
 	T *Add(T *view) {
-		std::lock_guard<std::mutex> guard(modifyLock_);
 		views_.push_back(view);
 		return view;
 	}
@@ -76,9 +75,6 @@ public:
 	void SetExclusiveTouch(bool exclusive) { exclusiveTouch_ = exclusive; }
 	void SetClickableBackground(bool clickableBackground) { clickableBackground_ = clickableBackground; }
 
-	void Lock() { modifyLock_.lock(); }
-	void Unlock() { modifyLock_.unlock(); }
-
 	void SetClip(bool clip) { clip_ = clip; }
 	std::string DescribeLog() const override { return "ViewGroup: " + View::DescribeLog(); }
 	std::string DescribeText() const override;
@@ -87,7 +83,6 @@ protected:
 	std::string DescribeListUnordered(const char *heading) const;
 	std::string DescribeListOrdered(const char *heading) const;
 
-	std::mutex modifyLock_;  // Hold this when changing the subviews.
 	std::vector<View *> views_;
 	View *defaultFocusView_ = nullptr;
 	Drawable bg_;

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -177,7 +177,6 @@ public:
 private:
 	void Invalidate(InvalidationCallbackFlags flags);
 
-	struct FrameData;
 	void ApplyDrawStateLate(VulkanRenderManager *renderManager, bool applyStencilRef, uint8_t stencilRef, bool useBlendConstant);
 	void ConvertStateToVulkanKey(FramebufferManagerVulkan &fbManager, ShaderManagerVulkan *shaderManager, int prim, VulkanPipelineRasterStateKey &key, VulkanDynamicState &dynState);
 	void BindShaderBlendTex();

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -580,7 +580,7 @@ bool EmuScreen::UnsyncTouch(const TouchInput &touch) {
 	}
 
 	if (root_) {
-		root_->Touch(touch);
+		UIScreen::UnsyncTouch(touch);
 	}
 	return true;
 }
@@ -870,6 +870,11 @@ bool EmuScreen::key(const KeyInput &key) {
 
 void EmuScreen::UnsyncAxis(const AxisInput *axes, size_t count) {
 	System_Notify(SystemNotification::ACTIVITY);
+
+	if (UI::IsFocusMovementEnabled()) {
+		return UIScreen::UnsyncAxis(axes, count);
+	}
+
 	return controlMapper_.Axis(axes, count);
 }
 

--- a/Windows/XinputDevice.cpp
+++ b/Windows/XinputDevice.cpp
@@ -16,8 +16,6 @@
 #include "Core/KeyMap.h"
 #include "Core/HLE/sceCtrl.h"
 
-static double newVibrationTime = 0.0;
-
 // Utilities to dynamically load XInput. Adapted from SDL.
 
 #if !PPSSPP_PLATFORM(UWP)
@@ -258,11 +256,11 @@ void XinputDevice::ApplyButtons(int pad, const XINPUT_STATE &state) {
 
 void XinputDevice::ApplyVibration(int pad, XINPUT_VIBRATION &vibration) {
 	if (PSP_IsInited()) {
-		newVibrationTime = time_now_d();
+		newVibrationTime_ = time_now_d();
 		// We have to run PPSSPP_XInputSetState at time intervals
 		// since it bugs otherwise with very high fast-forward speeds
 		// and freezes at constant vibration or no vibration at all.
-		if (newVibrationTime - prevVibrationTime >= 1.0 / 64.0) {
+		if (newVibrationTime_ - prevVibrationTime >= 1.0 / 64.0) {
 			if (GetUIState() == UISTATE_INGAME) {
 				vibration.wLeftMotorSpeed = sceCtrlGetLeftVibration(); // use any value between 0-65535 here
 				vibration.wRightMotorSpeed = sceCtrlGetRightVibration(); // use any value between 0-65535 here
@@ -275,7 +273,7 @@ void XinputDevice::ApplyVibration(int pad, XINPUT_VIBRATION &vibration) {
 				PPSSPP_XInputSetState(pad, &vibration);
 				prevVibration[pad] = vibration;
 			}
-			prevVibrationTime = newVibrationTime;
+			prevVibrationTime = newVibrationTime_;
 		}
 	} else {
 		DWORD dwResult = PPSSPP_XInputSetState(pad, &vibration);
@@ -284,4 +282,3 @@ void XinputDevice::ApplyVibration(int pad, XINPUT_VIBRATION &vibration) {
 		}
 	}
 }
-

--- a/Windows/XinputDevice.h
+++ b/Windows/XinputDevice.h
@@ -21,4 +21,5 @@ private:
 	float prevAxisValue_[4][6]{};
 	bool notified_[XUSER_MAX_COUNT]{};
 	u32 prevButtons_[4]{};
+	double newVibrationTime_ = 0.0;
 };


### PR DESCRIPTION
Since we now process all UI events on the main "emu" thread (after a little fix fixing the last wrong case that's also in this PR), we no longer need this synchronization.

Also remove some unused code.