### PR TITLE
Android joystick event handling: Don't blow up java ref counting by forgetting ReleaseElements.

### DIFF
--- a/Common/Render/Text/draw_text_android.cpp
+++ b/Common/Render/Text/draw_text_android.cpp
@@ -170,7 +170,7 @@ bool TextDrawerAndroid::DrawStringBitmap(std::vector<uint8_t> &bitmapData, TextS
 	} else {
 		_assert_msg_(false, "Bad TextDrawer format");
 	}
-	env->ReleaseIntArrayElements(imageData, jimage, 0);
+	env->ReleaseIntArrayElements(imageData, jimage, JNI_ABORT);
 	env->DeleteLocalRef(imageData);
 	return true;
 }

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1290,6 +1290,8 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeApp_joystickAxis(
 	}
 	NativeAxis(axis, count);
 	delete[] axis;
+	env->ReleaseIntArrayElements(axisIds, axisIdBuffer, JNI_ABORT);  // ABORT just means we don't want changes copied back!
+	env->ReleaseFloatArrayElements(values, valueBuffer, JNI_ABORT);  // ABORT just means we don't want changes copied back!
 }
 
 extern "C" jboolean Java_org_ppsspp_ppsspp_NativeApp_mouseWheelEvent(


### PR DESCRIPTION
Also, use JNI_ABORT to avoid writing back changes (we don't make any). Do this optimization for Android font rendering too.

Fixes #19737 