### PR TITLE
Infrastructure: Don't connect to adhoc unless infra-dns.json tells us to

### DIFF
--- a/Core/Dialog/PSPNetconfDialog.cpp
+++ b/Core/Dialog/PSPNetconfDialog.cpp
@@ -177,7 +177,6 @@ int PSPNetconfDialog::Update(int animSpeed) {
 			else if (state == PSP_NET_APCTL_STATE_DISCONNECTED) {
 				// When connecting with infrastructure, simulate a connection using the first network configuration entry.
 				if (connResult < 0) {
-					// connResult = sceNetApctlConnect(1);
 					connResult = hleCall(sceNetApctl, int, sceNetApctlConnect, 1);
 				}
 			}

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1372,7 +1372,7 @@ int friendFinder() {
 		if (metasocket == (int)INVALID_SOCKET && netAdhocctlInited && isAdhocctlNeedLogin) {
 			if (g_Config.bEnableWlan) {
 				if (initNetwork(&product_code) == 0) {
-					networkInited = true;
+					g_adhocServerConnected = true;
 					INFO_LOG(Log::sceNet, "FriendFinder: Network [RE]Initialized");
 					// At this point we are most-likely not in a Group within the Adhoc Server, so we should probably reset AdhocctlState
 					adhocctlState = ADHOCCTL_STATE_DISCONNECTED;
@@ -1380,7 +1380,7 @@ int friendFinder() {
 					isAdhocctlBusy = false;
 				} 
 				else {
-					networkInited = false;
+					g_adhocServerConnected = false;
 					shutdown((int)metasocket, SD_BOTH);
 					closesocket((int)metasocket);
 					metasocket = (int)INVALID_SOCKET;
@@ -1390,7 +1390,7 @@ int friendFinder() {
 		// Prevent retrying to Login again unless it was on demand
 		isAdhocctlNeedLogin = false;
 
-		if (networkInited) {
+		if (g_adhocServerConnected) {
 			// Ping Server
 			now = time_now_d() * 1000000.0; // Use time_now_d()*1000000.0 instead of CoreTiming::GetGlobalTimeUsScaled() if the game gets disconnected from AdhocServer too soon when FPS wasn't stable
 			// original code : ((sceKernelGetSystemTimeWide() - lastping) >= ADHOCCTL_PING_TIMEOUT)
@@ -1406,7 +1406,7 @@ int friendFinder() {
 					if (iResult == SOCKET_ERROR) {
 						ERROR_LOG(Log::sceNet, "FriendFinder: Socket Error (%i) when sending OPCODE_PING", error);
 						if (error != EAGAIN && error != EWOULDBLOCK) {
-							networkInited = false;
+							g_adhocServerConnected = false;
 							shutdown((int)metasocket, SD_BOTH);
 							closesocket((int)metasocket);
 							metasocket = (int)INVALID_SOCKET;

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1673,7 +1673,7 @@ static u32 sceMpegFinish()
 		// TODO: Need to properly hook module load/unload for this to work right.
 		//return ERROR_MPEG_NOT_YET_INIT;
 	} else {
-		INFO_LOG(Log::ME, "sceMpegFinish(...)");
+		INFO_LOG(Log::ME, "sceMpegFinish()");
 		__VideoPmpShutdown();
 	}
 	isMpegInit = false;

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -1317,6 +1317,10 @@ int NetApctl_GetState() {
 	return netApctlState;
 }
 
+bool __NetApctlConnected() {
+	return netApctlState >= PSP_NET_APCTL_STATE_GOT_IP;
+}
+
 static int sceNetApctlGetState(u32 pStateAddr) {
 	//if (!netApctlInited) return hleLogError(Log::sceNet, ERROR_NET_APCTL_NOT_IN_BSS, "apctl not in bss");
 

--- a/Core/HLE/sceNet.h
+++ b/Core/HLE/sceNet.h
@@ -109,7 +109,7 @@ private:
 };
 
 extern bool netInited;
-extern bool netApctlInited;
+extern bool g_netApctlInited;
 extern u32 netApctlState;
 extern SceNetApctlInfoInternal netApctlInfo;
 extern std::string defaultNetConfigName;
@@ -126,6 +126,10 @@ void __NetShutdown();
 void __NetDoState(PointerWrap &p);
 
 int NetApctl_GetState();
+
+inline bool __NetApctlConnected() {
+	return netApctlState >= PSP_NET_APCTL_STATE_GOT_IP;
+}
 
 int sceNetApctlConnect(int connIndex);
 
@@ -154,6 +158,8 @@ struct InfraDNSConfig {
 
 	std::string revivalTeam;
 	std::string revivalTeamURL;
+
+	bool connectAdHocForGrouping;
 };
 
 extern InfraDNSConfig g_infraDNSConfig;

--- a/Core/HLE/sceNet.h
+++ b/Core/HLE/sceNet.h
@@ -127,9 +127,7 @@ void __NetDoState(PointerWrap &p);
 
 int NetApctl_GetState();
 
-inline bool __NetApctlConnected() {
-	return netApctlState >= PSP_NET_APCTL_STATE_GOT_IP;
-}
+bool __NetApctlConnected();
 
 int sceNetApctlConnect(int connIndex);
 

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -128,7 +128,6 @@ void ZeroNetAdhocMatchingThreads();
 void SaveNetAdhocMatchingInited();
 void RestoreNetAdhocMatchingInited();
 
-
 bool __NetAdhocConnected() {
 	return netAdhocInited && netAdhocctlInited && (adhocctlState == ADHOCCTL_STATE_CONNECTED || adhocctlState == ADHOCCTL_STATE_GAMEMODE);
 }
@@ -1278,8 +1277,9 @@ int sceNetAdhocctlInit(int stackSize, int prio, u32 productAddr) {
 	// FIXME: Returning 0x8002013a (SCE_KERNEL_ERROR_LIBRARY_NOT_YET_LINKED) without adhoc module loaded first?
 	// FIXME: Sometimes returning 0x80410601 (ERROR_NET_ADHOC_AUTH_ALREADY_INITIALIZED / Library module is already initialized ?) when AdhocctlTerm is not fully done?
 
-	if (netAdhocctlInited)
+	if (netAdhocctlInited) {
 		return hleLogError(Log::sceNet, ERROR_NET_ADHOCCTL_ALREADY_INITIALIZED);
+	}
 
 	auto product = PSPPointer<SceNetAdhocctlAdhocId>::Create(productAddr);
 	if (product.IsValid()) {

--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -106,7 +106,7 @@ void __UpdateAdhocctlHandlers(u32 flags, u32 error);
 
 bool __NetAdhocConnected();
 
-// Called from netdialog
+// Called from netdialog (and from sceNetApctl)
 // NOTE: use hleCall for sceNet* ones!
 int sceNetAdhocctlGetState(u32 ptrToStatus);
 int sceNetAdhocctlCreate(const char * groupName);
@@ -116,6 +116,7 @@ int sceNetAdhocctlScan();
 int sceNetAdhocctlGetScanInfo(u32 sizeAddr, u32 bufAddr);
 int sceNetAdhocctlDisconnect();
 int sceNetAdhocctlInit(int stackSize, int prio, u32 productAddr);
+int sceNetAdhocctlTerm();
 
 int NetAdhocctl_Term();
 int NetAdhocctl_GetState();

--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -125,7 +125,7 @@ int NetAdhoc_Term();
 // May need to use these from sceNet.cpp
 extern bool netAdhocInited;
 extern bool netAdhocctlInited;
-extern bool networkInited;
+extern bool g_adhocServerConnected;
 extern bool netAdhocGameModeEntered;
 extern int netAdhocEnterGameModeTimeout;
 extern int adhocDefaultTimeout; //3000000 usec

--- a/Core/HLE/sceNetInet.h
+++ b/Core/HLE/sceNetInet.h
@@ -117,7 +117,7 @@ class PointerWrap;
 
 extern bool netInited;
 extern bool netInetInited;
-extern bool netApctlInited;
+extern bool g_netApctlInited;
 extern u32 netApctlState;
 extern SceNetApctlInfoInternal netApctlInfo;
 extern std::string defaultNetConfigName;

--- a/Core/HLE/sceNetResolver.cpp
+++ b/Core/HLE/sceNetResolver.cpp
@@ -67,11 +67,7 @@ static std::mutex g_netResolversLock;  // Do we really need this?
 static bool g_netResolverInitialized = true;
 
 static int sceNetResolverInit() {
-	// TODO: Move this to infra-jns.config! This isn't ok.
-	// However obviously don't remove the mHostToAlias mechanism.
-	g_Config.mHostToAlias["socomftb2.psp.online.scea.com"] = "67.222.156.250";
-	g_Config.mHostToAlias["socompsp-prod.muis.pdonline.scea.com"] = "67.222.156.250";
-
+	// Hardcoded mHostToAlias entries here have been moved to the infra-dns.json file.
 	return hleLogSuccessInfoI(Log::sceNet, 0);
 }
 

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -44,6 +44,7 @@
 #include "Core/HLE/sceUmd.h"
 #include "Core/HLE/sceNet.h"
 #include "Core/HLE/sceNetInet.h"
+#include "Core/HLE/sceNetAdhoc.h"
 
 #include "GPU/GPUCommon.h"
 #include "GPU/GPUState.h"
@@ -277,11 +278,12 @@ void GamePauseScreen::update() {
 		finishNextFrame_ = false;
 	}
 
-	if (netInited != lastNetInited_ || netInetInited != lastNetInetInited_) {
+	if (netInited != lastNetInited_ || netInetInited != lastNetInetInited_ || lastAdhocServerConnected_ != g_adhocServerConnected) {
 		INFO_LOG(Log::sceNet, "Network status changed, recreating views");
 		RecreateViews();
 		lastNetInetInited_ = netInetInited;
 		lastNetInited_ = netInited;
+		lastAdhocServerConnected_ = g_adhocServerConnected;
 	}
 
 	bool mustRunBehind = MustRunBehind();
@@ -384,7 +386,7 @@ void GamePauseScreen::CreateViews() {
 		}
 	}
 
-	if (netInited) {
+	if (netInited || g_adhocServerConnected) {
 		leftColumnItems->Add(new NoticeView(NoticeLevel::INFO, nw->T("Network connected"), ""));
 
 		if (!g_infraDNSConfig.revivalTeam.empty() && netInetInited) {
@@ -398,6 +400,10 @@ void GamePauseScreen::CreateViews() {
 					return UI::EVENT_DONE;
 				});
 			}
+		}
+
+		if (g_adhocServerConnected) {
+			leftColumnItems->Add(new TextView(std::string(nw->T("AdHoc Server")) + ": " + std::string(nw->T("Connected"))));
 		}
 	}
 

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -66,4 +66,5 @@ private:
 	UI::Button *playButton_ = nullptr;
 	bool lastNetInited_ = false;
 	bool lastNetInetInited_ = false;
+	bool lastAdhocServerConnected_ = false;
 };

--- a/assets/infra-dns.json
+++ b/assets/infra-dns.json
@@ -159,7 +159,11 @@
 				"UCUS98615",
 				"UCES00038"
 			],
-			"score": 4
+			"score": 4,
+			"domains": {
+				"socomftb2.psp.online.scea.com": "67.222.156.250",
+				"socompsp-prod.muis.pdonline.scea.com": "67.222.156.250"
+			}
 		},
 		{
 			"name": "SOCOM Fireteam Bravo 2",
@@ -167,7 +171,15 @@
 				"UCUS98645",
 				"UCES00543"
 			],
-			"score": 4
+			"other_ids": [
+				"UCKS45043",
+				"UCUS80171"
+			],
+			"score": 4,
+			"domains": {
+				"socomftb2.psp.online.scea.com": "67.222.156.250",
+				"socompsp-prod.muis.pdonline.scea.com": "67.222.156.250"
+			}
 		},
 		{
 			"name": "SOCOM Tactical Strike",
@@ -175,7 +187,14 @@
 				"UCUS98649",
 				"UCES00855"
 			],
-			"score": 3
+			"other_ids": [
+				"NPUG80220"
+			],
+			"score": 3,
+			"domains": {
+				"socomftb2.psp.online.scea.com": "67.222.156.250",
+				"socompsp-prod.muis.pdonline.scea.com": "67.222.156.250"
+			}
 		},
 		{
 			"name": "Syphon Filter: Dark Mirror",

--- a/assets/infra-dns.json
+++ b/assets/infra-dns.json
@@ -209,6 +209,23 @@
 				"ULUS10235",
 				"ULES00740"
 			],
+			"score": 5,
+			"connect_adhoc_for_grouping": true
+		},
+		{
+			"name": "Rocky Balboa",
+			"other_ids": [
+				"ULES00670"
+			],
+			"score": 0,
+			"connect_adhoc_for_grouping": true
+		},
+		{
+			"name": "Onore no Shinzuru",
+			"other_ids": [
+				"ULJM05465"
+			],
+			"score": 0,
 			"connect_adhoc_for_grouping": true
 		}
 	]

--- a/assets/infra-dns.json
+++ b/assets/infra-dns.json
@@ -133,7 +133,7 @@
 		},
 		{
 			"name": "Ratchet & Clank - Size Matters",
-			"dns": "67.222.156.251",
+			"dns": "67.222.156.250",
 			"other_ids": [
 				"UCES00420",
 				"UCUS98633"
@@ -151,6 +151,46 @@
 			"revival_credits": {
 				"group": "OutRun2006Tweaks"
 			}
+		},
+		{
+			"name": "SOCOM Fireteam Bravo",
+			"known_working_ids": [
+				"UCKS45021",
+				"UCUS98615",
+				"UCES00038"
+			],
+			"score": 4
+		},
+		{
+			"name": "SOCOM Fireteam Bravo 2",
+			"known_working_ids": [
+				"UCUS98645",
+				"UCES00543"
+			],
+			"score": 4
+		},
+		{
+			"name": "SOCOM Tactical Strike",
+			"known_working_ids": [
+				"UCUS98649",
+				"UCES00855"
+			],
+			"score": 3
+		},
+		{
+			"name": "Syphon Filter: Dark Mirror",
+			"known_working_ids": [
+				"UCUS98641"
+			],
+			"score": 5
+		},
+		{
+			"name": "Driver '76",
+			"known_working_ids": [
+				"ULUS10235",
+				"ULES00740"
+			],
+			"connect_adhoc_for_grouping": true
 		}
 	]
 }


### PR DESCRIPTION
Need your opinion @anr2me !

In my (limited) testing, forcibly connecting to adhoc for grouping just isn't necessary. But I haven't tested all games yet.

Maybe should add a manual setting?