### PR TITLE
sceIoGetStat: Fix retrieving timestamps from directories

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug",
+            "program": "build/PPSSPPSDL",
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+    "tasks": [
+        {
+            "type": "shell",
+            "label": "C/C++: build",
+            "command": "./b.sh",
+            "args": [
+                "--debug",
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "detail": "compiler: /usr/bin/g++"
+        },
+    ]
+}

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -697,15 +697,15 @@ PSPFileInfo DirectoryFileSystem::GetFileInfo(std::string filename) {
 
 	if (x.type != FILETYPE_DIRECTORY) {
 		x.size = info.size;
-		x.access = info.access;
-		time_t atime = info.atime;
-		time_t ctime = info.ctime;
-		time_t mtime = info.mtime;
-
-		localtime_r((time_t*)&atime, &x.atime);
-		localtime_r((time_t*)&ctime, &x.ctime);
-		localtime_r((time_t*)&mtime, &x.mtime);
 	}
+	x.access = info.access;
+	time_t atime = info.atime;
+	time_t ctime = info.ctime;
+	time_t mtime = info.mtime;
+
+	localtime_r((time_t*)&atime, &x.atime);
+	localtime_r((time_t*)&ctime, &x.ctime);
+	localtime_r((time_t*)&mtime, &x.mtime);
 
 	return ReplayApplyDiskFileInfo(x, CoreTiming::GetGlobalTimeUs());
 }


### PR DESCRIPTION
For some silly reason, we only correctly retrieved mtime etc from files, not directories.

Fixes #16939 finally (or at least should, I haven't checked the iteration order carefully).

Might also fix other things, who knows.

Big thanks to @Parik27 for figuring this one out.
