### PR TITLE
Struct viewer fixes and improvements

### DIFF
--- a/Common/GhidraClient.cpp
+++ b/Common/GhidraClient.cpp
@@ -18,6 +18,17 @@ static GhidraTypeKind ResolveTypeKind(const std::string& kind) {
 	return UNKNOWN;
 }
 
+static bool IsBitfieldEnum(const std::vector<GhidraEnumMember>& enumMembers) {
+	u64 previousValues = 0;
+	for (const auto& member : enumMembers) {
+		if (previousValues & member.value) {
+			return false;
+		}
+		previousValues |= member.value;
+	}
+	return true;
+}
+
 GhidraClient::~GhidraClient() {
 	if (thread_.joinable()) {
 		thread_.join();
@@ -131,6 +142,7 @@ bool GhidraClient::FetchTypes() {
 					member.comment = enumEntry.getStringOr("comment", "");
 					type.enumMembers.push_back(member);
 				}
+				type.enumBitfield = IsBitfieldEnum(type.enumMembers);
 				break;
 			}
 			case TYPEDEF:

--- a/Common/GhidraClient.h
+++ b/Common/GhidraClient.h
@@ -7,10 +7,8 @@
 #include <unordered_map>
 #include <vector>
 
-/**
- * Represents symbol from a Ghidra's program.
- * A symbol can be for example a data label, instruction label or a function.
- */
+// Represents symbol from a Ghidra's program.
+// A symbol can be for example a data label, instruction label or a function.
 struct GhidraSymbol {
 	u32 address = 0;
 	std::string name;
@@ -19,7 +17,7 @@ struct GhidraSymbol {
 	std::string dataTypePathName;
 };
 
-/** Possible kinds of data types, such as enum, structures or built-ins (Ghidra's primitive types). */
+// Possible kinds of data types, such as enum, structures or built-ins (Ghidra's primitive types).
 enum GhidraTypeKind {
 	ENUM,
 	TYPEDEF,
@@ -32,14 +30,14 @@ enum GhidraTypeKind {
 	UNKNOWN,
 };
 
-/** Describes single member of an enum type. */
+// Describes single member of an enum type.
 struct GhidraEnumMember {
 	std::string name;
 	u64 value = 0;
 	std::string comment;
 };
 
-/** Describes single member of a composite (structure or union) type. */
+// Describes single member of a composite (structure or union) type.
 struct GhidraCompositeMember {
 	std::string fieldName;
 	u32 ordinal = 0;
@@ -49,11 +47,9 @@ struct GhidraCompositeMember {
 	std::string comment;
 };
 
-/**
- * Describes data type from Ghidra. Note that some fields of this structure will only be populated depending on the
- * type's kind. Each type has a display name that is suitable for displaying to the user and a path name that
- * unambiguously identifies this type.
- */
+// Describes data type from Ghidra. Note that some fields of this structure will only be populated depending on the
+// type's kind. Each type has a display name that is suitable for displaying to the user and a path name that
+// unambiguously identifies this type.
 struct GhidraType {
 	GhidraTypeKind kind;
 	std::string displayName;
@@ -75,23 +71,21 @@ struct GhidraType {
 	std::string builtInGroup;
 };
 
-/**
- * GhidraClient implements fetching data (such as symbols or types) from a remote Ghidra project.
- *
- * This client uses unofficial API provided by the third party "ghidra-rest-api" extension. The extension is
- * available at https://github.com/kotcrab/ghidra-rest-api.
- *
- * This class doesn't fetch data from every possible endpoint, only those that are actually used by PPSSPP.
- *
- * How to use:
- * 1. The client is created in the Idle status.
- * 2. To start fetching data call the FetchAll() method. The client goes to Pending status and the data is fetched
- *    in a background thread so your code remains unblocked.
- * 3. Periodically check with the Ready() method is the operation has completed. (i.e. check if the client
-      is in the Ready status)
- * 4. If the client is ready call UpdateResult() to update result field with new data.
- * 5. The client is now back to Idle status, and you can call FetchAll() again later if needed.
- */
+// GhidraClient implements fetching data (such as symbols or types) from a remote Ghidra project.
+//
+// This client uses unofficial API provided by the third party "ghidra-rest-api" extension. The extension is
+// available at https://github.com/kotcrab/ghidra-rest-api.
+//
+// This class doesn't fetch data from every possible endpoint, only those that are actually used by PPSSPP.
+//
+// How to use:
+// 1. The client is created in the Idle status.
+// 2. To start fetching data call the FetchAll() method. The client goes to Pending status and the data is fetched
+//    in a background thread so your code remains unblocked.
+// 3. Periodically check with the Ready() method is the operation has completed. (i.e. check if the client
+//    is in the Ready status)
+// 4. If the client is ready call UpdateResult() to update result field with new data.
+// 5. The client is now back to Idle status, and you can call FetchAll() again later if needed.
 class GhidraClient {
 	enum class Status {
 		Idle,
@@ -106,16 +100,16 @@ public:
 		std::string error;
 	};
 
-	/** Current result of the client. Your thread is safe to access this regardless of client status. */
+	// Current result of the client. Your thread is safe to access this regardless of client status.
 	Result result;
 
 	~GhidraClient();
 
-	/** If client is idle then asynchronously starts fetching data from Ghidra. */
+	//  If client is idle then asynchronously starts fetching data from Ghidra.
 	void FetchAll(const std::string& host, int port);
 
-	/** If client is ready then updates the result field with newly fetched data. This must be called from the thread
-	 * using the result. */
+	// If client is ready then updates the result field with newly fetched data.
+	// This must be called from the thread using the result.
 	void UpdateResult();
 
 	bool Idle() const { return status_ == Status::Idle; }

--- a/Common/GhidraClient.h
+++ b/Common/GhidraClient.h
@@ -61,6 +61,7 @@ struct GhidraType {
 
 	std::vector<GhidraCompositeMember> compositeMembers;
 	std::vector<GhidraEnumMember> enumMembers;
+	bool enumBitfield = false; // Determined from a simple heuristic check
 	std::string pointerTypePathName;
 	std::string typedefTypePathName;
 	std::string typedefBaseTypePathName;

--- a/UI/ImDebugger/ImStructViewer.h
+++ b/UI/ImDebugger/ImStructViewer.h
@@ -5,18 +5,16 @@
 #include "Common/GhidraClient.h"
 #include "Core/MIPS/MIPSDebugInterface.h"
 
-/**
- * Struct viewer visualizes objects data in game memory using types and symbols fetched from a Ghidra project.
- * It also allows to set memory breakpoints and edit field values which is helpful when reverse engineering unknown
- * types.
- *
- * To use this you will need to install an unofficial Ghidra extension "ghidra-rest-api" by Kotcrab.
- * (available at https://github.com/kotcrab/ghidra-rest-api). After installing the extension and starting the API
- * server in Ghidra you can open the Struct viewer window and press the "Connect" button to start using it.
- *
- * See the original pull request https://github.com/hrydgard/ppsspp/pull/19629 for a screenshot and how to test this
- * without the need to set up Ghidra.
- */
+// Struct viewer visualizes objects data in game memory using types and symbols fetched from a Ghidra project.
+// It also allows to set memory breakpoints and edit field values which is helpful when reverse engineering unknown
+// types.
+//
+// To use this you will need to install an unofficial Ghidra extension "ghidra-rest-api" by Kotcrab.
+// (available at https://github.com/kotcrab/ghidra-rest-api). After installing the extension and starting the API
+// server in Ghidra you can open the Struct viewer window and press the "Connect" button to start using it.
+//
+// See the original pull request https://github.com/hrydgard/ppsspp/pull/19629 for a screenshot and how to test this
+// without the need to set up Ghidra.
 class ImStructViewer {
 	struct Watch {
 		std::string expression;

--- a/UI/ImDebugger/ImStructViewer.h
+++ b/UI/ImDebugger/ImStructViewer.h
@@ -17,6 +17,7 @@
 // without the need to set up Ghidra.
 class ImStructViewer {
 	struct Watch {
+		int id = 0;
 		std::string expression;
 		u32 address = 0;
 		std::string typePathName;
@@ -48,7 +49,8 @@ private:
 	bool fetchedAtLeastOnce_ = false; // True if fetched from Ghidra successfully at least once
 
 	std::vector<Watch> watches_;
-	int removeWatchIndex_ = -1; // Watch index entry to be removed on next draw
+	int nextWatchId_ = 0; // ID value to use when creating new watch entry
+	int removeWatchId_ = -1; // Watch entry id to be removed on next draw
 	Watch addWatch_; // Temporary variable to store watch entry added from the Globals tab
 	NewWatch newWatch_; // State for the new watch entry UI
 
@@ -68,8 +70,17 @@ private:
 		const std::string& typePathName,
 		const char* typeDisplayNameOverride,
 		const char* name,
-		int watchIndex,
+		int watchId,
 		ImGuiTreeNodeFlags extraTreeNodeFlags = 0);
+
+	void DrawIndexedMembers(
+		u32 base,
+		u32 offset,
+		const std::string& typePathName,
+		const char* name,
+		u32 elementCount,
+		int elementLength,
+		bool openFirst);
 
 	void DrawContextMenu(
 		u32 base,
@@ -77,6 +88,6 @@ private:
 		int length,
 		const std::string& typePathName,
 		const char* name,
-		int watchIndex,
+		int watchId,
 		const u64* value);
 };


### PR DESCRIPTION
Fixes for Struct viewer issues (mostly reported by @Nemoumbra) and some improvements:

- Can't add multiple watches at once from globals
- Removing watch can incorrectly affects tree state
- Fix formatting bitfield enum member with 0 value
- Better formatting for non bitfield enums
- More accurate setup instructions
- Improved UI for setting number of pointer elements
- Chunked display for large arrays and pointers