### PR TITLE
More Atrac refactoring before the big PR

### DIFF
--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -676,7 +676,7 @@ void Atrac::GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) {
 	bufferInfo->second.filePos = 0;
 }
 
-int Atrac::SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, int successCode) {
+int Atrac::SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) {
 	outputChannels_ = outputChannels;
 
 	if (outputChannels != track_.channels) {
@@ -731,7 +731,7 @@ int Atrac::SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels,
 	}
 	CreateDecoder();
 	INFO_LOG(Log::ME, "Atrac::SetData (buffer=%08x, readSize=%d, bufferSize=%d): %s %s (%d channels) audio", buffer, readSize, bufferSize, codecName, channelName, track_.channels);
-	return successCode;
+	return 0;
 }
 
 u32 Atrac::SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) {

--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -853,6 +853,10 @@ u32 Atrac::AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) {
 }
 
 u32 Atrac::GetNextSamples() {
+	if (CurrentSample() >= track_.endSample) {
+		return 0;
+	}
+
 	// It seems like the PSP aligns the sample position to 0x800...?
 	u32 skipSamples = track_.FirstSampleOffsetFull();
 	u32 firstSamples = (track_.SamplesPerFrame() - skipSamples) % track_.SamplesPerFrame();

--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -1181,3 +1181,12 @@ void Atrac::InitLowLevel(u32 paramsAddr, bool jointStereo) {
 	CreateDecoder();
 	WriteContextToPSPMem();
 }
+
+int Atrac::DecodeLowLevel(const u8 *srcData, int *bytesConsumed, s16 *dstData, int *bytesWritten) {
+	const int channels = outputChannels_;
+	int outSamples = 0;
+	decoder_->Decode(srcData, track_.BytesPerFrame(), bytesConsumed, channels, dstData, &outSamples);
+	*bytesWritten = outSamples * channels * sizeof(int16_t);
+	// TODO: Possibly return a decode error on bad data.
+	return 0;
+}

--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -547,6 +547,13 @@ int Atrac::AnalyzeAA3(u32 addr, u32 size, u32 fileSize) {
 	return AnalyzeAA3Track(addr, size, fileSize, &track_);
 }
 
+int AtracBase::GetSoundSample(int *endSample, int *loopStartSample, int *loopEndSample) {
+	*endSample = GetTrack().endSample;
+	*loopStartSample = GetTrack().loopStartSample == -1 ? -1 : GetTrack().loopStartSample - GetTrack().FirstSampleOffsetFull();
+	*loopEndSample = GetTrack().loopEndSample == -1 ? -1 : GetTrack().loopEndSample - GetTrack().FirstSampleOffsetFull();
+	return 0;
+}
+
 void Atrac::CalculateStreamInfo(u32 *outReadOffset) {
 	u32 readOffset = first_.fileoffset;
 	if (bufferState_ == ATRAC_STATUS_ALL_DATA_LOADED) {

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -236,7 +236,7 @@ public:
 	virtual void SetLoopNum(int loopNum);
 	virtual u32 ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) = 0;
 	virtual void GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) = 0;
-	virtual int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, int successCode) = 0;
+	virtual int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) = 0;
 
 	virtual int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize);
 	virtual u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) = 0;
@@ -292,7 +292,7 @@ public:
 	u32 AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) override;
 	u32 ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) override;
 	void GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) override;
-	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, int successCode) override;
+	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) override;
 	u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) override;
 	u32 DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains) override;
 	// Returns how many samples the next DecodeData will write.

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -211,6 +211,7 @@ public:
 	int LoopNum() const {
 		return loopNum_;
 	}
+	virtual int LoopStatus() const = 0;
 	u32 CodecType() const {
 		return track_.codecType;
 	}
@@ -235,7 +236,7 @@ public:
 	virtual u32 AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) = 0;
 	virtual void SetLoopNum(int loopNum);
 	virtual u32 ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) = 0;
-	virtual void GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) = 0;
+	virtual int GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) = 0;
 	virtual int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) = 0;
 
 	virtual int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize);
@@ -285,6 +286,12 @@ public:
 	u32 SecondBufferSize() const override {
 		return second_.size;
 	}
+	int LoopStatus() const override {
+		if (track_.loopinfo.size() > 0)
+			return 1;
+		else
+			return 0;
+	}
 
 	// Ask where in memory new data should be written.
 	void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) override;
@@ -292,7 +299,7 @@ public:
 	int AddStreamData(u32 bytesToAdd) override;
 	u32 AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) override;
 	u32 ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) override;
