### PR TITLE
Use fuse3 compatible appimagetool

### DIFF
--- a/scripts/makeappimage_32-bit.sh
+++ b/scripts/makeappimage_32-bit.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 if [ ! -f appimagetool-i686.AppImage ]; then
-    wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-i686.AppImage
+	APPIMAGETOOL=$(wget -q https://api.github.com/repos/probonopd/go-appimage/releases -O - | sed 's/"/ /g; s/ /\n/g' | grep -o 'https.*continuous.*tool.*i686.*mage$')
+	wget -q "$APPIMAGETOOL" -O ./appimagetool-i686.AppImage
     chmod +x appimagetool-i686.AppImage
 fi
 
@@ -28,4 +29,5 @@ pushd AppDir
 ln -s usr/share/icons/hicolor/256x256/apps/ppsspp.png
 chmod +x AppRun
 popd
-./appimagetool-i686.AppImage --appimage-extract-and-run AppDir
+ARCH=i386
+VERSION=$(./AppDir/AppRun --version) ./appimagetool-i686.AppImage --appimage-extract-and-run AppDir

--- a/scripts/makeappimage_64-bit.sh
+++ b/scripts/makeappimage_64-bit.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 if [ ! -f appimagetool-x86_64.AppImage ]; then
-    wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+	APPIMAGETOOL=$(wget -q https://api.github.com/repos/probonopd/go-appimage/releases -O - | sed 's/"/ /g; s/ /\n/g' | grep -o 'https.*continuous.*tool.*86_64.*mage$')
+	wget -q "$APPIMAGETOOL" -O ./appimagetool-x86_64.AppImage
     chmod +x appimagetool-x86_64.AppImage
 fi
 
@@ -28,4 +29,5 @@ pushd AppDir
 ln -s usr/share/icons/hicolor/256x256/apps/ppsspp.png
 chmod +x AppRun
 popd
-./appimagetool-x86_64.AppImage --appimage-extract-and-run AppDir
+ARCH=x86_64
+VERSION=$(./AppDir/AppRun --version) ./appimagetool-x86_64.AppImage --appimage-extract-and-run AppDir


### PR DESCRIPTION
appimagetool: https://github.com/probonopd/go-appimage

Fixes a common issue with ubuntu and some forks where `libfuse2` no longer comes installed.

This is a problem because ubuntu doesn't let you have both `libfuse2` and `libfuse3` installed together, even though it is fully possible and distros like arch let you do it.

This appimagetool also uses a zstd compression, which results in a slightly smaller appimage. It also works if the distro only has `libfuse2` installed.

Edit: If more info is needed, Cemu uses this appimagetool to make their appimage as well. 
