### PR TITLE
Work around metal buffer bug on MacOS + AMD GPU

### DIFF
--- a/Common/GPU/Vulkan/VulkanLoader.cpp
+++ b/Common/GPU/Vulkan/VulkanLoader.cpp
@@ -343,10 +343,6 @@ static VulkanLibraryHandle VulkanLoadLibrary(std::string *errorString) {
 	return nullptr;
 #elif PPSSPP_PLATFORM(UWP)
 	return nullptr;
-#elif PPSSPP_PLATFORM(MAC) && PPSSPP_ARCH(AMD64)
-	// Disable Vulkan on Mac/x86. Too many configurations that don't work with MoltenVK
-	// for whatever reason.
-	return nullptr;
 #elif PPSSPP_PLATFORM(WINDOWS)
 	return LoadLibrary(L"vulkan-1.dll");
 #else

--- a/Common/GPU/Vulkan/VulkanMemory.cpp
+++ b/Common/GPU/Vulkan/VulkanMemory.cpp
@@ -41,8 +41,8 @@ VulkanPushPool::VulkanPushPool(VulkanContext *vulkan, const char *name, size_t o
 
 	#if PPSSPP_PLATFORM(MAC) && PPSSPP_ARCH(AMD64)
 	if (vulkan_->GetPhysicalDeviceProperties().properties.vendorID == VULKAN_VENDOR_AMD) {
-		INFO_LOG(Log::G3D, "MoltenVK with AMD, allocating buffers with VMA_MEMORY_USAGE_GPU_TO_CPU");
-		allocation_usage_ = VMA_MEMORY_USAGE_GPU_TO_CPU;
+		INFO_LOG(Log::G3D, "MoltenVK with AMD, allocating buffers with VMA_MEMORY_USAGE_CPU_ONLY");
+		allocation_usage_ = VMA_MEMORY_USAGE_CPU_ONLY; // VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT + VK_MEMORY_PROPERTY_HOST_COHERENT_BIT in vma type index
 	} else {
 		allocation_usage_ = VMA_MEMORY_USAGE_CPU_TO_GPU;
 	}

--- a/Common/GPU/Vulkan/VulkanMemory.h
+++ b/Common/GPU/Vulkan/VulkanMemory.h
@@ -94,6 +94,6 @@ private:
 	int curBlockIndex_ = -1;
 	const char *name_;
 	#if PPSSPP_PLATFORM(MAC) && PPSSPP_ARCH(AMD64)
-	VmaMemoryUsage allocation_usage_;
+	VkMemoryPropertyFlags allocation_extra_flags_;
 	#endif
 };

--- a/Common/GPU/Vulkan/VulkanMemory.h
+++ b/Common/GPU/Vulkan/VulkanMemory.h
@@ -93,4 +93,7 @@ private:
 	VkBufferUsageFlags usage_;
 	int curBlockIndex_ = -1;
 	const char *name_;
+	#if PPSSPP_PLATFORM(MAC) && PPSSPP_ARCH(AMD64)
+	VmaMemoryUsage allocation_usage_;
+	#endif
 };


### PR DESCRIPTION
~With VMA_MEMORY_USAGE_CPU_TO_GPU buffers, metal buffer appears 0 filled in metal trace during vkCmdCopyBufferToImage triggered MTLBlitCommandEncoder instance method.~

~Allocate VMA_MEMORY_USAGE_GPU_TO_CPU instead on MacOS + AMD GPU~

Update: adding VK_MEMORY_PROPERTY_HOST_COHERENT_BIT to allocation on MacOS dGPU, ref https://github.com/KhronosGroup/MoltenVK/issues/960

This PR reenables vulkan on intel Macs, probably make sense to gather everyone from these issues to test it before considering merging:

https://github.com/hrydgard/ppsspp/issues/15473
https://github.com/hrydgard/ppsspp/issues/16990
https://github.com/hrydgard/ppsspp/issues/18139
https://github.com/hrydgard/ppsspp/issues/19594
...