### PR TITLE
More minor IR optimizations

### DIFF
--- a/Core/MIPS/IR/IRCompALU.cpp
+++ b/Core/MIPS/IR/IRCompALU.cpp
@@ -248,9 +248,20 @@ void IRFrontend::Comp_Special3(MIPSOpcode op) {
 	{
 		u32 sourcemask = mask >> pos;
 		u32 destmask = ~(sourcemask << pos);
-		ir.Write(IROp::AndConst, IRTEMP_0, rs, ir.AddConstant(sourcemask));
-		if (pos != 0) {
-			ir.Write(IROp::ShlImm, IRTEMP_0, IRTEMP_0, pos);
+
+		if (size != 32) {
+			// Need to use the sourcemask.
+			ir.Write(IROp::AndConst, IRTEMP_0, rs, ir.AddConstant(sourcemask));
+			if (pos != 0) {
+				ir.Write(IROp::ShlImm, IRTEMP_0, IRTEMP_0, pos);
+			}
+		} else {
+			// If the shl takes care of the sourcemask, don't need to and.
+			if (pos != 0) {
+				ir.Write(IROp::ShlImm, IRTEMP_0, rs, pos);
+			} else {
+				ir.Write(IROp::Mov, IRTEMP_0, rs);
+			}
 		}
 		ir.Write(IROp::AndConst, rt, rt, ir.AddConstant(destmask));
 		ir.Write(IROp::Or, rt, rt, IRTEMP_0);

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -121,6 +121,7 @@ static const IRMeta irMeta[] = {
 	{ IROp::FMovFromGPR, "FMovFromGPR", "FG" },
 	{ IROp::FMovToGPR, "FMovToGPR", "GF" },
 	{ IROp::OptFMovToGPRShr8, "OptFMovToGPRShr8", "GF" },
+	{ IROp::OptFCvtSWFromGPR, "OptFCvtSWFromGPR", "FG" },
 	{ IROp::FpCondFromReg, "FpCondFromReg", "_G" },
 	{ IROp::FpCondToReg, "FpCondToReg", "G" },
 	{ IROp::FpCtrlFromReg, "FpCtrlFromReg", "_G" },

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -138,6 +138,7 @@ enum class IROp : uint8_t {
 	FCvtScaledSW,
 
 	FMovFromGPR,
+	OptFCvtSWFromGPR,
 	FMovToGPR,
 	OptFMovToGPRShr8,
 

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -997,6 +997,9 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst) {
 		case IROp::FMovFromGPR:
 			memcpy(&mips->f[inst->dest], &mips->r[inst->src1], 4);
 			break;
+		case IROp::OptFCvtSWFromGPR:
+			mips->f[inst->dest] = (float)(int)mips->r[inst->src1];
+			break;
 		case IROp::FMovToGPR:
 			memcpy(&mips->r[inst->dest], &mips->f[inst->src1], 4);
 			break;
@@ -1007,6 +1010,7 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst) {
 			mips->r[inst->dest] = temp >> 8;
 			break;
 		}
+
 		case IROp::ExitToConst:
 			return inst->constant;
 

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -2200,10 +2200,20 @@ bool OptimizeLoadsAfterStores(const IRWriter &in, IRWriter &out, const IROptions
 		case IROp::Store32:
 			if (next.op == IROp::Load32 &&
 				next.constant == inst.constant &&
-				next.dest == inst.src3 &&
+				next.dest == inst.dest &&
 				next.src1 == inst.src1) {
 				// The upcoming load is completely redundant.
 				// Skip it.
+				i++;
+			}
+			break;
+		case IROp::StoreVec4:
+			if (next.op == IROp::LoadVec4 &&
+				next.constant == inst.constant &&
+				next.dest == inst.dest &&
+				next.src1 == inst.src1) {
+				// The upcoming load is completely redundant. These are common in Wipeout.
+				// Skip it. NOTE: It looks like vector load/stores uses different register assignments, but there's a union between dest and src3.
 				i++;
 			}
 			break;

--- a/Core/MIPS/IR/IRPassSimplify.cpp
+++ b/Core/MIPS/IR/IRPassSimplify.cpp
@@ -2269,10 +2269,18 @@ bool OptimizeForInterpreter(const IRWriter &in, IRWriter &out, const IROptions &
 					inst.op = IROp::OptFMovToGPRShr8;
 					i++;  // Skip the next instruction.
 				}
-				out.Write(inst);
-			} else {
-				out.Write(inst);
 			}
+			out.Write(inst);
+			break;
+		case IROp::FMovFromGPR:
+			if (!last) {
+				IRInst next = in.GetInstructions()[i + 1];
+				if (next.op == IROp::FCvtSW && next.src1 == inst.dest && next.dest == inst.dest) {
+					inst.op = IROp::OptFCvtSWFromGPR;
+					i++;  // Skip the next
+				}
+			}
+			out.Write(inst);
 			break;
 		default:
 			out.Write(inst);


### PR DESCRIPTION
Don't break up lwl/lwr/swl/swr instructions into components when using the interpreter, it can handle the original instructions faster directly.

Remove an unnecessary mask operation when using `ins` some ways.

Optimize away redundant store+load vector operations (seen a lot in the Wipeout games).

None of these alone have a big effect, but if we keep shaving the size of the generated IR code down, performance will improve. Plus, these are fun to work on and some of this will also benefit the IR Jits.