### PR TITLE
Switch to sleep_precise for WaitUntil(), bump VMA and gradle versions

### DIFF
--- a/Core/FrameTiming.cpp
+++ b/Core/FrameTiming.cpp
@@ -19,6 +19,7 @@
 // * Frame skipping. This gets complicated.
 // * The game not actually asking for flips, like in static loading screens
 
+#include "ppsspp_config.h"
 #include "Common/Profiler/Profiler.h"
 #include "Common/Log.h"
 #include "Common/TimeUtil.h"
@@ -35,7 +36,13 @@
 FrameTiming g_frameTiming;
 
 void WaitUntil(double now, double timestamp, const char *reason) {
-#ifdef _WIN32
+#if 1
+	// Use precise timing.
+	sleep_precise(timestamp - now);
+#else
+
+#if PPSSPP_PLATFORM(WINDOWS)
+	// Old method. TODO: Should we make an option?
 	while (time_now_d() < timestamp) {
 		sleep_ms(1, reason); // Sleep for 1ms on this thread
 	}
@@ -44,6 +51,8 @@ void WaitUntil(double now, double timestamp, const char *reason) {
 	if (left > 0.0 && left < 3.0) {
 		usleep((long)(left * 1000000));
 	}
+#endif
+
 #endif
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.8.0'
+        classpath 'com.android.tools.build:gradle:8.8.2'
     }
 }
 


### PR DESCRIPTION
WaitUntil() is used for frame timing.

This can improve frame pacing slightly, not just on Windows actually.

Also bumps gradle and VMA (vulkan memory allocator), the latter to avoid an assert with the latest NV drivers (fortunately. 1.19 is not affected since it doesn't request Vulkan 1.4).

Reference to VMA bug: https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/issues/457
