### PR TITLE
Fix slowdown on zero-vertex draw calls

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -958,12 +958,12 @@ void DrawEngineCommon::DecodeVerts(u8 *dest) {
 		DeferredVerts &dv = drawVerts_[i];
 
 		int indexLowerBound = dv.indexLowerBound;
-		drawVertexOffsets_[i] = decodedVerts_ - indexLowerBound;
+		drawVertexOffsets_[i] = numDecodedVerts_ - indexLowerBound;
 
 		int indexUpperBound = dv.indexUpperBound;
 		// Decode the verts (and at the same time apply morphing/skinning). Simple.
-		dec_->DecodeVerts(dest + decodedVerts_ * stride, dv.verts, &dv.uvScale, indexLowerBound, indexUpperBound);
-		decodedVerts_ += indexUpperBound - indexLowerBound + 1;
+		dec_->DecodeVerts(dest + numDecodedVerts_ * stride, dv.verts, &dv.uvScale, indexLowerBound, indexUpperBound);
+		numDecodedVerts_ += indexUpperBound - indexLowerBound + 1;
 	}
 	decodeVertsCounter_ = i;
 }

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -899,8 +899,11 @@ bool DrawEngineCommon::SubmitPrim(const void *verts, const void *inds, GEPrimiti
 	*bytesRead = vertexCount * dec_->VertexSize();
 
 	// Check that we have enough vertices to form the requested primitive.
-	if (vertexCount < 3 && ((vertexCount < 2 && prim > 0) || (prim > GE_PRIM_LINE_STRIP && prim != GE_PRIM_RECTANGLES)))
-		return false;
+	if (vertexCount < 3) {
+		if ((vertexCount < 2 && prim > 0) || (prim > GE_PRIM_LINE_STRIP && prim != GE_PRIM_RECTANGLES)) {
+			return false;
+		}
+	}
 
 	bool applySkin = (vertTypeID & GE_VTYPE_WEIGHT_MASK) && decOptions_.applySkinInDecode;
 
@@ -919,10 +922,10 @@ bool DrawEngineCommon::SubmitPrim(const void *verts, const void *inds, GEPrimiti
 	if (inds && numDrawVerts_ > decodeVertsCounter_ && drawVerts_[numDrawVerts_ - 1].verts == verts && !applySkin) {
 		// Same vertex pointer as a previous un-decoded draw call - let's just extend the decode!
 		di.vertDecodeIndex = numDrawVerts_ - 1;
-		DeferredVerts &dv = drawVerts_[numDrawVerts_ - 1];
 		u16 lb;
 		u16 ub;
 		GetIndexBounds(inds, vertexCount, vertTypeID, &lb, &ub);
+		DeferredVerts &dv = drawVerts_[numDrawVerts_ - 1];
 		if (lb < dv.indexLowerBound)
 			dv.indexLowerBound = lb;
 		if (ub > dv.indexUpperBound)
@@ -933,12 +936,8 @@ bool DrawEngineCommon::SubmitPrim(const void *verts, const void *inds, GEPrimiti
 		dv.verts = verts;
 		dv.vertexCount = vertexCount;
 		dv.uvScale = gstate_c.uv;
-		if (inds) {
-			GetIndexBounds(inds, vertexCount, vertTypeID, &dv.indexLowerBound, &dv.indexUpperBound);
-		} else {
-			dv.indexLowerBound = 0;
-			dv.indexUpperBound = vertexCount - 1;
-		}
+		// Does handle the unindexed case.
+		GetIndexBounds(inds, vertexCount, vertTypeID, &dv.indexLowerBound, &dv.indexUpperBound);
 	}
 
 	vertexCountInDrawCalls_ += vertexCount;

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -158,10 +158,6 @@ protected:
 	void DecodeVerts(u8 *dest);
 	void DecodeInds();
 
-	int MaxIndex() const {
-		return decodedVerts_;
-	}
-
 	// Preprocessing for spline/bezier
 	u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, u32 vertType, int *vertexSize = nullptr);
 
@@ -204,7 +200,7 @@ protected:
 		gpuStats.numVertsSubmitted += vertexCountInDrawCalls_;
 
 		indexGen.Reset();
-		decodedVerts_ = 0;
+		numDecodedVerts_ = 0;
 		numDrawVerts_ = 0;
 		numDrawInds_ = 0;
 		vertexCountInDrawCalls_ = 0;
@@ -278,7 +274,7 @@ protected:
 
 	// Vertex collector state
 	IndexGenerator indexGen;
-	int decodedVerts_ = 0;
+	int numDecodedVerts_ = 0;
 	GEPrimitiveType prevPrim_ = GE_PRIM_INVALID;
 
 	// Shader blending state

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -171,7 +171,7 @@ void SoftwareTransform::SetProjMatrix(const float mtx[14], bool invertedX, bool 
 	projMatrix_.translateAndScale(trans, scale);
 }
 
-void SoftwareTransform::Decode(int prim, u32 vertType, const DecVtxFormat &decVtxFormat, int maxIndex, SoftwareTransformResult *result) {
+void SoftwareTransform::Transform(int prim, u32 vertType, const DecVtxFormat &decVtxFormat, int maxIndex, SoftwareTransformResult *result) {
 	u8 *decoded = params_.decoded;
 	TransformedVertex *transformed = params_.transformed;
 	bool throughmode = (vertType & GE_VTYPE_THROUGH_MASK) != 0;

--- a/GPU/Common/SoftwareTransformCommon.h
+++ b/GPU/Common/SoftwareTransformCommon.h
@@ -62,11 +62,10 @@ struct SoftwareTransformParams {
 
 class SoftwareTransform {
 public:
-	SoftwareTransform(SoftwareTransformParams &params) : params_(params) {
-	}
+	SoftwareTransform(SoftwareTransformParams &params) : params_(params) {}
 
 	void SetProjMatrix(const float mtx[14], bool invertedX, bool invertedY, const Lin::Vec3 &trans, const Lin::Vec3 &scale);
-	void Decode(int prim, u32 vertexType, const DecVtxFormat &decVtxFormat, int maxIndex, SoftwareTransformResult *result);
+	void Transform(int prim, u32 vertexType, const DecVtxFormat &decVtxFormat, int maxIndex, SoftwareTransformResult *result);
 	void DetectOffsetTexture(int maxIndex);
 	void BuildDrawingParams(int prim, int vertexCount, u32 vertType, u16 *&inds, int &maxIndex, SoftwareTransformResult *result);
 

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -154,7 +154,11 @@ void GetIndexBounds(const void *inds, int count, u32 vertType, u16 *indexLowerBo
 		*indexUpperBound = (u16)upperBound;
 	} else {
 		*indexLowerBound = 0;
-		*indexUpperBound = count - 1;
+		if (count > 0) {
+			*indexUpperBound = count - 1;
+		} else {
+			*indexUpperBound = 0;
+		}
 	}
 }
 

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -292,7 +292,6 @@ void DrawEngineD3D11::DoFlush() {
 		bool useElements = !indexGen.SeenOnlyPurePrims() || prim == GE_PRIM_TRIANGLE_FAN;
 		int vertexCount = indexGen.VertexCount();
 		gpuStats.numUncachedVertsDrawn += vertexCount;
-		int maxIndex = MaxIndex();
 		if (!useElements && indexGen.PureCount()) {
 			vertexCount = indexGen.PureCount();
 		}
@@ -329,7 +328,7 @@ void DrawEngineD3D11::DoFlush() {
 		if (!vb_) {
 			// Push!
 			UINT vOffset;
-			int vSize = (maxIndex + 1) * dec_->GetDecVtxFmt().stride;
+			int vSize = numDecodedVerts_ * dec_->GetDecVtxFmt().stride;
 			uint8_t *vptr = pushVerts_->BeginPush(context_, &vOffset, vSize);
 			memcpy(vptr, decoded_, vSize);
 			pushVerts_->EndPush(context_);
@@ -403,20 +402,19 @@ void DrawEngineD3D11::DoFlush() {
 			UpdateCachedViewportState(vpAndScissor);
 		}
 
-		int maxIndex = MaxIndex();
 		SoftwareTransform swTransform(params);
 
 		const Lin::Vec3 trans(gstate_c.vpXOffset, -gstate_c.vpYOffset, gstate_c.vpZOffset * 0.5f + 0.5f);
 		const Lin::Vec3 scale(gstate_c.vpWidthScale, -gstate_c.vpHeightScale, gstate_c.vpDepthScale * 0.5f);
 		swTransform.SetProjMatrix(gstate.projMatrix, gstate_c.vpWidth < 0, gstate_c.vpHeight < 0, trans, scale);
 
-		swTransform.Decode(prim, dec_->VertexType(), dec_->GetDecVtxFmt(), maxIndex, &result);
+		swTransform.Transform(prim, dec_->VertexType(), dec_->GetDecVtxFmt(), numDecodedVerts_, &result);
 		// Non-zero depth clears are unusual, but some drivers don't match drawn depth values to cleared values.
 		// Games sometimes expect exact matches (see #12626, for example) for equal comparisons.
 		if (result.action == SW_CLEAR && everUsedEqualDepth_ && gstate.isClearModeDepthMask() && result.depth > 0.0f && result.depth < 1.0f)
 			result.action = SW_NOT_READY;
 		if (result.action == SW_NOT_READY) {
-			swTransform.DetectOffsetTexture(maxIndex);
+			swTransform.DetectOffsetTexture(numDecodedVerts_);
 		}
 
 		if (textureNeedsApply)
@@ -426,7 +424,7 @@ void DrawEngineD3D11::DoFlush() {
 		ApplyDrawState(prim);
 
 		if (result.action == SW_NOT_READY)
-			swTransform.BuildDrawingParams(prim, indexGen.VertexCount(), dec_->VertexType(), inds, maxIndex, &result);
+			swTransform.BuildDrawingParams(prim, indexGen.VertexCount(), dec_->VertexType(), inds, numDecodedVerts_, &result);
 		if (result.setSafeSize)
 			framebufferManager_->SetSafeSize(result.safeWidth, result.safeHeight);
 
@@ -454,7 +452,7 @@ void DrawEngineD3D11::DoFlush() {
 
 			UINT stride = sizeof(TransformedVertex);
 			UINT vOffset = 0;
-			int vSize = maxIndex * stride;
+			int vSize = numDecodedVerts_ * stride;
 			uint8_t *vptr = pushVerts_->BeginPush(context_, &vOffset, vSize);
 			memcpy(vptr, result.drawBuffer, vSize);
 			pushVerts_->EndPush(context_);

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -376,13 +376,21 @@ void DrawEngineVulkan::DoFlush() {
 			lastVType_ |= (1 << 26);
 			dec_ = GetVertexDecoder(lastVType_);
 		}
+		int prevDecodedVerts = numDecodedVerts_;
+
 		DecodeVerts(decoded_);
 		DecodeInds();
+
 		bool hasColor = (lastVType_ & GE_VTYPE_COL_MASK) != GE_VTYPE_COL_NONE;
 		if (gstate.isModeThrough()) {
 			gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && (hasColor || gstate.getMaterialAmbientA() == 255);
 		} else {
 			gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && ((hasColor && (gstate.materialupdate & 1)) || gstate.getMaterialAmbientA() == 255) && (!gstate.isLightingEnabled() || gstate.getAmbientA() == 255);
+		}
+
+		int vcount = indexGen.VertexCount();
+		if (numDecodedVerts_ > 10 * vcount) {
+			decIndex_ = decIndex_;
 		}
 
 		gpuStats.numUncachedVertsDrawn += indexGen.VertexCount();


### PR DESCRIPTION
Due to a short integer overflow, we ended up soft-transforming 65536 vertices instead of none. Not great.

Also cleans up some off-by-ones in DrawEngineD3D11/D3D9.

Fixes #18504 