### PR TITLE
PPGe/savedata: Add a bunch of safety checks for png images. 

### DIFF
--- a/Core/Dialog/SavedataParam.cpp
+++ b/Core/Dialog/SavedataParam.cpp
@@ -1720,11 +1720,13 @@ void SavedataParam::ClearFileInfo(SaveFileInfo &saveInfo, const std::string &sav
 	}
 
 	if (GetPspParam()->newData.IsValid() && GetPspParam()->newData->buf.IsValid()) {
-		// We have a png to show
+		// We may have a png to show
 		if (!noSaveIcon) {
 			noSaveIcon = new SaveFileInfo();
 			PspUtilitySavedataFileData *newData = GetPspParam()->newData;
-			noSaveIcon->texture = new PPGeImage(newData->buf.ptr, (SceSize)newData->size);
+			if (Memory::IsValidRange(newData->buf.ptr, newData->size)) {
+				noSaveIcon->texture = new PPGeImage(newData->buf.ptr, (SceSize)newData->size);
+			}
 		}
 		saveInfo.texture = noSaveIcon->texture;
 	} else if ((u32)GetPspParam()->mode == SCE_UTILITY_SAVEDATA_TYPE_SAVE && GetPspParam()->icon0FileData.buf.IsValid()) {

--- a/Core/Util/PPGeDraw.h
+++ b/Core/Util/PPGeDraw.h
@@ -146,14 +146,14 @@ private:
 	std::string filename_;
 
 	// Only valid if filename_.empty().
-	u32 png_;
-	size_t size_;
+	u32 png_ = 0;
+	size_t size_ = 0;
 
 	u32 texture_ = 0;
-	int width_;
-	int height_;
+	int width_ = 0;
+	int height_ = 0;
 
-	int lastFrame_;
+	int lastFrame_ = 0;
 	bool loadFailed_ = false;
 };
 


### PR DESCRIPTION
Fixes Digimon save crash, see #20125.