### PR TITLE
[Common Data Net/Core Debugger HLE/GPU Debugger] Fixed reduction data type size to strict 32-bit integer

### DIFF
--- a/Common/Data/Format/ZIMLoad.cpp
+++ b/Common/Data/Format/ZIMLoad.cpp
@@ -132,9 +132,9 @@ int LoadZIM(const char *filename, int *width, int *height, int *format, uint8_t 
 		return 0;
 	}
 
-	int retval = LoadZIMPtr(buffer, (int)size, width, height, format, image);
+	int retval = LoadZIMPtr(buffer, size, width, height, format, image);
 	if (!retval) {
-		ERROR_LOG(IO, "Not a valid ZIM file: %s (size: %d bytes)", filename, (int)size);
+		ERROR_LOG(IO, "Not a valid ZIM file: %s (size: %lld bytes)", filename, (long long)size);
 	}
 	delete [] buffer;
 	return retval;

--- a/Common/Net/HTTPServer.cpp
+++ b/Common/Net/HTTPServer.cpp
@@ -118,7 +118,7 @@ void ServerRequest::WriteHttpResponseHeader(const char *ver, int status, int64_t
 		buffer->Printf("Content-Length: %llu\r\n", size);
 	}
 	if (otherHeaders) {
-		buffer->Push(otherHeaders, (int)strlen(otherHeaders));
+		buffer->Push(otherHeaders, strlen(otherHeaders));
 	}
 	buffer->Push("\r\n");
 }

--- a/Core/Debugger/SymbolMap.cpp
+++ b/Core/Debugger/SymbolMap.cpp
@@ -1114,7 +1114,7 @@ void SymbolMap::FillSymbolListBox(HWND listbox,SymbolType symType) {
 
 	case ST_DATA:
 		{
-			int count = ARRAYSIZE(defaultSymbols)+(int)activeData.size();
+			size_t count = ARRAYSIZE(defaultSymbols)+activeData.size();
 			SendMessage(listbox, LB_INITSTORAGE, (WPARAM)count, (LPARAM)count * 30);
 
 			for (int i = 0; i < ARRAYSIZE(defaultSymbols); i++) {

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1912,7 +1912,7 @@ bool __KernelLoadGEDump(const std::string &base_filename, std::string *error_str
 	};
 
 	for (size_t i = 0; i < ARRAY_SIZE(runDumpCode); ++i) {
-		Memory::WriteUnchecked_U32(runDumpCode[i], mipsr4k.pc + (int)i * sizeof(u32_le));
+		Memory::WriteUnchecked_U32(runDumpCode[i], mipsr4k.pc + (u32)i * sizeof(u32_le));
 	}
 
 	PSPModule *module = new PSPModule();

--- a/GPU/Debugger/Playback.cpp
+++ b/GPU/Debugger/Playback.cpp
@@ -369,7 +369,7 @@ bool DumpExecute::SubmitCmds(const void *p, u32 sz) {
 		gpu->EnableInterrupts(true);
 	}
 
-	u32 pendingSize = (int)execListQueue.size() * sizeof(u32);
+	u32 pendingSize = (u32)execListQueue.size() * sizeof(u32);
 	// Validate space for jump.
 	u32 allocSize = pendingSize + sz + 8;
 	if (execListPos + allocSize >= execListBuf + LIST_BUF_SIZE) {


### PR DESCRIPTION
@hrydgard It may be left over from old code, some functions accept size_t, reducing memsize type can in some situations ruin result algorithm.