### PR TITLE
Add built-in IR Interpreter profiler

### DIFF
--- a/Common/UI/View.h
+++ b/Common/UI/View.h
@@ -462,7 +462,7 @@ public:
 	Visibility GetVisibility() const { return visibility_; }
 
 	const std::string &Tag() const { return tag_; }
-	void SetTag(const std::string &str) { tag_ = str; }
+	void SetTag(std::string_view str) { tag_ = str; }
 
 	// Fake RTTI
 	virtual bool IsViewGroup() const { return false; }

--- a/Common/UI/ViewGroup.cpp
+++ b/Common/UI/ViewGroup.cpp
@@ -67,6 +67,16 @@ bool ViewGroup::ContainsSubview(const View *view) const {
 	return false;
 }
 
+int ViewGroup::IndexOfSubview(const View *view) const {
+	int index = 0;
+	for (const View *subview : views_) {
+		if (subview == view)
+			return index;
+		index++;
+	}
+	return -1;
+}
+
 void ViewGroup::Clear() {
 	for (View *view : views_) {
 		delete view;

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -65,6 +65,7 @@ public:
 	bool CanBeFocused() const override { return false; }
 	bool IsViewGroup() const override { return true; }
 	bool ContainsSubview(const View *view) const override;
+	int IndexOfSubview(const View *view) const;
 
 	virtual void SetBG(const Drawable &bg) { bg_ = bg; }
 

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -155,6 +155,14 @@ public:
 	void RestoreSavedEmuHackOps(const std::vector<u32> &saved);
 
 	JitBlockDebugInfo GetBlockDebugInfo(int blockNum) const override;
+	JitBlockMeta GetBlockMeta(int blockNum) const override {
+		JitBlockMeta meta{};
+		if (IsValidBlock(blockNum)) {
+			meta.valid = true;
+			blocks_[blockNum].GetRange(meta.addr, meta.sizeInBytes);
+		}
+		return meta;
+	}
 	void ComputeStats(BlockCacheStats &bcStats) const override;
 	int GetBlockNumberFromStartAddress(u32 em_address, bool realBlocksOnly = true) const override;
 

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -33,6 +33,8 @@
 #include "stddef.h"
 #endif
 
+// #define IR_PROFILING
+
 namespace MIPSComp {
 
 // TODO : Use arena allocators. For now let's just malloc.
@@ -98,6 +100,10 @@ public:
 	void Finalize(int number);
 	void Destroy(int number);
 
+#ifdef IR_PROFILING
+	JitBlockProfileStats profileStats_{};
+#endif
+
 private:
 	u64 CalculateHash() const;
 
@@ -151,6 +157,14 @@ public:
 	JitBlockDebugInfo GetBlockDebugInfo(int blockNum) const override;
 	void ComputeStats(BlockCacheStats &bcStats) const override;
 	int GetBlockNumberFromStartAddress(u32 em_address, bool realBlocksOnly = true) const override;
+
+	bool SupportsProfiling() const override {
+#ifdef IR_PROFILING
+		return true;
+#else
+		return false;
+#endif
+	}
 
 private:
 	u32 AddressToPage(u32 addr) const;

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -135,7 +135,7 @@ public:
 		}
 	}
 	bool IsValidBlock(int blockNum) const override {
-		return blockNum < (int)blocks_.size() && blocks_[blockNum].IsValid();
+		return blockNum >= 0 && blockNum < (int)blocks_.size() && blocks_[blockNum].IsValid();
 	}
 	IRBlock *GetBlockUnchecked(int blockNum) {
 		return &blocks_[blockNum];

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -33,7 +33,7 @@
 #include "stddef.h"
 #endif
 
-#define IR_PROFILING
+// #define IR_PROFILING
 
 namespace MIPSComp {
 
@@ -162,6 +162,13 @@ public:
 			blocks_[blockNum].GetRange(meta.addr, meta.sizeInBytes);
 		}
 		return meta;
+	}
+	JitBlockProfileStats GetBlockProfileStats(int blockNum) const { // Cheap
+#ifdef IR_PROFILING
+		return blocks_[blockNum].profileStats_;
+#else
+		return JitBlockProfileStats{};
+#endif
 	}
 	void ComputeStats(BlockCacheStats &bcStats) const override;
 	int GetBlockNumberFromStartAddress(u32 em_address, bool realBlocksOnly = true) const override;

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -33,7 +33,7 @@
 #include "stddef.h"
 #endif
 
-// #define IR_PROFILING
+#define IR_PROFILING
 
 namespace MIPSComp {
 

--- a/Core/MIPS/IR/IRNativeCommon.cpp
+++ b/Core/MIPS/IR/IRNativeCommon.cpp
@@ -718,6 +718,10 @@ bool IRNativeBlockCacheDebugInterface::IsValidBlock(int blockNum) const {
 	return irBlocks_.IsValidBlock(blockNum);
 }
 
+JitBlockMeta IRNativeBlockCacheDebugInterface::GetBlockMeta(int blockNum) const {
+	return irBlocks_.GetBlockMeta(blockNum);
+}
+
 int IRNativeBlockCacheDebugInterface::GetNumBlocks() const {
 	return irBlocks_.GetNumBlocks();
 }

--- a/Core/MIPS/IR/IRNativeCommon.cpp
+++ b/Core/MIPS/IR/IRNativeCommon.cpp
@@ -730,6 +730,10 @@ int IRNativeBlockCacheDebugInterface::GetBlockNumberFromStartAddress(u32 em_addr
 	return irBlocks_.GetBlockNumberFromStartAddress(em_address, realBlocksOnly);
 }
 
+JitBlockProfileStats IRNativeBlockCacheDebugInterface::GetBlockProfileStats(int blockNum) const {
+	return irBlocks_.GetBlockProfileStats(blockNum);
+}
+
 void IRNativeBlockCacheDebugInterface::GetBlockCodeRange(int blockNum, int *startOffset, int *size) const {
 	int blockOffset = irBlocks_.GetBlock(blockNum)->GetTargetOffset();
 	int endOffset = backend_->GetNativeBlock(blockNum)->checkedOffset;

--- a/Core/MIPS/IR/IRNativeCommon.h
+++ b/Core/MIPS/IR/IRNativeCommon.h
@@ -165,6 +165,7 @@ public:
 	int GetNumBlocks() const override;
 	int GetBlockNumberFromStartAddress(u32 em_address, bool realBlocksOnly = true) const override;
 	JitBlockDebugInfo GetBlockDebugInfo(int blockNum) const override;
+	JitBlockMeta GetBlockMeta(int blockNum) const override;
 	void ComputeStats(BlockCacheStats &bcStats) const override;
 	bool IsValidBlock(int blockNum) const override;
 

--- a/Core/MIPS/IR/IRNativeCommon.h
+++ b/Core/MIPS/IR/IRNativeCommon.h
@@ -166,6 +166,7 @@ public:
 	int GetBlockNumberFromStartAddress(u32 em_address, bool realBlocksOnly = true) const override;
 	JitBlockDebugInfo GetBlockDebugInfo(int blockNum) const override;
 	JitBlockMeta GetBlockMeta(int blockNum) const override;
+	JitBlockProfileStats GetBlockProfileStats(int blockNum) const override;
 	void ComputeStats(BlockCacheStats &bcStats) const override;
 	bool IsValidBlock(int blockNum) const override;
 

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -103,13 +103,22 @@ struct JitBlockDebugInfo {
 	std::vector<std::string> targetDisasm;
 };
 
+struct JitBlockProfileStats {
+	int64_t executions;
+	int64_t totalNanos;
+};
+
 class JitBlockCacheDebugInterface {
 public:
 	virtual int GetNumBlocks() const = 0;
 	virtual int GetBlockNumberFromStartAddress(u32 em_address, bool realBlocksOnly = true) const = 0;
-	virtual JitBlockDebugInfo GetBlockDebugInfo(int blockNum) const = 0;
+	virtual JitBlockDebugInfo GetBlockDebugInfo(int blockNum) const = 0; // Expensive
+	virtual JitBlockProfileStats GetBlockProfileStats(int blockNum) const { // Cheap
+		return JitBlockProfileStats{};
+	}
 	virtual void ComputeStats(BlockCacheStats &bcStats) const = 0;
 	virtual bool IsValidBlock(int blockNum) const = 0;
+	virtual bool SupportsProfiling() const { return false; }
 
 	virtual ~JitBlockCacheDebugInterface() {}
 };

--- a/Core/MIPS/JitCommon/JitBlockCache.h
+++ b/Core/MIPS/JitCommon/JitBlockCache.h
@@ -120,9 +120,7 @@ public:
 	virtual int GetBlockNumberFromStartAddress(u32 em_address, bool realBlocksOnly = true) const = 0;
 	virtual JitBlockDebugInfo GetBlockDebugInfo(int blockNum) const = 0; // Expensive
 	virtual JitBlockMeta GetBlockMeta(int blockNum) const = 0;
-	virtual JitBlockProfileStats GetBlockProfileStats(int blockNum) const { // Cheap
-		return JitBlockProfileStats{};
-	}
+	virtual JitBlockProfileStats GetBlockProfileStats(int blockNum) const = 0;
 	virtual void ComputeStats(BlockCacheStats &bcStats) const = 0;
 	virtual bool IsValidBlock(int blockNum) const = 0;
 	virtual bool SupportsProfiling() const { return false; }
@@ -190,6 +188,9 @@ public:
 			meta.sizeInBytes = blocks_[blockNum].originalSize;
 		}
 		return meta;
+	}
+	JitBlockProfileStats GetBlockProfileStats(int blockNum) const override {
+		return JitBlockProfileStats{};
 	}
 
 	static int GetBlockExitSize();

--- a/UI/JitCompareScreen.cpp
+++ b/UI/JitCompareScreen.cpp
@@ -15,16 +15,27 @@ void JitCompareScreen::CreateViews() {
 
 	root_ = new LinearLayout(ORIENT_HORIZONTAL);
 
-	ScrollView *leftColumnScroll = root_->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(1.0f)));
+	ScrollView *leftColumnScroll = root_->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(200, FILL_PARENT)));
 	LinearLayout *leftColumn = leftColumnScroll->Add(new LinearLayout(ORIENT_VERTICAL));
 
