### PR TITLE
Minor module loading code cleanup

### DIFF
--- a/Common/StringUtils.cpp
+++ b/Common/StringUtils.cpp
@@ -250,6 +250,15 @@ std::string_view StripPrefix(std::string_view prefix, std::string_view s) {
 	}
 }
 
+std::string_view KeepAfterLast(std::string_view s, char c) {
+	size_t pos = s.rfind(c);
+	if (pos != std::string_view::npos) {
+		return s.substr(pos + 1);
+	} else {
+		return s;
+	}
+}
+
 void SkipSpace(const char **ptr) {
 	while (**ptr && isspace(**ptr)) {
 		(*ptr)++;

--- a/Common/StringUtils.h
+++ b/Common/StringUtils.h
@@ -94,6 +94,8 @@ std::string StringFromInt(int value);
 std::string StripSpaces(const std::string &s);
 std::string StripQuotes(const std::string &s);
 
+std::string_view KeepAfterLast(std::string_view s, char c);
+
 std::string_view StripSpaces(std::string_view s);
 std::string_view StripQuotes(std::string_view s);
 

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -97,15 +97,16 @@ struct Syscall {
 #define RETURN64(n) {u64 RETURN64_tmp = n; currentMIPS->r[MIPS_REG_V0] = RETURN64_tmp & 0xFFFFFFFF; currentMIPS->r[MIPS_REG_V1] = RETURN64_tmp >> 32;}
 #define RETURNF(fl) currentMIPS->f[0] = fl
 
-const char *GetFuncName(std::string_view module, u32 nib);
-const char *GetFuncName(int module, int func);
-const HLEFunction *GetFunc(std::string_view module, u32 nib);
-int GetFuncIndex(int moduleIndex, u32 nib);
-int GetModuleIndex(std::string_view modulename);
+const char *GetHLEFuncName(std::string_view module, u32 nib);
+const char *GetHLEFuncName(int module, int func);
+const HLEFunction *GetHLEFunc(std::string_view module, u32 nib);
+int GetHLEFuncIndexByNib(int moduleIndex, u32 nib);
+int GetHLEModuleIndex(std::string_view modulename);
+u32 GetNibByName(std::string_view module, std::string_view function);
 
-void RegisterModule(std::string_view name, int numFunctions, const HLEFunction *funcTable);
-int GetNumRegisteredModules();
-const HLEModule *GetModuleByIndex(int index);
+void RegisterHLEModule(std::string_view name, int numFunctions, const HLEFunction *funcTable);
+int GetNumRegisteredHLEModules();
+const HLEModule *GetHLEModuleByIndex(int index);
 
 // Run the current thread's callbacks after the syscall finishes.
 void hleCheckCurrentCallbacks();
@@ -158,7 +159,6 @@ inline s64 hleDelayResult(s64 result, const char *reason, int usec) {
 void HLEInit();
 void HLEDoState(PointerWrap &p);
 void HLEShutdown();
-u32 GetNibByName(std::string_view module, std::string_view function);
 u32 GetSyscallOp(std::string_view module, u32 nib);
 bool FuncImportIsSyscall(std::string_view module, u32 nib);
 bool WriteSyscall(std::string_view module, u32 nib, u32 address);

--- a/Core/HLE/HLETables.cpp
+++ b/Core/HLE/HLETables.cpp
@@ -288,13 +288,13 @@ void RegisterAllModules() {
 	Register_sceHeap();
 
 	for (int i = 0; i < numModules; i++) {
-		RegisterModule(moduleList[i].name, moduleList[i].numFunctions, moduleList[i].funcTable);
+		RegisterHLEModule(moduleList[i].name, moduleList[i].numFunctions, moduleList[i].funcTable);
 	}
 
 	// IMPORTANT: New modules have to be added at the end, or they will break savestates.
 
 	Register_StdioForKernel();
-	RegisterModule("LoadCoreForKernel", ARRAY_SIZE(LoadCoreForKernel), LoadCoreForKernel);
+	RegisterHLEModule("LoadCoreForKernel", ARRAY_SIZE(LoadCoreForKernel), LoadCoreForKernel);
 	Register_IoFileMgrForKernel();
 	Register_LoadExecForKernel();
 	Register_SysMemForKernel();

--- a/Core/HLE/KUBridge.cpp
+++ b/Core/HLE/KUBridge.cpp
@@ -43,5 +43,5 @@ const HLEFunction KUBridge[] =
 };
 
 void Register_KUBridge() {
-	RegisterModule("KUBridge", ARRAY_SIZE(KUBridge), KUBridge);
+	RegisterHLEModule("KUBridge", ARRAY_SIZE(KUBridge), KUBridge);
 }

--- a/Core/HLE/sceAac.cpp
+++ b/Core/HLE/sceAac.cpp
@@ -219,5 +219,5 @@ const HLEFunction sceAac[] = {
 };
 
 void Register_sceAac() {
-	RegisterModule("sceAac", ARRAY_SIZE(sceAac), sceAac);
+	RegisterHLEModule("sceAac", ARRAY_SIZE(sceAac), sceAac);
 }

--- a/Core/HLE/sceAdler.cpp
+++ b/Core/HLE/sceAdler.cpp
@@ -44,5 +44,5 @@ const HLEFunction sceAdler[] = {
 };
 
 void Register_sceAdler() {
-	RegisterModule("sceAdler", ARRAY_SIZE(sceAdler), sceAdler);
+	RegisterHLEModule("sceAdler", ARRAY_SIZE(sceAdler), sceAdler);
 }

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1200,6 +1200,6 @@ const HLEFunction sceAtrac3plus[] = {
 
 void Register_sceAtrac3plus() {
 	// Two names
-	RegisterModule("sceATRAC3plus_Library", ARRAY_SIZE(sceAtrac3plus), sceAtrac3plus);
-	RegisterModule("sceAtrac3plus", ARRAY_SIZE(sceAtrac3plus), sceAtrac3plus);
+	RegisterHLEModule("sceATRAC3plus_Library", ARRAY_SIZE(sceAtrac3plus), sceAtrac3plus);
+	RegisterHLEModule("sceAtrac3plus", ARRAY_SIZE(sceAtrac3plus), sceAtrac3plus);
 }

--- a/Core/HLE/sceAudio.cpp
+++ b/Core/HLE/sceAudio.cpp
@@ -549,5 +549,5 @@ const HLEFunction sceAudio[] =
 
 void Register_sceAudio()
 {
-	RegisterModule("sceAudio", ARRAY_SIZE(sceAudio), sceAudio);
+	RegisterHLEModule("sceAudio", ARRAY_SIZE(sceAudio), sceAudio);
 }

--- a/Core/HLE/sceAudioRouting.cpp
+++ b/Core/HLE/sceAudioRouting.cpp
@@ -61,5 +61,5 @@ const HLEFunction sceAudioRouting[] =
 
 void Register_sceAudioRouting()
 {
-	RegisterModule("sceAudioRouting", ARRAY_SIZE(sceAudioRouting), sceAudioRouting);
+	RegisterHLEModule("sceAudioRouting", ARRAY_SIZE(sceAudioRouting), sceAudioRouting);
 }

--- a/Core/HLE/sceAudiocodec.cpp
+++ b/Core/HLE/sceAudiocodec.cpp
@@ -174,7 +174,7 @@ const HLEFunction sceAudiocodec[] = {
 };
 
 void Register_sceAudiocodec() {
-	RegisterModule("sceAudiocodec", ARRAY_SIZE(sceAudiocodec), sceAudiocodec);
+	RegisterHLEModule("sceAudiocodec", ARRAY_SIZE(sceAudiocodec), sceAudiocodec);
 }
 
 void __sceAudiocodecDoState(PointerWrap &p){

--- a/Core/HLE/sceCcc.cpp
+++ b/Core/HLE/sceCcc.cpp
@@ -567,5 +567,5 @@ const HLEFunction sceCcc[] =
 
 void Register_sceCcc()
 {
-	RegisterModule("sceCcc", ARRAY_SIZE(sceCcc), sceCcc);
+	RegisterHLEModule("sceCcc", ARRAY_SIZE(sceCcc), sceCcc);
 }

--- a/Core/HLE/sceChnnlsv.cpp
+++ b/Core/HLE/sceChnnlsv.cpp
@@ -525,6 +525,6 @@ const HLEFunction sceChnnlsv[] =
 
 void Register_sceChnnlsv()
 {
-	RegisterModule("sceChnnlsv", ARRAY_SIZE(sceChnnlsv), sceChnnlsv);
+	RegisterHLEModule("sceChnnlsv", ARRAY_SIZE(sceChnnlsv), sceChnnlsv);
 	kirk_init();
 }

--- a/Core/HLE/sceCtrl.cpp
+++ b/Core/HLE/sceCtrl.cpp
@@ -591,12 +591,12 @@ static const HLEFunction sceCtrl[] =
 
 void Register_sceCtrl()
 {
-	RegisterModule("sceCtrl", ARRAY_SIZE(sceCtrl), sceCtrl);
+	RegisterHLEModule("sceCtrl", ARRAY_SIZE(sceCtrl), sceCtrl);
 }
 
 void Register_sceCtrl_driver()
 {
-	RegisterModule("sceCtrl_driver", ARRAY_SIZE(sceCtrl), sceCtrl);
+	RegisterHLEModule("sceCtrl_driver", ARRAY_SIZE(sceCtrl), sceCtrl);
 }
 
 u16 sceCtrlGetRightVibration() {

--- a/Core/HLE/sceDeflt.cpp
+++ b/Core/HLE/sceDeflt.cpp
@@ -96,5 +96,5 @@ const HLEFunction sceDeflt[] = {
 };
 
 void Register_sceDeflt() {
-	RegisterModule("sceDeflt", ARRAY_SIZE(sceDeflt), sceDeflt);
+	RegisterHLEModule("sceDeflt", ARRAY_SIZE(sceDeflt), sceDeflt);
 }

--- a/Core/HLE/sceDisplay.cpp
+++ b/Core/HLE/sceDisplay.cpp
@@ -1132,11 +1132,11 @@ const HLEFunction sceDisplay[] = {
 };
 
 void Register_sceDisplay() {
-	RegisterModule("sceDisplay", ARRAY_SIZE(sceDisplay), sceDisplay);
+	RegisterHLEModule("sceDisplay", ARRAY_SIZE(sceDisplay), sceDisplay);
 }
 
 void Register_sceDisplay_driver() {
-	RegisterModule("sceDisplay_driver", ARRAY_SIZE(sceDisplay), sceDisplay);
+	RegisterHLEModule("sceDisplay_driver", ARRAY_SIZE(sceDisplay), sceDisplay);
 }
 
 static void __DisplaySetFramerate(void) {

--- a/Core/HLE/sceDmac.cpp
+++ b/Core/HLE/sceDmac.cpp
@@ -121,5 +121,5 @@ const HLEFunction sceDmac[] = {
 };
 
 void Register_sceDmac() {
-	RegisterModule("sceDmac", ARRAY_SIZE(sceDmac), sceDmac);
+	RegisterHLEModule("sceDmac", ARRAY_SIZE(sceDmac), sceDmac);
 }

--- a/Core/HLE/sceFont.cpp
+++ b/Core/HLE/sceFont.cpp
@@ -1669,9 +1669,9 @@ const HLEFunction sceLibFont[] = {
 };
 
 void Register_sceFont() {
-	RegisterModule("sceLibFont", ARRAY_SIZE(sceLibFont), sceLibFont);
+	RegisterHLEModule("sceLibFont", ARRAY_SIZE(sceLibFont), sceLibFont);
 }
 
 void Register_sceLibFttt() {
-	RegisterModule("sceLibFttt", ARRAY_SIZE(sceLibFont), sceLibFont);
+	RegisterHLEModule("sceLibFttt", ARRAY_SIZE(sceLibFont), sceLibFont);
 }

--- a/Core/HLE/sceG729.cpp
+++ b/Core/HLE/sceG729.cpp
@@ -36,5 +36,5 @@ const HLEFunction sceG729[] =
 
 void Register_sceG729()
 {
-	RegisterModule("sceG729", ARRAY_SIZE(sceG729), sceG729);
+	RegisterHLEModule("sceG729", ARRAY_SIZE(sceG729), sceG729);
 }

--- a/Core/HLE/sceGameUpdate.cpp
+++ b/Core/HLE/sceGameUpdate.cpp
@@ -53,5 +53,5 @@ const HLEFunction sceGameUpdate[] =
 
 void Register_sceGameUpdate()
 {
-	RegisterModule("sceGameUpdate", ARRAY_SIZE(sceGameUpdate), sceGameUpdate);
+	RegisterHLEModule("sceGameUpdate", ARRAY_SIZE(sceGameUpdate), sceGameUpdate);
 }

--- a/Core/HLE/sceGe.cpp
+++ b/Core/HLE/sceGe.cpp
@@ -643,5 +643,5 @@ const HLEFunction sceGe_user[] = {
 };
 
 void Register_sceGe_user() {
-	RegisterModule("sceGe_user", ARRAY_SIZE(sceGe_user), sceGe_user);
+	RegisterHLEModule("sceGe_user", ARRAY_SIZE(sceGe_user), sceGe_user);
 }

--- a/Core/HLE/sceHeap.cpp
+++ b/Core/HLE/sceHeap.cpp
@@ -250,5 +250,5 @@ static const HLEFunction sceHeap[] =
 
 void Register_sceHeap()
 {
-	RegisterModule("sceHeap", ARRAY_SIZE(sceHeap), sceHeap);
+	RegisterHLEModule("sceHeap", ARRAY_SIZE(sceHeap), sceHeap);
 }

--- a/Core/HLE/sceHprm.cpp
+++ b/Core/HLE/sceHprm.cpp
@@ -72,5 +72,5 @@ const HLEFunction sceHprm[] =
 
 void Register_sceHprm()
 {
-	RegisterModule("sceHprm", ARRAY_SIZE(sceHprm), sceHprm);
+	RegisterHLEModule("sceHprm", ARRAY_SIZE(sceHprm), sceHprm);
 }

--- a/Core/HLE/sceHttp.cpp
+++ b/Core/HLE/sceHttp.cpp
@@ -874,5 +874,5 @@ const HLEFunction sceHttp[] = {
 
 void Register_sceHttp()
 {
-	RegisterModule("sceHttp",ARRAY_SIZE(sceHttp),sceHttp);
+	RegisterHLEModule("sceHttp",ARRAY_SIZE(sceHttp),sceHttp);
 }

--- a/Core/HLE/sceImpose.cpp
+++ b/Core/HLE/sceImpose.cpp
@@ -125,5 +125,5 @@ const HLEFunction sceImpose[] = {
 };
 
 void Register_sceImpose() {
-	RegisterModule("sceImpose", ARRAY_SIZE(sceImpose), sceImpose);
+	RegisterHLEModule("sceImpose", ARRAY_SIZE(sceImpose), sceImpose);
 }

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -3013,7 +3013,7 @@ const HLEFunction IoFileMgrForUser[] = {
 };
 
 void Register_IoFileMgrForUser() {
-	RegisterModule("IoFileMgrForUser", ARRAY_SIZE(IoFileMgrForUser), IoFileMgrForUser);
+	RegisterHLEModule("IoFileMgrForUser", ARRAY_SIZE(IoFileMgrForUser), IoFileMgrForUser);
 }
 
 const HLEFunction IoFileMgrForKernel[] = {
@@ -3053,7 +3053,7 @@ const HLEFunction IoFileMgrForKernel[] = {
 };
 
 void Register_IoFileMgrForKernel() {
-	RegisterModule("IoFileMgrForKernel", ARRAY_SIZE(IoFileMgrForKernel), IoFileMgrForKernel);
+	RegisterHLEModule("IoFileMgrForKernel", ARRAY_SIZE(IoFileMgrForKernel), IoFileMgrForKernel);
 }
 
 const HLEFunction StdioForUser[] = {
@@ -3071,7 +3071,7 @@ const HLEFunction StdioForUser[] = {
 };
 
 void Register_StdioForUser() {
-	RegisterModule("StdioForUser", ARRAY_SIZE(StdioForUser), StdioForUser);
+	RegisterHLEModule("StdioForUser", ARRAY_SIZE(StdioForUser), StdioForUser);
 }
 
 const HLEFunction StdioForKernel[] = {
@@ -3086,5 +3086,5 @@ const HLEFunction StdioForKernel[] = {
 };
 
 void Register_StdioForKernel() {
-	RegisterModule("StdioForKernel", ARRAY_SIZE(StdioForKernel), StdioForKernel);
+	RegisterHLEModule("StdioForKernel", ARRAY_SIZE(StdioForKernel), StdioForKernel);
 }

--- a/Core/HLE/sceJpeg.cpp
+++ b/Core/HLE/sceJpeg.cpp
@@ -655,5 +655,5 @@ const HLEFunction sceJpeg[] =
 };
 
 void Register_sceJpeg() {
-	RegisterModule("sceJpeg", ARRAY_SIZE(sceJpeg), sceJpeg);
+	RegisterHLEModule("sceJpeg", ARRAY_SIZE(sceJpeg), sceJpeg);
 }

--- a/Core/HLE/sceKernel.cpp
+++ b/Core/HLE/sceKernel.cpp
@@ -946,7 +946,7 @@ const HLEFunction ThreadManForKernel[] =
 
 void Register_ThreadManForUser()
 {
-	RegisterModule("ThreadManForUser", ARRAY_SIZE(ThreadManForUser), ThreadManForUser);
+	RegisterHLEModule("ThreadManForUser", ARRAY_SIZE(ThreadManForUser), ThreadManForUser);
 }
 
 
@@ -962,7 +962,7 @@ const HLEFunction LoadExecForUser[] =
 
 void Register_LoadExecForUser()
 {
-	RegisterModule("LoadExecForUser", ARRAY_SIZE(LoadExecForUser), LoadExecForUser);
+	RegisterHLEModule("LoadExecForUser", ARRAY_SIZE(LoadExecForUser), LoadExecForUser);
 }
  
 const HLEFunction LoadExecForKernel[] =
@@ -975,7 +975,7 @@ const HLEFunction LoadExecForKernel[] =
  
 void Register_LoadExecForKernel()
 {
-	RegisterModule("LoadExecForKernel", ARRAY_SIZE(LoadExecForKernel), LoadExecForKernel);
+	RegisterHLEModule("LoadExecForKernel", ARRAY_SIZE(LoadExecForKernel), LoadExecForKernel);
 }
 
 const HLEFunction ExceptionManagerForKernel[] =
@@ -992,7 +992,7 @@ const HLEFunction ExceptionManagerForKernel[] =
 
 void Register_ExceptionManagerForKernel()
 {
-	RegisterModule("ExceptionManagerForKernel", ARRAY_SIZE(ExceptionManagerForKernel), ExceptionManagerForKernel);
+	RegisterHLEModule("ExceptionManagerForKernel", ARRAY_SIZE(ExceptionManagerForKernel), ExceptionManagerForKernel);
 }
 
 // Seen in some homebrew
@@ -1021,12 +1021,12 @@ const HLEFunction UtilsForKernel[] = {
 
 void Register_UtilsForKernel()
 {
-	RegisterModule("UtilsForKernel", ARRAY_SIZE(UtilsForKernel), UtilsForKernel);
+	RegisterHLEModule("UtilsForKernel", ARRAY_SIZE(UtilsForKernel), UtilsForKernel);
 }
 
 void Register_ThreadManForKernel()
 {
-	RegisterModule("ThreadManForKernel", ARRAY_SIZE(ThreadManForKernel), ThreadManForKernel);
+	RegisterHLEModule("ThreadManForKernel", ARRAY_SIZE(ThreadManForKernel), ThreadManForKernel);
 }
 
 const char *KernelErrorToString(u32 err) {

--- a/Core/HLE/sceKernelHeap.cpp
+++ b/Core/HLE/sceKernelHeap.cpp
@@ -174,5 +174,5 @@ const HLEFunction SysMemForKernel[] = {
 };
 
 void Register_SysMemForKernel() {
-	RegisterModule("SysMemForKernel", ARRAY_SIZE(SysMemForKernel), SysMemForKernel);
+	RegisterHLEModule("SysMemForKernel", ARRAY_SIZE(SysMemForKernel), SysMemForKernel);
 }

--- a/Core/HLE/sceKernelInterrupt.cpp
+++ b/Core/HLE/sceKernelInterrupt.cpp
@@ -1005,12 +1005,12 @@ const HLEFunction SysclibForKernel[] =
 
 void Register_Kernel_Library()
 {
-	RegisterModule("Kernel_Library", ARRAY_SIZE(Kernel_Library), Kernel_Library);
+	RegisterHLEModule("Kernel_Library", ARRAY_SIZE(Kernel_Library), Kernel_Library);
 }
 
 void Register_SysclibForKernel()
 {
-	RegisterModule("SysclibForKernel", ARRAY_SIZE(SysclibForKernel), SysclibForKernel);
+	RegisterHLEModule("SysclibForKernel", ARRAY_SIZE(SysclibForKernel), SysclibForKernel);
 }
 
 const HLEFunction InterruptManager[] =
@@ -1029,7 +1029,7 @@ const HLEFunction InterruptManager[] =
 
 void Register_InterruptManager()
 {
-	RegisterModule("InterruptManager", ARRAY_SIZE(InterruptManager), InterruptManager);
+	RegisterHLEModule("InterruptManager", ARRAY_SIZE(InterruptManager), InterruptManager);
 }
 
 
@@ -1057,5 +1057,5 @@ const HLEFunction InterruptManagerForKernel[] =
 
 void Register_InterruptManagerForKernel()
 {
-	RegisterModule("InterruptManagerForKernel", ARRAY_SIZE(InterruptManagerForKernel), InterruptManagerForKernel);
+	RegisterHLEModule("InterruptManagerForKernel", ARRAY_SIZE(InterruptManagerForKernel), InterruptManagerForKernel);
 }

--- a/Core/HLE/sceKernelMemory.cpp
+++ b/Core/HLE/sceKernelMemory.cpp
@@ -2118,5 +2118,5 @@ const HLEFunction SysMemUserForUser[] = {
 };
 
 void Register_SysMemUserForUser() {
-	RegisterModule("SysMemUserForUser", ARRAY_SIZE(SysMemUserForUser), SysMemUserForUser);
+	RegisterHLEModule("SysMemUserForUser", ARRAY_SIZE(SysMemUserForUser), SysMemUserForUser);
 }

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -286,11 +286,11 @@ void PSPModule::ImportFunc(const FuncSymbolImport &func, bool reimporting) {
 		return;
 	}
 
-	DEBUG_LOG(Log::Loader, "Importing %s : %08x", GetFuncName(func.moduleName, func.nid), func.stubAddr);
+	DEBUG_LOG(Log::Loader, "Importing %s : %08x", GetHLEFuncName(func.moduleName, func.nid), func.stubAddr);
 
 	// Add the symbol to the symbol map for debugging.
 	char temp[256];
-	snprintf(temp, sizeof(temp), "zz_%s", GetFuncName(func.moduleName, func.nid));
+	snprintf(temp, sizeof(temp), "zz_%s", GetHLEFuncName(func.moduleName, func.nid));
 	g_symbolMap->AddFunction(temp, func.stubAddr, 8);
 
 	// Keep track and actually hook it up if possible.
@@ -644,7 +644,7 @@ void ImportFuncSymbol(const FuncSymbolImport &func, bool reimporting, const char
 	// TODO: Or not?
 	if (FuncImportIsSyscall(func.moduleName, func.nid)) {
 		if (reimporting && Memory::Read_Instruction(func.stubAddr + 4) != GetSyscallOp(func.moduleName, func.nid)) {
-			WARN_LOG(Log::Loader, "Reimporting updated syscall %s", GetFuncName(func.moduleName, func.nid));
+			WARN_LOG(Log::Loader, "Reimporting updated syscall %s", GetHLEFuncName(func.moduleName, func.nid));
 		}
 		WriteSyscall(func.moduleName, func.nid, func.stubAddr);
 		currentMIPS->InvalidateICache(func.stubAddr, 8);
@@ -677,15 +677,15 @@ void ImportFuncSymbol(const FuncSymbolImport &func, bool reimporting, const char
 		}
 	}
 
-	// It hasn't been exported yet, but hopefully it will later.
-	bool isKnownModule = GetModuleIndex(func.moduleName) != -1;
-	if (isKnownModule) {
+	// It hasn't been exported yet, but hopefully it will later. Check if we know about it through HLE.
+	const bool isKnownHLEModule = GetHLEModuleIndex(func.moduleName) != -1;
+	if (isKnownHLEModule) {
 		// We used to report this, but I don't think it's very interesting anymore.
-		WARN_LOG(Log::Loader, "Unknown syscall from known module '%s': 0x%08x (import for '%s')", func.moduleName, func.nid, importingModule);
+		WARN_LOG(Log::Loader, "Unknown syscall from known HLE module '%s': 0x%08x (import for '%s')", func.moduleName, func.nid, importingModule);
 	} else {
 		INFO_LOG(Log::Loader, "Function (%s,%08x) unresolved in '%s', storing for later resolving", func.moduleName, func.nid, importingModule);
 	}
-	if (isKnownModule || !reimporting) {
+	if (isKnownHLEModule || !reimporting) {
 		WriteFuncMissingStub(func.stubAddr, func.nid);
 		currentMIPS->InvalidateICache(func.stubAddr, 8);
 	}
@@ -2607,9 +2607,9 @@ const HLEFunction ModuleMgrForKernel[] = {
 };
 
 void Register_ModuleMgrForUser() {
-	RegisterModule("ModuleMgrForUser", ARRAY_SIZE(ModuleMgrForUser), ModuleMgrForUser);
+	RegisterHLEModule("ModuleMgrForUser", ARRAY_SIZE(ModuleMgrForUser), ModuleMgrForUser);
 }
 
 void Register_ModuleMgrForKernel() {
-	RegisterModule("ModuleMgrForKernel", ARRAY_SIZE(ModuleMgrForKernel), ModuleMgrForKernel);		
+	RegisterHLEModule("ModuleMgrForKernel", ARRAY_SIZE(ModuleMgrForKernel), ModuleMgrForKernel);		
 }

--- a/Core/HLE/sceKernelSemaphore.cpp
+++ b/Core/HLE/sceKernelSemaphore.cpp
@@ -427,5 +427,5 @@ const HLEFunction semaphore[] = {
 };
 
 void Register_semaphore() {
-	RegisterModule("semaphore", ARRAY_SIZE(semaphore), semaphore);
+	RegisterHLEModule("semaphore", ARRAY_SIZE(semaphore), semaphore);
 }

--- a/Core/HLE/sceMd5.cpp
+++ b/Core/HLE/sceMd5.cpp
@@ -185,5 +185,5 @@ const HLEFunction sceMd5[] = {
 };
 
 void Register_sceMd5() {
-	RegisterModule("sceMd5", ARRAY_SIZE(sceMd5), sceMd5);
+	RegisterHLEModule("sceMd5", ARRAY_SIZE(sceMd5), sceMd5);
 }

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -782,5 +782,5 @@ const HLEFunction sceMp3[] = {
 };
 
 void Register_sceMp3() {
-	RegisterModule("sceMp3", ARRAY_SIZE(sceMp3), sceMp3);
+	RegisterHLEModule("sceMp3", ARRAY_SIZE(sceMp3), sceMp3);
 }

--- a/Core/HLE/sceMp4.cpp
+++ b/Core/HLE/sceMp4.cpp
@@ -185,9 +185,9 @@ const HLEFunction mp4msv[] = {
 };
 
 void Register_sceMp4() {
-	RegisterModule("sceMp4", ARRAY_SIZE(sceMp4), sceMp4);
+	RegisterHLEModule("sceMp4", ARRAY_SIZE(sceMp4), sceMp4);
 }
 
 void Register_mp4msv() {
-	RegisterModule("mp4msv", ARRAY_SIZE(mp4msv), mp4msv);
+	RegisterHLEModule("mp4msv", ARRAY_SIZE(mp4msv), mp4msv);
 }

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -2318,7 +2318,7 @@ const HLEFunction sceMpeg[] =
 
 void Register_sceMpeg()
 {
-	RegisterModule("sceMpeg", ARRAY_SIZE(sceMpeg), sceMpeg);
+	RegisterHLEModule("sceMpeg", ARRAY_SIZE(sceMpeg), sceMpeg);
 }
 
 // This function is currently only been used for PMP videos
@@ -2354,5 +2354,5 @@ const HLEFunction sceMpegbase[] =
 
 void Register_sceMpegbase()
 {
-	RegisterModule("sceMpegbase", ARRAY_SIZE(sceMpegbase), sceMpegbase);
+	RegisterHLEModule("sceMpegbase", ARRAY_SIZE(sceMpegbase), sceMpegbase);
 };

--- a/Core/HLE/sceMt19937.cpp
+++ b/Core/HLE/sceMt19937.cpp
@@ -56,5 +56,5 @@ const HLEFunction sceMt19937[] =
 
 void Register_sceMt19937()
 {
-	RegisterModule("sceMt19937", ARRAY_SIZE(sceMt19937), sceMt19937);
+	RegisterHLEModule("sceMt19937", ARRAY_SIZE(sceMt19937), sceMt19937);
 }

--- a/Core/HLE/sceNet.cpp
+++ b/Core/HLE/sceNet.cpp
@@ -1720,21 +1720,21 @@ const HLEFunction sceNetIfhandle[] = {
 };
 
 void Register_sceNet() {
-	RegisterModule("sceNet", ARRAY_SIZE(sceNet), sceNet);
+	RegisterHLEModule("sceNet", ARRAY_SIZE(sceNet), sceNet);
 }
 
 void Register_sceNetApctl() {
-	RegisterModule("sceNetApctl", ARRAY_SIZE(sceNetApctl), sceNetApctl);
+	RegisterHLEModule("sceNetApctl", ARRAY_SIZE(sceNetApctl), sceNetApctl);
 }
 
 void Register_sceWlanDrv() {
-	RegisterModule("sceWlanDrv", ARRAY_SIZE(sceWlanDrv), sceWlanDrv);
+	RegisterHLEModule("sceWlanDrv", ARRAY_SIZE(sceWlanDrv), sceWlanDrv);
 }
 
 void Register_sceNetUpnp() {
-	RegisterModule("sceNetUpnp", ARRAY_SIZE(sceNetUpnp), sceNetUpnp);
+	RegisterHLEModule("sceNetUpnp", ARRAY_SIZE(sceNetUpnp), sceNetUpnp);
 }
 
 void Register_sceNetIfhandle() {
-	RegisterModule("sceNetIfhandle", ARRAY_SIZE(sceNetIfhandle), sceNetIfhandle);
+	RegisterHLEModule("sceNetIfhandle", ARRAY_SIZE(sceNetIfhandle), sceNetIfhandle);
 }

--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -5235,13 +5235,13 @@ const HLEFunction sceNetAdhocDiscover[] = {
 };
 
 void Register_sceNetAdhoc() {
-	RegisterModule("sceNetAdhoc", ARRAY_SIZE(sceNetAdhoc), sceNetAdhoc);
+	RegisterHLEModule("sceNetAdhoc", ARRAY_SIZE(sceNetAdhoc), sceNetAdhoc);
 }
 
 void Register_sceNetAdhocDiscover() {
-	RegisterModule("sceNetAdhocDiscover", ARRAY_SIZE(sceNetAdhocDiscover), sceNetAdhocDiscover);
+	RegisterHLEModule("sceNetAdhocDiscover", ARRAY_SIZE(sceNetAdhocDiscover), sceNetAdhocDiscover);
 }
 
 void Register_sceNetAdhocctl() {
-	RegisterModule("sceNetAdhocctl", ARRAY_SIZE(sceNetAdhocctl), sceNetAdhocctl);
+	RegisterHLEModule("sceNetAdhocctl", ARRAY_SIZE(sceNetAdhocctl), sceNetAdhocctl);
 }

--- a/Core/HLE/sceNetAdhocMatching.cpp
+++ b/Core/HLE/sceNetAdhocMatching.cpp
@@ -2677,7 +2677,7 @@ const HLEFunction sceNetAdhocMatching[] = {
 
 
 void Register_sceNetAdhocMatching() {
-	RegisterModule("sceNetAdhocMatching", ARRAY_SIZE(sceNetAdhocMatching), sceNetAdhocMatching);
+	RegisterHLEModule("sceNetAdhocMatching", ARRAY_SIZE(sceNetAdhocMatching), sceNetAdhocMatching);
 }
 
 void __NetAdhocMatchingInit() {

--- a/Core/HLE/sceNetInet.cpp
+++ b/Core/HLE/sceNetInet.cpp
@@ -1205,5 +1205,5 @@ const HLEFunction sceNetInet[] = {
 };
 
 void Register_sceNetInet() {
-	RegisterModule("sceNetInet", std::size(sceNetInet), sceNetInet);
+	RegisterHLEModule("sceNetInet", std::size(sceNetInet), sceNetInet);
 }

--- a/Core/HLE/sceNetResolver.cpp
+++ b/Core/HLE/sceNetResolver.cpp
@@ -294,5 +294,5 @@ const HLEFunction sceNetResolver[] = {
 };
 
 void Register_sceNetResolver() {
-	RegisterModule("sceNetResolver", ARRAY_SIZE(sceNetResolver), sceNetResolver);
+	RegisterHLEModule("sceNetResolver", ARRAY_SIZE(sceNetResolver), sceNetResolver);
 }

--- a/Core/HLE/sceNet_lib.cpp
+++ b/Core/HLE/sceNet_lib.cpp
@@ -133,5 +133,5 @@ const HLEFunction sceNet_lib[] = {
 
 
 void Register_sceNet_lib() {
-	RegisterModule("sceNet_lib", ARRAY_SIZE(sceNet_lib), sceNet_lib);
+	RegisterHLEModule("sceNet_lib", ARRAY_SIZE(sceNet_lib), sceNet_lib);
 }

--- a/Core/HLE/sceNp.cpp
+++ b/Core/HLE/sceNp.cpp
@@ -307,7 +307,7 @@ const HLEFunction sceNp[] = {
 
 void Register_sceNp()
 {
-	RegisterModule("sceNp", ARRAY_SIZE(sceNp), sceNp);
+	RegisterHLEModule("sceNp", ARRAY_SIZE(sceNp), sceNp);
 }
 
 static int sceNpAuthTerm()
@@ -552,7 +552,7 @@ const HLEFunction sceNpAuth[] = {
 
 void Register_sceNpAuth()
 {
-	RegisterModule("sceNpAuth", ARRAY_SIZE(sceNpAuth), sceNpAuth);
+	RegisterHLEModule("sceNpAuth", ARRAY_SIZE(sceNpAuth), sceNpAuth);
 }
 
 static int sceNpServiceTerm()
@@ -637,7 +637,7 @@ const HLEFunction sceNpService[] = {
 
 void Register_sceNpService()
 {
-	RegisterModule("sceNpService", ARRAY_SIZE(sceNpService), sceNpService);
+	RegisterHLEModule("sceNpService", ARRAY_SIZE(sceNpService), sceNpService);
 }
 
 // TODO: Move NpCommerce2-related stuff to sceNpCommerce2.cpp?
@@ -662,6 +662,6 @@ const HLEFunction sceNpCommerce2[] = {
 
 void Register_sceNpCommerce2()
 {
-	RegisterModule("sceNpCommerce2", ARRAY_SIZE(sceNpCommerce2), sceNpCommerce2);
+	RegisterHLEModule("sceNpCommerce2", ARRAY_SIZE(sceNpCommerce2), sceNpCommerce2);
 }
 

--- a/Core/HLE/sceNp2.cpp
+++ b/Core/HLE/sceNp2.cpp
@@ -602,5 +602,5 @@ const HLEFunction sceNpMatching2[] = {
 
 void Register_sceNpMatching2()
 {
-	RegisterModule("sceNpMatching2", ARRAY_SIZE(sceNpMatching2), sceNpMatching2);
+	RegisterHLEModule("sceNpMatching2", ARRAY_SIZE(sceNpMatching2), sceNpMatching2);
 }

--- a/Core/HLE/sceOpenPSID.cpp
+++ b/Core/HLE/sceOpenPSID.cpp
@@ -82,7 +82,7 @@ const HLEFunction sceOpenPSID[] = {
 
 void Register_sceOpenPSID()
 {
-	RegisterModule("sceOpenPSID", ARRAY_SIZE(sceOpenPSID), sceOpenPSID);
+	RegisterHLEModule("sceOpenPSID", ARRAY_SIZE(sceOpenPSID), sceOpenPSID);
 }
 
 // According to https://playstationdev.wiki/pspprxlibraries/5.00/kd/openpsid.xml
@@ -95,7 +95,7 @@ const HLEFunction sceOpenPSID_driver[] =
 
 void Register_sceOpenPSID_driver()
 {
-	RegisterModule("sceOpenPSID_driver", ARRAY_SIZE(sceOpenPSID_driver), sceOpenPSID_driver);
+	RegisterHLEModule("sceOpenPSID_driver", ARRAY_SIZE(sceOpenPSID_driver), sceOpenPSID_driver);
 }
 const HLEFunction sceDdrdb[] =
 {
@@ -104,5 +104,5 @@ const HLEFunction sceDdrdb[] =
 
 void Register_sceDdrdb()
 {
-	RegisterModule("sceDdrdb", ARRAY_SIZE(sceDdrdb), sceDdrdb);
+	RegisterHLEModule("sceDdrdb", ARRAY_SIZE(sceDdrdb), sceDdrdb);
 }

--- a/Core/HLE/sceP3da.cpp
+++ b/Core/HLE/sceP3da.cpp
@@ -73,5 +73,5 @@ const HLEFunction sceP3da[] =
 
 void Register_sceP3da()
 {
-	RegisterModule("sceP3da", ARRAY_SIZE(sceP3da), sceP3da);
+	RegisterHLEModule("sceP3da", ARRAY_SIZE(sceP3da), sceP3da);
 }

--- a/Core/HLE/sceParseHttp.cpp
+++ b/Core/HLE/sceParseHttp.cpp
@@ -175,5 +175,5 @@ const HLEFunction sceParseHttp[] = {
 };
 
 void Register_sceParseHttp() {
-	RegisterModule("sceParseHttp", ARRAY_SIZE(sceParseHttp), sceParseHttp);
+	RegisterHLEModule("sceParseHttp", ARRAY_SIZE(sceParseHttp), sceParseHttp);
 }

--- a/Core/HLE/sceParseUri.cpp
+++ b/Core/HLE/sceParseUri.cpp
@@ -163,5 +163,5 @@ const HLEFunction sceParseUri[] =
 
 void Register_sceParseUri()
 {
-	RegisterModule("sceParseUri", ARRAY_SIZE(sceParseUri), sceParseUri);
+	RegisterHLEModule("sceParseUri", ARRAY_SIZE(sceParseUri), sceParseUri);
 }

--- a/Core/HLE/scePauth.cpp
+++ b/Core/HLE/scePauth.cpp
@@ -68,5 +68,5 @@ const HLEFunction scePauth[] = {
 
 void Register_scePauth()
 {
-	RegisterModule("scePauth", ARRAY_SIZE(scePauth), scePauth);
+	RegisterHLEModule("scePauth", ARRAY_SIZE(scePauth), scePauth);
 }

--- a/Core/HLE/scePower.cpp
+++ b/Core/HLE/scePower.cpp
@@ -630,9 +630,9 @@ const HLEFunction sceSuspendForUser[] = {
 
 
 void Register_scePower() {
-	RegisterModule("scePower",ARRAY_SIZE(scePower),scePower);
+	RegisterHLEModule("scePower",ARRAY_SIZE(scePower),scePower);
 }
 
 void Register_sceSuspendForUser() {
-	RegisterModule("sceSuspendForUser", ARRAY_SIZE(sceSuspendForUser), sceSuspendForUser);
+	RegisterHLEModule("sceSuspendForUser", ARRAY_SIZE(sceSuspendForUser), sceSuspendForUser);
 }

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -2051,9 +2051,9 @@ const HLEFunction scePsmfPlayer[] =
 };
 
 void Register_scePsmf() {
-	RegisterModule("scePsmf",ARRAY_SIZE(scePsmf),scePsmf);
+	RegisterHLEModule("scePsmf",ARRAY_SIZE(scePsmf),scePsmf);
 }
 
 void Register_scePsmfPlayer() {
-	RegisterModule("scePsmfPlayer",ARRAY_SIZE(scePsmfPlayer),scePsmfPlayer);
+	RegisterHLEModule("scePsmfPlayer",ARRAY_SIZE(scePsmfPlayer),scePsmfPlayer);
 }

--- a/Core/HLE/scePspNpDrm_user.cpp
+++ b/Core/HLE/scePspNpDrm_user.cpp
@@ -53,7 +53,7 @@ const HLEFunction sceNpDrm[] = {
 };
 
 void Register_sceNpDrm() {
-	RegisterModule("sceNpDrm", ARRAY_SIZE(sceNpDrm), sceNpDrm);
-	RegisterModule("scePspNpDrm_user", ARRAY_SIZE(sceNpDrm), sceNpDrm);
+	RegisterHLEModule("sceNpDrm", ARRAY_SIZE(sceNpDrm), sceNpDrm);
+	RegisterHLEModule("scePspNpDrm_user", ARRAY_SIZE(sceNpDrm), sceNpDrm);
 }
  

--- a/Core/HLE/sceRtc.cpp
+++ b/Core/HLE/sceRtc.cpp
@@ -1015,5 +1015,5 @@ const HLEFunction sceRtc[] =
 
 void Register_sceRtc()
 {
-	RegisterModule("sceRtc", ARRAY_SIZE(sceRtc), sceRtc);
+	RegisterHLEModule("sceRtc", ARRAY_SIZE(sceRtc), sceRtc);
 }

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -764,6 +764,6 @@ const HLEFunction sceSasCore[] = {
 
 void Register_sceSasCore()
 {
-	RegisterModule("sceSasCore", ARRAY_SIZE(sceSasCore), sceSasCore);
+	RegisterHLEModule("sceSasCore", ARRAY_SIZE(sceSasCore), sceSasCore);
 }
 

--- a/Core/HLE/sceSfmt19937.cpp
+++ b/Core/HLE/sceSfmt19937.cpp
@@ -119,5 +119,5 @@ const HLEFunction sceSfmt19937[] =
 
 void Register_sceSfmt19937()
 {
-	RegisterModule("sceSfmt19937", ARRAY_SIZE(sceSfmt19937), sceSfmt19937);
+	RegisterHLEModule("sceSfmt19937", ARRAY_SIZE(sceSfmt19937), sceSfmt19937);
 }

--- a/Core/HLE/sceSha256.cpp
+++ b/Core/HLE/sceSha256.cpp
@@ -45,5 +45,5 @@ const HLEFunction sceSha256[] =
 
 void Register_sceSha256()
 {
-	RegisterModule("sceSha256", ARRAY_SIZE(sceSha256), sceSha256);
+	RegisterHLEModule("sceSha256", ARRAY_SIZE(sceSha256), sceSha256);
 }

--- a/Core/HLE/sceSircs.cpp
+++ b/Core/HLE/sceSircs.cpp
@@ -52,5 +52,5 @@ const HLEFunction sceSircs[] =
 
 void Register_sceSircs()
 {
-	RegisterModule("sceSircs", ARRAY_SIZE(sceSircs), sceSircs);
+	RegisterHLEModule("sceSircs", ARRAY_SIZE(sceSircs), sceSircs);
 }

--- a/Core/HLE/sceSsl.cpp
+++ b/Core/HLE/sceSsl.cpp
@@ -122,5 +122,5 @@ const HLEFunction sceSsl[] =
 
 void Register_sceSsl()
 {
-	RegisterModule("sceSsl", ARRAY_SIZE(sceSsl), sceSsl);
+	RegisterHLEModule("sceSsl", ARRAY_SIZE(sceSsl), sceSsl);
 }

--- a/Core/HLE/sceUmd.cpp
+++ b/Core/HLE/sceUmd.cpp
@@ -534,5 +534,5 @@ const HLEFunction sceUmdUser[] =
 
 void Register_sceUmdUser()
 {
-	RegisterModule("sceUmdUser", ARRAY_SIZE(sceUmdUser), sceUmdUser);
+	RegisterHLEModule("sceUmdUser", ARRAY_SIZE(sceUmdUser), sceUmdUser);
 }

--- a/Core/HLE/sceUsb.cpp
+++ b/Core/HLE/sceUsb.cpp
@@ -241,7 +241,7 @@ const HLEFunction sceUsbstorBoot[] =
 
 void Register_sceUsb()
 {
-	RegisterModule("sceUsbstor", ARRAY_SIZE(sceUsbstor), sceUsbstor);
-	RegisterModule("sceUsbstorBoot", ARRAY_SIZE(sceUsbstorBoot), sceUsbstorBoot);
-	RegisterModule("sceUsb", ARRAY_SIZE(sceUsb), sceUsb);
+	RegisterHLEModule("sceUsbstor", ARRAY_SIZE(sceUsbstor), sceUsbstor);
+	RegisterHLEModule("sceUsbstorBoot", ARRAY_SIZE(sceUsbstorBoot), sceUsbstorBoot);
+	RegisterHLEModule("sceUsb", ARRAY_SIZE(sceUsb), sceUsb);
 }

--- a/Core/HLE/sceUsbAcc.cpp
+++ b/Core/HLE/sceUsbAcc.cpp
@@ -42,5 +42,5 @@ const HLEFunction sceUsbAcc[] =
 
 void Register_sceUsbAcc()
 {
-	RegisterModule("sceUsbAcc", ARRAY_SIZE(sceUsbAcc), sceUsbAcc);
+	RegisterHLEModule("sceUsbAcc", ARRAY_SIZE(sceUsbAcc), sceUsbAcc);
 }

--- a/Core/HLE/sceUsbCam.cpp
+++ b/Core/HLE/sceUsbCam.cpp
@@ -324,7 +324,7 @@ const HLEFunction sceUsbCam[] =
 
 void Register_sceUsbCam()
 {
-	RegisterModule("sceUsbCam", ARRAY_SIZE(sceUsbCam), sceUsbCam);
+	RegisterHLEModule("sceUsbCam", ARRAY_SIZE(sceUsbCam), sceUsbCam);
 }
 
 std::vector<std::string> Camera::getDeviceList() {

--- a/Core/HLE/sceUsbGps.cpp
+++ b/Core/HLE/sceUsbGps.cpp
@@ -127,7 +127,7 @@ const HLEFunction sceUsbGps[] =
 
 void Register_sceUsbGps()
 {
-	RegisterModule("sceUsbGps", ARRAY_SIZE(sceUsbGps), sceUsbGps);
+	RegisterHLEModule("sceUsbGps", ARRAY_SIZE(sceUsbGps), sceUsbGps);
 }
 
 void GPS::init() {

--- a/Core/HLE/sceUsbMic.cpp
+++ b/Core/HLE/sceUsbMic.cpp
@@ -454,5 +454,5 @@ const HLEFunction sceUsbMic[] = {
 };
 
 void Register_sceUsbMic() {
-	RegisterModule("sceUsbMic", ARRAY_SIZE(sceUsbMic), sceUsbMic);
+	RegisterHLEModule("sceUsbMic", ARRAY_SIZE(sceUsbMic), sceUsbMic);
 }

--- a/Core/HLE/sceUtility.cpp
+++ b/Core/HLE/sceUtility.cpp
@@ -1476,5 +1476,5 @@ const HLEFunction sceUtility[] =
 
 void Register_sceUtility()
 {
-	RegisterModule("sceUtility", ARRAY_SIZE(sceUtility), sceUtility);
+	RegisterHLEModule("sceUtility", ARRAY_SIZE(sceUtility), sceUtility);
 }

--- a/Core/HLE/sceVaudio.cpp
+++ b/Core/HLE/sceVaudio.cpp
@@ -105,5 +105,5 @@ const HLEFunction sceVaudio[] = {
 };
 
 void Register_sceVaudio() {
-	RegisterModule("sceVaudio",ARRAY_SIZE(sceVaudio), sceVaudio );
+	RegisterHLEModule("sceVaudio",ARRAY_SIZE(sceVaudio), sceVaudio );
 }

--- a/Core/MIPS/MIPSDis.cpp
+++ b/Core/MIPS/MIPSDis.cpp
@@ -123,7 +123,7 @@ namespace MIPSDis
 		u32 callno = (op>>6) & 0xFFFFF; //20 bits
 		int funcnum = callno & 0xFFF;
 		int modulenum = (callno & 0xFF000) >> 12;
-		snprintf(out, outSize, "syscall\t	%s", GetFuncName(modulenum, funcnum));
+		snprintf(out, outSize, "syscall\t	%s", GetHLEFuncName(modulenum, funcnum));
 	}
 
 	void Dis_ToHiloTransfer(MIPSOpcode op, uint32_t pc, char *out, size_t outSize) {

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -882,7 +882,10 @@ void DumpFileIfEnabled(const u8 *dataPtr, const u32 length, const char *name, Du
 	}
 
 	const char *extension = DumpFileTypeToFileExtension(type);
-	const std::string filenameToDumpTo = StringFromFormat("%s_%s%s", g_paramSFO.GetDiscID().c_str(), name, extension);
+	std::string filenameToDumpTo = StringFromFormat("%s_%s", g_paramSFO.GetDiscID().c_str(), name);
+	if (!endsWithNoCase(filenameToDumpTo, extension)) {
+		filenameToDumpTo += extension;
+	}
 	const Path dumpDirectory = GetSysDirectory(DIRECTORY_DUMP);
 	const Path fullPath = dumpDirectory / filenameToDumpTo;
 
@@ -939,7 +942,7 @@ void DumpFileIfEnabled(const u8 *dataPtr, const u32 length, const char *name, Du
 	strcpy(path, fullPath.c_str());
 
 	// Re-suing the translation string here.
-	g_OSD.Show(OSDType::MESSAGE_SUCCESS, titleStr, fullPath.ToVisualString(), 5.0f, "decr");
+	g_OSD.Show(OSDType::MESSAGE_SUCCESS, titleStr, fullPath.ToVisualString(), 5.0f);
 	if (System_GetPropertyBool(SYSPROP_CAN_SHOW_FILE)) {
 		g_OSD.SetClickCallback("decr", [](bool clicked, void *userdata) {
 			char *path = (char *)userdata;

--- a/Core/System.h
+++ b/Core/System.h
@@ -58,6 +58,7 @@ enum PSPDirectories {
 	DIRECTORY_EXDATA,
 	DIRECTORY_CUSTOM_SHADERS,
 	DIRECTORY_CUSTOM_THEMES,
+	COUNT,
 };
 
 class GraphicsContext;

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -1526,11 +1526,11 @@ void DrawHLEModules(ImConfig &config) {
 		return;
 	}
 
-	const int moduleCount = GetNumRegisteredModules();
+	const int moduleCount = GetNumRegisteredHLEModules();
 	std::vector<const HLEModule *> modules;
 	modules.reserve(moduleCount);
 	for (int i = 0; i < moduleCount; i++) {
-		modules.push_back(GetModuleByIndex(i));
+		modules.push_back(GetHLEModuleByIndex(i));
 	}
 
 	std::sort(modules.begin(), modules.end(), [](const HLEModule* a, const HLEModule* b) {

--- a/unittest/JitHarness.cpp
+++ b/unittest/JitHarness.cpp
@@ -97,7 +97,7 @@ double ExecCPUTest(bool clearCache = true) {
 
 static void SetupJitHarness() {
 	// We register a syscall so we have an easy way to finish the test.
-	RegisterModule("UnitTestFakeSyscalls", ARRAY_SIZE(UnitTestFakeSyscalls), UnitTestFakeSyscalls);
+	RegisterHLEModule("UnitTestFakeSyscalls", ARRAY_SIZE(UnitTestFakeSyscalls), UnitTestFakeSyscalls);
 
 	// This is pretty much the bare minimum required to setup jit.
 	coreState = CORE_POWERUP;


### PR DESCRIPTION
Prep for more important changes, and renames a bunch of functions for clarity.

Also sneaks in a fix for #20187 , sorry, and fixes PRX dumping where we know the filename.