### PR TITLE
Misc fixes and cleanup, use DisableHLE with "sceCcc"

### DIFF
--- a/Common/Log.cpp
+++ b/Common/Log.cpp
@@ -47,7 +47,8 @@ static void *g_assertCancelCallbackUserData = 0;
 
 void SetAssertDialogParent(void *handle) {
 #if PPSSPP_PLATFORM(WINDOWS)
-	g_dialogParent = (HWND)handle;
+	// I thought this would be nice, but for some reason the dialog becomes invisible.
+	// g_dialogParent = (HWND)handle;
 #endif
 }
 

--- a/Common/UI/ViewGroup.h
+++ b/Common/UI/ViewGroup.h
@@ -305,7 +305,8 @@ public:
 
 	void AddBack(UIScreen *parent);
 
-	void SetCurrentTab(int tab, bool skipTween = false);
+	// Returns true if the tab wasn't created before (but is now).
+	bool SetCurrentTab(int tab, bool skipTween = false);
 
 	int GetCurrentTab() const { return currentTab_; }
 	std::string DescribeLog() const override { return "TabHolder: " + View::DescribeLog(); }
@@ -323,7 +324,7 @@ public:
 private:
 	void AddTabContents(std::string_view title, ViewGroup *tabContents);
 	EventReturn OnTabClick(EventParams &e);
