### PR TITLE
Achievement-related resources fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2636,6 +2636,8 @@ set(NativeAssets
 	assets/sfx_select.wav
 	assets/sfx_toggle_off.wav
 	assets/sfx_toggle_on.wav
+	assets/sfx_achievement_unlocked.wav
+	assets/sfx_leaderbord_submitted.wav
 	source_assets/image/logo.png
 	source_assets/image/icon_regular_72.png
 )


### PR DESCRIPTION
The `CMakeLists.txt` file was not changed when the new sounds were introduced. I don't know why no one noticed that before... Probably because the SDL build is not as used as the other builds. The moment I launched PPSSPP I saw this:
```
27:37:805 UI/BackgroundAudio.cpp:386 W[AUDIO]: Failed to load sample 'sfx_achievement_unlocked.wav'
27:53:897 UI/BackgroundAudio.cpp:519 E[SYSTEM]: Failed to load the default sample for UI sound 5
27:58:267 UI/BackgroundAudio.cpp:386 W[AUDIO]: Failed to load sample 'sfx_leaderbord_submitted.wav'
28:02:240 UI/BackgroundAudio.cpp:519 E[SYSTEM]: Failed to load the default sample for UI sound 6
```