### PR TITLE
Add no-SIMD fallback for CrossSIMD

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "(lldb) Launch",
+			"type": "cppdbg",
+			"request": "launch",
+			"program": "",
+			"osx": {
+				"program": "${workspaceFolder}/build/PPSSPPSDL.app/Contents/MacOS/PPSSPPSDL"
+			},
+			"linux": {
+				"program": "${workspaceRoot}/build/PPSSPPSDL"
+			},
+			"args": [],
+			"stopAtEntry": false,
+			"cwd": "${workspaceFolder}",
+			"environment": [],
+			"externalConsole": false,
+			"MIMode": "lldb"
+		}
+	]
+}

--- a/Common/Math/CrossSIMD.h
+++ b/Common/Math/CrossSIMD.h
@@ -745,6 +745,8 @@ struct Vec8U16 {
 
 #else
 
+#define CROSSSIMD_SLOW 1
+
 // Fake SIMD by using scalar.
 
 struct Mat4F32 {

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -140,10 +140,21 @@ std::string DefaultLangRegion() {
 }
 
 static int DefaultDepthRaster() {
+
+// For 64-bit ARM and x86 with SIMD, enable depth raster.
+#if PPSSPP_ARCH(ARM64_NEON) || PPSSPP_ARCH(SSE2)
+
 #if PPSSPP_PLATFORM(ANDROID) || PPSSPP_PLATFORM(IOS)
 	return (int)DepthRasterMode::LOW_QUALITY;
 #else
 	return (int)DepthRasterMode::DEFAULT;
+#endif
+
+#else
+
+	// 32-bit ARM or no SIMD, the depth raster will be too slow.
+	return (int)DepthRasterMode::OFF;
+
 #endif
 }
 

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -56,6 +56,7 @@ DrawEngineCommon::DrawEngineCommon() : decoderMap_(32) {
 	decIndex_ = (u16 *)AllocateMemoryPages(DECODED_INDEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
 	indexGen.Setup(decIndex_);
 
+#if PPSSPP_ARCH(SSE2) || PPSSPP_ARCH(ARM_NEON)
 	switch ((DepthRasterMode)g_Config.iDepthRasterMode) {
 	case DepthRasterMode::DEFAULT:
 	case DepthRasterMode::LOW_QUALITY:
@@ -67,6 +68,9 @@ DrawEngineCommon::DrawEngineCommon() : decoderMap_(32) {
 	case DepthRasterMode::OFF:
 		useDepthRaster_ = false;
 	}
+#else
+	useDepthRaster_ = false;
+#endif
 	if (useDepthRaster_) {
 		depthDraws_.reserve(256);
 	}

--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -56,7 +56,9 @@ DrawEngineCommon::DrawEngineCommon() : decoderMap_(32) {
 	decIndex_ = (u16 *)AllocateMemoryPages(DECODED_INDEX_BUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
 	indexGen.Setup(decIndex_);
 
-#if PPSSPP_ARCH(SSE2) || PPSSPP_ARCH(ARM_NEON)
+#ifdef CROSSSIMD_SLOW
+	useDepthRaster_ = false;
+#else
 	switch ((DepthRasterMode)g_Config.iDepthRasterMode) {
 	case DepthRasterMode::DEFAULT:
 	case DepthRasterMode::LOW_QUALITY:
@@ -68,8 +70,6 @@ DrawEngineCommon::DrawEngineCommon() : decoderMap_(32) {
 	case DepthRasterMode::OFF:
 		useDepthRaster_ = false;
 	}
-#else
-	useDepthRaster_ = false;
 #endif
 	if (useDepthRaster_) {
 		depthDraws_.reserve(256);

--- a/GPU/Software/TransformUnit.cpp
+++ b/GPU/Software/TransformUnit.cpp
@@ -155,14 +155,6 @@ WorldCoords TransformUnit::ModelToWorldNormal(const ModelCoords &coords) {
 	return Norm3ByMatrix43(coords, gstate.worldMatrix);
 }
 
-ViewCoords TransformUnit::WorldToView(const WorldCoords &coords) {
-	return Vec3ByMatrix43(coords, gstate.viewMatrix);
-}
-
-ClipCoords TransformUnit::ViewToClip(const ViewCoords &coords) {
-	return Vec3ByMatrix44(coords, gstate.projMatrix);
-}
-
 template <bool depthClamp, bool alwaysCheckRange>
 static ScreenCoords ClipToScreenInternal(Vec3f scaled, const ClipCoords &coords, bool *outside_range_flag) {
 	ScreenCoords ret;

--- a/GPU/Software/TransformUnit.h
+++ b/GPU/Software/TransformUnit.h
@@ -121,8 +121,6 @@ public:
 
 	static WorldCoords ModelToWorldNormal(const ModelCoords& coords);
 	static WorldCoords ModelToWorld(const ModelCoords& coords);
-	static ViewCoords WorldToView(const WorldCoords& coords);
-	static ClipCoords ViewToClip(const ViewCoords& coords);
 	static ScreenCoords ClipToScreen(const ClipCoords &coords, bool *outsideRangeFlag);
 	static inline DrawingCoords ScreenToDrawing(int x, int y) {
 		DrawingCoords ret;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -679,6 +679,8 @@ static void ShowFpsLimitNotice() {
 	case FPSLimit::CUSTOM2:
 		fpsLimit = g_Config.iFpsLimit2;
 		break;
+	default:
+		break;
 	}
 
 	// Now display it.

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -466,7 +466,7 @@ bool TestVFPUSinCos() {
 	return true;
 }
 
-bool TestMatrixTranspose() {
+bool TestVFPUMatrixTranspose() {
 	MatrixSize sz = M_4x4;
 	int matrix = 0;  // M000
 	u8 cols[4];
@@ -489,6 +489,7 @@ bool TestMatrixTranspose() {
 	return true;
 }
 
+// TODO: Hook this up again!
 void TestGetMatrix(int matrix, MatrixSize sz) {
 	INFO_LOG(Log::System, "Testing matrix %s", GetMatrixNotation(matrix, sz).c_str());
 	u8 fullMatrix[16];
@@ -1182,7 +1183,7 @@ TestItem availableTests[] = {
 	TEST_ITEM(Parsers),
 	TEST_ITEM(IRPassSimplify),
 	TEST_ITEM(Jit),
-	TEST_ITEM(MatrixTranspose),
+	TEST_ITEM(VFPUMatrixTranspose),
 	TEST_ITEM(ParseLBN),
 	TEST_ITEM(QuickTexHash),
 	TEST_ITEM(CLZ),


### PR DESCRIPTION
CrossSIMD is our new SIMD abstraction (so you don't have to write SSE2 or NEON directly).

This adds a fallback that simulates it on platforms where it's not been implemented natively yet (like RISC-V).

Fixes #19923 , although, the depth rasterizer doesn't actually work so it gets disabled (there's some bug) but at least it compiles.

To test this on ARM, you can comment out SIMD-related defines in ppsspp_config.h.