### PR TITLE
macOS/iOS: register font with CoreText

### DIFF
--- a/Common/Render/Text/draw_text_cocoa.mm
+++ b/Common/Render/Text/draw_text_cocoa.mm
@@ -32,7 +32,12 @@ enum {
 	MAX_TEXT_HEIGHT = 512
 };
 
-#define APPLE_FONT "Helvetica"
+#define APPLE_FONT "Roboto-Condensed"
+
+// for future OpenEmu support
+#ifndef PPSSPP_FONT_BUNDLE
+#define PPSSPP_FONT_BUNDLE [NSBundle mainBundle]
+#endif
 
 class TextDrawerFontContext {
 public:
@@ -44,8 +49,10 @@ public:
 		// Create an attributed string with string and font information
 		CGFloat fontSize = ceilf((height / dpiScale) * 1.25f);
 		INFO_LOG(Log::G3D, "Creating cocoa typeface '%s' size %d (effective size %0.1f)", APPLE_FONT, height, fontSize);
-		// CTFontRef font = CTFontCreateWithName(CFSTR(APPLE_FONT), fontSize, nil);
-		CTFontRef font = CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, fontSize, nil);
+		NSURL *fontURL = [PPSSPP_FONT_BUNDLE URLForResource:@"Roboto-Condensed" withExtension:@"ttf" subdirectory:@"assets"];
+		CTFontManagerRegisterFontsForURL((CFURLRef)fontURL, kCTFontManagerScopeProcess, NULL);
+		CTFontRef font = CTFontCreateWithName(CFSTR(APPLE_FONT), fontSize, nil);
+		// CTFontRef font = CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, fontSize, nil);
 		attributes = [NSDictionary dictionaryWithObjectsAndKeys:
 			(__bridge id)font, kCTFontAttributeName,
 			kCFBooleanTrue, kCTForegroundColorFromContextAttributeName,  // Lets us specify the color later.

--- a/Common/Render/Text/draw_text_cocoa.mm
+++ b/Common/Render/Text/draw_text_cocoa.mm
@@ -46,11 +46,16 @@ public:
 	}
 
 	void Create() {
+		// Register font with CoreText
+		// We only need to do this once.
+		static dispatch_once_t onceToken;
+		dispatch_once(&onceToken, ^{
+			NSURL *fontURL = [PPSSPP_FONT_BUNDLE URLForResource:@"Roboto-Condensed" withExtension:@"ttf" subdirectory:@"assets"];
+			CTFontManagerRegisterFontsForURL((CFURLRef)fontURL, kCTFontManagerScopeProcess, NULL);
+		});
 		// Create an attributed string with string and font information
 		CGFloat fontSize = ceilf((height / dpiScale) * 1.25f);
 		INFO_LOG(Log::G3D, "Creating cocoa typeface '%s' size %d (effective size %0.1f)", APPLE_FONT, height, fontSize);
-		NSURL *fontURL = [PPSSPP_FONT_BUNDLE URLForResource:@"Roboto-Condensed" withExtension:@"ttf" subdirectory:@"assets"];
-		CTFontManagerRegisterFontsForURL((CFURLRef)fontURL, kCTFontManagerScopeProcess, NULL);
 		CTFontRef font = CTFontCreateWithName(CFSTR(APPLE_FONT), fontSize, nil);
 		// CTFontRef font = CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, fontSize, nil);
 		attributes = [NSDictionary dictionaryWithObjectsAndKeys:

--- a/Common/Render/Text/draw_text_cocoa.mm
+++ b/Common/Render/Text/draw_text_cocoa.mm
@@ -65,12 +65,9 @@ public:
 		CFRelease(font);
 	}
 	void Destroy() {
-		//CFRelease(font);
-		font = {};
 	}
 
 	NSDictionary* attributes = nil;
-	CTFontRef font = nil;
 	std::string fname;
 	int height;
 	int bold;


### PR DESCRIPTION
This registers the font with CoreText for the application. This should work with both macOS and iOS.