### PR TITLE
Stick calibration/input: Fix inverse deadzone

### DIFF
--- a/Common/Render/ManagedTexture.cpp
+++ b/Common/Render/ManagedTexture.cpp
@@ -229,6 +229,7 @@ void ManagedTexture::DeviceLost() {
 	INFO_LOG(G3D, "ManagedTexture::DeviceLost(%s)", filename_.c_str());
 	if (taskWaitable_) {
 		taskWaitable_->WaitAndRelease();
+		taskWaitable_ = nullptr;
 		pendingImage_.Free();
 	}
 	if (texture_)

--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -109,13 +109,23 @@ static bool IsSignedAxis(int axis) {
 }
 
 // This is applied on the circular radius, not directly on the axes.
+// TODO: Share logic with tilt?
+
 static float MapAxisValue(float v) {
 	const float deadzone = g_Config.fAnalogDeadzone;
 	const float invDeadzone = g_Config.fAnalogInverseDeadzone;
 	const float sensitivity = g_Config.fAnalogSensitivity;
 	const float sign = v >= 0.0f ? 1.0f : -1.0f;
 
-	return sign * Clamp(invDeadzone + (fabsf(v) - deadzone) / (1.0f - deadzone) * (sensitivity - invDeadzone), 0.0f, 1.0f);
+	// Apply deadzone.
+	v = Clamp((fabsf(v) - deadzone) / (1.0f - deadzone), 0.0f, 1.0f);
+
+	// Apply sensitivity and inverse deadzone.
+	if (v != 0.0f) {
+		v = Clamp(invDeadzone + v * (sensitivity - invDeadzone), 0.0f, 1.0f);
+	}
+
+	return sign * v;
 }
 
 void ConvertAnalogStick(float x, float y, float *outX, float *outY) {


### PR DESCRIPTION
This was simply implemented wrong, now it works correctly, allowing centering properly.

I'm also thinking of adding a circular deadzone option, like in Tilt input. And our current "Circular input" setting is mostly weird, and generally replacable with just cranking up the sensitivity for the purpose of reaching out into the corners.

Reported by SixelAlexiS on Discord.