### PR TITLE
Set the games category in plists for Mac and iOS.

### DIFF
--- a/ios/PPSSPP-Info.plist
+++ b/ios/PPSSPP-Info.plist
@@ -50,6 +50,8 @@
 	<array>
 		<string>arm64</string>
 	</array>
+	<key>LSApplicationCategory</key>
+	<string>public.app-category.games</string>
 	<key>UIStatusBarHidden</key>
 	<true/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/macOS/Info.plist
+++ b/macOS/Info.plist
@@ -94,6 +94,8 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
+	<key>LSApplicationCategory</key>
+	<string>public.app-category.games</string>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Might enable Game Mode on iOS 18 as mentioned in #19267 , probably in addition to changing the category on the next update submission.