### PR TITLE
Memory::IsValidAddress: Consider VRAM with a kernel flag invalid.

### DIFF
--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -286,7 +286,7 @@ inline bool IsValidAddress(const u32 address) {
 	if ((address & 0x3E000000) == 0x08000000) {
 		return true;
 	} else if ((address & 0x3F800000) == 0x04000000) {
-		return true;
+		return address < 0x80000000;  // Let's disallow kernel-flagged VRAM. We don't have it mapped and I am not sure if it's accessible.
 	} else if ((address & 0xBFFFC000) == 0x00010000) {
 		return true;
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
@@ -300,7 +300,7 @@ inline bool IsValid4AlignedAddress(const u32 address) {
 	if ((address & 0x3E000003) == 0x08000000) {
 		return true;
 	} else if ((address & 0x3F800003) == 0x04000000) {
-		return true;
+		return address < 0x80000000;  // Let's disallow kernel-flagged VRAM. We don't have it mapped and I am not sure if it's accessible.
 	} else if ((address & 0xBFFFC003) == 0x00010000) {
 		return true;
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {
@@ -310,12 +310,15 @@ inline bool IsValid4AlignedAddress(const u32 address) {
 	}
 }
 
-
 inline u32 MaxSizeAtAddress(const u32 address){
 	if ((address & 0x3E000000) == 0x08000000) {
 		return 0x08000000 + g_MemorySize - (address & 0x3FFFFFFF);
 	} else if ((address & 0x3F800000) == 0x04000000) {
-		return 0x04800000 - (address & 0x3FFFFFFF);
+		if (address & 0x80000000) {
+			return 0;
+		} else {
+			return 0x04800000 - (address & 0x3FFFFFFF);
+		}
 	} else if ((address & 0xBFFFC000) == 0x00010000) {
 		return 0x00014000 - (address & 0x3FFFFFFF);
 	} else if ((address & 0x3F000000) >= 0x08000000 && (address & 0x3F000000) < 0x08000000 + g_MemorySize) {


### PR DESCRIPTION
We don't have it mapped in our memory map, so this can actually crash checked reads like Read_U32.

Since it isn't mapped, and it can't possibly be valid in retail PSP games to access VRAM this way, I don't think this will cause any problems.

However, if it does, we'll have to add the corresponding mappings to the memory map.