### PR TITLE
Cleanup: Avoid looking up the decoder multiple times per draw

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -27,6 +27,7 @@
 #include "GPU/Common/DrawEngineCommon.h"
 #include "GPU/Common/SplineCommon.h"
 #include "GPU/Common/VertexDecoderCommon.h"
+#include "GPU/Common/SoftwareTransformCommon.h"
 #include "GPU/ge_constants.h"
 #include "GPU/GPUState.h"
 
@@ -140,7 +141,7 @@ u32 DrawEngineCommon::NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr,
 	VertexDecoder *dec = GetVertexDecoder(vertTypeID);
 	if (vertexSize)
 		*vertexSize = dec->VertexSize();
-	return DrawEngineCommon::NormalizeVertices(outPtr, bufPtr, inPtr, dec, lowerBound, upperBound, vertType);
+	return ::NormalizeVertices(outPtr, bufPtr, inPtr, lowerBound, upperBound, dec, vertType);
 }
 
 void DrawEngineCommon::DispatchSubmitImm(GEPrimitiveType prim, TransformedVertex *buffer, int vertexCount, int cullMode, bool continuation) {
@@ -748,109 +749,6 @@ bool DrawEngineCommon::GetCurrentSimpleVertices(int count, std::vector<GPUDebugV
 	gstate_c.vertexFullAlpha = savedVertexFullAlpha;
 
 	return true;
-}
-
-// This normalizes a set of vertices in any format to SimpleVertex format, by processing away morphing AND skinning.
-// The rest of the transform pipeline like lighting will go as normal, either hardware or software.
-// The implementation is initially a bit inefficient but shouldn't be a big deal.
-// An intermediate buffer of not-easy-to-predict size is stored at bufPtr.
-u32 DrawEngineCommon::NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, VertexDecoder *dec, int lowerBound, int upperBound, u32 vertType) {
-	// First, decode the vertices into a GPU compatible format. This step can be eliminated but will need a separate
-	// implementation of the vertex decoder.
-	dec->DecodeVerts(bufPtr, inPtr, &gstate_c.uv, lowerBound, upperBound);
-
-	// OK, morphing eliminated but bones still remain to be taken care of.
-	// Let's do a partial software transform where we only do skinning.
-
-	VertexReader reader(bufPtr, dec->GetDecVtxFmt(), vertType);
-
-	SimpleVertex *sverts = (SimpleVertex *)outPtr;
-
-	const u8 defaultColor[4] = {
-		(u8)gstate.getMaterialAmbientR(),
-		(u8)gstate.getMaterialAmbientG(),
-		(u8)gstate.getMaterialAmbientB(),
-		(u8)gstate.getMaterialAmbientA(),
-	};
-
-	// Let's have two separate loops, one for non skinning and one for skinning.
-	if (!dec->skinInDecode && (vertType & GE_VTYPE_WEIGHT_MASK) != GE_VTYPE_WEIGHT_NONE) {
-		int numBoneWeights = vertTypeGetNumBoneWeights(vertType);
-		for (int i = lowerBound; i <= upperBound; i++) {
-			reader.Goto(i - lowerBound);
-			SimpleVertex &sv = sverts[i];
-			if (vertType & GE_VTYPE_TC_MASK) {
-				reader.ReadUV(sv.uv);
-			}
-
-			if (vertType & GE_VTYPE_COL_MASK) {
-				sv.color_32 = reader.ReadColor0_8888();
-			} else {
-				memcpy(sv.color, defaultColor, 4);
-			}
-
-			float nrm[3], pos[3];
-			float bnrm[3], bpos[3];
-
-			if (vertType & GE_VTYPE_NRM_MASK) {
-				// Normals are generated during tessellation anyway, not sure if any need to supply
-				reader.ReadNrm(nrm);
-			} else {
-				nrm[0] = 0;
-				nrm[1] = 0;
-				nrm[2] = 1.0f;
-			}
-			reader.ReadPos(pos);
-
-			// Apply skinning transform directly
-			float weights[8];
-			reader.ReadWeights(weights);
-			// Skinning
-			Vec3Packedf psum(0, 0, 0);
-			Vec3Packedf nsum(0, 0, 0);
-			for (int w = 0; w < numBoneWeights; w++) {
-				if (weights[w] != 0.0f) {
-					Vec3ByMatrix43(bpos, pos, gstate.boneMatrix + w * 12);
-					Vec3Packedf tpos(bpos);
-					psum += tpos * weights[w];
-
-					Norm3ByMatrix43(bnrm, nrm, gstate.boneMatrix + w * 12);
-					Vec3Packedf tnorm(bnrm);
-					nsum += tnorm * weights[w];
-				}
-			}
-			sv.pos = psum;
-			sv.nrm = nsum;
-		}
-	} else {
-		for (int i = lowerBound; i <= upperBound; i++) {
-			reader.Goto(i - lowerBound);
-			SimpleVertex &sv = sverts[i];
-			if (vertType & GE_VTYPE_TC_MASK) {
-				reader.ReadUV(sv.uv);
-			} else {
-				sv.uv[0] = 0.0f;  // This will get filled in during tessellation
-				sv.uv[1] = 0.0f;
-			}
-			if (vertType & GE_VTYPE_COL_MASK) {
-				sv.color_32 = reader.ReadColor0_8888();
-			} else {
-				memcpy(sv.color, defaultColor, 4);
-			}
-			if (vertType & GE_VTYPE_NRM_MASK) {
-				// Normals are generated during tessellation anyway, not sure if any need to supply
-				reader.ReadNrm((float *)&sv.nrm);
-			} else {
-				sv.nrm.x = 0.0f;
-				sv.nrm.y = 0.0f;
-				sv.nrm.z = 1.0f;
-			}
-			reader.ReadPos((float *)&sv.pos);
-		}
-	}
-
-	// Okay, there we are! Return the new type (but keep the index bits)
-	return GE_VTYPE_TC_FLOAT | GE_VTYPE_COL_8888 | GE_VTYPE_NRM_FLOAT | GE_VTYPE_POS_FLOAT | (vertType & (GE_VTYPE_IDX_MASK | GE_VTYPE_THROUGH));
 }
 
 void DrawEngineCommon::ApplyFramebufferRead(FBOTexState *fboTexState) {

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -119,7 +119,6 @@ void DrawEngineCommon::NotifyConfigChanged() {
 		delete decoder;
 	});
 	decoderMap_.Clear();
