### PR TITLE
Fix another game-shutdown race condition

### DIFF
--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -408,23 +408,6 @@ void VulkanRenderManager::StopThreads() {
 	_dbg_assert_(steps_.empty());
 }
 
-void VulkanRenderManager::DrainAndBlockCompileQueue() {
-	runCompileThread_ = false;
-	compileCond_.notify_all();
-	compileThread_.join();
-
-	_assert_(compileQueue_.empty());
-
-	// At this point, no more tasks can be queued to the threadpool. So wait for them all to go away.
-	CreateMultiPipelinesTask::WaitForAll();
-}
-
-void VulkanRenderManager::ReleaseCompileQueue() {
-	runCompileThread_ = true;
-	INFO_LOG(G3D, "Restarting Vulkan compiler thread");
-	compileThread_ = std::thread(&VulkanRenderManager::CompileThreadFunc, this);
-}
-
 void VulkanRenderManager::DestroyBackbuffers() {
 	StopThreads();
 	vulkan_->WaitUntilQueueIdle();

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -607,7 +607,6 @@ private:
 	std::condition_variable compileCond_;
 	std::mutex compileMutex_;
 	std::vector<CompileQueueEntry> compileQueue_;
-	std::atomic<bool> compileBlocked_{};  // Only for asserting on, now.
 
 	// Thread for measuring presentation delay.
 	std::thread presentWaitThread_;

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -524,8 +524,6 @@ public:
 		return outOfDateFrames_ > VulkanContext::MAX_INFLIGHT_FRAMES;
 	}
 
-	void Invalidate(InvalidationFlags flags);
-
 	VulkanBarrierBatch &PostInitBarrier() {
 		return postInitBarrier_;
 	}
@@ -537,14 +535,16 @@ public:
 private:
 	void EndCurRenderStep();
 
-	void ThreadFunc();
+	void RenderThreadFunc();
 	void CompileThreadFunc();
 
 	void Run(VKRRenderThreadTask &task);
 
 	// Bad for performance but sometimes necessary for synchronous CPU readbacks (screenshots and whatnot).
 	void FlushSync();
-	void StopThread();
+
+	void StartThreads();
+	void StopThreads();
 
 	void PresentWaitThreadFunc();
 	void PollPresentTiming();
@@ -587,7 +587,7 @@ private:
 
 	// Execution time state
 	VulkanContext *vulkan_;
-	std::thread thread_;
+	std::thread renderThread_;
 	VulkanQueueRunner queueRunner_;
 
 	// For pushing data on the queue.

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -529,8 +529,9 @@ public:
 	}
 
 	void ResetStats();
-	void DrainAndBlockCompileQueue();
-	void ReleaseCompileQueue();
+
+	void StartThreads();
+	void StopThreads();
 
 private:
 	void EndCurRenderStep();
@@ -542,9 +543,6 @@ private:
 
 	// Bad for performance but sometimes necessary for synchronous CPU readbacks (screenshots and whatnot).
 	void FlushSync();
-
-	void StartThreads();
-	void StopThreads();
 
 	void PresentWaitThreadFunc();
 	void PollPresentTiming();

--- a/GPU/Vulkan/GPU_Vulkan.cpp
+++ b/GPU/Vulkan/GPU_Vulkan.cpp
@@ -168,7 +168,7 @@ GPU_Vulkan::~GPU_Vulkan() {
 	if (draw_) {
 		VulkanRenderManager *rm = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 		// This now also does a hard sync with the render thread, so that we can safely delete our pipeline layout below.
-		rm->DrainAndBlockCompileQueue();
+		rm->StopThreads();
 	}
 
 	SaveCache(shaderCachePath_);
@@ -185,7 +185,7 @@ GPU_Vulkan::~GPU_Vulkan() {
 	// other managers are deleted in ~GPUCommonHW.
 	if (draw_) {
 		VulkanRenderManager *rm = (VulkanRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
-		rm->ReleaseCompileQueue();
+		rm->StartThreads();
 	}
 }
 
@@ -426,7 +426,7 @@ void GPU_Vulkan::DeviceLost() {
 	Draw::DrawContext *draw = draw_;
 	if (draw) {
 		VulkanRenderManager *rm = (VulkanRenderManager *)draw->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
-		rm->DrainAndBlockCompileQueue();
+		rm->StopThreads();
 	}
 
 	if (shaderCachePath_.Valid()) {
@@ -439,7 +439,7 @@ void GPU_Vulkan::DeviceLost() {
 
 	if (draw) {
 		VulkanRenderManager *rm = (VulkanRenderManager *)draw->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
-		rm->ReleaseCompileQueue();
+		rm->StartThreads();
 	}
 }
 


### PR DESCRIPTION
In crash logs from the fourth beta, discovered an additional race condition.

Let's just drop the big hammer when shutting down a game and stop the render thread entirely while clearing out shaders, instead of just trying to pause the compile thread. This simplifies the code and reduces the amount of paths.