### PR TITLE
Add confirmation on exit

### DIFF
--- a/Common/Data/Text/Parsers.cpp
+++ b/Common/Data/Text/Parsers.cpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "Common/Data/Text/Parsers.h"
+#include "Common/Data/Text/I18n.h"
 #include "Common/StringUtils.h"
 
 // Not strictly a parser...
@@ -27,6 +28,19 @@ std::string NiceSizeFormat(uint64_t size) {
 	char buffer[16];
 	NiceSizeFormat(size, buffer, sizeof(buffer));
 	return std::string(buffer);
+}
+
+std::string NiceTimeFormat(int seconds) {
+	auto di = GetI18NCategory(I18NCat::DIALOG);
+	if (seconds < 60) {
+		return StringFromFormat("%d seconds", seconds);
+	} else if (seconds < 60 * 60) {
+		int minutes = seconds / 60;
+		return StringFromFormat("%d minutes", minutes);
+	} else {
+		int hours = seconds / 3600;
+		return StringFromFormat("%d hours", hours);
+	}
 }
 
 bool Version::ParseVersionString(std::string str) {

--- a/Common/Data/Text/Parsers.h
+++ b/Common/Data/Text/Parsers.h
@@ -74,3 +74,7 @@ static bool TryParse(const std::string &str, N *const output) {
 void NiceSizeFormat(uint64_t size, char *out, size_t bufSize);
 
 std::string NiceSizeFormat(uint64_t size);
+
+// seconds, or minutes, or hours.
+// Uses I18N strings.
+std::string NiceTimeFormat(int seconds);

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -300,6 +300,7 @@ static const ConfigSetting generalSettings[] = {
 	ConfigSetting("RemoteTab", &g_Config.bRemoteTab, false, CfgFlag::DEFAULT),
 	ConfigSetting("RemoteISOSharedDir", &g_Config.sRemoteISOSharedDir, "", CfgFlag::DEFAULT),
 	ConfigSetting("RemoteISOShareType", &g_Config.iRemoteISOShareType, (int)RemoteISOShareType::RECENT, CfgFlag::DEFAULT),
+	ConfigSetting("AskForExitConfirmationAfterSeconds", &g_Config.iAskForExitConfirmationAfterSeconds, 60, CfgFlag::PER_GAME),
 
 #ifdef __ANDROID__
 	ConfigSetting("ScreenRotation", &g_Config.iScreenRotation, ROTATION_AUTO_HORIZONTAL),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -137,6 +137,7 @@ public:
 	bool bMemStickInserted;
 	int iMemStickSizeGB;
 	bool bLoadPlugins;
+	int iAskForExitConfirmationAfterSeconds;
 
 	int iScreenRotation;  // The rotation angle of the PPSSPP UI. Only supported on Android and possibly other mobile platforms.
 	int iInternalScreenRotation;  // The internal screen rotation angle. Useful for vertical SHMUPs and similar.

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -42,7 +42,7 @@
 static double g_lastSaveTime = -1.0;
 
 void ResetSecondsSinceLastGameSave() {
-	g_lastSaveTime = -1.0;
+	g_lastSaveTime = time_now_d();
 }
 
 double SecondsSinceLastGameSave() {

--- a/Core/Dialog/PSPSaveDialog.cpp
+++ b/Core/Dialog/PSPSaveDialog.cpp
@@ -29,6 +29,7 @@
 #include "Core/Dialog/PSPSaveDialog.h"
 #include "Core/FileSystems/MetaFileSystem.h"
 #include "Core/Util/PPGeDraw.h"
+#include "Common/TimeUtil.h"
 #include "Core/HLE/sceCtrl.h"
 #include "Core/HLE/sceUtility.h"
 #include "Core/HLE/ErrorCodes.h"
@@ -37,6 +38,20 @@
 #include "Core/Config.h"
 #include "Core/Reporting.h"
 #include "Core/SaveState.h"
+
+static double g_lastSaveTime = -1.0;
+
+void ResetSecondsSinceLastGameSave() {
+	g_lastSaveTime = -1.0;
+}
+
+double SecondsSinceLastGameSave() {
+	if (g_lastSaveTime < 0) {
+		return -1.0;
+	} else {
+		return time_now_d() - g_lastSaveTime;
+	}
+}
 
 const static float FONT_SCALE = 0.55f;
 
@@ -85,8 +100,7 @@ PSPSaveDialog::~PSPSaveDialog() {
 	JoinIOThread();
 }
 
-int PSPSaveDialog::Init(int paramAddr)
-{
+int PSPSaveDialog::Init(int paramAddr) {
 	// Ignore if already running
 	if (GetStatus() != SCE_UTILITY_STATUS_NONE) {
 		ERROR_LOG_REPORT(Log::sceUtility, "A save request is already running, not starting a new one");
@@ -1068,6 +1082,7 @@ void PSPSaveDialog::ExecuteIOAction() {
 		result = param.Load(param.GetPspParam(), GetSelectedSaveDirName(), currentSelectedSave);
 		if (result == 0) {
 			display = DS_LOAD_DONE;
+			g_lastSaveTime = time_now_d();
 		} else {
 			display = DS_LOAD_FAILED;
 		}
@@ -1076,6 +1091,7 @@ void PSPSaveDialog::ExecuteIOAction() {
 		SaveState::NotifySaveData();
 		if (param.Save(param.GetPspParam(), GetSelectedSaveDirName()) == 0) {
 			display = DS_SAVE_DONE;
+			g_lastSaveTime = time_now_d();
 		} else {
 			display = DS_SAVE_FAILED;
 		}

--- a/Core/Dialog/PSPSaveDialog.h
+++ b/Core/Dialog/PSPSaveDialog.h
@@ -104,6 +104,8 @@ private:
 
 	std::thread *ioThread = nullptr;
 	std::mutex paramLock;
-	volatile SaveIOStatus ioThreadStatus;
+	volatile SaveIOStatus ioThreadStatus = SAVEIO_NONE;
 };
 
+void ResetSecondsSinceLastGameSave();
+double SecondsSinceLastGameSave();

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -227,6 +227,8 @@ void __UtilityInit() {
 	SavedataParam::Init();
 	currentlyLoadedModules.clear();
 	volatileUnlockEvent = CoreTiming::RegisterEvent("UtilityVolatileUnlock", UtilityVolatileUnlock);
+
+	ResetSecondsSinceLastGameSave();
 }
 
 void __UtilityDoState(PointerWrap &p) {

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -60,8 +60,10 @@
 // Slot number is visual only, -2 will display special message
 constexpr int LOAD_UNDO_SLOT = -2;
 
-namespace SaveState
-{
+namespace SaveState {
+
+double g_lastSaveTime = -1.0;
+
 	struct SaveStart
 	{
 		void DoState(PointerWrap &p);
@@ -76,13 +78,10 @@ namespace SaveState
 		SAVESTATE_SAVE_SCREENSHOT,
 	};
 
-	struct Operation
-	{
+	struct Operation {
 		// The slot number is for visual purposes only. Set to -1 for operations where we don't display a message for example.
 		Operation(OperationType t, const Path &f, int slot_, Callback cb, void *cbUserData_)
-			: type(t), filename(f), callback(cb), slot(slot_), cbUserData(cbUserData_)
-		{
-		}
+			: type(t), filename(f), callback(cb), slot(slot_), cbUserData(cbUserData_) {}
 
 		OperationType type;
 		Path filename;
@@ -1005,6 +1004,7 @@ namespace SaveState
 						}
 					}
 #endif
+					g_lastSaveTime = time_now_d();
 				} else if (result == CChunkFileReader::ERROR_BROKEN_STATE) {
 					HandleLoadFailure(false);
 					callbackMessage = std::string(i18nLoadFailure) + ": " + errorString;
@@ -1040,6 +1040,7 @@ namespace SaveState
 						}
 					}
 #endif
+					g_lastSaveTime = time_now_d();
 				} else if (result == CChunkFileReader::ERROR_BROKEN_STATE) {
 					// TODO: What else might we want to do here? This should be very unusual.
 					callbackMessage = i18nSaveFailure;
@@ -1155,11 +1156,21 @@ namespace SaveState
 		saveDataGeneration = 0;
 		lastSaveDataGeneration = 0;
 		saveStateInitialGitVersion.clear();
+
+		g_lastSaveTime = -1.0;
 	}
 
 	void Shutdown()
 	{
 		std::lock_guard<std::mutex> guard(mutex);
 		rewindStates.Clear();
+	}
+
+	double SecondsSinceLastSavestate() {
+		if (g_lastSaveTime < 0) {
+			return -1.0;
+		} else {
+			return time_now_d() - g_lastSaveTime;
+		}
 	}
 }

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -1157,7 +1157,7 @@ double g_lastSaveTime = -1.0;
 		lastSaveDataGeneration = 0;
 		saveStateInitialGitVersion.clear();
 
-		g_lastSaveTime = -1.0;
+		g_lastSaveTime = time_now_d();
 	}
 
 	void Shutdown()

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -111,4 +111,7 @@ namespace SaveState
 
 	// Cleanup by triggering a restart if needed.
 	void Cleanup();
+
+	// Returns the time since last save. -1 if N/A.
+	double SecondsSinceLastSavestate();
 };

--- a/Core/SaveState.h
+++ b/Core/SaveState.h
@@ -25,8 +25,7 @@
 #include "Common/File/Path.h"
 #include "Common/Serialize/Serializer.h"
 
-namespace SaveState
-{
+namespace SaveState {
 	enum class Status {
 		FAILURE,
 		WARNING,
@@ -114,4 +113,4 @@ namespace SaveState
 
 	// Returns the time since last save. -1 if N/A.
 	double SecondsSinceLastSavestate();
-};
+}  // namespace SaveState

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1300,6 +1300,9 @@ void GameSettingsScreen::CreateSystemSettings(UI::ViewGroup *systemSettings) {
 
 	systemSettings->Add(new ItemHeader(sy->T("General")));
 
+	PopupSliderChoice *exitConfirmation = systemSettings->Add(new PopupSliderChoice(&g_Config.iAskForExitConfirmationAfterSeconds, 0, 1200, 60, sy->T("Ask for exit confirmation after seconds"), screenManager(), "s"));
+	exitConfirmation->SetZeroLabel(sy->T("Off"));
+
 #if PPSSPP_PLATFORM(ANDROID)
 	if (System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_MOBILE) {
 		auto co = GetI18NCategory(I18NCat::CONTROLS);

--- a/UI/PauseScreen.h
+++ b/UI/PauseScreen.h
@@ -45,7 +45,7 @@ private:
 	void CreateSavestateControls(UI::LinearLayout *viewGroup, bool vertical);
 
 	UI::EventReturn OnGameSettings(UI::EventParams &e);
-	UI::EventReturn OnExitToMenu(UI::EventParams &e);
+	UI::EventReturn OnExit(UI::EventParams &e);
 	UI::EventReturn OnReportFeedback(UI::EventParams &e);
 
 	UI::EventReturn OnRewind(UI::EventParams &e);

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -37,6 +37,7 @@
 #include "Common/TimeUtil.h"
 #include "Common/StringUtils.h"
 #include "Common/Data/Text/I18n.h"
+#include "Common/Data/Text/Parsers.h"
 #include "Common/Input/InputState.h"
 #include "Common/Input/KeyCodes.h"
 #include "Common/Thread/ThreadUtil.h"
@@ -85,6 +86,8 @@
 #include "GPU/GPUCommon.h"
 #include "UI/OnScreenDisplay.h"
 #include "UI/GameSettingsScreen.h"
+#include "Core/SaveState.h"
+#include "Core/Dialog/PSPSaveDialog.h"
 
 #define MOUSEEVENTF_FROMTOUCH_NOPEN 0xFF515780 //http://msdn.microsoft.com/en-us/library/windows/desktop/ms703320(v=vs.85).aspx
 #define MOUSEEVENTF_MASK_PLUS_PENTOUCH 0xFFFFFF80
@@ -1090,12 +1093,32 @@ namespace MainWindow
 			break;
 
 		case WM_CLOSE:
+			if (GetUIState() != UISTATE_MENU && g_Config.iAskForExitConfirmationAfterSeconds > 0) {
+				const double timeSinceSaveState = SaveState::SecondsSinceLastSavestate();
+				const double timeSinceGameSave = SecondsSinceLastGameSave();
+
+				const double minTime = std::min(timeSinceSaveState, timeSinceGameSave);
+				if (minTime > g_Config.iAskForExitConfirmationAfterSeconds) {
+					auto di = GetI18NCategory(I18NCat::DIALOG);
+					auto mm = GetI18NCategory(I18NCat::MAINMENU);
+					std::string dlgMsg = ApplySafeSubstitutions(di->T("You haven't saved your progress for %1."), NiceTimeFormat((int)minTime));
+					dlgMsg += '\n';
+					dlgMsg += '\n';
+					dlgMsg += di->T("Are you sure you want to exit? All unsaved progress will be lost.");
+
+					if (IDNO == MessageBox(hWnd, ConvertUTF8ToWString(dlgMsg).c_str(), ConvertUTF8ToWString(mm->T("Exit")).c_str(), MB_YESNO | MB_ICONQUESTION)) {
+						return 0;
+					}
+				}
+			}
+
+			DestroyWindow(hWnd);
+			return 0;
+
+		case WM_DESTROY:
 			InputDevice::StopPolling();
 			MainThread_Stop();
 			WindowsRawInput::Shutdown();
-			return DefWindowProc(hWnd,message,wParam,lParam);
-
-		case WM_DESTROY:
 			KillTimer(hWnd, TIMER_CURSORUPDATE);
 			KillTimer(hWnd, TIMER_CURSORMOVEUPDATE);
 			// Main window is gone, this tells the message loop to exit.

--- a/Windows/MainWindow.h
+++ b/Windows/MainWindow.h
@@ -82,6 +82,7 @@ namespace MainWindow
 	void SetWindowSize(int zoom);
 	void RunCallbackInWndProc(void (*callback)(void *window, void *userdata), void *userdata);
 	void SetKeepScreenBright(bool keepBright);
+	bool ConfirmExit(HWND hWnd);
 }
 
 #endif

--- a/Windows/MainWindowMenu.cpp
+++ b/Windows/MainWindowMenu.cpp
@@ -443,7 +443,7 @@ namespace MainWindow {
 			PostMessage(MainWindow::GetHWND(), WM_USER_RESTART_EMUTHREAD, 0, 0);
 		} else {
 			g_Config.bRestartRequired = true;
-			PostMessage(MainWindow::GetHWND(), WM_CLOSE, 0, 0);
+			DestroyWindow(MainWindow::GetHWND());
 		}
 	}
 
@@ -755,7 +755,9 @@ namespace MainWindow {
 		case ID_OPTIONS_FRAMESKIPTYPE_PRCNT:    setFrameSkippingType(FRAMESKIPTYPE_PRCNT); break;
 
 		case ID_FILE_EXIT:
-			PostMessage(hWnd, WM_CLOSE, 0, 0);
+			if (MainWindow::ConfirmExit(hWnd)) {
+				DestroyWindow(hWnd);
+			}
 			break;
 
 		case ID_DEBUG_BREAKONLOAD:

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -537,7 +537,8 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 	switch (type) {
 	case SystemRequestType::EXIT_APP:
 		if (!NativeIsRestarting()) {
-			PostMessage(MainWindow::GetHWND(), WM_CLOSE, 0, 0);
+			// Clean exit is handled in WM_DESTROY.
+			DestroyWindow(MainWindow::GetHWND());
 		}
 		return true;
 	case SystemRequestType::RESTART_APP:
@@ -549,7 +550,7 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 			PostMessage(MainWindow::GetHWND(), MainWindow::WM_USER_RESTART_EMUTHREAD, 0, 0);
 		} else {
 			g_Config.bRestartRequired = true;
-			PostMessage(MainWindow::GetHWND(), WM_CLOSE, 0, 0);
+			DestroyWindow(MainWindow::GetHWND());
 		}
 		return true;
 	}

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -1294,6 +1294,7 @@ Vulkan Features = Vulkan features
 12HR = ‎12 ساعة
 24HR = ‎24 ساعة
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = ‎تلقائي
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -366,10 +366,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d seconds
 * PSP res = ‎* PSP حجم
 Active = نشط
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = ‎رجوع
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -468,6 +471,7 @@ Username = الأسم
 When you save, it will load on a PSP, but not an older PPSSPP = When you save, it will load on a PSP, but not an older PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = ‎نعم
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = ‎تقريب
 
 [Error]

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = 12HR
 24HR = 24HR
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Geri
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = When you save, it will load on a PSP, but not an older PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = Bəli
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = 12ч.
 24HR = 24ч.
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Назад
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = When you save, it will load on a PSP, but not an older PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = Да
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = 12HR
 24HR = 24HR
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d segons
 * PSP res = * resolució PSP
 Active = Actiu
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Enrere
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Quant guardis, la partida carregarà a una PSP, però no en versions antigues de PPSSPP.
 When you save, it will not work on outdated PSP Firmware anymore = Quant guardis, no tornarà a funcionar a un firmware de PSP antic.
 Yes = Sí
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d vteřin
 * PSP res = * PSP rozlišení
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Zpět
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Pokud uložíte, můžete hru načíst na PSP, ale ne na starší verzi PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = Ano
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Přiblížení
 
 [Error]

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = 12HOD
 24HR = 24HOD
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d sekunder
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Tilbage
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Når du gemmer vil det kunne hentes på en PSP men ikke på en ældre PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = Ja
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = 12 timer
 24HR = 24 timer
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI Dump startet.

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d Sekunden
 * PSP res = * PSP Auflösung
 Active = Aktiv
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Zurück
 Bottom Center = Mitte unten
 Bottom Left = links unten
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Wenn Sie speichern, kann es von einer PSP gelesen werden, aber nicht von einem älteren PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = Wenn Sie speichern, wird es auf veralteter PSP Firmware nicht mehr funktionieren
 Yes = Ja
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan Besonderheiten
 12HR = 12 Std
 24HR = 24 Std
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Spielstand automatisch laden
 AVI Dump started. = AVI Dump gestartet.

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Poleboko'
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = When you save, it will load on a PSP, but not an older PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = Iyo mane
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = 12jang
 24HR = 24jang
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -1302,6 +1302,7 @@ Display Color Formats = Display Color Formats
 12HR = 12HR
 24HR = 24HR
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -382,10 +382,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Back
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -484,6 +487,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = When you save, it will load on a PSP, but not an older PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = Yes
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -1287,6 +1287,7 @@ Vulkan Features = Funciones Vulkan
 12HR = 12 horas
 24HR = 24 horas
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Automático
 Auto Load Savestate = Carga automática de estados de guardado
 AVI Dump started. = Grabación iniciada.

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d segundos
 * PSP res = * resolución PSP
 Active = Activo
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Atrás
 Bottom Center = Inferior centrado
 Bottom Left = Inferior izquierda
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Cuando guardes, la partida cargará en una PSP, pero no en versiones antiguas de PPSSPP.
 When you save, it will not work on outdated PSP Firmware anymore = Cuando guardes, no volverá a funcionar en un firmware de PSP antiguo.
 Yes = Sí
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Acercar
 
 [Error]

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d segundos
 * PSP res = * PSP res
 Active = Activo
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Atrás
 Bottom Center = Abajo
 Bottom Left = Abajo Izquierda
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Cuando guardes, la partida cargará en una PSP, pero no en versiones antiguas de PPSSPP.
 When you save, it will not work on outdated PSP Firmware anymore = Cuando guardes, la partida puede no funcionar en una PSP con firmware desactualizado.
 Yes = Sí
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -1288,6 +1288,7 @@ Vulkan Features = Funciones Vulkan
 12HR = 12HR
 24HR = 24HR
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Automático
 Auto Load Savestate = Carga automática de estados de guardado
 AVI Dump started. = Grabación iniciada.

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d میلی‌ثانیه
 %d seconds = %d ثانیه
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = ‎بازگشت
 Bottom Center = پایین وسط
 Bottom Left = پایین چپ
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = When you save, it will load on a PSP, but not an older PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = ‎بله
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = ‎12 ساعت
 24HR = ‎24 ساعت
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = ‎خودکار
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d sekuntia
 * PSP res = * PSP res
 Active = Aktiivinen
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Takaisin
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Käyttäjänimi
 When you save, it will load on a PSP, but not an older PPSSPP = When you save, it will load on a PSP, but not an older PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = Kyllä
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = 12HR
 24HR = 24HR
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Automaattinen
 Auto Load Savestate = Lataa tilatallennus automaattisesti
 AVI Dump started. = AVI-tallennus aloitettu.

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -1277,6 +1277,7 @@ Vulkan Features = Fonctionnalités Vulkan
 12HR = 12h
 24HR = 24h
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Automatique
 Auto Load Savestate = Charger un état automatiquement
 AVI Dump started. = Dump AVI démarré

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d secondes
 * PSP res = × définition PSP
 Active = Actif
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Retour
 Bottom Center = En bas au centre
 Bottom Left = En bas à gauche
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Si vous sauvegardez, le chargement sera possible sur une PSP, mais pas sur une ancienne version de PPSSPP.
 When you save, it will not work on outdated PSP Firmware anymore = Si vous sauvegardez, le chargement ne sera plus possible sur une PSP avec un ancien firmware.
 Yes = Oui
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = 12 hrs
 24HR = 24 hrs
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Atrás
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Cando gardes, a partida cargará nunha PSP, pero non en versións antigas de PPSSPP.
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = Sí
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Δυνατότητες Vulkan
 12HR = 12ωρο
 24HR = 24ωρο
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = Καταγραφή AVI ξεκίνησε.

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d δευτερόλεπτα
 * PSP res = * ανάλυση PSP
 Active = ΕΝΕΡΓΟ
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = ΠΙΣΩ
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Όταν αποθηκεύετε, θα φορτώσει στο PSP, αλλά όχι σε μια παλαιότερη έκδοση του PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = ΝΑΙ
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = PM/FM
 24HR = 24HR
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = <<
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = When you save, it will load on a PSP, but not an older PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = ןכ
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = PM/FM
 24HR = 24HR
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = <<
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = When you save, it will load on a PSP, but not an older PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = ןכ
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan svojstva
 12HR = 12HR
 24HR = 24HR
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto učitaj savestate
 AVI Dump started. = AVI dump započelo

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d sekundi
 * PSP res = * PSP res
 Active = Aktivno
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Nazad
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Kada spremiš,učitat će se na PSP, ali ne na starijem PPSSPP-u
 When you save, it will not work on outdated PSP Firmware anymore = Kada spremiš, neće uopće raditi na zastarjelom PSP firmwareu
 Yes = Da
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zumiraj
 
 [Error]

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan funkciók
 12HR = 12ó
 24HR = 24ó
 App switching mode = Alkalmazásváltás módja
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Állapotmentés automatikus betöltése
 AVI Dump started. = AVI írás elindítva

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d másodpercig
 * PSP res = * PSP felbontás
 Active = Aktív
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Vissza
 Bottom Center = Alul középen
 Bottom Left = Alul bal old.
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Ha mentesz, PSP-n vissza tudod majd tölteni, de egy régebbi PPSSPP-n nem
 When you save, it will not work on outdated PSP Firmware anymore = Ha mentesz, már nem fog működni elavult PSP alapszoftveren
 Yes = Igen
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d detik
 * PSP res = * PSP res
 Active = Aktif
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Kembali
 Bottom Center = Tengah bawah
 Bottom Left = Kiri bawah
@@ -460,6 +463,7 @@ Username = Nama pengguna
 When you save, it will load on a PSP, but not an older PPSSPP = Setelah anda menyimpan, ini akan dapat dimuat di PSP, namun tidak di PPSSPP lawas
 When you save, it will not work on outdated PSP Firmware anymore = Saat anda menyimpan, itu tidak akan berfungsi lagi pada firmware PSP yang sudah lawas
 Yes = Ya
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Perbesar
 
 [Error]

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Fitur-fitur Vulkan
 12HR = 12 jam
 24HR = 24 jam
 App switching mode = Mode peralihan aplikasi
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Otomatis
 Auto Load Savestate = Muat otomatis simpanan status
 AVI Dump started. = Pembuangan AVI dimulai.

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d secondi
 * PSP res = * definizione PSP
 Active = Attiva
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Indietro
 Bottom Center = In basso al centro
 Bottom Left = In basso a sinistra
@@ -460,6 +463,7 @@ Username = Nome utente
 When you save, it will load on a PSP, but not an older PPSSPP = Salvando, sarà possibile effettuare il caricamento su una PSP, ma non su un vecchio PPSSPP.
 When you save, it will not work on outdated PSP Firmware anymore = Salvando, non sarà più possibile effettuare il caricamento su un vecchio firmware PSP.
 Yes = Sì
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -1287,6 +1287,7 @@ Vulkan Features = Funzionalità Vulkan
 12HR = 12 ore
 24HR = 24 ore
 App switching mode = Modalità di commutazione delle app
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Automatico
 Auto Load Savestate = Carica automaticam. uno stato
 AVI Dump started. = Dump AVI avviato

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkanの機能
 12HR = 12時間
 24HR = 24時間
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = 自動
 Auto Load Savestate = 自動的にセーブステートをロードする
 AVI Dump started. = AVIダンプを開始しました

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -358,10 +358,13 @@ Vertex = 頂点
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d 秒
 * PSP res = * PSP 解像度
 Active = アクティブ
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = 戻る
 Bottom Center = 下中央
 Bottom Left = 左下
@@ -460,6 +463,7 @@ Username = ユーザー名
 When you save, it will load on a PSP, but not an older PPSSPP = 保存すると、PSPではロードできますが古いPPSSPPではロードできません
 When you save, it will not work on outdated PSP Firmware anymore = 保存すると、古いPSPファームウェアでは動作しなくなります
 Yes = はい
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = 拡大
 
 [Error]

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = 12-Jam
 24HR = 24-Jam
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Otomatis
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d detik
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Bali
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Nalika nyimpen, iku bakal mbukak ing PSP,nanging ora PPSSPP lawas
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = He.eh
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Gede
 
 [Error]

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -1278,6 +1278,7 @@ Display Color Formats = 디스플레이 색상 형식
 12HR = 12시간
 24HR = 24시간
 App switching mode = 앱 전환 모드
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = 자동
 Auto Load Savestate = 상태 저장 자동 불러오기
 AVI Dump started. = AVI 덤프가 시작됨

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -358,10 +358,13 @@ Vertex = 꼭짓점
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d 초
 * PSP res = * PSP 리소스
 Active = 활성화
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = 뒤로가기
 Bottom Center = 하단 중앙
 Bottom Left = 하단 왼쪽
@@ -460,6 +463,7 @@ Username = 사용자이름
 When you save, it will load on a PSP, but not an older PPSSPP = 저장하면 PSP에 불러오지만 이전 PPSSPP에는 불러오지 않습니다.
 When you save, it will not work on outdated PSP Firmware anymore = 저장하면 오래된 PSP 펌웨어에서는 더 이상 작동하지 않습니다.
 Yes = 예
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = 확대/축소
 
 [Error]

--- a/assets/lang/ku_SO.ini
+++ b/assets/lang/ku_SO.ini
@@ -372,10 +372,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = چالاک
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = گەڕانەوە
 Bottom Center = خوارەوە ناوەڕاست
 Bottom Left = خوارەوە چەپ
@@ -474,6 +477,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = When you save, it will load on a PSP, but not an older PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = بەڵێ
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = نزیک کردنەوە
 
 [Error]

--- a/assets/lang/ku_SO.ini
+++ b/assets/lang/ku_SO.ini
@@ -1292,6 +1292,7 @@ Display Color Formats = Display Color Formats
 12HR = 12 کاتژمێری
 24HR = 24 کاتژمێری
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d ວິນາທີ
 * PSP res = * ຂະໜາດຈໍ PSP
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = ຍ້ອນກັບ
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = ເມື່ອເຈົ້າເຊບເກມ, ຈະສາມາດນຳໄປໂຫຼດເທິງເຄື່ອງ PSP ໄດ້\nແຕ່ບໍ່ແມ່ນສຳລັບ PPSSPP ທີ່ເກົ່າກວ່າ
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = ແມ່ນ
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = ຊູມ
 
 [Error]

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = 12 ຊົ່ວໂມງ
 24HR = 24 ຊົ່ວໂມງ
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = ອັດຕະໂນມັດ
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = ເລີ່ມຖ່າຍໂອນຂໍ້ມູນ AVI ແລ້ວ.

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d sekundžių
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Atgal
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = When you save, it will load on a PSP, but not an older PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = Taip
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = 12HR
 24HR = 24HR
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = 12 JAM
 24HR = 24 JAM
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Balik
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = When you save, it will load on a PSP, but not an older PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = Ya
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d seconds
 * PSP res = * PSP-resolutie
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Terug
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Als u opslaat kunt u de opgeslagen data laden op\nPSP-systemen, maar niet op oudere PPSSPP-versies.
 When you save, it will not work on outdated PSP Firmware anymore = Als u opslaat, werkt deze niet meer op verouderde PSP-firmware.
 Yes = Ja
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Vergroten
 
 [Error]

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan-functies
 12HR = 12-uursweergave
 24HR = 24-uursweergave
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI-dump gestart

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Vulkan features
 12HR = 12HR
 24HR = 24HR
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d seconds
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Tilbake
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = When you save, it will load on a PSP, but not an older PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = Ja
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d sekund
 * PSP res = * rozdz. PSP
 Active = Aktywny
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Powrót
 Bottom Center = Dolny środek
 Bottom Left = Dolne lewo
@@ -460,6 +463,7 @@ Username = Nazwa użytkownika
 When you save, it will load on a PSP, but not an older PPSSPP = Jeśli zapiszesz, PSP wczyta ten zapis gry, ale starsze PPSSPP już nie.
 When you save, it will not work on outdated PSP Firmware anymore = Jeśli zapiszesz, ten zapis nie zadziała już na starych wersjach firmware PSP.
 Yes = Tak
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Powiększ
 
 [Error]

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -1291,6 +1291,7 @@ Vulkan Features = Opcje Vulkana
 12HR = 12 godzinny
 24HR = 24 godzinny
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Automatyczny
 Auto Load Savestate = Automatyczne wczytywanie stanów zapisu
 AVI Dump started. = Rozpoczęto zrzut do AVI

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -1302,6 +1302,7 @@ Display Color Formats = Exibir Formatos das Cores
 12HR = 12 HRs
 24HR = 24 HRs
 App switching mode = Modo de troca do App
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto-carregar o state salvo
 AVI Dump started. = Dump do AVI iniciado

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -382,10 +382,13 @@ Vertex = Vértice
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d segundos
 * PSP res = * Resolução do PSP
 Active = Ativo
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Voltar
 Bottom Center = No centro do rodapé
 Bottom Left = A esquerda do rodapé
@@ -484,6 +487,7 @@ Username = Nome de usuário
 When you save, it will load on a PSP, but not an older PPSSPP = Quando você salvar ele carregará num PSP mas não num PPSSPP mais antigo
 When you save, it will not work on outdated PSP Firmware anymore = Quando você salvar ele não funcionará mais num firmware de PSP desatualizado
 Yes = Sim
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -382,10 +382,13 @@ Vertex = Vértice
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d segundos
 * PSP res = * Resolução da PSP
 Active = Ativo
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Voltar
 Bottom Center = Centro do rodapé
 Bottom Left = A esquerda do rodapé
@@ -484,6 +487,7 @@ Username = Apelido
 When you save, it will load on a PSP, but not an older PPSSPP = Quando gravares, os dados irão carregar com sucesso numa PSP, mas não num PPSSPP antigo.
 When you save, it will not work on outdated PSP Firmware anymore = Quando gravares, os dados não funcionarão mais num firmware de PSP desatualizado.
 Yes = Sim
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -1304,6 +1304,7 @@ Display Color Formats = Mostrar Formatos das Cores
 12HR = 12 HRs
 24HR = 24 HRs
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Automático
 Auto Load Savestate = Carregar automaticamente o Estado salvo
 AVI Dump started. = Dump do AVI iniciado

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -1287,6 +1287,7 @@ Vulkan Features = Vulkan features
 12HR = 12HR
 24HR = 24HR
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = AVI dump started

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -359,10 +359,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d secunde
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Înapoi
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -461,6 +464,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Când salvezi, va încărca pe un PSP, dar nu un PPSSPP mai vechi
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = Da
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -358,10 +358,13 @@ Vertex = Вершина
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d мс
 %d seconds = %d секунд
 * PSP res = * разр. PSP
 Active = Активно
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Назад
 Bottom Center = Внизу в центре
 Bottom Left = Внизу слева
@@ -460,6 +463,7 @@ Username = Имя пользователя
 When you save, it will load on a PSP, but not an older PPSSPP = Когда вы сохранитесь, оно может быть загружено на PSP, но не на старой версии PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = Когда вы сохранитесь, оно больше не будет работать на устаревших версиях прошивки PSP
 Yes = Да
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Масштаб
 
 [Error]

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Возможности Vulkan
 12HR = 12-часовой
 24HR = 24-часовой
 App switching mode = Режим переключения приложений
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Авто
 Auto Load Savestate = Автозагрузка состояния
 AVI Dump started. = Дамп AVI запущен

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -1287,6 +1287,7 @@ Vulkan Features = Vulkan-features
 12HR = 12HR
 24HR = 24HR
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Auto
 Auto Load Savestate = Ladda savestate automatiskt
 AVI Dump started. = AVI dump started

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d sekunder
 * PSP res = * PSP res
 Active = Aktiv
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Tillbaka
 Bottom Center = Underkant centrerad
 Bottom Left = Underkant vänster
@@ -461,6 +464,7 @@ Username = Användarnamn
 When you save, it will load on a PSP, but not an older PPSSPP = When you save, it will load on a PSP, but not an older PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = Ja
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zooma
 
 [Error]

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -359,10 +359,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d na segundo
 * PSP res = * PSP res
 Active = Active
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Bumalik
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -461,6 +464,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Kapag iyong na-i save, gagana ito mismo sa PSP\npero hindi sa lumang bersyon ng PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = When you save, it will not work on outdated PSP firmware anymore
 Yes = Oo
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -1289,6 +1289,7 @@ Vulkan Features = Mga Features ni Vulkan
 12HR = 12 Oras
 24HR = 24 Oras
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Awto
 Auto Load Savestate = Awtomatik na pag load sa savestate
 AVI Dump started. = Nasimula na ang AVI dump

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -368,10 +368,13 @@ Vertex = เวอร์เท็ค
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d วินาที
 * PSP res = * ขนาดจอ PSP
 Active = เปิดการทำงาน
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = ย้อนกลับ
 Bottom Center = มุมล่างกลางจอ
 Bottom Left = มุมล่างซ้ายจอ
@@ -470,6 +473,7 @@ Username = ชื่อผู้ใช้งาน
 When you save, it will load on a PSP, but not an older PPSSPP = เซฟเกมของคุณนั้น สามารถนำไปโหลดผ่านบนเครื่อง PSP ได้\nแต่นำไปใช้กับ PPSSPP ที่เวอร์ชั่นเก่ากว่าไม่ได้
 When you save, it will not work on outdated PSP Firmware anymore = เซฟเกมของคุณนั้น ไม่สามารถนำไปใช้กับเครื่อง PSP ที่ใช้เฟิร์มแวร์รุ่นเก่าได้
 Yes = ใช่
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = ขยาย
 
 [Error]

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -1324,6 +1324,7 @@ Warning = คำเตือน
 12HR = 12 ชั่วโมง
 24HR = 24 ชั่วโมง
 App switching mode = โหมดการสลับแอพ
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = อัตโนมัติ
 Auto Load Savestate = โหลดเซฟสเตทให้อัตโนมัติ
 AVI Dump started. = เริ่มการอัดบันทึกวีดีโอ

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -1287,6 +1287,7 @@ Vulkan Features = Vulkan özellikleri
 12HR = 12 saat
 24HR = 24 saat
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Otomatik
 Auto Load Savestate = Otomatik durum kaydı yükle
 AVI Dump started. = AVI kaydı başladı.

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -360,10 +360,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d saniye
 * PSP res = * PSP Çözünürlüğü
 Active = Etkin
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Geri
 Bottom Center = Orta alt
 Bottom Left = Sol alt
@@ -462,6 +465,7 @@ Username = Kullanıcı adı
 When you save, it will load on a PSP, but not an older PPSSPP = Kayıt aldığında almış olduğunuz kayıt PSP'de yüklenebilecek ama eski bir PPSSPP sürümünde yüklenemeyecek.
 When you save, it will not work on outdated PSP Firmware anymore =  Kaydettiğinde artık eski PSP yazılımı üzerinde çalışmayacaktır.
 Yes = Evet
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Yakınlaştır
 
 [Error]

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Особливості Vulkan
 12HR = 12 годин
 24HR = 24 години
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Авто
 Auto Load Savestate = Автоматичне завантаження збережень
 AVI Dump started. = Дамп AVI запущено

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -358,10 +358,13 @@ Vertex = Вертех
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d сек
 * PSP res = * дозв. PSP
 Active = Активно
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Назад
 Bottom Center = Знизу центрально
 Bottom Left = Знизу ліворуч
@@ -460,6 +463,7 @@ Username = Ім'я користувача
 When you save, it will load on a PSP, but not an older PPSSPP = Коли ви збережетесь, це може завантажуватись на PSP, але не старій версії PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = Коли ви бережетесь, це більше не буде працювати на старих версіях прошивки PSP
 Yes = Так
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Масштаб
 
 [Error]

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -1286,6 +1286,7 @@ Vulkan Features = Tính năng Vulkan
 12HR = 12H
 24HR = 24H
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = Tự động
 Auto Load Savestate = Auto load savestate
 AVI Dump started. = Đưa AVI vào bắt đầu

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -358,10 +358,13 @@ Vertex = Vertex
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d giây
 * PSP res = * PSP như thật
 Active = Hoạt động
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = Trở lại
 Bottom Center = Bottom center
 Bottom Left = Bottom left
@@ -460,6 +463,7 @@ Username = Username
 When you save, it will load on a PSP, but not an older PPSSPP = Khi bạn save, nó có thể load được trên máy PSP, nhưng lại không thể load được trên PPSSPP phiên bản cũ
 When you save, it will not work on outdated PSP Firmware anymore = Khi bạn save, nó sẽ không hoạt động trên máy PSP đã lỗi thời.
 Yes = Có
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = Zoom
 
 [Error]

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -358,10 +358,13 @@ Vertex = 顶点着色器
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d ms
 %d seconds = %d秒
 * PSP res = * PSP分辨率
 Active = 激活
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = 返回
 Bottom Center = 正下方
 Bottom Left = 左下方
@@ -460,6 +463,7 @@ Username = 用户名
 When you save, it will load on a PSP, but not an older PPSSPP = 当您保存后，它只会在PSP实机上载入，而不是旧版本的PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = 当您保存后，它无法在过时的PSP固件上运行
 Yes = 是
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = 放大
 
 [Error]

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -1279,6 +1279,7 @@ No GPU driver bugs detected = GPU驱动运行良好
 12HR = 12小时制
 24HR = 24小时制
 App switching mode = App 切换模式
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = 自动
 Auto Load Savestate = 自动载入即时存档
 AVI Dump started. = AVI转储开始

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -358,10 +358,13 @@ Vertex = 頂點
 VFPU = VFPU
 
 [Dialog]
+%d hours = %d hours
+%d minutes = %d minutes
 %d ms = %d 毫秒
 %d seconds = %d 秒
 * PSP res = * PSP 解析度
 Active = 啟用
+Are you sure you want to exit? All unsaved progress will be lost. = Are you sure you want to exit? All unsaved progress will be lost.
 Back = 返回
 Bottom Center = 正下
 Bottom Left = 左下
@@ -460,6 +463,7 @@ Username = 使用者名稱
 When you save, it will load on a PSP, but not an older PPSSPP = 在您儲存後，它將會只能在 PSP 上載入，而非舊版 PPSSPP
 When you save, it will not work on outdated PSP Firmware anymore = 在您儲存後，它將無法在已過期的 PSP 韌體上運作
 Yes = 是
+You haven't saved your progress for %1. = You haven't saved your progress for %1.
 Zoom = 縮放
 
 [Error]

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -1278,6 +1278,7 @@ Display Color Formats = 顯示器色彩格式
 12HR = 12 小時制
 24HR = 24 小時制
 App switching mode = App switching mode
+Ask for exit confirmation after seconds = Ask for exit confirmation after seconds
 Auto = 自動
 Auto Load Savestate = 自動載入存檔
 AVI Dump started. = AVI 傾印已啟動


### PR DESCRIPTION
Adds it both when exiting through the pause screen Exit button, and closing the window on Windows.

Fixes #19985 

Add a setting so you can configure how much unsaved progress you need to have for the confirmation dialog to appear.

Default is 60 seconds, can be discussed.

(This is independent from adding a future "auto-save-on-exit" feature - that one can just disable this functionality)