### PR TITLE
CHD: Fix unnecessary reloads of "hunks" during large reads

### DIFF
--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -644,12 +644,6 @@ CHDFileBlockDevice::CHDFileBlockDevice(FileLoader *fileLoader)
 	impl_->chd = file;
 	impl_->header = chd_get_header(impl_->chd);
 
-	if (impl_->header->hunkbytes != 2048) {
-		badCHD_ = true;
-	} else {
-		badCHD_ = false;
-	}
-
 	readBuffer = new u8[impl_->header->hunkbytes];
 	currentHunk = -1;
 	blocksPerHunk = impl_->header->hunkbytes / impl_->header->unitbytes;

--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -683,9 +683,9 @@ bool CHDFileBlockDevice::ReadBlock(int blockNumber, u8 *outPtr, bool uncached)
 			ERROR_LOG(LOADER, "CHD read failed: %d %d %s", blockNumber, hunk, chd_error_string(err));
 			NotifyReadError();
 		}
+		currentHunk = hunk;
 	}
 	memcpy(outPtr, readBuffer + blockInHunk * impl_->header->unitbytes, GetBlockSize());
-
 	return true;
 }
 

--- a/Core/FileSystems/BlockDevices.h
+++ b/Core/FileSystems/BlockDevices.h
@@ -50,7 +50,6 @@ public:
 		return (u64)GetNumBlocks() * (u64)GetBlockSize();
 	}
 	virtual bool IsDisc() const = 0;
-	virtual bool IsBadCHD() const { return false; }
 
 	void NotifyReadError();
 
@@ -147,7 +146,6 @@ public:
 	bool ReadBlocks(u32 minBlock, int count, u8 *outPtr) override;
 	u32 GetNumBlocks() const override { return numBlocks; }
 	bool IsDisc() const override { return true; }
-	bool IsBadCHD() const override { return badCHD_; }
 private:
 	struct ExtendedCoreFile *core_file_ = nullptr;
 	std::unique_ptr<CHDImpl> impl_;
@@ -155,7 +153,6 @@ private:
 	u32 currentHunk = 0;
 	u32 blocksPerHunk = 0;
 	u32 numBlocks = 0;
-	bool badCHD_ = false;
 };
 
 BlockDevice *constructBlockDevice(FileLoader *fileLoader);

--- a/Tools/langtool/Cargo.lock
+++ b/Tools/langtool/Cargo.lock
@@ -76,9 +76,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "proc-macro-error"
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -180,9 +180,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -276,11 +276,6 @@ void EmuScreen::bootGame(const Path &filename) {
 		return;
 	}
 
