### PR TITLE
Fixed return copies from functions and added const ref params

### DIFF
--- a/Common/Data/Text/I18n.h
+++ b/Common/Data/Text/I18n.h
@@ -88,7 +88,7 @@ public:
 	// Try to avoid this. Still useful in snprintf.
 	const char *T_cstr(const char *key, const char *def = nullptr);
 
-	const std::map<std::string, std::string> Missed() const {
+	std::map<std::string, std::string> Missed() const {
 		std::lock_guard<std::mutex> guard(missedKeyLock_);
 		return missedKeyLog_;
 	}

--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -1879,7 +1879,7 @@ void D3D11DrawContext::GetFramebufferDimensions(Framebuffer *fbo, int *w, int *h
 	}
 }
 
-DrawContext *T3DCreateD3D11Context(ID3D11Device *device, ID3D11DeviceContext *context, ID3D11Device1 *device1, ID3D11DeviceContext1 *context1, IDXGISwapChain *swapChain, D3D_FEATURE_LEVEL featureLevel, HWND hWnd, std::vector<std::string> adapterNames, int maxInflightFrames) {
+DrawContext *T3DCreateD3D11Context(ID3D11Device *device, ID3D11DeviceContext *context, ID3D11Device1 *device1, ID3D11DeviceContext1 *context1, IDXGISwapChain *swapChain, D3D_FEATURE_LEVEL featureLevel, HWND hWnd, const std::vector<std::string> &adapterNames, int maxInflightFrames) {
 	return new D3D11DrawContext(device, context, device1, context1, swapChain, featureLevel, hWnd, adapterNames, maxInflightFrames);
 }
 

--- a/Common/GPU/thin3d_create.h
+++ b/Common/GPU/thin3d_create.h
@@ -28,7 +28,7 @@ DrawContext *T3DCreateGLContext(bool canChangeSwapInterval);
 
 #ifdef _WIN32
 DrawContext *T3DCreateDX9Context(IDirect3D9 *d3d, IDirect3D9Ex *d3dEx, int adapterId, IDirect3DDevice9 *device, IDirect3DDevice9Ex *deviceEx);
-DrawContext *T3DCreateD3D11Context(ID3D11Device *device, ID3D11DeviceContext *context, ID3D11Device1 *device1, ID3D11DeviceContext1 *context1, IDXGISwapChain *swapChain, D3D_FEATURE_LEVEL featureLevel, HWND hWnd, std::vector<std::string> adapterNames, int maxInflightFrames);
+DrawContext *T3DCreateD3D11Context(ID3D11Device *device, ID3D11DeviceContext *context, ID3D11Device1 *device1, ID3D11DeviceContext1 *context1, IDXGISwapChain *swapChain, D3D_FEATURE_LEVEL featureLevel, HWND hWnd, const std::vector<std::string> &adapterNames, int maxInflightFrames);
 #endif
 
 DrawContext *T3DCreateVulkanContext(VulkanContext *context, bool useRenderThread);

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -622,20 +622,20 @@ void CBreakPoints::UpdateCachedMemCheckRanges() {
 	}
 }
 
