### PR TITLE
More gameinfocache fixes

### DIFF
--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -317,7 +317,7 @@ void GameInfo::ParseParamSFO() {
 
 std::string GameInfo::GetTitle() {
 	std::lock_guard<std::mutex> guard(lock);
-	if (hasFlags & GameInfoFlags::PARAM_SFO) {
+	if ((hasFlags & GameInfoFlags::PARAM_SFO) && !title.empty()) {
 		return title;
 	} else {
 		return filePath_.GetFilename();

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -82,12 +82,12 @@ struct GameInfoTex {
 
 class GameInfo {
 public:
-	GameInfo();
+	GameInfo(const Path &gamePath);
 	~GameInfo();
 
 	bool Delete();  // Better be sure what you're doing when calling this.
 	bool DeleteAllSaveData();
-	bool LoadFromPath(const Path &gamePath);
+	bool CreateLoader();
 
 	bool HasFileLoader() const {
 		return fileLoader.get() != nullptr;
@@ -112,6 +112,11 @@ public:
 	bool Ready(GameInfoFlags flags) {
 		std::unique_lock<std::mutex> guard(lock);
 		return (hasFlags & flags) != 0;
+	}
+
+	void MarkReadyNoLock(GameInfoFlags flags) {
+		hasFlags |= flags;
+		pendingFlags &= ~flags;
 	}
 
 	GameInfoTex *GetBGPic() {

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -300,7 +300,7 @@ void SavedataButton::Draw(UIContext &dc) {
 	u32 color = 0, shadowColor = 0;
 	using namespace UI;
 
-	if (ginfo->icon.texture) {
+	if (ginfo->Ready(GameInfoFlags::ICON) && ginfo->icon.texture) {
 		texture = ginfo->icon.texture;
 	}
 


### PR DESCRIPTION
Fix a hang in PurgeType (called when exiting savedata manager).

Show the title of things faster, cleanup some things.