### PR TITLE
Mac SDL: Remove an annoying popup that happens when holding keys on some SDL versions

### DIFF
--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -1398,6 +1398,10 @@ int main(int argc, char *argv[]) {
 	// Ensure that the swap interval is set after context creation (needed for kmsdrm)
 	SDL_GL_SetSwapInterval(1);
 
+	// Avoid the IME popup when holding keys. This doesn't affect all versions of SDL.
+	// TODO: Enable it in text input fields
+	SDL_StopTextInput();
+
 	InitSDLAudioDevice();
 
 	if (joystick_enabled) {


### PR DESCRIPTION
It's quite common (and the default) to use keyboard keys like Z for button inputs that are held a lot, for example as the accelerator in Burnout.

On Mac, on certain SDL versions, this results in a little popup having you pick an accented type of Z, and similar for many other letters. Doesn't actually affect gameplay, but it's quite annoying, so let's get rid of it. Shouldn't hurt the non-affected SDL versions.