### PR TITLE
Vulkan loader: Make extension loading take into account that the instance and device API versions can be different

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -142,11 +142,11 @@ public:
 
 	std::string GetInfoString(InfoField info) const override {
 		switch (info) {
-		case APIVERSION: return "Direct3D 11";
-		case VENDORSTRING: return adapterDesc_;
-		case VENDOR: return "";
-		case DRIVER: return "-";
-		case SHADELANGVERSION:
+		case InfoField::APIVERSION: return "Direct3D 11";
+		case InfoField::VENDORSTRING: return adapterDesc_;
+		case InfoField::VENDOR: return "";
+		case InfoField::DRIVER: return "-";
+		case InfoField::SHADELANGVERSION:
 			switch (featureLevel_) {
 			case D3D_FEATURE_LEVEL_9_1: return "Feature Level 9.1"; break;
 			case D3D_FEATURE_LEVEL_9_2: return "Feature Level 9.2"; break;
@@ -159,7 +159,7 @@ public:
 			case D3D_FEATURE_LEVEL_12_1: return "Feature Level 12.1"; break;
 			}
 			return "Unknown feature level";
-		case APINAME: return "Direct3D 11";
+		case InfoField::APINAME: return "Direct3D 11";
 		default: return "?";
 		}
 	}

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -592,12 +592,12 @@ public:
 
 	std::string GetInfoString(InfoField info) const override {
 		switch (info) {
-		case APIVERSION: return "DirectX 9.0";
-		case VENDORSTRING: return identifier_.Description;
-		case VENDOR: return "";
-		case DRIVER: return identifier_.Driver;  // eh, sort of
-		case SHADELANGVERSION: return shadeLangVersion_;
-		case APINAME: return "Direct3D 9";
+		case InfoField::APIVERSION: return "DirectX 9.0";
+		case InfoField::VENDORSTRING: return identifier_.Description;
+		case InfoField::VENDOR: return "";
+		case InfoField::DRIVER: return identifier_.Driver;  // eh, sort of
+		case InfoField::SHADELANGVERSION: return shadeLangVersion_;
+		case InfoField::APINAME: return "Direct3D 9";
 		default: return "?";
 		}
 	}

--- a/Common/GPU/OpenGL/thin3d_gl.cpp
+++ b/Common/GPU/OpenGL/thin3d_gl.cpp
@@ -442,34 +442,35 @@ public:
 	std::string GetInfoString(InfoField info) const override {
 		// TODO: Make these actually query the right information
 		switch (info) {
-			case APINAME:
-				if (gl_extensions.IsGLES) {
-					return "OpenGL ES";
-				} else {
-					return "OpenGL";
-				}
-			case VENDORSTRING: return renderManager_.GetGLString(GL_VENDOR);
-			case VENDOR:
-				switch (caps_.vendor) {
-				case GPUVendor::VENDOR_AMD: return "VENDOR_AMD";
-				case GPUVendor::VENDOR_IMGTEC: return "VENDOR_POWERVR";
-				case GPUVendor::VENDOR_NVIDIA: return "VENDOR_NVIDIA";
-				case GPUVendor::VENDOR_INTEL: return "VENDOR_INTEL";
-				case GPUVendor::VENDOR_QUALCOMM: return "VENDOR_ADRENO";
-				case GPUVendor::VENDOR_ARM: return "VENDOR_ARM";
-				case GPUVendor::VENDOR_BROADCOM: return "VENDOR_BROADCOM";
-				case GPUVendor::VENDOR_VIVANTE: return "VENDOR_VIVANTE";
-				case GPUVendor::VENDOR_APPLE: return "VENDOR_APPLE";
-				case GPUVendor::VENDOR_MESA: return "VENDOR_MESA";
-				case GPUVendor::VENDOR_UNKNOWN:
-				default:
-					return "VENDOR_UNKNOWN";
-				}
-				break;
-			case DRIVER: return renderManager_.GetGLString(GL_RENDERER);
-			case SHADELANGVERSION: return renderManager_.GetGLString(GL_SHADING_LANGUAGE_VERSION);
-			case APIVERSION: return renderManager_.GetGLString(GL_VERSION);
-			default: return "?";
+		case InfoField::APINAME:
+			if (gl_extensions.IsGLES) {
+				return "OpenGL ES";
+			} else {
+				return "OpenGL";
+			}
+		case InfoField::VENDORSTRING:
+			return renderManager_.GetGLString(GL_VENDOR);
+		case InfoField::VENDOR:
+			switch (caps_.vendor) {
+			case GPUVendor::VENDOR_AMD: return "VENDOR_AMD";
+			case GPUVendor::VENDOR_IMGTEC: return "VENDOR_POWERVR";
+			case GPUVendor::VENDOR_NVIDIA: return "VENDOR_NVIDIA";
+			case GPUVendor::VENDOR_INTEL: return "VENDOR_INTEL";
+			case GPUVendor::VENDOR_QUALCOMM: return "VENDOR_ADRENO";
+			case GPUVendor::VENDOR_ARM: return "VENDOR_ARM";
+			case GPUVendor::VENDOR_BROADCOM: return "VENDOR_BROADCOM";
+			case GPUVendor::VENDOR_VIVANTE: return "VENDOR_VIVANTE";
+			case GPUVendor::VENDOR_APPLE: return "VENDOR_APPLE";
+			case GPUVendor::VENDOR_MESA: return "VENDOR_MESA";
+			case GPUVendor::VENDOR_UNKNOWN:
+			default:
+				return "VENDOR_UNKNOWN";
+			}
+			break;
+		case InfoField::DRIVER: return renderManager_.GetGLString(GL_RENDERER);
+		case InfoField::SHADELANGVERSION: return renderManager_.GetGLString(GL_SHADING_LANGUAGE_VERSION);
+		case InfoField::APIVERSION: return renderManager_.GetGLString(GL_VERSION);
+		default: return "?";
 		}
 	}
 