-	void GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) override;
+	int GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) override;
 	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) override;
 	u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) override;
 	u32 DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains) override;

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -253,6 +253,8 @@ public:
 	virtual u32 GetNextSamples() = 0;
 	virtual void InitLowLevel(u32 paramsAddr, bool jointStereo) = 0;
 
+	int GetSoundSample(int *endSample, int *loopStartSample, int *loopEndSample);
+
 protected:
 	Track track_{};
 	u16 outputChannels_ = 2;

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -241,6 +241,7 @@ public:
 	virtual int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize);
 	virtual u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) = 0;
 	virtual u32 DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains) = 0;
+	virtual int DecodeLowLevel(const u8 *srcData, int *bytesConsumed, s16 *dstData, int *bytesWritten) = 0;
 	virtual u32 GetNextSamples() = 0;
 	virtual void InitLowLevel(u32 paramsAddr, bool jointStereo) = 0;
 
@@ -295,6 +296,7 @@ public:
 	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) override;
 	u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) override;
 	u32 DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains) override;
+	int DecodeLowLevel(const u8 *srcData, int *bytesConsumed, s16 *dstData, int *bytesWritten) override;
 	// Returns how many samples the next DecodeData will write.
 	u32 GetNextSamples() override;
 	void InitLowLevel(u32 paramsAddr, bool jointStereo) override;

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -191,6 +191,13 @@ public:
 		return track_;
 	}
 
+	int Channels() const {
+		return track_.channels;
+	}
+	int SamplesPerFrame() const {
+		return track_.SamplesPerFrame();
+	}
+
 	int GetOutputChannels() const {
 		return outputChannels_;
 	}

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -114,13 +114,13 @@ void Atrac2::GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) {
 
 }
 
-int Atrac2::SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, int successCode) {
+int Atrac2::SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) {
 	if (readSize == bufferSize) {
 		bufferState_ = ATRAC_STATUS_ALL_DATA_LOADED;
 	} else {
 		bufferState_ = ATRAC_STATUS_HALFWAY_BUFFER;
 	}
-	return hleLogDebug(Log::ME, successCode);
+	return hleLogDebug(Log::ME, 0);
 }
 
 u32 Atrac2::SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) {

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -110,8 +110,8 @@ u32 Atrac2::ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWri
 	return 0;
 }
 
-void Atrac2::GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) {
-
+int Atrac2::GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) {
+	return 0;
 }
 
 int Atrac2::SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) {

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -156,3 +156,7 @@ void Atrac2::InitLowLevel(u32 paramsAddr, bool jointStereo) {
 	CreateDecoder();
 	WriteContextToPSPMem();
 }
+
+int Atrac2::DecodeLowLevel(const u8 *srcData, int *bytesConsumed, s16 *dstData, int *bytesWritten) {
+	return 0;
+}

--- a/Core/HLE/AtracCtx2.h
+++ b/Core/HLE/AtracCtx2.h
@@ -21,7 +21,7 @@ public:
 	u32 AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) override;
 	u32 ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) override;
 	void GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) override;
-	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, int successCode) override;
+	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) override;
 	u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) override;
 	u32 SecondBufferSize() const override;
 

--- a/Core/HLE/AtracCtx2.h
+++ b/Core/HLE/AtracCtx2.h
@@ -26,6 +26,7 @@ public:
 	u32 SecondBufferSize() const override;
 
 	u32 DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains) override;
+	int DecodeLowLevel(const u8 *srcData, int *bytesConsumed, s16 *dstData, int *bytesWritten) override;
 	u32 GetNextSamples() override;
 	void InitLowLevel(u32 paramsAddr, bool jointStereo) override;
 

--- a/Core/HLE/AtracCtx2.h
+++ b/Core/HLE/AtracCtx2.h
@@ -15,12 +15,13 @@ public:
 
 	int CurrentSample() const override { return currentSample_; }
 	int RemainingFrames() const override;
+	int LoopStatus() const override { return 0; }
 
 	void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) override;
 	int AddStreamData(u32 bytesToAdd) override;
 	u32 AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) override;
 	u32 ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) override;
