### PR TITLE
Core improvements: Run-from-breakpoint fix, add two new step types

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -80,6 +80,7 @@ static std::set<CoreStopRequestFunc> stopFuncs;
 
 // This can be read and written from ANYWHERE.
 volatile CoreState coreState = CORE_STEPPING_CPU;
+CoreState preGeCoreState = CORE_BOOT_ERROR;
 // If true, core state has been changed, but JIT has probably not noticed yet.
 volatile bool coreStatePending = false;
 
@@ -184,23 +185,30 @@ void Core_RunLoopUntil(u64 globalticks) {
 			case DLResult::Error:
 				// We should elegantly report the error, or I guess ignore it.
 				hleFinishSyscallAfterGe();
-				coreState = CORE_RUNNING_CPU;
+				coreState = preGeCoreState;
 				break;
 			case DLResult::Stall:
 			case DLResult::Done:
 				// Done executing for now
 				hleFinishSyscallAfterGe();
-				coreState = CORE_RUNNING_CPU;
+				coreState = preGeCoreState;
 				break;
 			default:
 				_dbg_assert_(false);
 				hleFinishSyscallAfterGe();
-				coreState = CORE_RUNNING_CPU;
+				coreState = preGeCoreState;
 				break;
 			}
 			break;
 		}
 	}
