### PR TITLE
[Workflow] Manually Generate UWP MSIX/MSIXBundle on-demand

### DIFF
--- a/.github/workflows/manual_generate_apk.yml
+++ b/.github/workflows/manual_generate_apk.yml
@@ -1,4 +1,4 @@
-name: Manual Generate APK
+name: Manual Generate Android APK
 on:
   workflow_dispatch:
     inputs:
@@ -54,7 +54,7 @@ jobs:
             cp android/build/*/apk/*/*/android-normal-debug.apk ppsspp/
           fi
 
-      - name: Upload APK
+      - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: android-${{ github.event.inputs.buildVariant }} build

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -1,4 +1,4 @@
-name: Manual Generate IPA
+name: Manual Generate iOS IPA
 on:
   workflow_dispatch:
     inputs:
@@ -14,7 +14,7 @@ on:
 
 jobs:
 
-  apk:
+  ipa:
     name: Generate ${{ github.event.inputs.buildVariant }} IPA
     runs-on: macos-latest
 
@@ -50,6 +50,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@main
         with:
+          key: ios
           create-symlink: true
       
       - name: Execute build
@@ -76,7 +77,7 @@ jobs:
             cd -
           fi
 
-      - name: Upload IPA
+      - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: iOS-${{ github.event.inputs.buildVariant }} build

--- a/.github/workflows/manual_generate_uwp.yml
+++ b/.github/workflows/manual_generate_uwp.yml
@@ -1,0 +1,97 @@
+name: Manual Generate UWP MSIX/MSIXBundle
+on:
+  workflow_dispatch:
+    inputs:
+
+      buildConfiguration:
+        type: choice
+        description: 'Build Configuration'
+        required: true
+        default: 'Release'
+        options: 
+        - Release
+        - Debug
+
+      buildPlatform:
+        type: choice
+        description: 'Build Platform'
+        required: true
+        default: 'Bundle'
+        options: 
+        - Bundle
+        - x64
+        - ARM64
+        - ARM
+
+jobs:
+
+  build-uwp:
+    name: Generate ${{ github.event.inputs.buildConfiguration }} ${{ github.event.inputs.buildPlatform }} UWP
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+        
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.1
+          
+      #- name: Setup cache # We probably need something like MSBuildCache for MSBuild to be able to use cache properly
+      #  id: cache-uwp
+      #  uses: actions/cache@v3
+      #  with:
+      #    path: |
+      #      UWP/${{ github.event.inputs.buildPlatform }}/${{ github.event.inputs.buildConfiguration }}/**
+      #    key: uwp-${{ github.event.inputs.buildConfiguration }}-${{ github.event.inputs.buildPlatform }}
+
+      - name: Testing values
+        run: |
+          # Testing values ...
+          #env
+          echo "Content of [env.GITHUB_WORKSPACE] = ${env.GITHUB_WORKSPACE}"
+          echo "Content of [[env.GITHUB_WORKSPACE]] = ${{env.GITHUB_WORKSPACE}}"
+          echo "Content of [env:GITHUB_WORKSPACE] = ${env:GITHUB_WORKSPACE}"
+          echo "Content of [github.workspace] = ${github.workspace}"
+          echo "Content of [[github.workspace]] = ${{github.workspace}}"
+          echo "double ${{ github.event.inputs.buildConfiguration }}"
+          echo ${{github.workspace}}
+          echo "single ${ github.event.inputs.buildConfiguration }"
+          echo $env:GITHUB_WORKSPACE
+      
+      - name: Execute MSIX build
+        working-directory: ${{ github.workspace }}
+        env:
+          INCLUDE_SYMBOLS: ${{ github.event.inputs.buildConfiguration == 'Debug' && 'true' || 'false' }}
+        if: ${{ github.event.inputs.buildPlatform != 'Bundle' }}
+        run: |
+          echo "include symbols = ${{ env.INCLUDE_SYMBOLS }}"
+          msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=${{ github.event.inputs.buildPlatform }} /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=true /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Never /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="${{ github.event.inputs.buildPlatform }}"
+
+      - name: Execute MSIXBundle build
+        working-directory: ${{ github.workspace }}
+        env:
+          INCLUDE_SYMBOLS: ${{ github.event.inputs.buildConfiguration == 'Debug' && 'true' || 'false' }}
+        if: ${{ github.event.inputs.buildPlatform == 'Bundle' }}
+        run: |
+          echo "include symbols = ${{ env.INCLUDE_SYMBOLS }}"
+          msbuild UWP/PPSSPP_UWP.sln /m /p:TrackFileAccess=false /p:Configuration=${{ github.event.inputs.buildConfiguration }} /p:Platform=x64 /p:IncludeSymbols=${{ env.INCLUDE_SYMBOLS }} /p:AppxSymbolPackageEnabled=${{ env.INCLUDE_SYMBOLS }} /p:AppxPackageSigningEnabled=true /p:PackageCertificateKeyFile=PPSSPP_UWP_TemporaryKey.pfx /p:AppxBundle=Always /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundlePlatforms="x64|ARM64|ARM"
+          
+      - name: Package build
+        working-directory: ${{ github.workspace }}
+        run: |
+          # Testing file location ...
+          #find . -name "PPSSPP*.exe"
+          #find . -name "*.appx*"
+          #find . -name "*.msix*"
+          mkdir ppsspp
+          #ls UWP/AppPackages/PPSSPP_UWP
+          cp -r UWP/AppPackages/PPSSPP_UWP/*.* ppsspp/
+          #ls ppsspp
+          
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: UWP-${{ github.event.inputs.buildConfiguration }}-${{ github.event.inputs.buildPlatform }} build
+          path: ppsspp/


### PR DESCRIPTION
Since we don't have UWP artifacts, here we go.

This will allow people to build UWP Package (Sideloading only) in `.msix` file when selecting a single platform, or `.msixbundle` file when selecting `Bundle` (contains all supported platforms).

PS: Symbol files only included on debug builds.

I also made minor changes to the APK and IPA workflows.