### PR TITLE
Fix Star Ocean with MSAA enabled: don't use the blit optimization (Vulkan)

### DIFF
--- a/Common/GPU/Vulkan/VulkanQueueRunner.cpp
+++ b/Common/GPU/Vulkan/VulkanQueueRunner.cpp
@@ -1525,6 +1525,10 @@ void VulkanQueueRunner::PerformBlit(const VKRStep &step, VkCommandBuffer cmd) {
 	int layerCount = std::min(step.blit.src->numLayers, step.blit.dst->numLayers);
 	_dbg_assert_(step.blit.src->numLayers >= step.blit.dst->numLayers);
 
+	// Blitting is not allowed for multisample images. You're suppose to use vkCmdResolveImage but it only goes in one direction (multi to single).
+	_dbg_assert_(step.blit.src->sampleCount == VkSampleCountFlagBits::VK_SAMPLE_COUNT_1_BIT);
+	_dbg_assert_(step.blit.dst->sampleCount == VkSampleCountFlagBits::VK_SAMPLE_COUNT_1_BIT);
+
 	VKRFramebuffer *src = step.blit.src;
 	VKRFramebuffer *dst = step.blit.dst;
 

--- a/GPU/Common/StencilCommon.cpp
+++ b/GPU/Common/StencilCommon.cpp
@@ -290,6 +290,11 @@ bool FramebufferManagerCommon::PerformWriteStencilFromMemory(u32 addr, int size,
 		useBlit = false;
 	}
 
+	// Blitting to (or from) multisampled images is not allowed.
+	if (dstBuffer->fbo && dstBuffer->fbo->MultiSampleLevel() != 0) {
+		useBlit = false;
+	}
+
 	u16 w = useBlit ? dstBuffer->width : dstBuffer->renderWidth;
 	u16 h = useBlit ? dstBuffer->height : dstBuffer->renderHeight;
 


### PR DESCRIPTION
Can't blit to multisampled images, so let's just use the path where we multipass-draw the stencil buffer directly instead of drawing it at a small scale and then upscaling it.

Fixes the Star Ocean part of #20105