### PR TITLE
memoryAreas knows size, containers haven replaced with more optimized and reserve()

### DIFF
--- a/Common/Math/expression_parser.cpp
+++ b/Common/Math/expression_parser.cpp
@@ -407,6 +407,7 @@ bool parsePostfixExpression(PostfixExpression& exp, IExpressionFunctions* funcs,
 	size_t num = 0;
 	uint32_t opcode;
 	std::vector<uint32_t> valueStack;
+	valueStack.reserve(exp.size());
 	unsigned int arg[5]{};
 	float fArg[5]{};
 	bool useFloat = false;

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -228,7 +228,7 @@ void __GeDoState(PointerWrap &p) {
 	if (s >= 2) {
 		Do(p, ge_pending_cb);
 	} else {
-		std::list<GeInterruptData_v1> old;
+		std::vector<GeInterruptData_v1> old;
 		Do(p, old);
 		ge_pending_cb.clear();
 		for (auto it = old.begin(), end = old.end(); it != end; ++it) {

--- a/Core/MIPS/ARM64/Arm64IRCompSystem.cpp
+++ b/Core/MIPS/ARM64/Arm64IRCompSystem.cpp
@@ -386,6 +386,7 @@ void Arm64JitBackend::CompIR_ValidateAddress(IRInst inst) {
 	ANDI2R(SCRATCH1, SCRATCH1, 0x3FFFFFFF, SCRATCH2);
 
 	std::vector<FixupBranch> validJumps;
+	validJumps.reserve(3);
 
 	FixupBranch unaligned;
 	if (alignment == 2) {

--- a/Core/MIPS/x86/X64IRCompSystem.cpp
+++ b/Core/MIPS/x86/X64IRCompSystem.cpp
@@ -395,6 +395,7 @@ void X64JitBackend::CompIR_ValidateAddress(IRInst inst) {
 	AND(32, R(SCRATCH1), Imm32(0x3FFFFFFF));
 
 	std::vector<FixupBranch> validJumps;
+	validJumps.reserve(3);
 
 	FixupBranch unaligned;
 	if (alignment != 1) {

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -255,7 +255,7 @@ bool CwCheatScreen::ImportCheats(const Path & cheatFile) {
 	}
 
 	std::vector<std::string> title;
-	std::vector<std::string> newList;
+	std::deque<std::string> newList;
 
 	char linebuf[2048]{};
 	bool parseGameEntry = false;

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <iomanip>
 #include <sstream>
+#include <array>
 
 #include "ext/xxhash.h"
 #include "Common/StringUtils.h"
@@ -849,11 +850,12 @@ std::vector<u32> CtrlMemView::searchString(const std::string &searchQuery) {
 	if (searchData.empty())
 		return searchResAddrs;
 
-	std::vector<std::pair<u32, u32>> memoryAreas;
-	memoryAreas.emplace_back(PSP_GetScratchpadMemoryBase(), PSP_GetScratchpadMemoryEnd());
-	// Ignore the video memory mirrors.
-	memoryAreas.emplace_back(PSP_GetVidMemBase(), 0x04200000);
-	memoryAreas.emplace_back(PSP_GetKernelMemoryBase(), PSP_GetUserMemoryEnd());
+	std::array<std::pair<u32, u32>, 3> memoryAreas = { {
+		{ PSP_GetScratchpadMemoryBase(), PSP_GetScratchpadMemoryEnd() },
+		// Ignore the video memory mirrors.
+		{ PSP_GetVidMemBase(), 0x04200000 },
+		{ PSP_GetKernelMemoryBase(), PSP_GetUserMemoryEnd() }
+	} };
 
 	for (const auto &area : memoryAreas) {
 		const u32 segmentStart = area.first;
@@ -899,11 +901,12 @@ void CtrlMemView::search(bool continueSearch) {
 		return;
 	}
 
-	std::vector<std::pair<u32, u32>> memoryAreas;
-	// Ignore the video memory mirrors.
-	memoryAreas.emplace_back(PSP_GetVidMemBase(), 0x04200000);
-	memoryAreas.emplace_back(PSP_GetKernelMemoryBase(), PSP_GetUserMemoryEnd());
-	memoryAreas.emplace_back(PSP_GetScratchpadMemoryBase(), PSP_GetScratchpadMemoryEnd());
+	std::array<std::pair<u32, u32>, 3> memoryAreas = { {
+		// Ignore the video memory mirrors.
+		{ PSP_GetVidMemBase(), 0x04200000 },
+		{ PSP_GetKernelMemoryBase(), PSP_GetUserMemoryEnd() },
+		{ PSP_GetScratchpadMemoryBase(), PSP_GetScratchpadMemoryEnd() }
+	} };
 	
 	searching_ = true;
 	redraw();	// so the cursor is disabled


### PR DESCRIPTION
@hrydgard, I think fixes are useful for improving code generation by compiler, especially since it affects arm64jit and x64jit where it is more important.

With regard to container replacement, it is assumed that it is more optimized when used in this section code, but if there is search or index access or other operations, container will have to be changed to a more suitable one.