### PR TITLE
Notifications: Allow controlling screen position

### DIFF
--- a/Common/System/OSD.cpp
+++ b/Common/System/OSD.cpp
@@ -69,6 +69,12 @@ void OnScreenDisplay::ClickEntry(size_t index, double now) {
 }
 
 void OnScreenDisplay::Show(OSDType type, std::string_view text, std::string_view text2, std::string_view icon, float duration_s, const char *id) {
+	if (text.empty()) {
+		// The user hacked the translation files to get rid of the message. Let's reward the dedication
+		// by skipping it entirely.
+		return;
+	}
+
 	// Automatic duration based on type.
 	if (duration_s <= 0.0f) {
 		switch (type) {

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -315,6 +315,7 @@ static const ConfigSetting generalSettings[] = {
 
 	ConfigSetting("MemStickInserted", &g_Config.bMemStickInserted, true, CfgFlag::PER_GAME | CfgFlag::REPORT),
 	ConfigSetting("LoadPlugins", &g_Config.bLoadPlugins, true, CfgFlag::PER_GAME),
+	ConfigSetting("NotificationPos", &g_Config.iNotificationPos, (int)ScreenEdgePosition::TOP_CENTER, CfgFlag::DEFAULT),
 
 	ConfigSetting("IgnoreCompatSettings", &g_Config.sIgnoreCompatSettings, "", CfgFlag::PER_GAME | CfgFlag::REPORT),
 

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -555,6 +555,7 @@ public:
 	bool bAchievementsEnableRAIntegration;
 
 	// Positioning of the various notifications
+	int iNotificationPos;
 	int iAchievementsLeaderboardTrackerPos;
 	int iAchievementsLeaderboardStartedOrFailedPos;
 	int iAchievementsLeaderboardSubmittedPos;

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -808,15 +808,16 @@ static int sceNetInit(u32 poolSize, u32 calloutPri, u32 calloutStack, u32 netini
 	auto n = GetI18NCategory(I18NCat::NETWORKING);
 
 	std::string msg(n->T("Network initialized"));
-	if (g_Config.bInfrastructureAutoDNS) {
-		msg += ": ";
-		msg += n->T("Auto DNS");
-		if (!g_infraDNSConfig.gameName.empty()) {
-			msg += " (" + g_infraDNSConfig.gameName + ")";
+	if (!msg.empty()) {
+		if (g_Config.bInfrastructureAutoDNS) {
+			msg += ": ";
+			msg += n->T("Auto DNS");
+			if (!g_infraDNSConfig.gameName.empty()) {
+				msg += " (" + g_infraDNSConfig.gameName + ")";
+			}
 		}
+		g_OSD.Show(OSDType::MESSAGE_INFO, msg, 2.0, "networkinit");
 	}
-
-	g_OSD.Show(OSDType::MESSAGE_INFO, msg, 2.0, "networkinit");
 	return hleLogSuccessI(Log::sceNet, 0);
 }
 

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -116,7 +116,12 @@ void TextureReplacer::NotifyConfigChanged() {
 		// Somewhat crude message, re-using translation strings.
 		auto d = GetI18NCategory(I18NCat::DEVELOPER);
 		auto di = GetI18NCategory(I18NCat::DIALOG);
-		g_OSD.Show(OSDType::MESSAGE_INFO, std::string(d->T("Save new textures")) + ": " + std::string(di->T("Enabled")), 2.0f);
+		std::string str(d->T("Save new textures"));
+		if (!str.empty()) {
+			str.append(": ");
+			str.append(di->T("Enabled"));
+			g_OSD.Show(OSDType::MESSAGE_INFO, str, 2.0f);
+		}
 	}
 }
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1117,6 +1117,11 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 
 	systemSettings->Add(new CheckBox(&g_Config.bTransparentBackground, sy->T("Transparent UI background")));
 
+	// Shared with achievements.
+	static const char *positions[] = { "None", "Bottom Left", "Bottom Center", "Bottom Right", "Top Left", "Top Center", "Top Right", "Center Left", "Center Right" };
+
+	systemSettings->Add(new PopupMultiChoice(&g_Config.iNotificationPos, sy->T("Notification screen position"), positions, -1, ARRAY_SIZE(positions), I18NCat::DIALOG, screenManager()));
+
 	static const char *backgroundAnimations[] = { "No animation", "Floating symbols", "Recent games", "Waves", "Moving background" };
 	systemSettings->Add(new PopupMultiChoice(&g_Config.iBackgroundAnimation, sy->T("UI background animation"), backgroundAnimations, 0, ARRAY_SIZE(backgroundAnimations), I18NCat::SYSTEM, screenManager()));
 

--- a/UI/OnScreenDisplay.cpp
+++ b/UI/OnScreenDisplay.cpp
@@ -288,9 +288,9 @@ void OnScreenMessagesView::Draw(UIContext &dc) {
 	edges[(size_t)ScreenEdgePosition::TOP_CENTER].alpha = 1.0f;
 
 	ScreenEdgePosition typeEdges[(size_t)OSDType::VALUE_COUNT]{};
-	// Default to top.
+	// Default to the configured position.
 	for (int i = 0; i < (size_t)OSDType::VALUE_COUNT; i++) {
-		typeEdges[i] = ScreenEdgePosition::TOP_CENTER;
+		typeEdges[i] = (ScreenEdgePosition)g_Config.iNotificationPos;
 	}
 
 	typeEdges[(size_t)OSDType::ACHIEVEMENT_CHALLENGE_INDICATOR] = (ScreenEdgePosition)g_Config.iAchievementsChallengePos;

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -1355,6 +1355,7 @@ Moving background = خلفية متحركة
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = ‎PSP ليست لعبة
+Notification screen position = Notification screen position
 Off = ‎مغلق
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Not a PSP game
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Not a PSP game
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Not a PSP game
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Toto není hra PSP
+Notification screen position = Notification screen position
 Off = Vypnuto
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Not a PSP game
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Neuester Spielstand
 No animation = No animation
 Not a PSP game = Kein PSP Spiel
+Notification screen position = Notification screen position
 Off = Aus
 Oldest Save = Ältester Spielstand
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Not a PSP game
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -1361,6 +1361,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Not a PSP game
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -1348,6 +1348,7 @@ Moving background = Fondo en movimiento
 Newest Save = Partida guardada más reciente
 No animation = Sin animación
 Not a PSP game = No es un juego de PSP
+Notification screen position = Notification screen position
 Off = No
 Oldest Save = Partida guardada más antigua
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -1349,6 +1349,7 @@ Moving background = Fondo en movimiento
 Newest Save = Nuevos datos de guardado
 No animation = Sin animación
 Not a PSP game = No es un juego de PSP
+Notification screen position = Notification screen position
 Off = No
 Oldest Save = Antiguos datos de guardado
 Only JPG and PNG images are supported = Sólo se admiten imágenes JPG y PNG

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -1347,6 +1347,7 @@ Moving background = پس زمینه فیلم
 Newest Save = جدید ترین ذخیره سازی
 No animation = بدون انمیشین
 Not a PSP game = ‎نیست PSP بازی
+Notification screen position = Notification screen position
 Off = ‎خاموش
 Oldest Save = قدیمی ترین ذخیره
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -1347,6 +1347,7 @@ Moving background = Liikkuva tausta
 Newest Save = Uusin tallennus
 No animation = Ei animaatiota
 Not a PSP game = Ei PSP-peli
+Notification screen position = Notification screen position
 Off = Pois
 Oldest Save = Vanhin tallennus
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -1338,6 +1338,7 @@ Moving background = Moving background
 Newest Save = Le plus récent état
 No animation = No animation
 Not a PSP game = Ce n'est pas un jeu PSP.
+Notification screen position = Notification screen position
 Off = Désactivé
 Oldest Save = Le plus ancien état
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Not a PSP game
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Νεότερο αρχείο αποθήκευσης
 No animation = No animation
 Not a PSP game = Δεν είναι παιχνίδι PSP
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Παλαιότερο αρχείο αποθήκευσης
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Not a PSP game
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Not a PSP game
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Najnoviji save
 No animation = No animation
 Not a PSP game = Nije PSP igra
+Notification screen position = Notification screen position
 Off = Isključeno
 Oldest Save = Najstariji save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -1347,6 +1347,7 @@ Moving background = Mozgó háttér
 Newest Save = Legújabb mentés
 No animation = Nincs animáció
 Not a PSP game = Nem egy PSP játék
+Notification screen position = Notification screen position
 Off = Ki
 Oldest Save = Legrégebbi mentés
 Only JPG and PNG images are supported = Csak JPG és PNG képek támogatottak.

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -1347,6 +1347,7 @@ Moving background = Latar belakang bergerak
 Newest Save = Simpanan terbaru
 No animation = Tanpa animasi
 Not a PSP game = Bukan permainan PSP
+Notification screen position = Notification screen position
 Off = Mati
 Oldest Save = Simpanan lawas
 Only JPG and PNG images are supported = Hanya gambar JPG dan PNG yang didukung

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -1332,6 +1332,7 @@ Fast Memory = Memoria Rapida (instabile)
 Force real clock sync (slower, less lag) = Forza sincronizzazione con frequenza reale (lento, meno lag)
 Moving background = Spostamento dello sfondo
 No animation = Nessuna animazione
+Notification screen position = Notification screen position
 Only JPG and PNG images are supported = Sono supportate solo immagini JPG e PNG
 Path does not exist! = Il percorso non esiste!
 Pause when not focused = Pausa quando non attivo

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = 最も新しいセーブ
 No animation = アニメーションなし
 Not a PSP game = PSPのゲームではありません
+Notification screen position = Notification screen position
 Off = オフ
 Oldest Save = 最も古いセーブ
 Only JPG and PNG images are supported = JPGとPNG画像のみ対応しています

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Ora ana dolanan PSP
+Notification screen position = Notification screen position
 Off = Mati
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -1337,6 +1337,7 @@ Moving background = 움직이는 배경
 Newest Save = 가장 최신 저장
 No animation = 애니메이션 없음
 Not a PSP game = PSP 게임이 아님
+Notification screen position = Notification screen position
 Off = 끔
 Oldest Save = 가장 오래된 저장
 Only JPG and PNG images are supported = JPG 및 PNG 이미지만 지원됩니다.

--- a/assets/lang/ku_SO.ini
+++ b/assets/lang/ku_SO.ini
@@ -1351,6 +1351,7 @@ Moving background = باکگراوندی جوڵاو
 Newest Save = Newest save
 No animation = بەبێ ئەنیمەیشن
 Not a PSP game = Not a PSP game
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = ອັນນີ້ບໍ່ແມ່ນເກມ PSP
+Notification screen position = Notification screen position
 Off = ປິດ
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Not a PSP game
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Not a PSP game
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Geen PSP-game
+Notification screen position = Notification screen position
 Off = Uit
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Not a PSP game
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -1352,6 +1352,7 @@ Moving background = Ruchome tło
 Newest Save = Najnowszy zapis
 No animation = Bez animacji
 Not a PSP game = To nie jest gra PSP
+Notification screen position = Notification screen position
 Off = Wył.
 Oldest Save = Najstarszy zapis
 Only JPG and PNG images are supported = Tylko pliki JPG i PNG są wspierane

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -1361,6 +1361,7 @@ Moving background = Movendo o cenário de fundo
 Newest Save = Save mais novo
 No animation = Sem animação
 Not a PSP game = Não é um jogo de PSP
+Notification screen position = Notification screen position
 Off = Desligado
 Oldest Save = Save mais antigo
 Only JPG and PNG images are supported = Só imagens JPGs e PNGs são suportadas

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -1363,6 +1363,7 @@ Moving background = Movendo o cenário de fundo
 Newest Save = Salvamento mais novo
 No animation = Sem animação
 Not a PSP game = Não é um jogo de PSP
+Notification screen position = Notification screen position
 Off = Desativado
 Oldest Save = Salvamento mais antigo
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -1348,6 +1348,7 @@ Moving background = Moving background
 Newest Save = Newest save
 No animation = No animation
 Not a PSP game = Nu e joc PSP
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Oldest save
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -1347,6 +1347,7 @@ Moving background = Двигающийся фон
 Newest Save = Самое новое сохранение
 No animation = Нет анимации
 Not a PSP game = Игра не для PSP
+Notification screen position = Notification screen position
 Off = Отключено
 Oldest Save = Самое старое сохранение
 Only JPG and PNG images are supported = Поддерживаются только изображения в формате JPG и PNG

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -1348,6 +1348,7 @@ Moving background = Rörlig bakgrund
 Newest Save = Nyaste sparfilen
 No animation = Ingen animation
 Not a PSP game = Inte ett PSP-spel
+Notification screen position = Notification screen position
 Off = Off
 Oldest Save = Äldsta sparfilen
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -1350,6 +1350,7 @@ Moving background = Gumagalaw na larawan
 Newest Save = Pinakabagong na i-save
 No animation = Walang animation
 Not a PSP game = Hindi PSP game
+Notification screen position = Notification screen position
 Off = Nakapatay
 Oldest Save = Pinakalumang na i-save
 Only JPG and PNG images are supported = Tanging ang mga JPG at PNG na mga imahe ang sinusuportahan

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -1385,6 +1385,7 @@ Moving background = พื้นหลังเคลื่อนไหว
 Newest Save = เซฟอันใหม่สุด
 No animation = ไม่แสดงอนิเมชั่น
 Not a PSP game = นี่ไม่ใช่เกม PSP นะจ้ะ
+Notification screen position = Notification screen position
 Off = ปิด
 Oldest Save = เซฟอันเก่าสุด
 Only JPG and PNG images are supported = รองรับเฉพาะไฟล์รูปภาพนามสกุล JPG และ PNG

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -1348,6 +1348,7 @@ Moving background = hareketli arka plan
 Newest Save = En yeni kayıt
 No animation = animasyon yok
 Not a PSP game = Bir PSP oyunu değil
+Notification screen position = Notification screen position
 Off = Kapalı
 Oldest Save = En eski kayıt
 Only JPG and PNG images are supported = Sadece JPG ve PNG resimleri desteklenir

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -1347,6 +1347,7 @@ Moving background = Рухомий фон
 Newest Save = Найновіші збереження
 No animation = Без анімації
 Not a PSP game = Не є грою для PSP
+Notification screen position = Notification screen position
 Off = Вимкнено
 Oldest Save = Найстаріші збереження
 Only JPG and PNG images are supported = Підтримуються лише зображення JPG і PNG

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -1347,6 +1347,7 @@ Moving background = Moving background
 Newest Save = Save mới nhất
 No animation = No animation
 Not a PSP game = Đây Không phải là game PSP
+Notification screen position = Notification screen position
 Off = Tắt
 Oldest Save = Save cũ nhất
 Only JPG and PNG images are supported = Only JPG and PNG images are supported

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -1288,6 +1288,7 @@ JIT using IR = 动态重编译 (IR模式)
 Loaded plugin: %1 = 已加载插件: %1
 Memory Stick in installed.txt = 记忆棒目录使用“installed.txt”
 Memory Stick in My Documents = 记忆棒目录使用“我的文档”
+Notification screen position = Notification screen position
 Only JPG and PNG images are supported = 只支持JPG和PNG图片
 Pause when not focused = 后台运行时自动暂停
 Plugins = 插件

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -1337,6 +1337,7 @@ Moving background = 動態背景
 Newest Save = 最新存檔
 No animation = 靜態背景
 Not a PSP game = 這不是 PSP 遊戲
+Notification screen position = Notification screen position
 Off = 關閉
 Oldest Save = 最舊存檔
 Only JPG and PNG images are supported = 僅支援 JPG 和 PNG 影像


### PR DESCRIPTION
New setting on the System tab, notification position.

Also eliminates notifications with missing translation strings, for people who are annoyed enough to be willing to hack the translation files.

Design changes for certain notification like speed changes coming later.