### PR TITLE
SDL OpenGL: enable fallback to Vulkan

### DIFF
--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -1289,6 +1289,8 @@ bool IsProbablyInDownloadsFolder(const Path &filename) {
 		}
 		break;
 	}
+	default:
+		break;
 	}
 	return filename.FilePathContainsNoCase("download");
 }

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -528,7 +528,11 @@ static u32 sceAtracGetStreamDataInfo(int atracID, u32 writePtrAddr, u32 writable
 static u32 sceAtracReleaseAtracID(int atracID) {
 	int result = deleteAtrac(atracID);
 	if (result < 0) {
-		return hleLogError(Log::ME, result, "did not exist");
+		if (atracID >= 0) {
+			return hleLogError(Log::ME, result, "did not exist");
+		} else {
+			return hleLogWarning(Log::ME, result, "did not exist");
+		}
 	}
 	return hleLogSuccessInfoI(Log::ME, result);
 }

--- a/SDL/SDLGLGraphicsContext.cpp
+++ b/SDL/SDLGLGraphicsContext.cpp
@@ -299,6 +299,13 @@ void EGL_Close() {
 
 #endif // USING_EGL
 
+bool SDLGLGraphicsContext::InitFromRenderThread() {
+	bool retval = GraphicsContext::InitFromRenderThread();
+	// HACK: Ensure that the swap interval is set after context creation (needed for kmsdrm)
+	SDL_GL_SetSwapInterval(1);
+	return retval;
+}
+
 // Returns 0 on success.
 int SDLGLGraphicsContext::Init(SDL_Window *&window, int x, int y, int w, int h, int mode, std::string *error_message) {
 	struct GLVersionPair {
@@ -435,6 +442,7 @@ int SDLGLGraphicsContext::Init(SDL_Window *&window, int x, int y, int w, int h, 
 		INFO_LOG(Log::G3D, "SDL SwapInterval: %d", interval);
 		SDL_GL_SetSwapInterval(interval);
 	});
+
 	window_ = window;
 	return 0;
 }

--- a/SDL/SDLGLGraphicsContext.cpp
+++ b/SDL/SDLGLGraphicsContext.cpp
@@ -299,8 +299,8 @@ void EGL_Close() {
 
 #endif // USING_EGL
 
-bool SDLGLGraphicsContext::InitFromRenderThread() {
-	bool retval = GraphicsContext::InitFromRenderThread();
+bool SDLGLGraphicsContext::InitFromRenderThread(std::string *errorMessage) {
+	bool retval = GraphicsContext::InitFromRenderThread(errorMessage);
 	// HACK: Ensure that the swap interval is set after context creation (needed for kmsdrm)
 	SDL_GL_SetSwapInterval(1);
 	return retval;
@@ -375,6 +375,7 @@ int SDLGLGraphicsContext::Init(SDL_Window *&window, int x, int y, int w, int h, 
 
 		glContext = SDL_GL_CreateContext(window);
 		if (glContext == nullptr) {
+			// OK, now we really have tried everything.
 			NativeShutdown();
 			fprintf(stderr, "SDL_GL_CreateContext failed: %s\n", SDL_GetError());
 			SDL_Quit();

--- a/SDL/SDLGLGraphicsContext.h
+++ b/SDL/SDLGLGraphicsContext.h
@@ -7,6 +7,8 @@
 #include "SDL_syswm.h"
 #endif
 
+#include <string>
+
 #include "Common/GPU/OpenGL/GLRenderManager.h"
 #include "Common/GPU/OpenGL/GLCommon.h"
 #include "Common/GraphicsContext.h"
@@ -16,7 +18,7 @@ public:
 	// Returns 0 on success.
 	int Init(SDL_Window *&window, int x, int y, int w, int h, int mode, std::string *error_message);
 
-	bool InitFromRenderThread() override;
+	bool InitFromRenderThread(std::string *errorMessage) override;
 
 	void Shutdown() override {}
 	void ShutdownFromRenderThread() override;

--- a/SDL/SDLGLGraphicsContext.h
+++ b/SDL/SDLGLGraphicsContext.h
@@ -16,6 +16,8 @@ public:
 	// Returns 0 on success.
 	int Init(SDL_Window *&window, int x, int y, int w, int h, int mode, std::string *error_message);
 
+	bool InitFromRenderThread() override;
+
 	void Shutdown() override {}
 	void ShutdownFromRenderThread() override;
 

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -1402,9 +1402,6 @@ int main(int argc, char *argv[]) {
 	SDL_ShowCursor(SDL_DISABLE);
 #endif
 
-	// Ensure that the swap interval is set after context creation (needed for kmsdrm)
-	SDL_GL_SetSwapInterval(1);
-
 	// Avoid the IME popup when holding keys. This doesn't affect all versions of SDL.
 	// TODO: Enable it in text input fields
 	SDL_StopTextInput();


### PR DESCRIPTION
If OpenGL init fails, correctly insta-fallback to Vulkan.

Also some minor cleanup and logger fixes

Fixes #19454