### PR TITLE
[Libretro] Fix crash on boot

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -90,7 +90,6 @@ static struct {
 #define VSYNC_SWAP_INTERVAL_RUN_SPEED_THRESHOLD 5.0f
 
 static bool libretro_supports_bitmasks = false;
-static bool libretro_supports_option_categories = false;
 static bool show_ip_address_options = true;
 static bool show_upnp_port_option = true;
 static bool show_detect_frame_rate_option = true;
@@ -405,7 +404,8 @@ void retro_set_environment(retro_environment_t cb)
 {
    environ_cb = cb;
 
-   libretro_set_core_options(environ_cb, &libretro_supports_option_categories);
+   bool option_categories = false;
+   libretro_set_core_options(environ_cb, &option_categories);
    struct retro_core_options_update_display_callback update_display_cb;
    update_display_cb.callback = set_variable_visibility;
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK, &update_display_cb);
@@ -1204,6 +1204,7 @@ static const struct retro_controller_info ports[] =
 void retro_init(void)
 {
    TimeInit();
+   SetCurrentThreadName("Main");
 
    struct retro_log_callback log;
    if (environ_cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &log))
@@ -1291,7 +1292,6 @@ void retro_deinit(void)
    printfLogger = nullptr;
 
    libretro_supports_bitmasks = false;
-   libretro_supports_option_categories = false;
 
    VsyncSwapIntervalReset();
 
@@ -1509,7 +1509,7 @@ bool retro_load_game(const struct retro_game_info *game)
    struct retro_core_option_display option_display;
 
    // Show/hide 'MSAA' and 'Texture Shader' options, Vulkan only
-   option_display.visible = (g_Config.iGPUBackend == (int)GPUBackend::VULKAN) ? true : false;
+   option_display.visible = (g_Config.iGPUBackend == (int)GPUBackend::VULKAN);
 #if 0 // see issue #16786
    option_display.key = "ppsspp_mulitsample_level";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
@@ -1519,7 +1519,7 @@ bool retro_load_game(const struct retro_game_info *game)
 
    // Show/hide 'Buffered Frames' option, Vulkan/GL only
    option_display.visible = (g_Config.iGPUBackend == (int)GPUBackend::VULKAN ||
-         g_Config.iGPUBackend == (int)GPUBackend::OPENGL) ? true : false;
+         g_Config.iGPUBackend == (int)GPUBackend::OPENGL);
    option_display.key = "ppsspp_inflight_frames";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -735,7 +735,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_change_mac_address01",
-      "MAC Address Pt  1: X-:--:--:--:--:--",
+      "MAC Address Pt  1: x-:--:--:--:--:--",
       NULL,
       NULL,
       NULL,
@@ -745,7 +745,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_change_mac_address02",
-      "MAC Address Pt  2: -X:--:--:--:--:--",
+      "MAC Address Pt  2: -x:--:--:--:--:--",
       NULL,
       NULL,
       NULL,
@@ -755,7 +755,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_change_mac_address03",
-      "MAC Address Pt  3: --:X-:--:--:--:--",
+      "MAC Address Pt  3: --:x-:--:--:--:--",
       NULL,
       NULL,
       NULL,
@@ -765,7 +765,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_change_mac_address04",
-      "MAC Address Pt  4: --:-X:--:--:--:--",
+      "MAC Address Pt  4: --:-x:--:--:--:--",
       NULL,
       NULL,
       NULL,
@@ -775,7 +775,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_change_mac_address05",
-      "MAC Address Pt  5: --:--:X-:--:--:--",
+      "MAC Address Pt  5: --:--:x-:--:--:--",
       NULL,
       NULL,
       NULL,
@@ -785,7 +785,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_change_mac_address06",
-      "MAC Address Pt  6: --:--:-X:--:--:--",
+      "MAC Address Pt  6: --:--:-x:--:--:--",
       NULL,
       NULL,
       NULL,
@@ -795,7 +795,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_change_mac_address07",
-      "MAC Address Pt  7: --:--:--:X-:--:--",
+      "MAC Address Pt  7: --:--:--:x-:--:--",
       NULL,
       NULL,
       NULL,
@@ -805,7 +805,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_change_mac_address08",
-      "MAC Address Pt  8: --:--:--:-X:--:--",
+      "MAC Address Pt  8: --:--:--:-x:--:--",
       NULL,
       NULL,
       NULL,
@@ -815,7 +815,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_change_mac_address09",
-      "MAC Address Pt  9: --:--:--:--:X-:--",
+      "MAC Address Pt  9: --:--:--:--:x-:--",
       NULL,
       NULL,
       NULL,
@@ -825,7 +825,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_change_mac_address10",
-      "MAC Address Pt 10: --:--:--:--:-X:--",
+      "MAC Address Pt 10: --:--:--:--:-x:--",
       NULL,
       NULL,
       NULL,
@@ -835,7 +835,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_change_mac_address11",
-      "MAC Address Pt 11: --:--:--:--:--:X-",
+      "MAC Address Pt 11: --:--:--:--:--:x-",
       NULL,
       NULL,
       NULL,
@@ -845,7 +845,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
    },
    {
       "ppsspp_change_mac_address12",
-      "MAC Address Pt 12: --:--:--:--:--:-X",
+      "MAC Address Pt 12: --:--:--:--:--:-x",
       NULL,
       NULL,
       NULL,


### PR DESCRIPTION
Currently crashes because `hostThreadName` is null during the string comparison here: https://github.com/hrydgard/ppsspp/blob/18b20e3175c80dc21c67df1fb9791618a5100004/Common/Log/LogManager.cpp#L261
So I simply added `SetCurrentThreadName("Main");` in retro_init, hope this is fine?
At first I wanted to do this:
```diff
diff --git a/Common/Thread/ThreadUtil.cpp b/Common/Thread/ThreadUtil.cpp
index 0e0badb084..d7b83a1661 100644
--- a/Common/Thread/ThreadUtil.cpp
+++ b/Common/Thread/ThreadUtil.cpp
@@ -117,7 +117,7 @@ void SetCurrentThreadNameThroughException(const char *threadName);
 
 const char *GetCurrentThreadName() {
 #ifdef TLS_SUPPORTED
-	return curThreadName;
+	return (curThreadName ? curThreadName : "");
 #else
 	return "";
 #endif
```
but since it's most likely a Libretro only issue I thought you'd prefer that I only make changes in libretro.cpp.
Lmk and I'll update the PR.

Also made a couple of very minor cleanups.