### PR TITLE
Various fixes to PathBrowser etc to handle browsing HTTP subfolders

### DIFF
--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -314,16 +314,15 @@ std::string Path::ToVisualString(const char *relativeRoot) const {
 bool Path::CanNavigateUp() const {
 	if (type_ == PathType::CONTENT_URI) {
 		return AndroidContentURI(path_).CanNavigateUp();
-	}
-	if (path_ == "/" || path_.empty()) {
-		return false;
-	}
-	if (type_ == PathType::HTTP) {
+	} else if (type_ == PathType::HTTP) {
 		size_t rootSlash = path_.find_first_of('/', strlen("https://"));
 		if (rootSlash == path_.npos || path_.size() == rootSlash + 1) {
 			// This means, "http://server" or "http://server/".  Can't go up.
 			return false;
 		}
+	}
+	if (path_ == "/" || path_.empty()) {
+		return false;
 	}
 	return true;
 }

--- a/Common/File/PathBrowser.cpp
+++ b/Common/File/PathBrowser.cpp
@@ -77,24 +77,33 @@ bool LoadRemoteFileList(const Path &url, const std::string &userAgent, bool *can
 		ERROR_LOG(IO, "Unsupported Content-Type: %s", contentType.c_str());
 		return false;
 	}
-
+	Path basePath(baseURL.ToString());
 	for (auto &item : items) {
 		// Apply some workarounds.
 		if (item.empty())
 			continue;
-		if (item.back() == '\r')
+		if (item.back() == '\r') {
 			item.pop_back();
+			if (item.empty())
+				continue;
+		}
 		if (item == baseURL.Resource())
 			continue;
 
 		File::FileInfo info;
+		if (item.back() == '/') {
+			item.pop_back();
+			if (item.empty())
+				continue;
+			info.isDirectory = true;
+		} else {
+			info.isDirectory = false;
+		}
 		info.name = item;
-		info.fullName = Path(baseURL.Relative(item).ToString());
-		info.isDirectory = endsWith(item, "/");
+		info.fullName = basePath / item;
 		info.exists = true;
 		info.size = 0;
 		info.isWritable = false;
-
 		files.push_back(info);
 	}
 

--- a/Common/Net/URL.cpp
+++ b/Common/Net/URL.cpp
@@ -42,12 +42,14 @@ void Url::Split() {
 
 	size_t sep = url_.find('/', colonSlashSlash + 3);
 	if (sep == std::string::npos) {
-		valid_ = false;
-		return;
+		sep = url_.size();
 	}
 
 	host_ = url_.substr(colonSlashSlash + 3, sep - colonSlashSlash - 3);
 	resource_ = url_.substr(sep);  // include the slash!
+	if (resource_.empty()) {
+		resource_ = "/";  // Assume what was meant was the root.
+	}
 
 	size_t portsep = host_.rfind(':');
 	if (portsep != host_.npos) {

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -160,8 +160,13 @@ bool RemoteISOConnectScreen::FindServer(std::string &resultHost, int &resultPort
 
 		bool supported = false;
 		for (const std::string &item : items) {
-			if (!RemoteISOFileSupported(item)) {
+			if (item.empty())
 				continue;
+			if (!RemoteISOFileSupported(item)) {
+				if (item.back() != '/') {
+					// We accept lists of just directories - we kinda have to.
+					continue;
+				}
 			}
 			supported = true;
 			break;


### PR DESCRIPTION
Followup to #18632

Together with #18639 , allows playing games over remote ISO subfolders. This is the client side, with fixes to PathBrowser etc.

Backwards compat may be a bit of a concern though plain lists should still work.
