### PR TITLE
File system perf 5, fix ini file regression

### DIFF
--- a/Common/Data/Format/IniFile.cpp
+++ b/Common/Data/Format/IniFile.cpp
@@ -544,7 +544,7 @@ bool IniFile::Load(std::istream &in) {
 #ifndef _WIN32
 		// Check for CRLF eol and convert it to LF
 		if (!line.empty() && line.at(line.size() - 1) == '\r') {
-			line = line.substr(line.size() - 1);
+			line = line.substr(0, line.size() - 1);
 		}
 #endif
 

--- a/Common/File/VFS/ZipFileReader.cpp
+++ b/Common/File/VFS/ZipFileReader.cpp
@@ -229,8 +229,7 @@ public:
 };
 
 VFSFileReference *ZipFileReader::GetFile(const char *path) {
-	std::lock_guard<std::mutex> guard(lock_);
-	int zi = zip_name_locate(zip_file_, path, ZIP_FL_NOCASE);
+	int zi = zip_name_locate(zip_file_, path, ZIP_FL_NOCASE);  // this is EXPENSIVE
 	if (zi < 0) {
 		// Not found.
 		return nullptr;
@@ -244,7 +243,6 @@ bool ZipFileReader::GetFileInfo(VFSFileReference *vfsReference, File::FileInfo *
 	ZipFileReaderFileReference *reference = (ZipFileReaderFileReference *)vfsReference;
 	// If you crash here, you called this while having the lock held by having the file open.
 	// Don't do that, check the info before you open the file.
-	std::lock_guard<std::mutex> guard(lock_);
 	zip_stat_t zstat;
 	if (zip_stat_index(zip_file_, reference->zi, 0, &zstat) != 0)
 		return false;

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1562,16 +1562,12 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 			// TODO: Filter away non-directories directly?
 			std::vector<PSPFileInfo> allSaves = pspFileSystem.GetDirListing(savePath);
 
-			bool fetchedAllSaves = false;
 			std::string gameName = GetGameName(param);
 
 			for (int i = 0; i < saveDataListCount; i++) {
 				// "<>" means saveName can be anything...
 				if (strncmp(saveNameListData[i], "<>", ARRAY_SIZE(saveNameListData[i])) == 0) {
-					// TODO:Maybe we need a way to reorder the files?
-					if (!fetchedAllSaves) {
-						fetchedAllSaves = true;
-					}
+					// TODO: Maybe we need a way to reorder the files?
 					for (auto it = allSaves.begin(); it != allSaves.end(); ++it) {
 						if (it->name.compare(0, gameName.length(), gameName) == 0) {
 							std::string saveName = it->name.substr(gameName.length());
@@ -1582,7 +1578,6 @@ int SavedataParam::SetPspParam(SceUtilitySavedataParam *param)
 							std::string fileDataPath = savePath + it->name;
 							if (it->exists) {
 								SetFileInfo(realCount, *it, saveName);
-								DEBUG_LOG(Log::sceUtility, "%s Exist", fileDataPath.c_str());
 								++realCount;
 							} else {
 								if (listEmptyFile) {

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -109,11 +109,16 @@ void TextureReplacer::NotifyConfigChanged() {
 	}
 
 	if (replaceEnabled_) {
-		replaceEnabled_ = LoadIni();
+		std::string error;
+		replaceEnabled_ = LoadIni(&error);
+		if (!error.empty() && !replaceEnabled_) {
+			ERROR_LOG(Log::G3D, "ERROR: %s", error.c_str());
+			g_OSD.Show(OSDType::MESSAGE_ERROR, error, 5.0f);
+		}
 	}
 }
 
-bool TextureReplacer::LoadIni() {
+bool TextureReplacer::LoadIni(std::string *error) {
 	hash_ = ReplacedTextureHash::QUICK;
 	aliases_.clear();
 	hashranges_.clear();
@@ -146,7 +151,7 @@ bool TextureReplacer::LoadIni() {
 	bool iniLoaded = ini.LoadFromVFS(*dir, INI_FILENAME);
 
 	if (iniLoaded) {
-		if (!LoadIniValues(ini, dir)) {
+		if (!LoadIniValues(ini, dir, false, error)) {
 			delete dir;
 			return false;
 		}
@@ -158,6 +163,7 @@ bool TextureReplacer::LoadIni() {
 				IniFile overrideIni;
 				iniLoaded = overrideIni.LoadFromVFS(*dir, overrideFilename);
 				if (!iniLoaded) {
+					*error = "Loading override ini failed: " + overrideFilename;
 					ERROR_LOG(Log::G3D, "Failed to load extra texture ini: %s", overrideFilename.c_str());
 					// Since this error is most likely to occure for texture pack creators, let's just bail here
 					// so that the creator is more likely to look in the logs for what happened.
@@ -166,7 +172,8 @@ bool TextureReplacer::LoadIni() {
 				}
 
 				INFO_LOG(Log::G3D, "Loading extra texture ini: %s", overrideFilename.c_str());
-				if (!LoadIniValues(overrideIni, nullptr, true)) {
+				if (!LoadIniValues(overrideIni, nullptr, true, error)) {
+					*error = "Override: " + *error;
 					delete dir;
 					return false;
 				}
@@ -176,10 +183,11 @@ bool TextureReplacer::LoadIni() {
 		if (vfsIsZip_) {
 			// We don't accept zip files without inis.
 			ERROR_LOG(Log::G3D, "Texture pack lacking ini file: %s", basePath_.c_str());
+			*error = "Zip files without ini files will not load";
 			delete dir;
 			return false;
 		} else {
-			WARN_LOG(Log::G3D, "Texture pack lacking ini file: %s", basePath_.c_str());
+			WARN_LOG(Log::G3D, "Texture pack lacking ini file: %s  Proceeding with only hash-named textures in the root.", basePath_.c_str());
 			// Do what we can do anyway: Scan for textures and build the map.
 			std::map<ReplacementCacheKey, std::map<int, std::string>> filenameMap;
 			ScanForHashNamedFiles(dir, filenameMap);
@@ -268,12 +276,15 @@ void TextureReplacer::ComputeAliasMap(const std::map<ReplacementCacheKey, std::m
 	}
 }
 
-bool TextureReplacer::LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverride) {
-	INFO_LOG(Log::G3D, "Loading ini file...");
+bool TextureReplacer::LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverride, std::string *error) {
+	INFO_LOG(Log::G3D, "Loading ini values...");
 
 	auto options = ini.GetOrCreateSection("options");
 	std::string hash;
-	options->Get("hash", &hash, "");
+	if (!options->Get("hash", &hash, "")) {
+		*error = "textures.ini: Hash type not specified";
+		return false;
+	}
 	if (strcasecmp(hash.c_str(), "quick") == 0) {
 		hash_ = ReplacedTextureHash::QUICK;
 	} else if (strcasecmp(hash.c_str(), "xxh32") == 0) {
@@ -281,7 +292,7 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverri
 	} else if (strcasecmp(hash.c_str(), "xxh64") == 0) {
 		hash_ = ReplacedTextureHash::XXH64;
 	} else if (!isOverride || !hash.empty()) {
-		ERROR_LOG(Log::G3D, "Unsupported hash type: %s", hash.c_str());
+		*error = "textures.ini: Unsupported hash type: " + hash;
 		return false;
 	}
 

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -194,7 +194,7 @@ bool TextureReplacer::LoadIni() {
 	}
 
 	auto gr = GetI18NCategory(I18NCat::GRAPHICS);
-	g_OSD.Show(OSDType::MESSAGE_SUCCESS, gr->T("Texture replacement pack activated"), 2.0f);
+	g_OSD.Show(OSDType::MESSAGE_SUCCESS, gr->T("Texture replacement pack activated"), 3.0f);
 
 	vfs_ = dir;
 

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -131,8 +131,8 @@ public:
 protected:
 	bool FindFiltering(u64 cachekey, u32 hash, TextureFiltering *forceFiltering);
 
-	bool LoadIni();
-	bool LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverride = false);
+	bool LoadIni(std::string *error);
+	bool LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverride, std::string *error);
 	void ParseHashRange(const std::string &key, const std::string &value);
 	void ParseFiltering(const std::string &key, const std::string &value);
 	void ParseReduceHashRange(const std::string& key, const std::string& value);

--- a/UI/ImDebugger/ImGe.cpp
+++ b/UI/ImDebugger/ImGe.cpp
@@ -30,7 +30,7 @@ void DrawTexturesWindow(ImConfig &cfg, TextureCacheCommon *textureCache) {
 }
 
 void DrawDisplayWindow(ImConfig &cfg, FramebufferManagerCommon *framebufferManager) {
-	if (!ImGui::Begin("Display", &cfg.framebuffersOpen)) {
+	if (!ImGui::Begin("Display", &cfg.displayOpen)) {
 		ImGui::End();
 		return;
 	}


### PR DESCRIPTION
Followup to #19676  , improve performance a bit when loading texture packs directly from zip files. Also fixes the regression and improves error reporting when loading texture replacements.