### PR TITLE
Beats: Fix file permissions on FAT so it can see custom MP3s.

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -917,13 +917,15 @@ void __IoCopyDate(ScePspDateTime& date_out, const tm& date_in)
 
 static void __IoGetStat(SceIoStat *stat, PSPFileInfo &info) {
 	memset(stat, 0xfe, sizeof(SceIoStat));
-	stat->st_size = (s64) info.size;
 
 	int type, attr;
-	if (info.type & FILETYPE_DIRECTORY)
-		type = SCE_STM_FDIR, attr = TYPE_DIR;
-	else
-		type = SCE_STM_FREG, attr = TYPE_FILE;
+	if (info.type & FILETYPE_DIRECTORY) {
+		type = SCE_STM_FDIR;
+		attr = TYPE_DIR;
+	} else {
+		type = SCE_STM_FREG;
+		attr = TYPE_FILE;
+	}
 
 	stat->st_mode = type | info.access;
 	stat->st_attr = attr;
@@ -2504,6 +2506,8 @@ static u32 sceIoDread(int id, u32 dirent_addr) {
 		bool isFAT = pspFileSystem.FlagsFromFilename(dir->name) & FileSystemFlags::SIMULATE_FAT32;
 		// Only write d_private for memory stick
 		if (isFAT) {
+			// All files look like they're executable on FAT. This is required for Beats, see issue #14812
+			entry->d_stat.st_mode |= 0111;
 			// write d_private for supporting Custom BGM
 			// ref JPCSP https://code.google.com/p/jpcsp/source/detail?r=3468
 			if (Memory::IsValidAddress(entry->d_private)){


### PR DESCRIPTION
On FAT file systems, files look like they have executable permission. For some reason Beats checks for this.

Unfortunately, this doesn't really make custom music playable - while they now display, they seem to start stuttering after a short while. Or it's just my files...

Also, should write a pspautotest...