### PR TITLE
Fix Tokimeki  Flashing to Black Screen issue

### DIFF
--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -441,7 +441,7 @@ VirtualFramebuffer *FramebufferManagerCommon::DoSetRenderFrameBuffer(Framebuffer
 					drawing_width += x_offset;
 					break;
 				}
-			} else if (PSP_CoreParameter().compat.flags().FramebufferAllowLargeVerticalOffset && params.fb_address > v->fb_address && v->fb_stride > 0 && (params.fb_address - v->fb_address) % v->FbStrideInBytes() == 0) {
+			} else if (PSP_CoreParameter().compat.flags().FramebufferAllowLargeVerticalOffset && params.fb_address > v->fb_address && v->fb_stride > 0 && (params.fb_address - v->fb_address) % v->FbStrideInBytes() == 0 && params.fb_stride != params.z_stride) {
 				int y_offset = (params.fb_address - v->fb_address) / v->FbStrideInBytes();
 				if (y_offset <= v->bufferHeight) {  // note: v->height is misdetected as 256 instead of 272 here in tokimeki. Note that 272 is just the height of the upper part, it's supersampling vertically.
 					vfb = v;


### PR DESCRIPTION
Fix #18811

In the opening the game,
fb_stride = 256, z_stride = 512

In the  "arm" screen ,
fb_stride = 512, z_stride = 512