### PR TITLE
Implement save data install from ZIP

### DIFF
--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -37,6 +37,9 @@
 #include <ctime>
 #include <memory>
 
+#include <sys/utime.h>
+#include <sys/types.h>
+
 #include "Common/Log.h"
 #include "Common/LogReporting.h"
 #include "Common/File/AndroidContentURI.h"
@@ -1238,6 +1241,22 @@ bool WriteDataToFile(bool text_file, const void* data, size_t size, const Path &
 	}
 	fclose(f);
 	return true;
+}
+
+void ChangeMTime(const Path &path, time_t mtime) {
+	if (path.Type() == PathType::CONTENT_URI) {
+		// No clue what to do here.
+		return;
+	}
+
+	_utimbuf buf{};
+	buf.actime = mtime;
+	buf.modtime = mtime;
+#ifdef _WIN32
+	_utime(path.c_str(), &buf);
+#else
+	utime(path.c_str(), &buf);
+#endif
 }
 
 }  // namespace File

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -20,6 +20,9 @@
 #ifndef UNICODE
 #error Win32 build requires a unicode build
 #endif
+#else
+#define _POSIX_SOURCE
+#define _LARGE_TIME_API
 #endif
 
 #include "ppsspp_config.h"
@@ -37,7 +40,6 @@
 #include <ctime>
 #include <memory>
 
-#include <sys/utime.h>
 #include <sys/types.h>
 
 #include "Common/Log.h"
@@ -49,6 +51,7 @@
 
 #ifdef _WIN32
 #include "Common/CommonWindows.h"
+#include <sys/utime.h>
 #include <Windows.h>
 #include <shlobj.h>		// for SHGetFolderPath
 #include <shellapi.h>
@@ -66,6 +69,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <utime.h>
 #endif
 
 #if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__)
