### PR TITLE
Vulkan: Fix trying to compare uninitialized parts of packed descriptors

### DIFF
--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -318,12 +318,14 @@ static VulkanLibraryHandle VulkanLoadLibrary(const char *logname) {
                     (std::string(tempDir.c_str()) + "/").c_str(),g_nativeLibDir.c_str(),
                     (std::string(driverPath.c_str()) + "/").c_str(),driverLibName.c_str(),
                     (std::string(fileRedirectDir.c_str()) + "/").c_str(),nullptr);
+            if (!lib) {
+                ERROR_LOG(G3D, "Failed to load custom driver");
+            }
         }
     }
 #endif
 
     if (!lib) {
-        ERROR_LOG(G3D, "Failed to load custom driver");
         for (int i = 0; i < ARRAY_SIZE(so_names); i++) {
             lib = dlopen(so_names[i], RTLD_NOW | RTLD_LOCAL);
             if (lib) {

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -1806,8 +1806,8 @@ void VKRPipelineLayout::FlushDescSets(VulkanContext *vulkan, int frame, QueuePro
 			case BindingType::STORAGE_BUFFER_VERTEX:
 			case BindingType::STORAGE_BUFFER_COMPUTE:
 				bufferInfo[numBuffers].buffer = data[i].buffer.buffer;
-				bufferInfo[numBuffers].offset = data[i].buffer.offset;
 				bufferInfo[numBuffers].range = data[i].buffer.range;
+				bufferInfo[numBuffers].offset = data[i].buffer.offset;
 				writes[numWrites].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
 				writes[numWrites].pBufferInfo = &bufferInfo[numBuffers];
 				writes[numWrites].pImageInfo = nullptr;
@@ -1816,8 +1816,8 @@ void VKRPipelineLayout::FlushDescSets(VulkanContext *vulkan, int frame, QueuePro
 			case BindingType::UNIFORM_BUFFER_DYNAMIC_ALL:
 			case BindingType::UNIFORM_BUFFER_DYNAMIC_VERTEX:
 				bufferInfo[numBuffers].buffer = data[i].buffer.buffer;
-				bufferInfo[numBuffers].offset = 0;
 				bufferInfo[numBuffers].range = data[i].buffer.range;
+				bufferInfo[numBuffers].offset = 0;
 				writes[numWrites].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
 				writes[numWrites].pBufferInfo = &bufferInfo[numBuffers];
 				writes[numWrites].pImageInfo = nullptr;

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -205,10 +205,12 @@ struct PackedDescriptor {
 			uint32_t range;
 			uint32_t offset;
 		} buffer;
+#if false
 		struct {
 			VkBuffer buffer;
 			uint64_t range;  // write range and a zero offset in one operation with this.
 		} buffer_zero_offset;
+#endif
 	};
 };
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -202,9 +202,13 @@ struct PackedDescriptor {
 		} image;
 		struct {
 			VkBuffer buffer;
-			uint32_t offset;
 			uint32_t range;
+			uint32_t offset;
 		} buffer;
+		struct {
+			VkBuffer buffer;
+			uint64_t range;  // write range and a zero offset in one operation with this.
+		} buffer_zero_offset;
 	};
 };
 

--- a/Common/Render/ManagedTexture.cpp
+++ b/Common/Render/ManagedTexture.cpp
@@ -32,8 +32,8 @@ public:
 		size_t fileSize;
 		uint8_t *buffer = g_VFS.ReadFile(filename_.c_str(), &fileSize);
 		if (!buffer) {
-			filename_.clear();
 			ERROR_LOG(IO, "Failed to read file '%s'", filename_.c_str());
+			filename_.clear();
 			*state_ = ManagedTexture::LoadState::FAILED;
 			return;
 		}

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -332,12 +332,12 @@ void DrawEngineVulkan::DoFlush() {
 		descriptors[1].image.sampler = samplerSecondaryNearest_;
 		descriptors[2].image.view = boundDepal_;
 		descriptors[2].image.sampler = (boundDepal_ && boundDepalSmoothed_) ? samplerSecondaryLinear_ : samplerSecondaryNearest_;
-		descriptors[3].buffer.buffer = baseBuf;
-		descriptors[3].buffer.range = sizeof(UB_VS_FS_Base);
-		descriptors[4].buffer.buffer = lightBuf;
-		descriptors[4].buffer.range = sizeof(UB_VS_Lights);
-		descriptors[5].buffer.buffer = boneBuf;
-		descriptors[5].buffer.range = sizeof(UB_VS_Bones);
+		descriptors[3].buffer_zero_offset.buffer = baseBuf;
+		descriptors[3].buffer_zero_offset.range = sizeof(UB_VS_FS_Base);
+		descriptors[4].buffer_zero_offset.buffer = lightBuf;
+		descriptors[4].buffer_zero_offset.range = sizeof(UB_VS_Lights);
+		descriptors[5].buffer_zero_offset.buffer = boneBuf;
+		descriptors[5].buffer_zero_offset.range = sizeof(UB_VS_Bones);
 		if (tess) {
 			const VkDescriptorBufferInfo *bufInfo = tessDataTransferVulkan->GetBufferInfo();
 			for (int j = 0; j < 3; j++) {

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -328,22 +328,30 @@ void DrawEngineVulkan::DoFlush() {
 		PackedDescriptor *descriptors = renderManager->PushDescriptorSet(descCount, &descSetIndex);
 		descriptors[0].image.view = imageView;
 		descriptors[0].image.sampler = sampler;
+
 		descriptors[1].image.view = boundSecondary_;
 		descriptors[1].image.sampler = samplerSecondaryNearest_;
+
 		descriptors[2].image.view = boundDepal_;
 		descriptors[2].image.sampler = (boundDepal_ && boundDepalSmoothed_) ? samplerSecondaryLinear_ : samplerSecondaryNearest_;
-		descriptors[3].buffer_zero_offset.buffer = baseBuf;
-		descriptors[3].buffer_zero_offset.range = sizeof(UB_VS_FS_Base);
-		descriptors[4].buffer_zero_offset.buffer = lightBuf;
-		descriptors[4].buffer_zero_offset.range = sizeof(UB_VS_Lights);
-		descriptors[5].buffer_zero_offset.buffer = boneBuf;
-		descriptors[5].buffer_zero_offset.range = sizeof(UB_VS_Bones);
+
+		descriptors[3].buffer.buffer = baseBuf;
+		descriptors[3].buffer.range = sizeof(UB_VS_FS_Base);
+		descriptors[3].buffer.offset = 0;
+
+		descriptors[4].buffer.buffer = lightBuf;
+		descriptors[4].buffer.range = sizeof(UB_VS_Lights);
+		descriptors[4].buffer.offset = 0;
+
+		descriptors[5].buffer.buffer = boneBuf;
+		descriptors[5].buffer.range = sizeof(UB_VS_Bones);
+		descriptors[5].buffer.offset = 0;
 		if (tess) {
 			const VkDescriptorBufferInfo *bufInfo = tessDataTransferVulkan->GetBufferInfo();
 			for (int j = 0; j < 3; j++) {
 				descriptors[j + 6].buffer.buffer = bufInfo[j].buffer;
-				descriptors[j + 6].buffer.offset = bufInfo[j].offset;
 				descriptors[j + 6].buffer.range = bufInfo[j].range;
+				descriptors[j + 6].buffer.offset = bufInfo[j].offset;
 			}
 		}
 		// TODO: Can we avoid binding all three when not needed? Same below for hardware transform.


### PR DESCRIPTION
Found by Valgrind.

Other minor cleanup, too.

This shouldn't have caused anything worse than slightly worse re-use of descriptors, fortunately.