### PR TITLE
Android: Add option to ask system for 60hz output

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -568,7 +568,7 @@ static int FastForwardModeFromString(const std::string &s) {
 	return DefaultFastForwardMode();
 }
 
-std::string FastForwardModeToString(int v) {
+static std::string FastForwardModeToString(int v) {
 	switch (FastForwardMode(v)) {
 	case FastForwardMode::CONTINUOUS:
 		return "CONTINUOUS";
@@ -592,6 +592,7 @@ static const ConfigSetting graphicsSettings[] = {
 	ConfigSetting("D3D11Device", &g_Config.sD3D11Device, "", CfgFlag::DEFAULT),
 #endif
 	ConfigSetting("CameraDevice", &g_Config.sCameraDevice, "", CfgFlag::DEFAULT),
+	ConfigSetting("DisplayFramerateMode", &g_Config.iDisplayFramerateMode, 0, CfgFlag::DEFAULT),
 	ConfigSetting("VendorBugChecksEnabled", &g_Config.bVendorBugChecksEnabled, true, CfgFlag::DONT_SAVE),
 	ConfigSetting("UseGeometryShader", &g_Config.bUseGeometryShader, false, CfgFlag::PER_GAME),
 	ConfigSetting("SkipBufferEffects", &g_Config.bSkipBufferEffects, false, CfgFlag::PER_GAME | CfgFlag::REPORT),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -155,6 +155,7 @@ public:
 	std::string sD3D11Device;  // Windows only
 	std::string sCameraDevice;
 	std::string sMicDevice;
+	int iDisplayFramerateMode;  // enum DisplayFramerateMode. Android-only.
 
 	bool bSoftwareRendering;
 	bool bSoftwareRenderingJit;

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -168,3 +168,11 @@ enum class DebugOverlay : int {
 	GPU_ALLOCATOR,
 	FRAMEBUFFER_LIST,
 };
+
+// Android-only for now
+enum class DisplayFramerateMode : int {
+	DEFAULT,
+	REQUEST_60HZ,
+	FORCE_60HZ_METHOD1,
+	FORCE_60HZ_METHOD2,
+};

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -598,6 +598,10 @@ void __DisplayFlip(int cyclesLate) {
 		postEffectRequiresFlip = duplicateFrames || g_Config.bShaderChainRequires60FPS;
 	}
 
+	if (!FrameTimingThrottled()) {
+		NOTICE_LOG(SYSTEM, "Throttle: %d %d", (int)fastForwardSkipFlip, (int)postEffectRequiresFlip);
+	}
+
 	const bool fbDirty = gpu->FramebufferDirty();
 
 	bool needFlip = fbDirty || noRecentFlip || postEffectRequiresFlip;

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -716,6 +716,10 @@ void TouchTestScreen::axis(const AxisInput &axis) {
 void TouchTestScreen::DrawForeground(UIContext &dc) {
 	Bounds bounds = dc.GetLayoutBounds();
 
+	double now = time_now_d();
+	double delta = now - lastFrameTime_;
+	lastFrameTime_ = now;
+
 	dc.BeginNoTex();
 	for (int i = 0; i < MAX_TOUCH_POINTS; i++) {
 		if (touches_[i].id != -1) {
@@ -747,18 +751,18 @@ void TouchTestScreen::DrawForeground(UIContext &dc) {
 #endif
 		"dp_res: %dx%d pixel_res: %dx%d\n"
 		"g_dpi: %0.3f g_dpi_scale: %0.3fx%0.3f\n"
-		"g_dpi_scale_real: %0.3fx%0.3f\n%s",
+		"g_dpi_scale_real: %0.3fx%0.3f\n"
+		"delta: %0.2f ms fps: %0.3f\n%s",
 #if PPSSPP_PLATFORM(ANDROID)
 		System_GetPropertyInt(SYSPROP_DISPLAY_XRES), System_GetPropertyInt(SYSPROP_DISPLAY_YRES),
 #endif
-		g_display.dp_xres, g_display.dp_yres,
-		g_display.pixel_xres, g_display.pixel_yres,
-		g_display.dpi,
-		g_display.dpi_scale_x, g_display.dpi_scale_y,
-		g_display.dpi_scale_real_x, g_display.dpi_scale_real_y, extra_debug);
+		g_display.dp_xres, g_display.dp_yres, g_display.pixel_xres, g_display.pixel_yres,
+		g_display.dpi, g_display.dpi_scale_x, g_display.dpi_scale_y,
+		g_display.dpi_scale_real_x, g_display.dpi_scale_real_y,
+		delta * 1000.0, 1.0 / delta,
+		extra_debug);
 
 	// On Android, also add joystick debug data.
-
 
 	dc.DrawTextShadow(buffer, bounds.centerX(), bounds.y + 20.0f, 0xFFFFFFFF, FLAG_DYNAMIC_ASCII);
 	dc.Flush();

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -169,6 +169,8 @@ protected:
 
 	UI::TextView *lastKeyEvents_ = nullptr;
 
+	double lastFrameTime_ = 0.0;
+
 	void CreateViews() override;
 	void UpdateLogView();
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1731,6 +1731,19 @@ void DeveloperToolsScreen::CreateViews() {
 		list->Add(new CheckBox(&g_Config.bGpuLogProfiler, dev->T("GPU log profiler")));
 	}
 
+#if PPSSPP_PLATFORM(ANDROID)
+	static const char *framerateModes[] = { "Default", "Request 60Hz", "Force 60Hz 1", "Force 60Hz 2" };
+	PopupMultiChoice *framerateMode = list->Add(new PopupMultiChoice(&g_Config.iDisplayFramerateMode, gr->T("Framerate mode"), framerateModes, 0, ARRAY_SIZE(framerateModes), I18NCat::GRAPHICS, screenManager()));
+	framerateMode->SetEnabledFunc([]() { return System_GetPropertyInt(SYSPROP_SYSTEMVERSION) >= 30; });
+	if (System_GetPropertyInt(SYSPROP_SYSTEMVERSION) < 31) {
+		framerateMode->HideChoice(3);  // not available
+	}
+	framerateMode->OnChoice.Add([this](UI::EventParams &e) {
+		System_Notify(SystemNotification::FORCE_RECREATE_ACTIVITY);
+		return UI::EVENT_DONE;
+	});
+#endif
+
 	static const char *ffModes[] = { "Render all frames", "", "Frame Skipping" };
 	PopupMultiChoice *ffMode = list->Add(new PopupMultiChoice(&g_Config.iFastForwardMode, dev->T("Fast-forward mode"), ffModes, 0, ARRAY_SIZE(ffModes), I18NCat::GRAPHICS, screenManager()));
 	ffMode->SetEnabledFunc([]() { return !g_Config.bVSync; });

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1464,6 +1464,10 @@ extern "C" jint JNICALL Java_org_ppsspp_ppsspp_NativeApp_getDesiredBackbufferHei
 	return desiredBackbufferSizeY;
 }
 
+extern "C" jint JNICALL Java_org_ppsspp_ppsspp_NativeApp_getDisplayFramerateMode(JNIEnv *, jclass) {
+	return g_Config.iDisplayFramerateMode;
+}
+
 std::vector<std::string> System_GetCameraDeviceList() {
 	jclass cameraClass = findClass("org/ppsspp/ppsspp/CameraHelper");
 	jmethodID deviceListMethod = getEnv()->GetStaticMethodID(cameraClass, "getDeviceList", "()Ljava/util/ArrayList;");

--- a/android/src/org/ppsspp/ppsspp/NativeApp.java
+++ b/android/src/org/ppsspp/ppsspp/NativeApp.java
@@ -56,6 +56,7 @@ public class NativeApp {
 	public static native String queryConfig(String queryName);
 
 	public static native int getSelectedCamera();
+	public static native int getDisplayFramerateMode();
 	public static native void setGpsDataAndroid(long time, float hdop, float latitude, float longitude, float altitude, float speed, float bearing);
 	public static native void setSatInfoAndroid(short index, short id, short elevation, short azimuth, short snr, short good);
 	public static native void pushCameraImageAndroid(byte[] image);

--- a/android/src/org/ppsspp/ppsspp/NativeGLView.java
+++ b/android/src/org/ppsspp/ppsspp/NativeGLView.java
@@ -18,6 +18,8 @@ import android.os.Build;
 import android.os.Handler;
 import android.util.Log;
 import android.view.MotionEvent;
+import android.view.Surface;
+import android.view.SurfaceControl;
 
 import com.bda.controller.Controller;
 import com.bda.controller.ControllerListener;
@@ -43,6 +45,7 @@ public class NativeGLView extends GLSurfaceView implements SensorEventListener, 
 		mAccelerometer = mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
 
 		mController = Controller.getInstance(activity);
+
 		try {
 			MogaHack.init(mController, activity);
 			Log.i(TAG, "MOGA initialized");

--- a/android/src/org/ppsspp/ppsspp/NativeSurfaceView.java
+++ b/android/src/org/ppsspp/ppsspp/NativeSurfaceView.java
@@ -17,6 +17,8 @@ import android.os.Handler;
 import android.util.Log;
 import android.view.InputDevice;
 import android.view.MotionEvent;
+import android.view.Surface;
+import android.view.SurfaceControl;
 import android.view.SurfaceView;
 
 import com.bda.controller.Controller;
@@ -44,8 +46,6 @@ public class NativeSurfaceView extends SurfaceView implements SensorEventListene
 		mAccelerometer = mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
 
 		mController = Controller.getInstance(activity);
-
-		// this.getHolder().setFormat(PixelFormat.RGBA_8888);
 
 		try {
 			MogaHack.init(mController, activity);

--- a/android/src/org/ppsspp/ppsspp/PpssppActivity.java
+++ b/android/src/org/ppsspp/ppsspp/PpssppActivity.java
@@ -1,5 +1,6 @@
 package org.ppsspp.ppsspp;
 
+import android.annotation.TargetApi;
 import android.app.AlertDialog;
 import android.content.Intent;
 import android.net.Uri;
@@ -150,6 +151,7 @@ public class PpssppActivity extends NativeActivity {
 		}
 	}
 
+	@TargetApi(Build.VERSION_CODES.HONEYCOMB_MR1)
 	public int openContentUri(String uriString, String mode) {
 		try {
 			Uri uri = Uri.parse(uriString);

--- a/android/src/org/ppsspp/ppsspp/SizeManager.java
+++ b/android/src/org/ppsspp/ppsspp/SizeManager.java
@@ -91,7 +91,11 @@ public class SizeManager implements SurfaceHolder.Callback {
 			Log.i(TAG, "Bad orientation detected but ignored" + (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT ? " (sdk version)" : ""));
 		}
 
-		Log.d(TAG, "Surface created. pixelWidth=" + pixelWidth + ", pixelHeight=" + pixelHeight + " holder: " + holder.toString() + " or: " + requestedOr);
+		Display display = activity.getWindowManager().getDefaultDisplay();
+
+		refreshRate = display.getRefreshRate();
+
+		Log.d(TAG, "Surface created. pixelWidth=" + pixelWidth + ", pixelHeight=" + pixelHeight + " holder: " + holder.toString() + " or: " + requestedOr + " " + refreshRate + "Hz");
 		NativeApp.setDisplayParameters(pixelWidth, pixelHeight, (int)densityDpi, refreshRate);
 		getDesiredBackbufferSize(desiredSize);
 


### PR DESCRIPTION
Add option in dev tools to ask Android for 60hz display using Surface.setFrameRate

Might help #18514 and #18480 if we're lucky.

Note, this doesn't change any games to 60fps or anything like that, it's just about display modes.