### PR TITLE
[Inet] Fixes potential buffer size issue.

### DIFF
--- a/Core/HLE/sceNetInet.cpp
+++ b/Core/HLE/sceNetInet.cpp
@@ -143,7 +143,7 @@ static int sceNetInetGetpeername(int socket, u32 namePtr, u32 namelenPtr) {
 		inetLastErrno = socket_errno;
 		return hleLogError(Log::sceNet, retval, "errno = %d", inetLastErrno);
 	} else {
-		// FIXME: We shouldn't use the returned len here, because the returned len is the actual size needed, which can be larger than the inputted len
+		// We shouldn't use the returned len here, because the returned len is the actual size needed, which can be larger than the inputted len
 		memcpy(name->sa_data, saddr.addr.sa_data, name->sa_len - (sizeof(name->sa_len) + sizeof(name->sa_family)));
 		name->sa_family = saddr.addr.sa_family;
 	}
@@ -177,7 +177,7 @@ static int sceNetInetGetsockname(int socket, u32 namePtr, u32 namelenPtr) {
 		inetLastErrno = socket_errno;
 		return hleLogError(Log::sceNet, retval, "errno = %d", inetLastErrno);
 	} else {
-		// FIXME: We shouldn't use the returned len here, because the returned len is the actual size needed, which can be larger than the inputted len
+		// We shouldn't use the returned len here, because the returned len is the actual size needed, which can be larger than the inputted len
 		memcpy(name->sa_data, saddr.addr.sa_data, name->sa_len - (sizeof(name->sa_len) + sizeof(name->sa_family)));
 		name->sa_family = saddr.addr.sa_family;
 	}


### PR DESCRIPTION
Based on [getpeername](https://man7.org/linux/man-pages/man2/getpeername.2.html) and [getsockname](https://man7.org/linux/man-pages/man2/getsockname.2.html)
> The returned address is truncated if the buffer provided is too
>       small; in this case, addrlen will return a value greater than was
>       supplied to the call.

PS: i haven't tested this on any games, hopefully not breaking anything.