### PR TITLE
Check file systems at runtime for case sensitivity

### DIFF
--- a/Common/File/Path.cpp
+++ b/Common/File/Path.cpp
@@ -425,9 +425,12 @@ bool Path::ComputePathTo(const Path &other, std::string &path) const {
 	}
 }
 
-#if HOST_IS_CASE_SENSITIVE
-
 static bool FixFilenameCase(const std::string &path, std::string &filename) {
+#if _WIN32
+	// We don't support case-insensitive file systems on Windows.
+	return true;
+#else
+
 	// Are we lucky?
 	if (File::Exists(Path(path + filename)))
 		return true;
@@ -469,9 +472,14 @@ static bool FixFilenameCase(const std::string &path, std::string &filename) {
 	closedir(dirp);
 
 	return retValue;
+#endif
 }
 
 bool FixPathCase(const Path &realBasePath, std::string &path, FixPathCaseBehavior behavior) {
+#if _WIN32
+	return true;
+#else
+
 	if (realBasePath.Type() == PathType::CONTENT_URI) {
 		// Nothing to do. These are already case insensitive, I think.
 		return true;
@@ -524,6 +532,5 @@ bool FixPathCase(const Path &realBasePath, std::string &path, FixPathCaseBehavio
 	}
 
 	return true;
-}
-
 #endif
+}

--- a/Common/File/Path.h
+++ b/Common/File/Path.h
@@ -145,9 +145,7 @@ private:
 // Utility function for parsing out file extensions.
 std::string GetExtFromString(std::string_view str);
 
-// Utility function for fixing the case of paths. Only present on Unix-like systems.
-
-#if HOST_IS_CASE_SENSITIVE
+// Utility function for fixing the case of paths. Only necessary on Unix-like systems.
 
 enum FixPathCaseBehavior {
 	FPC_FILE_MUST_EXIST,  // all path components must exist (rmdir, move from)
@@ -156,5 +154,3 @@ enum FixPathCaseBehavior {
 };
 
 bool FixPathCase(const Path &basePath, std::string &path, FixPathCaseBehavior behavior);
-
-#endif

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -284,7 +284,9 @@ bool DirectoryFileHandle::Open(const Path &basePath, std::string &fileName, File
 			DEBUG_LOG(Log::FileSystem, "Case may have been incorrect, second try opening %s (%s)", fullName.c_str(), fileName.c_str());
 
 			// And try again with the correct case this time
-#ifdef _WIN32
+#if PPSSPP_PLATFORM(UWP)
+			// Should never get here.
+#elif PPSSPP_PLATFORM(WINDOWS)
 			// Unlikely to get here, heh.
 			hFile = CreateFile(fullName.ToWString().c_str(), desired, sharemode, 0, openmode, 0, 0);
 			success = hFile != INVALID_HANDLE_VALUE;
@@ -295,7 +297,7 @@ bool DirectoryFileHandle::Open(const Path &basePath, std::string &fileName, File
 		}
 	}
 
-#ifndef _WIN32
+#if !PPSSPP_PLATFORM(WINDOWS)
 	if (success) {
 		// Reject directories, even if we succeed in opening them.
 		// TODO: Might want to do this stat first...

--- a/Core/FileSystems/FileSystem.h
+++ b/Core/FileSystems/FileSystem.h
@@ -70,6 +70,7 @@ enum class FileSystemFlags {
 	CARD = 4,
 	FLASH = 8,
 	STRIP_PSP = 16,
+	CASE_SENSITIVE = 32,
 };
 ENUM_CLASS_BITOPS(FileSystemFlags);
 


### PR DESCRIPTION
Avoids running expensive workarounds when not needed.

May improve I/O performance to memstick a little bit on some platforms like Android.
