### PR TITLE
OpenXR - Shadow of Destiny VR camera fixed

### DIFF
--- a/assets/compatvr.ini
+++ b/assets/compatvr.ini
@@ -98,6 +98,11 @@ ULUS10323 = true
 [MirroringVariant]
 # Forces mirroring of the view matrix
 
+# Shadow of Destiny / Shadow of Memories
+NPJH50036 = 3
+ULUS10459 = 3
+VP051J1 = 3
+
 # Tony Hawk's Underground 2 Remix
 ULES00033 = 3
 ULES00034 = 3


### PR DESCRIPTION
The same problem like in Tony Hawk. For some reason the method for detecting camera rotation mirroring (which works in 99% of games) doesn't work in this game.