### PR TITLE
File system perf, part 3

### DIFF
--- a/Common/File/DirListing.cpp
+++ b/Common/File/DirListing.cpp
@@ -43,7 +43,12 @@
 #endif // HAVE_LIBNX
 
 // NOTE: There's another one in FileUtil.cpp.
+#ifdef _WIN32
 constexpr bool SIMULATE_SLOW_IO = false;
+#else
+constexpr bool SIMULATE_SLOW_IO = false;
+#endif
+constexpr bool LOG_IO = false;
 
 namespace File {
 
@@ -57,8 +62,10 @@ static uint64_t FiletimeToStatTime(FILETIME ft) {
 #endif
 
 bool GetFileInfo(const Path &path, FileInfo * fileInfo) {
-	if (SIMULATE_SLOW_IO) {
+	if (LOG_IO) {
 		INFO_LOG(Log::System, "GetFileInfo %s", path.c_str());
+	}
+	if (SIMULATE_SLOW_IO) {
 		sleep_ms(300, "slow-io-sim");
 	}
 
@@ -184,8 +191,10 @@ std::vector<File::FileInfo> ApplyFilter(std::vector<File::FileInfo> files, const
 }
 
 bool GetFilesInDir(const Path &directory, std::vector<FileInfo> *files, const char *filter, int flags, std::string_view prefix) {
-	if (SIMULATE_SLOW_IO) {
+	if (LOG_IO) {
 		INFO_LOG(Log::System, "GetFilesInDir %s (ext %s, prefix %.*s)", directory.c_str(), filter, (int)prefix.size(), prefix.data());
+	}
+	if (SIMULATE_SLOW_IO) {
 		sleep_ms(300, "slow-io-sim");
 	}
 
@@ -267,10 +276,12 @@ bool GetFilesInDir(const Path &directory, std::vector<FileInfo> *files, const ch
 			continue;
 		}
 
+		/*
 		if (SIMULATE_SLOW_IO) {
 			INFO_LOG(Log::System, "GetFilesInDir item %s", virtualName.c_str());
 			sleep_ms(50, "slow-io-sim");
 		}
+		*/
 
 		FileInfo info;
 		info.name = virtualName;
@@ -345,6 +356,9 @@ bool GetFilesInDir(const Path &directory, std::vector<FileInfo> *files, const ch
 	closedir(dirp);
 #endif
 	std::sort(files->begin(), files->end());
+	if (LOG_IO) {
+		INFO_LOG(Log::System, "GetFilesInDir: Found %d files", (int)files->size());
+	}
 	return true;
 }
 

--- a/Common/File/DiskFree.h
+++ b/Common/File/DiskFree.h
@@ -5,5 +5,6 @@
 #include "Common/File/Path.h"
 
 // If this fails, false is returned and space is negative.
-// Try to avoid calling this from the main thread, if possible. Can be SLOW.
+// Try to avoid calling this from the main thread, if possible. Not super fast,
+// but is also not allowed to do things like scan the entire disk.
 bool free_disk_space(const Path &path, int64_t &space);

--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -91,7 +91,12 @@
 #include <sys/stat.h>
 
 // NOTE: There's another one in DirListing.cpp.
+#ifdef _WIN32
 constexpr bool SIMULATE_SLOW_IO = false;
+#else
+constexpr bool SIMULATE_SLOW_IO = false;
+#endif
+constexpr bool LOG_IO = false;
 
 #ifndef S_ISDIR
 #define S_ISDIR(m)  (((m)&S_IFMT) == S_IFDIR)
@@ -115,8 +120,10 @@ constexpr bool SIMULATE_SLOW_IO = false;
 namespace File {
 
 FILE *OpenCFile(const Path &path, const char *mode) {
-	if (SIMULATE_SLOW_IO) {
+	if (LOG_IO) {
 		INFO_LOG(Log::System, "OpenCFile %s, %s", path.c_str(), mode);
+	}
+	if (SIMULATE_SLOW_IO) {
 		sleep_ms(300, "slow-io-sim");
 	}
 	switch (path.Type()) {
@@ -217,8 +224,10 @@ static std::string OpenFlagToString(OpenFlag flags) {
 }
 
 int OpenFD(const Path &path, OpenFlag flags) {
-	if (SIMULATE_SLOW_IO) {
+	if (LOG_IO) {
 		INFO_LOG(Log::System, "OpenFD %s, %d", path.c_str(), flags);
+	}
+	if (SIMULATE_SLOW_IO) {
 		sleep_ms(300, "slow-io-sim");
 	}
 
@@ -315,8 +324,10 @@ static bool ResolvePathVista(const std::wstring &path, wchar_t *buf, DWORD bufSi
 #endif
 
 std::string ResolvePath(const std::string &path) {
-	if (SIMULATE_SLOW_IO) {
+	if (LOG_IO) {
 		INFO_LOG(Log::System, "ResolvePath %s", path.c_str());
+	}
+	if (SIMULATE_SLOW_IO) {
 		sleep_ms(100, "slow-io-sim");
 	}
 
@@ -408,9 +419,11 @@ bool ExistsInDir(const Path &path, const std::string &filename) {
 }
 
 bool Exists(const Path &path) {
+	if (LOG_IO) {
+		INFO_LOG(Log::System, "Exists %s", path.c_str());
+	}
 	if (SIMULATE_SLOW_IO) {
 		sleep_ms(200, "slow-io-sim");
-		INFO_LOG(Log::System, "Exists %s", path.c_str());
 	}
 
 	if (path.Type() == PathType::CONTENT_URI) {
@@ -445,9 +458,11 @@ bool Exists(const Path &path) {
 
 // Returns true if filename exists and is a directory
 bool IsDirectory(const Path &path) {
+	if (LOG_IO) {
+		INFO_LOG(Log::System, "IsDirectory %s", path.c_str());
+	}
 	if (SIMULATE_SLOW_IO) {
 		sleep_ms(100, "slow-io-sim");
-		INFO_LOG(Log::System, "IsDirectory %s", path.c_str());
 	}
 
 	switch (path.Type()) {
@@ -660,9 +675,11 @@ bool CreateFullPath(const Path &path) {
 
 // renames file srcFilename to destFilename, returns true on success
 bool Rename(const Path &srcFilename, const Path &destFilename) {
+	if (LOG_IO) {
+		INFO_LOG(Log::System, "Rename %s -> %s", srcFilename.c_str(), destFilename.c_str());
+	}
 	if (SIMULATE_SLOW_IO) {
 		sleep_ms(100, "slow-io-sim");
-		INFO_LOG(Log::System, "Rename %s -> %s", srcFilename.c_str(), destFilename.c_str());
 	}
 
 	if (srcFilename.Type() != destFilename.Type()) {
@@ -713,9 +730,11 @@ bool Rename(const Path &srcFilename, const Path &destFilename) {
 
 // copies file srcFilename to destFilename, returns true on success
 bool Copy(const Path &srcFilename, const Path &destFilename) {
+	if (LOG_IO) {
+		INFO_LOG(Log::System, "Copy %s -> %s", srcFilename.c_str(), destFilename.c_str());
+	}
 	if (SIMULATE_SLOW_IO) {
 		sleep_ms(100, "slow-io-sim");
-		INFO_LOG(Log::System, "Copy %s -> %s", srcFilename.c_str(), destFilename.c_str());
 	}
 	switch (srcFilename.Type()) {
 	case PathType::NATIVE:
@@ -857,9 +876,11 @@ bool MoveIfFast(const Path &srcFilename, const Path &destFilename) {
 // Returns the size of file (64bit)
 // TODO: Add a way to return an error.
 uint64_t GetFileSize(const Path &filename) {
+	if (LOG_IO) {
+		INFO_LOG(Log::System, "GetFileSize %s", filename.c_str());
+	}
 	if (SIMULATE_SLOW_IO) {
 		sleep_ms(100, "slow-io-sim");
-		INFO_LOG(Log::System, "GetFileSize %s", filename.c_str());
 	}
 	switch (filename.Type()) {
 	case PathType::NATIVE:
@@ -967,9 +988,11 @@ bool CreateEmptyFile(const Path &filename) {
 // Deletes an empty directory, returns true on success
 // WARNING: On Android with content URIs, it will delete recursively!
 bool DeleteDir(const Path &path) {
+	if (LOG_IO) {
+		INFO_LOG(Log::System, "DeleteDir %s", path.c_str());
+	}
 	if (SIMULATE_SLOW_IO) {
 		sleep_ms(100, "slow-io-sim");
-		INFO_LOG(Log::System, "DeleteDir %s", path.c_str());
 	}
 	switch (path.Type()) {
 	case PathType::NATIVE:

--- a/Common/Thread/ThreadManager.cpp
+++ b/Common/Thread/ThreadManager.cpp
@@ -130,10 +130,10 @@ bool ThreadManager::TeardownTask(Task *task, bool enqueue) {
 
 static void WorkerThreadFunc(GlobalThreadContext *global, TaskThreadContext *thread) {
 	if (thread->type == TaskType::CPU_COMPUTE) {
-		snprintf(thread->name, sizeof(thread->name), "PoolWorker %d", thread->index);
+		snprintf(thread->name, sizeof(thread->name), "PoolW %d", thread->index);
 	} else {
 		_assert_(thread->type == TaskType::IO_BLOCKING);
-		snprintf(thread->name, sizeof(thread->name), "PoolWorkerIO %d", thread->index);
+		snprintf(thread->name, sizeof(thread->name), "PoolW IO %d", thread->index);
 	}
 	SetCurrentThreadName(thread->name);
 

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1228,6 +1228,8 @@ bool SavedataParam::GetList(SceUtilitySavedataParam *param)
 
 		std::vector<PSPFileInfo> validDir;
 		std::vector<PSPFileInfo> sfoFiles;
+
+		// TODO: Here we can filter by prefix - only the savename in param is likely to be a regex.
 		std::vector<PSPFileInfo> allDir = pspFileSystem.GetDirListing(savePath);
 
 		std::string searchString = GetGameName(param) + GetSaveName(param);

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -366,12 +366,15 @@ size_t DirectoryFileHandle::Write(const u8* pointer, s64 size)
 		g_OSD.Show(OSDType::MESSAGE_ERROR, err->T("Disk full while writing data"), 0.0f, "diskfull");
 		// We only return an error when the disk is actually full.
 		// When writing this would cause the disk to be full, so it wasn't written, we return 0.
-		if (MemoryStick_FreeSpace() == 0) {
-			// Sign extend on 64-bit.
-			return (size_t)(s64)(s32)SCE_KERNEL_ERROR_ERRNO_DEVICE_NO_FREE_SPACE;
+		Path saveFolder = GetSysDirectory(DIRECTORY_SAVEDATA);
+		int64_t space;
+		if (free_disk_space(saveFolder, space)) {
+			if (space < size) {
+				// Sign extend to a 64-bit value.
+				return (size_t)(s64)(s32)SCE_KERNEL_ERROR_ERRNO_DEVICE_NO_FREE_SPACE;
+			}
 		}
 	}
-
 	return bytesWritten;
 }
 

--- a/Core/FileSystems/MetaFileSystem.cpp
+++ b/Core/FileSystems/MetaFileSystem.cpp
@@ -682,3 +682,9 @@ int64_t MetaFileSystem::ComputeRecursiveDirectorySize(const std::string &filenam
 		return false;
 	}
 }
+
+bool MetaFileSystem::ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) {
+	// Shouldn't be called. Can't recurse MetaFileSystem.
+	_dbg_assert_(false);
+	return false;
+}

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -144,16 +144,7 @@ public:
 
 	int64_t ComputeRecursiveDirectorySize(const std::string &dirPath);
 
-	// Shouldn't ever be called, but meh.
-	bool ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) override {
-		int64_t sizeTemp = ComputeRecursiveDirectorySize(path);
-		if (sizeTemp >= 0) {
-			*size = sizeTemp;
-			return true;
-		} else {
-			return false;
-		}
-	}
+	bool ComputeRecursiveDirSizeIfFast(const std::string &path, int64_t *size) override;
 
 	void Describe(char *buf, size_t size) const override { snprintf(buf, size, "Meta"); }
 

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -675,8 +675,8 @@ void __IoInit() {
 
 	pspFileSystem.Mount("flash0:", flash0System);
 
+	const std::string gameId = g_paramSFO.GetDiscID();
 	if (g_RemasterMode) {
-		const std::string gameId = g_paramSFO.GetDiscID();
 		const Path exdataPath = GetSysDirectory(DIRECTORY_EXDATA) / gameId;
 		if (File::Exists(exdataPath)) {
 			auto exdataSystem = std::make_shared<DirectoryFileSystem>(&pspFileSystem, exdataPath, FileSystemFlags::SIMULATE_FAT32 | FileSystemFlags::CARD);
@@ -698,7 +698,7 @@ void __IoInit() {
 
 	__KernelRegisterWaitTypeFuncs(WAITTYPE_ASYNCIO, __IoAsyncBeginCallback, __IoAsyncEndCallback);
 
-	MemoryStick_Init();
+	MemoryStick_Init(gameId);
 	lastMemStickState = MemoryStick_State();
 	lastMemStickFatState = MemoryStick_FatState();
 	__DisplayListenVblank(__IoVblank);

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -675,8 +675,8 @@ void __IoInit() {
 
 	pspFileSystem.Mount("flash0:", flash0System);
 
-	const std::string gameId = g_paramSFO.GetDiscID();
 	if (g_RemasterMode) {
+		const std::string gameId = g_paramSFO.GetDiscID();
 		const Path exdataPath = GetSysDirectory(DIRECTORY_EXDATA) / gameId;
 		if (File::Exists(exdataPath)) {
 			auto exdataSystem = std::make_shared<DirectoryFileSystem>(&pspFileSystem, exdataPath, FileSystemFlags::SIMULATE_FAT32 | FileSystemFlags::CARD);
@@ -698,7 +698,7 @@ void __IoInit() {
 
 	__KernelRegisterWaitTypeFuncs(WAITTYPE_ASYNCIO, __IoAsyncBeginCallback, __IoAsyncEndCallback);
 
-	MemoryStick_Init(gameId);
+	MemoryStick_Init();
 	lastMemStickState = MemoryStick_State();
 	lastMemStickFatState = MemoryStick_FatState();
 	__DisplayListenVblank(__IoVblank);

--- a/Core/HW/MemoryStick.h
+++ b/Core/HW/MemoryStick.h
@@ -42,8 +42,11 @@ enum MemStickDriverState {
 	PSP_MEMORYSTICK_STATE_DEVICE_REMOVED  = 8,
 };
 
-void MemoryStick_Init(std::string gameID);
+void MemoryStick_Init();
 void MemoryStick_Shutdown();
+
+void MemoryStick_NotifyGameName(std::string gameName);
+
 void MemoryStick_DoState(PointerWrap &p);
 MemStickState MemoryStick_State();
 MemStickFatState MemoryStick_FatState();
@@ -52,5 +55,5 @@ void MemoryStick_SetState(MemStickState state);
 void MemoryStick_SetFatState(MemStickFatState state);
 
 u64 MemoryStick_SectorSize();
-u64 MemoryStick_FreeSpace();
+u64 MemoryStick_FreeSpace(std::string gameID);
 void MemoryStick_NotifyWrite();

--- a/Core/HW/MemoryStick.h
+++ b/Core/HW/MemoryStick.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "Common/CommonTypes.h"
 
 class PointerWrap;
@@ -40,7 +42,7 @@ enum MemStickDriverState {
 	PSP_MEMORYSTICK_STATE_DEVICE_REMOVED  = 8,
 };
 
-void MemoryStick_Init();
+void MemoryStick_Init(std::string gameID);
 void MemoryStick_Shutdown();
 void MemoryStick_DoState(PointerWrap &p);
 MemStickState MemoryStick_State();

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -441,13 +441,11 @@ bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string) {
 
 	std::string homebrewName = PSP_CoreParameter().fileToStart.ToVisualString();
 	std::size_t lslash = homebrewName.find_last_of('/');
-#if PPSSPP_PLATFORM(UWP)
-	if (lslash == homebrewName.npos) {
-		lslash = homebrewName.find_last_of("\\");
-	}
-#endif
+	std::size_t rslash = homebrewName.find_last_of('\\');
 	if (lslash != homebrewName.npos)
 		homebrewName = homebrewName.substr(lslash + 1);
+	if (rslash != homebrewName.npos)
+		homebrewName = homebrewName.substr(rslash + 1);
 	std::string homebrewTitle = g_paramSFO.GetValueString("TITLE");
 	if (homebrewTitle.empty())
 		homebrewTitle = homebrewName;

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1135,6 +1135,7 @@ UCJS10039 = true
 UCJS18012 = true
 
 [MemstickFixedFree]
+# Assassin's Creed : Bloodlines - issue #12761
 ULJM05571 = true
 ULES01367 = true
 NPEH00029 = true


### PR DESCRIPTION
Followup to #19671  and #19668 

This avoids doing a large scan of all savedata on game startup. In the case of #12761 , we now do a much smaller scan of just the folders that the game touches.