### PR TITLE
CrossSIMD: Fix more no-simd fallbacks. The depth rasterizer now works in TEST_FALLBACK mode.

### DIFF
--- a/Common/Math/CrossSIMD.h
+++ b/Common/Math/CrossSIMD.h
@@ -765,18 +765,18 @@ struct Mat4F32 {
 		mat.m[1] = src[1];
 		mat.m[2] = src[2];
 		mat.m[3] = 0.0f;
-		mat.m[0] = src[3];
-		mat.m[1] = src[4];
-		mat.m[2] = src[5];
-		mat.m[3] = 0.0f;
-		mat.m[0] = src[6];
-		mat.m[1] = src[7];
-		mat.m[2] = src[8];
-		mat.m[3] = 0.0f;
-		mat.m[0] = src[9];
-		mat.m[1] = src[10];
-		mat.m[2] = src[11];
-		mat.m[3] = 1.0f;
+		mat.m[4] = src[3];
+		mat.m[5] = src[4];
+		mat.m[6] = src[5];
+		mat.m[7] = 0.0f;
+		mat.m[8] = src[6];
+		mat.m[9] = src[7];
+		mat.m[10] = src[8];
+		mat.m[11] = 0.0f;
+		mat.m[12] = src[9];
+		mat.m[13] = src[10];
+		mat.m[14] = src[11];
+		mat.m[15] = 1.0f;
 		return mat;
 	}
 
@@ -1083,23 +1083,21 @@ struct Vec4F32 {
 		return temp;
 	}
 
-	// In-place transpose. Fast on SIMD, not ideal on not.
+	// In-place transpose.
 	static void Transpose(Vec4F32 &col0, Vec4F32 &col1, Vec4F32 &col2, Vec4F32 &col3) {
-		std::swap(col0.v[1], col1.v[0]);
-		std::swap(col0.v[2], col2.v[0]);
-		std::swap(col0.v[3], col3.v[0]);
-
-		std::swap(col1.v[0], col0.v[1]);
-		std::swap(col1.v[2], col2.v[1]);
-		std::swap(col1.v[3], col3.v[1]);
-
-		std::swap(col2.v[0], col0.v[2]);
-		std::swap(col2.v[1], col1.v[2]);
-		std::swap(col2.v[3], col3.v[2]);
-
-		std::swap(col3.v[0], col0.v[3]);
-		std::swap(col3.v[1], col1.v[3]);
-		std::swap(col3.v[2], col2.v[3]);
+		float m[16];
+		for (int i = 0; i < 4; i++) {
+			m[0 + i] = col0.v[i];
+			m[4 + i] = col1.v[i];
+			m[8 + i] = col2.v[i];
+			m[12 + i] = col3.v[i];
+		}
+		for (int i = 0; i < 4; i++) {
+			col0.v[i] = m[i * 4 + 0];
+			col1.v[i] = m[i * 4 + 1];
+			col2.v[i] = m[i * 4 + 2];
+			col3.v[i] = m[i * 4 + 3];
+		}
 	}
 
 	inline Vec4F32 AsVec3ByMatrix44(const Mat4F32 &m) {

--- a/Common/UI/Root.cpp
+++ b/Common/UI/Root.cpp
@@ -97,9 +97,6 @@ bool IsFocusMovementEnabled() {
 }
 
 void LayoutViewHierarchy(const UIContext &dc, ViewGroup *root, bool ignoreInsets) {
-	_assert_(root);
-	_assert_(&dc);
-
 	Bounds rootBounds = ignoreInsets ? dc.GetBounds() : dc.GetLayoutBounds();
 
 	MeasureSpec horiz(EXACTLY, rootBounds.w);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -40,6 +40,7 @@
 #include "Common/File/FileUtil.h"
 #include "Common/File/VFS/VFS.h"
 #include "Common/Log/LogManager.h"
+#include "Common/Math/CrossSIMD.h"
 #include "Common/OSVersion.h"
 #include "Common/System/Display.h"
 #include "Common/System/System.h"
@@ -140,6 +141,11 @@ std::string DefaultLangRegion() {
 }
 
 static int DefaultDepthRaster() {
+#ifdef CROSSSIMD_SLOW
+	// No SIMD acceleration for the depth rasterizer.
+	// Default to off.
+	return (int)DepthRasterMode::OFF;
+#endif
 
 // For 64-bit ARM and x86 with SIMD, enable depth raster.
 #if PPSSPP_ARCH(ARM64_NEON) || PPSSPP_ARCH(SSE2)

--- a/GPU/Common/DepthRaster.cpp
+++ b/GPU/Common/DepthRaster.cpp
@@ -348,6 +348,7 @@ int DepthRasterClipIndexedRectangles(int *tx, int *ty, float *tz, const float *t
 		}
 
 		// These names are wrong .. until we transpose.
+		// TODO: Maybe combine two rects here at a time. But hardly relevant for performance.
 		Vec4F32 x = Vec4F32::Load(verts[0]);
 		Vec4F32 y = Vec4F32::Load(verts[1]);
 		Vec4F32 z = Vec4F32::Zero();


### PR DESCRIPTION
Which means that the depth rasterizer should work on Loongson or RISC-V now (although slowly).

It also means that we can more confidently start using CrossSIMD where it makes sense.

Thanks @fp64 for feedback.
