### PR TITLE
Libretro core fixes

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -772,11 +772,11 @@ static void check_variables(CoreParameter &coreParam)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (!strcmp(var.value, "No buffer"))
-         g_Config.iInflightFrames = 0;
-      else if (!strcmp(var.value, "Up to 1"))
          g_Config.iInflightFrames = 1;
-      else if (!strcmp(var.value, "Up to 2"))
+      else if (!strcmp(var.value, "Up to 1"))
          g_Config.iInflightFrames = 2;
+      else if (!strcmp(var.value, "Up to 2"))
+         g_Config.iInflightFrames = 3;
    }
 
    var.key = "ppsspp_skip_buffer_effects";

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -602,16 +602,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "disabled"
    },
    {
-      "ppsspp_vertex_cache",
-      "Vertex Cache",
-      NULL,
-      "Faster, but may cause temporary flicker.",
-      NULL,
-      "video",
-      BOOL_OPTIONS,
-      "disabled"
-   },
-   {
       "ppsspp_texture_scaling_type",
       "Texture Upscale Type",
       NULL,


### PR DESCRIPTION
These are pretty self-explanatory. The `Vertex Cache` option was removed from PPSSPP a while ago.  `iInflightFrames` values were off by one.