### PR TITLE
Continue general code refactor for all project

### DIFF
--- a/Common/Data/Encoding/Compression.cpp
+++ b/Common/Data/Encoding/Compression.cpp
@@ -53,7 +53,7 @@ bool compress_string(const std::string& str, std::string *dest, int compressionl
 		return false;
 	}
 
-	*dest = outstring;
+	*dest = std::move(outstring);
 	return true;
 }
 
@@ -99,6 +99,6 @@ bool decompress_string(const std::string& str, std::string *dest) {
 		return false;
 	}
 
-	*dest = outstring;
+	*dest = std::move(outstring);
 	return true;
 }

--- a/Common/Data/Text/I18n.cpp
+++ b/Common/Data/Text/I18n.cpp
@@ -89,7 +89,7 @@ const char *I18NCategory::T(const char *key, const char *def) {
 		if (def)
 			missedKeyLog_[key] = def;
 		else
-			missedKeyLog_[key] = modifiedKey;
+			missedKeyLog_[key] = std::move(modifiedKey);
 		return def ? def : key;
 	}
 }

--- a/Common/File/VFS/ZipFileReader.cpp
+++ b/Common/File/VFS/ZipFileReader.cpp
@@ -125,7 +125,6 @@ bool ZipFileReader::GetFileListing(const char *orig_path, std::vector<File::File
 	}
 
 	for (auto fiter = files.begin(); fiter != files.end(); ++fiter) {
-		std::string fpath = path;
 		File::FileInfo info;
 		info.name = *fiter;
 		std::string relativePath = std::string(path).substr(inZipPath_.size());

--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -919,7 +919,6 @@ bool D3D11Texture::Create(ID3D11DeviceContext *context, ID3D11Device *device, co
 
 	D3D11_SUBRESOURCE_DATA *initDataParam = nullptr;
 	D3D11_SUBRESOURCE_DATA initData[12]{};
-	std::vector<uint8_t> initDataBuffer[12];
 	if (desc.initData.size() && !generateMips && !desc.initDataCallback) {
 		int w = desc.width;
 		int h = desc.height;

--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -1161,7 +1161,7 @@ Pipeline *D3D11DrawContext::CreateGraphicsPipeline(const PipelineDesc &desc, con
 			break;
 		}
 	}
-	dPipeline->shaderModules = shaders;
+	dPipeline->shaderModules = std::move(shaders);
 
 	if (!vshader) {
 		// No vertex shader - no graphics

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -348,7 +348,7 @@ void GLQueueRunner::RunInitSteps(const FastVec<GLRInitStep> &steps, bool skipGLC
 				OutputDebugStringUTF8(infoLog.c_str());
 #endif
 				step.create_shader.shader->failed = true;
-				step.create_shader.shader->error = infoLog;  // Hm, we never use this.
+				step.create_shader.shader->error = std::move(infoLog);  // Hm, we never use this.
 			}
 			// Before we throw away the code, attach it to the shader for debugging.
 			step.create_shader.shader->code = code;

--- a/Common/GPU/OpenGL/GLRenderManager.h
+++ b/Common/GPU/OpenGL/GLRenderManager.h
@@ -309,7 +309,7 @@ public:
 		step.create_program.program = new GLRProgram();
 		step.create_program.program->semantics_ = semantics;
 		step.create_program.program->queries_ = queries;
-		step.create_program.program->initialize_ = initializers;
+		step.create_program.program->initialize_ = std::move(initializers);
 		step.create_program.program->locData_ = locData;
 		step.create_program.program->use_clip_distance[0] = flags.useClipDistance0;
 		step.create_program.program->use_clip_distance[1] = flags.useClipDistance1;

--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -586,7 +586,7 @@ void HTTPRequest::Do() {
 			// Perform the next GET.
 			if (resultCode_ == 0)
 				INFO_LOG(HTTP, "Download of %s redirected to %s", downloadURL.c_str(), redirectURL.c_str());
-			downloadURL = redirectURL;
+			downloadURL = std::move(redirectURL);
 			continue;
 		}
 

--- a/Common/Render/Text/draw_text_win.cpp
+++ b/Common/Render/Text/draw_text_win.cpp
@@ -105,7 +105,7 @@ uint32_t TextDrawerWin32::SetFont(const char *fontName, int size, int flags) {
 	TextDrawerFontContext *font = new TextDrawerFontContext();
 	font->bold = FW_LIGHT;
 	font->height = size;
-	font->fname = fname;
+	font->fname = std::move(fname);
 	font->dpiScale = dpiScale_;
 	font->Create();
 

--- a/Common/UI/IconCache.cpp
+++ b/Common/UI/IconCache.cpp
@@ -101,7 +101,7 @@ bool IconCache::LoadFromFile(FILE *file) {
 		}
 
 		Entry entry{};
-		entry.data = data;
+		entry.data = std::move(data);
 		entry.format = entryHeader.format;
 		entry.insertedTimeStamp = entryHeader.insertedTimestamp;
 		entry.usedTimeStamp = now;

--- a/Common/UI/Screen.h
+++ b/Common/UI/Screen.h
@@ -200,6 +200,4 @@ private:
 	// Used for options, in-game menus and other things you expect to be able to back out from onto something.
 	std::vector<Layer> stack_;
 	std::vector<Layer> nextStack_;
-
-	std::unordered_map<int64_t, int> lastAxis_;
 };

--- a/Common/UI/ScrollView.cpp
+++ b/Common/UI/ScrollView.cpp
@@ -335,7 +335,7 @@ void ScrollView::PersistData(PersistStatus status, std::string anonId, PersistMa
 
 	std::string tag = Tag();
 	if (tag.empty()) {
-		tag = anonId;
+		tag = std::move(anonId);
 	}
 
 	PersistBuffer &buffer = storage["ScrollView::" + tag];

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -146,7 +146,7 @@ void View::PersistData(PersistStatus status, std::string anonId, PersistMap &sto
 	// Remember if this view was a focused view.
 	std::string tag = Tag();
 	if (tag.empty()) {
-		tag = anonId;
+		tag = std::move(anonId);
 	}
 
 	const std::string focusedKey = "ViewFocused::" + tag;

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -76,7 +76,7 @@ void ViewGroup::Clear() {
 void ViewGroup::PersistData(PersistStatus status, std::string anonId, PersistMap &storage) {
 	std::string tag = Tag();
 	if (tag.empty()) {
-		tag = anonId;
+		tag = std::move(anonId);
 	}
 
 	for (size_t i = 0; i < views_.size(); i++) {
@@ -1046,7 +1046,7 @@ void TabHolder::PersistData(PersistStatus status, std::string anonId, PersistMap
 
 	std::string tag = Tag();
 	if (tag.empty()) {
-		tag = anonId;
+		tag = std::move(anonId);
 	}
 
 	PersistBuffer &buffer = storage["TabHolder::" + tag];

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -412,7 +412,7 @@ void Core_MemoryException(u32 address, u32 accessSize, u32 pc, MemoryExceptionTy
 		e.memory_type = type;
 		e.address = address;
 		e.accessSize = accessSize;
-		e.stackTrace = stackTrace;
+		e.stackTrace = std::move(stackTrace);
 		e.pc = pc;
 		Core_EnableStepping(true, "memory.exception", address);
 	}
@@ -440,7 +440,7 @@ void Core_MemoryExceptionInfo(u32 address, u32 accessSize, u32 pc, MemoryExcepti
 		e.memory_type = type;
 		e.address = address;
 		e.accessSize = accessSize;
-		e.stackTrace = stackTrace;
+		e.stackTrace = std::move(stackTrace);
 		e.pc = pc;
 		Core_EnableStepping(true, "memory.exception", address);
 	}

--- a/Core/Debugger/WebSocket/GameSubscriber.cpp
+++ b/Core/Debugger/WebSocket/GameSubscriber.cpp
@@ -104,8 +104,8 @@ void WebSocketVersion(DebuggerRequest &req) {
 	if (!req.ParamString("name", &name, DebuggerParamType::OPTIONAL_LOOSE))
 		return;
 
-	req.client->version = version;
-	req.client->name = name;
+	req.client->version = std::move(version);
+	req.client->name = std::move(name);
 
 	json.writeString("name", "PPSSPP");
 	json.writeString("version", PPSSPP_GIT_VERSION);

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -591,7 +591,7 @@ int DirectoryFileSystem::OpenFile(std::string filename, FileAccess access, const
 
 		u32 newHandle = hAlloc->GetNewHandle();
 
-		entry.guestFilename = filename;
+		entry.guestFilename = std::move(filename);
 		entry.access = (FileAccess)(access & FILEACCESS_PSP_FLAGS);
 
 		entries[newHandle] = entry;

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -279,7 +279,7 @@ void MetaFileSystem::Mount(const std::string &prefix, std::shared_ptr<IFileSyste
 
 	MountPoint x;
 	x.prefix = prefix;
-	x.system = system;
+	x.system = std::move(system);
 	for (auto &it : fileSystems) {
 		if (it.prefix == prefix) {
 			// Overwrite the old mount. Don't create a new one.
@@ -310,7 +310,7 @@ bool MetaFileSystem::Remount(const std::string &prefix, std::shared_ptr<IFileSys
 	std::lock_guard<std::recursive_mutex> guard(lock);
 	for (auto &it : fileSystems) {
 		if (it.prefix == prefix) {
-			it.system = system;
+			it.system = std::move(system);
 			return true;
 		}
 	}

--- a/Core/FileSystems/VirtualDiscFileSystem.cpp
+++ b/Core/FileSystems/VirtualDiscFileSystem.cpp
@@ -293,7 +293,7 @@ int VirtualDiscFileSystem::getFileListIndex(std::string &fileName)
 		return -1;
 
 	FileListEntry entry = {""};
-	entry.fileName = normalized;
+	entry.fileName = std::move(normalized);
 	entry.totalSize = File::GetFileSize(fullName);
 	entry.firstBlock = currentBlockIndex;
 	currentBlockIndex += (entry.totalSize+2047)/2048;

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2419,7 +2419,7 @@ static u32 sceIoDopen(const char *path) {
 	DirListing *dir = new DirListing();
 	SceUID id = kernelObjects.Create(dir);
 
-	dir->listing = listing;
+	dir->listing = std::move(listing);
 	dir->index = 0;
 	dir->name = std::string(path);
 
@@ -2465,7 +2465,7 @@ static u32 sceIoDopen(const char *path) {
 			}
 		}
 
-		dir->listing = filtered;
+		dir->listing = std::move(filtered);
 	}
 	
 	// TODO: The result is delayed only from the memstick, it seems.

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1964,7 +1964,7 @@ int sceKernelLoadExec(const char *filename, u32 paramPtr)
 
 		PSPFileInfo eboot_info = pspFileSystem.GetFileInfo(eboot_filename);
 		if (eboot_info.exists) {
-			exec_filename = eboot_filename;
+			exec_filename = std::move(eboot_filename);
 			info = eboot_info;
 		}
 	}

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -1371,6 +1371,7 @@ skip:
 
 	void LoadBuiltinHashMap() {
 		HashMapFunc mf;
+		hashMap.reserve(ARRAY_SIZE(hardcodedHashes));
 		for (size_t i = 0; i < ARRAY_SIZE(hardcodedHashes); i++) {
 			mf.hash = hardcodedHashes[i].hash;
 			mf.size = hardcodedHashes[i].funcSize;

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -593,7 +593,6 @@ bool PSP_Reboot(std::string *error_string) {
 	Core_Stop();
 	Core_WaitInactive();
 	PSP_Shutdown();
-	std::string resetError;
 	return PSP_Init(PSP_CoreParameter(), error_string);
 }
 

--- a/Core/TiltEventProcessor.cpp
+++ b/Core/TiltEventProcessor.cpp
@@ -224,8 +224,6 @@ void GenerateAnalogStickEvent(float tiltX, float tiltY) {
 }
 
 void GenerateDPadEvent(int digitalX, int digitalY) {
-	static const int dir[4] = { CTRL_RIGHT, CTRL_DOWN, CTRL_LEFT, CTRL_UP };
-
 	if (digitalX == 0) {
 		__CtrlUpdateButtons(0, tiltButtonsDown & (CTRL_RIGHT | CTRL_LEFT));
 		tiltButtonsDown &= ~(CTRL_LEFT | CTRL_RIGHT);
@@ -252,8 +250,6 @@ void GenerateDPadEvent(int digitalX, int digitalY) {
 }
 
 void GenerateActionButtonEvent(int digitalX, int digitalY) {
-	static const int buttons[4] = { CTRL_CIRCLE, CTRL_CROSS, CTRL_SQUARE, CTRL_TRIANGLE };
-
 	if (digitalX == 0) {
 		__CtrlUpdateButtons(0, tiltButtonsDown & (CTRL_SQUARE | CTRL_CIRCLE));
 		tiltButtonsDown &= ~(CTRL_SQUARE | CTRL_CIRCLE);

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -405,7 +405,7 @@ bool GameManager::DetectTexturePackDest(struct zip *z, int iniIndex, Path &dest)
 		for (const std::string &path : g_Config.RecentIsos()) {
 			std::string recentID = GetGameID(Path(path));
 			if (games.find(recentID) != games.end()) {
-				gameID = recentID;
+				gameID = std::move(recentID);
 				break;
 			}
 		}

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -190,8 +190,6 @@ bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLangu
 	}
 
 	// Currently only used by Vulkan.
-	std::vector<SamplerDef> samplers;
-
 	if (compat.shaderLanguage == ShaderLanguage::GLSL_VULKAN) {
 		if (useDiscardStencilBugWorkaround && !gstate_c.Use(GPU_ROUND_FRAGMENT_DEPTH_TO_16BIT)) {
 			WRITE(p, "layout (depth_unchanged) out float gl_FragDepth;\n");

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -328,7 +328,7 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverri
 				c = '/';
 			}
 		}
-		aliases_[pair.first] = alias;
+		aliases_[pair.first] = std::move(alias);
 	}
 
 	if (badFileNameCount > 0) {

--- a/GPU/D3D11/D3D11Util.cpp
+++ b/GPU/D3D11/D3D11Util.cpp
@@ -56,7 +56,7 @@ ID3D11VertexShader *CreateVertexShaderD3D11(ID3D11Device *device, const char *co
 	ID3D11VertexShader *vs;
 	device->CreateVertexShader(byteCode.data(), byteCode.size(), nullptr, &vs);
 	if (byteCodeOut)
-		*byteCodeOut = byteCode;
+		*byteCodeOut = std::move(byteCode);
 	return vs;
 }
 

--- a/GPU/GLES/GPU_GLES.cpp
+++ b/GPU/GLES/GPU_GLES.cpp
@@ -218,7 +218,7 @@ void GPU_GLES::BuildReportingInfo() {
 
 	char temp[16384];
 	snprintf(temp, sizeof(temp), "%s (%s %s), %s (extensions: %s)", glVersion.c_str(), glVendor.c_str(), glRenderer.c_str(), glSlVersion.c_str(), glExtensions.c_str());
-	reportingPrimaryInfo_ = glVendor;
+	reportingPrimaryInfo_ = std::move(glVendor);
 	reportingFullInfo_ = temp;
 
 	Reporting::UpdateConfig();

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -59,7 +59,7 @@ void CwCheatScreen::LoadCheatInfo() {
 	}
 
 	if (!engine_ || gameID != gameID_) {
-		gameID_ = gameID;
+		gameID_ = std::move(gameID);
 		delete engine_;
 		engine_ = new CWCheatEngine(gameID_);
 		engine_->CreateCheatFile();

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -257,7 +257,7 @@ void EmuScreen::bootGame(const Path &filename) {
 		if (!bootPending_) {
 			invalid_ = !PSP_IsInited();
 			if (invalid_) {
-				errorMessage_ = error_string;
+				errorMessage_ = std::move(error_string);
 				ERROR_LOG(BOOT, "isIniting bootGame error: %s", errorMessage_.c_str());
 				return;
 			}
@@ -338,7 +338,7 @@ void EmuScreen::bootGame(const Path &filename) {
 	if (!PSP_InitStart(coreParam, &error_string)) {
 		bootPending_ = false;
 		invalid_ = true;
-		errorMessage_ = error_string;
+		errorMessage_ = std::move(error_string);
 		ERROR_LOG(BOOT, "InitStart bootGame error: %s", errorMessage_.c_str());
 	}
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -2236,7 +2236,7 @@ bool HostnameSelectScreen::CanComplete(DialogResult result) {
 	}
 
 	resolverState_ = ResolverState::QUEUED;
-	toResolve_ = value;
+	toResolve_ = std::move(value);
 	resolverCond_.notify_one();
 
 	progressView_->SetText(n->T("Validating address..."));

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -155,7 +155,6 @@ public:
 	}
 
 	bool Key(const KeyInput &key) override {
-		std::vector<int> pspKeys;
 		bool showInfo = false;
 
 		if (HasFocus() && UI::IsInfoKey(key)) {

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -652,7 +652,7 @@ void NewLanguageScreen::OnCompleted(DialogResult result) {
 	if (code.empty())
 		return;
 
-	g_Config.sLanguageIni = code;
+	g_Config.sLanguageIni = std::move(code);
 
 	bool iniLoadedSuccessfully = false;
 	// Allow the lang directory to be overridden for testing purposes (e.g. Android, where it's hard to
@@ -669,7 +669,7 @@ void NewLanguageScreen::OnCompleted(DialogResult result) {
 		RecreateViews();
 	} else {
 		// Failed to load the language ini. Shouldn't really happen, but let's just switch back to the old language.
-		g_Config.sLanguageIni = oldLang;
+		g_Config.sLanguageIni = std::move(oldLang);
 	}
 }
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -307,7 +307,7 @@ static void CheckFailedGPUBackends() {
 	if (System_GetPropertyBool(SYSPROP_SUPPORTS_PERMISSIONS)) {
 		std::string data;
 		if (File::ReadFileToString(true, cache, data))
-			g_Config.sFailedGPUBackends = data;
+			g_Config.sFailedGPUBackends = std::move(data);
 	}
 
 	// Use this if you want to debug a graphics crash...

--- a/UI/OnScreenDisplay.cpp
+++ b/UI/OnScreenDisplay.cpp
@@ -472,7 +472,7 @@ void OnScreenMessagesView::Draw(UIContext &dc) {
 	}
 
 	std::lock_guard<std::mutex> lock(clickMutex_);
-	clickZones_ = dismissZones;
+	clickZones_ = std::move(dismissZones);
 }
 
 std::string OnScreenMessagesView::DescribeText() const {

--- a/UI/Theme.cpp
+++ b/UI/Theme.cpp
@@ -139,7 +139,7 @@ static void LoadThemeInfo(const std::vector<Path> &directories) {
 
 					File::FileInfo tmpInfo;
 					if (g_VFS.GetFileInfo((tmpPath + ".meta").c_str(), &tmpInfo) && g_VFS.GetFileInfo((tmpPath + ".zim").c_str(), &tmpInfo)) {
-						info.sUIAtlas = tmpPath;
+						info.sUIAtlas = std::move(tmpPath);
 					}
 				}
 

--- a/android/jni/TestRunner.cpp
+++ b/android/jni/TestRunner.cpp
@@ -180,6 +180,6 @@ bool RunTests() {
 	PSP_CoreParameter().headLess = false;
 	PSP_CoreParameter().graphicsContext = tempCtx;
 
-	g_Config.sReportHost = savedReportHost;
+	g_Config.sReportHost = std::move(savedReportHost);
 	return true;  // Managed to execute the tests. Says nothing about the result.
 }


### PR DESCRIPTION
@hrydgard I know that it is inconvenient for most to use std::move, std::swap, std::copy because developer should know that after std::move, variable value does not exist. So decide whether to use move semantics everywhere or only in critical performance places.