-	void EnsureTab(int index);
+	bool EnsureTab(int index);  // return true if it actually created a tab.
 
 	View *bannerView_ = nullptr;
 	LinearLayout *tabContainer_ = nullptr;

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -125,7 +125,8 @@ enum class DisableHLEFlags : int {
 	sceMpeg = (1 << 4),
 	sceMp3 = (1 << 5),
 	sceParseHttp = (1 << 6),
-	Count = 7,
+	sceCcc = (1 << 7),  // character conversion library.
+	Count = 8,
 	// TODO: Some of the networking libraries may be interesting candidates, like HTTP.
 };
 ENUM_CLASS_BITOPS(DisableHLEFlags);

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -192,7 +192,8 @@ DisableHLEFlags AlwaysDisableHLEFlags() {
 	// This will hide the checkbox in Developer Settings, too.
 	//
 	// PSMF testing issue: #20200
-	return DisableHLEFlags::scePsmf | DisableHLEFlags::scePsmfPlayer;
+	// sceCcc is simply a character conversion library, zero deps. If available we just load it.
+	return DisableHLEFlags::scePsmf | DisableHLEFlags::scePsmfPlayer | DisableHLEFlags::sceCcc;
 }
 
 // Process compat flags.

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -151,7 +151,7 @@ static const HLEModuleMeta g_moduleMeta[] = {
 	{"scePsmfP_library", "scePsmfPlayer", DisableHLEFlags::scePsmfPlayer},
 	{"scePsmfPlayer", "scePsmfPlayer", DisableHLEFlags::scePsmfPlayer},
 	{"sceSAScore", "sceSasCore"},
-	{"sceCcc_Library", "sceCcc"},
+	{"sceCcc_Library", "sceCcc", DisableHLEFlags::sceCcc},
 	{"SceParseHTTPheader_Library", "sceParseHttp", DisableHLEFlags::sceParseHttp},
 	{"SceParseURI_Library"},
 	// Guessing these names

--- a/Core/HLE/HLE.cpp
+++ b/Core/HLE/HLE.cpp
@@ -139,7 +139,7 @@ static const HLEModuleMeta g_moduleMeta[] = {
 	{"sceSsl_Module"},
 	{"sceDEFLATE_Library"},
 	{"sceMD5_Library"},
-	{"sceMemab"},
+	{"sceMemab"},  // Underlying AdHoc crypto library
 	{"sceAvcodec_driver"},
 	{"sceAudiocodec_Driver"},
 	{"sceAudiocodec"},

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -28,7 +28,6 @@
 #include "Core/Reporting.h"
 #include "Core/Config.h"
 #include "Core/Debugger/MemBlockInfo.h"
-#include "Core/HW/MediaEngine.h"
 #include "Core/HW/BufferQueue.h"
 
 #include "Core/HLE/sceKernel.h"

--- a/Core/HLE/sceAudiocodec.h
+++ b/Core/HLE/sceAudiocodec.h
@@ -67,16 +67,16 @@ struct SceAudiocodecCodec {
 	s32 unk48;  // 30 Atrac3 (non-+) related. Zero with Atrac3+.
 	s32 unk52;  // 34
 	s32 mp3_9999;  // 38  // unk56
-	s32 unk60;
+	s32 mp3_3;  // unk60 gets the value 3
 	s32 unk64;  // Atrac3+ size related
-	s32 unk68;
-	s32 unk72;
+	s32 mp3_9;
+	s32 mp3_0;
 	s32 unk76;
 	s32 unk80;
-	s32 unk84;
+	s32 mp3_1_first;
 	s32 unk88;
 	s32 unk92;
-	s32 unk96;
+	s32 mp3_1;
 	s32 unk100;
 	u32 allocMem; // 104
 	// make sure the size is 128

--- a/Core/HLE/sceKernelModule.cpp
+++ b/Core/HLE/sceKernelModule.cpp
@@ -1180,9 +1180,15 @@ static PSPModule *__KernelLoadELFFromPtr(const u8 *ptr, size_t elfSize, u32 load
 
 			// If we've made it this far, it should be safe to dump.
 			// Copy the name to ensure it's null terminated.
-			char name[32]{};
-			strncpy(name, head->modname, ARRAY_SIZE(head->modname));
-			DumpFileIfEnabled(ptr, (u32)elfSize, name, DumpFileType::EBOOT);
+			// TODO: How do we determine if it's the eboot?
+			if (endsWith(filename, "BOOT.BIN")) {
+				DumpFileIfEnabled(ptr, (u32)elfSize, "EBOOT.BIN", DumpFileType::EBOOT);
+			} else {
+				char name[32]{};
+				strncpy(name, head->modname, ARRAY_SIZE(head->modname));
+
+				DumpFileIfEnabled(ptr, (u32)elfSize, name, DumpFileType::PRX);
+			}
 		}
 	}
 

--- a/Core/HLE/sceMp3.cpp
+++ b/Core/HLE/sceMp3.cpp
@@ -76,7 +76,6 @@
 #include "Core/HLE/FunctionWrappers.h"
 #include "Core/HLE/sceKernelMemory.h"
 #include "Core/HLE/sceMp3.h"
-#include "Core/HW/MediaEngine.h"
 #include "Core/HW/SimpleAudioDec.h"
 #include "Core/MemMap.h"
 #include "Core/Reporting.h"

--- a/Core/HLE/scePsmf.cpp
+++ b/Core/HLE/scePsmf.cpp
@@ -15,6 +15,8 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+// NOTE: See note in header file. scePsmf/scePsmf are now unmaintained legacy.
+
 #include "Common/Serialize/Serializer.h"
 #include "Common/Serialize/SerializeFuncs.h"
 #include "Common/Serialize/SerializeMap.h"

--- a/Core/HLE/scePsmf.h
+++ b/Core/HLE/scePsmf.h
@@ -15,6 +15,12 @@
 // Official git repository and contact information can be found at
 // https://github.com/hrydgard/ppsspp and http://www.ppsspp.org/.
 
+
+// NOTE: This is now unmaintained legacy code. scePsmf/scePsmfPlayer is just a wrapper over sceMpeg
+// which is always shipped by games that use it, so we simply load the libraries now and focus
+// on emulating sceMpeg as accurately as possible. We might actually go one step deeper if we can
+// figure out sceVideocodec, as sceMpeg is also often shipped.
+
 #pragma once
 
 void Register_scePsmf();

--- a/Core/HLE/sceSas.cpp
+++ b/Core/HLE/sceSas.cpp
@@ -283,7 +283,7 @@ static u32 _sceSasCoreWithMix(u32 core, u32 inoutAddr, int leftVolume, int right
 		return hleReportError(Log::sceSas, SCE_SAS_ERROR_INVALID_PARAMETER, "invalid address");
 	}
 	if (sas->outputMode == PSP_SAS_OUTPUTMODE_RAW) {
-		return hleReportError(Log::sceSas, 0x80000004, "unsupported outputMode");
+		return hleReportError(Log::sceSas, SCE_KERNEL_ERROR_BAD_ARGUMENT, "unsupported outputMode");
 	}
 	if (!__KernelIsDispatchEnabled()) {
 		return hleLogError(Log::sceSas, SCE_KERNEL_ERROR_CAN_NOT_WAIT, "dispatch disabled");

--- a/GPU/GPUCommon.cpp
+++ b/GPU/GPUCommon.cpp
@@ -532,7 +532,7 @@ u32 GPUCommon::Continue(bool *runList) {
 	else
 	{
 		if (sceKernelGetCompiledSdkVersion() >= 0x02000000)
-			return 0x80000004;
+			return 0x80000004;  // matches SCE_KERNEL_ERROR_BAD_ARGUMENT but doesn't really seem like it. Maybe that error code is more general.
 		return -1;
 	}
 

--- a/UI/EmuScreen.cpp
+++ b/UI/EmuScreen.cpp
@@ -1283,6 +1283,9 @@ void EmuScreen::deviceLost() {
 	UIScreen::deviceLost();
 
 	if (imguiInited_) {
+		if (imDebugger_) {
+			imDebugger_->DeviceLost();
+		}
 		ImGui_ImplThin3d_DestroyDeviceObjects();
 	}
 }

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -1914,8 +1914,6 @@ void DeveloperToolsScreen::CreateViews() {
 	cpuTests->SetEnabled(TestsAvailable());
 #endif
 
-	list->Add(new CheckBox(&g_Config.bUseOldAtrac, dev->T("Use the old sceAtrac implementation")));
-
 	AddOverlayList(list, screenManager());
 
 	list->Add(new CheckBox(&g_Config.bEnableLogging, dev->T("Enable Logging")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLoggingChanged);
@@ -1990,6 +1988,8 @@ void DeveloperToolsScreen::CreateViews() {
 
 	auto displayRefreshRate = list->Add(new PopupSliderChoice(&g_Config.iDisplayRefreshRate, 60, 1000, 60, dev->T("Display refresh rate"), 1, screenManager()));
 	displayRefreshRate->SetFormat(si->T("%d Hz"));
+
+	list->Add(new CheckBox(&g_Config.bUseOldAtrac, dev->T("Use the old sceAtrac implementation")));
 
 	list->Add(new ItemHeader("Dump file types"));
 	list->Add(new BitCheckBox(&g_Config.iDumpFileTypes, (int)DumpFileType::EBOOT, dev->T("Dump Decrypted Eboot", "Dump Decrypted EBOOT.BIN (If Encrypted) When Booting Game")));

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -474,6 +474,7 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 
 	PopupMultiChoice *depthRasterMode = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iDepthRasterMode, gr->T("Lens flare occlusion"), depthRasterModes, 0, ARRAY_SIZE(depthRasterModes), I18NCat::GRAPHICS, screenManager()));
 	depthRasterMode->SetDisabledPtr(&g_Config.bSoftwareRendering);
+	depthRasterMode->SetChoiceIcon(3, ImageID("I_WARNING"));  // It's a performance trap.
 
 	CheckBox *texBackoff = graphicsSettings->Add(new CheckBox(&g_Config.bTextureBackoffCache, gr->T("Lazy texture caching", "Lazy texture caching (speedup)")));
 	texBackoff->SetDisabledPtr(&g_Config.bSoftwareRendering);

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -649,10 +649,26 @@ static void DrawInternals(ImConfig &cfg) {
 		{DIRECTORY_CUSTOM_THEMES, "CUSTOM_THEMES"},
 	};
 
-	if (ImGui::CollapsingHeader("Directories", ImGuiTreeNodeFlags_DefaultOpen)) {
+	if (ImGui::CollapsingHeader("GetSysDirectory")) {
 		for (auto &dir : dirs) {
 			ImGui::Text("%s: %s", dir.name, GetSysDirectory(dir.dir).c_str());
 		}
+	}
+
+	if (ImGui::CollapsingHeader("Memory")) {
+		ImGui::Text("Base pointer: %p", Memory::base);
+		ImGui::Text("Main memory size: %08x", Memory::g_MemorySize);
+		if (ImGui::Button("Copy to clipboard")) {
+			System_CopyStringToClipboard(StringFromFormat("0x%p", Memory::base));
+		}
+	}
+
+	if (ImGui::CollapsingHeader("ImGui state")) {
+		const auto &io = ImGui::GetIO();
+		ImGui::Text("WantCaptureMouse: %s", BoolStr(io.WantCaptureMouse));
+		ImGui::Text("WantCaptureKeyboard: %s", BoolStr(io.WantCaptureKeyboard));
+		ImGui::Text("WantCaptureMouseUnlessPopupClose: %s", BoolStr(io.WantCaptureMouseUnlessPopupClose));
+		ImGui::Text("WantTextInput: %s", BoolStr(io.WantTextInput));
 	}
 
 	ImGui::End();
@@ -671,15 +687,6 @@ static void DrawAdhoc(ImConfig &cfg) {
 	case 2: discoverStatusStr = "COMPLETED"; break;
 	default: break;
 	}
-
-	auto &io = ImGui::GetIO();
-
-	/*
-	ImGui::Text("WantCaptureMouse: %s", BoolStr(io.WantCaptureMouse));
-	ImGui::Text("WantCaptureKeyboard: %s", BoolStr(io.WantCaptureKeyboard));
-	ImGui::Text("WantCaptureMouseUnlessPopupClose: %s", BoolStr(io.WantCaptureMouseUnlessPopupClose));
-	ImGui::Text("WantTextInput: %s", BoolStr(io.WantTextInput));
-	*/
 
 	ImGui::Text("sceNetAdhoc inited: %s", BoolStr(netAdhocInited));
 	ImGui::Text("sceNetAdhocctl inited: %s", BoolStr(netAdhocctlInited));
@@ -1710,6 +1717,9 @@ void DrawHLEModules(ImConfig &config) {
 						case 'I': amask[i] = 'd'; break;
 						case 'f':
 						case 'F': amask[i] = 'x'; break;
+						default:
+							// others go straight through (p)
+							break;
 						}
 					}
 					w.F("%s 0x%08x %d %s", func.name, func.ID, strlen(func.argmask), amask.c_str()).endl();
@@ -2420,6 +2430,11 @@ void ImDisasmWindow::Draw(MIPSDebugInterface *mipsDebug, ImConfig &cfg, ImContro
 
 	StatusBar(disasmView_.StatusBarText());
 	ImGui::End();
+}
+
+void ImDebugger::DeviceLost() {
+	pixelViewer_.DeviceLost();
+	geDebugger_.DeviceLost();
 }
 
 Path ImDebugger::ConfigPath() {

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -237,6 +237,7 @@ public:
 	void PostCmd(ImCommand cmd) {
 		externalCommand_ = cmd;
 	}
+	void DeviceLost();
 
 private:
 	Path ConfigPath();

--- a/UI/ImDebugger/ImGe.h
+++ b/UI/ImDebugger/ImGe.h
@@ -70,6 +70,7 @@ struct ImGePixelViewer : public PixelLookup {
 		dirty_ = true;
 	}
 	bool FormatValueAt(char *buf, size_t bufSize, int x, int y) const override;
+	void DeviceLost();
 
 	uint32_t addr = 0x04110000;
 	uint16_t stride = 512;
@@ -95,6 +96,7 @@ struct ImGeReadbackViewer : public PixelLookup {
 		dirty_ = true;
 	}
 	bool FormatValueAt(char *buf, size_t bufSize, int x, int y) const override;
+	void DeviceLost();
 
 	// TODO: This is unsafe! If you load state for example with the debugger open...
 	// We need to re-fetch this each frame from the parameters.
@@ -124,6 +126,9 @@ public:
 		viewer_.stride = stride;
 		viewer_.format = format;
 	}
+	void DeviceLost() {
+		viewer_.DeviceLost();
+	}
 
 private:
 	ImGePixelViewer viewer_;
@@ -140,6 +145,7 @@ public:
 		return "GE Debugger";
 	}
 	void NotifyStep();
+	void DeviceLost();
 
 private:
 	ImGeDisasmView disasmView_;

--- a/UI/TabbedDialogScreen.cpp
+++ b/UI/TabbedDialogScreen.cpp
@@ -94,7 +94,6 @@ void TabbedUIDialogScreenWithGameBackground::CreateViews() {
 
 				noSearchResults_ = searchSettings->Add(new TextView("", new LinearLayoutParams(Margins(20, 5))));
 			}, true);
-
 		}
 	}
 }

