### PR TITLE
Implement vertex preview in the new Ge debugger

### DIFF
--- a/GPU/Debugger/State.cpp
+++ b/GPU/Debugger/State.cpp
@@ -831,7 +831,7 @@ static void ExpandSpline(int &count, int op, const std::vector<SimpleVertex> &si
 	FreeAlignedMemory(cpoints.col);
 }
 
-bool GetPrimPreview(u32 op, int which, GEPrimitiveType &prim, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices, int &count) {
+bool GetPrimPreview(u32 op, GEPrimitiveType &prim, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices, int &count) {
 	u32 prim_type = GE_PRIM_INVALID;
 	int count_u = 0;
 	int count_v = 0;
@@ -857,7 +857,7 @@ bool GetPrimPreview(u32 op, int which, GEPrimitiveType &prim, std::vector<GPUDeb
 		ERROR_LOG(Log::G3D, "Invalid debugging environment, shutting down?");
 		return false;
 	}
-	if (count == 0 || which == 0) {
+	if (count == 0) {
 		return false;
 	}
 

--- a/GPU/Debugger/State.h
+++ b/GPU/Debugger/State.h
@@ -45,6 +45,6 @@ void FormatVertColRaw(VertexDecoder *decoder, char *dest, size_t destSize, int r
 // These are utilities used by the debugger vertex preview.
 
 // Later I hope to re-use more of the real logic.
-bool GetPrimPreview(u32 op, int which, GEPrimitiveType &prim, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices, int &count);
+bool GetPrimPreview(u32 op, GEPrimitiveType &prim, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices, int &count);
 void DescribePixel(u32 pix, GPUDebugBufferFormat fmt, int x, int y, char desc[256]);
 void DescribePixelRGBA(u32 pix, GPUDebugBufferFormat fmt, int x, int y, char desc[256]);

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -902,14 +902,14 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 
 	if (lastCpuStepCount_ != Core_GetSteppingCounter()) {
 		lastCpuStepCount_ = Core_GetSteppingCounter();
-		disasm_.View().NotifyStep();
+		disasm_.NotifyStep();
 	}
 
 	if (lastGpuStepCount_ != GPUStepping::GetSteppingCounter()) {
 		// A GPU step has happened since last time. This means that we should re-center the cursor.
 		// Snapshot();
 		lastGpuStepCount_ = GPUStepping::GetSteppingCounter();
-		geDebugger_.View().NotifyStep();
+		geDebugger_.NotifyStep();
 	}
 
 	ImControl control{};

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -36,6 +36,9 @@ public:
 	ImDisasmView &View() {
 		return disasmView_;
 	}
+	void NotifyStep() {
+		disasmView_.NotifyStep();
+	}
 	void DirtySymbolMap() {
 		symsDirty_ = true;
 	}

--- a/UI/ImDebugger/ImGe.h
+++ b/UI/ImDebugger/ImGe.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "GPU/Common/GPUDebugInterface.h"
+
 // GE-related windows of the ImDebugger
 
 struct ImConfig;
@@ -7,7 +9,6 @@ struct ImControl;
 
 class FramebufferManagerCommon;
 class TextureCacheCommon;
-class GPUDebugInterface;
 
 void DrawFramebuffersWindow(ImConfig &cfg, FramebufferManagerCommon *framebufferManager);
 void DrawTexturesWindow(ImConfig &cfg, TextureCacheCommon *textureCache);
@@ -57,8 +58,17 @@ public:
 	const char *Title() const {
 		return "GE Debugger";
 	}
+	void NotifyStep() {
+		reloadPreview_ = true;
+		disasmView_.NotifyStep();
+	}
 
 private:
 	ImGeDisasmView disasmView_;
 	int showBannerInFrames_ = 0;
+	bool reloadPreview_ = false;
+	GEPrimitiveType previewPrim_;
+	std::vector<u16> previewIndices_;
+	std::vector<GPUDebugVertex> previewVertices_;
+	int previewCount_ = 0;
 };

--- a/Windows/GEDebugger/VertexPreview.cpp
+++ b/Windows/GEDebugger/VertexPreview.cpp
@@ -89,12 +89,16 @@ u32 CGEDebugger::PrimPreviewOp() {
 void CGEDebugger::UpdatePrimPreview(u32 op, int which) {
 	which &= previewsEnabled_;
 
+	if (which == 0) {
+		return;
+	}
+
 	static std::vector<GPUDebugVertex> vertices;
 	static std::vector<u16> indices;
 
 	int count = 0;
 	GEPrimitiveType prim;
-	if (!GetPrimPreview(op, which, prim, vertices, indices, count)) {
+	if (!GetPrimPreview(op, prim, vertices, indices, count)) {
 		return;
 	}
 


### PR DESCRIPTION
A bit rough, but at least functions the same as the old one. Many improvements are possible.

To test, click "Prim" in the new imgui Ge debugger window.

![image](https://github.com/user-attachments/assets/0f5453ed-b51c-42f2-a0ab-49f75df1c5b9)