--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -1863,6 +1863,7 @@ bool IsHashMaliDriverVersion(const VkPhysicalDeviceProperties &props) {
 		return true;
 	if (branch > 100 || major > 100)
 		return true;
+	// Can (in theory) have false negatives!
 	return false;
 }
 
@@ -1891,6 +1892,10 @@ std::string FormatDriverVersion(const VkPhysicalDeviceProperties &props) {
 	uint32_t minor = VK_VERSION_MINOR(props.driverVersion);
 	uint32_t branch = VK_VERSION_PATCH(props.driverVersion);
 	return StringFromFormat("%d.%d.%d (%08x)", major, minor, branch, props.driverVersion);
+}
+
+std::string FormatAPIVersion(u32 version) {
+	return StringFromFormat("%d.%d.%d", VK_API_VERSION_MAJOR(version), VK_API_VERSION_MINOR(version), VK_API_VERSION_PATCH(version));
 }
 
 // Mainly just the formats seen on gpuinfo.org for swapchains, as this function is only used for listing

--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -102,11 +102,13 @@ VkResult VulkanContext::CreateInstance(const CreateInfo &info) {
 
 	// Check which Vulkan version we should request.
 	// Our code is fine with any version from 1.0 to 1.2, we don't know about higher versions.
-	vulkanApiVersion_ = VK_API_VERSION_1_0;
+	vulkanInstanceApiVersion_ = VK_API_VERSION_1_0;
 	if (vkEnumerateInstanceVersion) {
-		vkEnumerateInstanceVersion(&vulkanApiVersion_);
-		vulkanApiVersion_ &= 0xFFFFF000;  // Remove patch version.
-		vulkanApiVersion_ = std::min(VK_API_VERSION_1_3, vulkanApiVersion_);
+		vkEnumerateInstanceVersion(&vulkanInstanceApiVersion_);
+		vulkanInstanceApiVersion_ &= 0xFFFFF000;  // Remove patch version.
+		vulkanInstanceApiVersion_ = std::min(VK_API_VERSION_1_3, vulkanInstanceApiVersion_);
+		std::string versionString = FormatAPIVersion(vulkanInstanceApiVersion_);
+		INFO_LOG(Log::G3D, "Detected Vulkan API version: %s", versionString.c_str());
 	}
 
 	instance_layer_names_.clear();
@@ -201,7 +203,7 @@ VkResult VulkanContext::CreateInstance(const CreateInfo &info) {
 	app_info.pEngineName = info.app_name;
 	// Let's increment this when we make major engine/context changes.
 	app_info.engineVersion = 2;
-	app_info.apiVersion = vulkanApiVersion_;
+	app_info.apiVersion = vulkanInstanceApiVersion_;
 
 	VkInstanceCreateInfo inst_info{ VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO };
 	inst_info.flags = 0;
@@ -240,7 +242,7 @@ VkResult VulkanContext::CreateInstance(const CreateInfo &info) {
 		return res;
 	}
 
-	VulkanLoadInstanceFunctions(instance_, extensionsLookup_, vulkanApiVersion_);
+	VulkanLoadInstanceFunctions(instance_, extensionsLookup_, vulkanInstanceApiVersion_);
 	if (!CheckLayers(instance_layer_properties_, instance_layer_names_)) {
 		WARN_LOG(Log::G3D, "CheckLayers for instance failed");
 		// init_error_ = "Failed to validate instance layers";
@@ -560,7 +562,7 @@ int VulkanContext::GetBestPhysicalDevice() {
 }
 
 bool VulkanContext::EnableDeviceExtension(const char *extension, uint32_t coreVersion) {
-	if (coreVersion != 0 && vulkanApiVersion_ >= coreVersion) {
+	if (coreVersion != 0 && vulkanDeviceApiVersion_ >= coreVersion) {
 		return true;
 	}
 	for (auto &iter : device_extension_properties_) {
@@ -573,7 +575,7 @@ bool VulkanContext::EnableDeviceExtension(const char *extension, uint32_t coreVe
 }
 
 bool VulkanContext::EnableInstanceExtension(const char *extension, uint32_t coreVersion) {
-	if (coreVersion != 0 && vulkanApiVersion_ >= coreVersion) {
+	if (coreVersion != 0 && vulkanInstanceApiVersion_ >= coreVersion) {
 		return true;
 	}
 	for (auto &iter : instance_extension_properties_) {
@@ -588,6 +590,8 @@ bool VulkanContext::EnableInstanceExtension(const char *extension, uint32_t core
 VkResult VulkanContext::CreateDevice(int physical_device) {
 	physical_device_ = physical_device;
 	INFO_LOG(Log::G3D, "Chose physical device %d: %s", physical_device, physicalDeviceProperties_[physical_device].properties.deviceName);
+
+	vulkanDeviceApiVersion_ = physicalDeviceProperties_[physical_device].properties.apiVersion;
 
 	GetDeviceLayerProperties();
 	if (!CheckLayers(device_layer_properties_, device_layer_names_)) {
@@ -668,6 +672,7 @@ VkResult VulkanContext::CreateDevice(int physical_device) {
 	extensionsLookup_.KHR_maintenance1 = EnableDeviceExtension(VK_KHR_MAINTENANCE1_EXTENSION_NAME, VK_API_VERSION_1_1);
 	extensionsLookup_.KHR_maintenance2 = EnableDeviceExtension(VK_KHR_MAINTENANCE2_EXTENSION_NAME, VK_API_VERSION_1_1);
 	extensionsLookup_.KHR_maintenance3 = EnableDeviceExtension(VK_KHR_MAINTENANCE3_EXTENSION_NAME, VK_API_VERSION_1_1);
+	extensionsLookup_.KHR_maintenance4 = EnableDeviceExtension("VK_KHR_maintenance4", VK_API_VERSION_1_3);
 	extensionsLookup_.KHR_multiview = EnableDeviceExtension(VK_KHR_MULTIVIEW_EXTENSION_NAME, VK_API_VERSION_1_1);
 
 	if (EnableDeviceExtension(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME, VK_API_VERSION_1_1)) {
@@ -796,9 +801,9 @@ VkResult VulkanContext::CreateDevice(int physical_device) {
 	VkResult res = vkCreateDevice(physical_devices_[physical_device_], &device_info, nullptr, &device_);
 	if (res != VK_SUCCESS) {
 		init_error_ = "Unable to create Vulkan device";
-		ERROR_LOG(Log::G3D, "Unable to create Vulkan device");
+		ERROR_LOG(Log::G3D, "%s", init_error_.c_str());
 	} else {
-		VulkanLoadDeviceFunctions(device_, extensionsLookup_, vulkanApiVersion_);
+		VulkanLoadDeviceFunctions(device_, extensionsLookup_, vulkanDeviceApiVersion_);
 	}
 	INFO_LOG(Log::G3D, "Vulkan Device created: %s", physicalDeviceProperties_[physical_device_].properties.deviceName);
 
@@ -806,7 +811,7 @@ VkResult VulkanContext::CreateDevice(int physical_device) {
 	VulkanSetAvailable(true);
 
 	VmaAllocatorCreateInfo allocatorInfo = {};
-	allocatorInfo.vulkanApiVersion = vulkanApiVersion_;
+	allocatorInfo.vulkanApiVersion = std::min(vulkanDeviceApiVersion_, vulkanInstanceApiVersion_);
 	allocatorInfo.physicalDevice = physical_devices_[physical_device_];
 	allocatorInfo.device = device_;
 	allocatorInfo.instance = instance_;

--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -528,6 +528,7 @@ const char *VulkanPresentModeToString(VkPresentModeKHR presentMode);
 const char *VulkanImageLayoutToString(VkImageLayout imageLayout);
 
 std::string FormatDriverVersion(const VkPhysicalDeviceProperties &props);
+std::string FormatAPIVersion(u32 version);
 
 // Simple heuristic.
 bool IsHashMaliDriverVersion(const VkPhysicalDeviceProperties &props);

--- a/Common/GPU/Vulkan/VulkanContext.h
+++ b/Common/GPU/Vulkan/VulkanContext.h
@@ -360,6 +360,7 @@ public:
 		// out of MAX_INFLIGHT_FRAMES.
 		return inflightFrames_;
 	}
+
 	// Don't call while a frame is in progress.
 	void UpdateInflightFrames(int n);
 
@@ -414,6 +415,14 @@ public:
 		return frame_[curFrame_].deleteList.GetLastDeleteCount();
 	}
 
+	u32 InstanceApiVersion() const {
+		return vulkanInstanceApiVersion_;
+	}
+
+	u32 DeviceApiVersion() const {
+		return vulkanDeviceApiVersion_;
+	}
+
 private:
 	bool ChooseQueue();
 
@@ -441,7 +450,8 @@ private:
 	VkDevice device_ = VK_NULL_HANDLE;
 	VkQueue gfx_queue_ = VK_NULL_HANDLE;
 	VkSurfaceKHR surface_ = VK_NULL_HANDLE;
-	u32 vulkanApiVersion_ = 0;
+	u32 vulkanInstanceApiVersion_ = 0;
+	u32 vulkanDeviceApiVersion_ = 0;
 
 	std::string init_error_;
 	std::vector<const char *> instance_layer_names_;

--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -265,7 +265,7 @@ bool g_vulkanAvailabilityChecked = false;
 bool g_vulkanMayBeAvailable = false;
 
 static PFN_vkVoidFunction LoadInstanceFunc(VkInstance instance, const char *name) {
-    PFN_vkVoidFunction funcPtr = vkGetInstanceProcAddr(instance, name);
+	PFN_vkVoidFunction funcPtr = vkGetInstanceProcAddr(instance, name);
 	if (!funcPtr) {
 		INFO_LOG(Log::G3D, "Missing function (instance): %s", name);
 	}
@@ -273,9 +273,9 @@ static PFN_vkVoidFunction LoadInstanceFunc(VkInstance instance, const char *name
 }
 #define LOAD_INSTANCE_FUNC(instance, x) x = (PFN_ ## x)LoadInstanceFunc(instance, #x);
 
-static PFN_vkVoidFunction LoadInstanceFuncCore(VkInstance instance, const char *name, const char *extName, u32 min_core, u32 vulkanApiVersion) {
-    PFN_vkVoidFunction funcPtr = vkGetInstanceProcAddr(instance, vulkanApiVersion >= min_core ? name : extName);
-	if (vulkanApiVersion >= min_core && !funcPtr) {
+static PFN_vkVoidFunction LoadInstanceFuncCore(VkInstance instance, const char *name, const char *extName, u32 min_core, u32 vulkanInstanceApiVersion) {
+	PFN_vkVoidFunction funcPtr = vkGetInstanceProcAddr(instance, vulkanInstanceApiVersion >= min_core ? name : extName);
+	if (vulkanInstanceApiVersion >= min_core && !funcPtr) {
 		// Try the ext name.
 		funcPtr = vkGetInstanceProcAddr(instance, extName);
 	}
@@ -285,10 +285,10 @@ static PFN_vkVoidFunction LoadInstanceFuncCore(VkInstance instance, const char *
 	return funcPtr;
 }
 #define LOAD_INSTANCE_FUNC_CORE(instance, x, ext_x, min_core) \
-    x = (PFN_ ## x)LoadInstanceFuncCore(instance, #x, #ext_x, min_core, vulkanApiVersion);
+    x = (PFN_ ## x)LoadInstanceFuncCore(instance, #x, #ext_x, min_core, vulkanInstanceApiVersion);
 
 static PFN_vkVoidFunction LoadDeviceFunc(VkDevice device, const char *name) {
-    PFN_vkVoidFunction funcPtr = vkGetDeviceProcAddr(device, name);
+	PFN_vkVoidFunction funcPtr = vkGetDeviceProcAddr(device, name);
 	if (!funcPtr) {
 		INFO_LOG(Log::G3D, "Missing function (device): %s", name);
 	}
@@ -296,9 +296,9 @@ static PFN_vkVoidFunction LoadDeviceFunc(VkDevice device, const char *name) {
 }
 #define LOAD_DEVICE_FUNC(device, x) x = (PFN_ ## x)LoadDeviceFunc(device, #x);
 
-static PFN_vkVoidFunction LoadDeviceFuncCore(VkDevice device, const char *name, const char *extName, u32 min_core, u32 vulkanApiVersion) {
-    PFN_vkVoidFunction funcPtr = vkGetDeviceProcAddr(device, vulkanApiVersion >= min_core ? name : extName);
-	if (vulkanApiVersion >= min_core && !funcPtr) {
+static PFN_vkVoidFunction LoadDeviceFuncCore(VkDevice device, const char *name, const char *extName, u32 min_core, u32 vulkanDeviceApiVersion) {
+	PFN_vkVoidFunction funcPtr = vkGetDeviceProcAddr(device, vulkanDeviceApiVersion >= min_core ? name : extName);
+	if (vulkanDeviceApiVersion >= min_core && !funcPtr) {
 		funcPtr = vkGetDeviceProcAddr(device, extName);
 	}
 	if (!funcPtr) {
@@ -307,7 +307,7 @@ static PFN_vkVoidFunction LoadDeviceFuncCore(VkDevice device, const char *name, 
 	return funcPtr;
 }
 #define LOAD_DEVICE_FUNC_CORE(device, x, ext_x, min_core) \
-    x = (PFN_ ## x)LoadDeviceFuncCore(device, #x, #ext_x, min_core, vulkanApiVersion);
+    x = (PFN_ ## x)LoadDeviceFuncCore(device, #x, #ext_x, min_core, vulkanDeviceApiVersion);
 
 #define LOAD_GLOBAL_FUNC(x) x = (PFN_ ## x)dlsym(vulkanLibrary, #x); if (!x) {INFO_LOG(Log::G3D,"Missing (global): %s", #x);}
 #define LOAD_GLOBAL_FUNC_LOCAL(lib, x) (PFN_ ## x)dlsym(lib, #x);
@@ -645,8 +645,9 @@ bool VulkanLoad(std::string *errorStr) {
 #endif
 }
 
-void VulkanLoadInstanceFunctions(VkInstance instance, const VulkanExtensions &enabledExtensions, uint32_t vulkanApiVersion) {
+void VulkanLoadInstanceFunctions(VkInstance instance, const VulkanExtensions &enabledExtensions, uint32_t vulkanInstanceApiVersion) {
 #if !PPSSPP_PLATFORM(IOS_APP_STORE)
+	INFO_LOG(Log::G3D, "Loading Vulkan instance functions. Instance API version: %08x (%d.%d.%d)", vulkanInstanceApiVersion, VK_API_VERSION_MAJOR(vulkanInstanceApiVersion), VK_API_VERSION_MINOR(vulkanInstanceApiVersion), VK_API_VERSION_PATCH(vulkanInstanceApiVersion));
 	// OK, let's use the above functions to get the rest.
 	LOAD_INSTANCE_FUNC(instance, vkDestroyInstance);
 	LOAD_INSTANCE_FUNC(instance, vkEnumeratePhysicalDevices);
@@ -720,9 +721,9 @@ void VulkanLoadInstanceFunctions(VkInstance instance, const VulkanExtensions &en
 // On some implementations, loading functions (that have Device as their first parameter) via vkGetDeviceProcAddr may
 // increase performance - but then these function pointers will only work on that specific device. Thus, this loader is not very
 // good for multi-device - not likely we'll ever try that anyway though.
-void VulkanLoadDeviceFunctions(VkDevice device, const VulkanExtensions &enabledExtensions, uint32_t vulkanApiVersion) {
+void VulkanLoadDeviceFunctions(VkDevice device, const VulkanExtensions &enabledExtensions, uint32_t vulkanDeviceApiVersion) {
 #if !PPSSPP_PLATFORM(IOS_APP_STORE)
-	INFO_LOG(Log::G3D, "Loading Vulkan device functions. Vulkan API version: %08x (%d.%d)", vulkanApiVersion, VK_VERSION_MAJOR(vulkanApiVersion), VK_VERSION_MINOR(vulkanApiVersion));
+	INFO_LOG(Log::G3D, "Loading Vulkan device functions. Device API version: %08x (%d.%d.%d)", vulkanDeviceApiVersion, VK_API_VERSION_MAJOR(vulkanDeviceApiVersion), VK_API_VERSION_MINOR(vulkanDeviceApiVersion), VK_API_VERSION_PATCH(vulkanDeviceApiVersion));
 
 	LOAD_DEVICE_FUNC(device, vkQueueSubmit);
 	LOAD_DEVICE_FUNC(device, vkQueueWaitIdle);
@@ -739,10 +740,8 @@ void VulkanLoadDeviceFunctions(VkDevice device, const VulkanExtensions &enabledE
 	LOAD_DEVICE_FUNC(device, vkBindImageMemory2);
 	LOAD_DEVICE_FUNC(device, vkGetBufferMemoryRequirements);
 	LOAD_DEVICE_FUNC(device, vkGetBufferMemoryRequirements2);
-	LOAD_DEVICE_FUNC(device, vkGetDeviceBufferMemoryRequirements);
 	LOAD_DEVICE_FUNC(device, vkGetImageMemoryRequirements);
 	LOAD_DEVICE_FUNC(device, vkGetImageMemoryRequirements2);
-	LOAD_DEVICE_FUNC(device, vkGetDeviceImageMemoryRequirements);
 	LOAD_DEVICE_FUNC(device, vkCreateFence);
 	LOAD_DEVICE_FUNC(device, vkDestroyFence);
 	LOAD_DEVICE_FUNC(device, vkResetFences);
@@ -859,6 +858,10 @@ void VulkanLoadDeviceFunctions(VkDevice device, const VulkanExtensions &enabledE
 	}
 	if (enabledExtensions.KHR_create_renderpass2) {
 		LOAD_DEVICE_FUNC_CORE(device, vkCreateRenderPass2, vkCreateRenderPass2KHR, VK_API_VERSION_1_2);
+	}
+	if (enabledExtensions.KHR_maintenance4) {
+		LOAD_DEVICE_FUNC_CORE(device, vkGetDeviceBufferMemoryRequirements, vkGetDeviceBufferMemoryRequirementsKHR, VK_API_VERSION_1_3);
+		LOAD_DEVICE_FUNC_CORE(device, vkGetDeviceImageMemoryRequirements, vkGetDeviceImageMemoryRequirementsKHR, VK_API_VERSION_1_3);
 	}
 #endif
 }

--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -264,7 +264,16 @@ static VulkanLibraryHandle vulkanLibrary;
 bool g_vulkanAvailabilityChecked = false;
 bool g_vulkanMayBeAvailable = false;
 
-#define LOAD_INSTANCE_FUNC(instance, x) x = (PFN_ ## x)vkGetInstanceProcAddr(instance, #x); if (!x) {INFO_LOG(Log::G3D, "Missing (instance): %s", #x);}
+static void *LoadInstanceFunc(VkInstance instance, const char *name) {
+	void *funcPtr = vkGetInstanceProcAddr(instance, name);
+	if (!funcPtr) {
+		INFO_LOG(Log::G3D, "Missing function (instance): %s", name);
+		return nullptr;
+	}
+	return funcPtr;
+}
+#define LOAD_INSTANCE_FUNC(instance, x) x = (PFN_ ## x)LoadInstanceFunc(instance, #x);
+
 #define LOAD_INSTANCE_FUNC_CORE(instance, x, ext_x, min_core) \
     x = (PFN_ ## x)vkGetInstanceProcAddr(instance, vulkanApiVersion >= min_core ? #x : #ext_x); \
 	if (vulkanApiVersion >= min_core && !x) x = (PFN_ ## x)vkGetInstanceProcAddr(instance, #ext_x); \

--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -688,7 +688,7 @@ void VulkanLoadInstanceFunctions(VkInstance instance, const VulkanExtensions &en
 // good for multi-device - not likely we'll ever try that anyway though.
 void VulkanLoadDeviceFunctions(VkDevice device, const VulkanExtensions &enabledExtensions, uint32_t vulkanApiVersion) {
 #if !PPSSPP_PLATFORM(IOS_APP_STORE)
-	INFO_LOG(Log::G3D, "Vulkan device functions loaded.");
+	INFO_LOG(Log::G3D, "Loading Vulkan device functions. Vulkan API version: %08x (%d.%d)", vulkanApiVersion, VK_VERSION_MAJOR(vulkanApiVersion), VK_VERSION_MINOR(vulkanApiVersion));
 
 	LOAD_DEVICE_FUNC(device, vkQueueSubmit);
 	LOAD_DEVICE_FUNC(device, vkQueueWaitIdle);

--- a/Common/GPU/Vulkan/VulkanLoader.h
+++ b/Common/GPU/Vulkan/VulkanLoader.h
@@ -255,6 +255,7 @@ struct VulkanExtensions {
 	bool KHR_maintenance1; // required for KHR_create_renderpass2
 	bool KHR_maintenance2;
 	bool KHR_maintenance3;
+	bool KHR_maintenance4;
 	bool KHR_multiview;  // required for KHR_create_renderpass2
 	bool KHR_get_memory_requirements2;
 	bool KHR_dedicated_allocation;

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -522,15 +522,14 @@ public:
 	std::string GetInfoString(InfoField info) const override {
 		// TODO: Make these actually query the right information
 		switch (info) {
-		case APINAME: return "Vulkan";
-		case VENDORSTRING: return vulkan_->GetPhysicalDeviceProperties().properties.deviceName;
-		case VENDOR: return VulkanVendorString(vulkan_->GetPhysicalDeviceProperties().properties.vendorID);
-		case DRIVER: return FormatDriverVersion(vulkan_->GetPhysicalDeviceProperties().properties);
-		case SHADELANGVERSION: return "N/A";;
-		case APIVERSION: 
+		case InfoField::APINAME: return "Vulkan";
+		case InfoField::VENDORSTRING: return vulkan_->GetPhysicalDeviceProperties().properties.deviceName;
+		case InfoField::VENDOR: return VulkanVendorString(vulkan_->GetPhysicalDeviceProperties().properties.vendorID);
+		case InfoField::DRIVER: return FormatDriverVersion(vulkan_->GetPhysicalDeviceProperties().properties);
+		case InfoField::SHADELANGVERSION: return "N/A";;
+		case InfoField::APIVERSION:
 		{
-			uint32_t ver = vulkan_->GetPhysicalDeviceProperties().properties.apiVersion;
-			return StringFromFormat("%d.%d.%d", ver >> 22, (ver >> 12) & 0x3ff, ver & 0xfff);
+			return FormatAPIVersion(vulkan_->GetPhysicalDeviceProperties().properties.apiVersion);
 		}
 		default: return "?";
 		}

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1055,6 +1055,14 @@ VKContext::VKContext(VulkanContext *vulkan, bool useRenderThread)
 
 	if (!vulkan->Extensions().KHR_depth_stencil_resolve) {
 		INFO_LOG(Log::G3D, "KHR_depth_stencil_resolve not supported, disabling multisampling");
+		multisampleAllowed = false;
+	}
+
+	if (!vulkan->Extensions().KHR_create_renderpass2) {
+		WARN_LOG(Log::G3D, "KHR_create_renderpass2 not supported, disabling multisampling");
+		multisampleAllowed = false;
+	} else {
+		_dbg_assert_(vkCreateRenderPass2 != nullptr);
 	}
 
 	// We limit multisampling functionality to reasonably recent and known-good tiling GPUs.
@@ -1067,7 +1075,8 @@ VKContext::VKContext(VulkanContext *vulkan, bool useRenderThread)
 			caps_.multiSampleLevelsMask = (limits.framebufferColorSampleCounts & limits.framebufferDepthSampleCounts & limits.framebufferStencilSampleCounts);
 			INFO_LOG(Log::G3D, "Multisample levels mask: %d", caps_.multiSampleLevelsMask);
 		} else {
-			INFO_LOG(Log::G3D, "Not enough depth/stencil resolve modes supported, disabling multisampling.");
+			INFO_LOG(Log::G3D, "Not enough depth/stencil resolve modes supported, disabling multisampling. Color: %d Depth: %d Stencil: %d",
+				limits.framebufferColorSampleCounts, limits.framebufferDepthSampleCounts, limits.framebufferStencilSampleCounts);
 			caps_.multiSampleLevelsMask = 1;
 		}
 	} else {

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -211,7 +211,7 @@ enum FormatSupport {
 	FMT_STORAGE_IMAGE = 64,
 };
 
-enum InfoField {
+enum class InfoField {
 	APINAME,
 	APIVERSION,
 	VENDORSTRING,

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -218,6 +218,7 @@ enum class InfoField {
 	VENDOR,
 	SHADELANGVERSION,
 	DRIVER,
+	DEVICE_API_VERSION,  // Vulkan-only
 };
 
 enum class GPUVendor {

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -539,8 +539,9 @@ void SystemInfoScreen::CreateTabs() {
 		gpuInfo->Add(new InfoItem(si->T("Vendor (detected)"), vendor));
 	gpuInfo->Add(new InfoItem(si->T("Driver Version"), draw->GetInfoString(InfoField::DRIVER)));
 #ifdef _WIN32
-	if (GetGPUBackend() != GPUBackend::VULKAN)
+	if (GetGPUBackend() != GPUBackend::VULKAN) {
 		gpuInfo->Add(new InfoItem(si->T("Driver Version"), System_GetProperty(SYSPROP_GPUDRIVER_VERSION)));
+	}
 #if !PPSSPP_PLATFORM(UWP)
 	if (GetGPUBackend() == GPUBackend::DIRECT3D9) {
 		gpuInfo->Add(new InfoItem(si->T("D3DCompiler Version"), StringFromFormat("%d", GetD3DCompilerVersion())));
@@ -644,12 +645,18 @@ void SystemInfoScreen::CreateTabs() {
 		} else {
 			apiVersion = StringFromFormat("v%d.%d.%d", gl_extensions.ver[0], gl_extensions.ver[1], gl_extensions.ver[2]);
 		}
+		versionInfo->Add(new InfoItem(si->T("API Version"), apiVersion));
 	} else {
 		apiVersion = draw->GetInfoString(InfoField::APIVERSION);
 		if (apiVersion.size() > 30)
 			apiVersion.resize(30);
+		versionInfo->Add(new InfoItem(si->T("API Version"), apiVersion));
+
+		if (GetGPUBackend() == GPUBackend::VULKAN) {
+			std::string deviceApiVersion = draw->GetInfoString(InfoField::DEVICE_API_VERSION);
+			versionInfo->Add(new InfoItem(si->T("Device API Version"), deviceApiVersion));
+		}
 	}
-	versionInfo->Add(new InfoItem(si->T("API Version"), apiVersion));
 	versionInfo->Add(new InfoItem(si->T("Shading Language"), draw->GetInfoString(InfoField::SHADELANGVERSION)));
 
 #if PPSSPP_PLATFORM(ANDROID)


### PR DESCRIPTION
This problem caused some issues with extension loading on devices like the Poco F4, where the Vulkan instance API version is 1.3, while the device API version is 1.1.

With this, or previous changes, #18818 appears to be fixed, so this re-enables MSAA on modern Adreno.