+}
+
+// Should only be called from GPUCommon functions (called from sceGe functions).
+void Core_SwitchToGe() {
+	// TODO: This should be an atomic exchange. Or we add bitflags into coreState.
+	preGeCoreState = coreState;
+	coreState = CORE_RUNNING_GE;
 }
 
 bool Core_RequestCPUStep(CPUStepType type, int stepSize) {
@@ -291,8 +299,6 @@ static void Core_PerformCPUStep(MIPSDebugInterface *cpu, CPUStepType stepType, i
 
 		u32 breakpointAddress = frames[1].pc;
 
-		// If the current PC is on a breakpoint, the user doesn't want to do nothing.
-		g_breakpoints.SetSkipFirst(currentMIPS->pc);
 		g_breakpoints.AddBreakPoint(breakpointAddress, true);
 		Core_Resume();
 		break;
@@ -301,15 +307,6 @@ static void Core_PerformCPUStep(MIPSDebugInterface *cpu, CPUStepType stepType, i
 		// Not yet implemented
 		break;
 	}
-}
-
-static void Core_PerformGeStep(CPUStepType stepType) {
-	// TODO
-}
-
-// Should only be called from GPUCommon functions (called from sceGe functions).
-void Core_SwitchToGe() {
-	coreState = CORE_RUNNING_GE;
 }
 
 static void Core_ProcessStepping(MIPSDebugInterface *cpu) {
@@ -399,6 +396,8 @@ void Core_Break(const char *reason, u32 relatedAddress) {
 
 // Free-threaded (or at least should be)
 void Core_Resume() {
+	// If the current PC is on a breakpoint, the user doesn't want to do nothing.
+	g_breakpoints.SetSkipFirst(currentMIPS->pc);
 	// Handle resuming from GE.
 	if (coreState == CORE_STEPPING_GE) {
 		coreState = CORE_RUNNING_GE;

--- a/Core/Core.h
+++ b/Core/Core.h
@@ -42,6 +42,7 @@ enum class CPUStepType {
 	Into,
 	Over,
 	Out,
+	Frame,
 };
 
 // Async, called from gui

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -77,6 +77,9 @@ static int idleOp;
 // Split syscall support. NOTE: This needs to be saved in DoState somehow!
 static int splitSyscallEatCycles = 0;
 
+// Stats
+static double hleSteppingTime = 0.0;
+static double hleFlipTime = 0.0;
 
 struct HLEMipsCallInfo {
 	u32 func;
@@ -752,12 +755,10 @@ void *GetQuickSyscallFunc(MIPSOpcode op) {
 	return (void *)&CallSyscallWithoutFlags;
 }
 
-static double hleSteppingTime = 0.0;
 void hleSetSteppingTime(double t) {
 	hleSteppingTime += t;
 }
 
-static double hleFlipTime = 0.0;
 void hleSetFlipTime(double t) {
 	hleFlipTime = t;
 }

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -160,6 +160,50 @@ static const char *ThreadStatusToString(u32 status) {
 	return "(unk)";
 }
 
+void WaitIDToString(WaitType waitType, SceUID waitID, char *buffer, size_t bufSize) {
+	switch (waitType) {
+	case WAITTYPE_AUDIOCHANNEL:
+		snprintf(buffer, bufSize, "chan %d", (int)waitID);
+		return;
+	case WAITTYPE_IO:
+		// TODO: More detail
+		snprintf(buffer, bufSize, "fd: %d", (int)waitID);
+		return;
+	case WAITTYPE_ASYNCIO:
+		snprintf(buffer, bufSize, "id: %d", (int)waitID);
+		return;
+	case WAITTYPE_THREADEND:
+	case WAITTYPE_MUTEX:
+	case WAITTYPE_LWMUTEX:
+	case WAITTYPE_MODULE:
+	case WAITTYPE_MSGPIPE:
+	case WAITTYPE_FPL:
+	case WAITTYPE_VPL:
+	case WAITTYPE_MBX:
+	case WAITTYPE_EVENTFLAG:
+	case WAITTYPE_SEMA:
+		// Get the name of the thread
+		if (kernelObjects.IsValid(waitID)) {
+			auto obj = kernelObjects.GetFast<KernelObject>(waitID);
+			if (obj && obj->GetName()) {
+				truncate_cpy(buffer, bufSize, obj->GetName());
+				return;
+			}
+		}
+		break;
+	case WAITTYPE_DELAY:
+	case WAITTYPE_SLEEP:
+	case WAITTYPE_HLEDELAY:
+	case WAITTYPE_UMD:
+		truncate_cpy(buffer, bufSize, "-");
+		return;
+	default:
+		truncate_cpy(buffer, bufSize, "(unimpl)");
+		return;
+	}
+
+}
+
 void DrawThreadView(ImConfig &cfg) {
 	ImGui::SetNextWindowSize(ImVec2(420, 300), ImGuiCond_FirstUseEver);
 	if (!ImGui::Begin("Threads", &cfg.threadsOpen)) {
@@ -168,7 +212,8 @@ void DrawThreadView(ImConfig &cfg) {
 	}
 
 	std::vector<DebugThreadInfo> info = GetThreadsInfo();
-	if (ImGui::BeginTable("threads", 7, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersH)) {
+	if (ImGui::BeginTable("threads", 8, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersH)) {
+		ImGui::TableSetupColumn("Id", ImGuiTableColumnFlags_WidthFixed);
 		ImGui::TableSetupColumn("Name", ImGuiTableColumnFlags_WidthFixed);
 		ImGui::TableSetupColumn("PC", ImGuiTableColumnFlags_WidthFixed);
 		ImGui::TableSetupColumn("Entry", ImGuiTableColumnFlags_WidthFixed);
@@ -182,6 +227,8 @@ void DrawThreadView(ImConfig &cfg) {
 		for (int i = 0; i < (int)info.size(); i++) {
 			const DebugThreadInfo &thread = info[i];
 			ImGui::TableNextRow();
+			ImGui::TableNextColumn();
+			ImGui::Text("%d", thread.id);
 			ImGui::TableNextColumn();
 			ImGui::PushID(i);
 			if (ImGui::Selectable(thread.name, cfg.selectedThread == i, ImGuiSelectableFlags_AllowDoubleClick | ImGuiSelectableFlags_SpanAllColumns)) {
@@ -200,16 +247,11 @@ void DrawThreadView(ImConfig &cfg) {
 			ImGui::TableNextColumn();
 			ImGui::TextUnformatted(ThreadStatusToString(thread.status));
 			ImGui::TableNextColumn();
-			if (thread.waitType != WAITTYPE_NONE) {
-				ImGui::TextUnformatted(getWaitTypeName(thread.waitType));
-			} else {
-				ImGui::TextUnformatted("N/A");
-			}
+			ImGui::TextUnformatted(getWaitTypeName(thread.waitType));
 			ImGui::TableNextColumn();
-			switch (thread.waitType) {
-			default:
-				ImGui::TextUnformatted("N/A");
-			}
+			char temp[64];
+			WaitIDToString(thread.waitType, thread.waitID, temp, sizeof(temp));
+			ImGui::TextUnformatted(temp);
 			if (ImGui::BeginPopup("threadPopup")) {
 				DebugThreadInfo &thread = info[i];
 				ImGui::Text("Thread: %s", thread.name);
@@ -218,16 +260,19 @@ void DrawThreadView(ImConfig &cfg) {
 					snprintf(temp, sizeof(temp), "%08x", thread.entrypoint);
 					System_CopyStringToClipboard(temp);
 				}
-				if (ImGui::MenuItem("Copy PC to clipboard")) {
+				if (ImGui::MenuItem("Copy thread PC to clipboard")) {
 					char temp[64];
 					snprintf(temp, sizeof(temp), "%08x", thread.curPC);
 					System_CopyStringToClipboard(temp);
 				}
 				if (ImGui::MenuItem("Kill thread")) {
+					// Dangerous!
 					sceKernelTerminateThread(thread.id);
 				}
-				if (ImGui::MenuItem("Force run")) {
-					__KernelResumeThreadFromWait(thread.id, 0);
+				if (thread.status == THREADSTATUS_WAIT) {
+					if (ImGui::MenuItem("Force run now")) {
+						__KernelResumeThreadFromWait(thread.id, 0);
+					}
 				}
 				ImGui::EndPopup();
 			}

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -1030,20 +1030,41 @@ void ImDisasmWindow::Draw(MIPSDebugInterface *mipsDebug, ImConfig &cfg, CoreStat
 	ImGui::BeginDisabled(coreState != CORE_STEPPING_CPU);
 
 	ImGui::SameLine();
-	if (ImGui::SmallButton("Step Into")) {
+	ImGui::Text("Step: ");
+	ImGui::SameLine();
+
+	if (ImGui::SmallButton("Into")) {
 		u32 stepSize = disasmView_.getInstructionSizeAt(mipsDebug->GetPC());
 		Core_RequestCPUStep(CPUStepType::Into, stepSize);
 	}
-
-	ImGui::SameLine();
-	if (ImGui::SmallButton("Step Over")) {
-		u32 stepSize = disasmView_.getInstructionSizeAt(mipsDebug->GetPC());
-		Core_RequestCPUStep(CPUStepType::Over, stepSize);
+	if (ImGui::IsItemHovered()) {
+		ImGui::SetTooltip("F11");
 	}
 
 	ImGui::SameLine();
-	if (ImGui::SmallButton("Step Out")) {
+	if (ImGui::SmallButton("Over")) {
+		u32 stepSize = disasmView_.getInstructionSizeAt(mipsDebug->GetPC());
+		Core_RequestCPUStep(CPUStepType::Over, stepSize);
+	}
+	if (ImGui::IsItemHovered()) {
+		ImGui::SetTooltip("F10");
+	}
+
+	ImGui::SameLine();
+	if (ImGui::SmallButton("Out")) {
 		Core_RequestCPUStep(CPUStepType::Out, 0);
+	}
+
+	ImGui::SameLine();
+	if (ImGui::SmallButton("Frame")) {
+		Core_RequestCPUStep(CPUStepType::Frame, 0);
+	}
+
+	ImGui::SameLine();
+	ImGui::SmallButton("Skim");
+	if (ImGui::IsItemActive()) {
+		u32 stepSize = disasmView_.getInstructionSizeAt(mipsDebug->GetPC());
+		Core_RequestCPUStep(CPUStepType::Into, stepSize);
 	}
 
 	ImGui::EndDisabled();


### PR DESCRIPTION
The CPU debugger can now quickly step to the next frame, and also now has a "skim" button that you can hold down to single-step once per frame.