### PR TITLE
OpenXR - Projection matrix on Quest 3 fixed

### DIFF
--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -26,13 +26,6 @@
 #include "Core/KeyMap.h"
 #include "Core/System.h"
 
-enum VRMatrix {
-	VR_PROJECTION_MATRIX,
-	VR_VIEW_MATRIX_LEFT_EYE,
-	VR_VIEW_MATRIX_RIGHT_EYE,
-	VR_MATRIX_COUNT
-};
-
 enum VRMirroring {
 	VR_MIRRORING_AXIS_X,
 	VR_MIRRORING_AXIS_Y,
@@ -51,9 +44,10 @@ static int vr3DGeometryCount = 0;
 static long vrCompat[VR_COMPAT_MAX];
 static bool vrFlatForced = false;
 static bool vrFlatGame = false;
-static float vrMatrix[VR_MATRIX_COUNT][16];
+static double vrFov[2] = {};
 static bool vrMirroring[VR_MIRRORING_COUNT];
 static int vrMirroringVariant = 0;
+static float vrViewMatrix[2][16];
 static XrView vrView[2];
 
 static void (*cbNativeAxis)(const AxisInput *axis, size_t count);
@@ -642,28 +636,16 @@ bool StartVRRender() {
 		}
 		UpdateVRViewMatrices();
 
-		// Update projection matrix
+		// Calculate field of view
 		XrFovf fov = {};
-		for (int eye = 0; eye < ovrMaxNumEyes; eye++) {
-			fov.angleLeft += vrView[eye].fov.angleLeft / 2.0f;
-			fov.angleRight += vrView[eye].fov.angleRight / 2.0f;
-			fov.angleUp += vrView[eye].fov.angleUp / 2.0f;
-			fov.angleDown += vrView[eye].fov.angleDown / 2.0f;
+		for (auto & eye : vrView) {
+			fov.angleLeft += eye.fov.angleLeft / 2.0f;
+			fov.angleRight += eye.fov.angleRight / 2.0f;
+			fov.angleUp += eye.fov.angleUp / 2.0f;
+			fov.angleDown += eye.fov.angleDown / 2.0f;
 		}
-		float nearZ = g_Config.fFieldOfViewPercentage / 200.0f;
-		float tanAngleLeft = tanf(fov.angleLeft);
-		float tanAngleRight = tanf(fov.angleRight);
-		float tanAngleDown = tanf(fov.angleDown);
-		float tanAngleUp = tanf(fov.angleUp);
-		float M[16] = {};
-		M[0] = 2 / (tanAngleRight - tanAngleLeft);
-		M[2] = (tanAngleRight + tanAngleLeft) / (tanAngleRight - tanAngleLeft);
-		M[5] = 2 / (tanAngleUp - tanAngleDown);
-		M[6] = (tanAngleUp + tanAngleDown) / (tanAngleUp - tanAngleDown);
-		M[10] = -1;
-		M[11] = -(nearZ + nearZ);
-		M[14] = -1;
-		memcpy(vrMatrix[VR_PROJECTION_MATRIX], M, sizeof(float) * 16);
+		vrFov[0] = 2.0 / (tan(fov.angleRight) - tan(fov.angleLeft));
+		vrFov[1] = 2.0 / (tan(fov.angleUp) - tan(fov.angleDown));
 
 		// Decide if the scene is 3D or not
 		VR_SetConfigFloat(VR_CONFIG_CANVAS_ASPECT, 480.0f / 272.0f);
@@ -808,19 +790,16 @@ void UpdateVRParams(float* projMatrix) {
 }
 
 void UpdateVRProjection(float* projMatrix, float* leftEye, float* rightEye) {
-	float* hmdProjection = vrMatrix[VR_PROJECTION_MATRIX];
-	for (int i = 0; i < 16; i++) {
-		if ((hmdProjection[i] > 0) != (projMatrix[i] > 0)) {
-			hmdProjection[i] *= -1.0f;
-		}
-	}
+	float hmdProjection[16];
+	memcpy(hmdProjection, projMatrix, 16 * sizeof(float));
+	hmdProjection[0] = vrFov[0];
+	hmdProjection[5] = vrFov[1];
 	memcpy(leftEye, hmdProjection, 16 * sizeof(float));
 	memcpy(rightEye, hmdProjection, 16 * sizeof(float));
 }
 
 void UpdateVRView(float* leftEye, float* rightEye) {
 	float* dst[] = {leftEye, rightEye};
-	float* matrix[] = {vrMatrix[VR_VIEW_MATRIX_LEFT_EYE], vrMatrix[VR_VIEW_MATRIX_RIGHT_EYE]};
 	for (int index = 0; index < 2; index++) {
 
 		// Validate the view matrix
@@ -834,7 +813,7 @@ void UpdateVRView(float* leftEye, float* rightEye) {
 
 		// Get view matrix from the headset
 		Lin::Matrix4x4 hmdView = {};
-		memcpy(hmdView.m, matrix[index], 16 * sizeof(float));
+		memcpy(hmdView.m, vrViewMatrix[index], 16 * sizeof(float));
 
 		// Combine the matrices
 		Lin::Matrix4x4 renderView = hmdView * gameView;
@@ -943,12 +922,12 @@ void UpdateVRViewMatrices() {
 		M[11] += side.z;
 	}
 
-	for (int matrix = VR_VIEW_MATRIX_LEFT_EYE; matrix <= VR_VIEW_MATRIX_RIGHT_EYE; matrix++) {
+	for (int eye = 0; eye < ovrMaxNumEyes; eye++) {
 
 		// Stereoscopy
 		bool vrStereo = !PSP_CoreParameter().compat.vrCompat().ForceMono && g_Config.bEnableStereo;
 		if (vrStereo) {
-			bool mirrored = vrMirroring[VR_MIRRORING_AXIS_Z] ^ (matrix == VR_VIEW_MATRIX_RIGHT_EYE);
+			bool mirrored = vrMirroring[VR_MIRRORING_AXIS_Z] ^ (eye == 1);
 			float dx = fabs(vrView[1].pose.position.x - vrView[0].pose.position.x);
 			float dy = fabs(vrView[1].pose.position.y - vrView[0].pose.position.y);
 			float dz = fabs(vrView[1].pose.position.z - vrView[0].pose.position.z);
@@ -961,6 +940,6 @@ void UpdateVRViewMatrices() {
 			M[11] += separation.z;
 		}
 
-		memcpy(vrMatrix[matrix], M, sizeof(float) * 16);
+		memcpy(vrViewMatrix[eye], M, sizeof(float) * 16);
 	}
 }

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -935,7 +935,6 @@ static const ConfigSetting vrSettings[] = {
 	ConfigSetting("VRCameraPitch", &g_Config.iCameraPitch, 0, CfgFlag::PER_GAME),
 	ConfigSetting("VRCanvasDistance", &g_Config.fCanvasDistance, 12.0f, CfgFlag::DEFAULT),
 	ConfigSetting("VRCanvas3DDistance", &g_Config.fCanvas3DDistance, 3.0f, CfgFlag::DEFAULT),
-	ConfigSetting("VRFieldOfView", &g_Config.fFieldOfViewPercentage, 100.0f, CfgFlag::PER_GAME),
 	ConfigSetting("VRHeadUpDisplayScale", &g_Config.fHeadUpDisplayScale, 0.3f, CfgFlag::PER_GAME),
 	ConfigSetting("VRMotionLength", &g_Config.fMotionLength, 0.5f, CfgFlag::DEFAULT),
 	ConfigSetting("VRHeadRotationScale", &g_Config.fHeadRotationScale, 5.0f, CfgFlag::PER_GAME),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -442,7 +442,6 @@ public:
 	float fCameraSide;
 	float fCanvasDistance;
 	float fCanvas3DDistance;
-	float fFieldOfViewPercentage;
 	float fHeadUpDisplayScale;
 	float fMotionLength;
 	float fHeadRotationScale;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1170,7 +1170,6 @@ void GameSettingsScreen::CreateVRSettings(UI::ViewGroup *vrSettings) {
 	vrSettings->Add(new ItemHeader(vr->T("VR camera")));
 	vrSettings->Add(new PopupSliderChoiceFloat(&g_Config.fCanvasDistance, 1.0f, 15.0f, 12.0f, vr->T("Distance to 2D menus and scenes"), 1.0f, screenManager(), ""));
 	vrSettings->Add(new PopupSliderChoiceFloat(&g_Config.fCanvas3DDistance, 1.0f, 15.0f, 3.0f, vr->T("Distance to 3D scenes when VR disabled"), 1.0f, screenManager(), ""));
-	vrSettings->Add(new PopupSliderChoiceFloat(&g_Config.fFieldOfViewPercentage, 100.0f, 200.0f, 100.0f, vr->T("Field of view scale"), 10.0f, screenManager(), vr->T("% of native FoV")));
 	vrSettings->Add(new CheckBox(&g_Config.bRescaleHUD, vr->T("Heads-up display detection")));
 	PopupSliderChoiceFloat* vrHudScale = vrSettings->Add(new PopupSliderChoiceFloat(&g_Config.fHeadUpDisplayScale, 0.0f, 1.5f, 0.3f, vr->T("Heads-up display scale"), 0.1f, screenManager(), ""));
 	vrHudScale->SetEnabledPtr(&g_Config.bRescaleHUD);

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -1361,13 +1361,11 @@ Download = ‎تحميل
 New version of PPSSPP available = ‎تتوفر نسخة جديدة من البرنامج
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -1353,13 +1353,11 @@ Download = Download
 New version of PPSSPP available = New version of PPSSPP available
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -1353,13 +1353,11 @@ Download = Свали
 New version of PPSSPP available = Налична е нова версия на PPSSPP
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -1353,13 +1353,11 @@ Download = Descarregar
 New version of PPSSPP available = Nova versió de PPSSPP disponible
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -1353,13 +1353,11 @@ Download = Stáhnout
 New version of PPSSPP available = Je dostupná nová verze PPSSPP
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -1353,13 +1353,11 @@ Download = Download
 New version of PPSSPP available = Ny version af PPSSPP tilgængelig
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -1353,13 +1353,11 @@ Download = Herunterladen
 New version of PPSSPP available = Neue PPSSPP Version verfügbar
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -1353,13 +1353,11 @@ Download = Download
 New version of PPSSPP available = New version of PPSSPP available
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -1378,14 +1378,12 @@ Progress: %1% = Progress: %1%
 Screen representation = Screen representation
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Heads-up display scale = Heads-up display scale
 Heads-up display detection = Heads-up display detection

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -1355,13 +1355,11 @@ Download = Descargar
 New version of PPSSPP available = Nueva versión de PPSSPP disponible
 
 [VR]
-% of native FoV = % de campo de visión nativo
 6DoF movement = Movimiento 6DoF
 Camera type = Camera type
 Distance to 2D menus and scenes = Distancia de los menús y escenas 2D
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Escala de campo de visión
 Force 72Hz update = Forzar actualizar a 72Hz
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -1355,13 +1355,11 @@ Download = Descargar
 New version of PPSSPP available = Nueva versión de PPSSPP disponible
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -1353,13 +1353,11 @@ Download = دانلود
 New version of PPSSPP available =  ورژن جدیدی از ppsspp موجود است
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -1353,13 +1353,11 @@ Download = Download
 New version of PPSSPP available = New version of PPSSPP available
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -1344,13 +1344,11 @@ Download = Télécharger
 New version of PPSSPP available = Nouvelle version de PPSSPP disponible
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -1353,13 +1353,11 @@ Download = Descargar
 New version of PPSSPP available = Nova versión de PPSSPP dispoñible
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -1353,13 +1353,11 @@ Download = Κατέβασμα
 New version of PPSSPP available = Νέα διαθέσιμη έκδοση PPSSPP
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -1353,13 +1353,11 @@ Download = Download
 New version of PPSSPP available = New version of PPSSPP available
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -1353,13 +1353,11 @@ Download = Download
 New version of PPSSPP available = New version of PPSSPP available
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -1353,13 +1353,11 @@ Download = Instaliraj
 New version of PPSSPP available = Nova verzija PPSSPP-a je dostupna
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -1353,13 +1353,11 @@ Download = Letöltés
 New version of PPSSPP available = Elérhető a PPSSPP egy újabb verziója
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -1353,13 +1353,11 @@ Download = Unduh
 New version of PPSSPP available = Versi baru PPSSPP tersedia
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -1355,13 +1355,11 @@ Download = Scarica
 New version of PPSSPP available = È disponibile una nuova versione di PPSSPP
 
 [VR]
-% of native FoV = % del FoV nativo
 6DoF movement = Movimento 6DoF
 Camera type = Tipo di telecamera
 Distance to 2D menus and scenes = Distanza dai menu e dalle scene 2D
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Solo per esperti
-Field of view scale = Scalatura "Field of view"
 Force 72Hz update = Forza aggiornamento a 72Hz
 Game camera rotation step per frame = Passo di rotazione della telecamera di gioco per fotogramma
 Game camera uses rotation smoothing = La telecamera di gioco utilizza la rotazione fluida

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -1353,13 +1353,11 @@ Download = ダウンロード
 New version of PPSSPP available = 新しいバージョンのPPSSPPを利用できます
 
 [VR]
-% of native FoV = ネイティブ視野角(FoV)の %
 6DoF movement = 6DoF動作
 Camera type = Camera type
 Distance to 2D menus and scenes = 2Dメニューと空間までの距離
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = 視野角のスケール
 Force 72Hz update = 72Hzに強制的に更新
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -1353,13 +1353,11 @@ Download = Unduh
 New version of PPSSPP available = Versi anyar PPSSPP mpun ono monggo di comot
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -1354,14 +1354,12 @@ Progress: %1% = 진행율: %1%
 Screen representation = 화면 표현
 
 [VR]
-% of native FoV = 실제 시야의 %
 6DoF movement = 6DoF 이동
 Distance to 2D menus and scenes = 2D 메뉴 및 장면까지의 거리
 Distance to 3D scenes when VR disabled = VR 비활성화 시 3D 장면까지의 거리
 Experts only = 전문가 전용
 Game camera rotation step per frame = 프레임당 게임 카메라 회전 단계
 Game camera uses rotation smoothing = 회전 스무딩을 사용하는 게임 카메라
-Field of view scale = 시야 스케일
 Force 72Hz update = 강제 72Hz 업데이트
 Heads-up display scale = 헤드업 디스플레이 스케일
 Heads-up display detection = 헤드업 디스플레이 감지

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -1353,13 +1353,11 @@ Download = ດາວໂຫຼດ
 New version of PPSSPP available = ເວີຊັ່ນໃໝ່ຂອງ PPSSPP ພ້ອມໃຫ້ໂຫຼດແລ້ວ!
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -1353,13 +1353,11 @@ Download = Parsisiūsti
 New version of PPSSPP available = Galima nauja "PPSSPP" versija
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -1353,13 +1353,11 @@ Download = Muat turun
 New version of PPSSPP available = Versi terbaru PPSSPP tersedia
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -1353,13 +1353,11 @@ Download = Downloaden
 New version of PPSSPP available = Er is een nieuwe versie van PPSSPP beschikbaar
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -1353,13 +1353,11 @@ Download = Download
 New version of PPSSPP available = New version of PPSSPP available
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -1359,13 +1359,11 @@ Download = Pobierz
 New version of PPSSPP available = Dostępna jest nowa wersja PPSSPP!
 
 [VR]
-% of native FoV = % natywnego FoV
 6DoF movement = 6DoF movement
 Camera type = Typ kamery
 Distance to 2D menus and scenes = Dystans do elemtentów 2D
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Tylko dla ekspertów
-Field of view scale = Skala pola widzenia
 Force 72Hz update = Wymuś odświeżanie w 72Hz
 Game camera rotation step per frame = Krok obrotu kamery gry na klatkę
 Game camera uses rotation smoothing = Kamera gry wykorzystuje wygładzanie rotacji

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -1378,14 +1378,12 @@ Progress: %1% = Progresso: %1%
 Screen representation = Representação da tela
 
 [VR]
-% of native FoV = % do campo de visão nativo
 6DoF movement = Movimentação do 6DoF
 Distance to 2D menus and scenes = Distância até os menus e cenas 2D
 Distance to 3D scenes when VR disabled = Distância nas cenas em 3D quando a realidade virtual está desativada
 Experts only = Só pra experts
 Game camera rotation step per frame = Passo da rotação da câmera do jogo por frame
 Game camera uses rotation smoothing = A câmera do jogo usa suavização da rotação
-Field of view scale = Escala do campo de visualização
 Force 72Hz update = Forçar atualização em 72 Hz
 Heads-up display scale = Escala do aviso antecipado da exibição
 Heads-up display detection = Detecção do aviso antecipado da exibição

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -1380,13 +1380,11 @@ Progress: %1% = Progresso: %1%
 Screen representation = Representação da tela
 
 [VR]
-% of native FoV = % do campo de visão (FoV) nativo
 6DoF movement = Movimento 6DoF
 Camera type = Tipo de câmera
 Distance to 2D menus and scenes = Distância aos menus e cenas 2D
 Distance to 3D scenes when VR disabled = Distância às cenas 3D quando a realidade virtual estiver desativada
 Experts only = Apenas programadores
-Field of view scale = Escala do campo de visão (FoV)
 Force 72Hz update = Forçar taxa de atualização de 72Hz
 Game camera rotation step per frame = Passo da rotação da câmera do jogo por frame
 Game camera uses rotation smoothing = A câmera do jogo usa suavização da rotação

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -1354,13 +1354,11 @@ Download = Descarcă
 New version of PPSSPP available = Nouă versiune de PPSSPP disponibilă.
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -1353,13 +1353,11 @@ Download = Загрузить
 New version of PPSSPP available = Доступна новая версия PPSSPP
 
 [VR]
-% of native FoV = % стандартного угла обзора
 6DoF movement = Движение 6DoF
 Camera type = Тип камеры
 Distance to 2D menus and scenes = Расстояние до 2D-меню и сцен
 Distance to 3D scenes when VR disabled = Расстояние до 3D-сцен при отключенной ВР
 Experts only = Только для экспертов
-Field of view scale = Масштаб угла обзора
 Force 72Hz update = Принудительная частота обновления 72 Гц
 Game camera rotation step per frame = Шаг поворота внутриигровой камеры за 1 кадр
 Game camera uses rotation smoothing = При повороте внутриигровой камеры используется сглаживание

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -1354,13 +1354,11 @@ Download = Ladda ner
 New version of PPSSPP available = Ny version av PPSSPP tillgänglig
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF rörelse
 Camera type = Kameratyp
 Distance to 2D menus and scenes = Avstånd till 2D-menyer och scener
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view-skala
 Force 72Hz update = Tvinga 72Hz uppdateringsfrekvens
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -1353,13 +1353,11 @@ Download = Download
 New version of PPSSPP available = Meron nang bagong bersiyon ang PPSSPP
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -1370,13 +1370,11 @@ Download = ดาวน์โหลด
 New version of PPSSPP available = PPSSPP เวอร์ชั่นใหม่พร้อมให้ดาวน์โหลดแล้ว!
 
 [VR]
-% of native FoV = % ของค่า FoV ดั้งเดิม
 6DoF movement = การเคลื่อนไหวแบบ 6DoF
 Camera type = ปรับแต่งประเภทมุมกล้อง
 Distance to 2D menus and scenes = ระยะห่างจากเมนูสองมิติ และฉาก
 Distance to 3D scenes when VR disabled = ระยะห่างจากฉากสามมิติ เมื่อ VR ถูกปิดใช้งาน
 Experts only = สำหรับผู้เชี่ยวชาญเท่านั้น
-Field of view scale = สเกลของมุมมองพื้นที่รอบตัว
 Force 72Hz update = บังคับรีเฟรชเรทไปที่ 72Hz
 Game camera rotation step per frame = สเต็ปการหมุนมุมกล้องเกมต่อเฟรม
 Game camera uses rotation smoothing = มุมกล้องเกมใช้การหมุนแบบนุ่มนวล

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -1354,13 +1354,11 @@ Download = İndir
 New version of PPSSPP available = PPSSPP'nin yeni versiyonu mevcut
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -1353,13 +1353,11 @@ Download = Завантажити
 New version of PPSSPP available = Доступна нова версія PPSSPP
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -1353,13 +1353,11 @@ Download = Tải về
 New version of PPSSPP available = Đã có phiên bản mới của PPSSPP
 
 [VR]
-% of native FoV = % of native FoV
 6DoF movement = 6DoF movement
 Camera type = Camera type
 Distance to 2D menus and scenes = Distance to 2D menus and scenes
 Distance to 3D scenes when VR disabled = Distance to 3D scenes when VR disabled
 Experts only = Experts only
-Field of view scale = Field of view scale
 Force 72Hz update = Force 72Hz update
 Game camera rotation step per frame = Game camera rotation step per frame
 Game camera uses rotation smoothing = Game camera uses rotation smoothing

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -1356,13 +1356,11 @@ No settings matched '%1' = 没有找到选项“%1”
 Search term = 搜索关键词
 
 [VR]
-% of native FoV = 原生视角的%
 6DoF movement = 6自由度移动
 Camera type = 相机类型
 Distance to 2D menus and scenes = 2D菜单和场景的距离
 Distance to 3D scenes when VR disabled = 3D场景的距离 (VR关闭时)
 Experts only = 专家模式
-Field of view scale = 视角比例
 Force 72Hz update = 强制72Hz刷新
 Game camera rotation step per frame = 游戏视角每帧灵敏度
 Game camera uses rotation smoothing = 游戏视角平滑转动

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -1354,13 +1354,11 @@ Progress: %1% = 進度：%1%
 Screen representation = 螢幕呈現
 
 [VR]
-% of native FoV = % 於原生視野
 6DoF movement = 六自由度移動
 Camera type = 相機類型
 Distance to 2D menus and scenes = 2D 選單及場景距離
 Distance to 3D scenes when VR disabled = VR 停用時的 3D 場景距離
 Experts only = 僅限專家
-Field of view scale = 視野縮放
 Force 72Hz update = 強制 72Hz 更新
 Game camera rotation step per frame = 遊戲相機每影格旋轉步數
 Game camera uses rotation smoothing = 遊戲相機使用旋轉平滑


### PR DESCRIPTION
This fixes many games on Meta Quest 3. For some reason the previous calculation of projection matrix didn't work on Quest 3. This is a simplified version which is not compatible with FOV feature. I think it is good to remove the FOV feature, it worked only if watching forwards anyway. It would be good to have it on 2D screens but for VR it is bad.