### PR TITLE
Tracing support for the IR Interpreter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2342,6 +2342,8 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/MIPS/MIPSVFPUFallbacks.h
 	Core/MIPS/MIPSAsm.cpp
 	Core/MIPS/MIPSAsm.h
+	Core/MIPS/MIPSTracer.cpp
+	Core/MIPS/MIPSTracer.h
 	Core/MemFault.cpp
 	Core/MemFault.h
 	Core/MemMap.cpp

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -43,6 +43,7 @@
 #include "Core/MIPS/MIPS.h"
 #include "Core/HLE/sceNetAdhoc.h"
 #include "GPU/Debugger/Stepping.h"
+#include "Core/MIPS/MIPSTracer.h"
 
 #ifdef _WIN32
 #include "Common/CommonWindows.h"
@@ -334,6 +335,9 @@ bool Core_Run(GraphicsContext *ctx) {
 
 void Core_EnableStepping(bool step, const char *reason, u32 relatedAddress) {
 	if (step) {
+		// Stop the tracer
+		mipsTracer.stop_tracing();
+
 		Core_UpdateState(CORE_STEPPING);
 		steppingCounter++;
 		_assert_msg_(reason != nullptr, "No reason specified for break");

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -583,6 +583,7 @@
     <ClCompile Include="KeyMap.cpp" />
     <ClCompile Include="KeyMapDefaults.cpp" />
     <ClCompile Include="MemFault.cpp" />
+    <ClCompile Include="MIPSTracer.cpp" />
     <ClCompile Include="MIPS\ARM64\Arm64IRAsm.cpp" />
     <ClCompile Include="MIPS\ARM64\Arm64IRCompALU.cpp" />
     <ClCompile Include="MIPS\ARM64\Arm64IRCompBranch.cpp" />
@@ -1193,6 +1194,7 @@
     <ClInclude Include="KeyMap.h" />
     <ClInclude Include="KeyMapDefaults.h" />
     <ClInclude Include="MemFault.h" />
+    <ClInclude Include="MIPSTracer.h" />
     <ClInclude Include="MIPS\ARM64\Arm64IRJit.h" />
     <ClInclude Include="MIPS\ARM64\Arm64IRRegCache.h" />
     <ClInclude Include="MIPS\fake\FakeJit.h" />

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -583,7 +583,6 @@
     <ClCompile Include="KeyMap.cpp" />
     <ClCompile Include="KeyMapDefaults.cpp" />
     <ClCompile Include="MemFault.cpp" />
-    <ClCompile Include="MIPSTracer.cpp" />
     <ClCompile Include="MIPS\ARM64\Arm64IRAsm.cpp" />
     <ClCompile Include="MIPS\ARM64\Arm64IRCompALU.cpp" />
     <ClCompile Include="MIPS\ARM64\Arm64IRCompBranch.cpp" />
@@ -993,6 +992,7 @@
     <ClCompile Include="MIPS\MIPSIntVFPU.cpp" />
     <ClCompile Include="MIPS\MIPSTables.cpp" />
     <ClCompile Include="MIPS\MIPSVFPUUtils.cpp" />
+    <ClCompile Include="MIPS\MIPSTracer.cpp" />
     <ClCompile Include="MIPS\MIPS\MipsJit.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
@@ -1194,7 +1194,6 @@
     <ClInclude Include="KeyMap.h" />
     <ClInclude Include="KeyMapDefaults.h" />
     <ClInclude Include="MemFault.h" />
-    <ClInclude Include="MIPSTracer.h" />
     <ClInclude Include="MIPS\ARM64\Arm64IRJit.h" />
     <ClInclude Include="MIPS\ARM64\Arm64IRRegCache.h" />
     <ClInclude Include="MIPS\fake\FakeJit.h" />
@@ -1408,6 +1407,7 @@
     <ClInclude Include="MIPS\MIPSIntVFPU.h" />
     <ClInclude Include="MIPS\MIPSTables.h" />
     <ClInclude Include="MIPS\MIPSVFPUUtils.h" />
+    <ClInclude Include="MIPS\MIPSTracer.h" />
     <ClInclude Include="MIPS\MIPS\MipsJit.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -123,6 +123,9 @@
     <ClCompile Include="MIPS\MIPSVFPUUtils.cpp">
       <Filter>MIPS</Filter>
     </ClCompile>
+    <ClCompile Include="MIPS\MIPSTracer.cpp">
+      <Filter>MIPS</Filter>
+    </ClCompile>
     <ClCompile Include="MIPS\MIPSAnalyst.cpp">
       <Filter>MIPS</Filter>
     </ClCompile>
@@ -1315,9 +1318,6 @@
     <ClCompile Include="HLE\AtracCtx2.cpp">
       <Filter>HLE\Libraries</Filter>
     </ClCompile>
-    <ClCompile Include="MIPSTracer.cpp">
-      <Filter>MIPS</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -1348,6 +1348,9 @@
       <Filter>MIPS</Filter>
     </ClInclude>
     <ClInclude Include="MIPS\MIPSVFPUUtils.h">
+      <Filter>MIPS</Filter>
+    </ClInclude>
+    <ClInclude Include="MIPS\MIPSTracer.h">
       <Filter>MIPS</Filter>
     </ClInclude>
     <ClInclude Include="MIPS\MIPSAnalyst.h">
@@ -2108,9 +2111,6 @@
     </ClInclude>
     <ClInclude Include="HLE\AtracCtx2.h">
       <Filter>HLE\Libraries</Filter>
-    </ClInclude>
-    <ClInclude Include="MIPSTracer.h">
-      <Filter>MIPS</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -1315,6 +1315,9 @@
     <ClCompile Include="HLE\AtracCtx2.cpp">
       <Filter>HLE\Libraries</Filter>
     </ClCompile>
+    <ClCompile Include="MIPSTracer.cpp">
+      <Filter>MIPS</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ELF\ElfReader.h">
@@ -2105,6 +2108,9 @@
     </ClInclude>
     <ClInclude Include="HLE\AtracCtx2.h">
       <Filter>HLE\Libraries</Filter>
+    </ClInclude>
+    <ClInclude Include="MIPSTracer.h">
+      <Filter>MIPS</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -309,7 +309,7 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, u32 &m
 		instructions.reserve(block_instructions.capacity());
 		// The first instruction is "Downcount"
 		instructions.push_back(block_instructions.front());
-		instructions.push_back({ IROp::LogBlockHash, 0, 0, 0, 0 });
+		instructions.push_back({ IROp::LogIRBlock, 0, 0, 0, 0 });
 		std::copy(block_instructions.begin() + 1, block_instructions.end(), std::back_inserter(instructions));
 	}
 

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -30,6 +30,7 @@
 #include "Core/MIPS/IR/IRInterpreter.h"
 #include "Core/MIPS/MIPSTracer.h"
 
+#include <iterator>
 
 namespace MIPSComp {
 

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -307,8 +307,10 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, u32 &m
 	else {
 		std::vector<IRInst> block_instructions = code->GetInstructions();
 		instructions.reserve(block_instructions.capacity());
-		block_instructions.push_back({ IROp::LogBlockHash, 0, 0, 0, 0 });
-		std::copy(block_instructions.begin(), block_instructions.end(), std::back_inserter(instructions));
+		// The first instruction is "Downcount"
+		instructions.push_back(block_instructions.front());
+		instructions.push_back({ IROp::LogBlockHash, 0, 0, 0, 0 });
+		std::copy(block_instructions.begin() + 1, block_instructions.end(), std::back_inserter(instructions));
 	}
 
 	if (logBlocks > 0 && dontLogBlocks == 0) {

--- a/Core/MIPS/IR/IRFrontend.cpp
+++ b/Core/MIPS/IR/IRFrontend.cpp
@@ -28,6 +28,8 @@
 #include "Core/MIPS/IR/IRRegCache.h"
 #include "Core/MIPS/IR/IRPassSimplify.h"
 #include "Core/MIPS/IR/IRInterpreter.h"
+#include "Core/MIPS/MIPSTracer.h"
+
 
 namespace MIPSComp {
 
@@ -299,7 +301,15 @@ void IRFrontend::DoJit(u32 em_address, std::vector<IRInst> &instructions, u32 &m
 		//	logBlocks = 1;
 	}
 
-	instructions = code->GetInstructions();
+	if (!mipsTracer.tracing_enabled) {
+		instructions = code->GetInstructions();
+	}
+	else {
+		std::vector<IRInst> block_instructions = code->GetInstructions();
+		instructions.reserve(block_instructions.capacity());
+		block_instructions.push_back({ IROp::LogBlockHash, 0, 0, 0, 0 });
+		std::copy(block_instructions.begin(), block_instructions.end(), std::back_inserter(instructions));
+	}
 
 	if (logBlocks > 0 && dontLogBlocks == 0) {
 		char temp2[256];

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -190,7 +190,7 @@ static const IRMeta irMeta[] = {
 	{ IROp::ApplyRoundingMode, "ApplyRoundingMode", "" },
 	{ IROp::UpdateRoundingMode, "UpdateRoundingMode", "" },
 
-	{IROp::LogIRBlock, "LogIRBlock", ""}
+	{ IROp::LogIRBlock, "LogIRBlock", "" },
 };
 
 const IRMeta *metaIndex[256];

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -189,6 +189,8 @@ static const IRMeta irMeta[] = {
 	{ IROp::RestoreRoundingMode, "RestoreRoundingMode", "" },
 	{ IROp::ApplyRoundingMode, "ApplyRoundingMode", "" },
 	{ IROp::UpdateRoundingMode, "UpdateRoundingMode", "" },
+
+	{IROp::LogBlockHash, "logBlockHash", ""}
 };
 
 const IRMeta *metaIndex[256];

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -190,7 +190,7 @@ static const IRMeta irMeta[] = {
 	{ IROp::ApplyRoundingMode, "ApplyRoundingMode", "" },
 	{ IROp::UpdateRoundingMode, "UpdateRoundingMode", "" },
 
-	{IROp::LogBlockHash, "logBlockHash", ""}
+	{IROp::LogBlockHash, "LogBlockHash", ""}
 };
 
 const IRMeta *metaIndex[256];

--- a/Core/MIPS/IR/IRInst.cpp
+++ b/Core/MIPS/IR/IRInst.cpp
@@ -190,7 +190,7 @@ static const IRMeta irMeta[] = {
 	{ IROp::ApplyRoundingMode, "ApplyRoundingMode", "" },
 	{ IROp::UpdateRoundingMode, "UpdateRoundingMode", "" },
 
-	{IROp::LogBlockHash, "LogBlockHash", ""}
+	{IROp::LogIRBlock, "LogIRBlock", ""}
 };
 
 const IRMeta *metaIndex[256];

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -237,6 +237,9 @@ enum class IROp : uint8_t {
 	ValidateAddress32,
 	ValidateAddress128,
 
+	// Tracing support.
+	LogBlockHash,
+
 	Nop,
 	Bad,
 };

--- a/Core/MIPS/IR/IRInst.h
+++ b/Core/MIPS/IR/IRInst.h
@@ -238,7 +238,7 @@ enum class IROp : uint8_t {
 	ValidateAddress128,
 
 	// Tracing support.
-	LogBlockHash,
+	LogIRBlock,
 
 	Nop,
 	Bad,

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -1238,7 +1238,9 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst) {
 			}
 			break;
 		case IROp::LogBlockHash:
-			// Do nothing for now
+			if (mipsTracer.tracing_enabled) {
+				mipsTracer.executed_blocks.push_back(inst->constant);
+			}
 			break;
 
 		case IROp::Nop: // TODO: This shouldn't crash, but for now we should not emit nops, so...

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -1237,7 +1237,7 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst) {
 				return mips->pc;
 			}
 			break;
-		case IROp::LogBlockHash:
+		case IROp::LogIRBlock:
 			if (mipsTracer.tracing_enabled) {
 				mipsTracer.executed_blocks.push_back(inst->constant);
 			}

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -32,6 +32,7 @@
 #include "Core/MIPS/IR/IRInst.h"
 #include "Core/MIPS/IR/IRInterpreter.h"
 #include "Core/System.h"
+#include "Core/MIPS/MIPSTracer.h"
 
 #ifdef mips
 // Why do MIPS compilers define something so generic?  Try to keep defined, at least...

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -1236,6 +1236,9 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst) {
 				return mips->pc;
 			}
 			break;
+		case IROp::LogBlockHash:
+			// Do nothing for now
+			break;
 
 		case IROp::Nop: // TODO: This shouldn't crash, but for now we should not emit nops, so...
 		case IROp::Bad:

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -42,6 +42,8 @@
 #include "Core/MIPS/JitCommon/JitCommon.h"
 #include "Core/Reporting.h"
 #include "Common/TimeUtil.h"
+#include "Core/MIPS/MIPSTracer.h"
+
 
 namespace MIPSComp {
 
@@ -165,13 +167,18 @@ bool IRJit::CompileBlock(u32 em_address, std::vector<IRInst> &instructions, u32 
 	}
 
 	IRBlock *b = blocks_.GetBlock(block_num);
-	if (preload) {
+	if (preload || mipsTracer.tracing_enabled) {
 		// Hash, then only update page stats, don't link yet.
 		// TODO: Should we always hash?  Then we can reuse blocks.
 		b->UpdateHash();
 	}
+
 	if (!CompileNativeBlock(&blocks_, block_num, preload))
 		return false;
+
+	if (mipsTracer.tracing_enabled) {
+		mipsTracer.prepare_block(b, blocks_);
+	}
 
 	// Updates stats, also patches the first MIPS instruction into an emuhack if 'preload == false'
 	blocks_.FinalizeBlock(block_num, preload);

--- a/Core/MIPS/IR/IRJit.cpp
+++ b/Core/MIPS/IR/IRJit.cpp
@@ -172,7 +172,8 @@ bool IRJit::CompileBlock(u32 em_address, std::vector<IRInst> &instructions, u32 
 	}
 	if (!CompileNativeBlock(&blocks_, block_num, preload))
 		return false;
-	// Overwrites the first instruction, and also updates stats.
+
+	// Updates stats, also patches the first MIPS instruction into an emuhack if 'preload == false'
 	blocks_.FinalizeBlock(block_num, preload);
 	if (!preload)
 		FinalizeNativeBlock(&blocks_, block_num);

--- a/Core/MIPS/IR/IRJit.h
+++ b/Core/MIPS/IR/IRJit.h
@@ -91,6 +91,9 @@ public:
 	u32 GetOriginalStart() const {
 		return origAddr_;
 	}
+	u64 GetHash() const {
+		return hash_;
+	}
 
 	void Finalize(int number);
 	void Destroy(int number);

--- a/Core/MIPS/MIPSTracer.cpp
+++ b/Core/MIPS/MIPSTracer.cpp
@@ -20,6 +20,7 @@
 #include <cstring> // for std::memcpy
 #include "Core/MIPS/MIPSTables.h" // for MIPSDisAsm
 #include "Core/MemMap.h" // for Memory::GetPointerUnchecked
+#include "Common/File/FileUtil.h" // for the File::OpenCFile
 
 
 bool TraceBlockStorage::save_block(const u32* instructions, u32 size) {

--- a/Core/MIPS/MIPSTracer.cpp
+++ b/Core/MIPS/MIPSTracer.cpp
@@ -57,7 +57,7 @@ void TraceBlockStorage::clear() {
 	INFO_LOG(Log::JIT, "TraceBlockStorage cleared");
 }
 
-void MIPSTracer::prepare_block(MIPSComp::IRBlock* block, MIPSComp::IRBlockCache& blocks) {
+void MIPSTracer::prepare_block(const MIPSComp::IRBlock* block, MIPSComp::IRBlockCache& blocks) {
 	u32 virt_addr, size;
 	block->GetRange(&virt_addr, &size);
 
@@ -120,7 +120,7 @@ bool MIPSTracer::flush_to_file() {
 	return true;
 }
 
-void MIPSTracer::flush_block_to_file(TraceBlockInfo& block_info) {
+void MIPSTracer::flush_block_to_file(const TraceBlockInfo& block_info) {
 	char buffer[512];
 
 	// The log format is '{prefix}{disassembled line}', where 'prefix' is '0x{8 hex digits of the address}: '

--- a/Core/MIPS/MIPSTracer.cpp
+++ b/Core/MIPS/MIPSTracer.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2024- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#include "Core/MIPS/MIPSTracer.h"
+
+#include <cstring> // for std::memcpy
+#include "Core/MIPS/MIPSTables.h" // for MIPSDisAsm
+
+
+bool TraceBlockStorage::push_block(u32* instructions, u32 size) {
+	if (cur_offset + size >= raw_instructions.size()) {
+		return false;
+	}
+	std::memcpy(cur_data_ptr, instructions, size);
+	cur_offset += size;
+	cur_data_ptr += size;
+	return true;
+}
+
+void TraceBlockStorage::initialize(u32 capacity) {
+	raw_instructions.resize(capacity);
+	cur_offset = 0;
+	cur_data_ptr = raw_instructions.data();
+}
+
+
+MIPSTracer mipsTracer;

--- a/Core/MIPS/MIPSTracer.cpp
+++ b/Core/MIPS/MIPSTracer.cpp
@@ -117,18 +117,24 @@ void MIPSTracer::flush_block_to_file(TraceBlockInfo& block_info) {
 	for (; addr < end_addr; addr += 4, ++index) {
 		snprintf(buffer, sizeof(buffer), "0x%08x: ", addr);
 		MIPSDisAsm(storage[index], addr, buffer + prefix_size, sizeof(buffer) - prefix_size, true);
+
+		// TODO: check if removing the std::string makes this faster
 		output << std::string(buffer) << "\n";
 	}
 }
 
 void MIPSTracer::start_tracing() {
+	if (!tracing_enabled) {
+		INFO_LOG(Log::JIT, "MIPSTracer enabled");
+	}
 	tracing_enabled = true;
-	INFO_LOG(Log::JIT, "MIPSTracer enabled");
 }
 
 void MIPSTracer::stop_tracing() {
+	if (tracing_enabled) {
+		INFO_LOG(Log::JIT, "MIPSTracer disabled");
+	}
 	tracing_enabled = false;
-	INFO_LOG(Log::JIT, "MIPSTracer disabled");
 }
 
 void MIPSTracer::initialize(u32 storage_capacity, u32 max_trace_size) {

--- a/Core/MIPS/MIPSTracer.cpp
+++ b/Core/MIPS/MIPSTracer.cpp
@@ -103,7 +103,7 @@ bool MIPSTracer::flush_to_file() {
 
 	output.open(logging_path, std::ios::out);
 	if (!output) {
-		WARN_LOG(Log::JIT, "MIPSTracer failed to open the file '%s'", logging_path);
+		WARN_LOG(Log::JIT, "MIPSTracer failed to open the file '%s'", logging_path.c_str());
 		return false;
 	}
 	auto trace = executed_blocks.get_content();

--- a/Core/MIPS/MIPSTracer.cpp
+++ b/Core/MIPS/MIPSTracer.cpp
@@ -58,7 +58,7 @@ void TraceBlockStorage::clear() {
 
 void MIPSTracer::prepare_block(MIPSComp::IRBlock* block, MIPSComp::IRBlockCache& blocks) {
 	u32 virt_addr, size;
-	block->GetRange(virt_addr, size);
+	block->GetRange(&virt_addr, &size);
 
 	u64 hash = block->GetHash();
 	auto it = hash_to_storage_index.find(hash);
@@ -99,7 +99,7 @@ void MIPSTracer::prepare_block(MIPSComp::IRBlock* block, MIPSComp::IRBlockCache&
 }
 
 bool MIPSTracer::flush_to_file() {
-	INFO_LOG(Log::JIT, "MIPSTracer ordered to flush the trace to a file...");
+	INFO_LOG(Log::JIT, "Flushing the trace to a file...");
 
 	output.open(logging_path, std::ios::out);
 	if (!output) {

--- a/Core/MIPS/MIPSTracer.cpp
+++ b/Core/MIPS/MIPSTracer.cpp
@@ -19,9 +19,10 @@
 
 #include <cstring> // for std::memcpy
 #include "Core/MIPS/MIPSTables.h" // for MIPSDisAsm
+#include "Core/MemMap.h" // for Memory::GetPointerUnchecked
 
 
-bool TraceBlockStorage::push_block(u32* instructions, u32 size) {
+bool TraceBlockStorage::push_block(const u32* instructions, u32 size) {
 	if (cur_offset + size >= raw_instructions.size()) {
 		return false;
 	}
@@ -37,5 +38,47 @@ void TraceBlockStorage::initialize(u32 capacity) {
 	cur_data_ptr = raw_instructions.data();
 }
 
+void MIPSTracer::prepare_block(MIPSComp::IRBlock* block, MIPSComp::IRBlockCache& blocks) {
+	auto hash = block->GetHash();
+	auto it = mipsTracer.hash_to_index.find(hash);
+
+	if (it != mipsTracer.hash_to_index.end()) {
+		u32 index = it->second;
+		auto ir_ptr = (IRInst*)blocks.GetBlockInstructionPtr(*block);
+		ir_ptr->constant = index;
+		return;
+	}
+
+	// 1) Copy the block instructions into our storage
+	u32 virt_addr, size;
+	block->GetRange(virt_addr, size);
+	u32 storage_index = mipsTracer.storage.cur_offset;
+
+	auto mips_instructions_ptr = (const u32*)Memory::GetPointerUnchecked(virt_addr);
+
+	if (!mipsTracer.storage.push_block(mips_instructions_ptr, size)) {
+		// We ran out of storage! TODO: report that to the user
+		mipsTracer.tracing_enabled = false;
+		return;
+	}
+	// Successfully inserted the block at index 'possible_index'!
+
+	mipsTracer.trace_info.push_back({ virt_addr, size, storage_index });
+
+	// 2) Save the hash and the index
+
+	u32 index = mipsTracer.trace_info.size() - 1;
+	hash_to_index.emplace(hash, index);
+
+	auto ir_ptr = (IRInst*)blocks.GetBlockInstructionPtr(*block);
+	ir_ptr->constant = index;
+}
+
+bool MIPSTracer::flush_to_file() {
+	// Do nothing for now
+	return true;
+}
 
 MIPSTracer mipsTracer;
+
+

--- a/Core/MIPS/MIPSTracer.h
+++ b/Core/MIPS/MIPSTracer.h
@@ -124,6 +124,12 @@ void CyclicBuffer<T>::resize(u32 new_capacity) {
 	buffer.resize(new_capacity);
 }
 
+
+// This system is meant for trace recording.
+// A trace here stands for a sequence of instructions and their respective addresses in RAM.
+// The register/memory changes (or thread switches) are not included!
+// Note: the tracer stores the basic blocks inside, which causes the last block to be dumped as a whole,
+// despite the fact that it may not have executed to its end by the time the tracer is stopped.
 struct MIPSTracer {
 	std::vector<TraceBlockInfo> trace_info;
 

--- a/Core/MIPS/MIPSTracer.h
+++ b/Core/MIPS/MIPSTracer.h
@@ -29,33 +29,33 @@
 #include "Common/Log.h"
 
 
-
-
 struct TraceBlockInfo {
 	u32 virt_address;
-	u32 size;
 	u32 storage_index;
 };
 
 struct TraceBlockStorage {
 	std::vector<u32> raw_instructions;
-	u32 cur_offset;
+	u32 cur_index;
 	u32* cur_data_ptr;
 
 	TraceBlockStorage(u32 capacity):
 		raw_instructions(capacity, 0),
-		cur_offset(0),
+		cur_index(0),
 		cur_data_ptr(raw_instructions.data())
 		{}
 
-	TraceBlockStorage(): raw_instructions(), cur_offset(0), cur_data_ptr(nullptr) {}
+	TraceBlockStorage(): raw_instructions(), cur_index(0), cur_data_ptr(nullptr) {}
 
-	bool push_block(const u32* instructions, u32 size);
+	bool save_block(const u32* instructions, u32 size);
 
 	void initialize(u32 capacity);
 	void clear();
 
-	Memory::Opcode operator[](u32 index) {
+	u32 operator[](u32 index) {
+		return raw_instructions[index];
+	}
+	Memory::Opcode read_asm(u32 index) {
 		return Memory::Opcode(raw_instructions[index]);
 	}
 };
@@ -131,7 +131,7 @@ struct MIPSTracer {
 	// The trace might be very big, in that case I don't mind losing the oldest entries.
 	CyclicBuffer<u32> executed_blocks;
 
-	std::unordered_map<u64, u32> hash_to_index;
+	std::unordered_map<u64, u32> hash_to_storage_index;
 
 	TraceBlockStorage storage;
 
@@ -159,7 +159,9 @@ struct MIPSTracer {
 	void initialize(u32 storage_capacity, u32 max_trace_size);
 	void clear();
 
-	MIPSTracer(): trace_info(), executed_blocks(), hash_to_index(), storage(), logging_path() {}
+	inline void print_stats() const;
+
+	MIPSTracer(): trace_info(), executed_blocks(), hash_to_storage_index(), storage(), logging_path() {}
 };
 
 extern MIPSTracer mipsTracer;

--- a/Core/MIPS/MIPSTracer.h
+++ b/Core/MIPS/MIPSTracer.h
@@ -144,16 +144,16 @@ struct MIPSTracer {
 	void start_tracing();
 	void stop_tracing();
 
-	void prepare_block(MIPSComp::IRBlock* block, MIPSComp::IRBlockCache& blocks);
-	void setLoggingPath(std::string path) {
+	void prepare_block(const MIPSComp::IRBlock* block, MIPSComp::IRBlockCache& blocks);
+	void set_logging_path(std::string path) {
 		logging_path = Path(path);
 	}
-	std::string getLoggingPath() const {
+	std::string get_logging_path() const {
 		return logging_path.ToString();
 	}
 
 	bool flush_to_file();
-	void flush_block_to_file(TraceBlockInfo& block);
+	void flush_block_to_file(const TraceBlockInfo& block);
 
 	void initialize(u32 storage_capacity, u32 max_trace_size);
 	void clear();

--- a/Core/MIPS/MIPSTracer.h
+++ b/Core/MIPS/MIPSTracer.h
@@ -20,15 +20,12 @@
 #include <unordered_map>
 #include <vector>
 #include <string>
-#include <iterator>
-#include <fstream>
 
 #include "Common/CommonTypes.h"
 #include "Core/Opcode.h"
 #include "Core/MIPS/IR/IRJit.h"
 #include "Common/Log.h"
 #include "Common/File/Path.h"
-#include "Common/File/FileUtil.h"
 
 
 struct TraceBlockInfo {

--- a/Core/MIPS/MIPSTracer.h
+++ b/Core/MIPS/MIPSTracer.h
@@ -25,6 +25,7 @@
 #include "Common/CommonTypes.h"
 #include "Core/Opcode.h"
 #include "Core/MIPS/IR/IRJit.h"
+#include "Common/Log.h"
 
 
 
@@ -51,6 +52,7 @@ struct TraceBlockStorage {
 	bool push_block(const u32* instructions, u32 size);
 
 	void initialize(u32 capacity);
+	void clear();
 
 	Memory::Opcode operator[](u32 index) {
 		return Memory::Opcode(raw_instructions[index]);
@@ -135,6 +137,12 @@ struct MIPSTracer {
 	std::string logging_path;
 	bool tracing_enabled = false;
 
+	int in_storage_capacity = 0;
+	int in_max_trace_size = 0;
+
+	void start_tracing();
+	void stop_tracing();
+
 	void prepare_block(MIPSComp::IRBlock* block, MIPSComp::IRBlockCache& blocks);
 	void setLoggingPath(std::string path) {
 		logging_path = path;
@@ -144,6 +152,8 @@ struct MIPSTracer {
 	}
 
 	bool flush_to_file();
+	void initialize(u32 storage_capacity, u32 max_trace_size);
+	void clear();
 
 	MIPSTracer(): trace_info(), executed_blocks(), hash_to_index(), storage(), logging_path() {}
 };

--- a/Core/MIPS/MIPSTracer.h
+++ b/Core/MIPS/MIPSTracer.h
@@ -27,6 +27,8 @@
 #include "Core/Opcode.h"
 #include "Core/MIPS/IR/IRJit.h"
 #include "Common/Log.h"
+#include "Common/File/Path.h"
+#include "Common/File/FileUtil.h"
 
 
 struct TraceBlockInfo {
@@ -135,8 +137,8 @@ struct MIPSTracer {
 
 	TraceBlockStorage storage;
 
-	std::string logging_path;
-	std::ofstream output;
+	Path logging_path;
+	FILE* output;
 	bool tracing_enabled = false;
 
 	int in_storage_capacity = 0x10'0000;
@@ -147,10 +149,10 @@ struct MIPSTracer {
 
 	void prepare_block(MIPSComp::IRBlock* block, MIPSComp::IRBlockCache& blocks);
 	void setLoggingPath(std::string path) {
-		logging_path = path;
+		logging_path = Path(path);
 	}
 	std::string getLoggingPath() const {
-		return logging_path;
+		return logging_path.ToString();
 	}
 
 	bool flush_to_file();

--- a/Core/MIPS/MIPSTracer.h
+++ b/Core/MIPS/MIPSTracer.h
@@ -1,0 +1,138 @@
+// Copyright (c) 2024- PPSSPP Project.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 2.0 or later versions.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License 2.0 for more details.
+
+// A copy of the GPL 2.0 should have been included with the program.
+// If not, see http://www.gnu.org/licenses/
+
+// Official git repository and contact information can be found at
+// https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
+
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+#include <string>
+#include <iterator>
+
+#include "Common/CommonTypes.h"
+#include "Core/Opcode.h"
+
+
+
+struct TraceBlockInfo {
+	u32 virt_address;
+	u32 size;
+	u32 storage_index;
+};
+
+struct TraceBlockStorage {
+	std::vector<u32> raw_instructions;
+	u32 cur_offset;
+	u32* cur_data_ptr;
+
+	TraceBlockStorage(u32 capacity):
+		raw_instructions(capacity, 0),
+		cur_offset(0),
+		cur_data_ptr(raw_instructions.data())
+		{}
+
+	TraceBlockStorage(): raw_instructions(), cur_offset(0), cur_data_ptr(nullptr) {}
+
+	bool push_block(u32* instructions, u32 size);
+
+	void initialize(u32 capacity);
+
+	Memory::Opcode operator[](u32 index) {
+		return Memory::Opcode(raw_instructions[index]);
+	}
+};
+
+
+template <typename T>
+struct CyclicBuffer {
+	std::vector<T> buffer;
+	u32 current_index;
+	bool overflow;
+
+	explicit CyclicBuffer(u32 capacity) : buffer(capacity, T()), current_index(0), overflow(false) {}
+
+	CyclicBuffer(): buffer(), current_index(0), overflow(false) {}
+
+	void push_back(const T& value);
+	void push_back(T&& value);
+
+	void clear();
+	void resize(u32 new_capacity);
+
+	std::vector<T> get_content() const;
+};
+
+template<typename T>
+std::vector<T> CyclicBuffer<T>::get_content() const {
+	if (!overflow) {
+		return std::vector<T>(buffer.begin(), buffer.begin() + current_index);
+	}
+
+	std::vector<T> ans;
+	ans.reserve(buffer.size());
+	std::copy(buffer.begin() + current_index, buffer.end(), std::back_inserter(ans));
+	std::copy(buffer.begin(), buffer.begin() + current_index, std::back_inserter(ans));
+	return ans;
+}
+
+template <typename T>
+void CyclicBuffer<T>::push_back(const T& value) {
+	buffer[current_index] = value;
+	++current_index;
+	if (current_index == buffer.size()) {
+		current_index = 0;
+		overflow = true;
+	}
+}
+
+template <typename T>
+void CyclicBuffer<T>::push_back(T&& value) {
+	buffer[current_index] = std::move(value);
+	++current_index;
+	if (current_index == buffer.size()) {
+		current_index = 0;
+		overflow = true;
+	}
+}
+
+template <typename T>
+void CyclicBuffer<T>::clear() {
+	buffer.clear();
+	current_index = 0;
+	overflow = false;
+}
+
+template <typename T>
+void CyclicBuffer<T>::resize(u32 new_capacity) {
+	buffer.resize(new_capacity);
+}
+
+struct MIPSTracer {
+	std::vector<TraceBlockInfo> trace_info;
+
+	// The trace might be very big, in that case I don't mind losing the oldest entries.
+	CyclicBuffer<u32> executed_blocks;
+
+	std::unordered_map<u64, u32> hash_to_index;
+
+	TraceBlockStorage storage;
+
+	std::string logging_path;
+
+	MIPSTracer(): trace_info(), executed_blocks(), hash_to_index(), storage(), logging_path() {}
+};
+
+extern MIPSTracer mipsTracer;

--- a/Core/MIPS/MIPSTracer.h
+++ b/Core/MIPS/MIPSTracer.h
@@ -21,6 +21,7 @@
 #include <vector>
 #include <string>
 #include <iterator>
+#include <fstream>
 
 #include "Common/CommonTypes.h"
 #include "Core/Opcode.h"
@@ -135,6 +136,7 @@ struct MIPSTracer {
 	TraceBlockStorage storage;
 
 	std::string logging_path;
+	std::ofstream output;
 	bool tracing_enabled = false;
 
 	int in_storage_capacity = 0;
@@ -152,6 +154,8 @@ struct MIPSTracer {
 	}
 
 	bool flush_to_file();
+	void flush_block_to_file(TraceBlockInfo& block);
+
 	void initialize(u32 storage_capacity, u32 max_trace_size);
 	void clear();
 

--- a/Core/MIPS/MIPSTracer.h
+++ b/Core/MIPS/MIPSTracer.h
@@ -24,6 +24,8 @@
 
 #include "Common/CommonTypes.h"
 #include "Core/Opcode.h"
+#include "Core/MIPS/IR/IRJit.h"
+
 
 
 
@@ -46,7 +48,7 @@ struct TraceBlockStorage {
 
 	TraceBlockStorage(): raw_instructions(), cur_offset(0), cur_data_ptr(nullptr) {}
 
-	bool push_block(u32* instructions, u32 size);
+	bool push_block(const u32* instructions, u32 size);
 
 	void initialize(u32 capacity);
 
@@ -131,6 +133,17 @@ struct MIPSTracer {
 	TraceBlockStorage storage;
 
 	std::string logging_path;
+	bool tracing_enabled = false;
+
+	void prepare_block(MIPSComp::IRBlock* block, MIPSComp::IRBlockCache& blocks);
+	void setLoggingPath(std::string path) {
+		logging_path = path;
+	}
+	std::string getLoggingPath() const {
+		return logging_path;
+	}
+
+	bool flush_to_file();
 
 	MIPSTracer(): trace_info(), executed_blocks(), hash_to_index(), storage(), logging_path() {}
 };

--- a/Core/MIPS/MIPSTracer.h
+++ b/Core/MIPS/MIPSTracer.h
@@ -139,8 +139,8 @@ struct MIPSTracer {
 	std::ofstream output;
 	bool tracing_enabled = false;
 
-	int in_storage_capacity = 0;
-	int in_max_trace_size = 0;
+	int in_storage_capacity = 0x10'0000;
+	int in_max_trace_size = 0x10'0000;
 
 	void start_tracing();
 	void stop_tracing();

--- a/Core/MIPSTracer.h
+++ b/Core/MIPSTracer.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/Core/MIPSTracer.h
+++ b/Core/MIPSTracer.h
@@ -1,1 +1,0 @@
-#pragma once

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1954,6 +1954,9 @@ void DeveloperToolsScreen::CreateViews() {
 	Button *InvalidateJitCache = list->Add(new Button(dev->T("Clear the JIT cache")));
 	InvalidateJitCache->OnClick.Handle(this, &DeveloperToolsScreen::OnMIPSTracerClearJitCache);
 
+	Button *ClearMIPSTracer = list->Add(new Button(dev->T("Clear the MIPSTracer")));
+	ClearMIPSTracer->OnClick.Handle(this, &DeveloperToolsScreen::OnMIPSTracerClearJitCache);
+
 	Draw::DrawContext *draw = screenManager()->getDrawContext();
 
 	list->Add(new ItemHeader(dev->T("Ubershaders")));
@@ -2144,8 +2147,6 @@ UI::EventReturn DeveloperToolsScreen::OnRemoteDebugger(UI::EventParams &e) {
 }
 
 UI::EventReturn DeveloperToolsScreen::OnMIPSTracerEnabled(UI::EventParams &e) {
-	mipsTracer.clear();
-
 	if (MIPSTracerEnabled_) {
 		u32 capacity = mipsTracer.in_storage_capacity;
 		u32 trace_size = mipsTracer.in_max_trace_size;
@@ -2188,8 +2189,14 @@ UI::EventReturn DeveloperToolsScreen::OnMIPSTracerFlushTrace(UI::EventParams &e)
 }
 
 UI::EventReturn DeveloperToolsScreen::OnMIPSTracerClearJitCache(UI::EventParams &e) {
-	INFO_LOG(Log::JIT, "Ordered to clear the jit cache");
+	INFO_LOG(Log::JIT, "Clearing the jit cache...");
 	System_PostUIMessage(UIMessage::REQUEST_CLEAR_JIT);
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn DeveloperToolsScreen::OnMIPSTracerClearTracer(UI::EventParams &e) {
+	INFO_LOG(Log::JIT, "Clearing the MIPSTracer...");
+	mipsTracer.clear();
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -79,7 +79,7 @@
 #include "GPU/GPUInterface.h"
 #include "GPU/Common/FramebufferManagerCommon.h"
 
-#include "Core/Core.h"
+#include "Core/Core.h" // for Core_IsStepping
 #include "Core/MIPS/MIPSTracer.h"
 
 #if PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS)

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1951,6 +1951,9 @@ void DeveloperToolsScreen::CreateViews() {
 #endif
 	});
 
+	Button *InvalidateJitCache = list->Add(new Button(dev->T("Clear the JIT cache")));
+	InvalidateJitCache->OnClick.Handle(this, &DeveloperToolsScreen::OnMIPSTracerClearJitCache);
+
 	Draw::DrawContext *draw = screenManager()->getDrawContext();
 
 	list->Add(new ItemHeader(dev->T("Ubershaders")));
@@ -2181,6 +2184,12 @@ UI::EventReturn DeveloperToolsScreen::OnMIPSTracerFlushTrace(UI::EventParams &e)
 		WARN_LOG(Log::JIT, "Error: cannot flush the trace to the specified file!");
 	}
 #endif
+	return UI::EVENT_DONE;
+}
+
+UI::EventReturn DeveloperToolsScreen::OnMIPSTracerClearJitCache(UI::EventParams &e) {
+	INFO_LOG(Log::JIT, "Ordered to clear the jit cache");
+	System_PostUIMessage(UIMessage::REQUEST_CLEAR_JIT);
 	return UI::EVENT_DONE;
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1909,7 +1909,7 @@ void DeveloperToolsScreen::CreateViews() {
 		return true;
 	});
 
-	MIPSTracerPath_ = mipsTracer.getLoggingPath();
+	MIPSTracerPath_ = mipsTracer.get_logging_path();
 	MIPSTracerPath = list->Add(new InfoItem(dev->T("Current log file"), MIPSTracerPath_));
 
 	PopupSliderChoice* storage_capacity = list->Add(
@@ -2151,7 +2151,7 @@ UI::EventReturn DeveloperToolsScreen::OnMIPSTracerPathChanged(UI::EventParams &e
 	auto dev = GetI18NCategory(I18NCat::DEVELOPER);
 	System_BrowseForFile(GetRequesterToken(), dev->T("Select the log file"), BrowseFileType::ANY,
 		[this](const std::string &value, int) {
-		mipsTracer.setLoggingPath(value);
+		mipsTracer.set_logging_path(value);
 		MIPSTracerPath_ = value;
 		MIPSTracerPath->SetRightText(MIPSTracerPath_);
 	});

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -2148,7 +2148,7 @@ UI::EventReturn DeveloperToolsScreen::OnMIPSTracerEnabled(UI::EventParams &e) {
 		u32 trace_size = mipsTracer.in_max_trace_size;
 
 		mipsTracer.initialize(capacity, trace_size);
-		// mipsTracer.start_tracing();
+		mipsTracer.start_tracing();
 	}
 	else {
 		mipsTracer.stop_tracing();

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -153,6 +153,7 @@ private:
 	UI::EventReturn OnMIPSTracerEnabled(UI::EventParams &e);
 	UI::EventReturn OnMIPSTracerPathChanged(UI::EventParams &e);
 	UI::EventReturn OnMIPSTracerFlushTrace(UI::EventParams &e);
+	UI::EventReturn OnMIPSTracerClearJitCache(UI::EventParams &e);
 	UI::EventReturn OnGPUDriverTest(UI::EventParams &e);
 	UI::EventReturn OnFramedumpTest(UI::EventParams &e);
 	UI::EventReturn OnMemstickTest(UI::EventParams &e);

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -150,6 +150,9 @@ private:
 	UI::EventReturn OnJitAffectingSetting(UI::EventParams &e);
 	UI::EventReturn OnJitDebugTools(UI::EventParams &e);
 	UI::EventReturn OnRemoteDebugger(UI::EventParams &e);
+	UI::EventReturn OnMIPSTracerEnabled(UI::EventParams &e);
+	UI::EventReturn OnMIPSTracerPathChanged(UI::EventParams &e);
+	UI::EventReturn OnMIPSTracerFlushTrace(UI::EventParams &e);
 	UI::EventReturn OnGPUDriverTest(UI::EventParams &e);
 	UI::EventReturn OnFramedumpTest(UI::EventParams &e);
 	UI::EventReturn OnMemstickTest(UI::EventParams &e);
@@ -164,6 +167,10 @@ private:
 		MAYBE,
 	};
 	HasIni hasTexturesIni_ = HasIni::MAYBE;
+
+	bool MIPSTracerEnabled_ = false;
+	std::string MIPSTracerPath_ = "";
+	UI::InfoItem* MIPSTracerPath = nullptr;
 };
 
 class HostnameSelectScreen : public PopupScreen {

--- a/UI/GameSettingsScreen.h
+++ b/UI/GameSettingsScreen.h
@@ -154,6 +154,7 @@ private:
 	UI::EventReturn OnMIPSTracerPathChanged(UI::EventParams &e);
 	UI::EventReturn OnMIPSTracerFlushTrace(UI::EventParams &e);
 	UI::EventReturn OnMIPSTracerClearJitCache(UI::EventParams &e);
+	UI::EventReturn OnMIPSTracerClearTracer(UI::EventParams &e);
 	UI::EventReturn OnGPUDriverTest(UI::EventParams &e);
 	UI::EventReturn OnFramedumpTest(UI::EventParams &e);
 	UI::EventReturn OnMemstickTest(UI::EventParams &e);

--- a/UWP/CoreUWP/CoreUWP.vcxproj
+++ b/UWP/CoreUWP/CoreUWP.vcxproj
@@ -305,6 +305,7 @@
     <ClInclude Include="..\..\Core\MIPS\MIPSTables.h" />
     <ClInclude Include="..\..\Core\MIPS\MIPSVFPUFallbacks.h" />
     <ClInclude Include="..\..\Core\MIPS\MIPSVFPUUtils.h" />
+    <ClInclude Include="..\..\Core\MIPS\MIPSTracer.h" />
     <ClInclude Include="..\..\Core\MIPS\x86\Jit.h" />
     <ClInclude Include="..\..\Core\MIPS\x86\JitSafeMem.h" />
     <ClInclude Include="..\..\Core\MIPS\x86\RegCache.h" />
@@ -583,6 +584,7 @@
     <ClCompile Include="..\..\Core\MIPS\MIPSTables.cpp" />
     <ClCompile Include="..\..\Core\MIPS\MIPSVFPUFallbacks.cpp" />
     <ClCompile Include="..\..\Core\MIPS\MIPSVFPUUtils.cpp" />
+    <ClCompile Include="..\..\Core\MIPS\MIPSTracer.cpp" />
     <ClCompile Include="..\..\Core\MIPS\x86\Asm.cpp" />
     <ClCompile Include="..\..\Core\MIPS\x86\CompALU.cpp" />
     <ClCompile Include="..\..\Core\MIPS\x86\CompBranch.cpp" />

--- a/UWP/CoreUWP/CoreUWP.vcxproj.filters
+++ b/UWP/CoreUWP/CoreUWP.vcxproj.filters
@@ -555,6 +555,9 @@
     <ClCompile Include="..\..\Core\MIPS\MIPSVFPUUtils.cpp">
       <Filter>MIPS</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\Core\MIPS\MIPSTracer.cpp">
+      <Filter>MIPS</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\Core\Dialog\PSPDialog.cpp">
       <Filter>Dialog</Filter>
     </ClCompile>
@@ -1622,6 +1625,9 @@
       <Filter>MIPS</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Core\MIPS\MIPSVFPUUtils.h">
+      <Filter>MIPS</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\Core\MIPS\MIPSTracer.h">
       <Filter>MIPS</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Core\Dialog\PSPDialog.h">

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -447,6 +447,7 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/MIPS/MIPSVFPUFallbacks.cpp.arm \
   $(SRC)/Core/MIPS/MIPSCodeUtils.cpp.arm \
   $(SRC)/Core/MIPS/MIPSDebugInterface.cpp \
+  $(SRC)/Core/MIPS/MIPSTracer.cpp \
   $(SRC)/Core/MIPS/IR/IRAnalysis.cpp \
   $(SRC)/Core/MIPS/IR/IRFrontend.cpp \
   $(SRC)/Core/MIPS/IR/IRJit.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -758,6 +758,7 @@ SOURCES_CXX += \
 	       $(COREDIR)/MIPS/MIPSStackWalk.cpp \
 	       $(COREDIR)/MIPS/MIPSVFPUUtils.cpp \
 	       $(COREDIR)/MIPS/MIPSVFPUFallbacks.cpp \
+	       $(COREDIR)/MIPS/MIPSTracer.cpp \
 	       $(COREDIR)/MemFault.cpp \
 	       $(COREDIR)/MemMap.cpp \
 	       $(COREDIR)/MemMapFunctions.cpp \


### PR DESCRIPTION
I've been working on the tracing support for a few years now, starting from the alpha `MIPSLogger`. I don't think it's worth listing the previous attempts and, say, the changes between https://github.com/Nemoumbra/ppsspp/tree/mips-logger and https://github.com/Nemoumbra/ppsspp/tree/mipslogger-faster, let's get to the point.

Note: this system is for experienced users only.
`MIPSTracer` works only in the IR Interpreter CPU core and it's disabled on Switch, Android and IOS (well, the code is there, but the UI to interact with the tracer is hidden under a preprocessor condition). For some reason the SDL build for Linux doesn't support the file picker, so the tracer can't work there. The button just doesn't do anything. I'm PRing it as is, because I intend to add the `nativefiledialog-extended` GTK file picker or something similar.

## Modus operandi
### Unmodified IR Interpreter
The IR Interpreter first checks if the `pc` is pointing at a special PPSSPP hack instruction which signifies that the [basic block](https://en.wikipedia.org/wiki/Basic_block) is ready for execution. If it's not a hack instruction, PPSSPP invokes the compiler (which should patch the first instruction on success) and retries. The compiler iterates over the MIPS instructions sequentially until the basic block's end and emits the PPSSPP's internal [IR](https://en.wikipedia.org/wiki/Intermediate_representation) from the assembly. Then it runs various optimizations and saves the resulting IR code. The basic block's start position is encoded inside the emuhack instruction and later the IR is executed by IR Interpreter.

### The compilation with the tracer enabled
The idea is to remember which blocks were executed and write this information to a file. If the tracing is ongoing, the compiler now will add one extra IR instruction to all blocks right after the first one (which is, generally speaking, a downcount). After the block is created, the tracer copies its content to a dedicated storage alongside with the block's size... unless it already saw a block like that before. In order to properly distinguish the blocks, we evaluate their hashes and place them in a mapping `hash -> storage index`, so if the hash is found in the unordered map, we don't have to copy the instructions!

In any case, we proceed by pushing the storage index and the block's start address into a supplementary vector `trace_info`, because identical basic blocks could appear at different addresses and we must remember them all. There's a little problem... I'm unable to prevent PPSSPP from both running fast and conserving memory as explained by the comment next to the line
`trace_info.push_back({ virt_addr, storage_index });` inside `MIPSTracer::prepare_block`. This means that if, *for some reason*, PPSSPP decides to recompile old basic blocks, the `trace_info` will be filled with identical entries, which we can't easily filter out on the fly. Say, if the game repeatedly reloads overlays, this will cause the vector to grow until the user runs out of RAM or stops the tracing session. That shouldn't be a problem though, such cases are rather rare.

The indexes of `trace_info` elements represent basic blocks and they can fit into 4 bytes, therefore they are used as block identifiers. Now the tracer reaches into the IR instructions' storage and fills the constant argument of the newly added `IROp::LogIRBlock`. Then the tracer lets the compiler do its thing (overwrite the first MIPS instruction).

### The execution
I designed the system to maximize the execution speed.
If the IR Interpreter sees the `LogIRBlock` instruction, it checks if we're tracing (perhaps, we're just running after a trace session, but some blocks still contain the logging instructions) and if we do, it pushes the block id into a [cyclic buffer](https://en.wikipedia.org/wiki/Circular_buffer) called `executed_blocks`. The user decides on the max number of basic blocks that can be saved to a trace. Once we run out of space, the cyclic buffer starts forgetting the oldest entries by overwriting them.
The tracing is stopped automatically once the core enters stepping.

### The trace generation
We iterate over the `executed_blocks` (which contains `trace_info` indexes that represent basic blocks) and flush all of them to a file. That requires fetching the basic block's size and content from out storage, disassembling the instructions and formatting the output lines.

## UI

![image](https://github.com/user-attachments/assets/870ff802-26da-4b74-8942-b38cd0ee710a)

I've added a new paragraph to the Developer tools, right before the Ubershaders. The first option is grayed out unless the CPU core is correct, a game is loaded and the CPU is stepping. Invalidating the JIT cache is required to force the recompilation of all basic blocks that could have been built without the logging instruction within should we ever run into them.

## Performance
I tested it on Windows and noticed almost no differences in performance when compared to the IR interpreter running on its own. I also staged an experiment by sitting at the idle Class Select screen of Patapon 3 EU under different circumstances.

MIPSTracer build:
- Debug:
    * IR Interpreter: 18 fps
    * Interpreter: 4 fps
    * IR Interpreter x MIPSTracer: 14 fps
- Release:
    * IR Interpreter: 30 fps
    * Interpreter: 30 fps
    * IR Interpreter x MIPSTracer: 30 fps

The old "MIPSLogger faster" build (which I didn't sync with upstream):
 - Debug:
    * IR Interpreter: 10 fps
    * Interpreter: 4 fps
    * Interpreter x MIPSLogger: :skull:
 - Release:
    * IR Interpreter: 30 fps
    * Interpreter: 30 fps
    * Interpreter x MIPSLogger: 27 fps

The file generation routine seems to be the longest.
| Resulting trace size (Mb) | Time to create the file (seconds) |
| ------------- | ------------- |
| 654  | 21.2  |
| 350  | 11.3  |
| 108  | 3.3  |

This is, of course, the Release mode.
Unfortunately, the UI hangs until the trace is written to a file. I really wish to know if PPSSPP can schedule background processes that reflect the UI somehow.

I would really love to know if I'm missing some things worth adding (excluding the translations, that part can be added later) or reconsidering.