### PR TITLE
thin3d/backends: Remove code that pretended that we supported multiple vertex streams

### DIFF
--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -1251,7 +1251,7 @@ void GLQueueRunner::PerformRenderPass(const GLRStep &step, bool first, bool last
 			}
 			for (size_t i = 0; i < layout->entries.size(); i++) {
 				auto &entry = layout->entries[i];
-				glVertexAttribPointer(entry.location, entry.count, entry.type, entry.normalized, entry.stride, (const void *)(c.draw.vertexOffset + entry.offset));
+				glVertexAttribPointer(entry.location, entry.count, entry.type, entry.normalized, layout->stride, (const void *)(c.draw.vertexOffset + entry.offset));
 			}
 			if (c.draw.indexBuffer) {
 				GLuint buf = c.draw.indexBuffer->buffer_;

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -190,10 +190,10 @@ public:
 		int count;
 		GLenum type;
 		GLboolean normalized;
-		int stride;
 		intptr_t offset;
 	};
 	std::vector<Entry> entries;
+	int stride;
 	int semanticsMask_ = 0;
 };
 
@@ -331,11 +331,12 @@ public:
 		return step.create_program.program;
 	}
 
-	GLRInputLayout *CreateInputLayout(const std::vector<GLRInputLayout::Entry> &entries) {
+	GLRInputLayout *CreateInputLayout(const std::vector<GLRInputLayout::Entry> &entries, int stride) {
 		GLRInitStep &step = initSteps_.push_uninitialized();
 		step.stepType = GLRInitStepType::CREATE_INPUT_LAYOUT;
 		step.create_input_layout.inputLayout = new GLRInputLayout();
 		step.create_input_layout.inputLayout->entries = entries;
+		step.create_input_layout.inputLayout->stride = stride;
 		for (auto &iter : step.create_input_layout.inputLayout->entries) {
 			step.create_input_layout.inputLayout->semanticsMask_ |= 1 << iter.location;
 		}

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -475,20 +475,14 @@ protected:
 	DataFormat format_ = DataFormat::UNDEFINED;
 };
 
-struct BindingDesc {
-	int stride;
-	bool instanceRate;
-};
-
 struct AttributeDesc {
-	int binding;
 	int location;  // corresponds to semantic
 	DataFormat format;
 	int offset;
 };
 
 struct InputLayoutDesc {
-	std::vector<BindingDesc> bindings;
+	int stride;
 	std::vector<AttributeDesc> attributes;
 };
 
@@ -787,7 +781,7 @@ public:
 
 	virtual void BindSamplerStates(int start, int count, SamplerState **state) = 0;
 	virtual void BindTextures(int start, int count, Texture **textures, TextureBindFlags flags = TextureBindFlags::NONE) = 0;
-	virtual void BindVertexBuffers(int start, int count, Buffer **buffers, const int *offsets) = 0;
+	virtual void BindVertexBuffer(Buffer *vertexBuffer, int offset) = 0;
 	virtual void BindIndexBuffer(Buffer *indexBuffer, int offset) = 0;
 
 	// Sometimes it's necessary to bind a texture not created by thin3d, and use with a thin3d pipeline.

--- a/Common/Render/DrawBuffer.cpp
+++ b/Common/Render/DrawBuffer.cpp
@@ -39,13 +39,11 @@ void DrawBuffer::Init(Draw::DrawContext *t3d, Draw::Pipeline *pipeline) {
 Draw::InputLayout *DrawBuffer::CreateInputLayout(Draw::DrawContext *t3d) {
 	using namespace Draw;
 	InputLayoutDesc desc = {
+		sizeof(Vertex),
 		{
-			{ sizeof(Vertex), false },
-		},
-		{
-			{ 0, SEM_POSITION, DataFormat::R32G32B32_FLOAT, 0 },
-			{ 0, SEM_TEXCOORD0, DataFormat::R32G32_FLOAT, 12 },
-			{ 0, SEM_COLOR0, DataFormat::R8G8B8A8_UNORM, 20 },
+			{ SEM_POSITION, DataFormat::R32G32B32_FLOAT, 0 },
+			{ SEM_TEXCOORD0, DataFormat::R32G32_FLOAT, 12 },
+			{ SEM_COLOR0, DataFormat::R8G8B8A8_UNORM, 20 },
 		},
 	};
 

--- a/GPU/Common/DepthBufferCommon.cpp
+++ b/GPU/Common/DepthBufferCommon.cpp
@@ -131,12 +131,10 @@ Draw::Pipeline *CreateReadbackPipeline(Draw::DrawContext *draw, const char *tag,
 	ShaderModule *readbackVs = draw->CreateShaderModule(ShaderStage::Vertex, shaderLanguageDesc.shaderLanguage, (const uint8_t *)vs, strlen(vs), vsTag);
 	_assert_(readbackFs && readbackVs);
 
-	InputLayoutDesc desc = {
+	static const InputLayoutDesc desc = {
+		8,
 		{
-			{ 8, false },
-		},
-		{
-			{ 0, SEM_POSITION, DataFormat::R32G32_FLOAT, 0 },
+			{ SEM_POSITION, DataFormat::R32G32_FLOAT, 0 },
 		},
 	};
 	InputLayout *inputLayout = draw->CreateInputLayout(desc);

--- a/GPU/Common/Draw2D.cpp
+++ b/GPU/Common/Draw2D.cpp
@@ -265,12 +265,10 @@ Draw2DPipeline *Draw2D::Create2DPipeline(std::function<Draw2DPipelineInfo (Shade
 
 	// verts have positions in 2D clip coordinates.
 	static const InputLayoutDesc desc = {
+		16,
 		{
-			{ 16, false },
-		},
-		{
-			{ 0, SEM_POSITION, DataFormat::R32G32_FLOAT, 0 },
-			{ 0, SEM_TEXCOORD0, DataFormat::R32G32_FLOAT, 8 },
+			{ SEM_POSITION, DataFormat::R32G32_FLOAT, 0 },
+			{ SEM_TEXCOORD0, DataFormat::R32G32_FLOAT, 8 },
 		},
 	};
 	InputLayout *inputLayout = draw_->CreateInputLayout(desc);

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -480,13 +480,11 @@ Draw::Pipeline *PresentationCommon::CreatePipeline(std::vector<Draw::ShaderModul
 
 	// TODO: Maybe get rid of color0.
 	InputLayoutDesc inputDesc = {
+		sizeof(Vertex),
 		{
-			{ sizeof(Vertex), false },
-		},
-		{
-			{ 0, pos, DataFormat::R32G32B32_FLOAT, 0 },
-			{ 0, tc, DataFormat::R32G32_FLOAT, 12 },
-			{ 0, SEM_COLOR0, DataFormat::R8G8B8A8_UNORM, 20 },
+			{ pos, DataFormat::R32G32B32_FLOAT, 0 },
+			{ tc, DataFormat::R32G32_FLOAT, 12 },
+			{ SEM_COLOR0, DataFormat::R8G8B8A8_UNORM, 20 },
 		},
 	};
 
@@ -791,7 +789,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 		if (shaderInfo->usePreviousFrame)
 			draw_->BindSamplerStates(2, 1, &sampler);
 
-		draw_->BindVertexBuffers(0, 1, &vdata_, &vertsOffset);
+		draw_->BindVertexBuffer(vdata_, vertsOffset);
 		draw_->Draw(4, 0);
 
 		postShaderOutput = postShaderFramebuffer;
@@ -898,7 +896,7 @@ void PresentationCommon::CopyToOutput(OutputFlags flags, int uvRotation, float u
 		draw_->UpdateDynamicUniformBuffer(&ub, sizeof(ub));
 	}
 
-	draw_->BindVertexBuffers(0, 1, &vdata_, nullptr);
+	draw_->BindVertexBuffer(vdata_, 0);
 
 	Draw::SamplerState *sampler = useNearest ? samplerNearest_ : samplerLinear_;
 	draw_->BindSamplerStates(0, 1, &sampler);

--- a/GPU/Common/StencilCommon.cpp
+++ b/GPU/Common/StencilCommon.cpp
@@ -230,11 +230,9 @@ bool FramebufferManagerCommon::PerformWriteStencilFromMemory(u32 addr, int size,
 		_assert_(stencilUploadFs && stencilUploadVs);
 
 		InputLayoutDesc desc = {
+			8,
 			{
-				{ 8, false },
-			},
-			{
-				{ 0, SEM_POSITION, DataFormat::R32G32_FLOAT, 0 },
+				{ SEM_POSITION, DataFormat::R32G32_FLOAT, 0 },
 			},
 		};
 		InputLayout *inputLayout = draw_->CreateInputLayout(desc);


### PR DESCRIPTION
Don't really see that we'll have much use for this feature, so simplify it away. Only single vertex stream data is now supported by the thin3d API. Multiple ones wasn't working properly across backends previously anyway.

So just code cleanup.