### PR TITLE
Fix compilation errors on LoongArch.

### DIFF
--- a/Common/Math/SIMDHeaders.h
+++ b/Common/Math/SIMDHeaders.h
@@ -10,6 +10,7 @@
 #include "ppsspp_config.h"
 
 #include "stdint.h"
+#include <string.h>
 
 #ifdef __clang__
 // Weird how you can't just use #pragma in a macro.
@@ -65,10 +66,6 @@ static inline uint32x4_t vcgezq_f32(float32x4_t v) {
 	return vcgeq_f32(v, vdupq_n_f32(0.0f));
 }
 
-#endif
-
-#if PPSSPP_ARCH(LOONGARCH64)
-#include "string.h"
 #endif
 
 #if PPSSPP_ARCH(SSE2)

--- a/Common/Math/SIMDHeaders.h
+++ b/Common/Math/SIMDHeaders.h
@@ -67,6 +67,10 @@ static inline uint32x4_t vcgezq_f32(float32x4_t v) {
 
 #endif
 
+#if PPSSPP_ARCH(LOONGARCH64)
+#include "string.h"
+#endif
+
 #if PPSSPP_ARCH(SSE2)
 
 #if defined __SSE4_2__

--- a/Common/Net/SocketCompat.h
+++ b/Common/Net/SocketCompat.h
@@ -118,20 +118,6 @@ inline bool connectInProgress(int errcode) { return (errcode == EAGAIN || errcod
 inline bool isDisconnected(int errcode) { return (errcode == EPIPE || errcode == ECONNRESET || errcode == ECONNABORTED || errcode == ESHUTDOWN); }
 #endif
 
-#ifndef POLL_ERR
-#define POLL_ERR 0x008 /* Error condition. */
-#endif
-#ifndef POLLERR
-#define POLLERR POLL_ERR
-#endif
-
-#ifndef POLL_PRI
-#define POLL_PRI 0x002 /* There is urgent data to read. */
-#endif
-#ifndef POLLPRI
-#define POLLPRI POLL_PRI
-#endif
-
 #ifndef SD_RECEIVE
 #define SD_RECEIVE SHUT_RD //0x00
 #endif


### PR DESCRIPTION
1. The first commit removes some redundant and unused defines.
They can cause compilation errors on LoongArch.
Removing them will troubleshoot the problem.
```
In file included from /home/katyusha/build/ppsspp/Common/File/FileDescriptor.cpp:8:
/home/katyusha/build/ppsspp/Common/Net/SocketCompat.h:122:18: error: expected identifier before numeric constant
  122 | #define POLL_ERR 0x008 /* Error condition. */
      |                  ^~~~~
/home/katyusha/build/ppsspp/Common/Net/SocketCompat.h:122:18: error: expected ‘}’ before numeric constant
In file included from /usr/include/signal.h:58,
                 from /home/katyusha/build/ppsspp/Common/CommonFuncs.h:45,
                 from /home/katyusha/build/ppsspp/Common/Log.h:21,
                 from /home/katyusha/build/ppsspp/Common/File/FileDescriptor.cpp:11:
/usr/include/bits/siginfo-consts.h:196:1: note: to match this ‘{’
  196 | {
      | ^
/home/katyusha/build/ppsspp/Common/Net/SocketCompat.h:122:18: error: expected unqualified-id before numeric constant
  122 | #define POLL_ERR 0x008 /* Error condition. */
      |                  ^~~~~
In file included from /usr/include/features.h:511,
                 from /usr/include/errno.h:25,
                 from /home/katyusha/build/ppsspp/Common/File/FileDescriptor.cpp:3:
/usr/include/signal.h:393:1: error: expected declaration before ‘}’ token
  393 | __END_DECLS
      | ^~~~~~~~~~~
```
2. The second commit fixes the "memcpy not declared" error on LoongArch.
This is just a temporary fix to using `memcpy` here.
In a real scenario, it should also include `lsxintrin.h` and `lasxintrin.h` to perform SIMD optimizations on LoongArch.
More information can be found here: https://jia.je/unofficial-loongarch-intrinsics-guide.

All changes have been tested on my LoongArch, ARM and X86 machines.