### PR TITLE
Memmap additions and cleanup

### DIFF
--- a/Core/Dialog/PSPOskDialog.cpp
+++ b/Core/Dialog/PSPOskDialog.cpp
@@ -110,7 +110,7 @@ void PSPOskDialog::ConvertUCS2ToUTF8(std::string& _string, const PSPPointer<u16_
 	char stringBuffer[maxLength + 1];
 	char *string = stringBuffer;
 
-	u16_le *input = &em_address[0];
+	const u16_le *input = &em_address[0];
 	int c;
 	while ((c = *input++) != 0 && string < stringBuffer + maxLength)
 	{
@@ -141,7 +141,7 @@ void GetWideStringFromPSPPointer(std::u16string& _string, const PSPPointer<u16_l
 	char16_t stringBuffer[maxLength + 1];
 	char16_t *string = stringBuffer;
 
-	u16_le *input = &em_address[0];
+	const u16_le *input = &em_address[0];
 	int c;
 	while ((c = *input++) != 0 && string < stringBuffer + maxLength)
 		*string++ = c;

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -380,6 +380,22 @@ inline const char *GetCharPointer(const u32 address) {
 	}
 }
 
+// Remaps the host pointer (potentially 64bit) into the 32bit virtual pointer, no checks are made
+inline u32 GetAddressFromHostPointerUnchecked(const void* host_ptr) {
+	auto address = static_cast<const u8*>(host_ptr) - base;
+	return static_cast<u32>(address);
+}
+
+// Remaps the host pointer (potentially 64bit) into the 32bit virtual pointer with checks
+inline u32 GetAddressFromHostPointer(const void* host_ptr) {
+	u32 address = GetAddressFromHostPointerUnchecked(host_ptr);
+	if (!IsValidAddress(address)) {
+		// Somehow report the error?
+		return 0;
+	}
+	return address;
+}
+
 }  // namespace Memory
 
 // Avoiding a global include for NotifyMemInfo.

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -399,7 +399,16 @@ struct PSPPointer
 #endif
 	}
 
-	inline T &operator[](int i) const
+	inline const T &operator[](int i) const
+	{
+#ifdef MASKED_PSP_MEMORY
+		return *((T *)(Memory::base + (ptr & Memory::MEMVIEW32_MASK)) + i);
+#else
+		return *((const T *)(Memory::base + ptr) + i);
+#endif
+	}
+
+	inline T &operator[](int i)
 	{
 #ifdef MASKED_PSP_MEMORY
 		return *((T *)(Memory::base + (ptr & Memory::MEMVIEW32_MASK)) + i);
@@ -408,7 +417,16 @@ struct PSPPointer
 #endif
 	}
 
-	inline T *operator->() const
+	inline const T *operator->() const
+	{
+#ifdef MASKED_PSP_MEMORY
+		return (T *)(Memory::base + (ptr & Memory::MEMVIEW32_MASK));
+#else
+		return (const T *)(Memory::base + ptr);
+#endif
+	}
+
+	inline T *operator->()
 	{
 #ifdef MASKED_PSP_MEMORY
 		return (T *)(Memory::base + (ptr & Memory::MEMVIEW32_MASK));


### PR DESCRIPTION
This adds the functions I need for the `scenet_lib` branch + fixes the `PSPPointer` API inconsistency we discussed in Discord.
Maybe we can also add the `static PSPPointer<T>::FromHostPointer(const void* host_ptr)` later.