### PR TITLE
UI image loading refactor

### DIFF
--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1685,7 +1685,7 @@ void VKContext::BindFramebufferAsTexture(Framebuffer *fbo, int binding, FBChanne
 		break;
 	}
 
-	boundTextures_[binding].clear();
+	boundTextures_[binding].reset(nullptr);
 	boundImageView_[binding] = renderManager_.BindFramebufferAsTexture(fb->GetFB(), binding, aspect, layer);
 }
 

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -419,11 +419,12 @@ struct AutoRef {
 		return ptr != nullptr;
 	}
 
-	void clear() {
+	// Takes over ownership over newItem, so we don't need to AddRef it, the number of owners didn't change.
+	void reset(T *newItem) {
 		if (ptr) {
 			ptr->Release();
-			ptr = nullptr;
 		}
+		ptr = newItem;
 	}
 
 	T *ptr = nullptr;

--- a/Common/Render/ManagedTexture.cpp
+++ b/Common/Render/ManagedTexture.cpp
@@ -152,6 +152,19 @@ Draw::Texture *CreateTextureFromFileData(Draw::DrawContext *draw, const uint8_t 
 	return texture;
 }
 
+Draw::Texture *CreateTextureFromFile(Draw::DrawContext *draw, const char *filename, ImageFileType type, bool generateMips) {
+	INFO_LOG(SYSTEM, "CreateTextureFromFile(%s)", filename);
+	size_t fileSize;
+	uint8_t *buffer = g_VFS.ReadFile(filename, &fileSize);
+	if (!buffer) {
+		ERROR_LOG(IO, "Failed to read file '%s'", filename);
+		return nullptr;
+	}
+	Draw::Texture *texture = CreateTextureFromFileData(draw, buffer, fileSize, type, generateMips, filename);
+	delete[] buffer;
+	return texture;
+}
+
 bool ManagedTexture::LoadFromFileData(const uint8_t *data, size_t dataSize, ImageFileType type, bool generateMips, const char *name) {
 	generateMips_ = generateMips;
 
@@ -171,6 +184,7 @@ bool ManagedTexture::LoadFromFileData(const uint8_t *data, size_t dataSize, Imag
 }
 
 bool ManagedTexture::LoadFromFile(const std::string &filename, ImageFileType type, bool generateMips) {
+	INFO_LOG(SYSTEM, "ManagedTexture::LoadFromFile (%s)", filename.c_str());
 	generateMips_ = generateMips;
 	size_t fileSize;
 	uint8_t *buffer = g_VFS.ReadFile(filename.c_str(), &fileSize);
@@ -191,6 +205,7 @@ bool ManagedTexture::LoadFromFile(const std::string &filename, ImageFileType typ
 }
 
 std::unique_ptr<ManagedTexture> CreateManagedTextureFromFile(Draw::DrawContext *draw, const char *filename, ImageFileType type, bool generateMips) {
+	INFO_LOG(SYSTEM, "ManagedTexture::CreateFromFile (%s)", filename);
 	if (!draw)
 		return std::unique_ptr<ManagedTexture>();
 	// TODO: Load the texture on a background thread.
@@ -233,18 +248,4 @@ Draw::Texture *ManagedTexture::GetTexture() {
 		loadPending_ = false;
 	}
 	return texture_;
-}
-
-// TODO: Remove the code duplication between this and LoadFromFileData
-std::unique_ptr<ManagedTexture> CreateManagedTextureFromFileData(Draw::DrawContext *draw, const uint8_t *data, int size, ImageFileType type, bool generateMips, const char *name) {
-	if (!draw)
-		return std::unique_ptr<ManagedTexture>();
-	ManagedTexture *mtex = new ManagedTexture(draw);
-	if (mtex->LoadFromFileData(data, size, type, generateMips, name)) {
-		return std::unique_ptr<ManagedTexture>(mtex);
-	} else {
-		// Best to return a null pointer if we fail!
-		delete mtex;
-		return std::unique_ptr<ManagedTexture>();
-	}
 }

--- a/Common/Render/ManagedTexture.cpp
+++ b/Common/Render/ManagedTexture.cpp
@@ -179,7 +179,7 @@ bool ManagedTexture::LoadFromFile(const std::string &filename, ImageFileType typ
 	return retval;
 }
 
-std::unique_ptr<ManagedTexture> CreateTextureFromFile(Draw::DrawContext *draw, const char *filename, ImageFileType type, bool generateMips) {
+std::unique_ptr<ManagedTexture> CreateManagedTextureFromFile(Draw::DrawContext *draw, const char *filename, ImageFileType type, bool generateMips) {
 	if (!draw)
 		return std::unique_ptr<ManagedTexture>();
 	// TODO: Load the texture on a background thread.
@@ -225,7 +225,7 @@ Draw::Texture *ManagedTexture::GetTexture() {
 }
 
 // TODO: Remove the code duplication between this and LoadFromFileData
-std::unique_ptr<ManagedTexture> CreateTextureFromFileData(Draw::DrawContext *draw, const uint8_t *data, int size, ImageFileType type, bool generateMips, const char *name) {
+std::unique_ptr<ManagedTexture> CreateManagedTextureFromFileData(Draw::DrawContext *draw, const uint8_t *data, int size, ImageFileType type, bool generateMips, const char *name) {
 	if (!draw)
 		return std::unique_ptr<ManagedTexture>();
 	ManagedTexture *mtex = new ManagedTexture(draw);

--- a/Common/Render/ManagedTexture.cpp
+++ b/Common/Render/ManagedTexture.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cstring>
 
 #include "Common/GPU/thin3d.h"
 #include "ext/jpge/jpgd.h"
@@ -16,6 +17,30 @@
 #include "Common/TimeUtil.h"
 #include "Common/Render/ManagedTexture.h"
 
+// For UI images loaded from disk, loaded into RAM, generally staged for upload.
+// The reason for the separation is so that the image can be loaded and decompressed on a thread,
+// and then only uploaded to the GPU on the main thread.
+struct TempImage {
+	~TempImage() {
+		_dbg_assert_(levels[0] == nullptr);
+	}
+	Draw::DataFormat fmt = Draw::DataFormat::UNDEFINED;
+	ImageFileType type = TYPE_UNKNOWN;
+	uint8_t *levels[16]{};   // only free the first pointer, they all point to the same buffer.
+	int zimFlags = 0;
+	int width[16]{};
+	int height[16]{};
+	int numLevels = 0;
+
+	bool LoadTextureLevels(const uint8_t *data, size_t size, ImageFileType typeSuggestion = DETECT);
+	void Free() {
+		if (levels[0]) {
+			free(levels[0]);
+			memset(levels, 0, sizeof(levels));
+		}
+	}
+};
+
 static Draw::DataFormat ZimToT3DFormat(int zim) {
 	switch (zim) {
 	case ZIM_RGBA8888: return Draw::DataFormat::R8G8B8A8_UNORM;
@@ -29,44 +54,40 @@ static ImageFileType DetectImageFileType(const uint8_t *data, size_t size) {
 	}
 	if (!memcmp(data, "ZIMG", 4)) {
 		return ZIM;
-	}
-	else if (!memcmp(data, "\x89\x50\x4E\x47", 4)) {
+	} else if (!memcmp(data, "\x89\x50\x4E\x47", 4)) {
 		return PNG;
-	}
-	else if (!memcmp(data, "\xff\xd8\xff\xe0", 4) || !memcmp(data, "\xff\xd8\xff\xe1", 4)) {
+	} else if (!memcmp(data, "\xff\xd8\xff\xe0", 4) || !memcmp(data, "\xff\xd8\xff\xe1", 4)) {
 		return JPEG;
-	}
-	else {
+	} else {
 		return TYPE_UNKNOWN;
 	}
 }
 
-static bool LoadTextureLevels(const uint8_t *data, size_t size, ImageFileType type, int width[16], int height[16], int *num_levels, Draw::DataFormat *fmt, uint8_t *image[16], int *zim_flags) {
-	if (type == DETECT) {
-		type = DetectImageFileType(data, size);
+bool TempImage::LoadTextureLevels(const uint8_t *data, size_t size, ImageFileType typeSuggestion) {
+	if (typeSuggestion == DETECT) {
+		typeSuggestion = DetectImageFileType(data, size);
 	}
-	if (type == TYPE_UNKNOWN) {
+	if (typeSuggestion == TYPE_UNKNOWN) {
 		ERROR_LOG(G3D, "File (size: %d) has unknown format", (int)size);
 		return false;
 	}
 
-	*num_levels = 0;
-	*zim_flags = 0;
+	type = typeSuggestion;
+	numLevels = 0;
+	zimFlags = 0;
 
-	switch (type) {
+	switch (typeSuggestion) {
 	case ZIM:
-	{
-		*num_levels = LoadZIMPtr((const uint8_t *)data, size, width, height, zim_flags, image);
-		*fmt = ZimToT3DFormat(*zim_flags & ZIM_FORMAT_MASK);
-	}
-	break;
+		numLevels = LoadZIMPtr((const uint8_t *)data, size, width, height, &zimFlags, levels);
+		fmt = ZimToT3DFormat(zimFlags & ZIM_FORMAT_MASK);
+		break;
 
 	case PNG:
-		if (1 == pngLoadPtr((const unsigned char *)data, size, &width[0], &height[0], &image[0])) {
-			*num_levels = 1;
-			*fmt = Draw::DataFormat::R8G8B8A8_UNORM;
-			if (!image[0]) {
-				ERROR_LOG(IO, "WTF");
+		if (1 == pngLoadPtr((const unsigned char *)data, size, &width[0], &height[0], &levels[0])) {
+			numLevels = 1;
+			fmt = Draw::DataFormat::R8G8B8A8_UNORM;
+			if (!levels[0]) {
+				ERROR_LOG(IO, "pngLoadPtr failed (input size = %d)", (int)size);
 				return false;
 			}
 		} else {
@@ -80,40 +101,36 @@ static bool LoadTextureLevels(const uint8_t *data, size_t size, ImageFileType ty
 		int actual_components = 0;
 		unsigned char *jpegBuf = jpgd::decompress_jpeg_image_from_memory(data, (int)size, &width[0], &height[0], &actual_components, 4);
 		if (jpegBuf) {
-			*num_levels = 1;
-			*fmt = Draw::DataFormat::R8G8B8A8_UNORM;
-			image[0] = (uint8_t *)jpegBuf;
+			numLevels = 1;
+			fmt = Draw::DataFormat::R8G8B8A8_UNORM;
+			levels[0] = (uint8_t *)jpegBuf;
 		}
+		break;
 	}
-	break;
 
 	default:
 		ERROR_LOG(IO, "Unsupported image format %d", (int)type);
 		return false;
 	}
 
-	return *num_levels > 0;
+	return numLevels > 0;
 }
 
 bool ManagedTexture::LoadFromFileData(const uint8_t *data, size_t dataSize, ImageFileType type, bool generateMips, const char *name) {
 	generateMips_ = generateMips;
 	using namespace Draw;
 
-	int width[16]{}, height[16]{};
-	uint8_t *image[16]{};
-
-	int num_levels = 0;
-	int zim_flags = 0;
-	DataFormat fmt;
-	if (!LoadTextureLevels(data, dataSize, type, width, height, &num_levels, &fmt, image, &zim_flags)) {
+	TempImage image;
+	if (!image.LoadTextureLevels(data, dataSize, type)) {
 		return false;
 	}
 
-	_assert_(image[0] != nullptr);
+	_assert_(image.levels[0] != nullptr);
 
-	if (num_levels < 0 || num_levels >= 16) {
-		ERROR_LOG(IO, "Invalid num_levels: %d. Falling back to one. Image: %dx%d", num_levels, width[0], height[0]);
-		num_levels = 1;
+	int numLevels = image.numLevels;
+	if (numLevels < 0 || numLevels >= 16) {
+		ERROR_LOG(IO, "Invalid num_levels: %d. Falling back to one. Image: %dx%d", numLevels, image.width[0], image.height[0]);
+		numLevels = 1;
 	}
 
 	// Free the old texture, if any.
@@ -122,26 +139,23 @@ bool ManagedTexture::LoadFromFileData(const uint8_t *data, size_t dataSize, Imag
 		texture_ = nullptr;
 	}
 
-	int potentialLevels = std::min(log2i(width[0]), log2i(height[0]));
-	if (width[0] > 0 && height[0] > 0) {
+	int potentialLevels = std::min(log2i(image.width[0]), log2i(image.height[0]));
+	if (image.width[0] > 0 && image.height[0] > 0) {
 		TextureDesc desc{};
 		desc.type = TextureType::LINEAR2D;
-		desc.format = fmt;
-		desc.width = width[0];
-		desc.height = height[0];
+		desc.format = image.fmt;
+		desc.width = image.width[0];
+		desc.height = image.height[0];
 		desc.depth = 1;
-		desc.mipLevels = generateMips ? potentialLevels : num_levels;
-		desc.generateMips = generateMips && potentialLevels > num_levels;
+		desc.mipLevels = generateMips ? potentialLevels : image.numLevels;
+		desc.generateMips = generateMips && potentialLevels > image.numLevels;
 		desc.tag = name;
-		for (int i = 0; i < num_levels; i++) {
-			desc.initData.push_back(image[i]);
+		for (int i = 0; i < image.numLevels; i++) {
+			desc.initData.push_back(image.levels[i]);
 		}
 		texture_ = draw_->CreateTexture(desc);
 	}
-	for (int i = 0; i < num_levels; i++) {
-		if (image[i])
-			free(image[i]);
-	}
+	image.Free();
 	return texture_ != nullptr;
 }
 

--- a/Common/Render/ManagedTexture.h
+++ b/Common/Render/ManagedTexture.h
@@ -40,6 +40,6 @@ private:
 	bool loadPending_ = false;
 };
 
-std::unique_ptr<ManagedTexture> CreateTextureFromFile(Draw::DrawContext *draw, const char *filename, ImageFileType fileType, bool generateMips);
-std::unique_ptr<ManagedTexture> CreateTextureFromFileData(Draw::DrawContext *draw, const uint8_t *data, int size, ImageFileType fileType, bool generateMips, const char *name);
+std::unique_ptr<ManagedTexture> CreateManagedTextureFromFile(Draw::DrawContext *draw, const char *filename, ImageFileType fileType, bool generateMips);
+std::unique_ptr<ManagedTexture> CreateManagedTextureFromFileData(Draw::DrawContext *draw, const uint8_t *data, int size, ImageFileType fileType, bool generateMips, const char *name);
 

--- a/Common/Render/ManagedTexture.h
+++ b/Common/Render/ManagedTexture.h
@@ -40,6 +40,7 @@ private:
 	bool loadPending_ = false;
 };
 
+Draw::Texture *CreateTextureFromFileData(Draw::DrawContext *draw, const uint8_t *data, size_t dataSize, ImageFileType type, bool generateMips, const char *name);
+
 std::unique_ptr<ManagedTexture> CreateManagedTextureFromFile(Draw::DrawContext *draw, const char *filename, ImageFileType fileType, bool generateMips);
 std::unique_ptr<ManagedTexture> CreateManagedTextureFromFileData(Draw::DrawContext *draw, const uint8_t *data, int size, ImageFileType fileType, bool generateMips, const char *name);
-

--- a/Common/Render/ManagedTexture.h
+++ b/Common/Render/ManagedTexture.h
@@ -41,6 +41,6 @@ private:
 };
 
 Draw::Texture *CreateTextureFromFileData(Draw::DrawContext *draw, const uint8_t *data, size_t dataSize, ImageFileType type, bool generateMips, const char *name);
+Draw::Texture *CreateTextureFromFile(Draw::DrawContext *draw, const char *filename, ImageFileType type, bool generateMips);
 
 std::unique_ptr<ManagedTexture> CreateManagedTextureFromFile(Draw::DrawContext *draw, const char *filename, ImageFileType fileType, bool generateMips);
-std::unique_ptr<ManagedTexture> CreateManagedTextureFromFileData(Draw::DrawContext *draw, const uint8_t *data, int size, ImageFileType fileType, bool generateMips, const char *name);

--- a/Common/UI/AsyncImageFileView.cpp
+++ b/Common/UI/AsyncImageFileView.cpp
@@ -78,7 +78,7 @@ void AsyncImageFileView::DeviceRestored(Draw::DrawContext *draw) {
 void AsyncImageFileView::Draw(UIContext &dc) {
 	using namespace Draw;
 	if (!texture_ && !textureFailed_ && !filename_.empty()) {
-		texture_ = CreateTextureFromFile(dc.GetDrawContext(), filename_.c_str(), DETECT, true);
+		texture_ = CreateManagedTextureFromFile(dc.GetDrawContext(), filename_.c_str(), DETECT, true);
 		if (!texture_.get())
 			textureFailed_ = true;
 	}

--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -41,17 +41,17 @@ void UIContext::setUIAtlas(const std::string &name) {
 
 void UIContext::BeginFrame() {
 	if (!uitexture_ || UIAtlas_ != lastUIAtlas_) {
-		uitexture_ = CreateTextureFromFile(draw_, UIAtlas_.c_str(), ImageFileType::ZIM, false);
+		uitexture_ = CreateManagedTextureFromFile(draw_, UIAtlas_.c_str(), ImageFileType::ZIM, false);
 		lastUIAtlas_ = UIAtlas_;
 		if (!fontTexture_) {
 #if PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(ANDROID)
 			// Don't bother with loading font_atlas.zim
 #else
-			fontTexture_ = CreateTextureFromFile(draw_, "font_atlas.zim", ImageFileType::ZIM, false);
+			fontTexture_ = CreateManagedTextureFromFile(draw_, "font_atlas.zim", ImageFileType::ZIM, false);
 #endif
 			if (!fontTexture_) {
 				// Load the smaller ascii font only, like on Android. For debug ui etc.
-				fontTexture_ = CreateTextureFromFile(draw_, "asciifont_atlas.zim", ImageFileType::ZIM, false);
+				fontTexture_ = CreateManagedTextureFromFile(draw_, "asciifont_atlas.zim", ImageFileType::ZIM, false);
 				if (!fontTexture_) {
 					WARN_LOG(SYSTEM, "Failed to load font_atlas.zim or asciifont_atlas.zim");
 				}

--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -22,6 +22,8 @@ UIContext::~UIContext() {
 	sampler_->Release();
 	delete fontStyle_;
 	delete textDrawer_;
+	uitexture_->Release();
+	fontTexture_->Release();
 }
 
 void UIContext::Init(Draw::DrawContext *thin3d, Draw::Pipeline *uipipe, Draw::Pipeline *uipipenotex, DrawBuffer *uidrawbuffer) {
@@ -41,17 +43,17 @@ void UIContext::setUIAtlas(const std::string &name) {
 
 void UIContext::BeginFrame() {
 	if (!uitexture_ || UIAtlas_ != lastUIAtlas_) {
-		uitexture_ = CreateManagedTextureFromFile(draw_, UIAtlas_.c_str(), ImageFileType::ZIM, false);
+		uitexture_ = CreateTextureFromFile(draw_, UIAtlas_.c_str(), ImageFileType::ZIM, false);
 		lastUIAtlas_ = UIAtlas_;
 		if (!fontTexture_) {
 #if PPSSPP_PLATFORM(WINDOWS) || PPSSPP_PLATFORM(ANDROID)
 			// Don't bother with loading font_atlas.zim
 #else
-			fontTexture_ = CreateManagedTextureFromFile(draw_, "font_atlas.zim", ImageFileType::ZIM, false);
+			fontTexture_ = CreateTextureFromFile(draw_, "font_atlas.zim", ImageFileType::ZIM, false);
 #endif
 			if (!fontTexture_) {
 				// Load the smaller ascii font only, like on Android. For debug ui etc.
-				fontTexture_ = CreateManagedTextureFromFile(draw_, "asciifont_atlas.zim", ImageFileType::ZIM, false);
+				fontTexture_ = CreateTextureFromFile(draw_, "asciifont_atlas.zim", ImageFileType::ZIM, false);
 				if (!fontTexture_) {
 					WARN_LOG(SYSTEM, "Failed to load font_atlas.zim or asciifont_atlas.zim");
 				}
@@ -88,15 +90,15 @@ void UIContext::BeginPipeline(Draw::Pipeline *pipeline, Draw::SamplerState *samp
 
 void UIContext::RebindTexture() const {
 	if (uitexture_)
-		draw_->BindTexture(0, uitexture_->GetTexture());
+		draw_->BindTexture(0, uitexture_);
 }
 
 void UIContext::BindFontTexture() const {
 	// Fall back to the UI texture, in case they have an old atlas.
 	if (fontTexture_)
-		draw_->BindTexture(0, fontTexture_->GetTexture());
+		draw_->BindTexture(0, fontTexture_);
 	else if (uitexture_)
-		draw_->BindTexture(0, uitexture_->GetTexture());
+		draw_->BindTexture(0, uitexture_);
 }
 
 void UIContext::Flush() {

--- a/Common/UI/Context.h
+++ b/Common/UI/Context.h
@@ -23,7 +23,6 @@ namespace Draw {
 }
 
 class Texture;
-class ManagedTexture;
 class DrawBuffer;
 class TextDrawer;
 
@@ -128,8 +127,8 @@ private:
 	Draw::SamplerState *sampler_ = nullptr;
 	Draw::Pipeline *ui_pipeline_ = nullptr;
 	Draw::Pipeline *ui_pipeline_notex_ = nullptr;
-	std::unique_ptr<ManagedTexture> uitexture_;
-	std::unique_ptr<ManagedTexture> fontTexture_;
+	Draw::Texture *uitexture_ = nullptr;
+	Draw::Texture *fontTexture_ = nullptr;
 
 	DrawBuffer *uidrawbuffer_ = nullptr;
 

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -267,6 +267,8 @@ void ScreenManager::shutdown() {
 	nextStack_.clear();
 	delete overlayScreen_;
 	overlayScreen_ = nullptr;
+	delete backgroundScreen_;
+	backgroundScreen_ = nullptr;
 }
 
 void ScreenManager::push(Screen *screen, int layerFlags) {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -924,7 +924,7 @@ public:
 
 		// PIC1 is the loading image, so let's only draw if it's available.
 		if (ginfo && ginfo->pic1.texture) {
-			Draw::Texture *texture = ginfo->pic1.texture->GetTexture();
+			Draw::Texture *texture = ginfo->pic1.texture;
 			if (texture) {
 				dc.GetDrawContext()->BindTexture(0, texture);
 

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -27,9 +27,9 @@
 #include "Common/File/VFS/VFS.h"
 #include "Common/File/FileUtil.h"
 #include "Common/File/Path.h"
+#include "Common/Render/ManagedTexture.h"
 #include "Common/StringUtils.h"
 #include "Common/TimeUtil.h"
-#include "Common/Render/ManagedTexture.h"
 #include "Core/FileSystems/ISOFileSystem.h"
 #include "Core/FileSystems/DirectoryFileSystem.h"
 #include "Core/FileSystems/VirtualDiscFileSystem.h"
@@ -42,6 +42,17 @@
 #include "UI/GameInfoCache.h"
 
 GameInfoCache *g_gameInfoCache;
+
+void GameInfoTex::Clear() {
+	if (!data.empty()) {
+		data.clear();
+		dataLoaded = false;
+	}
+	if (texture) {
+		texture->Release();
+		texture = nullptr;
+	}
+}
 
 GameInfo::GameInfo() : fileType(IdentifiedFileType::UNKNOWN) {
 	pending = true;

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -760,7 +760,7 @@ void GameInfoCache::WaitUntilDone(std::shared_ptr<GameInfo> &info) {
 }
 
 // Runs on the main thread. Only call from render() and similar, not update()!
-// Can also be called from the audio thread for menu background music.
+// Can also be called from the audio thread for menu background music, but that cannot request images!
 std::shared_ptr<GameInfo> GameInfoCache::GetInfo(Draw::DrawContext *draw, const Path &gamePath, int wantFlags) {
 	std::shared_ptr<GameInfo> info;
 

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -816,7 +816,7 @@ void GameInfoCache::SetupTexture(std::shared_ptr<GameInfo> &info, Draw::DrawCont
 	using namespace Draw;
 	if (tex.data.size()) {
 		if (!tex.texture) {
-			tex.texture = CreateManagedTextureFromFileData(thin3d, (const uint8_t *)tex.data.data(), (int)tex.data.size(), ImageFileType::DETECT, false, info->GetTitle().c_str());
+			tex.texture = CreateTextureFromFileData(thin3d, (const uint8_t *)tex.data.data(), (int)tex.data.size(), ImageFileType::DETECT, false, info->GetTitle().c_str());
 			if (tex.texture) {
 				tex.timeLoaded = time_now_d();
 			} else {

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -816,7 +816,7 @@ void GameInfoCache::SetupTexture(std::shared_ptr<GameInfo> &info, Draw::DrawCont
 	using namespace Draw;
 	if (tex.data.size()) {
 		if (!tex.texture) {
-			tex.texture = CreateTextureFromFileData(thin3d, (const uint8_t *)tex.data.data(), (int)tex.data.size(), ImageFileType::DETECT, false, info->GetTitle().c_str());
+			tex.texture = CreateManagedTextureFromFileData(thin3d, (const uint8_t *)tex.data.data(), (int)tex.data.size(), ImageFileType::DETECT, false, info->GetTitle().c_str());
 			if (tex.texture) {
 				tex.timeLoaded = time_now_d();
 			} else {

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -64,18 +64,22 @@ enum class IdentifiedFileType;
 
 struct GameInfoTex {
 	std::string data;
-	std::unique_ptr<ManagedTexture> texture;
+	Draw::Texture *texture = nullptr;
 	// The time at which the Icon and the BG were loaded.
 	// Can be useful to fade them in smoothly once they appear.
 	double timeLoaded = 0.0;
 	std::atomic<bool> dataLoaded{};
 
+	// Can ONLY be called from the main thread!
 	void Clear() {
 		if (!data.empty()) {
 			data.clear();
 			dataLoaded = false;
 		}
-		texture.reset(nullptr);
+		if (texture) {
+			texture->Release();
+			texture = nullptr;
+		}
 	}
 };
 

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -26,7 +26,6 @@
 #include "Common/Thread/Event.h"
 #include "Core/ELF/ParamSFO.h"
 #include "Common/File/Path.h"
-#include "Common/Render/ManagedTexture.h"
 
 namespace Draw {
 	class DrawContext;
@@ -71,16 +70,7 @@ struct GameInfoTex {
 	std::atomic<bool> dataLoaded{};
 
 	// Can ONLY be called from the main thread!
-	void Clear() {
-		if (!data.empty()) {
-			data.clear();
-			dataLoaded = false;
-		}
-		if (texture) {
-			texture->Release();
-			texture = nullptr;
-		}
-	}
+	void Clear();
 };
 
 class GameInfo {

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -231,7 +231,7 @@ void GameButton::Draw(UIContext &dc) {
 	using namespace UI;
 
 	if (ginfo->icon.texture) {
-		texture = ginfo->icon.texture->GetTexture();
+		texture = ginfo->icon.texture;
 	}
 
 	int x = bounds_.x;
@@ -1425,7 +1425,7 @@ bool MainScreen::DrawBackgroundFor(UIContext &dc, const Path &gamePath, float pr
 	}
 
 	auto pic = ginfo->GetBGPic();
-	Draw::Texture *texture = pic ? pic->texture->GetTexture() : nullptr;
+	Draw::Texture *texture = pic ? pic->texture : nullptr;
 
 	uint32_t color = whiteAlpha(ease(progress)) & 0xFFc0c0c0;
 	if (texture) {

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -269,7 +269,7 @@ private:
 		if (!pic)
 			return;
 
-		dc.GetDrawContext()->BindTexture(0, pic->texture->GetTexture());
+		dc.GetDrawContext()->BindTexture(0, pic->texture);
 		uint32_t color = whiteAlpha(amount) & 0xFFc0c0c0;
 		dc.Draw()->DrawTexRect(dc.GetBounds(), 0, 0, 1, 1, color);
 		dc.Flush();
@@ -379,7 +379,7 @@ void DrawGameBackground(UIContext &dc, const Path &gamePath, float x, float y, f
 
 	GameInfoTex *pic = ginfo ? ginfo->GetBGPic() : nullptr;
 	if (pic) {
-		dc.GetDrawContext()->BindTexture(0, pic->texture->GetTexture());
+		dc.GetDrawContext()->BindTexture(0, pic->texture);
 		uint32_t color = whiteAlpha(ease((time_now_d() - pic->timeLoaded) * 3)) & 0xFFc0c0c0;
 		dc.Draw()->DrawTexRect(dc.GetBounds(), 0,0,1,1, color);
 		dc.Flush();

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -294,7 +294,7 @@ void UIBackgroundInit(UIContext &dc) {
 	const Path bgJpg = GetSysDirectory(DIRECTORY_SYSTEM) / "background.jpg";
 	if (File::Exists(bgPng) || File::Exists(bgJpg)) {
 		const Path &bgFile = File::Exists(bgPng) ? bgPng : bgJpg;
-		bgTexture = CreateTextureFromFile(dc.GetDrawContext(), bgFile.c_str(), DETECT, true);
+		bgTexture = CreateManagedTextureFromFile(dc.GetDrawContext(), bgFile.c_str(), DETECT, true);
 	}
 }
 

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -300,7 +300,7 @@ void SavedataButton::Draw(UIContext &dc) {
 	using namespace UI;
 
 	if (ginfo->icon.texture) {
-		texture = ginfo->icon.texture->GetTexture();
+		texture = ginfo->icon.texture;
 	}
 
 	int x = bounds_.x;
@@ -736,7 +736,7 @@ void GameIconView::Draw(UIContext &dc) {
 	float nw = std::min(bounds_.h * textureWidth_ / textureHeight_, (float)bounds_.w);
 
 	dc.Flush();
-	dc.GetDrawContext()->BindTexture(0, info->icon.texture->GetTexture());
+	dc.GetDrawContext()->BindTexture(0, info->icon.texture);
 	dc.Draw()->Rect(bounds_.x, bounds_.y, nw, bounds_.h, color);
 	dc.Flush();
 	dc.RebindTexture();

--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -112,7 +112,7 @@ private:
 	std::shared_ptr<http::Request> download_;
 
 	std::string textureData_;
-	std::unique_ptr<ManagedTexture> texture_;
+	Draw::AutoRef<Draw::Texture> texture_;
 	bool textureFailed_ = false;
 	float fixedSizeW_ = 0.0f;
 	float fixedSizeH_ = 0.0f;
@@ -154,7 +154,9 @@ void HttpImageFileView::SetFilename(std::string filename) {
 	if (!useIconCache_ && path_ != filename) {
 		textureFailed_ = false;
 		path_ = filename;
-		texture_.reset(nullptr);
+		if (texture_) {
+			texture_.reset(nullptr);
+		}
 	}
 }
 
@@ -181,7 +183,7 @@ void HttpImageFileView::Draw(UIContext &dc) {
 		}
 
 		if (!textureData_.empty()) {
-			texture_ = CreateManagedTextureFromFileData(dc.GetDrawContext(), (const uint8_t *)(textureData_.data()), (int)textureData_.size(), DETECT, false, "store_icon");
+			texture_ = CreateTextureFromFileData(dc.GetDrawContext(), (const uint8_t *)(textureData_.data()), (int)textureData_.size(), DETECT, false, "store_icon");
 			if (!texture_)
 				textureFailed_ = true;
 			textureData_.clear();
@@ -198,7 +200,7 @@ void HttpImageFileView::Draw(UIContext &dc) {
 	if (useIconCache_) {
 		texture = g_iconCache.BindIconTexture(&dc, path_);
 	} else {
-		texture = texture_->GetTexture();
+		texture = texture_;
 	}
 
 	if (texture) {

--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -181,7 +181,7 @@ void HttpImageFileView::Draw(UIContext &dc) {
 		}
 
 		if (!textureData_.empty()) {
-			texture_ = CreateTextureFromFileData(dc.GetDrawContext(), (const uint8_t *)(textureData_.data()), (int)textureData_.size(), DETECT, false, "store_icon");
+			texture_ = CreateManagedTextureFromFileData(dc.GetDrawContext(), (const uint8_t *)(textureData_.data()), (int)textureData_.size(), DETECT, false, "store_icon");
 			if (!texture_)
 				textureFailed_ = true;
 			textureData_.clear();


### PR DESCRIPTION
The class `ManagedTexture` was originally meant for display of textures in the UI that would auto-reload from disk after DeviceLost/DeviceRestored.

Most of the existing uses are not used that way though, it's just been used as a convenient way to load image files.

So, do some refactoring of the image load logic to get rid of nearly all of them.

The actual reason is that I'm gonna make ManagedTexture a little more complex and implement image load on thread, for faster load of save state screenshots. The pause menu is a bit sluggish to open if you have five slots with high res screenshots. But for game icons and stuff, that's just not necessary.