### PR TITLE
Restore removed <algorithm> includes.

### DIFF
--- a/Common/CPUDetect.cpp
+++ b/Common/CPUDetect.cpp
@@ -35,6 +35,7 @@
 #include <cstdint>
 #include <memory.h>
 #include <set>
+#include <algorithm>
 
 #include "Common/Common.h"
 #include "Common/CPUDetect.h"

--- a/Common/Data/Encoding/Utf8.cpp
+++ b/Common/Data/Encoding/Utf8.cpp
@@ -22,7 +22,7 @@
 #include <cstring>
 #include <cstdarg>
 #include <cstdint>
-
+#include <algorithm>
 #include <string>
 
 #include "Common/Data/Encoding/Utf8.h"

--- a/Common/GPU/Vulkan/VulkanImage.cpp
+++ b/Common/GPU/Vulkan/VulkanImage.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "Common/Log.h"
 #include "Common/GPU/Vulkan/VulkanContext.h"
 #include "Common/GPU/Vulkan/VulkanAlloc.h"

--- a/Common/GPU/Vulkan/VulkanImage.h
+++ b/Common/GPU/Vulkan/VulkanImage.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include "VulkanLoader.h"
 
 class VulkanContext;

--- a/Common/GPU/Vulkan/VulkanMemory.cpp
+++ b/Common/GPU/Vulkan/VulkanMemory.cpp
@@ -18,14 +18,11 @@
 // Additionally, Common/Vulkan/* , including this file, are also licensed
 // under the public domain.
 
-#include <set>
-#include <mutex>
-
+#include <algorithm>
 #include "Common/Math/math_util.h"
 
 #include "Common/Log.h"
 #include "Common/TimeUtil.h"
-#include "Common/Math/math_util.h"
 #include "Common/GPU/Vulkan/VulkanMemory.h"
 #include "Common/Data/Text/Parsers.h"
 

--- a/Common/Render/DrawBuffer.cpp
+++ b/Common/Render/DrawBuffer.cpp
@@ -1,5 +1,6 @@
 #include <cmath>
 #include <vector>
+#include <algorithm>
 #include <stddef.h>
 
 #include "Common/System/Display.h"
