### PR TITLE
iOS: Fix threading issue, add back gesture

### DIFF
--- a/ios/ViewController.h
+++ b/ios/ViewController.h
@@ -10,7 +10,7 @@
 #import "LocationHelper.h"
 
 @interface ViewController : GLKViewController <iCadeEventDelegate,
-            LocationHandlerDelegate, CameraFrameDelegate>
+            LocationHandlerDelegate, CameraFrameDelegate, UIGestureRecognizerDelegate>
 
 - (void)shareText:(NSString *)text;
 - (void)shutdown;

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -197,7 +197,7 @@ extern float g_safeInsetBottom;
 	view.drawableDepthFormat = GLKViewDrawableDepthFormat24;
 	view.drawableStencilFormat = GLKViewDrawableStencilFormat8;
 	[EAGLContext setCurrentContext:self.context];
-	self.preferredFramesPerSecond = 60;
+	self.preferredFramesPerSecond = 60;  // NOTE: We don't yet take advantage of 120hz screens
 
 	[[DisplayManager shared] updateResolution:[UIScreen mainScreen]];
 
@@ -238,7 +238,6 @@ extern float g_safeInsetBottom;
 		while (threadEnabled) {
 			NativeFrame(graphicsContext);
 		}
-
 
 		INFO_LOG(SYSTEM, "Emulation thread shutting down\n");
 		NativeShutdownGraphics();
@@ -752,7 +751,10 @@ void stopLocation() {
 
 void System_LaunchUrl(LaunchUrlType urlType, char const* url)
 {
-	[[UIApplication sharedApplication] openURL:[NSURL URLWithString:[NSString stringWithCString:url encoding:NSStringEncodingConversionAllowLossy]]];
+	NSURL *nsUrl = [NSURL URLWithString:[NSString stringWithCString:url encoding:NSStringEncodingConversionAllowLossy]];
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[[UIApplication sharedApplication] openURL:nsUrl] options:@{} completionHandler:nil];
+	});
 }
 
 void bindDefaultFBO()

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -192,6 +192,12 @@ extern float g_safeInsetBottom;
 		self.context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
 	}
 
+    UISwipeGestureRecognizer *mSwipeLeftRecognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFrom:)];
+
+    [mSwipeLeftRecognizer setDirection:(UISwipeGestureRecognizerDirectionLeft | UISwipeGestureRecognizerDirectionRight)];
+
+    [[self view] addGestureRecognizer:mSwipeLeftRecognizer];
+    
 	GLKView* view = (GLKView *)self.view;
 	view.context = self.context;
 	view.drawableDepthFormat = GLKViewDrawableDepthFormat24;
@@ -248,6 +254,17 @@ extern float g_safeInsetBottom;
 
 		threadStopped = true;
 	});
+}
+
+- (void)handleSwipeFrom:(UISwipeGestureRecognizer *)recognizer
+{
+    if (recognizer.direction == UISwipeGestureRecognizerDirectionLeft) {
+        INFO_LOG(SYSTEM, "LEFT");
+    } else if (recognizer.direction == UISwipeGestureRecognizerDirectionRight) {
+        INFO_LOG(SYSTEM, "RIGHT");
+    } else {
+        INFO_LOG(SYSTEM, "OTHER SWIPE: %d", (int)recognizer.direction);
+    }
 }
 
 - (void)appWillTerminate:(NSNotification *)notification
@@ -753,7 +770,7 @@ void System_LaunchUrl(LaunchUrlType urlType, char const* url)
 {
 	NSURL *nsUrl = [NSURL URLWithString:[NSString stringWithCString:url encoding:NSStringEncodingConversionAllowLossy]];
 	dispatch_async(dispatch_get_main_queue(), ^{
-		[[UIApplication sharedApplication] openURL:nsUrl] options:@{} completionHandler:nil];
+		[[UIApplication sharedApplication] openURL:nsUrl options:@{} completionHandler:nil];
 	});
 }
 

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -192,12 +192,10 @@ extern float g_safeInsetBottom;
 		self.context = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
 	}
 
-    UISwipeGestureRecognizer *mSwipeLeftRecognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFrom:)];
+	UIScreenEdgePanGestureRecognizer *mBackGestureRecognizer = [[UIScreenEdgePanGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFrom:) ];
+	[mBackGestureRecognizer setEdges:UIRectEdgeLeft];
+	[[self view] addGestureRecognizer:mBackGestureRecognizer];
 
-    [mSwipeLeftRecognizer setDirection:(UISwipeGestureRecognizerDirectionLeft | UISwipeGestureRecognizerDirectionRight)];
-
-    [[self view] addGestureRecognizer:mSwipeLeftRecognizer];
-    
 	GLKView* view = (GLKView *)self.view;
 	view.context = self.context;
 	view.drawableDepthFormat = GLKViewDrawableDepthFormat24;
@@ -256,15 +254,16 @@ extern float g_safeInsetBottom;
 	});
 }
 
-- (void)handleSwipeFrom:(UISwipeGestureRecognizer *)recognizer
+- (void)handleSwipeFrom:(UIScreenEdgePanGestureRecognizer *)recognizer
 {
-    if (recognizer.direction == UISwipeGestureRecognizerDirectionLeft) {
-        INFO_LOG(SYSTEM, "LEFT");
-    } else if (recognizer.direction == UISwipeGestureRecognizerDirectionRight) {
-        INFO_LOG(SYSTEM, "RIGHT");
-    } else {
-        INFO_LOG(SYSTEM, "OTHER SWIPE: %d", (int)recognizer.direction);
-    }
+	if (recognizer.state == UIGestureRecognizerStateEnded) {
+		KeyInput key;
+		key.flags = KEY_DOWN | KEY_UP;
+		key.keyCode = NKCODE_BACK;
+		key.deviceId = DEVICE_ID_TOUCH;
+		NativeKey(key);
+		INFO_LOG(SYSTEM, "Detected back swipe");
+	}
 }
 
 - (void)appWillTerminate:(NSNotification *)notification

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -560,3 +560,4 @@ int main(int argc, char *argv[])
 		return UIApplicationMain(argc, argv, NSStringFromClass([PPSSPPUIApplication class]), NSStringFromClass([AppDelegate class]));
 	}
 }
+

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -437,6 +437,16 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 		[sharedViewController shareText:text];
 		return true;
 	}
+/*
+	// Not 100% sure the threading is right
+	case SystemRequestType::COPY_TO_CLIPBOARD:
+	{
+		@autoreleasepool {
+			[UIPasteboard generalPasteboard].string = @(param1.c_str());
+			return 0;
+		}
+	}
+*/
 	case SystemRequestType::SET_KEEP_SCREEN_BRIGHT:
         dispatch_async(dispatch_get_main_queue(), ^{
             INFO_LOG(SYSTEM, "SET_KEEP_SCREEN_BRIGHT: %d", (int)param3);


### PR DESCRIPTION
You can now go back in menus or pause the game by swiping from the left edge. Hope it won't be too easy to trigger on accident, or I might have to add an option. Was suggested by a Discord user or here on Github, can't remember. But a good escape route if touch controls are not visible, for example.