### PR TITLE
pspautotests runner (headless): Add ability to specify a directory to recurse

### DIFF
--- a/Common/File/DirListing.h
+++ b/Common/File/DirListing.h
@@ -33,6 +33,7 @@ enum {
 	GETFILES_GET_NAVIGATION_ENTRIES = 2,  // If you don't set this, "." and ".." will be skipped.
 };
 
+// Note: extensionFilter is ignored for directories, so you can recurse.
 bool GetFilesInDir(const Path &directory, std::vector<FileInfo> *files, const char *extensionFilter = nullptr, int flags = 0, std::string_view prefix = std::string_view());
 std::vector<File::FileInfo> ApplyFilter(std::vector<File::FileInfo> files, const char *extensionFilter, std::string_view prefix);
 


### PR DESCRIPTION
Suffix the directory with `/...`, to mean all tests below.

Also add the ability to `--ignore` individual tests.

This is very useful during development for convenient multi-test runs from within Visual Studio.

Example command line:

```
 --root pspautotests/tests/../ -o --compare --timeout=30 --graphics=software pspautotests/tests/audio/atrac/... --ignore pspautotests/tests/audio/atrac/second/resetting.prx --ignore pspautotests/tests/audio/atrac/replay.prx
```