### PR TITLE
iOS: Fix issue with keyboard popping up after file picker.

### DIFF
--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -229,6 +229,7 @@ enum class SystemNotification {
 	TEST_JAVA_EXCEPTION,
 	KEEP_SCREEN_AWAKE,
 	ACTIVITY,
+	UI_STATE_CHANGED,
 };
 
 // I guess it's not super great architecturally to centralize this, since it's not general - but same with a lot of

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -128,6 +128,7 @@ void UpdateUIState(GlobalUIState newState) {
 	if (globalUIState != newState && globalUIState != UISTATE_EXIT) {
 		globalUIState = newState;
 		System_Notify(SystemNotification::DISASSEMBLY);
+		System_Notify(SystemNotification::UI_STATE_CHANGED);
 		System_SetKeepScreenBright(globalUIState == UISTATE_INGAME);
 	}
 }

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -712,16 +712,23 @@ void InitPadLayout(float xres, float yres, float globalScale) {
 		bottom_key_spacing *= 0.8f;
 	}
 
+// On IOS, nudge the bottom button up a little to avoid the task switcher.
+#if PPSSPP_PLATFORM(IOS)
+	const float bottom_button_Y = 80.0f;
+#else
+	const float bottom_button_Y = 60.0f;
+#endif
+
 	int start_key_X = halfW + bottom_key_spacing * scale;
-	int start_key_Y = yres - 60 * scale;
+	int start_key_Y = yres - bottom_button_Y * scale;
 	initTouchPos(g_Config.touchStartKey, start_key_X, start_key_Y);
 
 	int select_key_X = halfW;
-	int select_key_Y = yres - 60 * scale;
+	int select_key_Y = yres - bottom_button_Y * scale;
 	initTouchPos(g_Config.touchSelectKey, select_key_X, select_key_Y);
 
 	int fast_forward_key_X = halfW - bottom_key_spacing * scale;
-	int fast_forward_key_Y = yres - 60 * scale;
+	int fast_forward_key_Y = yres - bottom_button_Y * scale;
 	initTouchPos(g_Config.touchFastForwardKey, fast_forward_key_X, fast_forward_key_Y);
 
 	// L and R------------------------------------------------------------

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -392,7 +392,22 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 // Enables tapping for edge area.
 -(UIRectEdge)preferredScreenEdgesDeferringSystemGestures
 {
-	return UIRectEdgeAll;
+	if (GetUIState() == UISTATE_INGAME) {
+		// In-game, we need all the control we can get. Though, we could possibly
+		// allow the top edge?
+		INFO_LOG(SYSTEM, "Defer system gestures on all edges");
+		return UIRectEdgeAll;
+	} else {
+		INFO_LOG(SYSTEM, "Allow system gestures on the bottom");
+		// Allow task switching gestures to take precedence, without causing
+		// scroll events in the UI.
+		return UIRectEdgeTop | UIRectEdgeLeft | UIRectEdgeRight;
+	}
+}
+
+- (void)uiStateChanged
+{
+	[self setNeedsUpdateOfScreenEdgesDeferringSystemGestures];
 }
 
 - (UIView *)getView {

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -448,11 +448,6 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 	INFO_LOG(SYSTEM, "Backspace");
 }
 
--(BOOL) hasText
-{
-	return YES;
-}
-
 -(void) insertText:(NSString *)text
 {
 	std::string str = std::string([text UTF8String]);
@@ -460,6 +455,7 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 	UTF8 chars(str);
 	while (!chars.end()) {
 		uint32_t codePoint = chars.next();
+		INFO_LOG(SYSTEM, "Codepoint#: %d", codePoint);
 		KeyInput input{};
 		input.deviceId = DEVICE_ID_KEYBOARD;
 		input.flags = KEY_CHAR;
@@ -470,17 +466,24 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 
 -(BOOL) canBecomeFirstResponder
 {
-	return YES;
+	return true;
+}
+
+-(BOOL) hasText
+{
+	return true;
 }
 
 -(void) showKeyboard {
 	dispatch_async(dispatch_get_main_queue(), ^{
+		INFO_LOG(SYSTEM, "becomeFirstResponder");
 		[self becomeFirstResponder];
 	});
 }
 
 -(void) hideKeyboard {
 	dispatch_async(dispatch_get_main_queue(), ^{
+		INFO_LOG(SYSTEM, "resignFirstResponder");
 		[self resignFirstResponder];
 	});
 }

--- a/ios/ViewControllerCommon.h
+++ b/ios/ViewControllerCommon.h
@@ -20,6 +20,8 @@
 - (void)didBecomeActive;
 - (void)willResignActive;
 
+- (void)uiStateChanged;
+
 @end
 
 extern id <PPSSPPViewController> sharedViewController;

--- a/ios/ViewControllerMetal.mm
+++ b/ios/ViewControllerMetal.mm
@@ -477,7 +477,22 @@ extern float g_safeInsetBottom;
 // Enables tapping for edge area.
 -(UIRectEdge)preferredScreenEdgesDeferringSystemGestures
 {
-	return UIRectEdgeAll;
+	if (GetUIState() == UISTATE_INGAME) {
+		// In-game, we need all the control we can get. Though, we could possibly
+		// allow the top edge?
+		INFO_LOG(SYSTEM, "Defer system gestures on all edges");
+		return UIRectEdgeAll;
+	} else {
+		INFO_LOG(SYSTEM, "Allow system gestures on the bottom");
+		// Allow task switching gestures to take precedence, without causing
+		// scroll events in the UI.
+		return UIRectEdgeTop | UIRectEdgeLeft | UIRectEdgeRight;
+	}
+}
+
+- (void)uiStateChanged
+{
+	[self setNeedsUpdateOfScreenEdgesDeferringSystemGestures];
 }
 
 - (void)bindDefaultFBO

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -386,7 +386,15 @@ bool System_GetPropertyBool(SystemProperty prop) {
 
 void System_Notify(SystemNotification notification) {
 	switch (notification) {
-	default: break;
+	case SystemNotification::UI_STATE_CHANGED:
+		dispatch_async(dispatch_get_main_queue(), ^{
+			if (sharedViewController) {
+				[sharedViewController uiStateChanged];
+			}
+		});
+		break;
+	default:
+		break;
 	}
 }
 


### PR DESCRIPTION
iOS kb APIs are crazy.

Also, slight tweaks to touch controls: Move the bottom three buttons up slightly to avoid the drag-up task switcher, and also ask iOS to not pass through touch events near it when we're in the menu. This makes task switching feel better.