### PR TITLE
Vulkan: UI texture loading error handling fixes

### DIFF
--- a/Common/GPU/Vulkan/VulkanImage.cpp
+++ b/Common/GPU/Vulkan/VulkanImage.cpp
@@ -42,7 +42,8 @@ bool VulkanTexture::CreateDirect(VkCommandBuffer cmd, int w, int h, int depth, i
 		ERROR_LOG(G3D, "Can't create a zero-size VulkanTexture");
 		return false;
 	}
-	if (w > 4096 || h > 4096) {
+	int maxDim = vulkan_->GetPhysicalDeviceProperties(0).properties.limits.maxImageDimension2D;
+	if (w > maxDim || h > maxDim) {
 		ERROR_LOG(G3D, "Can't create a texture this large");
 		return false;
 	}

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1298,7 +1298,7 @@ Texture *VKContext::CreateTexture(const TextureDesc &desc) {
 		return tex;
 	} else {
 		ERROR_LOG(G3D,  "Failed to create texture");
-		delete tex;
+		tex->Release();
 		return nullptr;
 	}
 }

--- a/Common/Render/ManagedTexture.cpp
+++ b/Common/Render/ManagedTexture.cpp
@@ -194,6 +194,10 @@ Draw::Texture *ManagedTexture::GetTexture() {
 		}
 		// Image load is done, texture creation is not.
 		texture_ = CreateTextureFromTempImage(draw_, pendingImage_, generateMips_, filename_.c_str());
+		if (!texture_) {
+			// Failed to create the texture for whatever reason, like dimensions. Don't retry next time.
+			state_ = LoadState::FAILED;
+		}
 		pendingImage_.Free();
 	}
 	return texture_;


### PR DESCRIPTION
Allow creation of as big textures as the hardware allows, instead of capping at 4096.

It can happen that we create savestate images bigger than that if you use 10x render resolution (That itself should be fixed, but we should also be able to read these images).

We also would crash if we rejected an image, that's been fixed.