### PR TITLE
DNS autoconf: Fix games that do their own DNS queries by querying sceUtility for the DNS IP

### DIFF
--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -2248,7 +2248,6 @@ int initNetwork(SceNetAdhocctlAdhocId *adhoc_id){
 		socklen_t addrLen = sizeof(LocalIP);
 		memset(&LocalIP, 0, addrLen);
 		getsockname((int)metasocket, &LocalIP, &addrLen);
-		g_OSD.Show(OSDType::MESSAGE_SUCCESS, n->T("Network initialized"), 1.0, "networkinit");
 		return 0;
 	} else {
 		return SOCKET_ERROR;

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -205,8 +205,7 @@ bool LoadDNSForGameID(std::string_view gameID, InfraDNSConfig *dns) {
 			continue;
 		}
 
-		std::string name = game.getStringOr("name", "");
-		std::string dyn_dns = game.getStringOr("dyn_dns", dns->dns.c_str());
+		dns->gameName = game.getStringOr("name", "");
 		dns->dns = game.getStringOr("dns", dns->dns.c_str());
 		dns->dyn_dns = game.getStringOr("dyn_dns", "");
 		if (game.hasChild("domains", JSON_OBJECT)) {
@@ -762,7 +761,17 @@ static int sceNetInit(u32 poolSize, u32 calloutPri, u32 calloutStack, u32 netini
 	netInited = true;
 
 	auto n = GetI18NCategory(I18NCat::NETWORKING);
-	g_OSD.Show(OSDType::MESSAGE_INFO, n->T("Network initialized"), 2.0, "networkinit");
+
+	std::string msg(n->T("Network initialized"));
+	if (g_Config.bInfrastructureAutoDNS) {
+		msg += ": ";
+		msg += n->T("Auto DNS");
+		if (!g_infraDNSConfig.gameName.empty()) {
+			msg += " (" + g_infraDNSConfig.gameName + ")";
+		}
+	}
+
+	g_OSD.Show(OSDType::MESSAGE_INFO, msg, 2.0, "networkinit");
 	return hleLogSuccessI(Log::sceNet, 0);
 }
 
@@ -900,8 +909,8 @@ void NetApctl_InitDefaultInfo() {
 	// Set dummy/fake parameters, assuming this is the currently selected Network Configuration profile
 	// FIXME: Some of these info supposed to be taken from netConfInfo
 	int validConfId = std::max(1, netApctlInfoId); // Should be: sceUtilityGetNetParamLatestID(validConfId);
-	truncate_cpy(netApctlInfo.name, sizeof(netApctlInfo.name), (defaultNetConfigName + std::to_string(validConfId)).c_str());
-	truncate_cpy(netApctlInfo.ssid, sizeof(netApctlInfo.ssid), defaultNetSSID.c_str());
+	truncate_cpy(netApctlInfo.name, sizeof(netApctlInfo.name), defaultNetConfigName + std::to_string(validConfId));
+	truncate_cpy(netApctlInfo.ssid, sizeof(netApctlInfo.ssid), defaultNetSSID);
 	// Default IP Address
 	char ipstr[INET_ADDRSTRLEN] = "0.0.0.0"; // Driver 76 needs a dot formatted IP instead of a zeroed buffer
 	truncate_cpy(netApctlInfo.ip, sizeof(netApctlInfo.ip), ipstr);
@@ -915,8 +924,8 @@ void NetApctl_InitInfo(int confId) {
 	memset(&netApctlInfo, 0, sizeof(netApctlInfo));
 	// Set dummy/fake values, some of these (ie. IP set to Auto) probably not suppose to have valid info before connected to an AP, right?
 	// FIXME: Some of these info supposed to be taken from netConfInfo
-	truncate_cpy(netApctlInfo.name, sizeof(netApctlInfo.name), (defaultNetConfigName + std::to_string(confId)).c_str());
-	truncate_cpy(netApctlInfo.ssid, sizeof(netApctlInfo.ssid), defaultNetSSID.c_str());
+	truncate_cpy(netApctlInfo.name, sizeof(netApctlInfo.name), defaultNetConfigName + std::to_string(confId));
+	truncate_cpy(netApctlInfo.ssid, sizeof(netApctlInfo.ssid), defaultNetSSID);
 	memcpy(netApctlInfo.bssid, "\1\1\2\2\3\3", sizeof(netApctlInfo.bssid)); // fake AP's mac address
 	netApctlInfo.ssidLength = static_cast<unsigned int>(defaultNetSSID.length());
 	netApctlInfo.strength = 99;
@@ -932,12 +941,22 @@ void NetApctl_InitInfo(int confId) {
 	((u8*)&sockAddr.sin_addr.s_addr)[3] = 1;
 	inet_ntop(AF_INET, &sockAddr.sin_addr, ipstr, sizeof(ipstr));
 	truncate_cpy(netApctlInfo.gateway, sizeof(netApctlInfo.gateway), ipstr);
-	// We should probably use public DNS Server instead of localhost IP since most people don't have DNS Server running on localhost (ie. Untold Legends The Warrior's Code is trying to lookup dns using the primary dns), but accessing public DNS Server from localhost may result to ENETUNREACH error if the gateway can't access the public server (ie. using SO_DONTROUTE)
-	//if (strcmp(ipstr, "127.0.0.1") == 0)
-		truncate_cpy(netApctlInfo.primaryDns, sizeof(netApctlInfo.primaryDns), g_Config.sInfrastructureDNSServer.c_str()); // Private Servers may need to use custom DNS Server
-	//else
-	//	truncate_cpy(netApctlInfo.primaryDns, sizeof(netApctlInfo.primaryDns), ipstr);
+
+	// We use the configured DNS server, whether manually or auto configured.
+	// Games often use this to perform their own DNS lookups through tcp/ip, so we need to pass in the configured server.
+	// The reason we need autoconfig is that private Servers may need to use custom DNS Server - and most games are now
+	// best played on private servers (only a few official ones remain, if any).
+	if (g_Config.bInfrastructureAutoDNS) {
+		INFO_LOG(Log::sceNet, "Responding to game query with AutoDNS address");
+		truncate_cpy(netApctlInfo.primaryDns, sizeof(netApctlInfo.primaryDns), g_infraDNSConfig.dns);
+	} else {
+		INFO_LOG(Log::sceNet, "Responding to game query with manual DNS address");
+		truncate_cpy(netApctlInfo.primaryDns, sizeof(netApctlInfo.primaryDns), g_Config.sInfrastructureDNSServer);
+	}
+
+	// We don't bother with a secondary DNS.
 	truncate_cpy(netApctlInfo.secondaryDns, sizeof(netApctlInfo.secondaryDns), "0.0.0.0"); // Fireteam Bravo 2 seems to try to use secondary DNS too if it's not 0.0.0.0
+
 	truncate_cpy(netApctlInfo.subNetMask, sizeof(netApctlInfo.subNetMask), "255.255.255.0");
 }
 

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -943,7 +943,7 @@ void NetApctl_InitInfo(int confId) {
 	truncate_cpy(netApctlInfo.gateway, sizeof(netApctlInfo.gateway), ipstr);
 
 	// We use the configured DNS server, whether manually or auto configured.
-	// Games often use this to perform their own DNS lookups through tcp/ip, so we need to pass in the configured server.
+	// Games (for example, Wipeout Pulse) often use this to perform their own DNS lookups through UDP, so we need to pass in the configured server.
 	// The reason we need autoconfig is that private Servers may need to use custom DNS Server - and most games are now
 	// best played on private servers (only a few official ones remain, if any).
 	if (g_Config.bInfrastructureAutoDNS) {

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -2703,7 +2703,7 @@ int sceNetAdhocctlGetPeerInfo(const char *mac, int size, u32 peerInfoAddr) {
 		if (isLocalMAC(maddr)) {
 			SceNetAdhocctlNickname nickname;
 
-			truncate_cpy((char*)&nickname.data, ADHOCCTL_NICKNAME_LEN, g_Config.sNickName.c_str());
+			truncate_cpy((char*)&nickname.data, ADHOCCTL_NICKNAME_LEN, g_Config.sNickName);
 			buf->next = 0;
 			buf->nickname = nickname;
 			buf->nickname.data[ADHOCCTL_NICKNAME_LEN - 1] = 0; // last char need to be null-terminated char

--- a/Core/HLE/sceNp.cpp
+++ b/Core/HLE/sceNp.cpp
@@ -285,7 +285,7 @@ static int sceNpGetUserProfile(u32 profilePtr)
 
 	profile.FillWithZero();
 	strncpy(profile->userId.handle.data, npOnlineId.c_str(), sizeof(profile->userId.handle.data));
-	truncate_cpy(profile->icon.data, sizeof(profile->icon.data), npAvatarUrl.c_str());
+	truncate_cpy(profile->icon.data, sizeof(profile->icon.data), npAvatarUrl);
 
 	INFO_LOG(Log::sceNet, "%s - Online ID: %s", __FUNCTION__, profile->userId.handle.data);
 	std::string datahex;

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -745,7 +745,7 @@ static int sceUtilityGetNetParam(int id, int param, u32 dataAddr) {
 
 	// TODO: Replace the temporary netApctlInfo with netConfInfo, since some of netApctlInfo contents supposed to be taken from netConfInfo during ApctlInit, while sceUtilityGetNetParam can be used before Apctl Initialized
 	char name[APCTL_PROFILENAME_MAXLEN];
-	truncate_cpy(name, sizeof(name), (defaultNetConfigName + std::to_string(id == 0 ? netParamLatestId:id)).c_str());
+	truncate_cpy(name, sizeof(name), defaultNetConfigName + std::to_string(id == 0 ? netParamLatestId:id));
 	char dummyWEPKey[6] = "XXXXX"; // WEP 64-bit = 10 hex digits key or 5-digit ASCII equivalent
 	char dummyUserPass[256] = "PPSSPP"; // FIXME: Username / Password max length = 255 chars?
 	char dummyWPAKey[64] = "XXXXXXXX"; // FIXME: WPA 256-bit = 64 hex digits key or 8 to 63-chars ASCII passphrases?
@@ -811,7 +811,7 @@ static int sceUtilityGetNetParam(int id, int param, u32 dataAddr) {
 		break;
 	case PSP_NETPARAM_MANUAL_DNS:
 		// 0 is auto.
-		// 1 is manual.
+		// 1 is manual. We always use manual.
 		if (!Memory::IsValidRange(dataAddr, 4))
 			return hleLogError(Log::sceNet, -1, "invalid arg");
 		Memory::WriteUnchecked_U32(1, dataAddr);  // manual


### PR DESCRIPTION
Followup to #19865 

Now Wipeout Pulse is correctly autoconfigured and "just works".