### PR TITLE
Atrac3 (not +): Keep decoding even on broken frames.

### DIFF
--- a/Core/HW/Atrac3Standalone.cpp
+++ b/Core/HW/Atrac3Standalone.cpp
@@ -95,8 +95,17 @@ public:
 			result = atrac3_decode_frame(at3Ctx_, buffers_, &nb_samples, inbuf, inbytes);
 		}
 		if (result < 0) {
+			// NOTE: Here, to recover from single bad packets, we update inBytesConsumed/outSamples with the regular packet size.
+			// Otherwise we might try to decode the same packet over and over.
+			// This is seen in some unofficial game mods, mainly.
+			if (inbytesConsumed) {
+				*inbytesConsumed = inbytes;
+			}
 			if (outSamples) {
-				*outSamples = 0;
+				if (*outSamples != 0) {
+					nb_samples = std::min(*outSamples, nb_samples);
+				}
+				*outSamples = nb_samples;
 			}
 			return false;
 		}

--- a/ext/at3_standalone/atrac3.cpp
+++ b/ext/at3_standalone/atrac3.cpp
@@ -755,13 +755,14 @@ int atrac3_decode_frame(ATRAC3Context *ctx, float *out_data[2], int *nb_samples,
         databuf = buf;
     }
 
+    *nb_samples = SAMPLES_PER_FRAME;
+
     ret = decode_frame(ctx, block_align, channels, databuf, out_data);
     if (ret) {
         av_log(AV_LOG_ERROR, "Frame decoding error!");
         return ret;
     }
 
-    *nb_samples = SAMPLES_PER_FRAME;
     return block_align;
 }
 


### PR DESCRIPTION
Fixes some music in some unofficial game mods, whose music got broken in 1.18. Was reported through e-mail by Miguel.

Not 100% sure if this should actually work, but this is how it was in older versions of PPSSPP... and shouldn't really affect any real games anyway, they don't come with broken atrac3 packets.