### PR TITLE
ImDebugger: Framebuffer listing, keyboard shortcuts and more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1524,6 +1524,8 @@ list(APPEND NativeAppSource
 	android/jni/TestRunner.cpp
 	UI/ImDebugger/ImDebugger.cpp
 	UI/ImDebugger/ImDebugger.h
+	UI/ImDebugger/ImGe.cpp
+	UI/ImDebugger/ImGe.h
 	UI/ImDebugger/ImDisasmView.cpp
 	UI/ImDebugger/ImDisasmView.h
 	UI/ImDebugger/ImStructViewer.cpp

--- a/Common/GPU/Vulkan/thin3d_vulkan.cpp
+++ b/Common/GPU/Vulkan/thin3d_vulkan.cpp
@@ -1723,6 +1723,9 @@ public:
 	void UpdateTag(const char *newTag) override {
 		buf_->UpdateTag(newTag);
 	}
+	const char *Tag() const override {
+		return buf_->Tag();
+	}
 private:
 	VKRFramebuffer *buf_;
 };

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -457,6 +457,8 @@ public:
 	int MultiSampleLevel() const { return multiSampleLevel_; }
 
 	virtual void UpdateTag(const char *tag) {}
+	virtual const char *Tag() { return "(no name)"; }
+
 protected:
 	int width_ = -1, height_ = -1, layers_ = 1, multiSampleLevel_ = 0;
 };

--- a/Common/GPU/thin3d.h
+++ b/Common/GPU/thin3d.h
@@ -457,7 +457,7 @@ public:
 	int MultiSampleLevel() const { return multiSampleLevel_; }
 
 	virtual void UpdateTag(const char *tag) {}
-	virtual const char *Tag() { return "(no name)"; }
+	virtual const char *Tag() const { return "(no name)"; }
 
 protected:
 	int width_ = -1, height_ = -1, layers_ = 1, multiSampleLevel_ = 0;

--- a/Common/Log/ConsoleListener.cpp
+++ b/Common/Log/ConsoleListener.cpp
@@ -153,6 +153,7 @@ void ConsoleListener::Close() {
 	if (thread_.joinable()) {
 		logPendingWritePos_.store((u32)-1, std::memory_order_release);
 		SetEvent(hTriggerEvent);
+		// If we seem hung here, it's just that you made a selection in the debug console, blocking output.
 		thread_.join();
 	}
 	if (hTriggerEvent) {

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -3703,4 +3703,6 @@ void FramebufferManagerCommon::DrawImGuiDebug(int &selected) const {
 		ImGui::PopID();
 	}
 	ImGui::EndTable();
+
+	// Now, draw the actual framebuffer image. This could be refined a lot.
 }

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -19,6 +19,8 @@
 #include <sstream>
 #include <cmath>
 
+#include "ext/imgui/imgui.h"
+
 #include "Common/GPU/thin3d.h"
 #include "Common/GPU/OpenGL/GLFeatures.h"
 #include "Common/Data/Collections/TinySet.h"
@@ -3660,4 +3662,45 @@ static void ApplyKillzoneFramebufferSplit(FramebufferHeuristicParams *params, in
 		gstate_c.SetCurRTOffset(0, 0);
 		*drawing_width = 480;
 	}
+}
+
+void FramebufferManagerCommon::DrawImGuiDebug(int &selected) const {
+	ImGui::BeginTable("framebuffers", 4);
+	ImGui::TableSetupColumn("Tag");
+	ImGui::TableSetupColumn("Color Addr");
+	ImGui::TableSetupColumn("Depth Addr");
+	ImGui::TableSetupColumn("Size");
+
+	ImGui::TableHeadersRow();
+	ImGui::TableSetColumnIndex(0);
+
+	for (int i = 0; i < (int)vfbs_.size(); i++) {
+		ImGui::TableNextRow();
+		ImGui::TableNextColumn();
+
+		auto &vfb = vfbs_[i];
+
+		const char *tag = vfb->fbo ? vfb->fbo->Tag() : "(no tag)";
+
+		ImGui::PushID(i);
+		if (ImGui::Selectable(tag, selected == i, ImGuiSelectableFlags_AllowDoubleClick | ImGuiSelectableFlags_SpanAllColumns)) {
+			selected = i;
+		}
+		if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
+			selected = i;
+			ImGui::OpenPopup("framebufferPopup");
+		}
+		ImGui::TableNextColumn();
+		ImGui::Text("%08x", vfb->fb_address);
+		ImGui::TableNextColumn();
+		ImGui::Text("%08x", vfb->z_address);
+		ImGui::TableNextColumn();
+		ImGui::Text("%dx%d", vfb->width, vfb->height);
+		if (ImGui::BeginPopup("framebufferPopup")) {
+			ImGui::Text("Framebuffer: %s", tag);
+			ImGui::EndPopup();
+		}
+		ImGui::PopID();
+	}
+	ImGui::EndTable();
 }