-	ClearTrackedVertexArrays();
 
 	useHWTransform_ = g_Config.bHardwareTransform;
 	useHWTessellation_ = UpdateUseHWTessellation(g_Config.bHardwareTessellation);

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -107,9 +107,13 @@ public:
 	bool TestBoundingBoxFast(const void *control_points, int vertexCount, u32 vertType);
 	bool TestBoundingBoxThrough(const void *vdata, int vertexCount, u32 vertType);
 
+	void FlushPartialDecode() {
+		DecodeVerts(dec_, decoded_);
+	}
+
 	void FlushSkin() {
 		if (dec_->skinInDecode) {
-			DecodeVerts(dec_, decoded_);
+			FlushPartialDecode();
 		}
 	}
 

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -88,8 +88,6 @@ public:
 
 	bool GetCurrentSimpleVertices(int count, std::vector<GPUDebugVertex> &vertices, std::vector<u16> &indices);
 
-	static u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, VertexDecoder *dec, int lowerBound, int upperBound, u32 vertType);
-
 	// Dispatches the queued-up draws.
 	virtual void Flush() = 0;
 

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -156,8 +156,6 @@ public:
 		return dec;
 	}
 
-	virtual void ClearTrackedVertexArrays() {}
-
 	void AssertEmpty() {
 		_dbg_assert_(numDrawVerts_ == 0 && numDrawInds_ == 0);
 	}

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -95,7 +95,8 @@ public:
 	// is different. Should probably refactor that.
 	// Note that vertTypeID should be computed using GetVertTypeID().
 	virtual void DispatchSubmitPrim(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, bool clockwise, int *bytesRead) {
-		SubmitPrim(verts, inds, prim, vertexCount, vertTypeID, clockwise, bytesRead);
+		VertexDecoder *dec = GetVertexDecoder(vertTypeID);
+		SubmitPrim(verts, inds, prim, vertexCount, dec, vertTypeID, clockwise, bytesRead);
 	}
 
 	virtual void DispatchSubmitImm(GEPrimitiveType prim, TransformedVertex *buffer, int vertexCount, int cullMode, bool continuation);
@@ -118,7 +119,7 @@ public:
 	}
 
 	int ExtendNonIndexedPrim(const uint32_t *cmd, const uint32_t *stall, u32 vertTypeID, bool clockwise, int *bytesRead, bool isTriangle);
