### PR TITLE
Using constexpr std::size() C++17 more faster and safer from typos

### DIFF
--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -570,7 +570,7 @@ static const char *const armRegStrings[] = {
 };
 
 const char *ARMRegAsString(ARMReg reg) {
-	if ((unsigned int)reg >= sizeof(armRegStrings)/sizeof(armRegStrings[0]))
+	if ((unsigned int)reg >= std::size(armRegStrings))
 		return "(bad)";
 	return armRegStrings[(int)reg];
 }

--- a/Common/Common.h
+++ b/Common/Common.h
@@ -58,7 +58,7 @@
 #endif
 
 #ifndef ARRAY_SIZE
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+#define ARRAY_SIZE(a) std::size(a)
 #endif
 
 #if defined(_WIN32)

--- a/Common/CommonFuncs.h
+++ b/Common/CommonFuncs.h
@@ -22,7 +22,7 @@
 #include "CommonTypes.h"
 
 #ifndef ARRAY_SIZE
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+#define ARRAY_SIZE(a) std::size(a)
 #endif
 
 #if !defined(_WIN32)

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -988,7 +988,7 @@ bool OpenFileInEditor(const Path &fileName) {
 const Path GetCurDirectory() {
 #ifdef _WIN32
 	wchar_t buffer[4096];
-	size_t len = GetCurrentDirectory(sizeof(buffer) / sizeof(wchar_t), buffer);
+	size_t len = GetCurrentDirectory(std::size(buffer), buffer);
 	std::string curDir = ConvertWStringToUTF8(buffer);
 	return Path(curDir);
 #else

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -977,7 +977,7 @@ static const ConfigSectionSettings sections[] = {
 	{"Achievements", achievementSettings, ARRAY_SIZE(achievementSettings)},
 };
 
-const size_t numSections = ARRAY_SIZE(sections);
+constexpr size_t numSections = ARRAY_SIZE(sections);
 
 static void IterateSettings(IniFile &iniFile, std::function<void(Section *section, const ConfigSetting &setting)> func) {
 	for (size_t i = 0; i < numSections; ++i) {

--- a/Core/ELF/PrxDecrypter.cpp
+++ b/Core/ELF/PrxDecrypter.cpp
@@ -315,7 +315,7 @@ static const TAG_INFO g_tagInfo[] =
 
 static const TAG_INFO *GetTagInfo(u32 tagFind)
 {
-	for (u32 iTag = 0; iTag < sizeof(g_tagInfo)/sizeof(TAG_INFO); iTag++)
+	for (u32 iTag = 0; iTag < std::size(g_tagInfo); iTag++)
 		if (g_tagInfo[iTag].tag == tagFind)
 			return &g_tagInfo[iTag];
 	return NULL; // not found
@@ -471,7 +471,7 @@ static const TAG_INFO2 g_tagInfo2[] =
 
 static const TAG_INFO2 *GetTagInfo2(u32 tagFind)
 {
-	for (u32 iTag = 0; iTag < sizeof(g_tagInfo2) / sizeof(TAG_INFO2); iTag++)
+	for (u32 iTag = 0; iTag < std::size(g_tagInfo2); iTag++)
 	{
 		if (g_tagInfo2[iTag].tag == tagFind)
 		{

--- a/Core/HDRemaster.h
+++ b/Core/HDRemaster.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cstddef>
+#include <iterator>
 #include "Common/CommonTypes.h"
 
 // This bool is the key to having the HD remasters work.

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <cstdarg>
 #include <type_traits>
+#include <iterator>
 
 #include "Common/CommonTypes.h"
 #include "Common/Log.h"

--- a/Core/HLE/HLETables.cpp
+++ b/Core/HLE/HLETables.cpp
@@ -213,7 +213,7 @@ const HLEModule moduleList[] =
 	{"pspeDebug", ARRAY_SIZE(pspeDebug), pspeDebug},
 };
 
-static const int numModules = ARRAY_SIZE(moduleList);
+static constexpr int numModules = ARRAY_SIZE(moduleList);
 
 void RegisterAllModules() {
 	Register_Kernel_Library();

--- a/Core/HLE/sceAudiocodec.cpp
+++ b/Core/HLE/sceAudiocodec.cpp
@@ -191,8 +191,8 @@ void __sceAudiocodecDoState(PointerWrap &p){
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsizeof-pointer-div"
 #endif
-			DoArray(p, codec_, s >= 2 ? count : (int)ARRAY_SIZE(codec_));
-			DoArray(p, ctxPtr_, s >= 2 ? count : (int)ARRAY_SIZE(ctxPtr_));
+			DoArray(p, codec_, s >= 2 ? count : sizeof(codec_) / codec_[0]);
+			DoArray(p, ctxPtr_, s >= 2 ? count : sizeof(ctxPtr_) / ctxPtr_[0]);
 			for (int i = 0; i < count; i++) {
 				auto decoder = new SimpleAudio(codec_[i]);
 				decoder->SetCtxPtr(ctxPtr_[i]);

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -165,14 +165,16 @@ void VagDecoder::DoState(PointerWrap &p) {
 	if (!s)
 		return;
 
+	const int size = std::size(samples);
 	if (s >= 2) {
-		DoArray(p, samples, ARRAY_SIZE(samples));
+		DoArray(p, samples, size);
 	} else {
-		int samplesOld[ARRAY_SIZE(samples)];
-		DoArray(p, samplesOld, ARRAY_SIZE(samples));
-		for (size_t i = 0; i < ARRAY_SIZE(samples); ++i) {
+		int* samplesOld = new int[size];
+		DoArray(p, samplesOld, size);
+		for (size_t i = 0; i < size; ++i) {
 			samples[i] = samplesOld[i];
 		}
+		delete[] samplesOld;
 	}
 	Do(p, curSample);
 

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -25,6 +25,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/HW/BufferQueue.h"
 #include "Core/HW/SasReverb.h"
+#include <iterator>
 
 class PointerWrap;
 

--- a/Core/MIPS/ARM/ArmRegCache.cpp
+++ b/Core/MIPS/ARM/ArmRegCache.cpp
@@ -63,13 +63,13 @@ const ARMReg *ArmRegCache::GetMIPSAllocationOrder(int &count) {
 		static const ARMReg allocationOrder[] = {
 			R1, R2, R3, R4, R5, R6, R12,
 		};
-		count = sizeof(allocationOrder) / sizeof(const int);
+		count = std::size(allocationOrder);
 		return allocationOrder;
 	} else {
 		static const ARMReg allocationOrder2[] = {
 			R1, R2, R3, R4, R5, R6, R7, R12,
 		};
-		count = sizeof(allocationOrder2) / sizeof(const int);
+		count = std::size(allocationOrder2);
 		return allocationOrder2;
 	}
 }

--- a/Core/MIPS/ARM/ArmRegCacheFPU.cpp
+++ b/Core/MIPS/ARM/ArmRegCacheFPU.cpp
@@ -100,10 +100,10 @@ const ARMReg *ArmRegCacheFPU::GetMIPSAllocationOrder(int &count) {
 	// NOTE: It's important that S2/S3 are not allocated with bNEON, even if !useNEONVFPU.
 	// They are used by a few instructions, like vh2f.
 	if (jo_->useNEONVFPU) {
-		count = sizeof(allocationOrderNEONVFPU) / sizeof(const ARMReg);
+		count = std::size(allocationOrderNEONVFPU);
 		return allocationOrderNEONVFPU;
 	} else {
-		count = sizeof(allocationOrderNEON) / sizeof(const ARMReg);
+		count = std::size(allocationOrderNEON);
 		return allocationOrderNEON;
 	}
 }

--- a/Core/MIPS/ARM64/Arm64RegCacheFPU.cpp
+++ b/Core/MIPS/ARM64/Arm64RegCacheFPU.cpp
@@ -93,10 +93,10 @@ const ARM64Reg *Arm64RegCacheFPU::GetMIPSAllocationOrder(int &count) {
 	};
 
 	if (jo_->useASIMDVFPU) {
-		count = sizeof(allocationOrderNEONVFPU) / sizeof(const ARM64Reg);
+		count = std::size(allocationOrderNEONVFPU);
 		return allocationOrderNEONVFPU;
 	} else {
-		count = sizeof(allocationOrder) / sizeof(const ARM64Reg);
+		count = std::size(allocationOrder);
 		return allocationOrder;
 	}
 }

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -283,18 +283,18 @@ void MIPSState::DoState(PointerWrap &p) {
 	else
 		MIPSComp::DoDummyJitState(p);
 
-	DoArray(p, r, sizeof(r) / sizeof(r[0]));
-	DoArray(p, f, sizeof(f) / sizeof(f[0]));
+	DoArray(p, r, std::size(r));
+	DoArray(p, f, std::size(f));
 	if (s <= 2) {
 		float vtemp[128];
-		DoArray(p, vtemp, sizeof(v) / sizeof(v[0]));
+		DoArray(p, vtemp, std::size(v));
 		for (int i = 0; i < 128; i++) {
 			v[voffset[i]] = vtemp[i];
 		}
 	} else {
-		DoArray(p, v, sizeof(v) / sizeof(v[0]));
+		DoArray(p, v, std::size(v));
 	}
-	DoArray(p, vfpuCtrl, sizeof(vfpuCtrl) / sizeof(vfpuCtrl[0]));
+	DoArray(p, vfpuCtrl, std::size(vfpuCtrl));
 	Do(p, pc);
 	Do(p, nextPC);
 	Do(p, downcount);

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -1019,14 +1019,14 @@ int FPURegCache::SanityCheck() const {
 }
 
 const int *FPURegCache::GetAllocationOrder(int &count) {
-	static const int allocationOrder[] = {
+	static constexpr int allocationOrder[] = {
 #if PPSSPP_ARCH(AMD64)
 		XMM6, XMM7, XMM8, XMM9, XMM10, XMM11, XMM12, XMM13, XMM14, XMM15, XMM2, XMM3, XMM4, XMM5
 #elif PPSSPP_ARCH(X86)
 		XMM2, XMM3, XMM4, XMM5, XMM6, XMM7,
 #endif
 	};
-	count = sizeof(allocationOrder) / sizeof(int);
+	count = std::size(allocationOrder);
 	return allocationOrder;
 }
 

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -111,7 +111,7 @@ static MemoryView views[] =
 	// implement those.
 };
 
-static const int num_views = sizeof(views) / sizeof(MemoryView);
+static constexpr int num_views = std::size(views);
 
 inline static bool CanIgnoreView(const MemoryView &view) {
 #ifdef MASKED_PSP_MEMORY

--- a/GPU/Common/ShaderId.h
+++ b/GPU/Common/ShaderId.h
@@ -145,7 +145,7 @@ struct ShaderID {
 
 	uint32_t d[2];
 	bool operator < (const ShaderID &other) const {
-		for (size_t i = 0; i < sizeof(d) / sizeof(uint32_t); i++) {
+		for (size_t i = 0; i < std::size(d); i++) {
 			if (d[i] < other.d[i])
 				return true;
 			if (d[i] > other.d[i])
@@ -154,7 +154,7 @@ struct ShaderID {
 		return false;
 	}
 	bool operator == (const ShaderID &other) const {
-		for (size_t i = 0; i < sizeof(d) / sizeof(uint32_t); i++) {
+		for (size_t i = 0; i < std::size(d); i++) {
 			if (d[i] != other.d[i])
 				return false;
 		}

--- a/GPU/GLES/FragmentTestCacheGLES.h
+++ b/GPU/GLES/FragmentTestCacheGLES.h
@@ -34,7 +34,7 @@ struct FragmentTestID {
 	};
 
 	bool operator < (const FragmentTestID &other) const {
-		for (size_t i = 0; i < sizeof(d) / sizeof(u32); i++) {
+		for (size_t i = 0; i < std::size(d); i++) {
 			if (d[i] < other.d[i])
 				return true;
 			if (d[i] > other.d[i])
@@ -43,7 +43,7 @@ struct FragmentTestID {
 		return false;
 	}
 	bool operator == (const FragmentTestID &other) const {
-		for (size_t i = 0; i < sizeof(d) / sizeof(u32); i++) {
+		for (size_t i = 0; i < std::size(d); i++) {
 			if (d[i] != other.d[i])
 				return false;
 		}

--- a/UI/GPUDriverTestScreen.cpp
+++ b/UI/GPUDriverTestScreen.cpp
@@ -444,12 +444,12 @@ void GPUDriverTestScreen::DiscardTest(UIContext &dc) {
 
 	static const char * const writeModeNames[] = { "Stencil+Depth", "Stencil", "Depth" };
 	Pipeline *writePipelines[] = { discardWriteDepthStencil_, discardWriteStencil_, discardWriteDepth_ };
-	const int numWriteModes = ARRAY_SIZE(writeModeNames);
+	constexpr int numWriteModes = ARRAY_SIZE(writeModeNames);
 
 	static const char * const testNames[] = { "Stenc", "Stenc+DepthA", "Depth", "StencA+Depth" };
 	Pipeline *testPipeline1[] = { drawTestStencilEqual_, drawTestStencilEqualDepthAlways_, drawTestDepthLessEqual_, drawTestStencilAlwaysDepthLessEqual_ };
 	Pipeline *testPipeline2[] = { drawTestStencilNotEqual_, drawTestStencilNotEqualDepthAlways_, drawTestDepthGreater_, drawTestStencilAlwaysDepthGreater_ };
-	const int numTests = ARRAY_SIZE(testNames);
+	constexpr int numTests = ARRAY_SIZE(testNames);
 
 	static const bool validCombinations[numWriteModes][numTests] = {
 		{true, true, true, true},

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -1022,7 +1022,7 @@ void CreditsScreen::DrawForeground(UIContext &dc) {
 	dc.Begin();
 	const Bounds &bounds = dc.GetLayoutBounds();
 
-	const int numItems = ARRAY_SIZE(credits);
+	constexpr int numItems = ARRAY_SIZE(credits);
 	int itemHeight = 36;
 	int totalHeight = numItems * itemHeight + bounds.h + 200;
 

--- a/android/jni/OpenSLContext.cpp
+++ b/android/jni/OpenSLContext.cpp
@@ -129,7 +129,7 @@ bool OpenSLContext::Init() {
 	const SLInterfaceID ids[2] = {SL_IID_BUFFERQUEUE, SL_IID_VOLUME};
 	const SLboolean req[2] = {SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE};
 	result = (*engineEngine)->CreateAudioPlayer(engineEngine, &bqPlayerObject, &audioSrc, &audioSnk,
-			sizeof(ids)/sizeof(ids[0]), ids, req);
+			std::size(ids), ids, req);
 	if (result != SL_RESULT_SUCCESS) {
 		ERROR_LOG(AUDIO, "OpenSL: CreateAudioPlayer failed: %d", (int)result);
 		(*outputMixObject)->Destroy(outputMixObject);
@@ -207,7 +207,7 @@ bool OpenSLContext::AudioRecord_Start(int sampleRate) {
 	const SLInterfaceID id[1] = {SL_IID_ANDROIDSIMPLEBUFFERQUEUE};
 	const SLboolean req[1] = {SL_BOOLEAN_TRUE};
 	result = (*engineEngine)->CreateAudioRecorder(engineEngine, &recorderObject, &audioSrc, &audioSnk,
-			sizeof(id)/sizeof(id[0]), id, req);
+		std::size(id), id, req);
 	if (!CheckResult(result, "CreateAudioRecorder failed"))
 		return false;
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1381,7 +1381,7 @@ static void retro_input(void)
             ret |= (1 << i);
    }
 
-   for (i = 0; i < sizeof(map) / sizeof(*map); i++)
+   for (i = 0; i < std::size(map); i++)
    {
       bool pressed = ret & (1 << map[i].retro);
 

--- a/unittest/TestShaderGenerators.cpp
+++ b/unittest/TestShaderGenerators.cpp
@@ -390,7 +390,7 @@ const ShaderLanguage languages[] = {
 	ShaderLanguage::GLSL_1xx,
 	ShaderLanguage::GLSL_3xx,
 };
-const int numLanguages = ARRAY_SIZE(languages);
+constexpr int numLanguages = ARRAY_SIZE(languages);
 
 bool TestVertexShaders() {
 	char *buffer[numLanguages];


### PR DESCRIPTION
@hrydgard, I think it will be very useful for emu, and also how do you think about replacing new operator with unique_ptr for safe memory cleanup and code reduce?