### PR TITLE
Fixed to free() C version, since memory block was allocated using malloc()

### DIFF
--- a/Common/Data/Collections/FastVec.h
+++ b/Common/Data/Collections/FastVec.h
@@ -48,7 +48,7 @@ public:
 
 	FastVec &operator=(FastVec &&other)	{
 		if (this != &other) {
-			delete[] data_;
+			free(data_);
 			data_ = other.data_;
 			size_ = other.size_;
 			capacity_ = other.capacity_;


### PR DESCRIPTION
@hrydgard,
Memory was allocated using malloc, as far as it is correct to apply C++ new and delete to these memory blocks. I didn't think about it and never did it, but most people on Internet forums write that you can't do that, maybe it's UB, or memory just won't clear.

Example discussion: https://stackoverflow.com/questions/10854210/behaviour-of-malloc-with-delete-in-c