### PR TITLE
Allow fullscreen for control layout editor

### DIFF
--- a/UI/TouchControlLayoutScreen.h
+++ b/UI/TouchControlLayoutScreen.h
@@ -32,6 +32,7 @@ public:
 	void onFinish(DialogResult reason) override;
 	void update() override;
 	void resized() override;
+	void touch(const TouchInput& touch) override;
 
 	const char *tag() const override { return "TouchControlLayout"; }
 
@@ -43,4 +44,6 @@ protected:
 private:
 	UI::ChoiceStrip *mode_ = nullptr;
 	ControlLayoutView *layoutView_ = nullptr;
+	bool fullscreenEdit_ = false;
+	double timestamps[10] = { -1.0 };
 };


### PR DESCRIPTION
I have seen this requested before, but I can't find the issue.

I think we have a gesture detector class, not sure how to use that. The `TouchInput.timestamp` is weird, like the exponent is around e-300, so I just ignored it.

Also fixes the scaling of the sticks that was broken.

![1](https://github.com/user-attachments/assets/04960f6c-19ee-4d96-b54e-5596af6dcc57)
![2](https://github.com/user-attachments/assets/0301584a-2d2d-40d2-a410-efb3152efa25)

PS: I didn't have the time to build and test on Android, but it should be fine.