### PR TITLE
Allow unpausing with keys bound to pause

### DIFF
--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -219,4 +219,4 @@ namespace KeyMap {
 	bool IsKeyMapped(InputDeviceID device, int key);
 
 	bool HasChanged(int &prevGeneration);
-}
+}  // namespace KeyMap

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1533,6 +1533,7 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 
 	bool blockedExecution = Achievements::IsBlockingExecution();
 	bool rebind = false;
+	uint32_t clearColor = 0;
 	if (!blockedExecution) {
 		PSP_BeginHostFrame();
 		PSP_RunLoopWhileState();
@@ -1553,13 +1554,13 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 			if (info.type != MIPSExceptionType::NONE) {
 				// Clear to blue background screen
 				bool dangerousSettings = !Reporting::IsSupported();
-				uint32_t color = dangerousSettings ? 0xFF900050 : 0xFF900000;
-				draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE, color }, "EmuScreen_RuntimeError");
+				clearColor = dangerousSettings ? 0xFF900050 : 0xFF900000;
+				draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE, clearColor }, "EmuScreen_RuntimeError");
 				// The info is drawn later in renderUI
 			} else {
 				// If we're stepping, it's convenient not to clear the screen entirely, so we copy display to output.
 				// This won't work in non-buffered, but that's fine.
-				draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_Stepping");
+				draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE, clearColor }, "EmuScreen_Stepping");
 				// Just to make sure.
 				if (PSP_IsInited()) {
 					gpu->CopyDisplayToOutput(true);
@@ -1579,7 +1580,7 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 	}
 
 	if (gpu && !gpu->PresentedThisFrame() && !skipBufferEffects) {
-		draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR }, "EmuScreen_NoFrame");
+		draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, clearColor }, "EmuScreen_NoFrame");
 		draw->SetViewport(viewport);
 		draw->SetScissorRect(0, 0, g_display.pixel_xres, g_display.pixel_yres);
 	}

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -32,6 +32,7 @@
 #include "Common/VR/PPSSPPVR.h"
 #include "Common/UI/AsyncImageFileView.h"
 
+#include "Core/KeyMap.h"
 #include "Core/Reporting.h"
 #include "Core/SaveState.h"
 #include "Core/System.h"
@@ -269,6 +270,24 @@ GamePauseScreen::GamePauseScreen(const Path &filename)
 
 GamePauseScreen::~GamePauseScreen() {
 	__DisplaySetWasPaused();
+}
+
+bool GamePauseScreen::key(const KeyInput &key) {
+	if (!UIScreen::key(key) && (key.flags & KEY_DOWN)) {
+		// Special case to be able to unpause with a bound pause key.
+		// Normally we can't bind keys used in the UI.
+		InputMapping mapping(key.deviceId, key.keyCode);
+		std::vector<int> pspButtons;
+		KeyMap::InputMappingToPspButton(mapping, &pspButtons);
+		for (auto button : pspButtons) {
+			if (button == VIRTKEY_PAUSE) {
+				TriggerFinish(DR_CANCEL);
+				return true;
+			}
+		}
+		return false;
+	}
+	return false;
 }
 
 void GamePauseScreen::CreateSavestateControls(UI::LinearLayout *leftColumnItems, bool vertical) {

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -36,6 +36,7 @@ public:
 	~GamePauseScreen();
 
 	void dialogFinished(const Screen *dialog, DialogResult dr) override;
+	bool key(const KeyInput &key) override;
 
 	const char *tag() const override { return "GamePause"; }
 


### PR DESCRIPTION
Fixes #9592 .

Normally we don't process key bindings in the UI. This adds a special case for this on the pause screen only.

Doesn't work with axis events.

Also throws in a background color fix.