### PR TITLE
Atrac: Split the context into a base class and a derived class, to be able to replace the buffering logic

### DIFF
--- a/Common/Serialize/SerializeFuncs.h
+++ b/Common/Serialize/SerializeFuncs.h
@@ -71,6 +71,17 @@ void DoClass(PointerWrap &p, T *&x) {
 	x->DoState(p);
 }
 
+template<class T, class S>
+void DoSubClass(PointerWrap &p, T *&x) {
+	if (p.mode == PointerWrap::MODE_READ) {
+		if (x != nullptr)
+			delete x;
+		x = new S();
+	}
+	x->DoState(p);
+}
+
+
 template<class T>
 void DoArray(PointerWrap &p, T *x, int count) {
 	DoHelper_<T>::DoArray(p, x, count);

--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -731,6 +731,16 @@ void Atrac::UpdateBitrate() {
 		track_.bitrate = (track_.bitrate + 511) >> 10;
 }
 
+void Atrac::GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) {
+	u32 calculatedReadOffset;
+	// TODO: Feels like this should already have been computed?
+	CalculateStreamInfo(&calculatedReadOffset);
+
+	*writePtr = first_.addr + first_.offset;
+	*writableBytes = first_.writableBytes;
+	*readOffset = calculatedReadOffset;
+}
+
 int Atrac::AddStreamData(u32 bytesToAdd) {
 	u32 readOffset;
 	CalculateStreamInfo(&readOffset);

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -154,7 +154,8 @@ struct Track {
 int AnalyzeAA3Track(u32 addr, u32 size, u32 filesize, Track *track);
 int AnalyzeAtracTrack(u32 addr, u32 size, Track *track);
 
-struct AtracBase {
+class AtracBase {
+public:
 	virtual ~AtracBase() {}
 	virtual void UpdateBufferState() = 0;
 

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -179,6 +179,10 @@ struct Atrac {
 		return (u32)(track_.dataOff + track_.bytesPerFrame + frameOffset * track_.bytesPerFrame);
 	}
 
+	u32 SecondBufferSize() const {
+		return second_.size;
+	}
+
 	const Track &GetTrack() const {
 		return track_;
 	}
@@ -223,6 +227,9 @@ struct Atrac {
 	u8 *BufferStart();
 
 	void SeekToSample(int sample);
+	int CurrentSample() const {
+		return currentSample_;
+	}
 
 	u32 CodecType() const {
 		return track_.codecType;
@@ -259,6 +266,7 @@ struct Atrac {
 	void UpdateContextFromPSPMem();
 	void WriteContextToPSPMem();
 
+	void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset);
 	int AddStreamData(u32 bytesToAdd);
 	u32 AddStreamDataSas(u32 bufPtr, u32 bytesToAdd);
 	void CreateDecoder();

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -132,18 +132,127 @@ struct Track {
 	u32 SamplesPerFrame() const {
 		return codecType == PSP_MODE_AT_3_PLUS ? ATRAC3PLUS_MAX_SAMPLES : ATRAC3_MAX_SAMPLES;
 	}
+
+	void UpdateBitrate() {
+		bitrate = (bytesPerFrame * 352800) / 1000;
+		if (codecType == PSP_MODE_AT_3_PLUS)
+			bitrate = ((bitrate >> 11) + 8) & 0xFFFFFFF0;
+		else
+			bitrate = (bitrate + 511) >> 10;
+	}
+
+	void AnalyzeReset() {
+		endSample = -1;
+		loopinfo.clear();
+		loopStartSample = -1;
+		loopEndSample = -1;
+		channels = 2;
+		// TODO: Could probably reset more.
+	}
 };
 
 int AnalyzeAA3Track(u32 addr, u32 size, u32 filesize, Track *track);
 int AnalyzeAtracTrack(u32 addr, u32 size, Track *track);
 
-struct Atrac {
+struct AtracBase {
+	virtual ~AtracBase() {}
+	virtual void UpdateBufferState() = 0;
+
+	virtual void DoState(PointerWrap &p) = 0;
+
+	u32 DecodePosBySample(int sample) const {
+		return (u32)(track_.firstSampleOffset + sample / (int)track_.SamplesPerFrame() * track_.bytesPerFrame);
+	}
+
+	u32 FileOffsetBySample(int sample) const {
+		int offsetSample = sample + track_.firstSampleOffset;
+		int frameOffset = offsetSample / (int)track_.SamplesPerFrame();
+		return (u32)(track_.dataOff + track_.bytesPerFrame + frameOffset * track_.bytesPerFrame);
+	}
+
+	const Track &GetTrack() const {
+		return track_;
+	}
+	// This should be rare.
+	Track &GetTrackMut() {
+		return track_;
+	}
+
+	int Bitrate() const {
+		return track_.bitrate;
+	}
+	int Channels() const {
+		return track_.channels;
+	}
+
+	int GetOutputChannels() const {
+		return outputChannels_;
+	}
+
+	int atracID_ = -1;
+	u16 outputChannels_ = 2;
+	int loopNum_ = 0;
+	Track track_{};
+
+	PSPPointer<SceAtracContext> context_{};
+
+	AtracStatus BufferState() const {
+		return bufferState_;
+	}
+
+	u32 CodecType() const {
+		return track_.codecType;
+	}
+	AudioDecoder *GetDecoder() const {
+		return decoder_;
+	}
+	u32 FirstOffsetExtra() const {
+		return ::FirstOffsetExtra(track_.codecType);
+	}
+	void CreateDecoder();
+
+	virtual uint32_t CurBufferAddress(int adjust = 0) const = 0;
+	virtual int CurrentSample() const = 0;
+	virtual int RemainingFrames() const = 0;
+	virtual u32 SecondBufferSize() const = 0;
+
+	virtual int Analyze(u32 addr, u32 size) = 0;
+	virtual int AnalyzeAA3(u32 addr, u32 size, u32 filesize) = 0;
+
+	void UpdateContextFromPSPMem();
+	virtual void WriteContextToPSPMem() = 0;
+
+	virtual void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) = 0;
+	virtual int AddStreamData(u32 bytesToAdd) = 0;
+	virtual u32 AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) = 0;
+	virtual void SetLoopNum(int loopNum) = 0;
+	virtual u32 ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) = 0;
+	virtual void GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) = 0;
+	virtual int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, int successCode) = 0;
+	virtual u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) = 0;
+	virtual int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) = 0;
+	virtual void ForceSeekToSample(int sample) = 0;
+	virtual void SeekToSample(int sample) = 0;
+	virtual u32 DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains) = 0;
+	virtual u32 GetNextSamples() = 0;
+	virtual void InitLowLevel(u32 paramsAddr, bool jointStereo) = 0;
+
+protected:
+	virtual void AnalyzeReset() = 0;
+
+	// TODO: Save the internal state of this, now technically possible.
+	AudioDecoder *decoder_ = nullptr;
+	AtracStatus bufferState_ = ATRAC_STATUS_NO_DATA;
+};
+
+class Atrac : public AtracBase {
+public:
 	~Atrac() {
 		ResetData();
 	}
-
 	void ResetData();
-	void UpdateBufferState() {
+
+	virtual void UpdateBufferState() {
 		if (bufferMaxSize_ >= track_.fileSize) {
 			if (first_.size < track_.fileSize) {
 				// The buffer is big enough, but we don't have all the data yet.
@@ -163,82 +272,7 @@ struct Atrac {
 		}
 	}
 
-	void DoState(PointerWrap &p);
-
-	u32 SamplesPerFrame() const {
-		return track_.SamplesPerFrame();
-	}
-
-	u32 DecodePosBySample(int sample) const {
-		return (u32)(track_.firstSampleOffset + sample / (int)track_.SamplesPerFrame() * track_.bytesPerFrame);
-	}
-
-	u32 FileOffsetBySample(int sample) const {
-		int offsetSample = sample + track_.firstSampleOffset;
-		int frameOffset = offsetSample / (int)track_.SamplesPerFrame();
-		return (u32)(track_.dataOff + track_.bytesPerFrame + frameOffset * track_.bytesPerFrame);
-	}
-
-	u32 SecondBufferSize() const {
-		return second_.size;
-	}
-
-	const Track &GetTrack() const {
-		return track_;
-	}
-
-	void UpdateBitrate();
-
-	int Bitrate() const {
-		return track_.bitrate;
-	}
-	int Channels() const {
-		return track_.channels;
-	}
-
-	int RemainingFrames() const;
-	int GetOutputChannels() const {
-		return outputChannels_;
-	}
-
-	u8 *dataBuf_ = nullptr;
-	// Indicates that the dataBuf_ array should not be used.
-	bool ignoreDataBuf_ = false;
-	u32 decodePos_ = 0;
-
-	int atracID_ = -1;
-	u16 outputChannels_ = 2;
-
-	int currentSample_ = 0;
-	int loopNum_ = 0;
-
-	InputBuffer first_{};
-	InputBuffer second_{};
-
-	Track track_{};
-
-	PSPPointer<SceAtracContext> context_{};
-
-	AtracStatus BufferState() const {
-		return bufferState_;
-	}
-
-	void ForceSeekToSample(int sample);
-	u8 *BufferStart();
-
-	void SeekToSample(int sample);
-	int CurrentSample() const {
-		return currentSample_;
-	}
-
-	u32 CodecType() const {
-		return track_.codecType;
-	}
-	AudioDecoder *GetDecoder() const {
-		return decoder_;
-	}
-
-	uint32_t CurBufferAddress(int adjust = 0) {
+	uint32_t CurBufferAddress(int adjust = 0) const override {
 		u32 off = FileOffsetBySample(currentSample_ + adjust);
 		if (off < first_.size && ignoreDataBuf_) {
 			return first_.addr + off;
@@ -247,53 +281,66 @@ struct Atrac {
 		return 0;
 	}
 
-	void CalculateStreamInfo(u32 *readOffset);
-
-	u32 FirstOffsetExtra() const {
-		return ::FirstOffsetExtra(track_.codecType);
+	u8 *BufferStart() {
+		return ignoreDataBuf_ ? Memory::GetPointerWrite(first_.addr) : dataBuf_;
 	}
 
+	void DoState(PointerWrap &p) override;
+	void WriteContextToPSPMem() override;
+
+	int Analyze(u32 addr, u32 size) override;
+	int AnalyzeAA3(u32 addr, u32 size, u32 filesize) override;
+
+	int CurrentSample() const override {
+		return currentSample_;
+	}
+	int RemainingFrames() const override;
+	u32 SecondBufferSize() const override {
+		return second_.size;
+	}
+
+	void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) override;
+	int AddStreamData(u32 bytesToAdd) override;
+	u32 AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) override;
+	void SetLoopNum(int loopNum) override;
+	u32 ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) override;
+	void GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) override;
+	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, int successCode) override;
+	u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) override;
+	int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) override;
+	void ForceSeekToSample(int sample) override;
+	void SeekToSample(int sample) override;
+	u32 DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains) override;
+	u32 GetNextSamples() override;
+	void InitLowLevel(u32 paramsAddr, bool jointStereo);
+
+	// Indicates that the dataBuf_ array should not be used.
+	u8 *dataBuf_ = nullptr;
+
+	InputBuffer first_{};
+	InputBuffer second_{};
+
+protected:
+	void AnalyzeReset();
+
+private:
 	u32 StreamBufferEnd() const {
 		// The buffer is always aligned to a frame in size, not counting an optional header.
 		// The header will only initially exist after the data is first set.
 		u32 framesAfterHeader = (bufferMaxSize_ - bufferHeaderSize_) / track_.bytesPerFrame;
 		return framesAfterHeader * track_.bytesPerFrame + bufferHeaderSize_;
 	}
