### PR TITLE
More Atrac code cleanup

### DIFF
--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -640,7 +640,9 @@ void Atrac::GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) {
 	bufferInfo->second.filePos = 0;
 }
 
-int Atrac::SetData(u32 buffer, u32 readSize, u32 bufferSize, int successCode) {
+int Atrac::SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, int successCode) {
+	outputChannels_ = outputChannels;
+
 	first_.addr = buffer;
 	first_.size = readSize;
 
@@ -932,8 +934,7 @@ u32 Atrac::DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, i
 		uint8_t *indata = BufferStart() + off;
 		int bytesConsumed = 0;
 		int outBytes = 0;
-		if (!decoder_->Decode(indata, track_.bytesPerFrame, &bytesConsumed,
-			outbuf, &outBytes)) {
+		if (!decoder_->Decode(indata, track_.bytesPerFrame, &bytesConsumed, outbuf, &outBytes)) {
 			// Decode failed.
 			*SamplesNum = 0;
 			*finish = 1;

--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -925,7 +925,6 @@ u32 Atrac::DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, i
 		ConsumeFrame();
 	}
 
-	// TODO: We don't support any other codec type, check seems unnecessary?
 	SeekToSample(currentSample_);
 
 	bool gotFrame = false;

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -162,25 +162,22 @@ struct Atrac {
 
 	int RemainingFrames() const;
 
-	int atracID_ = -1;
-
 	u8 *dataBuf_ = nullptr;
+	// Offset of the first sample in the input buffer
+	int dataOff_ = 0;
 	// Indicates that the dataBuf_ array should not be used.
 	bool ignoreDataBuf_ = false;
-
 	u32 decodePos_ = 0;
 
+	int atracID_ = -1;
 	u16 channels_ = 0;
 	u16 outputChannels_ = 2;
 
 	int currentSample_ = 0;
 	int endSample_ = 0;
 	int firstSampleOffset_ = 0;
-	// Offset of the first sample in the input buffer
-	int dataOff_ = 0;
 
 	std::vector<AtracLoopInfo> loopinfo_;
-
 	int loopStartSample_ = -1;
 	int loopEndSample_ = -1;
 	int loopNum_ = 0;
@@ -255,7 +252,7 @@ private:
 	u32 bufferMaxSize_ = 0;
 	int jointStereo_ = 0;
 
-	// Used by low-level decoding and to track streaming.
+	// Used to track streaming.
 	u32 bufferPos_ = 0;
 	u32 bufferValidBytes_ = 0;
 	u32 bufferHeaderSize_ = 0;

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -108,6 +108,8 @@ inline u32 FirstOffsetExtra(int codecType) {
 
 struct Track {
 	u32 fileSize;
+	u32 codecType;
+	u32 bytesPerFrame;
 };
 
 struct Atrac {
@@ -144,7 +146,7 @@ struct Atrac {
 	}
 	// Output frame size
 	u32 SamplesPerFrame() const {
-		return codecType_ == PSP_MODE_AT_3_PLUS ? ATRAC3PLUS_MAX_SAMPLES : ATRAC3_MAX_SAMPLES;
+		return track_.codecType == PSP_MODE_AT_3_PLUS ? ATRAC3PLUS_MAX_SAMPLES : ATRAC3_MAX_SAMPLES;
 	}
 
 	u32 DecodePosBySample(int sample) const {
@@ -205,7 +207,7 @@ struct Atrac {
 	void SeekToSample(int sample);
 
 	u32 CodecType() const {
-		return codecType_;
+		return track_.codecType;
 	}
 	AudioDecoder *GetDecoder() const {
 		return decoder_;
@@ -223,7 +225,7 @@ struct Atrac {
 	void CalculateStreamInfo(u32 *readOffset);
 
 	u32 FirstOffsetExtra() const {
-		return ::FirstOffsetExtra(codecType_);
+		return ::FirstOffsetExtra(track_.codecType);
 	}
 
 	u32 StreamBufferEnd() const {
@@ -253,9 +255,6 @@ struct Atrac {
 	u32 GetNextSamples();
 
 	void InitLowLevel(u32 paramsAddr, bool jointStereo);
-
-	// To be moved into private.
-	u32 codecType_ = 0;
 
 private:
 	void AnalyzeReset();

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -133,6 +133,9 @@ struct Track {
 	}
 };
 
+int AnalyzeAA3Track(u32 addr, u32 size, u32 filesize, Track *track);
+int AnalyzeAtracTrack(u32 addr, u32 size, Track *track);
+
 struct Atrac {
 	~Atrac() {
 		ResetData();

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -114,6 +114,8 @@ struct Track {
 	int endSample;
 	// Offset of the first sample in the input buffer
 	int dataOff = 0;
+	u32 bitrate = 64;
+	int jointStereo = 0;
 
 	std::vector<AtracLoopInfo> loopinfo;
 	int loopStartSample = -1;
@@ -179,7 +181,7 @@ struct Atrac {
 	void UpdateBitrate();
 
 	int Bitrate() const {
-		return bitrate_;
+		return track_.bitrate;
 	}
 	int Channels() const {
 		return channels_;
@@ -268,9 +270,7 @@ struct Atrac {
 private:
 	void AnalyzeReset();
 
-	u32 bitrate_ = 64;
 	u32 bufferMaxSize_ = 0;
-	int jointStereo_ = 0;
 
 	// Used to track streaming.
 	u32 bufferPos_ = 0;

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -108,6 +108,7 @@ inline u32 FirstOffsetExtra(int codecType) {
 
 struct Track {
 	u32 fileSize;
+	// This both does and doesn't belong in Track - it's fixed for an Atrac instance. Oh well.
 	u32 codecType;
 	u16 bytesPerFrame;
 	int firstSampleOffset;
@@ -192,6 +193,9 @@ struct Atrac {
 	}
 
 	int RemainingFrames() const;
+	int GetOutputChannels() const {
+		return outputChannels_;
+	}
 
 	u8 *dataBuf_ = nullptr;
 	// Indicates that the dataBuf_ array should not be used.
@@ -261,7 +265,7 @@ struct Atrac {
 	void SetLoopNum(int loopNum);
 	u32 ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf);
 	void GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample);
-	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int successCode = 0);
+	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, int successCode);
 	u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize);
 	int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize);
 	u32 DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains);

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -113,6 +113,10 @@ struct Track {
 	int firstSampleOffset;
 	int endSample;
 
+	std::vector<AtracLoopInfo> loopinfo;
+	int loopStartSample = -1;
+	int loopEndSample = -1;
+
 	// Input frame size
 	int BytesPerFrame() const {
 		return bytesPerFrame;
@@ -139,10 +143,10 @@ struct Atrac {
 				bufferState_ = ATRAC_STATUS_ALL_DATA_LOADED;
 			}
 		} else {
-			if (loopEndSample_ <= 0) {
+			if (track_.loopEndSample <= 0) {
 				// There's no looping, but we need to stream the data in our buffer.
 				bufferState_ = ATRAC_STATUS_STREAMED_WITHOUT_LOOP;
-			} else if (loopEndSample_ == track_.endSample + track_.firstSampleOffset + (int)FirstOffsetExtra()) {
+			} else if (track_.loopEndSample == track_.endSample + track_.firstSampleOffset + (int)FirstOffsetExtra()) {
 				bufferState_ = ATRAC_STATUS_STREAMED_LOOP_FROM_END;
 			} else {
 				bufferState_ = ATRAC_STATUS_STREAMED_LOOP_WITH_TRAILER;
@@ -193,10 +197,6 @@ struct Atrac {
 	u16 outputChannels_ = 2;
 
 	int currentSample_ = 0;
-
-	std::vector<AtracLoopInfo> loopinfo_;
-	int loopStartSample_ = -1;
-	int loopEndSample_ = -1;
 	int loopNum_ = 0;
 
 	InputBuffer first_{};

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -110,7 +110,8 @@ struct Track {
 	u32 fileSize;
 	u32 codecType;
 	u16 bytesPerFrame;
-	u32 firstSampleOffset;
+	int firstSampleOffset;
+	int endSample;
 
 	// Input frame size
 	int BytesPerFrame() const {
@@ -141,7 +142,7 @@ struct Atrac {
 			if (loopEndSample_ <= 0) {
 				// There's no looping, but we need to stream the data in our buffer.
 				bufferState_ = ATRAC_STATUS_STREAMED_WITHOUT_LOOP;
-			} else if (loopEndSample_ == endSample_ + track_.firstSampleOffset + (int)FirstOffsetExtra()) {
+			} else if (loopEndSample_ == track_.endSample + track_.firstSampleOffset + (int)FirstOffsetExtra()) {
 				bufferState_ = ATRAC_STATUS_STREAMED_LOOP_FROM_END;
 			} else {
 				bufferState_ = ATRAC_STATUS_STREAMED_LOOP_WITH_TRAILER;
@@ -192,7 +193,6 @@ struct Atrac {
 	u16 outputChannels_ = 2;
 
 	int currentSample_ = 0;
-	int endSample_ = 0;
 
 	std::vector<AtracLoopInfo> loopinfo_;
 	int loopStartSample_ = -1;

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -100,6 +100,10 @@ struct AtracLoopInfo {
 
 class AudioDecoder;
 
+inline u32 FirstOffsetExtra(int codecType) {
+	return codecType == PSP_MODE_AT_3_PLUS ? 368 : 69;
+}
+
 struct Atrac {
 	~Atrac() {
 		ResetData();
@@ -135,10 +139,6 @@ struct Atrac {
 	// Output frame size
 	u32 SamplesPerFrame() const {
 		return codecType_ == PSP_MODE_AT_3_PLUS ? ATRAC3PLUS_MAX_SAMPLES : ATRAC3_MAX_SAMPLES;
-	}
-
-	u32 FirstOffsetExtra() const {
-		return codecType_ == PSP_MODE_AT_3_PLUS ? 368 : 69;
 	}
 
 	u32 DecodePosBySample(int sample) const {
@@ -213,6 +213,10 @@ struct Atrac {
 	}
 
 	void CalculateStreamInfo(u32 *readOffset);
+
+	u32 FirstOffsetExtra() const {
+		return ::FirstOffsetExtra(codecType_);
+	}
 
 	u32 StreamBufferEnd() const {
 		// The buffer is always aligned to a frame in size, not counting an optional header.

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -116,6 +116,7 @@ struct Track {
 	int dataOff = 0;
 	u32 bitrate = 64;
 	int jointStereo = 0;
+	u16 channels = 0;
 
 	std::vector<AtracLoopInfo> loopinfo;
 	int loopStartSample = -1;
@@ -184,7 +185,7 @@ struct Atrac {
 		return track_.bitrate;
 	}
 	int Channels() const {
-		return channels_;
+		return track_.channels;
 	}
 
 	int RemainingFrames() const;
@@ -195,7 +196,6 @@ struct Atrac {
 	u32 decodePos_ = 0;
 
 	int atracID_ = -1;
-	u16 channels_ = 0;
 	u16 outputChannels_ = 2;
 
 	int currentSample_ = 0;

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -112,6 +112,8 @@ struct Track {
 	u16 bytesPerFrame;
 	int firstSampleOffset;
 	int endSample;
+	// Offset of the first sample in the input buffer
+	int dataOff = 0;
 
 	std::vector<AtracLoopInfo> loopinfo;
 	int loopStartSample = -1;
@@ -167,7 +169,7 @@ struct Atrac {
 	u32 FileOffsetBySample(int sample) const {
 		int offsetSample = sample + track_.firstSampleOffset;
 		int frameOffset = offsetSample / (int)track_.SamplesPerFrame();
-		return (u32)(dataOff_ + track_.bytesPerFrame + frameOffset * track_.bytesPerFrame);
+		return (u32)(track_.dataOff + track_.bytesPerFrame + frameOffset * track_.bytesPerFrame);
 	}
 
 	const Track &GetTrack() const {
@@ -186,8 +188,6 @@ struct Atrac {
 	int RemainingFrames() const;
 
 	u8 *dataBuf_ = nullptr;
-	// Offset of the first sample in the input buffer
-	int dataOff_ = 0;
 	// Indicates that the dataBuf_ array should not be used.
 	bool ignoreDataBuf_ = false;
 	u32 decodePos_ = 0;

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -109,7 +109,7 @@ inline u32 FirstOffsetExtra(int codecType) {
 struct Track {
 	u32 fileSize;
 	u32 codecType;
-	u32 bytesPerFrame;
+	u16 bytesPerFrame;
 };
 
 struct Atrac {
@@ -142,7 +142,7 @@ struct Atrac {
 
 	// Input frame size
 	int BytesPerFrame() const {
-		return bytesPerFrame_;
+		return track_.bytesPerFrame;
 	}
 	// Output frame size
 	u32 SamplesPerFrame() const {
@@ -150,13 +150,13 @@ struct Atrac {
 	}
 
 	u32 DecodePosBySample(int sample) const {
-		return (u32)(firstSampleOffset_ + sample / (int)SamplesPerFrame() * bytesPerFrame_);
+		return (u32)(firstSampleOffset_ + sample / (int)SamplesPerFrame() * track_.bytesPerFrame);
 	}
 
 	u32 FileOffsetBySample(int sample) const {
 		int offsetSample = sample + firstSampleOffset_;
 		int frameOffset = offsetSample / (int)SamplesPerFrame();
-		return (u32)(dataOff_ + bytesPerFrame_ + frameOffset * bytesPerFrame_);
+		return (u32)(dataOff_ + track_.bytesPerFrame + frameOffset * track_.bytesPerFrame);
 	}
 
 	void UpdateBitrate();
@@ -231,8 +231,8 @@ struct Atrac {
 	u32 StreamBufferEnd() const {
 		// The buffer is always aligned to a frame in size, not counting an optional header.
 		// The header will only initially exist after the data is first set.
-		u32 framesAfterHeader = (bufferMaxSize_ - bufferHeaderSize_) / bytesPerFrame_;
-		return framesAfterHeader * bytesPerFrame_ + bufferHeaderSize_;
+		u32 framesAfterHeader = (bufferMaxSize_ - bufferHeaderSize_) / track_.bytesPerFrame;
+		return framesAfterHeader * track_.bytesPerFrame + bufferHeaderSize_;
 	}
 
 	int Analyze(u32 addr, u32 size);
@@ -260,7 +260,6 @@ private:
 	void AnalyzeReset();
 
 	u32 bitrate_ = 64;
-	u16 bytesPerFrame_ = 0;
 	u32 bufferMaxSize_ = 0;
 	int jointStereo_ = 0;
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -462,17 +462,7 @@ static u32 sceAtracGetSecondBufferInfo(int atracID, u32 fileOffsetAddr, u32 desi
 		return hleReportError(ME, SCE_KERNEL_ERROR_ILLEGAL_ADDR, "invalid addresses");
 	}
 
-	if (atrac->BufferState() != ATRAC_STATUS_STREAMED_LOOP_WITH_TRAILER) {
-		// Writes zeroes in this error case.
-		*fileOffset = 0;
-		*desiredSize = 0;
-		return hleLogWarning(ME, ATRAC_ERROR_SECOND_BUFFER_NOT_NEEDED, "not needed");
-	}
-
-	*fileOffset = atrac->FileOffsetBySample(atrac->loopEndSample_ - atrac->firstSampleOffset_);
-	*desiredSize = atrac->first_.filesize - *fileOffset;
-
-	return hleLogSuccessI(ME, 0);
+	return atrac->GetSecondBufferInfo(fileOffset, desiredSize);
 }
 
 static u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSampleAddr, u32 outLoopEndSampleAddr) {

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -345,7 +345,7 @@ static u32 sceAtracGetLoopStatus(int atracID, u32 loopNumAddr, u32 statusAddr) {
 		Memory::WriteUnchecked_U32(atrac->loopNum_, loopNumAddr);
 	// return audio's loopinfo in at3 file
 	if (Memory::IsValidAddress(statusAddr)) {
-		if (atrac->loopinfo_.size() > 0)
+		if (atrac->GetTrack().loopinfo.size() > 0)
 			Memory::WriteUnchecked_U32(1, statusAddr);
 		else
 			Memory::WriteUnchecked_U32(0, statusAddr);
@@ -478,10 +478,10 @@ static u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoop
 		*outEndSample = atrac->GetTrack().endSample;
 	auto outLoopStart = PSPPointer<u32_le>::Create(outLoopStartSampleAddr);
 	if (outLoopStart.IsValid())
-		*outLoopStart = atrac->loopStartSample_ == -1 ? -1 : atrac->loopStartSample_ - atrac->track_.firstSampleOffset - atrac->FirstOffsetExtra();
+		*outLoopStart = atrac->GetTrack().loopStartSample == -1 ? -1 : atrac->GetTrack().loopStartSample - atrac->GetTrack().firstSampleOffset - atrac->FirstOffsetExtra();
 	auto outLoopEnd = PSPPointer<u32_le>::Create(outLoopEndSampleAddr);
 	if (outLoopEnd.IsValid())
-		*outLoopEnd = atrac->loopEndSample_ == -1 ? -1 : atrac->loopEndSample_ - atrac->track_.firstSampleOffset - atrac->FirstOffsetExtra();
+		*outLoopEnd = atrac->GetTrack().loopEndSample == -1 ? -1 : atrac->GetTrack().loopEndSample - atrac->GetTrack().firstSampleOffset - atrac->FirstOffsetExtra();
 
 	if (!outEndSample.IsValid() || !outLoopStart.IsValid() || !outLoopEnd.IsValid()) {
 		return hleReportError(ME, 0, "invalid address");
@@ -669,7 +669,7 @@ static u32 sceAtracSetLoopNum(int atracID, int loopNum) {
 		// Already logged.
 		return err;
 	}
-	if (atrac->loopinfo_.size() == 0) {
+	if (atrac->GetTrack().loopinfo.size() == 0) {
 		return hleLogError(ME, ATRAC_ERROR_NO_LOOP_INFORMATION, "no loop information");
 	}
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -765,7 +765,7 @@ static int sceAtracSetMOutHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u
 		// Already logged.
 		return ret;
 	}
-	if (atrac->channels_ != 1) {
+	if (atrac->GetTrack().channels != 1) {
 		// It seems it still sets the data.
 		atrac->outputChannels_ = 2;
 		atrac->SetData(buffer, readSize, bufferSize);
@@ -789,7 +789,7 @@ static u32 sceAtracSetMOutData(int atracID, u32 buffer, u32 bufferSize) {
 		// Already logged.
 		return ret;
 	}
-	if (atrac->channels_ != 1) {
+	if (atrac->GetTrack().channels != 1) {
 		// It seems it still sets the data.
 		atrac->outputChannels_ = 2;
 		atrac->SetData(buffer, bufferSize, bufferSize);
@@ -809,7 +809,7 @@ static int sceAtracSetMOutDataAndGetID(u32 buffer, u32 bufferSize) {
 		delete atrac;
 		return ret;
 	}
-	if (atrac->channels_ != 1) {
+	if (atrac->GetTrack().channels != 1) {
 		delete atrac;
 		return hleReportError(ME, ATRAC_ERROR_NOT_MONO, "not mono data");
 	}
@@ -834,7 +834,7 @@ static int sceAtracSetMOutHalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 bu
 		delete atrac;
 		return ret;
 	}
-	if (atrac->channels_ != 1) {
+	if (atrac->GetTrack().channels != 1) {
 		delete atrac;
 		return hleReportError(ME, ATRAC_ERROR_NOT_MONO, "not mono data");
 	}
@@ -937,7 +937,7 @@ static int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 	atrac->InitLowLevel(paramsAddr, jointStereo);
 
 	const char *codecName = atrac->track_.codecType == PSP_MODE_AT_3 ? "atrac3" : "atrac3+";
-	const char *channelName = atrac->channels_ == 1 ? "mono" : "stereo";
+	const char *channelName = atrac->GetTrack().channels == 1 ? "mono" : "stereo";
 	return hleLogSuccessInfoI(ME, 0, "%s %s audio", codecName, channelName);
 }
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -291,6 +291,7 @@ static u32 sceAtracGetBufferInfoForResetting(int atracID, int sample, u32 buffer
 	} else if (atrac->BufferState() == ATRAC_STATUS_STREAMED_LOOP_WITH_TRAILER && atrac->second_.size == 0) {
 		return hleReportError(ME, ATRAC_ERROR_SECOND_BUFFER_NEEDED, "no second buffer");
 	} else if ((u32)sample + atrac->firstSampleOffset_ > (u32)atrac->endSample_ + atrac->firstSampleOffset_) {
+		// NOTE: Above we have to add firstSampleOffset to both sides - we seem to rely on wraparound.
 		return hleLogWarning(ME, ATRAC_ERROR_BAD_SAMPLE, "invalid sample position");
 	} else {
 		atrac->GetResetBufferInfo(bufferInfo, sample);
@@ -544,6 +545,7 @@ static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFi
 	if (atrac->BufferState() == ATRAC_STATUS_STREAMED_LOOP_WITH_TRAILER && atrac->second_.size == 0) {
 		return hleReportError(ME, ATRAC_ERROR_SECOND_BUFFER_NEEDED, "no second buffer");
 	} else if ((u32)sample + atrac->firstSampleOffset_ > (u32)atrac->endSample_ + atrac->firstSampleOffset_) {
+		// NOTE: Above we have to add firstSampleOffset to both sides - we seem to rely on wraparound.
 		return hleLogWarning(ME, ATRAC_ERROR_BAD_SAMPLE, "invalid sample position");
 	}
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -290,7 +290,7 @@ static u32 sceAtracGetBufferInfoForResetting(int atracID, int sample, u32 buffer
 		return hleReportError(ME, SCE_KERNEL_ERROR_ILLEGAL_ADDR, "invalid buffer, should crash");
 	} else if (atrac->BufferState() == ATRAC_STATUS_STREAMED_LOOP_WITH_TRAILER && atrac->second_.size == 0) {
 		return hleReportError(ME, ATRAC_ERROR_SECOND_BUFFER_NEEDED, "no second buffer");
-	} else if ((u32)sample + atrac->GetTrack().firstSampleOffset > (u32)atrac->endSample_ + atrac->GetTrack().firstSampleOffset) {
+	} else if ((u32)sample + atrac->GetTrack().firstSampleOffset > (u32)atrac->GetTrack().endSample + atrac->GetTrack().firstSampleOffset) {
 		// NOTE: Above we have to add firstSampleOffset to both sides - we seem to rely on wraparound.
 		return hleLogWarning(ME, ATRAC_ERROR_BAD_SAMPLE, "invalid sample position");
 	} else {
@@ -393,7 +393,7 @@ static u32 sceAtracGetNextDecodePosition(int atracID, u32 outposAddr) {
 	}
 
 	if (Memory::IsValidAddress(outposAddr)) {
-		if (atrac->currentSample_ >= atrac->endSample_) {
+		if (atrac->currentSample_ >= atrac->GetTrack().endSample) {
 			Memory::WriteUnchecked_U32(0, outposAddr);
 			return hleLogSuccessI(ME, ATRAC_ERROR_ALL_DATA_DECODED, "all data decoded");
 		} else {
@@ -412,7 +412,7 @@ static u32 sceAtracGetNextSample(int atracID, u32 outNAddr) {
 		// Already logged.
 		return err;
 	}
-	if (atrac->currentSample_ >= atrac->endSample_) {
+	if (atrac->currentSample_ >= atrac->GetTrack().endSample) {
 		if (Memory::IsValidAddress(outNAddr))
 			Memory::WriteUnchecked_U32(0, outNAddr);
 		return hleLogSuccessI(ME, 0, "0 samples left");
@@ -475,7 +475,7 @@ static u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoop
 
 	auto outEndSample = PSPPointer<u32_le>::Create(outEndSampleAddr);
 	if (outEndSample.IsValid())
-		*outEndSample = atrac->endSample_;
+		*outEndSample = atrac->GetTrack().endSample;
 	auto outLoopStart = PSPPointer<u32_le>::Create(outLoopStartSampleAddr);
 	if (outLoopStart.IsValid())
 		*outLoopStart = atrac->loopStartSample_ == -1 ? -1 : atrac->loopStartSample_ - atrac->track_.firstSampleOffset - atrac->FirstOffsetExtra();
@@ -534,7 +534,7 @@ static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFi
 
 	if (atrac->BufferState() == ATRAC_STATUS_STREAMED_LOOP_WITH_TRAILER && atrac->second_.size == 0) {
 		return hleReportError(ME, ATRAC_ERROR_SECOND_BUFFER_NEEDED, "no second buffer");
-	} else if ((u32)sample + atrac->GetTrack().firstSampleOffset > (u32)atrac->endSample_ + atrac->GetTrack().firstSampleOffset) {
+	} else if ((u32)sample + atrac->GetTrack().firstSampleOffset > (u32)atrac->GetTrack().endSample + atrac->GetTrack().firstSampleOffset) {
 		// NOTE: Above we have to add firstSampleOffset to both sides - we seem to rely on wraparound.
 		return hleLogWarning(ME, ATRAC_ERROR_BAD_SAMPLE, "invalid sample position");
 	}

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -176,7 +176,7 @@ static u32 sceAtracGetAtracID(int codecType) {
 	}
 
 	Atrac *atrac = new Atrac();
-	atrac->codecType_ = codecType;
+	atrac->track_.codecType = codecType;
 	int atracID = createAtrac(atrac);
 	if (atracID < 0) {
 		delete atrac;
@@ -602,7 +602,7 @@ static u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize) {
 		return ret;
 	}
 
-	if (atrac->codecType_ != atracContextTypes[atracID]) {
+	if (atrac->track_.codecType != atracContextTypes[atracID]) {
 		// TODO: Should this not change the buffer size?
 		return hleReportError(ME, ATRAC_ERROR_WRONG_CODECTYPE, "atracID uses different codec type than data");
 	}
@@ -913,18 +913,13 @@ static int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 		return hleLogError(ME, ATRAC_ERROR_BAD_ATRACID, "bad atrac ID");
 	}
 
-	if (atrac->codecType_ != PSP_MODE_AT_3 && atrac->codecType_ != PSP_MODE_AT_3_PLUS) {
-		// TODO: Error code?  Was silently 0 before, and just didn't work.  Shouldn't ever happen...
-		return hleReportError(ME, ATRAC_ERROR_UNKNOWN_FORMAT, "bad codec type");
-	}
-
 	if (!Memory::IsValidAddress(paramsAddr)) {
 		// TODO: Returning zero as code was before.  Needs testing.
 		return hleReportError(ME, 0, "invalid pointers");
 	}
 
 	bool jointStereo = false;
-	if (atrac->codecType_ == PSP_MODE_AT_3) {
+	if (atrac->track_.codecType == PSP_MODE_AT_3) {
 		// See if we can match the actual jointStereo value.
 		bool found = false;
 		for (size_t i = 0; i < ARRAY_SIZE(at3HeaderMap); ++i) {
@@ -941,7 +936,7 @@ static int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 
 	atrac->InitLowLevel(paramsAddr, jointStereo);
 
-	const char *codecName = atrac->codecType_ == PSP_MODE_AT_3 ? "atrac3" : "atrac3+";
+	const char *codecName = atrac->track_.codecType == PSP_MODE_AT_3 ? "atrac3" : "atrac3+";
 	const char *channelName = atrac->channels_ == 1 ? "mono" : "stereo";
 	return hleLogSuccessInfoI(ME, 0, "%s %s audio", codecName, channelName);
 }


### PR DESCRIPTION
Breaks out the "fixed" parts of a playing track into a Track structure, which can be shared between the old and upcoming buffering implementations. That stuff won't change, and don't want to have to duplicate that code.