### PR TITLE
IRInterpreter compiler: Reject all vec2ops where the prefix is unknown while compiling

### DIFF
--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -884,7 +884,7 @@ static int sysclib_sprintf(u32 dst, u32 fmt) {
 
 	DEBUG_LOG(SCEKERNEL, "sysclib_sprintf result string has length %d, content:", (int)result.length());
 	DEBUG_LOG(SCEKERNEL, "%s", result.c_str());
-	if (!Memory::IsValidRange(dst, result.length() + 1)) {
+	if (!Memory::IsValidRange(dst, (u32)result.length() + 1)) {
 		ERROR_LOG(SCEKERNEL, "sysclib_sprintf result string is too long or dst is invalid");
 		return 0;
 	}

--- a/Core/MIPS/IR/IRCompVFPU.cpp
+++ b/Core/MIPS/IR/IRCompVFPU.cpp
@@ -969,6 +969,11 @@ namespace MIPSComp {
 
 	void IRFrontend::Comp_VV2Op(MIPSOpcode op) {
 		CONDITIONAL_DISABLE(VFPU_VEC);
+
+		if (js.HasUnknownPrefix()) {
+			DISABLE;
+		}
+
 		int optype = (op >> 16) & 0x1f;
 		if (optype == 0) {
 			if (js.HasUnknownPrefix() || !IsPrefixWithinSize(js.prefixS, op))


### PR DESCRIPTION
Fall back to interpreter in these cases, like we do in the other backends.

Also a warning fix.

Fixes #19164

May help #19172