### PR TITLE
Even more Atrac refactoring

### DIFF
--- a/Core/HLE/AtracCtx.cpp
+++ b/Core/HLE/AtracCtx.cpp
@@ -547,7 +547,7 @@ int Atrac::AnalyzeAA3(u32 addr, u32 size, u32 fileSize) {
 	return AnalyzeAA3Track(addr, size, fileSize, &track_);
 }
 
-int AtracBase::GetSoundSample(int *endSample, int *loopStartSample, int *loopEndSample) {
+int Atrac::GetSoundSample(int *endSample, int *loopStartSample, int *loopEndSample) const {
 	*endSample = GetTrack().endSample;
 	*loopStartSample = GetTrack().loopStartSample == -1 ? -1 : GetTrack().loopStartSample - GetTrack().FirstSampleOffsetFull();
 	*loopEndSample = GetTrack().loopEndSample == -1 ? -1 : GetTrack().loopEndSample - GetTrack().FirstSampleOffsetFull();

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -220,7 +220,7 @@ public:
 
 	void CreateDecoder();
 
-	virtual int CurrentSample() const = 0;
+	virtual int GetNextDecodePosition(int *pos) const = 0;
 	virtual int RemainingFrames() const = 0;
 	virtual u32 SecondBufferSize() const = 0;
 	virtual int Bitrate() const = 0;
@@ -236,7 +236,7 @@ public:
 	virtual int AddStreamData(u32 bytesToAdd) = 0;
 	virtual u32 AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) = 0;
 	virtual void SetLoopNum(int loopNum);
-	virtual u32 ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) = 0;
+	virtual int ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf, bool *delay) = 0;
 	virtual int GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) = 0;
 	virtual int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) = 0;
 
@@ -282,9 +282,7 @@ public:
 	int Analyze(u32 addr, u32 size) override;
 	int AnalyzeAA3(u32 addr, u32 size, u32 filesize) override;
 
-	int CurrentSample() const override {
-		return currentSample_;
-	}
+	int GetNextDecodePosition(int *pos) const override;
 	int RemainingFrames() const override;
 	u32 SecondBufferSize() const override {
 		return second_.size;
@@ -315,7 +313,7 @@ public:
 	// Notify the player that the user has written some new data.
 	int AddStreamData(u32 bytesToAdd) override;
 	u32 AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) override;
-	u32 ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) override;
+	int ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf, bool *delay) override;
 	int GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) override;
 	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) override;
 	u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) override;

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -184,13 +184,7 @@ public:
 
 	virtual void DoState(PointerWrap &p) = 0;
 
-	const Track &GetTrack() const {
-		return track_;
-	}
-
-	int Channels() const {
-		return track_.channels;
-	}
+	virtual int Channels() const = 0;
 
 	int GetOutputChannels() const {
 		return outputChannels_;
@@ -209,8 +203,10 @@ public:
 		return bufferState_;
 	}
 
+	virtual int SetLoopNum(int loopNum) = 0;
 	virtual int LoopNum() const = 0;
 	virtual int LoopStatus() const = 0;
+
 	u32 CodecType() const {
 		return track_.codecType;
 	}
@@ -224,6 +220,7 @@ public:
 	virtual int RemainingFrames() const = 0;
 	virtual u32 SecondBufferSize() const = 0;
 	virtual int Bitrate() const = 0;
+	virtual int BytesPerFrame() const = 0;
 	virtual int SamplesPerFrame() const = 0;
 
 	virtual int Analyze(u32 addr, u32 size) = 0;
@@ -235,7 +232,6 @@ public:
 	virtual void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) = 0;
 	virtual int AddStreamData(u32 bytesToAdd) = 0;
 	virtual u32 AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) = 0;
-	virtual void SetLoopNum(int loopNum);
 	virtual int ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf, bool *delay) = 0;
 	virtual int GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) = 0;
 	virtual int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) = 0;
@@ -287,6 +283,9 @@ public:
 	u32 SecondBufferSize() const override {
 		return second_.size;
 	}
+	int Channels() const override {
+		return track_.channels;
+	}
 	int LoopNum() const override {
 		return loopNum_;
 	}
@@ -299,6 +298,9 @@ public:
 	int Bitrate() const override {
 		return track_.Bitrate();
 	}
+	int BytesPerFrame() const override {
+		return track_.BytesPerFrame();
+	}
 	int SamplesPerFrame() const override {
 		return track_.SamplesPerFrame();
 	}
