### PR TITLE
OpenXR - Passthrough on the latest QuestOS fixed

### DIFF
--- a/Common/VR/VRBase.h
+++ b/Common/VR/VRBase.h
@@ -51,7 +51,6 @@ enum { ovrMaxNumEyes = 2 };
 typedef union {
 	XrCompositionLayerProjection Projection;
 	XrCompositionLayerCylinderKHR Cylinder;
-	XrCompositionLayerPassthroughFB Passthrough;
 } ovrCompositorLayer_Union;
 
 typedef struct {


### PR DESCRIPTION
Meta did a behavior change of the passthrough which leads to issue that passthrough cannot be disabled. This PR fixes that.

Issue reported here: https://www.reddit.com/r/Emulationonquest/comments/1ax05sd/ppsspp_vr_is_stuck_on_passthrough_can_this_be/