### PR TITLE
bump com.gladed.androidgitversion to fix android studio building

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'com.gladed.androidgitversion' version '0.4.5'
+	id 'com.gladed.androidgitversion' version '0.4.14'
 }
 apply plugin: 'com.android.application'
 


### PR DESCRIPTION
fixes "Could not find com.android.tools.build:gradle:2.3.3."

ref: https://github.com/gladed/gradle-android-git-version/issues/55