### PR TITLE
Minor debugger fixes

### DIFF
--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -111,8 +111,8 @@ void __AudioInit() {
 	CoreTiming::ScheduleEvent(audioIntervalCycles, eventAudioUpdate, 0);
 	CoreTiming::ScheduleEvent(audioHostIntervalCycles, eventHostAudioUpdate, 0);
 	for (u32 i = 0; i < PSP_AUDIO_CHANNEL_MAX + 1; i++) {
-		chans[i].index = i;
-		chans[i].clear();
+		g_audioChans[i].index = i;
+		g_audioChans[i].clear();
 	}
 
 	mixBuffer = new s32[hwBlockSize * 2];
@@ -156,17 +156,17 @@ void __AudioDoState(PointerWrap &p) {
 		System_AudioClear();
 	}
 
-	int chanCount = ARRAY_SIZE(chans);
+	int chanCount = ARRAY_SIZE(g_audioChans);
 	Do(p, chanCount);
-	if (chanCount != ARRAY_SIZE(chans))
+	if (chanCount != ARRAY_SIZE(g_audioChans))
 	{
 		ERROR_LOG(Log::sceAudio, "Savestate failure: different number of audio channels.");
 		p.SetError(p.ERROR_FAILURE);
 		return;
 	}
 	for (int i = 0; i < chanCount; ++i) {
-		chans[i].index = i;
-		chans[i].DoState(p);
+		g_audioChans[i].index = i;
+		g_audioChans[i].DoState(p);
 	}
 
 	__AudioCPUMHzChange();
@@ -178,8 +178,8 @@ void __AudioShutdown() {
 
 	mixBuffer = 0;
 	for (u32 i = 0; i < PSP_AUDIO_CHANNEL_MAX + 1; i++) {
-		chans[i].index = i;
-		chans[i].clear();
+		g_audioChans[i].index = i;
+		g_audioChans[i].clear();
 	}
 
 #ifndef MOBILE_DEVICE
@@ -338,10 +338,10 @@ void __AudioUpdate(bool resetRecording) {
 	int16_t srcBuffer[srcBufferSize];
 
 	for (u32 i = 0; i < PSP_AUDIO_CHANNEL_MAX + 1; i++)	{
-		if (!chans[i].reserved)
+		if (!g_audioChans[i].reserved)
 			continue;
 
-		__AudioWakeThreads(chans[i], 0, hwBlockSize);
+		__AudioWakeThreads(g_audioChans[i], 0, hwBlockSize);
 
 		if (!chanSampleQueues[i].size()) {
 			continue;

--- a/Core/HLE/__sceAudio.cpp
+++ b/Core/HLE/__sceAudio.cpp
@@ -338,8 +338,9 @@ void __AudioUpdate(bool resetRecording) {
 	int16_t srcBuffer[srcBufferSize];
 
 	for (u32 i = 0; i < PSP_AUDIO_CHANNEL_MAX + 1; i++)	{
-		if (!g_audioChans[i].reserved)
+		if (!g_audioChans[i].reserved) {
 			continue;
+		}
 
 		__AudioWakeThreads(g_audioChans[i], 0, hwBlockSize);
 
@@ -357,6 +358,11 @@ void __AudioUpdate(bool resetRecording) {
 		size_t sz1, sz2;
 
 		chanSampleQueues[i].popPointers(sz, &buf1, &sz1, &buf2, &sz2);
+
+		// We do this check as the very last thing before mixing, to maximize compatibility.
+		if (g_audioChans[i].mute) {
+			continue;
+		}
 
 		if (needsResample) {
 			auto read = [&](size_t i) {

--- a/Core/HLE/sceAudio.h
+++ b/Core/HLE/sceAudio.h
@@ -58,7 +58,7 @@ struct AudioChannel {
 };
 
 // The extra channel is for SRC/Output2/Vaudio (who all share, apparently.)
-extern AudioChannel chans[PSP_AUDIO_CHANNEL_MAX + 1];
+extern AudioChannel g_audioChans[PSP_AUDIO_CHANNEL_MAX + 1];
 
 void Register_sceAudio();
 

--- a/Core/HLE/sceAudio.h
+++ b/Core/HLE/sceAudio.h
@@ -49,6 +49,9 @@ struct AudioChannel {
 	u32 rightVolume = 0;
 	u32 format = 0;
 
+	// For the debugger only. Not saved.
+	bool mute = false;
+
 	std::vector<AudioChannelWaitInfo> waitingThreads;
 
 	void DoState(PointerWrap &p);

--- a/Core/HLE/sceVaudio.cpp
+++ b/Core/HLE/sceVaudio.cpp
@@ -47,16 +47,16 @@ static u32 sceVaudioChReserve(int sampleCount, int freq, int format) {
 		return SCE_KERNEL_ERROR_BUSY;
 	}
 	// We still have to check the channel also, which gives a different error.
-	if (chans[PSP_AUDIO_CHANNEL_VAUDIO].reserved) {
+	if (g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO].reserved) {
 		ERROR_LOG(Log::sceAudio, "sceVaudioChReserve(%i, %i, %i) - channel already reserved", sampleCount, freq, format);
 		return SCE_ERROR_AUDIO_CHANNEL_ALREADY_RESERVED;
 	}
 	DEBUG_LOG(Log::sceAudio, "sceVaudioChReserve(%i, %i, %i)", sampleCount, freq, format);
-	chans[PSP_AUDIO_CHANNEL_VAUDIO].reserved = true;
-	chans[PSP_AUDIO_CHANNEL_VAUDIO].sampleCount = sampleCount;
-	chans[PSP_AUDIO_CHANNEL_VAUDIO].format = format == 2 ? PSP_AUDIO_FORMAT_STEREO : PSP_AUDIO_FORMAT_MONO;
-	chans[PSP_AUDIO_CHANNEL_VAUDIO].leftVolume = 0;
-	chans[PSP_AUDIO_CHANNEL_VAUDIO].rightVolume = 0;
+	g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO].reserved = true;
+	g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO].sampleCount = sampleCount;
+	g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO].format = format == 2 ? PSP_AUDIO_FORMAT_STEREO : PSP_AUDIO_FORMAT_MONO;
+	g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO].leftVolume = 0;
+	g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO].rightVolume = 0;
 	vaudioReserved = true;
 	__AudioSetSRCFrequency(freq);
 	return 0;
@@ -64,11 +64,11 @@ static u32 sceVaudioChReserve(int sampleCount, int freq, int format) {
 
 static u32 sceVaudioChRelease() {
 	DEBUG_LOG(Log::sceAudio, "sceVaudioChRelease(...)");
-	if (!chans[PSP_AUDIO_CHANNEL_VAUDIO].reserved) {
+	if (!g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO].reserved) {
 		return SCE_ERROR_AUDIO_CHANNEL_NOT_RESERVED;
 	} else {
-		chans[PSP_AUDIO_CHANNEL_VAUDIO].reset();
-		chans[PSP_AUDIO_CHANNEL_VAUDIO].reserved = false;
+		g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO].reset();
+		g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO].reserved = false;
 		vaudioReserved = false;
 		return 0;
 	}
@@ -76,11 +76,11 @@ static u32 sceVaudioChRelease() {
 
 static u32 sceVaudioOutputBlocking(int vol, u32 buffer) {
 	DEBUG_LOG(Log::sceAudio, "sceVaudioOutputBlocking(%i, %08x)", vol, buffer);
-	chans[PSP_AUDIO_CHANNEL_VAUDIO].leftVolume = vol;
-	chans[PSP_AUDIO_CHANNEL_VAUDIO].rightVolume = vol;
+	g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO].leftVolume = vol;
+	g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO].rightVolume = vol;
 	// TODO: This may be wrong, not sure if's in a different format?
-	chans[PSP_AUDIO_CHANNEL_VAUDIO].sampleAddress = buffer;
-	return __AudioEnqueue(chans[PSP_AUDIO_CHANNEL_VAUDIO], PSP_AUDIO_CHANNEL_VAUDIO, true);
+	g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO].sampleAddress = buffer;
+	return __AudioEnqueue(g_audioChans[PSP_AUDIO_CHANNEL_VAUDIO], PSP_AUDIO_CHANNEL_VAUDIO, true);
 }
 
 static u32 sceVaudioSetEffectType(int effectType, int vol) {

--- a/GPU/Debugger/State.cpp
+++ b/GPU/Debugger/State.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstdio>
 #include "Common/Common.h"
 #include "Common/StringUtils.h"
@@ -907,10 +908,9 @@ bool GetPrimPreview(u32 op, GEPrimitiveType &prim, std::vector<GPUDebugVertex> &
 	u16 minIndex = 0;
 	u16 maxIndex = count - 1;
 	if (!indices.empty()) {
-		_dbg_assert_(count <= indices.size());
 		minIndex = 0xFFFF;
 		maxIndex = 0;
-		for (int i = 0; i < count; ++i) {
+		for (int i = 0; i < std::min((size_t)count, indices.size()); ++i) {
 			if (minIndex > indices[i]) {
 				minIndex = indices[i];
 			}

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -1245,8 +1245,9 @@ void DrawAudioChannels(ImConfig &cfg, ImControl &control) {
 		return;
 	}
 
-	if (ImGui::BeginTable("audios", 6, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersH)) {
+	if (ImGui::BeginTable("audios", 7, ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersH)) {
 		ImGui::TableSetupColumn("Index", ImGuiTableColumnFlags_WidthFixed);
+		ImGui::TableSetupColumn("Mute", ImGuiTableColumnFlags_WidthFixed);
 		ImGui::TableSetupColumn("SampleAddr", ImGuiTableColumnFlags_WidthFixed);
 		ImGui::TableSetupColumn("SampleCount", ImGuiTableColumnFlags_WidthFixed);
 		ImGui::TableSetupColumn("Volume", ImGuiTableColumnFlags_WidthFixed);
@@ -1262,11 +1263,14 @@ void DrawAudioChannels(ImConfig &cfg, ImControl &control) {
 			}
 			ImGui::TableNextRow();
 			ImGui::TableNextColumn();
+			ImGui::PushID(i);
 			if (i == 8) {
 				ImGui::TextUnformatted("audio2");
 			} else {
 				ImGui::Text("%d", i);
 			}
+			ImGui::TableNextColumn();
+			ImGui::Checkbox("", &g_audioChans[i].mute);
 			ImGui::TableNextColumn();
 			char id[2]{};
 			id[0] = i + 1;
@@ -1294,6 +1298,7 @@ void DrawAudioChannels(ImConfig &cfg, ImControl &control) {
 					ImGui::Text("%s: %d", thread->GetName(), t.numSamples);
 				}
 			}
+			ImGui::PopID();
 		}
 
 		ImGui::EndTable();

--- a/UI/ImDebugger/ImDebugger.cpp
+++ b/UI/ImDebugger/ImDebugger.cpp
@@ -1257,7 +1257,7 @@ void DrawAudioChannels(ImConfig &cfg, ImControl &control) {
 
 		// vaudio / output2 uses channel 8.
 		for (int i = 0; i < PSP_AUDIO_CHANNEL_MAX + 1; i++) {
-			if (!chans[i].reserved) {
+			if (!g_audioChans[i].reserved) {
 				continue;
 			}
 			ImGui::TableNextRow();
@@ -1270,13 +1270,13 @@ void DrawAudioChannels(ImConfig &cfg, ImControl &control) {
 			ImGui::TableNextColumn();
 			char id[2]{};
 			id[0] = i + 1;
-			ImClickableValue(id, chans[i].sampleAddress, control, ImCmd::SHOW_IN_MEMORY_VIEWER);
+			ImClickableValue(id, g_audioChans[i].sampleAddress, control, ImCmd::SHOW_IN_MEMORY_VIEWER);
 			ImGui::TableNextColumn();
-			ImGui::Text("%08x", chans[i].sampleCount);
+			ImGui::Text("%08x", g_audioChans[i].sampleCount);
 			ImGui::TableNextColumn();
-			ImGui::Text("%d | %d", chans[i].leftVolume, chans[i].rightVolume);
+			ImGui::Text("%d | %d", g_audioChans[i].leftVolume, g_audioChans[i].rightVolume);
 			ImGui::TableNextColumn();
-			switch (chans[i].format) {
+			switch (g_audioChans[i].format) {
 			case PSP_AUDIO_FORMAT_STEREO:
 				ImGui::TextUnformatted("Stereo");
 				break;
@@ -1288,7 +1288,7 @@ void DrawAudioChannels(ImConfig &cfg, ImControl &control) {
 				break;
 			}
 			ImGui::TableNextColumn();
-			for (auto t : chans[i].waitingThreads) {
+			for (auto t : g_audioChans[i].waitingThreads) {
 				KernelObject *thread = kernelObjects.GetFast<KernelObject>(t.threadID);
 				if (thread) {
 					ImGui::Text("%s: %d", thread->GetName(), t.numSamples);


### PR DESCRIPTION
Fix a crash while stepping through corrupt draws (#19261) and also adds mute checkboxes to the audio channel listing.