-	bool SubmitPrim(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, u32 vertTypeID, bool clockwise, int *bytesRead);
+	bool SubmitPrim(const void *verts, const void *inds, GEPrimitiveType prim, int vertexCount, VertexDecoder *dec, u32 vertTypeID, bool clockwise, int *bytesRead);
 	void SkipPrim(GEPrimitiveType prim, int vertexCount, u32 vertTypeID, int *bytesRead);
 
 	template<class Surface>
@@ -145,14 +146,14 @@ public:
 		return numDrawVerts_;
 	}
 
-	VertexDecoder *GetVertexDecoder(u32 vtype) {
+	VertexDecoder *GetVertexDecoder(u32 vertTypeID) {
 		VertexDecoder *dec;
-		if (decoderMap_.Get(vtype, &dec))
+		if (decoderMap_.Get(vertTypeID, &dec))
 			return dec;
 		dec = new VertexDecoder();
 		_assert_(dec);
-		dec->SetVertexType(vtype, decOptions_, decJitCache_);
-		decoderMap_.Insert(vtype, dec);
+		dec->SetVertexType(vertTypeID, decOptions_, decJitCache_);
+		decoderMap_.Insert(vertTypeID, dec);
 		return dec;
 	}
 

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -141,7 +141,16 @@ public:
 		return numDrawVerts_;
 	}
 
-	VertexDecoder *GetVertexDecoder(u32 vtype);
+	VertexDecoder *GetVertexDecoder(u32 vtype) {
+		VertexDecoder *dec;
+		if (decoderMap_.Get(vtype, &dec))
+			return dec;
+		dec = new VertexDecoder();
+		_assert_(dec);
+		dec->SetVertexType(vtype, decOptions_, decJitCache_);
+		decoderMap_.Insert(vtype, dec);
+		return dec;
+	}
 
 	virtual void ClearTrackedVertexArrays() {}
 
@@ -155,9 +164,6 @@ protected:
 
 	void DecodeVerts(VertexDecoder *dec, u8 *dest);
 	int DecodeInds();
-
-	// Preprocessing for spline/bezier
-	u32 NormalizeVertices(SimpleVertex *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, u32 vertType, int *vertexSize = nullptr);
 
 	int ComputeNumVertsToDecode() const;
 

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -157,7 +157,7 @@ protected:
 	int DecodeInds();
 
 	// Preprocessing for spline/bezier
