### PR TITLE
fix shader warning

### DIFF
--- a/GPU/Common/VertexShaderGenerator.cpp
+++ b/GPU/Common/VertexShaderGenerator.cpp
@@ -1056,7 +1056,7 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 				p.C("      } else {\n");  // type must be 0x02 - GE_LIGHTTYPE_SPOT
 				p.F("        angle = dot(u_lightdir%s, toLight);\n", iStr);
 				p.F("        if (angle >= u_lightangle_spotCoef%s.x) {\n", iStr);
-				p.F("          lightScale = attenuation * (u_lightangle_spotCoef%s.y <= 0.0 ? 1.0 : pow(angle, u_lightangle_spotCoef%s.y));\n", iStr, iStr, iStr);
+				p.F("          lightScale = attenuation * (u_lightangle_spotCoef%s.y <= 0.0 ? 1.0 : pow(abs(angle), u_lightangle_spotCoef%s.y));\n", iStr, iStr, iStr);
 				p.C("        } else {\n");
 				p.C("          lightScale = 0.0;\n");
 				p.C("        }\n");
@@ -1132,7 +1132,7 @@ bool GenerateVertexShader(const VShaderID &id, char *buffer, const ShaderLanguag
 				case GE_LIGHTTYPE_UNKNOWN:
 					p.F("  angle = dot(u_lightdir%s, toLight);\n", iStr, iStr);
 					p.F("  if (angle >= u_lightangle_spotCoef%s.x) {\n", iStr);
-					p.F("    lightScale = clamp(1.0 / dot(u_lightatt%s, vec3(1.0, distance, distance*distance)), 0.0, 1.0) * (u_lightangle_spotCoef%s.y <= 0.0 ? 1.0 : pow(angle, u_lightangle_spotCoef%s.y));\n", iStr, iStr, iStr);
+					p.F("    lightScale = clamp(1.0 / dot(u_lightatt%s, vec3(1.0, distance, distance*distance)), 0.0, 1.0) * (u_lightangle_spotCoef%s.y <= 0.0 ? 1.0 : pow(abs(angle), u_lightangle_spotCoef%s.y));\n", iStr, iStr, iStr);
 					p.C("  } else {\n");
 					p.C("    lightScale = 0.0;\n");
 					p.C("  }\n");


### PR DESCRIPTION
Fix for the warning.

```
Shader
[16516] E:\build-ppsspp-clang-debug\Shader@0x000011B12B5C2400(107,81-118): warning X3571: pow(f, e) will not work for negative f, use abs(f) or conditionally handle negative values if you expect them
[16516]    1:  #define vec2 float2
[16516]    2:  #define vec3 float3
[16516]    3:  #define vec4 float4
[16516]    4:  #define ivec2 int2
[16516]    5:  #define ivec4 int4
[16516]    6:  #define mat2 float2x2
[16516]    7:  #define mat4 float4x4
[16516]    8:  #define mat3x4 float4x3
[16516]    9:  #define splat3(x) vec3(x, x, x)
[16516]   10:  #define lowp
[16516]   11:  #define mediump
[16516]   12:  #define highp
[16516]   13:  
[16516]   14:  // 01000000:80000b20 HWX T N Light: LightUberShader Cull 
[16516]   15:  cbuffer base : register(b0) {
[16516]   16:    mat4 u_proj;
[16516]   17:    mat4 u_proj_through;
[16516]   18:    mat3x4 u_view;
[16516]   19:    mat3x4 u_world;
[16516]   20:    mat3x4 u_texmtx;
[16516]   21:    vec4 u_uvscaleoffset;
[16516]   22:    vec4 u_depthRange;
[16516]   23:    vec4 u_matambientalpha;
[16516]   24:    vec4 u_cullRangeMin;
[16516]   25:    vec4 u_cullRangeMax;
[16516]   26:    uint u_spline_counts;
[16516]   27:    uint u_depal_mask_shift_off_fmt;
[16516]   28:    uint u_colorWriteMask;
[16516]   29:    float u_mipBias;
[16516]   30:    vec2 u_texNoAlphaMul; float pad1; float pad2;
[16516]   31:    vec3 u_fogcolor;  uint u_alphacolorref;
[16516]   32:    vec3 u_texenv;    uint u_alphacolormask;
[16516]   33:    vec4 u_texclamp;
[16516]   34:    vec2 u_texclampoff; vec2 u_fogcoef;
[16516]   35:    vec3 u_blendFixA; float u_stencilReplaceValue;
[16516]   36:    vec3 u_blendFixB; float u_rotation;
[16516]   37:  };
[16516]   38:  cbuffer lights: register(b1) {
[16516]   39:    vec4 u_ambient;
[16516]   40:    vec3 u_matdiffuse;
[16516]   41:    vec4 u_matspecular;
[16516]   42:    vec3 u_matemissive;
[16516]   43:    uint u_lightControl;  // light ubershader control bits
[16516]   44:    vec3 u_lightpos[4];
[16516]   45:    vec3 u_lightdir[4];
[16516]   46:    vec3 u_lightatt[4];
[16516]   47:    vec4 u_lightangle_spotCoef[4];
[16516]   48:    vec3 u_lightambient[4];
[16516]   49:    vec3 u_lightdiffuse[4];
[16516]   50:    vec3 u_lightspecular[4];
[16516]   51:  };
[16516]   52:  cbuffer bones : register(b2) {
[16516]   53:   mat3x4 u_bone0; mat3x4 u_bone1; mat3x4 u_bone2; mat3x4 u_bone3; mat3x4 u_bone4; mat3x4 u_bone5; mat3x4 u_bone6; mat3x4 u_bone7; mat3x4 u_bone8;
[16516]   54:  };
[16516]   55:  struct VS_IN {                              
[16516]   56:    vec2 texcoord : TEXCOORD0;
[16516]   57:    vec3 normal : NORMAL;
[16516]   58:    vec3 position : POSITION;
[16516]   59:  };
[16516]   60:  struct VS_OUT {
[16516]   61:    vec3 v_texcoord : TEXCOORD0;
[16516]   62:    vec4 v_color0    : COLOR0;
[16516]   63:    float v_fogdepth : TEXCOORD1;
[16516]   64:    vec4 gl_Position   : SV_Position;
[16516]   65:    float2 gl_ClipDistance : SV_ClipDistance;
[16516]   66:    float2 gl_CullDistance : SV_CullDistance0;
[16516]   67:  };
[16516]   68:  vec3 normalizeOr001(vec3 v) {
[16516]   69:     return length(v) == 0.0 ? vec3(0.0, 0.0, 1.0) : normalize(v);
[16516]   70:  }
[16516]   71:  VS_OUT main(VS_IN In) {
[16516]   72:    VS_OUT Out;
[16516]   73:    vec2 texcoord = In.texcoord;
[16516]   74:    vec3 normal = In.normal;
[16516]   75:    vec3 position = In.position;
[16516]   76:    vec3 worldpos = mul(vec4(position, 1.0), u_world).xyz;
[16516]   77:    mediump vec3 worldnormal = normalizeOr001(mul(vec4(normal, 0.0), u_world).xyz);
[16516]   78:    vec4 viewPos = vec4(mul(vec4(worldpos, 1.0), u_view).xyz, 1.0);
[16516]   79:    vec4 outPos = mul(u_proj, viewPos);
[16516]   80:    vec4 ambientColor = u_matambientalpha;
[16516]   81:    vec3 diffuseColor = u_matdiffuse.rgb;
[16516]   82:    vec3 specularColor = u_matspecular.rgb;
[16516]   83:    lowp vec4 lightSum0 = u_ambient * ambientColor + vec4(u_matemissive, 0.0);
[16516]   84:    lowp vec3 lightSum1 = splat3(0.0);
[16516]   85:    vec3 toLight;
[16516]   86:    lowp vec3 diffuse;
[16516]   87:    float distance;
[16516]   88:    lowp float lightScale;
[16516]   89:    mediump float ldot;
[16516]   90:    lowp float angle;
[16516]   91:    uint comp; uint type; float attenuation;
[16516]   92:    for (uint i = 0; i < 4; i++) {
[16516]   93:    if ((u_lightControl & (0x1u << i)) != 0x0u) { 
[16516]   94:      comp = (u_lightControl >> uint(0x4u + 0x4u * i)) & 0x3u;
[16516]   95:      type = (u_lightControl >> uint(0x4u + 0x4u * i + 0x2u)) & 0x3u;
[16516]   96:      toLight = u_lightpos[i];
[16516]   97:      if (type != 0x0u) {
[16516]   98:        toLight -= worldpos;
[16516]   99:        distance = length(toLight);
[16516]  100:        toLight /= distance;
[16516]  101:        attenuation = clamp(1.0 / dot(u_lightatt[i], vec3(1.0, distance, distance*distance)), 0.0, 1.0);
[16516]  102:        if (type == 0x01u) {
[16516]  103:          lightScale = attenuation;
[16516]  104:        } else {
[16516]  105:          angle = dot(u_lightdir[i], toLight);
[16516]  106:          if (angle >= u_lightangle_spotCoef[i].x) {
[16516]  107:            lightScale = attenuation * (u_lightangle_spotCoef[i].y <= 0.0 ? 1.0 : pow(angle, u_lightangle_spotCoef[i].y));
[16516]  108:          } else {
[16516]  109:            lightScale = 0.0;
[16516]  110:          }
[16516]  111:        }
[16516]  112:      } else {
[16516]  113:        lightScale = 1.0;
[16516]  114:      }
[16516]  115:      ldot = dot(toLight, worldnormal);
[16516]  116:      if (comp == 0x2u) {
[16516]  117:        ldot = u_matspecular.a > 0.0 ? pow(max(ldot, 0.0), u_matspecular.a) : 1.0;
[16516]  118:      }
[16516]  119:      diffuse = (u_lightdiffuse[i] * diffuseColor) * max(ldot, 0.0);
[16516]  120:      if (comp == 0x1u) {
[16516]  121:        if (ldot >= 0.0) {
[16516]  122:          if (u_matspecular.a > 0.0) {
[16516]  123:            ldot = dot(normalize(toLight + vec3(0.0, 0.0, 1.0)), worldnormal);
[16516]  124:            ldot = pow(max(ldot, 0.0), u_matspecular.a);
[16516]  125:          } else {
[16516]  126:            ldot = 1.0;
[16516]  127:          }
[16516]  128:          lightSum1 += u_lightspecular[i] * specularColor * ldot * lightScale;
[16516]  129:        }
[16516]  130:      }
[16516]  131:      lightSum0.rgb += (u_lightambient[i] * ambientColor.rgb + diffuse) * lightScale;
[16516]  132:    }
[16516]  133:    }  Out.v_color0 = clamp(clamp(lightSum0, 0.0, 1.0) + vec4(lightSum1, 0.0), 0.0, 1.0);
[16516]  134:    Out.v_texcoord = vec3(texcoord.xy * u_uvscaleoffset.xy, 0.0);
[16516]  135:    Out.v_fogdepth = (viewPos.z + u_fogcoef.x) * u_fogcoef.y;
[16516]  136:    if (u_depthRange.y >= 1.0) {
[16516]  137:      Out.gl_ClipDistance.x = outPos.z;
[16516]  138:    } else if (u_depthRange.x + u_depthRange.y <= 65534.0) {
[16516]  139:      Out.gl_ClipDistance.x = outPos.w - outPos.z;
[16516]  140:    } else {
[16516]  141:      Out.gl_ClipDistance.x = 0.0;
[16516]  142:    }
[16516]  143:    vec3 projPos = outPos.xyz / outPos.w;
[16516]  144:    float projZ = (projPos.z - u_depthRange.z) * u_depthRange.w;
[16516]  145:    if (u_cullRangeMin.w <= 0.0 || projZ * outPos.w > -outPos.w) {
[16516]  146:      if ((projPos.x < u_cullRangeMin.x || projPos.y < u_cullRangeMin.y) || (projPos.x > u_cullRangeMax.x || projPos.y > u_cullRangeMax.y)) {
[16516]  147:        outPos.xyzw = u_cullRangeMax.wwww;
[16516]  148:      }
[16516]  149:    }
[16516]  150:    if (u_cullRangeMin.w <= 0.0) {
[16516]  151:      if (projPos.z < u_cullRangeMin.z || projPos.z > u_cullRangeMax.z) {
[16516]  152:        outPos.xyzw = u_cullRangeMax.wwww;
[16516]  153:      }
[16516]  154:    }
[16516]  155:    Out.gl_ClipDistance.y = projZ * outPos.w + outPos.w + 0.000001;
[16516]  156:    if (u_cullRangeMin.w > 0.0 && u_depthRange.w != 0.0f) {
[16516]  157:      Out.gl_CullDistance.x = projPos.z - u_cullRangeMin.z;
[16516]  158:      Out.gl_CullDistance.y = u_cullRangeMax.z - projPos.z;
[16516]  159:    } else {
[16516]  160:      Out.gl_CullDistance.x = 0.0;
[16516]  161:      Out.gl_CullDistance.y = 0.0;
[16516]  162:    }
[16516]  163:    Out.gl_Position = outPos;
[16516]  164:    return Out;
[16516]  165:  }
```