### PR TITLE
Fixed __KernelCheckResumeMsgPipeReceive and __KernelCheckResumeMsgPipeSend not return result back to calling function

### DIFF
--- a/Core/HLE/KernelWaitHelpers.h
+++ b/Core/HLE/KernelWaitHelpers.h
@@ -207,7 +207,8 @@ WaitBeginEndCallbackResult WaitEndCallback(SceUID threadID, SceUID prevCallbackI
 
 	bool wokeThreads;
 	// Attempt to unlock.
-	if (TryUnlock(ko, waitData, error, 0, wokeThreads)) {
+	int try_err;
+	if (TryUnlock(ko, waitData, error, try_err, wokeThreads)) {
 		return WAIT_CB_SUCCESS;
 	}
 

--- a/Core/HLE/sceKernelMsgPipe.cpp
+++ b/Core/HLE/sceKernelMsgPipe.cpp
@@ -567,7 +567,7 @@ static void __KernelMsgPipeBeginCallback(SceUID threadID, SceUID prevCallbackId)
 	}
 }
 
-static bool __KernelCheckResumeMsgPipeSend(MsgPipe *m, MsgPipeWaitingThread &waitInfo, u32 &error, int result, bool &wokeThreads)
+static bool __KernelCheckResumeMsgPipeSend(MsgPipe *m, MsgPipeWaitingThread &waitInfo, u32 &error, int &result, bool &wokeThreads)
 {
 	if (!waitInfo.IsStillWaiting(m->GetUID()))
 		return true;
@@ -589,7 +589,7 @@ static bool __KernelCheckResumeMsgPipeSend(MsgPipe *m, MsgPipeWaitingThread &wai
 	return true;
 }
 
-static bool __KernelCheckResumeMsgPipeReceive(MsgPipe *m, MsgPipeWaitingThread &waitInfo, u32 &error, int result, bool &wokeThreads)
+static bool __KernelCheckResumeMsgPipeReceive(MsgPipe *m, MsgPipeWaitingThread &waitInfo, u32 &error, int &result, bool &wokeThreads)
 {
 	if (!waitInfo.IsStillWaiting(m->GetUID()))
 		return true;


### PR DESCRIPTION
Maybe I misunderstood something and then I just had to cut out the parameter?

https://github.com/hrydgard/ppsspp/blob/bab6c5997b12df9f7b65bb367255b63057598947/Core/HLE/KernelWaitHelpers.h#L231-L238

