### PR TITLE
Libretro: Add video renderer core option

### DIFF
--- a/libretro/LibretroGraphicsContext.cpp
+++ b/libretro/LibretroGraphicsContext.cpp
@@ -90,8 +90,8 @@ LibretroGraphicsContext *LibretroGraphicsContext::CreateGraphicsContext() {
 	if (!Libretro::environ_cb(RETRO_ENVIRONMENT_GET_PREFERRED_HW_RENDER, &preferred))
 		preferred = RETRO_HW_CONTEXT_DUMMY;
 
-	if (Libretro::renderer != RETRO_HW_CONTEXT_DUMMY)
-		preferred = Libretro::renderer;
+	if (Libretro::backend != RETRO_HW_CONTEXT_DUMMY)
+		preferred = Libretro::backend;
 
 #ifndef USING_GLES2
 	if (preferred == RETRO_HW_CONTEXT_DUMMY || preferred == RETRO_HW_CONTEXT_OPENGL_CORE) {

--- a/libretro/LibretroGraphicsContext.h
+++ b/libretro/LibretroGraphicsContext.h
@@ -14,6 +14,7 @@
 
 #define NATIVEWIDTH  480
 #define NATIVEHEIGHT 272
+#define SOFT_BMP_SIZE NATIVEWIDTH * NATIVEHEIGHT * 4
 
 class LibretroGraphicsContext : public GraphicsContext {
 public:
@@ -89,19 +90,25 @@ public:
 	bool Init() override { return true; }
 	void SwapBuffers() override {
 		GPUDebugBuffer buf;
+		u16 w = NATIVEWIDTH;
+		u16 h = NATIVEHEIGHT;
 		gpuDebug->GetOutputFramebuffer(buf);
-		const std::vector<u32> pixels = TranslateDebugBufferToCompare(&buf, NATIVEWIDTH, NATIVEHEIGHT);
-		u32 offset = g_Config.bDisplayCropTo16x9 ? NATIVEWIDTH : 0;
-		video_cb(pixels.data() + offset, NATIVEWIDTH, PSP_CoreParameter().pixelHeight, NATIVEWIDTH << 2);
+		const std::vector<u32> pixels = TranslateDebugBufferToCompare(&buf, w, h);
+		memcpy(soft_bmp, pixels.data(), SOFT_BMP_SIZE);
+		u32 offset = g_Config.bDisplayCropTo16x9 ? w << 1 : 0;
+		h -= g_Config.bDisplayCropTo16x9 ? 2 : 0;
+		video_cb(soft_bmp + offset, w, h, w << 2);
     }
 	GPUCore GetGPUCore() override { return GPUCORE_SOFTWARE; }
 	const char *Ident() override { return "Software"; }
+
+	u16 soft_bmp[SOFT_BMP_SIZE] = {0};
 };
 
 namespace Libretro {
 extern LibretroGraphicsContext *ctx;
 extern retro_environment_t environ_cb;
-extern retro_hw_context_type renderer;
+extern retro_hw_context_type backend;
 
 enum class EmuThreadState {
 	DISABLED,

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -100,6 +100,7 @@ namespace Libretro
 {
    LibretroGraphicsContext *ctx;
    retro_environment_t environ_cb;
+   retro_hw_context_type renderer = RETRO_HW_CONTEXT_DUMMY;
    static retro_audio_sample_batch_t audio_batch_cb;
    static retro_input_poll_t input_poll_cb;
    static retro_input_state_t input_state_cb;
@@ -1329,6 +1330,26 @@ namespace Libretro
 
 } // namespace Libretro
 
+static void retro_check_renderer(void)
+{
+   struct retro_variable var = {0};
+
+   var.key = "ppsspp_renderer";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "hardware"))
+         renderer = RETRO_HW_CONTEXT_DUMMY;
+      else if (!strcmp(var.value, "hardware_gl"))
+         renderer = RETRO_HW_CONTEXT_OPENGL;
+      else if (!strcmp(var.value, "hardware_vk"))
+         renderer = RETRO_HW_CONTEXT_VULKAN;
+      else if (!strcmp(var.value, "hardware_d3d"))
+         renderer = RETRO_HW_CONTEXT_DIRECT3D;
+      else if (!strcmp(var.value, "software"))
+         renderer = RETRO_HW_CONTEXT_NONE;
+   }
+}
+
 bool retro_load_game(const struct retro_game_info *game)
 {
    retro_pixel_format fmt = retro_pixel_format::RETRO_PIXEL_FORMAT_XRGB8888;
@@ -1337,6 +1358,8 @@ bool retro_load_game(const struct retro_game_info *game)
       ERROR_LOG(SYSTEM, "XRGB8888 is not supported.\n");
       return false;
    }
+
+   retro_check_renderer();
 
    coreState = CORE_POWERUP;
    ctx       = LibretroGraphicsContext::CreateGraphicsContext();

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1155,6 +1155,18 @@ void retro_set_audio_sample(retro_audio_sample_t cb) { (void)cb; }
 void retro_set_input_poll(retro_input_poll_t cb) { input_poll_cb = cb; }
 void retro_set_input_state(retro_input_state_t cb) { input_state_cb = cb; }
 
+static const struct retro_controller_description psp_controllers[] =
+{
+   { "PSP", RETRO_DEVICE_JOYPAD },
+   { NULL, 0 }
+};
+
+static const struct retro_controller_info ports[] =
+{
+   { psp_controllers, 1 },
+   { NULL, 0 }
+};
+
 void retro_init(void)
 {
    VsyncSwapIntervalReset();
@@ -1181,6 +1193,7 @@ void retro_init(void)
       { 0 },
    };
    environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc);
