### PR TITLE
Fix sceUtilityLoadModuleAv, allow browsing memory tags in the memory viewer

### DIFF
--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -95,7 +95,11 @@ const AtracBase *__AtracGetCtx(int i, u32 *type) {
 void __AtracInit() {
 	_assert_(sizeof(SceAtracContext) == 256);
 
-	atracInited = true;
+	atracLibVersion = 0;
+	atracLibCrc = 0;
+
+	atracInited = true;  // TODO: This should probably only happen in __AtracNotifyLoadModule.
+
 	memset(atracContexts, 0, sizeof(atracContexts));
 
 	// Start with 2 of each in this order.
@@ -114,11 +118,16 @@ void __AtracShutdown() {
 	}
 }
 
-void __AtracLoadModule(int version, u32 crc, u32 bssAddr, int bssSize) {
+void __AtracNotifyLoadModule(int version, u32 crc, u32 bssAddr, int bssSize) {
 	atracLibVersion = version;
 	atracLibCrc = crc;
 	INFO_LOG(Log::ME, "Atrac module loaded: atracLibVersion 0x%0x, atracLibcrc %x, bss: %x (%x bytes)", atracLibVersion, atracLibCrc, bssAddr, bssSize);
 	// Later, save bssAddr/bssSize and use them to return context addresses.
+}
+
+void __AtracNotifyUnloadModule() {
+	atracLibVersion = 0;
+	atracLibCrc = 0;
 }
 
 void __AtracDoState(PointerWrap &p) {

--- a/Core/HLE/sceAtrac.h
+++ b/Core/HLE/sceAtrac.h
@@ -25,7 +25,9 @@ void Register_sceAtrac3plus();
 void __AtracInit();
 void __AtracDoState(PointerWrap &p);
 void __AtracShutdown();
-void __AtracLoadModule(int version, u32 crc, u32 bssAddr, int bssSize);
+
+void __AtracNotifyLoadModule(int version, u32 crc, u32 bssAddr, int bssSize);
+void __AtracNotifyUnloadModule();
 
 enum AtracStatus : u8 {
 	ATRAC_STATUS_NO_DATA = 1,

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -277,9 +277,9 @@ public:
 	const char *GetTypeName() override { return GetStaticTypeName(); }
 	static const char *GetStaticTypeName() { return "Module"; }
 	void GetQuickInfo(char *ptr, int size) override {
-		snprintf(ptr, size, "%s %d.%d name=%s gp=%08x entry=%08x",
-			isFake ? "faked " : "",
-			nm.version[0], nm.version[1],
+		snprintf(ptr, size, "%d.%d %sname=%s gp=%08x entry=%08x",
+			nm.version[1], nm.version[0],
+			isFake ? "(faked) " : "",
 			nm.name,
 			nm.gp_value,
 			nm.entry_addr);

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -117,7 +117,7 @@ static const ModuleLoadInfo moduleLoadInfo[] = {
 	ModuleLoadInfo(0x2ff, 0x00000000, "unk_0x2ff"),
 	ModuleLoadInfo(0x300, 0x00000000, "av_avcodec", &NotifyLoadStatusAvcodec),
 	ModuleLoadInfo(0x301, 0x00000000, "av_sascore"),
-	ModuleLoadInfo(0x302, 0x00008000, "av_atrac3plus", atrac3PlusModuleDeps, &NotifyLoadStatusAtrac),  // TODO: 0x8000 is likely too large.
+	ModuleLoadInfo(0x302, 0x00004000, "av_atrac3plus", atrac3PlusModuleDeps, &NotifyLoadStatusAtrac),  // TODO: 0x8000 is likely too large.
 	ModuleLoadInfo(0x303, 0x0000c000, "av_mpegbase", mpegBaseModuleDeps),
 	ModuleLoadInfo(0x304, 0x00004000, "av_mp3"),
 	ModuleLoadInfo(0x305, 0x0000a300, "av_vaudio"),

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -108,13 +108,13 @@ static const ModuleLoadInfo moduleLoadInfo[] = {
 	ModuleLoadInfo(0x104, 0x00002000, "net_parse_http"),
 	ModuleLoadInfo(0x105, 0x00028000, "net_http", httpModuleDeps),
 	ModuleLoadInfo(0x106, 0x00044000, "net_ssl", sslModuleDeps),
-	ModuleLoadInfo(0x107, 0x00010000, "0x107"),
+	ModuleLoadInfo(0x107, 0x00010000, "unk_0x107"),
 	ModuleLoadInfo(0x108, 0x00008000, "usb_pspcm", httpStorageModuleDeps),
 	ModuleLoadInfo(0x200, 0x00000000, "usb_mic"),
 	ModuleLoadInfo(0x201, 0x00000000, "usb_cam"),
 	ModuleLoadInfo(0x202, 0x00000000, "usb_gps"),
-	ModuleLoadInfo(0x203, 0x00000000, "0x203"),
-	ModuleLoadInfo(0x2ff, 0x00000000, "0x2ff"),
+	ModuleLoadInfo(0x203, 0x00000000, "usb_unk_0x203"),
+	ModuleLoadInfo(0x2ff, 0x00000000, "unk_0x2ff"),
 	ModuleLoadInfo(0x300, 0x00000000, "av_avcodec", &NotifyLoadStatusAvcodec),
 	ModuleLoadInfo(0x301, 0x00000000, "av_sascore"),
 	ModuleLoadInfo(0x302, 0x00008000, "av_atrac3plus", atrac3PlusModuleDeps, &NotifyLoadStatusAtrac),  // TODO: 0x8000 is likely too large.
@@ -123,16 +123,16 @@ static const ModuleLoadInfo moduleLoadInfo[] = {
 	ModuleLoadInfo(0x305, 0x0000a300, "av_vaudio"),
 	ModuleLoadInfo(0x306, 0x00004000, "av_aac"),
 	ModuleLoadInfo(0x307, 0x00000000, "av_g729"),
-	ModuleLoadInfo(0x308, 0x0003c000, "av_", mp4ModuleDeps),
+	ModuleLoadInfo(0x308, 0x0003c000, "av_mp4", mp4ModuleDeps),
 	ModuleLoadInfo(0x3fe, 0x00000000, "me_stuff"),
 	ModuleLoadInfo(0x3ff, 0x00000000, "me_core"),  // ME Core?
 	ModuleLoadInfo(0x400, 0x0000c000, "np_common"),
 	ModuleLoadInfo(0x401, 0x00018000, "np_service"),
 	ModuleLoadInfo(0x402, 0x00048000, "np_matching2"),
-	ModuleLoadInfo(0x403, 0x0000e000, "0x403"),
+	ModuleLoadInfo(0x403, 0x0000e000, "np_unk_0x403"),
 	ModuleLoadInfo(0x500, 0x00000000, "np_drm"),
 	ModuleLoadInfo(0x600, 0x00000000, "irda"),
-	ModuleLoadInfo(0x601, 0x00000000, "0x601"),
+	ModuleLoadInfo(0x601, 0x00000000, "unk_0x601"),
 };
 
 // Only a single dialog is allowed at a time.
@@ -576,7 +576,7 @@ static int LoadModuleInternal(u32 module) {
 	u32 allocSize = info->size;
 	u32 address = 0;
 	char name[128];
-	snprintf(name, sizeof(name), "UtilityModule/%x", module);
+	snprintf(name, sizeof(name), "UtilityModule/%3x_%s", module, info->name);
 	if (allocSize != 0) {
 		address = userMemory.Alloc(allocSize, false, name);
 	}

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -10,6 +10,7 @@
 #include "Common/Log/LogManager.h"
 #include "Core/Config.h"
 #include "Core/System.h"
+#include "Core/Debugger/MemBlockInfo.h"
 #include "Core/RetroAchievements.h"
 #include "Core/Core.h"
 #include "Core/Debugger/DebugInterface.h"
@@ -21,7 +22,6 @@
 #include "Core/FileSystems/MetaFileSystem.h"
 #include "Core/Debugger/SymbolMap.h"
 #include "Core/MemMap.h"
-#include "Core/System.h"
 #include "Core/HLE/HLE.h"
 #include "Core/HLE/SocketManager.h"
 #include "Core/HLE/NetInetConstants.h"
@@ -1852,21 +1852,38 @@ void ImMemWindow::Draw(MIPSDebugInterface *mipsDebug, ImConfig &cfg, ImControl &
 
 	ImVec2 size(0, -ImGui::GetFrameHeightWithSpacing());
 
+	auto node = [&](const char *title, uint32_t start, uint32_t len) {
+		if (ImGui::TreeNode(title)) {
+			if (ImGui::Selectable("(start)", cfg.selectedMemoryBlock == start)) {
+				cfg.selectedMemoryBlock = start;
+				GotoAddr(start);
+			}
+			const std::vector<MemBlockInfo> info = FindMemInfo(start, len);
+			for (auto &iter : info) {
+				ImGui::PushID(iter.start);
+				if (ImGui::Selectable(iter.tag.c_str(), cfg.selectedMemoryBlock == iter.start)) {
+					cfg.selectedMemoryBlock = iter.start;
+					GotoAddr(iter.start);
+				}
+				ImGui::PopID();
+			}
+			const u32 end = start + len;
+			if (ImGui::Selectable("(end)", cfg.selectedMemoryBlock == end)) {
+				cfg.selectedMemoryBlock = end;
+				GotoAddr(end);
+			}
+			ImGui::TreePop();
+		}
+	};
+
 	// Main views - list of interesting addresses to the left, memory view to the right.
 	if (ImGui::BeginChild("addr_list", ImVec2(200.0f, size.y), ImGuiChildFlags_ResizeX)) {
-		if (ImGui::Selectable("Scratch")) {
-			GotoAddr(0x00010000);
-		}
-		if (ImGui::Selectable("Kernel RAM")) {
-			GotoAddr(0x08000000);
-		}
-		if (ImGui::Selectable("User RAM")) {
-			GotoAddr(0x08800000);
-		}
-		if (ImGui::Selectable("VRAM")) {
-			GotoAddr(0x04000000);
-		}
+		node("Scratch",    0x00010000, 0x00004000);
+		node("Kernel RAM", 0x08000000, 0x00800000);
+		node("User RAM"  , 0x08800000, 0x01800000);
+		node("VRAM",       0x04000000, 0x00200000);
 	}
+
 	ImGui::EndChild();
 
 	ImGui::SameLine();

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -1575,6 +1575,10 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 			}
 			ImGui::EndMenu();
 		}
+		if (ImGui::BeginMenu("Core")) {
+			ImGui::MenuItem("Scheduler", nullptr, &cfg_.schedulerOpen);
+			ImGui::EndMenu();
+		}
 		if (ImGui::BeginMenu("CPU")) {
 			ImGui::MenuItem("CPU debugger", nullptr, &cfg_.disasmOpen);
 			ImGui::MenuItem("GPR regs", nullptr, &cfg_.gprOpen);
@@ -1582,8 +1586,9 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 			ImGui::MenuItem("VFPU regs", nullptr, &cfg_.vfpuOpen);
 			ImGui::MenuItem("Callstacks", nullptr, &cfg_.callstackOpen);
 			ImGui::MenuItem("Breakpoints", nullptr, &cfg_.breakpointsOpen);
-			ImGui::MenuItem("Scheduler", nullptr, &cfg_.schedulerOpen);
-			ImGui::Separator();
+			ImGui::EndMenu();
+		}
+		if (ImGui::BeginMenu("Memory")) {
 			for (int i = 0; i < 4; i++) {
 				char title[64];
 				snprintf(title, sizeof(title), "Memory %d", i + 1);
@@ -1592,7 +1597,7 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 			ImGui::MenuItem("Memory Dumper", nullptr, &cfg_.memDumpOpen);
 			ImGui::EndMenu();
 		}
-		if (ImGui::BeginMenu("HLE")) {
+		if (ImGui::BeginMenu("OS HLE")) {
 			ImGui::MenuItem("File System Browser", nullptr, &cfg_.filesystemBrowserOpen);
 			ImGui::MenuItem("Kernel Objects", nullptr, &cfg_.kernelObjectsOpen);
 			ImGui::MenuItem("Threads", nullptr, &cfg_.threadsOpen);

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -164,6 +164,7 @@ struct ImConfig {
 	int selectedBreakpoint = -1;
 	int selectedMemCheck = -1;
 	int selectedAtracCtx = 0;
+	u32 selectedMemoryBlock = 0;
 	uint64_t selectedTexAddr = 0;
 
 	bool realtimePixelPreview = false;


### PR DESCRIPTION
More prep for the new atrac implementation. Now there should always be a place to put the contexts...

Also, shrunk the reservation for sceAtrac being loaded from 0x8000 bytes to 0x4000, which is much closer to the truth. In theory, this can cause memory to be used a little differently, which may affects cheats in a few games. Hopefully they allocate their big arena before they allocate libraries... But we definitely had the wrong amount reserved for sceAtrac before.

Plus some debugger enhancements, you can now browse memory tags in the memory viewer, which also got its own top level menu.