### PR TITLE
Add proper checks for file type when picking a background image

### DIFF
--- a/Common/Render/ManagedTexture.cpp
+++ b/Common/Render/ManagedTexture.cpp
@@ -70,7 +70,7 @@ static Draw::DataFormat ZimToT3DFormat(int zim) {
 	}
 }
 
-static ImageFileType DetectImageFileType(const uint8_t *data, size_t size) {
+ImageFileType DetectImageFileType(const uint8_t *data, size_t size) {
 	if (size < 4) {
 		return ImageFileType::UNKNOWN;
 	}

--- a/Common/Render/ManagedTexture.h
+++ b/Common/Render/ManagedTexture.h
@@ -80,3 +80,5 @@ private:
 Draw::Texture *CreateTextureFromFileData(Draw::DrawContext *draw, const uint8_t *data, size_t dataSize, ImageFileType type, bool generateMips, const char *name);
 Draw::Texture *CreateTextureFromFile(Draw::DrawContext *draw, const char *filename, ImageFileType type, bool generateMips);
 Draw::Texture *CreateTextureFromTempImage(Draw::DrawContext *draw, const TempImage &image, bool generateMips, const char *name);
+
+ImageFileType DetectImageFileType(const uint8_t *data, size_t size);

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -128,8 +128,7 @@ android {
 							'-DANDROID_PLATFORM=android-16',
 							'-DANDROID_TOOLCHAIN=clang',
 							'-DANDROID_CPP_FEATURES=',
-							'-DANDROID_STL=c++_static',
-							'-DANDROID_ARM_NEON=TRUE'
+							'-DANDROID_STL=c++_static'
 				}
 			}
 			ndk {

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -1316,6 +1316,7 @@ No animation = No animation
 Not a PSP game = ‎PSP ليست لعبة
 Off = ‎مغلق
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = ‎PSP موديل

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Not a PSP game
 Off = Off
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP model

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Not a PSP game
 Off = Off
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP серия

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Not a PSP game
 Off = Off
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP model

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Toto není hra PSP
 Off = Vypnuto
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = Model PSP

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Not a PSP game
 Off = Off
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP model

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Kein PSP Spiel
 Off = Aus
 Oldest Save = Ältester Spielstand
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP Modell

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Not a PSP game
 Off = Off
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP model

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -1322,6 +1322,7 @@ No animation = No animation
 Not a PSP game = Not a PSP game
 Off = Off
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP model

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -1309,6 +1309,7 @@ No animation = Sin animación
 Not a PSP game = No es un juego de PSP
 Off = No
 Oldest Save = Partida guardada más antigua
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = ¡La ruta no existe!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = Modelo de PSP

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -1310,6 +1310,7 @@ No animation = Sin animación
 Not a PSP game = No es un juego de PSP
 Off = No
 Oldest Save = Antiguos datos de guardado
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = La ruta no existe.
 PSP Memory Stick = Memory Stick de PSP
 PSP Model = Modelo de PSP

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -1308,6 +1308,7 @@ No animation = بدون انمیشین
 Not a PSP game = ‎نیست PSP بازی
 Off = ‎خاموش
 Oldest Save = قدیمی ترین ذخیره
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = مسیر فایل پیدا نشد
 PSP Memory Stick = حافظه psp
 PSP Model = ‎PSP مدل

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -1308,6 +1308,7 @@ No animation = Ei animaatiota
 Not a PSP game = Ei PSP-peli
 Off = Pois
 Oldest Save = Vanhin tallennus
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Polkua ei ole olemassa!
 PSP Memory Stick = PSP-muistikortti
 PSP Model = PSP-malli

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -1299,6 +1299,7 @@ No animation = No animation
 Not a PSP game = Ce n'est pas un jeu PSP.
 Off = Désactivé
 Oldest Save = Le plus ancien état
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = Modèle de PSP

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Not a PSP game
 Off = Off
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = Modelo de PSP

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Δεν είναι παιχνίδι PSP
 Off = Off
 Oldest Save = Παλαιότερο αρχείο αποθήκευσης
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = Μοντέλο PSP

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Not a PSP game
 Off = Off
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP model

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Not a PSP game
 Off = Off
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP model

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Nije PSP igra
 Off = Isključeno
 Oldest Save = Najstariji save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP model

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Nem egy PSP játék
 Off = Ki
 Oldest Save = Legrégebbi mentés
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP modell

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -1308,6 +1308,7 @@ No animation = Tanpa animasi
 Not a PSP game = Bukan permainan PSP
 Off = Mati
 Oldest Save = Simpanan lawas
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Tidak ada jalur!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = Model PSP

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -1291,6 +1291,7 @@ Fast Memory = Memoria Rapida (instabile)
 Force real clock sync (slower, less lag) = Forza sincronizzazione con frequenza reale (lento, meno lag)
 Moving background = Spostamento dello sfondo
 No animation = Nessuna animazione
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Il percorso non esiste!
 PSP Memory Stick = Memory Stick PSP
 Recent games = Giochi recenti

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -1308,6 +1308,7 @@ No animation = アニメーションなし
 Not a PSP game = PSPのゲームではありません
 Off = オフ
 Oldest Save = 最も古いセーブ
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = パスが存在しません
 PSP Memory Stick = メモリースティックの設定
 PSP Model = PSPのモデル

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Ora ana dolanan PSP
 Off = Mati
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP model

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -1298,6 +1298,7 @@ No animation = 애니메이션 없음
 Not a PSP game = PSP 게임이 아님
 Off = 끔
 Oldest Save = 가장 오래된 저장
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = 경로가 존재하지 않습니다!
 PSP Memory Stick = PSP 메모리 스틱
 PSP Model = PSP 모델

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = ອັນນີ້ບໍ່ແມ່ນເກມ PSP
 Off = ປິດ
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = ໂມເດລ PSP

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Not a PSP game
 Off = Off
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = Emuliuojamo PSP modelis

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Not a PSP game
 Off = Off
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = Model PSP

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Geen PSP-game
 Off = Uit
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP-model

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Not a PSP game
 Off = Off
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP model

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -1314,6 +1314,7 @@ No animation = Bez animacji
 Not a PSP game = To nie jest gra PSP
 Off = Wył.
 Oldest Save = Najstarszy zapis
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Ta ścieżka nie istnieje!
 PSP Memory Stick = Karta Pamięci PSP
 PSP Model = Model PSP

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -1322,6 +1322,7 @@ No animation = Sem animação
 Not a PSP game = Não é um jogo de PSP
 Off = Desligado
 Oldest Save = Save mais antigo
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = O caminho não existe!
 PSP Memory Stick = Cartão de Memória do PSP
 PSP Model = Modelo do PSP

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -1324,6 +1324,7 @@ No animation = Sem animação
 Not a PSP game = Não é um jogo de PSP
 Off = Desativado
 Oldest Save = Salvamento mais antigo
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = O caminho não existe!
 PSP Memory Stick = Cartão de memória da PSP
 PSP Model = Modelo da PSP

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -1309,6 +1309,7 @@ No animation = No animation
 Not a PSP game = Nu e joc PSP
 Off = Off
 Oldest Save = Oldest save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = Model PSP

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -1308,6 +1308,7 @@ No animation = Нет анимации
 Not a PSP game = Игра не для PSP
 Off = Отключено
 Oldest Save = Самое старое сохранение
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Путь не существует!
 PSP Memory Stick = Карта памяти PSP
 PSP Model = Модель PSP

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -1309,6 +1309,7 @@ No animation = Ingen animation
 Not a PSP game = Inte ett PSP-spel
 Off = Off
 Oldest Save = Äldsta sparfilen
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP-modell

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -1308,6 +1308,7 @@ No animation = Walang animation
 Not a PSP game = Hindi PSP game
 Off = Off
 Oldest Save = Pinakalumang na i-save
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Direksyon ay hindi na lumabas!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = Modelo ng PSP

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -1330,6 +1330,7 @@ No animation = ไม่แสดงอนิเมชั่น
 Not a PSP game = นี่ไม่ใช่เกม PSP นะจ้ะ
 Off = ปิด
 Oldest Save = เซฟอันเก่าสุด
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = ไม่มีเส้นทางนี้อยู่!
 PSP Memory Stick = แหล่งเก็บข้อมูล PSP
 PSP Model = โมเดลของ PSP

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -1309,6 +1309,7 @@ No animation = animasyon yok
 Not a PSP game = Bir PSP oyunu değil
 Off = Kapalı
 Oldest Save = En eski kayıt
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Yol mevcut değil!
 PSP Memory Stick = PSP Hafıza Kartı
 PSP Model = PSP modeli

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Не є грою для PSP
 Off = Вимкнено
 Oldest Save = Найстаріші збереження
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = Модель PSP

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -1308,6 +1308,7 @@ No animation = No animation
 Not a PSP game = Đây Không phải là game PSP
 Off = Tắt
 Oldest Save = Save cũ nhất
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = Path does not exist!
 PSP Memory Stick = PSP Memory Stick
 PSP Model = PSP model

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -1246,6 +1246,7 @@ AVI Dump stopped. = AVI转储停止
 Cache ISO in RAM = 在内存中缓存完整ISO
 Change CPU Clock = 修改PSP的CPU频率 (不稳定)
 Loaded plugin: %1 = 已加载插件: %1
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Recording = Recording
 RetroAchievements = RetroAchievements
 Rewind Snapshot Interval = 倒带快照间隔

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -1298,6 +1298,7 @@ No animation = 靜態背景
 Not a PSP game = 這不是 PSP 遊戲
 Off = 關閉
 Oldest Save = 最舊存檔
+Only JPG and PNG images are supported = Only JPG and PNG images are supported
 Path does not exist! = 路徑不存在！
 PSP Memory Stick = PSP 記憶棒
 PSP Model = PSP 型號


### PR DESCRIPTION
Should fix some confusion, and also issues picking files from the Download folder on Android where the filenames we get don't always have extensions.

Just some last minute UX polish prompted by user reports.