### PR TITLE
Added typical CLion CMake build dirs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ build
 libretro/obj/local
 
 ppsspp_retroachievements.dat
+
+# For CLion
+cmake-build-*/


### PR DESCRIPTION
CLion creates the dirs like `cmake-build-debug/release/relwithdebuginfo` (or similar, but with toolchain's name).
I want to make it easier for our potential CLion users to work with the cloned repo.