### PR TITLE
draw_text: Unify DrawString between all platforms

### DIFF
--- a/Common/Render/Text/draw_text.cpp
+++ b/Common/Render/Text/draw_text.cpp
@@ -68,7 +68,7 @@ void TextDrawer::DrawString(DrawBuffer &target, std::string_view str, float x, f
 	} else {
 		DataFormat texFormat;
 		// Pick between the supported formats, of which at least one is supported on each platform. Prefer R8 (but only if swizzle is supported)
-		bool emoji = AnyEmojiInString(str.data(), str.length());
+		bool emoji = SupportsColorEmoji() && AnyEmojiInString(str.data(), str.length());
 		if (emoji) {
 			texFormat = Draw::DataFormat::R8G8B8A8_UNORM;
 		} else if ((draw_->GetDataFormatSupport(Draw::DataFormat::R8_UNORM) & Draw::FMT_TEXTURE) != 0 && draw_->GetDeviceCaps().textureSwizzleSupported) {

--- a/Common/Render/Text/draw_text.cpp
+++ b/Common/Render/Text/draw_text.cpp
@@ -62,6 +62,9 @@ void TextDrawer::DrawString(DrawBuffer &target, std::string_view str, float x, f
 	if (iter != cache_.end()) {
 		entry = iter->second.get();
 		entry->lastUsedFrame = frameCount_;
+		if (!entry->texture) {
+			return;
+		}
 	} else {
 		DataFormat texFormat;
 		// Pick between the supported formats, of which at least one is supported on each platform. Prefer R8 (but only if swizzle is supported)
@@ -106,19 +109,18 @@ void TextDrawer::DrawString(DrawBuffer &target, std::string_view str, float x, f
 		cache_[key] = std::unique_ptr<TextStringEntry>(entry);
 	}
 
-	if (entry->texture) {
-		draw_->BindTexture(0, entry->texture);
+	_dbg_assert_(entry->texture);
+	draw_->BindTexture(0, entry->texture);
 
-		// Okay, the texture is bound, let's draw.
-		float w = entry->width * fontScaleX_ * dpiScale_;
-		float h = entry->height * fontScaleY_ * dpiScale_;
-		float u = entry->width / (float)entry->bmWidth;
-		float v = entry->height / (float)entry->bmHeight;
-		DrawBuffer::DoAlign(align, &x, &y, &w, &h);
+	// Okay, the texture is bound, let's draw.
+	float w = entry->width * fontScaleX_ * dpiScale_;
+	float h = entry->height * fontScaleY_ * dpiScale_;
+	float u = entry->width / (float)entry->bmWidth;
+	float v = entry->height / (float)entry->bmHeight;
+	DrawBuffer::DoAlign(align, &x, &y, &w, &h);
 
-		target.DrawTexRect(x, y, x + w, y + h, 0.0f, 0.0f, u, v, color);
-		target.Flush(true);
-	}
+	target.DrawTexRect(x, y, x + w, y + h, 0.0f, 0.0f, u, v, color);
+	target.Flush(true);
 }
 
 void TextDrawer::DrawStringRect(DrawBuffer &target, std::string_view str, const Bounds &bounds, uint32_t color, int align) {

--- a/Common/Render/Text/draw_text.h
+++ b/Common/Render/Text/draw_text.h
@@ -51,13 +51,11 @@ public:
 	virtual void MeasureString(std::string_view str, float *w, float *h) = 0;
 	virtual void MeasureStringRect(std::string_view str, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) = 0;
 
-	// TODO: This one we should be able to make a default implementation for, calling the specialized DrawBitmap.
-	// Only problem is that we need to make sure that the texFormats are all supported by all the backends, or we explicitly limit.
-	virtual void DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) = 0;
+	virtual void DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT);
 
 	void DrawStringRect(DrawBuffer &target, std::string_view str, const Bounds &bounds, uint32_t color, int align);
-	virtual bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align = ALIGN_TOPLEFT) = 0;
-	bool DrawStringBitmapRect(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, const Bounds &bounds, int align);
+	virtual bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align, bool fullColor) = 0;
+	bool DrawStringBitmapRect(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, const Bounds &bounds, int align, bool fullColor);
 	// Use for housekeeping like throwing out old strings.
 	virtual void OncePerFrame() = 0;
 