--- a/GPU/Common/FramebufferManagerCommon.h
+++ b/GPU/Common/FramebufferManagerCommon.h
@@ -488,6 +488,8 @@ public:
 
 	bool PresentedThisFrame() const;
 
+	void DrawImGuiDebug(int &selected) const;
+
 protected:
 	virtual void ReadbackFramebuffer(VirtualFramebuffer *vfb, int x, int y, int w, int h, RasterChannel channel, Draw::ReadbackMode mode);
 	// Used for when a shader is required, such as GLES.

--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -25,6 +25,8 @@
 #include "GPU/GPU.h"
 #include "GPU/GPUInterface.h"
 
+class FramebufferManagerCommon;
+
 struct GPUDebugOp {
 	u32 pc;
 	u8 cmd;
@@ -218,6 +220,9 @@ public:
 
 	virtual uint32_t SetAddrTranslation(uint32_t value) = 0;
 	virtual uint32_t GetAddrTranslation() = 0;
+	
+	// TODO: Make a proper debug interface instead of accessing directly?
+	virtual FramebufferManagerCommon *GetFramebufferManagerCommon() = 0;
 
 	virtual bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices) {
 		return false;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -181,6 +181,10 @@ public:
 	bool GetCurrentDisplayList(DisplayList &list) override;
 	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices) override;
 
