### PR TITLE
Fix Harvest Moon not updating save metadata

### DIFF
--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -1112,7 +1112,8 @@ void PSPSaveDialog::ExecuteNotVisibleIOAction() {
 	param.ClearSFOCache();
 	auto &result = param.GetPspParam()->common.result;
 
-	switch ((SceUtilitySavedataType)(u32)param.GetPspParam()->mode) {
+	SceUtilitySavedataType utilityMode = (SceUtilitySavedataType)(u32)param.GetPspParam()->mode;
+	switch (utilityMode) {
 	case SCE_UTILITY_SAVEDATA_TYPE_LOAD: // Only load and exit
 	case SCE_UTILITY_SAVEDATA_TYPE_AUTOLOAD:
 		result = param.Load(param.GetPspParam(), GetSelectedSaveDirName(), currentSelectedSave);

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -238,6 +238,10 @@ bool CanExtractWithoutOverwrite(struct zip *z, const Path &destination, int maxO
 	}
 	for (int i = 0; i < numFiles; i++) {
 		const char *fn = zip_get_name(z, i, 0);
+		if (endsWith(fn, "/")) {
+			// we don't care about directory overwrites, that's fine.
+			continue;
+		}
 		Path p = destination / fn;
 		if (File::Exists(p)) {
 			INFO_LOG(Log::HLE, "Extract zip check: %s exists, can't extract without overwrite", p.ToVisualString().c_str());

--- a/UI/InstallZipScreen.cpp
+++ b/UI/InstallZipScreen.cpp
@@ -125,7 +125,9 @@ void InstallZipScreen::CreateViews() {
 
 			destFolders_.push_back(savedataDir);
 
-			leftColumn->Add(new NoticeView(NoticeLevel::WARN, di->T("Confirm Overwrite"), ""));
+			if (overwrite) {
+				leftColumn->Add(new NoticeView(NoticeLevel::WARN, di->T("Confirm Overwrite"), ""));
+			}
 
 			int columnWidth = 300;
 


### PR DESCRIPTION
This is an alternate solution for #18430, which helped #6078. Unfortunately the added check is not valid as it also prevents Harvest Moon from saving the in-game date properly to the savegame metadata.

Instead of checking the save type for whether to update the metadata, we just check if the data looks valid. There might be a better solution, but the various flags in `SceUtilitySavedataParam` like `overwriteMode` don't seem to correlate much with the validity of the metadata in other games.

@Kethen 

Fixes #18687