### PR TITLE
HLE auto log flag: Will let us entirely omit logging code from most syscalls, while still getting good logging.

### DIFF
--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -47,6 +47,8 @@ enum {
 	HLE_CLEAR_STACK_BYTES = 1 << 10,
 	// Indicates that this call operates in kernel mode.
 	HLE_KERNEL_SYSCALL = 1 << 11,
+	// Indicates that the framework performs the logging, depending on the return value.
+	HLE_AUTO_LOG = 1 << 12,
 };
 
 struct HLEFunction {
@@ -74,6 +76,7 @@ struct HLEFunction {
 	u32 flags;
 	// See HLE_CLEAR_STACK_BYTES.
 	u32 stackBytesToClear;
+	Log logCat;
 };
 
 struct HLEModule {

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -951,7 +951,7 @@ static void __DisplayWaitForVblanksCB(const char *reason, int vblanks) {
 
 static int sceDisplayWaitVblankStart() {
 	__DisplayWaitForVblanks("vblank start waited", 1);
-	return hleLogDebug(Log::sceDisplay, 0);
+	return 0;
 }
 
 static int sceDisplayWaitVblank() {
@@ -1107,7 +1107,7 @@ const HLEFunction sceDisplay[] = {
 	{0X289D82FE, &WrapI_UIII<sceDisplaySetFramebuf>,          "sceDisplaySetFrameBuf",             'i', "xiii"},
 	{0XEEDA2E54, &WrapU_UUUI<sceDisplayGetFramebuf>,          "sceDisplayGetFrameBuf",             'x', "pppi"},
 	{0X36CDFADE, &WrapI_V<sceDisplayWaitVblank>,              "sceDisplayWaitVblank",              'i', "",   HLE_NOT_DISPATCH_SUSPENDED },
-	{0X984C27E7, &WrapI_V<sceDisplayWaitVblankStart>,         "sceDisplayWaitVblankStart",         'i', "",   HLE_NOT_IN_INTERRUPT | HLE_NOT_DISPATCH_SUSPENDED },
+	{0X984C27E7, &WrapI_V<sceDisplayWaitVblankStart>,         "sceDisplayWaitVblankStart",         'i', "",   HLE_NOT_IN_INTERRUPT | HLE_NOT_DISPATCH_SUSPENDED | HLE_AUTO_LOG, 0, Log::sceDisplay },
 	{0X40F1469C, &WrapI_I<sceDisplayWaitVblankStartMulti>,    "sceDisplayWaitVblankStartMulti",    'i', "i"   },
 	{0X8EB9EC49, &WrapI_V<sceDisplayWaitVblankCB>,            "sceDisplayWaitVblankCB",            'i', "",   HLE_NOT_DISPATCH_SUSPENDED },
 	{0X46F186C3, &WrapI_V<sceDisplayWaitVblankStartCB>,       "sceDisplayWaitVblankStartCB",       'i', "",   HLE_NOT_IN_INTERRUPT | HLE_NOT_DISPATCH_SUSPENDED },

--- a/Core/MIPS/ARM/ArmCompBranch.cpp
+++ b/Core/MIPS/ARM/ArmCompBranch.cpp
@@ -690,14 +690,11 @@ void ArmJit::Comp_Syscall(MIPSOpcode op)
 #else
 	// Skip the CallSyscall where possible.
 	void *quickFunc = GetQuickSyscallFunc(op);
-	if (quickFunc)
-	{
+	if (quickFunc) {
 		gpr.SetRegImm(R0, (u32)(intptr_t)GetSyscallFuncPointer(op));
 		// Already flushed, so R1 is safe.
 		QuickCallFunction(R1, quickFunc);
-	}
-	else
-	{
+	} else {
 		gpr.SetRegImm(R0, op.encoding);
 		QuickCallFunction(R1, (void *)&CallSyscall);
 	}


### PR DESCRIPTION
Unfortunately, we do lose the file/line information if we do this. 

On the other hand, in every message like this, the HLE function name will be there, so maybe not a big deal as you can easily search for it...

Advantages are that HLE functions become smaller and cleaner, plus it's easier to change how all HLE function logging behave as the logging becomes centralized.

Not all functions will be able to make use of this, like if you want to add extra information to the logging messages beyond the parameters and return value.

So, I'm not sure how good an idea this is...