### PR TITLE
Add "Analog trigger threshold" setting, for conversion of analog trigger inputs to digital button inputs.

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -827,6 +827,7 @@ static const ConfigSetting controlSettings[] = {
 	ConfigSetting("AnalogAutoRotSpeed", &g_Config.fAnalogAutoRotSpeed, 8.0f, CfgFlag::PER_GAME),
 
 	ConfigSetting("AnalogLimiterDeadzone", &g_Config.fAnalogLimiterDeadzone, 0.6f, CfgFlag::DEFAULT),
+	ConfigSetting("AnalogTriggerThreshold", &g_Config.fAnalogTriggerThreshold, 0.75f, CfgFlag::DEFAULT),
 
 	ConfigSetting("AllowMappingCombos", &g_Config.bAllowMappingCombos, false, CfgFlag::DEFAULT),
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -396,6 +396,9 @@ public:
 	// Sets up how much the analog limiter button restricts digital->analog input.
 	float fAnalogLimiterDeadzone;
 
+	// Trigger configuration
+	float fAnalogTriggerThreshold;
+
 	// Sets whether combo mapping is enabled.
 	bool bAllowMappingCombos;
 

--- a/Core/ControlMapper.h
+++ b/Core/ControlMapper.h
@@ -93,3 +93,4 @@ private:
 };
 
 void ConvertAnalogStick(float x, float y, float *outX, float *outY);
+float GetDeviceAxisThreshold(int device, const InputMapping &mapping);

--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -48,6 +48,25 @@ std::set<std::string> g_seenPads;
 std::map<InputDeviceID, std::string> g_padNames;
 std::set<InputDeviceID> g_seenDeviceIds;
 
