### PR TITLE
Expose some PSP kernel structs in headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2170,6 +2170,7 @@ add_library(${CoreLibName} ${CoreLinkType}
 	Core/HLE/HLETables.cpp
 	Core/HLE/HLETables.h
 	Core/HLE/KernelWaitHelpers.h
+	Core/HLE/PSPThreadContext.h
 	Core/HLE/KUBridge.h
 	Core/HLE/KUBridge.cpp
 	Core/HLE/Plugins.h

--- a/Common/Math/expression_parser.h
+++ b/Common/Math/expression_parser.h
@@ -1,21 +1,18 @@
 #pragma once
 
 #include <cstdint>
-#include <cstddef>
 #include <string>
 #include <vector>
 
 typedef std::pair<uint32_t, uint32_t> ExpressionPair;
 typedef std::vector<ExpressionPair> PostfixExpression;
 
-enum ExpressionType
-{
+enum ExpressionType {
 	EXPR_TYPE_UINT = 0,
 	EXPR_TYPE_FLOAT = 2,
 };
 
-class IExpressionFunctions
-{
+class IExpressionFunctions {
 public:
 	virtual ~IExpressionFunctions() {}
 	virtual bool parseReference(char* str, uint32_t& referenceIndex) = 0;

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -1195,6 +1195,7 @@
     <ClInclude Include="HLE\KUBridge.h" />
     <ClInclude Include="HLE\NetInetConstants.h" />
     <ClInclude Include="HLE\Plugins.h" />
+    <ClInclude Include="HLE\PSPThreadContext.h" />
     <ClInclude Include="HLE\sceAac.h" />
     <ClInclude Include="HLE\sceKernelHeap.h" />
     <ClInclude Include="HLE\sceNetApctl.h" />

--- a/Core/Core.vcxproj.filters
+++ b/Core/Core.vcxproj.filters
@@ -2178,6 +2178,9 @@
     <ClInclude Include="LuaContext.h">
       <Filter>Core</Filter>
     </ClInclude>
+    <ClInclude Include="HLE\PSPThreadContext.h">
+      <Filter>HLE\Kernel</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\LICENSE.TXT" />

--- a/Core/Debugger/Breakpoints.h
+++ b/Core/Debugger/Breakpoints.h
@@ -22,6 +22,7 @@
 #include <mutex>
 
 #include "Core/MIPS/MIPSDebugInterface.h"
+#include "Common/Math/expression_parser.h"
 
 enum BreakAction : u32 {
 	BREAK_ACTION_IGNORE = 0x00,

--- a/Core/Debugger/SymbolMap.h
+++ b/Core/Debugger/SymbolMap.h
@@ -66,6 +66,7 @@ typedef struct HWND__ *HWND;
 class SymbolMap {
 public:
 	SymbolMap() {}
+
 	void Clear();
 	void SortSymbols();
 

--- a/Core/HLE/KernelThreadDebugInterface.h
+++ b/Core/HLE/KernelThreadDebugInterface.h
@@ -18,8 +18,10 @@
 #pragma once
 
 #include <cstdio>
-#include "Core/HLE/sceKernelThread.h"
+#include "Core/HLE/PSPThreadContext.h"
 #include "Core/MIPS/MIPSDebugInterface.h"
+
+struct PSPThreadContext;
 
 class KernelThreadDebugInterface : public DebugInterface {
 public:

--- a/Core/HLE/PSPThreadContext.h
+++ b/Core/HLE/PSPThreadContext.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// Had to break this out into its own header to solve a circular include issue.
+
+#include "Common/CommonTypes.h"
+
+struct PSPThreadContext {
+	void reset();
+
+	// r must be followed by f.
+	u32 r[32];
+	union {
+		float f[32];
+		u32 fi[32];
+		int fs[32];
+	};
+	union {
+		float v[128];
+		u32 vi[128];
+	};
+	u32 vfpuCtrl[16];
+
+	union {
+		struct {
+			u32 pc;
+
+			u32 lo;
+			u32 hi;
+
+			u32 fcr31;
+			u32 fpcond;
+		};
+		u32 other[6];
+	};
+};

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -92,9 +92,7 @@ struct NativeFPL
 };
 
 //FPL - Fixed Length Dynamic Memory Pool - every item has the same length
-struct FPL : public KernelObject
-{
-	FPL() : blocks(NULL), nextBlock(0) {}
+struct FPL : public KernelObject {
 	~FPL() {
 		delete [] blocks;
 	}
@@ -148,11 +146,11 @@ struct FPL : public KernelObject
 		Do(p, pausedWaits);
 	}
 
-	NativeFPL nf;
-	bool *blocks;
-	u32 address;
-	int alignedSize;
-	int nextBlock;
+	NativeFPL nf{};
+	bool *blocks = nullptr;
+	u32 address = 0;
+	int alignedSize = 0;
+	int nextBlock = 0;
 	std::vector<FplWaitingThread> waitingThreads;
 	// Key is the callback id it was for, or if no callback, the thread id.
 	std::map<SceUID, FplWaitingThread> pausedWaits;
@@ -379,8 +377,7 @@ struct SceKernelVplHeader {
 	}
 };
 
-struct VPL : public KernelObject
-{
+struct VPL : public KernelObject {
 	const char *GetName() override { return nv.name; }
 	const char *GetTypeName() override { return GetStaticTypeName(); }
 	static const char *GetStaticTypeName() { return "VPL"; }
@@ -410,8 +407,8 @@ struct VPL : public KernelObject
 		}
 	}
 
-	SceKernelVplInfo nv;
-	u32 address;
+	SceKernelVplInfo nv{};
+	u32 address = 0;
 	std::vector<VplWaitingThread> waitingThreads;
 	// Key is the callback id it was for, or if no callback, the thread id.
 	std::map<SceUID, VplWaitingThread> pausedWaits;

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -74,11 +74,6 @@
 #include "GPU/GPUCommon.h"
 #include "GPU/GPUState.h"
 
-enum {
-	PSP_THREAD_ATTR_KERNEL = 0x00001000,
-	PSP_THREAD_ATTR_USER = 0x80000000,
-};
-
 enum : u32 {
 	// Function exports.
 	NID_MODULE_START = 0xD632ACDB,

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -134,92 +134,26 @@ static const char * const blacklistedModules[] = {
 	"sceMemab",
 };
 
-struct WriteVarSymbolState;
-
-struct VarSymbolImport {
-	char moduleName[KERNELOBJECT_MAX_NAME_LENGTH + 1];
-	u32 nid;
-	u32 stubAddr;
-	u8 type;
-};
-
-struct VarSymbolExport {
-	bool Matches(const VarSymbolImport &other) const {
-		return nid == other.nid && !strncmp(moduleName, other.moduleName, KERNELOBJECT_MAX_NAME_LENGTH);
+const char *NativeModuleStatusToString(NativeModuleStatus status) {
+	switch (status) {
+	case MODULE_STATUS_STARTING: return "STARTING";
+	case MODULE_STATUS_STARTED: return "STARTED";
+	case MODULE_STATUS_STOPPING: return "STOPPING";
+	case MODULE_STATUS_STOPPED: return "STOPPED";
+	case MODULE_STATUS_UNLOADING: return "UNLOADING";
+	default: return "(err)";
 	}
+}
 
-	char moduleName[KERNELOBJECT_MAX_NAME_LENGTH + 1];
-	u32 nid;
-	u32 symAddr;
-};
+static void ImportVarSymbol(WriteVarSymbolState &state, const VarSymbolImport &var);
+static void ExportVarSymbol(const VarSymbolExport &var);
+static void UnexportVarSymbol(const VarSymbolExport &var);
 
-struct FuncSymbolImport {
-	char moduleName[KERNELOBJECT_MAX_NAME_LENGTH + 1];
-	u32 stubAddr;
-	u32 nid;
-};
+static void ImportFuncSymbol(const FuncSymbolImport &func, bool reimporting, const char *importingModule);
+static void ExportFuncSymbol(const FuncSymbolExport &func);
+static void UnexportFuncSymbol(const FuncSymbolExport &func);
 
-struct FuncSymbolExport {
-	bool Matches(const FuncSymbolImport &other) const {
-		return nid == other.nid && !strncmp(moduleName, other.moduleName, KERNELOBJECT_MAX_NAME_LENGTH);
-	}
-
-	char moduleName[KERNELOBJECT_MAX_NAME_LENGTH + 1];
-	u32 symAddr;
-	u32 nid;
-};
-
-void ImportVarSymbol(WriteVarSymbolState &state, const VarSymbolImport &var);
-void ExportVarSymbol(const VarSymbolExport &var);
-void UnexportVarSymbol(const VarSymbolExport &var);
-
-void ImportFuncSymbol(const FuncSymbolImport &func, bool reimporting, const char *importingModule);
-void ExportFuncSymbol(const FuncSymbolExport &func);
-void UnexportFuncSymbol(const FuncSymbolExport &func);
-
-class PSPModule;
 static bool KernelImportModuleFuncs(PSPModule *module, u32 *firstImportStubAddr, bool reimporting = false);
-
-struct NativeModule {
-	u32_le next;
-	u16_le attribute;
-	u8 version[2];
-	char name[28];
-	u32_le status;
-	u32_le unk1;
-	u32_le modid; // 0x2C
-	u32_le usermod_thid;
-	u32_le memid;
-	u32_le mpidtext;
-	u32_le mpiddata;
-	u32_le ent_top;
-	u32_le ent_size;
-	u32_le stub_top;
-	u32_le stub_size;
-	u32_le module_start_func;
-	u32_le module_stop_func;
-	u32_le module_bootstart_func;
-	u32_le module_reboot_before_func;
-	u32_le module_reboot_phase_func;
-	u32_le entry_addr;
-	u32_le gp_value;
-	u32_le text_addr;
-	u32_le text_size;
-	u32_le data_size;
-	u32_le bss_size;
-	u32_le nsegment;
-	u32_le segmentaddr[4];
-	u32_le segmentsize[4];
-	u32_le module_start_thread_priority;
-	u32_le module_start_thread_stacksize;
-	u32_le module_start_thread_attr;
-	u32_le module_stop_thread_priority;
-	u32_le module_stop_thread_stacksize;
-	u32_le module_stop_thread_attr;
-	u32_le module_reboot_before_thread_priority;
-	u32_le module_reboot_before_thread_stacksize;
-	u32_le module_reboot_before_thread_attr;
-};
 
 // by QueryModuleInfo
 struct ModuleInfo {
@@ -238,246 +172,171 @@ struct ModuleInfo {
 	char name[28];
 };
 
-struct ModuleWaitingThread {
-	SceUID threadID;
-	u32 statusPtr;
-};
-
-enum NativeModuleStatus {
-	MODULE_STATUS_STARTING = 4,
-	MODULE_STATUS_STARTED = 5,
-	MODULE_STATUS_STOPPING = 6,
-	MODULE_STATUS_STOPPED = 7,
-	MODULE_STATUS_UNLOADING = 8,
-};
-
-class PSPModule : public KernelObject {
-public:
-	PSPModule() {
-		modulePtr.ptr = 0;
-	}
-
-	~PSPModule() {
-		if (memoryBlockAddr) {
-			// If it's either below user memory, or using a high kernel bit, it's in kernel.
-			if (memoryBlockAddr < PSP_GetUserMemoryBase() || memoryBlockAddr > PSP_GetUserMemoryEnd()) {
-				kernelMemory.Free(memoryBlockAddr);
-			} else {
-				userMemory.Free(memoryBlockAddr);
-			}
-			g_symbolMap->UnloadModule(memoryBlockAddr, memoryBlockSize);
-		}
-
-		if (modulePtr.ptr) {
-			//Only alloc at kernel memory.
-			kernelMemory.Free(modulePtr.ptr);
-		}
-	}
-	const char *GetName() override { return nm.name; }
-	const char *GetTypeName() override { return GetStaticTypeName(); }
-	static const char *GetStaticTypeName() { return "Module"; }
-	void GetQuickInfo(char *ptr, int size) override {
-		snprintf(ptr, size, "%d.%d %sname=%s gp=%08x entry=%08x",
-			nm.version[1], nm.version[0],
-			isFake ? "(faked) " : "",
-			nm.name,
-			nm.gp_value,
-			nm.entry_addr);
-	}
-	void GetLongInfo(char *ptr, int bufSize) const override;
-	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_MODULE; }
-	static int GetStaticIDType() { return PPSSPP_KERNEL_TMID_Module; }
-	int GetIDType() const override { return PPSSPP_KERNEL_TMID_Module; }
-
-	u32 GetDataAddr() const {
-		return nm.text_addr + nm.text_size;
-	}
-	u32 GetBSSAddr() const {
-		return nm.text_addr + nm.text_size + nm.data_size;
-	}
-
-	void DoState(PointerWrap &p) override
-	{
-		auto s = p.Section("Module", 1, 6);
-		if (!s)
-			return;
-
-		if (s >= 5) {
-			Do(p, nm);
+PSPModule::~PSPModule() {
+	if (memoryBlockAddr) {
+		// If it's either below user memory, or using a high kernel bit, it's in kernel.
+		if (memoryBlockAddr < PSP_GetUserMemoryBase() || memoryBlockAddr > PSP_GetUserMemoryEnd()) {
+			kernelMemory.Free(memoryBlockAddr);
 		} else {
-			char temp[192];
-			NativeModule *pnm = &nm;
-			char *ptemp = temp;
-			DoArray(p, ptemp, 0xC0);
-			memcpy(pnm, ptemp, 0x2C);
-			pnm->modid = GetUID();
-			memcpy(((uint8_t *)pnm) + 0x30, ((uint8_t *)ptemp) + 0x2C, 0xC0 - 0x2C);
+			userMemory.Free(memoryBlockAddr);
 		}
+		g_symbolMap->UnloadModule(memoryBlockAddr, memoryBlockSize);
+	}
 
-		if (s >= 6)
-			Do(p, crc);
+	if (modulePtr.ptr) {
+		//Only alloc at kernel memory.
+		kernelMemory.Free(modulePtr.ptr);
+	}
+}
 
-		Do(p, memoryBlockAddr);
-		Do(p, memoryBlockSize);
-		Do(p, isFake);
+u32 PSPModule::GetMissingErrorCode() {
+	return SCE_KERNEL_ERROR_UNKNOWN_MODULE;
+}
 
-		if (s < 2) {
-			bool isStarted = false;
-			Do(p, isStarted);
-			if (isStarted)
-				nm.status = MODULE_STATUS_STARTED;
-			else
-				nm.status = MODULE_STATUS_STOPPED;
-		}
+void PSPModule::DoState(PointerWrap &p) {
+	auto s = p.Section("Module", 1, 6);
+	if (!s)
+		return;
 
-		if (s >= 3) {
-			Do(p, textStart);
-			Do(p, textEnd);
-		}
-		if (s >= 4) {
-			Do(p, libstub);
-			Do(p, libstubend);
-		}
+	if (s >= 5) {
+		Do(p, nm);
+	} else {
+		char temp[192];
+		NativeModule *pnm = &nm;
+		char *ptemp = temp;
+		DoArray(p, ptemp, 0xC0);
+		memcpy(pnm, ptemp, 0x2C);
+		pnm->modid = GetUID();
+		memcpy(((uint8_t *)pnm) + 0x30, ((uint8_t *)ptemp) + 0x2C, 0xC0 - 0x2C);
+	}
 
-		if (s >= 5) {
-			Do(p, modulePtr.ptr);
-		}
+	if (s >= 6)
+		Do(p, crc);
 
-		ModuleWaitingThread mwt = {0};
-		Do(p, waitingThreads, mwt);
-		FuncSymbolExport fsx = {{0}};
-		Do(p, exportedFuncs, fsx);
-		FuncSymbolImport fsi = {{0}};
-		Do(p, importedFuncs, fsi);
-		VarSymbolExport vsx = {{0}};
-		Do(p, exportedVars, vsx);
-		VarSymbolImport vsi = {{0}};
-		Do(p, importedVars, vsi);
+	Do(p, memoryBlockAddr);
+	Do(p, memoryBlockSize);
+	Do(p, isFake);
 
-		if (p.mode == p.MODE_READ) {
-			// On load state, we re-examine in case our syscall ids changed.
-			if (libstub != 0) {
-				importedFuncs.clear();
-				// Imports reloaded in KernelModuleDoState.
-			} else {
-				// Older save state.  Let's still reload, but this may not pick up new flags, etc.
-				bool foundBroken = false;
-				auto importedFuncsState = importedFuncs;
-				importedFuncs.clear();
-				for (const auto &func : importedFuncsState) {
-					if (func.moduleName[KERNELOBJECT_MAX_NAME_LENGTH] != '\0' || !Memory::IsValidAddress(func.stubAddr)) {
-						foundBroken = true;
-					} else {
-						ImportFunc(func, true);
-					}
-				}
+	if (s < 2) {
+		bool isStarted = false;
+		Do(p, isStarted);
+		if (isStarted)
+			nm.status = MODULE_STATUS_STARTED;
+		else
+			nm.status = MODULE_STATUS_STOPPED;
+	}
 
-				if (foundBroken) {
-					ERROR_LOG(Log::Loader, "Broken stub import data while loading state");
+	if (s >= 3) {
+		Do(p, textStart);
+		Do(p, textEnd);
+	}
+	if (s >= 4) {
+		Do(p, libstub);
+		Do(p, libstubend);
+	}
+
+	if (s >= 5) {
+		Do(p, modulePtr.ptr);
+	}
+
+	ModuleWaitingThread mwt = { 0 };
+	Do(p, waitingThreads, mwt);
+	FuncSymbolExport fsx = { {0} };
+	Do(p, exportedFuncs, fsx);
+	FuncSymbolImport fsi = { {0} };
+	Do(p, importedFuncs, fsi);
+	VarSymbolExport vsx = { {0} };
+	Do(p, exportedVars, vsx);
+	VarSymbolImport vsi = { {0} };
+	Do(p, importedVars, vsi);
+
+	if (p.mode == p.MODE_READ) {
+		// On load state, we re-examine in case our syscall ids changed.
+		if (libstub != 0) {
+			importedFuncs.clear();
+			// Imports reloaded in KernelModuleDoState.
+		} else {
+			// Older save state.  Let's still reload, but this may not pick up new flags, etc.
+			bool foundBroken = false;
+			auto importedFuncsState = importedFuncs;
+			importedFuncs.clear();
+			for (const auto &func : importedFuncsState) {
+				if (func.moduleName[KERNELOBJECT_MAX_NAME_LENGTH] != '\0' || !Memory::IsValidAddress(func.stubAddr)) {
+					foundBroken = true;
+				} else {
+					ImportFunc(func, true);
 				}
 			}
 
-			char moduleName[29] = {0};
-			truncate_cpy(moduleName, nm.name);
-			if (memoryBlockAddr != 0) {
-				g_symbolMap->AddModule(moduleName, memoryBlockAddr, memoryBlockSize);
+			if (foundBroken) {
+				ERROR_LOG(Log::Loader, "Broken stub import data while loading state");
 			}
 		}
 
-		HLEPlugins::DoState(p);
-
-		RebuildImpExpModuleNames();
-	}
-
-	// We don't do this in the destructor to avoid annoying messages on game shutdown.
-	void Cleanup();
-
-	void ImportFunc(const FuncSymbolImport &func, bool reimporting) {
-		if (!Memory::IsValidAddress(func.stubAddr)) {
-			WARN_LOG_REPORT(Log::Loader, "Invalid address for syscall stub %s %08x", func.moduleName, func.nid);
-			return;
-		}
-
-		DEBUG_LOG(Log::Loader, "Importing %s : %08x", GetFuncName(func.moduleName, func.nid), func.stubAddr);
-
-		// Add the symbol to the symbol map for debugging.
-		char temp[256];
-		snprintf(temp, sizeof(temp), "zz_%s", GetFuncName(func.moduleName, func.nid));
-		g_symbolMap->AddFunction(temp,func.stubAddr,8);
-
-		// Keep track and actually hook it up if possible.
-		importedFuncs.push_back(func);
-		impExpModuleNames.insert(func.moduleName);
-		ImportFuncSymbol(func, reimporting, GetName());
-	}
-
-	void ImportVar(WriteVarSymbolState &state, const VarSymbolImport &var) {
-		// Keep track and actually hook it up if possible.
-		importedVars.push_back(var);
-		impExpModuleNames.insert(var.moduleName);
-		ImportVarSymbol(state, var);
-	}
-
-	void ExportFunc(const FuncSymbolExport &func) {
-		if (isFake) {
-			return;
-		}
-		exportedFuncs.push_back(func);
-		impExpModuleNames.insert(func.moduleName);
-		ExportFuncSymbol(func);
-	}
-
-	void ExportVar(const VarSymbolExport &var) {
-		if (isFake) {
-			return;
-		}
-		exportedVars.push_back(var);
-		impExpModuleNames.insert(var.moduleName);
-		ExportVarSymbol(var);
-	}
-
-	template <typename T>
-	void RebuildImpExpList(const std::vector<T> &list) {
-		for (size_t i = 0; i < list.size(); ++i) {
-			impExpModuleNames.insert(list[i].moduleName);
+		char moduleName[29] = { 0 };
+		truncate_cpy(moduleName, nm.name);
+		if (memoryBlockAddr != 0) {
+			g_symbolMap->AddModule(moduleName, memoryBlockAddr, memoryBlockSize);
 		}
 	}
 
-	void RebuildImpExpModuleNames() {
-		impExpModuleNames.clear();
-		RebuildImpExpList(exportedFuncs);
-		RebuildImpExpList(importedFuncs);
-		RebuildImpExpList(exportedVars);
-		RebuildImpExpList(importedVars);
+	HLEPlugins::DoState(p);
+
+	RebuildImpExpModuleNames();
+}
+
+void PSPModule::ImportFunc(const FuncSymbolImport &func, bool reimporting) {
+	if (!Memory::IsValidAddress(func.stubAddr)) {
+		WARN_LOG_REPORT(Log::Loader, "Invalid address for syscall stub %s %08x", func.moduleName, func.nid);
+		return;
 	}
 
-	bool ImportsOrExportsModuleName(const std::string &moduleName) {
-		return impExpModuleNames.find(moduleName) != impExpModuleNames.end();
+	DEBUG_LOG(Log::Loader, "Importing %s : %08x", GetFuncName(func.moduleName, func.nid), func.stubAddr);
+
+	// Add the symbol to the symbol map for debugging.
+	char temp[256];
+	snprintf(temp, sizeof(temp), "zz_%s", GetFuncName(func.moduleName, func.nid));
+	g_symbolMap->AddFunction(temp, func.stubAddr, 8);
+
+	// Keep track and actually hook it up if possible.
+	importedFuncs.push_back(func);
+	impExpModuleNames.insert(func.moduleName);
+	ImportFuncSymbol(func, reimporting, GetName());
+}
+
+void PSPModule::ImportVar(WriteVarSymbolState &state, const VarSymbolImport &var) {
+	// Keep track and actually hook it up if possible.
+	importedVars.push_back(var);
+	impExpModuleNames.insert(var.moduleName);
+	ImportVarSymbol(state, var);
+}
+
+void PSPModule::ExportFunc(const FuncSymbolExport &func) {
+	if (isFake) {
+		return;
 	}
+	exportedFuncs.push_back(func);
+	impExpModuleNames.insert(func.moduleName);
+	ExportFuncSymbol(func);
+}
 
-	NativeModule nm{};
-	std::vector<ModuleWaitingThread> waitingThreads;
+void PSPModule::ExportVar(const VarSymbolExport &var) {
+	if (isFake) {
+		return;
+	}
+	exportedVars.push_back(var);
+	impExpModuleNames.insert(var.moduleName);
+	ExportVarSymbol(var);
+}
 
-	std::vector<FuncSymbolExport> exportedFuncs;
-	std::vector<FuncSymbolImport> importedFuncs;
-	std::vector<VarSymbolExport> exportedVars;
-	std::vector<VarSymbolImport> importedVars;
-	std::set<std::string> impExpModuleNames;
-	// Keep track of the code region so we can throw out analysis results
-	// when unloaded.
-	u32 textStart = 0;
-	u32 textEnd = 0;
-
-	// Keep track of the libstub pointers so we can recheck on load state.
-	u32 libstub = 0;
-	u32 libstubend = 0;
-
-	u32 memoryBlockAddr = 0;
-	u32 memoryBlockSize = 0;
-	u32 crc = 0;
-	PSPPointer<NativeModule> modulePtr;
-	bool isFake = false;
-};
+void PSPModule::GetQuickInfo(char *ptr, int size) {
+	snprintf(ptr, size, "%d.%d %sname=%s gp=%08x entry=%08x",
+		nm.version[1], nm.version[0],
+		isFake ? "(faked) " : "",
+		nm.name,
+		nm.gp_value,
+		nm.entry_addr);
+}
 
 void PSPModule::GetLongInfo(char *ptr, int bufSize) const {
 	StringWriter w(ptr, bufSize);

--- a/Core/HLE/sceKernelModule.h
+++ b/Core/HLE/sceKernelModule.h
@@ -20,7 +20,13 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <set>
+
 #include "Core/HLE/sceKernel.h"
+#include "Core/MemMap.h"
+
+class PointerWrap;
+struct SceKernelSMOption;
 
 struct PspModuleInfo {
 	u16_le moduleAttrs; //0x0000 User Mode, 0x1000 Kernel Mode
@@ -34,8 +40,169 @@ struct PspModuleInfo {
 	u32_le libstubend;       // ptr to end of .lib.stub section
 };
 
-class PointerWrap;
-struct SceKernelSMOption;
+enum NativeModuleStatus {
+	MODULE_STATUS_STARTING = 4,
+	MODULE_STATUS_STARTED = 5,
+	MODULE_STATUS_STOPPING = 6,
+	MODULE_STATUS_STOPPED = 7,
+	MODULE_STATUS_UNLOADING = 8,
+};
+
+const char *NativeModuleStatusToString(NativeModuleStatus status);
+
+struct NativeModule {
+	u32_le next;
+	u16_le attribute;
+	u8 version[2];
+	char name[28];
+	u32_le status;
+	u32_le unk1;
+	u32_le modid; // 0x2C
+	u32_le usermod_thid;
+	u32_le memid;
+	u32_le mpidtext;
+	u32_le mpiddata;
+	u32_le ent_top;
+	u32_le ent_size;
+	u32_le stub_top;
+	u32_le stub_size;
+	u32_le module_start_func;
+	u32_le module_stop_func;
+	u32_le module_bootstart_func;
+	u32_le module_reboot_before_func;
+	u32_le module_reboot_phase_func;
+	u32_le entry_addr;
+	u32_le gp_value;
+	u32_le text_addr;
+	u32_le text_size;
+	u32_le data_size;
+	u32_le bss_size;
+	u32_le nsegment;
+	u32_le segmentaddr[4];
+	u32_le segmentsize[4];
+	u32_le module_start_thread_priority;
+	u32_le module_start_thread_stacksize;
+	u32_le module_start_thread_attr;
+	u32_le module_stop_thread_priority;
+	u32_le module_stop_thread_stacksize;
+	u32_le module_stop_thread_attr;
+	u32_le module_reboot_before_thread_priority;
+	u32_le module_reboot_before_thread_stacksize;
+	u32_le module_reboot_before_thread_attr;
+};
+
+struct VarSymbolImport {
+	char moduleName[KERNELOBJECT_MAX_NAME_LENGTH + 1];
+	u32 nid;
+	u32 stubAddr;
+	u8 type;
+};
+
+struct VarSymbolExport {
+	bool Matches(const VarSymbolImport &other) const {
+		return nid == other.nid && !strncmp(moduleName, other.moduleName, KERNELOBJECT_MAX_NAME_LENGTH);
+	}
+
+	char moduleName[KERNELOBJECT_MAX_NAME_LENGTH + 1];
+	u32 nid;
+	u32 symAddr;
+};
+
+struct FuncSymbolImport {
+	char moduleName[KERNELOBJECT_MAX_NAME_LENGTH + 1];
+	u32 stubAddr;
+	u32 nid;
+};
+
+struct FuncSymbolExport {
+	bool Matches(const FuncSymbolImport &other) const {
+		return nid == other.nid && !strncmp(moduleName, other.moduleName, KERNELOBJECT_MAX_NAME_LENGTH);
+	}
+
+	char moduleName[KERNELOBJECT_MAX_NAME_LENGTH + 1];
+	u32 symAddr;
+	u32 nid;
+};
+
+struct WriteVarSymbolState;
+
+struct ModuleWaitingThread {
+	SceUID threadID;
+	u32 statusPtr;
+};
+
+class PSPModule : public KernelObject {
+public:
+	~PSPModule();
+	const char *GetName() override { return nm.name; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "Module"; }
+	void GetQuickInfo(char *ptr, int size) override;
+	void GetLongInfo(char *ptr, int bufSize) const override;
+	static u32 GetMissingErrorCode();
+	static int GetStaticIDType() { return PPSSPP_KERNEL_TMID_Module; }
+	int GetIDType() const override { return PPSSPP_KERNEL_TMID_Module; }
+
+	u32 GetDataAddr() const {
+		return nm.text_addr + nm.text_size;
+	}
+	u32 GetBSSAddr() const {
+		return nm.text_addr + nm.text_size + nm.data_size;
+	}
+
+	void DoState(PointerWrap &p) override;
+
+	// We don't do this in the destructor to avoid annoying messages on game shutdown.
+	void Cleanup();
+
+	void ImportFunc(const FuncSymbolImport &func, bool reimporting);
+	void ImportVar(WriteVarSymbolState &state, const VarSymbolImport &var);
+	void ExportFunc(const FuncSymbolExport &func);
+	void ExportVar(const VarSymbolExport &var);
+
+	template <typename T>
+	void RebuildImpExpList(const std::vector<T> &list) {
+		for (size_t i = 0; i < list.size(); ++i) {
+			impExpModuleNames.insert(list[i].moduleName);
+		}
+	}
+
+	void RebuildImpExpModuleNames() {
+		impExpModuleNames.clear();
+		RebuildImpExpList(exportedFuncs);
+		RebuildImpExpList(importedFuncs);
+		RebuildImpExpList(exportedVars);
+		RebuildImpExpList(importedVars);
+	}
+
+	bool ImportsOrExportsModuleName(const std::string &moduleName) {
+		return impExpModuleNames.find(moduleName) != impExpModuleNames.end();
+	}
+
+	NativeModule nm{};
+	std::vector<ModuleWaitingThread> waitingThreads;
+
+	std::vector<FuncSymbolExport> exportedFuncs;
+	std::vector<FuncSymbolImport> importedFuncs;
+	std::vector<VarSymbolExport> exportedVars;
+	std::vector<VarSymbolImport> importedVars;
+	std::set<std::string> impExpModuleNames;
+
+	// Keep track of the code region so we can throw out analysis results
+	// when unloaded.
+	u32 textStart = 0;
+	u32 textEnd = 0;
+
+	// Keep track of the libstub pointers so we can recheck on load state.
+	u32 libstub = 0;
+	u32 libstubend = 0;
+
+	u32 memoryBlockAddr = 0;
+	u32 memoryBlockSize = 0;
+	u32 crc = 0;
+	PSPPointer<NativeModule> modulePtr{};
+	bool isFake = false;
+};
 
 KernelObject *__KernelModuleObject();
 void __KernelModuleDoState(PointerWrap &p);

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -105,23 +105,6 @@ enum ThreadEventType {
 
 bool __KernelThreadTriggerEvent(bool isKernel, SceUID threadID, ThreadEventType type);
 
-enum {
-	PSP_THREAD_ATTR_KERNEL       = 0x00001000,
-	PSP_THREAD_ATTR_VFPU         = 0x00004000,
-	PSP_THREAD_ATTR_SCRATCH_SRAM = 0x00008000, // Save/restore scratch as part of context???
-	PSP_THREAD_ATTR_NO_FILLSTACK = 0x00100000, // No filling of 0xff.
-	PSP_THREAD_ATTR_CLEAR_STACK  = 0x00200000, // Clear thread stack when deleted.
-	PSP_THREAD_ATTR_LOW_STACK    = 0x00400000, // Allocate stack from bottom not top.
-	PSP_THREAD_ATTR_USER         = 0x80000000,
-	PSP_THREAD_ATTR_USBWLAN      = 0xa0000000,
-	PSP_THREAD_ATTR_VSH          = 0xc0000000,
-
-	// TODO: Support more, not even sure what all of these mean.
-	PSP_THREAD_ATTR_USER_MASK    = 0xf8f060ff,
-	PSP_THREAD_ATTR_USER_ERASE   = 0x78800000,
-	PSP_THREAD_ATTR_SUPPORTED    = (PSP_THREAD_ATTR_KERNEL | PSP_THREAD_ATTR_VFPU | PSP_THREAD_ATTR_NO_FILLSTACK | PSP_THREAD_ATTR_CLEAR_STACK | PSP_THREAD_ATTR_LOW_STACK | PSP_THREAD_ATTR_USER)
-};
-
 struct NativeCallback
 {
 	SceUInt_le size;
@@ -171,58 +154,6 @@ public:
 	}
 
 	NativeCallback nc;
-};
-
-#if COMMON_LITTLE_ENDIAN
-typedef WaitType WaitType_le;
-#else
-typedef swap_struct_t<WaitType, swap_32_t<WaitType> > WaitType_le;
-#endif
-
-// Real PSP struct, don't change the fields.
-struct SceKernelThreadRunStatus
-{
-	SceSize_le size;
-	u32_le status;
-	s32_le currentPriority;
-	WaitType_le waitType;
-	SceUID_le waitID;
-	s32_le wakeupCount;
-	SceKernelSysClock runForClocks;
-	s32_le numInterruptPreempts;
-	s32_le numThreadPreempts;
-	s32_le numReleases;
-};
-
-// Real PSP struct, don't change the fields.
-struct NativeThread
-{
-	u32_le nativeSize;
-	char name[KERNELOBJECT_MAX_NAME_LENGTH+1];
-
-	// Threading stuff
-	u32_le attr;
-	u32_le status;
-	u32_le entrypoint;
-	u32_le initialStack;
-	u32_le stackSize;
-	u32_le gpreg;
-
-	s32_le initialPriority;
-	s32_le currentPriority;
-	WaitType_le waitType;
-	SceUID_le waitID;
-	s32_le wakeupCount;
-	s32_le exitStatus;
-	SceKernelSysClock runForClocks;
-	s32_le numInterruptPreempts;
-	s32_le numThreadPreempts;
-	s32_le numReleases;
-};
-
-struct ThreadWaitInfo {
-	u32 waitValue;
-	u32 timeoutPtr;
 };
 
 // Owns outstanding MIPS calls and provides a way to get them by ID.
@@ -344,8 +275,7 @@ public:
 	PSPAction *chainedAction;
 };
 
-class ActionAfterCallback : public PSPAction
-{
+class ActionAfterCallback : public PSPAction {
 public:
 	ActionAfterCallback() {}
 	void run(MipsCall &call) override;
@@ -354,13 +284,11 @@ public:
 		return new ActionAfterCallback;
 	}
 
-	void setCallback(SceUID cbId_)
-	{
+	void setCallback(SceUID cbId_) {
 		cbId = cbId_;
 	}
 
-	void DoState(PointerWrap &p) override
-	{
+	void DoState(PointerWrap &p) override {
 		auto s = p.Section("ActionAfterCallback", 1);
 		if (!s)
 			return;
@@ -371,233 +299,172 @@ public:
 	SceUID cbId;
 };
 
-class PSPThread : public KernelObject {
-public:
-	PSPThread() : debug(context) {}
+u32 PSPThread::GetMissingErrorCode() {
+	return SCE_KERNEL_ERROR_UNKNOWN_THID;
+}
 
-	const char *GetName() override { return nt.name; }
-	const char *GetTypeName() override { return GetStaticTypeName(); }
-	static const char *GetStaticTypeName() { return "Thread"; }
-	void GetQuickInfo(char *ptr, int size) override {
-		snprintf(ptr, size, "pc= %08x sp= %08x %s %s %s %s %s %s (wt=%i wid=%i wv= %08x )",
-			context.pc, context.r[MIPS_REG_SP],
-			(nt.status & THREADSTATUS_RUNNING) ? "RUN" : "",
-			(nt.status & THREADSTATUS_READY) ? "READY" : "",
-			(nt.status & THREADSTATUS_WAIT) ? "WAIT" : "",
-			(nt.status & THREADSTATUS_SUSPEND) ? "SUSPEND" : "",
-			(nt.status & THREADSTATUS_DORMANT) ? "DORMANT" : "",
-			(nt.status & THREADSTATUS_DEAD) ? "DEAD" : "",
-			(int)nt.waitType,
-			nt.waitID,
-			waitInfo.waitValue);
+void PSPThread::GetQuickInfo(char *ptr, int size) {
+	snprintf(ptr, size, "pc= %08x sp= %08x %s %s %s %s %s %s (wt=%i wid=%i wv= %08x )",
+		context.pc, context.r[MIPS_REG_SP],
+		(nt.status & THREADSTATUS_RUNNING) ? "RUN" : "",
+		(nt.status & THREADSTATUS_READY) ? "READY" : "",
+		(nt.status & THREADSTATUS_WAIT) ? "WAIT" : "",
+		(nt.status & THREADSTATUS_SUSPEND) ? "SUSPEND" : "",
+		(nt.status & THREADSTATUS_DORMANT) ? "DORMANT" : "",
+		(nt.status & THREADSTATUS_DEAD) ? "DEAD" : "",
+		(int)nt.waitType,
+		nt.waitID,
+		waitInfo.waitValue);
+}
+
+BlockAllocator &PSPThread::StackAllocator() {
+	if (nt.attr & PSP_THREAD_ATTR_KERNEL) {
+		return kernelMemory;
 	}
+	return userMemory;
+}
 
-	static u32 GetMissingErrorCode() { return SCE_KERNEL_ERROR_UNKNOWN_THID; }
-	static int GetStaticIDType() { return SCE_KERNEL_TMID_Thread; }
-	int GetIDType() const override { return SCE_KERNEL_TMID_Thread; }
+bool PSPThread::AllocateStack(u32 &stackSize) {
+	_assert_msg_(stackSize >= 0x200, "thread stack should be 256 bytes or larger");
 
-	bool AllocateStack(u32 &stackSize) {
-		_assert_msg_(stackSize >= 0x200, "thread stack should be 256 bytes or larger");
+	FreeStack();
 
-		FreeStack();
-
-		bool fromTop = (nt.attr & PSP_THREAD_ATTR_LOW_STACK) == 0;
-		currentStack.start = StackAllocator().Alloc(stackSize, fromTop, StringFromFormat("stack/%s", nt.name).c_str());
-		if (currentStack.start == (u32)-1)
-		{
-			currentStack.start = 0;
-			nt.initialStack = 0;
-			ERROR_LOG(Log::sceKernel, "Failed to allocate stack for thread");
-			return false;
-		}
-
-		nt.initialStack = currentStack.start;
-		nt.stackSize = stackSize;
-		return true;
-	}
-
-	bool FillStack() {
-		// Fill the stack.
-		if ((nt.attr & PSP_THREAD_ATTR_NO_FILLSTACK) == 0) {
-			Memory::Memset(currentStack.start, 0xFF, nt.stackSize, "ThreadFillStack");
-		}
-		context.r[MIPS_REG_SP] = currentStack.start + nt.stackSize;
-		currentStack.end = context.r[MIPS_REG_SP];
-		// The k0 section is 256 bytes at the top of the stack.
-		context.r[MIPS_REG_SP] -= 256;
-		context.r[MIPS_REG_K0] = context.r[MIPS_REG_SP];
-		u32 k0 = context.r[MIPS_REG_K0];
-		Memory::Memset(k0, 0, 0x100, "ThreadK0");
-		Memory::Write_U32(GetUID(),        k0 + 0xc0);
-		Memory::Write_U32(nt.initialStack, k0 + 0xc8);
-		Memory::Write_U32(0xffffffff,      k0 + 0xf8);
-		Memory::Write_U32(0xffffffff,      k0 + 0xfc);
-		// After k0 comes the arguments, which is done by sceKernelStartThread().
-
-		Memory::Write_U32(GetUID(), nt.initialStack);
-		return true;
-	}
-
-	void FreeStack() {
-		if (currentStack.start != 0) {
-			DEBUG_LOG(Log::sceKernel, "Freeing thread stack %s", nt.name);
-
-			if ((nt.attr & PSP_THREAD_ATTR_CLEAR_STACK) != 0 && nt.initialStack != 0) {
-				Memory::Memset(nt.initialStack, 0, nt.stackSize, "ThreadFreeStack");
-			}
-
-			StackAllocator().Free(currentStack.start);
-			currentStack.start = 0;
-		}
-	}
-
-	bool PushExtendedStack(u32 size)
+	bool fromTop = (nt.attr & PSP_THREAD_ATTR_LOW_STACK) == 0;
+	currentStack.start = StackAllocator().Alloc(stackSize, fromTop, StringFromFormat("stack/%s", nt.name).c_str());
+	if (currentStack.start == (u32)-1)
 	{
-		u32 stack = userMemory.Alloc(size, true, StringFromFormat("extended/%s", nt.name).c_str());
-		if (stack == (u32)-1)
-			return false;
-
-		pushedStacks.push_back(currentStack);
-		currentStack.start = stack;
-		currentStack.end = stack + size;
-		nt.initialStack = currentStack.start;
-		nt.stackSize = currentStack.end - currentStack.start;
-
-		// We still drop the threadID at the bottom and fill it, but there's no k0.
-		Memory::Memset(currentStack.start, 0xFF, nt.stackSize, "ThreadExtendStack");
-		Memory::Write_U32(GetUID(), nt.initialStack);
-		return true;
+		currentStack.start = 0;
+		nt.initialStack = 0;
+		ERROR_LOG(Log::sceKernel, "Failed to allocate stack for thread");
+		return false;
 	}
 
-	bool PopExtendedStack()
-	{
-		if (pushedStacks.size() == 0)
-			return false;
+	nt.initialStack = currentStack.start;
+	nt.stackSize = stackSize;
+	return true;
+}
 
-		userMemory.Free(currentStack.start);
-		currentStack = pushedStacks.back();
-		pushedStacks.pop_back();
-		nt.initialStack = currentStack.start;
-		nt.stackSize = currentStack.end - currentStack.start;
-		return true;
+bool PSPThread::FillStack() {
+	// Fill the stack.
+	if ((nt.attr & PSP_THREAD_ATTR_NO_FILLSTACK) == 0) {
+		Memory::Memset(currentStack.start, 0xFF, nt.stackSize, "ThreadFillStack");
+	}
+	context.r[MIPS_REG_SP] = currentStack.start + nt.stackSize;
+	currentStack.end = context.r[MIPS_REG_SP];
+	// The k0 section is 256 bytes at the top of the stack.
+	context.r[MIPS_REG_SP] -= 256;
+	context.r[MIPS_REG_K0] = context.r[MIPS_REG_SP];
+	u32 k0 = context.r[MIPS_REG_K0];
+	Memory::Memset(k0, 0, 0x100, "ThreadK0");
+	Memory::Write_U32(GetUID(), k0 + 0xc0);
+	Memory::Write_U32(nt.initialStack, k0 + 0xc8);
+	Memory::Write_U32(0xffffffff, k0 + 0xf8);
+	Memory::Write_U32(0xffffffff, k0 + 0xfc);
+	// After k0 comes the arguments, which is done by sceKernelStartThread().
+
+	Memory::Write_U32(GetUID(), nt.initialStack);
+	return true;
+}
+
+void PSPThread::FreeStack() {
+	if (currentStack.start != 0) {
+		DEBUG_LOG(Log::sceKernel, "Freeing thread stack %s", nt.name);
+
+		if ((nt.attr & PSP_THREAD_ATTR_CLEAR_STACK) != 0 && nt.initialStack != 0) {
+			Memory::Memset(nt.initialStack, 0, nt.stackSize, "ThreadFreeStack");
+		}
+
+		StackAllocator().Free(currentStack.start);
+		currentStack.start = 0;
+	}
+}
+
+bool PSPThread::PushExtendedStack(u32 size) {
+	u32 stack = userMemory.Alloc(size, true, StringFromFormat("extended/%s", nt.name).c_str());
+	if (stack == (u32)-1)
+		return false;
+
+	pushedStacks.push_back(currentStack);
+	currentStack.start = stack;
+	currentStack.end = stack + size;
+	nt.initialStack = currentStack.start;
+	nt.stackSize = currentStack.end - currentStack.start;
+
+	// We still drop the threadID at the bottom and fill it, but there's no k0.
+	Memory::Memset(currentStack.start, 0xFF, nt.stackSize, "ThreadExtendStack");
+	Memory::Write_U32(GetUID(), nt.initialStack);
+	return true;
+}
+
+bool PSPThread::PopExtendedStack() {
+	if (pushedStacks.size() == 0)
+		return false;
+
+	userMemory.Free(currentStack.start);
+	currentStack = pushedStacks.back();
+	pushedStacks.pop_back();
+	nt.initialStack = currentStack.start;
+	nt.stackSize = currentStack.end - currentStack.start;
+	return true;
+}
+
+void PSPThread::Cleanup() {
+	// Callbacks are automatically deleted when their owning thread is deleted.
+	for (auto it = callbacks.begin(), end = callbacks.end(); it != end; ++it)
+		kernelObjects.Destroy<PSPCallback>(*it);
+
+	if (pushedStacks.size() != 0) {
+		WARN_LOG_REPORT(Log::sceKernel, "Thread ended within an extended stack");
+		for (size_t i = 0; i < pushedStacks.size(); ++i)
+			userMemory.Free(pushedStacks[i].start);
+	}
+	FreeStack();
+}
+
+void PSPThread::DoState(PointerWrap &p) {
+	auto s = p.Section("Thread", 1, 5);
+	if (!s)
+		return;
+
+	Do(p, nt);
+	Do(p, waitInfo);
+	Do(p, moduleId);
+	Do(p, isProcessingCallbacks);
+	Do(p, currentMipscallId);
+	Do(p, currentCallbackId);
+
+	// TODO: If we want to "version" a DoState method here, we can just use minVer = 0.
+	Do(p, context);
+
+	if (s <= 3) {
+		// We must have been loading an old state if we're here.
+		// Reorder VFPU data to new order.
+		float temp[128];
+		memcpy(temp, context.v, 128 * sizeof(float));
+		for (int i = 0; i < 128; i++) {
+			context.v[voffset[i]] = temp[i];
+		}
 	}
 
-	// Can't use a destructor since savestates will call that too.
-	void Cleanup()
-	{
-		// Callbacks are automatically deleted when their owning thread is deleted.
-		for (auto it = callbacks.begin(), end = callbacks.end(); it != end; ++it)
-			kernelObjects.Destroy<PSPCallback>(*it);
-
-		if (pushedStacks.size() != 0)
-		{
-			WARN_LOG_REPORT(Log::sceKernel, "Thread ended within an extended stack");
-			for (size_t i = 0; i < pushedStacks.size(); ++i)
-				userMemory.Free(pushedStacks[i].start);
-		}
-		FreeStack();
+	if (s <= 2) {
+		context.other[4] = context.other[5];
+		context.other[3] = context.other[4];
 	}
+	if (s <= 4)
+		std::swap(context.hi, context.lo);
 
-	BlockAllocator &StackAllocator() {
-		if (nt.attr & PSP_THREAD_ATTR_KERNEL) {
-			return kernelMemory;
-		}
-		return userMemory;
+	Do(p, callbacks);
+
+	Do(p, pendingMipsCalls);
+	Do(p, pushedStacks);
+	Do(p, currentStack);
+
+	if (s >= 2) {
+		Do(p, waitingThreads);
+		Do(p, pausedWaits);
 	}
+}
 
-	void setReturnValue(u32 retval);
-	void setReturnValue(u64 retval);
-	void resumeFromWait();
-	bool isWaitingFor(WaitType type, int id) const;
-	int getWaitID(WaitType type) const;
-	ThreadWaitInfo getWaitInfo() const;
-
-	// Utils
-	inline bool isRunning() const { return (nt.status & THREADSTATUS_RUNNING) != 0; }
-	inline bool isStopped() const { return (nt.status & THREADSTATUS_DORMANT) != 0; }
-	inline bool isReady() const { return (nt.status & THREADSTATUS_READY) != 0; }
-	inline bool isWaiting() const { return (nt.status & THREADSTATUS_WAIT) != 0; }
-	inline bool isSuspended() const { return (nt.status & THREADSTATUS_SUSPEND) != 0; }
-
-	void DoState(PointerWrap &p) override
-	{
-		auto s = p.Section("Thread", 1, 5);
-		if (!s)
-			return;
-
-		Do(p, nt);
-		Do(p, waitInfo);
-		Do(p, moduleId);
-		Do(p, isProcessingCallbacks);
-		Do(p, currentMipscallId);
-		Do(p, currentCallbackId);
-
-		// TODO: If we want to "version" a DoState method here, we can just use minVer = 0.
-		Do(p, context);
-
-		if (s <= 3)
-		{
-			// We must have been loading an old state if we're here.
-			// Reorder VFPU data to new order.
-			float temp[128];
-			memcpy(temp, context.v, 128 * sizeof(float));
-			for (int i = 0; i < 128; i++) {
-				context.v[voffset[i]] = temp[i];
-			}
-		}
-
-		if (s <= 2)
-		{
-			context.other[4] = context.other[5];
-			context.other[3] = context.other[4];
-		}
-		if (s <= 4)
-			std::swap(context.hi, context.lo);
-
-		Do(p, callbacks);
-
-		Do(p, pendingMipsCalls);
-		Do(p, pushedStacks);
-		Do(p, currentStack);
-
-		if (s >= 2)
-		{
-			Do(p, waitingThreads);
-			Do(p, pausedWaits);
-		}
-	}
-
-	NativeThread nt{};
-
-	ThreadWaitInfo waitInfo{};
-	SceUID moduleId = -1;
-
-	bool isProcessingCallbacks = false;
-	u32 currentMipscallId = -1;
-	SceUID currentCallbackId = -1;
-
-	PSPThreadContext context{};
-	KernelThreadDebugInterface debug;
-
-	std::vector<SceUID> callbacks;
-
-	std::list<u32> pendingMipsCalls;
-
-	struct StackInfo {
-		u32 start;
-		u32 end;
-	};
-	// This is a stack of... stacks, since sceKernelExtendThreadStack() can recurse.
-	// These are stacks that aren't "active" right now, but will pop off once the func returns.
-	std::vector<StackInfo> pushedStacks;
-
-	StackInfo currentStack{};
-
-	// For thread end.
-	std::vector<SceUID> waitingThreads;
-	// Key is the callback id it was for, or if no callback, the thread id.
-	std::map<SceUID, u64> pausedWaits;
-};
 
 struct WaitTypeFuncs
 {
@@ -3104,7 +2971,20 @@ void __KernelChangeThreadState(PSPThread *thread, ThreadStatus newStatus) {
 	}
 }
 
-
+const char *ThreadStatusToString(ThreadStatus status) {
+	switch (status) {
+	case THREADSTATUS_RUNNING: return "Running";
+	case THREADSTATUS_READY: return "Ready";
+	case THREADSTATUS_WAIT: return "Wait";
+	case THREADSTATUS_SUSPEND: return "Suspended";
+	case THREADSTATUS_DORMANT: return "Dormant";
+	case THREADSTATUS_DEAD: return "Dead";
+	case THREADSTATUS_WAITSUSPEND: return "WaitSuspended";
+	default:
+		break;
+	}
+	return "(unk)";
+}
 
 static bool __CanExecuteCallbackNow(PSPThread *thread) {
 	return currentCallbackThreadID == 0 && g_inCbCount == 0;
@@ -3540,7 +3420,7 @@ std::vector<DebugThreadInfo> GetThreadsInfo() {
 		info.id = uid;
 		strncpy(info.name,t->GetName(),KERNELOBJECT_MAX_NAME_LENGTH);
 		info.name[KERNELOBJECT_MAX_NAME_LENGTH] = 0;
-		info.status = t->nt.status;
+		info.status = (ThreadStatus)t->nt.status;
 		info.entrypoint = t->nt.entrypoint;
 		info.initialStack = t->nt.initialStack;
 		info.stackSize = (u32)t->nt.stackSize;

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -86,7 +86,7 @@ const WaitTypeNames waitTypeNames[] = {
 	{ WAITTYPE_USB,             "USB" },
 };
 
-const char *getWaitTypeName(WaitType type) {
+const char *WaitTypeToString(WaitType type) {
 	for (WaitTypeNames info : waitTypeNames) {
 		if (info.type == type)
 			return info.name;

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -19,15 +19,20 @@
 
 #include <string>
 #include <vector>
+#include <map>
+#include <list>
 
 #include "Common/CommonTypes.h"
 #include "Core/HLE/sceKernel.h"
+#include "Core/HLE/PSPThreadContext.h"
+#include "Core/HLE/KernelThreadDebugInterface.h"
 
 // There's a good description of the thread scheduling rules in:
 // http://code.google.com/p/jpcsp/source/browse/trunk/src/jpcsp/HLE/modules150/ThreadManForUser.java
 
 class PSPThread;
 class DebugInterface;
+class BlockAllocator;
 
 int sceKernelChangeThreadPriority(SceUID threadID, int priority);
 SceUID __KernelCreateThreadInternal(const char *threadName, SceUID moduleID, u32 entry, u32 prio, int stacksize, u32 attr);
@@ -82,8 +87,7 @@ struct SceKernelSysClock {
 
 // TODO: Map these to PSP wait types.  Most of these are wrong.
 // remember to update the waitTypeNames array in sceKernelThread.cpp when changing these
-enum WaitType : int
-{
+enum WaitType : int {
 	WAITTYPE_NONE         = 0,
 	WAITTYPE_SLEEP        = 1,
 	WAITTYPE_DELAY        = 2,
@@ -124,34 +128,156 @@ typedef void (* WaitEndCallbackFunc)(SceUID threadID, SceUID prevCallbackId);
 
 void __KernelRegisterWaitTypeFuncs(WaitType type, WaitBeginCallbackFunc beginFunc, WaitEndCallbackFunc endFunc);
 
-struct PSPThreadContext {
-	void reset();
+#if COMMON_LITTLE_ENDIAN
+typedef WaitType WaitType_le;
+#else
+typedef swap_struct_t<WaitType, swap_32_t<WaitType> > WaitType_le;
+#endif
 
-	// r must be followed by f.
-	u32 r[32];
-	union {
-		float f[32];
-		u32 fi[32];
-		int fs[32];
+// Real PSP struct, don't change the fields.
+struct SceKernelThreadRunStatus {
+	SceSize_le size;
+	u32_le status;
+	s32_le currentPriority;
+	WaitType_le waitType;
+	SceUID_le waitID;
+	s32_le wakeupCount;
+	SceKernelSysClock runForClocks;
+	s32_le numInterruptPreempts;
+	s32_le numThreadPreempts;
+	s32_le numReleases;
+};
+
+// Real PSP struct, don't change the fields.
+struct NativeThread {
+	u32_le nativeSize;
+	char name[KERNELOBJECT_MAX_NAME_LENGTH + 1];
+
+	// Threading stuff
+	u32_le attr;
+	u32_le status;
+	u32_le entrypoint;
+	u32_le initialStack;
+	u32_le stackSize;
+	u32_le gpreg;
+
+	s32_le initialPriority;
+	s32_le currentPriority;
+	WaitType_le waitType;
+	SceUID_le waitID;
+	s32_le wakeupCount;
+	s32_le exitStatus;
+	SceKernelSysClock runForClocks;
+	s32_le numInterruptPreempts;
+	s32_le numThreadPreempts;
+	s32_le numReleases;
+};
+
+struct ThreadWaitInfo {
+	u32 waitValue;
+	u32 timeoutPtr;
+};
+
+enum {
+	PSP_THREAD_ATTR_KERNEL = 0x00001000,
+	PSP_THREAD_ATTR_VFPU = 0x00004000,
+	PSP_THREAD_ATTR_SCRATCH_SRAM = 0x00008000, // Save/restore scratch as part of context???
+	PSP_THREAD_ATTR_NO_FILLSTACK = 0x00100000, // No filling of 0xff.
+	PSP_THREAD_ATTR_CLEAR_STACK = 0x00200000, // Clear thread stack when deleted.
+	PSP_THREAD_ATTR_LOW_STACK = 0x00400000, // Allocate stack from bottom not top.
+	PSP_THREAD_ATTR_USER = 0x80000000,
+	PSP_THREAD_ATTR_USBWLAN = 0xa0000000,
+	PSP_THREAD_ATTR_VSH = 0xc0000000,
+
+	// TODO: Support more, not even sure what all of these mean.
+	PSP_THREAD_ATTR_USER_MASK = 0xf8f060ff,
+	PSP_THREAD_ATTR_USER_ERASE = 0x78800000,
+	PSP_THREAD_ATTR_SUPPORTED = (PSP_THREAD_ATTR_KERNEL | PSP_THREAD_ATTR_VFPU | PSP_THREAD_ATTR_NO_FILLSTACK | PSP_THREAD_ATTR_CLEAR_STACK | PSP_THREAD_ATTR_LOW_STACK | PSP_THREAD_ATTR_USER)
+};
+
+enum ThreadStatus : u32 {
+	THREADSTATUS_RUNNING = 1,
+	THREADSTATUS_READY = 2,
+	THREADSTATUS_WAIT = 4,
+	THREADSTATUS_SUSPEND = 8,
+	THREADSTATUS_DORMANT = 16,
+	THREADSTATUS_DEAD = 32,
+
+	THREADSTATUS_WAITSUSPEND = THREADSTATUS_WAIT | THREADSTATUS_SUSPEND
+};
+const char *ThreadStatusToString(ThreadStatus status);
+
+class PSPThread : public KernelObject {
+public:
+	PSPThread() : debug(context) {}
+	const char *GetName() override { return nt.name; }
+	const char *GetTypeName() override { return GetStaticTypeName(); }
+	static const char *GetStaticTypeName() { return "Thread"; }
+	void GetQuickInfo(char *ptr, int size) override;
+
+	static u32 GetMissingErrorCode();
+	static int GetStaticIDType() { return SCE_KERNEL_TMID_Thread; }
+	int GetIDType() const override { return SCE_KERNEL_TMID_Thread; }
+
+	bool AllocateStack(u32 &stackSize);
+	bool FillStack();
+	void FreeStack();
+
+	bool PushExtendedStack(u32 size);
+	bool PopExtendedStack();
+
+	// Can't use a destructor since savestates will call that too.
+	void Cleanup();
+
+	BlockAllocator &StackAllocator();
+
+	void setReturnValue(u32 retval);
+	void setReturnValue(u64 retval);
+	void resumeFromWait();
+	bool isWaitingFor(WaitType type, int id) const;
+	int getWaitID(WaitType type) const;
+	ThreadWaitInfo getWaitInfo() const;
+
+	// Utils
+	inline bool isRunning() const { return (nt.status & THREADSTATUS_RUNNING) != 0; }
+	inline bool isStopped() const { return (nt.status & THREADSTATUS_DORMANT) != 0; }
+	inline bool isReady() const { return (nt.status & THREADSTATUS_READY) != 0; }
+	inline bool isWaiting() const { return (nt.status & THREADSTATUS_WAIT) != 0; }
+	inline bool isSuspended() const { return (nt.status & THREADSTATUS_SUSPEND) != 0; }
+
+	void DoState(PointerWrap &p) override;
+
+	NativeThread nt{};
+
+	ThreadWaitInfo waitInfo{};
+	SceUID moduleId = -1;
+	KernelThreadDebugInterface debug;
+
+	bool isProcessingCallbacks = false;
+	u32 currentMipscallId = -1;
+	SceUID currentCallbackId = -1;
+
+	PSPThreadContext context{};
+
+	std::vector<SceUID> callbacks;
+
+	// TODO: Should probably just be a vector.
+	std::list<u32> pendingMipsCalls;
+
+	struct StackInfo {
+		u32 start;
+		u32 end;
 	};
-	union {
-		float v[128];
-		u32 vi[128];
-	};
-	u32 vfpuCtrl[16];
+	// This is a stack of... stacks, since sceKernelExtendThreadStack() can recurse.
+	// These are stacks that aren't "active" right now, but will pop off once the func returns.
+	std::vector<StackInfo> pushedStacks;
 
-	union {
-		struct {
-			u32 pc;
+	StackInfo currentStack{};
 
-			u32 lo;
-			u32 hi;
-
-			u32 fcr31;
-			u32 fpcond;
-		};
-		u32 other[6];
-	};
+	// For thread end.
+	std::vector<SceUID> waitingThreads;
+	// Key is the callback id it was for, or if no callback, the thread id.
+	std::map<SceUID, u64> pausedWaits;
 };
 
 // Internal API, used by implementations of kernel functions
@@ -296,18 +422,6 @@ public:
 	int actionTypeID;
 };
 
-enum ThreadStatus
-{
-	THREADSTATUS_RUNNING = 1,
-	THREADSTATUS_READY   = 2,
-	THREADSTATUS_WAIT    = 4,
-	THREADSTATUS_SUSPEND = 8,
-	THREADSTATUS_DORMANT = 16,
-	THREADSTATUS_DEAD    = 32,
-
-	THREADSTATUS_WAITSUSPEND = THREADSTATUS_WAIT | THREADSTATUS_SUSPEND
-};
-
 void __KernelChangeThreadState(PSPThread *thread, ThreadStatus newStatus);
 
 typedef void (*ThreadCallback)(SceUID threadID);
@@ -317,7 +431,7 @@ struct DebugThreadInfo
 {
 	SceUID id;
 	char name[KERNELOBJECT_MAX_NAME_LENGTH+1];
-	u32 status;
+	ThreadStatus status;
 	u32 curPC;
 	u32 entrypoint;
 	u32 initialStack;

--- a/Core/HLE/sceKernelThread.h
+++ b/Core/HLE/sceKernelThread.h
@@ -115,7 +115,7 @@ enum WaitType : int
 	NUM_WAITTYPES
 };
 
-const char *getWaitTypeName(WaitType type);
+const char *WaitTypeToString(WaitType type);
 
 // Suspend wait and timeout while a thread enters a callback.
 typedef void (* WaitBeginCallbackFunc)(SceUID threadID, SceUID prevCallbackId);

--- a/Core/MIPS/MIPSDebugInterface.h
+++ b/Core/MIPS/MIPSDebugInterface.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <string>
-#include <cstdio>
+
 #include "Common/Math/expression_parser.h"
 #include "Core/MIPS/MIPS.h"
 #include "Core/Debugger/DebugInterface.h"

--- a/Core/MemMap.h
+++ b/Core/MemMap.h
@@ -406,6 +406,9 @@ inline const u8* GetPointerOrNull(const u32 address) {
 // Avoiding a global include for NotifyMemInfo.
 void PSPPointerNotifyRW(int rw, uint32_t ptr, uint32_t bytes, const char *tag, size_t tagLen);
 
+// TODO: These are actually quite annoying because they can't be followed in the MSVC debugger...
+// Need to find a solution for that. Can't just change the internal representation though, because
+// these can be present in PSP-native structs.
 template <typename T>
 struct PSPPointer
 {

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -25,7 +25,6 @@
 #include "Core/HLE/ErrorCodes.h"
 #include "Core/HLE/sceKernelMemory.h"
 #include "Core/HLE/sceKernelInterrupt.h"
-#include "Core/HLE/sceKernelThread.h"
 #include "Core/HLE/sceGe.h"
 #include "Core/Util/PPGeDraw.h"
 #include "Core/MemMapHelpers.h"
@@ -36,6 +35,8 @@
 #include "GPU/Debugger/Debugger.h"
 #include "GPU/Debugger/Record.h"
 #include "GPU/Debugger/Stepping.h"
+
+bool __KernelIsDispatchEnabled();
 
 void GPUCommon::Flush() {
 	drawEngineCommon_->Flush();

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -411,7 +411,7 @@ void DrawThreadView(ImConfig &cfg, ImControl &control) {
 			ImGui::TableNextColumn();
 			ImGui::TextUnformatted(ThreadStatusToString(thread.status));
 			ImGui::TableNextColumn();
-			ImGui::TextUnformatted(getWaitTypeName(thread.waitType));
+			ImGui::TextUnformatted(WaitTypeToString(thread.waitType));
 			ImGui::TableNextColumn();
 			char temp[64];
 			WaitIDToString(thread.waitType, thread.waitID, temp, sizeof(temp));

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -306,21 +306,6 @@ static void DrawVFPU(ImConfig &config, ImControl &control, const MIPSDebugInterf
 	ImGui::End();
 }
 
-static const char *ThreadStatusToString(u32 status) {
-	switch (status) {
-	case THREADSTATUS_RUNNING: return "Running";
-	case THREADSTATUS_READY: return "Ready";
-	case THREADSTATUS_WAIT: return "Wait";
-	case THREADSTATUS_SUSPEND: return "Suspended";
-	case THREADSTATUS_DORMANT: return "Dormant";
-	case THREADSTATUS_DEAD: return "Dead";
-	case THREADSTATUS_WAITSUSPEND: return "WaitSuspended";
-	default:
-		break;
-	}
-	return "(unk)";
-}
-
 void WaitIDToString(WaitType waitType, SceUID waitID, char *buffer, size_t bufSize) {
 	switch (waitType) {
 	case WAITTYPE_AUDIOCHANNEL:

--- a/Windows/Debugger/Debugger_Lists.cpp
+++ b/Windows/Debugger/Debugger_Lists.cpp
@@ -217,7 +217,7 @@ void CtrlThreadList::GetColumnText(wchar_t* dest, size_t destSize, int row, int 
 		}
 		break;
 	case TL_WAITTYPE:
-		wcscpy(dest, ConvertUTF8ToWString(getWaitTypeName(threads[row].waitType)).c_str());
+		wcscpy(dest, ConvertUTF8ToWString(WaitTypeToString(threads[row].waitType)).c_str());
 		break;
 	}
 }


### PR DESCRIPTION
Previously, these structs were hidden in their respective cpp files, so it was hard to display them in the debugger. This will be necessary for some features I want to add to the ImDebugger (inspect imports/exports of modules, etc).

That in turn will be needed for a planned investigation of trying to load certain modules supplied by games natively instead of HLE:ing them, now that we are able to decrypt any module (since a few years). Prime candidates for that is sceFont, scePsmf, scePsmfPlayer, sceJpeg, and possibly even sceMpeg in the long run, although will need to reverse engineer the low-level VideoCodec library for that.