### PR TITLE
Remove a bunch of dead code from CoreTiming ("threadsafe" events)

### DIFF
--- a/Common/Serialize/SerializeList.h
+++ b/Common/Serialize/SerializeList.h
@@ -99,3 +99,12 @@ void DoLinkedList(PointerWrap &p, LinkedListItem<T> *&list_start, LinkedListItem
 		list_cur = list_cur->next;
 	}
 }
+
+inline void DoIgnoreUnusedLinkedList(PointerWrap &p) {
+	u8 shouldExist = 0;
+	Do(p, shouldExist);
+	if (shouldExist) {
+		// We don't support this linked list and haven't used it forever.
+		p.SetError(p.ERROR_FAILURE);
+	}
+}

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -63,15 +63,7 @@ struct BaseEvent {
 typedef LinkedListItem<BaseEvent> Event;
 
 Event *first;
-Event *tsFirst;
-Event *tsLast;
-
-// event pools
 Event *eventPool = 0;
-Event *eventTsPool = 0;
-int allocatedTsEvents = 0;
-// Optimization to skip MoveEvents when possible.
-std::atomic<u32> hasTsEvents;
 
 // Downcount has been moved to currentMIPS, to save a couple of clocks in every ARM JIT block
 // as we can already reach that structure through a register.
@@ -81,8 +73,6 @@ alignas(16) s64 globalTimer;
 s64 idledCycles;
 s64 lastGlobalTimeTicks;
 s64 lastGlobalTimeUs;
-
-static std::mutex externalEventLock;
 
 std::vector<MHzChangeCallback> mhzChangeCallbacks;
 
@@ -140,29 +130,10 @@ Event* GetNewEvent()
 	return ev;
 }
 
-Event* GetNewTsEvent()
-{
-	allocatedTsEvents++;
-
-	if(!eventTsPool)
-		return new Event;
-
-	Event* ev = eventTsPool;
-	eventTsPool = ev->next;
-	return ev;
-}
-
 void FreeEvent(Event* ev)
 {
 	ev->next = eventPool;
 	eventPool = ev;
-}
-
-void FreeTsEvent(Event* ev)
-{
-	ev->next = eventTsPool;
-	eventTsPool = ev;
-	allocatedTsEvents--;
 }
 
 int RegisterEvent(const char *name, TimedCallback callback) {
@@ -222,27 +193,18 @@ void Init()
 	idledCycles = 0;
 	lastGlobalTimeTicks = 0;
 	lastGlobalTimeUs = 0;
-	hasTsEvents = 0;
 	mhzChangeCallbacks.clear();
 	CPU_HZ = initialHz;
 }
 
 void Shutdown()
 {
-	MoveEvents();
 	ClearPendingEvents();
 	UnregisterAllEvents();
 
 	while (eventPool) {
 		Event *ev = eventPool;
 		eventPool = ev->next;
-		delete ev;
-	}
-
-	std::lock_guard<std::mutex> lk(externalEventLock);
-	while (eventTsPool) {
-		Event *ev = eventTsPool;
-		eventTsPool = ev->next;
 		delete ev;
 	}
 }
@@ -260,39 +222,6 @@ u64 GetTicks()
 u64 GetIdleTicks()
 {
 	return (u64)idledCycles;
-}
-
-
-// This is to be called when outside threads, such as the graphics thread, wants to
-// schedule things to be executed on the main thread.
-void ScheduleEvent_Threadsafe(s64 cyclesIntoFuture, int event_type, u64 userdata)
-{
-	std::lock_guard<std::mutex> lk(externalEventLock);
-	Event *ne = GetNewTsEvent();
-	ne->time = GetTicks() + cyclesIntoFuture;
-	ne->type = event_type;
-	ne->next = 0;
-	ne->userdata = userdata;
-	if(!tsFirst)
-		tsFirst = ne;
-	if(tsLast)
-		tsLast->next = ne;
-	tsLast = ne;
-
-	hasTsEvents.store(1, std::memory_order::memory_order_release);
-}
-
-// Same as ScheduleEvent_Threadsafe(0, ...) EXCEPT if we are already on the CPU thread
-// in which case the event will get handled immediately, before returning.
-void ScheduleEvent_Threadsafe_Immediate(int event_type, u64 userdata)
-{
-	if(false) //Core::IsCPUThread())
-	{
-		std::lock_guard<std::mutex> lk(externalEventLock);
-		event_types[event_type].callback(userdata, 0);
-	}
-	else
-		ScheduleEvent_Threadsafe(0, event_type, userdata);
 }
 
 void ClearPendingEvents()
