### PR TITLE
Startup code cleanup

### DIFF
--- a/Core/CoreParameter.h
+++ b/Core/CoreParameter.h
@@ -75,7 +75,7 @@ struct CoreParameter {
 	int pixelWidth;
 	int pixelHeight;
 
-	// Can be modified at runtime.
+	// Can be modified at runtime. Do not belong here.
 	bool fastForward = false;
 	FPSLimit fpsLimit = FPSLimit::NORMAL;
 	int analogFpsLimit = 0;

--- a/Core/ELF/ParamSFO.h
+++ b/Core/ELF/ParamSFO.h
@@ -59,6 +59,7 @@ public:
 	// If not found, returns a negative value.
 	int GetDataOffset(const u8 *paramsfo, const char *dataName);
 
+	bool IsValid() const { return !values.empty(); }
 	void Clear();
 
 private:

--- a/Core/FileSystems/MetaFileSystem.h
+++ b/Core/FileSystems/MetaFileSystem.h
@@ -58,9 +58,8 @@ public:
 		Reset();
 	}
 
+	// Will replace the existing mount if already exists.
 	void Mount(const std::string &prefix, std::shared_ptr<IFileSystem> system);
-	// Fails if there's not already a file system at prefix.
-	bool Remount(const std::string &prefix, std::shared_ptr<IFileSystem> system);
 
 	void UnmountAll();
 	void Unmount(const std::string &prefix);

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -261,7 +261,9 @@ bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string) {
 				IdentifiedFileType ebootType = Identify_File(fileLoader, error_string);
 				if (ebootType == IdentifiedFileType::PSP_ISO_NP) {
 					MountGameISO(fileLoader);
-					InitMemoryForGameISO(fileLoader);
+					if (LoadParamSFOFromDisc()) {
+						InitMemorySizeForGame();
+					}
 					pspFileSystem.SetStartingDirectory("disc0:/PSP_GAME/USRDIR");
 					return Load_PSP_ISO(fileLoader, error_string);
 				}

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -249,9 +249,8 @@ Path ResolvePBPFile(const Path &filename) {
 	}
 }
 
-bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string) {
+bool LoadFile(FileLoader **fileLoaderPtr, IdentifiedFileType type, std::string *error_string) {
 	FileLoader *&fileLoader = *fileLoaderPtr;
-	IdentifiedFileType type = Identify_File(fileLoader, error_string);
 	switch (type) {
 	case IdentifiedFileType::PSP_PBP_DIRECTORY:
 		{

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -260,6 +260,7 @@ bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string) {
 				INFO_LOG(Log::Loader, "File is a PBP in a directory: %s", fileLoader->GetPath().c_str());
 				IdentifiedFileType ebootType = Identify_File(fileLoader, error_string);
 				if (ebootType == IdentifiedFileType::PSP_ISO_NP) {
+					MountGameISO(fileLoader);
 					InitMemoryForGameISO(fileLoader);
 					pspFileSystem.SetStartingDirectory("disc0:/PSP_GAME/USRDIR");
 					return Load_PSP_ISO(fileLoader, error_string);
@@ -386,8 +387,8 @@ bool UmdReplace(const Path &filepath, FileLoader **fileLoader, std::string &erro
 
 	FileLoader *loadedFile = ConstructFileLoader(filepath);
 
-	if (!loadedFile->Exists()) {
-		error = loadedFile->GetPath().ToVisualString() + " doesn't exist";
+	if (!loadedFile || !loadedFile->Exists()) {
+		error = loadedFile ? (loadedFile->GetPath().ToVisualString() + " doesn't exist") : "no loaded file";
 		delete loadedFile;
 		return false;
 	}
@@ -404,8 +405,8 @@ bool UmdReplace(const Path &filepath, FileLoader **fileLoader, std::string &erro
 	case IdentifiedFileType::PSP_ISO:
 	case IdentifiedFileType::PSP_ISO_NP:
 	case IdentifiedFileType::PSP_DISC_DIRECTORY:
-		if (!ReInitMemoryForGameISO(loadedFile)) {
-			error = "reinit memory failed";
+		if (!MountGameISO(loadedFile)) {
+			error = "mounting the new ISO failed";
 			return false;
 		}
 		break;

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -148,6 +148,6 @@ Path ResolvePBPFile(const Path &filename);
 IdentifiedFileType Identify_File(FileLoader *fileLoader, std::string *errorString);
 
 // Can modify the string filename, as it calls IdentifyFile above.
-bool LoadFile(FileLoader **fileLoaderPtr, std::string *error_string);
+bool LoadFile(FileLoader **fileLoaderPtr, IdentifiedFileType type, std::string *error_string);
 
 bool UmdReplace(const Path &filepath, FileLoader **fileLoader, std::string &error);

--- a/Core/PSPLoaders.h
+++ b/Core/PSPLoaders.h
@@ -24,7 +24,10 @@ class FileLoader;
 bool Load_PSP_ISO(FileLoader *fileLoader, std::string *error_string);
 bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string);
 bool Load_PSP_GE_Dump(FileLoader *fileLoader, std::string *error_string);
-void InitMemoryForGameISO(FileLoader *fileLoader);
+
 bool MountGameISO(FileLoader *fileLoader);
-void InitMemoryForGamePBP(FileLoader *fileLoader);
+bool LoadParamSFOFromDisc();
+bool LoadParamSFOFromPBP(FileLoader *fileLoader);
+void InitMemorySizeForGame();
+
 void PSPLoaders_Shutdown();

--- a/Core/PSPLoaders.h
+++ b/Core/PSPLoaders.h
@@ -25,6 +25,6 @@ bool Load_PSP_ISO(FileLoader *fileLoader, std::string *error_string);
 bool Load_PSP_ELF_PBP(FileLoader *fileLoader, std::string *error_string);
 bool Load_PSP_GE_Dump(FileLoader *fileLoader, std::string *error_string);
 void InitMemoryForGameISO(FileLoader *fileLoader);
-bool ReInitMemoryForGameISO(FileLoader *fileLoader);
+bool MountGameISO(FileLoader *fileLoader);
 void InitMemoryForGamePBP(FileLoader *fileLoader);
 void PSPLoaders_Shutdown();

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -243,6 +243,7 @@ bool CPU_Init(std::string *errorString, FileLoader *loadedFile, IdentifiedFileTy
 	case IdentifiedFileType::PSP_ISO:
 	case IdentifiedFileType::PSP_ISO_NP:
 	case IdentifiedFileType::PSP_DISC_DIRECTORY:
+		MountGameISO(loadedFile);
 		InitMemoryForGameISO(loadedFile);
 		break;
 	case IdentifiedFileType::PSP_PBP:

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -244,13 +244,17 @@ bool CPU_Init(std::string *errorString, FileLoader *loadedFile, IdentifiedFileTy
 	case IdentifiedFileType::PSP_ISO_NP:
 	case IdentifiedFileType::PSP_DISC_DIRECTORY:
 		MountGameISO(loadedFile);
-		InitMemoryForGameISO(loadedFile);
+		if (LoadParamSFOFromDisc()) {
+			InitMemorySizeForGame();
+		}
 		break;
 	case IdentifiedFileType::PSP_PBP:
 	case IdentifiedFileType::PSP_PBP_DIRECTORY:
 		// This is normal for homebrew.
 		// ERROR_LOG(Log::Loader, "PBP directory resolution failed.");
-		InitMemoryForGamePBP(loadedFile);
+		if (LoadParamSFOFromPBP(loadedFile)) {
+			InitMemorySizeForGame();
+		}
 		break;
 	case IdentifiedFileType::PSP_ELF:
 		if (Memory::g_PSPModel != PSP_MODEL_FAT) {


### PR DESCRIPTION
Just got annoyed with some confusing startup code. There's a lot more to do here, though.

Reduces the amounts of times we parse PARAM.SFO and calls IdentifyFile, so maybe a minor game start perf improvement.