### PR TITLE
Attempt to fix Outrun 2006 infrastructure

### DIFF
--- a/Core/HLE/sceNetInet.cpp
+++ b/Core/HLE/sceNetInet.cpp
@@ -493,6 +493,11 @@ static int sceNetInetSetsockopt(int socket, int level, int optname, u32 optvalPt
 				return hleLogError(Log::sceNet, -1, "buffer size too large?");
 			}
 			break;
+
+		case PSP_NET_INET_SO_ONESBCAST:
+			// Seen in Outrun 2006 (account registration), assuming that the flag mapping is correct, we can't support this. So we warn-log and pretend success.
+			return hleLogWarning(Log::sceNet, 0, "PSP_NET_INET_SO_ONESBCAST unsupported, ignoring");
+
 		default:
 			break;
 		}

--- a/Core/HLE/sceNetResolver.cpp
+++ b/Core/HLE/sceNetResolver.cpp
@@ -229,10 +229,7 @@ static int sceNetResolverCreate(u32 resolverIdPtr, u32 bufferPtr, int bufferLen)
 	if (Memory::IsValidRange(bufferPtr, 4) && bufferLen < 1)
 		return hleLogError(Log::sceNet, ERROR_NET_RESOLVER_INVALID_BUFLEN, "Invalid Buffer Length: %i", bufferLen);
 
-	if (!g_netResolverInitialized) {
-		// Possibly don't check this? Or auto-initialized? Outrun seems to assume it's not needed.
-		return hleLogError(Log::sceNet, ERROR_NET_RESOLVER_STOPPED, "Resolver Subsystem Stopped");
-	}
+	// Outrun calls this without init.
 
 	// TODO: Consider using SceUidManager instead of this 1-indexed id
 	// TODO: Implement ERROR_NET_RESOLVER_ID_MAX (possibly 32?)

--- a/assets/infra-dns.json
+++ b/assets/infra-dns.json
@@ -138,6 +138,19 @@
 				"UCES00420",
 				"UCUS98633"
 			]
+		},
+		{
+			"name": "Outrun 2006 - Coast 2 Coast",
+			"not_working_ids": [
+				"ULES00262",
+				"ULUS10064",
+				"ULKS46087"
+			],
+			"dns": "45.7.228.197",
+			"score": 1,
+			"revival_credits": {
+				"group": "OutRun2006Tweaks"
+			}
 		}
 	]
 }


### PR DESCRIPTION
However, not getting it to work just yet.. Running ULES00262.

~~This refactors away an unnecessary wrapper class from sceNetResolver because it got in the way.~~ This was moved to #19880 

I put the DNS 45.7.228.197 in infra.json for the game ID. It ends up asking it for `outrun2.stun.us.demonware.net`, and in response it gets 34.118.10.198 . Then, further access to this seems to time out when registering an account (the game has you enter user/pass before connecting).. Not sure what's going on.

Should try with the old fork, I guess... EDIT: Apparently the server isn't working. Oh well.

See [#](https://github.com/hrydgard/ppsspp/issues/19850#issuecomment-2597030859)