### PR TITLE
Tactics Ogre: Remove a redundant GPU readback operation

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -135,6 +135,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "LoadCLUTFromCurrentFrameOnly", &flags_.LoadCLUTFromCurrentFrameOnly);
 	CheckSetting(iniFile, gameID, "ForceUMDReadSpeed", &flags_.ForceUMDReadSpeed);
 	CheckSetting(iniFile, gameID, "AllowDelayedReadbacks", &flags_.AllowDelayedReadbacks);
+	CheckSetting(iniFile, gameID, "TacticsOgreEliminateDebugReadback", &flags_.TacticsOgreEliminateDebugReadback);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -105,6 +105,7 @@ struct CompatFlags {
 	bool LoadCLUTFromCurrentFrameOnly;
 	bool ForceUMDReadSpeed;
 	bool AllowDelayedReadbacks;
+	bool TacticsOgreEliminateDebugReadback;
 };
 
 struct VRCompat {

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -2683,6 +2683,10 @@ bool FramebufferManagerCommon::NotifyBlockTransferBefore(u32 dstBasePtr, int dst
 		// NotifyBlockTransferAfter will take care of the rest.
 		return false;
 	} else if (srcBuffer) {
+		if (width == 48 && height == 48 && srcY == 224 && srcX == 432 && PSP_CoreParameter().compat.flags().TacticsOgreEliminateDebugReadback) {
+			return false;
+		}
+
 		WARN_LOG_N_TIMES(btd, 10, G3D, "Block transfer readback %dx%d %dbpp from %08x (x:%d y:%d stride:%d) -> %08x (x:%d y:%d stride:%d)",
 			width, height, bpp,
 			srcBasePtr, srcRect.x_bytes / bpp, srcRect.y, srcStride,

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1716,3 +1716,11 @@ NPJH50263 = true
 # Added for easy experimentation. Many games using readbacks do not work well delaying them, though.
 # For example, Motorstorm lighting adaptation goes into self-oscillation (!)
 # UCES01250 = true
+
+[TacticsOgreEliminateDebugReadback]
+ULUS10565 = true
+ULES01500 = true
+ULJM05753 = true
+NPJH50348 = true
+ULJM06009 = true
+UCKS45164 = true


### PR DESCRIPTION
This is an old hack that has been discussed before but we never merged it. 

Tactics Ogre does a lot of expensive GPU readbacks, that it then actually uses for various graphics tricks (it seems to blur things on the CPU, for example). But, it also makes one small completely redundant readback every frame. Getting rid of that one can actually be pretty impactful on mobile, so let's just do it.

Note that it's now possible to set the "Skip GPU readbacks" setting to "Copy to Texture" which seems to work okay in this game now and will improve performance drastically on mobile, but some effects are missing, as mentioned above.