### PR TITLE
Refactor the display list processing loop

### DIFF
--- a/Common/TimeUtil.h
+++ b/Common/TimeUtil.h
@@ -45,3 +45,19 @@ private:
 	int64_t nsecs_;
 #endif
 };
+
+class TimeCollector {
+public:
+	TimeCollector(double *target, bool enable) : target_(enable ? target : nullptr) {
+		if (enable)
+			startTime_ = time_now_d();
+	}
+	~TimeCollector() {
+		if (target_) {
+			*target_ += time_now_d() - startTime_;
+		}
+	}
+private:
+	double startTime_;
+	double *target_;
+};

--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -190,20 +190,18 @@ void Core_RunLoopUntil(u64 globalticks) {
 				GPUStepping::EnterStepping();
 				break;
 			case DLResult::Error:
-				// We should elegantly report the error, or I guess ignore it.
+				// We should elegantly report the error somehow, or I guess ignore it.
 				hleFinishSyscallAfterGe();
 				coreState = preGeCoreState;
 				break;
-			case DLResult::Stall:
 			case DLResult::Done:
 				// Done executing for now
 				hleFinishSyscallAfterGe();
 				coreState = preGeCoreState;
 				break;
 			default:
+				// Not a valid return value.
 				_dbg_assert_(false);
-				hleFinishSyscallAfterGe();
-				coreState = preGeCoreState;
 				break;
 			}
 			break;

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -834,7 +834,7 @@ DLResult GPUCommon::ProcessDLQueue() {
 		if (!InterpretList(list)) {
 			switch (gpuState) {
 			case GPURunState::GPUSTATE_STALL:
-				return DLResult::Stall;
+				return DLResult::Done;
 			case GPURunState::GPUSTATE_BREAK:
 				return DLResult::Break;
 			default:

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -622,6 +622,8 @@ bool GPUCommon::InterpretList(DisplayList &list) {
 		start = time_now_d();
 	}
 
+	// TODO: Need to be careful when *resuming* a list (when it wasn't from a stall...)
+
 	if (list.state == PSP_GE_DL_STATE_PAUSED)
 		return false;
 	currentList = &list;

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -80,7 +80,6 @@ enum GPURunState {
 	GPUSTATE_STALL = 2,
 	GPUSTATE_INTERRUPT = 3,
 	GPUSTATE_ERROR = 4,
-	GPUSTATE_BREAK = 5,
 };
 
 enum GPUSyncType {

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -236,8 +236,6 @@ public:
 
 	virtual void PreExecuteOp(u32 op, u32 diff) {}
 
-	bool InterpretList(DisplayList &list);
-
 	DLResult ProcessDLQueue();
 
 	u32 UpdateStall(int listid, u32 newstall, bool *runList);

--- a/GPU/GPUDefinitions.h
+++ b/GPU/GPUDefinitions.h
@@ -22,7 +22,11 @@
 #undef None
 #endif
 
-enum DisplayListStatus {
+// NOTE: This seems a bit insane, but these are two very similar enums!
+
+// These are return values from DrawSync(), and also sceGeDrawSync().
+// So these are frozen and "official".
+enum DisplayListDrawSyncStatus {
 	// The list has been completed
 	PSP_GE_LIST_COMPLETED = 0,
 	// The list is queued but not executed yet
@@ -35,12 +39,13 @@ enum DisplayListStatus {
 	PSP_GE_LIST_PAUSED = 4,
 };
 
+// These are states, stored on the lists! not sure if these are exposed, or if their values can be changed?
 enum DisplayListState {
 	// No state assigned, the list is empty
 	PSP_GE_DL_STATE_NONE = 0,
 	// The list has been queued
 	PSP_GE_DL_STATE_QUEUED = 1,
-	// The list is being executed
+	// The list is being executed (or stalled?)
 	PSP_GE_DL_STATE_RUNNING = 2,
 	// The list was completed and will be removed
 	PSP_GE_DL_STATE_COMPLETED = 3,
@@ -60,8 +65,7 @@ enum GPUInvalidationType {
 };
 
 enum class DLResult {
-	Done,
+	Done,  // Or stall
 	Error,
-	Stall,
 	Break,  // used for stepping, breakpoints
 };

--- a/UI/ImDebugger/ImGe.cpp
+++ b/UI/ImDebugger/ImGe.cpp
@@ -457,6 +457,9 @@ void ImGeDebuggerWindow::Draw(ImConfig &cfg, ImControl &control, GPUDebugInterfa
 	DisplayList list;
 	if (gpuDebug->GetCurrentDisplayList(list)) {
 		op = Memory::Read_U32(list.pc);
+
+		// TODO: Also add support for block transfer previews!
+
 		bool isOnPrim = (op >> 24) == GE_CMD_PRIM;
 		if (isOnPrim) {
 			if (reloadPreview_) {


### PR DESCRIPTION
It was very hard to understand the combined flow of ProcessDLQueue/InterpretList, so this merges them into one big, slightly unwieldy function, but at least the flow is clear now.

And, it's pretty clear that we have timing bugs with stalled display lists, as some accounting just isn't done. In addition, when resuming from debugger breaks, we do some work that we shouldn't. The actual fixes will come in future PRs.