### PR TITLE
iOS ViewController refactor

### DIFF
--- a/ios/AppDelegate.h
+++ b/ios/AppDelegate.h
@@ -2,13 +2,13 @@
 
 #import <UIKit/UIKit.h>
 
-@class PPSSPPViewControllerGL;
+@protocol PPSSPPViewController;
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
 @property (strong, nonatomic) UIScreen *screen;
 
-@property (strong, nonatomic) PPSSPPViewControllerGL *viewController;
+@property (strong, nonatomic) id<PPSSPPViewController> viewController;
 
 @end

--- a/ios/AppDelegate.h
+++ b/ios/AppDelegate.h
@@ -2,13 +2,13 @@
 
 #import <UIKit/UIKit.h>
 
-@class ViewController;
+@class PPSSPPViewControllerGL;
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
 @property (strong, nonatomic) UIScreen *screen;
 
-@property (strong, nonatomic) ViewController *viewController;
+@property (strong, nonatomic) PPSSPPViewControllerGL *viewController;
 
 @end

--- a/ios/AppDelegate.mm
+++ b/ios/AppDelegate.mm
@@ -89,9 +89,10 @@
 	NSString *bundlePath = [[[NSBundle mainBundle] resourcePath] stringByAppendingString:@"/assets/"];
 	NativeInit(argc, (const char**)argv, documentsPath.UTF8String, bundlePath.UTF8String, NULL);
 
-
 	self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-	self.viewController = [[ViewController alloc] init];
+
+	// Here we can switch viewcontroller depending on backend.
+	self.viewController = [[PPSSPPViewControllerGL alloc] init];
 
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleAudioSessionInterruption:) name:AVAudioSessionInterruptionNotification object:[AVAudioSession sharedInstance]];
 

--- a/ios/AppDelegate.mm
+++ b/ios/AppDelegate.mm
@@ -91,14 +91,15 @@
 
 	self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
 
+	PPSSPPViewControllerGL *vc = [[PPSSPPViewControllerGL alloc] init];
 	// Here we can switch viewcontroller depending on backend.
-	self.viewController = [[PPSSPPViewControllerGL alloc] init];
+	self.viewController = vc;
 
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleAudioSessionInterruption:) name:AVAudioSessionInterruptionNotification object:[AVAudioSession sharedInstance]];
 
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleMediaServicesWereReset:) name:AVAudioSessionMediaServicesWereResetNotification object:nil];
 
-	self.window.rootViewController = self.viewController;
+	self.window.rootViewController = vc;
 	[self.window makeKeyAndVisible];
 
 	return YES;

--- a/ios/DisplayManager.mm
+++ b/ios/DisplayManager.mm
@@ -166,7 +166,7 @@
 	g_display.pixel_in_dps_x = (float)g_display.pixel_xres / (float)g_display.dp_xres;
 	g_display.pixel_in_dps_y = (float)g_display.pixel_yres / (float)g_display.dp_yres;
 	
-	[[sharedViewController view] setContentScaleFactor:scale];
+	[[sharedViewController getView] setContentScaleFactor:scale];
 	
 	// PSP native resize
 	PSP_CoreParameter().pixelWidth = g_display.pixel_xres;

--- a/ios/ViewController.h
+++ b/ios/ViewController.h
@@ -18,7 +18,7 @@
 - (void)bindDefaultFBO;
 @end
 
-@interface ViewController : GLKViewController <
+@interface PPSSPPViewControllerGL : GLKViewController <
     iCadeEventDelegate, LocationHandlerDelegate, CameraFrameDelegate,
     UIGestureRecognizerDelegate, UIKeyInput, PPSSPPViewController>
 @end

--- a/ios/ViewController.h
+++ b/ios/ViewController.h
@@ -16,6 +16,7 @@
 - (void)shareText:(NSString *)text;
 - (void)shutdown;
 - (void)bindDefaultFBO;
+- (UIView *)getView;
 @end
 
 @interface PPSSPPViewControllerGL : GLKViewController <

--- a/ios/ViewController.h
+++ b/ios/ViewController.h
@@ -9,17 +9,22 @@
 #import "CameraHelper.h"
 #import "LocationHelper.h"
 
-@interface ViewController : GLKViewController <iCadeEventDelegate,
-            LocationHandlerDelegate, CameraFrameDelegate, UIGestureRecognizerDelegate, UIKeyInput>
-
-- (void)shareText:(NSString *)text;
-- (void)shutdown;
+@protocol PPSSPPViewController<NSObject>
+@optional
 - (void)hideKeyboard;
 - (void)showKeyboard;