--- a/Windows/EmuThread.cpp
+++ b/Windows/EmuThread.cpp
@@ -67,7 +67,6 @@ void MainThread_Start(bool separateEmuThread) {
 void MainThread_Stop() {
 	// Already stopped?
 	UpdateUIState(UISTATE_EXIT);
-	Core_Stop();
 	_dbg_assert_(mainThread.joinable());
 	mainThread.join();
 }

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1247,12 +1247,6 @@ ULJS19067 = true
 ULAS42247 = true
 ULAS42318 = true
 
-[DisableFirstFrameReadback]
-# SOCOM: Fireteam Bravo 3 (see issue #18958, hopefully fixes crash in Stockpile mission, #10461)
-UCES-01242 = true
-NPJG-00035 = true
-NPHG-00032 = true
-
 [MpegAvcWarmUp]
 # God Eater issue #13527 ,It is custom mpeg library that required sceMpegGetAvcAu return ERROR_MPEG_NO_DATA but break FIFA 14 issue #14086
 # God Eater 1


### PR DESCRIPTION
Fixes #20217, and some other minor things.

Also, `sceCcc` is a trivial character conversion library, which is shipped with a few games.. Let's actually run it instead of HLE:ing it, it should be completely safe since it has no dependencies and doesn't load any files on its own. This will allow us to later delete our code that HLE-emulates it.

Some more work on MP3 support in sceAudiocodec, unfortunately not yet enough to work with Beats.