### PR TITLE
Use the new sceAtrac implementation by default

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -792,7 +792,7 @@ static const ConfigSetting soundSettings[] = {
 	ConfigSetting("AutoAudioDevice", &g_Config.bAutoAudioDevice, true, CfgFlag::DEFAULT),
 	ConfigSetting("AudioMixWithOthers", &g_Config.bAudioMixWithOthers, true, CfgFlag::DEFAULT),
 	ConfigSetting("AudioRespectSilentMode", &g_Config.bAudioRespectSilentMode, false, CfgFlag::DEFAULT),
-	ConfigSetting("UseExperimentalAtrac", &g_Config.bUseExperimentalAtrac, false, CfgFlag::DEFAULT),
+	ConfigSetting("UseOldAtrac", &g_Config.bUseOldAtrac, false, CfgFlag::DEFAULT),
 };
 
 static bool DefaultShowTouchControls() {

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -298,7 +298,7 @@ public:
 	bool bExtraAudioBuffering;  // For bluetooth
 	std::string sAudioDevice;
 	bool bAutoAudioDevice;
-	bool bUseExperimentalAtrac;
+	bool bUseOldAtrac;
 
 	// iOS only for now
 	bool bAudioMixWithOthers;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -216,7 +216,7 @@ static AtracBase *getAtrac(int atracID) {
 static int AllocAndRegisterAtrac(int codecType) {
 	for (int i = 0; i < g_atracMaxContexts; ++i) {
 		if (atracContextTypes[i] == codecType && atracContexts[i] == 0) {
-			if (g_Config.bUseExperimentalAtrac && g_atracBSS != 0) {
+			if (!g_Config.bUseOldAtrac && g_atracBSS != 0) {
 				atracContexts[i] = new Atrac2(GetAtracContextAddress(i), codecType);
 			} else {
 				atracContexts[i] = new Atrac(i, codecType);

--- a/Tools/langtool/Cargo.lock
+++ b/Tools/langtool/Cargo.lock
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "proc-macro2"
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -149,9 +149,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.99"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "utf8parse"

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -416,10 +416,6 @@ void EmuScreen::bootComplete() {
 	}
 #endif
 
-	if (g_Config.bUseExperimentalAtrac) {
-		g_OSD.Show(OSDType::MESSAGE_WARNING, dev->T("Use experimental sceAtrac"));
-	}
-
 #if !PPSSPP_PLATFORM(UWP)
 	if (GetGPUBackend() == GPUBackend::OPENGL) {
 		const char *renderer = gl_extensions.model;

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1902,7 +1902,7 @@ void DeveloperToolsScreen::CreateViews() {
 	cpuTests->SetEnabled(TestsAvailable());
 #endif
 
-	list->Add(new CheckBox(&g_Config.bUseExperimentalAtrac, dev->T("Use experimental sceAtrac")));
+	list->Add(new CheckBox(&g_Config.bUseOldAtrac, dev->T("Use the old sceAtrac implementation")));
 
 	AddOverlayList(list, screenManager());
 

--- a/UI/TabbedDialogScreen.cpp
+++ b/UI/TabbedDialogScreen.cpp
@@ -54,6 +54,7 @@ void TabbedUIDialogScreenWithGameBackground::CreateViews() {
 		tabHolder_->AddBack(this);
 		root_->Add(tabHolder_);
 	}
+
 	tabHolder_->SetTag(tag());  // take the tag from the screen.
 	root_->SetDefaultFocusView(tabHolder_);
 	settingTabContents_.clear();

--- a/assets/lang/ar_AE.ini
+++ b/assets/lang/ar_AE.ini
@@ -363,7 +363,7 @@ Control Debug = تصحيح التحكم
 Toggle Freeze = ‎تفعيل الإيقاف
 Touchscreen Test = إختبار لمس الشاشة
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/az_AZ.ini
+++ b/assets/lang/az_AZ.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Toggle freeze
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/bg_BG.ini
+++ b/assets/lang/bg_BG.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Toggle freeze
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/ca_ES.ini
+++ b/assets/lang/ca_ES.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Commuta la imatge
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/cz_CZ.ini
+++ b/assets/lang/cz_CZ.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Přepnout zamrznutí
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/da_DK.ini
+++ b/assets/lang/da_DK.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Skift freeze
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/de_DE.ini
+++ b/assets/lang/de_DE.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Bild einfrieren an/aus
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/dr_ID.ini
+++ b/assets/lang/dr_ID.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Toggle freeze
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/en_US.ini
+++ b/assets/lang/en_US.ini
@@ -379,7 +379,7 @@ Texture Replacement = Texture replacement
 Toggle Freeze = Toggle freeze
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/es_ES.ini
+++ b/assets/lang/es_ES.ini
@@ -356,7 +356,7 @@ Texture Replacement = Texturas de repuesto
 Toggle Freeze = Parar/Reanudar imagen
 Touchscreen Test = Test de pantalla táctil
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Usar sceAtrac experimental
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/es_LA.ini
+++ b/assets/lang/es_LA.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Parar/Reanudar imagen
 Touchscreen Test = Probar pantalla táctil
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/fa_IR.ini
+++ b/assets/lang/fa_IR.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Toggle freeze
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/fi_FI.ini
+++ b/assets/lang/fi_FI.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Toggle freeze
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/fr_FR.ini
+++ b/assets/lang/fr_FR.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Geler/Dégeler l'image
 Touchscreen Test = Test de l'écran tactile
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/gl_ES.ini
+++ b/assets/lang/gl_ES.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Parar/Reanudar imaxe
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/gr_EL.ini
+++ b/assets/lang/gr_EL.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Πάγωμα Εναλαγής
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/he_IL.ini
+++ b/assets/lang/he_IL.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Toggle freeze
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/he_IL_invert.ini
+++ b/assets/lang/he_IL_invert.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Toggle freeze
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/hr_HR.ini
+++ b/assets/lang/hr_HR.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Uključi zamrzavanje
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/hu_HU.ini
+++ b/assets/lang/hu_HU.ini
@@ -355,7 +355,7 @@ Control Debug = Irányítás hibakeresés
 Toggle Freeze = Fagyasztás ki/bekapcsolása
 Touchscreen Test = Érintőképernyő teszt
 Ubershaders = Ubershaderek
-Use experimental sceAtrac = Kísérleti sceAtrac használata
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/id_ID.ini
+++ b/assets/lang/id_ID.ini
@@ -355,7 +355,7 @@ Control Debug = Kontrol Awakutu
 Toggle Freeze = Alihkan pembekuan
 Touchscreen Test = Tes layar sentuh
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Gunakan sceAtrac eksperimental
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/it_IT.ini
+++ b/assets/lang/it_IT.ini
@@ -355,7 +355,7 @@ Control Debug = Debug Controlli
 Toggle Freeze = Attiva/Disattiva Congelamento
 Touchscreen Test = Test del Touchscreen
 Ubershaders = Ubershader
-Use experimental sceAtrac = Usa sceAtrac sperimentale
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/ja_JP.ini
+++ b/assets/lang/ja_JP.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = フリーズを切り替える
 Touchscreen Test = タッチスクリーンのテスト
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = 頂点
 VFPU = VFPU
 

--- a/assets/lang/jv_ID.ini
+++ b/assets/lang/jv_ID.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Pilian Beku
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/ko_KR.ini
+++ b/assets/lang/ko_KR.ini
@@ -355,7 +355,7 @@ Texture Replacement = 텍스쳐 교체
 Toggle Freeze = 프리징 토글
 Touchscreen Test = 터치화면 테스트
 Ubershaders = 우버셰이더
-Use experimental sceAtrac = 실험적인 sceAtrac 사용
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = 꼭짓점
 VFPU = VFPU
 

--- a/assets/lang/ku_SO.ini
+++ b/assets/lang/ku_SO.ini
@@ -369,7 +369,7 @@ Texture Replacement = Texture replacement
 Toggle Freeze = Toggle freeze
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/lo_LA.ini
+++ b/assets/lang/lo_LA.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = ປຸ່ມແຊ່ແຂງ
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/lt-LT.ini
+++ b/assets/lang/lt-LT.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Toggle freeze
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/ms_MY.ini
+++ b/assets/lang/ms_MY.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Toggle freeze
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/nl_NL.ini
+++ b/assets/lang/nl_NL.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Bevriezen in-/uitschakelen
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/no_NO.ini
+++ b/assets/lang/no_NO.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Toggle freeze
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/pl_PL.ini
+++ b/assets/lang/pl_PL.ini
@@ -355,7 +355,7 @@ Control Debug = Debugowanie sterowania
 Toggle Freeze = Wł./Wył. zamrożenie
 Touchscreen Test = Test ekranu dotykowego
 Ubershaders = Ubershadery
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/pt_BR.ini
+++ b/assets/lang/pt_BR.ini
@@ -379,7 +379,7 @@ Texture Replacement = Substituição das texturas
 Toggle Freeze = Alternar congelamento
 Touchscreen Test = Teste do Touchscreen
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Usar sceAtrac experimental
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vértice
 VFPU = VFPU
 

--- a/assets/lang/pt_PT.ini
+++ b/assets/lang/pt_PT.ini
@@ -379,7 +379,7 @@ Control Debug = Debugging dos controlos
 Toggle Freeze = Alternar congelamento
 Touchscreen Test = Teste do ecrã
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vértice
 VFPU = VFPU
 

--- a/assets/lang/ro_RO.ini
+++ b/assets/lang/ro_RO.ini
@@ -356,7 +356,7 @@ Control Debug = Control Debug
 Toggle Freeze = Toggle freeze
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/ru_RU.ini
+++ b/assets/lang/ru_RU.ini
@@ -355,7 +355,7 @@ Control Debug = Отладка управления
 Toggle Freeze = Запустить/остановить
 Touchscreen Test = Тест сенсорного экрана
 Ubershaders = Убершейдеры
-Use experimental sceAtrac = Использовать экспериментальный sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Вершина
 VFPU = VFPU
 

--- a/assets/lang/sv_SE.ini
+++ b/assets/lang/sv_SE.ini
@@ -355,7 +355,7 @@ Control Debug = Kontrollerfelsökning
 Toggle Freeze = Växla frysning
 Touchscreen Test = Touchskärm-test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Använd experimentell sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/tg_PH.ini
+++ b/assets/lang/tg_PH.ini
@@ -356,7 +356,7 @@ Control Debug = Control Debug
 Toggle Freeze = I-Toggle freeze
 Touchscreen Test = I-test and touchscreen
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/th_TH.ini
+++ b/assets/lang/th_TH.ini
@@ -365,7 +365,7 @@ Control Debug = แก้ไขจุดบกพร่องการควบ�
 Toggle Freeze = ปุ่มแช่แข็ง
 Touchscreen Test = ทดสอบหน้าจอสัมผัส
 Ubershaders = อูเบอร์เฉดเดอร์
-Use experimental sceAtrac = ใช้การถอดรหัสเสียง sceAtrac (ขั้นทดสอบ)
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = เวอร์เท็ค
 VFPU = VFPU
 

--- a/assets/lang/tr_TR.ini
+++ b/assets/lang/tr_TR.ini
@@ -357,7 +357,7 @@ Control Debug = Hata ayıklamayı kontrol et
 Toggle Freeze = Donmayı Aç/Kapa
 Touchscreen Test = Dokunmatik ekran testi
 Ubershaders = Ubershader'lar
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/uk_UA.ini
+++ b/assets/lang/uk_UA.ini
@@ -355,7 +355,7 @@ Control Debug = Контроль налагодження
 Toggle Freeze = Запустити/Зупинити
 Touchscreen Test = Тест сенсорного екрану
 Ubershaders = Юбер-шейдери
-Use experimental sceAtrac = Використовувати експериментальний sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Вертех
 VFPU = VFPU
 

--- a/assets/lang/vi_VN.ini
+++ b/assets/lang/vi_VN.ini
@@ -355,7 +355,7 @@ Control Debug = Control Debug
 Toggle Freeze = Chuyển qua chế độ đóng băng
 Touchscreen Test = Touchscreen test
 Ubershaders = Ubershaders
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = Vertex
 VFPU = VFPU
 

--- a/assets/lang/zh_CN.ini
+++ b/assets/lang/zh_CN.ini
@@ -355,7 +355,7 @@ Control Debug = 切换操纵调试
 Toggle Freeze = 切换冻结
 Touchscreen Test = 触屏测试
 Ubershaders = 超着色器 (消耗少量性能，并减少卡顿)
-Use experimental sceAtrac = 使用实验性 sceAtrac 解码器
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = 顶点着色器
 VFPU = VFPU
 

--- a/assets/lang/zh_TW.ini
+++ b/assets/lang/zh_TW.ini
@@ -355,7 +355,7 @@ Control Debug = 控制偵錯
 Toggle Freeze = 切換凍結開關
 Touchscreen Test = 觸控式螢幕測試
 Ubershaders = 超級著色器
-Use experimental sceAtrac = Use experimental sceAtrac
+Use the old sceAtrac implementation = Use the old sceAtrac implementation
 Vertex = 頂點
 VFPU = VFPU
 

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -351,7 +351,7 @@ int main(int argc, const char* argv[])
 	GPUCore gpuCore = GPUCORE_SOFTWARE;
 	CPUCore cpuCore = CPUCore::JIT;
 	int debuggerPort = -1;
-	bool newAtrac = false;
+	bool oldAtrac = false;
 	bool outputDebugStringLog = false;
 
 	std::vector<std::string> testFilenames;
@@ -392,8 +392,8 @@ int main(int argc, const char* argv[])
 			testOptions.bench = true;
 		else if (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--verbose"))
 			testOptions.verbose = true;
-		else if (!strcmp(argv[i], "--new-atrac"))
-			newAtrac = true;
+		else if (!strcmp(argv[i], "--old-atrac"))
+			oldAtrac = true;
 		else if (!strncmp(argv[i], "--graphics=", strlen("--graphics=")) && strlen(argv[i]) > strlen("--graphics="))
 		{
 			const char *gpuName = argv[i] + strlen("--graphics=");
@@ -533,7 +533,7 @@ int main(int argc, const char* argv[])
 	g_Config.iGameVolume = VOLUMEHI_FULL;
 	g_Config.iReverbVolume = VOLUMEHI_FULL;
 	g_Config.internalDataDirectory.clear();
-	g_Config.bUseExperimentalAtrac = newAtrac;
+	g_Config.bUseOldAtrac = oldAtrac;
 
 	Path exePath = File::GetExeDirectory();
 	g_Config.flash0Directory = exePath / "assets/flash0";

--- a/test.py
+++ b/test.py
@@ -553,7 +553,7 @@ def run_tests(test_list, args):
 
   if len(test_filenames):
     # TODO: Maybe --compare should detect --graphics?
-    cmdline = [PPSSPP_EXE, '--root', TEST_ROOT + '../', '--compare', '--new-atrac', '--timeout=' + str(TIMEOUT), '@-']
+    cmdline = [PPSSPP_EXE, '--root', TEST_ROOT + '../', '--compare', '--timeout=' + str(TIMEOUT), '@-']
     cmdline.extend([i for i in args if i not in ['-g', '-m', '-b']])
 
     c = Command(cmdline, '\n'.join(test_filenames))


### PR DESCRIPTION
Inverts/renames the setting to allow going back to the old sceAtrac implementation, to work around any compatibility issue.

Note that we can never delete the old implementation, old savestates will still use it - can't convert an existing session.

Let's get this in (soon) to encourage more testing. We can always go back before 1.19 if there are serious issues, but so far things look good.

Testing progress here: #20125 - staying as draft until major issues are fixed.