-
+- (void)shareText:(NSString *)text;
+- (void)shutdown;
+- (void)bindDefaultFBO;
 @end
 
-extern __unsafe_unretained ViewController* sharedViewController;
+@interface ViewController : GLKViewController <
+    iCadeEventDelegate, LocationHandlerDelegate, CameraFrameDelegate,
+    UIGestureRecognizerDelegate, UIKeyInput, PPSSPPViewController>
+@end
+
+extern id <PPSSPPViewController> sharedViewController;
+
 void setCameraSize(int width, int height);
 void startVideo();
 void stopVideo();

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -599,6 +599,10 @@ int ToTouchID(UITouch *uiTouch, bool allowAllocate) {
 	return UIRectEdgeAll;
 }
 
+- (UIView *)getView {
+	return [self view];
+}
+
 - (void)setupController:(GCController *)controller
 {
 	self.gameController = controller;

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -45,9 +45,9 @@
 #define IS_IPAD() ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad)
 #define IS_IPHONE() ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone)
 
-class IOSGraphicsContext : public GraphicsContext {
+class IOSGLESContext : public GraphicsContext {
 public:
-	IOSGraphicsContext() {
+	IOSGLESContext() {
 		CheckGLExtensions();
 		draw_ = Draw::T3DCreateGLContext(false);
 		renderManager_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
@@ -56,7 +56,7 @@ public:
 		bool success = draw_->CreatePresets();
 		_assert_msg_(success, "Failed to compile preset shaders");
 	}
-	~IOSGraphicsContext() {
+	~IOSGLESContext() {
 		delete draw_;
 	}
 	Draw::DrawContext *GetDrawContext() override {
@@ -103,7 +103,7 @@ static GraphicsContext *graphicsContext;
 static CameraHelper *cameraHelper;
 static LocationHelper *locationHelper;
 
-@interface ViewController () {
+@interface PPSSPPViewControllerGL () {
 	std::map<uint16_t, InputKeyCode> iCadeToKeyMap;
 }
 
@@ -116,7 +116,7 @@ static LocationHelper *locationHelper;
 
 @end
 
-@implementation ViewController
+@implementation PPSSPPViewControllerGL
 
 -(id) init {
 	self = [super init];
@@ -209,7 +209,7 @@ extern float g_safeInsetBottom;
 
 	[[DisplayManager shared] updateResolution:[UIScreen mainScreen]];
 
-	graphicsContext = new IOSGraphicsContext();
+	graphicsContext = new IOSGLESContext();
 
 	graphicsContext->GetDrawContext()->SetErrorCallback([](const char *shortDesc, const char *details, void *userdata) {
 		g_OSD.Show(OSDType::MESSAGE_ERROR, details, 0.0f, "error_callback");

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -98,7 +98,7 @@ static bool threadEnabled = true;
 static bool threadStopped = false;
 static UITouch *g_touches[10];
 
-__unsafe_unretained ViewController* sharedViewController;
+id<PPSSPPViewController> sharedViewController;
 static GraphicsContext *graphicsContext;
 static CameraHelper *cameraHelper;
 static LocationHelper *locationHelper;
@@ -181,7 +181,6 @@ extern float g_safeInsetBottom;
 
 - (void)viewDidAppear:(BOOL)animated {
 	[super viewDidAppear:animated];
-	[self hideKeyboard];
 }
 
 - (void)viewDidLoad {
@@ -239,6 +238,8 @@ extern float g_safeInsetBottom;
 
 	locationHelper = [[LocationHelper alloc] init];
 	[locationHelper setDelegate:self];
+
+	[self hideKeyboard];
 
 	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
 		NativeInitGraphics(graphicsContext);

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -1,4 +1,10 @@
 // main.mm boilerplate
+//
+// Overview
+//
+// main.mm: JIT enablement, starting the next step
+// AppDelegate.mm: Runs NativeInit, launches the main ViewController
+// ViewController.mm: The main application window
 
 #import <UIKit/UIKit.h>
 #import <dlfcn.h>


### PR DESCRIPTION
Avoid storing pointers to the main ViewController using the exact type. This will allow us to have two different ViewControllers depending on backend, one for GL and one for Vulkan. This seems to be required.

Prep for #19166 
