### PR TITLE
Add Linux file dialog support through "portable-file-dialogs"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,3 +65,6 @@
 [submodule "ext/lua"]
 	path = ext/lua
 	url = https://github.com/hrydgard/ppsspp-lua.git
+[submodule "ext/portable-file-dialogs"]
+	path = ext/portable-file-dialogs
+	url = git@github.com:samhocevar/portable-file-dialogs.git

--- a/Common/System/Request.h
+++ b/Common/System/Request.h
@@ -104,6 +104,7 @@ enum class BrowseFileType {
 	SOUND_EFFECT,
 	ZIP,
 	SYMBOL_MAP,
+	SYMBOL_MAP_NOCASH,
 	ATRAC3,
 	ANY,
 };

--- a/UI/DarwinFileSystemServices.mm
+++ b/UI/DarwinFileSystemServices.mm
@@ -88,7 +88,13 @@ void DarwinFileSystemServices::presentDirectoryPanel(
 			[panel setAllowedFileTypes:[NSArray arrayWithObject:@"db"]];
 			break;
 		case BrowseFileType::SOUND_EFFECT:
-			[panel setAllowedFileTypes:[NSArray arrayWithObject:@"wav"]];
+			[panel setAllowedFileTypes:[NSArray arrayWithObject:@"wav", @"mp3"]];
+			break;
+		case BrowseFileType::SYMBOL_MAP:
+			[panel setAllowedFileTypes:[NSArray arrayWithObject:@"ppsym"]];
+			break;
+		case BrowseFileType::SYMBOL_MAP_NOCASH:
+			[panel setAllowedFileTypes:[NSArray arrayWithObject:@"sym"]];
 			break;
 		case BrowseFileType::ATRAC3:
 			[panel setAllowedFileTypes:[NSArray arrayWithObject:@"at3"]];
@@ -113,21 +119,21 @@ void DarwinFileSystemServices::presentDirectoryPanel(
 		UIViewController *rootViewController = UIApplication.sharedApplication
 			.keyWindow
 			.rootViewController;
-		
+
 		// get current window view controller
 		if (!rootViewController)
 			return;
-		
+
 		NSMutableArray<NSString *> *types = [NSMutableArray array];
 		UIDocumentPickerMode pickerMode = UIDocumentPickerModeOpen;
-		
+
 		if (allowDirectories)
 			[types addObject: (__bridge NSString *)kUTTypeFolder];
 		if (allowFiles) {
 			[types addObject: (__bridge NSString *)kUTTypeItem];
 			pickerMode = UIDocumentPickerModeImport;
 		}
-		
+
 		UIDocumentPickerViewController *pickerVC = [[UIDocumentPickerViewController alloc] initWithDocumentTypes: types inMode: pickerMode];
 		// What if you wanted to go to heaven, but then God showed you the next few lines?
 		// serious note: have to do this, because __pickerDelegate has to stay retained as a class property
@@ -142,7 +148,7 @@ Path DarwinFileSystemServices::appropriateMemoryStickDirectoryToUse() {
     NSString *userPreferred = [[NSUserDefaults standardUserDefaults] stringForKey:@(PreferredMemoryStickUserDefaultsKey)];
     if (userPreferred)
         return Path(userPreferred.UTF8String);
-    
+
     return defaultMemoryStickPath();
 }
 

--- a/UI/DarwinFileSystemServices.mm
+++ b/UI/DarwinFileSystemServices.mm
@@ -88,7 +88,7 @@ void DarwinFileSystemServices::presentDirectoryPanel(
 			[panel setAllowedFileTypes:[NSArray arrayWithObject:@"db"]];
 			break;
 		case BrowseFileType::SOUND_EFFECT:
-			[panel setAllowedFileTypes:[NSArray arrayWithObject:@"wav", @"mp3"]];
+			[panel setAllowedFileTypes:[NSArray arrayWithObjects:@"wav", @"mp3", nil]];
 			break;
 		case BrowseFileType::SYMBOL_MAP:
 			[panel setAllowedFileTypes:[NSArray arrayWithObject:@"ppsym"]];

--- a/UWP/PPSSPP_UWPMain.cpp
+++ b/UWP/PPSSPP_UWPMain.cpp
@@ -436,7 +436,7 @@ bool System_GetPropertyBool(SystemProperty prop) {
 		return true;
 	case SYSPROP_HAS_KEYBOARD:
 	{
-		// Do actual check 
+		// Do actual check
 		// touch devices has input pane, we need to depend on it
 		// I don't know any possible way to display input dialog in non-xaml apps
 		return isKeyboardAvailable() || isTouchAvailable();
@@ -518,6 +518,9 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 			break;
 		case BrowseFileType::SYMBOL_MAP:
 			supportedExtensions = { ".ppmap" };
+			break;
+		case BrowseFileType::SYMBOL_MAP_NOCASH:
+			supportedExtensions = { ".sym" };
 			break;
 		case BrowseFileType::DB:
 			supportedExtensions = { ".db" };

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -539,6 +539,8 @@ static std::wstring MakeWindowsFilter(BrowseFileType type) {
 		return FinalizeFilter(L"Sound effect files (*.wav *.mp3)|*.wav;*.mp3|All files (*.*)|*.*||");
 	case BrowseFileType::SYMBOL_MAP:
 		return FinalizeFilter(L"Symbol map files (*.ppmap)|*.ppmap|All files (*.*)|*.*||");
+	case BrowseFileType::SYMBOL_MAP_NOCASH:
+		return FinalizeFilter(L"No$ symbol map files (*.sym)|*.sym|All files (*.*)|*.*||");
 	case BrowseFileType::ATRAC3:
 		return FinalizeFilter(L"ATRAC3/3+ files (*.at3)|*.at3|All files (*.*)|*.*||");
 	case BrowseFileType::ANY:


### PR DESCRIPTION
Uses https://github.com/samhocevar/portable-file-dialogs for simplicity.

Will not work unless KDE (kdialog) or GTK or something is installed.

Fixes #20174 