### PR TITLE
Refactor: Change *outBytes to *outSamples in AudioDecoder::Decode.

### DIFF
--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -949,16 +949,17 @@ u32 Atrac::DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, i
 	if (off < first_.size) {
 		uint8_t *indata = BufferStart() + off;
 		int bytesConsumed = 0;
-		int outBytes = 0;
-		if (!decoder_->Decode(indata, track_.bytesPerFrame, &bytesConsumed, outputChannels_, outbuf, &outBytes)) {
+		int outSamples = 0;
+		if (!decoder_->Decode(indata, track_.bytesPerFrame, &bytesConsumed, outputChannels_, (int16_t *)outbuf, &outSamples)) {
 			// Decode failed.
 			*SamplesNum = 0;
 			*finish = 1;
 			return ATRAC_ERROR_ALL_DATA_DECODED;
 		}
+		int outBytes = outSamples * outputChannels_ * sizeof(int16_t);
 		gotFrame = true;
 
-		numSamples = outBytes / 4;
+		numSamples = outSamples;
 		uint32_t packetAddr = CurBufferAddress(-skipSamples);
 		// got a frame
 		int skipped = std::min((u32)skipSamples, numSamples);

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -944,7 +944,7 @@ static int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 static int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedAddr, u32 samplesAddr, u32 sampleBytesAddr) {
 	auto srcp = PSPPointer<u8>::Create(sourceAddr);
 	auto srcConsumed = PSPPointer<u32_le>::Create(sourceBytesConsumedAddr);
-	auto outp = PSPPointer<u8>::Create(samplesAddr);
+	auto outp = PSPPointer<s16>::Create(samplesAddr);
 	auto outWritten = PSPPointer<u32_le>::Create(sampleBytesAddr);
 
 	AtracBase *atrac = getAtrac(atracID);
@@ -958,8 +958,9 @@ static int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesCo
 	}
 
 	int bytesConsumed = 0;
-	int bytesWritten = 0;
-	atrac->Decoder()->Decode(srcp, atrac->GetTrack().BytesPerFrame(), &bytesConsumed, 2, outp, &bytesWritten);
+	int outSamples = 0;
+	atrac->Decoder()->Decode(srcp, atrac->GetTrack().BytesPerFrame(), &bytesConsumed, 2, outp, &outSamples);
+	int bytesWritten = outSamples * 2 * sizeof(int16_t);
 	*srcConsumed = bytesConsumed;
 	*outWritten = bytesWritten;
 

--- a/Core/HLE/sceAudiocodec.cpp
+++ b/Core/HLE/sceAudiocodec.cpp
@@ -102,7 +102,6 @@ static int sceAudiocodecDecode(u32 ctxPtr, int codec) {
 	}
 
 	if (IsValidCodec(audioType)){
-		int outbytes = 0;
 		// find a decoder in audioList
 		auto decoder = findDecoder(ctxPtr);
 
@@ -119,7 +118,8 @@ static int sceAudiocodecDecode(u32 ctxPtr, int codec) {
 			auto ctx = PSPPointer<AudioCodecContext>::Create(ctxPtr);  // On stack, no need to allocate.
 			// Decode audio
 			int inDataConsumed = 0;
-			decoder->Decode(Memory::GetPointer(ctx->inDataPtr), ctx->inDataSize, &inDataConsumed, 2, Memory::GetPointerWrite(ctx->outDataPtr), &outbytes);
+			int outSamples = 0;
+			decoder->Decode(Memory::GetPointer(ctx->inDataPtr), ctx->inDataSize, &inDataConsumed, 2, (int16_t *)Memory::GetPointerWrite(ctx->outDataPtr), &outSamples);
 		}
 		DEBUG_LOG(ME, "sceAudiocodecDec(%08x, %i (%s))", ctxPtr, codec, GetCodecName(codec));
 		return 0;

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -739,16 +739,17 @@ static u32 sceMp3LowLevelDecode(u32 mp3, u32 sourceAddr, u32 sourceBytesConsumed
 		return -1;
 	}
 
-	auto inbuff = Memory::GetPointerWriteUnchecked(sourceAddr);
-	auto outbuff = Memory::GetPointerWriteUnchecked(samplesAddr);
+	const u8 *inbuff = Memory::GetPointerWriteUnchecked(sourceAddr);
+	int16_t *outbuf = (int16_t *)Memory::GetPointerWriteUnchecked(samplesAddr);
 	
-	int outpcmbytes = 0;
+	int outSamples = 0;
 	int inbytesConsumed = 0;
-	ctx->decoder->Decode(inbuff, 4096, &inbytesConsumed, 2, outbuff, &outpcmbytes);
-	NotifyMemInfo(MemBlockFlags::WRITE, samplesAddr, outpcmbytes, "Mp3LowLevelDecode");
+	ctx->decoder->Decode(inbuff, 4096, &inbytesConsumed, 2, outbuf, &outSamples);
+	int outBytes = outSamples * sizeof(int16_t) * 2;
+	NotifyMemInfo(MemBlockFlags::WRITE, samplesAddr, outBytes, "Mp3LowLevelDecode");
 	
 	Memory::Write_U32(inbytesConsumed, sourceBytesConsumedAddr);
-	Memory::Write_U32(outpcmbytes, sampleBytesAddr);
+	Memory::Write_U32(outBytes, sampleBytesAddr);
 	return 0;
 }
 

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -1054,7 +1054,7 @@ int MediaEngine::getNextAudioFrame(u8 **buf, int *headerCode1, int *headerCode2)
 }
 
 int MediaEngine::getAudioSamples(u32 bufferPtr) {
-	u8 *buffer = Memory::GetPointerWriteRange(bufferPtr, 8192);
+	int16_t *buffer = (int16_t *)Memory::GetPointerWriteRange(bufferPtr, 8192);
 	if (buffer == nullptr) {
 		ERROR_LOG_REPORT(ME, "Ignoring bad audio decode address %08x during video playback", bufferPtr);
 	}
@@ -1068,7 +1068,7 @@ int MediaEngine::getAudioSamples(u32 bufferPtr) {
 	if (frameSize == 0) {
 		return 0;
 	}
-	int outbytes = 0;
+	int outSamples = 0;
 
 	if (m_audioContext != nullptr) {
 		if (headerCode1 == 0x24) {
@@ -1078,11 +1078,12 @@ int MediaEngine::getAudioSamples(u32 bufferPtr) {
 		}
 
 		int inbytesConsumed = 0;
-		if (!m_audioContext->Decode(audioFrame, frameSize, &inbytesConsumed, 2, buffer, &outbytes)) {
+		if (!m_audioContext->Decode(audioFrame, frameSize, &inbytesConsumed, 2, buffer, &outSamples)) {
 			ERROR_LOG(ME, "Audio (%s) decode failed during video playback", GetCodecName(m_audioType));
 		}
+		int outBytes = outSamples * sizeof(int16_t) * 2;
 
-		NotifyMemInfo(MemBlockFlags::WRITE, bufferPtr, outbytes, "VideoDecodeAudio");
+		NotifyMemInfo(MemBlockFlags::WRITE, bufferPtr, outBytes, "VideoDecodeAudio");
 	}
 
 	return 0x2000;

--- a/Core/HW/SimpleAudioDec.h
+++ b/Core/HW/SimpleAudioDec.h
@@ -37,14 +37,11 @@ public:
 	virtual PSPAudioType GetAudioType() const = 0;
 
 	// inbytesConsumed can include skipping metadata.
-	virtual bool Decode(const uint8_t *inbuf, int inbytes, int *inbytesConsumed, int outputChannels, uint8_t *outbuf, int *outbytes) = 0;
+	// outSamples is in stereo samples. So you have to multiply by 4 for 16-bit stereo audio to get bytes.
+	virtual bool Decode(const uint8_t *inbuf, int inbytes, int *inbytesConsumed, int outputChannels, int16_t *outbuf, int *outSamples) = 0;
 	virtual bool IsOK() const = 0;
 
-	// These two are only ever called after Decode, so can initialize on first.
-	virtual int GetOutSamples() const = 0;
-
 	virtual void SetChannels(int channels) = 0;
-
 	virtual void FlushBuffers() {}
 
 	// Just metadata.

--- a/UI/BackgroundAudio.cpp
+++ b/UI/BackgroundAudio.cpp
@@ -217,11 +217,12 @@ public:
 			return false;
 
 		while (bgQueue.size() < (size_t)(len * 2)) {
-			int outBytes = 0;
+			int outSamples = 0;
 			int inbytesConsumed = 0;
-			decoder_->Decode(wave_.raw_data + raw_offset_, wave_.raw_bytes_per_frame, &inbytesConsumed, 2, (uint8_t *)buffer_, &outBytes);
-			if (!outBytes)
+			bool result = decoder_->Decode(wave_.raw_data + raw_offset_, wave_.raw_bytes_per_frame, &inbytesConsumed, 2, (int16_t *)buffer_, &outSamples);
+			if (!result || !outSamples)
 				return false;
+			int outBytes = outSamples * 2 * sizeof(int16_t);
 
 			if (wave_.raw_offset_loop_end != 0 && raw_offset_ == wave_.raw_offset_loop_end) {
 				// Only take the remaining bytes, but convert to stereo s16.


### PR DESCRIPTION
This lets us delete the `GetOutSamples()` function, and it feels natural to multiply up to get in bytes when needed, than to divide down.