### PR TITLE
Memory exception handler: Don't disassemble if ignoring the exception

### DIFF
--- a/Core/MemFault.cpp
+++ b/Core/MemFault.cpp
@@ -152,19 +152,6 @@ bool HandleFault(uintptr_t hostAddress, void *ctx) {
 
 	MemoryExceptionType type = MemoryExceptionType::NONE;
 
-	std::string infoString = "";
-
-	bool isAtDispatch = false;
-	if (MIPSComp::jit) {
-		std::string desc;
-		if (MIPSComp::jit->DescribeCodePtr(codePtr, desc)) {
-			infoString += desc + "\n";
-		}
-		if (MIPSComp::jit->IsAtDispatchFetch(codePtr)) {
-			isAtDispatch = true;
-		}
-	}
-
 	int instructionSize = 4;
 #if PPSSPP_ARCH(AMD64) || PPSSPP_ARCH(X86)
 	// X86, X86-64. Variable instruction size so need to analyze the mov instruction in detail.
@@ -251,12 +238,7 @@ bool HandleFault(uintptr_t hostAddress, void *ctx) {
 	}
 #endif
 
-	std::string disassembly;
-	if (DisassembleNativeAt(codePtr, instructionSize, &disassembly)) {
-		infoString += disassembly + "\n";
-	}
-
-	if (isAtDispatch) {
+	if (MIPSComp::jit && MIPSComp::jit->IsAtDispatchFetch(codePtr)) {
 		u32 targetAddr = currentMIPS->pc;  // bad approximation
 		// TODO: Do the other archs and platforms.
 #if PPSSPP_ARCH(AMD64) && PPSSPP_PLATFORM(WINDOWS)
@@ -299,6 +281,16 @@ bool HandleFault(uintptr_t hostAddress, void *ctx) {
 			ERROR_LOG(MEMMAP, "Bad memory access detected and ignored: %08x (%p)", guestAddress, (void *)hostAddress);
 		}
 	} else {
+		std::string infoString = "";
+		std::string temp;
+		if (MIPSComp::jit && MIPSComp::jit->DescribeCodePtr(codePtr, temp)) {
+			infoString += temp + "\n";
+		}
+		temp.clear();
+		if (DisassembleNativeAt(codePtr, instructionSize, &temp)) {
+			infoString += temp + "\n";
+		}
+
 		// Either bIgnoreBadMemAccess is off, or we failed recovery analysis.
 		// We can't ignore this memory access.
 		uint32_t approximatePC = currentMIPS->pc;


### PR DESCRIPTION
Gotten some strange application-not-responding reports where it seems to spend a ton of time here. This might prevent the app from becoming unresponsive. (DescribeCodePtr is expensive since it loops through all jit blocks).