### PR TITLE
Texture replacer: Fix for texture directories missing an ini file

### DIFF
--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -177,6 +177,16 @@ bool TextureReplacer::LoadIni() {
 			return false;
 		} else {
 			WARN_LOG(G3D, "Texture pack lacking ini file: %s", basePath_.c_str());
+			// Do what we can do anyway: Scan for textures and build the map.
+			std::map<ReplacementCacheKey, std::map<int, std::string>> filenameMap;
+			ScanForHashNamedFiles(dir, filenameMap);
+			ComputeAliasMap(filenameMap);
+			// Set some defaults.
+			allowVideo_ = false;
+			ignoreAddress_ = false;
+			reduceHash_ = false;
+			ignoreMipmap_ = false;
+			// TODO: others?
 		}
 	}
 

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -181,12 +181,6 @@ bool TextureReplacer::LoadIni() {
 			std::map<ReplacementCacheKey, std::map<int, std::string>> filenameMap;
 			ScanForHashNamedFiles(dir, filenameMap);
 			ComputeAliasMap(filenameMap);
-			// Set some defaults.
-			allowVideo_ = false;
-			ignoreAddress_ = false;
-			reduceHash_ = false;
-			ignoreMipmap_ = false;
-			// TODO: others?
 		}
 	}
 
@@ -599,6 +593,7 @@ ReplacedTexture *TextureReplacer::FindReplacement(u64 cachekey, u32 hash, int w,
 		}
 		desc.logId = desc.filenames[0];
 		desc.hashfiles = desc.filenames[0];  // The generated filename of the top level is used as the key in the data cache.
+		// TODO: here `hashfiles` is set to an empty string, breaking stuff below.
 	} else {
 		desc.logId = hashfiles;
 		SplitString(hashfiles, '|', desc.filenames);

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -190,6 +190,9 @@ bool TextureReplacer::LoadIni() {
 		}
 	}
 
+	auto gr = GetI18NCategory(I18NCat::GRAPHICS);
+	g_OSD.Show(OSDType::MESSAGE_SUCCESS, gr->T("Texture replacement pack activated"), 2.0f);
+
 	vfs_ = dir;
 
 	// If we have stuff loaded from before, need to update the vfs pointers to avoid
@@ -380,9 +383,6 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverri
 		}
 	}
 
-	auto gr = GetI18NCategory(I18NCat::GRAPHICS);
-
-	g_OSD.Show(OSDType::MESSAGE_SUCCESS, gr->T("Texture replacement pack activated"), 2.0f);
 	return true;
 }
 

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -135,6 +135,9 @@ protected:
 	float LookupReduceHashRange(int w, int h);
 	std::string LookupHashFile(u64 cachekey, u32 hash, bool *foundAlias, bool *ignored);
 
+	void ScanForHashNamedFiles(VFSBackend *dir, std::map<ReplacementCacheKey, std::map<int, std::string>> &filenameMap);
+	void ComputeAliasMap(const std::map<ReplacementCacheKey, std::map<int, std::string>> &filenameMap);
+
 	bool enabled_ = false;
 	bool allowVideo_ = false;
 	bool ignoreAddress_ = false;

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -18,9 +18,11 @@
 #pragma once
 
 #include "ppsspp_config.h"
+
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <map>
 #include <vector>
 
 #include "Common/CommonFuncs.h"


### PR DESCRIPTION
Missed testing this case when changing things a while ago.

This papers over the issue by pre-scanning the files to build the alias map, but there's also some broken logic that needs more testing than I have time for right now, so will fix that a bit later.