### PR TITLE
An attempt to fix Driver 76 multiplayer

### DIFF
--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -871,9 +871,6 @@ int sceNetApctlTerm() {
 static int sceNetApctlGetInfo(int code, u32 pInfoAddr) {
 	DEBUG_LOG(Log::sceNet, "UNTESTED %s(%i, %08x) at %08x", __FUNCTION__, code, pInfoAddr, currentMIPS->pc);
 
-	if (!netApctlInited)
-		return hleLogError(Log::sceNet, ERROR_NET_APCTL_NOT_IN_BSS, "apctl not in bss"); // Only have valid info after joining an AP and got an IP, right?
-
 	switch (code) {
 	case PSP_NET_APCTL_INFO_PROFILE_NAME:
 		if (!Memory::IsValidRange(pInfoAddr, APCTL_PROFILENAME_MAXLEN))

--- a/Core/HLE/sceNetInet.cpp
+++ b/Core/HLE/sceNetInet.cpp
@@ -595,7 +595,7 @@ static int sceNetInetBind(int socket, u32 namePtr, int namelen) {
 		// Get Local IP Address
 		sockaddr_in sockAddr{};
 		getLocalIp(&sockAddr);
-		DEBUG_LOG(Log::sceNet, "Bind: Address Replacement = %s => %s", ip2str(saddr.in.sin_addr).c_str(), ip2str(sockAddr.sin_addr).c_str());
+		WARN_LOG(Log::sceNet, "Bind: Address Replacement = %s => %s", ip2str(saddr.in.sin_addr).c_str(), ip2str(sockAddr.sin_addr).c_str());
 		saddr.in.sin_addr.s_addr = sockAddr.sin_addr.s_addr;
 	}
 	// TODO: Make use Port Offset only for PPSSPP to PPSSPP communications (ie. IP addresses available in the group/friendlist), otherwise should be considered as Online Service thus should use the port as is.


### PR DESCRIPTION
Potentially fixes games that use Quazal Net-Z https://github.com/hrydgard/ppsspp/issues/14555 (need someone to test the other games tho)

This game is kinda strange, it initialize Adhocctl instead of Apctl (to connect to an AP), but uses infrastructure syscalls instead of adhoc syscalls, it also tried to get IP from ApctlGetInfo, i wondered what kind of IP should be returned (we currently returning 0.0.0.0) when not connected to any Access Point (unless Adhoc actually have an IP too internally).

Anyway, currently only works on Windows with multiple-instances.

I couldn't get it to works with multiple-instances on Ubuntu (WSL2), and couldn't see much from the logs, because apparently Debug channel is being disabled on non-Windows (at least from the artifacts i tested)

On Android it's even more strange, that the game stuck with 0/0 (100%) FPS, the percentage is still moving so the emulation thread isn't blocked, the game just didn't render anything when entering multiplayer, may be it endlessly retrying something (most likely the sceNetInet* or sceNetApctl* syscall), i guess something inconsistent is happening on Android while other platforms didn't get locked up (not sure about Mac/iOS tho).

PS: This game also uses sceNetInetPoll instead of sceNetInetSelect, and i'm not sure whether our sceNetInetPoll implementation (which under the hood is using select as it's more widely available than poll/epoll) is consistent or not across platforms (ie. the POLL flags stuff)