### PR TITLE
Add a convenience method to VulkanContext to reduce code duplication

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -847,6 +847,33 @@ VkResult VulkanContext::InitDebugUtilsCallback() {
 	return res;
 }
 
+bool VulkanContext::CreateInstanceAndDevice(const CreateInfo &info) {
+	VkResult res = CreateInstance(info);
+	if (res != VK_SUCCESS) {
+		ERROR_LOG(G3D, "Failed to create vulkan context: %s", InitError().c_str());
+		VulkanSetAvailable(false);
+		return false;
+	}
+
+	int physicalDevice = GetBestPhysicalDevice();
+	if (physicalDevice < 0) {
+		ERROR_LOG(G3D, "No usable Vulkan device found.");
+		DestroyInstance();
+		return false;
+	}
+
+	ChooseDevice(physicalDevice);
+
+	INFO_LOG(G3D, "Creating Vulkan device (flags: %08x)", info.flags);
+	if (CreateDevice() != VK_SUCCESS) {
+		INFO_LOG(G3D, "Failed to create vulkan device: %s", InitError().c_str());
+		DestroyInstance();
+		return false;
+	}
+
+	return true;
+}
+
 void VulkanContext::SetDebugNameImpl(uint64_t handle, VkObjectType type, const char *name) {
 	VkDebugUtilsObjectNameInfoEXT info{ VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT };
 	info.pObjectName = name;

--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -183,6 +183,10 @@ public:
 	int GetPhysicalDeviceByName(const std::string &name);
 	void ChooseDevice(int physical_device);
 
+	// Convenience method to avoid code duplication.
+	// If it returns false, delete the context.
+	bool CreateInstanceAndDevice(const CreateInfo &info);
+
 	// The coreVersion is to avoid enabling extensions that are merged into core Vulkan from a certain version.
 	bool EnableInstanceExtension(const char *extension, uint32_t coreVersion);
 	bool EnableDeviceExtension(const char *extension, uint32_t coreVersion);

--- a/Core/Util/VulkanEmuThread.cpp
+++ b/Core/Util/VulkanEmuThread.cpp
@@ -1,0 +1,2 @@
+#include "Core/Util/VulkanEmuThread.h"
+

--- a/android/jni/AndroidVulkanContext.cpp
+++ b/android/jni/AndroidVulkanContext.cpp
@@ -68,33 +68,7 @@ bool AndroidVulkanContext::InitAPI() {
 	info.app_name = "PPSSPP";
 	info.app_ver = gitVer.ToInteger();
 	info.flags = FlagsFromConfig();
-	VkResult res = g_Vulkan->CreateInstance(info);
-	if (res != VK_SUCCESS) {
-		ERROR_LOG(G3D, "Failed to create vulkan context: %s", g_Vulkan->InitError().c_str());
-		VulkanSetAvailable(false);
-		delete g_Vulkan;
-		g_Vulkan = nullptr;
-		state_ = GraphicsContextState::FAILED_INIT;
-		return false;
-	}
-
-	int physicalDevice = g_Vulkan->GetBestPhysicalDevice();
-	if (physicalDevice < 0) {
-		ERROR_LOG(G3D, "No usable Vulkan device found.");
-		g_Vulkan->DestroyInstance();
-		delete g_Vulkan;
-		g_Vulkan = nullptr;
-		state_ = GraphicsContextState::FAILED_INIT;
-		return false;
-	}
-
-	g_Vulkan->ChooseDevice(physicalDevice);
-
-	INFO_LOG(G3D, "Creating Vulkan device (flags: %08x)", info.flags);
-	if (g_Vulkan->CreateDevice() != VK_SUCCESS) {
-		INFO_LOG(G3D, "Failed to create vulkan device: %s", g_Vulkan->InitError().c_str());
-		System_Toast("No Vulkan driver found. Using OpenGL instead.");
-		g_Vulkan->DestroyInstance();
+	if (!g_Vulkan->CreateInstanceAndDevice(info)) {
 		delete g_Vulkan;
 		g_Vulkan = nullptr;
 		state_ = GraphicsContextState::FAILED_INIT;


### PR DESCRIPTION
Will need the exact same code for iOS.

This was meant to be a bigger refactor, but I'm postponing that until later.