### PR TITLE
IR: Disable unworkable overwriting of instructions on invalidation. 

### DIFF
--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -248,6 +248,8 @@ protected:
 
 	MIPSState *mips_;
 
+	bool compilerEnabled_ = true;
+
 	// where to write branch-likely trampolines. not used atm
 	// u32 blTrampolines_;
 	// int blTrampolineCount_;


### PR DESCRIPTION
Broke psp-flower and probably other stuff, oops. Adds a comment about why.

Add a debug-mode sanity check.
