### PR TITLE
CtrlDisplayListView: fix ASAN eror

### DIFF
--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -86,7 +86,6 @@ LRESULT CALLBACK CtrlDisplayListView::wndProc(HWND hwnd, UINT msg, WPARAM wParam
 		// Continue with window creation.
 		return win != NULL;
 	case WM_NCDESTROY:
-		delete win;
 		break;
 	case WM_SIZE:
 		win->redraw();


### PR DESCRIPTION
I tried fixing another ASAN error. I wasn't sure how to properly delete the CtrlDisplayListView. Maybe deleting is not necessary when shutting down.

```
[16516] ==16516==ERROR: AddressSanitizer: heap-use-after-free on address 0x11832b4b6880 at pc 0x7ff7b2b8f13a bp 0x00422fefe970 sp 0x00422fefe9b8
[16516] READ of size 8 at 0x11832b4b6880 thread T0
[16516]     #0 0x7ff7b2b8f139 in CtrlDisplayListView::GetHWND() C:/src/ppsspp/Windows/GEDebugger/CtrlDisplayListView.h:43:10
[16516]     #1 0x7ff7b2b4e13b in RemoveDisplayListTab(GEDebuggerTab*, TabControl*, GETabPosition, void*) C:/src/ppsspp/Windows/GEDebugger/GEDebugger.cpp:82:22
[16516]     #2 0x7ff7b2b5e0e5 in CGEDebugger::RemoveTab(GEDebuggerTab*, GETabPosition)::$_0::operator()(GETabPosition, TabControl*, GEPanelIndex) const C:/src/ppsspp/Windows/GEDebugger/GEDebugger.cpp:622:4
[16516]     #3 0x7ff7b2b540e6 in CGEDebugger::RemoveTab(GEDebuggerTab*, GETabPosition) C:/src/ppsspp/Windows/GEDebugger/GEDebugger.cpp:629:2
[16516]     #4 0x7ff7b2b53bec in CGEDebugger::~CGEDebugger() C:/src/ppsspp/Windows/GEDebugger/GEDebugger.cpp:269:3
[16516]     #5 0x7ff7b2b54247 in CGEDebugger::~CGEDebugger() C:/src/ppsspp/Windows/GEDebugger/GEDebugger.cpp:265:29
[16516]     #6 0x7ff7b2c4216a in MainWindow::DestroyDebugWindows() C:/src/ppsspp/Windows/MainWindow.cpp:596:4
[16516]     #7 0x7ff7b2c90a5b in wWinMain C:/src/ppsspp/Windows/main.cpp:1070:2
[16516]     #8 0x7ff7b3a514f5 in wmain C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexewin.c:67:10
[16516]     #9 0x7ff7b2181318 in __tmainCRTStartup C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:267:15
[16516]     #10 0x7ff7b2181155 in .l_startw C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:157:9
[16516]     #11 0x7ff8f2f07343  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017343)
[16516]     #12 0x7ff8f3ea26b0  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x1800526b0)
[16516] 
[16516] 0x11832b4b6880 is located 0 bytes inside of 536-byte region [0x11832b4b6880,0x11832b4b6a98)
[16516] freed by thread T0 here:
[16516]     #0 0x7ff8571845f1 in operator delete(void*) (C:\msys64\clang64\bin\libclang_rt.asan_dynamic-x86_64.dll+0x1800545f1)
[16516]     #1 0x7ff7b2b040d1 in CtrlDisplayListView::wndProc(HWND__*, unsigned int, unsigned long long, long long) C:/src/ppsspp/Windows/GEDebugger/CtrlDisplayListView.cpp:89:3
[16516]     #2 0x7ff8f26de857  (C:\WINDOWS\System32\USER32.dll+0x18000e857)
[16516]     #3 0x7ff8f26de3db  (C:\WINDOWS\System32\USER32.dll+0x18000e3db)
[16516]     #4 0x7ff8f26f6af7  (C:\WINDOWS\System32\USER32.dll+0x180026af7)
[16516]     #5 0x7ff8f3ef0e63  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x1800a0e63)
[16516]     #6 0x7ff8f1c61123  (C:\WINDOWS\System32\win32u.dll+0x180001123)
[16516]     #7 0x7ff8f26dcaf4  (C:\WINDOWS\System32\USER32.dll+0x18000caf4)
[16516]     #8 0x7ff8f26dc7b7  (C:\WINDOWS\System32\USER32.dll+0x18000c7b7)
[16516]     #9 0x7ff7b2c3a9f3 in MainWindow::WndProc(HWND__*, unsigned int, unsigned long long, long long) C:/src/ppsspp/Windows/MainWindow.cpp:1043:11
[16516]     #10 0x7ff8f26de857  (C:\WINDOWS\System32\USER32.dll+0x18000e857)
[16516]     #11 0x7ff8f26de298  (C:\WINDOWS\System32\USER32.dll+0x18000e298)
[16516]     #12 0x7ff7b2c90a02 in wWinMain C:/src/ppsspp/Windows/main.cpp:1063:5
[16516]     #13 0x7ff7b3a514f5 in wmain C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexewin.c:67:10
[16516]     #14 0x7ff7b2181318 in __tmainCRTStartup C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:267:15
[16516]     #15 0x7ff7b2181155 in .l_startw C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:157:9
[16516]     #16 0x7ff8f2f07343  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017343)
[16516]     #17 0x7ff8f3ea26b0  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x1800526b0)
[16516] 
[16516] previously allocated by thread T0 here:
[16516]     #0 0x7ff857183d91 in operator new(unsigned long long) (C:\msys64\clang64\bin\libclang_rt.asan_dynamic-x86_64.dll+0x180053d91)
[16516]     #1 0x7ff7b2b0402e in CtrlDisplayListView::wndProc(HWND__*, unsigned int, unsigned long long, long long) C:/src/ppsspp/Windows/GEDebugger/CtrlDisplayListView.cpp:84:9
[16516]     #2 0x7ff8f26de857  (C:\WINDOWS\System32\USER32.dll+0x18000e857)
[16516]     #3 0x7ff8f26de3db  (C:\WINDOWS\System32\USER32.dll+0x18000e3db)
[16516]     #4 0x7ff8f26f2cc6  (C:\WINDOWS\System32\USER32.dll+0x180022cc6)
[16516]     #5 0x7ff8f3ef0e63  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x1800a0e63)
[16516]     #6 0x7ff8f1c61ec3  (C:\WINDOWS\System32\win32u.dll+0x180001ec3)
[16516]     #7 0x7ff8f26d7d8a  (C:\WINDOWS\System32\USER32.dll+0x180007d8a)
[16516]     #8 0x7ff8f26d7957  (C:\WINDOWS\System32\USER32.dll+0x180007957)
[16516]     #9 0x7ff8f26d77a1  (C:\WINDOWS\System32\USER32.dll+0x1800077a1)
[16516]     #10 0x7ff7b2c25d38 in TabControl::AddTabWindow(wchar_t const*, wchar_t const*, unsigned long) C:/src/ppsspp/Windows/W32Util/TabControl.cpp:33:19
[16516]     #11 0x7ff7b2b4e0f6 in AddDisplayListTab(GEDebuggerTab*, TabControl*, GETabPosition, HINSTANCE__*, HWND__*) C:/src/ppsspp/Windows/GEDebugger/GEDebugger.cpp:76:19
[16516]     #12 0x7ff7b2b5d2af in CGEDebugger::AddTab(GEDebuggerTab*, GETabPosition)::$_0::operator()(GETabPosition, TabControl*, GEPanelIndex) const C:/src/ppsspp/Windows/GEDebugger/GEDebugger.cpp:597:28
[16516]     #13 0x7ff7b2b52f66 in CGEDebugger::AddTab(GEDebuggerTab*, GETabPosition) C:/src/ppsspp/Windows/GEDebugger/GEDebugger.cpp:605:2
[16516]     #14 0x7ff7b2b5219f in CGEDebugger::CGEDebugger(HINSTANCE__*, HWND__*) C:/src/ppsspp/Windows/GEDebugger/GEDebugger.cpp:243:3
[16516]     #15 0x7ff7b2c41a7b in MainWindow::CreateGeDebuggerWindow() C:/src/ppsspp/Windows/MainWindow.cpp:555:27
[16516]     #16 0x7ff7b2c51de6 in MainWindow::MainWindowMenu_Process(HWND__*, unsigned long long) C:/src/ppsspp/Windows/MainWindowMenu.cpp:791:4
[16516]     #17 0x7ff7b2c39ec0 in MainWindow::WndProc(HWND__*, unsigned int, unsigned long long, long long) C:/src/ppsspp/Windows/MainWindow.cpp:962:5
[16516]     #18 0x7ff8f26de857  (C:\WINDOWS\System32\USER32.dll+0x18000e857)
[16516]     #19 0x7ff8f26de298  (C:\WINDOWS\System32\USER32.dll+0x18000e298)
[16516]     #20 0x7ff7b2c90a02 in wWinMain C:/src/ppsspp/Windows/main.cpp:1063:5
[16516]     #21 0x7ff7b3a514f5 in wmain C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexewin.c:67:10
[16516]     #22 0x7ff7b2181318 in __tmainCRTStartup C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:267:15
[16516]     #23 0x7ff7b2181155 in .l_startw C:/M/B/src/mingw-w64/mingw-w64-crt/crt/crtexe.c:157:9
[16516]     #24 0x7ff8f2f07343  (C:\WINDOWS\System32\KERNEL32.DLL+0x180017343)
[16516]     #25 0x7ff8f3ea26b0  (C:\WINDOWS\SYSTEM32\ntdll.dll+0x1800526b0)
[16516] 
[16516] SUMMARY: AddressSanitizer: heap-use-after-free C:/src/ppsspp/Windows/GEDebugger/CtrlDisplayListView.h:43:10 in CtrlDisplayListView::GetHWND()
[16516] Shadow bytes around the buggy address:
[16516]   0x11832b4b6600: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
[16516]   0x11832b4b6680: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
[16516]   0x11832b4b6700: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
[16516]   0x11832b4b6780: fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa fa
[16516]   0x11832b4b6800: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
[16516] =>0x11832b4b6880:[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
[16516]   0x11832b4b6900: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
[16516]   0x11832b4b6980: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
[16516]   0x11832b4b6a00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
[16516]   0x11832b4b6a80: fd fd fd fa fa fa fa fa fa fa fa fa fa fa fa fa
[16516]   0x11832b4b6b00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
[16516] Shadow byte legend (one shadow byte represents 8 application bytes):
[16516]   Addressable:           00
[16516]   Partially addressable: 01 02 03 04 05 06 07 
[16516]   Heap left redzone:       fa
[16516]   Freed heap region:       fd
[16516]   Stack left redzone:      f1
[16516]   Stack mid redzone:       f2
[16516]   Stack right redzone:     f3
[16516]   Stack after return:      f5
[16516]   Stack use after scope:   f8
[16516]   Global redzone:          f9
[16516]   Global init order:       f6
[16516]   Poisoned by user:        f7
[16516]   Container overflow:      fc
[16516]   Array cookie:            ac
[16516]   Intra object redzone:    bb
[16516]   ASan internal:           fe
[16516]   Left alloca redzone:     ca
[16516]   Right alloca redzone:    cb
[16516] ==16516==ABORTING
```