-	ScrollView *midColumnScroll = root_->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(2.0f)));
+	LinearLayout *mainView = root_->Add(new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(1.0f)));
+	LinearLayout *topBar = mainView->Add(new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
+	topBar->Add(new Button(dev->T("Prev")))->OnClick.Handle(this, &JitCompareScreen::OnPrevBlock);
+	topBar->Add(new Button(dev->T("Next")))->OnClick.Handle(this, &JitCompareScreen::OnNextBlock);
+	blockAddr_ = topBar->Add(new TextEdit("", dev->T("Block address"), ""));
+	blockAddr_->OnEnter.Handle(this, &JitCompareScreen::OnAddressChange);
+	blockName_ = topBar->Add(new TextView(dev->T("No block")));
+	blockStats_ = topBar->Add(new TextView(""));
+
+	LinearLayout *comparisonView = mainView->Add(new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(1.0f)));
+
+	ScrollView *midColumnScroll = comparisonView->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(1.0f)));
 	LinearLayout *midColumn = midColumnScroll->Add(new LinearLayout(ORIENT_VERTICAL));
 	midColumn->SetTag("JitCompareLeftDisasm");
 	leftDisasm_ = midColumn->Add(new LinearLayout(ORIENT_VERTICAL));
 	leftDisasm_->SetSpacing(0.0f);
 
