### PR TITLE
Fix some framedump playback issues

### DIFF
--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -88,7 +88,7 @@ constexpr bool SIMULATE_SLOW_IO = false;
 #else
 constexpr bool SIMULATE_SLOW_IO = false;
 #endif
-constexpr bool LOG_IO = false;
+constexpr bool LOG_IO = true;
 
 #ifndef S_ISDIR
 #define S_ISDIR(m)  (((m)&S_IFMT) == S_IFDIR)

--- a/Common/System/Request.cpp
+++ b/Common/System/Request.cpp
@@ -72,11 +72,11 @@ void RequestManager::ForgetRequestsWithToken(RequesterToken token) {
 	}
 }
 
-void RequestManager::PostSystemSuccess(int requestId, const char *responseString, int responseValue) {
+void RequestManager::PostSystemSuccess(int requestId, std::string_view responseString, int responseValue) {
 	std::lock_guard<std::mutex> guard(callbackMutex_);
 	auto iter = callbackMap_.find(requestId);
 	if (iter == callbackMap_.end()) {
-		ERROR_LOG(Log::System, "PostSystemSuccess: Unexpected request ID %d (responseString=%s)", requestId, responseString);
+		ERROR_LOG(Log::System, "PostSystemSuccess: Unexpected request ID %d (responseString=%.*s)", requestId, (int)responseString.size(), responseString.data());
 		return;
 	}
 
@@ -86,7 +86,7 @@ void RequestManager::PostSystemSuccess(int requestId, const char *responseString
 	response.responseString = responseString;
 	response.responseValue = responseValue;
 	pendingSuccesses_.push_back(response);
-	DEBUG_LOG(Log::System, "PostSystemSuccess: Request %d (%s, %d)", requestId, responseString, responseValue);
+	DEBUG_LOG(Log::System, "PostSystemSuccess: Request %d (%.*s, %d)", requestId, (int)responseString.size(), responseString.data(), responseValue);
 	callbackMap_.erase(iter);
 }
 

--- a/Common/System/Request.h
+++ b/Common/System/Request.h
@@ -4,6 +4,7 @@
 #include <mutex>
 #include <map>
 #include <functional>
+#include <string_view>
 
 #include "Common/System/System.h"
 
@@ -32,7 +33,7 @@ public:
 	bool MakeSystemRequest(SystemRequestType type, RequesterToken token, RequestCallback callback, RequestFailedCallback failedCallback, std::string_view param1, std::string_view param2, int64_t param3, int64_t param4 = 0);
 
 	// Called by the platform implementation, when it's finished with a request.
-	void PostSystemSuccess(int requestId, const char *responseString, int responseValue = 0);
+	void PostSystemSuccess(int requestId, std::string_view responseString, int responseValue = 0);
 	void PostSystemFailure(int requestId);
 
 	// This must be called every frame from the beginning of NativeFrame().

--- a/Core/FileSystems/BlobFileSystem.cpp
+++ b/Core/FileSystems/BlobFileSystem.cpp
@@ -19,6 +19,7 @@
 
 BlobFileSystem::BlobFileSystem(IHandleAllocator *hAlloc, FileLoader *fileLoader, std::string alias)
 : alloc_(hAlloc), fileLoader_(fileLoader), alias_(alias) {
+	NOTICE_LOG(Log::FileSystem, "%s", fileLoader->GetPath().c_str());
 }
 
 BlobFileSystem::~BlobFileSystem() {

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -69,16 +69,17 @@ DirectoryFileSystem::DirectoryFileSystem(IHandleAllocator *_hAlloc, const Path &
 	static const std::string_view upperCase = "WJPCZSBNNZFXSGOS";
 
 	// Check for case sensitivity
+	bool checkSucceeded = false;
 	File::CreateEmptyFile(basePath / mixedCase);
 	if (File::Exists(basePath / mixedCase)) {
-		INFO_LOG(Log::IO, "File system probably writable, so case sensitivity check should be reliable.");
+		checkSucceeded = true;
 		if (!File::Exists(basePath / upperCase)) {
 			flags |= FileSystemFlags::CASE_SENSITIVE;
 		}
 	}
 	File::Delete(basePath / mixedCase);
 
-	INFO_LOG(Log::IO, "Is file system case sensitive? %s (base: %s)", (flags & FileSystemFlags::CASE_SENSITIVE) ? "yes" : "no", _basePath.c_str());
+	INFO_LOG(Log::IO, "Is file system case sensitive? %s (base: '%s') (checkOK: %d)", (flags & FileSystemFlags::CASE_SENSITIVE) ? "yes" : "no", _basePath.c_str(), checkSucceeded);
 
 	hAlloc = _hAlloc;
 }

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -68,7 +68,7 @@ struct SceMpegRingBuffer {
 	u32_le callback_addr; // see sceMpegRingbufferPut
 	s32_le callback_args;
 	s32_le dataUpperBound;
-	s32_le semaID; // unused?
+	s32_le semaID; // unused? No, probably not, see #20084. Though when should we signal it?
 	u32_le mpeg; // pointer to mpeg struct, fixed up in sceMpegCreate
 	// Note: not available in all versions.
 	u32_le gp;

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -409,7 +409,15 @@ bool PSP_InitStart(const CoreParameter &coreParam, std::string *error_string) {
 	FileLoader *loadedFile = ResolveFileLoaderTarget(ConstructFileLoader(filename));
 #if PPSSPP_ARCH(AMD64)
 	if (g_Config.bCacheFullIsoInRam) {
-		loadedFile = new RamCachingFileLoader(loadedFile);
+		switch (coreParam.fileType) {
+		case IdentifiedFileType::PSP_ISO:
+		case IdentifiedFileType::PSP_ISO_NP:
+			loadedFile = new RamCachingFileLoader(loadedFile);
+			break;
+		default:
+			INFO_LOG(Log::System, "RAM caching is on, but file is not an ISO, so ignoring");
+			break;
+		}
 	}
 #endif
 

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -63,6 +63,7 @@
 #include "Core/SaveState.h"
 #include "Common/ExceptionHandlerSetup.h"
 #include "GPU/GPUCommon.h"
+#include "GPU/Debugger/Playback.h"
 #include "GPU/Debugger/RecordFormat.h"
 #include "Core/RetroAchievements.h"
 
@@ -325,6 +326,8 @@ void CPU_Shutdown() {
 	// Since we load on a background thread, wait for startup to complete.
 	PSP_LoadingLock lock;
 	PSPLoaders_Shutdown();
+
+	GPURecord::Replay_Unload();
 
 	if (g_Config.bAutoSaveSymbolMap) {
 		SaveSymbolMapIfSupported();

--- a/Core/Util/GameDB.h
+++ b/Core/Util/GameDB.h
@@ -19,6 +19,8 @@ struct GameDBInfo {
 class GameDB {
 public:
 	// Warning: Linear search. Don't call it every frame if possible.
+	// If this returns true, there is at least 1 entry in infos, so it's safe to go
+	// look up element 0 for a quick guess.
 	bool GetGameInfos(std::string_view id, std::vector<GameDBInfo> *infos);
 
 private:

--- a/GPU/Debugger/Playback.cpp
+++ b/GPU/Debugger/Playback.cpp
@@ -29,6 +29,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Log.h"
 #include "Common/Thread/ThreadUtil.h"
+#include "Common/System/Request.h"
 #include "Core/Config.h"
 #include "Core/Core.h"
 #include "Core/CoreTiming.h"
@@ -842,6 +843,9 @@ static u32 LoadReplay(const std::string &filename) {
 	size_t gameIDLength = strnlen(header.gameID, sizeof(header.gameID));
 	if (gameIDLength != 0) {
 		g_paramSFO.SetValue("DISC_ID", std::string(header.gameID, gameIDLength), (int)sizeof(header.gameID));
+		System_SetWindowTitle(g_paramSFO.GetValueString("DISC_ID"));
+	} else {
+		System_SetWindowTitle("(old dump: missing DISC_ID)");
 	}
 
 	u32 sz = 0;

--- a/GPU/Debugger/Playback.cpp
+++ b/GPU/Debugger/Playback.cpp
@@ -43,6 +43,7 @@
 #include "Core/MIPS/MIPS.h"
 #include "Core/MIPS/MIPSCodeUtils.h"
 #include "Core/System.h"
+#include "Core/Util/GameDB.h"
 #include "GPU/GPUCommon.h"
 #include "GPU/GPUState.h"
 #include "GPU/ge_constants.h"
@@ -73,6 +74,8 @@ static uint32_t lastExecVersion;
 static std::vector<Command> lastExecCommands;
 static std::vector<u8> lastExecPushbuf;
 
+// This thread is restarted every frame (dump execution) for simplicity. TODO: Make persistent?
+// Alternatively, get rid of it, but the code is written in a way that makes it difficult (you'll see if you try).
 static std::thread replayThread;
 
 static std::mutex opStartLock;
@@ -80,6 +83,7 @@ static std::condition_variable opStartWait;
 
 static std::mutex opFinishLock;
 static std::condition_variable opFinishWait;
+
 static Operation g_opToExec;
 static u32 g_retVal;
 static bool g_opDone = true;
@@ -825,6 +829,9 @@ static bool ReadCompressed(u32 fp, void *dest, size_t sz, uint32_t version) {
 
 static u32 LoadReplay(const std::string &filename) {
 	PROFILE_THIS_SCOPE("ReplayLoad");
+
+	NOTICE_LOG(Log::GeDebugger, "LoadReplay %s", filename.c_str());
+
 	u32 fp = pspFileSystem.OpenFile(filename, FILEACCESS_READ);
 	Header header;
 	pspFileSystem.ReadFile(fp, (u8 *)&header, sizeof(header));
@@ -843,9 +850,17 @@ static u32 LoadReplay(const std::string &filename) {
 	size_t gameIDLength = strnlen(header.gameID, sizeof(header.gameID));
 	if (gameIDLength != 0) {
 		g_paramSFO.SetValue("DISC_ID", std::string(header.gameID, gameIDLength), (int)sizeof(header.gameID));
-		System_SetWindowTitle(g_paramSFO.GetValueString("DISC_ID"));
+		std::vector<GameDBInfo> info;
+		std::string gameTitle = "(unknown title)";
+#if !defined(__LIBRETRO__)
+		if (g_gameDB.GetGameInfos(header.gameID, &info)) {
+			gameTitle = info[0].title;
+			g_paramSFO.SetValue("TITLE", gameTitle, (int)gameTitle.size());
+		}
+#endif
+		System_SetWindowTitle(g_paramSFO.GetValueString("DISC_ID") + " : " + gameTitle + " (GE frame dump)");
 	} else {
-		System_SetWindowTitle("(old dump: missing DISC_ID)");
+		System_SetWindowTitle("(GE frame dump: old format, missing DISC_ID)");
 	}
 
 	u32 sz = 0;
@@ -870,6 +885,18 @@ static u32 LoadReplay(const std::string &filename) {
 	lastExecFilename = filename;
 	lastExecVersion = version;
 	return version;
+}
+
+void Replay_Unload() {
+	_dbg_assert_(!replayThread.joinable());
+
+	lastExecFilename.clear();
+	lastExecVersion = 0;
+	lastExecCommands.clear();
+	lastExecPushbuf.clear();
+
+	g_opDone = true;
+	g_retVal = 0;
 }
 
 void WriteRunDumpCode(u32 codeStart) {

--- a/GPU/Debugger/Playback.h
+++ b/GPU/Debugger/Playback.h
@@ -30,6 +30,6 @@ enum class ReplayResult {
 
 void WriteRunDumpCode(u32 addr);
 ReplayResult RunMountedReplay(const std::string &filename);
-void ReplayShutdown();
+void Replay_Unload();
 
 }  // namespace GPURecord

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -154,17 +154,19 @@ void DevMenuScreen::CreatePopupContents(UI::ViewGroup *parent) {
 		return UI::EVENT_DONE;
 	});
 
-	items->Add(new Choice(dev->T("Create frame dump")))->OnClick.Add([](UI::EventParams &e) {
-		gpuDebug->GetRecorder()->RecordNextFrame([](const Path &dumpPath) {
-			NOTICE_LOG(Log::System, "Frame dump created at '%s'", dumpPath.c_str());
-			if (System_GetPropertyBool(SYSPROP_CAN_SHOW_FILE)) {
-				System_ShowFileInFolder(dumpPath);
-			} else {
-				g_OSD.Show(OSDType::MESSAGE_SUCCESS, dumpPath.ToVisualString(), 7.0f);
-			}
+	if (PSP_CoreParameter().fileType != IdentifiedFileType::PPSSPP_GE_DUMP) {
+		items->Add(new Choice(dev->T("Create frame dump")))->OnClick.Add([](UI::EventParams &e) {
+			gpuDebug->GetRecorder()->RecordNextFrame([](const Path &dumpPath) {
+				NOTICE_LOG(Log::System, "Frame dump created at '%s'", dumpPath.c_str());
+				if (System_GetPropertyBool(SYSPROP_CAN_SHOW_FILE)) {
+					System_ShowFileInFolder(dumpPath);
+				} else {
+					g_OSD.Show(OSDType::MESSAGE_SUCCESS, dumpPath.ToVisualString(), 7.0f);
+				}
+			});
+			return UI::EVENT_DONE;
 		});
-		return UI::EVENT_DONE;
-	});
+	}
 
 	// This one is not very useful these days, and only really on desktop. Hide it on other platforms.
 	if (System_GetPropertyInt(SYSPROP_DEVICE_TYPE) == DEVICE_TYPE_DESKTOP) {

--- a/UI/ImDebugger/ImGe.cpp
+++ b/UI/ImDebugger/ImGe.cpp
@@ -1087,7 +1087,7 @@ void ImGeDebuggerWindow::Draw(ImConfig &cfg, ImControl &control, GPUDebugInterfa
 				TexCacheEntry *tex = texcache ? texcache->SetTexture() : nullptr;
 				if (tex) {
 					ImGui::Text("Texture: ");
-					texcache->ApplyTexture();
+					texcache->ApplyTexture(false);
 
 					void *nativeView = texcache->GetNativeTextureView(tex, true);
 					ImTextureID texId = ImGui_ImplThin3d_AddNativeTextureTemp(nativeView);

--- a/UI/OnScreenDisplay.cpp
+++ b/UI/OnScreenDisplay.cpp
@@ -310,6 +310,7 @@ void OnScreenMessagesView::Draw(UIContext &dc) {
 	typeEdges[(size_t)OSDType::MESSAGE_CENTERED_WARNING] = ScreenEdgePosition::CENTER;
 	typeEdges[(size_t)OSDType::MESSAGE_CENTERED_ERROR] = ScreenEdgePosition::CENTER;
 	typeEdges[(size_t)OSDType::TRANSPARENT_STATUS] = ScreenEdgePosition::TOP_LEFT;
+	typeEdges[(size_t)OSDType::PROGRESS_BAR] = ScreenEdgePosition::TOP_CENTER;  // These only function at the top currently, needs fixing.
 
 	dc.SetFontStyle(dc.theme->uiFont);
 	dc.SetFontScale(1.0f, 1.0f);

--- a/UI/PauseScreen.cpp
+++ b/UI/PauseScreen.cpp
@@ -605,6 +605,11 @@ std::string GetConfirmExitMessage() {
 		confirmMessage += nw->T("Network connected");
 		confirmMessage += '\n';
 	} else if (g_Config.iAskForExitConfirmationAfterSeconds > 0 && unsavedSeconds > g_Config.iAskForExitConfirmationAfterSeconds) {
+		if (PSP_CoreParameter().fileType == IdentifiedFileType::PPSSPP_GE_DUMP) {
+			// No need to ask for this type of confirmation for dumps.
+			return confirmMessage;
+		}
+
 		auto di = GetI18NCategory(I18NCat::DIALOG);
 		confirmMessage = ApplySafeSubstitutions(di->T("You haven't saved your progress for %1."), NiceTimeFormat((int)unsavedSeconds));
 		confirmMessage += '\n';

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -100,6 +100,7 @@ static bool Run(GraphicsContext *ctx) {
 				return true;
 			}
 			break;
+		case CORE_POWERUP:
 		case CORE_POWERDOWN:
 			// Need to step the loop.
 			NativeFrame(ctx);
@@ -110,7 +111,6 @@ static bool Run(GraphicsContext *ctx) {
 			NativeFrame(ctx);
 			break;
 
-		case CORE_POWERUP:
 		case CORE_BOOT_ERROR:
 			// Exit loop!!
 			return true;

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -581,7 +581,6 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 		winTitle.append(L" (debug)");
 #endif
 		MainWindow::SetWindowTitle(winTitle.c_str());
-		PostMessage(MainWindow::GetHWND(), MainWindow::WM_USER_WINDOW_TITLE_CHANGED, 0, 0);
 		return true;
 	}
 	case SystemRequestType::SET_KEEP_SCREEN_BRIGHT:

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -638,7 +638,7 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 			// Unsupported.
 			return false;
 		}
-		bool load = type == SystemRequestType::BROWSE_FOR_FILE;
+		const bool load = type == SystemRequestType::BROWSE_FOR_FILE;
 		std::thread([=] {
 			std::string out;
 			if (W32Util::BrowseForFileName(load, MainWindow::GetHWND(), ConvertUTF8ToWString(param1).c_str(), nullptr, filter.c_str(), L"", out)) {
@@ -689,8 +689,7 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 	case SystemRequestType::CREATE_GAME_SHORTCUT:
 	{
 		// Get the game info to get our hands on the icon png
-		Path gamePath(param1);
-		std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(nullptr, gamePath, GameInfoFlags::ICON);
+		std::shared_ptr<GameInfo> info = g_gameInfoCache->GetInfo(nullptr, Path(param1), GameInfoFlags::ICON);
 		Path icoPath;
 		if (info->icon.dataLoaded) {
 			// Write the icon png out as a .ICO file so the shortcut can point to it
@@ -710,8 +709,8 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 	}
 	case SystemRequestType::RUN_CALLBACK_IN_WNDPROC:
 	{
-		auto func = reinterpret_cast<void (*)(void *window, void *userdata)>(param3);
-		void *userdata = reinterpret_cast<void *>(param4);
+		auto func = reinterpret_cast<void (*)(void *window, void *userdata)>((uintptr_t)param3);
+		void *userdata = reinterpret_cast<void *>((uintptr_t)param4);
 		MainWindow::RunCallbackInWndProc(func, userdata);
 		return true;
 	}

--- a/unittest/UnitTest.cpp
+++ b/unittest/UnitTest.cpp
@@ -1099,7 +1099,7 @@ bool TestBuffer() {
 	return true;
 }
 
-#if defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
+#if PPSSPP_ARCH(SSE2) && (defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER))
 [[gnu::target("sse4.1")]]
 #endif
 bool TestSIMD() {


### PR DESCRIPTION
Fixes loading multiple different framedumps one after each other, plus drag+drop into the window on Windows.

Also does some nice things like showing the game ID/title in the titlebar, etc, and minor fixes.

Also, no point to ask for confirmation when exiting from running a framedump..