### PR TITLE
Add mouse wheel scrolling support for Android to the UI

### DIFF
--- a/Common/UI/ScrollView.cpp
+++ b/Common/UI/ScrollView.cpp
@@ -119,7 +119,7 @@ bool ScrollView::Key(const KeyInput &input) {
 	if (input.flags & KEY_DOWN) {
 		if ((input.keyCode == NKCODE_EXT_MOUSEWHEEL_UP || input.keyCode == NKCODE_EXT_MOUSEWHEEL_DOWN) &&
 			(input.flags & KEY_HASWHEELDELTA)) {
-			scrollSpeed = (float)(short)(input.flags >> 16) * 1.25f;  // Fudge factor
+			scrollSpeed = (float)(short)(input.flags >> 16) * 1.25f;  // Fudge factor. TODO: Should be moved to the backends.
 		}
 
 		switch (input.keyCode) {

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1235,7 +1235,25 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_mouseWheelEvent(
 	JNIEnv *env, jclass, jint stick, jfloat x, jfloat y) {
 	if (!renderer_inited)
 		return false;
-	// TODO: Support mousewheel for android
+	// TODO: Mousewheel should probably be an axis instead.
+	int wheelDelta = y * 30.0f;
+	if (wheelDelta > 500) wheelDelta = 500;
+	if (wheelDelta < -500) wheelDelta = -500;
+
+	KeyInput key;
+	key.deviceId = DEVICE_ID_MOUSE;
+	if (wheelDelta < 0) {
+		key.keyCode = NKCODE_EXT_MOUSEWHEEL_DOWN;
+		wheelDelta = -wheelDelta;
+	} else {
+		key.keyCode = NKCODE_EXT_MOUSEWHEEL_UP;
+	}
+	// There's no separate keyup event for mousewheel events,
+	// so we release it with a slight delay.
+	key.flags = KEY_DOWN | KEY_HASWHEELDELTA | (wheelDelta << 16);
+	NativeKey(key);
+	key.flags = KEY_UP;
+	NativeKey(key);
 	return true;
 }
 

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -1024,7 +1024,7 @@ public abstract class NativeActivity extends Activity {
 				// process the mouse hover movement...
 				return true;
 			case MotionEvent.ACTION_SCROLL:
-				NativeApp.mouseWheelEvent(event.getX(), event.getY());
+				NativeApp.mouseWheelEvent(event.getAxisValue(MotionEvent.AXIS_HSCROLL), event.getAxisValue(MotionEvent.AXIS_VSCROLL));
 				return true;
 			}
 		}


### PR DESCRIPTION
Fixes #18471

Tested on a Poco F4 phone with a generic Bluetooth mouse.