### PR TITLE
Vulkan render queue runner: Count commands in debug builds, like the GL backend.

### DIFF
--- a/Common/GPU/Vulkan/VulkanFrameData.h
+++ b/Common/GPU/Vulkan/VulkanFrameData.h
@@ -29,6 +29,9 @@ struct QueueProfileContext {
 	double cpuEndTime;
 	double descWriteTime;
 	int descriptorsWritten;
+#ifdef _DEBUG
+	int commandCounts[11];
+#endif
 };
 
 class VKRFramebuffer;

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -280,7 +280,7 @@ private:
 	bool InitDepthStencilBuffer(VkCommandBuffer cmd);  // Used for non-buffered rendering.
 
 	VKRRenderPass *PerformBindFramebufferAsRenderTarget(const VKRStep &pass, VkCommandBuffer cmd);
-	void PerformRenderPass(const VKRStep &pass, VkCommandBuffer cmd, int curFrame);
+	void PerformRenderPass(const VKRStep &pass, VkCommandBuffer cmd, int curFrame, QueueProfileContext &profile);
 	void PerformCopy(const VKRStep &pass, VkCommandBuffer cmd);
 	void PerformBlit(const VKRStep &pass, VkCommandBuffer cmd);
 	void PerformReadback(const VKRStep &pass, VkCommandBuffer cmd, FrameData &frameData);
@@ -346,3 +346,5 @@ private:
 	};
 	DepthBufferInfo depth_;
 };
+
+const char *VKRRenderCommandToString(VKRRenderCommand cmd);

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -723,6 +723,17 @@ void VulkanRenderManager::BeginFrame(bool enableProfiling, bool enableLogProfile
 			str << line;
 			frameData.profile.profileSummary = str.str();
 		}
+
+#ifdef _DEBUG
+		std::string cmdString;
+		for (int i = 0; i < ARRAY_SIZE(frameData.profile.commandCounts); i++) {
+			if (frameData.profile.commandCounts[i] > 0) {
+				cmdString += StringFromFormat("%s: %d\n", VKRRenderCommandToString((VKRRenderCommand)i), frameData.profile.commandCounts[i]);
+			}
+		}
+		memset(frameData.profile.commandCounts, 0, sizeof(frameData.profile.commandCounts));
+		frameData.profile.profileSummary += cmdString;
+#endif
 	}
 
 	frameData.profile.descriptorsWritten = 0;


### PR DESCRIPTION
Just interesting to see the counts, for possible optimization purposes. Doesn't affect performance since it's removed in release builds.