### PR TITLE
More zip file install fixes

### DIFF
--- a/Common/File/AndroidContentURI.h
+++ b/Common/File/AndroidContentURI.h
@@ -67,6 +67,10 @@ public:
 		return root.empty() ? file : root;
 	}
 
+	const std::string &Provider() const {
+		return provider;
+	}
+
 	bool IsTreeURI() const {
 		return !root.empty();
 	}

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -1276,4 +1276,21 @@ void ChangeMTime(const Path &path, time_t mtime) {
 #endif
 }
 
+bool IsProbablyInDownloadsFolder(const Path &filename) {
+	INFO_LOG(Log::Common, "IsProbablyInDownloadsFolder: Looking at %s (%s)...", filename.c_str(), filename.ToVisualString().c_str());
+	switch (filename.Type()) {
+	case PathType::CONTENT_URI:
+	{
+		AndroidContentURI uri(filename.ToString());
+		INFO_LOG(Log::Common, "Content URI provider: %s", uri.Provider().c_str());
+		if (containsNoCase(uri.Provider(), "download")) {
+			// like com.android.providers.downloads.documents
+			return true;
+		}
+		break;
+	}
+	}
+	return filename.FilePathContainsNoCase("download");
+}
+
 }  // namespace File

--- a/Common/File/FileUtil.h
+++ b/Common/File/FileUtil.h
@@ -122,6 +122,10 @@ bool CreateEmptyFile(const Path &filename);
 // TODO: Belongs in System or something.
 bool OpenFileInEditor(const Path &fileName);
 
+// Uses some heuristics to determine if this is a folder that we would want to
+// write to.
+bool IsProbablyInDownloadsFolder(const Path &folder);
+
 // TODO: Belongs in System or something.
 const Path &GetExeDirectory();
 

--- a/Common/File/Path.h
+++ b/Common/File/Path.h
@@ -50,6 +50,9 @@ public:
 	PathType Type() const {
 		return type_;
 	}
+	bool IsLocalType() const {
+		return type_ == PathType::NATIVE || type_ == PathType::CONTENT_URI;
+	}
 
 	bool Valid() const { return !path_.empty(); }
 	bool IsRoot() const { return path_ == "/"; }  // Special value - only path that can end in a slash.

--- a/Common/StringUtils.cpp
+++ b/Common/StringUtils.cpp
@@ -93,6 +93,12 @@ long parseLong(std::string s) {
 	return value;
 }
 