-	if (info->badCHD) {
-		auto e = GetI18NCategory(I18NCat::ERRORS);
-		g_OSD.Show(OSDType::MESSAGE_CENTERED_ERROR, e->T("BadCHD", "Bad CHD file.\nCompress using \"chdman createdvd\" for good performance."), gamePath_.ToVisualString(), 7.0f);
-	}
-
 	auto sc = GetI18NCategory(I18NCat::SCREEN);
 	if (info->fileType == IdentifiedFileType::PSP_DISC_DIRECTORY) {
 		// Check for existence of ppsspp-index.lst - if it exists, the user likely knows what they're doing.

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -688,9 +688,6 @@ handleELF:
 				if (!bd) {
 					return;
 				}
-				if (bd->IsBadCHD()) {
-					info_->badCHD = true;
-				}
 				ISOFileSystem umd(&handles, bd);
 
 				// Alright, let's fetch the PARAM.SFO.

--- a/UI/GameInfoCache.h
+++ b/UI/GameInfoCache.h
@@ -147,7 +147,6 @@ public:
 	int disc_total = 0;
 	int disc_number = 0;
 	int region = -1;
-	bool badCHD = false;
 	IdentifiedFileType fileType;
 	ParamSFOData paramSFO;
 	bool hasConfig = false;

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -150,10 +150,6 @@ void GameScreen::CreateViews() {
 		tvVerified_ = infoLayout->Add(new NoticeView(NoticeLevel::INFO, ga->T("Click \"Calculate CRC\" to verify ISO"), "", new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
 		tvVerified_->SetVisibility(UI::V_GONE);
 		tvVerified_->SetSquishy(true);
-		if (info->badCHD) {
-			auto e = GetI18NCategory(I18NCat::ERRORS);
-			infoLayout->Add(new NoticeView(NoticeLevel::ERROR, e->T("BadCHD", "Bad CHD file.\nCompress using \"chdman createdvd\" for good performance."), "", new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)))->SetSquishy(true);
-		}
 	} else {
 		tvTitle_ = nullptr;
 		tvID_ = nullptr;

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -460,7 +460,6 @@ Zoom = ‎تقريب
 [Error]
 7z file detected (Require 7-Zip) = ‎الملف مضغوط (7z).\nمن فضلك فك الضغط أولاً (جرب 7-Zip أوWinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = ‎لا يمكن حفظ ملف لقطة الشاشة.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = file is compressed (7z).\nPlease decompress first (try 7-Zip or WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Could not save screenshot file.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = file is compressed (7z).\nPlease decompress first (try 7-Zip or WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Could not save screenshot file.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = file is compressed (7z).\nPlease decompress first (try 7-Zip or WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Could not save screenshot file.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -452,7 +452,6 @@ Zoom = Přiblížení
 [Error]
 7z file detected (Require 7-Zip) = Soubor je zabalen (7z).\nNejdříve ho musíte rozbalit (zkuste 7-Zip nebo WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD-file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Soubor se snímkem obrazovky nelze uložit.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = Fil er pakket (7z).\nPak venligst ud først (prøv 7-Zip eller WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Kunne ikke gemme skærmbilledefilen.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = Datei ist komprimiert (7z).\nBitte entpacken Sie diese zuerst (mit 7-Zip oder WinRAR).
 A PSP game couldn't be found on the disc. = Ein PSP Spiel konnte nicht auf der Disk gefunden werden.
-BadCHD = Bad CHD-file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Kann ELF außerhalb von mountRoot nicht booten.
 Could not save screenshot file = Screenshot konnte nicht gespeichert werden.
 D3D9or11 = Direct3D 9? (oder "nein" für Direct3D 11)

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = file is compressed (7z).\nPlease decompress first (try 7-Zip or WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Could not save screenshot file.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -477,7 +477,6 @@ Zoom = Zoom
 7z file detected (Require 7-Zip) = File is compressed (7z).\nPlease decompress first (try 7-Zip or WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance.
 Could not save screenshot file = Could not save screenshot file.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)
 D3D11CompilerMissing = D3DCompiler_47.dll not found. Please install. Or press Yes to try again using Direct3D 9 instead.

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -452,7 +452,6 @@ Zoom = Acercar
 [Error]
 7z file detected (Require 7-Zip) = Es un archivo comprimido (en 7z).\nPor lo que necesita ser descomprimido (usa 7-Zip o WinRAR).
 A PSP game couldn't be found on the disc. = No se pudo encontrar un juego de PSP en el disco.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = No se pudo inicar el ELF localizado fuera del mountRoot.
 Could not save screenshot file = No se pudo guardar la captura de pantalla.
 D3D9or11 = ¿Direct3D 9? (o "no" para Direct3D 11)

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = Es un archivo comprimido (7z).\nPor favor, descomprima primero (usa 7-Zip o WinRAR).
 A PSP game couldn't be found on the disc. = No se detecta el juego de PSP en el disco.
-BadCHD = Bad CHD-file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = No puede iniciar ELF localizado fuera de mountRoot.
 Could not save screenshot file = No se pudo guardar la captura de pantalla.
 D3D9or11 = ¿Direct3D 9? (o "no" para Direct3D 11)

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = file is compressed (7z).\nPlease decompress first (try 7-Zip or WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD-file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Could not save screenshot file.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = file is compressed (7z).\nPlease decompress first (try 7-Zip or WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD-file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Could not save screenshot file.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = Le fichier est compressé (.7z).\nVeuillez d'abord le décompresser (essayez 7-Zip ou WinRAR).
 A PSP game couldn't be found on the disc. = Aucun jeu PSP n'a été trouvé sur le disque.
-BadCHD = Bad CHD-file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Impossible de démarrer le fichier ELF situé en dehors du mountRoot.
 Could not save screenshot file = Impossible d'enregistrer la capture d'écran.
 D3D9or11 = Direct3D 9 ? (ou "non" pour Direct3D 11)

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = file is compressed (7z).\nPlease decompress first (try 7-Zip or WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Could not save screenshot file.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = Το αρχείο είναι συμπισμένο(7z).\nΠαρακαλώ αποσυμπιέστε το πρώτα (δοκιμάστε το 7-Zip ή το WinRAR).
 A PSP game couldn't be found on the disc. = Δεν βρέθηκαν παιχνίδια PSP στο δίσκο.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Δεν μπορεί να φορτωθεί ELF που βρίσκεται εκτός mountRoot.
 Could not save screenshot file = Αδυναμία αποθήκευσης αποτύπωσης οθόνης.
 D3D9or11 = Direct3D 9? (ή "όχι" για Direct3D 11)

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = file is compressed (7z).\nPlease decompress first (try 7-Zip or WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Could not save screenshot file.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = file is compressed (7z).\nPlease decompress first (try 7-Zip or WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Could not save screenshot file.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -452,7 +452,6 @@ Zoom = Zumiraj
 [Error]
 7z file detected (Require 7-Zip) = Datoteka je arhivirana (7z).\nMolimo vas, dearhivirajte datoteku prvo (probajte 7-Zip ili WinRAR).
 A PSP game couldn't be found on the disc. = PSP igra nije mogla biti pronađena na disku.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Nije moguće pokrenuti ELF datoteku lociranu izvan mountRoot.
 Could not save screenshot file = Nije moguće spremiti datoteku slike zaslona.
 D3D9or11 = Direct3D 9? (ili "ne" za Direct3D 11)

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = A fájl tömörített (7z).\nElőbb csomagold ki (használj 7-Zip-et vagy WinRAR-t)!
 A PSP game couldn't be found on the disc. = Nem található PSP játék a lemezen.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Nem indítható mountRoot-on kívül található ELF.
 Could not save screenshot file = Képernyőkép mentése sikertelen.
 D3D9or11 = Direct3D 9? (Nyomj "Nem"-et Direct3D 11 használatához)

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -452,7 +452,6 @@ Zoom = Perbesar
 [Error]
 7z file detected (Require 7-Zip) = Berkas terkompresi (7z).\nMohon ekstrak dahulu (coba 7-Zip atau WinRAR).
 A PSP game couldn't be found on the disc. = Sebuah permainan PSP tidak dapat ditemukan pada disk.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Tidak dapat mem-boot ELF yang terletak di luar mountRoot.
 Could not save screenshot file = Tidak dapat menyimpan berkas tangkapan layar.
 D3D9or11 = Direct3D 9? (atau "tidak" untuk Direct3D 11)

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = il file è compresso (7z).\nPrego, prima decomprimerlo (prova con 7-Zip o WinRAR).
 A PSP game couldn't be found on the disc. = Non è stato trovato nessun gioco PSP su disco.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Impossibile avviare il file ELF fuori dal mountRoot.
 Could not save screenshot file = Impossibile salvare il file screenshot.
 D3D9or11 = Direct3D 9? (oppure "no" per Direct3D 11)

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -452,7 +452,6 @@ Zoom = 拡大
 [Error]
 7z file detected (Require 7-Zip) = ファイルが圧縮されています (7z)。\nまず解凍してください (7-ZipかWinRARを使う)。
 A PSP game couldn't be found on the disc. = PSPのゲームがディスクにありません。
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = mountRootの外部にあるELFを起動できません。
 Could not save screenshot file = スクリーンショットファイルを保存できません。
 D3D9or11 = Direct3D 9? (「いいえ」でDirect3D 11)

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -452,7 +452,6 @@ Zoom = Gede
 [Error]
 7z file detected (Require 7-Zip) = berkas iki terkompres (7z).\nMohon bongkar dahulu (try 7-Zip or WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Ora dapat nyimpen tangkapan layar.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -453,7 +453,6 @@ Zoom = 확대/축소
 7z file detected (Require 7-Zip) = 파일은 (7z로) 압축되어 있습니다.\n먼저 압축을 해제하십시오 (7-Zip 또는 WinRAR 시도).
 A PSP game couldn't be found on the disc. = 디스크에서 PSP 게임을 찾을 수 없습니다.
 Cannot boot ELF located outside mountRoot. = mountRoot 외부에 있는 ELF를 부팅할 수 없습니다.
-BadCHD = CHD 파일이 잘못되었습니다.\n좋은 성능을 위해 "chdmancreatedvd"를 사용하여 압축하세요.
 Could not save screenshot file = 스크린샷 파일을 저장할 수 없습니다.
 D3D9or11 = 다이렉트3D 9? (또는 Direct3D 11의 경우 "아니오")
 D3D11CompilerMissing = D3DCompiler_47.dll을 찾을 수 없습니다. 설치하세요. 또는 예를 눌러 대신 Direct3D 9를 사용하여 다시 시도하세요.

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -452,7 +452,6 @@ Zoom = ຊູມ
 [Error]
 7z file detected (Require 7-Zip) = ໄຟລ໌ຖືກບີບອັດ (7z).\nກະລຸນາແຕກໄຟລ໌ກ່ອນ (ລອງໃຊ້ 7-Zip ຫຼື WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = ບໍ່ສາມາດບັນທຶກໄຟລ໌ພາບໜ້າຈໍ.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = file is compressed (7z).\nPlease decompress first (try 7-Zip or WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Could not save screenshot file.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = file is compressed (7z).\nPlease decompress first (try 7-Zip or WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Could not save screenshot file.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -452,7 +452,6 @@ Zoom = Vergroten
 [Error]
 7z file detected (Require 7-Zip) = het bestand is verkleind (7z).\nPak het bestand eerst uit (probeer 7-Zip of WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Kan het screenshotbestand niet opslaan.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = file is compressed (7z).\nPlease decompress first (try 7-Zip or WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Could not save screenshot file.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -452,7 +452,6 @@ Zoom = Powiększ
 [Error]
 7z file detected (Require 7-Zip) = plik skompresowany (7z).\nProszę najpierw wypakować (spróbuj 7-Zip lub WinRAR).
 A PSP game couldn't be found on the disc. = Na dysku nie znaleziono gry na PSP.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Nie można uruchomić ELF znajdującego się poza mountRoot.
 Could not save screenshot file = Nie można zapisać zrzutu ekranu.
 D3D9or11 = Direct3D 9? (Wybierz "nie" by wybrać Direct3D 11)

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -476,7 +476,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = O arquivo está comprimido (7z).\nPor favor descomprima-o primeiro (tente o 7-zip ou WinRAR).
 A PSP game couldn't be found on the disc. = Um jogo de PSP não pôde ser achado no disco.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Não pôde dar boot no ELF localizado fora do mountRoot.
 Could not save screenshot file = Não pôde salvar o arquivo da screenshot.
 D3D9or11 = Direct3D 9? (Ou "não" pro Direct3D 11)

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -476,7 +476,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = O ficheiro está comprimido (.7z).\nPor favor descomprima-o primeiro (tente usar o 7-zip ou WinRAR).
 A PSP game couldn't be found on the disc. = Nenhum jogo de PSP foi ser encontrado no disco.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Não é possível bootar no ELF localizado fora do mountRoot.
 Could not save screenshot file = Não foi possível salvar o ficheiro da captura de tela.
 D3D9or11 = Direct3D 9? ("não" para usar Direct3D 11)

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -453,7 +453,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = Fișierul e compresat (7z).\nVă rog decompresați întai (7-Zip sau WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD-file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Nu s-a putut salva fișierul imagine.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -452,7 +452,6 @@ Zoom = Масштаб
 [Error]
 7z file detected (Require 7-Zip) = Файл сжат (7z).\nПожалуйста, распакуйте (воспользуйтесь 7-Zip).
 A PSP game couldn't be found on the disc. = На диске не удалось найти игру для PSP.
-BadCHD = Файл CHD испорчен.\nСожмите данные с помощью "chdman createdvd" для наилучшего результата.
 Cannot boot ELF located outside mountRoot. = Невозможно загрузить ELF, расположенный вне mountRoot.
 Could not save screenshot file = Не удалось сохранить скриншот.
 D3D9or11 = Direct3D 9? (или "нет" для Direct3D 11)

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -453,7 +453,6 @@ Zoom = Zooma
 [Error]
 7z file detected (Require 7-Zip) = file is compressed (7z).\nPlease decompress first (try 7-Zip or WinRAR).
 A PSP game couldn't be found on the disc. = Kunde inte hitta ett PSP-spel på skivavbildningen.
-BadCHD = Felaktig CHD-fil.\nKomprimera om med "chdman createdvd" för bra prestanda.
 Cannot boot ELF located outside mountRoot. = Kan inte boota en ELF som ligger utanför mountRoot.
 Could not save screenshot file = Misslyckades spara skärmdump.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -453,7 +453,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = Ang file ay na-compress (7z).\nPaki-decompress muna (i-try ang 7-Zip o WinRAR).
 A PSP game couldn't be found on the disc. = Walang matagpuan na PSP game sa disk na ito.
-BadCHD = May mali sa CHD file na ito.\nGumamit ng "chdman createdvd" na command para sa magandang performance.
 Cannot boot ELF located outside mountRoot. = Hindi ma-boot ang ELF na matatagpuan sa labas ng mountRoot.
 Could not save screenshot file = Hindi ma-save ang screenshot.
 D3D9or11 = Direct3D 9? (o "Hindi" para sa Direct3D 11)

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -453,7 +453,6 @@ Zoom = ขยาย
 [Error]
 7z file detected (Require 7-Zip) = ไฟล์นี้ถูกบีบอัดมา (7z) โปรดแตกไฟล์ก่อน (ลองใช้ 7-Zip หรือ WinRAR หรือ Zarchiver)
 A PSP game couldn't be found on the disc. = ไม่พบเกม PSP ที่อยู่ในดิสก์นี้
-BadCHD = ไฟล์ CHD นี้ย่ำแย่\nแนะนำให้บีบอัดด้วยคำสั่ง "chdman createdvd" เพื่อประสิทธิภาพในการอ่านที่ดี
 Cannot boot ELF located outside mountRoot. = ไม่สามารถบู้ต ELF ที่ตั้งอยู่ข้างนอก mountRoot ได้
 Could not save screenshot file = ไม่สามารถบันทึกการจับภาพจากหน้าจอได้
 D3D9or11 = ต้องการสลับไปใช้ไดเร็คท์ 9 ใช่ไหม? (หรือเลือก "ไม่ใช่" เพื่อสลับไปใช้ ไดเร็คท์ 3D 11)

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -454,7 +454,6 @@ Zoom = Yakınlaştır
 [Error]
 7z file detected (Require 7-Zip) = dosya sıkıştırılmış (7z).\nLütfen ilk olarak dosyayı çıkartın (7-zip ya da WinRAR kullanın).
 A PSP game couldn't be found on the disc. = Diskte bir PSP oyunu bulunamadı.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = mountRoot dışında bulunan ELF önyüklenemiyor.
 Could not save screenshot file = Ekran görüntüsü kaydedilemedi.
 D3D9or11 = Direct3D 9? (Direct3D 11 için hayır'a basın)

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -452,7 +452,6 @@ Zoom = Масштаб
 [Error]
 7z file detected (Require 7-Zip) = файл стиснутий (7z). \ nБудь ласка, спочатку розпакуйте (спробуйте 7-Zip або WinRAR).
 A PSP game couldn't be found on the disc. = На диску не вдалось знайти гру для PSP.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Неможливо завантажити ELF, який знаходиться за межами mountRoot.
 Could not save screenshot file = Не вдалось зберегти файл знімку екрана.
 D3D9or11 = Direct3D 9? (чи "Ні" для Direct3D 11)

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -452,7 +452,6 @@ Zoom = Zoom
 [Error]
 7z file detected (Require 7-Zip) = File đã bị nén (7z).\nYêu cầu giải nén trước (thử dùng 7-Zip và WinRAR).
 A PSP game couldn't be found on the disc. = A PSP game couldn't be found on the disc.
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = Cannot boot ELF located outside mountRoot.
 Could not save screenshot file = Không thể lưu file ảnh chụp màn hình.
 D3D9or11 = Direct3D 9? (or "no" for Direct3D 11)

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -452,7 +452,6 @@ Zoom = 放大
 [Error]
 7z file detected (Require 7-Zip) = 这是7Z压缩文件。\n请试着使用7-zip或WinRAR进行解压缩。
 A PSP game couldn't be found on the disc. = 光盘中找不到PSP游戏。
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = 无法启动位于mountRoot之外的ELF文件。
 Could not save screenshot file = 无法保存屏幕截图文件
 D3D9or11 = 使用Direct3D 9？(或“否”以使用Direct3D 11)

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -452,7 +452,6 @@ Zoom = 縮放
 [Error]
 7z file detected (Require 7-Zip) = 檔案已壓縮 (7z)\n請先解壓縮 (嘗試 7-Zip 或 WinRAR)
 A PSP game couldn't be found on the disc. = 此光碟上找不到 PSP 遊戲
-BadCHD = Bad CHD file.\nCompress using "chdman createdvd" for good performance
 Cannot boot ELF located outside mountRoot. = 無法啟動位於 mountRoot 外的 ELF
 Could not save screenshot file = 無法儲存螢幕截圖檔案
 D3D9or11 = 使用 Direct3D 9？(或「否」以使用 Direct3D 11)


### PR DESCRIPTION
This fixes the worst performance problem of using large hunk sizes with CHDs in PPSSPP.

It seems that with this, performance is good enough that we can remove the warning for bad CHDs, but I still recommend 2048-byte hunk size and will continue to do so in the [website instructions](https://www.ppsspp.org/docs/getting-started/dumping-games/).

Fixes #18925