### PR TITLE
Deduplicate a OSD message, change DEBUG log level exclusions

### DIFF
--- a/Common/Log.h
+++ b/Common/Log.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "ppsspp_config.h"
 #include "CommonFuncs.h"
 
 #define	NOTICE_LEVEL  1  // VERY important information that is NOT errors. Like startup and debugprintfs from the game itself.
@@ -84,8 +85,8 @@ void GenericLog(LogLevel level, Log type, const char *file, int line, const char
 		;
 bool GenericLogEnabled(LogLevel level, Log type);
 
-// Exception for Windows - enable more log levels in release mode than on other platforms.
-#if defined(_DEBUG) || defined(_WIN32)
+// We only disable DEBUG and VERBOSE on Android/iOS now.
+#if defined(_DEBUG) || (!PPSSPP_PLATFORM(ANDROID) && !PPSSPP_PLATFORM(IOS))
 
 // Needs to be an int (and not use the enum) because it's used by the preprocessor!
 #define MAX_LOGLEVEL DEBUG_LEVEL

--- a/Core/HLE/proAdhocServer.cpp
+++ b/Core/HLE/proAdhocServer.cpp
@@ -1833,7 +1833,7 @@ int create_listen_socket(uint16_t port)
 		else {
 			ERROR_LOG(Log::sceNet, "AdhocServer: Bind returned %i (Socket error %d)", bindresult, socket_errno);
 			auto n = GetI18NCategory(I18NCat::NETWORKING);
-			g_OSD.Show(OSDType::MESSAGE_ERROR, std::string(n->T("AdhocServer Failed to Bind Port")) + " " + std::to_string(port));
+			g_OSD.Show(OSDType::MESSAGE_ERROR, std::string(n->T("AdhocServer Failed to Bind Port")) + " " + std::to_string(port), "portbindfail");
 		}
 
 		// Close Socket


### PR DESCRIPTION
Previously, in release builds, DEBUG logs were only enabled on Windows. After this, they're enabled on all platforms except mobile.

As for the log message, see #19842.