### PR TITLE
Optimize Buffer slightly more, fix using touchscreen controls using the mouse

### DIFF
--- a/Common/Buffer.cpp
+++ b/Common/Buffer.cpp
@@ -95,12 +95,12 @@ int Buffer::SkipLineCRLF() {
 
 // This relies on having buffered data!
 int Buffer::OffsetToAfterNextCRLF() {
-	for (int i = 0; i < (int)data_.size() - 1; i++) {
-		if (data_.peek(i) == '\r' && data_.peek(i + 1) == '\n') {
-			return i + 2;
-		}
+	int offset = data_.next_crlf_offset();
+	if (offset >= 0) {
+		return offset + 2;
+	} else {
+		return -1;
 	}
-	return -1;
 }
 
 void Buffer::Printf(const char *fmt, ...) {

--- a/Common/Data/Collections/CharQueue.h
+++ b/Common/Data/Collections/CharQueue.h
@@ -186,6 +186,27 @@ public:
 		head_ = b;
 	}
 
+	// If return value is negative, one wasn't found.
+	int next_crlf_offset() {
+		int offset = 0;
+		Block *b = head_;
+		do {
+			int remain = b->tail - b->head;
+			for (int i = 0; i < remain; i++) {
+				if (b->data[b->head + i] == '\r') {
+					// Use peek to avoid handling edge cases.
+					if (peek(offset + i + 1) == '\n') {
+						return offset + i;
+					}
+				}
+			}
+			offset += remain;
+			b = b->next;
+		} while (b);
+		// Ran out of data.
+		return -1;
+	}
+
 private:
 	struct Block {
 		~Block() {

--- a/Common/Net/NetBuffer.cpp
+++ b/Common/Net/NetBuffer.cpp
@@ -122,7 +122,7 @@ bool Buffer::ReadAllWithProgress(int fd, int knownSize, RequestProgress *progres
 }
 
 int Buffer::Read(int fd, size_t sz) {
-	char buf[1024];
+	char buf[4096];
 	int retval;
 	size_t received = 0;
 	while ((retval = recv(fd, buf, std::min(sz, sizeof(buf)), MSG_NOSIGNAL)) > 0) {

--- a/Common/Net/NetBuffer.cpp
+++ b/Common/Net/NetBuffer.cpp
@@ -15,6 +15,10 @@
 #define MSG_NOSIGNAL 0x00
 #endif
 
+#if _MSC_VER
+#pragma warning(disable:4267)
+#endif
+
 #include "Common/File/FileDescriptor.h"
 #include "Common/Log.h"
 #include "Common/Net/NetBuffer.h"

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -107,10 +107,12 @@ bool MultiTouchButton::Touch(const TouchInput &input) {
 		usedPointerMask |= 1 << input.id;
 	}
 	if (input.flags & TOUCH_MOVE) {
-		if (bounds_.Contains(input.x, input.y) && !(analogPointerMask & (1 << input.id)))
-			pointerDownMask_ |= 1 << input.id;
-		else
-			pointerDownMask_ &= ~(1 << input.id);
+		if (!(input.flags & TOUCH_MOUSE) || input.buttons) {
+			if (bounds_.Contains(input.x, input.y) && !(analogPointerMask & (1 << input.id)))
+				pointerDownMask_ |= 1 << input.id;
+			else
+				pointerDownMask_ &= ~(1 << input.id);
+		}
 	}
 	if (input.flags & TOUCH_UP) {
 		pointerDownMask_ &= ~(1 << input.id);
@@ -291,11 +293,13 @@ bool PSPDpad::Touch(const TouchInput &input) {
 		}
 	}
 	if (input.flags & TOUCH_MOVE) {
-		if (dragPointerId_ == -1 && bounds_.Contains(input.x, input.y) && !(analogPointerMask & (1 << input.id))) {
-			dragPointerId_ = input.id;
-		}
-		if (input.id == dragPointerId_) {
-			ProcessTouch(input.x, input.y, true);
+		if (!(input.flags & TOUCH_MOUSE) || input.buttons) {
+			if (dragPointerId_ == -1 && bounds_.Contains(input.x, input.y) && !(analogPointerMask & (1 << input.id))) {
+				dragPointerId_ = input.id;
+			}
+			if (input.id == dragPointerId_) {
+				ProcessTouch(input.x, input.y, true);
+			}
 		}
 	}
 	if (input.flags & TOUCH_UP) {

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -1076,6 +1076,10 @@ bool TestCharQueue() {
 	queue.pop_front_bulk(dest, 4);
 	EXPECT_EQ_MEM(dest, "opqr", 4);
 	EXPECT_TRUE(queue.empty());
+	queue.push_back("asdf");
+	EXPECT_EQ_INT(queue.next_crlf_offset(), -1);
+	queue.push_back("\r\r\n");
+	EXPECT_EQ_INT(queue.next_crlf_offset(), 5);
 	return true;
 }
 


### PR DESCRIPTION
Somewhat quicker searching for CRLF in buffers.

The touchscreen controls didn't expect mousemove events without buttons pressed, so fix that.