### PR TITLE
String view optimizations (code cleanup)

### DIFF
--- a/Common/File/AndroidContentURI.cpp
+++ b/Common/File/AndroidContentURI.cpp
@@ -1,12 +1,12 @@
 #include "Common/File/AndroidContentURI.h"
 
-bool AndroidContentURI::Parse(const std::string &path) {
+bool AndroidContentURI::Parse(std::string_view path) {
 	const char *prefix = "content://";
 	if (!startsWith(path, prefix)) {
 		return false;
 	}
 
-	std::string components = path.substr(strlen(prefix));
+	std::string_view components = path.substr(strlen(prefix));
 
 	std::vector<std::string> parts;
 	SplitString(components, '/', parts);
@@ -60,7 +60,7 @@ AndroidContentURI AndroidContentURI::WithRootFilePath(const std::string &filePat
 	return uri;
 }
 
-AndroidContentURI AndroidContentURI::WithComponent(const std::string &filePath) {
+AndroidContentURI AndroidContentURI::WithComponent(std::string_view filePath) {
 	AndroidContentURI uri = *this;
 	if (uri.file.empty()) {
 		// Not sure what to do.
@@ -68,16 +68,17 @@ AndroidContentURI AndroidContentURI::WithComponent(const std::string &filePath) 
 	}
 	if (uri.file.back() == ':') {
 		// Special case handling for Document URIs: Treat the ':' as a directory separator too (but preserved in the filename).
-		uri.file = uri.file + filePath;
+		uri.file.append(filePath);
 	} else {
-		uri.file = uri.file + "/" + filePath;
+		uri.file.push_back('/');
+		uri.file.append(filePath);
 	}
 	return uri;
 }
 
-AndroidContentURI AndroidContentURI::WithExtraExtension(const std::string &extension) {
+AndroidContentURI AndroidContentURI::WithExtraExtension(std::string_view extension) {
 	AndroidContentURI uri = *this;
-	uri.file = uri.file + extension;
+	uri.file.append(extension);
 	return uri;
 }
 

--- a/Common/File/AndroidContentURI.cpp
+++ b/Common/File/AndroidContentURI.cpp
@@ -8,7 +8,7 @@ bool AndroidContentURI::Parse(std::string_view path) {
 
 	std::string_view components = path.substr(strlen(prefix));
 
-	std::vector<std::string> parts;
+	std::vector<std::string_view> parts;
 	SplitString(components, '/', parts);
 	if (parts.size() == 3) {
 		// Single file URI.

--- a/Common/File/AndroidContentURI.h
+++ b/Common/File/AndroidContentURI.h
@@ -23,15 +23,15 @@ private:
 	std::string file;
 public:
 	AndroidContentURI() {}
-	explicit AndroidContentURI(const std::string &path) {
+	explicit AndroidContentURI(std::string_view path) {
 		Parse(path);
 	}
 
-	bool Parse(const std::string &path);
+	bool Parse(std::string_view path);
 
 	AndroidContentURI WithRootFilePath(const std::string &filePath);
-	AndroidContentURI WithComponent(const std::string &filePath);
-	AndroidContentURI WithExtraExtension(const std::string &extension);
+	AndroidContentURI WithComponent(std::string_view filePath);
+	AndroidContentURI WithExtraExtension(std::string_view extension);  // The ext string contains the dot.
 	AndroidContentURI WithReplacedExtension(const std::string &oldExtension, const std::string &newExtension) const;
 	AndroidContentURI WithReplacedExtension(const std::string &newExtension) const;
 

--- a/Common/File/AndroidStorage.cpp
+++ b/Common/File/AndroidStorage.cpp
@@ -61,16 +61,16 @@ void Android_RegisterStorageCallbacks(JNIEnv * env, jobject obj) {
 	_dbg_assert_(computeRecursiveDirectorySize);
 }
 
-bool Android_IsContentUri(const std::string &filename) {
+bool Android_IsContentUri(std::string_view filename) {
 	return startsWith(filename, "content://");
 }
 
-int Android_OpenContentUriFd(const std::string &filename, Android_OpenContentUriMode mode) {
+int Android_OpenContentUriFd(std::string_view filename, Android_OpenContentUriMode mode) {
 	if (!g_nativeActivity) {
 		return -1;
 	}
 
-	std::string fname = filename;
+	std::string fname(filename);
 	// PPSSPP adds an ending slash to directories before looking them up.
 	// TODO: Fix that in the caller (or don't call this for directories).
 	if (fname.back() == '/')

--- a/Common/File/AndroidStorage.h
+++ b/Common/File/AndroidStorage.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <string>
+#include <string_view>
 
 #include "Common/File/DirListing.h"
 
@@ -39,8 +40,8 @@ extern std::string g_externalDir;
 
 void Android_StorageSetNativeActivity(jobject nativeActivity);
 
-bool Android_IsContentUri(const std::string &uri);
-int Android_OpenContentUriFd(const std::string &uri, const Android_OpenContentUriMode mode);
+bool Android_IsContentUri(std::string_view uri);
+int Android_OpenContentUriFd(std::string_view uri, const Android_OpenContentUriMode mode);
 StorageError Android_CreateDirectory(const std::string &parentTreeUri, const std::string &dirName);
 StorageError Android_CreateFile(const std::string &parentTreeUri, const std::string &fileName);
 StorageError Android_MoveFile(const std::string &fileUri, const std::string &srcParentUri, const std::string &destParentUri);
@@ -63,8 +64,8 @@ void Android_RegisterStorageCallbacks(JNIEnv * env, jobject obj);
 
 // Stub out the Android Storage wrappers, so that we can avoid ifdefs everywhere.
 
-inline bool Android_IsContentUri(const std::string &uri) { return false; }
-inline int Android_OpenContentUriFd(const std::string &uri, const Android_OpenContentUriMode mode) { return -1; }
+inline bool Android_IsContentUri(std::string_view uri) { return false; }
+inline int Android_OpenContentUriFd(std::string_view uri, const Android_OpenContentUriMode mode) { return -1; }
 inline StorageError Android_CreateDirectory(const std::string &parentTreeUri, const std::string &dirName) { return StorageError::UNKNOWN; }
 inline StorageError Android_CreateFile(const std::string &parentTreeUri, const std::string &fileName) { return StorageError::UNKNOWN; }
 inline StorageError Android_MoveFile(const std::string &fileUri, const std::string &srcParentUri, const std::string &destParentUri) { return StorageError::UNKNOWN; }

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -592,7 +592,7 @@ bool CreateFullPath(const Path &path) {
 		return false;
 	}
 
-	std::vector<std::string> parts;
+	std::vector<std::string_view> parts;
 	SplitString(diff, '/', parts);
 
 	// Probably not necessary sanity check, ported from the old code.
@@ -602,7 +602,7 @@ bool CreateFullPath(const Path &path) {
 	}
 
 	Path curPath = root;
-	for (auto &part : parts) {
+	for (auto part : parts) {
 		curPath /= part;
 		if (!File::Exists(curPath)) {
 			File::CreateDir(curPath);

--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -22,7 +22,7 @@
 #include <sys/stat.h>
 #endif
 
-Path::Path(const std::string &str) {
+Path::Path(std::string_view str) {
 	Init(str);
 }
 
@@ -33,7 +33,7 @@ Path::Path(const std::wstring &str) {
 }
 #endif
 
-void Path::Init(const std::string &str) {
+void Path::Init(std::string_view str) {
 	if (str.empty()) {
 		type_ = PathType::UNDEFINED;
 		path_.clear();
@@ -81,7 +81,7 @@ void Path::Init(const std::string &str) {
 
 // We always use forward slashes internally, we convert to backslash only when
 // converted to a wstring.
-Path Path::operator /(const std::string &subdir) const {
+Path Path::operator /(std::string_view subdir) const {
 	if (type_ == PathType::CONTENT_URI) {
 		AndroidContentURI uri(path_);
 		return Path(uri.WithComponent(subdir).ToString());
@@ -104,18 +104,18 @@ Path Path::operator /(const std::string &subdir) const {
 	return Path(fullPath);
 }
 
-void Path::operator /=(const std::string &subdir) {
+void Path::operator /=(std::string_view subdir) {
 	*this = *this / subdir;
 }
 
-Path Path::WithExtraExtension(const std::string &ext) const {
+Path Path::WithExtraExtension(std::string_view ext) const {
 	if (type_ == PathType::CONTENT_URI) {
 		AndroidContentURI uri(path_);
 		return Path(uri.WithExtraExtension(ext).ToString());
 	}
 
 	_dbg_assert_(!ext.empty() && ext[0] == '.');
-	return Path(path_ + ext);
+	return Path(path_ + std::string(ext));
 }
 
 Path Path::WithReplacedExtension(const std::string &oldExtension, const std::string &newExtension) const {
@@ -161,7 +161,7 @@ std::string Path::GetFilename() const {
 	return path_;
 }
 
-std::string GetExtFromString(const std::string &str) {
+std::string GetExtFromString(std::string_view str) {
 	size_t pos = str.rfind(".");
 	if (pos == std::string::npos) {
 		return "";
@@ -171,7 +171,7 @@ std::string GetExtFromString(const std::string &str) {
 		// Don't want to detect "df/file" from "/as.df/file"
 		return "";
 	}
-	std::string ext = str.substr(pos);
+	std::string ext(str.substr(pos));
 	for (size_t i = 0; i < ext.size(); i++) {
 		ext[i] = tolower(ext[i]);
 	}

--- a/Common/File/Path.h
+++ b/Common/File/Path.h
@@ -3,6 +3,7 @@
 #include "ppsspp_config.h"
 
 #include <string>
+#include <string_view>
 
 #if defined(__APPLE__)
 
@@ -36,11 +37,11 @@ enum class PathType {
 
 class Path {
 private:
-	void Init(const std::string &str);
+	void Init(std::string_view str);
 
 public:
 	Path() : type_(PathType::UNDEFINED) {}
-	explicit Path(const std::string &str);
+	explicit Path(std::string_view str);
 
 #if PPSSPP_PLATFORM(WINDOWS)
 	explicit Path(const std::wstring &str);
@@ -71,13 +72,13 @@ public:
 	bool IsAbsolute() const;
 
 	// Returns a path extended with a subdirectory.
-	Path operator /(const std::string &subdir) const;
+	Path operator /(std::string_view subdir) const;
 
 	// Navigates down into a subdir.
-	void operator /=(const std::string &subdir);
+	void operator /=(std::string_view subdir);
 
 	// File extension manipulation.
-	Path WithExtraExtension(const std::string &ext) const;
+	Path WithExtraExtension(std::string_view ext) const;
 	Path WithReplacedExtension(const std::string &oldExtension, const std::string &newExtension) const;
 	Path WithReplacedExtension(const std::string &newExtension) const;
 
@@ -139,7 +140,7 @@ private:
 };
 
 // Utility function for parsing out file extensions.
-std::string GetExtFromString(const std::string &str);
+std::string GetExtFromString(std::string_view str);
 
 // Utility function for fixing the case of paths. Only present on Unix-like systems.
 

--- a/Common/File/PathBrowser.cpp
+++ b/Common/File/PathBrowser.cpp
@@ -78,7 +78,7 @@ bool LoadRemoteFileList(const Path &url, const std::string &userAgent, bool *can
 		return false;
 	}
 
-	for (std::string item : items) {
+	for (auto &item : items) {
 		// Apply some workarounds.
 		if (item.empty())
 			continue;

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -334,10 +334,10 @@ void GLQueueRunner::RunInitSteps(const FastVec<GLRInitStep> &steps, bool skipGLC
 					step.create_shader.shader->desc.c_str(),
 					infoLog.c_str(),
 					LineNumberString(code).c_str());
-				std::vector<std::string> lines;
+				std::vector<std::string_view> lines;
 				SplitString(errorString, '\n', lines);
-				for (auto &line : lines) {
-					ERROR_LOG(G3D, "%s", line.c_str());
+				for (auto line : lines) {
+					ERROR_LOG(G3D, "%.*s", line.size(), line.data());
 				}
 				if (errorCallback_) {
 					std::string desc = StringFromFormat("Shader compilation failed: %s", step.create_shader.stage == GL_VERTEX_SHADER ? "vertex" : "fragment");

--- a/Common/Input/InputState.cpp
+++ b/Common/Input/InputState.cpp
@@ -86,11 +86,12 @@ int GetAnalogYDirection(InputDeviceID deviceId) {
 }
 
 // NOTE: Changing the format of FromConfigString/ToConfigString breaks controls.ini backwards compatibility.
-InputMapping InputMapping::FromConfigString(const std::string &str) {
-	std::vector<std::string> parts;
+InputMapping InputMapping::FromConfigString(const std::string_view str) {
+	std::vector<std::string_view> parts;
 	SplitString(str, '-', parts);
-	InputDeviceID deviceId = (InputDeviceID)(atoi(parts[0].c_str()));
-	InputKeyCode keyCode = (InputKeyCode)atoi(parts[1].c_str());
+	// We only convert to std::string here to add null terminators for atoi.
+	InputDeviceID deviceId = (InputDeviceID)(atoi(std::string(parts[0]).c_str()));
+	InputKeyCode keyCode = (InputKeyCode)atoi(std::string(parts[1]).c_str());
 
 	InputMapping mapping;
 	mapping.deviceId = deviceId;

--- a/Common/Input/InputState.h
+++ b/Common/Input/InputState.h
@@ -79,7 +79,7 @@ public:
 		_dbg_assert_(direction != 0);
 	}
 
-	static InputMapping FromConfigString(const std::string &str);
+	static InputMapping FromConfigString(std::string_view str);
 	std::string ToConfigString() const;
 
 	InputDeviceID deviceId;

--- a/Common/Net/HTTPHeaders.cpp
+++ b/Common/Net/HTTPHeaders.cpp
@@ -26,12 +26,12 @@ bool RequestHeader::GetParamValue(const char *param_name, std::string *value) co
 	if (!params)
 		return false;
 	std::string p(params);
-	std::vector<std::string> v;
+	std::vector<std::string_view> v;
 	SplitString(p, '&', v);
 	for (size_t i = 0; i < v.size(); i++) {
-		std::vector<std::string> parts;
+		std::vector<std::string_view> parts;
 		SplitString(v[i], '=', parts);
-		DEBUG_LOG(IO, "Param: %s Value: %s", parts[0].c_str(), parts[1].c_str());
+		DEBUG_LOG(IO, "Param: %.*s Value: %.*s", parts[0].size(), parts[0].data(), parts[1].size(), parts[1].data());
 		if (parts[0] == param_name) {
 			*value = parts[1];
 			return true;

--- a/Common/Net/URL.cpp
+++ b/Common/Net/URL.cpp
@@ -115,13 +115,13 @@ const char HEX2DEC[256] =
 	/* F */ N1,N1,N1,N1, N1,N1,N1,N1, N1,N1,N1,N1, N1,N1,N1,N1
 };
 
-std::string UriDecode(const std::string & sSrc)
+std::string UriDecode(std::string_view sSrc)
 {
 	// Note from RFC1630:  "Sequences which start with a percent sign
 	// but are not followed by two hexadecimal characters (0-9, A-F) are reserved
 	// for future extension"
 
-	const unsigned char * pSrc = (const unsigned char *)sSrc.c_str();
+	const unsigned char * pSrc = (const unsigned char *)sSrc.data();
 	const size_t SRC_LEN = sSrc.length();
 	const unsigned char * const SRC_END = pSrc + SRC_LEN;
 	const unsigned char * const SRC_LAST_DEC = SRC_END - 2;   // last decodable '%' 
@@ -129,14 +129,10 @@ std::string UriDecode(const std::string & sSrc)
 	char * const pStart = new char[SRC_LEN];  // Output will be shorter.
 	char * pEnd = pStart;
 
-	while (pSrc < SRC_LAST_DEC)
-	{
-		if (*pSrc == '%')
-		{
+	while (pSrc < SRC_LAST_DEC) {
+		if (*pSrc == '%') {
 			char dec1, dec2;
-			if (N1 != (dec1 = HEX2DEC[*(pSrc + 1)])
-				&& N1 != (dec2 = HEX2DEC[*(pSrc + 2)]))
-			{
+			if (N1 != (dec1 = HEX2DEC[*(pSrc + 1)]) && N1 != (dec2 = HEX2DEC[*(pSrc + 2)])) {
 				*pEnd++ = (dec1 << 4) + dec2;
 				pSrc += 3;
 				continue;
@@ -156,8 +152,7 @@ std::string UriDecode(const std::string & sSrc)
 }
 
 // Only alphanum and underscore is safe.
-const char SAFE[256] =
-{
+static const char SAFE[256] = {
 	/*      0 1 2 3  4 5 6 7  8 9 A B  C D E F */
 	/* 0 */ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
 	/* 1 */ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0,
@@ -180,21 +175,18 @@ const char SAFE[256] =
 	/* F */ 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0
 };
 
-std::string UriEncode(const std::string & sSrc)
-{
+std::string UriEncode(std::string_view sSrc) {
 	const char DEC2HEX[16 + 1] = "0123456789ABCDEF";
-	const unsigned char * pSrc = (const unsigned char *)sSrc.c_str();
+	const unsigned char * pSrc = (const unsigned char *)sSrc.data();
 	const size_t SRC_LEN = sSrc.length();
 	unsigned char * const pStart = new unsigned char[SRC_LEN * 3];
 	unsigned char * pEnd = pStart;
 	const unsigned char * const SRC_END = pSrc + SRC_LEN;
 
-	for (; pSrc < SRC_END; ++pSrc)
-	{
-		if (SAFE[*pSrc]) 
+	for (; pSrc < SRC_END; ++pSrc) {
+		if (SAFE[*pSrc]) {
 			*pEnd++ = *pSrc;
-		else
-		{
+		} else {
 			// escape this char
 			*pEnd++ = '%';
 			*pEnd++ = DEC2HEX[*pSrc >> 4];

--- a/Common/Net/URL.h
+++ b/Common/Net/URL.h
@@ -203,5 +203,5 @@ private:
 };
 
 
-std::string UriDecode(const std::string & sSrc);
-std::string UriEncode(const std::string & sSrc);
+std::string UriDecode(std::string_view sSrc);
+std::string UriEncode(std::string_view sSrc);

--- a/Common/StringUtils.cpp
+++ b/Common/StringUtils.cpp
@@ -284,6 +284,23 @@ std::string_view StripQuotes(std::string_view s) {
 		return s;
 }
 
+void SplitString(std::string_view str, const char delim, std::vector<std::string_view> &output) {
+	size_t next = 0;
+	for (size_t pos = 0, len = str.length(); pos < len; ++pos) {
+		if (str[pos] == delim) {
+			output.emplace_back(str.substr(next, pos - next));
+			// Skip the delimiter itself.
+			next = pos + 1;
+		}
+	}
+
+	if (next == 0) {
+		output.push_back(str);
+	} else if (next < str.length()) {
+		output.emplace_back(str.substr(next));
+	}
+}
+
 void SplitString(std::string_view str, const char delim, std::vector<std::string> &output) {
 	size_t next = 0;
 	for (size_t pos = 0, len = str.length(); pos < len; ++pos) {
@@ -295,7 +312,7 @@ void SplitString(std::string_view str, const char delim, std::vector<std::string
 	}
 
 	if (next == 0) {
-		output.push_back(std::string(str));
+		output.emplace_back(str);
 	} else if (next < str.length()) {
 		output.emplace_back(str.substr(next));
 	}
@@ -320,8 +337,7 @@ static std::string ApplyHtmlEscapes(std::string str) {
 }
 
 // Meant for HTML listings and similar, so supports some HTML escapes.
-void GetQuotedStrings(const std::string& str, std::vector<std::string>& output)
-{
+void GetQuotedStrings(const std::string& str, std::vector<std::string> &output) {
 	size_t next = 0;
 	bool even = 0;
 	for (size_t pos = 0, len = str.length(); pos < len; ++pos) {
@@ -340,15 +356,13 @@ void GetQuotedStrings(const std::string& str, std::vector<std::string>& output)
 	}
 }
 
-std::string ReplaceAll(std::string result, const std::string& src, const std::string& dest)
-{
+std::string ReplaceAll(std::string result, const std::string& src, const std::string& dest) {
 	size_t pos = 0;
 
 	if (src == dest)
 		return result;
 
-	while (1)
-	{
+	while (true) {
 		pos = result.find(src, pos);
 		if (pos == result.npos)
 			break;

--- a/Common/StringUtils.cpp
+++ b/Common/StringUtils.cpp
@@ -284,8 +284,7 @@ std::string_view StripQuotes(std::string_view s) {
 		return s;
 }
 
-void SplitString(const std::string& str, const char delim, std::vector<std::string>& output)
-{
+void SplitString(std::string_view str, const char delim, std::vector<std::string> &output) {
 	size_t next = 0;
 	for (size_t pos = 0, len = str.length(); pos < len; ++pos) {
 		if (str[pos] == delim) {
@@ -296,7 +295,7 @@ void SplitString(const std::string& str, const char delim, std::vector<std::stri
 	}
 
 	if (next == 0) {
-		output.push_back(str);
+		output.push_back(std::string(str));
 	} else if (next < str.length()) {
 		output.emplace_back(str.substr(next));
 	}

--- a/Common/StringUtils.h
+++ b/Common/StringUtils.h
@@ -43,7 +43,7 @@ inline bool startsWith(std::string_view str, std::string_view key) {
 	return !memcmp(str.data(), key.data(), key.size());
 }
 
-inline bool endsWith(const std::string &str, const std::string &what) {
+inline bool endsWith(std::string_view str, std::string_view what) {
 	if (str.size() < what.size())
 		return false;
 	return str.substr(str.size() - what.size()) == what;
@@ -82,7 +82,8 @@ std::string_view StripSpaces(std::string_view s);
 std::string_view StripQuotes(std::string_view s);
 
 // TODO: Make this a lot more efficient by outputting string_views.
-void SplitString(std::string_view str, const char delim, std::vector<std::string>& output);
+void SplitString(std::string_view str, const char delim, std::vector<std::string_view> &output);
+void SplitString(std::string_view str, const char delim, std::vector<std::string> &output);
 
 void GetQuotedStrings(const std::string& str, std::vector<std::string>& output);
 

--- a/Common/StringUtils.h
+++ b/Common/StringUtils.h
@@ -81,7 +81,8 @@ std::string StripQuotes(const std::string &s);
 std::string_view StripSpaces(std::string_view s);
 std::string_view StripQuotes(std::string_view s);
 
-void SplitString(const std::string& str, const char delim, std::vector<std::string>& output);
+// TODO: Make this a lot more efficient by outputting string_views.
+void SplitString(std::string_view str, const char delim, std::vector<std::string>& output);
 
 void GetQuotedStrings(const std::string& str, std::vector<std::string>& output);
 

--- a/Common/UI/PopupScreens.cpp
+++ b/Common/UI/PopupScreens.cpp
@@ -17,9 +17,9 @@ void MessagePopupScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	using namespace UI;
 	UIContext &dc = *screenManager()->getUIContext();
 
-	std::vector<std::string> messageLines;
+	std::vector<std::string_view> messageLines;
 	SplitString(message_, '\n', messageLines);
-	for (const auto &lineOfText : messageLines)
+	for (auto lineOfText : messageLines)
 		parent->Add(new UI::TextView(lineOfText, ALIGN_LEFT | ALIGN_VCENTER, false))->SetTextColor(dc.theme->popupStyle.fgColor);
 }
 

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -927,10 +927,10 @@ private:
 
 class TextView : public InertView {
 public:
-	TextView(const std::string &text, LayoutParams *layoutParams = 0)
+	TextView(std::string_view text, LayoutParams *layoutParams = 0)
 		: InertView(layoutParams), text_(text), textAlign_(0), textColor_(0xFFFFFFFF), small_(false), shadow_(false), focusable_(false), clip_(true) {}
 
-	TextView(const std::string &text, int textAlign, bool small, LayoutParams *layoutParams = 0)
+	TextView(std::string_view text, int textAlign, bool small, LayoutParams *layoutParams = 0)
 		: InertView(layoutParams), text_(text), textAlign_(textAlign), textColor_(0xFFFFFFFF), small_(small), shadow_(false), focusable_(false), clip_(true) {}
 
 	void GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const override;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -81,6 +81,33 @@ static const char *logSectionName = "LogDebug";
 static const char *logSectionName = "Log";
 #endif
 
+std::string GPUBackendToString(GPUBackend backend) {
+	switch (backend) {
+	case GPUBackend::OPENGL:
+		return "OPENGL";
+	case GPUBackend::DIRECT3D9:
+		return "DIRECT3D9";
+	case GPUBackend::DIRECT3D11:
+		return "DIRECT3D11";
+	case GPUBackend::VULKAN:
+		return "VULKAN";
+	}
+	// Intentionally not a default so we get a warning.
+	return "INVALID";
+}
+
+GPUBackend GPUBackendFromString(std::string_view backend) {
+	if (!equalsNoCase(backend, "OPENGL") || backend == "0")
+		return GPUBackend::OPENGL;
+	if (!equalsNoCase(backend, "DIRECT3D9") || backend == "1")
+		return GPUBackend::DIRECT3D9;
+	if (!equalsNoCase(backend, "DIRECT3D11") || backend == "2")
+		return GPUBackend::DIRECT3D11;
+	if (!equalsNoCase(backend, "VULKAN") || backend == "3")
+		return GPUBackend::VULKAN;
+	return GPUBackend::OPENGL;
+}
+
 const char *DefaultLangRegion() {
 	// Unfortunate default.  There's no need to use bFirstRun, since this is only a default.
 	static std::string defaultLangRegion = "en_US";
@@ -513,7 +540,7 @@ bool Config::IsBackendEnabled(GPUBackend backend, bool validate) {
 	return true;
 }
 
-template <typename T, std::string (*FTo)(T), T (*FFrom)(const std::string &)>
+template <typename T, std::string (*FTo)(T), T (*FFrom)(std::string_view)>
 struct ConfigTranslator {
 	static std::string To(int v) {
 		return StringFromInt(v) + " (" + FTo(T(v)) + ")";

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -90,32 +90,8 @@ enum class RestoreSettingsBits : int {
 };
 ENUM_CLASS_BITOPS(RestoreSettingsBits);
 
-inline std::string GPUBackendToString(GPUBackend backend) {
-	switch (backend) {
-	case GPUBackend::OPENGL:
-		return "OPENGL";
-	case GPUBackend::DIRECT3D9:
-		return "DIRECT3D9";
-	case GPUBackend::DIRECT3D11:
-		return "DIRECT3D11";
-	case GPUBackend::VULKAN:
-		return "VULKAN";
-	}
-	// Intentionally not a default so we get a warning.
-	return "INVALID";
-}
-
-inline GPUBackend GPUBackendFromString(const std::string &backend) {
-	if (!strcasecmp(backend.c_str(), "OPENGL") || backend == "0")
-		return GPUBackend::OPENGL;
-	if (!strcasecmp(backend.c_str(), "DIRECT3D9") || backend == "1")
-		return GPUBackend::DIRECT3D9;
-	if (!strcasecmp(backend.c_str(), "DIRECT3D11") || backend == "2")
-		return GPUBackend::DIRECT3D11;
-	if (!strcasecmp(backend.c_str(), "VULKAN") || backend == "3")
-		return GPUBackend::VULKAN;
-	return GPUBackend::OPENGL;
-}
+std::string GPUBackendToString(GPUBackend backend);
+GPUBackend GPUBackendFromString(std::string_view backend);
 
 enum AudioBackendType {
 	AUDIO_BACKEND_AUTO,

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -906,9 +906,9 @@ const char *GetVirtKeyName(int vkey) {
 	return g_vKeyNames[index];
 }
 
-MultiInputMapping MultiInputMapping::FromConfigString(const std::string &str) {
+MultiInputMapping MultiInputMapping::FromConfigString(std::string_view str) {
 	MultiInputMapping out;
-	std::vector<std::string> parts;
+	std::vector<std::string_view> parts;
 	SplitString(str, ':', parts);
 	for (auto iter : parts) {
 		out.mappings.push_back(InputMapping::FromConfigString(iter));

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -114,9 +114,8 @@ namespace KeyMap {
 			mappings.push_back(mapping);
 		}
 		
-		static MultiInputMapping FromConfigString(const std::string &str);
+		static MultiInputMapping FromConfigString(std::string_view str);
 		std::string ToConfigString() const;
-
 		std::string ToVisualString() const;
 
 		bool operator <(const MultiInputMapping &other) {

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -1082,7 +1082,7 @@ void PPGeDrawText(const char *text, float x, float y, const PPGeStyle &style) {
 	PPGeDrawCurrentText(style.color);
 }
 
-static std::string StripTrailingWhite(const std::string &s) {
+static std::string_view StripTrailingWhite(std::string_view s) {
 	size_t lastChar = s.find_last_not_of(" \t\r\n");
 	if (lastChar != s.npos) {
 		return s.substr(0, lastChar + 1);
@@ -1090,8 +1090,8 @@ static std::string StripTrailingWhite(const std::string &s) {
 	return s;
 }
 
-static std::string CropLinesToCount(const std::string &s, int numLines) {
-	std::vector<std::string> lines;
+static std::string_view CropLinesToCount(std::string_view s, int numLines) {
+	std::vector<std::string_view> lines;
 	SplitString(s, '\n', lines);
 	if ((int)lines.size() <= numLines) {
 		return s;
@@ -1099,7 +1099,7 @@ static std::string CropLinesToCount(const std::string &s, int numLines) {
 
 	size_t len = 0;
 	for (int i = 0; i < numLines; ++i) {
-		len += lines[i].length() + 1;
+		len += lines[i].size() + 1;
 	}
 
 	return s.substr(0, len);
@@ -1138,7 +1138,8 @@ void PPGeDrawTextWrapped(const char *text, float x, float y, float wrapWidth, fl
 				actualHeight = (maxLines + 1) * lineHeight;
 				// Add an ellipsis if it's just too long to be readable.
 				// On a PSP, it does this without scaling it down.
-				s2 = StripTrailingWhite(CropLinesToCount(s2, (int)maxLines)) + "\n...";
+				s2 = StripTrailingWhite(CropLinesToCount(s2, (int)maxLines));
+				s2.append("\n...");
 			}
 
 			adjustedStyle.scale *= wrapHeight / actualHeight;
@@ -1164,7 +1165,8 @@ void PPGeDrawTextWrapped(const char *text, float x, float y, float wrapWidth, fl
 			actualHeight = (maxLines + 1) * char_lines_metrics.lineHeight;
 			// Add an ellipsis if it's just too long to be readable.
 			// On a PSP, it does this without scaling it down.
-			s = StripTrailingWhite(CropLinesToCount(s, (int)maxLines)) + "\n...";
+			s = StripTrailingWhite(CropLinesToCount(s, (int)maxLines));
+			s.append("\n...");
 		}
 
 		// Measure the text again after scaling down.


### PR DESCRIPTION
Passing around `string_view`s (pointer and length) often lets us do things with less allocations.

This reduces allocations by quite a bit in path processing. Not that this is a big bottleneck, but it also does a few changes that will be helpful when making some more impactful changes later.