+   environ_cb(RETRO_ENVIRONMENT_SET_CONTROLLER_INFO, (void*)ports);
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_INPUT_BITMASKS, NULL))
       libretro_supports_bitmasks = true;

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -711,15 +711,6 @@ static void check_variables(CoreParameter &coreParam)
          g_Config.bDisplayCropTo16x9 = true;
    }
 
-   var.key = "ppsspp_skip_gpu_readbacks";
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (!strcmp(var.value, "disabled"))
-         g_Config.iSkipGPUReadbackMode = (int)SkipGPUReadbackMode::NO_SKIP;
-      else
-         g_Config.iSkipGPUReadbackMode = (int)SkipGPUReadbackMode::SKIP;
-   }
-
    var.key = "ppsspp_frameskip";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
       g_Config.iFrameSkip = atoi(var.value);
@@ -771,22 +762,31 @@ static void check_variables(CoreParameter &coreParam)
          g_Config.iInflightFrames = 2;
    }
 
-   var.key = "ppsspp_gpu_hardware_transform";
+   var.key = "ppsspp_skip_buffer_effects";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (!strcmp(var.value, "disabled"))
-         g_Config.bHardwareTransform = false;
+         g_Config.bSkipBufferEffects = false;
       else
-         g_Config.bHardwareTransform = true;
+         g_Config.bSkipBufferEffects = true;
    }
 
-   var.key = "ppsspp_software_skinning";
+   var.key = "ppsspp_disable_range_culling";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (!strcmp(var.value, "disabled"))
-         g_Config.bSoftwareSkinning = false;
+         g_Config.bDisableRangeCulling = false;
       else
-         g_Config.bSoftwareSkinning = true;
+         g_Config.bDisableRangeCulling = true;
+   }
+
+   var.key = "ppsspp_skip_gpu_readbacks";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "disabled"))
+         g_Config.iSkipGPUReadbackMode = (int)SkipGPUReadbackMode::NO_SKIP;
+      else
+         g_Config.iSkipGPUReadbackMode = (int)SkipGPUReadbackMode::SKIP;
    }
 
    var.key = "ppsspp_lazy_texture_caching";
