### PR TITLE
Custom touch buttons: Allow empty button images, not just empty shapes

### DIFF
--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -882,6 +882,10 @@ UI::ViewGroup *CreatePadLayout(float xres, float yres, bool *pause, bool showPau
 	auto addCustomButton = [=](const ConfigCustomButton& cfg, const char *key, const ConfigTouchPos &touch) -> CustomButton * {
 		using namespace CustomKeyData;
 		if (touch.show) {
+			_dbg_assert_(cfg.shape < ARRAY_SIZE(customKeyShapes));
+			_dbg_assert_(cfg.image < ARRAY_SIZE(customKeyImages));
+
+			// Note: cfg.shape and cfg.image are bounds-checked elsewhere.
 			auto aux = root->Add(new CustomButton(cfg.key, key, cfg.toggle, cfg.repeat, controllMapper,
 					g_Config.iTouchButtonStyle == 0 ? customKeyShapes[cfg.shape].i : customKeyShapes[cfg.shape].l, customKeyShapes[cfg.shape].i,
 					customKeyImages[cfg.image].i, touch.scale, customKeyShapes[cfg.shape].d, buttonLayoutParams(touch)));
@@ -940,7 +944,15 @@ UI::ViewGroup *CreatePadLayout(float xres, float yres, bool *pause, bool showPau
 			root->Add(new PSPStick(stickBg, "Right analog stick", stickImage, ImageID("I_STICK"), 1, g_Config.touchRightAnalogStick.scale, buttonLayoutParams(g_Config.touchRightAnalogStick)));
 	}
 
+	// Sanitize custom button images, while adding them.
 	for (int i = 0; i < Config::CUSTOM_BUTTON_COUNT; i++) {
+		if (g_Config.CustomButton[i].shape >= ARRAY_SIZE(CustomKeyData::customKeyShapes)) {
+			g_Config.CustomButton[i].shape = 0;
+		}
+		if (g_Config.CustomButton[i].image >= ARRAY_SIZE(CustomKeyData::customKeyImages)) {
+			g_Config.CustomButton[i].image = 0;
+		}
+
 		char temp[64];
 		snprintf(temp, sizeof(temp), "Custom %d button", i + 1);
 		addCustomButton(g_Config.CustomButton[i], temp, g_Config.touchCustom[i]);

--- a/UI/GamepadEmu.h
+++ b/UI/GamepadEmu.h
@@ -252,6 +252,7 @@ namespace CustomKeyData {
 		{ ImageID("I_ARROW_UP"), 0.0f},
 		{ ImageID("I_ARROW_DOWN"), 0.0f},
 		{ ImageID("I_THREE_DOTS"), 0.0f},
+		{ ImageID("I_EMPTY"), 0.0f},
 	};
 
 	// Shape list

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -514,6 +514,8 @@ void ControlLayoutView::CreateViews() {
 	auto addDragCustomKey = [&](ConfigTouchPos &pos, const char *key, const ConfigCustomButton& cfg) {
 		DragDropButton *b = nullptr;
 		if (pos.show) {
+
+
 			b = new DragDropButton(pos, key, g_Config.iTouchButtonStyle == 0 ? customKeyShapes[cfg.shape].i : customKeyShapes[cfg.shape].l, customKeyImages[cfg.image].i, bounds);
 			b->FlipImageH(customKeyShapes[cfg.shape].f);
 			b->SetAngle(customKeyImages[cfg.image].r, customKeyShapes[cfg.shape].r);
@@ -523,6 +525,14 @@ void ControlLayoutView::CreateViews() {
 	};
 
 	for (int i = 0; i < Config::CUSTOM_BUTTON_COUNT; i++) {
+		// Similar to GamepadEmu, we sanitize the images for valid values.
+		if (g_Config.CustomButton[i].shape >= ARRAY_SIZE(CustomKeyData::customKeyShapes)) {
+			g_Config.CustomButton[i].shape = 0;
+		}
+		if (g_Config.CustomButton[i].image >= ARRAY_SIZE(CustomKeyData::customKeyImages)) {
+			g_Config.CustomButton[i].image = 0;
+		}
+
 		char temp[64];
 		snprintf(temp, sizeof(temp), "Custom %d button", i);
 		addDragCustomKey(g_Config.touchCustom[i], temp, g_Config.CustomButton[i]);


### PR DESCRIPTION
Feature request from Norchid on discord, this also made me find some out of bounds bugs in case of bad images in the config.

This means that there's a small chance of crashing if you use this new empty image and then downgrade PPSSPP, but that should be a pretty rare case.