### PR TITLE
More GE refactor

### DIFF
--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -340,11 +340,11 @@ u32 sceGeListEnQueue(u32 listAddress, u32 stallAddress, int callbackId, u32 optP
 	auto optParam = PSPPointer<PspGeListArgs>::Create(optParamAddr);
 
 	u32 listID = gpu->EnqueueList(listAddress, stallAddress, __GeSubIntrBase(callbackId), optParam, false);
-	if ((int)listID >= 0)
-		listID = LIST_ID_MAGIC ^ listID;
-
 	hleEatCycles(490);
 	CoreTiming::ForceCheck();
+
+	if ((int)listID >= 0)
+		listID = LIST_ID_MAGIC ^ listID;
 	return hleLogSuccessX(Log::sceGe, listID);
 }
 
@@ -355,11 +355,11 @@ u32 sceGeListEnQueueHead(u32 listAddress, u32 stallAddress, int callbackId, u32 
 	auto optParam = PSPPointer<PspGeListArgs>::Create(optParamAddr);
 
 	u32 listID = gpu->EnqueueList(listAddress, stallAddress, __GeSubIntrBase(callbackId), optParam, true);
-	if ((int)listID >= 0)
-		listID = LIST_ID_MAGIC ^ listID;
-
 	hleEatCycles(480);
 	CoreTiming::ForceCheck();
+
+	if ((int)listID >= 0)
+		listID = LIST_ID_MAGIC ^ listID;
 	return hleLogSuccessX(Log::sceGe, listID);
 }
 

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -335,8 +335,8 @@ static int __GeSubIntrBase(int callbackId) {
 
 u32 sceGeListEnQueue(u32 listAddress, u32 stallAddress, int callbackId, u32 optParamAddr) {
 	DEBUG_LOG(Log::sceGe,
-			"sceGeListEnQueue(addr=%08x, stall=%08x, cbid=%08x, param=%08x)",
-			listAddress, stallAddress, callbackId, optParamAddr);
+		"sceGeListEnQueue(addr=%08x, stall=%08x, cbid=%08x, param=%08x) ticks=%d",
+		listAddress, stallAddress, callbackId, optParamAddr, CoreTiming::GetTicks());
 	auto optParam = PSPPointer<PspGeListArgs>::Create(optParamAddr);
 
 	u32 listID = gpu->EnqueueList(listAddress, stallAddress, __GeSubIntrBase(callbackId), optParam, false);
@@ -350,8 +350,8 @@ u32 sceGeListEnQueue(u32 listAddress, u32 stallAddress, int callbackId, u32 optP
 
 u32 sceGeListEnQueueHead(u32 listAddress, u32 stallAddress, int callbackId, u32 optParamAddr) {
 	DEBUG_LOG(Log::sceGe,
-			"sceGeListEnQueueHead(addr=%08x, stall=%08x, cbid=%08x, param=%08x)",
-			listAddress, stallAddress, callbackId, optParamAddr);
+		"sceGeListEnQueueHead(addr=%08x, stall=%08x, cbid=%08x, param=%08x) ticks=%d",
+		listAddress, stallAddress, callbackId, optParamAddr, CoreTiming::GetTicks());
 	auto optParam = PSPPointer<PspGeListArgs>::Create(optParamAddr);
 
 	u32 listID = gpu->EnqueueList(listAddress, stallAddress, __GeSubIntrBase(callbackId), optParam, true);

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -642,7 +642,7 @@ void PSP_RunLoopUntil(u64 globalticks) {
 			_dbg_assert_(false);
 			break;
 		case CORE_RUNNING_GE:
-			gpu->ProcessDLQueue(DLRunType::Run, DLStepType::None);
+			gpu->ProcessDLQueue(true);
 			coreState = CORE_RUNNING_CPU;
 			break;
 		}

--- a/GPU/Debugger/Playback.cpp
+++ b/GPU/Debugger/Playback.cpp
@@ -334,7 +334,11 @@ void DumpExecute::SyncStall() {
 		return;
 	}
 
-	gpu->UpdateStall(execListID, execListPos);
+	bool runList;
+	gpu->UpdateStall(execListID, execListPos, &runList);
+	if (runList) {
+		gpu->RunGe();
+	}
 	s64 listTicks = gpu->GetListTicks(execListID);
 	if (listTicks != -1) {
 		s64 nowTicks = CoreTiming::GetTicks();
@@ -365,7 +369,11 @@ bool DumpExecute::SubmitCmds(const void *p, u32 sz) {
 
 		gpu->EnableInterrupts(false);
 		auto optParam = PSPPointer<PspGeListArgs>::Create(0);
-		execListID = gpu->EnqueueList(execListBuf, execListPos, -1, optParam, false);
+		bool runList;
+		execListID = gpu->EnqueueList(execListBuf, execListPos, -1, optParam, false, &runList);
+		if (runList) {
+			gpu->RunGe();
+		}
 		gpu->EnableInterrupts(true);
 	}
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -552,7 +552,7 @@ void GPUCommon::SwitchToGe() {
 	// Old method, although may make sense for performance if the ImDebugger isn't active.
 #if 1
 	// Call ProcessDLQueue directly.
-	ProcessDLQueue(DLRunType::Run, DLStepType::None);
+	ProcessDLQueue(false);
 #else
 	// New method, will allow ImDebugger to step the GPU.
 	// ARGH, what makes this different appears to be what happens AFTER the call to
@@ -844,10 +844,7 @@ int GPUCommon::GetNextListIndex() {
 
 // This is now called when coreState == CORE_RUNNING_GE.
 // TODO: It should return the next action.. (break into debugger or continue running)
-DLResult GPUCommon::ProcessDLQueue(DLRunType run, DLStepType step) {
-	_dbg_assert_(run == DLRunType::Run);
-	_dbg_assert_(step == DLStepType::None);
-
+DLResult GPUCommon::ProcessDLQueue(bool fromCore) {
 	startingTicks = CoreTiming::GetTicks();
 	cyclesExecuted = 0;
 
@@ -883,6 +880,12 @@ DLResult GPUCommon::ProcessDLQueue(DLRunType run, DLStepType step) {
 
 	__GeTriggerSync(GPU_SYNC_DRAW, 1, drawCompleteTicks);
 	// Since the event is in CoreTiming, we're in sync.  Just set 0 now.
+
+	if (fromCore) {
+		// Now update the core timing like we would have previously...
+		// TODO
+	}
+
 	return DLResult::Done;
 }
 

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -467,9 +467,9 @@ u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<Ps
 		drawCompleteTicks = (u64)-1;
 
 		// TODO save context when starting the list if param is set
+		// LATER: Wait, what? Please explain.
 		SwitchToGe();
 	}
-
 	return id;
 }
 
@@ -555,6 +555,8 @@ void GPUCommon::SwitchToGe() {
 	ProcessDLQueue(DLRunType::Run, DLStepType::None);
 #else
 	// New method, will allow ImDebugger to step the GPU.
+	// ARGH, what makes this different appears to be what happens AFTER the call to
+	// EnqueueList inside sceGeListEnqueue. Like the cycle eating and CoreTiming forcecheck.
 	Core_SwitchToGe();
 #endif
 }

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -245,8 +245,8 @@ public:
 
 	DLResult ProcessDLQueue(bool fromCore);
 
-	u32 UpdateStall(int listid, u32 newstall);
-	u32 EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<PspGeListArgs> args, bool head);
+	u32 UpdateStall(int listid, u32 newstall, bool *runList);
+	u32 EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<PspGeListArgs> args, bool head, bool *runList);
 	u32 DequeueList(int listid);
 	virtual int ListSync(int listid, int mode);
 	virtual u32 DrawSync(int mode);
@@ -255,7 +255,7 @@ public:
 	virtual void ResetMatrices();
 	virtual void DoState(PointerWrap &p);
 	bool BusyDrawing();
-	u32 Continue();
+	u32 Continue(bool *runList);
 	u32 Break(int mode);
 
 	virtual bool FramebufferDirty() = 0;
@@ -266,7 +266,7 @@ public:
 	virtual void DeviceLost() = 0;
 	virtual void DeviceRestore(Draw::DrawContext *draw) = 0;
 
-	void SwitchToGe();
+	void RunGe();
 
 	void DrawImGuiDebugger();
 

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -140,21 +140,6 @@ namespace Draw {
 class DrawContext;
 }
 
-enum class DLRunType {
-	Run,
-	RunDebug,
-	Step,
-};
-
-enum class DLStepType {
-	None,
-	Single,
-	Prim,
-	Draw,
-	Texture,
-	Rendertarget,
-};
-
 enum class DLResult {
 	Done,
 	Error,
@@ -257,7 +242,9 @@ public:
 	virtual void PreExecuteOp(u32 op, u32 diff) {}
 
 	bool InterpretList(DisplayList &list);
-	DLResult ProcessDLQueue(DLRunType run, DLStepType step);
+
+	DLResult ProcessDLQueue(bool fromCore);
+
 	u32 UpdateStall(int listid, u32 newstall);
 	u32 EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<PspGeListArgs> args, bool head);
 	u32 DequeueList(int listid);


### PR DESCRIPTION
This makes it clearer why #19693 fails - stuff happens after running the DL, before returning.

So in the next followup, we have to defer some things until after we're back from the Ge coreState.

This will all be worth it though.. we'll even be able to save/load state in the middle of Ge debugging, if all goes well.

I'm just a bit worried about the Ge intr handler... we might have to do something pretty tricky in CoreTiming :/   Or maybe we'll just sacrifice the ability to debug DLs in those particular rare cases...