### PR TITLE
Reduced struct sizes using align for x64 platforms, fields carefully moved

### DIFF
--- a/Common/GPU/OpenGL/GLQueueRunner.h
+++ b/Common/GPU/OpenGL/GLQueueRunner.h
@@ -95,13 +95,13 @@ struct GLRRenderData {
 			GLenum func;
 		} depth;
 		struct {
-			GLboolean enabled;
 			GLenum func;
-			uint8_t ref;
-			uint8_t compareMask;
 			GLenum sFail;
 			GLenum zFail;
 			GLenum pass;
+			GLboolean enabled;
+			uint8_t ref;
+			uint8_t compareMask;
 			uint8_t writeMask;
 		} stencil;
 		struct {
@@ -160,8 +160,8 @@ struct GLRRenderData {
 			uint8_t *data;  // owned, delete[]-d
 		} texture_subimage;
 		struct {
+			GLRFramebuffer* framebuffer;
 			int slot;
-			GLRFramebuffer *framebuffer;
 			int aspect;
 		} bind_fb_texture;
 		struct {
@@ -192,9 +192,9 @@ struct GLRRenderData {
 			GLRect2D rc;
 		} scissor;
 		struct {
-			GLboolean cullEnable;
 			GLenum frontFace;
 			GLenum cullFace;
+			GLboolean cullEnable;
 			GLboolean ditherEnable;
 			GLboolean depthClampEnable;
 		} raster;
@@ -326,9 +326,9 @@ struct GLRStep {
 			GLboolean filter;
 		} blit;
 		struct {
-			int aspectMask;
-			GLRFramebuffer *src;
+			GLRFramebuffer* src;
 			GLRect2D srcRect;
+			int aspectMask;
 			Draw::DataFormat dstFormat;
 		} readback;
 		struct {

--- a/Common/GPU/Vulkan/VulkanQueueRunner.h
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.h
@@ -70,12 +70,12 @@ struct VkRenderData {
 			uint32_t offset;
 		} draw;
 		struct {
+			VkBuffer vbuffer;
+			VkBuffer ibuffer;
 			uint32_t descSetIndex;
 			uint32_t uboOffsets[3];
 			uint16_t numUboOffsets;
 			uint16_t instances;
-			VkBuffer vbuffer;
-			VkBuffer ibuffer;
 			uint32_t voffset;
 			uint32_t ioffset;
 			uint32_t count;
@@ -184,9 +184,9 @@ struct VKRStep {
 			VkFilter filter;
 		} blit;
 		struct {
-			int aspectMask;
-			VKRFramebuffer *src;
+			VKRFramebuffer* src;
 			VkRect2D srcRect;
+			int aspectMask;
 			bool delayed;
 		} readback;
 		struct {

--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -155,10 +155,10 @@ struct CompileQueueEntry {
 	enum class Type {
 		GRAPHICS,
 	};
-	Type type;
+	VKRGraphicsPipeline* graphics = nullptr;
 	VkRenderPass compatibleRenderPass;
+	Type type;
 	RenderPassType renderPassType;
-	VKRGraphicsPipeline *graphics = nullptr;
 	VkSampleCountFlagBits sampleCount;
 };
 

--- a/Core/HW/SimpleAudioDec.h
+++ b/Core/HW/SimpleAudioDec.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2013- PPSSPP Project.
+﻿// Copyright (c) 2013- PPSSPP Project.
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -74,26 +74,7 @@ public:
 	u32 GetCtxPtr() const { return ctxPtr; }
 
 private:
-	void Init();
-	bool OpenCodec(int block_align);
-
-	u32 ctxPtr;
-	int audioType;
-	int sample_rate_;
-	int channels_;
-	int outSamples; // output samples per frame
-	int srcPos; // bytes consumed in source during the last decoding
-	int wanted_resample_freq; // wanted resampling rate/frequency
-
-	AVFrame *frame_;
-#if HAVE_LIBAVCODEC_CONST_AVCODEC // USE_FFMPEG is implied
-	const
-#endif
-	AVCodec *codec_;
-	AVCodecContext  *codecCtx_;
-	SwrContext      *swrCtx_;
-
-	bool codecOpen_;
+	uint32_t ctxPtr = 0xFFFFFFFF;
 };
 
 void AudioClose(SimpleAudio **ctx);

--- a/Core/MIPS/JitCommon/JitCommon.h
+++ b/Core/MIPS/JitCommon/JitCommon.h
@@ -158,10 +158,10 @@ namespace MIPSComp {
 	struct BranchInfo {
 		BranchInfo(u32 pc, MIPSOpcode op, MIPSOpcode delaySlotOp, bool andLink, bool likely);
 
+		u64 delaySlotInfo;
 		u32 compilerPC;
 		MIPSOpcode op;
 		MIPSOpcode delaySlotOp;
-		u64 delaySlotInfo;
 		bool likely;
 		bool andLink;
 		// Update manually if it's not always nice (rs/rt, rs/zero, etc.)

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -144,10 +144,6 @@ namespace MIPSAnalyst
 		u32 opcodeAddress;
 		MIPSOpcode encodedOpcode;
 
-		// shared between branches and conditional moves
-		bool isConditional;
-		bool conditionMet;
-
 		// branches
 		u32 branchTarget;
 		bool isBranch;
@@ -157,12 +153,16 @@ namespace MIPSAnalyst
 		int branchRegisterNum;
 
 		// data access
+		u32 dataAddress;
 		bool isDataAccess;
 		int dataSize;
-		u32 dataAddress;
 
-		bool hasRelevantAddress;
 		u32 relevantAddress;
+		bool hasRelevantAddress;
+
+		// shared between branches and conditional moves
+		bool isConditional;
+		bool conditionMet;
 	} MipsOpcodeInfo;
 
 	MipsOpcodeInfo GetOpcodeInfo(DebugInterface* cpu, u32 address);

--- a/GPU/Common/DepalettizeShaderCommon.cpp
+++ b/GPU/Common/DepalettizeShaderCommon.cpp
@@ -35,8 +35,8 @@ static const InputDef vsInputs[2] = {
 
 // TODO: Deduplicate with TextureShaderCommon.cpp
 static const SamplerDef samplers[2] = {
-	{ 0, "tex", SamplerFlags::ARRAY_ON_VULKAN },
-	{ 1, "pal" },
+	{ "tex", SamplerFlags::ARRAY_ON_VULKAN, 0 },
+	{ "pal", {}, 1 },
 };
 
 static const VaryingDef varyings[1] = {

--- a/GPU/Common/DepthBufferCommon.cpp
+++ b/GPU/Common/DepthBufferCommon.cpp
@@ -50,7 +50,7 @@ const UniformBufferDesc depthUBDesc{ sizeof(DepthUB), {
 } };
 
 static const SamplerDef samplers[] = {
-	{ 0, "tex" },
+	{ "tex", {}, 0 },
 };
 
 static const VaryingDef varyings[] = {

--- a/GPU/Common/Draw2D.cpp
+++ b/GPU/Common/Draw2D.cpp
@@ -36,7 +36,7 @@ static const VaryingDef varyings[1] = {
 };
 
 static const SamplerDef samplers[1] = {
-	{ 0, "tex", SamplerFlags::ARRAY_ON_VULKAN },
+	{ "tex", SamplerFlags::ARRAY_ON_VULKAN, 0 },
 };
 
 const UniformDef g_draw2Duniforms[5] = {

--- a/GPU/Common/FragmentShaderGenerator.cpp
+++ b/GPU/Common/FragmentShaderGenerator.cpp
@@ -37,15 +37,15 @@
 #define WRITE(p, ...) p.F(__VA_ARGS__)
 
 static const SamplerDef samplersMono[3] = {
-	{ 0, "tex" },
-	{ 1, "fbotex", SamplerFlags::ARRAY_ON_VULKAN },
-	{ 2, "pal" },
+	{ "tex", {}, 0 },
+	{ "fbotex", SamplerFlags::ARRAY_ON_VULKAN, 1 },
+	{ "pal", {}, 2 },
 };
 
 static const SamplerDef samplersStereo[3] = {
-	{ 0, "tex", SamplerFlags::ARRAY_ON_VULKAN },
-	{ 1, "fbotex", SamplerFlags::ARRAY_ON_VULKAN },
-	{ 2, "pal" },
+	{ "tex", SamplerFlags::ARRAY_ON_VULKAN, 0 },
+	{ "fbotex", SamplerFlags::ARRAY_ON_VULKAN, 1 },
+	{ "pal", {}, 2 },
 };
 
 bool GenerateFragmentShader(const FShaderID &id, char *buffer, const ShaderLanguageDesc &compat, Draw::Bugs bugs, uint64_t *uniformMask, FragmentShaderFlags *fragmentShaderFlags, std::string *errorString) {

--- a/GPU/Common/ReinterpretFramebuffer.cpp
+++ b/GPU/Common/ReinterpretFramebuffer.cpp
@@ -14,7 +14,7 @@ static const VaryingDef varyings[1] = {
 };
 
 static const SamplerDef samplers[1] = {
-	{ 0, "tex", SamplerFlags::ARRAY_ON_VULKAN }
+	{ "tex", SamplerFlags::ARRAY_ON_VULKAN, 0 }
 };
 
 // Requires full size integer math. It would be possible to make a floating point-only version with lots of

--- a/GPU/Common/StencilCommon.cpp
+++ b/GPU/Common/StencilCommon.cpp
@@ -107,7 +107,7 @@ static const VaryingDef varyings[1] = {
 };
 
 static const SamplerDef samplers[1] = {
-	{ 0, "tex" },
+	{ "tex", {}, 0 },
 };
 
 void GenerateStencilFs(char *buffer, const ShaderLanguageDesc &lang, const Draw::Bugs &bugs, bool useExport) {

--- a/GPU/Common/TextureShaderCommon.cpp
+++ b/GPU/Common/TextureShaderCommon.cpp
@@ -33,8 +33,8 @@ static const VaryingDef varyings[1] = {
 };
 
 static const SamplerDef samplers[2] = {
-	{ 0, "tex", SamplerFlags::ARRAY_ON_VULKAN },
-	{ 1, "pal" },
+	{ "tex", SamplerFlags::ARRAY_ON_VULKAN, 0 },
+	{ "pal", {}, 1 },
 };
 
 TextureShaderCache::TextureShaderCache(Draw::DrawContext *draw, Draw2D *draw2D) : draw_(draw), draw2D_(draw2D) { }

--- a/GPU/GLES/StencilBufferGLES.cpp
+++ b/GPU/GLES/StencilBufferGLES.cpp
@@ -49,7 +49,7 @@ const UniformBufferDesc depthUBDesc{ sizeof(DepthUB), {
 } };
 
 static const SamplerDef samplers[] = {
-	{ 0, "tex" },
+	{ "tex", {}, 0 },
 };
 
 static const VaryingDef varyings[] = {

--- a/UI/BackgroundAudio.cpp
+++ b/UI/BackgroundAudio.cpp
@@ -21,6 +21,10 @@
 #include "UI/BackgroundAudio.h"
 
 struct WavData {
+	u8 at3_extradata[16];
+	uint8_t* raw_data = nullptr;
+	int raw_data_size = 0;
+
 	int num_channels = -1;
 	int sample_rate = -1;
 	int numFrames = -1;
@@ -32,9 +36,6 @@ struct WavData {
 	int loop_end_offset = 0;
 	int codec = 0;
 	int raw_bytes_per_frame = 0;
-	uint8_t *raw_data = nullptr;
-	int raw_data_size = 0;
-	u8 at3_extradata[16];
 
 	void Read(RIFFReader &riff);
 

--- a/Windows/Debugger/Debugger_Lists.cpp
+++ b/Windows/Debugger/Debugger_Lists.cpp
@@ -29,7 +29,7 @@ GenericListViewColumn threadColumns[TL_COLUMNCOUNT] = {
 };
 
 GenericListViewDef threadListDef = {
-	threadColumns,	ARRAY_SIZE(threadColumns),	NULL,	false
+	threadColumns,	NULL,	ARRAY_SIZE(threadColumns),	false
 };
 
 GenericListViewColumn breakpointColumns[BPL_COLUMNCOUNT] = {
@@ -43,7 +43,7 @@ GenericListViewColumn breakpointColumns[BPL_COLUMNCOUNT] = {
 };
 
 GenericListViewDef breakpointListDef = {
-	breakpointColumns,	ARRAY_SIZE(breakpointColumns),	NULL,	true
+	breakpointColumns,	NULL,	ARRAY_SIZE(breakpointColumns),	true
 };
 
 GenericListViewColumn stackTraceColumns[SF_COLUMNCOUNT] = {
@@ -56,7 +56,7 @@ GenericListViewColumn stackTraceColumns[SF_COLUMNCOUNT] = {
 };
 
 GenericListViewDef stackTraceListDef = {
-	stackTraceColumns,	ARRAY_SIZE(stackTraceColumns),	NULL,	false
+	stackTraceColumns,	NULL,	ARRAY_SIZE(stackTraceColumns),	false
 };
 
 GenericListViewColumn moduleListColumns[ML_COLUMNCOUNT] = {
@@ -67,7 +67,7 @@ GenericListViewColumn moduleListColumns[ML_COLUMNCOUNT] = {
 };
 
 GenericListViewDef moduleListDef = {
-	moduleListColumns,	ARRAY_SIZE(moduleListColumns),	NULL,	false
+	moduleListColumns,	NULL,	ARRAY_SIZE(moduleListColumns),	false
 };
 
 GenericListViewColumn watchListColumns[WL_COLUMNCOUNT] = {
@@ -77,7 +77,7 @@ GenericListViewColumn watchListColumns[WL_COLUMNCOUNT] = {
 };
 
 GenericListViewDef watchListDef = {
-	watchListColumns, ARRAY_SIZE(watchListColumns), nullptr, false,
+	watchListColumns, nullptr,	ARRAY_SIZE(watchListColumns), false,
 };
 
 //

--- a/Windows/GEDebugger/TabDisplayLists.cpp
+++ b/Windows/GEDebugger/TabDisplayLists.cpp
@@ -25,7 +25,7 @@ const GenericListViewColumn displayListStackColumns[3] = {
 };
 
 GenericListViewDef displayListStackListDef = {
-	displayListStackColumns,	ARRAY_SIZE(displayListStackColumns),	NULL,	false
+	displayListStackColumns,	NULL,	ARRAY_SIZE(displayListStackColumns),	false
 };
 
 CtrlDisplayListStack::CtrlDisplayListStack(HWND hwnd): GenericListControl(hwnd,displayListStackListDef)
@@ -77,7 +77,7 @@ const GenericListViewColumn allDisplayListsColumns[ADL_COLUMNCOUNT] = {
 };
 
 GenericListViewDef allDisplayListsListDef = {
-	allDisplayListsColumns,	ARRAY_SIZE(allDisplayListsColumns),	NULL,	false
+	allDisplayListsColumns,	NULL,	ARRAY_SIZE(allDisplayListsColumns),	false
 };
 
 CtrlAllDisplayLists::CtrlAllDisplayLists(HWND hwnd): GenericListControl(hwnd,allDisplayListsListDef)

--- a/Windows/GEDebugger/TabState.cpp
+++ b/Windows/GEDebugger/TabState.cpp
@@ -46,8 +46,8 @@ static const GenericListViewColumn stateValuesCols[] = {
 
 GenericListViewDef stateValuesListDef = {
 	stateValuesCols,
-	ARRAY_SIZE(stateValuesCols),
 	nullptr,
+	ARRAY_SIZE(stateValuesCols),
 	false,
 };
 

--- a/Windows/GEDebugger/TabVertices.cpp
+++ b/Windows/GEDebugger/TabVertices.cpp
@@ -47,7 +47,7 @@ static const GenericListViewColumn vertexListCols[] = {
 };
 
 GenericListViewDef vertexListDef = {
-	vertexListCols,	ARRAY_SIZE(vertexListCols),	NULL,	false
+	vertexListCols,	NULL,	ARRAY_SIZE(vertexListCols),	false
 };
 
 enum VertexListCols {
@@ -72,7 +72,7 @@ static const GenericListViewColumn matrixListCols[] = {
 };
 
 GenericListViewDef matrixListDef = {
-	matrixListCols,	ARRAY_SIZE(matrixListCols),	NULL,	false
+	matrixListCols,	NULL,	ARRAY_SIZE(matrixListCols),	false
 };
 
 enum MatrixListCols {


### PR DESCRIPTION
Tested only on Debug

Before RAM util (master):

![image](https://github.com/hrydgard/ppsspp/assets/21138600/31579605-15a5-4cf5-a66c-bfc8ef002857)

After RAM util (align-struct-64):

![image](https://github.com/hrydgard/ppsspp/assets/21138600/666ea52b-db21-4451-adac-92a0306ad60a)

