### PR TITLE
macOS SDL: Set the metal layer resolution properly, remove DPI hacks.

### DIFF
--- a/SDL/SDLCocoaMetalLayer.mm
+++ b/SDL/SDLCocoaMetalLayer.mm
@@ -17,6 +17,7 @@ void *makeWindowMetalCompatible(void *window) {
 	if (![view.layer isKindOfClass:[CAMetalLayer class]])
 	{
 		[view setLayer:[CAMetalLayer layer]];
+		[[view layer] setContentsScale:[window backingScaleFactor]];
 	}
 	return view.layer;
 #else

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -185,8 +185,8 @@ static void StopSDLAudioDevice() {
 }
 
 static void UpdateScreenDPI(SDL_Window *window) {
-	int drawable_width, window_width;
-	SDL_GetWindowSize(window, &window_width, NULL);
+	int drawable_width, window_width, window_height;
+	SDL_GetWindowSize(window, &window_width, &window_height);
 
 	if (g_Config.iGPUBackend == (int)GPUBackend::OPENGL)
 		SDL_GL_GetDrawableSize(window, &drawable_width, NULL);
@@ -200,13 +200,6 @@ static void UpdateScreenDPI(SDL_Window *window) {
 	// Round up a little otherwise there would be a gap sometimes
 	// in fractional scaling
 	g_DesktopDPI = ((float) drawable_width + 1.0f) / window_width;
-
-	// Temporary hack
-#if PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS)
-	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN) {
-		g_DesktopDPI = 1.0f;
-	}
-#endif
 }
 
 // Simple implementations of System functions
@@ -1438,11 +1431,6 @@ int main(int argc, char *argv[]) {
 		}
 #endif
 	}
-#if PPSSPP_PLATFORM(MAC) || PPSSPP_PLATFORM(IOS)
-	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN) {
-		g_ForcedDPI = 1.0f;
-	}
-#endif
 
 	UpdateScreenDPI(window);
 


### PR DESCRIPTION
Fixes #19183

Thanks to @schm1dtmac for the fix.

@shm1dtmac also mentions that this may have issues when moving the window between displays, but this should still be an improvement for most people.