### PR TITLE
Disable debuggers when the RetroAchievements hardcore mode is enabled

### DIFF
--- a/Core/RetroAchievements.h
+++ b/Core/RetroAchievements.h
@@ -54,6 +54,9 @@ bool IsBlockingExecution();
 //
 // * Savestates
 // * Slowdown time (though hard to fully prevent, could use crazy post shaders or software rendering...)
+// * Debugging
+// * Cheats
+// * and similar...
 bool HardcoreModeActive();
 
 // Same as ChallengeModeActive but comes with a convenient user message. Don't use for every-frame checks or UI enablement,

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -2,6 +2,7 @@
 #include "ext/imgui/imgui_internal.h"
 
 #include "Common/StringUtils.h"
+#include "Core/RetroAchievements.h"
 #include "Core/Core.h"
 #include "Core/Debugger/DebugInterface.h"
 #include "Core/Debugger/DisassemblyManager.h"
@@ -235,6 +236,14 @@ void DrawModules(MIPSDebugInterface *debug, bool *open) {
 void ImDebugger::Frame(MIPSDebugInterface *mipsDebug) {
 	// Snapshot the coreState to avoid inconsistency.
 	const CoreState coreState = ::coreState;
+
+	if (Achievements::HardcoreModeActive()) {
+		ImGui::Begin("RetroAchievements hardcore mode");
+		ImGui::Text("The debugger may not be used when the\nRetroAchievements hardcore mode is enabled.");
+		ImGui::Text("To use the debugger, go into Settings / Tools / RetroAchievements and disable them.");
+		ImGui::End();
+		return;
+	}
 
 	if (ImGui::BeginMainMenuBar()) {
 		if (ImGui::BeginMenu("Debug")) {

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -19,6 +19,7 @@
 #include "Windows/Debugger/DebuggerShared.h"
 #include "Windows/Debugger/BreakpointWindow.h"
 #include "Windows/Debugger/EditSymbolsWindow.h"
+#include "Core/RetroAchievements.h"
 #include "Windows/main.h"
 
 #include "Common/CommonWindows.h"
@@ -492,7 +493,7 @@ void CtrlDisAsmView::drawArguments(HDC hdc, const DisassemblyLineInfo &line, int
 void CtrlDisAsmView::onPaint(WPARAM wParam, LPARAM lParam)
 {
 	auto memLock = Memory::Lock();
-	if (!debugger->isAlive()) return;
+	if (!debugger->isAlive() || Achievements::HardcoreModeActive()) return;
 
 	PAINTSTRUCT ps;
 	HDC actualHdc = BeginPaint(wnd, &ps);
@@ -672,6 +673,9 @@ void CtrlDisAsmView::followBranch()
 
 void CtrlDisAsmView::onChar(WPARAM wParam, LPARAM lParam)
 {
+	if (Achievements::HardcoreModeActive())
+		return;
+
 	if (keyTaken) return;
 
 	char str[2];
@@ -713,6 +717,9 @@ void CtrlDisAsmView::editBreakpoint()
 
 void CtrlDisAsmView::onKeyDown(WPARAM wParam, LPARAM lParam)
 {
+	if (Achievements::HardcoreModeActive())
+		return;
+
 	dontRedraw = false;
 	u32 windowEnd = manager.getNthNextAddress(windowStart,visibleRows);
 	keyTaken = true;
@@ -884,6 +891,8 @@ void CtrlDisAsmView::toggleBreakpoint(bool toggleEnabled)
 
 void CtrlDisAsmView::onMouseDown(WPARAM wParam, LPARAM lParam, int button)
 {
+	if (Achievements::HardcoreModeActive())
+		return;
 	dontRedraw = false;
 	int y = HIWORD(lParam);
 
@@ -947,6 +956,9 @@ void CtrlDisAsmView::NopInstructions(u32 selectRangeStart, u32 selectRangeEnd) {
 
 void CtrlDisAsmView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 {
+	if (Achievements::HardcoreModeActive())
+		return;
+
 	if (button == 1)
 	{
 		int y = HIWORD(lParam);
@@ -1112,6 +1124,9 @@ void CtrlDisAsmView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 
 void CtrlDisAsmView::onMouseMove(WPARAM wParam, LPARAM lParam, int button)
 {
+	if (Achievements::HardcoreModeActive())
+		return;
+
 	if ((button & 1) != 0)
 	{
 		int y = HIWORD(lParam);

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -9,6 +9,7 @@
 #include "Core/Config.h"
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
+#include "Core/RetroAchievements.h"
 #include "Windows/W32Util/ContextMenu.h"
 #include "Windows/W32Util/Misc.h"
 #include "Windows/InputBox.h"
@@ -177,6 +178,9 @@ CtrlMemView *CtrlMemView::getFrom(HWND hwnd) {
 
 
 void CtrlMemView::onPaint(WPARAM wParam, LPARAM lParam) {
+	if (Achievements::HardcoreModeActive())
+		return;
+
 	auto memLock = Memory::Lock();
 
 	// draw to a bitmap for double buffering
@@ -484,6 +488,9 @@ CtrlMemView::GotoMode CtrlMemView::GotoModeFromModifiers(bool isRightClick) {
 }
 
 void CtrlMemView::onMouseDown(WPARAM wParam, LPARAM lParam, int button) {
+	if (Achievements::HardcoreModeActive())
+		return;
+
 	int x = LOWORD(lParam); 
 	int y = HIWORD(lParam);
 
@@ -491,6 +498,9 @@ void CtrlMemView::onMouseDown(WPARAM wParam, LPARAM lParam, int button) {
 }
 
 void CtrlMemView::onMouseUp(WPARAM wParam, LPARAM lParam, int button) {
+	if (Achievements::HardcoreModeActive())
+		return;
+
 	if (button == 2) {
 		int32_t selectedSize = selectRangeEnd_ - selectRangeStart_;
 		bool enable16 = !asciiSelected_ && (selectedSize == 1 || (selectedSize & 1) == 0);
@@ -638,6 +648,9 @@ void CtrlMemView::onMouseUp(WPARAM wParam, LPARAM lParam, int button) {
 }
 
 void CtrlMemView::onMouseMove(WPARAM wParam, LPARAM lParam, int button) {
+	if (Achievements::HardcoreModeActive())
+		return;
+
 	int x = LOWORD(lParam);
 	int y = HIWORD(lParam);
 

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -5,6 +5,7 @@
 
 #include "Core/Debugger/Breakpoints.h"
 #include "Core/Debugger/SymbolMap.h"
+#include "Core/RetroAchievements.h"
 #include "Windows/Debugger/BreakpointWindow.h"
 #include "Windows/Debugger/CtrlDisAsmView.h"
 #include "Windows/Debugger/Debugger_MemoryDlg.h"
@@ -262,6 +263,9 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam)
 		break;
 	case WM_COMMAND:
 		{
+			if (Achievements::HardcoreModeActive())
+				return TRUE;
+
 			CtrlDisAsmView *ptr = DisAsmView();
 			switch (LOWORD(wParam)) {
 			case ID_TOGGLE_BREAK:

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -85,11 +85,13 @@ namespace MainWindow {
 			}
 		}
 
-		UINT menuEnable = menuEnableBool ? MF_ENABLED : MF_GRAYED;
-		UINT loadStateEnable = loadStateEnableBool ? MF_ENABLED : MF_GRAYED;
-		UINT saveStateEnable = saveStateEnableBool ? MF_ENABLED : MF_GRAYED;
-		UINT menuInGameEnable = state == UISTATE_INGAME ? MF_ENABLED : MF_GRAYED;
-		UINT umdSwitchEnable = state == UISTATE_INGAME && getUMDReplacePermit() ? MF_ENABLED : MF_GRAYED;
+		const UINT menuEnable = menuEnableBool ? MF_ENABLED : MF_GRAYED;
+		const UINT loadStateEnable = loadStateEnableBool ? MF_ENABLED : MF_GRAYED;
+		const UINT saveStateEnable = saveStateEnableBool ? MF_ENABLED : MF_GRAYED;
+		const UINT menuInGameEnable = state == UISTATE_INGAME ? MF_ENABLED : MF_GRAYED;
+		const UINT umdSwitchEnable = state == UISTATE_INGAME && getUMDReplacePermit() ? MF_ENABLED : MF_GRAYED;
+		const UINT debugEnable = !Achievements::HardcoreModeActive() ? MF_ENABLED : MF_GRAYED;
+		const UINT debugIngameEnable = (state == UISTATE_INGAME && !Achievements::HardcoreModeActive()) ? MF_ENABLED : MF_GRAYED;
 
 		EnableMenuItem(menu, ID_FILE_SAVESTATE_SLOT_MENU, saveStateEnable);
 		EnableMenuItem(menu, ID_FILE_SAVESTATEFILE, saveStateEnable);
@@ -101,15 +103,18 @@ namespace MainWindow {
 		EnableMenuItem(menu, ID_EMULATION_RESET, menuEnable);
 		EnableMenuItem(menu, ID_EMULATION_SWITCH_UMD, umdSwitchEnable);
 		EnableMenuItem(menu, ID_EMULATION_CHAT, g_Config.bEnableNetworkChat ? menuInGameEnable : MF_GRAYED);
-		EnableMenuItem(menu, ID_TOGGLE_BREAK, menuEnable);
-		EnableMenuItem(menu, ID_DEBUG_LOADMAPFILE, menuEnable);
-		EnableMenuItem(menu, ID_DEBUG_SAVEMAPFILE, menuEnable);
-		EnableMenuItem(menu, ID_DEBUG_LOADSYMFILE, menuEnable);
-		EnableMenuItem(menu, ID_DEBUG_SAVESYMFILE, menuEnable);
-		EnableMenuItem(menu, ID_DEBUG_RESETSYMBOLTABLE, menuEnable);
-		EnableMenuItem(menu, ID_DEBUG_SHOWDEBUGSTATISTICS, menuInGameEnable);
+		EnableMenuItem(menu, ID_TOGGLE_BREAK, debugIngameEnable);
+		EnableMenuItem(menu, ID_DEBUG_LOADMAPFILE, debugIngameEnable);
+		EnableMenuItem(menu, ID_DEBUG_SAVEMAPFILE, debugIngameEnable);
+		EnableMenuItem(menu, ID_DEBUG_LOADSYMFILE, debugIngameEnable);
+		EnableMenuItem(menu, ID_DEBUG_SAVESYMFILE, debugIngameEnable);
+		EnableMenuItem(menu, ID_DEBUG_RESETSYMBOLTABLE, debugIngameEnable);
+		EnableMenuItem(menu, ID_DEBUG_SHOWDEBUGSTATISTICS, debugEnable);
 		EnableMenuItem(menu, ID_DEBUG_EXTRACTFILE, menuEnable);
 		EnableMenuItem(menu, ID_DEBUG_MEMORYBASE, menuInGameEnable);
+		EnableMenuItem(menu, ID_DEBUG_DISASSEMBLY, debugEnable);
+		EnableMenuItem(menu, ID_DEBUG_MEMORYVIEW, debugEnable);
+		EnableMenuItem(menu, ID_DEBUG_GEDEBUGGER, debugEnable);
 
 		// While playing, this pop up doesn't work - and probably doesn't make sense.
 		EnableMenuItem(menu, ID_OPTIONS_LANGUAGE, state == UISTATE_INGAME ? MF_GRAYED : MF_ENABLED);


### PR DESCRIPTION
Disables the Win32 and imgui debuggers in this case, as it should according to the RA rules.