### PR TITLE
iOS: Add audio session mode controls

### DIFF
--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -382,7 +382,7 @@ bool VulkanMayBeAvailable() {
 #if PPSSPP_PLATFORM(IOS)
 	g_vulkanAvailabilityChecked = true;
 	g_vulkanMayBeAvailable = System_GetPropertyInt(SYSPROP_SYSTEMVERSION) >= 13;
-	INFO_LOG(SYSTEM, "VulkanMayBeAvailable: Detected version: %d", System_GetPropertyInt(SYSPROP_SYSTEMVERSION));
+	INFO_LOG(SYSTEM, "VulkanMayBeAvailable: Detected version: %d", (int)System_GetPropertyInt(SYSPROP_SYSTEMVERSION));
 	return g_vulkanMayBeAvailable;
 #else
 	// Unsupported in VR at the moment

--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -230,6 +230,7 @@ enum class SystemNotification {
 	KEEP_SCREEN_AWAKE,
 	ACTIVITY,
 	UI_STATE_CHANGED,
+	AUDIO_MODE_CHANGED,
 };
 
 // I guess it's not super great architecturally to centralize this, since it's not general - but same with a lot of

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -700,6 +700,8 @@ static const ConfigSetting soundSettings[] = {
 	ConfigSetting("AchievementSoundVolume", &g_Config.iAchievementSoundVolume, 6, CfgFlag::PER_GAME),
 	ConfigSetting("AudioDevice", &g_Config.sAudioDevice, "", CfgFlag::DEFAULT),
 	ConfigSetting("AutoAudioDevice", &g_Config.bAutoAudioDevice, true, CfgFlag::DEFAULT),
+	ConfigSetting("AudioMixWithOthers", &g_Config.bAudioMixWithOthers, true, CfgFlag::DEFAULT),
+	ConfigSetting("AudioRespectSilentMode", &g_Config.bAudioRespectSilentMode, false, CfgFlag::DEFAULT),
 	ConfigSetting("UseNewAtrac", &g_Config.bUseNewAtrac, false, CfgFlag::DEFAULT),
 };
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -280,6 +280,10 @@ public:
 	bool bAutoAudioDevice;
 	bool bUseNewAtrac;
 
+	// iOS only for now
+	bool bAudioMixWithOthers;
+	bool bAudioRespectSilentMode;
+
 	// UI
 	bool bShowDebuggerOnLoad;
 	int iShowStatusFlags;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -617,7 +617,23 @@ void GameSettingsScreen::CreateAudioSettings(UI::ViewGroup *audioSettings) {
 	auto ms = GetI18NCategory(I18NCat::MAINSETTINGS);
 
 	audioSettings->Add(new ItemHeader(ms->T("Audio")));
-	CheckBox *enableSound = audioSettings->Add(new CheckBox(&g_Config.bEnableSound,a->T("Enable Sound")));
+	CheckBox *enableSound = audioSettings->Add(new CheckBox(&g_Config.bEnableSound,a->T("Enable Sound")));	
+
+#if PPSSPP_PLATFORM(IOS)
+	CheckBox *respectSilentMode = audioSettings->Add(new CheckBox(&g_Config.bAudioRespectSilentMode, a->T("Respect silent mode")));
+	respectSilentMode->OnClick.Add([=](EventParams &e) {
+		System_Notify(SystemNotification::AUDIO_MODE_CHANGED);
+		return UI::EVENT_DONE;
+	});
+	respectSilentMode->SetEnabledPtr(&g_Config.bEnableSound);
+	CheckBox *mixWithOthers = audioSettings->Add(new CheckBox(&g_Config.bAudioMixWithOthers, a->T("Mix audio with other apps")));
+	mixWithOthers->OnClick.Add([=](EventParams &e) {
+		System_Notify(SystemNotification::AUDIO_MODE_CHANGED);
+		return UI::EVENT_DONE;
+	});
+	mixWithOthers->SetEnabledPtr(&g_Config.bEnableSound);
+#endif
+
 	PopupSliderChoice *volume = audioSettings->Add(new PopupSliderChoice(&g_Config.iGlobalVolume, VOLUME_OFF, VOLUME_FULL, VOLUME_FULL, a->T("Global volume"), screenManager()));
 	volume->SetEnabledPtr(&g_Config.bEnableSound);
 	volume->SetZeroLabel(a->T("Mute"));

--- a/ios/DisplayManager.mm
+++ b/ios/DisplayManager.mm
@@ -64,6 +64,9 @@
 	[self setOriginalFrame: [gameWindow frame]];
 	[self setOriginalBounds:[gameWindow bounds]];
 	[self setOriginalTransform:[gameWindow transform]];
+
+	// TODO: From iOS 13, should use UIScreenDidConnectNotification instead of the below.
+
 	// Display connected
 	[[NSNotificationCenter defaultCenter] addObserverForName:UIScreenDidConnectNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull notification) {
 		UIScreen *screen = (UIScreen *) notification.object;
@@ -74,8 +77,7 @@
 			return;
 		}
 		// Ignore mute switch when connected to external display
-		NSError *error = nil;
-		[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:&error];
+		iOSCoreAudioSetDisplayConnected(true);
 		[self updateScreen:screen];
 	}];
 	// Display disconnected
@@ -89,8 +91,7 @@
 			UIScreen *newScreen = [[self extDisplays] lastObject];
 			[self updateScreen:newScreen];
 		} else {
-			NSError *error = nil;
-			[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:&error];
+			iOSCoreAudioSetDisplayConnected(false);
 			[self updateScreen:[UIScreen mainScreen]];
 		}
 	}];