@@ -307,6 +309,8 @@ public:
 	Track &GetTrackMut() {
 		return track_;
 	}
+
+	int SetLoopNum(int loopNum) override;
 
 	// Ask where in memory new data should be written.
 	void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) override;

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -35,6 +35,10 @@
 //   * Half Minute Hero (bufsize 65536)
 //   * Flatout (tricky! needs investigation)
 
+Atrac2::Atrac2(int codecType) {
+	track_.codecType = codecType;
+}
+
 void Atrac2::DoState(PointerWrap &p) {
 	_assert_msg_(false, "Savestates not yet support with new Atrac implementation.\n\nTurn it off in Developer settings.\n\n");
 }
@@ -111,6 +115,10 @@ u32 Atrac2::ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWri
 }
 
 int Atrac2::GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) {
+	return 0;
+}
+
+int Atrac2::GetSoundSample(int *endSample, int *loopStartSample, int *loopEndSample) const {
 	return 0;
 }
 

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -110,7 +110,8 @@ u32 Atrac2::AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) {
 	return 0;
 }
 
-u32 Atrac2::ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) {
+int Atrac2::ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf, bool *delay) {
+	*delay = false;
 	return 0;
 }
 

--- a/Core/HLE/AtracCtx2.h
+++ b/Core/HLE/AtracCtx2.h
@@ -14,7 +14,7 @@ public:
 	int Analyze(u32 addr, u32 size) override;
 	int AnalyzeAA3(u32 addr, u32 size, u32 filesize) override;
 
-	int CurrentSample() const override { return currentSample_; }
+	int GetNextDecodePosition(int *pos) const { return 0; }
 	int RemainingFrames() const override;
 	int LoopStatus() const override { return 0; }
 	int Bitrate() const override { return 0; }
@@ -24,7 +24,7 @@ public:
 	void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) override;
 	int AddStreamData(u32 bytesToAdd) override;
 	u32 AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) override;
-	u32 ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf) override;
+	int ResetPlayPosition(int sample, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf, bool *delay) override;
 	int GetResetBufferInfo(AtracResetBufferInfo *bufferInfo, int sample) override;
 	int SetData(u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) override;
 	u32 SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) override;

--- a/Core/HLE/AtracCtx2.h
+++ b/Core/HLE/AtracCtx2.h
@@ -7,6 +7,7 @@
 
 class Atrac2 : public AtracBase {
 public:
+	Atrac2(int codecType);
 	void DoState(PointerWrap &p) override;
 	void WriteContextToPSPMem() override;
 
@@ -16,6 +17,9 @@ public:
 	int CurrentSample() const override { return currentSample_; }
 	int RemainingFrames() const override;
 	int LoopStatus() const override { return 0; }
+	int Bitrate() const override { return 0; }
+	int LoopNum() const override { return 0; }
+	int SamplesPerFrame() const override { return 0; }
 
 	void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) override;
 	int AddStreamData(u32 bytesToAdd) override;
@@ -30,6 +34,8 @@ public:
 	int DecodeLowLevel(const u8 *srcData, int *bytesConsumed, s16 *dstData, int *bytesWritten) override;
 	u32 GetNextSamples() override;
 	void InitLowLevel(u32 paramsAddr, bool jointStereo) override;
+
+	int GetSoundSample(int *endSample, int *loopStartSample, int *loopEndSample) const override;
 
 private:
 	int currentSample_ = 0;

--- a/Core/HLE/AtracCtx2.h
+++ b/Core/HLE/AtracCtx2.h
@@ -20,6 +20,9 @@ public:
 	int Bitrate() const override { return 0; }
 	int LoopNum() const override { return 0; }
 	int SamplesPerFrame() const override { return 0; }
+	int Channels() const override { return 2; }
+	int BytesPerFrame() const override { return 0; }
+	int SetLoopNum(int loopNum) override { return 0; }
 
 	void GetStreamDataInfo(u32 *writePtr, u32 *writableBytes, u32 *readOffset) override;
 	int AddStreamData(u32 bytesToAdd) override;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -553,15 +553,6 @@ static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFi
 	return hleDelayResult(hleLogDebugOrError(Log::ME, res), "reset play pos", 3000 + delay ? 200 : 0);
 }
 
