### PR TITLE
[Workflow] Manually Generate iOS IPA

### DIFF
--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -1,0 +1,83 @@
+name: Manual Generate IPA
+on:
+  workflow_dispatch:
+    inputs:
+
+      buildVariant:
+        type: choice
+        description: 'Build Variant'     
+        required: true
+        default: 'release'
+        options: 
+        - release
+        - debug
+
+jobs:
+
+  apk:
+    name: Generate ${{ github.event.inputs.buildVariant }} IPA
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+        
+      #- name: Fetch tags for macOS
+      #  # This is required for git describe --always to work for git-version.cpp.
+      #  run: |
+      #    git fetch --deepen=15000 --no-recurse-submodules --tags || exit 0
+
+      - name: Set Env Var(s)
+        run: |
+          echo "GIT_VERSION=$(git describe --always)" >> $GITHUB_ENV
+        
+      - name: Create macOS git-version.cpp & Version.txt
+        run: |
+          echo "const char *PPSSPP_GIT_VERSION = \"${GIT_VERSION}\";" > git-version.cpp
+          echo "#define PPSSPP_GIT_VERSION_NO_UPDATE 1" >> git-version.cpp
+          # Create Version.txt file (should probably do this during building process)
+          mkdir build-ios
+          mkdir build-ios/PPSSPP.app
+          echo $(echo $GIT_VERSION | cut -c 2-) > build-ios/PPSSPP.app/Version.txt
+          # Testing values ...
+          echo "Content of [GITHUB_REF##*/] = ${GITHUB_REF##*/}"
+          echo $(echo $GIT_VERSION | cut -c 2-)
+          # Testing file location ...
+          find . -name "Version.txt"
+          
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          create-symlink: true
+      
+      - name: Execute build
+        env:
+          CC: clang
+          CXX: clang++
+        run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          ./b.sh --ios --${{ github.event.inputs.buildVariant }}
+      
+      - name: Package build
+        run: |
+          # Testing file location ...
+          find . -name "Version.txt"
+          find . -name "*.app"
+          mkdir ppsspp
+          if [ -e build*/PPSSPP.app ]; then
+            mkdir ppsspp/Payload
+            cp -a build*/PPSSPP.app ppsspp/Payload
+            # GitHub Actions zipping kills symlinks and permissions.
+            cd ppsspp
+            zip -qry PPSSPP.ipa Payload
+            rm -rf Payload
+            cd -
+          fi
+
+      - name: Upload IPA
+        uses: actions/upload-artifact@v3
+        with:
+          name: iOS-${{ github.event.inputs.buildVariant }} build
+          path: ppsspp/


### PR DESCRIPTION
For testers who want the latest dev builds.
Based on https://github.com/hrydgard/ppsspp/pull/15450

Originally we're missing a file (`Version.txt` which contains the version without the leading `v` eg. `1.16.6-662-g33c0052c7`) when compared to the ipa file at https://p.xx.wtf/
So my workaround is by creating the file before executing `./b.sh --ios` hoping that the file will be included in the final PPSSPP.app (fortunately it did), probably should be created during building process.

I also changed `${GITHUB_REF##*/}` to something else (eg. `$(git describe --always)`), since this action use a different trigger, thus the content of `GITHUB_REF` will be the branch name (ie. `manual_generate_ipa`) instead of the version.

PS: i haven't tested the generated IPAs (release & debug) since i don't have iOS device, but the file structure should be similar to the one at https://p.xx.wtf/