### PR TITLE
Minor CMake fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -988,7 +988,7 @@ if(USE_FFMPEG)
 	find_package(FFmpeg REQUIRED avcodec avformat avutil swresample swscale)
 	# Check if we need to use avcodec_(alloc|free)_frame instead of av_frame_(alloc|free)
 	# Check if we need to use const AVCodec
-	set(CMAKE_REQUIRED_INCLUDES ${FFmpeg_INCLUDE_avcodec} ${FFmpeg_INCLUDE_avformat})
+	set(CMAKE_REQUIRED_INCLUDES ${FFmpeg_INCLUDE_avcodec};${FFmpeg_INCLUDE_avformat})
 	set(CMAKE_REQUIRED_LIBRARIES FFmpeg::avcodec;FFmpeg::avformat)
 	set(CMAKE_REQUIRED_FLAGS "-pedantic -Wall -Werror -Wno-unused-variable")
 	check_cxx_source_compiles("extern \"C\" {


### PR DESCRIPTION
I see the same behavior with and without but the docs say the list
is supposed to be separated by a semi-colon.