### PR TITLE
Refresh iOS/macOS versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,12 +221,6 @@ jobs:
         sudo apt-get update -y -qq
         sudo apt-get install libsdl2-dev libgl1-mesa-dev libglu1-mesa-dev libsdl2-ttf-dev libfontconfig1-dev
 
-    - name: Create macOS git-version.cpp for tagged release
-      if: startsWith(github.ref, 'refs/tags/') && runner.os == 'macOS' && matrix.extra == 'test'
-      run: |
-        echo "const char *PPSSPP_GIT_VERSION = \"${GITHUB_REF##*/}\";" > git-version.cpp
-        echo "#define PPSSPP_GIT_VERSION_NO_UPDATE 1" >> git-version.cpp
-
     - name: Setup ccache
       uses: hendrikmuhs/ccache-action@v1.2
       # Disable ccache on macos for now, it's become buggy for some reason.

--- a/.github/workflows/manual_generate_apk.yml
+++ b/.github/workflows/manual_generate_apk.yml
@@ -5,10 +5,10 @@ on:
 
       buildVariant:
         type: choice
-        description: 'Build Variant'     
+        description: 'Build Variant'
         required: true
         default: 'NormalOptimized'
-        options: 
+        options:
         - NormalOptimized
         - NormalDebug
 
@@ -23,27 +23,27 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-        
+
       - name: Setup JDK
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
           java-version: '17'
-        
+
       #- name: Setup SDK
       #  uses: android-actions/setup-android@v2
-          
+
       #- name: Setup NDK
       #  uses: nttld/setup-ndk@v1
       #  with:
       #    ndk-version: r21e
-      
+
       - name: Assemble APK
         run: bash ./gradlew assemble${{ github.event.inputs.buildVariant }} --stacktrace
-      
+
       #- name: Gradle Test
       #  run: bash ./gradlew test${{ github.event.inputs.buildVariant }}UnitTest --stacktrace
-      
+
       - name: Package build
         run: |
           find . -name "*.apk"

--- a/.github/workflows/manual_generate_ipa.yml
+++ b/.github/workflows/manual_generate_ipa.yml
@@ -5,10 +5,10 @@ on:
 
       buildVariant:
         type: choice
-        description: 'Build Variant'     
+        description: 'Build Variant'
         required: true
         default: 'release'
-        options: 
+        options:
         - release
         - debug
 
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-        
+
       #- name: Fetch tags for macOS
       #  # This is required for git describe --always to work for git-version.cpp.
       #  run: |
@@ -32,27 +32,13 @@ jobs:
       - name: Set Env Var(s)
         run: |
           echo "GIT_VERSION=$(git describe --always)" >> $GITHUB_ENV
-        
-      - name: Create macOS git-version.cpp & Version.txt
-        run: |
-          echo "const char *PPSSPP_GIT_VERSION = \"${GIT_VERSION}\";" > git-version.cpp
-          echo "#define PPSSPP_GIT_VERSION_NO_UPDATE 1" >> git-version.cpp
-          # Create Version.txt file (should probably do this during building process)
-          mkdir build-ios
-          mkdir build-ios/PPSSPP.app
-          echo $(echo $GIT_VERSION | cut -c 2-) > build-ios/PPSSPP.app/Version.txt
-          # Testing values ...
-          echo "Content of [GITHUB_REF##*/] = ${GITHUB_REF##*/}"
-          echo $(echo $GIT_VERSION | cut -c 2-)
-          # Testing file location ...
-          find . -name "Version.txt"
-          
+
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@main
         with:
           key: ios
           create-symlink: true
-      
+
       - name: Execute build
         env:
           CC: clang
@@ -60,11 +46,10 @@ jobs:
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
           ./b.sh --ios --${{ github.event.inputs.buildVariant }}
-      
+
       - name: Package build
         run: |
           # Testing file location ...
