### PR TITLE
Try to fix AtracRemainingFrames

### DIFF
--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -156,6 +156,7 @@ void Atrac::DoState(PointerWrap &p) {
 void Atrac::ResetData() {
 	delete decoder_;
 	decoder_ = nullptr;
+	loopNum_ = -99;
 
 	if (dataBuf_)
 		delete[] dataBuf_;
@@ -919,7 +920,12 @@ int Atrac::RemainingFrames() const {
 
 	if ((bufferState_ & ATRAC_STATUS_STREAMED_MASK) == ATRAC_STATUS_STREAMED_MASK) {
 		// Since we're streaming, the remaining frames are what's valid in the buffer.
-		return bufferValidBytes_ / track_.bytesPerFrame;
+		int RemainingFramesValue = bufferValidBytes_ / track_.bytesPerFrame;
+		if (loopNum_ == -99) {
+			loopNum_ == -1;
+			RemainingFramesValue--;
+		}
+		return RemainingFramesValue;
 	}
 
 	// Since the first frame is shorter by this offset, add to round up at this offset.


### PR DESCRIPTION
fix #15233
It is call sceAtracGetRemainFrame()  before ignore call sceAtracSetLoopNum() 
I.E.
01:13:560 ATRAC3 play  D[ME]: HLE\AtracCtx.cpp:375 Additional chunk data (beyond 16 bytes): 22 00 00 08 03 00 00 00 bf aa 23 e9 58 cb 71 44 a1 19 ff fa 01 e4 ce 62 01 00 28 5c 00 00 00 00 00 00 00 00 
01:13:560 ATRAC3 play  D[ME]: HLE\AtracCtx.cpp:237 ATRAC analyzed: AT3Plus channels: 2 filesize: 1545452 bitrate: 125 kbps jointStereo: 0
01:13:560 ATRAC3 play  D[ME]: HLE\AtracCtx.cpp:238 dataoff: 164 firstSampleOffset: 3749 endSample: 4249578
01:13:560 ATRAC3 play  D[ME]: HLE\AtracCtx.cpp:239 loopStartSample: 4117 loopEndSample: 4253695
01:13:560 ATRAC3 play  I[ME]: HLE\AtracCtx.cpp:731 Atrac::SetData (buffer=08905cc0, readSize=131072, bufferSize=131072): atrac3+ stereo (2 channels) audio
01:13:560 ATRAC3 play  D[ME]: HLE\sceAtrac.cpp:572 0=sceAtracSetDataAndGetID(08905cc0, 00020000)
01:13:560 ATRAC3 play  D[ME]: HLE\sceAtrac.cpp:449 00000000=sceAtracGetRemainFrame(0, 09efea24[000000ae])

I don't know that it is a hack or correct fix