-	void GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) override;
+	int GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) override;
 	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) override;
 	u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) override;
 	u32 SecondBufferSize() const override;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -343,7 +343,7 @@ static u32 sceAtracGetChannel(int atracID, u32 channelAddr) {
 	}
 
 	if (Memory::IsValidAddress(channelAddr)){
-		Memory::WriteUnchecked_U32(atrac->GetTrack().channels, channelAddr);
+		Memory::WriteUnchecked_U32(atrac->Channels(), channelAddr);
 		return hleLogDebug(Log::ME, 0);
 	} else {
 		return hleLogError(Log::ME, 0, "invalid address");
@@ -390,7 +390,7 @@ static u32 sceAtracGetMaxSample(int atracID, u32 maxSamplesAddr) {
 	}
 
 	if (Memory::IsValidAddress(maxSamplesAddr)) {
-		Memory::WriteUnchecked_U32(atrac->GetTrack().SamplesPerFrame(), maxSamplesAddr);
+		Memory::WriteUnchecked_U32(atrac->SamplesPerFrame(), maxSamplesAddr);
 		return hleLogDebug(Log::ME, 0);
 	} else {
 		return hleLogError(Log::ME, 0, "invalid address");
@@ -423,16 +423,11 @@ static u32 sceAtracGetNextSample(int atracID, u32 outNAddr) {
 	if (err != 0) {
 		return hleLogError(Log::ME, err);
 	}
-	if (atrac->CurrentSample() >= atrac->GetTrack().endSample) {
-		if (Memory::IsValidAddress(outNAddr))
-			Memory::WriteUnchecked_U32(0, outNAddr);
-		return hleLogDebug(Log::ME, 0, "0 samples left");
-	}
 
-	u32 numSamples = atrac->GetNextSamples();
-
-	if (Memory::IsValidAddress(outNAddr))
+	int numSamples = atrac->GetNextSamples();
+	if (Memory::IsValidAddress(outNAddr)) {
 		Memory::WriteUnchecked_U32(numSamples, outNAddr);
+	}
 	return hleLogDebug(Log::ME, 0, "%d samples left", numSamples);
 }
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -572,17 +572,14 @@ static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFi
 	return hleDelayResult(0, "reset play pos", 3000);
 }
 
-// Allowed to log like a HLE function, only called at the end of some.
 static int _AtracSetData(int atracID, u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, bool needReturnAtracID) {
 	AtracBase *atrac = getAtrac(atracID);
 	// Don't use AtracValidateManaged here.
 	if (!atrac) {
-		return hleLogError(Log::ME, SCE_ERROR_ATRAC_BAD_ATRACID, "invalid atrac ID");
+		return SCE_ERROR_ATRAC_BAD_ATRACID;
 	}
 	// SetData logs like a hle function.
-	int ret = atrac->SetData(buffer, readSize, bufferSize, outputChannels, needReturnAtracID ? atracID : 0);
-	// not sure the real delay time
-	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
+	return atrac->SetData(buffer, readSize, bufferSize, outputChannels, needReturnAtracID ? atracID : 0);
 }
 
 static u32 sceAtracSetHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 bufferSize) {
@@ -601,7 +598,9 @@ static u32 sceAtracSetHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 b
 		return hleLogError(Log::ME, ret);
 	}
 
-	return _AtracSetData(atracID, buffer, readSize, bufferSize, 2, false);
+	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 2, false);
+	// not sure the real delay time
+	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
 }
 
 static u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBufferSize) {
@@ -610,7 +609,6 @@ static u32 sceAtracSetSecondBuffer(int atracID, u32 secondBuffer, u32 secondBuff
 	if (err != 0) {
 		return hleLogError(Log::ME, err);
 	}
-
 	return hleLogDebugOrError(Log::ME, atrac->SetSecondBuffer(secondBuffer, secondBufferSize));
 }
 
@@ -630,7 +628,8 @@ static u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize) {
 		return hleReportError(Log::ME, SCE_ERROR_ATRAC_WRONG_CODECTYPE, "atracID uses different codec type than data");
 	}
 
-	return _AtracSetData(atracID, buffer, bufferSize, bufferSize, 2, false);
+	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 2, false);
+	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
 }
 
 static int sceAtracSetDataAndGetID(u32 buffer, int bufferSize) {
@@ -653,7 +652,8 @@ static int sceAtracSetDataAndGetID(u32 buffer, int bufferSize) {
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	return _AtracSetData(atracID, buffer, bufferSize, bufferSize, 2, true);
+	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 2, true);
+	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
 }
 
 static int sceAtracSetHalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 bufferSize) {
@@ -671,7 +671,8 @@ static int sceAtracSetHalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 buffer
 		delete atrac;
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
-	return _AtracSetData(atracID, buffer, readSize, bufferSize, 2, true);
+	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 2, true);
+	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
 }
 
 static u32 sceAtracStartEntry() {
@@ -786,7 +787,8 @@ static int sceAtracSetMOutHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u
 		atrac->SetData(buffer, readSize, bufferSize, 2, 0);
 		return hleReportError(Log::ME, SCE_ERROR_ATRAC_NOT_MONO, "not mono data");
 	} else {
-		return _AtracSetData(atracID, buffer, readSize, bufferSize, 1, false);
+		ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 1, false);
+		return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data mono", 100);
 	}
 }
 