-const std::vector<MemCheck> CBreakPoints::GetMemCheckRanges(bool write) {
+std::vector<MemCheck> CBreakPoints::GetMemCheckRanges(bool write) {
 	std::lock_guard<std::mutex> guard(memCheckMutex_);
 	if (write)
 		return memCheckRangesWrite_;
 	return memCheckRangesRead_;
 }
 
-const std::vector<MemCheck> CBreakPoints::GetMemChecks()
+std::vector<MemCheck> CBreakPoints::GetMemChecks()
 {
 	std::lock_guard<std::mutex> guard(memCheckMutex_);
 	return memChecks_;
 }
 
-const std::vector<BreakPoint> CBreakPoints::GetBreakpoints()
+std::vector<BreakPoint> CBreakPoints::GetBreakpoints()
 {
 	std::lock_guard<std::mutex> guard(breakPointsMutex_);
 	return breakPoints_;

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -161,10 +161,10 @@ public:
 	static u32 CheckSkipFirst();
 
 	// Includes uncached addresses.
-	static const std::vector<MemCheck> GetMemCheckRanges(bool write);
+	static std::vector<MemCheck> GetMemCheckRanges(bool write);
 
-	static const std::vector<MemCheck> GetMemChecks();
-	static const std::vector<BreakPoint> GetBreakpoints();
+	static std::vector<MemCheck> GetMemChecks();
+	static std::vector<BreakPoint> GetBreakpoints();
 
 	static bool HasBreakPoints();
 	static bool HasMemChecks();

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -308,7 +308,7 @@ int PSPSaveDialog::Init(int paramAddr)
 	return retval;
 }
 
-const std::string PSPSaveDialog::GetSelectedSaveDirName() const
+std::string PSPSaveDialog::GetSelectedSaveDirName() const
 {
 	switch ((SceUtilitySavedataType)(u32)param.GetPspParam()->mode)
 	{

--- a/Core/Dialog/PSPSaveDialog.h
+++ b/Core/Dialog/PSPSaveDialog.h
@@ -95,7 +95,7 @@ private:
 	void DisplaySaveDataInfo1();
 	void DisplaySaveDataInfo2(bool showNewData = false);
 	void DisplayMessage(std::string_view text, bool hasYesNo = false);
-	const std::string GetSelectedSaveDirName() const;
+	std::string GetSelectedSaveDirName() const;
 
 	void JoinIOThread();
 	void StartIOThread();

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -387,7 +387,7 @@ std::vector<u32> IRBlockCache::SaveAndClearEmuHackOps() {
 	return result;
 }
 
-void IRBlockCache::RestoreSavedEmuHackOps(std::vector<u32> saved) {
+void IRBlockCache::RestoreSavedEmuHackOps(const std::vector<u32> &saved) {
 	if ((int)blocks_.size() != (int)saved.size()) {
 		ERROR_LOG(JIT, "RestoreSavedEmuHackOps: Wrong saved block size.");
 		return;

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -139,7 +139,7 @@ public:
 	int FindByCookie(int cookie);
 
 	std::vector<u32> SaveAndClearEmuHackOps();
-	void RestoreSavedEmuHackOps(std::vector<u32> saved);
+	void RestoreSavedEmuHackOps(const std::vector<u32> &saved);
 
 	JitBlockDebugInfo GetBlockDebugInfo(int blockNum) const override;
 	void ComputeStats(BlockCacheStats &bcStats) const override;

--- a/Core/MIPS/JitCommon/JitBlockCache.cpp
+++ b/Core/MIPS/JitCommon/JitBlockCache.cpp
@@ -497,7 +497,7 @@ std::vector<u32> JitBlockCache::SaveAndClearEmuHackOps() {
 	return result;
 }
 
-void JitBlockCache::RestoreSavedEmuHackOps(std::vector<u32> saved) {
+void JitBlockCache::RestoreSavedEmuHackOps(const std::vector<u32> &saved) {
 	if (num_blocks_ != (int)saved.size()) {
 		ERROR_LOG(JIT, "RestoreSavedEmuHackOps: Wrong saved block size.");
 		return;

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -161,7 +161,7 @@ public:
 	// No jit operations may be run between these calls.
 	// Meant to be used to make memory safe for savestates, memcpy, etc.
 	std::vector<u32> SaveAndClearEmuHackOps();
-	void RestoreSavedEmuHackOps(std::vector<u32> saved);
+	void RestoreSavedEmuHackOps(const std::vector<u32> &saved);
 
 	int GetNumBlocks() const override { return num_blocks_; }
 

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -951,7 +951,7 @@ bool GameBrowser::IsCurrentPathPinned() {
 	return std::find(paths.begin(), paths.end(), File::ResolvePath(path_.GetPath().ToString())) != paths.end();
 }
 
-const std::vector<Path> GameBrowser::GetPinnedPaths() {
+std::vector<Path> GameBrowser::GetPinnedPaths() const {
 #ifndef _WIN32
 	static const std::string sepChars = "/";
 #else
@@ -979,7 +979,7 @@ const std::vector<Path> GameBrowser::GetPinnedPaths() {
 	return results;
 }
 
-const std::string GameBrowser::GetBaseName(const std::string &path) {
+std::string GameBrowser::GetBaseName(const std::string &path) const {
 #ifndef _WIN32
 	static const std::string sepChars = "/";
 #else

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -72,8 +72,8 @@ protected:
 
 private:
 	bool IsCurrentPathPinned();
-	const std::vector<Path> GetPinnedPaths();
-	const std::string GetBaseName(const std::string &path);
+	std::vector<Path> GetPinnedPaths() const;
+	std::string GetBaseName(const std::string &path) const;
 
 	UI::EventReturn GameButtonClick(UI::EventParams &e);
 	UI::EventReturn GameButtonHoldClick(UI::EventParams &e);

--- a/Windows/Debugger/Debugger_MemoryDlg.cpp
+++ b/Windows/Debugger/Debugger_MemoryDlg.cpp
@@ -115,7 +115,7 @@ void CMemoryDlg::Update(void)
 	}	
 }
 
-void CMemoryDlg::searchBoxRedraw(std::vector<u32> results) {
+void CMemoryDlg::searchBoxRedraw(const std::vector<u32> &results) {
 	wchar_t temp[256]{};
 	SendMessage(srcListHdl, WM_SETREDRAW, FALSE, 0);
 	ListBox_ResetContent(srcListHdl);

--- a/Windows/Debugger/Debugger_MemoryDlg.h
+++ b/Windows/Debugger/Debugger_MemoryDlg.h
@@ -22,7 +22,7 @@ private:
 public:
 	int index; //helper 
 
-	void searchBoxRedraw(std::vector<u32> results);
+	void searchBoxRedraw(const std::vector<u32> &results);
 
 	// constructor
 	CMemoryDlg(HINSTANCE _hInstance, HWND _hParent, DebugInterface *_cpu);


### PR DESCRIPTION
Most likely, const qualifiers were added by accident, I think it was meant that it was necessary to move object and not copy.

More info: https://stackoverflow.com/questions/57761077/return-const-value-prevent-move-semantics