### PR TITLE
Defer frame waits if possible

### DIFF
--- a/Core/FrameTiming.cpp
+++ b/Core/FrameTiming.cpp
@@ -39,7 +39,9 @@ void WaitUntil(double now, double timestamp) {
 	}
 #else
 	const double left = timestamp - now;
-	usleep((long)(left * 1000000));
+	if (left > 0.0) {
+		usleep((long)(left * 1000000));
+	}
 #endif
 }
 

--- a/Core/FrameTiming.cpp
+++ b/Core/FrameTiming.cpp
@@ -32,6 +32,17 @@
 
 FrameTiming g_frameTiming;
 
+void WaitUntil(double now, double timestamp) {
+#ifdef _WIN32
+	while (time_now_d() < timestamp) {
+		sleep_ms(1); // Sleep for 1ms on this thread
+	}
+#else
+	const double left = timestamp - now;
+	usleep((long)(left * 1000000));
+#endif
+}
+
 inline Draw::PresentMode GetBestImmediateMode(Draw::PresentMode supportedModes) {
 	if (supportedModes & Draw::PresentMode::MAILBOX) {
 		return Draw::PresentMode::MAILBOX;
@@ -47,6 +58,22 @@ void FrameTiming::Reset(Draw::DrawContext *draw) {
 	} else {
 		presentMode = GetBestImmediateMode(draw->GetDeviceCaps().presentModesSupported);
 		presentInterval = 0;
+	}
+}
+
+void FrameTiming::DeferWaitUntil(double until, double *curTimePtr) {
+	_dbg_assert_(until > 0.0);
+	waitUntil_ = until;
+	curTimePtr_ = curTimePtr;
+}
+
+void FrameTiming::PostSubmit() {
+	if (waitUntil_ != 0.0) {
+		WaitUntil(time_now_d(), waitUntil_);
+		if (curTimePtr_) {
+			*curTimePtr_ = waitUntil_;
+		}
+		waitUntil_ = 0.0;
 	}
 }
 

--- a/Core/FrameTiming.h
+++ b/Core/FrameTiming.h
@@ -8,14 +8,23 @@ namespace Draw {
 class DrawContext;
 }
 
-struct FrameTiming {
+class FrameTiming {
+public:
+	void DeferWaitUntil(double until, double *curTimePtr);
+	void PostSubmit();
+	void Reset(Draw::DrawContext *draw);
+
 	// Some backends won't allow changing this willy nilly.
 	Draw::PresentMode presentMode;
 	int presentInterval;
 
-	void Reset(Draw::DrawContext *draw);
+private:
+	double waitUntil_;
+	double *curTimePtr_;
 };
 
 extern FrameTiming g_frameTiming;
 
 Draw::PresentMode ComputePresentMode(Draw::DrawContext *draw, int *interval);
+
+void WaitUntil(double now, double timestamp);

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -645,8 +645,9 @@ void __DisplayFlip(int cyclesLate) {
 
 	if (fbReallyDirty || noRecentFlip || postEffectRequiresFlip) {
 		// Check first though, might've just quit / been paused.
-		nextFrame = Core_NextFrame();
-		if (!forceNoFlip && nextFrame) {
+		if (!forceNoFlip)
+			nextFrame = Core_NextFrame();
+		if (nextFrame) {
 			gpu->CopyDisplayToOutput(fbReallyDirty);
 			if (fbReallyDirty) {
 				DisplayFireActualFlip();

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -440,15 +440,7 @@ static void DoFrameTiming(bool throttle, bool *skipFrame, float scaledTimestep, 
 			// Wait until we've caught up.
 			// TODO: This is the wait we actually move to after the frame.
 			// But watch out, curFrameTime below must be updated correctly - I think.
-
-			while (time_now_d() < nextFrameTime) {
-#ifdef _WIN32
-				sleep_ms(1); // Sleep for 1ms on this thread
-#else
-				const double left = nextFrameTime - curFrameTime;
-				usleep((long)(left * 1000000));
-#endif
-			}
+			WaitUntil(curFrameTime, nextFrameTime);
 		}
 		curFrameTime = time_now_d();
 	}

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1117,6 +1117,7 @@ void NativeFrame(GraphicsContext *graphicsContext) {
 
 	// This, between EndFrame and Present, is where we should actually wait to do present time management.
 	// There might not be a meaningful distinction here for all backends..
+	g_frameTiming.PostSubmit();
 
 	if (renderCounter < 10 && ++renderCounter == 10) {
 		// We're rendering fine, clear out failure info.


### PR DESCRIPTION
To regulate speed, we insert waits into each frame. Previously, we waited right at the time we hit a vsync and stopped emulating, then continued to the submit phase of the frame, but with this, we submit the accumulated drawing commands to the GPU first, and then wait. 

While due to the frame overlap we already have this won't result in a lot of extra performance, it should help latency slightly, especially if the driver is smart or if we add some of the other stuff from #17917 later.


EDIT: For some reason, this seems to have issues on Android. So, draft for now.

EDIT2: With the last commit, it now only has problems when you enable frameskipping fast-forward, and that's not Android-specific..

EDIT3: Fixed the logic, oops.