### PR TITLE
iOS: Enable text chat

### DIFF
--- a/UI/ChatScreen.cpp
+++ b/UI/ChatScreen.cpp
@@ -26,7 +26,7 @@ void ChatMenu::CreateContents(UI::ViewGroup *parent) {
 	chatEdit_ = bottom->Add(new TextEdit("", n->T("Chat message"), n->T("Chat Here"), new LinearLayoutParams(1.0)));
 	chatEdit_->OnEnter.Handle(this, &ChatMenu::OnSubmit);
 
-#elif PPSSPP_PLATFORM(ANDROID)
+#elif PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(IOS)
 	bottom->Add(new Button(n->T("Chat Here"),new LayoutParams(FILL_PARENT, WRAP_CONTENT)))->OnClick.Handle(this, &ChatMenu::OnSubmit);
 	bottom->Add(new Button(n->T("Send")))->OnClick.Handle(this, &ChatMenu::OnSubmit);
 #endif
@@ -95,7 +95,7 @@ UI::EventReturn ChatMenu::OnSubmit(UI::EventParams &e) {
 	chatEdit_->SetText("");
 	chatEdit_->SetFocus();
 	sendChat(chat);
-#elif PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(SWITCH)
+#elif PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(SWITCH) || PPSSPP_PLATFORM(IOS)
 	auto n = GetI18NCategory(I18NCat::NETWORKING);
 	System_InputBoxGetString(token_, n->T("Chat"), "", [](const std::string &value, int) {
 		sendChat(value);

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -50,7 +50,7 @@ void InstallZipScreen::CreateViews() {
 	std::string shortFilename = zipPath_.GetFilename();
 	
 	// TODO: Do in the background?
-	ZipFileInfo zipInfo;
+	ZipFileInfo zipInfo{};
 	ZipFileContents contents = DetectZipFileContents(zipPath_, &zipInfo);
 
 	if (contents == ZipFileContents::ISO_FILE || contents == ZipFileContents::PSP_GAME_DIR) {

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -695,8 +695,12 @@ bool GameBrowser::HasSpecialFiles(std::vector<Path> &filenames) {
 
 void GameBrowser::Update() {
 	LinearLayout::Update();
-	if (listingPending_ && path_.IsListingReady()) {
+	if (refreshPending_) {
+		path_.Refresh();
+	}
+	if ((listingPending_ && path_.IsListingReady()) || refreshPending_) {
 		Refresh();
+		refreshPending_ = false;
 	}
 	if (searchPending_) {
 		ApplySearchFilter();
@@ -1613,6 +1617,12 @@ void MainScreen::dialogFinished(const Screen *dialog, DialogResult result) {
 		} else {
 			// Not refocusing, so we need to stop the audio.
 			g_BackgroundAudio.SetGame(Path());
+		}
+	}
+	if (tag == "InstallZip") {
+		INFO_LOG(Log::System, "InstallZip finished, refreshing");
+		if (gameBrowsers_.size() >= 2) {
+			gameBrowsers_[1]->RequestRefresh();
 		}
 	}
 }

--- a/UI/MainScreen.h
+++ b/UI/MainScreen.h
@@ -55,6 +55,9 @@ public:
 	void ApplySearchFilter(const std::string &filter);
 	void Draw(UIContext &dc) override;
 	void Update() override;
+	void RequestRefresh() {
+		refreshPending_ = true;
+	}
 
 	void SetHomePath(const Path &path) {
 		homePath_ = path;
@@ -106,6 +109,7 @@ private:
 	Path focusGamePath_;
 	bool listingPending_ = false;
 	bool searchPending_ = false;
+	bool refreshPending_ = false;
 	float lastScale_ = 1.0f;
 	bool lastLayoutWasGrid_ = true;
 	ScreenManager *screenManager_;


### PR DESCRIPTION
Makes it work like on Android (pop up a text input dialog).

Also fix a couple of bugs with ZIP file extraction, especially for zip files created on mac.