--- a/ios/DisplayManager.mm
+++ b/ios/DisplayManager.mm
@@ -6,6 +6,7 @@
 //
 
 #import "DisplayManager.h"
+#import "iOSCoreAudio.h"
 #import "ViewController.h"
 #import "AppDelegate.h"
 #include "Common/System/Display.h"

--- a/ios/iOSCoreAudio.h
+++ b/ios/iOSCoreAudio.h
@@ -20,3 +20,8 @@
 
 void iOSCoreAudioInit();
 void iOSCoreAudioShutdown();
+
+// Ignore mute switch when connected to external display.
+// Also, obey other settings.
+void iOSCoreAudioUpdateSession();
+void iOSCoreAudioSetDisplayConnected(bool connected);

--- a/ios/iOSCoreAudio.mm
+++ b/ios/iOSCoreAudio.mm
@@ -28,6 +28,22 @@
 #define SAMPLE_RATE 44100
 
 static AudioComponentInstance audioInstance = nil;
+static bool g_displayConnected = false;
+
+void iOSCoreAudioUpdateSession() {
+	NSError *error = nil;
+	// Default mode
+	if (g_displayConnected) {
+		[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:&error];
+	} else {
+		[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:&error];
+	}
+}
+
+void iOSCoreAudioSetDisplayConnected(bool connected) {
+	g_displayConnected = connected;
+	iOSCoreAudioUpdateSession();
+}
 
 int NativeMix(short *audio, int numSamples, int sampleRate);
 
@@ -75,7 +91,7 @@ void iOSCoreAudioInit()
 			NSLog(@"%@", error.localizedFailureReason);
 		}
 	}
-	
+
 	if (audioInstance) {
 		// Already running
 		return;

--- a/ios/iOSCoreAudio.mm
+++ b/ios/iOSCoreAudio.mm
@@ -21,6 +21,7 @@
 #include "iOSCoreAudio.h"
 
 #include "Common/Log.h"
+#include "Core/Config.h"
 
 #include <AudioToolbox/AudioToolbox.h>
 #import <AVFoundation/AVFoundation.h>
@@ -38,6 +39,8 @@ void iOSCoreAudioUpdateSession() {
 	} else {
 		[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:&error];
 	}
+
+	INFO_LOG(AUDIO, "RespectSilentMode: %d MixWithOthers: %d", g_Config.bAudioRespectSilentMode, g_Config.bAudioMixWithOthers);
 }
 
 void iOSCoreAudioSetDisplayConnected(bool connected) {
@@ -80,6 +83,8 @@ OSStatus iOSCoreAudioCallback(void *inRefCon,
 
 void iOSCoreAudioInit()
 {
+	iOSCoreAudioUpdateSession();
+
 	NSError *error = nil;
 	AVAudioSession *session = [AVAudioSession sharedInstance];
 	if (![session setActive:YES error:&error]) {

--- a/ios/iOSCoreAudio.mm
+++ b/ios/iOSCoreAudio.mm
@@ -33,14 +33,40 @@ static bool g_displayConnected = false;
 
 void iOSCoreAudioUpdateSession() {
 	NSError *error = nil;
-	// Default mode
 	if (g_displayConnected) {
+		INFO_LOG(AUDIO, "Display connected, setting Playback mode");
+		// Special handling when a display is connected. Always exclusive.
+		// Let's revisit this later.
 		[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:&error];
-	} else {
-		[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:&error];
+		return;
 	}
 
 	INFO_LOG(AUDIO, "RespectSilentMode: %d MixWithOthers: %d", g_Config.bAudioRespectSilentMode, g_Config.bAudioMixWithOthers);
+
+	// Hacky hack to force iOS to re-evaluate.
+	// Switching from CatogoryPlayback to CategoryPlayback with an option otherwise does nothing.
+	[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAudioProcessing error:&error];
+
+	// Here, we apply the settings.
+	const bool mixWithOthers = g_Config.bAudioMixWithOthers;
+	if (g_Config.bAudioMixWithOthers) {
+		if (g_Config.bAudioRespectSilentMode) {
+			[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:&error];
+		} else {
+			[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback withOptions:AVAudioSessionCategoryOptionMixWithOthers error:&error];
+		}
+	} else {
+		if (g_Config.bAudioRespectSilentMode) {
+			[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategorySoloAmbient error:&error];
+		} else {
+			[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback withOptions:0 error:&error];
+		}
+		// Can't achieve exclusive + respect silent mode
+	}
+
+	if (error) {
+		NSLog(@"%@", error);
+	}
 }
 
 void iOSCoreAudioSetDisplayConnected(bool connected) {

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -24,6 +24,7 @@
 #import "AppDelegate.h"
 #import "PPSSPPUIApplication.h"
 #import "ViewController.h"
+#import "iOSCoreAudio.h"
 
 #include "Common/MemoryUtil.h"
 #include "Common/System/NativeApp.h"
@@ -391,6 +392,11 @@ void System_Notify(SystemNotification notification) {
 			if (sharedViewController) {
 				[sharedViewController uiStateChanged];
 			}
+		});
+		break;
+	case SystemNotification::AUDIO_MODE_CHANGED:
+		dispatch_async(dispatch_get_main_queue(), ^{
+			iOSCoreAudioUpdateSession();
 		});
 		break;
 	default:


### PR DESCRIPTION
Adds support for respecting the silent switch, and allowing other apps to play in the background (mix with other apps).

Not sure about the best naming for the checkboxes.

Fixes #19197 