### PR TITLE
Protect against undefined behavior when bitwise shift occurs with negative value

### DIFF
--- a/Common/ArmEmitter.cpp
+++ b/Common/ArmEmitter.cpp
@@ -2865,7 +2865,7 @@ void ARMXEmitter::VMOVN(u32 Size, ARMReg Vd, ARMReg Vm)
 	_dbg_assert_msg_((Size & I_8) == 0, "%s cannot narrow from I_8", __FUNCTION__);
 
 	// For consistency with assembler syntax and VMOVL - encode one size down.
-	int halfSize = encodedSize(Size) - 1;
+	u32 halfSize = encodedSize(Size) - 1;
 
 	Write32((0xF3B << 20) | (halfSize << 18) | (1 << 17) | EncodeVd(Vd) | (1 << 9) | EncodeVm(Vm));
 }
@@ -2878,8 +2878,8 @@ void ARMXEmitter::VQMOVN(u32 Size, ARMReg Vd, ARMReg Vm)
 	_dbg_assert_msg_((Size & (I_UNSIGNED | I_SIGNED)) != 0, "Must specify I_SIGNED or I_UNSIGNED in %s NEON", __FUNCTION__);
 	_dbg_assert_msg_((Size & I_8) == 0, "%s cannot narrow from I_8", __FUNCTION__);
 
-	int halfSize = encodedSize(Size) - 1;
-	int op = (1 << 7) | (Size & I_UNSIGNED ? 1 << 6 : 0);
+	u32 halfSize = encodedSize(Size) - 1;
+	u32 op = (1 << 7) | (Size & I_UNSIGNED ? 1 << 6 : 0);
 
 	Write32((0xF3B << 20) | (halfSize << 18) | (1 << 17) | EncodeVd(Vd) | (1 << 9) | op | EncodeVm(Vm));
 }
@@ -2891,8 +2891,8 @@ void ARMXEmitter::VQMOVUN(u32 Size, ARMReg Vd, ARMReg Vm)
 	_dbg_assert_msg_(cpu_info.bNEON, "Can't use %s when CPU doesn't support it", __FUNCTION__);
 	_dbg_assert_msg_((Size & I_8) == 0, "%s cannot narrow from I_8", __FUNCTION__);
 
-	int halfSize = encodedSize(Size) - 1;
-	int op = (1 << 6);
+	u32 halfSize = encodedSize(Size) - 1;
+	u32 op = (1 << 6);
 
 	Write32((0xF3B << 20) | (halfSize << 18) | (1 << 17) | EncodeVd(Vd) | (1 << 9) | op | EncodeVm(Vm));
 }

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -589,7 +589,7 @@ namespace MIPSInt
 		int vs = _VS;
 		int optype = (op >> 16) & 0x1f;
 		VectorSize sz = GetVecSize(op);
-		int n = GetNumVectorElements(sz);
+		u32 n = GetNumVectorElements(sz);
 		ReadVector(s, sz, vs);
 		// Some of these are prefix hacks (affects constants, etc.)
 		switch (optype) {
@@ -1559,7 +1559,7 @@ namespace MIPSInt
 		FloatBits d;
 		int vd = _VD;
 		VectorSize sz = GetVecSize(op);
-		int n = GetNumVectorElements(sz);
+		u32 n = GetNumVectorElements(sz);
 		// Values are written in backwards order.
 		for (int i = n - 1; i >= 0; i--) {
 			switch ((op >> 16) & 0x1f) {
@@ -2113,7 +2113,7 @@ namespace MIPSInt
 			break;
 		}
 
-		int n = GetNumVectorElements(sz);
+		u32 n = GetNumVectorElements(sz);
 		ReadVector(s, sz, vs);
 		ReadVector(t, sz, vt);
 		if (optype != 7) {
@@ -2165,7 +2165,7 @@ namespace MIPSInt
 		int vs = _VS;
 		int vt = _VT;
 		VectorSize sz = GetVecSize(op);
-		int n = GetNumVectorElements(sz);
+		u32 n = GetNumVectorElements(sz);
 		ReadVector(s, sz, vs);
 		ReadVector(t, sz, vt);
 


### PR DESCRIPTION
Can such case happen if values come in negative from GetNumVectorElements() function or from encodedSize(Size)?