### PR TITLE
Mouse wheel: Centralize the sending of KEY_UP events on a timer.

### DIFF
--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -241,8 +241,10 @@ void PPSSPP_UWPMain::OnMouseWheel(float delta) {
 	KeyInput keyInput{};
 	keyInput.keyCode = key;
 	keyInput.deviceId = DEVICE_ID_MOUSE;
-	keyInput.flags = KEY_DOWN | KEY_UP;
+	keyInput.flags = KEY_DOWN;
 	NativeKey(keyInput);
+
+	// KEY_UP is now sent automatically afterwards for mouse wheel events, see NativeKey.
 }
 
 bool PPSSPP_UWPMain::OnHardwareButton(HardwareButton button) {

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -112,10 +112,8 @@ static std::wstring windowTitle;
 
 #define TIMER_CURSORUPDATE 1
 #define TIMER_CURSORMOVEUPDATE 2
-#define TIMER_WHEELRELEASE 3
 #define CURSORUPDATE_INTERVAL_MS 1000
 #define CURSORUPDATE_MOVE_TIMESPAN_MS 500
-#define WHEELRELEASE_DELAY_MS 16
 
 namespace MainWindow
 {
@@ -265,17 +263,6 @@ namespace MainWindow
 				ClipCursor(NULL);
 			}
 		}
-	}
-
-	void ReleaseMouseWheel() {
-		// For simplicity release both wheel events
-		KeyInput key;
-		key.deviceId = DEVICE_ID_MOUSE;
-		key.flags = KEY_UP;
-		key.keyCode = NKCODE_EXT_MOUSEWHEEL_DOWN;
-		NativeKey(key);
-		key.keyCode = NKCODE_EXT_MOUSEWHEEL_UP;
-		NativeKey(key);
 	}
 
 	static void HandleSizeChange(int newSizingType) {
@@ -927,10 +914,8 @@ namespace MainWindow
 				} else {
 					key.keyCode = NKCODE_EXT_MOUSEWHEEL_UP;
 				}
-				// There's no separate keyup event for mousewheel events,
-				// so we release it with a slight delay.
+				// There's no release event, but we simulate it in NativeKey/NativeFrame.
 				key.flags = KEY_DOWN | KEY_HASWHEELDELTA | (wheelDelta << 16);
-				SetTimer(hwndMain, TIMER_WHEELRELEASE, WHEELRELEASE_DELAY_MS, 0);
 				NativeKey(key);
 			}
 			break;
@@ -945,11 +930,6 @@ namespace MainWindow
 			case TIMER_CURSORMOVEUPDATE:
 				hideCursor = true;
 				KillTimer(hWnd, TIMER_CURSORMOVEUPDATE);
-				return 0;
-			// Hack: need to release wheel event with a delay for games to register it was "pressed down".
-			case TIMER_WHEELRELEASE:
-				ReleaseMouseWheel();
-				KillTimer(hWnd, TIMER_WHEELRELEASE);
 				return 0;
 			}
 			break;
@@ -1045,7 +1025,6 @@ namespace MainWindow
 		case WM_DESTROY:
 			KillTimer(hWnd, TIMER_CURSORUPDATE);
 			KillTimer(hWnd, TIMER_CURSORMOVEUPDATE);
-			KillTimer(hWnd, TIMER_WHEELRELEASE);
 			// Main window is gone, this tells the message loop to exit.
 			PostQuitMessage(0);
 			return 0;

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1300,8 +1300,6 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_mouseWheelEvent(
 	// so we release it with a slight delay.
 	key.flags = KEY_DOWN | KEY_HASWHEELDELTA | (wheelDelta << 16);
 	NativeKey(key);
-	key.flags = KEY_UP;
-	NativeKey(key);
 	return true;
 }
 


### PR DESCRIPTION
We had platform-specific code for this, but it can simply be implemented directly in NativeApp.cpp, so let's do that.

This sets the delay to 0.1s, which should be alright to replace #18565 .

If you scroll the wheel quickly, events are not limited to 0.1s spacing, instead a KEY_UP will be sent just before the new KEY_DOWN.

This is good when mapping the mouse wheel to PSP buttons, they'll work better.