### PR TITLE
sceNetInet: Stop resetting inetLastErrno to 0 in sceNetInetGetErrno()

### DIFF
--- a/Core/HLE/sceNetInet.cpp
+++ b/Core/HLE/sceNetInet.cpp
@@ -53,7 +53,7 @@ static int sceNetInetGetErrno() {
 	if (inetLastErrno == 0)
 		inetLastErrno = socket_errno;
 	int error = convertInetErrnoHost2PSP(inetLastErrno);
-	inetLastErrno = 0;
+	// We should not reset inetLastErrno to 0 here. This breaks MOHH.
 	return hleLogSuccessInfoI(Log::sceNet, error, "at %08x", currentMIPS->pc);
 }
 
@@ -61,7 +61,7 @@ static int sceNetInetGetPspError() {
 	if (inetLastErrno == 0)
 		inetLastErrno = socket_errno;
 	int error = convertInetErrno2PSPError(convertInetErrnoHost2PSP(inetLastErrno));
-	inetLastErrno = 0;
+	// We should not reset inetLastErrno to 0 here.
 	return hleLogSuccessInfoI(Log::sceNet, error, "at %08x", currentMIPS->pc);
 }
 


### PR DESCRIPTION
This fixes MOHH on Windows. See #19850 and #19841


No other platform resets errno on read, so this seems logical.

However, we need to test this for regressions.

Also, it would be even better if we can just merge this instead, which includes this: #19868