### PR TITLE
ImDebugger: Send inputs to the game when no windows are focused

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1023,16 +1023,34 @@ bool EmuScreen::UnsyncKey(const KeyInput &key) {
 			// Enable gamepad controls while running imgui (but ignore mouse/keyboard).
 			switch (key.deviceId) {
 			case DEVICE_ID_KEYBOARD:
+				if (!ImGui::GetIO().WantCaptureKeyboard) {
+					controlMapper_.Key(key, &pauseTrigger_);
+				}
+				break;
 			case DEVICE_ID_MOUSE:
+				if (!ImGui::GetIO().WantCaptureMouse) {
+					controlMapper_.Key(key, &pauseTrigger_);
+				}
 				break;
 			default:
 				controlMapper_.Key(key, &pauseTrigger_);
+				break;
 			}
 		}
 
 		return UIScreen::UnsyncKey(key);
 	}
 	return controlMapper_.Key(key, &pauseTrigger_);
+}
+
+void EmuScreen::UnsyncAxis(const AxisInput *axes, size_t count) {
+	System_Notify(SystemNotification::ACTIVITY);
+
+	if (UI::IsFocusMovementEnabled()) {
+		return UIScreen::UnsyncAxis(axes, count);
+	}
+
+	return controlMapper_.Axis(axes, count);
 }
 
 bool EmuScreen::key(const KeyInput &key) {
@@ -1060,16 +1078,6 @@ void EmuScreen::touch(const TouchInput &touch) {
 	} else {
 		UIScreen::touch(touch);
 	}
-}
-
-void EmuScreen::UnsyncAxis(const AxisInput *axes, size_t count) {
-	System_Notify(SystemNotification::ACTIVITY);
-
-	if (UI::IsFocusMovementEnabled()) {
-		return UIScreen::UnsyncAxis(axes, count);
-	}
-
-	return controlMapper_.Axis(axes, count);
 }
 
 class GameInfoBGView : public UI::InertView {


### PR DESCRIPTION
Click the background to defocus all windows.

Makes it a lot more convenient to watch ImDebugger windows while playing the game - no need for a gamepad anymore.