### PR TITLE
Optimize fbo_bind_fb_target and fbo_get_fb_target using constexpr template value C++17

### DIFF
--- a/Common/GPU/OpenGL/GLQueueRunner.h
+++ b/Common/GPU/OpenGL/GLQueueRunner.h
@@ -386,8 +386,10 @@ private:
 	void PerformReadbackImage(const GLRStep &pass);
 
 	void fbo_ext_create(const GLRInitStep &step);
-	void fbo_bind_fb_target(bool read, GLuint name);
-	GLenum fbo_get_fb_target(bool read, GLuint **cached);
+	template <bool read>
+	void fbo_bind_fb_target(GLuint name);
+	template <bool read>
+	GLenum fbo_get_fb_target(GLuint **cached);
 	void fbo_unbind();
 
 	std::string StepToString(const GLRStep &step) const;


### PR DESCRIPTION
@hrydgard,
I'm not sure of course, but maybe you're interested in rewriting some parameters of functions to create guaranteed C++17 metafunctions that are more optimized due to constant conditions and variables.
I doubt that the functions I fixed have a big impact on performance, but this is a step towards using such a method for functions that are frequently called.

More info here: https://stackoverflow.com/a/57211067
My tests on godbolt here: https://godbolt.org/z/4qq9n38Tz