### PR TITLE
Minor IR interpreter optimizations

### DIFF
--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -1138,12 +1138,13 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst, int count) {
 			// Unimplemented IR op. Bad.
 			Crash();
 		}
-#ifdef _DEBUG
-		if (mips->r[0] != 0)
-			Crash();
-#endif
 		inst++;
 	}
+
+#ifdef _DEBUG
+	if (mips->r[0] != 0)
+		Crash();
+#endif
 
 	// We hit count.  If this is a full block, it was badly constructed.
 	return 0;

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -250,8 +250,7 @@ void IRJit::RunLoopUntil(u64 globalticks) {
 			u32 inst = Memory::ReadUnchecked_U32(mips_->pc);
 			u32 opcode = inst & 0xFF000000;
 			if (opcode == MIPS_EMUHACK_OPCODE) {
-				u32 data = inst & 0xFFFFFF;
-				IRBlock *block = blocks_.GetBlock(data);
+				IRBlock *block = blocks_.GetBlockUnchecked(inst & 0xFFFFFF);
 				u32 startPC = mips_->pc;
 				mips_->pc = IRInterpret(mips_, block->GetInstructions(), block->GetNumInstructions());
 				// Note: this will "jump to zero" on a badly constructed block missing exits.

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -127,6 +127,9 @@ public:
 			return nullptr;
 		}
 	}
+	IRBlock *GetBlockUnchecked(int i) {
+		return &blocks_[i];
+	}
 	const IRBlock *GetBlock(int i) const {
 		if (i >= 0 && i < (int)blocks_.size()) {
 			return &blocks_[i];

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -621,8 +621,9 @@ namespace MIPSInt
 			break;
 		default:
 			ApplySwizzleS(s, sz);
+			break;
 		}
-		for (int i = 0; i < n; i++) {
+		for (int i = 0; i < (int)n; i++) {
 			switch (optype) {
 			case 0: d[i] = s[i]; break; //vmov
 			case 1: d[i] = s[i]; break; //vabs (prefix)


### PR DESCRIPTION
Remove some special cases that didn't cause better codegen. 

Don't bother checking the block index since we didn't check the return value anyway.