### PR TITLE
OpenXR - Gran Turismo camera shaking workaround

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -144,6 +144,7 @@ void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID)
 	CheckSetting(iniFile, gameID, "MirroringVariant", &vrCompat_.MirroringVariant);
 	CheckSetting(iniFile, gameID, "Skyplane", &vrCompat_.Skyplane);
 	CheckSetting(iniFile, gameID, "UnitsPerMeter", &vrCompat_.UnitsPerMeter);
+	CheckSetting(iniFile, gameID, "UnstableProjection", &vrCompat_.UnstableProjection);
 
 	NOTICE_LOG(G3D, "UnitsPerMeter for %s: %f", gameID.c_str(), vrCompat_.UnitsPerMeter);
 }

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -114,6 +114,7 @@ struct VRCompat {
 	int MirroringVariant;
 	bool Skyplane;
 	float UnitsPerMeter;
+	bool UnstableProjection;
 };
 
 class IniFile;

--- a/assets/compatvr.ini
+++ b/assets/compatvr.ini
@@ -131,6 +131,18 @@ ULJM05884 = true
 ULUS10160 = true
 
 
+[UnstableProjection]
+# Workaround for projection matrix which is changing fast.
+# Note that in some games this might cause graphics glitches on Meta Quest 3
+
+# Gran Turismo: The Real Driving Simulator
+NPJG00027 = true
+UCAS40265 = true
+UCES01245 = true
+UCJS10100 = true
+UCUS98632 = true
+
+
 [UnitsPerMeter]
 # Scale of game world to convert the world units into meters. This enables following VR features:
 # + 3D stereoscopy  (that can work only with accurate values)


### PR DESCRIPTION
Since https://github.com/hrydgard/ppsspp/pull/18438 there is VR camera shaking in Gran Turismo. This PR fixes that on all headsets.