### PR TITLE
[GPU/Vulkan] Fixed assignment index to itself

### DIFF
--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -390,7 +390,7 @@ void DrawEngineVulkan::DoFlush() {
 
 		int vcount = indexGen.VertexCount();
 		if (numDecodedVerts_ > 10 * vcount) {
-			decIndex_ = decIndex_;
+			decIndex_ = decodeIndsCounter_;
 		}
 
 		gpuStats.numUncachedVertsDrawn += indexGen.VertexCount();


### PR DESCRIPTION
@hrydgard I'm not sure if I chose assigned variable correctly, but maybe index counter was meant. The place found is very strange and clearly meant something else.