### PR TITLE
Add "Split syscall" mechanism

### DIFF
--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -129,6 +129,15 @@ u64 hleDelayResult(u64 result, const char *reason, int usec);
 void hleEatCycles(int cycles);
 void hleEatMicro(int usec);
 
+void hleCoreTimingForceCheck();
+
+// Causes the syscall to not fully execute immediately, instead give the Ge a chance to
+// execute display lists.
+void hleSplitSyscallOverGe();
+
+// Called after a split syscall from System.cpp
+void hleFinishSyscallAfterGe();
+
 inline int hleDelayResult(int result, const char *reason, int usec) {
 	return hleDelayResult((u32) result, reason, usec);
 }

--- a/Core/MIPS/MIPS.cpp
+++ b/Core/MIPS/MIPS.cpp
@@ -336,6 +336,7 @@ int MIPSState::RunLoopUntil(u64 globalTicks) {
 	case CPUCore::IR_INTERPRETER:
 		while (inDelaySlot) {
 			// We must get out of the delay slot before going into jit.
+			// This normally should never take more than one step...
 			SingleStep();
 		}
 		insideJit = true;

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -642,8 +642,14 @@ void PSP_RunLoopUntil(u64 globalticks) {
 			_dbg_assert_(false);
 			break;
 		case CORE_RUNNING_GE:
-			gpu->ProcessDLQueue(true);
-			coreState = CORE_RUNNING_CPU;
+			switch (gpu->ProcessDLQueue()) {
+			case DLResult::Error:  // TODO: shouldn't return this normally
+			case DLResult::Pause:  // like updatestall.
+			case DLResult::Done:
+				hleFinishSyscallAfterGe();
+				coreState = CORE_RUNNING_CPU;
+				break;
+			}
 			break;
 		}
 	}

--- a/GPU/Debugger/Playback.cpp
+++ b/GPU/Debugger/Playback.cpp
@@ -337,7 +337,8 @@ void DumpExecute::SyncStall() {
 	bool runList;
 	gpu->UpdateStall(execListID, execListPos, &runList);
 	if (runList) {
-		gpu->RunGe();
+		DLResult result = gpu->ProcessDLQueue();
+		_dbg_assert_(result == DLResult::Done || result == DLResult::Pause);
 	}
 	s64 listTicks = gpu->GetListTicks(execListID);
 	if (listTicks != -1) {
@@ -372,7 +373,7 @@ bool DumpExecute::SubmitCmds(const void *p, u32 sz) {
 		bool runList;
 		execListID = gpu->EnqueueList(execListBuf, execListPos, -1, optParam, false, &runList);
 		if (runList) {
-			gpu->RunGe();
+			gpu->ProcessDLQueue();
 		}
 		gpu->EnableInterrupts(true);
 	}

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -243,7 +243,7 @@ public:
 
 	bool InterpretList(DisplayList &list);
 
-	DLResult ProcessDLQueue(bool fromCore);
+	DLResult ProcessDLQueue();
 
 	u32 UpdateStall(int listid, u32 newstall, bool *runList);
 	u32 EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<PspGeListArgs> args, bool head, bool *runList);
@@ -266,7 +266,9 @@ public:
 	virtual void DeviceLost() = 0;
 	virtual void DeviceRestore(Draw::DrawContext *draw) = 0;
 
-	void RunGe();
+	// Returns true if we should split the call across GE execution.
+	// For example, a debugger is active.
+	bool ShouldSplitOverGe() const;
 
 	void DrawImGuiDebugger();
 

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -255,7 +255,12 @@ bool RunAutoTest(HeadlessHost *headlessHost, CoreParameter &coreParameter, const
 		if (coreState == CORE_STEPPING_CPU && !coreParameter.startBreak) {
 			break;
 		}
-		if (time_now_d() > deadline) {
+		bool debugger = false;
+#ifdef _WIN32
+		if (IsDebuggerPresent())
+			debugger = true;
+#endif
+		if (time_now_d() > deadline && !debugger) {
 			// Don't compare, print the output at least up to this point, and bail.
 			if (!opt.bench) {
 				printf("%s", output.c_str());


### PR DESCRIPTION
This adds a mechanism to delay finishing up a syscall and instead switch coreState to GE execution mode, and when done switch back and finish it up.

This replaces much of #19696 , and #19693 will be reworked on top of this.

Unfortunately, this doesn't solve two cases, when the GE is triggered from interrupt handlers. In this case we still process the displaylists synchronously (which itself isn't quite right, but does pass the tests).