### PR TITLE
Depth raster: Try rasterization on a background thread

### DIFF
--- a/Common/GPU/Vulkan/VulkanRenderManager.cpp
+++ b/Common/GPU/Vulkan/VulkanRenderManager.cpp
@@ -28,6 +28,7 @@ using namespace PPSSPP_VK;
 
 // renderPass is an example of the "compatibility class" or RenderPassType type.
 bool VKRGraphicsPipeline::Create(VulkanContext *vulkan, VkRenderPass compatibleRenderPass, RenderPassType rpType, VkSampleCountFlagBits sampleCount, double scheduleTime, int countToCompile) {
+	_dbg_assert_(desc);
 	// Good torture test to test the shutdown-while-precompiling-shaders issue on PC where it's normally
 	// hard to catch because shaders compile so fast.
 	// sleep_ms(200);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -140,7 +140,15 @@ const char *DefaultLangRegion() {
 }
 
 static int DefaultDepthRaster() {
-#if PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(IOS)
+	// All single cores default to off.
+	if (cpu_info.num_cores == 1) {
+		return (int)DepthRasterMode::OFF;
+	}
+
+	// ARMv7 also defaults to off.
+#if PPSSPP_PLATFORM(ARM)
+	return (int)DepthRasterMode::OFF;
+#elif PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(IOS)
 	return (int)DepthRasterMode::LOW_QUALITY;
 #else
 	return (int)DepthRasterMode::DEFAULT;

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -368,6 +368,7 @@ protected:
 private:
 	// Internal implementation details.
 	void DepthThreadFunc();
+	bool WaitForDepthPassFinish();
 
 	inline void EnqueueDepthDraw(const DepthDraw &draw);
 	inline void ProcessDepthDraw(const DepthDraw &draw);
@@ -391,7 +392,9 @@ private:
 	std::mutex depthEnqueueMutex_;
 	std::condition_variable depthEnqueueCond_;
 
-	bool processingDepthDraw_ = false;
+	bool finishedSubmitting_ = false;
+	bool finishedDrawing_ = false;
+	int curDraw_ = 0;
 	std::mutex depthFinishMutex_;
 	std::condition_variable depthFinishCond_;
 };

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -368,7 +368,7 @@ protected:
 private:
 	// Internal implementation details.
 	void DepthThreadFunc();
-	bool WaitForDepthPassFinish();
+	void WaitForDepthPassFinish();
 
 	inline void EnqueueDepthDraw(const DepthDraw &draw);
 	inline void ProcessDepthDraw(const DepthDraw &draw);

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -18,6 +18,8 @@
 #pragma once
 
 #include <vector>
+#include <mutex>
+#include <condition_variable>
 
 #include "Common/CommonTypes.h"
 #include "Common/Data/Collections/Hashmaps.h"
@@ -365,6 +367,7 @@ protected:
 
 private:
 	// Internal implementation details.
+	void DepthThreadFunc();
 
 	inline void EnqueueDepthDraw(const DepthDraw &draw);
 	inline void ProcessDepthDraw(const DepthDraw &draw);
@@ -381,5 +384,14 @@ private:
 
 	double depthRasterPassStart_ = 0.0;
 
+	std::thread depthThread_;
+	bool exitDepthThread_ = false;  // notify depthEnqueueCond_ to check this.
+
 	bool inDepthDrawPass_ = false;
+	std::mutex depthEnqueueMutex_;
+	std::condition_variable depthEnqueueCond_;
+
+	bool processingDepthDraw_ = false;
+	std::mutex depthFinishMutex_;
+	std::condition_variable depthFinishCond_;
 };

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -80,7 +80,7 @@ public:
 	virtual void BeginFrame();
 
 	void SetGPUCommon(GPUCommon *gpuCommon) {
-		gpuCommon = gpuCommon;
+		gpuCommon_ = gpuCommon;
 	}
 
 	virtual void DeviceLost() = 0;
@@ -210,7 +210,7 @@ protected:
 		gpuStats.numVertsSubmitted += vertexCountInDrawCalls_;
 		gpuStats.numVertsDecoded += numDecodedVerts_;
 
-		indexGen.Reset();
+		indexGen_.Reset();
 		numDecodedVerts_ = 0;
 		numDrawVerts_ = 0;
 		numDrawInds_ = 0;