@@ -73,8 +71,8 @@ public:
 protected:
 	TextDrawer(Draw::DrawContext *draw);
 
-	Draw::DrawContext *draw_;
 	virtual void ClearCache() = 0;
+
 	void WrapString(std::string &out, std::string_view str, float maxWidth, int flags);
 
 	struct CacheKey {
@@ -89,11 +87,15 @@ protected:
 		uint32_t fontHash;
 	};
 
+	Draw::DrawContext *draw_;
+
 	int frameCount_ = 0;
 	float fontScaleX_ = 1.0f;
 	float fontScaleY_ = 1.0f;
 	float dpiScale_ = 1.0f;
 	bool ignoreGlobalDpi_ = false;
+
+	uint32_t fontHash_ = 0;
 
 	std::map<CacheKey, std::unique_ptr<TextStringEntry>> cache_;
 	std::map<CacheKey, std::unique_ptr<TextMeasureEntry>> sizeCache_;

--- a/Common/Render/Text/draw_text.h
+++ b/Common/Render/Text/draw_text.h
@@ -71,6 +71,7 @@ public:
 protected:
 	TextDrawer(Draw::DrawContext *draw);
 
+	virtual bool SupportsColorEmoji() const = 0;
 	virtual void ClearCache() = 0;
 
 	void WrapString(std::string &out, std::string_view str, float maxWidth, int flags);

--- a/Common/Render/Text/draw_text.h
+++ b/Common/Render/Text/draw_text.h
@@ -51,8 +51,7 @@ public:
 	virtual void MeasureString(std::string_view str, float *w, float *h) = 0;
 	virtual void MeasureStringRect(std::string_view str, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) = 0;
 
-	virtual void DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT);
-
+	void DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT);
 	void DrawStringRect(DrawBuffer &target, std::string_view str, const Bounds &bounds, uint32_t color, int align);
 	virtual bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align, bool fullColor) = 0;
 	bool DrawStringBitmapRect(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, const Bounds &bounds, int align, bool fullColor);

--- a/Common/Render/Text/draw_text_android.h
+++ b/Common/Render/Text/draw_text_android.h
@@ -23,8 +23,7 @@ public:
 	void SetFont(uint32_t fontHandle) override;  // Shortcut once you've set the font once.
 	void MeasureString(std::string_view str, float *w, float *h) override;
 	void MeasureStringRect(std::string_view str, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) override;
-	void DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) override;
-	bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align = ALIGN_TOPLEFT) override;
+	bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align, bool fullColor) override;
 	// Use for housekeeping like throwing out old strings.
 	void OncePerFrame() override;
 
@@ -36,9 +35,6 @@ private:
 	jclass cls_textRenderer;
 	jmethodID method_measureText;
 	jmethodID method_renderText;
-
-	uint32_t fontHash_;
-	bool use4444Format_ = false;
 
 	std::map<uint32_t, AndroidFontEntry> fontMap_;
 };

--- a/Common/Render/Text/draw_text_android.h
+++ b/Common/Render/Text/draw_text_android.h
@@ -28,6 +28,8 @@ public:
 	void OncePerFrame() override;
 
 protected:
+	bool SupportsColorEmoji() const { return true; }
+
 	void ClearCache() override;
 
 private:

--- a/Common/Render/Text/draw_text_cocoa.h
+++ b/Common/Render/Text/draw_text_cocoa.h
@@ -21,7 +21,7 @@ public:
 	void MeasureString(std::string_view str, float *w, float *h) override;
 	void MeasureStringRect(std::string_view str, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) override;
 	void DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) override;
-	bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align = ALIGN_TOPLEFT) override;
+	bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align, bool fullColor) override;
 	// Use for housekeeping like throwing out old strings.
 	void OncePerFrame() override;
 
@@ -32,7 +32,6 @@ protected:
 	TextDrawerContext *ctx_;
 	std::map<uint32_t, std::unique_ptr<TextDrawerFontContext>> fontMap_;
 
-	uint32_t fontHash_;
 	std::map<CacheKey, std::unique_ptr<TextStringEntry>> cache_;
 	std::map<CacheKey, std::unique_ptr<TextMeasureEntry>> sizeCache_;
 };

