### PR TITLE
CwCheatScreen::LoadCheatInfo wait for GameInfo to be ready

### DIFF
--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -33,6 +33,8 @@
 #include "UI/GameInfoCache.h"
 #include "UI/CwCheatScreen.h"
 
+#include <thread>
+
 static const int FILE_CHECK_FRAME_INTERVAL = 53;
 
 static Path GetGlobalCheatFilePath() {
@@ -52,7 +54,7 @@ void CwCheatScreen::LoadCheatInfo() {
 	std::string gameID;
 	while(info->pending){
 		// After onResume() on Android, this could be the first thing that asks for game info
-		sleep(0);
+		std::this_thread::yield();
 	}
 	if (info && info->paramSFOLoaded) {
 		gameID = info->paramSFO.GetValueString("DISC_ID");

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -50,6 +50,10 @@ CwCheatScreen::~CwCheatScreen() {
 void CwCheatScreen::LoadCheatInfo() {
 	std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(nullptr, gamePath_, 0);
 	std::string gameID;
+	while(info->pending){
+		// After onResume() on Android, this could be the first thing that asks for game info
+		sleep(0);
+	}
 	if (info && info->paramSFOLoaded) {
 		gameID = info->paramSFO.GetValueString("DISC_ID");
 	}

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -52,7 +52,7 @@ CwCheatScreen::~CwCheatScreen() {
 void CwCheatScreen::LoadCheatInfo() {
 	std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(nullptr, gamePath_, 0);
 	std::string gameID;
-	while(info->pending){
+	while(info && info->pending){
 		// After onResume() on Android, this could be the first thing that asks for game info
 		std::this_thread::yield();
 	}


### PR DESCRIPTION
Fixes a type of https://github.com/hrydgard/ppsspp/issues/18694 caused by onResume()

```
01-20 14:44:59.127  3094  4393 I MediaProvider: Open with lower FS for /storage/emulated/0/PPSSPP/PSP/Cheats/.ini. Uid: 10085
```

It may or may not be exactly https://github.com/hrydgard/ppsspp/issues/18694 however since the original report noted that a full app restarted is needed, but on my end backing out of the `CwCheatScreen` and going back in was enough to list cheats again on android 13, and this PR only makes it so onResume() does not break it in the first place