### PR TITLE
HTTPS through naett: Get the body of the response even if code isn't 200

### DIFF
--- a/Common/Net/HTTPNaettRequest.cpp
+++ b/Common/Net/HTTPNaettRequest.cpp
@@ -77,6 +77,10 @@ bool HTTPSRequest::Done() {
 
 	// -1000 is a code specified by us to represent cancellation, that is unlikely to ever collide with naett error codes.
 	resultCode_ = IsCancelled() ? -1000 : naettGetStatus(res_);
+	int bodyLength;
+	const void *body = naettGetBody(res_, &bodyLength);
+	char *dest = buffer_.Append(bodyLength);
+	memcpy(dest, body, bodyLength);
 	if (resultCode_ < 0) {
 		// It's a naett error. Translate and handle.
 		switch (resultCode_) {
@@ -100,12 +104,8 @@ bool HTTPSRequest::Done() {
 			break;
 		}
 		failed_ = true;
-		progress_.Update(0, 0, true);
+		progress_.Update(bodyLength, bodyLength, true);
 	} else if (resultCode_ == 200) {
-		int bodyLength;
-		const void *body = naettGetBody(res_, &bodyLength);
-		char *dest = buffer_.Append(bodyLength);
-		memcpy(dest, body, bodyLength);
 		if (!outfile_.empty() && !buffer_.FlushToFile(outfile_)) {
 			ERROR_LOG(IO, "Failed writing download to '%s'", outfile_.c_str());
 		}


### PR DESCRIPTION
This is required for rcheevos to parse errors properly - it ignores the error code and parses it out of the body instead.

We should now be able to produce more focused error messages.