### PR TITLE
Change UI event notifications (used for soft-keyboard in UWP mode) from strings to enums

### DIFF
--- a/Common/System/Request.h
+++ b/Common/System/Request.h
@@ -160,8 +160,8 @@ inline void System_ShareText(std::string_view text) {
 	g_requestManager.MakeSystemRequest(SystemRequestType::SHARE_TEXT, NO_REQUESTER_TOKEN, nullptr, nullptr, text, "", 0);
 }
 
-inline void System_NotifyUIState(std::string_view state) {
-	g_requestManager.MakeSystemRequest(SystemRequestType::NOTIFY_UI_STATE, NO_REQUESTER_TOKEN, nullptr, nullptr, state, "", 0);
+inline void System_NotifyUIEvent(UIEventNotification notification) {
+	g_requestManager.MakeSystemRequest(SystemRequestType::NOTIFY_UI_EVENT, NO_REQUESTER_TOKEN, nullptr, nullptr, "", "", (int64_t)notification, 0);
 }
 
 inline void System_SetKeepScreenBright(bool keepScreenBright) {

--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -56,6 +56,13 @@ void System_LaunchUrl(LaunchUrlType urlType, const char *url);
 // Going forward, "optional" things (PPSSPP will still function alright without it) will be requests,
 // to make implementations simpler in the default case.
 
+enum class UIEventNotification {
+	MENU_RETURN,
+	POPUP_CLOSED,
+	TEXT_GOTFOCUS,
+	TEXT_LOSTFOCUS,
+};
+
 enum class SystemRequestType {
 	INPUT_TEXT_MODAL,
 	ASK_USERNAME_PASSWORD,
@@ -79,7 +86,7 @@ enum class SystemRequestType {
 	// Note: height specified as param3, width based on param1.size() / param3.
 	SEND_DEBUG_SCREENSHOT,
 
-	NOTIFY_UI_STATE,  // Used on Android only. Not a SystemNotification since it takes a parameter.
+	NOTIFY_UI_EVENT,  // Used to manage events that are useful for popup virtual keyboards.
 	SET_KEEP_SCREEN_BRIGHT,
 
 	// High-level hardware control

--- a/Common/UI/UIScreen.cpp
+++ b/Common/UI/UIScreen.cpp
@@ -398,7 +398,7 @@ void PopupScreen::TriggerFinish(DialogResult result) {
 		OnCompleted(result);
 	}
 	// Inform UI that popup close to hide OSK (if visible)
-	System_NotifyUIState("popup_closed");
+	System_NotifyUIEvent(UIEventNotification::POPUP_CLOSED);
 }
 
 void PopupScreen::CreateViews() {

--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -1110,14 +1110,12 @@ TextEdit::TextEdit(std::string_view text, std::string_view title, std::string_vi
 }
 
 void TextEdit::FocusChanged(int focusFlags) {
-#if PPSSPP_PLATFORM(UWP)
 	if (focusFlags == FF_GOTFOCUS) {
-		System_NotifyUIState("text_gotfocus");
+		System_NotifyUIEvent(UIEventNotification::TEXT_GOTFOCUS);
 	}
 	else {
-		System_NotifyUIState("text_lostfocus");
+		System_NotifyUIEvent(UIEventNotification::TEXT_LOSTFOCUS);
 	}
-#endif
 }
 
 void TextEdit::Draw(UIContext &dc) {

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -548,21 +548,23 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 			});
 		return true;
 	}
-	case SystemRequestType::NOTIFY_UI_STATE:
+	case SystemRequestType::NOTIFY_UI_EVENT:
 	{
-		if (!param1.empty()) {
-			if (!strcmp(param1.c_str(), "menu")) {
-				CloseLaunchItem();
-			}
-			else if (!strcmp(param1.c_str(), "popup_closed")) {
-				DeactivateTextEditInput();
-			}
-			else if (!strcmp(param1.c_str(), "text_gotfocus")) {
-				ActivateTextEditInput(true);
-			}
-			else if (!strcmp(param1.c_str(), "text_lostfocus")) {
-				DeactivateTextEditInput(true);
-			}
+		switch ((UIEventNotification)param3) {
+		case UIEventNotification::MENU_RETURN:
+			CloseLaunchItem();
+			break;
+		case UIEventNotification::POPUP_CLOSED:
+			DeactivateTextEditInput();
+			break;
+		case UIEventNotification::TEXT_GOTFOCUS:
+			ActivateTextEditInput(true);
+			break;
+		case UIEventNotification::TEXT_LOSTFOCUS:
+			DeactivateTextEditInput(true);
+			break;
+		default:
+			break;
 		}
 		return true;
 	}


### PR DESCRIPTION
Just cleaning up before re-using this mechanism for iOS keyboard support.