### PR TITLE
Remote Disc Streaming on iOS: Don't accidentally force the game browser to the local folder

### DIFF
--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -519,7 +519,9 @@ GameBrowser::GameBrowser(int token, const Path &path, BrowseFlags browseFlags, b
 	} else {
 		path_.SetRootAlias("ms:/", memstickRoot);
 	}
-	if (System_GetPropertyBool(SYSPROP_LIMITED_FILE_BROWSING)) {
+	if (System_GetPropertyBool(SYSPROP_LIMITED_FILE_BROWSING) &&
+		(path.Type() == PathType::NATIVE || path.Type() == PathType::CONTENT_URI)) {
+		// Note: We don't restrict if the path is HTTPS, otherwise remote disc streaming breaks!
 		path_.RestrictToRoot(GetSysDirectory(DIRECTORY_MEMSTICK_ROOT));
 	}
 	path_.SetPath(path);


### PR DESCRIPTION
On iOS we enforce browsing the app directory only due to permission issues, but this should not apply when opening a HTTPS URL. Oops.