### PR TITLE
Fix an ordering issue in Atrac context creation

### DIFF
--- a/Common/Serialize/SerializeFuncs.h
+++ b/Common/Serialize/SerializeFuncs.h
@@ -70,16 +70,15 @@ void DoClass(PointerWrap &p, T *&x) {
 	x->DoState(p);
 }
 
-template<class T, class S>
-void DoSubClass(PointerWrap &p, T *&x) {
+template<class T, class S, typename... Args>
+void DoSubClass(PointerWrap &p, T *&x, Args... args) {
 	if (p.mode == PointerWrap::MODE_READ) {
 		if (x != nullptr)
 			delete x;
-		x = new S();
+		x = new S(args...);
 	}
 	x->DoState(p);
 }
-
 
 template<class T>
 void DoArray(PointerWrap &p, T *x, int count) {

--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -188,7 +188,6 @@ public:
 		outputChannels_ = channels;
 	}
 
-	virtual void SetIDAndAddr(int atracID, u32 contextAddr) = 0;
 	virtual int GetID() const = 0;
 
 	PSPPointer<SceAtracContext> context_{};
@@ -247,7 +246,7 @@ protected:
 
 class Atrac : public AtracBase {
 public:
-	Atrac(int codecType = 0) {
+	Atrac(int atracID, int codecType = 0) : atracID_(atracID) {
 		if (codecType) {
 			track_.codecType = codecType;
 		}
@@ -270,9 +269,6 @@ public:
 	int GetNextDecodePosition(int *pos) const override;
 	int RemainingFrames() const override;
 
-	void SetIDAndAddr(int atracID, u32 contextAddr) override {
-		atracID_ = atracID;
-	}
 	int GetID() const override {
 		return atracID_;
 	}

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -35,13 +35,11 @@
 //   * Half Minute Hero (bufsize 65536)
 //   * Flatout (tricky! needs investigation)
 
-Atrac2::Atrac2(int codecType) {
-	track_.codecType = codecType;
-}
 
-void Atrac2::SetIDAndAddr(int atracID, u32 contextAddr) {
-	// Note: We don't allocate a context, we use memory directly from the loaded atrac binary (even if it's otherwise unused).
+Atrac2::Atrac2(int atracID, u32 contextAddr, int codecType) {
 	context_ = PSPPointer<SceAtracContext>::Create(contextAddr);
+	track_.codecType = codecType;
+	context_->info.codec = codecType;
 }
 
 void Atrac2::DoState(PointerWrap &p) {

--- a/Core/HLE/AtracCtx2.h
+++ b/Core/HLE/AtracCtx2.h
@@ -7,10 +7,9 @@
 
 class Atrac2 : public AtracBase {
 public:
-	Atrac2(int codecType);
+	Atrac2(int atracID, u32 contextAddr, int codecType);
 	void DoState(PointerWrap &p) override;
 
-	void SetIDAndAddr(int atracID, u32 contextAddr) override;
 	int GetID() const override { return 0; }
 
 	int GetNextDecodePosition(int *pos) const { return 0; }


### PR DESCRIPTION
Allocate and "register" atrac contexts in one go, to avoid a circular dependency problem with the new contexts. (can't do SetData without a context pointer, but couldn't give it a context pointer before SetData had run...). This requires sometimes unregistering if something went wrong, but that's fine.