### PR TITLE
Add code path to defer actions after runGe

### DIFF
--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -643,6 +643,7 @@ void PSP_RunLoopUntil(u64 globalticks) {
 			break;
 		case CORE_RUNNING_GE:
 			gpu->ProcessDLQueue(true);
+			gpu->RunDeferredAction();
 			coreState = CORE_RUNNING_CPU;
 			break;
 		}

--- a/GPU/Debugger/Playback.cpp
+++ b/GPU/Debugger/Playback.cpp
@@ -432,7 +432,6 @@ bool DumpExecute::SubmitCmds(const void *p, u32 sz) {
 	}
 
 	execListQueue.clear();
-
 	return true;
 }
 

--- a/GPU/Debugger/Playback.cpp
+++ b/GPU/Debugger/Playback.cpp
@@ -337,7 +337,8 @@ void DumpExecute::SyncStall() {
 	bool runList;
 	gpu->UpdateStall(execListID, execListPos, &runList);
 	if (runList) {
-		gpu->RunGe();
+		DeferredAction action{};
+		gpu->RunGe(action, true);  // force to run directly
 	}
 	s64 listTicks = gpu->GetListTicks(execListID);
 	if (listTicks != -1) {
@@ -372,7 +373,8 @@ bool DumpExecute::SubmitCmds(const void *p, u32 sz) {
 		bool runList;
 		execListID = gpu->EnqueueList(execListBuf, execListPos, -1, optParam, false, &runList);
 		if (runList) {
-			gpu->RunGe();
+			DeferredAction action{};
+			gpu->RunGe(action, true);  // force to run directly
 		}
 		gpu->EnableInterrupts(true);
 	}

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -555,7 +555,7 @@ u32 GPUCommon::Continue(bool *runList) {
 void GPUCommon::RunGe(DeferredAction action, bool forceRunDirect) {
 	deferredAction_ = action;
 	// Old method, although may make sense for performance if the ImDebugger isn't active.
-#if 1
+#if 0
 	// Call ProcessDLQueue directly.
 	ProcessDLQueue(false);
 	RunDeferredAction();

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -552,16 +552,21 @@ u32 GPUCommon::Continue(bool *runList) {
 	return 0;
 }
 
-void GPUCommon::RunGe() {
+void GPUCommon::RunGe(bool forceRunDirect) {
 	// Old method, although may make sense for performance if the ImDebugger isn't active.
 #if 1
 	// Call ProcessDLQueue directly.
 	ProcessDLQueue(false);
 #else
-	// New method, will allow ImDebugger to step the GPU.
-	// ARGH, what makes this different appears to be what happens AFTER the call to
-	// EnqueueList inside sceGeListEnqueue. Like the cycle eating and CoreTiming forcecheck.
-	Core_SwitchToGe();
+	// No sense in switching core mode if there's nothing to do, just maybe some bookkeeping.
+	if (dlQueue.empty() || forceRunDirect) {
+		ProcessDLQueue(false);
+	} else {
+		// New method, will allow ImDebugger to step the GPU.
+		// ARGH, what makes this different appears to be what happens AFTER the call to
+		// EnqueueList inside sceGeListEnqueue. Like the cycle eating and CoreTiming forcecheck.
+		Core_SwitchToGe();
+	}
 #endif
 }
 

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -266,7 +266,7 @@ public:
 	virtual void DeviceLost() = 0;
 	virtual void DeviceRestore(Draw::DrawContext *draw) = 0;
 
-	void RunGe();
+	void RunGe(bool forceRunDirect = false);
 
 	void DrawImGuiDebugger();
 

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -203,6 +203,12 @@ inline bool IsTrianglePrim(GEPrimitiveType prim) {
 	return prim > GE_PRIM_LINE_STRIP && prim != GE_PRIM_RECTANGLES;
 }
 
+struct DeferredAction {
+	int eatCycles;
+	bool forceCheck;
+	bool reschedule;
+};
+
 class GPUCommon : public GPUDebugInterface {
 public:
 	GPUCommon(GraphicsContext *gfxCtx, Draw::DrawContext *draw);
@@ -266,7 +272,8 @@ public:
 	virtual void DeviceLost() = 0;
 	virtual void DeviceRestore(Draw::DrawContext *draw) = 0;
 
-	void RunGe(bool forceRunDirect = false);
+	void RunGe(DeferredAction action, bool forceRunDirect = false);
+	void RunDeferredAction();
 
 	void DrawImGuiDebugger();
 
@@ -506,6 +513,8 @@ protected:
 
 	std::string reportingPrimaryInfo_;
 	std::string reportingFullInfo_;
+
+	DeferredAction deferredAction_;
 
 private:
 	void DoExecuteCall(u32 target);

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -1168,8 +1168,9 @@ void SoftGPU::Execute_TgenMtxData(u32 op, u32 diff) {
 	}
 
 	// Doesn't wrap to any other matrix.
-	if ((num & 0xF) < 12) {
-		matrixVisible.tgen[num & 0xF] = op & 0x00FFFFFF;
+	int wrappedNum = num & 0xF;
+	if (wrappedNum < 12) {
+		matrixVisible.tgen[wrappedNum] = op & 0x00FFFFFF;
 	}
 
 	num++;

--- a/headless/HeadlessHost.h
+++ b/headless/HeadlessHost.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "Common/Log.h"
 #include "Common/CommonTypes.h"
 #include "Common/File/Path.h"
 
@@ -31,6 +32,7 @@ public:
 	virtual void SendDebugOutput(const std::string &output) {
 		if (!writeDebugOutput_)
 			return;
+		OutputDebugStringUTF8(output.c_str());
 		if (output.find('\n') != output.npos) {
 			FlushDebugOutput();
 			fwrite(output.data(), sizeof(char), output.length(), stdout);


### PR DESCRIPTION
More work for preparing for Ge execution as a coreState.

This doesn't solve all issues. Especially, running Ge dumps needs a major rework in order to work correctly and be debuggable :(