### PR TITLE
Minor log manager refactor

### DIFF
--- a/Common/Log.cpp
+++ b/Common/Log.cpp
@@ -81,7 +81,8 @@ bool HandleAssert(const char *function, const char *file, int line, const char *
 	if (!getenv("CI")) {
 		int msgBoxStyle = MB_ICONINFORMATION | MB_YESNO;
 		std::wstring wtext = ConvertUTF8ToWString(formatted) + L"\n\nTry to continue?";
-		std::wstring wcaption = ConvertUTF8ToWString(std::string(caption) + " " + GetCurrentThreadName());
+		const char *threadName = GetCurrentThreadName();
+		std::wstring wcaption = ConvertUTF8ToWString(std::string(caption) + " " + (threadName ? threadName : "(unknown thread)"));
 		OutputDebugString(wtext.c_str());
 		printf("%s\n", formatted);
 		if (IDYES != MessageBox(0, wtext.c_str(), wcaption.c_str(), msgBoxStyle)) {

--- a/Common/Log/LogManager.cpp
+++ b/Common/Log/LogManager.cpp
@@ -114,8 +114,6 @@ void LogManager::Init(bool *enabledSetting, bool headless) {
 	}
 	initialized_ = true;
 
-	g_bLogEnabledSetting = enabledSetting;
-
 	_dbg_assert_(ARRAY_SIZE(g_logTypeNames) == (size_t)Log::NUMBER_OF_LOGS);
 
 	for (size_t i = 0; i < ARRAY_SIZE(g_logTypeNames); i++) {
@@ -370,7 +368,8 @@ void FileLogListener::Log(const LogMessage &message) {
 
 void OutputDebugStringLogListener::Log(const LogMessage &message) {
 	char buffer[4096];
-	snprintf(buffer, sizeof(buffer), "%s %s %s", message.timestamp, message.header, message.msg.c_str());
+	// We omit the timestamp for easy copy-paste-diffing.
+	snprintf(buffer, sizeof(buffer), "%s %s", message.header, message.msg.c_str());
 #if _MSC_VER
 	OutputDebugStringUTF8(buffer);
 #endif

--- a/Common/Log/LogManager.cpp
+++ b/Common/Log/LogManager.cpp
@@ -40,7 +40,8 @@
 #include "Common/File/FileUtil.h"
 #include "Common/StringUtils.h"
 
-// Don't need to savestate this.
+LogManager g_logManager;
+
 const char *hleCurrentThreadName = nullptr;
 
 bool *g_bLogEnabledSetting = nullptr;
@@ -58,30 +59,13 @@ void GenericLog(LogLevel level, Log type, const char *file, int line, const char
 		return;
 	va_list args;
 	va_start(args, fmt);
-	LogManager *instance = LogManager::GetInstance();
-	if (instance) {
-		instance->LogLine(level, type, file, line, fmt, args);
-	} else {
-		// Fall back to printf or direct android logger with a small buffer if the log manager hasn't been initialized yet.
-#if PPSSPP_PLATFORM(ANDROID)
-		char temp[512];
-		vsnprintf(temp, sizeof(temp), fmt, args);
-		__android_log_print(ANDROID_LOG_INFO, "PPSSPP", "EARLY: %s", temp);
-#else
-		vprintf(fmt, args);
-		printf("\n");
-#endif
-	}
+	g_logManager.LogLine(level, type, file, line, fmt, args);
 	va_end(args);
 }
 
 bool GenericLogEnabled(LogLevel level, Log type) {
-	if (LogManager::GetInstance())
-		return (*g_bLogEnabledSetting) && LogManager::GetInstance()->IsEnabled(level, type);
-	return false;
+	return (*g_bLogEnabledSetting) && g_logManager.IsEnabled(level, type);
 }
-
-LogManager *LogManager::logManager_ = nullptr;
 
 // NOTE: Needs to be kept in sync with the Log enum.
 static const char * const g_logTypeNames[] = {
@@ -106,23 +90,30 @@ static const char * const g_logTypeNames[] = {
 	"PRINTF",
 	"TEXREPLACE",
 
-	"SCEAUDIO",
-	"SCECTRL",
-	"SCEDISP",
-	"SCEFONT",
-	"SCEGE",
-	"SCEINTC",
-	"SCEIO",
-	"SCEKERNEL",
-	"SCEMODULE",
-	"SCENET",
-	"SCERTC",
-	"SCESAS",
-	"SCEUTIL",
-	"SCEMISC",
+		"SCEAUDIO",
+		"SCECTRL",
+		"SCEDISP",
+		"SCEFONT",
+		"SCEGE",
+		"SCEINTC",
+		"SCEIO",
+		"SCEKERNEL",
+		"SCEMODULE",
+		"SCENET",
+		"SCERTC",
+		"SCESAS",
+		"SCEUTIL",
+		"SCEMISC",
 };
 
-LogManager::LogManager(bool *enabledSetting) {
+void LogManager::Init(bool *enabledSetting, bool headless) {
+	g_bLogEnabledSetting = enabledSetting;
+	if (initialized_) {
+		// Just update the pointer, already done above.
+		return;
+	}
+	initialized_ = true;
+
 	g_bLogEnabledSetting = enabledSetting;
 
 	_dbg_assert_(ARRAY_SIZE(g_logTypeNames) == (size_t)Log::NUMBER_OF_LOGS);
@@ -167,14 +158,18 @@ LogManager::LogManager(bool *enabledSetting) {
 	AddListener(stdioLog_);
 #endif
 #if defined(_MSC_VER) && (defined(USING_WIN_UI) || PPSSPP_PLATFORM(UWP))
-	if (IsDebuggerPresent() && debuggerLog_ && LOG_MSC_OUTPUTDEBUG)
+	if (IsDebuggerPresent() && debuggerLog_ && (LOG_MSC_OUTPUTDEBUG || headless))
 		AddListener(debuggerLog_);
 #endif
 	AddListener(ringLog_);
 #endif
 }
+void LogManager::Shutdown() {
+	if (!initialized_) {
+		// already done
+		return;
+	}
 
-LogManager::~LogManager() {
 	for (int i = 0; i < (int)Log::NUMBER_OF_LOGS; ++i) {
 #if !defined(MOBILE_DEVICE) || defined(_DEBUG)
 		RemoveListener(fileLog_);
@@ -200,6 +195,14 @@ LogManager::~LogManager() {
 	delete debuggerLog_;
 #endif
 	delete ringLog_;
+
+	initialized_ = false;
+}
+
+LogManager::LogManager() {}
+
+LogManager::~LogManager() {
+	Shutdown();
 }
 
 void LogManager::ChangeFileLog(const char *filename) {
@@ -234,6 +237,22 @@ void LogManager::LoadConfig(const Section *section, bool debugDefaults) {
 }
 
 void LogManager::LogLine(LogLevel level, Log type, const char *file, int line, const char *format, va_list args) {
+	char msgBuf[1024];
+	if (!initialized_) {
+		// Fall back to printf or direct android logger with a small buffer if the log manager hasn't been initialized yet.
+#if PPSSPP_PLATFORM(ANDROID)
+		vsnprintf(msgBuf, sizeof(msgBuf), format, args);
+		__android_log_print(ANDROID_LOG_INFO, "PPSSPP", "EARLY: %s", msgBuf);
+#elif _MSC_VER
+		vsnprintf(msgBuf, sizeof(msgBuf), format, args);
+		OutputDebugStringUTF8(msgBuf);
+#else
+		vprintf(format, args);
+		printf("\n");
+#endif
+		return;
+	}
+
 	const LogChannel &log = log_[(size_t)type];
 	if (level > log.level || !log.enabled)
 		return;
@@ -283,7 +302,6 @@ void LogManager::LogLine(LogLevel level, Log type, const char *file, int line, c
 
 	GetCurrentTimeFormatted(message.timestamp);
 
-	char msgBuf[1024];
 	va_list args_copy;
 
 	va_copy(args_copy, args);
@@ -311,17 +329,8 @@ bool LogManager::IsEnabled(LogLevel level, Log type) {
 	return true;
 }
 
-void LogManager::Init(bool *enabledSetting) {
-	_assert_(logManager_ == nullptr);
-	logManager_ = new LogManager(enabledSetting);
-}
-
-void LogManager::Shutdown() {
-	delete logManager_;
-	logManager_ = nullptr;
-}
-
 void LogManager::AddListener(LogListener *listener) {
+	_dbg_assert_(initialized_);
 	if (!listener)
 		return;
 	std::lock_guard<std::mutex> lk(listeners_lock_);
@@ -329,6 +338,7 @@ void LogManager::AddListener(LogListener *listener) {
 }
 
 void LogManager::RemoveListener(LogListener *listener) {
+	_dbg_assert_(initialized_);
 	if (!listener)
 		return;
 	std::lock_guard<std::mutex> lk(listeners_lock_);

--- a/Common/Log/LogManager.h
+++ b/Common/Log/LogManager.h
@@ -93,10 +93,6 @@ private:
 	bool enabled_ = false;
 };
 
-// TODO: A simple buffered log that can be used to display the log in-window
-// on Android etc.
-// class BufferedLogListener { ... }
-
 struct LogChannel {
 	char m_shortName[32]{};
 	LogLevel level;

--- a/Common/Log/LogManager.h
+++ b/Common/Log/LogManager.h
@@ -104,12 +104,11 @@ class StdioListener;
 
 class LogManager {
 private:
-	LogManager(bool *enabledSetting);
-	~LogManager();
-
 	// Prevent copies.
 	LogManager(const LogManager &) = delete;
 	void operator=(const LogManager &) = delete;
+
+	bool initialized_ = false;
 
 	LogChannel log_[(size_t)Log::NUMBER_OF_LOGS];
 	FileLogListener *fileLog_ = nullptr;
@@ -119,12 +118,14 @@ private:
 	StdioListener *stdioLog_ = nullptr;
 	OutputDebugStringLogListener *debuggerLog_ = nullptr;
 	RingbufferLogListener *ringLog_ = nullptr;
-	static LogManager *logManager_;  // Singleton. Ugh.
 
 	std::mutex listeners_lock_;
 	std::vector<LogListener*> listeners_;
 
 public:
+	LogManager();
+	~LogManager();
+
 	void AddListener(LogListener *listener);
 	void RemoveListener(LogListener *listener);
 
@@ -175,19 +176,13 @@ public:
 		return ringLog_;
 	}
 
-	static inline LogManager* GetInstance() {
-		return logManager_;
-	}
-
-	static void SetInstance(LogManager *logManager) {
-		logManager_ = logManager;
-	}
-
-	static void Init(bool *enabledSetting);
-	static void Shutdown();
+	void Init(bool *enabledSetting, bool headless = false);
+	void Shutdown();
 
 	void ChangeFileLog(const char *filename);
 
 	void SaveConfig(Section *section);
 	void LoadConfig(const Section *section, bool debugDefaults);
 };
+
+extern LogManager g_logManager;

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -1170,7 +1170,7 @@ void Config::Load(const char *iniFileName, const char *controllerIniFilename) {
 #ifdef _DEBUG
 	debugDefaults = true;
 #endif
-	LogManager::GetInstance()->LoadConfig(log, debugDefaults);
+	g_logManager.LoadConfig(log, debugDefaults);
 
 	Section *recent = iniFile.GetOrCreateSection("Recent");
 	recent->Get("MaxRecent", &iMaxRecent, 60);
@@ -1371,8 +1371,7 @@ bool Config::Save(const char *saveReason) {
 		control->Delete("DPadRadius");
 
 		Section *log = iniFile.GetOrCreateSection(logSectionName);
-		if (LogManager::GetInstance())
-			LogManager::GetInstance()->SaveConfig(log);
+		g_logManager.SaveConfig(log);
 
 		// Time tracking
 		Section *playTime = iniFile.GetOrCreateSection("PlayTime");

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -149,13 +149,6 @@ void Core_WaitInactive() {
 	}
 }
 
-void Core_WaitInactive(int milliseconds) {
-	if (Core_IsActive() && !GPUStepping::IsStepping()) {
-		std::unique_lock<std::mutex> guard(m_hInactiveMutex);
-		m_InactiveCond.wait_for(guard, std::chrono::milliseconds(milliseconds));
-	}
-}
-
 void Core_SetPowerSaving(bool mode) {
 	powerSaving = mode;
 }

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -96,7 +96,6 @@ bool Core_IsInactive();
 // Warning: these three are only used on Windows - debugger integration.
 void Core_StateProcessed();
 void Core_WaitInactive();
-void Core_WaitInactive(int milliseconds);
 
 void Core_SetPowerSaving(bool mode);
 bool Core_GetPowerSaving();

--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -626,7 +626,7 @@ void BreakpointManager::Update(u32 addr) {
 		bool resume = false;
 		if (Core_IsStepping() == false) {
 			Core_Break("cpu.breakpoint.update", addr);
-			Core_WaitInactive(200);
+			Core_WaitInactive();
 			resume = true;
 		}
 

--- a/Core/Debugger/WebSocket/LogBroadcaster.cpp
+++ b/Core/Debugger/WebSocket/LogBroadcaster.cpp
@@ -75,13 +75,11 @@ private:
 
 LogBroadcaster::LogBroadcaster() {
 	listener_ = new DebuggerLogListener();
-	if (LogManager::GetInstance())
-		LogManager::GetInstance()->AddListener(listener_);
+	g_logManager.AddListener(listener_);
 }
 
 LogBroadcaster::~LogBroadcaster() {
-	if (LogManager::GetInstance())
-		LogManager::GetInstance()->RemoveListener(listener_);
+	g_logManager.RemoveListener(listener_);
 	delete listener_;
 }
 

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -697,7 +697,8 @@ void *GetQuickSyscallFunc(MIPSOpcode op) {
 	const HLEFunction *info = GetSyscallFuncPointer(op);
 	if (!info || !info->func)
 		return nullptr;
-	DEBUG_LOG(Log::HLE, "Compiling syscall to %s", info->name);
+
+	VERBOSE_LOG(Log::HLE, "Compiling syscall to '%s'", info->name);
 
 	// TODO: Do this with a flag?
 	if (op == idleOp)

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -398,7 +398,7 @@ static u32 sceGeDrawSync(u32 mode) {
 }
 
 static int sceGeContinue() {
-	DEBUG_LOG(Log::sceGe, "sceGeContinue");
+	DEBUG_LOG(Log::sceGe, "sceGeContinue()");
 	int ret = gpu->Continue();
 	hleEatCycles(220);
 	hleReSchedule("ge continue");

--- a/Core/Util/BlockAllocator.cpp
+++ b/Core/Util/BlockAllocator.cpp
@@ -222,12 +222,12 @@ u32 BlockAllocator::AllocAt(u32 position, u32 size, const char *tag)
 
 void BlockAllocator::MergeFreeBlocks(Block *fromBlock)
 {
-	DEBUG_LOG(Log::sceKernel, "Merging Blocks");
+	VERBOSE_LOG(Log::sceKernel, "Merging Blocks");
 
 	Block *prev = fromBlock->prev;
 	while (prev != NULL && prev->taken == false)
 	{
-		DEBUG_LOG(Log::sceKernel, "Block Alloc found adjacent free blocks - merging");
+		VERBOSE_LOG(Log::sceKernel, "Block Alloc found adjacent free blocks - merging");
 		prev->size += fromBlock->size;
 		if (fromBlock->next == NULL)
 			top_ = prev;
@@ -247,7 +247,7 @@ void BlockAllocator::MergeFreeBlocks(Block *fromBlock)
 	Block *next = fromBlock->next;
 	while (next != NULL && next->taken == false)
 	{
-		DEBUG_LOG(Log::sceKernel, "Block Alloc found adjacent free blocks - merging");
+		VERBOSE_LOG(Log::sceKernel, "Block Alloc found adjacent free blocks - merging");
 		fromBlock->size += next->size;
 		fromBlock->next = next->next;
 		delete next;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -857,13 +857,13 @@ DLResult GPUCommon::ProcessDLQueue(DLRunType run, DLStepType step) {
 
 	for (int listIndex = GetNextListIndex(); listIndex != -1; listIndex = GetNextListIndex()) {
 		DisplayList &l = dls[listIndex];
-		DEBUG_LOG(Log::G3D, "Starting DL execution at %08x - stall = %08x", l.pc, l.stall);
+		DEBUG_LOG(Log::G3D, "Starting DL execution at %08x - stall = %08x (startingTicks=%d)", l.pc, l.stall, startingTicks);
 		if (!InterpretList(l)) {
 			return DLResult::Error;
 		}
 
-		// Some other list could've taken the spot while we dilly-dallied around.
-		// LATER: Hm, really? Not unless we start time-slicing...
+		// Some other list could've taken the spot while we dilly-dallied around, so we need the check.
+		// Yes, this does happen.
 		if (l.state != PSP_GE_DL_STATE_QUEUED) {
 			// At the end, we can remove it from the queue and continue.
 			dlQueue.erase(std::remove(dlQueue.begin(), dlQueue.end(), listIndex), dlQueue.end());

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -175,7 +175,7 @@ void DevMenuScreen::CreatePopupContents(UI::ViewGroup *parent) {
 	scroll->Add(items);
 	parent->Add(scroll);
 
-	RingbufferLogListener *ring = LogManager::GetInstance()->GetRingbufferListener();
+	RingbufferLogListener *ring = g_logManager.GetRingbufferListener();
 	if (ring) {
 		ring->SetEnabled(true);
 	}
@@ -236,7 +236,7 @@ void GPIGPOScreen::CreatePopupContents(UI::ViewGroup *parent) {
 
 void LogScreen::UpdateLog() {
 	using namespace UI;
-	RingbufferLogListener *ring = LogManager::GetInstance()->GetRingbufferListener();
+	RingbufferLogListener *ring = g_logManager.GetRingbufferListener();
 	if (!ring)
 		return;
 	vert_->Clear();
@@ -319,8 +319,6 @@ void LogConfigScreen::CreateViews() {
 
 	vert->Add(new ItemHeader(dev->T("Logging Channels")));
 
-	LogManager *logMan = LogManager::GetInstance();
-
 	int cellSize = 400;
 
 	UI::GridLayoutSettings gridsettings(cellSize, 64, 5);
@@ -329,7 +327,7 @@ void LogConfigScreen::CreateViews() {
 
 	for (int i = 0; i < LogManager::GetNumChannels(); i++) {
 		Log type = (Log)i;
-		LogChannel *chan = logMan->GetLogChannel(type);
+		LogChannel *chan = g_logManager.GetLogChannel(type);
 		LinearLayout *row = new LinearLayout(ORIENT_HORIZONTAL, new LinearLayoutParams(cellSize - 50, WRAP_CONTENT));
 		row->SetSpacing(0);
 		row->Add(new CheckBox(&chan->enabled, "", "", new LinearLayoutParams(50, WRAP_CONTENT)));
@@ -339,27 +337,24 @@ void LogConfigScreen::CreateViews() {
 }
 
 UI::EventReturn LogConfigScreen::OnToggleAll(UI::EventParams &e) {
-	LogManager *logMan = LogManager::GetInstance();
 	for (int i = 0; i < LogManager::GetNumChannels(); i++) {
-		LogChannel *chan = logMan->GetLogChannel((Log)i);
+		LogChannel *chan = g_logManager.GetLogChannel((Log)i);
 		chan->enabled = !chan->enabled;
 	}
 	return UI::EVENT_DONE;
 }
 
 UI::EventReturn LogConfigScreen::OnEnableAll(UI::EventParams &e) {
-	LogManager *logMan = LogManager::GetInstance();
 	for (int i = 0; i < LogManager::GetNumChannels(); i++) {
-		LogChannel *chan = logMan->GetLogChannel((Log)i);
+		LogChannel *chan = g_logManager.GetLogChannel((Log)i);
 		chan->enabled = true;
 	}
 	return UI::EVENT_DONE;
 }
 
 UI::EventReturn LogConfigScreen::OnDisableAll(UI::EventParams &e) {
-	LogManager *logMan = LogManager::GetInstance();
 	for (int i = 0; i < LogManager::GetNumChannels(); i++) {
-		LogChannel *chan = logMan->GetLogChannel((Log)i);
+		LogChannel *chan = g_logManager.GetLogChannel((Log)i);
 		chan->enabled = false;
 	}
 	return UI::EVENT_DONE;
@@ -396,11 +391,10 @@ void LogLevelScreen::OnCompleted(DialogResult result) {
 	if (result != DR_OK)
 		return;
 	int selected = listView_->GetSelected();
-	LogManager *logMan = LogManager::GetInstance();
 	
 	for (int i = 0; i < LogManager::GetNumChannels(); ++i) {
 		Log type = (Log)i;
-		LogChannel *chan = logMan->GetLogChannel(type);
+		LogChannel *chan = g_logManager.GetLogChannel(type);
 		if (chan->enabled)
 			chan->level = (LogLevel)(selected + 1);
 	}

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -518,9 +518,7 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 		DiskCachingFileLoaderCache::SetCacheDir(g_Config.appCacheDirectory);
 	}
 
-	if (!LogManager::GetInstance()) {
-		LogManager::Init(&g_Config.bEnableLogging);
-	}
+	g_logManager.Init(&g_Config.bEnableLogging);
 
 #if !PPSSPP_PLATFORM(WINDOWS)
 	g_Config.SetSearchPath(GetSysDirectory(DIRECTORY_SYSTEM));
@@ -529,8 +527,6 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	// fail and it will be set to the default. Later, we load again when we get permission.
 	g_Config.Load();
 #endif
-
-	LogManager *logman = LogManager::GetInstance();
 
 	const char *fileToLog = nullptr;
 	Path stateToLoad;
@@ -674,21 +670,21 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 	}
 
 	if (fileToLog)
-		LogManager::GetInstance()->ChangeFileLog(fileToLog);
+		g_logManager.ChangeFileLog(fileToLog);
 
 	if (forceLogLevel)
-		LogManager::GetInstance()->SetAllLogLevels(logLevel);
+		g_logManager.SetAllLogLevels(logLevel);
 
 	PostLoadConfig();
 
 #if PPSSPP_PLATFORM(ANDROID)
 	logger = new AndroidLogger();
-	logman->AddListener(logger);
+	g_logManager.AddListener(logger);
 #elif (defined(MOBILE_DEVICE) && !defined(_DEBUG))
 	// Enable basic logging for any kind of mobile device, since LogManager doesn't.
 	// The MOBILE_DEVICE/_DEBUG condition matches LogManager.cpp.
 	logger = new PrintfLogger();
-	logman->AddListener(logger);
+	g_logManager.AddListener(logger);
 #endif
 
 	if (System_GetPropertyBool(SYSPROP_SUPPORTS_PERMISSIONS)) {
@@ -1491,7 +1487,7 @@ void NativeShutdown() {
 
 	// Avoid shutting this down when restarting core.
 	if (!restarting)
-		LogManager::Shutdown();
+		g_logManager.Shutdown();
 
 	if (logger) {
 		delete logger;

--- a/UWP/App.cpp
+++ b/UWP/App.cpp
@@ -74,7 +74,7 @@ void App::InitialPPSSPP() {
 	// because the next place it was called was in the EmuThread, and it's too late by then.
 	CreateSysDirectories();
 
-	LogManager::Init(&g_Config.bEnableLogging);
+	g_logManager.Init(&g_Config.bEnableLogging);
 
 	// Set the config path to local state by default
 	// it will be overrided by `NativeInit` if there is custom memStick

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -72,10 +72,10 @@ PPSSPP_UWPMain::PPSSPP_UWPMain(App ^app, const std::shared_ptr<DX::DeviceResourc
 	ctx_.reset(new UWPGraphicsContext(deviceResources));
 
 #if _DEBUG
-		LogManager::GetInstance()->SetAllLogLevels(LogLevel::LDEBUG);
+		g_logManager.SetAllLogLevels(LogLevel::LDEBUG);
 
 		if (g_Config.bEnableLogging) {
-			LogManager::GetInstance()->ChangeFileLog(GetLogFile().c_str());
+			g_logManager.ChangeFileLog(GetLogFile().c_str());
 		}
 #endif
 

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -302,7 +302,7 @@ BOOL CDisasm::DlgProc(UINT message, WPARAM wParam, LPARAM lParam) {
 					if (isRunning)
 					{
 						Core_Break("cpu.breakpoint.add", 0);
-						Core_WaitInactive(200);
+						Core_WaitInactive();
 					}
 
 					BreakpointWindow bpw(m_hDlg,cpu);

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -353,7 +353,7 @@ void MainThreadFunc() {
 		// Process the shutdown.  Without this, non-GL delays 800ms on shutdown.
 		Core_Run(g_graphicsContext);
 	}
-	Core_WaitInactive(800);
+	Core_WaitInactive();
 
 	g_inLoop = false;
 

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -1180,11 +1180,11 @@ namespace MainWindow
 
 	void ToggleDebugConsoleVisibility() {
 		if (!g_Config.bEnableLogging) {
-			LogManager::GetInstance()->GetConsoleListener()->Show(false);
+			g_logManager.GetConsoleListener()->Show(false);
 			EnableMenuItem(menu, ID_DEBUG_LOG, MF_GRAYED);
 		}
 		else {
-			LogManager::GetInstance()->GetConsoleListener()->Show(true);
+			g_logManager.GetConsoleListener()->Show(true);
 			EnableMenuItem(menu, ID_DEBUG_LOG, MF_ENABLED);
 		}
 	}

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -862,7 +862,7 @@ namespace MainWindow {
 		break;
 
 		case ID_DEBUG_LOG:
-			LogManager::GetInstance()->GetConsoleListener()->Show(LogManager::GetInstance()->GetConsoleListener()->Hidden());
+			g_logManager.GetConsoleListener()->Show(g_logManager.GetConsoleListener()->Hidden());
 			break;
 
 		case ID_DEBUG_IGNOREILLEGALREADS:

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -132,7 +132,7 @@ void System_Vibrate(int length_ms) {
 }
 
 static void AddDebugRestartArgs() {
-	if (LogManager::GetInstance()->GetConsoleListener()->IsOpen())
+	if (g_logManager.GetConsoleListener()->IsOpen())
 		restartArgs += " -l";
 }
 
@@ -897,7 +897,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 				// (this is an external process.)
 				bool result = VulkanMayBeAvailable();
 
-				LogManager::Shutdown();
+				g_logManager.Shutdown();
 				WinMainCleanup();
 				return result ? EXIT_CODE_VULKAN_WORKS : EXIT_FAILURE;
 			}
@@ -954,7 +954,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 
 	// This will be overridden by the actual config. But we do want to log during startup.
 	g_Config.bEnableLogging = true;
-	LogManager::Init(&g_Config.bEnableLogging);
+	g_logManager.Init(&g_Config.bEnableLogging);
 
 	// On Win32 it makes more sense to initialize the system directories here
 	// because the next place it was called was in the EmuThread, and it's too late by then.
@@ -1038,10 +1038,10 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	//   - By default in Debug, the console should be shown by default.
 	//   - The -l switch is expected to show the log console, REGARDLESS of config settings.
 	//   - It should be possible to log to a file without showing the console.
-	LogManager::GetInstance()->GetConsoleListener()->Init(showLog, 150, 120);
+	g_logManager.GetConsoleListener()->Init(showLog, 150, 120);
 
 	if (debugLogLevel) {
-		LogManager::GetInstance()->SetAllLogLevels(LogLevel::LDEBUG);
+		g_logManager.SetAllLogLevels(LogLevel::LDEBUG);
 	}
 
 	ContextMenuInit(_hInstance);
@@ -1127,7 +1127,7 @@ int WINAPI WinMain(HINSTANCE _hInstance, HINSTANCE hPrevInstance, LPSTR szCmdLin
 	DialogManager::DestroyAll();
 	timeEndPeriod(1);
 
-	LogManager::Shutdown();
+	g_logManager.Shutdown();
 	WinMainCleanup();
 
 	return 0;

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -1210,13 +1210,12 @@ void retro_init(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_LOG_INTERFACE, &log))
    {
       log_cb = log.log;
-      LogManager::Init(&g_Config.bEnableLogging);
+      g_logManager.Init(&g_Config.bEnableLogging);
       printfLogger = new PrintfLogger(log);
-      LogManager* logman = LogManager::GetInstance();
-      logman->RemoveListener(logman->GetStdioListener());
-      logman->RemoveListener(logman->GetDebuggerListener());
-      logman->ChangeFileLog(nullptr);
-      logman->AddListener(printfLogger);
+      g_logManager.RemoveListener(g_logManager.GetStdioListener());
+      g_logManager.RemoveListener(g_logManager.GetDebuggerListener());
+      g_logManager.ChangeFileLog(nullptr);
+      g_logManager.AddListener(printfLogger);
    }
 
    VsyncSwapIntervalReset();
@@ -1250,7 +1249,7 @@ void retro_init(void)
    g_Config.iInternalResolution = 0;
 
    // Log levels must be set after g_Config.Load
-   LogManager::GetInstance()->SetAllLogLevels(LogLevel::LINFO);
+   g_logManager.SetAllLogLevels(LogLevel::LINFO);
 
    const char* nickname = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_USERNAME, &nickname) && nickname)
@@ -1285,7 +1284,7 @@ void retro_init(void)
 void retro_deinit(void)
 {
    g_threadManager.Teardown();
-   LogManager::Shutdown();
+   g_logManager.Shutdown();
    log_cb = NULL;
 
    delete printfLogger;


### PR DESCRIPTION
Cleanup the log manager, add more control.

Remove the last classic "singleton" (with GetInstance() etc) from the codebase.

Now headless tests can log just to "OutputDebugString" which is convenient on Windows with MSVC.

Also removes a bad wait-with-timeout (we shouldn't use that kind of thing for things like that, unsafe).