### PR TITLE
OpenXR - Ensure we have a valid poses after app event

### DIFF
--- a/Common/VR/VRFramebuffer.cpp
+++ b/Common/VR/VRFramebuffer.cpp
@@ -504,6 +504,7 @@ int ovrApp_HandleXrEvents(ovrApp* app) {
 					default:
 						break;
 				}
+				recenter = true;
 			} break;
 			default:
 				ALOGV("xrPollEvent: Unknown event");


### PR DESCRIPTION
It seems the headset loses reference to coordinate system after session state change. This one line change ensures there is always a valid coordinate system.