### PR TITLE
[Workflow] Update JDK version to 17

### DIFF
--- a/.github/workflows/manual_generate_apk.yml
+++ b/.github/workflows/manual_generate_apk.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
         
       #- name: Setup SDK
       #  uses: android-actions/setup-android@v2


### PR DESCRIPTION
Due to error: Caused by: com.android.builder.errors.EvalIssueException: Android Gradle plugin requires Java 17 to run. You are currently using Java 11.