### PR TITLE
Objects in function parameters have been replaced with constant references

### DIFF
--- a/Common/Arm64Emitter.cpp
+++ b/Common/Arm64Emitter.cpp
@@ -552,7 +552,7 @@ void ARM64XEmitter::EncodeSystemInst(u32 op0, u32 op1, u32 CRn, u32 CRm, u32 op2
 	Write32((0x354 << 22) | (op0 << 19) | (op1 << 16) | (CRn << 12) | (CRm << 8) | (op2 << 5) | Rt);
 }
 
-void ARM64XEmitter::EncodeArithmeticInst(u32 instenc, bool flags, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Option)
+void ARM64XEmitter::EncodeArithmeticInst(u32 instenc, bool flags, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Option)
 {
 	bool b64Bit = Is64Bit(Rd);
 
@@ -646,7 +646,7 @@ void ARM64XEmitter::EncodeData3SrcInst(u32 instenc, ARM64Reg Rd, ARM64Reg Rn, AR
 	        (Ra << 10) | (Rn << 5) | Rd);
 }
 
-void ARM64XEmitter::EncodeLogicalInst(u32 instenc, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift)
+void ARM64XEmitter::EncodeLogicalInst(u32 instenc, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift)
 {
 	bool b64Bit = Is64Bit(Rd);
 
@@ -771,7 +771,7 @@ void ARM64XEmitter::EncodeBitfieldMOVInst(u32 op, ARM64Reg Rd, ARM64Reg Rn, u32 
 	        (immr << 16) | (imms << 10) | (Rn << 5) | Rd);
 }
 
-void ARM64XEmitter::EncodeLoadStoreRegisterOffset(u32 size, u32 opc, ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm)
+void ARM64XEmitter::EncodeLoadStoreRegisterOffset(u32 size, u32 opc, ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm)
 {
 	Rt = DecodeReg(Rt);
 	Rn = DecodeReg(Rn);
@@ -1186,7 +1186,7 @@ void ARM64XEmitter::ADD(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 	ADD(Rd, Rn, Rm, ArithOption(Rd, ST_LSL, 0));
 }
 
-void ARM64XEmitter::ADD(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Option)
+void ARM64XEmitter::ADD(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Option)
 {
 	EncodeArithmeticInst(0, false, Rd, Rn, Rm, Option);
 }
@@ -1196,7 +1196,7 @@ void ARM64XEmitter::ADDS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 	EncodeArithmeticInst(0, true, Rd, Rn, Rm, ArithOption(Rd, ST_LSL, 0));
 }
 
-void ARM64XEmitter::ADDS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Option)
+void ARM64XEmitter::ADDS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Option)
 {
 	EncodeArithmeticInst(0, true, Rd, Rn, Rm, Option);
 }
@@ -1206,7 +1206,7 @@ void ARM64XEmitter::SUB(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 	SUB(Rd, Rn, Rm, ArithOption(Rd, ST_LSL, 0));
 }
 
-void ARM64XEmitter::SUB(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Option)
+void ARM64XEmitter::SUB(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Option)
 {
 	EncodeArithmeticInst(1, false, Rd, Rn, Rm, Option);
 }
@@ -1216,7 +1216,7 @@ void ARM64XEmitter::SUBS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 	EncodeArithmeticInst(1, true, Rd, Rn, Rm, ArithOption(Rd, ST_LSL, 0));
 }
 
-void ARM64XEmitter::SUBS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Option)
+void ARM64XEmitter::SUBS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Option)
 {
 	EncodeArithmeticInst(1, true, Rd, Rn, Rm, Option);
 }
@@ -1226,7 +1226,7 @@ void ARM64XEmitter::CMN(ARM64Reg Rn, ARM64Reg Rm)
 	CMN(Rn, Rm, ArithOption(Rn, ST_LSL, 0));
 }
 
-void ARM64XEmitter::CMN(ARM64Reg Rn, ARM64Reg Rm, ArithOption Option)
+void ARM64XEmitter::CMN(ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Option)
 {
 	EncodeArithmeticInst(0, true, Is64Bit(Rn) ? ZR : WZR, Rn, Rm, Option);
 }
@@ -1236,7 +1236,7 @@ void ARM64XEmitter::CMP(ARM64Reg Rn, ARM64Reg Rm)
 	CMP(Rn, Rm, ArithOption(Rn, ST_LSL, 0));
 }
 
-void ARM64XEmitter::CMP(ARM64Reg Rn, ARM64Reg Rm, ArithOption Option)
+void ARM64XEmitter::CMP(ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Option)
 {
 	EncodeArithmeticInst(1, true, Is64Bit(Rn) ? ZR : WZR, Rn, Rm, Option);
 }
@@ -1432,44 +1432,44 @@ void ARM64XEmitter::MNEG(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm)
 }
 
 // Logical (shifted register)
-void ARM64XEmitter::AND(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift)
+void ARM64XEmitter::AND(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift)
 {
 	EncodeLogicalInst(0, Rd, Rn, Rm, Shift);
 }
-void ARM64XEmitter::BIC(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift)
+void ARM64XEmitter::BIC(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift)
 {
 	EncodeLogicalInst(1, Rd, Rn, Rm, Shift);
 }
-void ARM64XEmitter::ORR(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift)
+void ARM64XEmitter::ORR(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift)
 {
 	EncodeLogicalInst(2, Rd, Rn, Rm, Shift);
 }
-void ARM64XEmitter::ORN(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift)
+void ARM64XEmitter::ORN(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift)
 {
 	EncodeLogicalInst(3, Rd, Rn, Rm, Shift);
 }
-void ARM64XEmitter::EOR(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift)
+void ARM64XEmitter::EOR(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift)
 {
 	EncodeLogicalInst(4, Rd, Rn, Rm, Shift);
 }
-void ARM64XEmitter::EON(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift)
+void ARM64XEmitter::EON(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift)
 {
 	EncodeLogicalInst(5, Rd, Rn, Rm, Shift);
 }
-void ARM64XEmitter::ANDS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift)
+void ARM64XEmitter::ANDS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift)
 {
 	EncodeLogicalInst(6, Rd, Rn, Rm, Shift);
 }
-void ARM64XEmitter::BICS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift)
+void ARM64XEmitter::BICS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift)
 {
 	EncodeLogicalInst(7, Rd, Rn, Rm, Shift);
 }
-void ARM64XEmitter::TST(ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift)
+void ARM64XEmitter::TST(ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift)
 {
 	ANDS(Is64Bit(Rn) ? ZR : WZR, Rn, Rm, Shift);
 }
 
-void ARM64XEmitter::MOV(ARM64Reg Rd, ARM64Reg Rm, ArithOption Shift) {
+void ARM64XEmitter::MOV(ARM64Reg Rd, ARM64Reg Rm, const ArithOption &Shift) {
 	ORR(Rd, Is64Bit(Rd) ? ZR : WZR, Rm, Shift);
 }
 
@@ -1835,47 +1835,47 @@ void ARM64XEmitter::LDRSW(IndexType type, ARM64Reg Rt, ARM64Reg Rn, s32 imm)
 }
 
 // Load/Store register (register offset)
-void ARM64XEmitter::STRB(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm)
+void ARM64XEmitter::STRB(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm)
 {
 	EncodeLoadStoreRegisterOffset(0, 0, Rt, Rn, Rm);
 }
-void ARM64XEmitter::LDRB(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm)
+void ARM64XEmitter::LDRB(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm)
 {
 	EncodeLoadStoreRegisterOffset(0, 1, Rt, Rn, Rm);
 }
-void ARM64XEmitter::LDRSB(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm)
+void ARM64XEmitter::LDRSB(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm)
 {
 	bool b64Bit = Is64Bit(Rt);
 	EncodeLoadStoreRegisterOffset(0, 3 - b64Bit, Rt, Rn, Rm);
 }
-void ARM64XEmitter::STRH(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm)
+void ARM64XEmitter::STRH(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm)
 {
 	EncodeLoadStoreRegisterOffset(1, 0, Rt, Rn, Rm);
 }
-void ARM64XEmitter::LDRH(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm)
+void ARM64XEmitter::LDRH(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm)
 {
 	EncodeLoadStoreRegisterOffset(1, 1, Rt, Rn, Rm);
 }
-void ARM64XEmitter::LDRSH(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm)
+void ARM64XEmitter::LDRSH(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm)
 {
 	bool b64Bit = Is64Bit(Rt);
 	EncodeLoadStoreRegisterOffset(1, 3 - b64Bit, Rt, Rn, Rm);
 }
-void ARM64XEmitter::STR(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm)
+void ARM64XEmitter::STR(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm)
 {
 	bool b64Bit = Is64Bit(Rt);
 	EncodeLoadStoreRegisterOffset(2 + b64Bit, 0, Rt, Rn, Rm);
 }
-void ARM64XEmitter::LDR(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm)
+void ARM64XEmitter::LDR(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm)
 {
 	bool b64Bit = Is64Bit(Rt);
 	EncodeLoadStoreRegisterOffset(2 + b64Bit, 1, Rt, Rn, Rm);
 }
-void ARM64XEmitter::LDRSW(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm)
+void ARM64XEmitter::LDRSW(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm)
 {
 	EncodeLoadStoreRegisterOffset(2, 2, Rt, Rn, Rm);
 }