-static int _AtracSetData(int atracID, u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) {
-	AtracBase *atrac = getAtrac(atracID);
-	// Don't use AtracValidateManaged here.
-	if (!atrac) {
-		return SCE_ERROR_ATRAC_BAD_ATRACID;
-	}
-	return atrac->SetData(buffer, readSize, bufferSize, outputChannels);
-}
-
 static u32 sceAtracSetHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 bufferSize) {
 	AtracBase *atrac = getAtrac(atracID);
 	// Don't use AtracValidateManaged here.
@@ -578,7 +569,7 @@ static u32 sceAtracSetHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 b
 		return hleLogError(Log::ME, ret);
 	}
 
-	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 2);
+	ret = atrac->SetData(buffer, readSize, bufferSize, 2);
 	// not sure the real delay time
 	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
 }
@@ -608,7 +599,7 @@ static u32 sceAtracSetData(int atracID, u32 buffer, u32 bufferSize) {
 		return hleReportError(Log::ME, SCE_ERROR_ATRAC_WRONG_CODECTYPE, "atracID uses different codec type than data");
 	}
 
-	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 2);
+	ret = atrac->SetData(buffer, bufferSize, bufferSize, 2);
 	return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data", 100);
 }
 
@@ -632,7 +623,7 @@ static int sceAtracSetDataAndGetID(u32 buffer, int bufferSize) {
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 2);
+	ret = atrac->SetData(buffer, bufferSize, bufferSize, 2);
 	return hleDelayResult(hleLogDebugOrError(Log::ME, ret == 0 ? atracID : ret), "atrac set data", 100);
 }
 
@@ -651,7 +642,7 @@ static int sceAtracSetHalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 buffer
 		delete atrac;
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
-	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 2);
+	ret = atrac->SetData(buffer, readSize, bufferSize, 2);
 	return hleDelayResult(hleLogDebugOrError(Log::ME, ret == 0 ? atracID : ret), "atrac set data", 100);
 }
 
@@ -763,7 +754,7 @@ static int sceAtracSetMOutHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u
 		atrac->SetData(buffer, readSize, bufferSize, 2);
 		return hleReportError(Log::ME, SCE_ERROR_ATRAC_NOT_MONO, "not mono data");
 	} else {
-		ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 1);
+		ret = atrac->SetData(buffer, readSize, bufferSize, 1);
 		return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data mono", 100);
 	}
 }
@@ -785,7 +776,7 @@ static u32 sceAtracSetMOutData(int atracID, u32 buffer, u32 bufferSize) {
 		atrac->SetData(buffer, bufferSize, bufferSize, 2);
 		return hleReportError(Log::ME, SCE_ERROR_ATRAC_NOT_MONO, "not mono data");
 	} else {
-		ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 1);
+		ret = atrac->SetData(buffer, bufferSize, bufferSize, 1);
 		return hleDelayResult(hleLogDebugOrError(Log::ME, ret), "atrac set data mono", 100);
 	}
 }
@@ -808,7 +799,7 @@ static int sceAtracSetMOutDataAndGetID(u32 buffer, u32 bufferSize) {
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 1);
+	ret = atrac->SetData(buffer, bufferSize, bufferSize, 1);
 	return hleDelayResult(hleLogDebugOrError(Log::ME, ret == 0 ? atracID : ret), "atrac set data", 100);
 }
 
@@ -832,7 +823,7 @@ static int sceAtracSetMOutHalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 bu
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 1);
+	ret = atrac->SetData(buffer, readSize, bufferSize, 1);
 	return hleDelayResult(hleLogDebugOrError(Log::ME, ret == 0 ? atracID : ret), "atrac set data", 100);
 }
 
@@ -849,7 +840,7 @@ static int sceAtracSetAA3DataAndGetID(u32 buffer, u32 bufferSize, u32 fileSize, 
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	ret = _AtracSetData(atracID, buffer, bufferSize, bufferSize, 2);
+	ret = atrac->SetData(buffer, bufferSize, bufferSize, 2);
 	return hleDelayResult(hleLogDebugOrError(Log::ME, ret == 0 ? atracID : ret), "atrac set data", 100);
 }
 
@@ -971,7 +962,7 @@ static int sceAtracSetAA3HalfwayBufferAndGetID(u32 buffer, u32 readSize, u32 buf
 		return hleLogError(Log::ME, atracID, "no free ID");
 	}
 
