### PR TITLE
allow `ALL = true` then `gameID = false` blacklisting

### DIFF
--- a/Core/HLE/Plugins.cpp
+++ b/Core/HLE/Plugins.cpp
@@ -105,15 +105,17 @@ static std::vector<PluginInfo> FindPlugins(const std::string &gameID, const std:
 		std::set<std::string> matches;
 
 		std::string gameIni;
-		if (ini.GetOrCreateSection("games")->Get("ALL", &gameIni, "")) {
+		if (ini.GetOrCreateSection("games")->Get(gameID.c_str(), &gameIni, "")) {
 			if (!strcasecmp(gameIni.c_str(), "true")) {
 				matches.insert("plugin.ini");
+			} else if (!strcasecmp(gameIni.c_str(), "false")){
+				continue;
 			} else if (!gameIni.empty()) {
 				matches.insert(gameIni);
 			}
 		}
 
-		if (ini.GetOrCreateSection("games")->Get(gameID.c_str(), &gameIni, "")) {
+		if (ini.GetOrCreateSection("games")->Get("ALL", &gameIni, "")) {
 			if (!strcasecmp(gameIni.c_str(), "true")) {
 				matches.insert("plugin.ini");
 			} else if (!gameIni.empty()) {


### PR DESCRIPTION
Rearrange plugin enumeration code to allow list `ALL = true` to load a certain plugin on all games, then `<gameID> = false` to not load the plugin on certain games