### PR TITLE
Vulkan: Fix double-free in the low-memory fallback. Also, reject too-big textures

### DIFF
--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -387,7 +387,7 @@ protected:
 	virtual void Unbind() = 0;
 	virtual void ReleaseTexture(TexCacheEntry *entry, bool delete_them) = 0;
 	void DeleteTexture(TexCache::iterator it);
-	void Decimate(bool forcePressure = false);
+	void Decimate(TexCacheEntry *exceptThisOne, bool forcePressure);  // forcePressure defaults to false.
 
 	void ApplyTextureFramebuffer(VirtualFramebuffer *framebuffer, GETextureFormat texFormat, RasterChannel channel);
 	void ApplyTextureDepal(TexCacheEntry *entry);

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -921,9 +921,6 @@ void GPUCommon::Execute_Call(u32 op, u32 diff) {
 }
 
 void GPUCommon::DoExecuteCall(u32 target) {
-	// Saint Seiya needs correct support for relative calls.
-	const u32 retval = currentList->pc + 4;
-
 	// Bone matrix optimization - many games will CALL a bone matrix (!).
 	// We don't optimize during recording - so the matrix data gets recorded.
 	if (!debugRecording_ && Memory::IsValidRange(target, 13 * 4) && (Memory::ReadUnchecked_U32(target) >> 24) == GE_CMD_BONEMATRIXDATA) {
@@ -944,7 +941,7 @@ void GPUCommon::DoExecuteCall(u32 target) {
 		// TODO: UpdateState(GPUSTATE_ERROR) ?
 	} else {
 		auto &stackEntry = currentList->stack[currentList->stackptr++];
-		stackEntry.pc = retval;
+		stackEntry.pc = currentList->pc + 4;
 		stackEntry.offsetAddr = gstate_c.offsetAddr;
 		// The base address is NOT saved/restored for a regular call.
 		UpdatePC(currentList->pc, target - 4);


### PR DESCRIPTION
We incorrectly assumed that an "entry" would still be valid after decimate, but it might not be, so let's add an exclusion argument to Decimate.

Also, if a game specifies a texture larger than 512x512 and it's not a remaster, we're probably executing a bogus display list, and just need to try not to crash, in the hopes that the situation can rectify itself.