### PR TITLE
Adding missing include in CyclicBuffer.h

### DIFF
--- a/Common/Data/Collections/CyclicBuffer.h
+++ b/Common/Data/Collections/CyclicBuffer.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <vector>
-
+#include <iterator>
 #include "Common/CommonTypes.h"
 
 


### PR DESCRIPTION
I found I had to do this to prevent a compilation error in a Windows build.