### PR TITLE
ffmpeg: Fix the HAVE_LIBAVCODEC_CONST_AVCODEC test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -988,7 +988,8 @@ if(USE_FFMPEG)
 	find_package(FFmpeg REQUIRED avcodec avformat avutil swresample swscale)
 	# Check if we need to use avcodec_(alloc|free)_frame instead of av_frame_(alloc|free)
 	# Check if we need to use const AVCodec
-	set(CMAKE_REQUIRED_LIBRARIES avcodec;avformat)
+	set(CMAKE_REQUIRED_INCLUDES ${FFmpeg_INCLUDE_avcodec} ${FFmpeg_INCLUDE_avformat})
+	set(CMAKE_REQUIRED_LIBRARIES FFmpeg::avcodec;FFmpeg::avformat)
 	set(CMAKE_REQUIRED_FLAGS "-pedantic -Wall -Werror -Wno-unused-variable")
 	check_cxx_source_compiles("extern \"C\" {
 		#include <libavcodec/avcodec.h>
@@ -2449,7 +2450,7 @@ if(FFmpeg_FOUND)
 		target_compile_definitions(${CoreLibName} PRIVATE HAVE_LIBAVCODEC_CONST_AVCODEC=1)
 	endif()
 	set_target_properties(${CoreLibName} PROPERTIES NO_SYSTEM_FROM_IMPORTED true)
-	target_include_directories(${CoreLibName} BEFORE PUBLIC ${FFmpeg_INCLUDE_avcodec})
+	target_include_directories(${CoreLibName} BEFORE PUBLIC ${FFmpeg_INCLUDE_avcodec} ${FFmpeg_INCLUDE_avformat})
 	target_link_libraries(${CoreLibName}
 		FFmpeg::avcodec
 		FFmpeg::avformat


### PR DESCRIPTION
The test was not pulling in the FFmpeg header or library paths.

```
/home/brad/ports/pobj/ppsspp-1.17.1/bin/c++ -DHAVE_LIBAVCODEC_CONST_AVCODEC  -O2 -pipe -g -pedantic -Wall -Werror -Wno-unused-variable -std=gnu++17 -MD -MT CMakeFiles/cmTC_9e9ce.dir/src.cxx.o -MF CMakeFiles/cmTC_9e9ce.dir/src.cxx.o.d -o CMakeFiles/cmTC_9e9ce.dir/src.cxx.o -c /home/brad/ports/pobj/ppsspp-1.17.1/build-aarch64/CMakeFiles/CMakeScratch/TryCompile-E3C4ib/src.cxx /home/brad/ports/pobj/ppsspp-1.17.1/build-aarch64/CMakeFiles/CMakeScratch/TryCompile-E3C4ib/src.cxx:2:12: fatal error: 'libavcodec/avcodec.h' file not found
                #include <libavcodec/avcodec.h>
                          ^~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Fixing just the header path.

```
/home/brad/ports/pobj/ppsspp-1.17.1/bin/c++ -O2 -pipe -g -pedantic -Wall -Werror -Wno-unused-variable CMakeFiles/cmTC_cf251.dir/src.cxx.o -o cmTC_cf251  -lavcodec  -lavformat  -Wl,-rpath-link,/usr/X11R6/lib:/usr/local/lib && :
ld.lld: error: unable to find library -lavcodec
ld.lld: error: unable to find library -lavformat
```