### PR TITLE
libretro: Don't use VulkanLoader to load the vulkan library

### DIFF
--- a/libretro/LibretroVulkanContext.cpp
+++ b/libretro/LibretroVulkanContext.cpp
@@ -31,14 +31,6 @@ void LibretroVulkanContext::SwapBuffers() {
 static bool create_device(retro_vulkan_context *context, VkInstance instance, VkPhysicalDevice gpu, VkSurfaceKHR surface, PFN_vkGetInstanceProcAddr get_instance_proc_addr, const char **required_device_extensions, unsigned num_required_device_extensions, const char **required_device_layers, unsigned num_required_device_layers, const VkPhysicalDeviceFeatures *required_features) {
 	init_glslang();
 
-	std::string errorStr;
-	if (!VulkanLoad(&errorStr)) {
-		// TODO: In the context of RetroArch, someone has already loaded the functions.
-		// But grabbing the pointers for ourselves can't really be a bad thing.
-		ERROR_LOG(Log::G3D, "RetroArch called the Vulkan entry point without Vulkan available??? %s", errorStr.c_str());
-		return false;
-	}
-
 	vk = new VulkanContext();
 
 	vk_libretro_init(instance, gpu, surface, get_instance_proc_addr, required_device_extensions, num_required_device_extensions, required_device_layers, num_required_device_layers, required_features);

--- a/libretro/libretro_vulkan.cpp
+++ b/libretro/libretro_vulkan.cpp
@@ -376,7 +376,7 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr_libretro(VkInstan
 		return (PFN_vkVoidFunction)vkCreateLibretroSurfaceKHR;
 	}
 
-	PFN_vkVoidFunction fptr = vkGetInstanceProcAddr_org(instance, pName);
+	PFN_vkVoidFunction fptr = vk_init_info.get_instance_proc_addr(instance, pName);
    if (!fptr) {
       ERROR_LOG(Log::G3D, "Failed to load VK instance function: %s", pName);
       return fptr;
@@ -412,9 +412,13 @@ void vk_libretro_init(VkInstance instance, VkPhysicalDevice gpu, VkSurfaceKHR su
 
 	vkGetInstanceProcAddr_org = vkGetInstanceProcAddr;
 	vkGetInstanceProcAddr = vkGetInstanceProcAddr_libretro;
-	vkGetDeviceProcAddr_org = vkGetDeviceProcAddr;
+	vkGetDeviceProcAddr_org = (PFN_vkGetDeviceProcAddr)vkGetInstanceProcAddr(instance, "vkGetDeviceProcAddr");;
 	vkGetDeviceProcAddr = vkGetDeviceProcAddr_libretro;
 	vkCreateInstance = vkCreateInstance_libretro;
+
+	vkEnumerateInstanceVersion = (PFN_vkEnumerateInstanceVersion)vkGetInstanceProcAddr(NULL, "vkEnumerateInstanceVersion");
+	vkEnumerateInstanceExtensionProperties = (PFN_vkEnumerateInstanceExtensionProperties)vkGetInstanceProcAddr(NULL, "vkEnumerateInstanceExtensionProperties");
+	vkEnumerateInstanceLayerProperties = (PFN_vkEnumerateInstanceLayerProperties)vkGetInstanceProcAddr(NULL, "vkEnumerateInstanceLayerProperties");
 }
 
 void vk_libretro_set_hwrender_interface(retro_hw_render_interface *hw_render_interface) {


### PR DESCRIPTION
VulkanLoad() is going to try to open the Vulkan library, which on iOS 12 doesn't work, for reasons I'm happy to get into but aren't relevant. Rather than keep patching VulkanLoad() to find the libretro Vulkan library in random places, just use the Vulkan context that's passed by libretro, since we can get everything we need from there anyway.