### PR TITLE
GCC/llvm: Enable a lot more warnings, error on missing return value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,10 @@ if(NOT MSVC)
 	# NEON optimizations in libpng17 seem to cause PNG load errors, see #14485.
 	add_definitions(-DPNG_ARM_NEON_OPT=0)
 
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror=return-type -Wno-unused-function -Wno-sign-compare -Wno-unused-but-set-variable -Wno-reorder -Wno-unknown-pragmas -Wno-unused-value -Wno-unused-variable")
+	# This one is very useful but has many false positives.
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-class-memaccess")
+
 	if(ANDROID)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17")
 	endif()

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -91,7 +91,7 @@ void CalculateDisplayOutputRect(FRect *rc, float origW, float origH, const FRect
 		// Automatically set aspect ratio to match the display, IF the rotation matches the output display ratio! Otherwise, just
 		// sets standard aspect ratio because actually stretching will just look silly.
 		bool globalRotated = g_display.rotation == DisplayRotation::ROTATE_90 || g_display.rotation == DisplayRotation::ROTATE_270;
-		if (rotated == g_display.dp_yres > g_display.dp_xres) {
+		if (rotated == (g_display.dp_yres > g_display.dp_xres)) {
 			origRatio = frameRatio;
 		} else {
 			origRatio *= aspectRatioAdjust;

--- a/ios/main.mm
+++ b/ios/main.mm
@@ -417,7 +417,7 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
         dispatch_async(dispatch_get_main_queue(), ^{
 			[(AppDelegate *)[[UIApplication sharedApplication] delegate] restart:param1.c_str()];
 		});
-		break;
+		return true;
 
 	case SystemRequestType::EXIT_APP:
 		// NOTE: on iOS, this is considered a crash and not a valid way to exit.
@@ -508,8 +508,9 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
         });
 		return true;
 	default:
-		return false;
+		break;
 	}
+	return false;
 }
 
 void System_Toast(std::string_view text) {}


### PR DESCRIPTION
Should prevent #19579 from ever happening again, hopefully.

This is the key, and everyone should always enable it: `-Werror=return-type`