### PR TITLE
Add ability to limit PathBrowser to a specific root folder

### DIFF
--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -240,6 +240,9 @@ bool Path::FilePathContainsNoCase(std::string_view needle) const {
 }
 
 bool Path::StartsWith(const Path &other) const {
+	if (other.empty()) {
+		return true;
+	}
 	if (type_ != other.type_) {
 		// Bad
 		return false;

--- a/Common/File/PathBrowser.h
+++ b/Common/File/PathBrowser.h
@@ -8,7 +8,6 @@
 #include <vector>
 #include <cstdlib>
 
-
 #include "Common/File/DirListing.h"
 #include "Common/File/Path.h"
 
@@ -18,7 +17,6 @@
 class PathBrowser {
 public:
 	PathBrowser() {}
-	PathBrowser(const Path &path) { SetPath(path); }
 	~PathBrowser();
 
 	void SetPath(const Path &path);
@@ -41,11 +39,11 @@ public:
 	void SetUserAgent(const std::string &s) {
 		userAgent_ = s;
 	}
-	void SetRootAlias(const std::string &alias, const std::string &longValue) {
+	void SetRootAlias(const std::string &alias, const Path &rootPath) {
 		aliasDisplay_ = alias;
-		aliasMatch_ = longValue;
+		aliasMatch_ = rootPath;
 	}
-
+	void RestrictToRoot(const Path &root);
 	bool empty() const {
 		return path_.empty();
 	}
@@ -53,12 +51,14 @@ public:
 private:
 	void HandlePath();
 	void ResetPending();
+	void ApplyRestriction();
 
 	Path path_;
 	Path pendingPath_;
+	Path restrictedRoot_;
 	std::string userAgent_;
 	std::string aliasDisplay_;
-	std::string aliasMatch_;
+	Path aliasMatch_;
 	std::vector<File::FileInfo> pendingFiles_;
 	std::condition_variable pendingCond_;
 	std::mutex pendingLock_;

--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -193,6 +193,10 @@ enum SystemProperty {
 
 	SYSPROP_USER_DOCUMENTS_DIR,
 
+	// iOS app store limitation: The documents directory should be the only browsable directory.
+	// We'll not return true for this in non-app-store builds.
+	SYSPROP_LIMITED_FILE_BROWSING,
+
 	SYSPROP_OK_BUTTON_LEFT,
 
 	SYSPROP_MAIN_WINDOW_HANDLE,

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1227,6 +1227,13 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 		ResetControlLayout();
 	}
 
+	// Force JIT setting to a valid value for the current system configuration.
+	if (!System_GetPropertyBool(SYSPROP_CAN_JIT)) {
+		if (g_Config.iCpuCore == (int)CPUCore::JIT || g_Config.iCpuCore == (int)CPUCore::JIT_IR) {
+			g_Config.iCpuCore = (int)CPUCore::IR_INTERPRETER;
+		}
+	}
+
 	const char *gitVer = PPSSPP_GIT_VERSION;
 	Version installed(gitVer);
 	Version upgrade(upgradeVersion);

--- a/Core/KeyMapDefaults.cpp
+++ b/Core/KeyMapDefaults.cpp
@@ -352,7 +352,7 @@ void SetDefaultKeyMap(DefaultMaps dmap, bool replace) {
 	switch (dmap) {
 	case DEFAULT_MAPPING_KEYBOARD:
 	{
-		int keyboardLayout = System_GetPropertyInt(SYSPROP_KEYBOARD_LAYOUT);
+		int keyboardLayout = (int)System_GetPropertyInt(SYSPROP_KEYBOARD_LAYOUT);
 		switch (keyboardLayout) {
 		case KEYBOARD_LAYOUT_QWERTZ:
 			SetDefaultKeyMap(DEVICE_ID_KEYBOARD, defaultQwertzKeyboardKeyMap, ARRAY_SIZE(defaultQwertzKeyboardKeyMap), replace);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1755,7 +1755,7 @@ void DeveloperToolsScreen::CreateViews() {
 
 	list->Add(new ItemHeader(sy->T("General")));
 
-	bool canUseJit = true;
+	bool canUseJit = System_GetPropertyBool(SYSPROP_CAN_JIT);
 	// iOS can now use JIT on all modes, apparently.
 	// The bool may come in handy for future non-jit platforms though (UWP XB1?)
 

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -510,10 +510,14 @@ void DirButton::Draw(UIContext &dc) {
 }
 
 GameBrowser::GameBrowser(int token, const Path &path, BrowseFlags browseFlags, bool *gridStyle, ScreenManager *screenManager, std::string_view lastText, std::string_view lastLink, UI::LayoutParams *layoutParams)
-	: LinearLayout(UI::ORIENT_VERTICAL, layoutParams), path_(path), gridStyle_(gridStyle), browseFlags_(browseFlags), lastText_(lastText), lastLink_(lastLink), screenManager_(screenManager), token_(token) {
+	: LinearLayout(UI::ORIENT_VERTICAL, layoutParams), gridStyle_(gridStyle), browseFlags_(browseFlags), lastText_(lastText), lastLink_(lastLink), screenManager_(screenManager), token_(token) {
 	using namespace UI;
 	path_.SetUserAgent(StringFromFormat("PPSSPP/%s", PPSSPP_GIT_VERSION));
-	path_.SetRootAlias("ms:", GetSysDirectory(DIRECTORY_MEMSTICK_ROOT).ToVisualString() + "/");
+	path_.SetRootAlias("ms:", GetSysDirectory(DIRECTORY_MEMSTICK_ROOT));
+	if (System_GetPropertyBool(SYSPROP_LIMITED_FILE_BROWSING)) {
+		path_.RestrictToRoot(GetSysDirectory(DIRECTORY_MEMSTICK_ROOT));
+	}
+	path_.SetPath(path);
 	Refresh();
 }
 

--- a/UI/RemoteISOScreen.cpp
+++ b/UI/RemoteISOScreen.cpp
@@ -253,10 +253,11 @@ bool RemoteISOConnectScreen::FindServer(std::string &resultHost, int &resultPort
 }
 
 static bool LoadGameList(const Path &url, std::vector<Path> &games) {
-	PathBrowser browser(url);
+	PathBrowser browser;
+	browser.SetPath(url);
 	std::vector<File::FileInfo> files;
 	browser.SetUserAgent(StringFromFormat("PPSSPP/%s", PPSSPP_GIT_VERSION));
-	browser.SetRootAlias("ms:", GetSysDirectory(DIRECTORY_MEMSTICK_ROOT).ToVisualString() + "/");
+	browser.SetRootAlias("ms:", GetSysDirectory(DIRECTORY_MEMSTICK_ROOT));
 	browser.GetListing(files, "iso:cso:chd:pbp:elf:prx:ppdmp:", &scanCancelled);
 	if (scanCancelled) {
 		return false;

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -349,6 +349,8 @@ bool System_GetPropertyBool(SystemProperty prop) {
 #endif
 		case SYSPROP_CAN_JIT:
 			return g_jitAvailable;
+		case SYSPROP_LIMITED_FILE_BROWSING:
+			return false;  // But will return true in app store builds.
 #ifndef HTTPS_NOT_AVAILABLE
 		case SYSPROP_SUPPORTS_HTTPS:
 			return true;


### PR DESCRIPTION
Not yet used, but this ability will be required on iOS to have a chance of passing review.

Also, sneak in a bunch of smaller code cleanups.