-	ScrollView *rightColumnScroll = root_->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(2.0f)));
+	ScrollView *rightColumnScroll = comparisonView->Add(new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(1.0f)));
 	rightColumnScroll->SetTag("JitCompareRightDisasm");
 	LinearLayout *rightColumn = rightColumnScroll->Add(new LinearLayout(ORIENT_VERTICAL));
 	rightDisasm_ = rightColumn->Add(new LinearLayout(ORIENT_VERTICAL));
@@ -32,17 +43,11 @@ void JitCompareScreen::CreateViews() {
 
 	leftColumn->Add(new Choice(dev->T("Current")))->OnClick.Handle(this, &JitCompareScreen::OnCurrentBlock);
 	leftColumn->Add(new Choice(dev->T("By Address")))->OnClick.Handle(this, &JitCompareScreen::OnSelectBlock);
-	leftColumn->Add(new Choice(dev->T("Prev")))->OnClick.Handle(this, &JitCompareScreen::OnPrevBlock);
-	leftColumn->Add(new Choice(dev->T("Next")))->OnClick.Handle(this, &JitCompareScreen::OnNextBlock);
 	leftColumn->Add(new Choice(dev->T("Random")))->OnClick.Handle(this, &JitCompareScreen::OnRandomBlock);
 	leftColumn->Add(new Choice(dev->T("FPU")))->OnClick.Handle(this, &JitCompareScreen::OnRandomFPUBlock);
 	leftColumn->Add(new Choice(dev->T("VFPU")))->OnClick.Handle(this, &JitCompareScreen::OnRandomVFPUBlock);
 	leftColumn->Add(new Choice(dev->T("Stats")))->OnClick.Handle(this, &JitCompareScreen::OnShowStats);
 	leftColumn->Add(new Choice(di->T("Back")))->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
-	blockName_ = leftColumn->Add(new TextView(dev->T("No block")));
-	blockAddr_ = leftColumn->Add(new TextEdit("", dev->T("Block address"), "", new LayoutParams(FILL_PARENT, WRAP_CONTENT)));
-	blockAddr_->OnTextChange.Handle(this, &JitCompareScreen::OnAddressChange);
-	blockStats_ = leftColumn->Add(new TextView(""));
 
 	EventParams ignore{};
 	OnCurrentBlock(ignore);

--- a/UI/JitCompareScreen.cpp
+++ b/UI/JitCompareScreen.cpp
@@ -47,12 +47,14 @@ void JitCompareScreen::CreateViews() {
 		return UI::EVENT_DONE;
 	});
 	blockTopBar->Add(new Button("", ImageID("I_ARROW_LEFT")))->OnClick.Add([=](UI::EventParams &e) {
-		currentBlock_--;
+		if (currentBlock_ >= 1)
+			currentBlock_--;
 		UpdateDisasm();
 		return UI::EVENT_DONE;
 	});
 	blockTopBar->Add(new Button("", ImageID("I_ARROW_RIGHT")))->OnClick.Add([=](UI::EventParams &e) {
-		currentBlock_++;
+		if (currentBlock_ < blockList_.size() - 1)
+			currentBlock_++;
 		UpdateDisasm();
 		return UI::EVENT_DONE;
 	});
