### PR TITLE
Module loading improvements

### DIFF
--- a/Common/Common.vcxproj
+++ b/Common/Common.vcxproj
@@ -405,6 +405,7 @@
     <ClInclude Include="..\ext\basis_universal\basisu_transcoder_uastc.h" />
     <ClInclude Include="..\ext\imgui\imconfig.h" />
     <ClInclude Include="..\ext\imgui\imgui.h" />
+    <ClInclude Include="..\ext\imgui\imgui_extras.h" />
     <ClInclude Include="..\ext\imgui\imgui_impl_platform.h" />
     <ClInclude Include="..\ext\imgui\imgui_impl_thin3d.h" />
     <ClInclude Include="..\ext\imgui\imgui_internal.h" />

--- a/Common/Common.vcxproj.filters
+++ b/Common/Common.vcxproj.filters
@@ -691,6 +691,9 @@
     <ClInclude Include="..\ext\sol\sol.hpp">
       <Filter>ext\sol</Filter>
     </ClInclude>
+    <ClInclude Include="..\ext\imgui\imgui_extras.h">
+      <Filter>ext\imgui</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ABI.cpp" />

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -238,6 +238,7 @@ static const ConfigSetting generalSettings[] = {
 	ConfigSetting("GameListScrollPosition", &g_Config.fGameListScrollPosition, 0.0f, CfgFlag::DEFAULT),
 	ConfigSetting("DebugOverlay", &g_Config.iDebugOverlay, 0, CfgFlag::DONT_SAVE),
 	ConfigSetting("DefaultTab", &g_Config.iDefaultTab, 0, CfgFlag::DEFAULT),
+	ConfigSetting("DisableHLEFlags", &g_Config.iDisableHLE, 0, CfgFlag::PER_GAME),
 
 	ConfigSetting("ScreenshotMode", &g_Config.iScreenshotMode, 0, CfgFlag::DEFAULT),
 	ConfigSetting("ScreenshotsAsPNG", &g_Config.bScreenshotsAsPNG, false, CfgFlag::PER_GAME),

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -139,6 +139,7 @@ public:
 	bool bLoadPlugins;
 	int iAskForExitConfirmationAfterSeconds;
 	int iUIScaleFactor;  // In 8ths of powers of two.
+	int iDisableHLE;
 
 	int iScreenRotation;  // The rotation angle of the PPSSPP UI. Only supported on Android and possibly other mobile platforms.
 	int iInternalScreenRotation;  // The internal screen rotation angle. Useful for vertical SHMUPs and similar.

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -116,6 +116,21 @@ enum class RestoreSettingsBits : int {
 };
 ENUM_CLASS_BITOPS(RestoreSettingsBits);
 
+// Modules that are candidates for disabling HLE of.
+enum class DisableHLEFlags : int {
+	sceFont = (1 << 0),
+	sceAtrac = (1 << 1),
+	scePsmf = (1 << 2),
+	scePsmfPlayer = (1 << 3),
+	sceMpeg = (1 << 4),
+	sceMp3 = (1 << 5),
+	sceJpeg = (1 << 6),
+	sceParseHttp = (1 << 7),
+	Count = 8,
+	// TODO: Some of the networking libraries may be interesting candidates, like HTTP.
+};
+ENUM_CLASS_BITOPS(DisableHLEFlags);
+
 std::string GPUBackendToString(GPUBackend backend);
 GPUBackend GPUBackendFromString(std::string_view backend);
 

--- a/Core/Core.vcxproj
+++ b/Core/Core.vcxproj
@@ -680,7 +680,6 @@
     <ClCompile Include="Font\PGF.cpp" />
     <ClCompile Include="HDRemaster.cpp" />
     <ClCompile Include="HLE\HLE.cpp">
-      <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MaxSpeed</Optimization>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">MaxSpeed</Optimization>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">MaxSpeed</Optimization>
       <BasicRuntimeChecks Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Default</BasicRuntimeChecks>

--- a/Core/HLE/HLE.h
+++ b/Core/HLE/HLE.h
@@ -25,6 +25,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Log.h"
 #include "Core/MIPS/MIPS.h"
+#include "Core/ConfigValues.h"
 
 #ifdef _MSC_VER
 #pragma warning (error: 4834)  // discarding return value of function with 'nodiscard' attribute
@@ -97,8 +98,21 @@ struct Syscall {
 #define RETURN64(n) {u64 RETURN64_tmp = n; currentMIPS->r[MIPS_REG_V0] = RETURN64_tmp & 0xFFFFFFFF; currentMIPS->r[MIPS_REG_V1] = RETURN64_tmp >> 32;}
 #define RETURNF(fl) currentMIPS->f[0] = fl
 
+struct HLEModuleMeta {
+	// This is the modname (name from the PRX header). Probably, we should really blacklist on the module names of the exported symbol metadata.
+	const char *modname;
+	const char *importName;  // Technically a module can export functions with different module names, but doesn't seem to happen.
+	DisableHLEFlags disableFlag;
+};
+
+const HLEModuleMeta *GetHLEModuleMetaByFlag(DisableHLEFlags flag);
+const HLEModuleMeta *GetHLEModuleMeta(std::string_view modname);
+bool ShouldHLEModule(std::string_view modname, bool *wasDisabled = nullptr);
+bool ShouldHLEModuleByImportName(std::string_view importModuleName);
+
 const char *GetHLEFuncName(std::string_view module, u32 nib);
 const char *GetHLEFuncName(int module, int func);
+const HLEModule *GetHLEModuleByName(std::string_view name);
 const HLEFunction *GetHLEFunc(std::string_view module, u32 nib);
 int GetHLEFuncIndexByNib(int moduleIndex, u32 nib);
 int GetHLEModuleIndex(std::string_view modulename);
@@ -160,8 +174,7 @@ void HLEInit();
 void HLEDoState(PointerWrap &p);
 void HLEShutdown();
 u32 GetSyscallOp(std::string_view module, u32 nib);
-bool FuncImportIsSyscall(std::string_view module, u32 nib);
-bool WriteSyscall(std::string_view module, u32 nib, u32 address);
+bool WriteHLESyscall(std::string_view module, u32 nib, u32 address);
 void CallSyscall(MIPSOpcode op);
 void WriteFuncStub(u32 stubAddr, u32 symAddr);
 void WriteFuncMissingStub(u32 stubAddr, u32 nid);

--- a/Core/HLE/sceKernel.h
+++ b/Core/HLE/sceKernel.h
@@ -172,6 +172,15 @@ public:
 			return occupied[index];
 	}
 
+	template<class T>
+	bool Is(SceUID handle) const {
+		int index = handle - handleOffset;
+		if (index < 0 || index >= maxCount)
+			return false;
+		else
+			return occupied[index] && pool[handle - handleOffset]->GetIDType() == T::GetStaticIDType();
+	}
+
 	template <class T>
 	T* Get(SceUID handle, u32 &outError) {
 		if (handle < handleOffset || handle >= handleOffset+maxCount || !occupied[handle-handleOffset]) {
@@ -212,7 +221,7 @@ public:
 				continue;
 			T *t = static_cast<T *>(pool[i]);
 			if (t->GetIDType() == type) {
-				if (!func(i, t))
+				if (!func(i + handleOffset, t))
 					break;
 			}
 		}

--- a/Core/HLE/sceKernel.h
+++ b/Core/HLE/sceKernel.h
@@ -204,15 +204,15 @@ public:
 		return static_cast<T *>(pool[realHandle]);
 	}
 
-	template <class T, typename ArgT>
-	void Iterate(bool func(T *, ArgT), ArgT arg) {
+	template <typename T, typename F>
+	void Iterate(F func) {
 		int type = T::GetStaticIDType();
 		for (int i = 0; i < maxCount; i++) {
 			if (!occupied[i])
 				continue;
 			T *t = static_cast<T *>(pool[i]);
 			if (t->GetIDType() == type) {
-				if (!func(t, arg))
+				if (!func(i, t))
 					break;
 			}
 		}

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -52,12 +52,11 @@
 #include "Core/FileSystems/MetaFileSystem.h"
 #include "Core/Util/BlockAllocator.h"
 #include "Core/CoreTiming.h"
+#include "Core/ConfigValues.h"
 #include "Core/PSPLoaders.h"
 #include "Core/System.h"
 #include "Core/MemMapHelpers.h"
 #include "Core/Debugger/SymbolMap.h"
-#include "Core/MIPS/MIPS.h"
-
 #include "Core/HLE/sceKernel.h"
 #include "Core/HLE/sceKernelModule.h"
 #include "Core/HLE/sceKernelThread.h"
@@ -103,32 +102,6 @@ static const char * const lieAboutSuccessModules[] = {
 	"flash0:/kd/pspnet_resolver.prx",
 };
 
-// Modules to not load. TODO: Look into loosening this a little (say sceFont).
-static const char * const blacklistedModules[] = {
-	"sceATRAC3plus_Library",
-	"sceFont_Library",
-	"SceFont_Library",
-	"SceHttp_Library",
-	"sceMpeg_library",
-	"sceNetAdhocctl_Library",
-	"sceNetAdhocDownload_Library",
-	"sceNetAdhocMatching_Library",
-	"sceNetApDialogDummy_Library",
-	"sceNetAdhoc_Library",
-	"sceNetApctl_Library",
-	"sceNetInet_Library",
-	"sceNetResolver_Library",
-	"sceNet_Library",
-	"sceNetAdhoc_Library",
-	"sceNetAdhocAuth_Service",
-	"sceNetAdhocctl_Library",
-	"sceNetIfhandle_Service",
-	"sceSsl_Module",
-	"sceDEFLATE_Library",
-	"sceMD5_Library",
-	"sceMemab",
-};
-
 const char *NativeModuleStatusToString(NativeModuleStatus status) {
 	switch (status) {
 	case MODULE_STATUS_STARTING: return "STARTING";
@@ -165,6 +138,34 @@ struct ModuleInfo {
 	u16_le attribute;
 	u8 version[2];
 	char name[28];
+};
+
+struct PspLibStubEntry {
+	u32_le name;
+	u16_le version;
+	u16_le flags;
+	u8 size;
+	u8 numVars;
+	u16_le numFuncs;
+	// each symbol has an associated nid; nidData is a pointer
+	// (in .rodata.sceNid section) to an array of longs, one
+	// for each function, which identifies the function whose
+	// address is to be inserted.
+	//
+	// The hash is the first 4 bytes of a SHA-1 hash of the function
+	// name.	(Represented as a little-endian long, so the order
+	// of the bytes is reversed.)
+	u32_le nidData;
+	// the address of the function stubs where the function address jumps
+	// should be filled in
+	u32_le firstSymAddr;
+	// Optional, this is where var relocations are.
+	// They use the format: u32 addr, u32 nid, ...
+	// WARNING: May have garbage if size < 6.
+	u32_le varData;
+	// Not sure what this is yet, assume garbage for now.
+	// TODO: Tales of the World: Radiant Mythology 2 has something here?
+	u32_le extra;
 };
 
 PSPModule::~PSPModule() {
@@ -639,14 +640,26 @@ void UnexportVarSymbol(const VarSymbolExport &var) {
 	}
 }
 
+static bool FuncImportIsHLE(std::string_view module, u32 nid) {
+	// TODO: Take into account whether HLE is enabled for the module.
+	// Also, this needs to be more efficient.
+	if (!ShouldHLEModuleByImportName(module)) {
+		return false;
+	}
+
+	return GetHLEFunc(module, nid) != nullptr;
+}
+
 void ImportFuncSymbol(const FuncSymbolImport &func, bool reimporting, const char *importingModule) {
-	// Prioritize HLE implementations.
-	// TODO: Or not?
-	if (FuncImportIsSyscall(func.moduleName, func.nid)) {
+	bool shouldHLE = ShouldHLEModuleByImportName(func.moduleName);
+
+	// Prioritize HLE implementations, if we should HLE this.
+	if (shouldHLE && GetHLEFunc(func.moduleName, func.nid)) {
 		if (reimporting && Memory::Read_Instruction(func.stubAddr + 4) != GetSyscallOp(func.moduleName, func.nid)) {
 			WARN_LOG(Log::Loader, "Reimporting updated syscall %s", GetHLEFuncName(func.moduleName, func.nid));
 		}
-		WriteSyscall(func.moduleName, func.nid, func.stubAddr);
+		// TODO: There's some double lookup going on here (we already did the lookup in GetHLEFunc above).
+		WriteHLESyscall(func.moduleName, func.nid, func.stubAddr);
 		currentMIPS->InvalidateICache(func.stubAddr, 8);
 		if (g_Config.bPreloadFunctions) {
 			MIPSAnalyst::PrecompileFunction(func.stubAddr, 8);
@@ -678,21 +691,21 @@ void ImportFuncSymbol(const FuncSymbolImport &func, bool reimporting, const char
 	}
 
 	// It hasn't been exported yet, but hopefully it will later. Check if we know about it through HLE.
-	const bool isKnownHLEModule = GetHLEModuleIndex(func.moduleName) != -1;
-	if (isKnownHLEModule) {
+	if (shouldHLE) {
 		// We used to report this, but I don't think it's very interesting anymore.
 		WARN_LOG(Log::Loader, "Unknown syscall from known HLE module '%s': 0x%08x (import for '%s')", func.moduleName, func.nid, importingModule);
 	} else {
 		INFO_LOG(Log::Loader, "Function (%s,%08x) unresolved in '%s', storing for later resolving", func.moduleName, func.nid, importingModule);
 	}
-	if (isKnownHLEModule || !reimporting) {
+
+	if (shouldHLE || !reimporting) {
 		WriteFuncMissingStub(func.stubAddr, func.nid);
 		currentMIPS->InvalidateICache(func.stubAddr, 8);
 	}
 }
 
 void ExportFuncSymbol(const FuncSymbolExport &func) {
-	if (FuncImportIsSyscall(func.moduleName, func.nid)) {
+	if (FuncImportIsHLE(func.moduleName, func.nid)) {
 		// HLE covers this already - let's ignore the function.
 		WARN_LOG(Log::Loader, "Ignoring func export %s/%08x, already implemented in HLE.", func.moduleName, func.nid);
 		return;
@@ -720,7 +733,7 @@ void ExportFuncSymbol(const FuncSymbolExport &func) {
 }
 
 void UnexportFuncSymbol(const FuncSymbolExport &func) {
-	if (FuncImportIsSyscall(func.moduleName, func.nid)) {
+	if (FuncImportIsHLE(func.moduleName, func.nid)) {
 		// Oops, HLE covers this.
 		return;
 	}
@@ -769,72 +782,7 @@ void PSPModule::Cleanup() {
 	}
 }
 
-static bool IsHLEVersionedModule(const char *name) {
-	// TODO: Only some of these are currently known to be versioned.
-	// Potentially only sceMpeg_library matters.
-	// For now, we're just reporting version numbers.
-	for (size_t i = 0; i < ARRAY_SIZE(blacklistedModules); i++) {
-		if (!strncmp(name, blacklistedModules[i], 28)) {
-			return true;
-		}
-	}
-	static const char *otherModules[] = {
-		"sceAvcodec_driver",
-		"sceAudiocodec_Driver",
-		"sceAudiocodec",
-		"sceVideocodec_Driver",
-		"sceVideocodec",
-		"sceMpegbase_Driver",
-		"sceMpegbase",
-		"scePsmf_library",
-		"scePsmfP_library",
-		"scePsmfPlayer",
-		"sceSAScore",
-		"sceCcc_Library",
-		"SceParseHTTPheader_Library",
-		"SceParseURI_Library",
-		// Guessing.
-		"sceJpeg",
-		"sceJpeg_library",
-		"sceJpeg_Library",
-	};
-	for (size_t i = 0; i < ARRAY_SIZE(otherModules); i++) {
-		if (!strncmp(name, otherModules[i], 28)) {
-			return true;
-		}
-	}
-	return false;
-}
-
 static bool KernelImportModuleFuncs(PSPModule *module, u32 *firstImportStubAddr, bool reimporting) {
-	struct PspLibStubEntry {
-		u32_le name;
-		u16_le version;
-		u16_le flags;
-		u8 size;
-		u8 numVars;
-		u16_le numFuncs;
-		// each symbol has an associated nid; nidData is a pointer
-		// (in .rodata.sceNid section) to an array of longs, one
-		// for each function, which identifies the function whose
-		// address is to be inserted.
-		//
-		// The hash is the first 4 bytes of a SHA-1 hash of the function
-		// name.	(Represented as a little-endian long, so the order
-		// of the bytes is reversed.)
-		u32_le nidData;
-		// the address of the function stubs where the function address jumps
-		// should be filled in
-		u32_le firstSymAddr;
-		// Optional, this is where var relocations are.
-		// They use the format: u32 addr, u32 nid, ...
-		// WARNING: May have garbage if size < 6.
-		u32_le varData;
-		// Not sure what this is yet, assume garbage for now.
-		// TODO: Tales of the World: Radiant Mythology 2 has something here?
-		u32_le extra;
-	};
-
 	// Can't run - we didn't keep track of the libstub entry.
 	if (module->libstub == 0) {
 		return false;
@@ -1099,7 +1047,8 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 		head = (const PSP_Header *)ptr;
 		devkitVersion = head->devkitversion;
 
-		if (IsHLEVersionedModule(head->modname)) {
+		bool wasDisabled;
+		if (ShouldHLEModule(head->modname, &wasDisabled)) {
 			int ver = (head->module_ver_hi << 8) | head->module_ver_lo;
 			INFO_LOG(Log::sceModule, "Loading module %s with version %04x, devkit %08x, crc %x", head->modname, ver, head->devkitversion, module->crc);
 
@@ -1108,6 +1057,9 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 			fakeLoadedModule = true;
 		}
 
+		if (wasDisabled) {
+			g_OSD.Show(OSDType::MESSAGE_WARNING, StringFromFormat("HLE for %s has been manually disabled", head->modname));
+		}
 		const u8 *in = ptr;
 		const auto isGzip = head->comp_attribute & 1;
 		// Kind of odd.
@@ -1310,16 +1262,7 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 	char moduleName[29] = {0};
 	strncpy(moduleName, modinfo->name, ARRAY_SIZE(module->nm.name));
 
-	// Check for module blacklist - we don't allow games to load these modules from disc
-	// as we have HLE implementations and the originals won't run in the emu because they
-	// directly access hardware or for other reasons.
-	for (u32 i = 0; i < ARRAY_SIZE(blacklistedModules); i++) {
-		if (strncmp(modinfo->name, blacklistedModules[i], ARRAY_SIZE(modinfo->name)) == 0) {
-			module->isFake = true;
-		}
-	}
-
-	if (!module->isFake && module->memoryBlockAddr != 0) {
+	if (module->memoryBlockAddr != 0) {
 		g_symbolMap->AddModule(moduleName, module->memoryBlockAddr, module->memoryBlockSize);
 	}
 
@@ -1415,6 +1358,7 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 	}
 
 	// Look at the exports, too.
+	// TODO: Add them to the symbol map!
 
 	struct PspLibEntEntry {
 		u32_le name; /* ent's name (module name) address */
@@ -1500,7 +1444,7 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 				func.nid = nid;
 				func.symAddr = exportAddr;
 				if (ent->name == 0) {
-					WARN_LOG_REPORT(Log::HLE, "Exporting func from syslib export: %08x", nid);
+					WARN_LOG(Log::HLE, "Exporting func from syslib export: %08x", nid);
 				}
 				module->ExportFunc(func);
 			}
@@ -1587,7 +1531,7 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 
 	delete [] newptr;
 
-	if (!reportedModule && IsHLEVersionedModule(modinfo->name)) {
+	if (!reportedModule && ShouldHLEModule(modinfo->name)) {
 		INFO_LOG(Log::sceModule, "Loading module %s with version %04x, devkit %08x", modinfo->name, modinfo->moduleVersion, devkitVersion);
 
 		if (!strcmp(modinfo->name, "sceMpeg_library")) {

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1154,7 +1154,7 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 				// Use the name from the header.
 				elfFilename = head->modname;
 			}
-			DumpFileIfEnabled(ptr, head->psp_size, elfFilename.c_str(), DumpFileType::PRX);
+			DumpFileIfEnabled(ptr, elfSize, elfFilename.c_str(), DumpFileType::PRX);
 
 			// This should happen for all "kernel" modules.
 			*error_string = "Missing key";

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -295,14 +295,14 @@ void PSPModule::ImportFunc(const FuncSymbolImport &func, bool reimporting) {
 
 	// Keep track and actually hook it up if possible.
 	importedFuncs.push_back(func);
-	impExpModuleNames.insert(func.moduleName);
+	impModuleNames.insert(func.moduleName);
 	ImportFuncSymbol(func, reimporting, GetName());
 }
 
 void PSPModule::ImportVar(WriteVarSymbolState &state, const VarSymbolImport &var) {
 	// Keep track and actually hook it up if possible.
 	importedVars.push_back(var);
-	impExpModuleNames.insert(var.moduleName);
+	impModuleNames.insert(var.moduleName);
 	ImportVarSymbol(state, var);
 }
 
@@ -311,7 +311,7 @@ void PSPModule::ExportFunc(const FuncSymbolExport &func) {
 		return;
 	}
 	exportedFuncs.push_back(func);
-	impExpModuleNames.insert(func.moduleName);
+	expModuleNames.insert(func.moduleName);
 	ExportFuncSymbol(func);
 }
 
@@ -320,7 +320,7 @@ void PSPModule::ExportVar(const VarSymbolExport &var) {
 		return;
 	}
 	exportedVars.push_back(var);
-	impExpModuleNames.insert(var.moduleName);
+	expModuleNames.insert(var.moduleName);
 	ExportVarSymbol(var);
 }
 
@@ -1150,11 +1150,11 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 			// Opportunity to dump the decrypted elf, even if we choose to fake it.
 			// NOTE: filename is not necessarily a good choice!
 			std::string elfFilename(KeepAfterLast(filename, '/'));
-			if (elfFilename.empty()) {
+			if (elfFilename.empty() || startsWith(elfFilename, "sce_lbn")) {
 				// Use the name from the header.
 				elfFilename = head->modname;
 			}
-			DumpFileIfEnabled(ptr, elfSize, elfFilename.c_str(), DumpFileType::PRX);
+			DumpFileIfEnabled(ptr, (u32)elfSize, elfFilename.c_str(), DumpFileType::PRX);
 
 			// This should happen for all "kernel" modules.
 			*error_string = "Missing key";

--- a/Core/HLE/sceKernelModule.h
+++ b/Core/HLE/sceKernelModule.h
@@ -182,6 +182,7 @@ public:
 	NativeModule nm{};
 	std::vector<ModuleWaitingThread> waitingThreads;
 
+	// TODO: Should we store these grouped by moduleName instead? Seems more reasonable.
 	std::vector<FuncSymbolExport> exportedFuncs;
 	std::vector<FuncSymbolImport> importedFuncs;
 	std::vector<VarSymbolExport> exportedVars;

--- a/Core/HLE/sceKernelModule.h
+++ b/Core/HLE/sceKernelModule.h
@@ -161,22 +161,31 @@ public:
 	void ExportVar(const VarSymbolExport &var);
 
 	template <typename T>
-	void RebuildImpExpList(const std::vector<T> &list) {
+	void RebuildExpList(const std::vector<T> &list) {
 		for (size_t i = 0; i < list.size(); ++i) {
-			impExpModuleNames.insert(list[i].moduleName);
+			expModuleNames.insert(list[i].moduleName);
+		}
+	}
+
+	template <typename T>
+	void RebuildImpList(const std::vector<T> &list) {
+		for (size_t i = 0; i < list.size(); ++i) {
+			impModuleNames.insert(list[i].moduleName);
 		}
 	}
 
 	void RebuildImpExpModuleNames() {
-		impExpModuleNames.clear();
-		RebuildImpExpList(exportedFuncs);
-		RebuildImpExpList(importedFuncs);
-		RebuildImpExpList(exportedVars);
-		RebuildImpExpList(importedVars);
+		impModuleNames.clear();
+		expModuleNames.clear();
+		RebuildExpList(exportedFuncs);
+		RebuildImpList(importedFuncs);
+		RebuildExpList(exportedVars);
+		RebuildImpList(importedVars);
 	}
 
 	bool ImportsOrExportsModuleName(const std::string &moduleName) {
-		return impExpModuleNames.find(moduleName) != impExpModuleNames.end();
+		return impModuleNames.find(moduleName) != impModuleNames.end() ||
+			expModuleNames.find(moduleName) != expModuleNames.end();
 	}
 
 	NativeModule nm{};
@@ -187,7 +196,8 @@ public:
 	std::vector<FuncSymbolImport> importedFuncs;
 	std::vector<VarSymbolExport> exportedVars;
 	std::vector<VarSymbolImport> importedVars;
-	std::set<std::string> impExpModuleNames;
+	std::set<std::string> impModuleNames;
+	std::set<std::string> expModuleNames;
 
 	// Keep track of the code region so we can throw out analysis results
 	// when unloaded.

--- a/Core/HLE/sceKernelThread.cpp
+++ b/Core/HLE/sceKernelThread.cpp
@@ -746,7 +746,7 @@ static void __KernelWriteFakeSysCall(u32 nid, u32 *ptr, u32 &pos)
 {
 	*ptr = pos;
 	pos += 8;
-	WriteSyscall("FakeSysCalls", nid, *ptr);
+	WriteHLESyscall("FakeSysCalls", nid, *ptr);
 	MIPSAnalyst::PrecompileFunction(*ptr, 8);
 }
 
@@ -1931,7 +1931,7 @@ int __KernelStartThread(SceUID threadToStartID, int argSize, u32 argBlockPtr, bo
 
 	// At the bottom of those 64 bytes, the return syscall and ra is written.
 	// Test Drive Unlimited actually depends on it being in the correct place.
-	WriteSyscall("FakeSysCalls", NID_THREADRETURN, sp);
+	WriteHLESyscall("FakeSysCalls", NID_THREADRETURN, sp);
 	Memory::Write_U32(MIPS_MAKE_B(-1), sp + 8);
 	Memory::Write_U32(MIPS_MAKE_NOP(), sp + 12);
 

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -119,7 +119,7 @@ GlobalUIState GetUIState() {
 	return globalUIState;
 }
 
-void SetGPUBackend(GPUBackend type, const std::string &device) {
+void SetGPUBackend(GPUBackend type, std::string_view device) {
 	gpuBackend = type;
 	gpuBackendDevice = device;
 }
@@ -869,7 +869,7 @@ const char *DumpFileTypeToFileExtension(DumpFileType type) {
 	}
 }
 
-void DumpFileIfEnabled(const u8 *dataPtr, const u32 length, const char *name, DumpFileType type) {
+void DumpFileIfEnabled(const u8 *dataPtr, const u32 length, std::string_view name, DumpFileType type) {
 	if (!(g_Config.iDumpFileTypes & (int)type)) {
 		return;
 	}
@@ -883,7 +883,7 @@ void DumpFileIfEnabled(const u8 *dataPtr, const u32 length, const char *name, Du
 	}
 
 	const char *extension = DumpFileTypeToFileExtension(type);
-	std::string filenameToDumpTo = StringFromFormat("%s_%s", g_paramSFO.GetDiscID().c_str(), name);
+	std::string filenameToDumpTo = g_paramSFO.GetDiscID() + "_" + std::string(name);
 	if (!endsWithNoCase(filenameToDumpTo, extension)) {
 		filenameToDumpTo += extension;
 	}

--- a/Core/System.h
+++ b/Core/System.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <string_view>
 #include "Common/CommonTypes.h"
 #include "Common/File/Path.h"
 #include "Core/CoreParameter.h"
@@ -68,7 +69,7 @@ void ResetUIState();
 void UpdateUIState(GlobalUIState newState);
 GlobalUIState GetUIState();
 
-void SetGPUBackend(GPUBackend type, const std::string &device = "");
+void SetGPUBackend(GPUBackend type, std::string_view device = "");
 GPUBackend GetGPUBackend();
 std::string GetGPUBackendDevice();
 
@@ -128,4 +129,4 @@ inline CoreParameter &PSP_CoreParameter() {
 }
 
 // Centralized place for dumping useful files, also takes care of checking for dupes and creating a clickable UI popup.
-void DumpFileIfEnabled(const u8 *dataPtr, const u32 length, const char *name, DumpFileType type);
+void DumpFileIfEnabled(const u8 *dataPtr, const u32 length, std::string_view name, DumpFileType type);

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1995,6 +1995,15 @@ void DeveloperToolsScreen::CreateViews() {
 	list->Add(new BitCheckBox(&g_Config.iDumpFileTypes, (int)DumpFileType::PRX, dev->T("PRX")));
 	list->Add(new BitCheckBox(&g_Config.iDumpFileTypes, (int)DumpFileType::Atrac3, dev->T("Atrac3/3+")));
 
+	list->Add(new ItemHeader("Disable HLE (experimental! Not expected to work yet)"));
+	for (int i = 0; i < (int)DisableHLEFlags::Count; i++) {
+		DisableHLEFlags flag = (DisableHLEFlags)(1 << i);
+		const HLEModuleMeta *meta = GetHLEModuleMetaByFlag(flag);
+		if (meta) {
+			list->Add(new BitCheckBox(&g_Config.iDisableHLE, (int)flag, meta->modname));
+		}
+	}
+
 #if !PPSSPP_PLATFORM(ANDROID) && !PPSSPP_PLATFORM(IOS) && !PPSSPP_PLATFORM(SWITCH)
 	list->Add(new ItemHeader(dev->T("MIPSTracer")));
 

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -1420,8 +1420,8 @@ static void DrawUtilityModules(ImConfig &cfg, ImControl &control) {
 			ImGui::PushID(i);
 			ImGui::TableNextRow();
 			ImGui::TableNextColumn();
-			if (ImGui::Selectable(info->name, cfg.selectedModule == i, ImGuiSelectableFlags_SpanAllColumns)) {
-				cfg.selectedModule = i;
+			if (ImGui::Selectable(info->name, cfg.selectedUtilityModule == i, ImGuiSelectableFlags_SpanAllColumns)) {
+				cfg.selectedUtilityModule = i;
 			}
 			ImGui::TableNextColumn();
 			if (loadedAddr) {
@@ -1463,8 +1463,8 @@ static void DrawModules(const MIPSDebugInterface *debug, ImConfig &cfg, ImContro
 			ImGui::PushID(id);
 			ImGui::TableNextRow();
 			ImGui::TableNextColumn();
-			if (ImGui::Selectable(module->GetName(), cfg.selectedModule == id, ImGuiSelectableFlags_SpanAllColumns)) {
-				cfg.selectedModule = id;
+			if (ImGui::Selectable(module->GetName(), cfg.selectedModuleId == id, ImGuiSelectableFlags_SpanAllColumns)) {
+				cfg.selectedModuleId = id;
 			}
 			ImGui::TableNextColumn();
 			ImClickableValue("addr", module->memoryBlockAddr, control, ImCmd::SHOW_IN_MEMORY_VIEWER);
@@ -1479,6 +1479,21 @@ static void DrawModules(const MIPSDebugInterface *debug, ImConfig &cfg, ImContro
 		ImGui::EndTable();
 	}
 
+	if (kernelObjects.Is<PSPModule>(cfg.selectedModuleId)) {
+		PSPModule *sel = kernelObjects.GetFast<PSPModule>(cfg.selectedModuleId);
+		if (sel) {
+			ImGui::Text("%s %d.%d (%s)\n", sel->GetName(), sel->nm.version[1], sel->nm.version[0], sel->isFake ? "FAKE/HLE" : "normal");
+			char buf[512];
+			sel->GetLongInfo(buf, sizeof(buf));
+			ImGui::TextUnformatted(buf);
+			if (ImGui::CollapsingHeader("Imports")) {
+
+			}
+			if (ImGui::CollapsingHeader("Exports")) {
+
+			}
+		}
+	}
 	//if (cfg.selectedModule >= 0 && cfg.selectedModule < (int)modules.size()) {
 		// TODO: Show details
 	//}
@@ -1509,8 +1524,8 @@ static void DrawSymbols(const MIPSDebugInterface *debug, ImConfig &cfg, ImContro
 			ImGui::PushID(i);
 			ImGui::TableNextRow();
 			ImGui::TableNextColumn();
-			if (ImGui::Selectable(module.name.c_str(), cfg.selectedModule == i, ImGuiSelectableFlags_SpanAllColumns)) {
-				cfg.selectedModule = i;
+			if (ImGui::Selectable(module.name.c_str(), cfg.selectedSymbolModule == i, ImGuiSelectableFlags_SpanAllColumns)) {
+				cfg.selectedSymbolModule = i;
 			}
 			ImGui::TableNextColumn();
 			ImClickableValue("addr", module.address, control, ImCmd::SHOW_IN_MEMORY_VIEWER);
@@ -1524,7 +1539,7 @@ static void DrawSymbols(const MIPSDebugInterface *debug, ImConfig &cfg, ImContro
 		ImGui::EndTable();
 	}
 
-	if (cfg.selectedModule >= 0 && cfg.selectedModule < (int)modules.size()) {
+	if (cfg.selectedModuleId >= 0 && cfg.selectedModuleId < (int)modules.size()) {
 		// TODO: Show details
 	}
 	ImGui::End();

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -1489,37 +1489,40 @@ static void DrawModules(const MIPSDebugInterface *debug, ImConfig &cfg, ImContro
 				if (mod->isFake) {
 					ImGui::PopStyleColor();
 				}
-				if (ImGui::CollapsingHeader("Import/export modules")) {
-					for (auto &name : mod->impExpModuleNames) {
+				if (!mod->impModuleNames.empty() && ImGui::CollapsingHeader("Imported modules")) {
+					for (auto &name : mod->impModuleNames) {
 						ImGui::TextUnformatted(name);
 					}
 				}
-				if (ImGui::CollapsingHeader("Imports")) {
-					if (!mod->importedVars.empty()) {
-						if (ImGui::CollapsingHeader("Vars")) {
+				if (!mod->expModuleNames.empty() && ImGui::CollapsingHeader("Exported modules")) {
+					for (auto &name : mod->expModuleNames) {
+						ImGui::TextUnformatted(name);
+					}
+				}
+				if (!mod->importedFuncs.empty() || !mod->importedVars.empty()) {
+					if (ImGui::CollapsingHeader("Imports")) {
+						if (!mod->importedVars.empty() && ImGui::CollapsingHeader("Vars")) {
 							for (auto &var : mod->importedVars) {
 								ImGui::TextUnformatted("(some var)");  // TODO
 							}
 						}
-					}
-					for (auto &import : mod->importedFuncs) {
-						// Look the name up in our HLE database.
-						const HLEFunction *func = GetHLEFunc(import.moduleName, import.nid);
-						ImGui::TextUnformatted(import.moduleName);
-						if (func) {
-							ImGui::SameLine();
-							ImGui::TextUnformatted(func->name);
+						for (auto &import : mod->importedFuncs) {
+							// Look the name up in our HLE database.
+							const HLEFunction *func = GetHLEFunc(import.moduleName, import.nid);
+							ImGui::TextUnformatted(import.moduleName);
+							if (func) {
+								ImGui::SameLine();
+								ImGui::TextUnformatted(func->name);
+							}
+							ImGui::SameLine(); ImClickableValue("addr", import.stubAddr, control, ImCmd::SHOW_IN_CPU_DISASM);
 						}
-						ImGui::SameLine(); ImClickableValue("addr", import.stubAddr, control, ImCmd::SHOW_IN_CPU_DISASM);
 					}
 				}
 				if (!mod->exportedFuncs.empty() || !mod->exportedVars.empty()) {
 					if (ImGui::CollapsingHeader("Exports")) {
-						if (!mod->exportedVars.empty()) {
-							if (ImGui::CollapsingHeader("Vars")) {
-								for (auto &var : mod->importedVars) {
-									ImGui::TextUnformatted("(some var)");  // TODO
-								}
+						if (!mod->exportedVars.empty() && ImGui::CollapsingHeader("Vars")) {
+							for (auto &var : mod->importedVars) {
+								ImGui::TextUnformatted("(some var)");  // TODO
 							}
 						}
 						for (auto &exportFunc : mod->exportedFuncs) {
@@ -1533,8 +1536,6 @@ static void DrawModules(const MIPSDebugInterface *debug, ImConfig &cfg, ImContro
 							ImGui::SameLine(); ImClickableValue("addr", exportFunc.symAddr, control, ImCmd::SHOW_IN_CPU_DISASM);
 						}
 					}
-				} else {
-					ImGui::TextUnformatted("(no symbols exported)");
 				}
 			}
 		} else {

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -124,6 +124,7 @@ struct ImConfig {
 	bool threadsOpen;
 	bool callstackOpen;
 	bool breakpointsOpen;
+	bool symbolsOpen;
 	bool modulesOpen;
 	bool hleModulesOpen;
 	bool audioDecodersOpen;

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -159,7 +159,8 @@ struct ImConfig {
 	// bool filterByUsed = true;
 
 	// Various selections
-	int selectedModule = 0;
+	int selectedModuleId = 0;
+	int selectedSymbolModule = 0;
 	int selectedUtilityModule = 0;
 	int selectedThread = 0;
 	int selectedKernelObject = 0;

--- a/ext/imgui/imgui_extras.h
+++ b/ext/imgui/imgui_extras.h
@@ -1,0 +1,12 @@
+// Just some string_view and related wrappers.
+
+#include <string_view>
+#include "ext/imgui/imgui.h"
+
+namespace ImGui {
+
+inline void TextUnformatted(std::string_view str) {
+	TextUnformatted(str.data(), str.data() + str.size());
+}
+
+}  // namespace ImGui


### PR DESCRIPTION
- Adds a new developer feature to individually disable HLE of certain modules. When disabling HLE of sceAtrac, some games manage to load a sceAtrac library and starts talking to the underlying sceAudiocodec library to decode frames, which currently fails, but that's still good. (The real goal here though is to remove our HLE of Psmf/PsmfPlayer - they are just a big ugly wrapper around sceMpeg, it turns out, and unlike sceAtrac they are always shipped on disc). Also sceFont - see #19115 

- Adds a new module viewer in ImDebugger, which lets you inspect imports/exports

- Corrects PRX dumping to actually dump the whole files even if compressed (oops)