### PR TITLE
getLocalIp: Keep looking if we see 127.0.0.1

### DIFF
--- a/Common/Net/HTTPClient.cpp
+++ b/Common/Net/HTTPClient.cpp
@@ -159,7 +159,7 @@ bool Connection::Connect(int maxTries, double timeout, bool *cancelConnect) {
 
 			selectResult = select(maxfd, nullptr, &fds, nullptr, &tv);
 			if (cancelConnect && *cancelConnect) {
-				WARN_LOG(Log::HTTP, "connect: cancelled (1)");
+				WARN_LOG(Log::HTTP, "connect: cancelled (1): %s:%d", host_.c_str(), port_);
 				break;
 			}
 		}
@@ -183,7 +183,7 @@ bool Connection::Connect(int maxTries, double timeout, bool *cancelConnect) {
 		}
 
 		if (cancelConnect && *cancelConnect) {
-			WARN_LOG(Log::HTTP, "connect: cancelled (2)");
+			WARN_LOG(Log::HTTP, "connect: cancelled (2): %s:%d", host_.c_str(), port_);
 			break;
 		}
 

--- a/Core/HLE/proAdhoc.cpp
+++ b/Core/HLE/proAdhoc.cpp
@@ -1795,7 +1795,7 @@ int getLocalIp(sockaddr_in* SocketAddress) {
 
 // Fallback if not connected to AdhocServer
 // getifaddrs first appeared in glibc 2.3, On Android officially supported since __ANDROID_API__ >= 24
-#if defined(_IFADDRS_H_) || (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3) || (__ANDROID_API__ >= 24)
+#if (defined(_IFADDRS_H_) || (__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3) || (__ANDROID_API__ >= 24))
 	struct ifaddrs* ifAddrStruct = NULL;
 	struct ifaddrs* ifa = NULL;
 
@@ -1808,7 +1808,11 @@ int getLocalIp(sockaddr_in* SocketAddress) {
 			if (ifa->ifa_addr->sa_family == AF_INET) { // check it is IP4
 				// is a valid IP4 Address
 				SocketAddress->sin_addr = ((struct sockaddr_in*)ifa->ifa_addr)->sin_addr;
-				break;
+				u32 addr = ((struct sockaddr_in*)ifa->ifa_addr)->sin_addr.s_addr;
+				if (addr != 0x0100007f) {  // 127.0.0.1
+					// Found a plausible one
+					break;
+				}
 			}
 		}
 		freeifaddrs(ifAddrStruct);

--- a/Core/RetroAchievements.cpp
+++ b/Core/RetroAchievements.cpp
@@ -746,16 +746,20 @@ void UpdateSettings() {
 
 bool Shutdown() {
 	g_activeChallenges.clear();
+	if (g_rcClient) {
 #ifdef RC_CLIENT_SUPPORTS_RAINTEGRATION
-	rc_client_unload_raintegration(g_rcClient);
+		rc_client_unload_raintegration(g_rcClient);
 #endif
-	rc_client_destroy(g_rcClient);
-	g_rcClient = nullptr;
-	INFO_LOG(Log::Achievements, "Achievements shut down.");
+		rc_client_destroy(g_rcClient);
+		g_rcClient = nullptr;
+		INFO_LOG(Log::Achievements, "Achievements shut down.");
+	}
 	return true;
 }
 
 void ResetRuntime() {
+	if (!g_rcClient)
+		return;
 	INFO_LOG(Log::Achievements, "Resetting rcheevos state...");
 	rc_client_reset(g_rcClient);
 	g_activeChallenges.clear();


### PR DESCRIPTION
This path is unix-only, so it accounts for the difference against Windows seen in #19919

Fixes #19919 

Turns out that it seems to often just find 127.0.0.1, but if you let it keep looking it this case, it'll find the appropriate address to use, fixing the problem.

Not sure whether it's worth using this path or if we should use the next fallback instead as used by Windows, where we connect to 8.8.8.8 and check the local IP on the connection.