@@ -807,7 +809,8 @@ static u32 sceAtracSetMOutData(int atracID, u32 buffer, u32 bufferSize) {
 		atrac->SetData(buffer, bufferSize, bufferSize, 2, 0);
 		return hleReportError(Log::ME, SCE_ERROR_ATRAC_NOT_MONO, "not mono data");
 	} else {
-		return _AtracSetData(atracID, buffer, bufferSize, bufferSize, 1, false);
+		ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 1, false);
+		return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data mono", 100);
 	}
 }
 
@@ -829,7 +832,8 @@ static int sceAtracSetMOutDataAndGetID(u32 buffer, u32 bufferSize) {
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	return _AtracSetData(atracID, buffer, bufferSize, bufferSize, 1, true);
+	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 1, true);
+	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
 }
 
 static int sceAtracSetMOutHalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 bufferSize) {
@@ -852,7 +856,8 @@ static int sceAtracSetMOutHalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 bu
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	return _AtracSetData(atracID, buffer, readSize, bufferSize, 1, true);
+	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 1, true);
+	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
 }
 
 static int sceAtracSetAA3DataAndGetID(u32 buffer, u32 bufferSize, u32 fileSize, u32 metadataSizeAddr) {
@@ -868,7 +873,8 @@ static int sceAtracSetAA3DataAndGetID(u32 buffer, u32 bufferSize, u32 fileSize, 
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	return _AtracSetData(atracID, buffer, bufferSize, bufferSize, 2, true);
+	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 2, true);
+	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
 }
 
 static u32 _sceAtracGetContextAddress(int atracID) {
@@ -992,7 +998,8 @@ static int sceAtracSetAA3HalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 buf
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	return _AtracSetData(atracID, buffer, readSize, bufferSize, 2, true);
+	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 2, true);
+	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
 }
 
 // External interface used by sceSas' AT3 integration.

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -482,20 +482,20 @@ static u32 sceAtracGetSoundSample(int atracID, u32 outEndSampleAddr, u32 outLoop
 		return hleLogError(Log::ME, err);
 	}
 
-	auto outEndSample = PSPPointer<u32_le>::Create(outEndSampleAddr);
-	if (outEndSample.IsValid())
-		*outEndSample = atrac->GetTrack().endSample;
-	auto outLoopStart = PSPPointer<u32_le>::Create(outLoopStartSampleAddr);
-	if (outLoopStart.IsValid())
-		*outLoopStart = atrac->GetTrack().loopStartSample == -1 ? -1 : atrac->GetTrack().loopStartSample - atrac->GetTrack().FirstSampleOffsetFull();
-	auto outLoopEnd = PSPPointer<u32_le>::Create(outLoopEndSampleAddr);
-	if (outLoopEnd.IsValid())
-		*outLoopEnd = atrac->GetTrack().loopEndSample == -1 ? -1 : atrac->GetTrack().loopEndSample - atrac->GetTrack().FirstSampleOffsetFull();
-
-	if (!outEndSample.IsValid() || !outLoopStart.IsValid() || !outLoopEnd.IsValid()) {
-		return hleReportError(Log::ME, 0, "invalid address");
+	int endSample;
+	int loopStart;
+	int loopEnd;
+	int retval = atrac->GetSoundSample(&endSample, &loopStart, &loopEnd);
+	if (Memory::IsValidAddress(outEndSampleAddr)) {
+		Memory::WriteUnchecked_U32(endSample, outEndSampleAddr);
 	}
-	return hleLogDebug(Log::ME, 0);
+	if (Memory::IsValidAddress(outLoopStartSampleAddr)) {
+		Memory::WriteUnchecked_U32(loopStart, outLoopStartSampleAddr);
+	}
+	if (Memory::IsValidAddress(outLoopEndSampleAddr)) {
+		Memory::WriteUnchecked_U32(loopEnd, outLoopEndSampleAddr);
+	}
+	return hleLogDebug(Log::ME, retval);
 }
 
 // Games call this function to get some info for add more stream data,

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -572,14 +572,13 @@ static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFi
 	return hleDelayResult(0, "reset play pos", 3000);
 }
 
