### PR TITLE
Enable slow UMD compat flags for Crash of the Titans.

### DIFF
--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -853,6 +853,13 @@ ULJM05287 = true
 ULKS46155 = true
 ULUS10277 = true
 
+# Crash of the Titans - #12510
+ULES00915 = true
+ULES00916 = true
+ULES00917 = true
+ULES00918 = true
+ULUS10304 = true
+
 [GoWFramerateHack60]
 # Replaces ForceMax60FPS for GOW games, should provide smoother experience
 # Also works around softlock in GOW:GOS , see #8299
@@ -1833,6 +1840,13 @@ UCAS40244 = true
 UCKS45110 = true
 ULJS19044 = true
 NPJH50852 = true
+
+# Crash of the Titans - #12510
+ULES00915 = true
+ULES00916 = true
+ULES00917 = true
+ULES00918 = true
+ULUS10304 = true
 
 [TacticsOgreEliminateDebugReadback]
 ULUS10565 = true


### PR DESCRIPTION
Should help #20170