### PR TITLE
Rename and consolidate log functions

### DIFF
--- a/Common/CommonTypes.h
+++ b/Common/CommonTypes.h
@@ -24,6 +24,8 @@
 
 #if defined(_MSC_VER)
 
+#define NO_INLINE __declspec(noinline)
+
 typedef unsigned __int8 u8;
 typedef unsigned __int16 u16;
 typedef unsigned __int32 u32;
@@ -35,6 +37,8 @@ typedef signed __int32 s32;
 typedef signed __int64 s64;
 
 #else
+
+#define NO_INLINE __attribute__((noinline))
 
 #ifdef __SWITCH__
 // Some HID conflicts

--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -696,7 +696,7 @@ int Atrac::SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels,
 		Memory::Memcpy(dataBuf_, buffer, copybytes, "AtracSetData");
 	}
 	CreateDecoder();
-	return hleLogSuccessInfoI(Log::ME, successCode, "%s %s audio", codecName, channelName);
+	return hleLogInfo(Log::ME, successCode, "%s %s audio", codecName, channelName);
 }
 
 u32 Atrac::SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) {
@@ -714,7 +714,7 @@ u32 Atrac::SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) {
 	second_.addr = secondBuffer;
 	second_.size = secondBufferSize;
 	second_.fileoffset = secondFileOffset;
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 int AtracBase::GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) {
@@ -727,7 +727,7 @@ int AtracBase::GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) {
 
 	*fileOffset = track_.FileOffsetBySample(track_.loopEndSample - track_.firstSampleOffset);
 	*desiredSize = track_.fileSize - *fileOffset;
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 void Atrac::GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) {

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -128,7 +128,7 @@ int Atrac2::SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels
 	} else {
 		bufferState_ = ATRAC_STATUS_HALFWAY_BUFFER;
 	}
