### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/ext/libpng17/pngrutil.c
+++ b/ext/libpng17/pngrutil.c
@@ -2667,11 +2667,13 @@ png_check_chunk_length(png_const_structrp png_ptr, const png_uint_32 length)
       int channels[]={1,0,3,1,2,0,4};
       png_alloc_size_t idat_limit = PNG_UINT_31_MAX;
       size_t row_factor =
-         (png_ptr->width * channels[png_ptr->color_type] *
-             (png_ptr->bit_depth > 8? 2: 1)
-          + 1 + (png_ptr->interlaced? 6: 0));
+         (size_t)png_ptr->width
+         * (size_t)png_ptr->channels
+         * (png_ptr->bit_depth > 8? 2: 1)
+         + 1
+         + (png_ptr->interlaced? 6: 0);
       if (png_ptr->height > PNG_UINT_32_MAX/row_factor)
-         idat_limit=PNG_UINT_31_MAX;
+         idat_limit = PNG_UINT_31_MAX;
       else
          idat_limit = png_ptr->height * row_factor;
       row_factor = row_factor > 32566? 32566 : row_factor;


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in png_check_chunk_length() that was cloned from libpng but did not receive the security patch. The original issue was reported and fixed under https://github.com/glennrp/libpng/commit/8a05766cb74af05c04c53e6c9d60c13fc4d59bf2.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2018-13785
https://github.com/glennrp/libpng/commit/8a05766cb74af05c04c53e6c9d60c13fc4d59bf2