### PR TITLE
Implement FPU rounding mode support in the IR interpreter

### DIFF
--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -322,7 +322,7 @@ void sceKernelExitGame()
 	__KernelSwitchOffThread("game exited");
 	Core_Stop();
 
-	g_OSD.Show(OSDType::MESSAGE_INFO, "sceKernelExitGame()");
+	g_OSD.Show(OSDType::MESSAGE_INFO, "sceKernelExitGame()", 0.0f, "kernelexit");
 }
 
 void sceKernelExitGameWithStatus()

--- a/Core/MIPS/IR/IRCompFPU.cpp
+++ b/Core/MIPS/IR/IRCompFPU.cpp
@@ -223,6 +223,7 @@ void IRFrontend::Comp_mxc1(MIPSOpcode op) {
 			// Set rounding mode
 			RestoreRoundingMode();
 			ir.Write(IROp::FpCtrlFromReg, 0, rt);
+			// TODO: Do the UpdateRoundingMode check at runtime?
 			UpdateRoundingMode();
 			ApplyRoundingMode();
 		} else {

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -133,10 +133,8 @@ bool IRFrontend::CheckRounding(u32 blockAddress) {
 		js.startDefaultPrefix = false;
 		cleanSlate = true;
 	}
-
 	return cleanSlate;
 }
-
 
 void IRFrontend::Comp_ReplacementFunc(MIPSOpcode op) {
 	int index = op.encoding & MIPS_EMUHACK_VALUE_MASK;

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -108,12 +108,12 @@ void IRApplyRounding(MIPSState *mips) {
 			csr |= 0x8000;
 		}
 		_mm_setcsr(csr);
-#elif PPSSPP_ARCH(ARM64)
+#elif PPSSPP_ARCH(ARM64) && !PPSSPP_PLATFORM(WINDOWS)
 		// On ARM64 we need to use inline assembly for a portable solution.
-		// Note that in the JIT, for fcvts, we use specific conversions. However,
-		// fcvts also has a variant that reads the fpcr, and I think that's what our
-		// C++ code (the IR interpreter) ends up using.
-		u64 fpcr;  // not really 64-bit, just to match the regsiter size.
+		// Unfortunately we don't have this possibility on Windows with MSVC, so ifdeffed out above.
+		// Note that in the JIT, for fcvts, we use specific conversions. We could use the FCVTS variants
+		// directly through inline assembly.
+		u64 fpcr;  // not really 64-bit, just to match the register size.
 		asm volatile ("mrs %0, fpcr" : "=r" (fpcr));
 
 		// Translate MIPS to ARM rounding mode
@@ -138,7 +138,7 @@ void IRRestoreRounding() {
 	u32 csr = _mm_getcsr();
 	csr &= ~(7 << 13);
 	_mm_setcsr(csr);
-#elif PPSSPP_ARCH(ARM64)
+#elif PPSSPP_ARCH(ARM64) && !PPSSPP_PLATFORM(WINDOWS)
 	u64 fpcr;  // not really 64-bit, just to match the regsiter size.
 	asm volatile ("mrs %0, fpcr" : "=r" (fpcr));
 	fpcr &= ~(7 << 22);    // Clear bits [23:22] for rounding, 24 for FTZ

--- a/Core/MIPS/IR/IRInterpreter.h
+++ b/Core/MIPS/IR/IRInterpreter.h
@@ -11,6 +11,9 @@ u32 IRRunBreakpoint(u32 pc);
 u32 IRRunMemCheck(u32 pc, u32 addr);
 u32 IRInterpret(MIPSState *ms, const IRInst *inst);
 
+void IRApplyRounding();
+void IRRestoreRounding();
+
 template <uint32_t alignment>
 u32 RunValidateAddress(u32 pc, u32 addr, u32 isWrite) {
 	const auto toss = [&](MemoryExceptionType t) {

--- a/android/jni/TestRunner.cpp
+++ b/android/jni/TestRunner.cpp
@@ -66,6 +66,8 @@ bool TestsAvailable() {
 	// Hack to easily run the tests on Windows from the submodule
 	if (File::IsDirectory(Path("../pspautotests"))) {
 		testDirectory = Path("..");
+	} else if (File::IsDirectory(Path("pspautotests"))) {
+		testDirectory = Path(".");
 	}
 	return File::Exists(testDirectory / "pspautotests" / "tests");
 }
@@ -80,6 +82,8 @@ bool RunTests() {
 	// Hack to easily run the tests on Windows from the submodule
 	if (File::IsDirectory(Path("../pspautotests"))) {
 		baseDirectory = Path("..");
+	} else  if (File::IsDirectory(Path("pspautotests"))) {
+		baseDirectory = Path(".");
 	}
 #endif
 


### PR DESCRIPTION
Implemented for x86/x64 and ARM64.

Should fix reported issues with unbeatable bosses in Metal Gear on iOS (which can only use the IR interpreter, so effectively re-fixing #2845 and also #3988 on this backend.

Also I'm noticing that our IR interpreter uses suboptimal methods to convert float to int, some inline assembly would help. However, I'll leave fixing that for a future change. 
