### PR TITLE
Port over LunaMoo's compat flag for The Warriors video playback

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -140,6 +140,7 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "FramebufferAllowLargeVerticalOffset", &flags_.FramebufferAllowLargeVerticalOffset);
 	CheckSetting(iniFile, gameID, "DisableMemcpySlicing", &flags_.DisableMemcpySlicing);
 	CheckSetting(iniFile, gameID, "ForceEnableGPUReadback", &flags_.ForceEnableGPUReadback);
+	CheckSetting(iniFile, gameID, "UseFFMPEGFindStreamInfo", &flags_.UseFFMPEGFindStreamInfo);
 }
 
 void Compatibility::CheckVRSettings(IniFile &iniFile, const std::string &gameID) {

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -110,6 +110,7 @@ struct CompatFlags {
 	bool FramebufferAllowLargeVerticalOffset;
 	bool DisableMemcpySlicing;
 	bool ForceEnableGPUReadback;
+	bool UseFFMPEGFindStreamInfo;
 };
 
 struct VRCompat {

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1364,6 +1364,11 @@ UCET00278 = true
 UCUS98670 = true
 UCUS98646 = true
 
+[UseFFMPEGFindStreamInfo]
+# The Warriors: Works around regression (#8991) by reverting to the old behavior
+ULUS10213 = true
+ULES00483 = true
+
 [ForceLowerResolutionForEffectsOn]
 # The water effect of DiRT 2 and Outrun doesn't work in higher resolutions.
 


### PR DESCRIPTION
This reverts to the old behavior before we started parsing mpeg headers, that is, in 558b462 which is part of #8867.

@LunaMoo has this under "HackFixVideo" in his build.

See #8991. This doesn't really "fix" that, but works around it. Unfortunately :(