### PR TITLE
iOS: Chat input fix, Mac text input fix

### DIFF
--- a/Common/UI/View.cpp
+++ b/Common/UI/View.cpp
@@ -1329,7 +1329,7 @@ bool TextEdit::Key(const KeyInput &input) {
 
 	// Process chars.
 	if (input.flags & KEY_CHAR) {
-		int unichar = input.keyCode;
+		const int unichar = input.keyCode;
 		if (unichar >= 0x20 && !ctrlDown_) {  // Ignore control characters.
 			// Insert it! (todo: do it with a string insert)
 			char buf[8];

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -106,6 +106,7 @@ public:
 	}
 	void NotifyPresent() {
 		// Something else did the present, skipping PresentationCommon.
+		// If you haven't called BindFramebufferAsRenderTarget, you must not set this.
 		presentedThisFrame_ = true;
 	}
 

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -199,6 +199,8 @@ inline uint32_t RoundUpTo4(uint32_t value) {
 }
 
 void ReplacedTexture::Prepare(VFSBackend *vfs) {
+	_assert_(vfs != nullptr);
+
 	this->vfs_ = vfs;
 
 	std::unique_lock<std::mutex> lock(lock_);
@@ -293,6 +295,11 @@ ReplacedTexture::LoadLevelResult ReplacedTexture::LoadLevelData(VFSFileReference
 
 	if (data_.size() <= mipLevel) {
 		data_.resize(mipLevel + 1);
+	}
+
+	if (!vfs_) {
+		ERROR_LOG(Log::G3D, "Unexpected null vfs_ pointer in LoadLevelData");
+		return LoadLevelResult::LOAD_ERROR;
 	}
 
 	ReplacedTextureLevel level;

--- a/UI/ChatScreen.h
+++ b/UI/ChatScreen.h
@@ -5,8 +5,8 @@
 
 class ChatMenu : public UI::AnchorLayout {
 public:
-	ChatMenu(int token, const Bounds &screenBounds, UI::LayoutParams *lp = nullptr)
-		: UI::AnchorLayout(lp), token_(token) {
+	ChatMenu(int token, const Bounds &screenBounds, ScreenManager *screenManager, UI::LayoutParams *lp = nullptr)
+		: UI::AnchorLayout(lp), screenManager_(screenManager), token_(token) {
 		CreateSubviews(screenBounds);
 	}
 	void Update() override;
@@ -25,7 +25,9 @@ private:
 	void CreateContents(UI::ViewGroup *parent);
 	void UpdateChat();
 
-	UI::EventReturn OnSubmit(UI::EventParams &e);
+	UI::EventReturn OnAskForChatMessage(UI::EventParams &e);
+
+	UI::EventReturn OnSubmitMessage(UI::EventParams &e);
 	UI::EventReturn OnQuickChat1(UI::EventParams &e);
 	UI::EventReturn OnQuickChat2(UI::EventParams &e);
 	UI::EventReturn OnQuickChat3(UI::EventParams &e);
@@ -38,9 +40,12 @@ private:
 	UI::ScrollView *scroll_ = nullptr;
 	UI::LinearLayout *chatVert_ = nullptr;
 	UI::ViewGroup *box_ = nullptr;
+	ScreenManager *screenManager_;
 
 	int chatChangeID_ = 0;
 	bool toBottom_ = true;
 	bool promptInput_ = false;
 	int token_;
+	std::string messageTemp_;
+	UI::Button *chatButton_ = nullptr;
 };

--- a/UI/ChatScreen.h
+++ b/UI/ChatScreen.h
@@ -34,9 +34,7 @@ private:
 	UI::EventReturn OnQuickChat4(UI::EventParams &e);
 	UI::EventReturn OnQuickChat5(UI::EventParams &e);
 
-#if PPSSPP_PLATFORM(WINDOWS) || defined(USING_QT_UI) || defined(SDL)
 	UI::TextEdit *chatEdit_ = nullptr;
-#endif
 	UI::ScrollView *scroll_ = nullptr;
 	UI::LinearLayout *chatVert_ = nullptr;
 	UI::ViewGroup *box_ = nullptr;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -468,6 +468,11 @@ EmuScreen::~EmuScreen() {
 }
 
 void EmuScreen::dialogFinished(const Screen *dialog, DialogResult result) {
+	if (std::string_view(dialog->tag()) == "TextEditPopup") {
+		// Chat message finished.
+		return;
+	}
+
 	// TODO: improve the way with which we got commands from PauseMenu.
 	// DR_CANCEL/DR_BACK means clicked on "continue", DR_OK means clicked on "back to menu",
 	// DR_YES means a message sent to PauseMenu by System_PostUIMessage.
@@ -1055,7 +1060,7 @@ void EmuScreen::CreateViews() {
 			root_->Add(btn)->OnClick.Handle(this, &EmuScreen::OnChat);
 			chatButton_ = btn;
 		}
-		chatMenu_ = root_->Add(new ChatMenu(GetRequesterToken(), screenManager()->getUIContext()->GetBounds(), new LayoutParams(FILL_PARENT, FILL_PARENT)));
+		chatMenu_ = root_->Add(new ChatMenu(GetRequesterToken(), screenManager()->getUIContext()->GetBounds(), screenManager(), new LayoutParams(FILL_PARENT, FILL_PARENT)));
 		chatMenu_->SetVisibility(UI::V_GONE);
 	} else {
 		chatButton_ = nullptr;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1464,8 +1464,8 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 				if (!framebufferBound && PSP_IsInited()) {
 					// draw->BindFramebufferAsRenderTarget(nullptr, { RPAction::CLEAR, RPAction::CLEAR, RPAction::CLEAR, clearColor }, "EmuScreen_Stepping");
 					gpu->CopyDisplayToOutput(true);
+					framebufferBound = true;
 				}
-				framebufferBound = true;
 			}
 			break;
 		}

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -589,19 +589,19 @@ void EmuScreen::sendMessage(UIMessage message, const char *value) {
 			if (!chatButton_)
 				RecreateViews();
 
-#if defined(USING_WIN_UI)
-			// temporary workaround for hotkey its freeze the ui when open chat screen using hotkey and native keyboard is enable
-			if (g_Config.bBypassOSKWithKeyboard) {
-				// TODO: Make translatable.
-				g_OSD.Show(OSDType::MESSAGE_INFO, "Disable \"Use system native keyboard\" to use ctrl + c hotkey", 2.0f);
+			if (System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_DESKTOP) {
+				// temporary workaround for hotkey its freeze the ui when open chat screen using hotkey and native keyboard is enable
+				if (g_Config.bBypassOSKWithKeyboard) {
+					// TODO: Make translatable.
+					g_OSD.Show(OSDType::MESSAGE_INFO, "Disable \"Use system native keyboard\" to use ctrl + c hotkey", 2.0f);
+				} else {
+					UI::EventParams e{};
+					OnChatMenu.Trigger(e);
+				}
 			} else {
 				UI::EventParams e{};
 				OnChatMenu.Trigger(e);
 			}
-#else
-			UI::EventParams e{};
-			OnChatMenu.Trigger(e);
-#endif
 		}
 	} else if (message == UIMessage::APP_RESUMED && screenManager()->topScreen() == this) {
 		if (System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_TV) {
@@ -935,7 +935,6 @@ bool EmuScreen::UnsyncKey(const KeyInput &key) {
 	if (UI::IsFocusMovementEnabled()) {
 		return UIScreen::UnsyncKey(key);
 	}
-
 	return controlMapper_.Key(key, &pauseTrigger_);
 }
 

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -380,9 +380,9 @@ void GamePauseScreen::CreateViews() {
 		leftColumnItems->Add(new NoticeView(NoticeLevel::INFO, notAvailable, ""));
 	}
 
-	ViewGroup *middleColumn = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(64, FILL_PARENT, Margins(0, 10, 0, 15)));
+	LinearLayout *middleColumn = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(64, FILL_PARENT, Margins(0, 10, 0, 15)));
 	root_->Add(middleColumn);
-
+	middleColumn->SetSpacing(0.0f);
 	ViewGroup *rightColumnHolder = new LinearLayout(ORIENT_VERTICAL, new LinearLayoutParams(vertical ? 200 : 300, FILL_PARENT, actionMenuMargins));
 
 	ViewGroup *rightColumn = new ScrollView(ORIENT_VERTICAL, new LinearLayoutParams(1.0f));
@@ -404,7 +404,7 @@ void GamePauseScreen::CreateViews() {
 	root_->SetDefaultFocusView(continueChoice);
 	continueChoice->OnClick.Handle<UIScreen>(this, &UIScreen::OnBack);
 
-	rightColumnItems->Add(new Spacer(25.0));
+	rightColumnItems->Add(new Spacer(20.0));
 
 	std::string gameId = g_paramSFO.GetDiscID();
 	if (g_Config.hasGameConfig(gameId)) {
@@ -438,7 +438,7 @@ void GamePauseScreen::CreateViews() {
 		auto rp = GetI18NCategory(I18NCat::REPORTING);
 		rightColumnItems->Add(new Choice(rp->T("ReportButton", "Report Feedback")))->OnClick.Handle(this, &GamePauseScreen::OnReportFeedback);
 	}
-	rightColumnItems->Add(new Spacer(25.0));
+	rightColumnItems->Add(new Spacer(20.0));
 	if (g_Config.bPauseMenuExitsEmulator) {
 		auto mm = GetI18NCategory(I18NCat::MAINMENU);
 		rightColumnItems->Add(new Choice(mm->T("Exit")))->OnClick.Handle(this, &GamePauseScreen::OnExitToMenu);
@@ -453,7 +453,7 @@ void GamePauseScreen::CreateViews() {
 			playButton_->SetImageID(g_Config.bRunBehindPauseMenu ? ImageID("I_PAUSE") : ImageID("I_PLAY"));
 			return UI::EVENT_DONE;
 		});
-
+		middleColumn->Add(new Spacer(20.0));
 		Button *infoButton = middleColumn->Add(new Button("", ImageID("I_INFO"), new LinearLayoutParams(64, 64)));
 		infoButton->OnClick.Add([=](UI::EventParams &e) {
 			screenManager()->push(new GameScreen(gamePath_, true));


### PR DESCRIPTION
Followup to #19388 , which doesn't actually work

This also fixes keyboard input in UI text fields in MacOS again, was broken in #19441 by mistake.