### PR TITLE
Use a hacked MoltenVK that can be loaded (but doesn't work) on iOS 12.

### DIFF
--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -379,12 +379,12 @@ void VulkanSetAvailable(bool available) {
 }
 
 bool VulkanMayBeAvailable() {
-#if PPSSPP_PLATFORM(IOS_APP_STORE)
+#if PPSSPP_PLATFORM(IOS)
 	g_vulkanAvailabilityChecked = true;
-	g_vulkanMayBeAvailable = true;
-	return true;
+	g_vulkanMayBeAvailable = System_GetPropertyInt(SYSPROP_SYSTEMVERSION) >= 13;
+	INFO_LOG(SYSTEM, "VulkanMayBeAvailable: Detected version: %d", System_GetPropertyInt(SYSPROP_SYSTEMVERSION));
+	return g_vulkanMayBeAvailable;
 #else
-
 	// Unsupported in VR at the moment
 	if (IsVREnabled()) {
 		return false;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -515,7 +515,7 @@ int Config::NextValidBackend() {
 	return iGPUBackend;
 }
 
-bool Config::IsBackendEnabled(GPUBackend backend, bool validate) {
+bool Config::IsBackendEnabled(GPUBackend backend) {
 	std::vector<std::string> split;
 
 	SplitString(sDisabledGPUBackends, ',', split);
@@ -534,10 +534,8 @@ bool Config::IsBackendEnabled(GPUBackend backend, bool validate) {
 	if (backend != GPUBackend::OPENGL)
 		return false;
 #elif PPSSPP_PLATFORM(WINDOWS)
-	if (validate) {
-		if (backend == GPUBackend::DIRECT3D11 && !DoesVersionMatchWindows(6, 0, 0, 0, true))
-			return false;
-	}
+	if (backend == GPUBackend::DIRECT3D11 && !DoesVersionMatchWindows(6, 0, 0, 0, true))
+		return false;
 #else
 	if (backend == GPUBackend::DIRECT3D11 || backend == GPUBackend::DIRECT3D9)
 		return false;
@@ -547,11 +545,9 @@ bool Config::IsBackendEnabled(GPUBackend backend, bool validate) {
 	if (backend == GPUBackend::OPENGL)
 		return false;
 #endif
-	if (validate) {
-		if (backend == GPUBackend::VULKAN && !VulkanMayBeAvailable())
-			return false;
-	}
-
+	INFO_LOG(SYSTEM, "Checking for VK");
+	if (backend == GPUBackend::VULKAN && !VulkanMayBeAvailable())
+		return false;
 	return true;
 }
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -602,7 +602,7 @@ public:
 
 	bool IsPortrait() const;
 	int NextValidBackend();
-	bool IsBackendEnabled(GPUBackend backend, bool validate = true);
+	bool IsBackendEnabled(GPUBackend backend);
 
 	bool UseFullScreen() const {
 		if (iForceFullScreen != -1)

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,3 +1,7 @@
+Updating with a self-built MoltenVK
+===================================
+cp -r ../dev/build-molten/MoltenVK/Package/Release/MoltenVK/static/MoltenVK.xcframework ios/MoltenVK
+
 The Old iOS Build Instructions
 ==============================
 

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -561,7 +561,7 @@ int main(int argc, char *argv[])
 {
 	// SetCurrentThreadName("MainThread");
 	version = [[[UIDevice currentDevice] systemVersion] UTF8String];
-	if (2 != sscanf(version.c_str(), "%d", &g_iosVersionMajor)) {
+	if (1 != sscanf(version.c_str(), "%d", &g_iosVersionMajor)) {
 		// Just set it to 14.0 if the parsing fails for whatever reason.
 		g_iosVersionMajor = 14;
 	}


### PR DESCRIPTION
See https://github.com/KhronosGroup/MoltenVK/issues/2240

Vulkan will still be enabled for iOS 13 and above, until I figure out why this one doesn't work on iOS 12.