### PR TITLE
An attempt to fix Tekken 6 stuck issue when exiting Lobby

### DIFF
--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -2472,7 +2472,8 @@ u32 NetAdhocctl_Disconnect() {
 	// Library initialized
 	if (netAdhocctlInited) {
 		int iResult, error;
-		hleEatMicro(1000);
+		// We might need to have at least 16ms (1 frame?) delay before the game calls the next Adhocctl syscall for Tekken 6 not to stuck when exiting Lobby
+		hleEatMicro(16667);
 
 		if (isAdhocctlBusy && CoreTiming::IsScheduled(adhocctlNotifyEvent)) {
 			return ERROR_NET_ADHOCCTL_BUSY;


### PR DESCRIPTION
We might need to have at least 16ms (1 frame?) delay on `sceNetAdhocctlDisconnect` before the game calls the next Adhocctl syscall for Tekken 6 not to stuck when exiting Lobby. Fixes https://github.com/hrydgard/ppsspp/issues/18429

PS: Since i don't have any other multiplayer games on this HDD with bad sectors, i'm not sure whether this changes will affect other games or not.