### PR TITLE
iOS: Enable "double-swipe" to switch apps

### DIFF
--- a/ios/ViewController.mm
+++ b/ios/ViewController.mm
@@ -134,7 +134,8 @@ id<PPSSPPViewController> sharedViewController;
 }
 
 - (BOOL)prefersHomeIndicatorAutoHidden {
-    return YES;
+	// Would love to hide it, but it prevents the double-swipe protection from working.
+	return NO;
 }
 
 - (void)shareText:(NSString *)text {

--- a/ios/ViewControllerMetal.mm
+++ b/ios/ViewControllerMetal.mm
@@ -481,7 +481,8 @@ void VulkanRenderLoop(IOSVulkanContext *graphicsContext, CAMetalLayer *metalLaye
 }
 
 - (BOOL)prefersHomeIndicatorAutoHidden {
-    return YES;
+	// Would love to hide it, but it prevents the double-swipe protection from working.
+	return NO;
 }
 
 - (void)shareText:(NSString *)text {
@@ -530,7 +531,6 @@ extern float g_safeInsetBottom;
 	[self hideKeyboard];
 	[self updateGesture];
 }
-
 
 - (void)updateGesture {
 	INFO_LOG(SYSTEM, "Updating swipe gesture.");


### PR DESCRIPTION
To prevent accidental app switching.

Unfortunately, the way to do this is to disable auto-hiding of the swipe indicator. Another strange Apple quirk.