### PR TITLE
Enforce a max size for save state screenshot regardless of resolution mode 

### DIFF
--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -1050,8 +1050,8 @@ namespace SaveState
 
 			case SAVESTATE_SAVE_SCREENSHOT:
 			{
-				int maxRes = g_Config.iInternalResolution > 2 ? 2 : -1;
-				tempResult = TakeGameScreenshot(op.filename, ScreenshotFormat::JPG, SCREENSHOT_DISPLAY, nullptr, nullptr, maxRes);
+				int maxResMultiplier = 2;
+				tempResult = TakeGameScreenshot(op.filename, ScreenshotFormat::JPG, SCREENSHOT_DISPLAY, nullptr, nullptr, maxResMultiplier);
 				callbackResult = tempResult ? Status::SUCCESS : Status::FAILURE;
 				if (!tempResult) {
 					ERROR_LOG(SAVESTATE, "Failed to take a screenshot for the savestate! %s", op.filename.c_str());

--- a/Core/Screenshot.cpp
+++ b/Core/Screenshot.cpp
@@ -340,8 +340,6 @@ bool TakeGameScreenshot(const Path &filename, ScreenshotFormat fmt, ScreenshotTy
 
 	if (type == SCREENSHOT_DISPLAY || type == SCREENSHOT_RENDER) {
 		success = gpuDebug->GetCurrentFramebuffer(buf, type == SCREENSHOT_RENDER ? GPU_DBG_FRAMEBUF_RENDER : GPU_DBG_FRAMEBUF_DISPLAY, maxRes);
-
-		// Only crop to the top left when using a render screenshot.
 		w = maxRes > 0 ? 480 * maxRes : PSP_CoreParameter().renderWidth;
 		h = maxRes > 0 ? 272 * maxRes : PSP_CoreParameter().renderHeight;
 	} else if (g_display.rotation != DisplayRotation::ROTATE_0) {


### PR DESCRIPTION
Turns out our resizing was deactivated if iRenderResolution was < 2, which includes the auto mode for example.

Fixes #18556 