### PR TITLE
Store IR instructions in a bump-allocated vector instead of loose allocations

### DIFF
--- a/Core/MIPS/ARM64/Arm64IRJit.h
+++ b/Core/MIPS/ARM64/Arm64IRJit.h
@@ -40,9 +40,9 @@ public:
 	bool DescribeCodePtr(const u8 *ptr, std::string &name) const override;
 
 	void GenerateFixedCode(MIPSState *mipsState) override;
-	bool CompileBlock(IRBlock *block, int block_num, bool preload) override;
+	bool CompileBlock(IRBlockCache *irBlockCache, int block_num, bool preload) override;
 	void ClearAllBlocks() override;
-	void InvalidateBlock(IRBlock *block, int block_num) override;
+	void InvalidateBlock(IRBlockCache *irBlockCache, int block_num) override;
 
 	void UpdateFCR31(MIPSState *mipsState) override;
 

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -184,6 +184,8 @@ static const IRMeta irMeta[] = {
 const IRMeta *metaIndex[256];
 
 void InitIR() {
+	if (metaIndex[0])
+		return;
 	for (size_t i = 0; i < ARRAY_SIZE(irMeta); i++) {
 		metaIndex[(int)irMeta[i].op] = &irMeta[i];
 	}

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -256,13 +256,12 @@ void IRJit::RunLoopUntil(u64 globalticks) {
 			if (opcode == MIPS_EMUHACK_OPCODE) {
 				u32 offset = inst & 0x00FFFFFF; // Alternatively, inst - opcode
 #ifdef IR_PROFILING
-				{
-					TimeSpan span;
-					IRBlock *block = blocks_.GetBlock(blocks_.GetBlockNumFromOffset(inst & 0xFFFFFF));
-					mips->pc = IRInterpret(mips, blocks_.GetArenaPtr() + offset);
-					block->profileStats_.executions += 1;
-					block->profileStats_.totalNanos += span.ElapsedNanos();
-				}
+				IRBlock *block = blocks_.GetBlock(blocks_.GetBlockNumFromOffset(offset));
+				TimeSpan span;
+				mips->pc = IRInterpret(mips, blocks_.GetArenaPtr() + offset);
+				int64_t elapsedNanos = span.ElapsedNanos();
+				block->profileStats_.executions += 1;
+				block->profileStats_.totalNanos += elapsedNanos;
 #else
 				mips->pc = IRInterpret(mips, blocks_.GetArenaPtr() + offset);
 #endif

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -102,11 +102,11 @@ void IRJit::Compile(u32 em_address) {
 		// Look to see if we've preloaded this block.
 		int block_num = blocks_.FindPreloadBlock(em_address);
 		if (block_num != -1) {
-			IRBlock *b = blocks_.GetBlock(block_num);
+			IRBlock *block = blocks_.GetBlock(block_num);
 			// Okay, let's link and finalize the block now.
-			int cookie = b->GetTargetOffset() < 0 ? b->GetInstructionOffset() : b->GetTargetOffset();
-			b->Finalize(cookie);
-			if (b->IsValid()) {
+			int cookie = block->GetTargetOffset() < 0 ? block->GetInstructionOffset() : block->GetTargetOffset();
+			block->Finalize(cookie);
+			if (block->IsValid()) {
 				// Success, we're done.
 				FinalizeTargetBlock(&blocks_, block_num);
 				return;
@@ -448,7 +448,7 @@ std::vector<u32> IRBlockCache::SaveAndClearEmuHackOps() {
 
 	for (int number = 0; number < (int)blocks_.size(); ++number) {
 		IRBlock &b = blocks_[number];
-		int cookie = b.GetTargetOffset() < 0 ? b.GetInstructionOffset()  : b.GetTargetOffset();
+		int cookie = b.GetTargetOffset() < 0 ? b.GetInstructionOffset() : b.GetTargetOffset();
 		if (b.IsValid() && b.RestoreOriginalFirstOp(cookie)) {
 			result[number] = number;
 		} else {

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -469,7 +469,7 @@ void IRBlockCache::RestoreSavedEmuHackOps(const std::vector<u32> &saved) {
 		IRBlock &b = blocks_[number];
 		// Only if we restored it, write it back.
 		if (b.IsValid() && saved[number] != 0 && b.HasOriginalFirstOp()) {
-			int cookie = b.GetTargetOffset() < 0 ? number : b.GetTargetOffset();
+			int cookie = b.GetTargetOffset() < 0 ? b.GetInstructionOffset() : b.GetTargetOffset();
 			b.Finalize(cookie);
 		}
 	}

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -33,7 +33,15 @@
 #include "stddef.h"
 #endif
 
+// Very expensive, time-profiles every block.
+// Not to be released with this enabled.
+//
 // #define IR_PROFILING
+
+// Try to catch obvious misses of be above rule.
+#if defined(IR_PROFILING) && defined(GOLD)
+#error
+#endif
 
 namespace MIPSComp {
 
@@ -111,14 +119,7 @@ public:
 	std::vector<int> FindInvalidatedBlockNumbers(u32 address, u32 length);
 	void FinalizeBlock(int blockNum, bool preload = false);
 	int GetNumBlocks() const override { return (int)blocks_.size(); }
-	int AllocateBlock(int emAddr, u32 origSize, const std::vector<IRInst> &inst) {
-		int offset = (int)arena_.size();
-		for (int i = 0; i < inst.size(); i++) {
-			arena_.push_back(inst[i]);
-		}
-		blocks_.push_back(IRBlock(emAddr, origSize, offset, (u16)inst.size()));
-		return (int)blocks_.size() - 1;
-	}
+	int AllocateBlock(int emAddr, u32 origSize, const std::vector<IRInst> &inst);
 	IRBlock *GetBlock(int blockNum) {
 		if (blockNum >= 0 && blockNum < (int)blocks_.size()) {
 			return &blocks_[blockNum];

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -106,7 +106,7 @@ private:
 
 class IRBlockCache : public JitBlockCacheDebugInterface {
 public:
-	IRBlockCache() {}
+	IRBlockCache();
 	void Clear();
 	std::vector<int> FindInvalidatedBlockNumbers(u32 address, u32 length);
 	void FinalizeBlock(int blockNum, bool preload = false);

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -103,6 +103,7 @@ private:
 	u64 CalculateHash() const;
 
 	// Offset into the block cache's Arena
+	// TODO: These should maybe be stored in a separate array.
 	u32 instOffset_ = 0;
 	u64 hash_ = 0;
 	u32 origAddr_ = 0;

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -126,11 +126,15 @@ public:
 			return nullptr;
 		}
 	}
+	int GetBlockNumFromOffset(int offset) const;
 	const IRInst *GetBlockInstructionPtr(const IRBlock &block) const {
 		return arena_.data() + block.GetInstructionOffset();
 	}
 	const IRInst *GetBlockInstructionPtr(int blockNum) const {
 		return arena_.data() + blocks_[blockNum].GetInstructionOffset();
+	}
+	const IRInst *GetArenaPtr() const {
+		return arena_.data();
 	}
 	bool IsValidBlock(int blockNum) const override {
 		return blockNum >= 0 && blockNum < (int)blocks_.size() && blocks_[blockNum].IsValid();

--- a/Core/MIPS/IR/IRNativeCommon.h
+++ b/Core/MIPS/IR/IRNativeCommon.h
@@ -71,10 +71,10 @@ public:
 	int OffsetFromCodePtr(const u8 *ptr);
 
 	virtual void GenerateFixedCode(MIPSState *mipsState) = 0;
-	virtual bool CompileBlock(IRBlock *block, int block_num, bool preload) = 0;
+	virtual bool CompileBlock(IRBlockCache *irBlockCache, int block_num, bool preload) = 0;
 	virtual void ClearAllBlocks() = 0;
-	virtual void InvalidateBlock(IRBlock *block, int block_num) = 0;
-	void FinalizeBlock(IRBlock *block, int block_num, const JitOptions &jo);
+	virtual void InvalidateBlock(IRBlockCache *irBlockCache, int block_num) = 0;
+	void FinalizeBlock(IRBlockCache *irBlockCache, int block_num, const JitOptions &jo);
 
 	virtual void UpdateFCR31(MIPSState *mipsState) {}
 
@@ -199,8 +199,8 @@ public:
 
 protected:
 	void Init(IRNativeBackend &backend);
-	bool CompileTargetBlock(IRBlock *block, int block_num, bool preload) override;
-	void FinalizeTargetBlock(IRBlock *block, int block_num) override;
+	bool CompileTargetBlock(IRBlockCache *irBlockCache, int block_num, bool preload) override;
+	void FinalizeTargetBlock(IRBlockCache *irBlockCache, int block_num) override;
 
 	IRNativeBackend *backend_ = nullptr;
 	IRNativeHooks hooks_;

--- a/Core/MIPS/IR/IRRegCache.h
+++ b/Core/MIPS/IR/IRRegCache.h
@@ -40,6 +40,7 @@ class MIPSState;
 
 namespace MIPSComp {
 class IRBlock;
+class IRBlockCache;
 struct JitOptions;
 }
 
@@ -153,7 +154,7 @@ public:
 	IRNativeRegCacheBase(MIPSComp::JitOptions *jo);
 	virtual ~IRNativeRegCacheBase() {}
 
-	virtual void Start(MIPSComp::IRBlock *irBlock);
+	virtual void Start(MIPSComp::IRBlockCache *irBlockCache, int blockNum);
 	void SetIRIndex(int index) {
 		irIndex_ = index;
 	}
@@ -248,7 +249,9 @@ protected:
 	bool IsValidFPR(IRReg r) const;
 
 	MIPSComp::JitOptions *jo_;
+	int irBlockNum_ = 0;
 	const MIPSComp::IRBlock *irBlock_ = nullptr;
+	const MIPSComp::IRBlockCache *irBlockCache_ = nullptr;
 	int irIndex_ = 0;
 
 	struct {

--- a/Core/MIPS/MIPSIntVFPU.cpp
+++ b/Core/MIPS/MIPSIntVFPU.cpp
@@ -2128,7 +2128,7 @@ namespace MIPSInt
 			ApplySwizzleT(&t[n - 1], V_Single, -INFINITY);
 		}
 
-		for (int i = 0; i < n; i++) {
+		for (int i = 0; i < (int)n; i++) {
 			switch (optype) {
 			case 0: d.f[i] = s[i] + t[i]; break; //vadd
 			case 1: d.f[i] = s[i] - t[i]; break; //vsub

--- a/Core/MIPS/RiscV/RiscVJit.cpp
+++ b/Core/MIPS/RiscV/RiscVJit.cpp
@@ -56,10 +56,11 @@ static void NoBlockExits() {
 	_assert_msg_(false, "Never exited block, invalid IR?");
 }
 
-bool RiscVJitBackend::CompileBlock(IRBlock *block, int block_num, bool preload) {
+bool RiscVJitBackend::CompileBlock(IRBlockCache *irBlockCache, int block_num, bool preload) {
 	if (GetSpaceLeft() < 0x800)
 		return false;
 
+	IRBlock *block = irBlockCache->GetBlock(block_num);
 	BeginWrite(std::min(GetSpaceLeft(), (size_t)block->GetNumInstructions() * 32));
 
 	u32 startPC = block->GetOriginalStart();
@@ -81,11 +82,12 @@ bool RiscVJitBackend::CompileBlock(IRBlock *block, int block_num, bool preload) 
 	block->SetTargetOffset((int)GetOffset(blockStart));
 	compilingBlockNum_ = block_num;
 
-	regs_.Start(block);
+	regs_.Start(irBlockCache, block_num);
 
 	std::vector<const u8 *> addresses;
+	const IRInst *instructions = irBlockCache->GetBlockInstructionPtr(*block);
 	for (int i = 0; i < block->GetNumInstructions(); ++i) {
-		const IRInst &inst = block->GetInstructions()[i];
+		const IRInst &inst = instructions[i];
 		regs_.SetIRIndex(i);
 		addresses.push_back(GetCodePtr());
 
@@ -142,10 +144,11 @@ bool RiscVJitBackend::CompileBlock(IRBlock *block, int block_num, bool preload) 
 			addressesLookup[addresses[i]] = i;
 
 		INFO_LOG(JIT, "=============== RISCV (%08x, %d bytes) ===============", startPC, len);
+		const IRInst *instructions = irBlockCache->GetBlockInstructionPtr(*block);
 		for (const u8 *p = blockStart; p < GetCodePointer(); ) {
 			auto it = addressesLookup.find(p);
 			if (it != addressesLookup.end()) {
-				const IRInst &inst = block->GetInstructions()[it->second];
+				const IRInst &inst = instructions[it->second];
 
 				char temp[512];
 				DisassembleIR(temp, sizeof(temp), inst);
@@ -295,7 +298,8 @@ void RiscVJitBackend::ClearAllBlocks() {
 	EraseAllLinks(-1);
 }
 
-void RiscVJitBackend::InvalidateBlock(IRBlock *block, int block_num) {
+void RiscVJitBackend::InvalidateBlock(IRBlockCache *irBlockCache, int block_num) {
+	IRBlock *block = irBlockCache->GetBlock(block_num);
 	int offset = block->GetTargetOffset();
 	u8 *writable = GetWritablePtrFromCodePtr(GetBasePtr()) + offset;
 

--- a/Core/MIPS/RiscV/RiscVJit.h
+++ b/Core/MIPS/RiscV/RiscVJit.h
@@ -36,9 +36,9 @@ public:
 	bool DescribeCodePtr(const u8 *ptr, std::string &name) const override;
 
 	void GenerateFixedCode(MIPSState *mipsState) override;
-	bool CompileBlock(IRBlock *block, int block_num, bool preload) override;
+	bool CompileBlock(IRBlockCache *irBlockCache, int block_num, bool preload) override;
 	void ClearAllBlocks() override;
-	void InvalidateBlock(IRBlock *block, int block_num) override;
+	void InvalidateBlock(IRBlockCache *irBlockCache, int block_num) override;
 
 protected:
 	const CodeBlockCommon &CodeBlock() const override {

--- a/Core/MIPS/x86/X64IRJit.h
+++ b/Core/MIPS/x86/X64IRJit.h
@@ -52,9 +52,9 @@ public:
 	bool DescribeCodePtr(const u8 *ptr, std::string &name) const override;
 
 	void GenerateFixedCode(MIPSState *mipsState) override;
-	bool CompileBlock(IRBlock *block, int block_num, bool preload) override;
+	bool CompileBlock(IRBlockCache *irBlockCache, int block_num, bool preload) override;
 	void ClearAllBlocks() override;
-	void InvalidateBlock(IRBlock *block, int block_num) override;
+	void InvalidateBlock(IRBlockCache *irBlockCache, int block_num) override;
 
 protected:
 	const CodeBlockCommon &CodeBlock() const override {

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -592,7 +592,7 @@ void VertexDecoder::Step_Color565Morph() const
 		c[i] = clamp_u8((int)col[i]);
 	}
 	c[3] = 255;
-	// Always full alpha.
+	// Always full alpha. (Is this true??)
 }
 
 void VertexDecoder::Step_Color5551Morph() const


### PR DESCRIPTION
This allows us to store the offset directly inside the pseudo instructions, instead of block numbers which require an extra lookup in the dispatcher, which is expensive enough to matter.

On PC, this is a 5-10% performance improvement in the IRInterpreter, which is very decent. Not benchmarked on Apple yet.

The IR JITs are still working.

TODO before merge: 

- [x] We need to stop and reset once the offsets go beyond 24 bits. However, that is a lot of instructions so in practice this will be fine in 99% of games - still want to fix it though.
- [x] This crashed on iOS when switching games from GTA to Outrun. (have not seen this again)
- [x] Savestates don't seem to be working :(