@@ -170,7 +174,7 @@ FILE *OpenCFile(const Path &path, const char *mode) {
 
 #if defined(_WIN32) && defined(UNICODE)
 #if PPSSPP_PLATFORM(UWP) && !defined(__LIBRETRO__)
-	// We shouldn't use _wfopen here, 
+	// We shouldn't use _wfopen here,
 	// this function is not allowed to read outside Local and Installation folders
 	// FileSystem (broadFileSystemAccess) doesn't apply on _wfopen
 	// if we have custom memory stick location _wfopen will return null
@@ -474,7 +478,7 @@ bool Delete(const Path &filename) {
 
 	INFO_LOG(Log::Common, "Delete: file %s", filename.c_str());
 
-	// Return true because we care about the file no 
+	// Return true because we care about the file no
 	// being there, not the actual delete.
 	if (!Exists(filename)) {
 		WARN_LOG(Log::Common, "Delete: '%s' already does not exist", filename.c_str());
@@ -501,7 +505,7 @@ bool Delete(const Path &filename) {
 #endif
 #else
 	if (unlink(filename.c_str()) == -1) {
-		WARN_LOG(Log::Common, "Delete: unlink failed on %s: %s", 
+		WARN_LOG(Log::Common, "Delete: unlink failed on %s: %s",
 				 filename.c_str(), GetLastErrorMsg().c_str());
 		return false;
 	}
@@ -550,7 +554,7 @@ bool CreateDir(const Path &path) {
 	if (::CreateDirectory(path.ToWString().c_str(), NULL))
 		return true;
 #endif
-	
+
 	DWORD error = GetLastError();
 	if (error == ERROR_ALREADY_EXISTS) {
 		WARN_LOG(Log::Common, "CreateDir: CreateDirectory failed on %s: already exists", path.c_str());
@@ -619,7 +623,7 @@ bool CreateFullPath(const Path &path) {
 	return true;
 }
 
-// renames file srcFilename to destFilename, returns true on success 
+// renames file srcFilename to destFilename, returns true on success
 bool Rename(const Path &srcFilename, const Path &destFilename) {
 	if (srcFilename.Type() != destFilename.Type()) {
 		// Impossible. You're gonna need to make a copy, and delete the original. Not the responsibility
@@ -662,12 +666,12 @@ bool Rename(const Path &srcFilename, const Path &destFilename) {
 		return true;
 #endif
 
-	ERROR_LOG(Log::Common, "Rename: failed %s --> %s: %s", 
+	ERROR_LOG(Log::Common, "Rename: failed %s --> %s: %s",
 			  srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg().c_str());
 	return false;
 }
 
-// copies file srcFilename to destFilename, returns true on success 
+// copies file srcFilename to destFilename, returns true on success
 bool Copy(const Path &srcFilename, const Path &destFilename) {
 	switch (srcFilename.Type()) {
 	case PathType::NATIVE:
@@ -695,7 +699,7 @@ bool Copy(const Path &srcFilename, const Path &destFilename) {
 	if (CopyFile(srcFilename.ToWString().c_str(), destFilename.ToWString().c_str(), FALSE))
 		return true;
 #endif
-	ERROR_LOG(Log::Common, "Copy: failed %s --> %s: %s", 
+	ERROR_LOG(Log::Common, "Copy: failed %s --> %s: %s",
 			srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg().c_str());
 	return false;
 #else
@@ -708,7 +712,7 @@ bool Copy(const Path &srcFilename, const Path &destFilename) {
 	// Open input file
 	FILE *input = OpenCFile(srcFilename, "rb");
 	if (!input) {
-		ERROR_LOG(Log::Common, "Copy: input failed %s --> %s: %s", 
+		ERROR_LOG(Log::Common, "Copy: input failed %s --> %s: %s",
 				srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg().c_str());
 		return false;
 	}
@@ -717,7 +721,7 @@ bool Copy(const Path &srcFilename, const Path &destFilename) {
 	FILE *output = OpenCFile(destFilename, "wb");
 	if (!output) {
 		fclose(input);
-		ERROR_LOG(Log::Common, "Copy: output failed %s --> %s: %s", 
+		ERROR_LOG(Log::Common, "Copy: output failed %s --> %s: %s",
 				srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg().c_str());
 		return false;
 	}
@@ -728,11 +732,11 @@ bool Copy(const Path &srcFilename, const Path &destFilename) {
 		int rnum = fread(buffer, sizeof(char), BSIZE, input);
 		if (rnum != BSIZE) {
 			if (ferror(input) != 0) {
-				ERROR_LOG(Log::Common, 
-						"Copy: failed reading from source, %s --> %s: %s", 
+				ERROR_LOG(Log::Common,
+						"Copy: failed reading from source, %s --> %s: %s",
 						srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg().c_str());
 				fclose(input);
-				fclose(output);		
+				fclose(output);
 				return false;
 			}
 		}
@@ -740,11 +744,11 @@ bool Copy(const Path &srcFilename, const Path &destFilename) {
 		// write output
 		int wnum = fwrite(buffer, sizeof(char), rnum, output);
 		if (wnum != rnum) {
-			ERROR_LOG(Log::Common, 
-					"Copy: failed writing to output, %s --> %s: %s", 
+			ERROR_LOG(Log::Common,
+					"Copy: failed writing to output, %s --> %s: %s",
 					srcFilename.c_str(), destFilename.c_str(), GetLastErrorMsg().c_str());
 			fclose(input);
-			fclose(output);				
+			fclose(output);
 			return false;
 		}
 	}
@@ -886,9 +890,9 @@ uint64_t GetFileSize(FILE *f) {
 #endif
 }
 
-// creates an empty file filename, returns true on success 
+// creates an empty file filename, returns true on success
 bool CreateEmptyFile(const Path &filename) {
-	INFO_LOG(Log::Common, "CreateEmptyFile: %s", filename.c_str()); 
+	INFO_LOG(Log::Common, "CreateEmptyFile: %s", filename.c_str());
 	FILE *pFile = OpenCFile(filename, "wb");
 	if (!pFile) {
 		ERROR_LOG(Log::Common, "CreateEmptyFile: failed to create '%s': %s", filename.c_str(), GetLastErrorMsg().c_str());
@@ -1121,7 +1125,7 @@ bool IOFile::Seek(int64_t off, int origin)
 }
 
 uint64_t IOFile::Tell()
-{	
+{
 	if (IsOpen())
 		return ftello(m_file);
 	else
@@ -1249,12 +1253,15 @@ void ChangeMTime(const Path &path, time_t mtime) {
 		return;
 	}
 
+#ifdef _WIN32
 	_utimbuf buf{};
 	buf.actime = mtime;
 	buf.modtime = mtime;
-#ifdef _WIN32
 	_utime(path.c_str(), &buf);
 #else
+	utimbuf buf{};
+	buf.actime = mtime;
+	buf.modtime = mtime;
 	utime(path.c_str(), &buf);
 #endif
 }

--- a/Common/File/FileUtil.h
+++ b/Common/File/FileUtil.h
@@ -83,6 +83,8 @@ uint64_t ComputeRecursiveDirectorySize(const Path &path);
 // Returns true if successful, or path already exists.
 bool CreateDir(const Path &filename);
 
+void ChangeMTime(const Path &path, time_t mtime);
+
 // Creates the full path of fullPath returns true on success
 bool CreateFullPath(const Path &fullPath);
 

--- a/Core/ELF/ParamSFO.cpp
+++ b/Core/ELF/ParamSFO.cpp
@@ -62,24 +62,28 @@ void ParamSFOData::SetValue(const std::string &key, const u8 *value, unsigned in
 
 int ParamSFOData::GetValueInt(const std::string &key) const {
 	std::map<std::string,ValueData>::const_iterator it = values.find(key);
-	if(it == values.end() || it->second.type != VT_INT)
+	if (it == values.end() || it->second.type != VT_INT)
 		return 0;
 	return it->second.i_value;
 }
 
 std::string ParamSFOData::GetValueString(const std::string &key) const {
 	std::map<std::string,ValueData>::const_iterator it = values.find(key);
-	if(it == values.end() || (it->second.type != VT_UTF8))
+	if (it == values.end() || (it->second.type != VT_UTF8))
 		return "";
 	return it->second.s_value;
 }
 
+bool ParamSFOData::HasKey(const std::string &key) const {
+	return values.find(key) != values.end();
+}
+
 const u8 *ParamSFOData::GetValueData(const std::string &key, unsigned int *size) const {
 	std::map<std::string,ValueData>::const_iterator it = values.find(key);
-	if(it == values.end() || (it->second.type != VT_UTF8_SPE))
+	if (it == values.end() || (it->second.type != VT_UTF8_SPE)) {
 		return 0;
-	if(size)
-	{
+	}
+	if (size) {
 		*size = it->second.u_size;
 	}
 	return it->second.u_value;

--- a/Core/ELF/ParamSFO.h
+++ b/Core/ELF/ParamSFO.h
@@ -35,6 +35,7 @@ public:
 
 	int GetValueInt(const std::string &key) const;
 	std::string GetValueString(const std::string &key) const;
+	bool HasKey(const std::string &key) const;
 	const u8 *GetValueData(const std::string &key, unsigned int *size) const;
 
 	std::vector<std::string> GetKeys() const;

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -24,8 +24,6 @@
 #include <set>
 #include <sstream>
 #include <thread>
-#include <sys/types.h>
-#include <sys/utime.h>
 #ifdef SHARED_LIBZIP
 #include <zip.h>
 #else

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -24,13 +24,15 @@
 #include <set>
 #include <sstream>
 #include <thread>
-
+#include <sys/types.h>
+#include <sys/utime.h>
 #ifdef SHARED_LIBZIP
 #include <zip.h>
 #else
 #include "ext/libzip/zip.h"
 #endif
 #ifdef _WIN32
+
 #include "Common/CommonWindows.h"
 #endif
 #include "Common/Data/Encoding/Utf8.h"
@@ -652,8 +654,14 @@ bool GameManager::ExtractFile(struct zip *z, int file_index, const Path &outFile
 			*bytesCopied += readSize;
 			installProgress_ = (float)*bytesCopied / (float)allBytes;
 		}
+
 		zip_fclose(zf);
 		fclose(f);
+
+		// Copy the mtime, too. May not be possible on Android?
+		if (zstat.mtime) {
+			File::ChangeMTime(outFilename, zstat.mtime);
+		}
 		delete[] buffer;
 		return true;
 	} else {

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -610,7 +610,7 @@ bool ZipExtractFileToMemory(struct zip *z, int fileIndex, std::string *data) {
 	zip_int64_t retval = zip_fread(zf, data->data(), readSize);
 	zip_fclose(zf);
 
-	if (retval < 0 || retval < readSize) {
+	if (retval < 0 || retval < (int)readSize) {
 		ERROR_LOG(Log::HLE, "Failed to read %d bytes from zip (%d) - archive corrupt?", (int)readSize, (int)retval);
 		return false;
 	} else {

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -40,15 +40,18 @@ enum class ZipFileContents {
 	PSP_GAME_DIR,
 	ISO_FILE,
 	TEXTURE_PACK,
+	SAVE_DATA,
 };
 
 struct ZipFileInfo {
 	ZipFileContents contents;
 	int numFiles;
-	int stripChars;  // for PSP game
+	int stripChars;  // for PSP game - how much to strip from the path.
 	int isoFileIndex;  // for ISO
 	int textureIniIndex;  // for textures
 	bool ignoreMetaFiles;
+	std::string contentName;
+	std::string savedataDir;
 };
 
 struct ZipFileTask {
@@ -106,8 +109,8 @@ public:
 private:
 	void InstallZipContents(ZipFileTask task);
 
-	bool InstallMemstickGame(struct zip *z, const Path &zipFile, const Path &dest, const ZipFileInfo &info, bool allowRoot, bool deleteAfter);
-	bool InstallMemstickZip(struct zip *z, const Path &zipFile, const Path &dest, const ZipFileInfo &info, bool deleteAfter);
+	bool ExtractZipContents(struct zip *z, const Path &dest, const ZipFileInfo &info, bool allowRoot);
+	bool InstallMemstickZip(struct zip *z, const Path &zipFile, const Path &dest, const ZipFileInfo &info);
 	bool InstallZippedISO(struct zip *z, int isoFileIndex, const Path &zipfile, bool deleteAfter);
 	bool InstallRawISO(const Path &zipFile, const std::string &originalName, bool deleteAfter);
 	void UninstallGame(const std::string &name);
@@ -135,5 +138,11 @@ private:
 
 extern GameManager g_GameManager;
 
+struct zip *ZipOpenPath(Path fileName);
+void ZipClose(zip *z);
+
 void DetectZipFileContents(struct zip *z, ZipFileInfo *info);
 bool DetectZipFileContents(const Path &fileName, ZipFileInfo *info);
+
+bool ZipExtractFileToMemory(struct zip *z, int fileIndex, std::string *data);
+bool CanExtractWithoutOverwrite(struct zip *z, const Path &destination, int maxOkFiles);

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -50,8 +50,14 @@ struct ZipFileInfo {
 	int isoFileIndex;  // for ISO
 	int textureIniIndex;  // for textures
 	bool ignoreMetaFiles;
-	std::string contentName;
+	std::string gameTitle;  // from PARAM.SFO if available
+	std::string savedataTitle;
+	std::string savedataDetails;
 	std::string savedataDir;
+	std::string mTime;
+	s64 totalFileSize;
+
+	std::string contentName;
 };
 
 struct ZipFileTask {

--- a/Tools/langtool/Cargo.lock
+++ b/Tools/langtool/Cargo.lock
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",

--- a/UI/CwCheatScreen.cpp
+++ b/UI/CwCheatScreen.cpp
@@ -53,7 +53,7 @@ bool CwCheatScreen::TryLoadCheatInfo() {
 	if (!info->Ready(GameInfoFlags::PARAM_SFO)) {
 		return false;
 	}
-	gameID = info->paramSFO.GetValueString("DISC_ID");
+	gameID = info->GetParamSFO().GetValueString("DISC_ID");
 	if ((info->id.empty() || !info->disc_total)
 		&& gamePath_.FilePathContainsNoCase("PSP/GAME/")) {
 		gameID = g_paramSFO.GenerateFakeID(gamePath_);

--- a/UI/DebugOverlay.cpp
+++ b/UI/DebugOverlay.cpp
@@ -435,21 +435,23 @@ void DrawFPS(UIContext *ctx, const Bounds &bounds) {
 	float vps, fps, actual_fps;
 	__DisplayGetFPS(&vps, &fps, &actual_fps);
 
-	char fpsbuf[256]{};
-	if (g_Config.iShowStatusFlags == ((int)ShowStatusFlags::FPS_COUNTER | (int)ShowStatusFlags::SPEED_COUNTER)) {
+	char fpsbuf[256];
+	fpsbuf[0] = '\0';
+	if ((g_Config.iShowStatusFlags & ((int)ShowStatusFlags::FPS_COUNTER | (int)ShowStatusFlags::SPEED_COUNTER)) == ((int)ShowStatusFlags::FPS_COUNTER | (int)ShowStatusFlags::SPEED_COUNTER)) {
 		snprintf(fpsbuf, sizeof(fpsbuf), "%0.0f/%0.0f (%0.1f%%)", actual_fps, fps, vps / ((g_Config.iDisplayRefreshRate / 60.0f * 59.94f) / 100.0f));
 	} else {
 		if (g_Config.iShowStatusFlags & (int)ShowStatusFlags::FPS_COUNTER) {
 			snprintf(fpsbuf, sizeof(fpsbuf), "FPS: %0.1f", actual_fps);
-		}
-		if (g_Config.iShowStatusFlags & (int)ShowStatusFlags::SPEED_COUNTER) {
-			snprintf(fpsbuf, sizeof(fpsbuf), "%s Speed: %0.1f%%", fpsbuf, vps / (59.94f / 100.0f));
+		} else if (g_Config.iShowStatusFlags & (int)ShowStatusFlags::SPEED_COUNTER) {
+			snprintf(fpsbuf, sizeof(fpsbuf), "Speed: %0.1f%%", vps / (59.94f / 100.0f));
 		}
 	}
 
 #ifdef CAN_DISPLAY_CURRENT_BATTERY_CAPACITY
 	if (g_Config.iShowStatusFlags & (int)ShowStatusFlags::BATTERY_PERCENT) {
-		snprintf(fpsbuf, sizeof(fpsbuf), "%s Battery: %d%%", fpsbuf, getCurrentBatteryCapacity());
+		char temp[256];
+		snprintf(temp, sizeof(temp), "%s Battery: %d%%", fpsbuf, getCurrentBatteryCapacity());
+		snprintf(fpsbuf, sizeof(fpsbuf), "%s", temp);
 	}
 #endif
 

--- a/UI/GameInfoCache.cpp
+++ b/UI/GameInfoCache.cpp
@@ -33,6 +33,7 @@
 #include "Core/FileSystems/ISOFileSystem.h"
 #include "Core/FileSystems/DirectoryFileSystem.h"
 #include "Core/FileSystems/VirtualDiscFileSystem.h"
+#include "Core/HLE/sceUtility.h"
 #include "Core/ELF/PBPReader.h"
 #include "Core/SaveState.h"
 #include "Core/System.h"
@@ -128,7 +129,7 @@ bool GameInfo::Delete() {
 	}
 }
 
-u64 GameInfo::GetGameSizeOnDiskInBytes() {
+u64 GameInfo::GetSizeOnDiskInBytes() {
 	switch (fileType) {
 	case IdentifiedFileType::PSP_PBP_DIRECTORY:
 	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY:
@@ -140,7 +141,7 @@ u64 GameInfo::GetGameSizeOnDiskInBytes() {
 	}
 }
 
-u64 GameInfo::GetGameSizeUncompressedInBytes() {
+u64 GameInfo::GetSizeUncompressedInBytes() {
 	switch (fileType) {
 	case IdentifiedFileType::PSP_PBP_DIRECTORY:
 	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY:
@@ -158,6 +159,39 @@ u64 GameInfo::GetGameSizeUncompressedInBytes() {
 			return GetFileLoader()->FileSize();
 		}
 	}
+	}
+}
+
+std::string GetFileDateAsString(const Path &filename) {
+	tm time;
+	if (File::GetModifTime(filename, time)) {
+		char buf[256];
+		switch (g_Config.iDateFormat) {
+		case PSP_SYSTEMPARAM_DATE_FORMAT_YYYYMMDD:
+			strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &time);
+			break;
+		case PSP_SYSTEMPARAM_DATE_FORMAT_MMDDYYYY:
+			strftime(buf, sizeof(buf), "%m-%d-%Y %H:%M:%S", &time);
+			break;
+		case PSP_SYSTEMPARAM_DATE_FORMAT_DDMMYYYY:
+			strftime(buf, sizeof(buf), "%d-%m-%Y %H:%M:%S", &time);
+			break;
+		default: // Should never happen
+			return "";
+		}
+		return std::string(buf);
+	}
+	return "";
+}
+
+std::string GameInfo::GetMTime() const {
+	switch (fileType) {
+	case IdentifiedFileType::PSP_SAVEDATA_DIRECTORY:
+		return GetFileDateAsString(GetFilePath() / "PARAM.SFO");
+	case IdentifiedFileType::PSP_PBP_DIRECTORY:
+		return GetFileDateAsString(GetFilePath() / "EBOOT.PBP");
+	default:
+		return GetFileDateAsString(GetFilePath());
 	}
 }
 
@@ -183,7 +217,7 @@ std::vector<Path> GameInfo::GetSaveDataDirectories() {
 	return directories;
 }
 
-u64 GameInfo::GetSaveDataSizeInBytes() {
+u64 GameInfo::GetGameSavedataSizeInBytes() {
 	if (fileType == IdentifiedFileType::PSP_SAVEDATA_DIRECTORY || fileType == IdentifiedFileType::PPSSPP_SAVESTATE) {
 		return 0;
 	}
@@ -464,6 +498,10 @@ public:
 
 		if (flags_ & GameInfoFlags::FILE_TYPE) {
 			info_->fileType = Identify_File(info_->GetFileLoader().get(), &errorString);
+		}
+
+		if (!info_->Ready(GameInfoFlags::FILE_TYPE) && !(flags_ & GameInfoFlags::FILE_TYPE)) {
+			_dbg_assert_(false);
 		}
 
 		switch (info_->fileType) {
@@ -768,12 +806,24 @@ handleELF:
 
 		if (flags_ & GameInfoFlags::SIZE) {
 			std::lock_guard<std::mutex> lock(info_->lock);
-			info_->gameSizeOnDisk = info_->GetGameSizeOnDiskInBytes();
-			info_->saveDataSize = info_->GetSaveDataSizeInBytes();
-			info_->installDataSize = info_->GetInstallDataSizeInBytes();
+			info_->gameSizeOnDisk = info_->GetSizeOnDiskInBytes();
+			switch (info_->fileType) {
+			case IdentifiedFileType::PSP_ISO:
+			case IdentifiedFileType::PSP_ISO_NP:
+			case IdentifiedFileType::PSP_DISC_DIRECTORY:
+			case IdentifiedFileType::PSP_PBP:
+			case IdentifiedFileType::PSP_PBP_DIRECTORY:
+				info_->saveDataSize = info_->GetGameSavedataSizeInBytes();
+				info_->installDataSize = info_->GetInstallDataSizeInBytes();
+				break;
+			default:
+				info_->saveDataSize = 0;
+				info_->installDataSize = 0;
+				break;
+			}
 		}
 		if (flags_ & GameInfoFlags::UNCOMPRESSED_SIZE) {
-			info_->gameSizeUncompressed = info_->GetGameSizeUncompressedInBytes();
+			info_->gameSizeUncompressed = info_->GetSizeUncompressedInBytes();
 		}
 
 		// Time to update the flags.
@@ -882,6 +932,8 @@ void GameInfoCache::PurgeType(IdentifiedFileType fileType) {
 // Can also be called from the audio thread for menu background music, but that cannot request images!
 std::shared_ptr<GameInfo> GameInfoCache::GetInfo(Draw::DrawContext *draw, const Path &gamePath, GameInfoFlags wantFlags) {
 	const std::string &pathStr = gamePath.ToString();
+
+	// _dbg_assert_(gamePath != GetSysDirectory(DIRECTORY_SAVEDATA));
 
 	// This is always needed to determine the method to get the other info, so make sure it's computed first.
 	wantFlags |= GameInfoFlags::FILE_TYPE;

--- a/UI/GameScreen.cpp
+++ b/UI/GameScreen.cpp
@@ -503,7 +503,7 @@ UI::EventReturn GameScreen::OnPlay(UI::EventParams &e) {
 UI::EventReturn GameScreen::OnGameSettings(UI::EventParams &e) {
 	std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(NULL, gamePath_, GameInfoFlags::PARAM_SFO);
 	if (info && info->Ready(GameInfoFlags::PARAM_SFO)) {
-		std::string discID = info->paramSFO.GetValueString("DISC_ID");
+		std::string discID = info->GetParamSFO().GetValueString("DISC_ID");
 		if ((discID.empty() || !info->disc_total) && gamePath_.FilePathContainsNoCase("PSP/GAME/"))
 			discID = g_paramSFO.GenerateFakeID(gamePath_);
 		screenManager()->push(new GameSettingsScreen(gamePath_, discID, true));

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -202,5 +202,5 @@ void InstallZipScreen::update() {
 		std::shared_ptr<GameInfo> ginfo = g_gameInfoCache->GetInfo(screenManager()->getDrawContext(), savedataToOverwrite_, GameInfoFlags::FILE_TYPE | GameInfoFlags::PARAM_SFO | GameInfoFlags::ICON | GameInfoFlags::SIZE);
 		existingSaveView_->Update(ginfo.get());
 	}
-	UIScreen::update();
+	UIDialogScreenWithBackground::update();
 }

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -107,7 +107,10 @@ void InstallZipScreen::CreateViews() {
 			int columnWidth = 300;
 
 			LinearLayout *compareColumns = leftColumn->Add(new LinearLayout(UI::ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT)));
-			compareColumns->Add(new SavedataView(*screenManager()->getUIContext(), Path(), IdentifiedFileType::PSP_SAVEDATA_DIRECTORY,
+			LinearLayout *leftCompare = new LinearLayout(UI::ORIENT_VERTICAL);
+			leftCompare->Add(new TextView(iz->T("Data to import")));
+			compareColumns->Add(leftCompare);
+			leftCompare->Add(new SavedataView(*screenManager()->getUIContext(), Path(), IdentifiedFileType::PSP_SAVEDATA_DIRECTORY,
 				zipFileInfo_.gameTitle, zipFileInfo_.savedataTitle, zipFileInfo_.savedataDetails, NiceSizeFormat(zipFileInfo_.totalFileSize), zipFileInfo_.mTime, false, new LinearLayoutParams(columnWidth, WRAP_CONTENT)));
 
 			// Check for potential overwrite at destination, and ask the user if it's OK to overwrite.
@@ -117,6 +120,7 @@ void InstallZipScreen::CreateViews() {
 
 				LinearLayout *rightCompare = new LinearLayout(UI::ORIENT_VERTICAL);
 				rightCompare->Add(new TextView(iz->T("Existing data")));
+
 				compareColumns->Add(rightCompare);
 				existingSaveView_ = rightCompare->Add(new SavedataView(*screenManager()->getUIContext(), ginfo.get(), IdentifiedFileType::PSP_SAVEDATA_DIRECTORY, false, new LinearLayoutParams(columnWidth, WRAP_CONTENT)));
 				if (System_GetPropertyBool(SYSPROP_CAN_SHOW_FILE)) {

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -155,7 +155,7 @@ void InstallZipScreen::CreateViews() {
 bool InstallZipScreen::key(const KeyInput &key) {
 	// Ignore all key presses during download and installation to avoid user escape
 	if (g_GameManager.GetState() == GameManagerState::IDLE) {
-		return UIScreen::key(key);
+		return UIDialogScreen::key(key);
 	}
 	return false;
 }

--- a/UI/InstallZipScreen.h
+++ b/UI/InstallZipScreen.h
@@ -24,6 +24,8 @@
 
 #include "UI/MiscScreens.h"
 
+class SavedataView;
+
 class InstallZipScreen : public UIDialogScreenWithBackground {
 public:
 	InstallZipScreen(const Path &zipPath);
@@ -41,6 +43,8 @@ private:
 	UI::Choice *installChoice_ = nullptr;
 	UI::Choice *backChoice_ = nullptr;
 	UI::TextView *doneView_ = nullptr;
+	SavedataView *existingSaveView_ = nullptr;
+	Path savedataToOverwrite_;
 	Path zipPath_;
 	ZipFileInfo zipFileInfo_{};
 	bool returnToHomebrew_ = true;

--- a/UI/InstallZipScreen.h
+++ b/UI/InstallZipScreen.h
@@ -40,7 +40,6 @@ private:
 
 	UI::Choice *installChoice_ = nullptr;
 	UI::Choice *backChoice_ = nullptr;
-	UI::ProgressBar *progressBar_ = nullptr;
 	UI::TextView *doneView_ = nullptr;
 	Path zipPath_;
 	ZipFileInfo zipFileInfo_{};

--- a/UI/MainScreen.cpp
+++ b/UI/MainScreen.cpp
@@ -1544,6 +1544,7 @@ UI::EventReturn MainScreen::OnGameHighlight(UI::EventParams &e) {
 }
 
 UI::EventReturn MainScreen::OnGameSelectedInstant(UI::EventParams &e) {
+	// TODO: This is really not necessary here in all cases.
 	g_Config.Save("MainScreen::OnGameSelectedInstant");
 	ScreenManager *screen = screenManager();
 	LaunchFile(screen, Path(e.s));

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -273,7 +273,6 @@ bool SavedataButton::UpdateText() {
 }
 
 void SavedataButton::UpdateText(const std::shared_ptr<GameInfo> &ginfo) {
-	_dbg_assert_(ginfo->Ready(GameInfoFlags::PARAM_SFO));
 	const std::string currentTitle = ginfo->GetTitle();
 	if (!currentTitle.empty()) {
 		title_ = CleanSaveString(currentTitle);

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -23,6 +23,7 @@
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Math/curves.h"
+#include "Common/Data/Text/Parsers.h"
 #include "Common/System/NativeApp.h"
 #include "Common/System/Request.h"
 #include "Common/Data/Encoding/Utf8.h"
@@ -46,85 +47,112 @@
 
 class SavedataButton;
 
-std::string GetFileDateAsString(const Path &filename) {
-	tm time;
-	if (File::GetModifTime(filename, time)) {
-		char buf[256];
-		switch (g_Config.iDateFormat) {
-		case PSP_SYSTEMPARAM_DATE_FORMAT_YYYYMMDD:
-			strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &time);
-			break;
-		case PSP_SYSTEMPARAM_DATE_FORMAT_MMDDYYYY:
-			strftime(buf, sizeof(buf), "%m-%d-%Y %H:%M:%S", &time);
-			break;
-		case PSP_SYSTEMPARAM_DATE_FORMAT_DDMMYYYY:
-			strftime(buf, sizeof(buf), "%d-%m-%Y %H:%M:%S", &time);
-			break;
-		default: // Should never happen
-			return "";
+SavedataView::SavedataView(UIContext &dc, const Path &savePath, IdentifiedFileType type, std::string_view title, std::string_view savedataTitle, std::string_view savedataDetail, std::string_view fileSize, std::string_view mtime, bool showIcon, UI::LayoutParams *layoutParams)
+	: LinearLayout(UI::ORIENT_VERTICAL, layoutParams)
+{
+	using namespace UI;
+
+	const Style &textStyle = dc.theme->popupStyle;
+	LinearLayout *toprow = new LinearLayout(ORIENT_HORIZONTAL, new LayoutParams(FILL_PARENT, WRAP_CONTENT));
+	Add(toprow);
+	toprow->SetSpacing(0.0);
+
+	savedataTitle_ = nullptr;
+	fileSize_ = nullptr;
+	mTime_ = nullptr;
+	detail_ = nullptr;
+	if (type == IdentifiedFileType::PSP_SAVEDATA_DIRECTORY) {
+		if (showIcon) {
+			toprow->Add(new GameIconView(savePath, 2.0f, new LinearLayoutParams(Margins(5, 5))));
 		}
-		return std::string(buf);
+		LinearLayout *topright = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, 1.0f));
+		topright->SetSpacing(1.0f);
+		savedataTitle_ = topright->Add(new TextView(savedataTitle, ALIGN_LEFT | FLAG_WRAP_TEXT, false));
+		savedataTitle_->SetTextColor(textStyle.fgColor);
+		fileSize_ = topright->Add(new TextView(fileSize, 0, true));
+		fileSize_->SetTextColor(textStyle.fgColor);
+		mTime_ = topright->Add(new TextView(mtime, 0, true));
+		mTime_->SetTextColor(textStyle.fgColor);
+		toprow->Add(topright);
+		Add(new Spacer(3.0));
+		detail_ = Add(new TextView(ReplaceAll(savedataDetail, "\r", ""), ALIGN_LEFT | FLAG_WRAP_TEXT, true, new LinearLayoutParams(Margins(10, 0))));
+		detail_->SetTextColor(textStyle.fgColor);
+		Add(new Spacer(3.0));
+	} else {
+		_dbg_assert_(type == IdentifiedFileType::PPSSPP_SAVESTATE);
+		Path image_path = savePath.WithReplacedExtension(".ppst", ".jpg");
+		if (File::Exists(image_path)) {
+			toprow->Add(new AsyncImageFileView(image_path, IS_KEEP_ASPECT, new LinearLayoutParams(480, 272, Margins(10, 0))));
+		} else {
+			auto sa = GetI18NCategory(I18NCat::SAVEDATA);
+			toprow->Add(new TextView(sa->T("No screenshot"), new LinearLayoutParams(Margins(10, 5))))->SetTextColor(textStyle.fgColor);
+		}
+		mTime_ = Add(new TextView(mtime, 0, true, new LinearLayoutParams(Margins(10, 5))));
+		mTime_->SetTextColor(textStyle.fgColor);
 	}
-	return "";
 }
 
-static std::string TrimString(const std::string &str) {
-	size_t pos = str.find_last_not_of(" \r\n\t");
-	if (pos != str.npos) {
-		return str.substr(0, pos + 1);
+void SavedataView::Update(GameInfo *ginfo) {
+	if (!ginfo->Ready(GameInfoFlags::PARAM_SFO | GameInfoFlags::SIZE)) {
+		return;
 	}
-	return str;
+	_dbg_assert_(savedataTitle_);
+	if (savedataTitle_) {
+		savedataTitle_->SetText(ginfo->GetParamSFO().GetValueString("SAVEDATA_TITLE"));
+	}
+	if (detail_) {
+		detail_->SetText(ginfo->GetParamSFO().GetValueString("SAVEDATA_DETAIL"));
+	}
+	if (fileSize_) {
+		fileSize_->SetText(NiceSizeFormat(ginfo->gameSizeOnDisk));
+	}
+	if (mTime_) {
+		mTime_->SetText(ginfo->GetMTime());
+	}
 }
+
+SavedataView::SavedataView(UIContext &dc, GameInfo *ginfo, IdentifiedFileType type, bool showIcon, UI::LayoutParams *layoutParams)
+	: SavedataView(dc,
+		ginfo->GetFilePath(),
+		type,
+		"",
+		"",
+		"",
+		"",
+		"",
+		showIcon,
+		layoutParams) {}
 
 class SavedataPopupScreen : public PopupScreen {
 public:
-	SavedataPopupScreen(std::string savePath, std::string title) : PopupScreen(TrimString(title)), savePath_(savePath) { }
+	SavedataPopupScreen(Path savePath, std::string_view title) : PopupScreen(StripSpaces(title)), savePath_(savePath) { }
 
 	const char *tag() const override { return "SavedataPopup"; }
+	void update() override {
+		std::shared_ptr<GameInfo> ginfo = g_gameInfoCache->GetInfo(screenManager()->getDrawContext(), savePath_, GameInfoFlags::PARAM_SFO | GameInfoFlags::ICON | GameInfoFlags::SIZE);
+		if (!ginfo->Ready(GameInfoFlags::PARAM_SFO)) {
+			// Hm, this is no good. But hopefully the previous screen loaded it.
+			return;
+		}
+		if (savedataView_) {
+			savedataView_->Update(ginfo.get());
+		}
+	}
 
 	void CreatePopupContents(UI::ViewGroup *parent) override {
 		using namespace UI;
 		UIContext &dc = *screenManager()->getUIContext();
-		const Style &textStyle = dc.theme->popupStyle;
 
 		std::shared_ptr<GameInfo> ginfo = g_gameInfoCache->GetInfo(screenManager()->getDrawContext(), savePath_, GameInfoFlags::PARAM_SFO | GameInfoFlags::ICON | GameInfoFlags::SIZE);
-		if (!ginfo->Ready(GameInfoFlags::PARAM_SFO))
-			return;
+		if (!ginfo->Ready(GameInfoFlags::PARAM_SFO)) {
+			// This is OK, handled in Update. Though most likely, the previous screen loaded it.
+		}
 
 		ScrollView *contentScroll = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT, 1.0f, UI::Margins(0, 3)));
-		LinearLayout *content = new LinearLayout(ORIENT_VERTICAL);
 		parent->Add(contentScroll);
-		contentScroll->Add(content);
-		LinearLayout *toprow = new LinearLayout(ORIENT_HORIZONTAL, new LayoutParams(FILL_PARENT, WRAP_CONTENT));
-		content->Add(toprow);
-		toprow->SetSpacing(0.0);
 
-		if (ginfo->fileType == IdentifiedFileType::PSP_SAVEDATA_DIRECTORY) {
-			std::string savedata_detail = ginfo->paramSFO.GetValueString("SAVEDATA_DETAIL");
-			std::string savedata_title = ginfo->paramSFO.GetValueString("SAVEDATA_TITLE");
-
-			if (ginfo->icon.texture) {
-				toprow->Add(new GameIconView(savePath_, 2.0f, new LinearLayoutParams(Margins(5, 5))));
-			}
-			LinearLayout *topright = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(WRAP_CONTENT, WRAP_CONTENT, 1.0f));
-			topright->SetSpacing(1.0f);
-			topright->Add(new TextView(savedata_title, ALIGN_LEFT | FLAG_WRAP_TEXT, false))->SetTextColor(textStyle.fgColor);
-			topright->Add(new TextView(StringFromFormat("%lld kB", ginfo->gameSizeOnDisk / 1024), 0, true))->SetTextColor(textStyle.fgColor);
-			topright->Add(new TextView(GetFileDateAsString(savePath_ / "PARAM.SFO"), 0, true))->SetTextColor(textStyle.fgColor);
-			toprow->Add(topright);
-			content->Add(new Spacer(3.0));
-			content->Add(new TextView(ReplaceAll(savedata_detail, "\r", ""), ALIGN_LEFT | FLAG_WRAP_TEXT, true, new LinearLayoutParams(Margins(10, 0))))->SetTextColor(textStyle.fgColor);
-			content->Add(new Spacer(3.0));
-		} else {
-			Path image_path = savePath_.WithReplacedExtension(".ppst", ".jpg");
-			if (File::Exists(image_path)) {
-				toprow->Add(new AsyncImageFileView(image_path, IS_KEEP_ASPECT, new LinearLayoutParams(480, 272, Margins(10, 0))));
-			} else {
-				auto sa = GetI18NCategory(I18NCat::SAVEDATA);
-				toprow->Add(new TextView(sa->T("No screenshot"), new LinearLayoutParams(Margins(10, 5))))->SetTextColor(textStyle.fgColor);
-			}
-			content->Add(new TextView(GetFileDateAsString(savePath_), 0, true, new LinearLayoutParams(Margins(10, 5))))->SetTextColor(textStyle.fgColor);
-		}
+		// TODO: If the game info wasn't already loaded, we'll get a bogus fileType here.
+		savedataView_ = contentScroll->Add(new SavedataView(dc, ginfo.get(), ginfo->fileType, true));
 
 		auto di = GetI18NCategory(I18NCat::DIALOG);
 		LinearLayout *buttons = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(FILL_PARENT, WRAP_CONTENT));
@@ -141,6 +169,7 @@ protected:
 
 private:
 	UI::EventReturn OnDeleteButtonClick(UI::EventParams &e);
+	SavedataView *savedataView_ = nullptr;
 	Path savePath_;
 };
 
@@ -244,14 +273,15 @@ bool SavedataButton::UpdateText() {
 }
 
 void SavedataButton::UpdateText(const std::shared_ptr<GameInfo> &ginfo) {
+	_dbg_assert_(ginfo->Ready(GameInfoFlags::PARAM_SFO));
 	const std::string currentTitle = ginfo->GetTitle();
 	if (!currentTitle.empty()) {
 		title_ = CleanSaveString(currentTitle);
 	}
 	if (subtitle_.empty() && ginfo->gameSizeOnDisk > 0) {
-		std::string date = GetFileDateAsString(ginfo->GetFilePath() / "PARAM.SFO");
-		std::string savedata_title = ginfo->paramSFO.GetValueString("SAVEDATA_TITLE");
-		subtitle_ = CleanSaveString(savedata_title) + StringFromFormat(" (%lld kB, %s)", ginfo->gameSizeOnDisk / 1024, date.c_str());
+		std::string date = ginfo->GetMTime();
+		std::string savedata_title = ginfo->GetParamSFO().GetValueString("SAVEDATA_TITLE");
+		subtitle_ = CleanSaveString(savedata_title) + " (" + NiceSizeFormat(ginfo->gameSizeOnDisk) + ", " + date.c_str() + ")";
 	}
 }
 
@@ -648,7 +678,7 @@ UI::EventReturn SavedataScreen::OnSavedataButtonClick(UI::EventParams &e) {
 	if (!ginfo->Ready(GameInfoFlags::PARAM_SFO)) {
 		return UI::EVENT_DONE;
 	}
-	SavedataPopupScreen *popupScreen = new SavedataPopupScreen(e.s, ginfo->GetTitle());
+	SavedataPopupScreen *popupScreen = new SavedataPopupScreen(Path(e.s), ginfo->GetTitle());
 	if (e.v) {
 		popupScreen->SetPopupOrigin(e.v);
 	}

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -192,45 +192,6 @@ void SortedLinearLayout::Update() {
 	UI::LinearLayout::Update();
 }
 
-class SavedataButton : public UI::Clickable {
-public:
-	SavedataButton(const Path &gamePath, UI::LayoutParams *layoutParams = 0)
-		: UI::Clickable(layoutParams), savePath_(gamePath) {
-		SetTag(gamePath.ToString());
-	}
-
-	void Draw(UIContext &dc) override;
-	bool UpdateText();
-	std::string DescribeText() const override;
-	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override {
-		w = 500;
-		h = 74;
-	}
-
-	const Path &GamePath() const { return savePath_; }
-
-	uint64_t GetTotalSize() const {
-		return totalSize_;
-	}
-	int64_t GetDateSeconds() const {
-		return dateSeconds_;
-	}
-
-	void UpdateTotalSize();
-	void UpdateDateSeconds();
-
-private:
-	void UpdateText(const std::shared_ptr<GameInfo> &ginfo);
-
-	Path savePath_;
-	std::string title_;
-	std::string subtitle_;
-	uint64_t totalSize_ = 0;
-	int64_t dateSeconds_ = 0;
-	bool hasTotalSize_ = false;
-	bool hasDateSeconds_ = false;
-};
-
 void SavedataButton::UpdateTotalSize() {
 	if (hasTotalSize_)
 		return;
@@ -288,8 +249,9 @@ void SavedataButton::UpdateText(const std::shared_ptr<GameInfo> &ginfo) {
 		title_ = CleanSaveString(currentTitle);
 	}
 	if (subtitle_.empty() && ginfo->gameSizeOnDisk > 0) {
+		std::string date = GetFileDateAsString(ginfo->GetFilePath() / "PARAM.SFO");
 		std::string savedata_title = ginfo->paramSFO.GetValueString("SAVEDATA_TITLE");
-		subtitle_ = CleanSaveString(savedata_title) + StringFromFormat(" (%lld kB)", ginfo->gameSizeOnDisk / 1024);
+		subtitle_ = CleanSaveString(savedata_title) + StringFromFormat(" (%lld kB, %s)", ginfo->gameSizeOnDisk / 1024, date.c_str());
 	}
 }
 

--- a/UI/SavedataScreen.cpp
+++ b/UI/SavedataScreen.cpp
@@ -121,7 +121,11 @@ SavedataView::SavedataView(UIContext &dc, GameInfo *ginfo, IdentifiedFileType ty
 		"",
 		"",
 		showIcon,
-		layoutParams) {}
+		layoutParams) {
+	if (ginfo) {
+		Update(ginfo);
+	}
+}
 
 class SavedataPopupScreen : public PopupScreen {
 public:
@@ -129,6 +133,7 @@ public:
 
 	const char *tag() const override { return "SavedataPopup"; }
 	void update() override {
+		PopupScreen::update();
 		std::shared_ptr<GameInfo> ginfo = g_gameInfoCache->GetInfo(screenManager()->getDrawContext(), savePath_, GameInfoFlags::PARAM_SFO | GameInfoFlags::ICON | GameInfoFlags::SIZE);
 		if (!ginfo->Ready(GameInfoFlags::PARAM_SFO)) {
 			// Hm, this is no good. But hopefully the previous screen loaded it.

--- a/UI/SavedataScreen.h
+++ b/UI/SavedataScreen.h
@@ -145,3 +145,17 @@ private:
 	bool hasDateSeconds_ = false;
 };
 
+// View used for the detailed popup, and also in the import savedata comparison.
+// It doesn't do its own data loading for that reason.
+class SavedataView : public UI::LinearLayout {
+public:
+	SavedataView(UIContext &dc, GameInfo *ginfo, IdentifiedFileType type, bool showIcon, UI::LayoutParams *layoutParams = nullptr);
+	SavedataView(UIContext &dc, const Path &savePath, IdentifiedFileType type, std::string_view title, std::string_view savedataTitle, std::string_view savedataDetail, std::string_view fileSize, std::string_view mtime, bool showIcon, UI::LayoutParams *layoutParams = nullptr);
+
+	void Update(GameInfo *ginfo);
+private:
+	UI::TextView *savedataTitle_ = nullptr;
+	UI::TextView *detail_ = nullptr;
+	UI::TextView *mTime_ = nullptr;
+	UI::TextView *fileSize_ = nullptr;
+};

--- a/UI/SavedataScreen.h
+++ b/UI/SavedataScreen.h
@@ -105,3 +105,43 @@ private:
 	int textureWidth_ = 0;
 	int textureHeight_ = 0;
 };
+
+class SavedataButton : public UI::Clickable {
+public:
+	SavedataButton(const Path &gamePath, UI::LayoutParams *layoutParams = 0)
+		: UI::Clickable(layoutParams), savePath_(gamePath) {
+		SetTag(gamePath.ToString());
+	}
+
+	void Draw(UIContext &dc) override;
+	bool UpdateText();
+	std::string DescribeText() const override;
+	void GetContentDimensions(const UIContext &dc, float &w, float &h) const override {
+		w = 500;
+		h = 74;
+	}
+
+	const Path &GamePath() const { return savePath_; }
+
+	uint64_t GetTotalSize() const {
+		return totalSize_;
+	}
+	int64_t GetDateSeconds() const {
+		return dateSeconds_;
+	}
+
+	void UpdateTotalSize();
+	void UpdateDateSeconds();
+
+private:
+	void UpdateText(const std::shared_ptr<GameInfo> &ginfo);
+
+	Path savePath_;
+	std::string title_;
+	std::string subtitle_;
+	uint64_t totalSize_ = 0;
+	int64_t dateSeconds_ = 0;
+	bool hasTotalSize_ = false;
+	bool hasDateSeconds_ = false;
+};
+

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -709,7 +709,9 @@ Window Size = ‎حجم النافذة
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = ‎مسح الملف المضغوط
+Existing data = Existing data
 Install = ‎تثبيت
 Install game from ZIP file? = ‎تثبيت اللعبة من الملف المضغوط ?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -701,7 +701,9 @@ Window Size = Window size
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Delete ZIP file
+Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -701,7 +701,9 @@ Window Size = Размер на прозореца
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Изтрий ZIP архива
+Existing data = Existing data
 Install = Инсталирай
 Install game from ZIP file? = Инсталирай игра от ZIP архив?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -701,7 +701,9 @@ Window Size = Mida de la finestra
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Delete ZIP file
+Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -701,7 +701,9 @@ Window Size = Velikost okna
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Smazat soubor ZIP
+Existing data = Existing data
 Install = Nainstalovat
 Install game from ZIP file? = Instalovat hru ze souboru ZIP?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -701,7 +701,9 @@ Window Size = Vinduesstørrelse
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Slet ZIP fil
+Existing data = Existing data
 Install = Installer
 Install game from ZIP file? = Installer spil fra ZIP fil?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -701,7 +701,9 @@ Window Size = Fenstergröße
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = ZIP Datei löschen
+Existing data = Existing data
 Install = Installieren
 Install game from ZIP file? = Spiel aus ZIP Datei installieren?
 Install textures from ZIP file? = Texturen von ZIP Datei installieren?

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -701,7 +701,9 @@ Window Size = Window size
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Delete ZIP file
+Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -725,7 +725,9 @@ Window Size = Window size
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Delete ZIP file
+Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -701,7 +701,9 @@ Window Size = Tamaño de ventana
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Borrar archivo ZIP
+Existing data = Existing data
 Install = Instalar
 Install game from ZIP file? = ¿Instalar juego desde archivo ZIP?
 Install textures from ZIP file? = ¿Instalar texturas desde archivo ZIP?

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -701,7 +701,9 @@ Window Size = Tamaño de ventana
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Borrar archivo ZIP
+Existing data = Existing data
 Install = Instalar
 Install game from ZIP file? = ¿Instalar juego desde un archivo ZIP?
 Install textures from ZIP file? = ¿Instalar texturas desde un archivo ZIP?

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -701,7 +701,9 @@ Window Size = ‎سایز پنجره
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Delete ZIP file
+Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -701,7 +701,9 @@ Window Size = Ikkunan koko
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Poista ZIP-tiedosto
+Existing data = Existing data
 Install = Asenna
 Install game from ZIP file? = Asenna peli ZIP-tiedostosta?
 Install textures from ZIP file? = Asenna tekstuureja ZIP-tiedostosta?

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -701,7 +701,9 @@ Window Size = Taille de la fenêtre
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Supprimer le fichier ZIP
+Existing data = Existing data
 Install = Installer
 Install game from ZIP file? = Installer le jeu depuis le fichier ZIP ?
 Install textures from ZIP file? = Installer les textures depuis le fichier ZIP ?

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -701,7 +701,9 @@ Window Size = Tamaño de ventana
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Borrar arquivo ZIP
+Existing data = Existing data
 Install = Instalar
 Install game from ZIP file? = Instalar xogo dende un arquivo ZIP?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -701,7 +701,9 @@ Window Size = Μέγεθος Παραθύρου
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Διαγραφή αρχείου ZIP
+Existing data = Existing data
 Install = Εγκατάσταση
 Install game from ZIP file? = Εγκατάσταση παιχνιδιού από το αρχείο ZIP?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -701,7 +701,9 @@ Window Size = Window size
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Delete ZIP file
+Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -701,7 +701,9 @@ Window Size = Window size
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Delete ZIP file
+Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -701,7 +701,9 @@ Window Size = Veličina prozora
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Izbriši ZIP datoteku
+Existing data = Existing data
 Install = Instaliraj
 Install game from ZIP file? = Instaliraj igru iz ZIP datoteke?
 Install textures from ZIP file? = Instaliraj teksture iz ZIP datoteke?

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -701,7 +701,9 @@ Window Size = Ablak méret
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = ZIP fájl törlése
+Existing data = Existing data
 Install = Telepítés
 Install game from ZIP file? = Játék telepítése ZIP fájlból?
 Install textures from ZIP file? = Textúrák telepítése ZIP fájlból?

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -701,7 +701,9 @@ Window Size = Ukuran Window
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Hapus berkas ZIP
+Existing data = Existing data
 Install = Pasang
 Install game from ZIP file? = Pasang permainan dari berkas ZIP?
 Install textures from ZIP file? = Pasang tekstur dari file ZIP?

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -702,7 +702,9 @@ Window Size = Dimensioni Finestra
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Elimina file ZIP
+Existing data = Existing data
 Install = Installa
 Install game from ZIP file? = Installare il gioco dal file ZIP?
 Install textures from ZIP file? = Installare le texture dal file ZIP?

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -701,7 +701,9 @@ Window Size = ウィンドウサイズ
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = ZIPファイルを削除
+Existing data = Existing data
 Install = インストールする
 Install game from ZIP file? = ZIPファイルからゲームをインストールしますか？
 Install textures from ZIP file? = ZIPファイルからテクスチャをインストールしますか？

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -701,7 +701,9 @@ Window Size = Ukuran window
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Mbusek berkas ZIP
+Existing data = Existing data
 Install = Nginstal
 Install game from ZIP file? = Nginstal dolanan saka berkas ZIP?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -701,7 +701,9 @@ Window Size = 창 크기
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = ZIP 파일 삭제
+Existing data = Existing data
 Install = 설치
 Install game from ZIP file? = ZIP 파일에서 게임을 설치하겠습니까?
 Install textures from ZIP file? = ZIP 파일에서 텍스처를 설치하겠습니까?

--- a/assets/lang/ku_SO.ini
+++ b/assets/lang/ku_SO.ini
@@ -715,7 +715,9 @@ Window Size = Window size
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Delete ZIP file
+Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -701,7 +701,9 @@ Window Size = ຂະໜາດໜ້າຈໍ
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = ລຶບໄຟລ໌ ZIP
+Existing data = Existing data
 Install = ຕິດຕັ້ງ
 Install game from ZIP file? = ຕິດຕັ້ງເກມຈາກໄຟລ໌ ZIP ຫຼືບໍ່?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -701,7 +701,9 @@ Window Size = Lango dydis
 xBRZ = "xBRZ"
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Ištrinti ZIP failą
+Existing data = Existing data
 Install = Instaliuoti
 Install game from ZIP file? = Instaliuoti žaidimą iš ZIP failo?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -701,7 +701,9 @@ Window Size = Saiz tetingkap
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Padam fail ZIP
+Existing data = Existing data
 Install = Pasang
 Install game from ZIP file? = Pasang permainan dari fail ZIP?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -701,7 +701,9 @@ Window Size = Venstergrootte
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = ZIP-bestand wissen
+Existing data = Existing data
 Install = Installeren
 Install game from ZIP file? = Game installeren vanuit het ZIP-bestand?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -701,7 +701,9 @@ Window Size = Window size
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Delete ZIP file
+Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -705,7 +705,9 @@ Window Size = Rozmiar okna
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Usuń plik ZIP
+Existing data = Existing data
 Install = Zainstaluj
 Install game from ZIP file? = Zainstalować grę z pliku ZIP?
 Install textures from ZIP file? = Czy zainstalować teksturę z archiwum ZIP?

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -725,7 +725,9 @@ Window Size = Tamanho da janela
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Apagar arquivo ZIP
+Existing data = Existing data
 Install = Instalar
 Install game from ZIP file? = Instalar o jogo do arquivo ZIP?
 Install textures from ZIP file? = Instalar as texturas do arquivo ZIP?

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -725,7 +725,9 @@ Window Size = Tamanho da janela
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Eliminar ficheiro .zip
+Existing data = Existing data
 Install = Instalar
 Install game from ZIP file? = Instalar o jogo do ficheiro .zip?
 Install textures from ZIP file? = Instalar as texturas do ficheiro .zip?

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -702,7 +702,9 @@ Window Size = Mărime ecran
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Șterge fișier ZIP
+Existing data = Existing data
 Install = Instalează
 Install game from ZIP file? = Instalează joc din fișier ZIP?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -701,7 +701,9 @@ Window Size = Размер окна
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Удалить файл ZIP
+Existing data = Existing data
 Install = Установить
 Install game from ZIP file? = Установить игру из файла ZIP?
 Install textures from ZIP file? = Установить текстуры из файла ZIP?

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -702,33 +702,35 @@ Window Size = Fönsterstorlek
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data att importera
 Delete ZIP file = Ta bort ZIP-fil
+Existing data = Existerande data
 Install = Installera
 Install game from ZIP file? = Installera spel från ZIP-fil?
-Install textures from ZIP file? = Install textures from ZIP file?
-Installation failed = Installation failed
+Install textures from ZIP file? = Installera texturer från ZIP-fil?
+Installation failed = Installation misslyckades
 Installed! = Installerad!
-Texture pack doesn't support install = Texture pack doesn't support install
-Zip archive corrupt = ZIP archive corrupt
-Zip file does not contain PSP software = ZIP file does not contain PSP software
+Texture pack doesn't support install = Texturpaketet stöder ej installation
+Zip archive corrupt = ZIP-filen är korrupt
+Zip file does not contain PSP software = ZIP-filen innehåller inte PSP-mjukvara
 
 [KeyMapping]
-Allow combo mappings = Allow combo mappings
+Allow combo mappings = Tillåt combo mappings
 Autoconfigure = Autokonfiguration
 Autoconfigure for device = Autokonfigurera för enhet
 Bind All = Bind All
 Clear All = Rensa
 Combo mappings are not enabled = Combo mappings are not enabled
-Control modifiers = Control modifiers
+Control modifiers = Kontroll-modifiers
 Default All = Återställ allt
-Emulator controls = Emulator controls
+Emulator controls = Emulator-kontroller
 Extended PSP controls = Extended PSP controls
 Map a new key for = Mappa ny knapp för
 Map Key = Mappa tangent
 Map Mouse = Mappa mus
-Replace = Replace
-Show PSP = Show PSP
-Standard PSP controls = Standard PSP controls
+Replace = Ersätt
+Show PSP = Visa PSP
+Standard PSP controls = Standard PSP-kontroller
 Strict combo input order = Strict combo input order
 You can press ESC to cancel. = Tryck ESC för att avbryta.
 
@@ -746,7 +748,7 @@ Homebrew & Demos = Homebrew & Demos
 How to get games = Hur man skaffar spel
 How to get homebrew & demos = Hur man skaffar Homebrew & Demos
 Load = Ladda...
-Loading... = Loading...
+Loading... = Laddar...
 PinPath = Fäst
 PPSSPP can't load games or save right now = PPSSPP can't load games or save right now
 Recent = Senast spelat
@@ -754,7 +756,7 @@ SavesAreTemporary = PPSSPP is saving in temporary storage
 SavesAreTemporaryGuidance = Extract PPSSPP somewhere to save permanently
 SavesAreTemporaryIgnore = Ignorera varning
 UnpinPath = Lossa
-UseBrowseOrLoad = Use Browse to choose a folder, or Load to choose a file.
+UseBrowseOrLoad = Använd Bläddra för att välja en mapp, eller Ladda för att välja en fil.
 www.ppsspp.org = www.ppsspp.org
 
 [MainSettings]
@@ -969,7 +971,7 @@ Vignette = Vignett
 
 [PSPCredits]
 all the forum mods = all the forum mods
-build server = build server
+build server = bygg-server
 Buy Gold = Köp Guld
 check = Kolla också in Dolphin, den bästa Wii/GC-emulatorn
 CheckOutPPSSPP = Check out PPSSPP, the awesome PSP emulator: https://www.ppsspp.org/

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -702,7 +702,9 @@ Window Size = Window size
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Burahin ang ZIP File
+Existing data = Existing data
 Install = Install
 Install game from ZIP file? = I-install ang laro mula sa ZIP file?
 Install textures from ZIP file? = I-install ang texture mula sa ZIP file?

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -708,7 +708,9 @@ Window Size = ขนาดของหน้าจอ
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = ลบไฟล์ ZIP
+Existing data = Existing data
 Install = ติดตั้ง
 Install game from ZIP file? = ต้องการติดตั้งเกมจากไฟล์ ZIP เลยหรือไม่?
 Install textures from ZIP file? = ต้องการติดตั้งเท็คเจอร์จากไฟล์ ZIP เลยหรือไม่?

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -703,7 +703,9 @@ Window Size = Pencere boyutu
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = ZIP dosyasını sil
+Existing data = Existing data
 Install = Yükle
 Install game from ZIP file? = ZIP dosyasından oyun yüklensin mi?
 Install textures from ZIP file? = ZIP dosyasından dokular yüklensin mi?

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -701,7 +701,9 @@ Window Size = Розмір вікна
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Видалити ZIP файл
+Existing data = Existing data
 Install = Встановити
 Install game from ZIP file? = Встановити гру з ZIP-файлу?
 Install textures from ZIP file? = Встановити текстури з ZIP-файлу?

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -701,7 +701,9 @@ Window Size = Kích cỡ cửa sổ
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = Xóa file ZIP
+Existing data = Existing data
 Install = Cài đặt
 Install game from ZIP file? = Cài đặt trò chơi từ file ZIP?
 Install textures from ZIP file? = Install textures from ZIP file?

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -701,7 +701,9 @@ Window Size = 窗口大小
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = 删除ZIP文件
+Existing data = Existing data
 Install = 安装
 Install game from ZIP file? = 从ZIP文件安装游戏？
 Install textures from ZIP file? = 从ZIP文件安装纹理包？

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -701,7 +701,9 @@ Window Size = 視窗大小
 xBRZ = xBRZ
 
 [InstallZip]
+Data to import = Data to import
 Delete ZIP file = 刪除 ZIP 檔案
+Existing data = Existing data
 Install = 安裝
 Install game from ZIP file? = 從 ZIP 檔案安裝遊戲？
 Install textures from ZIP file? = 從 ZIP 檔案安裝紋理？


### PR DESCRIPTION
This makes it much easier to import zipped savedata, such as from GameFAQs. Just load the ZIP like if it was a game.

Might later add export funcionality as well.

![image](https://github.com/user-attachments/assets/afd33e0c-3692-4568-bbd0-86143485ca19)

Fixes #17966

Unfortunately, on Android with scoped storage, imported file times are not set correctly since it's not possible to edit the modified-timestamp of files using the scoped storage framework.