### PR TITLE
Control Mappings: Organize bindings into categories

### DIFF
--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -182,6 +182,16 @@ Point View::GetFocusPosition(FocusDirection dir) const {
 	}
 }
 
+Point CollapsibleHeader::GetFocusPosition(FocusDirection dir) const {
+	// Bias the focus position to the left.
+	switch (dir) {
+	case FOCUS_UP: return Point(bounds_.x + 50, bounds_.y + 2);
+	case FOCUS_DOWN: return Point(bounds_.x + 50, bounds_.y2() - 2);
+	default:
+		return View::GetFocusPosition(dir);
+	}
+}
+
 bool View::SetFocus() {
 	if (IsFocusMovementEnabled()) {
 		if (CanBeFocused()) {

--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -468,7 +468,7 @@ public:
 	virtual bool IsViewGroup() const { return false; }
 	virtual bool ContainsSubview(const View *view) const { return false; }
 
-	Point GetFocusPosition(FocusDirection dir) const;
+	virtual Point GetFocusPosition(FocusDirection dir) const;
 
 	template <class T>
 	T *AddTween(T *t) {
@@ -870,6 +870,8 @@ public:
 	void Draw(UIContext &dc) override;
 	void GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const override;
 	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
+
+	Point GetFocusPosition(FocusDirection dir) const override;
 
 	void SetHasSubitems(bool hasSubItems) { hasSubItems_ = hasSubItems; }
 private:

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -1186,9 +1186,7 @@ CollapsibleSection::CollapsibleSection(const std::string &title, LayoutParams *l
 	heading_->OnClick.Add([=](UI::EventParams &) {
 		// Change the visibility of all children except the first one.
 		// Later maybe try something more ambitious.
-		for (size_t i = 1; i < views_.size(); i++) {
-			views_[i]->SetVisibility(open_ ? V_VISIBLE : V_GONE);
-		}
+		UpdateVisibility();
 		return UI::EVENT_DONE;
 	});
 }
@@ -1196,6 +1194,12 @@ CollapsibleSection::CollapsibleSection(const std::string &title, LayoutParams *l
 void CollapsibleSection::Update() {
 	ViewGroup::Update();
 	heading_->SetHasSubitems(views_.size() > 1);
+}
+
+void CollapsibleSection::UpdateVisibility() {
+	for (size_t i = 1; i < views_.size(); i++) {
+		views_[i]->SetVisibility(open_ ? V_VISIBLE : V_GONE);
+	}
 }
 
 }  // namespace UI

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -327,7 +327,13 @@ public:
 
 	void Update() override;
 
+	void SetOpen(bool open) {
+		open_ = open;
+		UpdateVisibility();
+	}
+
 private:
+	void UpdateVisibility();
 	bool open_ = true;
 	CollapsibleHeader *heading_;
 };

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -399,9 +399,13 @@ const KeyMap_IntStrPair psp_button_names[] = {
 	{VIRTKEY_AXIS_Y_MIN, "An.Down"},
 	{VIRTKEY_AXIS_X_MIN, "An.Left"},
 	{VIRTKEY_AXIS_X_MAX, "An.Right"},
-	{VIRTKEY_ANALOG_LIGHTLY, "Analog limiter"},
 
+	{VIRTKEY_ANALOG_ROTATE_CW, "Rotate Analog (CW)"},
+	{VIRTKEY_ANALOG_ROTATE_CCW, "Rotate Analog (CCW)"},
+	{VIRTKEY_ANALOG_LIGHTLY, "Analog limiter"},
 	{VIRTKEY_RAPID_FIRE, "RapidFire"},
+	{VIRTKEY_AXIS_SWAP, "AxisSwap"},
+
 	{VIRTKEY_FASTFORWARD, "Fast-forward"},
 	{VIRTKEY_SPEED_TOGGLE, "SpeedToggle"},
 	{VIRTKEY_SPEED_CUSTOM1, "Alt speed 1"},
@@ -421,20 +425,13 @@ const KeyMap_IntStrPair psp_button_names[] = {
 	{VIRTKEY_TOGGLE_FULLSCREEN, "Toggle Fullscreen"},
 #endif
 
-	{VIRTKEY_AXIS_RIGHT_Y_MAX, "RightAn.Up"},
-	{VIRTKEY_AXIS_RIGHT_Y_MIN, "RightAn.Down"},
-	{VIRTKEY_AXIS_RIGHT_X_MIN, "RightAn.Left"},
-	{VIRTKEY_AXIS_RIGHT_X_MAX, "RightAn.Right"},
 	{VIRTKEY_OPENCHAT, "OpenChat" },
 
-	{VIRTKEY_AXIS_SWAP, "AxisSwap"},
 	{VIRTKEY_DEVMENU, "DevMenu"},
 	{VIRTKEY_TEXTURE_DUMP, "Texture Dumping"},
 	{VIRTKEY_TEXTURE_REPLACE, "Texture Replacement"},
 	{VIRTKEY_SCREENSHOT, "Screenshot"},
 	{VIRTKEY_MUTE_TOGGLE, "Mute toggle"},
-	{VIRTKEY_ANALOG_ROTATE_CW, "Rotate Analog (CW)"},
-	{VIRTKEY_ANALOG_ROTATE_CCW, "Rotate Analog (CCW)"},
 
 #ifdef OPENXR
 	{VIRTKEY_VR_CAMERA_ADJUST, "VR camera adjust"},
@@ -448,6 +445,11 @@ const KeyMap_IntStrPair psp_button_names[] = {
 
 	{VIRTKEY_TOGGLE_WLAN, "Toggle WLAN"},
 	{VIRTKEY_EXIT_APP, "Exit App"},
+
+	{VIRTKEY_AXIS_RIGHT_Y_MAX, "RightAn.Up"},
+	{VIRTKEY_AXIS_RIGHT_Y_MIN, "RightAn.Down"},
+	{VIRTKEY_AXIS_RIGHT_X_MIN, "RightAn.Left"},
+	{VIRTKEY_AXIS_RIGHT_X_MAX, "RightAn.Right"},
 
 	{CTRL_HOME, "Home"},
 	{CTRL_HOLD, "Hold"},

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -423,7 +423,8 @@ void KeyMappingNewKeyDialog::axis(const AxisInput &axis) {
 		InputMapping mapping(axis.deviceId, axis.axisId, 1);
 		triggeredAxes_.insert(mapping);
 		if (!g_Config.bAllowMappingCombos && !mapping_.mappings.empty()) {
-			comboMappingsNotEnabled_->SetVisibility(UI::V_VISIBLE);
+			if (mapping_.mappings.size() == 1 && mapping != mapping_.mappings[0])
+				comboMappingsNotEnabled_->SetVisibility(UI::V_VISIBLE);
 		} else if (!mapping_.mappings.contains(mapping)) {
 			mapping_.mappings.push_back(mapping);
 			RecreateViews();
@@ -432,7 +433,8 @@ void KeyMappingNewKeyDialog::axis(const AxisInput &axis) {
 		InputMapping mapping(axis.deviceId, axis.axisId, -1);
 		triggeredAxes_.insert(mapping);
 		if (!g_Config.bAllowMappingCombos && !mapping_.mappings.empty()) {
-			comboMappingsNotEnabled_->SetVisibility(UI::V_VISIBLE);
+			if (mapping_.mappings.size() == 1 && mapping != mapping_.mappings[0])
+				comboMappingsNotEnabled_->SetVisibility(UI::V_VISIBLE);
 		} else if (!mapping_.mappings.contains(mapping)) {
 			mapping_.mappings.push_back(mapping);
 			RecreateViews();

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -275,12 +275,39 @@ void ControlMappingScreen::CreateViews() {
 	root_->Add(rightScroll_);
 
 	std::vector<KeyMap::KeyMap_IntStrPair> mappableKeys = KeyMap::GetMappableKeys();
+
+	struct Cat {
+		const char *catName;
+		int firstKey;
+		bool openByDefault;
+	};
+	// Category name, first input from psp_button_names.
+	static const Cat cats[] = {
+		{"Standard PSP controls", CTRL_UP, true},
+		{"Control modifiers", VIRTKEY_ANALOG_ROTATE_CW, true},
+		{"Emulator controls", VIRTKEY_FASTFORWARD, true},
+		{"Extended PSP controls", VIRTKEY_AXIS_RIGHT_Y_MAX, false},
+	};
+
+	int curCat = -1;
+	CollapsibleSection *curSection = nullptr;
 	for (size_t i = 0; i < mappableKeys.size(); i++) {
-		SingleControlMapper *mapper = rightColumn->Add(
+		if (curCat < (int)ARRAY_SIZE(cats) && mappableKeys[i].key == cats[curCat + 1].firstKey) {
+			if (curCat >= 0 && !cats[curCat].openByDefault) {
+				curSection->SetOpen(false);
+			}
+			curCat++;
+			curSection = rightColumn->Add(new CollapsibleSection(km->T(cats[curCat].catName)));
+			curSection->SetSpacing(6.0f);
+		}
+		SingleControlMapper *mapper = curSection->Add(
 			new SingleControlMapper(mappableKeys[i].key, mappableKeys[i].name, screenManager(),
 				                    new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 		mapper->SetTag(StringFromFormat("KeyMap%s", mappableKeys[i].name));
 		mappers_.push_back(mapper);
+	}
+	if (curCat >= 0 && curSection && !cats[curCat].openByDefault) {
+		curSection->SetOpen(false);
 	}
 
 	keyMapGeneration_ = KeyMap::g_controllerMapGeneration;

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -36,7 +36,10 @@ class SingleControlMapper;
 
 class ControlMappingScreen : public UIDialogScreenWithGameBackground {
 public:
-	explicit ControlMappingScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {}
+	explicit ControlMappingScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {
+		categoryToggles_[0] = true;
+		categoryToggles_[1] = true;
+	}
 	const char *tag() const override { return "ControlMapping"; }
 
 protected:
@@ -51,6 +54,8 @@ private:
 	UI::ScrollView *rightScroll_ = nullptr;
 	std::vector<SingleControlMapper *> mappers_;
 	int keyMapGeneration_ = -1;
+
+	bool categoryToggles_[10]{};
 };
 
 class KeyMappingNewKeyDialog : public PopupScreen {

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -708,12 +708,16 @@ Autoconfigure for device = ‎إعداد تلقائي للعبة
 Bind All = Bind All
 Clear All = ‎إخلاء الكل
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = ‎إرجاع للإفتراضي
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = ‎خريطة مفتاح جديدة لـ
 Map Key = ‎خريطة مفتاح
 Map Mouse = ‎خريطة الفأرة
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = ‎يمكنك ضغط علي زر الخروج للإلغاء.
 
 [MainMenu]

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Autoconfigure for device
 Bind All = Bind All
 Clear All = Clear all
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Restore defaults
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Map a new key for
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Autoconfigure for device
 Bind All = Bind All
 Clear All = Изчисти всички
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Първоначални
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Избери нов клавиш за
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Autoconfigurar per a dispositiu
 Bind All = Assignar tots
 Clear All = Esborrar tot
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Restaurar
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Prem una tecla per
 Map Key = Mapejar tecla
 Map Mouse = Mapejar ratolí
 Replace = Reemplaçar
 Show PSP = Mostra PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Podeu prémer ESC per cancel·lar.
 
 [MainMenu]

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Automaticky nastavit pro zařízení
 Bind All = Bind All
 Clear All = Vše vyčistit
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Obnovit výchozí
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Mapovat novou klávesu pro
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Autokonfiguration af enhed
 Bind All = Bind All
 Clear All = Slet alt
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Sæt til standard
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Map en ny taste for
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Du kan trykke Esc for at afbryde.
 
 [MainMenu]

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Autokonfiguration für Gerät
 Bind All = Bind All
 Clear All = Alle löschen
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Zurücksetzen
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Drücke zuzuweisende Taste für
 Map Key = Taste zuweisen
 Map Mouse = Maus zuweisen
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Drücken Sie ESC zum abbrechen.
 
 [MainMenu]

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Autoconfigure for device
 Bind All = Bind All
 Clear All = Paccingngi nasan
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Poleboko' nasan
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Garaganni tombol baru
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -724,12 +724,16 @@ Autoconfigure for device = Autoconfigure for device
 Bind All = Bind All
 Clear All = Clear all
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Restore defaults
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Map a new key for
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Autoconfigurar para dispositivo
 Bind All = Asignar todos
 Clear All = Borrar todo
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Restaurar
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Pulsa una tecla para
 Map Key = Mapear tecla
 Map Mouse = Mapear ratón
 Replace = Remplazar
 Show PSP = Mostrar PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Puedes presionar ESC para cancelar.
 
 [MainMenu]

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Autoconfigurar para dispositivo
 Bind All = Ocultar todo
 Clear All = Borrar todo
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Restaurar
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Presiona una tecla para
 Map Key = Asignar tecla
 Map Mouse = Asignar ratón
 Replace = Reemplazar
 Show PSP = Mostrar PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Puedes presionar Esc para cancelar.
 
 [MainMenu]

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Autoconfigure for device
 Bind All = Bind All
 Clear All = ‎پاکسازی همه
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = ‎پیشفرض همه
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = ‎برای این دکمه یک کلید انتخاب کنید
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Automaattinen määritys laitteelle
 Bind All = Kartoita kaikki
 Clear All = Tyhjennä kaikki
 Combo mappings are not enabled = Yhdistelmäkuvaukset eivät ole käytössä
+Control modifiers = Control modifiers
 Default All = Palauta oletusasetukset
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Kartoita uusi näppäin kohteelle
 Map Key = Kartoita näppäin
 Map Mouse = Kartoita hiiri
 Replace = Korvaa
 Show PSP = Näytä PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Voit peruuttaa painamalla Esc.
 
 [MainMenu]

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Configuration automatique pour l'appareil
 Bind All = Bind All
 Clear All = Réinitialiser
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Par défaut
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Choisir une nouvelle touche pour
 Map Key = Assigner une touche
 Map Mouse = Assigner un contrôle de souris
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Vous pouvez presser "Échap" pour annuler.
 
 [MainMenu]

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Autoconfigurar para dispositivo
 Bind All = Bind All
 Clear All = Borrar todo
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Restaurar
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Pulsa unha tecla para
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Αυτόματη ρύθμιση για τη συσκ�
 Bind All = Bind All
 Clear All = Καθαρισμός
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Επαναφορά
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Πατήστε ένα πλήκτρο για το
 Map Key = ΡύΘμιση κουμπιού
 Map Mouse = ΡύΘμιση ποντικού
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Μπορείτε να πατήσετε Esc για ακύρωση.
 
 [MainMenu]

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Autoconfigure for device
 Bind All = Bind All
 Clear All = נקה הכל
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = החזר הכל
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = מיפוי מקש נוסף ל
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Autoconfigure for device
 Bind All = Bind All
 Clear All = לכה הקנ
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = לכה רזחה
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = ףסונ שקמ יופימ
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Automatski konfiguriraj za sve uređaje
 Bind All = Bind All
 Clear All = Obriši sve
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Vrati na zadano
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Postavi novu tipku za
 Map Key = Postavi tipku
 Map Mouse = Postavi miš
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Možes pritisnuti ESC za odustati.
 
 [MainMenu]

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Eszköz auto-beállítása
 Bind All = Bind All
 Clear All = Összes törlése
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Összeset alapért.
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Új gomb beállítása ehhez:
 Map Key = Billentyű társítása
 Map Mouse = Egér társítása
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Megszakításhoz használj ESC-et.
 
 [MainMenu]

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Konfigurasi otomatis untuk perangkat
 Bind All = Ikat/simpan semua
 Clear All = Bersihkan semua
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Kembalikan ke pengaturan awal
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Tombol kunci baru ditetapkan ke
 Map Key = Tetapkan kunci/tombol
 Map Mouse = Tetapkan mouse
 Replace = Timpa
 Show PSP = Tampilkan PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Kamu dapat membatalkan dengan menekan ESC.
 
 [MainMenu]

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -701,12 +701,16 @@ Autoconfigure for device = Configurazione Automatica per il Dispositivo
 Bind All = Associa Tutti
 Clear All = Pulisci Tutti
 Combo mappings are not enabled = Le mappature combinate non sono abilitate
+Control modifiers = Control modifiers
 Default All = Ripristina Tutti a Valori Predefiniti
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Mappa un nuovo tasto per:
 Map Key = Mappa Tasto
 Map Mouse = Mappa Mouse
 Replace = Sostituisci
 Show PSP = Mostra PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Puoi premere Esc per annullare.
 
 [MainMenu]

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = デバイスの自動設定
 Bind All = 全ての割り当てを行う
 Clear All = 全てクリアする
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = デフォルトに戻す
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = 新しいキーを入力
 Map Key = キーの割り当て指定
 Map Mouse = マウスの割り当て指定
 Replace = 置き換える
 Show PSP = PSP画像を表示
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Escを押すとキャンセルできます。
 
 [MainMenu]

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Konfigurasi otomatis kanggo piranti
 Bind All = Bind All
 Clear All = Ilangi kabeh
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Gawan kabeh
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Petakan tombol anyar
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = 장치 자동 구성
 Bind All = 모두 바인딩
 Clear All = 모두 지움
 Combo mappings are not enabled = 콤보 매핑이 활성화되지 않음
+Control modifiers = Control modifiers
 Default All = 기본값 복원
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = 새로운 키 입력
 Map Key = 키 매핑
 Map Mouse = 마우스 매핑
 Replace = 교체
 Show PSP = PSP 표시
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Esc를 눌러 취소할 수 있습니다.
 
 [MainMenu]

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = ກຳນົດຄ່າໃຫ້ອັດຕະໂ�
 Bind All = Bind All
 Clear All = ລຶບທັງໝົດ
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = ຄືນຄ່າເລີ່ມຕົ້ນໃໝ່ໝົດ
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = ປັບປຸ່ມໃໝ່ເພື່ອ
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = ເຈົ້າສາມາດກົດ Esc ເພື່ອຍົກເລີກ.
 
 [MainMenu]

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Automatiškai sukonfiguruoti įrenginiui
 Bind All = Bind All
 Clear All = Ištrinti viską
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Akturti numatytus parametrus
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Nustatyti naują klavišą
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Autoconfigure for device
 Bind All = Bind All
 Clear All = Bersihkan semua
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Lalaikan semua
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Petakan kekunci baru untuk
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Automatisch voor apparaat configureren
 Bind All = Bind All
 Clear All = Alles legen
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Herstellen
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Stel een nieuwe toets in voor
 Map Key = Toets indelen
 Map Mouse = Muis indelen
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Druk op Esc om te annuleren.
 
 [MainMenu]

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Autoconfigure for device
 Bind All = Bind All
 Clear All = Clear all
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Restore defaults
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Map a new key for
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -705,12 +705,16 @@ Autoconfigure for device = Skonfiguruj automatycznie
 Bind All = Przypisz (wszystkie)
 Clear All = Wyczyść (wszystkie)
 Combo mappings are not enabled = Mapowanie kombinacji jest wyłączone
+Control modifiers = Control modifiers
 Default All = Domyślne (wszystkie)
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Przypisz nowy klawisz dla
 Map Key = Mapuj przycisk
 Map Mouse = Mapuj mysz
 Replace = Zamień
 Show PSP = Pokaż PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Możesz zamknąć to okienko naciskając Esc.
 
 [MainMenu]

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -724,12 +724,16 @@ Autoconfigure for device = Auto-configurar pro dispositivo
 Bind All = Associar tudo
 Clear All = Limpar tudo
 Combo mappings are not enabled = Os mapeamentos dos combos não estão ativados
+Control modifiers = Control modifiers
 Default All = Restaurar os padrões
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Mapear uma nova tecla pra
 Map Key = Mapear tecla
 Map Mouse = Mapear o mouse
 Replace = Substituir
 Show PSP = Mostrar o PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Você pode pressionar o Esc pra cancelar.
 
 [MainMenu]

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -724,12 +724,16 @@ Autoconfigure for device = Configurar automaticamente para o dispositivo
 Bind All = Associar tudo
 Clear All = Limpar tudo
 Combo mappings are not enabled = Mapeamentos combo não estão ativados
+Control modifiers = Control modifiers
 Default All = Restaurar para os padrões
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Mapear uma nova tecla para
 Map Key = Mapear tecla
 Map Mouse = Mapear o Rato
 Replace = Substituir
 Show PSP = Mostrar a PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Podes pressionar a tecla Esc para cancelar.
 
 [MainMenu]

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -701,12 +701,16 @@ Autoconfigure for device = Configurare automată pt. dispozitiv
 Bind All = Bind All
 Clear All = Curătă tot
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Înapoi la inițial
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Configurează o nouă tastă pentru
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Автоконфиг для устройства
 Bind All = Настроить всё
 Clear All = Очистить все
 Combo mappings are not enabled = Раскладки комбо не включены
+Control modifiers = Control modifiers
 Default All = По умолчанию
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Назначить кнопку для
 Map Key = Назначить кнопку
 Map Mouse = Назначить мышь
 Replace = Заменить
 Show PSP = Показать вид PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Для отмены вы можете нажать Esc.
 
 [MainMenu]

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -701,12 +701,16 @@ Autoconfigure for device = Autokonfigurera för enhet
 Bind All = Bind All
 Clear All = Rensa
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Återställ allt
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Mappa ny knapp för
 Map Key = Mappa tangent
 Map Mouse = Mappa mus
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Tryck ESC för att avbryta.
 
 [MainMenu]

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Autoconfigure for device
 Bind All = Bind All
 Clear All = Burahin lahat
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Ibalik lahat sa dati
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Map a new key for
 Map Key = Map key
 Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = กำหนดค่าให้อัตโนม�
 Bind All = เซ็ตปุ่มทั้งหมด
 Clear All = ล้างทั้งหมด
 Combo mappings are not enabled = เซ็ตปุ่มคอมโบยังไม่ได้เปิดใช้งาน
+Control modifiers = Control modifiers
 Default All = คืนค่าเดิมทั้งหมด
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = ปรับปุ่มใหม่สำหรับ
 Map Key = ตั้งค่าปุ่ม
 Map Mouse = ตั้งค่าปุ่มเมาส์
 Replace = แทนที่
 Show PSP = แสดง PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = คุณสามารถกด ESC เพื่อยกเลิกได้
 
 [MainMenu]

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -702,12 +702,16 @@ Autoconfigure for device = Cihaz için otomatik ayarla
 Bind All = Hepsini Bağla
 Clear All = Hepsini Temizle
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Varsayılana Döndür
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Yeni bir tuş girin
 Map Key = Tuş girin
 Map Mouse = Mouse eşleştir
 Replace = Değiştir
 Show PSP = PSP'yi Göster
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = İptal etmek için Esc'ye basabilirsiniz.
 
 [MainMenu]

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Авто конфіг для пристрою
 Bind All = Bind All
 Clear All = Очистити все
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Скинути все
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Призначити кнопку для
 Map Key = Карта кнопки
 Map Mouse = Карта миші
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = Ви можете натиснути Esc, щоб скасувати.
 
 [MainMenu]

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = Tự động thiết lập với thiết bị này
 Bind All = Bind All
 Clear All = Xóa tất cả
 Combo mappings are not enabled = Combo mappings are not enabled
+Control modifiers = Control modifiers
 Default All = Trả lại thiết lập gốc
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = Nhập nút mới cho
 Map Key = bản đồ nút
 Map Mouse = bản đồ chuột
 Replace = Replace
 Show PSP = Show PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = bạn có thể nhấp Esc để hủy.
 
 [MainMenu]

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = 根据设备配置
 Bind All = 全部绑定
 Clear All = 全部清除
 Combo mappings are not enabled = 请打开多键合一
+Control modifiers = Control modifiers
 Default All = 恢复默认
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = 输入一个新按键：
 Map Key = 按键映射
 Map Mouse = 鼠标映射
 Replace = 替换现有
 Show PSP = PSP 布局
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = 可以按下Esc键取消
 
 [MainMenu]

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -700,12 +700,16 @@ Autoconfigure for device = 自動設定裝置
 Bind All = 全部繫結
 Clear All = 全部清除
 Combo mappings are not enabled = 組合對應未啟用
+Control modifiers = Control modifiers
 Default All = 重設為預設值
+Emulator controls = Emulator controls
+Extended PSP controls = Extended PSP controls
 Map a new key for = 對應新按鍵：
 Map Key = 對應按鍵
 Map Mouse = 對應滑鼠
 Replace = 取代
 Show PSP = 顯示 PSP
+Standard PSP controls = Standard PSP controls
 You can press ESC to cancel. = 您可以按下 ESC 取消
 
 [MainMenu]


### PR DESCRIPTION
Makes it a bit easier to navigate, by letting you collapse categories to find the bindings you need.

Right analog stick and the really odd bindings are moved to "Extended PSP controls" at the end.

![image](https://github.com/hrydgard/ppsspp/assets/130929/2a48b0bc-d6ee-4da5-868a-43dc72504401)

Makes #17507 slightly better.

