### PR TITLE
Fix or ignore some various Vulkan validation errors

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -183,7 +183,8 @@ public:
 	int GetPhysicalDeviceByName(const std::string &name);
 	void ChooseDevice(int physical_device);
 	bool EnableInstanceExtension(const char *extension);
-	bool EnableDeviceExtension(const char *extension);
+	// The core version is to avoid enabling extensions that are merged into core Vulkan from a certain version.
+	bool EnableDeviceExtension(const char *extension, uint32_t coreVersion);
 	VkResult CreateDevice();
 
 	const std::string &InitError() const { return init_error_; }
@@ -428,6 +429,7 @@ private:
 	VkDevice device_ = VK_NULL_HANDLE;
 	VkQueue gfx_queue_ = VK_NULL_HANDLE;
 	VkSurfaceKHR surface_ = VK_NULL_HANDLE;
+	u32 vulkanApiVersion_ = 0;
 
 	std::string init_error_;
 	std::vector<const char *> instance_layer_names_;

--- a/Common/GPU/Vulkan/VulkanDebug.cpp
+++ b/Common/GPU/Vulkan/VulkanDebug.cpp
@@ -74,30 +74,35 @@ VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDebugUtilsCallback(
 		// Can happen when VMA aggressively tries to allocate aperture memory for upload. It gracefully
 		// falls back to regular video memory, so we just ignore this. I'd argue this is a VMA bug, actually.
 		return false;
-	case 181611958:
-		// Extended validation.
-		// UNASSIGNED-BestPractices-vkCreateDevice-deprecated-extension
-		// Doing what this one says doesn't seem very reliable - if I rely strictly on the Vulkan version, I don't get some function pointers? Like createrenderpass2.
-		return false;
 	case 657182421:
 		// Extended validation (ARM best practices)
 		// Non-fifo validation not recommended
+		return false;
+	case 672904502:
+		// ARM best practices: index buffer usage warning (too few indices used compared to value range).
+		// This should be looked into more - happens even in moppi-flower which is weird.
 		return false;
 	case 337425955:
 		// False positive
 		// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3615
 		return false;
-
+	case 227275665:
+		// PowerVR (and all other) best practices: LOAD_OP_LOAD used in render pass.
+		return false;
 	case 1835555994: // [AMD] [NVIDIA] Performance warning : Pipeline VkPipeline 0xa808d50000000033[global_texcolor] was bound twice in the frame.
 		// Benign perf warnings.
 		return false;
 
-	case 1810669668:
+	case 1243445977:
 		// Clear value but no LOAD_OP_CLEAR. Not worth fixing right now.
 		return false;
 
 	case 1544472022:
 		// MSAA depth resolve write-after-write??
+		return false;
+
+	case -1306653903:
+		// ARM complaint about non-fifo swapchain
 		return false;
 
 	default:


### PR DESCRIPTION
Let's not enable extensions that have already been merged into core in the current version, to avoid some warnings.