### PR TITLE
Trash handling is too high level for FileUtil, move it up.

### DIFF
--- a/Common/File/FileUtil.h
+++ b/Common/File/FileUtil.h
@@ -233,12 +233,4 @@ inline bool ReadTextFileToString(const Path &path, std::string *str) {
 // Return value must be delete[]-d.
 uint8_t *ReadLocalFile(const Path &path, size_t *size);
 
-// Moves to trash/recycle bin.
-// This is only functional if SYSPROP_HAS_TRASH_BIN is true, otherwise will return false.
-bool MoveFileToTrash(const Path &path);
-
-// These move to trash if possible, otherwise permanently delete.
-bool MoveFileToTrashOrDelete(const Path &path);
-bool MoveDirectoryTreeToTrashOrDelete(const Path &path);
-
 }  // namespace

--- a/Common/System/Request.cpp
+++ b/Common/System/Request.cpp
@@ -150,3 +150,8 @@ void System_RunCallbackInWndProc(void (*callback)(void *, void *), void *userdat
 	int64_t castUserData = (int64_t)userdata;
 	g_requestManager.MakeSystemRequest(SystemRequestType::RUN_CALLBACK_IN_WNDPROC, NO_REQUESTER_TOKEN, nullptr, nullptr, "", "", castPtr, castUserData);
 }
+
+void System_MoveToTrash(const Path &path) {
+	g_requestManager.MakeSystemRequest(SystemRequestType::MOVE_TO_TRASH, NO_REQUESTER_TOKEN, nullptr, nullptr, path.ToString(), "", 0);
+}
+

--- a/Common/System/Request.h
+++ b/Common/System/Request.h
@@ -189,6 +189,7 @@ inline void System_SendDebugScreenshot(std::string_view data, int height) {
 	g_requestManager.MakeSystemRequest(SystemRequestType::SEND_DEBUG_SCREENSHOT, NO_REQUESTER_TOKEN, nullptr, nullptr, data, "", height);
 }
 
+void System_MoveToTrash(const Path &path);
 void System_RunCallbackInWndProc(void (*callback)(void *, void *), void *userdata);
 
 // Non-inline to avoid including Path.h

--- a/Common/System/System.h
+++ b/Common/System/System.h
@@ -98,6 +98,8 @@ enum class SystemRequestType {
 	MICROPHONE_COMMAND,
 
 	RUN_CALLBACK_IN_WNDPROC,
+
+	MOVE_TO_TRASH,
 };
 
 // Run a closure on the main thread. Used to safely implement UI that runs on another thread.

--- a/Core/Config.cpp
+++ b/Core/Config.cpp
@@ -49,6 +49,7 @@
 #include "Common/GPU/Vulkan/VulkanLoader.h"
 #include "Common/VR/PPSSPPVR.h"
 #include "Common/System/OSD.h"
+#include "Common/System/Request.h"
 #include "Core/Config.h"
 #include "Core/ConfigSettings.h"
 #include "Core/ConfigValues.h"
@@ -1690,7 +1691,11 @@ bool Config::deleteGameConfig(const std::string& pGameId) {
 	Path fullIniFilePath = Path(getGameConfigFile(pGameId, &exists));
 
 	if (exists) {
-		File::MoveFileToTrashOrDelete(fullIniFilePath);
+		if (System_GetPropertyBool(SYSPROP_HAS_TRASH_BIN)) {
+			System_MoveToTrash(fullIniFilePath);
+		} else {
+			File::Delete(fullIniFilePath);
+		}
 	}
 	return true;
 }

--- a/Core/Loaders.cpp
+++ b/Core/Loaders.cpp
@@ -318,6 +318,32 @@ bool UmdReplace(const Path &filepath, FileLoader **fileLoader, std::string &erro
 	return true;
 }
 