@@ -276,10 +278,11 @@ void JitCompareScreen::UpdateDisasm() {
 	} else {
 		blockListContainer_->Clear();
 		for (int i = 0; i < std::min(100, (int)blockList_.size()); i++) {
-			JitBlockMeta meta = blockCacheDebug->GetBlockMeta(blockList_[i]);
+			int blockNum = blockList_[i];
+			JitBlockMeta meta = blockCacheDebug->GetBlockMeta(blockNum);
 			char temp[512], small[512];
 			if (blockCacheDebug->SupportsProfiling()) {
-				JitBlockProfileStats stats = blockCacheDebug->GetBlockProfileStats(blockList_[i]);
+				JitBlockProfileStats stats = blockCacheDebug->GetBlockProfileStats(blockNum);
 				int execs = (int)stats.executions;
 				double us = (double)stats.totalNanos / 1000.0;
 				snprintf(temp, sizeof(temp), "%08x: %d instrs (%d exec, %0.2f us)", meta.addr, meta.sizeInBytes / 4, execs, us);

--- a/UI/JitCompareScreen.cpp
+++ b/UI/JitCompareScreen.cpp
@@ -69,7 +69,7 @@ void JitCompareScreen::UpdateDisasm() {
 	}
 
 	char temp[256];
-	snprintf(temp, sizeof(temp), "%i/%i", currentBlock_, blockCacheDebug->GetNumBlocks());
+	snprintf(temp, sizeof(temp), "%d/%d", currentBlock_, blockCacheDebug->GetNumBlocks());
 	blockName_->SetText(temp);
 
 	if (currentBlock_ < 0 || !blockCacheDebug || currentBlock_ >= blockCacheDebug->GetNumBlocks()) {

--- a/UI/JitCompareScreen.h
+++ b/UI/JitCompareScreen.h
@@ -42,6 +42,7 @@ private:
 		BLOCK_LENGTH_ASC,
 		TIME_SPENT,
 		EXECUTIONS,
+		MAX
 	};
 	ViewMode viewMode_ = ViewMode::BLOCK_LIST;
 	ListType listType_ = ListType::ALL_BLOCKS;

--- a/UI/JitCompareScreen.h
+++ b/UI/JitCompareScreen.h
@@ -23,7 +23,14 @@ private:
 	UI::EventReturn OnAddressChange(UI::EventParams &e);
 	UI::EventReturn OnShowStats(UI::EventParams &e);
 
-	int currentBlock_ = -1;
+	// To switch, change the below things and call RecreateViews();
+	enum ViewMode {
+		BLOCK_LIST,
+		DISASM,
+	};
+	ViewMode viewMode_ = DISASM;
+	int currentBlock_ = -1;  // For DISASM mode
+	std::vector<int> blockList_;  // for BLOCK_LIST mode
 
 	UI::TextView *blockName_;
 	UI::TextEdit *blockAddr_;

--- a/UI/JitCompareScreen.h
+++ b/UI/JitCompareScreen.h
@@ -4,31 +4,48 @@
 
 class JitCompareScreen : public UIDialogScreenWithBackground {
 public:
+	JitCompareScreen();
 	void CreateViews() override;
 
 	const char *tag() const override { return "JitCompare"; }
 
 private:
+	void Flip();
 	void UpdateDisasm();
-	UI::EventReturn OnRandomBlock(UI::EventParams &e);
-	UI::EventReturn OnRandomFPUBlock(UI::EventParams &e);
-	UI::EventReturn OnRandomVFPUBlock(UI::EventParams &e);
-	void OnRandomBlock(int flag);
 
-	UI::EventReturn OnCurrentBlock(UI::EventParams &e);
+	// Uses the current ListType
+	void FillBlockList();
+
+	UI::LinearLayout *comparisonView_;
+	UI::ScrollView *blockListView_;
+	UI::LinearLayout *blockListContainer_;
+
 	UI::EventReturn OnSelectBlock(UI::EventParams &e);
-	UI::EventReturn OnPrevBlock(UI::EventParams &e);
-	UI::EventReturn OnNextBlock(UI::EventParams &e);
 	UI::EventReturn OnBlockAddress(UI::EventParams &e);
 	UI::EventReturn OnAddressChange(UI::EventParams &e);
 	UI::EventReturn OnShowStats(UI::EventParams &e);
+	UI::EventReturn OnBlockClick(UI::EventParams &e);
 
 	// To switch, change the below things and call RecreateViews();
-	enum ViewMode {
+	enum class ViewMode {
 		BLOCK_LIST,
 		DISASM,
 	};
-	ViewMode viewMode_ = DISASM;
+	enum class ListType {
+		ALL_BLOCKS,
+		FPU_BLOCKS,
+		VFPU_BLOCKS,
+	};
+	enum class ListSort {
+		BLOCK_NUM,
+		BLOCK_LENGTH_DESC,
+		TIME_SPENT,
+		EXECUTIONS,
+	};
+	ViewMode viewMode_ = ViewMode::BLOCK_LIST;
+	ListType listType_ = ListType::ALL_BLOCKS;
+	ListSort listSort_ = ListSort::BLOCK_LENGTH_DESC;
+
 	int currentBlock_ = -1;  // For DISASM mode
 	std::vector<int> blockList_;  // for BLOCK_LIST mode
 

--- a/UI/JitCompareScreen.h
+++ b/UI/JitCompareScreen.h
@@ -17,7 +17,7 @@ private:
 	void FillBlockList();
 
 	UI::LinearLayout *comparisonView_;
-	UI::ScrollView *blockListView_;
+	UI::LinearLayout *blockListView_;
 	UI::LinearLayout *blockListContainer_;
 
 	UI::EventReturn OnSelectBlock(UI::EventParams &e);
@@ -39,6 +39,7 @@ private:
 	enum class ListSort {
 		BLOCK_NUM,
 		BLOCK_LENGTH_DESC,
+		BLOCK_LENGTH_ASC,
 		TIME_SPENT,
 		EXECUTIONS,
 	};


### PR DESCRIPTION
To be able to focus IR interpreter work on what matters the most in the future.

* Adds block execution timing (behind `#ifdef IR_PROFILING` in order to not affect performance in the usual case)
* Extend the JIT Compare screen to be able to list and sort blocks according to various criteria

As a result, we can now sort IR blocks by time spent executing them, and dive in to see what they look like, in order to identify possible optimizations.