### PR TITLE
DPI: Simplify by removing support for non-square pixels

### DIFF
--- a/Common/Render/DrawBuffer.cpp
+++ b/Common/Render/DrawBuffer.cpp
@@ -109,14 +109,14 @@ void DrawBuffer::Rect(float x, float y, float w, float h, uint32_t color, int al
 
 void DrawBuffer::hLine(float x1, float y, float x2, uint32_t color) {
 	// Round Y to the closest full pixel, since we're making it 1-pixel-thin.
-	y -= fmodf(y, g_display.pixel_in_dps_y);
-	Rect(x1, y, x2 - x1, g_display.pixel_in_dps_y, color);
+	y -= fmodf(y, g_display.pixel_in_dps);
+	Rect(x1, y, x2 - x1, g_display.pixel_in_dps, color);
 }
 
 void DrawBuffer::vLine(float x, float y1, float y2, uint32_t color) {
 	// Round X to the closest full pixel, since we're making it 1-pixel-thin.
-	x -= fmodf(x, g_display.pixel_in_dps_x);
-	Rect(x, y1, g_display.pixel_in_dps_x, y2 - y1, color);
+	x -= fmodf(x, g_display.pixel_in_dps);
+	Rect(x, y1, g_display.pixel_in_dps, y2 - y1, color);
 }
 
 void DrawBuffer::RectVGradient(float x1, float y1, float x2, float y2, uint32_t colorTop, uint32_t colorBottom) {
@@ -129,11 +129,11 @@ void DrawBuffer::RectVGradient(float x1, float y1, float x2, float y2, uint32_t 
 }
 
 void DrawBuffer::RectOutline(float x, float y, float w, float h, uint32_t color, int align) {
-	hLine(x, y, x + w + g_display.pixel_in_dps_x, color);
-	hLine(x, y + h, x + w + g_display.pixel_in_dps_x, color);
+	hLine(x, y, x + w + g_display.pixel_in_dps, color);
+	hLine(x, y + h, x + w + g_display.pixel_in_dps, color);
 
-	vLine(x, y, y + h + g_display.pixel_in_dps_y, color);
-	vLine(x + w, y, y + h + g_display.pixel_in_dps_y, color);
+	vLine(x, y, y + h + g_display.pixel_in_dps, color);
+	vLine(x + w, y, y + h + g_display.pixel_in_dps, color);
 }
 
 void DrawBuffer::MultiVGradient(float x, float y, float w, float h, const GradientStop *stops, int numStops) {

--- a/Common/Render/Text/draw_text.cpp
+++ b/Common/Render/Text/draw_text.cpp
@@ -38,7 +38,7 @@ void TextDrawer::SetFontScale(float xscale, float yscale) {
 float TextDrawer::CalculateDPIScale() const {
 	if (ignoreGlobalDpi_)
 		return dpiScale_;
-	float scale = g_display.dpi_scale_y;
+	float scale = g_display.dpi_scale;
 	if (scale >= 1.0f) {
 		scale = 1.0f;
 	}

--- a/Common/System/Display.cpp
+++ b/Common/System/Display.cpp
@@ -58,10 +58,10 @@ void DisplayProperties::Print() {
 	printf("dp_xres/yres: %d, %d\n", dp_xres, dp_yres);
 	printf("pixel_xres/yres: %d, %d\n", pixel_xres, pixel_yres);
 
-	printf("dpi, x, y: %f, %f, %f\n", dpi, dpi_scale_x, dpi_scale_y);
-	printf("pixel_in_dps: %f, %f\n", pixel_in_dps_x, pixel_in_dps_y);
+	printf("dpi, dpi_scale: %f, %f\n", dpi, dpi_scale);
+	printf("pixel_in_dps: %f\n", pixel_in_dps);
 
-	printf("dpi_real: %f, %f\n", dpi_scale_real_x, dpi_scale_real_y);
+	printf("dpi_real: %f\n", dpi_scale_real);
 	printf("display_hz: %f\n", display_hz);
 
 	printf("rotation: %d\n", (int)rotation);
@@ -77,14 +77,15 @@ Lin::Matrix4x4 ComputeOrthoMatrix(float xres, float yres, CoordConvention coordC
 		ortho.setOrthoD3D(0.0f, xres, 0, yres, -1.0f, 1.0f);
 		break;
 	case CoordConvention::Direct3D9:
+	{
 		ortho.setOrthoD3D(0.0f, xres, yres, 0.0f, -1.0f, 1.0f);
-		Matrix4x4 translation;
 		// Account for the small window adjustment.
-		translation.setTranslation(Vec3(
-			-0.5f * g_display.dpi_scale_x / g_display.dpi_scale_real_x,
-			-0.5f * g_display.dpi_scale_y / g_display.dpi_scale_real_y, 0.0f));
+		float half_pixel = -0.5f * g_display.dpi_scale / g_display.dpi_scale_real;
+		Matrix4x4 translation;
+		translation.setTranslation(Vec3(half_pixel, half_pixel, 0.0f));
 		ortho = translation * ortho;
 		break;
+	}
 	case CoordConvention::Direct3D11:
 		ortho.setOrthoD3D(0.0f, xres, yres, 0.0f, -1.0f, 1.0f);
 		break;

--- a/Common/System/Display.h
+++ b/Common/System/Display.h
@@ -16,22 +16,21 @@ enum class DisplayRotation {
 };
 
 struct DisplayProperties {
+	// Display resolution in virtual ("display") pixels
 	int dp_xres;
 	int dp_yres;
+	// Display resolution in true pixels.
 	int pixel_xres;
 	int pixel_yres;
 
-	float dpi = 1.0f;  // will be overwritten with a value that makes sense.
-	float dpi_scale_x = 1.0f;
-	float dpi_scale_y = 1.0f;
+	float dpi = 1.0f;
+	float dpi_scale = 1.0f;
 
 	// pixel_xres/yres in dps
-	float pixel_in_dps_x = 1.0f;
-	float pixel_in_dps_y = 1.0f;
+	float pixel_in_dps = 1.0f;
 
 	// If DPI is overridden (like in small window mode), these are still the original DPI.
-	float dpi_scale_real_x = 1.0f;
-	float dpi_scale_real_y = 1.0f;
+	float dpi_scale_real = 1.0f;
 
 	float display_hz = 60.0f;
 

--- a/Common/UI/Context.cpp
+++ b/Common/UI/Context.cpp
@@ -163,13 +163,12 @@ Bounds UIContext::GetLayoutBounds() const {
 void UIContext::ActivateTopScissor() {
 	Bounds bounds;
 	if (scissorStack_.size()) {
-		float scale_x = g_display.pixel_in_dps_x;
-		float scale_y = g_display.pixel_in_dps_y;
+		const float scale = g_display.pixel_in_dps;
 		bounds = scissorStack_.back();
-		int x = floorf(scale_x * bounds.x);
-		int y = floorf(scale_y * bounds.y);
-		int w = std::max(0.0f, ceilf(scale_x * bounds.w));
-		int h = std::max(0.0f, ceilf(scale_y * bounds.h));
+		int x = floorf(scale * bounds.x);
+		int y = floorf(scale * bounds.y);
+		int w = std::max(0.0f, ceilf(scale * bounds.w));
+		int h = std::max(0.0f, ceilf(scale * bounds.h));
 		if (x < 0 || y < 0 || x + w > g_display.pixel_xres || y + h > g_display.pixel_yres) {
 			DEBUG_LOG(Log::G3D, "UI scissor out of bounds: %d,%d-%d,%d / %d,%d", x, y, w, h, g_display.pixel_xres, g_display.pixel_yres);
 			if (x < 0) { w += x; x = 0; }

--- a/Common/VR/PPSSPPVR.cpp
+++ b/Common/VR/PPSSPPVR.cpp
@@ -202,7 +202,7 @@ void SetVRAppMode(VRAppMode mode) {
 	appMode = mode;
 }
 
-void UpdateVRInput(bool haptics, float dp_xscale, float dp_yscale) {
+void UpdateVRInput(bool haptics, float dp_scale) {
 	//axis
 	if (pspKeys[(int)VIRTKEY_VR_CAMERA_ADJUST]) {
 		AxisInput axis[2] = {};
@@ -321,8 +321,8 @@ void UpdateVRInput(bool haptics, float dp_xscale, float dp_yscale) {
 		//inform engine about the status
 		TouchInput touch;
 		touch.id = mouseController;
-		touch.x = x * dp_xscale;
-		touch.y = (height - y - 1) * dp_yscale / VR_GetConfigFloat(VR_CONFIG_CANVAS_ASPECT);
+		touch.x = x * dp_scale;
+		touch.y = (height - y - 1) * dp_scale / VR_GetConfigFloat(VR_CONFIG_CANVAS_ASPECT);
 		bool pressed = IN_VRGetButtonState(mouseController) & ovrButton_Trigger;
 		if (mousePressed != pressed) {
 			if (pressed) {

--- a/Common/VR/PPSSPPVR.h
+++ b/Common/VR/PPSSPPVR.h
@@ -36,7 +36,7 @@ void SetVRCallbacks(void(*axis)(const AxisInput *axis, size_t count), bool(*key)
 
 // VR input integration
 void SetVRAppMode(VRAppMode mode);
-void UpdateVRInput(bool haptics, float dp_xscale, float dp_yscale);
+void UpdateVRInput(bool haptics, float dp_scale);
 bool UpdateVRAxis(const AxisInput *axes, size_t count);
 bool UpdateVRKeys(const KeyInput &key);
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -209,7 +209,7 @@ static u32 AtracValidateData(const AtracBase *atrac) {
 	} else if (atrac->BufferState() == ATRAC_STATUS_NO_DATA) {
 		return hleLogError(Log::ME, ATRAC_ERROR_NO_DATA, "no data");
 	} else {
-		return 0;
+		return hleNoLog(0);
 	}
 }
 
@@ -223,7 +223,7 @@ static u32 AtracValidateManaged(const AtracBase *atrac) {
 	} else if (atrac->BufferState() == ATRAC_STATUS_FOR_SCESAS) {
 		return hleLogError(Log::ME, ATRAC_ERROR_IS_FOR_SCESAS, "SAS stream, can't use");
 	} else {
-		return 0;
+		return hleNoLog(0);
 	}
 }
 

--- a/Core/TiltEventProcessor.cpp
+++ b/Core/TiltEventProcessor.cpp
@@ -360,16 +360,15 @@ void ProcessDelta(double now, float dx, float dy) {
 void MouseDeltaToAxes(double now, float *mx, float *my) {
 	std::unique_lock<std::mutex> lock(g_mouseMutex);
 
-	float scaleFactor_x = g_display.dpi_scale_x * 0.1 * g_Config.fMouseSensitivity;
-	float scaleFactor_y = g_display.dpi_scale_y * 0.1 * g_Config.fMouseSensitivity;
+	float scaleFactor = g_display.dpi_scale * 0.1 * g_Config.fMouseSensitivity;
 
 	DecayMouse(now);
 
 	// TODO: Make configurable.
 	float mouseDeadZone = 0.1f;
 
-	float outX = clamp_value(g_mouseDeltaX * scaleFactor_x, -1.0f, 1.0f);
-	float outY = clamp_value(g_mouseDeltaY * scaleFactor_y, -1.0f, 1.0f);
+	float outX = clamp_value(g_mouseDeltaX * scaleFactor, -1.0f, 1.0f);
+	float outY = clamp_value(g_mouseDeltaY * scaleFactor, -1.0f, 1.0f);
 
 	ApplyDeadzoneXY(outX, outY, mx, my, mouseDeadZone, true);
 }

--- a/GPU/Common/PresentationCommon.cpp
+++ b/GPU/Common/PresentationCommon.cpp
@@ -58,10 +58,10 @@ FRect GetScreenFrame(float pixelWidth, float pixelHeight) {
 
 	if (applyInset) {
 		// Remove the DPI scale to get back to pixels.
-		float left = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_LEFT) / g_display.dpi_scale_x;
-		float right = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_RIGHT) / g_display.dpi_scale_x;
-		float top = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_TOP) / g_display.dpi_scale_y;
-		float bottom = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_BOTTOM) / g_display.dpi_scale_y;
+		float left = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_LEFT) / g_display.dpi_scale;
+		float right = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_RIGHT) / g_display.dpi_scale;
+		float top = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_TOP) / g_display.dpi_scale;
+		float bottom = System_GetPropertyFloat(SYSPROP_DISPLAY_SAFE_INSET_BOTTOM) / g_display.dpi_scale;
 
 		// Adjust left edge to compensate for cutouts (notches) if any.
 		rc.x += left;

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -585,15 +585,15 @@ bool MainUI::event(QEvent *e) {
 				break;
 			case Qt::TouchPointPressed:
 			case Qt::TouchPointReleased:
-				input.x = touchPoint.pos().x() * g_display.dpi_scale_x * xscale;
-				input.y = touchPoint.pos().y() * g_display.dpi_scale_y * yscale;
+				input.x = touchPoint.pos().x() * g_display.dpi_scale * xscale;
+				input.y = touchPoint.pos().y() * g_display.dpi_scale * yscale;
 				input.flags = (touchPoint.state() == Qt::TouchPointPressed) ? TOUCH_DOWN : TOUCH_UP;
 				input.id = touchPoint.id();
 				NativeTouch(input);
 				break;
 			case Qt::TouchPointMoved:
-				input.x = touchPoint.pos().x() * g_display.dpi_scale_x * xscale;
-				input.y = touchPoint.pos().y() * g_display.dpi_scale_y * yscale;
+				input.x = touchPoint.pos().x() * g_display.dpi_scale * xscale;
+				input.y = touchPoint.pos().y() * g_display.dpi_scale * yscale;
 				input.flags = TOUCH_MOVE;
 				input.id = touchPoint.id();
 				NativeTouch(input);
@@ -611,8 +611,8 @@ bool MainUI::event(QEvent *e) {
 	case QEvent::MouseButtonRelease:
 		switch(((QMouseEvent*)e)->button()) {
 		case Qt::LeftButton:
-			input.x = ((QMouseEvent*)e)->pos().x() * g_display.dpi_scale_x * xscale;
-			input.y = ((QMouseEvent*)e)->pos().y() * g_display.dpi_scale_y * yscale;
+			input.x = ((QMouseEvent*)e)->pos().x() * g_display.dpi_scale * xscale;
+			input.y = ((QMouseEvent*)e)->pos().y() * g_display.dpi_scale * yscale;
 			input.flags = (e->type() == QEvent::MouseButtonPress) ? TOUCH_DOWN : TOUCH_UP;
 			input.id = 0;
 			NativeTouch(input);
@@ -634,8 +634,8 @@ bool MainUI::event(QEvent *e) {
 		}
 		break;
 	case QEvent::MouseMove:
-		input.x = ((QMouseEvent*)e)->pos().x() * g_display.dpi_scale_x * xscale;
-		input.y = ((QMouseEvent*)e)->pos().y() * g_display.dpi_scale_y * yscale;
+		input.x = ((QMouseEvent*)e)->pos().x() * g_display.dpi_scale * xscale;
+		input.y = ((QMouseEvent*)e)->pos().y() * g_display.dpi_scale * yscale;
 		input.flags = TOUCH_MOVE;
 		input.id = 0;
 		NativeTouch(input);
@@ -842,12 +842,11 @@ int main(int argc, char *argv[])
 	g_display.pixel_xres = res.width();
 	g_display.pixel_yres = res.height();
 
-	g_display.dpi_scale_x = screen->logicalDotsPerInchX() / screen->physicalDotsPerInchX();
-	g_display.dpi_scale_y = screen->logicalDotsPerInchY() / screen->physicalDotsPerInchY();
-	g_display.dpi_scale_real_x = g_display.dpi_scale_x;
-	g_display.dpi_scale_real_y = g_display.dpi_scale_y;
-	g_display.dp_xres = (int)(g_display.pixel_xres * g_display.dpi_scale_x);
-	g_display.dp_yres = (int)(g_display.pixel_yres * g_display.dpi_scale_y);
+	g_display.dpi_scale = screen->logicalDotsPerInchX() / screen->physicalDotsPerInchX();
+	// We assume physicalDotsPerInchY is the same as PerInchX.
+	g_display.dpi_scale_real = g_display.dpi_scale;
+	g_display.dp_xres = (int)(g_display.pixel_xres * g_display.dpi_scale);
+	g_display.dp_yres = (int)(g_display.pixel_yres * g_display.dpi_scale);
 
 	refreshRate = screen->refreshRate();
 

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -759,8 +759,8 @@ static void ProcessSDLEvent(SDL_Window *window, const SDL_Event &event, InputSta
 	// - SDL gives us motion events in "system DPI" points
 	// - Native_UpdateScreenScale expects pixels, so in a way "96 DPI" points
 	// - The UI code expects motion events in "logical DPI" points
-	float mx = event.motion.x * g_DesktopDPI * g_display.dpi_scale_x;
-	float my = event.motion.y * g_DesktopDPI * g_display.dpi_scale_x;
+	float mx = event.motion.x * g_DesktopDPI * g_display.dpi_scale;
+	float my = event.motion.y * g_DesktopDPI * g_display.dpi_scale;
 
 	switch (event.type) {
 	case SDL_QUIT:
@@ -913,8 +913,8 @@ static void ProcessSDLEvent(SDL_Window *window, const SDL_Event &event, InputSta
 			SDL_GetWindowSize(window, &w, &h);
 			TouchInput input;
 			input.id = event.tfinger.fingerId;
-			input.x = event.tfinger.x * w * g_DesktopDPI * g_display.dpi_scale_x;
-			input.y = event.tfinger.y * h * g_DesktopDPI * g_display.dpi_scale_x;
+			input.x = event.tfinger.x * w * g_DesktopDPI * g_display.dpi_scale;
+			input.y = event.tfinger.y * h * g_DesktopDPI * g_display.dpi_scale;
 			input.flags = TOUCH_MOVE;
 			input.timestamp = event.tfinger.timestamp;
 			NativeTouch(input);
@@ -926,8 +926,8 @@ static void ProcessSDLEvent(SDL_Window *window, const SDL_Event &event, InputSta
 			SDL_GetWindowSize(window, &w, &h);
 			TouchInput input;
 			input.id = event.tfinger.fingerId;
-			input.x = event.tfinger.x * w * g_DesktopDPI * g_display.dpi_scale_x;
-			input.y = event.tfinger.y * h * g_DesktopDPI * g_display.dpi_scale_x;
+			input.x = event.tfinger.x * w * g_DesktopDPI * g_display.dpi_scale;
+			input.y = event.tfinger.y * h * g_DesktopDPI * g_display.dpi_scale;
 			input.flags = TOUCH_DOWN;
 			input.timestamp = event.tfinger.timestamp;
 			NativeTouch(input);
@@ -945,8 +945,8 @@ static void ProcessSDLEvent(SDL_Window *window, const SDL_Event &event, InputSta
 			SDL_GetWindowSize(window, &w, &h);
 			TouchInput input;
 			input.id = event.tfinger.fingerId;
-			input.x = event.tfinger.x * w * g_DesktopDPI * g_display.dpi_scale_x;
-			input.y = event.tfinger.y * h * g_DesktopDPI * g_display.dpi_scale_x;
+			input.x = event.tfinger.x * w * g_DesktopDPI * g_display.dpi_scale;
+			input.y = event.tfinger.y * h * g_DesktopDPI * g_display.dpi_scale;
 			input.flags = TOUCH_UP;
 			input.timestamp = event.tfinger.timestamp;
 			NativeTouch(input);

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -1276,15 +1276,15 @@ void TouchTestScreen::DrawForeground(UIContext &dc) {
 		"display_res: %dx%d\n"
 #endif
 		"dp_res: %dx%d pixel_res: %dx%d\n"
-		"g_dpi: %0.3f g_dpi_scale: %0.3fx%0.3f\n"
-		"g_dpi_scale_real: %0.3fx%0.3f\n"
+		"g_dpi: %0.3f g_dpi_scale: %0.3f\n"
+		"g_dpi_scale_real: %0.3f\n"
 		"delta: %0.2f ms fps: %0.3f\n%s",
 #if PPSSPP_PLATFORM(ANDROID)
 		(int)System_GetPropertyInt(SYSPROP_DISPLAY_XRES), (int)System_GetPropertyInt(SYSPROP_DISPLAY_YRES),
 #endif
 		g_display.dp_xres, g_display.dp_yres, g_display.pixel_xres, g_display.pixel_yres,
-		g_display.dpi, g_display.dpi_scale_x, g_display.dpi_scale_y,
-		g_display.dpi_scale_real_x, g_display.dpi_scale_real_y,
+		g_display.dpi, g_display.dpi_scale,
+		g_display.dpi_scale_real,
 		delta * 1000.0, 1.0 / delta,
 		extra_debug);
 

--- a/UI/DisplayLayoutScreen.cpp
+++ b/UI/DisplayLayoutScreen.cpp
@@ -50,10 +50,10 @@ enum Mode {
 
 static Bounds FRectToBounds(FRect rc) {
 	Bounds b;
-	b.x = rc.x * g_display.dpi_scale_x;
-	b.y = rc.y * g_display.dpi_scale_y;
-	b.w = rc.w * g_display.dpi_scale_x;
-	b.h = rc.h * g_display.dpi_scale_y;
+	b.x = rc.x * g_display.dpi_scale;
+	b.y = rc.y * g_display.dpi_scale;
+	b.w = rc.w * g_display.dpi_scale;
+	b.h = rc.h * g_display.dpi_scale;
 	return b;
 }
 

--- a/UI/GamepadEmu.cpp
+++ b/UI/GamepadEmu.cpp
@@ -1021,8 +1021,8 @@ bool GestureGamepad::Touch(const TouchInput &input) {
 
 			if (g_Config.bAnalogGesture) {
 				const float k = g_Config.fAnalogGestureSensibility * 0.02;
-				float dx = (input.x - downX_)*g_display.dpi_scale_x * k;
-				float dy = (input.y - downY_)*g_display.dpi_scale_y * k;
+				float dx = (input.x - downX_) * g_display.dpi_scale * k;
+				float dy = (input.y - downY_) * g_display.dpi_scale * k;
 				dx = std::min(1.0f, std::max(-1.0f, dx));
 				dy = std::min(1.0f, std::max(-1.0f, dy));
 				__CtrlSetAnalogXY(0, dx, -dy);
@@ -1062,8 +1062,8 @@ void GestureGamepad::Draw(UIContext &dc) {
 
 void GestureGamepad::Update() {
 	const float th = 1.0f;
-	float dx = deltaX_ * g_display.dpi_scale_x * g_Config.fSwipeSensitivity;
-	float dy = deltaY_ * g_display.dpi_scale_y * g_Config.fSwipeSensitivity;
+	float dx = deltaX_ * g_display.dpi_scale * g_Config.fSwipeSensitivity;
+	float dy = deltaY_ * g_display.dpi_scale * g_Config.fSwipeSensitivity;
 	if (g_Config.iSwipeRight != 0) {
 		if (dx > th) {
 			controlMapper_->PSPKey(DEVICE_ID_TOUCH, GestureKey::keyList[g_Config.iSwipeRight-1], KEY_DOWN);

--- a/UI/MiscScreens.cpp
+++ b/UI/MiscScreens.cpp
@@ -152,8 +152,8 @@ public:
 			dc.Draw()->RectVGradient(x, wave1*bounds.h, nextX, bounds.h, color, 0x00000000);
 
 			// Add some "antialiasing"
-			dc.Draw()->RectVGradient(x, wave0*bounds.h-3.0f * g_display.pixel_in_dps_y, nextX, wave0 * bounds.h, 0x00000000, color);
-			dc.Draw()->RectVGradient(x, wave1*bounds.h-3.0f * g_display.pixel_in_dps_y, nextX, wave1 * bounds.h, 0x00000000, color);
+			dc.Draw()->RectVGradient(x, wave0*bounds.h-3.0f * g_display.pixel_in_dps, nextX, wave0 * bounds.h, 0x00000000, color);
+			dc.Draw()->RectVGradient(x, wave1*bounds.h-3.0f * g_display.pixel_in_dps, nextX, wave1 * bounds.h, 0x00000000, color);
 		}
 
 		dc.Flush();

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -1512,8 +1512,8 @@ bool Native_IsWindowHidden() {
 
 static bool IsWindowSmall(int pixelWidth, int pixelHeight) {
 	// Can't take this from config as it will not be set if windows is maximized.
-	int w = (int)(pixelWidth * g_display.dpi_scale_x);
-	int h = (int)(pixelHeight * g_display.dpi_scale_y);
+	int w = (int)(pixelWidth * g_display.dpi_scale);
+	int h = (int)(pixelHeight * g_display.dpi_scale);
 	return g_Config.IsPortrait() ? (h < 480 + 80) : (w < 480 + 80);
 }
 
@@ -1530,22 +1530,18 @@ bool Native_UpdateScreenScale(int width, int height) {
 		g_logical_dpi = 96.0f;
 	}
 
-	g_display.dpi_scale_x = g_logical_dpi / g_display.dpi;
-	g_display.dpi_scale_y = g_logical_dpi / g_display.dpi;
-	g_display.dpi_scale_real_x = g_display.dpi_scale_x;
-	g_display.dpi_scale_real_y = g_display.dpi_scale_y;
+	g_display.dpi_scale = g_logical_dpi / g_display.dpi;
+	g_display.dpi_scale_real = g_display.dpi_scale;
 
 	smallWindow = IsWindowSmall(width, height);
 	if (smallWindow) {
 		g_display.dpi /= 2.0f;
-		g_display.dpi_scale_x *= 2.0f;
-		g_display.dpi_scale_y *= 2.0f;
+		g_display.dpi_scale *= 2.0f;
 	}
-	g_display.pixel_in_dps_x = 1.0f / g_display.dpi_scale_x;
-	g_display.pixel_in_dps_y = 1.0f / g_display.dpi_scale_y;
+	g_display.pixel_in_dps = 1.0f / g_display.dpi_scale;
 
-	int new_dp_xres = (int)(width * g_display.dpi_scale_x);
-	int new_dp_yres = (int)(height * g_display.dpi_scale_y);
+	int new_dp_xres = (int)(width * g_display.dpi_scale);
+	int new_dp_yres = (int)(height * g_display.dpi_scale);
 
 	bool dp_changed = new_dp_xres != g_display.dp_xres || new_dp_yres != g_display.dp_yres;
 	bool px_changed = g_display.pixel_xres != width || g_display.pixel_yres != height;

--- a/UI/TouchControlLayoutScreen.cpp
+++ b/UI/TouchControlLayoutScreen.cpp
@@ -320,8 +320,8 @@ public:
 			float xOffset = bounds_.x;
 			float yOffset = bounds_.y;
 
-			dc.Draw()->Rect((x1+x2)/2 + xOffset - g_display.pixel_in_dps_x, y1 + yOffset, 3.0f * g_display.pixel_in_dps_x, y2-y1, col);
-			dc.Draw()->Rect(x1 + xOffset, (y1+y2)/2 + yOffset - g_display.pixel_in_dps_y, x2-x1, 3.0f * g_display.pixel_in_dps_y, col);
+			dc.Draw()->Rect((x1+x2)/2 + xOffset - g_display.pixel_in_dps, y1 + yOffset, 3.0f * g_display.pixel_in_dps, y2-y1, col);
+			dc.Draw()->Rect(x1 + xOffset, (y1+y2)/2 + yOffset - g_display.pixel_in_dps, x2-x1, 3.0f * g_display.pixel_in_dps, col);
 
 			for (int x = x1 + (x1+x2)/2 % g_Config.iTouchSnapGridSize; x < x2; x += g_Config.iTouchSnapGridSize)
 				dc.Draw()->vLine(x + xOffset, y1 + yOffset, y2 + yOffset, col);

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -152,14 +152,11 @@ void PPSSPP_UWPMain::UpdateScreenState() {
 		// Boost DPI a bit to look better.
 		g_display.dpi *= 96.0f / 136.0f;
 	}
-	g_display.dpi_scale_x = 96.0f / g_display.dpi;
-	g_display.dpi_scale_y = 96.0f / g_display.dpi;
+	g_display.dpi_scale = 96.0f / g_display.dpi;
+	g_display.pixel_in_dps = 1.0f / g_display.dpi_scale;
 
-	g_display.pixel_in_dps_x = 1.0f / g_display.dpi_scale_x;
-	g_display.pixel_in_dps_y = 1.0f / g_display.dpi_scale_y;
-
-	g_display.dp_xres = g_display.pixel_xres * g_display.dpi_scale_x;
-	g_display.dp_yres = g_display.pixel_yres * g_display.dpi_scale_y;
+	g_display.dp_xres = g_display.pixel_xres * g_display.dpi_scale;
+	g_display.dp_yres = g_display.pixel_yres * g_display.dpi_scale;
 
 	context->RSSetViewports(1, &viewport);
 }
@@ -266,8 +263,8 @@ void PPSSPP_UWPMain::OnTouchEvent(int touchEvent, int touchId, float x, float y,
 	// and then apply our own "dpi".
 	float dpiFactor_x = m_deviceResources->GetActualDpi() / 96.0f;
 	float dpiFactor_y = dpiFactor_x;
-	dpiFactor_x /= g_display.pixel_in_dps_x;
-	dpiFactor_y /= g_display.pixel_in_dps_y;
+	dpiFactor_x /= g_display.pixel_in_dps;
+	dpiFactor_y /= g_display.pixel_in_dps;
 
 	TouchInput input{};
 	input.id = touchId;

--- a/Windows/Debugger/CtrlDisAsmView.cpp
+++ b/Windows/Debugger/CtrlDisAsmView.cpp
@@ -171,7 +171,7 @@ CtrlDisAsmView::CtrlDisAsmView(HWND _wnd)
 	SetWindowLong(wnd, GWL_STYLE, GetWindowLong(wnd,GWL_STYLE) | WS_VSCROLL);
 	SetScrollRange(wnd, SB_VERT, -1, 1, TRUE);
 
-	const float fontScale = 1.0f / g_display.dpi_scale_real_y;
+	const float fontScale = 1.0f / g_display.dpi_scale_real;
 	charWidth = g_Config.iFontWidth * fontScale;
 	rowHeight = (g_Config.iFontHeight + 2) * fontScale;
 	int scaledFontHeight = g_Config.iFontHeight * fontScale;

--- a/Windows/Debugger/CtrlMemView.cpp
+++ b/Windows/Debugger/CtrlMemView.cpp
@@ -35,7 +35,7 @@ CtrlMemView::CtrlMemView(HWND _wnd) {
 	SetWindowLong(wnd, GWL_STYLE, GetWindowLong(wnd,GWL_STYLE) | WS_VSCROLL);
 	SetScrollRange(wnd, SB_VERT, -1,1,TRUE);
 
-	const float fontScale = 1.0f / g_display.dpi_scale_real_y;
+	const float fontScale = 1.0f / g_display.dpi_scale_real;
 	charWidth_ = g_Config.iFontWidth * fontScale;
 	rowHeight_ = g_Config.iFontHeight * fontScale;
 	offsetPositionY_ = offsetLine * rowHeight_;

--- a/Windows/Debugger/CtrlRegisterList.cpp
+++ b/Windows/Debugger/CtrlRegisterList.cpp
@@ -131,7 +131,7 @@ CtrlRegisterList::CtrlRegisterList(HWND _wnd)
 	: wnd(_wnd) {
 	SetWindowLongPtr(wnd, GWLP_USERDATA, (LONG_PTR)this);
 
-	const float fontScale = 1.0f / g_display.dpi_scale_real_y;
+	const float fontScale = 1.0f / g_display.dpi_scale_real;
 	rowHeight = g_Config.iFontHeight * fontScale;
 	int charWidth = g_Config.iFontWidth * fontScale;
 	font = CreateFont(rowHeight, charWidth, 0, 0,

--- a/Windows/Debugger/Debugger_MemoryDlg.cpp
+++ b/Windows/Debugger/Debugger_MemoryDlg.cpp
@@ -255,7 +255,7 @@ void CMemoryDlg::Goto(u32 addr)
 
 void CMemoryDlg::Size()
 {
-	const float fontScale = 1.0f / g_display.dpi_scale_real_y;
+	const float fontScale = 1.0f / g_display.dpi_scale_real;
 
 	GetClientRect(m_hDlg,&winRect);
 	int dlg_w = winRect.right - winRect.left;

--- a/Windows/GEDebugger/CtrlDisplayListView.cpp
+++ b/Windows/GEDebugger/CtrlDisplayListView.cpp
@@ -45,7 +45,7 @@ CtrlDisplayListView::CtrlDisplayListView(HWND _wnd)
 	instructionSize = 4;
 
 	// In small window mode, g_dpi_scale may have been adjusted.
-	const float fontScale = 1.0f / g_display.dpi_scale_real_y;
+	const float fontScale = 1.0f / g_display.dpi_scale_real;
 	int fontHeight = g_Config.iFontHeight * fontScale;
 	int charWidth = g_Config.iFontWidth * fontScale;
 

--- a/Windows/MainWindow.cpp
+++ b/Windows/MainWindow.cpp
@@ -659,8 +659,8 @@ namespace MainWindow
 				// Hack: Take the opportunity to show the cursor.
 				mouseButtonDown = true;
 
-				float x = GET_X_LPARAM(lParam) * g_display.dpi_scale_x;
-				float y = GET_Y_LPARAM(lParam) * g_display.dpi_scale_y;
+				float x = GET_X_LPARAM(lParam) * g_display.dpi_scale;
+				float y = GET_Y_LPARAM(lParam) * g_display.dpi_scale;
 				WindowsRawInput::SetMousePos(x, y);
 
 				TouchInput touch{};
@@ -707,8 +707,8 @@ namespace MainWindow
 				prevCursorX = cursorX;
 				prevCursorY = cursorY;
 
-				float x = (float)cursorX * g_display.dpi_scale_x;
-				float y = (float)cursorY * g_display.dpi_scale_y;
+				float x = (float)cursorX * g_display.dpi_scale;
+				float y = (float)cursorY * g_display.dpi_scale;
 				WindowsRawInput::SetMousePos(x, y);
 
 				// Mouse moves now happen also when no button is pressed.
@@ -733,8 +733,8 @@ namespace MainWindow
 				// Hack: Take the opportunity to hide the cursor.
 				mouseButtonDown = false;
 
-				float x = (float)GET_X_LPARAM(lParam) * g_display.dpi_scale_x;
-				float y = (float)GET_Y_LPARAM(lParam) * g_display.dpi_scale_y;
+				float x = (float)GET_X_LPARAM(lParam) * g_display.dpi_scale;
+				float y = (float)GET_Y_LPARAM(lParam) * g_display.dpi_scale;
 				WindowsRawInput::SetMousePos(x, y);
 
 				TouchInput touch{};
@@ -753,8 +753,8 @@ namespace MainWindow
 
 		case WM_RBUTTONDOWN:
 		{
-			float x = GET_X_LPARAM(lParam) * g_display.dpi_scale_x;
-			float y = GET_Y_LPARAM(lParam) * g_display.dpi_scale_y;
+			float x = GET_X_LPARAM(lParam) * g_display.dpi_scale;
+			float y = GET_Y_LPARAM(lParam) * g_display.dpi_scale;
 
 			TouchInput touch{};
 			touch.buttons = 2;
@@ -767,8 +767,8 @@ namespace MainWindow
 
 		case WM_RBUTTONUP:
 		{
-			float x = GET_X_LPARAM(lParam) * g_display.dpi_scale_x;
-			float y = GET_Y_LPARAM(lParam) * g_display.dpi_scale_y;
+			float x = GET_X_LPARAM(lParam) * g_display.dpi_scale;
+			float y = GET_Y_LPARAM(lParam) * g_display.dpi_scale;
 
 			TouchInput touch{};
 			touch.buttons = 2;

--- a/Windows/TouchInputHandler.cpp
+++ b/Windows/TouchInputHandler.cpp
@@ -53,8 +53,8 @@ bool TouchInputHandler::GetTouchPoint(HWND hWnd, const TOUCHINPUT &input, float 
 	point.x = (LONG)(TOUCH_COORD_TO_PIXEL(input.x));
 	point.y = (LONG)(TOUCH_COORD_TO_PIXEL(input.y));
 	if (ScreenToClient(hWnd, &point)) {
-		x = point.x * g_display.dpi_scale_x;
-		y = point.y * g_display.dpi_scale_y;
+		x = point.x * g_display.dpi_scale;
+		y = point.y * g_display.dpi_scale;
 		return true;
 	}
 

--- a/android/jni/app-android.cpp
+++ b/android/jni/app-android.cpp
@@ -1000,19 +1000,16 @@ extern "C" jboolean Java_org_ppsspp_ppsspp_NativeRenderer_displayInit(JNIEnv * e
 
 static void recalculateDpi() {
 	g_display.dpi = (float)display_dpi_x;
-	g_display.dpi_scale_x = 240.0f / (float)display_dpi_x;
-	g_display.dpi_scale_y = 240.0f / (float)display_dpi_y;
-	g_display.dpi_scale_real_x = g_display.dpi_scale_x;
-	g_display.dpi_scale_real_y = g_display.dpi_scale_y;
+	g_display.dpi_scale_real = 240.0f / (float)display_dpi_x;
+	g_display.dpi_scale = g_display.dpi_scale_real;
 
-	g_display.dp_xres = display_xres * g_display.dpi_scale_x;
-	g_display.dp_yres = display_yres * g_display.dpi_scale_y;
+	g_display.dp_xres = display_xres * g_display.dpi_scale;
+	g_display.dp_yres = display_yres * g_display.dpi_scale;
 
-	g_display.pixel_in_dps_x = (float)g_display.pixel_xres / g_display.dp_xres;
-	g_display.pixel_in_dps_y = (float)g_display.pixel_yres / g_display.dp_yres;
+	g_display.pixel_in_dps = (float)g_display.pixel_xres / g_display.dp_xres;
 
 	INFO_LOG(Log::G3D, "RecalcDPI: display_xres=%d display_yres=%d pixel_xres=%d pixel_yres=%d", display_xres, display_yres, g_display.pixel_xres, g_display.pixel_yres);
-	INFO_LOG(Log::G3D, "RecalcDPI: g_dpi=%f g_dpi_scale_x=%f g_dpi_scale_y=%f dp_xres=%d dp_yres=%d", g_display.dpi, g_display.dpi_scale_x, g_display.dpi_scale_y, g_display.dp_xres, g_display.dp_yres);
+	INFO_LOG(Log::G3D, "RecalcDPI: g_dpi=%f g_dpi_scale=%f dp_xres=%d dp_yres=%d", g_display.dpi, g_display.dpi_scale, g_display.dp_xres, g_display.dp_yres);
 }
 
 extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_backbufferResize(JNIEnv *, jclass, jint bufw, jint bufh, jint format) {
@@ -1161,7 +1158,7 @@ extern "C" void Java_org_ppsspp_ppsspp_NativeRenderer_displayRender(JNIEnv *env,
 	}
 
 	if (IsVREnabled()) {
-		UpdateVRInput(g_Config.bHapticFeedback, g_display.dpi_scale_x, g_display.dpi_scale_y);
+		UpdateVRInput(g_Config.bHapticFeedback, g_display.dpi_scale);
 		FinishVRRender();
 	}
 }
@@ -1188,8 +1185,8 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_touch
 		return;
 	TouchInput touch{};
 	touch.id = pointerId;
-	touch.x = x * g_display.dpi_scale_x;
-	touch.y = y * g_display.dpi_scale_y;
+	touch.x = x * g_display.dpi_scale;
+	touch.y = y * g_display.dpi_scale;
 	touch.flags = code;
 	NativeTouch(touch);
 }
@@ -1320,10 +1317,10 @@ extern "C" void JNICALL Java_org_ppsspp_ppsspp_NativeApp_sendMessageFromJava(JNI
 		// We don't bother with supporting exact rectangular regions. Safe insets are good enough.
 		int left, right, top, bottom;
 		if (4 == sscanf(prm.c_str(), "%d:%d:%d:%d", &left, &right, &top, &bottom)) {
-			g_safeInsetLeft = (float)left * g_display.dpi_scale_x;
-			g_safeInsetRight = (float)right * g_display.dpi_scale_x;
-			g_safeInsetTop = (float)top * g_display.dpi_scale_y;
-			g_safeInsetBottom = (float)bottom * g_display.dpi_scale_y;
+			g_safeInsetLeft = (float)left * g_display.dpi_scale;
+			g_safeInsetRight = (float)right * g_display.dpi_scale;
+			g_safeInsetTop = (float)top * g_display.dpi_scale;
+			g_safeInsetBottom = (float)bottom * g_display.dpi_scale;
 		}
 	} else if (msg == "inputDeviceConnectedID") {
 		nextInputDeviceID = (InputDeviceID)parseLong(prm);

--- a/ext/imgui/imgui_impl_platform.cpp
+++ b/ext/imgui/imgui_impl_platform.cpp
@@ -56,8 +56,8 @@ void ImGui_ImplPlatform_TouchEvent(const TouchInput &touch) {
 	ImGuiIO& io = ImGui::GetIO();
 
 	// We use real pixels in the imgui, no DPI adjustment yet.
-	float x = touch.x / g_display.dpi_scale_x;
-	float y = touch.y / g_display.dpi_scale_y;
+	float x = touch.x / g_display.dpi_scale;
+	float y = touch.y / g_display.dpi_scale;
 
 	if (touch.flags & TOUCH_MOVE) {
 		io.AddMousePosEvent(x, y);

--- a/ext/imgui/imgui_impl_thin3d.cpp
+++ b/ext/imgui/imgui_impl_thin3d.cpp
@@ -293,13 +293,13 @@ void ImGui_ImplThin3d_DestroyDeviceObjects() {
 bool ImGui_ImplThin3d_Init(Draw::DrawContext *draw, const uint8_t *ttf_font, size_t size) {
 	ImGuiIO& io = ImGui::GetIO();
 	if (ttf_font) {
-		g_proportionalFont = io.Fonts->AddFontFromMemoryTTF((void *)ttf_font, (int)size, 21.0f / g_display.dpi_scale_x, nullptr, io.Fonts->GetGlyphRangesDefault());
+		g_proportionalFont = io.Fonts->AddFontFromMemoryTTF((void *)ttf_font, (int)size, 21.0f / g_display.dpi_scale, nullptr, io.Fonts->GetGlyphRangesDefault());
 	} else {
 		// fallback
 		g_proportionalFont = g_fixedFont;
 	}
 	g_fixedFont = io.Fonts->AddFontDefault();
-	ImGui::GetStyle().ScaleAllSizes(1.0f / g_display.dpi_scale_x);
+	ImGui::GetStyle().ScaleAllSizes(1.0f / g_display.dpi_scale);
 	ImGui::GetStyle().Colors[ImGuiCol_Border] = ImColor(IM_COL32(0x2A, 0x2F, 0x3B, 0xFF));
 
 	IMGUI_CHECKVERSION();

--- a/ios/DisplayManager.mm
+++ b/ios/DisplayManager.mm
@@ -148,18 +148,17 @@
 		float diagonal = sqrt(size.height * size.height + size.width * size.width);
 		g_display.dpi = diagonal * scale * 0.1f;
 	}
-	g_display.dpi_scale_x = 240.0f / g_display.dpi;
-	g_display.dpi_scale_y = 240.0f / g_display.dpi;
-	g_display.dpi_scale_real_x = g_display.dpi_scale_x;
-	g_display.dpi_scale_real_y = g_display.dpi_scale_y;
+	g_display.dpi_scale_real = 240.0f / g_display.dpi;
+
+	g_display.dpi_scale = g_display.dpi_scale_real;
+
 	g_display.pixel_xres = size.width * scale;
 	g_display.pixel_yres = size.height * scale;
 
-	g_display.dp_xres = g_display.pixel_xres * g_display.dpi_scale_x;
-	g_display.dp_yres = g_display.pixel_yres * g_display.dpi_scale_y;
+	g_display.dp_xres = g_display.pixel_xres * g_display.dpi_scale;
+	g_display.dp_yres = g_display.pixel_yres * g_display.dpi_scale;
 
-	g_display.pixel_in_dps_x = (float)g_display.pixel_xres / (float)g_display.dp_xres;
-	g_display.pixel_in_dps_y = (float)g_display.pixel_yres / (float)g_display.dp_yres;
+	g_display.pixel_in_dps = (float)g_display.pixel_xres / (float)g_display.dp_xres;
 	
 	[[sharedViewController getView] setContentScaleFactor:scale];
 	


### PR DESCRIPTION
No device that we support uses non-square pixels, so no need to carry around extra variables, complicating the code.