### PR TITLE
Combo key: Only trigger when keys are pressed in the mapped order

### DIFF
--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -58,6 +58,8 @@ private:
 	void onVKey(int vkey, bool down);
 	void onVKeyAnalog(int deviceId, int vkey, float value);
 
+	void UpdateCurInputAxis(const InputMapping &mapping, float value, double timestamp);
+
 	// To track mappable virtual keys. We can have as many as we want.
 	float virtKeys_[VIRTKEY_COUNT]{};
 	bool virtKeyOn_[VIRTKEY_COUNT]{};  // Track boolean output separaately since thresholds may differ.


### PR DESCRIPTION
If you enable combo key mappings, and set up so that Ctrl+U takes a screenshot for example, U+Ctrl would also take a screenshot (that is, you press U first, then Ctrl). This is a bit unusual. This change makes it so that the combo key only triggers if you press the keys in the order that you mapped, so in this case only Ctrl+U would work.

I am curious to hear if there are any arguments for the previous behavior, which wasn't really intentional.