@@ -578,7 +579,7 @@ void DrawBuffer::DrawTextRect(FontID font, std::string_view text, float x, float
 	float totalWidth, totalHeight;
 	MeasureTextRect(font, toDraw, Bounds(x, y, w, h), &totalWidth, &totalHeight, align);
 
-	std::vector<std::string> lines;
+	std::vector<std::string_view> lines;
 	SplitString(toDraw, '\n', lines);
 
 	float baseY = y;
@@ -591,7 +592,7 @@ void DrawBuffer::DrawTextRect(FontID font, std::string_view text, float x, float
 	}
 
 	// This allows each line to be horizontally centered by itself.
-	for (const std::string &line : lines) {
+	for (std::string_view line : lines) {
 		DrawText(font, line, x, baseY, color, align);
 
 		float tw, th;

--- a/Core/Debugger/MemBlockInfo.cpp
+++ b/Core/Debugger/MemBlockInfo.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include <atomic>
 #include <cstring>
 #include <mutex>

--- a/Core/Dialog/PSPGamedataInstallDialog.cpp
+++ b/Core/Dialog/PSPGamedataInstallDialog.cpp
@@ -15,10 +15,10 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include "Common/CommonTypes.h"
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"
-#include "Common/System/OSD.h"
 #include "Core/ELF/ParamSFO.h"
 #include "Core/MemMapHelpers.h"
 #include "Core/Reporting.h"

--- a/Core/Dialog/PSPMsgDialog.cpp
+++ b/Core/Dialog/PSPMsgDialog.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"
 #include "Common/StringUtils.h"

--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -15,7 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include "Common/CommonWindows.h"
+#include <algorithm>
 #include "Common/TimeUtil.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Serialize/Serializer.h"

--- a/Core/Dialog/PSPNpSigninDialog.cpp
+++ b/Core/Dialog/PSPNpSigninDialog.cpp
@@ -15,9 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#if defined(_WIN32)
-#include "Common/CommonWindows.h"
-#endif
+#include <algorithm>
 #include "Common/TimeUtil.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Serialize/Serializer.h"

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -16,6 +16,10 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "ppsspp_config.h"
+
+#include <cctype>
+#include <cmath>
+#include <algorithm>
 #include "Common/Data/Text/I18n.h"
 #include "Common/Math/math_util.h"
 #include "Common/Data/Encoding/Utf8.h"
@@ -30,11 +34,6 @@
 #include "Core/HW/Display.h"
 #include "Core/Config.h"
 #include "Core/Reporting.h"
-
-#ifndef _WIN32
-#include <ctype.h>
-#include <math.h>
-#endif
 
 // These are rough, it seems to take a long time to init, and probably depends on threads.
 // TODO: This takes like 700ms on a PSP but that's annoyingly long.

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -22,6 +22,8 @@
 #endif
 #endif
 
+
+#include <algorithm>
 #include <thread>
 
 #include "Common/Data/Encoding/Utf8.h"

--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include <memory>
 #include "Common/Log.h"
 #include "Common/Data/Text/I18n.h"

--- a/Core/FileLoaders/CachingFileLoader.cpp
+++ b/Core/FileLoaders/CachingFileLoader.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include <cstring>
 #include <thread>
 

--- a/Core/FileLoaders/DiskCachingFileLoader.cpp
+++ b/Core/FileLoaders/DiskCachingFileLoader.cpp
@@ -17,6 +17,7 @@
 
 #include "ppsspp_config.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <set>
 #include <mutex>

--- a/Core/FileLoaders/RamCachingFileLoader.cpp
+++ b/Core/FileLoaders/RamCachingFileLoader.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include <thread>
 #include <cstring>
 

--- a/Core/FileSystems/BlockDevices.cpp
+++ b/Core/FileSystems/BlockDevices.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include <cstring>
 
 #include "Common/Data/Text/I18n.h"

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include <cstring>
 #include <cstdio>
 

--- a/Core/Font/PGF.cpp
+++ b/Core/Font/PGF.cpp
@@ -20,6 +20,7 @@
 // Thanks to the JPCSP project! This sceFont implementation is basically a C++ take on JPCSP's font code.
 // Some parts, especially in this file, were simply copied, so I guess this really makes this file GPL3.
 
+#include <algorithm>
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"
 #include "Core/MemMap.h"

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -16,6 +16,8 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "ppsspp_config.h"
+
+#include <algorithm>
 #include <map>
 #include <unordered_map>
 

--- a/Core/HW/MemoryStick.cpp
+++ b/Core/HW/MemoryStick.cpp
@@ -15,6 +15,10 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
+#include <string>
+#include <vector>
+#include <string_view>
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"
 #include "Common/File/DiskFree.h"

--- a/Core/HW/StereoResampler.cpp
+++ b/Core/HW/StereoResampler.cpp
@@ -33,6 +33,7 @@
 #define CONTROL_AVG     32.0f
 
 #include "ppsspp_config.h"
+#include <algorithm>
 #include <cstring>
 #include <atomic>
 

--- a/Core/MemMap.cpp
+++ b/Core/MemMap.cpp
@@ -21,6 +21,7 @@
 #include "Common/CommonWindows.h"
 #endif
 
+#include <algorithm>
 #include <mutex>
 
 #include "Common/CommonTypes.h"

--- a/Core/RetroAchievements.cpp
+++ b/Core/RetroAchievements.cpp
@@ -12,7 +12,7 @@
 // md5_hash(PSP_GAME/EBOOT.BIN)
 // hash = md5_finalize()
 
-#include <functional>
+#include <algorithm>
 #include <set>
 #include <string>
 #include <vector>

--- a/Core/Screenshot.cpp
+++ b/Core/Screenshot.cpp
@@ -17,6 +17,8 @@
 
 #include "ppsspp_config.h"
 
+#include <algorithm>
+
 #include <png.h>
 #include "ext/jpge/jpge.h"
 

--- a/GPU/Common/GPUStateUtils.cpp
+++ b/GPU/Common/GPUStateUtils.cpp
@@ -16,6 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "ppsspp_config.h"
+#include <algorithm>
 #include <limits>
 
 #include "Core/ConfigValues.h"

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -15,10 +15,10 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include <cmath>
 #include <set>
 #include <cstdint>
-
 #include "Common/GPU/thin3d.h"
 
 #include "Common/System/Display.h"

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include <cmath>
 
 #include "Common/CPUDetect.h"

--- a/GPU/Common/TextureScalerCommon.cpp
+++ b/GPU/Common/TextureScalerCommon.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/. 
 
+#include <algorithm>
 #include <cstddef>
 #include <cstring>
 #include <cmath>

--- a/GPU/Common/TextureShaderCommon.cpp
+++ b/GPU/Common/TextureShaderCommon.cpp
@@ -15,7 +15,10 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include <map>
+#include <vector>
+#include <string>
 
 #include "Common/StringUtils.h"
 #include "GPU/GPUState.h"

--- a/GPU/Common/VertexDecoderCommon.cpp
+++ b/GPU/Common/VertexDecoderCommon.cpp
@@ -17,6 +17,10 @@
 
 #include "ppsspp_config.h"
 
+#include <algorithm>
+#include <vector>
+#include <string>
+
 #include "Common/CommonTypes.h"
 #include "Common/Data/Convert/ColorConv.h"
 #include "Common/Log.h"

--- a/GPU/D3D11/StateMappingD3D11.cpp
+++ b/GPU/D3D11/StateMappingD3D11.cpp
@@ -18,6 +18,7 @@
 #include <d3d11.h>
 #include <d3d11_1.h>
 
+#include <algorithm>
 
 #include "Common/Data/Convert/SmallDataConvert.h"
 

--- a/Windows/Debugger/CtrlDisAsmView.h
+++ b/Windows/Debugger/CtrlDisAsmView.h
@@ -14,8 +14,11 @@
 // To get a class instance to be able to access it, just use 
 //   CtrlDisAsmView::getFrom(GetDlgItem(yourdialog, IDC_yourid)).
 
+#include <algorithm>
 #include <vector>
+#include <string>
 #include <set>
+#include <map>
 
 #include "Common/CommonWindows.h"
 #include "Common/Log.h"


### PR DESCRIPTION
Turns out these were needed after all. For some reason, on Windows and Mac, <algorithm> gets auto-included by something else so I don't notice when it's missing, and MSVC's include dependency tracker doesn't see it either.