### PR TITLE
libretro: Analog deadzone and sensitivity options are additive (set to off by default)

### DIFF
--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -460,7 +460,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       "ppsspp_analog_deadzone",
       "Analog Deadzone",
       NULL,
-      "Select how far you have to push the analog stick before it starts being processed.",
+      "Additional deadzone to apply after frontend input.",
       NULL,
       "input",
       {
@@ -477,13 +477,13 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "0.50", "50%" },
          { NULL, NULL },
       },
-      "0.15"
+      "0.0"
    },
    {
       "ppsspp_analog_sensitivity",
       "Analog Axis Scale",
       NULL,
-      "Sets the analog stick axis scaling factor.",
+      "Additional sensitivity factor to apply after frontend input.",
       NULL,
       "input",
       {
@@ -496,7 +496,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          {"1.42", NULL}, {"1.43", NULL}, {"1.44", NULL}, {"1.45", NULL}, {"1.46", NULL}, {"1.47", NULL}, {"1.48", NULL},
          {"1.49", NULL}, {"1.50", NULL}, {NULL, NULL},
       },
-      "1.10"
+      "1.00"
    },
    {
       "ppsspp_skip_buffer_effects",


### PR DESCRIPTION
There's no way to determine if frontends adjust input before hitting PPSSPP. Off by default it is.