### PR TITLE
DescribePtr: Individually describe vertex decoders

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -1036,3 +1036,33 @@ void TessellationDataTransfer::CopyControlPoints(float *pos, float *tex, float *
 		}
 	}
 }
+
+bool DrawEngineCommon::DescribeCodePtr(const u8 *ptr, std::string &name) const {
+	if (!decJitCache_ || !decJitCache_->IsInSpace(ptr)) {
+		return false;
+	}
+
+	// Loop through all the decoders and see if we have a match.
+	VertexDecoder *found = nullptr;
+	u32 foundKey;
+
+	decoderMap_.Iterate([&](u32 key, VertexDecoder *value) {
+		if (!found) {
+			if (value->IsInSpace(ptr)) {
+				foundKey = key;
+				found = value;
+			}
+		}
+	});
+
+	if (found) {
+		char temp[256];
+		found->ToString(temp, false);
+		name = temp;
+		snprintf(temp, sizeof(temp), "_%08X", foundKey);
+		name += temp;
+		return true;
+	} else {
+		return false;
+	}
+}

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -138,11 +138,7 @@ public:
 		everUsedExactEqualDepth_ = v;
 	}
 
-	bool IsCodePtrVertexDecoder(const u8 *ptr) const {
-		if (decJitCache_)
-			return decJitCache_->IsInSpace(ptr);
-		return false;
-	}
+	bool DescribeCodePtr(const u8 *ptr, std::string &name) const;
 	int GetNumDrawCalls() const {
 		return numDrawVerts_;
 	}

--- a/GPU/Common/VertexDecoderArm.cpp
+++ b/GPU/Common/VertexDecoderArm.cpp
@@ -257,7 +257,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 			// Reset the code ptr and return zero to indicate that we failed.
 			ResetCodePtr(GetOffset(start));
 			char temp[1024] = {0};
-			dec.ToString(temp);
+			dec.ToString(temp, true);
 			INFO_LOG(G3D, "Could not compile vertex decoder: %s", temp);
 			return 0;
 		}
@@ -285,7 +285,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 	/*
 	DisassembleArm(start, GetCodePtr() - start);
 	char temp[1024] = {0};
-	dec.ToString(temp);
+	dec.ToString(temp, true);
 	INFO_LOG(G3D, "%s", temp);
 	*/
 

--- a/GPU/Common/VertexDecoderArm64.cpp
+++ b/GPU/Common/VertexDecoderArm64.cpp
@@ -253,7 +253,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 			// Reset the code ptr (effectively undoing what we generated) and return zero to indicate that we failed.
 			ResetCodePtr(GetOffset(start));
 			char temp[1024] = {0};
-			dec.ToString(temp);
+			dec.ToString(temp, true);
 			ERROR_LOG(G3D, "Could not compile vertex decoder, failed at step %d: %s", i, temp);
 			return nullptr;
 		}
