### PR TITLE
Atrac3 new impl: Fix Sol Trigger

### DIFF
--- a/Core/HLE/AtracCtx.h
+++ b/Core/HLE/AtracCtx.h
@@ -222,8 +222,9 @@ public:
 
 	virtual int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) = 0;
 	virtual int SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) = 0;
-	virtual u32 DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains) = 0;
+	virtual u32 DecodeData(u8 *outbuf, u32 outbufPtr, int *SamplesNum, int *finish, int *remains) = 0;
 	virtual int DecodeLowLevel(const u8 *srcData, int *bytesConsumed, s16 *dstData, int *bytesWritten) = 0;
+	virtual void DecodeForSas(s16 *dstData, int *bytesWritten, int *finish) = 0;
 	virtual u32 GetNextSamples() = 0;
 	virtual void InitLowLevel(const Atrac3LowLevelParams &params, int codecType) = 0;
 
@@ -313,8 +314,10 @@ public:
 	int SetData(const Track &track, u32 buffer, u32 readSize, u32 bufferSize, int outputChannels) override;
 	int GetSecondBufferInfo(u32 *fileOffset, u32 *desiredSize) override;
 	int SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) override;
-	u32 DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains) override;
+	u32 DecodeData(u8 *outbuf, u32 outbufPtr, int *SamplesNum, int *finish, int *remains) override;
 	int DecodeLowLevel(const u8 *srcData, int *bytesConsumed, s16 *dstData, int *bytesWritten) override;
