### PR TITLE
macOS: Update VulkanLoader for MoltenVK 1.2.8-style framework finding

### DIFF
--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -285,6 +285,7 @@ static const char * const so_names[] = {
 	"MoltenVK",
 #elif PPSSPP_PLATFORM(MAC)
 	"@executable_path/../Frameworks/libMoltenVK.dylib",
+	"MoltenVK",
 #else
 	"libvulkan.so",
 #if !defined(__ANDROID__)


### PR DESCRIPTION
Similar to https://github.com/hrydgard/ppsspp/pull/19079, RetroArch now includes MoltenVK as a framework instead of just a dylib.