### PR TITLE
sceAudiocodec: Restore AAC support, add AT3 (non-plus) support

### DIFF
--- a/Common/GPU/Vulkan/VulkanContext.cpp
+++ b/Common/GPU/Vulkan/VulkanContext.cpp
@@ -642,12 +642,12 @@ VkResult VulkanContext::CreateDevice(int physical_device) {
 	// This is as good a place as any to do this. Though, we don't use this much anymore after we added
 	// support for VMA.
 	vkGetPhysicalDeviceMemoryProperties(physical_devices_[physical_device_], &memory_properties_);
-	INFO_LOG(Log::G3D, "Memory Types (%d):", memory_properties_.memoryTypeCount);
+	DEBUG_LOG(Log::G3D, "Memory Types (%d):", memory_properties_.memoryTypeCount);
 	for (int i = 0; i < (int)memory_properties_.memoryTypeCount; i++) {
 		// Don't bother printing dummy memory types.
 		if (!memory_properties_.memoryTypes[i].propertyFlags)
 			continue;
-		INFO_LOG(Log::G3D, "  %d: Heap %d; Flags: %s%s%s%s  ", i, memory_properties_.memoryTypes[i].heapIndex,
+		DEBUG_LOG(Log::G3D, "  %d: Heap %d; Flags: %s%s%s%s  ", i, memory_properties_.memoryTypes[i].heapIndex,
 			(memory_properties_.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) ? "DEVICE_LOCAL " : "",
 			(memory_properties_.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) ? "HOST_VISIBLE " : "",
 			(memory_properties_.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_HOST_CACHED_BIT) ? "HOST_CACHED " : "",
@@ -1349,7 +1349,7 @@ bool VulkanContext::InitSwapchain() {
 	res = vkGetPhysicalDeviceSurfacePresentModesKHR(physical_devices_[physical_device_], surface_, &presentModeCount, presentModes);
 	_dbg_assert_(res == VK_SUCCESS);
 
-	VkExtent2D currentExtent { surfCapabilities_.currentExtent };
+	VkExtent2D currentExtent{ surfCapabilities_.currentExtent };
 	// https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSurfaceCapabilitiesKHR.html
 	// currentExtent is the current width and height of the surface, or the special value (0xFFFFFFFF, 0xFFFFFFFF) indicating that the surface size will be determined by the extent of a swapchain targeting the surface.
 	if (currentExtent.width == 0xFFFFFFFFu || currentExtent.height == 0xFFFFFFFFu
@@ -1357,7 +1357,7 @@ bool VulkanContext::InitSwapchain() {
 		|| currentExtent.width == 0 || currentExtent.height == 0
 #endif
 		) {
-		_dbg_assert_((bool)cbGetDrawSize_)
+		_dbg_assert_((bool)cbGetDrawSize_);
 		if (cbGetDrawSize_) {
 			currentExtent = cbGetDrawSize_();
 		}
@@ -1407,8 +1407,7 @@ bool VulkanContext::InitSwapchain() {
 	// queued for display):
 	uint32_t desiredNumberOfSwapChainImages = surfCapabilities_.minImageCount + 1;
 	if ((surfCapabilities_.maxImageCount > 0) &&
-		(desiredNumberOfSwapChainImages > surfCapabilities_.maxImageCount))
-	{
+		(desiredNumberOfSwapChainImages > surfCapabilities_.maxImageCount)) {
 		// Application must settle for fewer images than desired:
 		desiredNumberOfSwapChainImages = surfCapabilities_.maxImageCount;
 	}
@@ -1459,8 +1458,11 @@ bool VulkanContext::InitSwapchain() {
 		preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
 	}
 
-	std::string preTransformStr = surface_transforms_to_string(preTransform);
-	INFO_LOG(Log::G3D, "Transform supported: %s current: %s chosen: %s", supportedTransforms.c_str(), currentTransform.c_str(), preTransformStr.c_str());
+	// Only log transforms if relevant.
+	if (surfCapabilities_.supportedTransforms != VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR) {
+		std::string preTransformStr = surface_transforms_to_string(preTransform);
+		INFO_LOG(Log::G3D, "Transform supported: %s current: %s chosen: %s", supportedTransforms.c_str(), currentTransform.c_str(), preTransformStr.c_str());
+	}
 
 	if (physicalDeviceProperties_[physical_device_].properties.vendorID == VULKAN_VENDOR_IMGTEC) {
 		u32 driverVersion = physicalDeviceProperties_[physical_device_].properties.driverVersion;

--- a/Core/HLE/sceAtrac.cpp
+++ b/Core/HLE/sceAtrac.cpp
@@ -1023,42 +1023,6 @@ static u32 _sceAtracGetContextAddress(int atracID) {
 	return hleLogDebug(Log::ME, atrac->context_.ptr);
 }
 
-struct At3HeaderMap {
-	u16 bytes;
-	u16 channels;
-	u8 jointStereo;
-
-	bool Matches(int bytesPerFrame, int encodedChannels) const {
-		return this->bytes == bytesPerFrame && this->channels == encodedChannels;
-	}
-};
-
-// These should represent all possible supported bitrates (66, 104, and 132 for stereo.)
-static const At3HeaderMap at3HeaderMap[] = {
-	{ 0x00C0, 1, 0 }, // 132/2 (66) kbps mono
-	{ 0x0098, 1, 0 }, // 105/2 (52.5) kbps mono
-	{ 0x0180, 2, 0 }, // 132 kbps stereo
-	{ 0x0130, 2, 0 }, // 105 kbps stereo
-	// At this size, stereo can only use joint stereo.
-	{ 0x00C0, 2, 1 }, // 66 kbps stereo
-};
-
-bool IsAtrac3StreamJointStereo(int codecType, int bytesPerFrame, int channels) {
-	if (codecType != PSP_CODEC_AT3) {
-		// Well, might actually be, but it's not used in codec setup.
-		return false;
-	}
-
-	for (size_t i = 0; i < ARRAY_SIZE(at3HeaderMap); ++i) {
-		if (at3HeaderMap[i].Matches(bytesPerFrame, channels)) {
-			return at3HeaderMap[i].jointStereo;
-		}
-	}
-
-	// Not found? Should we log?
-	return false;
-}
-
 static int sceAtracLowLevelInitDecoder(int atracID, u32 paramsAddr) {
 	AtracBase *atrac = getAtrac(atracID);
 	if (!atrac) {

--- a/Core/HLE/sceAtrac.h
+++ b/Core/HLE/sceAtrac.h
@@ -136,8 +136,6 @@ class AtracBase;
 // For debugger use ONLY.
 const AtracBase *__AtracGetCtx(int i, u32 *type);
 
-bool IsAtrac3StreamJointStereo(int codecType, int bytesPerFrame, int channels);
-
 // External interface used by sceSas, see ATRAC_STATUS_FOR_SCESAS.
 u32 AtracSasAddStreamData(int atracID, u32 bufPtr, u32 bytesToAdd);
 void AtracSasDecodeData(int atracID, u8* outbuf, int *SamplesNum, int *finish);

--- a/Core/HLE/sceAudiocodec.h
+++ b/Core/HLE/sceAudiocodec.h
@@ -90,3 +90,5 @@ void __sceAudiocodecDoState(PointerWrap &p);
 
 class AudioDecoder;
 extern std::map<u32, AudioDecoder *> g_audioDecoderContexts;
+
+bool IsAtrac3StreamJointStereo(int codecType, int bytesPerFrame, int channels);

--- a/Core/HLE/sceMpeg.h
+++ b/Core/HLE/sceMpeg.h
@@ -88,6 +88,9 @@ struct MpegContext {
 	MpegContext();
 	~MpegContext();
 
+	MpegContext(const MpegContext &) = delete;
+	void operator=(const MpegContext &) = delete;
+
 	void DoState(PointerWrap &p);
 
 	u8 mpegheader[2048];
@@ -140,3 +143,5 @@ void Register_sceMpegbase();
 void __VideoPmpInit();
 void __VideoPmpDoState(PointerWrap &p);
 void __VideoPmpShutdown();
+
+const std::map<u32, MpegContext *> &__MpegGetContexts();

--- a/Core/HW/MediaEngine.cpp
+++ b/Core/HW/MediaEngine.cpp
@@ -17,6 +17,7 @@
 
 #include "Common/Serialize/SerializeFuncs.h"
 #include "Common/Math/SIMDHeaders.h"
+#include "Common/StringUtils.h"
 #include "Core/System.h"
 #include "Core/Debugger/MemBlockInfo.h"
 #include "Core/HW/MediaEngine.h"
@@ -86,7 +87,12 @@ void ffmpeg_logger(void *, int level, const char *format, va_list va_args) {
 	} else if (level >= AV_LOG_VERBOSE) {
 		DEBUG_LOG(Log::ME, "FF: %s", tmp);
 	} else {
-		INFO_LOG(Log::ME, "FF: %s", tmp);
+		// Downgrade some log messages we don't care about
+		if (startsWith(tmp, "No accelerated colorspace") || startsWith(tmp, "SEI type 1 size 40 truncated at 36")) {
+			VERBOSE_LOG(Log::ME, "FF: %s", tmp);
+		} else {
+			INFO_LOG(Log::ME, "FF: %s", tmp);
+		}
 	}
 }
 

--- a/Core/Util/AtracTrack.cpp
+++ b/Core/Util/AtracTrack.cpp
@@ -148,7 +148,6 @@ int AnalyzeAtracTrack(const u8 *buffer, u32 size, Track *track, std::string *err
 			} else if (at3fmt->fmtTag == AT3_PLUS_MAGIC) {
 				_dbg_assert_(at3fmt->fmtTag == 0xFFFE);
 				// It's in an "Extensible" wave format. Let's read some more.
-
 			}
 			if (chunkSize > 16) {
 				// Read and format extra bytes as hexadecimal

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -57,7 +57,7 @@ struct ImConfig {
 	bool symbolsOpen;
 	bool modulesOpen;
 	bool hleModulesOpen;
-	bool audioDecodersOpen;
+	bool mediaDecodersOpen;
 	bool structViewerOpen;
 	bool framebuffersOpen;
 	bool texturesOpen;
@@ -100,6 +100,7 @@ struct ImConfig {
 	int selectedMemCheck = -1;
 	int selectedAtracCtx = 0;
 	int selectedMemoryBlock = 0;
+	u32 selectedMpegCtx = 0;
 
 	uint64_t selectedTexAddr = 0;
 


### PR DESCRIPTION
Fixes the background music in the Kosmodrones homebrew finally.

This one is really unusual, I haven't seen many other homebrews using sceAudiocodec directly like this, but if there are others, there's hope they're fixed too.

Also adds a basic sceMpeg details display in ImDebugger.

Fixes #9067 