### PR TITLE
Hacky compat workaround for Resistance's ad-hoc mode

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -137,6 +137,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "AllowDelayedReadbacks", &flags_.AllowDelayedReadbacks);
 	CheckSetting(iniFile, gameID, "TacticsOgreEliminateDebugReadback", &flags_.TacticsOgreEliminateDebugReadback);
 	CheckSetting(iniFile, gameID, "FramebufferAllowLargeVerticalOffset", &flags_.FramebufferAllowLargeVerticalOffset);
+	CheckSetting(iniFile, gameID, "DisableMemcpySlicing", &flags_.DisableMemcpySlicing);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -107,6 +107,7 @@ struct CompatFlags {
 	bool AllowDelayedReadbacks;
 	bool TacticsOgreEliminateDebugReadback;
 	bool FramebufferAllowLargeVerticalOffset;
+	bool DisableMemcpySlicing;
 };
 
 struct VRCompat {

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -198,7 +198,7 @@ static int Replace_memcpy_jak() {
 			skip = gpu->PerformMemoryCopy(destPtr, srcPtr, bytes);
 		}
 	}
-	if (!skip && bytes > SLICE_SIZE && bytes != 512 * 272 * 4) {
+	if (!skip && bytes > SLICE_SIZE && bytes != 512 * 272 * 4 && !PSP_CoreParameter().compat.flags().DisableMemcpySlicing) {
 		// This is a very slow func.  To avoid thread blocking, do a slice at a time.
 		// Avoiding exactly 512 * 272 * 4 to detect videos, though.
 		bytes = SLICE_SIZE;
@@ -390,7 +390,7 @@ static int Replace_memset_jak() {
 	if (Memory::IsVRAMAddress(destPtr) && (skipGPUReplacements & (int)GPUReplacementSkip::MEMSET) == 0) {
 		skip = gpu->PerformMemorySet(destPtr, value, bytes);
 	}
-	if (!skip && bytes > SLICE_SIZE) {
+	if (!skip && bytes > SLICE_SIZE && !PSP_CoreParameter().compat.flags().DisableMemcpySlicing) {
 		// This is a very slow func.  To avoid thread blocking, do a slice at a time.
 		bytes = SLICE_SIZE;
 		sliced = true;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -969,6 +969,7 @@ ULES00869 = true
 # Resistance Retribution
 UCES01184 = true
 UCUS98668 = true
+UCJP00174 = true
 
 # Spider-Man 3
 ULES00938 = true
@@ -1737,3 +1738,8 @@ ULJM05753 = true
 NPJH50348 = true
 ULJM06009 = true
 UCKS45164 = true
+
+[DisableMemcpySlicing]
+UCES01184 = true
+UCUS98668 = true
+UCJP00174 = true


### PR DESCRIPTION
Slicing the slow memcpy calls in combination with some bug or misbehavior messes up some timing so it crashes. Too hard to fix for 1.17.1, so we do this :(

Helps #18817 