### PR TITLE
Remote game streaming: Add an option to put a tab on the main screen

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -265,6 +265,7 @@ static const ConfigSetting generalSettings[] = {
 	ConfigSetting("RemoteShareOnStartup", &g_Config.bRemoteShareOnStartup, false, CfgFlag::DEFAULT),
 	ConfigSetting("RemoteISOSubdir", &g_Config.sRemoteISOSubdir, "/", CfgFlag::DEFAULT),
 	ConfigSetting("RemoteDebuggerOnStartup", &g_Config.bRemoteDebuggerOnStartup, false, CfgFlag::DEFAULT),
+	ConfigSetting("RemoteTab", &g_Config.bRemoteTab, false, CfgFlag::DEFAULT),
 
 #ifdef __ANDROID__
 	ConfigSetting("ScreenRotation", &g_Config.iScreenRotation, ROTATION_AUTO_HORIZONTAL),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -129,6 +129,7 @@ public:
 	bool bRemoteShareOnStartup;
 	std::string sRemoteISOSubdir;
 	bool bRemoteDebuggerOnStartup;
+	bool bRemoteTab;
 	bool bMemStickInserted;
 	int iMemStickSizeGB;
 	bool bLoadPlugins;

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -32,10 +32,11 @@ enum GameBrowserFlags {
 enum class BrowseFlags {
 	NONE = 0,
 	NAVIGATE = 1,
-	ARCHIVES = 2,
-	PIN = 4,
-	HOMEBREW_STORE = 8,
-	STANDARD = 1 | 2 | 4,
+	BROWSE = 2,
+	ARCHIVES = 4,
+	PIN = 8,
+	HOMEBREW_STORE = 16,
+	STANDARD = 1 | 2 | 4 | 8,
 };
 ENUM_CLASS_BITOPS(BrowseFlags);
 
@@ -55,6 +56,10 @@ public:
 	void Draw(UIContext &dc) override;
 	void Update() override;
 
+	void SetHomePath(const Path &path) {
+		homePath_ = path;
+	}
+
 protected:
 	virtual bool DisplayTopBar();
 	virtual bool HasSpecialFiles(std::vector<Path> &filenames);
@@ -62,6 +67,8 @@ protected:
 	void ApplySearchFilter();
 
 	void Refresh();
+
+	Path homePath_;
 
 private:
 	bool IsCurrentPathPinned();

--- a/UI/RemoteISOScreen.h
+++ b/UI/RemoteISOScreen.h
@@ -85,7 +85,8 @@ protected:
 
 class RemoteISOBrowseScreen : public MainScreen {
 public:
-	RemoteISOBrowseScreen(const std::string &url, const std::vector<Path> &games);
+	RemoteISOBrowseScreen(const std::string &url, const std::vector<Path> &games)
+		: url_(url), games_(games) {}
 
 	const char *tag() const override { return "RemoteISOBrowse"; }
 
@@ -110,3 +111,6 @@ protected:
 
 	bool serverRunning_ = false;
 };
+
+std::string RemoteSubdir();
+std::string FormatRemoteISOUrl(const char *host, int port, const char *subdir);

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -1058,6 +1058,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = ‎إعدادات
 Share Games (Server) = ‎مشاركة الألعاب (السرفر)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = ‎توقف عن المشاركة
 Stopping.. = ‎يتوقف...
 

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Einstellungen
 Share Games (Server) = Spiele freigeben (Server)
 Share on PPSSPP startup = Beim Start von PPSSPP freigeben
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Freigabe stoppen
 Stopping.. = Stoppe...
 

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -1074,6 +1074,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -1051,6 +1051,7 @@ RemoteISOWinFirewall = AVISO: Firewall de Windows está bloqueando el acceso
 Settings = Ajustes
 Share Games (Server) = Compartir juegos (servidor)
 Share on PPSSPP startup = Compartir al iniciar PPSSPP
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Parar de compartir
 Stopping.. = Parando...
 

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -1052,6 +1052,7 @@ RemoteISOWinFirewall = ADVERTENCIA: cortafuegos de Windows está bloqueando el a
 Settings = Opciones
 Share Games (Server) = Compartir juegos (servidor)
 Share on PPSSPP startup = Compartir al empezar PSSPP
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Parar
 Stopping.. = Deteniendo...
 

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = VAROITUS: Windowsin palomuuri estää jakamisen
 Settings = Asetukset
 Share Games (Server) = Jaa pelejä (palvelin)
 Share on PPSSPP startup = Jaa käynnistyksen yhteydessä
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Lopeta jakaminen
 Stopping.. = Lopetetaan...
 

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -1041,6 +1041,7 @@ RemoteISOWinFirewall = AVERTISSEMENT : Le pare-feu Windows bloque le partage.
 Settings = Paramètres
 Share Games (Server) = Partager les jeux (serveur)
 Share on PPSSPP startup = Partager au démarrage de PPSSPP
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Arrêter le partage
 Stopping.. = Arrêt en cours...
 

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Ρυθμίσεις
 Share Games (Server) = Διαμοιρασμός παιχνιδιών (διακομιστής)
 Share on PPSSPP startup = Διαμοιρασμός κατά την εκκίνηση PPSSPP
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Διακοπή διαμοιρασμού
 Stopping.. = Διακοπή...
 

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Vatrozid blokira dijeljenje
 Settings = Postavke
 Share Games (Server) = Dijeli igre (server)
 Share on PPSSPP startup = Dijeli kada se PPSSPP upali
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Zaustavi dijeljenje
 Stopping.. = Zaustavljanje...
 

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Beállítások
 Share Games (Server) = Játékok megosztása (szerver)
 Share on PPSSPP startup = Játékok megosztása a PPSSPP indulásakor
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Megosztás leállítása
 Stopping.. = Leállítás alatt...
 

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = Peringatan: Windows firewall memblokir berbagi
 Settings = Pengaturan
 Share Games (Server) = Bagikan permainan (pelayan)
 Share on PPSSPP startup = Bagikan saat memulai PPSSPP
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Hentikan pembagian
 Stopping.. = Menghentikan...
 

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -1051,6 +1051,7 @@ RemoteISOWinFirewall = ATTENZIONE: Il firewall di Windows sta bloccando la condi
 Settings = Impostazioni
 Share Games (Server) = Giochi condivisi (server)
 Share on PPSSPP startup = Condividi all'avvio di PPSSPP
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Interrompi condivisione
 Stopping.. = Interruzione in corso...
 

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = 警告: Windowsファイアウォールが共有をブロ
 Settings = 設定
 Share Games (Server) = ゲームをシェアする (サーバ)
 Share on PPSSPP startup = PPSSPPの起動時にシェアする
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = シェアを停止する
 Stopping.. = 停止しています...
 

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = 경고: Windows 방화벽이 공유를 차단하고 있�
 Settings = 설정
 Share Games (Server) = 게임 공유하기 (서버)
 Share on PPSSPP startup = PPSSPP 시작시 자동으로 공유하기
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = 공유 끝내기
 Stopping.. = 중지하는 중...
 

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Instellingen
 Share Games (Server) = Games delen (server)
 Share on PPSSPP startup = Delen wanneer PPSSPP opstart
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stoppen met delen
 Stopping.. = Stoppen...
 

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -1056,6 +1056,7 @@ RemoteISOWinFirewall = UWAGA: Zapora ogniowa Windows blokuje udostępnianie
 Settings = Ustawienia
 Share Games (Server) = Udostępniaj gry (serwer)
 Share on PPSSPP startup = Udostępniaj przy starcie PPSSPP
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Zatrzymaj udostępnianie
 Stopping.. = Zatrzymywanie...
 

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -1074,6 +1074,7 @@ RemoteISOWinFirewall = AVISO: O Firewall do Windows está bloqueando o compartil
 Settings = Configurações
 Share Games (Server) = Compartilhar jogos (servidor)
 Share on PPSSPP startup = Compartilhar na inicialização do PPSSPP
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Parar com o compartilhamento
 Stopping.. = Parando...
 

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -1076,6 +1076,7 @@ RemoteISOWinFirewall = AVISO: O Firewall do Windows está a bloquear o partilham
 Settings = Definições
 Share Games (Server) = Partilhar Jogos (servidor)
 Share on PPSSPP startup = Partilhar na inicialização do PPSSPP
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Parar o partilhamento
 Stopping.. = A parar...
 

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -1051,6 +1051,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = ВНИМАНИЕ: Брандмауэр Windows блоки
 Settings = Настройки
 Share Games (Server) = Поделиться играми (сервер)
 Share on PPSSPP startup = Поделиться при запуске PPSSPP
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Остановить передачу
 Stopping.. = Остановка...
 

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -1051,6 +1051,7 @@ RemoteISOWinFirewall = VARNING: Windows Firewall blockerar delning
 Settings = Inställningar
 Share Games (Server) = Dela spel (server)
 Share on PPSSPP startup = Börja dela när PPSSPP startar
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Sluta dela
 Stopping.. = Slutar...
 

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = BABALA: Windows Firewall is blocking sharing
 Settings = Settings
 Share Games (Server) = Share games (server)
 Share on PPSSPP startup = Share on PPSSPP startup
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Stop sharing
 Stopping.. = Stopping...
 

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = คำเตือน: ไฟร์วอลล์ขอ�
 Settings = ตั้งค่า
 Share Games (Server) = แชร์เกม (เซิร์ฟเวอร์)
 Share on PPSSPP startup = แชร์เมื่อเริ่มต้น PPSSPP
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = หยุดแชร์
 Stopping.. = กำลังหยุด...
 

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -1051,6 +1051,7 @@ RemoteISOWinFirewall = UYARI: Windows Güvenlik Duvarı paylaşımı engelliyor
 Settings = Ayarlar
 Share Games (Server) = Oyunları paylaş (sunucu)
 Share on PPSSPP startup = PPSSPP açılışında paylaşın
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Paylaşmayı durdur
 Stopping.. = Durduruluyor...
 

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = УВАГА: Брандмауер Windows блокує с�
 Settings = Налаштування
 Share Games (Server) = Поділитися іграми (сервер)
 Share on PPSSPP startup = Поділитися при запуску PPSSPP
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Припинити ділитися
 Stopping.. = Зупинка...
 

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = WARNING: Windows Firewall is blocking sharing
 Settings = Cài đặt
 Share Games (Server) = Chia sẻ (server)
 Share on PPSSPP startup = Bắt đầu chia sẻ trong PPSSPP
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = Dừng chia sẻ
 Stopping.. = Đang dừng...
 

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -1051,6 +1051,7 @@ RemoteISOWinFirewall = 警告：Windows防火墙正在阻挡游戏共享
 Settings = 设置
 Share Games (Server) = 共享游戏 (服务器)
 Share on PPSSPP startup = PPSSPP启动时共享
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = 停止共享
 Stopping.. = 正在停止…
 

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -1050,6 +1050,7 @@ RemoteISOWinFirewall = 警告：Windows 防火牆已封鎖共用
 Settings = 設定
 Share Games (Server) = 共用遊戲 (伺服器)
 Share on PPSSPP startup = PPSSPP 啟動時共用
+Show Remote tab on main screen = Show Remote tab on main screen
 Stop Sharing = 停止共用
 Stopping.. = 正在停止…
 


### PR DESCRIPTION
Fixes #18317 

Also removes the "Browse..." button from the remote game stream browser, it wasn't relevant.