### PR TITLE
libretro: windows build fix

### DIFF
--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -1007,6 +1007,8 @@ SOURCES_CXX += \
 	$(COMMONDIR)/GPU/D3D11/D3D11Loader.cpp \
 	$(COMMONDIR)/GPU/D3D11/thin3d_d3d11.cpp
 
+INCFLAGS += -I$(CORE_DIR)/dx9sdk/Include -I$(CORE_DIR)/dx9sdk/Include/DX11
+
 endif
 
 SOURCES_CXX += \


### PR DESCRIPTION
(Very) partial revert of 2d9f5ecc8f3b846a6bf122f76267cb0097eedac1; it seems the libretro windows builder does not have `<wrl/client.h>` in its include paths by default.

<https://git.libretro.com/libretro/ppsspp/-/pipelines/330468>