### PR TITLE
Add GLES/EGL build config to build script

### DIFF
--- a/b.sh
+++ b/b.sh
@@ -84,6 +84,9 @@ do
 		--no_mmap) echo "Disable mmap"
 			CMAKE_ARGS="-DUSE_NO_MMAP=ON ${CMAKE_ARGS}"
 			;;
+   		--gles) echo "Using GLES/EGL"
+                	CMAKE_ARGS="-DUSING_GLES2=ON -DUSING_EGL=ON ${CMAKE_ARGS}"
+                	;;
 		*) MAKE_OPT="$1 ${MAKE_OPT}"
 			;;
 	esac


### PR DESCRIPTION
This is just proposed changes that I keep adding locally every time I clone the repo on a few RISC-V devices that still are waiting for the compliant open source ImgTec Vulkan drivers.