### PR TITLE
Fix lens flare in L.A. Rush

### DIFF
--- a/GPU/Common/DrawEngineCommon.cpp
+++ b/GPU/Common/DrawEngineCommon.cpp
@@ -35,15 +35,8 @@
 #include "GPU/ge_constants.h"
 #include "GPU/GPUState.h"
 
-#define QUAD_INDICES_MAX 65536
-
 enum {
 	TRANSFORMED_VERTEX_BUFFER_SIZE = VERTEX_BUFFER_MAX * sizeof(TransformedVertex),
-	DEPTH_TRANSFORMED_SIZE = VERTEX_BUFFER_MAX * 4 * sizeof(float),
-	DEPTH_SCREENVERTS_COMPONENT_COUNT = VERTEX_BUFFER_MAX,
-	DEPTH_SCREENVERTS_COMPONENT_SIZE = DEPTH_SCREENVERTS_COMPONENT_COUNT * sizeof(int) + 384,
-	DEPTH_SCREENVERTS_SIZE = DEPTH_SCREENVERTS_COMPONENT_SIZE * 3,
-	DEPTH_INDEXBUFFER_SIZE = VERTEX_BUFFER_MAX * 3 * sizeof(uint16_t),
 };
 
 DrawEngineCommon::DrawEngineCommon() : decoderMap_(32) {
@@ -902,6 +895,21 @@ bool DrawEngineCommon::DescribeCodePtr(const u8 *ptr, std::string &name) const {
 	}
 }
 