-
-	int Analyze(u32 addr, u32 size);
-	int AnalyzeAA3(u32 addr, u32 size, u32 filesize);
-
-	void UpdateContextFromPSPMem();
-	void WriteContextToPSPMem();
-
-	void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset);
-	int AddStreamData(u32 bytesToAdd);
-	u32 AddStreamDataSas(u32 bufPtr, u32 bytesToAdd);
-	void CreateDecoder();
-	void SetLoopNum(int loopNum);
-	u32 ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf);
-	void GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample);
-	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, int successCode);
-	u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize);
-	int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize);
-	u32 DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains);
 	void ConsumeFrame();
-	u32 GetNextSamples();
+	void CalculateStreamInfo(u32 *readOffset);
 
-	void InitLowLevel(u32 paramsAddr, bool jointStereo);
+	bool ignoreDataBuf_ = false;
 
-private:
-	void AnalyzeReset();
-
+	int currentSample_ = 0;
+	u32 decodePos_ = 0;
 	u32 bufferMaxSize_ = 0;
 
 	// Used to track streaming.
 	u32 bufferPos_ = 0;
 	u32 bufferValidBytes_ = 0;
 	u32 bufferHeaderSize_ = 0;
-
-	// TODO: Save the internal state of this, now technically possible.
-	AudioDecoder *decoder_ = nullptr;
-
-	AtracStatus bufferState_ = ATRAC_STATUS_NO_DATA;
 };

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -76,7 +76,7 @@ static const int atracDecodeDelay = 2300;
 
 const int PSP_NUM_ATRAC_IDS = 6;
 static bool atracInited = true;
