### PR TITLE
Fix issue with the collapsible sections in control mapping collapsing on every change, plus, combo fix

### DIFF
--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -899,7 +899,7 @@ protected:
 
 class CollapsibleHeader : public CheckBox {
 public:
-	CollapsibleHeader(bool *toggle, const std::string &text, LayoutParams *layoutParams = nullptr);
+	CollapsibleHeader(bool *open, const std::string &text, LayoutParams *layoutParams = nullptr);
 	void Draw(UIContext &dc) override;
 	void GetContentDimensionsBySpec(const UIContext &dc, MeasureSpec horiz, MeasureSpec vert, float &w, float &h) const override;
 	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override;
@@ -907,6 +907,9 @@ public:
 	Point GetFocusPosition(FocusDirection dir) const override;
 
 	void SetHasSubitems(bool hasSubItems) { hasSubItems_ = hasSubItems; }
+	void SetOpenPtr(bool *open) {
+		toggle_ = open;
+	}
 private:
 	bool hasSubItems_ = true;
 };

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -1175,11 +1175,12 @@ StickyChoice *ChoiceStrip::Choice(int index) {
 }
 
 CollapsibleSection::CollapsibleSection(const std::string &title, LayoutParams *layoutParams) : LinearLayout(ORIENT_VERTICAL, layoutParams) {
+	open_ = &localOpen_;
 	SetSpacing(0.0f);
 
-	heading_ = new CollapsibleHeader(&open_, title);
-	views_.push_back(heading_);
-	heading_->OnClick.Add([=](UI::EventParams &) {
+	header_ = new CollapsibleHeader(open_, title);
+	views_.push_back(header_);
+	header_->OnClick.Add([=](UI::EventParams &) {
 		// Change the visibility of all children except the first one.
 		// Later maybe try something more ambitious.
 		UpdateVisibility();
@@ -1189,12 +1190,12 @@ CollapsibleSection::CollapsibleSection(const std::string &title, LayoutParams *l
 
 void CollapsibleSection::Update() {
 	ViewGroup::Update();
-	heading_->SetHasSubitems(views_.size() > 1);
+	header_->SetHasSubitems(views_.size() > 1);
 }
 
 void CollapsibleSection::UpdateVisibility() {
 	for (size_t i = 1; i < views_.size(); i++) {
-		views_[i]->SetVisibility(open_ ? V_VISIBLE : V_GONE);
+		views_[i]->SetVisibility(*open_ ? V_VISIBLE : V_GONE);
 	}
 }
 

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -332,14 +332,20 @@ public:
 	void Update() override;
 
 	void SetOpen(bool open) {
+		*open_ = open;
+		UpdateVisibility();
+	}
+	void SetOpenPtr(bool *open) {
+		header_->SetOpenPtr(open);
 		open_ = open;
 		UpdateVisibility();
 	}
 
 private:
 	void UpdateVisibility();
-	bool open_ = true;
-	CollapsibleHeader *heading_;
+	bool localOpen_ = true;
+	bool *open_;
+	CollapsibleHeader *header_;
 };
 
 }  // namespace UI

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -836,6 +836,7 @@ static const ConfigSetting controlSettings[] = {
 	ConfigSetting("AnalogTriggerThreshold", &g_Config.fAnalogTriggerThreshold, 0.75f, CfgFlag::DEFAULT),
 
 	ConfigSetting("AllowMappingCombos", &g_Config.bAllowMappingCombos, false, CfgFlag::DEFAULT),
+	ConfigSetting("StrictComboOrder", &g_Config.bStrictComboOrder, false, CfgFlag::DEFAULT),
 
 	ConfigSetting("LeftStickHeadScale", &g_Config.fLeftStickHeadScale, 1.0f, CfgFlag::PER_GAME),
 	ConfigSetting("RightStickHeadScale", &g_Config.fRightStickHeadScale, 1.0f, CfgFlag::PER_GAME),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -407,6 +407,7 @@ public:
 
 	// Sets whether combo mapping is enabled.
 	bool bAllowMappingCombos;
+	bool bStrictComboOrder;
 
 	bool bMouseControl;
 	bool bMapMouse; // Workaround for mapping screen:|

--- a/Core/ControlMapper.cpp
+++ b/Core/ControlMapper.cpp
@@ -365,7 +365,7 @@ bool ControlMapper::UpdatePSPState(const InputMapping &changedMapping, double no
 					continue;
 				}
 				// Stop reverse ordering from triggering.
-				if (iter->second.timestamp < curTime) {
+				if (g_Config.bStrictComboOrder && iter->second.timestamp < curTime) {
 					all = false;
 					break;
 				} else {
@@ -416,7 +416,7 @@ bool ControlMapper::UpdatePSPState(const InputMapping &changedMapping, double no
 
 				if (iter != curInput_.end()) {
 					// Stop reverse ordering from triggering.
-					if (iter->second.timestamp < curTime) {
+					if (g_Config.bStrictComboOrder && iter->second.timestamp < curTime) {
 						product = 0.0f;
 						break;
 					} else {

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -280,22 +280,22 @@ void ControlMappingScreen::CreateViews() {
 	struct Cat {
 		const char *catName;
 		int firstKey;
-		bool openByDefault;
+		bool *open;
 	};
 	// Category name, first input from psp_button_names.
 	static const Cat cats[] = {
-		{"Standard PSP controls", CTRL_UP, true},
-		{"Control modifiers", VIRTKEY_ANALOG_ROTATE_CW, true},
-		{"Emulator controls", VIRTKEY_FASTFORWARD, true},
-		{"Extended PSP controls", VIRTKEY_AXIS_RIGHT_Y_MAX, false},
+		{"Standard PSP controls", CTRL_UP, &categoryToggles_[0]},
+		{"Control modifiers", VIRTKEY_ANALOG_ROTATE_CW, &categoryToggles_[1]},
+		{"Emulator controls", VIRTKEY_FASTFORWARD, &categoryToggles_[2]},
+		{"Extended PSP controls", VIRTKEY_AXIS_RIGHT_Y_MAX, &categoryToggles_[3]},
 	};
 
 	int curCat = -1;
 	CollapsibleSection *curSection = nullptr;
 	for (size_t i = 0; i < numMappableKeys; i++) {
 		if (curCat < (int)ARRAY_SIZE(cats) && mappableKeys[i].key == cats[curCat + 1].firstKey) {
-			if (curCat >= 0 && !cats[curCat].openByDefault) {
-				curSection->SetOpen(false);
+			if (curCat >= 0) {
+				curSection->SetOpenPtr(cats[curCat].open);
 			}
 			curCat++;
 			curSection = rightColumn->Add(new CollapsibleSection(km->T(cats[curCat].catName)));
@@ -307,8 +307,8 @@ void ControlMappingScreen::CreateViews() {
 		mapper->SetTag(StringFromFormat("KeyMap%s", mappableKeys[i].name));
 		mappers_.push_back(mapper);
 	}
-	if (curCat >= 0 && curSection && !cats[curCat].openByDefault) {
-		curSection->SetOpen(false);
+	if (curCat >= 0 && curSection) {
+		curSection->SetOpenPtr(cats[curCat].open);
 	}
 
 	keyMapGeneration_ = KeyMap::g_controllerMapGeneration;

--- a/UI/ControlMappingScreen.cpp
+++ b/UI/ControlMappingScreen.cpp
@@ -262,6 +262,7 @@ void ControlMappingScreen::CreateViews() {
 		return UI::EVENT_DONE;
 	});
 	leftColumn->Add(new CheckBox(&g_Config.bAllowMappingCombos, km->T("Allow combo mappings")));
+	leftColumn->Add(new CheckBox(&g_Config.bStrictComboOrder, km->T("Strict combo input order")));
 
 	leftColumn->Add(new Spacer(new LinearLayoutParams(1.0f)));
 	AddStandardBack(leftColumn);

--- a/UI/ControlMappingScreen.h
+++ b/UI/ControlMappingScreen.h
@@ -39,6 +39,8 @@ public:
 	explicit ControlMappingScreen(const Path &gamePath) : UIDialogScreenWithGameBackground(gamePath) {
 		categoryToggles_[0] = true;
 		categoryToggles_[1] = true;
+		categoryToggles_[2] = true;
+		categoryToggles_[3] = false;
 	}
 	const char *tag() const override { return "ControlMapping"; }
 

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -728,6 +728,7 @@ Map Mouse = ‎خريطة الفأرة
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = ‎يمكنك ضغط علي زر الخروج للإلغاء.
 
 [MainMenu]

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -720,6 +720,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -720,6 +720,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -720,6 +720,7 @@ Map Mouse = Mapejar ratolí
 Replace = Reemplaçar
 Show PSP = Mostra PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Podeu prémer ESC per cancel·lar.
 
 [MainMenu]

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -720,6 +720,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -720,6 +720,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Du kan trykke Esc for at afbryde.
 
 [MainMenu]

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -720,6 +720,7 @@ Map Mouse = Maus zuweisen
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Drücken Sie ESC zum abbrechen.
 
 [MainMenu]

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -720,6 +720,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -744,6 +744,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -720,6 +720,7 @@ Map Mouse = Mapear ratón
 Replace = Remplazar
 Show PSP = Mostrar PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Puedes presionar ESC para cancelar.
 
 [MainMenu]

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -720,6 +720,7 @@ Map Mouse = Asignar ratón
 Replace = Reemplazar
 Show PSP = Mostrar PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Puedes presionar Esc para cancelar.
 
 [MainMenu]

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -720,6 +720,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -720,6 +720,7 @@ Map Mouse = Kartoita hiiri
 Replace = Korvaa
 Show PSP = Näytä PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Voit peruuttaa painamalla Esc.
 
 [MainMenu]

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -720,6 +720,7 @@ Map Mouse = Assigner un contrôle de souris
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Vous pouvez presser "Échap" pour annuler.
 
 [MainMenu]

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -720,6 +720,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -720,6 +720,7 @@ Map Mouse = ΡύΘμιση ποντικού
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Μπορείτε να πατήσετε Esc για ακύρωση.
 
 [MainMenu]

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -720,6 +720,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -720,6 +720,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -720,6 +720,7 @@ Map Mouse = Postavi miš
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Možes pritisnuti ESC za odustati.
 
 [MainMenu]

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -720,6 +720,7 @@ Map Mouse = Egér társítása
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Megszakításhoz használj ESC-et.
 
 [MainMenu]

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -720,6 +720,7 @@ Map Mouse = Tetapkan mouse
 Replace = Timpa
 Show PSP = Tampilkan PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Kamu dapat membatalkan dengan menekan ESC.
 
 [MainMenu]

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -721,6 +721,7 @@ Map Mouse = Mappa Mouse
 Replace = Sostituisci
 Show PSP = Mostra PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Puoi premere Esc per annullare.
 
 [MainMenu]

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -720,6 +720,7 @@ Map Mouse = マウスの割り当て指定
 Replace = 置き換える
 Show PSP = PSP画像を表示
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Escを押すとキャンセルできます。
 
 [MainMenu]

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -720,6 +720,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -720,6 +720,7 @@ Map Mouse = 마우스 매핑
 Replace = 교체
 Show PSP = PSP 표시
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Esc를 눌러 취소할 수 있습니다.
 
 [MainMenu]

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -720,6 +720,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = ເຈົ້າສາມາດກົດ Esc ເພື່ອຍົກເລີກ.
 
 [MainMenu]

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -720,6 +720,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -720,6 +720,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -720,6 +720,7 @@ Map Mouse = Muis indelen
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Druk op Esc om te annuleren.
 
 [MainMenu]

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -720,6 +720,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -725,6 +725,7 @@ Map Mouse = Mapuj mysz
 Replace = Zamień
 Show PSP = Pokaż PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Możesz zamknąć to okienko naciskając Esc.
 
 [MainMenu]

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -744,6 +744,7 @@ Map Mouse = Mapear o mouse
 Replace = Substituir
 Show PSP = Mostrar o PSP
 Standard PSP controls = Controles padrão do PSP
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Você pode pressionar o Esc pra cancelar.
 
 [MainMenu]

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -744,6 +744,7 @@ Map Mouse = Mapear o Rato
 Replace = Substituir
 Show PSP = Mostrar a PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Podes pressionar a tecla Esc para cancelar.
 
 [MainMenu]

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -721,6 +721,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -720,6 +720,7 @@ Map Mouse = Назначить мышь
 Replace = Заменить
 Show PSP = Показать вид PSP
 Standard PSP controls = Стандартное управление PSP
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Для отмены вы можете нажать Esc.
 
 [MainMenu]

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -721,6 +721,7 @@ Map Mouse = Mappa mus
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Tryck ESC för att avbryta.
 
 [MainMenu]

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -720,6 +720,7 @@ Map Mouse = Map mouse
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = You can press Esc to cancel.
 
 [MainMenu]

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -726,6 +726,7 @@ Map Mouse = ตั้งค่าปุ่มเมาส์
 Replace = แทนที่
 Show PSP = แสดง PSP
 Standard PSP controls = การควบคุม PSP ขั้นพื้นฐาน
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = คุณสามารถกด ESC เพื่อยกเลิกได้
 
 [MainMenu]

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -722,6 +722,7 @@ Map Mouse = Mouse eşleştir
 Replace = Değiştir
 Show PSP = PSP'yi Göster
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = İptal etmek için Esc'ye basabilirsiniz.
 
 [MainMenu]

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -720,6 +720,7 @@ Map Mouse = Карта миші
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Ви можете натиснути Esc, щоб скасувати.
 
 [MainMenu]

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -720,6 +720,7 @@ Map Mouse = bản đồ chuột
 Replace = Replace
 Show PSP = Show PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = bạn có thể nhấp Esc để hủy.
 
 [MainMenu]

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -720,6 +720,7 @@ Map Mouse = 鼠标映射
 Replace = 替换现有
 Show PSP = PSP 布局
 Standard PSP controls = PSP基本按键
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = 可以按下Esc键取消
 
 [MainMenu]

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -720,6 +720,7 @@ Map Mouse = 對應滑鼠
 Replace = 取代
 Show PSP = 顯示 PSP
 Standard PSP controls = Standard PSP controls
+Strict combo input order = Strict combo input order
 You can press ESC to cancel. = 您可以按下 ESC 取消
 
 [MainMenu]


### PR DESCRIPTION
Fixes #18783 

Additionally, restores the previous combo key behavior, making the new one (order-dependence) an option.

It seems gamepads that accidentally create combos using shoulder triggers are pretty common, see #18784 