--- a/Common/Render/Text/draw_text_cocoa.h
+++ b/Common/Render/Text/draw_text_cocoa.h
@@ -25,6 +25,8 @@ public:
 	void OncePerFrame() override;
 
 protected:
+	bool SupportsColorEmoji() const override { return true; }
+
 	void ClearCache() override;
 	void RecreateFonts();  // On DPI change
 

--- a/Common/Render/Text/draw_text_cocoa.h
+++ b/Common/Render/Text/draw_text_cocoa.h
@@ -20,7 +20,6 @@ public:
 	void SetFont(uint32_t fontHandle) override;  // Shortcut once you've set the font once.
 	void MeasureString(std::string_view str, float *w, float *h) override;
 	void MeasureStringRect(std::string_view str, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) override;
-	void DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) override;
 	bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align, bool fullColor) override;
 	// Use for housekeeping like throwing out old strings.
 	void OncePerFrame() override;
@@ -31,9 +30,6 @@ protected:
 
 	TextDrawerContext *ctx_;
 	std::map<uint32_t, std::unique_ptr<TextDrawerFontContext>> fontMap_;
-
-	std::map<CacheKey, std::unique_ptr<TextStringEntry>> cache_;
-	std::map<CacheKey, std::unique_ptr<TextMeasureEntry>> sizeCache_;
 };
 
 #endif

--- a/Common/Render/Text/draw_text_qt.cpp
+++ b/Common/Render/Text/draw_text_qt.cpp
@@ -16,8 +16,7 @@
 #include <QtGui/QFontMetrics>
 #include <QtOpenGL/QGLWidget>
 
-TextDrawerQt::TextDrawerQt(Draw::DrawContext *draw) : TextDrawer(draw) {
-}
+TextDrawerQt::TextDrawerQt(Draw::DrawContext *draw) : TextDrawer(draw) {}
 
 TextDrawerQt::~TextDrawerQt() {
 	ClearCache();
@@ -139,53 +138,6 @@ bool TextDrawerQt::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextString
 		_assert_msg_(false, "Bad TextDrawer format");
 	}
 	return true;
-}
-
-void TextDrawerQt::DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align) {
-	using namespace Draw;
-	if (str.empty()) {
-		return;
-	}
-
-	CacheKey key{ std::string(str), fontHash_ };
-	target.Flush(true);
-
-	TextStringEntry *entry;
-
-	auto iter = cache_.find(key);
-	if (iter != cache_.end()) {
-		entry = iter->second.get();
-		entry->lastUsedFrame = frameCount_;
-	} else {
-		DataFormat texFormat = Draw::DataFormat::R4G4B4A4_UNORM_PACK16;
-
-		entry = new TextStringEntry(frameCount_);
-
-		TextureDesc desc{};
-		std::vector<uint8_t> bitmapData;
-		DrawStringBitmap(bitmapData, *entry, texFormat, str, align, false);
-		desc.initData.push_back(&bitmapData[0]);
-
-		desc.type = TextureType::LINEAR2D;
-		desc.format = texFormat;
-		desc.width = entry->bmWidth;
-		desc.height = entry->bmHeight;
-		desc.depth = 1;
-		desc.mipLevels = 1;
-		desc.tag = "TextDrawer";
-		entry->texture = draw_->CreateTexture(desc);
-		cache_[key] = std::unique_ptr<TextStringEntry>(entry);
-	}
-
-	if (entry->texture) {
-		draw_->BindTexture(0, entry->texture);
-
-		float w = entry->bmWidth * fontScaleX_ * dpiScale_;
-		float h = entry->bmHeight * fontScaleY_ * dpiScale_;
-		DrawBuffer::DoAlign(align, &x, &y, &w, &h);
-		target.DrawTexRect(x, y, x + w, y + h, 0.0f, 0.0f, 1.0f, 1.0f, color);
-		target.Flush(true);
-	}
 }
 
 void TextDrawerQt::ClearCache() {

--- a/Common/Render/Text/draw_text_qt.cpp
+++ b/Common/Render/Text/draw_text_qt.cpp
@@ -89,7 +89,9 @@ void TextDrawerQt::MeasureStringRect(std::string_view str, const Bounds &bounds,
 	*h = (float)size.height() * fontScaleY_ * dpiScale_;
 }
 
-bool TextDrawerQt::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align) {
+bool TextDrawerQt::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align, bool fullColor) {
+	_dbg_assert_(!fullColor);
+
 	if (str.empty()) {
 		bitmapData.clear();
 		return false;
@@ -161,7 +163,7 @@ void TextDrawerQt::DrawString(DrawBuffer &target, std::string_view str, float x,
 
 		TextureDesc desc{};
 		std::vector<uint8_t> bitmapData;
-		DrawStringBitmap(bitmapData, *entry, texFormat, str, align);
+		DrawStringBitmap(bitmapData, *entry, texFormat, str, align, false);
 		desc.initData.push_back(&bitmapData[0]);
 
 		desc.type = TextureType::LINEAR2D;
@@ -177,12 +179,10 @@ void TextDrawerQt::DrawString(DrawBuffer &target, std::string_view str, float x,
 
 	if (entry->texture) {
 		draw_->BindTexture(0, entry->texture);
-	}
 
-	float w = entry->bmWidth * fontScaleX_ * dpiScale_;
-	float h = entry->bmHeight * fontScaleY_ * dpiScale_;
-	DrawBuffer::DoAlign(align, &x, &y, &w, &h);
-	if (entry->texture) {
+		float w = entry->bmWidth * fontScaleX_ * dpiScale_;
+		float h = entry->bmHeight * fontScaleY_ * dpiScale_;
+		DrawBuffer::DoAlign(align, &x, &y, &w, &h);
 		target.DrawTexRect(x, y, x + w, y + h, 0.0f, 0.0f, 1.0f, 1.0f, color);
 		target.Flush(true);
 	}

--- a/Common/Render/Text/draw_text_qt.h
+++ b/Common/Render/Text/draw_text_qt.h
@@ -19,14 +19,13 @@ public:
 	void MeasureString(std::string_view str, float *w, float *h) override;
 	void MeasureStringRect(std::string_view str, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) override;
 	void DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) override;
-	bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align = ALIGN_TOPLEFT) override;
+	bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align, bool fullColor) override;
 	// Use for housekeeping like throwing out old strings.
 	void OncePerFrame() override;
 
 protected:
 	void ClearCache() override;
 
-	uint32_t fontHash_;
 	std::map<uint32_t, QFont *> fontMap_;
 };
 

