### PR TITLE
Libretro: More maintenance

### DIFF
--- a/libretro/LibretroGraphicsContext.cpp
+++ b/libretro/LibretroGraphicsContext.cpp
@@ -42,6 +42,10 @@ LibretroHWRenderContext::LibretroHWRenderContext(retro_hw_context_type context_t
 void LibretroHWRenderContext::ContextReset() {
 	INFO_LOG(G3D, "Context reset");
 
+	if (gpu && Libretro::useEmuThread) {
+		Libretro::EmuThreadPause();
+	}
+
 	if (gpu) {
 		gpu->DeviceLost();
 	}
@@ -56,6 +60,10 @@ void LibretroHWRenderContext::ContextReset() {
 
 	if (gpu) {
 		gpu->DeviceRestore(draw_);
+	}
+
+	if (gpu && Libretro::useEmuThread) {
+		Libretro::EmuThreadStart();
 	}
 }
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1655,7 +1655,7 @@ void retro_run(void)
 
    if (useEmuThread)
    {
-      if(   emuThreadState == EmuThreadState::PAUSED ||
+      if (  emuThreadState == EmuThreadState::PAUSED ||
             emuThreadState == EmuThreadState::PAUSE_REQUESTED)
       {
          VsyncSwapIntervalDetect();
@@ -1694,9 +1694,8 @@ namespace SaveState
 
 size_t retro_serialize_size(void)
 {
-   if(!gpu) { // The HW renderer isn't ready on first pass.
+   if (!gpu) // The HW renderer isn't ready on first pass.
       return 134217728; // 128MB ought to be enough for anybody.
-   }
 
    SaveState::SaveStart state;
    // TODO: Libretro API extension to use the savestate queue
@@ -1709,9 +1708,8 @@ size_t retro_serialize_size(void)
 
 bool retro_serialize(void *data, size_t size)
 {
-   if(!gpu) { // The HW renderer isn't ready on first pass.
+   if (!gpu) // The HW renderer isn't ready on first pass.
       return false;
-   }
 
    // TODO: Libretro API extension to use the savestate queue
    if (useEmuThread)
@@ -1733,6 +1731,9 @@ bool retro_serialize(void *data, size_t size)
 
 bool retro_unserialize(const void *data, size_t size)
 {
+   if (!gpu) // The HW renderer isn't ready on first pass.
+      return false;
+
    // TODO: Libretro API extension to use the savestate queue
    if (useEmuThread)
       EmuThreadPause(); // Does nothing if already paused

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -487,9 +487,12 @@ static std::string map_psp_language_to_i18n_locale(int val)
 
 static void check_variables(CoreParameter &coreParam)
 {
-   bool isFastForwarding;
-   if (environ_cb(RETRO_ENVIRONMENT_GET_FASTFORWARDING, &isFastForwarding))
-       coreParam.fastForward = isFastForwarding;
+   if (g_Config.bForceLagSync)
+   {
+      bool isFastForwarding;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_FASTFORWARDING, &isFastForwarding))
+          coreParam.fastForward = isFastForwarding;
+   }
 
    bool updated = false;
 


### PR DESCRIPTION
- Fixed logging to start early and continue to show items after `g_Config.Load`
- Fixed crash when opengl + vsync swap interval detection is switching rates
- Fixed crash when autostate load happens too early (currently not from command line, but from menu playlist)
- Remove `RETRO_ENVIRONMENT_GET_FASTFORWARDING` trickery since FF works fine without it, and it makes opengl to show the output rate wrong
