### PR TITLE
Don't disable savestates just because adhoc is "inited"

### DIFF
--- a/Core/Dialog/PSPDialog.cpp
+++ b/Core/Dialog/PSPDialog.cpp
@@ -15,6 +15,7 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+#include <algorithm>
 #include "Common/Data/Text/I18n.h"
 
 #include "Common/Serialize/Serializer.h"

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -64,8 +64,9 @@ static struct SceNetMallocStat netMallocStat;
 
 static std::map<int, ApctlHandler> apctlHandlers;
 
-std::string defaultNetConfigName = "NetConf";
-std::string defaultNetSSID = "Wifi"; // fake AP/hotspot
+const char * const defaultNetConfigName = "NetConf";
+const char * const defaultNetSSID = "Wifi"; // fake AP/hotspot
+
 int netApctlInfoId = 0;
 SceNetApctlInfoInternal netApctlInfo;
 
@@ -169,6 +170,8 @@ bool LoadDNSForGameID(std::string_view gameID, InfraDNSConfig *dns) {
 	if (!data) {
 		return false;
 	}
+
+	dns->loaded = true;
 
 	std::string_view jsonStr = std::string_view((const char *)data.get(), jsonSize);
 	json::JsonReader reader(jsonStr.data(), jsonStr.length());
@@ -979,7 +982,7 @@ void NetApctl_InitInfo(int confId) {
 	truncate_cpy(netApctlInfo.name, sizeof(netApctlInfo.name), defaultNetConfigName + std::to_string(confId));
 	truncate_cpy(netApctlInfo.ssid, sizeof(netApctlInfo.ssid), defaultNetSSID);
 	memcpy(netApctlInfo.bssid, "\1\1\2\2\3\3", sizeof(netApctlInfo.bssid)); // fake AP's mac address
-	netApctlInfo.ssidLength = static_cast<unsigned int>(defaultNetSSID.length());
+	netApctlInfo.ssidLength = static_cast<unsigned int>(strlen(defaultNetSSID));
 	netApctlInfo.strength = 99;
 	netApctlInfo.channel = g_Config.iWlanAdhocChannel;
 	if (netApctlInfo.channel == PSP_SYSTEMPARAM_ADHOC_CHANNEL_AUTOMATIC) netApctlInfo.channel = defaultWlanChannel;

--- a/Core/HLE/sceNet.h
+++ b/Core/HLE/sceNet.h
@@ -108,7 +108,7 @@ private:
 	u32_le argsAddr = 0;
 };
 
-extern bool netInited;
+extern bool g_netInited;
 extern bool g_netApctlInited;
 extern u32 netApctlState;
 extern SceNetApctlInfoInternal netApctlInfo;
@@ -130,6 +130,9 @@ int NetApctl_GetState();
 bool __NetApctlConnected();
 
 int sceNetApctlConnect(int connIndex);
+
+// Are we connected - for the purpose of disabling speed consoles and savestates etc.
+bool IsNetworkConnected();
 
 // These return false if allowed to be consistent with the similar function for achievements.
 bool NetworkWarnUserIfOnlineAndCantSavestate();

--- a/Core/HLE/sceNet.h
+++ b/Core/HLE/sceNet.h
@@ -112,8 +112,8 @@ extern bool g_netInited;
 extern bool g_netApctlInited;
 extern u32 netApctlState;
 extern SceNetApctlInfoInternal netApctlInfo;
-extern std::string defaultNetConfigName;
-extern std::string defaultNetSSID;
+extern const char * const defaultNetConfigName;
+extern const char * const defaultNetSSID;
 
 void Register_sceNet();
 void Register_sceNetApctl();
@@ -149,6 +149,7 @@ enum class InfraGameState {
 
 // Loaded an interpreted for a specific game from the JSON - doesn't represent the entire JSON.
 struct InfraDNSConfig {
+	bool loaded;
 	std::string gameName;
 	std::string dns;
 	std::string dyn_dns;

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -14,27 +14,16 @@
 
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
-
-#if defined(_WIN32)
-#include <WinSock2.h>
-#include "Common/CommonWindows.h"
-#endif
-
-#if !defined(_WIN32)
-#include <sys/types.h>
-#include <netinet/tcp.h>
-#endif
-
-#ifndef MSG_NOSIGNAL
-// Default value to 0x00 (do nothing) in systems where it's not supported.
-#define MSG_NOSIGNAL 0x00
-#endif
-
-#include <mutex>
 // sceNetAdhoc
 
 // This is a direct port of Coldbird's code from http://code.google.com/p/aemu/
 // All credit goes to him!
+
+
+#include <mutex>
+#include <string>
+
+#include "Common/Net/SocketCompat.h"
 #include "Common/Data/Text/I18n.h"
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"
@@ -88,7 +77,6 @@ int adhocMatchingEventDelay = 30000; //30000
 int adhocEventDelay = 2000000; //2000000 on real PSP ?
 
 constexpr u32 defaultLastRecvDelta = 10000; //10000 usec worked well for games published by Falcom (ie. Ys vs Sora Kiseki, Vantage Master Portable)
-
 
 SceUID threadAdhocID;
 

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1352,7 +1352,7 @@ int sceNetAdhocPdpCreate(const char *mac, int port, int bufferSize, u32 flag) {
 		return hleLogError(Log::sceNet, -1, "WLAN");
 	}
 
-	if (!netInited)
+	if (!g_netInited)
 		return hleLogError(Log::sceNet, 0x800201CA); //PSP_LWMUTEX_ERROR_NO_SUCH_LWMUTEX;
 
 	// Library is initialized

--- a/Core/HLE/sceNetAdhoc.h
+++ b/Core/HLE/sceNetAdhoc.h
@@ -20,7 +20,6 @@
 #include <deque>
 #include "Core/HLE/proAdhoc.h"
 
-
 #ifdef _MSC_VER
 #pragma pack(push,1)
 #endif
@@ -128,6 +127,8 @@ extern bool netAdhocInited;
 extern bool netAdhocctlInited;
 extern bool g_adhocServerConnected;
 extern bool netAdhocGameModeEntered;
+extern s32 netAdhocDiscoverStatus;
+
 extern int netAdhocEnterGameModeTimeout;
 extern int adhocDefaultTimeout; //3000000 usec
 extern int adhocDefaultDelay; //10000

--- a/Core/HLE/sceNetAdhocMatching.h
+++ b/Core/HLE/sceNetAdhocMatching.h
@@ -42,3 +42,5 @@ void RestoreNetAdhocMatchingInited();
 void Register_sceNetAdhocMatching();
 void __NetAdhocMatchingInit();
 void __NetAdhocMatchingShutdown();
+
+extern bool netAdhocMatchingInited;

--- a/Core/HLE/sceNetApctl.cpp
+++ b/Core/HLE/sceNetApctl.cpp
@@ -1,3 +1,16 @@
 // TODO: move apctl here
 
 #include "sceNetApctl.h"
+
+const char *ApctlStateToString(int apctlState) {
+	switch (apctlState) {
+	case PSP_NET_APCTL_STATE_DISCONNECTED: return "DISCONNECTED";
+	case PSP_NET_APCTL_STATE_SCANNING: return "SCANNING";
+	case PSP_NET_APCTL_STATE_JOINING: return "JOINING";
+	case PSP_NET_APCTL_STATE_GETTING_IP: return "GETTING_IP";
+	case PSP_NET_APCTL_STATE_GOT_IP: return "GOT_IP";
+	case PSP_NET_APCTL_STATE_EAP_AUTH: return "EAP_AUTH";
+	case PSP_NET_APCTL_STATE_KEY_EXCHANGE: return "KEY_EXCHANGE";
+	default: return "N/A";
+	}
+}

--- a/Core/HLE/sceNetApctl.h
+++ b/Core/HLE/sceNetApctl.h
@@ -27,6 +27,8 @@ enum {
 	PSP_NET_APCTL_EVENT_SCAN_STOP = 11 // FIXME: not sure what this is, MGS:PW seems to check this value within ApctlHandler during Recruit, related to sceNetApctlScanSSID2 ?
 };
 
+const char *ApctlStateToString(int apctlState);
+
 #define 	PSP_NET_APCTL_INFO_PROFILE_NAME			0
 #define 	PSP_NET_APCTL_INFO_BSSID				1
 #define 	PSP_NET_APCTL_INFO_SSID					2

--- a/Core/HLE/sceNetInet.h
+++ b/Core/HLE/sceNetInet.h
@@ -115,7 +115,7 @@ typedef struct InetSocket {
 
 class PointerWrap;
 
-extern bool netInited;
+extern bool g_netInited;
 extern bool netInetInited;
 extern bool g_netApctlInited;
 extern u32 netApctlState;

--- a/Core/HLE/sceNetInet.h
+++ b/Core/HLE/sceNetInet.h
@@ -120,8 +120,8 @@ extern bool netInetInited;
 extern bool g_netApctlInited;
 extern u32 netApctlState;
 extern SceNetApctlInfoInternal netApctlInfo;
-extern std::string defaultNetConfigName;
-extern std::string defaultNetSSID;
+extern const char *const defaultNetConfigName;
+extern const char *const defaultNetSSID;
 
 void Register_sceNetInet();
 

--- a/Core/HLE/scePspNpDrm_user.cpp
+++ b/Core/HLE/scePspNpDrm_user.cpp
@@ -5,37 +5,33 @@
 #include "Core/HLE/sceIo.h"
 
 static int sceNpDrmSetLicenseeKey(u32 npDrmKeyAddr) {
-	WARN_LOG(Log::HLE, "UNIMPL: sceNpDrmSetLicenseeKey(%08x)", npDrmKeyAddr);
-	return 0;
+	return hleLogWarning(Log::HLE, 0, "UNIMPL");
 }
 
 static int sceNpDrmClearLicenseeKey() {
-	WARN_LOG(Log::HLE, "UNIMPL: sceNpDrmClearLicenseeKey()");
-	return 0;
+	return hleLogWarning(Log::HLE, 0, "UNIMPL");
 }
 
 static int sceNpDrmRenameCheck(const char *filename) {
-	WARN_LOG(Log::HLE, "UNIMPL: sceNpDrmRenameCheck(%s)", filename);
-	return 0;
+	return hleLogWarning(Log::HLE, 0, "UNIMPL");
 }
 
 static int sceNpDrmEdataSetupKey(u32 edataFd) {
-	INFO_LOG(Log::HLE, "sceNpDrmEdataSetupKey(%x)", edataFd);
 	int usec = 0;
 	// set PGD offset
 	int retval = __IoIoctl(edataFd, 0x04100002, 0x90, 0, 0, 0, usec);
 	if (retval != 0) {
-		return hleDelayResult(retval, "io ctrl command", usec);
+		return hleDelayResult(hleLogError(Log::HLE, retval), "io ctrl command", usec);
 	}
 	// call PGD open
 	// Note that usec accumulates.
 	retval = __IoIoctl(edataFd, 0x04100001, 0, 0, 0, 0, usec);
-	return hleDelayResult(retval, "io ctrl command", usec);
+	return hleDelayResult(hleLogSuccessInfoI(Log::HLE, retval), "io ctrl command", usec);
 }
 
 static int sceNpDrmEdataGetDataSize(u32 edataFd) {
-	INFO_LOG(Log::HLE, "sceNpDrmEdataGetDataSize %x", edataFd);
-	return sceIoIoctl(edataFd, 0x04100010, 0, 0, 0, 0);
+	int retval = hleCall(IoFileMgrForKernel, u32, sceIoIoctl, edataFd, 0x04100010, 0, 0, 0, 0);
+	return hleLogSuccessInfoI(Log::HLE, retval);
 }
 
 static int sceNpDrmOpen() {

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -456,7 +456,7 @@ namespace SaveState
 
 	void Rewind(Callback callback, void *cbUserData)
 	{
-		if (netInited) {
+		if (g_netInited) {
 			return;
 		}
 		if (coreState == CoreState::CORE_RUNTIME_ERROR)

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -939,7 +939,7 @@ void EmuScreen::onVKey(int virtualKeyCode, bool down) {
 		break;
 	case VIRTKEY_TOGGLE_WLAN:
 		// Let's not allow the user to toggle wlan while connected, could get confusing.
-		if (down && !netInited) {
+		if (down && !g_netInited) {
 			auto n = GetI18NCategory(I18NCat::NETWORKING);
 			auto di = GetI18NCategory(I18NCat::DIALOG);
 			g_Config.bEnableWlan = !g_Config.bEnableWlan;
@@ -1884,7 +1884,7 @@ void EmuScreen::resized() {
 }
 
 bool MustRunBehind() {
-	return netInited || __NetAdhocConnected();
+	return IsNetworkConnected();
 }
 
 bool ShouldRunBehind() {

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -495,8 +495,6 @@ static void DrawNp(ImConfig &cfg) {
 		return;
 	}
 
-	ImGui::Text("ApCtl state: %s", ApctlStateToString(netApctlState));
-
 	ImGui::Text("Signed in: %d", npSigninState);
 	ImGui::Text("Title ID: %s", npTitleId.data);
 
@@ -508,6 +506,45 @@ static void DrawNp(ImConfig &cfg) {
 	ImGui::End();
 }
 
+static void DrawApctl(ImConfig &cfg) {
+	if (!ImGui::Begin("Apctl", &cfg.apctlOpen)) {
+		ImGui::End();
+		return;
+	}
+
+	ImGui::Text("State: %s", ApctlStateToString(netApctlState));
+	if (netApctlState != PSP_NET_APCTL_STATE_DISCONNECTED && ImGui::CollapsingHeader("ApCtl Details")) {
+		ImGui::Text("Name: %s", netApctlInfo.name);
+		ImGui::Text("IP: %s", netApctlInfo.ip);
+		ImGui::Text("SubnetMask: %s", netApctlInfo.ip);
+		ImGui::Text("SSID: %.*s", netApctlInfo.ssidLength, netApctlInfo.ssid);
+		ImGui::Text("SSID: %.*s", netApctlInfo.ssidLength, netApctlInfo.ssid);
+		ImGui::Text("Gateway: %s", netApctlInfo.gateway);
+		ImGui::Text("PrimaryDNS: %s", netApctlInfo.primaryDns);
+		ImGui::Text("SecondaryDNS: %s", netApctlInfo.secondaryDns);
+	}
+
+	if (g_Config.bInfrastructureAutoDNS) {
+		if (!g_infraDNSConfig.loaded) {
+			if (g_infraDNSConfig.gameName.empty()) {
+				ImGui::Text("Known game: %s", g_infraDNSConfig.gameName.c_str());
+			}
+			ImGui::Text("connectAdhocForGrouping: %s", BoolStr(g_infraDNSConfig.connectAdHocForGrouping));
+			ImGui::Text("DNS: %s", g_infraDNSConfig.dns.c_str());
+			if (!g_infraDNSConfig.dyn_dns.empty()) {
+				ImGui::Text("DynDNS: %s", g_infraDNSConfig.dyn_dns.c_str());
+			}
+			if (!g_infraDNSConfig.fixedDNS.empty()) {
+				ImGui::TextUnformatted("Fixed DNS");
+				for (auto iter : g_infraDNSConfig.fixedDNS) {
+					ImGui::Text("%s -> %s", iter.first.c_str(), iter.second.c_str());
+				}
+			}
+		}
+	}
+
+	ImGui::End();
+}
 static void DrawAdhoc(ImConfig &cfg) {
 	if (!ImGui::Begin("AdHoc", &cfg.adhocOpen)) {
 		ImGui::End();
@@ -1222,6 +1259,7 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Network")) {
+			ImGui::MenuItem("ApCtl", nullptr, &cfg_.apctlOpen);
 			ImGui::MenuItem("Sockets", nullptr, &cfg_.socketsOpen);
 			ImGui::MenuItem("NP", nullptr, &cfg_.npOpen);
 			ImGui::MenuItem("AdHoc", nullptr, &cfg_.adhocOpen);
@@ -1356,8 +1394,13 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 	if (cfg_.npOpen) {
 		DrawNp(cfg_);
 	}
+
 	if (cfg_.adhocOpen) {
 		DrawAdhoc(cfg_);
+	}
+
+	if (cfg_.apctlOpen) {
+		DrawApctl(cfg_);
 	}
 
 	// Process UI commands
@@ -1725,6 +1768,7 @@ void ImConfig::SyncConfig(IniFile *ini, bool save) {
 	sync.Sync("socketsOpen", &socketsOpen, false);
 	sync.Sync("npOpen", &npOpen, false);
 	sync.Sync("adhocOpen", &adhocOpen, false);
+	sync.Sync("apctlOpen", &apctlOpen, false);
 	sync.Sync("pixelViewerOpen", &pixelViewerOpen, false);
 	for (int i = 0; i < 4; i++) {
 		char name[64];

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -22,6 +22,11 @@
 #include "Core/HLE/SocketManager.h"
 #include "Core/HLE/NetInetConstants.h"
 #include "Core/HLE/sceNp.h"
+#include "Core/HLE/sceNet.h"
+#include "Core/HLE/sceNetApctl.h"
+#include "Core/HLE/sceNetAdhoc.h"
+#include "Core/HLE/proAdhoc.h"
+#include "Core/HLE/sceNetAdhocMatching.h"
 #include "Common/System/Request.h"
 
 #include "Core/HLE/sceAtrac.h"
@@ -490,12 +495,84 @@ static void DrawNp(ImConfig &cfg) {
 		return;
 	}
 
+	ImGui::Text("ApCtl state: %s", ApctlStateToString(netApctlState));
+
 	ImGui::Text("Signed in: %d", npSigninState);
 	ImGui::Text("Title ID: %s", npTitleId.data);
 
 	SceNpId id{};
 	NpGetNpId(&id);
 	ImGui::Text("User Handle: %s", id.handle.data);
+
+
+	ImGui::End();
+}
+
+static void DrawAdhoc(ImConfig &cfg) {
+	if (!ImGui::Begin("AdHoc", &cfg.adhocOpen)) {
+		ImGui::End();
+		return;
+	}
+
+	const char *discoverStatusStr = "N/A";
+	switch (netAdhocDiscoverStatus) {
+	case 0: discoverStatusStr = "NONE"; break;
+	case 1: discoverStatusStr = "IN_PROGRESS"; break;
+	case 2: discoverStatusStr = "COMPLETED"; break;
+	default: break;
+	}
+
+	auto &io = ImGui::GetIO();
+
+	/*
+	ImGui::Text("WantCaptureMouse: %s", BoolStr(io.WantCaptureMouse));
+	ImGui::Text("WantCaptureKeyboard: %s", BoolStr(io.WantCaptureKeyboard));
+	ImGui::Text("WantCaptureMouseUnlessPopupClose: %s", BoolStr(io.WantCaptureMouseUnlessPopupClose));
+	ImGui::Text("WantTextInput: %s", BoolStr(io.WantTextInput));
+	*/
+
+	ImGui::Text("sceNetAdhoc inited: %s", BoolStr(netAdhocInited));
+	ImGui::Text("sceNetAdhoc inited: %s", BoolStr(netAdhocInited));
+	ImGui::Text("sceNetAdhocctl inited: %s", BoolStr(netAdhocctlInited));
+	ImGui::Text("sceNetAdhocMatching inited: %s", BoolStr(netAdhocctlInited));
+	ImGui::Text("GameMode entered: %s", BoolStr(netAdhocGameModeEntered));
+	ImGui::Text("FriendFinder running: %s", BoolStr(g_adhocServerConnected));
+	ImGui::Text("sceNetAdhocDiscover status: %s", discoverStatusStr);
+
+	if (ImGui::BeginTable("sock", 5, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersH | ImGuiTableFlags_Resizable)) {
+		ImGui::TableSetupColumn("ID", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("Non-blocking", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("BufSize", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("IsClient", ImGuiTableColumnFlags_WidthFixed);
+
+		ImGui::TableHeadersRow();
+
+		for (int i = 0; i < MAX_SOCKET; i++) {
+			const AdhocSocket *socket = adhocSockets[i];
+			if (!socket) {
+				continue;
+			}
+
+			ImGui::TableNextRow();
+			ImGui::TableNextColumn();
+			ImGui::Text("%d", i + 1);
+			ImGui::TableNextColumn();
+			switch (socket->type) {
+			case SOCK_PDP: ImGui::TextUnformatted("PDP"); break;
+			case SOCK_PTP: ImGui::TextUnformatted("PTP"); break;
+			default: ImGui::Text("(%d)", socket->type); break;
+			}
+			ImGui::TableNextColumn();
+			ImGui::TextUnformatted(socket->nonblocking ? "Non-blocking" : "Blocking");
+			ImGui::TableNextColumn();
+			ImGui::Text("%d", socket->buffer_size);
+			ImGui::TableNextColumn();
+			ImGui::TextUnformatted(BoolStr(socket->isClient));
+		}
+		ImGui::EndTable();
+	}
+
 	ImGui::End();
 }
 
@@ -1147,6 +1224,7 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 		if (ImGui::BeginMenu("Network")) {
 			ImGui::MenuItem("Sockets", nullptr, &cfg_.socketsOpen);
 			ImGui::MenuItem("NP", nullptr, &cfg_.npOpen);
+			ImGui::MenuItem("AdHoc", nullptr, &cfg_.adhocOpen);
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Tools")) {
@@ -1277,6 +1355,9 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 
 	if (cfg_.npOpen) {
 		DrawNp(cfg_);
+	}
+	if (cfg_.adhocOpen) {
+		DrawAdhoc(cfg_);
 	}
 
 	// Process UI commands
@@ -1643,6 +1724,7 @@ void ImConfig::SyncConfig(IniFile *ini, bool save) {
 	sync.Sync("schedulerOpen", &schedulerOpen, false);
 	sync.Sync("socketsOpen", &socketsOpen, false);
 	sync.Sync("npOpen", &npOpen, false);
+	sync.Sync("adhocOpen", &adhocOpen, false);
 	sync.Sync("pixelViewerOpen", &pixelViewerOpen, false);
 	for (int i = 0; i < 4; i++) {
 		char name[64];

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -143,8 +143,9 @@ struct ImConfig {
 	bool pixelViewerOpen;
 	bool npOpen;
 	bool socketsOpen;
-	bool memDumpOpen;
+	bool apctlOpen;
 	bool adhocOpen;
+	bool memDumpOpen;
 	bool memViewOpen[4];
 
 	// HLE explorer settings

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -144,6 +144,7 @@ struct ImConfig {
 	bool npOpen;
 	bool socketsOpen;
 	bool memDumpOpen;
+	bool adhocOpen;
 	bool memViewOpen[4];
 
 	// HLE explorer settings
@@ -231,3 +232,4 @@ void ShowInWindowMenuItems(uint32_t addr, ImControl &control);
 void ShowInMemoryViewerMenuItem(uint32_t addr, ImControl &control);
 void ShowInMemoryDumperMenuItem(uint32_t addr, uint32_t size, MemDumpMode mode, ImControl &control);
 void StatusBar(std::string_view str);
+inline const char *BoolStr(bool s) { return s ? "true" : "false"; }

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -389,16 +389,23 @@ void GamePauseScreen::CreateViews() {
 	if (IsNetworkConnected()) {
 		leftColumnItems->Add(new NoticeView(NoticeLevel::INFO, nw->T("Network connected"), ""));
 
-		if (!g_infraDNSConfig.revivalTeam.empty() && netInetInited) {
-			leftColumnItems->Add(new TextView(std::string(nw->T("Infrastructure Mode server by")) + ":"));
-			leftColumnItems->Add(new TextView(g_infraDNSConfig.revivalTeam));
-			if (!g_infraDNSConfig.revivalTeamURL.empty()) {
-				leftColumnItems->Add(new Button(g_infraDNSConfig.revivalTeamURL))->OnClick.Add([](UI::EventParams &e) {
-					if (!g_infraDNSConfig.revivalTeamURL.empty()) {
-						System_LaunchUrl(LaunchUrlType::BROWSER_URL, g_infraDNSConfig.revivalTeamURL.c_str());
-					}
-					return UI::EVENT_DONE;
-				});
+		if (g_infraDNSConfig.loaded) {
+			if (g_infraDNSConfig.state == InfraGameState::NotWorking) {
+				leftColumnItems->Add(new NoticeView(NoticeLevel::WARN, nw->T("Some network functionality in this game is not working"), ""));
+			} else if (g_infraDNSConfig.state == InfraGameState::Unknown) {
+				leftColumnItems->Add(new NoticeView(NoticeLevel::WARN, nw->T("Network functionality in this game is not guaranteed"), ""));
+			}
+			if (!g_infraDNSConfig.revivalTeam.empty() && netInetInited) {
+				leftColumnItems->Add(new TextView(std::string(nw->T("Infrastructure Mode server by")) + ":"));
+				leftColumnItems->Add(new TextView(g_infraDNSConfig.revivalTeam));
+				if (!g_infraDNSConfig.revivalTeamURL.empty()) {
+					leftColumnItems->Add(new Button(g_infraDNSConfig.revivalTeamURL))->OnClick.Add([](UI::EventParams &e) {
+						if (!g_infraDNSConfig.revivalTeamURL.empty()) {
+							System_LaunchUrl(LaunchUrlType::BROWSER_URL, g_infraDNSConfig.revivalTeamURL.c_str());
+						}
+						return UI::EVENT_DONE;
+					});
+				}
 			}
 		}
 

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -278,11 +278,11 @@ void GamePauseScreen::update() {
 		finishNextFrame_ = false;
 	}
 
-	if (netInited != lastNetInited_ || netInetInited != lastNetInetInited_ || lastAdhocServerConnected_ != g_adhocServerConnected) {
+	if (g_netInited != lastNetInited_ || netInetInited != lastNetInetInited_ || lastAdhocServerConnected_ != g_adhocServerConnected) {
 		INFO_LOG(Log::sceNet, "Network status changed, recreating views");
 		RecreateViews();
 		lastNetInetInited_ = netInetInited;
-		lastNetInited_ = netInited;
+		lastNetInited_ = g_netInited;
 		lastAdhocServerConnected_ = g_adhocServerConnected;
 	}
 
@@ -386,7 +386,7 @@ void GamePauseScreen::CreateViews() {
 		}
 	}
 
-	if (netInited || g_adhocServerConnected) {
+	if (IsNetworkConnected()) {
 		leftColumnItems->Add(new NoticeView(NoticeLevel::INFO, nw->T("Network connected"), ""));
 
 		if (!g_infraDNSConfig.revivalTeam.empty() && netInetInited) {
@@ -409,7 +409,7 @@ void GamePauseScreen::CreateViews() {
 
 	bool achievementsAllowSavestates = !Achievements::HardcoreModeActive() || g_Config.bAchievementsSaveStateInHardcoreMode;
 	bool showSavestateControls = achievementsAllowSavestates;
-	if (netInited && !g_Config.bAllowSavestateWhileConnected) {
+	if (IsNetworkConnected() && !g_Config.bAllowSavestateWhileConnected) {
 		showSavestateControls = false;
 	}
 


### PR DESCRIPTION
That behavior broke save states and speed controls in a lot of games, see #19896 , and this PR fixes it.

However, the Network popup still comes up too early (on sceNetInit), so will need to fix that in a followup.

Also contains a buildfix, and more networking stuff in the ImDebugger.