### PR TITLE
at3_standalone: Make all allocations aligned.

### DIFF
--- a/Common/MemoryUtil.h
+++ b/Common/MemoryUtil.h
@@ -47,7 +47,8 @@ void FreeMemoryPages(void* ptr, size_t size);
 
 // Regular aligned memory. Don't try to apply memory protection willy-nilly to memory allocated this way as in-page alignment is unknown (though could be checked).
 // No longer asserts, will return nullptr on failure.
-void* AllocateAlignedMemory(size_t size, size_t alignment);
+// WARNING: Not necessarily malloc-compatible!
+void *AllocateAlignedMemory(size_t size, size_t alignment);
 void FreeAlignedMemory(void* ptr);
 
 int GetMemoryProtectPageSize();

--- a/ext/at3_standalone/get_bits.cpp
+++ b/ext/at3_standalone/get_bits.cpp
@@ -81,7 +81,7 @@ static int alloc_table(VLC *vlc, int size, int use_static)
         if (use_static)
             abort(); // cannot do anything, init_vlc() is used with too little memory
         vlc->table_allocated += (1 << vlc->bits);
-        vlc->table = (VLC_TYPE(*)[2])av_realloc_f(vlc->table, vlc->table_allocated, sizeof(VLC_TYPE) * 2);
+        vlc->table = (VLC_TYPE(*)[2])realloc(vlc->table, vlc->table_allocated);
         if (!vlc->table) {
             vlc->table_allocated = 0;
             vlc->table_size = 0;
@@ -311,14 +311,15 @@ int ff_init_vlc_sparse(VLC *vlc_arg, int nb_bits, int nb_codes,
     } else {
         av_free(buf);
         if (ret < 0) {
-            av_freep(&vlc->table);
+            free(vlc->table);
+            vlc->table = 0;
             return ret;
         }
     }
     return 0;
 }
 
-void ff_free_vlc(VLC *vlc)
-{
-    av_freep(&vlc->table);
+void ff_free_vlc(VLC *vlc) {
+    free(vlc->table);
+    vlc->table = nullptr;
 }


### PR DESCRIPTION
Also replaces av_realloc with regular realloc, as there's no aligned_realloc and pointers are not compatible with regular free.

Fixes #20155 