### PR TITLE
DrawEngine: Avoid decoding indices when we don't need them.

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -816,6 +816,10 @@ int DrawEngineCommon::ExtendNonIndexedPrim(const uint32_t *cmd, const uint32_t *
 	_dbg_assert_(numDrawInds_ <= MAX_DEFERRED_DRAW_INDS);  // if it's equal, the check below will take care of it before any action is taken.
 	_dbg_assert_(numDrawVerts_ > 0);
 
+	if (!clockwise) {
+		anyCCWOrIndexed_ = true;
+	}
+	int seenPrims = 0;
 	while (cmd != stall) {
 		uint32_t data = *cmd;
 		if ((data & 0xFFF80000) != 0x04000000) {
@@ -831,6 +835,7 @@ int DrawEngineCommon::ExtendNonIndexedPrim(const uint32_t *cmd, const uint32_t *
 		DeferredInds &di = drawInds_[numDrawInds_++];
 		di.indexType = 0;
 		di.prim = newPrim;
+		seenPrims |= (1 << newPrim);
 		di.clockwise = clockwise;
 		di.vertexCount = vertexCount;
 		di.vertDecodeIndex = prevDrawVerts;
@@ -838,6 +843,10 @@ int DrawEngineCommon::ExtendNonIndexedPrim(const uint32_t *cmd, const uint32_t *
 		offset += vertexCount;
 		cmd++;
 	}
+
+	seenPrims_ |= seenPrims;
+
+	_dbg_assert_(cmd != start);
 
 	int totalCount = offset - dv.vertexCount;
 	dv.vertexCount = offset;
@@ -910,9 +919,16 @@ bool DrawEngineCommon::SubmitPrim(const void *verts, const void *inds, GEPrimiti
 
 	DeferredInds &di = drawInds_[numDrawInds_++];
 	di.inds = inds;
-	di.indexType = (vertTypeID & GE_VTYPE_IDX_MASK) >> GE_VTYPE_IDX_SHIFT;
+	int indexType = (vertTypeID & GE_VTYPE_IDX_MASK) >> GE_VTYPE_IDX_SHIFT;
+	if (indexType) {
+		anyCCWOrIndexed_ = true;
+	}
+	di.indexType = indexType;
 	di.prim = prim;
 	di.clockwise = clockwise;
+	if (!clockwise) {
+		anyCCWOrIndexed_ = true;
+	}
 	di.vertexCount = vertexCount;
 	di.vertDecodeIndex = numDrawVerts_;
 	di.offset = 0;
@@ -942,6 +958,7 @@ bool DrawEngineCommon::SubmitPrim(const void *verts, const void *inds, GEPrimiti
 	}
 
 	vertexCountInDrawCalls_ += vertexCount;
+	seenPrims_ |= (1 << prim);
 
 	if (prim == GE_PRIM_RECTANGLES && (gstate.getTextureAddress(0) & 0x3FFFFFFF) == (gstate.getFrameBufAddress() & 0x3FFFFFFF)) {
 		// This prevents issues with consecutive self-renders in Ridge Racer.
@@ -952,6 +969,8 @@ bool DrawEngineCommon::SubmitPrim(const void *verts, const void *inds, GEPrimiti
 }
 
 void DrawEngineCommon::DecodeVerts(u8 *dest) {
+	// Note that this should be able to continue a partial decode - we don't necessarily start from zero here (although we do most of the time).
+
 	int i = decodeVertsCounter_;
 	int stride = (int)dec_->GetDecVtxFmt().stride;
 	for (; i < numDrawVerts_; i++) {
@@ -968,7 +987,9 @@ void DrawEngineCommon::DecodeVerts(u8 *dest) {
 	decodeVertsCounter_ = i;
 }
 
-void DrawEngineCommon::DecodeInds() {
+int DrawEngineCommon::DecodeInds() {
+	// Note that this should be able to continue a partial decode - we don't necessarily start from zero here (although we do most of the time).
+
 	int i = decodeIndsCounter_;
 	for (; i < numDrawInds_; i++) {
 		const DeferredInds &di = drawInds_[i];
@@ -994,12 +1015,7 @@ void DrawEngineCommon::DecodeInds() {
 	}
 	decodeIndsCounter_ = i;
 
-	// Sanity check
-	if (indexGen.Prim() < 0) {
-		ERROR_LOG_REPORT(G3D, "DecodeVerts: Failed to deduce prim: %i", indexGen.Prim());
-		// Force to points (0)
-		indexGen.AddPrim(GE_PRIM_POINTS, 0, 0, true);
-	}
+	return indexGen.VertexCount();
 }
 
 bool DrawEngineCommon::CanUseHardwareTransform(int prim) {

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -152,7 +152,7 @@ protected:
 	void UpdatePlanes();
 
 	void DecodeVerts(u8 *dest);
-	void DecodeInds();
+	int DecodeInds();
 
 	// Preprocessing for spline/bezier
 	u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, u32 vertType, int *vertexSize = nullptr);
@@ -202,6 +202,8 @@ protected:
 		vertexCountInDrawCalls_ = 0;
 		decodeIndsCounter_ = 0;
 		decodeVertsCounter_ = 0;
+		seenPrims_ = 0;
+		anyCCWOrIndexed_ = false;
 		gstate_c.vertexFullAlpha = true;
 
 		// Now seems as good a time as any to reset the min/max coords, which we may examine later.
@@ -209,6 +211,34 @@ protected:
 		gstate_c.vertBounds.minV = 512;
 		gstate_c.vertBounds.maxU = 0;
 		gstate_c.vertBounds.maxV = 0;
+	}
+
+	inline bool CollectedPureDraw() const {
+		switch (seenPrims_) {
+		case 1 << GE_PRIM_TRIANGLE_STRIP:
+			return !anyCCWOrIndexed_ && numDrawInds_ == 1;
+		case 1 << GE_PRIM_LINES:
+		case 1 << GE_PRIM_POINTS:
+		case 1 << GE_PRIM_TRIANGLES:
+			return !anyCCWOrIndexed_;
+		default:
+			return false;
+		}
+	}
+
+	inline void DecodeIndsAndGetData(GEPrimitiveType *prim, int *numVerts, int *maxIndex, bool *useElements, bool forceIndexed) {
+		if (!forceIndexed && CollectedPureDraw()) {
+			*prim = drawInds_[0].prim;
+			*numVerts = numDecodedVerts_;
+			*maxIndex = numDecodedVerts_;
+			*useElements = false;
+		} else {
+			int vertexCount = DecodeInds();
+			*numVerts = vertexCount;
+			*maxIndex = numDecodedVerts_;
+			*prim = IndexGenerator::GeneralPrim((GEPrimitiveType)drawInds_[0].prim);
+			*useElements = true;
+		}
 	}
 
 	uint32_t ComputeDrawcallsHash() const;
@@ -227,9 +257,7 @@ protected:
 	u16 *decIndex_ = nullptr;
 
 	// Cached vertex decoders
-	u32 lastVType_ = -1;  // corresponds to dec_.  Could really just pick it out of dec_...
 	DenseHashMap<u32, VertexDecoder *> decoderMap_;
-	VertexDecoder *dec_ = nullptr;
 	VertexDecoderJitCache *decJitCache_ = nullptr;
 	VertexDecoderOptions decOptions_{};
 
@@ -239,10 +267,10 @@ protected:
 	// Defer all vertex decoding to a "Flush" (except when software skinning)
 	struct DeferredVerts {
 		const void *verts;
+		UVScale uvScale;
 		u32 vertexCount;
 		u16 indexLowerBound;
 		u16 indexUpperBound;
-		UVScale uvScale;
 	};
 
 	struct DeferredInds {
@@ -250,7 +278,7 @@ protected:
 		u32 vertexCount;
 		u8 vertDecodeIndex;  // index into the drawVerts_ array to look up the vertexOffset.
 		u8 indexType;
-		s8 prim;
+		GEPrimitiveType prim;
 		bool clockwise;
 		u16 offset;
 	};
@@ -261,12 +289,18 @@ protected:
 	uint32_t drawVertexOffsets_[MAX_DEFERRED_DRAW_VERTS];
 	DeferredInds drawInds_[MAX_DEFERRED_DRAW_INDS];
 
+	VertexDecoder *dec_ = nullptr;
+	u32 lastVType_ = -1;  // corresponds to dec_.  Could really just pick it out of dec_...
 	int numDrawVerts_ = 0;
 	int numDrawInds_ = 0;
 	int vertexCountInDrawCalls_ = 0;
 
 	int decodeVertsCounter_ = 0;
 	int decodeIndsCounter_ = 0;
+
+	int seenPrims_ = 0;
+	bool anyCCWOrIndexed_ = 0;
+	bool anyIndexed_ = 0;
 
 	// Vertex collector state
 	IndexGenerator indexGen;

--- a/GPU/Common/IndexGenerator.h
+++ b/GPU/Common/IndexGenerator.h
@@ -26,32 +26,22 @@ class IndexGenerator {
 public:
 	void Setup(u16 *indexptr);
 	void Reset() {
-		prim_ = GE_PRIM_INVALID;
-		seenPrims_ = 0;
-		pureCount_ = 0;
 		this->inds_ = indsBase_;
 	}
 
-	bool PrimCompatible(int prim1, int prim2) {
+	static bool PrimCompatible(int prim1, int prim2) {
 		if (prim1 == GE_PRIM_INVALID || prim2 == GE_PRIM_KEEP_PREVIOUS)
 			return true;
 		return indexedPrimitiveType[prim1] == indexedPrimitiveType[prim2];
 	}
 
-	bool PrimCompatible(int prim) const {
-		if (prim_ == GE_PRIM_INVALID || prim == GE_PRIM_KEEP_PREVIOUS)
-			return true;
-		return indexedPrimitiveType[prim] == prim_;
-	}
-
-	GEPrimitiveType Prim() const { return prim_; }
-	GEPrimitiveType GeneralPrim() const {
-		switch (prim_) {
+	static GEPrimitiveType GeneralPrim(GEPrimitiveType prim) {
+		switch (prim) {
 		case GE_PRIM_LINE_STRIP: return GE_PRIM_LINES; break;
 		case GE_PRIM_TRIANGLE_STRIP:
 		case GE_PRIM_TRIANGLE_FAN: return GE_PRIM_TRIANGLES; break;
 		default:
-			return prim_;
+			return prim;
 		}
 	}
 
@@ -60,15 +50,8 @@ public:
 	void TranslatePrim(int prim, int numInds, const u16_le *inds, int indexOffset, bool clockwise);
 	void TranslatePrim(int prim, int numInds, const u32_le *inds, int indexOffset, bool clockwise);
 
+	// This is really the number of generated indices, or 3x the number of triangles.
 	int VertexCount() const { return inds_ - indsBase_; }
-	int SeenPrims() const { return seenPrims_; }
-	int PureCount() const { return pureCount_; }
-	bool SeenOnlyPurePrims() const {
-		return seenPrims_ == (1 << GE_PRIM_TRIANGLES) ||
-			seenPrims_ == (1 << GE_PRIM_LINES) ||
-			seenPrims_ == (1 << GE_PRIM_POINTS) ||
-			seenPrims_ == (1 << GE_PRIM_TRIANGLE_STRIP);
-	}
 
 private:
 	// Points (why index these? code simplicity)
@@ -84,34 +67,25 @@ private:
 	void AddRectangles(int numVerts, int indexOffset);
 
 	// These translate already indexed lists
-	template <class ITypeLE, int flag>
+	template <class ITypeLE>
 	void TranslatePoints(int numVerts, const ITypeLE *inds, int indexOffset);
-	template <class ITypeLE, int flag>
+	template <class ITypeLE>
 	void TranslateList(int numVerts, const ITypeLE *inds, int indexOffset, bool clockwise);
-	template <class ITypeLE, int flag>
+	template <class ITypeLE>
 	inline void TranslateLineList(int numVerts, const ITypeLE *inds, int indexOffset);
-	template <class ITypeLE, int flag>
+	template <class ITypeLE>
 	inline void TranslateLineStrip(int numVerts, const ITypeLE *inds, int indexOffset);
 
-	template <class ITypeLE, int flag>
+	template <class ITypeLE>
 	void TranslateStrip(int numVerts, const ITypeLE *inds, int indexOffset, bool clockwise);
-	template <class ITypeLE, int flag>
+	template <class ITypeLE>
 	void TranslateFan(int numVerts, const ITypeLE *inds, int indexOffset, bool clockwise);
 
-	template <class ITypeLE, int flag>
+	template <class ITypeLE>
 	inline void TranslateRectangles(int numVerts, const ITypeLE *inds, int indexOffset);
-
-	enum {
-		SEEN_INDEX8 = 1 << 16,
-		SEEN_INDEX16 = 1 << 17,
-		SEEN_INDEX32 = 1 << 18,
-	};
 
 	u16 *indsBase_;
 	u16 *inds_;
-	int pureCount_;
-	GEPrimitiveType prim_;
-	int seenPrims_;
 
 	static const u8 indexedPrimitiveType[7];
 };

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -286,16 +286,12 @@ void DrawEngineD3D11::DoFlush() {
 		ID3D11Buffer *vb_ = nullptr;
 		ID3D11Buffer *ib_ = nullptr;
 
+		int vertexCount;
+		int maxIndex;
+		bool useElements;
 		DecodeVerts(decoded_);
-		DecodeInds();
-
-		bool useElements = !indexGen.SeenOnlyPurePrims() || prim == GE_PRIM_TRIANGLE_FAN;
-		int vertexCount = indexGen.VertexCount();
+		DecodeIndsAndGetData(&prim, &vertexCount, &maxIndex, &useElements, false);
 		gpuStats.numUncachedVertsDrawn += vertexCount;
-		if (!useElements && indexGen.PureCount()) {
-			vertexCount = indexGen.PureCount();
-		}
-		prim = indexGen.Prim();
 
 		bool hasColor = (lastVType_ & GE_VTYPE_COL_MASK) != GE_VTYPE_COL_NONE;
 		if (gstate.isModeThrough()) {
@@ -336,7 +332,7 @@ void DrawEngineD3D11::DoFlush() {
 			context_->IASetVertexBuffers(0, 1, &buf, &stride, &vOffset);
 			if (useElements) {
 				UINT iOffset;
-				int iSize = 2 * indexGen.VertexCount();
+				int iSize = 2 * vertexCount;
 				uint8_t *iptr = pushInds_->BeginPush(context_, &iOffset, iSize);
 				memcpy(iptr, decIndex_, iSize);
 				pushInds_->EndPush(context_);
@@ -363,7 +359,8 @@ void DrawEngineD3D11::DoFlush() {
 			dec_ = GetVertexDecoder(lastVType_);
 		}
 		DecodeVerts(decoded_);
-		DecodeInds();
+		int vertexCount = DecodeInds();
+
 		bool hasColor = (lastVType_ & GE_VTYPE_COL_MASK) != GE_VTYPE_COL_NONE;
 		if (gstate.isModeThrough()) {
 			gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && (hasColor || gstate.getMaterialAmbientA() == 255);
@@ -371,12 +368,9 @@ void DrawEngineD3D11::DoFlush() {
 			gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && ((hasColor && (gstate.materialupdate & 1)) || gstate.getMaterialAmbientA() == 255) && (!gstate.isLightingEnabled() || gstate.getAmbientA() == 255);
 		}
 
-		gpuStats.numUncachedVertsDrawn += indexGen.VertexCount();
-		prim = indexGen.Prim();
-		// Undo the strip optimization, not supported by the SW code yet.
-		if (prim == GE_PRIM_TRIANGLE_STRIP)
-			prim = GE_PRIM_TRIANGLES;
-		VERBOSE_LOG(G3D, "Flush prim %i SW! %i verts in one go", prim, indexGen.VertexCount());
+		gpuStats.numUncachedVertsDrawn += vertexCount;
+		prim = IndexGenerator::GeneralPrim((GEPrimitiveType)drawInds_[0].prim);
+		VERBOSE_LOG(G3D, "Flush prim %i SW! %i verts in one go", prim, vertexCount);
 
 		u16 *inds = decIndex_;
 		SoftwareTransformResult result{};
@@ -424,7 +418,7 @@ void DrawEngineD3D11::DoFlush() {
 		ApplyDrawState(prim);
 
 		if (result.action == SW_NOT_READY)
-			swTransform.BuildDrawingParams(prim, indexGen.VertexCount(), dec_->VertexType(), inds, numDecodedVerts_, &result);
+			swTransform.BuildDrawingParams(prim, vertexCount, dec_->VertexType(), inds, numDecodedVerts_, &result);
 		if (result.setSafeSize)
 			framebufferManager_->SetSafeSize(result.safeWidth, result.safeHeight);
 

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -284,19 +284,20 @@ void DrawEngineGLES::DoFlush() {
 			u8 *dest = (u8 *)frameData.pushVertex->Allocate(vertsToDecode * dec_->GetDecVtxFmt().stride, 4, &vertexBuffer, &vertexBufferOffset);
 			DecodeVerts(dest);
 		}
-		DecodeInds();
 
-		// If there's only been one primitive type, and it's either TRIANGLES, LINES or POINTS,
-		// there is no need for the index buffer we built. We can then use glDrawArrays instead
-		// for a very minor speed boost. TODO: We can probably detect this case earlier, like before
-		// actually doing any vertex decoding (unless we're doing soft skinning and pre-decode on submit).
-		bool useElements = !indexGen.SeenOnlyPurePrims();
-		int vertexCount = indexGen.VertexCount();
-		gpuStats.numUncachedVertsDrawn += vertexCount;
-		if (!useElements && indexGen.PureCount()) {
-			vertexCount = indexGen.PureCount();
+		int vertexCount;
+		int maxIndex;
+		bool useElements;
+		DecodeVerts(decoded_);
+		DecodeIndsAndGetData(&prim, &vertexCount, &maxIndex, &useElements, false);
+
+		if (useElements) {
+			uint32_t esz = sizeof(uint16_t) * vertexCount;
+			void *dest = frameData.pushIndex->Allocate(esz, 2, &indexBuffer, &indexBufferOffset);
+			// TODO: When we need to apply an index offset, we can apply it directly when copying the indices here.
+			// Of course, minding the maximum value of 65535...
+			memcpy(dest, decIndex_, esz);
 		}
-		prim = indexGen.Prim();
 
 		bool hasColor = (lastVType_ & GE_VTYPE_COL_MASK) != GE_VTYPE_COL_NONE;
 		if (gstate.isModeThrough()) {
@@ -316,11 +317,6 @@ void DrawEngineGLES::DoFlush() {
 		LinkedShader *program = shaderManager_->ApplyFragmentShader(vsid, vshader, pipelineState_, framebufferManager_->UseBufferedRendering());
 		GLRInputLayout *inputLayout = SetupDecFmtForDraw(dec_->GetDecVtxFmt());
 		if (useElements) {
-			uint32_t esz = sizeof(uint16_t) * indexGen.VertexCount();
-			void *dest = frameData.pushIndex->Allocate(esz, 2, &indexBuffer, &indexBufferOffset);
-			// TODO: When we need to apply an index offset, we can apply it directly when copying the indices here.
-			// Of course, minding the maximum value of 65535...
-			memcpy(dest, decIndex_, esz);
 			render_->DrawIndexed(inputLayout,
 				vertexBuffer, vertexBufferOffset,
 				indexBuffer, indexBufferOffset,
@@ -338,7 +334,7 @@ void DrawEngineGLES::DoFlush() {
 			dec_ = GetVertexDecoder(lastVType_);
 		}
 		DecodeVerts(decoded_);
-		DecodeInds();
+		int vertexCount = DecodeInds();
 
 		bool hasColor = (lastVType_ & GE_VTYPE_COL_MASK) != GE_VTYPE_COL_NONE;
 		if (gstate.isModeThrough()) {
@@ -347,11 +343,8 @@ void DrawEngineGLES::DoFlush() {
 			gstate_c.vertexFullAlpha = gstate_c.vertexFullAlpha && ((hasColor && (gstate.materialupdate & 1)) || gstate.getMaterialAmbientA() == 255) && (!gstate.isLightingEnabled() || gstate.getAmbientA() == 255);
 		}
 
-		gpuStats.numUncachedVertsDrawn += indexGen.VertexCount();
-		prim = indexGen.Prim();
-		// Undo the strip optimization, not supported by the SW code yet.
-		if (prim == GE_PRIM_TRIANGLE_STRIP)
-			prim = GE_PRIM_TRIANGLES;
+		gpuStats.numUncachedVertsDrawn += vertexCount;
+		prim = IndexGenerator::GeneralPrim((GEPrimitiveType)drawInds_[0].prim);
 
 		u16 *inds = decIndex_;
 		SoftwareTransformResult result{};
@@ -377,7 +370,7 @@ void DrawEngineGLES::DoFlush() {
 			UpdateCachedViewportState(vpAndScissor_);
 		}
 
-		int vertexCount = indexGen.VertexCount();
+		int maxIndex = numDecodedVerts_;
 
 		// TODO: Split up into multiple draw calls for GLES 2.0 where you can't guarantee support for more than 0x10000 verts.
 		if (gl_extensions.IsGLES && !gl_extensions.GLES3) {

--- a/GPU/ge_constants.h
+++ b/GPU/ge_constants.h
@@ -583,8 +583,7 @@ enum GETexProjMapMode
 	GE_PROJMAP_NORMAL = 3,
 };
 
-enum GEPrimitiveType
-{
+enum GEPrimitiveType : int8_t {
 	GE_PRIM_POINTS = 0,
 	GE_PRIM_LINES = 1,
 	GE_PRIM_LINE_STRIP = 2,


### PR DESCRIPTION
I did this optimization a while ago before previous optimizations, and didn't see a difference back then. Now, though, this actually does seem to make a minor difference in some games, and I also think it makes the code cleaner. So let's get it in.

Basically we track some state when collecting the draws into bunches, instead of at actual draw time, so we know earlier whether we need to generate indices or not, allowing us to skip it in some cases.