### PR TITLE
Add dump decode hex data from atrac

### DIFF
--- a/Common/Log.h
+++ b/Common/Log.h
@@ -89,7 +89,7 @@ bool GenericLogEnabled(LogLevel level, Log type);
 #if defined(_DEBUG) || (!PPSSPP_PLATFORM(ANDROID) && !PPSSPP_PLATFORM(IOS))
 
 // Needs to be an int (and not use the enum) because it's used by the preprocessor!
-#define MAX_LOGLEVEL DEBUG_LEVEL
+#define MAX_LOGLEVEL VERBOSE_LEVEL
 
 #else
 


### PR DESCRIPTION
Change MAX_LOGLEVEL from DEBUG_LEVEL to  VERBOSE_LEVEL

The code 90% from Grok 3

Easier compare to jpcsp emulator log

Debuging in #19994

output:

46:20:967 ATRAC3 play  D[ME]: HLE\AtracCtx.cpp:1032 decodeData from 0x00000000(0x230) to 0x08A7F10C(0x800), skippedSamples=0x0, currentSample=0x15B63, outputChannels=2
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000000  3A 6D 21 64 B4 CB 1E 80 C0 00 2B 19 BF 7B B9 BC  >:m!d......+..{..<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000010  17 89 22 08 4A 54 ED E1 E4 AE 55 94 D2 DC B4 13  >..".JT....U.....<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000020  0E 1C C1 51 04 06 E9 AE 04 84 9B 94 ED AD 0E 2B  >...Q...........+<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000030  54 18 74 1D 41 9F 52 C0 73 9F C2 95 30 CA DD A3  >T.t.A.R.s...0...<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000040  8E 2E B1 9D FF 82 BC F2 43 EF 7E 56 36 37 23 13  >........C.~V67#.<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000050  D1 FB 93 CC 82 D9 4A 2D CA 16 F2 3B 2C 16 C5 FC  >......J-...;,...<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000060  79 45 D4 5D 5F 8F 34 E1 33 8F F8 63 BA 53 7F CA  >yE.]_.4.3..c.S..<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000070  AA 30 B2 25 2D 34 3E C5 B1 27 CB E8 68 D2 14 4A  >.0.%-4>..'..h..J<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000080  55 91 E7 FC FD AE 2E BB D3 5E BB 2C 7F D5 24 32  >U........^.,..$2<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000090  93 6D B7 8A 25 A8 64 34 F9 FB 42 D7 3C 90 C6 98  >.m..%.d4..B.<...<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 000000a0  2F BA C7 F9 5A D7 2D 27 24 9F 57 A7 28 C2 6B 66  >/...Z.-'$.W.(.kf<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 000000b0  A5 54 41 B4 4C 2D A3 E6 34 B4 66 56 AF DA C5 D6  >.TA.L-..4.fV....<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 000000c0  EA 57 0C A2 F3 BF ED BE BB 53 7D 3E 06 E3 C2 52  >.W.......S}>...R<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 000000d0  EC 18 E7 4E DA EA A8 A3 91 EB ED 26 83 7D C4 48  >...N.......&.}.H<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 000000e0  1F C0 FD 72 49 B7 23 EC 92 1D 49 B8 F1 14 2A 63  >...rI.#...I...*c<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 000000f0  85 23 D9 AD EE 6D 6B 97 5E 4F FA AB 8A 31 E6 FC  >.#...mk.^O...1..<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000100  D6 96 F9 37 EF 0C 1A 0A DC 9B 00 2A BF BA 9D 6A  >...7.......*...j<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000110  FD FC 97 90 05 A1 CA 28 35 02 BD B7 6B 01 D0 0A  >.......(5...k...<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000120  69 15 AD 7C 3D B6 52 43 EB 0B F3 B2 CA 3F FE 80  >i..|=.RC.....?..<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000130  4F 93 D2 C5 09 D8 15 19 65 2C EF 15 49 41 BD E5  >O.......e,..IA..<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000140  DC FE 41 38 E4 D2 54 D1 0E 8A 13 19 08 30 59 CB  >..A8..T......0Y.<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000150  3F E6 F5 C1 80 BE 54 58 38 EF A7 CD C3 87 76 8E  >?.....TX8.....v.<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000160  7F ED 52 30 12 B3 17 9C A7 F1 36 39 BE 78 1A F0  >..R0......69.x..<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000170  88 BC 02 0B E0 B5 BE BE D0 78 44 F2 B7 2A 6F FE  >.........xD..*o.<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000180  4E 94 C3 F6 9D 10 4E C7 8C 82 CE 7F 34 66 70 A1  >N.....N.....4fp.<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000190  6B 36 43 7B A8 FF 3B C1 BD 34 9C 91 BC 11 47 86  >k6C{..;..4....G.<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 000001a0  13 97 DA AF 51 3B 62 22 CF 2F 81 15 6A B7 B5 E5  >....Q;b"./..j...<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 000001b0  E3 4E 0F 29 AA 26 6F AE 62 E7 59 3F 72 B4 69 0A  >.N.).&o.b.Y?r.i.<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 000001c0  18 C3 99 06 8E EF 2F A6 9F 01 6F 93 7B 1F 49 A0  >....../...o.{.I.<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 000001d0  CE E3 03 65 32 D4 F1 13 5D 73 95 0F 41 6F 69 4E  >...e2...]s..AoiN<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 000001e0  48 05 1A EC 45 28 41 00 D8 E2 89 ED 11 CB FB 15  >H...E(A.........<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 000001f0  BA D3 F9 4C AB A9 7F 75 63 89 E6 29 36 78 2F D0  >...L...uc..)6x/.<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000200  BE DD 3D CC 25 82 70 BD 16 0A A0 3F FE 8C 9D E4  >..=.%.p....?....<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000210  EF 49 CC 97 BB 35 45 56 8D 29 AD B7 50 62 36 7D  >.I...5EV.)..Pb6}<
46:20:967 ATRAC3 play  V[ME]: HLE\AtracCtx.cpp:1037 00000220  03 1C 54 66 D3 BD 20 E0 21 D0 0A 5F 70 B7 90 0C  >..Tf.. .!.._p...<