-          find . -name "Version.txt"
           find . -name "*.app"
           mkdir ppsspp
           if [ -e build*/PPSSPP.app ]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2733,9 +2733,9 @@ if(TargetBin)
 			add_executable(${TargetBin} MACOSX_BUNDLE ${ICON_PATH_ABS} ${NativeAssets} ${BigFontAssets} ${SHADER_FILES} ${THEME_FILE} ${DEBUGGER_FILES} ${FLASH0_FILES} ${LANG_FILES} ${NativeAppSource})
 			file(INSTALL "${CMAKE_SOURCE_DIR}/ext/vulkan/macOS/Frameworks/libMoltenVK.dylib" DESTINATION "${CMAKE_BINARY_DIR}/${TargetBin}.app/Contents/Frameworks/")
 			if(USING_QT_UI)
-				add_custom_command(TARGET ${TargetBin} POST_BUILD COMMAND /bin/bash "${CMAKE_SOURCE_DIR}/Qt/macbundle.sh" "${CMAKE_BINARY_DIR}/PPSSPPQt.app")
+				add_custom_command(TARGET ${TargetBin} POST_BUILD COMMAND /bin/bash "${CMAKE_SOURCE_DIR}/Qt/macbundle.sh" "${CMAKE_BINARY_DIR}/PPSSPPQt.app" "${CMAKE_CURRENT_BINARY_DIR}")
 			elseif(NOT USE_SYSTEM_LIBSDL2)
-				add_custom_command(TARGET ${TargetBin} POST_BUILD COMMAND /bin/bash "${CMAKE_SOURCE_DIR}/SDL/macbundle.sh" "${CMAKE_BINARY_DIR}/${TargetBin}.app" "${TargetBin}")
+				add_custom_command(TARGET ${TargetBin} POST_BUILD COMMAND /bin/bash "${CMAKE_SOURCE_DIR}/SDL/macbundle.sh" "${CMAKE_BINARY_DIR}/${TargetBin}.app" "${TargetBin}" "${CMAKE_CURRENT_BINARY_DIR}")
 			endif()
 		endif()
 	elseif(WIN32)
