### PR TITLE
Warn that extracted ISOs might not work

### DIFF
--- a/Common/System/OSD.h
+++ b/Common/System/OSD.h
@@ -14,6 +14,7 @@ enum class OSDType {
 	MESSAGE_ERROR,
 	MESSAGE_ERROR_DUMP,  // displays lots of text (after the first line), small size
 	MESSAGE_FILE_LINK,
+	MESSAGE_CENTERED_WARNING,
 
 	ACHIEVEMENT_UNLOCKED,
 

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -151,6 +151,7 @@ enum class ScreenEdgePosition {
 	TOP_RIGHT = 5,
 	CENTER_LEFT = 6,
 	CENTER_RIGHT = 7,
+	CENTER = 8,  // Used for REALLY important messages! Not RetroAchievements notifications.
 	VALUE_COUNT,
 };
 

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -484,7 +484,9 @@ static void DoFrameIdleTiming() {
 			sleep_ms(1);
 #else
 			const double left = goal - cur_time;
-			usleep((long)(left * 1000000));
+			if (left > 0.0f && left < 1.0f) {  // Sanity check
+				usleep((long)(left * 1000000));
+			}
 #endif
 		}
 
@@ -743,7 +745,9 @@ void hleLagSync(u64 userdata, int cyclesLate) {
 		// Tight loop on win32 - intentionally, as timing is otherwise not precise enough.
 #ifndef _WIN32
 		const double left = goal - now;
-		usleep((long)(left * 1000000.0));
+		if (left > 0.0f && left < 1.0f) {  // Sanity check
+			usleep((long)(left * 1000000.0));
+		}
 #else
 		yield();
 #endif

--- a/Tools/langtool/src/main.rs
+++ b/Tools/langtool/src/main.rs
@@ -27,6 +27,11 @@ enum Command {
         section: String,
         key: String,
     },
+    AddNewKeyValue {
+        section: String,
+        key: String,
+        value: String,
+    },
     MoveKey {
         old: String,
         new: String,
@@ -116,9 +121,9 @@ fn remove_key(target_ini: &mut IniFile, section: &str, key: &str) -> io::Result<
     Ok(())
 }
 
-fn add_new_key(target_ini: &mut IniFile, section: &str, key: &str) -> io::Result<()> {
+fn add_new_key(target_ini: &mut IniFile, section: &str, key: &str, value: &str) -> io::Result<()> {
     if let Some(section) = target_ini.get_section_mut(section) {
-        section.insert_line_if_missing(&format!("{} = {}", key, key));
+        section.insert_line_if_missing(&format!("{} = {}", key, value));
     } else {
         println!("No section {}", section);
     }
@@ -206,7 +211,12 @@ fn main() {
             Command::AddNewKey {
                 ref section,
                 ref key,
-            } => add_new_key(&mut target_ini, section, key).unwrap(),
+            } => add_new_key(&mut target_ini, section, key, key).unwrap(),
+            Command::AddNewKeyValue {
+                ref section,
+                ref key,
+                ref value,
+            } => add_new_key(&mut target_ini, section, key, value).unwrap(),
             Command::MoveKey {
                 ref old,
                 ref new,
@@ -235,7 +245,14 @@ fn main() {
             ref section,
             ref key,
         } => {
-            add_new_key(&mut reference_ini, section, key).unwrap();
+            add_new_key(&mut reference_ini, section, key, key).unwrap();
+        }
+        Command::AddNewKeyValue {
+            ref section,
+            ref key,
+            ref value,
+        } => {
+            add_new_key(&mut reference_ini, section, key, value).unwrap();
         }
         Command::SortSection { ref section } => sort_section(&mut reference_ini, section).unwrap(),
         Command::RenameKey {

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -275,7 +275,7 @@ void EmuScreen::bootGame(const Path &filename) {
 
 	auto sc = GetI18NCategory(I18NCat::SCREEN);
 	if (info->fileType == IdentifiedFileType::PSP_DISC_DIRECTORY) {
-		g_OSD.Show(OSDType::MESSAGE_CENTERED_WARNING, sc->T("Warning: Extracted ISOs often don't work. Play the ISO file directly."), 7.0f);
+		g_OSD.Show(OSDType::MESSAGE_CENTERED_WARNING, sc->T("ExtractedIsoWarning", "Extracted ISOs often don't work.\nPlay the ISO file directly."), gamePath_.ToVisualString(), 7.0f);
 	}
 
 	extraAssertInfoStr_ = info->id + " " + info->GetTitle();

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -273,6 +273,11 @@ void EmuScreen::bootGame(const Path &filename) {
 	if (!info || info->pending)
 		return;
 
+	auto sc = GetI18NCategory(I18NCat::SCREEN);
+	if (info->fileType == IdentifiedFileType::PSP_DISC_DIRECTORY) {
+		g_OSD.Show(OSDType::MESSAGE_CENTERED_WARNING, sc->T("Warning: Extracted ISOs often don't work. Play the ISO file directly."), 7.0f);
+	}
+
 	extraAssertInfoStr_ = info->id + " " + info->GetTitle();
 	SetExtraAssertInfo(extraAssertInfoStr_.c_str());
 
@@ -283,7 +288,6 @@ void EmuScreen::bootGame(const Path &filename) {
 
 		g_Discord.SetPresenceGame(info->GetTitle().c_str());
 	} else {
-		auto sc = GetI18NCategory(I18NCat::SCREEN);
 		g_Discord.SetPresenceGame(sc->T("Untitled PSP game"));
 	}
 

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -600,8 +600,6 @@ handleELF:
 			// Let's use the comparison screenshot as an icon, if it exists.
 			if (ReadLocalFileToString(screenshotPath, &info_->icon.data, &info_->lock)) {
 				info_->icon.dataLoaded = true;
-			} else {
-				ERROR_LOG(G3D, "Error loading screenshot data: '%s'", screenshotPath.c_str());
 			}
 			break;
 		}

--- a/UI/OnScreenDisplay.cpp
+++ b/UI/OnScreenDisplay.cpp
@@ -53,7 +53,9 @@ static NoticeLevel GetNoticeLevel(OSDType type) {
 	case OSDType::MESSAGE_INFO: return NoticeLevel::INFO;
 	case OSDType::MESSAGE_ERROR:
 	case OSDType::MESSAGE_ERROR_DUMP: return NoticeLevel::ERROR;
-	case OSDType::MESSAGE_WARNING: return NoticeLevel::WARN;
+	case OSDType::MESSAGE_WARNING:
+	case OSDType::MESSAGE_CENTERED_WARNING:
+		return NoticeLevel::WARN;
 	case OSDType::MESSAGE_SUCCESS: return NoticeLevel::SUCCESS;
 	default: return NoticeLevel::SUCCESS;
 	}
@@ -290,6 +292,7 @@ void OnScreenMessagesView::Draw(UIContext &dc) {
 	typeEdges[(size_t)OSDType::LEADERBOARD_STARTED_FAILED] = (ScreenEdgePosition)g_Config.iAchievementsLeaderboardStartedOrFailedPos;
 	typeEdges[(size_t)OSDType::LEADERBOARD_SUBMITTED] = (ScreenEdgePosition)g_Config.iAchievementsLeaderboardSubmittedPos;
 	typeEdges[(size_t)OSDType::ACHIEVEMENT_UNLOCKED] = (ScreenEdgePosition)g_Config.iAchievementsUnlockedPos;
+	typeEdges[(size_t)OSDType::MESSAGE_CENTERED_WARNING] = ScreenEdgePosition::CENTER;
 
 	dc.SetFontScale(1.0f, 1.0f);
 
@@ -390,6 +393,7 @@ void OnScreenMessagesView::Draw(UIContext &dc) {
 		case ScreenEdgePosition::BOTTOM_RIGHT: horizAdj = 1; vertAdj = 1; break;
 		case ScreenEdgePosition::TOP_CENTER:  vertAdj = -1; break;
 		case ScreenEdgePosition::BOTTOM_CENTER: vertAdj = 1; break;
+		case ScreenEdgePosition::CENTER: break;
 		default: break;
 		}
 

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -1131,6 +1131,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = WARNING: Chainfire3D detected, may cause problems.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Failed to load state
 Failed to save state = Failed to save state
 fixed = ‎السرعة: الجانبي

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = WARNING: Chainfire3D detected, may cause problems.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Failed to load state
 Failed to save state = Failed to save state
 fixed = Speed: alternate

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = ВНИМАНИЕ: Chainfire3D засечен, може да създаде проблеми
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Failed to load state
 Failed to save state = Failed to save state
 fixed = Speed: alternate

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -1123,6 +1123,7 @@ Size = Mida
 [Screen]
 Cardboard VR OFF = Cardboard VR apagat
 Chainfire3DWarning = AVÍS: "Chainfire3D" detectat, pot causar problemes.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Error en carregar l'estat.
 Failed to save state = Error en desar l'estat.
 fixed = Velocitat: alternativa

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = VAROVÁNÍ: Zjištěn Chainfire3D, může způsobit problémy.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Načtení stavu selhalo
 Failed to save state = Uložení stavu selhalo
 fixed = Rychlost: alternativní

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = ADVARSEL: Chainfire3D detekteret, kan give problemer
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Kunne ikke hente tilstand
 Failed to save state = Kunne ikke gemme tilstand
 fixed = Hastighed: fast

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -1123,6 +1123,7 @@ Size = Größe
 [Screen]
 Cardboard VR OFF = Cardboard VR aus
 Chainfire3DWarning = WARNUNG: Chainfire3D erkannt, möglicherweise problematisch
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Laden des Standes fehlgeschlagen
 Failed to save state = Speichern des Standes fehlgeschlagen
 fixed = Geschwindigkeit: Fest

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = WARNING: Chainfire3D detected, may cause problems.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Failed to load state
 Failed to save state = Failed to save state
 fixed = Lassinna: sembarang

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -1147,6 +1147,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = WARNING: Chainfire3D detected, may cause problems.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Failed to load state
 Failed to save state = Failed to save state
 fixed = Speed: alternate

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -1124,6 +1124,7 @@ Size = Tamaño
 [Screen]
 Cardboard VR OFF = Cardboard VR apagado
 Chainfire3DWarning = AVISO: "Chainfire3D" detectado, puede causar problemas.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Error al cargar el estado.
 Failed to save state = Error al guardar el estado.
 fixed = Velocidad: alternativa

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -1125,6 +1125,7 @@ Size = Tamaño
 [Screen]
 Cardboard VR OFF = Cardboard VR apagado
 Chainfire3DWarning = ADVERTENCIA: Chainfire3D detectado, puede causar problemas.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Error al abrir el estado.
 Failed to save state = Error al guardar el estado.
 fixed = Velocidad: fija

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = WARNING: Chainfire3D detected, may cause problems.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Failed to load state
 Failed to save state = Failed to save state
 fixed = ‎سرعت: متناوب

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -1123,6 +1123,7 @@ Size = Koko
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = WARNING: Chainfire3D detected, may cause problems.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Failed to load state
 Failed to save state = Failed to save state
 fixed = Nopeus: vaihtoehtoinen

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -1114,6 +1114,7 @@ Size = Taille
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = Avertissement : Chainfire3D détecté, cela peut poser des problèmes.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Échec du chargement de l'état
 Failed to save state = Échec de la sauvegarde de l'état
 fixed = Vitesse alternative 1

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = AVISO: Chainfire3D detectado, pode causar problemas.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Erro ó cargar o estado
 Failed to save state = Error ó gardar o estado
 fixed = Velocidad: alternativa

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -1123,6 +1123,7 @@ Size = Μέγεθος
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = ΠΡΟΣΟΧΗ: Η εφαρμογή Chainfire3D εντοπίστηκε, ενδέχεται να προκαλέσει προβλήματα.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Σφάλμα φόρτωσης σημείου αποθήκευσης
 Failed to save state = Σφάλμα αποθήκευσης σημείου αποθήκευσης
 fixed = Ταχύτητα: καθορισμένη

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = WARNING: Chainfire3D detected, may cause problems.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Failed to load state
 Failed to save state = Failed to save state
 fixed = יותר מהיר

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = WARNING: Chainfire3D detected, may cause problems.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Failed to load state
 Failed to save state = Failed to save state
 fixed = ריהמ רתוי

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -1123,6 +1123,7 @@ Size = Veličina
 [Screen]
 Cardboard VR OFF = Cardboard VR isključen
 Chainfire3DWarning = UPOZORENJE: Chainfire3D uočen, može stvarati probleme.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Nije moguće učitati save
 Failed to save state = Nije moguće spremiti state
 fixed = Speed: alternate

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -1123,6 +1123,7 @@ Size = Méret
 [Screen]
 Cardboard VR OFF = Cardboard VR ki
 Chainfire3DWarning = FIGYELMEZTETÉS: Chainfire3D észlelve, problémákat okozhat
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Állapotmentés betöltése sikertelen
 Failed to save state = Állápotmentés készítése sikertelen
 fixed = Sebesség: alternatív

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -1123,6 +1123,7 @@ Size = Ukuran
 [Screen]
 Cardboard VR OFF = Cardboard VR mati
 Chainfire3DWarning = Peringatan: Chainfire3D terdeteksi, mungkin akan menyebabkan masalah.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Gagal memuat status permainan
 Failed to save state = Gagal menyimpan status permainan
 fixed = Kecepatan: alternatif

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -1124,6 +1124,7 @@ Size = Dimensioni
 [Screen]
 Cardboard VR OFF = Cardboard VR spenta
 Chainfire3DWarning = AVVISO: rilevato Chainfire3D, potrebbe causare problemi
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Impossibile caricare il salvataggio di stato
 Failed to save state = Impossibile salvare il salvataggio di stato
 Loaded. Game may refuse to save over different savedata. = Caricato. Il gioco potrebbe rifiutarsi da salvare su dati di salvataggio differenti.

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -1123,6 +1123,7 @@ Size = サイズ
 [Screen]
 Cardboard VR OFF = Cardboard VRオフ
 Chainfire3DWarning = 警告: Chainfire3Dを検出しました。問題が起きるかもしれません。
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = ステートのロードに失敗しました
 Failed to save state = ステートのセーブに失敗しました
 fixed = 速度: カスタム速度1

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = PERINGATAN: Chainfire3D terdeteksi, mungkin menyebabkan masalah.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Failed to load state
 Failed to save state = Failed to save state
 fixed = Kecepatan: ora-tetep

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -1123,6 +1123,7 @@ Size = 크기
 [Screen]
 Cardboard VR OFF = 카드보드 VR 끔
 Chainfire3DWarning = 경고: Chainfire3D가 감지되어 문제를 일으킬 수 있습니다.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = 상태를 불러오지 못함
 Failed to save state = 상태를 저장하지 못함
 fixed = 속도: 대체

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = ລະວັງ: ກວດພົບ Chainfire3D, ອາດເກີດບັນຫາໄດ້.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = ລົ້ມເຫຼວໃນການໂຫຼດໄຟລ໌ບັນທຶກ
 Failed to save state = ລົ້ມເຫຼວໃນການບັນທຶກໄຟລ໌ບັນທຶກ
 fixed = ຄວາມໄວ: ຕາມທີ່ປັບໃຊ້

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = ĮSPĖJIMAS: "Chainfire3D" surastas, gali kelti problemų!
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Failed to load state
 Failed to save state = Failed to save state
 fixed = Greitis: alternatyvus

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = AMARAN: Chainfire3D dikesan, boleh menyebabkan masalah
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Failed to load state
 Failed to save state = Failed to save state
 fixed = Kelajuan: Alternatif

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = WAARSCHUWING: Chainfire3D gedetecteerd, kan problemen veroorzaken.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Kon de savestate niet laden
 Failed to save state = Kon de savestate niet opslaan
 fixed = Snelheid: alternatief

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = WARNING: Chainfire3D detected, may cause problems.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Failed to load state
 Failed to save state = Failed to save state
 fixed = Hastighet: alternativ

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -1129,6 +1129,7 @@ Size = Rozmiar
 [Screen]
 Cardboard VR OFF = Wył. Cardboard VR
 Chainfire3DWarning = UWAGA: Wykryto Chainfire3D, może powodować problemy.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Nie można wczytać zapisu stanu
 Failed to save state = Nie można zapisać stanu
 fixed = Prędkość: alternatywna

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -1147,6 +1147,7 @@ Size = Tamanho
 [Screen]
 Cardboard VR OFF = VR do Cardboard desligado
 Chainfire3DWarning = AVISO: Chainfire3D detectado, pode causar problemas.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Falhou em carregar o state
 Failed to save state = Falhou em salvar o state
 fixed = Velocidade: alternativa

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -1149,6 +1149,7 @@ Size = Tamanho
 [Screen]
 Cardboard VR OFF = VR do Cardboard desligado
 Chainfire3DWarning = AVISO: Chainfire3D detectado, poderá causar problemas.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Erro ao carregar o Estado
 Failed to save state = Erro ao salvar o Estado
 fixed = Velocidade: alternativa

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -1124,6 +1124,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = AVERTIZARE: Chainfire3D detectat, poate cauza probleme.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Eroare la încărcare de stare
 Failed to save state = Eroare la salvare de stare
 fixed = Viteză: alternare

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -1123,6 +1123,7 @@ Size = Размер
 [Screen]
 Cardboard VR OFF = Cardboard VR отключен
 Chainfire3DWarning = ВНИМАНИЕ: обнаружен Chainfire3D, это может вызвать проблемы.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Не удалось загрузить состояние
 Failed to save state = Не удалось сохранить состояние
 fixed = Скорость: другая

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -1124,6 +1124,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR av
 Chainfire3DWarning = WARNING: Chainfire3D detected, may cause problems.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Misslyckades ladda state
 Failed to save state = Misslyckades spara state
 fixed = Hastighet: alternativ

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -1123,6 +1123,7 @@ Size = Size
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = WARNING: Chainfire3D detected, may cause problems.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Pumalya sa pag load ng savestate
 Failed to save state = Pumalya sa pag save ng savestate
 fixed = Bilis: Salitan

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -1127,6 +1127,7 @@ Size = ตามขนาด
 [Screen]
 Cardboard VR OFF = ปิดการใช้งาน แว่นการ์ดบอร์ด VR
 Chainfire3DWarning = ระวัง: ตรวจพบ Chainfire3D อาจก่อให้เกิดปัญหารบกวน
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = ล้มเหลวในการโหลดสเตท
 Failed to save state = ล้มเหลวในการเซฟสเตท
 fixed = ความเร็ว: ตามที่ปรับใช้

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -1124,6 +1124,7 @@ Size = Boyut
 [Screen]
 Cardboard VR OFF = Cardboard VR kapalı
 Chainfire3DWarning = UYARI: Chainfire3D algılandı, problemlere sebep olabilir.
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Durum yüklenemedi.
 Failed to save state = Durum kaydedilemedi.
 fixed = Hız: Alternatif

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -1123,6 +1123,7 @@ Size = Розмір
 [Screen]
 Cardboard VR OFF = Cardboard VR вимкнено
 Chainfire3DWarning = Увага: виявлений Chainfire3D, це може викликати проблеми
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Не вдалося завантажити стан
 Failed to save state = Не вдалося зберегти стан
 fixed = Альтернативна швидкість

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -1123,6 +1123,7 @@ Size = Kích cỡ
 [Screen]
 Cardboard VR OFF = Cardboard VR off
 Chainfire3DWarning = CẢNH BÁO: Phát hiện Chainfire3D, có thể gây ra vấn đề
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = Thất bại trong việc load trò chơi
 Failed to save state = Thất bại trong việc lưu trò chơi
 fixed = Tốc độ: alternate

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -1124,6 +1124,7 @@ Size = 大小
 [Screen]
 Cardboard VR OFF = Cardboard VR关闭
 Chainfire3DWarning = 警告：检测到Chainfire3D (3D神器)，可能会导致问题。
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = 无法载入即时存档
 Failed to save state = 无法保存即时存档
 fixed = 速度：预设1

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -1123,6 +1123,7 @@ Size = 大小
 [Screen]
 Cardboard VR OFF = Cardboard VR 關閉
 Chainfire3DWarning = 警告：偵測到 Chainfire3D，可能會造成問題
+ExtractedISOWarning = Extracted ISOs often don't work.\nPlay the ISO file directly.
 Failed to load state = 無法載入存檔
 Failed to save state = 無法儲存存檔
 fixed = 速度：替代


### PR DESCRIPTION
Due to how games do disc access, these often don't work, but as mentioned in #18735, more and more people seem to extract them for some reason.

Fixes #18735 by throwing a message right in the user's face. Hopefully can't be missed (though, famous last words...).