-static int _AtracSetData(int atracID, u32 buffer, u32 readSize, u32 bufferSize, int outputChannels, bool needReturnAtracID) {
+static int _AtracSetData(int atracID, u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) {
 	AtracBase *atrac = getAtrac(atracID);
 	// Don't use AtracValidateManaged here.
 	if (!atrac) {
 		return SCE_ERROR_ATRAC_BAD_ATRACID;
 	}
-	// SetData logs like a hle function.
-	return atrac->SetData(buffer, readSize, bufferSize, outputChannels, needReturnAtracID ? atracID : 0);
+	return atrac->SetData(buffer, readSize, bufferSize, outputChannels);
 }
 
 static u32 sceAtracSetHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 bufferSize) {
@@ -598,7 +597,7 @@ static u32 sceAtracSetHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 b
 		return hleLogError(Log::ME, ret);
 	}
 
-	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 2, false);
+	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 2);
 	// not sure the real delay time
 	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
 }
@@ -628,7 +627,7 @@ static u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize) {
 		return hleReportError(Log::ME, SCE_ERROR_ATRAC_WRONG_CODECTYPE, "atracID uses different codec type than data");
 	}
 
-	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 2, false);
+	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 2);
 	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
 }
 
@@ -652,8 +651,8 @@ static int sceAtracSetDataAndGetID(u32 buffer, int bufferSize) {
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 2, true);
-	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
+	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 2);
+	return hleDelayResult(hleLogDebugOrError(Log::ME, ret == 0 ? atracID : ret), "atrac set data", 100);
 }
 
 static int sceAtracSetHalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 bufferSize) {
@@ -671,8 +670,8 @@ static int sceAtracSetHalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 buffer
 		delete atrac;
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
-	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 2, true);
-	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
+	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 2);
+	return hleDelayResult(hleLogDebugOrError(Log::ME, ret == 0 ? atracID : ret), "atrac set data", 100);
 }
 
 static u32 sceAtracStartEntry() {
@@ -784,10 +783,10 @@ static int sceAtracSetMOutHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u
 	}
 	if (atrac->GetTrack().channels != 1) {
 		// It seems it still sets the data.
-		atrac->SetData(buffer, readSize, bufferSize, 2, 0);
+		atrac->SetData(buffer, readSize, bufferSize, 2);
 		return hleReportError(Log::ME, SCE_ERROR_ATRAC_NOT_MONO, "not mono data");
 	} else {
-		ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 1, false);
+		ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 1);
 		return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data mono", 100);
 	}
 }
@@ -806,10 +805,10 @@ static u32 sceAtracSetMOutData(int atracID, u32 buffer, u32 bufferSize) {
 	}
 	if (atrac->GetTrack().channels != 1) {
 		// It seems it still sets the data.
-		atrac->SetData(buffer, bufferSize, bufferSize, 2, 0);
+		atrac->SetData(buffer, bufferSize, bufferSize, 2);
 		return hleReportError(Log::ME, SCE_ERROR_ATRAC_NOT_MONO, "not mono data");
 	} else {
-		ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 1, false);
+		ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 1);
 		return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data mono", 100);
 	}
 }
@@ -832,8 +831,8 @@ static int sceAtracSetMOutDataAndGetID(u32 buffer, u32 bufferSize) {
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 1, true);
-	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
+	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 1);
+	return hleDelayResult(hleLogDebugOrError(Log::ME, ret == 0 ? atracID : ret), "atrac set data", 100);
 }
 
 static int sceAtracSetMOutHalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 bufferSize) {
@@ -856,8 +855,8 @@ static int sceAtracSetMOutHalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 bu
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 1, true);
-	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
+	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 1);
+	return hleDelayResult(hleLogDebugOrError(Log::ME, ret == 0 ? atracID : ret), "atrac set data", 100);
 }
 
 static int sceAtracSetAA3DataAndGetID(u32 buffer, u32 bufferSize, u32 fileSize, u32 metadataSizeAddr) {
@@ -873,8 +872,8 @@ static int sceAtracSetAA3DataAndGetID(u32 buffer, u32 bufferSize, u32 fileSize, 
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 2, true);
-	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
+	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 2);
+	return hleDelayResult(hleLogDebugOrError(Log::ME, ret == 0 ? atracID : ret), "atrac set data", 100);
 }
 
 static u32 _sceAtracGetContextAddress(int atracID) {
@@ -998,8 +997,8 @@ static int sceAtracSetAA3HalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 buf
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 2, true);
-	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
+	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 2);
+	return hleDelayResult(hleLogDebugOrError(Log::ME, ret == 0 ? atracID : ret), "atrac set data", 100);
 }
 
 // External interface used by sceSas' AT3 integration.


### PR DESCRIPTION
I've realized that the Track structure should not be needed after SetData, and it won't be with the new implementation. The new state saving doesn't need that headache, so let's get rid of all the post-load GetTrack() accesses from sceAtrac.cpp. 

This is the first step of two, to make finding any regressions (which I don't think there will be) easier.