### PR TITLE
libretro: Restore Vulkan MSAA video option

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -174,13 +174,9 @@ VkResult VulkanContext::CreateInstance(const CreateInfo &info) {
 		}
 	}
 
-	// Temporary hack for libretro. For some reason, when we try to load the functions from this extension,
-	// we get null pointers when running libretro. Quite strange.
-#if !defined(__LIBRETRO__)
 	if (EnableInstanceExtension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, VK_API_VERSION_1_1)) {
 		extensionsLookup_.KHR_get_physical_device_properties2 = true;
 	}
-#endif
 
 	if (EnableInstanceExtension(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME, 0)) {
 		extensionsLookup_.EXT_swapchain_colorspace = true;

--- a/libretro/LibretroVulkanContext.cpp
+++ b/libretro/LibretroVulkanContext.cpp
@@ -83,7 +83,7 @@ static const VkApplicationInfo *GetApplicationInfo(void) {
 	app_info.applicationVersion = Version(PPSSPP_GIT_VERSION).ToInteger();
 	app_info.pEngineName = "PPSSPP";
 	app_info.engineVersion = 2;
-	app_info.apiVersion = VK_API_VERSION_1_0;
+	app_info.apiVersion = VK_API_VERSION_1_3;
 	return &app_info;
 }
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -700,7 +700,6 @@ static void check_variables(CoreParameter &coreParam)
          g_Config.iInternalResolution = 1;
    }
 
-#if 0 // see issue #16786
    var.key = "ppsspp_mulitsample_level";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
@@ -715,7 +714,6 @@ static void check_variables(CoreParameter &coreParam)
       else if (!strcmp(var.value, "x8"))
          g_Config.iMultiSampleLevel = 3;
    }
-#endif
 
    var.key = "ppsspp_cropto16x9";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
@@ -1143,7 +1141,6 @@ static void check_variables(CoreParameter &coreParam)
          gpu->NotifyDisplayResized();
    }
 
-#if 0 // see issue #16786
    if (g_Config.iMultiSampleLevel != iMultiSampleLevel_prev && PSP_IsInited())
    {
       if (gpu)
@@ -1151,7 +1148,6 @@ static void check_variables(CoreParameter &coreParam)
          gpu->NotifyRenderResized();
       }
    }
-#endif
 
    if (updateAvInfo)
    {
@@ -1488,10 +1484,8 @@ bool retro_load_game(const struct retro_game_info *game)
 
    // Show/hide 'MSAA' and 'Texture Shader' options, Vulkan only
    option_display.visible = (g_Config.iGPUBackend == (int)GPUBackend::VULKAN);
-#if 0 // see issue #16786
    option_display.key = "ppsspp_mulitsample_level";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
-#endif
    option_display.key = "ppsspp_texture_shader";
    environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);
 

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -326,12 +326,11 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       },
       "480x272"
    },
-#if 0 // see issue #16786
    {
       "ppsspp_mulitsample_level",
-      "MSAA Antialiasing (Vulkan Only)",
+      "MSAA Antialiasing",
       NULL,
-      NULL,
+      "Vulkan only. Core restart required.",
       NULL,
       "video",
       {
@@ -343,7 +342,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       },
       "Disabled"
    },
-#endif
    {
       "ppsspp_cropto16x9",
       "Crop to 16x9",


### PR DESCRIPTION
I was unable to reproduce the mysterious crash when calling `vkGetPhysicalDeviceProperties2KHR` as described in the source file. I have a few theories as to why that is...but nothing really definitive. On the other hand `vkCreateDevice_libretro`'s feature overrides needed fixing because `VkDeviceCreateInfo::pEnabledFeatures` is an optional field and it'd crash on a null pointer. Its caller likes to use Features2 struct chaining instead.

The Vulkan instance version reported to libretro has also been bumped to 1.3. This should be inline with [Vulkan's spec](https://registry.khronos.org/vulkan/specs/latest/man/html/VkApplicationInfo.html) ("apiVersion must be the highest version of Vulkan that the application is designed to use").

Closes #16786.