### PR TITLE
Use a separate file for the "Failed GPU backends" on all platforms.

### DIFF
--- a/Common/GhidraClient.h
+++ b/Common/GhidraClient.h
@@ -104,6 +104,7 @@ public:
 	// Current result of the client. Your thread is safe to access this regardless of client status.
 	Result result;
 
+	GhidraClient() : status_(Status::Idle) {}
 	~GhidraClient();
 
 	//  If client is idle then asynchronously starts fetching data from Ghidra.

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -603,7 +603,6 @@ static const ConfigSetting graphicsSettings[] = {
 #if PPSSPP_PLATFORM(ANDROID) && PPSSPP_ARCH(ARM64)
 	ConfigSetting("CustomDriver", &g_Config.sCustomDriver, "", CfgFlag::DEFAULT),
 #endif
-	ConfigSetting("FailedGraphicsBackends", &g_Config.sFailedGPUBackends, "", CfgFlag::DEFAULT),
 	ConfigSetting("DisabledGraphicsBackends", &g_Config.sDisabledGPUBackends, "", CfgFlag::DEFAULT),
 	ConfigSetting("VulkanDevice", &g_Config.sVulkanDevice, "", CfgFlag::DEFAULT),
 #ifdef _WIN32

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -150,7 +150,7 @@ public:
 	// GFX
 	int iGPUBackend;
 	std::string sCustomDriver;
-	std::string sFailedGPUBackends;
+	std::string sFailedGPUBackends;  // NOT stored in ppsspp.ini anymore!
 	std::string sDisabledGPUBackends;
 	// We have separate device parameters for each backend so it doesn't get erased if you switch backends.
 	// If not set, will use the "best" device.

--- a/UI/ImDebugger/ImDisasmView.cpp
+++ b/UI/ImDebugger/ImDisasmView.cpp
@@ -315,6 +315,11 @@ void ImDisasmView::drawArguments(ImDrawList *drawList, Rect rc, const Disassembl
 }
 
 void ImDisasmView::Draw(ImDrawList *drawList) {
+	auto memLock = Memory::Lock();
+	if (!debugger->isAlive()) {
+		return;
+	}
+
 	// TODO: Don't need to do these every frame.
 	ImGui_PushFixedFont();
 
@@ -354,11 +359,6 @@ void ImDisasmView::Draw(ImDrawList *drawList) {
 	calculatePixelPositions();
 
 	visibleRows_ = (int)((rect.bottom - rect.top + rowHeight_ - 1.f) / rowHeight_);
-
-	auto memLock = Memory::Lock();
-	if (!debugger->isAlive()) {
-		return;
-	}
 
 	unsigned int address = windowStart_;
 	std::map<u32, float> addressPositions;
@@ -494,7 +494,6 @@ void ImDisasmView::Draw(ImDrawList *drawList) {
 	PopupMenu();
 
 	drawList->PopClipRect();
-
 }
 
 void ImDisasmView::ScrollRelative(int amount) {

--- a/UI/ImDebugger/ImDisasmView.h
+++ b/UI/ImDebugger/ImDisasmView.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <vector>
 #include <string>
 #include <set>


### PR DESCRIPTION
This avoids saving config to clear the list during startup. Saving config is a bit expensive and currently can temporarily freeze while the Recents clearing is still operating (this itself needs fixing).

Also sneak in a couple of other bugfixes.