-	ret = _AtracSetData(atracID, buffer, readSize, bufferSize, 2);
+	ret = atrac->SetData(buffer, readSize, bufferSize, 2);
 	return hleDelayResult(hleLogDebugOrError(Log::ME, ret == 0 ? atracID : ret), "atrac set data", 100);
 }
 

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -550,7 +550,14 @@ static u32 sceAtracResetPlayPosition(int atracID, int sample, int bytesWrittenFi
 
 	bool delay = false;
 	int res = atrac->ResetPlayPosition(sample, bytesWrittenFirstBuf, bytesWrittenSecondBuf, &delay);
-	return hleDelayResult(hleLogDebugOrError(Log::ME, res), "reset play pos", 3000 + delay ? 200 : 0);
+	if (res < 0) {
+		if (delay) {
+			return hleDelayResult(hleLogError(Log::ME, res), "reset play pos", 200);
+		} else {
+			return hleLogError(Log::ME, res);
+		}
+	}
+	return hleDelayResult(hleLogDebug(Log::ME, res), "reset play pos", 3000);
 }
 
 static u32 sceAtracSetHalfwayBuffer(int atracID, u32 buffer, u32 readSize, u32 bufferSize) {

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -1018,9 +1018,11 @@ void DrawAudioDecodersView(ImConfig &cfg, ImControl &control) {
 			if (ctx && ImGui::CollapsingHeader(header, ImGuiTreeNodeFlags_DefaultOpen)) {
 				int pos;
 				ctx->GetNextDecodePosition(&pos);
-				ImGui::ProgressBar((float)pos / (float)ctx->GetTrack().endSample, ImVec2(200.0f, 0.0f));
+				int endSample, loopStart, loopEnd;
+				ctx->GetSoundSample(&endSample, &loopStart, &loopEnd);
+				ImGui::ProgressBar((float)pos / (float)endSample, ImVec2(200.0f, 0.0f));
 				ImGui::Text("Status: %s", AtracStatusToString(ctx->BufferState()));
-				ImGui::Text("cur/end sample: %d/%d", pos, ctx->GetTrack().endSample);
+				ImGui::Text("cur/end sample: %d/%d", pos, endSample);
 				ImGui::Text("ctx addr: "); ImGui::SameLine(); ImClickableValue("addr", ctx->Decoder()->GetCtxPtr(), control, ImCmd::SHOW_IN_MEMORY_VIEWER);
 				ImGui::Text("loop: %d", ctx->LoopNum());
 			}

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -999,7 +999,9 @@ void DrawAudioDecodersView(ImConfig &cfg, ImControl &control) {
 				ImGui::TableNextColumn();
 				ImGui::Text("%d", ctx->GetOutputChannels());
 				ImGui::TableNextColumn();
-				ImGui::Text("%d", ctx->CurrentSample());
+				int pos;
+				ctx->GetNextDecodePosition(&pos);
+				ImGui::Text("%d", pos);
 				ImGui::TableNextColumn();
 				ImGui::Text("%d", ctx->RemainingFrames());
 			}
@@ -1014,9 +1016,11 @@ void DrawAudioDecodersView(ImConfig &cfg, ImControl &control) {
 			char header[32];
 			snprintf(header, sizeof(header), "Atrac context %d", cfg.selectedAtracCtx);
 			if (ctx && ImGui::CollapsingHeader(header, ImGuiTreeNodeFlags_DefaultOpen)) {
-				ImGui::ProgressBar((float)ctx->CurrentSample() / (float)ctx->GetTrack().endSample, ImVec2(200.0f, 0.0f));
+				int pos;
+				ctx->GetNextDecodePosition(&pos);
+				ImGui::ProgressBar((float)pos / (float)ctx->GetTrack().endSample, ImVec2(200.0f, 0.0f));
 				ImGui::Text("Status: %s", AtracStatusToString(ctx->BufferState()));
-				ImGui::Text("cur/end sample: %d/%d", ctx->CurrentSample(), ctx->GetTrack().endSample);
+				ImGui::Text("cur/end sample: %d/%d", pos, ctx->GetTrack().endSample);
 				ImGui::Text("ctx addr: "); ImGui::SameLine(); ImClickableValue("addr", ctx->Decoder()->GetCtxPtr(), control, ImCmd::SHOW_IN_MEMORY_VIEWER);
 				ImGui::Text("loop: %d", ctx->LoopNum());
 			}


### PR DESCRIPTION
This finally gets rid of the GetTrack() accessor.

Next, I also want to remove the separate Analyze step, and explicitly generate the Track in sceAtrac.cpp and pass it in, but let's get this in first. Then I can finally prepare for savestates, and THEN I'll be able to rebase and merge the big PR.