### PR TITLE
Remote ISO: Allow sharing a full folder instead of Recent

### DIFF
--- a/Common/StringUtils.cpp
+++ b/Common/StringUtils.cpp
@@ -356,12 +356,15 @@ void GetQuotedStrings(const std::string& str, std::vector<std::string> &output) 
 	}
 }
 
-std::string ReplaceAll(std::string result, const std::string& src, const std::string& dest) {
+std::string ReplaceAll(std::string_view input, std::string_view src, std::string_view dest) {
 	size_t pos = 0;
+
+	std::string result(input);
 
 	if (src == dest)
 		return result;
 
+	// TODO: Don't mutate the input, just append stuff to the output instead.
 	while (true) {
 		pos = result.find(src, pos);
 		if (pos == result.npos)

--- a/Common/StringUtils.h
+++ b/Common/StringUtils.h
@@ -87,7 +87,7 @@ void SplitString(std::string_view str, const char delim, std::vector<std::string
 
 void GetQuotedStrings(const std::string& str, std::vector<std::string>& output);
 
-std::string ReplaceAll(std::string input, const std::string& src, const std::string& dest);
+std::string ReplaceAll(std::string_view input, std::string_view src, std::string_view dest);
 
 // Takes something like R&eplace and returns Replace, plus writes 'e' to *shortcutChar
 // if not nullptr. Useful for Windows menu strings.

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -266,6 +266,8 @@ static const ConfigSetting generalSettings[] = {
 	ConfigSetting("RemoteISOSubdir", &g_Config.sRemoteISOSubdir, "/", CfgFlag::DEFAULT),
 	ConfigSetting("RemoteDebuggerOnStartup", &g_Config.bRemoteDebuggerOnStartup, false, CfgFlag::DEFAULT),
 	ConfigSetting("RemoteTab", &g_Config.bRemoteTab, false, CfgFlag::DEFAULT),
+	ConfigSetting("RemoteISOSharedDir", &g_Config.sRemoteISOSharedDir, "", CfgFlag::DEFAULT),
+	ConfigSetting("RemoteISOShareType", &g_Config.iRemoteISOShareType, (int)RemoteISOShareType::RECENT, CfgFlag::DEFAULT),
 
 #ifdef __ANDROID__
 	ConfigSetting("ScreenRotation", &g_Config.iScreenRotation, ROTATION_AUTO_HORIZONTAL),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -128,6 +128,8 @@ public:
 	bool bRemoteISOManual;
 	bool bRemoteShareOnStartup;
 	std::string sRemoteISOSubdir;
+	std::string sRemoteISOSharedDir;
+	int iRemoteISOShareType;
 	bool bRemoteDebuggerOnStartup;
 	bool bRemoteTab;
 	bool bMemStickInserted;

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -182,3 +182,8 @@ enum class SkipGPUReadbackMode : int {
 	SKIP,
 	COPY_TO_TEXTURE,
 };
+
+enum class RemoteISOShareType : int {
+	RECENT,
+	LOCAL_FOLDER,
+};

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -142,6 +142,12 @@ bool RemoteISOFileSupported(const std::string &filename) {
 }
 
 static std::string RemotePathForRecent(const std::string &filename) {
+	Path path(filename);
+	if (path.Type() == PathType::HTTP) {
+		// Don't re-share HTTP files from some other device.
+		return std::string();
+	}
+
 #ifdef _WIN32
 	static const std::string sep = "\\/";
 #else
@@ -161,7 +167,8 @@ static std::string RemotePathForRecent(const std::string &filename) {
 	if (RemoteISOFileSupported(basename)) {
 		return ServerUriEncode(basename);
 	}
-	return "";
+
+	return std::string();
 }
 
 static Path LocalFromRemotePath(const std::string &path) {

--- a/Core/WebServer.cpp
+++ b/Core/WebServer.cpp
@@ -22,10 +22,12 @@
 #include "Common/Net/HTTPClient.h"
 #include "Common/Net/HTTPServer.h"
 #include "Common/Net/Sinks.h"
+#include "Common/Net/URL.h"
 #include "Common/Thread/ThreadUtil.h"
 #include "Common/Log.h"
 #include "Common/File/FileUtil.h"
 #include "Common/File/FileDescriptor.h"
+#include "Common/File/DirListing.h"
 #include "Common/File/VFS/VFS.h"
 #include "Common/TimeUtil.h"
 #include "Common/StringUtils.h"
@@ -48,6 +50,16 @@ static std::thread serverThread;
 static ServerStatus serverStatus;
 static std::mutex serverStatusLock;
 static int serverFlags;
+
+// NOTE: These *only* encode spaces, which is really enough.
+
+std::string ServerUriEncode(std::string_view plain) {
+	return ReplaceAll(plain, " ", "%20");
+}
+
+std::string ServerUriDecode(std::string_view encoded) {
+	return ReplaceAll(encoded, "%20", " ");
+}
 
 static void UpdateStatus(ServerStatus s) {
 	std::lock_guard<std::mutex> guard(serverStatusLock);
@@ -147,19 +159,29 @@ static std::string RemotePathForRecent(const std::string &filename) {
 	// Let's not serve directories, since they won't work.  Only single files.
 	// Maybe can do PBPs and other files later.  Would be neat to stream virtual disc filesystems.
 	if (RemoteISOFileSupported(basename)) {
-		return ReplaceAll(basename, " ", "%20");
+		return ServerUriEncode(basename);
 	}
 	return "";
 }
 
 static Path LocalFromRemotePath(const std::string &path) {
-	for (const std::string &filename : g_Config.RecentIsos()) {
-		std::string basename = RemotePathForRecent(filename);
-		if (basename == path) {
-			return Path(filename);
+	switch ((RemoteISOShareType)g_Config.iRemoteISOShareType) {
+	case RemoteISOShareType::RECENT:
+		for (const std::string &filename : g_Config.RecentIsos()) {
+			std::string basename = RemotePathForRecent(filename);
+			if (basename == path) {
+				return Path(filename);
+			}
 		}
+		return Path();
+	case RemoteISOShareType::LOCAL_FOLDER:
+	{
+		std::string decoded = ServerUriDecode(path);
+		return Path(g_Config.sRemoteISOSharedDir) / decoded;
 	}
-	return Path();
+	default:
+		return Path();
+	}
 }
 
 static void DiscHandler(const http::ServerRequest &request, const Path &filename) {
@@ -226,12 +248,30 @@ static void HandleListing(const http::ServerRequest &request) {
 	request.WriteHttpResponseHeader("1.0", 200, -1, "text/plain");
 	request.Out()->Printf("/\n");
 	if (serverFlags & (int)WebServerFlags::DISCS) {
-		// List the current discs in their recent order.
-		for (const std::string &filename : g_Config.RecentIsos()) {
-			std::string basename = RemotePathForRecent(filename);
-			if (!basename.empty()) {
-				request.Out()->Printf("%s\n", basename.c_str());
+		switch ((RemoteISOShareType)g_Config.iRemoteISOShareType) {
+		case RemoteISOShareType::RECENT:
+			// List the current discs in their recent order.
+			for (const std::string &filename : g_Config.RecentIsos()) {
+				std::string basename = RemotePathForRecent(filename);
+				if (!basename.empty()) {
+					request.Out()->Printf("%s\n", basename.c_str());
+				}
 			}
+			break;
+		case RemoteISOShareType::LOCAL_FOLDER:
+		{
+			std::vector<File::FileInfo> entries;
+			File::GetFilesInDir(Path(g_Config.sRemoteISOSharedDir), &entries);
+			for (const auto &entry : entries) {
+				// TODO: Support browsing into subdirs. How are folders marked?
+				if (entry.isDirectory || !RemoteISOFileSupported(entry.name)) {
+					continue;
+				}
+				std::string encoded = ServerUriEncode(entry.name);
+				request.Out()->Printf("%s\n", encoded.c_str());
+			}
+			break;
+		}
 		}
 	}
 	if (serverFlags & (int)WebServerFlags::DEBUGGER) {


### PR DESCRIPTION
Can be convenient. This is backwards-compatible with old builds (old builds can stream these).

Will rework the UI a bit soon, so not adding translation strings properly yet.