### PR TITLE
GE dump playback refactor and fix

### DIFF
--- a/Core/HLE/HLETables.cpp
+++ b/Core/HLE/HLETables.cpp
@@ -97,7 +97,7 @@ const HLEFunction FakeSysCalls[] = {
 	{NID_EXTENDRETURN, __KernelReturnFromExtendStack, "__KernelReturnFromExtendStack", 'x', ""},
 	{NID_MODULERETURN, __KernelReturnFromModuleFunc, "__KernelReturnFromModuleFunc", 'x', ""},
 	{NID_IDLE, __KernelIdle, "_sceKernelIdle", 'x', ""},
-	{NID_GPUREPLAY, __KernelGPUReplay, "__KernelGPUReplay", 'x', ""},
+	{NID_GPUREPLAY, &WrapI_V<__KernelGPUReplay>, "__KernelGPUReplay", 'x', ""},
 	{NID_HLECALLRETURN, HLEReturnFromMipsCall, "HLEReturnFromMipsCall", 'x', ""},
 };
 

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1995,11 +1995,8 @@ bool __KernelLoadGEDump(const std::string &base_filename, std::string *error_str
 		// Make sure we don't get out of sync.
 		MIPS_MAKE_LUI(MIPS_REG_A0, 0),
 		MIPS_MAKE_SYSCALL("sceGe_user", "sceGeDrawSync"),
-		// Set the return address after the entry which saved the filename.
-		MIPS_MAKE_LUI(MIPS_REG_RA, mipsr4k.pc >> 16),
-		MIPS_MAKE_ADDIU(MIPS_REG_RA, MIPS_REG_RA, 8),
 		// Wait for the next vblank to render again.
-		MIPS_MAKE_JR_RA(),
+		MIPS_MAKE_J(mipsr4k.pc + 8),
 		MIPS_MAKE_SYSCALL("sceDisplay", "sceDisplayWaitVblankStart"),
 		// This never gets reached, just here to be safe.
 		MIPS_MAKE_BREAK(0),

--- a/Core/HLE/sceKernelModule.h
+++ b/Core/HLE/sceKernelModule.h
@@ -43,7 +43,7 @@ u32 __KernelGetModuleGP(SceUID module);
 bool KernelModuleIsKernelMode(SceUID module);
 bool __KernelLoadGEDump(const std::string &base_filename, std::string *error_string);
 bool __KernelLoadExec(const char *filename, u32 paramPtr, std::string *error_string);
-void __KernelGPUReplay();
+int __KernelGPUReplay();
 void __KernelReturnFromModuleFunc();
 SceUID KernelLoadModule(const std::string &filename, std::string *error_string);
 int KernelStartModule(SceUID moduleId, u32 argsize, u32 argAddr, u32 returnValueAddr, SceKernelSMOption *smoption, bool *needsWait);

--- a/Core/MIPS/MIPSCodeUtils.h
+++ b/Core/MIPS/MIPSCodeUtils.h
@@ -29,6 +29,7 @@
 #define MIPS_MAKE_JAL(addr) (0x0C000000 | ((addr)>>2))
 #define MIPS_MAKE_JR_RA()   (0x03e00008)
 #define MIPS_MAKE_NOP()     (0)
+#define MIPS_MAKE_BNEZ(pc, addr, rs) (0x14000000 | (rs << 21) | (((int)(addr - (pc + 4)) >> 2) & 0xFFFF))
 
 #define MIPS_MAKE_ADDIU(dreg, sreg, immval) ((9 << 26) | ((dreg) << 16) | ((sreg) << 21) | (immval))
 #define MIPS_MAKE_LUI(reg, immval) (0x3c000000 | ((reg) << 16) | (immval))

--- a/Core/MIPS/MIPSCodeUtils.h
+++ b/Core/MIPS/MIPSCodeUtils.h
@@ -29,7 +29,7 @@
 #define MIPS_MAKE_JAL(addr) (0x0C000000 | ((addr)>>2))
 #define MIPS_MAKE_JR_RA()   (0x03e00008)
 #define MIPS_MAKE_NOP()     (0)
-#define MIPS_MAKE_BNEZ(pc, addr, rs) (0x14000000 | (rs << 21) | (((int)(addr - (pc + 4)) >> 2) & 0xFFFF))
+#define MIPS_MAKE_BNEZ(pc, addr, rs) (0x14000000 | (rs << 21) | (u32)(((int)(addr - (pc + 4)) >> 2) & 0xFFFF))
 
 #define MIPS_MAKE_ADDIU(dreg, sreg, immval) ((9 << 26) | ((dreg) << 16) | ((sreg) << 21) | (immval))
 #define MIPS_MAKE_LUI(reg, immval) (0x3c000000 | ((reg) << 16) | (immval))

--- a/Core/PSPLoaders.cpp
+++ b/Core/PSPLoaders.cpp
@@ -45,12 +45,12 @@
 
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSAnalyst.h"
-#include "Core/MIPS/MIPSCodeUtils.h"
 
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
 #include "Core/System.h"
 #include "Core/PSPLoaders.h"
+#include "GPU/Debugger/Playback.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/sceKernel.h"
 #include "Core/HLE/sceKernelThread.h"

--- a/GPU/Common/ReplacedTexture.cpp
+++ b/GPU/Common/ReplacedTexture.cpp
@@ -170,6 +170,8 @@ bool ReplacedTexture::Poll(double budget) {
 	case ReplacementState::UNLOADED:
 		// We're gonna need to spawn a task.
 		break;
+	default:
+		break;
 	}
 
 	lastUsed_ = now;

--- a/GPU/Debugger/Playback.cpp
+++ b/GPU/Debugger/Playback.cpp
@@ -911,6 +911,8 @@ ReplayResult RunMountedReplay(const std::string &filename) {
 	case OpType::UpdateStallAddr:
 	{
 		bool runList;
+		hleEatCycles(190);
+		hleCoreTimingForceCheck();
 		gpu->UpdateStall(g_opToExec.listID, g_opToExec.param, &runList);
 		if (runList) {
 			hleSplitSyscallOverGe();
@@ -929,6 +931,8 @@ ReplayResult RunMountedReplay(const std::string &filename) {
 			hleSplitSyscallOverGe();
 		}
 		// We're not done yet, request another go.
+		hleEatCycles(490);
+		hleCoreTimingForceCheck();
 		return ReplayResult::Break;
 	}
 	case OpType::ReapplyGfxState:
@@ -942,6 +946,7 @@ ReplayResult RunMountedReplay(const std::string &filename) {
 		u32 execListID = g_opToExec.listID;
 		u32 mode = g_opToExec.param;
 		// try again but no need to split the sys call
+		hleEatCycles(220);
 		gpu->ListSync(execListID, mode);
 		return ReplayResult::Break;
 	}

--- a/GPU/Debugger/Playback.h
+++ b/GPU/Debugger/Playback.h
@@ -21,6 +21,12 @@
 
 namespace GPURecord {
 
-bool RunMountedReplay(const std::string &filename);
+enum class ReplayResult {
+	Done = 0,
+	Error = 1,
+	Break = 2,
+};
+
+ReplayResult RunMountedReplay(const std::string &filename);
 
 };

--- a/GPU/Debugger/Playback.h
+++ b/GPU/Debugger/Playback.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cstdlib>
 #include <string>
 
 namespace GPURecord {
@@ -27,6 +28,7 @@ enum class ReplayResult {
 	Break = 2,
 };
 
+void WriteRunDumpCode(u32 addr);
 ReplayResult RunMountedReplay(const std::string &filename);
 
-};
+}  // namespace GPURecord

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1554,7 +1554,7 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 		// Hopefully, after running, coreState is now CORE_NEXTFRAME
 		switch (coreState) {
 		case CORE_NEXTFRAME:
-			// Reached the end of the frame, all good. Set back to running for the next frame
+			// Reached the end of the frame while running at full blast, all good. Set back to running for the next frame
 			coreState = CORE_RUNNING_CPU;
 			flags |= ScreenRenderFlags::HANDLED_THROTTLING;
 			break;

--- a/UI/ImDebugger/ImGe.cpp
+++ b/UI/ImDebugger/ImGe.cpp
@@ -400,7 +400,7 @@ void DrawGeStateWindow(ImConfig &cfg, GPUDebugInterface *gpuDebug) {
 						static VertexDecoder decoder;
 						decoder.SetVertexType(state.vertType, options);
 
-						static const char *colNames[] = {
+						static const char * const colNames[] = {
 							"Index",
 							"X",
 							"Y",


### PR DESCRIPTION
Our GE dump playback was broken for stepping in the GE (GPU) debugger, which is a major use case for it.

Now it should work again, had to rework it after the recent refactoring of how GE stepping works.