### PR TITLE
IR interpreter: Replace the assert for downcount with a very predictable branch

### DIFF
--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -84,9 +84,9 @@ public:
 	}
 	bool OverlapsRange(u32 addr, u32 size) const;
 
-	void GetRange(u32 &start, u32 &size) const {
-		start = origAddr_;
-		size = origSize_;
+	void GetRange(u32 *start, u32 *size) const {
+		*start = origAddr_;
+		*size = origSize_;
 	}
 	u32 GetOriginalStart() const {
 		return origAddr_;
@@ -129,7 +129,7 @@ public:
 			return nullptr;
 		}
 	}
-	void RemoveBlock(int blockNum);
+	void RemoveBlockFromPageLookup(int blockNum);
 	int GetBlockNumFromIRArenaOffset(int offset) const;
 	const IRInst *GetBlockInstructionPtr(const IRBlock &block) const {
 		return arena_.data() + block.GetIRArenaOffset();
@@ -167,7 +167,7 @@ public:
 		JitBlockMeta meta{};
 		if (IsValidBlock(blockNum)) {
 			meta.valid = true;
-			blocks_[blockNum].GetRange(meta.addr, meta.sizeInBytes);
+			blocks_[blockNum].GetRange(&meta.addr, &meta.sizeInBytes);
 		}
 		return meta;
 	}

--- a/Core/MIPS/IR/IRNativeCommon.cpp
+++ b/Core/MIPS/IR/IRNativeCommon.cpp
@@ -570,7 +570,7 @@ bool IRNativeJit::DescribeCodePtr(const u8 *ptr, std::string &name) {
 	const IRBlock *block = blocks_.GetBlock(block_num);
 	if (block) {
 		u32 start = 0, size = 0;
-		block->GetRange(start, size);
+		block->GetRange(&start, &size);
 
 		// It helps to know which func this block is inside.
 		const std::string label = g_symbolMap ? g_symbolMap->GetDescription(start) : "";
@@ -782,7 +782,7 @@ void IRNativeBlockCacheDebugInterface::ComputeStats(BlockCacheStats &bcStats) co
 
 		// MIPS (PSP) size.
 		u32 origAddr, origSize;
-		b.GetRange(origAddr, origSize);
+		b.GetRange(&origAddr, &origSize);
 
 		double bloat = (double)codeSize / (double)origSize;
 		if (bloat < minBloat) {


### PR DESCRIPTION
Fixes breakpoints and other similar things, with a negligible penalty - the CPU branch predictor will just eliminate it in the common case.