### PR TITLE
Expose --escape-exit and --pause-menu-exit to be set from the ini file

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -289,6 +289,9 @@ static const ConfigSetting generalSettings[] = {
 #endif
 
 	ConfigSetting("PauseWhenMinimized", &g_Config.bPauseWhenMinimized, false, CfgFlag::PER_GAME),
+	ConfigSetting("PauseExitsEmulator", &g_Config.bPauseExitsEmulator, false, CfgFlag::DONT_SAVE),
+	ConfigSetting("PauseMenuExitsEmulator", &g_Config.bPauseMenuExitsEmulator, false, CfgFlag::DONT_SAVE),
+
 	ConfigSetting("DumpDecryptedEboots", &g_Config.bDumpDecryptedEboot, false, CfgFlag::PER_GAME),
 	ConfigSetting("FullscreenOnDoubleclick", &g_Config.bFullscreenOnDoubleclick, true, CfgFlag::DONT_SAVE),
 	ConfigSetting("ShowMenuBar", &g_Config.bShowMenuBar, true, CfgFlag::DEFAULT),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -97,7 +97,6 @@ public:
 
 	bool bPauseWhenMinimized;
 
-	// Not used on mobile devices.
 	bool bPauseExitsEmulator;
 	bool bPauseMenuExitsEmulator;
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -584,10 +584,8 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 					fileToLog = argv[i] + strlen("--log=");
 				if (!strncmp(argv[i], "--state=", strlen("--state=")) && strlen(argv[i]) > strlen("--state="))
 					stateToLoad = Path(std::string(argv[i] + strlen("--state=")));
-#if !defined(MOBILE_DEVICE)
 				if (!strncmp(argv[i], "--escape-exit", strlen("--escape-exit")))
 					g_Config.bPauseExitsEmulator = true;
-#endif
 				if (!strncmp(argv[i], "--pause-menu-exit", strlen("--pause-menu-exit")))
 					g_Config.bPauseMenuExitsEmulator = true;
 				if (!strcmp(argv[i], "--fullscreen")) {


### PR DESCRIPTION
You can now set:

- `--escape-exit` by setting `PauseExitsEmulator = true` in [General].  
- `--pause-menu-exit` by setting `PauseMenuExitsEmulator = true` in [General]. These are read-only settings.

Fixes #18528