### PR TITLE
FS: fix crash overreading data on flash0

### DIFF
--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -1067,6 +1067,9 @@ size_t VFSFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) {
 	EntryMap::iterator iter = entries.find(handle);
 	if (iter != entries.end())
 	{
+		if(iter->second.seekPos + size > iter->second.size)
+			size = iter->second.size - iter->second.seekPos;
+		if(size < 0) size = 0;
 		size_t bytesRead = size;
 		memcpy(pointer, iter->second.fileData + iter->second.seekPos, size);
 		iter->second.seekPos += size;


### PR DESCRIPTION
noticed while using intrafont with some homebrew code. when using musl libc's hardened malloc, the overread in the code caused PPSSPP to segfault.