### PR TITLE
Run unit tests on Alpine docker too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -362,3 +362,40 @@ jobs:
     - name: Execute headless tests
       working-directory: ${{ env.GITHUB_WORKSPACE }}
       run: python test.py -g --graphics=software
+
+  build_test_headless_alpine:
+    runs-on: ubuntu-latest
+    container: 
+      image: alpine:latest
+      options: --shm-size=8g
+    steps:
+    - name: Install Linux dependencies (Alpine)
+      run: |
+        apk add build-base wget git bash cmake python3 glu-dev sdl2-dev
+
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Fix git detected dubious ownership in repository
+      run: |
+        chown -R $(id -u):$(id -g) $PWD
+
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+    
+    - name: Compile ffmpeg
+      run: |
+        cd ffmpeg && ./linux_x86-64.sh
+
+    - name: Build for testing
+      run: |
+        ./b.sh --headless --unittest
+
+    - name: Execute unit tests
+      run: |
+        ./build/PPSSPPUnitTest ALL
+
+    - name: Execute headless tests
+      run: |
+        python test.py -g --graphics=software

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ option(USE_SYSTEM_MINIUPNPC "Dynamically link against system miniUPnPc" ${USE_SY
 option(USE_ASAN "Use address sanitizer" OFF)
 option(USE_UBSAN "Use undefined behaviour sanitizer" OFF)
 option(USE_CCACHE "Use ccache if detected" ON)
+option(USE_NO_MMAP "Disable mmap usage" OFF)
 
 if(USE_CCACHE)
 	include(ccache)
@@ -245,6 +246,12 @@ endif()
 # want to have to update all build systems.
 if(HTTPS_NOT_AVAILABLE)
 	add_definitions(-DHTTPS_NOT_AVAILABLE)
+endif()
+
+# Disable the usage of MMAP for the memory system.
+# It is not tested on all platforms and can cause issues.
+if(USE_NO_MMAP)
+	add_definitions(-DNO_MMAP -DMASKED_PSP_MEMORY)
 endif()
 
 # Work around for some misfeature of the current glslang build system

--- a/Common/Data/Collections/FastVec.h
+++ b/Common/Data/Collections/FastVec.h
@@ -7,6 +7,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <cstdint>
 
 #include "Common/Log.h"
 

--- a/Common/MemArenaPosix.cpp
+++ b/Common/MemArenaPosix.cpp
@@ -137,7 +137,7 @@ void MemArena::ReleaseView(s64 offset, void* view, size_t size) {
 
 u8* MemArena::Find4GBBase() {
 	// Now, create views in high memory where there's plenty of space.
-#if PPSSPP_ARCH(64BIT) && !defined(USE_ASAN)
+#if PPSSPP_ARCH(64BIT) && !defined(USE_ASAN) && !defined(NO_MMAP)
 	// We should probably just go look in /proc/self/maps for some free space.
 	// But let's try the anonymous mmap trick, just like on 32-bit, but bigger and
 	// aligned to 4GB for the movk trick. We can ensure that we get an aligned 4GB

--- a/b.sh
+++ b/b.sh
@@ -81,6 +81,9 @@ do
 		--alderlake) echo "Alderlake opt"
 			CMAKE_ARGS="-DCMAKE_C_FLAGS=\"-march=alderlake\" -DCMAKE_CPP_FLAGS=\"-march=alderlake\""
 			;;
+		--no_mmap) echo "Disable mmap"
+			CMAKE_ARGS="-DUSE_NO_MMAP=ON ${CMAKE_ARGS}"
+			;;
 		*) MAKE_OPT="$1 ${MAKE_OPT}"
 			;;
 	esac


### PR DESCRIPTION
## Description
The scope of this PR is to check in the CI that Unit tests are working fine for the Alpine docker version too.


We are now also offering the possibility of setting the `NO_MMAP` flag in the compilation scripts.
Current behavior with this flag is not stable, as some unit tests are not passing and with some other is crashing, this is why I have added it to the matrix of testing.
Some other minor changes have been made.

Cheers.