### PR TITLE
Fix building on OpenGL ES 2.0 (RPI VideoCore IV)

### DIFF
--- a/Common/GPU/OpenGL/DataFormatGL.cpp
+++ b/Common/GPU/OpenGL/DataFormatGL.cpp
@@ -146,12 +146,14 @@ bool Thin3DFormatToGLFormatAndType(DataFormat fmt, GLuint &internalFormat, GLuin
 		alignment = 16;
 		break;
 
+#ifdef GL_COMPRESSED_RGBA_ASTC_4x4_KHR
 	case DataFormat::ASTC_4x4_UNORM_BLOCK:
 		internalFormat = GL_COMPRESSED_RGBA_ASTC_4x4_KHR;
 		format = GL_RGBA;
 		type = GL_FLOAT;
 		alignment = 16;
 		break;
+#endif
 
 	default:
 		return false;

--- a/Common/GPU/OpenGL/GLFeatures.cpp
+++ b/Common/GPU/OpenGL/GLFeatures.cpp
@@ -592,7 +592,9 @@ bool CheckGLExtensions() {
 		for (int i = 0; i < numCompressedFormats; i++) {
 			switch (compressedFormats[i]) {
 			case GL_COMPRESSED_RGB8_ETC2: gl_extensions.supportsETC2 = true; break;
+#ifdef GL_COMPRESSED_RGBA_ASTC_4x4_KHR
 			case GL_COMPRESSED_RGBA_ASTC_4x4_KHR: gl_extensions.supportsASTC = true; break;
+#endif
 #ifndef USING_GLES2
 			case GL_COMPRESSED_RGBA_S3TC_DXT5_EXT: gl_extensions.supportsBC123 = true; break;
 			case GL_COMPRESSED_RGBA_BPTC_UNORM: gl_extensions.supportsBC7 = true; break;


### PR DESCRIPTION
GL_COMPRESSED_RGBA_ASTC_4x4_KHR is not defined and looks to be an OpenGL ES 3.0 extension.

This fixes building on the Raspberry Pi 1-3 using VideoCore IV OpenGL ES 2.0 headers.