### PR TITLE
Stepping cleanup, DebugInterface cleanup

### DIFF
--- a/Core/Debugger/Breakpoints.cpp
+++ b/Core/Debugger/Breakpoints.cpp
@@ -647,12 +647,12 @@ void BreakpointManager::Update(u32 addr) {
 	System_Notify(SystemNotification::DISASSEMBLY);
 }
 
-bool BreakpointManager::ValidateLogFormat(DebugInterface *cpu, const std::string &fmt) {
+bool BreakpointManager::ValidateLogFormat(MIPSDebugInterface *cpu, const std::string &fmt) {
 	std::string ignore;
 	return EvaluateLogFormat(cpu, fmt, ignore);
 }
 
-bool BreakpointManager::EvaluateLogFormat(DebugInterface *cpu, const std::string &fmt, std::string &result) {
+bool BreakpointManager::EvaluateLogFormat(MIPSDebugInterface *cpu, const std::string &fmt, std::string &result) {
 	PostfixExpression exp;
 	result.clear();
 
@@ -697,7 +697,7 @@ bool BreakpointManager::EvaluateLogFormat(DebugInterface *cpu, const std::string
 				}
 			}
 
-			if (!cpu->initExpression(expression.c_str(), exp)) {
+			if (!initExpression(cpu, expression.c_str(), exp)) {
 				return false;
 			}
 
@@ -707,7 +707,7 @@ bool BreakpointManager::EvaluateLogFormat(DebugInterface *cpu, const std::string
 				float f;
 			} expResult;
 			char resultString[256];
-			if (!cpu->parseExpression(exp, expResult.u)) {
+			if (!parseExpression(cpu, exp, expResult.u)) {
 				return false;
 			}
 

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -21,7 +21,7 @@
 #include <atomic>
 #include <mutex>
 
-#include "Core/Debugger/DebugInterface.h"
+#include "Core/MIPS/MIPSDebugInterface.h"
 
 enum BreakAction : u32 {
 	BREAK_ACTION_IGNORE = 0x00,
@@ -45,7 +45,7 @@ struct BreakPointCond {
 
 	u32 Evaluate() {
 		u32 result;
-		if (debug->parseExpression(expression, result) == false)
+		if (parseExpression(debug, expression, result) == false)
 			return 0;
 		return result;
 	}
@@ -185,8 +185,8 @@ public:
 
 	void Update(u32 addr = 0);
 
-	bool ValidateLogFormat(DebugInterface *cpu, const std::string &fmt);
-	bool EvaluateLogFormat(DebugInterface *cpu, const std::string &fmt, std::string &result);
+	bool ValidateLogFormat(MIPSDebugInterface *cpu, const std::string &fmt);
+	bool EvaluateLogFormat(MIPSDebugInterface *cpu, const std::string &fmt, std::string &result);
 
 private:
 	size_t FindBreakpoint(u32 addr, bool matchTemp = false, bool temp = false);

--- a/Core/Debugger/DebugInterface.h
+++ b/Core/Debugger/DebugInterface.h
@@ -26,21 +26,19 @@ struct MemMap;
 
 class DebugInterface {
 public:
-	virtual u32 GetHi() = 0;
-	virtual u32 GetLo() = 0;
-	virtual u32 GetLLBit() = 0;
-	virtual u32 GetFPCond() = 0;
+	virtual u32 GetPC() const = 0;
+	virtual u32 GetRA() const = 0;
+	virtual u32 GetHi() const = 0;
+	virtual u32 GetLo() const = 0;
+	virtual u32 GetLLBit() const = 0;
+	virtual u32 GetFPCond() const = 0;
+	virtual u32 GetGPR32Value(int reg) const = 0;
 
+	virtual void SetPC(u32 _pc) = 0;
 	virtual void SetHi(u32 val) = 0;
 	virtual void SetLo(u32 val) = 0;
-	virtual u32 GetGPR32Value(int reg) = 0;
 
-	virtual u32 GetPC() = 0;
-	virtual void SetPC(u32 _pc) = 0;
-	virtual u32 GetRA() = 0;
-
-	// More stuff for debugger
-	virtual u32 GetRegValue(int cat, int index) = 0;
+	virtual u32 GetRegValue(int cat, int index) const = 0;
+	virtual void PrintRegValue(int cat, int index, char *out, size_t outSize) const = 0;
 	virtual void SetRegValue(int cat, int index, u32 value) {}
-	virtual void PrintRegValue(int cat, int index, char *out, size_t outSize) = 0;
 };

--- a/Core/Debugger/DebugInterface.h
+++ b/Core/Debugger/DebugInterface.h
@@ -26,49 +26,21 @@ struct MemMap;
 
 class DebugInterface {
 public:
-	virtual int getInstructionSize(int instruction) = 0;
-
-	virtual bool isAlive() = 0;
-	virtual bool isBreakpoint(unsigned int address) = 0;
-	virtual void setBreakpoint(unsigned int address) = 0;
-	virtual void clearBreakpoint(unsigned int address) = 0;
-	virtual void clearAllBreakpoints() = 0;
-	virtual void toggleBreakpoint(unsigned int address) = 0;
-	virtual unsigned int readMemory(unsigned int address) {return 0;}
-	virtual void step() {}
-	virtual void runToBreakpoint() {}
-	virtual int getColor(unsigned int address, bool darkMode) const {return darkMode ? 0xFF101010 : 0xFFFFFFFF;}
-	virtual std::string getDescription(unsigned int address) {return "";}
-	virtual bool initExpression(const char* exp, PostfixExpression& dest) { return false; };
-	virtual bool parseExpression(PostfixExpression& exp, u32& dest) { return false; };
-
 	virtual u32 GetHi() = 0;
 	virtual u32 GetLo() = 0;
 	virtual u32 GetLLBit() = 0;
 	virtual u32 GetFPCond() = 0;
 
-	virtual void SetHi(u32 val) { };
-	virtual void SetLo(u32 val) { };
-	virtual const char *GetName() = 0;
+	virtual void SetHi(u32 val) = 0;
+	virtual void SetLo(u32 val) = 0;
 	virtual u32 GetGPR32Value(int reg) = 0;
-	virtual void SetGPR32Value(int reg, u32 value) = 0;
-	virtual float GetFPR32Value(int reg) { return -1.0f; }
-	virtual float GetVPR32Value(int reg) { return -1.0f; }
 
 	virtual u32 GetPC() = 0;
 	virtual void SetPC(u32 _pc) = 0;
 	virtual u32 GetRA() = 0;
 
-	virtual void DisAsm(u32 pc, char *out, size_t outSize) = 0;
-
 	// More stuff for debugger
-	virtual int GetNumCategories() = 0;
-	virtual int GetNumRegsInCategory(int cat) = 0;
-	virtual const char *GetCategoryName(int cat) = 0;
-	virtual std::string GetRegName(int cat, int index) = 0;
-	virtual void PrintRegValue(int cat, int index, char *out, size_t outSize) {
-		snprintf(out, outSize, "%08X", GetGPR32Value(index));
-	}
 	virtual u32 GetRegValue(int cat, int index) = 0;
 	virtual void SetRegValue(int cat, int index, u32 value) {}
+	virtual void PrintRegValue(int cat, int index, char *out, size_t outSize) = 0;
 };

--- a/Core/Debugger/DisassemblyManager.h
+++ b/Core/Debugger/DisassemblyManager.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include <string>
+#include <string_view>
+
 #include "ppsspp_config.h"
 #include <mutex>
 #include "Common/CommonTypes.h"
@@ -120,7 +123,7 @@ public:
 	DisassemblyMacro(u32 _address): address(_address) { }
 
 	void setMacroLi(u32 _immediate, u8 _rt);
-	void setMacroMemory(const std::string &_name, u32 _immediate, u8 _rt, int _dataSize);
+	void setMacroMemory(std::string_view _name, u32 _immediate, u8 _rt, int _dataSize);
 
 	void recheck() override { };
 	int getNumLines() override { return 1; };
@@ -175,7 +178,7 @@ private:
 class DisassemblyComment: public DisassemblyEntry
 {
 public:
-	DisassemblyComment(u32 _address, u32 _size, std::string name, std::string param);
+	DisassemblyComment(u32 _address, u32 _size, std::string_view name, std::string_view param);
 
 	void recheck() override { };
 	int getNumLines() override { return 1; };
@@ -193,14 +196,13 @@ private:
 
 class DebugInterface;
 
-class DisassemblyManager
-{
+class DisassemblyManager {
 public:
 	~DisassemblyManager();
 
 	void clear();
 
-	static void setCpu(DebugInterface* _cpu) { cpu = _cpu; };
+	static void setCpu(DebugInterface *cpu) { cpu_ = cpu; };
 	void setMaxParamChars(int num) { maxParamChars = num; clear(); };
 	void getLine(u32 address, bool insertSymbols, DisassemblyLineInfo &dest, DebugInterface *cpuDebug = nullptr);
 	void analyze(u32 address, u32 size);
@@ -210,12 +212,12 @@ public:
 	u32 getNthPreviousAddress(u32 address, int n = 1);
 	u32 getNthNextAddress(u32 address, int n = 1);
 
-	static DebugInterface* getCpu() { return cpu; };
+	static DebugInterface *getCpu() { return cpu_; };
 	static int getMaxParamChars() { return maxParamChars; };
 private:
 	static std::map<u32,DisassemblyEntry*> entries;
 	static std::recursive_mutex entriesLock_;
-	static DebugInterface* cpu;
+	static DebugInterface *cpu_;
 	static int maxParamChars;
 };
 

--- a/Core/Debugger/WebSocket/BreakpointSubscriber.cpp
+++ b/Core/Debugger/WebSocket/BreakpointSubscriber.cpp
@@ -74,7 +74,7 @@ struct WebSocketCPUBreakpointParams {
 		if (hasCondition) {
 			if (!req.ParamString("condition", &condition))
 				return false;
-			if (!currentDebugMIPS->initExpression(condition.c_str(), compiledCondition)) {
+			if (!initExpression(currentDebugMIPS, condition.c_str(), compiledCondition)) {
 				req.Fail(StringFromFormat("Could not parse expression syntax: %s", getExpressionError()));
 				return false;
 			}
@@ -292,7 +292,7 @@ struct WebSocketMemoryBreakpointParams {
 		if (hasCondition) {
 			if (!req.ParamString("condition", &condition))
 				return false;
-			if (!currentDebugMIPS->initExpression(condition.c_str(), compiledCondition)) {
+			if (!initExpression(currentDebugMIPS, condition.c_str(), compiledCondition)) {
 				req.Fail(StringFromFormat("Could not parse expression syntax: %s", getExpressionError()));
 				return false;
 			}

--- a/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp
+++ b/Core/Debugger/WebSocket/CPUCoreSubscriber.cpp
@@ -134,16 +134,16 @@ void WebSocketCPUGetAllRegs(DebuggerRequest &req) {
 	JsonWriter &json = req.Respond();
 
 	json.pushArray("categories");
-	for (int c = 0; c < cpuDebug->GetNumCategories(); ++c) {
+	for (int c = 0; c < MIPSDebugInterface::GetNumCategories(); ++c) {
 		json.pushDict();
 		json.writeInt("id", c);
-		json.writeString("name", cpuDebug->GetCategoryName(c));
+		json.writeString("name", MIPSDebugInterface::GetCategoryName(c));
 
-		int total = cpuDebug->GetNumRegsInCategory(c);
+		int total = MIPSDebugInterface::GetNumRegsInCategory(c);
 
 		json.pushArray("registerNames");
 		for (int r = 0; r < total; ++r)
-			json.writeString(cpuDebug->GetRegName(c, r));
+			json.writeString(MIPSDebugInterface::GetRegName(c, r));
 		if (c == 0) {
 			json.writeString("pc");
 			json.writeString("hi");
@@ -402,10 +402,10 @@ void WebSocketCPUEvaluate(DebuggerRequest &req) {
 
 	u32 val;
 	PostfixExpression postfix;
-	if (!cpuDebug->initExpression(exp.c_str(), postfix)) {
+	if (!initExpression(cpuDebug, exp.c_str(), postfix)) {
 		return req.Fail(StringFromFormat("Could not parse expression syntax: %s", getExpressionError()));
 	}
-	if (!cpuDebug->parseExpression(postfix, val)) {
+	if (!parseExpression(cpuDebug, postfix, val)) {
 		return req.Fail(StringFromFormat("Could not evaluate expression: %s", getExpressionError()));
 	}
 

--- a/Core/Debugger/WebSocket/SteppingSubscriber.cpp
+++ b/Core/Debugger/WebSocket/SteppingSubscriber.cpp
@@ -288,6 +288,6 @@ void WebSocketSteppingState::AddThreadCondition(uint32_t breakpointAddress, uint
 	BreakPointCond cond;
 	cond.debug = currentDebugMIPS;
 	cond.expressionString = StringFromFormat("threadid == 0x%08x", threadID);
-	if (currentDebugMIPS->initExpression(cond.expressionString.c_str(), cond.expression))
+	if (initExpression(currentDebugMIPS, cond.expressionString.c_str(), cond.expression))
 		g_breakpoints.ChangeBreakPointAddCond(breakpointAddress, cond);
 }

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -758,16 +758,11 @@ void *GetQuickSyscallFunc(MIPSOpcode op) {
 	return (void *)&CallSyscallWithoutFlags;
 }
 
-void hleSetSteppingTime(double t) {
-	hleSteppingTime += t;
-}
-
 void hleSetFlipTime(double t) {
 	hleFlipTime = t;
 }
 
-void CallSyscall(MIPSOpcode op)
-{
+void CallSyscall(MIPSOpcode op) {
 	PROFILE_THIS_SCOPE("syscall");
 	double start = 0.0;  // need to initialize to fix the race condition where coreCollectDebugStats is enabled in the middle of this func.
 	if (coreCollectDebugStats) {
@@ -797,11 +792,10 @@ void CallSyscall(MIPSOpcode op)
 		u32 callno = (op >> 6) & 0xFFFFF; //20 bits
 		int funcnum = callno & 0xFFF;
 		int modulenum = (callno & 0xFF000) >> 12;
-		double total = time_now_d() - start - hleSteppingTime;
+		double total = time_now_d() - start;
 		if (total >= hleFlipTime)
 			total -= hleFlipTime;
 		_dbg_assert_msg_(total >= 0.0, "Time spent in syscall became negative");
-		hleSteppingTime = 0.0;
 		hleFlipTime = 0.0;
 		updateSyscallStats(modulenum, funcnum, total);
 	}

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -114,8 +114,6 @@ void hleRunInterrupts();
 void hleDebugBreak();
 // Don't set temp regs to 0xDEADBEEF.
 void hleSkipDeadbeef();
-// Set time spent in debugger (for more useful debug stats while debugging.)
-void hleSetSteppingTime(double t);
 // Set time spent in realtime sync.
 void hleSetFlipTime(double t);
 // Check if the current syscall context is kernel.

--- a/Core/HLE/KernelThreadDebugInterface.h
+++ b/Core/HLE/KernelThreadDebugInterface.h
@@ -23,17 +23,20 @@
 
 class KernelThreadDebugInterface : public DebugInterface {
 public:
-	KernelThreadDebugInterface(PSPThreadContext &t) : ctx(t) {
-	}
+	KernelThreadDebugInterface(PSPThreadContext &t) : ctx(t) {}
 
-	u32 GetGPR32Value(int reg) override { return ctx.r[reg]; }
-	u32 GetPC() override { return ctx.pc; }
-	u32 GetRA() override { return ctx.r[MIPS_REG_RA]; }
-	u32 GetLLBit() override { return 0; }
-	u32 GetFPCond() override { return ctx.fpcond; }
+	u32 GetGPR32Value(int reg) const override { return ctx.r[reg]; }
+	u32 GetHi() const override { return ctx.hi; }
+	u32 GetLo() const override { return ctx.lo; }
+	u32 GetPC() const override { return ctx.pc; }
+	u32 GetRA() const override { return ctx.r[MIPS_REG_RA]; }
+	u32 GetLLBit() const override { return 0; }
+	u32 GetFPCond() const override { return ctx.fpcond; }
 	void SetPC(u32 _pc) override { ctx.pc = _pc; }
+	void SetHi(u32 val) override { ctx.hi = val; }
+	void SetLo(u32 val) override { ctx.lo = val; }
 
-	void PrintRegValue(int cat, int index, char *out, size_t outSize) override {
+	void PrintRegValue(int cat, int index, char *out, size_t outSize) const override {
 		switch (cat) {
 		case 0: snprintf(out, outSize, "%08X", ctx.r[index]); break;
 		case 1: snprintf(out, outSize, "%f", ctx.f[index]); break;
@@ -41,23 +44,7 @@ public:
 		}
 	}
 
-	u32 GetHi() override {
-		return ctx.hi;
-	}
-
-	u32 GetLo() override {
-		return ctx.lo;
-	}
-
-	void SetHi(u32 val) override {
-		ctx.hi = val;
-	}
-
-	void SetLo(u32 val) override {
-		ctx.lo = val;
-	}
-
-	u32 GetRegValue(int cat, int index) override {
+	u32 GetRegValue(int cat, int index) const override {
 		switch (cat) {
 		case 0: return ctx.r[index];
 		case 1: return ctx.fi[index];

--- a/Core/HLE/KernelThreadDebugInterface.h
+++ b/Core/HLE/KernelThreadDebugInterface.h
@@ -21,14 +21,16 @@
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/MIPS/MIPSDebugInterface.h"
 
-class KernelThreadDebugInterface : public MIPSDebugInterface {
+class KernelThreadDebugInterface : public DebugInterface {
 public:
-	KernelThreadDebugInterface(MIPSState *c, PSPThreadContext &t) : MIPSDebugInterface(c), ctx(t) {
+	KernelThreadDebugInterface(PSPThreadContext &t) : ctx(t) {
 	}
 
 	u32 GetGPR32Value(int reg) override { return ctx.r[reg]; }
 	u32 GetPC() override { return ctx.pc; }
 	u32 GetRA() override { return ctx.r[MIPS_REG_RA]; }
+	u32 GetLLBit() override { return 0; }
+	u32 GetFPCond() override { return ctx.fpcond; }
 	void SetPC(u32 _pc) override { ctx.pc = _pc; }
 
 	void PrintRegValue(int cat, int index, char *out, size_t outSize) override {

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -372,7 +372,7 @@ public:
 
 class PSPThread : public KernelObject {
 public:
-	PSPThread() : debug(currentMIPS, context) {}
+	PSPThread() : debug(context) {}
 
 	const char *GetName() override { return nt.name; }
 	const char *GetTypeName() override { return GetStaticTypeName(); }

--- a/Core/MIPS/MIPSAnalyst.cpp
+++ b/Core/MIPS/MIPSAnalyst.cpp
@@ -35,6 +35,7 @@
 #include "Core/System.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSVFPUUtils.h"
+#include "Core/MIPS/MIPSDebugInterface.h"
 #include "Core/MIPS/MIPSTables.h"
 #include "Core/MIPS/MIPSAnalyst.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
@@ -1424,7 +1425,7 @@ skip:
 		return vec;
 	}
 
-	MipsOpcodeInfo GetOpcodeInfo(DebugInterface* cpu, u32 address) {
+	MipsOpcodeInfo GetOpcodeInfo(DebugInterface *cpu, u32 address) {
 		MipsOpcodeInfo info;
 		memset(&info, 0, sizeof(info));
 

--- a/Core/MIPS/MIPSAnalyst.h
+++ b/Core/MIPS/MIPSAnalyst.h
@@ -22,12 +22,10 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/File/Path.h"
+#include "Core/Debugger/DebugInterface.h"
 #include "Core/MIPS/MIPS.h"
 
-class DebugInterface;
-
-namespace MIPSAnalyst
-{
+namespace MIPSAnalyst {
 	const int MIPS_NUM_GPRS = 32;
 
 	struct RegisterAnalysisResults {
@@ -139,8 +137,8 @@ namespace MIPSAnalyst
 	bool IsOpMemoryWrite(u32 pc);
 	bool OpHasDelaySlot(u32 pc);
 
-	typedef struct {
-		DebugInterface* cpu;
+	struct MipsOpcodeInfo {
+		DebugInterface *cpu;
 		u32 opcodeAddress;
 		MIPSOpcode encodedOpcode;
 
@@ -163,7 +161,7 @@ namespace MIPSAnalyst
 
 		bool hasRelevantAddress;
 		u32 relevantAddress;
-	} MipsOpcodeInfo;
+	};
 
 	MipsOpcodeInfo GetOpcodeInfo(DebugInterface* cpu, u32 address);
 

--- a/Core/MIPS/MIPSDebugInterface.cpp
+++ b/Core/MIPS/MIPSDebugInterface.cpp
@@ -54,7 +54,7 @@ enum ReferenceIndexType {
 
 class MipsExpressionFunctions : public IExpressionFunctions {
 public:
-	MipsExpressionFunctions(DebugInterface *_cpu): cpu(_cpu) {}
+	MipsExpressionFunctions(const DebugInterface *_cpu): cpu(_cpu) {}
 
 	bool parseReference(char* str, uint32_t& referenceIndex) override
 	{
@@ -199,7 +199,7 @@ public:
 	}
 
 private:
-	DebugInterface *cpu;
+	const DebugInterface *cpu;
 };
 
 unsigned int MIPSDebugInterface::readMemory(unsigned int address) {
@@ -282,12 +282,12 @@ std::string MIPSDebugInterface::GetRegName(int cat, int index) {
 	return "???";
 }
 
-bool initExpression(DebugInterface *debug, const char* exp, PostfixExpression& dest) {
+bool initExpression(const DebugInterface *debug, const char* exp, PostfixExpression& dest) {
 	MipsExpressionFunctions funcs(debug);
 	return initPostfixExpression(exp, &funcs, dest);
 }
 
-bool parseExpression(DebugInterface *debug, PostfixExpression& exp, u32& dest) {
+bool parseExpression(const DebugInterface *debug, PostfixExpression& exp, u32& dest) {
 	MipsExpressionFunctions funcs(debug);
 	return parsePostfixExpression(exp, &funcs, dest);
 }

--- a/Core/MIPS/MIPSDebugInterface.cpp
+++ b/Core/MIPS/MIPSDebugInterface.cpp
@@ -52,10 +52,9 @@ enum ReferenceIndexType {
 };
 
 
-class MipsExpressionFunctions: public IExpressionFunctions
-{
+class MipsExpressionFunctions : public IExpressionFunctions {
 public:
-	MipsExpressionFunctions(DebugInterface* cpu): cpu(cpu) { }
+	MipsExpressionFunctions(DebugInterface *_cpu): cpu(_cpu) {}
 
 	bool parseReference(char* str, uint32_t& referenceIndex) override
 	{
@@ -64,12 +63,12 @@ public:
 			char reg[8];
 			snprintf(reg, sizeof(reg), "r%d", i);
 
-			if (strcasecmp(str, reg) == 0 || strcasecmp(str, cpu->GetRegName(0, i).c_str()) == 0)
+			if (strcasecmp(str, reg) == 0 || strcasecmp(str, MIPSDebugInterface::GetRegName(0, i).c_str()) == 0)
 			{
 				referenceIndex = i;
 				return true;
 			}
-			else if (strcasecmp(str, cpu->GetRegName(1, i).c_str()) == 0)
+			else if (strcasecmp(str, MIPSDebugInterface::GetRegName(1, i).c_str()) == 0)
 			{
 				referenceIndex = REF_INDEX_FPU | i;
 				return true;
@@ -85,7 +84,7 @@ public:
 
 		for (int i = 0; i < 128; i++)
 		{
-			if (strcasecmp(str, cpu->GetRegName(2, i).c_str()) == 0)
+			if (strcasecmp(str, MIPSDebugInterface::GetRegName(2, i).c_str()) == 0)
 			{
 				referenceIndex = REF_INDEX_VFPU | i;
 				return true;
@@ -200,17 +199,8 @@ public:
 	}
 
 private:
-	DebugInterface* cpu;
+	DebugInterface *cpu;
 };
-
-
-
-void MIPSDebugInterface::DisAsm(u32 pc, char *out, size_t outSize) {
-	if (Memory::IsValidAddress(pc))
-		MIPSDisAsm(Memory::Read_Opcode_JIT(pc), pc, out, outSize);
-	else
-		truncate_cpy(out, outSize, "-");
-}
 
 unsigned int MIPSDebugInterface::readMemory(unsigned int address) {
 	if (Memory::IsValidRange(address, 4))
@@ -252,7 +242,7 @@ int MIPSDebugInterface::getColor(unsigned int address, bool darkMode) const {
 
 	int n = g_symbolMap->GetFunctionNum(address);
 	if (n == -1) {
-		return DebugInterface::getColor(address, darkMode);
+		return darkMode ? 0xFF101010 : 0xFFFFFFFF;
 	} else if (darkMode) {
 		return colorsDark[n % ARRAY_SIZE(colorsDark)];
 	} else {
@@ -262,28 +252,6 @@ int MIPSDebugInterface::getColor(unsigned int address, bool darkMode) const {
 
 std::string MIPSDebugInterface::getDescription(unsigned int address) {
 	return g_symbolMap->GetDescription(address);
-}
-
-bool MIPSDebugInterface::initExpression(const char* exp, PostfixExpression& dest)
-{
-	MipsExpressionFunctions funcs(this);
-	return initPostfixExpression(exp,&funcs,dest);
-}
-
-bool MIPSDebugInterface::parseExpression(PostfixExpression& exp, u32& dest)
-{
-	MipsExpressionFunctions funcs(this);
-	return parsePostfixExpression(exp,&funcs,dest);
-}
-
-void MIPSDebugInterface::runToBreakpoint() 
-{
-
-}
-
-const char *MIPSDebugInterface::GetName()
-{
-	return ("R4");
 }
 
 std::string MIPSDebugInterface::GetRegName(int cat, int index) {
@@ -304,9 +272,9 @@ std::string MIPSDebugInterface::GetRegName(int cat, int index) {
 		"f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31",
 	};
 
-	if (cat == 0 && (unsigned)index < sizeof(regName)) {
+	if (cat == 0 && (unsigned)index < ARRAY_SIZE(regName)) {
 		return regName[index];
-	} else if (cat == 1 && (unsigned)index < sizeof(fpRegName)) {
+	} else if (cat == 1 && (unsigned)index < ARRAY_SIZE(fpRegName)) {
 		return fpRegName[index];
 	} else if (cat == 2) {
 		return GetVectorNotation(index, V_Single);
@@ -314,3 +282,19 @@ std::string MIPSDebugInterface::GetRegName(int cat, int index) {
 	return "???";
 }
 
+bool initExpression(DebugInterface *debug, const char* exp, PostfixExpression& dest) {
+	MipsExpressionFunctions funcs(debug);
+	return initPostfixExpression(exp, &funcs, dest);
+}
+
+bool parseExpression(DebugInterface *debug, PostfixExpression& exp, u32& dest) {
+	MipsExpressionFunctions funcs(debug);
+	return parsePostfixExpression(exp, &funcs, dest);
+}
+
+void DisAsm(u32 pc, char *out, size_t outSize) {
+	if (Memory::IsValidAddress(pc))
+		MIPSDisAsm(Memory::Read_Opcode_JIT(pc), pc, out, outSize);
+	else
+		truncate_cpy(out, outSize, "-");
+}

--- a/Core/MIPS/MIPSDebugInterface.h
+++ b/Core/MIPS/MIPSDebugInterface.h
@@ -39,13 +39,13 @@ public:
 	int getColor(unsigned int address, bool darkMode) const;
 	std::string getDescription(unsigned int address);
 
-	u32 GetGPR32Value(int reg) override { return cpu->r[reg]; }
-	float GetFPR32Value(int reg) { return cpu->f[reg]; }
+	u32 GetGPR32Value(int reg) const override { return cpu->r[reg]; }
+	float GetFPR32Value(int reg) const { return cpu->f[reg]; }
 	void SetGPR32Value(int reg, u32 value) { cpu->r[reg] = value; }
 
-	u32 GetPC() override { return cpu->pc; }
-	u32 GetRA() override { return cpu->r[MIPS_REG_RA]; }
-	u32 GetFPCond() override { return cpu->fpcond; }
+	u32 GetPC() const override { return cpu->pc; }
+	u32 GetRA() const override { return cpu->r[MIPS_REG_RA]; }
+	u32 GetFPCond() const override { return cpu->fpcond; }
 	void SetPC(u32 _pc) override { cpu->pc = _pc; }
 
 	static const char *GetCategoryName(int cat) {
@@ -59,7 +59,7 @@ public:
 	}
 	static std::string GetRegName(int cat, int index);
 
-	void PrintRegValue(int cat, int index, char *out, size_t outSize) override {
+	void PrintRegValue(int cat, int index, char *out, size_t outSize) const override {
 		switch (cat) {
 		case 0: snprintf(out, outSize, "%08X", cpu->r[index]); break;
 		case 1: snprintf(out, outSize, "%f", cpu->f[index]); break;
@@ -67,15 +67,15 @@ public:
 		}
 	}
 
-	u32 GetHi() override {
+	u32 GetHi() const override {
 		return cpu->hi;
 	}
 
-	u32 GetLLBit() override {
+	u32 GetLLBit() const override {
 		return cpu->llBit;
 	}
 
-	u32 GetLo() override {
+	u32 GetLo() const override {
 		return cpu->lo;
 	}
 	
@@ -87,7 +87,7 @@ public:
 		cpu->lo = val;
 	}
 
-	u32 GetRegValue(int cat, int index) override {
+	u32 GetRegValue(int cat, int index) const override {
 		switch (cat) {
 		case 0:
 			return cpu->r[index];
@@ -124,6 +124,6 @@ public:
 	}
 };
 
-bool initExpression(DebugInterface *debug, const char* exp, PostfixExpression& dest);
-bool parseExpression(DebugInterface *debug, PostfixExpression& exp, u32& dest);
+bool initExpression(const DebugInterface *debug, const char* exp, PostfixExpression& dest);
+bool parseExpression(const DebugInterface *debug, PostfixExpression& exp, u32& dest);
 void DisAsm(u32 pc, char *out, size_t outSize);

--- a/Core/MIPS/MIPSDebugInterface.h
+++ b/Core/MIPS/MIPSDebugInterface.h
@@ -28,43 +28,36 @@ class MIPSDebugInterface : public DebugInterface
 	MIPSState *cpu;
 public:
 	MIPSDebugInterface(MIPSState *_cpu) { cpu = _cpu; }
-	int getInstructionSize(int instruction) override { return 4; }
-	bool isAlive() override;
-	bool isBreakpoint(unsigned int address) override;
-	void setBreakpoint(unsigned int address) override;
-	void clearBreakpoint(unsigned int address) override;
-	void clearAllBreakpoints() override;
-	void toggleBreakpoint(unsigned int address) override;
-	unsigned int readMemory(unsigned int address) override;
-	void step() override {}
-	void runToBreakpoint() override;
-	int getColor(unsigned int address, bool darkMode) const override;
-	std::string getDescription(unsigned int address) override;
-	bool initExpression(const char* exp, PostfixExpression& dest) override;
-	bool parseExpression(PostfixExpression& exp, u32& dest) override;
+	int getInstructionSize(int instruction) { return 4; }
+	bool isAlive();
+	bool isBreakpoint(unsigned int address);
+	void setBreakpoint(unsigned int address);
+	void clearBreakpoint(unsigned int address);
+	void clearAllBreakpoints();
+	void toggleBreakpoint(unsigned int address);
+	unsigned int readMemory(unsigned int address);
+	int getColor(unsigned int address, bool darkMode) const;
+	std::string getDescription(unsigned int address);
 
-	//overridden functions
-	const char *GetName() override;
 	u32 GetGPR32Value(int reg) override { return cpu->r[reg]; }
-	float GetFPR32Value(int reg) override { return cpu->f[reg]; }
-	void SetGPR32Value(int reg, u32 value) override { cpu->r[reg] = value; }
+	float GetFPR32Value(int reg) { return cpu->f[reg]; }
+	void SetGPR32Value(int reg, u32 value) { cpu->r[reg] = value; }
 
 	u32 GetPC() override { return cpu->pc; }
 	u32 GetRA() override { return cpu->r[MIPS_REG_RA]; }
 	u32 GetFPCond() override { return cpu->fpcond; }
-	void DisAsm(u32 pc, char *out, size_t outSize) override;
 	void SetPC(u32 _pc) override { cpu->pc = _pc; }
 
-	const char *GetCategoryName(int cat) override {
+	static const char *GetCategoryName(int cat) {
 		static const char *const names[3] = { "GPR", "FPU", "VFPU" };
 		return names[cat];
 	}
-	int GetNumCategories() override { return 3; }
-	int GetNumRegsInCategory(int cat) override {
-		static int r[3] = { 32, 32, 128 };
+	static int GetNumCategories() { return 3; }
+	static constexpr int GetNumRegsInCategory(int cat) {
+		constexpr int r[3] = { 32, 32, 128 };
 		return r[cat];
 	}
-	std::string GetRegName(int cat, int index) override;
+	static std::string GetRegName(int cat, int index);
 
 	void PrintRegValue(int cat, int index, char *out, size_t outSize) override {
 		switch (cat) {
@@ -130,3 +123,7 @@ public:
 		}
 	}
 };
+
+bool initExpression(DebugInterface *debug, const char* exp, PostfixExpression& dest);
+bool parseExpression(DebugInterface *debug, PostfixExpression& exp, u32& dest);
+void DisAsm(u32 pc, char *out, size_t outSize);

--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -213,10 +213,6 @@ public:
 	virtual GPUDebugOp DisassembleOp(u32 pc, u32 op) = 0;
 	virtual std::vector<GPUDebugOp> DisassembleOpRange(u32 startpc, u32 endpc) = 0;
 
-	// Enter/exit stepping mode.  Mainly for better debug stats on time taken.
-	virtual void NotifySteppingEnter() = 0;
-	virtual void NotifySteppingExit() = 0;
-
 	virtual u32 GetRelativeAddress(u32 data) = 0;
 	virtual u32 GetVertexAddress() = 0;
 	virtual u32 GetIndexAddress() = 0;

--- a/GPU/Debugger/Stepping.cpp
+++ b/GPU/Debugger/Stepping.cpp
@@ -21,6 +21,7 @@
 #include "Common/Log.h"
 #include "Common/Thread/ThreadUtil.h"
 #include "Core/Core.h"
+#include "Core/HW/Display.h"
 #include "GPU/Common/GPUDebugInterface.h"
 #include "GPU/Debugger/Stepping.h"
 #include "GPU/GPUState.h"
@@ -43,6 +44,10 @@ enum PauseAction {
 static bool isStepping;
 // Number of times we've entered stepping, to detect a resume asynchronously.
 static int stepCounter = 0;
+
+// Debug stats.
+static double g_timeSteppingStarted;
+static double g_timeSpentStepping;
 
 static std::mutex pauseLock;
 static PauseAction pauseAction = PAUSE_CONTINUE;
@@ -162,13 +167,11 @@ static void StartStepping() {
 		// Play it safe so we don't keep resetting.
 		lastGState.cmdmem[1] |= 0x01000000;
 	}
-	gpuDebug->NotifySteppingEnter();
 	isStepping = true;
 	stepCounter++;
 }
 
 static void StopStepping() {
-	gpuDebug->NotifySteppingExit();
 	lastGState = gstate;
 	isStepping = false;
 }

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -349,9 +349,6 @@ public:
 	GPUDebugOp DisassembleOp(u32 pc, u32 op) override;
 	std::vector<GPUDebugOp> DisassembleOpRange(u32 startpc, u32 endpc) override;
 
-	void NotifySteppingEnter() override;
-	void NotifySteppingExit() override;
-
 	u32 GetRelativeAddress(u32 data) override;
 	u32 GetVertexAddress() override;
 	u32 GetIndexAddress() override;
@@ -510,8 +507,4 @@ private:
 	void PopDLQueue();
 	void CheckDrawSync();
 	int  GetNextListIndex();
-
-	// Debug stats.
-	double timeSteppingStarted_;
-	double timeSpentStepping_;
 };

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -112,7 +112,7 @@ void DrawSchedulerView(ImConfig &cfg) {
 	ImGui::End();
 }
 
-void DrawRegisterView(ImConfig &config, ImControl &control, MIPSDebugInterface *mipsDebug) {
+void DrawRegisterView(ImConfig &config, ImControl &control, const MIPSDebugInterface *mipsDebug) {
 	ImGui::SetNextWindowSize(ImVec2(320, 600), ImGuiCond_FirstUseEver);
 	if (!ImGui::Begin("Registers", &config.regsOpen)) {
 		ImGui::End();
@@ -743,7 +743,7 @@ void DrawAudioChannels(ImConfig &cfg) {
 	ImGui::End();
 }
 
-void DrawCallStacks(MIPSDebugInterface *debug, bool *open) {
+static void DrawCallStacks(const MIPSDebugInterface *debug, bool *open) {
 	if (!ImGui::Begin("Callstacks", open)) {
 		ImGui::End();
 		return;
@@ -799,7 +799,7 @@ void DrawCallStacks(MIPSDebugInterface *debug, bool *open) {
 	ImGui::End();
 }
 
-void DrawModules(MIPSDebugInterface *debug, ImConfig &cfg) {
+static void DrawModules(const MIPSDebugInterface *debug, ImConfig &cfg) {
 	if (!ImGui::Begin("Modules", &cfg.modulesOpen) || !g_symbolMap) {
 		ImGui::End();
 		return;

--- a/UI/ImDebugger/ImDisasmView.h
+++ b/UI/ImDebugger/ImDisasmView.h
@@ -11,7 +11,7 @@
 #include "Common/Math/geom2d.h"
 
 #include "Core/Debugger/DisassemblyManager.h"
-#include "Core/Debugger/DebugInterface.h"
+#include "Core/MIPS/MIPSDebugInterface.h"
 
 struct ImConfig;
 struct ImControl;
@@ -45,14 +45,15 @@ public:
 	void getOpcodeText(u32 address, char *dest, int bufsize);
 	u32 yToAddress(float y);
 
-	void setDebugger(DebugInterface *deb) {
+	void setDebugger(MIPSDebugInterface *deb) {
 		if (debugger_ != deb) {
 			debugger_ = deb;
 			curAddress_ = debugger_->GetPC();
 			manager.setCpu(deb);
 		}
 	}
-	DebugInterface *getDebugger() {
+
+	MIPSDebugInterface *getDebugger() {
 		return debugger_;
 	}
 
@@ -147,7 +148,7 @@ private:
 	bool hasFocus_ = true;
 	bool showHex_ = false;
 
-	DebugInterface *debugger_ = nullptr;
+	MIPSDebugInterface *debugger_ = nullptr;
 
 	u32 windowStart_ = 0;
 	int visibleRows_ = 1;

--- a/UI/ImDebugger/ImMemView.h
+++ b/UI/ImDebugger/ImMemView.h
@@ -23,10 +23,10 @@ public:
 	ImMemView();
 	~ImMemView();
 
-	void setDebugger(DebugInterface *deb) {
+	void setDebugger(MIPSDebugInterface *deb) {
 		debugger_ = deb;
 	}
-	DebugInterface *getDebugger() {
+	MIPSDebugInterface *getDebugger() {
 		return debugger_;
 	}
 	std::vector<u32> searchString(const std::string &searchQuery);
@@ -69,7 +69,7 @@ private:
 	void PopupMenu();
 
 	static wchar_t szClassName[];
-	DebugInterface *debugger_ = nullptr;
+	MIPSDebugInterface *debugger_ = nullptr;
 
 	MemBlockFlags highlightFlags_ = MemBlockFlags::ALLOC;
 

--- a/UI/ImDebugger/ImStructViewer.cpp
+++ b/UI/ImDebugger/ImStructViewer.cpp
@@ -336,8 +336,8 @@ void ImStructViewer::DrawWatch() {
 			if (!watch.expression.empty()) {
 				u32 val;
 				PostfixExpression postfix;
-				if (mipsDebug_->initExpression(watch.expression.c_str(), postfix)
-				    && mipsDebug_->parseExpression(postfix, val)) {
+				if (initExpression(mipsDebug_, watch.expression.c_str(), postfix)
+				    && parseExpression(mipsDebug_, postfix, val)) {
 					address = val;
 				}
 			} else {
@@ -394,8 +394,8 @@ void ImStructViewer::DrawNewWatchEntry() {
 		PostfixExpression postfix;
 		if (newWatch_.typePathName.empty()) {
 			newWatch_.error = "type can't be empty";
-		} else if (!mipsDebug_->initExpression(newWatch_.expression, postfix)
-		           || !mipsDebug_->parseExpression(postfix, val)) {
+		} else if (!initExpression(mipsDebug_, newWatch_.expression, postfix)
+		           || !parseExpression(mipsDebug_, postfix, val)) {
 			newWatch_.error = "invalid expression";
 		} else {
 			std::string watchName = newWatch_.name;

--- a/Windows/Debugger/BreakpointWindow.cpp
+++ b/Windows/Debugger/BreakpointWindow.cpp
@@ -135,14 +135,14 @@ bool BreakpointWindow::fetchDialogData(HWND hwnd)
 
 	// parse address
 	GetWindowTextA(GetDlgItem(hwnd, IDC_BREAKPOINT_ADDRESS), str, 256);
-	if (cpu->initExpression(str, exp) == false)
+	if (initExpression(cpu, str, exp) == false)
 	{
 		snprintf(errorMessage, sizeof(errorMessage), "Invalid expression \"%s\": %s", str, getExpressionError());
 		MessageBoxA(hwnd, errorMessage, "Error", MB_OK);
 		return false;
 	}
 
-	if (cpu->parseExpression(exp, address) == false)
+	if (parseExpression(cpu, exp, address) == false)
 	{
 		snprintf(errorMessage, sizeof(errorMessage), "Invalid expression \"%s\": %s", str, getExpressionError());
 		MessageBoxA(hwnd, errorMessage, "Error", MB_OK);
@@ -153,14 +153,14 @@ bool BreakpointWindow::fetchDialogData(HWND hwnd)
 	{
 		// parse size
 		GetWindowTextA(GetDlgItem(hwnd, IDC_BREAKPOINT_SIZE), str, 256);
-		if (cpu->initExpression(str, exp) == false)
+		if (initExpression(cpu, str, exp) == false)
 		{
 			snprintf(errorMessage, sizeof(errorMessage), "Invalid expression \"%s\": %s", str, getExpressionError());
 			MessageBoxA(hwnd, errorMessage, "Error", MB_OK);
 			return false;
 		}
 
-		if (cpu->parseExpression(exp, size) == false)
+		if (parseExpression(cpu, exp, size) == false)
 		{
 			snprintf(errorMessage, sizeof(errorMessage), "Invalid expression \"%s\": %s", str, getExpressionError());
 			MessageBoxA(hwnd, errorMessage, "Error", MB_OK);
@@ -175,7 +175,7 @@ bool BreakpointWindow::fetchDialogData(HWND hwnd)
 	compiledCondition.clear();
 	if (!condition.empty())
 	{
-		if (cpu->initExpression(condition.c_str(), compiledCondition) == false)
+		if (initExpression(cpu, condition.c_str(), compiledCondition) == false)
 		{
 			snprintf(errorMessage, sizeof(errorMessage), "Invalid expression \"%s\": %s", condition.c_str(), getExpressionError());
 			MessageBoxA(hwnd, errorMessage, "Error", MB_OK);

--- a/Windows/Debugger/BreakpointWindow.h
+++ b/Windows/Debugger/BreakpointWindow.h
@@ -3,14 +3,14 @@
 #include "Common/CommonWindows.h"
 #include "Common/CommonTypes.h"
 #include "Core/Debugger/DebugInterface.h"
+#include "Core/MIPS/MIPSDebugInterface.h"
 
 struct BreakPoint;
 struct MemCheck;
 
-class BreakpointWindow
-{
+class BreakpointWindow {
 	HWND parentHwnd;
-	DebugInterface* cpu;
+	MIPSDebugInterface *cpu;
 
 	bool memory;
 	bool read;
@@ -31,7 +31,7 @@ class BreakpointWindow
 	INT_PTR DlgFunc(HWND hWnd, UINT iMsg, WPARAM wParam, LPARAM lParam);
 
 public:
-	BreakpointWindow(HWND parent, DebugInterface* cpu): cpu(cpu)
+	BreakpointWindow(HWND parent, MIPSDebugInterface* cpu): cpu(cpu)
 	{
 		parentHwnd = parent;
 		memory = true;

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -19,7 +19,7 @@
 
 #include "Common/CommonWindows.h"
 #include "Common/Log.h"
-#include "Core/Debugger/DebugInterface.h"
+#include "Core/MIPS/MIPSDebugInterface.h"
 #include "Core/Debugger/DisassemblyManager.h"
 
 class CtrlDisAsmView
@@ -38,7 +38,7 @@ class CtrlDisAsmView
 
 	bool hasFocus;
 	bool showHex;
-	DebugInterface *debugger;
+	MIPSDebugInterface *debugger;
 	static TCHAR szClassName[];
 
 	u32 windowStart;
@@ -108,7 +108,7 @@ public:
 	u32 yToAddress(int y);
 
 	void setDontRedraw(bool b) { dontRedraw = b; };
-	void setDebugger(DebugInterface *deb)
+	void setDebugger(MIPSDebugInterface *deb)
 	{
 		debugger=deb;
 		curAddress=debugger->GetPC();

--- a/Windows/Debugger/CtrlMemView.h
+++ b/Windows/Debugger/CtrlMemView.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include "Core/Debugger/DebugInterface.h"
 #include "Core/Debugger/MemBlockInfo.h"
+#include "Core/MIPS/MIPSDebugInterface.h"
 
 enum OffsetSpacing {
 	offsetSpace = 3, // the number of blank lines that should be left to make space for the offsets
@@ -34,10 +35,10 @@ public:
 	static LRESULT CALLBACK wndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 	static CtrlMemView *getFrom(HWND wnd);
 
-	void setDebugger(DebugInterface *deb) {
+	void setDebugger(MIPSDebugInterface *deb) {
 		debugger_ = deb;
 	}
-	DebugInterface *getDebugger() {
+	MIPSDebugInterface *getDebugger() {
 		return debugger_;
 	}
 	std::vector<u32> searchString(const std::string &searchQuery);
@@ -74,7 +75,7 @@ private:
 	void ScrollCursor(int bytes, GotoMode mdoe);
 
 	static wchar_t szClassName[];
-	DebugInterface *debugger_ = nullptr;
+	MIPSDebugInterface *debugger_ = nullptr;
 
 	HWND wnd;
 	HFONT font;

--- a/Windows/Debugger/CtrlRegisterList.h
+++ b/Windows/Debugger/CtrlRegisterList.h
@@ -16,7 +16,7 @@
 //To get a class instance to be able to access it, just use 
 //  CtrlRegisterList::getFrom(GetDlgItem(yourdialog, IDC_yourid)).
 
-#include "../../Core/Debugger/DebugInterface.h"
+#include "Core/MIPS/MIPSDebugInterface.h"
 
 class CtrlRegisterList
 {
@@ -32,7 +32,7 @@ class CtrlRegisterList
 	
 	bool selecting = false;
 	bool hasFocus = false;
-	DebugInterface *cpu = nullptr;
+	MIPSDebugInterface *cpu = nullptr;
 	static TCHAR szClassName[];
 
 	u32 lastPC = 0;
@@ -60,17 +60,15 @@ public:
 
 	int yToIndex(int y);
 
-	void setCPU(DebugInterface *deb)
-	{
+	void setCPU(MIPSDebugInterface *deb) {
 		cpu = deb;
-
-		int regs = cpu->GetNumRegsInCategory(0);
+		constexpr int regs = MIPSDebugInterface::GetNumRegsInCategory(0);
 		lastCat0Values = new u32[regs+3];
 		changedCat0Regs = new bool[regs+3];
 		memset(lastCat0Values, 0, (regs+3) * sizeof(u32));
 		memset(changedCat0Regs, 0, (regs+3) * sizeof(bool));
 	}
-	DebugInterface *getCPU()
+	MIPSDebugInterface *getCPU()
 	{
 		return cpu;
 	}

--- a/Windows/Debugger/DebuggerShared.cpp
+++ b/Windows/Debugger/DebuggerShared.cpp
@@ -1,4 +1,5 @@
 #include "Common/Data/Encoding/Utf8.h"
+#include "Core/MIPS/MIPSDebugInterface.h"
 
 #include "DebuggerShared.h"
 #include "../InputBox.h"
@@ -6,8 +7,9 @@
 bool parseExpression(const char* exp, DebugInterface* cpu, u32& dest)
 {
 	PostfixExpression postfix;
-	if (cpu->initExpression(exp,postfix) == false) return false;
-	return cpu->parseExpression(postfix,dest);
+	if (initExpression(cpu, exp, postfix) == false)
+		return false;
+	return parseExpression(cpu, postfix, dest);
 }
 
 void displayExpressionError(HWND hwnd)

--- a/Windows/Debugger/Debugger_Disasm.cpp
+++ b/Windows/Debugger/Debugger_Disasm.cpp
@@ -91,12 +91,12 @@ LRESULT CALLBACK FuncListProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lPa
 static constexpr UINT_PTR IDT_UPDATE = 0xC0DE0042;
 static constexpr UINT UPDATE_DELAY = 1000 / 60;
 
-CDisasm::CDisasm(HINSTANCE _hInstance, HWND _hParent, DebugInterface *_cpu) : Dialog((LPCSTR)IDD_DISASM, _hInstance, _hParent) {
+CDisasm::CDisasm(HINSTANCE _hInstance, HWND _hParent, MIPSDebugInterface *_cpu) : Dialog((LPCSTR)IDD_DISASM, _hInstance, _hParent) {
 	cpu = _cpu;
 	lastTicks_ = PSP_IsInited() ? CoreTiming::GetTicks() : 0;
 	breakpoints_ = &g_breakpoints;
 
-	SetWindowText(m_hDlg, ConvertUTF8ToWString(_cpu->GetName()).c_str());
+	SetWindowText(m_hDlg, L"R4");
 
 	RECT windowRect;
 	GetWindowRect(m_hDlg,&windowRect);

--- a/Windows/Debugger/Debugger_Disasm.h
+++ b/Windows/Debugger/Debugger_Disasm.h
@@ -17,7 +17,7 @@ class CDisasm : public Dialog {
 private:
 	int minWidth;
 	int minHeight;
-	DebugInterface *cpu;
+	MIPSDebugInterface *cpu;
 	u64 lastTicks_;
 
 	HWND statusBarWnd;
@@ -45,7 +45,7 @@ private:
 public:
 	int index;
 
-	CDisasm(HINSTANCE _hInstance, HWND _hParent, DebugInterface *cpu);
+	CDisasm(HINSTANCE _hInstance, HWND _hParent, MIPSDebugInterface *cpu);
 	~CDisasm();
 
 	void Show(bool bShow, bool includeToTop = true) override;

--- a/Windows/Debugger/Debugger_Lists.cpp
+++ b/Windows/Debugger/Debugger_Lists.cpp
@@ -265,7 +265,7 @@ const char* CtrlThreadList::getCurrentThreadName()
 // CtrlBreakpointList
 //
 
-CtrlBreakpointList::CtrlBreakpointList(HWND hwnd, DebugInterface* cpu, CtrlDisAsmView* disasm)
+CtrlBreakpointList::CtrlBreakpointList(HWND hwnd, MIPSDebugInterface* cpu, CtrlDisAsmView* disasm)
 	: GenericListControl(hwnd,breakpointListDef),cpu(cpu),disasm(disasm)
 {
 	SetSendInvalidRows(true);
@@ -835,7 +835,7 @@ void CtrlWatchList::RefreshValues() {
 		}
 
 		uint32_t prevValue = watch.currentValue;
-		watch.evaluateFailed = !cpu_->parseExpression(watch.expression, watch.currentValue);
+		watch.evaluateFailed = !parseExpression(cpu_, watch.expression, watch.currentValue);
 		if (prevValue != watch.currentValue)
 			changes = true;
 	}
@@ -959,7 +959,7 @@ void CtrlWatchList::AddWatch() {
 	WatchItemWindow win(nullptr, GetHandle(), cpu_);
 	if (win.Exec()) {
 		WatchInfo info;
-		if (cpu_->initExpression(win.GetExpression().c_str(), info.expression)) {
+		if (initExpression(cpu_, win.GetExpression().c_str(), info.expression)) {
 			info.name = win.GetName();
 			info.originalExpression = win.GetExpression();
 			info.format = win.GetFormat();
@@ -978,7 +978,7 @@ void CtrlWatchList::EditWatch(int pos) {
 	WatchItemWindow win(nullptr, GetHandle(), cpu_);
 	win.Init(watch.name, watch.originalExpression, watch.format);
 	if (win.Exec()) {
-		if (cpu_->initExpression(win.GetExpression().c_str(), watch.expression)) {
+		if (initExpression(cpu_, win.GetExpression().c_str(), watch.expression)) {
 			watch.name = win.GetName();
 			watch.originalExpression = win.GetExpression();
 			watch.format = win.GetFormat();

--- a/Windows/Debugger/Debugger_Lists.h
+++ b/Windows/Debugger/Debugger_Lists.h
@@ -36,7 +36,7 @@ class CtrlDisAsmView;
 class CtrlBreakpointList: public GenericListControl
 {
 public:
-	CtrlBreakpointList(HWND hwnd, DebugInterface* cpu, CtrlDisAsmView* disasm);
+	CtrlBreakpointList(HWND hwnd, MIPSDebugInterface* cpu, CtrlDisAsmView* disasm);
 	void reloadBreakpoints();
 protected:
 	bool WindowMessage(UINT msg, WPARAM wParam, LPARAM lParam, LRESULT &returnValue) override;
@@ -49,7 +49,7 @@ private:
 	std::vector<BreakPoint> displayedBreakPoints_;
 	std::vector<MemCheck> displayedMemChecks_;
 	std::wstring breakpointText;
-	DebugInterface* cpu;
+	MIPSDebugInterface* cpu;
 	CtrlDisAsmView* disasm;
 
 	void editBreakpoint(int itemIndex);

--- a/Windows/Debugger/Debugger_MemoryDlg.cpp
+++ b/Windows/Debugger/Debugger_MemoryDlg.cpp
@@ -54,11 +54,11 @@ LRESULT CALLBACK AddressEditProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM 
 }
 
 
-CMemoryDlg::CMemoryDlg(HINSTANCE _hInstance, HWND _hParent, DebugInterface *_cpu) : Dialog((LPCSTR)IDD_MEMORY, _hInstance,_hParent)
+CMemoryDlg::CMemoryDlg(HINSTANCE _hInstance, HWND _hParent, MIPSDebugInterface *_cpu) : Dialog((LPCSTR)IDD_MEMORY, _hInstance,_hParent)
 {
 	cpu = _cpu;
 	wchar_t temp[256];
-	wsprintf(temp,L"Memory Viewer - %S",cpu->GetName());
+	wsprintf(temp,L"Memory Viewer - R4");
 	SetWindowText(m_hDlg,temp);
 
 	ShowWindow(m_hDlg,SW_HIDE);

--- a/Windows/Debugger/Debugger_MemoryDlg.h
+++ b/Windows/Debugger/Debugger_MemoryDlg.h
@@ -3,9 +3,10 @@
 
 #include "Core/MemMap.h"
 
-#include "Core/Debugger/DebugInterface.h"
 #include "CtrlMemView.h"
 #include "Common/CommonWindows.h"
+
+class MIPSDebugInterface;
 
 class CMemoryDlg : public Dialog
 {
@@ -25,7 +26,7 @@ public:
 	void searchBoxRedraw(const std::vector<u32> &results);
 
 	// constructor
-	CMemoryDlg(HINSTANCE _hInstance, HWND _hParent, DebugInterface *_cpu);
+	CMemoryDlg(HINSTANCE _hInstance, HWND _hParent, MIPSDebugInterface *_cpu);
 	
 	// destructor
 	~CMemoryDlg(void);

--- a/Windows/Debugger/Debugger_VFPUDlg.cpp
+++ b/Windows/Debugger/Debugger_VFPUDlg.cpp
@@ -15,7 +15,7 @@ CVFPUDlg::CVFPUDlg(HINSTANCE _hInstance, HWND _hParent, DebugInterface *cpu_) : 
 {
 	cpu = cpu_;
 	wchar_t temp[256];
-	wsprintf(temp, L"VFPU - %S", cpu->GetName());
+	wsprintf(temp, L"VFPU - R4");
 	SetWindowText(m_hDlg,temp);
 
 	ShowWindow(m_hDlg,SW_HIDE);

--- a/Windows/Debugger/DumpMemoryWindow.cpp
+++ b/Windows/Debugger/DumpMemoryWindow.cpp
@@ -6,6 +6,7 @@
 #include "Core/HLE/ReplaceTables.h"
 #include "Core/MemMap.h"
 #include "Core/MIPS/JitCommon/JitBlockCache.h"
+#include "Core/MIPS/MIPSDebugInterface.h"
 #include "Windows/Debugger/DumpMemoryWindow.h"
 #include "Windows/resource.h"
 #include "Windows/W32Util/ShellUtil.h"
@@ -149,8 +150,8 @@ bool DumpMemoryWindow::fetchDialogData(HWND hwnd)
 
 	// parse start address
 	GetWindowTextA(GetDlgItem(hwnd,IDC_DUMP_STARTADDRESS),str,256);
-	if (cpu->initExpression(str,exp) == false
-		|| cpu->parseExpression(exp,start) == false)
+	if (initExpression(cpu, str,exp) == false
+		|| parseExpression(cpu, exp,start) == false)
 	{
 		snprintf(errorMessage, sizeof(errorMessage), "Invalid address expression \"%s\".",str);
 		MessageBoxA(hwnd,errorMessage,"Error",MB_OK);
@@ -159,8 +160,8 @@ bool DumpMemoryWindow::fetchDialogData(HWND hwnd)
 	
 	// parse size
 	GetWindowTextA(GetDlgItem(hwnd,IDC_DUMP_SIZE),str,256);
-	if (cpu->initExpression(str,exp) == false
-		|| cpu->parseExpression(exp,size) == false)
+	if (initExpression(cpu, str,exp) == false
+		|| parseExpression(cpu, exp,size) == false)
 	{
 		snprintf(errorMessage, sizeof(errorMessage), "Invalid size expression \"%s\".",str);
 		MessageBoxA(hwnd,errorMessage,"Error",MB_OK);

--- a/Windows/Debugger/EditSymbolsWindow.cpp
+++ b/Windows/Debugger/EditSymbolsWindow.cpp
@@ -1,6 +1,7 @@
 #include "EditSymbolsWindow.h"
 #include "../resource.h"
 
+#include "Core/MIPS/MIPSDebugInterface.h"
 
 bool EditSymbolsWindow::GetCheckState(HWND hwnd, int dlgItem) {
 	return SendMessage(GetDlgItem(hwnd, dlgItem), BM_GETCHECK, 0, 0) != 0;
@@ -16,13 +17,13 @@ bool EditSymbolsWindow::fetchDialogData(HWND hwnd)
 	// Parse the address
 	GetWindowTextA(GetDlgItem(hwnd, IDC_EDITSYMBOLS_ADDRESS), str, 256);
 
-	if (cpu->initExpression(str, exp) == false)
+	if (initExpression(cpu, str, exp) == false)
 	{
 		snprintf(errorMessage, sizeof(errorMessage), "Invalid expression \"%s\": %s", str, getExpressionError());
 		MessageBoxA(hwnd, errorMessage, "Error", MB_OK);
 		return false;
 	}
-	if (cpu->parseExpression(exp, address_) == false)
+	if (parseExpression(cpu, exp, address_) == false)
 	{
 		snprintf(errorMessage, sizeof(errorMessage), "Invalid expression \"%s\": %s", str, getExpressionError());
 		MessageBoxA(hwnd, errorMessage, "Error", MB_OK);
@@ -32,13 +33,13 @@ bool EditSymbolsWindow::fetchDialogData(HWND hwnd)
 	// Parse the size
 	GetWindowTextA(GetDlgItem(hwnd, IDC_EDITSYMBOLS_SIZE), str, 256);
 
-	if (cpu->initExpression(str, exp) == false)
+	if (initExpression(cpu, str, exp) == false)
 	{
 		snprintf(errorMessage, sizeof(errorMessage), "Invalid expression \"%s\": %s", str, getExpressionError());
 		MessageBoxA(hwnd, errorMessage, "Error", MB_OK);
 		return false;
 	}
-	if (cpu->parseExpression(exp, size_) == false)
+	if (parseExpression(cpu, exp, size_) == false)
 	{
 		snprintf(errorMessage, sizeof(errorMessage), "Invalid expression \"%s\": %s", str, getExpressionError());
 		MessageBoxA(hwnd, errorMessage, "Error", MB_OK);

--- a/Windows/Debugger/WatchItemWindow.cpp
+++ b/Windows/Debugger/WatchItemWindow.cpp
@@ -106,7 +106,7 @@ bool WatchItemWindow::FetchDialogData(HWND hwnd) {
 	GetWindowTextW(GetDlgItem(hwnd, IDC_BREAKPOINT_CONDITION), textValue, ARRAY_SIZE(textValue));
 	expression_ = ConvertWStringToUTF8(textValue);
 	PostfixExpression compiled;
-	if (!cpu_->initExpression(expression_.c_str(), compiled)) {
+	if (!initExpression(cpu_,  expression_.c_str(), compiled)) {
 		char errorMessage[512];
 		snprintf(errorMessage, sizeof(errorMessage), "Invalid expression \"%s\": %s", expression_.c_str(), getExpressionError());
 		MessageBoxA(hwnd, errorMessage, "Error", MB_OK);


### PR DESCRIPTION
Cleanup some unnecessary time accounting.

Additionally, simplify DebugInterface, so that KernelThreadDebugInterface isn't semantically silly anymore (it shouldn't carry a copy of the main MIPS object...).

We now use MIPSDebugInterface a bit more liberally, but might as well, since this code isn't planned to support any more CPUs..

Having less stuff in DebugInterface makes MIPSDebugInterface a bit easier to extend and modify.