### PR TITLE
Change GOWFramerateHack30 to FramerateHack30 and workaround timing issues

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -96,7 +96,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "ForceUMDDelay", &flags_.ForceUMDDelay);
 	CheckSetting(iniFile, gameID, "ForceMax60FPS", &flags_.ForceMax60FPS);
 	CheckSetting(iniFile, gameID, "GoWFramerateHack60", &flags_.GoWFramerateHack60);
-	CheckSetting(iniFile, gameID, "GoWFramerateHack30", &flags_.GoWFramerateHack30);
+	CheckSetting(iniFile, gameID, "FramerateHack30", &flags_.FramerateHack30);
 	CheckSetting(iniFile, gameID, "JitInvalidationHack", &flags_.JitInvalidationHack);
 	CheckSetting(iniFile, gameID, "HideISOFiles", &flags_.HideISOFiles);
 	CheckSetting(iniFile, gameID, "MoreAccurateVMMUL", &flags_.MoreAccurateVMMUL);

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -66,7 +66,7 @@ struct CompatFlags {
 	bool ForceUMDDelay;
 	bool ForceMax60FPS;
 	bool GoWFramerateHack60;
-	bool GoWFramerateHack30;
+	bool FramerateHack30;
 	bool JitInvalidationHack;
 	bool HideISOFiles;
 	bool MoreAccurateVMMUL;

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -1435,12 +1435,26 @@ static int Hook_soltrigger_render_ucschar() {
 }
 
 static int Hook_gow_fps_hack() {
-	if (PSP_CoreParameter().compat.flags().GoWFramerateHack60 || PSP_CoreParameter().compat.flags().GoWFramerateHack30) {
-		if (PSP_CoreParameter().compat.flags().GoWFramerateHack30) {
+	if (PSP_CoreParameter().compat.flags().GoWFramerateHack60 || PSP_CoreParameter().compat.flags().FramerateHack30) {
+		if (PSP_CoreParameter().compat.flags().FramerateHack30) {
 			__DisplayWaitForVblanks("vblank start waited", 2);
 		} else {
 			__DisplayWaitForVblanks("vblank start waited", 1);
 		}
+	}
+	return 0;
+}
+
+static int Hook_blitz_fps_hack() {
+	if (PSP_CoreParameter().compat.flags().FramerateHack30) {
+		__DisplayWaitForVblanks("vblank start waited", 1);
+	}
+	return 0;
+}
+
+static int Hook_brian_lara_fps_hack() {
+	if (PSP_CoreParameter().compat.flags().FramerateHack30) {
+		__DisplayWaitForVblanks("vblank start waited", 1);
 	}
 	return 0;
 }
@@ -1584,6 +1598,8 @@ static const ReplacementTableEntry entries[] = {
 	{ "gow_fps_hack", &Hook_gow_fps_hack, 0, REPFLAG_HOOKEXIT , 0 },
 	{ "gow_vortex_hack", &Hook_gow_vortex_hack, 0, REPFLAG_HOOKENTER, 0x60 },
 	{ "ZZT3_select_hack", &Hook_ZZT3_select_hack, 0, REPFLAG_HOOKENTER, 0xC4 },
+	{ "blitz_fps_hack", &Hook_blitz_fps_hack, 0, REPFLAG_HOOKEXIT , 0 },
+	{ "brian_lara_fps_hack", &Hook_brian_lara_fps_hack, 0, REPFLAG_HOOKEXIT , 0 },
 	{}
 };
 

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -514,6 +514,8 @@ static const HardHashTableEntry hardcodedHashes[] = {
 	{ 0x795d940ad0a605f8, 40, "gow_fps_hack", }, // God of War (all)
 	{ 0x4c75043b7b0c643b, 512, "gow_vortex_hack", }, // God of War: Ghost of Sparta vortex timer hack, avoids softlock #8299
 	{ 0x7624dde603717640, 288, "ZZT3_select_hack", }, // Zettai Zetsumei Toshi 3 - bypasses softlock on character select screen #4901
+	{ 0x0dc5ca84f707863c, 452, "blitz_fps_hack", }, // Blitz: Overtime
+	{ 0xf93d3cd093595a6c, 856, "brian_lara_fps_hack", }, // Brian Lara 2007: Pressure Play
 };
 
 namespace MIPSAnalyst {

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -854,10 +854,10 @@ UCUS98705 = true
 UCED00971 = true
 UCUS98713 = true
 
-[GoWFramerateHack30]
-# As the 60 fps version, but makes GOW games run on a potato,
-# Doesn't suffer from softlock #8299
-# disabled by default since most people wouldn't need it
+[FramerateHack30]
+# Note that this hack is not universal, will not work for games simply added to the list
+# 30 fps hacks for games that run well are disabled by default since it's only an option for users with very weak hardware
+# GOW in 30 fps doesn't suffer from softlock #8299, so the hack is actually simpler
 # GOW : Ghost of Sparta
 # UCUS98737 = true
 # UCAS40323 = true
@@ -890,6 +890,15 @@ UCUS98713 = true
 # UCUS98705 = true
 # UCED00971 = true
 # UCUS98713 = true
+
+# Brian Lara 2007: Pressure Play
+# workaround for incorrect fps/game speed
+ULES00814 = true
+ULES00815 = true
+
+# Blitz: Overtime
+# workaround for incorrect fps/game speed
+ULUS10200 = true
 
 [ForceMax60FPS]
 # Some games are very heavy and render as fast as they can. They benefit greatly from


### PR DESCRIPTION
Implements workarounds for the two games from #19256:
- Blitz: Overtime,
- Brian Lara 2007: Pressure Play.

 Which both are running incorrectly at 60 fps with double speed.

 Makes use of GOWFramerateHack30, now renamed to just FramerateHack30, but it's not universal, compat is only used for safety and to have an option to easily disable it, actual hacks are in function replacements.