### PR TITLE
Audiocodec findings, prepare for new Atrac3 implementation

### DIFF
--- a/Common/Data/Text/Parsers.cpp
+++ b/Common/Data/Text/Parsers.cpp
@@ -160,9 +160,13 @@ bool TryParse(const std::string &str, bool *const output) {
 }
 
 StringWriter &StringWriter::F(const char *format, ...) {
+	const size_t remainder = bufSize_ - (p_ - start_);
+	if (remainder < 3) {
+		return *this;
+	}
 	va_list args;
 	va_start(args, format);
-	p_ += vsprintf(p_, format, args);
+	p_ += vsnprintf(p_, remainder, format, args);
 	va_end(args);
 	return *this;
 }

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -74,6 +74,8 @@
 // any cache or separate version of the buffer - at most it manages decode state from earlier in
 // the buffer.
 
+// TODO: We should add checks that the utility module is loaded.
+
 static const int atracDecodeDelay = 2300;
 
 static bool atracInited = true;
@@ -112,10 +114,11 @@ void __AtracShutdown() {
 	}
 }
 
-void __AtracLoadModule(int version, u32 crc) {
+void __AtracLoadModule(int version, u32 crc, u32 bssAddr, int bssSize) {
 	atracLibVersion = version;
 	atracLibCrc = crc;
-	INFO_LOG(Log::ME, "AtracInit, atracLibVersion 0x%0x, atracLibcrc %x", atracLibVersion, atracLibCrc);
+	INFO_LOG(Log::ME, "Atrac module loaded: atracLibVersion 0x%0x, atracLibcrc %x, bss: %x (%x bytes)", atracLibVersion, atracLibCrc, bssAddr, bssSize);
+	// Later, save bssAddr/bssSize and use them to return context addresses.
 }
 
 void __AtracDoState(PointerWrap &p) {

--- a/Core/HLE/sceAtrac.h
+++ b/Core/HLE/sceAtrac.h
@@ -25,7 +25,7 @@ void Register_sceAtrac3plus();
 void __AtracInit();
 void __AtracDoState(PointerWrap &p);
 void __AtracShutdown();
-void __AtracLoadModule(int version, u32 crc);
+void __AtracLoadModule(int version, u32 crc, u32 bssAddr, int bssSize);
 
 enum AtracStatus : u8 {
 	ATRAC_STATUS_NO_DATA = 1,

--- a/Core/HLE/sceAudiocodec.h
+++ b/Core/HLE/sceAudiocodec.h
@@ -28,10 +28,10 @@ struct SceAudiocodecCodec {
 	s32 edramAddr; // c  // presumably in ME memory?
 	s32 neededMem; // 10  // 0x102400 for Atrac3+
 	s32 inited;  // 14
-	u32 inBuf; // 18  // This is updated for every frame that's decoded, to point to the start of the frame.
+	u32 inBuf; // 18  // Before decoding, set this to the start of the raw frame.
 	s32 srcFrameSize; // 1c
-	u32 outBuf; // 20
-	s32 dstBytesWritten; // 24  
+	u32 outBuf; // 20  // This is where the decoded data is written.
+	s32 dstBytesWritten; // 24
 	s8 unk40;  // 28  format or looping related
 	s8 unk41;  // 29  format or looping related
 	s16 unk42; // 2a

--- a/Core/HLE/sceAudiocodec.h
+++ b/Core/HLE/sceAudiocodec.h
@@ -21,43 +21,42 @@
 
 class PointerWrap;
 
-typedef struct {
-	s32_le unk0;
-	s32_le unk4;
-	s32_le err; // 8
-	s32_le edramAddr; // 12
-	s32_le neededMem; // 16
-	s32_le unk20;
-	u32_le inBuf; // 24
-	s32_le unk28;
-	u32_le outBuf; // 32
-	s32_le unk36;
-	s8 unk40;
-	s8 unk41;
-	s8 unk42;
-	s8 unk43;
+struct SceAudiocodecCodec {
+	s32 unk_init;
+	s32 unk4;
+	s32 err; // 8
+	s32 edramAddr; // c  // presumably in ME memory?
+	s32 neededMem; // 10  // 0x102400 for Atrac3+
+	s32 inited;  // 14
+	u32 inBuf; // 18  // This is updated for every frame that's decoded, to point to the start of the frame.
+	s32 srcFrameSize; // 1c
+	u32 outBuf; // 20
+	s32 dstBytesWritten; // 24  
+	s8 unk40;  // 28  format or looping related
+	s8 unk41;  // 29  format or looping related
+	s16 unk42; // 2a
 	s8 unk44;
 	s8 unk45;
 	s8 unk46;
 	s8 unk47;
-	s32_le unk48;
-	s32_le unk52;
-	s32_le unk56;
-	s32_le unk60;
-	s32_le unk64;
-	s32_le unk68;
-	s32_le unk72;
-	s32_le unk76;
-	s32_le unk80;
-	s32_le unk84;
-	s32_le unk88;
-	s32_le unk92;
-	s32_le unk96;
-	s32_le unk100;
-	u32_le allocMem; // 104
+	s32 unk48;  // 30 Atrac3 (non-+) related. Zero with Atrac3+.
+	s32 unk52;  // 34
+	s32 unk56;
+	s32 unk60;
+	s32 unk64;
+	s32 unk68;
+	s32 unk72;
+	s32 unk76;
+	s32 unk80;
+	s32 unk84;
+	s32 unk88;
+	s32 unk92;
+	s32 unk96;
+	s32 unk100;
+	u32 allocMem; // 104
 	// make sure the size is 128
 	u8 unk[20];
-} SceAudiocodecCodec;
+};
 
 void __AudioCodecInit();
 void __AudioCodecShutdown();

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -489,6 +489,10 @@ void KernelObject::GetQuickInfo(char *ptr, int size) {
 	strcpy(ptr, "-");
 }
 
+void KernelObject::GetLongInfo(char *ptr, int size) const {
+	strcpy(ptr, "-");
+}
+
 KernelObjectPool::KernelObjectPool() {
 	memset(occupied, 0, sizeof(bool)*maxCount);
 	nextID = initialNextID;

--- a/Core/HLE/sceKernel.h
+++ b/Core/HLE/sceKernel.h
@@ -29,7 +29,7 @@
 class PointerWrap;
 
 // If you add to this, make sure to check KernelObjectPool::CreateByIDType().
-enum TMIDPurpose {
+enum TMIDType : int {
 	SCE_KERNEL_TMID_Thread             = 1,
 	SCE_KERNEL_TMID_Semaphore          = 2,
 	SCE_KERNEL_TMID_EventFlag          = 3,
@@ -131,6 +131,7 @@ public:
 	virtual const char *GetName() {return "[UNKNOWN KERNEL OBJECT]";}
 	virtual int GetIDType() const = 0;
 	virtual void GetQuickInfo(char *ptr, int size);
+	virtual void GetLongInfo(char *ptr, int bufSize) const;
 
 	// Implement the following in all subclasses:
 	// static u32 GetMissingErrorCode()

--- a/Core/HLE/sceKernelModule.h
+++ b/Core/HLE/sceKernelModule.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 #include "Core/HLE/sceKernel.h"
 
 struct PspModuleInfo {

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -68,7 +68,7 @@ struct SceMpegRingBuffer {
 	u32_le callback_addr; // see sceMpegRingbufferPut
 	s32_le callback_args;
 	s32_le dataUpperBound;
-	s32_le semaID; // unused? No, probably not, see #20084. Though when should we signal it?
+	s32_le semaID; // unused? No, probably not, see #20084. Though when should we signal it? create it?
 	u32_le mpeg; // pointer to mpeg struct, fixed up in sceMpegCreate
 	// Note: not available in all versions.
 	u32_le gp;

--- a/Core/HLE/sceUtility.h
+++ b/Core/HLE/sceUtility.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <map>
+
 class PointerWrap;
 
 // Valid values for PSP_SYSTEMPARAM_ID_INT_LANGUAGE
@@ -122,5 +124,21 @@ void __UtilityShutdown();
 
 void UtilityDialogInitialize(UtilityDialogType type, int delayUs, int priority);
 void UtilityDialogShutdown(UtilityDialogType type, int delayUs, int priority);
+
+typedef void (*ModuleLoadCallback)(int state, u32 loadAddr, u32 loadSize);
+
+struct ModuleLoadInfo {
+	ModuleLoadInfo(int m, u32 s, const char *name, ModuleLoadCallback cb = nullptr);
+	ModuleLoadInfo(int m, u32 s, const char *name, const int *d, ModuleLoadCallback cb = nullptr);
+	const char *name;
+	const int mod;
+	const u32 size;
+	const int *const dependencies;
+	ModuleLoadCallback notify;
+};
+
+const std::map<int, u32> &__UtilityGetLoadedModules();  // ->first gets the module ID, for use in the following two functions.
+const ModuleLoadInfo *__UtilityModuleInfo(int moduleID);
+bool __UtilityModuleGetMemoryRange(int moduleID, u32 *startPtr, u32 *sizePtr);
 
 void Register_sceUtility();

--- a/UI/DevScreens.cpp
+++ b/UI/DevScreens.cpp
@@ -481,7 +481,7 @@ UI::EventReturn SystemInfoScreen::CopySummaryToClipboard(UI::EventParams &e) {
 	auto si = GetI18NCategory(I18NCat::DIALOG);
 
 	char *summary = new char[100000];
-	StringWriter w(summary);
+	StringWriter w(summary, 100000);
 
 	std::string_view build = "Release";
 #ifdef _DEBUG

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -149,6 +149,7 @@ struct ImConfig {
 	bool internalsOpen;
 	bool sasAudioOpen;
 	bool logConfigOpen;
+	bool utilityModulesOpen;
 	bool memViewOpen[4];
 
 	// HLE explorer settings
@@ -156,7 +157,9 @@ struct ImConfig {
 
 	// Various selections
 	int selectedModule = 0;
+	int selectedUtilityModule = 0;
 	int selectedThread = 0;
+	int selectedKernelObject = 0;
 	int selectedFramebuffer = -1;
 	int selectedBreakpoint = -1;
 	int selectedMemCheck = -1;


### PR DESCRIPTION
As mentioned in #20098 , there will be a need for a place to keep Atrac contexts in PSP RAM, and this should be in the space reserved for the currently loaded Atrac3+ library. So this now notifies the sceAtrac implementation when one is loaded (although this information is not yet used).

There are some complications. 

The libatrac3plus.prx library can be loaded either from disk with sceKernelLoadModule or from (simulated) firmware with sceUtilityLoadModule. In the first case, we actually load the library (well, not always fully, but we reserve the space), and in the latter case, we just reserve some memory for it (a bit too much, actually).

But there's a 3rd case - you can also use `sceUtilityLoadAvModule` to load it. So in some games we actually never reserved space at all! So, will need to change that, coming up in the next PR. There's a very small risk that some game might break by running out of memory...

Then, I'm going to make it so that in old save states, the old Atrac3 implementation will always be used, for simplicity.

This also adds some new debugger functionality, a new window for fake modules loaded through sceUtilityLoadModule.

And also updates the audiocodec struct with some new comments.
