### PR TITLE
Crash fix for some games

### DIFF
--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -298,10 +298,10 @@ int PSPMsgDialog::Update(int animSpeed) {
 			DisplayMessage(msgText, (flag & DS_YESNO) != 0, (flag & DS_OK) != 0);
 
 		if (flag & (DS_OK | DS_VALIDBUTTON)) 
-			DisplayButtons(DS_BUTTON_OK, messageDialog.common.size == SCE_UTILITY_MSGDIALOG_SIZE_V3 ? messageDialog.okayButton : NULL);
+			DisplayButtons(DS_BUTTON_OK, messageDialog.common.size == SCE_UTILITY_MSGDIALOG_SIZE_V3 ? messageDialog.okayButton : "");
 
 		if (flag & DS_CANCELBUTTON)
-			DisplayButtons(DS_BUTTON_CANCEL, messageDialog.common.size == SCE_UTILITY_MSGDIALOG_SIZE_V3 ? messageDialog.cancelButton : NULL);
+			DisplayButtons(DS_BUTTON_CANCEL, messageDialog.common.size == SCE_UTILITY_MSGDIALOG_SIZE_V3 ? messageDialog.cancelButton : "");
 
 		if (IsButtonPressed(cancelButtonFlag) && (flag & DS_CANCELBUTTON))
 		{


### PR DESCRIPTION
It looks like because of the 2nd argument of `DisplayButtons()` was changed from `const char*` to `std::string_view` recently (https://github.com/hrydgard/ppsspp/commit/c5791764d844744ecda441e003fede16d6091bb0#diff-07044294ee9e46c0b5a5700d34133ef38456279ca8ca8cfaa497c9d7498f8d59L100-R100) it was causing crashes in games that start with the "autosave" screen without a selection box? Mega Man Powered Up and Indiana Jones and the Staff of Kings now boot fine (and probably more).

Closes #18880 (and most likely #18873)