### PR TITLE
More ImDebugger improvements (sasaudio, ui)

### DIFF
--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -649,15 +649,17 @@ void __DisplayFlip(int cyclesLate) {
 
 	if (fbReallyDirty || noRecentFlip || postEffectRequiresFlip) {
 		// Check first though, might've just quit / been paused.
-		if (!forceNoFlip)
+		if (!forceNoFlip) {
 			nextFrame = Core_NextFrame();
+			if (!nextFrame) {
+				WARN_LOG(Log::sceDisplay, "Core_NextFrame returned false");
+			}
+		}
 		if (nextFrame) {
 			gpu->CopyDisplayToOutput(fbReallyDirty);
 			if (fbReallyDirty) {
 				DisplayFireActualFlip();
 			}
-		} else {
-			WARN_LOG(Log::sceDisplay, "Core_NextFrame returned false");
 		}
 	}
 

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -77,7 +77,11 @@ enum {
 
 // TODO - allow more than one, associating each with one Core pointer (passed in to all the functions)
 // No known games use more than one instance of Sas though.
-static SasInstance *sas = NULL;
+static SasInstance *sas;
+
+SasInstance *GetSasInstance() {
+	return sas;
+}
 
 enum SasThreadState {
 	DISABLED,
@@ -247,7 +251,7 @@ static u32 sceSasInit(u32 core, u32 grainSize, u32 maxVoices, u32 outputMode, u3
 	INFO_LOG(Log::sceSas, "sceSasInit(%08x, %i, %i, %i, %i)", core, grainSize, maxVoices, outputMode, sampleRate);
 
 	sas->SetGrainSize(grainSize);
-	// Seems like maxVoices is actually ignored for all intents and purposes.
+	// Seems like the maxVoices param is actually ignored for all intents and purposes.
 	sas->maxVoices = PSP_SAS_VOICES_MAX;
 	sas->outputMode = outputMode;
 	for (int i = 0; i < sas->maxVoices; i++) {

--- a/Core/HLE/sceSas.h
+++ b/Core/HLE/sceSas.h
@@ -24,3 +24,7 @@ void __SasShutdown();
 void __SasGetDebugStats(char *stats, size_t bufsize);
 
 void Register_sceSasCore();
+
+class SasInstance;
+
+SasInstance *GetSasInstance();

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -188,9 +188,9 @@ void VagDecoder::DoState(PointerWrap &p) {
 	Do(p, end_);
 }
 
-int SasAtrac3::setContext(u32 context) {
-	contextAddr_ = context;
-	atracID_ = AtracSasGetIDByContext(context);
+int SasAtrac3::setContext(u32 contextAddr) {
+	contextAddr_ = contextAddr;
+	atracID_ = AtracSasGetIDByContext(contextAddr);
 	if (!sampleQueue_)
 		sampleQueue_ = new BufferQueue();
 	sampleQueue_->clear();

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -140,6 +140,7 @@ public:
 	SasAtrac3() : contextAddr_(0), atracID_(-1), sampleQueue_(0), end_(false) {}
 	~SasAtrac3() { delete sampleQueue_; }
 	int setContext(u32 context);
+	int id() const { return atracID_; }
 	void getNextSamples(s16 *outbuf, int wantedSamples);
 	int addStreamData(u32 bufPtr, u32 addbytes);
 	void DoState(PointerWrap &p);

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -26,6 +26,7 @@
 #include "Common/System/OSD.h"
 #include "Common/File/VFS/VFS.h"
 #include "Common/VR/PPSSPPVR.h"
+#include "Common/Math/geom2d.h"
 #include "Common/Log.h"
 #include "Common/TimeUtil.h"
 #include "Core/Config.h"
@@ -42,6 +43,8 @@ struct Vertex {
 	float u, v;
 	uint32_t rgba;
 };
+
+extern Bounds g_imguiCentralNodeBounds;
 
 FRect GetScreenFrame(float pixelWidth, float pixelHeight) {
 	FRect rc = FRect{
@@ -66,6 +69,15 @@ FRect GetScreenFrame(float pixelWidth, float pixelHeight) {
 		rc.y += top;
 		rc.h -= (top + bottom);
 	}
+
+	if (g_Config.bShowImDebugger) {
+		// Set rectangle to match central node. Here we ignore bIgnoreScreenInsets.
+		rc.x = g_imguiCentralNodeBounds.x;
+		rc.y = g_imguiCentralNodeBounds.y;
+		rc.w = g_imguiCentralNodeBounds.w;
+		rc.h = g_imguiCentralNodeBounds.h;
+	}
+
 	return rc;
 }
 

--- a/GPU/Common/PresentationCommon.h
+++ b/GPU/Common/PresentationCommon.h
@@ -39,7 +39,6 @@ struct PostShaderUniforms {
 	float gl_HalfPixel[4];
 };
 
-// Could use UI::Bounds but don't want to depend on that here.
 struct FRect {
 	float x;
 	float y;

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1752,8 +1752,10 @@ void EmuScreen::runImDebugger() {
 			// io.AddKeyEvent(ImGuiMod_Super, e.key.super);
 
 			ImGuiID dockID = ImGui::DockSpaceOverViewport(0, ImGui::GetMainViewport(), ImGuiDockNodeFlags_PassthruCentralNode | ImGuiDockNodeFlags_NoDockingOverCentralNode);
-
 			ImGuiDockNode* node = ImGui::DockBuilderGetCentralNode(dockID);
+
+			// Not elegant! But don't know how else to pass through the bounds, without making a mess.
+			g_imguiCentralNodeBounds = Bounds(node->Pos.x, node->Pos.y, node->Size.x, node->Size.y);
 
 			if (!io.WantCaptureKeyboard) {
 				// Draw a focus rectangle to indicate inputs will be passed through.
@@ -1767,7 +1769,6 @@ void EmuScreen::runImDebugger() {
 					1.f
 				);
 			}
-
 			imDebugger_->Frame(currentDebugMIPS, gpuDebug, draw);
 
 			// Convert to drawlists.

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -95,6 +95,7 @@ using namespace std::placeholders;
 #include "UI/DebugOverlay.h"
 
 #include "ext/imgui/imgui.h"
+#include "ext/imgui/imgui_internal.h"
 #include "ext/imgui/imgui_impl_thin3d.h"
 #include "ext/imgui/imgui_impl_platform.h"
 
@@ -1750,7 +1751,22 @@ void EmuScreen::runImDebugger() {
 			io.AddKeyEvent(ImGuiMod_Alt, keyAltLeft_ || keyAltRight_);
 			// io.AddKeyEvent(ImGuiMod_Super, e.key.super);
 
-			ImGui::DockSpaceOverViewport(0, ImGui::GetMainViewport(), ImGuiDockNodeFlags_PassthruCentralNode);
+			ImGuiID dockID = ImGui::DockSpaceOverViewport(0, ImGui::GetMainViewport(), ImGuiDockNodeFlags_PassthruCentralNode | ImGuiDockNodeFlags_NoDockingOverCentralNode);
+
+			ImGuiDockNode* node = ImGui::DockBuilderGetCentralNode(dockID);
+
+			if (!io.WantCaptureKeyboard) {
+				// Draw a focus rectangle to indicate inputs will be passed through.
+				ImGui::GetBackgroundDrawList()->AddRect
+				(
+					node->Pos,
+					{ node->Pos.x + node->Size.x, node->Pos.y + node->Size.y },
+					IM_COL32(255, 255, 255, 90),
+					0.f,
+					ImDrawFlags_None,
+					1.f
+				);
+			}
 
 			imDebugger_->Frame(currentDebugMIPS, gpuDebug, draw);
 

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -141,7 +141,7 @@ void DrawSchedulerView(ImConfig &cfg) {
 
 static void DrawGPRs(ImConfig &config, ImControl &control, const MIPSDebugInterface *mipsDebug, const ImSnapshotState &prev) {
 	ImGui::SetNextWindowSize(ImVec2(320, 600), ImGuiCond_FirstUseEver);
-	if (!ImGui::Begin("MIPS GPRs", &config.gprOpen)) {
+	if (!ImGui::Begin("GPRs", &config.gprOpen)) {
 		ImGui::End();
 		return;
 	}
@@ -201,7 +201,7 @@ static void DrawGPRs(ImConfig &config, ImControl &control, const MIPSDebugInterf
 
 static void DrawFPRs(ImConfig &config, ImControl &control, const MIPSDebugInterface *mipsDebug, const ImSnapshotState &prev) {
 	ImGui::SetNextWindowSize(ImVec2(320, 600), ImGuiCond_FirstUseEver);
-	if (!ImGui::Begin("MIPS FPRs", &config.fprOpen)) {
+	if (!ImGui::Begin("FPRs", &config.fprOpen)) {
 		ImGui::End();
 		return;
 	}
@@ -253,7 +253,7 @@ static void DrawFPRs(ImConfig &config, ImControl &control, const MIPSDebugInterf
 
 static void DrawVFPU(ImConfig &config, ImControl &control, const MIPSDebugInterface *mipsDebug, const ImSnapshotState &prev) {
 	ImGui::SetNextWindowSize(ImVec2(320, 600), ImGuiCond_FirstUseEver);
-	if (!ImGui::Begin("MIPS VFPU regs", &config.vfpuOpen)) {
+	if (!ImGui::Begin("VFPU", &config.vfpuOpen)) {
 		ImGui::End();
 		return;
 	}

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -147,6 +147,7 @@ struct ImConfig {
 	bool adhocOpen;
 	bool memDumpOpen;
 	bool internalsOpen;
+	bool sasAudioOpen;
 	bool memViewOpen[4];
 
 	// HLE explorer settings
@@ -165,6 +166,8 @@ struct ImConfig {
 
 	bool displayLatched = false;
 	int requesterToken;
+
+	bool sasShowAllVoices = false;
 
 	// We use a separate ini file from the main PPSSPP config.
 	void LoadConfig(const Path &iniFile);

--- a/ext/imgui/imgui_impl_platform.cpp
+++ b/ext/imgui/imgui_impl_platform.cpp
@@ -10,6 +10,7 @@
 #include "imgui_impl_platform.h"
 
 static ImGuiMouseCursor g_cursor = ImGuiMouseCursor_Arrow;
+Bounds g_imguiCentralNodeBounds;
 
 void ImGui_ImplPlatform_KeyEvent(const KeyInput &key) {
 	ImGuiIO &io = ImGui::GetIO();

--- a/ext/imgui/imgui_impl_platform.h
+++ b/ext/imgui/imgui_impl_platform.h
@@ -3,6 +3,7 @@
 #include "ext/imgui/imgui.h"
 #include "Common/Input/KeyCodes.h"
 #include "Common/Input/InputState.h"
+#include "Common/Math/geom2d.h"
 
 class Path;
 
@@ -14,5 +15,7 @@ void ImGui_ImplPlatform_NewFrame();
 void ImGui_ImplPlatform_KeyEvent(const KeyInput &key);
 void ImGui_ImplPlatform_TouchEvent(const TouchInput &touch);
 void ImGui_ImplPlatform_AxisEvent(const AxisInput &axis);
+
+extern Bounds g_imguiCentralNodeBounds;
 
 ImGuiMouseCursor ImGui_ImplPlatform_GetCursor();


### PR DESCRIPTION
* Add SasAudio state viewer (incomplete, but useful)
* Make the display fit the central node, useful when docking stuff
* Add a focus rectangle to make it clear where keyboard input goes
* Rename MIPS register tabs to make them look nicer when tab-docked together