### PR TITLE
Disable preloading of function stubs if bPreloadFunctions is off

### DIFF
--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -772,7 +772,9 @@ void ImportFuncSymbol(const FuncSymbolImport &func, bool reimporting, const char
 		}
 		WriteSyscall(func.moduleName, func.nid, func.stubAddr);
 		currentMIPS->InvalidateICache(func.stubAddr, 8);
-		MIPSAnalyst::PrecompileFunction(func.stubAddr, 8);
+		if (g_Config.bPreloadFunctions) {
+			MIPSAnalyst::PrecompileFunction(func.stubAddr, 8);
+		}
 		return;
 	}
 
@@ -791,7 +793,9 @@ void ImportFuncSymbol(const FuncSymbolImport &func, bool reimporting, const char
 				}
 				WriteFuncStub(func.stubAddr, it->symAddr);
 				currentMIPS->InvalidateICache(func.stubAddr, 8);
-				MIPSAnalyst::PrecompileFunction(func.stubAddr, 8);
+				if (g_Config.bPreloadFunctions) {
+					MIPSAnalyst::PrecompileFunction(func.stubAddr, 8);
+				}
 				return;
 			}
 		}
@@ -831,7 +835,9 @@ void ExportFuncSymbol(const FuncSymbolExport &func) {
 				INFO_LOG(Log::Loader, "Resolving function %s/%08x", func.moduleName, func.nid);
 				WriteFuncStub(it->stubAddr, func.symAddr);
 				currentMIPS->InvalidateICache(it->stubAddr, 8);
-				MIPSAnalyst::PrecompileFunction(it->stubAddr, 8);
+				if (g_Config.bPreloadFunctions) {
+					MIPSAnalyst::PrecompileFunction(it->stubAddr, 8);
+				}
 			}
 		}
 	}

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -327,11 +327,7 @@ void IRBlockCache::Clear() {
 	arena_.shrink_to_fit();
 }
 
-IRBlockCache::IRBlockCache(bool compileToNative) : compileToNative_(compileToNative) {
-	// For whatever reason, this makes things go slower?? Probably just a CPU cache alignment fluke.
-	//arena_.reserve(1024 * 1024 * 12);
-	//arena_.reserve(1024);
-}
+IRBlockCache::IRBlockCache(bool compileToNative) : compileToNative_(compileToNative) {}
 
 int IRBlockCache::AllocateBlock(int emAddr, u32 origSize, const std::vector<IRInst> &insts) {
 	// We have 24 bits to represent offsets with.
@@ -346,7 +342,7 @@ int IRBlockCache::AllocateBlock(int emAddr, u32 origSize, const std::vector<IRIn
 		arena_.push_back(insts[i]);
 	}
 	int newBlockIndex = (int)blocks_.size();
-	blocks_.push_back(IRBlock(emAddr, origSize, offset, insts.size()));
+	blocks_.push_back(IRBlock(emAddr, origSize, offset, (u32)insts.size()));
 	return newBlockIndex;
 }
 
@@ -446,7 +442,7 @@ void IRBlockCache::RemoveBlock(int blockIndex) {
 
 	// Additionally, we zap the block in the IR arena.
 	IRInst bad{ IROp::Bad };
-	for (int off = block.GetIRArenaOffset(); off < block.GetIRArenaOffset() + block.GetNumIRInstructions(); off++) {
+	for (int off = block.GetIRArenaOffset(); off < (int)(block.GetIRArenaOffset() + block.GetNumIRInstructions()); off++) {
 		arena_[off] = bad;
 	}
 }


### PR DESCRIPTION
Fixes #19349, and likely more, when running with the IR Interpreter. Strange that the game worked at all.

The issue is that the arena could get resized due to precompile during sceKernelModuleLoad . Now respect the flag that turns precompile off properly (we should probably make it work differently instead, if we're gonna have it).