### PR TITLE
More sceAtrac code cleanup and comments

### DIFF
--- a/Common/Log.h
+++ b/Common/Log.h
@@ -121,6 +121,7 @@ __attribute__((format(printf, 5, 6)))
 bool HitAnyAsserts();
 void ResetHitAnyAsserts();
 void SetExtraAssertInfo(const char *info);
+void SetCleanExitOnAssert();
 
 #if defined(__ANDROID__)
 // Tricky macro to get the basename, that also works if *built* on Win32.

--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -717,7 +717,7 @@ u32 Atrac::SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) {
 	return hleLogSuccessI(ME, 0);
 }
 
-int Atrac::GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) {
+int AtracBase::GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) {
 	if (BufferState() != ATRAC_STATUS_STREAMED_LOOP_WITH_TRAILER) {
 		// Writes zeroes in this error case.
 		*fileOffset = 0;
@@ -947,6 +947,8 @@ u32 Atrac::DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, i
 	if (skipSamples != 0 && bufferHeaderSize_ == 0) {
 		// Skip the initial frame used to load state for the looped frame.
 		// TODO: We will want to actually read this in.
+		// TODO again: This seems to happen on the first frame of playback regardless of loops.
+		// Can't be good.
 		ConsumeFrame();
 	}
 

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -254,8 +254,9 @@ public:
 	virtual u32 ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) = 0;
 	virtual void GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) = 0;
 	virtual int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, int successCode) = 0;
+
+	virtual int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize);
 	virtual u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) = 0;
-	virtual int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) = 0;
 	virtual u32 DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains) = 0;
 	virtual u32 GetNextSamples() = 0;
 	virtual void InitLowLevel(u32 paramsAddr, bool jointStereo) = 0;
@@ -307,7 +308,6 @@ public:
 	void GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) override;
 	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, int successCode) override;
 	u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) override;
-	int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) override;
 	u32 DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains) override;
 	u32 GetNextSamples() override;
 	void InitLowLevel(u32 paramsAddr, bool jointStereo) override;

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -135,12 +135,6 @@ u32 Atrac2::SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) {
 	return 0;
 }
 
-int Atrac2::GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) {
-	*fileOffset = 0;
-	*desiredSize = 0;
-	return hleLogSuccessInfoI(ME, ATRAC_ERROR_SECOND_BUFFER_NOT_NEEDED, "not needed");
-}
-
 u32 Atrac2::DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains) {
 
 	return 0;

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -3,6 +3,37 @@
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/FunctionWrappers.h"
 #include "Core/HLE/AtracCtx2.h"
+#include "Core/HW/Atrac3Standalone.h"
+
+// Convenient command line:
+// Windows\x64\debug\PPSSPPHeadless.exe  --root pspautotests/tests/../ --compare --timeout=5 --new-atrac --graphics=software pspautotests/tests/audio/atrac/decode.prx
+
+// See the big comment in sceAtrac.cpp for an overview of the different modes of operation.
+//
+// Test cases
+//
+// Halfway buffer
+//
+// * None found yet
+//
+// All-data-loaded
+//
+// * MotoGP (menu music with specified loop). Simple repeated calls to sceAtracDecodeData
+// * Archer MacLean's Mercury (in-game, not menu)
+// * Crisis Core
+//
+// Streaming
+//
+// - Good ones (early)
+//   * Everybody's Golf 2 (0x2000 buffer size, loop from end)
+//   * Burnout Legends (no loop, 0x1800 buffer size)
+//   * Suicide Barbie
+// - Others
+//   * Bleach
+//   * God of War: Chains of Olympus
+//   * Ape Academy 2 (bufsize 8192)
+//   * Half Minute Hero (bufsize 65536)
+//   * Flatout (tricky! needs investigation)
 
 void Atrac2::DoState(PointerWrap &p) {
 	_assert_msg_(false, "Savestates not yet support with new Atrac implementation.\n\nTurn it off in Developer settings.\n\n");
@@ -28,14 +59,14 @@ void Atrac2::WriteContextToPSPMem() {
 	// TODO: Should we just keep this in PSP ram then, or something?
 	context->info.state = bufferState_;
 	if (track_.firstSampleOffset != 0) {
-		context->info.samplesPerChan = track_.firstSampleOffset + FirstOffsetExtra();
+		context->info.samplesPerChan = track_.FirstSampleOffsetFull();
 	} else {
 		context->info.samplesPerChan = (track_.codecType == PSP_MODE_AT_3_PLUS ? ATRAC3PLUS_MAX_SAMPLES : ATRAC3_MAX_SAMPLES);
 	}
 	context->info.sampleSize = track_.bytesPerFrame;
 	context->info.numChan = track_.channels;
-	context->info.dataOff = track_.dataOff;
-	context->info.endSample = track_.endSample + track_.firstSampleOffset + FirstOffsetExtra();
+	context->info.dataOff = track_.dataByteOffset;
+	context->info.endSample = track_.endSample + track_.FirstSampleOffsetFull();
 	context->info.dataEnd = track_.fileSize;
 	context->info.curOff = 0; // first_.fileoffset;
 	context->info.decodePos = track_.DecodePosBySample(currentSample_);
@@ -81,10 +112,6 @@ int Atrac2::AddStreamData(u32 bytesToAdd) {
 
 u32 Atrac2::AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) {
 	return 0;
-}
-
-void Atrac2::SetLoopNum(int loopNum) {
-
 }
 
 u32 Atrac2::ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) {
@@ -137,7 +164,7 @@ void Atrac2::InitLowLevel(u32 paramsAddr, bool jointStereo) {
 		track_.bitrate = ((track_.bitrate >> 11) + 8) & 0xFFFFFFF0;
 		track_.jointStereo = false;
 	}
-	track_.dataOff = 0;
+	track_.dataByteOffset = 0;
 	bufferState_ = ATRAC_STATUS_LOW_LEVEL;
 	currentSample_ = 0;
 	CreateDecoder();

--- a/Core/HLE/AtracCtx2.h
+++ b/Core/HLE/AtracCtx2.h
@@ -15,7 +15,6 @@ public:
 
 	int CurrentSample() const override { return currentSample_; }
 	int RemainingFrames() const override;
-	u32 SecondBufferSize() const override;
 
 	void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) override;
 	int AddStreamData(u32 bytesToAdd) override;
@@ -24,7 +23,8 @@ public:
 	void GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) override;
 	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, int successCode) override;
 	u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) override;
