### PR TITLE
Add support for 16kb page size on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,7 +396,7 @@ if(NOT MSVC)
 		# This one is very useful but has many false positives.
 		add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Wno-class-memaccess>")
 	else()
-		add_compile_options(-Wno-deprecated-declarations)
+		add_compile_options(-Wno-deprecated-declarations -Wno-missing-braces)
 	endif()
 
 	if(ANDROID)
@@ -2718,6 +2718,11 @@ set(WindowsFiles
 	Windows/stdafx.h
 )
 
+if(ANDROID AND ARM64)
+	# Support 16kb page size on Android
+	target_link_options(${CoreLibName} PRIVATE "-Wl,-z,max-page-size=16384")
+endif()
+
 list(APPEND LinkCommon ${CoreLibName} ${CMAKE_THREAD_LIBS_INIT})
 
 if(WIN32)
@@ -2903,6 +2908,9 @@ if(TargetBin)
 		set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ${TargetBin})
 	else()
 		add_executable(${TargetBin} ${NativeAppSource})
+	endif()
+	if(ANDROID AND ARM64)
+		target_link_options(${TargetBin} PRIVATE "-Wl,-z,max-page-size=16384")
 	endif()
 	target_link_libraries(${TargetBin} ${LinkCommon} Common)
 endif()

--- a/Common/Log/LogManager.cpp
+++ b/Common/Log/LogManager.cpp
@@ -263,7 +263,7 @@ void LogManager::LogLine(LogLevel level, Log type, const char *file, int line, c
 	const char *hostThreadName = GetCurrentThreadName();
 	if ((hostThreadName && strcmp(hostThreadName, "EmuThread") != 0) || !hleCurrentThreadName) {
 		// Use the host thread name.
-		threadName = hostThreadName;
+		threadName = hostThreadName ? hostThreadName : "unknown";
 	} else {
 		// Use the PSP HLE thread name.
 		threadName = hleCurrentThreadName;

--- a/Common/MemoryUtil.cpp
+++ b/Common/MemoryUtil.cpp
@@ -352,7 +352,12 @@ int GetMemoryProtectPageSize() {
 	if (sys_info.dwPageSize == 0)
 		GetSystemInfo(&sys_info);
 	return sys_info.dwPageSize;
+#else
+	static int pageSize = 0;
+	if (!pageSize) {
+		pageSize = sysconf(_SC_PAGE_SIZE);
+	}
+	return pageSize;
 #endif
-	return MEM_PAGE_SIZE;
 }
 #endif // !PPSSPP_PLATFORM(SWITCH)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -142,6 +142,7 @@ android {
 							'-DANDROID_PLATFORM=android-16',
 							'-DANDROID_TOOLCHAIN=clang',
 							'-DANDROID_CPP_FEATURES=',
+							'-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON',
 							'-DANDROID_STL=c++_static'
 				}
 			}
@@ -161,6 +162,7 @@ android {
 							'-DANDROID_CPP_FEATURES=',
 							'-DANDROID_STL=c++_static',
 							'-DANDROID_ARM_NEON=TRUE',
+							'-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON',
 							'-DGOLD=TRUE'
 				}
 			}
@@ -180,6 +182,7 @@ android {
 						'-DANDROID_TOOLCHAIN=clang',
 						'-DANDROID_CPP_FEATURES=',
 						'-DANDROID_STL=c++_static',
+						'-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON',
 						'-DANDROID_LEGACY=TRUE'
 				}
 			}
@@ -200,6 +203,7 @@ android {
 							'-DANDROID_CPP_FEATURES=',
 							'-DANDROID_STL=c++_static',
 							'-DANDROID_ARM_NEON=TRUE',
+							'-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON',
 							'-DOPENXR=TRUE',
 							'-DANDROID_LEGACY=TRUE'
 				}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,7 +47,9 @@ android {
 	}
 
 	compileSdk 35
