### PR TITLE
DXT5: Fix decoding of alpha channel for textures with a non-mod-4 width.

### DIFF
--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -566,10 +566,11 @@ void DXTDecoder::WriteColorsDXT3(u32 *dst, const DXT3Block *src, int pitch, int 
 
 void DXTDecoder::WriteColorsDXT5(u32 *dst, const DXT5Block *src, int pitch, int width, int height) {
 	// 48 bits, 3 bit index per pixel, 12 bits per line.
-	u64 alphadata = ((u64)(u16)src->alphadata1 << 32) | (u32)src->alphadata2;
+	u64 allAlpha = ((u64)(u16)src->alphadata1 << 32) | (u32)src->alphadata2;
 
 	for (int y = 0; y < height; y++) {
-		int colordata = src->color.lines[y];
+		uint32_t colordata = src->color.lines[y];
+		uint32_t alphadata = allAlpha >> (12 * y);
 		for (int x = 0; x < width; x++) {
 			dst[x] = colors_[colordata & 3] | (alpha_[alphadata & 7] << 24);
 			colordata >>= 2;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1351,6 +1351,13 @@ UCKS45124 = true
 UCJS10104 = true
 NPJG00047 = true
 
+# Tiger Woods 06 - bloom during rain
+ULUS10028 = true
+ULES00153 = true
+ULES00154 = true
+ULJM05059 = true
+ULAS42020 = true
+
 [ForceLowerResolutionForEffectsOff]
 # Some games really don't work with this. Ratchet & Clank looks terrible.
 UCUS98633 = true


### PR DESCRIPTION
Had to step through the DXT5 decoder to see it.. Silly logical mistake.

Fixes #18108 