### PR TITLE
iOS: Fix "Home" button on controllers (like the PS logo button on a PS4 controller)

### DIFF
--- a/Core/KeyMap.cpp
+++ b/Core/KeyMap.cpp
@@ -362,6 +362,9 @@ static const KeyMap_IntStrPair key_names[] = {
 	{NKCODE_START_QUESTION, "¿"},
 	{NKCODE_LEFTBRACE, "{"},
 	{NKCODE_RIGHTBRACE, "}"},
+
+	{NKCODE_GUIDE, "Guide"},
+	{NKCODE_INFO, "Info"},
 };
 
 static const KeyMap_IntStrPair axis_names[] = {

--- a/ios/Controls.h
+++ b/ios/Controls.h
@@ -11,7 +11,8 @@
 // Code extracted from ViewController.mm, in order to modularize
 // and share it between multiple view controllers.
 
-bool SetupController(GCController *controller);
+bool InitController(GCController *controller);
+void ShutdownController(GCController *controller);
 
 struct TouchTracker {
 public:

--- a/ios/Controls.mm
+++ b/ios/Controls.mm
@@ -23,10 +23,16 @@ static void analogTriggerPressed(InputAxis axis, float value) {
 	NativeAxis(&axisInput, 1);
 }
 
-bool SetupController(GCController *controller) {
+bool InitController(GCController *controller) {
 	GCExtendedGamepad *extendedProfile = controller.extendedGamepad;
 	if (extendedProfile == nil) {
 		return false;
+	}
+
+	if (@available(iOS 14.0, tvOS 14.0, *)) {
+		for (GCControllerElement* element in controller.physicalInputProfile.allElements) {
+			element.preferredSystemGestureState = GCSystemGestureStateDisabled;
+		}
 	}
 
 	extendedProfile.buttonA.valueChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed) {
@@ -106,7 +112,7 @@ bool SetupController(GCController *controller) {
 #if defined(__IPHONE_14_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_14_0
 	if ([extendedProfile respondsToSelector:@selector(buttonHome)] && extendedProfile.buttonHome != nil) {
 		extendedProfile.buttonHome.valueChangedHandler = ^(GCControllerButtonInput *button, float value, BOOL pressed) {
-			controllerButtonPressed(pressed, NKCODE_BUTTON_15);
+			controllerButtonPressed(pressed, NKCODE_HOME);
 		};
 	}
 #endif
@@ -146,6 +152,14 @@ bool SetupController(GCController *controller) {
 	};
 
 	return true;
+}
+
+void ShutdownController(GCController *controller) {
+	if (@available(iOS 14.0, tvOS 14.0, *)) {
+		for (GCControllerElement* element in controller.physicalInputProfile.allElements) {
+			element.preferredSystemGestureState = GCSystemGestureStateEnabled;
+		}
+	}
 }
 
 void TouchTracker::SendTouchEvent(float x, float y, int code, int pointerId) {

--- a/ios/PPSSPP-Info.plist
+++ b/ios/PPSSPP-Info.plist
@@ -44,6 +44,8 @@
 	<false/>
 	<key>UIRequiresFullScreen</key>
 	<true/>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>PPSSPP needs some local network access for network multiplayer support.</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>arm64</string>

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -466,7 +466,7 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 - (void)setupController:(GCController *)controller
 {
 	self.gameController = controller;
-	if (!SetupController(controller)) {
+	if (!InitController(controller)) {
 		self.gameController = nil;
 	}
 }

--- a/ios/ViewControllerMetal.mm
+++ b/ios/ViewControllerMetal.mm
@@ -595,7 +595,7 @@ extern float g_safeInsetBottom;
 - (void)setupController:(GCController *)controller
 {
 	self.gameController = controller;
-	if (!SetupController(controller)) {
+	if (!InitController(controller)) {
 		self.gameController = nil;
 	}
 }


### PR DESCRIPTION
This is done by disabling system gesture processing on these buttons. Works on iOS and iPad.

Thanks lo0p3r for the pointer to some [example code](https://github.com/moonlight-stream/moonlight-ios/blob/557765f2c0b83bcfd722b8965fa87bcb46878f6d/Limelight/Input/ControllerSupport.m#L718).

Also adds a message to the plist as mentioned in #19246 