### PR TITLE
Centralize socket-related includes, introduce socket_errno

### DIFF
--- a/Common/File/DirListing.cpp
+++ b/Common/File/DirListing.cpp
@@ -12,7 +12,6 @@
 #include <strings.h>
 #include <dirent.h>
 #include <unistd.h>
-#include <errno.h>
 #endif
 
 #include <cstring>

--- a/Common/File/FileDescriptor.cpp
+++ b/Common/File/FileDescriptor.cpp
@@ -3,21 +3,9 @@
 #include <errno.h>
 #include <cmath>
 #include <cstdio>
-#ifndef _WIN32
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <sys/select.h>
-#include <unistd.h>
-#else
-#include <io.h>
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#endif
-#include <fcntl.h>
 
 #include "Common/CommonTypes.h"
+#include "Common/Net/SocketCompat.h"
 #include "Common/Data/Encoding/Utf8.h"
 #include "Common/File/FileDescriptor.h"
 #include "Common/Log.h"

--- a/Common/Net/NetBuffer.cpp
+++ b/Common/Net/NetBuffer.cpp
@@ -1,19 +1,8 @@
 #include "ppsspp_config.h"
-#ifdef _WIN32
-#include <winsock2.h>
-#undef min
-#undef max
-#else
-#include <sys/socket.h>
-#include <unistd.h>
-#endif
+
 #include <algorithm>
 #include <cstring>
-
-#ifndef MSG_NOSIGNAL
-// Default value to 0x00 (do nothing) in systems where it's not supported.
-#define MSG_NOSIGNAL 0x00
-#endif
+#include "Common/Net/SocketCompat.h"
 
 #if _MSC_VER
 #pragma warning(disable:4267)