@@ -288,7 +288,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 
 	if (log) {
 		char temp[1024] = { 0 };
-		dec.ToString(temp);
+		dec.ToString(temp, true);
 		INFO_LOG(JIT, "=== %s (%d bytes) ===", temp, (int)(GetCodePtr() - start));
 		std::vector<std::string> lines = DisassembleArm64(start, (int)(GetCodePtr() - start));
 		for (auto line : lines) {

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -1276,7 +1276,7 @@ void VertexDecoder::SetVertexType(u32 fmt, const VertexDecoderOptions &options, 
 
 	if (reportNoPos) {
 		char temp[256]{};
-		ToString(temp);
+		ToString(temp, true);
 		ERROR_LOG_REPORT(G3D, "Vertices without position found: (%08x) %s", fmt_, temp);
 	}
 
@@ -1402,7 +1402,7 @@ void VertexDecoder::CompareToJit(const u8 *startPtr, u8 *decodedptr, int count, 
 		jittedReader.Goto(i);
 		if (!DecodedVertsAreSimilar(controlReader, jittedReader)) {
 			char name[512]{};
-			ToString(name);
+			ToString(name, true);
 			ERROR_LOG(G3D, "Encountered vertexjit mismatch at %d/%d for %s", i, count, name);
 			if (morphcount > 1) {
 				printf("Morph:\n");
@@ -1456,8 +1456,9 @@ static const char *idxnames[4] = { "-", "u8", "u16", "?" };
 static const char *weightnames[4] = { "-", "u8", "u16", "f" };
 static const char *colnames[8] = { "", "?", "?", "?", "565", "5551", "4444", "8888" };
 
-int VertexDecoder::ToString(char *output) const {
-	char * start = output;
+int VertexDecoder::ToString(char *output, bool spaces) const {
+	char *start = output;
+	
 	output += sprintf(output, "P: %s ", posnames[pos]);
 	if (nrm)
 		output += sprintf(output, "N: %s ", nrmnames[nrm]);
@@ -1474,7 +1475,16 @@ int VertexDecoder::ToString(char *output) const {
 	if (throughmode)
 		output += sprintf(output, " (through)");
 
-	output += sprintf(output, " (size: %i)", VertexSize());
+	output += sprintf(output, " (%ib)", VertexSize());
+
+	if (!spaces) {
+		size_t len = strlen(start);
+		for (int i = 0; i < len; i++) {
+			if (start[i] == ' ')
+				start[i] = '_';
+		}
+	}
+
 	return output - start;
 }
 
@@ -1482,7 +1492,7 @@ std::string VertexDecoder::GetString(DebugShaderStringType stringType) {
 	char buffer[256];
 	switch (stringType) {
 	case SHADER_STRING_SHORT_DESC:
-		ToString(buffer);
+		ToString(buffer, true);
 		return std::string(buffer);
 	case SHADER_STRING_SOURCE_CODE:
 		{

--- a/GPU/Common/VertexDecoderCommon.h
+++ b/GPU/Common/VertexDecoderCommon.h
@@ -431,7 +431,11 @@ public:
 	// output must be big for safety.
 	// Returns number of chars written.
 	// Ugly for speed.
-	int ToString(char *output) const;
+	int ToString(char *output, bool spaces) const;
+
+	bool IsInSpace(const uint8_t *ptr) const {
+		return ptr >= (const uint8_t *)jitted_ && ptr < ((const uint8_t *)jitted_ + jittedSize_);
+	}
 
 	// Mutable decoder state
 	mutable u8 *decoded_ = nullptr;
@@ -507,6 +511,7 @@ public:
 
 	// Returns a pointer to the code to run.
 	JittedVertexDecoder Compile(const VertexDecoder &dec, int32_t *jittedSize);
+	bool DescribeCodePtr(const u8 *ptr, std::string &name) const;
 	void Clear();
 
 	void Jit_WeightsU8();

--- a/GPU/Common/VertexDecoderRiscV.cpp
+++ b/GPU/Common/VertexDecoderRiscV.cpp
@@ -318,7 +318,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 			// Reset the code ptr (effectively undoing what we generated) and return zero to indicate that we failed.
 			ResetCodePtr(GetOffset(start));
 			char temp[1024]{};
-			dec.ToString(temp);
+			dec.ToString(temp, true);
 			ERROR_LOG(G3D, "Could not compile vertex decoder, failed at step %d: %s", i, temp);
 			return nullptr;
 		}
@@ -351,7 +351,7 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 
 	if (log) {
 		char temp[1024]{};
-		dec.ToString(temp);
+		dec.ToString(temp, true);
 		INFO_LOG(JIT, "=== %s (%d bytes) ===", temp, (int)(GetCodePtr() - start));
 		std::vector<std::string> lines = DisassembleRV64(start, (int)(GetCodePtr() - start));
 		for (auto line : lines) {

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1938,11 +1938,9 @@ bool GPUCommon::GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> 
 }
 
 bool GPUCommon::DescribeCodePtr(const u8 *ptr, std::string &name) {
-	if (drawEngineCommon_->IsCodePtrVertexDecoder(ptr)) {
-		name = "VertexDecoderJit";
-		return true;
-	}
-	return false;
+	// The only part of GPU emulation (other than software) that jits is the vertex decoder, currently,
+	// which is owned by the drawengine.
+	return drawEngineCommon_->DescribeCodePtr(ptr, name);
 }
 
 void GPUCommon::UpdateUVScaleOffset() {


### PR DESCRIPTION
This is used when profiling PPSSPP using [[Unknown]'s modified version of VerySleepy](https://github.com/unknownbrackets/verysleepy/tree/jit-support), that knows how to request symbols for jitted memory from PPSSPP.

With this, we can see which individual vertex decoder takes the most time. In GTA, for example, it's by far (GE_VTYPE_TC_8BIT | GE_VTYPE_COL_5551 | GE_VTYPE_POS_16BIT).

Also throws in a very small optimization for video playback.