### PR TITLE
Optimize DrawPixels for 16-bit RGB565 copies

### DIFF
--- a/Common/Data/Convert/ColorConv.cpp
+++ b/Common/Data/Convert/ColorConv.cpp
@@ -617,6 +617,7 @@ void ConvertRGB565ToBGR565(u16 *dst, const u16 *src, u32 numPixels) {
 	u32 i = 0;
 #endif
 
+	// TODO: Add a 64-bit loop too.
 	const u32 *src32 = (const u32 *)src;
 	u32 *dst32 = (u32 *)dst;
 	for (; i < numPixels / 2; i++) {


### PR DESCRIPTION
These are done repeatedly in God of War, and are slightly expensive on platforms like RISC-V due to unnecessary color conversion (we don't have optimized color conv functions for RISC-V yet).

So let's just use a 16-bit texture format directly if available instead of converting (and if the opposite RGB16 format is available, use that since conversion is cheap even without SIMD).