### PR TITLE
Screenshot performance improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2411,8 +2411,6 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/Screenshot.h
 	Core/System.cpp
 	Core/System.h
-	Core/ThreadPools.cpp
-	Core/ThreadPools.h
 	Core/Util/AtracTrack.cpp
 	Core/Util/AtracTrack.h
 	Core/Util/AudioFormat.cpp

--- a/Common/Thread/Promise.h
+++ b/Common/Thread/Promise.h
@@ -7,6 +7,22 @@
 #include "Common/Thread/Channel.h"
 #include "Common/Thread/ThreadManager.h"
 
+// Nobody needs to wait for this (except threadpool shutdown).
+template<class T>
+class IndependentTask : public Task {
+public:
+	IndependentTask(TaskType type, TaskPriority prio, T func) : func_(std::move(func)), type_(type), prio_(prio) {}
+	TaskType Type() const override { return type_; }
+	TaskPriority Priority() const override { return prio_; }
+	void Run() override {
+		func_();
+	}
+private:
+	T func_;
+	TaskType type_;
+	TaskPriority prio_;
+};
+
 template<class T>
 class PromiseTask : public Task {
 public:

--- a/Common/Thread/ThreadManager.cpp
+++ b/Common/Thread/ThreadManager.cpp
@@ -24,6 +24,8 @@ const int MAX_CORES_TO_USE = 16;
 const int MIN_IO_BLOCKING_THREADS = 4;
 static constexpr size_t TASK_PRIORITY_COUNT = (size_t)TaskPriority::COUNT;
 
+ThreadManager g_threadManager;
+
 struct GlobalThreadContext {
 	std::mutex mutex;
 	std::deque<Task *> compute_queue[TASK_PRIORITY_COUNT];

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -1084,7 +1084,6 @@
     <ClCompile Include="MIPS\MIPSStackWalk.cpp" />
     <ClCompile Include="Screenshot.cpp" />
     <ClCompile Include="System.cpp" />
-    <ClCompile Include="ThreadPools.cpp" />
     <ClCompile Include="TiltEventProcessor.cpp" />
     <ClCompile Include="Util\AtracTrack.cpp" />
     <ClCompile Include="Util\AudioFormat.cpp" />
@@ -1470,7 +1469,6 @@
     <ClInclude Include="Screenshot.h" />
     <ClInclude Include="System.h" />
     <ClInclude Include="ThreadEventQueue.h" />
-    <ClInclude Include="ThreadPools.h" />
     <ClInclude Include="TiltEventProcessor.h" />
     <ClInclude Include="Util\AtracTrack.h" />
     <ClInclude Include="Util\AudioFormat.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -952,9 +952,6 @@
     <ClCompile Include="KeyMap.cpp">
       <Filter>Core</Filter>
     </ClCompile>
-    <ClCompile Include="ThreadPools.cpp">
-      <Filter>Core</Filter>
-    </ClCompile>
     <ClCompile Include="Debugger\WebSocket\InputSubscriber.cpp">
       <Filter>Debugger\WebSocket</Filter>
     </ClCompile>
@@ -2032,9 +2029,6 @@
       <Filter>Ext\libzip</Filter>
     </ClInclude>
     <ClInclude Include="KeyMap.h">
-      <Filter>Core</Filter>
-    </ClInclude>
-    <ClInclude Include="ThreadPools.h">
       <Filter>Core</Filter>
     </ClInclude>
     <ClInclude Include="Debugger\WebSocket\InputSubscriber.h">

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -22,6 +22,7 @@
 #include <sstream>
 
 #include "Common/Thread/ParallelLoop.h"
+#include "Common/Thread/ThreadManager.h"
 #include "Core/CoreTiming.h"
 #include "Core/Debugger/MemBlockInfo.h"
 #include "Core/HLE/HLE.h"
@@ -30,7 +31,6 @@
 #include "Core/MemMapHelpers.h"
 #include "Core/Reporting.h"
 #include "Core/System.h"
-#include "Core/ThreadPools.h"
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"
 #include "Common/Serialize/SerializeMap.h"

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -483,7 +483,7 @@ void PSPModule::GetLongInfo(char *ptr, int bufSize) const {
 	StringWriter w(ptr, bufSize);
 	w.F("%s: Version %d.%d. %d segments", nm.name, nm.version[1], nm.version[0], nm.nsegment).endl();
 	w.F("Memory block: %08x (%08x/%d bytes)", memoryBlockAddr, memoryBlockSize, memoryBlockSize).endl();
-	for (int i = 0; i < nm.nsegment; i++) {
+	for (int i = 0; i < (int)nm.nsegment; i++) {
 		w.F("  %08x (%08x bytes)\n", nm.segmentaddr[i], nm.segmentsize[i]);
 	}
 	w.F("Text: %08x (%08x bytes)\n", nm.text_addr, nm.text_size);

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -1094,7 +1094,7 @@ double g_lastSaveTime = -1.0;
 			case SAVESTATE_SAVE_SCREENSHOT:
 			{
 				int maxResMultiplier = 2;
-				tempResult = TakeGameScreenshot(nullptr, op.filename, ScreenshotFormat::JPG, SCREENSHOT_DISPLAY, nullptr, nullptr, maxResMultiplier);
+				tempResult = TakeGameScreenshot(nullptr, op.filename, ScreenshotFormat::JPG, SCREENSHOT_DISPLAY, maxResMultiplier);
 				callbackResult = tempResult ? Status::SUCCESS : Status::FAILURE;
 				if (!tempResult) {
 					WARN_LOG(Log::SaveState, "Failed to take a screenshot for the savestate! (%s) The savestate will lack an icon.", op.filename.c_str());

--- a/Core/SaveState.cpp
+++ b/Core/SaveState.cpp
@@ -466,9 +466,9 @@ double g_lastSaveTime = -1.0;
 		Enqueue(Operation(SAVESTATE_REWIND, Path(), -1, callback, cbUserData));
 	}
 
-	void SaveScreenshot(const Path &filename, Callback callback, void *cbUserData) {
+	static void SaveScreenshot(const Path &filename) {
 		screenshotFailures = 0;
-		Enqueue(Operation(SAVESTATE_SAVE_SCREENSHOT, filename, -1, callback, cbUserData));
+		Enqueue(Operation(SAVESTATE_SAVE_SCREENSHOT, filename, -1, nullptr, nullptr));
 	}
 
 	bool CanRewind()
@@ -690,7 +690,7 @@ double g_lastSaveTime = -1.0;
 				DeleteIfExists(shotUndo);
 				RenameIfExists(shot, shotUndo);
 			}
-			SaveScreenshot(shot, Callback(), 0);
+			SaveScreenshot(shot);
 			Save(fn.WithExtraExtension(".tmp"), slot, renameCallback, cbUserData);
 		} else {
 			if (callback) {
@@ -1100,7 +1100,7 @@ double g_lastSaveTime = -1.0;
 					WARN_LOG(Log::SaveState, "Failed to take a screenshot for the savestate! (%s) The savestate will lack an icon.", op.filename.c_str());
 					if (coreState != CORE_STEPPING_CPU && screenshotFailures++ < SCREENSHOT_FAILURE_RETRIES) {
 						// Requeue for next frame (if we were stepping, no point, will just spam errors quickly).
-						SaveScreenshot(op.filename, op.callback, op.cbUserData);
+						SaveScreenshot(op.filename);
 					}
 				} else {
 					screenshotFailures = 0;

--- a/Core/Screenshot.cpp
+++ b/Core/Screenshot.cpp
@@ -328,9 +328,8 @@ static GPUDebugBuffer ApplyRotation(const GPUDebugBuffer &buf, DisplayRotation r
 	return rotated;
 }
 
-bool TakeGameScreenshot(Draw::DrawContext *draw, const Path &filename, ScreenshotFormat fmt, ScreenshotType type, int *width, int *height, int maxRes) {
+bool TakeGameScreenshot(Draw::DrawContext *draw, const Path &filename, ScreenshotFormat fmt, ScreenshotType type, int maxRes) {
 	GPUDebugBuffer buf;
-	bool success = false;
 	u32 w = (u32)-1;
 	u32 h = (u32)-1;
 
@@ -339,45 +338,34 @@ bool TakeGameScreenshot(Draw::DrawContext *draw, const Path &filename, Screensho
 			ERROR_LOG(Log::System, "Can't take screenshots when GPU not running");
 			return false;
 		}
-		success = gpuDebug->GetCurrentFramebuffer(buf, type == SCREENSHOT_RENDER ? GPU_DBG_FRAMEBUF_RENDER : GPU_DBG_FRAMEBUF_DISPLAY, maxRes);
+		if (!gpuDebug->GetCurrentFramebuffer(buf, type == SCREENSHOT_RENDER ? GPU_DBG_FRAMEBUF_RENDER : GPU_DBG_FRAMEBUF_DISPLAY, maxRes)) {
+			return false;
+		}
 		w = maxRes > 0 ? 480 * maxRes : PSP_CoreParameter().renderWidth;
 		h = maxRes > 0 ? 272 * maxRes : PSP_CoreParameter().renderHeight;
 	} else if (g_display.rotation != DisplayRotation::ROTATE_0) {
 		_dbg_assert_(draw);
 		GPUDebugBuffer temp;
-		success = ::GetOutputFramebuffer(draw, temp);
-		if (success) {
-			buf = ApplyRotation(temp, g_display.rotation);
+		if (!::GetOutputFramebuffer(draw, temp)) {
+			return false;
 		}
+		buf = ApplyRotation(temp, g_display.rotation);
 	} else {
 		_dbg_assert_(draw);
-		success = ::GetOutputFramebuffer(draw, buf);
+		if (!GetOutputFramebuffer(draw, buf)) {
+			return false;
+		}
 	}
 
-	if (!success) {
+	u8 *flipbuffer = nullptr;
+	const u8 *buffer = ConvertBufferToScreenshot(buf, false, flipbuffer, w, h);
+	if (!buffer) {
 		return false;
 	}
 
-	if (success) {
-		u8 *flipbuffer = nullptr;
-		const u8 *buffer = ConvertBufferToScreenshot(buf, false, flipbuffer, w, h);
-		success = buffer != nullptr;
-		if (success) {
-			if (width)
-				*width = w;
-			if (height)
-				*height = h;
-
-			success = Save888RGBScreenshot(filename, fmt, buffer, w, h);
-		}
-		delete[] flipbuffer;
-	}
-
-	if (!success) {
-		ERROR_LOG(Log::IO, "Failed to write screenshot.");
-	}
-
-	return success;
+	bool success = Save888RGBScreenshot(filename, fmt, buffer, w, h);
+	delete[] flipbuffer;
+	return true;
 }
 
 bool Save888RGBScreenshot(const Path &filename, ScreenshotFormat fmt, const u8 *bufferRGB888, int w, int h) {

--- a/Core/Screenshot.h
+++ b/Core/Screenshot.h
@@ -19,6 +19,8 @@
 
 #include "Common/File/Path.h"
 
+#include <functional>
+
 struct GPUDebugBuffer;
 namespace Draw {
 class DrawContext;
@@ -29,6 +31,8 @@ enum class ScreenshotFormat {
 	JPG,
 };
 
+// NOTE: The first two may need rotation, depending on the backend and screen orientation.
+// This is handled internally in TakeGameScreenshot().
 enum ScreenshotType {
 	// What's being show on screen (e.g. including FPS, etc.)
 	SCREENSHOT_OUTPUT,
@@ -38,10 +42,19 @@ enum ScreenshotType {
 	SCREENSHOT_RENDER,
 };
 
+enum class ScreenshotResult {
+	ScreenshotNotPossible,
+	DelayedResult,  // This specifies that the actual result is one of the two below and will arrive in the callback.
+	// These result can be delayed and arrive in the callback, if one is specified.
+	FailedToWriteFile,
+	Success,
+};
+
 const u8 *ConvertBufferToScreenshot(const GPUDebugBuffer &buf, bool alpha, u8 *&temp, u32 &w, u32 &h);
 
 // Can only be used while in game.
-bool TakeGameScreenshot(Draw::DrawContext *draw, const Path &filename, ScreenshotFormat fmt, ScreenshotType type, int maxRes = -1);
+// If the callback is passed in, the saving action happens on a background thread.
+ScreenshotResult TakeGameScreenshot(Draw::DrawContext *draw, const Path &filename, ScreenshotFormat fmt, ScreenshotType type, int maxRes = -1, std::function<void(bool success)> callback = nullptr);
 
 bool Save888RGBScreenshot(const Path &filename, ScreenshotFormat fmt, const u8 *bufferRGB888, int w, int h);
 bool Save8888RGBAScreenshot(const Path &filename, const u8 *bufferRGBA8888, int w, int h);

--- a/Core/Screenshot.h
+++ b/Core/Screenshot.h
@@ -41,7 +41,7 @@ enum ScreenshotType {
 const u8 *ConvertBufferToScreenshot(const GPUDebugBuffer &buf, bool alpha, u8 *&temp, u32 &w, u32 &h);
 
 // Can only be used while in game.
-bool TakeGameScreenshot(Draw::DrawContext *draw, const Path &filename, ScreenshotFormat fmt, ScreenshotType type, int *width = nullptr, int *height = nullptr, int maxRes = -1);
+bool TakeGameScreenshot(Draw::DrawContext *draw, const Path &filename, ScreenshotFormat fmt, ScreenshotType type, int maxRes = -1);
 
 bool Save888RGBScreenshot(const Path &filename, ScreenshotFormat fmt, const u8 *bufferRGB888, int w, int h);
 bool Save8888RGBAScreenshot(const Path &filename, const u8 *bufferRGBA8888, int w, int h);

--- a/Core/ThreadPools.cpp
+++ b/Core/ThreadPools.cpp
@@ -1,3 +1,0 @@
-#include "ThreadPools.h"
-
-ThreadManager g_threadManager;

--- a/Core/ThreadPools.h
+++ b/Core/ThreadPools.h
@@ -1,5 +1,0 @@
-#pragma once
-
-#include "Common/Thread/ThreadManager.h"
-
-extern ThreadManager g_threadManager;

--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -156,7 +156,7 @@ struct GPUDebugBuffer {
 	u32 GetRawPixel(int x, int y) const;
 	void SetRawPixel(int x, int y, u32 c);
 
-	u8 *GetDataWrite() {
+	u8 *GetData() {
 		return data_;
 	}
 

--- a/GPU/Common/GPUDebugInterface.h
+++ b/GPU/Common/GPUDebugInterface.h
@@ -153,12 +153,12 @@ struct GPUDebugBuffer {
 
 	void ZeroBytes();
 
-	u8 *GetData() {
-		return data_;
-	}
-
 	u32 GetRawPixel(int x, int y) const;
 	void SetRawPixel(int x, int y, u32 c);
+
+	u8 *GetDataWrite() {
+		return data_;
+	}
 
 	const u8 *GetData() const {
 		return data_;

--- a/GPU/Debugger/Record.cpp
+++ b/GPU/Debugger/Record.cpp
@@ -26,6 +26,7 @@
 
 #include "Common/CommonTypes.h"
 #include "Common/File/FileUtil.h"
+#include "Common/Thread/ThreadManager.h"
 #include "Common/Thread/ParallelLoop.h"
 #include "Common/Log.h"
 #include "Common/StringUtils.h"
@@ -36,7 +37,6 @@
 #include "Core/HLE/sceDisplay.h"
 #include "Core/MemMap.h"
 #include "Core/System.h"
-#include "Core/ThreadPools.h"
 #include "GPU/Common/GPUDebugInterface.h"
 #include "GPU/GPUCommon.h"
 #include "GPU/GPUState.h"

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -1384,7 +1384,7 @@ bool SoftGPU::GetCurrentFramebuffer(GPUDebugBuffer &buffer, GPUDebugFramebufferT
 	buffer.Allocate(size.x, size.y, fmt);
 
 	const int depth = fmt == GE_FORMAT_8888 ? 4 : 2;
-	u8 *dst = buffer.GetData();
+	u8 *dst = buffer.GetDataWrite();
 	const int byteWidth = size.x * depth;
 	for (int16_t y = 0; y < size.y; ++y) {
 		memcpy(dst, src, byteWidth);
@@ -1404,7 +1404,7 @@ bool SoftGPU::GetCurrentDepthbuffer(GPUDebugBuffer &buffer) {
 
 	const int depth = 2;
 	const u8 *src = depthbuf.data;
-	u8 *dst = buffer.GetData();
+	u8 *dst = buffer.GetDataWrite();
 	for (int16_t y = 0; y < size.y; ++y) {
 		memcpy(dst, src, size.x * depth);
 		dst += size.x * depth;
@@ -1430,7 +1430,7 @@ bool SoftGPU::GetCurrentStencilbuffer(GPUDebugBuffer &buffer) {
 	DrawingCoords size = GetTargetSize(gstate.FrameBufStride());
 	buffer.Allocate(size.x, size.y, GPU_DBG_FORMAT_8BIT);
 
-	u8 *row = buffer.GetData();
+	u8 *row = buffer.GetDataWrite();
 	for (int16_t y = 0; y < size.y; ++y) {
 		for (int16_t x = 0; x < size.x; ++x) {
 			row[x] = GetPixelStencil(gstate.FrameBufFormat(), gstate.FrameBufStride(), x, y);
@@ -1451,7 +1451,7 @@ bool SoftGPU::GetCurrentClut(GPUDebugBuffer &buffer)
 	const u32 pixels = 1024 / bpp;
 
 	buffer.Allocate(pixels, 1, (GEBufferFormat)gstate.getClutPaletteFormat());
-	memcpy(buffer.GetData(), clut, 1024);
+	memcpy(buffer.GetDataWrite(), clut, 1024);
 	return true;
 }
 

--- a/GPU/Software/SoftGpu.cpp
+++ b/GPU/Software/SoftGpu.cpp
@@ -1384,7 +1384,7 @@ bool SoftGPU::GetCurrentFramebuffer(GPUDebugBuffer &buffer, GPUDebugFramebufferT
 	buffer.Allocate(size.x, size.y, fmt);
 
 	const int depth = fmt == GE_FORMAT_8888 ? 4 : 2;
-	u8 *dst = buffer.GetDataWrite();
+	u8 *dst = buffer.GetData();
 	const int byteWidth = size.x * depth;
 	for (int16_t y = 0; y < size.y; ++y) {
 		memcpy(dst, src, byteWidth);
@@ -1404,7 +1404,7 @@ bool SoftGPU::GetCurrentDepthbuffer(GPUDebugBuffer &buffer) {
 
 	const int depth = 2;
 	const u8 *src = depthbuf.data;
-	u8 *dst = buffer.GetDataWrite();
+	u8 *dst = buffer.GetData();
 	for (int16_t y = 0; y < size.y; ++y) {
 		memcpy(dst, src, size.x * depth);
 		dst += size.x * depth;
@@ -1430,7 +1430,7 @@ bool SoftGPU::GetCurrentStencilbuffer(GPUDebugBuffer &buffer) {
 	DrawingCoords size = GetTargetSize(gstate.FrameBufStride());
 	buffer.Allocate(size.x, size.y, GPU_DBG_FORMAT_8BIT);
 
-	u8 *row = buffer.GetDataWrite();
+	u8 *row = buffer.GetData();
 	for (int16_t y = 0; y < size.y; ++y) {
 		for (int16_t x = 0; x < size.x; ++x) {
 			row[x] = GetPixelStencil(gstate.FrameBufFormat(), gstate.FrameBufStride(), x, y);
@@ -1445,13 +1445,12 @@ bool SoftGPU::GetCurrentTexture(GPUDebugBuffer &buffer, int level, bool *isFrame
 	return Rasterizer::GetCurrentTexture(buffer, level);
 }
 
-bool SoftGPU::GetCurrentClut(GPUDebugBuffer &buffer)
-{
+bool SoftGPU::GetCurrentClut(GPUDebugBuffer &buffer) {
 	const u32 bpp = gstate.getClutPaletteFormat() == GE_CMODE_32BIT_ABGR8888 ? 4 : 2;
 	const u32 pixels = 1024 / bpp;
 
 	buffer.Allocate(pixels, 1, (GEBufferFormat)gstate.getClutPaletteFormat());
-	memcpy(buffer.GetDataWrite(), clut, 1024);
+	memcpy(buffer.GetData(), clut, 1024);
 	return true;
 }
 

--- a/UI/NativeApp.cpp
+++ b/UI/NativeApp.cpp
@@ -84,6 +84,7 @@
 #include "Common/OSVersion.h"
 #include "Common/GPU/ShaderTranslation.h"
 #include "Common/VR/PPSSPPVR.h"
+#include "Common/Thread/ThreadManager.h"
 
 #include "Core/ControlMapper.h"
 #include "Core/Config.h"
@@ -109,7 +110,6 @@
 #include "Core/Util/AudioFormat.h"
 #include "Core/WebServer.h"
 #include "Core/TiltEventProcessor.h"
-#include "Core/ThreadPools.h"
 
 #include "GPU/GPUCommon.h"
 #include "GPU/Common/PresentationCommon.h"

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -182,21 +182,22 @@ ScreenRenderFlags ReportScreen::render(ScreenRenderMode mode) {
 				File::CreateDir(path);
 			}
 			screenshotFilename_ = path / ".reporting.jpg";
-			if (TakeGameScreenshot(screenManager()->getDrawContext(), screenshotFilename_, ScreenshotFormat::JPG, SCREENSHOT_DISPLAY, 4)) {
-				// Redo the views already, now with a screenshot included.
-				RecreateViews();
-			} else {
-				// Good news (?), the views are good as-is without a screenshot.
-				screenshotFilename_.clear();
-			}
+			ScreenshotResult ignored = TakeGameScreenshot(screenManager()->getDrawContext(), screenshotFilename_, ScreenshotFormat::JPG, SCREENSHOT_RENDER, 4, [this](bool success) {
+				if (success) {
+					// Redo the views already, now with a screenshot included.
+					RecreateViews();
+				} else {
+					// Good news (?), the views are good as-is without a screenshot.
+					screenshotFilename_.clear();
+				}
+			});
 			tookScreenshot_ = true;
 		}
 	}
 
 	// We take the screenshot first, then we start rendering.
 	// We are the only screen visible so this avoid starting and then trying to resume a backbuffer render pass.
-	ScreenRenderFlags flags = UIScreen::render(mode);
-
+	const ScreenRenderFlags flags = UIScreen::render(mode);
 	return flags;
 }
 

--- a/UI/ReportScreen.cpp
+++ b/UI/ReportScreen.cpp
@@ -182,7 +182,7 @@ ScreenRenderFlags ReportScreen::render(ScreenRenderMode mode) {
 				File::CreateDir(path);
 			}
 			screenshotFilename_ = path / ".reporting.jpg";
-			if (TakeGameScreenshot(screenManager()->getDrawContext(), screenshotFilename_, ScreenshotFormat::JPG, SCREENSHOT_DISPLAY, nullptr, nullptr, 4)) {
+			if (TakeGameScreenshot(screenManager()->getDrawContext(), screenshotFilename_, ScreenshotFormat::JPG, SCREENSHOT_DISPLAY, 4)) {
 				// Redo the views already, now with a screenshot included.
 				RecreateViews();
 			} else {

--- a/UWP/CoreUWP/CoreUWP.vcxproj
+++ b/UWP/CoreUWP/CoreUWP.vcxproj
@@ -331,7 +331,6 @@
     <ClInclude Include="..\..\Core\Screenshot.h" />
     <ClInclude Include="..\..\Core\System.h" />
     <ClInclude Include="..\..\Core\ThreadEventQueue.h" />
-    <ClInclude Include="..\..\Core\ThreadPools.h" />
     <ClInclude Include="..\..\Core\TiltEventProcessor.h" />
     <ClInclude Include="..\..\Core\Util\AtracTrack.h" />
     <ClInclude Include="..\..\Core\Util\GameDB.h" />
@@ -631,7 +630,6 @@
     <ClCompile Include="..\..\Core\SaveState.cpp" />
     <ClCompile Include="..\..\Core\Screenshot.cpp" />
     <ClCompile Include="..\..\Core\System.cpp" />
-    <ClCompile Include="..\..\Core\ThreadPools.cpp" />
     <ClCompile Include="..\..\Core\TiltEventProcessor.cpp" />
     <ClCompile Include="..\..\Core\Util\AtracTrack.cpp" />
     <ClCompile Include="..\..\Core\Util\GameDB.cpp" />

--- a/UWP/CoreUWP/CoreUWP.vcxproj.filters
+++ b/UWP/CoreUWP/CoreUWP.vcxproj.filters
@@ -1191,7 +1191,6 @@
       <Filter>Ext\libzip</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Core\KeyMap.cpp" />
-    <ClCompile Include="..\..\Core\ThreadPools.cpp" />
     <ClCompile Include="..\..\Core\ControlMapper.cpp" />
     <ClCompile Include="..\..\Core\KeyMapDefaults.cpp" />
     <ClCompile Include="..\..\Core\HLE\sceNp2.cpp">
@@ -1912,7 +1911,6 @@
       <Filter>Ext\jpge</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Core\KeyMap.h" />
-    <ClInclude Include="..\..\Core\ThreadPools.h" />
     <ClInclude Include="..\..\Core\ControlMapper.h" />
     <ClInclude Include="..\..\Core\KeyMapDefaults.h" />
     <ClInclude Include="..\..\Core\HLE\sceNp2.h">

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -619,7 +619,6 @@ EXEC_AND_LIB_FILES := \
   $(SRC)/Core/Screenshot.cpp \
   $(SRC)/Core/System.cpp \
   $(SRC)/Core/TiltEventProcessor.cpp \
-  $(SRC)/Core/ThreadPools.cpp \
   $(SRC)/Core/WebServer.cpp \
   $(SRC)/Core/Debugger/Breakpoints.cpp \
   $(SRC)/Core/Debugger/DisassemblyManager.cpp \

--- a/libretro/Makefile.common
+++ b/libretro/Makefile.common
@@ -825,7 +825,6 @@ SOURCES_CXX += \
 	       $(COREDIR)/SaveState.cpp \
 	       $(COREDIR)/Screenshot.cpp \
 	       $(COREDIR)/System.cpp \
-	       $(COREDIR)/ThreadPools.cpp \
 	       $(COREDIR)/Util/AtracTrack.cpp \
 	       $(COREDIR)/Util/BlockAllocator.cpp \
 	       $(COREDIR)/Util/MemStick.cpp \


### PR DESCRIPTION
Two changes:

* Now runs PNG/JPG encoding on separate threads in the background
* If there are many files, on slow file systems (like Android scoped storage) the way we checked for a free filename was atrociously slow. Switched to just getting the full file listing, which is pretty quick, and then scanning that.

Hopefully fixes #20134  . At least, for me, it seems really fast now.