### PR TITLE
Update libchdr to the latest, which supports zstd blocks

### DIFF
--- a/UWP/libchdr_UWP/libchdr_UWP.vcxproj
+++ b/UWP/libchdr_UWP/libchdr_UWP.vcxproj
@@ -80,7 +80,8 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros" /><PropertyGroup />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
   <PropertyGroup>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
@@ -88,7 +89,7 @@
     <ClCompile>
       <CompileAsWinRT>false</CompileAsWinRT>
       <SDLCheck>false</SDLCheck>
-      <AdditionalIncludeDirectories>..\..\ext\zlib;..\..\ext\libchdr\include;..\..\ext\libchdr\deps\lzma-22.01\include;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\ext\zlib;..\..\ext\zstd\lib;..\..\ext\libchdr\include;..\..\ext\libchdr\deps\lzma-22.01\include;$(ProjectDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions>_7ZIP_ST;_CRT_SECURE_NO_WARNINGS;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>

--- a/ext/libchdr-build/CMakeLists.txt
+++ b/ext/libchdr-build/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRC_DIR ../libchdr/src)
 include_directories(../libchdr/deps/lzma-22.01/include)
 include_directories(../libchdr/include)
 include_directories(../zlib)
+include_directories(../zstd/lib)
 
 add_definitions(-D_7ZIP_ST)
 

--- a/ext/libchdr.vcxproj
+++ b/ext/libchdr.vcxproj
@@ -197,7 +197,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <EnablePREfast>false</EnablePREfast>
-      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;zstd\lib;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -216,7 +216,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <EnablePREfast>false</EnablePREfast>
-      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;zstd\lib;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -234,7 +234,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <EnablePREfast>false</EnablePREfast>
-      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;zstd\lib;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -252,7 +252,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <EnablePREfast>false</EnablePREfast>
-      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;zstd\lib;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -277,7 +277,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions2</EnableEnhancedInstructionSet>
-      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;zstd\lib;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -305,7 +305,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;zstd\lib;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -332,7 +332,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;zstd\lib;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -359,7 +359,7 @@
       <OmitFramePointers>true</OmitFramePointers>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>libchdr\include;libchdr\deps\lzma-22.01\include;zlib;zstd\lib;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Apparently these perform better, and I assume people will start using these by default and expect them to work soon.

Sigh, I thought CHD was a fixed thing...

Also updated the guide on https://www.ppsspp.org/docs/getting-started/dumping-games/ with this information. 