### PR TITLE
Disable the Qt build temporarily

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,12 +158,12 @@ jobs:
           args: ./b.sh --libretro_android ppsspp_libretro
           id: android-libretro
 
-        - os: ubuntu-latest
-          extra: qt
-          cc: gcc
-          cxx: g++
-          args: ./b.sh --qt
-          id: qt
+        # - os: ubuntu-latest
+        #   extra: qt
+        #   cc: gcc
+        #   cxx: g++
+        #   args: ./b.sh --qt
+        #   id: qt
         - os: ubuntu-latest
           extra: libretro
           cc: gcc


### PR DESCRIPTION
The Qt installer that we use on CI is currently completely broken: https://github.com/jurplel/install-qt-action/issues/283

So builds are red without any fault of our own, which is not useful.