### PR TITLE
Allow merging framebuffers vertically like the old Juiced 2 fix.

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -136,6 +136,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ForceUMDReadSpeed", &flags_.ForceUMDReadSpeed);
 	CheckSetting(iniFile, gameID, "AllowDelayedReadbacks", &flags_.AllowDelayedReadbacks);
 	CheckSetting(iniFile, gameID, "TacticsOgreEliminateDebugReadback", &flags_.TacticsOgreEliminateDebugReadback);
+	CheckSetting(iniFile, gameID, "FramebufferAllowLargeVerticalOffset", &flags_.FramebufferAllowLargeVerticalOffset);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -106,6 +106,7 @@ struct CompatFlags {
 	bool ForceUMDReadSpeed;
 	bool AllowDelayedReadbacks;
 	bool TacticsOgreEliminateDebugReadback;
+	bool FramebufferAllowLargeVerticalOffset;
 };
 
 struct VRCompat {

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1273,6 +1273,13 @@ ULES00928 = true
 ULUS10312 = true
 ULKS46154 = true
 
+[FramebufferAllowLargeVerticalOffset]
+# Tokimeki Memorial 4 (see #6379)
+NPJH50127 = true
+ULKS46226 = true
+ULAS42206 = true
+ULJM05541 = true
+
 [AtracLoopHack]
 #Atrac looped incorrectly see #7601 #13773 #11586 #10139 #12083
 


### PR DESCRIPTION
Fixes #6379 (Tokimeki Memorial 4 rendering). See comments to that issue for explanation.

Gated behind a compat flag to not break anything at this late stage.

Note: Only tested on frame dumps, so who knows, there might be other weirdness elsewhere in the game.