### PR TITLE
SDL: Filter duplicate axis events. Fix autoconfigure to not use Xinput on non-Windows

### DIFF
--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -822,8 +822,12 @@ void AutoConfForPad(const std::string &name) {
 		SetDefaultKeyMap(DEFAULT_MAPPING_ANDROID_PAD, false);
 	}
 #else
-	// TODO: Should actually check for XInput?
-	if (name.find("Xbox") != std::string::npos) {
+#if PPSSPP_PLATFORM(WINDOWS)
+	const bool platformSupportsXinput = true;
+#else
+	const bool platformSupportsXinput = false;
+#endif
+	if (platformSupportsXinput && name.find("Xbox") != std::string::npos) {
 		SetDefaultKeyMap(DEFAULT_MAPPING_XINPUT, false);
 	} else {
 		SetDefaultKeyMap(DEFAULT_MAPPING_PAD, false);

--- a/Windows/DinputDevice.cpp
+++ b/Windows/DinputDevice.cpp
@@ -204,12 +204,13 @@ DinputDevice::~DinputDevice() {
 }
 
 void SendNativeAxis(InputDeviceID deviceId, int value, int &lastValue, InputAxis axisId) {
-	AxisInput axis;
-	axis.deviceId = deviceId;
-	axis.axisId = axisId;
-	axis.value = (float)value * (1.0f / 10000.0f); // Convert axis to normalised float
-	NativeAxis(&axis, 1);
-
+	if (value != lastValue) {
+		AxisInput axis;
+		axis.deviceId = deviceId;
+		axis.axisId = axisId;
+		axis.value = (float)value * (1.0f / 10000.0f); // Convert axis to normalised float
+		NativeAxis(&axis, 1);
+	}
 	lastValue = value;
 }
 
@@ -286,7 +287,7 @@ void DinputDevice::ApplyButtons(DIJOYSTATE2 &state) {
 
 	// Now the POV hat, which can technically go in any degree but usually does not.
 	if (LOWORD(state.rgdwPOV[0]) != lastPOV_[0]) {
-		KeyInput dpad[4];
+		KeyInput dpad[4]{};
 		for (int i = 0; i < 4; ++i) {
 			dpad[i].deviceId = DEVICE_ID_PAD_0 + pDevNum;
 			dpad[i].flags = KEY_UP;


### PR DESCRIPTION
On Mac/Linux, auto configure controls for Xbox controllers resulted in Xinput bindings, even though we don't support XInput evens at all on these platforms.

Might help #16788, at least it works just fine for me now.

Should also allow us to re-merge #18368 eventually.