### PR TITLE
Restore the Qt CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,12 +158,12 @@ jobs:
           args: ./b.sh --libretro_android ppsspp_libretro
           id: android-libretro
 
-        # - os: ubuntu-latest
-        #   extra: qt
-        #   cc: gcc
-        #   cxx: g++
-        #   args: ./b.sh --qt
-        #   id: qt
+        - os: ubuntu-latest
+          extra: qt
+          cc: gcc
+          cxx: g++
+          args: ./b.sh --qt
+          id: qt
         - os: ubuntu-latest
           extra: libretro
           cc: gcc


### PR DESCRIPTION
Obviously, when this passes we can merge it. Right now it'll likely break.

The Qt CI is broken due to an upstream issue, see #20263 