### PR TITLE
Use modern flip model and tearing flags for D3D11 swap chain creation

### DIFF
--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -410,6 +410,7 @@ D3D11DrawContext::D3D11DrawContext(ID3D11Device *device, ID3D11DeviceContext *de
 	if (SUCCEEDED(hr)) {
 		caps_.setMaxFrameLatencySupported = true;
 		dxgiDevice1->SetMaximumFrameLatency(maxInflightFrames);
+		dxgiDevice1->Release();
 	}
 }
 

--- a/Common/GPU/D3D11/thin3d_d3d11.cpp
+++ b/Common/GPU/D3D11/thin3d_d3d11.cpp
@@ -18,6 +18,7 @@
 
 #include <cfloat>
 #include <D3Dcommon.h>
+#include <dxgi1_5.h>
 #include <d3d11.h>
 #include <d3d11_1.h>
 #include <D3Dcompiler.h>
@@ -220,6 +221,7 @@ private:
 	ID3D11DeviceContext *context_;
 	ID3D11DeviceContext1 *context1_;
 	IDXGISwapChain *swapChain_;
+	bool swapChainTearingSupported_ = false;
 
 	ID3D11Texture2D *bbRenderTargetTex_ = nullptr; // NOT OWNED
 	ID3D11RenderTargetView *bbRenderTargetView_ = nullptr;
@@ -372,6 +374,15 @@ D3D11DrawContext::D3D11DrawContext(ID3D11Device *device, ID3D11DeviceContext *de
 		caps_.supportsD3D9 = false;
 	}
 
+	if (swapChain_) {
+		DXGI_SWAP_CHAIN_DESC swapChainDesc;
+		swapChain_->GetDesc(&swapChainDesc);
+
+		if (swapChainDesc.Flags & DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING) {
+			swapChainTearingSupported_ = true;
+		}
+	}
+
 	// Temp texture for read-back of small images. Custom textures are created on demand for larger ones.
 	// TODO: Should really benchmark if this extra complexity has any benefit.
 	D3D11_TEXTURE2D_DESC packDesc{};
@@ -483,14 +494,17 @@ void D3D11DrawContext::EndFrame() {
 void D3D11DrawContext::Present(PresentMode presentMode, int vblanks) {
 	frameTimeHistory_[frameCount_].queuePresent = time_now_d();
 
-	int interval = vblanks;
-	if (presentMode != PresentMode::FIFO) {
-		interval = 0;
-	}
 	// Safety for libretro
 	if (swapChain_) {
-		swapChain_->Present(interval, 0);
+		uint32_t interval = vblanks;
+		uint32_t flags = 0;
+		if (presentMode != PresentMode::FIFO) {
+			interval = 0;
+			flags |= swapChainTearingSupported_ ? DXGI_PRESENT_ALLOW_TEARING : 0; // Assume "vsync off" also means "allow tearing"
+		}
+		swapChain_->Present(interval, flags);
 	}
+
 	curRenderTargetView_ = nullptr;
 	curDepthStencilView_ = nullptr;
 	frameCount_++;

--- a/Windows/GPU/D3D11Context.h
+++ b/Windows/GPU/D3D11Context.h
@@ -43,6 +43,7 @@ private:
 
 	Draw::DrawContext *draw_ = nullptr;
 	IDXGISwapChain *swapChain_ = nullptr;
+	DXGI_SWAP_CHAIN_DESC swapChainDesc_ = {};
 	ID3D11Device *device_ = nullptr;
 	ID3D11Device1 *device1_ = nullptr;
 	ID3D11DeviceContext *context_ = nullptr;


### PR DESCRIPTION
As the title says. Also includes a bonus fix for a ref leak.

PPSSPP currently uses a “blt” present model swap chain and on modern versions of Windows this introduces undesirable latency/performance implications. Microsoft strongly advises developers to [use a flip model swap chain](https://devblogs.microsoft.com/directx/dxgi-flip-model/) instead. The [reasons behind this are somewhat complicated](https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/dxgi-flip-model?redirectedfrom=MSDN#comparing-the-dxgi-flip-model-and-the-bitblt-model), but ultimately it comes to down to how fullscreen exclusive mode (FSE) has to be emulated for certain programs by copying their backbuffers and compositing them with DWM. Said new models are able to elide the copies and thus improve performance.

Improvements will vary from system to system and can be measured with [Intel's PresentMon tool](https://github.com/GameTechDev/PresentMon/releases/tag/v2.3.0) if you're so inclined.

This PR is effectively complete. I'm keeping it as a draft since CI will likely fail due to outdated Windows SDK headers.