### PR TITLE
[libretro] Expose "Memory Stick inserted" option

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -585,6 +585,14 @@ static void check_variables(CoreParameter &coreParam)
          g_Config.bAnalogIsCircular = true;
    }
 
+   var.key = "ppsspp_memstick_inserted";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "disabled"))
+         g_Config.bMemStickInserted = false;
+      else
+         g_Config.bMemStickInserted = true;
+   }
 
    var.key = "ppsspp_internal_resolution";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -272,6 +272,16 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "ppsspp_memstick_inserted",
+      "Memory Stick inserted",
+      NULL,
+      "Some games require ejecting/inserting the Memory Stick.",
+      NULL,
+      "system",
+      BOOL_OPTIONS,
+      "enabled"
+   },
+   {
       "ppsspp_internal_resolution",
       "Internal Resolution (Restart)",
       NULL,


### PR DESCRIPTION
Exposes functionality introduced in https://github.com/hrydgard/ppsspp/pull/8889 to the libretro core