### PR TITLE
fix shutdown crash on Windows

### DIFF
--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -158,7 +158,6 @@ MIPSState::MIPSState() {
 }
 
 MIPSState::~MIPSState() {
-	Shutdown();
 }
 
 void MIPSState::Shutdown() {


### PR DESCRIPTION
When I shutdown ppsspp I get a crash:

```
Exception 0xc0000005 encountered at address 0x7ff8f7eb49f6: Access violation writing location 0x00000024

RtlWaitOnAddress (Unknown Source:0)
RtlEnterCriticalSection (Unknown Source:0)
RtlEnterCriticalSection (Unknown Source:0)
std::__1::__libcpp_recursive_mutex_lock(void* (*) [5]) (Unknown Source:0)
std::__1::recursive_mutex::lock() (Unknown Source:0)
std::__1::lock_guard<std::__1::recursive_mutex>::lock_guard[abi:se180100](std::__1::recursive_mutex&) (c:\msys64\clang64\include\c++\v1\__mutex\lock_guard.h:35)
MIPSState::Shutdown() (c:\src\ppsspp\Core\MIPS\MIPS.cpp:165)
MIPSState::~MIPSState() (c:\src\ppsspp\Core\MIPS\MIPS.cpp:161)
::__dtor_mipsr4k() (Unknown Source:0)
_execute_onexit_table (Unknown Source:0)
_execute_onexit_table (Unknown Source:0)
_execute_onexit_table (Unknown Source:0)
exit (Unknown Source:0)
exit (Unknown Source:0)
exit (Unknown Source:0)
__tmainCRTStartup (c:\M\B\src\mingw-w64\mingw-w64-crt\crt\crtexe.c:260)
WinMainCRTStartup (c:\M\B\src\mingw-w64\mingw-w64-crt\crt\crtexe.c:148)
BaseThreadInitThunk (Unknown Source:0)
RtlUserThreadStart (Unknown Source:0)
```

I fixed it. Not sure if it is correct, but it works.