### PR TITLE
Cull through-mode 2D draws against scissor rectangle

### DIFF
--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -107,6 +107,7 @@ public:
 	// This is a less accurate version of TestBoundingBox, but faster. Can have more false positives.
 	// Doesn't support indexing.
 	bool TestBoundingBoxFast(const void *control_points, int vertexCount, u32 vertType);
+	bool TestBoundingBoxThrough(const void *vdata, int vertexCount, u32 vertType);
 
 	void FlushSkin() {
 		bool applySkin = (lastVType_ & GE_VTYPE_WEIGHT_MASK) && decOptions_.applySkinInDecode;

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -3159,12 +3159,14 @@ void TextureCacheCommon::DrawImGuiDebug(uint64_t &selectedTextureId) const {
 
 	if (ImGui::CollapsingHeader("Texture Cache State"), ImGuiTreeNodeFlags_DefaultOpen) {
 		ImGui::Text("Cache: %d textures, size est %d", (int)cache_.size(), cacheSizeEstimate_);
-		ImGui::Text("Second: %d textures, size est %d", (int)secondCache_.size(), secondCacheSizeEstimate_);
-		ImGui::Text("Low memory mode: %d", (int)lowMemoryMode_);
+		if (!secondCache_.empty()) {
+			ImGui::Text("Second: %d textures, size est %d", (int)secondCache_.size(), secondCacheSizeEstimate_);
+		}
 		ImGui::Text("Standard/shader scale factor: %d/%d", standardScaleFactor_, shaderScaleFactor_);
 		ImGui::Text("Texels scaled this frame: %d", texelsScaledThisFrame_);
+		ImGui::Text("Low memory mode: %d", (int)lowMemoryMode_);
 		if (ImGui::CollapsingHeader("Texture Replacement", ImGuiTreeNodeFlags_DefaultOpen)) {
-			ImGui::Text("Frame time/budget: %0.3f/%0.3f ms", replacementTimeThisFrame_, replacementFrameBudget_);
+			ImGui::Text("Frame time/budget: %0.3f/%0.3f ms", replacementTimeThisFrame_ * 1000.0f, replacementFrameBudget_ * 1000.0f);
 			ImGui::Text("UNLOADED: %d PENDING: %d NOT_FOUND: %d ACTIVE: %d CANCEL_INIT: %d",
 				replacementStateCounts[(int)ReplacementState::UNLOADED],
 				replacementStateCounts[(int)ReplacementState::PENDING],


### PR DESCRIPTION
Currently only for through-mode draws with float pos. Helps to avoid loading textures that are not on screen, which especially helps when using texture replacement in some games that draw a lot of off-screen stuff for no good reason (Fate Extra).