### PR TITLE
IRJit: If we're in "JIT using IR" mode, don't accidentally optimize for the interpreter.

### DIFF
--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -44,11 +44,12 @@
 
 namespace MIPSComp {
 
-IRJit::IRJit(MIPSState *mipsState) : frontend_(mipsState->HasDefaultPrefix()), mips_(mipsState) {
+IRJit::IRJit(MIPSState *mipsState, bool actualJit) : frontend_(mipsState->HasDefaultPrefix()), mips_(mipsState) {
 	// u32 size = 128 * 1024;
 	InitIR();
 
-	jo.optimizeForInterpreter = true;
+	// If this IRJit instance will be used to drive a "JIT using IR", don't optimize for interpretation.
+	jo.optimizeForInterpreter = !actualJit;
 
 	IROptions opts{};
 	opts.disableFlags = g_Config.uJitDisableFlags;

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -195,7 +195,7 @@ private:
 
 class IRJit : public JitInterface {
 public:
-	IRJit(MIPSState *mipsState);
+	IRJit(MIPSState *mipsState, bool actualJit);
 	~IRJit();
 
 	void DoState(PointerWrap &p) override;

--- a/Core/MIPS/IR/IRNativeCommon.cpp
+++ b/Core/MIPS/IR/IRNativeCommon.cpp
@@ -481,7 +481,7 @@ void IRNativeBackend::CompileIRInst(IRInst inst) {
 }
 
 IRNativeJit::IRNativeJit(MIPSState *mipsState)
-	: IRJit(mipsState), debugInterface_(blocks_) {}
+	: IRJit(mipsState, true), debugInterface_(blocks_) {}
 
 void IRNativeJit::Init(IRNativeBackend &backend) {
 	backend_ = &backend;

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -214,7 +214,7 @@ void MIPSState::Init() {
 	if (PSP_CoreParameter().cpuCore == CPUCore::JIT || PSP_CoreParameter().cpuCore == CPUCore::JIT_IR) {
 		MIPSComp::jit = MIPSComp::CreateNativeJit(this, PSP_CoreParameter().cpuCore == CPUCore::JIT_IR);
 	} else if (PSP_CoreParameter().cpuCore == CPUCore::IR_INTERPRETER) {
-		MIPSComp::jit = new MIPSComp::IRJit(this);
+		MIPSComp::jit = new MIPSComp::IRJit(this, false);
 	} else {
 		MIPSComp::jit = nullptr;
 	}
@@ -252,7 +252,7 @@ void MIPSState::UpdateCore(CPUCore desired) {
 			MIPSComp::jit = nullptr;
 			delete oldjit;
 		}
-		newjit = new MIPSComp::IRJit(this);
+		newjit = new MIPSComp::IRJit(this, false);
 		break;
 
 	case CPUCore::INTERPRETER:


### PR DESCRIPTION
We generate some interpreter-only IR instructions in this case, which the IR JITs can't handle.

Fixes #19266 