### PR TITLE
Fix crash when saving screenshots on a thread

### DIFF
--- a/Common/Thread/ThreadManager.cpp
+++ b/Common/Thread/ThreadManager.cpp
@@ -139,6 +139,7 @@ static void WorkerThreadFunc(GlobalThreadContext *global, TaskThreadContext *thr
 	}
 	SetCurrentThreadName(thread->name);
 
+	// Should we do this on all threads?
 	if (thread->type == TaskType::IO_BLOCKING) {
 		AttachThreadToJNI();
 	}

--- a/Common/Thread/ThreadManager.h
+++ b/Common/Thread/ThreadManager.h
@@ -7,7 +7,7 @@
 // To help smart scheduling.
 enum class TaskType {
 	CPU_COMPUTE,
-	IO_BLOCKING,
+	IO_BLOCKING,  // NOTE: Only these can access scoped storage on Android (they initialize the JNI context).
 	DEDICATED_THREAD,  // These can never get stuck in queue behind others, but are more expensive to launch. Cannot use I/O.
 };
 

--- a/Core/Screenshot.cpp
+++ b/Core/Screenshot.cpp
@@ -361,7 +361,7 @@ ScreenshotResult TakeGameScreenshot(Draw::DrawContext *draw, const Path &filenam
 	}
 
 	if (callback) {
-		g_threadManager.EnqueueTask(new IndependentTask(TaskType::CPU_COMPUTE, TaskPriority::LOW,
+		g_threadManager.EnqueueTask(new IndependentTask(TaskType::IO_BLOCKING, TaskPriority::LOW,
 			[buf = std::move(buf), callback = std::move(callback), filename, fmt, w, h]() {
 			u8 *flipbuffer = nullptr;
 			u32 width = w, height = h;


### PR DESCRIPTION
Forgot that we only enable android JNI on "I/O" threads.

Fixes #20139