@@ -98,11 +87,7 @@ bool Buffer::ReadAllWithProgress(int fd, int knownSize, RequestProgress *progres
 		if (retval == 0) {
 			return true;
 		} else if (retval < 0) {
-#if PPSSPP_PLATFORM(WINDOWS)
-			if (WSAGetLastError() != WSAEWOULDBLOCK) {
-#else
-			if (errno != EWOULDBLOCK) {
-#endif
+			if (socket_errno != EWOULDBLOCK) {
 				ERROR_LOG(Log::IO, "Error reading from buffer: %i", retval);
 				return false;
 			}

--- a/Common/Net/SocketCompat.h
+++ b/Common/Net/SocketCompat.h
@@ -4,22 +4,40 @@
 
 #if PPSSPP_PLATFORM(WINDOWS)
 #include "Common/CommonWindows.h"
+#include <io.h>
+#include <winsock2.h>
 #include <WS2tcpip.h>
 #else
 #include <unistd.h>
 #include <sys/types.h>
+#include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/select.h>
+#include <sys/mman.h>
 #include <netinet/in.h>
-#include <netdb.h>
+#include <netinet/tcp.h>
 #include <arpa/inet.h>
+#include <netdb.h>
+#if !PPSSPP_PLATFORM(SWITCH)
+#include <ifaddrs.h>
+#endif
+#include <fcntl.h>
+#endif
 #include <fcntl.h>
 #include <errno.h>
-#endif
+
+#if defined(HAVE_LIBNX) || PPSSPP_PLATFORM(SWITCH)
+#undef __BSD_VISIBLE
+#define __BSD_VISIBLE 1
+#define TCP_MAXSEG 2
+#include <netdb.h>
+#include <switch.h>
+// Missing include, *shrugs*
+extern "C" struct hostent *gethostbyname(const char *name);
+#endif // defined(HAVE_LIBNX) || PPSSPP_PLATFORM(SWITCH)
 
 // TODO: move this to some common set
-#ifdef _WIN32
-#undef errno
+#if PPSSPP_PLATFORM(WINDOWS)
 #undef ESHUTDOWN
 #undef ECONNABORTED
 #undef ECONNRESET
@@ -49,7 +67,7 @@
 #undef ENETUNREACH
 #undef EHOSTUNREACH
 #undef ENETDOWN
-#define errno WSAGetLastError()
+#define socket_errno WSAGetLastError()
 #define ESHUTDOWN WSAESHUTDOWN
 #define ECONNABORTED WSAECONNABORTED
 #define ECONNRESET WSAECONNRESET
@@ -79,9 +97,10 @@
 #define ENETUNREACH WSAENETUNREACH
 #define EHOSTUNREACH WSAEHOSTUNREACH
 #define ENETDOWN WSAENETDOWN
-inline bool connectInProgress(int errcode) { return (errcode == WSAEWOULDBLOCK || errcode == WSAEINPROGRESS || errcode == WSAEALREADY || errcode == WSAEINVAL); } // WSAEINVAL should be treated as WSAEALREADY during connect for backward-compatibility with Winsock 1.1 
+inline bool connectInProgress(int errcode) { return (errcode == WSAEWOULDBLOCK || errcode == WSAEINPROGRESS || errcode == WSAEALREADY || errcode == WSAEINVAL); } // WSAEINVAL should be treated as WSAEALREADY during connect for backward-compatibility with Winsock 1.1
 inline bool isDisconnected(int errcode) { return (errcode == WSAECONNRESET || errcode == WSAECONNABORTED || errcode == WSAESHUTDOWN); }
 #else
+#define socket_errno errno
 #define SOCKET int
 #define INVALID_SOCKET -1
 #define SOCKET_ERROR -1
@@ -113,4 +132,9 @@ inline bool isDisconnected(int errcode) { return (errcode == EPIPE || errcode ==
 
 #ifndef SD_BOTH
 #define SD_BOTH SHUT_RDWR //0x02
+#endif
+
+#ifndef MSG_NOSIGNAL
+// Default value to 0x00 (do nothing) in systems where it's not supported.
+#define MSG_NOSIGNAL 0x00
 #endif

--- a/Common/Net/SocketCompat.h
+++ b/Common/Net/SocketCompat.h
@@ -14,6 +14,7 @@
 #include <sys/socket.h>
 #include <sys/select.h>
 #include <sys/mman.h>
+#include <net/if.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <arpa/inet.h>

--- a/Common/Net/WebsocketServer.cpp
+++ b/Common/Net/WebsocketServer.cpp
@@ -2,19 +2,8 @@
 #include <cctype>
 #include <cmath>
 #include <cstring>
-#ifndef _WIN32
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <sys/select.h>
-#include <unistd.h>
-#else
-#include <io.h>
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#endif
 
+#include "Common/Net/SocketCompat.h"
 #include "Common/Data/Encoding/Base64.h"
 #include "Common/Net/HTTPServer.h"
 #include "Common/Net/Sinks.h"

--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -54,7 +54,7 @@ static const uint8_t kor_lconsCom[33] = { 18,0,2,21,3,4,26,3,5,0,7,8,15,7,9,16,7
 // Korean (Hangul) last consonant Separation key
 static const uint8_t kor_lconsSpr[33] = { 2,1,9,4,4,12,5,4,18,8,8,0,9,8,6,10,8,7,11,8,9,12,8,16,13,8,17,14,8,18,17,17,9 };
 
-static const char * const OskKeyboardNames[] =
+static const std::string_view OskKeyboardNames[] =
 {
 	"en_US",
 	"ja_JP",
@@ -940,11 +940,11 @@ int PSPOskDialog::Update(int animSpeed) {
 		}
 
 		// Now, let's grab the name.
-		const char *countryCode = OskKeyboardNames[lang];
+		std::string countryCode(OskKeyboardNames[lang]);
 		const char *language = languageMapping[countryCode].first.c_str();
 
 		// It seems like this is a "fake" country code for extra keyboard purposes.
-		if (!strcmp(countryCode, "English Full-width"))
+		if (countryCode == "English Full-width")
 			language = "English Full-width";
 
 		return language;

--- a/Core/HLE/NetInetConstants.cpp
+++ b/Core/HLE/NetInetConstants.cpp
@@ -1,22 +1,8 @@
 #include "ppsspp_config.h"
 
-#if PPSSPP_PLATFORM(WINDOWS)
-#include "Common/CommonWindows.h"
-#include <WS2tcpip.h>
-#endif
-
-#if __linux__ || __APPLE__ || defined(__OpenBSD__)
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/mman.h>
-#include <netinet/tcp.h>
-#include <fcntl.h>
-#endif
-
 #include <string>
-#include "Common/Log.h"
-#include "Common/StringUtils.h"
 #include "Common/Net/SocketCompat.h"
+#include "Common/StringUtils.h"
 #include "Core/HLE/NetInetConstants.h"
 #include "Core/HLE/sceKernel.h"
 #include "Core/HLE/HLE.h"

--- a/Core/HLE/proAdhoc.h
+++ b/Core/HLE/proAdhoc.h
@@ -17,22 +17,7 @@
 
 #pragma once
 
-// Net stuff
-#if defined(_WIN32)
-#include "Common/CommonWindows.h"
-
-#include <WS2tcpip.h>
-#else
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/select.h>
-#include <netinet/in.h>
-#include <netdb.h>
-#include <arpa/inet.h>
-#include <fcntl.h>
-#include <errno.h>
-#endif
+#include "Common/Net/SocketCompat.h"
 
 #ifdef _MSC_VER
 #define PACK  // on MSVC we use #pragma pack() instead so let's kill this.
@@ -46,7 +31,6 @@
 #include <climits>
 
 #include "Common/Net/Resolve.h"
-#include "Common/Net/SocketCompat.h"
 #include "Common/Serialize/Serializer.h"
 #include "Core/MemMap.h"
 #include "Core/HLE/sceKernelThread.h"

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -15,21 +15,11 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
-#if __linux__ || __APPLE__ || defined(__OpenBSD__)
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/mman.h>
-#include <fcntl.h>
-#elif _WIN32
-#include <winsock2.h>
-#pragma comment(lib, "ws2_32.lib")
-#endif
-
-#include <iostream>
-#include <shared_mutex>
-
-// TODO: fixme move Core/Net to Common/Net
+#include <mutex>
+#include <string>
+#include <algorithm>
 #include "Common/Net/Resolve.h"
+#include "Common/Net/SocketCompat.h"
 #include "Core/Net/InetCommon.h"
 #include "Common/Data/Text/Parsers.h"
 

--- a/Core/HLE/sceNetInet.h
+++ b/Core/HLE/sceNetInet.h
@@ -7,8 +7,6 @@
 #include "Common/Net/SocketCompat.h"
 
 #include <memory>
-#include <shared_mutex>
-#include <unordered_map>
 
 // Using constants instead of numbers for readability reason, since PSP_THREAD_ATTR_KERNEL/USER is located in sceKernelThread.cpp instead of sceKernelThread.h
 #ifndef PSP_THREAD_ATTR_KERNEL

--- a/Core/Net/InetCommon.cpp
+++ b/Core/Net/InetCommon.cpp
@@ -1,26 +1,12 @@
 // TODO: license
 
-#if __linux__ || __APPLE__ || defined(__OpenBSD__)
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/mman.h>
-#include <fcntl.h>
-#endif
-
 // TODO: fixme move Core/Net to Common/Net
 #include "Common/Net/Resolve.h"
+#include "Common/Net/SocketCompat.h"
 #include "Core/Net/InetCommon.h"
-#include "Common/Data/Text/Parsers.h"
-
-#include "Common/Serialize/Serializer.h"
 #include "Core/Config.h"
 #include "Core/HLE/HLE.h"
 #include "Core/MemMapHelpers.h"
-
-#include "Core/HLE/proAdhoc.h"
-
-#include <iostream>
-#include <shared_mutex>
 
 #include "Core/HLE/sceNp.h"
 
@@ -31,7 +17,7 @@
 bool getDefaultOutboundSockaddr(sockaddr_in& destSockaddrIn, socklen_t& destSocklen) {
     auto fd = socket(AF_INET, SOCK_STREAM, 0);
     if (fd < 0) {
-        ERROR_LOG(Log::sceNet, "getSockAddrFromDefaultSocket: Failed to open socket (%s)", strerror(errno));
+        ERROR_LOG(Log::sceNet, "getSockAddrFromDefaultSocket: Failed to open socket (%s)", strerror(socket_errno));
         return false;
     }
     sockaddr_in connectingTo;
@@ -40,12 +26,12 @@ bool getDefaultOutboundSockaddr(sockaddr_in& destSockaddrIn, socklen_t& destSock
     connectingTo.sin_port = htons(53);
     connectingTo.sin_addr.s_addr = 0x08080808;
     if (connect(fd, (sockaddr*) &connectingTo, sizeof(connectingTo)) < 0) {
-        ERROR_LOG(Log::sceNet, "getSockAddrFromDefaultSocket: Failed to connect to Google (%s)", strerror(errno));
+        ERROR_LOG(Log::sceNet, "getSockAddrFromDefaultSocket: Failed to connect to Google (%s)", strerror(socket_errno));
         close(fd);
         return false;
     }
     if (getsockname(fd, (sockaddr*) &destSockaddrIn, &destSocklen) < 0) {
-        ERROR_LOG(Log::sceNet, "getSockAddrFromDefaultSocket: Failed to execute getsockname (%s)", strerror(errno));
+        ERROR_LOG(Log::sceNet, "getSockAddrFromDefaultSocket: Failed to execute getsockname (%s)", strerror(socket_errno));
         close(fd);
         return false;
     }

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1313,7 +1313,7 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iLanguage, psps->T("Game language"), defaultLanguages, -1, ARRAY_SIZE(defaultLanguages), I18NCat::PSPSETTINGS, screenManager()));
 	static const char *models[] = { "PSP-1000", "PSP-2000/3000" };
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iPSPModel, sy->T("PSP Model"), models, 0, ARRAY_SIZE(models), I18NCat::SYSTEM, screenManager()))->SetEnabled(!PSP_IsInited());
-	systemSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sNickName, sy->T("Change Nickname"), "", 32, screenManager()))->OnChange.Add([this](UI::EventParams &e) {
+	systemSettings->Add(new PopupTextInputChoice(GetRequesterToken(), &g_Config.sNickName, sy->T("Change Nickname"), "", 32, screenManager()))->OnChange.Add([](UI::EventParams &e) {
 		// Copy to infrastructure name if valid and not already set.
 		if (g_Config.sInfrastructureUsername.empty()) {
 			if (g_Config.sNickName == SanitizeString(g_Config.sNickName, StringRestriction::AlphaNumDashUnderscore, 3, 16)) {


### PR DESCRIPTION
This resolves some weird inconsistencies and include order problems related to `errno`. Needed for the next steps.