### PR TITLE
Fix Jak & daxter smoke effects (same problems as Ratchet)

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1369,6 +1369,19 @@ UCJS18030 = true
 UCJS18047 = true
 NPJG00015 = true
 
+# Jak & Daxter smoke effects (#20002)
+UCES01225 = true
+UCUS98634 = true
+UCUS98755 = true  # demo
+NPUG80330 = true
+NPHG00042 = true
+NPUG98755 = true
+NPEG90022 = true
+UCES01378 = true
+UCKS45131 = true
+UCJS10103 = true
+NPJG00038 = true
+
 [SplitFramebufferMargin]
 # Killzone: Liberation (see issue #6207)
 UCES00279 = true


### PR DESCRIPTION
We just enable the same depth-buffer-swizzle workaround - the games seem to run on the same engine, doing the same unholy trickery with depth buffer swizzle.

Fixes #20002 (although haven't tested through the game)

For the original issue, see #6105 , fixed by #15859

Surprised this hasn't been reported before.