### PR TITLE
Cache and hash data for DrawPixels

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -269,6 +269,7 @@ class DrawContext;
 
 struct DrawPixelsEntry {
 	Draw::Texture *tex;
+	uint64_t contentsHash;
 	int frameNumber;
 };
 

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -92,6 +92,7 @@ struct GPUStatistics {
 		numBlockingReadbacks = 0;
 		numReadbacks = 0;
 		numUploads = 0;
+		numCachedUploads = 0;
 		numDepal = 0;
 		numClears = 0;
 		numDepthCopies = 0;
@@ -126,6 +127,7 @@ struct GPUStatistics {
 	int numBlockingReadbacks;
 	int numReadbacks;
 	int numUploads;
+	int numCachedUploads;
 	int numDepal;
 	int numClears;
 	int numDepthCopies;

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1688,7 +1688,7 @@ size_t GPUCommonHW::FormatGPUStatsCommon(char *buffer, size_t size) {
 		"Vertices: %d drawn: %d\n"
 		"FBOs active: %d (evaluations: %d)\n"
 		"Textures: %d, dec: %d, invalidated: %d, hashed: %d kB\n"
-		"readbacks %d (%d non-block), uploads %d, depal %d\n"
+		"readbacks %d (%d non-block), upload %d (cached %d), depal %d\n"
 		"block transfers: %d\n"
 		"replacer: tracks %d references, %d unique textures\n"
 		"Cpy: depth %d, color %d, reint %d, blend %d, self %d\n"
@@ -1713,6 +1713,7 @@ size_t GPUCommonHW::FormatGPUStatsCommon(char *buffer, size_t size) {
 		gpuStats.numBlockingReadbacks,
 		gpuStats.numReadbacks,
 		gpuStats.numUploads,
+		gpuStats.numCachedUploads,
 		gpuStats.numDepal,
 		gpuStats.numBlockTransfers,
 		gpuStats.numReplacerTrackedTex,

--- a/GPU/ge_constants.h
+++ b/GPU/ge_constants.h
@@ -460,10 +460,10 @@ inline bool IsTextureFormat16Bit(GETextureFormat tfmt) {
 
 inline int BufferFormatBytesPerPixel(GEBufferFormat format) {
 	switch (format) {
-	case GE_FORMAT_8888: return 4;  // applies to depth as well.
+	case GE_FORMAT_8888: return 4;
 	case GE_FORMAT_CLUT8: return 1;
 	default:
-		return 2;
+		return 2;  // works for depth as well as the 16-bit color formats.
 	}
 }
 


### PR DESCRIPTION
We already had a cache to reuse texture objects so just opportunistically reuse them when easy to do so.

The overhead for hashing seems to be covered easily by the savings in texture uploads.

Improves performance in God of War (both) and during strokes in Everybody's Golf 2.