### PR TITLE
Implement the low-quality depth raster mode, default to it on Android/iOS

### DIFF
--- a/Common/Math/CrossSIMD.h
+++ b/Common/Math/CrossSIMD.h
@@ -160,7 +160,7 @@ struct Vec4S32 {
 	Vec4S32 Mul(Vec4S32 other) const { return *this * other; }
 
 	template<int imm>
-	Vec4S32 Shl() const { return Vec4S32{ _mm_slli_epi32(v, imm) }; }
+	Vec4S32 Shl() const { return Vec4S32{ imm == 0 ? v : _mm_slli_epi32(v, imm) }; }
 
 	// NOTE: May be slow.
 	int operator[](size_t index) const { return ((int *)&v)[index]; }

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -139,6 +139,14 @@ const char *DefaultLangRegion() {
 	return defaultLangRegion.c_str();
 }
 
+static int DefaultDepthRaster() {
+#if PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(IOS)
+	return (int)DepthRasterMode::LOW_QUALITY;
+#else
+	return (int)DepthRasterMode::DEFAULT;
+#endif
+}
+
 std::string CreateRandMAC() {
 	std::stringstream randStream;
 	srand(time(nullptr));
@@ -616,7 +624,7 @@ static const ConfigSetting graphicsSettings[] = {
 	ConfigSetting("UseGeometryShader", &g_Config.bUseGeometryShader, false, CfgFlag::PER_GAME),
 	ConfigSetting("SkipBufferEffects", &g_Config.bSkipBufferEffects, false, CfgFlag::PER_GAME | CfgFlag::REPORT),
 	ConfigSetting("DisableRangeCulling", &g_Config.bDisableRangeCulling, false, CfgFlag::PER_GAME | CfgFlag::REPORT),
-	ConfigSetting("DepthRasterMode", &g_Config.iDepthRasterMode, 0, CfgFlag::PER_GAME | CfgFlag::REPORT),
+	ConfigSetting("DepthRasterMode", &g_Config.iDepthRasterMode, &DefaultDepthRaster, CfgFlag::PER_GAME | CfgFlag::REPORT),
 	ConfigSetting("SoftwareRenderer", &g_Config.bSoftwareRendering, false, CfgFlag::PER_GAME),
 	ConfigSetting("SoftwareRendererJit", &g_Config.bSoftwareRenderingJit, true, CfgFlag::PER_GAME),
 	ConfigSetting("HardwareTransform", &g_Config.bHardwareTransform, true, CfgFlag::PER_GAME | CfgFlag::REPORT),

--- a/GPU/Common/DepthRaster.h
+++ b/GPU/Common/DepthRaster.h
@@ -56,4 +56,4 @@ int DepthRasterClipIndexedRectangles(int *tx, int *ty, float *tz, const float *t
 void DecodeAndTransformForDepthRaster(float *dest, const float *worldviewproj, const void *vertexData, int indexLowerBound, int indexUpperBound, VertexDecoder *dec, u32 vertTypeID);
 void TransformPredecodedForDepthRaster(float *dest, const float *worldviewproj, const void *decodedVertexData, VertexDecoder *dec, int count);
 void ConvertPredecodedThroughForDepthRaster(float *dest, const void *decodedVertexData, VertexDecoder *dec, int count);
-void DepthRasterScreenVerts(uint16_t *depth, int depthStride, const int *tx, const int *ty, const float *tz, int count, const DepthDraw &draw, const DepthScissor scissor);
+void DepthRasterScreenVerts(uint16_t *depth, int depthStride, const int *tx, const int *ty, const float *tz, int count, const DepthDraw &draw, const DepthScissor scissor, bool lowQ);

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -1098,6 +1098,7 @@ void DrawEngineCommon::FlushQueuedDepth() {
 	}
 
 	const bool collectStats = coreCollectDebugStats;
+	const bool lowQ = g_Config.iDepthRasterMode == (int)DepthRasterMode::LOW_QUALITY;
 
 	for (const auto &draw : depthDraws_) {
 		int *tx = depthScreenVerts_;
@@ -1127,7 +1128,7 @@ void DrawEngineCommon::FlushQueuedDepth() {
 		}
 		{
 			TimeCollector collectStat(&gpuStats.msRasterizeDepth, collectStats);
-			DepthRasterScreenVerts((uint16_t *)Memory::GetPointerWrite(draw.depthAddr), draw.depthStride, tx, ty, tz, outVertCount, draw, tileScissor);
+			DepthRasterScreenVerts((uint16_t *)Memory::GetPointerWrite(draw.depthAddr), draw.depthStride, tx, ty, tz, outVertCount, draw, tileScissor, lowQ);
 		}
 	}
 


### PR DESCRIPTION
It just halves the vertical raster resolution, doubling up pixels. Seems to cut raster time by 20-30%.

I really can't tell much of a difference in practice... Maybe we should default to it on all platforms.

part of #19757