### PR TITLE
iOS: Update VulkanLoader for MoltenVK 1.2.8-style framework finding

### DIFF
--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -282,6 +282,7 @@ static const char * const device_name_blacklist[] = {
 static const char * const so_names[] = {
 #if PPSSPP_PLATFORM(IOS)
 	"@executable_path/Frameworks/libMoltenVK.dylib",
+	"MoltenVK",
 #elif PPSSPP_PLATFORM(MAC)
 	"@executable_path/../Frameworks/libMoltenVK.dylib",
 #else


### PR DESCRIPTION
The MoltenVK 1.2.8 docs recommend adding "one or both" of 
> @executable_path/Frameworks
> @executable_path/Frameworks/MoltenVK.framework

This change assumes both.