### PR TITLE
Homebrew Store: Do uninstalls on a thread

### DIFF
--- a/Common/File/AndroidStorage.cpp
+++ b/Common/File/AndroidStorage.cpp
@@ -245,8 +245,9 @@ std::vector<File::FileInfo> Android_ListContentUri(const std::string &path, bool
 	env->DeleteLocalRef(fileList);
 
 	double elapsed = time_now_d() - start;
-	if (elapsed > 0.1) {
-		INFO_LOG(FILESYS, "Listing directory on content URI took %0.3f s (%d files)", elapsed, (int)items.size());
+	double threshold = 0.1;
+	if (elapsed >= threshold) {
+		INFO_LOG(FILESYS, "Listing directory on content URI '%s' took %0.3f s (%d files, log threshold = %0.3f)", path.c_str(), elapsed, (int)items.size(), threshold);
 	}
 	return items;
 }

--- a/Core/Util/GameDB.cpp
+++ b/Core/Util/GameDB.cpp
@@ -128,8 +128,12 @@ bool GameDB::GetGameInfos(std::string_view id, std::vector<GameDBInfo> *infos) {
 			// Ignore version and stuff for now
 			if (IDMatches(id, serial)) {
 				GameDBInfo info;
-				sscanf(line.crc.data(), "%08x", &info.crc);
-				sscanf(line.size.data(), "%llu", &info.size);
+				if (1 != sscanf(line.crc.data(), "%08x", &info.crc)) {
+					continue;
+				}
+				if (1 != sscanf(line.size.data(), "%llu", (long long *)&info.size)) {
+					continue;
+				}
 				info.title = line.title;
 				info.foreignTitle = line.foreignTitle;
 				infos->push_back(info);

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -171,11 +171,8 @@ void GameManager::Update() {
 	}
 
 	if (installDonePending_) {
-		if (installThread_.get() != nullptr) {
-			if (installThread_->joinable())
-				installThread_->join();
-			installThread_.reset();
-		}
+		if (installThread_.joinable())
+			installThread_.join();
 		installDonePending_ = false;
 	}
 }
@@ -717,7 +714,7 @@ bool GameManager::InstallGameOnThread(const Path &url, const Path &fileName, boo
 	if (installInProgress_ || installDonePending_) {
 		return false;
 	}
-	installThread_.reset(new std::thread(std::bind(&GameManager::InstallGame, this, url, fileName, deleteAfter)));
+	installThread_ = std::thread(std::bind(&GameManager::InstallGame, this, url, fileName, deleteAfter));
 	return true;
 }
 

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <thread>
+#include <atomic>
 
 #include "Common/Net/HTTPClient.h"
 #include "Common/File/Path.h"
@@ -46,7 +47,6 @@ public:
 	// This starts off a background process.
 	bool DownloadAndInstall(std::string storeZipUrl);
 	bool IsDownloading(std::string storeZipUrl);
-	bool Uninstall(std::string name);
 
 	// Cancels the download in progress, if any.
 	bool CancelDownload();
@@ -58,7 +58,7 @@ public:
 	void Update();
 
 	GameManagerState GetState() {
-		if (installInProgress_ || installDonePending_)
+		if (InstallInProgress() || installDonePending_)
 			return GameManagerState::INSTALLING;
 		if (curDownload_)
 			return GameManagerState::DOWNLOADING;
@@ -75,6 +75,7 @@ public:
 
 	// Only returns false if there's already an installation in progress.
 	bool InstallGameOnThread(const Path &url, const Path &tempFileName, bool deleteAfter);
+	bool UninstallGameOnThread(const std::string &name);
 
 private:
 	bool InstallGame(Path url, Path tempFileName, bool deleteAfter);
@@ -82,10 +83,15 @@ private:
 	bool InstallMemstickZip(struct zip *z, const Path &zipFile, const Path &dest, const ZipFileInfo &info, bool deleteAfter);
 	bool InstallZippedISO(struct zip *z, int isoFileIndex, const Path &zipfile, bool deleteAfter);
 	bool InstallRawISO(const Path &zipFile, const std::string &originalName, bool deleteAfter);
+	bool UninstallGame(std::string name);
+
 	void InstallDone();
+
 	bool ExtractFile(struct zip *z, int file_index, const Path &outFilename, size_t *bytesCopied, size_t allBytes);
 	bool DetectTexturePackDest(struct zip *z, int iniIndex, Path &dest);
 	void SetInstallError(const std::string &err);
+
+	bool InstallInProgress() const { return installThread_.joinable(); }
 
 	Path GetTempFilename() const;
 	std::string GetGameID(const Path &path) const;
@@ -93,8 +99,9 @@ private:
 	std::string GetISOGameID(FileLoader *loader) const;
 	std::shared_ptr<http::Request> curDownload_;
 	std::thread installThread_;
-	bool installInProgress_ = false;
-	bool installDonePending_ = false;
+	std::atomic<bool> installDonePending_{};
+	std::atomic<bool> cleanRecentsAfter_{};
+
 	float installProgress_ = 0.0f;
 	std::string installError_;
 };

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -78,12 +78,13 @@ public:
 	bool UninstallGameOnThread(const std::string &name);
 
 private:
+	// TODO: The return value on this is a bit pointless, we can't get at it.
 	bool InstallGame(Path url, Path tempFileName, bool deleteAfter);
 	bool InstallMemstickGame(struct zip *z, const Path &zipFile, const Path &dest, const ZipFileInfo &info, bool allowRoot, bool deleteAfter);
 	bool InstallMemstickZip(struct zip *z, const Path &zipFile, const Path &dest, const ZipFileInfo &info, bool deleteAfter);
 	bool InstallZippedISO(struct zip *z, int isoFileIndex, const Path &zipfile, bool deleteAfter);
 	bool InstallRawISO(const Path &zipFile, const std::string &originalName, bool deleteAfter);
-	bool UninstallGame(std::string name);
+	void UninstallGame(std::string name);
 
 	void InstallDone();
 

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -92,7 +92,7 @@ private:
 	std::string GetPBPGameID(FileLoader *loader) const;
 	std::string GetISOGameID(FileLoader *loader) const;
 	std::shared_ptr<http::Request> curDownload_;
-	std::shared_ptr<std::thread> installThread_;
+	std::thread installThread_;
 	bool installInProgress_ = false;
 	bool installDonePending_ = false;
 	float installProgress_ = 0.0f;

--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -274,6 +274,7 @@ private:
 	std::string DownloadURL();
 
 	StoreEntry entry_;
+	UI::Button *uninstallButton_ = nullptr;
 	UI::Button *installButton_ = nullptr;
 	UI::Button *launchButton_ = nullptr;
 	UI::Button *cancelButton_ = nullptr;
@@ -300,6 +301,7 @@ void ProductView::CreateViews() {
 		LinearLayout *progressDisplay = new LinearLayout(ORIENT_HORIZONTAL);
 		installButton_ = progressDisplay->Add(new Button(st->T("Install")));
 		installButton_->OnClick.Handle(this, &ProductView::OnInstall);
+		uninstallButton_ = nullptr;
 
 		speedView_ = progressDisplay->Add(new TextView(""));
 		speedView_->SetVisibility(isDownloading ? V_VISIBLE : V_GONE);
@@ -308,7 +310,8 @@ void ProductView::CreateViews() {
 		installButton_ = nullptr;
 		speedView_ = nullptr;
 		Add(new TextView(st->T("Already Installed")));
-		Add(new Button(st->T("Uninstall")))->OnClick.Add([=](UI::EventParams &e) {
+		uninstallButton_ = new Button(st->T("Uninstall"));
+		Add(uninstallButton_)->OnClick.Add([=](UI::EventParams &e) {
 			g_GameManager.UninstallGameOnThread(entry_.file);
 			return UI::EVENT_DONE;
 		});
@@ -340,6 +343,9 @@ void ProductView::Update() {
 	}
 	if (installButton_) {
 		installButton_->SetEnabled(g_GameManager.GetState() == GameManagerState::IDLE);
+	}
+	if (uninstallButton_) {
+		uninstallButton_->SetEnabled(g_GameManager.GetState() == GameManagerState::IDLE);
 	}
 	if (g_GameManager.GetState() == GameManagerState::DOWNLOADING) {
 		if (speedView_) {

--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -266,7 +266,6 @@ private:
 	void CreateViews();
 	UI::EventReturn OnInstall(UI::EventParams &e);
 	UI::EventReturn OnCancel(UI::EventParams &e);
-	UI::EventReturn OnUninstall(UI::EventParams &e);
 	UI::EventReturn OnLaunchClick(UI::EventParams &e);
 
 	bool IsGameInstalled() {
@@ -309,7 +308,10 @@ void ProductView::CreateViews() {
 		installButton_ = nullptr;
 		speedView_ = nullptr;
 		Add(new TextView(st->T("Already Installed")));
-		Add(new Button(st->T("Uninstall")))->OnClick.Handle(this, &ProductView::OnUninstall);
+		Add(new Button(st->T("Uninstall")))->OnClick.Add([=](UI::EventParams &e) {
+			g_GameManager.UninstallGameOnThread(entry_.file);
+			return UI::EVENT_DONE;
+		});
 		launchButton_ = new Button(st->T("Launch Game"));
 		launchButton_->OnClick.Handle(this, &ProductView::OnLaunchClick);
 		Add(launchButton_);
@@ -384,12 +386,6 @@ UI::EventReturn ProductView::OnInstall(UI::EventParams &e) {
 
 UI::EventReturn ProductView::OnCancel(UI::EventParams &e) {
 	g_GameManager.CancelDownload();
-	return UI::EVENT_DONE;
-}
-
-UI::EventReturn ProductView::OnUninstall(UI::EventParams &e) {
-	g_GameManager.Uninstall(entry_.file);
-	CreateViews();
 	return UI::EVENT_DONE;
 }
 

--- a/UI/Store.h
+++ b/UI/Store.h
@@ -74,7 +74,6 @@ protected:
 private:
 	void ParseListing(std::string json);
 	ProductItemView *GetSelectedItem();
-	std::vector<StoreEntry> FilterEntries();
 
 	std::string GetTranslatedString(const json::JsonGet json, std::string key, const char *fallback = nullptr) const;
 
@@ -98,8 +97,8 @@ private:
 	std::string lang_;
 	std::string lastSelectedName_;
 
-	UI::ViewGroup *scrollItemView_;
-	UI::ViewGroup *productPanel_;
-	UI::TextView *titleText_;
+	UI::ViewGroup *scrollItemView_ = nullptr;
+	UI::ViewGroup *productPanel_ = nullptr;
+	UI::TextView *titleText_ = nullptr;
 };
 


### PR DESCRIPTION
Avoids blocking the UI for long periods of time in case of some homebrew like Mega Drops on slow filesystems.

Also adds a progress popup for installs and uninstalls.

Part of #17450 