### PR TITLE
Fix issue where PresentedThisFrame didn't work correctly on SoftGPU

### DIFF
--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -722,10 +722,6 @@ void GPUCommon::PSPFrame() {
 	GPURecord::NotifyBeginFrame();
 }
 
-bool GPUCommon::PresentedThisFrame() const {
-	return framebufferManager_ ? framebufferManager_->PresentedThisFrame() : true;
-}
-
 void GPUCommon::SlowRunLoop(DisplayList &list) {
 	const bool dumpThisFrame = dumpThisFrame_;
 	while (downcount > 0) {

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -224,8 +224,6 @@ public:
 		fullInfo = reportingFullInfo_;
 	}
 
-	bool PresentedThisFrame() const override;
-
 protected:
 	void ClearCacheNextFrame() override {}
 

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -540,6 +540,10 @@ void GPUCommonHW::CopyDisplayToOutput(bool reallyDirty) {
 	gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
 }
 
+bool GPUCommonHW::PresentedThisFrame() const {
+	return framebufferManager_->PresentedThisFrame();
+}
+
 void GPUCommonHW::DoState(PointerWrap &p) {
 	GPUCommon::DoState(p);
 

--- a/GPU/GPUCommonHW.h
+++ b/GPU/GPUCommonHW.h
@@ -68,6 +68,8 @@ public:
 	void FastRunLoop(DisplayList &list) override;
 	void ExecuteOp(u32 op, u32 diff) override;
 
+	bool PresentedThisFrame() const override;
+
 private:
 	void CheckDepthUsage(VirtualFramebuffer *vfb) override;
 	void CheckFlushOp(int cmd, u32 diff);

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -656,6 +656,10 @@ void SoftGPU::CopyDisplayToOutput(bool reallyDirty) {
 	MarkDirty(displayFramebuf_, displayStride_, 272, displayFormat_, SoftGPUVRAMDirty::CLEAR);
 }
 
+bool SoftGPU::PresentedThisFrame() const {
+	return presentation_->PresentedThisFrame();
+}
+
 void SoftGPU::MarkDirty(uint32_t addr, uint32_t stride, uint32_t height, GEBufferFormat fmt, SoftGPUVRAMDirty value) {
 	uint32_t bytes = height * stride * (fmt == GE_FORMAT_8888 ? 4 : 2);
 	MarkDirty(addr, bytes, value);

--- a/GPU/Software/SoftGpu.h
+++ b/GPU/Software/SoftGpu.h
@@ -209,6 +209,8 @@ public:
 
 	typedef void (SoftGPU::*CmdFunc)(u32 op, u32 diff);
 
+	bool PresentedThisFrame() const override;
+
 protected:
 	void FastRunLoop(DisplayList &list) override;
 	void CopyToCurrentFboFromDisplayRam(int srcwidth, int srcheight);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1001,7 +1001,7 @@ void GameSettingsScreen::CreateToolsSettings(UI::ViewGroup *tools) {
 
 	tools->Add(new ItemHeader(ms->T("Tools")));
 
-	const bool showRetroAchievements = true;
+	const bool showRetroAchievements = true; // System_GetPropertyInt(SYSPROP_DEVICE_TYPE) != DEVICE_TYPE_VR;
 	if (showRetroAchievements) {
 		auto retro = tools->Add(new Choice(sy->T("RetroAchievements")));
 		retro->OnClick.Add([=](UI::EventParams &) -> UI::EventReturn {


### PR DESCRIPTION
Caused us to double-bind or not bind the framebuffer in some cases, causing asserts and/or crashes. Regression.

Should fix what @sum2012 reported in [#15828 ](https://github.com/hrydgard/ppsspp/issues/15828#issuecomment-2416578892)