--- a/Common/Render/Text/draw_text_qt.h
+++ b/Common/Render/Text/draw_text_qt.h
@@ -24,6 +24,8 @@ public:
 	void OncePerFrame() override;
 
 protected:
+	bool SupportsColorEmoji() const override { return false; }
+
 	void ClearCache() override;
 
 	std::map<uint32_t, QFont *> fontMap_;

--- a/Common/Render/Text/draw_text_qt.h
+++ b/Common/Render/Text/draw_text_qt.h
@@ -18,7 +18,6 @@ public:
 	void SetFont(uint32_t fontHandle) override;  // Shortcut once you've set the font once.
 	void MeasureString(std::string_view str, float *w, float *h) override;
 	void MeasureStringRect(std::string_view str, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) override;
-	void DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) override;
 	bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align, bool fullColor) override;
 	// Use for housekeeping like throwing out old strings.
 	void OncePerFrame() override;

--- a/Common/Render/Text/draw_text_sdl.cpp
+++ b/Common/Render/Text/draw_text_sdl.cpp
@@ -364,56 +364,6 @@ void TextDrawerSDL::MeasureStringRect(std::string_view str, const Bounds &bounds
 	*h = total_h * fontScaleY_ * dpiScale_;
 }
 
-void TextDrawerSDL::DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align) {
-	using namespace Draw;
-	if (str.empty())
-		return;
-
-	CacheKey key{ std::string(str), fontHash_ };
-	target.Flush(true);
-
-	TextStringEntry *entry;
-
-	auto iter = cache_.find(key);
-	if (iter != cache_.end()) {
-		entry = iter->second.get();
-		entry->lastUsedFrame = frameCount_;
-	} else {
-		DataFormat texFormat = Draw::DataFormat::R4G4B4A4_UNORM_PACK16;
-		if ((draw_->GetDataFormatSupport(texFormat) & Draw::FMT_TEXTURE) == 0) {
-			// This is always supported in Vulkan. The other format is the common OpenGL one.
-			texFormat = Draw::DataFormat::B4G4R4A4_UNORM_PACK16;
-		}
-
-		entry = new TextStringEntry(frameCount_);
-
-		TextureDesc desc{};
-		std::vector<uint8_t> bitmapData;
-		DrawStringBitmap(bitmapData, *entry, texFormat, str, align, false);
-		desc.initData.push_back(&bitmapData[0]);
-
-		desc.type = TextureType::LINEAR2D;
-		desc.format = texFormat;
-		desc.width = entry->bmWidth;
-		desc.height = entry->bmHeight;
-		desc.depth = 1;
-		desc.mipLevels = 1;
-		desc.tag = "TextDrawer";
-		entry->texture = draw_->CreateTexture(desc);
-		cache_[key] = std::unique_ptr<TextStringEntry>(entry);
-	}
-
-	if (entry->texture) {
-		draw_->BindTexture(0, entry->texture);
-
-		float w = entry->bmWidth * fontScaleX_ * dpiScale_;
-		float h = entry->bmHeight * fontScaleY_ * dpiScale_;
-		DrawBuffer::DoAlign(align, &x, &y, &w, &h);
-		target.DrawTexRect(x, y, x + w, y + h, 0.0f, 0.0f, 1.0f, 1.0f, color);
-		target.Flush(true);
-	}
-}
-
 bool TextDrawerSDL::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align, bool fullColor) {
 	_dbg_assert_(!fullColor)
 

--- a/Common/Render/Text/draw_text_sdl.cpp
+++ b/Common/Render/Text/draw_text_sdl.cpp
@@ -389,7 +389,7 @@ void TextDrawerSDL::DrawString(DrawBuffer &target, std::string_view str, float x
 
 		TextureDesc desc{};
 		std::vector<uint8_t> bitmapData;
-		DrawStringBitmap(bitmapData, *entry, texFormat, str, align);
+		DrawStringBitmap(bitmapData, *entry, texFormat, str, align, false);
 		desc.initData.push_back(&bitmapData[0]);
 
 		desc.type = TextureType::LINEAR2D;
@@ -405,18 +405,18 @@ void TextDrawerSDL::DrawString(DrawBuffer &target, std::string_view str, float x
 
 	if (entry->texture) {
 		draw_->BindTexture(0, entry->texture);
-	}
 
-	float w = entry->bmWidth * fontScaleX_ * dpiScale_;
-	float h = entry->bmHeight * fontScaleY_ * dpiScale_;
-	DrawBuffer::DoAlign(align, &x, &y, &w, &h);
-	if (entry->texture) {
+		float w = entry->bmWidth * fontScaleX_ * dpiScale_;
+		float h = entry->bmHeight * fontScaleY_ * dpiScale_;
+		DrawBuffer::DoAlign(align, &x, &y, &w, &h);
 		target.DrawTexRect(x, y, x + w, y + h, 0.0f, 0.0f, 1.0f, 1.0f, color);
 		target.Flush(true);
 	}
 }
 
-bool TextDrawerSDL::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align) {
+bool TextDrawerSDL::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align, bool fullColor) {
+	_dbg_assert_(!fullColor)
+
 	if (str.empty()) {
 		bitmapData.clear();
 		return false;

--- a/Common/Render/Text/draw_text_sdl.h
+++ b/Common/Render/Text/draw_text_sdl.h
@@ -21,12 +21,13 @@ public:
 	void SetFont(uint32_t fontHandle) override;  // Shortcut once you've set the font once.
 	void MeasureString(std::string_view str, float *w, float *h) override;
 	void MeasureStringRect(std::string_view str, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) override;
-	void DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) override;
 	bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align, bool fullColor) override;
 	// Use for housekeeping like throwing out old strings.
 	void OncePerFrame() override;
 
 protected:
+	bool SupportsColorEmoji() const override { return false; }
+
 	void ClearCache() override;
 	void PrepareFallbackFonts(std::string_view locale);
 	uint32_t CheckMissingGlyph(const std::string& text);

--- a/Common/Render/Text/draw_text_sdl.h
+++ b/Common/Render/Text/draw_text_sdl.h
@@ -22,7 +22,7 @@ public:
 	void MeasureString(std::string_view str, float *w, float *h) override;
 	void MeasureStringRect(std::string_view str, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) override;
 	void DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) override;
