### PR TITLE
More GE debugger refactoring, initial work on the new debugger

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -322,6 +322,11 @@ void Core_ProcessStepping(MIPSDebugInterface *cpu) {
 
 // Free-threaded (hm, possibly except tracing).
 void Core_Break(const char *reason, u32 relatedAddress) {
+	if (coreState != CORE_RUNNING_CPU) {
+		ERROR_LOG(Log::CPU, "Core_Break ony works in the CORE_RUNNING_CPU state");
+		return;
+	}
+
 	// Stop the tracer
 	{
 		std::lock_guard<std::mutex> lock(g_stepMutex);

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -54,7 +54,8 @@
 
 // Step command to execute next
 static std::mutex g_stepMutex;
-struct StepCommand {
+
+struct CPUStepCommand {
 	CPUStepType type;
 	int stepSize;
 	const char *reason;
@@ -69,7 +70,20 @@ struct StepCommand {
 		relatedAddr = 0;
 	}
 };
-static StepCommand g_stepCommand;
+
+static CPUStepCommand g_cpuStepCommand;
+
+struct GeStepCommand {
+	CPUStepType type;
+	bool empty() const {
+		return type == CPUStepType::None;
+	}
+	void clear() {
+		type = CPUStepType::None;
+	}
+};
+
+static GeStepCommand g_geStepCommand;
 
 // This is so that external threads can wait for the CPU to become inactive.
 static std::condition_variable m_InactiveCond;
@@ -157,15 +171,25 @@ bool Core_GetPowerSaving() {
 	return powerSaving;
 }
 
-bool Core_RequestSingleStep(CPUStepType type, int stepSize) {
+bool Core_RequestCPUStep(CPUStepType type, int stepSize) {
 	std::lock_guard<std::mutex> guard(g_stepMutex);
-	if (g_stepCommand.type != CPUStepType::None) {
-		ERROR_LOG(Log::CPU, "Can't submit two steps in one frame");
+	if (g_cpuStepCommand.type != CPUStepType::None) {
+		ERROR_LOG(Log::CPU, "Can't submit two steps in one host frame");
 		return false;
 	}
 	// Out-steps don't need a size.
 	_dbg_assert_(stepSize != 0 || type == CPUStepType::Out);
-	g_stepCommand = { type, stepSize };
+	g_cpuStepCommand = { type, stepSize };
+	return true;
+}
+
+bool Core_RequestGeStep(CPUStepType type) {
+	std::lock_guard<std::mutex> guard(g_stepMutex);
+	if (g_geStepCommand.type != CPUStepType::None) {
+		ERROR_LOG(Log::CPU, "Can't submit two steps in one host frame");
+		return false;
+	}
+	g_geStepCommand = { type };
 	return true;
 }
 
@@ -174,7 +198,7 @@ bool Core_RequestSingleStep(CPUStepType type, int stepSize) {
 // Yes, our disassembler does support those.
 // Doesn't return the new address, as that's just mips->getPC().
 // Internal use.
-static void Core_PerformStep(MIPSDebugInterface *cpu, CPUStepType stepType, int stepSize) {
+static void Core_PerformCPUStep(MIPSDebugInterface *cpu, CPUStepType stepType, int stepSize) {
 	switch (stepType) {
 	case CPUStepType::Into:
 	{
@@ -257,6 +281,11 @@ static void Core_PerformStep(MIPSDebugInterface *cpu, CPUStepType stepType, int 
 	}
 }
 
+static void Core_PerformGeStep(CPUStepType stepType) {
+	// TODO
+}
+
+// Should only be called from GPUCommon functions (called from sceGe functions).
 void Core_SwitchToGe() {
 	coreState = CORE_RUNNING_GE;
 }
@@ -269,6 +298,7 @@ void Core_ProcessStepping(MIPSDebugInterface *cpu) {
 
 	switch (coreState) {
 	case CORE_STEPPING_CPU:
+	case CORE_STEPPING_GE:
 		// All good
 		break;
 	default:
@@ -277,6 +307,7 @@ void Core_ProcessStepping(MIPSDebugInterface *cpu) {
 	}
 
 	// Or any GPU actions.
+	// Legacy stepping code.
 	GPUStepping::SingleStep();
 
 	// We're not inside jit now, so it's safe to clear the breakpoints.
@@ -291,19 +322,29 @@ void Core_ProcessStepping(MIPSDebugInterface *cpu) {
 	// Need to check inside the lock to avoid races.
 	std::lock_guard<std::mutex> guard(g_stepMutex);
 
-	if (coreState != CORE_STEPPING_CPU || g_stepCommand.empty()) {
+	if (coreState == CORE_STEPPING_GE) {
+		if (!g_geStepCommand.empty()) {
+			Core_PerformGeStep(g_geStepCommand.type);
+			// System_Notify(SystemNotification::)
+			g_geStepCommand.clear();
+			steppingCounter++;
+		}
+		return;
+	}
+
+	if (coreState != CORE_STEPPING_CPU || g_cpuStepCommand.empty()) {
 		return;
 	}
 
 	Core_ResetException();
 
-	if (!g_stepCommand.empty()) {
-		Core_PerformStep(cpu, g_stepCommand.type, g_stepCommand.stepSize);
-		if (g_stepCommand.type == CPUStepType::Into) {
+	if (!g_cpuStepCommand.empty()) {
+		Core_PerformCPUStep(cpu, g_cpuStepCommand.type, g_cpuStepCommand.stepSize);
+		if (g_cpuStepCommand.type == CPUStepType::Into) {
 			// We're already done. The other step types will resume the CPU.
 			System_Notify(SystemNotification::DISASSEMBLY_AFTERSTEP);
 		}
-		g_stepCommand.clear();
+		g_cpuStepCommand.clear();
 		steppingCounter++;
 	}
 
@@ -316,22 +357,22 @@ void Core_Break(const char *reason, u32 relatedAddress) {
 	// Stop the tracer
 	{
 		std::lock_guard<std::mutex> lock(g_stepMutex);
-		if (!g_stepCommand.empty() && Core_IsStepping()) {
+		if (!g_cpuStepCommand.empty() && Core_IsStepping()) {
 			// If we're in a failed step that uses a temp breakpoint, we need to be able to override it here.
-			switch (g_stepCommand.type) {
+			switch (g_cpuStepCommand.type) {
 			case CPUStepType::Over:
 			case CPUStepType::Out:
 				// Allow overwriting the command.
 				break;
 			default:
-				ERROR_LOG(Log::CPU, "Core_Break called with a step-command already in progress: %s", g_stepCommand.reason);
+				ERROR_LOG(Log::CPU, "Core_Break called with a step-command already in progress: %s", g_cpuStepCommand.reason);
 				return;
 			}
 		}
 		mipsTracer.stop_tracing();
-		g_stepCommand.type = CPUStepType::None;
-		g_stepCommand.reason = reason;
-		g_stepCommand.relatedAddr = relatedAddress;
+		g_cpuStepCommand.type = CPUStepType::None;
+		g_cpuStepCommand.reason = reason;
+		g_cpuStepCommand.relatedAddr = relatedAddress;
 		steppingCounter++;
 		_assert_msg_(reason != nullptr, "No reason specified for break");
 		Core_UpdateState(CORE_STEPPING_CPU);
@@ -341,6 +382,12 @@ void Core_Break(const char *reason, u32 relatedAddress) {
 
 // Free-threaded (or at least should be)
 void Core_Resume() {
+	// Handle resuming from GE.
+	if (coreState == CORE_STEPPING_GE) {
+		coreState = CORE_RUNNING_GE;
+		return;
+	}
+
 	// Clear the exception if we resume.
 	Core_ResetException();
 	coreState = CORE_RUNNING_CPU;
@@ -349,6 +396,8 @@ void Core_Resume() {
 
 // Should be called from the EmuThread.
 bool Core_NextFrame() {
+	_dbg_assert_(coreState != CORE_STEPPING_GE && coreState != CORE_RUNNING_GE);
+
 	if (coreState == CORE_RUNNING_CPU) {
 		coreState = CORE_NEXTFRAME;
 		return true;
@@ -364,9 +413,9 @@ int Core_GetSteppingCounter() {
 SteppingReason Core_GetSteppingReason() {
 	SteppingReason r;
 	std::lock_guard<std::mutex> lock(g_stepMutex);
-	if (!g_stepCommand.empty()) {
-		r.reason = g_stepCommand.reason;
-		r.relatedAddress = g_stepCommand.relatedAddr;
+	if (!g_cpuStepCommand.empty()) {
+		r.reason = g_cpuStepCommand.reason;
+		r.relatedAddress = g_cpuStepCommand.relatedAddr;
 	}
 	return r;
 }

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -22,6 +22,7 @@
 
 #include "Core/System.h"
 #include "Core/CoreParameter.h"
+#include "GPU/GPUDefinitions.h"
 
 class GraphicsContext;
 
@@ -50,7 +51,8 @@ void Core_Resume();
 
 // This should be called externally.
 // Can fail if another step type was requested this frame.
-bool Core_RequestSingleStep(CPUStepType stepType, int stepSize);
+bool Core_RequestCPUStep(CPUStepType stepType, int stepSize);
+bool Core_RequestGeStep(CPUStepType stepType);
 
 bool Core_ShouldRunBehind();
 bool Core_MustRunBehind();

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -52,7 +52,6 @@ void Core_Resume();
 // This should be called externally.
 // Can fail if another step type was requested this frame.
 bool Core_RequestCPUStep(CPUStepType stepType, int stepSize);
-bool Core_RequestGeStep(CPUStepType stepType);
 
 bool Core_ShouldRunBehind();
 bool Core_MustRunBehind();

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -46,7 +46,8 @@ enum class CPUStepType {
 
 // Async, called from gui
 void Core_Break(const char *reason, u32 relatedAddress = 0);
-// void Core_Step(CPUStepType type);  // CPUStepType::None not allowed
+
+// Resumes execution. Works both when stepping the CPU and the GE.
 void Core_Resume();
 
 // This should be called externally.

--- a/Core/Debugger/DisassemblyManager.cpp
+++ b/Core/Debugger/DisassemblyManager.cpp
@@ -39,8 +39,7 @@ std::recursive_mutex DisassemblyManager::entriesLock_;
 DebugInterface* DisassemblyManager::cpu;
 int DisassemblyManager::maxParamChars = 29;
 
-bool isInInterval(u32 start, u32 size, u32 value)
-{
+bool isInInterval(u32 start, u32 size, u32 value) {
 	return start <= value && value <= (start+size-1);
 }
 
@@ -196,7 +195,6 @@ void DisassemblyManager::analyze(u32 address, u32 size = 1024)
 		if (!PSP_IsInited())
 			return;
 
-		auto memLock = Memory::Lock();
 		std::lock_guard<std::recursive_mutex> guard(entriesLock_);
 		auto it = findDisassemblyEntry(entries, address, false);
 		if (it != entries.end())
@@ -285,12 +283,9 @@ std::vector<BranchLine> DisassemblyManager::getBranchLines(u32 start, u32 size)
 
 void DisassemblyManager::getLine(u32 address, bool insertSymbols, DisassemblyLineInfo &dest, DebugInterface *cpuDebug)
 {
-	// This is here really to avoid lock ordering issues.
-	auto memLock = Memory::Lock();
 	std::lock_guard<std::recursive_mutex> guard(entriesLock_);
 	auto it = findDisassemblyEntry(entries,address,false);
-	if (it == entries.end())
-	{
+	if (it == entries.end()) {
 		analyze(address);
 		it = findDisassemblyEntry(entries,address,false);
 	}
@@ -319,7 +314,6 @@ void DisassemblyManager::getLine(u32 address, bool insertSymbols, DisassemblyLin
 
 u32 DisassemblyManager::getStartAddress(u32 address)
 {
-	auto memLock = Memory::Lock();
 	std::lock_guard<std::recursive_mutex> guard(entriesLock_);
 	auto it = findDisassemblyEntry(entries,address,false);
 	if (it == entries.end())
@@ -337,15 +331,13 @@ u32 DisassemblyManager::getStartAddress(u32 address)
 
 u32 DisassemblyManager::getNthPreviousAddress(u32 address, int n)
 {
-	auto memLock = Memory::Lock();
 	std::lock_guard<std::recursive_mutex> guard(entriesLock_);
 	while (Memory::IsValidAddress(address))
 	{
 		auto it = findDisassemblyEntry(entries,address,false);
 		if (it == entries.end())
 			break;
-		while (it != entries.end())
-		{
+		while (it != entries.end()) {
 			DisassemblyEntry* entry = it->second;
 			int oldLineNum = entry->getLineNum(address,true);
 			if (n <= oldLineNum)
@@ -366,7 +358,6 @@ u32 DisassemblyManager::getNthPreviousAddress(u32 address, int n)
 
 u32 DisassemblyManager::getNthNextAddress(u32 address, int n)
 {
-	auto memLock = Memory::Lock();
 	std::lock_guard<std::recursive_mutex> guard(entriesLock_);
 	while (Memory::IsValidAddress(address))
 	{
@@ -401,7 +392,6 @@ DisassemblyManager::~DisassemblyManager() {
 
 void DisassemblyManager::clear()
 {
-	auto memLock = Memory::Lock();
 	std::lock_guard<std::recursive_mutex> guard(entriesLock_);
 	for (auto it = entries.begin(); it != entries.end(); it++)
 	{
@@ -412,7 +402,6 @@ void DisassemblyManager::clear()
 
 DisassemblyFunction::DisassemblyFunction(u32 _address, u32 _size): address(_address), size(_size)
 {
-	auto memLock = Memory::Lock();
 	if (!PSP_IsInited())
 		return;
 
@@ -426,7 +415,6 @@ DisassemblyFunction::~DisassemblyFunction() {
 
 void DisassemblyFunction::recheck()
 {
-	auto memLock = Memory::Lock();
 	if (!PSP_IsInited())
 		return;
 
@@ -888,7 +876,6 @@ bool DisassemblyMacro::disassemble(u32 address, DisassemblyLineInfo &dest, bool 
 
 DisassemblyData::DisassemblyData(u32 _address, u32 _size, DataType _type): address(_address), size(_size), type(_type)
 {
-	auto memLock = Memory::Lock();
 	if (!PSP_IsInited())
 		return;
 
@@ -898,7 +885,6 @@ DisassemblyData::DisassemblyData(u32 _address, u32 _size, DataType _type): addre
 
 void DisassemblyData::recheck()
 {
-	auto memLock = Memory::Lock();
 	if (!PSP_IsInited())
 		return;
 

--- a/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp
+++ b/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp
@@ -90,7 +90,7 @@ void WebSocketCPUResume(DebuggerRequest &req) {
 
 	g_breakpoints.SetSkipFirst(currentMIPS->pc);
 	if (currentMIPS->inDelaySlot) {
-		Core_RequestSingleStep(CPUStepType::Into, 1);
+		Core_RequestCPUStep(CPUStepType::Into, 1);
 	}
 	Core_Resume();
 }

--- a/Core/Debugger/WebSocket/SteppingSubscriber.cpp
+++ b/Core/Debugger/WebSocket/SteppingSubscriber.cpp
@@ -107,7 +107,7 @@ void WebSocketSteppingState::Into(DebuggerRequest &req) {
 		g_breakpoints.SetSkipFirst(currentMIPS->pc);
 
 		int c = GetNextInstructionCount(cpuDebug);
-		Core_RequestSingleStep(CPUStepType::Into, c);
+		Core_RequestCPUStep(CPUStepType::Into, c);
 	} else {
 		uint32_t breakpointAddress = cpuDebug->GetPC();
 		PrepareResume();
@@ -277,7 +277,7 @@ int WebSocketSteppingState::GetNextInstructionCount(DebugInterface *cpuDebug) {
 void WebSocketSteppingState::PrepareResume() {
 	if (currentMIPS->inDelaySlot) {
 		// Delay slot instructions are never joined, so we pass 1.
-		Core_RequestSingleStep(CPUStepType::Into, 1);
+		Core_RequestCPUStep(CPUStepType::Into, 1);
 	} else {
 		// If the current PC is on a breakpoint, the user doesn't want to do nothing.
 		g_breakpoints.SetSkipFirst(currentMIPS->pc);

--- a/Core/HW/Display.h
+++ b/Core/HW/Display.h
@@ -37,7 +37,7 @@ uint32_t __DisplayGetCurrentHcount();
 uint32_t __DisplayGetAccumulatedHcount();
 void DisplayAdjustAccumulatedHcount(uint32_t diff);
 
-void __DisplayGetDebugStats(char stats[], size_t bufsize);
+void __DisplayGetDebugStats(char *stats, size_t bufsize);
 void __DisplayGetAveragedFPS(float *out_vps, float *out_fps);
 void __DisplayGetFPS(float *out_vps, float *out_fps, float *out_actual_fps);
 void __DisplayGetVPS(float *out_vps);

--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -209,7 +209,7 @@ public:
 		return DisassembleOp(pc, Memory::Read_U32(pc));
 	}
 	virtual GPUDebugOp DisassembleOp(u32 pc, u32 op) = 0;
-	virtual std::vector<GPUDebugOp> DissassembleOpRange(u32 startpc, u32 endpc) = 0;
+	virtual std::vector<GPUDebugOp> DisassembleOpRange(u32 startpc, u32 endpc) = 0;
 
 	// Enter/exit stepping mode.  Mainly for better debug stats on time taken.
 	virtual void NotifySteppingEnter() = 0;

--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -205,10 +205,10 @@ public:
 	virtual void ResetListStall(int listID, u32 stall) = 0;
 	virtual void ResetListState(int listID, DisplayListState state) = 0;
 
-	GPUDebugOp DissassembleOp(u32 pc) {
-		return DissassembleOp(pc, Memory::Read_U32(pc));
+	GPUDebugOp DisassembleOp(u32 pc) {
+		return DisassembleOp(pc, Memory::Read_U32(pc));
 	}
-	virtual GPUDebugOp DissassembleOp(u32 pc, u32 op) = 0;
+	virtual GPUDebugOp DisassembleOp(u32 pc, u32 op) = 0;
 	virtual std::vector<GPUDebugOp> DissassembleOpRange(u32 startpc, u32 endpc) = 0;
 
 	// Enter/exit stepping mode.  Mainly for better debug stats on time taken.

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -3101,7 +3101,7 @@ void TextureCacheCommon::DrawImGuiDebug(uint64_t &selectedTextureId) const {
 		ImGui::Image(texId, ImVec2(128, 128));
 	}
 
-	if (!secondCache_.size()) {
+	if (!secondCache_.empty()) {
 		ImGui::Text("Secondary Cache (%d): TODO", (int)secondCache_.size());
 		// TODO
 	}

--- a/GPU/Debugger/Debugger.cpp
+++ b/GPU/Debugger/Debugger.cpp
@@ -83,7 +83,9 @@ void SetBreakNext(BreakNext next) {
 		GPUBreakpoints::AddCmdBreakpoint(GE_CMD_BEZIER, true);
 		GPUBreakpoints::AddCmdBreakpoint(GE_CMD_SPLINE, true);
 	}
-	GPUStepping::ResumeFromStepping();
+	if (GPUStepping::IsStepping()) {
+		GPUStepping::ResumeFromStepping();
+	}
 	lastStepTime = next == BreakNext::NONE ? -1.0 : time_now_d();
 }
 

--- a/GPU/Debugger/Debugger.h
+++ b/GPU/Debugger/Debugger.h
@@ -40,8 +40,14 @@ bool IsActive();
 void SetBreakNext(BreakNext next);
 void SetBreakCount(int c, bool relative = false);
 
+enum class NotifyResult {
+	Execute,
+	Skip,
+	Break
+};
+
 // While debugging is active, these may block.
-bool NotifyCommand(u32 pc);
+NotifyResult NotifyCommand(u32 pc);
 void NotifyDraw();
 void NotifyDisplay(u32 framebuf, u32 stride, int format);
 void NotifyBeginFrame();
@@ -52,4 +58,4 @@ int PrimsLastFrame();
 bool SetRestrictPrims(const char *rule);
 const char *GetRestrictPrims();
 
-}
+}  // namespace

--- a/GPU/Debugger/Playback.cpp
+++ b/GPU/Debugger/Playback.cpp
@@ -338,7 +338,7 @@ void DumpExecute::SyncStall() {
 	gpu->UpdateStall(execListID, execListPos, &runList);
 	if (runList) {
 		DLResult result = gpu->ProcessDLQueue();
-		_dbg_assert_(result == DLResult::Done || result == DLResult::Pause);
+		_dbg_assert_(result == DLResult::Done || result == DLResult::Stall);
 	}
 	s64 listTicks = gpu->GetListTicks(execListID);
 	if (listTicks != -1) {

--- a/GPU/Debugger/Stepping.h
+++ b/GPU/Debugger/Stepping.h
@@ -30,12 +30,14 @@ namespace GPUStepping {
 	bool EnterStepping();
 	bool IsStepping();
 	void ResumeFromStepping();
+	void WaitForAction();
 
 	int GetSteppingCounter();
 
 	// Called from the emu thread.
 	bool ProcessStepping();
 
+	// NOTE: These are only usable from non-EmuThread threads.
 	bool GPU_GetOutputFramebuffer(const GPUDebugBuffer *&buffer);
 	bool GPU_GetCurrentFramebuffer(const GPUDebugBuffer *&buffer, GPUDebugFramebufferType type);
 	bool GPU_GetCurrentDepthbuffer(const GPUDebugBuffer *&buffer);

--- a/GPU/Debugger/Stepping.h
+++ b/GPU/Debugger/Stepping.h
@@ -28,9 +28,13 @@ namespace GPUStepping {
 	// Should be called from the emu thread.
 	// Begins stepping and increments the stepping counter while inside a lock.
 	bool EnterStepping();
-	bool SingleStep();
 	bool IsStepping();
+	void ResumeFromStepping();
+
 	int GetSteppingCounter();
+
+	// Called from the emu thread.
+	bool ProcessStepping();
 
 	bool GPU_GetOutputFramebuffer(const GPUDebugBuffer *&buffer);
 	bool GPU_GetCurrentFramebuffer(const GPUDebugBuffer *&buffer, GPUDebugFramebufferType type);
@@ -40,9 +44,6 @@ namespace GPUStepping {
 	bool GPU_GetCurrentClut(const GPUDebugBuffer *&buffer);
 	bool GPU_SetCmdValue(u32 op);
 	bool GPU_FlushDrawing();
-
-	void ResumeFromStepping();
-	void ForceUnpause();
 
 	GPUgstate LastState();
 };

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -891,9 +891,9 @@ DLResult GPUCommon::ProcessDLQueue() {
 }
 
 bool GPUCommon::ShouldSplitOverGe() const {
-	// TODO: Should check for debugger active, etc.
-	// We only need to do this if we want to step through Ge display lists using the Ge debuggers.
-	return false;
+	// Check for debugger active, etc.
+	// We only need to do this if we want to be able to step through Ge display lists using the Ge debuggers.
+	return GPUDebug::IsActive() || g_Config.bShowImDebugger;
 }
 
 void GPUCommon::Execute_OffsetAddr(u32 op, u32 diff) {

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -1637,7 +1637,7 @@ GPUDebugOp GPUCommon::DisassembleOp(u32 pc, u32 op) {
 	return info;
 }
 
-std::vector<GPUDebugOp> GPUCommon::DissassembleOpRange(u32 startpc, u32 endpc) {
+std::vector<GPUDebugOp> GPUCommon::DisassembleOpRange(u32 startpc, u32 endpc) {
 	char buffer[1024];
 	std::vector<GPUDebugOp> result;
 	GPUDebugOp info;
@@ -1995,12 +1995,32 @@ bool GPUCommon::DescribeCodePtr(const u8 *ptr, std::string &name) {
 }
 
 void GPUCommon::DrawImGuiDebugger() {
+	// Proof of concept
+	if (ImGui::Button("Run")) {
+		Core_Resume();
+	}
+	ImGui::SameLine();
+	if (ImGui::Button("Next Tex")) {
+		GPUDebug::SetBreakNext(GPUDebug::BreakNext::TEX);
+	}
+	ImGui::SameLine();
+	if (ImGui::Button("Next Prim")) {
+		GPUDebug::SetBreakNext(GPUDebug::BreakNext::PRIM);
+	}
+	ImGui::SameLine();
+	if (ImGui::Button("Single step")) {
+		GPUDebug::SetBreakNext(GPUDebug::BreakNext::OP);
+	}
+
 	// First, let's list any active display lists.
 	ImGui::Text("Next list ID: %d", nextListID);
 	for (auto index : dlQueue) {
 		const auto &list = dls[index];
-		ImGui::Text("List %d", list.id);
-		ImGui::Text("pc: %08x (start: %08x)", list.pc, list.startpc);
-		ImGui::Text("bbox: %d", (int)list.bboxResult);
+		char title[64];
+		snprintf(title, sizeof(title), "List %d", list.id);
+		if (ImGui::CollapsingHeader(title, ImGuiTreeNodeFlags_DefaultOpen)) {
+			ImGui::Text("PC: %08x (start: %08x)", list.pc, list.startpc);
+			ImGui::Text("BBOX result: %d", (int)list.bboxResult);
+		}
 	}
 }

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -141,12 +141,6 @@ namespace Draw {
 class DrawContext;
 }
 
-enum class DLResult {
-	Done,
-	Error,
-	Pause,  // used for stepping, breakpoints
-};
-
 enum DrawType {
 	DRAW_UNKNOWN,
 	DRAW_PRIM,
@@ -355,7 +349,7 @@ public:
 	void ResetListState(int listID, DisplayListState state) override;
 
 	GPUDebugOp DisassembleOp(u32 pc, u32 op) override;
-	std::vector<GPUDebugOp> DissassembleOpRange(u32 startpc, u32 endpc) override;
+	std::vector<GPUDebugOp> DisassembleOpRange(u32 startpc, u32 endpc) override;
 
 	void NotifySteppingEnter() override;
 	void NotifySteppingExit() override;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -80,6 +80,7 @@ enum GPURunState {
 	GPUSTATE_STALL = 2,
 	GPUSTATE_INTERRUPT = 3,
 	GPUSTATE_ERROR = 4,
+	GPUSTATE_BREAK = 5,
 };
 
 enum GPUSyncType {
@@ -353,7 +354,7 @@ public:
 	void ResetListStall(int listID, u32 stall) override;
 	void ResetListState(int listID, DisplayListState state) override;
 
-	GPUDebugOp DissassembleOp(u32 pc, u32 op) override;
+	GPUDebugOp DisassembleOp(u32 pc, u32 op) override;
 	std::vector<GPUDebugOp> DissassembleOpRange(u32 startpc, u32 endpc) override;
 
 	void NotifySteppingEnter() override;
@@ -410,7 +411,7 @@ protected:
 	virtual void CheckDepthUsage(VirtualFramebuffer *vfb) {}
 	virtual void FastRunLoop(DisplayList &list) = 0;
 
-	void SlowRunLoop(DisplayList &list);
+	bool SlowRunLoop(DisplayList &list);  // Returns false on breakpoint.
 	void UpdatePC(u32 currentPC, u32 newPC);
 	void UpdateState(GPURunState state);
 	void FastLoadBoneMatrix(u32 target);

--- a/GPU/GPUDefinitions.h
+++ b/GPU/GPUDefinitions.h
@@ -53,3 +53,24 @@ enum GPUInvalidationType {
 	// Forced invalidation for when the texture hash may not catch changes.
 	GPU_INVALIDATE_FORCE,
 };
+
+enum class DLRunType {
+	Run,
+	RunDebug,
+	Step,
+};
+
+enum class DLStepType {
+	None,
+	Single,
+	Prim,
+	Draw,
+	Texture,
+	Rendertarget,
+};
+
+enum class DLResult {
+	Done,
+	Error,
+	Pause,  // used for stepping, breakpoints
+};

--- a/GPU/GPUDefinitions.h
+++ b/GPU/GPUDefinitions.h
@@ -59,21 +59,6 @@ enum GPUInvalidationType {
 	GPU_INVALIDATE_FORCE,
 };
 
-enum class DLRunType {
-	Run,
-	RunDebug,
-	Step,
-};
-
-enum class DLStepType {
-	None,
-	Single,
-	Prim,
-	Draw,
-	Texture,
-	Rendertarget,
-};
-
 enum class DLResult {
 	Done,
 	Error,

--- a/GPU/GPUDefinitions.h
+++ b/GPU/GPUDefinitions.h
@@ -17,6 +17,11 @@
 
 #pragma once
 
+// X11, sigh.
+#ifdef None
+#undef None
+#endif
+
 enum DisplayListStatus {
 	// The list has been completed
 	PSP_GE_LIST_COMPLETED = 0,

--- a/GPU/GPUDefinitions.h
+++ b/GPU/GPUDefinitions.h
@@ -72,5 +72,6 @@ enum class DLStepType {
 enum class DLResult {
 	Done,
 	Error,
-	Pause,  // used for stepping, breakpoints
+	Stall,
+	Break,  // used for stepping, breakpoints
 };

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1570,6 +1570,7 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 			flags |= ScreenRenderFlags::HANDLED_THROTTLING;
 			break;
 		case CORE_STEPPING_CPU:
+		case CORE_STEPPING_GE:
 		case CORE_RUNTIME_ERROR:
 		{
 			// If there's an exception, display information.

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -132,6 +132,7 @@ static const char *ThreadStatusToString(u32 status) {
 }
 
 void DrawThreadView(ImConfig &cfg) {
+	ImGui::SetNextWindowSize(ImVec2(420, 300), ImGuiCond_FirstUseEver);
 	if (!ImGui::Begin("Threads", &cfg.threadsOpen)) {
 		ImGui::End();
 		return;
@@ -213,6 +214,7 @@ static void RecurseFileSystem(IFileSystem *fs, std::string path) {
 }
 
 static void DrawFilesystemBrowser(ImConfig &cfg) {
+	ImGui::SetNextWindowSize(ImVec2(420, 500), ImGuiCond_FirstUseEver);
 	if (!ImGui::Begin("File System", &cfg.filesystemBrowserOpen)) {
 		ImGui::End();
 		return;
@@ -738,7 +740,6 @@ ImDebugger::~ImDebugger() {
 	cfg_.SaveConfig(ConfigPath());
 }
 
-
 void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebug) {
 	// Snapshot the coreState to avoid inconsistency.
 	const CoreState coreState = ::coreState;
@@ -753,15 +754,17 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 
 	if (ImGui::BeginMainMenuBar()) {
 		if (ImGui::BeginMenu("Debug")) {
-			if (coreState == CoreState::CORE_STEPPING_CPU) {
+			switch (coreState) {
+			case CoreState::CORE_STEPPING_CPU:
 				if (ImGui::MenuItem("Run")) {
 					Core_Resume();
 				}
-				// used to have the step commands here, but they belong in the disassembly window.
-			} else {
+				break;
+			case CoreState::CORE_RUNNING_CPU:
 				if (ImGui::MenuItem("Break")) {
 					Core_Break("Menu:Break");
 				}
+				break;
 			}
 			ImGui::Separator();
 			ImGui::MenuItem("Ignore bad memory accesses", nullptr, &g_Config.bIgnoreBadMemAccess);
@@ -821,7 +824,7 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Graphics")) {
-			ImGui::MenuItem("Ge Debugger", nullptr, &cfg_.geDebuggerOpen);
+			ImGui::MenuItem("GE Debugger", nullptr, &cfg_.geDebuggerOpen);
 			ImGui::MenuItem("Display Output", nullptr, &cfg_.displayOpen);
 			ImGui::MenuItem("Textures", nullptr, &cfg_.texturesOpen);
 			ImGui::MenuItem("Framebuffers", nullptr, &cfg_.framebuffersOpen);
@@ -858,7 +861,7 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 	}
 
 	if (cfg_.disasmOpen) {
-		disasm_.Draw(mipsDebug, &cfg_.disasmOpen, coreState);
+		disasm_.Draw(mipsDebug, cfg_, coreState);
 	}
 
 	if (cfg_.regsOpen) {
@@ -926,14 +929,14 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 	}
 }
 
-void ImDisasmWindow::Draw(MIPSDebugInterface *mipsDebug, bool *open, CoreState coreState) {
+void ImDisasmWindow::Draw(MIPSDebugInterface *mipsDebug, ImConfig &cfg, CoreState coreState) {
 	char title[256];
 	snprintf(title, sizeof(title), "%s - Disassembly", "Allegrex MIPS");
 
 	disasmView_.setDebugger(mipsDebug);
 
 	ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
-	if (!ImGui::Begin(title, open, ImGuiWindowFlags_NoNavInputs)) {
+	if (!ImGui::Begin(title, &cfg.disasmOpen, ImGuiWindowFlags_NoNavInputs)) {
 		ImGui::End();
 		return;
 	}
@@ -951,7 +954,12 @@ void ImDisasmWindow::Draw(MIPSDebugInterface *mipsDebug, bool *open, CoreState c
 	}
 
 	if (coreState == CORE_STEPPING_GE || coreState == CORE_RUNNING_GE) {
-		ImGui::Text("!!! Currently stepping the Ge. See that window (when implemented)");
+		ImGui::Text("!!! Currently stepping the GE");
+		ImGui::SameLine();
+		if (ImGui::SmallButton("Open Ge debugger")) {
+			cfg.geDebuggerOpen = true;
+			ImGui::SetWindowFocus("GE Debugger");
+		}
 	}
 
 	ImGui::BeginDisabled(coreState != CORE_STEPPING_CPU);

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -942,11 +942,11 @@ void ImDisasmWindow::Draw(MIPSDebugInterface *mipsDebug, bool *open, CoreState c
 		// Process stepping keyboard shortcuts.
 		if (ImGui::IsKeyPressed(ImGuiKey_F10)) {
 			u32 stepSize = disasmView_.getInstructionSizeAt(mipsDebug->GetPC());
-			Core_RequestSingleStep(CPUStepType::Over, stepSize);
+			Core_RequestCPUStep(CPUStepType::Over, stepSize);
 		}
 		if (ImGui::IsKeyPressed(ImGuiKey_F11)) {
 			u32 stepSize = disasmView_.getInstructionSizeAt(mipsDebug->GetPC());
-			Core_RequestSingleStep(CPUStepType::Into, stepSize);
+			Core_RequestCPUStep(CPUStepType::Into, stepSize);
 		}
 	}
 
@@ -972,18 +972,18 @@ void ImDisasmWindow::Draw(MIPSDebugInterface *mipsDebug, bool *open, CoreState c
 	ImGui::SameLine();
 	if (ImGui::SmallButton("Step Into")) {
 		u32 stepSize = disasmView_.getInstructionSizeAt(mipsDebug->GetPC());
-		Core_RequestSingleStep(CPUStepType::Into, stepSize);
+		Core_RequestCPUStep(CPUStepType::Into, stepSize);
 	}
 
 	ImGui::SameLine();
 	if (ImGui::SmallButton("Step Over")) {
 		u32 stepSize = disasmView_.getInstructionSizeAt(mipsDebug->GetPC());
-		Core_RequestSingleStep(CPUStepType::Over, stepSize);
+		Core_RequestCPUStep(CPUStepType::Over, stepSize);
 	}
 
 	ImGui::SameLine();
 	if (ImGui::SmallButton("Step Out")) {
-		Core_RequestSingleStep(CPUStepType::Out, 0);
+		Core_RequestCPUStep(CPUStepType::Out, 0);
 	}
 
 	ImGui::EndDisabled();

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -26,11 +26,12 @@
 
 class MIPSDebugInterface;
 class GPUDebugInterface;
+struct ImConfig;
 
 // Corresponds to the CDisasm dialog
 class ImDisasmWindow {
 public:
-	void Draw(MIPSDebugInterface *mipsDebug, bool *open, CoreState coreState);
+	void Draw(MIPSDebugInterface *mipsDebug, ImConfig &cfg, CoreState coreState);
 	ImDisasmView &View() {
 		return disasmView_;
 	}

--- a/UI/ImDebugger/ImDisasmView.cpp
+++ b/UI/ImDebugger/ImDisasmView.cpp
@@ -102,7 +102,6 @@ static std::string trimString(std::string input) {
 
 void ImDisasmView::assembleOpcode(u32 address, const std::string &defaultText) {
 	/*
-	auto memLock = Memory::Lock();
 	if (!Core_IsStepping()) {
 		MessageBox(wnd, L"Cannot change code while the core is running!", L"Error", MB_OK);
 		return;
@@ -315,7 +314,6 @@ void ImDisasmView::drawArguments(ImDrawList *drawList, Rect rc, const Disassembl
 }
 
 void ImDisasmView::Draw(ImDrawList *drawList) {
-	auto memLock = Memory::Lock();
 	if (!debugger->isAlive()) {
 		return;
 	}
@@ -922,7 +920,6 @@ void ImDisasmView::PopupMenu() {
 }
 
 void ImDisasmView::updateStatusBarText() {
-	auto memLock = Memory::Lock();
 	if (!PSP_IsInited())
 		return;
 
@@ -1047,8 +1044,6 @@ void ImDisasmView::SearchNext(bool forward) {
 		return;
 	}
 
-	auto memLock = Memory::Lock();
-
 	// Note: Search will replace matchAddress_ with the current address.
 	u32 searchAddress = manager.getNthNextAddress(matchAddress_, 1);
 
@@ -1110,7 +1105,6 @@ void ImDisasmView::SearchNext(bool forward) {
 }
 
 std::string ImDisasmView::disassembleRange(u32 start, u32 size) {
-	auto memLock = Memory::Lock();
 	std::string result;
 
 	// gather all branch targets without labels

--- a/UI/ImDebugger/ImGe.cpp
+++ b/UI/ImDebugger/ImGe.cpp
@@ -9,6 +9,7 @@
 #include "Core/HW/Display.h"
 
 void DrawFramebuffersWindow(ImConfig &cfg, FramebufferManagerCommon *framebufferManager) {
+	ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
 	if (!ImGui::Begin("Framebuffers", &cfg.framebuffersOpen)) {
 		ImGui::End();
 		return;
@@ -20,6 +21,7 @@ void DrawFramebuffersWindow(ImConfig &cfg, FramebufferManagerCommon *framebuffer
 }
 
 void DrawTexturesWindow(ImConfig &cfg, TextureCacheCommon *textureCache) {
+	ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
 	if (!ImGui::Begin("Textures", &cfg.texturesOpen)) {
 		ImGui::End();
 		return;
@@ -31,6 +33,7 @@ void DrawTexturesWindow(ImConfig &cfg, TextureCacheCommon *textureCache) {
 }
 
 void DrawDisplayWindow(ImConfig &cfg, FramebufferManagerCommon *framebufferManager) {
+	ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
 	if (!ImGui::Begin("Display", &cfg.displayOpen)) {
 		ImGui::End();
 		return;
@@ -59,6 +62,7 @@ void DrawDisplayWindow(ImConfig &cfg, FramebufferManagerCommon *framebufferManag
 
 // Note: This is not exclusively graphics.
 void DrawDebugStatsWindow(ImConfig &cfg) {
+	ImGui::SetNextWindowSize(ImVec2(300, 500), ImGuiCond_FirstUseEver);
 	if (!ImGui::Begin("Debug Stats", &cfg.debugStatsOpen)) {
 		ImGui::End();
 		return;
@@ -71,7 +75,8 @@ void DrawDebugStatsWindow(ImConfig &cfg) {
 
 // Stub
 void DrawGeDebuggerWindow(ImConfig &cfg) {
-	if (!ImGui::Begin("Debug Stats", &cfg.geDebuggerOpen)) {
+	ImGui::SetNextWindowSize(ImVec2(520, 600), ImGuiCond_FirstUseEver);
+	if (!ImGui::Begin("GE Debugger", &cfg.geDebuggerOpen)) {
 		ImGui::End();
 		return;
 	}

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -407,7 +407,6 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 
 						// If the current PC is on a breakpoint, the user doesn't want to do nothing.
 						breakpoints_->SetSkipFirst(currentMIPS->pc);
-
 						Core_Resume();
 					}
 				}

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -210,7 +210,7 @@ void CDisasm::step(CPUStepType stepType) {
 	lastTicks_ = CoreTiming::GetTicks();
 
 	u32 stepSize = ptr->getInstructionSizeAt(cpu->GetPC());
-	Core_RequestSingleStep(stepType, stepSize);
+	Core_RequestCPUStep(stepType, stepSize);
 }
 
 void CDisasm::runToLine() {

--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -180,7 +180,7 @@ void CtrlDisplayListView::onPaint(WPARAM wParam, LPARAM lParam)
 	
 	HICON breakPoint = (HICON)LoadIcon(GetModuleHandle(0),(LPCWSTR)IDI_STOP);
 
-	auto disasm = gpuDebug->DissassembleOpRange(windowStart, windowStart + (visibleRows + 2) * instructionSize);
+	auto disasm = gpuDebug->DisassembleOpRange(windowStart, windowStart + (visibleRows + 2) * instructionSize);
 
 	for (int i = 0; i < visibleRows+2; i++)
 	{

--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -341,7 +341,7 @@ void CtrlDisplayListView::onMouseUp(WPARAM wParam, LPARAM lParam, int button)
 				char *p = temp, *end = temp + space;
 				for (u32 pos = selectRangeStart; pos < selectRangeEnd && p < end; pos += instructionSize)
 				{
-					GPUDebugOp op = gpuDebug->DissassembleOp(pos);
+					GPUDebugOp op = gpuDebug->DisassembleOp(pos);
 					p += snprintf(p, end - p, "%s\r\n", op.desc.c_str());
 				}
 

--- a/Windows/GEDebugger/GEDebugger.cpp
+++ b/Windows/GEDebugger/GEDebugger.cpp
@@ -56,7 +56,6 @@
 #include "GPU/Debugger/Stepping.h"
 
 using namespace GPUBreakpoints;
-using namespace GPUDebug;
 using namespace GPUStepping;
 
 enum PrimaryDisplayType {
@@ -136,8 +135,8 @@ StepCountDlg::~StepCountDlg() {
 void StepCountDlg::Jump(int count, bool relative) {
 	if (relative && count == 0)
 		return;
-	SetBreakNext(BreakNext::COUNT);
-	SetBreakCount(count, relative);
+	GPUDebug::SetBreakNext(GPUDebug::BreakNext::COUNT);
+	GPUDebug::SetBreakCount(count, relative);
 };
 
 BOOL StepCountDlg::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
@@ -575,7 +574,7 @@ void CGEDebugger::UpdatePreviews() {
 	}
 
 	wchar_t primCounter[1024]{};
-	swprintf(primCounter, ARRAY_SIZE(primCounter), L"%d/%d", PrimsThisFrame(), PrimsLastFrame());
+	swprintf(primCounter, ARRAY_SIZE(primCounter), L"%d/%d", GPUDebug::PrimsThisFrame(), GPUDebug::PrimsLastFrame());
 	SetDlgItemText(m_hDlg, IDC_GEDBG_PRIMCOUNTER, primCounter);
 
 	for (GEDebuggerTab &tabState : tabStates_) {
@@ -698,7 +697,9 @@ void CGEDebugger::UpdatePrimaryPreview(const GPUgstate &state) {
 	}
 
 	if (bufferResult && primaryBuffer_ != nullptr) {
-		auto fmt = SimpleGLWindow::Format(primaryBuffer_->GetFormat());
+		const GPUDebugBufferFormat bufFmt = primaryBuffer_->GetFormat();
+		_dbg_assert_(bufFmt != GPUDebugBufferFormat::GPU_DBG_FORMAT_INVALID);
+		const SimpleGLWindow::Format fmt = (SimpleGLWindow::Format)bufFmt;
 		primaryWindow->SetFlags(flags);
 		primaryWindow->Draw(primaryBuffer_->GetData(), primaryBuffer_->GetStride(), primaryBuffer_->GetHeight(), primaryBuffer_->GetFlipped(), fmt);
 
@@ -735,7 +736,9 @@ void CGEDebugger::UpdateSecondPreview(const GPUgstate &state) {
 	}
 
 	if (bufferResult) {
-		auto fmt = SimpleGLWindow::Format(secondBuffer_->GetFormat());
+		const GPUDebugBufferFormat bufFmt = secondBuffer_->GetFormat();
+		_dbg_assert_(bufFmt != GPUDebugBufferFormat::GPU_DBG_FORMAT_INVALID);
+		const SimpleGLWindow::Format fmt = (SimpleGLWindow::Format)bufFmt;
 		secondWindow->SetFlags(TexturePreviewFlags(state));
 		if (showClut_) {
 			// Reduce the stride so it's easier to see.
@@ -1127,31 +1130,31 @@ BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 	case WM_COMMAND:
 		switch (LOWORD(wParam)) {
 		case IDC_GEDBG_STEPDRAW:
-			SetBreakNext(BreakNext::DRAW);
+			GPUDebug::SetBreakNext(GPUDebug::BreakNext::DRAW);
 			break;
 
 		case IDC_GEDBG_STEP:
-			SetBreakNext(BreakNext::OP);
+			GPUDebug::SetBreakNext(GPUDebug::BreakNext::OP);
 			break;
 
 		case IDC_GEDBG_STEPTEX:
-			SetBreakNext(BreakNext::TEX);
+			GPUDebug::SetBreakNext(GPUDebug::BreakNext::TEX);
 			break;
 
 		case IDC_GEDBG_STEPFRAME:
-			SetBreakNext(BreakNext::FRAME);
+			GPUDebug::SetBreakNext(GPUDebug::BreakNext::FRAME);
 			break;
 
 		case IDC_GEDBG_STEPVSYNC:
-			SetBreakNext(BreakNext::VSYNC);
+			GPUDebug::SetBreakNext(GPUDebug::BreakNext::VSYNC);
 			break;
 
 		case IDC_GEDBG_STEPPRIM:
-			SetBreakNext(BreakNext::PRIM);
+			GPUDebug::SetBreakNext(GPUDebug::BreakNext::PRIM);
 			break;
 
 		case IDC_GEDBG_STEPCURVE:
-			SetBreakNext(BreakNext::CURVE);
+			GPUDebug::SetBreakNext(GPUDebug::BreakNext::CURVE);
 			break;
 
 		case IDC_GEDBG_STEPCOUNT:
@@ -1218,7 +1221,7 @@ BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 			SetDlgItemText(m_hDlg, IDC_GEDBG_TEXADDR, L"");
 			SetDlgItemText(m_hDlg, IDC_GEDBG_PRIMCOUNTER, L"");
 
-			SetBreakNext(BreakNext::NONE);
+			GPUDebug::SetBreakNext(GPUDebug::BreakNext::NONE);
 			break;
 
 		case IDC_GEDBG_RECORD:
@@ -1266,7 +1269,7 @@ BOOL CGEDebugger::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 		break;
 
 	case WM_GEDBG_STEPDISPLAYLIST:
-		SetBreakNext(BreakNext::OP);
+		GPUDebug::SetBreakNext(GPUDebug::BreakNext::OP);
 		break;
 
 	case WM_GEDBG_TOGGLEPCBREAKPOINT:

--- a/Windows/GEDebugger/SimpleGLWindow.cpp
+++ b/Windows/GEDebugger/SimpleGLWindow.cpp
@@ -253,7 +253,7 @@ void SimpleGLWindow::DrawChecker() {
 	glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, vao_ ? 0 : indices);
 }
 
-void SimpleGLWindow::Draw(const u8 *data, int w, int h, bool flipped, Format fmt) {
+void SimpleGLWindow::Draw(const u8 *data, int w, int h, bool flipped, const Format fmt) {
 	wglMakeCurrent(hDC_, hGLRC_);
 
 	GLint components = GL_RGBA;


### PR DESCRIPTION
Follows #19690 , implements #19688

This mainly does a lot of plumbing, but the end result is that now we can correctly step the GE debugger while still keeping the EmuThread running, which means that it's now possible to implement a GE debugger in ImGui. This will allow a bunch of new debugging capabilities down the road (plus we'll finally have a crossplatform one, next to the web one), and makes it relatively easy for me to implement new debugging capabilities as I need them.

A tiny start of such a debugger is here, as well, although not usable yet.