+	void DecodeForSas(s16 *dstData, int *bytesWritten, int *finish) override;
+
 	// Returns how many samples the next DecodeData will write.
 	u32 GetNextSamples() override;
 	void InitLowLevel(const Atrac3LowLevelParams &params, int codecType) override;

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -173,13 +173,16 @@ Atrac2::Atrac2(u32 contextAddr, int codecType) {
 		info.codec = codecType;
 		info.state = ATRAC_STATUS_NO_DATA;
 		info.curBuffer = 0;
+
+		sasReadOffset_ = 0;
+		sasBasePtr_ = 0;
 	} else {
 		// We're loading state, we'll restore the context in DoState.
 	}
 }
 
 void Atrac2::DoState(PointerWrap &p) {
-	auto s = p.Section("Atrac2", 1, 1);
+	auto s = p.Section("Atrac2", 1, 2);
 	if (!s)
 		return;
 
@@ -187,6 +190,11 @@ void Atrac2::DoState(PointerWrap &p) {
 	// The only thing we need to save now is the outputChannels_ and the context pointer. And technically, not even that since
 	// it can be computed. Still, for future proofing, let's save it.
 	Do(p, context_);
+	// Actually, now we also need to save sas state. I guess this could also be saved on the Sas side, but this is easier.
+	if (s >= 2) {
+		Do(p, sasReadOffset_);
+		Do(p, sasBasePtr_);
+	}
 
 	const SceAtracIdInfo &info = context_->info;
 	if (p.mode == p.MODE_READ && info.state != ATRAC_STATUS_NO_DATA) {
@@ -489,14 +497,16 @@ int Atrac2::AddStreamData(u32 bytesToAdd) {
 }
 
 u32 Atrac2::AddStreamDataSas(u32 bufPtr, u32 bytesToAdd) {
+	SceAtracIdInfo &info = context_->info;
 	// Internal API, seems like a combination of GetStreamDataInfo and AddStreamData, for use when
 	// an Atrac context is bound to an sceSas channel.
 	// Sol Trigger is the only game I know that uses this.
 	_dbg_assert_(false);
 
-	// SceAtracIdInfo &info = context_->info;
-	// info.streamDataByte += bytesToAdd;
-	AddStreamData(bytesToAdd);
+	u8 *dest = Memory::GetPointerWrite(info.buffer);
+	memcpy(dest, Memory::GetPointer(bufPtr), bytesToAdd);
+	info.buffer += bytesToAdd;
+	info.streamDataByte += bytesToAdd;
 	return 0;
 }
 
@@ -629,7 +639,7 @@ void Atrac2::GetStreamDataInfo(u32 *writePtr, u32 *bytesToWrite, u32 *readFileOf
 	}
 }
 
-u32 Atrac2::DecodeData(u8 *outbuf, u32 outbufAddr, u32 *SamplesNum, u32 *finish, int *remains) {
+u32 Atrac2::DecodeData(u8 *outbuf, u32 outbufAddr, int *SamplesNum, int *finish, int *remains) {
 	SceAtracIdInfo &info = context_->info;
 
 	const int tries = info.numSkipFrames + 1;
@@ -645,7 +655,7 @@ u32 Atrac2::DecodeData(u8 *outbuf, u32 outbufAddr, u32 *SamplesNum, u32 *finish,
 	return 0;
 }
 
-u32 Atrac2::DecodeInternal(u32 outbufAddr, u32 *SamplesNum, u32 *finish) {
+u32 Atrac2::DecodeInternal(u32 outbufAddr, int *SamplesNum, int *finish) {
 	SceAtracIdInfo &info = context_->info;
 
 	// Check that there's enough data to decode.
@@ -886,7 +896,11 @@ int Atrac2::SetData(const Track &track, u32 bufferAddr, u32 readSize, u32 buffer
 
 	int skipCount = 0;  // TODO: use for delay
 	u32 retval = SkipFrames(&skipCount);
-	if (retval != 0) {
+
+	// Seen in Mui Mui house. Things go very wrong after this..
+	if (retval == SCE_ERROR_ATRAC_API_FAIL) {
+		ERROR_LOG(Log::ME, "Bad frame during initial skip");
+	} else if (retval != 0) {
 		ERROR_LOG(Log::ME, "SkipFrames during InitContext returned an error: %08x", retval);
 	}
 	WrapLastPacket();
@@ -922,7 +936,7 @@ void Atrac2::WrapLastPacket() {
 u32 Atrac2::SkipFrames(int *skipCount) {
 	SceAtracIdInfo &info = context_->info;
 	*skipCount = 0;
-	u32 finishIgnored;
+	int finishIgnored;
 	while (true) {
 		if (info.numSkipFrames == 0) {
 			return 0;
@@ -1013,4 +1027,29 @@ int Atrac2::DecodeLowLevel(const u8 *srcData, int *bytesConsumed, s16 *dstData, 
 	*bytesWritten = outSamples * channels * sizeof(int16_t);
 	// TODO: Possibly return a decode error on bad data.
 	return 0;
+}
+
+void Atrac2::DecodeForSas(s16 *dstData, int *bytesWritten, int *finish) {
+	SceAtracIdInfo &info = context_->info;
+
+	if (info.buffer) {
+		// Adopt it then zero it.
+		sasBasePtr_ = info.buffer;
+		sasReadOffset_ = 0;
+		info.buffer = 0;
+	}
+
+	const u8 *srcData = Memory::GetPointer(sasBasePtr_ + sasReadOffset_);
+
+	int outSamples = 0;
+	int bytesConsumed = 0;
+	decoder_->Decode(srcData, info.sampleSize, &bytesConsumed, 1, dstData, bytesWritten);
+
+	sasReadOffset_ += bytesConsumed;
+
+	if (sasReadOffset_ + info.dataOff >= info.fileDataEnd) {
+		*finish = 1;
+	} else {
+		*finish = 0;
+	}
 }

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -168,7 +168,7 @@ int Atrac2::RemainingFrames() const {
 Atrac2::Atrac2(u32 contextAddr, int codecType) {
 	if (contextAddr) {
 		context_ = PSPPointer<SceAtracContext>::Create(contextAddr);
-		// First-time initialization.
+		// First-time initialization. The rest is initialized in SetData.
 		SceAtracIdInfo &info = context_->info;
 		info.codec = codecType;
 		info.state = ATRAC_STATUS_NO_DATA;

--- a/Core/HLE/AtracCtx2.h
+++ b/Core/HLE/AtracCtx2.h
@@ -40,8 +40,10 @@ public:
 	int SetSecondBuffer(u32 secondBuffer, u32 secondBufferSize) override;
 	bool HasSecondBuffer() const override;
 
-	u32 DecodeData(u8 *outbuf, u32 outbufPtr, u32 *SamplesNum, u32 *finish, int *remains) override;
+	u32 DecodeData(u8 *outbuf, u32 outbufPtr, int *SamplesNum, int *finish, int *remains) override;
 	int DecodeLowLevel(const u8 *srcData, int *bytesConsumed, s16 *dstData, int *bytesWritten) override;
+	void DecodeForSas(s16 *dstData, int *bytesWritten, int *finish);
+
 	u32 GetNextSamples() override;
 
 	void InitLowLevel(const Atrac3LowLevelParams &params, int codecType) override;
@@ -57,7 +59,7 @@ public:
 	u32 GetInternalCodecError() const override;
 
 private:
-	u32 DecodeInternal(u32 outbufAddr, u32 *SamplesNum, u32 *finish);
+	u32 DecodeInternal(u32 outbufAddr, int *SamplesNum, int *finish);
 	void GetResetBufferInfoInternal(AtracResetBufferInfo *bufferInfo, int sample);
 	u32 ResetPlayPositionInternal(int seekPos, int bytesWrittenFirstBuf, int bytesWrittenSecondBuf);
 
@@ -68,4 +70,9 @@ private:
 	// to write the initial partial frame.
 	// Does not need to be saved.
 	int16_t *decodeTemp_ = nullptr;
+
+	// This is hidden state inside sceSas, really. Not visible in the context.
+	// But it doesn't really matter whether it's here or there.
+	u32 sasBasePtr_ = 0;
+	int sasReadOffset_ = 0;
 };

--- a/Core/HLE/sceAtrac.h
+++ b/Core/HLE/sceAtrac.h
@@ -138,5 +138,5 @@ bool IsAtrac3StreamJointStereo(int codecType, int bytesPerFrame, int channels);
 
 // External interface used by sceSas, see ATRAC_STATUS_FOR_SCESAS.
 u32 AtracSasAddStreamData(int atracID, u32 bufPtr, u32 bytesToAdd);
-u32 AtracSasDecodeData(int atracID, u8* outbuf, u32 outbufPtr, u32 *SamplesNum, u32* finish, int *remains);
-int AtracSasGetIDByContext(u32 contextAddr);
+void AtracSasDecodeData(int atracID, u8* outbuf, int *SamplesNum, int *finish);
+int AtracSasBindContextAndGetID(u32 contextAddr);

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -1680,7 +1680,7 @@ static u32 scePsmfPlayerGetCurrentPts(u32 psmfPlayer, u32 currentPtsAddr)
 	if (Memory::IsValidAddress(currentPtsAddr)) {
 		Memory::Write_U32(psmfplayer->psmfPlayerAvcAu.pts, currentPtsAddr);
 	}
-	return hleLogDebug(Log::ME, 0);
+	return hleLogDebug(Log::ME, 0, "pts: %d", psmfplayer->psmfPlayerAvcAu.pts);
 }
 
 static u32 scePsmfPlayerGetPsmfInfo(u32 psmfPlayer, u32 psmfInfoAddr, u32 widthAddr, u32 heightAddr) {

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -715,7 +715,7 @@ static u32 __sceSasConcatenateATRAC3(u32 core, int voiceNum, u32 atrac3DataAddr,
 		return hleLogWarning(Log::sceSas, ERROR_SAS_INVALID_VOICE, "invalid voicenum");
 	}
 
-	DEBUG_LOG_REPORT(Log::sceSas, "__sceSasConcatenateATRAC3(%08x, %i, %08x, %i)", core, voiceNum, atrac3DataAddr, atrac3DataLength);
+	DEBUG_LOG_REPORT_ONCE(concatAtrac3, Log::sceSas, "__sceSasConcatenateATRAC3(%08x, %i, %08x, %i)", core, voiceNum, atrac3DataAddr, atrac3DataLength);
 	__SasDrain();
 	SasVoice &v = sas->voices[voiceNum];
 	if (Memory::IsValidAddress(atrac3DataAddr))

--- a/Core/HW/SasAudio.cpp
+++ b/Core/HW/SasAudio.cpp
@@ -190,7 +190,8 @@ void VagDecoder::DoState(PointerWrap &p) {
 
 int SasAtrac3::setContext(u32 contextAddr) {
 	contextAddr_ = contextAddr;
-	atracID_ = AtracSasGetIDByContext(contextAddr);
+	// Note: This atracID_ is also stored in the loopNum member of the context.
+	atracID_ = AtracSasBindContextAndGetID(contextAddr);
 	if (!sampleQueue_)
 		sampleQueue_ = new BufferQueue();
 	sampleQueue_->clear();
@@ -203,13 +204,12 @@ void SasAtrac3::getNextSamples(s16 *outbuf, int wantedSamples) {
 		end_ = true;
 		return;
 	}
-	u32 finish = 0;
+	int finish = 0;
 	int wantedbytes = wantedSamples * sizeof(s16);
 	while (!finish && sampleQueue_->getQueueSize() < wantedbytes) {
-		u32 numSamples = 0;
-		int remains = 0;
+		int numSamples = 0;
 		static s16 buf[0x800];
-		AtracSasDecodeData(atracID_, (u8*)buf, 0, &numSamples, &finish, &remains);
+		AtracSasDecodeData(atracID_, (u8*)buf, &numSamples, &finish);
 		if (numSamples > 0)
 			sampleQueue_->push((u8*)buf, numSamples * sizeof(s16));
 		else

--- a/test.py
+++ b/test.py
@@ -93,6 +93,7 @@ tests_good = [
   "audio/atrac/second/needed",
   "audio/atrac/second/setbuffer",
   "audio/atrac/setdata",
+  "audio/atrac/sas",
   "audio/mp3/checkneeded",
   "audio/mp3/getbitrate",
   "audio/mp3/getchannel",


### PR DESCRIPTION
When you use an Atrac as a source for an sceSas channel, things act quite differently. 

However, this is not a full implementation of this technique, there are a few games that seem to use streaming (like L.A. Gridlock) and they likely don't work yet. 

These games may have issues too: 
https://report.ppsspp.org/logs/kind/193
https://report.ppsspp.org/logs/kind/197 