### PR TITLE
SIMD include cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -781,7 +781,8 @@ add_library(Common STATIC
 	Common/Input/InputState.cpp
 	Common/Input/InputState.h
 	Common/Math/fast/fast_matrix.c
-	Common/Math/CrossSIMD.h
+	Common/Math/SIMDHeaders.h
+	Common/Math/SIMDHeaders.h
 	Common/Math/curves.cpp
 	Common/Math/curves.h
 	Common/Math/expression_parser.cpp

--- a/Common/Common.h
+++ b/Common/Common.h
@@ -87,17 +87,3 @@
 
 #define __forceinline inline __attribute__((always_inline))
 #endif
-
-#if defined __SSE4_2__
-# define _M_SSE 0x402
-#elif defined __SSE4_1__
-# define _M_SSE 0x401
-#elif defined __SSSE3__
-# define _M_SSE 0x301
-#elif defined __SSE3__
-# define _M_SSE 0x300
-#elif defined __SSE2__
-# define _M_SSE 0x200
-#elif !defined(__GNUC__) && (defined(_M_X64) || defined(_M_IX86))
-# define _M_SSE 0x402
-#endif

--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -541,6 +541,7 @@
     <ClInclude Include="Math\lin\matrix4x4.h" />
     <ClInclude Include="Math\lin\vec3.h" />
     <ClInclude Include="Math\math_util.h" />
+    <ClInclude Include="Math\SIMDHeaders.h" />
     <ClInclude Include="Math\Statistics.h" />
     <ClInclude Include="Net\HTTPNaettRequest.h" />
     <ClInclude Include="Net\NetBuffer.h" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -676,6 +676,9 @@
     <ClInclude Include="Data\Collections\LinkedList.h">
       <Filter>Data\Collections</Filter>
     </ClInclude>
+    <ClInclude Include="Math\SIMDHeaders.h">
+      <Filter>Math</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />

--- a/Common/Data/Convert/SmallDataConvert.h
+++ b/Common/Data/Convert/SmallDataConvert.h
@@ -6,7 +6,7 @@
 
 #include "Common/Common.h"
 #include "ppsspp_config.h"
-#include "Common/Math/CrossSIMD.h"
+#include "Common/Math/SIMDHeaders.h"
 
 
 extern const float one_over_255_x4[4];

--- a/Common/Math/CrossSIMD.h
+++ b/Common/Math/CrossSIMD.h
@@ -1,67 +1,8 @@
 // CrossSIMD
 //
-// Compatibility wrappers for SIMD dialects.
-//
-// In the long run, might do a more general single-source-SIMD wrapper here consisting
-// of defines that translate to either NEON or SSE. It would be possible to write quite a lot of
-// our various color conversion functions and so on in a pretty generic manner.
+// This file will contain cross-instruction-set SIMD instruction wrappers.
 
 #pragma once
 
-#include "ppsspp_config.h"
+#include "Common/Math/SIMDHeaders.h"
 
-#include "stdint.h"
-
-#ifdef __clang__
-// Weird how you can't just use #pragma in a macro.
-#define DO_NOT_VECTORIZE_LOOP _Pragma("clang loop vectorize(disable)")
-#else
-#define DO_NOT_VECTORIZE_LOOP
-#endif
-
-#if PPSSPP_ARCH(SSE2)
-#include <emmintrin.h>
-#endif
-
-#if PPSSPP_ARCH(ARM_NEON)
-#if defined(_MSC_VER) && PPSSPP_ARCH(ARM64)
-#include <arm64_neon.h>
-#else
-#include <arm_neon.h>
-#endif
-#endif
-
-// Basic types
-
-#if PPSSPP_ARCH(ARM64_NEON)
-
-// No special ones here.
-
-#elif PPSSPP_ARCH(ARM_NEON)
-
-// Compatibility wrappers making ARM64 NEON code run on ARM32
-// With optimization on, these should compile down to the optimal code.
-
-static inline float32x4_t vmulq_laneq_f32(float32x4_t a, float32x4_t b, int lane) {
-	switch (lane & 3) {
-	case 0: return vmulq_lane_f32(a, vget_low_f32(b), 0);
-	case 1: return vmulq_lane_f32(a, vget_low_f32(b), 1);
-	case 2: return vmulq_lane_f32(a, vget_high_f32(b), 0);
-	default: return vmulq_lane_f32(a, vget_high_f32(b), 1);
-	}
-}
-
-static inline float32x4_t vmlaq_laneq_f32(float32x4_t a, float32x4_t b, float32x4_t c, int lane) {
-	switch (lane & 3) {
-	case 0: return vmlaq_lane_f32(a, b, vget_low_f32(c), 0);
-	case 1: return vmlaq_lane_f32(a, b, vget_low_f32(c), 1);
-	case 2: return vmlaq_lane_f32(a, b, vget_high_f32(c), 0);
-	default: return vmlaq_lane_f32(a, b, vget_high_f32(c), 1);
-	}
-}
-
-static inline uint32x4_t vcgezq_f32(float32x4_t v) {
-	return vcgeq_f32(v, vdupq_n_f32(0.0f));
-}
-
-#endif

--- a/Common/Math/SIMDHeaders.h
+++ b/Common/Math/SIMDHeaders.h
@@ -67,6 +67,20 @@ static inline uint32x4_t vcgezq_f32(float32x4_t v) {
 
 #if PPSSPP_ARCH(SSE2)
 
+#if defined __SSE4_2__
+# define _M_SSE 0x402
+#elif defined __SSE4_1__
+# define _M_SSE 0x401
+#elif defined __SSSE3__
+# define _M_SSE 0x301
+#elif defined __SSE3__
+# define _M_SSE 0x300
+#elif defined __SSE2__
+# define _M_SSE 0x200
+#elif !defined(__GNUC__) && (defined(_M_X64) || defined(_M_IX86))
+# define _M_SSE 0x402
+#endif
+
 // These are SSE2 versions of SSE4.1 instructions, for compatibility and ease of
 // writing code.
 // May later figure out how to use the appropriate ones depending on compile flags.

--- a/Common/Math/SIMDHeaders.h
+++ b/Common/Math/SIMDHeaders.h
@@ -64,3 +64,54 @@ static inline uint32x4_t vcgezq_f32(float32x4_t v) {
 }
 
 #endif
+
+#if PPSSPP_ARCH(SSE2)
+
+// These are SSE2 versions of SSE4.1 instructions, for compatibility and ease of
+// writing code.
+// May later figure out how to use the appropriate ones depending on compile flags.
+
+inline __m128i _mm_mullo_epi32_SSE2(const __m128i v0, const __m128i v1) {
+       __m128i a13 = _mm_shuffle_epi32(v0, 0xF5);             // (-,a3,-,a1)
+       __m128i b13 = _mm_shuffle_epi32(v1, 0xF5);             // (-,b3,-,b1)
+       __m128i prod02 = _mm_mul_epu32(v0, v1);                // (-,a2*b2,-,a0*b0)
+       __m128i prod13 = _mm_mul_epu32(a13, b13);              // (-,a3*b3,-,a1*b1)
+       __m128i prod01 = _mm_unpacklo_epi32(prod02, prod13);   // (-,-,a1*b1,a0*b0)
+       __m128i prod23 = _mm_unpackhi_epi32(prod02, prod13);   // (-,-,a3*b3,a2*b2)
+       return _mm_unpacklo_epi64(prod01, prod23);
+}
+
+inline __m128i _mm_max_epu16_SSE2(const __m128i v0, const __m128i v1) {
+       return _mm_xor_si128(
+               _mm_max_epi16(
+                       _mm_xor_si128(v0, _mm_set1_epi16((int16_t)0x8000)),
+                       _mm_xor_si128(v1, _mm_set1_epi16((int16_t)0x8000))),
+               _mm_set1_epi16((int16_t)0x8000));
+}
+
+inline __m128i _mm_min_epu16_SSE2(const __m128i v0, const __m128i v1) {
+       return _mm_xor_si128(
+               _mm_min_epi16(
+                       _mm_xor_si128(v0, _mm_set1_epi16((int16_t)0x8000)),
+                       _mm_xor_si128(v1, _mm_set1_epi16((int16_t)0x8000))),
+               _mm_set1_epi16((int16_t)0x8000));
+}
+
+// SSE2 replacement for half of a _mm_packus_epi32 but without the saturation.
+inline __m128i _mm_packu_epi32_SSE2(const __m128i v0) {
+	__m128i temp = _mm_shufflelo_epi16(v0, _MM_SHUFFLE(3, 3, 2, 0));
+	__m128 temp2 = _mm_castsi128_ps(_mm_shufflehi_epi16(temp, _MM_SHUFFLE(3, 3, 2, 0)));
+	return _mm_castps_si128(_mm_shuffle_ps(temp2, temp2, _MM_SHUFFLE(3, 3, 2, 0)));
+}
+
+// SSE2 replacement for the entire _mm_packus_epi32 but without the saturation.
+// Not ideal! pshufb would make this faster but that's SSSE3.
+inline __m128i _mm_packu2_epi32_SSE2(const __m128i v0, const __m128i v1) {
+	__m128i a0 = _mm_shufflelo_epi16(v0, _MM_SHUFFLE(3, 3, 2, 0));
+	__m128 packed0 = _mm_castsi128_ps(_mm_shufflehi_epi16(a0, _MM_SHUFFLE(3, 3, 2, 0)));
+	__m128i a1 = _mm_shufflelo_epi16(v1, _MM_SHUFFLE(3, 3, 2, 0));
+	__m128 packed1 = _mm_castsi128_ps(_mm_shufflehi_epi16(a1, _MM_SHUFFLE(3, 3, 2, 0)));
+	return _mm_castps_si128(_mm_shuffle_ps(packed0, packed1, _MM_SHUFFLE(2, 0, 2, 0)));
+}
+
+#endif

--- a/Common/Math/SIMDHeaders.h
+++ b/Common/Math/SIMDHeaders.h
@@ -1,0 +1,66 @@
+#pragma once
+
+// SIMD headers
+// Let's include these in one consistent way across the code base.
+// Here we'll also add wrappers that paper over differences between different versions
+// of an instruction set, like NEON vs ASIMD (64-bit).
+
+#pragma once
+
+#include "ppsspp_config.h"
+
+#include "stdint.h"
+
+#ifdef __clang__
+// Weird how you can't just use #pragma in a macro.
+#define DO_NOT_VECTORIZE_LOOP _Pragma("clang loop vectorize(disable)")
+#else
+#define DO_NOT_VECTORIZE_LOOP
+#endif
+
+#if PPSSPP_ARCH(SSE2)
+#include <emmintrin.h>
+#endif
+
+#if PPSSPP_ARCH(ARM_NEON)
+#if defined(_MSC_VER) && PPSSPP_ARCH(ARM64)
+#include <arm64_neon.h>
+#else
+#include <arm_neon.h>
+#endif
+#endif
+
+// Basic types
+
+#if PPSSPP_ARCH(ARM64_NEON)
+
+// No special ones here.
+
+#elif PPSSPP_ARCH(ARM_NEON)
+
+// Compatibility wrappers making ARM64 NEON code run on ARM32
+// With optimization on, these should compile down to the optimal code.
+
+static inline float32x4_t vmulq_laneq_f32(float32x4_t a, float32x4_t b, int lane) {
+	switch (lane & 3) {
+	case 0: return vmulq_lane_f32(a, vget_low_f32(b), 0);
+	case 1: return vmulq_lane_f32(a, vget_low_f32(b), 1);
+	case 2: return vmulq_lane_f32(a, vget_high_f32(b), 0);
+	default: return vmulq_lane_f32(a, vget_high_f32(b), 1);
+	}
+}
+
+static inline float32x4_t vmlaq_laneq_f32(float32x4_t a, float32x4_t b, float32x4_t c, int lane) {
+	switch (lane & 3) {
+	case 0: return vmlaq_lane_f32(a, b, vget_low_f32(c), 0);
+	case 1: return vmlaq_lane_f32(a, b, vget_low_f32(c), 1);
+	case 2: return vmlaq_lane_f32(a, b, vget_high_f32(c), 0);
+	default: return vmlaq_lane_f32(a, b, vget_high_f32(c), 1);
+	}
+}
+
+static inline uint32x4_t vcgezq_f32(float32x4_t v) {
+	return vcgeq_f32(v, vdupq_n_f32(0.0f));
+}
+
+#endif

--- a/Common/Math/fast/fast_matrix.c
+++ b/Common/Math/fast/fast_matrix.c
@@ -4,9 +4,7 @@
 
 #include "fast_matrix.h"
 
-#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
-
-#include <emmintrin.h>
+#if PPSSPP_ARCH(SSE2)
 
 #include "fast_matrix.h"
 
@@ -27,12 +25,6 @@ void fast_matrix_mul_4x4_sse(float *dest, const float *a, const float *b) {
 }
 
 #elif PPSSPP_ARCH(ARM_NEON)
-
-#if defined(_MSC_VER) && PPSSPP_ARCH(ARM64)
-#include <arm64_neon.h>
-#else
-#include <arm_neon.h>
-#endif
 
 #if PPSSPP_ARCH(ARM)
 static inline float32x4_t vfmaq_laneq_f32(float32x4_t _s, float32x4_t _a, float32x4_t _b, int lane) {

--- a/Common/Math/fast/fast_matrix.c
+++ b/Common/Math/fast/fast_matrix.c
@@ -1,6 +1,6 @@
 #include "ppsspp_config.h"
 
-#include "Common/Math/CrossSIMD.h"
+#include "Common/Math/SIMDHeaders.h"
 
 #include "fast_matrix.h"
 

--- a/Common/TimeUtil.cpp
+++ b/Common/TimeUtil.cpp
@@ -25,7 +25,7 @@
 
 // for _mm_pause
 #if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
-#include <immintrin.h>
+#include <emmintrin.h>
 #endif
 
 #include <ctime>

--- a/Core/HLE/ReplaceTables.cpp
+++ b/Core/HLE/ReplaceTables.cpp
@@ -39,7 +39,7 @@
 #include "GPU/Math3D.h"
 #include "GPU/GPU.h"
 #include "GPU/GPUCommon.h"
-#include "Common/Math/CrossSIMD.h"
+#include "Common/Math/SIMDHeaders.h"
 
 enum class GPUReplacementSkip {
 	MEMSET = 1,

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -24,11 +24,7 @@
 #include "Common/Serialize/SerializeFuncs.h"
 #include "Common/Data/Collections/FixedSizeQueue.h"
 #include "Common/System/System.h"
-
-#ifdef _M_SSE
-#include <emmintrin.h>
-#endif
-
+#include "Common/Math/SIMDHeaders.h"
 #include "Core/Config.h"
 #include "Core/CoreTiming.h"
 #include "Core/MemMapHelpers.h"

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -28,18 +28,6 @@
 
 #include <algorithm>
 
-#ifdef _M_SSE
-#include <emmintrin.h>
-#endif
-
-#if PPSSPP_ARCH(ARM_NEON)
-#if defined(_MSC_VER) && PPSSPP_ARCH(ARM64)
-#include <arm64_neon.h>
-#else
-#include <arm_neon.h>
-#endif
-#endif
-
 #ifdef USE_FFMPEG
 
 extern "C" {

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -16,7 +16,7 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "Common/Serialize/SerializeFuncs.h"
-#include "Common/Math/CrossSIMD.h"
+#include "Common/Math/SIMDHeaders.h"
 #include "Core/System.h"
 #include "Core/Debugger/MemBlockInfo.h"
 #include "Core/HW/MediaEngine.h"

--- a/Core/HW/StereoResampler.cpp
+++ b/Core/HW/StereoResampler.cpp
@@ -40,23 +40,13 @@
 #include "Common/Common.h"
 #include "Common/System/System.h"
 #include "Common/Log.h"
+#include "Common/Math/SIMDHeaders.h"
 #include "Common/TimeUtil.h"
 #include "Core/Config.h"
 #include "Core/ConfigValues.h"
 #include "Core/HW/StereoResampler.h"
 #include "Core/Util/AudioFormat.h"  // for clamp_u8
 #include "Core/System.h"
-
-#ifdef _M_SSE
-#include <emmintrin.h>
-#endif
-#if PPSSPP_ARCH(ARM_NEON)
-#if defined(_MSC_VER) && PPSSPP_ARCH(ARM64)
-#include <arm64_neon.h>
-#else
-#include <arm_neon.h>
-#endif
-#endif
 
 StereoResampler::StereoResampler() noexcept
 		: m_maxBufsize(MAX_BUFSIZE_DEFAULT)

--- a/Core/MIPS/IR/IRInterpreter.cpp
+++ b/Core/MIPS/IR/IRInterpreter.cpp
@@ -7,19 +7,7 @@
 #include "Common/Common.h"
 #include "Common/Data/Convert/SmallDataConvert.h"
 #include "Common/Math/math_util.h"
-
-#ifdef _M_SSE
-#include <emmintrin.h>
-#endif
-
-#if PPSSPP_ARCH(ARM_NEON)
-#if defined(_MSC_VER) && PPSSPP_ARCH(ARM64)
-#include <arm64_neon.h>
-#else
-#include <arm_neon.h>
-#endif
-#endif
-
+#include "Common/Math/SIMDHeaders.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
 #include "Core/Debugger/Breakpoints.h"

--- a/Core/MIPS/MIPSVFPUUtils.cpp
+++ b/Core/MIPS/MIPSVFPUUtils.cpp
@@ -20,6 +20,7 @@
 
 #include "Common/BitScan.h"
 #include "Common/File/VFS/VFS.h"
+#include "Common/Math/SIMDHeaders.h"
 #include "Common/StringUtils.h"
 #include "Core/Reporting.h"
 #include "Core/MIPS/MIPS.h"
@@ -711,9 +712,7 @@ static float vfpu_dot_cpp(const float a[4], const float b[4]) {
 	return result.f;
 }
 
-#if defined(__SSE2__)
-
-#include <emmintrin.h>
+#if PPSSPP_ARCH(SSE2)
 
 static inline __m128i mulhi32x4(__m128i a, __m128i b) {
 	__m128i m02 = _mm_mul_epu32(a, b);
@@ -873,10 +872,10 @@ static float vfpu_dot_sse2(const float a[4], const float b[4])
 	return result.f;
 }
 
-#endif // defined(__SSE2__)
+#endif // PPSSPP_ARCH(SSE2)
 
 float vfpu_dot(const float a[4], const float b[4]) {
-#if defined(__SSE2__)
+#if PPSSPP_ARCH(SSE2)
 	return vfpu_dot_sse2(a, b);
 #else
 	return vfpu_dot_cpp(a, b);

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -19,8 +19,8 @@
 // short instruction sequences. Surprisingly many are possible.
 
 #include "ppsspp_config.h"
-#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 #include <cmath>
 #include <limits>
 #include <emmintrin.h>

--- a/Core/MIPS/x86/CompVFPU.cpp
+++ b/Core/MIPS/x86/CompVFPU.cpp
@@ -23,11 +23,10 @@
 #if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 #include <cmath>
 #include <limits>
-#include <emmintrin.h>
-
 #include "Common/Math/math_util.h"
 
 #include "Common/CPUDetect.h"
+#include "Common/Math/SIMDHeaders.h"
 #include "Common/Log.h"
 #include "Core/Compatibility.h"
 #include "Core/Config.h"

--- a/Core/MIPS/x86/RegCacheFPU.cpp
+++ b/Core/MIPS/x86/RegCacheFPU.cpp
@@ -19,8 +19,7 @@
 #if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 
 #include <cstring>
-#include <emmintrin.h>
-
+#include "Common/Math/SIMDHeaders.h"
 #include "Common/Log.h"
 #include "Common/x64Emitter.h"
 #include "Core/MIPS/MIPSAnalyst.h"

--- a/Core/Util/AudioFormat.cpp
+++ b/Core/Util/AudioFormat.cpp
@@ -19,18 +19,7 @@
 #include "Common/Common.h"
 #include "Common/CPUDetect.h"
 #include "Core/Util/AudioFormat.h"
-
-#ifdef _M_SSE
-#include <emmintrin.h>
-#endif
-
-#if PPSSPP_ARCH(ARM_NEON)
-#if defined(_MSC_VER) && PPSSPP_ARCH(ARM64)
-#include <arm64_neon.h>
-#else
-#include <arm_neon.h>
-#endif
-#endif // PPSSPP_ARCH(ARM_NEON)
+#include "Common/Math/SIMDHeaders.h"
 
 // TODO: This shouldn't be a global.
 #if PPSSPP_ARCH(ARM_NEON)

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -21,7 +21,7 @@
 #include "Common/Data/Convert/ColorConv.h"
 #include "Common/Profiler/Profiler.h"
 #include "Common/LogReporting.h"
-#include "Common/Math/CrossSIMD.h"
+#include "Common/Math/SIMDHeaders.h"
 #include "Common/Math/lin/matrix4x4.h"
 #include "Core/Config.h"
 #include "GPU/Common/DrawEngineCommon.h"

--- a/GPU/Common/IndexGenerator.cpp
+++ b/GPU/Common/IndexGenerator.cpp
@@ -19,7 +19,6 @@
 
 #include "ppsspp_config.h"
 
-#include "Common/Common.h"
 #include "Common/Math/SIMDHeaders.h"
 #include "GPU/Common/IndexGenerator.h"
 

--- a/GPU/Common/IndexGenerator.cpp
+++ b/GPU/Common/IndexGenerator.cpp
@@ -20,7 +20,7 @@
 #include "ppsspp_config.h"
 
 #include "Common/Common.h"
-#include "Common/Math/CrossSIMD.h"
+#include "Common/Math/SIMDHeaders.h"
 #include "GPU/Common/IndexGenerator.h"
 
 // Points don't need indexing...

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -26,6 +26,7 @@
 #include "Common/LogReporting.h"
 #include "Common/MemoryUtil.h"
 #include "Common/StringUtils.h"
+#include "Common/Math/SIMDHeaders.h"
 #include "Common/TimeUtil.h"
 #include "Common/Math/math_util.h"
 #include "Common/GPU/thin3d.h"
@@ -45,18 +46,6 @@
 #include "ext/imgui/imgui.h"
 #include "ext/imgui/imgui_internal.h"
 #include "ext/imgui/imgui_impl_thin3d.h"
-
-
-#if defined(_M_SSE)
-#include <emmintrin.h>
-#endif
-#if PPSSPP_ARCH(ARM_NEON)
-#if defined(_MSC_VER) && PPSSPP_ARCH(ARM64)
-#include <arm64_neon.h>
-#else
-#include <arm_neon.h>
-#endif
-#endif
 
 // Videos should be updated every few frames, so we forget quickly.
 #define VIDEO_DECIMATE_AGE 4

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -3096,7 +3096,7 @@ void TextureCacheCommon::DrawImGuiDebug(uint64_t &selectedTextureId) const {
 
 	ImGui::SameLine();
 	ImGui::BeginChild("right", ImVec2(0.f, 0.0f));
-	if (ImGui::CollapsingHeader("Texture", ImGuiTreeNodeFlags_DefaultOpen)) {
+	if (ImGui::CollapsingHeader("Texture", nullptr, ImGuiTreeNodeFlags_DefaultOpen)) {
 		if (selectedTextureId) {
 			auto iter = cache_.find(selectedTextureId);
 			if (iter != cache_.end()) {
@@ -3143,7 +3143,7 @@ void TextureCacheCommon::DrawImGuiDebug(uint64_t &selectedTextureId) const {
 		}
 	}
 
-	if (ImGui::CollapsingHeader("Texture Cache State"), ImGuiTreeNodeFlags_DefaultOpen) {
+	if (ImGui::CollapsingHeader("Texture Cache State", nullptr, ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Text("Cache: %d textures, size est %d", (int)cache_.size(), cacheSizeEstimate_);
 		if (!secondCache_.empty()) {
 			ImGui::Text("Second: %d textures, size est %d", (int)secondCache_.size(), secondCacheSizeEstimate_);
@@ -3168,5 +3168,6 @@ void TextureCacheCommon::DrawImGuiDebug(uint64_t &selectedTextureId) const {
 			}
 		}
 	}
+
 	ImGui::EndChild();
 }

--- a/GPU/Common/TextureDecoder.cpp
+++ b/GPU/Common/TextureDecoder.cpp
@@ -21,12 +21,12 @@
 
 #include "Common/Common.h"
 #include "Common/Log.h"
-#include "Common/Math/CrossSIMD.h"
+#include "Common/Math/SIMDHeaders.h"
 
 #include "GPU/GPUState.h"
 #include "GPU/Common/TextureDecoder.h"
 
-#include "Common/Math/CrossSIMD.h"
+#include "Common/Math/SIMDHeaders.h"
 
 const u8 textureBitsPerPixel[16] = {
 	16,  //GE_TFMT_5650,

--- a/GPU/Common/TextureScalerCommon.cpp
+++ b/GPU/Common/TextureScalerCommon.cpp
@@ -28,7 +28,7 @@
 #include "Common/Thread/ParallelLoop.h"
 #include "ext/xbrz/xbrz.h"
 
-#include "Common/Math/CrossSIMD.h"
+#include "Common/Math/SIMDHeaders.h"
 
 
 // Report the time and throughput for each larger scaling operation in the log

--- a/GPU/Common/TextureScalerCommon.cpp
+++ b/GPU/Common/TextureScalerCommon.cpp
@@ -25,11 +25,9 @@
 #include "Core/Config.h"
 #include "Common/Common.h"
 #include "Common/Log.h"
+#include "Common/Math/SIMDHeaders.h"
 #include "Common/Thread/ParallelLoop.h"
 #include "ext/xbrz/xbrz.h"
-
-#include "Common/Math/SIMDHeaders.h"
-
 
 // Report the time and throughput for each larger scaling operation in the log
 //#define SCALING_MEASURE_TIME

--- a/GPU/Common/VertexDecoderHandwritten.cpp
+++ b/GPU/Common/VertexDecoderHandwritten.cpp
@@ -3,7 +3,7 @@
 #include "GPU/Common/VertexDecoderCommon.h"
 #include "GPU/GPUState.h"
 
-#include "Common/Math/CrossSIMD.h"
+#include "Common/Math/SIMDHeaders.h"
 
 // Candidates for hand-writing
 // (found using our custom Very Sleepy).

--- a/GPU/Common/VertexDecoderX86.cpp
+++ b/GPU/Common/VertexDecoderX86.cpp
@@ -16,12 +16,12 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "ppsspp_config.h"
-#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 
-#include <emmintrin.h>
+#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 
 #include "Common/CPUDetect.h"
 #include "Common/Data/Convert/ColorConv.h"
+#include "Common/Math/SIMDHeaders.h"
 #include "Core/Config.h"
 #include "GPU/GPUState.h"
 #include "GPU/Common/VertexDecoderCommon.h"

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -33,10 +33,6 @@
 #include "GPU/Common/TextureShaderCommon.h"
 #include "GPU/Common/DrawEngineCommon.h"
 
-#ifdef _M_SSE
-#include <emmintrin.h>
-#endif
-
 TextureCacheGLES::TextureCacheGLES(Draw::DrawContext *draw, Draw2D *draw2D)
 	: TextureCacheCommon(draw, draw2D) {
 	render_ = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -6,7 +6,7 @@
 
 #include "Common/GraphicsContext.h"
 #include "Common/LogReporting.h"
-#include "Common/Math/CrossSIMD.h"
+#include "Common/Math/SIMDHeaders.h"
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"
 #include "Common/Serialize/SerializeList.h"

--- a/GPU/GPUState.cpp
+++ b/GPU/GPUState.cpp
@@ -17,13 +17,13 @@
 
 #include "ppsspp_config.h"
 #include "Common/Common.h"
+#include "Common/Math/SIMDHeaders.h"
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"
 #include "Core/MemMap.h"
 #include "GPU/ge_constants.h"
 #include "GPU/GPUCommon.h"
 #include "GPU/GPUState.h"
-#include "Common/Math/SIMDHeaders.h"
 
 // This must be aligned so that the matrices within are aligned.
 alignas(16) GPUgstate gstate;

--- a/GPU/GPUState.cpp
+++ b/GPU/GPUState.cpp
@@ -23,7 +23,7 @@
 #include "GPU/ge_constants.h"
 #include "GPU/GPUCommon.h"
 #include "GPU/GPUState.h"
-#include "Common/Math/CrossSIMD.h"
+#include "Common/Math/SIMDHeaders.h"
 
 // This must be aligned so that the matrices within are aligned.
 alignas(16) GPUgstate gstate;

--- a/GPU/GPUState.h
+++ b/GPU/GPUState.h
@@ -24,17 +24,7 @@
 #include "GPU/GPU.h"
 #include "GPU/ge_constants.h"
 #include "GPU/Common/ShaderCommon.h"
-
-#if defined(_M_SSE)
-#include <emmintrin.h>
-#endif
-#if PPSSPP_ARCH(ARM_NEON)
-#if defined(_MSC_VER) && PPSSPP_ARCH(ARM64)
-#include <arm64_neon.h>
-#else
-#include <arm_neon.h>
-#endif
-#endif
+#include "Common/Math/SIMDHeaders.h"
 
 class PointerWrap;
 

--- a/GPU/Math3D.cpp
+++ b/GPU/Math3D.cpp
@@ -18,6 +18,11 @@
 #include "Common/Common.h"
 #include "GPU/Math3D.h"
 
+#if PPSSPP_ARCH(SSE2)
+// For the SSE4 stuff.
+#include <smmintrin.h>
+#endif
+
 namespace Math3D {
 
 template<>

--- a/GPU/Math3D.cpp
+++ b/GPU/Math3D.cpp
@@ -15,8 +15,9 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#include "Common/Common.h"
 #include "GPU/Math3D.h"
+#include "Common/Common.h"
+#include "Common/Math/SIMDHeaders.h"
 
 #if PPSSPP_ARCH(SSE2)
 // For the SSE4 stuff.

--- a/GPU/Math3D.h
+++ b/GPU/Math3D.h
@@ -24,19 +24,7 @@
 #include "Common/Common.h"
 #include "Core/Util/AudioFormat.h"  // for clamp_u8
 #include "Common/Math/fast/fast_matrix.h"
-
-#if defined(_M_SSE)
-#include <emmintrin.h>
-#include <smmintrin.h>
-#endif
-
-#if PPSSPP_ARCH(ARM_NEON)
-#if defined(_MSC_VER) && PPSSPP_ARCH(ARM64)
-#include <arm64_neon.h>
-#else
-#include <arm_neon.h>
-#endif
-#endif
+#include "Common/Math/SIMDHeaders.h"
 
 #if PPSSPP_PLATFORM(WINDOWS) && (defined(_MSC_VER) || defined(__clang__) || defined(__INTEL_COMPILER))
 #define MATH3D_CALL __vectorcall

--- a/GPU/Software/DrawPixelX86.cpp
+++ b/GPU/Software/DrawPixelX86.cpp
@@ -16,12 +16,13 @@
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
 #include "ppsspp_config.h"
+
 #if PPSSPP_ARCH(AMD64)
 
-#include <emmintrin.h>
 #include "Common/x64Emitter.h"
 #include "Common/CPUDetect.h"
 #include "Common/LogReporting.h"
+#include "Common/Math/SIMDHeaders.h"
 #include "GPU/GPUState.h"
 #include "GPU/Software/DrawPixel.h"
 #include "GPU/Software/SoftGpu.h"

--- a/GPU/Software/Lighting.cpp
+++ b/GPU/Software/Lighting.cpp
@@ -19,8 +19,14 @@
 #include <cmath>
 #include "Common/Common.h"
 #include "Common/CPUDetect.h"
+#include "Common/Math/SIMDHeaders.h"
 #include "GPU/GPUState.h"
 #include "GPU/Software/Lighting.h"
+
+#if PPSSPP_ARCH(SSE2)
+// For the SSE4 stuff.
+#include <smmintrin.h>
+#endif
 
 namespace Lighting {
 

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -38,6 +38,11 @@
 
 #include "Common/Math/SIMDHeaders.h"
 
+// For the SSE4 stuff
+#if PPSSPP_ARCH(SSE2)
+#include <smmintrin.h>
+#endif
+
 namespace Rasterizer {
 
 // Only OK on x64 where our stack is aligned

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -36,7 +36,7 @@
 #include "GPU/Software/SoftGpu.h"
 #include "GPU/Software/TransformUnit.h"
 
-#include "Common/Math/CrossSIMD.h"
+#include "Common/Math/SIMDHeaders.h"
 
 namespace Rasterizer {
 

--- a/GPU/Software/RasterizerRectangle.cpp
+++ b/GPU/Software/RasterizerRectangle.cpp
@@ -17,7 +17,7 @@
 #include "GPU/Software/Rasterizer.h"
 #include "GPU/Software/Sampler.h"
 #include "GPU/Software/SoftGpu.h"
-#include "Common/Math/CrossSIMD.h"
+#include "Common/Math/SIMDHeaders.h"
 
 extern DSStretch g_DarkStalkerStretch;
 // For Darkstalkers hack. Ugh.

--- a/GPU/Software/RasterizerRegCache.h
+++ b/GPU/Software/RasterizerRegCache.h
@@ -25,9 +25,8 @@
 #include <vector>
 
 #include "Common/Common.h"
-#if defined(_M_SSE)
-#include <emmintrin.h>
-#endif
+#include "Common/Math/SIMDHeaders.h"
+
 #if PPSSPP_ARCH(ARM64_NEON)
 #if defined(_MSC_VER) && PPSSPP_ARCH(ARM64)
 #include <arm64_neon.h>

--- a/GPU/Software/Sampler.cpp
+++ b/GPU/Software/Sampler.cpp
@@ -21,7 +21,7 @@
 #include "Common/Common.h"
 #include "Common/Data/Convert/ColorConv.h"
 #include "Common/LogReporting.h"
-#include "Common/Math/CrossSIMD.h"
+#include "Common/Math/SIMDHeaders.h"
 #include "Core/Config.h"
 #include "GPU/Common/TextureDecoder.h"
 #include "GPU/Software/BinManager.h"

--- a/GPU/Software/SamplerX86.cpp
+++ b/GPU/Software/SamplerX86.cpp
@@ -18,7 +18,7 @@
 #include "ppsspp_config.h"
 #if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
 
-#include <emmintrin.h>
+#include "Common/Math/SIMDHeaders.h"
 #include "Common/x64Emitter.h"
 #include "Common/BitScan.h"
 #include "Common/CPUDetect.h"

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -15,7 +15,10 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include "ppsspp_config.h"
+
 #include <cmath>
+
 #include "Common/Common.h"
 #include "Common/CPUDetect.h"
 #include "Common/Math/math_util.h"
@@ -25,11 +28,17 @@
 #include "GPU/Common/DrawEngineCommon.h"
 #include "GPU/Common/VertexDecoderCommon.h"
 #include "GPU/Common/SoftwareTransformCommon.h"
+#include "Common/Math/SIMDHeaders.h"
 #include "GPU/Software/BinManager.h"
 #include "GPU/Software/Clipper.h"
 #include "GPU/Software/Lighting.h"
 #include "GPU/Software/RasterizerRectangle.h"
 #include "GPU/Software/TransformUnit.h"
+
+// For the SSE4 stuff
+#if PPSSPP_ARCH(SSE2)
+#include <smmintrin.h>
+#endif
 
 #define TRANSFORM_BUF_SIZE (65536 * 48)
 

--- a/ext/at3_standalone/atrac3plusdsp.cpp
+++ b/ext/at3_standalone/atrac3plusdsp.cpp
@@ -659,7 +659,7 @@ void ff_atrac3p_ipqf(FFTContext *dct_ctx, Atrac3pIPQFChannelCtx *hist,
             const float *coeffs2 = ipqf_coeffs2[t];
 
             float *outp = out + s * 16;
-#if PPSSPP_ARCH(X86) || PPSSPP_ARCH(AMD64)
+#if PPSSPP_ARCH(SSE2)
             auto _mm_reverse = [](__m128 x) -> __m128 {
                 return _mm_shuffle_ps(x, x, _MM_SHUFFLE(0, 1, 2, 3));
             };

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -1098,6 +1098,9 @@ bool TestBuffer() {
 	return true;
 }
 
+#if defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
+[[gnu::target("sse4.1")]]
+#endif
 bool TestSIMD() {
 #if PPSSPP_ARCH(SSE2)
 	__m128i x = _mm_set_epi16(0, 0x4444, 0, 0x3333, 0, 0x2222, 0, 0x1111);

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -55,6 +55,12 @@
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/Buffer.h"
 #include "Common/File/Path.h"
+#include "Common/Math/SIMDHeaders.h"
+// Get some more instructions for testing
+#if PPSSPP_ARCH(SSE2)
+#include <immintrin.h>
+#endif
+
 #include "Common/Input/InputState.h"
 #include "Common/Math/math_util.h"
 #include "Common/Render/DrawBuffer.h"
@@ -1092,6 +1098,29 @@ bool TestBuffer() {
 	return true;
 }
 
+bool TestSIMD() {
+#if PPSSPP_ARCH(SSE2)
+	__m128i x = _mm_set_epi16(0, 0x4444, 0, 0x3333, 0, 0x2222, 0, 0x1111);
+	__m128i y = _mm_packu_epi32_SSE2(x);
+
+	uint64_t testdata[2];
+	_mm_store_si128((__m128i *)testdata, y);
+	EXPECT_EQ_INT(testdata[0], 0x4444333322221111);
+	EXPECT_EQ_INT(testdata[1], 0);
+
+	__m128i a = _mm_set_epi16(0, 0x4444, 0, 0x3333, 0, 0x2222, 0, 0x1111);
+	__m128i b = _mm_set_epi16(0, 0x8888, 0, 0x7777, 0, 0x6666, 0, 0x5555);
+	__m128i c = _mm_packu2_epi32_SSE2(a, b);
+	__m128i d = _mm_packus_epi32(a, b);
+
+	uint64_t testdata2[2];
+	_mm_store_si128((__m128i *)testdata2, c);
+	EXPECT_EQ_INT(testdata2[0], 0x4444333322221111);
+	EXPECT_EQ_INT(testdata2[1], 0x8888777766665555);
+#endif
+	return true;
+}
+
 typedef bool (*TestFunc)();
 struct TestItem {
 	const char *name;
@@ -1154,6 +1183,7 @@ TestItem availableTests[] = {
 	TEST_ITEM(ColorConv),
 	TEST_ITEM(CharQueue),
 	TEST_ITEM(Buffer),
+	TEST_ITEM(SIMD),
 };
 
 int main(int argc, const char *argv[]) {


### PR DESCRIPTION
Split CrossSIMD.h into the (future) wrapper and the new SIMDHeaders.h.

This is to avoid repeating some complex ifdefs in a lot of files.

Additionally, implement SSE2 replacements for some SSE4 instructions and use them in a couple of places.

Unfortunately, since we try to support really old Windows machines, I think we still can't require SSE4, as much as I'd love to.
