### PR TITLE
Disable Vulkan/MoltenVK on x64 macs

### DIFF
--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -294,6 +294,10 @@ static VulkanLibraryHandle VulkanLoadLibrary(std::string *errorString) {
 	return nullptr;
 #elif PPSSPP_PLATFORM(UWP)
 	return nullptr;
+#elif PPSSPP_PLATFORM(MACOS) && PPSSPP_ARCH(AMD64)
+	// Disable Vulkan on Mac/x86. Too many configurations that don't work with MoltenVK
+	// for whatever reason.
+	return nullptr;
 #elif PPSSPP_PLATFORM(WINDOWS)
 	return LoadLibrary(L"vulkan-1.dll");
 #else


### PR DESCRIPTION
Keep getting reports of radeon and intel GPUs that don't work with Vulkan.