### PR TITLE
Fix for error taking screenshots in Vulkan on many devices

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -1491,16 +1491,11 @@ bool VulkanContext::InitSwapchain() {
 
 	presentMode_ = swapchainPresentMode;
 
-	// Don't ask for TRANSFER_DST for the swapchain image, we don't use that.
-	// if (surfCapabilities_.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_DST_BIT)
-	//	swap_chain_info.imageUsage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-
-#ifndef ANDROID
-	// We don't support screenshots on Android
-	// Add more usage flags if they're supported.
-	if (surfCapabilities_.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
+	// We don't support screenshots on Android if TRANSFER_SRC usage flag is not supported.
+	if (surfCapabilities_.supportedUsageFlags & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) {
+		INFO_LOG(Log::G3D, "Swapchain supports TRANSFER_SRC");
 		swap_chain_info.imageUsage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-#endif
+	}
 
 	swap_chain_info.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
 	swap_chain_info.queueFamilyIndexCount = 0;

--- a/Core/Screenshot.cpp
+++ b/Core/Screenshot.cpp
@@ -346,7 +346,7 @@ bool TakeGameScreenshot(Draw::DrawContext *draw, const Path &filename, Screensho
 	} else if (g_display.rotation != DisplayRotation::ROTATE_0) {
 		_dbg_assert_(draw);
 		GPUDebugBuffer temp;
-		success = ::GetOutputFramebuffer(draw, buf);
+		success = ::GetOutputFramebuffer(draw, temp);
 		if (success) {
 			buf = ApplyRotation(temp, g_display.rotation);
 		}


### PR DESCRIPTION
Was trying to rotate an empty buffer instead of the screenshot, oops.

Only affects Android since it's the only platform that uses rotated framebuffers.

Additionally, fix a validation error.  (not actually checking the flag when taking a screenshot, because support for TRANSFER_SRC on swapchain images seems universal).

Fixes #19585 