### PR TITLE
Minor optimize methods std::string using param as char with simpler implementation

### DIFF
--- a/Common/Data/Format/IniFile.cpp
+++ b/Common/Data/Format/IniFile.cpp
@@ -328,20 +328,20 @@ bool Section::Get(const char* key, std::vector<std::string>& values) const
 		return false;
 	}
 	// ignore starting , if any
-	size_t subStart = temp.find_first_not_of(",");
+	size_t subStart = temp.find_first_not_of(',');
 	size_t subEnd;
 
 	// split by , 
 	while (subStart != std::string::npos) {
 		
 		// Find next , 
-		subEnd = temp.find_first_of(",", subStart);
+		subEnd = temp.find_first_of(',', subStart);
 		if (subStart != subEnd) 
 			// take from first char until next , 
 			values.push_back(StripSpaces(temp.substr(subStart, subEnd - subStart)));
 	
 		// Find the next non , char
-		subStart = temp.find_first_not_of(",", subEnd);
+		subStart = temp.find_first_not_of(',', subEnd);
 	} 
 	
 	return true;

--- a/Common/Data/Text/WrapText.cpp
+++ b/Common/Data/Text/WrapText.cpp
@@ -153,7 +153,7 @@ void WordWrapper::AppendWord(int endIndex, int lastChar, bool addNewline) {
 		x_ = 0.0f;
 	} else {
 		// We may have appended a newline - check.
-		size_t pos = out_.find_last_of("\n");
+		size_t pos = out_.find_last_of('\n');
 		if (pos != out_.npos) {
 			lastLineStart_ = pos + 1;
 		}

--- a/Common/File/AndroidContentURI.cpp
+++ b/Common/File/AndroidContentURI.cpp
@@ -114,7 +114,7 @@ bool AndroidContentURI::CanNavigateUp() const {
 // Only goes downwards in hierarchies. No ".." will ever be generated.
 bool AndroidContentURI::ComputePathTo(const AndroidContentURI &other, std::string &path) const {
 	size_t offset = FilePath().size() + 1;
-	std::string otherFilePath = other.FilePath();
+	const auto &otherFilePath = other.FilePath();
 	if (offset >= otherFilePath.size()) {
 		ERROR_LOG(SYSTEM, "Bad call to PathTo. '%s' -> '%s'", FilePath().c_str(), other.FilePath().c_str());
 		return false;
@@ -125,11 +125,11 @@ bool AndroidContentURI::ComputePathTo(const AndroidContentURI &other, std::strin
 }
 
 std::string AndroidContentURI::GetFileExtension() const {
-	size_t pos = file.rfind(".");
+	size_t pos = file.rfind('.');
 	if (pos == std::string::npos) {
 		return "";
 	}
-	size_t slash_pos = file.rfind("/");
+	size_t slash_pos = file.rfind('/');
 	if (slash_pos != std::string::npos && slash_pos > pos) {
 		// Don't want to detect "df/file" from "/as.df/file"
 		return "";

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -686,7 +686,7 @@ bool CBreakPoints::EvaluateLogFormat(DebugInterface *cpu, const std::string &fmt
 
 	size_t pos = 0;
 	while (pos < fmt.size()) {
-		size_t next = fmt.find_first_of("{", pos);
+		size_t next = fmt.find_first_of('{', pos);
 		if (next == fmt.npos) {
 			// End of the string.
 			result += fmt.substr(pos);
@@ -697,7 +697,7 @@ bool CBreakPoints::EvaluateLogFormat(DebugInterface *cpu, const std::string &fmt
 			pos = next;
 		}
 
-		size_t end = fmt.find_first_of("}", next + 1);
+		size_t end = fmt.find_first_of('}', next + 1);
 		if (end == fmt.npos) {
 			// Invalid: every expression needs a { and a }.
 			return false;

--- a/Core/HLE/sceNp2.cpp
+++ b/Core/HLE/sceNp2.cpp
@@ -219,7 +219,7 @@ static int sceNpMatching2ContextStart(int ctxId)
 			text = entity.substr(ofs, ofs2 - ofs);
 			INFO_LOG(SCENET, "%s - Agent-FQDN#%d Status: %s", __FUNCTION__, i, text.c_str());
 
-			ofs = entity.find(">", ++ofs2);
+			ofs = entity.find('>', ++ofs2);
 			if (ofs == std::string::npos)
 				return hleLogError(SCENET, SCE_NP_COMMUNITY_SERVER_ERROR_NO_SUCH_TITLE, "agent host not found");
 

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -436,7 +436,7 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 	std::string finalName = ms_path + file;
 
 	std::string homebrewName = PSP_CoreParameter().fileToStart.ToVisualString();
-	std::size_t lslash = homebrewName.find_last_of("/");
+	std::size_t lslash = homebrewName.find_last_of('/');
 #if PPSSPP_PLATFORM(UWP)
 	if (lslash == homebrewName.npos) {
 		lslash = homebrewName.find_last_of("\\");

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -988,7 +988,7 @@ namespace SaveState
 				if (title.empty()) {
 					// Homebrew title
 					title = PSP_CoreParameter().fileToStart.ToVisualString();
-					std::size_t lslash = title.find_last_of("/");
+					std::size_t lslash = title.find_last_of('/');
 					title = title.substr(lslash + 1);
 				}
 				result = CChunkFileReader::Save(op.filename, title, PPSSPP_GIT_VERSION, state);

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -581,7 +581,7 @@ bool GameManager::InstallMemstickGame(struct zip *z, const Path &zipfile, const 
 		Path outFilename = dest / zippedName.substr(info.stripChars);
 
 		bool isDir = zippedName.empty() || zippedName.back() == '/';
-		if (!isDir && zippedName.find("/") != std::string::npos) {
+		if (!isDir && zippedName.find('/') != std::string::npos) {
 			outFilename = dest / zippedName.substr(0, zippedName.rfind('/'));
 		} else if (!isDir) {
 			outFilename = dest;


### PR DESCRIPTION
Example compare algorithm functions as in screenshot.

![optimize-char-as-parameter-for-std-string-methods](https://github.com/hrydgard/ppsspp/assets/21138600/b991f6ac-f83c-4376-9c13-1fa6c3b55817)
