### PR TITLE
[HLE] sceDisplay: maybe necessary to increase accuracy timePerVblank is defined as double

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -1128,6 +1128,6 @@ void Register_sceDisplay_driver() {
 
 void __DisplaySetFramerate(int value) {
 	framerate = value;
-	timePerVblank = 1.001f / (float)framerate;
+	timePerVblank = 1.001 / (double)framerate;
 	frameMs = 1001.0 / (double)framerate;
 }


### PR DESCRIPTION
Does such precision need to be used for timePerVblank? if don't need it, can convert it to float type.