### PR TITLE
D3D9 fix

### DIFF
--- a/Common/GPU/D3D9/D3D9ShaderCompiler.cpp
+++ b/Common/GPU/D3D9/D3D9ShaderCompiler.cpp
@@ -15,8 +15,7 @@ using namespace Microsoft::WRL;
 
 struct ID3DXConstantTable;
 
-LPD3DBLOB CompileShaderToByteCodeD3D9(const char *code, const char *target, std::string *errorMessage) {
-	ComPtr<ID3DBlob> pShaderCode;
+HRESULT CompileShaderToByteCodeD3D9(const char *code, const char *target, std::string *errorMessage, ID3DBlob **ppShaderCode) {
 	ComPtr<ID3DBlob> pErrorMsg;
 
 	// Compile pixel shader.
@@ -29,7 +28,7 @@ LPD3DBLOB CompileShaderToByteCodeD3D9(const char *code, const char *target, std:
 		target,
 		0,
 		0,
-		&pShaderCode,
+		ppShaderCode,
 		&pErrorMsg);
 
 	if (pErrorMsg) {
@@ -43,12 +42,13 @@ LPD3DBLOB CompileShaderToByteCodeD3D9(const char *code, const char *target, std:
 		errorMessage->clear();
 	}
 
-	return pShaderCode.Detach();
+	return hr;
 }
 
 bool CompilePixelShaderD3D9(LPDIRECT3DDEVICE9 device, const char *code, LPDIRECT3DPIXELSHADER9 *pShader, std::string *errorMessage) {
-	ComPtr<ID3DBlob> pShaderCode = CompileShaderToByteCodeD3D9(code, "ps_3_0", errorMessage);
-	if (pShaderCode) {
+	ComPtr<ID3DBlob> pShaderCode;
+	HRESULT hr = CompileShaderToByteCodeD3D9(code, "ps_3_0", errorMessage, &pShaderCode);
+	if (SUCCEEDED(hr)) {
 		// Create pixel shader.
 		device->CreatePixelShader((DWORD*)pShaderCode->GetBufferPointer(), pShader);
 		return true;
@@ -58,8 +58,9 @@ bool CompilePixelShaderD3D9(LPDIRECT3DDEVICE9 device, const char *code, LPDIRECT
 }
 
 bool CompileVertexShaderD3D9(LPDIRECT3DDEVICE9 device, const char *code, LPDIRECT3DVERTEXSHADER9 *pShader, std::string *errorMessage) {
-	ComPtr<ID3DBlob> pShaderCode = CompileShaderToByteCodeD3D9(code, "vs_3_0", errorMessage);
-	if (pShaderCode) {
+	ComPtr<ID3DBlob> pShaderCode;
+	HRESULT hr = CompileShaderToByteCodeD3D9(code, "vs_3_0", errorMessage, &pShaderCode);
+	if (SUCCEEDED(hr)) {
 		// Create vertex shader.
 		device->CreateVertexShader((DWORD*)pShaderCode->GetBufferPointer(), pShader);
 		return true;

--- a/Common/GPU/D3D9/D3D9ShaderCompiler.h
+++ b/Common/GPU/D3D9/D3D9ShaderCompiler.h
@@ -9,7 +9,7 @@
 
 struct ID3DXConstantTable;
 
-LPD3DBLOB CompileShaderToByteCodeD3D9(const char *code, const char *target, std::string *errorMessage);
+HRESULT CompileShaderToByteCodeD3D9(const char *code, const char *target, std::string *errorMessage, LPD3DBLOB *pShaderCode);
 
 bool CompilePixelShaderD3D9(LPDIRECT3DDEVICE9 device, const char *code, LPDIRECT3DPIXELSHADER9 *pShader, std::string *errorMessage);
 bool CompileVertexShaderD3D9(LPDIRECT3DDEVICE9 device, const char *code, LPDIRECT3DVERTEXSHADER9 *pShader, std::string *errorMessage);

--- a/Common/GPU/D3D9/thin3d_d3d9.cpp
+++ b/Common/GPU/D3D9/thin3d_d3d9.cpp
@@ -1520,6 +1520,9 @@ bool D3D9Context::CopyFramebufferToMemory(Framebuffer *src, int channelBits, int
 	if (channelBits != FB_COLOR_BIT) {
 		fb->depthstenciltex->UnlockRect(0);
 	}
+	if (offscreen) {
+		offscreen->UnlockRect();
+	}
 
 	return SUCCEEDED(hr);
 }

--- a/unittest/TestShaderGenerators.cpp
+++ b/unittest/TestShaderGenerators.cpp
@@ -18,6 +18,7 @@
 #include "GPU/Common/DepalettizeShaderCommon.h"
 
 #if PPSSPP_PLATFORM(WINDOWS)
+#include <wrl/client.h>
 #include "GPU/D3D11/D3D11Util.h"
 #include "GPU/D3D11/D3D11Loader.h"
 
@@ -164,13 +165,9 @@ bool TestCompileShader(const char *buffer, ShaderLanguage lang, ShaderStage stag
 		case ShaderStage::Fragment: programType = "ps_3_0"; break;
 		default: return false;
 		}
-		LPD3DBLOB blob = CompileShaderToByteCodeD3D9(buffer, programType, errorMessage);
-		if (blob) {
-			blob->Release();
-			return true;
-		} else {
-			return false;
-		}
+		Microsoft::WRL::ComPtr<ID3DBlob> blob;
+		HRESULT hr = CompileShaderToByteCodeD3D9(buffer, programType, errorMessage, &blob);
+		return SUCCEEDED(hr);
 	}
 #endif
 


### PR DESCRIPTION
This a fix for a bug that I introduced in my MR #19413. Sorry.

I also made a small refactoring because I dislike using `ComPtr::Detach` and I prefer methods that return `HRESULT`. But I can drop it if you think it's unnecessary.