### PR TITLE
Revert to using FFMPEG for MP3 playback

### DIFF
--- a/Common/File/FileUtil.cpp
+++ b/Common/File/FileUtil.cpp
@@ -144,7 +144,7 @@ FILE *OpenCFile(const Path &path, const char *mode) {
 						return nullptr;
 					}
 				} else {
-					INFO_LOG_REPORT_ONCE(openCFileFailedNavigateUp, Log::IO, "Failed to navigate up to create file: %s", path.c_str());
+					INFO_LOG(Log::IO, "Failed to navigate up to create file: %s", path.c_str());
 					return nullptr;
 				}
 			} else {

--- a/Common/GPU/OpenGL/GLQueueRunner.cpp
+++ b/Common/GPU/OpenGL/GLQueueRunner.cpp
@@ -430,7 +430,7 @@ void GLQueueRunner::RunInitSteps(const FastVec<GLRInitStep> &steps, bool skipGLC
 		// Calling glGetError() isn't great, but at the end of init, only after creating textures, shouldn't be too bad...
 		GLenum err = glGetError();
 		if (err == GL_OUT_OF_MEMORY) {
-			WARN_LOG_REPORT(Log::G3D, "GL ran out of GPU memory; switching to low memory mode");
+			WARN_LOG(Log::G3D, "GL ran out of GPU memory; switching to low memory mode");
 			sawOutOfMemory_ = true;
 		} else if (err != GL_NO_ERROR) {
 			// We checked the err anyway, might as well log if there is one.

--- a/Core/ELF/ElfReader.cpp
+++ b/Core/ELF/ElfReader.cpp
@@ -499,7 +499,7 @@ int ElfReader::LoadInto(u32 loadAddress, bool fromTop)
 	}
 
 	if (vaddr == (u32)-1) {
-		ERROR_LOG_REPORT(Log::Loader, "Failed to allocate memory for ELF!");
+		ERROR_LOG(Log::Loader, "Failed to allocate memory for ELF!");
 		return SCE_KERNEL_ERROR_MEMBLOCK_ALLOC_FAILED;
 	}
 

--- a/Core/FileSystems/DirectoryFileSystem.cpp
+++ b/Core/FileSystems/DirectoryFileSystem.cpp
@@ -437,12 +437,12 @@ void DirectoryFileHandle::Close() {
 #ifdef _WIN32
 		Seek((s32)needsTrunc_, FILEMOVE_BEGIN);
 		if (SetEndOfFile(hFile) == 0) {
-			ERROR_LOG_REPORT(Log::FileSystem, "Failed to truncate file to %d bytes", (int)needsTrunc_);
+			ERROR_LOG(Log::FileSystem, "Failed to truncate file to %d bytes", (int)needsTrunc_);
 		}
 #elif !PPSSPP_PLATFORM(SWITCH)
 		// Note: it's not great that Switch cannot truncate appropriately...
 		if (ftruncate(hFile, (off_t)needsTrunc_) != 0) {
-			ERROR_LOG_REPORT(Log::FileSystem, "Failed to truncate file to %d bytes", (int)needsTrunc_);
+			ERROR_LOG(Log::FileSystem, "Failed to truncate file to %d bytes", (int)needsTrunc_);
 		}
 #endif
 	}

--- a/Core/FileSystems/ISOFileSystem.cpp
+++ b/Core/FileSystems/ISOFileSystem.cpp
@@ -478,7 +478,7 @@ size_t ISOFileSystem::ReadFile(u32 handle, u8 *pointer, s64 size, int &usec) {
 		OpenFileEntry &e = iter->second;
 
 		if (size < 0) {
-			ERROR_LOG_REPORT(Log::FileSystem, "Invalid read for %lld bytes from umd %s", size, e.file ? e.file->name.c_str() : "device");
+			ERROR_LOG(Log::FileSystem, "Invalid read for %lld bytes from umd %s", size, e.file ? e.file->name.c_str() : "device");
 			return 0;
 		}
 		

--- a/Core/HLE/sceAac.cpp
+++ b/Core/HLE/sceAac.cpp
@@ -116,7 +116,7 @@ static u32 sceAacInit(u32 id)
 
 static u32 sceAacInitResource(u32 numberIds) {
 	// Do nothing here
-	INFO_LOG_REPORT(Log::ME, "sceAacInitResource(%i)", numberIds);
+	WARN_LOG_REPORT(Log::ME, "sceAacInitResource(%i)", numberIds);
 	return hleNoLog(0);
 }
 

--- a/Core/HLE/sceHttp.cpp
+++ b/Core/HLE/sceHttp.cpp
@@ -705,7 +705,7 @@ static int sceHttpLoadSystemCookie() {
 static int sceHttpCreateTemplate(const char *userAgent, int httpVer, int autoProxyConf) {
 	WARN_LOG(Log::sceNet, "UNTESTED sceHttpCreateTemplate(%s, %d, %d) at %08x", safe_string(userAgent), httpVer, autoProxyConf, currentMIPS->pc);
 	// Reporting to find more games to be tested
-	DEBUG_LOG_REPORT_ONCE(sceHttpCreateTemplate, Log::sceNet, "UNTESTED sceHttpCreateTemplate(%s, %d, %d)", safe_string(userAgent), httpVer, autoProxyConf);
+	WARN_LOG_REPORT_ONCE(sceHttpCreateTemplate, Log::sceNet, "UNTESTED sceHttpCreateTemplate(%s, %d, %d)", safe_string(userAgent), httpVer, autoProxyConf);
 	std::lock_guard<std::mutex> guard(httpLock);
 	httpObjects.push_back(std::make_shared<HTTPTemplate>(userAgent? userAgent:"", httpVer, autoProxyConf));
 	int retid = (int)httpObjects.size();

--- a/Core/HLE/sceIo.cpp
+++ b/Core/HLE/sceIo.cpp
@@ -1534,7 +1534,7 @@ static FileNode *__IoOpen(int &error, const char *filename, int flags, int mode)
 
 		isTTY = true;
 	} else {
-		h = pspFileSystem.OpenFile(filename, (FileAccess)access);
+		h = pspFileSystem.OpenFile(filename, (FileAccess)(access | (int)FileAccess::FILEACCESS_PPSSPP_QUIET));
 		if (h < 0) {
 			error = h;
 			return nullptr;

--- a/Core/HLE/sceKernelMutex.cpp
+++ b/Core/HLE/sceKernelMutex.cpp
@@ -535,7 +535,12 @@ int sceKernelLockMutex(SceUID id, int count, u32 timeoutPtr)
 	if (__KernelLockMutex(mutex, count, error))
 		return hleLogDebug(Log::sceKernel, 0);
 	else if (error) {
-		return hleLogError(Log::sceKernel, error);
+		if (error == SCE_MUTEX_ERROR_ALREADY_LOCKED) {
+			// Benign it seems.
+			return hleLogDebug(Log::sceKernel, error);
+		} else {
+			return hleLogError(Log::sceKernel, error);
+		}
 	}
 
 	SceUID threadID = __KernelGetCurThread();

--- a/Core/HLE/sceMpeg.cpp
+++ b/Core/HLE/sceMpeg.cpp
@@ -1630,7 +1630,7 @@ static int sceMpegGetAtracAu(u32 mpeg, u32 streamId, u32 auAddr, u32 attrAddr)
 	// The audio can end earlier than the video does.
 	if (ringbuffer->packetsAvail == 0) {
 		// TODO: Does this really delay?
-		return hleDelayResult(hleLogError(Log::ME, SCE_MPEG_ERROR_NO_DATA), "mpeg get atrac", mpegDecodeErrorDelayMs);
+		return hleDelayResult(hleLogDebug(Log::ME, SCE_MPEG_ERROR_NO_DATA), "mpeg get atrac", mpegDecodeErrorDelayMs);
 	}
 
 	// esBuffer is the memory where this au data goes.  We don't write the data to memory.

--- a/Core/HLE/scePsmf.h
+++ b/Core/HLE/scePsmf.h
@@ -19,7 +19,7 @@
 // NOTE: This is now unmaintained legacy code. scePsmf/scePsmfPlayer is just a wrapper over sceMpeg
 // which is always shipped by games that use it, so we simply load the libraries now and focus
 // on emulating sceMpeg as accurately as possible. We might actually go one step deeper if we can
-// figure out sceVideocodec, as sceMpeg is also often shipped.
+// figure out sceVideocodec, as sceMpeg is also often shipped (but not always!)
 
 #pragma once
 

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -338,7 +338,9 @@ bool FFmpegAudioDecoder::Decode(const uint8_t *inbuf, int inbytes, int *inbytesC
 	}
 	
 	// get bytes consumed in source
-	*inbytesConsumed = len;
+	if (inbytesConsumed) {
+		*inbytesConsumed = len;
+	}
 
 	if (got_frame) {
 		// Initializing the sample rate convert. We will use it to convert float output into int.
@@ -352,15 +354,18 @@ bool FFmpegAudioDecoder::Decode(const uint8_t *inbuf, int inbytes, int *inbytesC
 #endif
 
 		if (!swrCtx_) {
+			// TODO: Allow these to differ.
+			const int inputSampleRate = codecCtx_->sample_rate;
+			const int outputSampleRate = codecCtx_->sample_rate;
 #if LIBAVUTIL_VERSION_MAJOR >= 59
 			swr_alloc_set_opts2(
 				&swrCtx_,
 				&wanted_channel_layout,
 				AV_SAMPLE_FMT_S16,
-				codecCtx_->sample_rate,
+				outputSampleRate,
 				&dec_channel_layout,
 				codecCtx_->sample_fmt,
-				codecCtx_->sample_rate,
+				inputSampleRate,
 				0,
 				NULL);
 #else
@@ -368,10 +373,10 @@ bool FFmpegAudioDecoder::Decode(const uint8_t *inbuf, int inbytes, int *inbytesC
 				swrCtx_,
 				wanted_channel_layout,
 				AV_SAMPLE_FMT_S16,
-				codecCtx_->sample_rate,
+				outputSampleRate,
 				dec_channel_layout,
 				codecCtx_->sample_fmt,
-				codecCtx_->sample_rate,
+				inputSampleRate,
 				0,
 				NULL);
 #endif
@@ -394,7 +399,9 @@ bool FFmpegAudioDecoder::Decode(const uint8_t *inbuf, int inbytes, int *inbytesC
 			return false;
 		}
 		// output stereo samples per frame
-		*outSamples = swrRet;
+		if (outSamples) {
+			*outSamples = swrRet;
+		}
 
 		// Save outbuf into pcm audio, you can uncomment this line to save and check the decoded audio into pcm file.
 		// SaveAudio("dump.pcm", outbuf, *outbytes);

--- a/Core/HW/SimpleAudioDec.cpp
+++ b/Core/HW/SimpleAudioDec.cpp
@@ -70,6 +70,10 @@ public:
 	bool Decode(const uint8_t* inbuf, int inbytes, int *inbytesConsumed, int outputChannels, int16_t *outbuf, int *outSamples) override {
 		_dbg_assert_(outputChannels == 2);
 
+		// When used from sceMp3LowLevelDecode, this fails to parse the mp3 header!
+		// It's because minimp3 is a bit more sensitive than ffmpeg - if you give it a buffer that's larger than the frame size,
+		// it'll check that there's a second matching frame before accepting. But in our case we only get one frame,
+		// but we do not know the size. So this might need some modifications in minimp3.
 		mp3dec_frame_info_t info{};
 		int samplesWritten = mp3dec_decode_frame(&mp3_, inbuf, inbytes, (mp3d_sample_t *)temp_, &info);
 		_dbg_assert_(samplesWritten <= MINIMP3_MAX_SAMPLES_PER_FRAME);
@@ -146,8 +150,13 @@ AudioDecoder *CreateAudioDecoder(PSPAudioType audioType, int sampleRateHz, int c
 	}
 
 	switch (audioType) {
-	case PSP_CODEC_MP3:
-		return new MiniMp3Audio();
+	// Our MiniMP3 backend has too many issues:
+	//   * Doesn't accept sample rate
+	//   * Doesn't accept data where there's only one valid frame if the buffer is bigger.
+	//     This prevents sceMp3LowLevelDecode from working, since nothing passes us the frame size.
+	//
+	// case PSP_CODEC_MP3:
+	// 	return new MiniMp3Audio();
 	case PSP_CODEC_AT3:
 	 	return CreateAtrac3Audio(channels, blockAlign, extraData, extraDataSize);
 	case PSP_CODEC_AT3PLUS:

--- a/Core/MIPS/x86/Jit.cpp
+++ b/Core/MIPS/x86/Jit.cpp
@@ -696,9 +696,10 @@ void Jit::Comp_Generic(MIPSOpcode op) {
 		else
 			ABI_CallFunctionC(func, op.encoding);
 		ApplyRoundingMode();
+	} else {
+		// These are basically always due to some kind of crash or corruption now.
+		ERROR_LOG(Log::JIT, "Trying to compile instruction %08x that can't be interpreted", op.encoding);
 	}
-	else
-		ERROR_LOG_REPORT(Log::JIT, "Trying to compile instruction %08x that can't be interpreted", op.encoding);
 
 	const MIPSInfo info = MIPSGetInfo(op);
 	if ((info & IS_VFPU) != 0 && (info & VFPU_NO_PREFIX) == 0)

--- a/Core/System.cpp
+++ b/Core/System.cpp
@@ -918,9 +918,8 @@ void DumpFileIfEnabled(const u8 *dataPtr, const u32 length, std::string_view nam
 			char *path = (char *)userdata;
 			if (clicked) {
 				System_ShowFileInFolder(Path(path));
-			} else {
-				delete[] path;
 			}
+			delete[] path;
 		}, path);
 	}
 }

--- a/GPU/Common/FramebufferManagerCommon.cpp
+++ b/GPU/Common/FramebufferManagerCommon.cpp
@@ -1615,7 +1615,7 @@ void FramebufferManagerCommon::CopyDisplayToOutput(bool reallyDirty) {
 		if (vfb) {
 			// Okay, we found one above.
 			// Log should be "Displaying from framebuf" but not worth changing the report.
-			INFO_LOG_REPORT_ONCE(displayoffset, Log::FrameBuf, "Rendering from framebuf with offset %08x -> %08x+%dx%d", addr, vfb->fb_address, offsetX, offsetY);
+			INFO_LOG(Log::FrameBuf, "Rendering from framebuf with offset %08x -> %08x+%dx%d", addr, vfb->fb_address, offsetX, offsetY);
 		}
 	}
 

--- a/GPU/Common/SoftwareTransformCommon.cpp
+++ b/GPU/Common/SoftwareTransformCommon.cpp
@@ -1087,12 +1087,8 @@ bool GetCurrentDrawAsDebugVertices(DrawEngineCommon *drawEngine, int count, std:
 				}
 				break;
 			case GE_VTYPE_IDX_32BIT:
-				WARN_LOG_REPORT_ONCE(simpleIndexes32, Log::G3D, "SimpleVertices: Decoding 32-bit indexes");
 				for (int i = 0; i < count; ++i) {
-					// These aren't documented and should be rare.  Let's bounds check each one.
-					if (inds32[i] != (u16)inds32[i]) {
-						ERROR_LOG_REPORT_ONCE(simpleIndexes32Bounds, Log::G3D, "SimpleVertices: Index outside 16-bit range");
-					}
+					// These are rare. Only the bottom 16 bits are used.
 					indices[i] = (u16)inds32[i];
 				}
 				break;

--- a/UI/DeveloperToolsScreen.cpp
+++ b/UI/DeveloperToolsScreen.cpp
@@ -337,6 +337,12 @@ void DeveloperToolsScreen::CreateGraphicsTab(UI::LinearLayout *list) {
 		});
 	}
 
+	static const char *depthRasterModes[] = { "Auto (default)", "Low", "Off", "Always on" };
+
+	PopupMultiChoice *depthRasterMode = list->Add(new PopupMultiChoice(&g_Config.iDepthRasterMode, gr->T("Lens flare occlusion"), depthRasterModes, 0, ARRAY_SIZE(depthRasterModes), I18NCat::GRAPHICS, screenManager()));
+	depthRasterMode->SetDisabledPtr(&g_Config.bSoftwareRendering);
+	depthRasterMode->SetChoiceIcon(3, ImageID("I_WARNING"));  // It's a performance trap.
+
 	list->Add(new ItemHeader(dev->T("Ubershaders")));
 	if (draw->GetShaderLanguageDesc().bitwiseOps && !draw->GetBugs().Has(Draw::Bugs::UNIFORM_INDEXING_BROKEN)) {
 		// If the above if fails, the checkbox is redundant since it'll be force disabled anyway.

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -441,6 +441,8 @@ void GameSettingsScreen::CreateGraphicsSettings(UI::ViewGroup *graphicsSettings)
 	PopupMultiChoice *depthRasterMode = graphicsSettings->Add(new PopupMultiChoice(&g_Config.iDepthRasterMode, gr->T("Lens flare occlusion"), depthRasterModes, 0, ARRAY_SIZE(depthRasterModes), I18NCat::GRAPHICS, screenManager()));
 	depthRasterMode->SetDisabledPtr(&g_Config.bSoftwareRendering);
 	depthRasterMode->SetChoiceIcon(3, ImageID("I_WARNING"));  // It's a performance trap.
+	if (g_Config.iDepthRasterMode != 3)
+		depthRasterMode->HideChoice(3);
 
 	CheckBox *texBackoff = graphicsSettings->Add(new CheckBox(&g_Config.bTextureBackoffCache, gr->T("Lazy texture caching", "Lazy texture caching (speedup)")));
 	texBackoff->SetDisabledPtr(&g_Config.bSoftwareRendering);

--- a/UI/ImDebugger/ImDebugger.h
+++ b/UI/ImDebugger/ImDebugger.h
@@ -99,6 +99,7 @@ struct ImConfig {
 	int selectedBreakpoint = -1;
 	int selectedMemCheck = -1;
 	int selectedAtracCtx = 0;
+	int selectedMp3Ctx = 0;
 	int selectedMemoryBlock = 0;
 	u32 selectedMpegCtx = 0;
 

--- a/ext/imgui/imgui_extras.cpp
+++ b/ext/imgui/imgui_extras.cpp
@@ -1,5 +1,7 @@
 // Just some string_view and related wrappers.
 
+#include <cstdio>
+#include <cstdlib>
 #include <string_view>
 #include "ext/imgui/imgui.h"
 
@@ -51,6 +53,12 @@ bool RepeatButtonShift(const char* label, float repeatRate) {
 	}
 
 	return clicked;
+}
+
+bool CollapsingHeaderWithCount(const char *title, int count, ImGuiTreeNodeFlags flags) {
+	char temp[256];
+	snprintf(temp, sizeof(temp), "%s (%d)##%s", title, count, title);
+	return ImGui::CollapsingHeader(temp, flags);
 }
 
 }  // namespace ImGui

--- a/ext/imgui/imgui_extras.h
+++ b/ext/imgui/imgui_extras.h
@@ -12,4 +12,6 @@ inline void TextUnformatted(std::string_view str) {
 bool RepeatButton(const char *title);
 bool RepeatButtonShift(const char* label, float repeatRate = 0.05f);
 
+bool CollapsingHeaderWithCount(const char *title, int count, ImGuiTreeNodeFlags flags = 0);
+
 }  // namespace ImGui


### PR DESCRIPTION
I tried using minimp3, but it's too sensitive to strange configurations like giving it too big a buffer to read, although with only one packet in it, which is what unavoidably happens in for example #19615 .

So until that can be fixed, go back. A temporary setback in our long term goal to minimize the dependency on FFMPEG.

Fixes #19615. 

Also assorted log and setting cleanup.

I also tried to add multiple sample rate support for sceMp3, but that was more complicated than expected and will be postponed (#20250)