-static Atrac *atracContexts[PSP_NUM_ATRAC_IDS];
+static AtracBase *atracContexts[PSP_NUM_ATRAC_IDS];
 static u32 atracContextTypes[PSP_NUM_ATRAC_IDS];
 static int atracLibVersion = 0;
 static u32 atracLibCrc = 0;
@@ -119,7 +119,7 @@ void __AtracDoState(PointerWrap &p) {
 		bool valid = atracContexts[i] != nullptr;
 		Do(p, valid);
 		if (valid) {
-			Do(p, atracContexts[i]);
+			DoSubClass<AtracBase, Atrac>(p, atracContexts[i]);
 		} else {
 			delete atracContexts[i];
 			atracContexts[i] = nullptr;
@@ -136,18 +136,18 @@ void __AtracDoState(PointerWrap &p) {
 	}
 }
 
-static Atrac *getAtrac(int atracID) {
+static AtracBase *getAtrac(int atracID) {
 	if (atracID < 0 || atracID >= PSP_NUM_ATRAC_IDS) {
 		return nullptr;
 	}
-	Atrac *atrac = atracContexts[atracID];
+	AtracBase *atrac = atracContexts[atracID];
 	if (atrac) {
 		atrac->UpdateContextFromPSPMem();
 	}
 	return atrac;
 }
 
-static int createAtrac(Atrac *atrac) {
+static int createAtrac(AtracBase *atrac) {
 	for (int i = 0; i < (int)ARRAY_SIZE(atracContexts); ++i) {
 		if (atracContextTypes[i] == atrac->CodecType() && atracContexts[i] == 0) {
 			atracContexts[i] = atrac;
@@ -175,7 +175,7 @@ static u32 sceAtracGetAtracID(int codecType) {
 		return hleReportError(ME, ATRAC_ERROR_INVALID_CODECTYPE, "invalid codecType");
 	}
 
-	Atrac *atrac = new Atrac();
+	AtracBase *atrac = new Atrac();
 	atrac->track_.codecType = codecType;
 	int atracID = createAtrac(atrac);
 	if (atracID < 0) {
@@ -186,7 +186,7 @@ static u32 sceAtracGetAtracID(int codecType) {
 	return hleLogSuccessInfoI(ME, atracID);
 }
 
-static u32 AtracValidateData(const Atrac *atrac) {
+static u32 AtracValidateData(const AtracBase *atrac) {
 	if (!atrac) {
 		return hleLogError(ME, ATRAC_ERROR_BAD_ATRACID, "bad atrac ID");
 	} else if (atrac->BufferState() == ATRAC_STATUS_NO_DATA) {
@@ -196,7 +196,7 @@ static u32 AtracValidateData(const Atrac *atrac) {
 	}
 }
 
-static u32 AtracValidateManaged(const Atrac *atrac) {
+static u32 AtracValidateManaged(const AtracBase *atrac) {
 	if (!atrac) {
 		return hleLogError(ME, ATRAC_ERROR_BAD_ATRACID, "bad atrac ID");
 	} else if (atrac->BufferState() == ATRAC_STATUS_NO_DATA) {
@@ -215,7 +215,7 @@ static u32 AtracValidateManaged(const Atrac *atrac) {
 //
 // The total size of the buffer is atrac->bufferMaxSize_.
 static u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -238,7 +238,7 @@ static u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd) {
 
 // Note that outAddr being null is completely valid here, used to skip data.
 static u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 finishFlagAddr, u32 remainAddr) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -279,7 +279,7 @@ static u32 sceAtracEndEntry() {
 static u32 sceAtracGetBufferInfoForResetting(int atracID, int sample, u32 bufferInfoAddr) {
 	auto bufferInfo = PSPPointer<AtracResetBufferInfo>::Create(bufferInfoAddr);
 
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -300,7 +300,7 @@ static u32 sceAtracGetBufferInfoForResetting(int atracID, int sample, u32 buffer
 }
 
 static u32 sceAtracGetBitrate(int atracID, u32 outBitrateAddr) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -318,7 +318,7 @@ static u32 sceAtracGetBitrate(int atracID, u32 outBitrateAddr) {
 }
 
 static u32 sceAtracGetChannel(int atracID, u32 channelAddr) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -334,7 +334,7 @@ static u32 sceAtracGetChannel(int atracID, u32 channelAddr) {
 }
 
 static u32 sceAtracGetLoopStatus(int atracID, u32 loopNumAddr, u32 statusAddr) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -356,7 +356,7 @@ static u32 sceAtracGetLoopStatus(int atracID, u32 loopNumAddr, u32 statusAddr) {
 }
 
 static u32 sceAtracGetInternalErrorInfo(int atracID, u32 errorAddr) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -369,7 +369,7 @@ static u32 sceAtracGetInternalErrorInfo(int atracID, u32 errorAddr) {
 }
 
 static u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -385,7 +385,7 @@ static u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr) {
 }
 
 static u32 sceAtracGetNextDecodePosition(int atracID, u32 outposAddr) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -406,7 +406,7 @@ static u32 sceAtracGetNextDecodePosition(int atracID, u32 outposAddr) {
 }
 
 static u32 sceAtracGetNextSample(int atracID, u32 outNAddr) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -430,7 +430,7 @@ static u32 sceAtracGetNextSample(int atracID, u32 outNAddr) {
 static u32 sceAtracGetRemainFrame(int atracID, u32 remainAddr) {
 	auto remainingFrames = PSPPointer<u32_le>::Create(remainAddr);
 
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -450,7 +450,7 @@ static u32 sceAtracGetSecondBufferInfo(int atracID, u32 fileOffsetAddr, u32 desi
 	auto fileOffset = PSPPointer<u32_le>::Create(fileOffsetAddr);
 	auto desiredSize = PSPPointer<u32_le>::Create(desiredSizeAddr);
 
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -466,7 +466,7 @@ static u32 sceAtracGetSecondBufferInfo(int atracID, u32 fileOffsetAddr, u32 desi
 }
 
 static u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSampleAddr, u32 outLoopEndSampleAddr) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -493,7 +493,7 @@ static u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoop
 // such as where the data read from, where the data add to,
 // and how many bytes are allowed to add.
 static u32 sceAtracGetStreamDataInfo(int atracID, u32 writePtrAddr, u32 writableBytesAddr, u32 readOffsetAddr) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -527,7 +527,7 @@ static u32 sceAtracReleaseAtracID(int atracID) {
 // Normally, sceAtracGetBufferInfoForResetting() is called to determine how to buffer.
 // The game must add sufficient packets to the buffer in order to complete the seek.
 static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -551,7 +551,7 @@ static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFi
 }
 
 static int _AtracSetData(int atracID, u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, bool needReturnAtracID) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	// Don't use AtracValidateManaged here.
 	if (!atrac)
 		return hleLogError(ME, ATRAC_ERROR_BAD_ATRACID, "invalid atrac ID");
@@ -561,7 +561,7 @@ static int _AtracSetData(int atracID, u32 buffer, u32 readSize, u32 bufferSize, 
 }
 
 static u32 sceAtracSetHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 bufferSize) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	// Don't use AtracValidateManaged here.
 	if (!atrac) {
 		return hleLogError(ME, ATRAC_ERROR_BAD_ATRACID, "invalid atrac ID");
@@ -581,7 +581,7 @@ static u32 sceAtracSetHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 b
 }
 
 static u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBufferSize) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -592,7 +592,7 @@ static u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBuff
 }
 
 static u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	if (!atrac) {
 		return hleLogError(ME, ATRAC_ERROR_BAD_ATRACID, "bad atrac ID");
 	}
@@ -660,7 +660,7 @@ static u32 sceAtracStartEntry() {
 }
 
 static u32 sceAtracSetLoopNum(int atracID, int loopNum) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -720,7 +720,7 @@ static int sceAtracReinit(int at3Count, int at3plusCount) {
 }
 
 static int sceAtracGetOutputChannel(int atracID, u32 outputChanPtr) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateData(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -735,7 +735,7 @@ static int sceAtracGetOutputChannel(int atracID, u32 outputChanPtr) {
 }
 
 static int sceAtracIsSecondBufferNeeded(int atracID) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	u32 err = AtracValidateManaged(atrac);
 	if (err != 0) {
 		// Already logged.
@@ -748,7 +748,7 @@ static int sceAtracIsSecondBufferNeeded(int atracID) {
 }
 
 static int sceAtracSetMOutHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 bufferSize) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	// Don't use AtracValidate* here.
 	if (!atrac) {
 		return hleLogError(ME, ATRAC_ERROR_BAD_ATRACID, "bad atrac ID");
@@ -773,7 +773,7 @@ static int sceAtracSetMOutHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u
 
 // Note: This doesn't seem to be part of any available libatrac3plus library.
 static u32 sceAtracSetMOutData(int atracID, u32 buffer, u32 bufferSize) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	// Don't use AtracValidate* here.
 	if (!atrac) {
 		return hleLogError(ME, ATRAC_ERROR_BAD_ATRACID, "bad atrac ID");
@@ -857,7 +857,7 @@ static int sceAtracSetAA3DataAndGetID(u32 buffer, u32 bufferSize, u32 fileSize, 
 }
 
 static u32 _sceAtracGetContextAddress(int atracID) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	if (!atrac) {
 		ERROR_LOG(ME, "_sceAtracGetContextAddress(%i): bad atrac id", atracID);
 		return 0;
@@ -882,7 +882,7 @@ struct At3HeaderMap {
 	u16 channels;
 	u8 jointStereo;
 
-	bool Matches(const Atrac *at) const {
+	bool Matches(const AtracBase *at) const {
 		return bytes == at->GetTrack().BytesPerFrame() && channels == at->Channels();
 	}
 };
@@ -898,7 +898,7 @@ static const At3HeaderMap at3HeaderMap[] = {
 };
 
 static int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	if (!atrac) {
 		return hleLogError(ME, ATRAC_ERROR_BAD_ATRACID, "bad atrac ID");
 	}
@@ -937,7 +937,7 @@ static int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesCo
 	auto outp = PSPPointer<u8>::Create(samplesAddr);
 	auto outWritten = PSPPointer<u32_le>::Create(sampleBytesAddr);
 
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	if (!atrac) {
 		return hleLogError(ME, ATRAC_ERROR_BAD_ATRACID, "bad atrac ID");
 	}
@@ -981,14 +981,14 @@ static int sceAtracSetAA3HalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 buf
 // External interface used by sceSas' AT3 integration.
 
 u32 AtracSasAddStreamData(int atracID, u32 bufPtr, u32 bytesToAdd) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	if (!atrac)
 		return 0;
 	return atrac->AddStreamDataSas(bufPtr, bytesToAdd);
 }
 
 u32 AtracSasDecodeData(int atracID, u8* outbuf, u32 outbufPtr, u32 *SamplesNum, u32* finish, int *remains) {
-	Atrac *atrac = getAtrac(atracID);
+	AtracBase *atrac = getAtrac(atracID);
 	if (!atrac)
 		return 0;
 	return atrac->DecodeData(outbuf, outbufPtr, SamplesNum, finish, remains);

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -307,7 +307,7 @@ static u32 sceAtracGetBitrate(int atracID, u32 outBitrateAddr) {
 		return err;
 	}
 
-	atrac->UpdateBitrate();
+	atrac->GetTrackMut().UpdateBitrate();
 
 	if (Memory::IsValidAddress(outBitrateAddr)) {
 		Memory::WriteUnchecked_U32(atrac->Bitrate(), outBitrateAddr);
@@ -377,7 +377,7 @@ static u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr) {
 	}
 
 	if (Memory::IsValidAddress(maxSamplesAddr)) {
-		Memory::WriteUnchecked_U32(atrac->SamplesPerFrame(), maxSamplesAddr);
+		Memory::WriteUnchecked_U32(atrac->GetTrack().SamplesPerFrame(), maxSamplesAddr);
 		return hleLogSuccessI(ME, 0);
 	} else {
 		return hleLogError(ME, 0, "invalid address");
@@ -500,9 +500,9 @@ static u32 sceAtracGetStreamDataInfo(int atracID, u32 writePtrAddr, u32 writable
 		return err;
 	}
 
-	u32 writePtr = 0;
-	u32 writableBytes = 0;
-	u32 readOffset = 0;
+	u32 writePtr;
+	u32 writableBytes;
+	u32 readOffset;
 	atrac->GetStreamDataInfo(&writePtr, &writableBytes, &readOffset);
 
 	if (Memory::IsValidAddress(writePtrAddr))


### PR DESCRIPTION
With this, we can easily replace the whole implementation of Atrac buffering with a new one, while keeping the old implementation around. 

This will allow us to keep savestate compatibility through a future complete rewrite of the buffering logic, which hopefully will be able to fix many of the remaining Atrac issues.