### PR TITLE
Rebase of ANR2ME's sceHttp implementation

### DIFF
--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -383,7 +383,7 @@ int Client::SendRequestWithData(const char *method, const RequestParams &req, co
 	return 0;
 }
 
-int Client::ReadResponseHeaders(net::Buffer *readbuf, std::vector<std::string> &responseHeaders, net::RequestProgress *progress, std::string * httpCode) {
+int Client::ReadResponseHeaders(net::Buffer *readbuf, std::vector<std::string> &responseHeaders, net::RequestProgress *progress, std::string *statusLine) {
 	// Snarf all the data we can into RAM. A little unsafe but hey.
 	static constexpr float CANCEL_INTERVAL = 0.25f;
 	bool ready = false;
@@ -421,8 +421,8 @@ int Client::ReadResponseHeaders(net::Buffer *readbuf, std::vector<std::string> &
 		return -1;
 	}
 
-	if (httpCode)
-		*httpCode = line;
+	if (statusLine)
+		*statusLine = line;
 
 	while (true) {
 		int sz = readbuf->TakeLineCRLF(&line);

--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -383,7 +383,7 @@ int Client::SendRequestWithData(const char *method, const RequestParams &req, co
 	return 0;
 }
 
-int Client::ReadResponseHeaders(net::Buffer *readbuf, std::vector<std::string> &responseHeaders, net::RequestProgress *progress) {
+int Client::ReadResponseHeaders(net::Buffer *readbuf, std::vector<std::string> &responseHeaders, net::RequestProgress *progress, std::string * httpCode) {
 	// Snarf all the data we can into RAM. A little unsafe but hey.
 	static constexpr float CANCEL_INTERVAL = 0.25f;
 	bool ready = false;
@@ -420,6 +420,9 @@ int Client::ReadResponseHeaders(net::Buffer *readbuf, std::vector<std::string> &
 		ERROR_LOG(Log::HTTP, "Could not parse HTTP status code: %s", line.c_str());
 		return -1;
 	}
+
+	if (httpCode)
+		*httpCode = line;
 
 	while (true) {
 		int sz = readbuf->TakeLineCRLF(&line);

--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -556,7 +556,7 @@ int HTTPRequest::Perform(const std::string &url) {
 	}
 
 	if (!client.Connect(2, 20.0, &cancelled_)) {
-		ERROR_LOG(Log::HTTP, "Failed connecting to server or cancelled.");
+		ERROR_LOG(Log::HTTP, "Failed connecting to server or cancelled (=%d).", cancelled_);
 		return -1;
 	}
 

--- a/Common/Net/HTTPClient.h
+++ b/Common/Net/HTTPClient.h
@@ -71,7 +71,7 @@ public:
 
 	int SendRequest(const char *method, const RequestParams &req, const char *otherHeaders, net::RequestProgress *progress);
 	int SendRequestWithData(const char *method, const RequestParams &req, const std::string &data, const char *otherHeaders, net::RequestProgress *progress);
-	int ReadResponseHeaders(net::Buffer *readbuf, std::vector<std::string> &responseHeaders, net::RequestProgress *progress);
+	int ReadResponseHeaders(net::Buffer *readbuf, std::vector<std::string> &responseHeaders, net::RequestProgress *progress, std::string* httpCode = nullptr);
 	// If your response contains a response, you must read it.
 	int ReadResponseEntity(net::Buffer *readbuf, const std::vector<std::string> &responseHeaders, Buffer *output, net::RequestProgress *progress);
 
@@ -83,7 +83,12 @@ public:
 		userAgent_ = value;
 	}
 
+	void SetHttpVersion(const char *version) {
+		httpVersion_ = version;
+	}
+
 protected:
+	std::string httpVersion_;
 	std::string userAgent_;
 	double dataTimeout_ = 900.0;
 };

--- a/Common/Net/HTTPClient.h
+++ b/Common/Net/HTTPClient.h
@@ -71,7 +71,7 @@ public:
 
 	int SendRequest(const char *method, const RequestParams &req, const char *otherHeaders, net::RequestProgress *progress);
 	int SendRequestWithData(const char *method, const RequestParams &req, const std::string &data, const char *otherHeaders, net::RequestProgress *progress);
-	int ReadResponseHeaders(net::Buffer *readbuf, std::vector<std::string> &responseHeaders, net::RequestProgress *progress, std::string* httpCode = nullptr);
+	int ReadResponseHeaders(net::Buffer *readbuf, std::vector<std::string> &responseHeaders, net::RequestProgress *progress, std::string *statusLine = nullptr);
 	// If your response contains a response, you must read it.
 	int ReadResponseEntity(net::Buffer *readbuf, const std::vector<std::string> &responseHeaders, Buffer *output, net::RequestProgress *progress);
 

--- a/Core/HLE/FunctionWrappers.h
+++ b/Core/HLE/FunctionWrappers.h
@@ -237,6 +237,11 @@ template<int func(u32, const char*, u32, u32, int)> void WrapI_UCUUI() {
 	RETURN(retval);
 }
 
+template<int func(u32, int, const char*, u32, u32)> void WrapI_UICUU() {
+	int retval = func(PARAM(0), PARAM(1), Memory::GetCharPointer(PARAM(2)), PARAM(3), PARAM(4));
+	RETURN(retval);
+}
+
 template<int func()> void WrapI_V() {
 	int retval = func();
 	RETURN(retval);

--- a/Core/HLE/FunctionWrappers.h
+++ b/Core/HLE/FunctionWrappers.h
@@ -232,6 +232,11 @@ template<int func(u32, u32, u32, u32, u32)> void WrapI_UUUUU() {
 	RETURN(retval);
 }
 
+template<int func(u32, const char*, u32, u32, int)> void WrapI_UCUUI() {
+	int retval = func(PARAM(0), Memory::GetCharPointer(PARAM(1)), PARAM(2), PARAM(3), PARAM(4));
+	RETURN(retval);
+}
+
 template<int func()> void WrapI_V() {
 	int retval = func();
 	RETURN(retval);
@@ -783,6 +788,11 @@ template<int func(int, u32, u32)> void WrapI_IUU() {
 template<u32 func(u32, u32, u32, u32, u32, u32, u32)> void WrapU_UUUUUUU() {
   u32 retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4), PARAM(5), PARAM(6));
   RETURN(retval);
+}
+
+template<int func(u32, u32, u32, u32, u32, u32, u32)> void WrapI_UUUUUUU() {
+	int retval = func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4), PARAM(5), PARAM(6));
+	RETURN(retval);
 }
 
 template<int func(int, u32, u32, u32, u32, u32, u32)> void WrapI_IUUUUUU() {

--- a/Core/HLE/sceHttp.cpp
+++ b/Core/HLE/sceHttp.cpp
@@ -218,7 +218,13 @@ int HTTPRequest::sendRequest(u32 postDataPtr, u32 postDataSize) {
 
 	// TODO: Do this on a separate thread, since this may blocks "Emu" thread here
 	// Try to resolve first
-	Url fileUrl(url);
+	// Note: LittleBigPlanet onlu passed the path (ie. /LITTLEBIGPLANETPSP_XML/login?) during sceHttpCreateRequest without the host domain, thus will need to be construced into a valid URI using the data from sceHttpCreateConnection upon validating/parsing the URL.
+	std::string fullURL = url;
+	if (startsWithNoCase(url, "/")) {
+		fullURL = scheme + "://" + hostString + ":" + std::to_string(port) + fullURL;
+	}
+
+	Url fileUrl(fullURL);
 	if (!fileUrl.Valid()) {
 		return SCE_HTTP_ERROR_INVALID_URL;
 	}
@@ -328,7 +334,7 @@ int sceHttpSetResolveRetry(int id, int retryCount) {
 }
 
 static int sceHttpInit(int poolSize) {
-	WARN_LOG(Log::sceNet, "UNTESTED sceHttpInit(%i)", poolSize);
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpInit(%i) at %08x", poolSize, currentMIPS->pc);
 	if (httpInited)
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_ALREADY_INITED, "http already inited");
 

--- a/Core/HLE/sceHttp.cpp
+++ b/Core/HLE/sceHttp.cpp
@@ -310,6 +310,9 @@ void __HttpInit() {
 
 void __HttpShutdown() {
 	std::lock_guard<std::mutex> guard(httpLock);
+	httpInited = false;
+	httpsInited = false;
+	httpCacheInited = false;
 	httpObjects.clear();
 }
 

--- a/Core/HLE/sceHttp.cpp
+++ b/Core/HLE/sceHttp.cpp
@@ -15,58 +15,359 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <sstream>
+#include <iterator>
+#include <numeric>
+#include <mutex>
+#include <algorithm>
+
+#include "Core/Core.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/FunctionWrappers.h"
-
+#include "Core/HLE/sceKernelMemory.h"
 #include "Core/HLE/sceHttp.h"
+#include "Core/Debugger/MemBlockInfo.h"
+#include "Common/StringUtils.h"
+#include "Common/LogReporting.h"
+#include "Common/Net/URL.h"
 #include "Common/Net/HTTPClient.h"
 
-// If http isn't loaded (seems unlikely), most functions should return SCE_KERNEL_ERROR_LIBRARY_NOTFOUND
 
-// Could come in handy someday if we ever implement sceHttp* for real.
-enum PSPHttpMethod {
-	PSP_HTTP_METHOD_GET,
-	PSP_HTTP_METHOD_POST,
-	PSP_HTTP_METHOD_HEAD
-};
+static std::vector<std::shared_ptr<HTTPTemplate>> httpObjects;
+static std::mutex httpLock;
 
-// Just a holder for settings like user agent string
-class HTTPTemplate {
-	char useragent[512];
-};
+bool httpInited = false;
+bool httpsInited = false;
+bool httpCacheInited = false;
 
-int sceHttpSetResolveRetry(int connectionID, int retryCount) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpSetResolveRetry(%d, %d)", connectionID, retryCount);
+HTTPTemplate::HTTPTemplate(const char* userAgent, int httpVer, int autoProxyConf) {
+	this->userAgent = userAgent ? userAgent : "";
+	this->httpVer = (SceHttpVersion)httpVer;
+	this->autoProxyConf = (SceHttpProxyMode)autoProxyConf;
+}
+
+int HTTPTemplate::addRequestHeader(const char* name, const char* value, u32 mode) {
+	// Note: std::map doesn't support key duplication, will need std::multimap to support SCE_HTTP_HEADER_ADD mode
+	//if (mode != SCE_HTTP_HEADER_OVERWRITE)
+	//	return SCE_HTTP_ERROR_NOT_SUPPORTED; // FIXME: PSP might not support mode other than SCE_HTTP_HEADER_OVERWRITE (0)
+	// Handle User-Agent separately, since PSP Browser seems to add "User-Agent" header manually
+	if (mode == SCE_HTTP_HEADER_OVERWRITE) {
+		std::string s = name;
+		std::transform(s.begin(), s.end(), s.begin(), [](const unsigned char i) { return std::tolower(i); });
+		if (s == "user-agent")
+			setUserAgent(value);
+	}
+
+	requestHeaders_[name] = value;
 	return 0;
 }
 
-static int sceHttpInit(int unknown) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpInit(%i)", unknown);
+int HTTPTemplate::removeRequestHeader(const char* name) {
+	requestHeaders_.erase(name);
+	return 0;
+}
+
+HTTPConnection::HTTPConnection(int templateID, const char* hostString, const char* scheme, u32 port, int enableKeepalive) {
+	// Copy base data as initial base value for this
+	HTTPTemplate::operator=(*httpObjects[templateID - 1LL]);
+
+	// Initialize
+	this->templateID = templateID;
+	this->hostString = hostString;
+	this->scheme = scheme;
+	this->port = port;
+	this->enableKeepalive = enableKeepalive;
+}
+
+HTTPRequest::HTTPRequest(int connectionID, int method, const char* url, u64 contentLength) {
+	// Copy base data as initial base value for this
+	// Since dynamic_cast/dynamic_pointer_cast/typeid requires RTTI to be enabled (ie. /GR instead of /GR- on msvc, enabled by default on most compilers), so we can only use static_cast here
+	HTTPConnection::operator=(static_cast<HTTPConnection&>(*httpObjects[connectionID - 1LL]));
+
+	// Initialize
+	this->connectionID = connectionID;
+	this->method = method;
+	this->url = url ? url : "";
+	this->contentLength = contentLength;
+
+	//progress_.cancelled = &cancelled_;
+	responseContent_.clear();
+}
+
+HTTPRequest::~HTTPRequest() {
+	client.Disconnect();
+	if (Memory::IsValidAddress(headerAddr_))
+		userMemory.Free(headerAddr_);
+}
+
+int HTTPRequest::getResponseContentLength() {
+	// FIXME: Will sceHttpGetContentLength returns an error if the request was not sent yet?
+	//if (progress_.progress == 0.0f)
+	//	return SCE_HTTP_ERROR_BEFORE_SEND;
+
+	entityLength_ = -1;
+	for (std::string& line : responseHeaders_) {
+		if (startsWithNoCase(line, "Content-Length:")) {
+			size_t size_pos = line.find_first_of(' ');
+			if (size_pos != line.npos) {
+				size_pos = line.find_first_not_of(' ', size_pos);
+			}
+			if (size_pos != line.npos) {
+				entityLength_ = atoi(&line[size_pos]);
+			}
+		}
+	}
+	return entityLength_;
+}
+
+int HTTPRequest::abortRequest() {
+	cancelled_ = true;
+	// FIXME: Will sceHttpAbortRequest returns an error if the request was not sent yet?
+	//if (progress_.progress == 0.0f)
+	//	return SCE_HTTP_ERROR_BEFORE_SEND;
+	return 0;
+}
+
+int HTTPRequest::getStatusCode() {
+	// FIXME: Will sceHttpGetStatusCode returns an error if the request was not sent yet?
+	//if (progress_.progress == 0.0f)
+	//	return SCE_HTTP_ERROR_BEFORE_SEND;
+	return responseCode_;
+}
+
+int HTTPRequest::getAllResponseHeaders(u32 headerAddrPtr, u32 headerSizePtr) {
+	// FIXME: Will sceHttpGetAllHeader returns an error if the request was not sent yet?
+	//if (progress_.progress == 0.0f)
+	//	return SCE_HTTP_ERROR_BEFORE_SEND;
+
+	const char* const delim = "\r\n";
+	std::ostringstream imploded;
+	std::copy(responseHeaders_.begin(), responseHeaders_.end(), std::ostream_iterator<std::string>(imploded, delim));
+	const std::string& s = httpLine_ + delim + imploded.str();
+	u32 sz = (u32)s.size();
+
+	u32* headerAddr = (u32*)Memory::GetPointerUnchecked(headerAddrPtr);
+	u32* headerSize = (u32*)Memory::GetPointerUnchecked(headerSizePtr);
+	// Resize internal header buffer (should probably be part of network memory pool?)
+	// FIXME: Do we still need to provides a valid address for the game even when header size is 0 ?
+	if (headerSize_ != sz && sz > 0) {
+		if (Memory::IsValidAddress(headerAddr_)) {
+			userMemory.Free(headerAddr_);
+		}
+		headerAddr_ = userMemory.Alloc(sz, false, "sceHttp response headers");
+		headerSize_ = sz;
+	}
+
+	u8* header = Memory::GetPointerWrite(headerAddr_);
+	DEBUG_LOG(Log::sceNet, "headerAddr: %08x => %08x", *headerAddr, headerAddr_);
+	DEBUG_LOG(Log::sceNet, "headerSize: %d => %d", *headerSize, sz);
+	if (!header && sz > 0) {
+		ERROR_LOG(Log::sceNet, "Failed to allocate internal header buffer.");
+		//*headerSize = 0;
+		//*headerAddr = 0;
+		return SCE_HTTP_ERROR_OUT_OF_MEMORY; // SCE_HTTP_ERROR_TOO_LARGE_RESPONSE_HEADER
+	}
+
+	if (sz > 0) {
+		memcpy(header, s.c_str(), sz);
+		NotifyMemInfo(MemBlockFlags::WRITE, headerAddr_, sz, "HttpGetAllHeader");
+	}
+	*headerSize = sz;
+	NotifyMemInfo(MemBlockFlags::WRITE, headerSizePtr, 4, "HttpGetAllHeader");
+
+	*headerAddr = headerAddr_;
+	NotifyMemInfo(MemBlockFlags::WRITE, headerAddrPtr, 4, "HttpGetAllHeader");
+
+	DEBUG_LOG(Log::sceNet, "Headers: %s", s.c_str());
+	return 0;
+}
+
+int HTTPRequest::readData(u32 destDataPtr, u32 size) {
+	// FIXME: Will sceHttpReadData returns an error if the request was not sent yet?
+	//if (progress_.progress == 0.0f)
+	//	return SCE_HTTP_ERROR_BEFORE_SEND;
+	u32 sz = std::min(size, (u32)responseContent_.size());
+	if (sz > 0) {
+		Memory::MemcpyUnchecked(destDataPtr, responseContent_.c_str(), sz);
+		NotifyMemInfo(MemBlockFlags::WRITE, destDataPtr, sz, "HttpReadData");
+		responseContent_.erase(0, sz);
+	}
+	return sz;
+}
+
+int HTTPRequest::sendRequest(u32 postDataPtr, u32 postDataSize) {
+	// Initialize Connection
+	client.SetDataTimeout(getRecvTimeout() / 1000000.0);
+	// Initialize Headers
+	if (getHttpVer() == SCE_HTTP_VERSION_1_0)
+		client.SetHttpVersion("1.0");
+	else
+		client.SetHttpVersion("1.1");
+	client.SetUserAgent(getUserAgent());
+	if (postDataSize > 0)
+		requestHeaders_["Content-Length"] = std::to_string(postDataSize);
+	const std::string delimiter = "\r\n";
+	const std::string extraHeaders = std::accumulate(requestHeaders_.begin(), requestHeaders_.end(), std::string(),
+		[delimiter](const std::string& s, const std::pair<const std::string, std::string>& p) {
+			return s + p.first + ": " + p.second + delimiter;
+		});
+
+	// TODO: Do this on a separate thread, since this may blocks "Emu" thread here
+	// Try to resolve first
+	Url fileUrl(url);
+	if (!fileUrl.Valid()) {
+		return SCE_HTTP_ERROR_INVALID_URL;
+	}
+	if (!client.Resolve(fileUrl.Host().c_str(), fileUrl.Port())) {
+		ERROR_LOG(Log::sceNet, "Failed resolving %s", fileUrl.ToString().c_str());
+		return -1;
+	}
+
+	// Establish Connection
+	if (!client.Connect(getResolveRetryCount(), getConnectTimeout() / 1000000.0, &cancelled_)) {
+		ERROR_LOG(Log::sceNet, "Failed connecting to server or cancelled.");
+		return -1; // SCE_HTTP_ERROR_ABORTED
+	}
+	if (cancelled_) {
+		return SCE_HTTP_ERROR_ABORTED;
+	}
+
+	// Send the Request
+	std::string methodstr = "GET";
+	switch (method) {
+	case PSP_HTTP_METHOD_POST:
+		methodstr = "POST";
+		break;
+	case PSP_HTTP_METHOD_HEAD:
+		methodstr = "HEAD";
+		break;
+	default:
+		break;
+	}
+	net::Buffer buffer_;
+	net::RequestProgress progress_(&cancelled_);
+	http::RequestParams req(fileUrl.Resource(), "*/*");
+	const char* postData = Memory::GetCharPointer(postDataPtr);
+	if (postDataSize > 0)
+		NotifyMemInfo(MemBlockFlags::READ, postDataPtr, postDataSize, "HttpSendRequest");
+	int err = client.SendRequestWithData(methodstr.c_str(), req, std::string(postData ? postData : "", postData ? postDataSize : 0), extraHeaders.c_str(), &progress_);
+	if (cancelled_) {
+		return SCE_HTTP_ERROR_ABORTED;
+	}
+	if (err < 0) {
+		return err; // SCE_HTTP_ERROR_BAD_RESPONSE;
+	}
+
+	// Retrieve Response's Status Code (and Headers too?)
+	responseCode_ = client.ReadResponseHeaders(&buffer_, responseHeaders_, &progress_, &httpLine_);
+	if (cancelled_) {
+		return SCE_HTTP_ERROR_ABORTED;
+	}
+
+	// TODO: Read response entity within readData() in smaller chunk(based on size arg of sceHttpReadData) instead of the whole content at once here
+	net::Buffer entity_;
+	int res = client.ReadResponseEntity(&buffer_, responseHeaders_, &entity_, &progress_);
+	if (res != 0) {
+		ERROR_LOG(Log::sceNet, "Unable to read HTTP response entity: %d", res);
+	}
+	entity_.TakeAll(&responseContent_);
+	if (cancelled_) {
+		return SCE_HTTP_ERROR_ABORTED;
+	}
+
+	return 0;
+}
+
+static void __HttpNotifyLifecycle(CoreLifecycle stage) {
+	if (stage == CoreLifecycle::STOPPING) {
+		for (const auto& it : httpObjects) {
+			if (it->className() == name_HTTPRequest)
+				(static_cast<HTTPRequest*>(it.get()))->abortRequest();
+		}
+	}
+}
+
+static void __HttpRequestStop() {
+	// This can happen from a separate thread.
+	std::lock_guard<std::mutex> guard(httpLock);
+	for (const auto& it : httpObjects) {
+		if (it->className() == name_HTTPRequest)
+			(static_cast<HTTPRequest*>(it.get()))->abortRequest();
+	}
+}
+
+void __HttpInit() {
+	Core_ListenLifecycle(&__HttpNotifyLifecycle);
+	Core_ListenStopRequest(&__HttpRequestStop);
+
+	// Finding memory leaks by object numbers
+	//_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+	//_CrtSetBreakAlloc(2407638);
+	//_CrtSetBreakAlloc(1691236);
+	//_CrtSetBreakAlloc(1691235);
+	//_CrtSetBreakAlloc(1691231);
+}
+
+void __HttpShutdown() {
+	std::lock_guard<std::mutex> guard(httpLock);
+	httpObjects.clear();
+}
+
+// id: ID of the template or connection
+int sceHttpSetResolveRetry(int id, int retryCount) {
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpSetResolveRetry(%d, %d)", id, retryCount);
+	if (id <= 0 || id > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	const auto& conn = httpObjects[id - 1LL];
+	if (!(conn->className() == name_HTTPTemplate || conn->className() == name_HTTPConnection))
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id (%s)", conn->className());
+
+	conn->setResolveRetry(retryCount);
+	return 0;
+}
+
+static int sceHttpInit(int poolSize) {
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpInit(%i)", poolSize);
+	if (httpInited)
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_ALREADY_INITED, "http already inited");
+
+	std::lock_guard<std::mutex> guard(httpLock);
+	httpObjects.clear();
+	// Reserve at least 1 element to prevent ::begin() from returning null when no element has been added yet
+	httpObjects.reserve(1);
+	httpInited = true;
 	return 0;
 }
 
 static int sceHttpEnd() {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpEnd()");
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpEnd()");
+	std::lock_guard<std::mutex> guard(httpLock);
+	httpObjects.clear();
+	httpInited = false;
 	return 0;
 }
 
 static int sceHttpInitCache(int size) {
 	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpInitCache(%d)", size);
+	httpCacheInited = true;
 	return 0;
 }
 
 static int sceHttpEndCache() {
 	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpEndCache()");
+	httpCacheInited = false;
 	return 0;
 }
 
-static int sceHttpEnableCache(int id) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpEnableCache(%d)", id);
+static int sceHttpEnableCache(int templateID) {
+	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpEnableCache(%d)", templateID);
 	return 0;
 }
 
-static int sceHttpDisableCache(int id) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpDisableCache(%d)", id);
+// FIXME: Can be TemplateID or ConnectionID ? Megaman PoweredUp seems to use both id on sceHttpDisableCache
+static int sceHttpDisableCache(int templateID) {
+	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpDisableCache(%d)", templateID);
 	return 0;
 }
 
@@ -76,42 +377,127 @@ static u32 sceHttpGetProxy(u32 id, u32 activateFlagPtr, u32 modePtr, u32 proxyHo
 }
 
 static int sceHttpGetStatusCode(int requestID, u32 statusCodePtr) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpGetStatusCode(%d, %x)", requestID, statusCodePtr);
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpGetStatusCode(%d, %x)", requestID, statusCodePtr);
+	if (requestID <= 0 || requestID > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	if (!Memory::IsValidRange(statusCodePtr, 4))
+		return hleLogError(Log::sceNet, -1, "invalid arg"); //SCE_HTTP_ERROR_INVALID_VALUE;
+
+	const auto& req = (HTTPRequest*)httpObjects[requestID - 1LL].get();
+	// FIXME: According to JPCSP, try to connect the request first
+	//req->connect();
+	int status = req->getStatusCode();
+	
+	DEBUG_LOG(Log::sceNet, "StatusCode = %d (in) => %d (out)", Memory::ReadUnchecked_U32(statusCodePtr), status);
+	Memory::WriteUnchecked_U32(status, statusCodePtr);
+	NotifyMemInfo(MemBlockFlags::WRITE, statusCodePtr, 4, "HttpGetStatusCode");
 	return 0;
 }
 
+// Games will repeatedly called sceHttpReadData until it returns (the size read into the data buffer) 0
+// FIXME: sceHttpReadData seems to be blocking current thread, since hleDelayResult can make Download progressbar to moves progressively instead of instantly jump to 100%
 static int sceHttpReadData(int requestID, u32 dataPtr, u32 dataSize) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpReadData(%d, %x, %x)", requestID, dataPtr, dataSize);
-	return 0;
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpReadData(%d, %x, %d)", requestID, dataPtr, dataSize);
+	if (requestID <= 0 || requestID > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	if (!Memory::IsValidRange(dataPtr, dataSize)) 
+		return hleLogError(Log::sceNet, -1, "invalid arg"); // SCE_HTTP_ERROR_INVALID_VALUE
+
+	const auto& req = (HTTPRequest*)httpObjects[requestID - 1LL].get();
+	// FIXME: According to JPCSP, try to connect the request first
+	//req->connect();
+
+	DEBUG_LOG(Log::sceNet, "Entity remaining / size = %d / %d", req->getResponseRemainingContentLength(), req->getResponseContentLength());
+	//if (req->getResponseContentLength()) == 0)
+	//	return hleLogError(SCENET, SCE_HTTP_ERROR_NO_CONTENT_LENGTH, "no content length");
+	int retval = req->readData(dataPtr, dataSize);
+
+	if (retval > 0) {
+		u8* data = (u8*)Memory::GetPointerUnchecked(dataPtr);
+		std::string datahex;
+		DataToHexString(10, 0, data, retval, &datahex);
+		DEBUG_LOG(Log::sceNet, "Data Dump (%d bytes):\n%s", retval, datahex.c_str());
+	}
+
+	// Faking latency to slow down download progressbar, since we currently downloading the full content at once instead of in chunk per sceHttpReadData's dataSize
+	return hleDelayResult(hleLogDebug(Log::sceNet, retval), "fake read data latency", 5000);
 }
 
+// FIXME: JPCSP didn't do anything other than appending the data into internal buffer, does sceHttpSendRequest can be called multiple times before using sceHttpGetStatusCode or sceHttpReadData? any game do this?
 static int sceHttpSendRequest(int requestID, u32 dataPtr, u32 dataSize) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpSendRequest(%d, %x, %x)", requestID, dataPtr, dataSize);
-	return 0;
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpSendRequest(%d, %x, %x)", requestID, dataPtr, dataSize);
+	if (!httpInited)
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_BEFORE_INIT, "http not initialized yet");
+
+	if (requestID <= 0 || requestID > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	if (dataSize > 0 && !Memory::IsValidRange(dataPtr, dataSize))
+		return hleLogError(Log::sceNet, -1, "invalid arg"); // SCE_HTTP_ERROR_INVALID_VALUE
+
+	const auto& req = (HTTPRequest*)httpObjects[requestID - 1LL].get();
+	// Internally try to connect, and get response headers (at least the status code?)
+	int retval = req->sendRequest(dataPtr, dataSize);
+	return hleLogDebug(Log::sceNet, retval);
 }
 
 static int sceHttpDeleteRequest(int requestID) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpDeleteRequest(%d)", requestID);
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpDeleteRequest(%d)", requestID);
+	std::lock_guard<std::mutex> guard(httpLock);
+	if (requestID <= 0 || requestID > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	if (httpObjects[requestID - 1LL]->className() != name_HTTPRequest)
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	httpObjects.erase(httpObjects.begin() + requestID - 1);
 	return 0;
 }
 
+// id: ID of the template, connection or request 
 static int sceHttpDeleteHeader(int id, const char *name) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpDeleteHeader(%d, %s)", id, name);
-	return 0;
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpDeleteHeader(%d, %s)", id, safe_string(name));
+	if (id <= 0 || id > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	const auto& req = (HTTPRequest*)httpObjects[id - 1LL].get();
+	return req->removeRequestHeader(name);
 }
 
 static int sceHttpDeleteConnection(int connectionID) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpDisableCache(%d)", connectionID);
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpDisableCache(%d)", connectionID);
+	std::lock_guard<std::mutex> guard(httpLock);
+	if (connectionID <= 0 || connectionID > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	if (httpObjects[connectionID - 1LL]->className() != name_HTTPConnection)
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	httpObjects.erase(httpObjects.begin() + connectionID - 1);
 	return 0;
 }
 
+// id: ID of the template, connection or request
 static int sceHttpSetConnectTimeOut(int id, u32 timeout) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpSetConnectTimeout(%d, %d)", id, timeout);
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpSetConnectTimeout(%d, %d)", id, timeout);
+	if (id <= 0 || id > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	auto& conn = httpObjects[id - 1LL];
+	conn->setConnectTimeout(timeout);
 	return 0;
 }
 
+// id: ID of the template, connection or request
 static int sceHttpSetSendTimeOut(int id, u32 timeout) {
 	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpSetSendTimeout(%d, %d)", id, timeout);
+	if (id <= 0 || id > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	auto& conn = httpObjects[id - 1LL];
+	conn->setSendTimeout(timeout);
 	return 0;
 }
 
@@ -120,64 +506,125 @@ static u32 sceHttpSetProxy(u32 id, u32 activateFlagPtr, u32 mode, u32 newProxyHo
 	return 0;
 }
 
+// id: ID of the template or connection
 static int sceHttpEnableCookie(int id) {
 	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpEnableCookie(%d)", id);
 	return 0;
 }
 
+// id: ID of the template or connection
 static int sceHttpEnableKeepAlive(int id) {
 	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpEnableKeepAlive(%d)", id);
 	return 0;
 }
 
+// id: ID of the template or connection
 static int sceHttpDisableCookie(int id) {
 	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpDisableCookie(%d)", id);
 	return 0;
 }
 
+// id: ID of the template or connection
 static int sceHttpDisableKeepAlive(int id) {
 	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpDisableKeepAlive(%d)", id);
 	return 0;
 }
 
 static int sceHttpsInit(int unknown1, int unknown2, int unknown3, int unknown4) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpsInit(%d, %d, %d, %d)", unknown1, unknown2, unknown3, unknown4);
+	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpsInit(%d, %d, %d, %x)", unknown1, unknown2, unknown3, unknown4);
+	httpsInited = true;
+	return 0;
+}
+
+static int sceHttpsInitWithPath(int unknown1, int unknown2, int unknown3) {
+	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpsInitWithPath(%d, %d, %d)", unknown1, unknown2, unknown3);
+	httpsInited = true;
 	return 0;
 }
 
 static int sceHttpsEnd() {
 	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpsEnd()");
+	httpsInited = false;
+	return 0;
+}
+
+static int sceHttpsDisableOption(int id) {
+	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpsDisableOption(%d)", id);
 	return 0;
 }
 
 // Parameter "method" should be one of PSPHttpMethod's listed entries
 static int sceHttpCreateRequest(int connectionID, int method, const char *path, u64 contentLength) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpCreateRequest(%d, %d, %s, %llx)", connectionID, method, path, contentLength);
-	return 0;
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpCreateRequest(%d, %d, %s, %llx)", connectionID, method, safe_string(path), contentLength);
+	std::lock_guard<std::mutex> guard(httpLock);
+	if (connectionID <= 0 || connectionID > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	if (httpObjects[connectionID - 1LL]->className() != name_HTTPConnection)
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	if (method < PSPHttpMethod::PSP_HTTP_METHOD_GET || method > PSPHttpMethod::PSP_HTTP_METHOD_HEAD)
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_UNKNOWN_METHOD, "unknown method");
+
+	httpObjects.emplace_back(std::make_shared<HTTPRequest>(connectionID, method, path? path:"", contentLength));
+	int retid = (int)httpObjects.size();
+	return hleLogSuccessI(Log::sceNet, retid);
 }
 
-static int sceHttpCreateConnection(int templateID, const char *hostString, const char *unknown1, u32 port, int unknown2) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpCreateConnection(%d, %s, %s, %d, %d)", templateID, hostString, unknown1, port, unknown2);
-	return 0;
+// FIXME: port type is probably u16
+static int sceHttpCreateConnection(int templateID, const char *hostString, const char *scheme, u32 port, int enableKeepalive) {
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpCreateConnection(%d, %s, %s, %d, %d)", templateID, safe_string(hostString), safe_string(scheme), port, enableKeepalive);
+	std::lock_guard<std::mutex> guard(httpLock);
+	if (templateID <= 0 || templateID > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	if (httpObjects[templateID - 1LL]->className() != name_HTTPTemplate)
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	httpObjects.emplace_back(std::make_shared<HTTPConnection>(templateID, hostString ? hostString : "", scheme ? scheme : "", port, enableKeepalive));
+	int retid = (int)httpObjects.size();
+	return hleLogSuccessI(Log::sceNet, retid);
 }
 
 static int sceHttpGetNetworkErrno(int request, u32 errNumPtr) {
 	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpGetNetworkErrno(%d, %x)", request, errNumPtr);
+	if (Memory::IsValidRange(errNumPtr, 4)) {
+		INFO_LOG(Log::sceNet, "Input errNum = %d", Memory::ReadUnchecked_U32(errNumPtr));
+		Memory::WriteUnchecked_U32(0, errNumPtr); // dummy error code 0 (no error?)
+		NotifyMemInfo(MemBlockFlags::WRITE, errNumPtr, 4, "HttpGetNetworkErrno");
+	}
 	return 0;
 }
 
+// id: ID of the template, connection or request
 static int sceHttpAddExtraHeader(int id, const char *name, const char *value, int unknown) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpAddExtraHeader(%d, %s, %s, %d)", id, name, value, unknown);
-	return 0;
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpAddExtraHeader(%d, %s, %s, %d)", id, safe_string(name), safe_string(value), unknown);
+	if (id <= 0 || id > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	const auto& req = (HTTPRequest*)httpObjects[id - 1LL].get();
+	return req->addRequestHeader(name, value, unknown);
 }
 
 static int sceHttpAbortRequest(int requestID) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpAbortRequest(%d)", requestID);
-	return 0;
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpAbortRequest(%d)", requestID);
+	if (requestID <= 0 || requestID > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	const auto& req = (HTTPRequest*)httpObjects[requestID - 1LL].get();
+	return req->abortRequest();
 }
 
 static int sceHttpDeleteTemplate(int templateID) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpDeleteTemplate(%d)", templateID);
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpDeleteTemplate(%d)", templateID);
+	std::lock_guard<std::mutex> guard(httpLock);
+	if (templateID <= 0 || templateID > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	if (httpObjects[templateID - 1LL]->className() != name_HTTPTemplate)
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	httpObjects.erase(httpObjects.begin() + templateID - 1);
 	return 0;
 }
 
@@ -186,8 +633,35 @@ static int sceHttpSetMallocFunction(u32 mallocFuncPtr, u32 freeFuncPtr, u32 real
 	return 0;
 }
 
+// id: ID of the template or connection
 static int sceHttpSetResolveTimeOut(int id, u32 timeout) {
 	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpSetResolveTimeOut(%d, %d)", id, timeout);
+	if (id <= 0 || id > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+	
+	const auto& conn = httpObjects[id - 1LL];
+	if (!(conn->className() == name_HTTPTemplate || conn->className() == name_HTTPConnection))
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id (%s)", conn->className());
+
+	conn->setResolveTimeout(timeout);
+	return 0;
+}
+
+//typedef int(* SceHttpsCallback) (unsigned int verifyEsrr, void *const sslCert[], int certNum, void *userArg)
+static int sceHttpsSetSslCallback(int id, u32 callbackFuncPtr, u32 userArgPtr) {
+	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpsSetSslCallback(%d, %x, %x)", id, callbackFuncPtr, userArgPtr);
+	return 0;
+}
+
+//typedef int(*SceHttpRedirectCallback) (int request, int statusCode, int* method, const char* location, void* userArg);
+static int sceHttpSetRedirectCallback(int requestID, u32 callbackFuncPtr, u32 userArgPtr) {
+	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpSetRedirectCallback(%d, %x, %x)", requestID, callbackFuncPtr, userArgPtr);
+	return 0;
+}
+
+//typedef int(*SceHttpAuthInfoCallback) (int request, SceHttpAuthType authType, const char* realm, char* username, char* password, int needEntity, unsigned char** entityBody, unsigned int* entitySize, int* save, void* userArg);
+static int sceHttpSetAuthInfoCallback(int id, u32 callbackFuncPtr, u32 userArgPtr) {
+	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpSetAuthInfoCallback(%d, %x, %x)", id, callbackFuncPtr, userArgPtr);
 	return 0;
 }
 
@@ -196,23 +670,25 @@ static int sceHttpSetAuthInfoCB(int id, u32 callbackFuncPtr) {
 	return 0;
 }
 
+// id: ID of the template or connection
 static int sceHttpEnableRedirect(int id) {
 	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpEnableRedirect(%d)", id);
 	return 0;
 }
 
-static int sceHttpEnableAuth(int id) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpEnableAuth(%d)", id);
+static int sceHttpEnableAuth(int templateID) {
+	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpEnableAuth(%d)", templateID);
 	return 0;
 }
 
+// id: ID of the template or connection
 static int sceHttpDisableRedirect(int id) {
 	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpDisableRedirect(%d)", id);
 	return 0;
 }
 
-static int sceHttpDisableAuth(int id) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpDisableAuth(%d)", id);
+static int sceHttpDisableAuth(int templateID) {
+	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpDisableAuth(%d)", templateID);
 	return 0;
 }
 
@@ -231,37 +707,118 @@ static int sceHttpLoadSystemCookie() {
 	return 0;
 }
 
-static int sceHttpCreateTemplate(const char *agent, int unknown1, int unknown2) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpCreateTemplate(%s, %d, %d)", agent, unknown1, unknown2);
-	return 0;
+// PSP Browser seems to set userAgent to 0 and later set the User-Agent header using sceHttpAddExtraHeader
+static int sceHttpCreateTemplate(const char *userAgent, int httpVer, int autoProxyConf) {
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpCreateTemplate(%s, %d, %d) at %08x", safe_string(userAgent), httpVer, autoProxyConf, currentMIPS->pc);
+	// Reporting to find more games to be tested
+	DEBUG_LOG_REPORT_ONCE(sceHttpCreateTemplate, Log::sceNet, "UNTESTED sceHttpCreateTemplate(%s, %d, %d)", safe_string(userAgent), httpVer, autoProxyConf);
+	std::lock_guard<std::mutex> guard(httpLock);
+	httpObjects.push_back(std::make_shared<HTTPTemplate>(userAgent? userAgent:"", httpVer, autoProxyConf));
+	int retid = (int)httpObjects.size();
+	return hleLogSuccessI(Log::sceNet, retid);
 }
 
 // Parameter "method" should be one of PSPHttpMethod's listed entries
 static int sceHttpCreateRequestWithURL(int connectionID, int method, const char *url, u64 contentLength) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpCreateRequestWithURL(%d, %d, %s, %llx)", connectionID, method, url, contentLength);
-	return 0;
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpCreateRequestWithURL(%d, %d, %s, %llx)", connectionID, method, safe_string(url), contentLength);
+	std::lock_guard<std::mutex> guard(httpLock);
+	if (connectionID <= 0 || connectionID > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	if (httpObjects[connectionID - 1LL]->className() != name_HTTPConnection)
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	if (method < PSPHttpMethod::PSP_HTTP_METHOD_GET || method > PSPHttpMethod::PSP_HTTP_METHOD_HEAD)
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_UNKNOWN_METHOD, "unknown method");
+
+	Url baseURL(url ? url : "");
+	if (!baseURL.Valid())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_URL, "invalid url");
+
+	httpObjects.emplace_back(std::make_shared<HTTPRequest>(connectionID, method, url? url:"", contentLength));
+	int retid = (int)httpObjects.size();
+	return hleLogSuccessI(Log::sceNet, retid);
 }
 
-static int sceHttpCreateConnectionWithURL(int templateID, const char *url, int unknown1) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpCreateConnectionWithURL(%d, %s, %d)", templateID, url, unknown1);
-	return 0;
+static int sceHttpCreateConnectionWithURL(int templateID, const char *url, int enableKeepalive) {
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpCreateConnectionWithURL(%d, %s, %d)", templateID, safe_string(url), enableKeepalive);
+	std::lock_guard<std::mutex> guard(httpLock);
+	if (templateID <= 0 || templateID > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	if (httpObjects[templateID - 1LL]->className() != name_HTTPTemplate)
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	Url baseURL(url? url: "");
+	if (!baseURL.Valid())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_URL, "invalid url");
+
+	httpObjects.emplace_back(std::make_shared<HTTPConnection>(templateID, baseURL.Host().c_str(), baseURL.Protocol().c_str(), baseURL.Port(), enableKeepalive));
+	int retid = (int)httpObjects.size();
+	return hleLogSuccessI(Log::sceNet, retid);
 }
 
+// id: ID of the template or connection
 static int sceHttpSetRecvTimeOut(int id, u32 timeout) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpSetRecvTimeOut(%d, %x)", id, timeout);
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpSetRecvTimeOut(%d, %d)", id, timeout);
+	if (id <= 0 || id > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	const auto& conn = httpObjects[id - 1LL];
+	if (!(conn->className() == name_HTTPTemplate || conn->className() == name_HTTPConnection))
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id (%s)", conn->className());
+
+	conn->setRecvTimeout(timeout);
 	return 0;
 }
 
-static int sceHttpGetAllHeader(int request, u32 headerPtrToPtr, u32 headerSize) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpGetAllHeader(%d, %x, %x)", request, headerPtrToPtr, headerSize);
+// FIXME: Headers should includes the "HTTP/MajorVer.MinorVer StatusCode Comment" line? so PSP Browser can parse it using sceParseHttpStatusLine
+// Note: Megaman PoweredUp seems to have an invalid address stored at the headerAddrPtr location, may be the game expecting us (network library) to give them a valid header address?
+static int sceHttpGetAllHeader(int requestID, u32 headerAddrPtr, u32 headerSizePtr) {
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpGetAllHeader(%d, %x, %x)", requestID, headerAddrPtr, headerSizePtr);
+	if (requestID <= 0 || requestID > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	if (!Memory::IsValidRange(headerAddrPtr, 4))
+		return hleLogError(Log::sceNet, -1, "invalid arg"); //SCE_HTTP_ERROR_INVALID_VALUE;
+
+	if (!Memory::IsValidRange(headerSizePtr, 4)) 
+		return hleLogError(Log::sceNet, -1, "invalid arg"); //SCE_HTTP_ERROR_INVALID_VALUE;
+
+	const auto& req = (HTTPRequest*)httpObjects[requestID - 1LL].get();
+	// FIXME: According to JPCSP, try to connect the request first
+	//req->connect();
+	int retval = req->getAllResponseHeaders(headerAddrPtr, headerSizePtr);
+	return hleLogDebug(Log::sceNet, retval);
+}
+
+// FIXME: contentLength is SceULong64 but this contentLengthPtr argument should be a 32bit pointer instead of 64bit, right?
+static int sceHttpGetContentLength(int requestID, u32 contentLengthPtr) {
+	WARN_LOG(Log::sceNet, "UNTESTED sceHttpGetContentLength(%d, %x)", requestID, contentLengthPtr);
+	if (requestID <= 0 || requestID > httpObjects.size())
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
+
+	if (!Memory::IsValidRange(contentLengthPtr, 8))
+		return hleLogError(Log::sceNet, -1, "invalid arg"); //SCE_HTTP_ERROR_INVALID_VALUE;
+
+	const auto& req = (HTTPRequest*)httpObjects[requestID - 1LL].get();
+	// FIXME: According to JPCSP, try to connect the request first
+	//req->connect();
+	int len = req->getResponseContentLength();
+	if (len < 0)
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_NO_CONTENT_LENGTH, "no content length");
+
+	DEBUG_LOG(Log::sceNet, "ContentLength = %lld (in) => %lld (out)", Memory::Read_U64(contentLengthPtr), (u64)len);
+	Memory::Write_U64((u64)len, contentLengthPtr);
+	NotifyMemInfo(MemBlockFlags::WRITE, contentLengthPtr, 8, "HttpGetContentLength");
 	return 0;
 }
 
-static int sceHttpGetContentLength(int requestID, u64 contentLengthPtr) {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpGetContentLength(%d, %llx)", requestID, contentLengthPtr);
-	return 0;
-}
-
+/*
+0x62411801 sceSircsInit
+0x19155a2f sceSircsEnd
+0x71eef62d sceSircsSend
+*/
 const HLEFunction sceHttp[] = {
 	{0XAB1ABE07, &WrapI_I<sceHttpInit>,                      "sceHttpInit",                    'i', "i"     },
 	{0XD1C8945E, &WrapI_V<sceHttpEnd>,                       "sceHttpEnd",                     'i', ""      },
@@ -307,15 +864,15 @@ const HLEFunction sceHttp[] = {
 	{0XCDF8ECB9, &WrapI_ICI<sceHttpCreateConnectionWithURL>, "sceHttpCreateConnectionWithURL", 'i', "isi"   },
 	{0X1F0FC3E3, &WrapI_IU<sceHttpSetRecvTimeOut>,           "sceHttpSetRecvTimeOut",          'i', "ix"    },
 	{0XDB266CCF, &WrapI_IUU<sceHttpGetAllHeader>,            "sceHttpGetAllHeader",            'i', "ixx"   },
-	{0X0282A3BD, &WrapI_IU64<sceHttpGetContentLength>,       "sceHttpGetContentLength",        'i', "iX"    },
+	{0X0282A3BD, &WrapI_IU<sceHttpGetContentLength>,         "sceHttpGetContentLength",        'i', "ix"    },
 	{0X7774BF4C, nullptr,                                    "sceHttpAddCookie",               '?', ""      },
-	{0X68AB0F86, nullptr,                                    "sceHttpsInitWithPath",           '?', ""      },
-	{0XB3FAF831, nullptr,                                    "sceHttpsDisableOption",          '?', ""      },
+	{0X68AB0F86, &WrapI_III<sceHttpsInitWithPath>,           "sceHttpsInitWithPath",           'i', "iii"   },
+	{0XB3FAF831, &WrapI_I<sceHttpsDisableOption>,            "sceHttpsDisableOption",          'i', "i"     },
 	{0X2255551E, nullptr,                                    "sceHttpGetNetworkPspError",      '?', ""      },
 	{0XAB1540D5, nullptr,                                    "sceHttpsGetSslError",            '?', ""      },
-	{0XA4496DE5, nullptr,                                    "sceHttpSetRedirectCallback",     '?', ""      },
-	{0X267618F4, nullptr,                                    "sceHttpSetAuthInfoCallback",     '?', ""      },
-	{0X569A1481, nullptr,                                    "sceHttpsSetSslCallback",         '?', ""      },
+	{0XA4496DE5, &WrapI_IUU<sceHttpSetRedirectCallback>,     "sceHttpSetRedirectCallback",     'i', "ixx"   },
+	{0X267618F4, &WrapI_IUU<sceHttpSetAuthInfoCallback>,     "sceHttpSetAuthInfoCallback",     'i', "ixx"   },
+	{0X569A1481, &WrapI_IUU<sceHttpsSetSslCallback>,         "sceHttpsSetSslCallback",         'i', "ixx"   },
 	{0XBAC31BF1, nullptr,                                    "sceHttpsEnableOption",           '?', ""      },
 };				
 

--- a/Core/HLE/sceHttp.cpp
+++ b/Core/HLE/sceHttp.cpp
@@ -146,8 +146,8 @@ int HTTPRequest::getAllResponseHeaders(u32 headerAddrPtr, u32 headerSizePtr) {
 	const std::string& s = httpLine_ + delim + imploded.str();
 	u32 sz = (u32)s.size();
 
-	u32* headerAddr = (u32*)Memory::GetPointerUnchecked(headerAddrPtr);
-	u32* headerSize = (u32*)Memory::GetPointerUnchecked(headerSizePtr);
+	auto headerAddr = PSPPointer<u32>::Create(headerAddrPtr);
+	auto headerSize = PSPPointer<u32>::Create(headerSizePtr);
 	// Resize internal header buffer (should probably be part of network memory pool?)
 	// FIXME: Do we still need to provides a valid address for the game even when header size is 0 ?
 	if (headerSize_ != sz && sz > 0) {
@@ -159,8 +159,8 @@ int HTTPRequest::getAllResponseHeaders(u32 headerAddrPtr, u32 headerSizePtr) {
 	}
 
 	u8* header = Memory::GetPointerWrite(headerAddr_);
-	DEBUG_LOG(Log::sceNet, "headerAddr: %08x => %08x", *headerAddr, headerAddr_);
-	DEBUG_LOG(Log::sceNet, "headerSize: %d => %d", *headerSize, sz);
+	DEBUG_LOG(Log::sceNet, "headerAddr: %08x => %08x", headerAddr.IsValid() ? *headerAddr : 0, headerAddr_);
+	DEBUG_LOG(Log::sceNet, "headerSize: %d => %d", headerSize.IsValid() ? *headerSize : 0, sz);
 	if (!header && sz > 0) {
 		ERROR_LOG(Log::sceNet, "Failed to allocate internal header buffer.");
 		//*headerSize = 0;
@@ -172,11 +172,17 @@ int HTTPRequest::getAllResponseHeaders(u32 headerAddrPtr, u32 headerSizePtr) {
 		memcpy(header, s.c_str(), sz);
 		NotifyMemInfo(MemBlockFlags::WRITE, headerAddr_, sz, "HttpGetAllHeader");
 	}
-	*headerSize = sz;
-	NotifyMemInfo(MemBlockFlags::WRITE, headerSizePtr, 4, "HttpGetAllHeader");
 
-	*headerAddr = headerAddr_;
-	NotifyMemInfo(MemBlockFlags::WRITE, headerAddrPtr, 4, "HttpGetAllHeader");
+	// Set the output
+	if (headerSize.IsValid()) {
+		*headerSize = sz;
+		headerSize.NotifyWrite("HttpGetAllHeader");
+	}
+
+	if (headerAddr.IsValid()) {
+		*headerAddr = headerAddr_;
+		headerAddr.NotifyWrite("HttpGetAllHeader");
+	}
 
 	DEBUG_LOG(Log::sceNet, "Headers: %s", s.c_str());
 	return 0;

--- a/Core/HLE/sceHttp.cpp
+++ b/Core/HLE/sceHttp.cpp
@@ -299,13 +299,6 @@ static void __HttpRequestStop() {
 void __HttpInit() {
 	Core_ListenLifecycle(&__HttpNotifyLifecycle);
 	Core_ListenStopRequest(&__HttpRequestStop);
-
-	// Finding memory leaks by object numbers
-	//_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
-	//_CrtSetBreakAlloc(2407638);
-	//_CrtSetBreakAlloc(1691236);
-	//_CrtSetBreakAlloc(1691235);
-	//_CrtSetBreakAlloc(1691231);
 }
 
 void __HttpShutdown() {

--- a/Core/HLE/sceHttp.cpp
+++ b/Core/HLE/sceHttp.cpp
@@ -105,15 +105,13 @@ int HTTPRequest::getResponseContentLength() {
 	//if (progress_.progress == 0.0f)
 	//	return SCE_HTTP_ERROR_BEFORE_SEND;
 
-	entityLength_ = -1;
+	entityLength_ = -1; // FIXME: should we default to 0 instead?
 	for (std::string& line : responseHeaders_) {
-		if (startsWithNoCase(line, "Content-Length:")) {
-			size_t size_pos = line.find_first_of(' ');
-			if (size_pos != line.npos) {
-				size_pos = line.find_first_not_of(' ', size_pos);
-			}
-			if (size_pos != line.npos) {
-				entityLength_ = atoi(&line[size_pos]);
+		if (startsWithNoCase(line, "Content-Length")) {
+			size_t pos = line.find_first_of(':');
+			if (pos != line.npos) {
+				pos++;
+				entityLength_ = atoi(&line[pos]);
 			}
 		}
 	}

--- a/Core/HLE/sceHttp.h
+++ b/Core/HLE/sceHttp.h
@@ -17,6 +17,275 @@
 
 #pragma once
 
-int sceHttpSetResolveRetry(int connectionID, int retryCount);
+#include "Common/Net/HTTPClient.h"
+
+// Based on https://docs.vitasdk.org/group__SceHttpUser.html
+#define 	SCE_HTTP_DEFAULT_RESOLVER_TIMEOUT   (1 * 1000 * 1000U)
+#define 	SCE_HTTP_DEFAULT_RESOLVER_RETRY   (5U)
+#define 	SCE_HTTP_DEFAULT_CONNECT_TIMEOUT   (30* 1000 * 1000U)
+#define 	SCE_HTTP_DEFAULT_SEND_TIMEOUT   (120* 1000 * 1000U)
+#define 	SCE_HTTP_DEFAULT_RECV_TIMEOUT   (120* 1000 * 1000U)
+#define 	SCE_HTTP_DEFAULT_RECV_BLOCK_SIZE   (1500U)
+#define 	SCE_HTTP_DEFAULT_RESPONSE_HEADER_MAX   (5000U)
+#define 	SCE_HTTP_DEFAULT_REDIRECT_MAX   (6U)
+#define 	SCE_HTTP_DEFAULT_TRY_AUTH_MAX   (6U)
+#define 	SCE_HTTP_INVALID_ID   0
+#define 	SCE_HTTP_ENABLE   (1)
+#define 	SCE_HTTP_DISABLE   (0)
+#define 	SCE_HTTP_USERNAME_MAX_SIZE   256
+#define 	SCE_HTTP_PASSWORD_MAX_SIZE   256
+
+// If http isn't loaded (seems unlikely), most functions should return SCE_KERNEL_ERROR_LIBRARY_NOTFOUND
+
+// lib_http specific error codes, based on https://uofw.github.io/uofw/lib__http_8h_source.html, combined with https://github.com/vitasdk/vita-headers/blob/master/include/psp2/net/http.h
+enum SceHttpErrorCode {
+	SCE_HTTP_ERROR_BEFORE_INIT = 0x80431001,
+	SCE_HTTP_ERROR_NOT_SUPPORTED = 0x80431004,
+	SCE_HTTP_ERROR_ALREADY_INITED = 0x80431020,
+	SCE_HTTP_ERROR_BUSY = 0x80431021,
+	SCE_HTTP_ERROR_OUT_OF_MEMORY = 0x80431022,
+	SCE_HTTP_ERROR_NOT_FOUND = 0x80431025,
+
+	SCE_HTTP_ERROR_UNKNOWN_SCHEME = 0x80431061,
+	SCE_HTTP_ERROR_NETWORK = 0x80431063,
+	SCE_HTTP_ERROR_BAD_RESPONSE = 0x80431064,
+	SCE_HTTP_ERROR_BEFORE_SEND = 0x80431065,
+	SCE_HTTP_ERROR_AFTER_SEND = 0x80431066,
+	SCE_HTTP_ERROR_TIMEOUT = 0x80431068,
+	SCE_HTTP_ERROR_UNKOWN_AUTH_TYPE = 0x80431069,
+	SCE_HTTP_ERROR_INVALID_VERSION = 0x8043106A,
+	SCE_HTTP_ERROR_UNKNOWN_METHOD = 0x8043106B,
+	SCE_HTTP_ERROR_READ_BY_HEAD_METHOD = 0x8043106F,
+	SCE_HTTP_ERROR_NOT_IN_COM = 0x80431070,
+	SCE_HTTP_ERROR_NO_CONTENT_LENGTH = 0x80431071,
+	SCE_HTTP_ERROR_CHUNK_ENC = 0x80431072,
+	SCE_HTTP_ERROR_TOO_LARGE_RESPONSE_HEADER = 0x80431073,
+	SCE_HTTP_ERROR_SSL = 0x80431075,
+	SCE_HTTP_ERROR_INSUFFICIENT_HEAPSIZE = 0x80431077,
+	SCE_HTTP_ERROR_BEFORE_COOKIE_LOAD = 0x80431078,
+	SCE_HTTP_ERROR_ABORTED = 0x80431080,
+	SCE_HTTP_ERROR_UNKNOWN = 0x80431081,
+
+	SCE_HTTP_ERROR_INVALID_ID = 0x80431100,
+	SCE_HTTP_ERROR_OUT_OF_SIZE = 0x80431104,
+	SCE_HTTP_ERROR_INVALID_VALUE = 0x804311FE,
+
+	SCE_HTTP_ERROR_PARSE_HTTP_NOT_FOUND = 0x80432025,
+	SCE_HTTP_ERROR_PARSE_HTTP_INVALID_RESPONSE = 0x80432060,
+	SCE_HTTP_ERROR_PARSE_HTTP_INVALID_VALUE = 0x804321FE,
+
+	SCE_HTTP_ERROR_INVALID_URL = 0x80433060,
+
+	SCE_HTTP_ERROR_RESOLVER_EPACKET = 0x80436001,
+	SCE_HTTP_ERROR_RESOLVER_ENODNS = 0x80436002,
+	SCE_HTTP_ERROR_RESOLVER_ETIMEDOUT = 0x80436003,
+	SCE_HTTP_ERROR_RESOLVER_ENOSUPPORT = 0x80436004,
+	SCE_HTTP_ERROR_RESOLVER_EFORMAT = 0x80436005,
+	SCE_HTTP_ERROR_RESOLVER_ESERVERFAILURE = 0x80436006,
+	SCE_HTTP_ERROR_RESOLVER_ENOHOST = 0x80436007,
+	SCE_HTTP_ERROR_RESOLVER_ENOTIMPLEMENTED = 0x80436008,
+	SCE_HTTP_ERROR_RESOLVER_ESERVERREFUSED = 0x80436009,
+	SCE_HTTP_ERROR_RESOLVER_ENORECORD = 0x8043600A
+};
+
+// lib_https specific error codes, based on https://uofw.github.io/uofw/lib__https_8h_source.html, combined with https://github.com/vitasdk/vita-headers/blob/master/include/psp2/net/http.h
+enum SceHttpsErrorCode {
+	SCE_HTTPS_ERROR_OUT_OF_MEMORY = 0x80435022,
+	SCE_HTTPS_ERROR_CERT = 0x80435060,
+	SCE_HTTPS_ERROR_HANDSHAKE = 0x80435061,
+	SCE_HTTPS_ERROR_IO = 0x80435062,
+	SCE_HTTPS_ERROR_INTERNAL = 0x80435063,
+	SCE_HTTPS_ERROR_PROXY = 0x80435064
+};
+
+// Could come in handy someday if we ever implement sceHttp* for real.
+enum PSPHttpMethod {
+	PSP_HTTP_METHOD_GET,
+	PSP_HTTP_METHOD_POST,
+	PSP_HTTP_METHOD_HEAD
+};
+
+// Based on https://github.com/vitasdk/vita-headers/blob/master/include/psp2/net/http.h
+enum SceHttpStatusCode {
+	SCE_HTTP_STATUS_CODE_CONTINUE = 100,
+	SCE_HTTP_STATUS_CODE_SWITCHING_PROTOCOLS = 101,
+	SCE_HTTP_STATUS_CODE_PROCESSING = 102,
+	SCE_HTTP_STATUS_CODE_OK = 200,
+	SCE_HTTP_STATUS_CODE_CREATED = 201,
+	SCE_HTTP_STATUS_CODE_ACCEPTED = 202,
+	SCE_HTTP_STATUS_CODE_NON_AUTHORITATIVE_INFORMATION = 203,
+	SCE_HTTP_STATUS_CODE_NO_CONTENT = 204,
+	SCE_HTTP_STATUS_CODE_RESET_CONTENT = 205,
+	SCE_HTTP_STATUS_CODE_PARTIAL_CONTENT = 206,
+	SCE_HTTP_STATUS_CODE_MULTI_STATUS = 207,
+	SCE_HTTP_STATUS_CODE_MULTIPLE_CHOICES = 300,
+	SCE_HTTP_STATUS_CODE_MOVED_PERMANENTLY = 301,
+	SCE_HTTP_STATUS_CODE_FOUND = 302,
+	SCE_HTTP_STATUS_CODE_SEE_OTHER = 303,
+	SCE_HTTP_STATUS_CODE_NOT_MODIFIED = 304,
+	SCE_HTTP_STATUS_CODE_USE_PROXY = 305,
+	SCE_HTTP_STATUS_CODE_TEMPORARY_REDIRECT = 307,
+	SCE_HTTP_STATUS_CODE_BAD_REQUEST = 400,
+	SCE_HTTP_STATUS_CODE_UNAUTHORIZED = 401,
+	SCE_HTTP_STATUS_CODE_PAYMENT_REQUIRED = 402,
+	SCE_HTTP_STATUS_CODE_FORBIDDDEN = 403,
+	SCE_HTTP_STATUS_CODE_NOT_FOUND = 404,
+	SCE_HTTP_STATUS_CODE_METHOD_NOT_ALLOWED = 405,
+	SCE_HTTP_STATUS_CODE_NOT_ACCEPTABLE = 406,
+	SCE_HTTP_STATUS_CODE_PROXY_AUTHENTICATION_REQUIRED = 407,
+	SCE_HTTP_STATUS_CODE_REQUEST_TIME_OUT = 408,
+	SCE_HTTP_STATUS_CODE_CONFLICT = 409,
+	SCE_HTTP_STATUS_CODE_GONE = 410,
+	SCE_HTTP_STATUS_CODE_LENGTH_REQUIRED = 411,
+	SCE_HTTP_STATUS_CODE_PRECONDITION_FAILED = 412,
+	SCE_HTTP_STATUS_CODE_REQUEST_ENTITY_TOO_LARGE = 413,
+	SCE_HTTP_STATUS_CODE_REQUEST_URI_TOO_LARGE = 414,
+	SCE_HTTP_STATUS_CODE_UNSUPPORTED_MEDIA_TYPE = 415,
+	SCE_HTTP_STATUS_CODE_REQUEST_RANGE_NOT_SATISFIBLE = 416,
+	SCE_HTTP_STATUS_CODE_EXPECTATION_FAILED = 417,
+	SCE_HTTP_STATUS_CODE_UNPROCESSABLE_ENTITY = 422,
+	SCE_HTTP_STATUS_CODE_LOCKED = 423,
+	SCE_HTTP_STATUS_CODE_FAILED_DEPENDENCY = 424,
+	SCE_HTTP_STATUS_CODE_UPGRADE_REQUIRED = 426,
+	SCE_HTTP_STATUS_CODE_INTERNAL_SERVER_ERROR = 500,
+	SCE_HTTP_STATUS_CODE_NOT_IMPLEMENTED = 501,
+	SCE_HTTP_STATUS_CODE_BAD_GATEWAY = 502,
+	SCE_HTTP_STATUS_CODE_SERVICE_UNAVAILABLE = 503,
+	SCE_HTTP_STATUS_CODE_GATEWAY_TIME_OUT = 504,
+	SCE_HTTP_STATUS_CODE_HTTP_VERSION_NOT_SUPPORTED = 505,
+	SCE_HTTP_STATUS_CODE_INSUFFICIENT_STORAGE = 507
+};
+
+enum SceHttpVersion {
+	SCE_HTTP_VERSION_1_0 = 1,
+	SCE_HTTP_VERSION_1_1
+};
+
+enum SceHttpProxyMode {
+	SCE_HTTP_PROXY_AUTO,
+	SCE_HTTP_PROXY_MANUAL
+};
+
+enum SceHttpAddHeaderMode {
+	SCE_HTTP_HEADER_OVERWRITE,
+	SCE_HTTP_HEADER_ADD
+};
+
+
+// Just a holder for class names
+static const char* name_HTTPTemplate = "HTTPTemplate";
+static const char* name_HTTPConnection = "HTTPConnection";
+static const char* name_HTTPRequest = "HTTPRequest";
+
+class HTTPTemplate {
+protected:
+	std::string userAgent; // char userAgent[512];
+	SceHttpVersion httpVer = SCE_HTTP_VERSION_1_0;
+	SceHttpProxyMode autoProxyConf = SCE_HTTP_PROXY_AUTO;
+
+	int useCookie = 0;
+	int useKeepAlive = 0;
+	int useCache = 0;
+	int useAuth = 0;
+	int useRedirect = 0;
+
+	u32 connectTimeout = SCE_HTTP_DEFAULT_CONNECT_TIMEOUT;
+	u32 sendTimeout = SCE_HTTP_DEFAULT_SEND_TIMEOUT;
+	u32 recvTimeout = SCE_HTTP_DEFAULT_RECV_TIMEOUT;
+	u32 resolveTimeout = SCE_HTTP_DEFAULT_RESOLVER_TIMEOUT;
+	int resolveRetryCount = SCE_HTTP_DEFAULT_RESOLVER_RETRY;
+
+	std::map<std::string, std::string> requestHeaders_;
+
+public:
+	HTTPTemplate() {}
+	HTTPTemplate(const char* userAgent, int httpVer, int autoProxyConf);
+	virtual ~HTTPTemplate() = default;
+
+	virtual const char* className() { return name_HTTPTemplate; } // to be more consistent, unlike typeid(v).name() which may varies among different compilers and requires RTTI
+
+	const std::string getUserAgent() { return userAgent; }
+	int getHttpVer() { return httpVer; }
+	int getAutoProxyConf() { return autoProxyConf; }
+
+	u32 getConnectTimeout() { return connectTimeout; }
+	u32 getSendTimeout() { return sendTimeout; }
+	u32 getRecvTimeout() { return recvTimeout; }
+	u32 getResolveTimeout() { return resolveTimeout; }
+	int getResolveRetryCount() { return resolveRetryCount; }
+
+	void setUserAgent(const char* userAgent) { this->userAgent = userAgent ? userAgent : ""; }
+	void setConnectTimeout(u32 timeout) { this->connectTimeout = timeout; }
+	void setSendTimeout(u32 timeout) { this->sendTimeout = timeout; }
+	void setRecvTimeout(u32 timeout) { this->recvTimeout = timeout; }
+	void setResolveTimeout(u32 timeout) { this->resolveTimeout = timeout; }
+	void setResolveRetry(u32 retryCount) { this->resolveRetryCount = retryCount; }
+
+	int addRequestHeader(const char* name, const char* value, u32 mode);
+	int removeRequestHeader(const char* name);
+};
+
+class HTTPConnection : public HTTPTemplate {
+protected:
+	int templateID = 0;
+	std::string hostString;
+	std::string scheme;
+	u16 port = 80;
+	int enableKeepalive = 0;
+
+public:
+	HTTPConnection() {}
+	HTTPConnection(int templateID, const char* hostString, const char* scheme, u32 port, int enableKeepalive);
+	virtual ~HTTPConnection() = default;
+
+	virtual const char* className() override { return name_HTTPConnection; }
+
+	int getTemplateID() { return templateID; }
+	const std::string getHost() { return hostString; }
+	const std::string getScheme() { return scheme; }
+	u16 getPort() { return port; }
+	int getKeepAlive() { return enableKeepalive; }
+};
+
+class HTTPRequest : public HTTPConnection {
+private:
+	int connectionID;
+	int method;
+	u64 contentLength;
+	std::string url;
+
+	u32 headerAddr_ = 0;
+	u32 headerSize_ = 0;
+	bool cancelled_ = false;
+	int responseCode_ = -1;
+	int entityLength_ = -1;
+
+	http::Client client;
+	//net::RequestProgress progress_(&cancelled_);
+	std::vector<std::string> responseHeaders_;
+	std::string httpLine_;
+	std::string responseContent_;
+
+public:
+	HTTPRequest(int connectionID, int method, const char* url, u64 contentLength);
+	~HTTPRequest();
+
+	virtual const char* className() override { return name_HTTPRequest; }
+
+	void setInternalHeaderAddr(u32 addr) { headerAddr_ = addr; }
+	int getConnectionID() { return connectionID; }
+	int getResponseRemainingContentLength() { return (int)responseContent_.size(); }
+
+	int getResponseContentLength();
+	int abortRequest();
+	int getStatusCode();
+	int getAllResponseHeaders(u32 headerAddrPtr, u32 headerSizePtr);
+	int readData(u32 destDataPtr, u32 size);
+	int sendRequest(u32 postDataPtr, u32 postDataSize);
+};
+
+
+void __HttpInit();
+void __HttpShutdown();
 
 void Register_sceHttp();

--- a/Core/HLE/sceHttp.h
+++ b/Core/HLE/sceHttp.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <map>
 #include "Common/Net/HTTPClient.h"
 
 // Based on https://docs.vitasdk.org/group__SceHttpUser.html

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -88,6 +88,7 @@
 #include "sceDmac.h"
 #include "sceMp4.h"
 #include "sceOpenPSID.h"
+#include "sceHttp.h"
 #include "Core/Util/PPGeDraw.h"
 
 /*
@@ -157,6 +158,7 @@ void __KernelInit()
 	__UsbCamInit();
 	__UsbMicInit();
 	__OpenPSIDInit();
+	__HttpInit();
 	
 	SaveState::Init();  // Must be after IO, as it may create a directory
 	Reporting::Init();
@@ -181,6 +183,7 @@ void __KernelShutdown()
 	hleCurrentThreadName = NULL;
 	kernelObjects.Clear();
 
+	__HttpShutdown();
 	__OpenPSIDShutdown();
 	__UsbCamShutdown();
 	__UsbMicShutdown();

--- a/Core/HLE/sceNetInet.cpp
+++ b/Core/HLE/sceNetInet.cpp
@@ -640,6 +640,9 @@ static u32 sceNetInetInetAddr(const char *hostname) {
 		sceNetInet->SetLastErrorToMatchPlatform();
 		return inAddr.s_addr;
 	}
+
+	// TODO: Should this return ret or inAddr.sAddr? Conflicting info between the two PRs!
+
 	return hleLogSuccessI(Log::sceNet, ret);
 }
 

--- a/Core/HLE/sceNetInet.h
+++ b/Core/HLE/sceNetInet.h
@@ -135,7 +135,10 @@ enum PspInetMessageFlag {
 };
 
 enum InetErrorCode {
+	INET_EAGAIN = 0x0B,
+	INET_ETIMEDOUT = 0x74,
     INET_EINPROGRESS = 119,
+	INET_EISCONN = 0x7F,
 };
 
 class SceNetInet {

--- a/Core/HLE/sceParseHttp.cpp
+++ b/Core/HLE/sceParseHttp.cpp
@@ -19,10 +19,92 @@
 #include <regex>
 
 #include "Core/HLE/HLE.h"
+#include "Core/HLE/sceHttp.h"
 #include "Core/HLE/sceParseHttp.h"
 #include "Core/HLE/FunctionWrappers.h"
 #include "Core/Debugger/MemBlockInfo.h"
+#include "Common/StringUtils.h"
 
+std::string getHeaderString(std::istringstream &headers) {
+	std::string line = "";
+	while (headers.rdbuf()->in_avail()) {
+		char c = headers.get();
+		if (c == '\n' || c == '\r') {
+			break;
+		}
+		line.push_back(c);
+	}
+
+	return line;
+}
+
+// FIXME: Is it allowed for fieldName to be null/0 or empty string ? JPCSP seems to ignore it
+static int sceParseHttpResponseHeader(u32 headerAddr, int headerLength, const char *fieldName, u32 valueAddr, u32 valueLengthAddr) {
+	WARN_LOG(Log::sceNet, "UNTESTED sceParseHttpResponseHeader(%x, %i, %s, %x, %x[%i]) at %08x", headerAddr, headerLength, fieldName, valueAddr, valueLengthAddr, Memory::Read_U32(valueLengthAddr), currentMIPS->pc);
+	if (!Memory::IsValidRange(headerAddr, headerLength))
+		return hleLogError(Log::sceNet, -1, "invalid arg");
+
+	if (!Memory::IsValidRange(valueLengthAddr, 4))
+		return hleLogError(Log::sceNet, -1, "invalid arg");
+
+	// FIXME: Not sure whether valuerAddr can be null or not (in case the game just need to get the size to allocate the value buffer first)
+	// Note: Based on the outputted value address from JPCSP, the address seems to be within the input headers address range, thus no need to allocate output value buffer
+	if (!Memory::IsValidRange(valueAddr, Memory::Read_U32(valueLengthAddr)))
+		return hleLogError(Log::sceNet, -1, "invalid arg");
+
+	std::string field = "";
+	if (fieldName != nullptr)
+		field = std::string(fieldName);
+	field = StripSpaces(field);
+	std::string headers(Memory::GetCharPointer(headerAddr), headerLength);
+	std::istringstream hdrs(headers);
+	u32 addr = 0;
+	u32 len = 0;
+	bool found = false;
+	while (hdrs.rdbuf()->in_avail()) {
+		std::string headerString = getHeaderString(hdrs);
+		const std::string delim = ":"; // JPCSP use ": " delimiter
+		size_t delimpos = headerString.find(delim);
+		std::string key = headerString.substr(0, delimpos); // the key part
+		if (equalsNoCase(StripSpaces(key), field.c_str())) {
+			found = true;
+			int offset = hdrs.tellg();
+			if (offset >= 0) {
+				offset -= (int)headerString.length();
+				offset--; // counting the excluded LF/CR
+			}
+			else {
+				offset = headerLength - (int)headerString.length();
+			}
+			addr = headerAddr + offset + (int)(delimpos != std::string::npos? delimpos + delim.length() : headerString.length()); // value address within the headers
+			headerString.erase(0, delimpos + delim.length()); // the value part
+			size_t valpos = headerString.find_first_not_of(" "); // excludes the leading space (if any)
+			if (valpos == std::string::npos) {
+				len = 0;
+			}
+			else {
+				len = (int)headerString.length() - (int)valpos;
+				addr += (int)valpos;
+			}
+
+			Memory::WriteUnchecked_U32(addr, valueAddr);
+			NotifyMemInfo(MemBlockFlags::WRITE, valueAddr, 4, "sceParseHttpResponseHeader");
+			Memory::WriteUnchecked_U32(len, valueLengthAddr);
+			NotifyMemInfo(MemBlockFlags::WRITE, valueLengthAddr, 4, "sceParseHttpResponseHeader");
+			break;
+		}
+	}
+
+	if (!found) {
+		Memory::WriteUnchecked_U32(0, valueAddr);
+		NotifyMemInfo(MemBlockFlags::WRITE, valueAddr, 4, "sceParseHttpResponseHeader");
+		Memory::WriteUnchecked_U32(0, valueLengthAddr);
+		NotifyMemInfo(MemBlockFlags::WRITE, valueLengthAddr, 4, "sceParseHttpResponseHeader");
+		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_PARSE_HTTP_NOT_FOUND, "parse http not found");
+	}
+
+	return hleLogSuccessI(Log::sceNet, len);
+}
 
 static int sceParseHttpStatusLine(u32 headerAddr, u32 headerLength, u32 httpVersionMajorAddr, u32 httpVersionMinorAddr, u32 httpStatusCodeAddr, u32 httpStatusCommentAddr, u32 httpStatusCommentLengthAddr) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceParseHttpStatusLine(%x, %d, %x, %x, %x, %x, %x) at %08x", headerAddr, headerLength, httpVersionMajorAddr, httpVersionMinorAddr, httpStatusCodeAddr, httpStatusCommentAddr, httpStatusCommentLengthAddr, currentMIPS->pc);
@@ -89,8 +171,8 @@ static int sceParseHttpStatusLine(u32 headerAddr, u32 headerLength, u32 httpVers
 
 const HLEFunction sceParseHttp [] = 
 {
-	{0X8077A433, &WrapI_UUUUUUU<sceParseHttpStatusLine>,    "sceParseHttpStatusLine",     'i', "xxxxxxx"},
-	{0XAD7BFDEF, nullptr,                                   "sceParseHttpResponseHeader", '?', ""       },
+	{0X8077A433, &WrapI_UUUUUUU<sceParseHttpStatusLine>,      "sceParseHttpStatusLine",     'i', "xxxxxxx"},
+	{0XAD7BFDEF, &WrapI_UICUU<sceParseHttpResponseHeader>,    "sceParseHttpResponseHeader", 'i', "xisxx"  },
 };
 
 void Register_sceParseHttp()

--- a/Core/HLE/sceParseHttp.cpp
+++ b/Core/HLE/sceParseHttp.cpp
@@ -15,13 +15,82 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <sstream>
+#include <regex>
+
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/sceParseHttp.h"
+#include "Core/HLE/FunctionWrappers.h"
+#include "Core/Debugger/MemBlockInfo.h"
+
+
+static int sceParseHttpStatusLine(u32 headerAddr, u32 headerLength, u32 httpVersionMajorAddr, u32 httpVersionMinorAddr, u32 httpStatusCodeAddr, u32 httpStatusCommentAddr, u32 httpStatusCommentLengthAddr) {
+	WARN_LOG(Log::sceNet, "UNTESTED sceParseHttpStatusLine(%x, %d, %x, %x, %x, %x, %x) at %08x", headerAddr, headerLength, httpVersionMajorAddr, httpVersionMinorAddr, httpStatusCodeAddr, httpStatusCommentAddr, httpStatusCommentLengthAddr, currentMIPS->pc);
+	if (!Memory::IsValidRange(headerAddr, headerLength))
+		return hleLogError(Log::sceNet, -1, "invalid arg");
+
+	std::string headers(Memory::GetCharPointer(headerAddr), headerLength);
+	// Get first line from header, line ending can be '\n' or '\r'
+	std::istringstream hdr(headers);
+	std::string line;
+	std::getline(hdr, line, '\n');
+	hdr.str(line);
+	std::getline(hdr, line, '\r');
+	NotifyMemInfo(MemBlockFlags::READ, headerAddr, (u32)line.size(), "ParseHttpStatusLine");
+	DEBUG_LOG(Log::sceNet, "Headers: %s", headers.c_str());
+
+	// Split the string by pattern, based on JPCSP
+	std::regex rgx("HTTP/(\\d)\\.(\\d)\\s+(\\d+)(.*)");
+	std::smatch matches;
+
+	if (!std::regex_search(line, matches, rgx))
+		return hleLogError(Log::sceNet, -1, "invalid arg"); // SCE_HTTP_ERROR_PARSE_HTTP_NOT_FOUND
+
+	try {
+		// Convert and Store the value
+		if (Memory::IsValidRange(httpVersionMajorAddr, 4)) {
+			Memory::WriteUnchecked_U32(stoi(matches[1].str()), httpVersionMajorAddr);
+			NotifyMemInfo(MemBlockFlags::WRITE, httpVersionMajorAddr, 4, "ParseHttpStatusLine");
+		}
+
+		if (Memory::IsValidRange(httpVersionMinorAddr, 4)) {
+			Memory::WriteUnchecked_U32(stoi(matches[2].str()), httpVersionMinorAddr);
+			NotifyMemInfo(MemBlockFlags::WRITE, httpVersionMinorAddr, 4, "ParseHttpStatusLine");
+		}
+
+		if (Memory::IsValidRange(httpStatusCodeAddr, 4)) {
+			Memory::WriteUnchecked_U32(stoi(matches[3].str()), httpStatusCodeAddr);
+			NotifyMemInfo(MemBlockFlags::WRITE, httpStatusCodeAddr, 4, "ParseHttpStatusLine");
+		}
+
+		std::string sc = matches[4].str();
+		if (Memory::IsValidRange(httpStatusCommentAddr, 4)) {
+			Memory::WriteUnchecked_U32(headerAddr + (int)headers.find(sc), httpStatusCommentAddr);
+			NotifyMemInfo(MemBlockFlags::WRITE, httpStatusCommentAddr, 4, "ParseHttpStatusLine");
+		}
+
+		if (Memory::IsValidRange(httpStatusCommentLengthAddr, 4)) {
+			Memory::WriteUnchecked_U32((u32)sc.size(), httpStatusCommentLengthAddr);
+			NotifyMemInfo(MemBlockFlags::WRITE, httpStatusCommentLengthAddr, 4, "ParseHttpStatusLine");
+		}
+	}
+	catch (const std::runtime_error& ex) {
+		hleLogError(Log::sceNet, -1, "Runtime error: %s", ex.what());
+	}
+	catch (const std::exception& ex) {
+		hleLogError(Log::sceNet, -1, "Error occurred: %s", ex.what()); // SCE_HTTP_ERROR_PARSE_HTTP_INVALID_VALUE
+	}
+	catch (...) {
+		hleLogError(Log::sceNet, -1, "Unknown error");
+	}
+
+	return 0;
+}
 
 const HLEFunction sceParseHttp [] = 
 {
-	{0X8077A433, nullptr,                            "sceParseHttpStatusLine",     '?', ""},
-	{0XAD7BFDEF, nullptr,                            "sceParseHttpResponseHeader", '?', ""},
+	{0X8077A433, &WrapI_UUUUUUU<sceParseHttpStatusLine>,    "sceParseHttpStatusLine",     'i', "xxxxxxx"},
+	{0XAD7BFDEF, nullptr,                                   "sceParseHttpResponseHeader", '?', ""       },
 };
 
 void Register_sceParseHttp()

--- a/Core/HLE/sceParseUri.cpp
+++ b/Core/HLE/sceParseUri.cpp
@@ -38,27 +38,26 @@ int workAreaAddString(u32 workAreaAddr, int workAreaSize, int offset, const char
 	return offset + length;
 }
 
-// FIXME: parsedUriArea, workArea, and workAreaSizeAddr can be 0/null?
+// FIXME: parsedUriArea, workArea can be 0/null? LittelBigPlanet seems to set workAreaSizeAddr to 0
 static int sceUriParse(u32 parsedUriAreaAddr, const char* url, u32 workAreaAddr, u32 workAreaSizeAddr, int workAreaSize) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceUriParse(%x, %s, %x, %x, %d) at %08x", parsedUriAreaAddr, safe_string(url), workAreaAddr, workAreaSizeAddr, workAreaSize, currentMIPS->pc);
 	if (url == nullptr)
 		return hleLogError(Log::sceNet, -1, "invalid arg");
 
-	if (!Memory::IsValidRange(workAreaSizeAddr, 4))
-		return hleLogError(Log::sceNet, -1, "invalid arg");
+	auto workAreaSz = PSPPointer<u32>::Create(workAreaSizeAddr);
 
 	// Size returner
 	if (parsedUriAreaAddr == 0 || workAreaAddr == 0) {
-		// Based on JPCSP: The required workArea size if maximum the size if the URL + 7 times the null-byte for string termination.
-		int urllen = (int)strlen(url);
-		Memory::WriteUnchecked_U32(urllen + 7, workAreaSizeAddr);
-		NotifyMemInfo(MemBlockFlags::WRITE, workAreaSizeAddr, 4, "UriParse");
-		return hleLogSuccessI(Log::sceNet, 0, "workAreaSize: %d, %d", urllen + 7, workAreaSize);
+		// Based on JPCSP: The required workArea size is maximum the size of the URL + 7 times the null-byte for string termination.
+		int sz = (int)strlen(url) + 7;
+		if (workAreaSz.IsValid()) {
+			*workAreaSz = sz;
+			workAreaSz.NotifyWrite("UriParse");
+		}
+		return hleLogSuccessI(Log::sceNet, 0, "workAreaSize: %d, %d", sz, workAreaSize);
 	}
 
 	auto parsedUri = PSPPointer<PSPParsedUri>::Create(parsedUriAreaAddr);
-	if (!parsedUri.IsValid()) 
-		return hleLogError(Log::sceNet, -1, "invalid arg");
 	
 	// Parse the URL into URI components
 	// Full URI = scheme ":" ["//" [username [":" password] "@"] host [":" port]] path ["?" query] ["#" fragment]
@@ -106,37 +105,50 @@ static int sceUriParse(u32 parsedUriAreaAddr, const char* url, u32 workAreaAddr,
 	
 	// FIXME: Related to "scheme-specific-part" (ie. parts after the scheme + ":") ? 0 = start with "//"
 	pos = std::string(url).find("://");
-	parsedUri->noSlash = (pos != std::string::npos) ? 0 : 1;
+	if (parsedUri.IsValid())
+		parsedUri->noSlash = (pos != std::string::npos) ? 0 : 1;
 
 	// Store the URI components in sequence into workAreanand store the respective addresses into the parsedUri structure.
 	int offset = 0;
-	parsedUri->schemeAddr = workAreaAddr + offset;
+	if (parsedUri.IsValid())
+		parsedUri->schemeAddr = workAreaAddr + offset;
 	offset = workAreaAddString(workAreaAddr, workAreaSize, offset, uri.Protocol().c_str()); // FiXME: scheme in lowercase, while protocol in uppercase?
 
-	parsedUri->userInfoUserNameAddr = workAreaAddr + offset;
+	if (parsedUri.IsValid())
+		parsedUri->userInfoUserNameAddr = workAreaAddr + offset;
 	offset = workAreaAddString(workAreaAddr, workAreaSize, offset, userInfoUserName.c_str());
 
-	parsedUri->userInfoPasswordAddr = workAreaAddr + offset;
+	if (parsedUri.IsValid())
+		parsedUri->userInfoPasswordAddr = workAreaAddr + offset;
 	offset = workAreaAddString(workAreaAddr, workAreaSize, offset, userInfoPassword.c_str());
 
-	parsedUri->hostAddr = workAreaAddr + offset;
+	if (parsedUri.IsValid())
+		parsedUri->hostAddr = workAreaAddr + offset;
 	offset = workAreaAddString(workAreaAddr, workAreaSize, offset, host.c_str());
 
-	parsedUri->pathAddr = workAreaAddr + offset;
+	if (parsedUri.IsValid())
+		parsedUri->pathAddr = workAreaAddr + offset;
 	offset = workAreaAddString(workAreaAddr, workAreaSize, offset, path.c_str());
 
-	parsedUri->queryAddr = workAreaAddr + offset;
+	if (parsedUri.IsValid())
+		parsedUri->queryAddr = workAreaAddr + offset;
 	offset = workAreaAddString(workAreaAddr, workAreaSize, offset, query.c_str());
 
-	parsedUri->fragmentAddr = workAreaAddr + offset;
+	if (parsedUri.IsValid())
+		parsedUri->fragmentAddr = workAreaAddr + offset;
 	offset = workAreaAddString(workAreaAddr, workAreaSize, offset, fragment.c_str());
 
-	parsedUri->port = uri.Port();
-	memset(parsedUri->unknown, 0, sizeof(parsedUri->unknown));
-	parsedUri.NotifyWrite("UriParse");
+	if (parsedUri.IsValid()) {
+		parsedUri->port = uri.Port();
+		memset(parsedUri->unknown, 0, sizeof(parsedUri->unknown));
+		parsedUri.NotifyWrite("UriParse");
+	}
 
-	Memory::WriteUnchecked_U32(offset, workAreaSizeAddr);
-	NotifyMemInfo(MemBlockFlags::WRITE, workAreaSizeAddr, 4, "UriParse");
+	// Update the size
+	if (workAreaSz.IsValid()) {
+		*workAreaSz = offset;
+		workAreaSz.NotifyWrite("UriParse");
+	}
 
 	return 0;
 }

--- a/Core/HLE/sceParseUri.cpp
+++ b/Core/HLE/sceParseUri.cpp
@@ -17,12 +17,135 @@
 
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/sceParseUri.h"
+#include "Core/HLE/FunctionWrappers.h"
+#include "Core/Debugger/MemBlockInfo.h"
+#include "Common/Net/URL.h"
+#include "Common/StringUtils.h"
+
+
+int workAreaAddString(u32 workAreaAddr, int workAreaSize, int offset, const char* s) {
+	const std::string str = (s? s:"");
+
+	int length = (int)str.length() + 1; // added space for null termination
+	if (offset + length > workAreaSize) {
+		length = workAreaSize - offset;
+		if (length <= 0) {
+			return offset;
+		}
+	}
+
+	Memory::MemcpyUnchecked(workAreaAddr + offset, str.c_str(), length);
+	return offset + length;
+}
+
+// FIXME: parsedUriArea, workArea, and workAreaSizeAddr can be 0/null?
+static int sceUriParse(u32 parsedUriAreaAddr, const char* url, u32 workAreaAddr, u32 workAreaSizeAddr, int workAreaSize) {
+	WARN_LOG(Log::sceNet, "UNTESTED sceUriParse(%x, %s, %x, %x, %d) at %08x", parsedUriAreaAddr, safe_string(url), workAreaAddr, workAreaSizeAddr, workAreaSize, currentMIPS->pc);
+	if (url == nullptr)
+		return hleLogError(Log::sceNet, -1, "invalid arg");
+
+	if (!Memory::IsValidRange(workAreaSizeAddr, 4))
+		return hleLogError(Log::sceNet, -1, "invalid arg");
+
+	// Size returner
+	if (parsedUriAreaAddr == 0 || workAreaAddr == 0) {
+		// Based on JPCSP: The required workArea size if maximum the size if the URL + 7 times the null-byte for string termination.
+		int urllen = (int)strlen(url);
+		Memory::WriteUnchecked_U32(urllen + 7, workAreaSizeAddr);
+		NotifyMemInfo(MemBlockFlags::WRITE, workAreaSizeAddr, 4, "UriParse");
+		return hleLogSuccessI(Log::sceNet, 0, "workAreaSize: %d, %d", urllen + 7, workAreaSize);
+	}
+
+	auto parsedUri = PSPPointer<PSPParsedUri>::Create(parsedUriAreaAddr);
+	if (!parsedUri.IsValid()) 
+		return hleLogError(Log::sceNet, -1, "invalid arg");
+	
+	// Parse the URL into URI components
+	// Full URI = scheme ":" ["//" [username [":" password] "@"] host [":" port]] path ["?" query] ["#" fragment]
+	Url uri(url);
+	// FIXME: URI without "://" should be valid too, due to PSPParsedUri.noSlash property
+	if (!uri.Valid()) {
+		return hleLogError(Log::sceNet, -1, "invalid arg");
+	}
+
+	// Parse Host() into userInfo (in the format "<userName>:<password>") and host
+	std::string host = uri.Host();
+	std::string userInfoUserName = "";
+	std::string userInfoPassword = "";
+	// Extract Host
+	size_t pos = host.find('@');
+	if (pos <= host.size()) {
+		userInfoUserName = host.substr(0, pos);
+		host.erase(0, pos + 1LL); // removing the "@"
+	}
+	// Extract UserName and Password
+	pos = userInfoUserName.find(':');
+	if (pos <= userInfoUserName.size()) {
+		userInfoPassword = userInfoUserName.substr(pos + 1LL); // removing the ":"
+		userInfoUserName.erase(pos);
+	}
+
+	// Parse Resource() into path(/), query(?), and fragment(#)
+	std::string path = uri.Resource();
+	std::string query = "";
+	std::string fragment = "";
+	// Extract Path
+	pos = path.find('?');
+	if (pos <= path.size()) {
+		query = path.substr(pos); // Not removing the leading "?". Query must have the leading "?" if it's not empty (according to JPCSP)
+		if (query.size() == 1)
+			query.clear();
+		path.erase(pos);
+	}
+	// Extract Query and Fragment
+	pos = query.find('#');
+	if (pos <= query.size()) {
+		fragment = query.substr(pos);  // FIXME: Should we remove the leading "#" ? probably not, just like query
+		query.erase(pos);
+	}
+	
+	// FIXME: Related to "scheme-specific-part" (ie. parts after the scheme + ":") ? 0 = start with "//"
+	pos = std::string(url).find("://");
+	parsedUri->noSlash = (pos != std::string::npos) ? 0 : 1;
+
+	// Store the URI components in sequence into workAreanand store the respective addresses into the parsedUri structure.
+	int offset = 0;
+	parsedUri->schemeAddr = workAreaAddr + offset;
+	offset = workAreaAddString(workAreaAddr, workAreaSize, offset, uri.Protocol().c_str()); // FiXME: scheme in lowercase, while protocol in uppercase?
+
+	parsedUri->userInfoUserNameAddr = workAreaAddr + offset;
+	offset = workAreaAddString(workAreaAddr, workAreaSize, offset, userInfoUserName.c_str());
+
+	parsedUri->userInfoPasswordAddr = workAreaAddr + offset;
+	offset = workAreaAddString(workAreaAddr, workAreaSize, offset, userInfoPassword.c_str());
+
+	parsedUri->hostAddr = workAreaAddr + offset;
+	offset = workAreaAddString(workAreaAddr, workAreaSize, offset, host.c_str());
+
+	parsedUri->pathAddr = workAreaAddr + offset;
+	offset = workAreaAddString(workAreaAddr, workAreaSize, offset, path.c_str());
+
+	parsedUri->queryAddr = workAreaAddr + offset;
+	offset = workAreaAddString(workAreaAddr, workAreaSize, offset, query.c_str());
+
+	parsedUri->fragmentAddr = workAreaAddr + offset;
+	offset = workAreaAddString(workAreaAddr, workAreaSize, offset, fragment.c_str());
+
+	parsedUri->port = uri.Port();
+	memset(parsedUri->unknown, 0, sizeof(parsedUri->unknown));
+	parsedUri.NotifyWrite("UriParse");
+
+	Memory::WriteUnchecked_U32(offset, workAreaSizeAddr);
+	NotifyMemInfo(MemBlockFlags::WRITE, workAreaSizeAddr, 4, "UriParse");
+
+	return 0;
+}
 
 const HLEFunction sceParseUri[] =
 {
 	{0X49E950EC, nullptr,                            "sceUriEscape",   '?', ""},
 	{0X062BB07E, nullptr,                            "sceUriUnescape", '?', ""},
-	{0X568518C9, nullptr,                            "sceUriParse",    '?', ""},
+	{0X568518C9, &WrapI_UCUUI<sceUriParse>,          "sceUriParse",    'i', "xsxxi" },
 	{0X7EE318AF, nullptr,                            "sceUriBuild",    '?', ""},
 };
 

--- a/Core/HLE/sceParseUri.h
+++ b/Core/HLE/sceParseUri.h
@@ -17,4 +17,28 @@
 
 #pragma once
 
+#ifdef _MSC_VER
+#define PACK  // on MSVC we use #pragma pack() instead so let's kill this.
+#pragma pack(push, 1)
+#else
+#define PACK __attribute__((packed))
+#endif
+
+typedef struct PSPParsedUri {
+	s32 noSlash;
+	s32 schemeAddr;
+	s32 userInfoUserNameAddr;
+	s32 userInfoPasswordAddr;
+	s32 hostAddr;
+	s32 pathAddr;
+	s32 queryAddr;
+	s32 fragmentAddr;
+	u16 port;
+	u8 unknown[10]; // padding might be included here?
+} PACK PSPParsedUri;
+
+#ifdef _MSC_VER 
+#pragma pack(pop)
+#endif
+
 void Register_sceParseUri();


### PR DESCRIPTION
Rebase of #18003 

Had to remove some duplicates from #19807 (derived from #18578), but I think it went okay.

Not tested much yet, will try to test a little before merge.

@anr2me 


IMPORTANT INFO from anr2me: 

> This code is still experimental (just to get things to work), but my implementation is kinda wrong compared to JPCSP implementation.
> My implementation is to use the parent simply as a template/base to initialize it's contents (ie. headers, userAgent, etc), thus any changes (ie. cookies, userAgent, etc) to the parent won't reflects existing children.
> But later, i find out that JPCSP implementation is id-based relationship between parent-child similar to database's records relationship) and changes on the parent will reflects on it's children, thus cookies can be shared on multiple children (like a multi-tabs on most browsers).

> So, this PR will need to be rewritten (probably using naett to support HTTPS too in the future), also need to do communication in a background thread to avoid stuttering the emulation.
> So leaving this as a draft until i had the time to rewrite it (in case i lost my local copy due to bad sector).