-	bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align = ALIGN_TOPLEFT) override;
+	bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align, bool fullColor) override;
 	// Use for housekeeping like throwing out old strings.
 	void OncePerFrame() override;
 
@@ -32,7 +32,6 @@ protected:
 	uint32_t CheckMissingGlyph(const std::string& text);
 	int FindFallbackFonts(uint32_t missingGlyph, int ptSize);
 
-	uint32_t fontHash_;
 	std::map<uint32_t, _TTF_Font *> fontMap_;
 
 	std::vector<_TTF_Font *> fallbackFonts_;

--- a/Common/Render/Text/draw_text_uwp.h
+++ b/Common/Render/Text/draw_text_uwp.h
@@ -23,8 +23,7 @@ public:
 	void SetFont(uint32_t fontHandle) override;  // Shortcut once you've set the font once.
 	void MeasureString(std::string_view str, float *w, float *h) override;
 	void MeasureStringRect(std::string_view str, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) override;
-	void DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) override;
-	bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align = ALIGN_TOPLEFT) override;
+	bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align, bool fullColor) override;
 	// Use for housekeeping like throwing out old strings.
 	void OncePerFrame() override;
 
@@ -34,8 +33,6 @@ protected:
 
 	TextDrawerContext *ctx_;
 	std::map<uint32_t, std::unique_ptr<TextDrawerFontContext>> fontMap_;
