### PR TITLE
Android: Batch motion events.

### DIFF
--- a/android/src/org/ppsspp/ppsspp/InputDeviceState.java
+++ b/android/src/org/ppsspp/ppsspp/InputDeviceState.java
@@ -20,6 +20,10 @@ public class InputDeviceState {
 	private int[] mAxes;
 	private float[] mAxisPrevValue;
 
+	// Buffers for the native calls.
+	private int[] mAxisIds = null;
+	private float[] mValues = null;
+
 	private int sources;
 
 	InputDevice getDevice() {
@@ -125,6 +129,8 @@ public class InputDeviceState {
 
 		mAxes = new int[numAxes];
 		mAxisPrevValue = new float[numAxes];
+		mAxisIds = new int[numAxes];
+		mValues = new float[numAxes];
 
 		int i = 0;
 		for (MotionRange range : device.getMotionRanges()) {
@@ -157,14 +163,18 @@ public class InputDeviceState {
 			Log.i(TAG, "Not a joystick event: source = " + event.getSource());
 			return false;
 		}
+		int count = 0;
 		for (int i = 0; i < mAxes.length; i++) {
 			int axisId = mAxes[i];
 			float value = event.getAxisValue(axisId);
 			if (value != mAxisPrevValue[i]) {
-				NativeApp.joystickAxis(deviceId, axisId, value);
+				mAxisIds[count] = axisId;
+				mValues[count] = value;
+				count++;
 				mAxisPrevValue[i] = value;
 			}
 		}
+		NativeApp.joystickAxis(deviceId, mAxisIds, mValues, count);
 		return true;
 	}
 }

--- a/android/src/org/ppsspp/ppsspp/NativeApp.java
+++ b/android/src/org/ppsspp/ppsspp/NativeApp.java
@@ -41,7 +41,7 @@ public class NativeApp {
 	public static native boolean keyDown(int deviceId, int key, boolean isRepeat);
 	public static native boolean keyUp(int deviceId, int key);
 
-	public static native void joystickAxis(int deviceId, int axis, float value);
+	public static native void joystickAxis(int deviceId, int []axis, float []value, int count);
 
 	public static native boolean mouseWheelEvent(float x, float y);
 

--- a/android/src/org/ppsspp/ppsspp/NativeGLView.java
+++ b/android/src/org/ppsspp/ppsspp/NativeGLView.java
@@ -172,12 +172,23 @@ public class NativeGLView extends GLSurfaceView implements SensorEventListener, 
 	// MOGA Controller - from ControllerListener
 	@Override
 	public void onMotionEvent(com.bda.controller.MotionEvent event) {
-		NativeApp.joystickAxis(NativeApp.DEVICE_ID_PAD_0, com.bda.controller.MotionEvent.AXIS_X, event.getAxisValue(com.bda.controller.MotionEvent.AXIS_X));
-		NativeApp.joystickAxis(NativeApp.DEVICE_ID_PAD_0, com.bda.controller.MotionEvent.AXIS_Y, event.getAxisValue(com.bda.controller.MotionEvent.AXIS_Y));
-		NativeApp.joystickAxis(NativeApp.DEVICE_ID_PAD_0, com.bda.controller.MotionEvent.AXIS_Z, event.getAxisValue(com.bda.controller.MotionEvent.AXIS_Z));
-		NativeApp.joystickAxis(NativeApp.DEVICE_ID_PAD_0, com.bda.controller.MotionEvent.AXIS_RZ, event.getAxisValue(com.bda.controller.MotionEvent.AXIS_RZ));
-		NativeApp.joystickAxis(NativeApp.DEVICE_ID_PAD_0, com.bda.controller.MotionEvent.AXIS_LTRIGGER, event.getAxisValue(com.bda.controller.MotionEvent.AXIS_LTRIGGER));
-		NativeApp.joystickAxis(NativeApp.DEVICE_ID_PAD_0, com.bda.controller.MotionEvent.AXIS_RTRIGGER, event.getAxisValue(com.bda.controller.MotionEvent.AXIS_RTRIGGER));
+		int [] axisIds = new int[]{
+			com.bda.controller.MotionEvent.AXIS_X,
+			com.bda.controller.MotionEvent.AXIS_Y,
+			com.bda.controller.MotionEvent.AXIS_Z,
+			com.bda.controller.MotionEvent.AXIS_RZ,
+			com.bda.controller.MotionEvent.AXIS_LTRIGGER,
+			com.bda.controller.MotionEvent.AXIS_RTRIGGER,
+		};
+		float [] values = new float[]{
+			event.getAxisValue(com.bda.controller.MotionEvent.AXIS_X),
+			event.getAxisValue(com.bda.controller.MotionEvent.AXIS_Y),
+			event.getAxisValue(com.bda.controller.MotionEvent.AXIS_Z),
+			event.getAxisValue(com.bda.controller.MotionEvent.AXIS_RZ),
+			event.getAxisValue(com.bda.controller.MotionEvent.AXIS_LTRIGGER),
+			event.getAxisValue(com.bda.controller.MotionEvent.AXIS_RTRIGGER),
+		};
+		NativeApp.joystickAxis(NativeApp.DEVICE_ID_PAD_0, axisIds, values, 6);
 	}
 
 	// MOGA Controller - from ControllerListener

--- a/android/src/org/ppsspp/ppsspp/NativeSurfaceView.java
+++ b/android/src/org/ppsspp/ppsspp/NativeSurfaceView.java
@@ -169,12 +169,24 @@ public class NativeSurfaceView extends SurfaceView implements SensorEventListene
 	// MOGA Controller - from ControllerListener
 	@Override
 	public void onMotionEvent(com.bda.controller.MotionEvent event) {
-		NativeApp.joystickAxis(NativeApp.DEVICE_ID_PAD_0, com.bda.controller.MotionEvent.AXIS_X, event.getAxisValue(com.bda.controller.MotionEvent.AXIS_X));
-		NativeApp.joystickAxis(NativeApp.DEVICE_ID_PAD_0, com.bda.controller.MotionEvent.AXIS_Y, event.getAxisValue(com.bda.controller.MotionEvent.AXIS_Y));
-		NativeApp.joystickAxis(NativeApp.DEVICE_ID_PAD_0, com.bda.controller.MotionEvent.AXIS_Z, event.getAxisValue(com.bda.controller.MotionEvent.AXIS_Z));
-		NativeApp.joystickAxis(NativeApp.DEVICE_ID_PAD_0, com.bda.controller.MotionEvent.AXIS_RZ, event.getAxisValue(com.bda.controller.MotionEvent.AXIS_RZ));
-		NativeApp.joystickAxis(NativeApp.DEVICE_ID_PAD_0, com.bda.controller.MotionEvent.AXIS_LTRIGGER, event.getAxisValue(com.bda.controller.MotionEvent.AXIS_LTRIGGER));
-		NativeApp.joystickAxis(NativeApp.DEVICE_ID_PAD_0, com.bda.controller.MotionEvent.AXIS_RTRIGGER, event.getAxisValue(com.bda.controller.MotionEvent.AXIS_RTRIGGER));
+		int [] axisIds = new int[]{
+			com.bda.controller.MotionEvent.AXIS_X,
+			com.bda.controller.MotionEvent.AXIS_Y,
+			com.bda.controller.MotionEvent.AXIS_Z,
+			com.bda.controller.MotionEvent.AXIS_RZ,
+			com.bda.controller.MotionEvent.AXIS_LTRIGGER,
+			com.bda.controller.MotionEvent.AXIS_RTRIGGER,
+		};
+		float [] values = new float[]{
+			event.getAxisValue(com.bda.controller.MotionEvent.AXIS_X),
+			event.getAxisValue(com.bda.controller.MotionEvent.AXIS_Y),
+			event.getAxisValue(com.bda.controller.MotionEvent.AXIS_Z),
+			event.getAxisValue(com.bda.controller.MotionEvent.AXIS_RZ),
+			event.getAxisValue(com.bda.controller.MotionEvent.AXIS_LTRIGGER),
+			event.getAxisValue(com.bda.controller.MotionEvent.AXIS_RTRIGGER),
+		};
+
+		NativeApp.joystickAxis(NativeApp.DEVICE_ID_PAD_0, axisIds, values, 6);
 	}
 
 	// MOGA Controller - from ControllerListener


### PR DESCRIPTION
Just cleaning out old branches, a leftover one from my previous input refactoring work. Reduces locking on motion (analog stick) events a bit on Android.