### PR TITLE
Fixed all set render state4 after DirectXState::Restore()

### DIFF
--- a/Common/GPU/D3D9/D3D9StateCache.h
+++ b/Common/GPU/D3D9/D3D9StateCache.h
@@ -250,7 +250,7 @@ private:
 			pD3Ddevice9->SetRenderState(_state1, p1);
 			pD3Ddevice9->SetRenderState(_state2, p2);
 			pD3Ddevice9->SetRenderState(_state3, p3);
-			pD3Ddevice9->SetRenderState(_state3, p4);
+			pD3Ddevice9->SetRenderState(_state4, p4);
 		}
 	};
 


### PR DESCRIPTION
@hrydgard Developers sometimes make mistakes due to inattention, it is important to look at compiler warnings.