### PR TITLE
Change when we call rc_client_do_frame to something that matches libretro

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -499,9 +499,6 @@ static void DoFrameIdleTiming() {
 void hleEnterVblank(u64 userdata, int cyclesLate) {
 	int vbCount = userdata;
 
-	// This should be a good place to do it. Should happen once per vblank. Here or in leave? Not sure it matters much.
-	Achievements::FrameUpdate();
-
 	VERBOSE_LOG(SCEDISPLAY, "Enter VBlank %i", vbCount);
 
 	DisplayFireVblankStart();

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1432,6 +1432,9 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 		}
 
 		PSP_EndHostFrame();
+
+		// This place rougly matches how libretro handles it (after retro_frame).
+		Achievements::FrameUpdate();
 	}
 
 


### PR DESCRIPTION
There's conflicting advice on when to do it, but to avoid people testing their cheevos twice, let's match as closely as we can.

This means that 30hz games will only have the callback run at 30hz.

The duplicate frames option may interfere, just like it may on libretro.