### PR TITLE
Handle block transfers from RAM to depth buffers.

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -511,8 +511,8 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(Framebuffer
 		vfb->usageFlags = FB_USAGE_RENDER_COLOR;
 
 		u32 colorByteSize = vfb->BufferByteSize(RASTER_COLOR);
-		if (Memory::IsVRAMAddress(params.fb_address) && params.fb_address + colorByteSize > framebufRangeEnd_) {
-			framebufRangeEnd_ = params.fb_address + colorByteSize;
+		if (Memory::IsVRAMAddress(params.fb_address) && params.fb_address + colorByteSize > framebufColorRangeEnd_) {
+			framebufColorRangeEnd_ = params.fb_address + colorByteSize;
 		}
 
 		// This is where we actually create the framebuffer. The true is "force".
@@ -2348,8 +2348,8 @@ VirtualFramebuffer *FramebufferManagerCommon::CreateRAMFramebuffer(uint32_t fbAd
 	vfbs_.push_back(vfb);
 
 	u32 byteSize = vfb->BufferByteSize(channel);
-	if (fbAddress + byteSize > framebufRangeEnd_) {
-		framebufRangeEnd_ = fbAddress + byteSize;
+	if (fbAddress + byteSize > framebufColorRangeEnd_) {
+		framebufColorRangeEnd_ = fbAddress + byteSize;
 	}
 
 	return vfb;
@@ -2525,7 +2525,7 @@ bool FramebufferManagerCommon::NotifyBlockTransferBefore(u32 dstBasePtr, int dst
 			dstStride *= 2;
 			width *= 2;
 		}
-	} else if (!MayIntersectFramebuffer(srcBasePtr) && !MayIntersectFramebuffer(dstBasePtr)) {
+	} else if (!MayIntersectFramebufferColor(srcBasePtr) && !MayIntersectFramebufferColor(dstBasePtr)) {
 		return false;
 	}
 
@@ -2710,7 +2710,7 @@ void FramebufferManagerCommon::NotifyBlockTransferAfter(u32 dstBasePtr, int dstS
 		}
 	}
 
-	if (MayIntersectFramebuffer(srcBasePtr) || MayIntersectFramebuffer(dstBasePtr)) {
+	if (MayIntersectFramebufferColor(srcBasePtr) || MayIntersectFramebufferColor(dstBasePtr)) {
 		// TODO: Figure out how we can avoid repeating the search here.
 
 		BlockTransferRect dstRect{};

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -382,6 +382,7 @@ public:
 		return useBufferedRendering_;
 	}
 
+	// TODO: Maybe just include the last depth buffer address in this, too.
 	bool MayIntersectFramebufferColor(u32 start) const {
 		// Clear the cache/kernel bits.
 		start &= 0x3FFFFFFF;

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -382,13 +382,13 @@ public:
 		return useBufferedRendering_;
 	}
 
-	bool MayIntersectFramebuffer(u32 start) const {
+	bool MayIntersectFramebufferColor(u32 start) const {
 		// Clear the cache/kernel bits.
 		start &= 0x3FFFFFFF;
 		if (Memory::IsVRAMAddress(start))
 			start &= 0x041FFFFF;
 		// Most games only have two framebuffers at the start.
-		if (start >= framebufRangeEnd_ || start < PSP_GetVidMemBase()) {
+		if (start >= framebufColorRangeEnd_ || start < PSP_GetVidMemBase()) {
 			return false;
 		}
 		return true;
@@ -572,7 +572,7 @@ protected:
 	Draw::Framebuffer *currentFramebufferCopy_ = nullptr;
 
 	// The range of PSP memory that may contain FBOs.  So we can skip iterating.
-	u32 framebufRangeEnd_ = 0;
+	u32 framebufColorRangeEnd_ = 0;
 
 	bool useBufferedRendering_ = false;
 	bool postShaderIsUpscalingFilter_ = false;

--- a/GPU/Common/StencilCommon.cpp
+++ b/GPU/Common/StencilCommon.cpp
@@ -166,7 +166,7 @@ bool FramebufferManagerCommon::PerformWriteStencilFromMemory(u32 addr, int size,
 	using namespace Draw;
 
 	addr &= 0x3FFFFFFF;
-	if (!MayIntersectFramebuffer(addr)) {
+	if (!MayIntersectFramebufferColor(addr)) {
 		return false;
 	}
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1853,7 +1853,7 @@ void GPUCommon::DoBlockTransfer(u32 skipDrawReason) {
 
 bool GPUCommon::PerformMemoryCopy(u32 dest, u32 src, int size, GPUCopyFlag flags) {
 	// Track stray copies of a framebuffer in RAM. MotoGP does this.
-	if (framebufferManager_->MayIntersectFramebuffer(src) || framebufferManager_->MayIntersectFramebuffer(dest)) {
+	if (framebufferManager_->MayIntersectFramebufferColor(src) || framebufferManager_->MayIntersectFramebufferColor(dest)) {
 		if (!framebufferManager_->NotifyFramebufferCopy(src, dest, size, flags, gstate_c.skipDrawReason)) {
 			// We use matching values in PerformReadbackToMemory/PerformWriteColorFromMemory.
 			// Since they're identical we don't need to copy.
@@ -1881,7 +1881,7 @@ bool GPUCommon::PerformMemoryCopy(u32 dest, u32 src, int size, GPUCopyFlag flags
 
 bool GPUCommon::PerformMemorySet(u32 dest, u8 v, int size) {
 	// This may indicate a memset, usually to 0, of a framebuffer.
-	if (framebufferManager_->MayIntersectFramebuffer(dest)) {
+	if (framebufferManager_->MayIntersectFramebufferColor(dest)) {
 		Memory::Memset(dest, v, size, "GPUMemset");
 		if (!framebufferManager_->NotifyFramebufferCopy(dest, dest, size, GPUCopyFlag::MEMSET, gstate_c.skipDrawReason)) {
 			InvalidateCache(dest, size, GPU_INVALIDATE_HINT);
@@ -1920,7 +1920,7 @@ void GPUCommon::PerformWriteFormattedFromMemory(u32 addr, int size, int frameWid
 }
 
 bool GPUCommon::PerformWriteStencilFromMemory(u32 dest, int size, WriteStencil flags) {
-	if (framebufferManager_->MayIntersectFramebuffer(dest)) {
+	if (framebufferManager_->MayIntersectFramebufferColor(dest)) {
 		framebufferManager_->PerformWriteStencilFromMemory(dest, size, flags);
 		return true;
 	}

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -773,7 +773,7 @@ void GPUCommonHW::InvalidateCache(u32 addr, int size, GPUInvalidationType type) 
 	else
 		textureCache_->InvalidateAll(type);
 
-	if (type != GPU_INVALIDATE_ALL && framebufferManager_->MayIntersectFramebuffer(addr)) {
+	if (type != GPU_INVALIDATE_ALL && framebufferManager_->MayIntersectFramebufferColor(addr)) {
 		// Vempire invalidates (with writeback) after drawing, but before blitting.
 		// TODO: Investigate whether we can get this to work some other way.
 		if (type == GPU_INVALIDATE_SAFE) {

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1573,6 +1573,9 @@ ULES01070 = true
 ULES01071 = true
 ULUS10347 = true
 
+# Hayate no Gotoku!! Nightmare Paradise - see issue #17878
+ULJM05416 = true
+
 [DaxterRotatedAnalogStick]
 # Daxter (see issue #17015)
 UCUS98618 = true


### PR DESCRIPTION
Reuses the existing compat flag BlockTransferDepth.

I do aim to remove that compat flag in the future, it's probably not even necessary here, it's just that general depth block transfers were already gated on it.

Fixes #17878

~~Before merge: Thinking of slightly cleaning it up by fixing the matching logic to accept 32-bit transfers to depth, instead of converting the transfer to 16-bit.~~ Done!