### PR TITLE
Fix compilation against newer ffmpeg versions

### DIFF
--- a/Core/AVIDump.cpp
+++ b/Core/AVIDump.cpp
@@ -45,6 +45,10 @@ extern "C" {
 #define av_frame_free avcodec_free_frame
 #endif
 
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(59, 16, 100)
+#define AVCodec const AVCodec
+#endif
+
 static AVFormatContext *s_format_context = nullptr;
 static AVCodecContext *s_codec_context = nullptr;
 static AVStream *s_stream = nullptr;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -126,7 +126,13 @@ extern "C" {
 #include "libavformat/avformat.h"
 #include "libswresample/swresample.h"
 #include "libavutil/samplefmt.h"
+#include "libavcodec/avcodec.h"
+#include "libavutil/version.h"
 }
+
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(59, 16, 100)
+#define AVCodec const AVCodec
+#endif
 
 #endif // USE_FFMPEG
 
@@ -1858,7 +1864,7 @@ int __AtracSetContext(Atrac *atrac) {
 		atrac->ReleaseFFMPEGContext();
 	}
 
-	const AVCodec *codec = avcodec_find_decoder(ff_codec);
+	AVCodec *codec = avcodec_find_decoder(ff_codec);
 	atrac->codecCtx_ = avcodec_alloc_context3(codec);
 
 	if (atrac->codecType_ == PSP_MODE_AT_3) {

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -111,7 +111,11 @@ extern "C" {
 #include "libavformat/avformat.h"
 #include "libavutil/imgutils.h"
 #include "libswscale/swscale.h"
+#include "libavcodec/avcodec.h"
 }
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(59, 16, 100)
+#define AVCodec const AVCodec
+#endif
 static AVPixelFormat pmp_want_pix_fmt;
 
 #endif

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -31,6 +31,7 @@ extern "C" {
 #include "libavformat/avformat.h"
 #include "libswresample/swresample.h"
 #include "libavutil/samplefmt.h"
+#include "libavcodec/avcodec.h"
 }
 
 #endif  // USE_FFMPEG

--- a/Core/HW/SimpleAudioDec.h
+++ b/Core/HW/SimpleAudioDec.h
@@ -27,6 +27,18 @@ struct AVCodec;
 struct AVCodecContext;
 struct SwrContext;
 
+#ifdef USE_FFMPEG
+
+extern "C" {
+#include "libavutil/version.h"
+};
+
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(59, 16, 100)
+#define AVCodec const AVCodec
+#endif
+
+#endif
+
 // Wraps FFMPEG for audio decoding in a nice interface.
 // Decodes packet by packet - does NOT demux.
 


### PR DESCRIPTION
- `AVCodec*` -> `const AVCodec*`
- `#include "libavcodec/avcodec.h"` where required
- `stream->need_parsing` is moved to an internal header and should no longer be set by outside code
- `stream->codec` is replaced with call to `avcodec_find_decoder`, etc