@@ -380,57 +309,6 @@ s64 UnscheduleEvent(int event_type, u64 userdata)
 	return result;
 }
 
-s64 UnscheduleThreadsafeEvent(int event_type, u64 userdata)
-{
-	s64 result = 0;
-	std::lock_guard<std::mutex> lk(externalEventLock);
-	if (!tsFirst)
-		return result;
-	while(tsFirst)
-	{
-		if (tsFirst->type == event_type && tsFirst->userdata == userdata)
-		{
-			result = tsFirst->time - GetTicks();
-
-			Event *next = tsFirst->next;
-			FreeTsEvent(tsFirst);
-			tsFirst = next;
-		}
-		else
-		{
-			break;
-		}
-	}
-	if (!tsFirst)
-	{
-		tsLast = NULL;
-		return result;
-	}
-
-	Event *prev = tsFirst;
-	Event *ptr = prev->next;
-	while (ptr)
-	{
-		if (ptr->type == event_type && ptr->userdata == userdata)
-		{
-			result = ptr->time - GetTicks();
-
-			prev->next = ptr->next;
-			if (ptr == tsLast)
-				tsLast = prev;
-			FreeTsEvent(ptr);
-			ptr = prev->next;
-		}
-		else
-		{
-			prev = ptr;
-			ptr = ptr->next;
-		}
-	}
-
-	return result;
-}
-
 void RegisterMHzChangeCallback(MHzChangeCallback callback) {
 	mhzChangeCallbacks.push_back(callback);
 }
@@ -485,54 +363,8 @@ void RemoveEvent(int event_type)
 	}
 }
 
-void RemoveThreadsafeEvent(int event_type)
-{
-	std::lock_guard<std::mutex> lk(externalEventLock);
-	if (!tsFirst)
-	{
-		return;
-	}
-	while(tsFirst)
-	{
-		if (tsFirst->type == event_type)
-		{
-			Event *next = tsFirst->next;
-			FreeTsEvent(tsFirst);
-			tsFirst = next;
-		}
-		else
-		{
-			break;
-		}
-	}
-	if (!tsFirst)
-	{
-		tsLast = NULL;
-		return;
-	}
-	Event *prev = tsFirst;
-	Event *ptr = prev->next;
-	while (ptr)
-	{
-		if (ptr->type == event_type)
-		{
-			prev->next = ptr->next;
-			if (ptr == tsLast)
-				tsLast = prev;
-			FreeTsEvent(ptr);
-			ptr = prev->next;
-		}
-		else
-		{
-			prev = ptr;
-			ptr = ptr->next;
-		}
-	}
-}
-
 void RemoveAllEvents(int event_type)
 {
-	RemoveThreadsafeEvent(event_type);
 	RemoveEvent(event_type);
 }
 
@@ -552,31 +384,6 @@ void ProcessEvents() {
 			// Caught up to the current time.
 			break;
 		}
