### PR TITLE
Atrac-standalone followup

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -179,20 +179,9 @@ struct AVPacket {
 #endif
 
 struct Atrac {
-	Atrac() : atracID_(-1), dataBuf_(0), decodePos_(0), bufferPos_(0),
-		channels_(0), outputChannels_(2), bitrate_(64), bytesPerFrame_(0), bufferMaxSize_(0), jointStereo_(0),
-		currentSample_(0), endSample_(0), firstSampleOffset_(0), dataOff_(0),
-		loopStartSample_(-1), loopEndSample_(-1), loopNum_(0),
-		failedDecode_(false), ignoreDataBuf_(false), codecType_(0),
-		bufferState_(ATRAC_STATUS_NO_DATA) {
+	Atrac() {
 		memset(&first_, 0, sizeof(first_));
 		memset(&second_, 0, sizeof(second_));
-#ifdef USE_FFMPEG
-		codecCtx_ = nullptr;
-		swrCtx_ = nullptr;
-		frame_ = nullptr;
-		packet_ = nullptr;
-#endif // USE_FFMPEG
 		context_ = 0;
 	}
 
@@ -401,40 +390,40 @@ struct Atrac {
 		return remainingBytes / bytesPerFrame_;
 	}
 
-	int atracID_;
-	u8 *dataBuf_;
+	int atracID_ = -1;
+	u8 *dataBuf_ = nullptr;
 
-	u32 decodePos_;
+	u32 decodePos_ = 0;
 	// Used by low-level decoding and to track streaming.
-	u32 bufferPos_;
-	u32 bufferValidBytes_;
+	u32 bufferPos_ = 0;
+	u32 bufferValidBytes_ = 0;
 	u32 bufferHeaderSize_ = 0;
 
-	u16 channels_;
-	u16 outputChannels_;
-	u32 bitrate_;
-	u16 bytesPerFrame_;
-	u32 bufferMaxSize_;
-	int jointStereo_;
+	u16 channels_ = 0;
+	u16 outputChannels_ = 2;
+	u32 bitrate_ = 64;
+	u16 bytesPerFrame_ = 0;
+	u32 bufferMaxSize_ = 0;
+	int jointStereo_ = 0;
 
-	int currentSample_;
-	int endSample_;
-	int firstSampleOffset_;
+	int currentSample_ = 0;
+	int endSample_ = 0;
+	int firstSampleOffset_ = 0;
 	// Offset of the first sample in the input buffer
-	int dataOff_;
+	int dataOff_ = 0;
 
 	std::vector<AtracLoopInfo> loopinfo_;
 
-	int loopStartSample_;
-	int loopEndSample_;
-	int loopNum_;
+	int loopStartSample_ = -1;
+	int loopEndSample_ = -1;
+	int loopNum_ = 0;
 
-	bool failedDecode_;
+	bool failedDecode_ = false;
 	// Indicates that the dataBuf_ array should not be used.
-	bool ignoreDataBuf_;
+	bool ignoreDataBuf_ = false;
 
-	u32 codecType_;
-	AtracStatus bufferState_;
+	u32 codecType_ = 0;
+	AtracStatus bufferState_ = ATRAC_STATUS_NO_DATA;
 
 	InputBuffer first_;
 	InputBuffer second_;

--- a/Core/HLE/sceAtrac.h
+++ b/Core/HLE/sceAtrac.h
@@ -48,8 +48,7 @@ typedef AtracStatus AtracStatus_le;
 typedef swap_struct_t<AtracStatus, swap_32_t<AtracStatus> > AtracStatus_le;
 #endif
 
-typedef struct
-{
+struct SceAtracIdInfo {
     u32_le decodePos; // 0
     u32_le endSample; // 4
     u32_le loopStart; // 8
@@ -76,15 +75,14 @@ typedef struct
     u32_le secondBufferByte; // 68
     // make sure the size is 128
 	u8 unk[56];
-} SceAtracIdInfo;
+};
 
-typedef struct
-{
+struct SceAtracId {
 	// size 128
     SceAudiocodecCodec codec;
 	// size 128
     SceAtracIdInfo info;
-} SceAtracId;
+};
 
 // provide some decoder interface
 

--- a/Core/HLE/sceAudiocodec.cpp
+++ b/Core/HLE/sceAudiocodec.cpp
@@ -118,7 +118,8 @@ static int sceAudiocodecDecode(u32 ctxPtr, int codec) {
 			// Use SimpleAudioDec to decode audio
 			auto ctx = PSPPointer<AudioCodecContext>::Create(ctxPtr);  // On stack, no need to allocate.
 			// Decode audio
-			decoder->Decode(Memory::GetPointer(ctx->inDataPtr), ctx->inDataSize, Memory::GetPointerWrite(ctx->outDataPtr), &outbytes);
+			int inDataConsumed = 0;
+			decoder->Decode(Memory::GetPointer(ctx->inDataPtr), ctx->inDataSize, &inDataConsumed, Memory::GetPointerWrite(ctx->outDataPtr), &outbytes);
 		}
 		DEBUG_LOG(ME, "sceAudiocodecDec(%08x, %i (%s))", ctxPtr, codec, GetCodecName(codec));
 		return 0;

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -743,10 +743,11 @@ static u32 sceMp3LowLevelDecode(u32 mp3, u32 sourceAddr, u32 sourceBytesConsumed
 	auto outbuff = Memory::GetPointerWriteUnchecked(samplesAddr);
 	
 	int outpcmbytes = 0;
-	ctx->decoder->Decode(inbuff, 4096, outbuff, &outpcmbytes);
+	int inbytesConsumed = 0;
+	ctx->decoder->Decode(inbuff, 4096, &inbytesConsumed, outbuff, &outpcmbytes);
 	NotifyMemInfo(MemBlockFlags::WRITE, samplesAddr, outpcmbytes, "Mp3LowLevelDecode");
 	
-	Memory::Write_U32(ctx->decoder->GetSourcePos(), sourceBytesConsumedAddr);
+	Memory::Write_U32(inbytesConsumed, sourceBytesConsumedAddr);
 	Memory::Write_U32(outpcmbytes, sampleBytesAddr);
 	return 0;
 }

--- a/Core/HW/Atrac3Standalone.cpp
+++ b/Core/HW/Atrac3Standalone.cpp
@@ -16,13 +16,13 @@ inline int16_t clamp16(float f) {
 class Atrac3Audio : public AudioDecoder {
 public:
 	Atrac3Audio(PSPAudioType audioType, int channels, size_t blockAlign, const uint8_t *extraData, size_t extraDataSize) : audioType_(audioType) {
-		blockAlign_ = blockAlign;
+		blockAlign_ = (int)blockAlign;
 		if (audioType == PSP_CODEC_AT3PLUS) {
 			at3pCtx_ = atrac3p_alloc(channels, &blockAlign_);
 			if (at3pCtx_)
 				codecOpen_ = true;
 		} else if (audioType_ == PSP_CODEC_AT3) {
-			at3Ctx_ = atrac3_alloc(channels, &blockAlign_, extraData, extraDataSize);
+			at3Ctx_ = atrac3_alloc(channels, &blockAlign_, extraData, (int)extraDataSize);
 			if (at3Ctx_)
 				codecOpen_ = true;
 		}

--- a/Core/HW/Atrac3Standalone.cpp
+++ b/Core/HW/Atrac3Standalone.cpp
@@ -46,6 +46,15 @@ public:
 		return codecOpen_;
 	}
 
+	void FlushBuffers() {
+		if (at3Ctx_) {
+			atrac3_flush_buffers(at3Ctx_);
+		}
+		if (at3pCtx_) {
+			atrac3p_flush_buffers(at3pCtx_);
+		}
+	}
+
 	bool Decode(const uint8_t *inbuf, int inbytes, uint8_t *outbuf, int *outbytes) override {
 		if (!codecOpen_) {
 			_dbg_assert_(false);

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -1077,7 +1077,8 @@ int MediaEngine::getAudioSamples(u32 bufferPtr) {
 			m_audioContext->SetChannels(1);
 		}
 
-		if (!m_audioContext->Decode(audioFrame, frameSize, buffer, &outbytes)) {
+		int inbytesConsumed = 0;
+		if (!m_audioContext->Decode(audioFrame, frameSize, &inbytesConsumed, buffer, &outbytes)) {
 			ERROR_LOG(ME, "Audio (%s) decode failed during video playback", GetCodecName(m_audioType));
 		}
 

--- a/Core/HW/SimpleAudioDec.h
+++ b/Core/HW/SimpleAudioDec.h
@@ -39,12 +39,12 @@ public:
 
 	virtual PSPAudioType GetAudioType() const = 0;
 
-	virtual bool Decode(const uint8_t* inbuf, int inbytes, uint8_t *outbuf, int *outbytes) = 0;
+	// inbytesConsumed can include skipping metadata.
+	virtual bool Decode(const uint8_t *inbuf, int inbytes, int *inbytesConsumed, uint8_t *outbuf, int *outbytes) = 0;
 	virtual bool IsOK() const = 0;
 
 	// These two are only ever called after Decode, so can initialize on first.
 	virtual int GetOutSamples() const = 0;
-	virtual int GetSourcePos() const = 0;
 
 	virtual void SetChannels(int channels) = 0;
 

--- a/Core/HW/SimpleAudioDec.h
+++ b/Core/HW/SimpleAudioDec.h
@@ -48,6 +48,8 @@ public:
 
 	virtual void SetChannels(int channels) = 0;
 
+	virtual void FlushBuffers() {}
+
 	// Just metadata.
 	void SetCtxPtr(uint32_t ptr) { ctxPtr = ptr; }
 	uint32_t GetCtxPtr() const { return ctxPtr; }

--- a/UI/BackgroundAudio.cpp
+++ b/UI/BackgroundAudio.cpp
@@ -218,7 +218,8 @@ public:
 
 		while (bgQueue.size() < (size_t)(len * 2)) {
 			int outBytes = 0;
-			decoder_->Decode(wave_.raw_data + raw_offset_, wave_.raw_bytes_per_frame, (uint8_t *)buffer_, &outBytes);
+			int inbytesConsumed = 0;
+			decoder_->Decode(wave_.raw_data + raw_offset_, wave_.raw_bytes_per_frame, &inbytesConsumed, (uint8_t *)buffer_, &outBytes);
 			if (!outBytes)
 				return false;
 

--- a/ext/at3_standalone/at3_decoders.h
+++ b/ext/at3_standalone/at3_decoders.h
@@ -8,11 +8,14 @@ struct ATRAC3Context;
 struct ATRAC3PContext;
 
 // If the block_align passed in is 0, tries to audio detect.
+// flush_buffers should be called when seeking before the next decode_frame.
 
 ATRAC3Context *atrac3_alloc(int channels, int *block_align, const uint8_t *extra_data, int extra_data_size);
 void atrac3_free(ATRAC3Context *ctx);
+void atrac3_flush_buffers(ATRAC3Context *ctx);
 int atrac3_decode_frame(ATRAC3Context *ctx, float *out_data[2], int *nb_samples, int *got_frame_ptr, const uint8_t *buf, int buf_size);
 
 ATRAC3PContext *atrac3p_alloc(int channels, int *block_align);
 void atrac3p_free(ATRAC3PContext *ctx);
+void atrac3p_flush_buffers(ATRAC3PContext *ctx);
 int atrac3p_decode_frame(ATRAC3PContext *ctx, float *out_data[2], int *nb_samples, int *got_frame_ptr, const uint8_t *buf, int buf_size);

--- a/ext/at3_standalone/atrac3.cpp
+++ b/ext/at3_standalone/atrac3.cpp
@@ -765,6 +765,11 @@ int atrac3_decode_frame(ATRAC3Context *ctx, float *out_data[2], int *nb_samples,
     return block_align;
 }
 
+void atrac3_flush_buffers(ATRAC3Context *c) {
+	// There's no known correct way to do this, so let's just reset some stuff.
+	memset(c->temp_buf, 0, sizeof(c->temp_buf));
+}
+
 static void atrac3_init_static_data(void)
 {
     int i;

--- a/ext/at3_standalone/atrac3plusdec.cpp
+++ b/ext/at3_standalone/atrac3plusdec.cpp
@@ -357,3 +357,7 @@ int atrac3p_decode_frame(ATRAC3PContext *ctx, float *out_data[2], int *nb_sample
 
     return FFMIN(ctx->block_align, avpkt_size);
 }
+
+void atrac3p_flush_buffers(ATRAC3PContext *ctx) {
+	// TODO: Not sure what should be zeroed here.
+}

--- a/ext/at3_standalone/compat.h
+++ b/ext/at3_standalone/compat.h
@@ -2,7 +2,7 @@
 
 #include <stdlib.h>
 
-// Compat hacks
+// Compat hacks to make an FFMPEG-like environment, so we can keep the core code mostly unchanged.
 
 #if defined(__GNUC__)
 #define DECLARE_ALIGNED(n,t,v)      t __attribute__ ((aligned (n))) v


### PR DESCRIPTION
Followup to #19033

Just some minor cleanups and add a "flush_buffers" API, in preparation for the sceAtrac port because it uses it (but with ffmpeg it never did anything behind the scenes, it wasn't implemented).