### PR TITLE
Vulkan: Allow MSAA on modern-ish mobile devices, but add a little warning sign.

### DIFF
--- a/Common/UI/PopupScreens.cpp
+++ b/Common/UI/PopupScreens.cpp
@@ -36,7 +36,7 @@ void MessagePopupScreen::OnCompleted(DialogResult result) {
 void ListPopupScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	using namespace UI;
 
-	listView_ = parent->Add(new ListView(&adaptor_, hidden_)); //, new LinearLayoutParams(1.0)));
+	listView_ = parent->Add(new ListView(&adaptor_, hidden_, icons_)); //, new LinearLayoutParams(1.0)));
 	listView_->SetMaxHeight(screenManager()->getUIContext()->GetBounds().h - 140);
 	listView_->OnChoice.Handle(this, &ListPopupScreen::OnListChoice);
 }
@@ -105,6 +105,7 @@ UI::EventReturn PopupMultiChoice::HandleClick(UI::EventParams &e) {
 	ListPopupScreen *popupScreen = new ListPopupScreen(ChopTitle(text_), choices, *value_ - minVal_,
 		std::bind(&PopupMultiChoice::ChoiceCallback, this, std::placeholders::_1));
 	popupScreen->SetHiddenChoices(hidden_);
+	popupScreen->SetChoiceIcons(icons_);
 	if (e.v)
 		popupScreen->SetPopupOrigin(e.v);
 	screenManager_->push(popupScreen);
@@ -623,8 +624,12 @@ void AbstractChoiceWithValueDisplay::Draw(UIContext &dc) {
 		textPadding_.right = w + paddingX;
 
 		Choice::Draw(dc);
+		int imagePadding = 0;
+		if (rightIconImage_.isValid()) {
+			imagePadding = bounds_.h;
+		}
 		dc.SetFontScale(scale, scale);
-		Bounds valueBounds(bounds_.x2() - textPadding_.right, bounds_.y, w, bounds_.h);
+		Bounds valueBounds(bounds_.x2() - textPadding_.right - imagePadding, bounds_.y, w, bounds_.h);
 		dc.DrawTextRect(valueText.c_str(), valueBounds, style.fgColor, ALIGN_RIGHT | ALIGN_VCENTER | FLAG_WRAP_TEXT);
 		dc.SetFontScale(1.0f, 1.0f);
 	} else {

--- a/Common/UI/PopupScreens.h
+++ b/Common/UI/PopupScreens.h
@@ -32,6 +32,9 @@ public:
 	void SetHiddenChoices(std::set<int> hidden) {
 		hidden_ = hidden;
 	}
+	void SetChoiceIcons(std::map<int, ImageID> icons) {
+		icons_ = icons;
+	}
 	const char *tag() const override { return "listpopup"; }
 
 	UI::Event OnChoice;
@@ -49,6 +52,7 @@ private:
 	std::function<void(int)> callback_;
 	bool showButtons_ = false;
 	std::set<int> hidden_;
+	std::map<int, ImageID> icons_;
 };
 
 class MessagePopupScreen : public PopupScreen {
@@ -231,6 +235,9 @@ public:
 	void HideChoice(int c) {
 		hidden_.insert(c);
 	}
+	void SetChoiceIcon(int c, ImageID id) {
+		icons_[c] = id;
+	}
 
 	UI::Event OnChoice;
 
@@ -254,6 +261,7 @@ private:
 	std::string valueText_;
 	bool restoreFocus_ = false;
 	std::set<int> hidden_;
+	std::map<int, ImageID> icons_;
 };
 
 // Allows passing in a dynamic vector of strings. Saves the string.

--- a/Common/UI/ScrollView.h
+++ b/Common/UI/ScrollView.h
@@ -89,7 +89,7 @@ private:
 class ListAdaptor {
 public:
 	virtual ~ListAdaptor() {}
-	virtual View *CreateItemView(int index) = 0;
+	virtual View *CreateItemView(int index, ImageID *optionalImageID) = 0;
 	virtual int GetNumItems() = 0;
 	virtual bool AddEventCallback(View *view, std::function<EventReturn(EventParams &)> callback) { return false; }
 	virtual std::string GetTitle(int index) const { return ""; }
@@ -100,7 +100,7 @@ public:
 class ChoiceListAdaptor : public ListAdaptor {
 public:
 	ChoiceListAdaptor(const char *items[], int numItems) : items_(items), numItems_(numItems) {}
-	View *CreateItemView(int index) override;
+	View *CreateItemView(int index, ImageID *optionalImageID) override;
 	int GetNumItems() override { return numItems_; }
 	bool AddEventCallback(View *view, std::function<EventReturn(EventParams &)> callback) override;
 
@@ -114,7 +114,7 @@ class StringVectorListAdaptor : public ListAdaptor {
 public:
 	StringVectorListAdaptor() : selected_(-1) {}
 	StringVectorListAdaptor(const std::vector<std::string> &items, int selected = -1) : items_(items), selected_(selected) {}
-	View *CreateItemView(int index) override;
+	View *CreateItemView(int index, ImageID *optionalImageID) override;
 	int GetNumItems() override { return (int)items_.size(); }
 	bool AddEventCallback(View *view, std::function<EventReturn(EventParams &)> callback) override;
 	void SetSelected(int sel) override { selected_ = sel; }
@@ -130,7 +130,7 @@ private:
 // In the future, it might be smart and load/unload items as they go, but currently not.
 class ListView : public ScrollView {
 public:
-	ListView(ListAdaptor *a, std::set<int> hidden = std::set<int>(), LayoutParams *layoutParams = 0);
+	ListView(ListAdaptor *a, std::set<int> hidden = std::set<int>(), std::map<int, ImageID> icons = std::map<int, ImageID>(), LayoutParams *layoutParams = 0);
 
 	int GetSelected() { return adaptor_->GetSelected(); }
 	void Measure(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert) override;
@@ -146,6 +146,7 @@ private:
 	LinearLayout *linLayout_;
 	float maxHeight_;
 	std::set<int> hidden_;
+	std::map<int, ImageID> icons_;
 };
 
 }  // namespace UI

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -301,12 +301,19 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 			System_PostUIMessage(UIMessage::GPU_RENDER_RESIZED);
 			return UI::EVENT_DONE;
 		});
-		msaaChoice->SetDisabledPtr(&g_Config.bSoftwareRendering);
+		if (g_Config.iMultiSampleLevel > 1 && draw->GetDeviceCaps().isTilingGPU) {
+			msaaChoice->SetIcon(ImageID("I_WARNING"), 0.7f);
+		}
+		msaaChoice->SetEnabledFunc([] {
+			return !g_Config.bSoftwareRendering && !g_Config.bSkipBufferEffects;
+		});
 
 		// Hide unsupported levels.
 		for (int i = 1; i < 5; i++) {
 			if ((draw->GetDeviceCaps().multiSampleLevelsMask & (1 << i)) == 0) {
 				msaaChoice->HideChoice(i);
+			} else if (i > 0 && draw->GetDeviceCaps().isTilingGPU) {
+				msaaChoice->SetChoiceIcon(i, ImageID("I_WARNING"));
 			}
 		}
 	}


### PR DESCRIPTION
MSAA on tiler GPUs can consume huge amounts of bandwidth if you also crank up the render resolution, the way we currently use it (we are not yet able to eliminate heavy load/store operations), so let's be a little bit careful.