### PR TITLE
Use __loongarch_lp64 instead of __loongarch64 as it is deprecated

### DIFF
--- a/ppsspp_config.h
+++ b/ppsspp_config.h
@@ -75,7 +75,7 @@
     #define PPSSPP_ARCH_64BIT 1
 #endif
 
-#if defined(__loongarch64)
+#if defined(__loongarch_lp64)
     //https://github.com/gcc-mirror/gcc/blob/master/gcc/config/loongarch/loongarch-c.cc
     #define PPSSPP_ARCH_LOONGARCH64 1
     #define PPSSPP_ARCH_64BIT 1


### PR DESCRIPTION
* According to the "[Software Development and Build Convention for LoongArch™ Architectures](https://github.com/loongson/la-softdev-convention/blob/master/la-softdev-convention.adoc)", we should use `__loongarch_lp64` instead of `__loongarch64`.
* [For historical reasons, the earliest LoongArch C/C++ compilers provided a bunch of MIPS-style preprocessor built-in macros. ](https://github.com/loongson/LoongArch-Documentation/commit/4691aca44a0badad2288be28169fa9d83e8122f8)It contained `__loongarch64`, which has been deprecated.
* Tested on 3A5000M and 3A6000