### PR TITLE
libretro: context cleanup

### DIFF
--- a/libretro/LibretroGLContext.cpp
+++ b/libretro/LibretroGLContext.cpp
@@ -8,7 +8,7 @@
 #include "libretro/LibretroGLContext.h"
 
 bool LibretroGLContext::Init() {
-	if (!LibretroHWRenderContext::Init(true))
+	if (!LibretroHWRenderContext::Init(false))
 		return false;
 
 	g_Config.iGPUBackend = (int)GPUBackend::OPENGL;

--- a/libretro/LibretroGLCoreContext.cpp
+++ b/libretro/LibretroGLCoreContext.cpp
@@ -8,7 +8,7 @@
 #include "libretro/LibretroGLCoreContext.h"
 
 bool LibretroGLCoreContext::Init() {
-	if (!LibretroHWRenderContext::Init(true))
+	if (!LibretroHWRenderContext::Init(false))
 		return false;
 
 	g_Config.iGPUBackend = (int)GPUBackend::OPENGL;

--- a/libretro/LibretroVulkanContext.cpp
+++ b/libretro/LibretroVulkanContext.cpp
@@ -41,7 +41,7 @@ static bool create_device(retro_vulkan_context *context, VkInstance instance, Vk
 
 	vk = new VulkanContext();
 
-   vk_libretro_init(instance, gpu, surface, get_instance_proc_addr, required_device_extensions, num_required_device_extensions, required_device_layers, num_required_device_layers, required_features);
+	vk_libretro_init(instance, gpu, surface, get_instance_proc_addr, required_device_extensions, num_required_device_extensions, required_device_layers, num_required_device_layers, required_features);
 
 	// TODO: Here we'll inject the instance and all of the stuff into the VulkanContext.
 
@@ -97,17 +97,17 @@ static const VkApplicationInfo *GetApplicationInfo(void) {
 }
 
 bool LibretroVulkanContext::Init() {
-	if (!LibretroHWRenderContext::Init(false)) {
+	if (!LibretroHWRenderContext::Init(true)) {
 		return false;
 	}
 
 	static const struct retro_hw_render_context_negotiation_interface_vulkan iface = {
-      RETRO_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE_VULKAN,
-      RETRO_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE_VULKAN_VERSION,
-      GetApplicationInfo,
-      create_device,  // Callback above.
-      nullptr,
-   };
+		RETRO_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE_VULKAN,
+		RETRO_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE_VULKAN_VERSION,
+		GetApplicationInfo,
+		create_device, // Callback above.
+		nullptr,
+	};
 	Libretro::environ_cb(RETRO_ENVIRONMENT_SET_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE, (void *)&iface);
 
 	g_Config.iGPUBackend = (int)GPUBackend::VULKAN;
@@ -131,6 +131,8 @@ void LibretroVulkanContext::ContextReset() {
 
 void LibretroVulkanContext::ContextDestroy() {
    INFO_LOG(G3D, "LibretroVulkanContext::ContextDestroy()");
+   vk->WaitUntilQueueIdle();
+   LibretroHWRenderContext::ContextDestroy();
 }
 
 void LibretroVulkanContext::CreateDrawContext() {

--- a/libretro/LibretroVulkanContext.h
+++ b/libretro/LibretroVulkanContext.h
@@ -13,8 +13,8 @@ public:
 	void *GetAPIContext() override;
 	void CreateDrawContext() override;
 
-   void ContextReset() override;
-   void ContextDestroy() override;
+	void ContextReset() override;
+	void ContextDestroy() override;
 
 	GPUCore GetGPUCore() override { return GPUCORE_VULKAN; }
 	const char *Ident() override { return "Vulkan"; }


### PR DESCRIPTION
A few changes in order to be able to toggle fullscreen with all available video drivers, at least on my Windows setup, so please test with other platforms. Also tried multiple core launches and closes on the same run, and all seems very solid here.

- Disabled cached context for both gl and glcore
- Added context destroy to vulkan stub to make it work when context is not cached, but decided to enable caching anyway
- Some whitespace tabulation cleanups

Please let me know if this `gpu->DeviceLost();` method is not the best possible, but at least it works.

Closes #10784