### PR TITLE
libpng full api: Remember to enable interlace handling, fix error handling

### DIFF
--- a/Common/Render/ManagedTexture.cpp
+++ b/Common/Render/ManagedTexture.cpp
@@ -116,6 +116,7 @@ bool TempImage::LoadTextureLevelsFromFileData(const uint8_t *data, size_t size, 
 			}
 		} else {
 			ERROR_LOG(Log::IO, "PNG load failed");
+			_dbg_assert_(!levels[0]);
 			return false;
 		}
 		break;


### PR DESCRIPTION
I hate hate hate libpng's API with all passion in the world. Why are all the defaults wrong?