### PR TITLE
Correct logging for "recursive" syscalls

### DIFF
--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -23,6 +23,7 @@
 #include "Core/Config.h"
 #include "Core/MemMapHelpers.h"
 #include "Core/Util/PPGeDraw.h"
+#include "Core/HLE/HLE.h"
 #include "Core/HLE/sceKernelMemory.h"
 #include "Core/HLE/sceCtrl.h"
 #include "Core/HLE/sceUtility.h"
@@ -176,7 +177,8 @@ int PSPNetconfDialog::Update(int animSpeed) {
 			else if (state == PSP_NET_APCTL_STATE_DISCONNECTED) {
 				// When connecting with infrastructure, simulate a connection using the first network configuration entry.
 				if (connResult < 0) {
-					connResult = sceNetApctlConnect(1);
+					// connResult = sceNetApctlConnect(1);
+					connResult = hleCall(sceNetApctl, int, sceNetApctlConnect, 1);
 				}
 			}
 		}

--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -219,13 +219,13 @@ int PSPNetconfDialog::Update(int animSpeed) {
 					{
 					case NETCONF_CREATE_ADHOC:
 						if (connResult < 0) {
-							connResult = sceNetAdhocctlCreate(request.NetconfData->groupName);
+							connResult = hleCall(sceNetAdhocctl, int, sceNetAdhocctlCreate, request.NetconfData->groupName);
 						}
 						break;
 					case NETCONF_JOIN_ADHOC:
 						// FIXME: Should we Scan for a matching group first before Joining a Group (like adhoc games normally do)? Or Is it really allowed to join non-existing group?
 						if (scanStep == 0) {
-							if (sceNetAdhocctlScan() >= 0) {
+							if (hleCall(sceNetAdhocctl, int, sceNetAdhocctlScan) >= 0) {
 								u32 structsz = sizeof(ScanInfos);
 								if (Memory::IsValidAddress(scanInfosAddr))
 									userMemory.Free(scanInfosAddr);
@@ -237,7 +237,7 @@ int PSPNetconfDialog::Update(int animSpeed) {
 						else if (scanStep == 1) {
 							s32 sz = Memory::Read_U32(scanInfosAddr);
 							// Get required buffer size
-							if (sceNetAdhocctlGetScanInfo(scanInfosAddr, 0) >= 0) {
+							if (hleCall(sceNetAdhocctl, int, sceNetAdhocctlGetScanInfo, scanInfosAddr, 0) >= 0) {
 								s32 reqsz = Memory::Read_U32(scanInfosAddr);
 								if (reqsz > sz) {
 									sz = reqsz;
@@ -248,7 +248,7 @@ int PSPNetconfDialog::Update(int animSpeed) {
 									Memory::Write_U32(sz, scanInfosAddr);
 								}
 								if (reqsz > 0) {
-									if (sceNetAdhocctlGetScanInfo(scanInfosAddr, scanInfosAddr + sizeof(s32)) >= 0) {
+									if (hleCall(sceNetAdhocctl, int, sceNetAdhocctlGetScanInfo, scanInfosAddr, scanInfosAddr + (u32)sizeof(s32)) >= 0) {
 										ScanInfos* scanInfos = (ScanInfos*)Memory::GetPointer(scanInfosAddr);
 										int n = scanInfos->sz / sizeof(SceNetAdhocctlScanInfoEmu);
 										// Assuming returned SceNetAdhocctlScanInfoEmu(s) are contagious where next is pointing to current addr + sizeof(SceNetAdhocctlScanInfoEmu)
@@ -276,7 +276,7 @@ int PSPNetconfDialog::Update(int animSpeed) {
 						}
 						else if (scanStep == 2) {
 							if (connResult < 0) {
-								connResult = sceNetAdhocctlJoin(scanInfosAddr + sizeof(s32));
+								connResult = hleCall(sceNetAdhocctl, int, sceNetAdhocctlJoin, scanInfosAddr + (u32)sizeof(s32));
 								if (connResult >= 0) {
 									// We are done!
 									if (Memory::IsValidAddress(scanInfosAddr))
@@ -288,7 +288,7 @@ int PSPNetconfDialog::Update(int animSpeed) {
 						break;
 					default:
 						if (connResult < 0) {
-							connResult = sceNetAdhocctlConnect(request.NetconfData->groupName);
+							connResult = hleCall(sceNetAdhocctl, int, sceNetAdhocctlConnect, request.NetconfData->groupName);
 						}
 						break;
 					}

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -6,8 +6,8 @@
 #include "Core/HW/Atrac3Standalone.h"
 
 // Convenient command line:
-// Windows\x64\debug\PPSSPPHeadless.exe  --root pspautotests/tests/../ --compare --timeout=5 --new-atrac --graphics=software pspautotests/tests/audio/atrac/decode.prx
-
+// Windows\x64\debug\PPSSPPHeadless.exe  --root pspautotests/tests/../ -o --compare --timeout=30 --graphics=software pspautotests/tests/audio/atrac/... --ignore pspautotests/tests/audio/atrac/second/resetting.prx --ignore pspautotests/tests/audio/atrac/second/replay.prx
+//
 // See the big comment in sceAtrac.cpp for an overview of the different modes of operation.
 //
 // Test cases

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -410,7 +410,7 @@ static bool hleExecuteDebugBreak(const HLEFunction *func) {
 
 // Should be used *outside* hleLogError for example. Not the other way around.
 u32 hleDelayResult(u32 result, const char *reason, int usec) {
-	_dbg_assert_(g_stackSize == 0);
+	// _dbg_assert_(g_stackSize == 0);
 
 	if (!__KernelIsDispatchEnabled()) {
 		WARN_LOG(Log::HLE, "%s: Dispatch disabled, not delaying HLE result (right thing to do?)", g_stackSize ? g_stack[0]->name : "?");
@@ -427,14 +427,14 @@ u32 hleDelayResult(u32 result, const char *reason, int usec) {
 u64 hleDelayResult(u64 result, const char *reason, int usec) {
 	// Note: hleDelayResult is called at the outer level, *outside* logging.
 	// So, we read from the entry that was just popped. This is OK.
-	_dbg_assert_(g_stackSize == 0);
+	// _dbg_assert_(g_stackSize == 0);
 	if (!__KernelIsDispatchEnabled()) {
-		WARN_LOG(Log::HLE, "%s: Dispatch disabled, not delaying HLE result (right thing to do?)", g_stack[0]->name);
+		WARN_LOG(Log::HLE, "%s: Dispatch disabled, not delaying HLE result (right thing to do?)", g_stack[0]->name ? g_stack[0]->name : "N/A");
 	} else {
 		// TODO: Defer this, so you can call this multiple times, in case of syscalls calling syscalls? Although, return values are tricky.
 		SceUID thread = __KernelGetCurThread();
 		if (KernelIsThreadWaiting(thread))
-			ERROR_LOG(Log::HLE, "%s: Delaying a thread that's already waiting", g_stack[0]->name);
+			ERROR_LOG(Log::HLE, "%s: Delaying a thread that's already waiting", g_stack[0]->name ? g_stack[0]->name : "N/A");
 		u64 param = (result & 0xFFFFFFFF00000000) | thread;
 		CoreTiming::ScheduleEvent(usToCycles(usec), delayedResultEvent, param);
 		__KernelWaitCurThread(WAITTYPE_HLEDELAY, 1, (u32)result, 0, false, reason);
@@ -975,7 +975,7 @@ size_t hleFormatLogArgs(char *message, size_t sz, const char *argmask) {
 
 void hleLeave() {
 	int stackSize = g_stackSize;
-	_dbg_assert_(stackSize > 0);
+	//_dbg_assert_(stackSize > 0);
 	if (stackSize > 0) {
 		g_stackSize = stackSize - 1;
 	}  // else warn?

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -736,7 +736,8 @@ static void CallSyscallWithFlags(const HLEFunction *info) {
 		info->func();
 	}
 
-	// Now, g_stackSize should be back to 0.
+	// Now, g_stackSize should be back to 0. Enable this for "pedantic mode", will find a lot of problems.
+	// Check g_stack[0] in the debugger.
 	// _dbg_assert_(g_stackSize == 0);
 
 	if (hleAfterSyscall != HLE_AFTER_NOTHING)
@@ -759,7 +760,8 @@ static void CallSyscallWithoutFlags(const HLEFunction *info) {
 
 	info->func();
 
-	// Now, g_stackSize should be back to 0.
+	// Now, g_stackSize should be back to 0. Enable this for "pedantic mode", will find a lot of problems.
+	// Check g_stack[0] in the debugger.
 	// _dbg_assert_(g_stackSize == 0);
 
 	if (hleAfterSyscall != HLE_AFTER_NOTHING)

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -130,6 +130,7 @@ static void hleDelayResultFinish(u64 userdata, int cycleslate) {
 
 void HLEInit() {
 	RegisterAllModules();
+	g_stackSize = 0;
 	delayedResultEvent = CoreTiming::RegisterEvent("HLEDelayedResult", hleDelayResultFinish);
 	idleOp = GetSyscallOp("FakeSysCalls", NID_IDLE);
 }
@@ -169,7 +170,6 @@ void HLEDoState(PointerWrap &p) {
 
 void HLEShutdown() {
 	hleAfterSyscall = HLE_AFTER_NOTHING;
-	g_stackSize = 0;
 	moduleDB.clear();
 	enqueuedMipsCalls.clear();
 	for (auto p : mipsCallActions) {

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -476,7 +476,7 @@ void hleEnqueueCall(u32 func, int argc, const u32 *argv, PSPAction *afterAction)
 void hleFlushCalls() {
 	u32 &sp = currentMIPS->r[MIPS_REG_SP];
 	PSPPointer<HLEMipsCallStack> stackData;
-	_dbg_assert_(g_stackSize > 0);
+	_dbg_assert_(g_stackSize == 0);
 	VERBOSE_LOG(Log::HLE, "Flushing %d HLE mips calls from %s, sp=%08x", (int)enqueuedMipsCalls.size(), g_stackSize ? g_stack[0]->name : "?", sp);
 
 	// First, we'll add a marker for the final return.
@@ -843,10 +843,12 @@ void CallSyscall(MIPSOpcode op) {
 
 void hlePushFuncDesc(std::string_view module, std::string_view funcName) {
 	const HLEModule *mod = GetModuleByName(module);
+	_dbg_assert_(mod != nullptr);
 	if (!mod) {
 		return;
 	}
 	const HLEFunction *func = GetFuncByName(mod, funcName);
+	_dbg_assert_(func != nullptr);
 	// Push to the stack.
 	g_stack[g_stackSize++] = func;
 }

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -257,7 +257,8 @@ inline R hleCallImpl(std::string_view module, std::string_view funcName, F func,
 	return func(args...);
 }
 
-#define hleCall(module, retType, funcName, ...) hleCallImpl<retType>(#module, #funcName, funcName, __VA_ARGS__)
+// Note: ## is to eat the last comma if it's not needed (no arguments).
+#define hleCall(module, retType, funcName, ...) hleCallImpl<retType>(#module, #funcName, funcName, ## __VA_ARGS__)
 
 // This is just a quick way to force logging to be more visible for one file.
 #ifdef HLE_LOG_FORCE

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -247,6 +247,18 @@ inline void hleNoLogVoid() {
 	hleLeave();
 }
 
+// TODO: See if we can search the tables with constexpr tricks!
+void hlePushFuncDesc(std::string_view module, std::string_view funcName);
+
+// Calls a syscall from another syscall, managing the logging stack.
+template<class R, class F, typename... Args>
+inline R hleCallImpl(std::string_view module, std::string_view funcName, F func, Args... args) {
+	hlePushFuncDesc(module, funcName);
+	return func(args...);
+}
+
+#define hleCall(module, retType, funcName, ...) hleCallImpl<retType>(#module, #funcName, funcName, __VA_ARGS__)
+
 // This is just a quick way to force logging to be more visible for one file.
 #ifdef HLE_LOG_FORCE
 #define HLE_LOG_LDEBUG LNOTICE

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <cstdarg>
 #include <type_traits>
+#include <string_view>
 
 #include "Common/CommonTypes.h"
 #include "Common/Log.h"
@@ -76,7 +77,7 @@ struct HLEFunction {
 };
 
 struct HLEModule {
-	const char *name;
+	std::string_view name;
 	int numFunctions;
 	const HLEFunction *funcTable;
 };
@@ -96,13 +97,13 @@ struct Syscall {
 #define RETURN64(n) {u64 RETURN64_tmp = n; currentMIPS->r[MIPS_REG_V0] = RETURN64_tmp & 0xFFFFFFFF; currentMIPS->r[MIPS_REG_V1] = RETURN64_tmp >> 32;}
 #define RETURNF(fl) currentMIPS->f[0] = fl
 
-const char *GetFuncName(const char *module, u32 nib);
+const char *GetFuncName(std::string_view module, u32 nib);
 const char *GetFuncName(int module, int func);
-const HLEFunction *GetFunc(const char *module, u32 nib);
+const HLEFunction *GetFunc(std::string_view module, u32 nib);
 int GetFuncIndex(int moduleIndex, u32 nib);
-int GetModuleIndex(const char *modulename);
+int GetModuleIndex(std::string_view modulename);
 
-void RegisterModule(const char *name, int numFunctions, const HLEFunction *funcTable);
+void RegisterModule(std::string_view name, int numFunctions, const HLEFunction *funcTable);
 int GetNumRegisteredModules();
 const HLEModule *GetModuleByIndex(int index);
 
@@ -157,10 +158,10 @@ inline s64 hleDelayResult(s64 result, const char *reason, int usec) {
 void HLEInit();
 void HLEDoState(PointerWrap &p);
 void HLEShutdown();
-u32 GetNibByName(const char *module, const char *function);
-u32 GetSyscallOp(const char *module, u32 nib);
-bool FuncImportIsSyscall(const char *module, u32 nib);
-bool WriteSyscall(const char *module, u32 nib, u32 address);
+u32 GetNibByName(std::string_view module, std::string_view function);
+u32 GetSyscallOp(std::string_view module, u32 nib);
+bool FuncImportIsSyscall(std::string_view module, u32 nib);
+bool WriteSyscall(std::string_view module, u32 nib, u32 address);
 void CallSyscall(MIPSOpcode op);
 void WriteFuncStub(u32 stubAddr, u32 symAddr);
 void WriteFuncMissingStub(u32 stubAddr, u32 nid);

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -282,8 +282,8 @@ inline R hleCallImpl(std::string_view module, std::string_view funcName, F func,
 #define hleLogVerbose(t, res, ...) hleLogHelper(t, HLE_LOG_LVERBOSE, res, 'x', ##__VA_ARGS__)
 
 // If res is negative, log warn/error, otherwise log debug.
-#define hleLogSuccessOrWarn(t, res, ...) hleLogHelper(t, (int)res < 0 ? LogLevel::LWARNING : HLE_LOG_LDEBUG, res, 'x', ##__VA_ARGS__)
-#define hleLogSuccessOrError(t, res, ...) hleLogHelper(t, (int)res < 0 ? LogLevel::LERROR : HLE_LOG_LDEBUG, res, 'x', ##__VA_ARGS__)
+#define hleLogSuccessOrWarn(t, res, ...) hleLogHelper(t, ((int)res < 0 ? LogLevel::LWARNING : HLE_LOG_LDEBUG), res, 'x', ##__VA_ARGS__)
+#define hleLogSuccessOrError(t, res, ...) hleLogHelper(t, ((int)res < 0 ? LogLevel::LERROR : HLE_LOG_LDEBUG), res, 'x', ##__VA_ARGS__)
 
 // NOTE: hleLogDebug is equivalent to hleLogSuccessI/X.
 #define hleLogDebug(t, res, ...) hleLogHelper(t, HLE_LOG_LDEBUG, res, 'x', ##__VA_ARGS__)

--- a/Core/HLE/sceDmac.cpp
+++ b/Core/HLE/sceDmac.cpp
@@ -65,9 +65,10 @@ static int __DmacMemcpy(u32 dst, u32 src, u32 size) {
 		// Approx. 225 MiB/s or 235929600 B/s, so let's go with 236 B/us.
 		int delayUs = size / 236;
 		dmacMemcpyDeadline = CoreTiming::GetTicks() + usToCycles(delayUs);
-		return hleDelayResult(0, "dmac copy", delayUs);
+		return delayUs;
+	} else {
+		return 0;
 	}
-	return 0;
 }
 
 static u32 sceDmacMemcpy(u32 dst, u32 src, u32 size) {
@@ -88,7 +89,9 @@ static u32 sceDmacMemcpy(u32 dst, u32 src, u32 size) {
 		// Might matter for overlapping copies.
 	}
 
-	return hleLogDebug(Log::HLE, __DmacMemcpy(dst, src, size));
+	int delay = __DmacMemcpy(dst, src, size);
+	int result = hleLogDebug(Log::HLE, 0);
+	return delay ? hleDelayResult(result, "dmac-memcpy", delay) : delay;
 }
 
 static u32 sceDmacTryMemcpy(u32 dst, u32 src, u32 size) {
@@ -106,7 +109,9 @@ static u32 sceDmacTryMemcpy(u32 dst, u32 src, u32 size) {
 		return hleLogDebug(Log::HLE, SCE_KERNEL_ERROR_BUSY, "busy");
 	}
 
-	return hleLogDebug(Log::HLE, __DmacMemcpy(dst, src, size));
+	int delay = __DmacMemcpy(dst, src, size);
+	int result = hleLogDebug(Log::HLE, 0);
+	return delay ? hleDelayResult(result, "dmac-memcpy", delay) : delay;
 }
 
 const HLEFunction sceDmac[] = {

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -1026,15 +1026,15 @@ static u32 sceFontNewLib(u32 paramPtr, u32 errorCodePtr) {
 	if (!params.IsValid() || !errorCode.IsValid()) {
 		ERROR_LOG_REPORT(Log::sceFont, "sceFontNewLib(%08x, %08x): invalid addresses", paramPtr, errorCodePtr);
 		// The PSP would crash in this situation, not a real error code.
-		return SCE_KERNEL_ERROR_ILLEGAL_ADDR;
+		return hleLogError(Log::sceFont, SCE_KERNEL_ERROR_ILLEGAL_ADDR);
 	}
+
 	if (!Memory::IsValidAddress(params->allocFuncAddr) || !Memory::IsValidAddress(params->freeFuncAddr)) {
 		ERROR_LOG_REPORT(Log::sceFont, "sceFontNewLib(%08x, %08x): missing alloc func", paramPtr, errorCodePtr);
 		*errorCode = ERROR_FONT_INVALID_PARAMETER;
-		return 0;
+		return hleLogError(Log::sceFont, 0);
 	}
 
-	INFO_LOG(Log::sceFont, "sceFontNewLib(%08x, %08x)", paramPtr, errorCodePtr);
 	*errorCode = 0;
 
 	FontLib *newLib = new FontLib(params, errorCodePtr);
@@ -1042,7 +1042,7 @@ static u32 sceFontNewLib(u32 paramPtr, u32 errorCodePtr) {
 	// The game should never see this value, the return value is replaced
 	// by the action. Except if we disable the alloc, in this case we return
 	// the handle correctly here.
-	return hleDelayResult(newLib->handle(), "new fontlib", 30000);
+	return hleDelayResult(hleLogSuccessInfoI(Log::sceFont, newLib->handle()), "new fontlib", 30000);
 }
 
 static int sceFontDoneLib(u32 fontLibHandle) {
@@ -1066,11 +1066,11 @@ static u32 sceFontOpen(u32 libHandle, u32 index, u32 mode, u32 errorCodePtr) {
 	FontLib *fontLib = GetFontLib(libHandle);
 	if (!fontLib) {
 		*errorCode = ERROR_FONT_INVALID_LIBID;
-		return hleLogDebug(Log::sceFont, 0, "invalid font lib");
+		return hleLogWarning(Log::sceFont, 0, "invalid font lib");
 	}
 	if (index >= internalFonts.size()) {
 		*errorCode = ERROR_FONT_INVALID_PARAMETER;
-		return hleLogDebug(Log::sceFont, 0, "invalid font index");
+		return hleLogWarning(Log::sceFont, 0, "invalid font index");
 	}
 
 	FontOpenMode openMode = mode != 1 ? FONT_OPEN_INTERNAL_STINGY : FONT_OPEN_INTERNAL_FULL;
@@ -1121,7 +1121,7 @@ static u32 sceFontOpenUserMemory(u32 libHandle, u32 memoryFontPtr, u32 memoryFon
 		return hleLogSuccessX(Log::sceFont, font->Handle());
 	}
 	delete f;
-	return 0;
+	return hleNoLog(0);
 }
 
 // Open a user font in a file into a FontLib

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -1162,21 +1162,21 @@ static u32 sceFontOpenUserFile(u32 libHandle, const char *fileName, u32 mode, u3
 	}
 
 	delete f;
-	// Message was already logged.
-	return 0;
+	// Message was already logged (or was it?)
+	return hleNoLog(0);
 }
 
 static int sceFontClose(u32 fontHandle) {
 	LoadedFont *font = GetLoadedFont(fontHandle, false);
 	if (font) {
-		DEBUG_LOG(Log::sceFont, "sceFontClose(%x)", fontHandle);
 		FontLib *fontLib = font->GetFontLib();
 		if (fontLib) {
 			fontLib->CloseFont(font, false);
 		}
-	} else
-		ERROR_LOG(Log::sceFont, "sceFontClose(%x) - font not open?", fontHandle);
-	return 0;
+		return hleLogDebug(Log::sceFont, 0);
+	} else {
+		return hleLogError(Log::sceFont, 0, "sceFontClose(%x) - font not open?", fontHandle);
+	}
 }
 
 static int sceFontFindOptimumFont(u32 libHandle, u32 fontStylePtr, u32 errorCodePtr) {
@@ -1214,7 +1214,7 @@ static int sceFontFindOptimumFont(u32 libHandle, u32 fontStylePtr, u32 errorCode
 			if (str == "ltn12.pgf") {
 				optimumFont = internalFonts[j];
 				*errorCode = 0;
-				return GetInternalFontIndex(optimumFont);
+				return hleLogSuccessInfoI(Log::sceFont, GetInternalFontIndex(optimumFont));
 			}
 		}
 	}
@@ -1297,30 +1297,26 @@ static int sceFontFindFont(u32 libHandle, u32 fontStylePtr, u32 errorCodePtr) {
 				continue;
 			}
 			*errorCode = 0;
-			return (int)i;
+			return hleNoLog((int)i);
 		}
 	}
 	*errorCode = 0;
-	return -1;
+	return hleLogWarning(Log::sceFont, -1);
 }
 
 static int sceFontGetFontInfo(u32 fontHandle, u32 fontInfoPtr) {
 	if (!Memory::IsValidAddress(fontInfoPtr)) {
-		ERROR_LOG(Log::sceFont, "sceFontGetFontInfo(%x, %x): bad fontInfo pointer", fontHandle, fontInfoPtr);
-		return ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_PARAMETER, "bad fontInfo pointer");
 	}
 	LoadedFont *font = GetLoadedFont(fontHandle, true);
 	if (!font) {
-		ERROR_LOG_REPORT(Log::sceFont, "sceFontGetFontInfo(%x, %x): bad font", fontHandle, fontInfoPtr);
-		return ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_PARAMETER, "bad font");
 	}
 
-	DEBUG_LOG(Log::sceFont, "sceFontGetFontInfo(%x, %x)", fontHandle, fontInfoPtr);
 	auto fi = PSPPointer<PGFFontInfo>::Create(fontInfoPtr);
 	font->GetPGF()->GetFontInfo(fi);
 	fi->fontStyle = font->GetFont()->GetFontStyle();
-
-	return 0;
+	return hleLogDebug(Log::sceFont, 0);
 }
 
 // It says FontInfo but it means Style - this is like sceFontGetFontList().
@@ -1328,36 +1324,31 @@ static int sceFontGetFontInfoByIndexNumber(u32 libHandle, u32 fontInfoPtr, u32 i
 	auto fontStyle = PSPPointer<PGFFontStyle>::Create(fontInfoPtr);
 	FontLib *fl = GetFontLib(libHandle);
 	if (!fl || fl->handle() == 0) {
-		ERROR_LOG_REPORT(Log::sceFont, "sceFontGetFontInfoByIndexNumber(%08x, %08x, %i): invalid font lib", libHandle, fontInfoPtr, index);
-		return !fl ? ERROR_FONT_INVALID_LIBID : ERROR_FONT_INVALID_PARAMETER;
+		int error = !fl ? ERROR_FONT_INVALID_LIBID : ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, error, "invalid font lib");
 	}
 	if (index >= internalFonts.size()) {
-		ERROR_LOG_REPORT(Log::sceFont, "sceFontGetFontInfoByIndexNumber(%08x, %08x, %i): invalid font index", libHandle, fontInfoPtr, index);
-		return ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_PARAMETER, "invalid font index");
 	}
 	if (!fontStyle.IsValid()) {
-		ERROR_LOG_REPORT(Log::sceFont, "sceFontGetFontInfoByIndexNumber(%08x, %08x, %i): invalid info pointer", libHandle, fontInfoPtr, index);
-		return ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_PARAMETER, "invalid info pointer");
 	}
 
-	DEBUG_LOG(Log::sceFont, "sceFontGetFontInfoByIndexNumber(%08x, %08x, %i)", libHandle, fontInfoPtr, index);
 	auto font = internalFonts[index];
 	*fontStyle = font->GetFontStyle();
 
-	return 0;
+	return hleLogDebug(Log::sceFont, 0);
 }
 
 static int sceFontGetCharInfo(u32 fontHandle, u32 charCode, u32 charInfoPtr) {
 	charCode &= 0xffff;
 	if (!Memory::IsValidAddress(charInfoPtr)) {
-		ERROR_LOG(Log::sceFont, "sceFontGetCharInfo(%08x, %i, %08x): bad charInfo pointer", fontHandle, charCode, charInfoPtr);
-		return ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_PARAMETER, "bad charInfo pointer");
 	}
 	LoadedFont *font = GetLoadedFont(fontHandle, true);
 	if (!font) {
 		// The PSP crashes, but we assume it'd work like sceFontGetFontInfo(), and not touch charInfo.
-		ERROR_LOG_REPORT(Log::sceFont, "sceFontGetCharInfo(%08x, %i, %08x): bad font", fontHandle, charCode, charInfoPtr);
-		return ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_PARAMETER, "bad font");
 	}
 
 	DEBUG_LOG(Log::sceFont, "sceFontGetCharInfo(%08x, %i, %08x)", fontHandle, charCode, charInfoPtr);
@@ -1365,7 +1356,7 @@ static int sceFontGetCharInfo(u32 fontHandle, u32 charCode, u32 charInfoPtr) {
 	font->GetCharInfo(charCode, charInfo);
 
 	if (!useAllocCallbacks)
-		return 0;
+		return hleLogDebug(Log::sceFont, 0);
 
 	u32 allocSize = charInfo->bitmapWidth * charInfo->bitmapHeight;
 	if (font->GetFontLib() && (charInfo->sfp26AdvanceH != 0 || charInfo->sfp26AdvanceV != 0)) {
@@ -1385,26 +1376,24 @@ static int sceFontGetCharInfo(u32 fontHandle, u32 charCode, u32 charInfoPtr) {
 		}
 	}
 
-	return 0;
+	return hleLogDebug(Log::sceFont, 0);
 }
 
 static int sceFontGetShadowInfo(u32 fontHandle, u32 charCode, u32 charInfoPtr) {
 	charCode &= 0xffff;
 	if (!Memory::IsValidAddress(charInfoPtr)) {
-		ERROR_LOG(Log::sceFont, "sceFontGetShadowInfo(%08x, %i, %08x): bad charInfo pointer", fontHandle, charCode, charInfoPtr);
-		return ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_PARAMETER, "bad charInfo pointer");
 	}
 	LoadedFont *font = GetLoadedFont(fontHandle, true);
 	if (!font) {
-		ERROR_LOG_REPORT(Log::sceFont, "sceFontGetShadowInfo(%08x, %i, %08x): bad font", fontHandle, charCode, charInfoPtr);
-		return ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_PARAMETER, "bad font");
 	}
 
 	DEBUG_LOG(Log::sceFont, "sceFontGetShadowInfo(%08x, %i, %08x)", fontHandle, charCode, charInfoPtr);
 	auto charInfo = PSPPointer<PGFCharInfo>::Create(charInfoPtr);
 	font->GetCharInfo(charCode, charInfo, FONT_PGF_SHADOWGLYPH);
 
-	return 0;
+	return hleLogDebug(Log::sceFont, 0);
 }
 
 static int sceFontGetCharImageRect(u32 fontHandle, u32 charCode, u32 charRectPtr) {
@@ -1412,20 +1401,17 @@ static int sceFontGetCharImageRect(u32 fontHandle, u32 charCode, u32 charRectPtr
 	auto charRect = PSPPointer<FontImageRect>::Create(charRectPtr);
 	LoadedFont *font = GetLoadedFont(fontHandle, true);
 	if (!font) {
-		ERROR_LOG_REPORT(Log::sceFont, "sceFontGetCharImageRect(%08x, %i, %08x): bad font", fontHandle, charCode, charRectPtr);
-		return ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_PARAMETER, "bad font");
 	}
 	if (!charRect.IsValid()) {
-		ERROR_LOG_REPORT(Log::sceFont, "sceFontGetCharImageRect(%08x, %i, %08x): invalid rect pointer", fontHandle, charCode, charRectPtr);
-		return ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_PARAMETER, "invalid rect pointer");
 	}
 
-	DEBUG_LOG(Log::sceFont, "sceFontGetCharImageRect(%08x, %i, %08x)", fontHandle, charCode, charRectPtr);
 	PGFCharInfo charInfo;
 	font->GetCharInfo(charCode, &charInfo);
 	charRect->width = charInfo.bitmapWidth;
 	charRect->height = charInfo.bitmapHeight;
-	return 0;
+	return hleLogDebug(Log::sceFont, 0, "w: %d h: %d", charInfo.bitmapWidth, charInfo.bitmapHeight);
 }
 
 static int sceFontGetShadowImageRect(u32 fontHandle, u32 charCode, u32 charRectPtr) {
@@ -1433,12 +1419,10 @@ static int sceFontGetShadowImageRect(u32 fontHandle, u32 charCode, u32 charRectP
 	auto charRect = PSPPointer<FontImageRect>::Create(charRectPtr);
 	LoadedFont *font = GetLoadedFont(fontHandle, true);
 	if (!font) {
-		ERROR_LOG_REPORT(Log::sceFont, "sceFontGetShadowImageRect(%08x, %i, %08x): bad font", fontHandle, charCode, charRectPtr);
-		return ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_PARAMETER, "bad font");
 	}
 	if (!charRect.IsValid()) {
-		ERROR_LOG_REPORT(Log::sceFont, "sceFontGetShadowImageRect(%08x, %i, %08x): invalid rect pointer", fontHandle, charCode, charRectPtr);
-		return ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_PARAMETER, "invalid rect pointer");
 	}
 
 	DEBUG_LOG(Log::sceFont, "sceFontGetShadowImageRect(%08x, %i, %08x)", fontHandle, charCode, charRectPtr);
@@ -1457,8 +1441,7 @@ static int sceFontGetCharGlyphImage(u32 fontHandle, u32 charCode, u32 glyphImage
 	}
 	LoadedFont *font = GetLoadedFont(fontHandle, true);
 	if (!font) {
-		ERROR_LOG_REPORT(Log::sceFont, "sceFontGetCharGlyphImage(%x, %x, %x): bad font", fontHandle, charCode, glyphImagePtr);
-		return ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_PARAMETER, "bad font");
 	}
 
 	DEBUG_LOG(Log::sceFont, "sceFontGetCharGlyphImage(%x, %x, %x)", fontHandle, charCode, glyphImagePtr);
@@ -1493,9 +1476,8 @@ static int sceFontSetAltCharacterCode(u32 fontLibHandle, u32 charCode) {
 		return ERROR_FONT_INVALID_LIBID;
 	}
 
-	INFO_LOG(Log::sceFont, "sceFontSetAltCharacterCode(%08x, %08x)", fontLibHandle, charCode);
 	fl->SetAltCharCode(charCode & 0xFFFF);
-	return 0;
+	return hleLogSuccessInfoI(Log::sceFont, 0);
 }
 
 static int sceFontFlush(u32 fontHandle) {
@@ -1534,35 +1516,30 @@ static int sceFontGetFontList(u32 fontLibHandle, u32 fontStylePtr, int numFonts)
 			fontStyles[i] = internalFonts[i]->GetFontStyle();
 	}
 
-	return hleDelayResult(0, "font list read", 100);
+	return hleDelayResult(hleLogDebug(Log::sceFont, 0), "font list read", 100);
 }
 
 static int sceFontGetNumFontList(u32 fontLibHandle, u32 errorCodePtr) {
 	auto errorCode = PSPPointer<s32_le>::Create(errorCodePtr);
 	if (!errorCode.IsValid()) {
-		ERROR_LOG_REPORT(Log::sceFont, "sceFontGetNumFontList(%08x, %08x): invalid error address", fontLibHandle, errorCodePtr);
-		return ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_PARAMETER, "invalid error address");
 	}
 	FontLib *fl = GetFontLib(fontLibHandle);
 	if (!fl) {
-		ERROR_LOG_REPORT(Log::sceFont, "sceFontGetNumFontList(%08x, %08x): invalid font lib", fontLibHandle, errorCodePtr);
 		*errorCode = ERROR_FONT_INVALID_LIBID;
-		return 0;
+		return hleLogError(Log::sceFont, 0, "invalid font lib");
 	}
-	DEBUG_LOG(Log::sceFont, "sceFontGetNumFontList(%08x, %08x)", fontLibHandle, errorCodePtr);
 	*errorCode = 0;
-	return fl->handle() == 0 ? 0 : (int)internalFonts.size();
+	return hleLogDebug(Log::sceFont, fl->handle() == 0 ? 0 : (int)internalFonts.size());
 }
 
 static int sceFontSetResolution(u32 fontLibHandle, float hRes, float vRes) {
 	FontLib *fl = GetFontLib(fontLibHandle);
 	if (!fl) {
-		ERROR_LOG_REPORT(Log::sceFont, "sceFontSetResolution(%08x, %f, %f): invalid font lib", fontLibHandle, hRes, vRes);
-		return ERROR_FONT_INVALID_LIBID;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_LIBID, "invalid font lib");
 	}
 	if (hRes <= 0.0f || vRes <= 0.0f) {
-		ERROR_LOG_REPORT(Log::sceFont, "sceFontSetResolution(%08x, %f, %f): negative value", fontLibHandle, hRes, vRes);
-		return ERROR_FONT_INVALID_PARAMETER;
+		return hleLogError(Log::sceFont, ERROR_FONT_INVALID_PARAMETER, "negative value in hRes %f or vRes %f", hRes, vRes);
 	}
 	INFO_LOG(Log::sceFont, "sceFontSetResolution(%08x, %f, %f)", fontLibHandle, hRes, vRes);
 	fl->SetResolution(hRes, vRes);

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -490,15 +490,17 @@ static u32 sceGeSetCallback(u32 structAddr) {
 
 	int subIntrBase = __GeSubIntrBase(cbID);
 
+	// TODO: Maybe don't ignore return values of the hleCalls?
+
 	if (ge_callback_data[cbID].finish_func != 0) {
-		sceKernelRegisterSubIntrHandler(PSP_GE_INTR, subIntrBase | PSP_GE_SUBINTR_FINISH,
+		hleCall(InterruptManager, u32, sceKernelRegisterSubIntrHandler, PSP_GE_INTR, subIntrBase | PSP_GE_SUBINTR_FINISH,
 				ge_callback_data[cbID].finish_func, ge_callback_data[cbID].finish_arg);
-		sceKernelEnableSubIntr(PSP_GE_INTR, subIntrBase | PSP_GE_SUBINTR_FINISH);
+		hleCall(InterruptManager, u32, sceKernelEnableSubIntr, PSP_GE_INTR, subIntrBase | PSP_GE_SUBINTR_FINISH);
 	}
 	if (ge_callback_data[cbID].signal_func != 0) {
-		sceKernelRegisterSubIntrHandler(PSP_GE_INTR, subIntrBase | PSP_GE_SUBINTR_SIGNAL,
+		hleCall(InterruptManager, u32, sceKernelRegisterSubIntrHandler, PSP_GE_INTR, subIntrBase | PSP_GE_SUBINTR_SIGNAL,
 				ge_callback_data[cbID].signal_func, ge_callback_data[cbID].signal_arg);
-		sceKernelEnableSubIntr(PSP_GE_INTR, subIntrBase | PSP_GE_SUBINTR_SIGNAL);
+		hleCall(InterruptManager, u32, sceKernelEnableSubIntr, PSP_GE_INTR, subIntrBase | PSP_GE_SUBINTR_SIGNAL);
 	}
 
 	return hleLogSuccessI(Log::sceGe, cbID);
@@ -515,8 +517,9 @@ static int sceGeUnsetCallback(u32 cbID) {
 	if (ge_used_callbacks[cbID]) {
 		int subIntrBase = __GeSubIntrBase(cbID);
 
-		sceKernelReleaseSubIntrHandler(PSP_GE_INTR, subIntrBase | PSP_GE_SUBINTR_FINISH);
-		sceKernelReleaseSubIntrHandler(PSP_GE_INTR, subIntrBase | PSP_GE_SUBINTR_SIGNAL);
+		// TODO: Maybe don't ignore return values?
+		hleCall(InterruptManager, u32, sceKernelReleaseSubIntrHandler, PSP_GE_INTR, subIntrBase | PSP_GE_SUBINTR_FINISH);
+		hleCall(InterruptManager, u32, sceKernelReleaseSubIntrHandler, PSP_GE_INTR, subIntrBase | PSP_GE_SUBINTR_SIGNAL);
 	} else {
 		WARN_LOG(Log::sceGe, "sceGeUnsetCallback(cbid=%08x): ignoring unregistered callback id", cbID);
 	}

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -390,14 +390,14 @@ u32 sceGeListEnQueueHead(u32 listAddress, u32 stallAddress, int callbackId, u32 
 	}
 	hleEatCycles(480);
 	hleCoreTimingForceCheck();
-	return listID; // We already logged above, logs get confusing if we use hleLogSuccess.
+	return hleNoLog(listID); // We already logged above, logs get confusing if we use hleLogSuccess.
 }
 
 static int sceGeListDeQueue(u32 listID) {
 	WARN_LOG(Log::sceGe, "sceGeListDeQueue(%08x)", listID);
 	int result = gpu->DequeueList(LIST_ID_MAGIC ^ listID);
 	hleReSchedule("dlist dequeued");
-	return result;
+	return hleNoLog(result);
 }
 
 static int sceGeListUpdateStallAddr(u32 displayListID, u32 stallAddress) {
@@ -416,7 +416,7 @@ static int sceGeListUpdateStallAddr(u32 displayListID, u32 stallAddress) {
 			gpu->ProcessDLQueue();
 		}
 	}
-	return retval;
+	return hleNoLog(retval);
 }
 
 // 0 : wait for completion. 1:check and return
@@ -465,9 +465,9 @@ static int sceGeBreak(u32 mode, u32 unknownPtr) {
 	DEBUG_LOG(Log::sceGe, "sceGeBreak(mode=%d, unknown=%08x)", mode, unknownPtr);
 	int result = gpu->Break(mode);
 	if (result >= 0 && mode == 0) {
-		return LIST_ID_MAGIC ^ result;
+		return hleNoLog(LIST_ID_MAGIC ^ result);
 	}
-	return result;
+	return hleNoLog(result);
 }
 
 static u32 sceGeSetCallback(u32 structAddr) {
@@ -626,7 +626,7 @@ static u32 sceGeEdramSetAddrTranslation(u32 new_size) {
 		return hleLogError(Log::sceGe, -1, "GPUInterface not available");
 	}
 
-	return hleReportDebug(Log::sceGe, gpu->SetAddrTranslation(new_size));
+	return hleLogDebug(Log::sceGe, gpu->SetAddrTranslation(new_size));
 }
 
 const HLEFunction sceGe_user[] = {

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2189,8 +2189,9 @@ static u32 sceIoOpenAsync(const char *filename, int flags, int mode) {
 
 	// TODO: Use an internal method so as not to pollute the log?
 	// Intentionally does not work when interrupts disabled.
-	if (!__KernelIsDispatchEnabled())
-		sceKernelResumeDispatchThread(1);
+	if (!__KernelIsDispatchEnabled()) {
+		hleCall(ThreadManForUser, u32, sceKernelResumeDispatchThread, 1);
+	}
 
 	int error;
 	FileNode *f = __IoOpen(error, filename, flags, mode);

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -972,15 +972,12 @@ static u32 sceIoGetstat(const char *filename, u32 addr) {
 		if (stat.IsValid()) {
 			__IoGetStat(stat, info);
 			stat.NotifyWrite("IoGetstat");
-			DEBUG_LOG(Log::sceIo, "sceIoGetstat(%s, %08x) : sector = %08x", filename, addr, info.startSector);
-			return hleDelayResult(0, "io getstat", usec);
+			return hleDelayResult(hleLogDebug(Log::sceIo, 0, "sector = %08x", info.startSector), "io getstat", usec);
 		} else {
-			ERROR_LOG(Log::sceIo, "sceIoGetstat(%s, %08x) : bad address", filename, addr);
-			return hleDelayResult(-1, "io getstat", usec);
+			return hleDelayResult(hleLogError(Log::sceIo, -1, "bad address"), "io getstat", usec);
 		}
 	} else {
-		DEBUG_LOG(Log::sceIo, "sceIoGetstat(%s, %08x) : FILE NOT FOUND", filename, addr);
-		return hleDelayResult(SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND, "io getstat", usec);
+		return hleDelayResult(hleLogError(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND, "FILE NOT FOUND"), "io getstat", usec);
 	}
 }
 
@@ -1158,11 +1155,9 @@ static u32 sceIoRead(int id, u32 data_addr, int size) {
 		f->waitingSyncThreads.push_back(__KernelGetCurThread());
 		return 0;
 	} else if (result >= 0) {
-		DEBUG_LOG(Log::sceIo, "%x=sceIoRead(%d, %08x, %x)", result, id, data_addr, size);
-		return hleDelayResult(result, "io read", us);
+		return hleDelayResult(hleLogDebug(Log::ME, result), "io read", us);
 	} else {
-		WARN_LOG(Log::sceIo, "sceIoRead(%d, %08x, %x): error %08x", id, data_addr, size, result);
-		return result;
+		return hleLogWarning(Log::ME, result, "error %08x", result);
 	}
 }
 
@@ -1286,20 +1281,18 @@ static u32 sceIoWrite(int id, u32 data_addr, int size) {
 		f->waitingSyncThreads.push_back(__KernelGetCurThread());
 		return 0;
 	} else if (result >= 0) {
-		DEBUG_LOG(Log::sceIo, "%x=sceIoWrite(%d, %08x, %x)", result, id, data_addr, size);
 		if (__KernelIsDispatchEnabled()) {
 			// If we wrote to stdout, return an error (even though we did log it) rather than delaying.
 			// On actual hardware, it would just return this... we just want the log output.
 			if (__IsInInterrupt()) {
 				return SCE_KERNEL_ERROR_ILLEGAL_CONTEXT;
 			}
-			return hleDelayResult(result, "io write", us);
+			return hleDelayResult(hleLogDebug(Log::sceIo, result), "io write", us);
 		} else {
-			return result;
+			return hleLogDebug(Log::sceIo, result);
 		}
 	} else {
-		WARN_LOG(Log::sceIo, "sceIoWrite(%d, %08x, %x): error %08x", id, data_addr, size, result);
-		return result;
+		return hleLogWarning(Log::sceIo, result, "%08x", result);
 	}
 }
 
@@ -1583,7 +1576,7 @@ static u32 sceIoOpen(const char *filename, int flags, int mode) {
 		_assert_(error != 0);
 		if (error == (int)SCE_KERNEL_ERROR_NOCWD) {
 			// TODO: Timing is not accurate.
-			return hleLogError(Log::sceIo, hleDelayResult(error, "file opened", 10000), "no current working directory");
+			return hleDelayResult(hleLogError(Log::sceIo, error, "no current working directory"), "file opened", 10000);
 		} else if (error == (int)SCE_KERNEL_ERROR_NODEV) {
 			return hleLogError(Log::sceIo, error, "device not found");
 		} else if (error == (int)SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND) {
@@ -1592,16 +1585,16 @@ static u32 sceIoOpen(const char *filename, int flags, int mode) {
 			// Card: Path depth matters, but typically between 10-13ms on a standard Pro Duo.
 			// TODO: If a UMD and spun down, this can easily take 1s+.
 			int delay = pspFileSystem.FlagsFromFilename(filename) & FileSystemFlags::UMD ? 6000 : 10000;
-			return hleLogWarning(Log::sceIo, hleDelayResult(error, "file opened", delay), "file not found");
+			return hleDelayResult(hleLogWarning(Log::sceIo, error, "file not found"), "file opened", delay);
 		} else {
-			return hleLogError(Log::sceIo, hleDelayResult(error, "file opened", 10000));
+			return hleDelayResult(hleLogError(Log::sceIo, error), "file opened", 10000);
 		}
 	}
 
 	int id = __IoAllocFd(f);
 	if (id < 0) {
 		kernelObjects.Destroy<FileNode>(f->GetUID());
-		return hleLogError(Log::sceIo, hleDelayResult(id, "file opened", 1000), "out of fds");
+		return hleDelayResult(hleLogError(Log::sceIo, id, "out of fds"), "file opened", 1000);
 	} else {
 		asyncParams[id].priority = asyncDefaultPriority;
 		IFileSystem *sys = pspFileSystem.GetSystemFromFilename(filename);
@@ -1612,16 +1605,15 @@ static u32 sceIoOpen(const char *filename, int flags, int mode) {
 		// UMD: Speed varies from 1-6ms.
 		// Card: Path depth matters, but typically between 10-13ms on a standard Pro Duo.
 		int delay = pspFileSystem.FlagsFromFilename(filename) & FileSystemFlags::UMD ? 4000 : 10000;
-		return hleLogSuccessI(Log::sceIo, hleDelayResult(id, "file opened", delay));
+		return hleDelayResult(hleLogSuccessI(Log::sceIo, id), "file opened", delay);
 	}
 }
 
 static u32 sceIoClose(int id) {
 	u32 error;
-	DEBUG_LOG(Log::sceIo, "sceIoClose(%d)", id);
 	__IoFreeFd(id, error);
 	// Timing is not accurate, aiming low for now.
-	return hleDelayResult(error, "file closed", 100);
+	return hleDelayResult(hleLogDebug(Log::sceIo, error), "file closed", 100);
 }
 
 static u32 sceIoRemove(const char *filename) {
@@ -1673,7 +1665,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 		// Get UMD disc type
 		if (Memory::IsValidAddress(outPtr) && outLen >= 8) {
 			Memory::Write_U32(0x10, outPtr + 4);  // Always return game disc (if present)
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		} else {
 			return hleLogError(Log::sceIo, ERROR_MEMSTICK_DEVCTL_BAD_PARAMS);
 		}
@@ -1682,7 +1674,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 		// Get UMD current LBA
 		if (Memory::IsValidAddress(outPtr) && outLen >= 4) {
 			Memory::Write_U32(0x10, outPtr);  // Assume first sector
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		} else {
 			return hleLogError(Log::sceIo, ERROR_MEMSTICK_DEVCTL_BAD_PARAMS);
 		}
@@ -1691,7 +1683,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 		if (Memory::IsValidAddress(argAddr) && argLen >= 4) {
 			PSPFileInfo info = pspFileSystem.GetFileInfo("umd1:");
 			Memory::Write_U32((u32) (info.size) - 1, outPtr);
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		} else {
 			return hleLogError(Log::sceIo, ERROR_MEMSTICK_DEVCTL_BAD_PARAMS);
 		}
@@ -1699,7 +1691,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 	case 0x01F100A3:  
 		// Seek UMD disc (raw)
 		if (Memory::IsValidAddress(argAddr) && argLen >= 4) {
-			return hleDelayResult(0, "dev seek", 100);
+			return hleDelayResult(hleLogDebug(Log::sceIo, 0), "dev seek", 100);
 		} else {
 			return hleLogError(Log::sceIo, ERROR_MEMSTICK_DEVCTL_BAD_PARAMS);
 		}
@@ -1707,7 +1699,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 	case 0x01F100A4:  
 		// Prepare UMD data into cache.
 		if (Memory::IsValidAddress(argAddr) && argLen >= 4) {
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		} else {
 			return hleLogError(Log::sceIo, ERROR_MEMSTICK_DEVCTL_BAD_PARAMS);
 		}
@@ -1716,7 +1708,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 		// Prepare UMD data into cache and get status
 		if (Memory::IsValidAddress(argAddr) && argLen >= 4) {
 			Memory::Write_U32(1, outPtr); // Status (unitary index of the requested read, greater or equal to 1)
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		} else {
 			return hleLogError(Log::sceIo, ERROR_MEMSTICK_DEVCTL_BAD_PARAMS);
 		}
@@ -1726,7 +1718,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 		if (Memory::IsValidAddress(argAddr) && argLen >= 4) {
 			// TODO : 
 			// Place the calling thread in wait state
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		} else {
 			return hleLogError(Log::sceIo, ERROR_MEMSTICK_DEVCTL_BAD_PARAMS);
 		}
@@ -1737,7 +1729,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 			// 0 - UMD data cache thread has finished
 			// 0x10 - UMD data cache thread is waiting
 			// 0x20 - UMD data cache thread is running
-			return 0; // Return finished
+			return hleLogDebug(Log::sceIo, 0); // Return finished
 		} else {
 			return hleLogError(Log::sceIo, ERROR_MEMSTICK_DEVCTL_BAD_PARAMS);
 		}
@@ -1747,7 +1739,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 		if (Memory::IsValidAddress(argAddr) && argLen >= 4) {
 			// TODO :
 			// Wake up the thread waiting for the UMD data cache handling.
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		} else {
 			return hleLogError(Log::sceIo, ERROR_MEMSTICK_DEVCTL_BAD_PARAMS);
 		}
@@ -1775,7 +1767,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 				} else {
 					Memory::Write_U32(PSP_MEMORYSTICK_STATE_DRIVER_READY, outPtr);
 				}
-				return 0;
+				return hleLogDebug(Log::sceIo, 0);
 			} else {
 				return hleLogError(Log::sceIo, ERROR_MEMSTICK_DEVCTL_BAD_PARAMS);
 			}
@@ -1800,7 +1792,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 					} else {
 						DEBUG_LOG(Log::sceIo, "sceIoDevctl: Memstick callback %i registered", cbId);
 					}
-					return 0;
+					return hleNoLog(0);
 				} else {
 					return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
 				}
@@ -1824,9 +1816,9 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 				if (slot != (size_t)-1) {
 					memStickCallbacks.erase(memStickCallbacks.begin() + slot);
 					DEBUG_LOG(Log::sceIo, "sceIoDevctl: Unregistered memstick callback %i", cbId);
-					return 0;
+					return hleLogDebug(Log::sceIo, 0);
 				} else {
-					return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
+					return hleLogError(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT);
 				}
 			} else {
 				return hleLogError(Log::sceIo, ERROR_MEMSTICK_DEVCTL_BAD_PARAMS);
@@ -1838,7 +1830,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 				// 1 = Inserted.
 				// 2 = Not inserted.
 				Memory::Write_U32(MemoryStick_State(), outPtr);
-				return 0;
+				return hleLogDebug(Log::sceIo, 0);
 			} else {
 				return hleLogError(Log::sceIo, ERROR_MEMSTICK_DEVCTL_BAD_PARAMS);
 			}
@@ -1846,7 +1838,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 		case 0x02425818:  
 			// Get MS capacity (fatms0).
 			if (MemoryStick_State() != PSP_MEMORYSTICK_STATE_INSERTED) {
-				return SCE_KERNEL_ERROR_ERRNO_DEVICE_NOT_FOUND;
+				return hleLogError(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_DEVICE_NOT_FOUND);
 			}
 			// TODO: Pretend we have a 2GB memory stick?  Should we check MemoryStick_FreeSpace?
 			if (Memory::IsValidRange(argAddr, 4) && argLen >= 4) {  // NOTE: not outPtr
@@ -1875,11 +1867,11 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 		case 0x02425824:
 			// Check if write protected
 			if (MemoryStick_State() != PSP_MEMORYSTICK_STATE_INSERTED) {
-				return SCE_KERNEL_ERROR_ERRNO_DEVICE_NOT_FOUND;
+				return hleLogError(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_DEVICE_NOT_FOUND);
 			}
 			if (Memory::IsValidRange(outPtr, 4) && outLen == 4) {
 				Memory::WriteUnchecked_U32(0, outPtr);
-				return 0;
+				return hleLogDebug(Log::sceIo, 0);
 			} else {
 				return hleLogError(Log::sceIo, -1, "Failed 0x02425824 fat");
 			}
@@ -1912,7 +1904,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 					} else {
 						DEBUG_LOG(Log::sceIo, "sceIoDevCtl: Memstick FAT callback %i registered", cbId);
 					}
-					return 0;
+					return hleNoLog(0);
 				} else {
 					return hleLogError(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT);
 				}
@@ -1936,7 +1928,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 				if (slot != (size_t)-1) {
 					memStickFatCallbacks.erase(memStickFatCallbacks.begin() + slot);
 					DEBUG_LOG(Log::sceIo, "sceIoDevCtl: Unregistered memstick FAT callback %i", cbId);
-					return 0;
+					return hleLogDebug(Log::sceIo, 0);
 				} else {
 					return hleLogError(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT);
 				}
@@ -1946,7 +1938,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 			// Set FAT as enabled
 			if (Memory::IsValidAddress(argAddr) && argLen == 4) {
 				MemoryStick_SetFatState((MemStickFatState)Memory::Read_U32(argAddr));
-				return 0;
+				return hleLogDebug(Log::sceIo, 0);
 			} else {
 				ERROR_LOG(Log::sceIo, "Failed 0x02415823 fat");
 				return -1;
@@ -1966,7 +1958,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 				// Does not care about outLen, even if it's 0.
 				// Note: writes 1 when inserted, 0 when not inserted.
 				Memory::Write_U32(MemoryStick_FatState(), outPtr);
-				return hleDelayResult(0, "check fat state", cyclesToUs(23500));
+				return hleDelayResult(hleLogDebug(Log::sceIo, 0), "check fat state", cyclesToUs(23500));
 			}
 			break;
 		case 0x02425824:  
@@ -1976,7 +1968,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 			}
 			if (Memory::IsValidAddress(outPtr) && outLen == 4) {
 				Memory::Write_U32(0, outPtr);
-				return 0;
+				return hleLogDebug(Log::sceIo, 0);
 			} else {
 				return hleLogError(Log::sceIo, -1, "Failed 0x02425824 fat");
 			}
@@ -1984,7 +1976,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 		case 0x02425818:  
 			// Get MS capacity (fatms0).
 			if (MemoryStick_State() != PSP_MEMORYSTICK_STATE_INSERTED) {
-				return SCE_KERNEL_ERROR_ERRNO_DEVICE_NOT_FOUND;
+				return hleLogError(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_DEVICE_NOT_FOUND);
 			}
 			// TODO: Pretend we have a 2GB memory stick?  Should we check MemoryStick_FreeSpace?
 			if (Memory::IsValidAddress(argAddr) && argLen >= 4) {  // NOTE: not outPtr
@@ -2003,7 +1995,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 					deviceSize->sectorCount = sectorCount;
 					deviceSize.NotifyWrite("fatms0:02425818");
 				}
-				return 0;
+				return hleLogDebug(Log::sceIo, 0);
 			} else {
 				return hleLogError(Log::sceIo, ERROR_MEMSTICK_DEVCTL_BAD_PARAMS);
 			}
@@ -2033,7 +2025,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 		case EMULATOR_DEVCTL__GET_HAS_DISPLAY:
 			if (Memory::IsValidAddress(outPtr))
 				Memory::Write_U32(PSP_CoreParameter().headLess ? 0 : 1, outPtr);
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		case EMULATOR_DEVCTL__SEND_OUTPUT:
 			if (Memory::IsValidRange(argAddr, argLen)) {
 				std::string data(Memory::GetCharPointerUnchecked(argAddr), argLen);
@@ -2046,12 +2038,12 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 		case EMULATOR_DEVCTL__IS_EMULATOR:
 			if (Memory::IsValidAddress(outPtr))
 				Memory::Write_U32(1, outPtr);
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		case EMULATOR_DEVCTL__VERIFY_STATE:
 			// Note that this is async, and makes sure the save state matches up.
 			SaveState::Verify();
 			// TODO: Maybe save/load to a file just to be sure?
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 
 		case EMULATOR_DEVCTL__EMIT_SCREENSHOT:
 		{
@@ -2061,14 +2053,14 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 			__DisplayGetFramebuf(&topaddr, &linesize, nullptr, 0);
 			// TODO: Convert based on pixel format / mode / something?
 			System_SendDebugScreenshot(std::string((const char *)&topaddr[0], linesize * 272), 272);
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		}
 		case EMULATOR_DEVCTL__TOGGLE_FASTFORWARD:
 			if (argAddr)
 				PSP_CoreParameter().fastForward = true;
 			else
 				PSP_CoreParameter().fastForward = false;
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		case EMULATOR_DEVCTL__GET_ASPECT_RATIO:
 			if (Memory::IsValidAddress(outPtr)) {
 				// TODO: Share code with CalculateDisplayOutputRect to take a few more things into account.
@@ -2081,7 +2073,7 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 				}
 				Memory::Write_Float(ar, outPtr);
 			}
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		case EMULATOR_DEVCTL__GET_SCALE:
 			if (Memory::IsValidAddress(outPtr)) {
 				// TODO: Maybe do something more sophisticated taking the longest side and screen rotation
@@ -2089,17 +2081,17 @@ static u32 sceIoDevctl(const char *name, int cmd, u32 argAddr, int argLen, u32 o
 				float scale = (float)g_display.dp_xres * g_Config.fDisplayScale / 480.0f;
 				Memory::Write_Float(scale, outPtr);
 			}
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		case EMULATOR_DEVCTL__GET_AXIS:
 			if (Memory::IsValidAddress(outPtr) && (argAddr >= 0 && argAddr < JOYSTICK_AXIS_MAX)) {
 				Memory::Write_Float(HLEPlugins::PluginDataAxis[argAddr], outPtr);
 			}
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		case EMULATOR_DEVCTL__GET_VKEY:
 			if (Memory::IsValidAddress(outPtr) && (argAddr >= 0 && argAddr < NKCODE_MAX)) {
 				Memory::Write_U8(HLEPlugins::GetKey(argAddr), outPtr);
 			}
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		}
 
 		return hleLogError(Log::sceIo, 0, "UNKNOWN PARAMETERS");
@@ -2220,7 +2212,7 @@ static u32 sceIoOpenAsync(const char *filename, int flags, int mode) {
 	int fd = __IoAllocFd(f);
 	if (fd < 0) {
 		kernelObjects.Destroy<FileNode>(f->GetUID());
-		return hleLogError(Log::sceIo, hleDelayResult(fd, "file opened", 1000), "out of fds");
+		return hleDelayResult(hleLogError(Log::sceIo, fd, "out of fds"), "file opened", 1000);
 	}
 
 	auto &params = asyncParams[fd];
@@ -2537,13 +2529,11 @@ static u32 sceIoDread(int id, u32 dirent_addr) {
 				}
 			}
 		}
-		DEBUG_LOG(Log::sceIo, "sceIoDread( %d %08x ) = %s", id, dirent_addr, entry->d_name);
-
 		// TODO: Improve timing.  Only happens on the *first* entry read, ms and umd.
 		if (dir->index++ == 0) {
-			return hleDelayResult(1, "readdir", 1000);
+			return hleDelayResult(hleLogDebug(Log::sceIo, 1, "%s", entry->d_name), "readdir", 1000);
 		}
-		return 1;
+		return hleLogDebug(Log::sceIo, 1, "%s", entry->d_name);
 	} else {
 		return hleLogError(Log::sceIo, SCE_KERNEL_ERROR_BADF, "invalid listing");
 	}
@@ -2554,6 +2544,7 @@ static u32 sceIoDclose(int id) {
 	return kernelObjects.Destroy<DirListing>(id);
 }
 
+// NOTE: Logs like a HLE function. Careful.
 int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen, int &usec) {
 	u32 error;
 	FileNode *f = __IoGetFd(id, error);
@@ -2809,8 +2800,7 @@ u32 sceIoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 ou
 	return result;
 }
 
-static u32 sceIoIoctlAsync(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen)
-{
+static u32 sceIoIoctlAsync(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen) {
 	u32 error;
 	FileNode *f = __IoGetFd(id, error);
 	if (f) {

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2599,7 +2599,7 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 			// Everything OK.
 			f->npdrm = true;
 			f->pgdInfo->data_offset += f->pgd_offset;
-			return 0;
+			return hleLogDebug(Log::sceIo, 0);
 		}
 		break;
 	}
@@ -2764,11 +2764,11 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 			// Position is in sectors, don't forget.
 			if (newPos < 0 || newPos > f->FileInfo().size) {
 				// Not allowed to seek past the end of the file with this API.
-				return SCE_KERNEL_ERROR_ERRNO_INVALID_FILE_SIZE;
+				return hleLogError(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_INVALID_FILE_SIZE);
 			}
 			pspFileSystem.SeekFile(f->handle, (s32)seekInfo->offset, seek);
 		} else {
-			return SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT;
+			return hleLogError(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_INVALID_ARGUMENT);
 		}
 		break;
 
@@ -2782,12 +2782,12 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 				Reporting::ReportMessage(temp, f->fullpath.c_str(), indataPtr, inlen, outdataPtr, outlen);
 				ERROR_LOG(Log::sceIo, "UNIMPL 0=sceIoIoctl id: %08x, cmd %08x, indataPtr %08x, inlen %08x, outdataPtr %08x, outLen %08x", id,cmd,indataPtr,inlen,outdataPtr,outlen);
 			}
-			return result;
+			return hleLogSuccessOrError(Log::sceIo, result);
 		}
 		break;
 	}
 
-	return 0;
+	return hleLogDebug(Log::sceIo, 0);
 }
 
 u32 sceIoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen)

--- a/Core/HLE/sceJpeg.cpp
+++ b/Core/HLE/sceJpeg.cpp
@@ -598,7 +598,7 @@ static int sceJpegInitMJpeg() {
 	// If it was -1, it's from an old save state, avoid double init error but assume inited.
 	if (mjpegInited == 0)
 		mjpegInited = 1;
-	return hleLogSuccessI(Log::ME, hleDelayResult(0, "mjpeg init", 130));
+	return hleDelayResult(hleLogSuccessI(Log::ME, 0), "mjpeg init", 130);
 }
 
 static int sceJpegFinishMJpeg() {
@@ -609,7 +609,7 @@ static int sceJpegFinishMJpeg() {
 
 	// Even from an old save state, if we see this we leave compat mode.
 	mjpegInited = 0;
-	return hleLogSuccessI(Log::ME, hleDelayResult(0, "mjpeg finish", 120));
+	return hleDelayResult(hleLogSuccessI(Log::ME, 0), "mjpeg finish", 120);
 }
 
 static int sceJpegMJpegCscWithColorOption() {

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -349,20 +349,15 @@ u32 sceKernelDevkitVersion()
 	int revision = firmwareVersion % 10;
 	int devkitVersion = (major << 24) | (minor << 16) | (revision << 8) | 0x10;
 
-	DEBUG_LOG(Log::sceKernel, "%08x=sceKernelDevkitVersion()", devkitVersion);
-	return devkitVersion;
+	return hleLogDebug(Log::sceKernel, devkitVersion, "%d.%d.%d", major, minor, revision);
 }
 
-u32 sceKernelRegisterKprintfHandler()
-{
-	ERROR_LOG(Log::sceKernel, "UNIMPL sceKernelRegisterKprintfHandler()");
-	return 0;
+u32 sceKernelRegisterKprintfHandler() {
+	return hleLogError(Log::sceKernel, 0, "UNIMPL");
 }
 
-int sceKernelRegisterDefaultExceptionHandler()
-{
-	ERROR_LOG(Log::sceKernel, "UNIMPL sceKernelRegisterDefaultExceptionHandler()");
-	return 0;
+int sceKernelRegisterDefaultExceptionHandler() {
+	return hleLogError(Log::sceKernel, 0, "UNIMPL");
 }
 
 void sceKernelSetGPO(u32 ledBits)
@@ -391,18 +386,18 @@ int sceKernelDcacheInvalidateRange(u32 addr, int size)
 	NOTICE_LOG(Log::CPU,"sceKernelDcacheInvalidateRange(%08x, %i)", addr, size);
 #endif
 	if (size < 0 || (int) addr + size < 0)
-		return SCE_KERNEL_ERROR_ILLEGAL_ADDR;
+		return hleNoLog(SCE_KERNEL_ERROR_ILLEGAL_ADDR);
 
 	if (size > 0)
 	{
 		if ((addr % 64) != 0 || (size % 64) != 0)
-			return SCE_KERNEL_ERROR_CACHE_ALIGNMENT;
+			return hleNoLog(SCE_KERNEL_ERROR_CACHE_ALIGNMENT);
 
 		if (addr != 0)
 			gpu->InvalidateCache(addr, size, GPU_INVALIDATE_HINT);
 	}
 	hleEatCycles(190);
-	return 0;
+	return hleNoLog(0);
 }
 
 int sceKernelIcacheInvalidateRange(u32 addr, int size) {
@@ -462,7 +457,7 @@ int sceKernelDcacheWritebackInvalidateAll()
 	gpu->InvalidateCache(0, -1, GPU_INVALIDATE_ALL);
 	hleEatCycles(1165);
 	hleReSchedule("dcache invalidate all");
-	return 0;
+	return hleLogDebug(Log::CPU, 0, "Dcache invalidated");
 }
 
 u32 sceKernelIcacheInvalidateAll()
@@ -472,7 +467,7 @@ u32 sceKernelIcacheInvalidateAll()
 #endif
 	// Note that this doesn't actually fully invalidate all with such a large range.
 	currentMIPS->InvalidateICache(0, 0x3FFFFFFF);
-	return 0;
+	return hleLogDebug(Log::CPU, 0, "Icache invalidated");
 }
 
 u32 sceKernelIcacheClearAll()
@@ -480,10 +475,9 @@ u32 sceKernelIcacheClearAll()
 #ifdef LOG_CACHE
 	NOTICE_LOG(Log::CPU, "Icache cleared - should clear JIT someday");
 #endif
-	DEBUG_LOG(Log::CPU, "Icache cleared - should clear JIT someday");
 	// Note that this doesn't actually fully invalidate all with such a large range.
 	currentMIPS->InvalidateICache(0, 0x3FFFFFFF);
-	return 0;
+	return hleLogDebug(Log::CPU, 0, "Icache cleared");
 }
 
 void KernelObject::GetQuickInfo(char *ptr, int size) {

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -110,10 +110,9 @@ static void sceKernelCpuResumeIntr(u32 enable)
 	hleEatCycles(15);
 }
 
-static int sceKernelIsCpuIntrEnable()
-{
+static int sceKernelIsCpuIntrEnable() {
 	u32 retVal = __InterruptsEnabled(); 
-	return hleLogDebug(Log::sceIntc, retVal);
+	return hleLogVerbose(Log::sceIntc, retVal);
 }
 
 static int sceKernelIsCpuIntrSuspended(int flag)
@@ -509,10 +508,8 @@ u32 sceKernelRegisterSubIntrHandler(u32 intrNumber, u32 subIntrNumber, u32 handl
 		}
 	} else if (error == SCE_KERNEL_ERROR_FOUND_HANDLER) {
 		return hleReportError(Log::sceIntc, error, "duplicate handler");
-	} else {
-		return hleReportError(Log::sceIntc, error);
 	}
-	return error;
+	return hleReportError(Log::sceIntc, error);
 }
 
 u32 sceKernelReleaseSubIntrHandler(u32 intrNumber, u32 subIntrNumber) {

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -91,7 +91,7 @@ static int sceKernelCpuSuspendIntr()
 		returnValue = 0;
 	}
 	hleEatCycles(15);
-	return returnValue;
+	return hleNoLog(returnValue);
 }
 
 static void sceKernelCpuResumeIntr(u32 enable)
@@ -108,6 +108,7 @@ static void sceKernelCpuResumeIntr(u32 enable)
 		__DisableInterrupts();
 	}
 	hleEatCycles(15);
+	hleNoLogVoid();
 }
 
 static int sceKernelIsCpuIntrEnable() {
@@ -123,6 +124,7 @@ static int sceKernelIsCpuIntrSuspended(int flag)
 
 static void sceKernelCpuResumeIntrWithSync(u32 enable)
 {
+	// Just a forward, don't bother with hleCall.
 	sceKernelCpuResumeIntr(enable);
 }
 

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -2218,6 +2218,7 @@ int __KernelStartModule(SceUID moduleId, u32 argsize, u32 argAddr, u32 returnVal
 
 		SceUID threadID = __KernelCreateThread(module->nm.name, moduleId, entryAddr, priority, stacksize, attribute, 0, (module->nm.attribute & 0x1000) != 0);
 		_dbg_assert_(threadID > 0);
+		// TOOD: Check the return value and bail?
 		__KernelStartThreadValidate(threadID, argsize, argAddr);
 		__KernelSetThreadRA(threadID, NID_MODULERETURN);
 
@@ -2314,6 +2315,7 @@ static u32 sceKernelStopModule(u32 moduleId, u32 argSize, u32 argAddr, u32 retur
 	{
 		SceUID threadID = __KernelCreateThread(module->nm.name, moduleId, stopFunc, priority, stacksize, attr, 0, (module->nm.attribute & 0x1000) != 0);
 		_dbg_assert_(threadID > 0);
+		// TOOD: Check the return value and bail?
 		__KernelStartThreadValidate(threadID, argSize, argAddr);
 		__KernelSetThreadRA(threadID, NID_MODULERETURN);
 		__KernelWaitCurThread(WAITTYPE_MODULE, moduleId, 1, 0, false, "stopped module");
@@ -2397,6 +2399,7 @@ u32 __KernelStopUnloadSelfModuleWithOrWithoutStatus(u32 exitCode, u32 argSize, u
 		if (Memory::IsValidAddress(stopFunc)) {
 			SceUID threadID = __KernelCreateThread(module->nm.name, moduleID, stopFunc, priority, stacksize, attr, 0, (module->nm.attribute & 0x1000) != 0);
 			_dbg_assert_(threadID > 0);
+			// TOOD: Check the return value and bail?
 			__KernelStartThreadValidate(threadID, argSize, argp);
 			__KernelSetThreadRA(threadID, NID_MODULERETURN);
 			__KernelWaitCurThread(WAITTYPE_MODULE, moduleID, 1, 0, false, "unloadstopped module");

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -2096,7 +2096,6 @@ u32 sceKernelLoadModule(const char *name, u32 flags, u32 optionAddr) {
 			}
 
 			// TODO: It would be more ideal to allocate memory for this module.
-
 			return hleLogSuccessInfoI(Log::Loader, module->GetUID(), "created fake module");
 		}
 	}

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2202,8 +2202,7 @@ int sceKernelExitDeleteThread(int exitStatus) {
 	if (!__KernelIsDispatchEnabled() && sceKernelGetCompiledSdkVersion() >= 0x03080000)
 		return hleLogError(Log::sceKernel, SCE_KERNEL_ERROR_CAN_NOT_WAIT);
 	PSPThread *thread = __GetCurrentThread();
-	if (thread)
-	{
+	if (thread) {
 		INFO_LOG(Log::sceKernel,"sceKernelExitDeleteThread(%d)", exitStatus);
 		uint32_t thread_attr = thread->nt.attr;
 		uint32_t uid = thread->GetUID();
@@ -2218,7 +2217,7 @@ int sceKernelExitDeleteThread(int exitStatus) {
 	}
 	else
 		ERROR_LOG_REPORT(Log::sceKernel, "sceKernelExitDeleteThread(%d) ERROR - could not find myself!", exitStatus);
-	return 0;
+	return hleNoLog(0);
 }
 
 u32 sceKernelSuspendDispatchThread()

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -2415,11 +2415,9 @@ u32 __KernelGetCurThreadStackStart() {
 	return 0;
 }
 
-SceUID sceKernelGetThreadId()
-{
-	VERBOSE_LOG(Log::sceKernel, "%i = sceKernelGetThreadId()", currentThread);
+SceUID sceKernelGetThreadId() {
 	hleEatCycles(180);
-	return currentThread;
+	return hleLogVerbose(Log::sceKernel, currentThread);
 }
 
 int sceKernelGetThreadCurrentPriority() {

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -318,7 +318,7 @@ static int sceMp3InitResource() {
 		return hleLogSuccessI(Log::ME, 0);
 	}
 	resourceInited = true;
-	return hleLogSuccessI(Log::ME, hleDelayResult(0, "mp3 resource init", 200));
+	return hleDelayResult(hleLogSuccessI(Log::ME, 0), "mp3 resource init", 200);
 }
 
 static int sceMp3TermResource() {
@@ -333,7 +333,7 @@ static int sceMp3TermResource() {
 	mp3Map.clear();
 
 	resourceInited = false;
-	return hleLogSuccessI(Log::ME, hleDelayResult(0, "mp3 resource term", 100));
+	return hleDelayResult(hleLogSuccessI(Log::ME, 0), "mp3 resource term", 100);
 }
 
 static int __CalculateMp3Channels(int bitval) {
@@ -717,7 +717,7 @@ static u32 sceMp3LowLevelInit(u32 mp3, u32 unk) {
 	// Indicate that we've run low level init by setting version to 1.
 	ctx->Version = 1;
 
-	return hleLogSuccessInfoI(Log::ME, hleDelayResult(0, "mp3 low level", 600));
+	return hleDelayResult(hleLogSuccessInfoI(Log::ME, 0), "mp3 low level", 600);
 }
 
 static u32 sceMp3LowLevelDecode(u32 mp3, u32 sourceAddr, u32 sourceBytesConsumedAddr, u32 samplesAddr, u32 sampleBytesAddr) {

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -463,7 +463,7 @@ static u32 sceMpegInit() {
 		INFO_LOG(Log::ME, "sceMpegInit(), mpegLibVersion 0x%0x, mpegLibcrc %x", mpegLibVersion, mpegLibCrc);
 	}
 	isMpegInit = true;
-	return hleDelayResult(0, "mpeg init", 750);
+	return hleDelayResult(hleNoLog(0), "mpeg init", 750);
 }
 
 static u32 __MpegRingbufferQueryMemSize(int packets) {
@@ -576,8 +576,7 @@ static u32 sceMpegCreate(u32 mpegAddr, u32 dataPtr, u32 size, u32 ringbufferAddr
 	ctx->isAnalyzed = false;
 	ctx->mediaengine = new MediaEngine();
 
-	INFO_LOG(Log::ME, "%08x=sceMpegCreate(%08x, %08x, %i, %08x, %i, %i, %i)", mpegHandle, mpegAddr, dataPtr, size, ringbufferAddr, frameWidth, mode, ddrTop);
-	return hleDelayResult(0, "mpeg create", 29000);
+	return hleDelayResult(hleLogSuccessInfoX(Log::ME, 0), "mpeg create", 29000);
 }
 
 static int sceMpegDelete(u32 mpeg)
@@ -588,12 +587,10 @@ static int sceMpegDelete(u32 mpeg)
 		return -1;
 	}
 
-	DEBUG_LOG(Log::ME, "sceMpegDelete(%08x)", mpeg);
-
 	delete ctx;
 	mpegMap.erase(Memory::Read_U32(mpeg));
 
-	return hleDelayResult(0, "mpeg delete", 40000);
+	return hleDelayResult(hleLogDebug(Log::ME, 0), "mpeg delete", 40000);
 }
 
 
@@ -1163,8 +1160,7 @@ static u32 sceMpegAvcDecode(u32 mpeg, u32 auAddr, u32 frameWidth, u32 bufferAddr
 	}
 
 	if (ringbuffer->packetsRead == 0 || ctx->mediaengine->IsVideoEnd()) {
-		WARN_LOG(Log::ME, "sceMpegAvcDecode(%08x, %08x, %d, %08x, %08x): mpeg buffer empty", mpeg, auAddr, frameWidth, bufferAddr, initAddr);
-		return hleDelayResult(ERROR_MPEG_AVC_DECODE_FATAL, "mpeg buffer empty", avcEmptyDelayMs);
+		return hleDelayResult(hleLogWarning(Log::ME, ERROR_MPEG_AVC_DECODE_FATAL, "mpeg buffer empty"), "mpeg buffer empty", avcEmptyDelayMs);
 	}
 
 	s32 beforeAvail = ringbuffer->packets - ctx->mediaengine->getRemainSize() / 2048;
@@ -1230,32 +1226,25 @@ static u32 sceMpegAvcDecode(u32 mpeg, u32 auAddr, u32 frameWidth, u32 bufferAddr
 	//return hleDelayResult(0, "mpeg decode", 200);
 }
 
-static u32 sceMpegAvcDecodeStop(u32 mpeg, u32 frameWidth, u32 bufferAddr, u32 statusAddr)
-{
-	if (!Memory::IsValidAddress(bufferAddr) || !Memory::IsValidAddress(statusAddr)){
-		ERROR_LOG(Log::ME, "sceMpegAvcDecodeStop(%08x, %08x, %08x, %08x): invalid addresses", mpeg, frameWidth, bufferAddr, statusAddr);
-		return -1;
+static u32 sceMpegAvcDecodeStop(u32 mpeg, u32 frameWidth, u32 bufferAddr, u32 statusAddr) {
+	if (!Memory::IsValidAddress(bufferAddr) || !Memory::IsValidAddress(statusAddr)) {
+		return hleLogError(Log::ME, -1, "invalid addresses");
 	}
 
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegAvcDecodeStop(%08x, %08x, %08x, %08x): bad mpeg handle", mpeg, frameWidth, bufferAddr, statusAddr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
-
-	DEBUG_LOG(Log::ME, "sceMpegAvcDecodeStop(%08x, %08x, %08x, %08x)", mpeg, frameWidth, bufferAddr, statusAddr);
 
 	// No last frame generated
 	Memory::Write_U32(0, statusAddr);
-	return 0;
+	return hleLogDebug(Log::ME, 0);
 }
 
-static u32 sceMpegUnRegistStream(u32 mpeg, int streamUid)
-{
+static u32 sceMpegUnRegistStream(u32 mpeg, int streamUid) {
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegUnRegistStream(%08x, %i): bad mpeg handle", mpeg, streamUid);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
 
 	StreamInfo info = {0};
@@ -1283,23 +1272,18 @@ static u32 sceMpegUnRegistStream(u32 mpeg, int streamUid)
 	info.sid = -1 ;
 	info.needsReset = true;
 	ctx->isAnalyzed = false;
-	return 0;
+	return hleNoLog(0);
 }
 
-static int sceMpegAvcDecodeDetail(u32 mpeg, u32 detailAddr)
-{
-	if (!Memory::IsValidAddress(detailAddr)){
-		WARN_LOG(Log::ME, "sceMpegAvcDecodeDetail(%08x, %08x): invalid addresses", mpeg, detailAddr);
-		return -1;
+static int sceMpegAvcDecodeDetail(u32 mpeg, u32 detailAddr) {
+	if (!Memory::IsValidAddress(detailAddr)) {
+		return hleLogError(Log::ME, -1, "invalid addresses");
 	}
 
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegAvcDecodeDetail(%08x, %08x): bad mpeg handle", mpeg, detailAddr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
-
-	DEBUG_LOG(Log::ME, "sceMpegAvcDecodeDetail(%08x, %08x)", mpeg, detailAddr);
 
 	Memory::Write_U32(ctx->avc.avcDecodeResult, detailAddr + 0);
 	Memory::Write_U32(ctx->videoFrameCount, detailAddr + 4);
@@ -1310,33 +1294,29 @@ static int sceMpegAvcDecodeDetail(u32 mpeg, u32 detailAddr)
 	Memory::Write_U32(0, detailAddr + 24);
 	Memory::Write_U32(0, detailAddr + 28);
 	Memory::Write_U32(ctx->avc.avcFrameStatus, detailAddr + 32);
-	return 0;
+	return hleLogDebug(Log::ME, 0);
 }
 
-static u32 sceMpegAvcDecodeStopYCbCr(u32 mpeg, u32 bufferAddr, u32 statusAddr)
-{
+static u32 sceMpegAvcDecodeStopYCbCr(u32 mpeg, u32 bufferAddr, u32 statusAddr) {
 	if (!Memory::IsValidAddress(bufferAddr) || !Memory::IsValidAddress(statusAddr)) {
-		ERROR_LOG(Log::ME, "UNIMPL sceMpegAvcDecodeStopYCbCr(%08x, %08x, %08x): invalid addresses", mpeg, bufferAddr, statusAddr);
-		return -1;
+		return hleLogError(Log::ME, -1, "UNIMPL + invalid addresses");
 	}
 
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "UNIMPL sceMpegAvcDecodeStopYCbCr(%08x, %08x, %08x): bad mpeg handle", mpeg, bufferAddr, statusAddr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "UNIMPL + bad mpeg handle");
 	}
 
 	ERROR_LOG(Log::ME, "UNIMPL sceMpegAvcDecodeStopYCbCr(%08x, %08x, %08x)", mpeg, bufferAddr, statusAddr);
 	Memory::Write_U32(0, statusAddr);
-	return 0;
+	return hleNoLog(0);
 }
 
 static int sceMpegAvcDecodeYCbCr(u32 mpeg, u32 auAddr, u32 bufferAddr, u32 initAddr)
 {
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegAvcDecodeYCbCr(%08x, %08x, %08x, %08x): bad mpeg handle", mpeg, auAddr, bufferAddr, initAddr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
 
 	SceMpegAu avcAu;
@@ -1344,13 +1324,11 @@ static int sceMpegAvcDecodeYCbCr(u32 mpeg, u32 auAddr, u32 bufferAddr, u32 initA
 
 	auto ringbuffer = PSPPointer<SceMpegRingBuffer>::Create(ctx->mpegRingbufferAddr);
 	if (!ringbuffer.IsValid()) {
-		ERROR_LOG(Log::ME, "Bogus mpegringbufferaddr");
-		return -1;
+		return hleLogError(Log::ME, -1, "Bogus mpegringbufferaddr");
 	}
 
 	if (ringbuffer->packetsRead == 0 || ctx->mediaengine->IsVideoEnd()) {
-		WARN_LOG(Log::ME, "sceMpegAvcDecodeYCbCr(%08x, %08x, %08x, %08x): mpeg buffer empty", mpeg, auAddr, bufferAddr, initAddr);
-		return hleDelayResult(ERROR_MPEG_AVC_DECODE_FATAL, "mpeg buffer empty", avcEmptyDelayMs);
+		return hleDelayResult(hleLogWarning(Log::ME, ERROR_MPEG_AVC_DECODE_FATAL, "mpeg buffer empty"), "mpeg buffer empty", avcEmptyDelayMs);
 	}
 
 	s32 beforeAvail = ringbuffer->packets - ctx->mediaengine->getRemainSize() / 2048;
@@ -1393,40 +1371,32 @@ static int sceMpegAvcDecodeYCbCr(u32 mpeg, u32 auAddr, u32 bufferAddr, u32 initA
 	}
 	ctx->avc.avcDecodeResult = MPEG_AVC_DECODE_SUCCESS;
 
-	DEBUG_LOG(Log::ME, "sceMpegAvcDecodeYCbCr(%08x, %08x, %08x, %08x)", mpeg, auAddr, bufferAddr, initAddr);
-
 	if (ctx->videoFrameCount <= 1)
-		return hleDelayResult(0, "mpeg decode", avcFirstDelayMs);
+		return hleDelayResult(hleLogDebug(Log::ME, 0), "mpeg decode", avcFirstDelayMs);
 	else
-		return hleDelayResult(0, "mpeg decode", avcDecodeDelayMs);
+		return hleDelayResult(hleLogDebug(Log::ME, 0), "mpeg decode", avcDecodeDelayMs);
+
 	//hleEatMicro(3300);
 	//return hleDelayResult(0, "mpeg decode", 200);
 }
 
-static u32 sceMpegAvcDecodeFlush(u32 mpeg)
-{
+static u32 sceMpegAvcDecodeFlush(u32 mpeg) {
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "UNIMPL sceMpegAvcDecodeFlush(%08x): bad mpeg handle", mpeg);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "UNIMPL + bad mpeg handle");
 	}
 
-	ERROR_LOG(Log::ME, "UNIMPL sceMpegAvcDecodeFlush(%08x)", mpeg);
 	if ( ctx->videoFrameCount > 0 || ctx->audioFrameCount > 0) {
 		//__MpegFinish();
 	}
-	return 0;
+	return hleLogWarning(Log::ME, 0, "UNIMPL");
 }
 
-static int sceMpegInitAu(u32 mpeg, u32 bufferAddr, u32 auPointer)
-{
+static int sceMpegInitAu(u32 mpeg, u32 bufferAddr, u32 auPointer) {
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegInitAu(%08x, %i, %08x): bad mpeg handle", mpeg, bufferAddr, auPointer);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
-
-	DEBUG_LOG(Log::ME, "sceMpegInitAu(%08x, %i, %08x)", mpeg, bufferAddr, auPointer);
 
 	SceMpegAu sceAu;
 	sceAu.read(auPointer);
@@ -1452,42 +1422,33 @@ static int sceMpegInitAu(u32 mpeg, u32 bufferAddr, u32 auPointer)
 
 		sceAu.write(auPointer);
 	}
-	return 0;
+	return hleLogDebug(Log::ME, 0);
 }
 
-static int sceMpegQueryAtracEsSize(u32 mpeg, u32 esSizeAddr, u32 outSizeAddr)
-{
+static int sceMpegQueryAtracEsSize(u32 mpeg, u32 esSizeAddr, u32 outSizeAddr) {
 	if (!Memory::IsValidAddress(esSizeAddr) || !Memory::IsValidAddress(outSizeAddr)) {
-		ERROR_LOG(Log::ME, "sceMpegQueryAtracEsSize(%08x, %08x, %08x): invalid addresses", mpeg, esSizeAddr, outSizeAddr);
-		return -1;
+		return hleLogError(Log::ME, -1, "invalid addresses");
 	}
 
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegQueryAtracEsSize(%08x, %08x, %08x): bad mpeg handle", mpeg, esSizeAddr, outSizeAddr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
-
-	DEBUG_LOG(Log::ME, "sceMpegQueryAtracEsSize(%08x, %08x, %08x)", mpeg, esSizeAddr, outSizeAddr);
 
 	Memory::Write_U32(MPEG_ATRAC_ES_SIZE, esSizeAddr);
 	Memory::Write_U32(MPEG_ATRAC_ES_OUTPUT_SIZE, outSizeAddr);
-	return 0;
+	return hleLogDebug(Log::ME, 0);
 }
 
-static int sceMpegRingbufferAvailableSize(u32 ringbufferAddr)
-{
+static int sceMpegRingbufferAvailableSize(u32 ringbufferAddr) {
 	auto ringbuffer = PSPPointer<SceMpegRingBuffer>::Create(ringbufferAddr);
-
 	if (!ringbuffer.IsValid()) {
-		ERROR_LOG(Log::ME, "sceMpegRingbufferAvailableSize(%08x): invalid ringbuffer, should crash", ringbufferAddr);
-		return SCE_KERNEL_ERROR_ILLEGAL_ADDRESS;
+		return hleLogError(Log::ME, SCE_KERNEL_ERROR_ILLEGAL_ADDRESS, "invalid ringbuffer, should crash");
 	}
 
 	MpegContext *ctx = getMpegCtx(ringbuffer->mpeg);
 	if (!ctx) {
-		ERROR_LOG(Log::ME, "sceMpegRingbufferAvailableSize(%08x): bad mpeg handle", ringbufferAddr);
-		return ERROR_MPEG_NOT_YET_INIT;
+		return hleLogError(Log::ME, ERROR_MPEG_NOT_YET_INIT, "bad mpeg handle");
 	}
 
 	ctx->mpegRingbufferAddr = ringbufferAddr;
@@ -1501,7 +1462,7 @@ static int sceMpegRingbufferAvailableSize(u32 ringbufferAddr)
 	} else {
 		VERBOSE_LOG(Log::ME, "%i=sceMpegRingbufferAvailableSize(%08x)", ringbuffer->packets - ringbuffer->packetsAvail, ringbufferAddr);
 	}
-	return ringbuffer->packets - ringbuffer->packetsAvail;
+	return hleNoLog(ringbuffer->packets - ringbuffer->packetsAvail);
 }
 
 void PostPutAction::run(MipsCall &call) {
@@ -1657,12 +1618,11 @@ static int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	avcAu.read(auAddr);
 
 	if (ringbuffer->packetsRead == 0 || ringbuffer->packetsAvail == 0) {
-		DEBUG_LOG(Log::ME, "ERROR_MPEG_NO_DATA=sceMpegGetAvcAu(%08x, %08x, %08x, %08x)", mpeg, streamId, auAddr, attrAddr);
 		avcAu.pts = -1;
 		avcAu.dts = -1;
 		avcAu.write(auAddr);
 		// TODO: Does this really reschedule?
-		return hleDelayResult(ERROR_MPEG_NO_DATA, "mpeg get avc", mpegDecodeErrorDelayMs);
+		return hleDelayResult(hleLogDebug(Log::ME, ERROR_MPEG_NO_DATA), "mpeg get avc", mpegDecodeErrorDelayMs);
 	}
 
 	auto streamInfo = ctx->streamMap.find(streamId);
@@ -1708,10 +1668,9 @@ static int sceMpegGetAvcAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 		Memory::Write_U32(1, attrAddr);
 	}
 
-	DEBUG_LOG(Log::ME, "%x=sceMpegGetAvcAu(%08x, %08x, %08x, %08x)", result, mpeg, streamId, auAddr, attrAddr);
 	// TODO: sceMpegGetAvcAu seems to modify esSize, and delay when it's > 1000 or something.
 	// There's definitely more to it, but ultimately it seems games should expect it to delay randomly.
-	return hleDelayResult(result, "mpeg get avc", 100);
+	return hleDelayResult(hleLogDebug(Log::ME, result), "mpeg get avc", 100);
 }
 
 static u32 sceMpegFinish()
@@ -1726,7 +1685,7 @@ static u32 sceMpegFinish()
 	}
 	isMpegInit = false;
 	//__MpegFinish();
-	return hleDelayResult(0, "mpeg finish", 250);
+	return hleDelayResult(hleLogDebug(Log::ME, 0), "mpeg finish", 250);
 }
 
 static u32 sceMpegQueryMemSize() {
@@ -1737,15 +1696,13 @@ static int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 {
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegGetAtracAu(%08x, %08x, %08x, %08x): bad mpeg handle", mpeg, streamId, auAddr, attrAddr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
 
 	auto ringbuffer = PSPPointer<SceMpegRingBuffer>::Create(ctx->mpegRingbufferAddr);
 	if (!ringbuffer.IsValid()) {
 		// Would have crashed before, TODO test behavior.
-		WARN_LOG(Log::ME, "sceMpegGetAtracAu(%08x, %08x, %08x, %08x): invalid ringbuffer address", mpeg, streamId, auAddr, attrAddr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "invalid ringbuffer address");
 	}
 
 	SceMpegAu atracAu;
@@ -1763,9 +1720,8 @@ static int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 
 	// The audio can end earlier than the video does.
 	if (ringbuffer->packetsAvail == 0) {
-		DEBUG_LOG(Log::ME, "ERROR_MPEG_NO_DATA=sceMpegGetAtracAu(%08x, %08x, %08x, %08x)", mpeg, streamId, auAddr, attrAddr);
 		// TODO: Does this really delay?
-		return hleDelayResult(ERROR_MPEG_NO_DATA, "mpeg get atrac", mpegDecodeErrorDelayMs);
+		return hleDelayResult(hleLogError(Log::ME, ERROR_MPEG_NO_DATA), "mpeg get atrac", mpegDecodeErrorDelayMs);
 	}
 
 	// esBuffer is the memory where this au data goes.  We don't write the data to memory.
@@ -1803,29 +1759,24 @@ static int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 		Memory::Write_U32(0, attrAddr);
 	}
 
-	DEBUG_LOG(Log::ME, "%x=sceMpegGetAtracAu(%08x, %08x, %08x, %08x)", result, mpeg, streamId, auAddr, attrAddr);
 	// TODO: Not clear on exactly when this delays.
-	return hleDelayResult(result, "mpeg get atrac", 100);
+	return hleDelayResult(hleLogDebug(Log::ME, result), "mpeg get atrac", 100);
 }
 
 static int sceMpegQueryPcmEsSize(u32 mpeg, u32 esSizeAddr, u32 outSizeAddr)
 {
 	if (!Memory::IsValidAddress(esSizeAddr) || !Memory::IsValidAddress(outSizeAddr)) {
-		ERROR_LOG(Log::ME, "sceMpegQueryPcmEsSize(%08x, %08x, %08x): invalid addresses", mpeg, esSizeAddr, outSizeAddr);
-		return -1;
+		return hleLogError(Log::ME, -1, "invalid addresses");
 	}
 
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegQueryPcmEsSize(%08x, %08x, %08x): bad mpeg handle", mpeg, esSizeAddr, outSizeAddr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
-
-	ERROR_LOG(Log::ME, "sceMpegQueryPcmEsSize(%08x, %08x, %08x)", mpeg, esSizeAddr, outSizeAddr);
 
 	Memory::Write_U32(MPEG_PCM_ES_SIZE, esSizeAddr);
 	Memory::Write_U32(MPEG_PCM_ES_OUTPUT_SIZE, outSizeAddr);
-	return 0;
+	return hleLogError(Log::ME, 0, "UNIMPL");
 }
 
 
@@ -1833,8 +1784,7 @@ static u32 sceMpegChangeGetAuMode(u32 mpeg, int streamUid, int mode)
 {
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegChangeGetAuMode(%08x, %i, %i): bad mpeg handle", mpeg, streamUid, mode);
-		return ERROR_MPEG_INVALID_VALUE;
+		return hleLogError(Log::ME, ERROR_MPEG_INVALID_VALUE, "bad mpeg handle");
 	}
 	if (mode != MPEG_AU_MODE_DECODE && mode != MPEG_AU_MODE_SKIP) {
 		ERROR_LOG(Log::ME, "UNIMPL sceMpegChangeGetAuMode(%08x, %i, %i): bad mode", mpeg, streamUid, mode);
@@ -1879,17 +1829,14 @@ static u32 sceMpegChangeGetAuMode(u32 mpeg, int streamUid, int mode)
 	return 0;
 }
 
-static u32 sceMpegChangeGetAvcAuMode(u32 mpeg, u32 stream_addr, int mode)
-{
+static u32 sceMpegChangeGetAvcAuMode(u32 mpeg, u32 stream_addr, int mode) {
 	if (!Memory::IsValidAddress(stream_addr)) {
-		ERROR_LOG(Log::ME, "UNIMPL sceMpegChangeGetAvcAuMode(%08x, %08x, %i): invalid addresses", mpeg, stream_addr, mode);
-		return -1;
+		return hleLogError(Log::ME, -1, "invalid addresses");
 	}
 
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "UNIMPL sceMpegChangeGetAvcAuMode(%08x, %08x, %i): bad mpeg handle", mpeg, stream_addr, mode);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "UNIMPL + bad mpeg handle");
 	}
 
 	ERROR_LOG_REPORT_ONCE(mpegChangeAvcAu, Log::ME, "UNIMPL sceMpegChangeGetAvcAuMode(%08x, %08x, %i)", mpeg, stream_addr, mode);
@@ -1944,11 +1891,8 @@ static u32 sceMpegFlushAllStream(u32 mpeg)
 {
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegFlushAllStream(%08x): bad mpeg handle", mpeg);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "UNIMPL + bad mpeg handle");
 	}
-
-	WARN_LOG(Log::ME, "UNIMPL sceMpegFlushAllStream(%08x)", mpeg);
 
 	ctx->isAnalyzed = false;
 
@@ -1959,7 +1903,7 @@ static u32 sceMpegFlushAllStream(u32 mpeg)
 		ringbuffer->packetsWritePos = 0;
 	}
 
-	return 0;
+	return hleLogWarning(Log::ME, 0, "UNIMPL");
 }
 
 static u32 sceMpegFlushStream(u32 mpeg, int stream_addr)
@@ -2002,16 +1946,12 @@ static u32 sceMpegAtracDecode(u32 mpeg, u32 auAddr, u32 bufferAddr, int init)
 {
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegAtracDecode(%08x, %08x, %08x, %i): bad mpeg handle", mpeg, auAddr, bufferAddr, init);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
 
 	if (!Memory::IsValidAddress(bufferAddr)) {
-		WARN_LOG(Log::ME, "sceMpegAtracDecode(%08x, %08x, %08x, %i): invalid addresses", mpeg, auAddr, bufferAddr, init);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "invalid addresses");
 	}
-
-	DEBUG_LOG(Log::ME, "sceMpegAtracDecode(%08x, %08x, %08x, %i)", mpeg, auAddr, bufferAddr, init);
 
 	SceMpegAu atracAu;
 	atracAu.read(auAddr);
@@ -2025,8 +1965,7 @@ static u32 sceMpegAtracDecode(u32 mpeg, u32 auAddr, u32 bufferAddr, int init)
 
 	atracAu.write(auAddr);
 
-
-	return hleDelayResult(0, "mpeg atrac decode", atracDecodeDelayMs);
+	return hleDelayResult(hleLogDebug(Log::ME, 0), "mpeg atrac decode", atracDecodeDelayMs);
 	//hleEatMicro(4000);
 	//return hleDelayResult(0, "mpeg atrac decode", 200);
 }
@@ -2035,17 +1974,13 @@ static u32 sceMpegAtracDecode(u32 mpeg, u32 auAddr, u32 bufferAddr, int init)
 static u32 sceMpegAvcCsc(u32 mpeg, u32 sourceAddr, u32 rangeAddr, int frameWidth, u32 destAddr)
 {
 	if (!Memory::IsValidAddress(sourceAddr) || !Memory::IsValidAddress(rangeAddr) || !Memory::IsValidAddress(destAddr)) {
-		ERROR_LOG(Log::ME, "sceMpegAvcCsc(%08x, %08x, %08x, %i, %08x): invalid addresses", mpeg, sourceAddr, rangeAddr, frameWidth, destAddr);
-		return -1;
+		return hleLogError(Log::ME, -1, "invalid addresses");
 	}
 
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegAvcCsc(%08x, %08x, %08x, %i, %08x): bad mpeg handle", mpeg, sourceAddr, rangeAddr, frameWidth, destAddr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
-
-	DEBUG_LOG(Log::ME, "sceMpegAvcCsc(%08x, %08x, %08x, %i, %08x)", mpeg, sourceAddr, rangeAddr, frameWidth, destAddr);
 
 	if (frameWidth == 0) {
 		if (!ctx->defaultFrameWidth) {
@@ -2074,31 +2009,27 @@ static u32 sceMpegAvcCsc(u32 mpeg, u32 sourceAddr, u32 rangeAddr, int frameWidth
 	// If do not use DelayResult,Wil cause flickering in Dengeki no Pilot: Tenkuu no Kizuna
 	// https://github.com/hrydgard/ppsspp/issues/7549
 
-	return hleDelayResult(0, "mpeg avc csc", avcCscDelayMs);
+	return hleDelayResult(hleLogDebug(Log::ME, 0), "mpeg avc csc", avcCscDelayMs);
 }
 
-static u32 sceMpegRingbufferDestruct(u32 ringbufferAddr)
-{
-	DEBUG_LOG(Log::ME, "sceMpegRingbufferDestruct(%08x)", ringbufferAddr);
+static u32 sceMpegRingbufferDestruct(u32 ringbufferAddr) {
 	// Apparently, does nothing.
-	return 0;
+	return hleLogDebug(Log::ME, 0);
 }
 
 static u32 sceMpegAvcInitYCbCr(u32 mpeg, int mode, int width, int height, u32 ycbcr_addr)
 {
 	if (!Memory::IsValidAddress(ycbcr_addr)) {
-		ERROR_LOG(Log::ME, "UNIMPL sceMpegAvcInitYCbCr(%08x, %i, %i, %i, %08x): invalid addresses", mpeg, mode, width, height, ycbcr_addr);
-		return -1;
+		return hleLogError(Log::ME, -1, "invalid addresses");
 	}
 
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "UNIMPL sceMpegAvcInitYCbCr(%08x, %i, %i, %i, %08x): bad mpeg handle", mpeg, mode, width, height, ycbcr_addr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
 
 	WARN_LOG_ONCE(sceMpegAvcInitYCbCr, Log::ME, "UNIMPL sceMpegAvcInitYCbCr(%08x, %i, %i, %i, %08x)", mpeg, mode, width, height, ycbcr_addr);
-	return 0;
+	return hleNoLog(0);
 }
 
 static int sceMpegAvcQueryYCbCrSize(u32 mpeg, u32 mode, u32 width, u32 height, u32 resultAddr)
@@ -2112,7 +2043,7 @@ static int sceMpegAvcQueryYCbCrSize(u32 mpeg, u32 mode, u32 width, u32 height, u
 
 	int size = (width / 2) * (height / 2) * 6 + 128;
 	Memory::Write_U32(size, resultAddr);
-	return 0;
+	return hleNoLog(0);
 }
 
 static u32 sceMpegQueryUserdataEsSize(u32 mpeg, u32 esSizeAddr, u32 outSizeAddr)

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -847,7 +847,7 @@ static u32 sceWlanGetEtherAddr(u32 addrAddr) {
 	}
 	NotifyMemInfo(MemBlockFlags::WRITE, addrAddr, 6, "WlanEtherAddr");
 
-	return hleLogSuccessI(Log::sceNet, hleDelayResult(0, "get ether mac", 200));
+	return hleDelayResult(hleLogSuccessI(Log::sceNet, 0), "get ether mac", 200);
 }
 
 static u32 sceNetGetLocalEtherAddr(u32 addrAddr) {

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -635,11 +635,15 @@ void __NetApctlCallbacks()
 		}
 		// Similar to Adhocctl, new State might need to be set after delayed, right before executing the mipscall (ie. simulated beforeAction)
 		ScheduleApctlState(event, newState, delayus, "apctl callback state");
+		hleNoLogVoid();
 		return;
 	}
 
 	// Must be delayed long enough whenever there is a pending callback to make sure previous callback & it's afterAction are fully executed
-	sceKernelDelayThread(delayus);
+
+	hleCall(ThreadManForUser, int, sceKernelDelayThread, delayus);
+
+	hleNoLogVoid();
 }
 
 static inline u32 AllocUser(u32 size, bool fromTop, const char *name) {
@@ -1270,7 +1274,7 @@ int sceNetApctlConnect(int confId) {
 	// Is this confId is the index to the scanning's result data or sceNetApctlGetBSSDescIDListUser result?
 	netApctlInfoId = confId;
 	// Note: We're borrowing AdhocServer for Grouping purpose, so we can simulate Broadcast over the internet just like Adhoc's pro-online implementation
-	int ret = sceNetAdhocctlConnect("INFRA");
+	int ret = hleCall(sceNetAdhocctl, int, sceNetAdhocctlConnect, "INFRA");
 
 	if (netApctlState == PSP_NET_APCTL_STATE_DISCONNECTED)
 		__UpdateApctlHandlers(0, PSP_NET_APCTL_STATE_JOINING, PSP_NET_APCTL_EVENT_CONNECT_REQUEST, 0);
@@ -1481,12 +1485,14 @@ static int sceNetApctlDelInternalHandler(u32 handlerID) {
 static int sceNetApctl_A7BB73DF(u32 handlerPtr, u32 handlerArg) {
 	ERROR_LOG(Log::sceNet, "UNIMPL %s(%08x, %08x)", __FUNCTION__, handlerPtr, handlerArg);
 	// This seems to be a 3rd kind of handler
+	// Simple forward, don't need to use hleCall
 	return sceNetApctlAddHandler(handlerPtr, handlerArg);
 }
 
 static int sceNetApctl_6F5D2981(u32 handlerID) {
 	ERROR_LOG(Log::sceNet, "UNIMPL %s(%i)", __FUNCTION__, handlerID);
 	// This seems to be a 3rd kind of handler
+	// Simple forward, don't need to use hleCall
 	return sceNetApctlDelHandler(handlerID);
 }
 
@@ -1496,6 +1502,7 @@ static int sceNetApctl_lib2_69745F0A(int handlerId) {
 
 static int sceNetApctl_lib2_4C19731F(int code, u32 pInfoAddr) {
 	ERROR_LOG(Log::sceNet, "UNIMPL %s(%i, %08x)", __FUNCTION__, code, pInfoAddr);
+	// Simple forward, don't need to use hleCall
 	return sceNetApctlGetInfo(code, pInfoAddr);
 }
 
@@ -1515,6 +1522,7 @@ static int sceNetApctlGetBSSDescEntry(int entryId, int infoId, u32 resultAddr) {
 
 static int sceNetApctl_lib2_C20A144C(int connIndex, u32 ps3MacAddressPtr) {
 	ERROR_LOG(Log::sceNet, "UNIMPL %s(%i, %08x)", __FUNCTION__, connIndex, ps3MacAddressPtr);
+	// Simple forward, don't need to use hleCall
 	return sceNetApctlConnect(connIndex);
 }
 

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -1036,7 +1036,8 @@ static int sceNetApctlInit(int stackSize, int initPriority) {
 		prodCode->type = 1; // VT_UTF8 since we're using DiscID instead of product id
 		memcpy(prodCode->data, discID.c_str(), std::min(ADHOCCTL_ADHOCID_LEN, (int)discID.size()));
 	}
-	sceNetAdhocctlInit(stackSize, initPriority, apctlProdCodeAddr);
+
+	hleCall(sceNetAdhocctl, int, sceNetAdhocctlInit, stackSize, initPriority, apctlProdCodeAddr);
 
 	netApctlInited = true;
 
@@ -1287,7 +1288,7 @@ int sceNetApctlDisconnect() {
 	// Like its 'sister' function sceNetAdhocctlDisconnect, we need to alert Apctl handlers that a disconnect took place
 	// or else games like Phantasy Star Portable 2 will hang at certain points (e.g. returning to the main menu after trying to connect to PSN).
 	// Note: Since we're borrowing AdhocServer for Grouping purpose, we should disconnect too
-	sceNetAdhocctlDisconnect();
+	hleCall(sceNetAdhocctl, int, sceNetAdhocctlDisconnect);
 
 	// Discards any pending events so we can disconnect immediately
 	apctlEvents.clear();

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -2263,7 +2263,7 @@ int sceNetAdhocctlScan() {
 			// TODO: Valhalla Knights 2 need handler notification, but need to test this on games that doesn't use Adhocctl Handler too (not sure if there are games like that tho)
 			notifyAdhocctlHandlers(ADHOCCTL_EVENT_ERROR, ERROR_NET_ADHOCCTL_ALREADY_CONNECTED);
 			hleEatMicro(500);
-			return 0;
+			return hleLogDebug(Log::sceNet, 0);
 		}
 
 		// Only scan when in Disconnected state, otherwise AdhocServer will kick you out
@@ -2281,7 +2281,7 @@ int sceNetAdhocctlScan() {
 
 			if (friendFinderRunning) {
 				AdhocctlRequest req = { OPCODE_SCAN, {0} };
-				return WaitBlockingAdhocctlSocket(req, us, "adhocctl scan");
+				return hleLogSuccessOrError(Log::sceNet, WaitBlockingAdhocctlSocket(req, us, "adhocctl scan"));
 			}
 			else {
 				adhocctlState = ADHOCCTL_STATE_DISCONNECTED;
@@ -2291,7 +2291,7 @@ int sceNetAdhocctlScan() {
 			// Not delaying here may cause Naruto Shippuden Ultimate Ninja Heroes 3 to get disconnected when the mission started
 			hleEatMicro(us);
 			// FIXME: When tested using JPCSP + official prx files it seems sceNetAdhocctlScan switching to a different thread for at least 100ms after returning success and before executing the next line?
-			return hleDelayResult(0, "scan delay", adhocEventPollDelay);
+			return hleDelayResult(hleLogDebug(Log::sceNet, 0), "scan delay", adhocEventPollDelay);
 		}
 		
 		// FIXME: Returning BUSY when previous adhocctl handler's callback is not fully executed yet, But returning success and notifying handler's callback with error (ie. ALREADY_CONNECTED) when previous adhocctl handler's callback is fully executed? Is there a case where error = BUSY sent through handler's callback?
@@ -5033,7 +5033,7 @@ static int sceNetAdhocctlGetAddrByName(const char *nickName, u32 sizeAddr, u32 b
 			peerlock.unlock();
 
 			// Return Success
-			return hleLogDebug(Log::sceNet, hleDelayResult(0, "delay 100 ~ 1000us", 100), "success"); // FIXME: Might have similar delay with GetPeerList? need to know which games using this tho
+			return hleDelayResult(hleLogDebug(Log::sceNet, 0, "success"), "delay 100 ~ 1000us", 100); // FIXME: Might have similar delay with GetPeerList? need to know which games using this tho
 		}
 
 		// Invalid Arguments

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1349,11 +1349,11 @@ int sceNetAdhocctlGetState(u32 ptrToStatus) {
 int sceNetAdhocPdpCreate(const char *mac, int port, int bufferSize, u32 flag) {
 	INFO_LOG(Log::sceNet, "sceNetAdhocPdpCreate(%s, %u, %u, %u) at %08x", mac2str((SceNetEtherAddr*)mac).c_str(), port, bufferSize, flag, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
-		return -1;
+		return hleLogError(Log::sceNet, -1, "WLAN");
 	}
 
 	if (!netInited)
-		return 0x800201CA; //PSP_LWMUTEX_ERROR_NO_SUCH_LWMUTEX;
+		return hleLogError(Log::sceNet, 0x800201CA); //PSP_LWMUTEX_ERROR_NO_SUCH_LWMUTEX;
 
 	// Library is initialized
 	SceNetEtherAddr * saddr = (SceNetEtherAddr *)mac;
@@ -1517,7 +1517,7 @@ static int sceNetAdhocctlGetParameter(u32 paramAddr) {
 	parameter.nickname.data[ADHOCCTL_NICKNAME_LEN - 1] = 0;
 	DEBUG_LOG(Log::sceNet, "sceNetAdhocctlGetParameter(%08x) [Ch=%i][Group=%s][BSSID=%s][name=%s]", paramAddr, parameter.channel, grpName, mac2str(&parameter.bssid.mac_addr).c_str(), parameter.nickname.data);
 	if (!g_Config.bEnableWlan) {
-		return ERROR_NET_ADHOCCTL_DISCONNECTED;
+		return hleLogError(Log::sceNet, ERROR_NET_ADHOCCTL_DISCONNECTED);
 	}
 
 	// Library initialized
@@ -1552,7 +1552,7 @@ int sceNetAdhocPdpSend(int id, const char *mac, u32 port, void *data, int len, i
 		VERBOSE_LOG(Log::sceNet, "sceNetAdhocPdpSend(%i, %s, %i, %p, %i, %i, %i) at %08x", id, mac2str((SceNetEtherAddr*)mac).c_str(), port, data, len, timeout, flag, currentMIPS->pc);
 	}
 	if (!g_Config.bEnableWlan) {
-		return -1;
+		return hleLogError(Log::sceNet, -1);
 	}
 	SceNetEtherAddr * daddr = (SceNetEtherAddr *)mac;
 	uint16_t dport = (uint16_t)port;
@@ -1776,7 +1776,7 @@ int sceNetAdhocPdpRecv(int id, void *addr, void * port, void *buf, void *dataLen
 	}
  
 	if (!g_Config.bEnableWlan) {
-		return -1;
+		return hleLogError(Log::sceNet, -1);
 	}
 
 	SceNetEtherAddr *saddr = (SceNetEtherAddr *)addr;
@@ -2252,7 +2252,7 @@ static int sceNetAdhocctlGetAdhocId(u32 productStructAddr) {
 int sceNetAdhocctlScan() {
 	INFO_LOG(Log::sceNet, "sceNetAdhocctlScan() at %08x", currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
-		return -1;
+		return hleLogError(Log::sceNet, -1, "WLAN off");
 	}
 
 	// Library initialized
@@ -2310,7 +2310,7 @@ int sceNetAdhocctlGetScanInfo(u32 sizeAddr, u32 bufAddr) {
 
 	INFO_LOG(Log::sceNet, "sceNetAdhocctlGetScanInfo([%08x]=%i, %08x) at %08x", sizeAddr, Memory::Read_U32(sizeAddr), bufAddr, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
-		return 0;
+		return hleLogWarning(Log::sceNet, 0, "WLAN off");
 	}
 
 	// Library initialized
@@ -2684,7 +2684,7 @@ static int sceNetAdhocctlGetNameByAddr(const char *mac, u32 nameAddr) {
 int sceNetAdhocctlGetPeerInfo(const char *mac, int size, u32 peerInfoAddr) {
 	VERBOSE_LOG(Log::sceNet, "sceNetAdhocctlGetPeerInfo(%s, %i, %08x) at %08x", mac2str((SceNetEtherAddr*)mac).c_str(), size, peerInfoAddr, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
-		return -1;
+		return hleLogError(Log::sceNet, -1);
 	}
 
 	SceNetEtherAddr * maddr = (SceNetEtherAddr *)mac;
@@ -2825,7 +2825,7 @@ int sceNetAdhocctlCreate(const char *groupName) {
 		memcpy(grpName, groupName, ADHOCCTL_GROUPNAME_LEN); // For logging purpose, must not be truncated
 	INFO_LOG(Log::sceNet, "sceNetAdhocctlCreate(%s) at %08x", grpName, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
-		return -1;
+		return hleLogError(Log::sceNet, -1, "WLAN off");
 	}
 
 	adhocctlCurrentMode = ADHOCCTL_MODE_NORMAL;
@@ -2839,7 +2839,7 @@ int sceNetAdhocctlConnect(const char* groupName) {
 		strncpy(grpName, groupName, ADHOCCTL_GROUPNAME_LEN); // For logging purpose, must not be truncated
 	INFO_LOG(Log::sceNet, "sceNetAdhocctlConnect(%s) at %08x", grpName, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
-		return -1;
+		return hleLogError(Log::sceNet, -1, "WLAN off");
 	}
 
 	adhocctlCurrentMode = ADHOCCTL_MODE_NORMAL;
@@ -3348,7 +3348,7 @@ int RecreatePtpSocket(int ptpId) {
 static int sceNetAdhocPtpOpen(const char *srcmac, int sport, const char *dstmac, int dport, int bufsize, int rexmt_int, int rexmt_cnt, int flag) {
 	INFO_LOG(Log::sceNet, "sceNetAdhocPtpOpen(%s, %d, %s, %d, %d, %d, %d, %d) at %08x", mac2str((SceNetEtherAddr*)srcmac).c_str(), sport, mac2str((SceNetEtherAddr*)dstmac).c_str(),dport,bufsize, rexmt_int, rexmt_cnt, flag, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
-		return -1;
+		return hleLogError(Log::sceNet, -1, "WLAN off");
 	}
 	SceNetEtherAddr* saddr = (SceNetEtherAddr*)srcmac;
 	SceNetEtherAddr* daddr = (SceNetEtherAddr*)dstmac;
@@ -3655,7 +3655,7 @@ static int sceNetAdhocPtpAccept(int id, u32 peerMacAddrPtr, u32 peerPortPtr, int
 		VERBOSE_LOG(Log::sceNet, "sceNetAdhocPtpAccept(%d, [%08x]=%s, [%08x]=%u, %d, %u) at %08x", id, peerMacAddrPtr, mac2str(addr).c_str(), peerPortPtr, port ? *port : -1, timeout, flag, currentMIPS->pc);
 	}
 	if (!g_Config.bEnableWlan) {
-		return -1;
+		return hleLogError(Log::sceNet, -1, "WLAN off");
 	}
 
 	// Library is initialized
@@ -3868,7 +3868,7 @@ int NetAdhocPtp_Connect(int id, int timeout, int flag, bool allowForcedConnect) 
 static int sceNetAdhocPtpConnect(int id, int timeout, int flag) {
 	INFO_LOG(Log::sceNet, "sceNetAdhocPtpConnect(%i, %i, %i) at %08x", id, timeout, flag, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
-		return -1;
+		return hleLogError(Log::sceNet, -1, "WLAN off");
 	}
 
 	return NetAdhocPtp_Connect(id, timeout, flag);
@@ -3926,7 +3926,7 @@ int NetAdhocPtp_Close(int id, int unknown) {
 static int sceNetAdhocPtpClose(int id, int unknown) {
 	INFO_LOG(Log::sceNet,"sceNetAdhocPtpClose(%d,%d) at %08x",id,unknown,currentMIPS->pc);
 	/*if (!g_Config.bEnableWlan) {
-		return 0;
+		return hleLogError(Log::sceNet, -1, "WLAN off");
 	}*/
 	
 	return NetAdhocPtp_Close(id, unknown);
@@ -3947,7 +3947,7 @@ static int sceNetAdhocPtpClose(int id, int unknown) {
 static int sceNetAdhocPtpListen(const char *srcmac, int sport, int bufsize, int rexmt_int, int rexmt_cnt, int backlog, int flag) {
 	INFO_LOG(Log::sceNet, "sceNetAdhocPtpListen(%s, %d, %d, %d, %d, %d, %d) at %08x", mac2str((SceNetEtherAddr*)srcmac).c_str(), sport,bufsize,rexmt_int,rexmt_cnt,backlog,flag, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
-		return -1;
+		return hleLogError(Log::sceNet, -1, "WLAN off");
 	}
 	// Library is initialized
 	SceNetEtherAddr * saddr = (SceNetEtherAddr *)srcmac;
@@ -4712,13 +4712,13 @@ void __NetTriggerCallbacks()
 				newState = ADHOCCTL_STATE_DISCONNECTED;
 				delayus = adhocDefaultDelay; // Tekken 5 expects AdhocctlDisconnect to be done within ~17ms (a frame?)
 				break;
-			case ADHOCCTL_EVENT_GAME: 
+			case ADHOCCTL_EVENT_GAME:
 			{
 				newState = ADHOCCTL_STATE_GAMEMODE;
 				delayus = adhocEventDelay;
 				// TODO: Use blocking PTP connection to sync the timing just like official prx did (which is done before notifying user-defined Adhocctl Handlers)
 				// Workaround: Extra delay to prevent Joining player to progress faster than the Creator on Pocket Pool, but unbalanced delays could cause an issue on Shaun White Snowboarding :(
-				if (adhocConnectionType == ADHOC_JOIN) 
+				if (adhocConnectionType == ADHOC_JOIN)
 					delayus += adhocExtraDelay * 3;
 				// Shows player list
 				INFO_LOG(Log::sceNet, "GameMode - All players have joined:");
@@ -4756,7 +4756,7 @@ void __NetTriggerCallbacks()
 	}
 
 	// Must be delayed long enough whenever there is a pending callback. Should it be 100-500ms for Adhocctl Events? or Not Less than the delays on sceNetAdhocctl HLE?
-	sceKernelDelayThread(adhocDefaultDelay);
+	hleCall(ThreadManForUser, int, sceKernelDelayThread, adhocDefaultDelay);
 }
 
 const HLEFunction sceNetAdhoc[] = {
@@ -4841,7 +4841,7 @@ static int sceNetAdhocctlGetPeerList(u32 sizeAddr, u32 bufAddr) {
 
 	DEBUG_LOG(Log::sceNet, "sceNetAdhocctlGetPeerList([%08x]=%i, %08x) at %08x", sizeAddr, /*buflen ? *buflen : -1*/Memory::Read_U32(sizeAddr), bufAddr, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
-		return -1;
+		return hleLogError(Log::sceNet, -1, "WLAN off");
 	}
 
 	// Initialized Library

--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -106,7 +106,8 @@ void __UpdateAdhocctlHandlers(u32 flags, u32 error);
 
 bool __NetAdhocConnected();
 
-// I have to call this from netdialog
+// Called from netdialog
+// NOTE: use hleCall for sceNet* ones!
 int sceNetAdhocctlGetState(u32 ptrToStatus);
 int sceNetAdhocctlCreate(const char * groupName);
 int sceNetAdhocctlConnect(const char* groupName);
@@ -142,8 +143,10 @@ extern u32 matchingThreadHackAddr;
 extern u32_le matchingThreadCode[3];
 
 // Exposing those for the matching routines
+// NOTE: use hleCall for sceNet* ones!
 int sceNetAdhocPdpSend(int id, const char* mac, u32 port, void* data, int len, int timeout, int flag);
 int sceNetAdhocPdpRecv(int id, void* addr, void* port, void* buf, void* dataLength, u32 timeout, int flag);
 int sceNetAdhocPdpCreate(const char* mac, int port, int bufferSize, u32 flag);
+
 int NetAdhoc_SetSocketAlert(int id, s32_le flag);
 int NetAdhocPdp_Delete(int id, int unknown);

--- a/Core/HLE/sceNetAdhocMatching.cpp
+++ b/Core/HLE/sceNetAdhocMatching.cpp
@@ -145,7 +145,7 @@ void broadcastPingMessage(SceNetAdhocMatchingContext * context) {
 			port = it->second;
 
 		context->socketlock->lock();
-		sceNetAdhocPdpSend(context->socket, (const char*)&peer->mac_addr, port, &ping, sizeof(ping), 0, ADHOC_F_NONBLOCK);
+		hleCall(sceNetAdhoc, int, sceNetAdhocPdpSend, context->socket, (const char*)&peer->mac_addr, port, &ping, (u32)sizeof(ping), 0, ADHOC_F_NONBLOCK);
 		context->socketlock->unlock();
 	}
 }
@@ -203,7 +203,7 @@ void broadcastHelloMessage(SceNetAdhocMatchingContext * context) {
 			port = it->second;
 
 		context->socketlock->lock();
-		sceNetAdhocPdpSend(context->socket, (const char*)&peer->mac_addr, port, hello, 5 + context->hellolen, 0, ADHOC_F_NONBLOCK);
+		hleCall(sceNetAdhoc, int, sceNetAdhocPdpSend, context->socket, (const char*)&peer->mac_addr, port, hello, 5 + context->hellolen, 0, ADHOC_F_NONBLOCK);
 		context->socketlock->unlock();
 	}
 	peerlock.unlock();
@@ -281,7 +281,7 @@ void sendAcceptPacket(SceNetAdhocMatchingContext * context, SceNetEtherAddr * ma
 
 	// Send Data
 	context->socketlock->lock();
-	sceNetAdhocPdpSend(context->socket, (const char*)mac, (*context->peerPort)[*mac], accept, 9 + optlen + siblingbuflen, 0, ADHOC_F_NONBLOCK);
+	hleCall(sceNetAdhoc, int, sceNetAdhocPdpSend, context->socket, (const char*)mac, (*context->peerPort)[*mac], accept, 9 + optlen + siblingbuflen, 0, ADHOC_F_NONBLOCK);
 	context->socketlock->unlock();
 
 	// Free Memory
@@ -329,7 +329,7 @@ void sendJoinPacket(SceNetAdhocMatchingContext * context, SceNetEtherAddr * mac,
 
 	// Send Data
 	context->socketlock->lock();
-	sceNetAdhocPdpSend(context->socket, (const char*)mac, (*context->peerPort)[*mac], join, 5 + optlen, 0, ADHOC_F_NONBLOCK);
+	hleCall(sceNetAdhoc, int, sceNetAdhocPdpSend, context->socket, (const char*)mac, (*context->peerPort)[*mac], join, 5 + optlen, 0, ADHOC_F_NONBLOCK);
 	context->socketlock->unlock();
 
 	// Free Memory
@@ -363,7 +363,7 @@ void sendCancelPacket(SceNetAdhocMatchingContext * context, SceNetEtherAddr * ma
 
 		// Send Data
 		context->socketlock->lock();
-		sceNetAdhocPdpSend(context->socket, (const char*)mac, (*context->peerPort)[*mac], cancel, 5 + optlen, 0, ADHOC_F_NONBLOCK);
+		hleCall(sceNetAdhoc, int, sceNetAdhocPdpSend, context->socket, (const char*)mac, (*context->peerPort)[*mac], cancel, 5 + optlen, 0, ADHOC_F_NONBLOCK);
 		context->socketlock->unlock();
 
 		// Free Memory
@@ -432,7 +432,7 @@ void sendBulkDataPacket(SceNetAdhocMatchingContext * context, SceNetEtherAddr * 
 
 	// Send Data
 	context->socketlock->lock();
-	sceNetAdhocPdpSend(context->socket, (const char*)mac, (*context->peerPort)[*mac], send, 5 + datalen, 0, ADHOC_F_NONBLOCK);
+	hleCall(sceNetAdhoc, int, sceNetAdhocPdpSend, context->socket, (const char*)mac, (*context->peerPort)[*mac], send, 5 + datalen, 0, ADHOC_F_NONBLOCK);
 	context->socketlock->unlock();
 
 	// Free Memory
@@ -484,7 +484,7 @@ void sendBirthPacket(SceNetAdhocMatchingContext * context, SceNetEtherAddr * mac
 
 		// Send Packet
 		context->socketlock->lock();
-		int sent = sceNetAdhocPdpSend(context->socket, (const char*)&peer->mac, (*context->peerPort)[peer->mac], packet, sizeof(packet), 0, ADHOC_F_NONBLOCK);
+		int sent = hleCall(sceNetAdhoc, int, sceNetAdhocPdpSend, context->socket, (const char*)&peer->mac, (*context->peerPort)[peer->mac], packet, (u32)sizeof(packet), 0, ADHOC_F_NONBLOCK);
 		context->socketlock->unlock();
 
 		// Log Send Success
@@ -528,7 +528,7 @@ void sendDeathPacket(SceNetAdhocMatchingContext * context, SceNetEtherAddr * mac
 
 			// Send Bye Packet
 			context->socketlock->lock();
-			sceNetAdhocPdpSend(context->socket, (const char*)&peer->mac, (*context->peerPort)[peer->mac], packet, sizeof(packet[0]), 0, ADHOC_F_NONBLOCK);
+			hleCall(sceNetAdhoc, int, sceNetAdhocPdpSend, context->socket, (const char*)&peer->mac, (*context->peerPort)[peer->mac], packet, (u32)sizeof(packet[0]), 0, ADHOC_F_NONBLOCK);
 			context->socketlock->unlock();
 		}
 		else {
@@ -539,7 +539,7 @@ void sendDeathPacket(SceNetAdhocMatchingContext * context, SceNetEtherAddr * mac
 
 				// Send Death Packet
 				context->socketlock->lock();
-				sceNetAdhocPdpSend(context->socket, (const char*)&peer->mac, (*context->peerPort)[peer->mac], packet, sizeof(packet), 0, ADHOC_F_NONBLOCK);
+				hleCall(sceNetAdhoc, int, sceNetAdhocPdpSend, context->socket, (const char*)&peer->mac, (*context->peerPort)[peer->mac], packet, (u32)sizeof(packet), 0, ADHOC_F_NONBLOCK);
 				context->socketlock->unlock();
 			}
 		}
@@ -567,7 +567,7 @@ void sendByePacket(SceNetAdhocMatchingContext * context) {
 
 			// Send Bye Packet
 			context->socketlock->lock();
-			sceNetAdhocPdpSend(context->socket, (const char*)&peer->mac, (*context->peerPort)[peer->mac], &opcode, sizeof(opcode), 0, ADHOC_F_NONBLOCK);
+			hleCall(sceNetAdhoc, int, sceNetAdhocPdpSend, context->socket, (const char*)&peer->mac, (*context->peerPort)[peer->mac], &opcode, (u32)sizeof(opcode), 0, ADHOC_F_NONBLOCK);
 			context->socketlock->unlock();
 		}
 	}
@@ -1136,6 +1136,7 @@ void actOnByePacket(SceNetAdhocMatchingContext * context, SceNetEtherAddr * send
 
 
 /**
+* TODO: This really should be a callback or event!
 * Matching Event Dispatcher Thread
 * @param args sizeof(SceNetAdhocMatchingContext *)
 * @param argp SceNetAdhocMatchingContext *
@@ -1854,7 +1855,7 @@ int NetAdhocMatching_Start(int matchingId, int evthPri, int evthPartitionId, int
 
 	if (item == NULL) {
 		// return ERROR_NET_ADHOC_MATCHING_INVALID_ID; //Faking success to prevent GTA:VCS from stuck unable to choose host/join menu
-		return 0;
+		return hleLogDebug(Log::sceNet, 0);
 	}
 
 	//sceNetAdhocMatchingSetHelloOpt(matchingId, optLen, optDataAddr); //SetHelloOpt only works when context is running
@@ -1872,7 +1873,7 @@ int NetAdhocMatching_Start(int matchingId, int evthPri, int evthPartitionId, int
 	//else return ERROR_NET_ADHOC_MATCHING_INVALID_ARG; // ERROR_NET_ADHOC_MATCHING_INVALID_OPTLEN; // Returning Not Success will cause GTA:VC stuck unable to choose host/join menu
 
 	// Create PDP Socket
-	int sock = sceNetAdhocPdpCreate((const char*)&item->mac, static_cast<int>(item->port), item->rxbuflen, 0);
+	int sock = hleCall(sceNetAdhoc, int, sceNetAdhocPdpCreate, (const char*)&item->mac, static_cast<int>(item->port), item->rxbuflen, 0);
 	item->socket = sock;
 	if (sock < 1) {
 		return hleLogError(Log::sceNet, ERROR_NET_ADHOC_MATCHING_PORT_IN_USE, "adhoc matching port in use");
@@ -1881,10 +1882,10 @@ int NetAdhocMatching_Start(int matchingId, int evthPri, int evthPartitionId, int
 	// Create & Start the Fake PSP Thread ("matching_ev%d" and "matching_io%d")
 	netAdhocMatchingValidateLoopMemory();
 	std::string thrname = std::string("MatchingThr") + std::to_string(matchingId);
-	matchingThreads[item->matching_thid] = sceKernelCreateThread(thrname.c_str(), matchingThreadHackAddr, evthPri, evthStack, 0, 0);
+	matchingThreads[item->matching_thid] = hleCall(ThreadManForUser, int, sceKernelCreateThread, thrname.c_str(), matchingThreadHackAddr, evthPri, evthStack, 0, 0);
 	//item->matchingThread = new HLEHelperThread(thrname.c_str(), "sceNetAdhocMatching", "__NetMatchingCallbacks", inthPri, inthStack);
 	if (matchingThreads[item->matching_thid] > 0) {
-		sceKernelStartThread(matchingThreads[item->matching_thid], 0, 0); //sceKernelStartThread(context->event_thid, sizeof(context), &context);
+		hleCall(ThreadManForUser, int, sceKernelStartThread, matchingThreads[item->matching_thid], 0, 0); //sceKernelStartThread(context->event_thid, sizeof(context), &context);
 		//item->matchingThread->Start(matchingId, 0);
 	}
 
@@ -1901,7 +1902,7 @@ int NetAdhocMatching_Start(int matchingId, int evthPri, int evthPartitionId, int
 	item->running = 1;
 	netAdhocMatchingStarted++;
 
-	return 0;
+	return hleLogDebug(Log::sceNet, 0);
 }
 
 #define KERNEL_PARTITION_ID  1
@@ -2004,7 +2005,7 @@ static int sceNetAdhocMatchingSelectTarget(int matchingId, const char *macAddres
 			sendAcceptMessage(context, peer, optLen, opt);
 
 			// Return Success
-			return 0;
+			return hleLogDebug(Log::sceNet, 0);
 		}
 	}
 
@@ -2025,7 +2026,7 @@ static int sceNetAdhocMatchingSelectTarget(int matchingId, const char *macAddres
 			sendJoinRequest(context, peer, optLen, opt);
 
 			// Return Success
-			return 0;
+			return hleLogDebug(Log::sceNet, 0);
 		}
 	}
 
@@ -2046,7 +2047,7 @@ static int sceNetAdhocMatchingSelectTarget(int matchingId, const char *macAddres
 			sendJoinRequest(context, peer, optLen, opt);
 
 			// Return Success
-			return 0;
+			return hleLogDebug(Log::sceNet, 0);
 		}
 
 		// Requesting Peer
@@ -2060,7 +2061,7 @@ static int sceNetAdhocMatchingSelectTarget(int matchingId, const char *macAddres
 			sendAcceptMessage(context, peer, optLen, opt);
 
 			// Return Success
-			return 0;
+			return hleLogDebug(Log::sceNet, 0);
 		}
 	}
 
@@ -2103,7 +2104,7 @@ int NetAdhocMatching_CancelTargetWithOpt(int matchingId, const char* macAddress,
 		// Peer not found
 		//return hleLogError(Log::sceNet, ERROR_NET_ADHOC_MATCHING_UNKNOWN_TARGET, "adhocmatching unknown target");
 		// Faking success to prevent the game (ie. Soul Calibur) to repeatedly calling this function when the other player is disconnected
-		return 0;
+		return hleLogDebug(Log::sceNet, 0);
 	}
 
 	// Valid Peer Mode
@@ -2131,13 +2132,13 @@ int NetAdhocMatching_CancelTargetWithOpt(int matchingId, const char* macAddress,
 
 		hleEatCycles(adhocDefaultDelay);
 		// Return Success
-		return 0;
+		return hleLogDebug(Log::sceNet, 0);
 	}
 
 	// Peer not found
 	//return hleLogError(Log::sceNet, ERROR_NET_ADHOC_MATCHING_UNKNOWN_TARGET, "adhocmatching unknown target");
 	// Faking success to prevent the game (ie. Soul Calibur) to repeatedly calling this function when the other player is disconnected
-	return 0;
+	return hleLogDebug(Log::sceNet, 0);
 }
 
 int sceNetAdhocMatchingCancelTargetWithOpt(int matchingId, const char *macAddress, int optLen, u32 optDataPtr) {
@@ -2157,7 +2158,6 @@ int sceNetAdhocMatchingCancelTarget(int matchingId, const char *macAddress) {
 }
 
 int sceNetAdhocMatchingGetHelloOpt(int matchingId, u32 optLenAddr, u32 optDataAddr) {
-	WARN_LOG(Log::sceNet, "UNTESTED sceNetAdhocMatchingGetHelloOpt(%i, %08x, %08x)", matchingId, optLenAddr, optDataAddr);
 	if (!g_Config.bEnableWlan) {
 		return hleLogError(Log::sceNet, -1, "WLAN off");
 	}
@@ -2187,11 +2187,10 @@ int sceNetAdhocMatchingGetHelloOpt(int matchingId, u32 optLenAddr, u32 optDataAd
 	// Multithreading Unlock
 	peerlock.unlock();
 
-	return 0;
+	return hleLogDebug(Log::sceNet, 0);
 }
 
 int sceNetAdhocMatchingSetHelloOpt(int matchingId, int optLenAddr, u32 optDataAddr) {
-	VERBOSE_LOG(Log::sceNet, "UNTESTED sceNetAdhocMatchingSetHelloOpt(%i, %i, %08x) at %08x", matchingId, optLenAddr, optDataAddr, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
 		return hleLogError(Log::sceNet, -1, "WLAN off");
 	}
@@ -2259,7 +2258,7 @@ int sceNetAdhocMatchingSetHelloOpt(int matchingId, int optLenAddr, u32 optDataAd
 	}
 
 	// Return Success
-	return 0;
+	return hleLogDebug(Log::sceNet, 0);
 }
 
 static int sceNetAdhocMatchingGetMembers(int matchingId, u32 sizeAddr, u32 buf) {
@@ -2453,7 +2452,7 @@ static int sceNetAdhocMatchingGetMembers(int matchingId, u32 sizeAddr, u32 buf) 
 	}
 
 	// Return Success
-	return hleDelayResult(0, "delay 100 ~ 1000us", 100); // seems to have different thread running within the delay duration
+	return hleDelayResult(hleLogDebug(Log::sceNet, 0), "delay 100 ~ 1000us", 100); // seems to have different thread running within the delay duration
 }
 
 // Gran Turismo may replace the 1st bit of the 1st byte of MAC address's OUI with 0 (unicast bit), or replace the whole 6-bytes of MAC address with all 00 (invalid mac) for unknown reason
@@ -2522,7 +2521,7 @@ int sceNetAdhocMatchingSendData(int matchingId, const char *mac, int dataLen, u3
 	sendBulkDataPacket(context, &peer->mac, dataLen, data);
 
 	// Return Success
-	return 0;
+	return hleLogDebug(Log::sceNet, 0);
 }
 
 int sceNetAdhocMatchingAbortSendData(int matchingId, const char *mac) {
@@ -2572,12 +2571,11 @@ int sceNetAdhocMatchingAbortSendData(int matchingId, const char *mac) {
 	}
 
 	// Return Success
-	return 0;
+	return hleLogDebug(Log::sceNet, 0);
 }
 
 // Get the maximum memory usage by the matching library
 static int sceNetAdhocMatchingGetPoolMaxAlloc() {
-	ERROR_LOG(Log::sceNet, "UNIMPL sceNetAdhocMatchingGetPoolMaxAlloc() at %08x", currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
 		return hleLogError(Log::sceNet, -1, "WLAN off");
 	}
@@ -2587,7 +2585,6 @@ static int sceNetAdhocMatchingGetPoolMaxAlloc() {
 }
 
 int sceNetAdhocMatchingGetPoolStat(u32 poolstatPtr) {
-	DEBUG_LOG(Log::sceNet, "UNTESTED sceNetAdhocMatchingGetPoolStat(%08x) at %08x", poolstatPtr, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
 		return hleLogError(Log::sceNet, -1, "WLAN off");
 	}
@@ -2611,7 +2608,7 @@ int sceNetAdhocMatchingGetPoolStat(u32 poolstatPtr) {
 	poolstat->free = fakePoolSize - poolstat->maximum;
 
 	// Return Success
-	return 0;
+	return hleLogDebug(Log::sceNet, 0);
 }
 
 void __NetMatchingCallbacks() { //(int matchingId)
@@ -2650,6 +2647,8 @@ void __NetMatchingCallbacks() { //(int matchingId)
 
 	// Must be delayed long enough whenever there is a pending callback. Should it be 10-100ms for Matching Events? or Not Less than the delays on sceNetAdhocMatching HLE?
 	hleCall(ThreadManForUser, int, sceKernelDelayThread, delayus);
+
+	hleNoLogVoid();
 }
 
 

--- a/Core/HLE/sceNetAdhocMatching.cpp
+++ b/Core/HLE/sceNetAdhocMatching.cpp
@@ -1737,7 +1737,7 @@ int sceNetAdhocMatchingTerm() {
 static int sceNetAdhocMatchingCreate(int mode, int maxnum, int port, int rxbuflen, int hello_int, int keepalive_int, int init_count, int rexmt_int, u32 callbackAddr) {
 	WARN_LOG(Log::sceNet, "sceNetAdhocMatchingCreate(mode=%i, maxnum=%i, port=%i, rxbuflen=%i, hello=%i, keepalive=%i, initcount=%i, rexmt=%i, callbackAddr=%08x) at %08x", mode, maxnum, port, rxbuflen, hello_int, keepalive_int, init_count, rexmt_int, callbackAddr, currentMIPS->pc);
 	if (!g_Config.bEnableWlan) {
-		return -1;
+		return hleLogError(Log::sceNet, -1, "WLAN off");
 	}
 
 	SceNetAdhocMatchingHandler handler;
@@ -1910,8 +1910,9 @@ int NetAdhocMatching_Start(int matchingId, int evthPri, int evthPartitionId, int
 // This should be similar with sceNetAdhocMatchingStart2 but using USER_PARTITION_ID (2) for PartitionId params
 static int sceNetAdhocMatchingStart(int matchingId, int evthPri, int evthStack, int inthPri, int inthStack, int optLen, u32 optDataAddr) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceNetAdhocMatchingStart(%i, %i, %i, %i, %i, %i, %08x) at %08x", matchingId, evthPri, evthStack, inthPri, inthStack, optLen, optDataAddr, currentMIPS->pc);
-	if (!g_Config.bEnableWlan)
-		return -1;
+	if (!g_Config.bEnableWlan) {
+		return hleLogError(Log::sceNet, -1, "WLAN off");
+	}
 
 	int retval = NetAdhocMatching_Start(matchingId, evthPri, USER_PARTITION_ID, evthStack, inthPri, USER_PARTITION_ID, inthStack, optLen, optDataAddr);
 	// Give a little time to make sure matching Threads are ready before the game use the next sceNet functions, should've checked for status instead of guessing the time?
@@ -1922,8 +1923,9 @@ static int sceNetAdhocMatchingStart(int matchingId, int evthPri, int evthStack, 
 // With params for Partition ID for the event & input handler stack
 static int sceNetAdhocMatchingStart2(int matchingId, int evthPri, int evthPartitionId, int evthStack, int inthPri, int inthPartitionId, int inthStack, int optLen, u32 optDataAddr) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceNetAdhocMatchingStart2(%i, %i, %i, %i, %i, %i, %i, %i, %08x) at %08x", matchingId, evthPri, evthPartitionId, evthStack, inthPri, inthPartitionId, inthStack, optLen, optDataAddr, currentMIPS->pc);
-	if (!g_Config.bEnableWlan)
-		return -1;
+	if (!g_Config.bEnableWlan) {
+		return hleLogError(Log::sceNet, -1, "WLAN off");
+	}
 
 	int retval = NetAdhocMatching_Start(matchingId, evthPri, evthPartitionId, evthStack, inthPri, inthPartitionId, inthStack, optLen, optDataAddr);
 	// Give a little time to make sure matching Threads are ready before the game use the next sceNet functions, should've checked for status instead of guessing the time?
@@ -1933,8 +1935,9 @@ static int sceNetAdhocMatchingStart2(int matchingId, int evthPri, int evthPartit
 
 static int sceNetAdhocMatchingSelectTarget(int matchingId, const char *macAddress, int optLen, u32 optDataPtr) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceNetAdhocMatchingSelectTarget(%i, %s, %i, %08x) at %08x", matchingId, mac2str((SceNetEtherAddr*)macAddress).c_str(), optLen, optDataPtr, currentMIPS->pc);
-	if (!g_Config.bEnableWlan)
-		return -1;
+	if (!g_Config.bEnableWlan) {
+		return hleLogError(Log::sceNet, -1, "WLAN off");
+	}
 
 	if (!netAdhocMatchingInited) {
 		// Uninitialized Library
@@ -2139,24 +2142,29 @@ int NetAdhocMatching_CancelTargetWithOpt(int matchingId, const char* macAddress,
 
 int sceNetAdhocMatchingCancelTargetWithOpt(int matchingId, const char *macAddress, int optLen, u32 optDataPtr) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceNetAdhocMatchingCancelTargetWithOpt(%i, %s, %i, %08x) at %08x", matchingId, mac2str((SceNetEtherAddr*)macAddress).c_str(), optLen, optDataPtr, currentMIPS->pc);
-	if (!g_Config.bEnableWlan)
-		return -1;
+	if (!g_Config.bEnableWlan) {
+		return hleLogError(Log::sceNet, -1, "WLAN off");
+	}
 	return NetAdhocMatching_CancelTargetWithOpt(matchingId, macAddress, optLen, optDataPtr);
 }
 
 int sceNetAdhocMatchingCancelTarget(int matchingId, const char *macAddress) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceNetAdhocMatchingCancelTarget(%i, %s)", matchingId, mac2str((SceNetEtherAddr*)macAddress).c_str());
-	if (!g_Config.bEnableWlan)
-		return -1;
+	if (!g_Config.bEnableWlan) {
+		return hleLogError(Log::sceNet, -1, "WLAN off");
+	}
 	return NetAdhocMatching_CancelTargetWithOpt(matchingId, macAddress, 0, 0);
 }
 
 int sceNetAdhocMatchingGetHelloOpt(int matchingId, u32 optLenAddr, u32 optDataAddr) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceNetAdhocMatchingGetHelloOpt(%i, %08x, %08x)", matchingId, optLenAddr, optDataAddr);
-	if (!g_Config.bEnableWlan)
-		return -1;
+	if (!g_Config.bEnableWlan) {
+		return hleLogError(Log::sceNet, -1, "WLAN off");
+	}
 
-	if (!Memory::IsValidAddress(optLenAddr)) return ERROR_NET_ADHOC_MATCHING_INVALID_ARG;
+	if (!Memory::IsValidAddress(optLenAddr)) {
+		return hleLogError(Log::sceNet, ERROR_NET_ADHOC_MATCHING_INVALID_ARG);
+	}
 
 	s32_le *optlen = PSPPointer<s32_le>::Create(optLenAddr);
 
@@ -2184,8 +2192,9 @@ int sceNetAdhocMatchingGetHelloOpt(int matchingId, u32 optLenAddr, u32 optDataAd
 
 int sceNetAdhocMatchingSetHelloOpt(int matchingId, int optLenAddr, u32 optDataAddr) {
 	VERBOSE_LOG(Log::sceNet, "UNTESTED sceNetAdhocMatchingSetHelloOpt(%i, %i, %08x) at %08x", matchingId, optLenAddr, optDataAddr, currentMIPS->pc);
-	if (!g_Config.bEnableWlan)
-		return -1;
+	if (!g_Config.bEnableWlan) {
+		return hleLogError(Log::sceNet, -1, "WLAN off");
+	}
 
 	if (!netAdhocMatchingInited)
 		return hleLogDebug(Log::sceNet, ERROR_NET_ADHOC_MATCHING_NOT_INITIALIZED, "adhocmatching not initialized");
@@ -2255,8 +2264,9 @@ int sceNetAdhocMatchingSetHelloOpt(int matchingId, int optLenAddr, u32 optDataAd
 
 static int sceNetAdhocMatchingGetMembers(int matchingId, u32 sizeAddr, u32 buf) {
 	DEBUG_LOG(Log::sceNet, "UNTESTED sceNetAdhocMatchingGetMembers(%i, [%08x]=%i, %08x) at %08x", matchingId, sizeAddr, Memory::Read_U32(sizeAddr), buf, currentMIPS->pc);
-	if (!g_Config.bEnableWlan)
-		return -1;
+	if (!g_Config.bEnableWlan) {
+		return hleLogError(Log::sceNet, -1, "WLAN off");
+	}
 
 	if (!netAdhocMatchingInited)
 		return hleLogDebug(Log::sceNet, ERROR_NET_ADHOC_MATCHING_NOT_INITIALIZED, "adhocmatching not initialized");
@@ -2449,8 +2459,9 @@ static int sceNetAdhocMatchingGetMembers(int matchingId, u32 sizeAddr, u32 buf) 
 // Gran Turismo may replace the 1st bit of the 1st byte of MAC address's OUI with 0 (unicast bit), or replace the whole 6-bytes of MAC address with all 00 (invalid mac) for unknown reason
 int sceNetAdhocMatchingSendData(int matchingId, const char *mac, int dataLen, u32 dataAddr) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceNetAdhocMatchingSendData(%i, %s, %i, %08x) at %08x", matchingId, mac2str((SceNetEtherAddr*)mac).c_str(), dataLen, dataAddr, currentMIPS->pc);
-	if (!g_Config.bEnableWlan)
-		return -1;
+	if (!g_Config.bEnableWlan) {
+		return hleLogError(Log::sceNet, -1, "WLAN off");
+	}
 
 	if (!netAdhocMatchingInited) {
 		// Uninitialized Library
@@ -2516,8 +2527,9 @@ int sceNetAdhocMatchingSendData(int matchingId, const char *mac, int dataLen, u3
 
 int sceNetAdhocMatchingAbortSendData(int matchingId, const char *mac) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceNetAdhocMatchingAbortSendData(%i, %s)", matchingId, mac2str((SceNetEtherAddr*)mac).c_str());
-	if (!g_Config.bEnableWlan)
-		return -1;
+	if (!g_Config.bEnableWlan) {
+		return hleLogError(Log::sceNet, -1, "WLAN off");
+	}
 
 	if (!netAdhocMatchingInited) {
 		// Uninitialized Library
@@ -2566,8 +2578,9 @@ int sceNetAdhocMatchingAbortSendData(int matchingId, const char *mac) {
 // Get the maximum memory usage by the matching library
 static int sceNetAdhocMatchingGetPoolMaxAlloc() {
 	ERROR_LOG(Log::sceNet, "UNIMPL sceNetAdhocMatchingGetPoolMaxAlloc() at %08x", currentMIPS->pc);
-	if (!g_Config.bEnableWlan)
-		return -1;
+	if (!g_Config.bEnableWlan) {
+		return hleLogError(Log::sceNet, -1, "WLAN off");
+	}
 
 	// Lazy way out - hardcoded return value
 	return hleLogDebug(Log::sceNet, fakePoolSize / 2, "faked value");
@@ -2575,8 +2588,9 @@ static int sceNetAdhocMatchingGetPoolMaxAlloc() {
 
 int sceNetAdhocMatchingGetPoolStat(u32 poolstatPtr) {
 	DEBUG_LOG(Log::sceNet, "UNTESTED sceNetAdhocMatchingGetPoolStat(%08x) at %08x", poolstatPtr, currentMIPS->pc);
-	if (!g_Config.bEnableWlan)
-		return -1;
+	if (!g_Config.bEnableWlan) {
+		return hleLogError(Log::sceNet, -1, "WLAN off");
+	}
 
 	if (!netAdhocMatchingInited) {
 		// Uninitialized Library
@@ -2635,7 +2649,7 @@ void __NetMatchingCallbacks() { //(int matchingId)
 	}
 
 	// Must be delayed long enough whenever there is a pending callback. Should it be 10-100ms for Matching Events? or Not Less than the delays on sceNetAdhocMatching HLE?
-	sceKernelDelayThreadCB(delayus);
+	hleCall(ThreadManForUser, int, sceKernelDelayThread, delayus);
 }
 
 

--- a/Core/HLE/sceNetInet.cpp
+++ b/Core/HLE/sceNetInet.cpp
@@ -316,9 +316,9 @@ int sceNetInetSelect(int nfds, u32 readfdsPtr, u32 writefdsPtr, u32 exceptfdsPtr
 
 	if (retval < 0) {
 		UpdateErrnoFromHost(socket_errno, __FUNCTION__);
-		return hleLogDebug(Log::sceNet, hleDelayResult(retval, "workaround until blocking-socket", 500)); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented (ie. Coded Arms Contagion)
+		return hleDelayResult(hleLogDebug(Log::sceNet, retval), "workaround until blocking-socket", 500); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented (ie. Coded Arms Contagion)
 	}
-	return hleLogSuccessI(Log::sceNet, hleDelayResult(retval, "workaround until blocking-socket", 500)); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented (ie. Coded Arms Contagion)
+	return hleDelayResult(hleLogSuccessI(Log::sceNet, retval), "workaround until blocking-socket", 500); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented (ie. Coded Arms Contagion)
 }
 
 int sceNetInetPoll(u32 fdsPtr, u32 nfds, int timeout) { // timeout in miliseconds just like posix poll? or in microseconds as other PSP timeout?
@@ -358,7 +358,7 @@ int sceNetInetPoll(u32 fdsPtr, u32 nfds, int timeout) { // timeout in milisecond
 	retval = select(maxHostFd + 1, &readfds, &writefds, &exceptfds, /*(timeout<0)? NULL:*/&tmout);
 	if (retval < 0) {
 		UpdateErrnoFromHost(EINTR, __FUNCTION__);
-		return hleLogError(Log::sceNet, hleDelayResult(retval, "workaround until blocking-socket", 500)); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented
+		return hleDelayResult(hleLogError(Log::sceNet, retval), "workaround until blocking-socket", 500); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented
 	}
 
 	retval = 0;
@@ -376,7 +376,7 @@ int sceNetInetPoll(u32 fdsPtr, u32 nfds, int timeout) { // timeout in milisecond
 		VERBOSE_LOG(Log::sceNet, "Poll Socket#%d Fd: %d, events: %04x, revents: %04x, availToRecv: %d", i, fdarray[i].fd, fdarray[i].events, fdarray[i].revents, (int)getAvailToRecv(fdarray[i].fd));
 	}
 	//hleEatMicro(1000);
-	return hleLogSuccessI(Log::sceNet, hleDelayResult(retval, "workaround until blocking-socket", 1000)); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented
+	return hleDelayResult(hleLogSuccessI(Log::sceNet, retval), "workaround until blocking-socket", 1000); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented
 }
 
 static int sceNetInetRecv(int socket, u32 bufPtr, u32 bufLen, u32 flags) {
@@ -401,7 +401,7 @@ static int sceNetInetRecv(int socket, u32 bufPtr, u32 bufLen, u32 flags) {
 	DataToHexString(10, 0, Memory::GetPointer(bufPtr), retval, &datahex);
 	VERBOSE_LOG(Log::sceNet, "Data Dump (%d bytes):\n%s", retval, datahex.c_str());
 
-	return hleLogSuccessInfoI(Log::sceNet, hleDelayResult(retval, "workaround until blocking-socket", 500)); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented
+	return hleDelayResult(hleLogSuccessInfoI(Log::sceNet, retval), "workaround until blocking-socket", 500); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented
 }
 
 static int sceNetInetSend(int socket, u32 bufPtr, u32 bufLen, u32 flags) {
@@ -835,8 +835,8 @@ static int sceNetInetRecvfrom(int socket, u32 bufferPtr, int len, int flags, u32
 	VERBOSE_LOG(Log::sceNet, "Data Dump (%d bytes):\n%s", retval, datahex.c_str());
 
 	// Using hleDelayResult as a workaround for games that need blocking-socket to be implemented (ie. Coded Arms Contagion)
-	return hleLogSuccessInfoI(Log::sceNet, hleDelayResult(retval, "workaround until blocking-socket", 500), 
-		"RecvFrom: Address = %s, Port = %d", ip2str(saddr.in.sin_addr).c_str(), ntohs(saddr.in.sin_port));
+	return hleDelayResult(hleLogSuccessInfoI(Log::sceNet, retval,
+		"RecvFrom: Address = %s, Port = %d", ip2str(saddr.in.sin_addr).c_str(), ntohs(saddr.in.sin_port)), "workaround until blocking-socket", 500);
 }
 
 static int sceNetInetSendto(int socket, u32 bufferPtr, int len, int flags, u32 toPtr, int tolen) {

--- a/Core/HLE/sceNp.cpp
+++ b/Core/HLE/sceNp.cpp
@@ -195,11 +195,10 @@ static int sceNpGetOnlineId(u32 idPtr)
 	return hleLogWarning(Log::sceNet, 0, "Online ID: %s", id->data);
 }
 
-int NpGetNpId(SceNpId* npid)
-{
+int NpGetNpId(SceNpId* npid) {
 	// Callers make sure that the rest of npid is zero filled, which takes care of the terminator.
 	strncpy(npid->handle.data, npOnlineId.c_str(), sizeof(npid->handle.data));
-	return hleLogDebug(Log::sceNet, 0);
+	return 0;
 }
 
 static int sceNpGetNpId(u32 idPtr)

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -480,7 +480,7 @@ static u32 scePowerSetClockFrequency(u32 pllfreq, u32 cpufreq, u32 busfreq) {
 		else if ((newPll == 266 && oldPll == 333) || (newPll == 333 && oldPll == 266))
 			usec = 16600;
 
-		return hleDelayResult(0, "scepower set clockFrequency", usec);
+		return hleDelayResult(hleNoLog(0), "scepower set clockFrequency", usec);
 	}
 	if (GetLockedCPUSpeedMhz() <= 0)
 		CoreTiming::SetClockFrequencyHz(PowerCpuMhzToHz(cpufreq, pllFreq));

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1170,7 +1170,7 @@ static int scePsmfPlayerStop(u32 psmfPlayer) {
 
 	int delayUs = 3000;
 	DelayPsmfStateChange(psmfPlayer, PSMF_PLAYER_STATUS_STANDBY, delayUs);
-	return hleLogSuccessInfoI(Log::ME, hleDelayResult(0, "psmfplayer stop", delayUs));
+	return hleDelayResult(hleLogSuccessInfoI(Log::ME, 0), "psmfplayer stop", delayUs);
 }
 
 static int scePsmfPlayerBreak(u32 psmfPlayer) {
@@ -1230,7 +1230,7 @@ static int _PsmfPlayerSetPsmfOffset(u32 psmfPlayer, const char *filename, int of
 
 	psmfplayer->filehandle = pspFileSystem.OpenFile(filename, (FileAccess) FILEACCESS_READ);
 	if (psmfplayer->filehandle < 0) {
-		return hleLogError(Log::ME, hleDelayResult(SCE_KERNEL_ERROR_ILLEGAL_ARGUMENT, "psmfplayer set", delayUs), "invalid file data or does not exist");
+		return hleDelayResult(hleLogError(Log::ME, SCE_KERNEL_ERROR_ILLEGAL_ARGUMENT, "invalid file data or does not exist"), "psmfplayer set", delayUs);
 	}
 
 	if (offset != 0)
@@ -1250,7 +1250,7 @@ static int _PsmfPlayerSetPsmfOffset(u32 psmfPlayer, const char *filename, int of
 	// TODO: Merge better with Psmf.
 	u16 numStreams = *(u16_be *)(buf + 0x80);
 	if (numStreams > 128) {
-		return hleReportError(Log::ME, hleDelayResult(SCE_KERNEL_ERROR_ILLEGAL_ARGUMENT, "psmfplayer set", delayUs), "too many streams in PSMF video, bogus data");
+		return hleDelayResult(hleReportError(Log::ME, SCE_KERNEL_ERROR_ILLEGAL_ARGUMENT, "too many streams in PSMF video, bogus data"), "psmfplayer set", delayUs);
 	}
 
 	psmfplayer->totalVideoStreams = 0;
@@ -1294,7 +1294,7 @@ static int _PsmfPlayerSetPsmfOffset(u32 psmfPlayer, const char *filename, int of
 	psmfplayer->totalDurationTimestamp = psmfplayer->mediaengine->getLastTimeStamp();
 
 	DelayPsmfStateChange(psmfPlayer, PSMF_PLAYER_STATUS_STANDBY, delayUs);
-	return hleLogSuccessInfoI(Log::ME, hleDelayResult(0, "psmfplayer set", delayUs));
+	return hleDelayResult(hleLogSuccessInfoI(Log::ME, 0), "psmfplayer set", delayUs);
 }
 
 static int scePsmfPlayerSetPsmf(u32 psmfPlayer, const char *filename) {
@@ -1463,7 +1463,7 @@ static int scePsmfPlayerStart(u32 psmfPlayer, u32 psmfPlayerData, int initPts)
 
 	psmfplayer->seekDestTimeStamp = initPts;
 	__PsmfPlayerContinueSeek(psmfplayer);
-	return delayUs == 0 ? 0 : hleDelayResult(0, "psmfplayer start", delayUs);
+	return delayUs == 0 ? 0 : hleDelayResult(hleNoLog(0), "psmfplayer start", delayUs);
 }
 
 static int scePsmfPlayerDelete(u32 psmfPlayer)

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1154,8 +1154,7 @@ static int scePsmfPlayerCreate(u32 psmfPlayer, u32 dataPtr) {
 
 	int delayUs = 20000;
 	DelayPsmfStateChange(psmfPlayer, PSMF_PLAYER_STATUS_INIT, delayUs);
-	INFO_LOG(Log::ME, "psmfplayer create, psmfPlayerLibVersion 0x%0x, psmfPlayerLibcrc %x", psmfPlayerLibVersion, psmfPlayerLibcrc);
-	return hleDelayResult(0, "player create", delayUs);	
+	return hleDelayResult(hleLogSuccessInfoI(Log::ME, 0, "psmfplayer create, psmfPlayerLibVersion 0x%0x, psmfPlayerLibcrc %x", psmfPlayerLibVersion, psmfPlayerLibcrc), "player create", delayUs);
 }
 
 static int scePsmfPlayerStop(u32 psmfPlayer) {

--- a/Core/Util/PPGeDraw.cpp
+++ b/Core/Util/PPGeDraw.cpp
@@ -38,6 +38,7 @@
 #include "GPU/GPUCommon.h"
 #include "Core/FileSystems/MetaFileSystem.h"
 #include "Core/Util/PPGeDraw.h"
+#include "Core/HLE/HLE.h"
 #include "Core/HLE/sceKernel.h"
 #include "Core/HLE/sceKernelMemory.h"
 #include "Core/HLE/sceGe.h"
@@ -469,7 +470,7 @@ void PPGeEnd()
 		// We actually drew something
 		gpu->EnableInterrupts(false);
 		NotifyMemInfo(MemBlockFlags::WRITE, dlPtr, dlWritePtr - dlPtr, "PPGe ListCmds");
-		u32 list = sceGeListEnQueue(dlPtr, dlWritePtr, -1, listArgs.ptr);
+		u32 list = hleCall(sceGe_user, u32, sceGeListEnQueue, dlPtr, dlWritePtr, -1, listArgs.ptr);
 		DEBUG_LOG(Log::sceGe, "PPGe enqueued display list %i", list);
 		gpu->EnableInterrupts(true);
 	}

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -977,11 +977,12 @@ void DrawHLEModules(ImConfig &config) {
 	}
 
 	std::sort(modules.begin(), modules.end(), [](const HLEModule* a, const HLEModule* b) {
-		return std::strcmp(a->name, b->name) < 0;
+		return a->name < b->name;
 	});
-
+	std::string label;
 	for (auto mod : modules) {
-		if (ImGui::TreeNode(mod->name)) {
+		label = mod->name;
+		if (ImGui::TreeNode(label.c_str())) {
 			for (int j = 0; j < mod->numFunctions; j++) {
 				auto &func = mod->funcTable[j];
 				ImGui::Text("%s(%s)", func.name, func.argmask);

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -615,16 +615,18 @@ namespace MainWindow
 		case WM_SETCURSOR:
 			if ((lParam & 0xFFFF) == HTCLIENT && g_Config.bShowImDebugger) {
 				LPTSTR win32_cursor = 0;
-				switch (ImGui_ImplPlatform_GetCursor()) {
-				case ImGuiMouseCursor_Arrow:        win32_cursor = IDC_ARROW; break;
-				case ImGuiMouseCursor_TextInput:    win32_cursor = IDC_IBEAM; break;
-				case ImGuiMouseCursor_ResizeAll:    win32_cursor = IDC_SIZEALL; break;
-				case ImGuiMouseCursor_ResizeEW:     win32_cursor = IDC_SIZEWE; break;
-				case ImGuiMouseCursor_ResizeNS:     win32_cursor = IDC_SIZENS; break;
-				case ImGuiMouseCursor_ResizeNESW:   win32_cursor = IDC_SIZENESW; break;
-				case ImGuiMouseCursor_ResizeNWSE:   win32_cursor = IDC_SIZENWSE; break;
-				case ImGuiMouseCursor_Hand:         win32_cursor = IDC_HAND; break;
-				case ImGuiMouseCursor_NotAllowed:   win32_cursor = IDC_NO; break;
+				if (g_Config.bShowImDebugger) {
+					switch (ImGui_ImplPlatform_GetCursor()) {
+					case ImGuiMouseCursor_Arrow:        win32_cursor = IDC_ARROW; break;
+					case ImGuiMouseCursor_TextInput:    win32_cursor = IDC_IBEAM; break;
+					case ImGuiMouseCursor_ResizeAll:    win32_cursor = IDC_SIZEALL; break;
+					case ImGuiMouseCursor_ResizeEW:     win32_cursor = IDC_SIZEWE; break;
+					case ImGuiMouseCursor_ResizeNS:     win32_cursor = IDC_SIZENS; break;
+					case ImGuiMouseCursor_ResizeNESW:   win32_cursor = IDC_SIZENESW; break;
+					case ImGuiMouseCursor_ResizeNWSE:   win32_cursor = IDC_SIZENWSE; break;
+					case ImGuiMouseCursor_Hand:         win32_cursor = IDC_HAND; break;
+					case ImGuiMouseCursor_NotAllowed:   win32_cursor = IDC_NO; break;
+					}
 				}
 				if (win32_cursor) {
 					SetCursor(::LoadCursor(nullptr, win32_cursor));


### PR DESCRIPTION
We have a convenient way to automatically log parameters of HLE syscalls. Unfortunately it breaks down when one syscall calls another.

This fixes that by introducing "hleCall()", and imposing some new rules. To make this work, i've had to fix a LOT of logging inconsistencies and cleaned things up.

Long term this is probably worth it for more accurate logs.

~~Also unbreaks Tekken 6 which I accidentally broke recently.~~ (edit: fixed separately in #19895 )