+bool containsNoCase(std::string_view haystack, std::string_view needle) {
+	auto pred = [](char ch1, char ch2) { return std::toupper(ch1) == std::toupper(ch2); };
+	auto found = std::search(haystack.begin(), haystack.end(), needle.begin(), needle.end(), pred);
+	return found != haystack.end();
+}
+
 bool CharArrayFromFormatV(char* out, int outsize, const char* format, va_list args)
 {
 	int writtenCount = vsnprintf(out, outsize, format, args);

--- a/Common/StringUtils.h
+++ b/Common/StringUtils.h
@@ -69,6 +69,8 @@ inline bool equalsNoCase(std::string_view str, std::string_view key) {
 	return strncasecmp(str.data(), key.data(), key.size()) == 0;
 }
 
+bool containsNoCase(std::string_view haystack, std::string_view needle);
+
 void DataToHexString(const uint8_t *data, size_t size, std::string *output);
 void DataToHexString(int indent, uint32_t startAddr, const uint8_t* data, size_t size, std::string* output);
 

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -64,6 +64,7 @@ struct ZipFileTask {
 	std::optional<ZipFileInfo> zipFileInfo;
 	Path url;  // Same as filename if installing from disk. Probably not really useful.
 	Path fileName;
+	Path destination;  // If set, will override the default destination.
 	bool deleteAfter;
 };
 
@@ -117,8 +118,7 @@ private:
 
 	bool ExtractZipContents(struct zip *z, const Path &dest, const ZipFileInfo &info, bool allowRoot);
 	bool InstallMemstickZip(struct zip *z, const Path &zipFile, const Path &dest, const ZipFileInfo &info);
-	bool InstallZippedISO(struct zip *z, int isoFileIndex, const Path &zipfile, bool deleteAfter);
-	bool InstallRawISO(const Path &zipFile, const std::string &originalName, bool deleteAfter);
+	bool InstallZippedISO(struct zip *z, int isoFileIndex, const Path &destDir);
 	void UninstallGame(const std::string &name);
 
 	void InstallDone();

--- a/UI/InstallZipScreen.h
+++ b/UI/InstallZipScreen.h
@@ -19,6 +19,8 @@
 
 #include <functional>
 
+#include "Common/File/Path.h"
+
 #include "Common/UI/View.h"
 #include "Common/UI/UIScreen.h"
 
@@ -46,6 +48,8 @@ private:
 	SavedataView *existingSaveView_ = nullptr;
 	Path savedataToOverwrite_;
 	Path zipPath_;
+	std::vector<Path> destFolders_;
+	int destFolderChoice_ = 0;
 	ZipFileInfo zipFileInfo_{};
 	bool returnToHomebrew_ = true;
 	bool installStarted_ = false;

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -714,6 +714,7 @@ Delete ZIP file = ‎مسح الملف المضغوط
 Existing data = Existing data
 Install = ‎تثبيت
 Install game from ZIP file? = ‎تثبيت اللعبة من الملف المضغوط ?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = فشل في التثبيت
 Installed! = ‎مثبت!

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Delete ZIP file
 Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Installed!

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Изтрий ZIP архива
 Existing data = Existing data
 Install = Инсталирай
 Install game from ZIP file? = Инсталирай игра от ZIP архив?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Инсталирано!

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Delete ZIP file
 Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Installed!

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Smazat soubor ZIP
 Existing data = Existing data
 Install = Nainstalovat
 Install game from ZIP file? = Instalovat hru ze souboru ZIP?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Instalováno!

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Slet ZIP fil
 Existing data = Existing data
 Install = Installer
 Install game from ZIP file? = Installer spil fra ZIP fil?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Installeret!

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -706,6 +706,7 @@ Delete ZIP file = ZIP Datei löschen
 Existing data = Existing data
 Install = Installieren
 Install game from ZIP file? = Spiel aus ZIP Datei installieren?
+Install in folder = Install in folder
 Install textures from ZIP file? = Texturen von ZIP Datei installieren?
 Installation failed = Installation failed
 Installed! = Installiert!

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Delete ZIP file
 Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Installed!

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -730,6 +730,7 @@ Delete ZIP file = Delete ZIP file
 Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Installed!

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Borrar archivo ZIP
 Existing data = Existing data
 Install = Instalar
 Install game from ZIP file? = ¿Instalar juego desde archivo ZIP?
+Install in folder = Install in folder
 Install textures from ZIP file? = ¿Instalar texturas desde archivo ZIP?
 Installation failed = Installation failed
 Installed! = ¡Instalado!

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Borrar archivo ZIP
 Existing data = Existing data
 Install = Instalar
 Install game from ZIP file? = ¿Instalar juego desde un archivo ZIP?
+Install in folder = Install in folder
 Install textures from ZIP file? = ¿Instalar texturas desde un archivo ZIP?
 Installation failed = Instalación fallida
 Installed! = ¡Instalado!

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Delete ZIP file
 Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Installed!

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Poista ZIP-tiedosto
 Existing data = Existing data
 Install = Asenna
 Install game from ZIP file? = Asenna peli ZIP-tiedostosta?
+Install in folder = Install in folder
 Install textures from ZIP file? = Asenna tekstuureja ZIP-tiedostosta?
 Installation failed = Installation failed
 Installed! = Asenettu!

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Supprimer le fichier ZIP
 Existing data = Existing data
 Install = Installer
 Install game from ZIP file? = Installer le jeu depuis le fichier ZIP ?
+Install in folder = Install in folder
 Install textures from ZIP file? = Installer les textures depuis le fichier ZIP ?
 Installation failed = Installation failed
 Installed! = Installé !

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Borrar arquivo ZIP
 Existing data = Existing data
 Install = Instalar
 Install game from ZIP file? = Instalar xogo dende un arquivo ZIP?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = ¡Instalado!

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Διαγραφή αρχείου ZIP
 Existing data = Existing data
 Install = Εγκατάσταση
 Install game from ZIP file? = Εγκατάσταση παιχνιδιού από το αρχείο ZIP?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Εγκαταστάθηκε!

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Delete ZIP file
 Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Installed!

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Delete ZIP file
 Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Installed!

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Izbriši ZIP datoteku
 Existing data = Existing data
 Install = Instaliraj
 Install game from ZIP file? = Instaliraj igru iz ZIP datoteke?
+Install in folder = Install in folder
 Install textures from ZIP file? = Instaliraj teksture iz ZIP datoteke?
 Installation failed = Installation failed
 Installed! = Instalirano!

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -706,6 +706,7 @@ Delete ZIP file = ZIP fájl törlése
 Existing data = Existing data
 Install = Telepítés
 Install game from ZIP file? = Játék telepítése ZIP fájlból?
+Install in folder = Install in folder
 Install textures from ZIP file? = Textúrák telepítése ZIP fájlból?
 Installation failed = Installation failed
 Installed! = Telepítve!

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Hapus berkas ZIP
 Existing data = Existing data
 Install = Pasang
 Install game from ZIP file? = Pasang permainan dari berkas ZIP?
+Install in folder = Install in folder
 Install textures from ZIP file? = Pasang tekstur dari file ZIP?
 Installation failed = Installation failed
 Installed! = Terpasang!

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -707,6 +707,7 @@ Delete ZIP file = Elimina file ZIP
 Existing data = Existing data
 Install = Installa
 Install game from ZIP file? = Installare il gioco dal file ZIP?
+Install in folder = Install in folder
 Install textures from ZIP file? = Installare le texture dal file ZIP?
 Installation failed = Installation failed
 Installed! = Installato!

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -706,6 +706,7 @@ Delete ZIP file = ZIPファイルを削除
 Existing data = Existing data
 Install = インストールする
 Install game from ZIP file? = ZIPファイルからゲームをインストールしますか？
+Install in folder = Install in folder
 Install textures from ZIP file? = ZIPファイルからテクスチャをインストールしますか？
 Installation failed = インストール失敗
 Installed! = インストールしました

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Mbusek berkas ZIP
 Existing data = Existing data
 Install = Nginstal
 Install game from ZIP file? = Nginstal dolanan saka berkas ZIP?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Keinstal!

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -706,6 +706,7 @@ Delete ZIP file = ZIP 파일 삭제
 Existing data = Existing data
 Install = 설치
 Install game from ZIP file? = ZIP 파일에서 게임을 설치하겠습니까?
+Install in folder = Install in folder
 Install textures from ZIP file? = ZIP 파일에서 텍스처를 설치하겠습니까?
 Installation failed = 설치 실패
 Installed! = 설치되었습니다!

--- a/assets/lang/ku_SO.ini
+++ b/assets/lang/ku_SO.ini
@@ -720,6 +720,7 @@ Delete ZIP file = Delete ZIP file
 Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Installed!

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -706,6 +706,7 @@ Delete ZIP file = ລຶບໄຟລ໌ ZIP
 Existing data = Existing data
 Install = ຕິດຕັ້ງ
 Install game from ZIP file? = ຕິດຕັ້ງເກມຈາກໄຟລ໌ ZIP ຫຼືບໍ່?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = ຕິດຕັ້ງແລ້ວ!

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Ištrinti ZIP failą
 Existing data = Existing data
 Install = Instaliuoti
 Install game from ZIP file? = Instaliuoti žaidimą iš ZIP failo?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Instaliuota!

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Padam fail ZIP
 Existing data = Existing data
 Install = Pasang
 Install game from ZIP file? = Pasang permainan dari fail ZIP?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Dipasang!

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -706,6 +706,7 @@ Delete ZIP file = ZIP-bestand wissen
 Existing data = Existing data
 Install = Installeren
 Install game from ZIP file? = Game installeren vanuit het ZIP-bestand?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Installatie voltooid!

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Delete ZIP file
 Existing data = Existing data
 Install = Install
 Install game from ZIP file? = Install game from ZIP file?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Installed!

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -710,6 +710,7 @@ Delete ZIP file = Usuń plik ZIP
 Existing data = Existing data
 Install = Zainstaluj
 Install game from ZIP file? = Zainstalować grę z pliku ZIP?
+Install in folder = Install in folder
 Install textures from ZIP file? = Czy zainstalować teksturę z archiwum ZIP?
 Installation failed = Installation failed
 Installed! = Zainstalowano!

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -730,6 +730,7 @@ Delete ZIP file = Apagar arquivo ZIP
 Existing data = Existing data
 Install = Instalar
 Install game from ZIP file? = Instalar o jogo do arquivo ZIP?
+Install in folder = Install in folder
 Install textures from ZIP file? = Instalar as texturas do arquivo ZIP?
 Installation failed = A instalação falhou
 Installed! = Instalado!

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -730,6 +730,7 @@ Delete ZIP file = Eliminar ficheiro .zip
 Existing data = Existing data
 Install = Instalar
 Install game from ZIP file? = Instalar o jogo do ficheiro .zip?
+Install in folder = Install in folder
 Install textures from ZIP file? = Instalar as texturas do ficheiro .zip?
 Installation failed = Installation failed
 Installed! = Instalado!

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -707,6 +707,7 @@ Delete ZIP file = Șterge fișier ZIP
 Existing data = Existing data
 Install = Instalează
 Install game from ZIP file? = Instalează joc din fișier ZIP?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Instalat!

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Удалить файл ZIP
 Existing data = Existing data
 Install = Установить
 Install game from ZIP file? = Установить игру из файла ZIP?
+Install in folder = Install in folder
 Install textures from ZIP file? = Установить текстуры из файла ZIP?
 Installation failed = Не удалось установить
 Installed! = Установлено!

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -707,6 +707,7 @@ Delete ZIP file = Ta bort ZIP-fil
 Existing data = Existerande data
 Install = Installera
 Install game from ZIP file? = Installera spel från ZIP-fil?
+Install in folder = Installera i mapp
 Install textures from ZIP file? = Installera texturer från ZIP-fil?
 Installation failed = Installation misslyckades
 Installed! = Installerad!

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -707,6 +707,7 @@ Delete ZIP file = Burahin ang ZIP File
 Existing data = Existing data
 Install = Install
 Install game from ZIP file? = I-install ang laro mula sa ZIP file?
+Install in folder = Install in folder
 Install textures from ZIP file? = I-install ang texture mula sa ZIP file?
 Installation failed = Hindi mainstall
 Installed! = Naka-install na!

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -713,6 +713,7 @@ Delete ZIP file = ลบไฟล์ ZIP
 Existing data = Existing data
 Install = ติดตั้ง
 Install game from ZIP file? = ต้องการติดตั้งเกมจากไฟล์ ZIP เลยหรือไม่?
+Install in folder = Install in folder
 Install textures from ZIP file? = ต้องการติดตั้งเท็คเจอร์จากไฟล์ ZIP เลยหรือไม่?
 Installation failed = การติดตั้งล้มเหลว
 Installed! = ติดตั้งเสร็จสิ้น!

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -708,6 +708,7 @@ Delete ZIP file = ZIP dosyasını sil
 Existing data = Existing data
 Install = Yükle
 Install game from ZIP file? = ZIP dosyasından oyun yüklensin mi?
+Install in folder = Install in folder
 Install textures from ZIP file? = ZIP dosyasından dokular yüklensin mi?
 Installation failed = Yükleme başarısız
 Installed! = Yüklendi!

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Видалити ZIP файл
 Existing data = Existing data
 Install = Встановити
 Install game from ZIP file? = Встановити гру з ZIP-файлу?
+Install in folder = Install in folder
 Install textures from ZIP file? = Встановити текстури з ZIP-файлу?
 Installation failed = Installation failed
 Installed! = Встановлено!

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -706,6 +706,7 @@ Delete ZIP file = Xóa file ZIP
 Existing data = Existing data
 Install = Cài đặt
 Install game from ZIP file? = Cài đặt trò chơi từ file ZIP?
+Install in folder = Install in folder
 Install textures from ZIP file? = Install textures from ZIP file?
 Installation failed = Installation failed
 Installed! = Đã cài xong!

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -706,6 +706,7 @@ Delete ZIP file = 删除ZIP文件
 Existing data = Existing data
 Install = 安装
 Install game from ZIP file? = 从ZIP文件安装游戏？
+Install in folder = Install in folder
 Install textures from ZIP file? = 从ZIP文件安装纹理包？
 Installation failed = 安装失败!
 Installed! = 安装完成！

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -706,6 +706,7 @@ Delete ZIP file = 刪除 ZIP 檔案
 Existing data = Existing data
 Install = 安裝
 Install game from ZIP file? = 從 ZIP 檔案安裝遊戲？
+Install in folder = Install in folder
 Install textures from ZIP file? = 從 ZIP 檔案安裝紋理？
 Installation failed = 安裝失敗
 Installed! = 已安裝！


### PR DESCRIPTION
Fix some more misbehavior. Don't extract files from the download directory into the parent folder, instead offer the user a choice.