### PR TITLE
Log "host" thread names when not on EmuThread

### DIFF
--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -343,7 +343,7 @@ static VulkanLibraryHandle VulkanLoadLibrary(std::string *errorString) {
 	return nullptr;
 #elif PPSSPP_PLATFORM(UWP)
 	return nullptr;
-#elif PPSSPP_PLATFORM(MACOS) && PPSSPP_ARCH(AMD64)
+#elif PPSSPP_PLATFORM(MAC) && PPSSPP_ARCH(AMD64)
 	// Disable Vulkan on Mac/x86. Too many configurations that don't work with MoltenVK
 	// for whatever reason.
 	return nullptr;


### PR DESCRIPTION
When not on the EmuThread, insert the host threadname in log lines instead of the PSP thread name. This makes logs make more sense.

To avoid any potential perf regressions on mobile, this is only on desktop for now.

Also fixes an Intel mac detection issue.