### PR TITLE
Update compat.ini

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1199,7 +1199,7 @@ UCES00001 = true
 UCKS45008 = true
 NPJG00059 = true
 
-# SOCOM: Fireteam Bravo 3
+# SOCOM: Fireteam Bravo 3 (see issue #18958, hopefully fixes crash in Stockpile mission, #10461)
 UCES-01242 = true
 NPJG-00035 = true
 NPHG-00032 = true

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1199,6 +1199,11 @@ UCES00001 = true
 UCKS45008 = true
 NPJG00059 = true
 
+# SOCOM: Fireteam Bravo 3
+UCES-01242 = true
+NPJG-00035 = true
+NPHG-00032 = true
+
 [MpegAvcWarmUp]
 # God Eater issue #13527 ,It is custom mpeg library that required sceMpegGetAvcAu return ERROR_MPEG_NO_DATA but break FIFA 14 issue #14086
 # God Eater 1


### PR DESCRIPTION
Updated compat.ini to include a fix for SOCOM: Fireteam Bravo 3, particularly in response to the mission "Stockpile".