### PR TITLE
Add some more RISC-V extensions to emitter

### DIFF
--- a/Common/CPUDetect.h
+++ b/Common/CPUDetect.h
@@ -114,6 +114,11 @@ struct CPUInfo {
 	bool RiscV_Zbb;
 	bool RiscV_Zbc;
 	bool RiscV_Zbs;
+	bool RiscV_Zcb;
+	bool RiscV_Zfa;
+	bool RiscV_Zfh;
+	bool RiscV_Zfhmin;
+	bool RiscV_Zicond;
 
 	// LoongArch specific extension flags.
 	bool LOONGARCH_CPUCFG;

--- a/Common/CPUDetect.h
+++ b/Common/CPUDetect.h
@@ -119,6 +119,8 @@ struct CPUInfo {
 	bool RiscV_Zfh;
 	bool RiscV_Zfhmin;
 	bool RiscV_Zicond;
+	bool RiscV_Zvbb;
+	bool RiscV_Zvkb;
 
 	// LoongArch specific extension flags.
 	bool LOONGARCH_CPUCFG;

--- a/Common/RiscVCPUDetect.cpp
+++ b/Common/RiscVCPUDetect.cpp
@@ -245,6 +245,11 @@ std::vector<std::string> CPUInfo::Features() {
 		{ RiscV_Zbb, "Bitmanip Zbb" },
 		{ RiscV_Zbc, "Bitmanip Zbc" },
 		{ RiscV_Zbs, "Bitmanip Zbs" },
+		{ RiscV_Zcb, "Compress Zcb" },
+		{ RiscV_Zfa, "Float Additional" },
+		{ RiscV_Zfh, "Float Half" },
+		{ RiscV_Zfhmin, "Float Half Minimal" },
+		{ RiscV_Zicond, "Integer Conditional" },
 		{ RiscV_Zicsr, "Zicsr" },
 		{ CPU64bit, "64-bit" },
 	};

--- a/Common/RiscVCPUDetect.cpp
+++ b/Common/RiscVCPUDetect.cpp
@@ -241,6 +241,8 @@ std::vector<std::string> CPUInfo::Features() {
 		{ RiscV_D, "Double" },
 		{ RiscV_C, "Compressed" },
 		{ RiscV_V, "Vector" },
+		{ RiscV_Zvbb, "Vector Basic Bitmanip" },
+		{ RiscV_Zvkb, "Vector Crypto Bitmanip" },
 		{ RiscV_Zba, "Bitmanip Zba" },
 		{ RiscV_Zbb, "Bitmanip Zbb" },
 		{ RiscV_Zbc, "Bitmanip Zbc" },

--- a/Common/RiscVEmitter.cpp
+++ b/Common/RiscVEmitter.cpp
@@ -32,8 +32,7 @@ static inline bool SupportsCompressed(char zcx = '\0') {
 		return false;
 
 	switch (zcx) {
-	// TODO: cpu_info.RiscV_Zcb
-	case 'b': return false;
+	case 'b': return cpu_info.RiscV_Zcb;
 	case '\0': return true;
 	default: return false;
 	}
@@ -79,18 +78,15 @@ static inline bool SupportsBitmanip(char zbx) {
 }
 
 static inline bool SupportsIntConditional() {
-	// TODO: cpu_info.RiscV_Zicond;
-	return false;
+	return cpu_info.RiscV_Zicond;
 }
 
 static inline bool SupportsFloatHalf(bool allowMin = false) {
-	// TODO
-	return false;
+	return cpu_info.RiscV_Zfh || (cpu_info.RiscV_Zfhmin && allowMin);
 }
 
 static inline bool SupportsFloatExtra() {
-	// TODO: cpu_info.RiscV_Zfa
-	return false;
+	return cpu_info.RiscV_Zfa;
 }
 
 enum class Opcode32 {

--- a/Common/RiscVEmitter.cpp
+++ b/Common/RiscVEmitter.cpp
@@ -78,6 +78,11 @@ static inline bool SupportsBitmanip(char zbx) {
 	}
 }
 
+static inline bool SupportsIntConditional() {
+	// TODO: cpu_info.RiscV_Zicond;
+	return false;
+}
+
 static inline bool SupportsFloatHalf(bool allowMin = false) {
 	// TODO
 	return false;
@@ -219,6 +224,9 @@ enum class Funct3 {
 	BSET = 0b001,
 	BEXT = 0b101,
 
+	CZERO_EQZ = 0b101,
+	CZERO_NEZ = 0b111,
+
 	C_ADDI4SPN = 0b000,
 	C_FLD = 0b001,
 	C_LW = 0b010,
@@ -282,6 +290,7 @@ enum class Funct7 {
 
 	ADDUW_ZEXT = 0b0000100,
 	MINMAX_CLMUL = 0b0000101,
+	CZERO = 0b0000111,
 	SH_ADD = 0b0010000,
 	BSET_ORC = 0b0010100,
 	NOT = 0b0100000,
@@ -4299,6 +4308,18 @@ void RiscVEmitter::BSETI(RiscVReg rd, RiscVReg rs1, u32 shamt) {
 	_assert_msg_(rd != R_ZERO, "%s should avoid write to zero", __func__);
 	_assert_msg_(SupportsBitmanip('s'), "%s instruction unsupported without B", __func__);
 	Write32(EncodeGIShift(Opcode32::OP_IMM, rd, Funct3::BSET, rs1, shamt, Funct7::BSET_ORC));
+}
+
+void RiscVEmitter::CZERO_EQZ(RiscVReg rd, RiscVReg rs1, RiscVReg rs2) {
+	_assert_msg_(rd != R_ZERO, "%s should avoid write to zero", __func__);
+	_assert_msg_(SupportsIntConditional(), "%s instruction unsupported without Zicond", __func__);
+	Write32(EncodeR(Opcode32::OP, rd, Funct3::CZERO_EQZ, rs1, rs2, Funct7::CZERO));
+}
+
+void RiscVEmitter::CZERO_NEZ(RiscVReg rd, RiscVReg rs1, RiscVReg rs2) {
+	_assert_msg_(rd != R_ZERO, "%s should avoid write to zero", __func__);
+	_assert_msg_(SupportsIntConditional(), "%s instruction unsupported without Zicond", __func__);
+	Write32(EncodeR(Opcode32::OP, rd, Funct3::CZERO_NEZ, rs1, rs2, Funct7::CZERO));
 }
 
 bool RiscVEmitter::AutoCompress() const {

--- a/Common/RiscVEmitter.h
+++ b/Common/RiscVEmitter.h
@@ -965,6 +965,9 @@ public:
 	void BSET(RiscVReg rd, RiscVReg rs1, RiscVReg rs2);
 	void BSETI(RiscVReg rd, RiscVReg rs1, u32 shamt);
 
+	void CZERO_EQZ(RiscVReg rd, RiscVReg rs1, RiscVReg rs2);
+	void CZERO_NEZ(RiscVReg rd, RiscVReg rs1, RiscVReg rs2);
+
 	// Compressed instructions.
 	void C_ADDI4SPN(RiscVReg rd, u32 nzuimm10);
 	void C_FLD(RiscVReg rd, RiscVReg addr, u8 uimm8);

--- a/Common/RiscVEmitter.h
+++ b/Common/RiscVEmitter.h
@@ -915,6 +915,23 @@ public:
 	void VCOMPRESS_VM(RiscVReg vd, RiscVReg vs2, RiscVReg vs1);
 	void VMVR_V(int regs, RiscVReg vd, RiscVReg vs2);
 
+	void VANDN_VV(RiscVReg vd, RiscVReg vs2, RiscVReg vs1, VUseMask vm = VUseMask::NONE);
+	void VANDN_VX(RiscVReg vd, RiscVReg vs2, RiscVReg rs1, VUseMask vm = VUseMask::NONE);
+	void VBREV_V(RiscVReg vd, RiscVReg vs2, VUseMask vm = VUseMask::NONE);
+	void VBREV8_V(RiscVReg vd, RiscVReg vs2, VUseMask vm = VUseMask::NONE);
+	void VREV8_V(RiscVReg vd, RiscVReg vs2, VUseMask vm = VUseMask::NONE);
+	void VCLZ_V(RiscVReg vd, RiscVReg vs2, VUseMask vm = VUseMask::NONE);
+	void VCTZ_V(RiscVReg vd, RiscVReg vs2, VUseMask vm = VUseMask::NONE);
+	void VCPOP_V(RiscVReg vd, RiscVReg vs2, VUseMask vm = VUseMask::NONE);
+	void VROL_VV(RiscVReg vd, RiscVReg vs2, RiscVReg vs1, VUseMask vm = VUseMask::NONE);
+	void VROL_VX(RiscVReg vd, RiscVReg vs2, RiscVReg rs1, VUseMask vm = VUseMask::NONE);
+	void VROR_VV(RiscVReg vd, RiscVReg vs2, RiscVReg vs1, VUseMask vm = VUseMask::NONE);
+	void VROR_VX(RiscVReg vd, RiscVReg vs2, RiscVReg rs1, VUseMask vm = VUseMask::NONE);
+	void VROR_VI(RiscVReg vd, RiscVReg vs2, u8 uimm6, VUseMask vm = VUseMask::NONE);
+	void VWSLL_VV(RiscVReg vd, RiscVReg vs2, RiscVReg vs1, VUseMask vm = VUseMask::NONE);
+	void VWSLL_VX(RiscVReg vd, RiscVReg vs2, RiscVReg rs1, VUseMask vm = VUseMask::NONE);
+	void VWSLL_VI(RiscVReg vd, RiscVReg vs2, u8 uimm5, VUseMask vm = VUseMask::NONE);
+
 	// Bitmanip instructions.
 	void ADD_UW(RiscVReg rd, RiscVReg rs1, RiscVReg rs2);
 	void SH_ADD(int shift, RiscVReg rd, RiscVReg rs1, RiscVReg rs2);

--- a/Common/RiscVEmitter.h
+++ b/Common/RiscVEmitter.h
@@ -421,6 +421,26 @@ public:
 	void FLE(int bits, RiscVReg rd, RiscVReg rs1, RiscVReg rs2);
 	void FCLASS(int bits, RiscVReg rd, RiscVReg rs1);
 
+	// Additional floating point (Zfa.)
+	bool CanFLI(int bits, double v) const;
+	bool CanFLI(int bits, uint32_t pattern) const;
+	bool CanFLI(int bits, float v) const {
+		return CanFLI(bits, (double)v);
+	}
+	void FLI(int bits, RiscVReg rd, double v);
+	void FLI(int bits, RiscVReg rd, uint32_t pattern);
+	void FLI(int bits, RiscVReg rd, float v) {
+		FLI(bits, rd, (double)v);
+	}
+	void FMINM(int bits, RiscVReg rd, RiscVReg rs1, RiscVReg rs2);
+	void FMAXM(int bits, RiscVReg rd, RiscVReg rs1, RiscVReg rs2);
+	void FROUND(int bits, RiscVReg rd, RiscVReg rs1, Round rm = Round::DYNAMIC);
+
+	// Convenience helper for FLI support.
+	void QuickFLI(int bits, RiscVReg rd, double v, RiscVReg scratchReg);
+	void QuickFLI(int bits, RiscVReg rd, uint32_t pattern, RiscVReg scratchReg);
+	void QuickFLI(int bits, RiscVReg rd, float v, RiscVReg scratchReg);
+
 	// Control state register manipulation.
 	void CSRRW(RiscVReg rd, Csr csr, RiscVReg rs1);
 	void CSRRS(RiscVReg rd, Csr csr, RiscVReg rs1);

--- a/Common/RiscVEmitter.h
+++ b/Common/RiscVEmitter.h
@@ -938,6 +938,9 @@ public:
 	void SEXT_W(RiscVReg rd, RiscVReg rs) {
 		ADDIW(rd, rs, 0);
 	}
+	void ZEXT_B(RiscVReg rd, RiscVReg rs) {
+		ANDI(rd, rs, 0xFF);
+	}
 	void ZEXT_H(RiscVReg rd, RiscVReg rs);
 	void ZEXT_W(RiscVReg rd, RiscVReg rs) {
 		ADD_UW(rd, rs, R_ZERO);
@@ -1011,6 +1014,22 @@ public:
 	void C_SWSP(RiscVReg rs2, u8 uimm8);
 	void C_FSWSP(RiscVReg rs2, u8 uimm8);
 	void C_SDSP(RiscVReg rs2, u32 uimm9);
+
+	void C_LBU(RiscVReg rd, RiscVReg rs1, u8 uimm2);
+	void C_LHU(RiscVReg rd, RiscVReg rs1, u8 uimm2);
+	void C_LH(RiscVReg rd, RiscVReg rs1, u8 uimm2);
+	void C_SB(RiscVReg rs2, RiscVReg rs1, u8 uimm2);
+	void C_SH(RiscVReg rs2, RiscVReg rs1, u8 uimm2);
+	void C_ZEXT_B(RiscVReg rd);
+	void C_SEXT_B(RiscVReg rd);
+	void C_ZEXT_H(RiscVReg rd);
+	void C_SEXT_H(RiscVReg rd);
+	void C_ZEXT_W(RiscVReg rd);
+	void C_SEXT_W(RiscVReg rd) {
+		C_ADDIW(rd, 0);
+	}
+	void C_NOT(RiscVReg rd);
+	void C_MUL(RiscVReg rd, RiscVReg rs2);
 
 	bool CBInRange(const void *func) const;
 	bool CJInRange(const void *func) const;

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -144,7 +144,7 @@ static u32 sceAudioOutput(u32 chan, int vol, u32 samplePtr) {
 		ERROR_LOG(SCEAUDIO, "sceAudioOutput(%08x, %08x, %08x) - channel not reserved", chan, vol, samplePtr);
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_INIT;
 	} else {
-		DEBUG_LOG(SCEAUDIO, "sceAudioOutputPanned(%08x, %08x, %08x)", chan, vol, samplePtr);
+		DEBUG_LOG(SCEAUDIO, "sceAudioOutput(%08x, %08x, %08x)", chan, vol, samplePtr);
 		if (vol >= 0) {
 			chans[chan].leftVolume = vol;
 			chans[chan].rightVolume = vol;

--- a/Core/MIPS/RiscV/RiscVCompSystem.cpp
+++ b/Core/MIPS/RiscV/RiscVCompSystem.cpp
@@ -50,14 +50,10 @@ void RiscVJitBackend::CompIR_Basic(IRInst inst) {
 
 	case IROp::SetConstF:
 		regs_.Map(inst);
-		if (inst.constant == 0) {
+		if (inst.constant == 0)
 			FCVT(FConv::S, FConv::W, regs_.F(inst.dest), R_ZERO);
-		} else {
-			// TODO: In the future, could use FLI if it's approved.
-			// Also, is FCVT faster?
-			LI(SCRATCH1, (int32_t)inst.constant);
-			FMV(FMv::W, FMv::X, regs_.F(inst.dest), SCRATCH1);
-		}
+		else
+			QuickFLI(32, regs_.F(inst.dest), inst.constant, SCRATCH1);
 		break;
 
 	case IROp::Downcount:

--- a/Core/MIPS/RiscV/RiscVCompVec.cpp
+++ b/Core/MIPS/RiscV/RiscVCompVec.cpp
@@ -54,56 +54,86 @@ void RiscVJitBackend::CompIR_VecAssign(IRInst inst) {
 			break;
 
 		case Vec4Init::AllONE:
-			LI(SCRATCH1, 1.0f);
-			FMV(FMv::W, FMv::X, regs_.F(inst.dest), SCRATCH1);
-			for (int i = 1; i < 4; ++i)
-				FMV(32, regs_.F(inst.dest + i), regs_.F(inst.dest));
+			if (CanFLI(32, 1.0f)) {
+				for (int i = 0; i < 4; ++i)
+					FLI(32, regs_.F(inst.dest + i), 1.0f);
+			} else {
+				LI(SCRATCH1, 1.0f);
+				FMV(FMv::W, FMv::X, regs_.F(inst.dest), SCRATCH1);
+				for (int i = 1; i < 4; ++i)
+					FMV(32, regs_.F(inst.dest + i), regs_.F(inst.dest));
+			}
 			break;
 
 		case Vec4Init::AllMinusONE:
-			LI(SCRATCH1, -1.0f);
-			FMV(FMv::W, FMv::X, regs_.F(inst.dest), SCRATCH1);
-			for (int i = 1; i < 4; ++i)
-				FMV(32, regs_.F(inst.dest + i), regs_.F(inst.dest));
+			if (CanFLI(32, -1.0f)) {
+				for (int i = 0; i < 4; ++i)
+					FLI(32, regs_.F(inst.dest + i), -1.0f);
+			} else {
+				LI(SCRATCH1, -1.0f);
+				FMV(FMv::W, FMv::X, regs_.F(inst.dest), SCRATCH1);
+				for (int i = 1; i < 4; ++i)
+					FMV(32, regs_.F(inst.dest + i), regs_.F(inst.dest));
+			}
 			break;
 
 		case Vec4Init::Set_1000:
-			LI(SCRATCH1, 1.0f);
+			if (!CanFLI(32, 1.0f))
+				LI(SCRATCH1, 1.0f);
 			for (int i = 0; i < 4; ++i) {
-				if (i == 0)
-					FMV(FMv::W, FMv::X, regs_.F(inst.dest + i), SCRATCH1);
-				else
+				if (i == 0) {
+					if (CanFLI(32, 1.0f))
+						FLI(32, regs_.F(inst.dest + i), 1.0f);
+					else
+						FMV(FMv::W, FMv::X, regs_.F(inst.dest + i), SCRATCH1);
+				} else {
 					FCVT(FConv::S, FConv::W, regs_.F(inst.dest + i), R_ZERO);
+				}
 			}
 			break;
 
 		case Vec4Init::Set_0100:
-			LI(SCRATCH1, 1.0f);
+			if (!CanFLI(32, 1.0f))
+				LI(SCRATCH1, 1.0f);
 			for (int i = 0; i < 4; ++i) {
-				if (i == 1)
-					FMV(FMv::W, FMv::X, regs_.F(inst.dest + i), SCRATCH1);
-				else
+				if (i == 1) {
+					if (CanFLI(32, 1.0f))
+						FLI(32, regs_.F(inst.dest + i), 1.0f);
+					else
+						FMV(FMv::W, FMv::X, regs_.F(inst.dest + i), SCRATCH1);
+				} else {
 					FCVT(FConv::S, FConv::W, regs_.F(inst.dest + i), R_ZERO);
+				}
 			}
 			break;
 
 		case Vec4Init::Set_0010:
-			LI(SCRATCH1, 1.0f);
+			if (!CanFLI(32, 1.0f))
+				LI(SCRATCH1, 1.0f);
 			for (int i = 0; i < 4; ++i) {
-				if (i == 2)
-					FMV(FMv::W, FMv::X, regs_.F(inst.dest + i), SCRATCH1);
-				else
+				if (i == 2) {
+					if (CanFLI(32, 1.0f))
+						FLI(32, regs_.F(inst.dest + i), 1.0f);
+					else
+						FMV(FMv::W, FMv::X, regs_.F(inst.dest + i), SCRATCH1);
+				} else {
 					FCVT(FConv::S, FConv::W, regs_.F(inst.dest + i), R_ZERO);
+				}
 			}
 			break;
 
 		case Vec4Init::Set_0001:
-			LI(SCRATCH1, 1.0f);
+			if (!CanFLI(32, 1.0f))
+				LI(SCRATCH1, 1.0f);
 			for (int i = 0; i < 4; ++i) {
-				if (i == 3)
-					FMV(FMv::W, FMv::X, regs_.F(inst.dest + i), SCRATCH1);
-				else
+				if (i == 3) {
+					if (CanFLI(32, 1.0f))
+						FLI(32, regs_.F(inst.dest + i), 1.0f);
+					else
+						FMV(FMv::W, FMv::X, regs_.F(inst.dest + i), SCRATCH1);
+				} else {
 					FCVT(FConv::S, FConv::W, regs_.F(inst.dest + i), R_ZERO);
+				}
 			}
 			break;
 		}

--- a/GPU/Common/VertexDecoderRiscV.cpp
+++ b/GPU/Common/VertexDecoderRiscV.cpp
@@ -223,10 +223,8 @@ JittedVertexDecoder VertexDecoderJitCache::Compile(const VertexDecoder &dec, int
 	}
 
 	// TODO: Only load these when needed?
-	LI(scratchReg, by128);
-	FMV(FMv::W, FMv::X, by128Reg, scratchReg);
-	LI(scratchReg, by32768);
-	FMV(FMv::W, FMv::X, by32768Reg, scratchReg);
+	QuickFLI(32, by128Reg, by128, scratchReg);
+	QuickFLI(32, by32768Reg, by32768, scratchReg);
 	if (posThroughStep) {
 		LI(scratchReg, const65535);
 		FMV(FMv::W, FMv::X, const65535Reg, scratchReg);

--- a/GPU/Common/VertexDecoderRiscV.cpp
+++ b/GPU/Common/VertexDecoderRiscV.cpp
@@ -1004,7 +1004,7 @@ void VertexDecoderJitCache::Jit_Color5551() {
 	SRLI(tempReg2, tempReg1, 5);
 	SRLI(tempReg3, tempReg1, 10);
 
-	// Set tempReg3 to -1 if the alpha bit is set.
+	// Set scratchReg to -1 if the alpha bit is set.
 	SLLIW(scratchReg, tempReg1, 16);
 	SRAIW(scratchReg, scratchReg, 31);
 	// Now we can mask the flag.


### PR DESCRIPTION
This adds some additional recently ratified extensions, to the emitter.  They're not tested really, as I don't have anything that actually has these extensions.

FLI is kinda nice.  I think the conditional ones (czero) have been in draft a while, so might be most likely to show up implemented in actual hardware the soonest.

-[Unknown]