@@ -2784,7 +2784,7 @@ if(IOS AND NOT LIBRETRO)
 	add_custom_command(TARGET PPSSPP POST_BUILD
 		COMMAND mkdir -p \"${APP_DIR_NAME}\"
 		COMMAND tar -c -C ${CMAKE_CURRENT_BINARY_DIR} --exclude .DS_Store --exclude .git assets *.png | tar -x -C \"${APP_DIR_NAME}\"
-		COMMAND /bin/bash "${CMAKE_SOURCE_DIR}/ios/macbundle.sh" \"${APP_DIR_NAME}\"
+		COMMAND /bin/bash "${CMAKE_SOURCE_DIR}/ios/macbundle.sh" \"${APP_DIR_NAME}\" \"${CMAKE_CURRENT_BINARY_DIR}\"
 	)
 	set(MACOSX_DEPLOYMENT_TARGET ${DEPLOYMENT_TARGET})
 	set_target_properties(${TargetBin} PROPERTIES
@@ -2793,7 +2793,7 @@ if(IOS AND NOT LIBRETRO)
 		RESOURCE "ios/Settings.bundle"
 		RESOURCE "ext/vulkan/iOS/Frameworks"
 		XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET ${DEPLOYMENT_TARGET}
-		XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "iPhone/iPad"
+		XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2"
 		XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES
 		XCODE_ATTRIBUTE_ENABLE_BITCODE NO
 		XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "-"

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -226,7 +226,7 @@ bool MemoryMap_Setup(u32 flags) {
 		uintptr_t max_base_addr = 0x7FFF0000 - 0x10000000;
 		uintptr_t min_base_addr = 0x01000000;
 		uintptr_t stride = 0x400000;
-#elif PPSSPP_ARCH(ARM64) && PPSSPP_PLATFORM(IOS)
+#elif PPSSPP_PLATFORM(IOS) && (PPSSPP_ARCH(ARM64) || PPSSPP_ARCH(AMD64))
 		// iOS
 		uintptr_t max_base_addr = 0x1FFFF0000ULL - 0x80000000ULL;
 		uintptr_t min_base_addr = 0x100000000ULL;

--- a/Qt/macbundle.sh
+++ b/Qt/macbundle.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 PPSSPP="${1}"
+CMAKE_BINARY_DIR="${2}"
 PPSSPPQt="${PPSSPP}/Contents/MacOS/PPSSPPQt"
 
 if [ ! -f "${PPSSPPQt}" ]; then
@@ -8,6 +9,7 @@ if [ ! -f "${PPSSPPQt}" ]; then
   exit 0
 fi
 
+plutil -replace CFBundleExecutable -string PPSSPPQt ${PPSSPP}/Contents/Info.plist
 plutil -replace NSPrincipalClass -string NSApplication ${PPSSPP}/Contents/Info.plist
 plutil -replace NSHighResolutionCapable -bool YES ${PPSSPP}/Contents/Info.plist
 
@@ -15,11 +17,11 @@ plutil -replace NSLocationWhenInUseUsageDescription -string "Your location may b
 plutil -replace NSCameraUsageDescription -string "Your camera may be used to emulate Go!Cam, a camera accessory" ${PPSSPP}/Contents/Info.plist
 plutil -replace NSMicrophoneUsageDescription -string "Your microphone may be used to emulate Go!Cam/Talkman, a microphone accessory" ${PPSSPP}/Contents/Info.plist
 
-GIT_VERSION_LINE=$(grep "PPSSPP_GIT_VERSION = " "$(dirname "${0}")/../git-version.cpp")
-SHORT_VERSION_MATCH='.*"v([0-9\.]+(-[0-9]+)?).*";'
+GIT_VERSION_LINE=$(grep "PPSSPP_GIT_VERSION = " "${CMAKE_BINARY_DIR}/git-version.cpp")
+SHORT_VERSION_MATCH='.*"v([0-9]+(\.[0-9]+)*).*";'
 LONG_VERSION_MATCH='.*"v(.*)";'
 if [[ "${GIT_VERSION_LINE}" =~ ^${SHORT_VERSION_MATCH}$ ]]; then
-	plutil -replace CFBundleShortVersionString -string $(echo ${GIT_VERSION_LINE} | perl -pe "s/${SHORT_VERSION_MATCH}/\$1/g") ${PPSSPP}/Contents/Info.plist
+	plutil -replace CFBundleShortVersionString -string $(echo ${GIT_VERSION_LINE} | perl -pe "s/-/./g; s/${SHORT_VERSION_MATCH}/\$1/g") ${PPSSPP}/Contents/Info.plist
 	plutil -replace CFBundleVersion            -string $(echo ${GIT_VERSION_LINE} | perl -pe "s/${LONG_VERSION_MATCH}/\$1/g")  ${PPSSPP}/Contents/Info.plist
 else
 	plutil -replace CFBundleShortVersionString -string "" ${PPSSPP}/Contents/Info.plist

--- a/SDL/macbundle.sh
+++ b/SDL/macbundle.sh
@@ -4,6 +4,7 @@ echo "Hello from macbundle.sh"
 
 PPSSPP="${1}"
 PPSSPP_SHORTNAME="${2}"
+CMAKE_BINARY_DIR="${3}"
 PPSSPPSDL="${PPSSPP}/Contents/MacOS/${PPSSPP_SHORTNAME}"
 MOLTENVK="${PPSSPP}/Contents/Frameworks/libMoltenVK.dylib"
 
@@ -36,13 +37,13 @@ install_name_tool -rpath "${RPATH}" "@executable_path/../Frameworks" "${PPSSPPSD
 
 echo "Done."
 
-GIT_VERSION_LINE=$(grep "PPSSPP_GIT_VERSION = " "$(dirname "${0}")/../build/git-version.cpp")
+GIT_VERSION_LINE=$(grep "PPSSPP_GIT_VERSION = " "${CMAKE_BINARY_DIR}/git-version.cpp")
 
 echo "Setting version to '${GIT_VERSION_LINE}'..."
-SHORT_VERSION_MATCH='.*"v([0-9\.]+(-[0-9]+)?).*";'
+SHORT_VERSION_MATCH='.*"v([0-9]+(\.[0-9]+)*).*";'
 LONG_VERSION_MATCH='.*"v(.*)";'
 if [[ "${GIT_VERSION_LINE}" =~ ^${SHORT_VERSION_MATCH}$ ]]; then
-	plutil -replace CFBundleShortVersionString -string $(echo ${GIT_VERSION_LINE} | perl -pe "s/${SHORT_VERSION_MATCH}/\$1/g") ${PPSSPP}/Contents/Info.plist
+	plutil -replace CFBundleShortVersionString -string $(echo ${GIT_VERSION_LINE} | perl -pe "s/-/./g; s/${SHORT_VERSION_MATCH}/\$1/g") ${PPSSPP}/Contents/Info.plist
 	plutil -replace CFBundleVersion            -string $(echo ${GIT_VERSION_LINE} | perl -pe "s/${LONG_VERSION_MATCH}/\$1/g")  ${PPSSPP}/Contents/Info.plist
 else
 	plutil -replace CFBundleShortVersionString -string "" ${PPSSPP}/Contents/Info.plist

--- a/cmake/Toolchains/ios.cmake
+++ b/cmake/Toolchains/ios.cmake
@@ -77,7 +77,7 @@ set(CMAKE_OSX_SYSROOT ${CMAKE_IOS_SDK_ROOT} CACHE PATH "Sysroot used for iOS sup
 if(IOS_PLATFORM STREQUAL "OS" OR IOS_PLATFORM STREQUAL "TVOS")
   set(IOS_ARCH "arm64")
 else()
-  set(IOS_ARCH "i386;x86_64")
+  set(IOS_ARCH "x86_64")
 endif()
 
 set(CMAKE_OSX_ARCHITECTURES "${IOS_ARCH}" CACHE STRING "Build architecture for iOS")

--- a/ios/macbundle.sh
+++ b/ios/macbundle.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 PPSSPP="${1}"
+CMAKE_BINARY_DIR="${2}"
 PPSSPPiOS="${PPSSPP}/PPSSPP"
 
 if [ ! -f "${PPSSPPiOS}" ]; then
@@ -8,11 +9,11 @@ if [ ! -f "${PPSSPPiOS}" ]; then
   exit 0
 fi
 
-GIT_VERSION_LINE=$(grep "PPSSPP_GIT_VERSION = " "$(dirname "${0}")/../git-version.cpp")
-SHORT_VERSION_MATCH='.*"v([0-9\.]+(-[0-9]+)?).*";'
+GIT_VERSION_LINE=$(grep "PPSSPP_GIT_VERSION = " "${CMAKE_BINARY_DIR}/git-version.cpp")
+SHORT_VERSION_MATCH='.*"v([0-9]+(\.[0-9]+)*).*";'
 LONG_VERSION_MATCH='.*"v(.*)";'
 if [[ "${GIT_VERSION_LINE}" =~ ^${SHORT_VERSION_MATCH}$ ]]; then
-	plutil -replace CFBundleShortVersionString -string $(echo ${GIT_VERSION_LINE} | perl -pe "s/${SHORT_VERSION_MATCH}/\$1/g") ${PPSSPP}/Info.plist
+	plutil -replace CFBundleShortVersionString -string $(echo ${GIT_VERSION_LINE} | perl -pe "s/-/./g; s/${SHORT_VERSION_MATCH}/\$1/g") ${PPSSPP}/Info.plist
 	plutil -replace CFBundleVersion            -string $(echo ${GIT_VERSION_LINE} | perl -pe "s/${LONG_VERSION_MATCH}/\$1/g")  ${PPSSPP}/Info.plist
 else
 	plutil -replace CFBundleShortVersionString -string "" ${PPSSPP}/Info.plist


### PR DESCRIPTION
- Fix CFBundleExecutable for QT version
- Fix CFBundleVersion by searching git-version in BINARY_DIR
- Fix TARGETED_DEVICE_FAMILY value
- Remove i386 version for iOS simulator
- Remove minus sign from CFBundleShortVersionString. Now the version is shown in iOS>Settings>General>Storage>PPSSPP

I also had to force [ZSTD_ENABLE_ASM_X86_64_BMI2=0](https://github.com/facebook/zstd/blob/4a74eb8cfb4a1887140c7581cbf0dfcf2fedec7a/lib/common/portability_macros.h#L136) to build the iOS version for simulator