### PR TITLE
Replace call of SetWaitableTimerEx with SetWaitableTimer

### DIFF
--- a/Common/TimeUtil.cpp
+++ b/Common/TimeUtil.cpp
@@ -283,7 +283,8 @@ void sleep_precise(double seconds) {
 				break;
 			LARGE_INTEGER due;
 			due.QuadPart = -(sleepTicks > maxTicks ? maxTicks : sleepTicks);
-			SetWaitableTimerEx(Timer, &due, 0, NULL, NULL, NULL, 0);
+			// Note: SetWaitableTimerEx is not available on Vista.
+			SetWaitableTimer(Timer, &due, 0, NULL, NULL, NULL);
 			WaitForSingleObject(Timer, INFINITE);
 			QueryPerformanceCounter(&qpc);
 		}


### PR DESCRIPTION
This makes the build work on retroarch's build server, and keeps compatibility with Windows Vista (although we hardly test for that).