-	u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, u32 vertType, int *vertexSize = nullptr);
+	u32 NormalizeVertices(SimpleVertex *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, u32 vertType, int *vertexSize = nullptr);
 
 	int ComputeNumVertsToDecode() const;
 

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -939,7 +939,7 @@ bool SoftwareTransform::ExpandPoints(int vertexCount, int &maxIndex, int vertsSi
 // The rest of the transform pipeline like lighting will go as normal, either hardware or software.
 // The implementation is initially a bit inefficient but shouldn't be a big deal.
 // An intermediate buffer of not-easy-to-predict size is stored at bufPtr.
-u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, VertexDecoder *dec, u32 vertType) {
+u32 NormalizeVertices(SimpleVertex *sverts, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, VertexDecoder *dec, u32 vertType) {
 	// First, decode the vertices into a GPU compatible format. This step can be eliminated but will need a separate
 	// implementation of the vertex decoder.
 	dec->DecodeVerts(bufPtr, inPtr, &gstate_c.uv, lowerBound, upperBound);
@@ -948,8 +948,6 @@ u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, i
 	// Let's do a partial software transform where we only do skinning.
 
 	VertexReader reader(bufPtr, dec->GetDecVtxFmt(), vertType);
-
-	SimpleVertex *sverts = (SimpleVertex *)outPtr;
 
 	const u8 defaultColor[4] = {
 		(u8)gstate.getMaterialAmbientR(),

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -934,3 +934,106 @@ bool SoftwareTransform::ExpandPoints(int vertexCount, int &maxIndex, int vertsSi
 	inds = newInds;
 	return true;
 }
+
+// This normalizes a set of vertices in any format to SimpleVertex format, by processing away morphing AND skinning.
+// The rest of the transform pipeline like lighting will go as normal, either hardware or software.
+// The implementation is initially a bit inefficient but shouldn't be a big deal.
+// An intermediate buffer of not-easy-to-predict size is stored at bufPtr.
+u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, VertexDecoder *dec, u32 vertType) {
+	// First, decode the vertices into a GPU compatible format. This step can be eliminated but will need a separate
+	// implementation of the vertex decoder.
+	dec->DecodeVerts(bufPtr, inPtr, &gstate_c.uv, lowerBound, upperBound);
+
+	// OK, morphing eliminated but bones still remain to be taken care of.
+	// Let's do a partial software transform where we only do skinning.
+
+	VertexReader reader(bufPtr, dec->GetDecVtxFmt(), vertType);
+
+	SimpleVertex *sverts = (SimpleVertex *)outPtr;
+
+	const u8 defaultColor[4] = {
+		(u8)gstate.getMaterialAmbientR(),
+		(u8)gstate.getMaterialAmbientG(),
+		(u8)gstate.getMaterialAmbientB(),
+		(u8)gstate.getMaterialAmbientA(),
+	};
+
+	// Let's have two separate loops, one for non skinning and one for skinning.
+	if (!dec->skinInDecode && (vertType & GE_VTYPE_WEIGHT_MASK) != GE_VTYPE_WEIGHT_NONE) {
+		int numBoneWeights = vertTypeGetNumBoneWeights(vertType);
+		for (int i = lowerBound; i <= upperBound; i++) {
+			reader.Goto(i - lowerBound);
+			SimpleVertex &sv = sverts[i];
+			if (vertType & GE_VTYPE_TC_MASK) {
+				reader.ReadUV(sv.uv);
+			}
+
+			if (vertType & GE_VTYPE_COL_MASK) {
+				sv.color_32 = reader.ReadColor0_8888();
+			} else {
+				memcpy(sv.color, defaultColor, 4);
+			}
+
+			float nrm[3], pos[3];
+			float bnrm[3], bpos[3];
+
+			if (vertType & GE_VTYPE_NRM_MASK) {
+				// Normals are generated during tessellation anyway, not sure if any need to supply
+				reader.ReadNrm(nrm);
+			} else {
+				nrm[0] = 0;
+				nrm[1] = 0;
+				nrm[2] = 1.0f;
+			}
+			reader.ReadPos(pos);
+
+			// Apply skinning transform directly
+			float weights[8];
+			reader.ReadWeights(weights);
+			// Skinning
+			Vec3Packedf psum(0, 0, 0);
+			Vec3Packedf nsum(0, 0, 0);
+			for (int w = 0; w < numBoneWeights; w++) {
+				if (weights[w] != 0.0f) {
+					Vec3ByMatrix43(bpos, pos, gstate.boneMatrix + w * 12);
+					Vec3Packedf tpos(bpos);
+					psum += tpos * weights[w];
+
+					Norm3ByMatrix43(bnrm, nrm, gstate.boneMatrix + w * 12);
+					Vec3Packedf tnorm(bnrm);
+					nsum += tnorm * weights[w];
+				}
+			}
+			sv.pos = psum;
+			sv.nrm = nsum;
+		}
+	} else {
+		for (int i = lowerBound; i <= upperBound; i++) {
+			reader.Goto(i - lowerBound);
+			SimpleVertex &sv = sverts[i];
+			if (vertType & GE_VTYPE_TC_MASK) {
+				reader.ReadUV(sv.uv);
+			} else {
+				sv.uv[0] = 0.0f;  // This will get filled in during tessellation
+				sv.uv[1] = 0.0f;
+			}
+			if (vertType & GE_VTYPE_COL_MASK) {
+				sv.color_32 = reader.ReadColor0_8888();
+			} else {
+				memcpy(sv.color, defaultColor, 4);
+			}
+			if (vertType & GE_VTYPE_NRM_MASK) {
+				// Normals are generated during tessellation anyway, not sure if any need to supply
+				reader.ReadNrm((float *)&sv.nrm);
+			} else {
+				sv.nrm.x = 0.0f;
+				sv.nrm.y = 0.0f;
+				sv.nrm.z = 1.0f;
+			}
+			reader.ReadPos((float *)&sv.pos);
+		}
+	}
+
+	// Okay, there we are! Return the new type (but keep the index bits)
+	return GE_VTYPE_TC_FLOAT | GE_VTYPE_COL_8888 | GE_VTYPE_NRM_FLOAT | GE_VTYPE_POS_FLOAT | (vertType & (GE_VTYPE_IDX_MASK | GE_VTYPE_THROUGH));
+}

--- a/GPU/Common/SoftwareTransformCommon.h
+++ b/GPU/Common/SoftwareTransformCommon.h
@@ -20,6 +20,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Math/lin/matrix4x4.h"
 #include "GPU/Common/VertexDecoderCommon.h"
+#include "GPU/Common/TransformCommon.h"
 
 class FramebufferManagerCommon;
 class TextureCacheCommon;
@@ -86,4 +87,4 @@ protected:
 };
 
 // Slow. See description in the cpp file.
-u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, VertexDecoder *dec, u32 vertType);
+u32 NormalizeVertices(SimpleVertex *sverts, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, VertexDecoder *dec, u32 vertType);