+enum {
+	DEPTH_TRANSFORMED_MAX_VERTS = VERTEX_BUFFER_MAX,
+	DEPTH_TRANSFORMED_BYTES = DEPTH_TRANSFORMED_MAX_VERTS * 4 * sizeof(float),
+	DEPTH_SCREENVERTS_COMPONENT_COUNT = VERTEX_BUFFER_MAX,
+	DEPTH_SCREENVERTS_COMPONENT_BYTES = DEPTH_SCREENVERTS_COMPONENT_COUNT * sizeof(int) + 384,
+	DEPTH_SCREENVERTS_TOTAL_BYTES = DEPTH_SCREENVERTS_COMPONENT_BYTES * 3,
+	DEPTH_INDEXBUFFER_BYTES = DEPTH_TRANSFORMED_MAX_VERTS * 3 * sizeof(uint16_t),  // hmmm
+};
+
+// We process vertices for depth rendering in several stages:
+// First, we transform and collect vertices into depthTransformed_ (4-vectors, xyzw).
+// Then, we group and cull the vertices into four-triangle groups, which are placed in
+// depthScreenVerts_, with x, y and z separated into different part of the array.
+// (Alternatively, if drawing rectangles, they're just added linearly).
+// After that, we send these groups out for SIMD setup and rasterization.
 void DrawEngineCommon::InitDepthRaster() {
 	switch ((DepthRasterMode)g_Config.iDepthRasterMode) {
 	case DepthRasterMode::DEFAULT:
@@ -917,21 +925,21 @@ void DrawEngineCommon::InitDepthRaster() {
 
 	if (useDepthRaster_) {
 		depthDraws_.reserve(256);
-		depthTransformed_ = (float *)AllocateMemoryPages(DEPTH_TRANSFORMED_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
-		depthScreenVerts_ = (int *)AllocateMemoryPages(DEPTH_SCREENVERTS_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
-		depthIndices_ = (uint16_t *)AllocateMemoryPages(DEPTH_INDEXBUFFER_SIZE, MEM_PROT_READ | MEM_PROT_WRITE);
+		depthTransformed_ = (float *)AllocateMemoryPages(DEPTH_TRANSFORMED_BYTES, MEM_PROT_READ | MEM_PROT_WRITE);
+		depthScreenVerts_ = (int *)AllocateMemoryPages(DEPTH_SCREENVERTS_TOTAL_BYTES, MEM_PROT_READ | MEM_PROT_WRITE);
+		depthIndices_ = (uint16_t *)AllocateMemoryPages(DEPTH_INDEXBUFFER_BYTES, MEM_PROT_READ | MEM_PROT_WRITE);
 	}
 }
 
 void DrawEngineCommon::ShutdownDepthRaster() {
 	if (depthTransformed_) {
-		FreeMemoryPages(depthTransformed_, DEPTH_TRANSFORMED_SIZE);
+		FreeMemoryPages(depthTransformed_, DEPTH_TRANSFORMED_BYTES);
 	}
 	if (depthScreenVerts_) {
-		FreeMemoryPages(depthScreenVerts_, DEPTH_SCREENVERTS_SIZE);
+		FreeMemoryPages(depthScreenVerts_, DEPTH_SCREENVERTS_TOTAL_BYTES);
 	}
 	if (depthIndices_) {
-		FreeMemoryPages(depthIndices_, DEPTH_INDEXBUFFER_SIZE);
+		FreeMemoryPages(depthIndices_, DEPTH_INDEXBUFFER_BYTES);
 	}
 }
 
@@ -998,8 +1006,8 @@ bool DrawEngineCommon::CalculateDepthDraw(DepthDraw *draw, GEPrimitiveType prim,
 		_dbg_assert_(gstate.isDepthWriteEnabled());
 	}
 
-	if (depthVertexCount_ + vertexCount >= DEPTH_INDEXBUFFER_SIZE) {
-		// Can't add more.
+	if (depthVertexCount_ + vertexCount >= DEPTH_TRANSFORMED_MAX_VERTS) {
+		// Can't add more. We need to flush.
 		return false;
 	}
 
@@ -1018,7 +1026,7 @@ bool DrawEngineCommon::CalculateDepthDraw(DepthDraw *draw, GEPrimitiveType prim,
 	return true;
 }
 
-void DrawEngineCommon::DepthRasterTransform(GEPrimitiveType prim, VertexDecoder *dec, uint32_t vertTypeID, int vertexCount) {
+void DrawEngineCommon::DepthRasterSubmitRaw(GEPrimitiveType prim, VertexDecoder *dec, uint32_t vertTypeID, int vertexCount) {
 	if (!gstate.isModeClear() && (!gstate.isDepthTestEnabled() || !gstate.isDepthWriteEnabled())) {
 		return;
 	}
@@ -1043,8 +1051,9 @@ void DrawEngineCommon::DepthRasterTransform(GEPrimitiveType prim, VertexDecoder 
 	int numDecoded = 0;
 	for (int i = 0; i < numDrawVerts_; i++) {
 		const DeferredVerts &dv = drawVerts_[i];
-		if (dv.indexUpperBound + 1 - dv.indexLowerBound + numDecoded >= VERTEX_BUFFER_MAX) {
+		if (dv.indexUpperBound + 1 - dv.indexLowerBound + numDecoded >= DEPTH_TRANSFORMED_MAX_VERTS) {
 			// Hit our limit! Stop decoding in this draw.
+			// We should have already broken out in CalculateDepthDraw.
 			break;
 		}
 		// Decode the verts (and at the same time apply morphing/skinning). Simple.
@@ -1080,6 +1089,7 @@ void DrawEngineCommon::DepthRasterPredecoded(GEPrimitiveType prim, const void *i
 
 	TimeCollector collectStat(&gpuStats.msPrepareDepth, coreCollectDebugStats);
 
+	// Make sure these have already been indexed away.
 	_dbg_assert_(prim != GE_PRIM_TRIANGLE_STRIP && prim != GE_PRIM_TRIANGLE_FAN);
 
 	if (dec->throughmode) {

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -177,6 +177,8 @@ protected:
 
 	void ApplyFramebufferRead(FBOTexState *fboTexState);
 
+	void InitDepthRaster();
+	void ShutdownDepthRaster();
 	void DepthRasterTransform(GEPrimitiveType prim, VertexDecoder *dec, uint32_t vertTypeID, int vertexCount);
 	void DepthRasterPredecoded(GEPrimitiveType prim, const void *inVerts, int numDecoded, VertexDecoder *dec, int vertexCount);
 	bool CalculateDepthDraw(DepthDraw *draw, GEPrimitiveType prim, int vertexCount);

--- a/GPU/Common/DrawEngineCommon.h
+++ b/GPU/Common/DrawEngineCommon.h
@@ -179,7 +179,7 @@ protected:
 
 	void InitDepthRaster();
 	void ShutdownDepthRaster();
-	void DepthRasterTransform(GEPrimitiveType prim, VertexDecoder *dec, uint32_t vertTypeID, int vertexCount);
+	void DepthRasterSubmitRaw(GEPrimitiveType prim, VertexDecoder *dec, uint32_t vertTypeID, int vertexCount);
 	void DepthRasterPredecoded(GEPrimitiveType prim, const void *inVerts, int numDecoded, VertexDecoder *dec, int vertexCount);
 	bool CalculateDepthDraw(DepthDraw *draw, GEPrimitiveType prim, int vertexCount);
 

--- a/GPU/D3D11/DrawEngineD3D11.cpp
+++ b/GPU/D3D11/DrawEngineD3D11.cpp
@@ -327,7 +327,7 @@ void DrawEngineD3D11::Flush() {
 			}
 		}
 		if (useDepthRaster_) {
-			DepthRasterTransform(prim, dec_, dec_->VertexType(), vertexCount);
+			DepthRasterSubmitRaw(prim, dec_, dec_->VertexType(), vertexCount);
 		}
 	} else {
 		PROFILE_THIS_SCOPE("soft");

--- a/GPU/Directx9/DrawEngineDX9.cpp
+++ b/GPU/Directx9/DrawEngineDX9.cpp
@@ -293,7 +293,7 @@ void DrawEngineDX9::Flush() {
 			}
 		}
 		if (useDepthRaster_) {
-			DepthRasterTransform(prim, dec_, dec_->VertexType(), vertexCount);
+			DepthRasterSubmitRaw(prim, dec_, dec_->VertexType(), vertexCount);
 		}
 	} else {
 		VertexDecoder *swDec = dec_;

--- a/GPU/GLES/DrawEngineGLES.cpp
+++ b/GPU/GLES/DrawEngineGLES.cpp
@@ -316,7 +316,7 @@ void DrawEngineGLES::Flush() {
 				glprim[prim], 0, vertexCount);
 		}
 		if (useDepthRaster_) {
-			DepthRasterTransform(prim, dec_, dec_->VertexType(), vertexCount);
+			DepthRasterSubmitRaw(prim, dec_, dec_->VertexType(), vertexCount);
 		}
 	} else {
 		PROFILE_THIS_SCOPE("soft");

--- a/GPU/Vulkan/DrawEngineVulkan.cpp
+++ b/GPU/Vulkan/DrawEngineVulkan.cpp
@@ -371,7 +371,7 @@ void DrawEngineVulkan::Flush() {
 			renderManager->Draw(descSetIndex, ARRAY_SIZE(dynamicUBOOffsets), dynamicUBOOffsets, vbuf, vbOffset, vertexCount);
 		}
 		if (useDepthRaster_) {
-			DepthRasterTransform(prim, dec_, dec_->VertexType(), vertexCount);
+			DepthRasterSubmitRaw(prim, dec_, dec_->VertexType(), vertexCount);
 		}
 	} else {
 		PROFILE_THIS_SCOPE("soft");

--- a/assets/compat.ini
+++ b/assets/compat.ini
@@ -1712,6 +1712,10 @@ UCAS40289 = true
 NPUH10025 = true
 NPEH00047 = true
 
+# L.A. Rush (also known as just Rush) (sun lens flare)
+ULES00554 = true
+ULUS10174 = true
+
 [BlockTransferDepth]
 # Iron Man - see issue #16530
 # Note that this option also requires IntraVRAMBlockTransferAllowCreateFB.


### PR DESCRIPTION
Actually this fixes a crash in depth raster, which makes it possible to enable it for L.A. Rush (aka just Rush).

This fixes the sun lens flare in the game, part of #15923 