### PR TITLE
Enforce run-behind-pause-screen if ad-hoc multiplayer active

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -102,6 +102,10 @@ void Core_Stop() {
 	}
 }
 
+bool Core_ShouldRunBehind() {
+	return g_Config.bRunBehindPauseMenu;
+}
+
 bool Core_IsStepping() {
 	return coreState == CORE_STEPPING || coreState == CORE_POWERDOWN;
 }

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -41,6 +41,7 @@
 #include "Core/Debugger/Breakpoints.h"
 #include "Core/HW/Display.h"
 #include "Core/MIPS/MIPS.h"
+#include "Core/HLE/sceNetAdhoc.h"
 #include "GPU/Debugger/Stepping.h"
 
 #ifdef _WIN32
@@ -103,7 +104,8 @@ void Core_Stop() {
 }
 
 bool Core_ShouldRunBehind() {
-	return g_Config.bRunBehindPauseMenu;
+	// Enforce run-behind if ad-hoc connected
+	return g_Config.bRunBehindPauseMenu || __NetAdhocConnected();
 }
 
 bool Core_IsStepping() {

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -37,6 +37,8 @@ void Core_SetGraphicsContext(GraphicsContext *ctx);
 // called from gui
 void Core_EnableStepping(bool step, const char *reason = nullptr, u32 relatedAddress = 0);
 
+bool Core_ShouldRunBehind();
+
 bool Core_NextFrame();
 void Core_DoSingleStep();
 void Core_UpdateSingleStep();

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -127,7 +127,7 @@ static int sceNetAdhocPdpSend(int id, const char* mac, u32 port, void* data, int
 static int sceNetAdhocPdpRecv(int id, void* addr, void* port, void* buf, void* dataLength, u32 timeout, int flag);
 
 bool __NetAdhocConnected() {
-	return netAdhocInited && netAdhocctlInited && adhocctlState == ADHOCCTL_STATE_CONNECTED;
+	return netAdhocInited && netAdhocctlInited && (adhocctlState == ADHOCCTL_STATE_CONNECTED || adhocctlState == ADHOCCTL_STATE_GAMEMODE);
 }
 
 void __NetAdhocShutdown() {

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -126,6 +126,9 @@ static int sceNetAdhocPdpCreate(const char* mac, int port, int bufferSize, u32 f
 static int sceNetAdhocPdpSend(int id, const char* mac, u32 port, void* data, int len, int timeout, int flag);
 static int sceNetAdhocPdpRecv(int id, void* addr, void* port, void* buf, void* dataLength, u32 timeout, int flag);
 
+bool __NetAdhocConnected() {
+	return netAdhocInited && netAdhocctlInited && adhocctlState == ADHOCCTL_STATE_CONNECTED;
+}
 
 void __NetAdhocShutdown() {
 	// Kill AdhocServer Thread

--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -104,6 +104,8 @@ void __NetAdhocDoState(PointerWrap &p);
 void __UpdateAdhocctlHandlers(u32 flags, u32 error);
 void __UpdateMatchingHandler(const MatchingArgs &params);
 
+bool __NetAdhocConnected();
+
 // I have to call this from netdialog
 int sceNetAdhocctlGetState(u32 ptrToStatus);
 int sceNetAdhocctlCreate(const char * groupName);

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1448,11 +1448,11 @@ static void DrawFPS(UIContext *ctx, const Bounds &bounds) {
 
 bool EmuScreen::canBeBackground(bool isTop) const {
 	if (g_Config.bSkipBufferEffects) {
-		return isTop || (g_Config.bTransparentBackground && g_Config.bRunBehindPauseMenu);
+		return isTop || (g_Config.bTransparentBackground && Core_ShouldRunBehind());
 	}
 
 	if (!g_Config.bTransparentBackground && !isTop) {
-		if (g_Config.bRunBehindPauseMenu || screenManager()->topScreen()->wantBrightBackground())
+		if (Core_ShouldRunBehind() || screenManager()->topScreen()->wantBrightBackground())
 			return true;
 		return false;
 	}
@@ -1513,7 +1513,7 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 
 	if (mode & ScreenRenderMode::TOP) {
 		System_Notify(SystemNotification::KEEP_SCREEN_AWAKE);
-	} else if (!g_Config.bRunBehindPauseMenu && strcmp(screenManager()->topScreen()->tag(), "DevMenu") != 0) {
+	} else if (!Core_ShouldRunBehind() && strcmp(screenManager()->topScreen()->tag(), "DevMenu") != 0) {
 		// Not on top. Let's not execute, only draw the image.
 		draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::DONT_CARE, RPAction::DONT_CARE }, "EmuScreen_Stepping");
 		// Just to make sure.


### PR DESCRIPTION
This forces the game to keep running behind the menu if adhoc is connected, avoiding desyncs-by-mistake.

@anr2me What do you think? Is this the right approach?
