### PR TITLE
Buildfix for VS2017

### DIFF
--- a/Core/HLE/sceHttp.cpp
+++ b/Core/HLE/sceHttp.cpp
@@ -20,6 +20,7 @@
 #include <numeric>
 #include <mutex>
 #include <algorithm>
+#include <cctype> // for std::tolower
 
 #include "Core/Core.h"
 #include "Core/HLE/HLE.h"

--- a/Core/HLE/sceNetInet.cpp
+++ b/Core/HLE/sceNetInet.cpp
@@ -39,6 +39,7 @@
 
 #include <iostream>
 #include <shared_mutex>
+#include <algorithm>
 
 #include "Core/HLE/sceNp.h"
 #include "Core/Reporting.h"


### PR DESCRIPTION
This time it's not only our friend `<algorithm>` for `std::min/max`, it's also `<cctype>` for `std::tolower`.