### PR TITLE
GPS: Set valid values and request updates on savestate loading

### DIFF
--- a/Core/HLE/sceUsbGps.cpp
+++ b/Core/HLE/sceUsbGps.cpp
@@ -48,6 +48,10 @@ void __UsbGpsDoState(PointerWrap &p) {
 		return;
 
 	Do(p, gpsStatus);
+	if (gpsStatus == GPS_STATE_ON) {
+		GPS::init();
+		System_GPSCommand("open");
+	}
 }
 
 void __UsbGpsShutdown() {


### PR DESCRIPTION
Previously the gpsData/satData structs were empty until any app executed sceUsbGpsOpen()