### PR TITLE
Refactor atlas/zimtool CMakeLists.txt

### DIFF
--- a/ext/libpng17/CMakeLists.txt
+++ b/ext/libpng17/CMakeLists.txt
@@ -1,6 +1,7 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.8)
+project(libpng17)
 
-add_library(png17 
+add_library(png17 STATIC
 	pngconf.h
 	pngdebug.h
 	png.c
@@ -18,9 +19,24 @@ add_library(png17
 	pngrutil.c
 	pngset.c
 	pngstruct.h
-	pngtest.c
 	pngtrans.c
 	pngwio.c
 	pngwrite.c
 	pngwtran.c
-	pngwutil.c)
+	pngwutil.c
+)
+
+# Add arm files for ARM processors
+if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm(64)?|aarch64")
+	set (ARM_FILES arm/arm_init.c
+	)
+
+	# Check if it's 32 bit
+	if("${CMAKE_SIZEOF_VOID_P}" EQUAL 4)
+		list(APPEND ARM_FILES arm/filter_neon.S)
+	else()
+		list(APPEND ARM_FILES arm/filter_neon_intrinsics.c)
+	endif()
+
+	target_sources(png17 PRIVATE ${ARM_FILES})
+endif()

--- a/ext/libpng17/CMakeLists.txt
+++ b/ext/libpng17/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(png17 STATIC
 	pngrutil.c
 	pngset.c
 	pngstruct.h
+	pngtest.c
 	pngtrans.c
 	pngwio.c
 	pngwrite.c

--- a/ext/native/tools/CMakeLists.txt
+++ b/ext/native/tools/CMakeLists.txt
@@ -1,44 +1,42 @@
-cmake_minimum_required(VERSION 2.6)
-
+cmake_minimum_required(VERSION 3.8)
 project (Tools)
 
-add_definitions(-O2)
-add_definitions(-Wall)
-add_definitions(-DSDL)
-add_definitions(-Wno-multichar)
-add_definitions(-fno-strict-aliasing)
-#add_definitions(-fopenmp)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+add_compile_definitions(SDL MAX_LOGLEVEL=-1)
+add_compile_options(-O2 -Wall -Wno-multichar -fno-strict-aliasing)
+
+# Obsolete code?
 if(IOS)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++ -DMAX_LOGLEVEL=-1")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
 elseif(APPLE)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -mmacosx-version-min=10.7 -DMAX_LOGLEVEL=-1")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -mmacosx-version-min=10.7")
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.7.0)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -DMAX_LOGLEVEL=-1")
-else()
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -DMAX_LOGLEVEL=-1")
-endif()
+# Find dependencies
+find_package(Freetype REQUIRED)
+find_package(ZLIB REQUIRED)
+find_library(UTIL util REQUIRED)
+find_library(ZSTD zstd REQUIRED)
 
-# add_definitions(-fstrict-aliasing)
-
-include_directories(..)
-include_directories(../..)
-include_directories(../../..)
-
-link_directories(/opt/local/lib)
-
-# Horrible horrible hack
-include_directories(/usr/include/freetype2)
-include_directories(/usr/local/include/freetype2)
-include_directories(/opt/local/include/freetype2)
-include_directories(/opt/local/include)
+include_directories(${FREETYPE_INCLUDE_DIRS}
+	../
+	../../
+	../../../
+)
 
 add_subdirectory(../../libpng17 png17)
 
-add_executable(build/atlastool atlastool.cpp ../../../Common/Data/Format/PNGLoad.cpp ../../../Common/Data/Encoding/Utf8.cpp ../../../Common/Data/Format/ZIMSave.cpp)
-target_link_libraries(build/atlastool freetype util png17 z zstd)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build)
 
-add_executable(build/zimtool zimtool.cpp ../../../Common/Data/Format/PNGLoad.cpp ../../../Common/Data/Format/ZIMSave.cpp)
-target_link_libraries(build/zimtool freetype util png17 z zstd)
+set(COMMON_FILES
+	../../../Common/Data/Format/PNGLoad.cpp
+	../../../Common/Data/Format/ZIMSave.cpp
+)
+
+# Both executables are linked to the same libraries
+link_libraries(${FREETYPE_LIBRARIES} ${UTIL} png17 ${ZLIB_LIBRARIES} ${ZSTD})
+
+add_executable(atlastool atlastool.cpp ../../../Common/Data/Encoding/Utf8.cpp ${COMMON_FILES})
+add_executable(zimtool zimtool.cpp ${COMMON_FILES})

--- a/ext/native/tools/CMakeLists.txt
+++ b/ext/native/tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project (Tools)
+project(Tools)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Setting C++ standard to C++ fixes this error:
```
In file included from /home/ppsspp/Common/Data/Encoding/Utf8.cpp:30:
/home/ppsspp/ext/native/tools/../../../Common/Data/Encoding/Utf8.h:36:28: error: ‘string_view’ is not a member of ‘std’
   36 | bool AnyEmojiInString(std::string_view str, size_t byteCount);
      |                            ^~~~~~~~~~~
/home/ppsspp/ext/native/tools/../../../Common/Data/Encoding/Utf8.h:36:28: note: ‘std::string_view’ is only available from C++17 onwards
```