### PR TITLE
HLE: Automatic error code logging

### DIFF
--- a/Common/Data/Collections/CharQueue.h
+++ b/Common/Data/Collections/CharQueue.h
@@ -55,7 +55,7 @@ public:
 		} else {
 			// Can't fit? Just allocate a new block and fill it up with the new data.
 			int bsize = (int)blockSize_;
-			if (size > bsize) {
+			if ((int)size > bsize) {
 				bsize = (int)size;
 			}
 			Block *b = new Block{};
@@ -102,7 +102,7 @@ public:
 		Block *b = head_;
 		do {
 			int remain = b->tail - b->head;
-			if (remain > peekOff) {
+			if (remain > (int)peekOff) {
 				return b->data[b->head + peekOff];
 			} else {
 				peekOff -= remain;

--- a/Common/StringUtils.cpp
+++ b/Common/StringUtils.cpp
@@ -97,7 +97,7 @@ bool containsNoCase(std::string_view haystack, std::string_view needle) {
 
 int countChar(std::string_view haystack, char needle) {
 	int count = 0;
-	for (int i = 0; i < haystack.size(); i++) {
+	for (int i = 0; i < (int)haystack.size(); i++) {
 		if (haystack[i] == needle) {
 			count++;
 		}
@@ -111,6 +111,7 @@ std::string SanitizeString(std::string_view input, StringRestriction restriction
 	}
 	// First, remove any chars not in A-Za-z0-9_-. This will effectively get rid of any Unicode char, emojis etc too.
 	std::string sanitized;
+	sanitized.reserve(input.size());
 	for (auto c : input) {
 		switch (restriction) {
 		case StringRestriction::None:
@@ -128,7 +129,7 @@ std::string SanitizeString(std::string_view input, StringRestriction restriction
 	}
 
 	if (minLength >= 0) {
-		if (sanitized.size() < minLength) {
+		if ((int)sanitized.size() < minLength) {
 			// Just reject it by returning an empty string, as we can't really
 			// conjure up new characters here.
 			return std::string();
@@ -137,7 +138,7 @@ std::string SanitizeString(std::string_view input, StringRestriction restriction
 
 	if (maxLength >= 0) {
 		// TODO: Cut at whole UTF-8 chars!
-		if (sanitized.size() > maxLength) {
+		if ((int)sanitized.size() > maxLength) {
 			sanitized.resize(maxLength);
 		}
 	}

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -1016,15 +1016,28 @@ void hleDoLogInternal(Log t, LogLevel level, u64 res, const char *file, int line
 	}
 
 	const char *fmt;
+	const char *errStr;
 	switch (retmask) {
 	case 'x':
 		// Truncate the high bits of the result (from any sign extension.)
 		res = (u32)res;
-		fmt = "%s%08llx=%s(%s)%s";
+		if ((int)res < 0 && (errStr = KernelErrorToString((u32)res))) {
+			// It's a known syscall error code, let's display it as string.
+			res = (u64)(uintptr_t)errStr;
+			fmt = "%sSCE_KERNEL_ERROR_%s=%s(%s)%s";
+		} else {
+			fmt = "%s%08llx=%s(%s)%s";
+		}
 		break;
 	case 'i':
 	case 'I':
-		fmt = "%s%lld=%s(%s)%s";
+		if ((int)res < 0 && (errStr = KernelErrorToString((u32)res))) {
+			// It's a known syscall error code, let's display it as string.
+			res = (u64)(uintptr_t)errStr;
+			fmt = "%sSCE_KERNEL_ERROR_%s=%s(%s)%s";
+		} else {
+			fmt = "%s%lld=%s(%s)%s";
+		}
 		break;
 	case 'f':
 		// TODO: For now, floats are just shown as bits.

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -1016,14 +1016,13 @@ void hleDoLogInternal(Log t, LogLevel level, u64 res, const char *file, int line
 	}
 
 	const char *fmt;
-	const char *errStr;
+	const char *errStr = nullptr;
 	switch (retmask) {
 	case 'x':
 		// Truncate the high bits of the result (from any sign extension.)
 		res = (u32)res;
 		if ((int)res < 0 && (errStr = KernelErrorToString((u32)res))) {
 			// It's a known syscall error code, let's display it as string.
-			res = (u64)(uintptr_t)errStr;
 			fmt = "%sSCE_KERNEL_ERROR_%s=%s(%s)%s";
 		} else {
 			fmt = "%s%08llx=%s(%s)%s";
@@ -1033,7 +1032,6 @@ void hleDoLogInternal(Log t, LogLevel level, u64 res, const char *file, int line
 	case 'I':
 		if ((int)res < 0 && (errStr = KernelErrorToString((u32)res))) {
 			// It's a known syscall error code, let's display it as string.
-			res = (u64)(uintptr_t)errStr;
 			fmt = "%sSCE_KERNEL_ERROR_%s=%s(%s)%s";
 		} else {
 			fmt = "%s%lld=%s(%s)%s";
@@ -1055,7 +1053,11 @@ void hleDoLogInternal(Log t, LogLevel level, u64 res, const char *file, int line
 
 	const char *kernelFlag = (funcFlags & HLE_KERNEL_SYSCALL) ? "K " : "";
 	if (retmask != 'v') {
-		GenericLog(level, t, file, line, fmt, kernelFlag, res, funcName, formatted_args, formatted_reason);
+		if (errStr) {
+			GenericLog(level, t, file, line, fmt, kernelFlag, errStr, funcName, formatted_args, formatted_reason);
+		} else {
+			GenericLog(level, t, file, line, fmt, kernelFlag, res, funcName, formatted_args, formatted_reason);
+		}
 	} else {
 		// Skipping the res argument for this format string.
 		GenericLog(level, t, file, line, fmt, kernelFlag, funcName, formatted_args, formatted_reason);

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -844,7 +844,7 @@ void __DisplaySetFramebuf(u32 topaddr, int linesize, int pixelFormat, int sync) 
 }
 
 // Some games (GTA) never call this during gameplay, so bad place to put a framerate counter.
-u32 sceDisplaySetFramebuf(u32 topaddr, int linesize, int pixelformat, int sync) {
+int sceDisplaySetFramebuf(u32 topaddr, int linesize, int pixelformat, int sync) {
 	if (sync != PSP_DISPLAY_SETBUF_IMMEDIATE && sync != PSP_DISPLAY_SETBUF_NEXTFRAME) {
 		return hleLogError(Log::sceDisplay, SCE_KERNEL_ERROR_INVALID_MODE, "invalid sync mode");
 	}
@@ -949,12 +949,12 @@ static void __DisplayWaitForVblanksCB(const char *reason, int vblanks) {
 	__DisplayWaitForVblanks(reason, vblanks, true);
 }
 
-static u32 sceDisplayWaitVblankStart() {
+static int sceDisplayWaitVblankStart() {
 	__DisplayWaitForVblanks("vblank start waited", 1);
 	return hleLogDebug(Log::sceDisplay, 0);
 }
 
-static u32 sceDisplayWaitVblank() {
+static int sceDisplayWaitVblank() {
 	if (!DisplayIsVblank()) {
 		__DisplayWaitForVblanks("vblank waited", 1);
 		return hleLogDebug(Log::sceDisplay, 0);
@@ -965,7 +965,7 @@ static u32 sceDisplayWaitVblank() {
 	}
 }
 
-static u32 sceDisplayWaitVblankStartMulti(int vblanks) {
+static int sceDisplayWaitVblankStartMulti(int vblanks) {
 	if (vblanks <= 0) {
 		return hleLogWarning(Log::sceDisplay, SCE_KERNEL_ERROR_INVALID_VALUE, "invalid number of vblanks");
 	}
@@ -978,7 +978,7 @@ static u32 sceDisplayWaitVblankStartMulti(int vblanks) {
 	return hleLogDebug(Log::sceDisplay, 0);
 }
 
-static u32 sceDisplayWaitVblankCB() {
+static int sceDisplayWaitVblankCB() {
 	if (!DisplayIsVblank()) {
 		__DisplayWaitForVblanksCB("vblank waited", 1);
 		return hleLogDebug(Log::sceDisplay, 0);
@@ -989,12 +989,12 @@ static u32 sceDisplayWaitVblankCB() {
 	}
 }
 
-static u32 sceDisplayWaitVblankStartCB() {
+static int sceDisplayWaitVblankStartCB() {
 	__DisplayWaitForVblanksCB("vblank start waited", 1);
 	return hleLogDebug(Log::sceDisplay, 0);
 }
 
-static u32 sceDisplayWaitVblankStartMultiCB(int vblanks) {
+static int sceDisplayWaitVblankStartMultiCB(int vblanks) {
 	if (vblanks <= 0) {
 		return hleLogWarning(Log::sceDisplay, SCE_KERNEL_ERROR_INVALID_VALUE, "invalid number of vblanks");
 	}
@@ -1007,13 +1007,13 @@ static u32 sceDisplayWaitVblankStartMultiCB(int vblanks) {
 	return hleLogDebug(Log::sceDisplay, 0);
 }
 
-static u32 sceDisplayGetVcount() {
+static int sceDisplayGetVcount() {
 	hleEatCycles(150);
 	hleReSchedule("get vcount");
 	return hleLogVerbose(Log::sceDisplay, __DisplayGetVCount());
 }
 
-static u32 sceDisplayGetCurrentHcount() {
+static int sceDisplayGetCurrentHcount() {
 	hleEatCycles(275);
 	return hleLogDebug(Log::sceDisplay, __DisplayGetCurrentHcount());
 }
@@ -1104,19 +1104,19 @@ static u32 sceDisplaySetHoldMode(u32 hMode) {
 
 const HLEFunction sceDisplay[] = {
 	{0X0E20F177, &WrapU_III<sceDisplaySetMode>,               "sceDisplaySetMode",                 'x', "iii" },
-	{0X289D82FE, &WrapU_UIII<sceDisplaySetFramebuf>,          "sceDisplaySetFrameBuf",             'x', "xiii"},
+	{0X289D82FE, &WrapI_UIII<sceDisplaySetFramebuf>,          "sceDisplaySetFrameBuf",             'i', "xiii"},
 	{0XEEDA2E54, &WrapU_UUUI<sceDisplayGetFramebuf>,          "sceDisplayGetFrameBuf",             'x', "pppi"},
-	{0X36CDFADE, &WrapU_V<sceDisplayWaitVblank>,              "sceDisplayWaitVblank",              'x', "",   HLE_NOT_DISPATCH_SUSPENDED },
-	{0X984C27E7, &WrapU_V<sceDisplayWaitVblankStart>,         "sceDisplayWaitVblankStart",         'x', "",   HLE_NOT_IN_INTERRUPT | HLE_NOT_DISPATCH_SUSPENDED },
-	{0X40F1469C, &WrapU_I<sceDisplayWaitVblankStartMulti>,    "sceDisplayWaitVblankStartMulti",    'x', "i"   },
-	{0X8EB9EC49, &WrapU_V<sceDisplayWaitVblankCB>,            "sceDisplayWaitVblankCB",            'x', "",   HLE_NOT_DISPATCH_SUSPENDED },
-	{0X46F186C3, &WrapU_V<sceDisplayWaitVblankStartCB>,       "sceDisplayWaitVblankStartCB",       'x', "",   HLE_NOT_IN_INTERRUPT | HLE_NOT_DISPATCH_SUSPENDED },
-	{0X77ED8B3A, &WrapU_I<sceDisplayWaitVblankStartMultiCB>,  "sceDisplayWaitVblankStartMultiCB",  'x', "i"   },
+	{0X36CDFADE, &WrapI_V<sceDisplayWaitVblank>,              "sceDisplayWaitVblank",              'i', "",   HLE_NOT_DISPATCH_SUSPENDED },
+	{0X984C27E7, &WrapI_V<sceDisplayWaitVblankStart>,         "sceDisplayWaitVblankStart",         'i', "",   HLE_NOT_IN_INTERRUPT | HLE_NOT_DISPATCH_SUSPENDED },
+	{0X40F1469C, &WrapI_I<sceDisplayWaitVblankStartMulti>,    "sceDisplayWaitVblankStartMulti",    'i', "i"   },
+	{0X8EB9EC49, &WrapI_V<sceDisplayWaitVblankCB>,            "sceDisplayWaitVblankCB",            'i', "",   HLE_NOT_DISPATCH_SUSPENDED },
+	{0X46F186C3, &WrapI_V<sceDisplayWaitVblankStartCB>,       "sceDisplayWaitVblankStartCB",       'i', "",   HLE_NOT_IN_INTERRUPT | HLE_NOT_DISPATCH_SUSPENDED },
+	{0X77ED8B3A, &WrapI_I<sceDisplayWaitVblankStartMultiCB>,  "sceDisplayWaitVblankStartMultiCB",  'i', "i"   },
 	{0XDBA6C4C4, &WrapF_V<sceDisplayGetFramePerSec>,          "sceDisplayGetFramePerSec",          'f', ""    },
-	{0X773DD3A3, &WrapU_V<sceDisplayGetCurrentHcount>,        "sceDisplayGetCurrentHcount",        'x', ""    },
+	{0X773DD3A3, &WrapI_V<sceDisplayGetCurrentHcount>,        "sceDisplayGetCurrentHcount",        'i', ""    },
 	{0X210EAB3A, &WrapI_V<sceDisplayGetAccumulatedHcount>,    "sceDisplayGetAccumulatedHcount",    'i', ""    },
 	{0XA83EF139, &WrapI_I<sceDisplayAdjustAccumulatedHcount>, "sceDisplayAdjustAccumulatedHcount", 'i', "i"   },
-	{0X9C6EAAD7, &WrapU_V<sceDisplayGetVcount>,               "sceDisplayGetVcount",               'x', ""    },
+	{0X9C6EAAD7, &WrapI_V<sceDisplayGetVcount>,               "sceDisplayGetVcount",               'i', ""    },
 	{0XDEA197D4, &WrapU_UUU<sceDisplayGetMode>,               "sceDisplayGetMode",                 'x', "ppp" },
 	{0X7ED59BC4, &WrapU_U<sceDisplaySetHoldMode>,             "sceDisplaySetHoldMode",             'x', "x"   },
 	{0XA544C486, &WrapU_U<sceDisplaySetResumeMode>,           "sceDisplaySetResumeMode",           'x', "x"   },

--- a/Core/HLE/sceHttp.cpp
+++ b/Core/HLE/sceHttp.cpp
@@ -323,7 +323,7 @@ void __HttpShutdown() {
 // id: ID of the template or connection
 int sceHttpSetResolveRetry(int id, int retryCount) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpSetResolveRetry(%d, %d)", id, retryCount);
-	if (id <= 0 || id > httpObjects.size())
+	if (id <= 0 || id > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	const auto& conn = httpObjects[id - 1LL];
@@ -385,7 +385,7 @@ static u32 sceHttpGetProxy(u32 id, u32 activateFlagPtr, u32 modePtr, u32 proxyHo
 
 static int sceHttpGetStatusCode(int requestID, u32 statusCodePtr) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpGetStatusCode(%d, %x)", requestID, statusCodePtr);
-	if (requestID <= 0 || requestID > httpObjects.size())
+	if (requestID <= 0 || requestID > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	if (!Memory::IsValidRange(statusCodePtr, 4))
@@ -406,7 +406,7 @@ static int sceHttpGetStatusCode(int requestID, u32 statusCodePtr) {
 // FIXME: sceHttpReadData seems to be blocking current thread, since hleDelayResult can make Download progressbar to moves progressively instead of instantly jump to 100%
 static int sceHttpReadData(int requestID, u32 dataPtr, u32 dataSize) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpReadData(%d, %x, %d)", requestID, dataPtr, dataSize);
-	if (requestID <= 0 || requestID > httpObjects.size())
+	if (requestID <= 0 || requestID > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	if (!Memory::IsValidRange(dataPtr, dataSize)) 
@@ -438,7 +438,7 @@ static int sceHttpSendRequest(int requestID, u32 dataPtr, u32 dataSize) {
 	if (!httpInited)
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_BEFORE_INIT, "http not initialized yet");
 
-	if (requestID <= 0 || requestID > httpObjects.size())
+	if (requestID <= 0 || requestID > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	if (dataSize > 0 && !Memory::IsValidRange(dataPtr, dataSize))
@@ -453,7 +453,7 @@ static int sceHttpSendRequest(int requestID, u32 dataPtr, u32 dataSize) {
 static int sceHttpDeleteRequest(int requestID) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpDeleteRequest(%d)", requestID);
 	std::lock_guard<std::mutex> guard(httpLock);
-	if (requestID <= 0 || requestID > httpObjects.size())
+	if (requestID <= 0 || requestID > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	if (httpObjects[requestID - 1LL]->className() != name_HTTPRequest)
@@ -466,7 +466,7 @@ static int sceHttpDeleteRequest(int requestID) {
 // id: ID of the template, connection or request 
 static int sceHttpDeleteHeader(int id, const char *name) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpDeleteHeader(%d, %s)", id, safe_string(name));
-	if (id <= 0 || id > httpObjects.size())
+	if (id <= 0 || id > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	const auto& req = (HTTPRequest*)httpObjects[id - 1LL].get();
@@ -476,7 +476,7 @@ static int sceHttpDeleteHeader(int id, const char *name) {
 static int sceHttpDeleteConnection(int connectionID) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpDisableCache(%d)", connectionID);
 	std::lock_guard<std::mutex> guard(httpLock);
-	if (connectionID <= 0 || connectionID > httpObjects.size())
+	if (connectionID <= 0 || connectionID > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	if (httpObjects[connectionID - 1LL]->className() != name_HTTPConnection)
@@ -489,7 +489,7 @@ static int sceHttpDeleteConnection(int connectionID) {
 // id: ID of the template, connection or request
 static int sceHttpSetConnectTimeOut(int id, u32 timeout) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpSetConnectTimeout(%d, %d)", id, timeout);
-	if (id <= 0 || id > httpObjects.size())
+	if (id <= 0 || id > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	auto& conn = httpObjects[id - 1LL];
@@ -500,7 +500,7 @@ static int sceHttpSetConnectTimeOut(int id, u32 timeout) {
 // id: ID of the template, connection or request
 static int sceHttpSetSendTimeOut(int id, u32 timeout) {
 	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpSetSendTimeout(%d, %d)", id, timeout);
-	if (id <= 0 || id > httpObjects.size())
+	if (id <= 0 || id > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	auto& conn = httpObjects[id - 1LL];
@@ -564,7 +564,7 @@ static int sceHttpsDisableOption(int id) {
 static int sceHttpCreateRequest(int connectionID, int method, const char *path, u64 contentLength) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpCreateRequest(%d, %d, %s, %llx)", connectionID, method, safe_string(path), contentLength);
 	std::lock_guard<std::mutex> guard(httpLock);
-	if (connectionID <= 0 || connectionID > httpObjects.size())
+	if (connectionID <= 0 || connectionID > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	if (httpObjects[connectionID - 1LL]->className() != name_HTTPConnection)
@@ -582,7 +582,7 @@ static int sceHttpCreateRequest(int connectionID, int method, const char *path, 
 static int sceHttpCreateConnection(int templateID, const char *hostString, const char *scheme, u32 port, int enableKeepalive) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpCreateConnection(%d, %s, %s, %d, %d)", templateID, safe_string(hostString), safe_string(scheme), port, enableKeepalive);
 	std::lock_guard<std::mutex> guard(httpLock);
-	if (templateID <= 0 || templateID > httpObjects.size())
+	if (templateID <= 0 || templateID > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	if (httpObjects[templateID - 1LL]->className() != name_HTTPTemplate)
@@ -608,7 +608,7 @@ static int sceHttpGetNetworkErrno(int request, u32 errNumPtr) {
 // id: ID of the template, connection or request
 static int sceHttpAddExtraHeader(int id, const char *name, const char *value, int unknown) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpAddExtraHeader(%d, %s, %s, %d)", id, safe_string(name), safe_string(value), unknown);
-	if (id <= 0 || id > httpObjects.size())
+	if (id <= 0 || id > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	const auto& req = (HTTPRequest*)httpObjects[id - 1LL].get();
@@ -617,7 +617,7 @@ static int sceHttpAddExtraHeader(int id, const char *name, const char *value, in
 
 static int sceHttpAbortRequest(int requestID) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpAbortRequest(%d)", requestID);
-	if (requestID <= 0 || requestID > httpObjects.size())
+	if (requestID <= 0 || requestID > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	const auto& req = (HTTPRequest*)httpObjects[requestID - 1LL].get();
@@ -627,7 +627,7 @@ static int sceHttpAbortRequest(int requestID) {
 static int sceHttpDeleteTemplate(int templateID) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpDeleteTemplate(%d)", templateID);
 	std::lock_guard<std::mutex> guard(httpLock);
-	if (templateID <= 0 || templateID > httpObjects.size())
+	if (templateID <= 0 || templateID > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	if (httpObjects[templateID - 1LL]->className() != name_HTTPTemplate)
@@ -645,7 +645,7 @@ static int sceHttpSetMallocFunction(u32 mallocFuncPtr, u32 freeFuncPtr, u32 real
 // id: ID of the template or connection
 static int sceHttpSetResolveTimeOut(int id, u32 timeout) {
 	ERROR_LOG(Log::sceNet, "UNIMPL sceHttpSetResolveTimeOut(%d, %d)", id, timeout);
-	if (id <= 0 || id > httpObjects.size())
+	if (id <= 0 || id > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 	
 	const auto& conn = httpObjects[id - 1LL];
@@ -731,7 +731,7 @@ static int sceHttpCreateTemplate(const char *userAgent, int httpVer, int autoPro
 static int sceHttpCreateRequestWithURL(int connectionID, int method, const char *url, u64 contentLength) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpCreateRequestWithURL(%d, %d, %s, %llx)", connectionID, method, safe_string(url), contentLength);
 	std::lock_guard<std::mutex> guard(httpLock);
-	if (connectionID <= 0 || connectionID > httpObjects.size())
+	if (connectionID <= 0 || connectionID > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	if (httpObjects[connectionID - 1LL]->className() != name_HTTPConnection)
@@ -752,7 +752,7 @@ static int sceHttpCreateRequestWithURL(int connectionID, int method, const char 
 static int sceHttpCreateConnectionWithURL(int templateID, const char *url, int enableKeepalive) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpCreateConnectionWithURL(%d, %s, %d)", templateID, safe_string(url), enableKeepalive);
 	std::lock_guard<std::mutex> guard(httpLock);
-	if (templateID <= 0 || templateID > httpObjects.size())
+	if (templateID <= 0 || templateID > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	if (httpObjects[templateID - 1LL]->className() != name_HTTPTemplate)
@@ -772,7 +772,7 @@ static int sceHttpCreateConnectionWithURL(int templateID, const char *url, int e
 // id: ID of the template or connection
 static int sceHttpSetRecvTimeOut(int id, u32 timeout) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpSetRecvTimeOut(%d, %d)", id, timeout);
-	if (id <= 0 || id > httpObjects.size())
+	if (id <= 0 || id > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	const auto& conn = httpObjects[id - 1LL];
@@ -787,7 +787,7 @@ static int sceHttpSetRecvTimeOut(int id, u32 timeout) {
 // Note: Megaman PoweredUp seems to have an invalid address stored at the headerAddrPtr location, may be the game expecting us (network library) to give them a valid header address?
 static int sceHttpGetAllHeader(int requestID, u32 headerAddrPtr, u32 headerSizePtr) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpGetAllHeader(%d, %x, %x)", requestID, headerAddrPtr, headerSizePtr);
-	if (requestID <= 0 || requestID > httpObjects.size())
+	if (requestID <= 0 || requestID > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	if (!Memory::IsValidRange(headerAddrPtr, 4))
@@ -806,7 +806,7 @@ static int sceHttpGetAllHeader(int requestID, u32 headerAddrPtr, u32 headerSizeP
 // FIXME: contentLength is SceULong64 but this contentLengthPtr argument should be a 32bit pointer instead of 64bit, right?
 static int sceHttpGetContentLength(int requestID, u32 contentLengthPtr) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpGetContentLength(%d, %x)", requestID, contentLengthPtr);
-	if (requestID <= 0 || requestID > httpObjects.size())
+	if (requestID <= 0 || requestID > (int)httpObjects.size())
 		return hleLogError(Log::sceNet, SCE_HTTP_ERROR_INVALID_ID, "invalid id");
 
 	if (!Memory::IsValidRange(contentLengthPtr, 8))


### PR DESCRIPTION
Logs syscall error codes as strings, when returned from syscalls with 'i' and 'x' types.

If there are syscalls with negative values that are meaningful, we'll introduce another type to avoid this. I don't actually know of any, though.