### PR TITLE
Move CPU stepping logic out of the disassembler window code

### DIFF
--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -217,6 +217,7 @@ enum class SystemNotification {
 	UI,
 	MEM_VIEW,
 	DISASSEMBLY,
+	DISASSEMBLY_AFTERSTEP,
 	DEBUG_MODE_CHANGE,
 	BOOT_DONE,  // this is sent from EMU thread! Make sure that Host handles it properly!
 	SYMBOL_MAP_UPDATED,

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -346,7 +346,7 @@ void Core_ProcessStepping() {
 	static int lastSteppingCounter = -1;
 	if (lastSteppingCounter != steppingCounter) {
 		CBreakPoints::ClearTemporaryBreakPoints();
-		System_Notify(SystemNotification::DISASSEMBLY);
+		System_Notify(SystemNotification::DISASSEMBLY_AFTERSTEP);
 		System_Notify(SystemNotification::MEM_VIEW);
 		lastSteppingCounter = steppingCounter;
 	}

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -364,7 +364,7 @@ void Core_ProcessStepping() {
 		}
 
 		// Update disasm dialog.
-		System_Notify(SystemNotification::DISASSEMBLY);
+		System_Notify(SystemNotification::DISASSEMBLY_AFTERSTEP);
 		System_Notify(SystemNotification::MEM_VIEW);
 	}
 }

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -426,6 +426,7 @@ void Core_Resume() {
 	coreState = CORE_RUNNING;
 	coreStatePending = false;
 	m_StepCond.notify_all();
+	System_Notify(SystemNotification::DEBUG_MODE_CHANGE);
 }
 
 bool Core_NextFrame() {

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -28,23 +28,36 @@ class GraphicsContext;
 // called from emu thread
 void UpdateRunLoop(GraphicsContext *ctx);
 
+// For platforms that don't call Core_Run
+void Core_SetGraphicsContext(GraphicsContext *ctx);
+
 // Returns false when an UI exit state is detected.
 bool Core_Run(GraphicsContext *ctx);
 void Core_Stop();
 
-// For platforms that don't call Core_Run
-void Core_SetGraphicsContext(GraphicsContext *ctx);
+/*
+enum class CPUStepType {
+	None,
+	Into,
+	Over,
+	Out,
+};
+*/
 
-// called from gui
-void Core_EnableStepping(bool step, const char *reason = nullptr, u32 relatedAddress = 0);
+// Async, called from gui
+void Core_Break(const char *reason, u32 relatedAddress = 0);
+// void Core_Step(CPUStepType type);  // CPUStepType::None not allowed
+void Core_Resume();
+
+// Refactor.
+void Core_DoSingleStep();
+void Core_UpdateSingleStep();
+void Core_ProcessStepping();
 
 bool Core_ShouldRunBehind();
 bool Core_MustRunBehind();
 
 bool Core_NextFrame();
-void Core_DoSingleStep();
-void Core_UpdateSingleStep();
-void Core_ProcessStepping();
 
 // Changes every time we enter stepping.
 int Core_GetSteppingCounter();
@@ -113,7 +126,7 @@ void Core_MemoryException(u32 address, u32 accessSize, u32 pc, MemoryExceptionTy
 void Core_MemoryExceptionInfo(u32 address, u32 accessSize, u32 pc, MemoryExceptionType type, std::string_view additionalInfo, bool forceReport);
 
 void Core_ExecException(u32 address, u32 pc, ExecExceptionType type);
-void Core_Break(u32 pc);
+void Core_BreakException(u32 pc);
 // Call when loading save states, etc.
 void Core_ResetException();
 

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -24,6 +24,7 @@
 #include "Core/CoreParameter.h"
 
 class GraphicsContext;
+class DebugInterface;
 
 // called from emu thread
 void UpdateRunLoop(GraphicsContext *ctx);
@@ -35,19 +36,28 @@ void Core_SetGraphicsContext(GraphicsContext *ctx);
 bool Core_Run(GraphicsContext *ctx);
 void Core_Stop();
 
-/*
+// X11, sigh.
+#ifdef None
+#undef None
+#endif
+
 enum class CPUStepType {
 	None,
 	Into,
 	Over,
 	Out,
 };
-*/
 
 // Async, called from gui
 void Core_Break(const char *reason, u32 relatedAddress = 0);
 // void Core_Step(CPUStepType type);  // CPUStepType::None not allowed
 void Core_Resume();
+
+// Handles more advanced step types (used by the debugger).
+// stepSize is to support stepping through compound instructions like fused lui+ladd (li).
+// Yes, our disassembler does support those.
+// Returns the new address.
+uint32_t Core_PerformStep(DebugInterface *mips, CPUStepType stepType, int stepSize);
 
 // Refactor.
 void Core_DoSingleStep();

--- a/Core/CoreTiming.cpp
+++ b/Core/CoreTiming.cpp
@@ -153,7 +153,7 @@ int RegisterEvent(const char *name, TimedCallback callback) {
 
 void AntiCrashCallback(u64 userdata, int cyclesLate) {
 	ERROR_LOG(Log::SaveState, "Savestate broken: an unregistered event was called.");
-	Core_EnableStepping(true, "savestate.crash", 0);
+	Core_Break("savestate.crash", 0);
 }
 
 void RestoreRegisterEvent(int &event_type, const char *name, TimedCallback callback) {

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -75,7 +75,7 @@ BreakAction MemCheck::Action(u32 addr, bool write, int size, u32 pc, const char 
 	// Conditions have always already been checked if we get here.
 	Log(addr, write, size, pc, reason);
 	if ((result & BREAK_ACTION_PAUSE) && coreState != CORE_POWERUP) {
-		Core_EnableStepping(true, "memory.breakpoint", start);
+		Core_Break("memory.breakpoint", start);
 	}
 
 	return result;
@@ -331,7 +331,7 @@ BreakAction CBreakPoints::ExecBreakPoint(u32 addr) {
 			}
 		}
 		if ((info.result & BREAK_ACTION_PAUSE) && coreState != CORE_POWERUP) {
-			Core_EnableStepping(true, "cpu.breakpoint", info.addr);
+			Core_Break("cpu.breakpoint", info.addr);
 		}
 
 		return info.result;
@@ -653,7 +653,7 @@ void CBreakPoints::Update(u32 addr) {
 	if (MIPSComp::jit && addr != -1) {
 		bool resume = false;
 		if (Core_IsStepping() == false) {
-			Core_EnableStepping(true, "cpu.breakpoint.update", addr);
+			Core_Break("cpu.breakpoint.update", addr);
 			Core_WaitInactive(200);
 			resume = true;
 		}
@@ -665,7 +665,7 @@ void CBreakPoints::Update(u32 addr) {
 			mipsr4k.ClearJitCache();
 
 		if (resume)
-			Core_EnableStepping(false);
+			Core_Resume();
 	}
 
 	if (anyMemChecks_ && addr != -1)

--- a/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp
+++ b/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp
@@ -71,7 +71,7 @@ void WebSocketCPUStepping(DebuggerRequest &req) {
 		return req.Fail("CPU not started");
 	}
 	if (!Core_IsStepping() && Core_IsActive()) {
-		Core_EnableStepping(true, "cpu.stepping", 0);
+		Core_Break("cpu.stepping", 0);
 	}
 }
 
@@ -92,7 +92,7 @@ void WebSocketCPUResume(DebuggerRequest &req) {
 	if (currentMIPS->inDelaySlot) {
 		Core_DoSingleStep();
 	}
-	Core_EnableStepping(false);
+	Core_Resume();
 }
 
 // Request the current CPU status (cpu.status)

--- a/Core/Debugger/WebSocket/MemorySubscriber.cpp
+++ b/Core/Debugger/WebSocket/MemorySubscriber.cpp
@@ -64,7 +64,7 @@ static AutoDisabledReplacements LockMemoryAndCPU(uint32_t addr, bool keepReplace
 	if (Core_IsStepping()) {
 		result.wasStepping = true;
 	} else {
-		Core_EnableStepping(true, "memory.access", addr);
+		Core_Break("memory.access", addr);
 		Core_WaitInactive();
 	}
 
@@ -99,7 +99,7 @@ AutoDisabledReplacements::~AutoDisabledReplacements() {
 		RestoreSavedReplacements(replacements);
 	}
 	if (!wasStepping)
-		Core_EnableStepping(false);
+		Core_Resume();
 	delete lock;
 }
 

--- a/Core/Debugger/WebSocket/SteppingSubscriber.cpp
+++ b/Core/Debugger/WebSocket/SteppingSubscriber.cpp
@@ -93,7 +93,7 @@ void WebSocketSteppingState::Into(DebuggerRequest &req) {
 	if (!currentDebugMIPS->isAlive())
 		return req.Fail("CPU not started");
 	if (!Core_IsStepping()) {
-		Core_EnableStepping(true, "cpu.stepInto", 0);
+		Core_Break("cpu.stepInto", 0);
 		return;
 	}
 
@@ -119,7 +119,7 @@ void WebSocketSteppingState::Into(DebuggerRequest &req) {
 		if (cpuDebug != currentDebugMIPS) {
 			CBreakPoints::AddBreakPoint(breakpointAddress, true);
 			AddThreadCondition(breakpointAddress, threadID);
-			Core_EnableStepping(false);
+			Core_Resume();
 		}
 	}
 }
@@ -173,7 +173,7 @@ void WebSocketSteppingState::Over(DebuggerRequest &req) {
 		CBreakPoints::AddBreakPoint(breakpointAddress, true);
 		if (cpuDebug != currentDebugMIPS)
 			AddThreadCondition(breakpointAddress, threadID);
-		Core_EnableStepping(false);
+		Core_Resume();
 	}
 }
 
@@ -222,7 +222,7 @@ void WebSocketSteppingState::Out(DebuggerRequest &req) {
 		CBreakPoints::AddBreakPoint(breakpointAddress, true);
 		if (cpuDebug != currentDebugMIPS)
 			AddThreadCondition(breakpointAddress, threadID);
-		Core_EnableStepping(false);
+		Core_Resume();
 	}
 }
 
@@ -248,7 +248,7 @@ void WebSocketSteppingState::RunUntil(DebuggerRequest &req) {
 	// We may have arrived already if PauseResume() stepped out of a delay slot.
 	if (currentMIPS->pc != address || wasAtAddress) {
 		CBreakPoints::AddBreakPoint(address, true);
-		Core_EnableStepping(false);
+		Core_Resume();
 	}
 }
 
@@ -264,7 +264,7 @@ void WebSocketSteppingState::HLE(DebuggerRequest &req) {
 
 	PrepareResume();
 	hleDebugBreak();
-	Core_EnableStepping(false);
+	Core_Resume();
 }
 
 uint32_t WebSocketSteppingState::GetNextAddress(DebugInterface *cpuDebug) {

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -361,7 +361,7 @@ bool hleExecuteDebugBreak(const HLEFunction &func)
 			return false;
 	}
 
-	Core_EnableStepping(true, "hle.step", latestSyscallPC);
+	Core_Break("hle.step", latestSyscallPC);
 	return true;
 }
 

--- a/Core/MIPS/ARM64/Arm64IRCompSystem.cpp
+++ b/Core/MIPS/ARM64/Arm64IRCompSystem.cpp
@@ -260,7 +260,7 @@ void Arm64JitBackend::CompIR_System(IRInst inst) {
 		RestoreRoundingMode(true);
 		SaveStaticRegisters();
 		MovFromPC(W0);
-		QuickCallFunction(SCRATCH2_64, &Core_Break);
+		QuickCallFunction(SCRATCH2_64, &Core_BreakException);
 		LoadStaticRegisters();
 		ApplyRoundingMode(true);
 		MovFromPC(SCRATCH1);

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -1196,7 +1196,7 @@ u32 IRInterpret(MIPSState *mips, const IRInst *inst) {
 			break;
 
 		case IROp::Break:
-			Core_Break(mips->pc);
+			Core_BreakException(mips->pc);
 			return mips->pc + 4;
 
 		case IROp::Breakpoint:

--- a/Core/MIPS/MIPSInt.cpp
+++ b/Core/MIPS/MIPSInt.cpp
@@ -178,7 +178,7 @@ namespace MIPSInt
 	void Int_Break(MIPSOpcode op)
 	{
 		Reporting::ReportMessage("BREAK instruction hit");
-		Core_Break(PC);
+		Core_BreakException(PC);
 		PC += 4;
 	}
 

--- a/Core/MIPS/MIPSTables.cpp
+++ b/Core/MIPS/MIPSTables.cpp
@@ -1004,7 +1004,7 @@ static void RunUntilWithChecks(u64 globalTicks) {
 			if (hasBPs && CBreakPoints::IsAddressBreakPoint(curMips->pc) && CBreakPoints::CheckSkipFirst() != curMips->pc) {
 				auto cond = CBreakPoints::GetBreakPointCondition(currentMIPS->pc);
 				if (!cond || cond->Evaluate()) {
-					Core_EnableStepping(true, "cpu.breakpoint", curMips->pc);
+					Core_Break("cpu.breakpoint", curMips->pc);
 					if (CBreakPoints::IsTempBreakPoint(curMips->pc))
 						CBreakPoints::RemoveBreakPoint(curMips->pc);
 					break;

--- a/Core/MIPS/RiscV/RiscVCompSystem.cpp
+++ b/Core/MIPS/RiscV/RiscVCompSystem.cpp
@@ -232,7 +232,7 @@ void RiscVJitBackend::CompIR_System(IRInst inst) {
 		RestoreRoundingMode(true);
 		SaveStaticRegisters();
 		MovFromPC(X10);
-		QuickCallFunction(&Core_Break, SCRATCH2);
+		QuickCallFunction(&Core_BreakException, SCRATCH2);
 		LoadStaticRegisters();
 		ApplyRoundingMode(true);
 		MovFromPC(SCRATCH1);

--- a/Core/MIPS/x86/CompBranch.cpp
+++ b/Core/MIPS/x86/CompBranch.cpp
@@ -109,7 +109,7 @@ static void JitBranchLogMismatch(MIPSOpcode op, u32 pc)
 	char temp[256];
 	MIPSDisAsm(op, pc, temp, sizeof(temp), true);
 	ERROR_LOG(Log::JIT, "Bad jump: %s - int:%08x jit:%08x", temp, currentMIPS->intBranchExit, currentMIPS->jitBranchExit);
-	Core_EnableStepping(true, "jit.branchdebug", pc);
+	Core_Break("jit.branchdebug", pc);
 }
 
 void Jit::BranchLog(MIPSOpcode op)

--- a/Core/MIPS/x86/X64IRCompSystem.cpp
+++ b/Core/MIPS/x86/X64IRCompSystem.cpp
@@ -255,7 +255,7 @@ void X64JitBackend::CompIR_System(IRInst inst) {
 		RestoreRoundingMode(true);
 		SaveStaticRegisters();
 		MovFromPC(SCRATCH1);
-		ABI_CallFunctionR((const void *)&Core_Break, SCRATCH1);
+		ABI_CallFunctionR((const void *)&Core_BreakException, SCRATCH1);
 		LoadStaticRegisters();
 		ApplyRoundingMode(true);
 		MovFromPC(SCRATCH1);

--- a/Core/RetroAchievements.cpp
+++ b/Core/RetroAchievements.cpp
@@ -554,7 +554,7 @@ static void raintegration_event_handler(const rc_client_raintegration_event_t *e
 		break;
 	case RC_CLIENT_RAINTEGRATION_EVENT_PAUSE:
 		// The toolkit has hit a breakpoint and wants to pause the emulator. Do so.
-		Core_EnableStepping(true, "ra_breakpoint");
+		Core_Break("ra_breakpoint");
 		break;
 	case RC_CLIENT_RAINTEGRATION_EVENT_HARDCORE_CHANGED:
 		// Hardcore mode has been changed (either directly by the user, or disabled through the use of the tools).

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -426,7 +426,7 @@ namespace SaveState
 	{
 		rewindStates.NotifyState();
 		if (coreState == CoreState::CORE_RUNTIME_ERROR)
-			Core_EnableStepping(true, "savestate.load", 0);
+			Core_Break("savestate.load", 0);
 		Enqueue(Operation(SAVESTATE_LOAD, filename, slot, callback, cbUserData));
 	}
 
@@ -434,7 +434,7 @@ namespace SaveState
 	{
 		rewindStates.NotifyState();
 		if (coreState == CoreState::CORE_RUNTIME_ERROR)
-			Core_EnableStepping(true, "savestate.save", 0);
+			Core_Break("savestate.save", 0);
 		Enqueue(Operation(SAVESTATE_SAVE, filename, slot, callback, cbUserData));
 	}
 
@@ -446,7 +446,7 @@ namespace SaveState
 	void Rewind(Callback callback, void *cbUserData)
 	{
 		if (coreState == CoreState::CORE_RUNTIME_ERROR)
-			Core_EnableStepping(true, "savestate.rewind", 0);
+			Core_Break("savestate.rewind", 0);
 		Enqueue(Operation(SAVESTATE_REWIND, Path(), -1, callback, cbUserData));
 	}
 

--- a/SDL/CocoaBarItems.mm
+++ b/SDL/CocoaBarItems.mm
@@ -438,10 +438,10 @@ void OSXOpenURL(const char *url) {
    std::shared_ptr<I18NCategory> developerUILocalization = GetI18NCategory(I18NCat::DEVELOPER);
 #define DEVELOPERUI_LOCALIZED(key) @(developerUILocalization->T_cstr(key))
     if (Core_IsStepping()) {
-        Core_EnableStepping(false, "ui.break");
+        Core_Resume();
         item.title = DESKTOPUI_LOCALIZED("Break");
     } else {
-        Core_EnableStepping(true, "ui.break");
+        Core_Break("ui.break", 0);
         item.title = DEVELOPERUI_LOCALIZED("Resume");
     }
 }
@@ -452,7 +452,7 @@ void OSXOpenURL(const char *url) {
 
 -(void)resetAction: (NSMenuItem *)item {
     System_PostUIMessage(UIMessage::REQUEST_GAME_RESET);
-	Core_EnableStepping(false);
+	Core_Resume();
 }
 
 -(void)chatAction: (NSMenuItem *)item {

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -843,7 +843,7 @@ static void ProcessSDLEvent(SDL_Window *window, const SDL_Event &event, InputSta
 				if (ctrl && (k == SDLK_w))
 				{
 					if (Core_IsStepping())
-						Core_EnableStepping(false);
+						Core_Resume();
 					Core_Stop();
 					System_PostUIMessage(UIMessage::REQUEST_GAME_STOP);
 					// NOTE: Unlike Windows version, this
@@ -854,7 +854,7 @@ static void ProcessSDLEvent(SDL_Window *window, const SDL_Event &event, InputSta
 				if (ctrl && (k == SDLK_b))
 				{
 					System_PostUIMessage(UIMessage::REQUEST_GAME_RESET);
-					Core_EnableStepping(false);
+					Core_Resume();
 				}
 			}
 			break;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -118,7 +118,7 @@ static void __EmuScreenVblank()
 	if (frameStep_ && lastNumFlips != gpuStats.numFlips)
 	{
 		frameStep_ = false;
-		Core_EnableStepping(true, "ui.frameAdvance", 0);
+		Core_Break("ui.frameAdvance", 0);
 		lastNumFlips = gpuStats.numFlips;
 	}
 #ifndef MOBILE_DEVICE
@@ -495,7 +495,7 @@ static void AfterSaveStateAction(SaveState::Status status, std::string_view mess
 
 static void AfterStateBoot(SaveState::Status status, std::string_view message, void *ignored) {
 	AfterSaveStateAction(status, message, ignored);
-	Core_EnableStepping(false);
+	Core_Resume();
 	System_Notify(SystemNotification::DISASSEMBLY);
 }
 
@@ -658,7 +658,7 @@ void EmuScreen::onVKey(int virtualKeyCode, bool down) {
 	case VIRTKEY_FASTFORWARD:
 		if (down) {
 			if (coreState == CORE_STEPPING) {
-				Core_EnableStepping(false);
+				Core_Resume();
 			}
 			PSP_CoreParameter().fastForward = true;
 		} else {
@@ -1452,10 +1452,10 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 			// If game is running, pause emulation immediately. Otherwise, advance a single frame.
 			if (Core_IsStepping()) {
 				frameStep_ = true;
-				Core_EnableStepping(false);
+				Core_Resume();
 			} else if (!frameStep_) {
 				lastNumFlips = gpuStats.numFlips;
-				Core_EnableStepping(true, "ui.frameAdvance", 0);
+				Core_Break("ui.frameAdvance", 0);
 			}
 		}
 	}

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -918,7 +918,7 @@ UI::ViewGroup *CreatePadLayout(float xres, float yres, bool *pause, bool showPau
 		fastForward->SetAngle(180.0f);
 		fastForward->OnChange.Add([](UI::EventParams &e) {
 			if (e.a && coreState == CORE_STEPPING) {
-				Core_EnableStepping(false);
+				Core_Resume();
 			}
 			return UI::EVENT_DONE;
 		});

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -1428,5 +1428,5 @@ u32 CtrlDisAsmView::getInstructionSizeAt(u32 address)
 {
 	u32 start = manager.getStartAddress(address);
 	u32 next  = manager.getNthNextAddress(start,1);
-	return next-address;
+	return next - address;
 }

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -169,7 +169,7 @@ public:
 	void setCurAddress(u32 newAddress, bool extend = false)
 	{
 		newAddress = manager.getStartAddress(newAddress);
-		u32 after = manager.getNthNextAddress(newAddress,1);
+		const u32 after = manager.getNthNextAddress(newAddress,1);
 		curAddress = newAddress;
 		selectRangeStart = extend ? std::min(selectRangeStart, newAddress) : newAddress;
 		selectRangeEnd = extend ? std::max(selectRangeEnd, after) : after;

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -427,7 +427,7 @@ void CtrlMemView::onChar(WPARAM wParam, LPARAM lParam) {
 
 	bool active = Core_IsActive();
 	if (active)
-		Core_EnableStepping(true, "memory.access", curAddress_);
+		Core_Break("memory.access", curAddress_);
 
 	if (asciiSelected_) {
 		Memory::WriteUnchecked_U8((u8)wParam, curAddress_);
@@ -452,7 +452,7 @@ void CtrlMemView::onChar(WPARAM wParam, LPARAM lParam) {
 
 	Reporting::NotifyDebugger();
 	if (active)
-		Core_EnableStepping(false);
+		Core_Resume();
 }
 
 void CtrlMemView::redraw() {

--- a/Windows/Debugger/DebuggerShared.h
+++ b/Windows/Debugger/DebuggerShared.h
@@ -9,7 +9,8 @@ enum { WM_DEB_GOTOWPARAM = WM_USER+2,
 	WM_DEB_SETDEBUGLPARAM,
 	WM_DEB_UPDATE,
 	WM_DEB_SETSTATUSBARTEXT,
-	WM_DEB_GOTOHEXEDIT
+	WM_DEB_GOTOHEXEDIT,
+	WM_DEB_AFTERSTEP,
 };
 
 bool executeExpressionWindow(HWND hwnd, DebugInterface* cpu, u32& dest);

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -205,17 +205,16 @@ void CDisasm::stepInto()
 	}
 
 	CtrlDisAsmView *ptr = DisAsmView();
+	ptr->setDontRedraw(true);
 	lastTicks_ = CoreTiming::GetTicks();
 
 	u32 stepSize = ptr->getInstructionSizeAt(cpu->GetPC());
 	u32 newAddress = Core_PerformStep(cpu, CPUStepType::Into, stepSize);
 
-	ptr->scrollStepping(newAddress);
 	Sleep(1);
-	ptr->gotoPC();
+	ptr->scrollStepping(newAddress);
+	ptr->gotoAddr(newAddress);
 	UpdateDialog();
-	threadList->reloadThreads();
-	stackTraceView->loadStackTrace();
 }
 
 void CDisasm::stepOver()
@@ -225,24 +224,19 @@ void CDisasm::stepOver()
 	}
 	
 	CtrlDisAsmView *ptr = DisAsmView();
+	ptr->setDontRedraw(true);
 	lastTicks_ = CoreTiming::GetTicks();
 
-	// Not really sure why this is needed here.
-	ptr->setDontRedraw(true);
-
-	// If the current PC is on a breakpoint, the user doesn't want to do nothing.
-	u32 currentPc = cpu->GetPC();
-	u32 stepSize = ptr->getInstructionSizeAt(currentPc);
-	u32 breakpointAddress = Core_PerformStep(cpu, CPUStepType::Over, stepSize);
+	u32 stepSize = ptr->getInstructionSizeAt(cpu->GetPC());
+	u32 newAddress = Core_PerformStep(cpu, CPUStepType::Over, stepSize);
 
 	Sleep(1);
-	ptr->scrollStepping(breakpointAddress);
-	ptr->gotoAddr(breakpointAddress);
+	ptr->scrollStepping(newAddress);
+	ptr->gotoAddr(newAddress);
 	UpdateDialog();
 }
 
 void CDisasm::stepOut() {
-	auto memLock = Memory::Lock();
 	if (!PSP_IsInited())
 		return;
 
@@ -250,10 +244,12 @@ void CDisasm::stepOut() {
 	ptr->setDontRedraw(true);
 	lastTicks_ = CoreTiming::GetTicks();
 
-	u32 breakpointAddress = Core_PerformStep(cpu, CPUStepType::Out, 0);
+	u32 stepSize = ptr->getInstructionSizeAt(cpu->GetPC());
+	u32 newAddress = Core_PerformStep(cpu, CPUStepType::Out, stepSize);
 
 	Sleep(1);
-	ptr->gotoAddr(breakpointAddress);
+	ptr->scrollStepping(newAddress);
+	ptr->gotoAddr(newAddress);
 	UpdateDialog();
 }
 

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -286,7 +286,7 @@ void CDisasm::stepOver()
 	}
 
 	CBreakPoints::AddBreakPoint(breakpointAddress,true);
-	Core_EnableStepping(false);
+	Core_Resume();
 	Sleep(1);
 	ptr->gotoAddr(breakpointAddress);
 	UpdateDialog();
@@ -322,7 +322,7 @@ void CDisasm::stepOut() {
 	ptr->setDontRedraw(true);
 
 	CBreakPoints::AddBreakPoint(breakpointAddress,true);
-	Core_EnableStepping(false);
+	Core_Resume();
 	Sleep(1);
 	ptr->gotoAddr(breakpointAddress);
 	UpdateDialog();
@@ -340,7 +340,7 @@ void CDisasm::runToLine()
 	lastTicks = CoreTiming::GetTicks();
 	ptr->setDontRedraw(true);
 	CBreakPoints::AddBreakPoint(pos,true);
-	Core_EnableStepping(false);
+	Core_Resume();
 }
 
 BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
@@ -418,7 +418,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					bool isRunning = Core_IsActive();
 					if (isRunning)
 					{
-						Core_EnableStepping(true, "cpu.breakpoint.add", 0);
+						Core_Break("cpu.breakpoint.add", 0);
 						Core_WaitInactive(200);
 					}
 
@@ -426,7 +426,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					if (bpw.exec()) bpw.addBreakpoint();
 
 					if (isRunning)
-						Core_EnableStepping(false);
+						Core_Resume();
 					view->UnlockPosition();
 					keepStatusBarText = false;
 				}
@@ -519,7 +519,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					if (!Core_IsStepping())		// stop
 					{
 						ptr->setDontRedraw(false);
-						Core_EnableStepping(true, "ui.break", 0);
+						Core_Break("ui.break", 0);
 						Sleep(1); //let cpu catch up
 						ptr->gotoPC();
 						UpdateDialog();
@@ -529,7 +529,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 						// If the current PC is on a breakpoint, the user doesn't want to do nothing.
 						CBreakPoints::SetSkipFirst(currentMIPS->pc);
 
-						Core_EnableStepping(false);
+						Core_Resume();
 					}
 				}
 				break;
@@ -556,7 +556,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					CBreakPoints::SetSkipFirst(currentMIPS->pc);
 
 					hleDebugBreak();
-					Core_EnableStepping(false);
+					Core_Resume();
 				}
 				break;
 

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -198,7 +198,7 @@ CDisasm::~CDisasm()
 	delete moduleList;
 }
 
-void CDisasm::stepInto()
+void CDisasm::step(CPUStepType stepType)
 {
 	if (!PSP_IsInited() || !Core_IsStepping()) {
 		return;
@@ -209,43 +209,7 @@ void CDisasm::stepInto()
 	lastTicks_ = CoreTiming::GetTicks();
 
 	u32 stepSize = ptr->getInstructionSizeAt(cpu->GetPC());
-	u32 newAddress = Core_PerformStep(cpu, CPUStepType::Into, stepSize);
-
-	Sleep(1);
-	ptr->scrollStepping(newAddress);
-	ptr->gotoAddr(newAddress);
-	UpdateDialog();
-}
-
-void CDisasm::stepOver()
-{
-	if (!PSP_IsInited() || Core_IsActive()) {
-		return;
-	}
-	
-	CtrlDisAsmView *ptr = DisAsmView();
-	ptr->setDontRedraw(true);
-	lastTicks_ = CoreTiming::GetTicks();
-
-	u32 stepSize = ptr->getInstructionSizeAt(cpu->GetPC());
-	u32 newAddress = Core_PerformStep(cpu, CPUStepType::Over, stepSize);
-
-	Sleep(1);
-	ptr->scrollStepping(newAddress);
-	ptr->gotoAddr(newAddress);
-	UpdateDialog();
-}
-
-void CDisasm::stepOut() {
-	if (!PSP_IsInited())
-		return;
-
-	CtrlDisAsmView *ptr = DisAsmView();
-	ptr->setDontRedraw(true);
-	lastTicks_ = CoreTiming::GetTicks();
-
-	u32 stepSize = ptr->getInstructionSizeAt(cpu->GetPC());
-	u32 newAddress = Core_PerformStep(cpu, CPUStepType::Out, stepSize);
+	u32 newAddress = Core_PerformStep(cpu, stepType, stepSize);
 
 	Sleep(1);
 	ptr->scrollStepping(newAddress);
@@ -357,11 +321,11 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 				break;
 
 			case ID_DEBUG_STEPOVER:
-				if (GetFocus() == GetDlgItem(m_hDlg,IDC_DISASMVIEW)) stepOver();
+				if (GetFocus() == GetDlgItem(m_hDlg,IDC_DISASMVIEW)) step(CPUStepType::Over);
 				break;
 
 			case ID_DEBUG_STEPINTO:
-				if (GetFocus() == GetDlgItem(m_hDlg,IDC_DISASMVIEW)) stepInto();
+				if (GetFocus() == GetDlgItem(m_hDlg,IDC_DISASMVIEW)) step(CPUStepType::Into);
 				break;
 
 			case ID_DEBUG_RUNTOLINE:
@@ -369,7 +333,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 				break;
 
 			case ID_DEBUG_STEPOUT:
-				if (GetFocus() == GetDlgItem(m_hDlg,IDC_DISASMVIEW)) stepOut();
+				if (GetFocus() == GetDlgItem(m_hDlg,IDC_DISASMVIEW)) step(CPUStepType::Out);
 				break;
 
 			case ID_DEBUG_HIDEBOTTOMTABS:
@@ -459,15 +423,15 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 				break;
 
 			case IDC_STEP:
-				stepInto();
+				step(CPUStepType::Into);
 				break;
 
 			case IDC_STEPOVER:
-				stepOver();
+				step(CPUStepType::Over);
 				break;
 
 			case IDC_STEPOUT:
-				stepOut();
+				step(CPUStepType::Out);
 				break;
 				
 			case IDC_STEPHLE:

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -398,13 +398,9 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 					if (!PSP_IsInited()) {
 						break;
 					}
-					if (!Core_IsStepping())		// stop
-					{
+					if (!Core_IsStepping())	{  // stop
 						ptr->setDontRedraw(false);
 						Core_Break("ui.break", 0);
-						Sleep(1); //let cpu catch up
-						ptr->gotoPC();
-						UpdateDialog();
 					} else {					// go
 						lastTicks_ = CoreTiming::GetTicks();
 

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -208,14 +208,15 @@ void CDisasm::step(CPUStepType stepType)
 	ptr->setDontRedraw(true);
 	lastTicks_ = CoreTiming::GetTicks();
 
-	u32 oldAddress = cpu->GetPC();
-	u32 stepSize = ptr->getInstructionSizeAt(oldAddress);
+	u32 stepSize = ptr->getInstructionSizeAt(cpu->GetPC());
 	Core_PerformStep(cpu, stepType, stepSize);
 
 	Sleep(1);
+
 	// At this point, the step should be done, and the new address is just PC.
 	// Ideally, this part should be done as a reaction to an update message and not directly here.
 	// That way we could get rid of the sleep.
+	u32 oldAddress = ptr->getSelection();
 	u32 newAddress = cpu->GetPC();
 	if (newAddress > oldAddress && newAddress < oldAddress + 12) {
 		// Heuristic for when to scroll at the edge rather than jump the window.

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -208,11 +208,19 @@ void CDisasm::step(CPUStepType stepType)
 	ptr->setDontRedraw(true);
 	lastTicks_ = CoreTiming::GetTicks();
 
-	u32 stepSize = ptr->getInstructionSizeAt(cpu->GetPC());
-	u32 newAddress = Core_PerformStep(cpu, stepType, stepSize);
+	u32 oldAddress = cpu->GetPC();
+	u32 stepSize = ptr->getInstructionSizeAt(oldAddress);
+	Core_PerformStep(cpu, stepType, stepSize);
 
 	Sleep(1);
-	ptr->scrollStepping(newAddress);
+	// At this point, the step should be done, and the new address is just PC.
+	// Ideally, this part should be done as a reaction to an update message and not directly here.
+	// That way we could get rid of the sleep.
+	u32 newAddress = cpu->GetPC();
+	if (newAddress > oldAddress && newAddress < oldAddress + 12) {
+		// Heuristic for when to scroll at the edge rather than jump the window.
+		ptr->scrollStepping(newAddress);
+	}
 	ptr->gotoAddr(newAddress);
 	UpdateDialog();
 }

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -198,8 +198,7 @@ CDisasm::~CDisasm()
 	delete moduleList;
 }
 
-void CDisasm::step(CPUStepType stepType)
-{
+void CDisasm::step(CPUStepType stepType) {
 	if (!PSP_IsInited() || !Core_IsStepping()) {
 		return;
 	}
@@ -213,17 +212,12 @@ void CDisasm::step(CPUStepType stepType)
 
 	Sleep(1);
 
-	// At this point, the step should be done, and the new address is just PC.
-	// Ideally, this part should be done as a reaction to an update message and not directly here.
-	// That way we could get rid of the sleep.
-	u32 oldAddress = ptr->getSelection();
-	u32 newAddress = cpu->GetPC();
-	if (newAddress > oldAddress && newAddress < oldAddress + 12) {
-		// Heuristic for when to scroll at the edge rather than jump the window.
-		ptr->scrollStepping(newAddress);
-	}
-	ptr->gotoAddr(newAddress);
-	UpdateDialog();
+	// TODO: This should be called from ProcessStep
+	NotifyStepDone();
+}
+
+void CDisasm::NotifyStepDone() {
+	PostMessage(m_hDlg, WM_DEB_AFTERSTEP, 0, 0);
 }
 
 void CDisasm::runToLine() {
@@ -484,6 +478,23 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 	case WM_DEB_MAPLOADED:
 		NotifyMapLoaded();
 		break;
+
+	case WM_DEB_AFTERSTEP:
+	{
+		CtrlDisAsmView *ptr = DisAsmView();
+		// At this point, the step should be done, and the new address is just PC.
+		// Ideally, this part should be done as a reaction to an update message and not directly here.
+		// That way we could get rid of the sleep.
+		u32 oldAddress = ptr->getSelection();
+		u32 newAddress = cpu->GetPC();
+		if (newAddress > oldAddress && newAddress < oldAddress + 12) {
+			// Heuristic for when to scroll at the edge rather than jump the window.
+			ptr->scrollStepping(newAddress);
+		}
+		ptr->gotoAddr(newAddress);
+		UpdateDialog();
+		break;
+	}
 
 	case WM_DEB_GOTOWPARAM:
 	{

--- a/Windows/Debugger/Debugger_Disasm.h
+++ b/Windows/Debugger/Debugger_Disasm.h
@@ -59,7 +59,6 @@ public:
 
 	void Goto(u32 addr);
 	void NotifyMapLoaded();
-	void NotifyStepDone();
 
 private:
 	CtrlDisAsmView *DisAsmView();

--- a/Windows/Debugger/Debugger_Disasm.h
+++ b/Windows/Debugger/Debugger_Disasm.h
@@ -38,9 +38,7 @@ private:
 	void UpdateSize(WORD width, WORD height);
 	void SavePosition();
 	void updateThreadLabel(bool clear);
-	void stepInto();
-	void stepOver();
-	void stepOut();
+	void step(CPUStepType stepType);
 	void runToLine();
 
 public:

--- a/Windows/Debugger/Debugger_Disasm.h
+++ b/Windows/Debugger/Debugger_Disasm.h
@@ -18,7 +18,7 @@ private:
 	int minWidth;
 	int minHeight;
 	DebugInterface *cpu;
-	u64 lastTicks;
+	u64 lastTicks_;
 
 	HWND statusBarWnd;
 	CtrlBreakpointList* breakpointList;

--- a/Windows/Debugger/Debugger_Disasm.h
+++ b/Windows/Debugger/Debugger_Disasm.h
@@ -59,6 +59,7 @@ public:
 
 	void Goto(u32 addr);
 	void NotifyMapLoaded();
+	void NotifyStepDone();
 
 private:
 	CtrlDisAsmView *DisAsmView();

--- a/Windows/Debugger/DumpMemoryWindow.cpp
+++ b/Windows/Debugger/DumpMemoryWindow.cpp
@@ -82,7 +82,7 @@ INT_PTR CALLBACK DumpMemoryWindow::dlgFunc(HWND hwnd, UINT iMsg, WPARAM wParam, 
 				bool priorDumpWasStepping = Core_IsStepping();
 				if (!priorDumpWasStepping && PSP_IsInited()) {
 					// If emulator isn't paused force paused state, but wait before locking.
-					Core_EnableStepping(true, "memory.access", bp->start);
+					Core_Break("memory.access", bp->start);
 					Core_WaitInactive();
 				}
 
@@ -117,7 +117,7 @@ INT_PTR CALLBACK DumpMemoryWindow::dlgFunc(HWND hwnd, UINT iMsg, WPARAM wParam, 
 				fclose(output);
 				if (!priorDumpWasStepping) {
 					// If emulator wasn't paused before memory dump resume emulation automatically.
-					Core_EnableStepping(false);
+					Core_Resume();
 				}
 
 				MessageBoxA(hwnd, "Done.", "Information", MB_OK);

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -285,7 +285,7 @@ void MainThreadFunc() {
 	if (g_Config.bBrowse)
 		PostMessage(MainWindow::GetHWND(), WM_COMMAND, ID_FILE_LOAD, 0);
 
-	Core_EnableStepping(false);
+	Core_Resume();
 
 	if (useEmuThread) {
 		while (emuThreadState != (int)EmuThreadState::DISABLED) {

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -841,10 +841,15 @@ namespace MainWindow
 				}
 				if (!noFocusPause && g_Config.bPauseOnLostFocus && GetUIState() == UISTATE_INGAME) {
 					if (pause != Core_IsStepping()) {
-						if (disasmWindow)
+						if (disasmWindow) {
 							SendMessage(disasmWindow->GetDlgHandle(), WM_COMMAND, IDC_STOPGO, 0);
-						else
-							Core_EnableStepping(pause, "ui.lost_focus", 0);
+						} else {
+							if (pause) {
+								Core_Break("ui.lost_focus", 0);
+							} else {
+								Core_Resume();
+							}
+						}
 					}
 				}
 
@@ -1018,7 +1023,7 @@ namespace MainWindow
 					if (DragQueryFile(hdrop, 0, filename, ARRAY_SIZE(filename)) != 0) {
 						const std::string utf8_filename = ReplaceAll(ConvertWStringToUTF8(filename), "\\", "/");
 						System_PostUIMessage(UIMessage::REQUEST_GAME_BOOT, utf8_filename);
-						Core_EnableStepping(false);
+						Core_Resume();
 					}
 				}
 				DragFinish(hdrop);

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -330,7 +330,7 @@ namespace MainWindow {
 		if (GetUIState() == UISTATE_INGAME) {
 			browsePauseAfter = Core_IsStepping();
 			if (!browsePauseAfter)
-				Core_EnableStepping(true, "ui.boot", 0);
+				Core_Break("ui.boot", 0);
 		}
 		auto mm = GetI18NCategory(I18NCat::MAINMENU);
 
@@ -349,7 +349,7 @@ namespace MainWindow {
 
 	void BrowseAndBootDone(std::string filename) {
 		if (GetUIState() == UISTATE_INGAME || GetUIState() == UISTATE_EXCEPTION || GetUIState() == UISTATE_PAUSEMENU) {
-			Core_EnableStepping(false);
+			Core_Resume();
 		}
 		filename = ReplaceAll(filename, "\\", "/");
 		System_PostUIMessage(UIMessage::REQUEST_GAME_BOOT, filename);
@@ -475,12 +475,12 @@ namespace MainWindow {
 				if (disasmWindow)
 					SendMessage(disasmWindow->GetDlgHandle(), WM_COMMAND, IDC_STOPGO, 0);
 				else
-					Core_EnableStepping(false);
+					Core_Resume();
 			} else {
 				if (disasmWindow)
 					SendMessage(disasmWindow->GetDlgHandle(), WM_COMMAND, IDC_STOPGO, 0);
 				else
-					Core_EnableStepping(true, "ui.break", 0);
+					Core_Break("ui.break", 0);
 			}
 			noFocusPause = !noFocusPause;	// If we pause, override pause on lost focus
 			break;
@@ -491,7 +491,7 @@ namespace MainWindow {
 
 		case ID_EMULATION_STOP:
 			if (Core_IsStepping())
-				Core_EnableStepping(false);
+				Core_Resume();
 
 			Core_Stop();
 			System_PostUIMessage(UIMessage::REQUEST_GAME_STOP);
@@ -500,7 +500,7 @@ namespace MainWindow {
 
 		case ID_EMULATION_RESET:
 			System_PostUIMessage(UIMessage::REQUEST_GAME_RESET);
-			Core_EnableStepping(false);
+			Core_Resume();
 			break;
 
 		case ID_EMULATION_SWITCH_UMD:

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -436,6 +436,11 @@ void System_Notify(SystemNotification notification) {
 			PostDialogMessage(disasmWindow, WM_DEB_UPDATE);
 		break;
 
+	case SystemNotification::DISASSEMBLY_AFTERSTEP:
+		if (disasmWindow)
+			PostDialogMessage(disasmWindow, WM_DEB_AFTERSTEP);
+		break;
+
 	case SystemNotification::SYMBOL_MAP_UPDATED:
 		if (g_symbolMap)
 			g_symbolMap->SortSymbols();  // internal locking is performed here


### PR DESCRIPTION
This is a first, very tiny step towards a cross platform debugger. This simplifies and moves some tricky CPU stepping logic out of the debug window code, so it can be shared with the new debugger.

A lot more refactoring is needed before we can start to implement it, though, and it depends on merging #19569 .