### PR TITLE
Add option to slow down mouse wheel to closer resemble button presses

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -838,6 +838,7 @@ static const ConfigSetting controlSettings[] = {
 	ConfigSetting("ConfineMap", &g_Config.bMouseConfine, false, CfgFlag::PER_GAME),
 	ConfigSetting("MouseSensitivity", &g_Config.fMouseSensitivity, 0.1f, CfgFlag::PER_GAME),
 	ConfigSetting("MouseSmoothing", &g_Config.fMouseSmoothing, 0.9f, CfgFlag::PER_GAME),
+	ConfigSetting("MouseWheelUpDelay", &g_Config.iMouseWheelUpDelay, 1, CfgFlag::PER_GAME),
 
 	ConfigSetting("SystemControls", &g_Config.bSystemControls, true, CfgFlag::DEFAULT),
 	ConfigSetting("RapidFileInterval", &g_Config.iRapidFireInterval, 5, CfgFlag::DEFAULT),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -403,6 +403,7 @@ public:
 	bool bMouseConfine; // Trap inside the window.
 	float fMouseSensitivity;
 	float fMouseSmoothing;
+	int iMouseWheelUpDelay;
 
 	bool bSystemControls;
 	int iRapidFireInterval;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -781,6 +781,9 @@ void GameSettingsScreen::CreateControlsSettings(UI::ViewGroup *controlsSettings)
 			auto smoothingSlider = controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fMouseSmoothing, 0.0f, 0.95f, 0.9f, co->T("Mouse smoothing"), 0.05f, screenManager(), "x"));
 			smoothingSlider->SetEnabledPtr(&g_Config.bMouseControl);
 			smoothingSlider->SetLiveUpdate(true);
+
+			auto wheelUpDelaySlider = controlsSettings->Add(new PopupSliderChoice(&g_Config.iMouseWheelUpDelay, 1, 10, 1, co->T("Mouse wheel delay"), screenManager()));
+			wheelUpDelaySlider->SetEnabledPtr(&g_Config.bMouseControl);
 		}
 	}
 }

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -781,9 +781,10 @@ void GameSettingsScreen::CreateControlsSettings(UI::ViewGroup *controlsSettings)
 			auto smoothingSlider = controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fMouseSmoothing, 0.0f, 0.95f, 0.9f, co->T("Mouse smoothing"), 0.05f, screenManager(), "x"));
 			smoothingSlider->SetEnabledPtr(&g_Config.bMouseControl);
 			smoothingSlider->SetLiveUpdate(true);
-
+#if defined(USING_WIN_UI)
 			auto wheelUpDelaySlider = controlsSettings->Add(new PopupSliderChoice(&g_Config.iMouseWheelUpDelay, 1, 10, 1, co->T("Mouse wheel delay"), screenManager()));
 			wheelUpDelaySlider->SetEnabledPtr(&g_Config.bMouseControl);
+#endif
 		}
 	}
 }

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -930,7 +930,7 @@ namespace MainWindow
 				// There's no separate keyup event for mousewheel events,
 				// so we release it with a slight delay.
 				key.flags = KEY_DOWN | KEY_HASWHEELDELTA | (wheelDelta << 16);
-				SetTimer(hwndMain, TIMER_WHEELRELEASE, WHEELRELEASE_DELAY_MS, 0);
+				SetTimer(hwndMain, TIMER_WHEELRELEASE, WHEELRELEASE_DELAY_MS * g_Config.iMouseWheelUpDelay, 0);
 				NativeKey(key);
 			}
 			break;


### PR DESCRIPTION
Should fix #18564
Default is unchanged, add's an option to delay it.