### PR TITLE
Settings banner for game specific settings

### DIFF
--- a/Tools/langtool/src/section.rs
+++ b/Tools/langtool/src/section.rs
@@ -33,7 +33,7 @@ impl Section {
         }
     }
 
-    pub fn get_line(&mut self, key: &str) -> Option<String> {
+    pub fn get_line(&self, key: &str) -> Option<String> {
         for line in self.lines.iter() {
             let prefix = if let Some(pos) = line.find(" =") {
                 &line[0..pos]

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -1020,7 +1020,7 @@ bool ShaderViewScreen::key(const KeyInput &ki) {
 }
 
 
-const std::string framedumpsBaseUrl = "http://framedump.ppsspp.org/repro/";
+const std::string_view framedumpsBaseUrl("http://framedump.ppsspp.org/repro/");
 
 FrameDumpTestScreen::FrameDumpTestScreen() {
 
@@ -1053,7 +1053,7 @@ void FrameDumpTestScreen::CreateViews() {
 	dumps->Add(new ItemHeader("GE Frame Dumps"));
 
 	for (auto &file : files_) {
-		std::string url = framedumpsBaseUrl + file;
+		std::string url = std::string(framedumpsBaseUrl) + file;
 		Choice *c = dumps->Add(new Choice(file));
 		c->SetTag(url);
 		c->OnClick.Handle<FrameDumpTestScreen>(this, &FrameDumpTestScreen::OnLoadDump);
@@ -1075,7 +1075,7 @@ void FrameDumpTestScreen::update() {
 
 	if (!listing_) {
 		const char *acceptMime = "text/html, */*; q=0.8";
-		listing_ = g_DownloadManager.StartDownload(framedumpsBaseUrl, Path(), http::ProgressBarMode::DELAYED, acceptMime);
+		listing_ = g_DownloadManager.StartDownload(std::string(framedumpsBaseUrl), Path(), http::ProgressBarMode::DELAYED, acceptMime);
 	}
 
 	if (listing_ && listing_->Done() && files_.empty()) {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -516,7 +516,8 @@ void EmuScreen::focusChanged(ScreenFocusChange focusChange) {
 void EmuScreen::sendMessage(UIMessage message, const char *value) {
 	// External commands, like from the Windows UI.
 	if (message == UIMessage::REQUEST_GAME_PAUSE && screenManager()->topScreen() == this) {
-		screenManager()->push(new GamePauseScreen(gamePath_));
+		std::string gameID = g_paramSFO.GetValueString("DISC_ID");
+		screenManager()->push(new GamePauseScreen(gamePath_, gameID));
 	} else if (message == UIMessage::REQUEST_GAME_STOP) {
 		// We will push MainScreen in update().
 		PSP_Shutdown();
@@ -603,8 +604,8 @@ void EmuScreen::sendMessage(UIMessage message, const char *value) {
 			if (!KeyMap::IsKeyMapped(DEVICE_ID_PAD_0, VIRTKEY_PAUSE) || !KeyMap::IsKeyMapped(DEVICE_ID_PAD_1, VIRTKEY_PAUSE)) {
 				// If it's a TV (so no built-in back button), and there's no back button mapped to a pad,
 				// use this as the fallback way to get into the menu.
-
-				screenManager()->push(new GamePauseScreen(gamePath_));
+				std::string gameID = g_paramSFO.GetValueString("DISC_ID");
+				screenManager()->push(new GamePauseScreen(gamePath_, gameID));
 			}
 		}
 	} else if (message == UIMessage::REQUEST_PLAY_SOUND) {
@@ -1229,7 +1230,8 @@ void EmuScreen::update() {
 
 	if (pauseTrigger_) {
 		pauseTrigger_ = false;
-		screenManager()->push(new GamePauseScreen(gamePath_));
+		std::string gameID = g_paramSFO.GetValueString("DISC_ID");
+		screenManager()->push(new GamePauseScreen(gamePath_, gameID));
 	}
 
 	if (saveStatePreview_ && !bootPending_) {

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -233,32 +233,67 @@ void GameSettingsScreen::PreCreateViews() {
 	iAlternateSpeedPercentAnalog_ = (g_Config.iAnalogFpsLimit * 100) / 60;
 }
 
+void GameSettingsScreen::CreateBanner(UI::LinearLayout *parent, std::string_view category, std::string_view url) {
+	using namespace UI;
+	auto ms = GetI18NCategory(I18NCat::MAINSETTINGS);
+
+	LinearLayout *banner = new LinearLayout(ORIENT_HORIZONTAL);
+	std::string title(category);
+	bool hasGameConfig = false;
+	if (g_Config.hasGameConfig(gameID_)) {
+		auto info = g_gameInfoCache->GetInfo(nullptr, gamePath_, GameInfoFlags::PARAM_SFO);
+		title = info->GetTitle() + " - " + gameID_;
+		hasGameConfig = true;
+	}
+	if (hasGameConfig) {
+		banner->Add(new ImageView(ImageID("I_GEAR"), "", UI::ImageSizeMode::IS_KEEP_ASPECT, new LinearLayoutParams(50, 50, 0.0f, G_CENTER)));
+	}
+	banner->Add(new TextView(title, new LinearLayoutParams(Margins(10, 10))));
+	banner->Add(new Spacer(0.0f, new LinearLayoutParams(1.0f)));
+	if (!url.empty()) {
+		banner->Add(new Button(ms->T("Help"), new LinearLayoutParams(Margins(8, 8))))->OnClick.Add([=](UI::EventParams &e) {
+			std::string fullUrl = std::string("https://www.ppsspp.org/docs/settings/") + std::string(url);
+			System_LaunchUrl(LaunchUrlType::BROWSER_URL, fullUrl.c_str());
+			return UI::EVENT_DONE;
+		});
+	}
+	banner->SetBG(UI::Drawable(0x30000000));
+	parent->Add(banner);
+}
+
 void GameSettingsScreen::CreateTabs() {
 	using namespace UI;
 	auto ms = GetI18NCategory(I18NCat::MAINSETTINGS);
 
 	LinearLayout *graphicsSettings = AddTab("GameSettingsGraphics", ms->T("Graphics"));
+	CreateBanner(graphicsSettings, ms->T("Graphics"), "graphics");
 	CreateGraphicsSettings(graphicsSettings);
 
 	LinearLayout *controlsSettings = AddTab("GameSettingsControls", ms->T("Controls"));
+	CreateBanner(controlsSettings, ms->T("Controls"), "controls");
 	CreateControlsSettings(controlsSettings);
 
 	LinearLayout *audioSettings = AddTab("GameSettingsAudio", ms->T("Audio"));
+	CreateBanner(audioSettings, ms->T("Audio"), "audio");
 	CreateAudioSettings(audioSettings);
 
 	LinearLayout *networkingSettings = AddTab("GameSettingsNetworking", ms->T("Networking"));
+	CreateBanner(networkingSettings, ms->T("Networking"), "network");
 	CreateNetworkingSettings(networkingSettings);
 
-	LinearLayout *tools = AddTab("GameSettingsTools", ms->T("Tools"));
-	CreateToolsSettings(tools);
+	LinearLayout *toolsSettings = AddTab("GameSettingsTools", ms->T("Tools"));
+	CreateBanner(toolsSettings, ms->T("Tools"), "tools");
+	CreateToolsSettings(toolsSettings);
 
 	LinearLayout *systemSettings = AddTab("GameSettingsSystem", ms->T("System"));
 	systemSettings->SetSpacing(0);
+	CreateBanner(systemSettings, ms->T("System"), "system");
 	CreateSystemSettings(systemSettings);
 
 	int deviceType = System_GetPropertyInt(SYSPROP_DEVICE_TYPE);
 	if ((deviceType == DEVICE_TYPE_VR) || g_Config.bForceVR) {
-		LinearLayout *vrSettings = AddTab("GameSettingsVR", ms->T("VR"));
+		LinearLayout *vrSettings = AddTab("GameSettingsVR", ms->T("VR"), "");
+		CreateBanner(vrSettings, ms->T("VR"), "");
 		CreateVRSettings(vrSettings);
 	}
 }

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -48,6 +48,7 @@ protected:
 
 private:
 	void PreCreateViews() override;
+	void CreateBanner(UI::LinearLayout *parent, std::string_view category, std::string_view url);
 
 	void CreateGraphicsSettings(UI::ViewGroup *graphicsSettings);
 	void CreateControlsSettings(UI::ViewGroup *tools);

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -267,8 +267,8 @@ void GamePauseScreen::update() {
 	SetVRAppMode(VRAppMode::VR_MENU_MODE);
 }
 
-GamePauseScreen::GamePauseScreen(const Path &filename)
-	: UIDialogScreenWithGameBackground(filename) {
+GamePauseScreen::GamePauseScreen(const Path &filename, std::string gameID)
+	: UIDialogScreenWithGameBackground(filename), gameID_(gameID) {
 	// So we can tell if something blew up while on the pause screen.
 	std::string assertStr = "PauseScreen: " + filename.GetFilename();
 	SetExtraAssertInfo(assertStr.c_str());
@@ -467,7 +467,7 @@ void GamePauseScreen::CreateViews() {
 }
 
 UI::EventReturn GamePauseScreen::OnGameSettings(UI::EventParams &e) {
-	screenManager()->push(new GameSettingsScreen(gamePath_));
+	screenManager()->push(new GameSettingsScreen(gamePath_, gameID_));
 	return UI::EVENT_DONE;
 }
 

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -33,7 +33,7 @@ enum class PauseScreenMode {
 
 class GamePauseScreen : public UIDialogScreenWithGameBackground {
 public:
-	GamePauseScreen(const Path &filename);
+	GamePauseScreen(const Path &filename, std::string gameID);
 	~GamePauseScreen();
 
 	void dialogFinished(const Screen *dialog, DialogResult dr) override;
@@ -70,4 +70,5 @@ private:
 	PauseScreenMode mode_ = PauseScreenMode::MAIN;
 
 	UI::Button *playButton_ = nullptr;
+	std::string gameID_;
 };

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -771,6 +771,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = ‎الصوت
 Controls = ‎التحكم
 Graphics = ‎الجرافكس
+Help = ‎مساعدة
 Networking = ‎الشبكة
 Search = البحث
 System = ‎النظام

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Səs
 Controls = Kontrollar
 Graphics = Qrafika
+Help = Help
 Networking = Networking
 Search = Search
 System = Sistem

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Аудио
 Controls = Контроли
 Graphics = Графика
+Help = Помощ
 Networking = Networking
 Search = Search
 System = Система

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Àudio
 Controls = Controls
 Graphics = Gràfics
+Help = Ajuda
 Networking = Joc en xarxa
 Search = Cercar
 System = Sistema

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Zvuk
 Controls = Ovládání
 Graphics = Grafika
+Help = Nápověda
 Networking = Síť
 Search = Search
 System = Systém

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -767,6 +767,7 @@ Networking = Netværk
 Search = Search
 System = System
 Tools = Tools
+Help = Help
 
 [MappableControls]
 Alt speed 1 = Alt speed 1

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Ton
 Controls = Bedienung
 Graphics = Grafik
+Help = Hilfe
 Networking = Netzwerk
 Search = Suche
 System = System

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Suarana
 Controls = Tombolna
 Graphics = Gambara'na
+Help = Pabalian
 Networking = Networking
 Search = Search
 System = Sistemna

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -791,6 +791,7 @@ Networking = Networking
 System = System
 Tools = Tools
 Search = Search
+Help = Help
 
 [MappableControls]
 Alt speed 1 = Alt speed 1

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = Sitio oficial
 Audio = Sonido
 Controls = Controles
 Graphics = Gráficos
+Help = Ayuda
 Networking = Juego en red
 Search = Buscar
 System = Sistema

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Audio
 Controls = Controles
 Graphics = Gráficos
+Help = Ayuda
 Networking = Juego en red
 Search = Buscar
 System = Sistema

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = ‎وبسایت شبیه ساز
 Audio = ‎صدا
 Controls = ‎کنترل‌ها
 Graphics = ‎گرافیک
+Help = ‎راهنما
 Networking = ‎شبکه
 Search = جستجو
 System = ‎سیستم

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Ääni
 Controls = Ohjaus
 Graphics = Grafiikka
+Help = Apua
 Networking = Verkko
 Search = Haku
 System = Järjestelmä

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = Visiter le site officiel
 Audio = Son
 Controls = Commandes
 Graphics = Graphismes
+Help = Aide
 Networking = Réseau
 Search = Search
 System = Système

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = Sitio oficial
 Audio = Son
 Controls = Controis
 Graphics = Gráficos
+Help = Axuda
 Networking = Xogo en rede
 Search = Search
 System = Sistema

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Ήχος
 Controls = Χειριστήριο
 Graphics = Γραφικά
+Help = Βοήθεια
 Networking = Δικτύωση
 Search = Search
 System = Σύστημα

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = לאתר
 Audio = שמע
 Controls = מקשים
 Graphics = גראפיקה
+Help = Help
 Networking = Networking
 Search = Search
 System = מערכת

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = רתאל
 Audio = עמש
 Controls = םישקמ
 Graphics = הקיפארג
+Help = Help
 Networking = Networking
 Search = Search
 System = תכרעמ

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Zvuk
 Controls = Kontrole
 Graphics = Grafike
+Help = Pomoć
 Networking = Internet
 Search = Search
 System = Sistem

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Hang
 Controls = Irányítás
 Graphics = Grafika
+Help = Segítség
 Networking = Hálózat
 Search = Search
 System = Rendszer

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Suara
 Controls = Kontrol
 Graphics = Grafis
+Help = Bantuan
 Networking = Koneksi
 System = Sistem
 Tools = Alat

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -764,6 +764,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Audio
 Controls = Controlli
 Graphics = Grafica
+Help = Aiuto
 Networking = Rete
 Search = Ricerca
 System = Sistema

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = オーディオ
 Controls = コントロール
 Graphics = グラフィックス
+Help = ヘルプ(&H)
 Networking = ネットワーク
 Search = 検索
 System = システム

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Suoro
 Controls = Kontrol
 Graphics = Tampilan
+Help = Pithulungan
 Networking = Jaringan
 Search = Search
 System = Sistem

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = 오디오
 Controls = 조작
 Graphics = 그래픽
+Help = 도움말(&H)
 Networking = 네트워킹
 System = 시스템
 Tools = 도구

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = ສຽງ
 Controls = ການຄວບຄຸມ
 Graphics = ກຣາບຟິກ
+Help = ຊ່ອຍເຫຼືອ
 Networking = ເຄື່ອຂ່າຍ
 Search = Search
 System = ລະບົບ

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Garsas
 Controls = Valdymas
 Graphics = Grafika
+Help = Help
 Networking = Tinklų parametrai
 Search = Search
 System = Sistema

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Suara
 Controls = Kawalan
 Graphics = Grafik
+Help = Bantuan
 Networking = Networking
 Search = Search
 System = Sistem

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Geluid
 Controls = Besturing
 Graphics = Beeld
+Help = Help
 Networking = Netwerk
 Search = Search
 System = Systeem

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Lyd
 Controls = Kontroll
 Graphics = Grafikk
+Help = Help
 Networking = Networking
 Search = Search
 System = System

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -767,6 +767,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Dźwięk
 Controls = Sterowanie
 Graphics = Grafika
+Help = Pomoc
 Networking = Sieć
 Search = Wyszukiwanie
 System = System

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -787,6 +787,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Áudio
 Controls = Controles
 Graphics = Gráficos
+Help = Ajuda
 Networking = Rede
 System = Sistema
 Tools = Ferramentas

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -787,6 +787,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Áudio
 Controls = Controlos
 Graphics = Gráficos
+Help = Ajuda
 Networking = Rede
 System = Sistema
 Tools = Ferramentas

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -764,6 +764,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Audio
 Controls = Setări de Control
 Graphics = Grafică
+Help = Help
 Networking = Rețelistică
 Search = Search
 System = Sistem

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Аудио
 Controls = Управление
 Graphics = Графика
+Help = Справка
 Networking = Сеть
 Search = Поиск
 System = Системные

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -764,6 +764,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Ljud
 Controls = Kontroll
 Graphics = Grafik
+Help = Hjälp
 Networking = Nätverk
 Search = Sök
 System = System

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -764,6 +764,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Tunog
 Controls = Kontrol
 Graphics = Graphics
+Help = Tulong
 Networking = Networking
 Search = Mag-hanap
 System = Sistema

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -770,6 +770,7 @@ www.ppsspp.org = เว็บไซต์หลัก PPSSPP
 Audio = เสียง
 Controls = ควบคุม
 Graphics = กราฟิก
+Help = ช่วยเหลือ
 Networking = เครือข่าย
 Search = ค้นหา
 System = ระบบ

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -767,6 +767,8 @@ Controls = Kontroller
 Graphics = Grafik
 Networking = Ağ
 Search = Arama
+Help = Yardım
+Search = Ara
 System = Sistem
 Tools = Araçlar
 

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Аудіо
 Controls = Управління
 Graphics = Графіка
+Help = Довідка
 Networking = Мережа
 Search = Search
 System = Система

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = www.ppsspp.org
 Audio = Âm thanh
 Controls = Điều khiển
 Graphics = Đồ họa
+Help = Giúp đỡ
 Networking = Mạng
 Search = Search
 System = Hệ thống

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = 访问官网
 Audio = 声音设置
 Controls = 控制设置
 Graphics = 图像设置
+Help = 帮助
 Networking = 网络设置
 System = 系统设置
 Tools = 工具

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -763,6 +763,7 @@ www.ppsspp.org = 官方網站
 Audio = 音訊
 Controls = 控制
 Graphics = 圖形
+Help = 說明
 Networking = 網路
 System = 系統
 Tools = 工具


### PR DESCRIPTION
This shows a banner if you're editing game-specific settings:

![image](https://github.com/hrydgard/ppsspp/assets/130929/c246272d-6437-4309-88f4-4251bb19cefa)

Unfortunately, we don't have a way to display exactly which settings are game-specific, but this might reduce confusion a bit?

The banner also has room for a Help button that leads to for example https://www.ppsspp.org/docs/settings/graphics . 

However, I don't 100% like this, it's a bit bulky - and I'm also not really sure what to display there if editing global settings.

Thoughts?