### PR TITLE
ImDebugger: Add some audio investigation tools

### DIFF
--- a/Core/Config.h
+++ b/Core/Config.h
@@ -263,6 +263,7 @@ public:
 	int iDefaultTab;
 	int iScreenshotMode;
 	bool bVulkanDisableImplicitLayers;
+	bool bForceFfmpegForAudioDec;
 
 	std::vector<std::string> vPostShaderNames; // Off for chain end (only Off for no shader)
 	std::map<std::string, float> mPostShaderSetting;

--- a/Core/HLE/AtracCtx2.cpp
+++ b/Core/HLE/AtracCtx2.cpp
@@ -819,7 +819,7 @@ int Atrac2::SetData(const Track &track, u32 bufferAddr, u32 readSize, u32 buffer
 
 	SceAtracIdInfo &info = context_->info;
 
-	if (track.codecType != PSP_MODE_AT_3 && track.codecType != PSP_MODE_AT_3_PLUS) {
+	if (track.codecType != PSP_CODEC_AT3 && track.codecType != PSP_CODEC_AT3PLUS) {
 		// Shouldn't have gotten here, Analyze() checks this.
 		ERROR_LOG(Log::ME, "unexpected codec type %d in set data", track.codecType);
 		return SCE_ERROR_ATRAC_UNKNOWN_FORMAT;
@@ -832,7 +832,7 @@ int Atrac2::SetData(const Track &track, u32 bufferAddr, u32 readSize, u32 buffer
 	if (readSize >= track.fileSize) {
 		INFO_LOG(Log::ME, "The full file was set directly - we can dump it.");
 		char filename[512];
-		snprintf(filename, sizeof(filename), "%s_%d%s", track.codecType == PSP_MODE_AT_3 ? "at3" : "at3plus", track.endSample, track.channels == 1 ? "_mono" : "");
+		snprintf(filename, sizeof(filename), "%s_%d%s", track.codecType == PSP_CODEC_AT3 ? "at3" : "at3plus", track.endSample, track.channels == 1 ? "_mono" : "");
 		DumpFileIfEnabled(Memory::GetPointer(bufferAddr), readSize, filename, DumpFileType::Atrac3);
 	}
 
@@ -1004,7 +1004,7 @@ int Atrac2::Bitrate() const {
 	const SceAtracIdInfo &info = context_->info;
 
 	int bitrate = (info.sampleSize * 352800) / 1000;
-	if (info.codec == PSP_MODE_AT_3_PLUS)
+	if (info.codec == PSP_CODEC_AT3PLUS)
 		bitrate = ((bitrate >> 11) + 8) & 0xFFFFFFF0;
 	else
 		bitrate = (bitrate + 511) >> 10;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -122,10 +122,10 @@ void __AtracInit() {
 	memset(g_muteFlag, 0, sizeof(g_muteFlag));
 
 	// Start with 2 of each in this order.
-	atracContextTypes[0] = PSP_MODE_AT_3_PLUS;
-	atracContextTypes[1] = PSP_MODE_AT_3_PLUS;
-	atracContextTypes[2] = PSP_MODE_AT_3;
-	atracContextTypes[3] = PSP_MODE_AT_3;
+	atracContextTypes[0] = PSP_CODEC_AT3PLUS;
+	atracContextTypes[1] = PSP_CODEC_AT3PLUS;
+	atracContextTypes[2] = PSP_CODEC_AT3;
+	atracContextTypes[3] = PSP_CODEC_AT3;
 	atracContextTypes[4] = 0;
 	atracContextTypes[5] = 0;
 }
@@ -255,7 +255,7 @@ static int UnregisterAndDeleteAtrac(int atracID) {
 // Really, allocate an Atrac context of a specific codec type.
 // Useful to initialize a context for low level decode.
 static u32 sceAtracGetAtracID(int codecType) {
-	if (codecType != PSP_MODE_AT_3 && codecType != PSP_MODE_AT_3_PLUS) {
+	if (codecType != PSP_CODEC_AT3 && codecType != PSP_CODEC_AT3PLUS) {
 		return hleReportError(Log::ME, SCE_ERROR_ATRAC_INVALID_CODECTYPE, "invalid codecType");
 	}
 
@@ -808,13 +808,13 @@ static int sceAtracReinit(int at3Count, int at3plusCount) {
 	for (int i = 0; i < at3plusCount; ++i) {
 		space -= 2;
 		if (space >= 0) {
-			atracContextTypes[next++] = PSP_MODE_AT_3_PLUS;
+			atracContextTypes[next++] = PSP_CODEC_AT3PLUS;
 		}
 	}
 	for (int i = 0; i < at3Count; ++i) {
 		space -= 1;
 		if (space >= 0) {
-			atracContextTypes[next++] = PSP_MODE_AT_3;
+			atracContextTypes[next++] = PSP_CODEC_AT3;
 		}
 	}
 
@@ -1044,7 +1044,7 @@ static const At3HeaderMap at3HeaderMap[] = {
 };
 
 bool IsAtrac3StreamJointStereo(int codecType, int bytesPerFrame, int channels) {
-	if (codecType != PSP_MODE_AT_3) {
+	if (codecType != PSP_CODEC_AT3) {
 		// Well, might actually be, but it's not used in codec setup.
 		return false;
 	}
@@ -1075,7 +1075,7 @@ static int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 
 	atrac->InitLowLevel(*params, codecType);
 
-	const char *codecName = codecType == PSP_MODE_AT_3 ? "atrac3" : "atrac3+";
+	const char *codecName = codecType == PSP_CODEC_AT3 ? "atrac3" : "atrac3+";
 	const char *encodedChannelName = params->encodedChannels == 1 ? "mono" : "stereo";
 	const char *outputChannelName = params->outputChannels == 1 ? "mono" : "stereo";
 	return hleLogInfo(Log::ME, 0, "%s %s->%s audio", codecName, encodedChannelName, outputChannelName);

--- a/Core/HLE/sceAtrac.h
+++ b/Core/HLE/sceAtrac.h
@@ -26,6 +26,7 @@ void Register_sceAtrac3plus();
 void __AtracInit();
 void __AtracDoState(PointerWrap &p);
 void __AtracShutdown();
+int __AtracMaxContexts();
 
 void __AtracNotifyLoadModule(int version, u32 crc, u32 bssAddr, int bssSize);
 void __AtracNotifyUnloadModule();
@@ -141,3 +142,7 @@ bool IsAtrac3StreamJointStereo(int codecType, int bytesPerFrame, int channels);
 u32 AtracSasAddStreamData(int atracID, u32 bufPtr, u32 bytesToAdd);
 void AtracSasDecodeData(int atracID, u8* outbuf, int *SamplesNum, int *finish);
 int AtracSasBindContextAndGetID(u32 contextAddr);
+
+// To provide checkboxes in the debugger UI.
+// This setting is not saved.
+bool *__AtracMuteFlag(int atracID);

--- a/Core/HLE/sceKernelHeap.cpp
+++ b/Core/HLE/sceKernelHeap.cpp
@@ -171,6 +171,7 @@ const HLEFunction SysMemForKernel[] = {
 	{ 0X536AD5E1, &WrapU_V<sceKernelGetUidmanCB>,                  "sceKernelGetUidmanCB",               'i', "i" ,    HLE_KERNEL_SYSCALL },
 	{ 0X7B749390, &WrapI_IU<sceKernelFreeHeapMemory>,              "sceKernelFreeHeapMemory",            'i', "ix" ,   HLE_KERNEL_SYSCALL },
 	{ 0XEB7A74DB, &WrapI_IUU<sceKernelAllocHeapMemoryWithOption>,  "sceKernelAllocHeapMemoryWithOption", 'i', "ixp" ,  HLE_KERNEL_SYSCALL },
+	{ 0x6373995d, nullptr,                                         "sceKernelGetModel",                  'i', "",      HLE_KERNEL_SYSCALL },
 };
 
 void Register_SysMemForKernel() {

--- a/Core/HLE/sceSas.h
+++ b/Core/HLE/sceSas.h
@@ -22,6 +22,7 @@ void __SasDoState(PointerWrap &p);
 void __SasShutdown();
 
 void __SasGetDebugStats(char *stats, size_t bufsize);
+bool *__SasGetGlobalMuteFlag();
 
 void Register_sceSasCore();
 

--- a/Core/HW/SasAudio.h
+++ b/Core/HW/SasAudio.h
@@ -315,7 +315,7 @@ public:
 
 	FILE *audioDump = nullptr;
 
-	void Mix(u32 outAddr, u32 inAddr = 0, int leftVol = 0, int rightVol = 0);
+	void Mix(u32 outAddr, u32 inAddr, int leftVol, int rightVol, bool mute);
 	void MixVoice(SasVoice &voice);
 
 	// Applies reverb to send buffer, according to waveformEffect.

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -39,6 +39,7 @@ extern "C" {
 
 #include "Core/FFMPEGCompat.h"
 }
+#include "Core/Config.h"
 
 #else
 
@@ -136,15 +137,23 @@ private:
 };
 
 AudioDecoder *CreateAudioDecoder(PSPAudioType audioType, int sampleRateHz, int channels, size_t blockAlign, const uint8_t *extraData, size_t extraDataSize) {
+	bool forceFfmpeg = false;
+#ifdef USE_FFMPEG
+	forceFfmpeg = g_Config.bForceFfmpegForAudioDec;
+#endif
+	if (forceFfmpeg) {
+		return new FFmpegAudioDecoder(audioType, sampleRateHz, channels);
+	}
+
 	switch (audioType) {
 	case PSP_CODEC_MP3:
 		return new MiniMp3Audio();
-	// case PSP_CODEC_AT3:
-	// 	return CreateAtrac3Audio(channels, blockAlign, extraData, extraDataSize);
-	// case PSP_CODEC_AT3PLUS:
-	// 	return CreateAtrac3PlusAudio(channels, blockAlign);
+	case PSP_CODEC_AT3:
+	 	return CreateAtrac3Audio(channels, blockAlign, extraData, extraDataSize);
+	case PSP_CODEC_AT3PLUS:
+		return CreateAtrac3PlusAudio(channels, blockAlign);
 	default:
-		// Only AAC falls back to FFMPEG now.
+		// Only AAC normally falls back to FFMPEG now.
 		return new FFmpegAudioDecoder(audioType, sampleRateHz, channels);
 	}
 }

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -139,10 +139,10 @@ AudioDecoder *CreateAudioDecoder(PSPAudioType audioType, int sampleRateHz, int c
 	switch (audioType) {
 	case PSP_CODEC_MP3:
 		return new MiniMp3Audio();
-	case PSP_CODEC_AT3:
-		return CreateAtrac3Audio(channels, blockAlign, extraData, extraDataSize);
-	case PSP_CODEC_AT3PLUS:
-		return CreateAtrac3PlusAudio(channels, blockAlign);
+	// case PSP_CODEC_AT3:
+	// 	return CreateAtrac3Audio(channels, blockAlign, extraData, extraDataSize);
+	// case PSP_CODEC_AT3PLUS:
+	// 	return CreateAtrac3PlusAudio(channels, blockAlign);
 	default:
 		// Only AAC falls back to FFMPEG now.
 		return new FFmpegAudioDecoder(audioType, sampleRateHz, channels);

--- a/Core/Util/AtracTrack.cpp
+++ b/Core/Util/AtracTrack.cpp
@@ -4,6 +4,10 @@
 #include "Core/HLE/ErrorCodes.h"
 #include "Core/MemMap.h"
 
+// Atrac file parsing constants
+#define AT3_MAGIC           0x0270
+#define AT3_PLUS_MAGIC      0xFFFE  // This is normally a marker for WAVE_FORMAT_EXTENSIBLE
+
 const int RIFF_CHUNK_MAGIC = 0x46464952;
 const int RIFF_WAVE_MAGIC = 0x45564157;
 const int FMT_CHUNK_MAGIC = 0x20746D66;
@@ -110,9 +114,9 @@ int AnalyzeAtracTrack(const u8 *buffer, u32 size, Track *track, std::string *err
 			}
 
 			if (at3fmt->fmtTag == AT3_MAGIC)
-				track->codecType = PSP_MODE_AT_3;
+				track->codecType = PSP_CODEC_AT3;
 			else if (at3fmt->fmtTag == AT3_PLUS_MAGIC)
-				track->codecType = PSP_MODE_AT_3_PLUS;
+				track->codecType = PSP_CODEC_AT3PLUS;
 			else {
 				*error = "AnalyzeTrack: invalid fmt magic: %04x";
 				return SCE_ERROR_ATRAC_UNKNOWN_FORMAT;
@@ -288,14 +292,14 @@ int AnalyzeAA3Track(const u8 *buffer, u32 size, u32 fileSize, Track *track, std:
 
 	switch (buffer[32]) {
 	case 0:
-		track->codecType = PSP_MODE_AT_3;
+		track->codecType = PSP_CODEC_AT3;
 		track->bytesPerFrame = (codecParams & 0x03FF) * 8;
 		track->bitrate = at3SampleRates[(codecParams >> 13) & 7] * track->bytesPerFrame * 8 / 1024;
 		track->channels = 2;
 		track->jointStereo = (codecParams >> 17) & 1;
 		break;
 	case 1:
-		track->codecType = PSP_MODE_AT_3_PLUS;
+		track->codecType = PSP_CODEC_AT3PLUS;
 		track->bytesPerFrame = ((codecParams & 0x03FF) * 8) + 8;
 		track->bitrate = at3SampleRates[(codecParams >> 13) & 7] * track->bytesPerFrame * 8 / 2048;
 		track->channels = (codecParams >> 10) & 7;

--- a/Core/Util/AtracTrack.h
+++ b/Core/Util/AtracTrack.h
@@ -5,11 +5,7 @@
 #include <vector>
 #include <string>
 
-// Atrac file parsing.
-#define AT3_MAGIC           0x0270
-#define AT3_PLUS_MAGIC      0xFFFE
-#define PSP_MODE_AT_3_PLUS  0x00001000
-#define PSP_MODE_AT_3       0x00001001
+#include "Core/HLE/sceAudiocodec.h"
 
 constexpr u32 ATRAC3_MAX_SAMPLES = 0x400;  // 1024
 constexpr u32 ATRAC3PLUS_MAX_SAMPLES = 0x800;   // 2048
@@ -72,7 +68,7 @@ struct Track {
 
 	inline int FirstOffsetExtra() const {
 		// These first samples are skipped, after first possibly skipping 0-2 full frames, it seems.
-		return codecType == PSP_MODE_AT_3_PLUS ? 0x170 : 0x45;
+		return codecType == PSP_CODEC_AT3PLUS ? 0x170 : 0x45;
 	}
 
 	// Includes the extra offset. See firstSampleOffset comment above.
@@ -82,12 +78,12 @@ struct Track {
 
 	// Output frame size, different between the two supported codecs.
 	int SamplesPerFrame() const {
-		return codecType == PSP_MODE_AT_3_PLUS ? ATRAC3PLUS_MAX_SAMPLES : ATRAC3_MAX_SAMPLES;
+		return codecType == PSP_CODEC_AT3PLUS ? ATRAC3PLUS_MAX_SAMPLES : ATRAC3_MAX_SAMPLES;
 	}
 
 	int Bitrate() const {
 		int bitrate = (bytesPerFrame * 352800) / 1000;
-		if (codecType == PSP_MODE_AT_3_PLUS)
+		if (codecType == PSP_CODEC_AT3PLUS)
 			bitrate = ((bitrate >> 11) + 8) & 0xFFFFFFF0;
 		else
 			bitrate = (bitrate + 511) >> 10;

--- a/UI/DeveloperToolsScreen.cpp
+++ b/UI/DeveloperToolsScreen.cpp
@@ -291,6 +291,12 @@ void DeveloperToolsScreen::CreateMIPSTracerTab(UI::LinearLayout *list) {
 	ClearMIPSTracer->OnClick.Handle(this, &DeveloperToolsScreen::OnMIPSTracerClearTracer);
 }
 
+void DeveloperToolsScreen::CreateAudioTab(UI::LinearLayout *list) {
+	using namespace UI;
+	auto dev = GetI18NCategory(I18NCat::DEVELOPER);
+	list->Add(new CheckBox(&g_Config.bForceFfmpegForAudioDec, dev->T("Use FFMPEG for all compressed audio")));
+}
+
 void DeveloperToolsScreen::CreateGraphicsTab(UI::LinearLayout *list) {
 	using namespace UI;
 	auto dev = GetI18NCategory(I18NCat::DEVELOPER);
@@ -402,11 +408,14 @@ void DeveloperToolsScreen::CreateTabs() {
 	AddTab("General", sy->T("General"), [this](UI::LinearLayout *parent) {
 		CreateGeneralTab(parent);
 	});
+	AddTab("TextureReplacement", dev->T("Texture Replacement"), [this](UI::LinearLayout *parent) {
+		CreateTextureReplacementTab(parent);
+	});
 	AddTab("Graphics", ms->T("Graphics"), [this](UI::LinearLayout *parent) {
 		CreateGraphicsTab(parent);
 	});
-	AddTab("TextureReplacement", dev->T("Texture Replacement"), [this](UI::LinearLayout *parent) {
-		CreateTextureReplacementTab(parent);
+	AddTab("Audio", ms->T("Audio"), [this](UI::LinearLayout *parent) {
+		CreateAudioTab(parent);
 	});
 	AddTab("Tests", dev->T("Tests"), [this](UI::LinearLayout *parent) {
 		CreateTestsTab(parent);

--- a/UI/DeveloperToolsScreen.cpp
+++ b/UI/DeveloperToolsScreen.cpp
@@ -100,11 +100,10 @@ void DeveloperToolsScreen::CreateTextureReplacementTab(UI::LinearLayout *list) {
 void DeveloperToolsScreen::CreateGeneralTab(UI::LinearLayout *list) {
 	using namespace UI;
 	auto dev = GetI18NCategory(I18NCat::DEVELOPER);
-	auto si = GetI18NCategory(I18NCat::SYSINFO);
 	auto sy = GetI18NCategory(I18NCat::SYSTEM);
 	auto gr = GetI18NCategory(I18NCat::GRAPHICS);
 
-	list->Add(new ItemHeader(sy->T("General")));
+	list->Add(new ItemHeader(sy->T("CPU Core")));
 
 	bool canUseJit = System_GetPropertyBool(SYSPROP_CAN_JIT);
 	// iOS can now use JIT on all modes, apparently.
@@ -130,13 +129,9 @@ void DeveloperToolsScreen::CreateGeneralTab(UI::LinearLayout *list) {
 	list->Add(new Choice(dev->T("JIT debug tools")))->OnClick.Handle(this, &DeveloperToolsScreen::OnJitDebugTools);
 	list->Add(new CheckBox(&g_Config.bShowDeveloperMenu, dev->T("Show Developer Menu")));
 
-#if !PPSSPP_PLATFORM(UWP)
-	Choice *cpuTests = new Choice(dev->T("Run CPU Tests"));
-	list->Add(cpuTests)->OnClick.Handle(this, &DeveloperToolsScreen::OnRunCPUTests);
-	cpuTests->SetEnabled(TestsAvailable() && !PSP_IsInited());
-#endif
-
 	AddOverlayList(list, screenManager());
+
+	list->Add(new ItemHeader(sy->T("General")));
 
 	list->Add(new CheckBox(&g_Config.bEnableLogging, dev->T("Enable Logging")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLoggingChanged);
 	list->Add(new Choice(dev->T("Logging Channels")))->OnClick.Handle(this, &DeveloperToolsScreen::OnLogConfig);
@@ -145,45 +140,13 @@ void DeveloperToolsScreen::CreateGeneralTab(UI::LinearLayout *list) {
 		list->Add(new CheckBox(&g_Config.bGpuLogProfiler, dev->T("GPU log profiler")));
 	}
 
-	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN) {
-		list->Add(new CheckBox(&g_Config.bRenderMultiThreading, dev->T("Multi-threaded rendering"), ""))->OnClick.Add([](UI::EventParams &e) {
-			// TODO: Not translating yet. Will combine with other translations of settings that need restart.
-			g_OSD.Show(OSDType::MESSAGE_WARNING, "Restart required");
-			return UI::EVENT_DONE;
-		});
-	}
-
-	if (GetGPUBackend() == GPUBackend::VULKAN && SupportsCustomDriver()) {
-		auto driverChoice = list->Add(new Choice(gr->T("AdrenoTools driver manager")));
-		driverChoice->OnClick.Add([=](UI::EventParams &e) {
-			screenManager()->push(new DriverManagerScreen(gamePath_));
-			return UI::EVENT_DONE;
-		});
-	}
-
-	// For now, we only implement GPU driver tests for Vulkan and OpenGL. This is simply
-	// because the D3D drivers are generally solid enough to not need this type of investigation.
-	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN || g_Config.iGPUBackend == (int)GPUBackend::OPENGL) {
-		list->Add(new Choice(dev->T("GPU Driver Test")))->OnClick.Handle(this, &DeveloperToolsScreen::OnGPUDriverTest);
-	}
-	list->Add(new CheckBox(&g_Config.bVendorBugChecksEnabled, dev->T("Enable driver bug workarounds")));
-	Choice *frameDumpTests = list->Add(new Choice(dev->T("Framedump tests")));
-	frameDumpTests->OnClick.Add([this](UI::EventParams &e) {
-		screenManager()->push(new FrameDumpTestScreen());
-		return UI::EVENT_DONE;
-	});
-	frameDumpTests->SetEnabled(!PSP_IsInited());
-
-	list->Add(new Choice(dev->T("Touchscreen Test")))->OnClick.Handle(this, &DeveloperToolsScreen::OnTouchscreenTest);
-	// list->Add(new Choice(dev->T("Memstick Test")))->OnClick.Handle(this, &DeveloperToolsScreen::OnMemstickTest);
+	list->Add(new CheckBox(&g_Config.bShowOnScreenMessages, dev->T("Show on-screen messages")));
 
 	allowDebugger_ = !WebServerStopped(WebServerFlags::DEBUGGER);
 	canAllowDebugger_ = !WebServerStopping(WebServerFlags::DEBUGGER);
 	CheckBox *allowDebugger = new CheckBox(&allowDebugger_, dev->T("Allow remote debugger"));
 	list->Add(allowDebugger)->OnClick.Handle(this, &DeveloperToolsScreen::OnRemoteDebugger);
 	allowDebugger->SetEnabledPtr(&canAllowDebugger_);
-
-	list->Add(new CheckBox(&g_Config.bShowOnScreenMessages, dev->T("Show on-screen messages")));
 
 	list->Add(new Choice(dev->T("GPI/GPO switches/LEDs")))->OnClick.Add([=](UI::EventParams &e) {
 		screenManager()->push(new GPIGPOScreen(dev->T("GPI/GPO switches/LEDs")));
@@ -209,20 +172,35 @@ void DeveloperToolsScreen::CreateGeneralTab(UI::LinearLayout *list) {
 	});
 #endif
 
-	static const char *ffModes[] = { "Render all frames", "", "Frame Skipping" };
-	PopupMultiChoice *ffMode = list->Add(new PopupMultiChoice(&g_Config.iFastForwardMode, dev->T("Fast-forward mode"), ffModes, 0, ARRAY_SIZE(ffModes), I18NCat::GRAPHICS, screenManager()));
-	ffMode->SetEnabledFunc([]() { return !g_Config.bVSync; });
-	ffMode->HideChoice(1);  // not used
-
-	auto displayRefreshRate = list->Add(new PopupSliderChoice(&g_Config.iDisplayRefreshRate, 60, 1000, 60, dev->T("Display refresh rate"), 1, screenManager()));
-	displayRefreshRate->SetFormat(si->T("%d Hz"));
-
 	// Makes it easy to get savestates out of an iOS device. The file listing shown in MacOS doesn't allow
 	// you to descend into directories.
 #if PPSSPP_PLATFORM(IOS)
 	list->Add(new Choice(dev->T("Copy savestates to memstick root")))->OnClick.Handle(this, &DeveloperToolsScreen::OnCopyStatesToRoot);
 #endif
+}
 
+void DeveloperToolsScreen::CreateTestsTab(UI::LinearLayout *list) {
+	using namespace UI;
+	auto dev = GetI18NCategory(I18NCat::DEVELOPER);
+
+	list->Add(new Choice(dev->T("Touchscreen Test")))->OnClick.Handle(this, &DeveloperToolsScreen::OnTouchscreenTest);
+	// list->Add(new Choice(dev->T("Memstick Test")))->OnClick.Handle(this, &DeveloperToolsScreen::OnMemstickTest);
+	Choice *frameDumpTests = list->Add(new Choice(dev->T("Framedump tests")));
+	frameDumpTests->OnClick.Add([this](UI::EventParams &e) {
+		screenManager()->push(new FrameDumpTestScreen());
+		return UI::EVENT_DONE;
+	});
+	frameDumpTests->SetEnabled(!PSP_IsInited());
+#if !PPSSPP_PLATFORM(UWP)
+	Choice *cpuTests = new Choice(dev->T("Run CPU Tests"));
+	list->Add(cpuTests)->OnClick.Handle(this, &DeveloperToolsScreen::OnRunCPUTests);
+	cpuTests->SetEnabled(TestsAvailable() && !PSP_IsInited());
+#endif
+	// For now, we only implement GPU driver tests for Vulkan and OpenGL. This is simply
+	// because the D3D drivers are generally solid enough to not need this type of investigation.
+	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN || g_Config.iGPUBackend == (int)GPUBackend::OPENGL) {
+		list->Add(new Choice(dev->T("GPU Driver Test")))->OnClick.Handle(this, &DeveloperToolsScreen::OnGPUDriverTest);
+	}
 }
 
 void DeveloperToolsScreen::CreateDumpFileTab(UI::LinearLayout *list) {
@@ -318,11 +296,40 @@ void DeveloperToolsScreen::CreateGraphicsTab(UI::LinearLayout *list) {
 	auto dev = GetI18NCategory(I18NCat::DEVELOPER);
 	auto gr = GetI18NCategory(I18NCat::GRAPHICS);
 	auto ps = GetI18NCategory(I18NCat::POSTSHADERS);
+	auto sy = GetI18NCategory(I18NCat::SYSTEM);
+	auto si = GetI18NCategory(I18NCat::SYSINFO);
 
 	Draw::DrawContext *draw = screenManager()->getDrawContext();
 
+	list->Add(new ItemHeader(sy->T("General")));
+	list->Add(new CheckBox(&g_Config.bVendorBugChecksEnabled, dev->T("Enable driver bug workarounds")));
+
+	static const char *ffModes[] = { "Render all frames", "", "Frame Skipping" };
+	PopupMultiChoice *ffMode = list->Add(new PopupMultiChoice(&g_Config.iFastForwardMode, dev->T("Fast-forward mode"), ffModes, 0, ARRAY_SIZE(ffModes), I18NCat::GRAPHICS, screenManager()));
+	ffMode->SetEnabledFunc([]() { return !g_Config.bVSync; });
+	ffMode->HideChoice(1);  // not used
+
+	auto displayRefreshRate = list->Add(new PopupSliderChoice(&g_Config.iDisplayRefreshRate, 60, 1000, 60, dev->T("Display refresh rate"), 1, screenManager()));
+	displayRefreshRate->SetFormat(si->T("%d Hz"));
+
 	list->Add(new ItemHeader(dev->T("Vulkan")));
 	list->Add(new CheckBox(&g_Config.bVulkanDisableImplicitLayers, dev->T("Prevent loading overlays")));
+
+	if (g_Config.iGPUBackend == (int)GPUBackend::VULKAN) {
+		list->Add(new CheckBox(&g_Config.bRenderMultiThreading, dev->T("Multi-threaded rendering"), ""))->OnClick.Add([](UI::EventParams &e) {
+			// TODO: Not translating yet. Will combine with other translations of settings that need restart.
+			g_OSD.Show(OSDType::MESSAGE_WARNING, "Restart required");
+			return UI::EVENT_DONE;
+		});
+	}
+
+	if (GetGPUBackend() == GPUBackend::VULKAN && SupportsCustomDriver()) {
+		auto driverChoice = list->Add(new Choice(gr->T("AdrenoTools driver manager")));
+		driverChoice->OnClick.Add([=](UI::EventParams &e) {
+			screenManager()->push(new DriverManagerScreen(gamePath_));
+			return UI::EVENT_DONE;
+		});
+	}
 
 	list->Add(new ItemHeader(dev->T("Ubershaders")));
 	if (draw->GetShaderLanguageDesc().bitwiseOps && !draw->GetBugs().Has(Draw::Bugs::UNIFORM_INDEXING_BROKEN)) {
@@ -392,11 +399,17 @@ void DeveloperToolsScreen::CreateTabs() {
 	auto sy = GetI18NCategory(I18NCat::SYSTEM);
 	auto ms = GetI18NCategory(I18NCat::MAINSETTINGS);
 
+	AddTab("General", sy->T("General"), [this](UI::LinearLayout *parent) {
+		CreateGeneralTab(parent);
+	});
+	AddTab("Graphics", ms->T("Graphics"), [this](UI::LinearLayout *parent) {
+		CreateGraphicsTab(parent);
+	});
 	AddTab("TextureReplacement", dev->T("Texture Replacement"), [this](UI::LinearLayout *parent) {
 		CreateTextureReplacementTab(parent);
 	});
-	AddTab("General", sy->T("General"), [this](UI::LinearLayout *parent) {
-		CreateGeneralTab(parent);
+	AddTab("Tests", dev->T("Tests"), [this](UI::LinearLayout *parent) {
+		CreateTestsTab(parent);
 	});
 	AddTab("DumpFiles", sy->T("Dump files"), [this](UI::LinearLayout *parent) {
 		CreateDumpFileTab(parent);
@@ -410,10 +423,6 @@ void DeveloperToolsScreen::CreateTabs() {
 		CreateMIPSTracerTab(parent);
 	});
 #endif
-	AddTab("Graphics", ms->T("Graphics"), [this](UI::LinearLayout *parent) {
-		CreateGraphicsTab(parent);
-	});
-
 	// Reconsider whenever recreating views.
 	hasTexturesIni_ = HasIni::MAYBE;
 }

--- a/UI/DeveloperToolsScreen.h
+++ b/UI/DeveloperToolsScreen.h
@@ -21,6 +21,7 @@ private:
 	void CreateHLETab(UI::LinearLayout *parent);
 	void CreateMIPSTracerTab(UI::LinearLayout *list);
 	void CreateTestsTab(UI::LinearLayout *list);
+	void CreateAudioTab(UI::LinearLayout *list);
 	void CreateGraphicsTab(UI::LinearLayout *list);
 
 	UI::EventReturn OnRunCPUTests(UI::EventParams &e);

--- a/UI/DeveloperToolsScreen.h
+++ b/UI/DeveloperToolsScreen.h
@@ -20,6 +20,7 @@ private:
 	void CreateDumpFileTab(UI::LinearLayout *parent);
 	void CreateHLETab(UI::LinearLayout *parent);
 	void CreateMIPSTracerTab(UI::LinearLayout *list);
+	void CreateTestsTab(UI::LinearLayout *list);
 	void CreateGraphicsTab(UI::LinearLayout *list);
 
 	UI::EventReturn OnRunCPUTests(UI::EventParams &e);

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -957,6 +957,7 @@ void DrawAudioDecodersView(ImConfig &cfg, ImControl &control) {
 	}
 
 	if (ImGui::CollapsingHeader("sceAtrac", ImGuiTreeNodeFlags_DefaultOpen)) {
+		ImGui::Checkbox("Force FFMPEG", &g_Config.bForceFfmpegForAudioDec);
 		if (ImGui::BeginTable("atracs", 8, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersH)) {
 			ImGui::TableSetupColumn("Index", ImGuiTableColumnFlags_WidthFixed);
 			ImGui::TableSetupColumn("Mute", ImGuiTableColumnFlags_WidthFixed);
@@ -1851,6 +1852,10 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 					System_CopyStringToClipboard(StringFromFormat("%016llx", (uint64_t)(uintptr_t)Memory::base));
 				}
 			}
+			ImGui::Separator();
+			if (ImGui::MenuItem("Close")) {
+				g_Config.bShowImDebugger = false;
+			}
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Core")) {
@@ -1969,11 +1974,22 @@ void ImDebugger::Frame(MIPSDebugInterface *mipsDebug, GPUDebugInterface *gpuDebu
 			ImGui::MenuItem("Dear ImGui Style editor", nullptr, &cfg_.styleEditorOpen);
 			ImGui::EndMenu();
 		}
-
-		// Let's have this at the top level, to help anyone confused.
-		if (ImGui::BeginMenu("Close Debugger")) {
+		if (ImGui::MenuItem("Close")) {
 			g_Config.bShowImDebugger = false;
-			ImGui::EndMenu();
+		}
+		switch (coreState) {
+		case CoreState::CORE_STEPPING_CPU:
+			if (ImGui::MenuItem(">> Run")) {
+				Core_Resume();
+			}
+			break;
+		case CoreState::CORE_RUNNING_CPU:
+			if (ImGui::MenuItem("|| Break")) {
+				Core_Break(BreakReason::DebugBreak);
+			}
+			break;
+		default:
+			break;
 		}
 		ImGui::EndMainMenuBar();
 	}

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -1306,6 +1306,8 @@ void DrawSasAudio(ImConfig &cfg) {
 		return;
 	}
 
+	ImGui::Checkbox("Mute", __SasGetGlobalMuteFlag());
+	ImGui::SameLine();
 	ImGui::Checkbox("Show all voices", &cfg.sasShowAllVoices);
 
 	if (ImGui::BeginTable("saschannels", 9, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersH)) {

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -991,10 +991,10 @@ void DrawAudioDecodersView(ImConfig &cfg, ImControl &control) {
 				case 0:
 					ImGui::TextUnformatted("-");  // Uninitialized
 					break;
-				case PSP_MODE_AT_3_PLUS:
+				case PSP_CODEC_AT3PLUS:
 					ImGui::TextUnformatted("Atrac3+");
 					break;
-				case PSP_MODE_AT_3:
+				case PSP_CODEC_AT3:
 					ImGui::TextUnformatted("Atrac3");
 					break;
 				default:


### PR DESCRIPTION
Adds muting flags, and a way to revert to use FFMPEG for audio decoding, instead of our extracted decoder.

To help with investigating #19640 

![image](https://github.com/user-attachments/assets/4c40fd44-d0e5-40ea-8028-41159b2df6f3)

Also first reorganizes the developer tools screen a bit.