### PR TITLE
Run-behind-pause: Fix some edge cases with the transparent background setting

### DIFF
--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -257,13 +257,6 @@ void ScreenManager::sendMessage(UIMessage message, const char *value) {
 	}
 }
 
-Screen *ScreenManager::topScreen() const {
-	if (!stack_.empty())
-		return stack_.back().screen;
-	else
-		return 0;
-}
-
 void ScreenManager::shutdown() {
 	std::lock_guard<std::recursive_mutex> guard(inputLock_);
 	for (auto layer : stack_)

--- a/Common/UI/Screen.h
+++ b/Common/UI/Screen.h
@@ -90,6 +90,7 @@ public:
 	virtual void RecreateViews() {}
 
 	ScreenManager *screenManager() { return screenManager_; }
+	const ScreenManager *screenManager() const { return screenManager_; }
 	void setScreenManager(ScreenManager *sm) { screenManager_ = sm; }
 
 	virtual const char *tag() const = 0;
@@ -158,7 +159,12 @@ public:
 	// Generic facility for gross hacks :P
 	void sendMessage(UIMessage message, const char *value);
 
-	Screen *topScreen() const;
+	const Screen *topScreen() const {
+		return stack_.empty() ? nullptr : stack_.back().screen;
+	}
+	Screen *topScreen() {
+		return stack_.empty() ? nullptr : stack_.back().screen;
+	}
 
 	void getFocusPosition(float &x, float &y, float &z);
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1420,11 +1420,11 @@ bool EmuScreen::canBeBackground(bool isTop) const {
 		return isTop || (g_Config.bTransparentBackground && g_Config.bRunBehindPauseMenu);
 	}
 
-	bool forceTransparent = false;  // this needs to be true somehow on the display layout screen.
-
-	if (!g_Config.bTransparentBackground && !forceTransparent)
+	if (!g_Config.bTransparentBackground && !isTop) {
+		if (g_Config.bRunBehindPauseMenu || screenManager()->topScreen()->wantBrightBackground())
+			return true;
 		return false;
-
+	}
 	return true;
 }
 


### PR DESCRIPTION
If you turn off transparent background, the background will now become transparent anyway if you unpause when the pause screen is up, so the EmuScreen can run.

Also, the DisplayLayoutScreen works again with the option disabled.

Followup to #18515 