### PR TITLE
Depth raster: Some prep for parallelization

### DIFF
--- a/Common/File/AndroidStorage.cpp
+++ b/Common/File/AndroidStorage.cpp
@@ -250,7 +250,7 @@ std::vector<File::FileInfo> Android_ListContentUri(const std::string &uri, const
 			} else if (ParseFileInfo(line, &info)) {
 				// We can just reconstruct the URI.
 				info.fullName = Path(uri) / info.name;
-				INFO_LOG(Log::FileSystem, "%s", info.name.c_str());
+				// INFO_LOG(Log::FileSystem, "%s", info.name.c_str());
 				items.push_back(info);
 			}
 		}

--- a/Common/Thread/ParallelLoop.h
+++ b/Common/Thread/ParallelLoop.h
@@ -46,3 +46,50 @@ void ParallelRangeLoop(ThreadManager *threadMan, const std::function<void(int, i
 // NOTE: These support a max of 2GB.
 void ParallelMemcpy(ThreadManager *threadMan, void *dst, const void *src, size_t bytes, TaskPriority priority = TaskPriority::NORMAL);
 void ParallelMemset(ThreadManager *threadMan, void *dst, uint8_t value, size_t bytes, TaskPriority priority = TaskPriority::NORMAL);
+
+
+template<class T>
+class SimpleParallelTask : public Task {
+public:
+	SimpleParallelTask(WaitableCounter *counter, T func, int index, int count, TaskPriority p)
+		: counter_(counter), func_(func), index_(index), count_(count), priority_(p) {
+	}
+
+	TaskType Type() const override {
+		return TaskType::CPU_COMPUTE;
+	}
+
+	TaskPriority Priority() const override {
+		return priority_;
+	}
+
+	void Run() override {
+		func_(index_, count_);
+		counter_->Count();
+	}
+
+	T func_;
+	WaitableCounter *counter_;
+
+	int index_;
+	int count_;
+	const TaskPriority priority_;
+};
+
+template<class T>
+WaitableCounter *RunParallel(ThreadManager *threadMan, T func, int count, TaskPriority priority = TaskPriority::NORMAL) {
+	if (count == 1) {
+		func(0, 1);
+		return nullptr;
+	}
+
+	WaitableCounter *counter = new WaitableCounter(count);
+
+	for (int i = 0; i < count; i++) {
+		threadMan->EnqueueTaskOnThread(i, new SimpleParallelTask<T>(counter, func, i, count, priority));
+	}
+
+	return counter;
+}
+
+// To wait for all tasks to finish: if (counter) counter->WaitAndRelease();

--- a/Core/HW/MemoryStick.cpp
+++ b/Core/HW/MemoryStick.cpp
@@ -31,6 +31,7 @@
 #include "Core/HW/MemoryStick.h"
 #include "Core/System.h"
 #include "Common/CommonTypes.h"
+#include "Common/TimeUtil.h"
 #include "Common/Thread/Promise.h"
 
 // MS and FatMS states.
@@ -108,6 +109,7 @@ static uint64_t ComputeSizeOfSavedataForGame(const Path &saveFolder, const std::
 }
 
 u64 MemoryStick_FreeSpace(std::string gameID) {
+	double start = time_now_d();
 	INFO_LOG(Log::IO, "Calculating free disk space (%s)", gameID.c_str());
 
 	const CompatFlags &flags = PSP_CoreParameter().compat.flags();
@@ -143,6 +145,7 @@ u64 MemoryStick_FreeSpace(std::string gameID) {
 			realFreeSpace = memstickInitialFree - memstickCurrentUse;
 		}
 	}
+	INFO_LOG(Log::IO, "Done calculating free disk space (%0.3f s)", time_now_d() - start);
 
 	return std::min(simulatedFreeSpace, realFreeSpace);
 }

--- a/GPU/Common/DepthRaster.h
+++ b/GPU/Common/DepthRaster.h
@@ -26,6 +26,8 @@ struct DepthScissor {
 	u16 y1;
 	u16 x2;
 	u16 y2;
+
+	DepthScissor Tile(int tile, int numTiles) const;
 };
 
 struct DepthDraw {
@@ -49,9 +51,9 @@ struct DepthDraw {
 class VertexDecoder;
 struct TransformedVertex;
 
-int DepthRasterClipIndexedTriangles(int *tx, int *ty, float *tz, const float *transformed, const uint16_t *indexBuffer, const DepthDraw &draw);
-int DepthRasterClipIndexedRectangles(int *tx, int *ty, float *tz, const float *transformed, const uint16_t *indexBuffer, const DepthDraw &draw);
+int DepthRasterClipIndexedTriangles(int *tx, int *ty, float *tz, const float *transformed, const uint16_t *indexBuffer, const DepthDraw &draw, const DepthScissor scissor);
+int DepthRasterClipIndexedRectangles(int *tx, int *ty, float *tz, const float *transformed, const uint16_t *indexBuffer, const DepthDraw &draw, const DepthScissor scissor);
 void DecodeAndTransformForDepthRaster(float *dest, const float *worldviewproj, const void *vertexData, int indexLowerBound, int indexUpperBound, VertexDecoder *dec, u32 vertTypeID);
 void TransformPredecodedForDepthRaster(float *dest, const float *worldviewproj, const void *decodedVertexData, VertexDecoder *dec, int count);
 void ConvertPredecodedThroughForDepthRaster(float *dest, const void *decodedVertexData, VertexDecoder *dec, int count);
-void DepthRasterScreenVerts(uint16_t *depth, int depthStride, const int *tx, const int *ty, const float *tz, int count, const DepthDraw &draw);
+void DepthRasterScreenVerts(uint16_t *depth, int depthStride, const int *tx, const int *ty, const float *tz, int count, const DepthDraw &draw, const DepthScissor scissor);

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -1109,14 +1109,16 @@ void DrawEngineCommon::FlushQueuedDepth() {
 		const float *vertices = depthTransformed_ + 4 * draw.vertexOffset;
 		const uint16_t *indices = depthIndices_ + draw.indexOffset;
 
+		DepthScissor tileScissor = draw.scissor.Tile(0, 1);
+
 		{
 			TimeCollector collectStat(&gpuStats.msCullDepth, collectStats);
 			switch (draw.prim) {
 			case GE_PRIM_RECTANGLES:
-				outVertCount = DepthRasterClipIndexedRectangles(tx, ty, tz, vertices, indices, draw);
+				outVertCount = DepthRasterClipIndexedRectangles(tx, ty, tz, vertices, indices, draw, tileScissor);
 				break;
 			case GE_PRIM_TRIANGLES:
-				outVertCount = DepthRasterClipIndexedTriangles(tx, ty, tz, vertices, indices, draw);
+				outVertCount = DepthRasterClipIndexedTriangles(tx, ty, tz, vertices, indices, draw, tileScissor);
 				break;
 			default:
 				_dbg_assert_(false);
@@ -1125,7 +1127,7 @@ void DrawEngineCommon::FlushQueuedDepth() {
 		}
 		{
 			TimeCollector collectStat(&gpuStats.msRasterizeDepth, collectStats);
-			DepthRasterScreenVerts((uint16_t *)Memory::GetPointerWrite(draw.depthAddr), draw.depthStride, tx, ty, tz, outVertCount, draw);
+			DepthRasterScreenVerts((uint16_t *)Memory::GetPointerWrite(draw.depthAddr), draw.depthStride, tx, ty, tz, outVertCount, draw, tileScissor);
 		}
 	}
 

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -1042,6 +1042,10 @@ void DrawEngineCommon::DepthRasterTransform(GEPrimitiveType prim, VertexDecoder 
 	depthIndexCount_ += vertexCount;
 	depthVertexCount_ += numDecoded;
 
+	if (depthDraws_.empty()) {
+		rasterTimeStart_ = time_now_d();
+	}
+
 	depthDraws_.push_back(draw);
 
 	// FlushQueuedDepth();
@@ -1081,11 +1085,19 @@ void DrawEngineCommon::DepthRasterPredecoded(GEPrimitiveType prim, const void *i
 
 	depthDraws_.push_back(draw);
 
+	if (depthDraws_.empty()) {
+		rasterTimeStart_ = time_now_d();
+	}
 	// FlushQueuedDepth();
 }
 
 void DrawEngineCommon::FlushQueuedDepth() {
-	TimeCollector collectStat(&gpuStats.msRasterizeDepth, coreCollectDebugStats);
+	if (rasterTimeStart_ != 0.0) {
+		gpuStats.msRasterTimeAvailable += time_now_d() - rasterTimeStart_;
+		rasterTimeStart_ = 0.0;
+	}
+
+	const bool collectStats = coreCollectDebugStats;
 
 	for (const auto &draw : depthDraws_) {
 		int *tx = depthScreenVerts_;
@@ -1097,19 +1109,24 @@ void DrawEngineCommon::FlushQueuedDepth() {
 		const float *vertices = depthTransformed_ + 4 * draw.vertexOffset;
 		const uint16_t *indices = depthIndices_ + draw.indexOffset;
 
-		switch (draw.prim) {
-		case GE_PRIM_RECTANGLES:
-			outVertCount = DepthRasterClipIndexedRectangles(tx, ty, tz, vertices, indices, draw);
-			break;
-		case GE_PRIM_TRIANGLES:
-			outVertCount = DepthRasterClipIndexedTriangles(tx, ty, tz, vertices, indices, draw);
-			break;
-		default:
-			_dbg_assert_(false);
-			break;
+		{
+			TimeCollector collectStat(&gpuStats.msCullDepth, collectStats);
+			switch (draw.prim) {
+			case GE_PRIM_RECTANGLES:
+				outVertCount = DepthRasterClipIndexedRectangles(tx, ty, tz, vertices, indices, draw);
+				break;
+			case GE_PRIM_TRIANGLES:
+				outVertCount = DepthRasterClipIndexedTriangles(tx, ty, tz, vertices, indices, draw);
+				break;
+			default:
+				_dbg_assert_(false);
+				break;
+			}
 		}
-		// TODO: Could potentially split into tasks here!
-		DepthRasterScreenVerts((uint16_t *)Memory::GetPointerWrite(draw.depthAddr), draw.depthStride, tx, ty, tz, outVertCount, draw);
+		{
+			TimeCollector collectStat(&gpuStats.msRasterizeDepth, collectStats);
+			DepthRasterScreenVerts((uint16_t *)Memory::GetPointerWrite(draw.depthAddr), draw.depthStride, tx, ty, tz, outVertCount, draw);
+		}
 	}
 
 	// Reset queue

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -367,4 +367,6 @@ protected:
 	int depthVertexCount_ = 0;
 	int depthIndexCount_ = 0;
 	std::vector<DepthDraw> depthDraws_;
+
+	double rasterTimeStart_ = 0.0;
 };

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -108,8 +108,10 @@ struct GPUStatistics {
 		numCachedReplacedTextures = 0;
 		numClutTextures = 0;
 		msProcessingDisplayLists = 0;
-		msPrepareDepth = 0.0f;
-		msRasterizeDepth = 0.0f;
+		msPrepareDepth = 0.0;
+		msCullDepth = 0.0;
+		msRasterizeDepth = 0.0;
+		msRasterTimeAvailable = 0.0;
 		numDepthRasterPrims = 0;
 		numDepthRasterEarlySize = 0;
 		numDepthRasterNoPixels = 0;
@@ -156,7 +158,9 @@ struct GPUStatistics {
 	int numClutTextures;
 	double msProcessingDisplayLists;
 	double msPrepareDepth;
+	double msCullDepth;
 	double msRasterizeDepth;
+	double msRasterTimeAvailable;
 	int vertexGPUCycles;
 	int otherGPUCycles;
 	int numDepthRasterPrims;

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1763,7 +1763,7 @@ void GPUCommonHW::Execute_BoneMtxData(u32 op, u32 diff) {
 			gstate_c.Dirty(DIRTY_BONEMATRIX0 << (num / 12));
 		} else {
 			gstate_c.deferredVertTypeDirty |= DIRTY_BONEMATRIX0 << (num / 12);
-		}
+		} 
 		((u32 *)gstate.boneMatrix)[num] = newVal;
 	}
 	num++;
@@ -1801,7 +1801,8 @@ size_t GPUCommonHW::FormatGPUStatsCommon(char *buffer, size_t size) {
 		"replacer: tracks %d references, %d unique textures\n"
 		"Cpy: depth %d, color %d, reint %d, blend %d, self %d\n"
 		"GPU cycles: %d (%0.1f per vertex)\n"
-		"Z-rast: %0.2f/%0.2f ms, %d prim, %d nopix, %d small, %d earlysize, %d zcull, %d box\n%s",
+		"Z-rast: %0.2f+%0.2f+%0.2f (total %0.2f/%0.2f) ms\n"
+		"Z-rast: %d prim, %d nopix, %d small, %d earlysize, %d zcull, %d box\n%s",
 		gpuStats.msProcessingDisplayLists * 1000.0f,
 		gpuStats.numDrawSyncs,
 		gpuStats.numListSyncs,
@@ -1839,7 +1840,10 @@ size_t GPUCommonHW::FormatGPUStatsCommon(char *buffer, size_t size) {
 		gpuStats.vertexGPUCycles + gpuStats.otherGPUCycles,
 		vertexAverageCycles,
 		gpuStats.msPrepareDepth * 1000.0,
+		gpuStats.msCullDepth * 1000.0,
 		gpuStats.msRasterizeDepth * 1000.0,
+		(gpuStats.msPrepareDepth + gpuStats.msCullDepth + gpuStats.msRasterizeDepth) * 1000.0,
+		gpuStats.msRasterTimeAvailable * 1000.0,
 		gpuStats.numDepthRasterPrims,
 		gpuStats.numDepthRasterNoPixels,
 		gpuStats.numDepthRasterTooSmall,


### PR DESCRIPTION
However, I tried actually parallelizing by tiling in another branch and it was a loss (!). Not sure whether our thread manager is doing something stupid, or what's going on.

Anyway, this just adds some infrastructure and a useful measurement.

I think instead of tiling, it's better to focus on first optimizing the triangle setup, and then having a single thread depth-raster in the background while running the draw list up to the next sync point or framebuffer switch.