### PR TITLE
New sceAtrac impl: Fix low level decoding

### DIFF
--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -1024,7 +1024,13 @@ int Atrac2::DecodeLowLevel(const u8 *srcData, int *bytesConsumed, s16 *dstData, 
 
 	const int channels = outputChannels_;
 	int outSamples = 0;
-	decoder_->Decode(srcData, info.sampleSize, bytesConsumed, channels, dstData, &outSamples);
+	bool success = decoder_->Decode(srcData, info.sampleSize, bytesConsumed, channels, dstData, &outSamples);
+	if (!success) {
+		ERROR_LOG(Log::ME, "Low level decoding failed: sampleSize: %d bytesConsumed: %d", info.sampleSize, *bytesConsumed);
+		*bytesConsumed = 0;
+		*bytesWritten = 0;
+		return SCE_ERROR_ATRAC_API_FAIL;  // need to check what return value we get here.
+	}
 	*bytesWritten = outSamples * channels * sizeof(int16_t);
 	// TODO: Possibly return a decode error on bad data.
 	return 0;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1080,6 +1080,8 @@ static int sceAtracLowLevelDecode(int atracID, u32 sourceAddr, u32 sourceBytesCo
 	int bytesWritten = 0;
 
 	int retval = atrac->DecodeLowLevel(srcp, &bytesConsumed, outp, &bytesWritten);
+	*srcConsumed = bytesConsumed;
+	*outWritten = bytesWritten;
 
 	NotifyMemInfo(MemBlockFlags::WRITE, samplesAddr, bytesWritten, "AtracLowLevelDecode");
 	return hleDelayResult(hleLogDebug(Log::ME, retval), "low level atrac decode data", atracDecodeDelay);

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -118,7 +118,8 @@ static const ModuleLoadInfo moduleLoadInfo[] = {
 	ModuleLoadInfo(0x300, 0x00000000, "av_avcodec", &NotifyLoadStatusAvcodec),  // AudioCodec
 	ModuleLoadInfo(0x301, 0x00000000, "av_sascore"),
 	// The size varies a bit per version, from about 0x3C00 to 0x4500 bytes. We could make a lookup table...
-	ModuleLoadInfo(0x302, 0x00004000, "av_atrac3plus", atrac3PlusModuleDeps, &NotifyLoadStatusAtrac),
+	// Changing this breaks some bad cheats though..
+	ModuleLoadInfo(0x302, 0x00008000, "av_atrac3plus", atrac3PlusModuleDeps, &NotifyLoadStatusAtrac),
 	ModuleLoadInfo(0x303, 0x0000c000, "av_mpegbase", mpegBaseModuleDeps),
 	ModuleLoadInfo(0x304, 0x00004000, "av_mp3"),
 	ModuleLoadInfo(0x305, 0x0000a300, "av_vaudio"),


### PR DESCRIPTION
Forgot to write out the in/out byte sizes. Fixes Digimon Adventure music playback, see #20125

Also tries to add some error handling.