### PR TITLE
Don't gate the RetroAchievements customize tab on the availability of a file chooser

### DIFF
--- a/UI/RetroAchievementScreens.cpp
+++ b/UI/RetroAchievementScreens.cpp
@@ -254,10 +254,8 @@ void RetroAchievementsSettingsScreen::CreateTabs() {
 	using namespace UI;
 
 	CreateAccountTab(AddTab("AchievementsAccount", ac->T("Account")));
-	if (System_GetPropertyBool(SYSPROP_HAS_FILE_BROWSER)) {
-		// Don't bother creating this tab if we don't have a file browser.
-		CreateCustomizeTab(AddTab("AchievementsCustomize", ac->T("Customize")));
-	}
+	// Don't bother creating this tab if we don't have a file browser.
+	CreateCustomizeTab(AddTab("AchievementsCustomize", ac->T("Customize")));
 	CreateDeveloperToolsTab(AddTab("AchievementsDeveloperTools", sy->T("Developer Tools")));
 }
 
@@ -358,12 +356,14 @@ void RetroAchievementsSettingsScreen::CreateCustomizeTab(UI::ViewGroup *viewGrou
 	auto a = GetI18NCategory(I18NCat::AUDIO);
 
 	using namespace UI;
-	viewGroup->Add(new ItemHeader(ac->T("Sound Effects")));
-	viewGroup->Add(new AudioFileChooser(GetRequesterToken(), &g_Config.sAchievementsUnlockAudioFile, ac->T("Achievement unlocked"), UISound::ACHIEVEMENT_UNLOCKED));
-	viewGroup->Add(new AudioFileChooser(GetRequesterToken(), &g_Config.sAchievementsLeaderboardSubmitAudioFile, ac->T("Leaderboard score submission"), UISound::LEADERBOARD_SUBMITTED));
-	PopupSliderChoice *volume = viewGroup->Add(new PopupSliderChoice(&g_Config.iAchievementSoundVolume, VOLUME_OFF, VOLUME_FULL, VOLUME_FULL, a->T("Achievement sound volume"), screenManager()));
-	volume->SetEnabledPtr(&g_Config.bEnableSound);
-	volume->SetZeroLabel(a->T("Mute"));
+	if (System_GetPropertyBool(SYSPROP_HAS_FILE_BROWSER)) {
+		viewGroup->Add(new ItemHeader(ac->T("Sound Effects")));
+		viewGroup->Add(new AudioFileChooser(GetRequesterToken(), &g_Config.sAchievementsUnlockAudioFile, ac->T("Achievement unlocked"), UISound::ACHIEVEMENT_UNLOCKED));
+		viewGroup->Add(new AudioFileChooser(GetRequesterToken(), &g_Config.sAchievementsLeaderboardSubmitAudioFile, ac->T("Leaderboard score submission"), UISound::LEADERBOARD_SUBMITTED));
+		PopupSliderChoice *volume = viewGroup->Add(new PopupSliderChoice(&g_Config.iAchievementSoundVolume, VOLUME_OFF, VOLUME_FULL, VOLUME_FULL, a->T("Achievement sound volume"), screenManager()));
+		volume->SetEnabledPtr(&g_Config.bEnableSound);
+		volume->SetZeroLabel(a->T("Mute"));
+	}
 
 	static const char *positions[] = { "None", "Bottom Left", "Bottom Center", "Bottom Right", "Top Left", "Top Center", "Top Right", "Center Left", "Center Right" };
 

--- a/UI/RetroAchievementScreens.cpp
+++ b/UI/RetroAchievementScreens.cpp
@@ -356,14 +356,14 @@ void RetroAchievementsSettingsScreen::CreateCustomizeTab(UI::ViewGroup *viewGrou
 	auto a = GetI18NCategory(I18NCat::AUDIO);
 
 	using namespace UI;
+	viewGroup->Add(new ItemHeader(ac->T("Sound Effects")));
 	if (System_GetPropertyBool(SYSPROP_HAS_FILE_BROWSER)) {
-		viewGroup->Add(new ItemHeader(ac->T("Sound Effects")));
 		viewGroup->Add(new AudioFileChooser(GetRequesterToken(), &g_Config.sAchievementsUnlockAudioFile, ac->T("Achievement unlocked"), UISound::ACHIEVEMENT_UNLOCKED));
 		viewGroup->Add(new AudioFileChooser(GetRequesterToken(), &g_Config.sAchievementsLeaderboardSubmitAudioFile, ac->T("Leaderboard score submission"), UISound::LEADERBOARD_SUBMITTED));
-		PopupSliderChoice *volume = viewGroup->Add(new PopupSliderChoice(&g_Config.iAchievementSoundVolume, VOLUME_OFF, VOLUME_FULL, VOLUME_FULL, a->T("Achievement sound volume"), screenManager()));
-		volume->SetEnabledPtr(&g_Config.bEnableSound);
-		volume->SetZeroLabel(a->T("Mute"));
 	}
+	PopupSliderChoice *volume = viewGroup->Add(new PopupSliderChoice(&g_Config.iAchievementSoundVolume, VOLUME_OFF, VOLUME_FULL, VOLUME_FULL, a->T("Achievement sound volume"), screenManager()));
+	volume->SetEnabledPtr(&g_Config.bEnableSound);
+	volume->SetZeroLabel(a->T("Mute"));
 
 	static const char *positions[] = { "None", "Bottom Left", "Bottom Center", "Bottom Right", "Top Left", "Top Center", "Top Right", "Center Left", "Center Right" };
 


### PR DESCRIPTION
Previously we hid the customize tab on the RetroAchievements settings screen if there was no file chooser, since it was only used for picking audio files.

No longer the case, so let's remove this erroneous check, and instead just hide the audio choosers in this case.