### PR TITLE
[C++17] Recheck some memset with zeros on buffer underflow

### DIFF
--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -177,7 +177,7 @@ void CPUInfo::Detect() {
 	// Assume CPU supports the CPUID instruction. Those that don't can barely
 	// boot modern OS:es anyway.
 	u32 cpu_id[4];
-	memset(cpu_string, 0, sizeof(cpu_string));
+	memset(cpu_string, 0, std::size(cpu_string) * sizeof(char));
 
 	// Detect CPU's CPUID capabilities, and grab cpu string
 	do_cpuid(cpu_id, 0x00000000);

--- a/Common/Crypto/md5.cpp
+++ b/Common/Crypto/md5.cpp
@@ -34,7 +34,8 @@
 #else
 #include "md5.h"
 
-#include <string.h>
+#include <cstring>
+#include <string>
 
 /*
  * 32-bit integer manipulation macros (little endian)
@@ -317,7 +318,7 @@ void ppsspp_md5_hmac_starts( md5_context *ctx, unsigned char *key, int keylen )
     ppsspp_md5_starts( ctx );
     ppsspp_md5_update( ctx, ctx->ipad, 64 );
 
-    memset( sum, 0, sizeof( sum ) );
+    memset( sum, 0, std::size(sum) * sizeof(unsigned char) );
 }
 
 /*
@@ -341,7 +342,7 @@ void ppsspp_md5_hmac_finish( md5_context *ctx, unsigned char output[16] )
     ppsspp_md5_update( ctx, tmpbuf, 16 );
     ppsspp_md5_finish( ctx, output );
 
-    memset( tmpbuf, 0, sizeof( tmpbuf ) );
+    memset( tmpbuf, 0, std::size(tmpbuf) * sizeof(unsigned char) );
 }
 
 /*

--- a/Common/Crypto/sha1.cpp
+++ b/Common/Crypto/sha1.cpp
@@ -33,8 +33,9 @@
 #include "polarssl/sha1.h"
 */
 #include "sha1.h"
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <string>
+#include <cstdio>
 
 /*
  * 32-bit integer manipulation macros (big endian)
@@ -352,7 +353,7 @@ void sha1_hmac_starts( sha1_context *ctx, unsigned char *key, int keylen )
     sha1_starts( ctx );
     sha1_update( ctx, ctx->ipad, 64 );
 
-    memset( sum, 0, sizeof( sum ) );
+    memset( sum, 0, std::size(sum) * sizeof(unsigned char) );
 }
 
 /*
@@ -376,7 +377,7 @@ void sha1_hmac_finish( sha1_context *ctx, unsigned char output[20] )
     sha1_update( ctx, tmpbuf, 20 );
     sha1_finish( ctx, output );
 
-    memset( tmpbuf, 0, sizeof( tmpbuf ) );
+    memset( tmpbuf, 0, std::size(tmpbuf) * sizeof(unsigned char) );
 }
 
 /*

--- a/Common/GPU/OpenGL/GLRenderManager.cpp
+++ b/Common/GPU/OpenGL/GLRenderManager.cpp
@@ -395,7 +395,7 @@ void GLRenderManager::Finish() {
 				cmdString += StringFromFormat("%s: %d\n", RenderCommandToString((GLRRenderCommand)i), frameData.profile.commandCounts[i]);
 			}
 		}
-		memset(frameData.profile.commandCounts, 0, sizeof(frameData.profile.commandCounts));
+		memset(frameData.profile.commandCounts, 0, std::size(frameData.profile.commandCounts) * sizeof(int));
 		profilePassesString_ = cmdString + profilePassesString_;
 #endif
 

--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -723,7 +723,7 @@ void VulkanRenderManager::BeginFrame(bool enableProfiling, bool enableLogProfile
 				cmdString += StringFromFormat("%s: %d\n", VKRRenderCommandToString((VKRRenderCommand)i), frameData.profile.commandCounts[i]);
 			}
 		}
-		memset(frameData.profile.commandCounts, 0, sizeof(frameData.profile.commandCounts));
+		memset(frameData.profile.commandCounts, 0, std::size(frameData.profile.commandCounts) * sizeof(int));
 		frameData.profile.profileSummary += cmdString;
 #endif
 	}

--- a/Common/Input/GestureDetector.cpp
+++ b/Common/Input/GestureDetector.cpp
@@ -10,7 +10,7 @@
 const float estimatedInertiaDamping = 0.75f;
 
 GestureDetector::GestureDetector() {
-	memset(pointers, 0, sizeof(pointers));
+	memset(pointers, 0, std::size(pointers) * sizeof(GestureDetector::Pointer));
 }
 
 TouchInput GestureDetector::Update(const TouchInput &touch, const Bounds &bounds) {

--- a/Common/Profiler/Profiler.cpp
+++ b/Common/Profiler/Profiler.cpp
@@ -34,8 +34,8 @@ struct Category {
 
 struct CategoryFrame {
 	CategoryFrame() {
-		memset(time_taken, 0, sizeof(time_taken));
-		memset(count, 0, sizeof(count));
+		memset(time_taken, 0, std::size(time_taken) * sizeof(float));
+		memset(count, 0, std::size(count) * sizeof(int));
 	}
 	float time_taken[MAX_CATEGORIES];
 	int count[MAX_CATEGORIES];

--- a/Common/Render/ManagedTexture.h
+++ b/Common/Render/ManagedTexture.h
@@ -36,7 +36,7 @@ struct TempImage {
 	void Free() {
 		if (levels[0]) {
 			free(levels[0]);
-			memset(levels, 0, sizeof(levels));
+			memset(levels, 0, std::size(levels) * sizeof(uint8_t));
 		}
 	}
 };

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -397,8 +397,8 @@ int SavedataParam::DeleteData(SceUtilitySavedataParam* param) {
 			if (strncmp(fileList[i].filename, fileName.c_str(), sizeof(fileList[i].filename)) != 0)
 				continue;
 
-			memset(fileList[i].filename, 0, sizeof(fileList[i].filename));
-			memset(fileList[i].hash, 0, sizeof(fileList[i].hash));
+			memset(fileList[i].filename, 0, std::size(fileList[i].filename) * sizeof(char));
+			memset(fileList[i].hash, 0, std::size(fileList[i].hash) * sizeof(u8));
 			changed = true;
 			break;
 		}
@@ -1125,8 +1125,8 @@ int SavedataParam::GetSizes(SceUtilitySavedataParam *param)
 		param->msFree->freeClusters = (u32)(freeBytes / MemoryStick_SectorSize());
 		param->msFree->freeSpaceKB = (u32)(freeBytes / 0x400);
 		const std::string spaceTxt = SavedataParam::GetSpaceText(freeBytes, false);
-		memset(param->msFree->freeSpaceStr, 0, sizeof(param->msFree->freeSpaceStr));
-		strncpy(param->msFree->freeSpaceStr, spaceTxt.c_str(), sizeof(param->msFree->freeSpaceStr));
+		memset(param->msFree->freeSpaceStr, 0, std::size(param->msFree->freeSpaceStr) * sizeof(char));
+		strncpy(param->msFree->freeSpaceStr, spaceTxt.c_str(), std::size(param->msFree->freeSpaceStr) * sizeof(char));
 		NotifyMemInfo(MemBlockFlags::WRITE, param->msFree.ptr, sizeof(SceUtilitySavedataMsFreeInfo), "SavedataGetSizes");
 	}
 	if (param->msData.IsValid())
@@ -1192,14 +1192,14 @@ int SavedataParam::GetSizes(SceUtilitySavedataParam *param)
 		param->utilityData->usedClusters = total_size / (u32)MemoryStick_SectorSize();
 		param->utilityData->usedSpaceKB = total_size / 0x400;
 		std::string spaceTxt = SavedataParam::GetSpaceText(total_size, true);
-		memset(param->utilityData->usedSpaceStr, 0, sizeof(param->utilityData->usedSpaceStr));
-		strncpy(param->utilityData->usedSpaceStr, spaceTxt.c_str(), sizeof(param->utilityData->usedSpaceStr));
+		memset(param->utilityData->usedSpaceStr, 0, std::size(param->utilityData->usedSpaceStr) * sizeof(char));
+		strncpy(param->utilityData->usedSpaceStr, spaceTxt.c_str(), std::size(param->utilityData->usedSpaceStr) * sizeof(char));
 
 		// TODO: Maybe these are rounded to the nearest 32KB?  Or something?
 		param->utilityData->usedSpace32KB = total_size / 0x400;
 		spaceTxt = SavedataParam::GetSpaceText(total_size, true);
-		memset(param->utilityData->usedSpace32Str, 0, sizeof(param->utilityData->usedSpace32Str));
-		strncpy(param->utilityData->usedSpace32Str, spaceTxt.c_str(), sizeof(param->utilityData->usedSpace32Str));
+		memset(param->utilityData->usedSpace32Str, 0, std::size(param->utilityData->usedSpace32Str) * sizeof(char));
+		strncpy(param->utilityData->usedSpace32Str, spaceTxt.c_str(), std::size(param->utilityData->usedSpace32Str) * sizeof(char));
 		NotifyMemInfo(MemBlockFlags::WRITE, param->utilityData.ptr, sizeof(SceUtilitySavedataUsedDataInfo), "SavedataGetSizes");
 	}
 	return ret;


### PR DESCRIPTION
More readable-accurate calculation size arrays filled zeros for x86, x64 and C++17 guarantee compile-time constexpr calculate size for memset