@@ -327,7 +327,7 @@ protected:
 	bool applySkinInDecode_ = false;
 
 	// Vertex collector state
-	IndexGenerator indexGen;
+	IndexGenerator indexGen_;
 	int numDecodedVerts_ = 0;
 	GEPrimitiveType prevPrim_ = GE_PRIM_INVALID;
 
@@ -340,9 +340,9 @@ protected:
 	ComputedPipelineState pipelineState_;
 
 	// Hardware tessellation
-	TessellationDataTransfer *tessDataTransfer = nullptr;
+	TessellationDataTransfer *tessDataTransfer_ = nullptr;
 
-	GPUCommon *gpuCommon_;
+	GPUCommon *gpuCommon_ = nullptr;
 
 	// Culling
 private:
@@ -379,5 +379,7 @@ private:
 	int depthIndexCount_ = 0;
 	std::vector<DepthDraw> depthDraws_;
 
-	double rasterTimeStart_ = 0.0;
+	double depthRasterPassStart_ = 0.0;
+
+	bool inDepthDrawPass_ = false;
 };

--- a/GPU/Common/SplineCommon.cpp
+++ b/GPU/Common/SplineCommon.cpp
@@ -552,7 +552,7 @@ void DrawEngineCommon::SubmitCurve(const void *control_points, const void *indic
 	surface.Init(maxVerts);
 
 	if (CanUseHardwareTessellation(surface.primType)) {
-		HardwareTessellation(output, surface, origVertType, points, tessDataTransfer);
+		HardwareTessellation(output, surface, origVertType, points, tessDataTransfer_);
 	} else {
 		ControlPoints cpoints(points, num_points, managedBuf);
 		if (cpoints.IsValid())

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -82,7 +82,7 @@ void DrawEngineD3D11::InitDeviceObjects() {
 	pushInds_ = new PushBufferD3D11(device_, INDEX_PUSH_SIZE, D3D11_BIND_INDEX_BUFFER);
 
 	tessDataTransferD3D11 = new TessellationDataTransferD3D11(context_, device_);
-	tessDataTransfer = tessDataTransferD3D11;
+	tessDataTransfer_ = tessDataTransferD3D11;
 
 	draw_->SetInvalidationCallback(std::bind(&DrawEngineD3D11::Invalidate, this, std::placeholders::_1));
 }
@@ -108,7 +108,7 @@ void DrawEngineD3D11::DestroyDeviceObjects() {
 	ClearInputLayoutMap();
 	delete tessDataTransferD3D11;
 	tessDataTransferD3D11 = nullptr;
-	tessDataTransfer = nullptr;
+	tessDataTransfer_ = nullptr;
 	delete pushVerts_;
 	delete pushInds_;
 	depthStencilCache_.Iterate([&](const uint64_t &key, ID3D11DepthStencilState *ds) {

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -84,7 +84,7 @@ DrawEngineDX9::DrawEngineDX9(Draw::DrawContext *draw) : draw_(draw), vertexDeclM
 	InitDeviceObjects();
 
 	tessDataTransferDX9 = new TessellationDataTransferDX9();
-	tessDataTransfer = tessDataTransferDX9;
+	tessDataTransfer_ = tessDataTransferDX9;
 
 	device_->CreateVertexDeclaration(TransformedVertexElements, &transformedVertexDecl_);
 }

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -59,7 +59,7 @@ DrawEngineGLES::DrawEngineGLES(Draw::DrawContext *draw) : inputLayoutMap_(16), d
 	InitDeviceObjects();
 
 	tessDataTransferGLES = new TessellationDataTransferGLES(render_);
-	tessDataTransfer = tessDataTransferGLES;
+	tessDataTransfer_ = tessDataTransferGLES;
 }
 
 DrawEngineGLES::~DrawEngineGLES() {
@@ -231,7 +231,7 @@ void DrawEngineGLES::Flush() {
 		// Something went badly wrong. Try to survive by simply skipping the draw, though.
 		_dbg_assert_msg_(false, "Trying to DoFlush while not in a render pass. This is bad.");
 		// can't goto bail here, skips too many variable initializations. So let's wipe the most important stuff.
-		indexGen.Reset();
+		indexGen_.Reset();
 		numDecodedVerts_ = 0;
 		numDrawVerts_ = 0;
 		numDrawInds_ = 0;

--- a/GPU/GPU.h
+++ b/GPU/GPU.h
@@ -118,6 +118,9 @@ struct GPUStatistics {
 		numDepthRasterTooSmall = 0;
 		numDepthRasterZCulled = 0;
 		numDepthEarlyBoxCulled = 0;
+		numDepthThreadCaughtUp = 0;
+		numDepthThreadFinished = 0;
+		numDepthDraws = 0;
 		vertexGPUCycles = 0;
 		otherGPUCycles = 0;
 	}
@@ -169,6 +172,9 @@ struct GPUStatistics {
 	int numDepthRasterTooSmall;
 	int numDepthRasterZCulled;
 	int numDepthEarlyBoxCulled;
+	int numDepthThreadCaughtUp;
+	int numDepthThreadFinished;
+	int numDepthDraws;
 	// Flip count. Doesn't really belong here.
 	int numFlips;
 };

--- a/GPU/GPUCommonHW.cpp
+++ b/GPU/GPUCommonHW.cpp
@@ -1802,7 +1802,9 @@ size_t GPUCommonHW::FormatGPUStatsCommon(char *buffer, size_t size) {
 		"Cpy: depth %d, color %d, reint %d, blend %d, self %d\n"
 		"GPU cycles: %d (%0.1f per vertex)\n"
 		"Z-rast: %0.2f+%0.2f+%0.2f (total %0.2f/%0.2f) ms\n"
-		"Z-rast: %d prim, %d nopix, %d small, %d earlysize, %d zcull, %d box\n%s",
+		"Z-rast: %d prim, %d nopix, %d small, %d earlysize, %d zcull, %d box\n"
+		"Z-rast: %d draws, %d thread caught up, %d thread finishes\n"
+		"%s",
 		gpuStats.msProcessingDisplayLists * 1000.0f,
 		gpuStats.numDrawSyncs,
 		gpuStats.numListSyncs,
@@ -1850,6 +1852,9 @@ size_t GPUCommonHW::FormatGPUStatsCommon(char *buffer, size_t size) {
 		gpuStats.numDepthRasterEarlySize,
 		gpuStats.numDepthRasterZCulled,
 		gpuStats.numDepthEarlyBoxCulled,
+		gpuStats.numDepthDraws,
+		gpuStats.numDepthThreadCaughtUp,
+		gpuStats.numDepthThreadFinished,
 		debugRecording_ ? "(debug-recording)" : ""
 	);
 }

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -94,7 +94,7 @@ void DrawEngineVulkan::InitDeviceObjects() {
 	_dbg_assert_(VK_SUCCESS == res);
 
 	tessDataTransferVulkan = new TessellationDataTransferVulkan(vulkan);
-	tessDataTransfer = tessDataTransferVulkan;
+	tessDataTransfer_ = tessDataTransferVulkan;
 
 	draw_->SetInvalidationCallback(std::bind(&DrawEngineVulkan::Invalidate, this, std::placeholders::_1));
 }
@@ -115,7 +115,7 @@ void DrawEngineVulkan::DestroyDeviceObjects() {
 	draw_->SetInvalidationCallback(InvalidationCallback());
 
 	delete tessDataTransferVulkan;
-	tessDataTransfer = nullptr;
+	tessDataTransfer_ = nullptr;
 	tessDataTransferVulkan = nullptr;
 
 	pushUBO_ = nullptr;
@@ -577,7 +577,7 @@ void DrawEngineVulkan::Flush() {
 }
 
 void DrawEngineVulkan::ResetAfterDraw() {
-	indexGen.Reset();
+	indexGen_.Reset();
 	numDecodedVerts_ = 0;
 	numDrawVerts_ = 0;
 	numDrawInds_ = 0;


### PR DESCRIPTION
This moves the main raster work to a single background thread, so the main thread can keep processing the display list while raster is happening on the background thread, up until a synchronization point. Unfortunately, much like the previous attempt, the win is ~0 or even negative currently, at least on PC...

There's a bit more synchronization happening than I thought, maybe it can be reduced.

For now, leaving as draft and moving on to other things for a while. 