### PR TITLE
Allow binding Toggle touch controls to a custom touch button

### DIFF
--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -658,8 +658,10 @@ bool EmuScreen::UnsyncTouch(const TouchInput &touch) {
 		}
 	}
 
-	if (!(g_Config.bShowImDebugger && imguiInited_)) {
-		GamepadTouch();
+	if (touch.flags & TOUCH_DOWN) {
+		if (!(g_Config.bShowImDebugger && imguiInited_)) {
+			GamepadTouch();
+		}
 	}
 
 	if (root_) {

--- a/UI/GamepadEmu.h
+++ b/UI/GamepadEmu.h
@@ -326,6 +326,7 @@ namespace CustomKeyData {
 		{ ImageID::invalid(), VIRTKEY_AXIS_X_MAX },
 		{ ImageID::invalid(), VIRTKEY_AXIS_Y_MAX },
 		{ ImageID::invalid(), VIRTKEY_PREVIOUS_SLOT },
+		{ ImageID::invalid(), VIRTKEY_TOGGLE_TOUCH_CONTROLS },
 	};
 	static_assert(ARRAY_SIZE(customKeyList) <= 64, "Too many key for a uint64_t bit mask");
 };


### PR DESCRIPTION
What it says on the tin. Had to add a check so that touch-up events don't re-enable them.

Fixes #20034 