@@ -807,6 +807,24 @@ static void check_variables(CoreParameter &coreParam)
          g_Config.iSplineBezierQuality = 1;
       else if (!strcmp(var.value, "High"))
          g_Config.iSplineBezierQuality = 2;
+   }
+
+   var.key = "ppsspp_gpu_hardware_transform";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "disabled"))
+         g_Config.bHardwareTransform = false;
+      else
+         g_Config.bHardwareTransform = true;
+   }
+
+   var.key = "ppsspp_software_skinning";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "disabled"))
+         g_Config.bSoftwareSkinning = false;
+      else
+         g_Config.bSoftwareSkinning = true;
    }
 
    var.key = "ppsspp_hardware_tesselation";

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -110,8 +110,8 @@ struct retro_core_option_v2_category option_cats_us[] = {
    },
    {
       "hacks",
-      "Speed Hacks",
-      "Configure speed hacks. Can cause rendering errors!"
+      "Hacks",
+      "Configure speed and emulation hacks. Can cause rendering errors!"
    },
    {
       "network",
@@ -236,9 +236,9 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_language",
-      "Language",
+      "Game Language",
       NULL,
-      "Choose language, 'Automatic' will use the frontend language.",
+      "'Automatic' will use the frontend language.",
       NULL,
       "system",
       {
@@ -274,44 +274,54 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "psp_2000_3000"
    },
    {
-      "ppsspp_renderer",
-      "Renderer",
+      "ppsspp_backend",
+      "Backend",
       NULL,
-      "'Hardware (Auto)' selects the renderer depending upon the current libretro frontend video driver. Restart required.",
+      "'Automatic' will use the frontend video driver. Core restart required.",
       NULL,
       "video",
       {
-         { "hardware",    "Hardware (Auto)" },
-         { "hardware_gl", "Hardware (OpenGL)" },
+         { "auto",   "Automatic" },
+         { "opengl", "OpenGL" },
 #ifndef HAVE_LIBNX
-         { "hardware_vk", "Hardware (Vulkan)" },
+         { "vulkan", "Vulkan" },
 #endif
 #ifdef _WIN32
-         { "hardware_d3d", "Hardware (D3D11)" },
+         { "d3d11",  "D3D11" },
 #endif
-         { "software",    "Software" },
+         { "none",   "None" },
          { NULL, NULL },
       },
-      "hardware"
+      "auto"
+   },
+   {
+      "ppsspp_software_rendering",
+      "Software Rendering",
+      NULL,
+      "Slow, accurate. Core restart required.",
+      NULL,
+      "video",
+      BOOL_OPTIONS,
+      "disabled"
    },
    {
       "ppsspp_internal_resolution",
-      "Internal Resolution",
+      "Rendering Resolution",
       NULL,
-      "Restart required.",
+      "Core restart required with Vulkan.",
       NULL,
       "video",
       {
-         { "480x272",   NULL },
-         { "960x544",   NULL },
-         { "1440x816",  NULL },
-         { "1920x1088", NULL },
-         { "2400x1360", NULL },
-         { "2880x1632", NULL },
-         { "3360x1904", NULL },
-         { "3840x2176", NULL },
-         { "4320x2448", NULL },
-         { "4800x2720", NULL },
+         { "480x272",   "1x (480x272)" },
+         { "960x544",   "2x (960x544)" },
+         { "1440x816",  "3x (1440x816)" },
+         { "1920x1088", "4x (1920x1088)" },
+         { "2400x1360", "5x (2400x1360)" },
+         { "2880x1632", "6x (2880x1632)" },
+         { "3360x1904", "7x (3360x1904)" },
+         { "3840x2176", "8x (3840x2176)" },
+         { "4320x2448", "9x (4320x2448)" },
+         { "4800x2720", "10x (4800x2720)" },
          { NULL, NULL },
       },
       "480x272"
@@ -338,7 +348,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "ppsspp_cropto16x9",
       "Crop to 16x9",
       NULL,
-      "Remove one line from top and bottom to get exact 16:9. Restart required with Vulkan!",
+      "Remove one line from top and bottom to get exact 16:9. Core restart required with Vulkan.",
       NULL,
       "video",
       BOOL_OPTIONS,
@@ -411,7 +421,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_inflight_frames",
-      "Buffered Frames",
+      "Buffer Graphics Commands",
       NULL,
       "GL/Vulkan only, slower, less lag, restart.",
       NULL,
@@ -504,6 +514,22 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "High"
    },
    {
+      "ppsspp_lower_resolution_for_effects",
+      "Lower Resolution for Effects",
+      NULL,
+      "Reduces artifacts.",
+      NULL,
+      "hacks",
+      {
+         { "disabled",   NULL },
+         { "Safe",       NULL },
+         { "Balanced",   NULL },
+         { "Aggressive", NULL },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
       "ppsspp_gpu_hardware_transform",
       "Hardware Transform",
       NULL,
@@ -544,24 +570,8 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
-      "ppsspp_lower_resolution_for_effects",
-      "Lower Resolution for Effects",
-      NULL,
-      NULL,
-      NULL,
-      "video",
-      {
-         { "disabled",   NULL },
-         { "Safe",       NULL },
-         { "Balanced",   NULL },
-         { "Aggressive", NULL },
-         { NULL, NULL },
-      },
-      "disabled"
-   },
-   {
       "ppsspp_texture_scaling_type",
-      "Texture Scaling Type",
+      "Texture Upscale Type",
       NULL,
       NULL,
       NULL,
@@ -577,7 +587,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_texture_scaling_level",
-      "Texture Scaling Level",
+      "Texture Upscaling Level",
       NULL,
       "CPU heavy, some scaling may be delayed to avoid stutter.",
       NULL,

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -349,6 +349,16 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
 #endif
    {
+      "ppsspp_cropto16x9",
+      "Crop to 16x9",
+      NULL,
+      "Remove one line from top and bottom to get exact 16:9. Restart required with Vulkan!",
+      NULL,
+      "video",
+      BOOL_OPTIONS,
+      "enabled"
+   },
+   {
       "ppsspp_skip_gpu_readbacks",
       "Skip GPU Readbacks",
       NULL,

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -288,10 +288,31 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "enabled"
    },
    {
+      "ppsspp_renderer",
+      "Renderer",
+      NULL,
+      "'Hardware (Auto)' selects the renderer depending upon the current libretro frontend video driver. Restart required.",
+      NULL,
+      "video",
+      {
+         { "hardware",    "Hardware (Auto)" },
+         { "hardware_gl", "Hardware (OpenGL)" },
+#ifndef HAVE_LIBNX
+         { "hardware_vk", "Hardware (Vulkan)" },
+#endif
+#ifdef _WIN32
+         { "hardware_d3d", "Hardware (D3D11)" },
+#endif
+         { "software",    "Software" },
+         { NULL, NULL },
+      },
+      "hardware"
+   },
+   {
       "ppsspp_internal_resolution",
-      "Internal Resolution (Restart)",
+      "Internal Resolution",
       NULL,
-      NULL,
+      "Restart required.",
       NULL,
       "video",
       {

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -104,6 +104,16 @@ struct retro_core_option_v2_category option_cats_us[] = {
       "Configure video options."
    },
    {
+      "input",
+      "Input",
+      "Configure input options."
+   },
+   {
+      "hacks",
+      "Speed Hacks",
+      "Configure speed hacks. Can cause rendering errors!"
+   },
+   {
       "network",
       "Network",
       "Configure network options."
@@ -112,31 +122,6 @@ struct retro_core_option_v2_category option_cats_us[] = {
 };
 
 struct retro_core_option_v2_definition option_defs_us[] = {
-   {
-      "ppsspp_language",
-      "Language",
-      NULL,
-      "Choose language, 'Automatic' will use the frontend language.",
-      NULL,
-      "system",
-      {
-         { "Automatic",           NULL },
-         { "English",             NULL },
-         { "Japanese",            NULL },
-         { "French",              NULL },
-         { "Spanish",             NULL },
-         { "German",              NULL },
-         { "Italian",             NULL },
-         { "Dutch",               NULL },
-         { "Portuguese",          NULL },
-         { "Russian",             NULL },
-         { "Korean",              NULL },
-         { "Chinese Traditional", NULL },
-         { "Chinese Simplified",  NULL },
-         { NULL, NULL },
-      },
-      "Automatic"
-   },
    {
       "ppsspp_cpu_core",
       "CPU Core",
@@ -156,7 +141,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "ppsspp_fast_memory",
       "Fast Memory",
       NULL,
-      NULL,
+      "Unstable.",
       NULL,
       "system",
       BOOL_OPTIONS,
@@ -189,9 +174,9 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_force_lag_sync",
-      "Force Real Clock Sync (Slower, less lag)",
+      "Force Real Clock Sync",
       NULL,
-      NULL,
+      "Slower, less lag.",
       NULL,
       "system",
       BOOL_OPTIONS,
@@ -220,6 +205,16 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "ppsspp_memstick_inserted",
+      "Memory Stick Inserted",
+      NULL,
+      "Some games require ejecting/inserting the Memory Stick.",
+      NULL,
+      "system",
+      BOOL_OPTIONS,
+      "enabled"
+   },
+   {
       "ppsspp_cache_iso",
       "Cache Full ISO in RAM",
       NULL,
@@ -240,6 +235,31 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
+      "ppsspp_language",
+      "Language",
+      NULL,
+      "Choose language, 'Automatic' will use the frontend language.",
+      NULL,
+      "system",
+      {
+         { "Automatic",           NULL },
+         { "English",             NULL },
+         { "Japanese",            NULL },
+         { "French",              NULL },
+         { "Spanish",             NULL },
+         { "German",              NULL },
+         { "Italian",             NULL },
+         { "Dutch",               NULL },
+         { "Portuguese",          NULL },
+         { "Russian",             NULL },
+         { "Korean",              NULL },
+         { "Chinese Traditional", NULL },
+         { "Chinese Simplified",  NULL },
+         { NULL, NULL },
+      },
+      "Automatic"
+   },
+   {
       "ppsspp_psp_model",
       "PSP Model",
       NULL,
@@ -252,40 +272,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { NULL, NULL },
       },
       "psp_2000_3000"
-   },
-   {
-      "ppsspp_button_preference",
-      "Confirmation Button",
-      NULL,
-      NULL,
-      NULL,
-      "system",
-      {
-         { "Cross",  NULL },
-         { "Circle", NULL },
-         { NULL, NULL },
-      },
-      "Cross"
-   },
-   {
-      "ppsspp_analog_is_circular",
-      "Analog Circle vs Square Gate Compensation",
-      NULL,
-      NULL,
-      NULL,
-      "system",
-      BOOL_OPTIONS,
-      "disabled"
-   },
-   {
-      "ppsspp_memstick_inserted",
-      "Memory Stick Inserted",
-      NULL,
-      "Some games require ejecting/inserting the Memory Stick.",
-      NULL,
-      "system",
-      BOOL_OPTIONS,
-      "enabled"
    },
    {
       "ppsspp_renderer",
@@ -359,16 +345,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "enabled"
    },
    {
-      "ppsspp_skip_gpu_readbacks",
-      "Skip GPU Readbacks",
-      NULL,
-      "Some games require GPU readbacks, so be careful.",
-      NULL,
-      "video",
-      BOOL_OPTIONS,
-      "disabled"
-   },
-   {
       "ppsspp_frameskip",
       "Frameskip",
       NULL,
@@ -415,7 +391,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_frame_duplication",
-      "Duplicate Frames in 30 Hz Games",
+      "Render Duplicate Frames to 60 Hz",
       NULL,
       "Can make framerate smoother in games that run at lower framerates.",
       NULL,
@@ -425,9 +401,9 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_detect_vsync_swap_interval",
-      "Detect Frame Rate Changes (Notify frontend)",
+      "Detect Frame Rate Changes",
       NULL,
-      NULL,
+      "Notify frontend.",
       NULL,
       "video",
       BOOL_OPTIONS,
@@ -435,9 +411,9 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_inflight_frames",
-      "Buffered Frames (GL/Vulkan only, slower, less lag, restart)",
+      "Buffered Frames",
       NULL,
-      NULL,
+      "GL/Vulkan only, slower, less lag, restart.",
       NULL,
       "video",
       {
@@ -447,6 +423,85 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { NULL, NULL },
       },
       "Up to 2"
+   },
+   {
+      "ppsspp_button_preference",
+      "Confirmation Button",
+      NULL,
+      NULL,
+      NULL,
+      "input",
+      {
+         { "Cross",  NULL },
+         { "Circle", NULL },
+         { NULL, NULL },
+      },
+      "Cross"
+   },
+   {
+      "ppsspp_analog_is_circular",
+      "Analog Circle vs Square Gate Compensation",
+      NULL,
+      NULL,
+      NULL,
+      "input",
+      BOOL_OPTIONS,
+      "disabled"
+   },
+   {
+      "ppsspp_skip_buffer_effects",
+      "Skip Buffer Effects",
+      NULL,
+      "Faster, but nothing may draw in some games.",
+      NULL,
+      "hacks",
+      BOOL_OPTIONS,
+      "disabled"
+   },
+   {
+      "ppsspp_disable_range_culling",
+      "Disable Culling",
+      NULL,
+      "",
+      NULL,
+      "hacks",
+      BOOL_OPTIONS,
+      "disabled"
+   },
+   {
+      "ppsspp_skip_gpu_readbacks",
+      "Skip GPU Readbacks",
+      NULL,
+      "Some games require GPU readbacks, so be careful.",
+      NULL,
+      "hacks",
+      BOOL_OPTIONS,
+      "disabled"
+   },
+   {
+      "ppsspp_lazy_texture_caching",
+      "Lazy Texture Caching (Speedup)",
+      NULL,
+      "Faster, but can cause text problems in a few games.",
+      NULL,
+      "hacks",
+      BOOL_OPTIONS,
+      "disabled"
+   },
+   {
+      "ppsspp_spline_quality",
+      "Spline/Bezier Curves Quality",
+      NULL,
+      "Only used by some games, controls smoothness of curves.",
+      NULL,
+      "hacks",
+      {
+         { "Low",    NULL },
+         { "Medium", NULL },
+         { "High",   NULL },
+         { NULL, NULL },
+      },
+      "High"
    },
    {
       "ppsspp_gpu_hardware_transform",
@@ -469,45 +524,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "enabled"
    },
    {
-      "ppsspp_vertex_cache",
-      "Vertex Cache",
-      NULL,
-      "Faster, but may cause temporary flicker.",
-      NULL,
-      "video",
-      BOOL_OPTIONS,
-      "disabled"
-   },
-   {
-      "ppsspp_lazy_texture_caching",
-      "Lazy Texture Caching (Speedup)",
-      NULL,
-      "Faster, but can cause text problems in a few games.",
-      NULL,
-      "video",
-      BOOL_OPTIONS,
-      "disabled"
-   },
-   {
-      "ppsspp_spline_quality",
-      "Spline/Bezier Curves Quality",
-      NULL,
-      "Only used by some games, controls smoothness of curves.",
-      NULL,
-      "video",
-      {
-         { "Low",    NULL },
-         { "Medium", NULL },
-         { "High",   NULL },
-         { NULL, NULL },
-      },
-      "High"
-   },
-   {
       "ppsspp_hardware_tesselation",
       "Hardware Tesselation",
       NULL,
       "Uses hardware to make curves.",
+      NULL,
+      "video",
+      BOOL_OPTIONS,
+      "disabled"
+   },
+   {
+      "ppsspp_vertex_cache",
+      "Vertex Cache",
+      NULL,
+      "Faster, but may cause temporary flicker.",
       NULL,
       "video",
       BOOL_OPTIONS,
@@ -574,9 +604,9 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_texture_shader",
-      "Texture Shader (Vulkan only, overrides 'Texture Scaling Type')",
+      "Texture Shader",
       NULL,
-      NULL,
+      "Vulkan only, overrides 'Texture Scaling Type'.",
       NULL,
       "video",
       {

--- a/libretro/libretro_vulkan.cpp
+++ b/libretro/libretro_vulkan.cpp
@@ -125,14 +125,17 @@ static VKAPI_ATTR VkResult VKAPI_CALL vkCreateLibretroSurfaceKHR(VkInstance inst
 VKAPI_ATTR VkResult VKAPI_CALL vkGetPhysicalDeviceSurfaceCapabilitiesKHR_libretro(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR *pSurfaceCapabilities) {
 	VkResult res = vkGetPhysicalDeviceSurfaceCapabilitiesKHR_org(physicalDevice, surface, pSurfaceCapabilities);
 	if (res == VK_SUCCESS) {
-      int w = g_Config.iInternalResolution * 480;
-      int h = g_Config.iInternalResolution * 272;
+		int w = g_Config.iInternalResolution * NATIVEWIDTH;
+		int h = g_Config.iInternalResolution * NATIVEHEIGHT;
 
-      pSurfaceCapabilities->minImageExtent.width = w;
-      pSurfaceCapabilities->minImageExtent.height = h;
-      pSurfaceCapabilities->maxImageExtent.width = w;
-      pSurfaceCapabilities->maxImageExtent.height = h;
-      pSurfaceCapabilities->currentExtent.width = w;
+		if (g_Config.bDisplayCropTo16x9)
+			h -= g_Config.iInternalResolution * 2;
+
+		pSurfaceCapabilities->minImageExtent.width = w;
+		pSurfaceCapabilities->minImageExtent.height = h;
+		pSurfaceCapabilities->maxImageExtent.width = w;
+		pSurfaceCapabilities->maxImageExtent.height = h;
+		pSurfaceCapabilities->currentExtent.width = w;
 		pSurfaceCapabilities->currentExtent.height = h;
 	}
 	return res;

--- a/libretro/libretro_vulkan.h
+++ b/libretro/libretro_vulkan.h
@@ -29,6 +29,7 @@
 
 #include "ext/vulkan/vulkan.h"
 #include "libretro.h"
+#include "LibretroGraphicsContext.h"
 
 #define RETRO_HW_RENDER_INTERFACE_VULKAN_VERSION 5
 #define RETRO_HW_RENDER_CONTEXT_NEGOTIATION_INTERFACE_VULKAN_VERSION 1


### PR DESCRIPTION
- Add core option for video renderer
  - Defaults to current auto mode
  - Was not possible to add both gl and glcore, since frontend will return glcore regardless if it exists, unless gl is already the current frontend driver
  Closes #14866
- Add core option for cropping to 16x9
- Add separate core option category for speed hacks
- Add missing speed hacks as core options
- Set the only available emulated controller type with `SET_CONTROLLER_INFO`
- Reorganized core options to match better with the original regarding labels and order

Also hooked up software renderer, and please tell me if there is a better way of getting the image than using `TranslateDebugBufferToCompare()`. It has a minor issue though with the image getting full of garbage in the background if frontend pauses the core in the menu, but otherwise seems fine. Also wasn't able to figure out how to reset context cleanly with Vulkan after toggling the 16x9 crop mode while the core is running, so left that for later times.