+// Close the return value with ZipClose (if non-null, of course).
+struct zip *ZipOpenPath(const Path &fileName) {
+	int error = 0;
+	// Need to special case for content URI here, similar to OpenCFile.
+	struct zip *z;
+#if PPSSPP_PLATFORM(ANDROID)
+	if (fileName.Type() == PathType::CONTENT_URI) {
+		int fd = File::OpenFD(fileName, File::OPEN_READ);
+		z = zip_fdopen(fd, 0, &error);
+	} else
+#endif
+	{  // continuation of above else in the ifdef
+		z = zip_open(fileName.c_str(), 0, &error);
+	}
+
+	if (!z) {
+		ERROR_LOG(Log::HLE, "Failed to open ZIP file '%s', error code=%i", fileName.c_str(), error);
+	}
+	return z;
+}
+
+void ZipClose(struct zip *z) {
+	if (z)
+		zip_close(z);
+}
+
 bool DetectZipFileContents(const Path &fileName, ZipFileInfo *info) {
 	struct zip *z = ZipOpenPath(fileName);
 	if (!z) {

--- a/Core/Loaders.h
+++ b/Core/Loaders.h
@@ -155,9 +155,6 @@ Path ResolvePBPFile(const Path &filename);
 
 IdentifiedFileType Identify_File(FileLoader *fileLoader, std::string *errorString);
 
-// Can modify the string filename, as it calls IdentifyFile above.
-bool LoadFile(FileLoader **fileLoaderPtr, IdentifiedFileType type, std::string *error_string);
-
 bool UmdReplace(const Path &filepath, FileLoader **fileLoader, std::string &error);
 
 
@@ -186,6 +183,9 @@ struct ZipFileInfo {
 
 	std::string contentName;
 };
+
+struct zip *ZipOpenPath(const Path &fileName);
+void ZipClose(zip *z);
 
 bool DetectZipFileContents(const Path &fileName, ZipFileInfo *info);
 void DetectZipFileContents(struct zip *z, ZipFileInfo *info);

--- a/Core/Util/GameManager.cpp
+++ b/Core/Util/GameManager.cpp
@@ -52,32 +52,6 @@
 
 GameManager g_GameManager;
 
-// Close the return value with ZipClose (if non-null, of course).
-struct zip *ZipOpenPath(Path fileName) {
-	int error = 0;
-	// Need to special case for content URI here, similar to OpenCFile.
-	struct zip *z;
-#if PPSSPP_PLATFORM(ANDROID)
-	if (fileName.Type() == PathType::CONTENT_URI) {
-		int fd = File::OpenFD(fileName, File::OPEN_READ);
-		z = zip_fdopen(fd, 0, &error);
-	} else
-#endif
-	{  // continuation of above else in the ifdef
-		z = zip_open(fileName.c_str(), 0, &error);
-	}
-
-	if (!z) {
-		ERROR_LOG(Log::HLE, "Failed to open ZIP file '%s', error code=%i", fileName.c_str(), error);
-	}
-	return z;
-}
-
-void ZipClose(struct zip *z) {
-	if (z)
-		zip_close(z);
-}
-
 GameManager::GameManager() {
 }
 

--- a/Core/Util/GameManager.h
+++ b/Core/Util/GameManager.h
@@ -27,7 +27,6 @@
 #include <optional>
 
 #include "Common/Net/HTTPClient.h"
-#include "Common/File/Path.h"
 
 enum class GameManagerState {
 	IDLE,
@@ -45,6 +44,7 @@ struct ZipFileTask {
 
 struct zip;
 class FileLoader;
+class Path;
 struct ZipFileInfo;
 
 class GameManager {
@@ -118,8 +118,5 @@ private:
 };
 
 extern GameManager g_GameManager;
-
-struct zip *ZipOpenPath(Path fileName);
-void ZipClose(zip *z);
 
 bool CanExtractWithoutOverwrite(struct zip *z, const Path &destination, int maxOkFiles);

--- a/Windows/W32Util/ShellUtil.h
+++ b/Windows/W32Util/ShellUtil.h
@@ -10,13 +10,13 @@ class Path;
 namespace W32Util {
 
 std::string BrowseForFolder2(HWND parent, std::string_view title, std::string_view initialPath);
-
 bool BrowseForFileName(bool _bLoad, HWND _hParent, const wchar_t*_pTitle,
 	const wchar_t *_pInitialFolder, const wchar_t *_pFilter, const wchar_t*_pExtension,
 	std::string& _strFileName);
 std::vector<std::string> BrowseForFileNameMultiSelect(bool _bLoad, HWND _hParent, const wchar_t*_pTitle,
 	const wchar_t*_pInitialFolder, const wchar_t*_pFilter, const wchar_t*_pExtension);
 
+bool MoveToTrash(const Path &path);
 std::string UserDocumentsPath();
 
 bool CreateDesktopShortcut(std::string_view argumentPath, std::string_view gameTitle, const Path &icoFile);

--- a/Windows/main.cpp
+++ b/Windows/main.cpp
@@ -720,6 +720,11 @@ bool System_MakeRequest(SystemRequestType type, int requestId, const std::string
 		MainWindow::RunCallbackInWndProc(func, userdata);
 		return true;
 	}
+	case SystemRequestType::MOVE_TO_TRASH:
+	{
+		W32Util::MoveToTrash(Path(param1));
+		return true;
+	}
 	default:
 		return false;
 	}


### PR DESCRIPTION
This should fix libretro's build: https://git.libretro.com/libretro/ppsspp/-/jobs/6728765

Trash is a shell-level thing, and is a bit too high level to be in FileUtil.cpp anyway. We don't want to link that functionality into the libretro build for example, so it's better that we make it a "system request".

When I moved out the zip file content detection, I slightly messed up, so fixing that too.

This makes the coming Mac implementation much easier too.

Also bump pspautotests, though we haven't activated any new tests.