### PR TITLE
Keep infra-dns.json updated from metadata.ppsspp.org

### DIFF
--- a/Common/Buffer.cpp
+++ b/Common/Buffer.cpp
@@ -115,7 +115,7 @@ void Buffer::Printf(const char *fmt, ...) {
 	memcpy(ptr, buffer, retval);
 }
 
-bool Buffer::FlushToFile(const Path &filename) {
+bool Buffer::FlushToFile(const Path &filename, bool clear) {
 	FILE *f = File::OpenCFile(filename, "wb");
 	if (!f)
 		return false;
@@ -124,7 +124,9 @@ bool Buffer::FlushToFile(const Path &filename) {
 		data_.iterate_blocks([=](const char *blockData, size_t blockSize) {
 			return fwrite(blockData, 1, blockSize, f) == blockSize;
 		});
-		data_.clear();
+		if (clear) {
+			data_.clear();
+		}
 	}
 	fclose(f);
 	return true;

--- a/Common/Buffer.h
+++ b/Common/Buffer.h
@@ -66,9 +66,9 @@ public:
 	// Simple I/O.
 
 	// Writes the entire buffer to the file descriptor. Also resets the
-	// size to zero. On failure, data remains in buffer and nothing is
+	// size to zero, if the clear flag is true. On failure, data remains in buffer and nothing is
 	// written.
-	bool FlushToFile(const Path &filename);
+	bool FlushToFile(const Path &filename, bool clear);
 
 	// Utilities. Try to avoid checking for size.
 	size_t size() const { return data_.size(); }

--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -486,8 +486,8 @@ int Client::ReadResponseEntity(net::Buffer *readbuf, const std::vector<std::stri
 	return 0;
 }
 
-HTTPRequest::HTTPRequest(RequestMethod method, std::string_view url, std::string_view postData, std::string_view postMime, const Path &outfile, RequestFlags progressBarMode, std::string_view name)
-	: Request(method, url, name, &cancelled_, progressBarMode), postData_(postData), postMime_(postMime) {
+HTTPRequest::HTTPRequest(RequestMethod method, std::string_view url, std::string_view postData, std::string_view postMime, const Path &outfile, RequestFlags flags, std::string_view name)
+	: Request(method, url, name, &cancelled_, flags), postData_(postData), postMime_(postMime) {
 	outfile_ = outfile;
 }
 

--- a/Common/Net/HTTPClient.h
+++ b/Common/Net/HTTPClient.h
@@ -96,7 +96,7 @@ protected:
 // Really an asynchronous request.
 class HTTPRequest : public Request {
 public:
-	HTTPRequest(RequestMethod method, std::string_view url, std::string_view postData, std::string_view postMime, const Path &outfile, RequestFlags progressBarMode = RequestFlags::ProgressBar | RequestFlags::ProgressBarDelayed, std::string_view name = "");
+	HTTPRequest(RequestMethod method, std::string_view url, std::string_view postData, std::string_view postMime, const Path &outfile, RequestFlags flags = RequestFlags::ProgressBar | RequestFlags::ProgressBarDelayed, std::string_view name = "");
 	~HTTPRequest();
 
 	void Start() override;
@@ -117,6 +117,20 @@ private:
 	bool completed_ = false;
 	bool failed_ = false;
 	bool joined_ = false;
+};
+
+// Fake request for cache hits.
+class CachedRequest : public Request {
+public:
+	CachedRequest(RequestMethod method, std::string_view url, std::string_view name, bool *cancelled, RequestFlags flags, std::string_view responseData)
+		: Request(method, url, name, cancelled, flags)
+	{
+		buffer_.Append(responseData);
+	}
+	void Start() override {}
+	void Join() override {}
+	bool Done() override { return true; }
+	bool Failed() const override { return false; }
 };
 
 }  // namespace http

--- a/Common/Net/HTTPClient.h
+++ b/Common/Net/HTTPClient.h
@@ -35,7 +35,6 @@ protected:
 
 private:
 	uintptr_t sock_ = -1;
-
 };
 
 }	// namespace net
@@ -116,10 +115,11 @@ private:
 	std::string postMime_;
 	bool completed_ = false;
 	bool failed_ = false;
-	bool joined_ = false;
 };
 
 // Fake request for cache hits.
