### PR TITLE
Revert back to the old way of fitting into 16:9: Crop one line at the top and bottom

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -592,7 +592,7 @@ static const ConfigSetting graphicsSettings[] = {
 	ConfigSetting("iShowStatusFlags", &g_Config.iShowStatusFlags, 0, CfgFlag::PER_GAME),
 	ConfigSetting("GraphicsBackend", &g_Config.iGPUBackend, &DefaultGPUBackend, &GPUBackendTranslator::To, &GPUBackendTranslator::From, CfgFlag::DEFAULT | CfgFlag::REPORT),
 #if PPSSPP_PLATFORM(ANDROID) && PPSSPP_ARCH(ARM64)
-    ConfigSetting("CustomDriver", &g_Config.customDriver, "", CfgFlag::DEFAULT),
+	ConfigSetting("CustomDriver", &g_Config.customDriver, "", CfgFlag::DEFAULT),
 #endif
 	ConfigSetting("FailedGraphicsBackends", &g_Config.sFailedGPUBackends, "", CfgFlag::DEFAULT),
 	ConfigSetting("DisabledGraphicsBackends", &g_Config.sDisabledGPUBackends, "", CfgFlag::DEFAULT),
@@ -647,6 +647,7 @@ static const ConfigSetting graphicsSettings[] = {
 	ConfigSetting("DisplayIntegerScale", &g_Config.bDisplayIntegerScale, false, CfgFlag::PER_GAME),
 	ConfigSetting("DisplayAspectRatio", &g_Config.fDisplayAspectRatio, 1.0f, CfgFlag::PER_GAME),
 	ConfigSetting("DisplayStretch", &g_Config.bDisplayStretch, false, CfgFlag::PER_GAME),
+	ConfigSetting("DisplayCropTo16x9", &g_Config.bDisplayCropTo16x9, true, CfgFlag::PER_GAME),
 
 	ConfigSetting("ImmersiveMode", &g_Config.bImmersiveMode, true, CfgFlag::PER_GAME),
 	ConfigSetting("SustainedPerformanceMode", &g_Config.bSustainedPerformanceMode, false, CfgFlag::PER_GAME),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -180,6 +180,7 @@ public:
 	float fDisplayOffsetY;
 	float fDisplayScale;   // Relative to the most constraining axis (x or y).
 	bool bDisplayIntegerScale;  // Snaps scaling to integer scale factors in raw pixels.
+	bool bDisplayCropTo16x9;  // Crops to 16:9 if the resolution is very close.
 	float fDisplayAspectRatio;  // Stored relative to the PSP's native ratio, so 1.0 is the normal pixel aspect ratio.
 
 	bool bImmersiveMode;  // Mode on Android Kitkat 4.4 and later that hides the back button etc.

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -84,14 +84,6 @@ void CalculateDisplayOutputRect(FRect *rc, float origW, float origH, const FRect
 	float scale = g_Config.fDisplayScale;
 	float aspectRatioAdjust = g_Config.fDisplayAspectRatio;
 
-	// Ye olde 1080p hack, new version: If everything is setup to exactly cover the screen (defaults), and the screen display aspect ratio is 16:9,
-	// stretch the PSP's aspect ratio veeery slightly to fill it completely.
-	if (scale == 1.0f && offsetX == 0.5f && offsetY == 0.5f && aspectRatioAdjust == 1.0f && !g_Config.bDisplayIntegerScale) {
-		if (fabsf(frame.w / frame.h - 16.0f / 9.0f) < 0.0001f) {
-			aspectRatioAdjust = (frame.w / frame.h) / (480.0f / 272.0f);
-		}
-	}
-
 	float origRatio = !rotated ? origW / origH : origH / origW;
 	float frameRatio = frame.w / frame.h;
 
@@ -119,6 +111,15 @@ void CalculateDisplayOutputRect(FRect *rc, float origW, float origH, const FRect
 		// Image is taller than frame. Center horizontally.
 		outW = scaledHeight * origRatio;
 		outH = scaledHeight;
+	}
+
+	// Ye olde 1080p hack: If everything is setup to exactly cover the screen (defaults), and the screen display aspect ratio is 16:9,
+	// cut off one line from the top and bottom.
+	if (scale == 1.0f && aspectRatioAdjust == 1.0f && offsetX == 0.5f && offsetY == 0.5f && !g_Config.bDisplayIntegerScale && g_Config.bDisplayCropTo16x9) {
+		if (fabsf(frame.w / frame.h - 16.0f / 9.0f) < 0.0001f) {
+			outW *= 272.0f / 270.0f;
+			outH *= 272.0f / 270.0f;
+		}
 	}
 
 	if (g_Config.bDisplayIntegerScale) {


### PR DESCRIPTION
I seem to have switched to a stretch at some point, which isn't ideal and can be achieved anyway with the existing stretch option. A two-line crop (1 at top, 1 at bottom) is generally the better option and preserves the correct aspect ratio.

There's now also a hidden ini setting to turn it off. I might be convinced to add it as a real setting once I figure out a good name for it. The setting:

```ini
[Graphics]
DisplayCropTo16x9 = True
```

Fixes #18693