### PR TITLE
Force LoongArchCPUInfoParser::TotalLogicalCount() to always return

### DIFF
--- a/Common/LoongArchCPUDetect.cpp
+++ b/Common/LoongArchCPUDetect.cpp
@@ -94,15 +94,11 @@ int LoongArchCPUInfoParser::TotalLogicalCount() {
 		int low, high, found;
 		std::getline(presentFile, line);
 		found = sscanf(line.c_str(), "%d-%d", &low, &high);
-		if (found == 1){
-			return 1;
-		}
 		if (found == 2){
 			return high - low + 1;
 		}
-	}else{
-		return 1;
 	}
+	return 1;
 }
 
 #endif


### PR DESCRIPTION
Can't compile project because LoongArchCPUInfoParser::TotalLogicalCount() does not return in some cases (this causes compiler error). So I fixed it.