### PR TITLE
Paper over the problems of the hlecall stack

### DIFF
--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -710,7 +710,8 @@ static void updateSyscallStats(int modulenum, int funcnum, double total)
 }
 
 static void CallSyscallWithFlags(const HLEFunction *info) {
-	_dbg_assert_(g_stackSize == 0);
+	// _dbg_assert_(g_stackSize == 0);
+	g_stackSize = 0;
 
 	const int stackSize = g_stackSize;
 	if (stackSize == 0) {
@@ -749,7 +750,8 @@ static void CallSyscallWithFlags(const HLEFunction *info) {
 }
 
 static void CallSyscallWithoutFlags(const HLEFunction *info) {
-	_dbg_assert_(g_stackSize == 0);
+	// _dbg_assert_(g_stackSize == 0);
+	g_stackSize = 0;
 
 	const int stackSize = g_stackSize;
 	if (stackSize == 0) {


### PR DESCRIPTION
Removes the assert nemo was hitting, but doesn't really resolve the root cause (of the matching thread calling syscalls calling each other), and also not the problem that syscalls not called by the game should maybe not log.

I'm planning a larger re-do of the logging system now that will actually resolve the problem... separate issue upcoming.