### PR TITLE
GE debugger: Cleaner resume from stepping. Fixes GE debugging in God of War

### DIFF
--- a/Core/Core.cpp
+++ b/Core/Core.cpp
@@ -186,7 +186,7 @@ void Core_RunLoopUntil(u64 globalticks) {
 			break;  // Will loop around to go to RUNNING_GE or NEXTFRAME, which will exit.
 		case CORE_RUNNING_GE:
 			switch (gpu->ProcessDLQueue()) {
-			case DLResult::Break:
+			case DLResult::DebugBreak:
 				GPUStepping::EnterStepping();
 				break;
 			case DLResult::Error:

--- a/GPU/GPUCommon.h
+++ b/GPU/GPUCommon.h
@@ -456,6 +456,7 @@ protected:
 	u32 cycleLastPC;
 	int cyclesExecuted;
 
+	bool resumingFromDebugBreak_ = false;
 	bool dumpNextFrame_ = false;
 	bool dumpThisFrame_ = false;
 	bool debugRecording_;

--- a/GPU/GPUDefinitions.h
+++ b/GPU/GPUDefinitions.h
@@ -67,5 +67,5 @@ enum GPUInvalidationType {
 enum class DLResult {
 	Done,  // Or stall
 	Error,
-	Break,  // used for stepping, breakpoints
+	DebugBreak,  // used for stepping, breakpoints
 };


### PR DESCRIPTION
Followup to #19727 

Probably, some similar checks should be done when resuming from stalls...