### PR TITLE
libretro: restore requested vulkan api version to match VulkanLoader

### DIFF
--- a/libretro/LibretroVulkanContext.cpp
+++ b/libretro/LibretroVulkanContext.cpp
@@ -83,7 +83,7 @@ static const VkApplicationInfo *GetApplicationInfo(void) {
 	app_info.applicationVersion = Version(PPSSPP_GIT_VERSION).ToInteger();
 	app_info.pEngineName = "PPSSPP";
 	app_info.engineVersion = 2;
-	app_info.apiVersion = VK_API_VERSION_1_3;
+	app_info.apiVersion = VK_API_VERSION_1_0;
 	return &app_info;
 }
 


### PR DESCRIPTION
Changed by #19857 , this breaks loading the ppsspp core on devices where the Vulkan api provided is 1.2 (or lower), particularly Apple devices.