-	}
-}
-
-void MoveEvents()
-{
-	hasTsEvents.store(0, std::memory_order::memory_order_release);
-
-	std::lock_guard<std::mutex> lk(externalEventLock);
-	// Move events from async queue into main queue
-	while (tsFirst)
-	{
-		Event *next = tsFirst->next;
-		AddEventToQueue(tsFirst);
-		tsFirst = next;
-	}
-	tsLast = NULL;
-
-	// Move free events to threadsafe pool
-	while(allocatedTsEvents > 0 && eventPool)
-	{
-		Event *ev = eventPool;
-		eventPool = ev->next;
-		ev->next = eventTsPool;
-		eventTsPool = ev;
-		allocatedTsEvents--;
 	}
 }
 
@@ -600,8 +407,6 @@ void Advance() {
 	globalTimer += cyclesExecuted;
 	currentMIPS->downcount = slicelength;
 
-	if (hasTsEvents.load(std::memory_order_acquire))
-		MoveEvents();
 	ProcessEvents();
 
 	if (!first) {
@@ -693,8 +498,6 @@ void Event_DoStateOld(PointerWrap &p, BaseEvent *ev)
 }
 
 void DoState(PointerWrap &p) {
-	std::lock_guard<std::mutex> lk(externalEventLock);
-
 	auto s = p.Section("CoreTiming", 1, 3);
 	if (!s)
 		return;
@@ -719,10 +522,10 @@ void DoState(PointerWrap &p) {
 
 	if (s >= 3) {
 		DoLinkedList<BaseEvent, GetNewEvent, FreeEvent, Event_DoState>(p, first, (Event **) NULL);
-		DoLinkedList<BaseEvent, GetNewTsEvent, FreeTsEvent, Event_DoState>(p, tsFirst, &tsLast);
+		DoIgnoreUnusedLinkedList(p);
 	} else {
 		DoLinkedList<BaseEvent, GetNewEvent, FreeEvent, Event_DoStateOld>(p, first, (Event **) NULL);
-		DoLinkedList<BaseEvent, GetNewTsEvent, FreeTsEvent, Event_DoStateOld>(p, tsFirst, &tsLast);
+		DoIgnoreUnusedLinkedList(p);
 	}
 
 	Do(p, CPU_HZ);

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -363,11 +363,6 @@ void RemoveEvent(int event_type)
 	}
 }
 
-void RemoveAllEvents(int event_type)
-{
-	RemoveEvent(event_type);
-}
-
 void ProcessEvents() {
 	while (first) {
 		if (first->time <= (s64)GetTicks()) {
@@ -482,8 +477,7 @@ std::string GetScheduledEventsSummary() {
 	return text;
 }
 
-void Event_DoState(PointerWrap &p, BaseEvent *ev)
-{
+void Event_DoState(PointerWrap &p, BaseEvent *ev) {
 	// There may be padding, so do each one individually.
 	Do(p, ev->time);
 	Do(p, ev->userdata);
@@ -491,8 +485,7 @@ void Event_DoState(PointerWrap &p, BaseEvent *ev)
 	usedEventTypes.insert(ev->type);
 }
 
-void Event_DoStateOld(PointerWrap &p, BaseEvent *ev)
-{
+void Event_DoStateOld(PointerWrap &p, BaseEvent *ev) {
 	Do(p, *ev);
 	usedEventTypes.insert(ev->type);
 }
@@ -521,10 +514,11 @@ void DoState(PointerWrap &p) {
 	restoredEventTypes.clear();
 
 	if (s >= 3) {
-		DoLinkedList<BaseEvent, GetNewEvent, FreeEvent, Event_DoState>(p, first, (Event **) NULL);
+		DoLinkedList<BaseEvent, GetNewEvent, FreeEvent, Event_DoState>(p, first, (Event **)nullptr);
+		// This is here because we previously stored a second queue of "threadsafe" events. Gone now. Remove in the next section version upgrade.
 		DoIgnoreUnusedLinkedList(p);
 	} else {
-		DoLinkedList<BaseEvent, GetNewEvent, FreeEvent, Event_DoStateOld>(p, first, (Event **) NULL);
+		DoLinkedList<BaseEvent, GetNewEvent, FreeEvent, Event_DoStateOld>(p, first, (Event **)nullptr);
 		DoIgnoreUnusedLinkedList(p);
 	}
 

--- a/Core/CoreTiming.h
+++ b/Core/CoreTiming.h
@@ -95,10 +95,8 @@ namespace CoreTiming
 	s64 UnscheduleEvent(int event_type, u64 userdata);
 
 	void RemoveEvent(int event_type);
-	void RemoveAllEvents(int event_type);
 	bool IsScheduled(int event_type);
 	void Advance();
-	void ProcessFifoWaitEvents();
 	void ForceCheck();
 
 	// Pretend that the main CPU has executed enough cycles to reach the next event.

--- a/Core/CoreTiming.h
+++ b/Core/CoreTiming.h
@@ -92,17 +92,12 @@ namespace CoreTiming
 	// userdata MAY NOT CONTAIN POINTERS. userdata might get written and reloaded from disk,
 	// when we implement state saves.
 	void ScheduleEvent(s64 cyclesIntoFuture, int event_type, u64 userdata=0);
-	void ScheduleEvent_Threadsafe(s64 cyclesIntoFuture, int event_type, u64 userdata=0);
-	void ScheduleEvent_Threadsafe_Immediate(int event_type, u64 userdata=0);
 	s64 UnscheduleEvent(int event_type, u64 userdata);
-	s64 UnscheduleThreadsafeEvent(int event_type, u64 userdata);
 
 	void RemoveEvent(int event_type);
-	void RemoveThreadsafeEvent(int event_type);
 	void RemoveAllEvents(int event_type);
 	bool IsScheduled(int event_type);
 	void Advance();
-	void MoveEvents();
 	void ProcessFifoWaitEvents();
 	void ForceCheck();
 

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -179,7 +179,7 @@ static void __KernelUmdActivate()
 		__KernelNotifyCallback(driveCBId, notifyArg);
 
 	// Don't activate immediately, take time to "spin up."
-	CoreTiming::RemoveAllEvents(umdStatChangeEvent);
+	CoreTiming::RemoveEvent(umdStatChangeEvent);
 	CoreTiming::ScheduleEvent(usToCycles(MICRO_DELAY_ACTIVATE), umdStatChangeEvent, 1);
 }
 
@@ -189,7 +189,7 @@ static void __KernelUmdDeactivate()
 	if (driveCBId != 0)
 		__KernelNotifyCallback(driveCBId, notifyArg);
 
-	CoreTiming::RemoveAllEvents(umdStatChangeEvent);
+	CoreTiming::RemoveEvent(umdStatChangeEvent);
 	__UmdStatChange(0, 0);
 }
 

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -247,8 +247,6 @@ static void ExpandRange(std::pair<u32, u32> &range, u32 newStart, u32 newEnd) {
 
 void JitBlockCache::FinalizeBlock(int block_num, bool block_link) {
 	JitBlock &b = blocks_[block_num];
-	_dbg_assert_(b.blockNum == block_num);
-
 	_assert_msg_(Memory::IsValidAddress(b.originalAddress), "FinalizeBlock: Bad originalAddress %08x in block %d (b.num: %d) proxy: %s sz: %d", b.originalAddress, block_num, b.blockNum, b.proxyFor ? "y" : "n", b.codeSize);
 
 	b.originalFirstOpcode = Memory::Read_Opcode_JIT(b.originalAddress);


### PR DESCRIPTION
We haven't used these "threadsafe" events since we removed our first attempt at GPU threading, so like for 10 years, and maybe some experimentation in the networking code according to some comments. 

Regarding savestates, it's unlikely that any savestates that had some of these events stored would load anyway. By just storing a single byte empty list marker in savestates, and rejecting save states that do have events in this list, we avoid even bumping the savestate version here.

@unknownbrackets , agree? Might also keep enough code to load the events and throw them into the regular queue.