### PR TITLE
Various changes to the webserver to handle serving HTTP subfolders

### DIFF
--- a/Common/UI/PopupScreens.cpp
+++ b/Common/UI/PopupScreens.cpp
@@ -713,7 +713,7 @@ std::string FolderChooserChoice::ValueText() const {
 		return di->T("Default");
 	}
 	Path path(*value_);
-	return path.GetFilename();
+	return path.ToVisualString();
 }
 
 }  // namespace


### PR DESCRIPTION
Followup to #18632

Together with #18640, allows playing games over remote ISO subfolders. This is the server side.

Backwards compat may be a bit of a concern though plain lists should still work.


