### PR TITLE
Rework of sum2012's Half Skip readback mode

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -250,7 +250,7 @@ public:
 	float fCwCheatScrollPosition;
 	float fGameListScrollPosition;
 	int iBloomHack; //0 = off, 1 = safe, 2 = balanced, 3 = aggressive
-	int iSkipGPUReadbackMode;  // 0 = off, 1 = skip, 2 = to texture
+	int iSkipGPUReadbackMode;  // 0 = off, 1 = skip, 2 = to texture, 3 = half skip
 	int iSplineBezierQuality; // 0 = low , 1 = Intermediate , 2 = High
 	bool bHardwareTessellation;
 	bool bShaderCache;  // Hidden ini-only setting, useful for debugging shader compile times.

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -250,7 +250,7 @@ public:
 	float fCwCheatScrollPosition;
 	float fGameListScrollPosition;
 	int iBloomHack; //0 = off, 1 = safe, 2 = balanced, 3 = aggressive
-	int iSkipGPUReadbackMode;  // 0 = off, 1 = skip, 2 = to texture, 3 = half skip
+	int iSkipGPUReadbackMode;  // 0 = off, 1 = skip, 2 = to texture, 3 = skip half
 	int iSplineBezierQuality; // 0 = low , 1 = Intermediate , 2 = High
 	bool bHardwareTessellation;
 	bool bShaderCache;  // Hidden ini-only setting, useful for debugging shader compile times.

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -207,6 +207,7 @@ enum class SkipGPUReadbackMode : int {
 	NO_SKIP,
 	SKIP,
 	COPY_TO_TEXTURE,
+	HALF_SKIP,
 };
 
 enum class RemoteISOShareType : int {

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -656,7 +656,10 @@ protected:
 
 	// Half-skip toggles.
 	bool halfSkipDownloadFramebufferOnSwitch_ = false;
+	bool halfSkipDownloadFramebufferOnCopy_ = false;
 	bool halfSkipShouldDownloadFramebufferDepth_ = false;
+
+	bool ShouldReadback(bool *toggle);
 };
 
 // Should probably live elsewhere.

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -525,7 +525,7 @@ protected:
 	void ResizeFramebufFBO(VirtualFramebuffer *vfb, int w, int h, bool force = false, bool skipCopy = false);
 
 	static bool ShouldDownloadFramebufferColor(const VirtualFramebuffer *vfb);
-	static bool ShouldDownloadFramebufferDepth(const VirtualFramebuffer *vfb);
+	bool ShouldDownloadFramebufferDepth(const VirtualFramebuffer *vfb);
 	void DownloadFramebufferOnSwitch(VirtualFramebuffer *vfb);
 
 	bool FindTransferFramebuffer(u32 basePtr, int stride, int x, int y, int w, int h, int bpp, bool destination, BlockTransferRect *rect);
@@ -653,6 +653,10 @@ protected:
 	// Depth readback helper state
 	u8 *convBuf_ = nullptr;
 	u32 convBufSize_ = 0;
+
+	// Half-skip toggles.
+	bool halfSkipDownloadFramebufferOnSwitch_ = false;
+	bool halfSkipShouldDownloadFramebufferDepth_ = false;
 };
 
 // Should probably live elsewhere.

--- a/Tools/langtool/README.md
+++ b/Tools/langtool/README.md
@@ -16,6 +16,11 @@ To see command line usage, type:
 cargo run -- --help
 ```
 
+Most common usage, to add a key:
+
+cargo run -- add-new-key Graphics "Skip half"
+
+
 To autoformat the code, use:
 
 ```bash

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -457,7 +457,7 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 	CheckBox *disableCulling = graphicsSettings->Add(new CheckBox(&g_Config.bDisableRangeCulling, gr->T("Disable culling")));
 	disableCulling->SetDisabledPtr(&g_Config.bSoftwareRendering);
 
