### PR TITLE
ImGeDebugger stepping improvements

### DIFF
--- a/Common/Render/Text/draw_text.cpp
+++ b/Common/Render/Text/draw_text.cpp
@@ -167,6 +167,9 @@ void TextDrawer::MeasureStringRect(std::string_view str, const Bounds &bounds, f
 }
 
 void TextDrawer::DrawStringRect(DrawBuffer &target, std::string_view str, const Bounds &bounds, uint32_t color, int align) {
+	if (bounds.w < 0.0f || bounds.h < 0.0f) {
+		return;
+	}
 	float x = bounds.x;
 	float y = bounds.y;
 	if (align & ALIGN_HCENTER) {

--- a/GPU/Debugger/State.cpp
+++ b/GPU/Debugger/State.cpp
@@ -12,6 +12,9 @@
 #include "Core/System.h"
 
 void FormatStateRow(GPUDebugInterface *gpudebug, char *dest, size_t destSize, CmdFormatType fmt, u32 value, bool enabled, u32 otherValue, u32 otherValue2) {
+	value &= 0xFFFFFF;
+	otherValue &= 0xFFFFFF;
+	otherValue2 &= 0xFFFFFF;
 	switch (fmt) {
 	case CMD_FMT_HEX:
 		snprintf(dest, destSize, "%06x", value);

--- a/GPU/Debugger/Stepping.h
+++ b/GPU/Debugger/Stepping.h
@@ -46,5 +46,6 @@ namespace GPUStepping {
 	bool GPU_SetCmdValue(u32 op);
 	bool GPU_FlushDrawing();
 
-	GPUgstate LastState();
+	// Can be used to highlight differences in a debugger.
+	const GPUgstate &LastState();
 };

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1539,6 +1539,11 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 		}
 	}
 
+	// Running it early allows things like direct readbacks of buffers, things we can't do
+	// when we have started the final render pass. Well, technically we probably could with some manipulation
+	// of pass order in the render managers..
+	runImDebugger();
+
 	bool blockedExecution = Achievements::IsBlockingExecution();
 	uint32_t clearColor = 0;
 	if (!blockedExecution) {
@@ -1655,7 +1660,7 @@ ScreenRenderFlags EmuScreen::render(ScreenRenderMode mode) {
 	return flags;
 }
 
-void EmuScreen::renderImDebugger() {
+void EmuScreen::runImDebugger() {
 	if (g_Config.bShowImDebugger) {
 		Draw::DrawContext *draw = screenManager()->getDrawContext();
 		if (!imguiInited_) {
@@ -1691,6 +1696,14 @@ void EmuScreen::renderImDebugger() {
 			imDebugger_->Frame(currentDebugMIPS, gpuDebug);
 
 			ImGui::Render();
+		}
+	}
+}
+
+void EmuScreen::renderImDebugger() {
+	if (g_Config.bShowImDebugger) {
+		Draw::DrawContext *draw = screenManager()->getDrawContext();
+		if (PSP_IsInited()) {
 			ImGui_ImplThin3d_RenderDrawData(ImGui::GetDrawData(), draw);
 		}
 	}

--- a/UI/EmuScreen.h
+++ b/UI/EmuScreen.h
@@ -79,6 +79,7 @@ private:
 	void bootComplete();
 	bool hasVisibleUI();
 	void renderUI();
+	void runImDebugger();
 	void renderImDebugger();
 
 	void onVKey(int virtualKeyCode, bool down);

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -65,6 +65,9 @@ void ShowInWindowMenuItems(uint32_t addr, ImControl &control) {
 }
 
 void StatusBar(std::string_view status) {
+	if (!status.size()) {
+		return;
+	}
 	ImGui::TextUnformatted(status.data(), status.data() + status.length());
 	ImGui::SameLine();
 	if (ImGui::SmallButton("Copy")) {

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -127,18 +127,19 @@ static void DrawGPRs(ImConfig &config, ImControl &control, const MIPSDebugInterf
 		return;
 	}
 
-	bool noDiff = coreState == CORE_RUNNING_CPU;
+	bool noDiff = coreState == CORE_RUNNING_CPU || coreState == CORE_STEPPING_GE;
 
 	if (ImGui::BeginTable("gpr", 3, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersH)) {
-		ImGui::TableSetupColumn("regname", ImGuiTableColumnFlags_WidthFixed);
-		ImGui::TableSetupColumn("value", ImGuiTableColumnFlags_WidthFixed);
-		ImGui::TableSetupColumn("value_i", ImGuiTableColumnFlags_WidthStretch);
+		ImGui::TableSetupColumn("Reg", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("Decimal", ImGuiTableColumnFlags_WidthStretch);
+
+		ImGui::TableHeadersRow();
 
 		auto gprLine = [&](int index, const char *regname, int value, int prevValue) {
 			bool diff = value != prevValue && !noDiff;
 			bool disabled = value == 0xdeadbeef;
 
-			ImGui::TableNextRow();
 			ImGui::TableNextColumn();
 			ImGui::TextUnformatted(regname);
 			ImGui::TableNextColumn();
@@ -154,8 +155,8 @@ static void DrawGPRs(ImConfig &config, ImControl &control, const MIPSDebugInterf
 			} else {
 				ImGui::Text("%08x", value);
 			}
+			ImGui::TableNextColumn();
 			if (value >= -1000000 && value <= 1000000) {
-				ImGui::TableSetColumnIndex(2);
 				ImGui::Text("%d", value);
 			}
 			if (diff || disabled) {
@@ -163,11 +164,16 @@ static void DrawGPRs(ImConfig &config, ImControl &control, const MIPSDebugInterf
 			}
 		};
 		for (int i = 0; i < 32; i++) {
+			ImGui::TableNextRow();
 			gprLine(i, mipsDebug->GetRegName(0, i).c_str(), mipsDebug->GetGPR32Value(i), prev.gpr[i]);
 		}
+		ImGui::TableNextRow();
 		gprLine(32, "hi", mipsDebug->GetHi(), prev.hi);
+		ImGui::TableNextRow();
 		gprLine(33, "lo", mipsDebug->GetLo(), prev.lo);
+		ImGui::TableNextRow();
 		gprLine(34, "pc", mipsDebug->GetPC(), prev.pc);
+		ImGui::TableNextRow();
 		gprLine(35, "ll", mipsDebug->GetLLBit(), prev.ll);
 		ImGui::EndTable();
 	}
@@ -181,12 +187,14 @@ static void DrawFPRs(ImConfig &config, ImControl &control, const MIPSDebugInterf
 		return;
 	}
 
-	bool noDiff = coreState == CORE_RUNNING_CPU;
+	bool noDiff = coreState == CORE_RUNNING_CPU || coreState == CORE_STEPPING_GE;
 
 	if (ImGui::BeginTable("fpr", 3, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersH)) {
-		ImGui::TableSetupColumn("regname", ImGuiTableColumnFlags_WidthFixed);
-		ImGui::TableSetupColumn("value", ImGuiTableColumnFlags_WidthFixed);
-		ImGui::TableSetupColumn("value_i", ImGuiTableColumnFlags_WidthStretch);
+		ImGui::TableSetupColumn("Reg", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("Hex", ImGuiTableColumnFlags_WidthStretch);
+
+		ImGui::TableHeadersRow();
 
 		// fpcond
 		ImGui::TableNextRow();

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -120,85 +120,101 @@ void DrawSchedulerView(ImConfig &cfg) {
 	ImGui::End();
 }
 
-void DrawRegisterView(ImConfig &config, ImControl &control, const MIPSDebugInterface *mipsDebug) {
+static void DrawGPRs(ImConfig &config, ImControl &control, const MIPSDebugInterface *mipsDebug, const ImSnapshotState &prev) {
 	ImGui::SetNextWindowSize(ImVec2(320, 600), ImGuiCond_FirstUseEver);
-	if (!ImGui::Begin("Registers", &config.regsOpen)) {
+	if (!ImGui::Begin("MIPS GPRs", &config.vfpuOpen)) {
 		ImGui::End();
 		return;
 	}
 
-	if (ImGui::BeginTabBar("RegisterGroups", ImGuiTabBarFlags_None)) {
-		if (ImGui::BeginTabItem("GPR")) {
-			if (ImGui::BeginTable("gpr", 3, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersH)) {
-				ImGui::TableSetupColumn("regname", ImGuiTableColumnFlags_WidthFixed);
-				ImGui::TableSetupColumn("value", ImGuiTableColumnFlags_WidthFixed);
-				ImGui::TableSetupColumn("value_i", ImGuiTableColumnFlags_WidthStretch);
+	if (ImGui::BeginTable("gpr", 3, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersH)) {
+		ImGui::TableSetupColumn("regname", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("value", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("value_i", ImGuiTableColumnFlags_WidthStretch);
 
-				auto gprLine = [&](int index, const char *regname, int value) {
-					ImGui::TableNextRow();
-					ImGui::TableNextColumn();
-					ImGui::TextUnformatted(regname);
-					ImGui::TableNextColumn();
-					if (Memory::IsValid4AlignedAddress(value)) {
-						ImGui::PushID(index);
-						ImClickableAddress(value, control, index == MIPS_REG_RA ? ImCmd::SHOW_IN_CPU_DISASM : ImCmd::SHOW_IN_MEMORY_VIEWER);
-						ImGui::PopID();
-					} else {
-						ImGui::Text("%08x", value);
-					}
-					if (value >= -1000000 && value <= 1000000) {
-						ImGui::TableSetColumnIndex(2);
-						ImGui::Text("%d", value);
-					}
-				};
-				for (int i = 0; i < 32; i++) {
-					gprLine(i, mipsDebug->GetRegName(0, i).c_str(), mipsDebug->GetGPR32Value(i));
-				}
-				gprLine(32, "hi", mipsDebug->GetHi());
-				gprLine(33, "lo", mipsDebug->GetLo());
-				gprLine(34, "pc", mipsDebug->GetPC());
-				gprLine(35, "ll", mipsDebug->GetLLBit());
-				ImGui::EndTable();
+		auto gprLine = [&](int index, const char *regname, int value, int prevValue) {
+			bool diff = false; // value != prevValue;
+			bool disabled = value == 0xdeadbeef;
+
+			ImGui::TableNextRow();
+			ImGui::TableNextColumn();
+			ImGui::TextUnformatted(regname);
+			ImGui::TableNextColumn();
+			if (diff) {
+				ImGui::PushStyleColor(ImGuiCol_Text, disabled ? ImDebuggerColor_Diff : ImDebuggerColor_DiffAlpha);
+			} else if (disabled) {
+				ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 255, 255, 128));
 			}
-
-			ImGui::EndTabItem();
-		}
-		if (ImGui::BeginTabItem("FPU")) {
-			if (ImGui::BeginTable("fpr", 3, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersH)) {
-				ImGui::TableSetupColumn("regname", ImGuiTableColumnFlags_WidthFixed);
-				ImGui::TableSetupColumn("value", ImGuiTableColumnFlags_WidthFixed);
-				ImGui::TableSetupColumn("value_i", ImGuiTableColumnFlags_WidthStretch);
-
-				// fpcond
-				ImGui::TableNextRow();
-				ImGui::TableNextColumn();
-				ImGui::TextUnformatted("fpcond");
-				ImGui::TableNextColumn();
-				ImGui::Text("%08x", mipsDebug->GetFPCond());
-
-				for (int i = 0; i < 32; i++) {
-					float fvalue = mipsDebug->GetFPR32Value(i);
-					u32 fivalue;
-					memcpy(&fivalue, &fvalue, sizeof(fivalue));
-					ImGui::TableNextRow();
-					ImGui::TableNextColumn();
-					ImGui::TextUnformatted(mipsDebug->GetRegName(1, i).c_str());
-					ImGui::TableNextColumn();
-					ImGui::Text("%0.7f", fvalue);
-					ImGui::TableNextColumn();
-					ImGui::Text("%08x", fivalue);
-				}
-
-				ImGui::EndTable();
+			if (Memory::IsValid4AlignedAddress(value)) {
+				ImGui::PushID(index);
+				ImClickableAddress(value, control, index == MIPS_REG_RA ? ImCmd::SHOW_IN_CPU_DISASM : ImCmd::SHOW_IN_MEMORY_VIEWER);
+				ImGui::PopID();
+			} else {
+				ImGui::Text("%08x", value);
 			}
-			ImGui::EndTabItem();
+			if (value >= -1000000 && value <= 1000000) {
+				ImGui::TableSetColumnIndex(2);
+				ImGui::Text("%d", value);
+			}
+			if (diff || disabled) {
+				ImGui::PopStyleColor();
+			}
+		};
+		for (int i = 0; i < 32; i++) {
+			gprLine(i, mipsDebug->GetRegName(0, i).c_str(), mipsDebug->GetGPR32Value(i), prev.gpr[i]);
 		}
-		if (ImGui::BeginTabItem("VFPU")) {
-			ImGui::Text("TODO");
-			ImGui::EndTabItem();
-		}
-		ImGui::EndTabBar();
+		gprLine(32, "hi", mipsDebug->GetHi(), prev.hi);
+		gprLine(33, "lo", mipsDebug->GetLo(), prev.lo);
+		gprLine(34, "pc", mipsDebug->GetPC(), prev.pc);
+		gprLine(35, "ll", mipsDebug->GetLLBit(), prev.ll);
+		ImGui::EndTable();
 	}
+	ImGui::End();
+}
+
+static void DrawFPRs(ImConfig &config, ImControl &control, const MIPSDebugInterface *mipsDebug, const ImSnapshotState &prev) {
+	ImGui::SetNextWindowSize(ImVec2(320, 600), ImGuiCond_FirstUseEver);
+	if (!ImGui::Begin("MIPS FPRs", &config.vfpuOpen)) {
+		ImGui::End();
+		return;
+	}
+	if (ImGui::BeginTable("fpr", 3, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersH)) {
+		ImGui::TableSetupColumn("regname", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("value", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("value_i", ImGuiTableColumnFlags_WidthStretch);
+
+		// fpcond
+		ImGui::TableNextRow();
+		ImGui::TableNextColumn();
+		ImGui::TextUnformatted("fpcond");
+		ImGui::TableNextColumn();
+		ImGui::Text("%08x", mipsDebug->GetFPCond());
+
+		for (int i = 0; i < 32; i++) {
+			float fvalue = mipsDebug->GetFPR32Value(i);
+			u32 fivalue;
+			memcpy(&fivalue, &fvalue, sizeof(fivalue));
+			ImGui::TableNextRow();
+			ImGui::TableNextColumn();
+			ImGui::TextUnformatted(mipsDebug->GetRegName(1, i).c_str());
+			ImGui::TableNextColumn();
+			ImGui::Text("%0.7f", fvalue);
+			ImGui::TableNextColumn();
+			ImGui::Text("%08x", fivalue);
+		}
+
+		ImGui::EndTable();
+	}
+	ImGui::End();
+}
+
+static void DrawVFPU(ImConfig &config, ImControl &control, const MIPSDebugInterface *mipsDebug, const ImSnapshotState &prev) {
+	ImGui::SetNextWindowSize(ImVec2(320, 600), ImGuiCond_FirstUseEver);
+	if (!ImGui::Begin("MIPS FPRs", &config.vfpuOpen)) {
+		ImGui::End();
+		return;
+	}
+	ImGui::Text("TODO");
 	ImGui::End();
 }
 
@@ -910,6 +926,7 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 
 	if (lastCpuStepCount_ != Core_GetSteppingCounter()) {
 		lastCpuStepCount_ = Core_GetSteppingCounter();
+		Snapshot(currentMIPS);
 		disasm_.NotifyStep();
 	}
 
@@ -988,7 +1005,9 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 		}
 		if (ImGui::BeginMenu("CPU")) {
 			ImGui::MenuItem("CPU debugger", nullptr, &cfg_.disasmOpen);
-			ImGui::MenuItem("Registers", nullptr, &cfg_.regsOpen);
+			ImGui::MenuItem("GPR regs", nullptr, &cfg_.gprOpen);
+			ImGui::MenuItem("FPR regs", nullptr, &cfg_.fprOpen);
+			ImGui::MenuItem("VFPU regs", nullptr, &cfg_.vfpuOpen);
 			ImGui::MenuItem("Callstacks", nullptr, &cfg_.callstackOpen);
 			ImGui::MenuItem("Breakpoints", nullptr, &cfg_.breakpointsOpen);
 			ImGui::MenuItem("Scheduler", nullptr, &cfg_.schedulerOpen);
@@ -1049,8 +1068,16 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 		disasm_.Draw(mipsDebug, cfg_, control, coreState);
 	}
 
-	if (cfg_.regsOpen) {
-		DrawRegisterView(cfg_, control, mipsDebug);
+	if (cfg_.gprOpen) {
+		DrawGPRs(cfg_, control, mipsDebug, snapshot_);
+	}
+
+	if (cfg_.fprOpen) {
+		DrawFPRs(cfg_, control, mipsDebug, snapshot_);
+	}
+
+	if (cfg_.vfpuOpen) {
+		DrawVFPU(cfg_, control, mipsDebug, snapshot_);
 	}
 
 	if (cfg_.breakpointsOpen) {
@@ -1156,8 +1183,14 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 	}
 }
 
-void ImDebugger::Snapshot() {
-
+void ImDebugger::Snapshot(MIPSState *mips) {
+	memcpy(snapshot_.gpr, mips->r, sizeof(snapshot_.gpr));
+	memcpy(snapshot_.fpr, mips->fs, sizeof(snapshot_.fpr));
+	memcpy(snapshot_.vpr, mips->v, sizeof(snapshot_.vpr));
+	snapshot_.pc = mips->pc;
+	snapshot_.lo = mips->lo;
+	snapshot_.hi = mips->hi;
+	snapshot_.ll = mips->llBit;
 }
 
 void ImMemWindow::Draw(MIPSDebugInterface *mipsDebug, ImConfig &cfg, ImControl &control, int index) {
@@ -1450,7 +1483,9 @@ void ImConfig::SyncConfig(IniFile *ini, bool save) {
 	sync.SetSection(ini->GetOrCreateSection("Windows"));
 	sync.Sync("disasmOpen", &disasmOpen, true);
 	sync.Sync("demoOpen ", &demoOpen, false);
-	sync.Sync("regsOpen", &regsOpen, true);
+	sync.Sync("gprOpen", &gprOpen, false);
+	sync.Sync("fprOpen", &fprOpen, false);
+	sync.Sync("vfpuOpen", &vfpuOpen, false);
 	sync.Sync("threadsOpen", &threadsOpen, false);
 	sync.Sync("callstackOpen", &callstackOpen, false);
 	sync.Sync("breakpointsOpen", &breakpointsOpen, false);

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -176,7 +176,7 @@ static void DrawGPRs(ImConfig &config, ImControl &control, const MIPSDebugInterf
 
 static void DrawFPRs(ImConfig &config, ImControl &control, const MIPSDebugInterface *mipsDebug, const ImSnapshotState &prev) {
 	ImGui::SetNextWindowSize(ImVec2(320, 600), ImGuiCond_FirstUseEver);
-	if (!ImGui::Begin("MIPS FPRs", &config.vfpuOpen)) {
+	if (!ImGui::Begin("MIPS FPRs", &config.fprOpen)) {
 		ImGui::End();
 		return;
 	}
@@ -197,15 +197,26 @@ static void DrawFPRs(ImConfig &config, ImControl &control, const MIPSDebugInterf
 
 		for (int i = 0; i < 32; i++) {
 			float fvalue = mipsDebug->GetFPR32Value(i);
+			float prevValue = prev.fpr[i];
+
+			// NOTE: Using memcmp to avoid NaN problems.
+			bool diff = memcmp(&fvalue, &prevValue, 4) != 0 && !noDiff;
+
 			u32 fivalue;
 			memcpy(&fivalue, &fvalue, sizeof(fivalue));
 			ImGui::TableNextRow();
 			ImGui::TableNextColumn();
+			if (diff) {
+				ImGui::PushStyleColor(ImGuiCol_Text, ImDebuggerColor_Diff);
+			}
 			ImGui::TextUnformatted(mipsDebug->GetRegName(1, i).c_str());
 			ImGui::TableNextColumn();
 			ImGui::Text("%0.7f", fvalue);
 			ImGui::TableNextColumn();
 			ImGui::Text("%08x", fivalue);
+			if (diff) {
+				ImGui::PopStyleColor();
+			}
 		}
 
 		ImGui::EndTable();
@@ -215,7 +226,7 @@ static void DrawFPRs(ImConfig &config, ImControl &control, const MIPSDebugInterf
 
 static void DrawVFPU(ImConfig &config, ImControl &control, const MIPSDebugInterface *mipsDebug, const ImSnapshotState &prev) {
 	ImGui::SetNextWindowSize(ImVec2(320, 600), ImGuiCond_FirstUseEver);
-	if (!ImGui::Begin("MIPS FPRs", &config.vfpuOpen)) {
+	if (!ImGui::Begin("MIPS VFPU regs", &config.vfpuOpen)) {
 		ImGui::End();
 		return;
 	}

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -199,6 +199,7 @@ private:
 	ImMemWindow mem_[4];  // We support 4 separate instances of the memory viewer.
 	ImStructViewer structViewer_;
 
+	ImSnapshotState newSnapshot_;
 	ImSnapshotState snapshot_;
 
 	int lastCpuStepCount_ = -1;

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -99,12 +99,25 @@ private:
 	u32 gotoAddr_ = 0x08800000;
 };
 
+// Snapshot of the MIPS CPU and other things we want to show diffs off.
+struct ImSnapshotState {
+	u32 gpr[32];
+	float fpr[32];
+	float vpr[128];
+	u32 pc;
+	u32 lo;
+	u32 hi;
+	u32 ll;
+};
+
 struct ImConfig {
 	// Defaults for saved settings are set in SyncConfig.
 
 	bool disasmOpen;
 	bool demoOpen;
-	bool regsOpen;
+	bool gprOpen;
+	bool fprOpen;
+	bool vfpuOpen;
 	bool threadsOpen;
 	bool callstackOpen;
 	bool breakpointsOpen;
@@ -173,7 +186,7 @@ public:
 
 	// Should be called just before starting a step or run, so that things can
 	// save state that they can later compare with, to highlight changes.
-	void Snapshot();
+	void Snapshot(MIPSState *mips);
 
 private:
 	Path ConfigPath();
@@ -185,6 +198,8 @@ private:
 	ImGeStateWindow geStateWindow_;
 	ImMemWindow mem_[4];  // We support 4 separate instances of the memory viewer.
 	ImStructViewer structViewer_;
+
+	ImSnapshotState snapshot_;
 
 	int lastCpuStepCount_ = -1;
 	int lastGpuStepCount_ = -1;

--- a/UI/ImDebugger/ImGe.cpp
+++ b/UI/ImDebugger/ImGe.cpp
@@ -791,7 +791,7 @@ void ImGeStateWindow::Draw(ImConfig &cfg, ImControl &control, GPUDebugInterface 
 
 						const bool enabled = info.enableCmd == 0 || (gstate.cmdmem[info.enableCmd] & 1) == 1;
 						if (diff) {
-							ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 96, 32, enabled ? 255 : 128));
+							ImGui::PushStyleColor(ImGuiCol_Text, enabled ? ImDebuggerColor_Diff : ImDebuggerColor_DiffAlpha);
 						} else if (!enabled) {
 							ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(255, 255, 255, 128));
 						}

--- a/UI/ImDebugger/ImGe.h
+++ b/UI/ImDebugger/ImGe.h
@@ -10,6 +10,9 @@ struct ImControl;
 class FramebufferManagerCommon;
 class TextureCacheCommon;
 
+constexpr ImU32 ImDebuggerColor_Diff = IM_COL32(255, 96, 32, 255);
+constexpr ImU32 ImDebuggerColor_DiffAlpha = IM_COL32(255, 96, 32, 128);
+
 void DrawFramebuffersWindow(ImConfig &cfg, FramebufferManagerCommon *framebufferManager);
 void DrawTexturesWindow(ImConfig &cfg, TextureCacheCommon *textureCache);
 void DrawDisplayWindow(ImConfig &cfg, FramebufferManagerCommon *framebufferManager);

--- a/ext/imgui/imgui_impl_thin3d.cpp
+++ b/ext/imgui/imgui_impl_thin3d.cpp
@@ -49,6 +49,10 @@ static BackendData *ImGui_ImplThin3d_GetBackendData() {
 
 // Render function
 void ImGui_ImplThin3d_RenderDrawData(ImDrawData* draw_data, Draw::DrawContext *draw) {
+	if (!draw_data) {
+		// Possible race condition.
+		return;
+	}
 	// Avoid rendering when minimized, scale coordinates for retina displays (screen coordinates != framebuffer coordinates)
 	int fb_width = (int)(draw_data->DisplaySize.x * draw_data->FramebufferScale.x);
 	int fb_height = (int)(draw_data->DisplaySize.y * draw_data->FramebufferScale.y);


### PR DESCRIPTION
Fixes "Draw" stepping, now works better than before (instead of stopping after the draw, it now stops at the first PRIM after a flush, which is more interesting).

Also lots of minor improvements to the debuggers.