### PR TITLE
Don't enable the Mali "never" workaround on all GPUs (oops). Minor fixes.

### DIFF
--- a/Common/GPU/Vulkan/VulkanRenderManager.h
+++ b/Common/GPU/Vulkan/VulkanRenderManager.h
@@ -533,6 +533,10 @@ public:
 	void StartThreads();
 	void StopThreads();
 
+	size_t GetNumSteps() const {
+		return steps_.size();
+	}
+
 private:
 	void EndCurRenderStep();
 

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -380,6 +380,13 @@ public:
 	VKContext(VulkanContext *vulkan, bool useRenderThread);
 	~VKContext();
 
+	BackendState GetCurrentBackendState() const override {
+		return BackendState{
+			(u32)renderManager_.GetNumSteps(),
+			true,
+		};
+	}
+
 	void DebugAnnotate(const char *annotation) override;
 	void Wait() override {
 		vkDeviceWaitIdle(vulkan_->GetDevice());

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1054,8 +1054,6 @@ VKContext::VKContext(VulkanContext *vulkan, bool useRenderThread)
 		INFO_LOG(G3D, "KHR_depth_stencil_resolve not supported, disabling multisampling");
 	}
 
-	bugs_.Infest(Draw::Bugs::NO_DEPTH_CANNOT_DISCARD_STENCIL_MALI);
-
 	// We limit multisampling functionality to reasonably recent and known-good tiling GPUs.
 	if (multisampleAllowed) {
 		// Check for depth stencil resolve. Without it, depth textures won't work, and we don't want that mess

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -687,6 +687,11 @@ enum class DebugFlags {
 };
 ENUM_CLASS_BITOPS(DebugFlags);
 
+struct BackendState {
+	u32 passes;
+	bool valid;
+};
+
 class DrawContext {
 public:
 	virtual ~DrawContext();
@@ -704,6 +709,10 @@ public:
 	virtual std::vector<std::string> GetDeviceList() const { return std::vector<std::string>(); }
 	virtual std::vector<std::string> GetPresentModeList(std::string_view currentMarkerString) const { return std::vector<std::string>(); }
 	virtual std::vector<std::string> GetSurfaceFormatList() const { return std::vector<std::string>(); }
+
+	virtual BackendState GetCurrentBackendState() const {
+		return BackendState{};
+	}
 
 	// Describes the primary shader language that this implementation prefers.
 	const ShaderLanguageDesc &GetShaderLanguageDesc() {

--- a/Common/UI/Screen.cpp
+++ b/Common/UI/Screen.cpp
@@ -187,7 +187,8 @@ ScreenRenderFlags ScreenManager::render() {
 		bool first = true;
 		do {
 			--iter;
-			if (!foundBackgroundScreen && iter->screen->canBeBackground(first)) {
+			ScreenRenderRole role = iter->screen->renderRole(first);
+			if (!foundBackgroundScreen && (role & ScreenRenderRole::CAN_BE_BACKGROUND)) {
 				// There still might be a screen that wants to be background - generally the EmuScreen if present.
 				layers.push_back(iter->screen);
 				foundBackgroundScreen = iter->screen;
@@ -198,6 +199,9 @@ ScreenRenderFlags ScreenManager::render() {
 				coveringScreen = iter->screen;
 			}
 			first = false;
+			if (role & ScreenRenderRole::MUST_BE_FIRST) {
+				break;
+			}
 		} while (iter != stack_.begin());
 
 		if (backgroundScreen_ && !foundBackgroundScreen) {

--- a/Common/UI/Screen.h
+++ b/Common/UI/Screen.h
@@ -61,6 +61,14 @@ enum class ScreenRenderFlags {
 };
 ENUM_CLASS_BITOPS(ScreenRenderFlags);
 
+
+enum class ScreenRenderRole {
+	NONE = 0,
+	CAN_BE_BACKGROUND = 1,
+	MUST_BE_FIRST = 2,
+};
+ENUM_CLASS_BITOPS(ScreenRenderRole);
+
 class Screen {
 public:
 	Screen() : screenManager_(nullptr) { }
@@ -74,7 +82,7 @@ public:
 	virtual void sendMessage(UIMessage message, const char *value) {}
 	virtual void deviceLost() {}
 	virtual void deviceRestored() {}
-	virtual bool canBeBackground(bool isTop) const { return false; }
+	virtual ScreenRenderRole renderRole(bool isTop) const { return ScreenRenderRole::NONE; }
 	virtual bool wantBrightBackground() const { return false; }  // special hack for DisplayLayoutScreen.
 
 	virtual void focusChanged(ScreenFocusChange focusChange);

--- a/GPU/Common/VertexDecoderHandwritten.cpp
+++ b/GPU/Common/VertexDecoderHandwritten.cpp
@@ -84,12 +84,12 @@ void VtxDec_Tu16_C8888_Pfloat(const u8 *srcp, u8 *dstp, int count, const UVScale
 		float32x2_t finalUV = vadd_f32(vmul_f32(vcvt_f32_u32(fuv), uvScale), uvOff);
 		u32 normal = src[i].packed_normal;
 		uint32x4_t colpos = vld1q_u32((const u32 *)&src[i].col);
-        alphaMask = vandq_u32(alphaMask, colpos);
+		alphaMask = vandq_u32(alphaMask, colpos);
 		vst1_f32(&dst[i].u, finalUV);
 		dst[i].packed_normal = normal;
 		vst1q_u32(&dst[i].col, colpos);
 	}
-    alpha = vgetq_lane_u32(alphaMask, 0);
+	alpha = vgetq_lane_u32(alphaMask, 0);
 #else
 	for (int i = 0; i < count; i++) {
 		float u = src[i].u * uscale + uoff;

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -46,7 +46,7 @@ public:
 	void dialogFinished(const Screen *dialog, DialogResult result) override;
 	void sendMessage(UIMessage message, const char *value) override;
 	void resized() override;
-	bool canBeBackground(bool isTop) const override;
+	ScreenRenderRole renderRole(bool isTop) const override;
 
 	// Note: Unlike your average boring UIScreen, here we override the Unsync* functions
 	// to get minimal latency and full control. We forward to UIScreen when needed.


### PR DESCRIPTION
* Revert an accidental enabling of the Mali workaround from #18813 on all GPUs. Might help #19133 
* Code formatting fix
* Fix a crash when bringing up the dev menu with certain setting combinations