### PR TITLE
RetroAchievements: Add option to allow saving, but not loading, in challenge / hardcore mode.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -283,6 +283,7 @@ static const ConfigSetting achievementSettings[] = {
 	ConfigSetting("AchievementsEncoreMode", &g_Config.bAchievementsEncoreMode, false, CfgFlag::DEFAULT),
 	ConfigSetting("AchievementsUnofficial", &g_Config.bAchievementsUnofficial, false, CfgFlag::DEFAULT),
 	ConfigSetting("AchievementsLogBadMemReads", &g_Config.bAchievementsLogBadMemReads, false, CfgFlag::DEFAULT),
+	ConfigSetting("bAchievementsSaveStateInChallengeMode", &g_Config.bAchievementsSaveStateInChallengeMode, false, CfgFlag::DEFAULT),
 
 	// Achievements login info. Note that password is NOT stored, only a login token.
 	// And that login token is stored separately from the ini, see NativeSaveSecret, but it can also be loaded

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -491,6 +491,7 @@ public:
 	bool bAchievementsUnofficial;
 	bool bAchievementsSoundEffects;
 	bool bAchievementsLogBadMemReads;
+	bool bAchievementsSaveStateInChallengeMode;
 
 	// Positioning of the various notifications
 	int iAchievementsLeaderboardTrackerPos;

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -400,8 +400,12 @@ namespace SaveState
 	void Enqueue(SaveState::Operation op)
 	{
 		if (Achievements::ChallengeModeActive()) {
-			// No savestate operations are permitted, let's just ignore it.
-			return;
+			if (g_Config.bAchievementsSaveStateInChallengeMode && (op.type == SaveState::SAVESTATE_SAVE) || (op.type == SAVESTATE_SAVE_SCREENSHOT)) {
+				// We allow saving in challenge mode if this setting is on.
+			} else {
+				// Operation not allowed
+				return;
+			}
 		}
 
 		std::lock_guard<std::mutex> guard(mutex);

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -200,8 +200,10 @@ SaveSlotView::SaveSlotView(const Path &gameFilename, int slot, bool vertical, UI
 	fv->OnClick.Handle(this, &SaveSlotView::OnScreenshotClick);
 
 	if (SaveState::HasSaveInSlot(gamePath_, slot)) {
-		loadStateButton_ = buttons->Add(new Button(pa->T("Load State"), new LinearLayoutParams(0.0, G_VCENTER)));
-		loadStateButton_->OnClick.Handle(this, &SaveSlotView::OnLoadState);
+		if (!Achievements::ChallengeModeActive()) {
+			loadStateButton_ = buttons->Add(new Button(pa->T("Load State"), new LinearLayoutParams(0.0, G_VCENTER)));
+			loadStateButton_->OnClick.Handle(this, &SaveSlotView::OnLoadState);
+		}
 
 		std::string dateStr = SaveState::GetSlotDateAsString(gamePath_, slot_);
 		if (!dateStr.empty()) {
@@ -286,7 +288,7 @@ void GamePauseScreen::CreateSavestateControls(UI::LinearLayout *leftColumnItems,
 	leftColumnItems->Add(new Spacer(0.0));
 
 	LinearLayout *buttonRow = leftColumnItems->Add(new LinearLayout(ORIENT_HORIZONTAL));
-	if (g_Config.bEnableStateUndo) {
+	if (g_Config.bEnableStateUndo && !Achievements::ChallengeModeActive()) {
 		UI::Choice *loadUndoButton = buttonRow->Add(new Choice(pa->T("Undo last load")));
 		loadUndoButton->SetEnabled(SaveState::HasUndoLoad(gamePath_));
 		loadUndoButton->OnClick.Handle(this, &GamePauseScreen::OnLoadUndo);
@@ -296,7 +298,7 @@ void GamePauseScreen::CreateSavestateControls(UI::LinearLayout *leftColumnItems,
 		saveUndoButton->OnClick.Handle(this, &GamePauseScreen::OnLastSaveUndo);
 	}
 
-	if (g_Config.iRewindSnapshotInterval > 0) {
+	if (g_Config.iRewindSnapshotInterval > 0 && !Achievements::ChallengeModeActive()) {
 		UI::Choice *rewindButton = buttonRow->Add(new Choice(pa->T("Rewind")));
 		rewindButton->SetEnabled(SaveState::CanRewind());
 		rewindButton->OnClick.Handle(this, &GamePauseScreen::OnRewind);
@@ -328,7 +330,7 @@ void GamePauseScreen::CreateViews() {
 		leftColumnItems->Add(new Spacer(5.0));
 	}
 
-	if (!Achievements::ChallengeModeActive()) {
+	if (!Achievements::ChallengeModeActive() || g_Config.bAchievementsSaveStateInChallengeMode) {
 		CreateSavestateControls(leftColumnItems, vertical);
 	} else {
 		// Let's show the active challenges.

--- a/UI/RetroAchievementScreens.cpp
+++ b/UI/RetroAchievementScreens.cpp
@@ -380,6 +380,7 @@ void RetroAchievementsSettingsScreen::CreateDeveloperToolsTab(UI::ViewGroup *vie
 	viewGroup->Add(new CheckBox(&g_Config.bAchievementsEncoreMode, ac->T("Encore Mode")))->SetEnabledPtr(&g_Config.bAchievementsEnable);
 	viewGroup->Add(new CheckBox(&g_Config.bAchievementsUnofficial, ac->T("Unofficial achievements")))->SetEnabledPtr(&g_Config.bAchievementsEnable);
 	viewGroup->Add(new CheckBox(&g_Config.bAchievementsLogBadMemReads, ac->T("Log bad memory accesses")))->SetEnabledPtr(&g_Config.bAchievementsEnable);
+	viewGroup->Add(new CheckBox(&g_Config.bAchievementsSaveStateInChallengeMode, ac->T("Allow Save State in Challenge Mode (but not Load State)")))->SetEnabledPtr(&g_Config.bAchievementsEnable);
 }
 
 void MeasureAchievement(const UIContext &dc, const rc_client_achievement_t *achievement, AchievementRenderStyle style, float *w, float *h) {

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -17,6 +17,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -33,6 +33,7 @@ Achievements = Achievements
 Achievements enabled = Achievements enabled
 Achievements are disabled = Achievements are disabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now
 Challenge indicator = Challenge indicator

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -9,6 +9,7 @@ Achievements = Logros
 Achievements are disabled = Los logros están desactivados
 Achievements enabled = Los logros están activados
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Alrededor mio
 Can't log in to RetroAchievements right now = No se pudo iniciar sesión a RetroAchievements en estos momentos

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -9,6 +9,7 @@ Achievements = Logros
 Achievements are disabled = Los logros están desactivados
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = No se pudo iniciar sesión a RetroAchievements

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -9,6 +9,7 @@ Achievements = Saavutukset
 Achievements are disabled = Saavutukset ovat pois käytöstä
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = RetroAchievements:iin ei voida kirjautua juuri nyt

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -9,6 +9,7 @@ Achievements = Obiettivi
 Achievements enabled = Obiettivi abilitati
 Achievements are disabled = Gli obiettivi sono disabilitati
 Achievements with active challenges = Obiettivi con sfide attive
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Obiettivi quasi completati
 Can't log in to RetroAchievements right now = Impossibile accedere a RetroAchievements in questo momento
 Challenge indicator = Indicatore sfida

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -9,6 +9,7 @@ Achievements = 実績
 Achievements are disabled = 実績は無効化されています
 Achievements enabled = 実績を有効化
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = もう少しで達成する実績
 Around me = 自分の近く
 Can't log in to RetroAchievements right now = 現在RetroAchievementsにログインできません。

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -9,6 +9,7 @@ Achievements = 성과
 Achievements enabled = 성과 활성화
 Achievements are disabled = 성과 비활성화
 Achievements with active challenges = 도전 과제가 활성화된 성과
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = 거의 완료된 성과
 Can't log in to RetroAchievements right now = 지금 RetroAchievements에 로그인할 수 없음
 Challenge indicator = 도전 표시기

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -9,6 +9,7 @@ Achievements = Osiągnięcia
 Achievements are disabled = Osiągnięcia są wyłączone
 Achievements enabled = Osiągnięcia włączone
 Achievements with active challenges = Osiągnięcia z aktywnymi wyzwaniami
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Prawie ukończone osiągnięcia
 Around me = Wokół mnie
 Can't log in to RetroAchievements right now = W tym momencie nie można zalogować do RetroAchievements

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -33,6 +33,7 @@ Achievements = Conquistas
 Achievements enabled = Conquistas ativadas
 Achievements are disabled = As conquistas estão desativadas
 Achievements with active challenges = Conquistas com desafios ativos
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Conquistas quase completadas
 Can't log in to RetroAchievements right now = Não consegue logar no RetroAchievements agora
 Challenge indicator = Indicador do desafio

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -33,6 +33,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -9,6 +9,7 @@ Achievements = Достижения
 Achievements are disabled = Достижения отключены
 Achievements enabled = Достижения включены
 Achievements with active challenges = Достижения с активными испытаниями
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Почти завершенные достижения
 Around me = Вокруг меня
 Can't log in to RetroAchievements right now = Сейчас невозможно войти в RetroAchievements

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements är avstängda
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Nästan avklarade achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Kan inte logga in till RetroAchievements just nu

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -9,6 +9,7 @@ Achievements = เป้าหมายความสำเร็จ
 Achievements enabled = เปิดใช้งาน เป้าหมายความสำเร็จ
 Achievements are disabled = ปิดใช้งาน เป้าหมายความสำเร็จ
 Achievements with active challenges = เป้าหมายความสำเร็จพร้อมด้วยโหมดท้าทาย
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = เป้าหมายความสำเร็จใกล้จะเสร็จสมบูรณ์
 Around me = รอบตัวฉัน
 Can't log in to RetroAchievements right now = ไม่สามารถล็อกอินเข้าไปยัง RetroAchievements ได้ในขณะนี้

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -9,6 +9,7 @@ Achievements = Achievements
 Achievements are disabled = Achievements are disabled
 Achievements enabled = Achievements enabled
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = Around me
 Can't log in to RetroAchievements right now = Can't log in to RetroAchievements right now

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -9,6 +9,7 @@ Achievements = 成就
 Achievements are disabled = 未启用成就功能
 Achievements enabled = 启用成就功能
 Achievements with active challenges = 附有挑战的成就
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = 即将达成的成绩
 Around me = 与我接近的
 Can't log in to RetroAchievements right now = 暂时无法登录到RetroAchievements

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -9,6 +9,7 @@ Achievements = 成就
 Achievements are disabled = 成就已停用
 Achievements enabled = 成就已啟用
 Achievements with active challenges = Achievements with active challenges
+Allow Save State in Challenge Mode (but not Load State) = Allow Save State in Challenge Mode (but not Load State)
 Almost completed achievements = Almost completed achievements
 Around me = 我的位置
 Can't log in to RetroAchievements right now = 目前無法登入至 RetroAchievements


### PR DESCRIPTION
This has been requested many times and is useful for achievement development/debugging, so let's simply have an option allow it. It's not enabled by default since it can be confusing to see save buttons but not load buttons if you don't know the purpose.

It doesn't enable cheating for achievemenst since you still can't load these states in challenge mode.

Part of #17631