### PR TITLE
Android: Fix running plain PRXs on scoped storage. Minor cleanup.

### DIFF
--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -262,16 +262,14 @@ bool DirectoryFileHandle::Open(const Path &basePath, std::string &fileName, File
 			return false;
 		}
 		fullName = GetLocalPath(basePath, fileName);
-		const char *fullNameC = fullName.c_str();
-
-		DEBUG_LOG(FILESYS, "Case may have been incorrect, second try opening %s (%s)", fullNameC, fileName.c_str());
+		DEBUG_LOG(FILESYS, "Case may have been incorrect, second try opening %s (%s)", fullName.c_str(), fileName.c_str());
 
 		// And try again with the correct case this time
 #ifdef _WIN32
-		hFile = CreateFile(fullNameC, desired, sharemode, 0, openmode, 0, 0);
+		hFile = CreateFile(fullName.c_str(), desired, sharemode, 0, openmode, 0, 0);
 		success = hFile != INVALID_HANDLE_VALUE;
 #else
-		hFile = open(fullNameC, flags, 0666);
+		hFile = open(fullName.c_str(), flags, 0666);
 		success = hFile != -1;
 #endif
 	}

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -427,7 +427,7 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 		pspFileSystem.SetStartingDirectory(ms_path);
 	}
 
-	std::shared_ptr<IFileSystem> fs = std::shared_ptr<IFileSystem>(new DirectoryFileSystem(&pspFileSystem, Path(path), FileSystemFlags::SIMULATE_FAT32 | FileSystemFlags::CARD));
+	std::shared_ptr<IFileSystem> fs = std::shared_ptr<IFileSystem>(new DirectoryFileSystem(&pspFileSystem, full_path.NavigateUp(), FileSystemFlags::SIMULATE_FAT32 | FileSystemFlags::CARD));
 	pspFileSystem.Mount("umd0:", fs);
 
 	std::string finalName = ms_path + file;

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -395,6 +395,7 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 		ms_path = "umd0:/";
 	}
 
+	Path dir;
 	if (!PSP_CoreParameter().mountRoot.empty()) {
 		// We don't want to worry about .. and cwd and such.
 		const Path rootNorm = NormalizePath(PSP_CoreParameter().mountRoot);
@@ -423,15 +424,10 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 		file = filepath + "/" + file;
 		path = rootNorm.ToString();
 		pspFileSystem.SetStartingDirectory(filepath);
+		dir = Path(path);
 	} else {
 		pspFileSystem.SetStartingDirectory(ms_path);
-	}
-
-	Path dir;
-	if (full_path.Type() == PathType::CONTENT_URI) {
 		dir = full_path.NavigateUp();
-	} else {
-		dir = Path(path);
 	}
 
 	std::shared_ptr<IFileSystem> fs = std::shared_ptr<IFileSystem>(new DirectoryFileSystem(&pspFileSystem, dir, FileSystemFlags::SIMULATE_FAT32 | FileSystemFlags::CARD));

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -427,7 +427,14 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 		pspFileSystem.SetStartingDirectory(ms_path);
 	}
 
-	std::shared_ptr<IFileSystem> fs = std::shared_ptr<IFileSystem>(new DirectoryFileSystem(&pspFileSystem, full_path.NavigateUp(), FileSystemFlags::SIMULATE_FAT32 | FileSystemFlags::CARD));
+	Path dir;
+	if (full_path.Type() == PathType::CONTENT_URI) {
+		dir = full_path.NavigateUp();
+	} else {
+		dir = Path(path);
+	}
+
+	std::shared_ptr<IFileSystem> fs = std::shared_ptr<IFileSystem>(new DirectoryFileSystem(&pspFileSystem, dir, FileSystemFlags::SIMULATE_FAT32 | FileSystemFlags::CARD));
 	pspFileSystem.Mount("umd0:", fs);
 
 	std::string finalName = ms_path + file;

--- a/android/src/org/ppsspp/ppsspp/NativeActivity.java
+++ b/android/src/org/ppsspp/ppsspp/NativeActivity.java
@@ -1348,7 +1348,11 @@ public abstract class NativeActivity extends Activity {
 		AlertDialog dlg = builder.create();
 
 		dlg.setCancelable(true);
-		dlg.show();
+		try {
+			dlg.show();
+		} catch (Exception e) {
+			NativeApp.reportException(e, "AlertDialog");
+		}
 	}
 
 	public boolean processCommand(String command, String params) {


### PR DESCRIPTION
Not sure when this regressed, but with this it's working again.