-	int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) override;
+	u32 SecondBufferSize() const override;
+
 	u32 DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains) override;
 	u32 GetNextSamples() override;
 	void InitLowLevel(u32 paramsAddr, bool jointStereo) override;

--- a/Core/HLE/AtracCtx2.h
+++ b/Core/HLE/AtracCtx2.h
@@ -20,7 +20,6 @@ public:
 	void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) override;
 	int AddStreamData(u32 bytesToAdd) override;
 	u32 AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) override;
-	void SetLoopNum(int loopNum) override;
 	u32 ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) override;
 	void GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) override;
 	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, int successCode) override;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -405,7 +405,7 @@ static u32 sceAtracGetNextDecodePosition(int atracID, u32 outposAddr) {
 	if (Memory::IsValidAddress(outposAddr)) {
 		if (atrac->CurrentSample() >= atrac->GetTrack().endSample) {
 			Memory::WriteUnchecked_U32(0, outposAddr);
-			return hleLogSuccessI(ME, ATRAC_ERROR_ALL_DATA_DECODED, "all data decoded");
+			return hleLogSuccessI(ME, ATRAC_ERROR_ALL_DATA_DECODED, "all data decoded - beyond endSample");
 		} else {
 			Memory::WriteUnchecked_U32(atrac->CurrentSample(), outposAddr);
 			return hleLogSuccessI(ME, 0);
@@ -488,10 +488,10 @@ static u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoop
 		*outEndSample = atrac->GetTrack().endSample;
 	auto outLoopStart = PSPPointer<u32_le>::Create(outLoopStartSampleAddr);
 	if (outLoopStart.IsValid())
-		*outLoopStart = atrac->GetTrack().loopStartSample == -1 ? -1 : atrac->GetTrack().loopStartSample - atrac->GetTrack().firstSampleOffset - atrac->FirstOffsetExtra();
+		*outLoopStart = atrac->GetTrack().loopStartSample == -1 ? -1 : atrac->GetTrack().loopStartSample - atrac->GetTrack().FirstSampleOffsetFull();
 	auto outLoopEnd = PSPPointer<u32_le>::Create(outLoopEndSampleAddr);
 	if (outLoopEnd.IsValid())
-		*outLoopEnd = atrac->GetTrack().loopEndSample == -1 ? -1 : atrac->GetTrack().loopEndSample - atrac->GetTrack().firstSampleOffset - atrac->FirstOffsetExtra();
+		*outLoopEnd = atrac->GetTrack().loopEndSample == -1 ? -1 : atrac->GetTrack().loopEndSample - atrac->GetTrack().FirstSampleOffsetFull();
 
 	if (!outEndSample.IsValid() || !outLoopStart.IsValid() || !outLoopEnd.IsValid()) {
 		return hleReportError(ME, 0, "invalid address");

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -319,6 +319,7 @@ int main(int argc, const char* argv[])
 {
 	PROFILE_INIT();
 #if PPSSPP_PLATFORM(WINDOWS)
+	SetCleanExitOnAssert();
 	timeBeginPeriod(1);
 #else
 	// Ignore sigpipe.

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -339,6 +339,7 @@ int main(int argc, const char* argv[])
 	GPUCore gpuCore = GPUCORE_SOFTWARE;
 	CPUCore cpuCore = CPUCore::JIT;
 	int debuggerPort = -1;
+	bool newAtrac = false;
 
 	std::vector<std::string> testFilenames;
 	const char *mountIso = nullptr;
@@ -375,6 +376,8 @@ int main(int argc, const char* argv[])
 			testOptions.bench = true;
 		else if (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--verbose"))
 			testOptions.verbose = true;
+		else if (!strcmp(argv[i], "--new-atrac"))
+			newAtrac = true;
 		else if (!strncmp(argv[i], "--graphics=", strlen("--graphics=")) && strlen(argv[i]) > strlen("--graphics="))
 		{
 			const char *gpuName = argv[i] + strlen("--graphics=");
@@ -498,6 +501,7 @@ int main(int argc, const char* argv[])
 	g_Config.iGlobalVolume = VOLUME_FULL;
 	g_Config.iReverbVolume = VOLUME_FULL;
 	g_Config.internalDataDirectory.clear();
+	g_Config.bUseNewAtrac = newAtrac;
 
 	Path exePath = File::GetExeDirectory();
 	g_Config.flash0Directory = exePath / "assets/flash0";


### PR DESCRIPTION
I started to re-implement AtracCtx, but after understanding things better, decided to instead start by backporting some of the findings and comments I've made to the old code. See especially AtracCtx.h. Once done, I'm going to start over with the re-implementation, which will be more based on the existing code than my first try.

There are some strange inconsistencies in how FirstOffsetExtra() is applied, but nearly all uses could be merged into adding/subtracting firstSampleOffset, so made a convenient function for that.

Also, this improves the behavior of asserts in the headless build (that we use to run PSP autotests) on Windows.