+AxisType GetAxisType(InputAxis input) {
+	switch (input) {
+	case JOYSTICK_AXIS_GAS:
+	case JOYSTICK_AXIS_BRAKE:
+	case JOYSTICK_AXIS_LTRIGGER:
+	case JOYSTICK_AXIS_RTRIGGER:
+		return AxisType::TRIGGER;
+	case JOYSTICK_AXIS_X:
+	case JOYSTICK_AXIS_Y:
+	case JOYSTICK_AXIS_Z:
+	case JOYSTICK_AXIS_RX:
+	case JOYSTICK_AXIS_RY:
+	case JOYSTICK_AXIS_RZ:
+		return AxisType::STICK;
+	default:
+		return AxisType::OTHER;
+	}
+}
+
 // Utility for UI navigation
 void SingleInputMappingFromPspButton(int btn, std::vector<InputMapping> *mappings, bool ignoreMouse) {
 	std::vector<MultiInputMapping> multiMappings;
@@ -874,7 +893,7 @@ bool HasChanged(int &prevGeneration) {
 	return false;
 }
 
-static const char *g_vKeyNames[] = {
+static const char * const g_vKeyNames[] = {
 	"AXIS_X_MIN",
 	"AXIS_Y_MIN",
 	"AXIS_X_MAX",

--- a/Core/KeyMap.h
+++ b/Core/KeyMap.h
@@ -78,10 +78,6 @@ enum {
 	VIRTKEY_COUNT = VIRTKEY_LAST - VIRTKEY_FIRST
 };
 
-const float AXIS_BIND_THRESHOLD = 0.75f;
-const float AXIS_BIND_RELEASE_THRESHOLD = 0.35f;  // Used during mapping only to detect a "key-up" reliably.
-const float AXIS_BIND_THRESHOLD_MOUSE = 0.01f;
-
 struct MappedAnalogAxis {
 	int axisId;
 	int direction;
@@ -224,4 +220,13 @@ namespace KeyMap {
 	bool IsKeyMapped(InputDeviceID device, int key);
 
 	bool HasChanged(int &prevGeneration);
+
+	// Used for setting thresholds. Technically we could allow a setting per axis, but this is a reasonable compromise.
+	enum class AxisType {
+		TRIGGER,
+		STICK,
+		OTHER,
+	};
+
+	AxisType GetAxisType(InputAxis axis);
 }  // namespace KeyMap

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -600,6 +600,7 @@ ReplacedTexture *TextureReplacer::FindReplacement(u64 cachekey, u32 hash, int w,
 		desc.hashfiles = hashfiles;
 	}
 
+	_dbg_assert_(!hashfiles.empty());
 	// OK, we might already have a matching texture, we use hashfiles as a key. Look it up in the level cache.
 	auto iter = levelCache_.find(hashfiles);
 	if (iter != levelCache_.end()) {

--- a/Tools/langtool/Cargo.lock
+++ b/Tools/langtool/Cargo.lock
@@ -76,9 +76,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "proc-macro-error"
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
 dependencies = [
  "unicode-ident",
 ]

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -441,6 +441,10 @@ bool KeyMappingNewMouseKeyDialog::key(const KeyInput &key) {
 	return true;
 }
 
+// Only used during the bind process. In other places, it's configurable for some types of axis, like trigger.
+const float AXIS_BIND_THRESHOLD = 0.75f;
+const float AXIS_BIND_RELEASE_THRESHOLD = 0.35f;  // Used during mapping only to detect a "key-up" reliably.
+
 void KeyMappingNewKeyDialog::axis(const AxisInput &axis) {
 	if (time_now_d() < delayUntil_)
 		return;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -669,6 +669,7 @@ void GameSettingsScreen::CreateControlsSettings(UI::ViewGroup *controlsSettings)
 	controlsSettings->Add(new ItemHeader(ms->T("Controls")));
 	controlsSettings->Add(new Choice(co->T("Control Mapping")))->OnClick.Handle(this, &GameSettingsScreen::OnControlMapping);
 	controlsSettings->Add(new Choice(co->T("Calibrate Analog Stick")))->OnClick.Handle(this, &GameSettingsScreen::OnCalibrateAnalogs);
+	controlsSettings->Add(new PopupSliderChoiceFloat(&g_Config.fAnalogTriggerThreshold, 0.25f, 0.98f, 0.75f, co->T("Analog trigger threshold"), screenManager()));
 
 #if defined(USING_WIN_UI) || (PPSSPP_PLATFORM(LINUX) && !PPSSPP_PLATFORM(ANDROID))
 	controlsSettings->Add(new CheckBox(&g_Config.bSystemControls, co->T("Enable standard shortcut keys")));

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -90,6 +90,7 @@ Analog Limiter = ‎محدد التناظري
 Analog Settings = Analog Settings
 Analog Stick = ‎عصا تناظرية
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = ‎حينما يتم ضغط زر تحديد التناظر
 Auto = ‎تلقائي
 Auto-centering analog stick = ‎تنصيف العصا التناظرية تلقائياً

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analog limiter
 Analog Settings = Analog Settings
 Analog Stick = Analog stick
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = When the analog limiter button is pressed
 Auto = Auto
 Auto-centering analog stick = Auto-centering analog stick

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analog limiter
 Analog Settings = Analog Settings
 Analog Stick = Analog stick
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = When the analog limiter button is pressed
 Auto = Автоматично
 Auto-centering analog stick = Auto-centering analog stick

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -82,6 +82,7 @@ Analog Limiter = Limitador analògic
 Analog Settings = Configuració de l'stick
 Analog Stick = Palanca analògica
 Analog Style = Estil de l'stick
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Quan es prem el botó del limitador de l'stick
 Auto = Automàtic
 Auto-centering analog stick = Auto centrat de l'stick

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analogový omezovač
 Analog Settings = Analog Settings
 Analog Stick = Analogová páčka
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = When the analog limiter button is pressed
 Auto = Auto
 Auto-centering analog stick = Automatické vystředění analogové páčky

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analog begrænser
 Analog Settings = Analog Settings
 Analog Stick = Analog stick
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Når den analoge begrænser knap er trykket ned
 Auto = Automatisk
 Auto-centering analog stick = Auto-centering analog stick

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analogbegrenzer
 Analog Settings = Analog Einstellungen
 Analog Stick = Analogstick
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Wenn die Analogbegrenzer-Taste gedrückt ist
 Auto = Automatisch
 Auto-centering analog stick = Analogstick automatisch zentrieren

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analog limiter
 Analog Settings = Analog Settings
 Analog Stick = Analog stick
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = When the analog limiter button is pressed
 Auto = Auto
 Auto-centering analog stick = Auto-centering analog stick

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -106,6 +106,7 @@ Analog Limiter = Analog limiter
 Analog Settings = Analog Settings
 Analog Stick = Analog stick
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = When the analog limiter button is pressed
 Auto = Auto
 Auto-centering analog stick = Auto-centering analog stick

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -80,6 +80,7 @@ WASAPI (fast) = WASAPI (rápido)
 Analog Binding = Asignar stick
 Analog Settings = Ajustes de stick
 Analog Style = Estilo de stick
+Analog trigger threshold = Analog trigger threshold
 Auto-rotation speed = Velocidad auto rotación del stick
 Analog Limiter = Limitador del stick
 Analog Stick = Stick izquierdo

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -80,6 +80,7 @@ WASAPI (fast) = WASAPI (rápido)
 Analog Binding = Asignar análogo
 Analog Settings = Config. del análogo
 Analog Style = Estilo del análogo
+Analog trigger threshold = Analog trigger threshold
 Auto-rotation speed = Vel. de rotación auto. del análogo
 Analog Limiter = Limitador del análogo
 Analog Stick = Analog stick

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -82,6 +82,7 @@ Analog Limiter = ‎محدود کننده آنالوگ
 Analog Settings = تنظیمات انالوگ
 Analog Stick = ‎دسته آنالوگ
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = ‎هنگامی که دکمه محدود کننده آنالوگ فشرده شود
 Auto = ‎اتوماتیک
 Auto-centering analog stick = ‎تنظیم مرکز آنالوگ به صورت خودکار

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analoginen rajoitin
 Analog Settings = Analogisen asetukset
 Analog Stick = Analoginen sauva
 Analog Style = Analogisen tyyli
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Kun analogisen rajoittimen näppäintä painetaan
 Auto = Automaattinen
 Auto-centering analog stick = Automaattisesti keskittävä analoginen sauva

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -80,6 +80,7 @@ WASAPI (fast) = WASAPI (rapide)
 Analog Binding = Analog Binding
 Analog Settings = Analog Settings
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 Auto-rotation speed = Vitesse de rotation automatique du stick analogique
 Analog Limiter = Limiteur analogique
 Analog Stick = Stick analogique

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -82,6 +82,7 @@ Analog Limiter = Limitador analóxico
 Analog Settings = Analog Settings
 Analog Stick = Stick analóxico
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = When the analog limiter button is pressed
 Auto = Automática
 Auto-centering analog stick = Auto-centering analog stick

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -82,6 +82,7 @@ Analog Limiter = Περιορισμός αναλογικού
 Analog Settings = Analog Settings
 Analog Stick = Αναλογικός μοχλός
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Όταν το κουμπί περιορισμού αναλογικού είναι πατημένο
 Auto = Αυτόματο
 Auto-centering analog stick = Αυτόματος κεντρισμός αναλογικού μοχλού

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analog limiter
 Analog Settings = Analog Settings
 Analog Stick = Analog stick
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = When the analog limiter button is pressed
 Auto = Auto
 Auto-centering analog stick = Auto-centering analog stick

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analog limiter
 Analog Settings = Analog Settings
 Analog Stick = Analog stick
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = When the analog limiter button is pressed
 Auto = Auto
 Auto-centering analog stick = Auto-centering analog stick

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -80,6 +80,7 @@ WASAPI (fast) = WASAPI (brzo)
 Analog Binding = Analog Binding
 Analog Settings = Analog Settings
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 Auto-rotation speed = Auto-Rotacija analogne brzine
 Analog Limiter = Analogni ograničivač
 Analog Stick = Analogni stick

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -80,6 +80,7 @@ WASAPI (fast) = WASAPI (gyors)
 Analog Binding = Analog Binding
 Analog Settings = Analog Settings
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 Auto-rotation speed = Automata analóg forgató sebessége
 Analog Limiter = Analóg korlátozó
 Analog Stick = Analóg kar

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -82,6 +82,7 @@ Analog Limiter = Pembatas analog
 Analog Settings = Pengaturan analog
 Analog Stick = Stik analog
 Analog Style = Gaya analog
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Ketika tombol pembatas analog ditekan
 Auto = Otomatis
 Auto-centering analog stick = Penengahan otomatis stik analog

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -82,6 +82,7 @@ Analog Limiter = Limitatore Analogico
 Analog Settings = Impostazioni Analogico
 Analog Stick = Stick Analogico
 Analog Style = Stile Analogico
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Quando viene premuto il tasto del limitatore analogico
 Auto = Automatico
 Auto-centering analog stick = Auto-centramento dello stick analogico

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -80,6 +80,7 @@ WASAPI (fast) = WASAPI (高速)
 Analog Binding = 右アナログパッドへの対応ボタン割り当て
 Analog Settings = アナログパッドの設定
 Analog Style = 右アナログパッドのスタイル
+Analog trigger threshold = Analog trigger threshold
 Auto-rotation speed = アナログの自動回転速度
 Analog Limiter = アナログパッドのリミッタ
 Analog Stick = アナログパッド

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analog limiter
 Analog Settings = Analog Settings
 Analog Stick = Analog stick
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = When the analog limiter button is pressed
 Auto = Otomatis
 Auto-centering analog stick = Otomatis Analog stick nang tengah

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -82,6 +82,7 @@ Analog Limiter = 아날로그 리미터
 Analog Settings = 아날로그 설정
 Analog Stick = 아날로그 스틱
 Analog Style = 아날로그 스타일
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = 아날로그 리미터 버튼을 눌렀을 때
 Auto = 자동
 Auto-centering analog stick = 자동 센터링 아날로그 스틱

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -82,6 +82,7 @@ Analog Limiter = ໂຕຈຳກັດອະນາລ໋ອກ
 Analog Settings = Analog Settings
 Analog Stick = ປຸ່ມອະນາລ໋ອກ
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = ເມື່ອກົດທີ່ຂອບປຸ່ມອະນາລ໋ອກ ໂຕຈຳກັດອະນາລ໋ອກຈະເຮັດວຽກ
 Auto = ອັດຕະໂນມັດ
 Auto-centering analog stick = ອະນາລ໋ອກກັບຄືນຈຸດສູນກາງອັດຕະໂນມັດ

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analog limiter
 Analog Settings = Analog Settings
 Analog Stick = Analoginė svirtelė
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = When the analog limiter button is pressed
 Auto = Automatinis
 Auto-centering analog stick = Auto-centering analog stick

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analog limiter
 Analog Settings = Analog Settings
 Analog Stick = Analog stick
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = When the analog limiter button is pressed
 Auto = Auto
 Auto-centering analog stick = Auto-centering analog stick

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analooglimiet
 Analog Settings = Analog Settings
 Analog Stick = Analoge stick
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Wanneer de analooglimiettoets is ingedrukt
 Auto = Automatisch
 Auto-centering analog stick = Analoge stick automatisch centreren

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analog limiter
 Analog Settings = Analog Settings
 Analog Stick = Analog stick
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = When the analog limiter button is pressed
 Auto = Auto
 Auto-centering analog stick = Auto-centering analog stick

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -82,6 +82,7 @@ Analog Limiter = Ogranicznik Analoga
 Analog Settings = Ustawienia Analoga
 Analog Stick = Gałka Analogowa
 Analog Style = Styl Analoga
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Jeśli "Ogranicznik Analoga" jest aktywny
 Auto = Automatyczny
 Auto-centering analog stick = Autocentrowanie analoga

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -106,6 +106,7 @@ Analog Limiter = Limitador do analógico
 Analog Settings = Configurações do Analógico
 Analog Stick = Direcional analógico
 Analog Style = Estilo do Analógico
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Quando o botão limitador do analógico é pressionado
 Auto = Automático
 Auto-centering analog stick = Auto-centralizar o direcional analógico

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -106,6 +106,7 @@ Analog Limiter = Limitador do Analógico
 Analog Settings = Definições do Analógico
 Analog Stick = Analógico
 Analog Style = Estilo do Analógico
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Quando o botão limitador do analógico é pressionado
 Auto = Automático
 Auto-centering analog stick =Centralização automática do analógico

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -82,6 +82,7 @@ Analog Limiter = Limită pt. control analog
 Analog Settings = Analog Settings
 Analog Stick = Butonul analog
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Când este apasat butonul de limitare control analog
 Auto = Automat
 Auto-centering analog stick = Centrare automată a butonului analog

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -82,6 +82,7 @@ Analog Limiter = Аналоговый ограничитель
 Analog Settings = Настройки аналогового стика
 Analog Stick = Аналоговый стик
 Analog Style = Стиль стика
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Когда нажата кнопка аналогового ограничителя
 Auto = Авто
 Auto-centering analog stick = Автоцентрируемый стик

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analog fartkontroll
 Analog Settings = Inställningar för analog spak
 Analog Stick = Analog styrspak
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = When the analog limiter button is pressed
 Auto = Auto
 Auto-centering analog stick = Auto-centrerande analog styrspak

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -82,6 +82,7 @@ Analog Limiter = Taga limit ng analog
 Analog Settings = Ayusin ang analog
 Analog Stick = Analog stick
 Analog Style = Analog style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Kapag ang pindutan ng analog limiter ay mapindot
 Auto = Awto
 Auto-centering analog stick = Awtomatikong-isentro ang analog stick

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -82,6 +82,7 @@ Analog Limiter = ตัวจำกัดปุ่มอนาล็อก
 Analog Settings = ตั้งค่าปุ่มอนาล็อก
 Analog Stick = ปุ่มอนาล็อก
 Analog Style = สไตล์ของปุ่มอนาล็อก
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = เมื่อกดที่ขอบปุ่มอนาล็อก ตัวจำกัดอนาล็อกจะทำงาน
 Auto = อัตโนมัติ
 Auto-centering analog stick = อนาล็อกกลับคืนจุดศูนย์กลางอัตโนมัติ

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -82,6 +82,7 @@ Analog Limiter = Analog sınırlayıcı
 Analog Settings = Analog Ayarları
 Analog Stick = Analog çubuk
 Analog Style = Analog Biçimi
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Analog sınırlayıcı tuşuna basınca
 Auto = Otomatik
 Auto-centering analog stick = Analog çubuğu otomatik ortala

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -80,6 +80,7 @@ WASAPI (fast) = WASAPI (швидко)
 Analog Binding = Analog Binding
 Analog Settings = Analog Settings
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 Auto-rotation speed = Швидкість автоматичного обертання аналогу
 Analog Limiter = Аналоговий обмежувач
 Analog Stick = Аналоговий стік

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -82,6 +82,7 @@ Analog Limiter = Phạm vi của Analog
 Analog Settings = Analog Settings
 Analog Stick = Cần Analog
 Analog Style = Analog Style
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = Khi phạm vi của analog được chọn
 Auto = Tự động
 Auto-centering analog stick = Cần Analog auto định tâm

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -80,6 +80,7 @@ WASAPI (fast) = WASAPI (快)
 Analog Binding = 摇杆绑定
 Analog Settings = 摇杆设置
 Analog Style = 摇杆样式
+Analog trigger threshold = Analog trigger threshold
 Auto-rotation speed = 自动旋转速度
 Analog Limiter = 摇杆限制
 Analog Stick = 摇杆

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -82,6 +82,7 @@ Analog Limiter = 類比限制器
 Analog Settings = 類比設定
 Analog Stick = 類比搖桿
 Analog Style = 類比樣式
+Analog trigger threshold = Analog trigger threshold
 AnalogLimiter Tip = 類比限制器按鈕被按下時
 Auto = 自動
 Auto-centering analog stick = 自動置中類比搖桿


### PR DESCRIPTION
See comment: https://github.com/hrydgard/ppsspp/issues/8414#issuecomment-1871095394

Previously this was hard-coded at 75%.

This sets the sensitivity specifically for trigger-like inputs (triggerL/R, gas/brake). Other analog inputs are not affected.