### PR TITLE
Cleanup read-file-to-string functions

### DIFF
--- a/Common/ArmCPUDetect.cpp
+++ b/Common/ArmCPUDetect.cpp
@@ -90,7 +90,7 @@ const char syscpupresentfile[] = "/sys/devices/system/cpu/present";
 
 std::string GetCPUString() {
 	std::string procdata;
-	bool readSuccess = File::ReadFileToString(true, Path(procfile), procdata);
+	bool readSuccess = File::ReadSysTextFileToString(Path(procfile), &procdata);
 	std::istringstream file(procdata);
 	std::string cpu_string;
 
@@ -113,7 +113,7 @@ std::string GetCPUString() {
 
 std::string GetCPUBrandString() {
 	std::string procdata;
-	bool readSuccess = File::ReadFileToString(true, Path(procfile), procdata);
+	bool readSuccess = File::ReadSysTextFileToString(Path(procfile), &procdata);
 	std::istringstream file(procdata);
 	std::string brand_string;
 
@@ -143,7 +143,7 @@ unsigned char GetCPUImplementer()
 	unsigned char implementer = 0;
 
 	std::string procdata;
-	if (!File::ReadFileToString(true, Path(procfile), procdata))
+	if (!File::ReadSysTextFileToString(Path(procfile), &procdata))
 		return 0;
 	std::istringstream file(procdata);
 
@@ -166,7 +166,7 @@ unsigned short GetCPUPart()
 	unsigned short part = 0;
 
 	std::string procdata;
-	if (!File::ReadFileToString(true, Path(procfile), procdata))
+	if (!File::ReadSysTextFileToString(Path(procfile), &procdata))
 		return 0;
 	std::istringstream file(procdata);
 
@@ -188,7 +188,7 @@ bool CheckCPUFeature(const std::string& feature)
 	std::string line, marker = "Features\t: ";
 
 	std::string procdata;
-	if (!File::ReadFileToString(true, Path(procfile), procdata))
+	if (!File::ReadSysTextFileToString(Path(procfile), &procdata))
 		return false;
 	std::istringstream file(procdata);
 	while (std::getline(file, line))
@@ -214,7 +214,7 @@ int GetCoreCount()
 	int cores = 1;
 
 	std::string presentData;
-	bool presentSuccess = File::ReadFileToString(true, Path(syscpupresentfile), presentData);
+	bool presentSuccess = File::ReadSysTextFileToString(Path(syscpupresentfile), &presentData);
 	std::istringstream presentFile(presentData);
 
 	if (presentSuccess) {
@@ -228,7 +228,7 @@ int GetCoreCount()
 	}
 
 	std::string procdata;
-	if (!File::ReadFileToString(true, Path(procfile), procdata))
+	if (!File::ReadSysTextFileToString(Path(procfile), &procdata))
 		return 1;
 	std::istringstream file(procdata);
 	

--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -126,7 +126,7 @@ static std::vector<int> ParseCPUList(const std::string &filename) {
 	std::string data;
 	std::vector<int> results;
 
-	if (File::ReadFileToString(true, Path(filename), data)) {
+	if (File::ReadSysTextFileToString(Path(filename), &data)) {
 		std::vector<std::string> ranges;
 		SplitString(data, ',', ranges);
 		for (auto range : ranges) {

--- a/Common/Data/Format/IniFile.cpp
+++ b/Common/Data/Format/IniFile.cpp
@@ -517,7 +517,7 @@ bool IniFile::Load(const Path &path)
 
 	// Open file
 	std::string data;
-	if (!File::ReadFileToString(true, path, data)) {
+	if (!File::ReadTextFileToString(path, &data)) {
 		return false;
 	}
 	std::stringstream sstream(data);

--- a/Common/File/FileUtil.h
+++ b/Common/File/FileUtil.h
@@ -205,8 +205,20 @@ private:
 bool WriteStringToFile(bool text_file, const std::string &str, const Path &filename);
 bool WriteDataToFile(bool text_file, const void* data, size_t size, const Path &filename);
 
-bool ReadFileToString(bool text_file, const Path &filename, std::string &str);
+bool ReadFileToStringOptions(bool text_file, bool allowShort, const Path &path, std::string *str);
+
+// Wrappers that clarify the intentions.
+inline bool ReadBinaryFileToString(const Path &path, std::string *str) {
+	return ReadFileToStringOptions(false, false, path, str);
+}
+inline bool ReadSysTextFileToString(const Path &path, std::string *str) {
+	return ReadFileToStringOptions(true, true, path, str);
+}
+inline bool ReadTextFileToString(const Path &path, std::string *str) {
+	return ReadFileToStringOptions(true, false, path, str);
+}
+
 // Return value must be delete[]-d.
-uint8_t *ReadLocalFile(const Path &filename, size_t *size);
+uint8_t *ReadLocalFile(const Path &path, size_t *size);
 
 }  // namespace

--- a/Common/LoongArchCPUDetect.cpp
+++ b/Common/LoongArchCPUDetect.cpp
@@ -54,7 +54,7 @@ private:
 
 LoongArchCPUInfoParser::LoongArchCPUInfoParser() {
 	std::string procdata, line;
-	if (!File::ReadFileToString(true, Path(procfile), procdata))
+	if (!File::ReadSysTextFileToString(Path(procfile), &procdata))
 		return;
 
 	std::istringstream file(procdata);
@@ -87,7 +87,7 @@ int LoongArchCPUInfoParser::ProcessorCount() {
 
 int LoongArchCPUInfoParser::TotalLogicalCount() {
 	std::string presentData, line;
-	bool presentSuccess = File::ReadFileToString(true, Path(syscpupresentfile), presentData);
+	bool presentSuccess = File::ReadSysTextFileToString(Path(syscpupresentfile), &presentData);
 	if (presentSuccess) {
 		std::istringstream presentFile(presentData);
 

--- a/Common/MipsCPUDetect.cpp
+++ b/Common/MipsCPUDetect.cpp
@@ -37,7 +37,7 @@ std::string GetCPUString() {
 	std::string cpu_string = "Unknown";
 
 	std::string procdata;
-	if (!File::ReadFileToString(true, procfile, procdata))
+	if (!File::ReadSysTextFileToString(procfile, &procdata))
 		return cpu_string;
 	std::istringstream file(procdata);
 	
@@ -59,7 +59,7 @@ unsigned char GetCPUImplementer()
 	unsigned char implementer = 0;
 
 	std::string procdata;
-	if (!File::ReadFileToString(true, procfile, procdata))
+	if (!File::ReadSysTextFileToString(procfile, &procdata))
 		return 0;
 	std::istringstream file(procdata);
 
@@ -82,7 +82,7 @@ unsigned short GetCPUPart()
 	unsigned short part = 0;
 
 	std::string procdata;
-	if (!File::ReadFileToString(true, procfile, procdata))
+	if (!File::ReadSysTextFileToString(procfile, &procdata))
 		return 0;
 	std::istringstream file(procdata);
 
@@ -104,7 +104,7 @@ bool CheckCPUASE(const std::string& ase)
 	std::string line, marker = "ASEs implemented\t: ";
 
 	std::string procdata;
-	if (!File::ReadFileToString(true, procfile, procdata))
+	if (!File::ReadSysTextFileToString(procfile, &procdata))
 		return false;
 	std::istringstream file(procdata);
 	
@@ -131,7 +131,7 @@ int GetCoreCount()
 	int cores = 1;
 
 	std::string presentData;
-	bool presentSuccess = File::ReadFileToString(true, syscpupresentfile, presentData);
+	bool presentSuccess = File::ReadSysTextFileToString(syscpupresentfile, &presentData);
 	std::istringstream presentFile(presentData);
 
 	if (presentSuccess) {
@@ -145,7 +145,7 @@ int GetCoreCount()
 	}
 
 	std::string procdata;
-	if (!File::ReadFileToString(true, procfile, procdata))
+	if (!File::ReadSysTextFileToString(procfile, &procdata))
 		return 1;
 	std::istringstream file(procdata);
 	

--- a/Common/RiscVCPUDetect.cpp
+++ b/Common/RiscVCPUDetect.cpp
@@ -60,7 +60,7 @@ private:
 
 RiscVCPUInfoParser::RiscVCPUInfoParser() {
 	std::string procdata, line;
-	if (!File::ReadFileToString(true, Path(procfile), procdata))
+	if (!File::ReadSysTextFileToString(Path(procfile), &procdata))
 		return;
 
 	std::istringstream file(procdata);
@@ -94,7 +94,7 @@ int RiscVCPUInfoParser::ProcessorCount() {
 
 int RiscVCPUInfoParser::TotalLogicalCount() {
 	std::string presentData, line;
-	bool presentSuccess = File::ReadFileToString(true, Path(syscpupresentfile), presentData);
+	bool presentSuccess = File::ReadSysTextFileToString(Path(syscpupresentfile), &presentData);
 	if (presentSuccess) {
 		std::istringstream presentFile(presentData);
 
@@ -136,7 +136,7 @@ bool RiscVCPUInfoParser::FirmwareMatchesCompatible(const std::string &str) {
 		firmwareLoaded_ = true;
 
 		std::string data;
-		if (!File::ReadFileToString(true, Path(firmwarefile), data))
+		if (!File::ReadSysTextFileToString(Path(firmwarefile), &data))
 			return false;
 
 		SplitString(data, '\0', firmware_);

--- a/Core/Reporting.cpp
+++ b/Core/Reporting.cpp
@@ -501,8 +501,9 @@ namespace Reporting
 	void AddScreenshotData(MultipartFormDataEncoder &postdata, const Path &filename)
 	{
 		std::string data;
-		if (!filename.empty() && File::ReadFileToString(false, filename, data))
+		if (!filename.empty() && File::ReadBinaryFileToString(filename, &data)) {
 			postdata.Add("screenshot", data, "screenshot.jpg", "image/jpeg");
+		}
 
 		const std::string iconFilename = "disc0:/PSP_GAME/ICON0.PNG";
 		std::vector<u8> iconData;

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -69,7 +69,7 @@ bool CwCheatScreen::TryLoadCheatInfo() {
 
 	// We won't parse this, just using it to detect changes to the file.
 	std::string str;
-	if (File::ReadFileToString(true, engine_->CheatFilename(), str)) {
+	if (File::ReadTextFileToString(engine_->CheatFilename(), &str)) {
 		fileCheckHash_ = XXH3_64bits(str.c_str(), str.size());
 	}
 	fileCheckCounter_ = 0;
@@ -146,7 +146,7 @@ void CwCheatScreen::update() {
 	if (fileCheckCounter_++ >= FILE_CHECK_FRAME_INTERVAL && engine_) {
 		// Check if the file has changed.  If it has, we'll reload.
 		std::string str;
-		if (File::ReadFileToString(true, engine_->CheatFilename(), str)) {
+		if (File::ReadTextFileToString(engine_->CheatFilename(), &str)) {
 			uint64_t newHash = XXH3_64bits(str.c_str(), str.size());
 			if (newHash != fileCheckHash_) {
 				// This will update the hash.

--- a/UI/DriverManagerScreen.cpp
+++ b/UI/DriverManagerScreen.cpp
@@ -100,7 +100,7 @@ DriverChoice::DriverChoice(const std::string &driverName, bool current, UI::Layo
 
 	Path metaPath = GetDriverPath() / driverName / "meta.json";
 	std::string metaJson;
-	if (File::ReadFileToString(true, metaPath, metaJson)) {
+	if (File::ReadTextFileToString(metaPath, &metaJson)) {
 		std::string errorStr;
 		meta.Read(metaJson, &errorStr);
 	}

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -351,15 +351,20 @@ static bool ReadFileToString(IFileSystem *fs, const char *filename, std::string 
 	if (mtx) {
 		std::string data;
 		data.resize(info.size);
-		fs->ReadFile(handle, (u8 *)data.data(), info.size);
+		size_t readSize = fs->ReadFile(handle, (u8 *)data.data(), info.size);
 		fs->CloseFile(handle);
-
+		if (readSize != info.size) {
+			return false;
+		}
 		std::lock_guard<std::mutex> lock(*mtx);
 		*contents = std::move(data);
 	} else {
 		contents->resize(info.size);
-		fs->ReadFile(handle, (u8 *)contents->data(), info.size);
+		size_t readSize = fs->ReadFile(handle, (u8 *)contents->data(), info.size);
 		fs->CloseFile(handle);
+		if (readSize != info.size) {
+			return false;
+		}
 	}
 	return true;
 }

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -371,7 +371,7 @@ static bool ReadFileToString(IFileSystem *fs, const char *filename, std::string 
 
 static bool ReadLocalFileToString(const Path &path, std::string *contents, std::mutex *mtx) {
 	std::string data;
-	if (!File::ReadFileToString(false, path, data)) {
+	if (!File::ReadBinaryFileToString(path, &data)) {
 		return false;
 	}
 	if (mtx) {

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -309,7 +309,7 @@ static void CheckFailedGPUBackends() {
 
 	if (System_GetPropertyBool(SYSPROP_SUPPORTS_PERMISSIONS)) {
 		std::string data;
-		if (File::ReadFileToString(true, cache, data))
+		if (File::ReadTextFileToString(cache, &data))
 			g_Config.sFailedGPUBackends = data;
 	}
 
@@ -433,7 +433,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	if (File::Exists(memstickDirFile)) {
 		INFO_LOG(SYSTEM, "Reading '%s' to find memstick dir.", memstickDirFile.c_str());
 		std::string memstickDir;
-		if (File::ReadFileToString(true, memstickDirFile, memstickDir)) {
+		if (File::ReadTextFileToString(memstickDirFile, &memstickDir)) {
 			Path memstickPath(memstickDir);
 			if (!memstickPath.empty() && File::Exists(memstickPath)) {
 				g_Config.memStickDirectory = memstickPath;
@@ -460,7 +460,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	if (File::Exists(memstickDirFile)) {
 		INFO_LOG(SYSTEM, "Reading '%s' to find memstick dir.", memstickDirFile.c_str());
 		std::string memstickDir;
-		if (File::ReadFileToString(true, memstickDirFile, memstickDir)) {
+		if (File::ReadTextFileToString(memstickDirFile, &memstickDir)) {
 			Path memstickPath(memstickDir);
 			if (!memstickPath.empty() && File::Exists(memstickPath)) {
 				g_Config.memStickDirectory = memstickPath;
@@ -1542,7 +1542,7 @@ bool NativeSaveSecret(const char *nameOfSecret, const std::string &data) {
 std::string NativeLoadSecret(const char *nameOfSecret) {
 	Path path = GetSecretPath(nameOfSecret);
 	std::string data;
-	if (!File::ReadFileToString(false, path, data)) {
+	if (!File::ReadBinaryFileToString(path, &data)) {
 		data.clear();  // just to be sure.
 	}
 	return data;

--- a/android/jni/TestRunner.cpp
+++ b/android/jni/TestRunner.cpp
@@ -144,7 +144,7 @@ bool RunTests() {
 		PSP_EndHostFrame();
 
 		std::string expect_results;
-		if (!File::ReadFileToString(true, expectedFile, expect_results)) {
+		if (!File::ReadTextFileToString(expectedFile, &expect_results)) {
 			ERROR_LOG(SYSTEM, "Error opening expectedFile %s", expectedFile.c_str());
 			break;
 		}

--- a/headless/Compare.cpp
+++ b/headless/Compare.cpp
@@ -271,7 +271,7 @@ bool CompareOutput(const Path &bootFilename, const std::string &output, bool ver
 				printf("%s", output.c_str());
 				printf("============== expected output:\n");
 				std::string fullExpected;
-				if (File::ReadFileToString(true, expect_filename, fullExpected))
+				if (File::ReadTextFileToString(expect_filename, &fullExpected))
 					printf("%s", fullExpected.c_str());
 				printf("===============================\n");
 			}


### PR DESCRIPTION
Better always check the size to be exact when reading binary files.