### PR TITLE
Add missing return statement from PBPReader::GetSubFileAsString. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ include/glslang/build_info.h
 
 # For ppsspp.ini, etc.
 ppsspp.ini
+imgui.ini
 PPSSPPControls.dat
 
 # Qt Linguist files
@@ -101,6 +102,7 @@ local.properties
 r.sh
 Windows/compileData*
 Windows/*.ipch
+Windows/imgui.ini
 
 # For vim
 *.swp

--- a/Core/ELF/PBPReader.cpp
+++ b/Core/ELF/PBPReader.cpp
@@ -95,8 +95,10 @@ bool PBPReader::GetSubFileAsString(PBPSubFile file, std::string *out) const {
 		ERROR_LOG(Log::Loader, "PBP file read truncated: %d -> %d", (int)expected, (int)bytes);
 		if (bytes < expected) {
 			out->resize(bytes);
+			// should we still return true here?
 		}
 	}
+	return true;
 }
 
 PBPReader::~PBPReader() {


### PR DESCRIPTION
Compiler should have rejected this, sigh...

There will definitely be an 1.18.1.