### PR TITLE
iOS: Disable the swipe-back gesture in-game, to maximize touch responsiveness

### DIFF
--- a/Common/Render/Text/draw_text_cocoa.mm
+++ b/Common/Render/Text/draw_text_cocoa.mm
@@ -125,6 +125,8 @@ void TextDrawerCocoa::MeasureString(std::string_view str, float *w, float *h) {
 	if (iter != sizeCache_.end()) {
 		entry = iter->second.get();
 	} else {
+		// INFO_LOG(SYSTEM, "Measuring %.*s", (int)str.length(), str.data());
+
 		auto iter = fontMap_.find(fontHash_);
 		NSDictionary *attributes = nil;
 		if (iter != fontMap_.end()) {

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -221,6 +221,7 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 
 - (void)viewDidAppear:(BOOL)animated {
 	[super viewDidAppear:animated];
+	INFO_LOG(G3D, "viewDidAppear");
 	[self hideKeyboard];
 	[self updateGesture];
 }

--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -113,7 +113,9 @@ id<PPSSPPViewController> sharedViewController;
 
 @end
 
-@implementation PPSSPPViewControllerGL
+@implementation PPSSPPViewControllerGL {
+	UIScreenEdgePanGestureRecognizer *mBackGestureRecognizer;
+}
 
 -(id) init {
 	self = [super init];
@@ -220,6 +222,7 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 - (void)viewDidAppear:(BOOL)animated {
 	[super viewDidAppear:animated];
 	[self hideKeyboard];
+	[self updateGesture];
 }
 
 - (void)viewDidLoad {
@@ -268,10 +271,6 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 	[locationHelper setDelegate:self];
 
 	[self hideKeyboard];
-
-	UIScreenEdgePanGestureRecognizer *mBackGestureRecognizer = [[UIScreenEdgePanGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFrom:) ];
-	[mBackGestureRecognizer setEdges:UIRectEdgeLeft];
-	[[self view] addGestureRecognizer:mBackGestureRecognizer];
 
 	// Initialize the motion manager for accelerometer control.
 	self.motionManager = [[CMMotionManager alloc] init];
@@ -447,7 +446,7 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 	} else {
 		INFO_LOG(SYSTEM, "Allow system gestures on the bottom");
 		// Allow task switching gestures to take precedence, without causing
-		// scroll events in the UI.
+		// scroll events in the UI. Otherwise, we get "ghost" scrolls when switching tasks.
 		return UIRectEdgeTop | UIRectEdgeLeft | UIRectEdgeRight;
 	}
 }
@@ -456,6 +455,24 @@ void GLRenderLoop(IOSGLESContext *graphicsContext) {
 {
 	[self setNeedsUpdateOfScreenEdgesDeferringSystemGestures];
 	[self hideKeyboard];
+	[self updateGesture];
+}
+
+- (void)updateGesture {
+	INFO_LOG(SYSTEM, "Updating swipe gesture.");
+
+	if (mBackGestureRecognizer) {
+		INFO_LOG(SYSTEM, "Removing swipe gesture.");
+		[[self view] removeGestureRecognizer:mBackGestureRecognizer];
+		mBackGestureRecognizer = nil;
+	}
+
+	if (GetUIState() != UISTATE_INGAME) {
+		INFO_LOG(SYSTEM, "Adding swipe gesture.");
+		mBackGestureRecognizer = [[UIScreenEdgePanGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFrom:) ];
+		[mBackGestureRecognizer setEdges:UIRectEdgeLeft];
+		[[self view] addGestureRecognizer:mBackGestureRecognizer];
+	}
 }
 
 - (UIView *)getView {

--- a/ios/ViewControllerMetal.mm
+++ b/ios/ViewControllerMetal.mm
@@ -217,7 +217,9 @@ static std::thread g_renderLoopThread;
 
 @end  // @interface
 
-@implementation PPSSPPViewControllerMetal 
+@implementation PPSSPPViewControllerMetal {
+	UIScreenEdgePanGestureRecognizer *mBackGestureRecognizer;
+}
 
 - (id)init {
 	self = [super init];
@@ -440,10 +442,6 @@ void VulkanRenderLoop(IOSVulkanContext *graphicsContext, CAMetalLayer *metalLaye
 	locationHelper = [[LocationHelper alloc] init];
 	[locationHelper setDelegate:self];
 
-	UIScreenEdgePanGestureRecognizer *mBackGestureRecognizer = [[UIScreenEdgePanGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFrom:) ];
-	[mBackGestureRecognizer setEdges:UIRectEdgeLeft];
-	[[self view] addGestureRecognizer:mBackGestureRecognizer];
-
 	// Initialize the motion manager for accelerometer control.
 	self.motionManager = [[CMMotionManager alloc] init];
 }
@@ -478,7 +476,8 @@ void VulkanRenderLoop(IOSVulkanContext *graphicsContext, CAMetalLayer *metalLaye
 	[super viewDidAppear:animated];
 	INFO_LOG(G3D, "viewDidAppear");
 	[self hideKeyboard];
-	INFO_LOG(G3D, "viewDidAppearDone");
+	[self updateGesture];
+
 }
 
 - (BOOL)prefersHomeIndicatorAutoHidden {
@@ -529,6 +528,25 @@ extern float g_safeInsetBottom;
 {
 	[self setNeedsUpdateOfScreenEdgesDeferringSystemGestures];
 	[self hideKeyboard];
+	[self updateGesture];
+}
+
+
+- (void)updateGesture {
+	INFO_LOG(SYSTEM, "Updating swipe gesture.");
+
+	if (mBackGestureRecognizer) {
+		INFO_LOG(SYSTEM, "Removing swipe gesture.");
+		[[self view] removeGestureRecognizer:mBackGestureRecognizer];
+		mBackGestureRecognizer = nil;
+	}
+
+	if (GetUIState() != UISTATE_INGAME) {
+		INFO_LOG(SYSTEM, "Adding swipe gesture.");
+		mBackGestureRecognizer = [[UIScreenEdgePanGestureRecognizer alloc] initWithTarget:self action:@selector(handleSwipeFrom:) ];
+		[mBackGestureRecognizer setEdges:UIRectEdgeLeft];
+		[[self view] addGestureRecognizer:mBackGestureRecognizer];
+	}
 }
 
 - (void)bindDefaultFBO


### PR DESCRIPTION
Got a lot of complaints about lost responsiveness on the left edge of the screen after adding the gesture.

The gesture remains in menus, but it's now disabled in-game.