### PR TITLE
[Common Data/Core Dialog HLE/GPU Common Vulkan] Optimize create smart pointers using C++17 std::make_*

### DIFF
--- a/Common/Data/Format/IniFile.cpp
+++ b/Common/Data/Format/IniFile.cpp
@@ -445,7 +445,7 @@ Section* IniFile::GetSection(const char* sectionName) {
 Section* IniFile::GetOrCreateSection(const char* sectionName) {
 	Section* section = GetSection(sectionName);
 	if (!section) {
-		sections.push_back(std::unique_ptr<Section>(new Section(sectionName)));
+		sections.push_back(std::make_unique<Section>(sectionName));
 		section = sections.back().get();
 	}
 	return section;
@@ -502,7 +502,7 @@ void IniFile::SortSections()
 bool IniFile::Load(const Path &path)
 {
 	sections.clear();
-	sections.push_back(std::unique_ptr<Section>(new Section("")));
+	sections.push_back(std::make_unique<Section>(""));
 	// first section consists of the comments before the first real section
 
 	// Open file
@@ -558,14 +558,14 @@ bool IniFile::Load(std::istream &in) {
 			if (sectionNameEnd != std::string::npos) {
 				// New section!
 				std::string sub = line.substr(1, sectionNameEnd - 1);
-				sections.push_back(std::unique_ptr<Section>(new Section(sub)));
+				sections.push_back(std::make_unique<Section>(sub));
 
 				if (sectionNameEnd + 1 < line.size()) {
 					sections.back()->comment = line.substr(sectionNameEnd + 1);
 				}
 			} else {
 				if (sections.empty()) {
-					sections.push_back(std::unique_ptr<Section>(new Section("")));
+					sections.push_back(std::make_unique<Section>(""));
 				}
 				ParsedIniLine parsedLine;
 				parsedLine.ParseFrom(line);

--- a/Common/Data/Text/I18n.cpp
+++ b/Common/Data/Text/I18n.cpp
@@ -58,7 +58,7 @@ void I18NRepo::Clear() {
 	std::lock_guard<std::mutex> guard(catsLock_);
 	for (auto &iter : cats_) {
 		// Initialize with empty categories, so that early lookups don't crash.
-		iter = std::shared_ptr<I18NCategory>(new I18NCategory());
+		iter = std::make_shared<I18NCategory>();
 	}
 }
 

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -404,7 +404,7 @@ int SavedataParam::DeleteData(SceUtilitySavedataParam* param) {
 		}
 
 		if (changed) {
-			std::unique_ptr<u8[]> updatedList(new u8[fileListSize]);
+			auto updatedList = std::make_unique<u8[]> (fileListSize);
 			memcpy(updatedList.get(), fileList, fileListSize);
 			sfoFile->SetValue("SAVEDATA_FILE_LIST", updatedList.get(), fileListSize, (int)FILE_LIST_TOTAL_SIZE);
 

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1514,7 +1514,7 @@ void PostPutAction::run(MipsCall &call) {
 	// It seems validation is done only by older mpeg libs.
 	if (mpegLibVersion < 0x0105 && packetsAddedThisRound > 0) {
 		// TODO: Faster / less wasteful validation.
-		std::unique_ptr<MpegDemux> demuxer(new MpegDemux(packetsAddedThisRound * 2048, 0));
+		auto demuxer = std::make_unique<MpegDemux>(packetsAddedThisRound * 2048, 0);
 		int readOffset = ringbuffer->packetsRead % (s32)ringbuffer->packets;
 		uint32_t bufSize = Memory::ValidSize(ringbuffer->data + readOffset * 2048, packetsAddedThisRound * 2048);
 		const u8 *buf = Memory::GetPointer(ringbuffer->data + readOffset * 2048);

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -597,7 +597,7 @@ ReplacedTexture::LoadLevelResult ReplacedTexture::LoadLevelData(VFSFileReference
 
 	} else if (imageType == ReplacedImageType::ZIM) {
 
-		std::unique_ptr<uint8_t[]> zim(new uint8_t[fileSize]);
+		auto zim = std::make_unique<uint8_t[]>(fileSize);
 		if (!zim) {
 			ERROR_LOG(G3D, "Failed to allocate memory for texture replacement");
 			vfs_->CloseFile(openFile);

--- a/GPU/Vulkan/PipelineManagerVulkan.cpp
+++ b/GPU/Vulkan/PipelineManagerVulkan.cpp
@@ -644,7 +644,7 @@ void PipelineManagerVulkan::SavePipelineCache(FILE *file, bool saveRawPipelineCa
 			fwrite(&size, sizeof(size), 1, file);
 			return;
 		}
-		std::unique_ptr<uint8_t[]> buffer(new uint8_t[dataSize]);
+		auto buffer = std::make_unique<uint8_t[]>(dataSize);
 		vkGetPipelineCacheData(vulkan_->GetDevice(), pipelineCache_, &dataSize, buffer.get());
 		size = (uint32_t)dataSize;
 		fwrite(&size, sizeof(size), 1, file);
@@ -731,7 +731,7 @@ bool PipelineManagerVulkan::LoadPipelineCache(FILE *file, bool loadRawPipelineCa
 			WARN_LOG(G3D, "Zero-sized Vulkan pipeline cache.");
 			return true;
 		}
-		std::unique_ptr<uint8_t[]> buffer(new uint8_t[size]);
+		auto buffer = std::make_unique<uint8_t[]>(size);
 		success = fread(buffer.get(), 1, size, file) == size;
 		// Verify header.
 		VkPipelineCacheHeader *header = (VkPipelineCacheHeader *)buffer.get();


### PR DESCRIPTION
@hrydgard Since in CMakeLists has a minimum requirement C++17 standard, you can safely use functions make_unique, make_shared, etc. You can find information why it's worth using them in some places.