### PR TITLE
Fix crash/assert in old Ge debugger with OpenGL, remove obsolete compat flag

### DIFF
--- a/Core/Compatibility.cpp
+++ b/Core/Compatibility.cpp
@@ -142,7 +142,6 @@ void Compatibility::CheckSettings(IniFile &iniFile, const std::string &gameID) {
 	CheckSetting(iniFile, gameID, "Fontltn12Hack", &flags_.Fontltn12Hack);
 	CheckSetting(iniFile, gameID, "LoadCLUTFromCurrentFrameOnly", &flags_.LoadCLUTFromCurrentFrameOnly);
 	CheckSetting(iniFile, gameID, "ForceUMDReadSpeed", &flags_.ForceUMDReadSpeed);
-	CheckSetting(iniFile, gameID, "AllowDelayedReadbacks", &flags_.AllowDelayedReadbacks);
 	CheckSetting(iniFile, gameID, "KernelGetSystemTimeLowEatMoreCycles", &flags_.KernelGetSystemTimeLowEatMoreCycles);
 	CheckSetting(iniFile, gameID, "TacticsOgreEliminateDebugReadback", &flags_.TacticsOgreEliminateDebugReadback);
 	CheckSetting(iniFile, gameID, "FramebufferAllowLargeVerticalOffset", &flags_.FramebufferAllowLargeVerticalOffset);

--- a/Core/Compatibility.h
+++ b/Core/Compatibility.h
@@ -105,7 +105,6 @@ struct CompatFlags {
 	bool Fontltn12Hack;
 	bool LoadCLUTFromCurrentFrameOnly;
 	bool ForceUMDReadSpeed;
-	bool AllowDelayedReadbacks;
 	bool KernelGetSystemTimeLowEatMoreCycles;
 	bool TacticsOgreEliminateDebugReadback;
 	bool FramebufferAllowLargeVerticalOffset;

--- a/GPU/Common/DepthBufferCommon.cpp
+++ b/GPU/Common/DepthBufferCommon.cpp
@@ -215,9 +215,6 @@ bool FramebufferManagerCommon::ReadbackDepthbuffer(Draw::Framebuffer *fbo, int x
 
 		DepthUB ub{};
 
-		// Setting this to 0.95f eliminates flickering lights with delayed readback in Syphon Filter.
-		// That's pretty ugly though! But we'll need to do that if we're gonna enable delayed readback in those games.
-		const float fudgeFactor = 1.0f;
 		DepthScaleFactors depthScale = GetDepthScaleFactors(gstate_c.UseFlags());
 		ub.u_depthFactor[0] = depthScale.Offset();
 		ub.u_depthFactor[1] = depthScale.Scale();
@@ -232,9 +229,9 @@ bool FramebufferManagerCommon::ReadbackDepthbuffer(Draw::Framebuffer *fbo, int x
 
 		// Fullscreen triangle coordinates.
 		static const float positions[6] = {
-			0.0, 0.0,
-			1.0, 0.0,
-			0.0, 1.0,
+			0.0f, 0.0f,
+			1.0f, 0.0f,
+			0.0f, 1.0f,
 		};
 		draw_->DrawUP(positions, 3);
 

--- a/GPU/Common/TextureCacheCommon.cpp
+++ b/GPU/Common/TextureCacheCommon.cpp
@@ -2080,7 +2080,7 @@ CheckAlphaResult TextureCacheCommon::ReadIndexedTex(u8 *out, int outPitch, int l
 	}
 }
 
-void TextureCacheCommon::ApplyTexture() {
+void TextureCacheCommon::ApplyTexture(bool doBind) {
 	TexCacheEntry *entry = nextTexture_;
 	if (!entry) {
 		// Maybe we bound a framebuffer?
@@ -2161,7 +2161,9 @@ void TextureCacheCommon::ApplyTexture() {
 		gstate_c.SetTextureIsBGRA(false);
 	} else {
 		entry->lastFrame = gpuStats.numFlips;
-		BindTexture(entry);
+		if (doBind) {
+			BindTexture(entry);
+		}
 		gstate_c.SetTextureFullAlpha(entry->GetAlphaStatus() == TexCacheEntry::STATUS_ALPHA_FULL);
 		gstate_c.SetTextureIs3D((entry->status & TexCacheEntry::STATUS_3D) != 0);
 		gstate_c.SetTextureIsArray(false);

--- a/GPU/Common/TextureCacheCommon.h
+++ b/GPU/Common/TextureCacheCommon.h
@@ -349,7 +349,7 @@ public:
 		shaderManager_ = sm;
 	}
 
-	void ApplyTexture();
+	void ApplyTexture(bool doBind = true);
 	bool SetOffsetTexture(u32 yOffset);
 	void Invalidate(u32 addr, int size, GPUInvalidationType type);
 	void InvalidateAll(GPUInvalidationType type);

--- a/GPU/GLES/TextureCacheGLES.cpp
+++ b/GPU/GLES/TextureCacheGLES.cpp
@@ -386,7 +386,7 @@ bool TextureCacheGLES::GetCurrentTextureDebug(GPUDebugBuffer &buffer, int level,
 	TexCacheEntry *entry = nextTexture_;
 	// We might need a render pass to set the sampling params, unfortunately.  Otherwise BuildTexture may crash.
 	framebufferManagerGL_->RebindFramebuffer("RebindFramebuffer - GetCurrentTextureDebug");
-	ApplyTexture();
+	ApplyTexture(false);
 
 	GLRenderManager *renderManager = (GLRenderManager *)draw_->GetNativeObject(Draw::NativeObject::RENDER_MANAGER);
 

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1681,9 +1681,6 @@ UCAS40289 = true
 NPUH10025 = true
 NPEH00047 = true
 
-[ReadbackDepth]
-# Obsolete, SoftwareRasterDepth is a far better solution.
-
 [BlockTransferDepth]
 # Iron Man - see issue #16530
 # Note that this option also requires IntraVRAMBlockTransferAllowCreateFB.
@@ -1810,12 +1807,6 @@ UCAS40244 = true
 UCKS45110 = true
 ULJS19044 = true
 NPJH50852 = true
-
-[AllowDelayedReadbacks]
-# NOTE: This only affects Vulkan currently.
-# Added for easy experimentation. Many games using readbacks do not work well delaying them, though.
-# For example, Motorstorm lighting adaptation goes into self-oscillation (!)
-# UCES01250 = true
 
 [TacticsOgreEliminateDebugReadback]
 ULUS10565 = true


### PR DESCRIPTION
AllowDelayedReadback has no uses anymore.