-void ARM64XEmitter::PRFM(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm)
+void ARM64XEmitter::PRFM(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm)
 {
 	EncodeLoadStoreRegisterOffset(3, 2, Rt, Rn, Rm);
 }
@@ -2491,7 +2491,7 @@ void ARM64FloatEmitter::EncodeLoadStorePair(u32 size, bool load, IndexType type,
 
 }
 
-void ARM64FloatEmitter::EncodeLoadStoreRegisterOffset(u32 size, bool load, ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm)
+void ARM64FloatEmitter::EncodeLoadStoreRegisterOffset(u32 size, bool load, ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm)
 {
 	_assert_msg_(Rm.GetType() == ArithOption::TYPE_EXTENDEDREG, "%s must contain an extended reg as Rm!", __FUNCTION__);
 
@@ -2941,11 +2941,11 @@ void ARM64FloatEmitter::STP(u8 size, IndexType type, ARM64Reg Rt, ARM64Reg Rt2, 
 }
 
 // Loadstore register offset
-void ARM64FloatEmitter::STR(u8 size, ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm)
+void ARM64FloatEmitter::STR(u8 size, ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm)
 {
 	EncodeLoadStoreRegisterOffset(size, false, Rt, Rn, Rm);
 }
-void ARM64FloatEmitter::LDR(u8 size, ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm)
+void ARM64FloatEmitter::LDR(u8 size, ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm)
 {
 	EncodeLoadStoreRegisterOffset(size, true, Rt, Rn, Rm);
 }

--- a/Common/Arm64Emitter.h
+++ b/Common/Arm64Emitter.h
@@ -370,7 +370,7 @@ private:
 	void EncodeUnconditionalBranchInst(u32 opc, u32 op2, u32 op3, u32 op4, ARM64Reg Rn);
 	void EncodeExceptionInst(u32 instenc, u32 imm);
 	void EncodeSystemInst(u32 op0, u32 op1, u32 CRn, u32 CRm, u32 op2, ARM64Reg Rt);
-	void EncodeArithmeticInst(u32 instenc, bool flags, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Option);
+	void EncodeArithmeticInst(u32 instenc, bool flags, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Option);
 	void EncodeArithmeticCarryInst(u32 op, bool flags, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void EncodeCondCompareImmInst(u32 op, ARM64Reg Rn, u32 imm, u32 nzcv, CCFlags cond);
 	void EncodeCondCompareRegInst(u32 op, ARM64Reg Rn, ARM64Reg Rm, u32 nzcv, CCFlags cond);
@@ -378,7 +378,7 @@ private:
 	void EncodeData1SrcInst(u32 instenc, ARM64Reg Rd, ARM64Reg Rn);
 	void EncodeData2SrcInst(u32 instenc, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 	void EncodeData3SrcInst(u32 instenc, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ARM64Reg Ra);
-	void EncodeLogicalInst(u32 instenc, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift);
+	void EncodeLogicalInst(u32 instenc, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift);
 	void EncodeLoadRegisterInst(u32 bitop, ARM64Reg Rt, u32 imm);
 	void EncodeLoadStoreExcInst(u32 instenc, ARM64Reg Rs, ARM64Reg Rt2, ARM64Reg Rn, ARM64Reg Rt);
 	void EncodeLoadStorePairedInst(u32 op, ARM64Reg Rt, ARM64Reg Rt2, ARM64Reg Rn, u32 imm);
@@ -386,7 +386,7 @@ private:
 	void EncodeLoadStoreIndexedInst(u32 op, ARM64Reg Rt, ARM64Reg Rn, s32 imm, u8 size);
 	void EncodeMOVWideInst(u32 op, ARM64Reg Rd, u32 imm, ShiftAmount pos);
 	void EncodeBitfieldMOVInst(u32 op, ARM64Reg Rd, ARM64Reg Rn, u32 immr, u32 imms);
-	void EncodeLoadStoreRegisterOffset(u32 size, u32 opc, ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm);
+	void EncodeLoadStoreRegisterOffset(u32 size, u32 opc, ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm);
 	void EncodeAddSubImmInst(u32 op, bool flags, u32 shift, u32 imm, ARM64Reg Rn, ARM64Reg Rd);
 	void EncodeLogicalImmInst(u32 op, ARM64Reg Rd, ARM64Reg Rn, u32 immr, u32 imms, int n);
 	void EncodeLoadStorePair(u32 op, u32 load, IndexType type, ARM64Reg Rt, ARM64Reg Rt2, ARM64Reg Rn, s32 imm);
@@ -479,17 +479,17 @@ public:
 
 	// Add/Subtract (Extended/Shifted register)
 	void ADD(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
-	void ADD(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Option);
+	void ADD(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Option);
 	void ADDS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
-	void ADDS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Option);
+	void ADDS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Option);
 	void SUB(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
-	void SUB(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Option);
+	void SUB(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Option);
 	void SUBS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
-	void SUBS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Option);
+	void SUBS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Option);
 	void CMN(ARM64Reg Rn, ARM64Reg Rm);
-	void CMN(ARM64Reg Rn, ARM64Reg Rm, ArithOption Option);
+	void CMN(ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Option);
 	void CMP(ARM64Reg Rn, ARM64Reg Rm);
-	void CMP(ARM64Reg Rn, ARM64Reg Rm, ArithOption Option);
+	void CMP(ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Option);
 
 	// Add/Subtract (with carry)
 	void ADC(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
@@ -559,15 +559,15 @@ public:
 	void MNEG(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm);
 
 	// Logical (shifted register)
-	void AND(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift);
-	void BIC(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift);
-	void ORR(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift);
-	void ORN(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift);
-	void EOR(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift);
-	void EON(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift);
-	void ANDS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift);
-	void BICS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift);
-	void TST(ARM64Reg Rn, ARM64Reg Rm, ArithOption Shift);
+	void AND(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift);
+	void BIC(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift);
+	void ORR(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift);
+	void ORN(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift);
+	void EOR(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift);
+	void EON(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift);
+	void ANDS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift);
+	void BICS(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift);
+	void TST(ARM64Reg Rn, ARM64Reg Rm, const ArithOption &Shift);
 
 	// Wrap the above for saner syntax
 	void AND(ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm) { AND(Rd, Rn, Rm, ArithOption(Rd, ST_LSL, 0)); }
@@ -581,7 +581,7 @@ public:
 	void TST(ARM64Reg Rn, ARM64Reg Rm) { TST(Rn, Rm, ArithOption(Is64Bit(Rn) ? ZR : WZR, ST_LSL, 0)); }
 
 	// Convenience wrappers around ORR. These match the official convenience syntax.
-	void MOV(ARM64Reg Rd, ARM64Reg Rm, ArithOption Shift);
+	void MOV(ARM64Reg Rd, ARM64Reg Rm, const ArithOption &Shift);
 	void MOV(ARM64Reg Rd, ARM64Reg Rm);
 	void MVN(ARM64Reg Rd, ARM64Reg Rm);
 
@@ -681,16 +681,16 @@ public:
 	void LDRSW(IndexType type, ARM64Reg Rt, ARM64Reg Rn, s32 imm);
 
 	// Load/Store register (register offset)
-	void STRB(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm);
-	void LDRB(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm);
-	void LDRSB(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm);
-	void STRH(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm);
-	void LDRH(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm);
-	void LDRSH(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm);
-	void STR(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm);
-	void LDR(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm);
-	void LDRSW(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm);
-	void PRFM(ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm);
+	void STRB(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm);
+	void LDRB(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm);
+	void LDRSB(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm);
+	void STRH(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm);
+	void LDRH(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm);
+	void LDRSH(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm);
+	void STR(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm);
+	void LDR(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm);
+	void LDRSW(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm);
+	void PRFM(ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm);
 
 	// Load/Store register (unscaled offset)
 	void STURB(ARM64Reg Rt, ARM64Reg Rn, s32 imm);
@@ -811,8 +811,8 @@ public:
 	void STP(u8 size, IndexType type, ARM64Reg Rt, ARM64Reg Rt2, ARM64Reg Rn, s32 imm);
 
 	// Loadstore register offset
-	void STR(u8 size, ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm);
-	void LDR(u8 size, ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm);
+	void STR(u8 size, ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm);
+	void LDR(u8 size, ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm);
 
 	// Scalar - 1 Source
 	void FABS(ARM64Reg Rd, ARM64Reg Rn);
@@ -1040,7 +1040,7 @@ private:
 	void EmitConvertScalarToInt(ARM64Reg Rd, ARM64Reg Rn, RoundingMode round, bool sign);
 	void EmitScalar3Source(bool isDouble, ARM64Reg Rd, ARM64Reg Rn, ARM64Reg Rm, ARM64Reg Ra, int opcode);
 	void EncodeLoadStorePair(u32 size, bool load, IndexType type, ARM64Reg Rt, ARM64Reg Rt2, ARM64Reg Rn, s32 imm);
