### PR TITLE
Homebrew Store: Minor update adding license and website links

### DIFF
--- a/Common/StringUtils.cpp
+++ b/Common/StringUtils.cpp
@@ -171,6 +171,14 @@ std::string IndentString(const std::string &str, const std::string &sep, bool sk
 	return output.str();
 }
 
+std::string_view StripPrefix(std::string_view prefix, std::string_view s) {
+	if (startsWith(s, prefix)) {
+		return s.substr(prefix.size(), s.size() - prefix.size());
+	} else {
+		return s;
+	}
+}
+
 void SkipSpace(const char **ptr) {
 	while (**ptr && isspace(**ptr)) {
 		(*ptr)++;

--- a/Common/StringUtils.h
+++ b/Common/StringUtils.h
@@ -81,6 +81,8 @@ std::string StripQuotes(const std::string &s);
 std::string_view StripSpaces(std::string_view s);
 std::string_view StripQuotes(std::string_view s);
 
+std::string_view StripPrefix(std::string_view prefix, std::string_view s);
+
 // NOTE: str must live at least as long as all uses of output.
 void SplitString(std::string_view str, const char delim, std::vector<std::string_view> &output);
 // Try to avoid this when possible, in favor of the string_view version.

--- a/Tools/langtool/Cargo.lock
+++ b/Tools/langtool/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -19,33 +19,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.5"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -87,15 +87,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "heck"
@@ -105,9 +105,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "langtool"
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -142,9 +142,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.67"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8655ed1d86f3af4ee3fd3263786bc14245ad17c4c7e85ba7187fb3ae028c90"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -190,48 +190,48 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/UI/Store.h
+++ b/UI/Store.h
@@ -50,9 +50,11 @@ struct StoreEntry {
 	std::string description;
 	std::string author;
 	std::string iconURL;
-	std::string file;  // This is the folder name of the installed one too, and hence a "unique-ish" identifier.
+	std::string file;  // This is the folder name of the installed one too, and hence a "unique-ish" identifier. Also used as a-link on the license website, if !license.empty().
 	std::string category;
 	std::string downloadURL;  // Only set for games that are not hosted on store.ppsspp.org
+	std::string websiteURL;
+	std::string license;
 	bool hidden;
 	int contentRating;  // 100 means to hide it on iOS. No other values defined yet.
 	u64 size;

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -1180,6 +1180,7 @@ Search term = Search term
 
 [Store]
 Connection Error = ‎خطأ في الإتصال
+Details = Details
 Install = ‎تثبيت
 Installed = ‎مثبتة بالفعل
 Launch Game = ‎إبدء اللعبة
@@ -1187,6 +1188,7 @@ Loading... = ‎تحميل...
 MB = ‎ميجا
 Size = ‎الحجم
 Uninstall = ‎إلغاء التثبيت
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Connection error
+Details = Details
 Install = Install
 Installed = Installed
 Launch Game = Launch game
@@ -1179,6 +1180,7 @@ Loading... = Loading...
 MB = MB
 Size = Size
 Uninstall = Uninstall
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Грешка при свързването
+Details = Details
 Install = Инсталирай
 Installed = Вече е инсталирано
 Launch Game = Launch game
@@ -1179,6 +1180,7 @@ Loading... = Зареждане...
 MB = MB
 Size = Големина
 Uninstall = Деинсталирай
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Error de connexió
+Details = Details
 Install = Instal·lar
 Installed = Ja instal·lat
 Launch Game = Iniciar joc
@@ -1179,6 +1180,7 @@ Loading... = Carregant...
 MB = MB
 Size = Mida
 Uninstall = Desinstal·lar
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Chyba připojení
+Details = Details
 Install = Nainstalovat
 Installed = Již instalováno
 Launch Game = Spustit hru
@@ -1179,6 +1180,7 @@ Loading... = Načítání...
 MB = MB
 Size = Velikost
 Uninstall = Odinstalovat
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Forbindelsesfejl
+Details = Details
 Install = Installer
 Installed = Allerede installeret
 Launch Game = Start spil
@@ -1179,6 +1180,7 @@ Loading... = Henter...
 MB = MB
 Size = Størrelse
 Uninstall = Afinstaller
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -1172,6 +1172,7 @@ Search term = Suchbegriff
 
 [Store]
 Connection Error = Verbindungsfehler
+Details = Details
 Install = Installieren
 Installed = Bereits installiert
 Launch Game = Spiel starten
@@ -1179,6 +1180,7 @@ Loading... = Lade...
 MB = MB
 Size = Größe
 Uninstall = Deinstallieren
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Connection error
+Details = Details
 Install = Install
 Installed = Installed
 Launch Game = Launch game
@@ -1179,6 +1180,7 @@ Loading... = Loading...
 MB = MB
 Size = Size
 Uninstall = Uninstall
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -1188,6 +1188,7 @@ Untitled PSP game = Untitled PSP game
 
 [Store]
 Connection Error = Connection error
+Details = Details
 Install = Install
 Installed = Installed
 Launch Game = Launch game
@@ -1195,6 +1196,7 @@ Loading... = Loading...
 MB = MB
 Size = Size
 Uninstall = Uninstall
+Website = Website
 
 [SysInfo]
 %d (%d per core, %d cores) = %d (%d per core, %d cores)

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -1173,6 +1173,7 @@ Search term = Buscar término
 
 [Store]
 Connection Error = Error de conexión
+Details = Details
 Install = Instalar
 Installed = Ya instalado
 Launch Game = Iniciar juego
@@ -1180,6 +1181,7 @@ Loading... = Cargando...
 MB = MB
 Size = Tamaño
 Uninstall = Desinstalar
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -1174,6 +1174,7 @@ Search term = Buscar termino
 
 [Store]
 Connection Error = Error de conexión
+Details = Details
 Install = Instalar
 Installed = Ya instalado
 Launch Game = Lanzar juego
@@ -1181,6 +1182,7 @@ Loading... = Cargando...
 MB = MB
 Size = Tamaño
 Uninstall = Desinstalar
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -1172,6 +1172,7 @@ Search term = عبارت جستجو
 
 [Store]
 Connection Error = خطای اتصال
+Details = Details
 Install = نصب
 Installed = نصب شده
 Launch Game = اجرای بازی
@@ -1179,6 +1180,7 @@ Loading... = بارگیری...
 MB = MB
 Size = حجم
 Uninstall = حذف نصب
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -1172,6 +1172,7 @@ Search term = Hakusana
 
 [Store]
 Connection Error = Yhteysvirhe
+Details = Details
 Install = Asenna
 Installed = Jo asennettu
 Launch Game = Käynnistä peli
@@ -1179,6 +1180,7 @@ Loading... = Ladataan...
 MB = Mt
 Size = Koko
 Uninstall = Poista asennus
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -1163,6 +1163,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Erreur de connexion
+Details = Details
 Install = Installer
 Installed = Déjà installé
 Launch Game = Lancer le jeu
@@ -1170,6 +1171,7 @@ Loading... = Chargement...
 MB = Mo
 Size = Taille
 Uninstall = Désinstaller
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Erro de conexión
+Details = Details
 Install = Instalar
 Installed = Xa instalado
 Launch Game = Launch game
@@ -1179,6 +1180,7 @@ Loading... = Cargando...
 MB = MB
 Size = Tamaño
 Uninstall = Desinstalar
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Σφάλμα σύνδεσης
+Details = Details
 Install = Εγκατάσταση
 Installed = Ήδη εγκατεστημένο
 Launch Game = Έναρξη παιχνιδιού
@@ -1179,6 +1180,7 @@ Loading... = Φόρτωση...
 MB = MB
 Size = Μέγεθος
 Uninstall = Απεγκατάσταση
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Connection error
+Details = Details
 Install = Install
 Installed = Installed
 Launch Game = Launch game
@@ -1179,6 +1180,7 @@ Loading... = Loading...
 MB = MB
 Size = Size
 Uninstall = Uninstall
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Connection error
+Details = Details
 Install = Install
 Installed = Installed
 Launch Game = Launch game
@@ -1179,6 +1180,7 @@ Loading... = Loading...
 MB = MB
 Size = Size
 Uninstall = Uninstall
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Pogreška u spajanju
+Details = Details
 Install = Instaliraj
 Installed = Već instalirano
 Launch Game = Pokreni igru
@@ -1179,6 +1180,7 @@ Loading... = Učitavanje...
 MB = MB
 Size = Veličina
 Uninstall = Deinstaliraj
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Kapcsolódási hiba
+Details = Details
 Install = Telepítés
 Installed = Már telepítve
 Launch Game = Játék indítása
@@ -1179,6 +1180,7 @@ Loading... = Töltés...
 MB = MB
 Size = Méret
 Uninstall = Eltávolítás
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Kesalahan pada koneksi
+Details = Details
 Install = Pasang
 Installed = Sudah terpasang
 Launch Game = Jalankan permainan
@@ -1179,6 +1180,7 @@ Loading... = Memuat...
 MB = MB
 Size = Ukuran
 Uninstall = Mencopot pemasangan
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -1173,6 +1173,7 @@ Search term = Cerca termine
 
 [Store]
 Connection Error = Errore di connessione
+Details = Details
 Install = Installa
 Installed = Già installato
 Launch Game = Avvia il gioco
@@ -1180,6 +1181,7 @@ Loading... = Caricamento...
 MB = MB
 Size = Dimensioni
 Uninstall = Disinstalla
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = 接続エラー
+Details = Details
 Install = インストールする
 Installed = インストール済み
 Launch Game = ゲームを起動する
@@ -1179,6 +1180,7 @@ Loading... = ロードしています...
 MB = MB
 Size = サイズ
 Uninstall = アンインストールする
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Galat koneksi
+Details = Details
 Install = Nginstal
 Installed = Mpun terpasang
 Launch Game = Bukak Dolanan
@@ -1179,6 +1180,7 @@ Loading... = Nteni...
 MB = MB
 Size = Ukuran
 Uninstall = Copot
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -1164,6 +1164,7 @@ Untitled PSP game = 제목 없는 PSP 게임
 
 [Store]
 Connection Error = 연결 오류
+Details = Details
 Install = 설치
 Installed = 이미 설치됨
 Launch Game = 게임 실행
@@ -1171,6 +1172,7 @@ Loading... = 불러오기 중...
 MB = 메가바이트
 Size = 크기
 Uninstall = 제거
+Website = Website
 
 [SysInfo]
 %d (%d per core, %d cores) = %d (코어 당 %d, 코어 %d 개)

--- a/assets/lang/ku_SO.ini
+++ b/assets/lang/ku_SO.ini
@@ -1178,6 +1178,7 @@ Untitled PSP game = Untitled PSP game
 
 [Store]
 Connection Error = Connection error
+Details = Details
 Install = Install
 Installed = Installed
 Launch Game = Launch game
@@ -1185,6 +1186,7 @@ Loading... = Loading...
 MB = MB
 Size = Size
 Uninstall = Uninstall
+Website = Website
 
 [SysInfo]
 %d (%d per core, %d cores) = %d (%d per core, %d cores)

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = ການເຊື່ອມຕໍ່ລົ້ມເຫຼວ
+Details = Details
 Install = ຕິດຕັ້ງ
 Installed = ຕິດຕັ້ງຮຽບຮ້ອຍແລ້ວ
 Launch Game = ເລີ່ມເກມ
@@ -1179,6 +1180,7 @@ Loading... = ກຳລັງໂຫຼດ...
 MB = MB
 Size = ຂະໜາດ
 Uninstall = ຖອນການຕິດຕັ້ງ
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Prisijungimo klaida
+Details = Details
 Install = Instaliuoti
 Installed = Jau instaliuota
 Launch Game = Paleisti žaidimą
@@ -1179,6 +1180,7 @@ Loading... = Kraunama...
 MB = Megabaitai
 Size = Dydis
 Uninstall = Išinstaliuoti
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Kesalahan Sambungan
+Details = Details
 Install = Pasang
 Installed = Telah dipasang sebelumnya
 Launch Game = Launch game
@@ -1179,6 +1180,7 @@ Loading... = Memuatkan...
 MB = MB
 Size = Saiz
 Uninstall = Nyahpasang
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Verbindingsfout
+Details = Details
 Install = Installeren
 Installed = Al geïnstalleerd
 Launch Game = Game starten
@@ -1179,6 +1180,7 @@ Loading... = Laden
 MB = MB
 Size = Grootte
 Uninstall = Deïnstalleren
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Connection error
+Details = Details
 Install = Install
 Installed = Installed
 Launch Game = Launch game
@@ -1179,6 +1180,7 @@ Loading... = Loading...
 MB = MB
 Size = Size
 Uninstall = Uninstall
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -1177,6 +1177,7 @@ Search term = Wyszukaj frazę
 
 [Store]
 Connection Error = Błąd połączenia
+Details = Details
 Install = Zainstaluj
 Installed = Zainstalowane
 Launch Game = Rozpocznij grę
@@ -1184,6 +1185,7 @@ Loading... = Ładowanie...
 MB = MB
 Size = Rozmiar
 Uninstall = Odinstaluj
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -1188,6 +1188,7 @@ Untitled PSP game = Jogo de PSP sem título
 
 [Store]
 Connection Error = Erro de conexão
+Details = Details
 Install = Instalar
 Installed = Instalada
 Launch Game = Iniciar jogo
@@ -1195,6 +1196,7 @@ Loading... = Carregando...
 MB = MBs
 Size = Tamanho
 Uninstall = Desinstalar
+Website = Website
 
 [SysInfo]
 %d (%d per core, %d cores) = %d (%d por núcleo, %d núcleos)

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -1190,6 +1190,7 @@ Untitled PSP game = Jogo de PSP sem título
 
 [Store]
 Connection Error = Erro de conexão
+Details = Details
 Install = Instalar
 Installed = Já instalado
 Launch Game = Iniciar jogo
@@ -1197,6 +1198,7 @@ Loading... = Carregando...
 MB = MBs
 Size = Tamanho
 Uninstall = Desinstalar
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -1173,6 +1173,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Eroare de conexiune
+Details = Details
 Install = Instalare
 Installed = Deja instalat
 Launch Game = Launch game
@@ -1180,6 +1181,7 @@ Loading... = Se încarcă...
 MB = MB
 Size = Mărime
 Uninstall = Dezinstalare
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -1172,6 +1172,7 @@ Search term = Поисковый запрос
 
 [Store]
 Connection Error = Ошибка подключения
+Details = Details
 Install = Установить
 Installed = Установлено
 Launch Game = Запустить игру
@@ -1179,6 +1180,7 @@ Loading... = Загрузка...
 MB = Мб
 Size = Размер
 Uninstall = Удалить
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Гц

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -1173,6 +1173,7 @@ Search term = Sökterm
 
 [Store]
 Connection Error = Uppkopplingsfel
+Details = Details
 Install = Installera
 Installed = Installerad
 Launch Game = Starta spel
@@ -1180,6 +1181,7 @@ Loading... = Laddar...
 MB = MB
 Size = Storlek
 Uninstall = Avinstallera
+Website = Website
 
 [SysInfo]
 %d (%d per core, %d cores) = %d (%d per kärna, %d kärnor)

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -1175,6 +1175,7 @@ Search term = Kataga sa paghahanap
 
 [Store]
 Connection Error = May error sa Koneksyon.
+Details = Details
 Install = I-Install
 Installed = Na-installed na
 Launch Game = Buksan ang laro
@@ -1182,6 +1183,7 @@ Loading... = Binabasa...
 MB = MB
 Size = Sukat
 Uninstall = I-Uninstall
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -1182,6 +1182,7 @@ Search term = คำที่ต้องการค้นหา
 
 [Store]
 Connection Error = การเชื่อมต่อล้มเหลว
+Details = Details
 Install = ติดตั้ง
 Installed = ติดตั้งเรียบร้อย
 Launch Game = เริ่มเกม
@@ -1189,6 +1190,7 @@ Loading... = กำลังโหลด...
 MB = เมกกะไบต์
 Size = ขนาด
 Uninstall = ถอนการติดตั้ง
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f เฮิร์ต

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -1173,6 +1173,7 @@ Search term = Arama terimi
 
 [Store]
 Connection Error = Bağlantı hatası
+Details = Details
 Install = Yükle
 Installed = Zaten yüklü
 Launch Game = Oyunu başlat
@@ -1180,6 +1181,7 @@ Loading... = Yükleniyor...
 MB = MB
 Size = Boyut
 Uninstall = Sil
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Помилка підключення
+Details = Details
 Install = Встановити
 Installed = Вже встановлено
 Launch Game = Запустити гри
@@ -1179,6 +1180,7 @@ Loading... = Завантаження...
 MB = Мб
 Size = Розмір
 Uninstall = Видалити
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -1172,6 +1172,7 @@ Search term = Search term
 
 [Store]
 Connection Error = Lỗi kết nối
+Details = Details
 Install = Cài
 Installed = Đã cài rồi
 Launch Game = Launch game
@@ -1179,6 +1180,7 @@ Loading... = Đang load...
 MB = MB
 Size = Kích cỡ
 Uninstall = Gỡ
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -1165,6 +1165,7 @@ Untitled PSP game = 无标题的PSP游戏
 
 [Store]
 Connection Error = 网络错误
+Details = Details
 Install = 安装
 Installed = 已安装
 Launch Game = 开始游戏
@@ -1172,6 +1173,7 @@ Loading... = 载入中…
 MB = MB
 Size = 大小
 Uninstall = 卸载
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -1164,6 +1164,7 @@ Untitled PSP game = 未命名 PSP 遊戲
 
 [Store]
 Connection Error = 連線錯誤
+Details = Details
 Install = 安裝
 Installed = 已安裝
 Launch Game = 啟動遊戲
@@ -1171,6 +1172,7 @@ Loading... = 正在載入…
 MB = MB
 Size = 大小
 Uninstall = 解除安裝
+Website = Website
 
 [SysInfo]
 %0.2f Hz = %0.2f Hz


### PR DESCRIPTION
The license button links to the new page https://www.ppsspp.org/docs/reference/homebrew-store-distribution/ , which contains information about how the homebrew apps are allowed to be distributed.

Something like this was requested by Apple in App Store Review.