### PR TITLE
DepthRaster: Better guardband rejection, parallelize triangle setup

### DIFF
--- a/Common/Math/CrossSIMD.h
+++ b/Common/Math/CrossSIMD.h
@@ -485,6 +485,7 @@ struct Vec4S32 {
 	Vec4S32 operator ^(Vec4S32 other) const { return Vec4S32{ veorq_s32(v, other.v) }; }
 	Vec4S32 AndNot(Vec4S32 inverted) const { return Vec4S32{ vandq_s32(v, vmvnq_s32(inverted.v))}; }
 	Vec4S32 Mul(Vec4S32 other) const { return Vec4S32{ vmulq_s32(v, other.v) }; }
+	void operator &=(Vec4S32 other) { v = vandq_s32(v, other.v); }
 
 	template<int imm>
 	Vec4S32 Shl() const { return Vec4S32{ vshlq_n_s32(v, imm) }; }

--- a/Common/Math/CrossSIMD.h
+++ b/Common/Math/CrossSIMD.h
@@ -121,12 +121,6 @@ struct Vec4S32 {
 	void Store2(int *dst) { _mm_storel_epi64((__m128i *)dst, v); }
 	void StoreAligned(int *dst) { _mm_store_si128((__m128i *)dst, v);}
 
-	// Swaps the two lower elements. Useful for reversing triangles..
-	Vec4S32 SwapLowerElements() {
-		return Vec4S32{
-			_mm_shuffle_epi32(v, _MM_SHUFFLE(3, 2, 0, 1))
-		};
-	}
 	Vec4S32 SignBits32ToMask() {
 		return Vec4S32{
 			_mm_srai_epi32(v, 31)
@@ -144,6 +138,12 @@ struct Vec4S32 {
 		return Vec4S32{ _mm_madd_epi16(v, _mm_and_si128(other.v, _mm_set1_epi32(0x0000FFFF))) };
 	}
 
+	Vec4S32 SignExtend16() const { return Vec4S32{ _mm_srai_epi32(_mm_slli_epi32(v, 16), 16) }; }
+	// NOTE: These can be done in sequence, but when done, you must FixupAfterMinMax to get valid output.
+	Vec4S32 Min16(Vec4S32 other) const { return Vec4S32{ _mm_min_epi16(v, other.v) }; }
+	Vec4S32 Max16(Vec4S32 other) const { return Vec4S32{ _mm_max_epi16(v, other.v) }; }
+	Vec4S32 FixupAfterMinMax() const { return SignExtend16(); }
+
 	Vec4S32 operator +(Vec4S32 other) const { return Vec4S32{ _mm_add_epi32(v, other.v) }; }
 	Vec4S32 operator -(Vec4S32 other) const { return Vec4S32{ _mm_sub_epi32(v, other.v) }; }
 	Vec4S32 operator |(Vec4S32 other) const { return Vec4S32{ _mm_or_si128(v, other.v) }; }
@@ -152,6 +152,11 @@ struct Vec4S32 {
 	// TODO: andnot
 	void operator +=(Vec4S32 other) { v = _mm_add_epi32(v, other.v); }
 	void operator -=(Vec4S32 other) { v = _mm_sub_epi32(v, other.v); }
+
+	Vec4S32 operator <<(int imm) const { return Vec4S32{ _mm_slli_epi32(v, imm) }; }
+
+	// NOTE: May be slow.
+	int operator[](size_t index) const { return ((int *)&v)[index]; }
 
 	// NOTE: This uses a CrossSIMD wrapper if we don't compile with SSE4 support, and is thus slow.
 	Vec4S32 operator *(Vec4S32 other) const { return Vec4S32{ _mm_mullo_epi32_SSE2(v, other.v) }; }  // (ab3,ab2,ab1,ab0)
@@ -217,9 +222,12 @@ struct Vec4F32 {
 	void operator *=(Vec4F32 other) { v = _mm_mul_ps(v, other.v); }
 	void operator /=(Vec4F32 other) { v = _mm_div_ps(v, other.v); }
 	Vec4F32 operator *(float f) const { return Vec4F32{ _mm_mul_ps(v, _mm_set1_ps(f)) }; }
+	// NOTE: May be slow.
+	float operator[](size_t index) const { return ((float *)&v)[index]; }
 
 	Vec4F32 Mul(float f) const { return Vec4F32{ _mm_mul_ps(v, _mm_set1_ps(f)) }; }
-	Vec4F32 Recip() { return Vec4F32{ _mm_rcp_ps(v) }; }
+	Vec4F32 RecipApprox() const { return Vec4F32{ _mm_rcp_ps(v) }; }
+	Vec4F32 Recip() const { return Vec4F32{ _mm_div_ps(_mm_set1_ps(1.0f), v) }; }
 
 	Vec4F32 Clamp(float lower, float higher) {
 		return Vec4F32{
@@ -236,13 +244,6 @@ struct Vec4F32 {
 		alignas(16) static const uint32_t mask[4] = { 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x0 };
 		alignas(16) static const float onelane3[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
 		return Vec4F32{ _mm_or_ps(_mm_and_ps(v, _mm_load_ps((const float *)mask)), _mm_load_ps((const float *)onelane3)) };
-	}
-
-	// Swaps the two lower elements. Useful for reversing triangles..
-	Vec4F32 SwapLowerElements() {
-		return Vec4F32{
-			_mm_shuffle_ps(v, v, _MM_SHUFFLE(3, 2, 0, 1))
-		};
 	}
 
 	inline Vec4F32 AsVec3ByMatrix44(const Mat4F32 &m) {
@@ -443,16 +444,17 @@ struct Vec4S32 {
 	void Store2(int *dst) { vst1_s32(dst, vget_low_s32(v)); }
 	void StoreAligned(int *dst) { vst1q_s32(dst, v); }
 
-	// Swaps the two lower elements, but NOT the two upper ones. Useful for reversing triangles..
-	// This is quite awkward on ARM64 :/ Maybe there's a better solution?
-	Vec4S32 SwapLowerElements() {
-		int32x2_t upper = vget_high_s32(v);
-		int32x2_t lowerSwapped = vrev64_s32(vget_low_s32(v));
-		return Vec4S32{ vcombine_s32(lowerSwapped, upper) };
-	};
-
 	// Warning: Unlike on x86, this is a full 32-bit multiplication.
 	Vec4S32 MulAsS16(Vec4S32 other) const { return Vec4S32{ vmulq_s32(v, other.v) }; }
+
+	Vec4S32 SignExtend16() const { return Vec4S32{ vshrq_n_s32(vshlq_n_s32(v, 16), 16) }; }
+	// NOTE: These can be done in sequence, but when done, you must FixupAfterMinMax to get valid output (on SSE2 at least).
+	Vec4S32 Min16(Vec4S32 other) const { return Vec4S32{ vminq_s32(v, other.v) }; }
+	Vec4S32 Max16(Vec4S32 other) const { return Vec4S32{ vmaxq_s32(v, other.v) }; }
+	Vec4S32 FixupAfterMinMax() const { return Vec4S32{ v }; }
+
+	// NOTE: May be slow.
+	int operator[](size_t index) const { return ((int *)&v)[index]; }
 
 	Vec4S32 operator +(Vec4S32 other) const { return Vec4S32{ vaddq_s32(v, other.v) }; }
 	Vec4S32 operator -(Vec4S32 other) const { return Vec4S32{ vsubq_s32(v, other.v) }; }
@@ -508,6 +510,9 @@ struct Vec4F32 {
 		return Vec4F32{ vcvtq_f32_s32(other.v) };
 	}
 
+	// NOTE: May be slow.
+	float operator[](size_t index) const { return ((float *)&v)[index]; }
+
 	Vec4F32 operator +(Vec4F32 other) const { return Vec4F32{ vaddq_f32(v, other.v) }; }
 	Vec4F32 operator -(Vec4F32 other) const { return Vec4F32{ vsubq_f32(v, other.v) }; }
 	Vec4F32 operator *(Vec4F32 other) const { return Vec4F32{ vmulq_f32(v, other.v) }; }
@@ -521,11 +526,18 @@ struct Vec4F32 {
 
 	Vec4F32 Mul(float f) const { return Vec4F32{ vmulq_f32(v, vdupq_n_f32(f)) }; }
 
-	Vec4F32 Recip() {
+	Vec4F32 Recip() const {
 		float32x4_t recip = vrecpeq_f32(v);
 		// Use a couple Newton-Raphson steps to refine the estimate.
-		// May be able to get away with only one refinement, not sure!
+		// To save one iteration at the expense of accuracy, use RecipApprox().
 		recip = vmulq_f32(vrecpsq_f32(v, recip), recip);
+		recip = vmulq_f32(vrecpsq_f32(v, recip), recip);
+		return Vec4F32{ recip };
+	}
+
+	Vec4F32 RecipApprox() const {
+		float32x4_t recip = vrecpeq_f32(v);
+		// To approximately match the precision of x86-64's rcpps, do a single iteration.
 		recip = vmulq_f32(vrecpsq_f32(v, recip), recip);
 		return Vec4F32{ recip };
 	}
@@ -543,13 +555,6 @@ struct Vec4F32 {
 	Vec4F32 WithLane3One() const {
 		return Vec4F32{ vsetq_lane_f32(1.0f, v, 3) };
 	}
-
-	// Swaps the two lower elements, but NOT the two upper ones. Useful for reversing triangles..
-	// This is quite awkward on ARM64 :/ Maybe there's a better solution?
-	Vec4F32 SwapLowerElements() {
-		float32x2_t lowerSwapped = vrev64_f32(vget_low_f32(v));
-		return Vec4F32{ vcombine_f32(lowerSwapped, vget_high_f32(v)) };
-	};
 
 	// One of many possible solutions. Sometimes we could also use vld4q_f32 probably..
 	static void Transpose(Vec4F32 &col0, Vec4F32 &col1, Vec4F32 &col2, Vec4F32 &col3) {

--- a/Common/Math/CrossSIMD.h
+++ b/Common/Math/CrossSIMD.h
@@ -152,6 +152,9 @@ struct Vec4S32 {
 	// TODO: andnot
 	void operator +=(Vec4S32 other) { v = _mm_add_epi32(v, other.v); }
 	void operator -=(Vec4S32 other) { v = _mm_sub_epi32(v, other.v); }
+	void operator &=(Vec4S32 other) { v = _mm_and_si128(v, other.v); }
+	void operator |=(Vec4S32 other) { v = _mm_or_si128(v, other.v); }
+	void operator ^=(Vec4S32 other) { v = _mm_xor_si128(v, other.v); }
 
 	Vec4S32 AndNot(Vec4S32 inverted) const { return Vec4S32{ _mm_andnot_si128(inverted.v, v) }; }  // NOTE: with _mm_andnot, the first parameter is inverted, and then and is performed.
 	Vec4S32 Mul(Vec4S32 other) const { return *this * other; }
@@ -583,6 +586,8 @@ struct Vec4F32 {
 	Vec4S32 CompareEq(Vec4F32 other) const { return Vec4S32{ vreinterpretq_s32_u32(vceqq_f32(v, other.v)) }; }
 	Vec4S32 CompareLt(Vec4F32 other) const { return Vec4S32{ vreinterpretq_s32_u32(vcltq_f32(v, other.v)) }; }
 	Vec4S32 CompareGt(Vec4F32 other) const { return Vec4S32{ vreinterpretq_s32_u32(vcgtq_f32(v, other.v)) }; }
+	Vec4S32 CompareLe(Vec4F32 other) const { return Vec4S32{ vreinterpretq_s32_u32(vcleq_f32(v, other.v)) }; }
+	Vec4S32 CompareGe(Vec4F32 other) const { return Vec4S32{ vreinterpretq_s32_u32(vcgeq_f32(v, other.v)) }; }
 
 	// One of many possible solutions. Sometimes we could also use vld4q_f32 probably..
 	static void Transpose(Vec4F32 &col0, Vec4F32 &col1, Vec4F32 &col2, Vec4F32 &col3) {

--- a/Common/Math/SIMDHeaders.h
+++ b/Common/Math/SIMDHeaders.h
@@ -88,29 +88,29 @@ static inline uint32x4_t vcgezq_f32(float32x4_t v) {
 // May later figure out how to use the appropriate ones depending on compile flags.
 
 inline __m128i _mm_mullo_epi32_SSE2(const __m128i v0, const __m128i v1) {
-       __m128i a13 = _mm_shuffle_epi32(v0, 0xF5);             // (-,a3,-,a1)
-       __m128i b13 = _mm_shuffle_epi32(v1, 0xF5);             // (-,b3,-,b1)
-       __m128i prod02 = _mm_mul_epu32(v0, v1);                // (-,a2*b2,-,a0*b0)
-       __m128i prod13 = _mm_mul_epu32(a13, b13);              // (-,a3*b3,-,a1*b1)
-       __m128i prod01 = _mm_unpacklo_epi32(prod02, prod13);   // (-,-,a1*b1,a0*b0)
-       __m128i prod23 = _mm_unpackhi_epi32(prod02, prod13);   // (-,-,a3*b3,a2*b2)
-       return _mm_unpacklo_epi64(prod01, prod23);
+	__m128i a13 = _mm_shuffle_epi32(v0, 0xF5);             // (-,a3,-,a1)
+	__m128i b13 = _mm_shuffle_epi32(v1, 0xF5);             // (-,b3,-,b1)
+	__m128i prod02 = _mm_mul_epu32(v0, v1);                // (-,a2*b2,-,a0*b0)
+	__m128i prod13 = _mm_mul_epu32(a13, b13);              // (-,a3*b3,-,a1*b1)
+	__m128i prod01 = _mm_unpacklo_epi32(prod02, prod13);   // (-,-,a1*b1,a0*b0)
+	__m128i prod23 = _mm_unpackhi_epi32(prod02, prod13);   // (-,-,a3*b3,a2*b2)
+	return _mm_unpacklo_epi64(prod01, prod23);
 }
 
 inline __m128i _mm_max_epu16_SSE2(const __m128i v0, const __m128i v1) {
-       return _mm_xor_si128(
-               _mm_max_epi16(
-                       _mm_xor_si128(v0, _mm_set1_epi16((int16_t)0x8000)),
-                       _mm_xor_si128(v1, _mm_set1_epi16((int16_t)0x8000))),
-               _mm_set1_epi16((int16_t)0x8000));
+	return _mm_xor_si128(
+		_mm_max_epi16(
+			_mm_xor_si128(v0, _mm_set1_epi16((int16_t)0x8000)),
+			_mm_xor_si128(v1, _mm_set1_epi16((int16_t)0x8000))),
+		_mm_set1_epi16((int16_t)0x8000));
 }
 
 inline __m128i _mm_min_epu16_SSE2(const __m128i v0, const __m128i v1) {
-       return _mm_xor_si128(
-               _mm_min_epi16(
-                       _mm_xor_si128(v0, _mm_set1_epi16((int16_t)0x8000)),
-                       _mm_xor_si128(v1, _mm_set1_epi16((int16_t)0x8000))),
-               _mm_set1_epi16((int16_t)0x8000));
+	return _mm_xor_si128(
+		_mm_min_epi16(
+			_mm_xor_si128(v0, _mm_set1_epi16((int16_t)0x8000)),
+			_mm_xor_si128(v1, _mm_set1_epi16((int16_t)0x8000))),
+		_mm_set1_epi16((int16_t)0x8000));
 }
 
 // SSE2 replacement for half of a _mm_packus_epi32 but without the saturation.

--- a/GPU/Common/DepthRaster.cpp
+++ b/GPU/Common/DepthRaster.cpp
@@ -156,16 +156,12 @@ TriangleResult DepthRasterTriangle(uint16_t *depthBuf, int stride, DepthScissor 
 	float z_01 = (tz[8] - tz[0]) * oneOverTriArea;
 
 	// Step deltas
-	Vec4S32 oneStepX12 = Vec4S32::Splat(A12 * stepXSize);
-	Vec4S32 oneStepY12 = Vec4S32::Splat(B12 * stepYSize);
-
-	// Step deltas
-	Vec4S32 oneStepX20 = Vec4S32::Splat(A20 * stepXSize);
-	Vec4S32 oneStepY20 = Vec4S32::Splat(B20 * stepYSize);
-
-	// Step deltas
-	Vec4S32 oneStepX01 = Vec4S32::Splat(A01 * stepXSize);
-	Vec4S32 oneStepY01 = Vec4S32::Splat(B01 * stepYSize);
+	int stepX12 = A12 * stepXSize;
+	int stepY12 = B12 * stepYSize;
+	int stepX20 = A20 * stepXSize;
+	int stepY20 = B20 * stepYSize;
+	int stepX01 = A01 * stepXSize;
+	int stepY01 = B01 * stepYSize;
 
 	// x/y values for initial pixel block. Add horizontal offsets.
 	Vec4S32 initialX = Vec4S32::Splat(minX) + Vec4S32::LoadAligned(zero123);
@@ -178,13 +174,16 @@ TriangleResult DepthRasterTriangle(uint16_t *depthBuf, int stride, DepthScissor 
 	Vec4S32 w1_row = Vec4S32::Splat(A20) * initialX + Vec4S32::Splat(B20 * initialY + C20);
 	Vec4S32 w2_row = Vec4S32::Splat(A01) * initialX + Vec4S32::Splat(B01 * initialY + C01);
 
-	Vec4F32 z_20_v = Vec4F32::Splat(z_20);
-	Vec4F32 z_01_v = Vec4F32::Splat(z_01);
-
-	Vec4F32 zdeltaX = z_20_v * Vec4F32FromS32(oneStepX20) + z_01_v * Vec4F32FromS32(oneStepX01);
-	Vec4F32 zdeltaY = z_20_v * Vec4F32FromS32(oneStepY20) + z_01_v * Vec4F32FromS32(oneStepY01);
+	Vec4F32 zdeltaX = Vec4F32::Splat(z_20 * (float)stepX20 + z_01 * (float)stepX01);
+	Vec4F32 zdeltaY = Vec4F32::Splat(z_20 * (float)stepY20 + z_01 * (float)stepY01);
 	Vec4F32 zrow = Vec4F32::Splat(zbase) + Vec4F32FromS32(w1_row) * z_20 + Vec4F32FromS32(w2_row) * z_01;
 
+	Vec4S32 oneStepX12 = Vec4S32::Splat(stepX12);
+	Vec4S32 oneStepY12 = Vec4S32::Splat(stepY12);
+	Vec4S32 oneStepX20 = Vec4S32::Splat(stepX20);
+	Vec4S32 oneStepY20 = Vec4S32::Splat(stepY20);
+	Vec4S32 oneStepX01 = Vec4S32::Splat(stepX01);
+	Vec4S32 oneStepY01 = Vec4S32::Splat(stepY01);
 	// Rasterize
 	for (int y = minY; y <= maxY; y += stepYSize, w0_row += oneStepY12, w1_row += oneStepY20, w2_row += oneStepY01, zrow += zdeltaY) {
 		// Barycentric coordinates at start of row

--- a/GPU/Common/DepthRaster.cpp
+++ b/GPU/Common/DepthRaster.cpp
@@ -494,7 +494,7 @@ int DepthRasterClipIndexedTriangles(int *tx, int *ty, float *tz, const float *tr
 
 		// Floating point double triangle area. Can't be reused for the integer-snapped raster reliably (though may work...)
 		// Still good for culling early and pretty cheap to compute.
-		Vec4F32 doubleTriArea = (x1 - x0) * (y2 - y0) - (x2 - x0) * (y1 - y0) - Vec4F32::Splat((float)(MIN_TWICE_TRI_AREA + 2));
+		Vec4F32 doubleTriArea = (x1 - x0) * (y2 - y0) - (x2 - x0) * (y1 - y0) - Vec4F32::Splat((float)(MIN_TWICE_TRI_AREA));
 		if (!AnyZeroSignBit(doubleTriArea)) {
 			gpuStats.numDepthRasterEarlySize += 4;
 			continue;

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -56,6 +56,7 @@
 #include "Common/Buffer.h"
 #include "Common/File/Path.h"
 #include "Common/Math/SIMDHeaders.h"
+#include "Common/Math/CrossSIMD.h"
 // Get some more instructions for testing
 #if PPSSPP_ARCH(SSE2)
 #include <immintrin.h>
@@ -1124,6 +1125,21 @@ bool TestSIMD() {
 	EXPECT_EQ_INT(testdata2[2], 0x8888777766665555);
 	EXPECT_EQ_INT(testdata2[2], 0x8888777766665555);
 #endif
+
+	const int testval[2][4] = {
+		{ 0x1000, 0x2000, 0x3000, 0x7000 },
+		{ -0x1000, -0x2000, -0x3000, -0x7000 }
+	};
+
+	for (int i = 0; i < 2; i++) {
+		Vec4S32 s = Vec4S32::Load(testval[i]);
+		Vec4S32 square = s * s;
+		Vec4S32 square16 = s.Mul16(s);
+		EXPECT_EQ_INT(square[0], square16[0]);
+		EXPECT_EQ_INT(square[1], square16[1]);
+		EXPECT_EQ_INT(square[2], square16[2]);
+		EXPECT_EQ_INT(square[3], square16[3]);
+	}
 	return true;
 }
 

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -1049,7 +1049,7 @@ CharQueue GetQueue() {
 
 bool TestCharQueue() {
 	// We use a tiny block size for testing.
-	CharQueue queue = std::move(GetQueue());
+	CharQueue queue = GetQueue();
 
 	// Add 16 chars.
 	queue.push_back("abcdefghijkl");


### PR DESCRIPTION
The guardband rejection fixes makes it so that 16x16->32 bit multiplications are enough for triangle setup, which is good for the SSE2 path, just like @fp64 said previously. Though, I've kept things generic to work on NEON too (didn't exploit the madd instruction fully..)

The triangle setup parallelization seems to speed up the rasterization by 20%+ (very unscientifically measured). Raster is now so fast that it sometimes rivals the cull pass (DepthRasterClipIndexedTriangles) which now is slightly heavier, but worth it.

There are more possible optimizations, but want to get this in as-is. Midnight Club is now close to doing this fast enough on my weak test phone. But I might have to implement the planned "low quality" mode (few people will ever notice the difference anyway as it only affects lens flares).