### PR TITLE
Atrac: Refactor: Move a lot more code into the Atrac class

### DIFF
--- a/Core/HLE/sceAtrac.h
+++ b/Core/HLE/sceAtrac.h
@@ -25,6 +25,7 @@ void Register_sceAtrac3plus();
 void __AtracInit();
 void __AtracDoState(PointerWrap &p);
 void __AtracShutdown();
+void __AtracLoadModule(int version, u32 crc);
 
 enum AtracStatus : u8 {
 	ATRAC_STATUS_NO_DATA = 1,
@@ -84,9 +85,7 @@ struct SceAtracContext {
     SceAtracIdInfo info;
 };
 
-// provide some decoder interface
-
-u32 _AtracAddStreamData(int atracID, u32 bufPtr, u32 bytesToAdd);
-u32 _AtracDecodeData(int atracID, u8* outbuf, u32 outbufPtr, u32 *SamplesNum, u32* finish, int *remains);
-int _AtracGetIDByContext(u32 contextAddr);
-void __AtracLoadModule(int version, u32 crc);
+// External interface used by sceSas.
+u32 AtracSasAddStreamData(int atracID, u32 bufPtr, u32 bytesToAdd);
+u32 AtracSasDecodeData(int atracID, u8* outbuf, u32 outbufPtr, u32 *SamplesNum, u32* finish, int *remains);
+int AtracSasGetIDByContext(u32 contextAddr);

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -192,7 +192,7 @@ void VagDecoder::DoState(PointerWrap &p) {
 
 int SasAtrac3::setContext(u32 context) {
 	contextAddr_ = context;
-	atracID_ = _AtracGetIDByContext(context);
+	atracID_ = AtracSasGetIDByContext(context);
 	if (!sampleQueue_)
 		sampleQueue_ = new BufferQueue();
 	sampleQueue_->clear();
@@ -211,7 +211,7 @@ void SasAtrac3::getNextSamples(s16 *outbuf, int wantedSamples) {
 		u32 numSamples = 0;
 		int remains = 0;
 		static s16 buf[0x800];
-		_AtracDecodeData(atracID_, (u8*)buf, 0, &numSamples, &finish, &remains);
+		AtracSasDecodeData(atracID_, (u8*)buf, 0, &numSamples, &finish, &remains);
 		if (numSamples > 0)
 			sampleQueue_->push((u8*)buf, numSamples * sizeof(s16));
 		else
@@ -223,7 +223,7 @@ void SasAtrac3::getNextSamples(s16 *outbuf, int wantedSamples) {
 
 int SasAtrac3::addStreamData(u32 bufPtr, u32 addbytes) {
 	if (atracID_ > 0) {
-		_AtracAddStreamData(atracID_, bufPtr, addbytes);
+		AtracSasAddStreamData(atracID_, bufPtr, addbytes);
 	}
 	return 0;
 }


### PR DESCRIPTION
This is so that we can replace the implementation easier later (with one that handles buffering better).

Also makes some of the code easier to read, without all the `atrac->`