### PR TITLE
OpenXR - Fix rendering when skip framebuffer effects is enabled

### DIFF
--- a/Common/VR/VRBase.h
+++ b/Common/VR/VRBase.h
@@ -66,6 +66,7 @@ typedef struct {
 	uint32_t TextureSwapChainIndex;
 	ovrSwapChain ColorSwapChain;
 	void* ColorSwapChainImage;
+	unsigned int* GLDepthBuffers;
 	unsigned int* GLFrameBuffers;
 	VkFramebuffer* VKFrameBuffers;
 	VkImageView* VKColorImages;


### PR DESCRIPTION
In https://github.com/hrydgard/ppsspp/pull/19416 I thought the depth buffer isn't needed.
As DamicsIta pointed in #ppsspp-vr-testing out that's not the case.

This PR fixes that. I validated the fix works on all supported headsets.