-	ndkVersion "21.4.7075529"
+
+	ndkVersion "27.2.12479018"
+
 	defaultConfig {
 		/*
 		configurations.all {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
 	// Convenient wrapper around DocumentContract. Might look into writing our own
 	// to see if there's some performance to squeeze at some point, but doubt it.
-	implementation "androidx.documentfile:documentfile:1.0.1"
+	implementation "androidx.documentfile:documentfile:1.1.0"
 }
 
 android {
@@ -50,6 +50,11 @@ android {
 
 	ndkVersion "27.2.12479018"
 
+	compileOptions {
+		sourceCompatibility JavaVersion.VERSION_11
+		targetCompatibility JavaVersion.VERSION_11
+	}
+
 	defaultConfig {
 		/*
 		configurations.all {
@@ -73,7 +78,7 @@ android {
 		file("versionname.txt").text = androidGitVersion.name()
 		file("versioncode.txt").text = androidGitVersion.code().toString()
 
-		minSdk 9
+		minSdk 21
 		targetSdk 35
 		if (project.hasProperty("ANDROID_VERSION_CODE") && project.hasProperty("ANDROID_VERSION_NAME")) {
 			versionCode ANDROID_VERSION_CODE
@@ -139,7 +144,7 @@ android {
 				cmake {
 					// Available arguments listed at https://developer.android.com/ndk/guides/cmake.html
 					arguments '-DANDROID=true',
-							'-DANDROID_PLATFORM=android-16',
+							'-DANDROID_PLATFORM=android-21',
 							'-DANDROID_TOOLCHAIN=clang',
 							'-DANDROID_CPP_FEATURES=',
 							'-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON',
@@ -157,7 +162,7 @@ android {
 				cmake {
 					// Available arguments listed at https://developer.android.com/ndk/guides/cmake.html
 					arguments '-DANDROID=true',
-							'-DANDROID_PLATFORM=android-16',
+							'-DANDROID_PLATFORM=android-21',
 							'-DANDROID_TOOLCHAIN=clang',
 							'-DANDROID_CPP_FEATURES=',
 							'-DANDROID_STL=c++_static',
@@ -178,7 +183,7 @@ android {
 				cmake {
 					// Available arguments listed at https://developer.android.com/ndk/guides/cmake.html
 					arguments '-DANDROID=true',
-						'-DANDROID_PLATFORM=android-16',
+						'-DANDROID_PLATFORM=android-21',
 						'-DANDROID_TOOLCHAIN=clang',
 						'-DANDROID_CPP_FEATURES=',
 						'-DANDROID_STL=c++_static',
@@ -198,14 +203,15 @@ android {
 				cmake {
 					// Available arguments listed at https://developer.android.com/ndk/guides/cmake.html
 					arguments '-DANDROID=true',
-							'-DANDROID_PLATFORM=android-16',
+							'-DANDROID_PLATFORM=android-21',
 							'-DANDROID_TOOLCHAIN=clang',
 							'-DANDROID_CPP_FEATURES=',
 							'-DANDROID_STL=c++_static',
 							'-DANDROID_ARM_NEON=TRUE',
 							'-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON',
 							'-DOPENXR=TRUE',
-							'-DANDROID_LEGACY=TRUE'
+							'-DANDROID_LEGACY=TRUE',
+							'-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON'
 				}
 			}
 			ndk {

--- a/android/jni/Application.mk
+++ b/android/jni/Application.mk
@@ -2,4 +2,5 @@ APP_STL := c++_static
 APP_PLATFORM := android-9
 APP_ABI := arm64-v8a armeabi-v7a x86_64
 APP_GNUSTL_CPP_FEATURES := exceptions
+APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true
 NDK_TOOLCHAIN_VERSION := clang

--- a/android/jni/Locals.mk
+++ b/android/jni/Locals.mk
@@ -68,4 +68,6 @@ ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
   LOCAL_C_INCLUDES += $(LOCAL_PATH)/../../ffmpeg/android/arm64/include
   LOCAL_C_INCLUDES += $(LOCAL_PATH)/../../ext/libadrenotools/include
   LOCAL_C_INCLUDES += $(LOCAL_PATH)/../../ext/libadrenotools/lib/linkernsbypass
+
+  LOCAL_LDFLAGS += "-Wl,-z,max-page-size=16384"
 endif

--- a/build.gradle
+++ b/build.gradle
@@ -14,4 +14,8 @@ allprojects {
         google()
         mavenCentral()
     }
+    // The below can be used to show more deprecated stuff in the build output.
+    // tasks.withType(JavaCompile).configureEach {
+    //   options.compilerArgs << "-Xlint:deprecation"
+    // }
 }


### PR DESCRIPTION
Android devices will show up with 16kb pages in the future, although there are none right now. https://developer.android.com/guide/practices/page-sizes 

More information here: https://android-developers.googleblog.com/2024/08/adding-16-kb-page-size-to-android.html

Newer blog post: https://android-developers.googleblog.com/2024/12/get-your-apps-ready-for-16-kb-page-size-devices.html

When trying to test the virtual 16kb image on Windows, I run into [this issue](https://stackoverflow.com/questions/74760054/panic-avds-cpu-architecture-arm64-is-not-supported-by-the-qemu2-emulator-on). Silly that there's no better error message than some logspam.

Anyway, this means that this needs to be tested in a VM on Mac, reminder to self.