### PR TITLE
More logging cleanup

### DIFF
--- a/Common/Data/Text/Parsers.h
+++ b/Common/Data/Text/Parsers.h
@@ -83,6 +83,7 @@ std::string NiceTimeFormat(int seconds);
 // Not a parser, needs a better location.
 // Simplified version of ShaderWriter. Would like to have that inherit from this but can't figure out how
 // due to the return value chaining.
+// TODO: We actually also have Buffer, with .Printf(), which is almost as convenient. Should maybe improve that instead?
 class StringWriter {
 public:
 	explicit StringWriter(char *buffer) : p_(buffer) {

--- a/Common/StringUtils.cpp
+++ b/Common/StringUtils.cpp
@@ -238,10 +238,10 @@ void SkipSpace(const char **ptr) {
 	}
 }
 
-void DataToHexString(const uint8_t *data, size_t size, std::string *output) {
+void DataToHexString(const uint8_t *data, size_t size, std::string *output, bool lineBreaks) {
 	Buffer buffer;
 	for (size_t i = 0; i < size; i++) {
-		if (i && !(i & 15))
+		if (i && !(i & 15) && lineBreaks)
 			buffer.Printf("\n");
 		buffer.Printf("%02x ", data[i]);
 	}

--- a/Common/StringUtils.h
+++ b/Common/StringUtils.h
@@ -83,7 +83,7 @@ enum class StringRestriction {
 
 std::string SanitizeString(std::string_view username, StringRestriction restriction, int minLength, int maxLength);
 
-void DataToHexString(const uint8_t *data, size_t size, std::string *output);
+void DataToHexString(const uint8_t *data, size_t size, std::string *output, bool lineBreaks = true);
 void DataToHexString(int indent, uint32_t startAddr, const uint8_t* data, size_t size, std::string* output);
 
 std::string StringFromFormat(const char* format, ...);

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -436,12 +436,12 @@ void DirectoryFileHandle::Close() {
 #ifdef _WIN32
 		Seek((s32)needsTrunc_, FILEMOVE_BEGIN);
 		if (SetEndOfFile(hFile) == 0) {
-			ERROR_LOG_REPORT(Log::FileSystem, "Failed to truncate file to %d bytes", needsTrunc_);
+			ERROR_LOG_REPORT(Log::FileSystem, "Failed to truncate file to %d bytes", (int)needsTrunc_);
 		}
 #elif !PPSSPP_PLATFORM(SWITCH)
 		// Note: it's not great that Switch cannot truncate appropriately...
 		if (ftruncate(hFile, (off_t)needsTrunc_) != 0) {
-			ERROR_LOG_REPORT(Log::FileSystem, "Failed to truncate file to %d bytes", needsTrunc_);
+			ERROR_LOG_REPORT(Log::FileSystem, "Failed to truncate file to %d bytes", (int)needsTrunc_);
 		}
 #endif
 	}

--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -678,7 +678,7 @@ int Atrac::SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels,
 	outputChannels_ = outputChannels;
 
 	if (outputChannels != track_.channels) {
-		WARN_LOG(Log::ME, "outputChannels %d doesn't match track_.channels %d", outputChannels, track_.channels);
+		WARN_LOG(Log::ME, "Atrac::SetData: outputChannels %d doesn't match track_.channels %d", outputChannels, track_.channels);
 	}
 
 	first_.addr = buffer;
@@ -699,7 +699,8 @@ int Atrac::SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels,
 	if (track_.codecType != PSP_MODE_AT_3 && track_.codecType != PSP_MODE_AT_3_PLUS) {
 		// Shouldn't have gotten here, Analyze() checks this.
 		bufferState_ = ATRAC_STATUS_NO_DATA;
-		return hleReportError(Log::ME, SCE_ERROR_ATRAC_UNKNOWN_FORMAT, "unexpected codec type in set data");
+		ERROR_LOG(Log::ME, "unexpected codec type %d in set data", track_.codecType);
+		return SCE_ERROR_ATRAC_UNKNOWN_FORMAT;
 	}
 
 	if (bufferState_ == ATRAC_STATUS_ALL_DATA_LOADED || bufferState_ == ATRAC_STATUS_HALFWAY_BUFFER) {
@@ -727,7 +728,8 @@ int Atrac::SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels,
 		Memory::Memcpy(dataBuf_, buffer, copybytes, "AtracSetData");
 	}
 	CreateDecoder();
-	return hleLogInfo(Log::ME, successCode, "%s %s (%d channels) audio", codecName, channelName, track_.channels);
+	INFO_LOG(Log::ME, "Atrac::SetData (buffer=%08x, readSize=%d, bufferSize=%d): %s %s (%d channels) audio", buffer, readSize, bufferSize, codecName, channelName, track_.channels);
+	return successCode;
 }
 
 u32 Atrac::SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) {

--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -743,12 +743,12 @@ int AtracBase::GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) {
 		// Writes zeroes in this error case.
 		*fileOffset = 0;
 		*desiredSize = 0;
-		return hleLogWarning(Log::ME, SCE_ERROR_ATRAC_SECOND_BUFFER_NOT_NEEDED, "not needed");
+		return SCE_ERROR_ATRAC_SECOND_BUFFER_NOT_NEEDED;
 	}
 
 	*fileOffset = track_.FileOffsetBySample(track_.loopEndSample - track_.firstSampleOffset);
 	*desiredSize = track_.fileSize - *fileOffset;
-	return hleLogDebug(Log::ME, 0);
+	return 0;
 }
 
 void Atrac::GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) {

--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -249,23 +249,24 @@ int Atrac::Analyze(u32 addr, u32 size) {
 
 	// 72 is about the size of the minimum required data to even be valid.
 	if (size < 72) {
-		return hleReportError(Log::ME, SCE_ERROR_ATRAC_SIZE_TOO_SMALL, "buffer too small");
+		return SCE_ERROR_ATRAC_SIZE_TOO_SMALL;
 	}
 
 	// TODO: Check the range (addr, size) instead.
 	if (!Memory::IsValidAddress(addr)) {
-		return hleReportWarning(Log::ME, SCE_KERNEL_ERROR_ILLEGAL_ADDRESS, "invalid buffer address");
+		return SCE_KERNEL_ERROR_ILLEGAL_ADDRESS;
 	}
 
 	// TODO: Validate stuff.
 	if (Memory::ReadUnchecked_U32(addr) != RIFF_CHUNK_MAGIC) {
-		return hleReportError(Log::ME, SCE_ERROR_ATRAC_UNKNOWN_FORMAT, "invalid RIFF header");
+		ERROR_LOG(Log::ME, "Couldn't find RIFF header");
+		return SCE_ERROR_ATRAC_UNKNOWN_FORMAT;
 	}
 
 	int retval = AnalyzeAtracTrack(addr, size, &track_);
 	first_._filesize_dontuse = track_.fileSize;
 	track_.DebugLog();
-	return hleLogDebugOrError(Log::ME, retval);
+	return retval;
 }
 
 int AnalyzeAtracTrack(u32 addr, u32 size, Track *track) {

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -79,19 +79,11 @@ void Atrac2::WriteContextToPSPMem() {
 }
 
 int Atrac2::Analyze(u32 addr, u32 size) {
-	int retval = AnalyzeAtracTrack(addr, size, &track_);
-	if (retval < 0) {
-		return retval;
-	}
-	return 0;
+	return AnalyzeAtracTrack(addr, size, &track_);
 }
-int Atrac2::AnalyzeAA3(u32 addr, u32 size, u32 filesize) {
-	int retval = AnalyzeAA3Track(addr, size, filesize, &track_);
-	if (retval < 0) {
-		return retval;
-	}
 
-	return 0;
+int Atrac2::AnalyzeAA3(u32 addr, u32 size, u32 filesize) {
+	return AnalyzeAA3Track(addr, size, filesize, &track_);
 }
 
 int Atrac2::RemainingFrames() const {

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -292,7 +292,7 @@ inline R hleCallImpl(std::string_view module, std::string_view funcName, F func,
 // called by them. Use regular ERROR_LOG etc for those.
 
 #define hleLogReturnHelper(convert, t, level, res, ...) \
-	(((int)level <= MAX_LOGLEVEL) ? hleDoLog<true, convert>(t, level, (res), __FILE__, __LINE__, nullptr, ##__VA_ARGS__) : (res))
+	(((int)level <= MAX_LOGLEVEL) ? hleDoLog<true, convert>(t, level, (res), __FILE__, __LINE__, nullptr, ##__VA_ARGS__) : hleNoLog(res))
 
 #define hleLogError(t, res, ...) hleLogReturnHelper(false, t, LogLevel::LERROR, res, ##__VA_ARGS__)
 #define hleLogWarning(t, res, ...) hleLogReturnHelper(false, t, LogLevel::LWARNING, res, ##__VA_ARGS__)

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -270,7 +270,7 @@ static u32 sceAtracDecodeData(int atracID, u32 outAddr, u32 numSamplesAddr, u32 
 		if (ret == 0 && Memory::IsValidAddress(remainAddr))
 			Memory::WriteUnchecked_U32(remains, remainAddr);
 	}
-	DEBUG_LOG(Log::ME, "%08x=sceAtracDecodeData(%i, %08x, %08x[%08x], %08x[%08x], %08x[%d])", ret, atracID, outAddr, 
+	DEBUG_LOG(Log::ME, "%08x=sceAtracDecodeData(%i, %08x, %08x[%08x], %08x[%08x], %08x[%d])", ret, atracID, outAddr,
 			  numSamplesAddr, numSamples,
 			  finishFlagAddr, finish,
 			  remainAddr, remains);
@@ -464,7 +464,13 @@ static u32 sceAtracGetSecondBufferInfo(int atracID, u32 fileOffsetAddr, u32 desi
 		return hleReportError(Log::ME, SCE_KERNEL_ERROR_ILLEGAL_ADDR, "invalid addresses");
 	}
 
-	return hleLogDebugOrError(Log::ME, atrac->GetSecondBufferInfo(fileOffset, desiredSize));
+	int result = atrac->GetSecondBufferInfo(fileOffset, desiredSize);
+	switch (result) {
+	case (int)SCE_ERROR_ATRAC_SECOND_BUFFER_NOT_NEEDED:
+		return hleLogDebug(Log::ME, result);
+	default:
+		return hleLogDebugOrError(Log::ME, result);
+	}
 }
 
 static u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSampleAddr, u32 outLoopEndSampleAddr) {

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -849,9 +849,8 @@ static int sceAtracSetAA3DataAndGetID(u32 buffer, u32 bufferSize, u32 fileSize, 
 	AtracBase *atrac = allocAtrac();
 	int ret = atrac->AnalyzeAA3(buffer, bufferSize, fileSize);
 	if (ret < 0) {
-		// Already logged.
 		delete atrac;
-		return ret;
+		return hleLogError(Log::ME, ret);
 	}
 	int atracID = createAtrac(atrac);
 	if (atracID < 0) {
@@ -973,9 +972,8 @@ static int sceAtracSetAA3HalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 buf
 	AtracBase *atrac = allocAtrac();
 	int ret = atrac->AnalyzeAA3(buffer, readSize, fileSize);
 	if (ret < 0) {
-		// Already logged.
 		delete atrac;
-		return ret;
+		return hleLogError(Log::ME, ret);
 	}
 	int atracID = createAtrac(atrac);
 	if (atracID < 0) {

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -464,7 +464,7 @@ static u32 sceAtracGetSecondBufferInfo(int atracID, u32 fileOffsetAddr, u32 desi
 		return hleReportError(Log::ME, SCE_KERNEL_ERROR_ILLEGAL_ADDR, "invalid addresses");
 	}
 
-	return atrac->GetSecondBufferInfo(fileOffset, desiredSize);
+	return hleLogDebugOrError(Log::ME, atrac->GetSecondBufferInfo(fileOffset, desiredSize));
 }
 
 static u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoopStartSampleAddr, u32 outLoopEndSampleAddr) {

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -563,7 +563,7 @@ static int _AtracSetData(int atracID, u32 buffer, u32 readSize, u32 bufferSize, 
 	// SetData logs like a hle function.
 	int ret = atrac->SetData(buffer, readSize, bufferSize, outputChannels, needReturnAtracID ? atracID : 0);
 	// not sure the real delay time
-	return hleDelayResult(ret, "atrac set data", 100);
+	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
 }
 
 static u32 sceAtracSetHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 bufferSize) {

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -550,7 +550,7 @@ static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFi
 		return res;
 	}
 
-	return hleDelayResult(hleLogInfo(Log::ME, 0), "reset play pos", 3000);
+	return hleDelayResult(0, "reset play pos", 3000);
 }
 
 // Allowed to log like a HLE function, only called at the end of some.

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -735,7 +735,7 @@ public:
 
 	u32 GetAltCharCode() const { return altCharCode_; }
 
-	u32 GetOpenAllocatedAddress(int index) const { 
+	u32 GetOpenAllocatedAddress(int index) const {
 		if(index < numFonts())
 			return openAllocatedAddresses_[index];
 		return 0;
@@ -1206,7 +1206,7 @@ static int sceFontFindOptimumFont(u32 libHandle, u32 fontStylePtr, u32 errorCode
 	Font *optimumFont = 0;
 	Font *nearestFont = 0;
 	float nearestDist = std::numeric_limits<float>::infinity();
-	
+
 	if (PSP_CoreParameter().compat.flags().Fontltn12Hack && requestedStyle->fontLanguage == 2) {
 		for (size_t j = 0; j < internalFonts.size(); j++) {
 			const auto &tempmatchStyle = internalFonts[j]->GetFontStyle();
@@ -1248,10 +1248,10 @@ static int sceFontFindOptimumFont(u32 libHandle, u32 fontStylePtr, u32 errorCode
 	}
 	if (optimumFont) {
 		*errorCode = 0;
-		return hleLogInfo(Log::sceFont, GetInternalFontIndex(optimumFont) ,"");
+		return hleLogInfo(Log::sceFont, GetInternalFontIndex(optimumFont));
 	} else {
 		*errorCode = 0;
-		return hleLogInfo(Log::sceFont, 0, "");
+		return hleLogInfo(Log::sceFont, 0);
 	}
 }
 

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -507,11 +507,8 @@ static u32 sceGeSetCallback(u32 structAddr) {
 }
 
 static int sceGeUnsetCallback(u32 cbID) {
-	DEBUG_LOG(Log::sceGe, "sceGeUnsetCallback(cbid=%08x)", cbID);
-
 	if (cbID >= ARRAY_SIZE(ge_used_callbacks)) {
-		WARN_LOG(Log::sceGe, "sceGeUnsetCallback(cbid=%08x): invalid callback id", cbID);
-		return SCE_KERNEL_ERROR_INVALID_ID;
+		return hleLogWarning(Log::sceGe, SCE_KERNEL_ERROR_INVALID_ID, "invalid callback id");
 	}
 
 	if (ge_used_callbacks[cbID]) {
@@ -525,18 +522,15 @@ static int sceGeUnsetCallback(u32 cbID) {
 	}
 
 	ge_used_callbacks[cbID] = false;
-	return 0;
+	return hleLogDebug(Log::sceGe, 0);
 }
 
 // Points to 512 32-bit words, where we can probably layout the context however we want
 // unless some insane game pokes it and relies on it...
 u32 sceGeSaveContext(u32 ctxAddr) {
-	DEBUG_LOG(Log::sceGe, "sceGeSaveContext(%08x)", ctxAddr);
-
 	if (gpu->BusyDrawing()) {
-		WARN_LOG(Log::sceGe, "sceGeSaveContext(%08x): lists in process, aborting", ctxAddr);
 		// Real error code.
-		return -1;
+		return hleLogWarning(Log::sceGe, -1, "lists in process, aborting");
 	}
 
 	// Let's just dump gstate.
@@ -546,15 +540,12 @@ u32 sceGeSaveContext(u32 ctxAddr) {
 
 	// This action should probably be pushed to the end of the queue of the display thread -
 	// when we have one.
-	return 0;
+	return hleLogDebug(Log::sceGe, 0);
 }
 
 u32 sceGeRestoreContext(u32 ctxAddr) {
-	DEBUG_LOG(Log::sceGe, "sceGeRestoreContext(%08x)", ctxAddr);
-
 	if (gpu->BusyDrawing()) {
-		WARN_LOG(Log::sceGe, "sceGeRestoreContext(%08x): lists in process, aborting", ctxAddr);
-		return SCE_KERNEL_ERROR_BUSY;
+		return hleLogWarning(Log::sceGe, SCE_KERNEL_ERROR_BUSY, "lists in process, aborting");
 	}
 
 	if (Memory::IsValidAddress(ctxAddr)) {
@@ -562,7 +553,7 @@ u32 sceGeRestoreContext(u32 ctxAddr) {
 	}
 
 	gpu->ReapplyGfxState();
-	return 0;
+	return hleLogDebug(Log::sceGe, 0);
 }
 
 static int sceGeGetMtx(int type, u32 matrixPtr) {

--- a/Core/HLE/sceHprm.cpp
+++ b/Core/HLE/sceHprm.cpp
@@ -22,46 +22,38 @@
 #include "Core/MIPS/MIPS.h"
 
 static u32 sceHprmPeekCurrentKey(u32 keyAddress) {
-	DEBUG_LOG(Log::HLE,"0=sceHprmPeekCurrentKey(ptr)");
 	Memory::Write_U32(0, keyAddress);
-	return 0;
+	return hleLogDebug(Log::HLE, 0);
 }
 
 // TODO: Might make sense to reflect the headphone status of the host here,
 // if the games adjust their sound.
 static u32 sceHprmIsHeadphoneExist() {
-	DEBUG_LOG(Log::HLE, "sceHprmIsHeadphoneExist()");
-	return 0;
+	return hleLogDebug(Log::HLE, 0);
 }
 
 static u32 sceHprmIsMicrophoneExist() {
-	DEBUG_LOG(Log::HLE, "sceHprmIsMicrophoneExist()");
-	return 0;
+	return hleLogDebug(Log::HLE, 0);
 }
 
 static u32 sceHprmIsRemoteExist() {
-	DEBUG_LOG(Log::HLE, "sceHprmIsRemoteExist()");
-	return 0;
+	return hleLogDebug(Log::HLE, 0);
 }
 
 static u32 sceHprmRegisterCallback() {
-	ERROR_LOG(Log::HLE, "UNIMPL %s", __FUNCTION__);
-	return 0;
+	return hleLogError(Log::HLE, 0, "UNIMPL");
 }
 
 static u32 sceHprmUnregisterCallback() {
-	ERROR_LOG(Log::HLE, "UNIMPL %s", __FUNCTION__);
-	return 0;
+	return hleLogError(Log::HLE, 0, "UNIMPL");
 }
 
 static u32 sceHprmPeekLatch(u32 latchAddr) {
-	DEBUG_LOG(Log::HLE,"sceHprmPeekLatch latchAddr %08x",latchAddr);
-	return 0;
+	return hleLogDebug(Log::HLE,0, "latchAddr %08x", latchAddr);
 }
 
 static u32 sceHprmReadLatch(u32 latchAddr) {
-	DEBUG_LOG(Log::HLE,"sceHprmReadLatch latchAddr %08x",latchAddr);
-	return 0;
+	return hleLogDebug(Log::HLE, 0, "latchAddr %08x", latchAddr);
 }
 
 const HLEFunction sceHprm[] = 

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -365,15 +365,15 @@ int sceKernelRegisterDefaultExceptionHandler() {
 	return hleLogError(Log::sceKernel, 0, "UNIMPL");
 }
 
-void sceKernelSetGPO(u32 ledBits)
-{
+void sceKernelSetGPO(u32 ledBits) {
 	// Sets debug LEDs. Some games do interesting stuff with this, like a metronome in Parappa.
 	// Shows up as a vertical strip of LEDs at the side of the screen, if enabled.
 	g_GPOBits = ledBits;
+	DEBUG_LOG(Log::sceKernel, "sceKernelSetGPO: %08x", ledBits);
+	return hleNoLogVoid();
 }
 
-u32 sceKernelGetGPI()
-{
+u32 sceKernelGetGPI() {
 	// Always returns 0 on production systems.
 	// On developer systems, there are 8 switches that control the lower 8 bits of the return value.
 	return hleLogDebug(Log::sceKernel, g_GPIBits);

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -650,7 +650,6 @@ struct SystemStatus {
 };
 
 static int sceKernelReferSystemStatus(u32 statusPtr) {
-	DEBUG_LOG(Log::sceKernel, "sceKernelReferSystemStatus(%08x)", statusPtr);
 	auto status = PSPPointer<SystemStatus>::Create(statusPtr);
 	if (status.IsValid()) {
 		memset((SystemStatus *)status, 0, sizeof(SystemStatus));
@@ -658,7 +657,7 @@ static int sceKernelReferSystemStatus(u32 statusPtr) {
 		// TODO: Fill in the struct!
 		status.NotifyWrite("SystemStatus");
 	}
-	return 0;
+	return hleLogDebug(Log::sceKernel, 0);
 }
 
 // Unused - believed to be the returned struct from sceKernelReferThreadProfiler.

--- a/Core/HLE/sceKernel.h
+++ b/Core/HLE/sceKernel.h
@@ -181,16 +181,16 @@ public:
 				WARN_LOG(Log::sceKernel, "Kernel: Bad %s handle %d (%08x)", T::GetStaticTypeName(), handle, handle);
 			}
 			outError = T::GetMissingErrorCode();
-			return 0;
+			return nullptr;
 		} else {
 			// Previously we had a dynamic_cast here, but since RTTI was disabled traditionally,
 			// it just acted as a static cast and everything worked. This means that we will never
 			// see the Wrong type object error below, but we'll just have to live with that danger.
-			T* t = static_cast<T*>(pool[handle - handleOffset]);
+			T *t = static_cast<T *>(pool[handle - handleOffset]);
 			if (t == nullptr || t->GetIDType() != T::GetStaticIDType()) {
 				WARN_LOG(Log::sceKernel, "Kernel: Wrong object type for %d (%08x), was %s, should have been %s", handle, handle, t ? t->GetTypeName() : "null", T::GetStaticTypeName());
 				outError = T::GetMissingErrorCode();
-				return 0;
+				return nullptr;
 			}
 			outError = SCE_KERNEL_ERROR_OK;
 			return t;

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -1476,16 +1476,16 @@ SceUID sceKernelCreateVpl(const char *name, int partition, u32 attr, u32 vplSize
 			WARN_LOG_REPORT(Log::sceKernel, "sceKernelCreateVpl(): unsupported options parameter, size = %d", size);
 	}
 
-	return id;
+	return hleNoLog(id);
 }
 
-int sceKernelDeleteVpl(SceUID uid)
-{
-	DEBUG_LOG(Log::sceKernel, "sceKernelDeleteVpl(%i)", uid);
+int sceKernelDeleteVpl(SceUID uid) {
 	u32 error;
 	VPL *vpl = kernelObjects.Get<VPL>(uid, error);
-	if (vpl)
-	{
+	if (!vpl) {
+		return hleLogError(Log::sceKernel, error);
+	} else {
+		DEBUG_LOG(Log::sceKernel, "sceKernelDeleteVpl(%i)", uid);
 		bool wokeThreads = __KernelClearVplThreads(vpl, SCE_KERNEL_ERROR_WAIT_DELETE);
 		if (wokeThreads)
 			hleReSchedule("vpl deleted");
@@ -1495,10 +1495,8 @@ int sceKernelDeleteVpl(SceUID uid)
 		if (alloc)
 			alloc->Free(vpl->address);
 		kernelObjects.Destroy<VPL>(uid);
-		return 0;
+		return hleNoLog(0);
 	}
-	else
-		return error;
 }
 
 // Returns false for invalid parameters (e.g. don't check callbacks, etc.)
@@ -1650,7 +1648,7 @@ int sceKernelTryAllocateVpl(SceUID uid, u32 size, u32 addrPtr)
 {
 	u32 error;
 	__KernelAllocateVpl(uid, size, addrPtr, error, true, __FUNCTION__);
-	return error;
+	return hleLogDebug(Log::sceKernel, error);
 }
 
 int sceKernelFreeVpl(SceUID uid, u32 addr) {

--- a/Core/HLE/sceKernelMsgPipe.cpp
+++ b/Core/HLE/sceKernelMsgPipe.cpp
@@ -715,7 +715,7 @@ int sceKernelCreateMsgPipe(const char *name, int partition, u32 attr, u32 size, 
 			WARN_LOG_REPORT(Log::sceKernel, "sceKernelCreateMsgPipe(%s) unsupported options parameter, size = %d", name, optionsSize);
 	}
 
-	return id;
+	return hleNoLog(id);
 }
 
 int sceKernelDeleteMsgPipe(SceUID uid)
@@ -724,10 +724,8 @@ int sceKernelDeleteMsgPipe(SceUID uid)
 
 	u32 error;
 	MsgPipe *m = kernelObjects.Get<MsgPipe>(uid, error);
-	if (!m)
-	{
-		ERROR_LOG(Log::sceKernel, "sceKernelDeleteMsgPipe(%i) - ERROR %08x", uid, error);
-		return error;
+	if (!m) {
+		return hleLogError(Log::sceKernel, error, "bad msgpipe id");
 	}
 
 	hleEatCycles(3100);
@@ -806,47 +804,47 @@ int sceKernelSendMsgPipe(SceUID uid, u32 sendBufAddr, u32 sendSize, u32 waitMode
 {
 	u32 error = __KernelValidateSendMsgPipe(uid, sendBufAddr, sendSize, waitMode, resultAddr);
 	if (error != 0) {
-		return error;
+		return hleLogError(Log::sceKernel, error);
 	}
 	MsgPipe *m = kernelObjects.Get<MsgPipe>(uid, error);
 	if (!m) {
-		return hleLogError(Log::sceKernel, error, "ERROR %08x", error);
+		return hleLogError(Log::sceKernel, error, "bad msgpipe id");
 	}
 
-	DEBUG_LOG(Log::sceKernel, "sceKernelSendMsgPipe(id=%i, addr=%08x, size=%i, mode=%i, result=%08x, timeout=%08x)", uid, sendBufAddr, sendSize, waitMode, resultAddr, timeoutPtr);
-	return __KernelSendMsgPipe(m, sendBufAddr, sendSize, waitMode, resultAddr, timeoutPtr, false, false);
+	int result = __KernelSendMsgPipe(m, sendBufAddr, sendSize, waitMode, resultAddr, timeoutPtr, false, false);
+	return hleLogDebug(Log::sceKernel, result);
 }
 
 int sceKernelSendMsgPipeCB(SceUID uid, u32 sendBufAddr, u32 sendSize, u32 waitMode, u32 resultAddr, u32 timeoutPtr)
 {
 	u32 error = __KernelValidateSendMsgPipe(uid, sendBufAddr, sendSize, waitMode, resultAddr);
 	if (error != 0) {
-		return error;
+		return hleLogError(Log::sceKernel, error);
 	}
 	MsgPipe *m = kernelObjects.Get<MsgPipe>(uid, error);
 	if (!m) {
-		return hleLogError(Log::sceKernel, error, "ERROR %08x", error);
+		return hleLogError(Log::sceKernel, error, "bad msgpipe id");
 	}
 
-	DEBUG_LOG(Log::sceKernel, "sceKernelSendMsgPipeCB(id=%i, addr=%08x, size=%i, mode=%i, result=%08x, timeout=%08x)", uid, sendBufAddr, sendSize, waitMode, resultAddr, timeoutPtr);
 	// TODO: Verify callback behavior.
 	hleCheckCurrentCallbacks();
-	return __KernelSendMsgPipe(m, sendBufAddr, sendSize, waitMode, resultAddr, timeoutPtr, true, false);
+	int result = __KernelSendMsgPipe(m, sendBufAddr, sendSize, waitMode, resultAddr, timeoutPtr, true, false);
+	return hleLogDebug(Log::sceKernel, result);
 }
 
 int sceKernelTrySendMsgPipe(SceUID uid, u32 sendBufAddr, u32 sendSize, u32 waitMode, u32 resultAddr)
 {
 	u32 error = __KernelValidateSendMsgPipe(uid, sendBufAddr, sendSize, waitMode, resultAddr, true);
 	if (error != 0) {
-		return error;
+		return hleLogError(Log::sceKernel, error);
 	}
 	MsgPipe *m = kernelObjects.Get<MsgPipe>(uid, error);
 	if (!m) {
-		return hleLogError(Log::sceKernel, error, "ERROR %08x, couldn't find msgpipe", error);
+		return hleLogError(Log::sceKernel, error, "bad msgpipe id");
 	}
 
-	DEBUG_LOG(Log::sceKernel, "sceKernelTrySendMsgPipe(id=%i, addr=%08x, size=%i, mode=%i, result=%08x)", uid, sendBufAddr, sendSize, waitMode, resultAddr);
-	return __KernelSendMsgPipe(m, sendBufAddr, sendSize, waitMode, resultAddr, 0, false, true);
+	int result = __KernelSendMsgPipe(m, sendBufAddr, sendSize, waitMode, resultAddr, 0, false, true);
+	return hleLogDebug(Log::sceKernel, result);
 }
 
 static int __KernelValidateReceiveMsgPipe(SceUID uid, u32 receiveBufAddr, u32 receiveSize, int waitMode, u32 resultAddr, bool tryMode = false)
@@ -910,47 +908,47 @@ int sceKernelReceiveMsgPipe(SceUID uid, u32 receiveBufAddr, u32 receiveSize, u32
 {
 	u32 error = __KernelValidateReceiveMsgPipe(uid, receiveBufAddr, receiveSize, waitMode, resultAddr);
 	if (error != 0) {
-		return error;
+		return hleLogError(Log::sceKernel, error);
 	}
 	MsgPipe *m = kernelObjects.Get<MsgPipe>(uid, error);
 	if (!m) {
-		return hleLogError(Log::sceKernel, error, "ERROR %08x", error);
+		return hleLogError(Log::sceKernel, error, "bad msgpipe id");
 	}
 
-	DEBUG_LOG(Log::sceKernel, "sceKernelReceiveMsgPipe(%i, %08x, %i, %i, %08x, %08x)", uid, receiveBufAddr, receiveSize, waitMode, resultAddr, timeoutPtr);
-	return __KernelReceiveMsgPipe(m, receiveBufAddr, receiveSize, waitMode, resultAddr, timeoutPtr, false, false);
+	int result = __KernelReceiveMsgPipe(m, receiveBufAddr, receiveSize, waitMode, resultAddr, timeoutPtr, false, false);
+	return hleLogDebug(Log::sceKernel, result);
 }
 
 int sceKernelReceiveMsgPipeCB(SceUID uid, u32 receiveBufAddr, u32 receiveSize, u32 waitMode, u32 resultAddr, u32 timeoutPtr)
 {
 	u32 error = __KernelValidateReceiveMsgPipe(uid, receiveBufAddr, receiveSize, waitMode, resultAddr);
 	if (error != 0) {
-		return error;
+		return hleLogError(Log::sceKernel, error);
 	}
 	MsgPipe *m = kernelObjects.Get<MsgPipe>(uid, error);
 	if (!m) {
-		return hleLogError(Log::sceKernel, error, "ERROR %08x", error);
+		return hleLogError(Log::sceKernel, error, "bad msgpipe id");
 	}
 
-	DEBUG_LOG(Log::sceKernel, "sceKernelReceiveMsgPipeCB(%i, %08x, %i, %i, %08x, %08x)", uid, receiveBufAddr, receiveSize, waitMode, resultAddr, timeoutPtr);
 	// TODO: Verify callback behavior.
 	hleCheckCurrentCallbacks();
-	return __KernelReceiveMsgPipe(m, receiveBufAddr, receiveSize, waitMode, resultAddr, timeoutPtr, true, false);
+	int result = __KernelReceiveMsgPipe(m, receiveBufAddr, receiveSize, waitMode, resultAddr, timeoutPtr, true, false);
+	return hleLogDebug(Log::sceKernel, result);
 }
 
 int sceKernelTryReceiveMsgPipe(SceUID uid, u32 receiveBufAddr, u32 receiveSize, u32 waitMode, u32 resultAddr)
 {
 	u32 error = __KernelValidateReceiveMsgPipe(uid, receiveBufAddr, receiveSize, waitMode, resultAddr, true);
 	if (error != 0) {
-		return error;
+		return hleLogError(Log::sceKernel, error);
 	}
 	MsgPipe *m = kernelObjects.Get<MsgPipe>(uid, error);
 	if (!m) {
-		return hleLogError(Log::sceKernel, error, "ERROR %08x", error);
+		return hleLogError(Log::sceKernel, error, "bad msgpipe id");
 	}
 
-	DEBUG_LOG(Log::sceKernel, "sceKernelTryReceiveMsgPipe(%i, %08x, %i, %i, %08x)", uid, receiveBufAddr, receiveSize, waitMode, resultAddr);
-	return __KernelReceiveMsgPipe(m, receiveBufAddr, receiveSize, waitMode, resultAddr, 0, false, true);
+	int result = __KernelReceiveMsgPipe(m, receiveBufAddr, receiveSize, waitMode, resultAddr, 0, false, true);
+	return hleLogDebug(Log::sceKernel, result);
 }
 
 int sceKernelCancelMsgPipe(SceUID uid, u32 numSendThreadsAddr, u32 numReceiveThreadsAddr)
@@ -960,7 +958,7 @@ int sceKernelCancelMsgPipe(SceUID uid, u32 numSendThreadsAddr, u32 numReceiveThr
 	u32 error;
 	MsgPipe *m = kernelObjects.Get<MsgPipe>(uid, error);
 	if (!m) {
-		return hleLogError(Log::sceKernel, error, "ERROR %08x", error);
+		return hleLogError(Log::sceKernel, error, "bad msgpipe id");
 	}
 
 	hleEatCycles(1100);

--- a/Core/HLE/sceKernelTime.cpp
+++ b/Core/HLE/sceKernelTime.cpp
@@ -74,7 +74,7 @@ int sceKernelGetSystemTime(u32 sysclockPtr)
 	VERBOSE_LOG(Log::sceKernel, "sceKernelGetSystemTime(out:%16llx)", t);
 	hleEatCycles(265);
 	hleReSchedule("system time");
-	return 0;
+	return hleNoLog(0);
 }
 
 u32 sceKernelGetSystemTimeLow()

--- a/Core/HLE/sceKernelVTimer.cpp
+++ b/Core/HLE/sceKernelVTimer.cpp
@@ -270,7 +270,7 @@ u64 sceKernelGetVTimerBaseWide(SceUID uid) {
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
 	if (!vt) {
-		return hleLogError(Log::sceKernel, error, "bad timer ID");
+		return hleLogError(Log::sceKernel, -1, "bad timer ID");
 	}
 
 	return hleLogDebug(Log::sceKernel, vt->nvt.base);
@@ -294,7 +294,8 @@ u64 sceKernelGetVTimerTimeWide(SceUID uid) {
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
 	if (!vt) {
-		return hleLogError(Log::sceKernel, error, "bad timer ID");
+		// Strange error code! But, it matches tests.
+		return hleLogError(Log::sceKernel, -1, "bad timer ID. error=%08x", error);
 	}
 
 	u64 time = __getVTimerCurrentTime(vt);
@@ -333,7 +334,8 @@ u64 sceKernelSetVTimerTimeWide(SceUID uid, u64 timeClock) {
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
 	if (!vt) {
-		return hleLogError(Log::sceKernel, error, "bad timer ID");
+		// Strange error code! But, it matches tests.
+		return hleLogError(Log::sceKernel, -1, "bad timer ID. error=%08x", error);
 	}
 
 	return hleLogDebug(Log::sceKernel, __KernelSetVTimer(vt, timeClock));
@@ -359,7 +361,7 @@ u32 sceKernelStartVTimer(SceUID uid) {
 		return hleLogError(Log::sceKernel, error, "bad timer ID");
 	}
 
-	if (vt->nvt.active != 0) {
+	if (vt->nvt.active) {
 		return hleLogDebug(Log::sceKernel, 1);
 	}
 

--- a/Core/HLE/sceKernelVTimer.cpp
+++ b/Core/HLE/sceKernelVTimer.cpp
@@ -85,9 +85,9 @@ static u64 __getVTimerCurrentTime(VTimer* vt) {
 static int __KernelCancelVTimer(SceUID id) {
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(id, error);
-
-	if (!vt)
+	if (!vt) {
 		return error;
+	}
 
 	CoreTiming::UnscheduleEvent(vtimerTimer, id);
 	vt->nvt.handlerAddr = 0;
@@ -216,10 +216,8 @@ void __KernelVTimerInit() {
 
 u32 sceKernelCreateVTimer(const char *name, u32 optParamAddr) {
 	if (!name) {
-		WARN_LOG_REPORT(Log::sceKernel, "%08x=sceKernelCreateVTimer(): invalid name", SCE_KERNEL_ERROR_ERROR);
-		return SCE_KERNEL_ERROR_ERROR;
+		return hleLogWarning(Log::sceKernel, SCE_KERNEL_ERROR_ERROR, "invalid name");
 	}
-	DEBUG_LOG(Log::sceKernel, "sceKernelCreateVTimer(%s, %08x)", name, optParamAddr);
 
 	VTimer *vtimer = new VTimer;
 	SceUID id = kernelObjects.Create(vtimer);
@@ -232,21 +230,17 @@ u32 sceKernelCreateVTimer(const char *name, u32 optParamAddr) {
 	if (optParamAddr != 0) {
 		u32 size = Memory::Read_U32(optParamAddr);
 		if (size > 4)
-			WARN_LOG_REPORT(Log::sceKernel, "sceKernelCreateVTimer(%s) unsupported options parameter, size = %d", name, size);
+			WARN_LOG_REPORT_ONCE(vtimeropt, Log::sceKernel, "sceKernelCreateVTimer(%s) unsupported options parameter, size = %d", name, size);
 	}
 
-	return id;
+	return hleLogDebug(Log::sceKernel, id);
 }
 
 u32 sceKernelDeleteVTimer(SceUID uid) {
-	DEBUG_LOG(Log::sceKernel, "sceKernelDeleteVTimer(%08x)", uid);
-
 	u32 error;
 	VTimer* vt = kernelObjects.Get<VTimer>(uid, error);
-
-	if (error) {
-		WARN_LOG(Log::sceKernel, "%08x=sceKernelDeleteVTimer(%08x)", error, uid);
-		return error;
+	if (!vt) {
+		return hleLogError(Log::sceKernel, error, "bad timer ID");
 	}
 
 	for (std::list<SceUID>::iterator it = vtimers.begin(); it != vtimers.end(); ++it) {
@@ -256,71 +250,55 @@ u32 sceKernelDeleteVTimer(SceUID uid) {
 		}
 	}
 
-	return kernelObjects.Destroy<VTimer>(uid);
+	return hleLogDebugOrError(Log::sceKernel, kernelObjects.Destroy<VTimer>(uid));
 }
 
 u32 sceKernelGetVTimerBase(SceUID uid, u32 baseClockAddr) {
-	DEBUG_LOG(Log::sceKernel, "sceKernelGetVTimerBase(%08x, %08x)", uid, baseClockAddr);
-
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
-
-	if (error) {
-		WARN_LOG(Log::sceKernel, "%08x=sceKernelGetVTimerBase(%08x, %08x)", error, uid, baseClockAddr);
-		return error;
+	if (!vt) {
+		return hleLogError(Log::sceKernel, error, "bad timer ID");
 	}
 
 	if (Memory::IsValidAddress(baseClockAddr))
 		Memory::Write_U64(vt->nvt.base, baseClockAddr);
 
-	return 0;
+	return hleLogDebug(Log::sceKernel, 0);
 }
 
 u64 sceKernelGetVTimerBaseWide(SceUID uid) {
-	DEBUG_LOG(Log::sceKernel, "sceKernelGetVTimerBaseWide(%08x)", uid);
-
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
-
-	if (error) {
-		WARN_LOG(Log::sceKernel, "%08x=sceKernelGetVTimerBaseWide(%08x)", error, uid);
-		return -1;
+	if (!vt) {
+		return hleLogError(Log::sceKernel, error, "bad timer ID");
 	}
 
-	return vt->nvt.base;
+	return hleLogDebug(Log::sceKernel, vt->nvt.base);
 }
 
 u32 sceKernelGetVTimerTime(SceUID uid, u32 timeClockAddr) {
-	DEBUG_LOG(Log::sceKernel, "sceKernelGetVTimerTime(%08x, %08x)", uid, timeClockAddr);
-
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
-
-	if (error) {
-		WARN_LOG(Log::sceKernel, "%08x=sceKernelGetVTimerTime(%08x, %08x)", error, uid, timeClockAddr);
-		return error;
+	if (!vt) {
+		return hleLogError(Log::sceKernel, error, "bad timer ID");
 	}
 
 	u64 time = __getVTimerCurrentTime(vt);
 	if (Memory::IsValidAddress(timeClockAddr))
 		Memory::Write_U64(time, timeClockAddr);
 
-	return 0;
+	return hleLogDebug(Log::sceKernel, 0);
 }
 
 u64 sceKernelGetVTimerTimeWide(SceUID uid) {
-	DEBUG_LOG(Log::sceKernel, "sceKernelGetVTimerTimeWide(%08x)", uid);
-
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
-
-	if (error) {
-		WARN_LOG(Log::sceKernel, "%08x=sceKernelGetVTimerTimeWide(%08x)", error, uid);
-		return -1;
+	if (!vt) {
+		return hleLogError(Log::sceKernel, error, "bad timer ID");
 	}
 
 	u64 time = __getVTimerCurrentTime(vt);
-	return time;
+	return hleLogDebug(Log::sceKernel, time);
 }
 
 static u64 __KernelSetVTimer(VTimer *vt, u64 time) {
@@ -334,39 +312,31 @@ static u64 __KernelSetVTimer(VTimer *vt, u64 time) {
 }
 
 u32 sceKernelSetVTimerTime(SceUID uid, u32 timeClockAddr) {
-	DEBUG_LOG(Log::sceKernel, "sceKernelSetVTimerTime(%08x, %08x)", uid, timeClockAddr);
-
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
-
-	if (error) {
-		WARN_LOG(Log::sceKernel, "%08x=sceKernelSetVTimerTime(%08x, %08x)", error, uid, timeClockAddr);
-		return error;
+	if (!vt) {
+		return hleLogError(Log::sceKernel, error, "bad timer ID");
 	}
 
 	u64 time = Memory::Read_U64(timeClockAddr);
 	if (Memory::IsValidAddress(timeClockAddr))
 		Memory::Write_U64(__KernelSetVTimer(vt, time), timeClockAddr);
 
-	return 0;
+	return hleLogDebug(Log::sceKernel, 0);
 }
 
 u64 sceKernelSetVTimerTimeWide(SceUID uid, u64 timeClock) {
 	if (__IsInInterrupt()) {
-		WARN_LOG(Log::sceKernel, "sceKernelSetVTimerTimeWide(%08x, %llu): in interrupt", uid, timeClock);
-		return -1;
+		return hleLogWarning(Log::sceKernel, -1, "in interrupt");
 	}
-	DEBUG_LOG(Log::sceKernel, "sceKernelSetVTimerTimeWide(%08x, %llu)", uid, timeClock);
 
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
-
-	if (error || vt == NULL) {
-		WARN_LOG(Log::sceKernel, "%08x=sceKernelSetVTimerTimeWide(%08x, %llu)", error, uid, timeClock);
-		return -1;
+	if (!vt) {
+		return hleLogError(Log::sceKernel, error, "bad timer ID");
 	}
 
-	return __KernelSetVTimer(vt, timeClock);
+	return hleLogDebug(Log::sceKernel, __KernelSetVTimer(vt, timeClock));
 }
 
 static void __startVTimer(VTimer *vt) {
@@ -379,26 +349,22 @@ static void __startVTimer(VTimer *vt) {
 
 u32 sceKernelStartVTimer(SceUID uid) {
 	hleEatCycles(12200);
-
 	if (uid == runningVTimer) {
-		WARN_LOG(Log::sceKernel, "sceKernelStartVTimer(%08x): invalid vtimer", uid);
-		return SCE_KERNEL_ERROR_ILLEGAL_VTID;
+		return hleLogWarning(Log::sceKernel, SCE_KERNEL_ERROR_ILLEGAL_VTID, "invalid vtimer - can't be runningVTimer");
 	}
-
-	DEBUG_LOG(Log::sceKernel, "sceKernelStartVTimer(%08x)", uid);
 
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
-
-	if (vt)	{
-		if (vt->nvt.active != 0)
-			return 1;
-
-		__startVTimer(vt);
-		return 0;
+	if (!vt) {
+		return hleLogError(Log::sceKernel, error, "bad timer ID");
 	}
 
-	return error;
+	if (vt->nvt.active != 0) {
+		return hleLogDebug(Log::sceKernel, 1);
+	}
+
+	__startVTimer(vt);
+	return hleLogDebug(Log::sceKernel, 0);
 }
 
 static void __stopVTimer(VTimer *vt) {
@@ -410,41 +376,35 @@ static void __stopVTimer(VTimer *vt) {
 
 u32 sceKernelStopVTimer(SceUID uid) {
 	if (uid == runningVTimer) {
-		WARN_LOG(Log::sceKernel, "sceKernelStopVTimer(%08x): invalid vtimer", uid);
-		return SCE_KERNEL_ERROR_ILLEGAL_VTID;
+		return hleLogWarning(Log::sceKernel, SCE_KERNEL_ERROR_ILLEGAL_VTID, "invalid vtimer - can't be runningVTimer");
 	}
-	DEBUG_LOG(Log::sceKernel, "sceKernelStopVTimer(%08x)", uid);
 
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
-
-	if (vt)	{
-		if (vt->nvt.active == 0)
-			return 0;
-
-		__stopVTimer(vt);
-		return 1;
+	if (!vt) {
+		return hleLogError(Log::sceKernel, error, "bad timer ID");
 	}
 
-	return error;
+	if (vt->nvt.active == 0) {
+		return hleLogDebug(Log::sceKernel, 0);
+	}
+
+	__stopVTimer(vt);
+	return hleLogDebug(Log::sceKernel, 1);
 }
 
 u32 sceKernelSetVTimerHandler(SceUID uid, u32 scheduleAddr, u32 handlerFuncAddr, u32 commonAddr) {
 	hleEatCycles(900);
 	if (uid == runningVTimer) {
-		WARN_LOG(Log::sceKernel, "sceKernelSetVTimerHandler(%08x, %08x, %08x, %08x): invalid vtimer", uid, scheduleAddr, handlerFuncAddr, commonAddr);
-		return SCE_KERNEL_ERROR_ILLEGAL_VTID;
+		return hleLogWarning(Log::sceKernel, SCE_KERNEL_ERROR_ILLEGAL_VTID, "invalid vtimer - can't be runningVTimer");
 	}
 
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
-
-	if (error) {
-		WARN_LOG(Log::sceKernel, "%08x=sceKernelSetVTimerHandler(%08x, %08x, %08x, %08x)", error, uid, scheduleAddr, handlerFuncAddr, commonAddr);
-		return error;
+	if (!vt) {
+		return hleLogError(Log::sceKernel, error, "bad timer ID");
 	}
 
-	DEBUG_LOG(Log::sceKernel, "sceKernelSetVTimerHandler(%08x, %08x, %08x, %08x)", uid, scheduleAddr, handlerFuncAddr, commonAddr);
 	hleEatCycles(2000);
 
 	u64 schedule = Memory::Read_U64(scheduleAddr);
@@ -456,25 +416,20 @@ u32 sceKernelSetVTimerHandler(SceUID uid, u32 scheduleAddr, u32 handlerFuncAddr,
 		__KernelScheduleVTimer(vt, vt->nvt.schedule);
 	}
 
-	return 0;
+	return hleLogDebug(Log::sceKernel, 0);
 }
 
 u32 sceKernelSetVTimerHandlerWide(SceUID uid, u64 schedule, u32 handlerFuncAddr, u32 commonAddr) {
 	hleEatCycles(900);
 	if (uid == runningVTimer) {
-		WARN_LOG(Log::sceKernel, "sceKernelSetVTimerHandlerWide(%08x, %llu, %08x, %08x): invalid vtimer", uid, schedule, handlerFuncAddr, commonAddr);
-		return SCE_KERNEL_ERROR_ILLEGAL_VTID;
+		return hleLogWarning(Log::sceKernel, SCE_KERNEL_ERROR_ILLEGAL_VTID, "invalid vtimer - can't be runningVTimer");
 	}
 
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
-
-	if (error) {
-		WARN_LOG(Log::sceKernel, "%08x=sceKernelSetVTimerHandlerWide(%08x, %llu, %08x, %08x)", error, uid, schedule, handlerFuncAddr, commonAddr);
-		return error;
+	if (!vt) {
+		return hleLogError(Log::sceKernel, error, "bad timer ID");
 	}
-
-	DEBUG_LOG(Log::sceKernel, "sceKernelSetVTimerHandlerWide(%08x, %llu, %08x, %08x)", uid, schedule, handlerFuncAddr, commonAddr);
 
 	vt->nvt.handlerAddr = handlerFuncAddr;
 	if (handlerFuncAddr) {
@@ -484,30 +439,23 @@ u32 sceKernelSetVTimerHandlerWide(SceUID uid, u64 schedule, u32 handlerFuncAddr,
 		__KernelScheduleVTimer(vt, vt->nvt.schedule);
 	}
 
-	return 0;
+	return hleLogDebug(Log::sceKernel, 0);
 }
 
 u32 sceKernelCancelVTimerHandler(SceUID uid) {
 	if (uid == runningVTimer) {
-		WARN_LOG(Log::sceKernel, "sceKernelCancelVTimerHandler(%08x): invalid vtimer", uid);
-		return SCE_KERNEL_ERROR_ILLEGAL_VTID;
+		return hleLogWarning(Log::sceKernel, SCE_KERNEL_ERROR_ILLEGAL_VTID, "invalid vtimer - can't be runningVTimer");
 	}
 
-	DEBUG_LOG(Log::sceKernel, "sceKernelCancelVTimerHandler(%08x)", uid);
-
 	//__cancelVTimer checks if uid is valid
-	return __KernelCancelVTimer(uid);
+	return hleLogDebugOrError(Log::sceKernel, __KernelCancelVTimer(uid));
 }
 
 u32 sceKernelReferVTimerStatus(SceUID uid, u32 statusAddr) {
-	DEBUG_LOG(Log::sceKernel, "sceKernelReferVTimerStatus(%08x, %08x)", uid, statusAddr);
-
 	u32 error;
 	VTimer *vt = kernelObjects.Get<VTimer>(uid, error);
-
-	if (error) {
-		WARN_LOG(Log::sceKernel, "%08x=sceKernelReferVTimerStatus(%08x, %08x)", error, uid, statusAddr);
-		return error;
+	if (!vt) {
+		return hleLogError(Log::sceKernel, error, "bad timer ID");
 	}
 
 	if (Memory::IsValidAddress(statusAddr)) {
@@ -517,10 +465,11 @@ u32 sceKernelReferVTimerStatus(SceUID uid, u32 statusAddr) {
 		Memory::Memcpy(statusAddr, &status, std::min(size, (u32)sizeof(status)), "VTimerStatus");
 	}
 
-	return 0;
+	return hleLogDebug(Log::sceKernel, 0);
 }
 
 // Not sure why this is exposed...
 void _sceKernelReturnFromTimerHandler() {
 	ERROR_LOG_REPORT(Log::sceKernel,"_sceKernelReturnFromTimerHandler - should not be called!");
+	return hleNoLogVoid();
 }

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -472,36 +472,33 @@ static u32 __MpegRingbufferQueryMemSize(int packets) {
 
 static u32 sceMpegRingbufferQueryMemSize(int packets) {
 	u32 size = __MpegRingbufferQueryMemSize(packets);
-	DEBUG_LOG(Log::ME, "%i = sceMpegRingbufferQueryMemSize(%i)", size, packets);
-	return size;
+	return hleLogDebug(Log::ME, size);
 }
-
 
 static u32 sceMpegRingbufferConstruct(u32 ringbufferAddr, u32 numPackets, u32 data, u32 size, u32 callbackAddr, u32 callbackArg) {
 	if (!Memory::IsValidAddress(ringbufferAddr)) {
 		ERROR_LOG_REPORT(Log::ME, "sceMpegRingbufferConstruct(%08x, %i, %08x, %08x, %08x, %08x): bad ringbuffer, should crash", ringbufferAddr, numPackets, data, size, callbackAddr, callbackArg);
-		return SCE_KERNEL_ERROR_ILLEGAL_ADDRESS;
+		return hleNoLog(SCE_KERNEL_ERROR_ILLEGAL_ADDRESS);
 	}
 
 	if ((int)size < 0) {
 		ERROR_LOG_REPORT(Log::ME, "sceMpegRingbufferConstruct(%08x, %i, %08x, %08x, %08x, %08x): invalid size", ringbufferAddr, numPackets, data, size, callbackAddr, callbackArg);
-		return ERROR_MPEG_NO_MEMORY;
+		return hleNoLog(ERROR_MPEG_NO_MEMORY);
 	}
 
 	if (__MpegRingbufferQueryMemSize(numPackets) > size) {
 		if (numPackets < 0x00100000) {
 			ERROR_LOG_REPORT(Log::ME, "sceMpegRingbufferConstruct(%08x, %i, %08x, %08x, %08x, %08x): too many packets for buffer", ringbufferAddr, numPackets, data, size, callbackAddr, callbackArg);
-			return ERROR_MPEG_NO_MEMORY;
+			return hleNoLog(ERROR_MPEG_NO_MEMORY);
 		} else {
 			// The PSP's firmware allows some cases here, due to a bug in its validation.
 			ERROR_LOG_REPORT(Log::ME, "sceMpegRingbufferConstruct(%08x, %i, %08x, %08x, %08x, %08x): too many packets for buffer, bogus size", ringbufferAddr, numPackets, data, size, callbackAddr, callbackArg);
 		}
 	}
 
-	DEBUG_LOG(Log::ME, "sceMpegRingbufferConstruct(%08x, %i, %08x, %08x, %08x, %08x)", ringbufferAddr, numPackets, data, size, callbackAddr, callbackArg);
 	auto ring = PSPPointer<SceMpegRingBuffer>::Create(ringbufferAddr);
 	InitRingbuffer(ring, numPackets, data, size, callbackAddr, callbackArg);
-	return 0;
+	return hleLogDebug(Log::ME, 0);
 }
 
 static u32 MpegRequiredMem() {
@@ -511,16 +508,13 @@ static u32 MpegRequiredMem() {
 	return MPEG_MEMSIZE_0105;
 }
 
-static u32 sceMpegCreate(u32 mpegAddr, u32 dataPtr, u32 size, u32 ringbufferAddr, u32 frameWidth, u32 mode, u32 ddrTop)
-{
+static u32 sceMpegCreate(u32 mpegAddr, u32 dataPtr, u32 size, u32 ringbufferAddr, u32 frameWidth, u32 mode, u32 ddrTop) {
 	if (!Memory::IsValidAddress(mpegAddr)) {
-		WARN_LOG(Log::ME, "sceMpegCreate(%08x, %08x, %i, %08x, %i, %i, %i): invalid addresses", mpegAddr, dataPtr, size, ringbufferAddr, frameWidth, mode, ddrTop);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "invalid addresses");
 	}
 
 	if (size < MpegRequiredMem()) {
-		WARN_LOG(Log::ME, "ERROR_MPEG_NO_MEMORY=sceMpegCreate(%08x, %08x, %i, %08x, %i, %i, %i)", mpegAddr, dataPtr, size, ringbufferAddr, frameWidth, mode, ddrTop);
-		return ERROR_MPEG_NO_MEMORY;
+		return hleLogWarning(Log::ME, ERROR_MPEG_NO_MEMORY);
 	}
 
 	auto ringbuffer = PSPPointer<SceMpegRingBuffer>::Create(ringbufferAddr);
@@ -579,12 +573,10 @@ static u32 sceMpegCreate(u32 mpegAddr, u32 dataPtr, u32 size, u32 ringbufferAddr
 	return hleDelayResult(hleLogInfo(Log::ME, 0), "mpeg create", 29000);
 }
 
-static int sceMpegDelete(u32 mpeg)
-{
+static int sceMpegDelete(u32 mpeg) {
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegDelete(%08x): bad mpeg handle", mpeg);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
 
 	delete ctx;
@@ -597,14 +589,12 @@ static int sceMpegDelete(u32 mpeg)
 static int sceMpegAvcDecodeMode(u32 mpeg, u32 modeAddr)
 {
 	if (!Memory::IsValidAddress(modeAddr)) {
-		WARN_LOG(Log::ME, "sceMpegAvcDecodeMode(%08x, %08x): invalid addresses", mpeg, modeAddr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "invalid addresses");
 	}
 
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegAvcDecodeMode(%08x, %08x): bad mpeg handle", mpeg, modeAddr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
 
 	DEBUG_LOG(Log::ME, "sceMpegAvcDecodeMode(%08x, %08x)", mpeg, modeAddr);
@@ -622,47 +612,37 @@ static int sceMpegAvcDecodeMode(u32 mpeg, u32 modeAddr)
 static int sceMpegQueryStreamOffset(u32 mpeg, u32 bufferAddr, u32 offsetAddr)
 {
 	if (!Memory::IsValidAddress(bufferAddr) || !Memory::IsValidAddress(offsetAddr)) {
-		ERROR_LOG(Log::ME, "sceMpegQueryStreamOffset(%08x, %08x, %08x): invalid addresses", mpeg, bufferAddr, offsetAddr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "invalid addresses");
 	}
 
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegQueryStreamOffset(%08x, %08x, %08x): bad mpeg handle", mpeg, bufferAddr, offsetAddr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
-
-	DEBUG_LOG(Log::ME, "sceMpegQueryStreamOffset(%08x, %08x, %08x)", mpeg, bufferAddr, offsetAddr);
 
 	// Kinda destructive, no? Shouldn't this just do what sceMpegQueryStreamSize does?
 	AnalyzeMpeg(Memory::GetPointerWriteUnchecked(bufferAddr), Memory::ValidSize(bufferAddr, 32768), ctx);
 
 	if (ctx->mpegMagic != PSMF_MAGIC) {
-		ERROR_LOG(Log::ME, "sceMpegQueryStreamOffset: Bad PSMF magic");
-		Memory::Write_U32(0, offsetAddr);
-		return ERROR_MPEG_INVALID_VALUE;
+		Memory::WriteUnchecked_U32(0, offsetAddr);
+		return hleLogError(Log::ME, ERROR_MPEG_INVALID_VALUE, "Bad PSMF magic");
 	} else if (ctx->mpegVersion < 0) {
-		ERROR_LOG(Log::ME, "sceMpegQueryStreamOffset: Bad version");
-		Memory::Write_U32(0, offsetAddr);
-		return ERROR_MPEG_BAD_VERSION;
+		Memory::WriteUnchecked_U32(0, offsetAddr);
+		return hleLogError(Log::ME, ERROR_MPEG_BAD_VERSION, "Bad version");
 	} else if ((ctx->mpegOffset & 2047) != 0 || ctx->mpegOffset == 0) {
-		ERROR_LOG(Log::ME, "sceMpegQueryStreamOffset: Bad offset");
-		Memory::Write_U32(0, offsetAddr);
-		return ERROR_MPEG_INVALID_VALUE;
+		Memory::WriteUnchecked_U32(0, offsetAddr);
+		return hleLogError(Log::ME, ERROR_MPEG_INVALID_VALUE, "Bad offset");
 	}
 
-	Memory::Write_U32(ctx->mpegOffset, offsetAddr);
-	return 0;
+	Memory::WriteUnchecked_U32(ctx->mpegOffset, offsetAddr);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static u32 sceMpegQueryStreamSize(u32 bufferAddr, u32 sizeAddr)
 {
 	if (!Memory::IsValidAddress(bufferAddr) || !Memory::IsValidAddress(sizeAddr)) {
-		ERROR_LOG(Log::ME, "sceMpegQueryStreamSize(%08x, %08x): invalid addresses", bufferAddr, sizeAddr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "invalid addresses");
 	}
-
-	DEBUG_LOG(Log::ME, "sceMpegQueryStreamSize(%08x, %08x)", bufferAddr, sizeAddr);
 
 	MpegContext ctx;
 	ctx.mediaengine = nullptr;  // makes sure we don't actually load the stream.
@@ -671,28 +651,23 @@ static u32 sceMpegQueryStreamSize(u32 bufferAddr, u32 sizeAddr)
 	AnalyzeMpeg(Memory::GetPointerWriteUnchecked(bufferAddr), Memory::ValidSize(bufferAddr, 32768), &ctx);
 
 	if (ctx.mpegMagic != PSMF_MAGIC) {
-		ERROR_LOG(Log::ME, "sceMpegQueryStreamSize: Bad PSMF magic");
-		Memory::Write_U32(0, sizeAddr);
-		return ERROR_MPEG_INVALID_VALUE;
+		Memory::WriteUnchecked_U32(0, sizeAddr);
+		return hleLogError(Log::ME, ERROR_MPEG_INVALID_VALUE, "Bad PSMF magic");
 	} else if ((ctx.mpegOffset & 2047) != 0 ) {
-		ERROR_LOG(Log::ME, "sceMpegQueryStreamSize: Bad offset");
-		Memory::Write_U32(0, sizeAddr);
-		return ERROR_MPEG_INVALID_VALUE;
+		Memory::WriteUnchecked_U32(0, sizeAddr);
+		return hleLogError(Log::ME, ERROR_MPEG_INVALID_VALUE, "Bad offset %08x", ctx.mpegOffset);
 	}
 
-	Memory::Write_U32(ctx.mpegStreamSize, sizeAddr);
-	return 0;
+	Memory::WriteUnchecked_U32(ctx.mpegStreamSize, sizeAddr);
+	return hleLogDebug(Log::ME, 0);
 }
 
 static int sceMpegRegistStream(u32 mpeg, u32 streamType, u32 streamNum)
 {
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegRegistStream(%08x, %i, %i): bad mpeg handle", mpeg, streamType, streamNum);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
-
-	INFO_LOG(Log::ME, "sceMpegRegistStream(%08x, %i, %i)", mpeg, streamType, streamNum);
 
 	switch (streamType) {
 	case MPEG_AVC_STREAM:
@@ -725,49 +700,43 @@ static int sceMpegRegistStream(u32 mpeg, u32 streamType, u32 streamNum)
 	info.sid = sid;
 	info.needsReset = true;
 	ctx->streamMap[sid] = info;
-	return sid;
+	return hleLogInfo(Log::ME, sid);
 }
 
-static int sceMpegMallocAvcEsBuf(u32 mpeg)
-{
+static int sceMpegMallocAvcEsBuf(u32 mpeg) {
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegMallocAvcEsBuf(%08x): bad mpeg handle", mpeg);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
-
-	DEBUG_LOG(Log::ME, "sceMpegMallocAvcEsBuf(%08x)", mpeg);
 
 	// Doesn't actually malloc, just keeps track of a couple of flags
 	for (int i = 0; i < MPEG_DATA_ES_BUFFERS; i++) {
 		if (!ctx->esBuffers[i]) {
 			ctx->esBuffers[i] = true;
-			return i + 1;
+			return hleLogDebug(Log::ME, i + 1);
 		}
 	}
+
 	// No es buffer
-	return 0;
+	return hleLogDebug(Log::ME, 0);
 }
 
 static int sceMpegFreeAvcEsBuf(u32 mpeg, int esBuf)
 {
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegFreeAvcEsBuf(%08x, %i): bad mpeg handle", mpeg, esBuf);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
 
-	DEBUG_LOG(Log::ME, "sceMpegFreeAvcEsBuf(%08x, %i)", mpeg, esBuf);
-
 	if (esBuf == 0) {
-		return ERROR_MPEG_INVALID_VALUE;
+		return hleLogError(Log::ME, ERROR_MPEG_INVALID_VALUE);
 	}
 
 	if (esBuf >= 1 && esBuf <= MPEG_DATA_ES_BUFFERS) {
 		// TODO: Check if it's already been free'd?
 		ctx->esBuffers[esBuf - 1] = false;
 	}
-	return 0;
+	return hleLogDebug(Log::ME, 0);
 }
 
 // check the existence of pmp media context 
@@ -1127,8 +1096,7 @@ static u32 sceMpegAvcDecode(u32 mpeg, u32 auAddr, u32 frameWidth, u32 bufferAddr
 {
 	MpegContext *ctx = getMpegCtx(mpeg);
 	if (!ctx) {
-		WARN_LOG(Log::ME, "sceMpegAvcDecode(%08x, %08x, %d, %08x, %08x): bad mpeg handle", mpeg, auAddr, frameWidth, bufferAddr, initAddr);
-		return -1;
+		return hleLogWarning(Log::ME, -1, "bad mpeg handle");
 	}
 
 	if (frameWidth == 0) {  // wtf, go sudoku passes in 0xcccccccc
@@ -1144,8 +1112,7 @@ static u32 sceMpegAvcDecode(u32 mpeg, u32 auAddr, u32 frameWidth, u32 bufferAddr
 	
 	auto ringbuffer = PSPPointer<SceMpegRingBuffer>::Create(ctx->mpegRingbufferAddr);
 	if (!ringbuffer.IsValid()) {
-		ERROR_LOG(Log::ME, "Bogus mpegringbufferaddr");
-		return -1;
+		return hleLogError(Log::ME, -1, "Bogus mpegringbufferaddr");
 	}
 	
 	u32 buffer = Memory::Read_U32(bufferAddr);
@@ -1364,9 +1331,8 @@ static int sceMpegAvcDecodeYCbCr(u32 mpeg, u32 auAddr, u32 bufferAddr, u32 initA
 	if (mpegLibVersion >= 0x010A) {
 		// Sunday Vs Magazine Shuuketsu! Choujou Daikessen expect, issue #11060
 		Memory::Write_U32(1, initAddr);
-	}
-	else {	
-	// Save the current frame's status to initAddr
+	} else {	
+		// Save the current frame's status to initAddr
 		Memory::Write_U32(ctx->avc.avcFrameStatus, initAddr);
 	}
 	ctx->avc.avcDecodeResult = MPEG_AVC_DECODE_SUCCESS;

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -606,7 +606,7 @@ static int sceMpegAvcDecodeMode(u32 mpeg, u32 modeAddr)
 	} else {
 		ERROR_LOG(Log::ME, "sceMpegAvcDecodeMode(%i, %i): unknown pixelMode ", mode, pixelMode);
 	}
-	return 0;
+	return hleNoLog(0);
 }
 
 static int sceMpegQueryStreamOffset(u32 mpeg, u32 bufferAddr, u32 offsetAddr)

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -128,7 +128,7 @@ void __NetAdhocShutdown() {
 	}
 
 	NetAdhocctl_Term();
-	
+
 	if (netAdhocInited) {
 		NetAdhoc_Term();
 	}
@@ -164,7 +164,7 @@ static void __GameModeNotify(u64 userdata, int cyclesLate) {
 					__KernelResumeThreadFromWait(threadID, gameModeSocket);
 					return;
 				}
-				else 
+				else
 					INFO_LOG(Log::sceNet, "GameMode: Synchronizer (%d, %d) has started", gameModeSocket, gameModeBuffSize);
 			}
 			if (gameModeSocket < 0) {
@@ -191,7 +191,7 @@ static void __GameModeNotify(u64 userdata, int cyclesLate) {
 						auto it = gameModePeerPorts.find(gma.mac);
 						if (it != gameModePeerPorts.end())
 							port = it->second;
-							
+
 						int sent = hleCall(sceNetAdhoc, int, sceNetAdhocPdpSend, gameModeSocket, (const char*)&gma.mac, port, masterGameModeArea.data, masterGameModeArea.size, 0, ADHOC_F_NONBLOCK);
 						if (sent != ERROR_NET_ADHOC_WOULD_BLOCK) {
 							gma.dataSent = 1;
@@ -201,7 +201,7 @@ static void __GameModeNotify(u64 userdata, int cyclesLate) {
 					}
 					else if (gma.dataSent) sentcount++;
 				}
-				if (sentcount == replicaGameModeAreas.size()) 
+				if (sentcount == replicaGameModeAreas.size())
 					masterGameModeArea.dataUpdated = 0;
 			}
 			// Need to sync (send + recv) all players initial data (data from CreateMaster) after Master + All Replicas are created, and before the first UpdateMaster / UpdateReplica is called for Star Wars The Force Unleashed to show the correct players color on minimap (also prevent Starting issue on other GameMode games)
@@ -397,7 +397,7 @@ static void __AdhocctlState(u64 userdata, int cyclesLate) {
 	u32 waitVal = __KernelGetWaitValue(threadID, error);
 	if (error == 0) {
 		adhocctlState = waitVal;
-		// FIXME: It seems Adhocctl is still busy within the Adhocctl Handler function (ie. during callbacks), 
+		// FIXME: It seems Adhocctl is still busy within the Adhocctl Handler function (ie. during callbacks),
 		// so we should probably set isAdhocctlBusy to false after mispscall are fully executed (ie. in afterAction).
 		// But since Adhocctl Handler is optional, there might be cases where there are no handler thus no callback/mipcall being triggered,
 		// so we should probably need to set isAdhocctlBusy to false here too as a workaround (or may be there is internal handler by default?)
@@ -477,9 +477,9 @@ int DoBlockingPdpRecv(AdhocSocketRequest& req, s64& result) {
 	sockerr = socket_errno;
 
 	// Discard packets from IP that can't be translated into MAC address to prevent confusing the game, since the sender MAC won't be updated and may contains invalid/undefined value.
-	// TODO: In order to discard packets from unresolvable IP (can't be translated into player's MAC) properly, we'll need to manage the socket buffer ourself, 
+	// TODO: In order to discard packets from unresolvable IP (can't be translated into player's MAC) properly, we'll need to manage the socket buffer ourself,
 	//       by reading the whole available data, separates each datagram and discard unresolvable one, so we can calculate the correct number of available data to recv on GetPdpStat too.
-	//       We may also need to implement encryption (or a simple checksum will do) in order to validate the packet to findout whether it came from PPSSPP or a different App that may be sending/broadcasting data to the same port being used by a game 
+	//       We may also need to implement encryption (or a simple checksum will do) in order to validate the packet to findout whether it came from PPSSPP or a different App that may be sending/broadcasting data to the same port being used by a game
 	//       (in case the IP was resolvable but came from a different App, which will need to be discarded too)
 	if (ret != SOCKET_ERROR && !resolveIP(sin.sin_addr.s_addr, &mac)) {
 		// Remove the packet from socket buffer
@@ -920,7 +920,7 @@ int DoBlockingPtpFlush(AdhocSocketRequest& req, s64& result) {
 		else
 			result = ERROR_NET_ADHOC_TIMEOUT;
 	}
-	
+
 	if (sockerr != 0) {
 		DEBUG_LOG(Log::sceNet, "sceNetAdhocPtpFlush[%i]: Socket Error (%i)", req.id, sockerr);
 	}
@@ -1178,7 +1178,7 @@ void __NetAdhocDoState(PointerWrap &p) {
 		netAdhocGameModeEntered = false;
 		netAdhocEnterGameModeTimeout = 15000000;
 	}
-	
+
 	if (p.mode == p.MODE_READ) {
 		// Discard leftover events
 		adhocctlEvents.clear();
@@ -1187,7 +1187,7 @@ void __NetAdhocDoState(PointerWrap &p) {
 		sendTargetPeers.clear();
 		deleteAllAdhocSockets();
 		deleteMatchingEvents();
-		
+
 		// Let's not change "Inited" value when Loading SaveState to prevent memory & port leaks
 		RestoreNetAdhocMatchingInited();
 
@@ -1292,7 +1292,7 @@ int sceNetAdhocctlInit(int stackSize, int prio, u32 productAddr) {
 	if (!friendFinderRunning) {
 		friendFinderThread = std::thread(friendFinder);
 	}
-	
+
 	// Need to make sure to be connected to Adhoc Server (indicated by networkInited) before returning to prevent GTA VCS failed to create/join a group and unable to see any game room
 	int us = adhocDefaultDelay;
 	if (g_Config.bEnableWlan && !g_adhocServerConnected) {
@@ -1350,7 +1350,7 @@ int sceNetAdhocPdpCreate(const char *mac, int port, int bufferSize, u32 flag) {
 	if (netAdhocInited) {
 		// Valid Arguments are supplied
 		if (mac != NULL && bufferSize > 0) {
-			// Port is in use by another PDP Socket. 
+			// Port is in use by another PDP Socket.
 			if (isPDPPortInUse(port)) {
 				// FIXME: When PORT_IN_USE error occured it seems the index to the socket id also increased, which means it tries to create & bind the socket first and then closes it due to failed to bind
 				return hleLogDebug(Log::sceNet, ERROR_NET_ADHOC_PORT_IN_USE, "port in use");
@@ -1403,7 +1403,7 @@ int sceNetAdhocPdpCreate(const char *mac, int port, int bufferSize, u32 flag) {
 						WARN_LOG(Log::sceNet, "sceNetAdhocPdpCreate - Ports below 1024(ie. %hu) may require Admin Privileges", requestedport);
 					}
 					addr.sin_port = htons(requestedport);
-					
+
 					// Bound Socket to local Port
 					int iResult = bind(usocket, (struct sockaddr*)&addr, sizeof(addr));
 
@@ -1428,7 +1428,7 @@ int sceNetAdhocPdpCreate(const char *mac, int port, int bufferSize, u32 flag) {
 						if (internal != NULL) {
 							// Find Free Translator Index
 							// FIXME: We should probably use an increasing index instead of looking for an empty slot from beginning if we want to simulate a real socket id
-							int i = 0; 
+							int i = 0;
 							for (; i < MAX_SOCKET; i++) if (adhocSockets[i] == NULL) break;
 
 							// Found Free Translator Index
@@ -1453,14 +1453,14 @@ int sceNetAdhocPdpCreate(const char *mac, int port, int bufferSize, u32 flag) {
 								// Forward Port on Router
 								//sceNetPortOpen("UDP", port);
 								UPnP_Add(IP_PROTOCOL_UDP, isOriPort ? port : port + portOffset, port + portOffset); // g_PortManager.Add(IP_PROTOCOL_UDP, isOriPort ? port : port + portOffset, port + portOffset);
-								
+
 								// Switch to non-blocking for futher usage
 								changeBlockingMode(usocket, 1);
 
 								// Success
 								INFO_LOG(Log::sceNet, "sceNetAdhocPdpCreate - PSP Socket id: %i, Host Socket id: %i", i + 1, usocket);
 								return i + 1;
-							} 
+							}
 
 							// Free Memory for Internal Data
 							free(internal);
@@ -1475,7 +1475,7 @@ int sceNetAdhocPdpCreate(const char *mac, int port, int bufferSize, u32 flag) {
 						ERROR_LOG(Log::sceNet, "Socket error (%i) when binding port %u", socket_errno, ntohs(addr.sin_port));
 						auto n = GetI18NCategory(I18NCat::NETWORKING);
 						g_OSD.Show(OSDType::MESSAGE_ERROR, std::string(n->T("Failed to Bind Port")) + " " + std::to_string(port + portOffset) + "\n" + std::string(n->T("Please change your Port Offset")), 0.0f, "portbindfail");
-						
+
 						return hleLogDebug(Log::sceNet, ERROR_NET_ADHOC_PORT_NOT_AVAIL, "port not available");
 					}
 				}
@@ -1545,7 +1545,7 @@ int sceNetAdhocPdpSend(int id, const char *mac, u32 port, void *data, int len, i
 	}
 	SceNetEtherAddr * daddr = (SceNetEtherAddr *)mac;
 	uint16_t dport = (uint16_t)port;
-	
+
 	//if (dport < 7) dport += 1341;
 
 	// Really should flatten this with early outs, all this indentation is making me dizzy.
@@ -1572,7 +1572,7 @@ int sceNetAdhocPdpSend(int id, const char *mac, u32 port, void *data, int len, i
 							//if (flag) timeout = 0;
 
 							// Apply Send Timeout Settings to Socket
-							if (timeout > 0) 
+							if (timeout > 0)
 								setSockTimeout(pdpsocket.id, SO_SNDTIMEO, timeout);
 
 							if (socket->flags & ADHOC_F_ALERTSEND) {
@@ -1633,7 +1633,7 @@ int sceNetAdhocPdpSend(int id, const char *mac, u32 port, void *data, int len, i
 									}
 
 									// Non-Blocking
-									if (flag) 
+									if (flag)
 										return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_WOULD_BLOCK, "would block");
 
 									// Does PDP can Timeout? There is no concept of Timeout when sending UDP due to no ACK, but might happen if the socket buffer is full, not sure about PDP since some games did use the timeout arg
@@ -1656,7 +1656,7 @@ int sceNetAdhocPdpSend(int id, const char *mac, u32 port, void *data, int len, i
 								//	target.sin_family = AF_INET;
 								//	sceNetInetInetAton(info.ip, &target.sin_addr);
 								//	target.sin_port = sceNetHtons(dport);
-								//	
+								//
 								//	// Send Data
 								//	sceNetInetSendto(socket->id, data, len, ((flag != 0) ? (INET_MSG_DONTWAIT) : (0)), (SceNetInetSockaddr *)&target, sizeof(target));
 								//}
@@ -1763,7 +1763,7 @@ int sceNetAdhocPdpRecv(int id, void *addr, void * port, void *buf, void *dataLen
 	} else {
 		VERBOSE_LOG(Log::sceNet, "sceNetAdhocPdpRecv(%i, %p, %p, %p, %p, %i, %i) at %08x", id, addr, port, buf, dataLength, timeout, flag, currentMIPS->pc);
 	}
- 
+
 	if (!g_Config.bEnableWlan) {
 		return hleLogError(Log::sceNet, -1);
 	}
@@ -1780,7 +1780,7 @@ int sceNetAdhocPdpRecv(int id, void *addr, void * port, void *buf, void *dataLen
 			socket->nonblocking = flag;
 
 			// Valid Arguments
-			if (saddr != NULL && port != NULL && buf != NULL && len != NULL) { 
+			if (saddr != NULL && port != NULL && buf != NULL && len != NULL) {
 #ifndef PDP_DIRTY_MAGIC
 				// Schedule Timeout Removal
 				//if (flag == 1) timeout = 0;
@@ -1805,7 +1805,7 @@ int sceNetAdhocPdpRecv(int id, void *addr, void * port, void *buf, void *dataLen
 #endif
 
 				// Apply Receive Timeout Settings to Socket. Let's not wait forever (0 = indefinitely)
-				if (timeout > 0) 
+				if (timeout > 0)
 					setSockTimeout(pdpsocket.id, SO_RCVTIMEO, timeout);
 
 				if (socket->flags & ADHOC_F_ALERTRECV) {
@@ -1824,7 +1824,7 @@ int sceNetAdhocPdpRecv(int id, void *addr, void * port, void *buf, void *dataLen
 				SceNetEtherAddr mac;
 				int received = 0;
 				int error;
-				
+
 				int disCnt = 16;
 				while (--disCnt > 0)
 				{
@@ -1836,9 +1836,9 @@ int sceNetAdhocPdpRecv(int id, void *addr, void * port, void *buf, void *dataLen
 					received = recvfrom(pdpsocket.id, dummyPeekBuf64k, dummyPeekBuf64kSize, MSG_PEEK | MSG_NOSIGNAL, (struct sockaddr*)&sin, &sinlen);
 					error = socket_errno;
 					// Discard packets from IP that can't be translated into MAC address to prevent confusing the game, since the sender MAC won't be updated and may contains invalid/undefined value.
-					// TODO: In order to discard packets from unresolvable IP (can't be translated into player's MAC) properly, we'll need to manage the socket buffer ourself, 
+					// TODO: In order to discard packets from unresolvable IP (can't be translated into player's MAC) properly, we'll need to manage the socket buffer ourself,
 					//       by reading the whole available data, separates each datagram and discard unresolvable one, so we can calculate the correct number of available data to recv on GetPdpStat too.
-					//       We may also need to implement encryption (or a simple checksum will do) in order to validate the packet to findout whether it came from PPSSPP or a different App that may be sending/broadcasting data to the same port being used by a game 
+					//       We may also need to implement encryption (or a simple checksum will do) in order to validate the packet to findout whether it came from PPSSPP or a different App that may be sending/broadcasting data to the same port being used by a game
 					//       (in case the IP was resolvable but came from a different App, which will need to be discarded too)
 					// Note: Looping to check too many packets (ie. contiguous) to discard per one non-blocking PdpRecv syscall may cause a slow down
 					if (received != SOCKET_ERROR && !resolveIP(sin.sin_addr.s_addr, &mac)) {
@@ -1900,7 +1900,7 @@ int sceNetAdhocPdpRecv(int id, void *addr, void * port, void *buf, void *dataLen
 					VERBOSE_LOG(Log::sceNet, "%08x=sceNetAdhocPdpRecv: would block", ERROR_NET_ADHOC_WOULD_BLOCK); // Temporary fix to avoid a crash on the Logs due to trying to Logs syscall's argument from another thread (ie. AdhocMatchingInput thread)
 					return ERROR_NET_ADHOC_WOULD_BLOCK; // hleLogSuccessVerboseX(Log::sceNet, ERROR_NET_ADHOC_WOULD_BLOCK, "would block");
 				}
-				
+
 				hleEatMicro(50);
 				// Received Data. UDP can also receives 0 data, while on TCP 0 data = connection gracefully closed, but not sure about PDP tho
 				if (received >= 0) {
@@ -1985,7 +1985,7 @@ int sceNetAdhocSetSocketAlert(int id, int flag) {
  	WARN_LOG_REPORT_ONCE(sceNetAdhocSetSocketAlert, Log::sceNet, "UNTESTED sceNetAdhocSetSocketAlert(%d, %08x) at %08x", id, flag, currentMIPS->pc);
 
 	int retval = NetAdhoc_SetSocketAlert(id, flag);
-	return hleDelayResult(hleLogDebug(Log::sceNet, retval, ""), "set socket alert delay", 1000);
+	return hleDelayResult(hleLogDebug(Log::sceNet, retval), "set socket alert delay", 1000);
 }
 
 int PollAdhocSocket(SceNetAdhocPollSd* sds, int count, int timeout, int nonblock) {
@@ -1994,7 +1994,7 @@ int PollAdhocSocket(SceNetAdhocPollSd* sds, int count, int timeout, int nonblock
 	int fd;
 	int maxfd = 0;
 	FD_ZERO(&readfds); FD_ZERO(&writefds); FD_ZERO(&exceptfds);
-	
+
 	for (int i = 0; i < count; i++) {
 		sds[i].revents = 0;
 		// Fill in Socket ID
@@ -2010,7 +2010,7 @@ int PollAdhocSocket(SceNetAdhocPollSd* sds, int count, int timeout, int nonblock
 				fd = sock->data.pdp.id;
 			}
 			if (fd > maxfd) maxfd = fd;
-			FD_SET(fd, &readfds); 
+			FD_SET(fd, &readfds);
 			FD_SET(fd, &writefds);
 			FD_SET(fd, &exceptfds);
 		}
@@ -2025,7 +2025,7 @@ int PollAdhocSocket(SceNetAdhocPollSd* sds, int count, int timeout, int nonblock
 			if (sds[i].id > 0 && sds[i].id <= MAX_SOCKET && adhocSockets[sds[i].id - 1] != NULL) {
 				auto sock = adhocSockets[sds[i].id - 1];
 				if (sock->type == SOCK_PTP) {
-					fd = sock->data.ptp.id;					
+					fd = sock->data.ptp.id;
 				}
 				else {
 					fd = sock->data.pdp.id;
@@ -2033,12 +2033,12 @@ int PollAdhocSocket(SceNetAdhocPollSd* sds, int count, int timeout, int nonblock
 				if ((sds[i].events & ADHOC_EV_RECV) && FD_ISSET(fd, &readfds))
 					sds[i].revents |= ADHOC_EV_RECV;
 				if ((sds[i].events & ADHOC_EV_SEND) && FD_ISSET(fd, &writefds))
-					sds[i].revents |= ADHOC_EV_SEND;				
+					sds[i].revents |= ADHOC_EV_SEND;
 				if (sock->alerted_flags)
 					sds[i].revents |= ADHOC_EV_ALERT;
 				// Mask certain revents bits with events bits
 				sds[i].revents &= sds[i].events;
-				
+
 				if (sock->type == SOCK_PTP) {
 					// FIXME: Should we also make use "retry_interval" for ADHOC_EV_ACCEPT, similar to ADHOC_EV_CONNECT ?
 					if (sock->data.ptp.state == ADHOC_PTP_STATE_LISTEN && (sds[i].events & ADHOC_EV_ACCEPT) && FD_ISSET(fd, &readfds)) {
@@ -2105,7 +2105,7 @@ int sceNetAdhocPollSocket(u32 socketStructAddr, int count, int timeout, int nonb
 			if (nonblock)
 				timeout = 0;
 
-			if (count > (int)FD_SETSIZE) 
+			if (count > (int)FD_SETSIZE)
 				count = FD_SETSIZE; // return 0; //ERROR_NET_ADHOC_INVALID_ARG
 
 			// Acquire Network Lock
@@ -2223,7 +2223,7 @@ static int sceNetAdhocPdpDelete(int id, int unknown) {
 
 static int sceNetAdhocctlGetAdhocId(u32 productStructAddr) {
 	INFO_LOG(Log::sceNet, "sceNetAdhocctlGetAdhocId(%08x) at %08x", productStructAddr, currentMIPS->pc);
-	
+
 	if (!netAdhocctlInited)
 		return hleLogDebug(Log::sceNet, ERROR_NET_ADHOCCTL_NOT_INITIALIZED, "not initialized");
 
@@ -2282,7 +2282,7 @@ int sceNetAdhocctlScan() {
 			// FIXME: When tested using JPCSP + official prx files it seems sceNetAdhocctlScan switching to a different thread for at least 100ms after returning success and before executing the next line?
 			return hleDelayResult(hleLogDebug(Log::sceNet, 0), "scan delay", adhocEventPollDelay);
 		}
-		
+
 		// FIXME: Returning BUSY when previous adhocctl handler's callback is not fully executed yet, But returning success and notifying handler's callback with error (ie. ALREADY_CONNECTED) when previous adhocctl handler's callback is fully executed? Is there a case where error = BUSY sent through handler's callback?
 		return hleLogError(Log::sceNet, ERROR_NET_ADHOCCTL_BUSY, "busy");
 	}
@@ -2316,7 +2316,7 @@ int sceNetAdhocctlGetScanInfo(u32 sizeAddr, u32 bufAddr) {
 			peerlock.lock();
 
 			// FIXME: When already connected to a group GetScanInfo will return size = 0 ? or may be only hides the group created by it's self?
-			if (adhocctlState == ADHOCCTL_STATE_CONNECTED || adhocctlState == ADHOCCTL_STATE_GAMEMODE) { 
+			if (adhocctlState == ADHOCCTL_STATE_CONNECTED || adhocctlState == ADHOCCTL_STATE_GAMEMODE) {
 				*buflen = 0;
 				DEBUG_LOG(Log::sceNet, "NetworkList [Available: 0] Already in a Group");
 			}
@@ -2445,7 +2445,7 @@ u32 NetAdhocctl_Disconnect() {
 		}
 
 		// Connected State (Adhoc Mode). Attempting to leave a group while not in a group will be kicked out by Adhoc Server (ie. some games tries to disconnect more than once within a short time)
-		if (adhocctlState != ADHOCCTL_STATE_DISCONNECTED) { 
+		if (adhocctlState != ADHOCCTL_STATE_DISCONNECTED) {
 			isAdhocctlBusy = true;
 
 			// Clear Network Name
@@ -2470,7 +2470,7 @@ u32 NetAdhocctl_Disconnect() {
 					ERROR_LOG(Log::sceNet, "Socket error (%i) when sending", error);
 					// Set Disconnected State
 					adhocctlState = ADHOCCTL_STATE_DISCONNECTED;
-				} 
+				}
 				else if (friendFinderRunning) {
 					AdhocctlRequest req = { OPCODE_DISCONNECT, {0} };
 					WaitBlockingAdhocctlSocket(req, 0, "adhocctl disconnect");
@@ -2575,7 +2575,7 @@ int NetAdhocctl_Term() {
 		shutdown((int)metasocket, SD_BOTH);
 		closesocket((int)metasocket);
 		metasocket = (int)INVALID_SOCKET;
-		// Delete fake PSP Thread. 
+		// Delete fake PSP Thread.
 		// kernelObjects may already been cleared early during a Shutdown, thus trying to access it may generates Warning/Error in the log
 		if (threadAdhocID > 0 && strcmp(__KernelGetThreadName(threadAdhocID), "ERROR") != 0) {
 			__KernelStopThread(threadAdhocID, SCE_KERNEL_ERROR_THREAD_TERMINATED, "AdhocThread stopped");
@@ -2603,7 +2603,7 @@ int sceNetAdhocctlTerm() {
 
 static int sceNetAdhocctlGetNameByAddr(const char *mac, u32 nameAddr) {
 	DEBUG_LOG(Log::sceNet, "UNTESTED sceNetAdhocctlGetNameByAddr(%s, %08x) at %08x", mac2str((SceNetEtherAddr*)mac).c_str(), nameAddr, currentMIPS->pc);
-	
+
 	// Library initialized
 	if (netAdhocctlInited)
 	{
@@ -2612,7 +2612,7 @@ static int sceNetAdhocctlGetNameByAddr(const char *mac, u32 nameAddr) {
 		{
 			SceNetAdhocctlNickname * nickname = (SceNetAdhocctlNickname *)Memory::GetPointer(nameAddr);
 			// Get Local MAC Address
-			SceNetEtherAddr localmac; 
+			SceNetEtherAddr localmac;
 			getLocalMac(&localmac);
 
 			// Local MAC Matches
@@ -2628,7 +2628,7 @@ static int sceNetAdhocctlGetNameByAddr(const char *mac, u32 nameAddr) {
 			}
 
 			// Multithreading Lock
-			peerlock.lock(); 
+			peerlock.lock();
 
 			// Peer Reference
 			SceNetAdhocctlPeerInfo * peer = friends;
@@ -2643,7 +2643,7 @@ static int sceNetAdhocctlGetNameByAddr(const char *mac, u32 nameAddr) {
 					*nickname = peer->nickname;
 
 					// Multithreading Unlock
-					peerlock.unlock(); 
+					peerlock.unlock();
 
 					DEBUG_LOG(Log::sceNet, "sceNetAdhocctlGetNameByAddr - [PeerName:%s]", (char*)nickname);
 
@@ -2653,7 +2653,7 @@ static int sceNetAdhocctlGetNameByAddr(const char *mac, u32 nameAddr) {
 			}
 
 			// Multithreading Unlock
-			peerlock.unlock(); 
+			peerlock.unlock();
 
 			DEBUG_LOG(Log::sceNet, "sceNetAdhocctlGetNameByAddr - PlayerName not found");
 			// Player not found
@@ -2682,7 +2682,7 @@ int sceNetAdhocctlGetPeerInfo(const char *mac, int size, u32 peerInfoAddr) {
 	// Library initialized
 	if (netAdhocctlInited) {
 		if ((size < (int)sizeof(SceNetAdhocctlPeerInfoEmu)) || (buf == NULL)) return ERROR_NET_ADHOCCTL_INVALID_ARG;
-		
+
 		int retval = ERROR_NET_ADHOC_NO_ENTRY; // -1;
 
 		// Local MAC
@@ -2702,7 +2702,7 @@ int sceNetAdhocctlGetPeerInfo(const char *mac, int size, u32 peerInfoAddr) {
 			retval = 0;
 		}
 		// Find Peer by MAC
-		else 
+		else
 		{
 			// Multithreading Lock
 			peerlock.lock();
@@ -2780,7 +2780,7 @@ int NetAdhocctl_Create(const char *groupName) {
 						adhocctlState = ADHOCCTL_STATE_CONNECTED;
 						// Notify Event Handlers, Needed for the Nickname to be shown on the screen when success is faked
 						// Connected Event's mipscall need be executed before returning from sceNetAdhocctlCreate (or before the next sceNet function?)
-						notifyAdhocctlHandlers(ADHOCCTL_EVENT_CONNECT, 0); //CoreTiming::ScheduleEvent_Threadsafe_Immediate(eventAdhocctlHandlerUpdate, join32(ADHOCCTL_EVENT_CONNECT, 0)); 
+						notifyAdhocctlHandlers(ADHOCCTL_EVENT_CONNECT, 0); //CoreTiming::ScheduleEvent_Threadsafe_Immediate(eventAdhocctlHandlerUpdate, join32(ADHOCCTL_EVENT_CONNECT, 0));
 					}
 				}
 
@@ -2817,7 +2817,7 @@ int sceNetAdhocctlCreate(const char *groupName) {
 
 	adhocctlCurrentMode = ADHOCCTL_MODE_NORMAL;
 	adhocConnectionType = ADHOC_CREATE;
-	return hleLogDebug(Log::sceNet, NetAdhocctl_Create(groupName), "");
+	return hleLogDebug(Log::sceNet, NetAdhocctl_Create(groupName));
 }
 
 int sceNetAdhocctlConnect(const char* groupName) {
@@ -2831,7 +2831,7 @@ int sceNetAdhocctlConnect(const char* groupName) {
 
 	adhocctlCurrentMode = ADHOCCTL_MODE_NORMAL;
 	adhocConnectionType = ADHOC_CONNECT;
-	return hleLogDebug(Log::sceNet, NetAdhocctl_Create(groupName), "");
+	return hleLogDebug(Log::sceNet, NetAdhocctl_Create(groupName));
 }
 
 int sceNetAdhocctlJoin(u32 scanInfoAddr) {
@@ -2855,7 +2855,7 @@ int sceNetAdhocctlJoin(u32 scanInfoAddr) {
 			// TODO: Adhoc Server may need to be changed to differentiate between Host/Create and Join, otherwise it can't support multiple Host using the same Group name, thus causing one of the Host to be confused being treated as Join.
 			adhocctlCurrentMode = ADHOCCTL_MODE_NORMAL;
 			adhocConnectionType = ADHOC_JOIN;
-			return hleLogDebug(Log::sceNet, NetAdhocctl_Create(grpName), "");
+			return hleLogDebug(Log::sceNet, NetAdhocctl_Create(grpName));
 		}
 
 		// Invalid Argument
@@ -2924,7 +2924,7 @@ static int sceNetAdhocctlCreateEnterGameMode(const char * group_name, int game_t
 		memcpy(grpName, group_name, ADHOCCTL_GROUPNAME_LEN); // For logging purpose, must not be truncated
 	WARN_LOG_REPORT_ONCE(sceNetAdhocctlCreateEnterGameMode, Log::sceNet, "UNTESTED sceNetAdhocctlCreateEnterGameMode(%s, %i, %i, %08x, %i, %i) at %08x", grpName, game_type, num_members, membersAddr, timeout, flag, currentMIPS->pc);
 
-	return hleLogDebug(Log::sceNet, NetAdhocctl_CreateEnterGameMode(group_name, game_type, num_members, membersAddr, timeout, flag), "");
+	return hleLogDebug(Log::sceNet, NetAdhocctl_CreateEnterGameMode(group_name, game_type, num_members, membersAddr, timeout, flag));
 }
 
 /**
@@ -2965,7 +2965,7 @@ static int sceNetAdhocctlJoinEnterGameMode(const char * group_name, const char *
 	adhocConnectionType = ADHOC_JOIN;
 	netAdhocGameModeEntered = true;
 	netAdhocEnterGameModeTimeout = timeout;
-	return hleLogDebug(Log::sceNet, NetAdhocctl_Create(group_name), "");
+	return hleLogDebug(Log::sceNet, NetAdhocctl_Create(group_name));
 }
 
 /**
@@ -2985,7 +2985,7 @@ int sceNetAdhocctlCreateEnterGameModeMin(const char *group_name, int game_type, 
 		memcpy(grpName, group_name, ADHOCCTL_GROUPNAME_LEN); // For logging purpose, must not be truncated
 	WARN_LOG_REPORT_ONCE(sceNetAdhocctlCreateEnterGameModeMin, Log::sceNet, "UNTESTED sceNetAdhocctlCreateEnterGameModeMin(%s, %i, %i, %i, %08x, %d, %i) at %08x", grpName, game_type, min_members, num_members, membersAddr, timeout, flag, currentMIPS->pc);
 	// We don't really need the Minimum User Check
-	return hleLogDebug(Log::sceNet, NetAdhocctl_CreateEnterGameMode(group_name, game_type, num_members, membersAddr, timeout, flag), "");
+	return hleLogDebug(Log::sceNet, NetAdhocctl_CreateEnterGameMode(group_name, game_type, num_members, membersAddr, timeout, flag));
 }
 
 int NetAdhoc_Term() {
@@ -3029,7 +3029,7 @@ int sceNetAdhocTerm() {
 
 static int sceNetAdhocGetPdpStat(u32 structSize, u32 structAddr) {
 	VERBOSE_LOG(Log::sceNet, "sceNetAdhocGetPdpStat(%08x, %08x) at %08x", structSize, structAddr, currentMIPS->pc);
-	
+
 	// Library is initialized
 	if (netAdhocInited)
 	{
@@ -3095,7 +3095,7 @@ static int sceNetAdhocGetPdpStat(u32 structSize, u32 structAddr) {
 					buf[i].next = 0;
 
 					// Link Previous Element
-					if (i > 0) 
+					if (i > 0)
 						buf[i - 1].next = structAddr + (i * sizeof(SceNetAdhocPdpStat));
 
 					VERBOSE_LOG(Log::sceNet, "Stat PDP Socket Id: %d (%d), LPort: %d, RecvSbCC: %d", buf[i].id, sock->data.pdp.id, buf[i].lport, buf[i].rcv_sb_cc);
@@ -3129,7 +3129,7 @@ static int sceNetAdhocGetPdpStat(u32 structSize, u32 structAddr) {
  * @return 0 on success or... ADHOC_INVALID_ARG, ADHOC_NOT_INITIALIZED
  */
 static int sceNetAdhocGetPtpStat(u32 structSize, u32 structAddr) {
-	// Spams a lot 
+	// Spams a lot
 	VERBOSE_LOG(Log::sceNet,"sceNetAdhocGetPtpStat(%08x, %08x) at %08x",structSize,structAddr,currentMIPS->pc);
 
 	s32_le *buflen = NULL;
@@ -3147,26 +3147,26 @@ static int sceNetAdhocGetPtpStat(u32 structSize, u32 structAddr) {
 			// Return Required Size
 			*buflen = sizeof(SceNetAdhocPtpStat) * socketcount;
 			VERBOSE_LOG(Log::sceNet, "Stat PTP Socket Count: %d", socketcount);
-			
+
 			// Success
 			return 0;
 		}
-		
+
 		// Status Returner Mode
 		else if (buflen != NULL && buf != NULL) {
 			// Figure out how many Sockets we will return
 			int count = *buflen / sizeof(SceNetAdhocPtpStat);
 			if (count > socketcount) count = socketcount;
-			
+
 			// Copy Counter
 			int i = 0;
-			
+
 			// Iterate Sockets
 			for (int j = 0; j < MAX_SOCKET && i < count; j++) {
 				// Valid Socket Entry
 				auto sock = adhocSockets[j];
 				if ( sock != NULL && sock->type == SOCK_PTP) {
-					// Update connection state. 
+					// Update connection state.
 					// GvG Next Plus relies on GetPtpStat to determine if Connection has been Established or not, but should not be updated too long for GvG to work, and should not be updated too fast(need to be 1 frame after PollSocket checking for ADHOC_EV_CONNECT) for Bleach Heat the Soul 7 to work properly.
 					if ((sock->data.ptp.state == ADHOC_PTP_STATE_SYN_SENT || sock->data.ptp.state == ADHOC_PTP_STATE_SYN_RCVD) && (static_cast<s64>(CoreTiming::GetGlobalTimeUsScaled() - sock->lastAttempt) > 33333/*sock->retry_interval*/)) {
 						// FIXME: May be we should poll all of them together on a single poll call instead of each socket separately?
@@ -3195,36 +3195,36 @@ static int sceNetAdhocGetPtpStat(u32 structSize, u32 structAddr) {
 
 					// Copy Socket Data from internal Memory
 					memcpy(&buf[i], &sock->data.ptp, sizeof(SceNetAdhocPtpStat));
-					
+
 					// Fix Client View Socket ID
 					buf[i].id = j + 1;
 
 					// Write End of List Reference
 					buf[i].next = 0;
-					
+
 					// Link previous Element to this one
 					if (i > 0)
 						buf[i - 1].next = structAddr + (i * sizeof(SceNetAdhocPtpStat));
 
 					VERBOSE_LOG(Log::sceNet, "Stat PTP Socket Id: %d (%d), LPort: %d, RecvSbCC: %d, State: %d", buf[i].id, sock->data.ptp.id, buf[i].lport, buf[i].rcv_sb_cc, buf[i].state);
-					
+
 					// Increment Counter
 					i++;
 				}
 			}
-			
+
 			// Update Buffer Length
 			*buflen = i * sizeof(SceNetAdhocPtpStat);
-			
+
 			hleEatMicro(50); // Not sure how long it takes, since GetPtpStat didn't get logged when using prx files on JPCSP
 			// Success
 			return 0;
 		}
-		
+
 		// Invalid Arguments
 		return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_INVALID_ARG, "invalid arg, at %08x", currentMIPS->pc);
 	}
-	
+
 	// Library is uninitialized
 	return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_NOT_INITIALIZED, "not initialized, at %08x", currentMIPS->pc);
 }
@@ -3360,7 +3360,7 @@ static int sceNetAdhocPtpOpen(const char *srcmac, int sport, const char *dstmac,
 				//sport 0 should be shifted back to 0 when using offset Phantasy Star Portable 2 use this
 				sport = -static_cast<int>(portOffset);
 			}
-			
+
 			// Valid Arguments
 			if (bufsize > 0 && rexmt_int > 0 && rexmt_cnt > 0) {
 				// Create Infrastructure Socket (?)
@@ -3458,7 +3458,7 @@ static int sceNetAdhocPtpOpen(const char *srcmac, int sport, const char *dstmac,
 								// Add Port Forward to Router. We may not even need to forward this local port, since PtpOpen usually have port 0 (any port) as source port and followed by PtpConnect (which mean acting as Client), right?
 								//sceNetPortOpen("TCP", sport);
 								if (!isClient)
-									UPnP_Add(IP_PROTOCOL_TCP, isOriPort ? sport : sport + portOffset, sport + portOffset); 
+									UPnP_Add(IP_PROTOCOL_TCP, isOriPort ? sport : sport + portOffset, sport + portOffset);
 
 								// Switch to non-blocking for futher usage
 								changeBlockingMode(tcpsocket, 1);
@@ -3500,11 +3500,11 @@ static int sceNetAdhocPtpOpen(const char *srcmac, int sport, const char *dstmac,
 			// Invalid Arguments
 			return hleLogDebug(Log::sceNet, ERROR_NET_ADHOC_INVALID_ARG, "invalid arg");
 		}
-		
+
 		// Invalid Addresses
 		return hleLogDebug(Log::sceNet, ERROR_NET_ADHOC_INVALID_ADDR, "invalid address"); // ERROR_NET_ADHOC_INVALID_ARG;
 	}
-	
+
 	// Library is uninitialized
 	return hleLogDebug(Log::sceNet, ERROR_NET_ADHOC_NOT_INITIALIZED, "adhoc not initialized");
 }
@@ -3554,7 +3554,7 @@ int AcceptPtpSocket(int ptpId, int newsocket, sockaddr_in& peeraddr, SceNetEther
 					// Inherits some of Listening socket's properties
 					// Socket Type
 					internal->type = SOCK_PTP;
-					internal->nonblocking = socket->nonblocking; 
+					internal->nonblocking = socket->nonblocking;
 					internal->attemptCount = 1; // Used to differentiate between closed state of disconnected socket and not connected yet.
 					internal->retry_interval = socket->retry_interval;
 					internal->retry_count = socket->retry_count;
@@ -3586,9 +3586,9 @@ int AcceptPtpSocket(int ptpId, int newsocket, sockaddr_in& peeraddr, SceNetEther
 					internal->data.ptp.state = ADHOC_PTP_STATE_ESTABLISHED;
 
 					// Return Peer Address & Port Information
-					if (addr != NULL) 
+					if (addr != NULL)
 						*addr = internal->data.ptp.paddr;
-					if (port != NULL) 
+					if (port != NULL)
 						*port = internal->data.ptp.pport;
 
 					// Link PTP Socket
@@ -3717,7 +3717,7 @@ static int sceNetAdhocPtpAccept(int id, u32 peerMacAddrPtr, u32 peerPortPtr, int
 		// Invalid Arguments
 		return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_INVALID_ARG, "invalid arg");
 	}
-	
+
 	// Library is uninitialized
 	return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_NOT_INITIALIZED, "not initialized");
 }
@@ -3915,7 +3915,7 @@ static int sceNetAdhocPtpClose(int id, int unknown) {
 	/*if (!g_Config.bEnableWlan) {
 		return hleLogError(Log::sceNet, -1, "WLAN off");
 	}*/
-	
+
 	return NetAdhocPtp_Close(id, unknown);
 }
 
@@ -3958,7 +3958,7 @@ static int sceNetAdhocPtpListen(const char *srcmac, int sport, int bufsize, int 
 				//sport 0 should be shifted back to 0 when using offset Phantasy Star Portable 2 use this
 				sport = -static_cast<int>(portOffset);
 			}
-			
+
 			// Valid Arguments
 			if (bufsize > 0 && rexmt_int > 0 && rexmt_cnt > 0 && backlog > 0)
 			{
@@ -4096,11 +4096,11 @@ static int sceNetAdhocPtpListen(const char *srcmac, int sport, int bufsize, int 
 			// Invalid Arguments
 			return hleLogDebug(Log::sceNet, ERROR_NET_ADHOC_INVALID_ARG, "invalid arg");
 		}
-		
+
 		// Invalid Addresses
 		return hleLogDebug(Log::sceNet, ERROR_NET_ADHOC_INVALID_ADDR, "invalid address");
 	}
-	
+
 	// Library is uninitialized
 	return hleLogDebug(Log::sceNet, ERROR_NET_ADHOC_NOT_INITIALIZED, "adhoc not initialized");
 }
@@ -4127,16 +4127,16 @@ static int sceNetAdhocPtpSend(int id, u32 dataAddr, u32 dataSizeAddr, int timeou
 			auto socket = adhocSockets[id - 1];
 			auto& ptpsocket = socket->data.ptp;
 			socket->nonblocking = flag;
-			
+
 			// Connected Socket
 			if (ptpsocket.state == ADHOC_PTP_STATE_ESTABLISHED || ptpsocket.state == ADHOC_PTP_STATE_SYN_SENT) {
 				// Valid Arguments
 				if (data != NULL && len != NULL && *len > 0) {
 					// Schedule Timeout Removal
 					//if (flag) timeout = 0; // JPCSP seems to always Send PTP as blocking, also a possibility to send to multiple destination?
-					
+
 					// Apply Send Timeout Settings to Socket
-					if (timeout > 0) 
+					if (timeout > 0)
 						setSockTimeout(ptpsocket.id, SO_SNDTIMEO, timeout);
 
 					if (socket->flags & ADHOC_F_ALERTSEND) {
@@ -4144,17 +4144,17 @@ static int sceNetAdhocPtpSend(int id, u32 dataAddr, u32 dataSizeAddr, int timeou
 
 						return hleLogError(Log::sceNet, ERROR_NET_ADHOC_SOCKET_ALERTED, "socket alerted");
 					}
-					
+
 					// Acquire Network Lock
 					// _acquireNetworkLock();
-					
+
 					// Send Data
 					int sent = send(ptpsocket.id, data, *len, MSG_NOSIGNAL);
 					int error = socket_errno;
-					
+
 					// Free Network Lock
 					// _freeNetworkLock();
-					
+
 					// Success
 					if (sent > 0) {
 						hleEatMicro(50); // mostly 1ms, sometimes 1~10ms ? doesn't seems to be switching to a different thread during this duration
@@ -4162,7 +4162,7 @@ static int sceNetAdhocPtpSend(int id, u32 dataAddr, u32 dataSizeAddr, int timeou
 						*len = sent;
 
 						DEBUG_LOG(Log::sceNet, "sceNetAdhocPtpSend[%i:%u]: Sent %u bytes to %s:%u\n", id, ptpsocket.lport, sent, mac2str(&ptpsocket.paddr).c_str(), ptpsocket.pport);
-						
+
 						// Set to Established on successful Send when an attempt to Connect was initiated
 						if (ptpsocket.state == ADHOC_PTP_STATE_SYN_SENT)
 							ptpsocket.state = ADHOC_PTP_STATE_ESTABLISHED;
@@ -4170,39 +4170,39 @@ static int sceNetAdhocPtpSend(int id, u32 dataAddr, u32 dataSizeAddr, int timeou
 						// Return Success
 						return 0;
 					}
-					
+
 					// Non-Critical Error
 					else if (sent == SOCKET_ERROR && (error == EAGAIN || error == EWOULDBLOCK || (ptpsocket.state == ADHOC_PTP_STATE_SYN_SENT && (error == ENOTCONN || connectInProgress(error))))) {
 						// Non-Blocking
-						if (flag) 
+						if (flag)
 							return hleLogVerbose(Log::sceNet, ERROR_NET_ADHOC_WOULD_BLOCK, "would block");
-						
+
 						// Simulate blocking behaviour with non-blocking socket
 						u64 threadSocketId = ((u64)__KernelGetCurThread()) << 32 | ptpsocket.id;
 						return WaitBlockingAdhocSocket(threadSocketId, PTP_SEND, id, (void*)data, len, timeout, nullptr, nullptr, "ptp send");
 					}
 
 					DEBUG_LOG(Log::sceNet, "sceNetAdhocPtpSend[%i:%u -> %s:%u]: Result:%i (Error:%i)", id, ptpsocket.lport, mac2str(&ptpsocket.paddr).c_str(), ptpsocket.pport, sent, error);
-					
+
 					// Change Socket State
 					ptpsocket.state = ADHOC_PTP_STATE_CLOSED;
-					
+
 					// Disconnected
 					return hleLogError(Log::sceNet, ERROR_NET_ADHOC_DISCONNECTED, "disconnected");
 				}
-				
+
 				// Invalid Arguments
 				return hleLogError(Log::sceNet, ERROR_NET_ADHOC_INVALID_ARG, "invalid arg");
 			}
-			
+
 			// Not Connected
 			return hleLogError(Log::sceNet, ERROR_NET_ADHOC_NOT_CONNECTED, "not connected");
 		}
-		
+
 		// Invalid Socket
 		return hleLogError(Log::sceNet, ERROR_NET_ADHOC_INVALID_SOCKET_ID, "invalid socket id");
 	}
-	
+
 	// Library is uninitialized
 	return hleLogError(Log::sceNet, ERROR_NET_ADHOC_NOT_INITIALIZED, "not initialized");
 }
@@ -4270,7 +4270,7 @@ static int sceNetAdhocPtpRecv(int id, u32 dataAddr, u32 dataSizeAddr, int timeou
 					// Free Network Lock
 					// _freeNetworkLock();
 
-					hleEatMicro(50); 
+					hleEatMicro(50);
 
 					// Received Data
 					if (received > 0) {
@@ -4316,7 +4316,7 @@ static int sceNetAdhocPtpRecv(int id, u32 dataAddr, u32 dataSizeAddr, int timeou
 		// Invalid Arguments
 		return hleLogError(Log::sceNet, ERROR_NET_ADHOC_INVALID_ARG, "invalid socket arg");
 	}
-	
+
 	// Library is uninitialized
 	return hleLogError(Log::sceNet, ERROR_NET_ADHOC_NOT_INITIALIZED, "not initialized");
 }
@@ -4391,7 +4391,7 @@ static int sceNetAdhocPtpFlush(int id, int timeout, int nonblock) {
 			// Dummy Result, Always success?
 			return 0;
 		}
-		
+
 		// Invalid Socket
 		return hleLogError(Log::sceNet, ERROR_NET_ADHOC_INVALID_SOCKET_ID, "invalid socket id");
 	}
@@ -4447,7 +4447,7 @@ static int sceNetAdhocGameModeCreateMaster(u32 dataAddr, int size) {
 		}
 		return hleLogDebug(Log::sceNet, 0, "success"); // returned an id just like CreateReplica? always return 0?
 	}
-	
+
 	return hleLogError(Log::sceNet, ERROR_NET_ADHOC_NOT_CREATED, "not created");
 }
 
@@ -4533,7 +4533,7 @@ static int sceNetAdhocGameModeUpdateMaster() {
 		for (auto& gma : replicaGameModeAreas)
 			gma.dataSent = 0;
 	}
-	
+
 	hleEatMicro(100);
 	return 0;
 }
@@ -4601,7 +4601,7 @@ static int sceNetAdhocGameModeUpdateReplica(int id, u32 infoAddr) {
 				if (gmuinfo != NULL) {
 					gmuinfo->length = sizeof(GameModeUpdateInfo);
 					gmuinfo->updated = 1;
-					gmuinfo->timeStamp = std::max(gma.updateTimestamp, CoreTiming::GetGlobalTimeUsScaled() - defaultLastRecvDelta);				
+					gmuinfo->timeStamp = std::max(gma.updateTimestamp, CoreTiming::GetGlobalTimeUsScaled() - defaultLastRecvDelta);
 				}
 			}
 			else {
@@ -4651,7 +4651,7 @@ int sceNetAdhocGetSocketAlert(int id, u32 flagPtr) {
 	if (id < 1 || id > MAX_SOCKET || adhocSockets[id - 1] == NULL)
 		return hleLogDebug(Log::sceNet, ERROR_NET_ADHOC_INVALID_SOCKET_ID, "invalid socket id");
 
-	s32_le flg = adhocSockets[id - 1]->flags;	
+	s32_le flg = adhocSockets[id - 1]->flags;
 	Memory::Write_U32(flg, flagPtr);
 
 	return hleLogDebug(Log::sceNet, 0, "flags = %08x", flg);
@@ -4777,7 +4777,7 @@ const HLEFunction sceNetAdhoc[] = {
 	{0X7A662D6B, &WrapI_UIII<sceNetAdhocPollSocket>,                   "sceNetAdhocPollSocket",                  'i', "xiii"     },
 	// Fake function for PPSSPP's use.
 	{0X756E6E6F, &WrapV_V<__NetTriggerCallbacks>,                      "__NetTriggerCallbacks",                  'v', ""         },
-};							
+};
 
 int NetAdhocctl_ExitGameMode() {
 	if (gameModeSocket > 0) {
@@ -4795,7 +4795,7 @@ int NetAdhocctl_ExitGameMode() {
 
 static int sceNetAdhocctlExitGameMode() {
 	WARN_LOG(Log::sceNet, "UNTESTED sceNetAdhocctlExitGameMode() at %08x", currentMIPS->pc);
-	
+
 	return NetAdhocctl_ExitGameMode();
 }
 
@@ -4814,7 +4814,7 @@ static int sceNetAdhocctlGetGameModeInfo(u32 infoAddr) {
 	for (auto& mac : gameModeMacs) {
 		VERBOSE_LOG(Log::sceNet, "GameMode macAddress#%d=%s", i, mac2str(&mac).c_str());
 		gmInfo->members[i++] = mac;
-		if (i >= ADHOCCTL_GAMEMODE_MAX_MEMBERS) 
+		if (i >= ADHOCCTL_GAMEMODE_MAX_MEMBERS)
 			break;
 	}
 
@@ -4872,7 +4872,7 @@ static int sceNetAdhocctlGetPeerList(u32 sizeAddr, u32 bufAddr) {
 						// Exclude Soon to be timedout peers?
 						if (!excludeTimedout || peer->last_recv != 0) {
 							// Faking Last Receive Time
-							if (peer->last_recv != 0) 
+							if (peer->last_recv != 0)
 								peer->last_recv = std::max(peer->last_recv, CoreTiming::GetGlobalTimeUsScaled() - defaultLastRecvDelta);
 
 							// Copy Peer Info
@@ -4927,9 +4927,9 @@ static int sceNetAdhocctlGetAddrByName(const char *nickName, u32 sizeAddr, u32 b
 	char nckName[ADHOCCTL_NICKNAME_LEN];
 	memcpy(nckName, nickName, ADHOCCTL_NICKNAME_LEN); // Copied to null-terminated var to prevent unexpected behaviour on Logs
 	nckName[ADHOCCTL_NICKNAME_LEN - 1] = 0;
-	
+
 	WARN_LOG_REPORT_ONCE(sceNetAdhocctlGetAddrByName, Log::sceNet, "UNTESTED sceNetAdhocctlGetAddrByName(%s, [%08x]=%d/%zu, %08x) at %08x", nckName, sizeAddr, buflen ? *buflen : -1, sizeof(SceNetAdhocctlPeerInfoEmu), bufAddr, currentMIPS->pc);
-	
+
 	// Library initialized
 	if (netAdhocctlInited)
 	{
@@ -5083,14 +5083,14 @@ int sceNetAdhocDiscoverInitStart(u32 paramAddr) {
 		return hleLogError(Log::sceNet, -1, "invalid param?");
 	// FIXME: paramAddr seems to be stored at 0x000010D8 without validating the value first
 	//*((int*)Memory::GetPointer(0x000010D8)) = paramAddr;
-	
-	// Based on Legend Of The Dragon: 
+
+	// Based on Legend Of The Dragon:
 	// The 1st 24 x 32bit(addr) seems to be pointers to subroutine containings sceNetAdhocctlCreate/sceNetAdhocctlJoin/sceNetAdhocctlDisconnect/sceNetAdhocctlScan/sceNetRand/sceKernelGetSystemTimeWide/etc.
-	// Offset 0x60: 10 00 06 06 
+	// Offset 0x60: 10 00 06 06
 	// Offset 0x70: FF FF FF FF (before Init) -> 00 00 00 00 (after Init) -> FF FF FF FF (after Term) // Seems to be value returned from sceNetAdhocctl_lib_F8BABD85, and the address (0x000010A0) seems to be the lowest one for storing data
 	// Offset 0x80: 00 -> 0B/0C/0D/13 -> 00 // This seems to be (current step?) at address at 0x000010B0 (ie. *((int *) 0x000010B0) = 0x0000000B), something todo with param->unknown1(sleep mode?)
-	// Offset 0x84: 00 -> 03 -> 03 // somekind of State? Something todo with param->unknown1(sleep mode?) along with data at 0x000010B0 (current step?) 
-	// Offset 0x98: 0000 -> 0000/0200 -> 0000 // This seems to be somekind of flags at 0x000010C8 (ie. *((int *) 0x000010C8) = (var4 | 0x00000080)), something todo with data at 0x000010B0 (current step?) 
+	// Offset 0x84: 00 -> 03 -> 03 // somekind of State? Something todo with param->unknown1(sleep mode?) along with data at 0x000010B0 (current step?)
+	// Offset 0x98: 0000 -> 0000/0200 -> 0000 // This seems to be somekind of flags at 0x000010C8 (ie. *((int *) 0x000010C8) = (var4 | 0x00000080)), something todo with data at 0x000010B0 (current step?)
 	// Offset 0xA0: WLAN channel from sceUtilityGetSystemParamInt (ie. sceUtilityGetSystemParamInt(0x00000002, 0x000010D0) on decompiled prx, but on JPCSP+prx Logs it's sceUtilityGetSystemParamInt(0x00000002, 0x09F43FD0))
 	// Offset 0xA4: Seems to be at 0x000010D4 and related to RequestSuspend
 	// Offset 0xA8: paramAddr // This seems to be a fixed address at 0x000010D8 (ie. *((int *) 0x000010D8) = paramAddr)

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -2380,15 +2380,15 @@ int sceNetAdhocctlGetScanInfo(u32 sizeAddr, u32 bufAddr) {
 
 			hleEatMicro(200);
 			// Return Success
-			return 0;
+			return hleLogDebug(Log::sceNet, 0);
 		}
 
 		// Generic Error
-		return -1;
+		return hleLogError(Log::sceNet, -1);
 	}
 
 	// Library uninitialized
-	return ERROR_NET_ADHOCCTL_NOT_INITIALIZED;
+	return hleLogError(Log::sceNet, ERROR_NET_ADHOCCTL_NOT_INITIALIZED);
 }
 
 // TODO: How many handlers can the PSP actually have for Adhocctl?
@@ -2430,7 +2430,7 @@ static u32 sceNetAdhocctlAddHandler(u32 handlerPtr, u32 handlerArg) {
 	}
 
 	// The id to return is the number of handlers currently registered
-	return retval;
+	return hleNoLog(retval);
 }
 
 u32 NetAdhocctl_Disconnect() {
@@ -2532,12 +2532,10 @@ static u32 sceNetAdhocctlDelHandler(u32 handlerID) {
 
 	if (adhocctlHandlers.find(handlerID) != adhocctlHandlers.end()) {
 		adhocctlHandlers.erase(handlerID);
-		INFO_LOG(Log::sceNet, "sceNetAdhocctlDelHandler(%d) at %08x", handlerID, currentMIPS->pc);
+		return hleLogInfo(Log::sceNet, 0);
 	} else {
-		WARN_LOG(Log::sceNet, "sceNetAdhocctlDelHandler(%d): Invalid Handler ID", handlerID);
+		return hleLogWarning(Log::sceNet, 0, "Invalid Handler ID");
 	}
-
-	return 0;
 }
 
 int NetAdhocctl_Term() {
@@ -2592,13 +2590,12 @@ int NetAdhocctl_Term() {
 
 int sceNetAdhocctlTerm() {
 	// WLAN might be disabled in the middle of successfull multiplayer, but we still need to cleanup right?
-	INFO_LOG(Log::sceNet, "sceNetAdhocctlTerm() at %08x", currentMIPS->pc);
 
 	//if (netAdhocMatchingInited) NetAdhocMatching_Term();
 	int retval = NetAdhocctl_Term();
 
 	hleEatMicro(adhocDefaultDelay);
-	return retval;
+	return hleLogInfo(Log::sceNet, retval);
 }
 
 static int sceNetAdhocctlGetNameByAddr(const char *mac, u32 nameAddr) {
@@ -2648,24 +2645,23 @@ static int sceNetAdhocctlGetNameByAddr(const char *mac, u32 nameAddr) {
 					DEBUG_LOG(Log::sceNet, "sceNetAdhocctlGetNameByAddr - [PeerName:%s]", (char*)nickname);
 
 					// Return Success
-					return 0;
+					return hleLogDebug(Log::sceNet, 0);
 				}
 			}
 
 			// Multithreading Unlock
 			peerlock.unlock();
 
-			DEBUG_LOG(Log::sceNet, "sceNetAdhocctlGetNameByAddr - PlayerName not found");
 			// Player not found
-			return ERROR_NET_ADHOC_NO_ENTRY;
+			return hleLogDebug(Log::sceNet, ERROR_NET_ADHOC_NO_ENTRY, "PlayerName not found");
 		}
 
 		// Invalid Arguments
-		return ERROR_NET_ADHOCCTL_INVALID_ARG;
+		return hleLogError(Log::sceNet, ERROR_NET_ADHOCCTL_INVALID_ARG);
 	}
 
 	// Library uninitialized
-	return ERROR_NET_ADHOCCTL_NOT_INITIALIZED;
+	return hleLogError(Log::sceNet, ERROR_NET_ADHOCCTL_NOT_INITIALIZED);
 }
 
 int sceNetAdhocctlGetPeerInfo(const char *mac, int size, u32 peerInfoAddr) {
@@ -2728,11 +2724,11 @@ int sceNetAdhocctlGetPeerInfo(const char *mac, int size, u32 peerInfoAddr) {
 			peerlock.unlock();
 		}
 		hleEatMicro(50);
-		return retval;
+		return hleNoLog(retval);
 	}
 
 	// Library uninitialized
-	return ERROR_NET_ADHOCCTL_NOT_INITIALIZED;
+	return hleLogError(Log::sceNet, ERROR_NET_ADHOCCTL_NOT_INITIALIZED);
 }
 
 int NetAdhocctl_Create(const char *groupName) {

--- a/Core/HLE/sceOpenPSID.cpp
+++ b/Core/HLE/sceOpenPSID.cpp
@@ -31,32 +31,25 @@ void __OpenPSIDInit() {
 }
 
 void __OpenPSIDShutdown() {
-
 	return;
 }
 
-static int sceOpenPSIDGetOpenPSID(u32 OpenPSIDPtr)
-{
-	WARN_LOG(Log::HLE, "UNTESTED %s(%08x)", __FUNCTION__, OpenPSIDPtr);
-
+static int sceOpenPSIDGetOpenPSID(u32 OpenPSIDPtr) {
 	auto ptr = PSPPointer<SceOpenPSID>::Create(OpenPSIDPtr);
 	if (ptr.IsValid()) {
 		*ptr = dummyOpenPSID;
 		ptr.NotifyWrite("OpenPSIDGetOpenPSID");
 	}
-	return 0;
+	return hleLogWarning(Log::HLE, 0, "UNTESTED");
 }
 
-static int sceOpenPSIDGetPSID(u32 OpenPSIDPtr,u32 unknown)
-{
-	WARN_LOG(Log::HLE, "UNTESTED %s(%08x, %08x)", __FUNCTION__, OpenPSIDPtr, unknown);
-
+static int sceOpenPSIDGetPSID(u32 OpenPSIDPtr, u32 unknown) {
 	auto ptr = PSPPointer<SceOpenPSID>::Create(OpenPSIDPtr);
 	if (ptr.IsValid()) {
 		*ptr = dummyOpenPSID;
 		ptr.NotifyWrite("OpenPSIDGetPSID");
 	}
-	return 0;
+	return hleLogWarning(Log::HLE, 0, "UNTESTED");
 }
 
 /*
@@ -74,21 +67,15 @@ Returns:
 	0 on success, otherwise < 0.
 */
 static s32 sceDdrdb_F013F8BF(u32 pDataPtr, u32 pSigPtr) {
-	ERROR_LOG(Log::HLE, "UNIMPL %s(%08x, %08x)", __FUNCTION__, pDataPtr, pSigPtr);
-
-	return 0;
+	return hleLogError(Log::HLE, 0, "UNIMPL");
 }
 
 // unkPtr might be a pointer to OpenPSID
 static s32 sceOpenPSIDGetProductCode(u32 unkPtr) {
-	ERROR_LOG_REPORT(Log::HLE, "UNIMPL %s(%08x)", __FUNCTION__, unkPtr);
-
-	return 0;
+	return hleLogError(Log::HLE, 0, "UNIMPL");
 }
 
-
-const HLEFunction sceOpenPSID[] = 
-{
+const HLEFunction sceOpenPSID[] = {
 	{0xC69BEBCE, &WrapI_U<sceOpenPSIDGetOpenPSID>,    "sceOpenPSIDGetOpenPSID",      'i', "x" },
 	{0xB29330DE, &WrapI_U<sceOpenPSIDGetProductCode>, "sceOpenPSIDGetProductCode",   'i', "x" },
 };

--- a/Core/HLE/sceP3da.cpp
+++ b/Core/HLE/sceP3da.cpp
@@ -21,17 +21,16 @@
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"
 
-
 static u32 sceP3daBridgeInit(u32 channelsNum, u32 samplesNum)
 {
 	ERROR_LOG_REPORT(Log::sceAudio, "UNIMPL sceP3daBridgeInit(%08x, %08x)", channelsNum, samplesNum);
-	return 0;
+	return hleNoLog(0);
 }
 
 static u32 sceP3daBridgeExit()
 {
 	ERROR_LOG_REPORT(Log::sceAudio, "UNIMPL sceP3daBridgeExit()");
-	return 0;
+	return hleNoLog(0);
 }
 
 static inline int getScaleValue(u32 channelsNum) {
@@ -45,7 +44,6 @@ static inline int getScaleValue(u32 channelsNum) {
 
 static u32 sceP3daBridgeCore(u32 p3daCoreAddr, u32 channelsNum, u32 samplesNum, u32 inputAddr, u32 outputAddr)
 {
-	DEBUG_LOG(Log::sceAudio, "sceP3daBridgeCore(%08x, %08x, %08x, %08x, %08x)", p3daCoreAddr, channelsNum, samplesNum, inputAddr, outputAddr);
 	if (Memory::IsValidAddress(inputAddr) && Memory::IsValidAddress(outputAddr)) {
 		int scaleval = getScaleValue(channelsNum);
 		s16_le *outbuf = (s16_le *)Memory::GetPointerWriteUnchecked(outputAddr);
@@ -63,7 +61,7 @@ static u32 sceP3daBridgeCore(u32 p3daCoreAddr, u32 channelsNum, u32 samplesNum, 
 		}
 	}
 	// same as sas core
-	return hleDelayResult(0, "p3da core", 240);
+	return hleDelayResult(hleLogDebug(Log::sceAudio, 0), "p3da core", 240);
 }
 
 const HLEFunction sceP3da[] =

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -426,7 +426,7 @@ static int sceKernelVolatileMemLock(int type, u32 paddr, u32 psize) {
 		break;
 	}
 
-	return error;
+	return hleNoLog(error);
 }
 
 

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1367,20 +1367,20 @@ static int scePsmfPlayerStart(u32 psmfPlayer, u32 psmfPlayerData, int initPts)
 	if (psmfplayer->totalAudioStreams > 0) {
 		if (playerData->audioCodec != 0x0F && playerData->audioCodec != 0x01) {
 			ERROR_LOG_REPORT(Log::ME, "scePsmfPlayerStart(%08x, %08x, %d): invalid audio codec %02x", psmfPlayer, psmfPlayerData, initPts, playerData->audioCodec);
-			return ERROR_PSMFPLAYER_INVALID_STREAM;
+			return hleNoLog(ERROR_PSMFPLAYER_INVALID_STREAM);
 		}
 		if (playerData->audioStreamNum >= psmfplayer->totalAudioStreams) {
 			ERROR_LOG_REPORT(Log::ME, "scePsmfPlayerStart(%08x, %08x, %d): unable to change audio stream to %d", psmfPlayer, psmfPlayerData, initPts, playerData->audioStreamNum);
-			return ERROR_PSMFPLAYER_INVALID_CONFIG;
+			return hleNoLog(ERROR_PSMFPLAYER_INVALID_CONFIG);
 		}
 	}
 	if (playerData->videoCodec != 0x0E && playerData->videoCodec != 0x00) {
 		ERROR_LOG_REPORT(Log::ME, "scePsmfPlayerStart(%08x, %08x, %d): invalid video codec %02x", psmfPlayer, psmfPlayerData, initPts, playerData->videoCodec);
-		return ERROR_PSMFPLAYER_INVALID_STREAM;
+		return hleNoLog(ERROR_PSMFPLAYER_INVALID_STREAM);
 	}
 	if (playerData->videoStreamNum < 0 || playerData->videoStreamNum >= psmfplayer->totalVideoStreams) {
 		ERROR_LOG_REPORT(Log::ME, "scePsmfPlayerStart(%08x, %08x, %d): unable to change video stream to %d", psmfPlayer, psmfPlayerData, initPts, playerData->videoStreamNum);
-		return ERROR_PSMFPLAYER_INVALID_CONFIG;
+		return hleNoLog(ERROR_PSMFPLAYER_INVALID_CONFIG);
 	}
 
 	switch ((PsmfPlayerMode)(s32)playerData->playMode) {

--- a/Core/HLE/sceRtc.cpp
+++ b/Core/HLE/sceRtc.cpp
@@ -640,11 +640,11 @@ static int sceRtcCompareTick(u32 tick1Ptr, u32 tick2Ptr)
 		u64 tick1 = Memory::Read_U64(tick1Ptr);
 		u64 tick2 = Memory::Read_U64(tick2Ptr);
 		if (tick1 > tick2)
-			return 1;
+			return hleNoLog(1);
 		if (tick1 < tick2)
-			return -1;
+			return hleNoLog(-1);
 	}
-	return 0;
+	return hleNoLog(0);
 }
 
 static int sceRtcTickAddTicks(u32 destTickPtr, u32 srcTickPtr, u64 numTicks)
@@ -656,9 +656,7 @@ static int sceRtcTickAddTicks(u32 destTickPtr, u32 srcTickPtr, u64 numTicks)
 		srcTick += numTicks;
 		Memory::Write_U64(srcTick, destTickPtr);
 	}
-
-	DEBUG_LOG(Log::sceRtc, "sceRtcTickAddTicks(%x,%x,%llu)", destTickPtr, srcTickPtr, numTicks);
-	return 0;
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static int sceRtcTickAddMicroseconds(u32 destTickPtr,u32 srcTickPtr, u64 numMS)
@@ -670,9 +668,7 @@ static int sceRtcTickAddMicroseconds(u32 destTickPtr,u32 srcTickPtr, u64 numMS)
 		srcTick += numMS;
 		Memory::Write_U64(srcTick, destTickPtr);
 	}
-
-	DEBUG_LOG(Log::sceRtc, "sceRtcTickAddMicroseconds(%x,%x,%llu)", destTickPtr, srcTickPtr, numMS);
-	return 0;
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static int sceRtcTickAddSeconds(u32 destTickPtr, u32 srcTickPtr, u64 numSecs)
@@ -684,8 +680,7 @@ static int sceRtcTickAddSeconds(u32 destTickPtr, u32 srcTickPtr, u64 numSecs)
 		srcTick += numSecs * 1000000UL;
 		Memory::Write_U64(srcTick, destTickPtr);
 	}
-	DEBUG_LOG(Log::sceRtc, "sceRtcTickAddSeconds(%x,%x,%llu)", destTickPtr, srcTickPtr, numSecs);
-	return 0;
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static int sceRtcTickAddMinutes(u32 destTickPtr, u32 srcTickPtr, u64 numMins)
@@ -697,8 +692,7 @@ static int sceRtcTickAddMinutes(u32 destTickPtr, u32 srcTickPtr, u64 numMins)
 		srcTick += numMins*60000000UL;
 		Memory::Write_U64(srcTick, destTickPtr);
 	}
-	DEBUG_LOG(Log::sceRtc, "sceRtcTickAddMinutes(%x,%x,%llu)", destTickPtr, srcTickPtr, numMins);
-	return 0;
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static int sceRtcTickAddHours(u32 destTickPtr, u32 srcTickPtr, int numHours)
@@ -709,8 +703,7 @@ static int sceRtcTickAddHours(u32 destTickPtr, u32 srcTickPtr, int numHours)
 		srcTick += numHours * 3600ULL * 1000000ULL;
 		Memory::Write_U64(srcTick, destTickPtr);
 	}
-	DEBUG_LOG(Log::sceRtc, "sceRtcTickAddMinutes(%d,%d,%d)", destTickPtr, srcTickPtr, numHours);
-	return 0;
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static int sceRtcTickAddDays(u32 destTickPtr, u32 srcTickPtr, int numDays)
@@ -722,8 +715,7 @@ static int sceRtcTickAddDays(u32 destTickPtr, u32 srcTickPtr, int numDays)
 		srcTick += numDays * 86400ULL * 1000000ULL;
 		Memory::Write_U64(srcTick, destTickPtr);
 	}
-	DEBUG_LOG(Log::sceRtc, "sceRtcTickAddDays(%d,%d,%d)", destTickPtr, srcTickPtr, numDays);
-	return 0;
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static int sceRtcTickAddWeeks(u32 destTickPtr, u32 srcTickPtr, int numWeeks)
@@ -735,16 +727,14 @@ static int sceRtcTickAddWeeks(u32 destTickPtr, u32 srcTickPtr, int numWeeks)
 		srcTick += numWeeks * 7ULL * 86400ULL * 1000000ULL;
 		Memory::Write_U64(srcTick, destTickPtr);
 	}
-	DEBUG_LOG(Log::sceRtc, "sceRtcTickAddWeeks(%d,%d,%d)", destTickPtr, srcTickPtr, numWeeks);
-	return 0;
+	return hleLogDebug(Log::sceRtc, 0);
 }
 
 static int sceRtcTickAddMonths(u32 destTickPtr, u32 srcTickPtr, int numMonths)
 {
 	if (!Memory::IsValidAddress(destTickPtr) || !Memory::IsValidAddress(srcTickPtr))
 	{
-		WARN_LOG(Log::sceRtc, "sceRtcTickAddMonths(%08x, %08x, %d): invalid address", destTickPtr, srcTickPtr, numMonths);
-		return -1;
+		return hleLogWarning(Log::sceRtc, -1, "invalid address");
 	}
 
 	u64 srcTick = Memory::Read_U64(srcTickPtr);
@@ -776,15 +766,13 @@ static int sceRtcTickAddMonths(u32 destTickPtr, u32 srcTickPtr, int numMonths)
 	}
 
 	DEBUG_LOG(Log::sceRtc, "sceRtcTickAddMonths(%08x, %08x = %lld, %d)", destTickPtr, srcTickPtr, srcTick, numMonths);
-	return 0;
+	return hleNoLog(0);
 }
 
 static int sceRtcTickAddYears(u32 destTickPtr, u32 srcTickPtr, int numYears)
 {
-	if (!Memory::IsValidAddress(destTickPtr) || !Memory::IsValidAddress(srcTickPtr))
-	{
-		WARN_LOG(Log::sceRtc, "sceRtcTickAddYears(%08x, %08x, %d): invalid address", destTickPtr, srcTickPtr, numYears);
-		return -1;
+	if (!Memory::IsValidAddress(destTickPtr) || !Memory::IsValidAddress(srcTickPtr)) {
+		return hleLogWarning(Log::sceRtc, -1, "invalid address");
 	}
 
 	u64 srcTick = Memory::Read_U64(srcTickPtr);
@@ -804,7 +792,7 @@ static int sceRtcTickAddYears(u32 destTickPtr, u32 srcTickPtr, int numYears)
 	}
 
 	DEBUG_LOG(Log::sceRtc, "sceRtcTickAddYears(%08x, %08x = %lld, %d)", destTickPtr, srcTickPtr, srcTick, numYears);
-	return 0;
+	return hleNoLog(0);
 }
 
 static int sceRtcParseDateTime(u32 destTickPtr, u32 dateStringPtr)

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -480,7 +480,7 @@ static u32 sceSasSetKeyOff(u32 core, int voiceNum) {
 	} else {
 		__SasDrain();
 		if (sas->voices[voiceNum].paused || !sas->voices[voiceNum].on) {
-			return ERROR_SAS_VOICE_PAUSED;
+			return hleLogDebug(Log::sceSas, ERROR_SAS_VOICE_PAUSED);  // this is ok
 		}
 
 		SasVoice &v = sas->voices[voiceNum];
@@ -509,11 +509,10 @@ static u32 sceSasSetSL(u32 core, int voiceNum, int level) {
 		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_VOICE, "invalid voiceNum");
 	}
 
-	DEBUG_LOG(Log::sceSas, "sceSasSetSL(%08x, %i, %08x)", core, voiceNum, level);
 	__SasDrain();
 	SasVoice &v = sas->voices[voiceNum];
 	v.envelope.SetSustainLevel(level);
-	return 0;
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 static u32 sceSasSetADSR(u32 core, int voiceNum, int flag, int a, int d, int s, int r) {
@@ -524,15 +523,13 @@ static u32 sceSasSetADSR(u32 core, int voiceNum, int flag, int a, int d, int s, 
 	int invalid = (a < 0 ? 0x1 : 0) | (d < 0 ? 0x2 : 0) | (s < 0 ? 0x4 : 0) | (r < 0 ? 0x8 : 0);
 	if (invalid & flag) {
 		WARN_LOG_REPORT(Log::sceSas, "sceSasSetADSR(%08x, %i, %i, %08x, %08x, %08x, %08x): invalid value", core, voiceNum, flag, a, d, s, r);
-		return ERROR_SAS_INVALID_ADSR_RATE;
+		return hleNoLog(ERROR_SAS_INVALID_ADSR_RATE);
 	}
-
-	DEBUG_LOG(Log::sceSas, "0=sceSasSetADSR(%08x, %i, %i, %08x, %08x, %08x, %08x)", core, voiceNum, flag, a, d, s, r);
 
 	__SasDrain();
 	SasVoice &v = sas->voices[voiceNum];
 	v.envelope.SetRate(flag, a, d, s, r);
-	return 0;
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 static u32 sceSasSetADSRMode(u32 core, int voiceNum, int flag, int a, int d, int s, int r) {
@@ -563,18 +560,17 @@ static u32 sceSasSetADSRMode(u32 core, int voiceNum, int flag, int a, int d, int
 	if (invalid & flag) {
 		if (a == 5 && d == 5 && s == 5 && r == 5) {
 			// Some games do this right at init.  It seems to fail even on a PSP, but let's not report it.
-			DEBUG_LOG(Log::sceSas, "sceSasSetADSRMode(%08x, %i, %i, %08x, %08x, %08x, %08x): invalid modes", core, voiceNum, flag, a, d, s, r);
+			return hleLogDebug(Log::sceSas, ERROR_SAS_INVALID_ADSR_CURVE_MODE, "sceSasSetADSRMode(%08x, %i, %i, %08x, %08x, %08x, %08x): invalid modes", core, voiceNum, flag, a, d, s, r);
 		} else {
 			WARN_LOG_REPORT(Log::sceSas, "sceSasSetADSRMode(%08x, %i, %i, %08x, %08x, %08x, %08x): invalid modes", core, voiceNum, flag, a, d, s, r);
+			return hleNoLog(ERROR_SAS_INVALID_ADSR_CURVE_MODE);
 		}
-		return ERROR_SAS_INVALID_ADSR_CURVE_MODE;
 	}
 
-	DEBUG_LOG(Log::sceSas, "sceSasSetADSRMode(%08x, %i, %i, %08x, %08x, %08x, %08x)", core, voiceNum, flag, a, d, s, r);
 	__SasDrain();
 	SasVoice &v = sas->voices[voiceNum];
 	v.envelope.SetEnvelope(flag, a, d, s, r);
-	return 0;
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -226,29 +226,27 @@ void __SasShutdown() {
 	sas = 0;
 }
 
-
 static u32 sceSasInit(u32 core, u32 grainSize, u32 maxVoices, u32 outputMode, u32 sampleRate) {
 	if (!Memory::IsValidAddress(core) || (core & 0x3F) != 0) {
 		ERROR_LOG_REPORT(Log::sceSas, "sceSasInit(%08x, %i, %i, %i, %i): bad core address", core, grainSize, maxVoices, outputMode, sampleRate);
-		return ERROR_SAS_BAD_ADDRESS;
+		return hleNoLog(ERROR_SAS_BAD_ADDRESS);
 	}
 	if (maxVoices == 0 || maxVoices > PSP_SAS_VOICES_MAX) {
 		ERROR_LOG_REPORT(Log::sceSas, "sceSasInit(%08x, %i, %i, %i, %i): bad max voices", core, grainSize, maxVoices, outputMode, sampleRate);
-		return ERROR_SAS_INVALID_MAX_VOICES;
+		return hleNoLog(ERROR_SAS_INVALID_MAX_VOICES);
 	}
 	if (grainSize < 0x40 || grainSize > 0x800 || (grainSize & 0x1F) != 0) {
 		ERROR_LOG_REPORT(Log::sceSas, "sceSasInit(%08x, %i, %i, %i, %i): bad grain size", core, grainSize, maxVoices, outputMode, sampleRate);
-		return ERROR_SAS_INVALID_GRAIN;
+		return hleNoLog(ERROR_SAS_INVALID_GRAIN);
 	}
 	if (outputMode != 0 && outputMode != 1) {
 		ERROR_LOG_REPORT(Log::sceSas, "sceSasInit(%08x, %i, %i, %i, %i): bad output mode", core, grainSize, maxVoices, outputMode, sampleRate);
-		return ERROR_SAS_INVALID_OUTPUT_MODE;
+		return hleNoLog(ERROR_SAS_INVALID_OUTPUT_MODE);
 	}
 	if (sampleRate != 44100) {
 		ERROR_LOG_REPORT(Log::sceSas, "sceSasInit(%08x, %i, %i, %i, %i): bad sample rate", core, grainSize, maxVoices, outputMode, sampleRate);
-		return ERROR_SAS_INVALID_SAMPLE_RATE;
+		return hleNoLog(ERROR_SAS_INVALID_SAMPLE_RATE);
 	}
-	INFO_LOG(Log::sceSas, "sceSasInit(%08x, %i, %i, %i, %i)", core, grainSize, maxVoices, outputMode, sampleRate);
 
 	sas->SetGrainSize(grainSize);
 	// Seems like the maxVoices param is actually ignored for all intents and purposes.
@@ -259,7 +257,7 @@ static u32 sceSasInit(u32 core, u32 grainSize, u32 maxVoices, u32 outputMode, u3
 		sas->voices[i].playing = false;
 		sas->voices[i].loop = false;
 	}
-	return 0;
+	return hleLogInfo(Log::sceSas, 0);
 }
 
 static u32 sceSasGetEndFlag(u32 core) {
@@ -270,8 +268,7 @@ static u32 sceSasGetEndFlag(u32 core) {
 			endFlag |= (1 << i);
 	}
 
-	VERBOSE_LOG(Log::sceSas, "%08x=sceSasGetEndFlag(%08x)", endFlag, core);
-	return endFlag;
+	return hleLogVerbose(Log::sceSas, endFlag);
 }
 
 static int delaySasResult(int result) {
@@ -319,7 +316,7 @@ static u32 _sceSasCoreWithMix(u32 core, u32 inoutAddr, int leftVolume, int right
 
 	__SasEnqueueMix(inoutAddr, inoutAddr, leftVolume, rightVolume);
 
-	return hleLogVerbose(Log::sceSas, delaySasResult(0));
+	return delaySasResult(hleLogVerbose(Log::sceSas, 0));
 }
 
 static u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loop) {
@@ -329,20 +326,18 @@ static u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loo
 
 	if (size == 0 || ((u32)size & 0xF) != 0) {
 		if (size == 0) {
-			DEBUG_LOG(Log::sceSas, "%s: invalid size %d", __FUNCTION__, size);
+			return hleLogDebug(Log::sceSas, ERROR_SAS_INVALID_PARAMETER, "invalid size %d", size);
 		} else {
-			WARN_LOG(Log::sceSas, "%s: invalid size %d", __FUNCTION__, size);
+			return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_PARAMETER, "invalid size %d", size);
 		}
-		return ERROR_SAS_INVALID_PARAMETER;
 	}
 	if (loop != 0 && loop != 1) {
 		WARN_LOG_REPORT(Log::sceSas, "%s: invalid loop mode %d", __FUNCTION__, loop);
-		return ERROR_SAS_INVALID_LOOP_POS;
+		return hleNoLog(ERROR_SAS_INVALID_LOOP_POS);
 	}
 
 	if (!Memory::IsValidAddress(vagAddr)) {
-		ERROR_LOG(Log::sceSas, "%s: Ignoring invalid VAG audio address %08x", __FUNCTION__, vagAddr);
-		return 0;
+		return hleLogError(Log::sceSas, 0, "Ignoring invalid VAG audio address %08x", vagAddr);
 	}
 
 	__SasDrain();
@@ -372,7 +367,7 @@ static u32 sceSasSetVoice(u32 core, int voiceNum, u32 vagAddr, int size, int loo
 		v.playing = true;
 	}
 	v.vag.Start(vagAddr, size, loop != 0);
-	return 0;
+	return hleNoLog(0);
 }
 
 static u32 sceSasSetVoicePCM(u32 core, int voiceNum, u32 pcmAddr, int size, int loopPos) {
@@ -380,16 +375,14 @@ static u32 sceSasSetVoicePCM(u32 core, int voiceNum, u32 pcmAddr, int size, int 
 		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_VOICE, "invalid voicenum");
 	}
 	if (size <= 0 || size > 0x10000) {
-		WARN_LOG(Log::sceSas, "%s: invalid size %d", __FUNCTION__, size);
-		return ERROR_SAS_INVALID_PCM_SIZE;
+		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_PCM_SIZE, "invalid size %d", size);
 	}
 	if (loopPos >= size) {
 		ERROR_LOG_REPORT(Log::sceSas, "sceSasSetVoicePCM(%08x, %i, %08x, %i, %i): bad loop pos", core, voiceNum, pcmAddr, size, loopPos);
-		return ERROR_SAS_INVALID_LOOP_POS;
+		return hleNoLog(ERROR_SAS_INVALID_LOOP_POS);
 	}
 	if (!Memory::IsValidAddress(pcmAddr)) {
-		ERROR_LOG(Log::sceSas, "Ignoring invalid PCM audio address %08x", pcmAddr);
-		return 0;
+		return hleLogError(Log::sceSas, 0, "Ignoring invalid PCM audio address %08x", pcmAddr);
 	}
 
 	__SasDrain();
@@ -397,8 +390,6 @@ static u32 sceSasSetVoicePCM(u32 core, int voiceNum, u32 pcmAddr, int size, int 
 	if (v.type == VOICETYPE_ATRAC3) {
 		return hleLogError(Log::sceSas, ERROR_SAS_ATRAC3_ALREADY_SET, "voice is already ATRAC3");
 	}
-
-	DEBUG_LOG(Log::sceSas, "sceSasSetVoicePCM(%08x, %i, %08x, %i, %i)", core, voiceNum, pcmAddr, size, loopPos);
 
 	u32 prevPcmAddr = v.pcmAddr;
 	v.type = VOICETYPE_PCM;
@@ -408,7 +399,7 @@ static u32 sceSasSetVoicePCM(u32 core, int voiceNum, u32 pcmAddr, int size, int 
 	v.pcmLoopPos = loopPos >= 0 ? loopPos : 0;
 	v.loop = loopPos >= 0 ? true : false;
 	v.playing = true;
-	return 0;
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 static u32 sceSasGetPauseFlag(u32 core) {
@@ -419,13 +410,10 @@ static u32 sceSasGetPauseFlag(u32 core) {
 			pauseFlag |= (1 << i);
 	}
 
-	DEBUG_LOG(Log::sceSas, "sceSasGetPauseFlag(%08x)", pauseFlag);
-	return pauseFlag;
+	return hleLogDebug(Log::sceSas, pauseFlag);
 }
 
 static u32 sceSasSetPause(u32 core, u32 voicebit, int pause) {
-	DEBUG_LOG(Log::sceSas, "sceSasSetPause(%08x, %08x, %i)", core, voicebit, pause);
-
 	__SasDrain();
 	for (int i = 0; voicebit != 0; i++, voicebit >>= 1) {
 		if (i < PSP_SAS_VOICES_MAX && i >= 0) {
@@ -434,20 +422,18 @@ static u32 sceSasSetPause(u32 core, u32 voicebit, int pause) {
 		}
 	}
 
-	return 0;
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 static u32 sceSasSetVolume(u32 core, int voiceNum, int leftVol, int rightVol, int effectLeftVol, int effectRightVol) {
-	DEBUG_LOG(Log::sceSas, "sceSasSetVolume(%08x, %i, %i, %i, %i, %i)", core, voiceNum, leftVol, rightVol, effectLeftVol, effectRightVol);
-
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
-		WARN_LOG(Log::sceSas, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
-		return ERROR_SAS_INVALID_VOICE;
+		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_VOICE, "invalid voicenum");
 	}
 	bool overVolume = abs(leftVol) > PSP_SAS_VOL_MAX || abs(rightVol) > PSP_SAS_VOL_MAX;
 	overVolume = overVolume || abs(effectLeftVol) > PSP_SAS_VOL_MAX || abs(effectRightVol) > PSP_SAS_VOL_MAX;
-	if (overVolume)
-		return ERROR_SAS_INVALID_VOLUME;
+	if (overVolume) {
+		return hleLogError(Log::sceSas, ERROR_SAS_INVALID_VOLUME);
+	}
 
 	__SasDrain();
 	SasVoice &v = sas->voices[voiceNum];
@@ -455,52 +441,43 @@ static u32 sceSasSetVolume(u32 core, int voiceNum, int leftVol, int rightVol, in
 	v.volumeRight = rightVol;
 	v.effectLeft = effectLeftVol;
 	v.effectRight = effectRightVol;
-	return 0;
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 static u32 sceSasSetPitch(u32 core, int voiceNum, int pitch) {
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
-		WARN_LOG(Log::sceSas, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
-		return ERROR_SAS_INVALID_VOICE;
+		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_VOICE, "invalid voiceNum");
 	}
 	if (pitch < PSP_SAS_PITCH_MIN || pitch > PSP_SAS_PITCH_MAX) {
-		WARN_LOG(Log::sceSas, "sceSasSetPitch(%08x, %i, %i): bad pitch", core, voiceNum, pitch);
-		return ERROR_SAS_INVALID_PITCH;
+		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_PITCH, "bad pitch");
 	}
 
-	DEBUG_LOG(Log::sceSas, "sceSasSetPitch(%08x, %i, %i)", core, voiceNum, pitch);
 	__SasDrain();
 	SasVoice &v = sas->voices[voiceNum];
 	v.pitch = pitch;
-	return 0;
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 static u32 sceSasSetKeyOn(u32 core, int voiceNum) {
-	DEBUG_LOG(Log::sceSas, "sceSasSetKeyOn(%08x, %i)", core, voiceNum);
-
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
-		WARN_LOG(Log::sceSas, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
-		return ERROR_SAS_INVALID_VOICE;
+		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_VOICE, "invalid voiceNum");
 	}
 
 	__SasDrain();
 	if (sas->voices[voiceNum].paused || sas->voices[voiceNum].on) {
-		return ERROR_SAS_VOICE_PAUSED;
+		return hleLogError(Log::sceSas, ERROR_SAS_VOICE_PAUSED);
 	}
 
 	SasVoice &v = sas->voices[voiceNum];
 	v.KeyOn();
-	return 0;
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 // sceSasSetKeyOff can be used to start sounds, that just sound during the Release phase!
 static u32 sceSasSetKeyOff(u32 core, int voiceNum) {
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0) {
-		WARN_LOG(Log::sceSas, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
-		return ERROR_SAS_INVALID_VOICE;
+		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_VOICE, "invalid voiceNum");
 	} else {
-		DEBUG_LOG(Log::sceSas, "sceSasSetKeyOff(%08x, %i)", core, voiceNum);
-
 		__SasDrain();
 		if (sas->voices[voiceNum].paused || !sas->voices[voiceNum].on) {
 			return ERROR_SAS_VOICE_PAUSED;
@@ -508,33 +485,28 @@ static u32 sceSasSetKeyOff(u32 core, int voiceNum) {
 
 		SasVoice &v = sas->voices[voiceNum];
 		v.KeyOff();
-		return 0;
+		return hleLogDebug(Log::sceSas, 0);
 	}
 }
 
 static u32 sceSasSetNoise(u32 core, int voiceNum, int freq) {
-	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
-		WARN_LOG(Log::sceSas, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
-		return ERROR_SAS_INVALID_VOICE;
+	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0) {
+		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_VOICE, "invalid voiceNum");
 	}
 	if (freq < 0 || freq >= 64) {
-		DEBUG_LOG(Log::sceSas, "sceSasSetNoise(%08x, %i, %i)", core, voiceNum, freq);
-		return ERROR_SAS_INVALID_NOISE_FREQ;
+		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_NOISE_FREQ);
 	}
-
-	DEBUG_LOG(Log::sceSas, "sceSasSetNoise(%08x, %i, %i)", core, voiceNum, freq);
 
 	__SasDrain();
 	SasVoice &v = sas->voices[voiceNum];
 	v.type = VOICETYPE_NOISE;
 	v.noiseFreq = freq;
-	return 0;
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 static u32 sceSasSetSL(u32 core, int voiceNum, int level) {
 	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
-		WARN_LOG(Log::sceSas, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
-		return ERROR_SAS_INVALID_VOICE;
+		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_VOICE, "invalid voiceNum");
 	}
 
 	DEBUG_LOG(Log::sceSas, "sceSasSetSL(%08x, %i, %08x)", core, voiceNum, level);
@@ -545,9 +517,8 @@ static u32 sceSasSetSL(u32 core, int voiceNum, int level) {
 }
 
 static u32 sceSasSetADSR(u32 core, int voiceNum, int flag, int a, int d, int s, int r) {
-	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
-		WARN_LOG(Log::sceSas, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
-		return ERROR_SAS_INVALID_VOICE;
+	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0) {
+		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_VOICE, "invalid voiceNum");
 	}
 	// Create a mask like flag for the invalid values.
 	int invalid = (a < 0 ? 0x1 : 0) | (d < 0 ? 0x2 : 0) | (s < 0 ? 0x4 : 0) | (r < 0 ? 0x8 : 0);
@@ -565,9 +536,8 @@ static u32 sceSasSetADSR(u32 core, int voiceNum, int flag, int a, int d, int s, 
 }
 
 static u32 sceSasSetADSRMode(u32 core, int voiceNum, int flag, int a, int d, int s, int r) {
-	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
-		WARN_LOG(Log::sceSas, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
-		return ERROR_SAS_INVALID_VOICE;
+	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0) {
+		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_VOICE, "invalid voiceNum");
 	}
 
 	// Probably by accident (?), the PSP ignores the top bit of these values.
@@ -609,35 +579,29 @@ static u32 sceSasSetADSRMode(u32 core, int voiceNum, int flag, int a, int d, int
 
 
 static u32 sceSasSetSimpleADSR(u32 core, int voiceNum, u32 ADSREnv1, u32 ADSREnv2) {
-	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
-		WARN_LOG(Log::sceSas, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
-		return ERROR_SAS_INVALID_VOICE;
+	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0) {
+		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_VOICE, "invalid voiceNum");
 	}
 	// This bit could be related to decay type or systain type, but gives an error if you try to set it.
 	if ((ADSREnv2 >> 13) & 1) {
-		WARN_LOG_REPORT(Log::sceSas, "sceSasSetSimpleADSR(%08x, %d, %04x, %04x): Invalid ADSREnv2", core, voiceNum, ADSREnv1, ADSREnv2);
-		return ERROR_SAS_INVALID_ADSR_CURVE_MODE;
+		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_ADSR_CURVE_MODE, "Invalid ADSREnv2");
 	}
-
-	DEBUG_LOG(Log::sceSas, "sasSetSimpleADSR(%08x, %i, %08x, %08x)", core, voiceNum, ADSREnv1, ADSREnv2);
 
 	__SasDrain();
 	SasVoice &v = sas->voices[voiceNum];
 	v.envelope.SetSimpleEnvelope(ADSREnv1 & 0xFFFF, ADSREnv2 & 0xFFFF);
-	return 0;
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 static u32 sceSasGetEnvelopeHeight(u32 core, int voiceNum) {
-	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0)	{
-		ERROR_LOG(Log::sceSas, "%s: invalid voicenum %d", __FUNCTION__, voiceNum);
-		return ERROR_SAS_INVALID_VOICE;
+	if (voiceNum >= PSP_SAS_VOICES_MAX || voiceNum < 0) {
+		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_VOICE, "invalid voiceNum");
 	}
 
 	__SasDrain();
 	SasVoice &v = sas->voices[voiceNum];
 	int height = v.envelope.GetHeight();
-	DEBUG_LOG(Log::sceSas, "%i = sceSasGetEnvelopeHeight(%08x, %i)", height, core, voiceNum);
-	return height;
+	return hleLogDebug(Log::sceSas, height);
 }
 
 static u32 sceSasRevType(u32 core, int type) {
@@ -683,39 +647,33 @@ static u32 sceSasRevVON(u32 core, int dry, int wet) {
 }
 
 static u32 sceSasGetGrain(u32 core) {
-	DEBUG_LOG(Log::sceSas, "sceSasGetGrain(%08x)", core);
-	return sas->GetGrainSize();
+	return hleLogDebug(Log::sceSas, sas->GetGrainSize());
 }
 
 static u32 sceSasSetGrain(u32 core, int grain) {
-	INFO_LOG(Log::sceSas, "sceSasSetGrain(%08x, %i)", core, grain);
 	__SasDrain();
 	sas->SetGrainSize(grain);
-	return 0;
+	return hleLogInfo(Log::sceSas, 0);
 }
 
 static u32 sceSasGetOutputMode(u32 core) {
-	DEBUG_LOG(Log::sceSas, "sceSasGetOutputMode(%08x)", core);
-	return sas->outputMode;
+	return hleLogDebug(Log::sceSas, sas->outputMode);
 }
 
 static u32 sceSasSetOutputMode(u32 core, u32 outputMode) {
 	if (outputMode != 0 && outputMode != 1) {
 		ERROR_LOG_REPORT(Log::sceSas, "sceSasSetOutputMode(%08x, %i): bad output mode", core, outputMode);
-		return ERROR_SAS_INVALID_OUTPUT_MODE;
+		return hleNoLog(ERROR_SAS_INVALID_OUTPUT_MODE);
 	}
-	DEBUG_LOG(Log::sceSas, "sceSasSetOutputMode(%08x, %i)", core, outputMode);
+
 	__SasDrain();
 	sas->outputMode = outputMode;
-
-	return 0;
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 static u32 sceSasGetAllEnvelopeHeights(u32 core, u32 heightsAddr) {
-	DEBUG_LOG(Log::sceSas, "sceSasGetAllEnvelopeHeights(%08x, %i)", core, heightsAddr);
-
 	if (!Memory::IsValidAddress(heightsAddr)) {
-		return ERROR_SAS_INVALID_PARAMETER;
+		return hleLogError(Log::sceSas, ERROR_SAS_INVALID_PARAMETER);
 	}
 
 	__SasDrain();
@@ -724,17 +682,17 @@ static u32 sceSasGetAllEnvelopeHeights(u32 core, u32 heightsAddr) {
 		Memory::Write_U32(voiceHeight, heightsAddr + i * 4);
 	}
 
-	return 0;
+	return hleLogDebug(Log::sceSas, 0);
 }
 
 static u32 sceSasSetTriangularWave(u32 sasCore, int voice, int unknown) {
 	ERROR_LOG_REPORT(Log::sceSas, "UNIMPL sceSasSetTriangularWave(%08x, %i, %i)", sasCore, voice, unknown);
-	return 0;
+	return hleNoLog(0);
 }
 
 static u32 sceSasSetSteepWave(u32 sasCore, int voice, int unknown) {
 	ERROR_LOG_REPORT(Log::sceSas, "UNIMPL sceSasSetSteepWave(%08x, %i, %i)", sasCore, voice, unknown);
-	return 0;
+	return hleNoLog(0);
 }
 
 static u32 __sceSasSetVoiceATRAC3(u32 core, int voiceNum, u32 atrac3Context) {
@@ -766,7 +724,7 @@ static u32 __sceSasConcatenateATRAC3(u32 core, int voiceNum, u32 atrac3DataAddr,
 	SasVoice &v = sas->voices[voiceNum];
 	if (Memory::IsValidAddress(atrac3DataAddr))
 		v.atrac3.addStreamData(atrac3DataAddr, atrac3DataLength);
-	return 0;
+	return hleNoLog(0);
 }
 
 static u32 __sceSasUnsetATRAC3(u32 core, int voiceNum) {

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -1152,16 +1152,12 @@ static u32 sceUtilityGetSystemParamInt(u32 id, u32 destaddr) {
 	return hleLogInfo(Log::sceUtility, 0, "param: %08x", param);
 }
 
-static u32 sceUtilityLoadNetModule(u32 module)
-{
-	DEBUG_LOG(Log::sceUtility,"FAKE: sceUtilityLoadNetModule(%i)", module);
-	return 0;
+static u32 sceUtilityLoadNetModule(u32 module) {
+	return hleLogInfo(Log::sceUtility, 0, "FAKE");
 }
 
-static u32 sceUtilityUnloadNetModule(u32 module)
-{
-	DEBUG_LOG(Log::sceUtility,"FAKE: sceUtilityUnloadNetModule(%i)", module);
-	return 0;
+static u32 sceUtilityUnloadNetModule(u32 module) {
+	return hleLogInfo(Log::sceUtility, 0, "FAKE");
 }
 
 static int sceUtilityNpSigninInitStart(u32 paramsPtr) {
@@ -1204,55 +1200,44 @@ static int sceUtilityNpSigninGetStatus() {
 	return hleLogVerbose(Log::sceUtility, status);
 }
 
-static void sceUtilityInstallInitStart(u32 unknown)
-{
+static void sceUtilityInstallInitStart(u32 unknown) {
 	WARN_LOG_REPORT(Log::sceUtility, "UNIMPL sceUtilityInstallInitStart()");
+	return hleNoLogVoid();
 }
 
-static int sceUtilityStoreCheckoutShutdownStart()
-{
-	ERROR_LOG(Log::sceUtility,"UNIMPL sceUtilityStoreCheckoutShutdownStart()");
-	return 0;
+static int sceUtilityStoreCheckoutShutdownStart() {
+	return hleLogError(Log::sceUtility, 0, "UNIMPL");
 }
 
-static int sceUtilityStoreCheckoutInitStart(u32 paramsPtr)
-{
-	ERROR_LOG(Log::sceUtility,"UNIMPL sceUtilityStoreCheckoutInitStart(%d)", paramsPtr);
-	return 0;
+static int sceUtilityStoreCheckoutInitStart(u32 paramsPtr) {
+	return hleLogError(Log::sceUtility, 0, "UNIMPL");
 }
 
-static int sceUtilityStoreCheckoutUpdate(int drawSpeed)
-{
-	ERROR_LOG(Log::sceUtility,"UNIMPL sceUtilityStoreCheckoutUpdate(%d)", drawSpeed);
-	return 0;
+static int sceUtilityStoreCheckoutUpdate(int drawSpeed) {
+	return hleLogError(Log::sceUtility, 0, "UNIMPL");
 }
 
-static int sceUtilityStoreCheckoutGetStatus()
-{
-	ERROR_LOG(Log::sceUtility,"UNIMPL sceUtilityStoreCheckoutGetStatus()");
-	return 0;
+static int sceUtilityStoreCheckoutGetStatus() {
+	return hleLogError(Log::sceUtility, 0, "UNIMPL");
 }
 
 static int sceUtilityGameSharingShutdownStart() {
 	if (currentDialogType != UtilityDialogType::GAMESHARING) {
-		WARN_LOG(Log::sceUtility, "sceUtilityGameSharingShutdownStart(): wrong dialog type");
-		return SCE_ERROR_UTILITY_WRONG_TYPE;
+		return hleLogWarning(Log::sceUtility, SCE_ERROR_UTILITY_WRONG_TYPE, "wrong dialog type");
 	}
 	
 	DeactivateDialog();
-	ERROR_LOG(Log::sceUtility, "UNIMPL sceUtilityGameSharingShutdownStart()");
-	return 0;
+	return hleLogError(Log::sceUtility, 0, "UNIMPL");
 }
 
 static int sceUtilityGameSharingInitStart(u32 paramsPtr) {
 	if (currentDialogActive && currentDialogType != UtilityDialogType::GAMESHARING) {
-		WARN_LOG(Log::sceUtility, "sceUtilityGameSharingInitStart(%08x)", paramsPtr);
-		return SCE_ERROR_UTILITY_WRONG_TYPE;
+		return hleLogWarning(Log::sceUtility, SCE_ERROR_UTILITY_WRONG_TYPE);
 	}
-	
+
 	ActivateDialog(UtilityDialogType::GAMESHARING);
 	ERROR_LOG_REPORT(Log::sceUtility, "UNIMPL sceUtilityGameSharingInitStart(%08x)", paramsPtr);
-	return 0;
+	return hleNoLog(0);
 }
 
 static int sceUtilityGameSharingUpdate(int animSpeed) {
@@ -1280,7 +1265,7 @@ static u32 sceUtilityLoadUsbModule(u32 module)
 	}
 
 	ERROR_LOG_REPORT(Log::sceUtility, "UNIMPL sceUtilityLoadUsbModule(%i)", module);
-	return 0;
+	return hleNoLog(0);
 }
 
 static u32 sceUtilityUnloadUsbModule(u32 module)
@@ -1291,7 +1276,7 @@ static u32 sceUtilityUnloadUsbModule(u32 module)
 	}
 
 	ERROR_LOG_REPORT(Log::sceUtility, "UNIMPL sceUtilityUnloadUsbModule(%i)", module);
-	return 0;
+	return hleNoLog(0);
 }
 
 const HLEFunction sceUtility[] = 

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -1724,7 +1724,7 @@ void ImMemWindow::Draw(MIPSDebugInterface *mipsDebug, ImConfig &cfg, ImControl &
 		}
 	}
 	ImGui::EndChild();
-	
+
 	ImGui::SameLine();
 	if (ImGui::BeginChild("memview", size)) {
 		memView_.Draw(ImGui::GetWindowDrawList());

--- a/UI/ImDebugger/ImMemView.cpp
+++ b/UI/ImDebugger/ImMemView.cpp
@@ -517,7 +517,7 @@ void ImMemView::updateStatusBarText() {
 	snprintf(text, sizeof(text), "%08x", curAddress_);
 	// There should only be one.
 	for (MemBlockInfo info : memRangeInfo) {
-		snprintf(text, sizeof(text), "%08x - %s %08x-%08x (PC %08x / %lld ticks)", curAddress_, info.tag.c_str(), info.start, info.start + info.size, info.pc, info.ticks);
+		snprintf(text, sizeof(text), "%08x - %s %08x-%08x (PC %08x / %lld ticks)", curAddress_, info.tag.c_str(), info.start, info.start + info.size, info.pc, (long long)info.ticks);
 	}
 	statusMessage_ = text;
 }


### PR DESCRIPTION
Yes, this seems excessive, but by enabling the harsh logging validation in HLE.cpp, I've found a fairly large number of cases of missing or wrong logging. Bad logging is bad for debugging.

Plus, this shortens the code by 400 lines. Some of that is just formatting, but some is actually simplification.

So might as well go through it all (by testing games, hitting the asserts) and make it compliant.