--- a/GPU/Common/SoftwareTransformCommon.h
+++ b/GPU/Common/SoftwareTransformCommon.h
@@ -84,3 +84,6 @@ protected:
 	const SoftwareTransformParams &params_;
 	Lin::Matrix4x4 projMatrix_;
 };
+
+// Slow. See description in the cpp file.
+u32 NormalizeVertices(u8 *outPtr, u8 *bufPtr, const u8 *inPtr, int lowerBound, int upperBound, VertexDecoder *dec, u32 vertType);

--- a/GPU/Common/SplineCommon.cpp
+++ b/GPU/Common/SplineCommon.cpp
@@ -507,7 +507,8 @@ void DrawEngineCommon::SubmitCurve(const void *control_points, const void *indic
 	if (indices)
 		GetIndexBounds(indices, num_points, vertType, &index_lower_bound, &index_upper_bound);
 
-	VertexDecoder *origVDecoder = GetVertexDecoder(GetVertTypeID(vertType, gstate.getUVGenMode(), applySkinInDecode_));
+	u32 vertTypeID = GetVertTypeID(vertType, gstate.getUVGenMode(), applySkinInDecode_);
+	VertexDecoder *origVDecoder = GetVertexDecoder(vertTypeID);
 	*bytesRead = num_points * origVDecoder->VertexSize();
 
 	// Simplify away bones and morph before proceeding
@@ -525,7 +526,7 @@ void DrawEngineCommon::SubmitCurve(const void *control_points, const void *indic
 	}
 
 	u32 origVertType = vertType;
-	vertType = NormalizeVertices((u8 *)simplified_control_points, temp_buffer, (u8 *)control_points, index_lower_bound, index_upper_bound, vertType);
+	vertType = NormalizeVertices(simplified_control_points, temp_buffer, (u8 *)control_points, index_lower_bound, index_upper_bound, vertType);
 
 	VertexDecoder *vdecoder = GetVertexDecoder(vertType);
 
@@ -574,7 +575,7 @@ void DrawEngineCommon::SubmitCurve(const void *control_points, const void *indic
 		gstate_c.uv.vOff = 0;
 	}
 
-	uint32_t vertTypeID = GetVertTypeID(vertTypeWithIndex16, gstate.getUVGenMode(), applySkinInDecode_);
+	vertTypeID = GetVertTypeID(vertTypeWithIndex16, gstate.getUVGenMode(), applySkinInDecode_);
 	int generatedBytesRead;
 	if (output.count)
 		DispatchSubmitPrim(output.vertices, output.indices, PatchPrimToPrim(surface.primType), output.count, vertTypeID, true, &generatedBytesRead);

--- a/GPU/Common/SplineCommon.cpp
+++ b/GPU/Common/SplineCommon.cpp
@@ -24,6 +24,7 @@
 #include "GPU/Common/GPUStateUtils.h"
 #include "GPU/Common/SplineCommon.h"
 #include "GPU/Common/DrawEngineCommon.h"
+#include "GPU/Common/SoftwareTransformCommon.h"
 #include "GPU/ge_constants.h"
 #include "GPU/GPUState.h"  // only needed for UVScale stuff
 
@@ -526,7 +527,7 @@ void DrawEngineCommon::SubmitCurve(const void *control_points, const void *indic
 	}
 
 	u32 origVertType = vertType;
-	vertType = NormalizeVertices(simplified_control_points, temp_buffer, (u8 *)control_points, index_lower_bound, index_upper_bound, vertType);
+	vertType = ::NormalizeVertices(simplified_control_points, temp_buffer, (u8 *)control_points, index_lower_bound, index_upper_bound, origVDecoder, vertType);
 
 	VertexDecoder *vdecoder = GetVertexDecoder(vertType);
 

--- a/GPU/Common/SplineCommon.h
+++ b/GPU/Common/SplineCommon.h
@@ -22,21 +22,11 @@
 #include "Common/Swap.h"
 #include "GPU/Math3D.h"
 #include "GPU/ge_constants.h"
+#include "GPU/Common/TransformCommon.h"
+
 #include "Core/Config.h"
 
 #define HALF_CEIL(x) (x + 1) / 2 // Integer ceil = (int)ceil((float)x / 2.0f)
-
-// PSP compatible format so we can use the end of the pipeline in beziers etc
-// 8 + 4 + 12 + 12 = 36 bytes
-struct SimpleVertex {
-	float uv[2];
-	union {
-		u8 color[4];
-		u32_le color_32;
-	};
-	Vec3Packedf nrm;
-	Vec3Packedf pos;
-};
 
 class SimpleBufferManager;
 

--- a/GPU/Common/TransformCommon.h
+++ b/GPU/Common/TransformCommon.h
@@ -22,6 +22,7 @@
 #include "Common/CommonTypes.h"
 #include "GPU/ge_constants.h"
 #include "GPU/Math3D.h"
+#include "GPU/GPU.h"
 
 struct Color4 {
 	float r, g, b, a;
@@ -94,3 +95,14 @@ private:
 	float lcolor[3][4][3];
 };
 
+// PSP compatible format so we can use the end of the pipeline in beziers etc
+// 8 + 4 + 12 + 12 = 36 bytes
+struct SimpleVertex {
+	float uv[2];
+	union {
+		u8 color[4];
+		u32_le color_32;
+	};
+	Vec3Packedf nrm;
+	Vec3Packedf pos;
+};

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -115,7 +115,6 @@ void DrawEngineD3D11::DestroyDeviceObjects() {
 		draw_->SetInvalidationCallback(InvalidationCallback());
 	}
 
-	ClearTrackedVertexArrays();
 	ClearInputLayoutMap();
 	delete tessDataTransferD3D11;
 	tessDataTransferD3D11 = nullptr;

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -111,7 +111,6 @@ void DrawEngineDX9::DestroyDeviceObjects() {
 	if (draw_) {
 		draw_->SetInvalidationCallback(InvalidationCallback());
 	}
-	ClearTrackedVertexArrays();
 }
 
 struct DeclTypeInfo {

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -130,8 +130,6 @@ void DrawEngineGLES::DestroyDeviceObjects() {
 		frameData_[i].pushIndex = nullptr;
 	}
 
-	ClearTrackedVertexArrays();
-
 	if (softwareInputLayout_)
 		render_->DeleteInputLayout(softwareInputLayout_);
 	softwareInputLayout_ = nullptr;

--- a/GPU/GLES/DrawEngineGLES.h
+++ b/GPU/GLES/DrawEngineGLES.h
@@ -79,8 +79,6 @@ public:
 	void DeviceLost() override;
 	void DeviceRestore(Draw::DrawContext *draw) override;
 
-	void ClearTrackedVertexArrays() override {}
-
 	void BeginFrame() override;
 	void EndFrame();
 
@@ -103,7 +101,6 @@ private:
 	void InitDeviceObjects();
 	void DestroyDeviceObjects();
 
-	void DoFlush();
 	void ApplyDrawState(int prim);
 	void ApplyDrawStateLate(bool setStencil, int stencilValue);
 

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -997,6 +997,7 @@ void GPUCommonHW::Execute_Prim(u32 op, u32 diff) {
 	int cullMode = gstate.getCullMode();
 
 	uint32_t vertTypeID = GetVertTypeID(vertexType, gstate.getUVGenMode(), g_Config.bSoftwareSkinning);
+	VertexDecoder *decoder = drawEngineCommon_->GetVertexDecoder(vertTypeID);
 
 	// Through mode early-out for simple float 2D draws, like in Fate Extra CCC (very beneficial there due to avoiding texture loads)
 	if ((vertexType & (GE_VTYPE_THROUGH_MASK | GE_VTYPE_POS_MASK | GE_VTYPE_IDX_MASK)) == (GE_VTYPE_THROUGH_MASK | GE_VTYPE_POS_FLOAT | GE_VTYPE_IDX_NONE)) {
@@ -1037,7 +1038,7 @@ void GPUCommonHW::Execute_Prim(u32 op, u32 diff) {
 	// Cuts down on checking, while not losing that much efficiency.
 	bool onePassed = false;
 	if (passCulling) {
-		if (!drawEngineCommon_->SubmitPrim(verts, inds, prim, count, vertTypeID, true, &bytesRead)) {
+		if (!drawEngineCommon_->SubmitPrim(verts, inds, prim, count, decoder, vertTypeID, true, &bytesRead)) {
 			canExtend = false;
 		}
 		onePassed = true;
@@ -1115,7 +1116,7 @@ void GPUCommonHW::Execute_Prim(u32 op, u32 diff) {
 				}
 			}
 			if (passCulling) {
-				if (!drawEngineCommon_->SubmitPrim(verts, inds, newPrim, count, vertTypeID, clockwise, &bytesRead)) {
+				if (!drawEngineCommon_->SubmitPrim(verts, inds, newPrim, count, decoder, vertTypeID, clockwise, &bytesRead)) {
 					canExtend = false;
 				}
 				// As soon as one passes, assume we don't need to check the rest of this batch.
@@ -1140,6 +1141,7 @@ void GPUCommonHW::Execute_Prim(u32 op, u32 diff) {
 				canExtend = false;  // TODO: Might support extending between some vertex types in the future.
 				vertexType = data;
 				vertTypeID = GetVertTypeID(vertexType, gstate.getUVGenMode(), g_Config.bSoftwareSkinning);
+				decoder = drawEngineCommon_->GetVertexDecoder(vertTypeID);
 			}
 			break;
 		}

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -554,7 +554,6 @@ void GPUCommonHW::DoState(PointerWrap &p) {
 	// None of these are necessary when saving.
 	if (p.mode == p.MODE_READ && !PSP_CoreParameter().frozen) {
 		textureCache_->Clear(true);
-		drawEngineCommon_->ClearTrackedVertexArrays();
 
 		gstate_c.Dirty(DIRTY_TEXTURE_IMAGE);
 		framebufferManager_->DestroyAllFBOs();

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -27,6 +27,7 @@
 #include "GPU/GPUState.h"
 #include "GPU/Common/DrawEngineCommon.h"
 #include "GPU/Common/VertexDecoderCommon.h"
+#include "GPU/Common/SoftwareTransformCommon.h"
 #include "GPU/Common/SplineCommon.h"
 #include "GPU/Common/TextureDecoder.h"
 #include "GPU/Debugger/Debugger.h"
@@ -979,7 +980,7 @@ bool TransformUnit::GetCurrentSimpleVertices(int count, std::vector<GPUDebugVert
 	if (!Memory::IsValidRange(gstate_c.vertexAddr, (indexUpperBound + 1) * vdecoder.VertexSize()))
 		return false;
 
-	DrawEngineCommon::NormalizeVertices((u8 *)(&simpleVertices[0]), (u8 *)(&temp_buffer[0]), Memory::GetPointer(gstate_c.vertexAddr), &vdecoder, indexLowerBound, indexUpperBound, gstate.vertType);
+	::NormalizeVertices((u8 *)(&simpleVertices[0]), (u8 *)(&temp_buffer[0]), Memory::GetPointer(gstate_c.vertexAddr), indexLowerBound, indexUpperBound, &vdecoder, gstate.vertType);
 
 	float world[16];
 	float view[16];

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -980,7 +980,7 @@ bool TransformUnit::GetCurrentSimpleVertices(int count, std::vector<GPUDebugVert
 	if (!Memory::IsValidRange(gstate_c.vertexAddr, (indexUpperBound + 1) * vdecoder.VertexSize()))
 		return false;
 
-	::NormalizeVertices((u8 *)(&simpleVertices[0]), (u8 *)(&temp_buffer[0]), Memory::GetPointer(gstate_c.vertexAddr), indexLowerBound, indexUpperBound, &vdecoder, gstate.vertType);
+	::NormalizeVertices(&simpleVertices[0], (u8 *)(&temp_buffer[0]), Memory::GetPointer(gstate_c.vertexAddr), indexLowerBound, indexUpperBound, &vdecoder, gstate.vertType);
 
 	float world[16];
 	float view[16];


### PR DESCRIPTION
We've started to do various pre-processing of vertices like frustum culling of certain draws, which requires the vertex decoder. This was previously managed inside the DrawEngine so if we wanted it before SubmitPrim, we had to look it up separately first.

This change eliminates that lookup overhead. Should be very minor speedup but mainly it's cleaner, and I don't want to add yet another lookup for an upcoming change.