### PR TITLE
SDL audio: Add config slider for audio samples

### DIFF
--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -768,6 +768,7 @@ static const ConfigSetting soundSettings[] = {
 	ConfigSetting("Enable", &g_Config.bEnableSound, true, CfgFlag::PER_GAME),
 	ConfigSetting("AudioBackend", &g_Config.iAudioBackend, 0, CfgFlag::PER_GAME),
 	ConfigSetting("ExtraAudioBuffering", &g_Config.bExtraAudioBuffering, false, CfgFlag::DEFAULT),
+	ConfigSetting("AudioSamples", &g_Config.iAudioSamples, 256, CfgFlag::DEFAULT),
 
 	// Legacy volume settings, these get auto upgraded through default handlers on the new settings. NOTE: Must be before the new ones in the order here.
 	// The default settings here are still relevant, they will get propagated into the new ones.

--- a/Core/Config.h
+++ b/Core/Config.h
@@ -286,6 +286,7 @@ public:
 	// Sound
 	bool bEnableSound;
 	int iAudioBackend;
+	int iAudioSamples;
 
 	// Legacy volume settings, 0-10. These get auto-upgraded and should not be used.
 	int iLegacyGameVolume;

--- a/Core/ConfigValues.h
+++ b/Core/ConfigValues.h
@@ -32,6 +32,8 @@ constexpr int PSP_DEFAULT_FIRMWARE = 660;
 constexpr int VOLUME_OFF = 0;
 constexpr int VOLUME_FULL = 10;
 constexpr int VOLUMEHI_FULL = 100;  // for newer volume params. will convert them all later
+constexpr int AUDIOSAMPLES_MIN = 0;
+constexpr int AUDIOSAMPLES_MAX = 2048;
 
 // This matches exactly the old shift-based curve.
 float Volume10ToMultiplier(int volume);

--- a/Qt/QtMain.cpp
+++ b/Qt/QtMain.cpp
@@ -87,7 +87,7 @@ static void InitSDLAudioDevice() {
 	fmt.freq = 44100;
 	fmt.format = AUDIO_S16;
 	fmt.channels = 2;
-	fmt.samples = 256;
+	fmt.samples = g_Config.iAudioSamples;
 	fmt.callback = &mixaudio;
 	fmt.userdata = nullptr;
 

--- a/SDL/SDLMain.cpp
+++ b/SDL/SDLMain.cpp
@@ -146,7 +146,7 @@ static void InitSDLAudioDevice(const std::string &name = "") {
 	fmt.freq = g_sampleRate;
 	fmt.format = AUDIO_S16;
 	fmt.channels = 2;
-	fmt.samples = 256;
+	fmt.samples = g_Config.iAudioSamples;
 	fmt.callback = &sdl_mixaudio_callback;
 	fmt.userdata = nullptr;
 

--- a/UI/GameSettingsScreen.cpp
+++ b/UI/GameSettingsScreen.cpp
@@ -715,6 +715,8 @@ void GameSettingsScreen::CreateAudioSettings(UI::ViewGroup *audioSettings) {
 		PopupMultiChoiceDynamic *MicChoice = audioSettings->Add(new PopupMultiChoiceDynamic(&g_Config.sMicDevice, a->T("Microphone Device"), micList, I18NCat::NONE, screenManager()));
 		MicChoice->OnChoice.Handle(this, &GameSettingsScreen::OnMicDeviceChange);
 	}
+
+	PopupSliderChoice *audioSamples = audioSettings->Add(new PopupSliderChoice(&g_Config.iAudioSamples, AUDIOSAMPLES_MIN, AUDIOSAMPLES_MAX, 256, a->T("Audio Samples"), screenManager()));
 }
 
 void GameSettingsScreen::CreateControlsSettings(UI::ViewGroup *controlsSettings) {


### PR DESCRIPTION
As described on Issue #12705 several users have problems with audio popping, crackling, and distorion with different sample values.

Previous commit ece6edf reduced default samples from 1024 to 256 but there does not seem to be an ideal value for all platforms.

Make the option configurable in Audio Backend Settings.