### PR TITLE
Disable HLE of scePsmf and scePsmfPlayer

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -140,6 +140,7 @@ public:
 	int iAskForExitConfirmationAfterSeconds;
 	int iUIScaleFactor;  // In 8ths of powers of two.
 	int iDisableHLE;
+	int iForceEnableHLE;  // This is the opposite of DisableHLE but can force on HLE even when we've made it permanently off. Only used in tests, not hooked up to the ini file yet.
 
 	int iScreenRotation;  // The rotation angle of the PPSSPP UI. Only supported on Android and possibly other mobile platforms.
 	int iInternalScreenRotation;  // The internal screen rotation angle. Useful for vertical SHMUPs and similar.

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -189,9 +189,10 @@ const HLEModuleMeta *GetHLEModuleMetaByImport(std::string_view importModuleName)
 
 DisableHLEFlags AlwaysDisableHLEFlags() {
 	// Once a module seems stable to load properly, we'll graduate it here.
-	// This will hide the checkbox, too.
-	// return DisableHLEFlags::scePsmf | DisableHLEFlags::scePsmfPlayer;
-	return (DisableHLEFlags)0;
+	// This will hide the checkbox in Developer Settings, too.
+	//
+	// PSMF testing issue: #20200
+	return DisableHLEFlags::scePsmf | DisableHLEFlags::scePsmfPlayer;
 }
 
 // Process compat flags.

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -201,6 +201,8 @@ static DisableHLEFlags GetDisableHLEFlags() {
 	if (PSP_CoreParameter().compat.flags().DisableHLESceFont) {
 		flags |= DisableHLEFlags::sceFont;
 	}
+
+	flags &= ~(DisableHLEFlags)g_Config.iForceEnableHLE;
 	return flags;
 }
 

--- a/headless/Headless.cpp
+++ b/headless/Headless.cpp
@@ -1,3 +1,4 @@
+
 // Headless version of PPSSPP, for testing using http://code.google.com/p/pspautotests/ .
 // See headless.txt.
 // To build on non-windows systems, just run CMake in the SDL directory, it will build both a normal ppsspp and the headless version.
@@ -537,6 +538,7 @@ int main(int argc, const char* argv[])
 	g_Config.iReverbVolume = VOLUMEHI_FULL;
 	g_Config.internalDataDirectory.clear();
 	g_Config.bUseOldAtrac = oldAtrac;
+	g_Config.iForceEnableHLE = 0xFFFFFFFF;  // Run all modules as HLE. We don't have anything to load in this context.
 
 	Path exePath = File::GetExeDirectory();
 	g_Config.flash0Directory = exePath / "assets/flash0";


### PR DESCRIPTION
Testing has shown that this seems to work great and fixes issues, such as #18094. These two modules are just a parser and a shim over sceMpeg, and we're better off actually loading them and running the original code, instead of re-implementing it through HLE.

sceMpeg still needs accuracy improvements though, and it's built on some pretty low level components so it will be harder to peel off the next level of the HLE onion.

See #20200.

If there are regressions, this is trivial and even quite safe to revert.