### PR TITLE
OpenXR - Do not require controllers connected

### DIFF
--- a/android/VRManifest.xml
+++ b/android/VRManifest.xml
@@ -4,6 +4,7 @@
     <uses-feature android:glEsVersion="0x00030001" />
     <uses-feature android:name="android.hardware.vr.headtracking" android:version="1" android:required="true" />
     <uses-feature android:name="com.oculus.feature.PASSTHROUGH" android:required="false" />
+    <uses-feature android:name="oculus.software.handtracking" android:required="false" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
When using VR version with gamepad, users are bothered with "Controllers not connected" dialog once the VR controller lost tracking. This PR fixes this annoying behaviour by indicating the app supports hand tracking (although it doesn't).

https://github.com/hrydgard/ppsspp/issues/19321 fixed