### PR TITLE
Colored logs for SDL

### DIFF
--- a/Common/ConsoleListener.cpp
+++ b/Common/ConsoleListener.cpp
@@ -626,12 +626,12 @@ void ConsoleListener::Log(const LogMessage &msg) {
 		case LogLevel::LWARNING: // light yellow
 			strcpy(ColorAttr, "\033[93m");
 			break;
-        case LogLevel::LINFO: // cyan
-            strcpy(ColorAttr, "\033[96m");
-            break;
-        case LogLevel::LDEBUG: // gray
-            strcpy(ColorAttr, "\033[90m");
-            break;
+		case LogLevel::LINFO: // cyan
+			strcpy(ColorAttr, "\033[96m");
+			break;
+		case LogLevel::LDEBUG: // gray
+			strcpy(ColorAttr, "\033[90m");
+			break;
 		default:
 			break;
 		}

--- a/Common/ConsoleListener.cpp
+++ b/Common/ConsoleListener.cpp
@@ -626,6 +626,12 @@ void ConsoleListener::Log(const LogMessage &msg) {
 		case LogLevel::LWARNING: // light yellow
 			strcpy(ColorAttr, "\033[93m");
 			break;
+        case LogLevel::LINFO: // cyan
+            strcpy(ColorAttr, "\033[96m");
+            break;
+        case LogLevel::LDEBUG: // gray
+            strcpy(ColorAttr, "\033[90m");
+            break;
 		default:
 			break;
 		}


### PR DESCRIPTION
For some reason neither INFO nor DEBUG logs used to have any special coloring which has been enabled for ages in the Windows build.
The logging system in the SDK build is far from optimal (check `using namespace std;` and `cout << "gamecontrollerdb.txt missing" << endl;` in [SDKJoystick.cpp](https://github.com/hrydgard/ppsspp/blob/master/SDL/SDLJoystick.cpp#L41)), but I don't think I can rewrite everything there in one go. Let it be just the colors for now.