### PR TITLE
Fix toast warning in SDL build

### DIFF
--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -1,7 +1,3 @@
-// SDL/EGL implementation of the framework.
-// This is quite messy due to platform-specific implementations and #ifdef's.
-// If your platform is not supported, it is suggested to use Qt instead.
-
 #include <cstdlib>
 #include <unistd.h>
 #include <pwd.h>
@@ -1495,6 +1491,16 @@ int main(int argc, char *argv[]) {
 #endif
 
 	bool waitOnExit = g_Config.iGPUBackend == (int)GPUBackend::OPENGL;
+
+	// P2cd0
+	// Check if the path to a directory containing an unpacked ISO is passed as a command line argument
+	for (int i = 1; i < argc; i++) {
+		if (File::IsDirectory(argv[i])) {
+			// Display the toast warning
+			System_Toast("Warning: Playing unpacked games may cause issues.");
+			break;
+		}
+	}
 
 	if (!mainThreadIsRender) {
 		// Vulkan mode uses this.

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -1492,10 +1492,9 @@ int main(int argc, char *argv[]) {
 
 	bool waitOnExit = g_Config.iGPUBackend == (int)GPUBackend::OPENGL;
 
-	// P2cd0
 	// Check if the path to a directory containing an unpacked ISO is passed as a command line argument
 	for (int i = 1; i < argc; i++) {
-		if (File::IsDirectory(argv[i])) {
+		if (File::IsDirectory(Path(argv[i]))) {
 			// Display the toast warning
 			System_Toast("Warning: Playing unpacked games may cause issues.");
 			break;


### PR DESCRIPTION
Related to #18951

Add toast warning for unpacked ISO directories in SDL build.

* Check if the path to a directory containing an unpacked ISO is passed as a command line argument.
* Display the toast warning "Warning: Playing unpacked games may cause issues." if an unpacked ISO directory is detected.

