### PR TITLE
Fix issue with hleLogDebugOrError where the return value argument got repeated

### DIFF
--- a/Core/HLE/sceKernelHeap.cpp
+++ b/Core/HLE/sceKernelHeap.cpp
@@ -75,8 +75,9 @@ static int sceKernelCreateHeap(int partitionId, int size, int flags, const char 
 static int sceKernelAllocHeapMemory(int heapId, int size) {
 	u32 error;
 	KernelHeap *heap = kernelObjects.Get<KernelHeap>(heapId, error);
-	if (!heap)
+	if (!heap) {
 		return hleLogError(Log::sceKernel, error, "invalid heapId");
+	}
 
 	// There's 8 bytes at the end of every block, reserved.
 	u32 memSize = KERNEL_HEAP_BLOCK_HEADER_SIZE + size;

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -2173,10 +2173,9 @@ u32 sceKernelLoadModule(const char *name, u32 flags, u32 optionAddr) {
 	return hleDelayResult(hleNoLog(module->GetUID()), "module loaded", 500);
 }
 
-static u32 sceKernelLoadModuleNpDrm(const char *name, u32 flags, u32 optionAddr)
-{
-	// TODO: Handle recursive syscall properly
-	return hleLogDebugOrError(Log::Loader, sceKernelLoadModule(name, flags, optionAddr));
+static u32 sceKernelLoadModuleNpDrm(const char *name, u32 flags, u32 optionAddr) {
+	// Just forward it, same parameters so the logging will make sense.
+	return sceKernelLoadModule(name, flags, optionAddr);
 }
 
 int __KernelStartModule(SceUID moduleId, u32 argsize, u32 argAddr, u32 returnValueAddr, SceKernelSMOption *smoption, bool *needsWait) {

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -358,7 +358,8 @@ u32 GPUCommon::EnqueueList(u32 listpc, u32 stall, int subIntrBase, PSPPointer<Ps
 
 	// If args->size is below 16, it's the old struct without stack info.
 	if (args.IsValid() && args->size >= 16 && args->numStacks >= 256) {
-		return hleLogError(Log::G3D, SCE_KERNEL_ERROR_INVALID_SIZE, "invalid stack depth %d", args->numStacks);
+		ERROR_LOG(Log::G3D, "invalid stack depth %d", args->numStacks);
+		return SCE_KERNEL_ERROR_INVALID_SIZE;
 	}
 
 	int id = -1;


### PR DESCRIPTION
Not good when the argument is a function call.. macros have issues.

Might help #20052 

Also removes BEL and other control characters from stdout logging.