-
-	uint32_t fontHash_;
 
 	// Direct2D drawing components.
 	ID2D1Factory5*        m_d2dFactory;

--- a/Common/Render/Text/draw_text_uwp.h
+++ b/Common/Render/Text/draw_text_uwp.h
@@ -28,6 +28,8 @@ public:
 	void OncePerFrame() override;
 
 protected:
+	bool SupportsColorEmoji() const override { return true; }
+
 	void ClearCache() override;
 	void RecreateFonts();  // On DPI change
 

--- a/Common/Render/Text/draw_text_win.h
+++ b/Common/Render/Text/draw_text_win.h
@@ -28,6 +28,8 @@ public:
 	void OncePerFrame() override;
 
 protected:
+	bool SupportsColorEmoji() const override { return false; }
+
 	void ClearCache() override;
 	void RecreateFonts();  // On DPI change
 

--- a/Common/Render/Text/draw_text_win.h
+++ b/Common/Render/Text/draw_text_win.h
@@ -23,8 +23,7 @@ public:
 	void SetFont(uint32_t fontHandle) override;  // Shortcut once you've set the font once.
 	void MeasureString(std::string_view str, float *w, float *h) override;
 	void MeasureStringRect(std::string_view str, const Bounds &bounds, float *w, float *h, int align = ALIGN_TOPLEFT) override;
-	void DrawString(DrawBuffer &target, std::string_view str, float x, float y, uint32_t color, int align = ALIGN_TOPLEFT) override;
-	bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align = ALIGN_TOPLEFT) override;
+	bool DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextStringEntry &entry, Draw::DataFormat texFormat, std::string_view str, int align, bool fullColor) override;
 	// Use for housekeeping like throwing out old strings.
 	void OncePerFrame() override;
 
@@ -34,8 +33,6 @@ protected:
 
 	TextDrawerContext *ctx_;
 	std::map<uint32_t, std::unique_ptr<TextDrawerFontContext>> fontMap_;
-
-	uint32_t fontHash_;
 };
 
 #endif

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -917,7 +917,7 @@ static PPGeTextDrawerImage PPGeGetTextImage(const char *text, const PPGeStyle &s
 		textDrawer->SetFontScale(style.scale, style.scale);
 		Bounds b(0, 0, maxWidth, 272.0f);
 		std::string cleaned = ReplaceAll(text, "\r", "");
-		textDrawer->DrawStringBitmapRect(bitmapData, im.entry, Draw::DataFormat::R8_UNORM, cleaned.c_str(), b, tdalign);
+		textDrawer->DrawStringBitmapRect(bitmapData, im.entry, Draw::DataFormat::R8_UNORM, cleaned.c_str(), b, tdalign, false);
 
 		int bufwBytes = ((im.entry.bmWidth + 31) / 32) * 16;
 		u32 sz = bufwBytes * (im.entry.bmHeight + 1);


### PR DESCRIPTION
Avoids repeating code in the backends, makes changes easier.