### PR TITLE
Add a bunch of restrictions when online

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -908,6 +908,7 @@ static const ConfigSetting networkSettings[] = {
 	ConfigSetting("UPnPUseOriginalPort", &g_Config.bUPnPUseOriginalPort, false, CfgFlag::PER_GAME),
 	ConfigSetting("InfrastructureUsername", &g_Config.sInfrastructureUsername, &DefaultInfrastructureUsername, CfgFlag::PER_GAME),
 	ConfigSetting("InfrastructureAutoDNS", &g_Config.bInfrastructureAutoDNS, true, CfgFlag::PER_GAME),
+	ConfigSetting("AllowSavestateWhileConnected", &g_Config.bAllowSavestateWhileConnected, false, CfgFlag::DONT_SAVE),
 
 	ConfigSetting("EnableNetworkChat", &g_Config.bEnableNetworkChat, false, CfgFlag::PER_GAME),
 	ConfigSetting("ChatButtonPosition", &g_Config.iChatButtonPosition, (int)ScreenEdgePosition::BOTTOM_LEFT, CfgFlag::PER_GAME),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -462,6 +462,7 @@ public:
 	std::string sInfrastructureDNSServer;
 	std::string sInfrastructureUsername;  // Username used for Infrastructure play. Different restrictions.
 	bool bInfrastructureAutoDNS;
+	bool bAllowSavestateWhileConnected;  // Developer option, ini-only. No normal users need this, it's always wrong to save/load state when online.
 
 	bool bEnableWlan;
 	std::map<std::string, std::string> mHostToAlias;  // Local DNS database stored in ini file

--- a/Core/FrameTiming.cpp
+++ b/Core/FrameTiming.cpp
@@ -29,6 +29,7 @@
 #include "Core/System.h"
 #include "Core/Config.h"
 #include "Core/HW/Display.h"
+#include "Core/HLE/sceNet.h"
 #include "Core/FrameTiming.h"
 
 FrameTiming g_frameTiming;
@@ -93,10 +94,16 @@ Draw::PresentMode ComputePresentMode(Draw::DrawContext *draw, int *interval) {
 			wantInstant = true;
 		}
 
-		if (PSP_CoreParameter().fastForward) {
+		if (PSP_CoreParameter().fastForward && NetworkAllowSpeedControl()) {
 			wantInstant = true;
 		}
-		if (PSP_CoreParameter().fpsLimit != FPSLimit::NORMAL) {
+
+		FPSLimit limit = PSP_CoreParameter().fpsLimit;
+		if (!NetworkAllowSpeedControl()) {
+			limit = FPSLimit::NORMAL;
+		}
+
+		if (limit != FPSLimit::NORMAL) {
 			int limit;
 			if (PSP_CoreParameter().fpsLimit == FPSLimit::CUSTOM1)
 				limit = g_Config.iFpsLimit1;

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -46,6 +46,7 @@
 #include "Core/HLE/FunctionWrappers.h"
 #include "Core/HLE/sceDisplay.h"
 #include "Core/HLE/sceKernel.h"
+#include "Core/HLE/sceNet.h"
 #include "Core/HLE/sceKernelThread.h"
 #include "Core/HLE/sceKernelInterrupt.h"
 #include "Core/HW/Display.h"
@@ -353,6 +354,10 @@ void __DisplaySetWasPaused() {
 
 // TOOD: Should return 59.997?
 static int FrameTimingLimit() {
+	if (!NetworkAllowSpeedControl()) {
+		return 60;
+	}
+
 	bool challenge = Achievements::HardcoreModeActive();
 
 	auto fixRate = [=](int limit) {

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -95,6 +95,34 @@ int NetApctl_Term();
 void NetApctl_InitDefaultInfo();
 void NetApctl_InitInfo(int confId);
 
+bool NetworkWarnUserIfOnlineAndCantSavestate() {
+	if (netInited && !g_Config.bAllowSavestateWhileConnected) {
+		auto nw = GetI18NCategory(I18NCat::NETWORKING);
+		g_OSD.Show(OSDType::MESSAGE_INFO, nw->T("Save states are not available when online"), 3.0f, "saveonline");
+		return true;
+	} else {
+		return false;
+	}
+}
+
+bool NetworkWarnUserIfOnlineAndCantSpeed() {
+	if (netInited) {
+		auto nw = GetI18NCategory(I18NCat::NETWORKING);
+		g_OSD.Show(OSDType::MESSAGE_INFO, nw->T("Speed controls are not available when online"), 3.0f, "speedonline");
+		return true;
+	} else {
+		return false;
+	}
+}
+
+bool NetworkAllowSpeedControl() {
+	return !netInited;
+}
+
+bool NetworkAllowSaveState() {
+	return !netInited || g_Config.bAllowSavestateWhileConnected;
+}
+
 void AfterApctlMipsCall::DoState(PointerWrap & p) {
 	auto s = p.Section("AfterApctlMipsCall", 1, 1);
 	if (!s)

--- a/Core/HLE/sceNet.h
+++ b/Core/HLE/sceNet.h
@@ -130,6 +130,13 @@ int NetApctl_GetState();
 int sceNetApctlConnect(int connIndex);
 int sceNetApctlTerm();
 
+// These return false if allowed to be consistent with the similar function for achievements.
+bool NetworkWarnUserIfOnlineAndCantSavestate();
+bool NetworkWarnUserIfOnlineAndCantSpeed();
+
+bool NetworkAllowSaveState();
+bool NetworkAllowSpeedControl();
+
 enum class InfraGameState {
 	Unknown,
 	Working,

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -67,6 +67,7 @@ using namespace std::placeholders;
 #include "Core/MIPS/MIPS.h"
 #include "Core/HLE/sceCtrl.h"
 #include "Core/HLE/sceSas.h"
+#include "Core/HLE/sceNet.h"
 #include "Core/HLE/sceNetAdhoc.h"
 #include "Core/Debugger/SymbolMap.h"
 #include "Core/RetroAchievements.h"
@@ -1841,7 +1842,7 @@ void EmuScreen::resized() {
 }
 
 bool MustRunBehind() {
-	return __NetAdhocConnected();
+	return netInited || __NetAdhocConnected();
 }
 
 bool ShouldRunBehind() {

--- a/UI/GamepadEmu.h
+++ b/UI/GamepadEmu.h
@@ -71,7 +71,6 @@ class BoolButton : public MultiTouchButton {
 public:
 	BoolButton(bool *value, const char *key, ImageID bgImg, ImageID bgDownImg, ImageID img, float scale, UI::LayoutParams *layoutParams)
 		: MultiTouchButton(key, bgImg, bgDownImg, img, scale, layoutParams), value_(value) {
-
 	}
 	bool Touch(const TouchInput &input) override;
 	bool IsDown() override { return *value_; }

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -64,4 +64,5 @@ private:
 	DialogResult finishNextFrameResult_ = DR_CANCEL;
 
 	UI::Button *playButton_ = nullptr;
+	bool lastNetInited_ = false;
 };

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -49,6 +49,7 @@
 #include "Windows/W32Util/DarkMode.h"
 
 #include "Core/HLE/sceUmd.h"
+#include "Core/HLE/sceNet.h"
 #include "Core/SaveState.h"
 #include "Core/Core.h"
 #include "Core/RetroAchievements.h"
@@ -83,6 +84,11 @@ namespace MainWindow {
 			if (!g_Config.bAchievementsSaveStateInHardcoreMode) {
 				saveStateEnableBool = false;
 			}
+		}
+
+		if (!NetworkAllowSaveState()) {
+			loadStateEnableBool = false;
+			saveStateEnableBool = false;
 		}
 
 		const UINT menuEnable = menuEnableBool ? MF_ENABLED : MF_GRAYED;
@@ -491,7 +497,9 @@ namespace MainWindow {
 			break;
 
 		case ID_EMULATION_PAUSE:
-			System_PostUIMessage(UIMessage::REQUEST_GAME_PAUSE);
+			if (!NetworkWarnUserIfOnlineAndCantSpeed()) {
+				System_PostUIMessage(UIMessage::REQUEST_GAME_PAUSE);
+			}
 			break;
 
 		case ID_EMULATION_STOP:
@@ -527,8 +535,9 @@ namespace MainWindow {
 				System_PostUIMessage(UIMessage::SHOW_CHAT_SCREEN);
 			}
 			break;
+
 		case ID_FILE_LOADSTATEFILE:
-			if (!Achievements::WarnUserIfHardcoreModeActive(false)) {
+			if (!Achievements::WarnUserIfHardcoreModeActive(false) && !NetworkWarnUserIfOnlineAndCantSavestate()) {
 				if (W32Util::BrowseForFileName(true, hWnd, L"Load state", 0, L"Save States (*.ppst)\0*.ppst\0All files\0*.*\0\0", L"ppst", fn)) {
 					SetCursor(LoadCursor(0, IDC_WAIT));
 					SaveState::Load(Path(fn), -1, SaveStateActionFinished);
@@ -536,7 +545,7 @@ namespace MainWindow {
 			}
 			break;
 		case ID_FILE_SAVESTATEFILE:
-			if (!Achievements::WarnUserIfHardcoreModeActive(true)) {
+			if (!Achievements::WarnUserIfHardcoreModeActive(true) && !NetworkWarnUserIfOnlineAndCantSavestate()) {
 				if (W32Util::BrowseForFileName(false, hWnd, L"Save state", 0, L"Save States (*.ppst)\0*.ppst\0All files\0*.*\0\0", L"ppst", fn)) {
 					SetCursor(LoadCursor(0, IDC_WAIT));
 					SaveState::Save(Path(fn), -1, SaveStateActionFinished);
@@ -546,7 +555,7 @@ namespace MainWindow {
 
 		case ID_FILE_SAVESTATE_NEXT_SLOT:
 		{
-			if (!Achievements::WarnUserIfHardcoreModeActive(true)) {
+			if (!Achievements::WarnUserIfHardcoreModeActive(true) && !NetworkWarnUserIfOnlineAndCantSavestate()) {
 				SaveState::NextSlot();
 				System_PostUIMessage(UIMessage::SAVESTATE_DISPLAY_SLOT);
 			}
@@ -555,7 +564,7 @@ namespace MainWindow {
 
 		case ID_FILE_SAVESTATE_NEXT_SLOT_HC:
 		{
-			if (!Achievements::WarnUserIfHardcoreModeActive(true)) {
+			if (!Achievements::WarnUserIfHardcoreModeActive(true) && !NetworkWarnUserIfOnlineAndCantSavestate()) {
 				// We let F3 (search next) in the imdebugger take priority, if active.
 				if (!KeyMap::PspButtonHasMappings(VIRTKEY_NEXT_SLOT) && !g_Config.bShowImDebugger) {
 					SaveState::NextSlot();
@@ -570,13 +579,13 @@ namespace MainWindow {
 		case ID_FILE_SAVESTATE_SLOT_3:
 		case ID_FILE_SAVESTATE_SLOT_4:
 		case ID_FILE_SAVESTATE_SLOT_5:
-			if (!Achievements::WarnUserIfHardcoreModeActive(true)) {
+			if (!Achievements::WarnUserIfHardcoreModeActive(true) && !NetworkWarnUserIfOnlineAndCantSavestate()) {
 				g_Config.iCurrentStateSlot = wmId - ID_FILE_SAVESTATE_SLOT_1;
 			}
 			break;
 
 		case ID_FILE_QUICKLOADSTATE:
-			if (!Achievements::WarnUserIfHardcoreModeActive(false)) {
+			if (!Achievements::WarnUserIfHardcoreModeActive(false) && !NetworkWarnUserIfOnlineAndCantSavestate()) {
 				SetCursor(LoadCursor(0, IDC_WAIT));
 				SaveState::LoadSlot(PSP_CoreParameter().fileToStart, g_Config.iCurrentStateSlot, SaveStateActionFinished);
 			}
@@ -584,7 +593,7 @@ namespace MainWindow {
 
 		case ID_FILE_QUICKLOADSTATE_HC:
 		{
-			if (!Achievements::WarnUserIfHardcoreModeActive(false)) {
+			if (!Achievements::WarnUserIfHardcoreModeActive(false) && !NetworkWarnUserIfOnlineAndCantSavestate()) {
 				if (!KeyMap::PspButtonHasMappings(VIRTKEY_LOAD_STATE)) {
 					SetCursor(LoadCursor(0, IDC_WAIT));
 					SaveState::LoadSlot(PSP_CoreParameter().fileToStart, g_Config.iCurrentStateSlot, SaveStateActionFinished);
@@ -594,7 +603,7 @@ namespace MainWindow {
 		}
 		case ID_FILE_QUICKSAVESTATE:
 		{
-			if (!Achievements::WarnUserIfHardcoreModeActive(true)) {
+			if (!Achievements::WarnUserIfHardcoreModeActive(true) && !NetworkWarnUserIfOnlineAndCantSavestate()) {
 				SetCursor(LoadCursor(0, IDC_WAIT));
 				SaveState::SaveSlot(PSP_CoreParameter().fileToStart, g_Config.iCurrentStateSlot, SaveStateActionFinished);
 			}
@@ -603,7 +612,7 @@ namespace MainWindow {
 
 		case ID_FILE_QUICKSAVESTATE_HC:
 		{
-			if (!Achievements::WarnUserIfHardcoreModeActive(true)) {
+			if (!Achievements::WarnUserIfHardcoreModeActive(true) && !NetworkWarnUserIfOnlineAndCantSavestate()) {
 				if (!KeyMap::PspButtonHasMappings(VIRTKEY_SAVE_STATE))
 				{
 					SetCursor(LoadCursor(0, IDC_WAIT));


### PR DESCRIPTION
No savestate, no speed controls.

There's an escape route with a hidden ini file option to enable savestates when online, for development purposes. Otherwise they are useless since your game will break.

The goal of all this is to make it harder for users to accidentally screw up their multiplayer sessions by using features that will inevitably break them.