### PR TITLE
Show little indicators on achievements of the type 

### DIFF
--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -970,7 +970,7 @@ static u32 sceIoGetstat(const char *filename, u32 addr) {
 			return hleDelayResult(hleLogError(Log::sceIo, -1, "bad address"), "io getstat", usec);
 		}
 	} else {
-		return hleDelayResult(hleLogError(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND, "FILE NOT FOUND"), "io getstat", usec);
+		return hleDelayResult(hleLogWarning(Log::sceIo, SCE_KERNEL_ERROR_ERRNO_FILE_NOT_FOUND, "FILE NOT FOUND"), "io getstat", usec);
 	}
 }
 

--- a/UI/RetroAchievementScreens.cpp
+++ b/UI/RetroAchievementScreens.cpp
@@ -510,7 +510,24 @@ void RenderAchievement(UIContext &dc, const rc_client_achievement_t *achievement
 	case AchievementRenderStyle::UNLOCKED:
 	{
 		dc.SetFontScale(1.0f, 1.0f);
-		dc.DrawTextRect(achievement->title, bounds.Inset(iconSpace + 12.0f, 2.0f, padding, padding), fgColor, ALIGN_TOPLEFT);
+		std::string title = achievement->title;
+
+		// Add simple display of the achievement types.
+		// Needs refinement, but works.
+		// See issue #19632
+		switch (achievement->type) {
+		case RC_CLIENT_ACHIEVEMENT_TYPE_MISSABLE:
+			title += " [m]";
+			break;
+		case RC_CLIENT_ACHIEVEMENT_TYPE_PROGRESSION:
+			title += " [p]";
+			break;
+		case RC_CLIENT_ACHIEVEMENT_TYPE_WIN:
+			title += " [win]";
+			break;
+		}
+
+		dc.DrawTextRect(title, bounds.Inset(iconSpace + 12.0f, 2.0f, padding, padding), fgColor, ALIGN_TOPLEFT);
 
 		dc.SetFontScale(0.66f, 0.66f);
 		dc.DrawTextRectSqueeze(DeNull(achievement->description), bounds.Inset(iconSpace + 12.0f, 39.0f, padding, padding), fgColor, ALIGN_TOPLEFT);


### PR DESCRIPTION
[p] for progression, [m] for missable, [win] for win.

Fixes part of  #19632, although not exactly pretty. 