### PR TITLE
Add special texture hashing mode solving the Tag Force problem

### DIFF
--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -301,6 +301,7 @@ bool TextureReplacer::LoadIniValues(IniFile &ini, VFSBackend *dir, bool isOverri
 	// Multiplies sizeInRAM/bytesPerLine in XXHASH by 0.5.
 	options->Get("reduceHash", &reduceHash_, reduceHash_);
 	options->Get("ignoreMipmap", &ignoreMipmap_, ignoreMipmap_);
+	options->Get("skipLastDXT1Blocks128x64", &skipLastDXT1Blocks128x64_, skipLastDXT1Blocks128x64_);
 	if (reduceHash_ && hash_ == ReplacedTextureHash::QUICK) {
 		reduceHash_ = false;
 		ERROR_LOG(Log::TexReplacement, "Texture Replacement: reduceHash option requires safer hash, use xxh32 or xxh64 instead.");
@@ -516,12 +517,18 @@ u32 TextureReplacer::ComputeHash(u32 addr, int bufw, int w, int h, bool swizzled
 	if (bufw <= w) {
 		// We can assume the data is contiguous.  These are the total used pixels.
 		const u32 totalPixels = bufw * h + (w - bufw);
-		const u32 sizeInRAM = (textureBitsPerPixel[fmt] * totalPixels) / 8 * reduceHashSize;
+		u32 sizeInRAM = (textureBitsPerPixel[fmt] * totalPixels) / 8 * reduceHashSize;
 
 		// Sanity check: Ignore textures that are at the end of RAM.
 		if (Memory::MaxSizeAtAddress(addr) < sizeInRAM) {
 			ERROR_LOG(Log::G3D, "Can't hash a %d bytes textures at %08x - end point is outside memory", sizeInRAM, addr);
 			return 0;
+		}
+
+		// Hack for Yu Gi Oh texture hashing problem. See issue #19714
+		if (skipLastDXT1Blocks128x64_ && fmt == GE_TFMT_DXT1 && w == 128 && h == 64) {
+			// Skip the last few blocks as specified.
+			sizeInRAM -= 8 * skipLastDXT1Blocks128x64_;
 		}
 
 		switch (hash_) {

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -506,10 +506,13 @@ u32 TextureReplacer::ComputeHash(u32 addr, int bufw, int w, int h, bool swizzled
 	}
 
 	const u8 *checkp = Memory::GetPointerUnchecked(addr);
+
+	float reduceHashSize = 1.0f;
 	if (reduceHash_) {
 		reduceHashSize = LookupReduceHashRange(w, h);
 		// default to reduceHashGlobalValue which default is 0.5
 	}
+
 	if (bufw <= w) {
 		// We can assume the data is contiguous.  These are the total used pixels.
 		const u32 totalPixels = bufw * h + (w - bufw);

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -149,6 +149,7 @@ protected:
 	bool ignoreAddress_ = false;
 	bool reduceHash_ = false;
 	bool ignoreMipmap_ = false;
+	int skipLastDXT1Blocks128x64_ = 0;
 
 	float reduceHashGlobalValue = 0.5f; // Global value for textures dump pngs of all sizes, 0.5 by default but can be set in textures.ini
 

--- a/GPU/Common/TextureReplacer.h
+++ b/GPU/Common/TextureReplacer.h
@@ -150,7 +150,6 @@ protected:
 	bool reduceHash_ = false;
 	bool ignoreMipmap_ = false;
 
-	float reduceHashSize = 1.0f; // default value with reduceHash to false
 	float reduceHashGlobalValue = 0.5f; // Global value for textures dump pngs of all sizes, 0.5 by default but can be set in textures.ini
 
 	double lastTextureCacheSizeGB_ = 0.0;

--- a/GPU/Vulkan/TextureCacheVulkan.cpp
+++ b/GPU/Vulkan/TextureCacheVulkan.cpp
@@ -652,8 +652,6 @@ void TextureCacheVulkan::BuildTexture(TexCacheEntry *const entry) {
 			}
 			// Format might be wrong in lowMemoryMode_, so don't save.
 			if (plan.saveTexture && !lowMemoryMode_) {
-				INFO_LOG(Log::G3D, "Calling NotifyTextureDecoded %08x", entry->addr);
-
 				// When hardware texture scaling is enabled, this saves the original.
 				int w = dataScaled ? mipWidth : mipUnscaledWidth;
 				int h = dataScaled ? mipHeight : mipUnscaledHeight;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -2089,6 +2089,7 @@ UI::EventReturn DeveloperToolsScreen::OnLoggingChanged(UI::EventParams &e) {
 }
 
 UI::EventReturn DeveloperToolsScreen::OnRunCPUTests(UI::EventParams &e) {
+	// TODO: If game is loaded, don't do anything.
 #if !PPSSPP_PLATFORM(UWP)
 	RunTests();
 #endif


### PR DESCRIPTION
See #19714 

Under `[options]` in your textures.ini:

skipLastDXT1Blocks128x64 = 20

Then save and replace the new textures.

Don't want to build some complicated rule-based thing until we have more
use cases, so this is quite specialized.
