### PR TITLE
Prevent soft-locking the emulator on bad PBP files

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -337,7 +337,7 @@ bool SavedataParam::Delete(SceUtilitySavedataParam* param, int saveId) {
 
 	std::string dirPath = GetSaveFilePath(param, GetSaveDir(saveId));
 	if (dirPath.size() == 0) {
-		ERROR_LOG(Log::sceUtility, "GetSaveFilePath (%.*s) returned empty - cannot delete save directory. Might already be deleted?", sizeof(param->gameName), param->gameName);
+		ERROR_LOG(Log::sceUtility, "GetSaveFilePath (%.*s) returned empty - cannot delete save directory. Might already be deleted?", (int)sizeof(param->gameName), param->gameName);
 		return false;
 	}
 

--- a/Core/MIPS/IR/IRRegCache.h
+++ b/Core/MIPS/IR/IRRegCache.h
@@ -31,7 +31,7 @@ constexpr int TOTAL_MAPPABLE_IRREGS = 256;
 // Arbitrary - increase if your backend has more.
 constexpr int TOTAL_POSSIBLE_NATIVEREGS = 128;
 
-typedef int8_t IRNativeReg;
+typedef int8_t IRNativeReg;  // invalid value is -1
 
 constexpr IRReg IRREG_INVALID = 255;
 

--- a/Core/MIPS/x86/X64IRRegCache.cpp
+++ b/Core/MIPS/x86/X64IRRegCache.cpp
@@ -265,7 +265,7 @@ X64Reg X64IRRegCache::GetAndLockTempFPR() {
 
 void X64IRRegCache::ReserveAndLockXGPR(Gen::X64Reg r) {
 	IRNativeReg nreg = GPRToNativeReg(r);
-	if (nr[nreg].mipsReg != -1)
+	if (nr[nreg].mipsReg != IRREG_INVALID)
 		FlushNativeReg(nreg);
 	nr[r].tempLockIRIndex = irIndex_;
 }

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1224,17 +1224,17 @@ void EmuScreen::update() {
 		return;
 	}
 
+	if (pauseTrigger_) {
+		pauseTrigger_ = false;
+		screenManager()->push(new GamePauseScreen(gamePath_));
+	}
+
 	if (invalid_)
 		return;
 
 	double now = time_now_d();
 
 	controlMapper_.Update(now);
-
-	if (pauseTrigger_) {
-		pauseTrigger_ = false;
-		screenManager()->push(new GamePauseScreen(gamePath_));
-	}
 
 	if (saveStatePreview_ && !bootPending_) {
 		int currentSlot = SaveState::GetCurrentSlot();
@@ -1297,6 +1297,11 @@ ScreenRenderRole EmuScreen::renderRole(bool isTop) const {
 				return true;
 			return false;
 		}
+
+		if (invalid_) {
+			return false;
+		}
+
 		return true;
 	};
 

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -67,7 +67,6 @@ private:
 	UI::EventReturn OnDisableCardboard(UI::EventParams &params);
 	UI::EventReturn OnChat(UI::EventParams &params);
 	UI::EventReturn OnResume(UI::EventParams &params);
-	UI::EventReturn OnReset(UI::EventParams &params);
 
 	void bootGame(const Path &filename);
 	bool bootAllowStorage(const Path &filename);
@@ -114,6 +113,7 @@ private:
 	UI::TextView *loadingTextView_ = nullptr;
 	UI::Button *resumeButton_ = nullptr;
 	UI::Button *resetButton_ = nullptr;
+	UI::Button *backButton_ = nullptr;
 	UI::View *chatButton_ = nullptr;
 	ChatMenu *chatMenu_ = nullptr;
 


### PR DESCRIPTION
Just some polish for this error case.

Also, on the game crash screen, add a "back" button for convenience.