### PR TITLE
Portable file dialogs: Check in instead of using a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,6 +65,3 @@
 [submodule "ext/lua"]
 	path = ext/lua
 	url = https://github.com/hrydgard/ppsspp-lua.git
-[submodule "ext/portable-file-dialogs"]
-	path = ext/portable-file-dialogs
-	url = git@github.com:samhocevar/portable-file-dialogs.git


### PR DESCRIPTION
Getting strange errors in CI: https://github.com/hrydgard/ppsspp/actions/runs/14144292752/job/39629751806

so let's just check it in.