+// The download manager uses this when caching was requested, and a new-enough file was present in the cache directory.
+// This is simply a finished request, that can still be queried like a normal one so users don't know it came from the cache.
 class CachedRequest : public Request {
 public:
 	CachedRequest(RequestMethod method, std::string_view url, std::string_view name, bool *cancelled, RequestFlags flags, std::string_view responseData)

--- a/Common/Net/HTTPNaettRequest.cpp
+++ b/Common/Net/HTTPNaettRequest.cpp
@@ -12,8 +12,8 @@
 
 namespace http {
 
-HTTPSRequest::HTTPSRequest(RequestMethod method, std::string_view url, std::string_view postData, std::string_view postMime, const Path &outfile, RequestFlags progressBarMode, std::string_view name)
-	: Request(method, url, name, &cancelled_, progressBarMode), method_(method), postData_(postData), postMime_(postMime) {
+HTTPSRequest::HTTPSRequest(RequestMethod method, std::string_view url, std::string_view postData, std::string_view postMime, const Path &outfile, RequestFlags flags, std::string_view name)
+	: Request(method, url, name, &cancelled_, flags), method_(method), postData_(postData), postMime_(postMime) {
 	outfile_ = outfile;
 }
 

--- a/Common/Net/HTTPNaettRequest.cpp
+++ b/Common/Net/HTTPNaettRequest.cpp
@@ -107,7 +107,8 @@ bool HTTPSRequest::Done() {
 		failed_ = true;
 		progress_.Update(bodyLength, bodyLength, true);
 	} else if (resultCode_ == 200) {
-		if (!outfile_.empty() && !buffer_.FlushToFile(outfile_)) {
+		bool clear = !(flags_ & RequestFlags::KeepInMemory);
+		if (!outfile_.empty() && !buffer_.FlushToFile(outfile_, clear)) {
 			ERROR_LOG(Log::IO, "Failed writing download to '%s'", outfile_.c_str());
 		}
 		progress_.Update(bodyLength, bodyLength, true);

--- a/Common/Net/HTTPNaettRequest.h
+++ b/Common/Net/HTTPNaettRequest.h
@@ -14,7 +14,7 @@ namespace http {
 // Really an asynchronous request.
 class HTTPSRequest : public Request {
 public:
-	HTTPSRequest(RequestMethod method, std::string_view url, std::string_view postData, std::string_view postMime, const Path &outfile, RequestFlags progressBarMode = RequestFlags::ProgressBar | RequestFlags::ProgressBarDelayed, std::string_view name = "");
+	HTTPSRequest(RequestMethod method, std::string_view url, std::string_view postData, std::string_view postMime, const Path &outfile, RequestFlags flags = RequestFlags::ProgressBar | RequestFlags::ProgressBarDelayed, std::string_view name = "");
 	~HTTPSRequest();
 
 	void Start() override;

--- a/Common/Net/HTTPRequest.cpp
+++ b/Common/Net/HTTPRequest.cpp
@@ -52,6 +52,13 @@ Path UrlToCachePath(const Path &cacheDir, std::string_view url) {
 	return cacheDir / fn;
 }
 
+Path RequestManager::UrlToCachePath(const std::string_view url) {
+	if (cacheDir_.empty()) {
+		return Path();
+	}
+	return http::UrlToCachePath(cacheDir_, url);
+}
+
 std::shared_ptr<Request> CreateRequest(RequestMethod method, std::string_view url, std::string_view postdata, std::string_view postMime, const Path &outfile, RequestFlags flags, std::string_view name) {
 	if (IsHttpsUrl(url) && System_GetPropertyBool(SYSPROP_SUPPORTS_HTTPS)) {
 #ifndef HTTPS_NOT_AVAILABLE
@@ -71,7 +78,7 @@ std::shared_ptr<Request> RequestManager::StartDownload(std::string_view url, con
 		_dbg_assert_(outfile.empty());  // It's automatically replaced below
 
 		// Come up with a cache file path.
-		Path cacheFile = UrlToCachePath(cacheDir_, url);
+		Path cacheFile = UrlToCachePath(url);
 
 		// TODO: This should be done on the thread, maybe. But let's keep it simple for now.
 		time_t cacheFileTime;

--- a/Common/Net/HTTPRequest.cpp
+++ b/Common/Net/HTTPRequest.cpp
@@ -9,8 +9,8 @@
 
 namespace http {
 
-Request::Request(RequestMethod method, std::string_view url, std::string_view name, bool *cancelled, RequestFlags mode)
-	: method_(method), url_(url), name_(name), progress_(cancelled), flags_(mode) {
+Request::Request(RequestMethod method, std::string_view url, std::string_view name, bool *cancelled, RequestFlags flags)
+	: method_(method), url_(url), name_(name), progress_(cancelled), flags_(flags) {
 	INFO_LOG(Log::HTTP, "HTTP %s request: %.*s (%.*s)", RequestMethodToString(method), (int)url.size(), url.data(), (int)name.size(), name.data());
 
 	progress_.callback = [=](int64_t bytes, int64_t contentLength, bool done) {

--- a/Common/Net/HTTPRequest.h
+++ b/Common/Net/HTTPRequest.h
@@ -127,13 +127,15 @@ public:
 	void Update();
 	void CancelAll();
 
-	void SetUserAgent(const std::string &userAgent) {
+	void SetUserAgent(std::string_view userAgent) {
 		userAgent_ = userAgent;
 	}
 
 	void SetCacheDir(const Path &path) {
 		cacheDir_ = path;
 	}
+
+	Path UrlToCachePath(const std::string_view url);
 
 private:
 	std::vector<std::shared_ptr<Request>> downloads_;

--- a/Common/Net/HTTPRequest.h
+++ b/Common/Net/HTTPRequest.h
@@ -18,7 +18,8 @@ enum class RequestFlags {
 	Default = 0,
 	ProgressBar = 1,
 	ProgressBarDelayed = 2,
-	// Cached = 4 etc
+	Cached24H = 4,
+	KeepInMemory = 8,
 };
 ENUM_CLASS_BITOPS(RequestFlags);
 
@@ -59,6 +60,12 @@ public:
 	std::string url() const { return url_; }
 
 	const Path &OutFile() const { return outfile_; }
+	void OverrideOutFile(const Path &path) {
+		outfile_ = path;
+	}
+	void AddFlag(RequestFlags flag) {
+		flags_ |= flag;
+	}
 
 	void Cancel() { cancelled_ = true; }
 	bool IsCancelled() const { return cancelled_; }
@@ -97,6 +104,7 @@ public:
 		CancelAll();
 	}
 
+	// NOTE: This is the only version that supports the cache flag (for now).
 	std::shared_ptr<Request> StartDownload(std::string_view url, const Path &outfile, RequestFlags flags, const char *acceptMime = nullptr);
 
 	std::shared_ptr<Request> StartDownloadWithCallback(
@@ -123,6 +131,10 @@ public:
 		userAgent_ = userAgent;
 	}
 
+	void SetCacheDir(const Path &path) {
+		cacheDir_ = path;
+	}
+
 private:
 	std::vector<std::shared_ptr<Request>> downloads_;
 	// These get copied to downloads_ in Update(). It's so that callbacks can add new downloads
@@ -130,6 +142,7 @@ private:
 	std::vector<std::shared_ptr<Request>> newDownloads_;
 
 	std::string userAgent_;
+	Path cacheDir_;
 };
 
 inline const char *RequestMethodToString(RequestMethod method) {

--- a/Core/Dialog/PSPNetconfDialog.h
+++ b/Core/Dialog/PSPNetconfDialog.h
@@ -61,4 +61,6 @@ private:
 	u32 scanInfosAddr = 0;
 	int scanStep = 0;
 	u64 startTime = 0;
+
+	bool jsonReady_ = false;
 };

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -2791,8 +2791,7 @@ int __IoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 out
 	return hleLogDebug(Log::sceIo, 0);
 }
 
-u32 sceIoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen)
-{
+u32 sceIoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen) {
 	int usec = 0;
 	int result = __IoIoctl(id, cmd, indataPtr, inlen, outdataPtr, outlen, usec);
 	if (usec != 0) {

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -159,21 +159,11 @@ void AfterApctlMipsCall::SetData(int HandlerID, int OldState, int NewState, int 
 	argsAddr = ArgsAddr;
 }
 
-bool LoadDNSForGameID(std::string_view gameID, InfraDNSConfig *dns) {
+bool LoadDNSForGameID(std::string_view gameID, std::string_view jsonStr, InfraDNSConfig *dns) {
 	using namespace json;
 
 	*dns = {};
 
-	// TODO: Load from cache instead of zip (if possible), and sometimes update it.
-	size_t jsonSize;
-	std::unique_ptr<uint8_t[]> data(g_VFS.ReadFile("infra-dns.json", &jsonSize));
-	if (!data) {
-		return false;
-	}
-
-	dns->loaded = true;
-
-	std::string_view jsonStr = std::string_view((const char *)data.get(), jsonSize);
 	json::JsonReader reader(jsonStr.data(), jsonStr.length());
 	if (!reader.ok() || !reader.root()) {
 		ERROR_LOG(Log::IO, "Error parsing DNS JSON");
@@ -277,17 +267,18 @@ bool LoadDNSForGameID(std::string_view gameID, InfraDNSConfig *dns) {
 		break;
 	}
 
+	dns->loaded = true;
 	return true;
 }
 
-void LoadAutoDNS() {
+static void LoadAutoDNS(std::string_view json) {
 	if (!g_Config.bInfrastructureAutoDNS) {
 		return;
 	}
 
 	// Load the automatic DNS config for this game - or the defaults.
 	std::string discID = g_paramSFO.GetDiscID();
-	LoadDNSForGameID(discID, &g_infraDNSConfig);
+	LoadDNSForGameID(discID, json, &g_infraDNSConfig);
 
 	// If dyn_dns is non-empty, try to use it to replace the specified DNS.
 	// If fails, we just use the dns. TODO: Do this in the background somehow...
@@ -324,6 +315,55 @@ void LoadAutoDNS() {
 			net::DNSResolveFree(resolved);
 		}
 	}
+}
+
+std::shared_ptr<http::Request> g_infraDL;
+
+void StartInfraJsonDownload() {
+	if (!g_Config.bInfrastructureAutoDNS) {
+		return;
+	}
+
+	if (g_infraDL) {
+		INFO_LOG(Log::sceNet, "json is already being downloaded");
+	}
+	const char *acceptMime = "application/json, text/*; q=0.9, */*; q=0.8";
+	g_infraDL = g_DownloadManager.StartDownload("http://metadata.ppsspp.org/infra-dns.json", Path(), http::ProgressBarMode::NONE, acceptMime);
+}
+
+bool PollInfraJsonDownload(std::string *jsonOutput) {
+	if (!g_Config.bInfrastructureAutoDNS) {
+		return true;
+	}
+
+	if (!g_infraDL) {
+		INFO_LOG(Log::sceNet, "No json download going on");
+		return false;
+	}
+
+	if (!g_infraDL->Done()) {
+		return false;
+	}
+
+	// The request is done, but did it fail?
+	if (g_infraDL->Failed()) {
+		// Let's just grab the assets file. Because later this will mean that we didn't even get the cached copy.
+		size_t jsonSize = 0;
+		std::unique_ptr<uint8_t[]> jsonStr(g_VFS.ReadFile("infra-dns.json", &jsonSize));
+		if (!jsonStr) {
+			jsonOutput->clear();
+			return true;  // A clear output but returning true means something vent very wrong.
+		}
+		*jsonOutput = std::string((const char *)jsonStr.get(), jsonSize);
+		return true;
+	}
+
+	// OK, we actually got data. Load it!
+	INFO_LOG(Log::sceNet, "json downloaded");
+	g_infraDL->buffer().TakeAll(jsonOutput);
+
+	LoadAutoDNS(*jsonOutput);
+	return true;
 }
 
 void InitLocalhostIP() {
@@ -819,8 +859,6 @@ static int sceNetInit(u32 poolSize, u32 calloutPri, u32 calloutStack, u32 netini
 
 	// Clear Socket Translator Memory
 	memset(&adhocSockets, 0, sizeof(adhocSockets));
-
-	LoadAutoDNS();
 
 	g_netInited = true;
 

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -328,7 +328,7 @@ void StartInfraJsonDownload() {
 		INFO_LOG(Log::sceNet, "json is already being downloaded");
 	}
 	const char *acceptMime = "application/json, text/*; q=0.9, */*; q=0.8";
-	g_infraDL = g_DownloadManager.StartDownload("http://metadata.ppsspp.org/infra-dns.json", Path(), http::RequestFlags::Default, acceptMime);
+	g_infraDL = g_DownloadManager.StartDownload("http://metadata.ppsspp.org/infra-dns.json", Path(), http::RequestFlags::Cached24H, acceptMime);
 }
 
 bool PollInfraJsonDownload(std::string *jsonOutput) {
@@ -359,8 +359,12 @@ bool PollInfraJsonDownload(std::string *jsonOutput) {
 	}
 
 	// OK, we actually got data. Load it!
-	INFO_LOG(Log::sceNet, "json downloaded");
 	g_infraDL->buffer().TakeAll(jsonOutput);
+
+	if (jsonOutput->empty()) {
+		_dbg_assert_msg_(false, "Json output is empty!");
+		ERROR_LOG(Log::sceNet, "JSON output is empty! Something went wrong.");
+	}
 
 	LoadAutoDNS(*jsonOutput);
 	return true;

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -328,7 +328,7 @@ void StartInfraJsonDownload() {
 		INFO_LOG(Log::sceNet, "json is already being downloaded");
 	}
 	const char *acceptMime = "application/json, text/*; q=0.9, */*; q=0.8";
-	g_infraDL = g_DownloadManager.StartDownload("http://metadata.ppsspp.org/infra-dns.json", Path(), http::ProgressBarMode::NONE, acceptMime);
+	g_infraDL = g_DownloadManager.StartDownload("http://metadata.ppsspp.org/infra-dns.json", Path(), http::RequestFlags::Default, acceptMime);
 }
 
 bool PollInfraJsonDownload(std::string *jsonOutput) {

--- a/Core/HLE/sceNet.h
+++ b/Core/HLE/sceNet.h
@@ -134,6 +134,11 @@ int sceNetApctlConnect(int connIndex);
 // Are we connected - for the purpose of disabling speed consoles and savestates etc.
 bool IsNetworkConnected();
 
+// Kicks off a fetch of the json download, unless it's cached and new enough.
+void StartInfraJsonDownload();
+// Polls the fetch, if returns true, jsonOutput should be looked at. If it's empty, something went very wrong as we fallback on the asset file.
+bool PollInfraJsonDownload(std::string *jsonOutput);
+
 // These return false if allowed to be consistent with the similar function for achievements.
 bool NetworkWarnUserIfOnlineAndCantSavestate();
 bool NetworkWarnUserIfOnlineAndCantSpeed();

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -724,6 +724,8 @@ void NativeInit(int argc, const char *argv[], const char *savegame_dir, const ch
 		}
 	}
 
+	g_DownloadManager.SetCacheDir(GetSysDirectory(DIRECTORY_APP_CACHE));
+
 	DEBUG_LOG(Log::System, "ScreenManager!");
 	g_screenManager = new ScreenManager();
 	if (g_Config.memStickDirectory.empty()) {

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -279,13 +279,14 @@ void GamePauseScreen::update() {
 	}
 
 	const bool networkConnected = IsNetworkConnected();
-	if (g_netInited != lastNetInited_ || netInetInited != lastNetInetInited_ || lastAdhocServerConnected_ != g_adhocServerConnected || lastOnline_ != networkConnected) {
+	if (g_netInited != lastNetInited_ || netInetInited != lastNetInetInited_ || lastAdhocServerConnected_ != g_adhocServerConnected || lastOnline_ != networkConnected || lastDNSConfigLoaded_ != g_infraDNSConfig.loaded) {
 		INFO_LOG(Log::sceNet, "Network status changed, recreating views");
 		RecreateViews();
 		lastNetInetInited_ = netInetInited;
 		lastNetInited_ = g_netInited;
 		lastAdhocServerConnected_ = g_adhocServerConnected;
 		lastOnline_ = networkConnected;
+		lastDNSConfigLoaded_ = g_infraDNSConfig.loaded;
 	}
 
 	const bool mustRunBehind = MustRunBehind();

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -64,8 +64,11 @@ private:
 	DialogResult finishNextFrameResult_ = DR_CANCEL;
 
 	UI::Button *playButton_ = nullptr;
+
+	// State change tracking, a bit ugly heh, but works.
 	bool lastOnline_ = false;
 	bool lastNetInited_ = false;
 	bool lastNetInetInited_ = false;
 	bool lastAdhocServerConnected_ = false;
+	bool lastDNSConfigLoaded_ = false;
 };

--- a/UWP/UWP.vcxproj
+++ b/UWP/UWP.vcxproj
@@ -441,6 +441,10 @@
       <DeploymentContent>true</DeploymentContent>
       <Link>Content\%(Filename)%(Extension)</Link>
     </None>
+    <None Include="..\Assets\infra-dns.json">
+      <DeploymentContent>true</DeploymentContent>
+      <Link>Content\%(Filename)%(Extension)</Link>
+    </None>
     <None Include="..\Assets\knownfuncs.ini">
       <DeploymentContent>true</DeploymentContent>
       <Link>Content\%(Filename)%(Extension)</Link>

--- a/UWP/UWP.vcxproj.filters
+++ b/UWP/UWP.vcxproj.filters
@@ -186,6 +186,9 @@
     <None Include="..\Assets\langregion.ini">
       <Filter>Content</Filter>
     </None>
+    <None Include="..\Assets\infra-dns.json">
+      <Filter>Content</Filter>
+    </None>
     <None Include="..\Assets\redump.csv">
       <Filter>Content</Filter>
     </None>


### PR DESCRIPTION
Adds basic file caching support to the download manager.

Now updates it dynamically from `http://metadata.ppsspp.org/infra-dns.json` (I do need to remember to keep it up to date now when making changes...).

If the download fails (server down or something) fallbacks first to cache, then to the supplied file in /assets.

Cache expires after 24h (but as mentioned, will still be used if the download fails).

The file is fetched during apctl init, hopefully early enough. Would be interesting to see if some game breaks, if so we can fetch also from sceUtility if a game tries to fetch DNS from there first...