-	static const char *skipGpuReadbackModes[] = { "No (default)", "Skip", "Copy to texture" };
+	static const char *skipGpuReadbackModes[] = { "No (default)", "Skip", "Copy to texture" , "Half skip"};
 
 	PopupMultiChoice *skipGPUReadbacks = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iSkipGPUReadbackMode, gr->T("Skip GPU Readbacks"), skipGpuReadbackModes, 0, ARRAY_SIZE(skipGpuReadbackModes), I18NCat::GRAPHICS, screenManager()));
 	skipGPUReadbacks->SetDisabledPtr(&g_Config.bSoftwareRendering);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -457,7 +457,7 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 	CheckBox *disableCulling = graphicsSettings->Add(new CheckBox(&g_Config.bDisableRangeCulling, gr->T("Disable culling")));
 	disableCulling->SetDisabledPtr(&g_Config.bSoftwareRendering);
 
-	static const char *skipGpuReadbackModes[] = { "No (default)", "Skip", "Copy to texture" , "Half skip"};
+	static const char *skipGpuReadbackModes[] = { "No (default)", "Skip", "Copy to texture" , "Skip half"};
 
 	PopupMultiChoice *skipGPUReadbacks = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iSkipGPUReadbackMode, gr->T("Skip GPU Readbacks"), skipGpuReadbackModes, 0, ARRAY_SIZE(skipGpuReadbackModes), I18NCat::GRAPHICS, screenManager()));
 	skipGPUReadbacks->SetDisabledPtr(&g_Config.bSoftwareRendering);

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -692,6 +692,7 @@ Screen Scaling Filter = ‎فلتر تكبير حجم الشاشة
 Show Debug Statistics = ‎أظهر معلومات التصحيح
 Show FPS Counter = ‎أظهر عداد الـFPS
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = ‎تصيير السوفت وير (slow)
 Software Skinning = ‎طلاء برمجي

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Screen scaling filter
 Show Debug Statistics = Show debug statistics
 Show FPS Counter = Show FPS counter
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Software rendering (experimental)
 Software Skinning = Software skinning

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Screen scaling filter
 Show Debug Statistics = Покажи debug инфо
 Show FPS Counter = Покажи брояча за кадри в сек.
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Software rendering (експериментално)
 Software Skinning = Software skinning

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Filtre d'escalat de pantalla
 Show Debug Statistics = Mostra estadístiques de depuració
 Show FPS Counter = Mostra comptador de FPS
 Skip GPU Readbacks = Saltar la lectura de GPU
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Renderitzat per programari
 Software Skinning = "Skinning" per programari

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Filtr změny velikosti obrazovky
 Show Debug Statistics = Zobrazit statistiky ladění
 Show FPS Counter = Zobrazit počítadlo
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Softwarové vykreslování (experimentální)
 Software Skinning = Textury aplikuje software

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Skærmskaleringsfilter
 Show Debug Statistics = Vis debugstatistik
 Show FPS Counter = Vis FPS
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Software rendering (eksperiment)
 Software Skinning = Software skinning

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Filter für Bildskalierung
 Show Debug Statistics = Debugstatistiken anzeigen
 Show FPS Counter = FPS anzeigen
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Software Renderer (experimentell)
 Software Skinning = Software Skinning

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Screen scaling filter
 Show Debug Statistics = Padenni Debugna
 Show FPS Counter = Padenni FPSna
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Pakeanni Software Tampilkan (dicoba-cobara)
 Software Skinning = Software skinning

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -708,6 +708,7 @@ Screen Scaling Filter = Screen scaling filter
 Show Debug Statistics = Show debug statistics
 Show FPS Counter = Show FPS counter
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Software rendering (slow, accurate)
 Software Skinning = Software skinning

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Filtro de escalado de pantalla
 Show Debug Statistics = Mostrar estadísticas de depuración
 Show FPS Counter = Mostrar contador de FPS
 Skip GPU Readbacks = Saltar la lectura de GPU
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Renderizado por software
 Software Skinning = "Skinning" por software

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Filtro de escalado de pantalla
 Show Debug Statistics = Mostrar estadísticas de depuración
 Show FPS Counter = Mostrar contador de FPS
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Renderizado por software (experimental)
 Software Skinning = Skineado por software

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = ‎فیلتر تغییر ساز صفحه
 Show Debug Statistics = ‎نمایش اطلاعات دیباگ
 Show FPS Counter = ‎نمایش شمارنده فریم بر ثانیه
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = ‎(رندر نرم افزاری (آزمایشی
 Software Skinning = Software skinning

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Näytön skaalauksen suodatin
 Show Debug Statistics = Näytä virheenkorjaustilastot
 Show FPS Counter = Näytä kuvalaskuri (FPS)
 Skip GPU Readbacks = Ohita GPU-lukemat
+Skip half = Skip half
 Smart 2D texture filtering = Älykäs 2D-tekstuurien suodatus
 Software Rendering = Ohjelmistopohjainen renderointi (kokeellinen)
 Software Skinning = Ohjelmistopohjainen muokkaus (skinning)

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Filtre de mise à l'échelle de l'écran
 Show Debug Statistics = Montrer les statistiques de débogage
 Show FPS Counter = Montrer les compteurs
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Rendu logiciel (expérimental)
 Software Skinning = Enveloppe logicielle

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Filtro de escalado de pantalla
 Show Debug Statistics = Mostrar estadísticas de depuración
 Show FPS Counter = Mostrar contador de FPS
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Renderizado por software (beta)
 Software Skinning = «Skinning» por software

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Φίλτο κλιμάκωσης οθόνης
 Show Debug Statistics = Εμφάνιση στατιστικών αποσφαλμάτωσης
 Show FPS Counter = Εμφάνιση μετρητή FPS
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Απεικόνιση Λογισμικού (πειραματικό)
 Software Skinning = Εκδορά Λογισμικού

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Screen scaling filter
 Show Debug Statistics = הצג סטטיסטיקת באגים
 Show FPS Counter = הצג מונה
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = עיבוד תוכנה (ניסיוני)
 Software Skinning = Software skinning

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Screen scaling filter
 Show Debug Statistics = םיגאב תקיטסיטטס גצה
 Show FPS Counter = הנומ גצה
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = )ינויסינ( הנכות דוביע
 Software Skinning = Software skinning

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Mjerenje filtriranje zaslona
 Show Debug Statistics = Pokaži statistike otklanjanja grešaka
 Show FPS Counter = Pokaži FPS counter
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Žbukanje softvera (sporo)
 Software Skinning = Skiniranje softvera

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Képernyő skálázási szűrő
 Show Debug Statistics = Hibakereső statisztikák mutatása
 Show FPS Counter = FPS számláló mutatása
 Skip GPU Readbacks = GPU visszaolvasások átugrása
+Skip half = Skip half
 Smart 2D texture filtering = Okos 2D textúra szűrés
 Software Rendering = Szoftveres renderelés (lassú)
 Software Skinning = Szoftveres skinning

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -685,6 +685,7 @@ Show Debug Statistics = Tampilkan statistik awakutu
 Show FPS Counter = Tampilkan penghitung FPS
 Skip GPU Readbacks = Skip GPU Readbacks
 Smart 2D texture filtering = Penyaringan tekstur 2D yang cerdas
+Skip half = Skip half
 Software Rendering = Pelukisan perangkat lunak (eksperimental)
 Software Skinning = Pengkulitan perangkat lunak
 SoftwareSkinning Tip = Menggabungkan model berkulit pada CPU, lebih cepat di kebanyakan permainan

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -685,6 +685,7 @@ Screen Scaling Filter = Filtro Scalatura Schermo
 Show Debug Statistics = Mostra Statistiche Debug
 Show FPS Counter = Mostra FPS
 Skip GPU Readbacks = Salta le letture della GPU
+Skip half = Skip half
 Smart 2D texture filtering = Filtro texture 2D intelligente
 Software Rendering = Rendering tramite Software (sperimentale)
 Software Skinning = Screpolatura software

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = 画像スケーリングのフィルタ
 Show Debug Statistics = デバッグ情報を表示する
 Show FPS Counter = FPSを表示する
 Skip GPU Readbacks = GPUリードバックのスキップ
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2Dテクスチャフィルタリング
 Software Rendering = ソフトウェアレンダリング (実験的)
 Software Skinning = ソフトウェアスキニング

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Layar njongko Filter
 Show Debug Statistics = Tampilno statistik debug
 Show FPS Counter = Tampilno penghitung FPS
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Software rendering (jajalan)
 Software Skinning = Software skinning

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = 화면 크기 조정 필터
 Show Debug Statistics = 디버그 통계 표시
 Show FPS Counter = FPS 카운터 표시
 Skip GPU Readbacks = GPU 다시 읽기 건너뛰기
+Skip half = Skip half
 Smart 2D texture filtering = 스마트 2D 텍스처 필터링
 Software Rendering = 소프트웨어 렌더링 (느림)
 Software Skinning = 소프트웨어 스키닝

--- a/assets/lang/ku_SO.ini
+++ b/assets/lang/ku_SO.ini
@@ -698,6 +698,7 @@ Screen Scaling Filter = Screen scaling filter
 Show Debug Statistics = Show debug statistics
 Show FPS Counter = Show FPS counter
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Software rendering (slow, accurate)
 Software Skinning = Software skinning

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = ໂຕຕອງປັບສເກລໜ້າຈໍ
 Show Debug Statistics = ສະແດງຄ່າທາງສະຖິຕິການແກ້ໄຂຈຸດບົກພ່ອງ
 Show FPS Counter = ສະແດງຄ່າເຟຣມເຣດ ແລະ ຄວາມໄວ/ວິນາທີ
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = ໃຊ້ຊອບແວຣ໌ສະແດງຜົນ (ລຸ້ນທົດລອງ)
 Software Skinning = ຊ໋ອບແວຣ໌ສກິນນິງ

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Screen scaling filter
 Show Debug Statistics = Rodyti testinio režimo statistikas
 Show FPS Counter = Rodyti kadrų per sekundę rodmenis
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Programinės įrangos rodymas(ekspermentalus)
 Software Skinning = Programinės įrangos "nulupimas"

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Screen scaling filter
 Show Debug Statistics = Papar statistik pepijat
 Show FPS Counter = Papar penghitung FPS
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Render perisian (eksperimen)
 Software Skinning = Pembalutan Perisian

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Beeldschalingsfilter
 Show Debug Statistics = Foutopsporingsstatistieken weergeven
 Show FPS Counter = FPS-teller weergeven
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Renderen via software (experimenteel)
 Software Skinning = Skinning via software

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Screen scaling filter
 Show Debug Statistics = Vis debugstatistik
 Show FPS Counter = Vis FPS-teller
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Programvare gjengivelse (eksperiment)
 Software Skinning = Software skinning

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -688,6 +688,7 @@ Screen Scaling Filter = Filtrowanie skalowania ekranu
 Show Debug Statistics = Pokaż statystyki debugowania
 Show FPS Counter = Pokaż licznik FPS
 Skip GPU Readbacks = Pomiń odczyty zwrotne GPU
+Skip half = Skip half
 Smart 2D texture filtering = Inteligentne filtrowanie tekstur 2D
 Software Rendering = Renderowanie programowe (wolne)
 Software Skinning = Programowy skinning

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -708,6 +708,7 @@ Screen Scaling Filter = Filtro do dimensionamento da tela
 Show Debug Statistics = Mostrar estatísticas do debug
 Show FPS Counter = Mostrar contador dos FPS
 Skip GPU Readbacks = Ignorar leituras da GPU
+Skip half = Skip half
 Smart 2D texture filtering = Filtragem inteligente das texturas 2D
 Software Rendering = Renderização por software (lento)
 Software Skinning = Skinning via software

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -708,6 +708,7 @@ Screen Scaling Filter = Filtro do dimensionamento da tela
 Show Debug Statistics = Mostrar estatísticas de Debug
 Show FPS Counter = Mostrar contador de FPS
 Skip GPU Readbacks = Saltar Readbacks da GPU
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Renderização por software (lento)
 Software Skinning = Skinning por software

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -685,6 +685,7 @@ Screen Scaling Filter = Filtrul de scalare al ecranului
 Show Debug Statistics = Arată statistici de depanare
 Show FPS Counter = Arată FPS
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Afișare cu sofware (experimental)
 Software Skinning = Skinning cu software

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Фильтр масштабирования экрана
 Show Debug Statistics = Показывать отладочную информацию
 Show FPS Counter = Показывать счетчик FPS
 Skip GPU Readbacks = Пропускать чтение данных ГП
+Skip half = Skip half
 Smart 2D texture filtering = Умная фильтрация 2D-текстур
 Software Rendering = Программный рендеринг (медленно)
 Software Skinning = Программная заливка

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -685,6 +685,7 @@ Screen Scaling Filter = Skärmskalningsfilter
 Show Debug Statistics = Visa debugstatistik
 Show FPS Counter = Visa FPS-räknare
 Skip GPU Readbacks = Skippa dataläsningar från GPU:n
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Mjukvarurendering (långsam men ofta mer korrekt)
 Software Skinning = Software Skinning

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -685,6 +685,7 @@ Screen Scaling Filter = Screen Scaling Filter
 Show Debug Statistics = Ipakita ang debug statistics
 Show FPS Counter = Ipakita ang FPS
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Software Rendering (Expiremental)
 Software Skinning = Software skinning

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -700,6 +700,7 @@ Show Speed = แสดงค่าความเร็ว
 Skip = ข้าม
 Skip Buffer Effects = ข้ามการใช้บัฟเฟอร์เอฟเฟ็คท์ (ปิดบัฟเฟอร์)
 Skip GPU Readbacks = ข้ามการอ่านข้อมูลส่งกลับไปยัง GPU
+Skip half = Skip half
 Smart 2D texture filtering = ตัวกรองเท็คเจอร์ประเภท 2D แบบชาญฉลาด
 Software Rendering = ใช้ซอฟต์แวร์ในการแสดงผล (ช้า แต่แม่นยำ)
 Software Skinning = ซอฟต์แวร์ สกินนิ่ง

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -686,6 +686,7 @@ Screen Scaling Filter = Ekran ölçekleme filtresi
 Show Debug Statistics = Hata ayıklama istatistiklerini göster
 Show FPS Counter = FPS sayacını göster
 Skip GPU Readbacks = GPU Okumalarını Atla
+Skip half = Skip half
 Smart 2D texture filtering = Akıllı 2D doku filtreleme
 Software Rendering = Yazılımsal işleme (Deneysel)
 Software Skinning = Yazılımsal Kaplama

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Фільтр обчислення екрану
 Show Debug Statistics = Відоброжати зневадження
 Show FPS Counter = Показати FPS
 Skip GPU Readbacks = Пропустити зворотні зчитування GPU
+Skip half = Skip half
 Smart 2D texture filtering = Розумна 2D фільтрація текстур
 Software Rendering = Програмний рендеринг (експериментально)
 Software Skinning = Програмна заливка

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = Bộ lọc họa tiết rộng
 Show Debug Statistics = Hiện thông số debug
 Show FPS Counter = Hiện thông số FPS
 Skip GPU Readbacks = Skip GPU Readbacks
+Skip half = Skip half
 Smart 2D texture filtering = Smart 2D texture filtering
 Software Rendering = Dựng hình bằng phần mềm
 Software Skinning = phủ lớp bằng phần mềm

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = 画面缩放算法
 Show Debug Statistics = 显示调试信息
 Show FPS Counter = 显示帧率
 Skip GPU Readbacks = 跳过GPU块传输
+Skip half = Skip half
 Smart 2D texture filtering = 自动保留2D纹理像素风格
 Software Rendering = 软件渲染 (慢)
 Software Skinning = 软件蒙皮

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -684,6 +684,7 @@ Screen Scaling Filter = 螢幕縮放濾鏡
 Show Debug Statistics = 顯示偵錯統計資料
 Show FPS Counter = 顯示 FPS 計數器
 Skip GPU Readbacks = 跳過 GPU 讀回
+Skip half = Skip half
 Smart 2D texture filtering = 智慧 2D 紋理過濾
 Software Rendering = 軟體轉譯 (慢)
 Software Skinning = 軟體除皮


### PR DESCRIPTION
Replaces #18807

Strangely, this doesn't seem to halve the readbacks in Motorstorm (they happen through the memcpy mechanism). Haven't yet determined exactly why.