-	return hleLogSuccessI(Log::ME, successCode);
+	return hleLogDebug(Log::ME, successCode);
 }
 
 u32 Atrac2::SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) {

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -281,25 +281,18 @@ inline R hleCallImpl(std::string_view module, std::string_view funcName, F func,
 // IMPORTANT: These *must* only be used directly in HLE functions. They cannot be used by utility functions
 // called by them. Use regular ERROR_LOG etc for those.
 
-#define hleLogHelper(t, level, res, retmask, ...) \
+#define hleLogReturnHelper(t, level, res, retmask, ...) \
 	(((int)level <= MAX_LOGLEVEL) ? hleDoLog<true>(t, level, (res), __FILE__, __LINE__, nullptr, retmask, ##__VA_ARGS__) : (res))
 
-#define hleLogError(t, res, ...) hleLogHelper(t, LogLevel::LERROR, res, 'x', ##__VA_ARGS__)
-#define hleLogWarning(t, res, ...) hleLogHelper(t, LogLevel::LWARNING, res, 'x', ##__VA_ARGS__)
-#define hleLogVerbose(t, res, ...) hleLogHelper(t, HLE_LOG_LVERBOSE, res, 'x', ##__VA_ARGS__)
+#define hleLogError(t, res, ...) hleLogReturnHelper(t, LogLevel::LERROR, res, 'x', ##__VA_ARGS__)
+#define hleLogWarning(t, res, ...) hleLogReturnHelper(t, LogLevel::LWARNING, res, 'x', ##__VA_ARGS__)
+#define hleLogDebug(t, res, ...) hleLogReturnHelper(t, HLE_LOG_LDEBUG, res, 'x', ##__VA_ARGS__)
+#define hleLogInfo(t, res, ...) hleLogReturnHelper(t, LogLevel::LINFO, res, 'x', ##__VA_ARGS__)
+#define hleLogVerbose(t, res, ...) hleLogReturnHelper(t, HLE_LOG_LVERBOSE, res, 'x', ##__VA_ARGS__)
 
 // If res is negative, log warn/error, otherwise log debug.
-#define hleLogSuccessOrWarn(t, res, ...) hleLogHelper(t, ((int)res < 0 ? LogLevel::LWARNING : HLE_LOG_LDEBUG), res, 'x', ##__VA_ARGS__)
-#define hleLogSuccessOrError(t, res, ...) hleLogHelper(t, ((int)res < 0 ? LogLevel::LERROR : HLE_LOG_LDEBUG), res, 'x', ##__VA_ARGS__)
-
-// NOTE: hleLogDebug is equivalent to hleLogSuccessI/X.
-#define hleLogDebug(t, res, ...) hleLogHelper(t, HLE_LOG_LDEBUG, res, 'x', ##__VA_ARGS__)
-#define hleLogSuccessX(t, res, ...) hleLogHelper(t, HLE_LOG_LDEBUG, res, 'x', ##__VA_ARGS__)
-#define hleLogSuccessI(t, res, ...) hleLogHelper(t, HLE_LOG_LDEBUG, res, 'i', ##__VA_ARGS__)
-#define hleLogSuccessInfoX(t, res, ...) hleLogHelper(t, LogLevel::LINFO, res, 'x', ##__VA_ARGS__)
-#define hleLogSuccessInfoI(t, res, ...) hleLogHelper(t, LogLevel::LINFO, res, 'i', ##__VA_ARGS__)
-#define hleLogSuccessVerboseX(t, res, ...) hleLogHelper(t, HLE_LOG_LVERBOSE, res, 'x', ##__VA_ARGS__)
-#define hleLogSuccessVerboseI(t, res, ...) hleLogHelper(t, HLE_LOG_LVERBOSE, res, 'i', ##__VA_ARGS__)
+#define hleLogDebugOrWarn(t, res, ...) hleLogReturnHelper(t, ((int)res < 0 ? LogLevel::LWARNING : HLE_LOG_LDEBUG), res, 'x', ##__VA_ARGS__)
+#define hleLogDebugOrError(t, res, ...) hleLogReturnHelper(t, ((int)res < 0 ? LogLevel::LERROR : HLE_LOG_LDEBUG), res, 'x', ##__VA_ARGS__)
 
 #define hleReportError(t, res, ...) hleDoLog<true>(t, LogLevel::LERROR, res, __FILE__, __LINE__, "", 'x', ##__VA_ARGS__)
 #define hleReportWarning(t, res, ...) hleDoLog<true>(t, LogLevel::LWARNING, res, __FILE__, __LINE__, "", 'x', ##__VA_ARGS__)

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -200,7 +200,7 @@ static u32 sceAtracGetAtracID(int codecType) {
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	return hleLogSuccessInfoI(Log::ME, atracID);
+	return hleLogInfo(Log::ME, atracID);
 }
 
 static u32 AtracValidateData(const AtracBase *atrac) {
@@ -250,7 +250,7 @@ static u32 sceAtracAddStreamData(int atracID, u32 bytesToAdd) {
 	if (ret < 0) {
 		return ret;
 	}
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 // Note that outAddr being null is completely valid here, used to skip data.
@@ -312,7 +312,7 @@ static u32 sceAtracGetBufferInfoForResetting(int atracID, int sample, u32 buffer
 		return hleLogWarning(Log::ME, ATRAC_ERROR_BAD_SAMPLE, "invalid sample position");
 	} else {
 		atrac->GetResetBufferInfo(bufferInfo, sample);
-		return hleLogSuccessInfoI(Log::ME, 0);
+		return hleLogInfo(Log::ME, 0);
 	}
 }
 
@@ -328,7 +328,7 @@ static u32 sceAtracGetBitrate(int atracID, u32 outBitrateAddr) {
 
 	if (Memory::IsValidAddress(outBitrateAddr)) {
 		Memory::WriteUnchecked_U32(atrac->GetTrack().bitrate, outBitrateAddr);
-		return hleLogSuccessI(Log::ME, 0);
+		return hleLogDebug(Log::ME, 0);
 	} else {
 		return hleLogError(Log::ME, 0, "invalid address");
 	}
@@ -344,7 +344,7 @@ static u32 sceAtracGetChannel(int atracID, u32 channelAddr) {
 
 	if (Memory::IsValidAddress(channelAddr)){
 		Memory::WriteUnchecked_U32(atrac->GetTrack().channels, channelAddr);
-		return hleLogSuccessI(Log::ME, 0);
+		return hleLogDebug(Log::ME, 0);
 	} else {
 		return hleLogError(Log::ME, 0, "invalid address");
 	}
@@ -366,7 +366,7 @@ static u32 sceAtracGetLoopStatus(int atracID, u32 loopNumAddr, u32 statusAddr) {
 			Memory::WriteUnchecked_U32(1, statusAddr);
 		else
 			Memory::WriteUnchecked_U32(0, statusAddr);
-		return hleLogSuccessI(Log::ME, 0);
+		return hleLogDebug(Log::ME, 0);
 	} else {
 		return hleLogError(Log::ME, 0, "invalid address");
 	}
@@ -395,7 +395,7 @@ static u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr) {
 
 	if (Memory::IsValidAddress(maxSamplesAddr)) {
 		Memory::WriteUnchecked_U32(atrac->GetTrack().SamplesPerFrame(), maxSamplesAddr);
-		return hleLogSuccessI(Log::ME, 0);
+		return hleLogDebug(Log::ME, 0);
 	} else {
 		return hleLogError(Log::ME, 0, "invalid address");
 	}
@@ -412,10 +412,10 @@ static u32 sceAtracGetNextDecodePosition(int atracID, u32 outposAddr) {
 	if (Memory::IsValidAddress(outposAddr)) {
 		if (atrac->CurrentSample() >= atrac->GetTrack().endSample) {
 			Memory::WriteUnchecked_U32(0, outposAddr);
-			return hleLogSuccessI(Log::ME, ATRAC_ERROR_ALL_DATA_DECODED, "all data decoded - beyond endSample");
+			return hleLogDebug(Log::ME, ATRAC_ERROR_ALL_DATA_DECODED, "all data decoded - beyond endSample");
 		} else {
 			Memory::WriteUnchecked_U32(atrac->CurrentSample(), outposAddr);
-			return hleLogSuccessI(Log::ME, 0);
+			return hleLogDebug(Log::ME, 0);
 		}
 	} else {
 		return hleLogError(Log::ME, 0, "invalid address");
@@ -432,14 +432,14 @@ static u32 sceAtracGetNextSample(int atracID, u32 outNAddr) {
 	if (atrac->CurrentSample() >= atrac->GetTrack().endSample) {
 		if (Memory::IsValidAddress(outNAddr))
 			Memory::WriteUnchecked_U32(0, outNAddr);
-		return hleLogSuccessI(Log::ME, 0, "0 samples left");
+		return hleLogDebug(Log::ME, 0, "0 samples left");
 	}
 
 	u32 numSamples = atrac->GetNextSamples();
 
 	if (Memory::IsValidAddress(outNAddr))
 		Memory::WriteUnchecked_U32(numSamples, outNAddr);
-	return hleLogSuccessI(Log::ME, 0, "%d samples left", numSamples);
+	return hleLogDebug(Log::ME, 0, "%d samples left", numSamples);
 }
 
 // Obtains the number of frames remaining in the buffer which can be decoded.
@@ -460,7 +460,7 @@ static u32 sceAtracGetRemainFrame(int atracID, u32 remainAddr) {
 	}
 
 	*remainingFrames = atrac->RemainingFrames();
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static u32 sceAtracGetSecondBufferInfo(int atracID, u32 fileOffsetAddr, u32 desiredSizeAddr) {
@@ -503,7 +503,7 @@ static u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoop
 	if (!outEndSample.IsValid() || !outLoopStart.IsValid() || !outLoopEnd.IsValid()) {
 		return hleReportError(Log::ME, 0, "invalid address");
 	}
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 // Games call this function to get some info for add more stream data,
@@ -529,7 +529,7 @@ static u32 sceAtracGetStreamDataInfo(int atracID, u32 writePtrAddr, u32 writable
 	if (Memory::IsValidAddress(readOffsetAddr))
 		Memory::WriteUnchecked_U32(readOffset, readOffsetAddr);
 
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static u32 sceAtracReleaseAtracID(int atracID) {
@@ -541,7 +541,7 @@ static u32 sceAtracReleaseAtracID(int atracID) {
 			return hleLogWarning(Log::ME, result, "did not exist");
 		}
 	}
-	return hleLogSuccessInfoI(Log::ME, result);
+	return hleLogInfo(Log::ME, result);
 }
 
 // This is called when a game wants to seek (or "reset") to a specific position in the audio data.
@@ -568,7 +568,7 @@ static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFi
 		return res;
 	}
 
-	return hleDelayResult(hleLogSuccessInfoI(Log::ME, 0), "reset play pos", 3000);
+	return hleDelayResult(hleLogInfo(Log::ME, 0), "reset play pos", 3000);
 }
 
 // Allowed to log like a HLE function, only called at the end of some.
@@ -699,7 +699,7 @@ static u32 sceAtracSetLoopNum(int atracID, int loopNum) {
 	}
 
 	atrac->SetLoopNum(loopNum);
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static int sceAtracReinit(int at3Count, int at3plusCount) {
@@ -717,7 +717,7 @@ static int sceAtracReinit(int at3Count, int at3plusCount) {
 	// This seems to deinit things.  Mostly, it cause a reschedule on next deinit (but -1, -1 does not.)
 	if (at3Count == 0 && at3plusCount == 0) {
 		atracInited = false;
-		return hleDelayResult(hleLogSuccessInfoI(Log::ME, 0, "deinit"), "atrac reinit", 200);
+		return hleDelayResult(hleLogInfo(Log::ME, 0, "deinit"), "atrac reinit", 200);
 	}
 
 	// First, ATRAC3+.  These IDs seem to cost double (probably memory.)
@@ -739,10 +739,10 @@ static int sceAtracReinit(int at3Count, int at3plusCount) {
 	int result = space >= 0 ? 0 : (int)SCE_KERNEL_ERROR_OUT_OF_MEMORY;
 	if (atracInited || next == 0) {
 		atracInited = true;
-		return hleLogSuccessInfoI(Log::ME, result);
+		return hleLogInfo(Log::ME, result);
 	} else {
 		atracInited = true;
-		return hleDelayResult(hleLogSuccessInfoI(Log::ME, result), "atrac reinit", 400);
+		return hleDelayResult(hleLogInfo(Log::ME, result), "atrac reinit", 400);
 	}
 }
 
@@ -755,7 +755,7 @@ static int sceAtracGetOutputChannel(int atracID, u32 outputChanPtr) {
 	}
 	if (Memory::IsValidAddress(outputChanPtr)) {
 		Memory::WriteUnchecked_U32(atrac->GetOutputChannels(), outputChanPtr);
-		return hleLogSuccessI(Log::ME, 0);
+		return hleLogDebug(Log::ME, 0);
 	} else {
 		return hleLogError(Log::ME, 0, "invalid address");
 	}
@@ -771,7 +771,7 @@ static int sceAtracIsSecondBufferNeeded(int atracID) {
 
 	// Note that this returns true whether the buffer is already set or not.
 	int needed = atrac->BufferState() == ATRAC_STATUS_STREAMED_LOOP_WITH_TRAILER ? 1 : 0;
-	return hleLogSuccessI(Log::ME, needed);
+	return hleLogDebug(Log::ME, needed);
 }
 
 static int sceAtracSetMOutHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 bufferSize) {
@@ -955,7 +955,7 @@ static int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 
 	const char *codecName = atrac->GetTrack().codecType == PSP_MODE_AT_3 ? "atrac3" : "atrac3+";
 	const char *channelName = atrac->GetTrack().channels == 1 ? "mono" : "stereo";
-	return hleLogSuccessInfoI(Log::ME, 0, "%s %s audio", codecName, channelName);
+	return hleLogInfo(Log::ME, 0, "%s %s audio", codecName, channelName);
 }
 
 static int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesConsumedAddr, u32 samplesAddr, u32 sampleBytesAddr) {

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -222,7 +222,7 @@ static u32 sceAudioChRelease(u32 chan) {
 	// TODO: Does this error if busy?
 	chans[chan].reset();
 	chans[chan].reserved = false;
-	return hleLogSuccessI(Log::sceAudio, 0);
+	return hleLogDebug(Log::sceAudio, 0);
 }
 
 static u32 sceAudioSetChannelDataLen(u32 chan, u32 len) {
@@ -287,7 +287,7 @@ static u32 sceAudioOutput2Reserve(u32 sampleCount) {
 	chan.format = PSP_AUDIO_FORMAT_STEREO;
 	chan.reserved = true;
 	__AudioSetSRCFrequency(0);
-	return hleLogSuccessI(Log::sceAudio, 0);
+	return hleLogDebug(Log::sceAudio, 0);
 }
 
 static u32 sceAudioOutput2OutputBlocking(u32 vol, u32 dataPtr) {
@@ -309,7 +309,7 @@ static u32 sceAudioOutput2OutputBlocking(u32 vol, u32 dataPtr) {
 	int result = __AudioEnqueue(chan, PSP_AUDIO_CHANNEL_OUTPUT2, true);
 	if (result < 0)
 		return hleLogError(Log::sceAudio, result);
-	return hleLogSuccessI(Log::sceAudio, result);
+	return hleLogDebug(Log::sceAudio, result);
 }
 
 static u32 sceAudioOutput2ChangeLength(u32 sampleCount) {
@@ -318,7 +318,7 @@ static u32 sceAudioOutput2ChangeLength(u32 sampleCount) {
 		return hleLogError(Log::sceAudio, SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED, "channel not reserved");
 	}
 	chan.sampleCount = sampleCount;
-	return hleLogSuccessI(Log::sceAudio, 0);
+	return hleLogDebug(Log::sceAudio, 0);
 }
 
 static u32 sceAudioOutput2GetRestSample() {
@@ -331,7 +331,7 @@ static u32 sceAudioOutput2GetRestSample() {
 		// If ChangeLength reduces the size, it still gets output but this return is clamped.
 		size = chan.sampleCount;
 	}
-	return hleLogSuccessI(Log::sceAudio, size);
+	return hleLogDebug(Log::sceAudio, size);
 }
 
 static u32 sceAudioOutput2Release() {
@@ -343,7 +343,7 @@ static u32 sceAudioOutput2Release() {
 
 	chan.reset();
 	chan.reserved = false;
-	return hleLogSuccessI(Log::sceAudio, 0);
+	return hleLogDebug(Log::sceAudio, 0);
 }
 
 static u32 sceAudioSetFrequency(u32 freq) {
@@ -392,7 +392,7 @@ static u32 sceAudioSRCChReserve(u32 sampleCount, u32 freq, u32 format) {
 	chan.format = format == 2 ? PSP_AUDIO_FORMAT_STEREO : PSP_AUDIO_FORMAT_MONO;
 	// Zero means default to 44.1kHz.
 	__AudioSetSRCFrequency(freq);
-	return hleLogSuccessI(Log::sceAudio, 0);
+	return hleLogDebug(Log::sceAudio, 0);
 }
 
 static u32 sceAudioSRCChRelease() {
@@ -404,7 +404,7 @@ static u32 sceAudioSRCChRelease() {
 
 	chan.reset();
 	chan.reserved = false;
-	return hleLogSuccessI(Log::sceAudio, 0);
+	return hleLogDebug(Log::sceAudio, 0);
 }
 
 static u32 sceAudioSRCOutputBlocking(u32 vol, u32 buf) {
@@ -425,14 +425,14 @@ static u32 sceAudioSRCOutputBlocking(u32 vol, u32 buf) {
 	int result = __AudioEnqueue(chan, PSP_AUDIO_CHANNEL_SRC, true);
 	if (result < 0)
 		return hleLogError(Log::sceAudio, result);
-	return hleLogSuccessI(Log::sceAudio, result);
+	return hleLogDebug(Log::sceAudio, result);
 }
 
 static int sceAudioInputBlocking(u32 maxSamples, u32 sampleRate, u32 bufAddr) {
 	if (!Memory::IsValidAddress(bufAddr)) {
 		return hleLogError(Log::HLE, -1, "invalid address");
 	}
-	return hleLogSuccessInfoI(Log::HLE, __MicInput(maxSamples, sampleRate, bufAddr, AUDIOINPUT));
+	return hleLogInfo(Log::HLE, __MicInput(maxSamples, sampleRate, bufAddr, AUDIOINPUT));
 }
 
 static int sceAudioInput(u32 maxSamples, u32 sampleRate, u32 bufAddr) {

--- a/Core/HLE/sceChnnlsv.cpp
+++ b/Core/HLE/sceChnnlsv.cpp
@@ -219,7 +219,7 @@ static int sceSdGetLastIndex(u32 addressCtx, u32 addressHash, u32 addressKey) {
 	u8 *hash = Memory::GetPointerWrite(addressHash);
 	if (!ctx.IsValid() || !hash)
 		return hleLogError(Log::sceMisc, 0, "Invalid pointer");
-	return hleLogSuccessI(Log::sceMisc, sceSdGetLastIndex_(*ctx, hash, Memory::GetPointerWrite(addressKey)));
+	return hleLogDebug(Log::sceMisc, sceSdGetLastIndex_(*ctx, hash, Memory::GetPointerWrite(addressKey)));
 }
 
 int sceSdGetLastIndex_(pspChnnlsvContext1& ctx, u8* in_hash, const u8* in_key)
@@ -328,7 +328,7 @@ static int sceSdSetIndex(u32 addressCtx, int value) {
 	auto ctx = PSPPointer<pspChnnlsvContext1>::Create(addressCtx);
 	if (!ctx.IsValid())
 		return hleLogError(Log::sceMisc, 0, "Invalid pointer");
-	return hleLogSuccessI(Log::sceMisc, sceSdSetIndex_(*ctx, value));
+	return hleLogDebug(Log::sceMisc, sceSdSetIndex_(*ctx, value));
 }
 
 int sceSdSetIndex_(pspChnnlsvContext1& ctx, int value)
@@ -345,7 +345,7 @@ static int sceSdRemoveValue(u32 addressCtx, u32 addressData, int length) {
 	auto ctx = PSPPointer<pspChnnlsvContext1>::Create(addressCtx);
 	if (!ctx.IsValid() || !Memory::IsValidAddress(addressData))
 		return hleLogError(Log::sceMisc, 0, "Invalid pointer");
-	return hleLogSuccessI(Log::sceMisc, sceSdRemoveValue_(*ctx, Memory::GetPointerWrite(addressData), length));
+	return hleLogDebug(Log::sceMisc, sceSdRemoveValue_(*ctx, Memory::GetPointerWrite(addressData), length));
 }
 
 int sceSdRemoveValue_(pspChnnlsvContext1& ctx, const u8* data, int length)
@@ -397,7 +397,7 @@ static int sceSdCreateList(u32 ctx2Addr, int mode, int unkwn, u32 dataAddr, u32 
 	if (!ctx2.IsValid() || !data)
 		return hleLogError(Log::sceMisc, 0, "Invalid pointer");
 
-	return hleLogSuccessI(Log::sceMisc, sceSdCreateList_(*ctx2, mode, unkwn, data, cryptkey));
+	return hleLogDebug(Log::sceMisc, sceSdCreateList_(*ctx2, mode, unkwn, data, cryptkey));
 }
 
 int sceSdCreateList_(pspChnnlsvContext2& ctx2, int mode, int uknw, u8* data, const u8* cryptkey)
@@ -460,7 +460,7 @@ static int sceSdSetMember(u32 ctxAddr, u32 dataAddr, int alignedLen) {
 	if (!ctx.IsValid() || !data)
 		return hleLogError(Log::sceMisc, 0, "Invalid pointer");
 
-	return hleLogSuccessI(Log::sceMisc, sceSdSetMember_(*ctx, data, alignedLen));
+	return hleLogDebug(Log::sceMisc, sceSdSetMember_(*ctx, data, alignedLen));
 }
 
 int sceSdSetMember_(pspChnnlsvContext2& ctx, u8* data, int alignedLen)
@@ -501,7 +501,7 @@ static int sceSdCleanList(u32 ctxAddr) {
 	auto ctx = PSPPointer<pspChnnlsvContext2>::Create(ctxAddr);
 	if (!ctx.IsValid())
 		return hleLogError(Log::sceMisc, 0, "Invalid pointer");
-	return hleLogSuccessI(Log::sceMisc, sceSdCleanList_(*ctx));
+	return hleLogDebug(Log::sceMisc, sceSdCleanList_(*ctx));
 }
 
 int sceSdCleanList_(pspChnnlsvContext2& ctx)

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -557,7 +557,7 @@ static u32 sceCtrlPeekLatch(u32 latchDataPtr) {
 	if (userLatch.IsValid()) {
 		__CtrlWriteUserLatch(userLatch, ctrlLatchBufs);
 	}
-	return hleLogSuccessI(Log::sceCtrl, ctrlLatchBufs);
+	return hleLogDebug(Log::sceCtrl, ctrlLatchBufs);
 }
 
 static u32 sceCtrlReadLatch(u32 latchDataPtr) {
@@ -565,7 +565,7 @@ static u32 sceCtrlReadLatch(u32 latchDataPtr) {
 	if (userLatch.IsValid()) {
 		__CtrlWriteUserLatch(userLatch, ctrlLatchBufs);
 	}
-	return hleLogSuccessI(Log::sceCtrl, __CtrlResetLatch());
+	return hleLogDebug(Log::sceCtrl, __CtrlResetLatch());
 }
 
 static const HLEFunction sceCtrl[] =

--- a/Core/HLE/sceDeflt.cpp
+++ b/Core/HLE/sceDeflt.cpp
@@ -65,7 +65,7 @@ static int CommonDecompress(int windowBits, u32 OutBuffer, int OutBufferLength, 
 		NotifyMemInfo(MemBlockFlags::WRITE, OutBuffer, stream.total_out, tagData, tagSize);
 	}
 
-	return hleLogSuccessI(Log::HLE, stream.total_out);
+	return hleLogDebug(Log::HLE, stream.total_out);
 }
 
 static int sceDeflateDecompress(u32 OutBuffer, int OutBufferLength, u32 InBuffer, u32 Crc32Addr) {

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -772,7 +772,7 @@ void hleLagSync(u64 userdata, int cyclesLate) {
 }
 
 static u32 sceDisplayIsVblank() {
-	return hleLogSuccessI(Log::sceDisplay, DisplayIsVblank());
+	return hleLogDebug(Log::sceDisplay, DisplayIsVblank());
 }
 
 void __DisplayWaitForVblanks(const char *reason, int vblanks, bool callbacks) {
@@ -807,7 +807,7 @@ static u32 sceDisplaySetMode(int displayMode, int displayWidth, int displayHeigh
 
 	// On success, this implicitly waits for a vblank start.
 	__DisplayWaitForVblanks("display mode", 1);
-	return hleLogSuccessI(Log::sceDisplay, 0);
+	return hleLogDebug(Log::sceDisplay, 0);
 }
 
 void __DisplaySetFramebuf(u32 topaddr, int linesize, int pixelFormat, int sync) {
@@ -910,12 +910,12 @@ u32 sceDisplaySetFramebuf(u32 topaddr, int linesize, int pixelformat, int sync) 
 		// Okay, the game is going at too high a frame rate.  God of War and Fat Princess both do this.
 		// Simply eating the cycles works and is fast, but breaks other games (like Jeanne d'Arc.)
 		// So, instead, we delay this HLE thread only (a small deviation from correct behavior.)
-		return hleDelayResult(hleLogSuccessI(Log::sceDisplay, 0, "delaying frame thread"), "set framebuf", cyclesToUs(delayCycles));
+		return hleDelayResult(hleLogDebug(Log::sceDisplay, 0, "delaying frame thread"), "set framebuf", cyclesToUs(delayCycles));
 	} else {
 		if (topaddr == 0) {
-			return hleLogSuccessI(Log::sceDisplay, 0, "disabling display");
+			return hleLogDebug(Log::sceDisplay, 0, "disabling display");
 		} else {
-			return hleLogSuccessI(Log::sceDisplay, 0);
+			return hleLogDebug(Log::sceDisplay, 0);
 		}
 	}
 }
@@ -942,7 +942,7 @@ static u32 sceDisplayGetFramebuf(u32 topaddrPtr, u32 linesizePtr, u32 pixelForma
 	if (Memory::IsValidAddress(pixelFormatPtr))
 		Memory::Write_U32(fbState.fmt, pixelFormatPtr);
 
-	return hleLogSuccessI(Log::sceDisplay, 0);
+	return hleLogDebug(Log::sceDisplay, 0);
 }
 
 static void __DisplayWaitForVblanksCB(const char *reason, int vblanks) {
@@ -951,17 +951,17 @@ static void __DisplayWaitForVblanksCB(const char *reason, int vblanks) {
 
 static u32 sceDisplayWaitVblankStart() {
 	__DisplayWaitForVblanks("vblank start waited", 1);
-	return hleLogSuccessI(Log::sceDisplay, 0);
+	return hleLogDebug(Log::sceDisplay, 0);
 }
 
 static u32 sceDisplayWaitVblank() {
 	if (!DisplayIsVblank()) {
 		__DisplayWaitForVblanks("vblank waited", 1);
-		return hleLogSuccessI(Log::sceDisplay, 0);
+		return hleLogDebug(Log::sceDisplay, 0);
 	} else {
 		hleEatCycles(1110);
 		hleReSchedule("vblank wait skipped");
-		return hleLogSuccessI(Log::sceDisplay, 1, "not waiting since in vblank");
+		return hleLogDebug(Log::sceDisplay, 1, "not waiting since in vblank");
 	}
 }
 
@@ -975,23 +975,23 @@ static u32 sceDisplayWaitVblankStartMulti(int vblanks) {
 		return hleLogWarning(Log::sceDisplay, SCE_KERNEL_ERROR_ILLEGAL_CONTEXT, "in interrupt");
 
 	__DisplayWaitForVblanks("vblank start multi waited", vblanks);
-	return hleLogSuccessI(Log::sceDisplay, 0);
+	return hleLogDebug(Log::sceDisplay, 0);
 }
 
 static u32 sceDisplayWaitVblankCB() {
 	if (!DisplayIsVblank()) {
 		__DisplayWaitForVblanksCB("vblank waited", 1);
-		return hleLogSuccessI(Log::sceDisplay, 0);
+		return hleLogDebug(Log::sceDisplay, 0);
 	} else {
 		hleEatCycles(1110);
 		hleReSchedule("vblank wait skipped");
-		return hleLogSuccessI(Log::sceDisplay, 1, "not waiting since in vblank");
+		return hleLogDebug(Log::sceDisplay, 1, "not waiting since in vblank");
 	}
 }
 
 static u32 sceDisplayWaitVblankStartCB() {
 	__DisplayWaitForVblanksCB("vblank start waited", 1);
-	return hleLogSuccessI(Log::sceDisplay, 0);
+	return hleLogDebug(Log::sceDisplay, 0);
 }
 
 static u32 sceDisplayWaitVblankStartMultiCB(int vblanks) {
@@ -1004,18 +1004,18 @@ static u32 sceDisplayWaitVblankStartMultiCB(int vblanks) {
 		return hleLogWarning(Log::sceDisplay, SCE_KERNEL_ERROR_ILLEGAL_CONTEXT, "in interrupt");
 
 	__DisplayWaitForVblanksCB("vblank start multi waited", vblanks);
-	return hleLogSuccessI(Log::sceDisplay, 0);
+	return hleLogDebug(Log::sceDisplay, 0);
 }
 
 static u32 sceDisplayGetVcount() {
 	hleEatCycles(150);
 	hleReSchedule("get vcount");
-	return hleLogSuccessVerboseI(Log::sceDisplay, __DisplayGetVCount());
+	return hleLogVerbose(Log::sceDisplay, __DisplayGetVCount());
 }
 
 static u32 sceDisplayGetCurrentHcount() {
 	hleEatCycles(275);
-	return hleLogSuccessI(Log::sceDisplay, __DisplayGetCurrentHcount());
+	return hleLogDebug(Log::sceDisplay, __DisplayGetCurrentHcount());
 }
 
 static int sceDisplayAdjustAccumulatedHcount(int value) {
@@ -1028,13 +1028,13 @@ static int sceDisplayAdjustAccumulatedHcount(int value) {
 	int diff = value - accumHCount;
 	DisplayAdjustAccumulatedHcount(diff);
 
-	return hleLogSuccessI(Log::sceDisplay, 0);
+	return hleLogDebug(Log::sceDisplay, 0);
 }
 
 static int sceDisplayGetAccumulatedHcount() {
 	u32 accumHCount = __DisplayGetAccumulatedHcount();
 	hleEatCycles(235);
-	return hleLogSuccessI(Log::sceDisplay, accumHCount);
+	return hleLogDebug(Log::sceDisplay, accumHCount);
 }
 
 static float sceDisplayGetFramePerSec() {
@@ -1044,7 +1044,7 @@ static float sceDisplayGetFramePerSec() {
 
 static u32 sceDisplayIsForeground() {
 	int result = hasSetMode && framebuf.topaddr != 0 ? 1 : 0;
-	return hleLogSuccessI(Log::sceDisplay, result);
+	return hleLogDebug(Log::sceDisplay, result);
 }
 
 static u32 sceDisplayGetMode(u32 modeAddr, u32 widthAddr, u32 heightAddr) {
@@ -1054,7 +1054,7 @@ static u32 sceDisplayGetMode(u32 modeAddr, u32 widthAddr, u32 heightAddr) {
 		Memory::Write_U32(width, widthAddr);
 	if (Memory::IsValidAddress(heightAddr))
 		Memory::Write_U32(height, heightAddr);
-	return hleLogSuccessI(Log::sceDisplay, 0);
+	return hleLogDebug(Log::sceDisplay, 0);
 }
 
 static u32 sceDisplayIsVsync() {
@@ -1062,13 +1062,13 @@ static u32 sceDisplayIsVsync() {
 	u64 start = DisplayFrameStartTicks() + msToCycles(vsyncStartMs);
 	u64 end = DisplayFrameStartTicks() + msToCycles(vsyncEndMs);
 
-	return hleLogSuccessI(Log::sceDisplay, now >= start && now <= end ? 1 : 0);
+	return hleLogDebug(Log::sceDisplay, now >= start && now <= end ? 1 : 0);
 }
 
 static u32 sceDisplayGetResumeMode(u32 resumeModeAddr) {
 	if (Memory::IsValidAddress(resumeModeAddr))
 		Memory::Write_U32(resumeMode, resumeModeAddr);
-	return hleLogSuccessI(Log::sceDisplay, 0);
+	return hleLogDebug(Log::sceDisplay, 0);
 }
 
 static u32 sceDisplaySetResumeMode(u32 rMode) {

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -1042,14 +1042,14 @@ static u32 sceFontNewLib(u32 paramPtr, u32 errorCodePtr) {
 	// The game should never see this value, the return value is replaced
 	// by the action. Except if we disable the alloc, in this case we return
 	// the handle correctly here.
-	return hleDelayResult(hleLogSuccessInfoI(Log::sceFont, newLib->handle()), "new fontlib", 30000);
+	return hleDelayResult(hleLogInfo(Log::sceFont, newLib->handle()), "new fontlib", 30000);
 }
 
 static int sceFontDoneLib(u32 fontLibHandle) {
 	FontLib *fl = GetFontLib(fontLibHandle);
 	if (fl) {
 		fl->Done();
-		return hleLogSuccessInfoI(Log::sceFont, 0);
+		return hleLogInfo(Log::sceFont, 0);
 	}
 
 	return hleLogWarning(Log::sceFont, 0, "invalid font lib");
@@ -1079,8 +1079,8 @@ static u32 sceFontOpen(u32 libHandle, u32 index, u32 mode, u32 errorCodePtr) {
 		*errorCode = 0;
 		// Delay only on the first open.
 		if (fontLib->GetFontRefCount(internalFonts[index]) == 1)
-			return hleDelayResult(hleLogSuccessX(Log::sceFont, font->Handle()), "font open", 10000);
-		return hleLogSuccessX(Log::sceFont, font->Handle());
+			return hleDelayResult(hleLogDebug(Log::sceFont, font->Handle()), "font open", 10000);
+		return hleLogDebug(Log::sceFont, font->Handle());
 	}
 	return 0;
 }
@@ -1118,7 +1118,7 @@ static u32 sceFontOpenUserMemory(u32 libHandle, u32 memoryFontPtr, u32 memoryFon
 	LoadedFont *font = fontLib->OpenFont(f, FONT_OPEN_USERBUFFER, *errorCode);
 	if (font) {
 		*errorCode = 0;
-		return hleLogSuccessX(Log::sceFont, font->Handle());
+		return hleLogDebug(Log::sceFont, font->Handle());
 	}
 	delete f;
 	return hleNoLog(0);
@@ -1158,7 +1158,7 @@ static u32 sceFontOpenUserFile(u32 libHandle, const char *fileName, u32 mode, u3
 	LoadedFont *font = fontLib->OpenFont(f, openMode, *errorCode);
 	if (font) {
 		*errorCode = 0;
-		return hleLogSuccessInfoX(Log::sceFont, font->Handle());
+		return hleLogInfo(Log::sceFont, font->Handle());
 	}
 
 	delete f;
@@ -1214,7 +1214,7 @@ static int sceFontFindOptimumFont(u32 libHandle, u32 fontStylePtr, u32 errorCode
 			if (str == "ltn12.pgf") {
 				optimumFont = internalFonts[j];
 				*errorCode = 0;
-				return hleLogSuccessInfoI(Log::sceFont, GetInternalFontIndex(optimumFont));
+				return hleLogInfo(Log::sceFont, GetInternalFontIndex(optimumFont));
 			}
 		}
 	}
@@ -1248,10 +1248,10 @@ static int sceFontFindOptimumFont(u32 libHandle, u32 fontStylePtr, u32 errorCode
 	}
 	if (optimumFont) {
 		*errorCode = 0;
-		return hleLogSuccessInfoX(Log::sceFont, GetInternalFontIndex(optimumFont) ,"");
+		return hleLogInfo(Log::sceFont, GetInternalFontIndex(optimumFont) ,"");
 	} else {
 		*errorCode = 0;
-		return hleLogSuccessInfoX(Log::sceFont, 0, "");
+		return hleLogInfo(Log::sceFont, 0, "");
 	}
 }
 
@@ -1477,7 +1477,7 @@ static int sceFontSetAltCharacterCode(u32 fontLibHandle, u32 charCode) {
 	}
 
 	fl->SetAltCharCode(charCode & 0xFFFF);
-	return hleLogSuccessInfoI(Log::sceFont, 0);
+	return hleLogInfo(Log::sceFont, 0);
 }
 
 static int sceFontFlush(u32 fontHandle) {

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -503,7 +503,7 @@ static u32 sceGeSetCallback(u32 structAddr) {
 		hleCall(InterruptManager, u32, sceKernelEnableSubIntr, PSP_GE_INTR, subIntrBase | PSP_GE_SUBINTR_SIGNAL);
 	}
 
-	return hleLogSuccessI(Log::sceGe, cbID);
+	return hleLogDebug(Log::sceGe, cbID);
 }
 
 static int sceGeUnsetCallback(u32 cbID) {
@@ -577,7 +577,7 @@ static int sceGeGetMtx(int type, u32 matrixPtr) {
 	if (!gpu || !gpu->GetMatrix24(GEMatrixType(type), dest, 0))
 		return hleLogError(Log::sceGe, SCE_KERNEL_ERROR_INVALID_INDEX, "invalid matrix");
 
-	return hleLogSuccessInfoI(Log::sceGe, 0);
+	return hleLogInfo(Log::sceGe, 0);
 }
 
 static u32 sceGeGetCmd(int cmd) {
@@ -607,7 +607,7 @@ static u32 sceGeGetCmd(int cmd) {
 		default:
 			break;
 		}
-		return hleLogSuccessInfoX(Log::sceGe, val);
+		return hleLogInfo(Log::sceGe, val);
 	}
 	return hleLogError(Log::sceGe, SCE_KERNEL_ERROR_INVALID_INDEX);
 }

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -634,7 +634,7 @@ const HLEFunction sceGe_user[] = {
 	{0XAB49E76A, &WrapU_UUIU<sceGeListEnQueue>,          "sceGeListEnQueue",             'x', "xxip"},
 	{0X1C0D95A6, &WrapU_UUIU<sceGeListEnQueueHead>,      "sceGeListEnQueueHead",         'x', "xxip"},
 	{0XE0D68148, &WrapI_UU<sceGeListUpdateStallAddr>,    "sceGeListUpdateStallAddr",     'i', "xx"  },
-	{0X03444EB4, &WrapI_UU<sceGeListSync>,               "sceGeListSync",                'i', "xx"  },
+	{0X03444EB4, &WrapI_UU<sceGeListSync>,               "sceGeListSync",                'x', "xx"  },
 	{0XB287BD61, &WrapU_U<sceGeDrawSync>,                "sceGeDrawSync",                'x', "x"   },
 	{0XB448EC0D, &WrapI_UU<sceGeBreak>,                  "sceGeBreak",                   'i', "xx"  },
 	{0X4C06E472, &WrapI_V<sceGeContinue>,                "sceGeContinue",                'i', ""    },

--- a/Core/HLE/sceHttp.cpp
+++ b/Core/HLE/sceHttp.cpp
@@ -575,7 +575,7 @@ static int sceHttpCreateRequest(int connectionID, int method, const char *path, 
 
 	httpObjects.emplace_back(std::make_shared<HTTPRequest>(connectionID, method, path? path:"", contentLength));
 	int retid = (int)httpObjects.size();
-	return hleLogSuccessI(Log::sceNet, retid);
+	return hleLogDebug(Log::sceNet, retid);
 }
 
 // FIXME: port type is probably u16 (but passed in a single register anyway, so type doesn't matter)
@@ -592,7 +592,7 @@ static int sceHttpCreateConnection(int templateID, const char *hostString, const
 
 	httpObjects.emplace_back(std::make_shared<HTTPConnection>(templateID, hostString ? hostString : "", scheme ? scheme : "", port, enableKeepalive));
 	int retid = (int)httpObjects.size();
-	return hleLogSuccessI(Log::sceNet, retid);
+	return hleLogDebug(Log::sceNet, retid);
 }
 
 static int sceHttpGetNetworkErrno(int request, u32 errNumPtr) {
@@ -724,7 +724,7 @@ static int sceHttpCreateTemplate(const char *userAgent, int httpVer, int autoPro
 	std::lock_guard<std::mutex> guard(httpLock);
 	httpObjects.push_back(std::make_shared<HTTPTemplate>(userAgent? userAgent:"", httpVer, autoProxyConf));
 	int retid = (int)httpObjects.size();
-	return hleLogSuccessI(Log::sceNet, retid);
+	return hleLogDebug(Log::sceNet, retid);
 }
 
 // Parameter "method" should be one of PSPHttpMethod's listed entries
@@ -746,7 +746,7 @@ static int sceHttpCreateRequestWithURL(int connectionID, int method, const char 
 
 	httpObjects.emplace_back(std::make_shared<HTTPRequest>(connectionID, method, url ? url : "", contentLength));
 	int retid = (int)httpObjects.size();
-	return hleLogSuccessI(Log::sceNet, retid);
+	return hleLogDebug(Log::sceNet, retid);
 }
 
 static int sceHttpCreateConnectionWithURL(int templateID, const char *url, int enableKeepalive) {
@@ -766,7 +766,7 @@ static int sceHttpCreateConnectionWithURL(int templateID, const char *url, int e
 
 	httpObjects.emplace_back(std::make_shared<HTTPConnection>(templateID, baseURL.Host().c_str(), baseURL.Protocol().c_str(), baseURL.Port(), enableKeepalive));
 	int retid = (int)httpObjects.size();
-	return hleLogSuccessI(Log::sceNet, retid);
+	return hleLogDebug(Log::sceNet, retid);
 }
 
 // id: ID of the template or connection

--- a/Core/HLE/sceImpose.cpp
+++ b/Core/HLE/sceImpose.cpp
@@ -76,7 +76,7 @@ static u32 sceImposeSetLanguageMode(u32 languageVal, u32 buttonVal) {
 	if (language != g_Config.GetPSPLanguage()) {
 		return hleLogWarning(Log::sceUtility, 0, "ignoring requested language");
 	}
-	return hleLogSuccessI(Log::sceUtility, 0);
+	return hleLogDebug(Log::sceUtility, 0);
 }
 
 static u32 sceImposeGetLanguageMode(u32 languagePtr, u32 btnPtr) {

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1170,7 +1170,7 @@ static u32 sceIoReadAsync(int id, u32 data_addr, int size) {
 		params.std.addr = data_addr;
 		params.std.size = size;
 		IoStartAsyncThread(id, f);
-		return hleLogSuccessI(Log::sceIo, 0);
+		return hleLogDebug(Log::sceIo, 0);
 	} else {
 		return hleLogError(Log::sceIo, error, "bad file descriptor");
 	}
@@ -1301,7 +1301,7 @@ static u32 sceIoWriteAsync(int id, u32 data_addr, int size) {
 		params.std.addr = data_addr;
 		params.std.size = size;
 		IoStartAsyncThread(id, f);
-		return hleLogSuccessI(Log::sceIo, 0);
+		return hleLogDebug(Log::sceIo, 0);
 	} else {
 		return hleLogError(Log::sceIo, error, "bad file descriptor");
 	}
@@ -1459,7 +1459,7 @@ static u32 sceIoLseekAsync(int id, s64 offset, int whence) {
 		params.seek.pos = offset;
 		params.seek.whence = whence;
 		IoStartAsyncThread(id, f);
-		return hleLogSuccessI(Log::sceIo, 0);
+		return hleLogDebug(Log::sceIo, 0);
 	} else {
 		return hleLogError(Log::sceIo, error, "bad file descriptor");
 	}
@@ -1482,7 +1482,7 @@ static u32 sceIoLseek32Async(int id, int offset, int whence) {
 		params.seek.pos = offset;
 		params.seek.whence = whence;
 		IoStartAsyncThread(id, f);
-		return hleLogSuccessI(Log::sceIo, 0);
+		return hleLogDebug(Log::sceIo, 0);
 	} else {
 		return hleLogError(Log::sceIo, error, "bad file descriptor");
 	}
@@ -1590,12 +1590,12 @@ static u32 sceIoOpen(const char *filename, int flags, int mode) {
 		IFileSystem *sys = pspFileSystem.GetSystemFromFilename(filename);
 		if (sys && !f->isTTY && (sys->DevType(f->handle) & (PSPDevType::BLOCK | PSPDevType::EMU_LBN))) {
 			// These are fast to open, no delay or even rescheduling happens.
-			return hleLogSuccessI(Log::sceIo, id);
+			return hleLogDebug(Log::sceIo, id);
 		}
 		// UMD: Speed varies from 1-6ms.
 		// Card: Path depth matters, but typically between 10-13ms on a standard Pro Duo.
 		int delay = pspFileSystem.FlagsFromFilename(filename) & FileSystemFlags::UMD ? 4000 : 10000;
-		return hleDelayResult(hleLogSuccessI(Log::sceIo, id), "file opened", delay);
+		return hleDelayResult(hleLogDebug(Log::sceIo, id), "file opened", delay);
 	}
 }
 
@@ -2116,7 +2116,7 @@ static int sceIoChangeAsyncPriority(int id, int priority) {
 
 	if (id == -1) {
 		asyncDefaultPriority = priority;
-		return hleLogSuccessI(Log::sceIo, 0);
+		return hleLogDebug(Log::sceIo, 0);
 	}
 
 	u32 error;
@@ -2133,7 +2133,7 @@ static int sceIoChangeAsyncPriority(int id, int priority) {
 	}
 
 	asyncParams[id].priority = priority;
-	return hleLogSuccessI(Log::sceIo, 0);
+	return hleLogDebug(Log::sceIo, 0);
 }
 
 static int sceIoCloseAsync(int id) {
@@ -2151,7 +2151,7 @@ static int sceIoCloseAsync(int id) {
 	auto &params = asyncParams[id];
 	params.op = IoAsyncOp::CLOSE;
 	IoStartAsyncThread(id, f);
-	return hleLogSuccessI(Log::sceIo, 0);
+	return hleLogDebug(Log::sceIo, 0);
 }
 
 static u32 sceIoSetAsyncCallback(int id, u32 clbckId, u32 clbckArg) {
@@ -2216,7 +2216,7 @@ static u32 sceIoOpenAsync(const char *filename, int flags, int mode) {
 	}
 
 	f->asyncResult = fd;
-	return hleLogSuccessI(Log::sceIo, fd);
+	return hleLogDebug(Log::sceIo, fd);
 }
 
 static u32 sceIoGetAsyncStat(int id, u32 poll, u32 address) {
@@ -2281,7 +2281,7 @@ static int sceIoWaitAsync(int id, u32 address) {
 			}
 			f->waitingThreads.push_back(__KernelGetCurThread());
 			__KernelWaitCurThread(WAITTYPE_ASYNCIO, f->GetUID(), address, 0, false, "io waited");
-			return hleLogSuccessI(Log::sceIo, 0, "waiting");
+			return hleLogDebug(Log::sceIo, 0, "waiting");
 		} else if (f->hasAsyncResult) {
 			if (!__KernelIsDispatchEnabled()) {
 				return hleLogDebug(Log::sceIo, SCE_KERNEL_ERROR_CAN_NOT_WAIT, "dispatch disabled");
@@ -2293,7 +2293,7 @@ static int sceIoWaitAsync(int id, u32 address) {
 				__IoFreeFd(id, error);
 			}
 
-			return hleLogSuccessI(Log::sceIo, 0, "complete");
+			return hleLogDebug(Log::sceIo, 0, "complete");
 		} else {
 			return hleLogWarning(Log::sceIo, SCE_KERNEL_ERROR_NOASYNC, "no async pending");
 		}
@@ -2317,7 +2317,7 @@ static int sceIoWaitAsyncCB(int id, u32 address) {
 			// TODO: This seems to re-enable dispatch or something?
 			f->waitingThreads.push_back(__KernelGetCurThread());
 			__KernelWaitCurThread(WAITTYPE_ASYNCIO, f->GetUID(), address, 0, true, "io waited");
-			return hleLogSuccessI(Log::sceIo, 0, "waiting");
+			return hleLogDebug(Log::sceIo, 0, "waiting");
 		} else if (f->hasAsyncResult) {
 			Memory::Write_U64((u64) f->asyncResult, address);
 			f->hasAsyncResult = false;
@@ -2326,7 +2326,7 @@ static int sceIoWaitAsyncCB(int id, u32 address) {
 				__IoFreeFd(id, error);
 			}
 
-			return hleLogSuccessI(Log::sceIo, 0, "complete");
+			return hleLogDebug(Log::sceIo, 0, "complete");
 		} else {
 			return hleLogWarning(Log::sceIo, SCE_KERNEL_ERROR_NOASYNC, "no async pending");
 		}
@@ -2340,7 +2340,7 @@ static u32 sceIoPollAsync(int id, u32 address) {
 	FileNode *f = __IoGetFd(id, error);
 	if (f) {
 		if (f->pendingAsyncResult) {
-			return hleLogSuccessVerboseI(Log::sceIo, 1, "not ready");
+			return hleLogVerbose(Log::sceIo, 1, "not ready");
 		} else if (f->hasAsyncResult) {
 			Memory::Write_U64((u64) f->asyncResult, address);
 			f->hasAsyncResult = false;
@@ -2348,7 +2348,7 @@ static u32 sceIoPollAsync(int id, u32 address) {
 			if (f->closePending) {
 				__IoFreeFd(id, error);
 			}
-			return hleLogSuccessI(Log::sceIo, 0);
+			return hleLogDebug(Log::sceIo, 0);
 		} else {
 			return hleLogDebug(Log::sceIo, SCE_KERNEL_ERROR_NOASYNC, "no async pending");
 		}
@@ -2780,9 +2780,9 @@ u32 sceIoIoctl(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 ou
 	int usec = 0;
 	int result = __IoIoctl(id, cmd, indataPtr, inlen, outdataPtr, outlen, usec);
 	if (usec != 0) {
-		return hleDelayResult(hleLogSuccessOrError(Log::sceIo, result), "io ctrl command", usec);
+		return hleDelayResult(hleLogDebugOrError(Log::sceIo, result), "io ctrl command", usec);
 	}
-	return hleLogSuccessOrError(Log::sceIo, result);
+	return hleLogDebugOrError(Log::sceIo, result);
 }
 
 static u32 sceIoIoctlAsync(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdataPtr, u32 outlen) {
@@ -2801,7 +2801,7 @@ static u32 sceIoIoctlAsync(u32 id, u32 cmd, u32 indataPtr, u32 inlen, u32 outdat
 		params.ioctl.outAddr = outdataPtr;
 		params.ioctl.outSize = outlen;
 		IoStartAsyncThread(id, f);
-		return hleLogSuccessI(Log::sceIo, 0);
+		return hleLogDebug(Log::sceIo, 0);
 	} else {
 		return hleLogError(Log::sceIo, error, "bad file descriptor");
 	}

--- a/Core/HLE/sceJpeg.cpp
+++ b/Core/HLE/sceJpeg.cpp
@@ -164,8 +164,8 @@ static int JpegCsc(u32 imageAddr, u32 yCbCrAddr, int widthHeight, int bufferWidt
 	NotifyMemInfo(MemBlockFlags::WRITE, imageAddr, (uint32_t)destSize, "JpegCsc");
 
 	if ((widthHeight & 0xFFFF) == 0)
-		return hleLogSuccessI(Log::ME, -1);
-	return hleLogSuccessI(Log::ME, 0);
+		return hleLogDebug(Log::ME, -1);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static int JpegMJpegCsc(u32 imageAddr, u32 yCbCrAddr, int widthHeight, int bufferWidth, int &usec) {
@@ -237,7 +237,7 @@ static int JpegMJpegCsc(u32 imageAddr, u32 yCbCrAddr, int widthHeight, int buffe
 
 	NotifyMemInfo(MemBlockFlags::WRITE, imageAddr, destSize, "JpegMJpegCsc");
 
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static int sceJpegMJpegCsc(u32 imageAddr, u32 yCbCrAddr, int widthHeight, int bufferWidth) {
@@ -320,7 +320,7 @@ static int DecodeJpeg(u32 jpegAddr, int jpegSize, u32 imageAddr, int &usec) {
 	}
 
 	free(jpegBuf);
-	return hleLogSuccessX(Log::ME, getWidthHeight(width, height));
+	return hleLogDebug(Log::ME, getWidthHeight(width, height));
 }
 
 static int sceJpegDecodeMJpeg(u32 jpegAddr, int jpegSize, u32 imageAddr, int dhtMode) {
@@ -411,7 +411,7 @@ static int JpegGetOutputInfo(u32 jpegAddr, int jpegSize, u32 colourInfoAddr) {
 		fclose(wfp);
 #endif //JPEG_DEBUG
 
-	return hleLogSuccessX(Log::ME, getYCbCrBufferSize(width, height));
+	return hleLogDebug(Log::ME, getYCbCrBufferSize(width, height));
 }
 
 static int sceJpegGetOutputInfo(u32 jpegAddr, int jpegSize, u32 colourInfoAddr, int dhtMode) {
@@ -533,7 +533,7 @@ static int JpegDecodeMJpegYCbCr(u32 jpegAddr, int jpegSize, u32 yCbCrAddr, int y
 
 	// Rough estimate based on observed timing.
 	usec += (width * height) / 14;
-	return hleLogSuccessX(Log::ME, getWidthHeight(width, height));
+	return hleLogDebug(Log::ME, getWidthHeight(width, height));
 }
 
 static int sceJpegDecodeMJpegYCbCr(u32 jpegAddr, int jpegSize, u32 yCbCrAddr, int yCbCrSize, int dhtMode) {
@@ -578,7 +578,7 @@ static int sceJpegCreateMJpeg(int width, int height) {
 	mjpegWidth = width;
 	mjpegHeight = height;
 
-	return hleLogSuccessInfoI(Log::ME, 0);
+	return hleLogInfo(Log::ME, 0);
 }
 
 static int sceJpegDeleteMJpeg() {
@@ -588,7 +588,7 @@ static int sceJpegDeleteMJpeg() {
 		return hleLogError(Log::ME, ERROR_JPEG_INVALID_STATE, "not yet created");
 
 	mjpegInited = 1;
-	return hleLogSuccessInfoI(Log::ME, 0);
+	return hleLogInfo(Log::ME, 0);
 }
 
 static int sceJpegInitMJpeg() {
@@ -598,7 +598,7 @@ static int sceJpegInitMJpeg() {
 	// If it was -1, it's from an old save state, avoid double init error but assume inited.
 	if (mjpegInited == 0)
 		mjpegInited = 1;
-	return hleDelayResult(hleLogSuccessI(Log::ME, 0), "mjpeg init", 130);
+	return hleDelayResult(hleLogDebug(Log::ME, 0), "mjpeg init", 130);
 }
 
 static int sceJpegFinishMJpeg() {
@@ -609,7 +609,7 @@ static int sceJpegFinishMJpeg() {
 
 	// Even from an old save state, if we see this we leave compat mode.
 	mjpegInited = 0;
-	return hleDelayResult(hleLogSuccessI(Log::ME, 0), "mjpeg finish", 120);
+	return hleDelayResult(hleLogDebug(Log::ME, 0), "mjpeg finish", 120);
 }
 
 static int sceJpegMJpegCscWithColorOption() {

--- a/Core/HLE/sceKernelEventFlag.cpp
+++ b/Core/HLE/sceKernelEventFlag.cpp
@@ -237,7 +237,7 @@ int sceKernelCreateEventFlag(const char *name, u32 flag_attr, u32 flag_initPatte
 	if ((flag_attr & ~PSP_EVENT_WAITMULTIPLE) != 0)
 		WARN_LOG_REPORT(Log::sceKernel, "sceKernelCreateEventFlag(%s) unsupported attr parameter: %08x", name, flag_attr);
 
-	return hleLogSuccessI(Log::sceKernel, id);
+	return hleLogDebug(Log::sceKernel, id);
 }
 
 u32 sceKernelCancelEventFlag(SceUID uid, u32 pattern, u32 numWaitThreadsPtr) {
@@ -254,7 +254,7 @@ u32 sceKernelCancelEventFlag(SceUID uid, u32 pattern, u32 numWaitThreadsPtr) {
 			hleReSchedule("event flag canceled");
 
 		hleEatCycles(580);
-		return hleLogSuccessI(Log::sceKernel, 0);
+		return hleLogDebug(Log::sceKernel, 0);
 	} else {
 		return hleLogDebug(Log::sceKernel, error, "invalid event flag");
 	}
@@ -267,7 +267,7 @@ u32 sceKernelClearEventFlag(SceUID id, u32 bits) {
 		e->nef.currentPattern &= bits;
 		// Note that it's not possible for threads to get woken up by this action.
 		hleEatCycles(430);
-		return hleLogSuccessI(Log::sceKernel, 0);
+		return hleLogDebug(Log::sceKernel, 0);
 	} else {
 		return hleLogDebug(Log::sceKernel, error, "invalid event flag");
 	}
@@ -281,7 +281,7 @@ u32 sceKernelDeleteEventFlag(SceUID uid) {
 		if (wokeThreads)
 			hleReSchedule("event flag deleted");
 
-		return hleLogSuccessI(Log::sceKernel, kernelObjects.Destroy<EventFlag>(uid));
+		return hleLogDebug(Log::sceKernel, kernelObjects.Destroy<EventFlag>(uid));
 	} else {
 		return hleLogDebug(Log::sceKernel, error, "invalid event flag");
 	}
@@ -308,7 +308,7 @@ u32 sceKernelSetEventFlag(SceUID id, u32 bitsToSet) {
 			hleReSchedule("event flag set");
 
 		hleEatCycles(430);
-		return hleLogSuccessI(Log::sceKernel, 0);
+		return hleLogDebug(Log::sceKernel, 0);
 	} else {
 		return hleLogDebug(Log::sceKernel, error, "invalid event flag");
 	}
@@ -389,7 +389,7 @@ int sceKernelWaitEventFlag(SceUID id, u32 bits, u32 wait, u32 outBitsPtr, u32 ti
 				return hleLogDebug(Log::sceKernel, SCE_KERNEL_ERROR_EVF_MULTI);
 			}
 
-			(void)hleLogSuccessI(Log::sceKernel, 0, "waiting");
+			(void)hleLogDebug(Log::sceKernel, 0, "waiting");
 
 			// No match - must wait.
 			th.threadID = __KernelGetCurThread();
@@ -402,7 +402,7 @@ int sceKernelWaitEventFlag(SceUID id, u32 bits, u32 wait, u32 outBitsPtr, u32 ti
 			__KernelSetEventFlagTimeout(e, timeoutPtr);
 			__KernelWaitCurThread(WAITTYPE_EVENTFLAG, id, 0, timeoutPtr, false, "event flag waited");
 		} else {
-			(void)hleLogSuccessI(Log::sceKernel, 0);
+			(void)hleLogDebug(Log::sceKernel, 0);
 		}
 
 		hleEatCycles(500);
@@ -452,7 +452,7 @@ int sceKernelWaitEventFlagCB(SceUID id, u32 bits, u32 wait, u32 outBitsPtr, u32 
 				return hleLogDebug(Log::sceKernel, SCE_KERNEL_ERROR_EVF_MULTI);
 			}
 
-			(void)hleLogSuccessI(Log::sceKernel, 0, "waiting");
+			(void)hleLogDebug(Log::sceKernel, 0, "waiting");
 
 			// No match - must wait.
 			th.threadID = __KernelGetCurThread();
@@ -468,7 +468,7 @@ int sceKernelWaitEventFlagCB(SceUID id, u32 bits, u32 wait, u32 outBitsPtr, u32 
 			else
 				__KernelWaitCurThread(WAITTYPE_EVENTFLAG, id, 0, timeoutPtr, true, "event flag waited");
 		} else {
-			(void)hleLogSuccessI(Log::sceKernel, 0);
+			(void)hleLogDebug(Log::sceKernel, 0);
 			__KernelApplyEventFlagMatch(&e->nef.currentPattern, bits, wait, outBitsPtr);
 			hleCheckCurrentCallbacks();
 		}
@@ -509,7 +509,7 @@ int sceKernelPollEventFlag(SceUID id, u32 bits, u32 wait, u32 outBitsPtr) {
 			// No match - return that, this is polling, not waiting.
 			return hleLogDebug(Log::sceKernel, SCE_KERNEL_ERROR_EVF_COND);
 		} else {
-			return hleLogSuccessI(Log::sceKernel, 0);
+			return hleLogDebug(Log::sceKernel, 0);
 		}
 	} else {
 		return hleLogDebug(Log::sceKernel, error, "invalid event flag");
@@ -532,7 +532,7 @@ u32 sceKernelReferEventFlagStatus(SceUID id, u32 statusPtr) {
 			*status = e->nef;
 			status.NotifyWrite("EventFlagStatus");
 		}
-		return hleLogSuccessI(Log::sceKernel, 0);
+		return hleLogDebug(Log::sceKernel, 0);
 	} else {
 		return hleLogDebug(Log::sceKernel, error, "invalid event flag");
 	}

--- a/Core/HLE/sceKernelHeap.cpp
+++ b/Core/HLE/sceKernelHeap.cpp
@@ -69,7 +69,7 @@ static int sceKernelCreateHeap(int partitionId, int size, int flags, const char 
 	heap->address = addr;
 	heap->alloc.Init(heap->address + 128, heap->size - 128, true);
 	heap->uid = uid;
-	return hleLogSuccessInfoX(Log::sceKernel, uid);
+	return hleLogInfo(Log::sceKernel, uid);
 }
 
 static int sceKernelAllocHeapMemory(int heapId, int size) {
@@ -81,7 +81,7 @@ static int sceKernelAllocHeapMemory(int heapId, int size) {
 	// There's 8 bytes at the end of every block, reserved.
 	u32 memSize = KERNEL_HEAP_BLOCK_HEADER_SIZE + size;
 	u32 addr = heap->alloc.Alloc(memSize, true);
-	return hleLogSuccessInfoX(Log::sceKernel, addr);
+	return hleLogInfo(Log::sceKernel, addr);
 }
 
 static int sceKernelDeleteHeap(int heapId) {
@@ -95,7 +95,7 @@ static int sceKernelDeleteHeap(int heapId) {
 	if (allocator)
 		allocator->Free(heap->address);
 	kernelObjects.Destroy<KernelHeap>(heap->uid);
-	return hleLogSuccessInfoX(Log::sceKernel, 0);
+	return hleLogInfo(Log::sceKernel, 0);
 }
 
 static u32 sceKernelPartitionTotalFreeMemSize(int partitionId) {
@@ -126,12 +126,12 @@ static int sceKernelFreeHeapMemory(int heapId, u32 block) {
 	if (!heap)
 		return hleLogError(Log::sceKernel, error, "invalid heapId");
 	if (block == 0) {
-		return hleLogSuccessInfoI(Log::sceKernel, 0, "heapId,0: block");
+		return hleLogInfo(Log::sceKernel, 0, "heapId,0: block");
 	}
 	if (!heap->alloc.FreeExact(block)) {
 		return hleLogError(Log::sceKernel, SCE_KERNEL_ERROR_INVALID_POINTER, "invalid pointer %08x", block);
 	}
-	return hleLogSuccessInfoI(Log::sceKernel, 0, "heapId, block");
+	return hleLogInfo(Log::sceKernel, 0, "heapId, block");
 }
 
 static int sceKernelAllocHeapMemoryWithOption(int heapId, u32 memSize, u32 paramsPtr) {

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -524,7 +524,7 @@ u32 sceKernelReleaseSubIntrHandler(u32 intrNumber, u32 subIntrNumber) {
 	}
 
 	u32 error = __ReleaseSubIntrHandler(intrNumber, subIntrNumber);
-	return hleLogSuccessOrError(Log::sceIntc, error);
+	return hleLogDebugOrError(Log::sceIntc, error);
 }
 
 u32 sceKernelEnableSubIntr(u32 intrNumber, u32 subIntrNumber) {
@@ -937,7 +937,7 @@ static u32 sysclib_strncpy(u32 dest, u32 src, u32 size) {
 		*destp++ = 0;
 	}
 
-	return hleLogSuccessX(Log::sceKernel, dest);
+	return hleLogDebug(Log::sceKernel, dest);
 }
 
 static u32 sysclib_strtol(u32 strPtr, u32 endPtrPtr, int base) {	

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -920,7 +920,7 @@ int sceKernelReferFplStatus(SceUID uid, u32 statusPtr) {
 			*status = fpl->nf;
 			status.NotifyWrite("FplStatus");
 		}
-		return hleLogSuccessI(Log::sceKernel, 0);
+		return hleLogDebug(Log::sceKernel, 0);
 	} else {
 		return hleLogError(Log::sceKernel, error, "invalid fpl");
 	}
@@ -1176,7 +1176,7 @@ static int sceKernelPrintf(const char *formatString) {
 		result.resize(result.size() - 1);
 
 	if (supported)
-		return hleLogSuccessInfoI(Log::Printf, 0, "\"%s\"", result.c_str());
+		return hleLogInfo(Log::Printf, 0, "\"%s\"", result.c_str());
 	else
 		return hleLogError(Log::Printf, 0, "UNIMPL fmt (%s, %08x, %08x, %08x)", format.c_str(), PARAM(1), PARAM(2), PARAM(3));
 }
@@ -1769,7 +1769,7 @@ int sceKernelReferVplStatus(SceUID uid, u32 infoPtr) {
 			*info = vpl->nv;
 			info.NotifyWrite("VplStatus");
 		}
-		return hleLogSuccessI(Log::sceKernel, 0);
+		return hleLogDebug(Log::sceKernel, 0);
 	} else {
 		return hleLogError(Log::sceKernel, error, "invalid vpl");
 	}
@@ -2098,7 +2098,7 @@ SceUID sceKernelCreateTlspl(const char *name, u32 partition, u32 attr, u32 block
 	tls->alignment = alignment;
 	tls->usage.resize(count, 0);
 
-	return hleLogSuccessInfoI(Log::sceKernel, id);
+	return hleLogInfo(Log::sceKernel, id);
 }
 
 int sceKernelDeleteTlspl(SceUID uid)
@@ -2251,7 +2251,7 @@ int sceKernelReferTlsplStatus(SceUID uid, u32 infoPtr) {
 			*info = tls->ntls;
 			info.NotifyWrite("TlsplStatus");
 		}
-		return hleLogSuccessI(Log::sceKernel, 0);
+		return hleLogDebug(Log::sceKernel, 0);
 	} else {
 		return hleLogError(Log::sceKernel, error, "invalid tlspl");
 	}

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -2096,7 +2096,7 @@ u32 sceKernelLoadModule(const char *name, u32 flags, u32 optionAddr) {
 			}
 
 			// TODO: It would be more ideal to allocate memory for this module.
-			return hleLogSuccessInfoI(Log::Loader, module->GetUID(), "created fake module");
+			return hleLogInfo(Log::Loader, module->GetUID(), "created fake module");
 		}
 	}
 
@@ -2176,7 +2176,7 @@ u32 sceKernelLoadModule(const char *name, u32 flags, u32 optionAddr) {
 static u32 sceKernelLoadModuleNpDrm(const char *name, u32 flags, u32 optionAddr)
 {
 	// TODO: Handle recursive syscall properly
-	return hleLogSuccessOrError(Log::Loader, sceKernelLoadModule(name, flags, optionAddr));
+	return hleLogDebugOrError(Log::Loader, sceKernelLoadModule(name, flags, optionAddr));
 }
 
 int __KernelStartModule(SceUID moduleId, u32 argsize, u32 argAddr, u32 returnValueAddr, SceKernelSMOption *smoption, bool *needsWait) {
@@ -2243,7 +2243,7 @@ static u32 sceKernelStartModule(u32 moduleId, u32 argsize, u32 argAddr, u32 retu
 	} else if (module->isFake) {
 		if (returnValueAddr)
 			Memory::Write_U32(0, returnValueAddr);
-		return hleLogSuccessInfoI(Log::sceModule, moduleId, "Faked (undecryptable module)");
+		return hleLogInfo(Log::sceModule, moduleId, "Faked (undecryptable module)");
 	} else if (module->nm.status == MODULE_STATUS_STARTED) {
 		// TODO: Maybe should be SCE_KERNEL_ERROR_ALREADY_STARTED, but I get SCE_KERNEL_ERROR_ERROR.
 		// But I also get crashes...
@@ -2259,7 +2259,7 @@ static u32 sceKernelStartModule(u32 moduleId, u32 argsize, u32 argAddr, u32 retu
 			module->nm.status = MODULE_STATUS_STARTING;
 			module->waitingThreads.push_back(mwt);
 		}
-		return hleLogSuccessInfoI(Log::sceModule, ret);
+		return hleLogInfo(Log::sceModule, ret);
 	}
 }
 
@@ -2281,7 +2281,7 @@ static u32 sceKernelStopModule(u32 moduleId, u32 argSize, u32 argAddr, u32 retur
 	if (module->isFake) {
 		if (returnValueAddr)
 			Memory::Write_U32(0, returnValueAddr);
-		return hleLogSuccessInfoI(Log::sceModule, 0, "faking");
+		return hleLogInfo(Log::sceModule, 0, "faking");
 	}
 	if (module->nm.status != MODULE_STATUS_STARTED) {
 		return hleLogError(Log::sceModule, SCE_KERNEL_ERROR_ALREADY_STOPPED, "already stopped");
@@ -2327,7 +2327,7 @@ static u32 sceKernelStopModule(u32 moduleId, u32 argSize, u32 argAddr, u32 retur
 	else if (stopFunc == 0)
 	{
 		module->nm.status = MODULE_STATUS_STOPPED;
-		return hleLogSuccessInfoI(Log::sceModule, 0, "no stop func, skipping");
+		return hleLogInfo(Log::sceModule, 0, "no stop func, skipping");
 	}
 	else
 	{
@@ -2519,13 +2519,13 @@ static u32 sceKernelGetModuleIdByAddress(u32 moduleAddr)
 	if (state.result == (SceUID)SCE_KERNEL_ERROR_UNKNOWN_MODULE) {
 		return hleLogError(Log::sceModule, state.result, "module not found at address");
 	} else {
-		return hleLogSuccessOrError(Log::sceModule, state.result, "%08x", state.result);
+		return hleLogDebugOrError(Log::sceModule, state.result, "%08x", state.result);
 	}
 }
 
 static u32 sceKernelGetModuleId()
 {
-	return hleLogSuccessI(Log::sceModule, __KernelGetCurThreadModuleId());
+	return hleLogDebug(Log::sceModule, __KernelGetCurThreadModuleId());
 }
 
 u32 sceKernelFindModuleByUID(u32 uid)
@@ -2535,7 +2535,7 @@ u32 sceKernelFindModuleByUID(u32 uid)
 	if (!module || module->isFake) {
 		return hleLogError(Log::sceModule, 0, "Module Not Found or Fake");
 	}
-	return hleLogSuccessInfoI(Log::sceModule, module->modulePtr.ptr);
+	return hleLogInfo(Log::sceModule, module->modulePtr.ptr);
 }
 
 u32 sceKernelFindModuleByName(const char *name)
@@ -2548,7 +2548,7 @@ u32 sceKernelFindModuleByName(const char *name)
 		if (strcmp(name, module->nm.name) == 0) {
 			if (!module->isFake) {
 				INFO_LOG(Log::sceModule, "%d = sceKernelFindModuleByName(%s)", module->modulePtr.ptr, name);
-				return hleLogSuccessInfoI(Log::sceModule, module->modulePtr.ptr);
+				return hleLogInfo(Log::sceModule, module->modulePtr.ptr);
 			} else {
 				return hleDelayResult(hleLogWarning(Log::sceModule, 0, "Module Fake"), "Module Fake", 1000 * 1000);
 			}

--- a/Core/HLE/sceKernelMsgPipe.cpp
+++ b/Core/HLE/sceKernelMsgPipe.cpp
@@ -1004,7 +1004,7 @@ int sceKernelReferMsgPipeStatus(SceUID uid, u32 statusPtr) {
 			*status = m->nmp;
 			status.NotifyWrite("MsgPipeStatus");
 		}
-		return hleLogSuccessI(Log::sceKernel, 0);
+		return hleLogDebug(Log::sceKernel, 0);
 	} else {
 		return hleLogError(Log::sceKernel, error, "bad message pipe");
 	}

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -339,7 +339,7 @@ int sceKernelCreateMutex(const char *name, u32 attr, int initialCount, u32 optio
 	if ((attr & ~PSP_MUTEX_ATTR_KNOWN) != 0)
 		WARN_LOG_REPORT(Log::sceKernel, "sceKernelCreateMutex(%s) unsupported attr parameter: %08x", name, attr);
 
-	return hleLogSuccessX(Log::sceKernel, id);
+	return hleLogDebug(Log::sceKernel, id);
 }
 
 int sceKernelDeleteMutex(SceUID id)
@@ -673,7 +673,7 @@ int sceKernelReferMutexStatus(SceUID id, u32 infoAddr) {
 		*info = m->nm;
 		info.NotifyWrite("MutexStatus");
 	}
-	return hleLogSuccessI(Log::sceKernel, 0);
+	return hleLogDebug(Log::sceKernel, 0);
 }
 
 int sceKernelCreateLwMutex(u32 workareaPtr, const char *name, u32 attr, int initialCount, u32 optionsPtr)
@@ -1084,7 +1084,7 @@ static int __KernelReferLwMutexStatus(SceUID uid, u32 infoPtr) {
 		*info = m->nm;
 		info.NotifyWrite("LwMutexStatus");
 	}
-	return hleLogSuccessI(Log::sceKernel, 0);
+	return hleLogDebug(Log::sceKernel, 0);
 }
 
 int sceKernelReferLwMutexStatusByID(SceUID uid, u32 infoPtr) {

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -231,7 +231,7 @@ int sceKernelCreateSema(const char* name, u32 attr, int initVal, int maxVal, u32
 		else if (Memory::Read_U32(optionPtr) > 4)
 			return hleLogDebug(Log::sceKernel, id, "invalid options parameter size");
 	}
-	return hleLogSuccessX(Log::sceKernel, id);
+	return hleLogDebug(Log::sceKernel, id);
 }
 
 int sceKernelDeleteSema(SceUID id)
@@ -270,7 +270,7 @@ int sceKernelReferSemaStatus(SceUID id, u32 infoPtr) {
 			*info = s->ns;
 			info.NotifyWrite("SemaStatus");
 		}
-		return hleLogSuccessI(Log::sceKernel, 0);
+		return hleLogDebug(Log::sceKernel, 0);
 	} else {
 		return hleLogError(Log::sceKernel, error);
 	}

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -1294,7 +1294,7 @@ u32 sceKernelReferThreadStatus(u32 threadID, u32 statusPtr)
 
 	hleEatCycles(1400);
 	hleReSchedule("refer thread status");
-	return hleLogSuccessVerboseI(Log::sceKernel, 0);
+	return hleLogVerbose(Log::sceKernel, 0);
 }
 
 // Thanks JPCSP
@@ -1341,7 +1341,7 @@ int __KernelGetThreadExitStatus(SceUID threadID) {
 
 	// __KernelResetThread and __KernelCreateThread set exitStatus in case it's DORMANT.
 	if (t->nt.status == THREADSTATUS_DORMANT) {
-		return hleLogSuccessI(Log::sceKernel, t->nt.exitStatus);
+		return hleLogDebug(Log::sceKernel, t->nt.exitStatus);
 	}
 	return hleLogVerbose(Log::sceKernel, SCE_KERNEL_ERROR_NOT_DORMANT, "not dormant");
 }
@@ -2022,7 +2022,7 @@ int sceKernelCreateThread(const char *threadName, u32 entry, u32 prio, int stack
 	if (retval < 0) {
 		return hleLogError(Log::sceKernel, retval);
 	} else {
-		return hleLogSuccessInfoI(Log::sceKernel, retval);
+		return hleLogInfo(Log::sceKernel, retval);
 	}
 }
 
@@ -2124,7 +2124,7 @@ int __KernelStartThreadValidate(SceUID threadToStartID, int argSize, u32 argBloc
 // int sceKernelStartThread(SceUID threadToStartID, SceSize argSize, void *argBlock)
 int sceKernelStartThread(SceUID threadToStartID, int argSize, u32 argBlockPtr) {
 	int retval = __KernelStartThreadValidate(threadToStartID, argSize, argBlockPtr);
-	return hleLogSuccessOrError(Log::sceKernel, retval);
+	return hleLogDebugOrError(Log::sceKernel, retval);
 }
 
 int sceKernelGetThreadStackFreeSize(SceUID threadID)
@@ -2298,7 +2298,7 @@ int sceKernelRotateThreadReadyQueue(int priority) {
 		hleReSchedule("rotatethreadreadyqueue");
 		hleEatCycles(250);
 	}
-	return hleLogSuccessVerboseI(Log::sceKernel, result);
+	return hleLogVerbose(Log::sceKernel, result);
 }
 
 int sceKernelDeleteThread(int threadID) {
@@ -2386,7 +2386,7 @@ int sceKernelTerminateThread(SceUID threadID) {
 		RETURN(0);
 		__KernelThreadTriggerEvent((t->nt.attr & PSP_THREAD_ATTR_KERNEL) != 0, t->GetUID(), THREADEVENT_EXIT);
 
-		return hleLogSuccessInfoI(Log::sceKernel, 0);
+		return hleLogInfo(Log::sceKernel, 0);
 	} else {
 		return hleLogError(Log::sceKernel, error, "thread doesn't exist");
 	}
@@ -2432,7 +2432,7 @@ SceUID sceKernelGetThreadId() {
 
 int sceKernelGetThreadCurrentPriority() {
 	u32 retVal = __GetCurrentThread()->nt.currentPriority;
-	return hleLogSuccessI(Log::sceKernel, retVal);
+	return hleLogDebug(Log::sceKernel, retVal);
 }
 
 int sceKernelChangeCurrentThreadAttr(u32 clearAttr, u32 setAttr) {
@@ -2446,7 +2446,7 @@ int sceKernelChangeCurrentThreadAttr(u32 clearAttr, u32 setAttr) {
 		return hleReportError(Log::sceKernel, -1, "no current thread");
 
 	t->nt.attr = (t->nt.attr & ~clearAttr) | setAttr;
-	return hleLogSuccessI(Log::sceKernel, 0);
+	return hleLogDebug(Log::sceKernel, 0);
 }
 
 // Assumes validated parameters.
@@ -2502,7 +2502,7 @@ int sceKernelChangeThreadPriority(SceUID threadID, int priority) {
 		hleEatCycles(450);
 		hleReSchedule("change thread priority");
 
-		return hleLogSuccessI(Log::sceKernel, 0);
+		return hleLogDebug(Log::sceKernel, 0);
 	} else {
 		return hleLogError(Log::sceKernel, error, "thread not found");
 	}
@@ -2535,7 +2535,7 @@ int sceKernelDelayThreadCB(u32 usec) {
 	s64 delayUs = __KernelDelayThreadUs(usec);
 	__KernelScheduleWakeup(curThread, delayUs);
 	__KernelWaitCurThread(WAITTYPE_DELAY, curThread, 0, 0, true, "thread delayed");
-	return hleLogSuccessI(Log::sceKernel, 0, "delaying %lld usecs", delayUs);
+	return hleLogDebug(Log::sceKernel, 0, "delaying %lld usecs", delayUs);
 }
 
 int sceKernelDelayThread(u32 usec) {
@@ -2546,7 +2546,7 @@ int sceKernelDelayThread(u32 usec) {
 	s64 delayUs = __KernelDelayThreadUs(usec);
 	__KernelScheduleWakeup(curThread, delayUs);
 	__KernelWaitCurThread(WAITTYPE_DELAY, curThread, 0, 0, false, "thread delayed");
-	return hleLogSuccessI(Log::sceKernel, 0, "delaying %lld usecs", delayUs);
+	return hleLogDebug(Log::sceKernel, 0, "delaying %lld usecs", delayUs);
 }
 
 int sceKernelDelaySysClockThreadCB(u32 sysclockAddr) {
@@ -2563,7 +2563,7 @@ int sceKernelDelaySysClockThreadCB(u32 sysclockAddr) {
 	s64 delayUs = __KernelDelayThreadUs(usec);
 	__KernelScheduleWakeup(curThread, delayUs);
 	__KernelWaitCurThread(WAITTYPE_DELAY, curThread, 0, 0, true, "thread delayed");
-	return hleLogSuccessI(Log::sceKernel, 0, "delaying %lld usecs", delayUs);
+	return hleLogDebug(Log::sceKernel, 0, "delaying %lld usecs", delayUs);
 }
 
 int sceKernelDelaySysClockThread(u32 sysclockAddr) {
@@ -2580,7 +2580,7 @@ int sceKernelDelaySysClockThread(u32 sysclockAddr) {
 	s64 delayUs = __KernelDelayThreadUs(usec);
 	__KernelScheduleWakeup(curThread, delayUs);
 	__KernelWaitCurThread(WAITTYPE_DELAY, curThread, 0, 0, false, "thread delayed");
-	return hleLogSuccessI(Log::sceKernel, 0, "delaying %lld usecs", delayUs);
+	return hleLogDebug(Log::sceKernel, 0, "delaying %lld usecs", delayUs);
 }
 
 u32 __KernelGetThreadPrio(SceUID id) {
@@ -2609,11 +2609,11 @@ int sceKernelWakeupThread(SceUID uid) {
 	if (t) {
 		if (!t->isWaitingFor(WAITTYPE_SLEEP, 0)) {
 			t->nt.wakeupCount++;
-			return hleLogSuccessI(Log::sceKernel, 0, "wakeupCount incremented to %i", t->nt.wakeupCount);
+			return hleLogDebug(Log::sceKernel, 0, "wakeupCount incremented to %i", t->nt.wakeupCount);
 		} else {
 			__KernelResumeThreadFromWait(uid, 0);
 			hleReSchedule("thread woken up");
-			return hleLogSuccessVerboseI(Log::sceKernel, 0, "woke thread at %i", t->nt.wakeupCount);
+			return hleLogVerbose(Log::sceKernel, 0, "woke thread at %i", t->nt.wakeupCount);
 		}
 	} else {
 		return hleLogError(Log::sceKernel, error, "bad thread id");
@@ -2630,7 +2630,7 @@ int sceKernelCancelWakeupThread(SceUID uid) {
 	if (t) {
 		int wCount = t->nt.wakeupCount;
 		t->nt.wakeupCount = 0;
-		return hleLogSuccessI(Log::sceKernel, wCount, "wakeupCount reset to 0");
+		return hleLogDebug(Log::sceKernel, wCount, "wakeupCount reset to 0");
 	} else {
 		return hleLogError(Log::sceKernel, error, "bad thread id");
 	}
@@ -2645,10 +2645,10 @@ static int __KernelSleepThread(bool doCallbacks) {
 
 	if (thread->nt.wakeupCount > 0) {
 		thread->nt.wakeupCount--;
-		return hleLogSuccessI(Log::sceKernel, 0, "wakeupCount decremented to %i", thread->nt.wakeupCount);
+		return hleLogDebug(Log::sceKernel, 0, "wakeupCount decremented to %i", thread->nt.wakeupCount);
 	} else {
 		__KernelWaitCurThread(WAITTYPE_SLEEP, 0, 0, 0, doCallbacks, "thread slept");
-		return hleLogSuccessVerboseI(Log::sceKernel, 0, "sleeping");
+		return hleLogVerbose(Log::sceKernel, 0, "sleeping");
 	}
 	return 0;
 }
@@ -2867,7 +2867,7 @@ SceUID sceKernelCreateCallback(const char *name, u32 entrypoint, u32 signalArg)
 	if (thread)
 		thread->callbacks.push_back(id);
 
-	return hleLogSuccessI(Log::sceKernel, id);
+	return hleLogDebug(Log::sceKernel, id);
 }
 
 int sceKernelDeleteCallback(SceUID cbId)
@@ -2882,7 +2882,7 @@ int sceKernelDeleteCallback(SceUID cbId)
 		if (cb->nc.notifyCount != 0)
 			readyCallbacksCount--;
 
-		return hleLogSuccessI(Log::sceKernel, kernelObjects.Destroy<PSPCallback>(cbId));
+		return hleLogDebug(Log::sceKernel, kernelObjects.Destroy<PSPCallback>(cbId));
 	} else {
 		return hleLogError(Log::sceKernel, error, "bad cbId");
 	}
@@ -2895,7 +2895,7 @@ int sceKernelNotifyCallback(SceUID cbId, int notifyArg)
 	PSPCallback *cb = kernelObjects.Get<PSPCallback>(cbId, error);
 	if (cb) {
 		__KernelNotifyCallback(cbId, notifyArg);
-		return hleLogSuccessI(Log::sceKernel, 0);
+		return hleLogDebug(Log::sceKernel, 0);
 	} else {
 		return hleLogError(Log::sceKernel, error, "bad cbId");
 	}
@@ -2908,7 +2908,7 @@ int sceKernelCancelCallback(SceUID cbId)
 	if (cb) {
 		// This just resets the notify count.
 		cb->nc.notifyArg = 0;
-		return hleLogSuccessI(Log::sceKernel, 0);
+		return hleLogDebug(Log::sceKernel, 0);
 	} else {
 		return hleLogError(Log::sceKernel, error, "bad cbId");
 	}
@@ -2919,7 +2919,7 @@ int sceKernelGetCallbackCount(SceUID cbId)
 	u32 error;
 	PSPCallback *cb = kernelObjects.Get<PSPCallback>(cbId, error);
 	if (cb) {
-		return hleLogSuccessVerboseI(Log::sceKernel, cb->nc.notifyCount);
+		return hleLogVerbose(Log::sceKernel, cb->nc.notifyCount);
 	} else {
 		return hleLogError(Log::sceKernel, error, "bad cbId");
 	}
@@ -2933,7 +2933,7 @@ int sceKernelReferCallbackStatus(SceUID cbId, u32 statusAddr) {
 		if (status.IsValid() && status->size != 0) {
 			*status = c->nc;
 			status.NotifyWrite("CallbackStatus");
-			return hleLogSuccessI(Log::sceKernel, 0);
+			return hleLogDebug(Log::sceKernel, 0);
 		} else {
 			return hleLogDebug(Log::sceKernel, 0, "struct size was 0");
 		}
@@ -2971,7 +2971,7 @@ u32 sceKernelExtendThreadStack(u32 size, u32 entryAddr, u32 entryParameter)
 	currentMIPS->r[MIPS_REG_SP] = thread->currentStack.end - 0x10;
 
 	hleSkipDeadbeef();
-	return hleLogSuccessI(Log::sceKernel, 0);
+	return hleLogDebug(Log::sceKernel, 0);
 }
 
 void __KernelReturnFromExtendStack()
@@ -3787,7 +3787,7 @@ SceUID sceKernelRegisterThreadEventHandler(const char *name, SceUID threadID, u3
 	SceUID uid = kernelObjects.Create(teh);
 	threadEventHandlers[threadID].push_back(uid);
 
-	return hleLogSuccessI(Log::sceKernel, uid);
+	return hleLogDebug(Log::sceKernel, uid);
 }
 
 int sceKernelReleaseThreadEventHandler(SceUID uid) {
@@ -3799,7 +3799,7 @@ int sceKernelReleaseThreadEventHandler(SceUID uid) {
 
 	auto &handlers = threadEventHandlers[teh->nteh.threadID];
 	handlers.erase(std::remove(handlers.begin(), handlers.end(), uid), handlers.end());
-	return hleLogSuccessI(Log::sceKernel, kernelObjects.Destroy<ThreadEventHandler>(uid));
+	return hleLogDebug(Log::sceKernel, kernelObjects.Destroy<ThreadEventHandler>(uid));
 }
 
 int sceKernelReferThreadEventHandlerStatus(SceUID uid, u32 infoPtr) {
@@ -3813,7 +3813,7 @@ int sceKernelReferThreadEventHandlerStatus(SceUID uid, u32 infoPtr) {
 	if (info.IsValid() && info->size != 0) {
 		*info = teh->nteh;
 		info.NotifyWrite("ThreadEventHandlerStatus");
-		return hleLogSuccessI(Log::sceKernel, 0);
+		return hleLogDebug(Log::sceKernel, 0);
 	} else {
 		return hleLogDebug(Log::sceKernel, 0, "struct size was 0");
 	}

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -224,9 +224,9 @@ static int sceMp3Decode(u32 mp3, u32 outPcmPtr) {
 	int pcmBytes = ctx->AuDecode(outPcmPtr);
 	if (pcmBytes > 0) {
 		// decode data successfully, delay thread
-		return hleDelayResult(hleLogSuccessI(Log::ME, pcmBytes), "mp3 decode", mp3DecodeDelay);
+		return hleDelayResult(hleLogDebug(Log::ME, pcmBytes), "mp3 decode", mp3DecodeDelay);
 	} else if (pcmBytes == 0) {
-		return hleLogSuccessI(Log::ME, pcmBytes);
+		return hleLogDebug(Log::ME, pcmBytes);
 	}
 	// Should already have logged.
 	return pcmBytes;
@@ -242,7 +242,7 @@ static int sceMp3ResetPlayPosition(u32 mp3) {
 		return hleLogError(Log::ME, ERROR_MP3_NOT_YET_INIT_HANDLE, "not yet init");
 	}
 
-	return hleLogSuccessI(Log::ME, ctx->AuResetPlayPosition());
+	return hleLogDebug(Log::ME, ctx->AuResetPlayPosition());
 }
 
 static int sceMp3CheckStreamDataNeeded(u32 mp3) {
@@ -255,7 +255,7 @@ static int sceMp3CheckStreamDataNeeded(u32 mp3) {
 		return hleLogError(Log::ME, ERROR_MP3_UNRESERVED_HANDLE, "incorrect handle type");
 	}
 
-	return hleLogSuccessI(Log::ME, ctx->AuCheckStreamDataNeeded());
+	return hleLogDebug(Log::ME, ctx->AuCheckStreamDataNeeded());
 }
 
 static u32 sceMp3ReserveMp3Handle(u32 mp3Addr) {
@@ -309,21 +309,21 @@ static u32 sceMp3ReserveMp3Handle(u32 mp3Addr) {
 	int handle = (int)mp3Map.size();
 	mp3Map[handle] = Au;
 
-	return hleLogSuccessI(Log::ME, handle);
+	return hleLogDebug(Log::ME, handle);
 }
 
 static int sceMp3InitResource() {
 	// TODO: Could validate the utility modules have been loaded?
 	if (resourceInited) {
-		return hleLogSuccessI(Log::ME, 0);
+		return hleLogDebug(Log::ME, 0);
 	}
 	resourceInited = true;
-	return hleDelayResult(hleLogSuccessI(Log::ME, 0), "mp3 resource init", 200);
+	return hleDelayResult(hleLogDebug(Log::ME, 0), "mp3 resource init", 200);
 }
 
 static int sceMp3TermResource() {
 	if (!resourceInited) {
-		return hleLogSuccessI(Log::ME, 0);
+		return hleLogDebug(Log::ME, 0);
 	}
 
 	// Free any handles that are still open.
@@ -333,7 +333,7 @@ static int sceMp3TermResource() {
 	mp3Map.clear();
 
 	resourceInited = false;
-	return hleDelayResult(hleLogSuccessI(Log::ME, 0), "mp3 resource term", 100);
+	return hleDelayResult(hleLogDebug(Log::ME, 0), "mp3 resource term", 100);
 }
 
 static int __CalculateMp3Channels(int bitval) {
@@ -498,7 +498,7 @@ static int sceMp3Init(u32 mp3) {
 
 	ctx->Version = versionBits;
 
-	return hleDelayResult(hleLogSuccessI(Log::ME, 0), "mp3 init", PARSE_DELAY_MS);
+	return hleDelayResult(hleLogDebug(Log::ME, 0), "mp3 init", PARSE_DELAY_MS);
 }
 
 static int sceMp3GetLoopNum(u32 mp3) {
@@ -511,7 +511,7 @@ static int sceMp3GetLoopNum(u32 mp3) {
 		return hleLogError(Log::ME, ERROR_MP3_UNRESERVED_HANDLE, "incorrect handle type");
 	}
 
-	return hleLogSuccessI(Log::ME, ctx->LoopNum);
+	return hleLogDebug(Log::ME, ctx->LoopNum);
 }
 
 static int sceMp3GetMaxOutputSample(u32 mp3) {
@@ -526,7 +526,7 @@ static int sceMp3GetMaxOutputSample(u32 mp3) {
 		return hleLogWarning(Log::ME, 0, "no channel available for low level");
 	}
 
-	return hleLogSuccessI(Log::ME, ctx->MaxOutputSample);
+	return hleLogDebug(Log::ME, ctx->MaxOutputSample);
 }
 
 static int sceMp3GetSumDecodedSample(u32 mp3) {
@@ -539,7 +539,7 @@ static int sceMp3GetSumDecodedSample(u32 mp3) {
 		return hleLogError(Log::ME, ERROR_MP3_UNRESERVED_HANDLE, "incorrect handle type");
 	}
 
-	return hleLogSuccessI(Log::ME, ctx->SumDecodedSamples);
+	return hleLogDebug(Log::ME, ctx->SumDecodedSamples);
 }
 
 static int sceMp3SetLoopNum(u32 mp3, int loop) {
@@ -556,7 +556,7 @@ static int sceMp3SetLoopNum(u32 mp3, int loop) {
 		loop = -1;
 
 	ctx->LoopNum = loop;
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static int sceMp3GetMp3ChannelNum(u32 mp3) {
@@ -571,7 +571,7 @@ static int sceMp3GetMp3ChannelNum(u32 mp3) {
 		return hleLogWarning(Log::ME, 0, "no channel available for low level");
 	}
 
-	return hleLogSuccessI(Log::ME, ctx->Channels);
+	return hleLogDebug(Log::ME, ctx->Channels);
 }
 
 static int sceMp3GetBitRate(u32 mp3) {
@@ -586,7 +586,7 @@ static int sceMp3GetBitRate(u32 mp3) {
 		return hleLogWarning(Log::ME, 0, "no bitrate available for low level");
 	}
 
-	return hleLogSuccessI(Log::ME, ctx->BitRate);
+	return hleLogDebug(Log::ME, ctx->BitRate);
 }
 
 static int sceMp3GetSamplingRate(u32 mp3) {
@@ -601,7 +601,7 @@ static int sceMp3GetSamplingRate(u32 mp3) {
 		return hleLogWarning(Log::ME, 0, "no sample rate available for low level");
 	}
 
-	return hleLogSuccessI(Log::ME, ctx->SamplingRate);
+	return hleLogDebug(Log::ME, ctx->SamplingRate);
 }
 
 static int sceMp3GetInfoToAddStreamData(u32 mp3, u32 dstPtr, u32 towritePtr, u32 srcposPtr) {
@@ -614,7 +614,7 @@ static int sceMp3GetInfoToAddStreamData(u32 mp3, u32 dstPtr, u32 towritePtr, u32
 		return hleLogError(Log::ME, ERROR_MP3_UNRESERVED_HANDLE, "incorrect handle type");
 	}
 
-	return hleLogSuccessI(Log::ME, ctx->AuGetInfoToAddStreamData(dstPtr, towritePtr, srcposPtr));
+	return hleLogDebug(Log::ME, ctx->AuGetInfoToAddStreamData(dstPtr, towritePtr, srcposPtr));
 }
 
 static int sceMp3NotifyAddStreamData(u32 mp3, int size) {
@@ -627,7 +627,7 @@ static int sceMp3NotifyAddStreamData(u32 mp3, int size) {
 		return hleLogError(Log::ME, ERROR_MP3_UNRESERVED_HANDLE, "incorrect handle type");
 	}
 
-	return hleLogSuccessI(Log::ME, ctx->AuNotifyAddStreamData(size));
+	return hleLogDebug(Log::ME, ctx->AuNotifyAddStreamData(size));
 }
 
 static int sceMp3ReleaseMp3Handle(u32 mp3) {
@@ -635,7 +635,7 @@ static int sceMp3ReleaseMp3Handle(u32 mp3) {
 	if (ctx) {
 		delete ctx;
 		mp3Map.erase(mp3);
-		return hleLogSuccessI(Log::ME, 0);
+		return hleLogDebug(Log::ME, 0);
 	} else if (mp3 >= MP3_MAX_HANDLES) {
 		return hleLogError(Log::ME, ERROR_MP3_INVALID_HANDLE, "invalid handle");
 	}
@@ -664,7 +664,7 @@ static u32 sceMp3GetFrameNum(u32 mp3) {
 		return hleLogError(Log::ME, ERROR_MP3_NOT_YET_INIT_HANDLE, "not yet init");
 	}
 
-	return hleLogSuccessI(Log::ME, ctx->FrameNum);
+	return hleLogDebug(Log::ME, ctx->FrameNum);
 }
 
 static u32 sceMp3GetMPEGVersion(u32 mp3) {
@@ -698,7 +698,7 @@ static u32 sceMp3ResetPlayPositionByFrame(u32 mp3, u32 frame) {
 		return hleLogError(Log::ME, ERROR_MP3_BAD_RESET_FRAME, "bad frame position");
 	}
 
-	return hleLogSuccessI(Log::ME, ctx->AuResetPlayPositionByFrame(frame));
+	return hleLogDebug(Log::ME, ctx->AuResetPlayPositionByFrame(frame));
 }
 
 static u32 sceMp3LowLevelInit(u32 mp3, u32 unk) {
@@ -717,7 +717,7 @@ static u32 sceMp3LowLevelInit(u32 mp3, u32 unk) {
 	// Indicate that we've run low level init by setting version to 1.
 	ctx->Version = 1;
 
-	return hleDelayResult(hleLogSuccessInfoI(Log::ME, 0), "mp3 low level", 600);
+	return hleDelayResult(hleLogInfo(Log::ME, 0), "mp3 low level", 600);
 }
 
 static u32 sceMp3LowLevelDecode(u32 mp3, u32 sourceAddr, u32 sourceBytesConsumedAddr, u32 samplesAddr, u32 sampleBytesAddr) {

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -576,7 +576,7 @@ static u32 sceMpegCreate(u32 mpegAddr, u32 dataPtr, u32 size, u32 ringbufferAddr
 	ctx->isAnalyzed = false;
 	ctx->mediaengine = new MediaEngine();
 
-	return hleDelayResult(hleLogSuccessInfoX(Log::ME, 0), "mpeg create", 29000);
+	return hleDelayResult(hleLogInfo(Log::ME, 0), "mpeg create", 29000);
 }
 
 static int sceMpegDelete(u32 mpeg)
@@ -1218,9 +1218,9 @@ static u32 sceMpegAvcDecode(u32 mpeg, u32 auAddr, u32 frameWidth, u32 bufferAddr
 	ctx->avc.avcDecodeResult = MPEG_AVC_DECODE_SUCCESS;
 
 	if (ctx->videoFrameCount <= 1) {
-		return hleDelayResult(hleLogSuccessI(Log::ME, 0), "mpeg decode", accumDelay + avcFirstDelayMs);
+		return hleDelayResult(hleLogDebug(Log::ME, 0), "mpeg decode", accumDelay + avcFirstDelayMs);
 	} else {
-		return hleDelayResult(hleLogSuccessI(Log::ME, 0), "mpeg decode", accumDelay + avcDecodeDelayMs);
+		return hleDelayResult(hleLogDebug(Log::ME, 0), "mpeg decode", accumDelay + avcDecodeDelayMs);
 	}
 	//hleEatMicro(3300);
 	//return hleDelayResult(0, "mpeg decode", 200);
@@ -1682,7 +1682,7 @@ static u32 sceMpegFinish()
 }
 
 static u32 sceMpegQueryMemSize() {
-	return hleLogSuccessX(Log::ME, MpegRequiredMem());
+	return hleLogDebug(Log::ME, MpegRequiredMem());
 }
 
 static int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
@@ -2159,7 +2159,7 @@ static int sceMpegAvcConvertToYuv420(u32 mpeg, u32 bufferOutputAddr, u32 bufferA
 	if (data) {
 		__MpegAvcConvertToYuv420(data, bufferOutputAddr, width, height);
 	}
-	return hleLogSuccessX(Log::ME, (width << 16) | height);
+	return hleLogDebug(Log::ME, (width << 16) | height);
 }
 
 static int sceMpegGetUserdataAu(u32 mpeg, u32 streamUid, u32 auAddr, u32 resultAddr)

--- a/Core/HLE/sceMt19937.cpp
+++ b/Core/HLE/sceMt19937.cpp
@@ -37,7 +37,7 @@ static u32 sceMt19937Init(u32 mt19937Addr, u32 seed)
 	// This is made to match the memory layout of a PSP MT structure exactly.
 	// Let's just construct it in place with placement new. Elite C++ hackery FTW.
 	new (ptr) MersenneTwister(seed);
-	return hleLogSuccessInfoI(Log::HLE, 0);
+	return hleLogInfo(Log::HLE, 0);
 }
 
 static u32 sceMt19937UInt(u32 mt19937Addr)
@@ -45,7 +45,7 @@ static u32 sceMt19937UInt(u32 mt19937Addr)
 	if (!Memory::IsValidAddress(mt19937Addr))
 		return hleLogError(Log::HLE, -1);
 	MersenneTwister *mt = (MersenneTwister *)Memory::GetPointer(mt19937Addr);
-	return hleLogSuccessVerboseX(Log::HLE, mt->R32());
+	return hleLogVerbose(Log::HLE, mt->R32());
 }
 
 const HLEFunction sceMt19937[] =

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -897,7 +897,7 @@ static int sceNetInit(u32 poolSize, u32 calloutPri, u32 calloutStack, u32 netini
 
 	auto n = GetI18NCategory(I18NCat::NETWORKING);
 
-	return hleLogSuccessI(Log::sceNet, 0);
+	return hleLogDebug(Log::sceNet, 0);
 }
 
 // Free(delete) thread info / data. 
@@ -931,7 +931,7 @@ static u32 sceWlanGetEtherAddr(u32 addrAddr) {
 	}
 	NotifyMemInfo(MemBlockFlags::WRITE, addrAddr, 6, "WlanEtherAddr");
 
-	return hleDelayResult(hleLogSuccessI(Log::sceNet, 0), "get ether mac", 200);
+	return hleDelayResult(hleLogDebug(Log::sceNet, 0), "get ether mac", 200);
 }
 
 static u32 sceNetGetLocalEtherAddr(u32 addrAddr) {
@@ -943,11 +943,11 @@ static u32 sceNetGetLocalEtherAddr(u32 addrAddr) {
 }
 
 static u32 sceWlanDevIsPowerOn() {
-	return hleLogSuccessVerboseI(Log::sceNet, g_Config.bEnableWlan ? 1 : 0);
+	return hleLogVerbose(Log::sceNet, g_Config.bEnableWlan ? 1 : 0);
 }
 
 static u32 sceWlanGetSwitchState() {
-	return hleLogSuccessVerboseI(Log::sceNet, g_Config.bEnableWlan ? 1 : 0);
+	return hleLogVerbose(Log::sceNet, g_Config.bEnableWlan ? 1 : 0);
 }
 
 // Probably a void function, but often returns a useful value.
@@ -1025,7 +1025,7 @@ static int sceNetGetMallocStat(u32 statPtr) {
 
 	*stat = netMallocStat;
 	stat.NotifyWrite("sceNetGetMallocStat");
-	return hleLogSuccessVerboseI(Log::sceNet, 0);
+	return hleLogVerbose(Log::sceNet, 0);
 }
 
 void NetApctl_InitDefaultInfo() {
@@ -1123,7 +1123,7 @@ static int sceNetApctlInit(int stackSize, int initPriority) {
 	}
 
 	g_netApctlInited = true;
-	return hleLogSuccessInfoI(Log::sceNet, 0);
+	return hleLogInfo(Log::sceNet, 0);
 }
 
 int NetApctl_Term() {
@@ -1154,7 +1154,7 @@ int NetApctl_Term() {
 static int sceNetApctlTerm() {
 	int retval = NetApctl_Term();
 	hleEatMicro(adhocDefaultDelay);
-	return hleLogSuccessInfoI(Log::sceNet, retval);
+	return hleLogInfo(Log::sceNet, retval);
 }
 
 static int sceNetApctlGetInfo(int code, u32 pInfoAddr) {
@@ -1288,7 +1288,7 @@ static int sceNetApctlGetInfo(int code, u32 pInfoAddr) {
 		return hleLogError(Log::sceNet, ERROR_NET_APCTL_INVALID_CODE, "apctl invalid code");
 	}
 
-	return hleLogSuccessI(Log::sceNet, 0);
+	return hleLogDebug(Log::sceNet, 0);
 }
 
 static int NetApctl_AddHandler(u32 handlerPtr, u32 handlerArg) {
@@ -1339,7 +1339,7 @@ static int NetApctl_DelHandler(u32 handlerID) {
 	auto iter = apctlHandlers.find(handlerID);
 	if (iter != apctlHandlers.end()) {
 		apctlHandlers.erase(iter);
-		return hleLogSuccessInfoI(Log::sceNet, 0, "Deleted Apctl handler: %d", handlerID);
+		return hleLogInfo(Log::sceNet, 0, "Deleted Apctl handler: %d", handlerID);
 	} else {
 		return hleLogError(Log::sceNet, -1, "Invalid Apctl handler: %d", handlerID);
 	}
@@ -1372,7 +1372,7 @@ int sceNetApctlConnect(int confId) {
 
 	// hleDelayResult(0, "give time to init/cleanup", adhocEventDelayMS * 1000);
 	// TODO: Blocks current thread and wait for a state change to prevent user-triggered connection attempt from causing events to piles up
-	return hleLogSuccessInfoI(Log::sceNet, 0, "connect = %i", ret);
+	return hleLogInfo(Log::sceNet, 0, "connect = %i", ret);
 }
 
 int sceNetApctlDisconnect() {
@@ -1387,7 +1387,7 @@ int sceNetApctlDisconnect() {
 	apctlEvents.clear();
 	__UpdateApctlHandlers(netApctlState, PSP_NET_APCTL_STATE_DISCONNECTED, PSP_NET_APCTL_EVENT_DISCONNECT_REQUEST, 0);
 	// TODO: Blocks current thread and wait for a state change, but the state should probably need to be changed within 1 frame-time (~16ms) 
-	return hleLogSuccessInfoI(Log::sceNet, 0);
+	return hleLogInfo(Log::sceNet, 0);
 }
 
 int NetApctl_GetState() {
@@ -1406,7 +1406,7 @@ static int sceNetApctlGetState(u32 pStateAddr) {
 		// Return Thread Status
 		Memory::Write_U32(NetApctl_GetState(), pStateAddr);
 		// Return Success
-		return hleLogSuccessI(Log::sceNet, 0);
+		return hleLogDebug(Log::sceNet, 0);
 	}
 
 	return hleLogError(Log::sceNet, -1, "apctl invalid arg"); // 0x8002013A or ERROR_NET_WLAN_INVALID_ARG ?
@@ -1422,7 +1422,7 @@ int NetApctl_ScanUser() {
 		return hleLogError(Log::sceNet, ERROR_NET_APCTL_NOT_DISCONNECTED, "apctl not disconnected");
 
 	__UpdateApctlHandlers(0, PSP_NET_APCTL_STATE_SCANNING, PSP_NET_APCTL_EVENT_SCAN_REQUEST, 0);
-	return hleLogSuccessInfoX(Log::sceNet, 0);
+	return hleLogInfo(Log::sceNet, 0);
 }
 
 static int sceNetApctlScanUser() {
@@ -1465,7 +1465,7 @@ int NetApctl_GetBSSDescIDListUser(u32 sizeAddr, u32 bufAddr) {
 			Memory::Write_U32(0, bufAddr + offset - userInfoSize);
 	}
 
-	return hleLogSuccessInfoI(Log::sceNet, 0);
+	return hleLogInfo(Log::sceNet, 0);
 }
 
 static int sceNetApctlGetBSSDescIDListUser(u32 sizeAddr, u32 bufAddr) {
@@ -1647,13 +1647,13 @@ static int sceNetUpnpGetNatInfo() {
 static int sceNetGetDropRate(u32 dropRateAddr, u32 dropDurationAddr) {
 	Memory::Write_U32(netDropRate, dropRateAddr);
 	Memory::Write_U32(netDropDuration, dropDurationAddr);
-	return hleLogSuccessInfoI(Log::sceNet, 0);
+	return hleLogInfo(Log::sceNet, 0);
 }
 
 static int sceNetSetDropRate(u32 dropRate, u32 dropDuration) {
 	netDropRate = dropRate;
 	netDropDuration = dropDuration;
-	return hleLogSuccessInfoI(Log::sceNet, 0);
+	return hleLogInfo(Log::sceNet, 0);
 }
 
 const HLEFunction sceNet[] = {

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -1253,7 +1253,7 @@ u32 sceNetAdhocInit() {
 		deleteAllGMB();
 
 		// Return Success
-		return hleLogSuccessInfoI(Log::sceNet, 0, "at %08x", currentMIPS->pc);
+		return hleLogInfo(Log::sceNet, 0, "at %08x", currentMIPS->pc);
 	}
 	// Already initialized
 	return hleLogWarning(Log::sceNet, ERROR_NET_ADHOC_ALREADY_INITIALIZED, "already initialized");
@@ -1296,7 +1296,7 @@ int sceNetAdhocctlInit(int stackSize, int prio, u32 productAddr) {
 	int us = adhocDefaultDelay;
 	if (g_Config.bEnableWlan && !g_adhocServerConnected) {
 		AdhocctlRequest dummyreq = { OPCODE_LOGIN, {0} };
-		return hleLogSuccessOrWarn(Log::sceNet, WaitBlockingAdhocctlSocket(dummyreq, us, "adhocctl init"));
+		return hleLogDebugOrWarn(Log::sceNet, WaitBlockingAdhocctlSocket(dummyreq, us, "adhocctl init"));
 	}
 	// Give a little time for friendFinder thread to be ready before the game use the next sceNet functions, should've checked for friendFinderRunning status instead of guessing the time?
 	hleEatMicro(us);
@@ -1322,7 +1322,7 @@ int sceNetAdhocctlGetState(u32 ptrToStatus) {
 	Memory::Write_U32(state, ptrToStatus);
 
 	// Return Success
-	return hleLogSuccessVerboseI(Log::sceNet, 0, "state = %d", state);
+	return hleLogVerbose(Log::sceNet, 0, "state = %d", state);
 }
 
 /**
@@ -1633,7 +1633,7 @@ int sceNetAdhocPdpSend(int id, const char *mac, u32 port, void *data, int len, i
 
 									// Non-Blocking
 									if (flag) 
-										return hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_WOULD_BLOCK, "would block");
+										return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_WOULD_BLOCK, "would block");
 
 									// Does PDP can Timeout? There is no concept of Timeout when sending UDP due to no ACK, but might happen if the socket buffer is full, not sure about PDP since some games did use the timeout arg
 									return hleLogDebug(Log::sceNet, ERROR_NET_ADHOC_TIMEOUT, "timeout?"); // ERROR_NET_ADHOC_INVALID_ADDR;
@@ -1879,7 +1879,7 @@ int sceNetAdhocPdpRecv(int id, void *addr, void * port, void *buf, void *dataLen
 					if (peer != NULL) peer->last_recv = CoreTiming::GetGlobalTimeUsScaled();
 					peerlock.unlock();
 
-					return hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_NOT_ENOUGH_SPACE, "not enough space");
+					return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_NOT_ENOUGH_SPACE, "not enough space");
 				}
 
 				sinlen = sizeof(sin);
@@ -2269,7 +2269,7 @@ int sceNetAdhocctlScan() {
 
 			if (friendFinderRunning) {
 				AdhocctlRequest req = { OPCODE_SCAN, {0} };
-				return hleLogSuccessOrError(Log::sceNet, WaitBlockingAdhocctlSocket(req, us, "adhocctl scan"));
+				return hleLogDebugOrError(Log::sceNet, WaitBlockingAdhocctlSocket(req, us, "adhocctl scan"));
 			}
 			else {
 				adhocctlState = ADHOCCTL_STATE_DISCONNECTED;
@@ -2522,7 +2522,7 @@ int sceNetAdhocctlDisconnect() {
 	char grpName[9] = { 0 };
 	memcpy(grpName, parameter.group_name.data, ADHOCCTL_GROUPNAME_LEN); // Copied to null-terminated var to prevent unexpected behaviour on Logs
 	int ret = NetAdhocctl_Disconnect();
-	return hleLogSuccessI(Log::sceNet, ret, "group=%s", grpName);
+	return hleLogDebug(Log::sceNet, ret, "group=%s", grpName);
 }
 
 static u32 sceNetAdhocctlDelHandler(u32 handlerID) {
@@ -3023,7 +3023,7 @@ int sceNetAdhocTerm() {
 	int retval = NetAdhoc_Term();
 
 	hleEatMicro(adhocDefaultDelay);
-	return hleLogSuccessInfoI(Log::sceNet, retval);
+	return hleLogInfo(Log::sceNet, retval);
 }
 
 static int sceNetAdhocGetPdpStat(u32 structSize, u32 structAddr) {
@@ -3113,11 +3113,11 @@ static int sceNetAdhocGetPdpStat(u32 structSize, u32 structAddr) {
 		}
 
 		// Invalid Arguments
-		return hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_INVALID_ARG, "invalid arg, at %08x", currentMIPS->pc);
+		return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_INVALID_ARG, "invalid arg, at %08x", currentMIPS->pc);
 	}
 
 	// Library is uninitialized
-	return hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_NOT_INITIALIZED, "not initialized, at %08x", currentMIPS->pc);
+	return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_NOT_INITIALIZED, "not initialized, at %08x", currentMIPS->pc);
 }
 
 
@@ -3221,11 +3221,11 @@ static int sceNetAdhocGetPtpStat(u32 structSize, u32 structAddr) {
 		}
 		
 		// Invalid Arguments
-		return hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_INVALID_ARG, "invalid arg, at %08x", currentMIPS->pc);
+		return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_INVALID_ARG, "invalid arg, at %08x", currentMIPS->pc);
 	}
 	
 	// Library is uninitialized
-	return hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_NOT_INITIALIZED, "not initialized, at %08x", currentMIPS->pc);
+	return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_NOT_INITIALIZED, "not initialized, at %08x", currentMIPS->pc);
 }
 
 
@@ -3601,7 +3601,7 @@ int AcceptPtpSocket(int ptpId, int newsocket, sockaddr_in& peeraddr, SceNetEther
 					changeBlockingMode(newsocket, 1);
 
 					// Return Socket
-					return hleLogSuccessI(Log::sceNet, i + 1, "Established (%s:%u) - state: %d", ip2str(peeraddr.sin_addr).c_str(), internal->data.ptp.pport, internal->data.ptp.state);
+					return hleLogDebug(Log::sceNet, i + 1, "Established (%s:%u) - state: %d", ip2str(peeraddr.sin_addr).c_str(), internal->data.ptp.pport, internal->data.ptp.state);
 				}
 
 				// Free Memory
@@ -3699,26 +3699,26 @@ static int sceNetAdhocPtpAccept(int id, u32 peerMacAddrPtr, u32 peerPortPtr, int
 
 					// Action would block
 					if (flag)
-						return hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_WOULD_BLOCK, "would block");
+						return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_WOULD_BLOCK, "would block");
 
 					// Timeout
-					return hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_TIMEOUT, "timeout");
+					return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_TIMEOUT, "timeout");
 				}
 
 				// Client Socket
-				return hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_NOT_LISTENED, "not listened");
+				return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_NOT_LISTENED, "not listened");
 			}
 
 			// Invalid Socket
-			return hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_INVALID_SOCKET_ID, "invalid socket id");
+			return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_INVALID_SOCKET_ID, "invalid socket id");
 		}
 
 		// Invalid Arguments
-		return hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_INVALID_ARG, "invalid arg");
+		return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_INVALID_ARG, "invalid arg");
 	}
 	
 	// Library is uninitialized
-	return hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_NOT_INITIALIZED, "not initialized");
+	return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_NOT_INITIALIZED, "not initialized");
 }
 
 int NetAdhocPtp_Connect(int id, int timeout, int flag, bool allowForcedConnect) {
@@ -4174,7 +4174,7 @@ static int sceNetAdhocPtpSend(int id, u32 dataAddr, u32 dataSizeAddr, int timeou
 					else if (sent == SOCKET_ERROR && (error == EAGAIN || error == EWOULDBLOCK || (ptpsocket.state == ADHOC_PTP_STATE_SYN_SENT && (error == ENOTCONN || connectInProgress(error))))) {
 						// Non-Blocking
 						if (flag) 
-							return hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_WOULD_BLOCK, "would block");
+							return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_WOULD_BLOCK, "would block");
 						
 						// Simulate blocking behaviour with non-blocking socket
 						u64 threadSocketId = ((u64)__KernelGetCurThread()) << 32 | ptpsocket.id;
@@ -4263,7 +4263,7 @@ static int sceNetAdhocPtpRecv(int id, u32 dataAddr, u32 dataSizeAddr, int timeou
 							return WaitBlockingAdhocSocket(threadSocketId, PTP_RECV, id, buf, len, timeout, nullptr, nullptr, "ptp recv");
 						}
 
-						return hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_WOULD_BLOCK, "would block");
+						return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_WOULD_BLOCK, "would block");
 					}
 
 					// Free Network Lock
@@ -4376,7 +4376,7 @@ static int sceNetAdhocPtpFlush(int id, int timeout, int nonblock) {
 				if (error == EAGAIN || error == EWOULDBLOCK) {
 					// Non-Blocking
 					if (nonblock)
-						return hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_WOULD_BLOCK, "would block");
+						return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_WOULD_BLOCK, "would block");
 
 					// Simulate blocking behaviour with non-blocking socket
 					u64 threadSocketId = ((u64)__KernelGetCurThread()) << 32 | ptpsocket.id;
@@ -4507,7 +4507,7 @@ static int sceNetAdhocGameModeCreateReplica(const char *mac, u32 dataAddr, int s
 				DEBUG_LOG(Log::sceNet, "GameMode: Blocking Thread %d to Sync initial Master data", __KernelGetCurThread());
 			}
 		}
-		return hleLogSuccessInfoI(Log::sceNet, ret, "success");
+		return hleLogInfo(Log::sceNet, ret, "success");
 	}
 
 	return hleLogError(Log::sceNet, ERROR_NET_ADHOC_NOT_CREATED, "not created");
@@ -5119,7 +5119,7 @@ int sceNetAdhocDiscoverInitStart(u32 paramAddr) {
 	netAdhocDiscoverStatus = NET_ADHOC_DISCOVER_STATUS_IN_PROGRESS;
 	netAdhocDiscoverParam->result = NET_ADHOC_DISCOVER_RESULT_NO_PEER_FOUND;
 	netAdhocDiscoverStartTime = CoreTiming::GetGlobalTimeUsScaled();
-	return hleLogSuccessInfoX(Log::sceNet, 0);
+	return hleLogInfo(Log::sceNet, 0);
 }
 
 // Note1: When canceling the progress, Legend Of The Dragon will use DiscoverStop -> AdhocctlDisconnect -> DiscoverTerm (when status changed to 2)

--- a/Core/HLE/sceNetInet.cpp
+++ b/Core/HLE/sceNetInet.cpp
@@ -63,13 +63,13 @@ static int sceNetInetInit() {
 	if (netInetInited)
 		return hleLogError(Log::sceNet, ERROR_NET_INET_ALREADY_INITIALIZED);
 	netInetInited = true;
-	return hleLogSuccessI(Log::sceNet, 0);
+	return hleLogDebug(Log::sceNet, 0);
 }
 
 static int sceNetInetTerm() {
 	WARN_LOG(Log::sceNet, "UNIMPL sceNetInetTerm()");
 	__NetInetShutdown();
-	return hleLogSuccessI(Log::sceNet, 0);
+	return hleLogDebug(Log::sceNet, 0);
 }
 
 static int sceNetInetGetErrno() {
@@ -82,7 +82,7 @@ static int sceNetInetGetErrno() {
 
 static int sceNetInetGetPspError() {
 	uint32_t error = convertInetErrno2PSPError(g_inetLastErrno);
-	return hleLogSuccessInfoI(Log::sceNet, error, "returning %s converted to %08x at %08x", convertInetErrno2str(g_inetLastErrno), error, currentMIPS->pc);
+	return hleLogInfo(Log::sceNet, error, "returning %s converted to %08x at %08x", convertInetErrno2str(g_inetLastErrno), error, currentMIPS->pc);
 }
 
 static int sceNetInetInetPton(int af, const char* hostname, u32 inAddrPtr) {
@@ -96,7 +96,7 @@ static int sceNetInetInetPton(int af, const char* hostname, u32 inAddrPtr) {
 		UpdateErrnoFromHost(socket_errno, __FUNCTION__);
 		return hleLogError(Log::sceNet, retval);
 	}
-	return hleLogSuccessI(Log::sceNet, retval);
+	return hleLogDebug(Log::sceNet, retval);
 }
 
 static int sceNetInetInetAton(const char* hostname, u32 inAddrPtr) {
@@ -107,7 +107,7 @@ static int sceNetInetInetAton(const char* hostname, u32 inAddrPtr) {
 	// TODO: Wait what, we're calling pton in aton?
 	int retval = inet_pton(AF_INET, hostname, (void*)Memory::GetPointer(inAddrPtr));
 	// inet_aton() returns nonzero if the address is valid, zero if not.
-	return hleLogSuccessI(Log::sceNet, retval);
+	return hleLogDebug(Log::sceNet, retval);
 }
 
 // TODO: Need to find out whether it's possible to get partial output or not, since Coded Arms Contagion is using a small bufsize(4)
@@ -124,7 +124,7 @@ static u32 sceNetInetInetNtop(int af, u32 srcInAddrPtr, u32 dstBufPtr, u32 bufsi
 	if (inet_ntop(convertSocketDomainPSP2Host(af), Memory::GetCharPointer(srcInAddrPtr), (char*)Memory::GetCharPointer(dstBufPtr), bufsize) == NULL) {
 		//return hleLogDebug(Log::sceNet, 0, "invalid arg?"); // Temporarily commented out in case it's allowed to have partial output
 	}
-	return hleLogSuccessX(Log::sceNet, dstBufPtr, "%s", safe_string(Memory::GetCharPointer(dstBufPtr)));
+	return hleLogDebug(Log::sceNet, dstBufPtr, "%s", safe_string(Memory::GetCharPointer(dstBufPtr)));
 }
 
 static u32_le sceNetInetInetAddr(const char *hostname) {
@@ -135,7 +135,7 @@ static u32_le sceNetInetInetAddr(const char *hostname) {
 	u32 retval = INADDR_NONE; // inet_addr(hostname); // deprecated?
 	inet_pton(AF_INET, hostname, &retval); // Alternative to the deprecated inet_addr
 
-	return hleLogSuccessX(Log::sceNet, retval);
+	return hleLogDebug(Log::sceNet, retval);
 }
 
 static int sceNetInetGetpeername(int socket, u32 namePtr, u32 namelenPtr) {
@@ -169,7 +169,7 @@ static int sceNetInetGetpeername(int socket, u32 namePtr, u32 namelenPtr) {
 	// We shouldn't use the returned len here, because the returned len is the actual size needed, which can be larger than the inputted len
 	memcpy(name->sa_data, saddr.addr.sa_data, name->sa_len - (sizeof(name->sa_len) + sizeof(name->sa_family)));
 	name->sa_family = saddr.addr.sa_family;
-	return hleLogSuccessInfoI(Log::sceNet, 0);
+	return hleLogInfo(Log::sceNet, 0);
 }
 
 static int sceNetInetGetsockname(int socket, u32 namePtr, u32 namelenPtr) {
@@ -202,7 +202,7 @@ static int sceNetInetGetsockname(int socket, u32 namePtr, u32 namelenPtr) {
 	// We shouldn't use the returned len here, because the returned len is the actual size needed, which can be larger than the inputted len
 	memcpy(name->sa_data, saddr.addr.sa_data, name->sa_len - (sizeof(name->sa_len) + sizeof(name->sa_family)));
 	name->sa_family = saddr.addr.sa_family;
-	return hleLogSuccessInfoI(Log::sceNet, 0);
+	return hleLogInfo(Log::sceNet, 0);
 }
 
 // FIXME: nfds is number of fd(s) as in posix poll, or was it maximum fd value as in posix select? Star Wars Battlefront Renegade seems to set the nfds to 64, while Coded Arms Contagion is using 256
@@ -322,7 +322,7 @@ int sceNetInetSelect(int nfds, u32 readfdsPtr, u32 writefdsPtr, u32 exceptfdsPtr
 		UpdateErrnoFromHost(socket_errno, __FUNCTION__);
 		return hleDelayResult(hleLogDebug(Log::sceNet, retval), "workaround until blocking-socket", 500); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented (ie. Coded Arms Contagion)
 	}
-	return hleDelayResult(hleLogSuccessI(Log::sceNet, retval), "workaround until blocking-socket", 500); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented (ie. Coded Arms Contagion)
+	return hleDelayResult(hleLogDebug(Log::sceNet, retval), "workaround until blocking-socket", 500); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented (ie. Coded Arms Contagion)
 }
 
 int sceNetInetPoll(u32 fdsPtr, u32 nfds, int timeout) { // timeout in miliseconds just like posix poll? or in microseconds as other PSP timeout?
@@ -380,7 +380,7 @@ int sceNetInetPoll(u32 fdsPtr, u32 nfds, int timeout) { // timeout in milisecond
 		VERBOSE_LOG(Log::sceNet, "Poll Socket#%d Fd: %d, events: %04x, revents: %04x, availToRecv: %d", i, fdarray[i].fd, fdarray[i].events, fdarray[i].revents, (int)getAvailToRecv(fdarray[i].fd));
 	}
 	//hleEatMicro(1000);
-	return hleDelayResult(hleLogSuccessI(Log::sceNet, retval), "workaround until blocking-socket", 1000); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented
+	return hleDelayResult(hleLogDebug(Log::sceNet, retval), "workaround until blocking-socket", 1000); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented
 }
 
 static int sceNetInetRecv(int socket, u32 bufPtr, u32 bufLen, u32 flags) {
@@ -405,7 +405,7 @@ static int sceNetInetRecv(int socket, u32 bufPtr, u32 bufLen, u32 flags) {
 	DataToHexString(10, 0, Memory::GetPointer(bufPtr), retval, &datahex);
 	VERBOSE_LOG(Log::sceNet, "Data Dump (%d bytes):\n%s", retval, datahex.c_str());
 
-	return hleDelayResult(hleLogSuccessInfoI(Log::sceNet, retval), "workaround until blocking-socket", 500); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented
+	return hleDelayResult(hleLogInfo(Log::sceNet, retval), "workaround until blocking-socket", 500); // Using hleDelayResult as a workaround for games that need blocking-socket to be implemented
 }
 
 static int sceNetInetSend(int socket, u32 bufPtr, u32 bufLen, u32 flags) {
@@ -425,7 +425,7 @@ static int sceNetInetSend(int socket, u32 bufPtr, u32 bufLen, u32 flags) {
 		UpdateErrnoFromHost(socket_errno, __FUNCTION__);
 		return hleLogError(Log::sceNet, retval);
 	}
-	return hleLogSuccessInfoI(Log::sceNet, retval);
+	return hleLogInfo(Log::sceNet, retval);
 }
 
 static int sceNetInetSocket(int domain, int type, int protocol) {
@@ -449,7 +449,7 @@ static int sceNetInetSocket(int domain, int type, int protocol) {
 	setSockReuseAddrPort(inetSock->sock);
 	// Disable Connection Reset error on UDP to avoid strange behavior
 	setUDPConnReset(inetSock->sock, false);
-	return hleLogSuccessI(Log::sceNet, socket);
+	return hleLogDebug(Log::sceNet, socket);
 }
 
 static int sceNetInetSetsockopt(int socket, int level, int optname, u32 optvalPtr, int optlen) {
@@ -469,7 +469,7 @@ static int sceNetInetSetsockopt(int socket, int level, int optname, u32 optvalPt
 		switch (optname) {
 		case PSP_NET_INET_SO_NBIO:
 			inetSock->nonblocking = optval;
-			return hleLogSuccessI(Log::sceNet, 0);
+			return hleLogDebug(Log::sceNet, 0);
 		// FIXME: Should we ignore SO_BROADCAST flag since we are using fake broadcast (ie. only broadcast to friends),
 		//        But Infrastructure/Online play might need to use broadcast for SSDP and to support LAN MP with real PSP
 		/*else if (level == PSP_NET_INET_SOL_SOCKET && optname == PSP_NET_INET_SO_BROADCAST) {
@@ -479,12 +479,12 @@ static int sceNetInetSetsockopt(int socket, int level, int optname, u32 optvalPt
 		// TODO: Ignoring SO_REUSEADDR flag to prevent disrupting multiple-instance feature
 		case PSP_NET_INET_SO_REUSEADDR:
 			//memcpy(&sock->reuseaddr, (int*)optval, std::min(sizeof(sock->reuseaddr), optlen));
-			return hleLogSuccessI(Log::sceNet, 0);
+			return hleLogDebug(Log::sceNet, 0);
 
 		// TODO: Ignoring SO_REUSEPORT flag to prevent disrupting multiple-instance feature (not sure if PSP has SO_REUSEPORT or not tho, defined as 15 on Android)
 		case PSP_NET_INET_SO_REUSEPORT: // 15
 			//memcpy(&sock->reuseport, (int*)optval, std::min(sizeof(sock->reuseport), optlen));
-			return hleLogSuccessI(Log::sceNet, 0);
+			return hleLogDebug(Log::sceNet, 0);
 
 		// TODO: Ignoring SO_NOSIGPIPE flag to prevent crashing PPSSPP (not sure if PSP has NOSIGPIPE or not tho, defined as 0x1022 on Darwin)
 		case PSP_NET_INET_SO_NOSIGPIPE: // WARNING: Not sure about this one. But we definitely don't want signals, so we ignore it.
@@ -523,7 +523,7 @@ static int sceNetInetSetsockopt(int socket, int level, int optname, u32 optvalPt
 		UpdateErrnoFromHost(socket_errno, __FUNCTION__);
 		return hleLogError(Log::sceNet, retval);
 	}
-	return hleLogSuccessI(Log::sceNet, retval);
+	return hleLogDebug(Log::sceNet, retval);
 }
 
 static int sceNetInetGetsockopt(int socket, int level, int optname, u32 optvalPtr, u32 optlenPtr) {
@@ -543,7 +543,7 @@ static int sceNetInetGetsockopt(int socket, int level, int optname, u32 optvalPt
 		//*optlen = std::min(sizeof(sock->nonblocking), *optlen);
 		//memcpy((int*)optval, &sock->nonblocking, *optlen);
 		//if (sock->nonblocking && *optlen>0) *optval = 0x80; // on true, returning 0x80 when retrieved using getsockopt?
-		return hleLogSuccessI(Log::sceNet, 0);
+		return hleLogDebug(Log::sceNet, 0);
 	}
 	// FIXME: Should we ignore SO_BROADCAST flag since we are using fake broadcast (ie. only broadcast to friends),
 	//        But Infrastructure/Online play might need to use broadcast for SSDP and to support LAN MP with real PSP
@@ -557,19 +557,19 @@ static int sceNetInetGetsockopt(int socket, int level, int optname, u32 optvalPt
 	else if (level == PSP_NET_INET_SOL_SOCKET && optname == PSP_NET_INET_SO_REUSEADDR) {
 		//*optlen = std::min(sizeof(sock->reuseaddr), *optlen);
 		//memcpy((int*)optval, &sock->reuseaddr, *optlen);
-		return hleLogSuccessI(Log::sceNet, 0);
+		return hleLogDebug(Log::sceNet, 0);
 	}
 	// TODO: Ignoring SO_REUSEPORT flag to prevent disrupting multiple-instance feature (not sure if PSP has SO_REUSEPORT or not tho, defined as 15 on Android)
 	else if (level == PSP_NET_INET_SOL_SOCKET && optname == PSP_NET_INET_SO_REUSEPORT) { // 15
 		//*optlen = std::min(sizeof(sock->reuseport), *optlen);
 		//memcpy((int*)optval, &sock->reuseport, *optlen);
-		return hleLogSuccessI(Log::sceNet, 0);
+		return hleLogDebug(Log::sceNet, 0);
 	}
 	// TODO: Ignoring SO_NOSIGPIPE flag to prevent crashing PPSSPP (not sure if PSP has NOSIGPIPE or not tho, defined as 0x1022 on Darwin)
 	else if (level == PSP_NET_INET_SOL_SOCKET && optname == 0x1022) { // PSP_NET_INET_SO_NOSIGPIPE ?
 		//*optlen = std::min(sizeof(sock->nosigpipe), *optlen);
 		//memcpy((int*)optval, &sock->nosigpipe, *optlen);
-		return hleLogSuccessI(Log::sceNet, 0);
+		return hleLogDebug(Log::sceNet, 0);
 	}
 	int retval = 0;
 	// PSP timeout are a single 32bit value (micro seconds)
@@ -588,7 +588,7 @@ static int sceNetInetGetsockopt(int socket, int level, int optname, u32 optvalPt
 		return hleLogError(Log::sceNet, retval);
 	}
 	DEBUG_LOG(Log::sceNet, "SockOpt: OptValue = %d", *optval);
-	return hleLogSuccessI(Log::sceNet, retval);
+	return hleLogDebug(Log::sceNet, retval);
 }
 
 static int sceNetInetBind(int socket, u32 namePtr, int namelen) {
@@ -649,7 +649,7 @@ static int sceNetInetBind(int socket, u32 namePtr, int namelen) {
 	saddr.in.sin_port = 0;
 	sendto(socket, dummyPeekBuf64k, 0, MSG_NOSIGNAL, (struct sockaddr*)&saddr, sizeof(saddr));
 	*/
-	return hleLogSuccessInfoI(Log::sceNet, retval);
+	return hleLogInfo(Log::sceNet, retval);
 }
 
 static int sceNetInetConnect(int socket, u32 sockAddrPtr, int sockAddrLen) {
@@ -692,7 +692,7 @@ static int sceNetInetConnect(int socket, u32 sockAddrPtr, int sockAddrLen) {
 		// We should sniff these messages...
 	}
 
-	return hleLogSuccessInfoI(Log::sceNet, retval, "Connect: Address = %s, Port = %d", ip2str(saddr.in.sin_addr).c_str(), ntohs(saddr.in.sin_port));
+	return hleLogInfo(Log::sceNet, retval, "Connect: Address = %s, Port = %d", ip2str(saddr.in.sin_addr).c_str(), ntohs(saddr.in.sin_port));
 }
 
 static int sceNetInetListen(int socket, int backlog) {
@@ -707,7 +707,7 @@ static int sceNetInetListen(int socket, int backlog) {
 		return hleLogError(Log::sceNet, retval);
 	}
 
-	return hleLogSuccessInfoI(Log::sceNet, retval);
+	return hleLogInfo(Log::sceNet, retval);
 }
 
 static int sceNetInetAccept(int socket, u32 addrPtr, u32 addrLenPtr) {
@@ -746,7 +746,7 @@ static int sceNetInetAccept(int socket, u32 addrPtr, u32 addrLenPtr) {
 	}
 	DEBUG_LOG(Log::sceNet, "Accept: Address = %s, Port = %d", ip2str(saddr.in.sin_addr).c_str(), ntohs(saddr.in.sin_port));
 
-	return hleLogSuccessInfoI(Log::sceNet, newSocketId);
+	return hleLogInfo(Log::sceNet, newSocketId);
 }
 
 static int sceNetInetShutdown(int socket, int how) {
@@ -764,7 +764,7 @@ static int sceNetInetShutdown(int socket, int how) {
 	}
 
 	int retVal = shutdown(inetSock->sock, hostHow);  // no translation
-	return hleLogSuccessInfoI(Log::sceNet, retVal);
+	return hleLogInfo(Log::sceNet, retVal);
 }
 
 static int sceNetInetSocketAbort(int socket) {
@@ -775,7 +775,7 @@ static int sceNetInetSocketAbort(int socket) {
 
 	// FIXME: either using shutdown/close or select? probably using select if blocking mode is being simulated with non-blocking
 	int retVal = shutdown(inetSock->sock, SHUT_RDWR);
-	return hleLogSuccessInfoI(Log::sceNet, retVal);
+	return hleLogInfo(Log::sceNet, retVal);
 }
 
 static int sceNetInetClose(int socket) {
@@ -785,7 +785,7 @@ static int sceNetInetClose(int socket) {
 	}
 
 	g_socketManager.Close(inetSock);
-	return hleLogSuccessInfoI(Log::sceNet, 0);
+	return hleLogInfo(Log::sceNet, 0);
 }
 
 // TODO: How is this different than just sceNetInetClose?
@@ -801,7 +801,7 @@ static int sceNetInetCloseWithRST(int socket) {
 	sl.l_linger = 0;	// timeout interval in seconds
 	setsockopt(inetSock->sock, SOL_SOCKET, SO_LINGER, (const char*)&sl, sizeof(sl));
 	g_socketManager.Close(inetSock);
-	return hleLogSuccessInfoI(Log::sceNet, 0);
+	return hleLogInfo(Log::sceNet, 0);
 }
 
 static int sceNetInetRecvfrom(int socket, u32 bufferPtr, int len, int flags, u32 fromPtr, u32 fromlenPtr) {
@@ -848,7 +848,7 @@ static int sceNetInetRecvfrom(int socket, u32 bufferPtr, int len, int flags, u32
 	VERBOSE_LOG(Log::sceNet, "Data Dump (%d bytes):\n%s", retval, datahex.c_str());
 
 	// Using hleDelayResult as a workaround for games that need blocking-socket to be implemented (ie. Coded Arms Contagion)
-	return hleDelayResult(hleLogSuccessInfoI(Log::sceNet, retval,
+	return hleDelayResult(hleLogInfo(Log::sceNet, retval,
 		"RecvFrom: Address = %s, Port = %d", ip2str(saddr.in.sin_addr).c_str(), ntohs(saddr.in.sin_port)), "workaround until blocking-socket", 500);
 }
 
@@ -921,7 +921,7 @@ static int sceNetInetSendto(int socket, u32 bufferPtr, int len, int flags, u32 t
 		}
 	}
 
-	return hleLogSuccessInfoI(Log::sceNet, retval, "SendTo: Address = %s, Port = %d", ip2str(saddr.in.sin_addr).c_str(), ntohs(saddr.in.sin_port));
+	return hleLogInfo(Log::sceNet, retval, "SendTo: Address = %s, Port = %d", ip2str(saddr.in.sin_addr).c_str(), ntohs(saddr.in.sin_port));
 }
 
 // Similar to POSIX's sendmsg or Winsock2's WSASendMsg? Are their packets compatible one another?
@@ -1119,7 +1119,7 @@ static int sceNetInetSendmsg(int socket, u32 msghdrPtr, int flags) {
 			return hleLogError(Log::sceNet, retval);
 		}
 	}
-	return hleLogSuccessInfoI(Log::sceNet, retval); // returns number of bytes sent?
+	return hleLogInfo(Log::sceNet, retval); // returns number of bytes sent?
 }
 
 // Similar to POSIX's recvmsg or Mswsock's WSARecvMsg? Are their packets compatible one another?

--- a/Core/HLE/sceNetResolver.cpp
+++ b/Core/HLE/sceNetResolver.cpp
@@ -68,7 +68,7 @@ static bool g_netResolverInitialized = true;
 
 static int sceNetResolverInit() {
 	// Hardcoded mHostToAlias entries here have been moved to the infra-dns.json file.
-	return hleLogSuccessInfoI(Log::sceNet, 0);
+	return hleLogInfo(Log::sceNet, 0);
 }
 
 void __NetResolverShutdown() {
@@ -79,7 +79,7 @@ void __NetResolverShutdown() {
 static int sceNetResolverTerm() {
 	g_netResolverInitialized = false;
 	__NetResolverShutdown();
-	return hleLogSuccessInfoI(Log::sceNet, 0);
+	return hleLogInfo(Log::sceNet, 0);
 }
 
 // Note: timeouts are in seconds
@@ -175,7 +175,7 @@ static int sceNetResolverStartNtoA(int resolverId, u32 hostnamePtr, u32 inAddrPt
 
 	for (int attempt = 0; attempt < retry; ++attempt) {
 		if (const int status = NetResolver_StartNtoA(resolverId, hostnamePtr, inAddrPtr, timeout, retry); status >= 0) {
-			return hleLogSuccessInfoI(Log::sceNet, status);
+			return hleLogInfo(Log::sceNet, status);
 		}
 	}
 	return -1;
@@ -239,7 +239,7 @@ static int sceNetResolverCreate(u32 resolverIdPtr, u32 bufferPtr, int bufferLen)
 	};
 
 	Memory::Write_U32(currentNetResolverId, resolverIdPtr);
-	return hleLogSuccessInfoI(Log::sceNet, 0, "ID: %d", Memory::Read_U32(resolverIdPtr));
+	return hleLogInfo(Log::sceNet, 0, "ID: %d", Memory::Read_U32(resolverIdPtr));
 }
 
 static int sceNetResolverStop(u32 resolverId) {
@@ -260,7 +260,7 @@ static int sceNetResolverStop(u32 resolverId) {
 	}
 
 	resolverIter->second.isRunning = false;
-	return hleLogSuccessInfoI(Log::sceNet, 0);
+	return hleLogInfo(Log::sceNet, 0);
 }
 
 static int sceNetResolverDelete(u32 resolverId) {
@@ -276,7 +276,7 @@ static int sceNetResolverDelete(u32 resolverId) {
 	}
 	g_netResolvers.erase(resolverIter);
 
-	return hleLogSuccessInfoI(Log::sceNet, 0);
+	return hleLogInfo(Log::sceNet, 0);
 }
 
 const HLEFunction sceNetResolver[] = {

--- a/Core/HLE/sceParseHttp.cpp
+++ b/Core/HLE/sceParseHttp.cpp
@@ -103,7 +103,7 @@ static int sceParseHttpResponseHeader(u32 headerAddr, int headerLength, const ch
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_PARSE_HTTP_NOT_FOUND, "parse http not found");
 	}
 
-	return hleLogSuccessI(Log::sceNet, len);
+	return hleLogDebug(Log::sceNet, len);
 }
 
 static int sceParseHttpStatusLine(u32 headerAddr, u32 headerLength, u32 httpVersionMajorAddr, u32 httpVersionMinorAddr, u32 httpStatusCodeAddr, u32 httpStatusCommentAddr, u32 httpStatusCommentLengthAddr) {
@@ -166,7 +166,7 @@ static int sceParseHttpStatusLine(u32 headerAddr, u32 headerLength, u32 httpVers
 		return hleLogError(Log::sceNet, -1, "Unknown error");
 	}
 
-	return hleLogSuccessI(Log::sceNet, 0);
+	return hleLogDebug(Log::sceNet, 0);
 }
 
 const HLEFunction sceParseHttp[] = {

--- a/Core/HLE/sceParseUri.cpp
+++ b/Core/HLE/sceParseUri.cpp
@@ -54,7 +54,7 @@ static int sceUriParse(u32 parsedUriAreaAddr, const char* url, u32 workAreaAddr,
 			*workAreaSz = sz;
 			workAreaSz.NotifyWrite("UriParse");
 		}
-		return hleLogSuccessI(Log::sceNet, 0, "workAreaSize: %d, %d", sz, workAreaSize);
+		return hleLogDebug(Log::sceNet, 0, "workAreaSize: %d, %d", sz, workAreaSize);
 	}
 
 	auto parsedUri = PSPPointer<PSPParsedUri>::Create(parsedUriAreaAddr);

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -239,7 +239,7 @@ static int scePowerRegisterCallback(int slot, int cbId) {
 		int arg = PSP_POWER_CB_AC_POWER | PSP_POWER_CB_BATTERY_EXIST | PSP_POWER_CB_BATTERY_FULL;
 		__KernelNotifyCallback(cbId, arg);
 	}
-	return hleLogSuccessOrError(Log::HLE, retval);
+	return hleLogDebugOrError(Log::HLE, retval);
 }
 
 static int scePowerUnregisterCallback(int slotId) {
@@ -326,7 +326,7 @@ static int sceKernelVolatileMemTryLock(int type, u32 paddr, u32 psize) {
 		break;
 	}
 
-	return hleLogSuccessOrError(Log::HLE, error);
+	return hleLogDebugOrError(Log::HLE, error);
 }
 
 int KernelVolatileMemUnlock(int type) {
@@ -373,7 +373,7 @@ static int sceKernelVolatileMemUnlock(int type) {
 		return error;
 	}
 
-	return hleLogSuccessI(Log::HLE, 0);
+	return hleLogDebug(Log::HLE, 0);
 }
 
 static int sceKernelVolatileMemLock(int type, u32 paddr, u32 psize) {
@@ -483,7 +483,7 @@ static u32 scePowerSetCpuClockFrequency(u32 cpufreq) {
 		return hleLogDebug(Log::sceMisc, 0, "locked by user config at %i", GetLockedCPUSpeedMhz());
 	}
 	CoreTiming::SetClockFrequencyHz(PowerCpuMhzToHz(cpufreq, pllFreq));
-	return hleLogSuccessI(Log::sceMisc, 0);
+	return hleLogDebug(Log::sceMisc, 0);
 }
 
 static u32 scePowerSetBusClockFrequency(u32 busfreq) {
@@ -508,20 +508,20 @@ static u32 scePowerSetBusClockFrequency(u32 busfreq) {
 	else
 		busFreq = pllFreq / 2;
 
-	return hleLogSuccessI(Log::sceMisc, 0);
+	return hleLogDebug(Log::sceMisc, 0);
 }
 
 static u32 scePowerGetCpuClockFrequencyInt() {
 	int cpuFreq = CoreTiming::GetClockFrequencyHz() / 1000000;
-	return hleLogSuccessI(Log::sceMisc, cpuFreq);
+	return hleLogDebug(Log::sceMisc, cpuFreq);
 }
 
 static u32 scePowerGetPllClockFrequencyInt() {
-	return hleLogSuccessInfoI(Log::sceMisc, pllFreq / 1000000);
+	return hleLogInfo(Log::sceMisc, pllFreq / 1000000);
 }
 
 static u32 scePowerGetBusClockFrequencyInt() {
-	return hleLogSuccessInfoI(Log::sceMisc, busFreq / 1000000);
+	return hleLogInfo(Log::sceMisc, busFreq / 1000000);
 }
 
 static float scePowerGetCpuClockFrequencyFloat() {

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -793,7 +793,7 @@ static u32 scePsmfSetPsmf(u32 psmfStruct, u32 psmfData) {
 		delete iter->second;
 	psmfMap[data->headerOffset] = psmf;
 
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static u32 scePsmfGetNumberOfStreams(u32 psmfStruct) {
@@ -801,7 +801,7 @@ static u32 scePsmfGetNumberOfStreams(u32 psmfStruct) {
 	if (!psmf) {
 		return hleLogError(Log::ME, ERROR_PSMF_NOT_INITIALIZED, "invalid psmf");
 	}
-	return hleLogSuccessI(Log::ME, psmf->numStreams);
+	return hleLogDebug(Log::ME, psmf->numStreams);
 }
 
 static u32 scePsmfGetNumberOfSpecificStreams(u32 psmfStruct, int streamType) {
@@ -817,7 +817,7 @@ static u32 scePsmfGetNumberOfSpecificStreams(u32 psmfStruct, int streamType) {
 		}
 	}
 
-	return hleLogSuccessI(Log::ME, streamNum);
+	return hleLogDebug(Log::ME, streamNum);
 }
 
 static u32 scePsmfSpecifyStreamWithStreamType(u32 psmfStruct, u32 streamType, u32 channel) {
@@ -831,7 +831,7 @@ static u32 scePsmfSpecifyStreamWithStreamType(u32 psmfStruct, u32 streamType, u3
 		// Also, returns 0 even when no stream found.
 		return hleLogWarning(Log::ME, 0, "no stream found");
 	}
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static u32 scePsmfSpecifyStreamWithStreamTypeNumber(u32 psmfStruct, u32 streamType, u32 typeNum) {
@@ -843,7 +843,7 @@ static u32 scePsmfSpecifyStreamWithStreamTypeNumber(u32 psmfStruct, u32 streamTy
 		// Don't update stream, just bail out.
 		return hleLogWarning(Log::ME, ERROR_PSMF_INVALID_ID, "no stream found");
 	}
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static u32 scePsmfSpecifyStream(u32 psmfStruct, int streamNum) {
@@ -855,7 +855,7 @@ static u32 scePsmfSpecifyStream(u32 psmfStruct, int streamNum) {
 		psmf->setStreamNum(psmfStruct, ERROR_PSMF_NOT_INITIALIZED);
 		return hleLogWarning(Log::ME, ERROR_PSMF_INVALID_ID, "bad stream id");
 	}
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static u32 scePsmfGetVideoInfo(u32 psmfStruct, u32 videoInfoAddr) {
@@ -875,7 +875,7 @@ static u32 scePsmfGetVideoInfo(u32 psmfStruct, u32 videoInfoAddr) {
 	}
 	Memory::Write_U32(info->videoWidth_ == PsmfStream::USE_PSMF ? psmf->videoWidth : info->videoWidth_, videoInfoAddr);
 	Memory::Write_U32(info->videoHeight_ == PsmfStream::USE_PSMF ? psmf->videoHeight : info->videoHeight_, videoInfoAddr + 4);
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static u32 scePsmfGetAudioInfo(u32 psmfStruct, u32 audioInfoAddr) {
@@ -895,7 +895,7 @@ static u32 scePsmfGetAudioInfo(u32 psmfStruct, u32 audioInfoAddr) {
 	}
 	Memory::Write_U32(info->audioChannels_ == PsmfStream::USE_PSMF ? psmf->audioChannels : info->audioChannels_, audioInfoAddr);
 	Memory::Write_U32(info->audioFrequency_ == PsmfStream::USE_PSMF ? psmf->audioFrequency : info->audioFrequency_, audioInfoAddr + 4);
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static u32 scePsmfGetCurrentStreamType(u32 psmfStruct, u32 typeAddr, u32 channelAddr) {
@@ -913,7 +913,7 @@ static u32 scePsmfGetCurrentStreamType(u32 psmfStruct, u32 typeAddr, u32 channel
 		Memory::Write_U32(psmf->currentStreamType, typeAddr);
 		Memory::Write_U32(psmf->currentStreamChannel, channelAddr);
 	}
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static u32 scePsmfGetStreamSize(u32 psmfStruct, u32 sizeAddr)
@@ -1026,7 +1026,7 @@ static u32 scePsmfGetCurrentStreamNumber(u32 psmfStruct) {
 	if (psmf->currentStreamNum < 0) {
 		return hleLogError(Log::ME, psmf->currentStreamNum, "invalid stream");
 	}
-	return hleLogSuccessI(Log::ME, psmf->currentStreamNum);
+	return hleLogDebug(Log::ME, psmf->currentStreamNum);
 }
 
 static u32 scePsmfCheckEPMap(u32 psmfStruct)
@@ -1057,7 +1057,7 @@ static u32 scePsmfGetEPWithId(u32 psmfStruct, int epid, u32 entryAddr)
 		*entry = psmf->EPMap[epid];
 		entry.NotifyWrite("PsmfGetEPWithId");
 	}
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static u32 scePsmfGetEPWithTimestamp(u32 psmfStruct, u32 ts, u32 entryAddr)
@@ -1081,7 +1081,7 @@ static u32 scePsmfGetEPWithTimestamp(u32 psmfStruct, u32 ts, u32 entryAddr)
 		*entry = psmf->EPMap[epid];
 		entry.NotifyWrite("PsmfGetEPWithTimestamp");
 	}
-	return hleLogSuccessI(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static u32 scePsmfGetEPidWithTimestamp(u32 psmfStruct, u32 ts)
@@ -1154,7 +1154,7 @@ static int scePsmfPlayerCreate(u32 psmfPlayer, u32 dataPtr) {
 
 	int delayUs = 20000;
 	DelayPsmfStateChange(psmfPlayer, PSMF_PLAYER_STATUS_INIT, delayUs);
-	return hleDelayResult(hleLogSuccessInfoI(Log::ME, 0, "psmfplayer create, psmfPlayerLibVersion 0x%0x, psmfPlayerLibcrc %x", psmfPlayerLibVersion, psmfPlayerLibcrc), "player create", delayUs);
+	return hleDelayResult(hleLogInfo(Log::ME, 0, "psmfplayer create, psmfPlayerLibVersion 0x%0x, psmfPlayerLibcrc %x", psmfPlayerLibVersion, psmfPlayerLibcrc), "player create", delayUs);
 }
 
 static int scePsmfPlayerStop(u32 psmfPlayer) {
@@ -1169,7 +1169,7 @@ static int scePsmfPlayerStop(u32 psmfPlayer) {
 
 	int delayUs = 3000;
 	DelayPsmfStateChange(psmfPlayer, PSMF_PLAYER_STATUS_STANDBY, delayUs);
-	return hleDelayResult(hleLogSuccessInfoI(Log::ME, 0), "psmfplayer stop", delayUs);
+	return hleDelayResult(hleLogInfo(Log::ME, 0), "psmfplayer stop", delayUs);
 }
 
 static int scePsmfPlayerBreak(u32 psmfPlayer) {
@@ -1293,7 +1293,7 @@ static int _PsmfPlayerSetPsmfOffset(u32 psmfPlayer, const char *filename, int of
 	psmfplayer->totalDurationTimestamp = psmfplayer->mediaengine->getLastTimeStamp();
 
 	DelayPsmfStateChange(psmfPlayer, PSMF_PLAYER_STATUS_STANDBY, delayUs);
-	return hleDelayResult(hleLogSuccessInfoI(Log::ME, 0), "psmfplayer set", delayUs);
+	return hleDelayResult(hleLogInfo(Log::ME, 0), "psmfplayer set", delayUs);
 }
 
 static int scePsmfPlayerSetPsmf(u32 psmfPlayer, const char *filename) {
@@ -1627,7 +1627,7 @@ static int scePsmfPlayerGetAudioData(u32 psmfPlayer, u32 audioDataAddr)
 	}
 
 	if (psmfplayer->playMode == PSMF_PLAYER_MODE_PAUSE) {
-		return hleLogSuccessInfoI(Log::HLE, ERROR_PSMFPLAYER_NO_MORE_DATA, "paused mode");
+		return hleLogInfo(Log::HLE, ERROR_PSMFPLAYER_NO_MORE_DATA, "paused mode");
 	}
 
 	int ret = 0;
@@ -1772,7 +1772,7 @@ static u32 scePsmfPlayerGetCurrentAudioStream(u32 psmfPlayer, u32 audioCodecAddr
 	if (Memory::IsValidAddress(audioStreamNumAddr)) {
 		Memory::Write_U32(psmfplayer->audioStreamNum, audioStreamNumAddr);
 	}
-	return hleLogSuccessInfoI(Log::ME, 0);
+	return hleLogInfo(Log::ME, 0);
 }
 
 static int scePsmfPlayerSetTempBuf(u32 psmfPlayer, u32 tempBufAddr, u32 tempBufSize)
@@ -1791,7 +1791,7 @@ static int scePsmfPlayerSetTempBuf(u32 psmfPlayer, u32 tempBufAddr, u32 tempBufS
 	// fake it right now, use tempbuf from memory directly
 	//psmfplayer->tempbuf = tempBufAddr;
 	//psmfplayer->tempbufSize = tempBufSize;
-	return hleLogSuccessInfoI(Log::ME, 0);
+	return hleLogInfo(Log::ME, 0);
 }
 
 static u32 scePsmfPlayerChangePlayMode(u32 psmfPlayer, int playMode, int playSpeed)

--- a/Core/HLE/scePspNpDrm_user.cpp
+++ b/Core/HLE/scePspNpDrm_user.cpp
@@ -30,12 +30,12 @@ static int sceNpDrmEdataSetupKey(u32 edataFd) {
 	// call PGD open
 	// Note that usec accumulates.
 	retval = __IoIoctl(edataFd, 0x04100001, 0, 0, 0, 0, usec);
-	return hleDelayResult(hleLogSuccessOrError(Log::sceIo, retval), "io ctrl command", usec);
+	return hleDelayResult(hleLogDebugOrError(Log::sceIo, retval), "io ctrl command", usec);
 }
 
 static int sceNpDrmEdataGetDataSize(u32 edataFd) {
 	int retval = hleCall(IoFileMgrForKernel, u32, sceIoIoctl, edataFd, 0x04100010, 0, 0, 0, 0);
-	return hleLogSuccessInfoI(Log::sceIo, retval);
+	return hleLogInfo(Log::sceIo, retval);
 }
 
 static int sceNpDrmOpen() {

--- a/Core/HLE/sceRtc.cpp
+++ b/Core/HLE/sceRtc.cpp
@@ -317,7 +317,7 @@ static u32 sceRtcGetCurrentClock(u32 pspTimePtr, int tz) {
 
 	hleEatCycles(1900);
 	hleReSchedule("rtc current clock");
-	return hleLogSuccessI(Log::sceRtc, 0);
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static u32 sceRtcGetCurrentClockLocalTime(u32 pspTimePtr) {
@@ -339,7 +339,7 @@ static u32 sceRtcGetCurrentClockLocalTime(u32 pspTimePtr) {
 
 	hleEatCycles(2000);
 	hleReSchedule("rtc current clock local");
-	return hleLogSuccessI(Log::sceRtc, 0);
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static u32 sceRtcSetTick(u32 pspTimePtr, u32 tickPtr) {
@@ -350,7 +350,7 @@ static u32 sceRtcSetTick(u32 pspTimePtr, u32 tickPtr) {
 		return hleLogError(Log::sceRtc, 0, "bad address");
 
 	__RtcTicksToPspTime(*pt, *tick);
-	return hleLogSuccessI(Log::sceRtc, 0);
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static u32 sceRtcGetTick(u32 pspTimePtr, u32 tickPtr) {
@@ -363,7 +363,7 @@ static u32 sceRtcGetTick(u32 pspTimePtr, u32 tickPtr) {
 		return hleLogWarning(Log::sceRtc, SCE_KERNEL_ERROR_INVALID_VALUE, "invalid time");
 
 	*tick = __RtcPspTimeToTicks(*pt);
-	return hleLogSuccessI(Log::sceRtc, 0);
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static u32 sceRtcGetDayOfWeek(u32 year, u32 month, u32 day)
@@ -504,7 +504,7 @@ static int sceRtcCheckValid(u32 datePtr) {
 		result = PSP_TIME_INVALID_SECONDS;
 	else if (pt->microsecond >= 1000000UL)
 		result = PSP_TIME_INVALID_MICROSECONDS;
-	return hleLogSuccessI(Log::sceRtc, result);
+	return hleLogDebug(Log::sceRtc, result);
 }
 
 static int sceRtcSetTime_t(u32 datePtr, u32 time) {
@@ -513,7 +513,7 @@ static int sceRtcSetTime_t(u32 datePtr, u32 time) {
 		return hleLogError(Log::sceRtc, 1, "bad address");
 
 	__RtcTicksToPspTime(*pt, time * 1000000ULL + rtcMagicOffset);
-	return hleLogSuccessI(Log::sceRtc, 0);
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static int sceRtcSetTime64_t(u32 datePtr, u64 time) {
@@ -522,7 +522,7 @@ static int sceRtcSetTime64_t(u32 datePtr, u64 time) {
 		return hleLogError(Log::sceRtc, 1, "bad address");
 
 	__RtcTicksToPspTime(*pt, time * 1000000ULL + rtcMagicOffset);
-	return hleLogSuccessI(Log::sceRtc, 0);
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static int sceRtcGetTime_t(u32 datePtr, u32 timePtr) {
@@ -532,7 +532,7 @@ static int sceRtcGetTime_t(u32 datePtr, u32 timePtr) {
 		return hleLogError(Log::sceRtc, 1, "bad address");
 
 	*timep = (u32)((__RtcPspTimeToTicks(*pt) - rtcMagicOffset) / 1000000ULL);
-	return hleLogSuccessI(Log::sceRtc, 0);
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static int sceRtcGetTime64_t(u32 datePtr, u32 timePtr) {
@@ -542,7 +542,7 @@ static int sceRtcGetTime64_t(u32 datePtr, u32 timePtr) {
 		return hleLogError(Log::sceRtc, 1, "bad address");
 
 	*timep = (__RtcPspTimeToTicks(*pt) - rtcMagicOffset) / 1000000ULL;
-	return hleLogSuccessI(Log::sceRtc, 0);
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static int sceRtcSetDosTime(u32 datePtr, u32 dosTime) {
@@ -561,7 +561,7 @@ static int sceRtcSetDosTime(u32 datePtr, u32 dosTime) {
 	pt->second = (hms << 1) & 0x3E;
 	pt->microsecond = 0;
 
-	return hleLogSuccessI(Log::sceRtc, 0);
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static int sceRtcGetDosTime(u32 datePtr, u32 dosTime) {
@@ -588,7 +588,7 @@ static int sceRtcGetDosTime(u32 datePtr, u32 dosTime) {
 	int hms = hour | minute | second;
 
 	*dosp = (ymd << 16) | hms;
-	return hleLogSuccessI(Log::sceRtc, 0);
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static int sceRtcSetWin32FileTime(u32 datePtr, u64 win32Time)

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -296,7 +296,7 @@ static u32 _sceSasCore(u32 core, u32 outAddr) {
 
 	__SasEnqueueMix(outAddr);
 
-	return hleLogSuccessVerboseI(Log::sceSas, delaySasResult(0));
+	return hleLogVerbose(Log::sceSas, delaySasResult(0));
 }
 
 // Another way of running the mixer, the inoutAddr should be both input and output
@@ -315,7 +315,7 @@ static u32 _sceSasCoreWithMix(u32 core, u32 inoutAddr, int leftVolume, int right
 
 	__SasEnqueueMix(inoutAddr, inoutAddr, leftVolume, rightVolume);
 
-	return hleLogSuccessVerboseI(Log::sceSas, delaySasResult(0));
+	return hleLogVerbose(Log::sceSas, delaySasResult(0));
 }
 
 static u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loop) {
@@ -643,7 +643,7 @@ static u32 sceSasRevType(u32 core, int type) {
 
 	__SasDrain();
 	sas->SetWaveformEffectType(type);
-	return hleLogSuccessI(Log::sceSas, 0);
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 static u32 sceSasRevParam(u32 core, int delay, int feedback) {
@@ -657,7 +657,7 @@ static u32 sceSasRevParam(u32 core, int delay, int feedback) {
 	__SasDrain();
 	sas->waveformEffect.delay = delay;
 	sas->waveformEffect.feedback = feedback;
-	return hleLogSuccessI(Log::sceSas, 0);
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 static u32 sceSasRevEVOL(u32 core, u32 lv, u32 rv) {
@@ -668,14 +668,14 @@ static u32 sceSasRevEVOL(u32 core, u32 lv, u32 rv) {
 	__SasDrain();
 	sas->waveformEffect.leftVol = lv;
 	sas->waveformEffect.rightVol = rv;
-	return hleLogSuccessI(Log::sceSas, 0);
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 static u32 sceSasRevVON(u32 core, int dry, int wet) {
 	__SasDrain();
 	sas->waveformEffect.isDryOn = dry != 0;
 	sas->waveformEffect.isWetOn = wet != 0;
-	return hleLogSuccessI(Log::sceSas, 0);
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 static u32 sceSasGetGrain(u32 core) {
@@ -749,7 +749,7 @@ static u32 __sceSasSetVoiceATRAC3(u32 core, int voiceNum, u32 atrac3Context) {
 	v.atrac3.setContext(atrac3Context);
 	Memory::Write_U32(atrac3Context, core + 56 * voiceNum + 20);
 
-	return hleLogSuccessI(Log::sceSas, 0);
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 static u32 __sceSasConcatenateATRAC3(u32 core, int voiceNum, u32 atrac3DataAddr, int atrac3DataLength) {
@@ -782,7 +782,7 @@ static u32 __sceSasUnsetATRAC3(u32 core, int voiceNum) {
 	v.paused = false;
 	Memory::Write_U32(0, core + 56 * voiceNum + 20);
 
-	return hleLogSuccessI(Log::sceSas, 0);
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 void __SasGetDebugStats(char *stats, size_t bufsize) {

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -290,7 +290,7 @@ static int sceUmdActivate(u32 mode, const char *name) {
 	if (mode != 1) {
 		return hleLogError(Log::sceIo, 0, "UNTESTED");
 	}
-	return hleLogSuccessI(Log::sceIo, 0);
+	return hleLogDebug(Log::sceIo, 0);
 }
 
 static int sceUmdDeactivate(u32 mode, const char *name)
@@ -398,7 +398,7 @@ static int sceUmdWaitDriveStat(u32 stat) {
 		return hleLogDebug(Log::sceIo, 0);
 	}
 
-	return hleLogSuccessI(Log::sceIo, 0);
+	return hleLogDebug(Log::sceIo, 0);
 }
 
 static int sceUmdWaitDriveStatWithTimer(u32 stat, u32 timeout) {
@@ -422,7 +422,7 @@ static int sceUmdWaitDriveStatWithTimer(u32 stat, u32 timeout) {
 		hleReSchedule("umd stat checked");
 	}
 
-	return hleLogSuccessI(Log::sceIo, 0);
+	return hleLogDebug(Log::sceIo, 0);
 }
 
 static int sceUmdWaitDriveStatCB(u32 stat, u32 timeout) {
@@ -446,12 +446,12 @@ static int sceUmdWaitDriveStatCB(u32 stat, u32 timeout) {
 		__UmdWaitStat(timeout);
 		umdWaitingThreads.push_back(__KernelGetCurThread());
 		__KernelWaitCurThread(WAITTYPE_UMD, 1, stat, 0, true, "umd stat waited");
-		return hleLogSuccessI(Log::sceIo, 0, "waiting");
+		return hleLogDebug(Log::sceIo, 0, "waiting");
 	} else {
 		hleReSchedule("umd stat waited");
 	}
 
-	return hleLogSuccessI(Log::sceIo, 0);
+	return hleLogDebug(Log::sceIo, 0);
 }
 
 static u32 sceUmdCancelWaitDriveStat() {

--- a/Core/HLE/sceUsb.cpp
+++ b/Core/HLE/sceUsb.cpp
@@ -150,13 +150,13 @@ void __UsbDoState(PointerWrap &p) {
 static int sceUsbStart(const char* driverName, u32 argsSize, u32 argsPtr) {
 	usbStarted = true;
 	UsbUpdateState();
-	return hleLogSuccessInfoI(Log::HLE, 0);
+	return hleLogInfo(Log::HLE, 0);
 }
 
 static int sceUsbStop(const char* driverName, u32 argsSize, u32 argsPtr) {
 	usbStarted = false;
 	UsbUpdateState();
-	return hleLogSuccessInfoI(Log::HLE, 0);
+	return hleLogInfo(Log::HLE, 0);
 }
 
 static int sceUsbGetState() {
@@ -190,7 +190,7 @@ static int sceUsbWaitState(int state, u32 waitMode, u32 timeoutPtr) {
 		return hleLogError(Log::HLE, SCE_KERNEL_ERROR_EVF_ILPAT, "bad state");
 
 	if (UsbMatchState(state, waitMode)) {
-		return hleLogSuccessX(Log::HLE, UsbCurrentState());
+		return hleLogDebug(Log::HLE, UsbCurrentState());
 	}
 
 	// We'll have to wait as long as it takes.  Cleanup first, just in case.
@@ -199,7 +199,7 @@ static int sceUsbWaitState(int state, u32 waitMode, u32 timeoutPtr) {
 
 	UsbSetTimeout(PSPPointer<int>::Create(timeoutPtr));
 	__KernelWaitCurThread(WAITTYPE_USB, state, waitMode, timeoutPtr, false, "usb state waited");
-	return hleLogSuccessI(Log::HLE, 0, "waiting");
+	return hleLogDebug(Log::HLE, 0, "waiting");
 }
 
 static int sceUsbWaitStateCB(int state, u32 waitMode, u32 timeoutPtr) {

--- a/Core/HLE/sceUsbCam.cpp
+++ b/Core/HLE/sceUsbCam.cpp
@@ -119,7 +119,7 @@ static int sceUsbCamSetupMic(u32 paramAddr, u32 workareaAddr, int wasize) {
 		config->micParam = *param;
 		param.NotifyRead("UsbCamSetupMic");
 	}
-	return hleLogSuccessInfoI(Log::sceMisc, 0);
+	return hleLogInfo(Log::sceMisc, 0);
 }
 
 static int sceUsbCamStartMic() {

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -406,7 +406,7 @@ static int UtilityInitDialog(int type) {
 	accessThreadFinished = true;
 	accessThreadState = "init finished";
 	if (dialog)
-		return hleLogSuccessI(Log::sceUtility, dialog->FinishInit());
+		return hleLogDebug(Log::sceUtility, dialog->FinishInit());
 	return hleLogError(Log::sceUtility, 0, "invalid dialog type?");
 }
 
@@ -415,7 +415,7 @@ static int UtilityFinishDialog(int type) {
 	accessThreadFinished = true;
 	accessThreadState = "shutdown finished";
 	if (dialog)
-		return hleLogSuccessI(Log::sceUtility, dialog->FinishShutdown());
+		return hleLogDebug(Log::sceUtility, dialog->FinishShutdown());
 	return hleLogError(Log::sceUtility, 0, "invalid dialog type?");
 }
 
@@ -438,7 +438,7 @@ static int sceUtilitySavedataInitStart(u32 paramAddr) {
 	}
 
 	ActivateDialog(UtilityDialogType::SAVEDATA);
-	return hleLogSuccessX(Log::sceUtility, saveDialog->Init(paramAddr));
+	return hleLogDebug(Log::sceUtility, saveDialog->Init(paramAddr));
 }
 
 static int sceUtilitySavedataShutdownStart() {
@@ -448,7 +448,7 @@ static int sceUtilitySavedataShutdownStart() {
 	DeactivateDialog();
 	int ret = saveDialog->Shutdown();
 	hleEatCycles(30000);
-	return hleLogSuccessX(Log::sceUtility, ret);
+	return hleLogDebug(Log::sceUtility, ret);
 }
 
 static int sceUtilitySavedataGetStatus() {
@@ -462,9 +462,9 @@ static int sceUtilitySavedataGetStatus() {
 	CleanupDialogThreads();
 	if (oldStatus != status) {
 		oldStatus = status;
-		return hleLogSuccessI(Log::sceUtility, status);
+		return hleLogDebug(Log::sceUtility, status);
 	}
-	return hleLogSuccessVerboseI(Log::sceUtility, status);
+	return hleLogVerbose(Log::sceUtility, status);
 }
 
 static int sceUtilitySavedataUpdate(int animSpeed) {
@@ -472,7 +472,7 @@ static int sceUtilitySavedataUpdate(int animSpeed) {
 		return hleLogWarning(Log::sceUtility, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 	
-	int result = hleLogSuccessI(Log::sceUtility, saveDialog->Update(animSpeed));
+	int result = hleLogDebug(Log::sceUtility, saveDialog->Update(animSpeed));
 	if (result >= 0)
 		return hleDelayResult(result, "savedata update", 300);
 	return result;
@@ -486,13 +486,13 @@ static u32 sceUtilityLoadAvModule(u32 module) {
 	
 	if (module == 0)
 		JpegNotifyLoadStatus(1);
-	return hleDelayResult(hleLogSuccessInfoI(Log::sceUtility, 0), "utility av module loaded", 25000);
+	return hleDelayResult(hleLogInfo(Log::sceUtility, 0), "utility av module loaded", 25000);
 }
 
 static u32 sceUtilityUnloadAvModule(u32 module) {
 	if (module == 0)
 		JpegNotifyLoadStatus(-1);
-	return hleDelayResult(hleLogSuccessInfoI(Log::sceUtility, 0), "utility av module unloaded", 800);
+	return hleDelayResult(hleLogInfo(Log::sceUtility, 0), "utility av module unloaded", 800);
 }
 
 static const ModuleLoadInfo *__UtilityModuleInfo(int module) {
@@ -536,9 +536,9 @@ static u32 sceUtilityLoadModule(u32 module) {
 
 	// TODO: Each module has its own timing, technically, but this is a low-end.
 	if (module == 0x3FF)
-		return hleDelayResult(hleLogSuccessInfoI(Log::sceUtility, 0), "utility module loaded", 130);
+		return hleDelayResult(hleLogInfo(Log::sceUtility, 0), "utility module loaded", 130);
 	else
-		return hleDelayResult(hleLogSuccessInfoI(Log::sceUtility, 0), "utility module loaded", 25000);
+		return hleDelayResult(hleLogInfo(Log::sceUtility, 0), "utility module loaded", 25000);
 }
 
 static u32 sceUtilityUnloadModule(u32 module) {
@@ -560,9 +560,9 @@ static u32 sceUtilityUnloadModule(u32 module) {
 
 	// TODO: Each module has its own timing, technically, but this is a low-end.
 	if (module == 0x3FF)
-		return hleDelayResult(hleLogSuccessInfoI(Log::sceUtility, 0), "utility module unloaded", 110);
+		return hleDelayResult(hleLogInfo(Log::sceUtility, 0), "utility module unloaded", 110);
 	else
-		return hleDelayResult(hleLogSuccessInfoI(Log::sceUtility, 0), "utility module unloaded", 400);
+		return hleDelayResult(hleLogInfo(Log::sceUtility, 0), "utility module unloaded", 400);
 }
 
 static int sceUtilityMsgDialogInitStart(u32 paramAddr) {
@@ -571,7 +571,7 @@ static int sceUtilityMsgDialogInitStart(u32 paramAddr) {
 	}
 	
 	ActivateDialog(UtilityDialogType::MSG);
-	return hleLogSuccessInfoX(Log::sceUtility, msgDialog->Init(paramAddr));
+	return hleLogInfo(Log::sceUtility, msgDialog->Init(paramAddr));
 }
 
 static int sceUtilityMsgDialogShutdownStart() {
@@ -580,7 +580,7 @@ static int sceUtilityMsgDialogShutdownStart() {
 	}
 	
 	DeactivateDialog();
-	return hleLogSuccessX(Log::sceUtility, msgDialog->Shutdown());
+	return hleLogDebug(Log::sceUtility, msgDialog->Shutdown());
 }
 
 static int sceUtilityMsgDialogUpdate(int animSpeed) {
@@ -590,9 +590,9 @@ static int sceUtilityMsgDialogUpdate(int animSpeed) {
 	
 	int ret = msgDialog->Update(animSpeed);
 	if (ret >= 0)
-		return hleDelayResult(hleLogSuccessX(Log::sceUtility, ret), "msgdialog update", 800);
+		return hleDelayResult(hleLogDebug(Log::sceUtility, ret), "msgdialog update", 800);
 	else
-		return hleLogSuccessX(Log::sceUtility, ret);
+		return hleLogDebug(Log::sceUtility, ret);
 }
 
 static int sceUtilityMsgDialogGetStatus() {
@@ -604,9 +604,9 @@ static int sceUtilityMsgDialogGetStatus() {
 	CleanupDialogThreads();
 	if (oldStatus != status) {
 		oldStatus = status;
-		return hleLogSuccessI(Log::sceUtility, status);
+		return hleLogDebug(Log::sceUtility, status);
 	}
-	return hleLogSuccessVerboseI(Log::sceUtility, status);
+	return hleLogVerbose(Log::sceUtility, status);
 }
 
 static int sceUtilityMsgDialogAbort() {
@@ -614,7 +614,7 @@ static int sceUtilityMsgDialogAbort() {
 		return hleLogWarning(Log::sceUtility, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 	
-	return hleLogSuccessX(Log::sceUtility, msgDialog->Abort());
+	return hleLogDebug(Log::sceUtility, msgDialog->Abort());
 }
 
 
@@ -625,7 +625,7 @@ static int sceUtilityOskInitStart(u32 oskPtr) {
 	}
 	
 	ActivateDialog(UtilityDialogType::OSK);
-	return hleLogSuccessInfoX(Log::sceUtility, oskDialog->Init(oskPtr));
+	return hleLogInfo(Log::sceUtility, oskDialog->Init(oskPtr));
 }
 
 static int sceUtilityOskShutdownStart() {
@@ -634,7 +634,7 @@ static int sceUtilityOskShutdownStart() {
 	}
 	
 	DeactivateDialog();
-	return hleLogSuccessX(Log::sceUtility, oskDialog->Shutdown());
+	return hleLogDebug(Log::sceUtility, oskDialog->Shutdown());
 }
 
 static int sceUtilityOskUpdate(int animSpeed) {
@@ -645,7 +645,7 @@ static int sceUtilityOskUpdate(int animSpeed) {
 	// This is the vblank period, plus a little slack. Needed to fix timing bug in Ghost Recon: Predator.
 	// See issue #12044.
 	hleEatCycles(msToCycles(0.7315 + 0.1));
-	return hleLogSuccessX(Log::sceUtility, oskDialog->Update(animSpeed));
+	return hleLogDebug(Log::sceUtility, oskDialog->Update(animSpeed));
 }
 
 static int sceUtilityOskGetStatus() {
@@ -657,9 +657,9 @@ static int sceUtilityOskGetStatus() {
 	CleanupDialogThreads();
 	if (oldStatus != status) {
 		oldStatus = status;
-		return hleLogSuccessI(Log::sceUtility, status);
+		return hleLogDebug(Log::sceUtility, status);
 	}
-	return hleLogSuccessVerboseI(Log::sceUtility, status);
+	return hleLogVerbose(Log::sceUtility, status);
 }
 
 
@@ -669,7 +669,7 @@ static int sceUtilityNetconfInitStart(u32 paramsAddr) {
 	}
 	
 	ActivateDialog(UtilityDialogType::NET);
-	return hleLogSuccessInfoI(Log::sceUtility, netDialog->Init(paramsAddr));
+	return hleLogInfo(Log::sceUtility, netDialog->Init(paramsAddr));
 }
 
 static int sceUtilityNetconfShutdownStart() {
@@ -678,7 +678,7 @@ static int sceUtilityNetconfShutdownStart() {
 	}
 	
 	DeactivateDialog();
-	return hleLogSuccessI(Log::sceUtility, netDialog->Shutdown());
+	return hleLogDebug(Log::sceUtility, netDialog->Shutdown());
 }
 
 static int sceUtilityNetconfUpdate(int animSpeed) {
@@ -686,7 +686,7 @@ static int sceUtilityNetconfUpdate(int animSpeed) {
 		return hleLogWarning(Log::sceUtility, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 
-	return hleLogSuccessI(Log::sceUtility, netDialog->Update(animSpeed));
+	return hleLogDebug(Log::sceUtility, netDialog->Update(animSpeed));
 }
 
 static int sceUtilityNetconfGetStatus() {
@@ -699,9 +699,9 @@ static int sceUtilityNetconfGetStatus() {
 	CleanupDialogThreads();
 	if (oldStatus != status) {
 		oldStatus = status;
-		return hleLogSuccessI(Log::sceUtility, status);
+		return hleLogDebug(Log::sceUtility, status);
 	}
-	return hleLogSuccessVerboseI(Log::sceUtility, status);
+	return hleLogVerbose(Log::sceUtility, status);
 }
 
 /**
@@ -995,7 +995,7 @@ static int sceUtilityScreenshotGetStatus() {
 		oldStatus = status;
 		return hleLogWarning(Log::sceUtility, status);
 	}
-	return hleLogSuccessVerboseI(Log::sceUtility, status);
+	return hleLogVerbose(Log::sceUtility, status);
 }
 
 static int sceUtilityScreenshotContStart(u32 paramAddr) {
@@ -1015,7 +1015,7 @@ static int sceUtilityGamedataInstallInitStart(u32 paramsAddr) {
 	int result = gamedataInstallDialog->Init(paramsAddr);
 	if (result < 0)
 		DeactivateDialog();
-	return hleLogSuccessInfoX(Log::sceUtility, result);
+	return hleLogInfo(Log::sceUtility, result);
 }
 
 static int sceUtilityGamedataInstallShutdownStart() {
@@ -1024,7 +1024,7 @@ static int sceUtilityGamedataInstallShutdownStart() {
 	}
 	
 	DeactivateDialog();
-	return hleLogSuccessX(Log::sceUtility, gamedataInstallDialog->Shutdown());
+	return hleLogDebug(Log::sceUtility, gamedataInstallDialog->Shutdown());
 }
 
 static int sceUtilityGamedataInstallUpdate(int animSpeed) {
@@ -1032,7 +1032,7 @@ static int sceUtilityGamedataInstallUpdate(int animSpeed) {
 		return hleLogWarning(Log::sceUtility, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 	
-	return hleLogSuccessX(Log::sceUtility, gamedataInstallDialog->Update(animSpeed));
+	return hleLogDebug(Log::sceUtility, gamedataInstallDialog->Update(animSpeed));
 }
 
 static int sceUtilityGamedataInstallGetStatus() {
@@ -1044,7 +1044,7 @@ static int sceUtilityGamedataInstallGetStatus() {
 
 	int status = gamedataInstallDialog->GetStatus();
 	CleanupDialogThreads();
-	return hleLogSuccessI(Log::sceUtility, status);
+	return hleLogDebug(Log::sceUtility, status);
 }
 
 static int sceUtilityGamedataInstallAbort() {
@@ -1053,7 +1053,7 @@ static int sceUtilityGamedataInstallAbort() {
 	}
 	
 	DeactivateDialog();
-	return hleLogSuccessX(Log::sceUtility, gamedataInstallDialog->Abort());
+	return hleLogDebug(Log::sceUtility, gamedataInstallDialog->Abort());
 }
 
 //TODO: should save to config file
@@ -1181,7 +1181,7 @@ static int sceUtilityNpSigninInitStart(u32 paramsPtr) {
 	}
 
 	ActivateDialog(UtilityDialogType::NPSIGNIN);
-	return hleLogSuccessInfoI(Log::sceUtility, npSigninDialog->Init(paramsPtr));
+	return hleLogInfo(Log::sceUtility, npSigninDialog->Init(paramsPtr));
 }
 
 static int sceUtilityNpSigninShutdownStart() {
@@ -1190,7 +1190,7 @@ static int sceUtilityNpSigninShutdownStart() {
 	}
 
 	DeactivateDialog();
-	return hleLogSuccessI(Log::sceUtility, npSigninDialog->Shutdown());
+	return hleLogDebug(Log::sceUtility, npSigninDialog->Shutdown());
 }
 
 static int sceUtilityNpSigninUpdate(int animSpeed) {
@@ -1198,7 +1198,7 @@ static int sceUtilityNpSigninUpdate(int animSpeed) {
 		return hleLogWarning(Log::sceUtility, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 
-	return hleLogSuccessI(Log::sceUtility, npSigninDialog->Update(animSpeed));
+	return hleLogDebug(Log::sceUtility, npSigninDialog->Update(animSpeed));
 }
 
 static int sceUtilityNpSigninGetStatus() {
@@ -1210,9 +1210,9 @@ static int sceUtilityNpSigninGetStatus() {
 	CleanupDialogThreads();
 	if (oldStatus != status) {
 		oldStatus = status;
-		return hleLogSuccessI(Log::sceUtility, status);
+		return hleLogDebug(Log::sceUtility, status);
 	}
-	return hleLogSuccessVerboseI(Log::sceUtility, status);
+	return hleLogVerbose(Log::sceUtility, status);
 }
 
 static void sceUtilityInstallInitStart(u32 unknown)

--- a/GPU/Vulkan/DrawEngineVulkan.h
+++ b/GPU/Vulkan/DrawEngineVulkan.h
@@ -31,6 +31,7 @@
 // The format of the various uniform buffers may vary though - vertex shaders that don't skin
 // won't get any bone data, etc.
 
+#include "Common/CommonTypes.h"
 #include "Common/Data/Collections/Hashmaps.h"
 
 #include "GPU/Vulkan/VulkanUtil.h"
@@ -43,14 +44,6 @@
 #include "GPU/Common/GPUStateUtils.h"
 #include "GPU/Vulkan/StateMappingVulkan.h"
 #include "GPU/Vulkan/VulkanRenderManager.h"
-
-
-// TODO: Move to some appropriate header.
-#ifdef _MSC_VER
-#define NO_INLINE __declspec(noinline)
-#else
-#define NO_INLINE __attribute__((noinline))
-#endif
 
 struct DecVtxFormat;
 struct UVScale;


### PR DESCRIPTION
This consolidates HLE logging into fewer, more logical functions. Also, removes the distinction between *LogX and *LogI functions, the type used when logging the return value is now taken from the HLE function metadata.

The next step will be to add a 'e'/'E' (int vs u32) return type that will automatically decode and display error codes as text, but I don't want to include that here to reduce the size of this change.