### PR TITLE
Async texture load on Pause screen

### DIFF
--- a/Common/Render/ManagedTexture.h
+++ b/Common/Render/ManagedTexture.h
@@ -53,6 +53,10 @@ public:
 	void DeviceLost();
 	void DeviceRestored(Draw::DrawContext *draw);
 
+	bool Failed() const {
+		return state_ == LoadState::FAILED;
+	}
+
 	enum class LoadState {
 		PENDING,
 		FAILED,

--- a/Common/Render/ManagedTexture.h
+++ b/Common/Render/ManagedTexture.h
@@ -1,27 +1,51 @@
 #pragma once
 
+#include <cstring>
+#include <string_view>
 #include <memory>
 
 #include "Common/GPU/thin3d.h"
 #include "Common/UI/View.h"
 #include "Common/File/Path.h"
 
-enum ImageFileType {
+enum class ImageFileType {
 	PNG,
 	JPEG,
 	ZIM,
 	DETECT,
-	TYPE_UNKNOWN,
+	UNKNOWN,
 };
 
+class TextureLoadTask;
+class LimitedWaitable;
+
+// For UI images loaded from disk, loaded into RAM, generally staged for upload.
+// The reason for the separation is so that the image can be loaded and decompressed on a thread,
+// and then only uploaded to the GPU on the main thread.
+struct TempImage {
+	~TempImage();
+	Draw::DataFormat fmt = Draw::DataFormat::UNDEFINED;
+	ImageFileType type = ImageFileType::UNKNOWN;
+	uint8_t *levels[16]{};   // only free the first pointer, they all point to the same buffer.
+	int zimFlags = 0;
+	int width[16]{};
+	int height[16]{};
+	int numLevels = 0;
+
+	bool LoadTextureLevels(const uint8_t *data, size_t size, ImageFileType typeSuggestion = ImageFileType::DETECT);
+	void Free() {
+		if (levels[0]) {
+			free(levels[0]);
+			memset(levels, 0, sizeof(levels));
+		}
+	}
+};
+
+// Managed (will auto-reload from file) and async. For use in UI.
 class ManagedTexture {
 public:
-	ManagedTexture(Draw::DrawContext *draw) : draw_(draw) {}
-	~ManagedTexture() {
-		if (texture_)
-			texture_->Release();
-	}
-	bool LoadFromFile(const std::string &filename, ImageFileType type = ImageFileType::DETECT, bool generateMips = false);
+	ManagedTexture(Draw::DrawContext *draw, std::string_view filename, ImageFileType type = ImageFileType::DETECT, bool generateMips = false);
+	~ManagedTexture();
 	Draw::Texture *GetTexture();  // For immediate use, don't store.
 	int Width() const { return texture_->Width(); }
 	int Height() const { return texture_->Height(); }
@@ -29,15 +53,25 @@ public:
 	void DeviceLost();
 	void DeviceRestored(Draw::DrawContext *draw);
 
+	enum class LoadState {
+		PENDING,
+		FAILED,
+		SUCCESS,
+	};
+
 private:
+	void StartLoadTask();
+
 	Draw::Texture *texture_ = nullptr;
 	Draw::DrawContext *draw_;
 	std::string filename_;  // Textures that are loaded from files can reload themselves automatically.
 	bool generateMips_ = false;
-	bool loadPending_ = false;
+	ImageFileType type_ = ImageFileType::DETECT;
+	TextureLoadTask *loadTask_ = nullptr;
+	LimitedWaitable *taskWaitable_ = nullptr;
+	TempImage pendingImage_;
+	LoadState state_ = LoadState::PENDING;
 };
 
 Draw::Texture *CreateTextureFromFileData(Draw::DrawContext *draw, const uint8_t *data, size_t dataSize, ImageFileType type, bool generateMips, const char *name);
 Draw::Texture *CreateTextureFromFile(Draw::DrawContext *draw, const char *filename, ImageFileType type, bool generateMips);
-
-std::unique_ptr<ManagedTexture> CreateManagedTextureFromFile(Draw::DrawContext *draw, const char *filename, ImageFileType fileType, bool generateMips);

--- a/Common/Render/ManagedTexture.h
+++ b/Common/Render/ManagedTexture.h
@@ -16,15 +16,12 @@ enum ImageFileType {
 
 class ManagedTexture {
 public:
-	ManagedTexture(Draw::DrawContext *draw) : draw_(draw) {
-	}
+	ManagedTexture(Draw::DrawContext *draw) : draw_(draw) {}
 	~ManagedTexture() {
 		if (texture_)
 			texture_->Release();
 	}
-
 	bool LoadFromFile(const std::string &filename, ImageFileType type = ImageFileType::DETECT, bool generateMips = false);
-	bool LoadFromFileData(const uint8_t *data, size_t dataSize, ImageFileType type, bool generateMips, const char *name);
 	Draw::Texture *GetTexture();  // For immediate use, don't store.
 	int Width() const { return texture_->Width(); }
 	int Height() const { return texture_->Height(); }

--- a/Common/Thread/Waitable.h
+++ b/Common/Thread/Waitable.h
@@ -43,6 +43,11 @@ public:
 		cond_.notify_all();
 	}
 
+	// For simple polling.
+	bool Ready() const {
+		return triggered_;
+	}
+
 private:
 	std::condition_variable cond_;
 	std::mutex mutex_;

--- a/Common/UI/AsyncImageFileView.cpp
+++ b/Common/UI/AsyncImageFileView.cpp
@@ -100,12 +100,14 @@ void AsyncImageFileView::Draw(UIContext &dc) {
 			dc.DrawText(text_.c_str(), bounds_.centerX(), bounds_.centerY(), 0xFFFFFFFF, ALIGN_CENTER | FLAG_DYNAMIC_ASCII);
 		}
 	} else {
-		if (!filename_.empty()) {
-			// draw a black rectangle to represent the missing screenshot.
-			dc.FillRect(UI::Drawable(0xFF000000), GetBounds());
-		} else {
-			// draw a dark gray rectangle to represent no save state.
-			dc.FillRect(UI::Drawable(0x50202020), GetBounds());
+		if (!texture_ || texture_->Failed()) {
+			if (!filename_.empty()) {
+				// draw a black rectangle to represent the missing screenshot.
+				dc.FillRect(UI::Drawable(0xFF000000), GetBounds());
+			} else {
+				// draw a dark gray rectangle to represent no save state.
+				dc.FillRect(UI::Drawable(0x50202020), GetBounds());
+			}
 		}
 		if (!text_.empty()) {
 			dc.DrawText(text_.c_str(), bounds_.centerX(), bounds_.centerY(), 0xFFFFFFFF, ALIGN_CENTER | FLAG_DYNAMIC_ASCII);

--- a/Common/UI/AsyncImageFileView.cpp
+++ b/Common/UI/AsyncImageFileView.cpp
@@ -79,7 +79,7 @@ void AsyncImageFileView::DeviceRestored(Draw::DrawContext *draw) {
 void AsyncImageFileView::Draw(UIContext &dc) {
 	using namespace Draw;
 	if (!texture_ && !textureFailed_ && !filename_.empty()) {
-		texture_ = CreateManagedTextureFromFile(dc.GetDrawContext(), filename_.c_str(), DETECT, true);
+		texture_ = std::unique_ptr<ManagedTexture>(new ManagedTexture(dc.GetDrawContext(), filename_.c_str(), ImageFileType::DETECT, true));
 		if (!texture_.get())
 			textureFailed_ = true;
 	}

--- a/Common/UI/AsyncImageFileView.cpp
+++ b/Common/UI/AsyncImageFileView.cpp
@@ -2,6 +2,7 @@
 #include "Common/UI/AsyncImageFileView.h"
 #include "Common/UI/Context.h"
 #include "Common/Render/DrawBuffer.h"
+#include "Common/Render/ManagedTexture.h"
 
 AsyncImageFileView::AsyncImageFileView(const Path &filename, UI::ImageSizeMode sizeMode, UI::LayoutParams *layoutParams)
 	: UI::Clickable(layoutParams), canFocus_(true), filename_(filename), color_(0xFFFFFFFF), sizeMode_(sizeMode), textureFailed_(false), fixedSizeW_(0.0f), fixedSizeH_(0.0f) {}

--- a/Common/UI/AsyncImageFileView.h
+++ b/Common/UI/AsyncImageFileView.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "Common/UI/View.h"
-#include "Common/Render/ManagedTexture.h"
 #include "Common/File/Path.h"
 
 class UIContext;
+class ManagedTexture;
 
 // AsyncImageFileView loads a texture from a file, and reloads it as necessary.
 // TODO: Actually make async, doh.

--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -22,8 +22,10 @@ UIContext::~UIContext() {
 	sampler_->Release();
 	delete fontStyle_;
 	delete textDrawer_;
-	uitexture_->Release();
-	fontTexture_->Release();
+	if (uitexture_)
+		uitexture_->Release();
+	if (fontTexture_)
+		fontTexture_->Release();
 }
 
 void UIContext::Init(Draw::DrawContext *thin3d, Draw::Pipeline *uipipe, Draw::Pipeline *uipipenotex, DrawBuffer *uidrawbuffer) {

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -296,7 +296,7 @@ void UIBackgroundInit(UIContext &dc) {
 	const Path bgJpg = GetSysDirectory(DIRECTORY_SYSTEM) / "background.jpg";
 	if (File::Exists(bgPng) || File::Exists(bgJpg)) {
 		const Path &bgFile = File::Exists(bgPng) ? bgPng : bgJpg;
-		bgTexture = CreateTextureFromFile(dc.GetDrawContext(), bgFile.c_str(), DETECT, true);
+		bgTexture = CreateTextureFromFile(dc.GetDrawContext(), bgFile.c_str(), ImageFileType::DETECT, true);
 	}
 }
 

--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -183,7 +183,7 @@ void HttpImageFileView::Draw(UIContext &dc) {
 		}
 
 		if (!textureData_.empty()) {
-			texture_ = CreateTextureFromFileData(dc.GetDrawContext(), (const uint8_t *)(textureData_.data()), (int)textureData_.size(), DETECT, false, "store_icon");
+			texture_ = CreateTextureFromFileData(dc.GetDrawContext(), (const uint8_t *)(textureData_.data()), (int)textureData_.size(), ImageFileType::DETECT, false, "store_icon");
 			if (!texture_)
 				textureFailed_ = true;
 			textureData_.clear();


### PR DESCRIPTION
Load the savestate thumbnails on background tasks on the thread pool. 

Makes the pause menu feel a lot snappier to pop up when you have multiple save states.

Made possible by #18537 