+	FramebufferManagerCommon *GetFramebufferManagerCommon() override {
+		return nullptr;
+	}
+
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType shader) override { return std::vector<std::string>(); };
 	std::string DebugGetShaderString(std::string id, DebugShaderType shader, DebugShaderStringType stringType) override {
 		return "N/A";

--- a/GPU/GPUCommonHW.h
+++ b/GPU/GPUCommonHW.h
@@ -28,6 +28,10 @@ public:
 	bool GetCurrentTexture(GPUDebugBuffer &buffer, int level, bool *isFramebuffer) override;
 	bool GetCurrentClut(GPUDebugBuffer &buffer) override;
 
+	FramebufferManagerCommon *GetFramebufferManagerCommon() override {
+		return framebufferManager_;
+	}
+
 	// Using string because it's generic - makes no assumptions on the size of the shader IDs of this backend.
 	std::vector<std::string> DebugGetShaderIDs(DebugShaderType shader) override;
 	std::string DebugGetShaderString(std::string id, DebugShaderType shader, DebugShaderStringType stringType) override;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1656,7 +1656,7 @@ void EmuScreen::renderImDebugger() {
 			ImGui_ImplThin3d_NewFrame(draw, ui_draw2d.GetDrawMatrix());
 
 			ImGui::NewFrame();
-			imDebugger_->Frame(currentDebugMIPS);
+			imDebugger_->Frame(currentDebugMIPS, gpuDebug);
 
 			ImGui::Render();
 			ImGui_ImplThin3d_RenderDrawData(ImGui::GetDrawData(), draw);

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -375,30 +375,31 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("CPU")) {
-			ImGui::Checkbox("CPU debugger", &cfg_.disasmOpen);
-			ImGui::Checkbox("Registers", &cfg_.regsOpen);
-			ImGui::Checkbox("Callstacks", &cfg_.callstackOpen);
+			ImGui::MenuItem("CPU debugger", nullptr, &cfg_.disasmOpen);
+			ImGui::MenuItem("Registers", nullptr, &cfg_.regsOpen);
+			ImGui::MenuItem("Callstacks", nullptr, &cfg_.callstackOpen);
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("OS HLE")) {
-			ImGui::Checkbox("HLE Threads", &cfg_.threadsOpen);
-			ImGui::Checkbox("HLE Modules", &cfg_.modulesOpen);
-			ImGui::Checkbox("sceAtrac", &cfg_.atracOpen);
+			ImGui::MenuItem("HLE Threads", nullptr, &cfg_.threadsOpen);
+			ImGui::MenuItem("HLE Modules",nullptr,  &cfg_.modulesOpen);
+			ImGui::MenuItem("sceAtrac", nullptr, &cfg_.atracOpen);
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Ge (GPU)")) {
-			ImGui::Checkbox("Framebuffers", &cfg_.framebuffersOpen);
+			ImGui::MenuItem("Framebuffers", nullptr, &cfg_.framebuffersOpen);
+			// More to come here...
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Tools")) {
-			ImGui::Checkbox("Struct viewer", &cfg_.structViewerOpen);
+			ImGui::MenuItem("Struct viewer", nullptr, &cfg_.structViewerOpen);
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Misc")) {
 			if (ImGui::MenuItem("Close Debugger")) {
 				g_Config.bShowImDebugger = false;
 			}
-			ImGui::Checkbox("Dear ImGUI Demo", &cfg_.demoOpen);
+			ImGui::MenuItem("Dear ImGUI Demo", nullptr, &cfg_.demoOpen);
 			ImGui::EndMenu();
 		}
 		ImGui::EndMainMenuBar();
@@ -501,6 +502,25 @@ void ImDisasmWindow::Draw(MIPSDebugInterface *mipsDebug, bool *open, CoreState c
 		disasmView_.gotoPC();
 	}
 
+	if (ImGui::BeginPopup("disSearch")) {
+		if (ImGui::InputText("Search", searchTerm_, sizeof(searchTerm_), ImGuiInputTextFlags_EnterReturnsTrue)) {
+			disasmView_.Search(searchTerm_);
+			ImGui::CloseCurrentPopup();
+		}
+		ImGui::EndPopup();
+	}
+
+	ImGui::SameLine();
+	if (ImGui::SmallButton("Search")) {
+		// Open a small popup
+		ImGui::OpenPopup("disSearch");
+	}
+
+	ImGui::SameLine();
+	if (ImGui::SmallButton("Next")) {
+		disasmView_.SearchNext(true);
+	}
+
 	ImGui::SameLine();
 	ImGui::Checkbox("Follow PC", &disasmView_.followPC_);
 
@@ -517,8 +537,9 @@ void ImDisasmWindow::Draw(MIPSDebugInterface *mipsDebug, bool *open, CoreState c
 		ImGui::TableSetColumnIndex(0);
 		ImVec2 sz = ImGui::GetContentRegionAvail();
 		if (ImGui::BeginListBox("##symbols", ImVec2(150.0, sz.y - ImGui::GetTextLineHeightWithSpacing() * 2))) {
-			if (symCache_.empty()) {
+			if (symCache_.empty() || symsDirty_) {
 				symCache_ = g_symbolMap->GetAllSymbols(SymbolType::ST_FUNCTION);
+				symsDirty_ = false;
 			}
 			ImGuiListClipper clipper;
 			clipper.Begin((int)symCache_.size(), -1);

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -26,7 +26,11 @@
 // Callstack window
 #include "Core/MIPS/MIPSStackWalk.h"
 
+// GPU things
+#include "GPU/Common/GPUDebugInterface.h"
+
 #include "UI/ImDebugger/ImDebugger.h"
+#include "UI/ImDebugger/ImGe.h"
 
 void DrawRegisterView(MIPSDebugInterface *mipsDebug, bool *open) {
 	if (!ImGui::Begin("Registers", open)) {
@@ -332,7 +336,7 @@ void DrawHLEModules(ImConfig &config) {
 	ImGui::End();
 }
 
-void ImDebugger::Frame(MIPSDebugInterface *mipsDebug) {
+void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebug) {
 	// Snapshot the coreState to avoid inconsistency.
 	const CoreState coreState = ::coreState;
 
@@ -370,14 +374,23 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug) {
 			}
 			ImGui::EndMenu();
 		}
-		if (ImGui::BeginMenu("Window")) {
-			ImGui::Checkbox("Dear ImGUI Demo", &cfg_.demoOpen);
+		if (ImGui::BeginMenu("CPU")) {
 			ImGui::Checkbox("CPU debugger", &cfg_.disasmOpen);
 			ImGui::Checkbox("Registers", &cfg_.regsOpen);
 			ImGui::Checkbox("Callstacks", &cfg_.callstackOpen);
-			ImGui::Checkbox("HLE Modules", &cfg_.modulesOpen);
+			ImGui::EndMenu();
+		}
+		if (ImGui::BeginMenu("OS HLE")) {
 			ImGui::Checkbox("HLE Threads", &cfg_.threadsOpen);
+			ImGui::Checkbox("HLE Modules", &cfg_.modulesOpen);
 			ImGui::Checkbox("sceAtrac", &cfg_.atracOpen);
+			ImGui::EndMenu();
+		}
+		if (ImGui::BeginMenu("Ge (GPU)")) {
+			ImGui::Checkbox("Framebuffers", &cfg_.framebuffersOpen);
+			ImGui::EndMenu();
+		}
+		if (ImGui::BeginMenu("Tools")) {
 			ImGui::Checkbox("Struct viewer", &cfg_.structViewerOpen);
 			ImGui::EndMenu();
 		}
@@ -385,6 +398,7 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug) {
 			if (ImGui::MenuItem("Close Debugger")) {
 				g_Config.bShowImDebugger = false;
 			}
+			ImGui::Checkbox("Dear ImGUI Demo", &cfg_.demoOpen);
 			ImGui::EndMenu();
 		}
 		ImGui::EndMainMenuBar();
@@ -420,6 +434,10 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug) {
 
 	if (cfg_.hleModulesOpen) {
 		DrawHLEModules(cfg_);
+	}
+
+	if (cfg_.framebuffersOpen) {
+		DrawFramebuffersWindow(cfg_, gpuDebug->GetFramebufferManagerCommon());
 	}
 
 	if (cfg_.structViewerOpen) {

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -42,6 +42,8 @@ private:
 	// Symbol cache
 	std::vector<SymbolEntry> symCache_;
 	bool symsDirty_ = true;
+	int selectedSymbol_ = -1;
+	char selectedSymbolName_[128];
 
 	ImDisasmView disasmView_;
 	char searchTerm_[64]{};

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -41,8 +41,10 @@ private:
 
 	// Symbol cache
 	std::vector<SymbolEntry> symCache_;
+	bool symsDirty_ = true;
 
 	ImDisasmView disasmView_;
+	char searchTerm_[64]{};
 };
 
 class ImLuaConsole {

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -73,6 +73,14 @@ struct ImConfig {
 	int selectedFramebuffer = -1;
 };
 
+enum ImUiCmd {
+	TRIGGER_FIND_POPUP = 0,
+};
+
+struct ImUiCommand {
+	ImUiCmd cmd;
+};
+
 struct ImDebugger {
 	void Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebug);
 

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -15,6 +15,7 @@
 
 #include "UI/ImDebugger/ImDisasmView.h"
 #include "UI/ImDebugger/ImStructViewer.h"
+#include "UI/ImDebugger/ImGe.h"
 
 // This is the main state container of the whole Dear ImGUI-based in-game cross-platform debugger.
 //
@@ -22,7 +23,7 @@
 // * If windows/objects need state, prefix the class name with Im and just store straight in parent struct
 
 class MIPSDebugInterface;
-
+class GPUDebugInterface;
 
 // Corresponds to the CDisasm dialog
 class ImDisasmWindow {
@@ -59,6 +60,7 @@ struct ImConfig {
 	bool hleModulesOpen = false;
 	bool atracOpen = true;
 	bool structViewerOpen = false;
+	bool framebuffersOpen = false;
 
 	// HLE explorer settings
 	// bool filterByUsed = true;
@@ -66,10 +68,11 @@ struct ImConfig {
 	// Various selections
 	int selectedModule = 0;
 	int selectedThread = 0;
+	int selectedFramebuffer = -1;
 };
 
 struct ImDebugger {
-	void Frame(MIPSDebugInterface *mipsDebug);
+	void Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebug);
 
 	ImDisasmWindow disasm_;
 	ImLuaConsole luaConsole_;

--- a/UI/ImDebugger/ImDisasmView.cpp
+++ b/UI/ImDebugger/ImDisasmView.cpp
@@ -565,7 +565,7 @@ void ImDisasmView::ProcessKeyboardShortcuts() {
 	if (io.KeyMods & ImGuiMod_Ctrl) {
 		if (ImGui::IsKeyPressed(ImGuiKey_F)) {
 			// Toggle the find popup
-			ImGui::OpenPopup("disSearch");
+			// ImGui::OpenPopup("disSearch");
 		}
 		if (ImGui::IsKeyPressed(ImGuiKey_C) || ImGui::IsKeyPressed(ImGuiKey_Insert)) {
 			CopyInstructions(selectRangeStart_, selectRangeEnd_, CopyInstructionsMode::DISASM);

--- a/UI/ImDebugger/ImDisasmView.h
+++ b/UI/ImDebugger/ImDisasmView.h
@@ -7,7 +7,6 @@
 #include "ext/imgui/imgui.h"
 
 #include "Common/CommonTypes.h"
-#include "Common/Log.h"
 
 #include "Core/Debugger/DisassemblyManager.h"
 #include "Core/Debugger/DebugInterface.h"
@@ -31,16 +30,16 @@ public:
 
 	void onChar(int c);
 	void onKeyDown(ImGuiKey key);
-	void onMouseDown(int x, int y, int button);
-	void onMouseUp(int x, int y, int button);
-	void onMouseMove(int x, int y, int button);
+	void onMouseDown(float x, float y, int button);
+	void onMouseUp(float x, float y, int button);
+	void onMouseMove(float x, float y, int button);
 	void scrollAddressIntoView();
 	bool curAddressIsVisible();
 	void ScanVisibleFunctions();
 	void clearFunctions() { manager.clear(); };
 
 	void getOpcodeText(u32 address, char* dest, int bufsize);
-	u32 yToAddress(int y);
+	u32 yToAddress(float y);
 
 	void setDebugger(DebugInterface *deb) {
 		if (debugger != deb) {

--- a/UI/ImDebugger/ImDisasmView.h
+++ b/UI/ImDebugger/ImDisasmView.h
@@ -134,7 +134,7 @@ private:
 	void CopyInstructions(u32 startAddr, u32 endAddr, CopyInstructionsMode mode);
 	void NopInstructions(u32 startAddr, u32 endAddr);
 	std::set<std::string> getSelectedLineArguments();
-	void drawArguments(ImDrawList *list, ImDisasmView::Rect rc, const DisassemblyLineInfo &line, int x, int y, ImColor textColor, const std::set<std::string> &currentArguments);
+	void drawArguments(ImDrawList *list, ImDisasmView::Rect rc, const DisassemblyLineInfo &line, float x, float y, ImColor textColor, const std::set<std::string> &currentArguments);
 
 	DisassemblyManager manager;
 	u32 curAddress_ = 0;

--- a/UI/ImDebugger/ImDisasmView.h
+++ b/UI/ImDebugger/ImDisasmView.h
@@ -29,7 +29,6 @@ public:
 	void ScrollRelative(int amount);
 
 	void onChar(int c);
-	void onKeyDown(ImGuiKey key);
 	void onMouseDown(float x, float y, int button);
 	void onMouseUp(float x, float y, int button);
 	void onMouseMove(float x, float y, int button);
@@ -96,6 +95,8 @@ public:
 		positionLocked_--;
 		_assert_(positionLocked_ >= 0);
 	}
+	void Search(std::string_view needle);
+	void SearchNext(bool forward);
 
 	// Check these every frame!
 	const std::string &StatusBarText() const {
@@ -121,10 +122,10 @@ private:
 		float bottom;
 	};
 
+	void ProcessKeyboardShortcuts();
 	void assembleOpcode(u32 address, const std::string &defaultText);
 	std::string disassembleRange(u32 start, u32 size);
 	void disassembleToFile();
-	void search(bool continueSearch);
 	void FollowBranch();
 	void calculatePixelPositions();
 	bool getDisasmAddressText(u32 address, char* dest, bool abbreviateLabels, bool showData);

--- a/UI/ImDebugger/ImGe.cpp
+++ b/UI/ImDebugger/ImGe.cpp
@@ -1,0 +1,14 @@
+#include "UI/ImDebugger/ImGe.h"
+#include "UI/ImDebugger/ImDebugger.h"
+#include "GPU/Common/FramebufferManagerCommon.h"
+
+void DrawFramebuffersWindow(ImConfig &cfg, FramebufferManagerCommon *framebufferManager) {
+	if (!ImGui::Begin("Framebuffers", &cfg.framebuffersOpen)) {
+		ImGui::End();
+		return;
+	}
+
+	framebufferManager->DrawImGuiDebug(cfg.selectedFramebuffer);
+
+	ImGui::End();
+}

--- a/UI/ImDebugger/ImGe.h
+++ b/UI/ImDebugger/ImGe.h
@@ -1,0 +1,9 @@
+#pragma once
+
+// GE-related windows of the ImDebugger
+
+struct ImConfig;
+
+class FramebufferManagerCommon;
+
+void DrawFramebuffersWindow(ImConfig &cfg, FramebufferManagerCommon *framebufferManager);

--- a/UI/ImDebugger/ImGe.h
+++ b/UI/ImDebugger/ImGe.h
@@ -7,3 +7,8 @@ struct ImConfig;
 class FramebufferManagerCommon;
 
 void DrawFramebuffersWindow(ImConfig &cfg, FramebufferManagerCommon *framebufferManager);
+
+class ImGeDebugger {
+public:
+
+};

--- a/UI/UI.vcxproj
+++ b/UI/UI.vcxproj
@@ -53,6 +53,7 @@
     <ClCompile Include="GPUDriverTestScreen.cpp" />
     <ClCompile Include="ImDebugger\ImDebugger.cpp" />
     <ClCompile Include="ImDebugger\ImDisasmView.cpp" />
+    <ClCompile Include="ImDebugger\ImGe.cpp" />
     <ClCompile Include="ImDebugger\ImStructViewer.cpp" />
     <ClCompile Include="JitCompareScreen.cpp" />
     <ClCompile Include="JoystickHistoryView.cpp" />
@@ -96,6 +97,7 @@
     <ClInclude Include="GPUDriverTestScreen.h" />
     <ClInclude Include="ImDebugger\ImDebugger.h" />
     <ClInclude Include="ImDebugger\ImDisasmView.h" />
+    <ClInclude Include="ImDebugger\ImGe.h" />
     <ClInclude Include="ImDebugger\ImStructViewer.h" />
     <ClInclude Include="JitCompareScreen.h" />
     <ClInclude Include="JoystickHistoryView.h" />

--- a/UI/UI.vcxproj.filters
+++ b/UI/UI.vcxproj.filters
@@ -107,6 +107,9 @@
     <ClCompile Include="ImDebugger\ImStructViewer.cpp">
       <Filter>ImDebugger</Filter>
     </ClCompile>
+    <ClCompile Include="ImDebugger\ImGe.cpp">
+      <Filter>ImDebugger</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="GameInfoCache.h" />
@@ -212,6 +215,9 @@
       <Filter>ImDebugger</Filter>
     </ClInclude>
     <ClInclude Include="ImDebugger\ImStructViewer.h">
+      <Filter>ImDebugger</Filter>
+    </ClInclude>
+    <ClInclude Include="ImDebugger\ImGe.h">
       <Filter>ImDebugger</Filter>
     </ClInclude>
   </ItemGroup>

--- a/UWP/UI_UWP/UI_UWP.vcxproj
+++ b/UWP/UI_UWP/UI_UWP.vcxproj
@@ -128,6 +128,7 @@
     <ClInclude Include="..\..\UI\GPUDriverTestScreen.h" />
     <ClInclude Include="..\..\UI\ImDebugger\ImDebugger.h" />
     <ClInclude Include="..\..\UI\ImDebugger\ImDisasmView.h" />
+    <ClInclude Include="..\..\UI\ImDebugger\ImGe.h" />
     <ClInclude Include="..\..\UI\ImDebugger\ImStructViewer.h" />
     <ClInclude Include="..\..\UI\InstallZipScreen.h" />
     <ClInclude Include="..\..\UI\JitCompareScreen.h" />
@@ -171,6 +172,7 @@
     <ClCompile Include="..\..\UI\GPUDriverTestScreen.cpp" />
     <ClCompile Include="..\..\UI\ImDebugger\ImDebugger.cpp" />
     <ClCompile Include="..\..\UI\ImDebugger\ImDisasmView.cpp" />
+    <ClCompile Include="..\..\UI\ImDebugger\ImGe.cpp" />
     <ClCompile Include="..\..\UI\ImDebugger\ImStructViewer.cpp" />
     <ClCompile Include="..\..\UI\InstallZipScreen.cpp" />
     <ClCompile Include="..\..\UI\JitCompareScreen.cpp" />

--- a/UWP/UI_UWP/UI_UWP.vcxproj.filters
+++ b/UWP/UI_UWP/UI_UWP.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClCompile Include="..\..\UI\ImDebugger\ImStructViewer.cpp">
       <Filter>ImDebugger</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\UI\ImDebugger\ImGe.cpp">
+      <Filter>ImDebugger</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -95,6 +98,9 @@
       <Filter>ImDebugger</Filter>
     </ClInclude>
     <ClInclude Include="..\..\UI\ImDebugger\ImStructViewer.h">
+      <Filter>ImDebugger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\UI\ImDebugger\ImGe.h">
       <Filter>ImDebugger</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -556,7 +556,8 @@ namespace MainWindow {
 		case ID_FILE_SAVESTATE_NEXT_SLOT_HC:
 		{
 			if (!Achievements::WarnUserIfHardcoreModeActive(true)) {
-				if (!KeyMap::PspButtonHasMappings(VIRTKEY_NEXT_SLOT)) {
+				// We let F3 (search next) in the imdebugger take priority, if active.
+				if (!KeyMap::PspButtonHasMappings(VIRTKEY_NEXT_SLOT) && !g_Config.bShowImDebugger) {
 					SaveState::NextSlot();
 					System_PostUIMessage(UIMessage::SAVESTATE_DISPLAY_SLOT);
 				}

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -876,6 +876,7 @@ LOCAL_SRC_FILES := \
   $(SRC)/android/jni/AndroidAudio.cpp \
   $(SRC)/android/jni/OpenSLContext.cpp \
   $(SRC)/UI/ImDebugger/ImDebugger.cpp \
+  $(SRC)/UI/ImDebugger/ImGe.cpp \
   $(SRC)/UI/ImDebugger/ImDisasmView.cpp \
   $(SRC)/UI/ImDebugger/ImStructViewer.cpp \
   $(SRC)/UI/AudioCommon.cpp \


### PR DESCRIPTION
This fixes a lot of the keyboard shortcuts that were lost in the port of the disassembly window from Win32 (although there's still an issue with modifier keys).

Also reorganizes the menu a little, and adds instruction search and a framebuffer listing.