### PR TITLE
Software renderer: Fix regression with gouraud shaded lines

### DIFF
--- a/GPU/Debugger/State.cpp
+++ b/GPU/Debugger/State.cpp
@@ -563,7 +563,6 @@ static void FormatVertColRawType(char *dest, size_t destSize, const void *data, 
 static void FormatVertColRawColor(char *dest, size_t destSize, const void *data, int type);
 
 void FormatVertColRaw(VertexDecoder *decoder, char *dest, size_t destSize, int row, int col) {
-	auto memLock = Memory::Lock();
 	if (!PSP_IsInited()) {
 		truncate_cpy(dest, destSize, "Invalid");
 		return;

--- a/GPU/Software/Rasterizer.cpp
+++ b/GPU/Software/Rasterizer.cpp
@@ -1694,7 +1694,7 @@ void DrawLine(const VertexData &v0, const VertexData &v1, const BinCoords &range
 	auto &pixelID = state.pixelID;
 	auto &samplerID = state.samplerID;
 
-	const bool interpolateColor = !state.shadeGouraud || (v0.color0 == v1.color0 && v0.color1 == v1.color1);
+	const bool interpolateColor = state.shadeGouraud && !(v0.color0 == v1.color0 && v0.color1 == v1.color1);
 	const Vec4<int> v0_c0 = Vec4<int>::FromRGBA(v0.color0);
 	const Vec4<int> v1_c0 = Vec4<int>::FromRGBA(v1.color0);
 	const Vec3<int> v0_c1 = Vec3<int>::FromRGB(v0.color1);


### PR DESCRIPTION
Was broken by a logic mistake in this commit: a2abf94

(also includes an unrelated commit)

Fixes the shading problem in #3332