-	void EncodeLoadStoreRegisterOffset(u32 size, bool load, ARM64Reg Rt, ARM64Reg Rn, ArithOption Rm);
+	void EncodeLoadStoreRegisterOffset(u32 size, bool load, ARM64Reg Rt, ARM64Reg Rn, const ArithOption &Rm);
 	void EncodeModImm(bool Q, u8 op, u8 cmode, u8 o2, ARM64Reg Rd, u8 abcdefgh);
 
 	void SSHLL(u8 src_size, ARM64Reg Rd, ARM64Reg Rn, u32 shift, bool upper);

--- a/Common/Data/Text/Parsers.cpp
+++ b/Common/Data/Text/Parsers.cpp
@@ -52,7 +52,7 @@ int Version::ToInteger() const {
 	return major * 1000000 + minor * 10000 + sub;
 }
 
-bool ParseMacAddress(std::string str, uint8_t macAddr[6]) {
+bool ParseMacAddress(const std::string &str, uint8_t macAddr[6]) {
 	unsigned int mac[6];
 	if (6 != sscanf(str.c_str(), "%02x:%02x:%02x:%02x:%02x:%02x", &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5])) {
 		return false;

--- a/Common/Data/Text/Parsers.h
+++ b/Common/Data/Text/Parsers.h
@@ -53,7 +53,7 @@ private:
 	bool ParseVersionString(std::string str);
 };
 
-bool ParseMacAddress(std::string str, uint8_t macAddr[6]);
+bool ParseMacAddress(const std::string &str, uint8_t macAddr[6]);
 
 bool TryParse(const std::string &str, bool *const output);
 bool TryParse(const std::string &str, uint32_t *const output);

--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -486,7 +486,7 @@ bool VulkanContext::CheckLayers(const std::vector<LayerProperties> &layer_props,
 	return true;
 }
 
-int VulkanContext::GetPhysicalDeviceByName(std::string name) {
+int VulkanContext::GetPhysicalDeviceByName(const std::string &name) {
 	for (size_t i = 0; i < physical_devices_.size(); i++) {
 		if (physicalDeviceProperties_[i].properties.deviceName == name)
 			return (int)i;

--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -180,7 +180,7 @@ public:
 	void DestroyInstance();
 
 	int GetBestPhysicalDevice();
-	int GetPhysicalDeviceByName(std::string name);
+	int GetPhysicalDeviceByName(const std::string &name);
 	void ChooseDevice(int physical_device);
 	bool EnableInstanceExtension(const char *extension);
 	bool EnableDeviceExtension(const char *extension);

--- a/Common/Input/InputState.cpp
+++ b/Common/Input/InputState.cpp
@@ -74,7 +74,7 @@ void SetInfoKeys(const std::vector<InputMapping> &info) {
 	infoKeys = info;
 }
 
-void SetAnalogFlipY(std::unordered_map<InputDeviceID, int> flipYByDeviceId) {
+void SetAnalogFlipY(const std::unordered_map<InputDeviceID, int> &flipYByDeviceId) {
 	uiFlipAnalogY = flipYByDeviceId;
 }
 

--- a/Common/Input/InputState.h
+++ b/Common/Input/InputState.h
@@ -201,5 +201,5 @@ void SetTabLeftRightKeys(const std::vector<InputMapping> &tabLeft, const std::ve
 void SetInfoKeys(const std::vector<InputMapping> &info);
 
 // 0 means unknown (attempt autodetect), -1 means flip, 1 means original direction.
-void SetAnalogFlipY(std::unordered_map<InputDeviceID, int> flipYByDeviceId);
+void SetAnalogFlipY(const std::unordered_map<InputDeviceID, int> &flipYByDeviceId);
 int GetAnalogYDirection(InputDeviceID deviceId);

--- a/Common/StringUtils.cpp
+++ b/Common/StringUtils.cpp
@@ -60,7 +60,7 @@ const char* safe_string(const char* s) {
 	return s ? s : "(null)";
 }
 
-long parseHexLong(std::string s) {
+long parseHexLong(const std::string &s) {
 	long value = 0;
 
 	if (s.substr(0,2) == "0x") {

--- a/Common/StringUtils.h
+++ b/Common/StringUtils.h
@@ -103,7 +103,7 @@ inline size_t truncate_cpy(char(&out)[Count], const char *src) {
 
 const char* safe_string(const char* s);
 
-long parseHexLong(std::string s);
+long parseHexLong(const std::string &s);
 long parseLong(std::string s);
 std::string StringFromFormat(const char* format, ...);
 // Cheap!

--- a/Common/System/OSD.cpp
+++ b/Common/System/OSD.cpp
@@ -224,7 +224,7 @@ void OnScreenDisplay::ShowLeaderboardSubmitted(const std::string &title, const s
 	g_OSD.Show(OSDType::LEADERBOARD_SUBMITTED, title, value, 3.0f);
 }
 
-void OnScreenDisplay::SetProgressBar(std::string id, std::string &&message, float minValue, float maxValue, float progress, float delay) {
+void OnScreenDisplay::SetProgressBar(const std::string &id, std::string &&message, float minValue, float maxValue, float progress, float delay) {
 	_dbg_assert_(!my_isnanorinf(progress));
 	_dbg_assert_(!my_isnanorinf(minValue));
 	_dbg_assert_(!my_isnanorinf(maxValue));
@@ -256,7 +256,7 @@ void OnScreenDisplay::SetProgressBar(std::string id, std::string &&message, floa
 	entries_.push_back(bar);
 }
 
-void OnScreenDisplay::RemoveProgressBar(std::string id, bool success, float delay_s) {
+void OnScreenDisplay::RemoveProgressBar(const std::string &id, bool success, float delay_s) {
 	std::lock_guard<std::mutex> guard(mutex_);
 	for (auto iter = entries_.begin(); iter != entries_.end(); iter++) {
 		if (iter->type == OSDType::PROGRESS_BAR && iter->id == id) {

--- a/Common/System/OSD.h
+++ b/Common/System/OSD.h
@@ -59,8 +59,8 @@ public:
 	// Progress bar controls
 	// Set is both create and update. If you set maxValue <= minValue, you'll create an "indeterminate" progress
 	// bar that doesn't show a specific amount of progress.
-	void SetProgressBar(std::string id, std::string &&message, float minValue, float maxValue, float progress, float delay_s);
-	void RemoveProgressBar(std::string id, bool success, float delay_s);
+	void SetProgressBar(const std::string &id, std::string &&message, float minValue, float maxValue, float progress, float delay_s);
+	void RemoveProgressBar(const std::string &id, bool success, float delay_s);
 
 	// Call every frame to keep the sidebar visible. Otherwise it'll fade out.
 	void NudgeSidebar();

--- a/Common/UI/AsyncImageFileView.h
+++ b/Common/UI/AsyncImageFileView.h
@@ -22,7 +22,7 @@ public:
 
 	void SetFilename(const Path &filename);
 	void SetColor(uint32_t color) { color_ = color; }
-	void SetOverlayText(std::string text) { text_ = text; }
+	void SetOverlayText(const std::string &text) { text_ = text; }
 	void SetFixedSize(float fixW, float fixH) { fixedSizeW_ = fixW; fixedSizeH_ = fixH; }
 	void SetCanBeFocused(bool can) { canFocus_ = can; }
 

--- a/Common/UI/PopupScreens.h
+++ b/Common/UI/PopupScreens.h
@@ -29,10 +29,10 @@ public:
 	std::string GetChoiceString() const {
 		return adaptor_.GetTitle(listView_->GetSelected());
 	}
-	void SetHiddenChoices(std::set<int> hidden) {
+	void SetHiddenChoices(const std::set<int> &hidden) {
 		hidden_ = hidden;
 	}
-	void SetChoiceIcons(std::map<int, ImageID> icons) {
+	void SetChoiceIcons(const std::map<int, ImageID> &icons) {
 		icons_ = icons;
 	}
 	const char *tag() const override { return "listpopup"; }

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1838,7 +1838,7 @@ int Config::GetPSPLanguage() {
 	}
 }
 
-void PlayTimeTracker::Start(std::string gameId) {
+void PlayTimeTracker::Start(const std::string &gameId) {
 	if (gameId.empty()) {
 		return;
 	}
@@ -1860,7 +1860,7 @@ void PlayTimeTracker::Start(std::string gameId) {
 	tracker_[gameId] = playTime;
 }
 
-void PlayTimeTracker::Stop(std::string gameId) {
+void PlayTimeTracker::Stop(const std::string &gameId) {
 	if (gameId.empty()) {
 		return;
 	}

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -48,8 +48,8 @@ public:
 	};
 
 	// It's OK to call these redundantly.
-	void Start(std::string gameId);
-	void Stop(std::string gameId);
+	void Start(const std::string &gameId);
+	void Stop(const std::string &gameId);
 
 	void Load(const Section *section);
 	void Save(Section *section);

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -418,7 +418,7 @@ void Core_MemoryException(u32 address, u32 accessSize, u32 pc, MemoryExceptionTy
 	}
 }
 
-void Core_MemoryExceptionInfo(u32 address, u32 accessSize, u32 pc, MemoryExceptionType type, std::string additionalInfo, bool forceReport) {
+void Core_MemoryExceptionInfo(u32 address, u32 accessSize, u32 pc, MemoryExceptionType type, const std::string &additionalInfo, bool forceReport) {
 	const char *desc = MemoryExceptionTypeAsString(type);
 	// In jit, we only flush PC when bIgnoreBadMemAccess is off.
 	if ((g_Config.iCpuCore == (int)CPUCore::JIT || g_Config.iCpuCore == (int)CPUCore::JIT_IR) && g_Config.bIgnoreBadMemAccess) {

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -105,7 +105,7 @@ enum class ExecExceptionType {
 // Separate one for without info, to avoid having to allocate a string
 void Core_MemoryException(u32 address, u32 accessSize, u32 pc, MemoryExceptionType type);
 
-void Core_MemoryExceptionInfo(u32 address, u32 accessSize, u32 pc, MemoryExceptionType type, std::string additionalInfo, bool forceReport);
+void Core_MemoryExceptionInfo(u32 address, u32 accessSize, u32 pc, MemoryExceptionType type, const std::string &additionalInfo, bool forceReport);
 
 void Core_ExecException(u32 address, u32 pc, ExecExceptionType type);
 void Core_Break(u32 pc);

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -820,7 +820,7 @@ void DisassemblyMacro::setMacroLi(u32 _immediate, u8 _rt)
 	numOpcodes = 2;
 }
 
-void DisassemblyMacro::setMacroMemory(std::string _name, u32 _immediate, u8 _rt, int _dataSize)
+void DisassemblyMacro::setMacroMemory(const std::string &_name, u32 _immediate, u8 _rt, int _dataSize)
 {
 	type = MACRO_MEMORYIMM;
 	name = _name;

--- a/Core/Debugger/DisassemblyManager.h
+++ b/Core/Debugger/DisassemblyManager.h
@@ -120,7 +120,7 @@ public:
 	DisassemblyMacro(u32 _address): address(_address) { }
 
 	void setMacroLi(u32 _immediate, u8 _rt);
-	void setMacroMemory(std::string _name, u32 _immediate, u8 _rt, int _dataSize);
+	void setMacroMemory(const std::string &_name, u32 _immediate, u8 _rt, int _dataSize);
 
 	void recheck() override { };
 	int getNumLines() override { return 1; };

--- a/Core/Dialog/PSPGamedataInstallDialog.cpp
+++ b/Core/Dialog/PSPGamedataInstallDialog.cpp
@@ -49,7 +49,7 @@ static const std::string SFO_FILENAME = "PARAM.SFO";
 
 namespace
 {
-	std::vector<std::string> GetPSPFileList (std::string dirpath) {
+	std::vector<std::string> GetPSPFileList (const std::string &dirpath) {
 		std::vector<std::string> FileList;
 		auto Fileinfos = pspFileSystem.GetDirListing(dirpath);
 
@@ -258,7 +258,7 @@ int PSPGamedataInstallDialog::Shutdown(bool force) {
 	return PSPDialog::Shutdown(force);
 }
 
-std::string PSPGamedataInstallDialog::GetGameDataInstallFileName(const SceUtilityGamedataInstallParam *param, std::string filename) {
+std::string PSPGamedataInstallDialog::GetGameDataInstallFileName(const SceUtilityGamedataInstallParam *param, const std::string &filename) {
 	if (!param)
 		return "";
 	std::string GameDataInstallPath = saveBasePath + param->gameName + param->dataName + "/";

--- a/Core/Dialog/PSPGamedataInstallDialog.h
+++ b/Core/Dialog/PSPGamedataInstallDialog.h
@@ -44,7 +44,7 @@ public:
 	void DoState(PointerWrap &p) override;
 
 	int Abort();
-	std::string GetGameDataInstallFileName(const SceUtilityGamedataInstallParam *param, std::string filename);
+	std::string GetGameDataInstallFileName(const SceUtilityGamedataInstallParam *param, const std::string &filename);
 
 protected:
 	// TODO: Manage status correctly.

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -179,7 +179,7 @@ void PSPMsgDialog::FormatErrorCode(uint32_t code) {
 	}
 }
 
-void PSPMsgDialog::DisplayMessage(std::string text, bool hasYesNo, bool hasOK) {
+void PSPMsgDialog::DisplayMessage(const std::string &text, bool hasYesNo, bool hasOK) {
 	auto di = GetI18NCategory(I18NCat::DIALOG);
 
 	PPGeStyle buttonStyle = FadedStyle(PPGeAlign::BOX_CENTER, FONT_SCALE);

--- a/Core/Dialog/PSPMsgDialog.h
+++ b/Core/Dialog/PSPMsgDialog.h
@@ -76,7 +76,7 @@ protected:
 
 private:
 	void FormatErrorCode(uint32_t code);
-	void DisplayMessage(std::string text, bool hasYesNo = false, bool hasOK = false);
+	void DisplayMessage(const std::string &text, bool hasYesNo = false, bool hasOK = false);
 
 	enum Flags
 	{

--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -103,7 +103,7 @@ void PSPNetconfDialog::DrawIndicator() {
 	PPGeDrawImage(456, 248, 20.0f, 20.0f, 1, 10, 1, 10, 10, 10, FadedImageStyle());
 }
 
-void PSPNetconfDialog::DisplayMessage(std::string text1, std::string text2a, std::string text2b, std::string text3a, std::string text3b, bool hasYesNo, bool hasOK) {
+void PSPNetconfDialog::DisplayMessage(const std::string &text1, const std::string &text2a, const std::string &text2b, const std::string &text3a, const std::string &text3b, bool hasYesNo, bool hasOK) {
 	auto di = GetI18NCategory(I18NCat::DIALOG);
 
 	PPGeStyle buttonStyle = FadedStyle(PPGeAlign::BOX_CENTER, FONT_SCALE);

--- a/Core/Dialog/PSPNetconfDialog.h
+++ b/Core/Dialog/PSPNetconfDialog.h
@@ -52,7 +52,7 @@ protected:
 	}
 
 private:
-	void DisplayMessage(std::string text1, std::string text2a = "", std::string text2b = "", std::string text3a = "", std::string text3b = "", bool hasYesNo = false, bool hasOK = false);
+	void DisplayMessage(const std::string &text1, const std::string &text2a = "", const std::string &text2b = "", const std::string &text3a = "", const std::string &text3b = "", bool hasYesNo = false, bool hasOK = false);
 	void DrawBanner();
 	void DrawIndicator();
 

--- a/Core/Dialog/PSPNpSigninDialog.cpp
+++ b/Core/Dialog/PSPNpSigninDialog.cpp
@@ -100,7 +100,7 @@ void PSPNpSigninDialog::DrawLogo() {
 	PPGeDrawImage(416, 22, 64.0f, 64.0f, 1, 10, 1, 10, 64, 64, FadedImageStyle());
 }
 
-void PSPNpSigninDialog::DisplayMessage(std::string text1, std::string text2a, std::string text2b, std::string text3a, std::string text3b, bool hasYesNo, bool hasOK) {
+void PSPNpSigninDialog::DisplayMessage(const std::string &text1, const std::string &text2a, const std::string &text2b, const std::string &text3a, const std::string &text3b, bool hasYesNo, bool hasOK) {
 	auto di = GetI18NCategory(I18NCat::DIALOG);
 
 	PPGeStyle buttonStyle = FadedStyle(PPGeAlign::BOX_CENTER, FONT_SCALE);

--- a/Core/Dialog/PSPNpSigninDialog.h
+++ b/Core/Dialog/PSPNpSigninDialog.h
@@ -48,7 +48,7 @@ protected:
 	}
 
 private:
-	void DisplayMessage(std::string text1, std::string text2a = "", std::string text2b = "", std::string text3a = "", std::string text3b = "", bool hasYesNo = false, bool hasOK = false);
+	void DisplayMessage(const std::string &text1, const std::string &text2a = "", const std::string &text2b = "", const std::string &text3a = "", const std::string &text3b = "", bool hasYesNo = false, bool hasOK = false);
 	void DrawBanner();
 	void DrawIndicator();
 	void DrawLogo();

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -580,7 +580,7 @@ void PSPSaveDialog::DisplaySaveDataInfo2(bool showNewData) {
 	PPGeDrawText(saveinfoTxt.c_str(), 8, 200, textStyle);
 }
 
-void PSPSaveDialog::DisplayMessage(std::string text, bool hasYesNo)
+void PSPSaveDialog::DisplayMessage(const std::string &text, bool hasYesNo)
 {
 	PPGeStyle textStyle = FadedStyle(PPGeAlign::BOX_CENTER, FONT_SCALE);
 

--- a/Core/Dialog/PSPSaveDialog.h
+++ b/Core/Dialog/PSPSaveDialog.h
@@ -94,7 +94,7 @@ private:
 	void DisplaySaveIcon(bool checkExists);
 	void DisplaySaveDataInfo1();
 	void DisplaySaveDataInfo2(bool showNewData = false);
-	void DisplayMessage(std::string text, bool hasYesNo = false);
+	void DisplayMessage(const std::string &text, bool hasYesNo = false);
 	const std::string GetSelectedSaveDirName() const;
 
 	void JoinIOThread();

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -63,7 +63,7 @@ namespace
 		truncate_cpy(str, strLength, value.c_str());
 	}
 
-	bool ReadPSPFile(std::string filename, u8 **data, s64 dataSize, s64 *readSize)
+	bool ReadPSPFile(const std::string &filename, u8 **data, s64 dataSize, s64 *readSize)
 	{
 		int handle = pspFileSystem.OpenFile(filename, FILEACCESS_READ);
 		if (handle < 0)
@@ -86,7 +86,7 @@ namespace
 		return result != 0;
 	}
 
-	bool WritePSPFile(std::string filename, const u8 *data, SceSize dataSize)
+	bool WritePSPFile(const std::string &filename, const u8 *data, SceSize dataSize)
 	{
 		int handle = pspFileSystem.OpenFile(filename, (FileAccess)(FILEACCESS_WRITE | FILEACCESS_CREATE | FILEACCESS_TRUNCATE));
 		if (handle < 0)
@@ -110,7 +110,7 @@ namespace
 		return info;
 	}
 
-	bool PSPMatch(std::string text, std::string regexp)
+	bool PSPMatch(const std::string &text, const std::string &regexp)
 	{
 		if(text.empty() && regexp.empty())
 			return true;
@@ -1607,7 +1607,7 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 	return 0;
 }
 
-void SavedataParam::SetFileInfo(SaveFileInfo &saveInfo, PSPFileInfo &info, std::string saveName, std::string savrDir)
+void SavedataParam::SetFileInfo(SaveFileInfo &saveInfo, PSPFileInfo &info, const std::string &saveName, const std::string &savrDir)
 {
 	saveInfo.size = info.size;
 	saveInfo.saveName = saveName;
@@ -1647,7 +1647,7 @@ void SavedataParam::SetFileInfo(SaveFileInfo &saveInfo, PSPFileInfo &info, std::
 	}
 }
 
-void SavedataParam::SetFileInfo(int idx, PSPFileInfo &info, std::string saveName, std::string saveDir)
+void SavedataParam::SetFileInfo(int idx, PSPFileInfo &info, const std::string &saveName, const std::string &saveDir)
 {
 	SetFileInfo(saveDataList[idx], info, saveName, saveDir);
 	saveDataList[idx].idx = idx;
@@ -1679,7 +1679,7 @@ void SavedataParam::ClearFileInfo(SaveFileInfo &saveInfo, const std::string &sav
 	}
 }
 
-PSPFileInfo SavedataParam::GetSaveInfo(std::string saveDir) {
+PSPFileInfo SavedataParam::GetSaveInfo(const std::string &saveDir) {
 	PSPFileInfo info = pspFileSystem.GetFileInfo(saveDir);
 	if (info.exists) {
 		info.access = 0777;
@@ -1970,7 +1970,7 @@ int SavedataParam::GetSaveCryptMode(const SceUtilitySavedataParam *param, const 
 	return 0;
 }
 
-bool SavedataParam::IsInSaveDataList(std::string saveName, int count) {
+bool SavedataParam::IsInSaveDataList(const std::string &saveName, int count) {
 	for(int i = 0; i < count; ++i) {
 		if(strcmp(saveDataList[i].saveName.c_str(),saveName.c_str()) == 0)
 			return true;

--- a/Core/Dialog/SavedataParam.h
+++ b/Core/Dialog/SavedataParam.h
@@ -318,7 +318,7 @@ public:
 	int GetFilesList(SceUtilitySavedataParam* param, u32 requestAddr);
 	bool GetSize(SceUtilitySavedataParam* param);
 	int GetSaveCryptMode(const SceUtilitySavedataParam *param, const std::string &saveDirName);
-	bool IsInSaveDataList(std::string saveName, int count);
+	bool IsInSaveDataList(const std::string &saveName, int count);
 
 	std::string GetGameName(const SceUtilitySavedataParam *param) const;
 	std::string GetSaveName(const SceUtilitySavedataParam *param) const;
@@ -361,10 +361,10 @@ public:
 
 private:
 	void Clear();
-	void SetFileInfo(int idx, PSPFileInfo &info, std::string saveName, std::string saveDir = "");
-	void SetFileInfo(SaveFileInfo &saveInfo, PSPFileInfo &info, std::string saveName, std::string saveDir = "");
+	void SetFileInfo(int idx, PSPFileInfo &info, const std::string &saveName, const std::string &saveDir = "");
+	void SetFileInfo(SaveFileInfo &saveInfo, PSPFileInfo &info, const std::string &saveName, const std::string &saveDir = "");
 	void ClearFileInfo(SaveFileInfo &saveInfo, const std::string &saveName);
-	PSPFileInfo GetSaveInfo(std::string saveDir);
+	PSPFileInfo GetSaveInfo(const std::string &saveDir);
 
 	int LoadSaveData(SceUtilitySavedataParam *param, const std::string &saveDirName, const std::string& dirPath, bool secureMode);
 	u32 LoadCryptedSave(SceUtilitySavedataParam *param, u8 *data, const u8 *saveData, int &saveSize, int prevCryptMode, const u8 *expectedHash, bool &saveDone);

--- a/Core/ELF/ParamSFO.cpp
+++ b/Core/ELF/ParamSFO.cpp
@@ -43,38 +43,38 @@ struct IndexTable
 	u32_le data_table_offset; /* Offset of the param_data from start of data_table */
 };
 
-void ParamSFOData::SetValue(std::string key, unsigned int value, int max_size) {
+void ParamSFOData::SetValue(const std::string &key, unsigned int value, int max_size) {
 	values[key].type = VT_INT;
 	values[key].i_value = value;
 	values[key].max_size = max_size;
 }
-void ParamSFOData::SetValue(std::string key, std::string value, int max_size) {
+void ParamSFOData::SetValue(const std::string &key, const std::string &value, int max_size) {
 	values[key].type = VT_UTF8;
 	values[key].s_value = value;
 	values[key].max_size = max_size;
 }
 
-void ParamSFOData::SetValue(std::string key, const u8 *value, unsigned int size, int max_size) {
+void ParamSFOData::SetValue(const std::string &key, const u8 *value, unsigned int size, int max_size) {
 	values[key].type = VT_UTF8_SPE;
 	values[key].SetData(value, size);
 	values[key].max_size = max_size;
 }
 
-int ParamSFOData::GetValueInt(std::string key) const {
+int ParamSFOData::GetValueInt(const std::string &key) const {
 	std::map<std::string,ValueData>::const_iterator it = values.find(key);
 	if(it == values.end() || it->second.type != VT_INT)
 		return 0;
 	return it->second.i_value;
 }
 
-std::string ParamSFOData::GetValueString(std::string key) const {
+std::string ParamSFOData::GetValueString(const std::string &key) const {
 	std::map<std::string,ValueData>::const_iterator it = values.find(key);
 	if(it == values.end() || (it->second.type != VT_UTF8))
 		return "";
 	return it->second.s_value;
 }
 
-const u8 *ParamSFOData::GetValueData(std::string key, unsigned int *size) const {
+const u8 *ParamSFOData::GetValueData(const std::string &key, unsigned int *size) const {
 	std::map<std::string,ValueData>::const_iterator it = values.find(key);
 	if(it == values.end() || (it->second.type != VT_UTF8_SPE))
 		return 0;
@@ -195,7 +195,7 @@ bool ParamSFOData::ReadSFO(const u8 *paramsfo, size_t size) {
 	return true;
 }
 
-int ParamSFOData::GetDataOffset(const u8 *paramsfo, std::string dataName) {
+int ParamSFOData::GetDataOffset(const u8 *paramsfo, const std::string &dataName) {
 	const Header *header = (const Header *)paramsfo;
 	if (header->magic != 0x46535000)
 		return -1;
@@ -320,7 +320,7 @@ void ParamSFOData::ValueData::SetData(const u8* data, int size) {
 	u_size = size;
 }
 
-std::string ParamSFOData::GenerateFakeID(std::string filename) const {
+std::string ParamSFOData::GenerateFakeID(const std::string &filename) const {
 	// Generates fake gameID for homebrew based on it's folder name.
 	// Should probably not be a part of ParamSFO, but it'll be called in same places.
 	std::string file = PSP_CoreParameter().fileToStart.ToString();

--- a/Core/ELF/ParamSFO.h
+++ b/Core/ELF/ParamSFO.h
@@ -27,16 +27,16 @@
 class ParamSFOData
 {
 public:
-	void SetValue(std::string key, unsigned int value, int max_size);
-	void SetValue(std::string key, std::string value, int max_size);
-	void SetValue(std::string key, const u8 *value, unsigned int size, int max_size);
+	void SetValue(const std::string &key, unsigned int value, int max_size);
+	void SetValue(const std::string &key, const std::string &value, int max_size);
+	void SetValue(const std::string &key, const u8 *value, unsigned int size, int max_size);
 
-	int GetValueInt(std::string key) const;
-	std::string GetValueString(std::string key) const;
-	const u8 *GetValueData(std::string key, unsigned int *size) const;
+	int GetValueInt(const std::string &key) const;
+	std::string GetValueString(const std::string &key) const;
+	const u8 *GetValueData(const std::string &key, unsigned int *size) const;
 
 	std::vector<std::string> GetKeys() const;
-	std::string GenerateFakeID(std::string filename = "") const;
+	std::string GenerateFakeID(const std::string &filename = "") const;
 
 	std::string GetDiscID();
 
@@ -51,7 +51,7 @@ public:
 		}
 	}
 
-	int GetDataOffset(const u8 *paramsfo, std::string dataName);
+	int GetDataOffset(const u8 *paramsfo, const std::string &dataName);
 
 	void Clear();
 

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -966,7 +966,7 @@ VFSFileSystem::~VFSFileSystem() {
 	entries.clear();
 }
 
-std::string VFSFileSystem::GetLocalPath(std::string localPath) {
+std::string VFSFileSystem::GetLocalPath(const std::string &localPath) {
 	return basePath + localPath;
 }
 

--- a/Core/FileSystems/DirectoryFileSystem.h
+++ b/Core/FileSystems/DirectoryFileSystem.h
@@ -145,5 +145,5 @@ private:
 	std::string basePath;
 	IHandleAllocator *hAlloc;
 
-	std::string GetLocalPath(std::string localpath);
+	std::string GetLocalPath(const std::string &localpath);
 };

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -30,7 +30,7 @@
 
 const int sectorSize = 2048;
 
-bool parseLBN(std::string filename, u32 *sectorStart, u32 *readSize) {
+bool parseLBN(const std::string &filename, u32 *sectorStart, u32 *readSize) {
 	// The format of this is: "/sce_lbn" "0x"? HEX* ANY* "_size" "0x"? HEX* ANY*
 	// That means that "/sce_lbn/_size1/" is perfectly valid.
 	// Most commonly, it looks like /sce_lbn0x10_size0x100 or /sce_lbn10_size100 (always hex.)

--- a/Core/FileSystems/ISOFileSystem.h
+++ b/Core/FileSystems/ISOFileSystem.h
@@ -25,7 +25,7 @@
 
 #include "BlockDevices.h"
 
-bool parseLBN(std::string filename, u32 *sectorStart, u32 *readSize);
+bool parseLBN(const std::string &filename, u32 *sectorStart, u32 *readSize);
 
 class ISOFileSystem : public IFileSystem {
 public:

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -274,7 +274,7 @@ std::string MetaFileSystem::NormalizePrefix(std::string prefix) const {
 	return prefix;
 }
 
-void MetaFileSystem::Mount(std::string prefix, std::shared_ptr<IFileSystem> system) {
+void MetaFileSystem::Mount(const std::string &prefix, std::shared_ptr<IFileSystem> system) {
 	std::lock_guard<std::recursive_mutex> guard(lock);
 
 	MountPoint x;
@@ -297,7 +297,7 @@ void MetaFileSystem::UnmountAll() {
 	currentDir.clear();
 }
 
-void MetaFileSystem::Unmount(std::string prefix) {
+void MetaFileSystem::Unmount(const std::string &prefix) {
 	for (auto iter = fileSystems.begin(); iter != fileSystems.end(); iter++) {
 		if (iter->prefix == prefix) {
 			fileSystems.erase(iter);
@@ -306,7 +306,7 @@ void MetaFileSystem::Unmount(std::string prefix) {
 	}
 }
 
-bool MetaFileSystem::Remount(std::string prefix, std::shared_ptr<IFileSystem> system) {
+bool MetaFileSystem::Remount(const std::string &prefix, std::shared_ptr<IFileSystem> system) {
 	std::lock_guard<std::recursive_mutex> guard(lock);
 	for (auto &it : fileSystems) {
 		if (it.prefix == prefix) {

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -57,12 +57,12 @@ public:
 		Reset();
 	}
 
-	void Mount(std::string prefix, std::shared_ptr<IFileSystem> system);
+	void Mount(const std::string &prefix, std::shared_ptr<IFileSystem> system);
 	// Fails if there's not already a file system at prefix.
-	bool Remount(std::string prefix, std::shared_ptr<IFileSystem> system);
+	bool Remount(const std::string &prefix, std::shared_ptr<IFileSystem> system);
 
 	void UnmountAll();
-	void Unmount(std::string prefix);
+	void Unmount(const std::string &prefix);
 
 	// The pointer returned from these are for temporary usage only. Do not store.
 	IFileSystem *GetSystem(const std::string &prefix);

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1310,7 +1310,7 @@ void timeoutFriendsRecursive(SceNetAdhocctlPeerInfo * node, int32_t* count) {
 	if (count != NULL) (*count)++;
 }
 
-void sendChat(std::string chatString) {
+void sendChat(const std::string &chatString) {
 	SceNetAdhocctlChatPacketC2S chat;
 	auto n = GetI18NCategory(I18NCat::NETWORKING);
 	chat.base.opcode = OPCODE_CHAT;

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -1038,7 +1038,7 @@ void addFriend(SceNetAdhocctlConnectPacketS2C * packet);
 * Send chat or get that
 * @param std::string ChatString 
 */
-void sendChat(std::string chatString);
+void sendChat(const std::string &chatString);
 std::vector<std::string> getChatLog();
 int GetChatChangeID();
 int GetChatMessageCount();

--- a/Core/HLE/sceKernelMsgPipe.cpp
+++ b/Core/HLE/sceKernelMsgPipe.cpp
@@ -125,7 +125,7 @@ struct MsgPipeWaitingThread
 	}
 };
 
-static bool __KernelMsgPipeThreadSortPriority(MsgPipeWaitingThread thread1, MsgPipeWaitingThread thread2)
+static bool __KernelMsgPipeThreadSortPriority(const MsgPipeWaitingThread &thread1, const MsgPipeWaitingThread &thread2)
 {
 	return __KernelThreadSortPriority(thread1.threadID, thread2.threadID);
 }

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1233,7 +1233,7 @@ void __UpdateAdhocctlHandlers(u32 flag, u32 error) {
 	adhocctlEvents.push_back({ flag, error });
 }
 
-void __UpdateMatchingHandler(MatchingArgs ArgsPtr) {
+void __UpdateMatchingHandler(const MatchingArgs &ArgsPtr) {
 	std::lock_guard<std::recursive_mutex> adhocGuard(adhocEvtMtx);
 	matchingEvents.push_back(ArgsPtr);
 }

--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -102,7 +102,7 @@ void __NetAdhocInit();
 void __NetAdhocShutdown();
 void __NetAdhocDoState(PointerWrap &p);
 void __UpdateAdhocctlHandlers(u32 flags, u32 error);
-void __UpdateMatchingHandler(MatchingArgs params);
+void __UpdateMatchingHandler(const MatchingArgs &params);
 
 // I have to call this from netdialog
 int sceNetAdhocctlGetState(u32 ptrToStatus);

--- a/Core/HW/AsyncIOManager.cpp
+++ b/Core/HW/AsyncIOManager.cpp
@@ -39,7 +39,7 @@ bool AsyncIOManager::HasOperation(u32 handle) {
 	return false;
 }
 
-void AsyncIOManager::ScheduleOperation(AsyncIOEvent ev) {
+void AsyncIOManager::ScheduleOperation(const AsyncIOEvent &ev) {
 	{
 		std::lock_guard<std::mutex> guard(resultsLock_);
 		if (!resultsPending_.insert(ev.handle).second) {
@@ -143,7 +143,7 @@ void AsyncIOManager::Write(u32 handle, const u8 *buf, size_t bytes) {
 	EventResult(handle, AsyncIOResult(result, usec));
 }
 
-void AsyncIOManager::EventResult(u32 handle, AsyncIOResult result) {
+void AsyncIOManager::EventResult(u32 handle, const AsyncIOResult &result) {
 	std::lock_guard<std::mutex> guard(resultsLock_);
 	if (results_.find(handle) != results_.end()) {
 		ERROR_LOG_REPORT(SCEIO, "Overwriting previous result for file action on handle %d", handle);

--- a/Core/HW/AsyncIOManager.h
+++ b/Core/HW/AsyncIOManager.h
@@ -83,7 +83,7 @@ public:
 	void DoState(PointerWrap &p);
 
 	bool HasOperation(u32 handle);
-	void ScheduleOperation(AsyncIOEvent ev);
+	void ScheduleOperation(const AsyncIOEvent &ev);
 	void Shutdown();
 
 	bool HasResult(u32 handle);
@@ -102,7 +102,7 @@ private:
 	void Read(u32 handle, u8 *buf, size_t bytes, u32 invalidateAddr);
 	void Write(u32 handle, const u8 *buf, size_t bytes);
 
-	void EventResult(u32 handle, AsyncIOResult result);
+	void EventResult(u32 handle, const AsyncIOResult &result);
 
 	std::mutex resultsLock_;
 	std::condition_variable resultsWait_;

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -608,7 +608,7 @@ bool IsKeyMapped(InputDeviceID device, int key) {
 	return false;
 }
 
-bool ReplaceSingleKeyMapping(int btn, int index, MultiInputMapping key) {
+bool ReplaceSingleKeyMapping(int btn, int index, const MultiInputMapping &key) {
 	std::lock_guard<std::recursive_mutex> guard(g_controllerMapLock);
 	// Check for duplicate
 	for (int i = 0; i < (int)g_controllerMap[btn].size(); ++i) {

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -188,7 +188,7 @@ namespace KeyMap {
 	// Any configuration will be saved to the Core config.
 	void SetInputMapping(int psp_key, const MultiInputMapping &key, bool replace);
 	// Return false if bind was a duplicate and got removed
-	bool ReplaceSingleKeyMapping(int btn, int index, MultiInputMapping key);
+	bool ReplaceSingleKeyMapping(int btn, int index, const MultiInputMapping &key);
 
 	MappedAnalogAxes MappedAxesForDevice(InputDeviceID deviceId);
 

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -37,7 +37,7 @@
 
 static std::map<std::string, std::unique_ptr<FileLoaderFactory>> factories;
 
-void RegisterFileLoaderFactory(std::string prefix, std::unique_ptr<FileLoaderFactory> factory) {
+void RegisterFileLoaderFactory(const std::string &prefix, std::unique_ptr<FileLoaderFactory> factory) {
 	factories[prefix] = std::move(factory);
 }
 

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -152,7 +152,7 @@ public:
 	virtual ~FileLoaderFactory() {}
 	virtual FileLoader *ConstructFileLoader(const Path &filename) = 0;
 };
-void RegisterFileLoaderFactory(std::string prefix, std::unique_ptr<FileLoaderFactory> factory);
+void RegisterFileLoaderFactory(const std::string &prefix, std::unique_ptr<FileLoaderFactory> factory);
 
 // Can modify the string filename, as it calls IdentifyFile above.
 bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string);

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -623,7 +623,7 @@ namespace Reporting
 		return true;
 	}
 
-	bool Enable(bool flag, std::string host)
+	bool Enable(bool flag, const std::string &host)
 	{
 		if (IsSupported() && IsEnabled() != flag)
 		{

--- a/Core/Reporting.h
+++ b/Core/Reporting.h
@@ -53,7 +53,7 @@ namespace Reporting
 
 	// Set the current enabled state of the reporting system and desired reporting server host.
 	// Returns if anything was changed.
-	bool Enable(bool flag, std::string host);
+	bool Enable(bool flag, const std::string &host);
 
 	// Use the default reporting setting (per compiled settings) of host and enabled state.
 	void EnableDefault();

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -397,7 +397,7 @@ namespace SaveState
 		pspFileSystem.DoState(p);
 	}
 
-	void Enqueue(SaveState::Operation op)
+	void Enqueue(const SaveState::Operation &op)
 	{
 		if (Achievements::HardcoreModeActive()) {
 			if (g_Config.bAchievementsSaveStateInHardcoreMode && ((op.type == SaveState::SAVESTATE_SAVE) || (op.type == SAVESTATE_SAVE_SCREENSHOT))) {

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -86,12 +86,12 @@ Path GameManager::GetTempFilename() const {
 #endif
 }
 
-bool GameManager::IsGameInstalled(std::string name) {
+bool GameManager::IsGameInstalled(const std::string &name) {
 	Path pspGame = GetSysDirectory(DIRECTORY_GAME);
 	return File::Exists(pspGame / name);
 }
 
-bool GameManager::DownloadAndInstall(std::string storeFileUrl) {
+bool GameManager::DownloadAndInstall(const std::string &storeFileUrl) {
 	if (curDownload_.get() != nullptr) {
 		ERROR_LOG(HLE, "Can only process one download at a time");
 		return false;
@@ -107,7 +107,7 @@ bool GameManager::DownloadAndInstall(std::string storeFileUrl) {
 	return true;
 }
 
-bool GameManager::IsDownloading(std::string storeZipUrl) {
+bool GameManager::IsDownloading(const std::string &storeZipUrl) {
 	if (curDownload_)
 		return curDownload_->url() == storeZipUrl;
 	return false;
@@ -128,7 +128,7 @@ float GameManager::DownloadSpeedKBps() {
 	return 0.0f;
 }
 
-void GameManager::UninstallGame(std::string name) {
+void GameManager::UninstallGame(const std::string &name) {
 	SetCurrentThreadName("UninstallGame");
 
 	AndroidJNIThreadContext context;  // Destructor detaches.
@@ -285,7 +285,7 @@ ZipFileContents DetectZipFileContents(struct zip *z, ZipFileInfo *info) {
 }
 
 // Parameters need to be by value, since this is a thread func.
-bool GameManager::InstallGame(Path url, Path fileName, bool deleteAfter) {
+bool GameManager::InstallGame(const Path &url, const Path &fileName, bool deleteAfter) {
 	SetCurrentThreadName("InstallGame");
 
 	if (installDonePending_) {

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -42,11 +42,11 @@ class GameManager {
 public:
 	GameManager();
 
-	bool IsGameInstalled(std::string name);
+	bool IsGameInstalled(const std::string &name);
 
 	// This starts off a background process.
-	bool DownloadAndInstall(std::string storeZipUrl);
-	bool IsDownloading(std::string storeZipUrl);
+	bool DownloadAndInstall(const std::string &storeZipUrl);
+	bool IsDownloading(const std::string &storeZipUrl);
 
 	// Cancels the download in progress, if any.
 	bool CancelDownload();
@@ -79,12 +79,12 @@ public:
 
 private:
 	// TODO: The return value on this is a bit pointless, we can't get at it.
-	bool InstallGame(Path url, Path tempFileName, bool deleteAfter);
+	bool InstallGame(const Path &url, const Path &tempFileName, bool deleteAfter);
 	bool InstallMemstickGame(struct zip *z, const Path &zipFile, const Path &dest, const ZipFileInfo &info, bool allowRoot, bool deleteAfter);
 	bool InstallMemstickZip(struct zip *z, const Path &zipFile, const Path &dest, const ZipFileInfo &info, bool deleteAfter);
 	bool InstallZippedISO(struct zip *z, int isoFileIndex, const Path &zipfile, bool deleteAfter);
 	bool InstallRawISO(const Path &zipFile, const std::string &originalName, bool deleteAfter);
-	void UninstallGame(std::string name);
+	void UninstallGame(const std::string &name);
 
 	void InstallDone();
 

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -948,7 +948,7 @@ static PPGeTextDrawerImage PPGeGetTextImage(const char *text, const PPGeStyle &s
 	return im;
 }
 
-static void PPGeDrawTextImage(PPGeTextDrawerImage im, float x, float y, const PPGeStyle &style) {
+static void PPGeDrawTextImage(const PPGeTextDrawerImage &im, float x, float y, const PPGeStyle &style) {
 	if (!im.ptr) {
 		return;
 	}

--- a/GPU/Common/TextureShaderCommon.cpp
+++ b/GPU/Common/TextureShaderCommon.cpp
@@ -241,7 +241,7 @@ std::vector<std::string> TextureShaderCache::DebugGetShaderIDs(DebugShaderType t
 	return ids;
 }
 
-std::string TextureShaderCache::DebugGetShaderString(std::string idstr, DebugShaderType type, DebugShaderStringType stringType) {
+std::string TextureShaderCache::DebugGetShaderString(const std::string &idstr, DebugShaderType type, DebugShaderStringType stringType) {
 	uint32_t id = 0;
 	sscanf(idstr.c_str(), "%08x", &id);
 	auto iter = depalCache_.find(id);

--- a/GPU/Common/TextureShaderCommon.h
+++ b/GPU/Common/TextureShaderCommon.h
@@ -54,7 +54,7 @@ public:
 	void Clear();
 	void Decimate();
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType type);
-	std::string DebugGetShaderString(std::string id, DebugShaderType type, DebugShaderStringType stringType);
+	std::string DebugGetShaderString(const std::string &id, DebugShaderType type, DebugShaderStringType stringType);
 
 	void DeviceLost();
 	void DeviceRestore(Draw::DrawContext *draw);

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -166,7 +166,7 @@ static bool UsesBlendConstant(int factor) {
 	}
 }
 
-static std::string CutFromMain(std::string str) {
+static std::string CutFromMain(const std::string &str) {
 	std::vector<std::string> lines;
 	SplitString(str, '\n', lines);
 
@@ -495,7 +495,7 @@ static const char *const blendFactors[19] = {
 	"INV_SRC1_A",
 };
 
-std::string PipelineManagerVulkan::DebugGetObjectString(std::string id, DebugShaderType type, DebugShaderStringType stringType, ShaderManagerVulkan *shaderManager) {
+std::string PipelineManagerVulkan::DebugGetObjectString(const std::string &id, DebugShaderType type, DebugShaderStringType stringType, ShaderManagerVulkan *shaderManager) {
 	if (type != SHADER_TYPE_PIPELINE)
 		return "N/A";
 

--- a/GPU/Vulkan/PipelineManagerVulkan.h
+++ b/GPU/Vulkan/PipelineManagerVulkan.h
@@ -95,7 +95,7 @@ public:
 
 	void InvalidateMSAAPipelines();
 
-	std::string DebugGetObjectString(std::string id, DebugShaderType type, DebugShaderStringType stringType, ShaderManagerVulkan *shaderManager);
+	std::string DebugGetObjectString(const std::string &id, DebugShaderType type, DebugShaderStringType stringType, ShaderManagerVulkan *shaderManager);
 	std::vector<std::string> DebugGetObjectIDs(DebugShaderType type) const;
 
 	// Saves data for faster creation next time.

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -159,7 +159,7 @@ VkSampler SamplerCache::GetOrCreateSampler(const SamplerCacheKey &key) {
 	return sampler;
 }
 
-std::string SamplerCache::DebugGetSamplerString(std::string id, DebugShaderStringType stringType) {
+std::string SamplerCache::DebugGetSamplerString(const std::string &id, DebugShaderStringType stringType) {
 	SamplerCacheKey key;
 	key.FromString(id);
 	return StringFromFormat("%s/%s mag:%s min:%s mip:%s maxLod:%f minLod:%f bias:%f",
@@ -852,7 +852,7 @@ std::vector<std::string> TextureCacheVulkan::DebugGetSamplerIDs() const {
 	return samplerCache_.DebugGetSamplerIDs();
 }
 
-std::string TextureCacheVulkan::DebugGetSamplerString(std::string id, DebugShaderStringType stringType) {
+std::string TextureCacheVulkan::DebugGetSamplerString(const std::string &id, DebugShaderStringType stringType) {
 	return samplerCache_.DebugGetSamplerString(id, stringType);
 }
 

--- a/GPU/Vulkan/TextureCacheVulkan.h
+++ b/GPU/Vulkan/TextureCacheVulkan.h
@@ -44,7 +44,7 @@ public:
 	void DeviceRestore(VulkanContext *vulkan);
 
 	std::vector<std::string> DebugGetSamplerIDs() const;
-	std::string DebugGetSamplerString(std::string id, DebugShaderStringType stringType);
+	std::string DebugGetSamplerString(const std::string &id, DebugShaderStringType stringType);
 
 private:
 	VulkanContext *vulkan_;
@@ -81,7 +81,7 @@ public:
 	VulkanDeviceAllocator *GetAllocator() { return allocator_; }
 
 	std::vector<std::string> DebugGetSamplerIDs() const;
-	std::string DebugGetSamplerString(std::string id, DebugShaderStringType stringType);
+	std::string DebugGetSamplerString(const std::string &id, DebugShaderStringType stringType);
 
 protected:
 	void BindTexture(TexCacheEntry *entry) override;

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -69,7 +69,7 @@ private:
 	UI::EventReturn OnReplace(UI::EventParams &params);
 	UI::EventReturn OnReplaceAll(UI::EventParams &params);
 
-	void MappedCallback(MultiInputMapping key);
+	void MappedCallback(const MultiInputMapping &key);
 
 	enum Action {
 		NONE,
@@ -163,7 +163,7 @@ void SingleControlMapper::Refresh() {
 	}
 }
 
-void SingleControlMapper::MappedCallback(MultiInputMapping kdf) {
+void SingleControlMapper::MappedCallback(const MultiInputMapping &kdf) {
 	if (kdf.empty()) {
 		// Don't want to try to add this.
 		return;
@@ -1192,7 +1192,7 @@ UI::EventReturn VisualMappingScreen::OnBindAll(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
-void VisualMappingScreen::HandleKeyMapping(MultiInputMapping key) {
+void VisualMappingScreen::HandleKeyMapping(const KeyMap::MultiInputMapping &key) {
 	KeyMap::SetInputMapping(nextKey_, key, replace_);
 	KeyMap::UpdateNativeMenuKeys();
 

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -197,7 +197,7 @@ protected:
 private:
 	UI::EventReturn OnMapButton(UI::EventParams &e);
 	UI::EventReturn OnBindAll(UI::EventParams &e);
-	void HandleKeyMapping(KeyMap::MultiInputMapping key);
+	void HandleKeyMapping(const KeyMap::MultiInputMapping &key);
 	void MapNext(bool successive);
 
 	MockPSP *psp_ = nullptr;

--- a/UI/MemStickScreen.cpp
+++ b/UI/MemStickScreen.cpp
@@ -50,7 +50,7 @@
 #include "UI/MiscScreens.h"
 #include "UI/OnScreenDisplay.h"
 
-static bool FolderSeemsToBeUsed(Path newMemstickFolder) {
+static bool FolderSeemsToBeUsed(const Path &newMemstickFolder) {
 	// Inspect the potential new folder, quickly.
 	if (File::Exists(newMemstickFolder / "PSP/SAVEDATA") || File::Exists(newMemstickFolder / "SAVEDATA")) {
 		// Does seem likely. We could add more criteria like checking for actual savegames or something.
@@ -514,7 +514,7 @@ struct FileSuffix {
 	u64 fileSize;
 };
 
-static bool ListFileSuffixesRecursively(const Path &root, Path folder, std::vector<std::string> &dirSuffixes, std::vector<FileSuffix> &fileSuffixes) {
+static bool ListFileSuffixesRecursively(const Path &root, const Path &folder, std::vector<std::string> &dirSuffixes, std::vector<FileSuffix> &fileSuffixes) {
 	std::vector<File::FileInfo> files;
 	if (!File::GetFilesInDir(folder, &files)) {
 		return false;

--- a/UI/MemStickScreen.h
+++ b/UI/MemStickScreen.h
@@ -93,7 +93,7 @@ private:
 
 class ProgressReporter {
 public:
-	void Set(std::string value) {
+	void Set(const std::string &value) {
 		std::lock_guard<std::mutex> guard(mutex_);
 		progress_ = value;
 	}

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -266,7 +266,7 @@ UI::EventReturn SavedataPopupScreen::OnDeleteButtonClick(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
-static std::string CleanSaveString(std::string str) {
+static std::string CleanSaveString(const std::string &str) {
 	std::string s = ReplaceAll(str, "&", "&&");
 	s = ReplaceAll(s, "\n", " ");
 	s = ReplaceAll(s, "\r", " ");

--- a/UI/Store.cpp
+++ b/UI/Store.cpp
@@ -43,7 +43,7 @@ static std::string StoreBaseUrl() {
 }
 
 // baseUrl is assumed to have a trailing slash, and not contain any subdirectories.
-std::string ResolveUrl(std::string baseUrl, std::string url) {
+std::string ResolveUrl(const std::string &baseUrl, const std::string &url) {
 	if (url.empty()) {
 		return baseUrl;
 	} else if (url[0] == '/') {
@@ -91,7 +91,7 @@ public:
 	void Draw(UIContext &dc) override;
 	std::string DescribeText() const override { return ""; }
 
-	void SetFilename(std::string filename);
+	void SetFilename(const std::string &filename);
 	void SetColor(uint32_t color) { color_ = color; }
 	void SetFixedSize(float fixW, float fixH) { fixedSizeW_ = fixW; fixedSizeH_ = fixH; }
 	void SetCanBeFocused(bool can) { canFocus_ = can; }
@@ -150,7 +150,7 @@ void HttpImageFileView::GetContentDimensions(const UIContext &dc, float &w, floa
 	}
 }
 
-void HttpImageFileView::SetFilename(std::string filename) {
+void HttpImageFileView::SetFilename(const std::string &filename) {
 	if (!useIconCache_ && path_ != filename) {
 		textureFailed_ = false;
 		path_ = filename;
@@ -454,7 +454,7 @@ void StoreScreen::update() {
 	}
 }
 
-void StoreScreen::ParseListing(std::string json) {
+void StoreScreen::ParseListing(const std::string &json) {
 	using namespace json;
 	JsonReader reader(json.c_str(), json.size());
 	if (!reader.ok() || !reader.root()) {
@@ -585,7 +585,7 @@ UI::EventReturn StoreScreen::OnRetry(UI::EventParams &e) {
 	return UI::EVENT_DONE;
 }
 
-std::string StoreScreen::GetTranslatedString(const json::JsonGet json, std::string key, const char *fallback) const {
+std::string StoreScreen::GetTranslatedString(const json::JsonGet json, const std::string &key, const char *fallback) const {
 	json::JsonGet dict = json.getDict("en_US");
 	if (dict && json.hasChild(lang_.c_str(), JSON_OBJECT)) {
 		if (json.getDict(lang_.c_str()).hasChild(key.c_str(), JSON_STRING)) {

--- a/UI/Store.h
+++ b/UI/Store.h
@@ -72,10 +72,10 @@ protected:
 	UI::EventReturn OnGameLaunch(UI::EventParams &e);
 
 private:
-	void ParseListing(std::string json);
+	void ParseListing(const std::string &json);
 	ProductItemView *GetSelectedItem();
 
-	std::string GetTranslatedString(const json::JsonGet json, std::string key, const char *fallback = nullptr) const;
+	std::string GetTranslatedString(const json::JsonGet json, const std::string &key, const char *fallback = nullptr) const;
 
 	std::shared_ptr<http::Request> listing_;
 	std::shared_ptr<http::Request> image_;

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -277,7 +277,7 @@ std::string trimString(std::string input)
 	return input;
 }
 
-void CtrlDisAsmView::assembleOpcode(u32 address, std::string defaultText)
+void CtrlDisAsmView::assembleOpcode(u32 address, const std::string &defaultText)
 {
 	auto memLock = Memory::Lock();
 	if (Core_IsStepping() == false) {

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -67,7 +67,7 @@ class CtrlDisAsmView
 		ADDRESSES,
 	};
 
-	void assembleOpcode(u32 address, std::string defaultText);
+	void assembleOpcode(u32 address, const std::string &defaultText);
 	std::string disassembleRange(u32 start, u32 size);
 	void disassembleToFile();
 	void search(bool continueSearch);


### PR DESCRIPTION
@hrydgard do not be lazy to review PR changes, sometimes I accidentally forget to specify `&` for parameters.
I expect feedback, I understand that most fixes will not increase generic speed calling functions, but it is useful for refactoring code.