### PR TITLE
ZipFileReader: Small performance optimization when reading by filename

### DIFF
--- a/Common/File/VFS/ZipFileReader.cpp
+++ b/Common/File/VFS/ZipFileReader.cpp
@@ -58,8 +58,12 @@ uint8_t *ZipFileReader::ReadFile(const char *path, size_t *size) {
 	std::lock_guard<std::mutex> guard(lock_);
 	// Figure out the file size first.
 	struct zip_stat zstat;
-	zip_stat(zip_file_, temp_path.c_str(), ZIP_FL_NOCASE | ZIP_FL_UNCHANGED, &zstat);
-	zip_file *file = zip_fopen(zip_file_, temp_path.c_str(), ZIP_FL_NOCASE | ZIP_FL_UNCHANGED);
+	int retval = zip_stat(zip_file_, temp_path.c_str(), ZIP_FL_NOCASE | ZIP_FL_UNCHANGED, &zstat);
+	if (retval != 0) {
+		ERROR_LOG(Log::IO, "Error opening %s from ZIP", temp_path.c_str());
+		return 0;
+	}
+	zip_file *file = zip_fopen_index(zip_file_, zstat.index, ZIP_FL_NOCASE | ZIP_FL_UNCHANGED);
 	if (!file) {
 		ERROR_LOG(Log::IO, "Error opening %s from ZIP", temp_path.c_str());
 		return 0;

--- a/GPU/Common/TextureReplacer.cpp
+++ b/GPU/Common/TextureReplacer.cpp
@@ -240,6 +240,7 @@ bool TextureReplacer::LoadIni(std::string *error) {
 
 void TextureReplacer::ScanForHashNamedFiles(VFSBackend *dir, std::map<ReplacementCacheKey, std::map<int, std::string>> &filenameMap) {
 	// Scan the root of the texture folder/zip and preinitialize the hash map.
+	// TODO: Could put VFSFileReference into the map...
 	std::vector<File::FileInfo> filesInRoot;
 	dir->GetFileListing("", &filesInRoot, nullptr);
 	for (auto file : filesInRoot) {


### PR DESCRIPTION
We already compute the index using stat, don't need to look up by filename again.